### PR TITLE
ビルド時警告の削減：operator new/delete 部分

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -539,6 +539,7 @@
     <ClCompile Include="..\sakura_core\cmd\CViewCommander_Support.cpp" />
     <ClCompile Include="..\sakura_core\cmd\CViewCommander_TagJump.cpp" />
     <ClCompile Include="..\sakura_core\cmd\CViewCommander_Window.cpp" />
+    <ClCompile Include="..\sakura_core\config\build_config.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HaneisuToZeneisu.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HankataToZenhira.cpp" />

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -2252,6 +2252,9 @@
     <ClCompile Include="..\sakura_core\uiparts\CWaitCursor.cpp">
       <Filter>Cpp Source Files\uiparts</Filter>
     </ClCompile>
+    <ClCompile Include="..\sakura_core\config\build_config.cpp">
+      <Filter>Cpp Source Files\config</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\resource\auto_scroll_center.bmp">

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -127,6 +127,7 @@ cmd/CViewCommander_Settings.o \
 cmd/CViewCommander_Support.o \
 cmd/CViewCommander_TagJump.o \
 cmd/CViewCommander_Window.o \
+config/build_config.o \
 convert/CConvert.o \
 convert/CConvert_HaneisuToZeneisu.o \
 convert/CConvert_HankataToZenhira.o \

--- a/sakura_core/config/build_config.cpp
+++ b/sakura_core/config/build_config.cpp
@@ -1,0 +1,48 @@
+﻿#include "StdAfx.h"
+#include "build_config.h"
+#include <stdlib.h> //malloc,free
+
+//デバッグ検証用：newされた領域をわざと汚す。2007.11.27 kobake
+#ifdef FILL_STRANGE_IN_NEW_MEMORY
+
+inline void _fill_new_memory(void* p, size_t nSize, const char* pSrc, size_t nSrcLen)
+{
+	char* s = (char*)p;
+	size_t i;
+	for (i = 0; i < nSize; i++)
+	{
+		*s++ = pSrc[i%nSrcLen];
+	}
+}
+
+void* operator new(size_t nSize)
+{
+	void* p = ::malloc(nSize);
+	_fill_new_memory(p, nSize, "n_e_w_!_", 8); //確保されたばかりのメモリ状態は「n_e_w_!_....」となります
+	return p;
+}
+
+#ifdef _MSC_VER
+#if _MSC_VER == 1500
+_Ret_bytecap_(_Size)	// for VS2008 Debug mode
+#endif
+#endif
+
+void* operator new[](size_t nSize)
+{
+	void* p = ::malloc(nSize);
+	_fill_new_memory(p, nSize, "N_E_W_!_", 8); //確保されたばかりのメモリ状態は「N_E_W_!_N_E_W_!_N_E_W_!_....」となります
+	return p;
+}
+
+void operator delete(void* p)
+{
+	::free(p);
+}
+
+void operator delete[](void* p)
+{
+	::free(p);
+}
+
+#endif

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -88,41 +88,15 @@ static const bool UNICODE_BOOL=false;
 
 //デバッグ検証用：newされた領域をわざと汚す。2007.11.27 kobake
 #ifdef FILL_STRANGE_IN_NEW_MEMORY
-	#include <stdlib.h> //malloc,free
-	inline void _fill_new_memory(void* p, size_t nSize, const char* pSrc, size_t nSrcLen)
-	{
-		char* s = (char*)p;
-		size_t i;
-		for(i = 0; i < nSize; i++)
-		{
-			*s++ = pSrc[i%nSrcLen];
-		}
-	}
-	inline void* operator new(size_t nSize)
-	{
-		void* p = ::malloc(nSize);
-		_fill_new_memory(p,nSize,"ﾆｭｰ",3); //確保されたばかりのメモリ状態は「ﾆｭｰﾆｭｰﾆｭｰ…」となります
-		return p;
-	}
-#ifdef _MSC_VER
-#if _MSC_VER == 1500
-	_Ret_bytecap_(_Size)	// for VS2008 Debug mode
-#endif
-#endif
-	inline void* operator new[](size_t nSize)
-	{
-		void* p = ::malloc(nSize);
-		_fill_new_memory(p,nSize,"ｷﾞｭｰ",4); //確保されたばかりのメモリ状態は「ｷﾞｭｰｷﾞｭｰｷﾞｭｰ…」となります
-		return p;
-	}
-	inline void operator delete(void* p)
-	{
-		::free(p);
-	}
-	inline void operator delete[](void* p)
-	{
-		::free(p);
-	}
+	void* operator new(size_t nSize);
+	#ifdef _MSC_VER
+		#if _MSC_VER == 1500
+			_Ret_bytecap_(_Size)	// for VS2008 Debug mode
+		#endif
+	#endif
+	void* operator new[](size_t nSize);
+	void operator delete(void* p);
+	void operator delete[](void* p);
 #endif
 
 


### PR DESCRIPTION
## operator new/delete の warning C9595 対策
- build_config.h で inline 定義されていた operator new/delete の定義を build_config.cpp 側に移した。
- build_config.cpp のエンコーディングを UTF-8 にする都合で、文字列定数で半角カナを使うのはやめてASCII文字列に差し替え。

## 関連PR
- ビルド時警告の削減 #48

operator new/delete 部分についてはちょっと処理がややこしいので原作者 (kobake) のほうで対応。
