### PR TITLE
バージョン情報で git の commit hash を表示する

### DIFF
--- a/sakura/.gitignore
+++ b/sakura/.gitignore
@@ -33,3 +33,4 @@
 /_UpgradeReport_Files
 /ipch
 /UpgradeLog.XML
+/.vs

--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -4,6 +4,18 @@ HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_defin
 HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_enum.h -mode=enum -enum=EFunctionCode
 MakefileMake -file=..\sakura_core\Makefile -dir=..\sakura_core
 
+set GITREV_H=..\sakura_core\gitrev.h
+
+for /f "usebackq" %%s in (`git show -s --format^=%%H`) do (
+    set COMMITID=%%s
+)
+
+if "%COMMITID%" == "" (
+	type nul                                  > %GITREV_H%
+) else (
+	echo #define GIT_COMMIT_HASH "%COMMITID%" > %GITREV_H%
+)
+
 SubWCRev.exe "..\\" "..\sakura_core\svnrev_template.h" "..\sakura_core\svnrev.h"
 if %ERRORLEVEL% NEQ 0 (
   echo Automatic revision update unavailable, using generic template instead.

--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -25,13 +25,5 @@ if "%SHORT_COMMITID%" == "" (
 	echo #define GIT_SHORT_COMMIT_HASH "%SHORT_COMMITID%" >> %GITREV_H%
 )
 
-SubWCRev.exe "..\\" "..\sakura_core\svnrev_template.h" "..\sakura_core\svnrev.h"
-if %ERRORLEVEL% NEQ 0 (
-  echo Automatic revision update unavailable, using generic template instead.
-  echo You can safely ignore this message - see svnrev.h for details.
-  copy /Y "..\sakura_core\svnrev_unknown.h" "..\sakura_core\svnrev.h"
-)
-
 ENDLOCAL
-:: Always return an errorlevel of 0 -- this allows compilation to continue if SubWCRev failed.
 rem exit 0

--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -9,11 +9,20 @@ set GITREV_H=..\sakura_core\gitrev.h
 for /f "usebackq" %%s in (`git show -s --format^=%%H`) do (
     set COMMITID=%%s
 )
+for /f "usebackq" %%s in (`git show -s --format^=%%h`) do (
+    set SHORT_COMMITID=%%s
+)
 
+type nul                                  > %GITREV_H%
 if "%COMMITID%" == "" (
-	type nul                                  > %GITREV_H%
+	type nul                                  >> %GITREV_H%
 ) else (
-	echo #define GIT_COMMIT_HASH "%COMMITID%" > %GITREV_H%
+	echo #define GIT_COMMIT_HASH "%COMMITID%" >> %GITREV_H%
+)
+if "%SHORT_COMMITID%" == "" (
+	type nul                                              >> %GITREV_H%
+) else (
+	echo #define GIT_SHORT_COMMIT_HASH "%SHORT_COMMITID%" >> %GITREV_H%
 )
 
 SubWCRev.exe "..\\" "..\sakura_core\svnrev_template.h" "..\sakura_core\svnrev.h"

--- a/sakura/sakura_vc2017.vcxproj
+++ b/sakura/sakura_vc2017.vcxproj
@@ -461,6 +461,7 @@
     <ClInclude Include="..\sakura_core\sakura_rc.h" />
     <ClInclude Include="..\sakura_core\StdAfx.h" />
     <ClInclude Include="..\sakura_core\String_define.h" />
+    <ClInclude Include="..\sakura_core\gitrev.h" />
     <ClInclude Include="..\sakura_core\svnrev.h" />
     <ClInclude Include="..\sakura_core\typeprop\CDlgKeywordSelect.h" />
     <ClInclude Include="..\sakura_core\typeprop\CDlgSameColor.h" />

--- a/sakura/sakura_vc2017.vcxproj
+++ b/sakura/sakura_vc2017.vcxproj
@@ -462,7 +462,6 @@
     <ClInclude Include="..\sakura_core\StdAfx.h" />
     <ClInclude Include="..\sakura_core\String_define.h" />
     <ClInclude Include="..\sakura_core\gitrev.h" />
-    <ClInclude Include="..\sakura_core\svnrev.h" />
     <ClInclude Include="..\sakura_core\typeprop\CDlgKeywordSelect.h" />
     <ClInclude Include="..\sakura_core\typeprop\CDlgSameColor.h" />
     <ClInclude Include="..\sakura_core\typeprop\CDlgTypeAscertain.h" />

--- a/sakura/sakura_vc2017.vcxproj.filters
+++ b/sakura/sakura_vc2017.vcxproj.filters
@@ -136,9 +136,6 @@
     <ClInclude Include="..\sakura_core\StdAfx.h">
       <Filter>Other Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\sakura_core\svnrev.h">
-      <Filter>Other Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\sakura_core\String_define.h">
       <Filter>Other Files</Filter>
     </ClInclude>

--- a/sakura_core/.gitignore
+++ b/sakura_core/.gitignore
@@ -1,1 +1,2 @@
+/gitrev.h
 /svnrev.h

--- a/sakura_core/.gitignore
+++ b/sakura_core/.gitignore
@@ -1,2 +1,1 @@
 /gitrev.h
-/svnrev.h

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -153,7 +153,8 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	//	2010.04.15 Moca コンパイラ情報を分離/WINヘッダ,N_SHAREDATA_VERSION追加
 
 	// 以下の形式で出力
-	//サクラエディタ   Ver. 2.0.0.0 (Rev.9999)
+	//サクラエディタ   Ver. 2.0.0.0
+	//(hash xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
 	//
 	//      Share Ver: 96
 	//      Compile Info: V 1400  WR WIN600/I601/C000/N600

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -25,7 +25,6 @@
 #include "util/file.h"
 #include "util/module.h"
 #include "gitrev.h"
-#include "svnrev.h"
 #include "sakura_rc.h" // 2002/2/10 aroka •œ‹A
 #include "sakura.hh"
 
@@ -173,13 +172,6 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		LOWORD(dwVersionMS),
 		HIWORD(dwVersionLS),
 		LOWORD(dwVersionLS)
-	);
-#elif (SVN_REV == 0)
-	auto_sprintf( szMsg, _T("Ver. %d.%d.%d.%d\r\n"),
-		HIWORD( dwVersionMS ),
-		LOWORD( dwVersionMS ),
-		HIWORD( dwVersionLS ),
-		LOWORD( dwVersionLS )
 	);
 #else
 	auto_sprintf( szMsg, _T("Ver. %d.%d.%d.%d (Rev.") _T(SVN_REV_STR) _T(")\r\n"),

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -24,6 +24,7 @@
 #include "uiparts/HandCursor.h"
 #include "util/file.h"
 #include "util/module.h"
+#include "gitrev.h"
 #include "svnrev.h"
 #include "sakura_rc.h" // 2002/2/10 aroka 復帰
 #include "sakura.hh"
@@ -165,7 +166,14 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	// バージョン&リビジョン情報
 	DWORD dwVersionMS, dwVersionLS;
 	GetAppVersionInfo( NULL, VS_VERSION_INFO, &dwVersionMS, &dwVersionLS );
-#if (SVN_REV == 0)
+#if defined(GIT_COMMIT_HASH)
+	auto_sprintf(szMsg, _T("Ver. %d.%d.%d.%d\r\n(hash ") _T(GIT_COMMIT_HASH) _T(")\r\n"),
+		HIWORD(dwVersionMS),
+		LOWORD(dwVersionMS),
+		HIWORD(dwVersionLS),
+		LOWORD(dwVersionLS)
+	);
+#elif (SVN_REV == 0)
 	auto_sprintf( szMsg, _T("Ver. %d.%d.%d.%d\r\n"),
 		HIWORD( dwVersionMS ),
 		LOWORD( dwVersionMS ),

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -154,7 +154,7 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	// 以下の形式で出力
 	//サクラエディタ   Ver. 2.0.0.0
-	//(hash xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
+	//(GitHash xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
 	//
 	//      Share Ver: 96
 	//      Compile Info: V 1400  WR WIN600/I601/C000/N600
@@ -168,7 +168,7 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	DWORD dwVersionMS, dwVersionLS;
 	GetAppVersionInfo( NULL, VS_VERSION_INFO, &dwVersionMS, &dwVersionLS );
 #if defined(GIT_COMMIT_HASH)
-	auto_sprintf(szMsg, _T("Ver. %d.%d.%d.%d\r\n(hash ") _T(GIT_COMMIT_HASH) _T(")\r\n"),
+	auto_sprintf(szMsg, _T("Ver. %d.%d.%d.%d\r\n(GitHash ") _T(GIT_COMMIT_HASH) _T(")\r\n"),
 		HIWORD(dwVersionMS),
 		LOWORD(dwVersionMS),
 		HIWORD(dwVersionLS),

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -2811,7 +2811,9 @@ BEGIN
             VALUE "OriginalFilename", "sakura.exe\0"
             VALUE "ProductName", "サクラエディタ\0"
             VALUE "ProductVersion", PR_VER_STR
-#if (SVN_REV != 0)
+#if defined(GIT_COMMIT_HASH)
+                " (hash " GIT_COMMIT_HASH ")"
+#elif (SVN_REV != 0)
                 " (Rev." SVN_REV_STR ")"
 #endif
 #ifdef _DEBUG

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -5,6 +5,7 @@
 #ifndef SAKURA_LANG_RESOURCE
 	#include "sakura_rc.h"
 	#include "Funccode_define.h"
+	#include "gitrev.h"
 	#include "svnrev.h"
 	#include "String_define.h"
 #else

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -6,7 +6,6 @@
 	#include "sakura_rc.h"
 	#include "Funccode_define.h"
 	#include "gitrev.h"
-	#include "svnrev.h"
 	#include "String_define.h"
 #else
 	#include "sakura_lang.h"
@@ -2814,8 +2813,6 @@ BEGIN
             VALUE "ProductVersion", PR_VER_STR
 #if defined(GIT_SHORT_COMMIT_HASH)
                 " (GitHash " GIT_SHORT_COMMIT_HASH ")"
-#elif (SVN_REV != 0)
-                " (Rev." SVN_REV_STR ")"
 #endif
 #ifdef _DEBUG
                 " Debug version"

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -2812,8 +2812,8 @@ BEGIN
             VALUE "OriginalFilename", "sakura.exe\0"
             VALUE "ProductName", "サクラエディタ\0"
             VALUE "ProductVersion", PR_VER_STR
-#if defined(GIT_COMMIT_HASH)
-                " (hash " GIT_COMMIT_HASH ")"
+#if defined(GIT_SHORT_COMMIT_HASH)
+                " (hash " GIT_SHORT_COMMIT_HASH ")"
 #elif (SVN_REV != 0)
                 " (Rev." SVN_REV_STR ")"
 #endif

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -2813,7 +2813,7 @@ BEGIN
             VALUE "ProductName", "サクラエディタ\0"
             VALUE "ProductVersion", PR_VER_STR
 #if defined(GIT_SHORT_COMMIT_HASH)
-                " (hash " GIT_SHORT_COMMIT_HASH ")"
+                " (GitHash " GIT_SHORT_COMMIT_HASH ")"
 #elif (SVN_REV != 0)
                 " (Rev." SVN_REV_STR ")"
 #endif

--- a/sakura_core/svnrev_template.h
+++ b/sakura_core/svnrev_template.h
@@ -1,2 +1,0 @@
-#define SVN_REV $WCREV$
-#define SVN_REV_STR "$WCREV$"

--- a/sakura_core/svnrev_unknown.h
+++ b/sakura_core/svnrev_unknown.h
@@ -1,2 +1,0 @@
-#define SVN_REV 0
-#define SVN_REV_STR ""


### PR DESCRIPTION
バージョン情報で git の commit hash を表示する

# git の commit hash の取得

git show -s --format=%H

# git の commit hash (短い形式) の取得

git show -s --format=%h

# バッチファイルのエスケープ

http://www.robvanderwoude.com/escapechars.php

-  = は ^=
-  % は %%

# コマンド出力を変数に代入する方法

http://bleis-tift.hatenablog.com/entry/20080502/1209689071

