### PR TITLE
appveyor.yml の構成変更

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,28 +6,34 @@ init:
 - ps: Start-Sleep -s 5
 - ps: Restart-Computer
 
+configuration:
+  - Release
+  - Debug
+
+platform:
+  - x86
+
 build_script:
 - cmd: >-
     set SLN_FILE=sakura\sakura.sln
 
+    echo PLATFORM      %PLATFORM%
+
+    echo CONFIGURATION %CONFIGURATION%
 
     set EXTRA_CMD=/verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
     set MSBUILD_EXE="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
 
 
-    echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=x86 /p:Configuration=Debug      /t:"Clean","Rebuild"  %EXTRA_CMD%
-         %MSBUILD_EXE% %SLN_FILE% /p:Platform=x86 /p:Configuration=Debug      /t:"Clean","Rebuild"  %EXTRA_CMD%
 
-    echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=x86 /p:Configuration=Release    /t:"Clean","Rebuild"  %EXTRA_CMD%
-         %MSBUILD_EXE% %SLN_FILE% /p:Platform=x86 /p:Configuration=Release    /t:"Clean","Rebuild"  %EXTRA_CMD%
+    echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
+         %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
 
     echo appveyor_yml
 
 artifacts:
-- path: sakura\Debug\sakura.exe
-- path: sakura\Debug\sakura.pdb
-- path: sakura\Release\sakura.exe
-- path: sakura\Release\sakura.pdb
-- path: sakura_lang_en_US\Debug\sakura_lang_en_US.dll
-- path: sakura_lang_en_US\Release\sakura_lang_en_US.dll
+- path: sakura\%CONFIGURATION%\sakura.exe
+- path: sakura\%CONFIGURATION%\sakura.pdb
+- path: sakura_lang_en_US\%CONFIGURATION%\sakura_lang_en_US.dll
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ build_script:
     echo appveyor_yml
 
 artifacts:
-- path: sakura\%CONFIGURATION%\sakura.exe
-- path: sakura\%CONFIGURATION%\sakura.pdb
-- path: sakura_lang_en_US\%CONFIGURATION%\sakura_lang_en_US.dll
+- path: sakura\$(configuration)\sakura.exe
+- path: sakura\$(configuration)\sakura.pdb
+- path: sakura_lang_en_US\$(configuration)\sakura_lang_en_US.dll
 


### PR DESCRIPTION
# 概略

現状の appveyor.yml は一度のブートで Debug/Release の構成のビルドを行います。

# 修正の背景

しかしながら、#40  で試しに x64 対応したソリューションでは
x86 の構成をビルドした後に、x64 をビルドするとコンパイルが通りますが、
クリーン環境で x64 をビルドするとコンパイルエラーになります。

これは、x86 版では HeaderMake.exe がプロジェクトファイルと同じディレクトリに生成されて
それを前提に preBuild.bat が実行されるが、
x64 では $(SolutionDir)$(Platform)\$(Configuration) に HeaderMake.exe が生成されるので
preBuild.bat を実行実行しても必要なヘッダファイルが生成されないためです。

# 修正の目的

別のビルドの生成物によってビルドに成功したり、失敗する問題を検出するために
各ビルドがクリーン環境でビルドされるように変更します。

# 修正のデメリット

各構成をビルドするたびに、ターゲット環境の再起動等が走るので
トータルのビルド時間が長くなります。









