### PR TITLE
ソリューションを最上位階層に移動

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Backup
 *.iobj
 *.ipdb
 UpgradeLog.htm
+/Win32

--- a/HeaderMake/HeaderMake.vcxproj
+++ b/HeaderMake/HeaderMake.vcxproj
@@ -41,12 +41,12 @@
     <_ProjectFileVersion>15.0.27130.2020</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)</OutDir>
+    <OutDir>$(SolutionDir)sakura\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)</OutDir>
+    <OutDir>$(SolutionDir)sakura\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
@@ -63,7 +63,7 @@
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile> 
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -80,7 +80,7 @@
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile> 
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/MakefileMake/MakefileMake.vcxproj
+++ b/MakefileMake/MakefileMake.vcxproj
@@ -41,12 +41,12 @@
     <_ProjectFileVersion>15.0.27130.2020</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)</OutDir>
+    <OutDir>$(SolutionDir)sakura\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)</OutDir>
+    <OutDir>$(SolutionDir)sakura\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
@@ -63,7 +63,7 @@
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile> 
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -80,7 +80,7 @@
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile> 
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://github.com/sakura-editor/sakura/wiki
 More information: https://github.com/sakura-editor/sakura/issues/6
 
 ## How to build
-Visual Studio Community 2017 で `sakura/sakura.sln` を開いてビルド。
+Visual Studio Community 2017 で `sakura.sln` を開いてビルド。
 
 ## CI Build (AppVeyor)
 本リポジトリの最新 master は以下の AppVeyor プロジェクト上で自動ビルドされます。  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ platform:
 
 build_script:
 - cmd: >-
-    set SLN_FILE=sakura\sakura.sln
+    set SLN_FILE=sakura.sln
 
     echo PLATFORM      %PLATFORM%
 
@@ -33,6 +33,6 @@ build_script:
     echo appveyor_yml
 
 artifacts:
-- path: sakura\**\**\*.exe
-- path: sakura\**\**\*.dll
-- path: sakura\**\**\*.pdb
+- path: '**\$(configuration)\*.exe'
+- path: '**\$(configuration)\*.dll'
+- path: '**\$(configuration)\*.pdb'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ configuration:
   - Debug
 
 platform:
-  - x86
+  - Win32
 
 build_script:
 - cmd: >-
@@ -33,6 +33,6 @@ build_script:
     echo appveyor_yml
 
 artifacts:
-- path: '**\$(configuration)\*.exe'
-- path: '**\$(configuration)\*.dll'
-- path: '**\$(configuration)\*.pdb'
+- path: '$(platform)\$(configuration)\*.exe'
+- path: '$(platform)\$(configuration)\*.dll'
+- path: '$(platform)\$(configuration)\*.pdb'

--- a/sakura.sln
+++ b/sakura.sln
@@ -2,13 +2,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sakura", "sakura.vcxproj", "{AF03508C-515E-4A0E-87BE-67ED1E254BD0}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sakura", "sakura\sakura.vcxproj", "{AF03508C-515E-4A0E-87BE-67ED1E254BD0}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HeaderMake", "..\HeaderMake\HeaderMake.vcxproj", "{0F2918B0-23E3-42E8-A1A8-8739F726A23E}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HeaderMake", "HeaderMake\HeaderMake.vcxproj", "{0F2918B0-23E3-42E8-A1A8-8739F726A23E}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MakefileMake", "..\MakefileMake\MakefileMake.vcxproj", "{40735439-B12B-40AC-92F7-F1183D8B6862}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MakefileMake", "MakefileMake\MakefileMake.vcxproj", "{40735439-B12B-40AC-92F7-F1183D8B6862}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sakura_lang_en_US", "..\sakura_lang_en_US\sakura_lang.vcxproj", "{7A6D0F29-E560-4985-835B-5F92A08EB242}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sakura_lang_en_US", "sakura_lang_en_US\sakura_lang.vcxproj", "{7A6D0F29-E560-4985-835B-5F92A08EB242}"
 	ProjectSection(ProjectDependencies) = postProject
 		{AF03508C-515E-4A0E-87BE-67ED1E254BD0} = {AF03508C-515E-4A0E-87BE-67ED1E254BD0}
 	EndProjectSection

--- a/sakura.sln
+++ b/sakura.sln
@@ -15,26 +15,26 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sakura_lang_en_US", "sakura
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AF03508C-515E-4A0E-87BE-67ED1E254BD0}.Debug|x86.ActiveCfg = Debug|Win32
-		{AF03508C-515E-4A0E-87BE-67ED1E254BD0}.Debug|x86.Build.0 = Debug|Win32
-		{AF03508C-515E-4A0E-87BE-67ED1E254BD0}.Release|x86.ActiveCfg = Release|Win32
-		{AF03508C-515E-4A0E-87BE-67ED1E254BD0}.Release|x86.Build.0 = Release|Win32
-		{0F2918B0-23E3-42E8-A1A8-8739F726A23E}.Debug|x86.ActiveCfg = Debug|Win32
-		{0F2918B0-23E3-42E8-A1A8-8739F726A23E}.Debug|x86.Build.0 = Debug|Win32
-		{0F2918B0-23E3-42E8-A1A8-8739F726A23E}.Release|x86.ActiveCfg = Release|Win32
-		{0F2918B0-23E3-42E8-A1A8-8739F726A23E}.Release|x86.Build.0 = Release|Win32
-		{40735439-B12B-40AC-92F7-F1183D8B6862}.Debug|x86.ActiveCfg = Debug|Win32
-		{40735439-B12B-40AC-92F7-F1183D8B6862}.Debug|x86.Build.0 = Debug|Win32
-		{40735439-B12B-40AC-92F7-F1183D8B6862}.Release|x86.ActiveCfg = Release|Win32
-		{40735439-B12B-40AC-92F7-F1183D8B6862}.Release|x86.Build.0 = Release|Win32
-		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Debug|x86.ActiveCfg = Debug|Win32
-		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Debug|x86.Build.0 = Debug|Win32
-		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Release|x86.ActiveCfg = Release|Win32
-		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Release|x86.Build.0 = Release|Win32
+		{AF03508C-515E-4A0E-87BE-67ED1E254BD0}.Debug|Win32.ActiveCfg = Debug|Win32
+		{AF03508C-515E-4A0E-87BE-67ED1E254BD0}.Debug|Win32.Build.0 = Debug|Win32
+		{AF03508C-515E-4A0E-87BE-67ED1E254BD0}.Release|Win32.ActiveCfg = Release|Win32
+		{AF03508C-515E-4A0E-87BE-67ED1E254BD0}.Release|Win32.Build.0 = Release|Win32
+		{0F2918B0-23E3-42E8-A1A8-8739F726A23E}.Debug|Win32.ActiveCfg = Debug|Win32
+		{0F2918B0-23E3-42E8-A1A8-8739F726A23E}.Debug|Win32.Build.0 = Debug|Win32
+		{0F2918B0-23E3-42E8-A1A8-8739F726A23E}.Release|Win32.ActiveCfg = Release|Win32
+		{0F2918B0-23E3-42E8-A1A8-8739F726A23E}.Release|Win32.Build.0 = Release|Win32
+		{40735439-B12B-40AC-92F7-F1183D8B6862}.Debug|Win32.ActiveCfg = Debug|Win32
+		{40735439-B12B-40AC-92F7-F1183D8B6862}.Debug|Win32.Build.0 = Debug|Win32
+		{40735439-B12B-40AC-92F7-F1183D8B6862}.Release|Win32.ActiveCfg = Release|Win32
+		{40735439-B12B-40AC-92F7-F1183D8B6862}.Release|Win32.Build.0 = Release|Win32
+		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Debug|Win32.Build.0 = Debug|Win32
+		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Release|Win32.ActiveCfg = Release|Win32
+		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
ソリューションが複数プロジェクトを持っているときにはソリューションとプロジェクトのフォルダが同一階層にあるのは好ましくないため、ソリューションの場所を一階層上げます。

## 注記
ソリューションの Platform (x86) とプロジェクトの Platform (Win32) の名前が一致していないため、Platform を出力パスに含めると AppVeyor の artifacts の指定が難しくなる。今回は Platform 名を Win32 に寄せることで差異を解消した。(プロジェクト側の Platform 名を変更しようとすると Toolset 影響があるため、ソリューション側の Platform 名 (こちらは単なるラベル) を変えた)

## ビルド結果イメージ
```
sakura/
  HeaderMake.exe
  MakefileMake.exe

Win32/Debug/
  sakura.exe
  sakura_lang_en_US.dll

Win32/Release/
  sakura.exe
  sakura_lang_en_US.dll
```
