### PR TITLE
appveyor への対応 (Visual Studio 2017)

### DIFF
--- a/HeaderMake/HeaderMake_vc2017.vcxproj
+++ b/HeaderMake/HeaderMake_vc2017.vcxproj
@@ -60,6 +60,7 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(ProjectName).exe</OutputFile>
@@ -75,6 +76,7 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(ProjectName).exe</OutputFile>

--- a/MakefileMake/MakefileMake_vc2017.vcxproj
+++ b/MakefileMake/MakefileMake_vc2017.vcxproj
@@ -60,6 +60,7 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(ProjectName).exe</OutputFile>
@@ -75,6 +76,7 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(ProjectName).exe</OutputFile>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+init:
+- ps: Set-WinSystemLocale ja-JP
+- ps: Start-Sleep -s 5
+- ps: Restart-Computer
+
+build_script:
+- cmd: >-
+    set SLN_FILE=sakura\sakura_vc2017.sln
+
+
+    set EXTRA_CMD=/verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+    set MSBUILD_EXE="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
+
+
+    echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=x86 /p:Configuration=Debug_Unicode      /t:"Clean","Rebuild"  %EXTRA_CMD%
+         %MSBUILD_EXE% %SLN_FILE% /p:Platform=x86 /p:Configuration=Debug_Unicode      /t:"Clean","Rebuild"  %EXTRA_CMD%
+
+    echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=x86 /p:Configuration=Release_Unicode    /t:"Clean","Rebuild"  %EXTRA_CMD%
+         %MSBUILD_EXE% %SLN_FILE% /p:Platform=x86 /p:Configuration=Release_Unicode    /t:"Clean","Rebuild"  %EXTRA_CMD%
+
+    echo appveyor_yml
+
+artifacts:
+- path: sakura\Debug_Unicode\sakura.exe
+- path: sakura\Debug_Unicode\sakura.pdb
+- path: sakura\Release_Unicode\sakura.exe
+- path: sakura\Release_Unicode\sakura.pdb

--- a/sakura/sakura_vc2017.vcxproj
+++ b/sakura/sakura_vc2017.vcxproj
@@ -103,6 +103,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -139,6 +140,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -172,6 +174,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -206,6 +209,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
#10: appveyor への対応 (Visual Studio 2017)

-  /source-charset:shift_jis を指定して、英語環境 (appveyor) 上でもコンパイルできるようにする
- appveyor.yml を追加

参考サイト
- https://docs.microsoft.com/ja-jp/cpp/build/reference/source-charset-set-source-character-set
- https://msdn.microsoft.com/ja-jp/library/dd317756.aspx
- http://teitoku-window.hatenablog.com/entry/2017/09/21/201750
- https://github.com/appveyor/ci/issues/846

