### PR TITLE
ビルド時警告の削減

### DIFF
--- a/HeaderMake/HeaderMake.vcxproj
+++ b/HeaderMake/HeaderMake.vcxproj
@@ -67,6 +67,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/MakefileMake/MakefileMake.vcxproj
+++ b/MakefileMake/MakefileMake.vcxproj
@@ -67,6 +67,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -110,6 +110,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
       <Command>call postBuild.bat "$(TargetPath).manifest"</Command>

--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -24,7 +24,19 @@
 #ifndef SAKURA_STDAPI_85471C2C_6AEE_410D_BD09_A59056A5BA68_H_
 #define SAKURA_STDAPI_85471C2C_6AEE_410D_BD09_A59056A5BA68_H_
 
-#include <ImageHlp.h> //MakeSureDirectoryPathExists
+
+//ランタイム情報ライブラリにアクセスするWindowsヘッダを参照する
+//c++規格への準拠が厳しくなったため、WindowsSDKが無名enumをtypedefするコードが怒られる。
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+	//一時的に警告を無効にしてインクルードする
+	#pragma warning(push)
+	#pragma warning(disable:4091)
+	#include <ImageHlp.h> //MakeSureDirectoryPathExists
+	#pragma warning(pop)
+#else
+	#include <ImageHlp.h> //MakeSureDirectoryPathExists
+#endif
+
 
 //デバッグ用。
 //VistaだとExtTextOutの結果が即反映されない。この関数を用いると即反映されるので、


### PR DESCRIPTION
最新のビルド結果に残っている警告を消すための対応です。(関連: #44)

対応内容は3種類で、各コミットのコミットメッセージに内容を書いています。
これを適用すると警告が全部消えてきれいな状態になる見込みです。