### PR TITLE
AppVeyorバッジ追加、AppVeyor URL修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Sakura Editor
+[![Build status](https://ci.appveyor.com/api/projects/status/xlsp22h1q91mh96j/branch/master?svg=true)](https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master)
+
 A free Japanese text editor for Windows
 
 ## Web Site
@@ -24,10 +26,10 @@ Visual Studio Community 2017 で `sakura/sakura_vc2017.sln` を開いてビル�
 
 ## CI Build (AppVeyor)
 本リポジトリの最新 master は以下の AppVeyor プロジェクト上で自動ビルドされます。  
-https://ci.appveyor.com/project/sakuraeditor/sakura
+https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master
 
 最新のビルド結果（バイナリ）はここから取得できます。  
-https://ci.appveyor.com/project/sakuraeditor/build/artifacts
+https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master/artifacts
 
-最新以前のビルド結果は以下から参照できます。  
-https://ci.appveyor.com/project/sakuraeditor/history
+最新以外のビルド結果は以下から参照できます。  
+https://ci.appveyor.com/project/sakuraeditor/sakura/history

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: 1.0.{build}
 image: Visual Studio 2017
+clone_folder: C:\projects\$(APPVEYOR_ACCOUNT_NAME)\$(APPVEYOR_PROJECT_NAME)_$(APPVEYOR_BUILD_VERSION)
 init:
 - ps: Set-WinSystemLocale ja-JP
 - ps: Start-Sleep -s 5


### PR DESCRIPTION
## 内容
- README 見出し直下に AppVeyorバッジ追加
- README 内の AppVeyor の URL が一部間違っていたのを修正

## 対象 Isssue
- Appveyor の バッジを README.md に追加してほしい #16

## 対応手順
AppVeyor に sakura-editor ユーザでログインした状態で以下の設定ページを開く。

- https://ci.appveyor.com/project/sakuraeditor/sakura/settings/badges

この中にある `Branch sample markdown code` から取得できる以下の Markdown をコピーして README の見出し直下に挿入。

```
[![Build status](https://ci.appveyor.com/api/projects/status/xlsp22h1q91mh96j/branch/master?svg=true)](https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master)
```

## 残存エラー
https://ci.appveyor.com/project/sakuraeditor/sakura/build/1.0.28
```
fatal: destination path 'C:\projects\sakura' already exists and is not an empty directory.
Command exited with code 128
```

#15 でこのエラーは解消したつもりでしたが、まだ直ってなかったみたいです。
`clone_folder` を yml 側で指定する等で対処できないかどうか検証します。
