### PR TITLE
 dlg 配下のいくつかのファイルを UTF-8 (BOM付) に単純変換

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief Dialog Box�̊��N���X
+﻿/*!	@file
+	@brief Dialog Boxの基底クラス
 
 	@author Norio Nakatani
 */
@@ -28,7 +28,7 @@
 #include "util/shell.h"
 #include "util/module.h"
 
-/* �_�C�A���O�v���V�[�W�� */
+/* ダイアログプロシージャ */
 INT_PTR CALLBACK MyDialogProc(
 	HWND hwndDlg,	// handle to dialog box
 	UINT uMsg,		// message
@@ -57,19 +57,19 @@ INT_PTR CALLBACK MyDialogProc(
 }
 
 
-/*!	�R���X�g���N�^
+/*!	コンストラクタ
 
-	@date 2002.2.17 YAZAKI CShareData�̃C���X�^���X�́ACProcess�ɂЂƂ���̂݁B
+	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 */
 CDialog::CDialog(bool bSizable, bool bCheckShareData)
 {
 //	MYTRACE( _T("CDialog::CDialog()\n") );
-	/* ���L�f�[�^�\���̂̃A�h���X��Ԃ� */
+	/* 共有データ構造体のアドレスを返す */
 	m_pShareData = &GetDllShareData(bCheckShareData);
 
-	m_hInstance = NULL;		/* �A�v���P�[�V�����C���X�^���X�̃n���h�� */
-	m_hwndParent = NULL;	/* �I�[�i�[�E�B���h�E�̃n���h�� */
-	m_hWnd  = NULL;			/* ���̃_�C�A���O�̃n���h�� */
+	m_hInstance = NULL;		/* アプリケーションインスタンスのハンドル */
+	m_hwndParent = NULL;	/* オーナーウィンドウのハンドル */
+	m_hWnd  = NULL;			/* このダイアログのハンドル */
 	m_hwndSizeBox = NULL;
 	m_bSizable = bSizable;
 	m_lParam = (LPARAM)NULL;
@@ -89,21 +89,21 @@ CDialog::~CDialog()
 	return;
 }
 
-//! ���[�_���_�C�A���O�̕\��
+//! モーダルダイアログの表示
 /*!
-	@param hInstance [in] �A�v���P�[�V�����C���X�^���X�̃n���h��
-	@param hwndParent [in] �I�[�i�[�E�B���h�E�̃n���h��
+	@param hInstance [in] アプリケーションインスタンスのハンドル
+	@param hwndParent [in] オーナーウィンドウのハンドル
 
-	@date 2011.04.10 nasukoji	�e���ꃁ�b�Z�[�W���\�[�X�Ή�
+	@date 2011.04.10 nasukoji	各国語メッセージリソース対応
 */
 INT_PTR CDialog::DoModal( HINSTANCE hInstance, HWND hwndParent, int nDlgTemplete, LPARAM lParam )
 {
 	m_bInited = FALSE;
 	m_bModal = TRUE;
-	m_hInstance = hInstance;	/* �A�v���P�[�V�����C���X�^���X�̃n���h�� */
-	m_hwndParent = hwndParent;	/* �I�[�i�[�E�B���h�E�̃n���h�� */
+	m_hInstance = hInstance;	/* アプリケーションインスタンスのハンドル */
+	m_hwndParent = hwndParent;	/* オーナーウィンドウのハンドル */
 	m_lParam = lParam;
-	m_hLangRsrcInstance = CSelectLang::getLangRsrcInstance();		// ���b�Z�[�W���\�[�XDLL�̃C���X�^���X�n���h��
+	m_hLangRsrcInstance = CSelectLang::getLangRsrcInstance();		// メッセージリソースDLLのインスタンスハンドル
 	return ::DialogBoxParam(
 		m_hLangRsrcInstance,
 		MAKEINTRESOURCE( nDlgTemplete ),
@@ -113,21 +113,21 @@ INT_PTR CDialog::DoModal( HINSTANCE hInstance, HWND hwndParent, int nDlgTemplete
 	);
 }
 
-//! ���[�h���X�_�C�A���O�̕\��
+//! モードレスダイアログの表示
 /*!
-	@param hInstance [in] �A�v���P�[�V�����C���X�^���X�̃n���h��
-	@param hwndParent [in] �I�[�i�[�E�B���h�E�̃n���h��
+	@param hInstance [in] アプリケーションインスタンスのハンドル
+	@param hwndParent [in] オーナーウィンドウのハンドル
 
-	@date 2011.04.10 nasukoji	�e���ꃁ�b�Z�[�W���\�[�X�Ή�
+	@date 2011.04.10 nasukoji	各国語メッセージリソース対応
 */
 HWND CDialog::DoModeless( HINSTANCE hInstance, HWND hwndParent, int nDlgTemplete, LPARAM lParam, int nCmdShow )
 {
 	m_bInited = FALSE;
 	m_bModal = FALSE;
-	m_hInstance = hInstance;	/* �A�v���P�[�V�����C���X�^���X�̃n���h�� */
-	m_hwndParent = hwndParent;	/* �I�[�i�[�E�B���h�E�̃n���h�� */
+	m_hInstance = hInstance;	/* アプリケーションインスタンスのハンドル */
+	m_hwndParent = hwndParent;	/* オーナーウィンドウのハンドル */
 	m_lParam = lParam;
-	m_hLangRsrcInstance = CSelectLang::getLangRsrcInstance();		// ���b�Z�[�W���\�[�XDLL�̃C���X�^���X�n���h��
+	m_hLangRsrcInstance = CSelectLang::getLangRsrcInstance();		// メッセージリソースDLLのインスタンスハンドル
 	m_hWnd = ::CreateDialogParam(
 		m_hLangRsrcInstance,
 		MAKEINTRESOURCE( nDlgTemplete ),
@@ -145,8 +145,8 @@ HWND CDialog::DoModeless( HINSTANCE hInstance, HWND hwndParent, LPCDLGTEMPLATE l
 {
 	m_bInited = FALSE;
 	m_bModal = FALSE;
-	m_hInstance = hInstance;	/* �A�v���P�[�V�����C���X�^���X�̃n���h�� */
-	m_hwndParent = hwndParent;	/* �I�[�i�[�E�B���h�E�̃n���h�� */
+	m_hInstance = hInstance;	/* アプリケーションインスタンスのハンドル */
+	m_hwndParent = hwndParent;	/* オーナーウィンドウのハンドル */
 	m_lParam = lParam;
 	m_hWnd = ::CreateDialogIndirectParam(
 		m_hInstance,
@@ -182,7 +182,7 @@ BOOL CDialog::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	// Modified by KEITA for WIN64 2003.9.6
 	::SetWindowLongPtr( m_hWnd, DWLP_USER, lParam );
 
-	/* �_�C�A���O�f�[�^�̐ݒ� */
+	/* ダイアログデータの設定 */
 	SetData();
 
 	SetDialogPosSize();
@@ -194,7 +194,7 @@ BOOL CDialog::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 void CDialog::SetDialogPosSize()
 {
 #if 0
-	/* �_�C�A���O�̃T�C�Y�A�ʒu�̍Č� */
+	/* ダイアログのサイズ、位置の再現 */
 	if( -1 != m_xPos && -1 != m_yPos ){
 		::SetWindowPos( m_hWnd, NULL, m_xPos, m_yPos, 0, 0, SWP_NOSIZE | SWP_NOOWNERZORDER | SWP_NOZORDER );
 		DEBUG_TRACE( _T("CDialog::OnInitDialog() m_xPos=%d m_yPos=%d\n"), m_xPos, m_yPos );
@@ -205,8 +205,8 @@ void CDialog::SetDialogPosSize()
 #endif
 
 	if( -1 != m_xPos && -1 != m_yPos ){
-		/* �E�B���h�E�ʒu�E�T�C�Y���Č� */
-		// 2014.11.28 �t�H���g�ύX�Ή�
+		/* ウィンドウ位置・サイズを再現 */
+		// 2014.11.28 フォント変更対応
 		if( m_nWidth == -1 && m_nHeight == -1 ){
 			RECT	rc;
 			::GetWindowRect( m_hWnd, &rc );
@@ -216,12 +216,12 @@ void CDialog::SetDialogPosSize()
 
 		if( !(::GetWindowLongPtr( m_hWnd, GWL_STYLE ) & WS_CHILD) ){
 			// 2006.06.09 ryoji
-			// ���j�^�̃��[�N�̈�������E�㉺�ɂP�h�b�g�������̈���ɑS�̂����܂�悤�Ɉʒu��������
+			// モニタのワーク領域よりも左右上下に１ドット小さい領域内に全体が収まるように位置調整する
 			//
-			// note: �_�C�A���O�����[�N�̈拫�E�ɂ҂����荇�킹�悤�Ƃ���ƁA
-			//       �����I�ɐe�̒����Ɉړ��������Ă��܂��Ƃ�������
-			//      �i�}���`���j�^���Őe����v���C�}�����j�^�ɂ���ꍇ�����H�j
-			//       �󋵂ɍ��킹�ď�����ς���͖̂��Ȃ̂ŁA�ꗥ�A�P�h�b�g�̋󂫂�����
+			// note: ダイアログをワーク領域境界にぴったり合わせようとすると、
+			//       強制的に親の中央に移動させられてしまうときがある
+			//      （マルチモニタ環境で親が非プライマリモニタにある場合だけ？）
+			//       状況に合わせて処理を変えるのは厄介なので、一律、１ドットの空きを入れる
 
 			RECT rc;
 			RECT rcWork;
@@ -258,7 +258,7 @@ void CDialog::SetDialogPosSize()
 
 		WINDOWPLACEMENT cWindowPlacement;
 		cWindowPlacement.length = sizeof( cWindowPlacement );
-		cWindowPlacement.showCmd = m_nShowCmd;	//	�ő剻�E�ŏ���
+		cWindowPlacement.showCmd = m_nShowCmd;	//	最大化・最小化
 		cWindowPlacement.rcNormalPosition.left = m_xPos;
 		cWindowPlacement.rcNormalPosition.top = m_yPos;
 		cWindowPlacement.rcNormalPosition.right = m_nWidth + m_xPos;
@@ -269,11 +269,11 @@ void CDialog::SetDialogPosSize()
 
 BOOL CDialog::OnDestroy( void )
 {
-	/* �E�B���h�E�ʒu�E�T�C�Y���L�� */
+	/* ウィンドウ位置・サイズを記憶 */
 	WINDOWPLACEMENT cWindowPlacement;
 	cWindowPlacement.length = sizeof( cWindowPlacement );
 	if (::GetWindowPlacement( m_hWnd, &cWindowPlacement )){
-		m_nShowCmd = cWindowPlacement.showCmd;	//	�ő剻�E�ŏ���
+		m_nShowCmd = cWindowPlacement.showCmd;	//	最大化・最小化
 		m_xPos = cWindowPlacement.rcNormalPosition.left;
 		m_yPos = cWindowPlacement.rcNormalPosition.top;
 		m_nWidth = cWindowPlacement.rcNormalPosition.right - cWindowPlacement.rcNormalPosition.left;
@@ -283,7 +283,7 @@ BOOL CDialog::OnDestroy( void )
 		m_nWidth = -1;
 		m_nHeight = -1;
 	}
-	/* �j�� */
+	/* 破棄 */
 	if( NULL != m_hwndSizeBox ){
 		::DestroyWindow( m_hwndSizeBox );
 		m_hwndSizeBox = NULL;
@@ -314,27 +314,27 @@ BOOL CDialog::OnSize( WPARAM wParam, LPARAM lParam )
 	RECT	rc;
 	::GetWindowRect( m_hWnd, &rc );
 
-	/* �_�C�A���O�̃T�C�Y�̋L�� */
+	/* ダイアログのサイズの記憶 */
 	m_xPos = rc.left;
 	m_yPos = rc.top;
 	m_nWidth = rc.right - rc.left;
 	m_nHeight = rc.bottom - rc.top;
 
-	/* �T�C�Y�{�b�N�X�̈ړ� */
+	/* サイズボックスの移動 */
 	if( NULL != m_hwndSizeBox ){
 		::GetClientRect( m_hWnd, &rc );
 //		::SetWindowPos( m_hwndSizeBox, NULL,
-//	Sept. 17, 2000 JEPRO_16thdot �A�C�R����16dot�ڂ��\�������悤�Ɏ��s��ύX����K�v����H
-//	Jan. 12, 2001 JEPRO (directed by stonee) 15��16�ɕύX����ƃA�E�g���C����͂̃_�C�A���O�̉E���ɂ���
-//	�O���b�v�T�C�Y��`�V��'���ł��Ă��܂�(�ړ�����I)�A�_�C�A���O��傫���ł��Ȃ��Ƃ�����Q����������̂�
-//	�ύX���Ȃ����Ƃɂ���(�v����Ɍ���łɖ߂�������)
+//	Sept. 17, 2000 JEPRO_16thdot アイコンの16dot目が表示されるように次行を変更する必要ある？
+//	Jan. 12, 2001 JEPRO (directed by stonee) 15を16に変更するとアウトライン解析のダイアログの右下にある
+//	グリップサイズに`遊び'ができてしまい(移動する！)、ダイアログを大きくできないという障害が発生するので
+//	変更しないことにした(要するに原作版に戻しただけ)
 //			rc.right - rc.left - 15, rc.bottom - rc.top - 15,
 //			13, 13,
 //			SWP_NOOWNERZORDER | SWP_NOZORDER
 //		);
 
 //	Jan. 12, 2001 Stonee (suggested by genta)
-//		"13"�Ƃ����Œ�l�ł͂Ȃ��V�X�e������擾�����X�N���[���o�[�T�C�Y���g���悤�ɏC��
+//		"13"という固定値ではなくシステムから取得したスクロールバーサイズを使うように修正
 		::SetWindowPos( m_hwndSizeBox, NULL,
 		rc.right - rc.left - GetSystemMetrics(SM_CXVSCROLL), //<-- stonee
 		rc.bottom - rc.top - GetSystemMetrics(SM_CYHSCROLL), //<-- stonee
@@ -343,7 +343,7 @@ BOOL CDialog::OnSize( WPARAM wParam, LPARAM lParam )
 		SWP_NOOWNERZORDER | SWP_NOZORDER
 		);
 
-		//	SizeBox���e�X�g
+		//	SizeBox問題テスト
 		if( wParam == SIZE_MAXIMIZED ){
 			::ShowWindow( m_hwndSizeBox, SW_HIDE );
 		}else{
@@ -358,14 +358,14 @@ BOOL CDialog::OnSize( WPARAM wParam, LPARAM lParam )
 BOOL CDialog::OnMove( WPARAM wParam, LPARAM lParam )
 {
 
-	/* �_�C�A���O�̈ʒu�̋L�� */
+	/* ダイアログの位置の記憶 */
 	if( !m_bInited ){
 		return TRUE;
 	}
 	RECT	rc;
 	::GetWindowRect( m_hWnd, &rc );
 
-	/* �_�C�A���O�̃T�C�Y�̋L�� */
+	/* ダイアログのサイズの記憶 */
 	m_xPos = rc.left;
 	m_yPos = rc.top;
 	m_nWidth = rc.right - rc.left;
@@ -379,7 +379,7 @@ BOOL CDialog::OnMove( WPARAM wParam, LPARAM lParam )
 
 void CDialog::CreateSizeBox( void )
 {
-	/* �T�C�Y�{�b�N�X */
+	/* サイズボックス */
 	m_hwndSizeBox = ::CreateWindowEx(
 		WS_EX_CONTROLPARENT,								/* no extended styles */
 		_T("SCROLLBAR"),									/* scroll bar control class */
@@ -403,7 +403,7 @@ void CDialog::CreateSizeBox( void )
 
 
 
-/* �_�C�A���O�̃��b�Z�[�W���� */
+/* ダイアログのメッセージ処理 */
 INT_PTR CDialog::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 //	DEBUG_TRACE( _T("CDialog::DispatchEvent() uMsg == %xh\n"), uMsg );
@@ -436,23 +436,23 @@ BOOL CDialog::OnCommand( WPARAM wParam, LPARAM lParam )
 	WORD	wNotifyCode;
 	WORD	wID;
 	HWND	hwndCtl;
-	wNotifyCode = HIWORD(wParam);	/* �ʒm�R�[�h */
-	wID			= LOWORD(wParam);	/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
-	hwndCtl		= (HWND) lParam;	/* �R���g���[���̃n���h�� */
+	wNotifyCode = HIWORD(wParam);	/* 通知コード */
+	wID			= LOWORD(wParam);	/* 項目ID、 コントロールID、 またはアクセラレータID */
+	hwndCtl		= (HWND) lParam;	/* コントロールのハンドル */
 	TCHAR	szClass[32];
 
-	// IDOK �� IDCANCEL �̓{�^������łȂ��Ă���������
+	// IDOK と IDCANCEL はボタンからでなくても同じ扱い
 	// MSDN [Windows Management] "Dialog Box Programming Considerations"
 	if( wID == IDOK || wID == IDCANCEL ){
 		return OnBnClicked( wID );
 	}
 
-	// �ʒm�����R���g���[���������ꍇ�̏���
+	// 通知元がコントロールだった場合の処理
 	if( hwndCtl ){
 		::GetClassName(hwndCtl, szClass, _countof(szClass));
 		if( ::lstrcmpi(szClass, _T("Button")) == 0 ){
 			switch( wNotifyCode ){
-			/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+			/* ボタン／チェックボックスがクリックされた */
 			case BN_CLICKED:	return OnBnClicked( wID );
 			}
 		}else if( ::lstrcmpi(szClass, _T("Static")) == 0 ){
@@ -471,9 +471,9 @@ BOOL CDialog::OnCommand( WPARAM wParam, LPARAM lParam )
 			}
 		}else if( ::lstrcmpi(szClass, _T("ComboBox")) == 0 ){
 			switch( wNotifyCode ){
-			/* �R���{�{�b�N�X�p���b�Z�[�W */
+			/* コンボボックス用メッセージ */
 			case CBN_SELCHANGE:	return OnCbnSelChange( hwndCtl, wID );
-			// @@2005.03.31 MIK �^�O�W�����vDialog�Ŏg���̂Œǉ�
+			// @@2005.03.31 MIK タグジャンプDialogで使うので追加
 			case CBN_EDITCHANGE:	return OnCbnEditChange( hwndCtl, wID );
 			case CBN_DROPDOWN:	return OnCbnDropDown( hwndCtl, wID );
 		//	case CBN_CLOSEUP:	return OnCbnCloseUp( hwndCtl, wID );
@@ -489,13 +489,13 @@ BOOL CDialog::OnCommand( WPARAM wParam, LPARAM lParam )
 BOOL CDialog::OnPopupHelp( WPARAM wPara, LPARAM lParam )
 {
 	HELPINFO *p = (HELPINFO *)lParam;
-	MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)GetHelpIdTable() );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+	MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)GetHelpIdTable() );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 	return TRUE;
 }
 
 BOOL CDialog::OnContextMenu( WPARAM wPara, LPARAM lParam )
 {
-	MyWinHelp( m_hWnd, HELP_CONTEXTMENU, (ULONG_PTR)GetHelpIdTable() );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+	MyWinHelp( m_hWnd, HELP_CONTEXTMENU, (ULONG_PTR)GetHelpIdTable() );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 	return TRUE;
 }
 
@@ -511,26 +511,26 @@ LPVOID CDialog::GetHelpIdTable(void)
 
 BOOL CDialog::OnCbnSelEndOk( HWND hwndCtl, int wID )
 {
-	//�R���{�{�b�N�X�̃��X�g��\�������܂ܕ������ҏW���AEnter�L�[��
-	//�����ƕ����񂪏����錻�ۂ̑΍�B
-	//Enter�L�[�������Ă��̊֐��ɓ�������A���X�g���\���ɂ��Ă��܂��B
+	//コンボボックスのリストを表示したまま文字列を編集し、Enterキーを
+	//押すと文字列が消える現象の対策。
+	//Enterキーを押してこの関数に入ったら、リストを非表示にしてしまう。
 
-	//���X�g���\���ɂ���ƑO����v���镶�����I��ł��܂��̂ŁA
-	//���O�ɕ������ޔ����A���X�g��\����ɕ�������B
+	//リストを非表示にすると前方一致する文字列を選んでしまうので、
+	//事前に文字列を退避し、リスト非表示後に復元する。
 
 	int nLength;
 	LPTSTR sBuf;
 
-	//�������ޔ�
+	//文字列を退避
 	nLength = ::GetWindowTextLength( hwndCtl );
 	sBuf = new TCHAR[nLength + 1];
 	::GetWindowText( hwndCtl, sBuf, nLength+1 );
 	sBuf[nLength] = _T('\0');
 
-	//���X�g���\���ɂ���
+	//リストを非表示にする
 	Combo_ShowDropdown( hwndCtl, FALSE );
 
-	//������𕜌��E�S�I��
+	//文字列を復元・全選択
 	::SetWindowText( hwndCtl, sBuf );
 	Combo_SetEditSel( hwndCtl, 0, -1 );
 	delete[] sBuf;
@@ -542,16 +542,16 @@ BOOL CDialog::OnCbnDropDown( HWND hwndCtl, int wID )
 {
 	return OnCbnDropDown( hwndCtl, false );
 }
-/** �R���{�{�b�N�X�̃h���b�v�_�E��������
+/** コンボボックスのドロップダウン時処理
 
-	�R���{�{�b�N�X���h���b�v�_�E������鎞��
-	�h���b�v�_�E�����X�g�̕����A�C�e��������̍ő�\�����ɍ��킹��
+	コンボボックスがドロップダウンされる時に
+	ドロップダウンリストの幅をアイテム文字列の最大表示幅に合わせる
 
-	@param hwndCtl [in]		�R���{�{�b�N�X�̃E�B���h�E�n���h��
-	@param wID [in]			�R���{�{�b�N�X��ID
+	@param hwndCtl [in]		コンボボックスのウィンドウハンドル
+	@param wID [in]			コンボボックスのID
 
 	@author ryoji
-	@date 2009.03.29 �V�K�쐬
+	@date 2009.03.29 新規作成
 */
 BOOL CDialog::OnCbnDropDown( HWND hwndCtl, bool scrollBar )
 {
@@ -597,14 +597,14 @@ bool CDialog::DirectoryUp( TCHAR* szDir )
 {
 	size_t nLen = auto_strlen( szDir );
 	if( 3 < nLen ){
-		// X:\ ��\\. ��蒷��
+		// X:\ や\\. より長い
 		CutLastYenFromDirectoryPath( szDir );
 		const TCHAR *p = GetFileTitlePointer(szDir);
 		if( 0 < p - szDir){
 			if( 3 < p - szDir ){
-				szDir[p - szDir - 1] = '\0'; // \�����̂�-1
+				szDir[p - szDir - 1] = '\0'; // \を削るので-1
 			}else{
-				// �uC:\�v��\���c��
+				// 「C:\」の\を残す
 				szDir[p - szDir] = '\0';
 			}
 		}
@@ -613,7 +613,7 @@ bool CDialog::DirectoryUp( TCHAR* szDir )
 	return false;
 }
 
-// �R���g���[���ɉ�ʂ̃t�H���g��ݒ�	2012/11/27 Uchi
+// コントロールに画面のフォントを設定	2012/11/27 Uchi
 HFONT CDialog::SetMainFont( HWND hTarget )
 {
 	if (hTarget == NULL)	return NULL;
@@ -621,12 +621,12 @@ HFONT CDialog::SetMainFont( HWND hTarget )
 	HFONT	hFont;
 	LOGFONT	lf;
 
-	// �ݒ肷��t�H���g�̍������擾
+	// 設定するフォントの高さを取得
 	hFont = (HFONT)::SendMessage(hTarget, WM_GETFONT, 0, 0);
 	GetObject(hFont, sizeof(lf), &lf);
 	LONG nfHeight = lf.lfHeight;
 
-	// LOGFONT�̍쐬
+	// LOGFONTの作成
 	lf = m_pShareData->m_Common.m_sView.m_lf;
 	lf.lfHeight			= nfHeight;
 	lf.lfWidth			= 0;
@@ -637,16 +637,16 @@ HFONT CDialog::SetMainFont( HWND hTarget )
 	lf.lfUnderline		= FALSE;
 	lf.lfStrikeOut		= FALSE;
 	//lf.lfCharSet		= lf.lfCharSet;
-	lf.lfOutPrecision	= OUT_TT_ONLY_PRECIS;		// Raster Font ���g��Ȃ��悤��
+	lf.lfOutPrecision	= OUT_TT_ONLY_PRECIS;		// Raster Font を使わないように
 	//lf.lfClipPrecision	= lf.lfClipPrecision;
 	//lf.lfQuality		= lf.lfQuality;
 	//lf.lfPitchAndFamily	= lf.lfPitchAndFamily;
-	//_tcsncpy( lf.lfFaceName, lf.lfFaceName, _countof(lf.lfFaceName));	// ��ʂ̃t�H���g�ɐݒ�	2012/11/27 Uchi
+	//_tcsncpy( lf.lfFaceName, lf.lfFaceName, _countof(lf.lfFaceName));	// 画面のフォントに設定	2012/11/27 Uchi
 
-	// �t�H���g���쐬
+	// フォントを作成
 	hFont = ::CreateFontIndirect(&lf);
 	if (hFont) {
-		// �t�H���g�̐ݒ�
+		// フォントの設定
 		::SendMessage(hTarget, WM_SETFONT, (WPARAM)hFont, MAKELPARAM(FALSE, 0));
 	}
 	return hFont;
@@ -661,7 +661,7 @@ void CDialog::ResizeItem( HWND hTarget, const POINT& ptDlgDefault, const POINT& 
 	width = rcItemDefault.right - rcItemDefault.left;
 	height = rcItemDefault.bottom - rcItemDefault.top;
 	if( (anchor & (ANCHOR_LEFT | ANCHOR_RIGHT)) == ANCHOR_LEFT ){
-		// �Ȃ�
+		// なし
 	}
 	else if( (anchor & (ANCHOR_LEFT | ANCHOR_RIGHT)) == ANCHOR_RIGHT ){
 		/*
@@ -682,7 +682,7 @@ void CDialog::ResizeItem( HWND hTarget, const POINT& ptDlgDefault, const POINT& 
 	}
 	
 	if( (anchor & (ANCHOR_TOP | ANCHOR_BOTTOM) ) == ANCHOR_TOP ){
-		// �Ȃ�
+		// なし
 	}
 	else if( (anchor & (ANCHOR_TOP | ANCHOR_BOTTOM) ) == ANCHOR_BOTTOM ){
 		pt.y = rcItemDefault.top + (ptDlgNew.y - ptDlgDefault.y);

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief Dialog BoxŠî’êƒNƒ‰ƒXƒwƒbƒ_ƒtƒ@ƒCƒ‹
+ï»¿/*!	@file
+	@brief Dialog BoxåŸºåº•ã‚¯ãƒ©ã‚¹ãƒ˜ãƒƒãƒ€ãƒ•ã‚¡ã‚¤ãƒ«
 
 	@author Norio Nakatani
 */
@@ -62,14 +62,14 @@ struct SComboBoxItemDeleter
 };
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 /*!
-	@brief ƒ_ƒCƒAƒƒOƒEƒBƒ“ƒhƒE‚ğˆµ‚¤ƒNƒ‰ƒX
+	@brief ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’æ‰±ã†ã‚¯ãƒ©ã‚¹
 
-	ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ğì‚é‚Æ‚«‚É‚Í‚±‚±‚©‚çŒp³‚³‚¹‚éD
+	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã‚’ä½œã‚‹ã¨ãã«ã¯ã“ã“ã‹ã‚‰ç¶™æ‰¿ã•ã›ã‚‹ï¼
 
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 */
 class CDialog
 {
@@ -82,10 +82,10 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	virtual INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );	/* ƒ_ƒCƒAƒƒO‚ÌƒƒbƒZ[ƒWˆ— */
-	INT_PTR DoModal( HINSTANCE, HWND, int, LPARAM );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
-	HWND DoModeless( HINSTANCE, HWND, int, LPARAM, int );	/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\¦ */
-	HWND DoModeless( HINSTANCE, HWND, LPCDLGTEMPLATE, LPARAM, int );	/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	virtual INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
+	INT_PTR DoModal( HINSTANCE, HWND, int, LPARAM );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
+	HWND DoModeless( HINSTANCE, HWND, int, LPARAM, int );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
+	HWND DoModeless( HINSTANCE, HWND, LPCDLGTEMPLATE, LPARAM, int );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 	void CloseDialog( INT_PTR );
 
 	virtual BOOL OnInitDialog( HWND, WPARAM wParam, LPARAM lParam );
@@ -99,8 +99,8 @@ public:
 	virtual BOOL OnTimer( WPARAM wParam ){return TRUE;}
 	virtual BOOL OnKeyDown( WPARAM wParam, LPARAM lParam ){return TRUE;}
 	virtual BOOL OnDeviceChange( WPARAM wParam, LPARAM lParam ){return TRUE;}
-	virtual int GetData( void ){return 1;}/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-	virtual void SetData( void ){return;}/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+	virtual int GetData( void ){return 1;}/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+	virtual void SetData( void ){return;}/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 	virtual BOOL OnBnClicked( int );
 	virtual BOOL OnStnClicked( int ){return FALSE;}
 	virtual BOOL OnEnChange( HWND hwndCtl, int wID ){return FALSE;}
@@ -108,7 +108,7 @@ public:
 	virtual BOOL OnLbnSelChange( HWND hwndCtl, int wID ){return FALSE;}
 	virtual BOOL OnLbnDblclk( int wID ){return FALSE;}
 	virtual BOOL OnCbnSelChange( HWND hwndCtl, int wID ){return FALSE;}
-	virtual BOOL OnCbnEditChange( HWND hwndCtl, int wID ){return FALSE;} // @@2005.03.31 MIK ƒ^ƒOƒWƒƒƒ“ƒvDialog
+	virtual BOOL OnCbnEditChange( HWND hwndCtl, int wID ){return FALSE;} // @@2005.03.31 MIK ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—Dialog
 	virtual BOOL OnCbnDropDown( HWND hwndCtl, int wID );
 	static BOOL OnCbnDropDown( HWND hwndCtl, bool scrollBar );
 //	virtual BOOL OnCbnCloseUp( HWND hwndCtl, int wID ){return FALSE;}
@@ -131,20 +131,20 @@ public:
 
 public:
 	HWND GetHwnd() const{ return m_hWnd; }
-	//“ÁêƒCƒ“ƒ^[ƒtƒF[ƒX (g—p‚ÍD‚Ü‚µ‚­‚È‚¢)
+	//ç‰¹æ®Šã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ (ä½¿ç”¨ã¯å¥½ã¾ã—ããªã„)
 	void _SetHwnd(HWND hwnd){ m_hWnd = hwnd; }
 
 public:
-	HINSTANCE		m_hInstance;	/* ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒCƒ“ƒXƒ^ƒ“ƒX‚Ìƒnƒ“ƒhƒ‹ */
-	HWND			m_hwndParent;	/* ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹ */
+	HINSTANCE		m_hInstance;	/* ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ« */
+	HWND			m_hwndParent;	/* ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ« */
 private:
-	HWND			m_hWnd;			/* ‚±‚Ìƒ_ƒCƒAƒƒO‚Ìƒnƒ“ƒhƒ‹ */
+	HWND			m_hWnd;			/* ã“ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒãƒ³ãƒ‰ãƒ« */
 public:
 	HWND			m_hwndSizeBox;
 	LPARAM			m_lParam;
-	BOOL			m_bModal;		/* ƒ‚[ƒ_ƒ‹ ƒ_ƒCƒAƒƒO‚© */
-	bool			m_bSizable;		// ‰Â•Ïƒ_ƒCƒAƒƒO‚©‚Ç‚¤‚©
-	int				m_nShowCmd;		//	Å‘å‰»/Å¬‰»
+	BOOL			m_bModal;		/* ãƒ¢ãƒ¼ãƒ€ãƒ« ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‹ */
+	bool			m_bSizable;		// å¯å¤‰ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‹ã©ã†ã‹
+	int				m_nShowCmd;		//	æœ€å¤§åŒ–/æœ€å°åŒ–
 	int				m_nWidth;
 	int				m_nHeight;
 	int				m_xPos;
@@ -152,7 +152,7 @@ public:
 //	void*			m_pcEditView;
 	DLLSHAREDATA*	m_pShareData;
 	BOOL			m_bInited;
-	HINSTANCE		m_hLangRsrcInstance;		// ƒƒbƒZ[ƒWƒŠƒ\[ƒXDLL‚ÌƒCƒ“ƒXƒ^ƒ“ƒXƒnƒ“ƒhƒ‹	// 2011.04.10 nasukoji
+	HINSTANCE		m_hLangRsrcInstance;		// ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒªã‚½ãƒ¼ã‚¹DLLã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ãƒãƒ³ãƒ‰ãƒ«	// 2011.04.10 nasukoji
 
 protected:
 	void CreateSizeBox( void );
@@ -160,7 +160,7 @@ protected:
 
 	HWND GetItemHwnd(int nID){ return ::GetDlgItem( GetHwnd(), nID ); }
 
-	// ƒRƒ“ƒgƒ[ƒ‹‚É‰æ–Ê‚ÌƒtƒHƒ“ƒg‚ğİ’è	2012/11/27 Uchi
+	// ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«ç”»é¢ã®ãƒ•ã‚©ãƒ³ãƒˆã‚’è¨­å®š	2012/11/27 Uchi
 	HFONT SetMainFont( HWND hTarget );
 };
 

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒo[ƒWƒ‡ƒ“î•ñƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
-	@date	1998/3/13 ì¬
+	@date	1998/3/13 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -25,10 +25,10 @@
 #include "util/file.h"
 #include "util/module.h"
 #include "gitrev.h"
-#include "sakura_rc.h" // 2002/2/10 aroka •œ‹A
+#include "sakura_rc.h" // 2002/2/10 aroka å¾©å¸°
 #include "sakura.hh"
 
-// ƒo[ƒWƒ‡ƒ“î•ñ CDlgAbout.cpp	//@@@ 2002.01.07 add start MIK
+// ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ± CDlgAbout.cpp	//@@@ 2002.01.07 add start MIK
 const DWORD p_helpids[] = {	//12900
 	IDOK,					HIDOK_ABOUT,
 	IDC_EDIT_ABOUT,			HIDC_ABOUT_EDIT_ABOUT,
@@ -41,8 +41,8 @@ const DWORD p_helpids[] = {	//12900
 };	//@@@ 2002.01.07 add end MIK
 
 //	From Here Feb. 7, 2002 genta
-// 2006.01.17 Moca COMPILER_VER‚ð’Ç‰Á
-// 2010.04.15 Moca icc/dmc‚ð’Ç‰Á‚µCPU‚ð•ª—£
+// 2006.01.17 Moca COMPILER_VERã‚’è¿½åŠ 
+// 2010.04.15 Moca icc/dmcã‚’è¿½åŠ ã—CPUã‚’åˆ†é›¢
 #if defined(_M_IA64)
 #  define TARGET_M_SUFFIX "_I64"
 #elif defined(_M_AMD64)
@@ -100,7 +100,7 @@ const DWORD p_helpids[] = {	//12900
 
 //	From Here Nov. 7, 2000 genta
 /*!
-	•W€ˆÈŠO‚ÌƒƒbƒZ[ƒW‚ð•ß‘¨‚·‚é
+	æ¨™æº–ä»¥å¤–ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹
 */
 INT_PTR CDlgAbout::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam )
 {
@@ -109,7 +109,7 @@ INT_PTR CDlgAbout::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lP
 	switch( wMsg ){
 	case WM_CTLCOLORDLG:
 	case WM_CTLCOLORSTATIC:
-		// EDIT‚à READONLY ‚© DISABLE‚Ìê‡ WM_CTLCOLORSTATIC ‚É‚È‚è‚Ü‚·
+		// EDITã‚‚ READONLY ã‹ DISABLEã®å ´åˆ WM_CTLCOLORSTATIC ã«ãªã‚Šã¾ã™
 		if( (HWND)lParam == GetDlgItem(hWnd, IDC_EDIT_ABOUT) ){
 			::SetTextColor( (HDC)wParam, RGB( 102, 102, 102 ) );
 		} else {
@@ -121,16 +121,16 @@ INT_PTR CDlgAbout::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lP
 }
 //	To Here Nov. 7, 2000 genta
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\Ž¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgAbout::DoModal( HINSTANCE hInstance, HWND hwndParent )
 {
 	return (int)CDialog::DoModal( hInstance, hwndParent, IDD_ABOUT, (LPARAM)NULL );
 }
 
-/*! ‰Šú‰»ˆ—
-	@date 2008.05.05 novice GetModuleHandle(NULL)¨NULL‚É•ÏX
-	@date 2011.04.10 nasukoji	Še‘ŒêƒƒbƒZ[ƒWƒŠƒ\[ƒX‘Î‰ž
-	@date 2013.04.07 novice svn revision î•ñ’Ç‰Á
+/*! åˆæœŸåŒ–å‡¦ç†
+	@date 2008.05.05 novice GetModuleHandle(NULL)â†’NULLã«å¤‰æ›´
+	@date 2011.04.10 nasukoji	å„å›½èªžãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒªã‚½ãƒ¼ã‚¹å¯¾å¿œ
+	@date 2013.04.07 novice svn revision æƒ…å ±è¿½åŠ 
 */
 BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 {
@@ -139,31 +139,31 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	TCHAR			szMsg[2048];
 	TCHAR			szFile[_MAX_PATH];
 
-	/* ‚±‚ÌŽÀsƒtƒ@ƒCƒ‹‚Ìî•ñ */
+	/* ã“ã®å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ã®æƒ…å ± */
 	::GetModuleFileName( NULL, szFile, _countof( szFile ) );
 	
-	//	Oct. 22, 2005 genta ƒ^ƒCƒ€ƒXƒ^ƒ“ƒvŽæ“¾‚Ì‹¤’ÊŠÖ”—˜—p
+	//	Oct. 22, 2005 genta ã‚¿ã‚¤ãƒ ã‚¹ã‚¿ãƒ³ãƒ—å–å¾—ã®å…±é€šé–¢æ•°åˆ©ç”¨
 
-	/* ƒo[ƒWƒ‡ƒ“î•ñ */
-	//	Nov. 6, 2000 genta	Unofficial Release‚Ìƒo[ƒWƒ‡ƒ“‚Æ‚µ‚ÄÝ’è
-	//	Jun. 8, 2001 genta	GPL‰»‚É”º‚¢AOfficial‚ÈRelease‚Æ‚µ‚Ä‚Ì“¹‚ð•à‚ÝŽn‚ß‚é
-	//	Feb. 7, 2002 genta ƒRƒ“ƒpƒCƒ‰î•ñ’Ç‰Á
-	//	2004.05.13 Moca ƒo[ƒWƒ‡ƒ“”Ô†‚ÍAƒvƒƒZƒX‚²‚Æ‚ÉŽæ“¾‚·‚é
-	//	2010.04.15 Moca ƒRƒ“ƒpƒCƒ‰î•ñ‚ð•ª—£/WINƒwƒbƒ_,N_SHAREDATA_VERSION’Ç‰Á
+	/* ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ± */
+	//	Nov. 6, 2000 genta	Unofficial Releaseã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã¨ã—ã¦è¨­å®š
+	//	Jun. 8, 2001 genta	GPLåŒ–ã«ä¼´ã„ã€OfficialãªReleaseã¨ã—ã¦ã®é“ã‚’æ­©ã¿å§‹ã‚ã‚‹
+	//	Feb. 7, 2002 genta ã‚³ãƒ³ãƒ‘ã‚¤ãƒ©æƒ…å ±è¿½åŠ 
+	//	2004.05.13 Moca ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã¯ã€ãƒ—ãƒ­ã‚»ã‚¹ã”ã¨ã«å–å¾—ã™ã‚‹
+	//	2010.04.15 Moca ã‚³ãƒ³ãƒ‘ã‚¤ãƒ©æƒ…å ±ã‚’åˆ†é›¢/WINãƒ˜ãƒƒãƒ€,N_SHAREDATA_VERSIONè¿½åŠ 
 
-	// ˆÈ‰º‚ÌŒ`Ž®‚Åo—Í
-	//ƒTƒNƒ‰ƒGƒfƒBƒ^   Ver. 2.0.0.0
+	// ä»¥ä¸‹ã®å½¢å¼ã§å‡ºåŠ›
+	//ã‚µã‚¯ãƒ©ã‚¨ãƒ‡ã‚£ã‚¿   Ver. 2.0.0.0
 	//(GitHash xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
 	//
 	//      Share Ver: 96
 	//      Compile Info: V 1400  WR WIN600/I601/C000/N600
 	//      Last Modified: 1999/9/9 00:00:00
-	//      (‚ ‚ê‚ÎSKR_PATCH_INFO‚Ì•¶Žš—ñ‚ª‚»‚Ì‚Ü‚Ü•\Ž¦)
+	//      (ã‚ã‚Œã°SKR_PATCH_INFOã®æ–‡å­—åˆ—ãŒãã®ã¾ã¾è¡¨ç¤º)
 	CNativeT cmemMsg;
 	cmemMsg.AppendString(LS(STR_DLGABOUT_APPNAME));
 	cmemMsg.AppendString(_T("   "));
 
-	// ƒo[ƒWƒ‡ƒ“&ƒŠƒrƒWƒ‡ƒ“î•ñ
+	// ãƒãƒ¼ã‚¸ãƒ§ãƒ³&ãƒªãƒ“ã‚¸ãƒ§ãƒ³æƒ…å ±
 	DWORD dwVersionMS, dwVersionLS;
 	GetAppVersionInfo( NULL, VS_VERSION_INFO, &dwVersionMS, &dwVersionLS );
 #if defined(GIT_COMMIT_HASH)
@@ -185,13 +185,13 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	cmemMsg.AppendString( _T("\r\n") );
 
-	// ‹¤—Lƒƒ‚ƒŠî•ñ
+	// å…±æœ‰ãƒ¡ãƒ¢ãƒªæƒ…å ±
 	auto_sprintf( szMsg,  _T("      Share Ver: %3d\r\n"),
 		N_SHAREDATA_VERSION
 	);
 	cmemMsg.AppendString( szMsg );
 
-	// ƒRƒ“ƒpƒCƒ‹î•ñ
+	// ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«æƒ…å ±
 	cmemMsg.AppendString( _T("      Compile Info: ") );
 	int Compiler_ver = COMPILER_VER;
 	auto_sprintf( szMsg, _T(COMPILER_TYPE) _T(TARGET_M_SUFFIX) _T("%d ")
@@ -201,7 +201,7 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	);
 	cmemMsg.AppendString( szMsg );
 
-	// XV“úî•ñ
+	// æ›´æ–°æ—¥æƒ…å ±
 	CFileTime cFileTime;
 	GetLastWriteTimestamp( szFile, &cFileTime );
 	auto_sprintf( szMsg,  _T("      Last Modified: %d/%d/%d %02d:%02d:%02d\r\n"),
@@ -214,7 +214,7 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	);
 	cmemMsg.AppendString( szMsg );
 
-	// ƒpƒbƒ`‚Ìî•ñ‚ðƒRƒ“ƒpƒCƒ‹Žž‚É“n‚¹‚é‚æ‚¤‚É‚·‚é
+	// ãƒ‘ãƒƒãƒã®æƒ…å ±ã‚’ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«æ™‚ã«æ¸¡ã›ã‚‹ã‚ˆã†ã«ã™ã‚‹
 #ifdef SKR_PATCH_INFO
 	cmemMsg.AppendString( _T("      ") );
 	const TCHAR* ptszPatchInfo = to_tchar(SKR_PATCH_INFO);
@@ -226,8 +226,8 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	::DlgItem_SetText( GetHwnd(), IDC_EDIT_VER, cmemMsg.GetStringPtr() );
 
 	//	From Here Jun. 8, 2001 genta
-	//	Edit Box‚ÉƒƒbƒZ[ƒW‚ð’Ç‰Á‚·‚éD
-	// 2011.06.01 nasukoji	Še‘ŒêƒƒbƒZ[ƒWƒŠƒ\[ƒX‘Î‰ž
+	//	Edit Boxã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¿½åŠ ã™ã‚‹ï¼Ž
+	// 2011.06.01 nasukoji	å„å›½èªžãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒªã‚½ãƒ¼ã‚¹å¯¾å¿œ
 	LPCTSTR pszDesc = LS( IDS_ABOUT_DESCRIPTION );
 	if( _tcslen(pszDesc) > 0 ){
 		_tcsncpy( szMsg, pszDesc, _countof(szMsg) - 1 );
@@ -237,7 +237,7 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	//	To Here Jun. 8, 2001 genta
 
 	//	From Here Dec. 2, 2002 genta
-	//	ƒAƒCƒRƒ“‚ðƒJƒXƒ^ƒ}ƒCƒYƒAƒCƒRƒ“‚É‡‚í‚¹‚é
+	//	ã‚¢ã‚¤ã‚³ãƒ³ã‚’ã‚«ã‚¹ã‚¿ãƒžã‚¤ã‚ºã‚¢ã‚¤ã‚³ãƒ³ã«åˆã‚ã›ã‚‹
 	HICON hIcon = GetAppIcon( m_hInstance, ICON_DEFAULT_APP, FN_APP_ICON, false );
 	HWND hIconWnd = GetDlgItem( GetHwnd(), IDC_STATIC_MYICON );
 	
@@ -246,13 +246,13 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	}
 	//	To Here Dec. 2, 2002 genta
 
-	// URLƒEƒBƒ“ƒhƒE‚ðƒTƒuƒNƒ‰ƒX‰»‚·‚é
+	// URLã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã‚µãƒ–ã‚¯ãƒ©ã‚¹åŒ–ã™ã‚‹
 	m_UrlUrWnd.SetSubclassWindow( GetDlgItem( GetHwnd(), IDC_STATIC_URL_UR ) );
 
-	//	Oct. 22, 2005 genta Œ´ìŽÒƒz[ƒ€ƒy[ƒW‚ª–³‚­‚È‚Á‚½‚Ì‚Åíœ
+	//	Oct. 22, 2005 genta åŽŸä½œè€…ãƒ›ãƒ¼ãƒ ãƒšãƒ¼ã‚¸ãŒç„¡ããªã£ãŸã®ã§å‰Šé™¤
 	//m_UrlOrgWnd.SubclassWindow( GetDlgItem( GetHwnd(), IDC_STATIC_URL_ORG ) );
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnInitDialog( GetHwnd(), wParam, lParam );
 }
 
@@ -275,10 +275,10 @@ BOOL CDlgAbout::OnBnClicked( int wID )
 BOOL CDlgAbout::OnStnClicked( int wID )
 {
 	switch( wID ){
-	//	2006.07.27 genta Œ´ìŽÒ˜A—æ‚Ìƒ{ƒ^ƒ“‚ðíœ (ƒwƒ‹ƒv‚©‚çíœ‚³‚ê‚Ä‚¢‚é‚½‚ß)
+	//	2006.07.27 genta åŽŸä½œè€…é€£çµ¡å…ˆã®ãƒœã‚¿ãƒ³ã‚’å‰Šé™¤ (ãƒ˜ãƒ«ãƒ—ã‹ã‚‰å‰Šé™¤ã•ã‚Œã¦ã„ã‚‹ãŸã‚)
 	case IDC_STATIC_URL_UR:
 //	case IDC_STATIC_URL_ORG:	del 2008/7/4 Uchi
-		//	Web Browser‚Ì‹N“®
+		//	Web Browserã®èµ·å‹•
 		{
 			TCHAR buf[512];
 			::GetWindowText( ::GetDlgItem( GetHwnd(), wID ), buf, _countof(buf) );
@@ -286,7 +286,7 @@ BOOL CDlgAbout::OnStnClicked( int wID )
 			return TRUE;
 		}
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnStnClicked( wID );
 }
 
@@ -298,14 +298,14 @@ LPVOID CDlgAbout::GetHelpIdTable(void)
 
 BOOL CUrlWnd::SetSubclassWindow( HWND hWnd )
 {
-	// STATICƒEƒBƒ“ƒhƒE‚ðƒTƒuƒNƒ‰ƒX‰»‚·‚é
-	// Œ³‚ÌSTATIC‚Í WS_TABSTOP, SS_NOTIFY ƒXƒ^ƒCƒ‹‚Ì‚à‚Ì‚ðŽg—p‚·‚é‚±‚Æ
+	// STATICã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã‚µãƒ–ã‚¯ãƒ©ã‚¹åŒ–ã™ã‚‹
+	// å…ƒã®STATICã¯ WS_TABSTOP, SS_NOTIFY ã‚¹ã‚¿ã‚¤ãƒ«ã®ã‚‚ã®ã‚’ä½¿ç”¨ã™ã‚‹ã“ã¨
 	if( GetHwnd() != NULL )
 		return FALSE;
 	if( !IsWindow( hWnd ) )
 		return FALSE;
 
-	// ƒTƒuƒNƒ‰ƒX‰»‚ðŽÀs‚·‚é
+	// ã‚µãƒ–ã‚¯ãƒ©ã‚¹åŒ–ã‚’å®Ÿè¡Œã™ã‚‹
 	LONG_PTR lptr;
 	SetLastError( 0 );
 	lptr = SetWindowLongPtr( hWnd, GWLP_USERDATA, (LONG_PTR)this );
@@ -316,7 +316,7 @@ BOOL CUrlWnd::SetSubclassWindow( HWND hWnd )
 		return FALSE;
 	m_hWnd = hWnd;
 
-	// ‰ºü•t‚«ƒtƒHƒ“ƒg‚É•ÏX‚·‚é
+	// ä¸‹ç·šä»˜ããƒ•ã‚©ãƒ³ãƒˆã«å¤‰æ›´ã™ã‚‹
 	HFONT hFont;
 	LOGFONT lf;
 	hFont = (HFONT)SendMessageAny( hWnd, WM_GETFONT, (WPARAM)0, (LPARAM)0 );
@@ -339,27 +339,27 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 
 	switch ( msg ) {
 	case WM_SETCURSOR:
-		// ƒJ[ƒ\ƒ‹Œ`ó•ÏX
-		SetHandCursor();		// Hand Cursor‚ðÝ’è 2013/1/29 Uchi
+		// ã‚«ãƒ¼ã‚½ãƒ«å½¢çŠ¶å¤‰æ›´
+		SetHandCursor();		// Hand Cursorã‚’è¨­å®š 2013/1/29 Uchi
 		return (LRESULT)0;
 	case WM_LBUTTONDOWN:
-		// ƒL[ƒ{[ƒhƒtƒH[ƒJƒX‚ðŽ©•ª‚É“–‚Ä‚é
+		// ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã‚’è‡ªåˆ†ã«å½“ã¦ã‚‹
 		SendMessageAny( GetParent(hWnd), WM_NEXTDLGCTL, (WPARAM)hWnd, (LPARAM)1 );
 		break;
 	case WM_SETFOCUS:
 	case WM_KILLFOCUS:
-		// Ä•`‰æ
+		// å†æç”»
 		InvalidateRect( hWnd, NULL, TRUE );
 		UpdateWindow( hWnd );
 		break;
 	case WM_GETDLGCODE:
-		// ƒfƒtƒHƒ‹ƒgƒvƒbƒVƒ…ƒ{ƒ^ƒ“‚Ì‚æ‚¤‚ÉU•‘‚¤iEnterƒL[‚Ì—LŒø‰»j
-		// •ûŒüƒL[‚Í–³Œø‰»iIE‚Ìƒo[ƒWƒ‡ƒ“î•ñƒ_ƒCƒAƒƒO‚Æ“¯—lj
+		// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆãƒ—ãƒƒã‚·ãƒ¥ãƒœã‚¿ãƒ³ã®ã‚ˆã†ã«æŒ¯èˆžã†ï¼ˆEnterã‚­ãƒ¼ã®æœ‰åŠ¹åŒ–ï¼‰
+		// æ–¹å‘ã‚­ãƒ¼ã¯ç„¡åŠ¹åŒ–ï¼ˆIEã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã¨åŒæ§˜ï¼‰
 		return DLGC_DEFPUSHBUTTON | DLGC_WANTARROWS;
 	case WM_MOUSEMOVE:
-		// ƒJ[ƒ\ƒ‹‚ªƒEƒBƒ“ƒhƒE“à‚É“ü‚Á‚½‚çƒ^ƒCƒ}[‹N“®
-		// ƒEƒBƒ“ƒhƒEŠO‚Éo‚½‚çƒ^ƒCƒ}[íœ
-		// Šeƒ^ƒCƒ~ƒ“ƒO‚ÅÄ•`‰æ
+		// ã‚«ãƒ¼ã‚½ãƒ«ãŒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å†…ã«å…¥ã£ãŸã‚‰ã‚¿ã‚¤ãƒžãƒ¼èµ·å‹•
+		// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¤–ã«å‡ºãŸã‚‰ã‚¿ã‚¤ãƒžãƒ¼å‰Šé™¤
+		// å„ã‚¿ã‚¤ãƒŸãƒ³ã‚°ã§å†æç”»
 		BOOL bHilighted;
 		pt.x = LOWORD( lParam );
 		pt.y = HIWORD( lParam );
@@ -375,7 +375,7 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 		}
 		break;
 	case WM_TIMER:
-		// ƒJ[ƒ\ƒ‹‚ªƒEƒBƒ“ƒhƒEŠO‚É‚ ‚éê‡‚É‚à WM_MOUSEMOVE ‚ð‘—‚é
+		// ã‚«ãƒ¼ã‚½ãƒ«ãŒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¤–ã«ã‚ã‚‹å ´åˆã«ã‚‚ WM_MOUSEMOVE ã‚’é€ã‚‹
 		GetCursorPos( &pt );
 		ScreenToClient( hWnd, &pt );
 		GetClientRect( hWnd, &rc );
@@ -383,7 +383,7 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 			SendMessageAny( hWnd, WM_MOUSEMOVE, 0, MAKELONG( pt.x, pt.y ) );
 		break;
 	case WM_PAINT:
-		// ƒEƒBƒ“ƒhƒE‚Ì•`‰æ
+		// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®æç”»
 		PAINTSTRUCT ps;
 		HFONT hFont;
 		HFONT hFontOld;
@@ -391,19 +391,19 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 
 		hdc = BeginPaint( hWnd, &ps );
 
-		// Œ»Ý‚ÌƒNƒ‰ƒCƒAƒ“ƒg‹éŒ`AƒeƒLƒXƒgAƒtƒHƒ“ƒg‚ðŽæ“¾‚·‚é
+		// ç¾åœ¨ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆçŸ©å½¢ã€ãƒ†ã‚­ã‚¹ãƒˆã€ãƒ•ã‚©ãƒ³ãƒˆã‚’å–å¾—ã™ã‚‹
 		GetClientRect( hWnd, &rc );
 		GetWindowText( hWnd, szText, _countof(szText) );
 		hFont = (HFONT)SendMessageAny( hWnd, WM_GETFONT, (WPARAM)0, (LPARAM)0 );
 
-		// ƒeƒLƒXƒg•`‰æ
+		// ãƒ†ã‚­ã‚¹ãƒˆæç”»
 		SetBkMode( hdc, TRANSPARENT );
 		SetTextColor( hdc, pUrlWnd->m_bHilighted? RGB( 0x84, 0, 0 ): RGB( 0, 0, 0xff ) );
 		hFontOld = (HFONT)SelectObject( hdc, (HGDIOBJ)hFont );
 		TextOut( hdc, 2, 0, szText, _tcslen( szText ) );
 		SelectObject( hdc, (HGDIOBJ)hFontOld );
 
-		// ƒtƒH[ƒJƒX˜g•`‰æ
+		// ãƒ•ã‚©ãƒ¼ã‚«ã‚¹æž æç”»
 		if( GetFocus() == hWnd )
 			DrawFocusRect( hdc, &rc );
 
@@ -413,13 +413,13 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 		hdc = (HDC)wParam;
 		GetClientRect( hWnd, &rc );
 
-		// ”wŒi•`‰æ
+		// èƒŒæ™¯æç”»
 		if( pUrlWnd->m_bHilighted ){
-			// ƒnƒCƒ‰ƒCƒgŽž”wŒi•`‰æ
+			// ãƒã‚¤ãƒ©ã‚¤ãƒˆæ™‚èƒŒæ™¯æç”»
 			SetBkColor( hdc, RGB( 0xff, 0xff, 0 ) );
 			::ExtTextOutW_AnyBuild( hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL );
 		}else{
-			// e‚ÉWM_CTLCOLORSTATIC‚ð‘—‚Á‚Ä”wŒiƒuƒ‰ƒV‚ðŽæ“¾‚µA”wŒi•`‰æ‚·‚é
+			// è¦ªã«WM_CTLCOLORSTATICã‚’é€ã£ã¦èƒŒæ™¯ãƒ–ãƒ©ã‚·ã‚’å–å¾—ã—ã€èƒŒæ™¯æç”»ã™ã‚‹
 			HBRUSH hbr;
 			HBRUSH hbrOld;
 			hbr = (HBRUSH)SendMessageAny( GetParent( hWnd ), WM_CTLCOLORSTATIC, wParam, (LPARAM)hWnd );
@@ -429,7 +429,7 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 		}
 		return (LRESULT)1;
 	case WM_DESTROY:
-		// ŒãŽn––
+		// å¾Œå§‹æœ«
 		KillTimer( hWnd, 1 );
 		SetWindowLongPtr( hWnd, GWLP_WNDPROC, (LONG_PTR)pUrlWnd->m_pOldProc );
 		if( pUrlWnd->m_hFont != NULL )

--- a/sakura_core/dlg/CDlgAbout.h
+++ b/sakura_core/dlg/CDlgAbout.h
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ƒo[ƒWƒ‡ƒ“î•ñƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
-	@date 1998/05/22 ì¬
-	@date 1999/12/05 Äì¬
+	@date 1998/05/22 ä½œæˆ
+	@date 1999/12/05 å†ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -18,10 +18,10 @@
 
 #include "dlg/CDialog.h"
 /*!
-	@brief About BoxŠÇ—
+	@brief About Boxç®¡ç†
 	
-	DispatchEvent‚ğ“Æ©‚É’è‹`‚·‚é‚±‚Æ‚ÅCCDialog‚ÅƒTƒ|[ƒg‚³‚ê‚Ä‚¢‚È‚¢
-	ƒƒbƒZ[ƒW‚ğ•ß‘¨‚·‚éD
+	DispatchEventã‚’ç‹¬è‡ªã«å®šç¾©ã™ã‚‹ã“ã¨ã§ï¼ŒCDialogã§ã‚µãƒãƒ¼ãƒˆã•ã‚Œã¦ã„ãªã„
+	ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹ï¼
 */
 
 class CUrlWnd
@@ -43,8 +43,8 @@ protected:
 class CDlgAbout : public CDialog
 {
 public:
-	int DoModal( HINSTANCE, HWND );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
-	//	Nov. 7, 2000 genta	•W€ˆÈŠO‚ÌƒƒbƒZ[ƒW‚ğ•ß‘¨‚·‚é
+	int DoModal( HINSTANCE, HWND );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
+	//	Nov. 7, 2000 genta	æ¨™æº–ä»¥å¤–ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );
 protected:
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );

--- a/sakura_core/dlg/CDlgCancel.cpp
+++ b/sakura_core/dlg/CDlgCancel.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒLƒƒƒ“ƒZƒ‹ƒ{ƒ^ƒ“ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ã‚­ãƒ£ãƒ³ã‚»ãƒ«ãƒœã‚¿ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
 */
@@ -15,12 +15,12 @@
 
 CDlgCancel::CDlgCancel()
 {
-	m_bCANCEL = FALSE;	/* IDCANCELƒ{ƒ^ƒ“‚ª‰Ÿ‚³‚ê‚½ */
+	m_bCANCEL = FALSE;	/* IDCANCELãƒœã‚¿ãƒ³ãŒæŠ¼ã•ã‚ŒãŸ */
 	m_bAutoCleanup = false;
 }
 
-/** •W€ˆÈŠO‚ÌƒƒbƒZ[ƒW‚ğ•ß‘¨‚·‚é
-	@date 2008.05.28 ryoji V‹Kì¬
+/** æ¨™æº–ä»¥å¤–ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹
+	@date 2008.05.28 ryoji æ–°è¦ä½œæˆ
 */
 INT_PTR CDlgCancel::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam )
 {
@@ -43,8 +43,8 @@ INT_PTR CDlgCancel::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM l
 	return result;
 }
 
-/** ©“®”jŠü‚ğ’x‰„Às‚·‚é
-	@date 2008.05.28 ryoji V‹Kì¬
+/** è‡ªå‹•ç ´æ£„ã‚’é…å»¶å®Ÿè¡Œã™ã‚‹
+	@date 2008.05.28 ryoji æ–°è¦ä½œæˆ
 */
 void CDlgCancel::DeleteAsync( void )
 {
@@ -52,16 +52,16 @@ void CDlgCancel::DeleteAsync( void )
 	::PostMessageAny( GetHwnd(), WM_CLOSE, 0, 0 );
 }
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgCancel::DoModal( HINSTANCE hInstance, HWND hwndParent, int nDlgTemplete )
 {
-	m_bCANCEL = FALSE;	/* IDCANCELƒ{ƒ^ƒ“‚ª‰Ÿ‚³‚ê‚½ */
+	m_bCANCEL = FALSE;	/* IDCANCELãƒœã‚¿ãƒ³ãŒæŠ¼ã•ã‚ŒãŸ */
 	return (int)CDialog::DoModal( hInstance, hwndParent, nDlgTemplete, (LPARAM)NULL );
 }
-/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 HWND CDlgCancel::DoModeless( HINSTANCE hInstance, HWND hwndParent, int nDlgTemplete )
 {
-	m_bCANCEL = FALSE;	/* IDCANCELƒ{ƒ^ƒ“‚ª‰Ÿ‚³‚ê‚½ */
+	m_bCANCEL = FALSE;	/* IDCANCELãƒœã‚¿ãƒ³ãŒæŠ¼ã•ã‚ŒãŸ */
 	return CDialog::DoModeless( hInstance, hwndParent, nDlgTemplete, (LPARAM)NULL, SW_SHOW );
 }
 
@@ -78,7 +78,7 @@ BOOL CDlgCancel::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	::SendMessageAny( GetHwnd(), WM_SETICON, ICON_BIG, (LPARAM)hIcon );
 
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 //	CreateSizeBox();
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 }
@@ -87,7 +87,7 @@ BOOL CDlgCancel::OnBnClicked( int wID )
 {
 	switch( wID ){
 	case IDCANCEL:
-		m_bCANCEL = TRUE;	/* IDCANCELƒ{ƒ^ƒ“‚ª‰Ÿ‚³‚ê‚½ */
+		m_bCANCEL = TRUE;	/* IDCANCELãƒœã‚¿ãƒ³ãŒæŠ¼ã•ã‚ŒãŸ */
 //		CloseDialog( 0 );
 		return TRUE;
 	}

--- a/sakura_core/dlg/CDlgCancel.h
+++ b/sakura_core/dlg/CDlgCancel.h
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ƒLƒƒƒ“ƒZƒ‹ƒ{ƒ^ƒ“ƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ã‚­ãƒ£ãƒ³ã‚»ãƒ«ãƒœã‚¿ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
-	@date 1998/09/09 ì¬
-    @date 1999/12/02 Äì¬
+	@date 1998/09/09 ä½œæˆ
+    @date 1999/12/02 å†ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -22,7 +22,7 @@ class CDlgCancel;
 
 
 /*!
-	@brief ƒLƒƒƒ“ƒZƒ‹ƒ{ƒ^ƒ“ƒ_ƒCƒAƒƒO
+	@brief ã‚­ãƒ£ãƒ³ã‚»ãƒ«ãƒœã‚¿ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 */
 class CDlgCancel : public CDialog
 {
@@ -31,29 +31,29 @@ public:
 	||  Constructors
 	*/
 	CDlgCancel();
-//	void Create( HINSTANCE, HWND );	/* ‰Šú‰» */
+//	void Create( HINSTANCE, HWND );	/* åˆæœŸåŒ– */
 
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, int );	/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\Ž¦ */
-	HWND DoModeless( HINSTANCE, HWND, int );	/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\Ž¦ */
+	int DoModal( HINSTANCE, HWND, int );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
+	HWND DoModeless( HINSTANCE, HWND, int );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 //	HWND Open( LPCTSTR );
-//	void Close( void );	/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ìíœ */
-	BOOL IsCanceled( void ){ return m_bCANCEL; } /* IDCANCELƒ{ƒ^ƒ“‚ª‰Ÿ‚³‚ê‚½‚©H */
-	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );	/* ƒ_ƒCƒAƒƒO‚ÌƒƒbƒZ[ƒWˆ— *//* BOOL->INT_PTR 2008/7/18 Uchi*/
-	void DeleteAsync( void );	/* Ž©“®”jŠü‚ð’x‰„ŽÀs‚·‚é */	// 2008.05.28 ryoji
+//	void Close( void );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®å‰Šé™¤ */
+	BOOL IsCanceled( void ){ return m_bCANCEL; } /* IDCANCELãƒœã‚¿ãƒ³ãŒæŠ¼ã•ã‚ŒãŸã‹ï¼Ÿ */
+	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† *//* BOOL->INT_PTR 2008/7/18 Uchi*/
+	void DeleteAsync( void );	/* è‡ªå‹•ç ´æ£„ã‚’é…å»¶å®Ÿè¡Œã™ã‚‹ */	// 2008.05.28 ryoji
 
-//	HINSTANCE	m_hInstance;	/* ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒCƒ“ƒXƒ^ƒ“ƒX‚Ìƒnƒ“ƒhƒ‹ */
-//	HWND		m_hwndParent;	/* ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹ */
-//	HWND		m_hWnd;			/* ‚±‚Ìƒ_ƒCƒAƒƒO‚Ìƒnƒ“ƒhƒ‹ */
-	BOOL		m_bCANCEL;		/* IDCANCELƒ{ƒ^ƒ“‚ª‰Ÿ‚³‚ê‚½ */
-	bool		m_bAutoCleanup;	/* Ž©“®Œãˆ—Œ^ */	// 2008.05.28 ryoji
+//	HINSTANCE	m_hInstance;	/* ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ« */
+//	HWND		m_hwndParent;	/* ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ« */
+//	HWND		m_hWnd;			/* ã“ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒãƒ³ãƒ‰ãƒ« */
+	BOOL		m_bCANCEL;		/* IDCANCELãƒœã‚¿ãƒ³ãŒæŠ¼ã•ã‚ŒãŸ */
+	bool		m_bAutoCleanup;	/* è‡ªå‹•å¾Œå‡¦ç†åž‹ */	// 2008.05.28 ryoji
 
 protected:
 	/*
-	||  ŽÀ‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );
 	BOOL OnBnClicked( int );

--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒtƒ@ƒCƒ‹”äŠrƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«æ¯”è¼ƒãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
 */
@@ -26,15 +26,15 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 
-// ƒtƒ@ƒCƒ‹“à—e”äŠr CDlgCompare.cpp	//@@@ 2002.01.07 add start MIK
+// ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒ CDlgCompare.cpp	//@@@ 2002.01.07 add start MIK
 const DWORD p_helpids[] = {	//12300
 //	IDC_STATIC,						-1,
 	IDOK,							HIDOK_CMP,					//OK
-	IDCANCEL,						HIDCANCEL_CMP,				//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_CMP_BUTTON_HELP,		//ƒwƒ‹ƒv
-	IDC_CHECK_TILE_H,				HIDC_CMP_CHECK_TILE_H,		//¶‰E‚É•\¦
-	IDC_LIST_FILES,					HIDC_CMP_LIST_FILES,		//ƒtƒ@ƒCƒ‹ˆê——
-	IDC_STATIC_COMPARESRC,			HIDC_CMP_STATIC_COMPARESRC,	//ƒ\[ƒXƒtƒ@ƒCƒ‹
+	IDCANCEL,						HIDCANCEL_CMP,				//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_CMP_BUTTON_HELP,		//ãƒ˜ãƒ«ãƒ—
+	IDC_CHECK_TILE_H,				HIDC_CMP_CHECK_TILE_H,		//å·¦å³ã«è¡¨ç¤º
+	IDC_LIST_FILES,					HIDC_CMP_LIST_FILES,		//ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§
+	IDC_STATIC_COMPARESRC,			HIDC_CMP_STATIC_COMPARESRC,	//ã‚½ãƒ¼ã‚¹ãƒ•ã‚¡ã‚¤ãƒ«
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
 
@@ -50,10 +50,10 @@ static const SAnchorList anchorList[] = {
 CDlgCompare::CDlgCompare()
 	: CDialog(true)
 {
-	/* ƒTƒCƒY•ÏX‚ÉˆÊ’u‚ğ§Œä‚·‚éƒRƒ“ƒgƒ[ƒ‹” */
+	/* ã‚µã‚¤ã‚ºå¤‰æ›´æ™‚ã«ä½ç½®ã‚’åˆ¶å¾¡ã™ã‚‹ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«æ•° */
 	assert( _countof(anchorList) == _countof(m_rcItems) );
 
-	m_bCompareAndTileHorz = TRUE;	/* ¶‰E‚É•À‚×‚Ä•\¦ */
+	m_bCompareAndTileHorz = TRUE;	/* å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º */
 
 	m_ptDefaultSize.x = -1;
 	m_ptDefaultSize.y = -1;
@@ -61,7 +61,7 @@ CDlgCompare::CDlgCompare()
 }
 
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgCompare::DoModal(
 	HINSTANCE		hInstance,
 	HWND			hwndParent,
@@ -81,19 +81,19 @@ BOOL CDlgCompare::OnBnClicked( int wID )
 {
 	switch( wID ){
 	case IDC_BUTTON_HELP:
-		/* u“à—e”äŠrv‚Ìƒwƒ‹ƒv */
-		//Stonee, 2001/03/12 ‘ælˆø”‚ğA‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_COMPARE) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ã€Œå†…å®¹æ¯”è¼ƒã€ã®ãƒ˜ãƒ«ãƒ— */
+		//Stonee, 2001/03/12 ç¬¬å››å¼•æ•°ã‚’ã€æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_COMPARE) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
-//	From Here Oct. 10, 2000 JEPRO added  Ref. code ‚ÍCDlgFind.cpp ‚Ì OnBnClicked
-//	ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ğƒ{ƒ^ƒ“‰»‚µ‚ÄCDlgCompare.cpp‚É’¼Ú‘‚«‚ñ‚Å‚İ‚½‚ª¸”s
-//	ƒ_ƒCƒAƒƒO‚Ìƒ{ƒ^ƒ“‚Í‰º‚É•s‰Â‹‰»‚µ‚Ä‚¨‚¢‚Ä‚ ‚è‚Ü‚·B
-//	ˆÈ‰º‚Ì’Ç‰ÁƒR[ƒh‚Í‘S•”Á‚µ‚ÄŒ‹\‚Å‚·‚©‚ç’N‚©ì‚Á‚Ä‚­‚¾‚³‚¢B…•½ƒXƒNƒ[ƒ‹‚à“ü‚ê‚Ä‚­‚ê‚é‚Æ‚È‚¨‚¤‚ê‚µ‚¢‚Å‚·B
-//	case IDC_BUTTON1:	/* ã‰º‚É•\¦ */
-//		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+//	From Here Oct. 10, 2000 JEPRO added  Ref. code ã¯CDlgFind.cpp ã® OnBnClicked
+//	ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã‚’ãƒœã‚¿ãƒ³åŒ–ã—ã¦CDlgCompare.cppã«ç›´æ¥æ›¸ãè¾¼ã‚“ã§ã¿ãŸãŒå¤±æ•—
+//	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒœã‚¿ãƒ³ã¯ä¸‹ã«ä¸å¯è¦–åŒ–ã—ã¦ãŠã„ã¦ã‚ã‚Šã¾ã™ã€‚
+//	ä»¥ä¸‹ã®è¿½åŠ ã‚³ãƒ¼ãƒ‰ã¯å…¨éƒ¨æ¶ˆã—ã¦çµæ§‹ã§ã™ã‹ã‚‰èª°ã‹ä½œã£ã¦ãã ã•ã„ã€‚æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚‚å…¥ã‚Œã¦ãã‚Œã‚‹ã¨ãªãŠã†ã‚Œã—ã„ã§ã™ã€‚
+//	case IDC_BUTTON1:	/* ä¸Šä¸‹ã«è¡¨ç¤º */
+//		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 //		return TRUE;
-//	case IDOK:			/* ¶‰E‚É•\¦ */
-//		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+//	case IDOK:			/* å·¦å³ã«è¡¨ç¤º */
+//		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 //		HWND	hwndCompareWnd;
 //		HWND*	phwndArr;
 //		int		i;
@@ -110,20 +110,20 @@ BOOL CDlgCompare::OnBnClicked( int wID )
 //		CloseDialog( 0 );
 //		return TRUE;
 //	To Here Oct. 10, 2000
-	case IDOK:			/* ¶‰E‚É•\¦ */
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	case IDOK:			/* å·¦å³ã«è¡¨ç¤º */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		::EndDialog( GetHwnd(), GetData() );
 		return TRUE;
 	case IDCANCEL:
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgCompare::SetData( void )
 {
 	HWND			hwndList;
@@ -137,58 +137,58 @@ void CDlgCompare::SetData( void )
 
 	hwndList = :: GetDlgItem( GetHwnd(), IDC_LIST_FILES );
 
-//	2002/2/10 aroka ƒtƒ@ƒCƒ‹–¼‚Å”äŠr‚µ‚È‚¢‚½‚ß•s—p (2001.12.26 YAZAKI‚³‚ñ)
-//	//	Oct. 15, 2001 genta ƒtƒ@ƒCƒ‹–¼”»’è‚Ì stricmp‚ğbcc‚Å‚àŠú‘Ò’Ê‚è“®‚©‚·‚½‚ß
+//	2002/2/10 aroka ãƒ•ã‚¡ã‚¤ãƒ«åã§æ¯”è¼ƒã—ãªã„ãŸã‚ä¸ç”¨ (2001.12.26 YAZAKIã•ã‚“)
+//	//	Oct. 15, 2001 genta ãƒ•ã‚¡ã‚¤ãƒ«ååˆ¤å®šã® stricmpã‚’bccã§ã‚‚æœŸå¾…é€šã‚Šå‹•ã‹ã™ãŸã‚
 //	setlocale ( LC_ALL, "C" );
 
-	/* Œ»İŠJ‚¢‚Ä‚¢‚é•ÒW‘‹‚ÌƒŠƒXƒg‚ğƒƒjƒ…[‚É‚·‚é */
+	/* ç¾åœ¨é–‹ã„ã¦ã„ã‚‹ç·¨é›†çª“ã®ãƒªã‚¹ãƒˆã‚’ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«ã™ã‚‹ */
 	nRowNum = CAppNodeManager::getInstance()->GetOpenedWindowArr( &pEditNodeArr, TRUE );
 	if( nRowNum > 0 ){
-		// …•½ƒXƒNƒ[ƒ‹•‚ÍÀÛ‚É•\¦‚·‚é•¶š—ñ‚Ì•‚ğŒv‘ª‚µ‚ÄŒˆ‚ß‚é	// 2009.09.26 ryoji
+		// æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å¹…ã¯å®Ÿéš›ã«è¡¨ç¤ºã™ã‚‹æ–‡å­—åˆ—ã®å¹…ã‚’è¨ˆæ¸¬ã—ã¦æ±ºã‚ã‚‹	// 2009.09.26 ryoji
 		CTextWidthCalc calc(hwndList);
 		int score = 0;
 		TCHAR		szFile1[_MAX_PATH];
 		SplitPath_FolderAndFile(m_pszPath, NULL, szFile1);
 		for( i = 0; i < nRowNum; ++i ){
-			/* ƒgƒŒƒC‚©‚çƒGƒfƒBƒ^‚Ö‚Ì•ÒWƒtƒ@ƒCƒ‹–¼—v‹’Ê’m */
+			/* ãƒˆãƒ¬ã‚¤ã‹ã‚‰ã‚¨ãƒ‡ã‚£ã‚¿ã¸ã®ç·¨é›†ãƒ•ã‚¡ã‚¤ãƒ«åè¦æ±‚é€šçŸ¥ */
 			::SendMessageAny( pEditNodeArr[i].GetHwnd(), MYWM_GETFILEINFO, 0, 0 );
 			pfi = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
-//@@@ 2001.12.26 YAZAKI ƒtƒ@ƒCƒ‹–¼‚Å”äŠr‚·‚é‚Æ(–³‘è)‚¾‚Á‚½‚Æ‚«‚É–â‘è“¯m‚Ì”äŠr‚ª‚Å‚«‚È‚¢
+//@@@ 2001.12.26 YAZAKI ãƒ•ã‚¡ã‚¤ãƒ«åã§æ¯”è¼ƒã™ã‚‹ã¨(ç„¡é¡Œ)ã ã£ãŸã¨ãã«å•é¡ŒåŒå£«ã®æ¯”è¼ƒãŒã§ããªã„
 			if (pEditNodeArr[i].GetHwnd() == CEditWnd::getInstance()->GetHwnd()){
-				// 2010.07.30 ©•ª‚Ì–¼‘O‚à‚±‚±‚©‚çİ’è‚·‚é
+				// 2010.07.30 è‡ªåˆ†ã®åå‰ã‚‚ã“ã“ã‹ã‚‰è¨­å®šã™ã‚‹
 				CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szMenu, _countof(szMenu), pfi, pEditNodeArr[i].m_nId, -1, calc.GetDC() );
 				::DlgItem_SetText( GetHwnd(), IDC_STATIC_COMPARESRC, szMenu );
 				continue;
 			}
-			// ”Ô†‚Í ƒEƒBƒ“ƒhƒEƒŠƒXƒg‚Æ“¯‚¶‚É‚È‚é‚æ‚¤‚É‚·‚é
+			// ç•ªå·ã¯ ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆã¨åŒã˜ã«ãªã‚‹ã‚ˆã†ã«ã™ã‚‹
 			CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szMenu, _countof(szMenu), pfi, pEditNodeArr[i].m_nId, i, calc.GetDC() );
 
 			nItem = ::List_AddString( hwndList, szMenu );
 			List_SetItemData( hwndList, nItem, pEditNodeArr[i].GetHwnd() );
 
-			// ‰¡•‚ğŒvZ‚·‚é
+			// æ¨ªå¹…ã‚’è¨ˆç®—ã™ã‚‹
 			calc.SetTextWidthIfMax(szMenu);
 
-			// ƒtƒ@ƒCƒ‹–¼ˆê’v‚ÌƒXƒRƒA‚ğŒvZ‚·‚é
+			// ãƒ•ã‚¡ã‚¤ãƒ«åä¸€è‡´ã®ã‚¹ã‚³ã‚¢ã‚’è¨ˆç®—ã™ã‚‹
 			TCHAR szFile2[_MAX_PATH];
 			SplitPath_FolderAndFile( pfi->m_szPath, NULL, szFile2 );
 			int scoreTemp = FileMatchScoreSepExt( szFile1, szFile2 );
 			if( score < scoreTemp ){
-				// ƒXƒRƒA‚Ì‚¢‚¢‚à‚Ì‚ğ‘I‘ğ
+				// ã‚¹ã‚³ã‚¢ã®ã„ã„ã‚‚ã®ã‚’é¸æŠ
 				score = scoreTemp;
 				selIndex = nItem;
 			}
 		}
 		delete [] pEditNodeArr;
-		// 2002/11/01 Moca ’Ç‰Á ƒŠƒXƒgƒrƒ…[‚Ì‰¡•‚ğİ’èB‚±‚ê‚ğ‚â‚ç‚È‚¢‚Æ…•½ƒXƒNƒ[ƒ‹ƒo[‚ªg‚¦‚È‚¢
+		// 2002/11/01 Moca è¿½åŠ  ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®æ¨ªå¹…ã‚’è¨­å®šã€‚ã“ã‚Œã‚’ã‚„ã‚‰ãªã„ã¨æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ãŒä½¿ãˆãªã„
 		List_SetHorizontalExtent( hwndList, calc.GetCx() );
 	}
 	List_SetCurSel( hwndList, selIndex );
 
-	/* ¶‰E‚É•À‚×‚Ä•\¦ */
+	/* å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º */
 	//@@@ 2003.06.12 MIK
-	// TAB 1ƒEƒBƒ“ƒhƒE•\¦‚Ì‚Æ‚«‚Í•À‚×‚Ä”äŠr‚Å‚«‚È‚­‚·‚é
+	// TAB 1ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦è¡¨ç¤ºã®ã¨ãã¯ä¸¦ã¹ã¦æ¯”è¼ƒã§ããªãã™ã‚‹
 	if( FALSE != m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd
 	 && !m_pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin )
 	{
@@ -202,8 +202,8 @@ void CDlgCompare::SetData( void )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-/* TRUE==³í  FALSE==“ü—ÍƒGƒ‰[ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+/* TRUE==æ­£å¸¸  FALSE==å…¥åŠ›ã‚¨ãƒ©ãƒ¼ */
 int CDlgCompare::GetData( void )
 {
 	HWND			hwndList;
@@ -215,16 +215,16 @@ int CDlgCompare::GetData( void )
 		return FALSE;
 	}else{
 		*m_phwndCompareWnd = (HWND)List_GetItemData( hwndList, nItem );
-		/* ƒgƒŒƒC‚©‚çƒGƒfƒBƒ^‚Ö‚Ì•ÒWƒtƒ@ƒCƒ‹–¼—v‹’Ê’m */
+		/* ãƒˆãƒ¬ã‚¤ã‹ã‚‰ã‚¨ãƒ‡ã‚£ã‚¿ã¸ã®ç·¨é›†ãƒ•ã‚¡ã‚¤ãƒ«åè¦æ±‚é€šçŸ¥ */
 		::SendMessageAny( *m_phwndCompareWnd, MYWM_GETFILEINFO, 0, 0 );
 		pfi = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
-		// 2010.07.30 ƒpƒX–¼‚Í‚â‚ß‚Ä•\¦–¼‚É•ÏX
+		// 2010.07.30 ãƒ‘ã‚¹åã¯ã‚„ã‚ã¦è¡¨ç¤ºåã«å¤‰æ›´
 		int nId = CAppNodeManager::getInstance()->GetEditNode( *m_phwndCompareWnd )->GetId();
 		CTextWidthCalc calc(hwndList);
-		CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( m_pszCompareLabel, _MAX_PATH/*’·‚³•s–¾*/, pfi, nId, -1, calc.GetDC() );
+		CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( m_pszCompareLabel, _MAX_PATH/*é•·ã•ä¸æ˜*/, pfi, nId, -1, calc.GetDC() );
 	
-		/* ¶‰E‚É•À‚×‚Ä•\¦ */
+		/* å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º */
 		m_bCompareAndTileHorz = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_TILE_H );
 
 		return TRUE;
@@ -279,7 +279,7 @@ BOOL CDlgCompare::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 BOOL CDlgCompare::OnSize( WPARAM wParam, LPARAM lParam )
 {
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	CDialog::OnSize( wParam, lParam );
 
 	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcCompareDialog );

--- a/sakura_core/dlg/CDlgCompare.h
+++ b/sakura_core/dlg/CDlgCompare.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒtƒ@ƒCƒ‹”äŠrƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«æ¯”è¼ƒãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
 */
@@ -18,7 +18,7 @@ class CDlgCompare;
 
 #include "dlg/CDialog.h"
 /*!
-	@brief ƒtƒ@ƒCƒ‹”äŠrƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«æ¯”è¼ƒãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 */
 class CDlgCompare : public CDialog
 {
@@ -31,28 +31,28 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM, const TCHAR*, TCHAR*, HWND* );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, LPARAM, const TCHAR*, TCHAR*, HWND* );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 	const TCHAR*	m_pszPath;
 	TCHAR*			m_pszCompareLabel;
 	HWND*			m_phwndCompareWnd;
-	BOOL			m_bCompareAndTileHorz;/* ¶‰E‚É•À‚×‚Ä•\¦ */
+	BOOL			m_bCompareAndTileHorz;/* å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º */
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL OnBnClicked( int );
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
 
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// •W€ˆÈŠO‚ÌƒƒbƒZ[ƒW‚ğ•ß‘¨‚·‚é
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// æ¨™æº–ä»¥å¤–ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );
 	BOOL OnSize( WPARAM wParam, LPARAM lParam );
 	BOOL OnMove( WPARAM wParam, LPARAM lParam );
 	BOOL OnMinMaxInfo( LPARAM lParam );
 
-	void SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 
 private:
 	POINT			m_ptDefaultSize;

--- a/sakura_core/dlg/CDlgCtrlCode.h
+++ b/sakura_core/dlg/CDlgCtrlCode.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh“ü—Íƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰å…¥åŠ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
 	@date 2002.6.2
@@ -35,9 +35,9 @@ class CDlgCtrlCode;
 
 #include "dlg/CDialog.h"
 /*!
-	@brief ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh“ü—Íƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+	@brief ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰å…¥åŠ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 */
-//2007.10.18 kobake GetCharCode()‚ğì¬B
+//2007.10.18 kobake GetCharCode()ã‚’ä½œæˆã€‚
 class CDlgCtrlCode : public CDialog
 {
 public:
@@ -49,27 +49,27 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, LPARAM );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
-	wchar_t GetCharCode() const{ return m_nCode; } //!< ‘I‘ğ‚³‚ê‚½•¶šƒR[ƒh‚ğæ“¾
+	wchar_t GetCharCode() const{ return m_nCode; } //!< é¸æŠã•ã‚ŒãŸæ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚’å–å¾—
 
 private:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL	OnInitDialog( HWND, WPARAM wParam, LPARAM lParam );
 	BOOL	OnBnClicked( int );
 	BOOL	OnNotify( WPARAM wParam, LPARAM lParam );
 	LPVOID	GetHelpIdTable( void );
 
-	void	SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int		GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void	SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int		GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 
 private:
 	/*
-	|| ƒƒ“ƒo•Ï”
+	|| ãƒ¡ãƒ³ãƒå¤‰æ•°
 	*/
-	wchar_t		m_nCode;	// ƒR[ƒh
+	wchar_t		m_nCode;	// ã‚³ãƒ¼ãƒ‰
 };
 
 

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief DIFF·•ª•\¦ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief DIFFå·®åˆ†è¡¨ç¤ºãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
 	@date 2002.5.27
@@ -9,7 +9,7 @@
 	Copyright (C) 2001, Stonee, genta, JEPRO, YAZAKI
 	Copyright (C) 2002, aroka, MIK, Moca
 	Copyright (C) 2003, MIK, genta
-	Copyright (C) 2004, MIK, genta, ‚¶‚ã‚¤‚¶
+	Copyright (C) 2004, MIK, genta, ã˜ã‚…ã†ã˜
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2009, ryoji
 
@@ -47,9 +47,9 @@ const DWORD p_helpids[] = {	//13200
 	IDOK,						HIDC_DIFF_IDOK,
 	IDCANCEL,					HIDC_DIFF_IDCANCEL,
 	IDC_BUTTON_HELP,			HIDC_BUTTON_DIFF_HELP,
-	IDC_CHECK_DIFF_EXEC_STATE,	HIDC_CHECK_DIFF_EXEC_STATE,	//DIFF·•ª‚ªŒ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ğ•\¦  2003.05.12 MIK
-	IDC_CHECK_NOTIFYNOTFOUND,	HIDC_CHECK_DIFF_NOTIFYNOTFOUND,	// Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ğ•\¦	// 2006.10.10 ryoji
-	IDC_CHECK_SEARCHALL,		HIDC_CHECK_DIFF_SEARCHALL,		// æ“ªi––”öj‚©‚çÄŒŸõ‚·‚é	// 2006.10.10 ryoji
+	IDC_CHECK_DIFF_EXEC_STATE,	HIDC_CHECK_DIFF_EXEC_STATE,	//DIFFå·®åˆ†ãŒè¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º  2003.05.12 MIK
+	IDC_CHECK_NOTIFYNOTFOUND,	HIDC_CHECK_DIFF_NOTIFYNOTFOUND,	// è¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º	// 2006.10.10 ryoji
+	IDC_CHECK_SEARCHALL,		HIDC_CHECK_DIFF_SEARCHALL,		// å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ã™ã‚‹	// 2006.10.10 ryoji
 //	IDC_FRAME_SEARCH_MSG,		HIDC_FRAME_DIFF_SEARCH_MSG,
 //	IDC_STATIC,					-1,
 	0, 0
@@ -85,7 +85,7 @@ CDlgDiff::CDlgDiff()
 	: CDialog(true)
 	, m_nIndexSave( 0 )
 {
-	/* ƒTƒCƒY•ÏX‚ÉˆÊ’u‚ğ§Œä‚·‚éƒRƒ“ƒgƒ[ƒ‹” */
+	/* ã‚µã‚¤ã‚ºå¤‰æ›´æ™‚ã«ä½ç½®ã‚’åˆ¶å¾¡ã™ã‚‹ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«æ•° */
 	assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	m_nDiffFlgOpt    = 0;
@@ -98,12 +98,12 @@ CDlgDiff::CDlgDiff()
 	return;
 }
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgDiff::DoModal(
 	HINSTANCE			hInstance,
 	HWND				hwndParent,
 	LPARAM				lParam,
-	const TCHAR*		pszPath		//©ƒtƒ@ƒCƒ‹
+	const TCHAR*		pszPath		//è‡ªãƒ•ã‚¡ã‚¤ãƒ«
 )
 {
 	_tcscpy(m_szFile1, pszPath);
@@ -116,16 +116,16 @@ BOOL CDlgDiff::OnBnClicked( int wID )
 	switch( wID )
 	{
 	case IDC_BUTTON_HELP:
-		/* ƒwƒ‹ƒv */
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_DIFF_DIALOG) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ãƒ˜ãƒ«ãƒ— */
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_DIFF_DIALOG) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 
-	case IDC_BUTTON_DIFF_DST:	/* QÆ */
+	case IDC_BUTTON_DIFF_DST:	/* å‚ç…§ */
 		{
 			CDlgOpenFile	cDlgOpenFile;
 			TCHAR			szPath[_MAX_PATH];
 			_tcscpy( szPath, m_szFile2 );
-			/* ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“ƒ_ƒCƒAƒƒO‚Ì‰Šú‰» */
+			/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸåŒ– */
 			cDlgOpenFile.Create(
 				m_hInstance,
 				GetHwnd(),
@@ -136,7 +136,7 @@ BOOL CDlgDiff::OnBnClicked( int wID )
 			{
 				_tcscpy( m_szFile2, szPath );
 				::DlgItem_SetText( GetHwnd(), IDC_EDIT_DIFF_DST, m_szFile2 );
-				//ŠO•”ƒtƒ@ƒCƒ‹‚ğ‘I‘ğó‘Ô‚É
+				//å¤–éƒ¨ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é¸æŠçŠ¶æ…‹ã«
 				::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_DST1, TRUE );
 				::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_DST2, FALSE );
 				List_SetCurSel( ::GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES), -1 );
@@ -144,8 +144,8 @@ BOOL CDlgDiff::OnBnClicked( int wID )
 		}
 		return TRUE;
 
-	case IDOK:			/* ¶‰E‚É•\¦ */
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	case IDOK:			/* å·¦å³ã«è¡¨ç¤º */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		::EndDialog( GetHwnd(), GetData() );
 		return TRUE;
 
@@ -158,7 +158,7 @@ BOOL CDlgDiff::OnBnClicked( int wID )
 		//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_EDIT_DIFF_DST ), TRUE );
 		//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_BUTTON_DIFF_DST ), TRUE );
 		//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES ), FALSE );
-		//	Feb. 28, 2004 genta ‘I‘ğ‰ğœ‘O‚É‘O‰ñ‚ÌˆÊ’u‚ğ‹L‰¯
+		//	Feb. 28, 2004 genta é¸æŠè§£é™¤å‰ã«å‰å›ã®ä½ç½®ã‚’è¨˜æ†¶
 		{
 			int n = List_GetCurSel( GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES ) );
 			if( n != LB_ERR ){
@@ -175,7 +175,7 @@ BOOL CDlgDiff::OnBnClicked( int wID )
 		//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES ), TRUE );
 		{
 			//	Aug. 9, 2003 genta
-			//	ListBox‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚È‚©‚Á‚½‚çCæ“ª‚Ìƒtƒ@ƒCƒ‹‚ğ‘I‘ğ‚·‚éD
+			//	ListBoxãŒé¸æŠã•ã‚Œã¦ã„ãªã‹ã£ãŸã‚‰ï¼Œå…ˆé ­ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é¸æŠã™ã‚‹ï¼
 			HWND hwndList = GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES );
 			if( List_GetCurSel( hwndList ) == LB_ERR )
 			{
@@ -193,14 +193,14 @@ BOOL CDlgDiff::OnBnClicked( int wID )
 		return TRUE;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgDiff::SetData( void )
 {
-	//ƒIƒvƒVƒ‡ƒ“
+	//ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 	m_nDiffFlgOpt = m_pShareData->m_nDiffFlgOpt;
 	if( m_nDiffFlgOpt & 0x0001 ) ::CheckDlgButton( GetHwnd(), IDC_CHECK_DIFF_OPT_CASE,   TRUE );
 	if( m_nDiffFlgOpt & 0x0002 ) ::CheckDlgButton( GetHwnd(), IDC_CHECK_DIFF_OPT_SPACE,  TRUE );
@@ -208,7 +208,7 @@ void CDlgDiff::SetData( void )
 	if( m_nDiffFlgOpt & 0x0008 ) ::CheckDlgButton( GetHwnd(), IDC_CHECK_DIFF_OPT_BLINE,  TRUE );
 	if( m_nDiffFlgOpt & 0x0010 ) ::CheckDlgButton( GetHwnd(), IDC_CHECK_DIFF_OPT_TABSPC, TRUE );
 
-	//V‹Œƒtƒ@ƒCƒ‹
+	//æ–°æ—§ãƒ•ã‚¡ã‚¤ãƒ«
 	if( m_nDiffFlgOpt & 0x0020 )
 	{
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_FILE1, FALSE );
@@ -223,16 +223,16 @@ void CDlgDiff::SetData( void )
 	//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_DIFF_FILE1 ), FALSE );
 	//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_DIFF_FILE2 ), FALSE );
 
-	//DIFF·•ª‚ªŒ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ğ•\¦ 2003.05.12 MIK
+	//DIFFå·®åˆ†ãŒè¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º 2003.05.12 MIK
 	if( m_nDiffFlgOpt & 0x0040 ) ::CheckDlgButton( GetHwnd(), IDC_CHECK_DIFF_EXEC_STATE, TRUE );
 
-	/* Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦ */
+	/* è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º */
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_NOTIFYNOTFOUND, m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND );
 	
-	/* æ“ªi––”öj‚©‚çÄŒŸõ */
+	/* å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ */
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_SEARCHALL, m_pShareData->m_Common.m_sSearch.m_bSearchAll );
 
-	/* •ÒW’†‚Ìƒtƒ@ƒCƒ‹ˆê——‚ğì¬‚·‚é */
+	/* ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§ã‚’ä½œæˆã™ã‚‹ */
 	{
 		HWND		hwndList;
 		int			nRowNum;
@@ -246,57 +246,57 @@ void CDlgDiff::SetData( void )
 		ECodeType	code;
 		int			selCode = CODE_NONE;
 
-		// ©•ª‚Ì•¶šƒR[ƒh‚ğæ“¾
+		// è‡ªåˆ†ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚’å–å¾—
 		::SendMessageAny( CEditWnd::getInstance()->GetHwnd(), MYWM_GETFILEINFO, 0, 0 );
 		pFileInfo = &m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 		code = pFileInfo->m_nCharCode;
 
-		/* ƒŠƒXƒg‚Ìƒnƒ“ƒhƒ‹æ“¾ */
+		/* ãƒªã‚¹ãƒˆã®ãƒãƒ³ãƒ‰ãƒ«å–å¾— */
 		hwndList = :: GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES );
 
-		/* Œ»İŠJ‚¢‚Ä‚¢‚é•ÒW‘‹‚ÌƒŠƒXƒg‚ğƒƒjƒ…[‚É‚·‚é */
+		/* ç¾åœ¨é–‹ã„ã¦ã„ã‚‹ç·¨é›†çª“ã®ãƒªã‚¹ãƒˆã‚’ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«ã™ã‚‹ */
 		nRowNum = CAppNodeManager::getInstance()->GetOpenedWindowArr( &pEditNode, TRUE );
 		if( nRowNum > 0 )
 		{
-			// …•½ƒXƒNƒ[ƒ‹•‚ÍÀÛ‚É•\¦‚·‚é•¶š—ñ‚Ì•‚ğŒv‘ª‚µ‚ÄŒˆ‚ß‚é	// 2009.09.26 ryoji
+			// æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å¹…ã¯å®Ÿéš›ã«è¡¨ç¤ºã™ã‚‹æ–‡å­—åˆ—ã®å¹…ã‚’è¨ˆæ¸¬ã—ã¦æ±ºã‚ã‚‹	// 2009.09.26 ryoji
 			CTextWidthCalc calc(hwndList);
 			int score = 0;
 			TCHAR		szFile1[_MAX_PATH];
 			SplitPath_FolderAndFile(m_szFile1, NULL, szFile1);
 			for( i = 0; i < nRowNum; i++ )
 			{
-				/* ƒgƒŒƒC‚©‚çƒGƒfƒBƒ^‚Ö‚Ì•ÒWƒtƒ@ƒCƒ‹–¼—v‹’Ê’m */
+				/* ãƒˆãƒ¬ã‚¤ã‹ã‚‰ã‚¨ãƒ‡ã‚£ã‚¿ã¸ã®ç·¨é›†ãƒ•ã‚¡ã‚¤ãƒ«åè¦æ±‚é€šçŸ¥ */
 				::SendMessageAny( pEditNode[i].GetHwnd(), MYWM_GETFILEINFO, 0, 0 );
 				pFileInfo = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
-				/* ©•ª‚È‚çƒXƒLƒbƒv */
+				/* è‡ªåˆ†ãªã‚‰ã‚¹ã‚­ãƒƒãƒ— */
 				if ( pEditNode[i].GetHwnd() == CEditWnd::getInstance()->GetHwnd() )
 				{
-					// “¯‚¶Œ`®‚É‚µ‚Ä‚¨‚­B‚½‚¾‚µƒAƒNƒZƒXƒL[”Ô†‚Í‚È‚µ
+					// åŒã˜å½¢å¼ã«ã—ã¦ãŠãã€‚ãŸã ã—ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ç•ªå·ã¯ãªã—
 					CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szName, _countof(szName), pFileInfo, pEditNode[i].m_nId, -1, calc.GetDC() );
 					::DlgItem_SetText( GetHwnd(), IDC_STATIC_DIFF_SRC, szName );
 					continue;
 				}
 
-				// ”Ô†‚ÍƒEƒBƒ“ƒhƒEˆê——‚Æ“¯‚¶”Ô†‚ğg‚¤
+				// ç•ªå·ã¯ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§ã¨åŒã˜ç•ªå·ã‚’ä½¿ã†
 				CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szName, _countof(szName), pFileInfo, pEditNode[i].m_nId, i, calc.GetDC() );
 
 
-				/* ƒŠƒXƒg‚É“o˜^‚·‚é */
+				/* ãƒªã‚¹ãƒˆã«ç™»éŒ²ã™ã‚‹ */
 				nItem = ::List_AddString( hwndList, szName );
 				List_SetItemData( hwndList, nItem, pEditNode[i].GetHwnd() );
 				count++;
 
-				// ‰¡•‚ğŒvZ‚·‚é
+				// æ¨ªå¹…ã‚’è¨ˆç®—ã™ã‚‹
 				calc.SetTextWidthIfMax(szName);
 
-				// ƒtƒ@ƒCƒ‹–¼ˆê’v‚ÌƒXƒRƒA‚ğŒvZ‚·‚é
+				// ãƒ•ã‚¡ã‚¤ãƒ«åä¸€è‡´ã®ã‚¹ã‚³ã‚¢ã‚’è¨ˆç®—ã™ã‚‹
 				TCHAR szFile2[_MAX_PATH];
 				SplitPath_FolderAndFile( pFileInfo->m_szPath, NULL, szFile2 );
 				int scoreTemp = FileMatchScoreSepExt( szFile1, szFile2 );
 				if( score < scoreTemp ||
 					(selCode != code && code == pFileInfo->m_nCharCode && score == scoreTemp) ){
-					// ƒXƒRƒA‚Ì‚¢‚¢‚à‚Ì‚ğ‘I‘ğ. “¯‚¶‚È‚ç•¶šƒR[ƒh‚ª“¯‚¶‚à‚Ì‚ğ‘I‘ğ
+					// ã‚¹ã‚³ã‚¢ã®ã„ã„ã‚‚ã®ã‚’é¸æŠ. åŒã˜ãªã‚‰æ–‡å­—ã‚³ãƒ¼ãƒ‰ãŒåŒã˜ã‚‚ã®ã‚’é¸æŠ
 					score = scoreTemp;
 					selIndex = nItem;
 					selCode = pFileInfo->m_nCharCode;
@@ -304,72 +304,72 @@ void CDlgDiff::SetData( void )
 			}
 
 			delete [] pEditNode;
-			// 2002/11/01 Moca ’Ç‰Á ƒŠƒXƒgƒrƒ…[‚Ì‰¡•‚ğİ’èB‚±‚ê‚ğ‚â‚ç‚È‚¢‚Æ…•½ƒXƒNƒ[ƒ‹ƒo[‚ªg‚¦‚È‚¢
+			// 2002/11/01 Moca è¿½åŠ  ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®æ¨ªå¹…ã‚’è¨­å®šã€‚ã“ã‚Œã‚’ã‚„ã‚‰ãªã„ã¨æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ãŒä½¿ãˆãªã„
 			List_SetHorizontalExtent( hwndList, calc.GetCx() + 8 );
 
-			/* Å‰‚ğ‘I‘ğ */
+			/* æœ€åˆã‚’é¸æŠ */
 			//List_SetCurSel( hwndList, 0 );
 		}
 
-		//	From Here 2004.02.22 ‚¶‚ã‚¤‚¶
-		//	ŠJ‚¢‚Ä‚¢‚éƒtƒ@ƒCƒ‹‚ª‚ ‚éê‡‚É‚Í‰Šúó‘Ô‚Å‚»‚¿‚ç‚ğ—Dæ
+		//	From Here 2004.02.22 ã˜ã‚…ã†ã˜
+		//	é–‹ã„ã¦ã„ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ãŒã‚ã‚‹å ´åˆã«ã¯åˆæœŸçŠ¶æ…‹ã§ãã¡ã‚‰ã‚’å„ªå…ˆ
 		if( count == 0 )
 		{
-			/* ‘Šèƒtƒ@ƒCƒ‹‚Ì‘I‘ğ */
+			/* ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«ã®é¸æŠ */
 			::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_DST1, TRUE );
 			::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_DST2, FALSE );
-			/* ‚»‚Ì‘¼‚Ì•ÒW’†ƒŠƒXƒg‚Í‚È‚µ */
+			/* ãã®ä»–ã®ç·¨é›†ä¸­ãƒªã‚¹ãƒˆã¯ãªã— */
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_DIFF_DST2 ), FALSE );
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES ), FALSE );
 		}
 		else
 		{
-			/* ‘Šèƒtƒ@ƒCƒ‹‚Ì‘I‘ğ */
+			/* ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«ã®é¸æŠ */
 			::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_DST1, FALSE );
 			::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_DST2, TRUE );
-			//	ListBox‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚È‚©‚Á‚½‚çCæ“ª‚Ìƒtƒ@ƒCƒ‹‚ğ‘I‘ğ‚·‚éD
+			//	ListBoxãŒé¸æŠã•ã‚Œã¦ã„ãªã‹ã£ãŸã‚‰ï¼Œå…ˆé ­ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é¸æŠã™ã‚‹ï¼
 			HWND hwndList = GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES );
 			if( List_GetCurSel( hwndList ) == LB_ERR )
 			{
 			    List_SetCurSel( hwndList, selIndex );
 			}
 		}
-		//	To Here 2004.02.22 ‚¶‚ã‚¤‚¶
-		//	Feb. 28, 2004 genta ˆê”Ôã‚ğ‘I‘ğˆÊ’u‚Æ‚·‚éD
+		//	To Here 2004.02.22 ã˜ã‚…ã†ã˜
+		//	Feb. 28, 2004 genta ä¸€ç•ªä¸Šã‚’é¸æŠä½ç½®ã¨ã™ã‚‹ï¼
 		m_nIndexSave = selIndex;
 	}
 
 	return;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-/* TRUE==³í  FALSE==“ü—ÍƒGƒ‰[ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+/* TRUE==æ­£å¸¸  FALSE==å…¥åŠ›ã‚¨ãƒ©ãƒ¼ */
 int CDlgDiff::GetData( void )
 {
 	BOOL	ret = TRUE;
 
-	//DIFFƒIƒvƒVƒ‡ƒ“
+	//DIFFã‚ªãƒ—ã‚·ãƒ§ãƒ³
 	m_nDiffFlgOpt = 0;
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_DIFF_OPT_CASE   ) == BST_CHECKED ) m_nDiffFlgOpt |= 0x0001;
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_DIFF_OPT_SPACE  ) == BST_CHECKED ) m_nDiffFlgOpt |= 0x0002;
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_DIFF_OPT_SPCCHG ) == BST_CHECKED ) m_nDiffFlgOpt |= 0x0004;
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_DIFF_OPT_BLINE  ) == BST_CHECKED ) m_nDiffFlgOpt |= 0x0008;
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_DIFF_OPT_TABSPC ) == BST_CHECKED ) m_nDiffFlgOpt |= 0x0010;
-	//ƒtƒ@ƒCƒ‹V‹Œ
+	//ãƒ•ã‚¡ã‚¤ãƒ«æ–°æ—§
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_DIFF_FILE2      ) == BST_CHECKED ) m_nDiffFlgOpt |= 0x0020;
-	//DIFF·•ª‚ªŒ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ğ•\¦ 2003.05.12 MIK
+	//DIFFå·®åˆ†ãŒè¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º 2003.05.12 MIK
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_DIFF_EXEC_STATE ) == BST_CHECKED ) m_nDiffFlgOpt |= 0x0040;
 	m_pShareData->m_nDiffFlgOpt = m_nDiffFlgOpt;
 
-	//‘Šèƒtƒ@ƒCƒ‹–¼
+	//ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«å
 	_tcscpy( m_szFile2, _T("") );
 	m_hWnd_Dst = NULL;
 	m_bIsModifiedDst = false;
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_DIFF_DST1 ) == BST_CHECKED )
 	{
 		::DlgItem_GetText( GetHwnd(), IDC_EDIT_DIFF_DST, m_szFile2, _countof2(m_szFile2) );
-		//	2004.05.19 MIK ŠO•”ƒtƒ@ƒCƒ‹‚ªw’è‚³‚ê‚Ä‚¢‚È‚¢ê‡‚ÍƒLƒƒƒ“ƒZƒ‹
-		//‘Šèƒtƒ@ƒCƒ‹‚ªw’è‚³‚ê‚Ä‚È‚¯‚ê‚ÎƒLƒƒƒ“ƒZƒ‹
+		//	2004.05.19 MIK å¤–éƒ¨ãƒ•ã‚¡ã‚¤ãƒ«ãŒæŒ‡å®šã•ã‚Œã¦ã„ãªã„å ´åˆã¯ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+		//ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«ãŒæŒ‡å®šã•ã‚Œã¦ãªã‘ã‚Œã°ã‚­ãƒ£ãƒ³ã‚»ãƒ«
 		if( m_szFile2[0] == '\0' ) ret = FALSE;
 
 	}
@@ -379,14 +379,14 @@ int CDlgDiff::GetData( void )
 		int			nItem;
 		EditInfo	*pFileInfo;
 
-		/* ƒŠƒXƒg‚©‚ç‘Šè‚ÌƒEƒCƒ“ƒhƒEƒnƒ“ƒhƒ‹‚ğæ“¾ */
+		/* ãƒªã‚¹ãƒˆã‹ã‚‰ç›¸æ‰‹ã®ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«ã‚’å–å¾— */
 		hwndList = :: GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES );
 		nItem = List_GetCurSel( hwndList );
 		if( nItem != LB_ERR )
 		{
 			m_hWnd_Dst = (HWND)List_GetItemData( hwndList, nItem );
 
-			/* ƒgƒŒƒC‚©‚çƒGƒfƒBƒ^‚Ö‚Ì•ÒWƒtƒ@ƒCƒ‹–¼—v‹’Ê’m */
+			/* ãƒˆãƒ¬ã‚¤ã‹ã‚‰ã‚¨ãƒ‡ã‚£ã‚¿ã¸ã®ç·¨é›†ãƒ•ã‚¡ã‚¤ãƒ«åè¦æ±‚é€šçŸ¥ */
 			::SendMessageAny( m_hWnd_Dst, MYWM_GETFILEINFO, 0, 0 );
 			pFileInfo = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
@@ -405,20 +405,20 @@ int CDlgDiff::GetData( void )
 		ret = FALSE;
 	}
 
-	/* Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦ */
+	/* è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º */
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_NOTIFYNOTFOUND ) == BST_CHECKED )
 		m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND = TRUE;
 	else
 		m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND = FALSE;
 
-	/* æ“ªi––”öj‚©‚çÄŒŸõ */
+	/* å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ */
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_SEARCHALL ) == BST_CHECKED )
 		m_pShareData->m_Common.m_sSearch.m_bSearchAll = TRUE;
 	else
 		m_pShareData->m_Common.m_sSearch.m_bSearchAll = FALSE;
 
-	//‘Šèƒtƒ@ƒCƒ‹‚ªw’è‚³‚ê‚Ä‚È‚¯‚ê‚ÎƒLƒƒƒ“ƒZƒ‹
-	//	2004.02.21 MIK ‘Šè‚ª–³‘è‚¾‚Æ”äŠr‚Å‚«‚È‚¢‚Ì‚Å”»’èíœ
+	//ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«ãŒæŒ‡å®šã•ã‚Œã¦ãªã‘ã‚Œã°ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	//	2004.02.21 MIK ç›¸æ‰‹ãŒç„¡é¡Œã ã¨æ¯”è¼ƒã§ããªã„ã®ã§åˆ¤å®šå‰Šé™¤
 	//if( m_szFile2[0] == '\0' ) ret = FALSE;
 
 	return ret;
@@ -437,7 +437,7 @@ BOOL CDlgDiff::OnLbnSelChange( HWND hwndCtl, int wID )
 		return TRUE;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnLbnSelChange( hwndCtl, wID );
 }
 
@@ -451,7 +451,7 @@ BOOL CDlgDiff::OnEnChange( HWND hwndCtl, int wID )
 	{
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_DST1, TRUE );
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_DST2, FALSE );
-		//	Feb. 28, 2004 genta ‘I‘ğ‰ğœ‘O‚É‘O‰ñ‚ÌˆÊ’u‚ğ‹L‰¯‚µ‚Ä‘I‘ğ‰ğœ
+		//	Feb. 28, 2004 genta é¸æŠè§£é™¤å‰ã«å‰å›ã®ä½ç½®ã‚’è¨˜æ†¶ã—ã¦é¸æŠè§£é™¤
 		int n = List_GetCurSel( GetDlgItem( GetHwnd(), IDC_LIST_DIFF_FILES ) );
 		if( n != LB_ERR ){
 			m_nIndexSave = n;
@@ -460,7 +460,7 @@ BOOL CDlgDiff::OnEnChange( HWND hwndCtl, int wID )
 		return TRUE;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnEnChange( hwndCtl, wID );
 }
 
@@ -519,7 +519,7 @@ BOOL CDlgDiff::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 BOOL CDlgDiff::OnSize( WPARAM wParam, LPARAM lParam )
 {
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	CDialog::OnSize( wParam, lParam );
 
 	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcDiffDialog );

--- a/sakura_core/dlg/CDlgDiff.h
+++ b/sakura_core/dlg/CDlgDiff.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief DIFF·•ª•\¦ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief DIFFå·®åˆ†è¡¨ç¤ºãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
 	@date 2002.5.27
@@ -36,9 +36,9 @@ class CDlgDiff;
 
 #include "dlg/CDialog.h"
 /*!
-	@brief DIFF·•ª•\¦ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+	@brief DIFFå·®åˆ†è¡¨ç¤ºãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 */
-//	Feb. 28, 2004 genta ÅŒã‚É‘I‘ğ‚³‚ê‚Ä‚¢‚½”Ô†‚ğ•Û‘¶‚·‚é
+//	Feb. 28, 2004 genta æœ€å¾Œã«é¸æŠã•ã‚Œã¦ã„ãŸç•ªå·ã‚’ä¿å­˜ã™ã‚‹
 class CDlgDiff : public CDialog
 {
 public:
@@ -50,39 +50,39 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM, const TCHAR* );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, LPARAM, const TCHAR* );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL	OnBnClicked( int );
 	BOOL	OnLbnSelChange( HWND hwndCtl, int wID );
 	BOOL	OnLbnDblclk( int wID );
 	BOOL	OnEnChange( HWND hwndCtl, int wID );
 	LPVOID	GetHelpIdTable(void);
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// •W€ˆÈŠO‚ÌƒƒbƒZ[ƒW‚ğ•ß‘¨‚·‚é
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// æ¨™æº–ä»¥å¤–ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );
 	BOOL OnSize( WPARAM wParam, LPARAM lParam );
 	BOOL OnMove( WPARAM wParam, LPARAM lParam );
 	BOOL OnMinMaxInfo( LPARAM lParam );
 
-	void	SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int		GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void	SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int		GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 
 private:
-	int			m_nIndexSave;		// ÅŒã‚É‘I‘ğ‚³‚ê‚Ä‚¢‚½”Ô†
+	int			m_nIndexSave;		// æœ€å¾Œã«é¸æŠã•ã‚Œã¦ã„ãŸç•ªå·
 	POINT		m_ptDefaultSize;
 	RECT		m_rcItems[22];
 
 public:
-	SFilePath	m_szFile1;			// ©ƒtƒ@ƒCƒ‹
-	SFilePath	m_szFile2;			// ‘Šèƒtƒ@ƒCƒ‹
-	bool		m_bIsModifiedDst;	// ‘Šèƒtƒ@ƒCƒ‹XV’†
-	ECodeType	m_nCodeTypeDst;		// ‘Šèƒtƒ@ƒCƒ‹‚Ì•¶šƒR[ƒh
-	bool		m_bBomDst;			// ‘Šèƒtƒ@ƒCƒ‹‚ÌBOM
-	int			m_nDiffFlgOpt;		// DIFFƒIƒvƒVƒ‡ƒ“
-	HWND		m_hWnd_Dst;			// ‘ŠèƒEƒCƒ“ƒhƒEƒnƒ“ƒhƒ‹
+	SFilePath	m_szFile1;			// è‡ªãƒ•ã‚¡ã‚¤ãƒ«
+	SFilePath	m_szFile2;			// ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«
+	bool		m_bIsModifiedDst;	// ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«æ›´æ–°ä¸­
+	ECodeType	m_nCodeTypeDst;		// ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰
+	bool		m_bBomDst;			// ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«ã®BOM
+	int			m_nDiffFlgOpt;		// DIFFã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	HWND		m_hWnd_Dst;			// ç›¸æ‰‹ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«
 
 };
 

--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ŠO•”ƒRƒ}ƒ“ƒhÀsƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
 */
@@ -19,7 +19,7 @@
 #include "StdAfx.h"
 #include "dlg/CDlgExec.h"
 #include "dlg/CDlgOpenFile.h"	//Mar. 28, 2001 JEPRO
-#include "func/Funccode.h"	//Stonee, 2001/03/12  ƒRƒƒ“ƒgƒAƒEƒg‚³‚ê‚Ä‚½‚Ì‚ğ—LŒø‚É‚µ‚½
+#include "func/Funccode.h"	//Stonee, 2001/03/12  ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã•ã‚Œã¦ãŸã®ã‚’æœ‰åŠ¹ã«ã—ãŸ
 #include "util/shell.h"
 #include "util/window.h"
 #include "_main/CAppMode.h"
@@ -27,29 +27,29 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 
-//ŠO•”ƒRƒ}ƒ“ƒh CDlgExec.cpp	//@@@ 2002.01.07 add start MIK
+//å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰ CDlgExec.cpp	//@@@ 2002.01.07 add start MIK
 const DWORD p_helpids[] = {	//12100
-	IDC_BUTTON_REFERENCE,			HIDC_EXEC_BUTTON_REFERENCE,		//QÆ
-	IDOK,							HIDOK_EXEC,						//Às
-	IDCANCEL,						HIDCANCEL_EXEC,					//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_EXEC_BUTTON_HELP,			//ƒwƒ‹ƒv
-	IDC_CHECK_GETSTDOUT,			HIDC_EXEC_CHECK_GETSTDOUT,		//•W€o—Í‚ğ“¾‚é
-	IDC_COMBO_CODE_GET,				HIDC_COMBO_CODE_GET,			//•W€o—Í•¶šƒR[ƒh
-	IDC_COMBO_m_szCommand,			HIDC_EXEC_COMBO_m_szCommand,	//ƒRƒ}ƒ“ƒh
-	IDC_RADIO_OUTPUT,				HIDC_RADIO_OUTPUT,				//•W€o—ÍƒŠƒ_ƒCƒŒƒNƒgæFƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE
-	IDC_RADIO_EDITWINDOW,			HIDC_RADIO_EDITWINDOW,			//•W€o—ÍƒŠƒ_ƒCƒŒƒNƒgæF•ÒW’†‚ÌƒEƒBƒ“ƒhƒE
-	IDC_CHECK_SENDSTDIN,			HIDC_CHECK_SENDSTDIN,			//•W€“ü—Í‚É‘—‚é
-	IDC_COMBO_CODE_SEND,			HIDC_COMBO_CODE_SEND,			//•W€o—Í•¶šƒR[ƒh
-	IDC_CHECK_CUR_DIR,				HIDC_CHECK_CUR_DIR,				//ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ
-	IDC_COMBO_CUR_DIR,				HIDC_COMBO_CUR_DIR,				//ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠw’è
-	IDC_BUTTON_REFERENCE2,			HIDC_COMBO_CUR_DIR,				//ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠw’è(QÆ)
+	IDC_BUTTON_REFERENCE,			HIDC_EXEC_BUTTON_REFERENCE,		//å‚ç…§
+	IDOK,							HIDOK_EXEC,						//å®Ÿè¡Œ
+	IDCANCEL,						HIDCANCEL_EXEC,					//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_EXEC_BUTTON_HELP,			//ãƒ˜ãƒ«ãƒ—
+	IDC_CHECK_GETSTDOUT,			HIDC_EXEC_CHECK_GETSTDOUT,		//æ¨™æº–å‡ºåŠ›ã‚’å¾—ã‚‹
+	IDC_COMBO_CODE_GET,				HIDC_COMBO_CODE_GET,			//æ¨™æº–å‡ºåŠ›æ–‡å­—ã‚³ãƒ¼ãƒ‰
+	IDC_COMBO_m_szCommand,			HIDC_EXEC_COMBO_m_szCommand,	//ã‚³ãƒãƒ³ãƒ‰
+	IDC_RADIO_OUTPUT,				HIDC_RADIO_OUTPUT,				//æ¨™æº–å‡ºåŠ›ãƒªãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆå…ˆï¼šã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	IDC_RADIO_EDITWINDOW,			HIDC_RADIO_EDITWINDOW,			//æ¨™æº–å‡ºåŠ›ãƒªãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆå…ˆï¼šç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	IDC_CHECK_SENDSTDIN,			HIDC_CHECK_SENDSTDIN,			//æ¨™æº–å…¥åŠ›ã«é€ã‚‹
+	IDC_COMBO_CODE_SEND,			HIDC_COMBO_CODE_SEND,			//æ¨™æº–å‡ºåŠ›æ–‡å­—ã‚³ãƒ¼ãƒ‰
+	IDC_CHECK_CUR_DIR,				HIDC_CHECK_CUR_DIR,				//ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª
+	IDC_COMBO_CUR_DIR,				HIDC_COMBO_CUR_DIR,				//ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªæŒ‡å®š
+	IDC_BUTTON_REFERENCE2,			HIDC_COMBO_CUR_DIR,				//ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªæŒ‡å®š(å‚ç…§)
 //	IDC_STATIC,						-1,
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
 
 CDlgExec::CDlgExec()
 {
-	m_szCommand[0] = _T('\0');	/* ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“ */
+	m_szCommand[0] = _T('\0');	/* ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³ */
 	return;
 }
 
@@ -58,10 +58,10 @@ static const int codeTable2[] = { 0x00, 0x10, 0x100 };
 
 
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgExec::DoModal( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam )
 {
-	m_szCommand[0] = _T('\0');	/* ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“ */
+	m_szCommand[0] = _T('\0');	/* ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³ */
 	m_bEditable = CEditDoc::GetInstance(0)->IsEditable();
 	return (int)CDialog::DoModal( hInstance, hwndParent, IDD_EXEC, lParam );
 }
@@ -94,7 +94,7 @@ BOOL CDlgExec::OnInitDialog( HWND hwnd, WPARAM wParam, LPARAM lParam )
 	return bRet;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgExec::SetData( void )
 {
 //	MYTRACE( _T("CDlgExec::SetData()") );
@@ -102,20 +102,20 @@ void CDlgExec::SetData( void )
 	HWND	hwndCombo;
 
 	/*****************************
-	*           ‰Šú             *
+	*           åˆæœŸ             *
 	*****************************/
-	/* ƒ†[ƒU[‚ªƒRƒ“ƒ{ ƒ{ƒbƒNƒX‚ÌƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+	/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚³ãƒ³ãƒœ ãƒœãƒƒã‚¯ã‚¹ã®ã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 	Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_COMBO_m_szCommand ), _countof( m_szCommand ) - 1 );
 	Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_COMBO_CUR_DIR ), _countof2( m_szCurDir ) - 1 );
-	/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒ†[ƒU[ ƒCƒ“ƒ^[ƒtƒFƒCƒX‚ğŠg’£ƒCƒ“ƒ^[ƒtƒF[ƒX‚É‚·‚é */
+	/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼ ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ã‚¤ã‚¹ã‚’æ‹¡å¼µã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã«ã™ã‚‹ */
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_m_szCommand ), TRUE );
 
-	{	//	From Here 2007.01.02 maru ˆø”‚ğŠg’£‚Ì‚½‚ß
-		//	ƒ}ƒNƒ‚©‚ç‚ÌŒÄ‚Ño‚µ‚Å‚ÍShareData‚É•Û‘¶‚³‚¹‚È‚¢‚æ‚¤‚ÉCShareData‚Æ‚Ìó‚¯“n‚µ‚ÍExecCmd‚ÌŠO‚Å
+	{	//	From Here 2007.01.02 maru å¼•æ•°ã‚’æ‹¡å¼µã®ãŸã‚
+		//	ãƒã‚¯ãƒ­ã‹ã‚‰ã®å‘¼ã³å‡ºã—ã§ã¯ShareDataã«ä¿å­˜ã•ã›ãªã„ã‚ˆã†ã«ï¼ŒShareDataã¨ã®å—ã‘æ¸¡ã—ã¯ExecCmdã®å¤–ã§
 		int nExecFlgOpt;
 		nExecFlgOpt = m_pShareData->m_nExecFlgOpt;
 		
-		// ƒrƒ…[ƒ‚[ƒh‚âã‘‚«‹Ö~‚Ì‚Æ‚«‚Í•ÒW’†ƒEƒBƒ“ƒhƒE‚Ö‚Ío—Í‚µ‚È‚¢	// 2009.02.21 ryoji
+		// ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ã‚„ä¸Šæ›¸ãç¦æ­¢ã®ã¨ãã¯ç·¨é›†ä¸­ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸ã¯å‡ºåŠ›ã—ãªã„	// 2009.02.21 ryoji
 		if( !m_bEditable ){
 			nExecFlgOpt &= ~0x02;
 		}
@@ -128,14 +128,14 @@ void CDlgExec::SetData( void )
 
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_OUTPUT ), nExecFlgOpt & 0x01 ? TRUE : FALSE );
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_EDITWINDOW ), ((nExecFlgOpt & 0x01) && m_bEditable)? TRUE : FALSE );
-		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_COMBO_CODE_GET ), nExecFlgOpt & 0x01 ? TRUE : FALSE );		// •W€o—ÍOffAUnicode‚ğg—p‚·‚é‚ğDesable‚·‚é	2008/6/20 Uchi
-		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_COMBO_CODE_SEND ), nExecFlgOpt & 0x04 ? TRUE : FALSE );		// •W€“ü—ÍOffAUnicode‚ğg—p‚·‚é‚ğDesable‚·‚é	2008/6/20 Uchi
+		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_COMBO_CODE_GET ), nExecFlgOpt & 0x01 ? TRUE : FALSE );		// æ¨™æº–å‡ºåŠ›Offæ™‚ã€Unicodeã‚’ä½¿ç”¨ã™ã‚‹ã‚’Desableã™ã‚‹	2008/6/20 Uchi
+		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_COMBO_CODE_SEND ), nExecFlgOpt & 0x04 ? TRUE : FALSE );		// æ¨™æº–å…¥åŠ›Offæ™‚ã€Unicodeã‚’ä½¿ç”¨ã™ã‚‹ã‚’Desableã™ã‚‹	2008/6/20 Uchi
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_COMBO_CUR_DIR ), nExecFlgOpt & 0x200 ? TRUE : FALSE );
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_BUTTON_REFERENCE2 ), nExecFlgOpt & 0x200 ? TRUE : FALSE );
-	}	//	To Here 2007.01.02 maru ˆø”‚ğŠg’£‚Ì‚½‚ß
+	}	//	To Here 2007.01.02 maru å¼•æ•°ã‚’æ‹¡å¼µã®ãŸã‚
 
 	/*****************************
-	*         ƒf[ƒ^İ’è         *
+	*         ãƒ‡ãƒ¼ã‚¿è¨­å®š         *
 	*****************************/
 	_tcscpy( m_szCommand, m_pShareData->m_sHistory.m_aCommands[0] );
 	hwndCombo = ::GetDlgItem( GetHwnd(), IDC_COMBO_m_szCommand );
@@ -179,7 +179,7 @@ void CDlgExec::SetData( void )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 int CDlgExec::GetData( void )
 {
 	DlgItem_GetText( GetHwnd(), IDC_COMBO_m_szCommand, m_szCommand, _countof( m_szCommand ));
@@ -188,20 +188,20 @@ int CDlgExec::GetData( void )
 	}else{
 		m_szCurDir[0] = _T('\0');
 	}
-	{	//	From Here 2007.01.02 maru ˆø”‚ğŠg’£‚Ì‚½‚ß
-		//	ƒ}ƒNƒ‚©‚ç‚ÌŒÄ‚Ño‚µ‚Å‚ÍShareData‚É•Û‘¶‚³‚¹‚È‚¢‚æ‚¤‚ÉCShareData‚Æ‚Ìó‚¯“n‚µ‚ÍExecCmd‚ÌŠO‚Å
+	{	//	From Here 2007.01.02 maru å¼•æ•°ã‚’æ‹¡å¼µã®ãŸã‚
+		//	ãƒã‚¯ãƒ­ã‹ã‚‰ã®å‘¼ã³å‡ºã—ã§ã¯ShareDataã«ä¿å­˜ã•ã›ãªã„ã‚ˆã†ã«ï¼ŒShareDataã¨ã®å—ã‘æ¸¡ã—ã¯ExecCmdã®å¤–ã§
 		int nFlgOpt = 0;
-		nFlgOpt |= ( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_GETSTDOUT ) ) ? 0x01 : 0;	// •W€o—Í‚ğ“¾‚é
-		nFlgOpt |= ( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_EDITWINDOW ) ) ? 0x02 : 0;	// •W€o—Í‚ğ•ÒW’†‚ÌƒEƒCƒ“ƒhƒE‚Ö
-		nFlgOpt |= ( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_SENDSTDIN ) ) ? 0x04 : 0;	// •ÒW’†ƒtƒ@ƒCƒ‹‚ğ•W€“ü—Í‚Ö
-		nFlgOpt |= ( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_CUR_DIR ) ) ? 0x200 : 0;	// ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠw’è
+		nFlgOpt |= ( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_GETSTDOUT ) ) ? 0x01 : 0;	// æ¨™æº–å‡ºåŠ›ã‚’å¾—ã‚‹
+		nFlgOpt |= ( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_EDITWINDOW ) ) ? 0x02 : 0;	// æ¨™æº–å‡ºåŠ›ã‚’ç·¨é›†ä¸­ã®ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã¸
+		nFlgOpt |= ( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_SENDSTDIN ) ) ? 0x04 : 0;	// ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æ¨™æº–å…¥åŠ›ã¸
+		nFlgOpt |= ( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_CUR_DIR ) ) ? 0x200 : 0;	// ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªæŒ‡å®š
 		int sel;
 		sel = Combo_GetCurSel( GetItemHwnd( IDC_COMBO_CODE_GET ) );
 		nFlgOpt |= codeTable1[sel];
 		sel = Combo_GetCurSel( GetItemHwnd( IDC_COMBO_CODE_SEND ) );
 		nFlgOpt |= codeTable2[sel];
 		m_pShareData->m_nExecFlgOpt = nFlgOpt;
-	}	//	To Here 2007.01.02 maru ˆø”‚ğŠg’£‚Ì‚½‚ß
+	}	//	To Here 2007.01.02 maru å¼•æ•°ã‚’æ‹¡å¼µã®ãŸã‚
 	return 1;
 }
 
@@ -211,20 +211,20 @@ BOOL CDlgExec::OnBnClicked( int wID )
 {
 	switch( wID ){
 	case IDC_CHECK_GETSTDOUT:
-		{	//	From Here 2007.01.02 maru ˆø”‚ğŠg’£‚Ì‚½‚ß
+		{	//	From Here 2007.01.02 maru å¼•æ•°ã‚’æ‹¡å¼µã®ãŸã‚
 			BOOL bEnabled;
 			bEnabled = (BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_GETSTDOUT)) ? TRUE : FALSE;
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_OUTPUT ), bEnabled );
-			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_EDITWINDOW ), (bEnabled && m_bEditable) ? TRUE : FALSE );	// ƒrƒ…[ƒ‚[ƒh‚âã‘‚«‹Ö~‚ÌğŒ’Ç‰Á	// 2009.02.21 ryoji
-		}	//	To Here 2007.01.02 maru ˆø”‚ğŠg’£‚Ì‚½‚ß
+			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_EDITWINDOW ), (bEnabled && m_bEditable) ? TRUE : FALSE );	// ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ã‚„ä¸Šæ›¸ãç¦æ­¢ã®æ¡ä»¶è¿½åŠ 	// 2009.02.21 ryoji
+		}	//	To Here 2007.01.02 maru å¼•æ•°ã‚’æ‹¡å¼µã®ãŸã‚
 
-		// •W€o—ÍOffAUnicode‚ğg—p‚·‚é‚ğDesable‚·‚é	2008/6/20 Uchi
+		// æ¨™æº–å‡ºåŠ›Offæ™‚ã€Unicodeã‚’ä½¿ç”¨ã™ã‚‹ã‚’Desableã™ã‚‹	2008/6/20 Uchi
 		::EnableWindow(
 			GetItemHwnd( IDC_COMBO_CODE_GET ), 
 			BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_GETSTDOUT )
 		);
 		break;
-	case IDC_CHECK_SENDSTDIN:	// •W€“ü—ÍOffAUnicode‚ğg—p‚·‚é‚ğDesable‚·‚é	2008/6/20 Uchi
+	case IDC_CHECK_SENDSTDIN:	// æ¨™æº–å…¥åŠ›Offæ™‚ã€Unicodeã‚’ä½¿ç”¨ã™ã‚‹ã‚’Desableã™ã‚‹	2008/6/20 Uchi
 		::EnableWindow( GetItemHwnd( IDC_COMBO_CODE_SEND ), 
 			BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_SENDSTDIN ) );
 		break;
@@ -236,20 +236,20 @@ BOOL CDlgExec::OnBnClicked( int wID )
 		break;
 
 	case IDC_BUTTON_HELP:
-		/* uŒŸõv‚Ìƒwƒ‹ƒv */
-		//Stonee, 2001/03/12 ‘ælˆø”‚ğA‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_EXECMD_DIALOG) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ã€Œæ¤œç´¢ã€ã®ãƒ˜ãƒ«ãƒ— */
+		//Stonee, 2001/03/12 ç¬¬å››å¼•æ•°ã‚’ã€æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_EXECMD_DIALOG) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		break;
 
 	//From Here Mar. 28, 2001 JEPRO
-	case IDC_BUTTON_REFERENCE:	/* ƒtƒ@ƒCƒ‹–¼‚ÌuQÆ...vƒ{ƒ^ƒ“ */
+	case IDC_BUTTON_REFERENCE:	/* ãƒ•ã‚¡ã‚¤ãƒ«åã®ã€Œå‚ç…§...ã€ãƒœã‚¿ãƒ³ */
 		{
 			CDlgOpenFile	cDlgOpenFile;
 			TCHAR			szPath[_MAX_PATH + 1];
 			int				size = _countof(szPath) - 1;
 			_tcsncpy( szPath, m_szCommand, size);
 			szPath[size] = _T('\0');
-			/* ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“ƒ_ƒCƒAƒƒO‚Ì‰Šú‰» */
+			/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸåŒ– */
 			cDlgOpenFile.Create(
 				m_hInstance,
 				GetHwnd(),
@@ -273,8 +273,8 @@ BOOL CDlgExec::OnBnClicked( int wID )
 		}
 		return TRUE;
 
-	case IDOK:			/* ‰ºŒŸõ */
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	case IDOK:			/* ä¸‹æ¤œç´¢ */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		GetData();
 		CloseDialog( 1 );
 		return TRUE;

--- a/sakura_core/dlg/CDlgExec.h
+++ b/sakura_core/dlg/CDlgExec.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ŠO•”ƒRƒ}ƒ“ƒhÀsƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
 */
@@ -18,7 +18,7 @@
 #define _CDLGEXEC_H_
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 class CDlgExec : public CDialog
 {
@@ -30,11 +30,11 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, LPARAM );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
-	TCHAR	m_szCommand[1024 + 1];	/* ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“ */
-	SFilePath	m_szCurDir;	/* ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ */
-	bool	m_bEditable;			/* •ÒWƒEƒBƒ“ƒhƒE‚Ö‚Ì“ü—Í‰Â”\ */	// 2009.02.21 ryoji
+	TCHAR	m_szCommand[1024 + 1];	/* ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³ */
+	SFilePath	m_szCurDir;	/* ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª */
+	bool	m_bEditable;			/* ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸ã®å…¥åŠ›å¯èƒ½ */	// 2009.02.21 ryoji
 
 
 protected:
@@ -43,9 +43,9 @@ protected:
 	SComboBoxItemDeleter m_comboDelCur;
 	CRecentCurDir m_cRecentCur;
 
-	/* ƒI[ƒo[ƒ‰ƒCƒh? */
-	int GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-	void SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+	/* ã‚ªãƒ¼ãƒãƒ¼ãƒ©ã‚¤ãƒ‰? */
+	int GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+	void SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );
 	BOOL OnBnClicked( int );
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief —š—ğ‚ÌŠÇ—ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief å±¥æ­´ã®ç®¡ç†ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
 	@date 2003.4.8
@@ -47,24 +47,24 @@
 #include "sakura.hh"
 
 const DWORD p_helpids[] = {
-	IDC_TAB_FAVORITE,				HIDC_TAB_FAVORITE,				//ƒ^ƒu
-	IDC_LIST_FAVORITE_FILE,			HIDC_LIST_FAVORITE_FILE,		//ƒtƒ@ƒCƒ‹
-	IDC_LIST_FAVORITE_FOLDER,		HIDC_LIST_FAVORITE_FOLDER,		//ƒtƒHƒ‹ƒ_
-	IDC_LIST_FAVORITE_EXCEPTMRU,	HIDC_LIST_FAVORITE_EXCEPTMRU,	//MRUœŠO
-	IDC_LIST_FAVORITE_SEARCH,		HIDC_LIST_FAVORITE_SEARCH,		//ŒŸõ
-	IDC_LIST_FAVORITE_REPLACE,		HIDC_LIST_FAVORITE_REPLACE,		//’uŠ·
-	IDC_LIST_FAVORITE_GREP_FILE,	HIDC_LIST_FAVORITE_GREPFILE,	//GREPƒtƒ@ƒCƒ‹
-	IDC_LIST_FAVORITE_GREP_FOLDER,	HIDC_LIST_FAVORITE_GREPFOLDER,	//GREPƒtƒHƒ‹ƒ_
-	IDC_LIST_FAVORITE_CMD,			HIDC_LIST_FAVORITE_CMD,			//ƒRƒ}ƒ“ƒh
-	IDC_LIST_FAVORITE_CUR_DIR,		HIDC_LIST_FAVORITE_CUR_DIR,		//ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ
+	IDC_TAB_FAVORITE,				HIDC_TAB_FAVORITE,				//ã‚¿ãƒ–
+	IDC_LIST_FAVORITE_FILE,			HIDC_LIST_FAVORITE_FILE,		//ãƒ•ã‚¡ã‚¤ãƒ«
+	IDC_LIST_FAVORITE_FOLDER,		HIDC_LIST_FAVORITE_FOLDER,		//ãƒ•ã‚©ãƒ«ãƒ€
+	IDC_LIST_FAVORITE_EXCEPTMRU,	HIDC_LIST_FAVORITE_EXCEPTMRU,	//MRUé™¤å¤–
+	IDC_LIST_FAVORITE_SEARCH,		HIDC_LIST_FAVORITE_SEARCH,		//æ¤œç´¢
+	IDC_LIST_FAVORITE_REPLACE,		HIDC_LIST_FAVORITE_REPLACE,		//ç½®æ›
+	IDC_LIST_FAVORITE_GREP_FILE,	HIDC_LIST_FAVORITE_GREPFILE,	//GREPãƒ•ã‚¡ã‚¤ãƒ«
+	IDC_LIST_FAVORITE_GREP_FOLDER,	HIDC_LIST_FAVORITE_GREPFOLDER,	//GREPãƒ•ã‚©ãƒ«ãƒ€
+	IDC_LIST_FAVORITE_CMD,			HIDC_LIST_FAVORITE_CMD,			//ã‚³ãƒãƒ³ãƒ‰
+	IDC_LIST_FAVORITE_CUR_DIR,		HIDC_LIST_FAVORITE_CUR_DIR,		//ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª
 //	IDC_STATIC_BUTTONS,				-1,
-	IDC_BUTTON_CLEAR,				HIDC_BUTTON_FAVORITE_CLEAR,		//‚·‚×‚Ä	// 2006.10.10 ryoji
-	IDC_BUTTON_DELETE_NOFAVORATE,   HIDC_BUTTON_FAVORITE_DELETE_NOFAVORATE,  //‚¨‹C‚É“ü‚èˆÈŠO
-	IDC_BUTTON_DELETE_NOTFOUND,		HIDC_BUTTON_FAVORITE_DELETE_NOTFOUND		,  //‘¶İ‚µ‚È‚¢€–Ú
-	IDC_BUTTON_DELETE_SELECTED,     HIDC_BUTTON_FAVORITE_DELETE_SELECTED,    //‘I‘ğ€–Ú
-	IDC_BUTTON_ADD_FAVORITE,        HIDC_BUTTON_ADD_FAVORITE,		// ’Ç‰Á
-	IDOK,							HIDC_FAVORITE_IDOK,				//•Â‚¶‚é
-	IDC_BUTTON_HELP,				HIDC_BUTTON_FAVORITE_HELP,		//ƒwƒ‹ƒv
+	IDC_BUTTON_CLEAR,				HIDC_BUTTON_FAVORITE_CLEAR,		//ã™ã¹ã¦	// 2006.10.10 ryoji
+	IDC_BUTTON_DELETE_NOFAVORATE,   HIDC_BUTTON_FAVORITE_DELETE_NOFAVORATE,  //ãŠæ°—ã«å…¥ã‚Šä»¥å¤–
+	IDC_BUTTON_DELETE_NOTFOUND,		HIDC_BUTTON_FAVORITE_DELETE_NOTFOUND		,  //å­˜åœ¨ã—ãªã„é …ç›®
+	IDC_BUTTON_DELETE_SELECTED,     HIDC_BUTTON_FAVORITE_DELETE_SELECTED,    //é¸æŠé …ç›®
+	IDC_BUTTON_ADD_FAVORITE,        HIDC_BUTTON_ADD_FAVORITE,		// è¿½åŠ 
+	IDOK,							HIDC_FAVORITE_IDOK,				//é–‰ã˜ã‚‹
+	IDC_BUTTON_HELP,				HIDC_BUTTON_FAVORITE_HELP,		//ãƒ˜ãƒ«ãƒ—
 //	IDC_STATIC_FAVORITE_MSG,		-1,
 	0, 0
 };
@@ -82,7 +82,7 @@ static const SAnchorList anchorList[] = {
 	{IDC_STATIC_FAVORITE_MSG, 		ANCHOR_BOTTOM},
 };
 
-//SDK‚É‚µ‚©’è‹`‚³‚ê‚Ä‚¢‚È‚¢B
+//SDKã«ã—ã‹å®šç¾©ã•ã‚Œã¦ã„ãªã„ã€‚
 #ifndef	ListView_SetCheckState
 //#if (_WIN32_IE >= 0x0300)
 #define ListView_SetCheckState(hwndLV, i, fCheck) \
@@ -103,11 +103,11 @@ struct CompareListViewLParam
 };
 
 /*
-	CRecent‚ÌŠeÀ‘•ƒNƒ‰ƒX‚Í DLLSHAREDATA ‚Ö’¼ÚƒAƒNƒZƒX‚µ‚Ä‚¢‚éB
-	—š—ğ‚Í‚Ù‚©‚ÌƒEƒBƒ“ƒhƒE‚ª‘‚«Š·‚¦‚é‰Â”\«‚ª‚ ‚é‚½‚ßA
-	ƒ_ƒCƒAƒƒO‚ªƒAƒNƒeƒBƒu‚É‚È‚Á‚½Û‚É•ÏX‚ğŠm”F‚µÄæ“¾‚·‚é‚æ‚¤‚É‚È‚Á‚Ä‚¢‚éB
-	•ÒW’†‚Í•ÏX‚ğŠm”F‚µ‚Ä‚¢‚È‚¢‚Ì‚ÅA— ‚ÅDLLSHAREDATA‚ğ•ÏX‚³‚ê‚é‚ÆListView‚Æ
-	DLLSHAREDATA‚ªˆê’v‚µ‚È‚¢‰Â”\«‚à‚ ‚éB
+	CRecentã®å„å®Ÿè£…ã‚¯ãƒ©ã‚¹ã¯ DLLSHAREDATA ã¸ç›´æ¥ã‚¢ã‚¯ã‚»ã‚¹ã—ã¦ã„ã‚‹ã€‚
+	å±¥æ­´ã¯ã»ã‹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒæ›¸ãæ›ãˆã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹ãŸã‚ã€
+	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãŒã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ãªã£ãŸéš›ã«å¤‰æ›´ã‚’ç¢ºèªã—å†å–å¾—ã™ã‚‹ã‚ˆã†ã«ãªã£ã¦ã„ã‚‹ã€‚
+	ç·¨é›†ä¸­ã¯å¤‰æ›´ã‚’ç¢ºèªã—ã¦ã„ãªã„ã®ã§ã€è£ã§DLLSHAREDATAã‚’å¤‰æ›´ã•ã‚Œã‚‹ã¨ListViewã¨
+	DLLSHAREDATAãŒä¸€è‡´ã—ãªã„å¯èƒ½æ€§ã‚‚ã‚ã‚‹ã€‚
 */
 
 
@@ -119,7 +119,7 @@ CDlgFavorite::CDlgFavorite()
 	m_nCurrentTab = 0;
 	_tcscpy( m_szMsg, _T("") );
 
-	/* ƒTƒCƒY•ÏX‚ÉˆÊ’u‚ğ§Œä‚·‚éƒRƒ“ƒgƒ[ƒ‹” */
+	/* ã‚µã‚¤ã‚ºå¤‰æ›´æ™‚ã«ä½ç½®ã‚’åˆ¶å¾¡ã™ã‚‹ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«æ•° */
 	assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	{
@@ -233,7 +233,7 @@ CDlgFavorite::CDlgFavorite()
 		m_aFavoriteInfo[i].m_bEditable  = false;
 		m_aFavoriteInfo[i].m_bAddExcept = false;
 
-		/* ‚±‚êˆÈã‘‚â‚·‚Æ‚«‚Íƒe[ƒuƒ‹ƒTƒCƒY‚à‘‚«Š·‚¦‚Ä‚Ë */
+		/* ã“ã‚Œä»¥ä¸Šå¢—ã‚„ã™ã¨ãã¯ãƒ†ãƒ¼ãƒ–ãƒ«ã‚µã‚¤ã‚ºã‚‚æ›¸ãæ›ãˆã¦ã­ */
 		assert( i < _countof(m_aFavoriteInfo) );
 	}
 	for( i = 0; i < FAVORITE_INFO_MAX; i++ ){
@@ -253,7 +253,7 @@ CDlgFavorite::~CDlgFavorite()
 	}
 }
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgFavorite::DoModal(
 	HINSTANCE	hInstance,
 	HWND		hwndParent,
@@ -263,7 +263,7 @@ int CDlgFavorite::DoModal(
 	return (int)CDialog::DoModal( hInstance, hwndParent, IDD_FAVORITE, lParam );
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgFavorite::SetData( void )
 {
 	int		nTab;
@@ -280,9 +280,9 @@ void CDlgFavorite::SetData( void )
 	return;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ì1‚Â‚Ìƒ^ƒu‚Ìİ’èEXV
-	@param nIndex       ƒ^ƒu‚ÌIndex
-	@param nLvItemIndex ‘I‘ğE•\¦‚µ‚½‚¢ListView‚ÌIndexB-1‚Å‘I‘ğ‚µ‚È‚¢
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®1ã¤ã®ã‚¿ãƒ–ã®è¨­å®šãƒ»æ›´æ–°
+	@param nIndex       ã‚¿ãƒ–ã®Index
+	@param nLvItemIndex é¸æŠãƒ»è¡¨ç¤ºã—ãŸã„ListViewã®Indexã€‚-1ã§é¸æŠã—ãªã„
 */
 void CDlgFavorite::SetDataOne( int nIndex, int nLvItemIndex )
 {
@@ -292,9 +292,9 @@ void CDlgFavorite::SetDataOne( int nIndex, int nLvItemIndex )
 
 	const CRecent*  pRecent = m_aFavoriteInfo[nIndex].m_pRecent;
 
-	/* ƒŠƒXƒg */
+	/* ãƒªã‚¹ãƒˆ */
 	hwndList = ::GetDlgItem( GetHwnd(), m_aFavoriteInfo[nIndex].m_nId );
-	ListView_DeleteAllItems( hwndList );  /* ƒŠƒXƒg‚ğ‹ó‚É‚·‚é */
+	ListView_DeleteAllItems( hwndList );  /* ãƒªã‚¹ãƒˆã‚’ç©ºã«ã™ã‚‹ */
 
 	const int   nViewCount = pRecent->GetViewCount();
 	const int   nItemCount = pRecent->GetItemCount();
@@ -328,7 +328,7 @@ void CDlgFavorite::SetDataOne( int nIndex, int nLvItemIndex )
 	}
 
 	if( -1 != m_aListViewInfo[nIndex].nSortColumn ){
-		//ƒ\[ƒg‚ğˆÛ
+		//ã‚½ãƒ¼ãƒˆã‚’ç¶­æŒ
 		ListViewSort( m_aListViewInfo[nIndex], pRecent, m_aListViewInfo[nIndex].nSortColumn, false );
 	}
 
@@ -337,7 +337,7 @@ void CDlgFavorite::SetDataOne( int nIndex, int nLvItemIndex )
 		nNewFocus = nLvItemIndex;
 	}
 
-	//ƒAƒCƒeƒ€‚ª‚ ‚Á‚Ä‚Ç‚ê‚à”ñ‘I‘ğ‚È‚çA—v‹‚É‹ß‚¢ƒAƒCƒeƒ€(æ“ª‚©––”ö)‚ğ‘I‘ğ
+	//ã‚¢ã‚¤ãƒ†ãƒ ãŒã‚ã£ã¦ã©ã‚Œã‚‚éé¸æŠãªã‚‰ã€è¦æ±‚ã«è¿‘ã„ã‚¢ã‚¤ãƒ†ãƒ (å…ˆé ­ã‹æœ«å°¾)ã‚’é¸æŠ
 	if( nItemCount > 0 && -1 != nLvItemIndex && nNewFocus == -1 )
 	{
 		nNewFocus = (0 < nLvItemIndex ? nItemCount - 1: 0);
@@ -352,9 +352,9 @@ void CDlgFavorite::SetDataOne( int nIndex, int nLvItemIndex )
 	return;
 }
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚ğæ“¾‚µA‹¤—Lƒf[ƒ^‚Ì‚¨‹C‚É“ü‚è‚ğXV
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾—ã—ã€å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®ãŠæ°—ã«å…¥ã‚Šã‚’æ›´æ–°
 	
-	@retval TRUE ³í(¡‚Ì‚Æ‚±‚ëFALSE‚Í•Ô‚³‚È‚¢)
+	@retval TRUE æ­£å¸¸(ä»Šã®ã¨ã“ã‚FALSEã¯è¿”ã•ãªã„)
 */
 int CDlgFavorite::GetData( void )
 {
@@ -366,7 +366,7 @@ int CDlgFavorite::GetData( void )
 		{
 			GetFavorite( nTab );
 
-			//ƒŠƒXƒg‚ğXV‚·‚éB
+			//ãƒªã‚¹ãƒˆã‚’æ›´æ–°ã™ã‚‹ã€‚
 			CRecent* pRecent = m_aFavoriteInfo[nTab].m_pRecent;
 			pRecent->UpdateView();
 		}
@@ -409,7 +409,7 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		m_nHeight = rcDialog.bottom - rcDialog.top;
 	}
 
-	//ƒŠƒXƒgƒrƒ…[‚Ì•\¦ˆÊ’u‚ğæ“¾‚·‚éB
+	//ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®è¡¨ç¤ºä½ç½®ã‚’å–å¾—ã™ã‚‹ã€‚
 	m_nCurrentTab = 0;
 	hwndBaseList = ::GetDlgItem( hwndDlg, m_aFavoriteInfo[0].m_nId );
 	{
@@ -418,7 +418,7 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		m_rcListDefault = rc;
 	}
 
-	// ƒEƒBƒ“ƒhƒE‚ÌƒŠƒTƒCƒY
+	// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒªã‚µã‚¤ã‚º
 	SetDialogPosSize();
 
 	hwndTab = ::GetDlgItem( hwndDlg, IDC_TAB_FAVORITE );
@@ -426,22 +426,22 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	GetItemClientRect( m_aFavoriteInfo[0].m_nId, rc );
 
-	// ƒŠƒXƒgƒrƒ…[‚ÌItem/SubItem•‚ğŒvZ
+	// ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®Item/SubItemå¹…ã‚’è¨ˆç®—
 	std::tstring pszFavTest = LS( STR_DLGFAV_FAVORITE );
 	TCHAR* pszFAVORITE_TEXT = const_cast<TCHAR*>(pszFavTest.c_str());
 	const int nListViewWidthClient = rc.right - rc.left
 		 - CTextWidthCalc::WIDTH_MARGIN_SCROLLBER - ::GetSystemMetrics(SM_CXVSCROLL);
-	// ‰Šú’l‚Í]—ˆ•û®‚Ì%w’è
+	// åˆæœŸå€¤ã¯å¾“æ¥æ–¹å¼ã®%æŒ‡å®š
 	int nItemCx = nListViewWidthClient * 16 / 100;
 	int nSubItem1Cx = nListViewWidthClient * 79 / 100;
 	
 	{
-		// “K—p‚³‚ê‚Ä‚¢‚éƒtƒHƒ“ƒg‚©‚çZo
+		// é©ç”¨ã•ã‚Œã¦ã„ã‚‹ãƒ•ã‚©ãƒ³ãƒˆã‹ã‚‰ç®—å‡º
 		CTextWidthCalc calc( hwndBaseList );
 		calc.SetTextWidthIfMax( pszFAVORITE_TEXT, CTextWidthCalc::WIDTH_LV_HEADER );
 		TCHAR szBuf[200];
 		for(int i = 0; i < 40; i++ ){
-			// uM (”ñ•\¦)v“™‚Ì•‚ğ‹‚ß‚é
+			// ã€ŒM (éè¡¨ç¤º)ã€ç­‰ã®å¹…ã‚’æ±‚ã‚ã‚‹
 			FormatFavoriteColumn( szBuf, _countof(szBuf), i, false);
 			calc.SetTextWidthIfMax( szBuf, CTextWidthCalc::WIDTH_LV_ITEM_CHECKBOX );
 		}
@@ -474,13 +474,13 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		col.iSubItem = 1;
 		ListView_InsertColumn( hwndList, 1, &col );
 
-		/* s‘I‘ğ */
+		/* è¡Œé¸æŠ */
 		lngStyle = ListView_GetExtendedListViewStyle( hwndList );
 		lngStyle |= LVS_EX_FULLROWSELECT;
 		if( m_aFavoriteInfo[nTab].m_bHaveFavorite ) lngStyle |= LVS_EX_CHECKBOXES;
 		ListView_SetExtendedListViewStyle( hwndList, lngStyle );
 
-		/* ƒ^ƒu€–Ú’Ç‰Á */
+		/* ã‚¿ãƒ–é …ç›®è¿½åŠ  */
 		tcitem.mask = TCIF_TEXT;
 		tcitem.pszText = const_cast<TCHAR*>(m_aFavoriteInfo[nTab].m_pszCaption);
 		TabCtrl_InsertItem( hwndTab, nTab, &tcitem );
@@ -499,31 +499,31 @@ BOOL CDlgFavorite::OnBnClicked( int wID )
 	switch( wID )
 	{
 	case IDC_BUTTON_HELP:
-		/* ƒwƒ‹ƒv */
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID( F_FAVORITE ) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ãƒ˜ãƒ«ãƒ— */
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID( F_FAVORITE ) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 
 	case IDOK:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		::EndDialog( GetHwnd(), (BOOL)GetData() );
 		return TRUE;
 
 	case IDCANCEL:
-		// 2010.03.20 ƒLƒƒƒ“ƒZƒ‹‚ğ”p~BOK‚Æ“¯‚¶‚É‚·‚éB
-		// [X]ƒ{ƒ^ƒ“‚ğ‰Ÿ‚·‚Æ’Ê‰ß‚·‚é
+		// 2010.03.20 ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã‚’å»ƒæ­¢ã€‚OKã¨åŒã˜ã«ã™ã‚‹ã€‚
+		// [X]ãƒœã‚¿ãƒ³ã‚’æŠ¼ã™ã¨é€šéã™ã‚‹
 		::EndDialog( GetHwnd(), (BOOL)GetData() );
 		return TRUE;
 
-	// 2010.03.20 Moca u‚¨‹C‚É“ü‚èˆÈŠO‚©‚·‚×‚Äíœv‘I‘ğƒƒbƒZ[ƒWƒ{ƒbƒNƒX‚ğ”p~‚µ
-	//     ‚»‚ê‚¼‚ê‚Ìƒ{ƒ^ƒ“‚É•ÏX
-	//‚·‚×‚Äíœ
+	// 2010.03.20 Moca ã€ŒãŠæ°—ã«å…¥ã‚Šä»¥å¤–ã‹ã™ã¹ã¦å‰Šé™¤ã€é¸æŠãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã‚’å»ƒæ­¢ã—
+	//     ãã‚Œãã‚Œã®ãƒœã‚¿ãƒ³ã«å¤‰æ›´
+	//ã™ã¹ã¦å‰Šé™¤
 	case IDC_BUTTON_CLEAR:
 		{
 			::DlgItem_SetText( GetHwnd(), IDC_STATIC_FAVORITE_MSG, _T("") );
 			CRecent	*pRecent = m_aFavoriteInfo[m_nCurrentTab].m_pRecent;
 			if( pRecent ){
 				const int nRet = ConfirmMessage( GetHwnd(), 
-					LS( STR_DLGFAV_CONF_DEL_FAV ),	// "Å‹ßg‚Á‚½%ts‚Ì—š—ğ‚ğíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H\n"
+					LS( STR_DLGFAV_CONF_DEL_FAV ),	// "æœ€è¿‘ä½¿ã£ãŸ%tsã®å±¥æ­´ã‚’å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ\n"
 					m_aFavoriteInfo[m_nCurrentTab].m_pszCaption );
 				if( IDYES == nRet ){
 					pRecent->DeleteAllItem();
@@ -533,13 +533,13 @@ BOOL CDlgFavorite::OnBnClicked( int wID )
 			}
 		}
 		return TRUE;
-	//‚¨‹C‚É“ü‚èˆÈŠOíœ
+	//ãŠæ°—ã«å…¥ã‚Šä»¥å¤–å‰Šé™¤
 	case IDC_BUTTON_DELETE_NOFAVORATE:
 		{
 			::DlgItem_SetText( GetHwnd(), IDC_STATIC_FAVORITE_MSG, _T("") );
 			if( m_aFavoriteInfo[m_nCurrentTab].m_bHaveFavorite ){
 				int const nRet = ConfirmMessage( GetHwnd(), 
-					LS( STR_DLGFAV_CONF_DEL_NOTFAV ),	// "Å‹ßg‚Á‚½%ts‚Ì—š—ğ‚Ì‚¨‹C‚É“ü‚èˆÈŠO‚ğíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H"
+					LS( STR_DLGFAV_CONF_DEL_NOTFAV ),	// "æœ€è¿‘ä½¿ã£ãŸ%tsã®å±¥æ­´ã®ãŠæ°—ã«å…¥ã‚Šä»¥å¤–ã‚’å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
 					m_aFavoriteInfo[m_nCurrentTab].m_pszCaption );
 				CRecent * const pRecent = m_aFavoriteInfo[m_nCurrentTab].m_pRecent;
 				if( IDYES == nRet && pRecent ){
@@ -552,19 +552,19 @@ BOOL CDlgFavorite::OnBnClicked( int wID )
 			}
 		}
 		return TRUE;
-	// ‘¶İ‚µ‚È‚¢€–Ú ‚ğíœ
+	// å­˜åœ¨ã—ãªã„é …ç›® ã‚’å‰Šé™¤
 	case IDC_BUTTON_DELETE_NOTFOUND:
 		{
 			::DlgItem_SetText( GetHwnd(), IDC_STATIC_FAVORITE_MSG, _T("") );
 			if( m_aFavoriteInfo[m_nCurrentTab].m_bFilePath ){
 				const int nRet = ConfirmMessage( GetHwnd(), 
-					LS( STR_DLGFAV_CONF_DEL_PATH ),	// "Å‹ßg‚Á‚½%ts‚Ì‘¶İ‚µ‚È‚¢ƒpƒX‚ğíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H"
+					LS( STR_DLGFAV_CONF_DEL_PATH ),	// "æœ€è¿‘ä½¿ã£ãŸ%tsã®å­˜åœ¨ã—ãªã„ãƒ‘ã‚¹ã‚’å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
 					m_aFavoriteInfo[m_nCurrentTab].m_pszCaption );
 				CRecent * const pRecent = m_aFavoriteInfo[m_nCurrentTab].m_pRecent;
 				if( IDYES == nRet && pRecent ){
 					GetFavorite( m_nCurrentTab );
 
-					// ‘¶İ‚µ‚È‚¢ƒpƒX‚Ìíœ
+					// å­˜åœ¨ã—ãªã„ãƒ‘ã‚¹ã®å‰Šé™¤
 					for( int i = pRecent->GetItemCount() - 1; i >= 0; i-- ){
 						size_t nLen = auto_strlen(pRecent->GetItemText(i));
 						std::vector<TCHAR> vecPath(nLen + 2);
@@ -582,7 +582,7 @@ BOOL CDlgFavorite::OnBnClicked( int wID )
 			}
 		}
 		return TRUE;
-	//‘I‘ğ€–Ú‚Ìíœ
+	//é¸æŠé …ç›®ã®å‰Šé™¤
 	case IDC_BUTTON_DELETE_SELECTED:
 		{
 			DeleteSelected();
@@ -595,7 +595,7 @@ BOOL CDlgFavorite::OnBnClicked( int wID )
 		return TRUE;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
@@ -635,7 +635,7 @@ BOOL CDlgFavorite::OnNotify( WPARAM wParam, LPARAM lParam )
 				}
 				return TRUE;
 
-			// ListViewƒwƒbƒ_ƒNƒŠƒbƒN:ƒ\[ƒg‚·‚é
+			// ListViewãƒ˜ãƒƒãƒ€ã‚¯ãƒªãƒƒã‚¯:ã‚½ãƒ¼ãƒˆã™ã‚‹
 			case LVN_COLUMNCLICK:
 				ListViewSort(
 					m_aListViewInfo[m_nCurrentTab],
@@ -643,7 +643,7 @@ BOOL CDlgFavorite::OnNotify( WPARAM wParam, LPARAM lParam )
 					pnlv->iSubItem, true );
 				return TRUE;
 			
-			// ListView‚ÅDeleteƒL[‚ª‰Ÿ‚³‚ê‚½:íœ
+			// ListViewã§Deleteã‚­ãƒ¼ãŒæŠ¼ã•ã‚ŒãŸ:å‰Šé™¤
 			case LVN_KEYDOWN:
 				switch( ((NMLVKEYDOWN*)lParam)->wVKey )
 				{
@@ -685,7 +685,7 @@ BOOL CDlgFavorite::OnNotify( WPARAM wParam, LPARAM lParam )
 		}
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnNotify( wParam, lParam );
 }
 
@@ -696,11 +696,11 @@ void CDlgFavorite::TabSelectChange(bool bSetFocus)
 	int nIndex = TabCtrl_GetCurSel( hwndTab );
 	if( -1 != nIndex )
 	{
-		//V‚µ‚­•\¦‚·‚éB
+		//æ–°ã—ãè¡¨ç¤ºã™ã‚‹ã€‚
 		HWND hwndList = GetItemHwnd( m_aFavoriteInfo[nIndex].m_nId );
 		::ShowWindow( hwndList, SW_SHOW );
 
-		//Œ»İ•\¦’†‚ÌƒŠƒXƒg‚ğ‰B‚·B
+		//ç¾åœ¨è¡¨ç¤ºä¸­ã®ãƒªã‚¹ãƒˆã‚’éš ã™ã€‚
 		HWND hwndList2 = GetItemHwnd( m_aFavoriteInfo[m_nCurrentTab].m_nId );
 		::ShowWindow( hwndList2, SW_HIDE );
 
@@ -732,7 +732,7 @@ BOOL CDlgFavorite::OnActivate( WPARAM wParam, LPARAM lParam )
 		break;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnActivate( wParam, lParam );
 }
 
@@ -742,7 +742,7 @@ LPVOID CDlgFavorite::GetHelpIdTable( void )
 }
 
 /*
-	ƒŠƒXƒg‚ğXV‚·‚éB
+	ãƒªã‚¹ãƒˆã‚’æ›´æ–°ã™ã‚‹ã€‚
 */
 bool CDlgFavorite::RefreshList( void )
 {
@@ -754,7 +754,7 @@ bool CDlgFavorite::RefreshList( void )
 	_tcscpy( msg, _T("") );
 	_tcscpy( m_szMsg, _T("") );
 
-	//‘SƒŠƒXƒg‚ÌŒ»İ‘I‘ğ’†‚ÌƒAƒCƒeƒ€‚ğæ“¾‚·‚éB
+	//å…¨ãƒªã‚¹ãƒˆã®ç¾åœ¨é¸æŠä¸­ã®ã‚¢ã‚¤ãƒ†ãƒ ã‚’å–å¾—ã™ã‚‹ã€‚
 	for( nTab = 0; NULL != m_aFavoriteInfo[nTab].m_pRecent; nTab++ )
 	{
 		bret = RefreshListOne( nTab );
@@ -770,7 +770,7 @@ bool CDlgFavorite::RefreshList( void )
 	if( ret_val )
 	{
 		auto_snprintf_s( m_szMsg, _countof(m_szMsg),
-			LS( STR_DLGFAV_FAV_REFRESH ),	// "—š—ğ(%ts)‚ªXV‚³‚ê‚½‚½‚ß•ÒW’†î•ñ‚ğ”jŠü‚µÄ•\¦‚µ‚Ü‚µ‚½B"
+			LS( STR_DLGFAV_FAV_REFRESH ),	// "å±¥æ­´(%ts)ãŒæ›´æ–°ã•ã‚ŒãŸãŸã‚ç·¨é›†ä¸­æƒ…å ±ã‚’ç ´æ£„ã—å†è¡¨ç¤ºã—ã¾ã—ãŸã€‚"
 			msg );
 	}
 
@@ -778,7 +778,7 @@ bool CDlgFavorite::RefreshList( void )
 }
 
 /*
-	—š—ğí•ÊƒŠƒXƒg‚Ì‚¤‚¿1ŒÂ‚ÌƒŠƒXƒgƒrƒ…[‚ğXV‚·‚éB
+	å±¥æ­´ç¨®åˆ¥ãƒªã‚¹ãƒˆã®ã†ã¡1å€‹ã®ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã‚’æ›´æ–°ã™ã‚‹ã€‚
 */
 bool CDlgFavorite::RefreshListOne( int nIndex )
 {
@@ -797,9 +797,9 @@ bool CDlgFavorite::RefreshListOne( int nIndex )
 	nCurrentIndex = ListView_GetNextItem( hwndList, -1, LVNI_SELECTED );
 	if( -1 == nCurrentIndex ) nCurrentIndex = ListView_GetNextItem( hwndList, -1, LVNI_FOCUSED );
 
-	if( nItemCount != nCount ) goto changed;	//ŒÂ”‚ª•Ï‚í‚Á‚½‚Ì‚ÅÄ\’z
+	if( nItemCount != nCount ) goto changed;	//å€‹æ•°ãŒå¤‰ã‚ã£ãŸã®ã§å†æ§‹ç¯‰
 
-	//‚¨‹C‚É“ü‚è”‚ª•Ï‚í‚Á‚½‚Ì‚ÅÄ\’z
+	//ãŠæ°—ã«å…¥ã‚Šæ•°ãŒå¤‰ã‚ã£ãŸã®ã§å†æ§‹ç¯‰
 	if( m_aFavoriteInfo[nIndex].m_nViewCount != pRecent->GetViewCount() ) goto changed;
 
 	for( i = 0; i < nCount; i++ )
@@ -813,9 +813,9 @@ bool CDlgFavorite::RefreshListOne( int nIndex )
 		lvitem.iItem      = i;
 		lvitem.iSubItem   = 1;
 		bret = ListView_GetItem( hwndList, &lvitem );
-		if( !bret ) goto changed;	//ƒGƒ‰[‚È‚Ì‚ÅÄ\’z
+		if( !bret ) goto changed;	//ã‚¨ãƒ©ãƒ¼ãªã®ã§å†æ§‹ç¯‰
 
-		//ƒAƒCƒeƒ€“à—e‚ª•Ï‚í‚Á‚½‚Ì‚ÅÄ\’z
+		//ã‚¢ã‚¤ãƒ†ãƒ å†…å®¹ãŒå¤‰ã‚ã£ãŸã®ã§å†æ§‹ç¯‰
 		if( lvitem.lParam != pRecent->FindItemByText( szText ) ) goto changed;
 	}
 
@@ -828,7 +828,7 @@ changed:
 	return true;
 }
 
-// ‚¨‹C‚É“ü‚è‚Ìƒtƒ‰ƒO‚¾‚¯“K—p
+// ãŠæ°—ã«å…¥ã‚Šã®ãƒ•ãƒ©ã‚°ã ã‘é©ç”¨
 void CDlgFavorite::GetFavorite( int nIndex )
 {
 	CRecent * const pRecent  = m_aFavoriteInfo[nIndex].m_pRecent;
@@ -845,8 +845,8 @@ void CDlgFavorite::GetFavorite( int nIndex )
 
 
 /*
-	‘I‘ğ’†‚Ì€–Ú‚ğíœ
-	ƒŠƒXƒg‚ÌXV‚à‚·‚é
+	é¸æŠä¸­ã®é …ç›®ã‚’å‰Šé™¤
+	ãƒªã‚¹ãƒˆã®æ›´æ–°ã‚‚ã™ã‚‹
 */
 int CDlgFavorite::DeleteSelected()
 {
@@ -873,7 +873,7 @@ int CDlgFavorite::DeleteSelected()
 				}
 			}
 			std::sort(selRecIndexs.rbegin(),selRecIndexs.rend());
-			// ‘å‚«‚¢‚Ù‚¤‚©‚çíœ‚µ‚È‚¢‚ÆACRecent‘¤‚Ìindex‚ª‚¸‚ê‚é
+			// å¤§ãã„ã»ã†ã‹ã‚‰å‰Šé™¤ã—ãªã„ã¨ã€CRecentå´ã®indexãŒãšã‚Œã‚‹
 			size_t nSize = selRecIndexs.size();
 			for( size_t n = 0; n < nSize; n++ )
 			{
@@ -884,25 +884,25 @@ int CDlgFavorite::DeleteSelected()
 			if( 0 < nDelItemCount ){
 				int nItem = nLastSelectedItem;
 				if( -1 != nItem ){
-					nItem += 1; // íœ‚µ‚½ƒAƒCƒeƒ€‚ÌŸ‚ÌƒAƒCƒeƒ€
-					nItem -= nDelItemCount; // V‚µ‚¢ˆÊ’u‚ÍAíœ‚µ‚½•ª‚¾‚¯‚¸‚ê‚é
+					nItem += 1; // å‰Šé™¤ã—ãŸã‚¢ã‚¤ãƒ†ãƒ ã®æ¬¡ã®ã‚¢ã‚¤ãƒ†ãƒ 
+					nItem -= nDelItemCount; // æ–°ã—ã„ä½ç½®ã¯ã€å‰Šé™¤ã—ãŸåˆ†ã ã‘ãšã‚Œã‚‹
 					if( pRecent->GetItemCount() <= nItem ){
-						// ‹Œƒf[ƒ^‚ÌÅŒã‚Ì—v‘f‚ªíœ‚³‚ê‚Ä‚¢‚é‚Æ‚«‚ÍA
-						// Vƒf[ƒ^‚ÌÅŒã‚ğ‘I‘ğ
+						// æ—§ãƒ‡ãƒ¼ã‚¿ã®æœ€å¾Œã®è¦ç´ ãŒå‰Šé™¤ã•ã‚Œã¦ã„ã‚‹ã¨ãã¯ã€
+						// æ–°ãƒ‡ãƒ¼ã‚¿ã®æœ€å¾Œã‚’é¸æŠ
 						nItem = pRecent->GetItemCount() -1;
 					}
 				}
 				int nLvTopIndex = ListView_GetTopIndex(hwndList);
 				SetDataOne(m_nCurrentTab, nItem);
 				if( 1 == nDelItemCount ){
-					// 1‚Âíœ‚Ì‚Æ‚«‚ÍAYƒXƒNƒ[ƒ‹ˆÊ’u‚ğ•Û
-					// 2‚ÂˆÈã‚Í•¡G‚È‚Ì‚ÅSetDataOne‚É‚¨‚Ü‚©‚¹‚·‚é
+					// 1ã¤å‰Šé™¤ã®ã¨ãã¯ã€Yã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ä½ç½®ã‚’ä¿æŒ
+					// 2ã¤ä»¥ä¸Šã¯è¤‡é›‘ãªã®ã§SetDataOneã«ãŠã¾ã‹ã›ã™ã‚‹
 					nLvTopIndex = t_max(0, t_min(pRecent->GetItemCount() - 1, nLvTopIndex));
 					int nNowLvTopIndex = ListView_GetTopIndex(hwndList);
 					if( nNowLvTopIndex != nLvTopIndex ){
 						CMyRect rect;
 						if( ListView_GetItemRect(hwndList, nNowLvTopIndex, &rect, LVIR_BOUNDS) ){
-							// ListView_Scroll‚ÌYÀ•W‚Ípixel’PˆÊ‚ÅƒXƒNƒ[ƒ‹•Ï‰»•ª‚ğw’è
+							// ListView_Scrollã®Yåº§æ¨™ã¯pixelå˜ä½ã§ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å¤‰åŒ–åˆ†ã‚’æŒ‡å®š
 							ListView_Scroll(hwndList, 0,
 								(nLvTopIndex - nNowLvTopIndex) * (rect.bottom - rect.top) );
 						}
@@ -922,7 +922,7 @@ void CDlgFavorite::UpdateUIState()
 	DlgItem_Enable( GetHwnd(), IDC_BUTTON_ADD_FAVORITE,
 		m_aFavoriteInfo[m_nCurrentTab].m_bEditable && recent.GetItemCount() <= recent.GetArrayCount() );
 
-	// íœ‚Ì—LŒøE–³Œø‰»
+	// å‰Šé™¤ã®æœ‰åŠ¹ãƒ»ç„¡åŠ¹åŒ–
 	DlgItem_Enable( GetHwnd(), IDC_BUTTON_CLEAR,
 		0 < recent.GetItemCount() );
 
@@ -1027,15 +1027,15 @@ void CDlgFavorite::RightMenu(POINT &menuPos)
 	nEnable = (0 < recent.GetItemCount() ? 0 : MF_GRAYED);
 	::InsertMenu( hMenu, iPos++, MF_BYPOSITION | MF_STRING | nEnable, MENU_DELETE_SELECTED, LS( STR_DLGFAV_MENU_DEL_SEL ) );
 
-	// ƒƒjƒ…[‚ğ•\¦‚·‚é
+	// ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹
 	POINT pt = menuPos;
 	RECT rcWork;
-	GetMonitorWorkRect( pt, &rcWork );	// ƒ‚ƒjƒ^‚Ìƒ[ƒNƒGƒŠƒA
+	GetMonitorWorkRect( pt, &rcWork );	// ãƒ¢ãƒ‹ã‚¿ã®ãƒ¯ãƒ¼ã‚¯ã‚¨ãƒªã‚¢
 	int nId = ::TrackPopupMenu( hMenu, TPM_LEFTALIGN | TPM_TOPALIGN | TPM_LEFTBUTTON | TPM_RETURNCMD,
 								( pt.x > rcWork.left )? pt.x: rcWork.left,
 								( pt.y < rcWork.bottom )? pt.y: rcWork.bottom,
 								0, GetHwnd(), NULL);
-	::DestroyMenu( hMenu );	// ƒTƒuƒƒjƒ…[‚ÍÄ‹A“I‚É”jŠü‚³‚ê‚é
+	::DestroyMenu( hMenu );	// ã‚µãƒ–ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã¯å†å¸°çš„ã«ç ´æ£„ã•ã‚Œã‚‹
 
 	switch( nId ){
 	case MENU_EDIT:
@@ -1061,7 +1061,7 @@ void CDlgFavorite::RightMenu(POINT &menuPos)
 						}
 					}
 					if( bAddFalse ){
-						WarningMessage(GetHwnd(), LS( STR_DLGFAV_LIST_LIMIT_OVER ) );	// "œŠOƒŠƒXƒg‚ª‚¢‚Á‚Ï‚¢‚Å’Ç‰Á‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½B"
+						WarningMessage(GetHwnd(), LS( STR_DLGFAV_LIST_LIMIT_OVER ) );	// "é™¤å¤–ãƒªã‚¹ãƒˆãŒã„ã£ã±ã„ã§è¿½åŠ ã§ãã¾ã›ã‚“ã§ã—ãŸã€‚"
 					}
 					SetDataOne(m_nExceptTab, -1);
 					UpdateUIState();
@@ -1089,7 +1089,7 @@ void CDlgFavorite::RightMenu(POINT &menuPos)
 
 int FormatFavoriteColumn(TCHAR* buf, int size, int index, bool view)
 {
-	// 2010.03.21 Moca Text‚É˜A”Ô‚ğİ’è‚·‚é‚±‚Æ‚É‚æ‚Á‚ÄƒAƒNƒZƒXƒL[‚É‚·‚é
+	// 2010.03.21 Moca Textã«é€£ç•ªã‚’è¨­å®šã™ã‚‹ã“ã¨ã«ã‚ˆã£ã¦ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã«ã™ã‚‹
 	// 0 - 9 A - Z
 	const int mod = index % 36;
 	const TCHAR c = (TCHAR)(((mod) <= 9)?(_T('0') + mod):(_T('A') + mod - 10));
@@ -1098,7 +1098,7 @@ int FormatFavoriteColumn(TCHAR* buf, int size, int index, bool view)
 
 
 /*!
-	ListView‚ÌItem(index)‚©‚çLParam‚ğintŒ^‚Æ‚µ‚Äæ“¾
+	ListViewã®Item(index)ã‹ã‚‰LParamã‚’intå‹ã¨ã—ã¦å–å¾—
 */
 static int ListView_GetLParamInt( HWND hwndList, int lvIndex )
 {
@@ -1115,34 +1115,34 @@ static int ListView_GetLParamInt( HWND hwndList, int lvIndex )
 
 /*!
 	
-	@param info [in,out] ƒŠƒXƒgƒrƒ…[‚Ìƒ\[ƒgó‘Ôî•ñ
-	@param pRecent       ƒ\[ƒgƒAƒCƒeƒ€
-	@param column          ƒ\[ƒg‚µ‚½‚¢—ñ”Ô†
-	@param bReverse      ƒ\[ƒgÏ‚İ‚Ìê‡‚É~‡‚ÉØ‚è‘Ö‚¦‚é
+	@param info [in,out] ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®ã‚½ãƒ¼ãƒˆçŠ¶æ…‹æƒ…å ±
+	@param pRecent       ã‚½ãƒ¼ãƒˆã‚¢ã‚¤ãƒ†ãƒ 
+	@param column          ã‚½ãƒ¼ãƒˆã—ãŸã„åˆ—ç•ªå·
+	@param bReverse      ã‚½ãƒ¼ãƒˆæ¸ˆã¿ã®å ´åˆã«é™é †ã«åˆ‡ã‚Šæ›¿ãˆã‚‹
 */
 // static
 void CDlgFavorite::ListViewSort(ListViewSortInfo& info, const CRecent* pRecent, int column, bool bReverse )
 {
 	CompareListViewLParam lparamInfo;
-	// ƒ\[ƒg‡‚ÌŒˆ’è
+	// ã‚½ãƒ¼ãƒˆé †ã®æ±ºå®š
 	if( info.nSortColumn != column ){
 		info.bSortAscending = true;
 	}else{
-		// ƒ\[ƒg‹t‡(~‡)
+		// ã‚½ãƒ¼ãƒˆé€†é †(é™é †)
 		info.bSortAscending = (bReverse ? (!info.bSortAscending): true);
 	}
 	
-	// ƒwƒbƒ_‘‚«Š·‚¦
+	// ãƒ˜ãƒƒãƒ€æ›¸ãæ›ãˆ
 	TCHAR szHeader[200];
 	LV_COLUMN	col;
 	if( -1 != info.nSortColumn ){
-		// Œ³‚Ìƒ\[ƒg‚Ìu ¥v‚ğæ‚èœ‚­
+		// å…ƒã®ã‚½ãƒ¼ãƒˆã®ã€Œ â–¼ã€ã‚’å–ã‚Šé™¤ã
 		col.mask = LVCF_TEXT;
 		col.pszText = szHeader;
 		col.cchTextMax = _countof(szHeader);
 		col.iSubItem = 0;
 		ListView_GetColumn( info.hListView, info.nSortColumn, &col );
-		int nLen = (int)_tcslen(szHeader) - _tcslen(_T("¥"));
+		int nLen = (int)_tcslen(szHeader) - _tcslen(_T("â–¼"));
 		if( 0 <= nLen ){
 			szHeader[nLen] = _T('\0');
 		}
@@ -1151,13 +1151,13 @@ void CDlgFavorite::ListViewSort(ListViewSortInfo& info, const CRecent* pRecent, 
 		col.iSubItem = 0;
 		ListView_SetColumn( info.hListView, info.nSortColumn, &col );
 	}
-	// u¥v‚ğ•t‰Á
+	// ã€Œâ–¼ã€ã‚’ä»˜åŠ 
 	col.mask = LVCF_TEXT;
 	col.pszText = szHeader;
 	col.cchTextMax = _countof(szHeader) - 4;
 	col.iSubItem = 0;
 	ListView_GetColumn( info.hListView, column, &col );
-	_tcscat(szHeader, info.bSortAscending ? _T("¥") : _T("£"));
+	_tcscat(szHeader, info.bSortAscending ? _T("â–¼") : _T("â–²"));
 	col.mask = LVCF_TEXT;
 	col.pszText = szHeader;
 	col.iSubItem = 0;
@@ -1200,7 +1200,7 @@ INT_PTR CDlgFavorite::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 
 BOOL CDlgFavorite::OnSize( WPARAM wParam, LPARAM lParam )
 {
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	CDialog::OnSize( wParam, lParam );
 
 	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcFavoriteDialog );

--- a/sakura_core/dlg/CDlgFavorite.h
+++ b/sakura_core/dlg/CDlgFavorite.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief —š—ğ‚ÌŠÇ—ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief å±¥æ­´ã®ç®¡ç†ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
 	@date 2003.4.8
@@ -37,8 +37,8 @@
 #include "dlg/CDialog.h"
 #include "recent/CRecent.h"
 
-//!u—š—ğ‚Æ‚¨‹C‚É“ü‚è‚ÌŠÇ—vƒ_ƒCƒAƒƒO
-//ƒAƒNƒZƒX•û–@F[İ’è] - [—š—ğ‚ÌŠÇ—]
+//!ã€Œå±¥æ­´ã¨ãŠæ°—ã«å…¥ã‚Šã®ç®¡ç†ã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
+//ã‚¢ã‚¯ã‚»ã‚¹æ–¹æ³•ï¼š[è¨­å®š] - [å±¥æ­´ã®ç®¡ç†]
 class CDlgFavorite : public CDialog
 {
 public:
@@ -51,28 +51,28 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, LPARAM );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL	OnInitDialog( HWND, WPARAM wParam, LPARAM lParam );
 	BOOL	OnBnClicked( int );
 	BOOL	OnNotify( WPARAM wParam, LPARAM lParam );
 	BOOL	OnActivate( WPARAM wParam, LPARAM lParam );
 	LPVOID	GetHelpIdTable( void );
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// •W€ˆÈŠO‚ÌƒƒbƒZ[ƒW‚ğ•ß‘¨‚·‚é
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// æ¨™æº–ä»¥å¤–ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹
 	BOOL	OnSize( WPARAM wParam, LPARAM lParam );
 	BOOL	OnMove( WPARAM wParam, LPARAM lParam );
 	BOOL	OnMinMaxInfo( LPARAM lParam );
 
-	void	SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int		GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void	SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int		GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 
 	void	TabSelectChange( bool );
 	bool	RefreshList( void );
-	void	SetDataOne( int nIndex, int nLvItemIndex );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+	void	SetDataOne( int nIndex, int nLvItemIndex );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 	bool	RefreshListOne( int nIndex );
 	//void	ChangeSlider( int nIndex );
 	void	UpdateUIState();
@@ -95,21 +95,21 @@ private:
 	CRecentCurDir		m_cRecentCurDir;
 
 	enum {
-		// ! ŠÇ—”
-		FAVORITE_INFO_MAX = 10 // ŠÇ—” +1(”Ô•º)
+		// ! ç®¡ç†æ•°
+		FAVORITE_INFO_MAX = 10 // ç®¡ç†æ•° +1(ç•ªå…µ)
 	};
 
 	struct FavoriteInfo {
-		CRecent*	m_pRecent;			//ƒIƒuƒWƒFƒNƒg‚Ö‚Ìƒ|ƒCƒ“ƒ^
-		std::tstring	m_strCaption;	//ƒLƒƒƒvƒVƒ‡ƒ“
-		const TCHAR*	m_pszCaption;	//ƒLƒƒƒvƒVƒ‡ƒ“
-		int			m_nId;				//ƒRƒ“ƒgƒ[ƒ‹‚ÌID
-		bool		m_bHaveFavorite;	//‚¨‹C‚É“ü‚è‚ğ‚Á‚Ä‚¢‚é‚©H
-		bool		m_bHaveView;		//•\¦”•ÏX‹@”\‚ğ‚à‚Á‚Ä‚¢‚é‚©H
-		bool		m_bFilePath;		//ƒtƒ@ƒCƒ‹/ƒtƒHƒ‹ƒ_‚©H
-		bool		m_bEditable;		//•ÒW‰Â”\
-		bool		m_bAddExcept;		//œŠO‚Ö’Ç‰Á
-		int			m_nViewCount;		//ƒJƒŒƒ“ƒg‚Ì•\¦”
+		CRecent*	m_pRecent;			//ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã¸ã®ãƒã‚¤ãƒ³ã‚¿
+		std::tstring	m_strCaption;	//ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³
+		const TCHAR*	m_pszCaption;	//ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³
+		int			m_nId;				//ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®ID
+		bool		m_bHaveFavorite;	//ãŠæ°—ã«å…¥ã‚Šã‚’æŒã£ã¦ã„ã‚‹ã‹ï¼Ÿ
+		bool		m_bHaveView;		//è¡¨ç¤ºæ•°å¤‰æ›´æ©Ÿèƒ½ã‚’ã‚‚ã£ã¦ã„ã‚‹ã‹ï¼Ÿ
+		bool		m_bFilePath;		//ãƒ•ã‚¡ã‚¤ãƒ«/ãƒ•ã‚©ãƒ«ãƒ€ã‹ï¼Ÿ
+		bool		m_bEditable;		//ç·¨é›†å¯èƒ½
+		bool		m_bAddExcept;		//é™¤å¤–ã¸è¿½åŠ 
+		int			m_nViewCount;		//ã‚«ãƒ¬ãƒ³ãƒˆã®è¡¨ç¤ºæ•°
 		FavoriteInfo():
 			m_pRecent(NULL)
 			,m_pszCaption(NULL)
@@ -123,9 +123,9 @@ private:
 		{};
 	};
 	struct ListViewSortInfo {
-		HWND	hListView; //!< ƒŠƒXƒgƒrƒ…[‚Ì HWND
-		int		nSortColumn; //!< ƒ\[ƒg—ñ -1‚Å–¢w’è
-		bool	bSortAscending; //!< ƒ\[ƒg‚ª¸‡
+		HWND	hListView; //!< ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã® HWND
+		int		nSortColumn; //!< ã‚½ãƒ¼ãƒˆåˆ— -1ã§æœªæŒ‡å®š
+		bool	bSortAscending; //!< ã‚½ãƒ¼ãƒˆãŒæ˜‡é †
 	};
 
 	FavoriteInfo        m_aFavoriteInfo[FAVORITE_INFO_MAX];

--- a/sakura_core/dlg/CDlgFileUpdateQuery.cpp
+++ b/sakura_core/dlg/CDlgFileUpdateQuery.cpp
@@ -1,7 +1,7 @@
-/*! @file
-	@brief �X�V�ʒm�y�ъm�F�_�C�A���O
+﻿/*! @file
+	@brief 更新通知及び確認ダイアログ
 
-	�t�@�C���̍X�V�ʒm�Ɠ���̊m�F���s���_�C�A���O�{�b�N�X
+	ファイルの更新通知と動作の確認を行うダイアログボックス
 
 	@author genta
 	@date 2002.12.04
@@ -44,26 +44,26 @@ BOOL CDlgFileUpdateQuery::OnInitDialog( HWND hWnd, WPARAM wParam, LPARAM lParam 
 }
 
 /*!
-	�{�^���������ꂽ�Ƃ��̓���
+	ボタンが押されたときの動作
 */
 BOOL CDlgFileUpdateQuery::OnBnClicked(int id)
 {
 	EFileUpdateQuery result;
 
 	switch( id ){
-	case IDC_BTN_RELOAD: // �ēǍ�
+	case IDC_BTN_RELOAD: // 再読込
 		result = EFUQ_RELOAD;
 		break;
-	case IDC_BTN_CLOSE: // ����
+	case IDC_BTN_CLOSE: // 閉じる
 		result = EFUQ_CLOSE;
 		break;
-	case IDC_BTN_NOTIFYONLY: // �Ȍ�ʒm���b�Z�[�W�̂�
+	case IDC_BTN_NOTIFYONLY: // 以後通知メッセージのみ
 		result = EFUQ_NOTIFYONLY;
 		break;
-	case IDC_BTN_NOSUPERVISION: // �Ȍ�X�V���Ď����Ȃ�
+	case IDC_BTN_NOSUPERVISION: // 以後更新を監視しない
 		result = EFUQ_NOSUPERVISION;
 		break;
-	case IDC_BTN_AUTOLOAD:		// �Ȍ㖢�ҏW�ōă��[�h
+	case IDC_BTN_AUTOLOAD:		// 以後未編集で再ロード
 		result = EFUQ_AUTOLOAD;
 		break;
 	default:

--- a/sakura_core/dlg/CDlgFileUpdateQuery.h
+++ b/sakura_core/dlg/CDlgFileUpdateQuery.h
@@ -1,7 +1,7 @@
-/*! @file
-	@brief �X�V�ʒm�y�ъm�F�_�C�A���O
+﻿/*! @file
+	@brief 更新通知及び確認ダイアログ
 
-	�t�@�C���̍X�V�ʒm�Ɠ���̊m�F���s���_�C�A���O�{�b�N�X
+	ファイルの更新通知と動作の確認を行うダイアログボックス
 
 	@author genta
 	@date 2002.12.04
@@ -35,11 +35,11 @@
 #include "dlg/CDialog.h"
 
 enum EFileUpdateQuery {
-	EFUQ_CLOSE			= 0,	//!< ����
-	EFUQ_RELOAD			= 1,	//!< �ēǍ�
-	EFUQ_NOTIFYONLY		= 2,	//!< �Ȍ�ʒm���b�Z�[�W�̂�
-	EFUQ_NOSUPERVISION	= 3,	//!< �Ȍ�X�V���Ď����Ȃ�
-	EFUQ_AUTOLOAD		= 4		//!< �Ȍ㖢�ҏW�ōă��[�h
+	EFUQ_CLOSE			= 0,	//!< 閉じる
+	EFUQ_RELOAD			= 1,	//!< 再読込
+	EFUQ_NOTIFYONLY		= 2,	//!< 以後通知メッセージのみ
+	EFUQ_NOSUPERVISION	= 3,	//!< 以後更新を監視しない
+	EFUQ_AUTOLOAD		= 4		//!< 以後未編集で再ロード
 };
 
 class CDlgFileUpdateQuery : public CDialog {

--- a/sakura_core/dlg/CDlgFind.cpp
+++ b/sakura_core/dlg/CDlgFind.cpp
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ŒŸõƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date	1998/12/12 Äì¬
-	@date 2001/06/23 N.Nakatani ’PŒê’PˆÊ‚ÅŒŸõ‚·‚é‹@”\‚ðŽÀ‘•
+	@date	1998/12/12 å†ä½œæˆ
+	@date 2001/06/23 N.Nakatani å˜èªžå˜ä½ã§æ¤œç´¢ã™ã‚‹æ©Ÿèƒ½ã‚’å®Ÿè£…
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -25,21 +25,21 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 
-//ŒŸõ CDlgFind.cpp	//@@@ 2002.01.07 add start MIK
+//æ¤œç´¢ CDlgFind.cpp	//@@@ 2002.01.07 add start MIK
 const DWORD p_helpids[] = {	//11800
-	IDC_BUTTON_SEARCHNEXT,			HIDC_FIND_BUTTON_SEARCHNEXT,		//ŽŸ‚ðŒŸõ
-	IDC_BUTTON_SEARCHPREV,			HIDC_FIND_BUTTON_SEARCHPREV,		//‘O‚ðŒŸõ
-	IDCANCEL,						HIDCANCEL_FIND,						//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_FIND_BUTTON_HELP,				//ƒwƒ‹ƒv
-	IDC_CHK_WORD,					HIDC_FIND_CHK_WORD,					//’PŒê’PˆÊ
-	IDC_CHK_LOHICASE,				HIDC_FIND_CHK_LOHICASE,				//‘å•¶Žš¬•¶Žš
-	IDC_CHK_REGULAREXP,				HIDC_FIND_CHK_REGULAREXP,			//³‹K•\Œ»
-	IDC_CHECK_NOTIFYNOTFOUND,		HIDC_FIND_CHECK_NOTIFYNOTFOUND,		//Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚É’Ê’m
-	IDC_CHECK_bAutoCloseDlgFind,	HIDC_FIND_CHECK_bAutoCloseDlgFind,	//Ž©“®“I‚É•Â‚¶‚é
-	IDC_COMBO_TEXT,					HIDC_FIND_COMBO_TEXT,				//ŒŸõ•¶Žš—ñ
-	IDC_STATIC_JRE32VER,			HIDC_FIND_STATIC_JRE32VER,			//³‹K•\Œ»ƒo[ƒWƒ‡ƒ“
-	IDC_BUTTON_SETMARK,				HIDC_FIND_BUTTON_SETMARK,			//2002.01.16 hor ŒŸõŠY“–s‚ðƒ}[ƒN
-	IDC_CHECK_SEARCHALL,			HIDC_FIND_CHECK_SEARCHALL,			//2002.01.26 hor æ“ªi––”öj‚©‚çÄŒŸõ
+	IDC_BUTTON_SEARCHNEXT,			HIDC_FIND_BUTTON_SEARCHNEXT,		//æ¬¡ã‚’æ¤œç´¢
+	IDC_BUTTON_SEARCHPREV,			HIDC_FIND_BUTTON_SEARCHPREV,		//å‰ã‚’æ¤œç´¢
+	IDCANCEL,						HIDCANCEL_FIND,						//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_FIND_BUTTON_HELP,				//ãƒ˜ãƒ«ãƒ—
+	IDC_CHK_WORD,					HIDC_FIND_CHK_WORD,					//å˜èªžå˜ä½
+	IDC_CHK_LOHICASE,				HIDC_FIND_CHK_LOHICASE,				//å¤§æ–‡å­—å°æ–‡å­—
+	IDC_CHK_REGULAREXP,				HIDC_FIND_CHK_REGULAREXP,			//æ­£è¦è¡¨ç¾
+	IDC_CHECK_NOTIFYNOTFOUND,		HIDC_FIND_CHECK_NOTIFYNOTFOUND,		//è¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã«é€šçŸ¥
+	IDC_CHECK_bAutoCloseDlgFind,	HIDC_FIND_CHECK_bAutoCloseDlgFind,	//è‡ªå‹•çš„ã«é–‰ã˜ã‚‹
+	IDC_COMBO_TEXT,					HIDC_FIND_COMBO_TEXT,				//æ¤œç´¢æ–‡å­—åˆ—
+	IDC_STATIC_JRE32VER,			HIDC_FIND_STATIC_JRE32VER,			//æ­£è¦è¡¨ç¾ãƒãƒ¼ã‚¸ãƒ§ãƒ³
+	IDC_BUTTON_SETMARK,				HIDC_FIND_BUTTON_SETMARK,			//2002.01.16 hor æ¤œç´¢è©²å½“è¡Œã‚’ãƒžãƒ¼ã‚¯
+	IDC_CHECK_SEARCHALL,			HIDC_FIND_CHECK_SEARCHALL,			//2002.01.26 hor å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢
 //	IDC_STATIC,						-1,
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
@@ -52,9 +52,9 @@ CDlgFind::CDlgFind()
 
 
 /*!
-	ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒhƒƒbƒvƒ_ƒEƒ“ƒƒbƒZ[ƒW‚ð•ß‘¨‚·‚é
+	ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ‰ãƒ­ãƒƒãƒ—ãƒ€ã‚¦ãƒ³ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹
 
-	@date 2013.03.24 novice V‹Kì¬
+	@date 2013.03.24 novice æ–°è¦ä½œæˆ
 */
 BOOL CDlgFind::OnCbnDropDown( HWND hwndCtl, int wID )
 {
@@ -71,17 +71,17 @@ BOOL CDlgFind::OnCbnDropDown( HWND hwndCtl, int wID )
 	return CDialog::OnCbnDropDown( hwndCtl, wID );
 }
 
-/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\Ž¦ */
+/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 HWND CDlgFind::DoModeless( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam )
 {
-	m_sSearchOption = m_pShareData->m_Common.m_sSearch.m_sSearchOption;		// ŒŸõƒIƒvƒVƒ‡ƒ“
-	m_bNOTIFYNOTFOUND = m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND;	// ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ð•\Ž¦
-	m_ptEscCaretPos_PHY = ((CEditView*)lParam)->GetCaret().GetCaretLogicPos();	// ŒŸõŠJŽnŽž‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‘Þ”ð
-	((CEditView*)lParam)->m_bSearch = TRUE;							// ŒŸõŠJŽnˆÊ’u‚Ì“o˜^—L–³		02/07/28 ai
+	m_sSearchOption = m_pShareData->m_Common.m_sSearch.m_sSearchOption;		// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	m_bNOTIFYNOTFOUND = m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND;	// æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º
+	m_ptEscCaretPos_PHY = ((CEditView*)lParam)->GetCaret().GetCaretLogicPos();	// æ¤œç´¢é–‹å§‹æ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®é€€é¿
+	((CEditView*)lParam)->m_bSearch = TRUE;							// æ¤œç´¢é–‹å§‹ä½ç½®ã®ç™»éŒ²æœ‰ç„¡		02/07/28 ai
 	return CDialog::DoModeless( hInstance, hwndParent, IDD_FIND, lParam, SW_SHOW );
 }
 
-/* ƒ‚[ƒhƒŒƒXŽžFŒŸõ‘ÎÛ‚Æ‚È‚éƒrƒ…[‚Ì•ÏX */
+/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹æ™‚ï¼šæ¤œç´¢å¯¾è±¡ã¨ãªã‚‹ãƒ“ãƒ¥ãƒ¼ã®å¤‰æ›´ */
 void CDlgFind::ChangeView( LPARAM pcEditView )
 {
 	m_lParam = pcEditView;
@@ -97,7 +97,7 @@ BOOL CDlgFind::OnInitDialog( HWND hwnd, WPARAM wParam, LPARAM lParam )
 	m_comboDel.pRecent = &m_cRecentSearch;
 	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT), &m_comboDel);
 
-	// ƒtƒHƒ“ƒgÝ’è	2012/11/27 Uchi
+	// ãƒ•ã‚©ãƒ³ãƒˆè¨­å®š	2012/11/27 Uchi
 	HFONT hFontOld = (HFONT)::SendMessageAny( GetItemHwnd( IDC_COMBO_TEXT ), WM_GETFONT, 0, 0 );
 	HFONT hFont = SetMainFont( GetItemHwnd( IDC_COMBO_TEXT ) );
 	m_cFontText.SetFont( hFontOld, hFont, GetItemHwnd( IDC_COMBO_TEXT ) );
@@ -114,55 +114,55 @@ BOOL CDlgFind::OnDestroy()
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚ÌÝ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgFind::SetData( void )
 {
 //	MYTRACE( _T("CDlgFind::SetData()") );
 
 	/*****************************
-	*           ‰Šú‰»           *
+	*           åˆæœŸåŒ–           *
 	*****************************/
 	// Here Jun. 26, 2001 genta
-	// ³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ‚É‚æ‚èjre.dll”»’è‚ðíœ
+	// æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—ã«ã‚ˆã‚Šjre.dllåˆ¤å®šã‚’å‰Šé™¤
 
-	/* ƒ†[ƒU[‚ªƒRƒ“ƒ{ ƒ{ƒbƒNƒX‚ÌƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ð§ŒÀ‚·‚é */
-	// 2011.12.18 ’·‚³§ŒÀ“P”p
+	/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚³ãƒ³ãƒœ ãƒœãƒƒã‚¯ã‚¹ã®ã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
+	// 2011.12.18 é•·ã•åˆ¶é™æ’¤å»ƒ
 	// Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT ), _MAX_PATH - 1 );
-	/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒ†[ƒU[ ƒCƒ“ƒ^[ƒtƒFƒCƒX‚ðŠg’£ƒCƒ“ƒ^[ƒtƒF[ƒX‚É‚·‚é */
+	/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼ ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ã‚¤ã‚¹ã‚’æ‹¡å¼µã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã«ã™ã‚‹ */
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT ), TRUE );
 
 
 	/*****************************
-	*         ƒf[ƒ^Ý’è         *
+	*         ãƒ‡ãƒ¼ã‚¿è¨­å®š         *
 	*****************************/
-	/* ŒŸõ•¶Žš—ñ */
-	// ŒŸõ•¶Žš—ñƒŠƒXƒg‚ÌÝ’è(ŠÖ”‰»)	2010/5/28 Uchi
+	/* æ¤œç´¢æ–‡å­—åˆ— */
+	// æ¤œç´¢æ–‡å­—åˆ—ãƒªã‚¹ãƒˆã®è¨­å®š(é–¢æ•°åŒ–)	2010/5/28 Uchi
 	SetCombosList();
 
-	/* ‰p‘å•¶Žš‚Æ‰p¬•¶Žš‚ð‹æ•Ê‚·‚é */
+	/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 	::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, m_sSearchOption.bLoHiCase );
 
 	// 2001/06/23 Norio Nakatani
-	/* ’PŒê’PˆÊ‚ÅŒŸõ */
+	/* å˜èªžå˜ä½ã§æ¤œç´¢ */
 	::CheckDlgButton( GetHwnd(), IDC_CHK_WORD, m_sSearchOption.bWordOnly );
 
-	/* ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ð•\Ž¦ */
+	/* æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º */
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_NOTIFYNOTFOUND, m_bNOTIFYNOTFOUND );
 
 	// From Here Jun. 29, 2001 genta
-	// ³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ
-	// ˆ—ƒtƒ[‹y‚Ñ”»’èðŒ‚ÌŒ©’¼‚µB•K‚¸³‹K•\Œ»‚Ìƒ`ƒFƒbƒN‚Æ
-	// –³ŠÖŒW‚ÉCheckRegexpVersion‚ð’Ê‰ß‚·‚é‚æ‚¤‚É‚µ‚½B
+	// æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—
+	// å‡¦ç†ãƒ•ãƒ­ãƒ¼åŠã³åˆ¤å®šæ¡ä»¶ã®è¦‹ç›´ã—ã€‚å¿…ãšæ­£è¦è¡¨ç¾ã®ãƒã‚§ãƒƒã‚¯ã¨
+	// ç„¡é–¢ä¿‚ã«CheckRegexpVersionã‚’é€šéŽã™ã‚‹ã‚ˆã†ã«ã—ãŸã€‚
 	if( CheckRegexpVersion( GetHwnd(), IDC_STATIC_JRE32VER, false )
 		&& m_sSearchOption.bRegularExp){
-		/* ‰p‘å•¶Žš‚Æ‰p¬•¶Žš‚ð‹æ•Ê‚·‚é */
+		/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 		::CheckDlgButton( GetHwnd(), IDC_CHK_REGULAREXP, 1 );
-//³‹K•\Œ»‚ªON‚Å‚àA‘å•¶Žš¬•¶Žš‚ð‹æ•Ê‚·‚é^‚µ‚È‚¢‚ð‘I‘ð‚Å‚«‚é‚æ‚¤‚ÉB
+//æ­£è¦è¡¨ç¾ãŒONã§ã‚‚ã€å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ï¼ã—ãªã„ã‚’é¸æŠžã§ãã‚‹ã‚ˆã†ã«ã€‚
 //		::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, 1 );
 //		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_LOHICASE ), FALSE );
 
 		// 2001/06/23 N.Nakatani
-		/* ’PŒê’PˆÊ‚Å’T‚· */
+		/* å˜èªžå˜ä½ã§æŽ¢ã™ */
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ), FALSE );
 	}
 	else {
@@ -170,23 +170,23 @@ void CDlgFind::SetData( void )
 	}
 	// To Here Jun. 29, 2001 genta
 
-	/* ŒŸõƒ_ƒCƒAƒƒO‚ðŽ©“®“I‚É•Â‚¶‚é */
+	/* æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_bAutoCloseDlgFind, m_pShareData->m_Common.m_sSearch.m_bAutoCloseDlgFind );
 
-	/* æ“ªi––”öj‚©‚çÄŒŸõ 2002.01.26 hor */
+	/* å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ 2002.01.26 hor */
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_SEARCHALL, m_pShareData->m_Common.m_sSearch.m_bSearchAll );
 
 	return;
 }
 
 
-// ŒŸõ•¶Žš—ñƒŠƒXƒg‚ÌÝ’è
+// æ¤œç´¢æ–‡å­—åˆ—ãƒªã‚¹ãƒˆã®è¨­å®š
 //	2010/5/28 Uchi
 void CDlgFind::SetCombosList( void )
 {
 	HWND	hwndCombo;
 
-	/* ŒŸõ•¶Žš—ñ */
+	/* æ¤œç´¢æ–‡å­—åˆ— */
 	hwndCombo = ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT );
 	while (Combo_GetCount(hwndCombo) > 0) {
 		Combo_DeleteString( hwndCombo, 0);
@@ -200,55 +200,55 @@ void CDlgFind::SetCombosList( void )
 }
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚ÌŽæ“¾ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 int CDlgFind::GetData( void )
 {
 //	MYTRACE( _T("CDlgFind::GetData()") );
 
-	/* ‰p‘å•¶Žš‚Æ‰p¬•¶Žš‚ð‹æ•Ê‚·‚é */
+	/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 	m_sSearchOption.bLoHiCase = (0!=IsDlgButtonChecked( GetHwnd(), IDC_CHK_LOHICASE ));
 
 	// 2001/06/23 Norio Nakatani
-	/* ’PŒê’PˆÊ‚ÅŒŸõ */
+	/* å˜èªžå˜ä½ã§æ¤œç´¢ */
 	m_sSearchOption.bWordOnly = (0!=IsDlgButtonChecked( GetHwnd(), IDC_CHK_WORD ));
 
-	/* ˆê’v‚·‚é’PŒê‚Ì‚ÝŒŸõ‚·‚é */
-	/* ³‹K•\Œ» */
+	/* ä¸€è‡´ã™ã‚‹å˜èªžã®ã¿æ¤œç´¢ã™ã‚‹ */
+	/* æ­£è¦è¡¨ç¾ */
 	m_sSearchOption.bRegularExp = (0!=IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ));
 
-	/* ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ð•\Ž¦ */
+	/* æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º */
 	m_bNOTIFYNOTFOUND = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_NOTIFYNOTFOUND );
 
-	m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND = m_bNOTIFYNOTFOUND;	// ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ð•\Ž¦
+	m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND = m_bNOTIFYNOTFOUND;	// æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º
 
-	/* ŒŸõ•¶Žš—ñ */
+	/* æ¤œç´¢æ–‡å­—åˆ— */
 	int nBufferSize = ::GetWindowTextLength( GetItemHwnd(IDC_COMBO_TEXT) ) + 1;
 	std::vector<TCHAR> vText(nBufferSize);
 	::DlgItem_GetText( GetHwnd(), IDC_COMBO_TEXT, &vText[0], nBufferSize);
 	m_strText = to_wchar(&vText[0]);
 
-	/* ŒŸõƒ_ƒCƒAƒƒO‚ðŽ©“®“I‚É•Â‚¶‚é */
+	/* æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
 	m_pShareData->m_Common.m_sSearch.m_bAutoCloseDlgFind = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_bAutoCloseDlgFind );
 
-	/* æ“ªi––”öj‚©‚çÄŒŸõ 2002.01.26 hor */
+	/* å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ 2002.01.26 hor */
 	m_pShareData->m_Common.m_sSearch.m_bSearchAll = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_SEARCHALL );
 
 	if( 0 < m_strText.length() ){
-		/* ³‹K•\Œ»H */
+		/* æ­£è¦è¡¨ç¾ï¼Ÿ */
 		// From Here Jun. 26, 2001 genta
-		//	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ
+		//	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—
 		int nFlag = 0x00;
 		nFlag |= m_sSearchOption.bLoHiCase ? 0x01 : 0x00;
 		if( m_sSearchOption.bRegularExp && !CheckRegexpSyntax( m_strText.c_str(), GetHwnd(), true, nFlag ) ){
 			return -1;
 		}
-		// To Here Jun. 26, 2001 genta ³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ·‚µ‘Ö‚¦
+		// To Here Jun. 26, 2001 genta æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªå·®ã—æ›¿ãˆ
 
-		/* ŒŸõ•¶Žš—ñ */
-		//@@@ 2002.2.2 YAZAKI CShareData‚ÉˆÚ“®
+		/* æ¤œç´¢æ–‡å­—åˆ— */
+		//@@@ 2002.2.2 YAZAKI CShareDataã«ç§»å‹•
 		if( m_strText.size() < _MAX_PATH ){
 			CSearchKeywordManager().AddToSearchKeyArr( m_strText.c_str() );
-			m_pShareData->m_Common.m_sSearch.m_sSearchOption = m_sSearchOption;		// ŒŸõƒIƒvƒVƒ‡ƒ“
+			m_pShareData->m_Common.m_sSearch.m_sSearchOption = m_sSearchOption;		// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 		}
 		CEditView*	pcEditView = (CEditView*)m_lParam;
 		if( pcEditView->m_strCurSearchKey == m_strText && pcEditView->m_sCurSearchOption == m_sSearchOption ){
@@ -259,9 +259,9 @@ int CDlgFind::GetData( void )
 		}
 		pcEditView->m_nCurSearchKeySequence = GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence;
 		if( !m_bModal ){
-			/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚ÌÝ’è */
+			/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 			//SetData();
-			SetCombosList();		//	ƒRƒ“ƒ{‚Ì‚Ý‚Ì‰Šú‰»	2010/5/28 Uchi
+			SetCombosList();		//	ã‚³ãƒ³ãƒœã®ã¿ã®åˆæœŸåŒ–	2010/5/28 Uchi
 		}
 		return 1;
 	}else{
@@ -277,113 +277,113 @@ BOOL CDlgFind::OnBnClicked( int wID )
 	CEditView*	pcEditView = (CEditView*)m_lParam;
 	switch( wID ){
 	case IDC_BUTTON_HELP:
-		/* uŒŸõv‚Ìƒwƒ‹ƒv */
-		//Stonee, 2001/03/12 ‘æŽlˆø”‚ðA‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ð’²‚×‚é‚æ‚¤‚É‚µ‚½
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_SEARCH_DIALOG) );	//Apr. 5, 2001 JEPRO C³˜R‚ê‚ð’Ç‰Á	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ã€Œæ¤œç´¢ã€ã®ãƒ˜ãƒ«ãƒ— */
+		//Stonee, 2001/03/12 ç¬¬å››å¼•æ•°ã‚’ã€æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_SEARCH_DIALOG) );	//Apr. 5, 2001 JEPRO ä¿®æ­£æ¼ã‚Œã‚’è¿½åŠ 	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		break;
-	case IDC_CHK_REGULAREXP:	/* ³‹K•\Œ» */
+	case IDC_CHK_REGULAREXP:	/* æ­£è¦è¡¨ç¾ */
 //		MYTRACE( _T("IDC_CHK_REGULAREXP ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ) = %d\n"), ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ) );
 		if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ) ){
 
 			// From Here Jun. 26, 2001 genta
-			//	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ
+			//	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—
 			if( !CheckRegexpVersion( GetHwnd(), IDC_STATIC_JRE32VER, true ) ){
 				::CheckDlgButton( GetHwnd(), IDC_CHK_REGULAREXP, 0 );
 			}else{
 			// To Here Jun. 26, 2001 genta
 
-				/* ‰p‘å•¶Žš‚Æ‰p¬•¶Žš‚ð‹æ•Ê‚·‚é */
+				/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 				//	Jan. 31, 2002 genta
-				//	‘å•¶ŽšE¬•¶Žš‚Ì‹æ•Ê‚Í³‹K•\Œ»‚ÌÝ’è‚ÉŠÖ‚í‚ç‚¸•Û‘¶‚·‚é
+				//	å¤§æ–‡å­—ãƒ»å°æ–‡å­—ã®åŒºåˆ¥ã¯æ­£è¦è¡¨ç¾ã®è¨­å®šã«é–¢ã‚ã‚‰ãšä¿å­˜ã™ã‚‹
 				//::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, 1 );
 				//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_LOHICASE ), FALSE );
 
 				// 2001/06/23 Norio Nakatani
-				/* ’PŒê’PˆÊ‚ÅŒŸõ */
+				/* å˜èªžå˜ä½ã§æ¤œç´¢ */
 				::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ), FALSE );
 			}
 		}else{
-			/* ‰p‘å•¶Žš‚Æ‰p¬•¶Žš‚ð‹æ•Ê‚·‚é */
+			/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 			//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_LOHICASE ), TRUE );
 			//	Jan. 31, 2002 genta
-			//	‘å•¶ŽšE¬•¶Žš‚Ì‹æ•Ê‚Í³‹K•\Œ»‚ÌÝ’è‚ÉŠÖ‚í‚ç‚¸•Û‘¶‚·‚é
+			//	å¤§æ–‡å­—ãƒ»å°æ–‡å­—ã®åŒºåˆ¥ã¯æ­£è¦è¡¨ç¾ã®è¨­å®šã«é–¢ã‚ã‚‰ãšä¿å­˜ã™ã‚‹
 			//::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, 0 );
 
 			// 2001/06/23 Norio Nakatani
-			/* ’PŒê’PˆÊ‚ÅŒŸõ */
+			/* å˜èªžå˜ä½ã§æ¤œç´¢ */
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ), TRUE );
 		}
 		break;
-	case IDC_BUTTON_SEARCHPREV:	/* ãŒŸõ */	//Feb. 13, 2001 JEPRO ƒ{ƒ^ƒ“–¼‚ð[IDC_BUTTON1]¨[IDC_BUTTON_SERACHPREV]‚É•ÏX
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚ÌŽæ“¾ */
+	case IDC_BUTTON_SEARCHPREV:	/* ä¸Šæ¤œç´¢ */	//Feb. 13, 2001 JEPRO ãƒœã‚¿ãƒ³åã‚’[IDC_BUTTON1]â†’[IDC_BUTTON_SERACHPREV]ã«å¤‰æ›´
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		nRet = GetData();
 		if( 0 < nRet ){
-			if( m_bModal ){		/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚© */
+			if( m_bModal ){		/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‹ */
 				CloseDialog( 1 );
 			}else{
-				/* ‘O‚ðŒŸõ */
+				/* å‰ã‚’æ¤œç´¢ */
 				pcEditView->GetCommander().HandleCommand( F_SEARCH_PREV, true, (LPARAM)GetHwnd(), 0, 0, 0 );
 
-				/* Ä•`‰æ 2005.04.06 zenryaku 0•¶Žš•ƒ}ƒbƒ`‚ÅƒLƒƒƒŒƒbƒg‚ð•\Ž¦‚·‚é‚½‚ß */
-				pcEditView->Redraw();	// ‘O‰ñ0•¶Žš•ƒ}ƒbƒ`‚ÌÁ‹Ž‚É‚à•K—v
+				/* å†æç”» 2005.04.06 zenryaku 0æ–‡å­—å¹…ãƒžãƒƒãƒã§ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’è¡¨ç¤ºã™ã‚‹ãŸã‚ */
+				pcEditView->Redraw();	// å‰å›ž0æ–‡å­—å¹…ãƒžãƒƒãƒã®æ¶ˆåŽ»ã«ã‚‚å¿…è¦
 
 				// 02/06/26 ai Start
-				// ŒŸõŠJŽnˆÊ’u‚ð“o˜^
+				// æ¤œç´¢é–‹å§‹ä½ç½®ã‚’ç™»éŒ²
 				if( FALSE != pcEditView->m_bSearch ){
-					// ŒŸõŠJŽnŽž‚ÌƒJ[ƒ\ƒ‹ˆÊ’u“o˜^ðŒ•ÏX 02/07/28 ai start
+					// æ¤œç´¢é–‹å§‹æ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç™»éŒ²æ¡ä»¶å¤‰æ›´ 02/07/28 ai start
 					pcEditView->m_ptSrchStartPos_PHY = m_ptEscCaretPos_PHY;
 					pcEditView->m_bSearch = FALSE;
 					// 02/07/28 ai end
 				}//  02/06/26 ai End
 
-				/* ŒŸõƒ_ƒCƒAƒƒO‚ðŽ©“®“I‚É•Â‚¶‚é */
+				/* æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
 				if( m_pShareData->m_Common.m_sSearch.m_bAutoCloseDlgFind ){
 					CloseDialog( 0 );
 				}
 			}
 		}
 		else if (nRet == 0){
-			OkMessage( GetHwnd(), LS(STR_DLGFIND1) );	// ŒŸõðŒ‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢B
+			OkMessage( GetHwnd(), LS(STR_DLGFIND1) );	// æ¤œç´¢æ¡ä»¶ã‚’æŒ‡å®šã—ã¦ãã ã•ã„ã€‚
 		}
 		return TRUE;
-	case IDC_BUTTON_SEARCHNEXT:		/* ‰ºŒŸõ */	//Feb. 13, 2001 JEPRO ƒ{ƒ^ƒ“–¼‚ð[IDOK]¨[IDC_BUTTON_SERACHNEXT]‚É•ÏX
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚ÌŽæ“¾ */
+	case IDC_BUTTON_SEARCHNEXT:		/* ä¸‹æ¤œç´¢ */	//Feb. 13, 2001 JEPRO ãƒœã‚¿ãƒ³åã‚’[IDOK]â†’[IDC_BUTTON_SERACHNEXT]ã«å¤‰æ›´
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		nRet = GetData();
 		if( 0 < nRet ){
-			if( m_bModal ){		/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚© */
+			if( m_bModal ){		/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‹ */
 				CloseDialog( 2 );
 			}
 			else{
-				/* ŽŸ‚ðŒŸõ */
+				/* æ¬¡ã‚’æ¤œç´¢ */
 				pcEditView->GetCommander().HandleCommand( F_SEARCH_NEXT, true, (LPARAM)GetHwnd(), 0, 0, 0 );
 
-				/* Ä•`‰æ 2005.04.06 zenryaku 0•¶Žš•ƒ}ƒbƒ`‚ÅƒLƒƒƒŒƒbƒg‚ð•\Ž¦‚·‚é‚½‚ß */
-				pcEditView->Redraw();	// ‘O‰ñ0•¶Žš•ƒ}ƒbƒ`‚ÌÁ‹Ž‚É‚à•K—v
+				/* å†æç”» 2005.04.06 zenryaku 0æ–‡å­—å¹…ãƒžãƒƒãƒã§ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’è¡¨ç¤ºã™ã‚‹ãŸã‚ */
+				pcEditView->Redraw();	// å‰å›ž0æ–‡å­—å¹…ãƒžãƒƒãƒã®æ¶ˆåŽ»ã«ã‚‚å¿…è¦
 
-				// ŒŸõŠJŽnˆÊ’u‚ð“o˜^
+				// æ¤œç´¢é–‹å§‹ä½ç½®ã‚’ç™»éŒ²
 				if( FALSE != pcEditView->m_bSearch ){
-					// ŒŸõŠJŽnŽž‚ÌƒJ[ƒ\ƒ‹ˆÊ’u“o˜^ðŒ•ÏX 02/07/28 ai start
+					// æ¤œç´¢é–‹å§‹æ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç™»éŒ²æ¡ä»¶å¤‰æ›´ 02/07/28 ai start
 					pcEditView->m_ptSrchStartPos_PHY = m_ptEscCaretPos_PHY;
 					pcEditView->m_bSearch = FALSE;
 				}
 
-				/* ŒŸõƒ_ƒCƒAƒƒO‚ðŽ©“®“I‚É•Â‚¶‚é */
+				/* æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
 				if( m_pShareData->m_Common.m_sSearch.m_bAutoCloseDlgFind ){
 					CloseDialog( 0 );
 				}
 			}
 		}
 		else if (nRet == 0){
-			OkMessage( GetHwnd(), LS(STR_DLGFIND1) );	// ŒŸõðŒ‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢B
+			OkMessage( GetHwnd(), LS(STR_DLGFIND1) );	// æ¤œç´¢æ¡ä»¶ã‚’æŒ‡å®šã—ã¦ãã ã•ã„ã€‚
 		}
 		return TRUE;
-	case IDC_BUTTON_SETMARK:	//2002.01.16 hor ŠY“–sƒ}[ƒN
+	case IDC_BUTTON_SETMARK:	//2002.01.16 hor è©²å½“è¡Œãƒžãƒ¼ã‚¯
 		if( 0 < GetData() ){
-			if( m_bModal ){		/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚© */
+			if( m_bModal ){		/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‹ */
 				CloseDialog( 2 );
 			}else{
 				pcEditView->GetCommander().HandleCommand( F_BOOKMARK_PATTERN, false, 0, 0, 0, 0 );
-				/* ŒŸõƒ_ƒCƒAƒƒO‚ðŽ©“®“I‚É•Â‚¶‚é */
+				/* æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
 				if( m_pShareData->m_Common.m_sSearch.m_bAutoCloseDlgFind ){
 					CloseDialog( 0 );
 				}
@@ -402,11 +402,11 @@ BOOL CDlgFind::OnBnClicked( int wID )
 
 BOOL CDlgFind::OnActivate( WPARAM wParam, LPARAM lParam )
 {
-	// 0•¶Žš•ƒ}ƒbƒ`•`‰æ‚ÌON/OFF	// 2009.11.29 ryoji
+	// 0æ–‡å­—å¹…ãƒžãƒƒãƒæç”»ã®ON/OFF	// 2009.11.29 ryoji
 	CEditView*	pcEditView = (CEditView*)m_lParam;
 	CLayoutRange cRangeSel = pcEditView->GetSelectionInfo().m_sSelect;
 	if( cRangeSel.IsValid() && cRangeSel.IsLineOne() && cRangeSel.IsOne() )
-		pcEditView->InvalidateRect(NULL);	// ƒAƒNƒeƒBƒu‰»^”ñƒAƒNƒeƒBƒu‰»‚ªŠ®—¹‚µ‚Ä‚©‚çÄ•`‰æ
+		pcEditView->InvalidateRect(NULL);	// ã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–ï¼éžã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–ãŒå®Œäº†ã—ã¦ã‹ã‚‰å†æç”»
 
 	return CDialog::OnActivate(wParam, lParam);
 }

--- a/sakura_core/dlg/CDlgFind.h
+++ b/sakura_core/dlg/CDlgFind.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ŒŸõƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date	1998/12/02 Äì¬
+	@date	1998/12/02 å†ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -20,7 +20,7 @@
 
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 class CDlgFind : public CDialog
 {
@@ -32,29 +32,29 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-//	int DoModal( HINSTANCE, HWND, LPARAM );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
-	HWND DoModeless( HINSTANCE, HWND, LPARAM );	/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\¦ */
+//	int DoModal( HINSTANCE, HWND, LPARAM );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
+	HWND DoModeless( HINSTANCE, HWND, LPARAM );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 	void ChangeView( LPARAM );
 
-	SSearchOption m_sSearchOption;	// ŒŸõƒIƒvƒVƒ‡ƒ“
-	int		m_bNOTIFYNOTFOUND;	// ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦
-	std::wstring	m_strText;	// ŒŸõ•¶š—ñ
+	SSearchOption m_sSearchOption;	// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	int		m_bNOTIFYNOTFOUND;	// æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º
+	std::wstring	m_strText;	// æ¤œç´¢æ–‡å­—åˆ—
 
-	CLogicPoint	m_ptEscCaretPos_PHY;	// ŒŸõŠJn‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‘Ş”ğƒGƒŠƒA
+	CLogicPoint	m_ptEscCaretPos_PHY;	// æ¤œç´¢é–‹å§‹æ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®é€€é¿ã‚¨ãƒªã‚¢
 
 	CRecentSearch			m_cRecentSearch;
 	SComboBoxItemDeleter	m_comboDel;
 	CFontAutoDeleter		m_cFontText;
 
 protected:
-//@@@ 2002.2.2 YAZAKI CShareData‚ÉˆÚ“®
+//@@@ 2002.2.2 YAZAKI CShareDataã«ç§»å‹•
 //	void AddToSearchKeyArr( const char* );
-	/* ƒI[ƒo[ƒ‰ƒCƒh? */
+	/* ã‚ªãƒ¼ãƒãƒ¼ãƒ©ã‚¤ãƒ‰? */
 	BOOL OnCbnDropDown( HWND hwndCtl, int wID );
-	int GetData( void );		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-	void SetCombosList( void );	/* ŒŸõ•¶š—ñ/’uŠ·Œã•¶š—ñƒŠƒXƒg‚Ìİ’è */
-	void SetData( void );		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+	int GetData( void );		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+	void SetCombosList( void );	/* æ¤œç´¢æ–‡å­—åˆ—/ç½®æ›å¾Œæ–‡å­—åˆ—ãƒªã‚¹ãƒˆã®è¨­å®š */
+	void SetData( void );		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );
 	BOOL OnDestroy();
 	BOOL OnBnClicked( int );

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief GREPƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief GREPãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
 */
@@ -33,32 +33,32 @@
 
 //GREP CDlgGrep.cpp	//@@@ 2002.01.07 add start MIK
 const DWORD p_helpids[] = {	//12000
-	IDC_BUTTON_FOLDER,				HIDC_GREP_BUTTON_FOLDER,			//ƒtƒHƒ‹ƒ_
-	IDC_BUTTON_CURRENTFOLDER,		HIDC_GREP_BUTTON_CURRENTFOLDER,		//Œ»ƒtƒHƒ‹ƒ_
-	IDOK,							HIDOK_GREP,							//ŒŸõ
-	IDCANCEL,						HIDCANCEL_GREP,						//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_GREP_BUTTON_HELP,				//ƒwƒ‹ƒv
-	IDC_CHK_WORD,					HIDC_GREP_CHK_WORD,					//’PŒê’PˆÊ
-	IDC_CHK_SUBFOLDER,				HIDC_GREP_CHK_SUBFOLDER,			//ƒTƒuƒtƒHƒ‹ƒ_‚àŒŸõ
-	IDC_CHK_FROMTHISTEXT,			HIDC_GREP_CHK_FROMTHISTEXT,			//‚±‚Ìƒtƒ@ƒCƒ‹‚©‚ç
-	IDC_CHK_LOHICASE,				HIDC_GREP_CHK_LOHICASE,				//‘å•¶š¬•¶š
-	IDC_CHK_REGULAREXP,				HIDC_GREP_CHK_REGULAREXP,			//³‹K•\Œ»
-	IDC_COMBO_CHARSET,				HIDC_GREP_COMBO_CHARSET,			//•¶šƒR[ƒhƒZƒbƒg
-	IDC_CHECK_CP,					HIDC_GREP_CHECK_CP,					//ƒR[ƒhƒy[ƒW
-	IDC_COMBO_TEXT,					HIDC_GREP_COMBO_TEXT,				//ğŒ
-	IDC_COMBO_FILE,					HIDC_GREP_COMBO_FILE,				//ƒtƒ@ƒCƒ‹
-	IDC_COMBO_FOLDER,				HIDC_GREP_COMBO_FOLDER,				//ƒtƒHƒ‹ƒ_
-	IDC_BUTTON_FOLDER_UP,			HIDC_GREP_BUTTON_FOLDER_UP,			//ã
-	IDC_RADIO_OUTPUTLINE,			HIDC_GREP_RADIO_OUTPUTLINE,			//Œ‹‰Êo—ÍFs’PˆÊ
-	IDC_RADIO_OUTPUTMARKED,			HIDC_GREP_RADIO_OUTPUTMARKED,		//Œ‹‰Êo—ÍFŠY“–•”•ª
-	IDC_RADIO_OUTPUTSTYLE1,			HIDC_GREP_RADIO_OUTPUTSTYLE1,		//Œ‹‰Êo—ÍŒ`®Fƒm[ƒ}ƒ‹
-	IDC_RADIO_OUTPUTSTYLE2,			HIDC_GREP_RADIO_OUTPUTSTYLE2,		//Œ‹‰Êo—ÍŒ`®Fƒtƒ@ƒCƒ‹–ˆ
-	IDC_RADIO_OUTPUTSTYLE3,			HIDC_RADIO_OUTPUTSTYLE3,			//Œ‹‰Êo—ÍŒ`®FŒ‹‰Ê‚Ì‚İ
-	IDC_STATIC_JRE32VER,			HIDC_GREP_STATIC_JRE32VER,			//³‹K•\Œ»ƒo[ƒWƒ‡ƒ“
-	IDC_CHK_DEFAULTFOLDER,			HIDC_GREP_CHK_DEFAULTFOLDER,		//ƒtƒHƒ‹ƒ_‚Ì‰Šú’l‚ğƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_‚É‚·‚é
-	IDC_CHECK_FILE_ONLY,			HIDC_CHECK_FILE_ONLY,				//ƒtƒ@ƒCƒ‹–ˆÅ‰‚Ì‚İŒŸõ
-	IDC_CHECK_BASE_PATH,			HIDC_CHECK_BASE_PATH,				//ƒx[ƒXƒtƒHƒ‹ƒ_•\¦
-	IDC_CHECK_SEP_FOLDER,			HIDC_CHECK_SEP_FOLDER,				//ƒtƒHƒ‹ƒ_–ˆ‚É•\¦
+	IDC_BUTTON_FOLDER,				HIDC_GREP_BUTTON_FOLDER,			//ãƒ•ã‚©ãƒ«ãƒ€
+	IDC_BUTTON_CURRENTFOLDER,		HIDC_GREP_BUTTON_CURRENTFOLDER,		//ç¾ãƒ•ã‚©ãƒ«ãƒ€
+	IDOK,							HIDOK_GREP,							//æ¤œç´¢
+	IDCANCEL,						HIDCANCEL_GREP,						//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_GREP_BUTTON_HELP,				//ãƒ˜ãƒ«ãƒ—
+	IDC_CHK_WORD,					HIDC_GREP_CHK_WORD,					//å˜èªå˜ä½
+	IDC_CHK_SUBFOLDER,				HIDC_GREP_CHK_SUBFOLDER,			//ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚æ¤œç´¢
+	IDC_CHK_FROMTHISTEXT,			HIDC_GREP_CHK_FROMTHISTEXT,			//ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰
+	IDC_CHK_LOHICASE,				HIDC_GREP_CHK_LOHICASE,				//å¤§æ–‡å­—å°æ–‡å­—
+	IDC_CHK_REGULAREXP,				HIDC_GREP_CHK_REGULAREXP,			//æ­£è¦è¡¨ç¾
+	IDC_COMBO_CHARSET,				HIDC_GREP_COMBO_CHARSET,			//æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
+	IDC_CHECK_CP,					HIDC_GREP_CHECK_CP,					//ã‚³ãƒ¼ãƒ‰ãƒšãƒ¼ã‚¸
+	IDC_COMBO_TEXT,					HIDC_GREP_COMBO_TEXT,				//æ¡ä»¶
+	IDC_COMBO_FILE,					HIDC_GREP_COMBO_FILE,				//ãƒ•ã‚¡ã‚¤ãƒ«
+	IDC_COMBO_FOLDER,				HIDC_GREP_COMBO_FOLDER,				//ãƒ•ã‚©ãƒ«ãƒ€
+	IDC_BUTTON_FOLDER_UP,			HIDC_GREP_BUTTON_FOLDER_UP,			//ä¸Š
+	IDC_RADIO_OUTPUTLINE,			HIDC_GREP_RADIO_OUTPUTLINE,			//çµæœå‡ºåŠ›ï¼šè¡Œå˜ä½
+	IDC_RADIO_OUTPUTMARKED,			HIDC_GREP_RADIO_OUTPUTMARKED,		//çµæœå‡ºåŠ›ï¼šè©²å½“éƒ¨åˆ†
+	IDC_RADIO_OUTPUTSTYLE1,			HIDC_GREP_RADIO_OUTPUTSTYLE1,		//çµæœå‡ºåŠ›å½¢å¼ï¼šãƒãƒ¼ãƒãƒ«
+	IDC_RADIO_OUTPUTSTYLE2,			HIDC_GREP_RADIO_OUTPUTSTYLE2,		//çµæœå‡ºåŠ›å½¢å¼ï¼šãƒ•ã‚¡ã‚¤ãƒ«æ¯
+	IDC_RADIO_OUTPUTSTYLE3,			HIDC_RADIO_OUTPUTSTYLE3,			//çµæœå‡ºåŠ›å½¢å¼ï¼šçµæœã®ã¿
+	IDC_STATIC_JRE32VER,			HIDC_GREP_STATIC_JRE32VER,			//æ­£è¦è¡¨ç¾ãƒãƒ¼ã‚¸ãƒ§ãƒ³
+	IDC_CHK_DEFAULTFOLDER,			HIDC_GREP_CHK_DEFAULTFOLDER,		//ãƒ•ã‚©ãƒ«ãƒ€ã®åˆæœŸå€¤ã‚’ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€ã«ã™ã‚‹
+	IDC_CHECK_FILE_ONLY,			HIDC_CHECK_FILE_ONLY,				//ãƒ•ã‚¡ã‚¤ãƒ«æ¯æœ€åˆã®ã¿æ¤œç´¢
+	IDC_CHECK_BASE_PATH,			HIDC_CHECK_BASE_PATH,				//ãƒ™ãƒ¼ã‚¹ãƒ•ã‚©ãƒ«ãƒ€è¡¨ç¤º
+	IDC_CHECK_SEP_FOLDER,			HIDC_CHECK_SEP_FOLDER,				//ãƒ•ã‚©ãƒ«ãƒ€æ¯ã«è¡¨ç¤º
 //	IDC_STATIC,						-1,
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
@@ -67,12 +67,12 @@ static void SetGrepFolder( HWND hwndCtrl, LPCTSTR folder );
 
 CDlgGrep::CDlgGrep()
 {
-	m_bSubFolder = FALSE;				// ƒTƒuƒtƒHƒ‹ƒ_‚©‚ç‚àŒŸõ‚·‚é
-	m_bFromThisText = FALSE;			// ‚±‚Ì•ÒW’†‚ÌƒeƒLƒXƒg‚©‚çŒŸõ‚·‚é
-	m_sSearchOption.Reset();			// ŒŸõƒIƒvƒVƒ‡ƒ“
-	m_nGrepCharSet = CODE_SJIS;			// •¶šƒR[ƒhƒZƒbƒg
-	m_nGrepOutputLineType = 1;			// s‚ğo—Í/ŠY“–•”•ª/”Ûƒ}ƒbƒ`s ‚ğo—Í
-	m_nGrepOutputStyle = 1;				// Grep: o—ÍŒ`®
+	m_bSubFolder = FALSE;				// ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‹ã‚‰ã‚‚æ¤œç´¢ã™ã‚‹
+	m_bFromThisText = FALSE;			// ã“ã®ç·¨é›†ä¸­ã®ãƒ†ã‚­ã‚¹ãƒˆã‹ã‚‰æ¤œç´¢ã™ã‚‹
+	m_sSearchOption.Reset();			// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	m_nGrepCharSet = CODE_SJIS;			// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
+	m_nGrepOutputLineType = 1;			// è¡Œã‚’å‡ºåŠ›/è©²å½“éƒ¨åˆ†/å¦ãƒãƒƒãƒè¡Œ ã‚’å‡ºåŠ›
+	m_nGrepOutputStyle = 1;				// Grep: å‡ºåŠ›å½¢å¼
 	m_bGrepOutputFileOnly = false;
 	m_bGrepOutputBaseFolder = false;
 	m_bGrepSeparateFolder = false;
@@ -84,9 +84,9 @@ CDlgGrep::CDlgGrep()
 }
 
 /*!
-	ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒhƒƒbƒvƒ_ƒEƒ“ƒƒbƒZ[ƒW‚ğ•ß‘¨‚·‚é
+	ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ‰ãƒ­ãƒƒãƒ—ãƒ€ã‚¦ãƒ³ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹
 
-	@date 2013.03.24 novice V‹Kì¬
+	@date 2013.03.24 novice æ–°è¦ä½œæˆ
 */
 BOOL CDlgGrep::OnCbnDropDown( HWND hwndCtl, int wID )
 {
@@ -119,25 +119,25 @@ BOOL CDlgGrep::OnCbnDropDown( HWND hwndCtl, int wID )
 	return CDialog::OnCbnDropDown( hwndCtl, wID );
 }
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgGrep::DoModal( HINSTANCE hInstance, HWND hwndParent, const TCHAR* pszCurrentFilePath )
 {
-	m_bSubFolder = m_pShareData->m_Common.m_sSearch.m_bGrepSubFolder;			// Grep: ƒTƒuƒtƒHƒ‹ƒ_‚àŒŸõ
-	m_sSearchOption = m_pShareData->m_Common.m_sSearch.m_sSearchOption;		// ŒŸõƒIƒvƒVƒ‡ƒ“
-	m_nGrepCharSet = m_pShareData->m_Common.m_sSearch.m_nGrepCharSet;			// •¶šƒR[ƒhƒZƒbƒg
-	m_nGrepOutputLineType = m_pShareData->m_Common.m_sSearch.m_nGrepOutputLineType;	// s‚ğo—Í/ŠY“–•”•ª/”Ûƒ}ƒbƒ`s ‚ğo—Í
-	m_nGrepOutputStyle = m_pShareData->m_Common.m_sSearch.m_nGrepOutputStyle;	// Grep: o—ÍŒ`®
+	m_bSubFolder = m_pShareData->m_Common.m_sSearch.m_bGrepSubFolder;			// Grep: ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚æ¤œç´¢
+	m_sSearchOption = m_pShareData->m_Common.m_sSearch.m_sSearchOption;		// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	m_nGrepCharSet = m_pShareData->m_Common.m_sSearch.m_nGrepCharSet;			// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
+	m_nGrepOutputLineType = m_pShareData->m_Common.m_sSearch.m_nGrepOutputLineType;	// è¡Œã‚’å‡ºåŠ›/è©²å½“éƒ¨åˆ†/å¦ãƒãƒƒãƒè¡Œ ã‚’å‡ºåŠ›
+	m_nGrepOutputStyle = m_pShareData->m_Common.m_sSearch.m_nGrepOutputStyle;	// Grep: å‡ºåŠ›å½¢å¼
 	m_bGrepOutputFileOnly = m_pShareData->m_Common.m_sSearch.m_bGrepOutputFileOnly;
 	m_bGrepOutputBaseFolder = m_pShareData->m_Common.m_sSearch.m_bGrepOutputBaseFolder;
 	m_bGrepSeparateFolder = m_pShareData->m_Common.m_sSearch.m_bGrepSeparateFolder;
 
-	// 2013.05.21 ƒRƒ“ƒXƒgƒ‰ƒNƒ^‚©‚çDoModal‚ÉˆÚ“®
-	// m_strText ‚ÍŒÄ‚Ño‚µŒ³‚Åİ’èÏ‚İ
+	// 2013.05.21 ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã‹ã‚‰DoModalã«ç§»å‹•
+	// m_strText ã¯å‘¼ã³å‡ºã—å…ƒã§è¨­å®šæ¸ˆã¿
 	if( m_szFile[0] == _T('\0') && m_pShareData->m_sSearchKeywords.m_aGrepFiles.size() ){
-		_tcscpy( m_szFile, m_pShareData->m_sSearchKeywords.m_aGrepFiles[0] );		/* ŒŸõƒtƒ@ƒCƒ‹ */
+		_tcscpy( m_szFile, m_pShareData->m_sSearchKeywords.m_aGrepFiles[0] );		/* æ¤œç´¢ãƒ•ã‚¡ã‚¤ãƒ« */
 	}
 	if( m_szFolder[0] == _T('\0') && m_pShareData->m_sSearchKeywords.m_aGrepFolders.size() ){
-		_tcscpy( m_szFolder, m_pShareData->m_sSearchKeywords.m_aGrepFolders[0] );	/* ŒŸõƒtƒHƒ‹ƒ_ */
+		_tcscpy( m_szFolder, m_pShareData->m_sSearchKeywords.m_aGrepFolders[0] );	/* æ¤œç´¢ãƒ•ã‚©ãƒ«ãƒ€ */
 	}
 
 	if( pszCurrentFilePath ){	// 2010.01.10 ryoji
@@ -155,20 +155,20 @@ BOOL CDlgGrep::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 {
 	_SetHwnd( hwndDlg );
 
-	/* ƒ†[ƒU[‚ªƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ÌƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+	/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 	//	Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT ), _MAX_PATH - 1 );
 	Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_COMBO_FILE ), _countof2(m_szFile) - 1 );
 	Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_COMBO_FOLDER ), _countof2(m_szFolder) - 1 );
 
-	/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒ†[ƒU[ ƒCƒ“ƒ^[ƒtƒFƒCƒX‚ğŠg’£ƒCƒ“ƒ^[ƒtƒF[ƒX‚É‚·‚é */
+	/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼ ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ã‚¤ã‚¹ã‚’æ‹¡å¼µã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã«ã™ã‚‹ */
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT ), TRUE );
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_FILE ), TRUE );
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_FOLDER ), TRUE );
 
-	/* ƒ_ƒCƒAƒƒO‚ÌƒAƒCƒRƒ“ */
-//2002.02.08 GrepƒAƒCƒRƒ“‚à‘å‚«‚¢ƒAƒCƒRƒ“‚Æ¬‚³‚¢ƒAƒCƒRƒ“‚ğ•ÊX‚É‚·‚éB
+	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚¢ã‚¤ã‚³ãƒ³ */
+//2002.02.08 Grepã‚¢ã‚¤ã‚³ãƒ³ã‚‚å¤§ãã„ã‚¢ã‚¤ã‚³ãƒ³ã¨å°ã•ã„ã‚¢ã‚¤ã‚³ãƒ³ã‚’åˆ¥ã€…ã«ã™ã‚‹ã€‚
 	HICON	hIconBig, hIconSmall;
-	//	Dec, 2, 2002 genta ƒAƒCƒRƒ““Ç‚İ‚İ•û–@•ÏX
+	//	Dec, 2, 2002 genta ã‚¢ã‚¤ã‚³ãƒ³èª­ã¿è¾¼ã¿æ–¹æ³•å¤‰æ›´
 	hIconBig   = GetAppIcon( m_hInstance, ICON_DEFAULT_GREP, FN_GREP_ICON, false );
 	hIconSmall = GetAppIcon( m_hInstance, ICON_DEFAULT_GREP, FN_GREP_ICON, true );
 	::SendMessageAny( GetHwnd(), WM_SETICON, ICON_SMALL, (LPARAM)hIconSmall );
@@ -176,7 +176,7 @@ BOOL CDlgGrep::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	// 2002/09/22 Moca Add
 	int i;
-	/* •¶šƒR[ƒhƒZƒbƒg‘I‘ğƒRƒ“ƒ{ƒ{ƒbƒNƒX‰Šú‰» */
+	/* æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆé¸æŠã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹åˆæœŸåŒ– */
 	CCodeTypesForCombobox cCodeTypes;
 	for( i = 0; i < cCodeTypes.GetCount(); ++i ){
 		int idx = Combo_AddString( ::GetDlgItem( GetHwnd(), IDC_COMBO_CHARSET ), cCodeTypes.GetName(i) );
@@ -198,20 +198,20 @@ BOOL CDlgGrep::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	m_comboDelFolder.pRecent = &m_cRecentGrepFolder;
 	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_FOLDER), &m_comboDelFolder);
 
-	// ƒtƒHƒ“ƒgİ’è	2012/11/27 Uchi
+	// ãƒ•ã‚©ãƒ³ãƒˆè¨­å®š	2012/11/27 Uchi
 	HFONT hFontOld = (HFONT)::SendMessageAny( GetItemHwnd( IDC_COMBO_TEXT ), WM_GETFONT, 0, 0 );
 	HFONT hFont = SetMainFont( GetItemHwnd( IDC_COMBO_TEXT ) );
 	m_cFontText.SetFont( hFontOld, hFont, GetItemHwnd( IDC_COMBO_TEXT ) );
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 //	CreateSizeBox();
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 }
 
-/*! @brief ƒtƒHƒ‹ƒ_w’èEditBox‚ÌƒR[ƒ‹ƒoƒbƒNŠÖ”
+/*! @brief ãƒ•ã‚©ãƒ«ãƒ€æŒ‡å®šEditBoxã®ã‚³ãƒ¼ãƒ«ãƒãƒƒã‚¯é–¢æ•°
 
-	@date 2007.02.09 bosagami V‹Kì¬
-	@date 2007.09.02 genta ƒfƒBƒŒƒNƒgƒŠƒ`ƒFƒbƒN‚ğ‹­‰»
+	@date 2007.02.09 bosagami æ–°è¦ä½œæˆ
+	@date 2007.09.02 genta ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãƒã‚§ãƒƒã‚¯ã‚’å¼·åŒ–
 */
 LRESULT CALLBACK OnFolderProc(HWND hwnd,UINT msg,WPARAM wparam,LPARAM lparam)
 {
@@ -226,12 +226,12 @@ LRESULT CALLBACK OnFolderProc(HWND hwnd,UINT msg,WPARAM wparam,LPARAM lparam)
 		DragQueryFile((HDROP)wparam, 0, sPath, _countof2(sPath) - 1);
 		::DragFinish((HDROP)wparam);
 
-		//ƒtƒ@ƒCƒ‹ƒpƒX‚Ì‰ğŒˆ
+		//ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã®è§£æ±º
 		CSakuraEnvironment::ResolvePath(sPath);
 		
-		//	ƒtƒ@ƒCƒ‹‚ªƒhƒƒbƒv‚³‚ê‚½ê‡‚ÍƒtƒHƒ‹ƒ_‚ğØ‚èo‚·
-		//	ƒtƒHƒ‹ƒ_‚Ìê‡‚ÍÅŒã‚ª¸‚í‚ê‚é‚Ì‚Åsplit‚µ‚Ä‚Í‚¢‚¯‚È‚¢D
-		if( IsFileExists( sPath, true )){	//	‘æ2ˆø”‚ªtrue‚¾‚ÆƒfƒBƒŒƒNƒgƒŠ‚Í‘ÎÛŠO
+		//	ãƒ•ã‚¡ã‚¤ãƒ«ãŒãƒ‰ãƒ­ãƒƒãƒ—ã•ã‚ŒãŸå ´åˆã¯ãƒ•ã‚©ãƒ«ãƒ€ã‚’åˆ‡ã‚Šå‡ºã™
+		//	ãƒ•ã‚©ãƒ«ãƒ€ã®å ´åˆã¯æœ€å¾ŒãŒå¤±ã‚ã‚Œã‚‹ã®ã§splitã—ã¦ã¯ã„ã‘ãªã„ï¼
+		if( IsFileExists( sPath, true )){	//	ç¬¬2å¼•æ•°ãŒtrueã ã¨ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã¯å¯¾è±¡å¤–
 			SFilePath szWork;
 			SplitPath_FolderAndFile( sPath, szWork, NULL );
 			_tcscpy( sPath, szWork );
@@ -254,16 +254,16 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 {
 	switch( wID ){
 	case IDC_BUTTON_HELP:
-		/* uGrepv‚Ìƒwƒ‹ƒv */
-		//Stonee, 2001/03/12 ‘ælˆø”‚ğA‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_GREP_DIALOG) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ã€ŒGrepã€ã®ãƒ˜ãƒ«ãƒ— */
+		//Stonee, 2001/03/12 ç¬¬å››å¼•æ•°ã‚’ã€æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_GREP_DIALOG) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
-	case IDC_CHK_FROMTHISTEXT:	/* ‚±‚Ì•ÒW’†‚ÌƒeƒLƒXƒg‚©‚çŒŸõ‚·‚é */
-		// 2010.05.30 ŠÖ”‰»
+	case IDC_CHK_FROMTHISTEXT:	/* ã“ã®ç·¨é›†ä¸­ã®ãƒ†ã‚­ã‚¹ãƒˆã‹ã‚‰æ¤œç´¢ã™ã‚‹ */
+		// 2010.05.30 é–¢æ•°åŒ–
 		SetDataFromThisText( 0 != ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_FROMTHISTEXT ) );
 		return TRUE;
-	case IDC_BUTTON_CURRENTFOLDER:	/* Œ»İ•ÒW’†‚Ìƒtƒ@ƒCƒ‹‚ÌƒtƒHƒ‹ƒ_ */
-		/* ƒtƒ@ƒCƒ‹‚ğŠJ‚¢‚Ä‚¢‚é‚© */
+	case IDC_BUTTON_CURRENTFOLDER:	/* ç¾åœ¨ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ•ã‚©ãƒ«ãƒ€ */
+		/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã„ã¦ã„ã‚‹ã‹ */
 		if( m_szCurrentFilePath[0] != _T('\0') ){
 			TCHAR	szWorkFolder[MAX_PATH];
 			TCHAR	szWorkFile[MAX_PATH];
@@ -271,7 +271,7 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 			SetGrepFolder( GetItemHwnd(IDC_COMBO_FOLDER), szWorkFolder );
 		}
 		else{
-			/* Œ»İ‚ÌƒvƒƒZƒX‚ÌƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚ğæ“¾‚µ‚Ü‚· */
+			/* ç¾åœ¨ã®ãƒ—ãƒ­ã‚»ã‚¹ã®ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’å–å¾—ã—ã¾ã™ */
 			TCHAR	szWorkFolder[MAX_PATH];
 			::GetCurrentDirectory( _countof( szWorkFolder ) - 1, szWorkFolder );
 			SetGrepFolder( GetItemHwnd(IDC_COMBO_FOLDER), szWorkFolder );
@@ -286,7 +286,7 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 			std::vector<std::tstring> vPaths;
 			CGrepAgent::CreateFolders( szFolder, vPaths );
 			if( 0 < vPaths.size() ){
-				// ÅŒã‚ÌƒpƒX‚ª‘€ì‘ÎÛ
+				// æœ€å¾Œã®ãƒ‘ã‚¹ãŒæ“ä½œå¯¾è±¡
 				auto_strncpy( szFolder, vPaths.rbegin()->c_str(), nMaxPath );
 				szFolder[nMaxPath-1] = _T('\0');
 				if( DirectoryUp( szFolder ) ){
@@ -316,49 +316,49 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 		return TRUE;
 
 
-//	case IDC_CHK_LOHICASE:	/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
+//	case IDC_CHK_LOHICASE:	/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 //		MYTRACE( _T("IDC_CHK_LOHICASE\n") );
 //		return TRUE;
-	case IDC_CHK_REGULAREXP:	/* ³‹K•\Œ» */
+	case IDC_CHK_REGULAREXP:	/* æ­£è¦è¡¨ç¾ */
 //		MYTRACE( _T("IDC_CHK_REGULAREXP ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ) = %d\n"), ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ) );
 		if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ) ){
 			// From Here Jun. 26, 2001 genta
-			//	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ
+			//	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—
 			if( !CheckRegexpVersion( GetHwnd(), IDC_STATIC_JRE32VER, true ) ){
 				::CheckDlgButton( GetHwnd(), IDC_CHK_REGULAREXP, 0 );
 			}else{
 				//	To Here Jun. 26, 2001 genta
-				/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
-				//	³‹K•\Œ»‚Ì‚Æ‚«‚à‘I‘ğ‚Å‚«‚é‚æ‚¤‚ÉB
+				/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
+				//	æ­£è¦è¡¨ç¾ã®ã¨ãã‚‚é¸æŠã§ãã‚‹ã‚ˆã†ã«ã€‚
 //				::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, 1 );
 //				::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_LOHICASE ), FALSE );
 
 				//2001/06/23 N.Nakatani
-				/* ’PŒê’PˆÊ‚ÅŒŸõ */
+				/* å˜èªå˜ä½ã§æ¤œç´¢ */
 				::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ), FALSE );
 			}
 		}else{
-			/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
-			//	³‹K•\Œ»‚Ì‚Æ‚«‚à‘I‘ğ‚Å‚«‚é‚æ‚¤‚ÉB
+			/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
+			//	æ­£è¦è¡¨ç¾ã®ã¨ãã‚‚é¸æŠã§ãã‚‹ã‚ˆã†ã«ã€‚
 //			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_LOHICASE ), TRUE );
 //			::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, 0 );
 
 
 //2001/06/23 N.Nakatani
-//’PŒê’PˆÊ‚Ìgrep‚ªÀ‘•‚³‚ê‚½‚çƒRƒƒ“ƒg‚ğŠO‚·‚Æv‚¢‚Ü‚·
-//2002/03/07À‘•‚µ‚Ä‚İ‚½B
-			/* ’PŒê’PˆÊ‚ÅŒŸõ */
+//å˜èªå˜ä½ã®grepãŒå®Ÿè£…ã•ã‚ŒãŸã‚‰ã‚³ãƒ¡ãƒ³ãƒˆã‚’å¤–ã™ã¨æ€ã„ã¾ã™
+//2002/03/07å®Ÿè£…ã—ã¦ã¿ãŸã€‚
+			/* å˜èªå˜ä½ã§æ¤œç´¢ */
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ), TRUE );
 
 		}
 		return TRUE;
 
 	case IDC_BUTTON_FOLDER:
-		/* ƒtƒHƒ‹ƒ_QÆƒ{ƒ^ƒ“ */
+		/* ãƒ•ã‚©ãƒ«ãƒ€å‚ç…§ãƒœã‚¿ãƒ³ */
 		{
 			const int nMaxPath = MAX_GREP_PATH;
 			TCHAR	szFolder[nMaxPath];
-			/* ŒŸõƒtƒHƒ‹ƒ_ */
+			/* æ¤œç´¢ãƒ•ã‚©ãƒ«ãƒ€ */
 			::DlgItem_GetText( GetHwnd(), IDC_COMBO_FOLDER, szFolder, nMaxPath - 1 );
 			if( szFolder[0] == _T('\0') ){
 				::GetCurrentDirectory( nMaxPath, szFolder );
@@ -379,7 +379,7 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 		}
 		return TRUE;
 	case IDC_CHK_DEFAULTFOLDER:
-		/* ƒtƒHƒ‹ƒ_‚Ì‰Šú’l‚ğƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_‚É‚·‚é */
+		/* ãƒ•ã‚©ãƒ«ãƒ€ã®åˆæœŸå€¤ã‚’ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€ã«ã™ã‚‹ */
 		{
 			m_pShareData->m_Common.m_sSearch.m_bGrepDefaultFolder = ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_DEFAULTFOLDER );
 		}
@@ -398,7 +398,7 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 		}
 		break;
 	case IDOK:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		if( GetData() ){
 //			::EndDialog( hwndDlg, TRUE );
 			CloseDialog( TRUE );
@@ -410,22 +410,22 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 		return TRUE;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgGrep::SetData( void )
 {
-	/* ŒŸõ•¶š—ñ */
+	/* æ¤œç´¢æ–‡å­—åˆ— */
 	::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_strText.c_str() );
 
-	/* ŒŸõƒtƒ@ƒCƒ‹ */
+	/* æ¤œç´¢ãƒ•ã‚¡ã‚¤ãƒ« */
 	::DlgItem_SetText( GetHwnd(), IDC_COMBO_FILE, m_szFile );
 
-	/* ŒŸõƒtƒHƒ‹ƒ_ */
+	/* æ¤œç´¢ãƒ•ã‚©ãƒ«ãƒ€ */
 	::DlgItem_SetText( GetHwnd(), IDC_COMBO_FOLDER, m_szFolder );
 
 	if((m_szFolder[0] == _T('\0') || m_pShareData->m_Common.m_sSearch.m_bGrepDefaultFolder) &&
@@ -437,29 +437,29 @@ void CDlgGrep::SetData( void )
 		SetGrepFolder( GetItemHwnd(IDC_COMBO_FOLDER), szWorkFolder );
 	}
 
-	/* ƒTƒuƒtƒHƒ‹ƒ_‚©‚ç‚àŒŸõ‚·‚é */
+	/* ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‹ã‚‰ã‚‚æ¤œç´¢ã™ã‚‹ */
 	::CheckDlgButton( GetHwnd(), IDC_CHK_SUBFOLDER, m_bSubFolder );
 
-	// ‚±‚Ì•ÒW’†‚ÌƒeƒLƒXƒg‚©‚çŒŸõ‚·‚é
+	// ã“ã®ç·¨é›†ä¸­ã®ãƒ†ã‚­ã‚¹ãƒˆã‹ã‚‰æ¤œç´¢ã™ã‚‹
 	::CheckDlgButton( GetHwnd(), IDC_CHK_FROMTHISTEXT, m_bFromThisText );
-	// 2010.05.30 ŠÖ”‰»
+	// 2010.05.30 é–¢æ•°åŒ–
 	SetDataFromThisText( m_bFromThisText != FALSE );
 
-	/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
+	/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 	::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, m_sSearchOption.bLoHiCase );
 
-	// 2001/06/23 N.Nakatani Œ»“_‚Å‚ÍGrep‚Å‚Í’PŒê’PˆÊ‚ÌŒŸõ‚ÍƒTƒ|[ƒg‚Å‚«‚Ä‚¢‚Ü‚¹‚ñ
-	// 2002/03/07 ƒeƒXƒgƒTƒ|[ƒg
-	/* ˆê’v‚·‚é’PŒê‚Ì‚İŒŸõ‚·‚é */
+	// 2001/06/23 N.Nakatani ç¾æ™‚ç‚¹ã§ã¯Grepã§ã¯å˜èªå˜ä½ã®æ¤œç´¢ã¯ã‚µãƒãƒ¼ãƒˆã§ãã¦ã„ã¾ã›ã‚“
+	// 2002/03/07 ãƒ†ã‚¹ãƒˆã‚µãƒãƒ¼ãƒˆ
+	/* ä¸€è‡´ã™ã‚‹å˜èªã®ã¿æ¤œç´¢ã™ã‚‹ */
 	::CheckDlgButton( GetHwnd(), IDC_CHK_WORD, m_sSearchOption.bWordOnly );
-//	::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ) , false );	//ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ğg—p•s‰Â‚É‚·‚à
+//	::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ) , false );	//ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã‚’ä½¿ç”¨ä¸å¯ã«ã™ã‚‚
 
 
-	/* •¶šƒR[ƒh©“®”»•Ê */
+	/* æ–‡å­—ã‚³ãƒ¼ãƒ‰è‡ªå‹•åˆ¤åˆ¥ */
 //	::CheckDlgButton( GetHwnd(), IDC_CHK_KANJICODEAUTODETECT, m_bKanjiCode_AutoDetect );
 
 	// 2002/09/22 Moca Add
-	/* •¶šƒR[ƒhƒZƒbƒg */
+	/* æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
 	{
 		int		nIdx, nCurIdx = -1;
 		ECodeType nCharSet;
@@ -484,7 +484,7 @@ void CDlgGrep::SetData( void )
 		}
 	}
 
-	/* s‚ğo—Í‚·‚é‚©ŠY“–•”•ª‚¾‚¯o—Í‚·‚é‚© */
+	/* è¡Œã‚’å‡ºåŠ›ã™ã‚‹ã‹è©²å½“éƒ¨åˆ†ã ã‘å‡ºåŠ›ã™ã‚‹ã‹ */
 	if( m_nGrepOutputLineType == 1 ){
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_OUTPUTLINE, TRUE );
 	}else if( m_nGrepOutputLineType == 2 ){
@@ -495,7 +495,7 @@ void CDlgGrep::SetData( void )
 
 	::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHECK_BASE_PATH ), TRUE );
 	::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHECK_SEP_FOLDER ),TRUE );
-	/* Grep: o—ÍŒ`® */
+	/* Grep: å‡ºåŠ›å½¢å¼ */
 	if( 1 == m_nGrepOutputStyle ){
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_OUTPUTSTYLE1, TRUE );
 	}else
@@ -511,19 +511,19 @@ void CDlgGrep::SetData( void )
 	}
 
 	// From Here Jun. 29, 2001 genta
-	// ³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ
-	// ˆ—ƒtƒ[‹y‚Ñ”»’èğŒ‚ÌŒ©’¼‚µB•K‚¸³‹K•\Œ»‚Ìƒ`ƒFƒbƒN‚Æ
-	// –³ŠÖŒW‚ÉCheckRegexpVersion‚ğ’Ê‰ß‚·‚é‚æ‚¤‚É‚µ‚½B
+	// æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—
+	// å‡¦ç†ãƒ•ãƒ­ãƒ¼åŠã³åˆ¤å®šæ¡ä»¶ã®è¦‹ç›´ã—ã€‚å¿…ãšæ­£è¦è¡¨ç¾ã®ãƒã‚§ãƒƒã‚¯ã¨
+	// ç„¡é–¢ä¿‚ã«CheckRegexpVersionã‚’é€šéã™ã‚‹ã‚ˆã†ã«ã—ãŸã€‚
 	if( CheckRegexpVersion( GetHwnd(), IDC_STATIC_JRE32VER, false )
 		&& m_sSearchOption.bRegularExp){
-		/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
+		/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 		::CheckDlgButton( GetHwnd(), IDC_CHK_REGULAREXP, 1 );
-		//	³‹K•\Œ»‚Ì‚Æ‚«‚à‘I‘ğ‚Å‚«‚é‚æ‚¤‚ÉB
+		//	æ­£è¦è¡¨ç¾ã®ã¨ãã‚‚é¸æŠã§ãã‚‹ã‚ˆã†ã«ã€‚
 //		::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, 1 );
 //		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_LOHICASE ), FALSE );
 
 		// 2001/06/23 N.Nakatani
-		/* ’PŒê’PˆÊ‚Å’T‚· */
+		/* å˜èªå˜ä½ã§æ¢ã™ */
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ), FALSE );
 	}
 	else {
@@ -541,7 +541,7 @@ void CDlgGrep::SetData( void )
 	CheckDlgButtonBool( GetHwnd(), IDC_CHECK_BASE_PATH, m_bGrepOutputBaseFolder );
 	CheckDlgButtonBool( GetHwnd(), IDC_CHECK_SEP_FOLDER, m_bGrepSeparateFolder );
 
-	// ƒtƒHƒ‹ƒ_‚Ì‰Šú’l‚ğƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_‚É‚·‚é
+	// ãƒ•ã‚©ãƒ«ãƒ€ã®åˆæœŸå€¤ã‚’ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€ã«ã™ã‚‹
 	::CheckDlgButton( GetHwnd(), IDC_CHK_DEFAULTFOLDER, m_pShareData->m_Common.m_sSearch.m_bGrepDefaultFolder );
 
 	return;
@@ -549,7 +549,7 @@ void CDlgGrep::SetData( void )
 
 
 /*!
-	Œ»İ•ÒW’†ƒtƒ@ƒCƒ‹‚©‚çŒŸõƒ`ƒFƒbƒN‚Å‚Ìİ’è
+	ç¾åœ¨ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰æ¤œç´¢ãƒã‚§ãƒƒã‚¯ã§ã®è¨­å®š
 */
 void CDlgGrep::SetDataFromThisText( bool bChecked )
 {
@@ -557,7 +557,7 @@ void CDlgGrep::SetDataFromThisText( bool bChecked )
 	if( 0 != m_szCurrentFilePath[0] && bChecked ){
 		TCHAR	szWorkFolder[MAX_PATH];
 		TCHAR	szWorkFile[MAX_PATH];
-		// 2003.08.01 Moca ƒtƒ@ƒCƒ‹–¼‚ÍƒXƒy[ƒX‚È‚Ç‚Í‹æØ‚è‹L†‚É‚È‚é‚Ì‚ÅA""‚ÅˆÍ‚¢AƒGƒXƒP[ƒv‚·‚é
+		// 2003.08.01 Moca ãƒ•ã‚¡ã‚¤ãƒ«åã¯ã‚¹ãƒšãƒ¼ã‚¹ãªã©ã¯åŒºåˆ‡ã‚Šè¨˜å·ã«ãªã‚‹ã®ã§ã€""ã§å›²ã„ã€ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã™ã‚‹
 		szWorkFile[0] = _T('"');
 		SplitPath_FolderAndFile( m_szCurrentFilePath, szWorkFolder, szWorkFile + 1 );
 		_tcscat( szWorkFile, _T("\"") ); // 2003.08.01 Moca
@@ -575,32 +575,32 @@ void CDlgGrep::SetDataFromThisText( bool bChecked )
 	return;
 }
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
-	@retval TRUE  ³í
-	@retval FALSE “ü—ÍƒGƒ‰[
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
+	@retval TRUE  æ­£å¸¸
+	@retval FALSE å…¥åŠ›ã‚¨ãƒ©ãƒ¼
 */
 int CDlgGrep::GetData( void )
 {
-	/* ƒTƒuƒtƒHƒ‹ƒ_‚©‚ç‚àŒŸõ‚·‚é*/
+	/* ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‹ã‚‰ã‚‚æ¤œç´¢ã™ã‚‹*/
 	m_bSubFolder = ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_SUBFOLDER );
 
-	/* ‚±‚Ì•ÒW’†‚ÌƒeƒLƒXƒg‚©‚çŒŸõ‚·‚é */
+	/* ã“ã®ç·¨é›†ä¸­ã®ãƒ†ã‚­ã‚¹ãƒˆã‹ã‚‰æ¤œç´¢ã™ã‚‹ */
 	m_bFromThisText = ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_FROMTHISTEXT );
 
-	/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
+	/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 	m_sSearchOption.bLoHiCase = (0!=::IsDlgButtonChecked( GetHwnd(), IDC_CHK_LOHICASE ));
 
 	//2001/06/23 N.Nakatani
-	/* ’PŒê’PˆÊ‚ÅŒŸõ */
+	/* å˜èªå˜ä½ã§æ¤œç´¢ */
 	m_sSearchOption.bWordOnly = (0!=::IsDlgButtonChecked( GetHwnd(), IDC_CHK_WORD ));
 
-	/* ³‹K•\Œ» */
+	/* æ­£è¦è¡¨ç¾ */
 	m_sSearchOption.bRegularExp = (0!=::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ));
 
-	/* •¶šƒR[ƒh©“®”»•Ê */
+	/* æ–‡å­—ã‚³ãƒ¼ãƒ‰è‡ªå‹•åˆ¤åˆ¥ */
 //	m_bKanjiCode_AutoDetect = ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_KANJICODEAUTODETECT );
 
-	/* •¶šƒR[ƒhƒZƒbƒg */
+	/* æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
 	{
 		int		nIdx;
 		HWND	hWndCombo = ::GetDlgItem( GetHwnd(), IDC_COMBO_CHARSET );
@@ -609,7 +609,7 @@ int CDlgGrep::GetData( void )
 	}
 
 
-	/* s‚ğo—Í/ŠY“–•”•ª/”Ûƒ}ƒbƒ`s ‚ğo—Í */
+	/* è¡Œã‚’å‡ºåŠ›/è©²å½“éƒ¨åˆ†/å¦ãƒãƒƒãƒè¡Œ ã‚’å‡ºåŠ› */
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_OUTPUTLINE ) ){
 		m_nGrepOutputLineType = 1;
 	}else if( ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_NOHIT ) ){
@@ -618,12 +618,12 @@ int CDlgGrep::GetData( void )
 		m_nGrepOutputLineType = 0;
 	}
 
-	/* Grep: o—ÍŒ`® */
+	/* Grep: å‡ºåŠ›å½¢å¼ */
 	if( FALSE != ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_OUTPUTSTYLE1 ) ){
-		m_nGrepOutputStyle = 1;				/* Grep: o—ÍŒ`® */
+		m_nGrepOutputStyle = 1;				/* Grep: å‡ºåŠ›å½¢å¼ */
 	}
 	if( FALSE != ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_OUTPUTSTYLE2 ) ){
-		m_nGrepOutputStyle = 2;				/* Grep: o—ÍŒ`® */
+		m_nGrepOutputStyle = 2;				/* Grep: å‡ºåŠ›å½¢å¼ */
 	}
 	if( FALSE != ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_OUTPUTSTYLE3 ) ){
 		m_nGrepOutputStyle = 3;
@@ -634,27 +634,27 @@ int CDlgGrep::GetData( void )
 	m_bGrepSeparateFolder = IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_SEP_FOLDER );
 
 
-	/* ŒŸõ•¶š—ñ */
+	/* æ¤œç´¢æ–‡å­—åˆ— */
 	int nBufferSize = ::GetWindowTextLength( GetItemHwnd(IDC_COMBO_TEXT) ) + 1;
 	std::vector<TCHAR> vText(nBufferSize);
 	::DlgItem_GetText( GetHwnd(), IDC_COMBO_TEXT, &vText[0], nBufferSize);
 	m_strText = to_wchar(&vText[0]);
 	m_bSetText = true;
-	/* ŒŸõƒtƒ@ƒCƒ‹ */
+	/* æ¤œç´¢ãƒ•ã‚¡ã‚¤ãƒ« */
 	::DlgItem_GetText( GetHwnd(), IDC_COMBO_FILE, m_szFile, _countof2(m_szFile) );
-	/* ŒŸõƒtƒHƒ‹ƒ_ */
+	/* æ¤œç´¢ãƒ•ã‚©ãƒ«ãƒ€ */
 	::DlgItem_GetText( GetHwnd(), IDC_COMBO_FOLDER, m_szFolder, _countof2(m_szFolder) );
 
-	m_pShareData->m_Common.m_sSearch.m_nGrepCharSet = m_nGrepCharSet;			// •¶šƒR[ƒh©“®”»•Ê
-	m_pShareData->m_Common.m_sSearch.m_nGrepOutputLineType = m_nGrepOutputLineType;	// s‚ğo—Í/ŠY“–•”•ª/”Ûƒ}ƒbƒ`s ‚ğo—Í
-	m_pShareData->m_Common.m_sSearch.m_nGrepOutputStyle = m_nGrepOutputStyle;	// Grep: o—ÍŒ`®
+	m_pShareData->m_Common.m_sSearch.m_nGrepCharSet = m_nGrepCharSet;			// æ–‡å­—ã‚³ãƒ¼ãƒ‰è‡ªå‹•åˆ¤åˆ¥
+	m_pShareData->m_Common.m_sSearch.m_nGrepOutputLineType = m_nGrepOutputLineType;	// è¡Œã‚’å‡ºåŠ›/è©²å½“éƒ¨åˆ†/å¦ãƒãƒƒãƒè¡Œ ã‚’å‡ºåŠ›
+	m_pShareData->m_Common.m_sSearch.m_nGrepOutputStyle = m_nGrepOutputStyle;	// Grep: å‡ºåŠ›å½¢å¼
 	m_pShareData->m_Common.m_sSearch.m_bGrepOutputFileOnly = m_bGrepOutputFileOnly;
 	m_pShareData->m_Common.m_sSearch.m_bGrepOutputBaseFolder = m_bGrepOutputBaseFolder;
 	m_pShareData->m_Common.m_sSearch.m_bGrepSeparateFolder = m_bGrepSeparateFolder;
 
-//‚â‚ß‚Ü‚µ‚½
+//ã‚„ã‚ã¾ã—ãŸ
 //	if( 0 == wcslen( m_szText ) ){
-//		WarningMessage(	GetHwnd(), _T("ŒŸõ‚ÌƒL[ƒ[ƒh‚ğw’è‚µ‚Ä‚­‚¾‚³‚¢B") );
+//		WarningMessage(	GetHwnd(), _T("æ¤œç´¢ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’æŒ‡å®šã—ã¦ãã ã•ã„ã€‚") );
 //		return FALSE;
 //	}
 	if( 0 != auto_strlen( m_szFile ) ){
@@ -668,11 +668,11 @@ int CDlgGrep::GetData( void )
 			return FALSE;
 		}
 	}
-	/* ‚±‚Ì•ÒW’†‚ÌƒeƒLƒXƒg‚©‚çŒŸõ‚·‚é */
+	/* ã“ã®ç·¨é›†ä¸­ã®ãƒ†ã‚­ã‚¹ãƒˆã‹ã‚‰æ¤œç´¢ã™ã‚‹ */
 	if( m_szFile[0] == _T('\0') ){
 		//	Jun. 16, 2003 Moca
-		//	ŒŸõƒpƒ^[ƒ“‚ªw’è‚³‚ê‚Ä‚¢‚È‚¢ê‡‚ÌƒƒbƒZ[ƒW•\¦‚ğ‚â‚ßA
-		//	u*.*v‚ªw’è‚³‚ê‚½‚à‚Ì‚ÆŒ©‚È‚·D
+		//	æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ãŒæŒ‡å®šã•ã‚Œã¦ã„ãªã„å ´åˆã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸è¡¨ç¤ºã‚’ã‚„ã‚ã€
+		//	ã€Œ*.*ã€ãŒæŒ‡å®šã•ã‚ŒãŸã‚‚ã®ã¨è¦‹ãªã™ï¼
 		_tcscpy( m_szFile, _T("*.*") );
 	}
 	if( m_szFolder[0] == _T('\0') ){
@@ -681,10 +681,10 @@ int CDlgGrep::GetData( void )
 	}
 
 	{
-		//ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚ğ•Û‘¶B‚±‚ÌƒuƒƒbƒN‚©‚ç”²‚¯‚é‚Æ‚«‚É©“®‚ÅƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚Í•œŒ³‚³‚ê‚éB
+		//ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’ä¿å­˜ã€‚ã“ã®ãƒ–ãƒ­ãƒƒã‚¯ã‹ã‚‰æŠœã‘ã‚‹ã¨ãã«è‡ªå‹•ã§ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã¯å¾©å…ƒã•ã‚Œã‚‹ã€‚
 		CCurrentDirectoryBackupPoint cCurDirBackup;
 
-		// 2011.11.24 Moca •¡”ƒtƒHƒ‹ƒ_w’è
+		// 2011.11.24 Moca è¤‡æ•°ãƒ•ã‚©ãƒ«ãƒ€æŒ‡å®š
 		std::vector<std::tstring> vPaths;
 		CGrepAgent::CreateFolders( m_szFolder, vPaths );
 		int nFolderLen = 0;
@@ -692,14 +692,14 @@ int CDlgGrep::GetData( void )
 		TCHAR szFolder[nMaxPath];
 		szFolder[0] = _T('\0');
 		for( int i = 0 ; i < (int)vPaths.size(); i ++ ){
-			// ‘Š‘ÎƒpƒX¨â‘ÎƒpƒX
+			// ç›¸å¯¾ãƒ‘ã‚¹â†’çµ¶å¯¾ãƒ‘ã‚¹
 			if( !::SetCurrentDirectory( vPaths[i].c_str() ) ){
 				WarningMessage(	GetHwnd(), LS(STR_DLGGREP5) );
 				return FALSE;
 			}
 			TCHAR szFolderItem[nMaxPath];
 			::GetCurrentDirectory( nMaxPath, szFolderItem );
-			// ;‚ªƒtƒHƒ‹ƒ_–¼‚ÉŠÜ‚Ü‚ê‚Ä‚¢‚½‚ç""‚ÅˆÍ‚¤
+			// ;ãŒãƒ•ã‚©ãƒ«ãƒ€åã«å«ã¾ã‚Œã¦ã„ãŸã‚‰""ã§å›²ã†
 			if( auto_strchr( szFolderItem, _T(';') ) ){
 				szFolderItem[0] = _T('"');
 				::GetCurrentDirectory( nMaxPath, szFolderItem + 1 );
@@ -719,36 +719,36 @@ int CDlgGrep::GetData( void )
 		auto_strcpy( m_szFolder, szFolder );
 	}
 
-//@@@ 2002.2.2 YAZAKI CShareData.AddToSearchKeyArr()’Ç‰Á‚É”º‚¤•ÏX
-	/* ŒŸõ•¶š—ñ */
+//@@@ 2002.2.2 YAZAKI CShareData.AddToSearchKeyArr()è¿½åŠ ã«ä¼´ã†å¤‰æ›´
+	/* æ¤œç´¢æ–‡å­—åˆ— */
 	if( 0 < m_strText.size() ){
 		// From Here Jun. 26, 2001 genta
-		//	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ
+		//	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—
 		int nFlag = 0;
 		nFlag |= m_sSearchOption.bLoHiCase ? 0x01 : 0x00;
 		if( m_sSearchOption.bRegularExp  && !CheckRegexpSyntax( m_strText.c_str(), GetHwnd(), true, nFlag) ){
 			return FALSE;
 		}
-		// To Here Jun. 26, 2001 genta ³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ·‚µ‘Ö‚¦
+		// To Here Jun. 26, 2001 genta æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªå·®ã—æ›¿ãˆ
 		if( m_strText.size() < _MAX_PATH ){
 			CSearchKeywordManager().AddToSearchKeyArr( m_strText.c_str() );
-			m_pShareData->m_Common.m_sSearch.m_sSearchOption = m_sSearchOption;		// ŒŸõƒIƒvƒVƒ‡ƒ“
+			m_pShareData->m_Common.m_sSearch.m_sSearchOption = m_sSearchOption;		// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 		}
 	}else{
-		// 2014.07.01 ‹óƒL[‚à“o˜^‚·‚é
+		// 2014.07.01 ç©ºã‚­ãƒ¼ã‚‚ç™»éŒ²ã™ã‚‹
 		CSearchKeywordManager().AddToSearchKeyArr( L"" );
 	}
 
-	// ‚±‚Ì•ÒW’†‚ÌƒeƒLƒXƒg‚©‚çŒŸõ‚·‚éê‡A—š—ğ‚Éc‚³‚È‚¢	Uchi 2008/5/23
-	// 2016.03.08 Moca u‚±‚Ìƒtƒ@ƒCƒ‹‚©‚çŒŸõv‚Ìê‡‚ÍƒTƒuƒtƒHƒ‹ƒ_‹¤’Êİ’è‚ğXV‚µ‚È‚¢
+	// ã“ã®ç·¨é›†ä¸­ã®ãƒ†ã‚­ã‚¹ãƒˆã‹ã‚‰æ¤œç´¢ã™ã‚‹å ´åˆã€å±¥æ­´ã«æ®‹ã•ãªã„	Uchi 2008/5/23
+	// 2016.03.08 Moca ã€Œã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰æ¤œç´¢ã€ã®å ´åˆã¯ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€å…±é€šè¨­å®šã‚’æ›´æ–°ã—ãªã„
 	if (!m_bFromThisText) {
-		/* ŒŸõƒtƒ@ƒCƒ‹ */
+		/* æ¤œç´¢ãƒ•ã‚¡ã‚¤ãƒ« */
 		CSearchKeywordManager().AddToGrepFileArr( m_szFile );
 
-		/* ŒŸõƒtƒHƒ‹ƒ_ */
+		/* æ¤œç´¢ãƒ•ã‚©ãƒ«ãƒ€ */
 		CSearchKeywordManager().AddToGrepFolderArr( m_szFolder );
 
-		// GrepFƒTƒuƒtƒHƒ‹ƒ_‚àŒŸõ
+		// Grepï¼šã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚æ¤œç´¢
 		m_pShareData->m_Common.m_sSearch.m_bGrepSubFolder = m_bSubFolder;
 	}
 

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -652,11 +652,6 @@ int CDlgGrep::GetData( void )
 	m_pShareData->m_Common.m_sSearch.m_bGrepOutputBaseFolder = m_bGrepOutputBaseFolder;
 	m_pShareData->m_Common.m_sSearch.m_bGrepSeparateFolder = m_bGrepSeparateFolder;
 
-//やめました
-//	if( 0 == wcslen( m_szText ) ){
-//		WarningMessage(	GetHwnd(), _T("検索のキーワードを指定してください。") );
-//		return FALSE;
-//	}
 	if( 0 != auto_strlen( m_szFile ) ){
 		CGrepEnumKeys enumKeys;
 		int nErrorNo = enumKeys.SetFileKeys( m_szFile );

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief GREPƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief GREPãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date 1998.09/07  V‹Kì¬
-	@date 1999.12/05 Äì¬
+	@date 1998.09/07  æ–°è¦ä½œæˆ
+	@date 1999.12/05 å†ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -22,7 +22,7 @@ class CDlgGrep;
 #include "recent/CRecent.h"
 #include "util/window.h"
 
-//! GREPƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+//! GREPãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 class CDlgGrep : public CDialog
 {
 public:
@@ -34,27 +34,27 @@ public:
 	||  Attributes & Operations
 	*/
 	BOOL OnCbnDropDown( HWND hwndCtl, int wID );
-	int DoModal( HINSTANCE, HWND, const TCHAR* );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
-//	HWND DoModeless( HINSTANCE, HWND, const char* );	/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, const TCHAR* );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
+//	HWND DoModeless( HINSTANCE, HWND, const char* );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 
-	BOOL		m_bSubFolder;/*!< ƒTƒuƒtƒHƒ‹ƒ_‚©‚ç‚àŒŸõ‚·‚é */
-	BOOL		m_bFromThisText;/*!< ‚±‚Ì•ÒW’†‚ÌƒeƒLƒXƒg‚©‚çŒŸõ‚·‚é */
+	BOOL		m_bSubFolder;/*!< ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‹ã‚‰ã‚‚æ¤œç´¢ã™ã‚‹ */
+	BOOL		m_bFromThisText;/*!< ã“ã®ç·¨é›†ä¸­ã®ãƒ†ã‚­ã‚¹ãƒˆã‹ã‚‰æ¤œç´¢ã™ã‚‹ */
 
-	SSearchOption	m_sSearchOption;	//!< ŒŸõƒIƒvƒVƒ‡ƒ“
+	SSearchOption	m_sSearchOption;	//!< æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 
-	ECodeType	m_nGrepCharSet;			/*!< •¶šƒR[ƒhƒZƒbƒg */
-	int			m_nGrepOutputStyle;		/*!< Grep: o—ÍŒ`® */
-	int			m_nGrepOutputLineType;		//!< Œ‹‰Êo—ÍFs‚ğo—Í/ŠY“–•”•ª/”Ûƒ}ƒbƒ`s
-	bool		m_bGrepOutputFileOnly;		/*!< ƒtƒ@ƒCƒ‹–ˆÅ‰‚Ì‚İŒŸõ */
-	bool		m_bGrepOutputBaseFolder;	/*!< ƒx[ƒXƒtƒHƒ‹ƒ_•\¦ */
-	bool		m_bGrepSeparateFolder;		/*!< ƒtƒHƒ‹ƒ_–ˆ‚É•\¦ */
+	ECodeType	m_nGrepCharSet;			/*!< æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
+	int			m_nGrepOutputStyle;		/*!< Grep: å‡ºåŠ›å½¢å¼ */
+	int			m_nGrepOutputLineType;		//!< çµæœå‡ºåŠ›ï¼šè¡Œã‚’å‡ºåŠ›/è©²å½“éƒ¨åˆ†/å¦ãƒãƒƒãƒè¡Œ
+	bool		m_bGrepOutputFileOnly;		/*!< ãƒ•ã‚¡ã‚¤ãƒ«æ¯æœ€åˆã®ã¿æ¤œç´¢ */
+	bool		m_bGrepOutputBaseFolder;	/*!< ãƒ™ãƒ¼ã‚¹ãƒ•ã‚©ãƒ«ãƒ€è¡¨ç¤º */
+	bool		m_bGrepSeparateFolder;		/*!< ãƒ•ã‚©ãƒ«ãƒ€æ¯ã«è¡¨ç¤º */
 
 
-	std::wstring	m_strText;				/*!< ŒŸõ•¶š—ñ */
-	bool			m_bSetText;				//!< ŒŸõ•¶š—ñ‚ğİ’è‚µ‚½‚©
-	SFilePathLong	m_szFile;				//!< ŒŸõƒtƒ@ƒCƒ‹
-	SFilePathLong	m_szFolder;				//!< ŒŸõƒtƒHƒ‹ƒ_
+	std::wstring	m_strText;				/*!< æ¤œç´¢æ–‡å­—åˆ— */
+	bool			m_bSetText;				//!< æ¤œç´¢æ–‡å­—åˆ—ã‚’è¨­å®šã—ãŸã‹
+	SFilePathLong	m_szFile;				//!< æ¤œç´¢ãƒ•ã‚¡ã‚¤ãƒ«
+	SFilePathLong	m_szFolder;				//!< æ¤œç´¢ãƒ•ã‚©ãƒ«ãƒ€
 	SFilePath	m_szCurrentFilePath;
 protected:
 	SComboBoxItemDeleter	m_comboDelText;
@@ -66,16 +66,16 @@ protected:
 	CFontAutoDeleter		m_cFontText;
 
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );
 	BOOL OnDestroy();
 	BOOL OnBnClicked( int );
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
 
-	void SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-	void SetDataFromThisText( bool );	/* Œ»İ•ÒW’†ƒtƒ@ƒCƒ‹‚©‚çŒŸõƒ`ƒFƒbƒN‚Å‚Ìİ’è */
+	void SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+	void SetDataFromThisText( bool );	/* ç¾åœ¨ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰æ¤œç´¢ãƒã‚§ãƒƒã‚¯ã§ã®è¨­å®š */
 };
 
 

--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief GREP’uŠ·ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief GREPç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
 */
@@ -29,35 +29,35 @@
 #include "sakura.hh"
 
 const DWORD p_helpids[] = {
-	IDC_BUTTON_FOLDER,				HIDC_GREP_REP_BUTTON_FOLDER,			//ƒtƒHƒ‹ƒ_
-	IDC_BUTTON_CURRENTFOLDER,		HIDC_GREP_REP_BUTTON_CURRENTFOLDER,		//Œ»ƒtƒHƒ‹ƒ_
-	IDOK,							HIDOK_GREP_REP,							//’uŠ·ŠJn
-	IDCANCEL,						HIDCANCEL_GREP_REP,						//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_GREP_REP_BUTTON_HELP,				//ƒwƒ‹ƒv
-	IDC_CHK_PASTE,					HIDC_GREP_REP_CHK_PASTE,				//ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯
-	IDC_CHK_WORD,					HIDC_GREP_REP_CHK_WORD,					//’PŒê’PˆÊ
-	IDC_CHK_SUBFOLDER,				HIDC_GREP_REP_CHK_SUBFOLDER,			//ƒTƒuƒtƒHƒ‹ƒ_‚àŒŸõ
-//	IDC_CHK_FROMTHISTEXT,			HIDC_GREP_REP_CHK_FROMTHISTEXT,			//‚±‚Ìƒtƒ@ƒCƒ‹‚©‚ç
-	IDC_CHK_LOHICASE,				HIDC_GREP_REP_CHK_LOHICASE,				//‘å•¶š¬•¶š
-	IDC_CHK_REGULAREXP,				HIDC_GREP_REP_CHK_REGULAREXP,			//³‹K•\Œ»
-	IDC_CHK_BACKUP,					HIDC_GREP_REP_CHK_BACKUP,				//ƒoƒbƒNƒAƒbƒvì¬
-	IDC_COMBO_CHARSET,				HIDC_GREP_REP_COMBO_CHARSET,			//•¶šƒR[ƒhƒZƒbƒg
+	IDC_BUTTON_FOLDER,				HIDC_GREP_REP_BUTTON_FOLDER,			//ãƒ•ã‚©ãƒ«ãƒ€
+	IDC_BUTTON_CURRENTFOLDER,		HIDC_GREP_REP_BUTTON_CURRENTFOLDER,		//ç¾ãƒ•ã‚©ãƒ«ãƒ€
+	IDOK,							HIDOK_GREP_REP,							//ç½®æ›é–‹å§‹
+	IDCANCEL,						HIDCANCEL_GREP_REP,						//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_GREP_REP_BUTTON_HELP,				//ãƒ˜ãƒ«ãƒ—
+	IDC_CHK_PASTE,					HIDC_GREP_REP_CHK_PASTE,				//ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘
+	IDC_CHK_WORD,					HIDC_GREP_REP_CHK_WORD,					//å˜èªå˜ä½
+	IDC_CHK_SUBFOLDER,				HIDC_GREP_REP_CHK_SUBFOLDER,			//ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚æ¤œç´¢
+//	IDC_CHK_FROMTHISTEXT,			HIDC_GREP_REP_CHK_FROMTHISTEXT,			//ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰
+	IDC_CHK_LOHICASE,				HIDC_GREP_REP_CHK_LOHICASE,				//å¤§æ–‡å­—å°æ–‡å­—
+	IDC_CHK_REGULAREXP,				HIDC_GREP_REP_CHK_REGULAREXP,			//æ­£è¦è¡¨ç¾
+	IDC_CHK_BACKUP,					HIDC_GREP_REP_CHK_BACKUP,				//ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ä½œæˆ
+	IDC_COMBO_CHARSET,				HIDC_GREP_REP_COMBO_CHARSET,			//æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
 	IDC_CHECK_CP,					HIDC_GREP_REP_CHECK_CP,					//CP
-	IDC_COMBO_TEXT,					HIDC_GREP_REP_COMBO_TEXT,				//’uŠ·‘O
-	IDC_COMBO_TEXT2,				HIDC_GREP_REP_COMBO_TEXT2,				//’uŠ·Œã
-	IDC_COMBO_FILE,					HIDC_GREP_REP_COMBO_FILE,				//ƒtƒ@ƒCƒ‹
-	IDC_COMBO_FOLDER,				HIDC_GREP_REP_COMBO_FOLDER,				//ƒtƒHƒ‹ƒ_
-	IDC_BUTTON_FOLDER_UP,			HIDC_GREP_REP_BUTTON_FOLDER_UP,			//ã
-	IDC_RADIO_OUTPUTLINE,			HIDC_GREP_REP_RADIO_OUTPUTLINE,			//Œ‹‰Êo—ÍFs’PˆÊ
-	IDC_RADIO_OUTPUTMARKED,			HIDC_GREP_REP_RADIO_OUTPUTMARKED,		//Œ‹‰Êo—ÍFŠY“–•”•ª
-	IDC_RADIO_OUTPUTSTYLE1,			HIDC_GREP_REP_RADIO_OUTPUTSTYLE1,		//Œ‹‰Êo—ÍŒ`®Fƒm[ƒ}ƒ‹
-	IDC_RADIO_OUTPUTSTYLE2,			HIDC_GREP_REP_RADIO_OUTPUTSTYLE2,		//Œ‹‰Êo—ÍŒ`®Fƒtƒ@ƒCƒ‹–ˆ
-	IDC_RADIO_OUTPUTSTYLE3,			HIDC_GREP_REP_RADIO_OUTPUTSTYLE3,		//Œ‹‰Êo—ÍŒ`®FŒ‹‰Ê‚Ì‚İ
-	IDC_STATIC_JRE32VER,			HIDC_GREP_REP_STATIC_JRE32VER,			//³‹K•\Œ»ƒo[ƒWƒ‡ƒ“
-	IDC_CHK_DEFAULTFOLDER,			HIDC_GREP_REP_CHK_DEFAULTFOLDER,		//ƒtƒHƒ‹ƒ_‚Ì‰Šú’l‚ğƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_‚É‚·‚é
-	IDC_CHECK_FILE_ONLY,			HIDC_GREP_REP_CHECK_FILE_ONLY,			//ƒtƒ@ƒCƒ‹–ˆÅ‰‚Ì‚İŒŸõ
-	IDC_CHECK_BASE_PATH,			HIDC_GREP_REP_CHECK_BASE_PATH,			//ƒx[ƒXƒtƒHƒ‹ƒ_•\¦
-	IDC_CHECK_SEP_FOLDER,			HIDC_GREP_REP_CHECK_SEP_FOLDER,			//ƒtƒHƒ‹ƒ_–ˆ‚É•\¦
+	IDC_COMBO_TEXT,					HIDC_GREP_REP_COMBO_TEXT,				//ç½®æ›å‰
+	IDC_COMBO_TEXT2,				HIDC_GREP_REP_COMBO_TEXT2,				//ç½®æ›å¾Œ
+	IDC_COMBO_FILE,					HIDC_GREP_REP_COMBO_FILE,				//ãƒ•ã‚¡ã‚¤ãƒ«
+	IDC_COMBO_FOLDER,				HIDC_GREP_REP_COMBO_FOLDER,				//ãƒ•ã‚©ãƒ«ãƒ€
+	IDC_BUTTON_FOLDER_UP,			HIDC_GREP_REP_BUTTON_FOLDER_UP,			//ä¸Š
+	IDC_RADIO_OUTPUTLINE,			HIDC_GREP_REP_RADIO_OUTPUTLINE,			//çµæœå‡ºåŠ›ï¼šè¡Œå˜ä½
+	IDC_RADIO_OUTPUTMARKED,			HIDC_GREP_REP_RADIO_OUTPUTMARKED,		//çµæœå‡ºåŠ›ï¼šè©²å½“éƒ¨åˆ†
+	IDC_RADIO_OUTPUTSTYLE1,			HIDC_GREP_REP_RADIO_OUTPUTSTYLE1,		//çµæœå‡ºåŠ›å½¢å¼ï¼šãƒãƒ¼ãƒãƒ«
+	IDC_RADIO_OUTPUTSTYLE2,			HIDC_GREP_REP_RADIO_OUTPUTSTYLE2,		//çµæœå‡ºåŠ›å½¢å¼ï¼šãƒ•ã‚¡ã‚¤ãƒ«æ¯
+	IDC_RADIO_OUTPUTSTYLE3,			HIDC_GREP_REP_RADIO_OUTPUTSTYLE3,		//çµæœå‡ºåŠ›å½¢å¼ï¼šçµæœã®ã¿
+	IDC_STATIC_JRE32VER,			HIDC_GREP_REP_STATIC_JRE32VER,			//æ­£è¦è¡¨ç¾ãƒãƒ¼ã‚¸ãƒ§ãƒ³
+	IDC_CHK_DEFAULTFOLDER,			HIDC_GREP_REP_CHK_DEFAULTFOLDER,		//ãƒ•ã‚©ãƒ«ãƒ€ã®åˆæœŸå€¤ã‚’ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€ã«ã™ã‚‹
+	IDC_CHECK_FILE_ONLY,			HIDC_GREP_REP_CHECK_FILE_ONLY,			//ãƒ•ã‚¡ã‚¤ãƒ«æ¯æœ€åˆã®ã¿æ¤œç´¢
+	IDC_CHECK_BASE_PATH,			HIDC_GREP_REP_CHECK_BASE_PATH,			//ãƒ™ãƒ¼ã‚¹ãƒ•ã‚©ãƒ«ãƒ€è¡¨ç¤º
+	IDC_CHECK_SEP_FOLDER,			HIDC_GREP_REP_CHECK_SEP_FOLDER,			//ãƒ•ã‚©ãƒ«ãƒ€æ¯ã«è¡¨ç¤º
 	0, 0
 };
 
@@ -71,22 +71,22 @@ CDlgGrepReplace::CDlgGrepReplace()
 
 
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgGrepReplace::DoModal( HINSTANCE hInstance, HWND hwndParent, const TCHAR* pszCurrentFilePath, LPARAM lParam )
 {
-	m_bSubFolder = m_pShareData->m_Common.m_sSearch.m_bGrepSubFolder;			// Grep: ƒTƒuƒtƒHƒ‹ƒ_‚àŒŸõ
-	m_sSearchOption = m_pShareData->m_Common.m_sSearch.m_sSearchOption;		// ŒŸõƒIƒvƒVƒ‡ƒ“
-	m_nGrepCharSet = m_pShareData->m_Common.m_sSearch.m_nGrepCharSet;			// •¶šƒR[ƒhƒZƒbƒg
-	m_nGrepOutputLineType = m_pShareData->m_Common.m_sSearch.m_nGrepOutputLineType;	// s‚ğo—Í‚·‚é‚©ŠY“–•”•ª‚¾‚¯o—Í‚·‚é‚©
-	m_nGrepOutputStyle = m_pShareData->m_Common.m_sSearch.m_nGrepOutputStyle;	// Grep: o—ÍŒ`®
+	m_bSubFolder = m_pShareData->m_Common.m_sSearch.m_bGrepSubFolder;			// Grep: ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚æ¤œç´¢
+	m_sSearchOption = m_pShareData->m_Common.m_sSearch.m_sSearchOption;		// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	m_nGrepCharSet = m_pShareData->m_Common.m_sSearch.m_nGrepCharSet;			// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
+	m_nGrepOutputLineType = m_pShareData->m_Common.m_sSearch.m_nGrepOutputLineType;	// è¡Œã‚’å‡ºåŠ›ã™ã‚‹ã‹è©²å½“éƒ¨åˆ†ã ã‘å‡ºåŠ›ã™ã‚‹ã‹
+	m_nGrepOutputStyle = m_pShareData->m_Common.m_sSearch.m_nGrepOutputStyle;	// Grep: å‡ºåŠ›å½¢å¼
 	m_bPaste = false;
 	m_bBackup = m_pShareData->m_Common.m_sSearch.m_bGrepBackup;
 
 	if( m_szFile[0] == _T('\0') && m_pShareData->m_sSearchKeywords.m_aGrepFiles.size() ){
-		_tcscpy( m_szFile, m_pShareData->m_sSearchKeywords.m_aGrepFiles[0] );		/* ŒŸõƒtƒ@ƒCƒ‹ */
+		_tcscpy( m_szFile, m_pShareData->m_sSearchKeywords.m_aGrepFiles[0] );		/* æ¤œç´¢ãƒ•ã‚¡ã‚¤ãƒ« */
 	}
 	if( m_szFolder[0] == _T('\0') && m_pShareData->m_sSearchKeywords.m_aGrepFolders.size() ){
-		_tcscpy( m_szFolder, m_pShareData->m_sSearchKeywords.m_aGrepFolders[0] );	/* ŒŸõƒtƒHƒ‹ƒ_ */
+		_tcscpy( m_szFolder, m_pShareData->m_sSearchKeywords.m_aGrepFolders[0] );	/* æ¤œç´¢ãƒ•ã‚©ãƒ«ãƒ€ */
 	}
 	if( pszCurrentFilePath ){	// 2010.01.10 ryoji
 		_tcscpy(m_szCurrentFilePath, pszCurrentFilePath);
@@ -99,7 +99,7 @@ BOOL CDlgGrepReplace::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 {
 	_SetHwnd( hwndDlg );
 
-	/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒ†[ƒU[ ƒCƒ“ƒ^[ƒtƒFƒCƒX‚ğŠg’£ƒCƒ“ƒ^[ƒtƒF[ƒX‚É‚·‚é */
+	/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼ ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ã‚¤ã‚¹ã‚’æ‹¡å¼µã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã«ã™ã‚‹ */
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT2 ), TRUE );
 
 	HFONT hFontOld = (HFONT)::SendMessageAny( GetItemHwnd( IDC_COMBO_TEXT2 ), WM_GETFONT, 0, 0 );
@@ -140,16 +140,16 @@ BOOL CDlgGrepReplace::OnBnClicked( int wID )
 			}
 		}
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDlgGrep::OnBnClicked( wID );
 }
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgGrepReplace::SetData( void )
 {
-	/* ’uŠ·Œã */
+	/* ç½®æ›å¾Œ */
 	::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT2, m_strText2.c_str() );
 	HWND	hwndCombo = ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT2 );
 	for( int i = 0; i < m_pShareData->m_sSearchKeywords.m_aReplaceKeys.size(); ++i ){
@@ -164,14 +164,14 @@ void CDlgGrepReplace::SetData( void )
 
 
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
-	TRUE==³í  FALSE==“ü—ÍƒGƒ‰[
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
+	TRUE==æ­£å¸¸  FALSE==å…¥åŠ›ã‚¨ãƒ©ãƒ¼
 */
 int CDlgGrepReplace::GetData( void )
 {
 	m_bPaste = IsDlgButtonCheckedBool( GetHwnd(), IDC_CHK_PASTE );
 
-	/* ’uŠ·Œã */
+	/* ç½®æ›å¾Œ */
 	int nBufferSize = ::GetWindowTextLength( GetItemHwnd(IDC_COMBO_TEXT2) ) + 1;
 	std::vector<TCHAR> vText(nBufferSize);
 	::DlgItem_GetText( GetHwnd(), IDC_COMBO_TEXT2, &vText[0], nBufferSize);

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief GREP’uŠ·ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief GREPç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date 2011.12.15 CDlgFrep.h‚©‚çì¬
+	@date 2011.12.15 CDlgFrep.hã‹ã‚‰ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -21,7 +21,7 @@ class CDlgGrep;
 #include "dlg/CDialog.h"
 #include "dlg/CDlgGrep.h"
 
-//! GREP’uŠ·ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+//! GREPç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 class CDlgGrepReplace : public CDlgGrep
 {
 public:
@@ -32,27 +32,27 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, const TCHAR*, LPARAM );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, const TCHAR*, LPARAM );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 	bool		m_bPaste;
 	bool		m_bBackup;
 
-	std::wstring	m_strText2;				//!< ’uŠ·Œã
-	int				m_nReplaceKeySequence;	//!< ’uŠ·ŒãƒV[ƒPƒ“ƒX
+	std::wstring	m_strText2;				//!< ç½®æ›å¾Œ
+	int				m_nReplaceKeySequence;	//!< ç½®æ›å¾Œã‚·ãƒ¼ã‚±ãƒ³ã‚¹
 
 protected:
 	CFontAutoDeleter		m_cFontText2;
 
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );
 	BOOL OnDestroy();
 	BOOL OnBnClicked( int );
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
 
-	void SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 };
 
 

--- a/sakura_core/dlg/CDlgInput1.cpp
+++ b/sakura_core/dlg/CDlgInput1.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief 1s“ü—Íƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief 1è¡Œå…¥åŠ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date	1998/05/31 ì¬
+	@date	1998/05/31 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -21,18 +21,18 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 
-// “ü—Í CDlgInput1.cpp	//@@@ 2002.01.07 add start MIK
+// å…¥åŠ› CDlgInput1.cpp	//@@@ 2002.01.07 add start MIK
 static const DWORD p_helpids[] = {	//13000
 	IDOK,					HIDOK_DLG1,
 	IDCANCEL,				HIDCANCEL_DLG1,
-	IDC_EDIT_INPUT1,		HIDC_DLG1_EDIT1,	//“ü—ÍƒtƒB[ƒ‹ƒh	IDC_EDIT1->IDC_EDIT_INPUT1	2008/7/3 Uchi
-	IDC_STATIC_MSG,			HIDC_DLG1_EDIT1,	//ƒƒbƒZ[ƒW
+	IDC_EDIT_INPUT1,		HIDC_DLG1_EDIT1,	//å…¥åŠ›ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰	IDC_EDIT1->IDC_EDIT_INPUT1	2008/7/3 Uchi
+	IDC_STATIC_MSG,			HIDC_DLG1_EDIT1,	//ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
 //	IDC_STATIC,				-1,
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
 
 
-/* ƒ_ƒCƒAƒƒOƒvƒƒV[ƒWƒƒ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ */
 INT_PTR CALLBACK CDlgInput1Proc(
 	HWND hwndDlg,	// handle to dialog box
 	UINT uMsg,		// message
@@ -76,7 +76,7 @@ CDlgInput1::~CDlgInput1()
 
 
 
-/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 BOOL CDlgInput1::DoModal(
 	HINSTANCE		hInstApp,
 	HWND			hwndParent,
@@ -87,12 +87,12 @@ BOOL CDlgInput1::DoModal(
 )
 {
 	BOOL bRet;
-	m_hInstance = hInstApp;		/* ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒCƒ“ƒXƒ^ƒ“ƒX‚Ìƒnƒ“ƒhƒ‹ */
-	m_hwndParent = hwndParent;	/* ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹ */
-	m_pszTitle = pszTitle;		/* ƒ_ƒCƒAƒƒOƒ^ƒCƒgƒ‹ */
-	m_pszMessage = pszMessage;		/* ƒƒbƒZ[ƒW */
-	m_nMaxTextLen = nMaxTextLen;	/* “ü—ÍƒTƒCƒYãŒÀ */
-//	m_pszText = pszText;			/* ƒeƒLƒXƒg */
+	m_hInstance = hInstApp;		/* ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ« */
+	m_hwndParent = hwndParent;	/* ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ« */
+	m_pszTitle = pszTitle;		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚¿ã‚¤ãƒˆãƒ« */
+	m_pszMessage = pszMessage;		/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ */
+	m_nMaxTextLen = nMaxTextLen;	/* å…¥åŠ›ã‚µã‚¤ã‚ºä¸Šé™ */
+//	m_pszText = pszText;			/* ãƒ†ã‚­ã‚¹ãƒˆ */
 	m_cmemText.SetString( pszText );
 	bRet = (BOOL)::DialogBoxParam(
 		CSelectLang::getLangRsrcInstance(),
@@ -126,7 +126,7 @@ BOOL CDlgInput1::DoModal(
 
 
 
-/* ƒ_ƒCƒAƒƒO‚ÌƒƒbƒZ[ƒWˆ— */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CDlgInput1::DispatchEvent(
 	HWND hwndDlg,	// handle to dialog box
 	UINT uMsg,		// message
@@ -139,26 +139,26 @@ INT_PTR CDlgInput1::DispatchEvent(
 //	int		nRet;
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		::SetWindowText( hwndDlg, m_pszTitle );	/* ƒ_ƒCƒAƒƒOƒ^ƒCƒgƒ‹ */
-		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_INPUT1 ), m_nMaxTextLen );	/* “ü—ÍƒTƒCƒYãŒÀ */
-		DlgItem_SetText( hwndDlg, IDC_EDIT_INPUT1, m_cmemText.GetStringPtr() );	/* ƒeƒLƒXƒg */
-		::SetWindowText( ::GetDlgItem( hwndDlg, IDC_STATIC_MSG ), m_pszMessage );	/* ƒƒbƒZ[ƒW */
+		::SetWindowText( hwndDlg, m_pszTitle );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚¿ã‚¤ãƒˆãƒ« */
+		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_INPUT1 ), m_nMaxTextLen );	/* å…¥åŠ›ã‚µã‚¤ã‚ºä¸Šé™ */
+		DlgItem_SetText( hwndDlg, IDC_EDIT_INPUT1, m_cmemText.GetStringPtr() );	/* ãƒ†ã‚­ã‚¹ãƒˆ */
+		::SetWindowText( ::GetDlgItem( hwndDlg, IDC_STATIC_MSG ), m_pszMessage );	/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ */
 
 		return TRUE;
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID			= LOWORD(wParam);	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+		wNotifyCode = HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID			= LOWORD(wParam);	/* é …ç›®IDã€ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDã€ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 		switch( wNotifyCode ){
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 			switch( wID ){
 			case IDOK:
 				m_cmemText.AllocStringBuffer( ::GetWindowTextLength( ::GetDlgItem( hwndDlg, IDC_EDIT_INPUT1 ) ) );
-				::GetWindowText( ::GetDlgItem( hwndDlg, IDC_EDIT_INPUT1 ), m_cmemText.GetStringPtr(), m_nMaxTextLen + 1 );	/* ƒeƒLƒXƒg */
+				::GetWindowText( ::GetDlgItem( hwndDlg, IDC_EDIT_INPUT1 ), m_cmemText.GetStringPtr(), m_nMaxTextLen + 1 );	/* ãƒ†ã‚­ã‚¹ãƒˆ */
 				::EndDialog( hwndDlg, TRUE );
 				return TRUE;
 			case IDCANCEL:
@@ -172,13 +172,13 @@ INT_PTR CDlgInput1::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 	//@@@ 2002.01.07 add end
 	}

--- a/sakura_core/dlg/CDlgInput1.h
+++ b/sakura_core/dlg/CDlgInput1.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief 1s“ü—Íƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief 1è¡Œå…¥åŠ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date	1998/05/31 ì¬
+	@date	1998/05/31 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -17,10 +17,10 @@ class CDlgInput1;
 #define _CDLGINPUT1_H_
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 /*!
-	@brief ‚Ps“ü—Íƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+	@brief ï¼‘è¡Œå…¥åŠ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 */
 class CDlgInput1
 {
@@ -30,25 +30,25 @@ public:
 	*/
 	CDlgInput1();
 	~CDlgInput1();
-	BOOL DoModal( HINSTANCE , HWND , const TCHAR* , const TCHAR* , int , TCHAR*  );	/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\Ž¦ */
-	BOOL DoModal( HINSTANCE , HWND , const TCHAR* , const TCHAR* , int , NOT_TCHAR*  );	/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\Ž¦ */
+	BOOL DoModal( HINSTANCE , HWND , const TCHAR* , const TCHAR* , int , TCHAR*  );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
+	BOOL DoModal( HINSTANCE , HWND , const TCHAR* , const TCHAR* , int , NOT_TCHAR*  );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 	/*
 	||  Attributes & Operations
 	*/
-	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );	/* ƒ_ƒCƒAƒƒO‚ÌƒƒbƒZ[ƒWˆ— */
+	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 
-	HINSTANCE	m_hInstance;	/* ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒCƒ“ƒXƒ^ƒ“ƒX‚Ìƒnƒ“ƒhƒ‹ */
-	HWND		m_hwndParent;	/* ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹ */
-	HWND		m_hWnd;			/* ‚±‚Ìƒ_ƒCƒAƒƒO‚Ìƒnƒ“ƒhƒ‹ */
+	HINSTANCE	m_hInstance;	/* ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ« */
+	HWND		m_hwndParent;	/* ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ« */
+	HWND		m_hWnd;			/* ã“ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒãƒ³ãƒ‰ãƒ« */
 
-	const TCHAR*	m_pszTitle;		/* ƒ_ƒCƒAƒƒOƒ^ƒCƒgƒ‹ */
-	const TCHAR*	m_pszMessage;	/* ƒƒbƒZ[ƒW */
-	int			m_nMaxTextLen;	/* “ü—ÍƒTƒCƒYãŒÀ */
-//	char*		m_pszText;		/* ƒeƒLƒXƒg */
-	CNativeT	m_cmemText;		/* ƒeƒLƒXƒg */
+	const TCHAR*	m_pszTitle;		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚¿ã‚¤ãƒˆãƒ« */
+	const TCHAR*	m_pszMessage;	/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ */
+	int			m_nMaxTextLen;	/* å…¥åŠ›ã‚µã‚¤ã‚ºä¸Šé™ */
+//	char*		m_pszText;		/* ãƒ†ã‚­ã‚¹ãƒˆ */
+	CNativeT	m_cmemText;		/* ãƒ†ã‚­ã‚¹ãƒˆ */
 protected:
 	/*
-	||  ŽÀ‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 };
 

--- a/sakura_core/dlg/CDlgJump.cpp
+++ b/sakura_core/dlg/CDlgJump.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief w’ès‚Ö‚ÌƒWƒƒƒ“ƒvƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief æŒ‡å®šè¡Œã¸ã®ã‚¸ãƒ£ãƒ³ãƒ—ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date	1998/05/31 ì¬
+	@date	1998/05/31 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -20,23 +20,23 @@
 #include "doc/CEditDoc.h"
 #include "func/Funccode.h"		// Stonee, 2001/03/12
 #include "outline/CFuncInfo.h"
-#include "outline/CFuncInfoArr.h"// 2002/2/10 aroka ƒwƒbƒ_®—
+#include "outline/CFuncInfoArr.h"// 2002/2/10 aroka ãƒ˜ãƒƒãƒ€æ•´ç†
 #include "util/shell.h"
 #include "window/CEditWnd.h"
 #include "sakura_rc.h"
 #include "sakura.hh"
 
-// ƒWƒƒƒ“ƒv CDlgJump.cpp	//@@@ 2002.01.07 add start MIK
+// ã‚¸ãƒ£ãƒ³ãƒ— CDlgJump.cpp	//@@@ 2002.01.07 add start MIK
 const DWORD p_helpids[] = {	//12800
-	IDC_BUTTON_JUMP,				HIDC_JUMP_BUTTON_JUMP,			//ƒWƒƒƒ“ƒv
-	IDCANCEL,						HIDCANCEL_JUMP,					//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_JUMP_BUTTON_HELP,			//ƒwƒ‹ƒv
+	IDC_BUTTON_JUMP,				HIDC_JUMP_BUTTON_JUMP,			//ã‚¸ãƒ£ãƒ³ãƒ—
+	IDCANCEL,						HIDCANCEL_JUMP,					//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_JUMP_BUTTON_HELP,			//ãƒ˜ãƒ«ãƒ—
 	IDC_CHECK_PLSQL,				HIDC_JUMP_CHECK_PLSQL,			//PL/SQL
 	IDC_COMBO_PLSQLBLOCKS,			HIDC_JUMP_COMBO_PLSQLBLOCKS,	//
-	IDC_EDIT_LINENUM,				HIDC_JUMP_EDIT_LINENUM,			//s”Ô†
+	IDC_EDIT_LINENUM,				HIDC_JUMP_EDIT_LINENUM,			//è¡Œç•ªå·
 	IDC_EDIT_PLSQL_E1,				HIDC_JUMP_EDIT_PLSQL_E1,		//
-	IDC_RADIO_LINENUM_LAYOUT,		HIDC_JUMP_RADIO_LINENUM_LAYOUT,	//Ü‚è•Ô‚µ’PˆÊ
-	IDC_RADIO_LINENUM_CRLF,			HIDC_JUMP_RADIO_LINENUM_CRLF,	//‰üs’PˆÊ
+	IDC_RADIO_LINENUM_LAYOUT,		HIDC_JUMP_RADIO_LINENUM_LAYOUT,	//æŠ˜ã‚Šè¿”ã—å˜ä½
+	IDC_RADIO_LINENUM_CRLF,			HIDC_JUMP_RADIO_LINENUM_CRLF,	//æ”¹è¡Œå˜ä½
 	IDC_SPIN_LINENUM,				HIDC_JUMP_EDIT_LINENUM,			//12870,	//
 	IDC_SPIN_PLSQL_E1,				HIDC_JUMP_EDIT_PLSQL_E1,		//12871,	//
 //	IDC_STATIC,						-1,
@@ -45,8 +45,8 @@ const DWORD p_helpids[] = {	//12800
 
 CDlgJump::CDlgJump()
 {
-	m_nLineNum = 0;			/* s”Ô† */
-	m_bPLSQL = FALSE;		/* PL/SQLƒ\[ƒX‚Ì—LŒøs‚© */
+	m_nLineNum = 0;			/* è¡Œç•ªå· */
+	m_bPLSQL = FALSE;		/* PL/SQLã‚½ãƒ¼ã‚¹ã®æœ‰åŠ¹è¡Œã‹ */
 	m_nPLSQL_E1 = 1;
 	m_nPLSQL_E2 = 1;
 
@@ -54,7 +54,7 @@ CDlgJump::CDlgJump()
 	return;
 }
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgJump::DoModal(
 	HINSTANCE	hInstance,
 	HWND		hwndParent,
@@ -65,8 +65,8 @@ int CDlgJump::DoModal(
 }
 
 
-// From Here Oct. 6, 2000 JEPRO added s”Ô†“ü—Íƒ{ƒbƒNƒX‚ÉƒXƒsƒ“ƒRƒ“ƒgƒ[ƒ‹‚ğ•t‚¯‚é‚½‚ß
-// CDlgPrintSetting.cpp‚ÌOnNotify‚ÆOnSpin‹y‚ÑCpropComFile.cpp‚ÌDispatchEvent_p2“à‚Ìcase WM_NOTIFY‚ğQl‚É‚µ‚½
+// From Here Oct. 6, 2000 JEPRO added è¡Œç•ªå·å…¥åŠ›ãƒœãƒƒã‚¯ã‚¹ã«ã‚¹ãƒ”ãƒ³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚’ä»˜ã‘ã‚‹ãŸã‚
+// CDlgPrintSetting.cppã®OnNotifyã¨OnSpinåŠã³CpropComFile.cppã®DispatchEvent_p2å†…ã®case WM_NOTIFYã‚’å‚è€ƒã«ã—ãŸ
 BOOL CDlgJump::OnNotify( WPARAM wParam, LPARAM lParam )
 {
 	NM_UPDOWN*		pMNUD;
@@ -74,10 +74,10 @@ BOOL CDlgJump::OnNotify( WPARAM wParam, LPARAM lParam )
 	int				nData;
 	idCtrl = (int)wParam;
 	pMNUD  = (NM_UPDOWN*)lParam;
-/* ƒXƒsƒ“ƒRƒ“ƒgƒ[ƒ‹‚Ìˆ— */
+/* ã‚¹ãƒ”ãƒ³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®å‡¦ç† */
 	switch( idCtrl ){
 	case IDC_SPIN_LINENUM:
-	/* ƒWƒƒƒ“ƒv‚µ‚½‚¢s”Ô†‚Ìw’è */
+	/* ã‚¸ãƒ£ãƒ³ãƒ—ã—ãŸã„è¡Œç•ªå·ã®æŒ‡å®š */
 		nData = ::GetDlgItemInt( GetHwnd(), IDC_EDIT_LINENUM, NULL, FALSE );
 		if( pMNUD->iDelta < 0 ){
 			++nData;
@@ -129,11 +129,11 @@ BOOL CDlgJump::OnBnClicked( int wID )
 {
 	switch( wID ){
 	case IDC_BUTTON_HELP:
-		/* uw’ès‚ÖƒWƒƒƒ“ƒvv‚Ìƒwƒ‹ƒv */
-		//Stonee, 2001/03/12 ‘ælˆø”‚ğA‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_JUMP_DIALOG) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ã€ŒæŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—ã€ã®ãƒ˜ãƒ«ãƒ— */
+		//Stonee, 2001/03/12 ç¬¬å››å¼•æ•°ã‚’ã€æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_JUMP_DIALOG) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
-	case IDC_CHECK_PLSQL:		/* PL/SQLƒ\[ƒX‚Ì—LŒøs‚© */
+	case IDC_CHECK_PLSQL:		/* PL/SQLã‚½ãƒ¼ã‚¹ã®æœ‰åŠ¹è¡Œã‹ */
 		if( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_PLSQL ) ){
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_LABEL_PLSQL1 ), TRUE );	//Sept. 12, 2000 JEPRO
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_LABEL_PLSQL2 ), TRUE );	//Sept. 12, 2000 JEPRO
@@ -154,7 +154,7 @@ BOOL CDlgJump::OnBnClicked( int wID )
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_LINENUM_LAYOUT ), TRUE );
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_LINENUM_CRLF ), TRUE );
 		}
-		/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+		/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 		if( m_pShareData->m_bLineNumIsCRLF_ForJump ){
 			::CheckDlgButton( GetHwnd(), IDC_RADIO_LINENUM_LAYOUT, FALSE );
 			::CheckDlgButton( GetHwnd(), IDC_RADIO_LINENUM_CRLF, TRUE );
@@ -163,33 +163,33 @@ BOOL CDlgJump::OnBnClicked( int wID )
 			::CheckDlgButton( GetHwnd(), IDC_RADIO_LINENUM_CRLF, FALSE );
 		}
 		return TRUE;
-	case IDC_BUTTON_JUMP:			/* w’ès‚ÖƒWƒƒƒ“ƒv */	//Feb. 20, 2001 JEPRO ƒ{ƒ^ƒ“–¼‚ğ[IDOK]¨[IDC_BUTTON_JUMP]‚É•ÏX
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-		//From Here Feb. 20, 2001 JEPRO Ÿs‚ğƒRƒƒ“ƒgƒAƒEƒg (CEditView_Command.cpp ‚Ì Command_JUMP ‚àŠÖŒW‚µ‚Ä‚¢‚é‚Ì‚ÅQÆ‚Ì‚±‚Æ)
+	case IDC_BUTTON_JUMP:			/* æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ— */	//Feb. 20, 2001 JEPRO ãƒœã‚¿ãƒ³åã‚’[IDOK]â†’[IDC_BUTTON_JUMP]ã«å¤‰æ›´
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+		//From Here Feb. 20, 2001 JEPRO æ¬¡è¡Œã‚’ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆ (CEditView_Command.cpp ã® Command_JUMP ã‚‚é–¢ä¿‚ã—ã¦ã„ã‚‹ã®ã§å‚ç…§ã®ã“ã¨)
 //		::EndDialog( GetHwnd(), GetData() );
-//		Ÿs‚©‚ç’Ç‰Á
+//		æ¬¡è¡Œã‹ã‚‰è¿½åŠ 
 		if( 0 < GetData() ){
 			CloseDialog( 1 );
 		}else{
 			OkMessage( GetHwnd(), LS(STR_DLGJUMP1) );
 		}
 //To Here Feb. 20, 2001
-		{	//@@@ 2002.2.2 YAZAKI w’ès‚ÖƒWƒƒƒ“ƒv‚ğAƒ_ƒCƒAƒƒO‚ğ•\¦‚·‚éƒRƒ}ƒ“ƒh‚ÆAÀÛ‚ÉƒWƒƒƒ“ƒv‚·‚éƒRƒ}ƒ“ƒh‚É•ª—£B
+		{	//@@@ 2002.2.2 YAZAKI æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—ã‚’ã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è¡¨ç¤ºã™ã‚‹ã‚³ãƒãƒ³ãƒ‰ã¨ã€å®Ÿéš›ã«ã‚¸ãƒ£ãƒ³ãƒ—ã™ã‚‹ã‚³ãƒãƒ³ãƒ‰ã«åˆ†é›¢ã€‚
 			CEditDoc*		pCEditDoc = (CEditDoc*)m_lParam;
-			pCEditDoc->m_pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_JUMP, true, 0, 0, 0, 0);	//	ƒWƒƒƒ“ƒvƒRƒ}ƒ“ƒh”­s
+			pCEditDoc->m_pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_JUMP, true, 0, 0, 0, 0);	//	ã‚¸ãƒ£ãƒ³ãƒ—ã‚³ãƒãƒ³ãƒ‰ç™ºè¡Œ
 		}
 		return TRUE;
 	case IDCANCEL:
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgJump::SetData( void )
 {
 	CEditDoc*		pCEditDoc = (CEditDoc*)m_lParam;
@@ -197,26 +197,26 @@ void CDlgJump::SetData( void )
 	int				i;
 	HWND			hwndCtrl;
 	wchar_t			szText[1024];
-	int				nIndexCurSel = 0;	//	Sep. 11, 2004 genta ‰Šú‰»
+	int				nIndexCurSel = 0;	//	Sep. 11, 2004 genta åˆæœŸåŒ–
 	int				nIndex;
-	int				nWorkLine; //$$ ğŒ‚É‚æ‚èAƒŒƒCƒAƒEƒgEƒƒWƒbƒN‚Ì’PˆÊ‚ª¬İ‚·‚é‚½‚ßAƒ~ƒX‚ÌŒ´ˆö‚É‚È‚è‚â‚·‚¢
+	int				nWorkLine; //$$ æ¡ä»¶ã«ã‚ˆã‚Šã€ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆãƒ»ãƒ­ã‚¸ãƒƒã‚¯ã®å˜ä½ãŒæ··åœ¨ã™ã‚‹ãŸã‚ã€ãƒŸã‚¹ã®åŸå› ã«ãªã‚Šã‚„ã™ã„
 	int				nPLSQLBlockNum;
 
 //	GetHwnd() = hwndDlg;
-//From Here Oct. 7, 2000 JEPRO ‘O‰ñ“ü—Í‚µ‚½s”Ô†‚ğ•Û‚·‚é‚æ‚¤‚É‰ºs‚ğ•ÏX
-//	::DlgItem_SetText( GetHwnd(), IDC_EDIT_LINENUM, "" );	/* s”Ô† */
+//From Here Oct. 7, 2000 JEPRO å‰å›å…¥åŠ›ã—ãŸè¡Œç•ªå·ã‚’ä¿æŒã™ã‚‹ã‚ˆã†ã«ä¸‹è¡Œã‚’å¤‰æ›´
+//	::DlgItem_SetText( GetHwnd(), IDC_EDIT_LINENUM, "" );	/* è¡Œç•ªå· */
 	if( 0 == m_nLineNum ){
-		::DlgItem_SetText( GetHwnd(), IDC_EDIT_LINENUM, _T("") );	/* s”Ô† */
+		::DlgItem_SetText( GetHwnd(), IDC_EDIT_LINENUM, _T("") );	/* è¡Œç•ªå· */
 	}else{
-		::SetDlgItemInt( GetHwnd(), IDC_EDIT_LINENUM, m_nLineNum, FALSE );	/* ‘O‰ñ‚Ìs”Ô† */
+		::SetDlgItemInt( GetHwnd(), IDC_EDIT_LINENUM, m_nLineNum, FALSE );	/* å‰å›ã®è¡Œç•ªå· */
 	}
 //To Here Oct. 7, 2000
 	::SetDlgItemInt( GetHwnd(), IDC_EDIT_PLSQL_E1, m_nPLSQL_E1, FALSE );
 
-	/* PL/SQLŠÖ”ƒŠƒXƒgì¬ */
+	/* PL/SQLé–¢æ•°ãƒªã‚¹ãƒˆä½œæˆ */
 	hwndCtrl = ::GetDlgItem( GetHwnd(), IDC_COMBO_PLSQLBLOCKS );
 
-/* ƒ^ƒCƒv•Ê‚Éİ’è‚³‚ê‚½ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
+/* ã‚¿ã‚¤ãƒ—åˆ¥ã«è¨­å®šã•ã‚ŒãŸã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
 	if( OUTLINE_PLSQL == pCEditDoc->m_cDocType.GetDocumentAttribute().m_eDefaultOutline ){
 		pCEditDoc->m_cDocOutline.MakeFuncList_PLSQL( &cFuncInfoArr );
 	}
@@ -228,7 +228,7 @@ void CDlgJump::SetData( void )
 			41 == cFuncInfoArr.GetAt( i )->m_nInfo ){
 		}
 		if( 31 == cFuncInfoArr.GetAt( i )->m_nInfo ){
-			if( m_pShareData->m_bLineNumIsCRLF_ForJump ){	/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+			if( m_pShareData->m_bLineNumIsCRLF_ForJump ){	/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 				auto_sprintf( szText, LSW(STR_DLGJUMP_PSLQL),
 					cFuncInfoArr.GetAt( i )->m_nFuncLineCRLF,
 					cFuncInfoArr.GetAt( i )->m_cmemFuncName.GetStringPtr()
@@ -240,7 +240,7 @@ void CDlgJump::SetData( void )
 				);
 			}
 			nIndex = Combo_AddString( hwndCtrl, szText );
-			if( m_pShareData->m_bLineNumIsCRLF_ForJump ){	/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+			if( m_pShareData->m_bLineNumIsCRLF_ForJump ){	/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 				Combo_SetItemData( hwndCtrl, nIndex, (Int)cFuncInfoArr.GetAt( i )->m_nFuncLineCRLF );
 			}
 			else{
@@ -249,7 +249,7 @@ void CDlgJump::SetData( void )
 			nPLSQLBlockNum++;
 		}
 		if( 41 == cFuncInfoArr.GetAt( i )->m_nInfo ){
-			if( m_pShareData->m_bLineNumIsCRLF_ForJump ){	/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+			if( m_pShareData->m_bLineNumIsCRLF_ForJump ){	/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 				auto_sprintf( szText, LSW(STR_DLGJUMP_PSLQL),
 					cFuncInfoArr.GetAt( i )->m_nFuncLineCRLF,
 					cFuncInfoArr.GetAt( i )->m_cmemFuncName.GetStringPtr()
@@ -261,7 +261,7 @@ void CDlgJump::SetData( void )
 				);
 			}
 			nIndexCurSel = nIndex = Combo_AddString( hwndCtrl, szText );
-			if( m_pShareData->m_bLineNumIsCRLF_ForJump ){	/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+			if( m_pShareData->m_bLineNumIsCRLF_ForJump ){	/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 				nWorkLine = (Int)cFuncInfoArr.GetAt( i )->m_nFuncLineCRLF;
 				Combo_SetItemData( hwndCtrl, nIndex, (Int)cFuncInfoArr.GetAt( i )->m_nFuncLineCRLF );
 			}else{
@@ -273,16 +273,16 @@ void CDlgJump::SetData( void )
 	}
 	Combo_SetCurSel( hwndCtrl, nIndexCurSel );
 
-	/* PL/SQL‚ÌƒpƒbƒP[ƒW–{‘Ì‚ªŒŸo‚³‚ê‚½ê‡ */
+	/* PL/SQLã®ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸æœ¬ä½“ãŒæ¤œå‡ºã•ã‚ŒãŸå ´åˆ */
 	if( -1 != nWorkLine ){
 		m_nPLSQL_E1 = nWorkLine;
 		::SetDlgItemInt( GetHwnd(), IDC_EDIT_PLSQL_E1, m_nPLSQL_E1, FALSE );
 	}
-	/* PL/SQL‚ÌƒpƒbƒP[ƒWƒuƒƒbƒN‚ªŒŸo‚³‚ê‚½ê‡ */
+	/* PL/SQLã®ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸ãƒ–ãƒ­ãƒƒã‚¯ãŒæ¤œå‡ºã•ã‚ŒãŸå ´åˆ */
 	if( 0 < nPLSQLBlockNum ){
 		m_bPLSQL = TRUE;
 	}
-	::CheckDlgButton( GetHwnd(), IDC_CHECK_PLSQL, m_bPLSQL );	/* PL/SQLƒ\[ƒX‚Ì—LŒøs‚© */
+	::CheckDlgButton( GetHwnd(), IDC_CHECK_PLSQL, m_bPLSQL );	/* PL/SQLã‚½ãƒ¼ã‚¹ã®æœ‰åŠ¹è¡Œã‹ */
 	if( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_PLSQL ) ){
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_LABEL_PLSQL1 ), TRUE );	//Sept. 12, 2000 JEPRO
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_LABEL_PLSQL2 ), TRUE );	//Sept. 12, 2000 JEPRO
@@ -303,7 +303,7 @@ void CDlgJump::SetData( void )
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_LINENUM_LAYOUT ), TRUE );
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_RADIO_LINENUM_CRLF ), TRUE );
 	}
-	/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+	/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 	if( m_pShareData->m_bLineNumIsCRLF_ForJump ){
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_LINENUM_LAYOUT, FALSE );
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_LINENUM_CRLF, TRUE );
@@ -317,20 +317,20 @@ void CDlgJump::SetData( void )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-/*   TRUE==³í   FALSE==“ü—ÍƒGƒ‰[  */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+/*   TRUE==æ­£å¸¸   FALSE==å…¥åŠ›ã‚¨ãƒ©ãƒ¼  */
 int CDlgJump::GetData( void )
 {
 	BOOL	pTranslated;
 
-	/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+	/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_LINENUM_LAYOUT ) ){
 		m_pShareData->m_bLineNumIsCRLF_ForJump = false;
 	}else{
 		m_pShareData->m_bLineNumIsCRLF_ForJump = true;
 	}
 
-	/* PL/SQLƒ\[ƒX‚Ì—LŒøs‚© */
+	/* PL/SQLã‚½ãƒ¼ã‚¹ã®æœ‰åŠ¹è¡Œã‹ */
 	m_bPLSQL = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_PLSQL );
 	m_nPLSQL_E1 = ::GetDlgItemInt( GetHwnd(), IDC_EDIT_PLSQL_E1, &pTranslated, FALSE );
 	if( m_nPLSQL_E1 == 0 && !pTranslated ){
@@ -342,7 +342,7 @@ int CDlgJump::GetData( void )
 //		m_nPLSQL_E2 = 1;
 //	}
 
-	/* s”Ô† */
+	/* è¡Œç•ªå· */
 	m_nLineNum = ::GetDlgItemInt( GetHwnd(), IDC_EDIT_LINENUM, &pTranslated, FALSE );
 	if( m_nLineNum == 0 && !pTranslated ){
 		return FALSE;

--- a/sakura_core/dlg/CDlgJump.h
+++ b/sakura_core/dlg/CDlgJump.h
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief w’ès‚Ö‚ÌƒWƒƒƒ“ƒvƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief æŒ‡å®šè¡Œã¸ã®ã‚¸ãƒ£ãƒ³ãƒ—ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date 1998/05/31 ì¬
-	@date 1999/12/05 Äì¬
+	@date 1998/05/31 ä½œæˆ
+	@date 1999/12/05 å†ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -20,7 +20,7 @@ class CDlgJump;
 #define _CDLGJUMP_H_
 
 #include "dlg/CDialog.h"
-//! w’ès‚Ö‚ÌƒWƒƒƒ“ƒvƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+//! æŒ‡å®šè¡Œã¸ã®ã‚¸ãƒ£ãƒ³ãƒ—ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 class CDlgJump : public CDialog
 {
 public:
@@ -31,22 +31,22 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, LPARAM );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
-	int			m_nLineNum;		/*!< s”Ô† */
-	BOOL		m_bPLSQL;		/*!< PL/SQLƒ\[ƒX‚Ì—LŒøs‚© */
+	int			m_nLineNum;		/*!< è¡Œç•ªå· */
+	BOOL		m_bPLSQL;		/*!< PL/SQLã‚½ãƒ¼ã‚¹ã®æœ‰åŠ¹è¡Œã‹ */
 	int			m_nPLSQL_E1;
 	int			m_nPLSQL_E2;
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL OnNotify( WPARAM,  LPARAM );	//	Oct. 6, 2000 JEPRO added for Spin control
 	BOOL OnCbnSelChange( HWND, int );
 	BOOL OnBnClicked( int );
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
-	void SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 };
 
 

--- a/sakura_core/dlg/CDlgOpenFile.h
+++ b/sakura_core/dlg/CDlgOpenFile.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date	1998/08/10 ì¬
+	@date	1998/08/10 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -32,22 +32,22 @@ struct SSaveInfo;	// doc/CDocListener.h
 struct OPENFILENAMEZ;
 class CDlgOpenFileMem;
 
-/*! ƒtƒBƒ‹ƒ^İ’è */
+/*! ãƒ•ã‚£ãƒ«ã‚¿è¨­å®š */
 enum EFilter {
-	EFITER_NONE,		//!< ‚È‚µ
-	EFITER_TEXT,		//!< ƒeƒLƒXƒg
-	EFITER_MACRO,		//!< ƒ}ƒNƒ
+	EFITER_NONE,		//!< ãªã—
+	EFITER_TEXT,		//!< ãƒ†ã‚­ã‚¹ãƒˆ
+	EFITER_MACRO,		//!< ãƒã‚¯ãƒ­
 	EFITER_MAX,
 };
 
-/*!	ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+/*!	ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 */
 class CDlgOpenFile
 {
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CDlgOpenFile();
 	~CDlgOpenFile();
 	void Create(
@@ -59,38 +59,38 @@ public:
 		const std::vector<LPCTSTR>& vOPENFOLDER		= std::vector<LPCTSTR>()
 	);
 
-	//‘€ì
-	bool DoModal_GetOpenFileName( TCHAR*, EFilter eAddFileter = EFITER_TEXT );	/* ŠJ‚­ƒ_ƒCƒAƒƒO ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */	//2002/08/21 moca	ˆø”’Ç‰Á
-	bool DoModal_GetSaveFileName( TCHAR* );	/* •Û‘¶ƒ_ƒCƒAƒƒO ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */	//2002/08/21 30,2002 moca	ˆø”’Ç‰Á
-	bool DoModalOpenDlg( SLoadInfo* pLoadInfo, std::vector<std::tstring>*, bool bOptions = true );	/* ŠJ‚­ƒ_ƒCƒAƒO ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
-	bool DoModalSaveDlg( SSaveInfo*	pSaveInfo, bool bSimpleMode );	/* •Û‘¶ƒ_ƒCƒAƒƒO ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	//æ“ä½œ
+	bool DoModal_GetOpenFileName( TCHAR*, EFilter eAddFileter = EFITER_TEXT );	/* é–‹ããƒ€ã‚¤ã‚¢ãƒ­ã‚° ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */	//2002/08/21 moca	å¼•æ•°è¿½åŠ 
+	bool DoModal_GetSaveFileName( TCHAR* );	/* ä¿å­˜ãƒ€ã‚¤ã‚¢ãƒ­ã‚° ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */	//2002/08/21 30,2002 moca	å¼•æ•°è¿½åŠ 
+	bool DoModalOpenDlg( SLoadInfo* pLoadInfo, std::vector<std::tstring>*, bool bOptions = true );	/* é–‹ããƒ€ã‚¤ã‚¢ã‚° ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
+	bool DoModalSaveDlg( SSaveInfo*	pSaveInfo, bool bSimpleMode );	/* ä¿å­˜ãƒ€ã‚¤ã‚¢ãƒ­ã‚° ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 protected:
 	CDlgOpenFileMem*	m_mem;
 
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 
-	//	May 29, 2004 genta ƒGƒ‰[ˆ—‚ğ‚Ü‚Æ‚ß‚é (advised by MIK)
+	//	May 29, 2004 genta ã‚¨ãƒ©ãƒ¼å‡¦ç†ã‚’ã¾ã¨ã‚ã‚‹ (advised by MIK)
 	void	DlgOpenFail(void);
 
-	// 2005.11.02 ryoji OS ƒo[ƒWƒ‡ƒ“‘Î‰‚Ì OPENFILENAME ‰Šú‰»—pŠÖ”
+	// 2005.11.02 ryoji OS ãƒãƒ¼ã‚¸ãƒ§ãƒ³å¯¾å¿œã® OPENFILENAME åˆæœŸåŒ–ç”¨é–¢æ•°
 	void InitOfn( OPENFILENAMEZ* );
 
-	// 2005.11.02 ryoji ‰ŠúƒŒƒCƒAƒEƒgİ’èˆ—
+	// 2005.11.02 ryoji åˆæœŸãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¨­å®šå‡¦ç†
 	static void InitLayout( HWND hwndOpenDlg, HWND hwndDlg, HWND hwndBaseCtrl );
 
-	// 2006.09.03 Moca ƒtƒ@ƒCƒ‹ƒ_ƒCƒAƒƒO‚ÌƒGƒ‰[‰ñ”ğ
-	//! ƒŠƒgƒ‰ƒC‹@”\•t‚« GetOpenFileName
+	// 2006.09.03 Moca ãƒ•ã‚¡ã‚¤ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚¨ãƒ©ãƒ¼å›é¿
+	//! ãƒªãƒˆãƒ©ã‚¤æ©Ÿèƒ½ä»˜ã GetOpenFileName
 	bool _GetOpenFileNameRecover( OPENFILENAMEZ* ofn );
-	//! ƒŠƒgƒ‰ƒC‹@”\•t‚« GetOpenFileName
+	//! ãƒªãƒˆãƒ©ã‚¤æ©Ÿèƒ½ä»˜ã GetOpenFileName
 	bool GetSaveFileNameRecover( OPENFILENAMEZ* ofn );
 
 	friend UINT_PTR CALLBACK OFNHookProc( HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam );
 
 public:
-	// İ’èƒtƒHƒ‹ƒ_‘Š‘Îƒtƒ@ƒCƒ‹‘I‘ğ(‹¤—Lƒf[ƒ^,iniˆÊ’uˆË‘¶)
+	// è¨­å®šãƒ•ã‚©ãƒ«ãƒ€ç›¸å¯¾ãƒ•ã‚¡ã‚¤ãƒ«é¸æŠ(å…±æœ‰ãƒ‡ãƒ¼ã‚¿,iniä½ç½®ä¾å­˜)
 	static BOOL SelectFile(HWND parent, HWND hwndCtl, const TCHAR* filter, bool resolvePath, EFilter eAddFilter = EFITER_TEXT);
 
 private:

--- a/sakura_core/dlg/CDlgPluginOption.h
+++ b/sakura_core/dlg/CDlgPluginOption.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒvƒ‰ƒOƒCƒ“İ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ãƒ—ãƒ©ã‚°ã‚¤ãƒ³è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Uchi
 	@date 2010/3/22
@@ -35,18 +35,18 @@
 
 class CPropPlugin;
 
-/*!	@brief uƒvƒ‰ƒOƒCƒ“İ’èvƒ_ƒCƒAƒƒO
+/*!	@brief ã€Œãƒ—ãƒ©ã‚°ã‚¤ãƒ³è¨­å®šã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
-	‹¤’Êİ’è‚Ìƒvƒ‰ƒOƒCƒ“İ’è‚ÅCw’èƒvƒ‰ƒOƒCƒ“‚ÌƒIƒvƒVƒ‡ƒ“‚ğİ’è‚·‚é‚½‚ß‚É
-	g—p‚³‚ê‚éƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+	å…±é€šè¨­å®šã®ãƒ—ãƒ©ã‚°ã‚¤ãƒ³è¨­å®šã§ï¼ŒæŒ‡å®šãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã‚’è¨­å®šã™ã‚‹ãŸã‚ã«
+	ä½¿ç”¨ã•ã‚Œã‚‹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 */
 
-// •ÒWÅ‘å’·
+// ç·¨é›†æœ€å¤§é•·
 #define MAX_LENGTH_VALUE	1024
 
 typedef std::wstring wstring;
 
-// Œ^ 
+// å‹ 
 static const wstring	OPTION_TYPE_BOOL = wstring( L"bool" );
 static const wstring	OPTION_TYPE_INT  = wstring( L"int" );
 static const wstring	OPTION_TYPE_SEL  = wstring( L"sel" );
@@ -64,11 +64,11 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, CPropPlugin*, int );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, CPropPlugin*, int );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL	OnInitDialog( HWND, WPARAM wParam, LPARAM lParam );
 	BOOL	OnBnClicked( int );
@@ -78,23 +78,23 @@ protected:
 	BOOL	OnActivate( WPARAM wParam, LPARAM lParam );
 	LPVOID	GetHelpIdTable( void );
 
-	void	SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int		GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void	SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int		GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 
-	void	ChangeListPosition( void );					// •ÒW—Ìˆæ‚ğƒŠƒXƒgƒrƒ…[‚É‡‚¹‚ÄØ‘Ö‚¦‚é
-	void	MoveFocusToEdit( void );					// •ÒW—Ìˆæ‚ÉƒtƒH[ƒJƒX‚ğˆÚ‚·
+	void	ChangeListPosition( void );					// ç·¨é›†é ˜åŸŸã‚’ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã«åˆã›ã¦åˆ‡æ›¿ãˆã‚‹
+	void	MoveFocusToEdit( void );					// ç·¨é›†é ˜åŸŸã«ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã‚’ç§»ã™
 	void	SetToEdit( int );
 	void	SetFromEdit( int );
-	void	SelectEdit( int );							// •ÒW—Ìˆæ‚ÌØ‚è‘Ö‚¦
-	void	SepSelect( wstring, wstring*, wstring* );	// ‘I‘ğ—p•¶š—ñ•ª‰ğ
-	void	SelectDirectory( int iLine );				// ƒfƒBƒŒƒNƒgƒŠ‚ğ‘I‘ğ‚·‚é
+	void	SelectEdit( int );							// ç·¨é›†é ˜åŸŸã®åˆ‡ã‚Šæ›¿ãˆ
+	void	SepSelect( wstring, wstring*, wstring* );	// é¸æŠç”¨æ–‡å­—åˆ—åˆ†è§£
+	void	SelectDirectory( int iLine );				// ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’é¸æŠã™ã‚‹
 
 private:
 	CPlugin*		m_cPlugin;
 	CPropPlugin*	m_cPropPlugin;
-	int 			m_ID;			// ƒvƒ‰ƒOƒCƒ“”Ô†iƒGƒfƒBƒ^‚ª‚Ó‚é”Ô†j
-	int				m_Line;			// Œ»İ•ÒW’†‚ÌƒIƒvƒVƒ‡ƒ“s”Ô†
-	std::tstring	m_sReadMeName;	// ReadMe ƒtƒ@ƒCƒ‹–¼
+	int 			m_ID;			// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç•ªå·ï¼ˆã‚¨ãƒ‡ã‚£ã‚¿ãŒãµã‚‹ç•ªå·ï¼‰
+	int				m_Line;			// ç¾åœ¨ç·¨é›†ä¸­ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³è¡Œç•ªå·
+	std::tstring	m_sReadMeName;	// ReadMe ãƒ•ã‚¡ã‚¤ãƒ«å
 };
 
 #endif /* SAKURA_CDLGPLUGINOPTION_7BD4A901_BC40_4CA1_8311_85B8CAA783F08_H_ */

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -1,16 +1,16 @@
-/*!	@file
-	@brief ˆóüİ’èƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief å°åˆ·è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
 	
-	@date 2006.08.14 Moca —p†•ûŒüƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ğ”p~‚µAƒ{ƒ^ƒ“‚ğ—LŒø‰»D
-		—p†–¼ˆê——‚Ìd•¡íœD
+	@date 2006.08.14 Moca ç”¨ç´™æ–¹å‘ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã‚’å»ƒæ­¢ã—ã€ãƒœã‚¿ãƒ³ã‚’æœ‰åŠ¹åŒ–ï¼
+		ç”¨ç´™åä¸€è¦§ã®é‡è¤‡å‰Šé™¤ï¼
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2001, hor, Stonee
 	Copyright (C) 2002, MIK, aroka, YAZAKI
-	Copyright (C) 2003, ‚©‚ë‚Æ
+	Copyright (C) 2003, ã‹ã‚ã¨
 	Copyright (C) 2006, ryoji
 
 	This software is provided 'as-is', without any express or implied
@@ -42,51 +42,51 @@
 #include "sakura_rc.h"	// 2002/2/10 aroka
 #include "sakura.hh"
 
-// ˆóüİ’è CDlgPrintSetting.cpp	//@@@ 2002.01.07 add start MIK
+// å°åˆ·è¨­å®š CDlgPrintSetting.cpp	//@@@ 2002.01.07 add start MIK
 const DWORD p_helpids[] = {	//12500
-	IDC_COMBO_SETTINGNAME,			HIDC_PS_COMBO_SETTINGNAME,	//ƒy[ƒWİ’è
-	IDC_BUTTON_EDITSETTINGNAME,		HIDC_PS_BUTTON_EDITSETTINGNAME,	//İ’è–¼•ÏX
-	IDC_COMBO_FONT_HAN,				HIDC_PS_COMBO_FONT_HAN,		//”¼ŠpƒtƒHƒ“ƒg
-	IDC_COMBO_FONT_ZEN,				HIDC_PS_COMBO_FONT_ZEN,		//‘SŠpƒtƒHƒ“ƒg
-	IDC_EDIT_FONTHEIGHT,			HIDC_PS_EDIT_FONTHEIGHT,	//ƒtƒHƒ“ƒg‚
+	IDC_COMBO_SETTINGNAME,			HIDC_PS_COMBO_SETTINGNAME,	//ãƒšãƒ¼ã‚¸è¨­å®š
+	IDC_BUTTON_EDITSETTINGNAME,		HIDC_PS_BUTTON_EDITSETTINGNAME,	//è¨­å®šåå¤‰æ›´
+	IDC_COMBO_FONT_HAN,				HIDC_PS_COMBO_FONT_HAN,		//åŠè§’ãƒ•ã‚©ãƒ³ãƒˆ
+	IDC_COMBO_FONT_ZEN,				HIDC_PS_COMBO_FONT_ZEN,		//å…¨è§’ãƒ•ã‚©ãƒ³ãƒˆ
+	IDC_EDIT_FONTHEIGHT,			HIDC_PS_EDIT_FONTHEIGHT,	//ãƒ•ã‚©ãƒ³ãƒˆé«˜
 	IDC_SPIN_FONTHEIGHT,			HIDC_PS_EDIT_FONTHEIGHT,	//12570,
 	IDC_SPIN_LINESPACE,				HIDC_PS_EDIT_LINESPACE,		//12571,
-	IDC_EDIT_LINESPACE,				HIDC_PS_EDIT_LINESPACE,		//s‘—‚è
-	IDC_EDIT_DANSUU,				HIDC_PS_EDIT_DANSUU,		//’i”
+	IDC_EDIT_LINESPACE,				HIDC_PS_EDIT_LINESPACE,		//è¡Œé€ã‚Š
+	IDC_EDIT_DANSUU,				HIDC_PS_EDIT_DANSUU,		//æ®µæ•°
 	IDC_SPIN_DANSUU,				HIDC_PS_EDIT_DANSUU,		//12572,
-	IDC_EDIT_DANSPACE,				HIDC_PS_EDIT_DANSPACE,		//’i‚ÌŒ„ŠÔ
+	IDC_EDIT_DANSPACE,				HIDC_PS_EDIT_DANSPACE,		//æ®µã®éš™é–“
 	IDC_SPIN_DANSPACE,				HIDC_PS_EDIT_DANSPACE,		//12573,
-	IDC_COMBO_PAPER,				HIDC_PS_COMBO_PAPER,		//—p†ƒTƒCƒY
-	IDC_RADIO_PORTRAIT,				HIDC_PS_STATIC_PAPERORIENT,	//‰¡Œü‚«
-	IDC_RADIO_LANDSCAPE,			HIDC_PS_STATIC_PAPERORIENT,	//cŒü‚«
-	IDC_EDIT_MARGINTY,				HIDC_PS_EDIT_MARGINTY,		//—]”’ã
+	IDC_COMBO_PAPER,				HIDC_PS_COMBO_PAPER,		//ç”¨ç´™ã‚µã‚¤ã‚º
+	IDC_RADIO_PORTRAIT,				HIDC_PS_STATIC_PAPERORIENT,	//æ¨ªå‘ã
+	IDC_RADIO_LANDSCAPE,			HIDC_PS_STATIC_PAPERORIENT,	//ç¸¦å‘ã
+	IDC_EDIT_MARGINTY,				HIDC_PS_EDIT_MARGINTY,		//ä½™ç™½ä¸Š
 	IDC_SPIN_MARGINTY,				HIDC_PS_EDIT_MARGINTY,		//12574,
-	IDC_EDIT_MARGINBY,				HIDC_PS_EDIT_MARGINBY,		//—]”’‰º
+	IDC_EDIT_MARGINBY,				HIDC_PS_EDIT_MARGINBY,		//ä½™ç™½ä¸‹
 	IDC_SPIN_MARGINBY,				HIDC_PS_EDIT_MARGINBY,		//12575,
-	IDC_EDIT_MARGINLX,				HIDC_PS_EDIT_MARGINLX,		//—]”’¶
+	IDC_EDIT_MARGINLX,				HIDC_PS_EDIT_MARGINLX,		//ä½™ç™½å·¦
 	IDC_SPIN_MARGINLX,				HIDC_PS_EDIT_MARGINLX,		//12576,
-	IDC_EDIT_MARGINRX,				HIDC_PS_EDIT_MARGINRX,		//—]”’‰E
+	IDC_EDIT_MARGINRX,				HIDC_PS_EDIT_MARGINRX,		//ä½™ç™½å³
 	IDC_SPIN_MARGINRX,				HIDC_PS_EDIT_MARGINRX,		//12577,
-	IDC_CHECK_WORDWRAP,				HIDC_PS_CHECK_WORDWRAP,		//ƒ[ƒhƒ‰ƒbƒv
-	IDC_CHECK_LINENUMBER,			HIDC_PS_CHECK_LINENUMBER,	//s”Ô†
-	IDC_CHECK_PS_KINSOKUHEAD,		HIDC_PS_CHECK_KINSOKUHEAD,	//s“ª‹Ö‘¥	//@@@ 2002.04.09 MIK
-	IDC_CHECK_PS_KINSOKUTAIL,		HIDC_PS_CHECK_KINSOKUTAIL,	//s––‹Ö‘¥	//@@@ 2002.04.09 MIK
-	IDC_CHECK_PS_KINSOKURET,		HIDC_PS_CHECK_KINSOKURET,	//‰üs•¶š‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.14 MIK
-	IDC_CHECK_PS_KINSOKUKUTO,		HIDC_PS_CHECK_KINSOKUKUTO,	//‹å“Ç“_‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.17 MIK
-	IDC_CHECK_COLORPRINT,			HIDC_PS_CHECK_COLORPRINT,	//ƒJƒ‰[ˆóü			// 2013/4/26 Uchi
-	IDC_EDIT_HEAD1,					HIDC_PS_EDIT_HEAD1,			//ƒwƒbƒ_[(¶Šñ‚¹)		// 2006.10.11 ryoji
-	IDC_EDIT_HEAD2,					HIDC_PS_EDIT_HEAD2,			//ƒwƒbƒ_[(’†‰›Šñ‚¹)	// 2006.10.11 ryoji
-	IDC_EDIT_HEAD3,					HIDC_PS_EDIT_HEAD3,			//ƒwƒbƒ_[(‰EŠñ‚¹)		// 2006.10.11 ryoji
-	IDC_EDIT_FOOT1,					HIDC_PS_EDIT_FOOT1,			//ƒtƒbƒ^[(¶Šñ‚¹)		// 2006.10.11 ryoji
-	IDC_EDIT_FOOT2,					HIDC_PS_EDIT_FOOT2,			//ƒtƒbƒ^[(’†‰›Šñ‚¹)	// 2006.10.11 ryoji
-	IDC_EDIT_FOOT3,					HIDC_PS_EDIT_FOOT3,			//ƒtƒbƒ^[(‰EŠñ‚¹)		// 2006.10.11 ryoji
-	IDC_CHECK_USE_FONT_HEAD,		HIDC_PS_FONT_HEAD,			//ƒwƒbƒ_[(ƒtƒHƒ“ƒg)	// 2013.05.16 Uchi
-	IDC_BUTTON_FONT_HEAD,			HIDC_PS_FONT_HEAD,			//ƒwƒbƒ_[(ƒtƒHƒ“ƒg)	// 2013.05.16 Uchi
-	IDC_CHECK_USE_FONT_FOOT,		HIDC_PS_FONT_FOOT,			//ƒtƒbƒ^[(ƒtƒHƒ“ƒg)	// 2013/5/16 Uchi
-	IDC_BUTTON_FONT_FOOT,			HIDC_PS_FONT_FOOT,			//ƒtƒbƒ^[(ƒtƒHƒ“ƒg)	// 2013/5/16 Uchi
+	IDC_CHECK_WORDWRAP,				HIDC_PS_CHECK_WORDWRAP,		//ãƒ¯ãƒ¼ãƒ‰ãƒ©ãƒƒãƒ—
+	IDC_CHECK_LINENUMBER,			HIDC_PS_CHECK_LINENUMBER,	//è¡Œç•ªå·
+	IDC_CHECK_PS_KINSOKUHEAD,		HIDC_PS_CHECK_KINSOKUHEAD,	//è¡Œé ­ç¦å‰‡	//@@@ 2002.04.09 MIK
+	IDC_CHECK_PS_KINSOKUTAIL,		HIDC_PS_CHECK_KINSOKUTAIL,	//è¡Œæœ«ç¦å‰‡	//@@@ 2002.04.09 MIK
+	IDC_CHECK_PS_KINSOKURET,		HIDC_PS_CHECK_KINSOKURET,	//æ”¹è¡Œæ–‡å­—ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.14 MIK
+	IDC_CHECK_PS_KINSOKUKUTO,		HIDC_PS_CHECK_KINSOKUKUTO,	//å¥èª­ç‚¹ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.17 MIK
+	IDC_CHECK_COLORPRINT,			HIDC_PS_CHECK_COLORPRINT,	//ã‚«ãƒ©ãƒ¼å°åˆ·			// 2013/4/26 Uchi
+	IDC_EDIT_HEAD1,					HIDC_PS_EDIT_HEAD1,			//ãƒ˜ãƒƒãƒ€ãƒ¼(å·¦å¯„ã›)		// 2006.10.11 ryoji
+	IDC_EDIT_HEAD2,					HIDC_PS_EDIT_HEAD2,			//ãƒ˜ãƒƒãƒ€ãƒ¼(ä¸­å¤®å¯„ã›)	// 2006.10.11 ryoji
+	IDC_EDIT_HEAD3,					HIDC_PS_EDIT_HEAD3,			//ãƒ˜ãƒƒãƒ€ãƒ¼(å³å¯„ã›)		// 2006.10.11 ryoji
+	IDC_EDIT_FOOT1,					HIDC_PS_EDIT_FOOT1,			//ãƒ•ãƒƒã‚¿ãƒ¼(å·¦å¯„ã›)		// 2006.10.11 ryoji
+	IDC_EDIT_FOOT2,					HIDC_PS_EDIT_FOOT2,			//ãƒ•ãƒƒã‚¿ãƒ¼(ä¸­å¤®å¯„ã›)	// 2006.10.11 ryoji
+	IDC_EDIT_FOOT3,					HIDC_PS_EDIT_FOOT3,			//ãƒ•ãƒƒã‚¿ãƒ¼(å³å¯„ã›)		// 2006.10.11 ryoji
+	IDC_CHECK_USE_FONT_HEAD,		HIDC_PS_FONT_HEAD,			//ãƒ˜ãƒƒãƒ€ãƒ¼(ãƒ•ã‚©ãƒ³ãƒˆ)	// 2013.05.16 Uchi
+	IDC_BUTTON_FONT_HEAD,			HIDC_PS_FONT_HEAD,			//ãƒ˜ãƒƒãƒ€ãƒ¼(ãƒ•ã‚©ãƒ³ãƒˆ)	// 2013.05.16 Uchi
+	IDC_CHECK_USE_FONT_FOOT,		HIDC_PS_FONT_FOOT,			//ãƒ•ãƒƒã‚¿ãƒ¼(ãƒ•ã‚©ãƒ³ãƒˆ)	// 2013/5/16 Uchi
+	IDC_BUTTON_FONT_FOOT,			HIDC_PS_FONT_FOOT,			//ãƒ•ãƒƒã‚¿ãƒ¼(ãƒ•ã‚©ãƒ³ãƒˆ)	// 2013/5/16 Uchi
 	IDOK,							HIDOK_PS,					//OK
-	IDCANCEL,						HIDCANCEL_PS,				//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_PS_BUTTON_HELP,		//ƒwƒ‹ƒv
+	IDCANCEL,						HIDCANCEL_PS,				//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_PS_BUTTON_HELP,		//ãƒ˜ãƒ«ãƒ—
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
 
@@ -112,7 +112,7 @@ int CALLBACK SetData_EnumFontFamProc(
 	return 1;
 }
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgPrintSetting::DoModal(
 	HINSTANCE		hInstance,
 	HWND			hwndParent,
@@ -143,24 +143,24 @@ BOOL CDlgPrintSetting::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam 
 {
 	_SetHwnd( hwndDlg );
 
-	/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒ†[ƒU[ ƒCƒ“ƒ^[ƒtƒFƒCƒX‚ğŠg’£ƒCƒ“ƒ^[ƒtƒF[ƒX‚É‚·‚é */
+	/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼ ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ã‚¤ã‚¹ã‚’æ‹¡å¼µã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã«ã™ã‚‹ */
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_SETTINGNAME ), TRUE );
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_FONT_HAN ), TRUE );
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_FONT_ZEN ), TRUE );
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_PAPER ), TRUE );
 
-	// ƒ^ƒCƒ}[‚Å‚ÌXV‚ğ‚â‚ß‚ÄA”\“®“I‚ÉXV—v‹‚·‚é 2013.5.5 aroka
-	// CDialog::OnInitDialog‚Ì‰œ‚ÅOnChangeSettingType‚ªŒÄ‚Î‚ê‚é‚Ì‚Å‚±‚±‚Å‚ÍXV—v‹‚µ‚È‚¢
+	// ã‚¿ã‚¤ãƒãƒ¼ã§ã®æ›´æ–°ã‚’ã‚„ã‚ã¦ã€èƒ½å‹•çš„ã«æ›´æ–°è¦æ±‚ã™ã‚‹ 2013.5.5 aroka
+	// CDialog::OnInitDialogã®å¥¥ã§OnChangeSettingTypeãŒå‘¼ã°ã‚Œã‚‹ã®ã§ã“ã“ã§ã¯æ›´æ–°è¦æ±‚ã—ãªã„
 	//	::SetTimer( GetHwnd(), IDT_PRINTSETTING, 500, NULL );
 	//UpdatePrintableLineAndColumn();
 
-	// ƒ_ƒCƒAƒƒO‚ÌƒtƒHƒ“ƒg‚Ìæ“¾
-	m_hFontDlg = (HFONT)::SendMessage( GetHwnd(), WM_GETFONT, 0, 0 );	// ƒ_ƒCƒAƒƒO‚ÌƒtƒHƒ“ƒg
+	// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ•ã‚©ãƒ³ãƒˆã®å–å¾—
+	m_hFontDlg = (HFONT)::SendMessage( GetHwnd(), WM_GETFONT, 0, 0 );	// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ•ã‚©ãƒ³ãƒˆ
 	LOGFONT	lf;
 	::GetObject(m_hFontDlg, sizeof(LOGFONT), &lf);
-	m_nFontHeight = lf.lfHeight;		// ƒtƒHƒ“ƒgƒTƒCƒY
+	m_nFontHeight = lf.lfHeight;		// ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚º
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnInitDialog( GetHwnd(), wParam, lParam );
 }
 
@@ -168,7 +168,7 @@ BOOL CDlgPrintSetting::OnDestroy( void )
 {
 	::KillTimer( GetHwnd(), IDT_PRINTSETTING );
 
-	// ƒtƒHƒ“ƒg‚Ì”jŠü
+	// ãƒ•ã‚©ãƒ³ãƒˆã®ç ´æ£„
 	HFONT	hFontOld;
 	hFontOld = (HFONT)::SendMessage(::GetDlgItem( GetHwnd(), IDC_STATIC_FONT_HEAD ), WM_GETFONT, 0, 0 );
 	if (m_hFontDlg != hFontOld) {
@@ -179,7 +179,7 @@ BOOL CDlgPrintSetting::OnDestroy( void )
 		::DeleteObject( hFontOld );
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnDestroy();
 }
 
@@ -206,7 +206,7 @@ BOOL CDlgPrintSetting::OnNotify( WPARAM wParam, LPARAM lParam )
 	case IDC_SPIN_MARGINBY:
 	case IDC_SPIN_MARGINLX:
 	case IDC_SPIN_MARGINRX:
-		/* ƒXƒsƒ“ƒRƒ“ƒgƒ[ƒ‹‚Ìˆ— */
+		/* ã‚¹ãƒ”ãƒ³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®å‡¦ç† */
 		OnSpin( idCtrl, bSpinDown );
 		UpdatePrintableLineAndColumn();
 		break;
@@ -219,14 +219,14 @@ BOOL CDlgPrintSetting::OnCbnSelChange( HWND hwndCtl, int wID )
 //	if( ::GetDlgItem( GetHwnd(), IDC_COMBO_SETTINGNAME ) == hwndCtl ){
 	switch( wID ){
 	case IDC_COMBO_SETTINGNAME:
-		/* İ’è‚Ìƒ^ƒCƒv‚ª•Ï‚í‚Á‚½ */
+		/* è¨­å®šã®ã‚¿ã‚¤ãƒ—ãŒå¤‰ã‚ã£ãŸ */
 		OnChangeSettingType( TRUE );
 		return TRUE;
 	case IDC_COMBO_FONT_HAN:
 	case IDC_COMBO_FONT_ZEN:
 	case IDC_COMBO_PAPER:
 		UpdatePrintableLineAndColumn();
-		break;	// ‚±‚±‚Å‚Ís‚ÆŒ…‚ÌXV—v‹‚Ì‚İBŒã‚Ìˆ—‚ÍCDialog‚É”C‚¹‚éB
+		break;	// ã“ã“ã§ã¯è¡Œã¨æ¡ã®æ›´æ–°è¦æ±‚ã®ã¿ã€‚å¾Œã®å‡¦ç†ã¯CDialogã«ä»»ã›ã‚‹ã€‚
 	}
 	return FALSE;
 }
@@ -239,9 +239,9 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 	HWND			hwndComboSettingName;
 	switch( wID ){
 	case IDC_BUTTON_HELP:
-		/* uˆóüƒy[ƒWİ’èv‚Ìƒwƒ‹ƒv */
-		//Stonee, 2001/03/12 ‘ælˆø”‚ğA‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_PRINT_PAGESETUP) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ã€Œå°åˆ·ãƒšãƒ¼ã‚¸è¨­å®šã€ã®ãƒ˜ãƒ«ãƒ— */
+		//Stonee, 2001/03/12 ç¬¬å››å¼•æ•°ã‚’ã€æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_PRINT_PAGESETUP) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 	case IDC_BUTTON_EDITSETTINGNAME:
 		_tcscpy( szWork, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName );
@@ -262,7 +262,7 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 			int		size = _countof(m_PrintSettingArr[0].m_szPrintSettingName) - 1;
 			_tcsncpy( m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName, szWork, size);
 			m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName[size] = _T('\0');
-			/* ˆóüİ’è–¼ˆê—— */
+			/* å°åˆ·è¨­å®šåä¸€è¦§ */
 			hwndComboSettingName = ::GetDlgItem( GetHwnd(), IDC_COMBO_SETTINGNAME );
 			Combo_ResetContent( hwndComboSettingName );
 			int		nSelectIdx;
@@ -288,9 +288,9 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 			INT		nPointSize;
 
 			if (lf.lfFaceName[0] == _T('\0')) {
-				// ”¼ŠpƒtƒHƒ“ƒg‚ğİ’è
+				// åŠè§’ãƒ•ã‚©ãƒ³ãƒˆã‚’è¨­å®š
 				auto_strcpy( lf.lfFaceName, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintFontFaceHan );
-				// 1/10mm¨‰æ–Êƒhƒbƒg”
+				// 1/10mmâ†’ç”»é¢ãƒ‰ãƒƒãƒˆæ•°
 				lf.lfHeight = -( m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintFontHeight * 
 					::GetDeviceCaps ( ::GetDC( m_hwndParent ), LOGPIXELSY ) / 254 );
 			}
@@ -311,9 +311,9 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 			INT		nPointSize;
 
 			if (lf.lfFaceName[0] == _T('\0')) {
-				// ”¼ŠpƒtƒHƒ“ƒg‚ğİ’è
+				// åŠè§’ãƒ•ã‚©ãƒ³ãƒˆã‚’è¨­å®š
 				auto_strcpy( lf.lfFaceName, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintFontFaceHan );
-				// 1/10mm¨‰æ–Êƒhƒbƒg”
+				// 1/10mmâ†’ç”»é¢ãƒ‰ãƒƒãƒˆæ•°
 				lf.lfHeight = -( m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintFontHeight * 
 					::GetDeviceCaps ( ::GetDC( m_hwndParent ), LOGPIXELSY ) / 254 );
 			}
@@ -350,7 +350,7 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 		return TRUE;
 	case IDOK:
 		if( CalcPrintableLineAndColumn() ){
-			/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+			/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 			::EndDialog( GetHwnd(), GetData() );
 		}
 		return TRUE;
@@ -360,12 +360,12 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 	case IDC_RADIO_PORTRAIT:
 	case IDC_RADIO_LANDSCAPE:
 		UpdatePrintableLineAndColumn();
-		break;	// ‚±‚±‚Å‚Ís‚ÆŒ…‚ÌXV—v‹‚Ì‚İBŒã‚Ìˆ—‚ÍCDialog‚É”C‚¹‚éB
+		break;	// ã“ã“ã§ã¯è¡Œã¨æ¡ã®æ›´æ–°è¦æ±‚ã®ã¿ã€‚å¾Œã®å‡¦ç†ã¯CDialogã«ä»»ã›ã‚‹ã€‚
 	case IDC_CHECK_LINENUMBER:
 		UpdatePrintableLineAndColumn();
-		break;	// ‚±‚±‚Å‚Ís‚ÆŒ…‚ÌXV—v‹‚Ì‚İBŒã‚Ìˆ—‚ÍCDialog‚É”C‚¹‚éB
+		break;	// ã“ã“ã§ã¯è¡Œã¨æ¡ã®æ›´æ–°è¦æ±‚ã®ã¿ã€‚å¾Œã®å‡¦ç†ã¯CDialogã«ä»»ã›ã‚‹ã€‚
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
@@ -375,15 +375,15 @@ BOOL CDlgPrintSetting::OnStnClicked( int wID )
 	switch( wID ){
 	case IDC_STATIC_ENABLECOLUMNS:
 	case IDC_STATIC_ENABLELINES:
-		// Œ»óƒNƒŠƒbƒN‚Íó‚¯•t‚¯‚Ä‚¢‚È‚¢‚ªAƒƒbƒZ[ƒWˆ—‚µ‚½‚¢‚Ì‚Å‚±‚±‚É”z’u 2013.5.5 aroka
-		// ƒƒbƒZ[ƒW‚ª˜A‘±‚µ‚Ä‘—‚ç‚ê‚½‚Æ‚«‚Íˆê‰ñ‚¾‚¯‘Î‰‚·‚é 2013.5.5 aroka
+		// ç¾çŠ¶ã‚¯ãƒªãƒƒã‚¯ã¯å—ã‘ä»˜ã‘ã¦ã„ãªã„ãŒã€ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†ã—ãŸã„ã®ã§ã“ã“ã«é…ç½® 2013.5.5 aroka
+		// ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãŒé€£ç¶šã—ã¦é€ã‚‰ã‚ŒãŸã¨ãã¯ä¸€å›ã ã‘å¯¾å¿œã™ã‚‹ 2013.5.5 aroka
 		if( m_bPrintableLinesAndColumnInvalid ){
 			m_bPrintableLinesAndColumnInvalid = false;
 			CalcPrintableLineAndColumn();
 		}
 		return TRUE;
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnStnClicked( wID );
 }
 
@@ -391,11 +391,11 @@ BOOL CDlgPrintSetting::OnStnClicked( int wID )
 BOOL CDlgPrintSetting::OnEnChange( HWND hwndCtl, int wID )
 {
 	switch( wID ){
-	case IDC_EDIT_FONTHEIGHT:	// ƒtƒHƒ“ƒg•‚ÌÅ¬’l‚ª”ñ‚O‚Ì‚½‚ß'12'‚Æ“ü—Í‚·‚é‚Æ'1'‚Ì‚Æ‚±‚ë‚ÅR‚ç‚ê‚Ä‚µ‚Ü‚¤ 2013.5.5 aroka
-		if( ::GetDlgItemInt( GetHwnd(), IDC_EDIT_FONTHEIGHT, NULL, FALSE ) >=10 ){	// “ñŒ…ˆÈã‚Ìê‡‚Í—Ìˆæƒ`ƒFƒbƒN 2013.5.20 aroka
+	case IDC_EDIT_FONTHEIGHT:	// ãƒ•ã‚©ãƒ³ãƒˆå¹…ã®æœ€å°å€¤ãŒéï¼ã®ãŸã‚'12'ã¨å…¥åŠ›ã™ã‚‹ã¨'1'ã®ã¨ã“ã‚ã§è¹´ã‚‰ã‚Œã¦ã—ã¾ã† 2013.5.5 aroka
+		if( ::GetDlgItemInt( GetHwnd(), IDC_EDIT_FONTHEIGHT, NULL, FALSE ) >=10 ){	// äºŒæ¡ä»¥ä¸Šã®å ´åˆã¯é ˜åŸŸãƒã‚§ãƒƒã‚¯ 2013.5.20 aroka
 			UpdatePrintableLineAndColumn();
 		}
-		break;	// ‚±‚±‚Å‚Ís‚ÆŒ…‚ÌXV—v‹‚Ì‚İBŒã‚Ìˆ—‚ÍCDialog‚É”C‚¹‚éB
+		break;	// ã“ã“ã§ã¯è¡Œã¨æ¡ã®æ›´æ–°è¦æ±‚ã®ã¿ã€‚å¾Œã®å‡¦ç†ã¯CDialogã«ä»»ã›ã‚‹ã€‚
 	case IDC_EDIT_LINESPACE:
 	case IDC_EDIT_DANSUU:
 	case IDC_EDIT_DANSPACE:
@@ -404,9 +404,9 @@ BOOL CDlgPrintSetting::OnEnChange( HWND hwndCtl, int wID )
 	case IDC_EDIT_MARGINLX:
 	case IDC_EDIT_MARGINRX:
 		UpdatePrintableLineAndColumn();
-		break;	// ‚±‚±‚Å‚Ís‚ÆŒ…‚ÌXV—v‹‚Ì‚İBŒã‚Ìˆ—‚ÍCDialog‚É”C‚¹‚éB
+		break;	// ã“ã“ã§ã¯è¡Œã¨æ¡ã®æ›´æ–°è¦æ±‚ã®ã¿ã€‚å¾Œã®å‡¦ç†ã¯CDialogã«ä»»ã›ã‚‹ã€‚
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnEnChange( hwndCtl, wID );
 }
 
@@ -415,28 +415,28 @@ BOOL CDlgPrintSetting::OnEnKillFocus( HWND hwndCtl, int wID )
 {
 	switch( wID ){
 	case IDC_EDIT_FONTHEIGHT:
-	//case IDC_EDIT_LINESPACE:	// EN_CHANGE ‚ÅŒvZ‚µ‚Ä‚¢‚é‚Ì‚Åç’·‚©‚ÈA‚Æv‚¢ƒRƒƒ“ƒgƒAƒEƒg 2013.5.5 aroka
+	//case IDC_EDIT_LINESPACE:	// EN_CHANGE ã§è¨ˆç®—ã—ã¦ã„ã‚‹ã®ã§å†—é•·ã‹ãªã€ã¨æ€ã„ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆ 2013.5.5 aroka
 	//case IDC_EDIT_DANSUU:
 	//case IDC_EDIT_DANSPACE:
 	//case IDC_EDIT_MARGINTY:
 	//case IDC_EDIT_MARGINBY:
 	//case IDC_EDIT_MARGINLX:
 	//case IDC_EDIT_MARGINRX:
-	case IDC_EDIT_HEAD1:	// ƒeƒLƒXƒg•ÒW‚Ì‚½‚Ñ‚Éƒ`ƒFƒbƒN‚·‚é‚Æ’x‚¢‚Ì‚ÅƒtƒH[ƒJƒXˆÚ“®‚Ì‚İ 2013.5.12 aroka
+	case IDC_EDIT_HEAD1:	// ãƒ†ã‚­ã‚¹ãƒˆç·¨é›†ã®ãŸã³ã«ãƒã‚§ãƒƒã‚¯ã™ã‚‹ã¨é…ã„ã®ã§ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ç§»å‹•æ™‚ã®ã¿ 2013.5.12 aroka
 	case IDC_EDIT_HEAD2:
 	case IDC_EDIT_HEAD3:
 	case IDC_EDIT_FOOT1:
 	case IDC_EDIT_FOOT2:
 	case IDC_EDIT_FOOT3:
 		UpdatePrintableLineAndColumn();
-		break;	// ‚±‚±‚Å‚Ís‚ÆŒ…‚ÌXV—v‹‚Ì‚İBŒã‚Ìˆ—‚ÍCDialog‚É”C‚¹‚éB
+		break;	// ã“ã“ã§ã¯è¡Œã¨æ¡ã®æ›´æ–°è¦æ±‚ã®ã¿ã€‚å¾Œã®å‡¦ç†ã¯CDialogã«ä»»ã›ã‚‹ã€‚
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnEnKillFocus( hwndCtl, wID );
 }
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgPrintSetting::SetData( void )
 {
 	HDC		hdc;
@@ -448,7 +448,7 @@ void CDlgPrintSetting::SetData( void )
 	int	nSelectIdx;
 
 
-	/* ƒtƒHƒ“ƒgˆê—— */
+	/* ãƒ•ã‚©ãƒ³ãƒˆä¸€è¦§ */
 	hdc = ::GetDC( m_hwndParent );
 	hwndComboFont = ::GetDlgItem( GetHwnd(), IDC_COMBO_FONT_HAN );
 	Combo_ResetContent( hwndComboFont );
@@ -462,17 +462,17 @@ void CDlgPrintSetting::SetData( void )
 	);
 	::ReleaseDC( m_hwndParent, hdc );
 
-	/* —p†ƒTƒCƒYˆê—— */
+	/* ç”¨ç´™ã‚µã‚¤ã‚ºä¸€è¦§ */
 	hwndComboPaper = ::GetDlgItem( GetHwnd(), IDC_COMBO_PAPER );
 	Combo_ResetContent( hwndComboPaper );
-	// 2006.08.14 Moca —p†–¼ˆê——‚Ìd•¡íœ
+	// 2006.08.14 Moca ç”¨ç´™åä¸€è¦§ã®é‡è¤‡å‰Šé™¤
 	for( i = 0; i < CPrint::m_nPaperInfoArrNum; ++i ){
 		nItemIdx = Combo_AddString( hwndComboPaper, CPrint::m_paperInfoArr[i].m_pszName );
 		Combo_SetItemData( hwndComboPaper, nItemIdx, CPrint::m_paperInfoArr[i].m_nId );
 	}
 
 
-	/* ˆóüİ’è–¼ˆê—— */
+	/* å°åˆ·è¨­å®šåä¸€è¦§ */
 	hwndComboSettingName = ::GetDlgItem( GetHwnd(), IDC_COMBO_SETTINGNAME );
 	Combo_ResetContent( hwndComboSettingName );
 	nSelectIdx = 0;
@@ -485,7 +485,7 @@ void CDlgPrintSetting::SetData( void )
 	}
 	Combo_SetCurSel( hwndComboSettingName, nSelectIdx );
 
-	/* İ’è‚Ìƒ^ƒCƒv‚ª•Ï‚í‚Á‚½ */
+	/* è¨­å®šã®ã‚¿ã‚¤ãƒ—ãŒå¤‰ã‚ã£ãŸ */
 	OnChangeSettingType( FALSE );
 
 	return;
@@ -494,21 +494,21 @@ void CDlgPrintSetting::SetData( void )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-/* TRUE==³í FALSE==“ü—ÍƒGƒ‰[ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+/* TRUE==æ­£å¸¸ FALSE==å…¥åŠ›ã‚¨ãƒ©ãƒ¼ */
 int CDlgPrintSetting::GetData( void )
 {
 	HWND	hwndCtrl;
 	int		nIdx1;
 	int		nWork;
 
-	/* ƒtƒHƒ“ƒgˆê—— */
+	/* ãƒ•ã‚©ãƒ³ãƒˆä¸€è¦§ */
 	hwndCtrl = ::GetDlgItem( GetHwnd(), IDC_COMBO_FONT_HAN );
 	nIdx1 = Combo_GetCurSel( hwndCtrl );
 	Combo_GetLBText( hwndCtrl, nIdx1,
 		m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintFontFaceHan
 	);
-	/* ƒtƒHƒ“ƒgˆê—— */
+	/* ãƒ•ã‚©ãƒ³ãƒˆä¸€è¦§ */
 	hwndCtrl = ::GetDlgItem( GetHwnd(), IDC_COMBO_FONT_ZEN );
 	nIdx1 = Combo_GetCurSel( hwndCtrl );
 	Combo_GetLBText( hwndCtrl, nIdx1,
@@ -520,7 +520,7 @@ int CDlgPrintSetting::GetData( void )
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintDansuu = ::GetDlgItemInt( GetHwnd(), IDC_EDIT_DANSUU, NULL, FALSE );
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintDanSpace = ::GetDlgItemInt( GetHwnd(), IDC_EDIT_DANSPACE, NULL, FALSE ) * 10;
 
-	/* “ü—Í’l(”’l)‚ÌƒGƒ‰[ƒ`ƒFƒbƒN‚ğ‚µ‚Ä³‚µ‚¢’l‚ğ•Ô‚· */
+	/* å…¥åŠ›å€¤(æ•°å€¤)ã®ã‚¨ãƒ©ãƒ¼ãƒã‚§ãƒƒã‚¯ã‚’ã—ã¦æ­£ã—ã„å€¤ã‚’è¿”ã™ */
 	nWork = DataCheckAndCorrect( IDC_EDIT_FONTHEIGHT, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintFontHeight );
 	if( nWork != m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintFontHeight ){
 		m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintFontHeight = nWork;
@@ -544,14 +544,14 @@ int CDlgPrintSetting::GetData( void )
 		::SetDlgItemInt( GetHwnd(), IDC_EDIT_DANSPACE, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintDanSpace / 10, FALSE );
 	}
 
-	/* —p†ƒTƒCƒYˆê—— */
+	/* ç”¨ç´™ã‚µã‚¤ã‚ºä¸€è¦§ */
 	hwndCtrl = ::GetDlgItem( GetHwnd(), IDC_COMBO_PAPER );
 	nIdx1 = Combo_GetCurSel( hwndCtrl );
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintPaperSize =
 		(short)Combo_GetItemData( hwndCtrl, nIdx1 );
 
-	// —p†‚ÌŒü‚«
-	// 2006.08.14 Moca —p†•ûŒüƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ğ”p~‚µAƒ{ƒ^ƒ“‚ğ—LŒø‰»
+	// ç”¨ç´™ã®å‘ã
+	// 2006.08.14 Moca ç”¨ç´™æ–¹å‘ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã‚’å»ƒæ­¢ã—ã€ãƒœã‚¿ãƒ³ã‚’æœ‰åŠ¹åŒ–
 	if( IsDlgButtonCheckedBool( GetHwnd(), IDC_RADIO_PORTRAIT ) ){
 		m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintPaperOrientation = DMORIENT_PORTRAIT;
 	}else{
@@ -563,7 +563,7 @@ int CDlgPrintSetting::GetData( void )
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginLX = ::GetDlgItemInt( GetHwnd(), IDC_EDIT_MARGINLX, NULL, FALSE ) * 10;
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginRX = ::GetDlgItemInt( GetHwnd(), IDC_EDIT_MARGINRX, NULL, FALSE ) * 10;
 
-	/* “ü—Í’l(”’l)‚ÌƒGƒ‰[ƒ`ƒFƒbƒN‚ğ‚µ‚Ä³‚µ‚¢’l‚ğ•Ô‚· */
+	/* å…¥åŠ›å€¤(æ•°å€¤)ã®ã‚¨ãƒ©ãƒ¼ãƒã‚§ãƒƒã‚¯ã‚’ã—ã¦æ­£ã—ã„å€¤ã‚’è¿”ã™ */
 	nWork = DataCheckAndCorrect( IDC_EDIT_MARGINTY, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginTY / 10 );
 	if( nWork != m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginTY / 10 ){
 		m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginTY = nWork * 10;
@@ -585,40 +585,40 @@ int CDlgPrintSetting::GetData( void )
 		::SetDlgItemInt( GetHwnd(), IDC_EDIT_MARGINRX, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginRX / 10, FALSE );
 	}
 
-	// s”Ô†‚ğˆóü
+	// è¡Œç•ªå·ã‚’å°åˆ·
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintLineNumber = IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_LINENUMBER );
-	// ‰p•¶ƒ[ƒhƒ‰ƒbƒv
+	// è‹±æ–‡ãƒ¯ãƒ¼ãƒ‰ãƒ©ãƒƒãƒ—
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintWordWrap = IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_WORDWRAP );
 
-	//s“ª‹Ö‘¥	//@@@ 2002.04.09 MIK
+	//è¡Œé ­ç¦å‰‡	//@@@ 2002.04.09 MIK
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintKinsokuHead = IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_PS_KINSOKUHEAD );
-	//s––‹Ö‘¥	//@@@ 2002.04.09 MIK
+	//è¡Œæœ«ç¦å‰‡	//@@@ 2002.04.09 MIK
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintKinsokuTail = IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_PS_KINSOKUTAIL );
-	//‰üs•¶š‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.13 MIK
+	//æ”¹è¡Œæ–‡å­—ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.13 MIK
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintKinsokuRet = IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_PS_KINSOKURET );
-	//‹å“Ç“_‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.17 MIK
+	//å¥èª­ç‚¹ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.17 MIK
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintKinsokuKuto = IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_PS_KINSOKUKUTO );
 
-	// ƒJƒ‰[ˆóü
+	// ã‚«ãƒ©ãƒ¼å°åˆ·
 	m_PrintSettingArr[m_nCurrentPrintSetting].m_bColorPrint =
 		( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_COLORPRINT ) );
 
 	//@@@ 2002.2.4 YAZAKI
-	/* ƒwƒbƒ_[ */
-	::DlgItem_GetText( GetHwnd(), IDC_EDIT_HEAD1, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[0], HEADER_MAX );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
-	::DlgItem_GetText( GetHwnd(), IDC_EDIT_HEAD2, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[1], HEADER_MAX );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
-	::DlgItem_GetText( GetHwnd(), IDC_EDIT_HEAD3, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[2], HEADER_MAX );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
+	/* ãƒ˜ãƒƒãƒ€ãƒ¼ */
+	::DlgItem_GetText( GetHwnd(), IDC_EDIT_HEAD1, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[0], HEADER_MAX );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
+	::DlgItem_GetText( GetHwnd(), IDC_EDIT_HEAD2, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[1], HEADER_MAX );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
+	::DlgItem_GetText( GetHwnd(), IDC_EDIT_HEAD3, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[2], HEADER_MAX );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
 
-	/* ƒtƒbƒ^[ */
-	::DlgItem_GetText( GetHwnd(), IDC_EDIT_FOOT1, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[0], HEADER_MAX );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
-	::DlgItem_GetText( GetHwnd(), IDC_EDIT_FOOT2, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[1], HEADER_MAX );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
-	::DlgItem_GetText( GetHwnd(), IDC_EDIT_FOOT3, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[2], HEADER_MAX );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
+	/* ãƒ•ãƒƒã‚¿ãƒ¼ */
+	::DlgItem_GetText( GetHwnd(), IDC_EDIT_FOOT1, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[0], HEADER_MAX );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
+	::DlgItem_GetText( GetHwnd(), IDC_EDIT_FOOT2, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[1], HEADER_MAX );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
+	::DlgItem_GetText( GetHwnd(), IDC_EDIT_FOOT3, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[2], HEADER_MAX );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
 
-	// ƒwƒbƒ_ƒtƒHƒ“ƒg
+	// ãƒ˜ãƒƒãƒ€ãƒ•ã‚©ãƒ³ãƒˆ
 	if (!IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_USE_FONT_HEAD )) {
 		memset( &m_PrintSettingArr[m_nCurrentPrintSetting].m_lfHeader, 0, sizeof(LOGFONT) );
 	}
-	// ƒtƒbƒ^ƒtƒHƒ“ƒg
+	// ãƒ•ãƒƒã‚¿ãƒ•ã‚©ãƒ³ãƒˆ
 	if (!IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_USE_FONT_FOOT )) {
 		memset( &m_PrintSettingArr[m_nCurrentPrintSetting].m_lfFooter, 0, sizeof(LOGFONT) );
 	}
@@ -627,7 +627,7 @@ int CDlgPrintSetting::GetData( void )
 }
 
 
-/* İ’è‚Ìƒ^ƒCƒv‚ª•Ï‚í‚Á‚½ */
+/* è¨­å®šã®ã‚¿ã‚¤ãƒ—ãŒå¤‰ã‚ã£ãŸ */
 void CDlgPrintSetting::OnChangeSettingType( BOOL bGetData )
 {
 	HWND	hwndComboSettingName;
@@ -648,12 +648,12 @@ void CDlgPrintSetting::OnChangeSettingType( BOOL bGetData )
 	}
 	m_nCurrentPrintSetting = Combo_GetItemData( hwndComboSettingName, nIdx1 );
 
-	/* ƒtƒHƒ“ƒgˆê—— */
+	/* ãƒ•ã‚©ãƒ³ãƒˆä¸€è¦§ */
 	hwndCtrl = ::GetDlgItem( GetHwnd(), IDC_COMBO_FONT_HAN );
 	nIdx1 = Combo_FindStringExact( hwndCtrl, 0, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintFontFaceHan );
 	Combo_SetCurSel( hwndCtrl, nIdx1 );
 
-	/* ƒtƒHƒ“ƒgˆê—— */
+	/* ãƒ•ã‚©ãƒ³ãƒˆä¸€è¦§ */
 	hwndCtrl = ::GetDlgItem( GetHwnd(), IDC_COMBO_FONT_ZEN );
 	nIdx1 = Combo_FindStringExact( hwndCtrl, 0, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintFontFaceZen );
 	Combo_SetCurSel( hwndCtrl, nIdx1 );
@@ -663,7 +663,7 @@ void CDlgPrintSetting::OnChangeSettingType( BOOL bGetData )
 	::SetDlgItemInt( GetHwnd(), IDC_EDIT_DANSUU, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintDansuu, FALSE );
 	::SetDlgItemInt( GetHwnd(), IDC_EDIT_DANSPACE, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintDanSpace / 10, FALSE );
 
-	/* —p†ƒTƒCƒYˆê—— */
+	/* ç”¨ç´™ã‚µã‚¤ã‚ºä¸€è¦§ */
 	hwndCtrl = ::GetDlgItem( GetHwnd(), IDC_COMBO_PAPER );
 	nItemNum = Combo_GetCount( hwndCtrl );
 	for( i = 0; i < nItemNum; ++i ){
@@ -674,52 +674,52 @@ void CDlgPrintSetting::OnChangeSettingType( BOOL bGetData )
 		}
 	}
 
-	// —p†‚ÌŒü‚«
-	// 2006.08.14 Moca —p†•ûŒüƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ğ”p~‚µAƒ{ƒ^ƒ“‚ğ—LŒø‰»
+	// ç”¨ç´™ã®å‘ã
+	// 2006.08.14 Moca ç”¨ç´™æ–¹å‘ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã‚’å»ƒæ­¢ã—ã€ãƒœã‚¿ãƒ³ã‚’æœ‰åŠ¹åŒ–
 	bool bIsPortrait = ( m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintPaperOrientation == DMORIENT_PORTRAIT );
 	CheckDlgButtonBool( GetHwnd(), IDC_RADIO_PORTRAIT, bIsPortrait );
 	CheckDlgButtonBool( GetHwnd(), IDC_RADIO_LANDSCAPE, !bIsPortrait );
 
-	// —]”’
+	// ä½™ç™½
 	::SetDlgItemInt( GetHwnd(), IDC_EDIT_MARGINTY, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginTY / 10, FALSE );
 	::SetDlgItemInt( GetHwnd(), IDC_EDIT_MARGINBY, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginBY / 10, FALSE );
 	::SetDlgItemInt( GetHwnd(), IDC_EDIT_MARGINLX, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginLX / 10, FALSE );
 	::SetDlgItemInt( GetHwnd(), IDC_EDIT_MARGINRX, m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintMarginRX / 10, FALSE );
 
-	// s”Ô†‚ğˆóü
+	// è¡Œç•ªå·ã‚’å°åˆ·
 	CheckDlgButtonBool( GetHwnd(), IDC_CHECK_LINENUMBER, m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintLineNumber );
-	// ‰p•¶ƒ[ƒhƒ‰ƒbƒv
+	// è‹±æ–‡ãƒ¯ãƒ¼ãƒ‰ãƒ©ãƒƒãƒ—
 	CheckDlgButtonBool( GetHwnd(), IDC_CHECK_WORDWRAP, m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintWordWrap );
 
-	// s“ª‹Ö‘¥	//@@@ 2002.04.09 MIK
+	// è¡Œé ­ç¦å‰‡	//@@@ 2002.04.09 MIK
 	CheckDlgButtonBool( GetHwnd(), IDC_CHECK_PS_KINSOKUHEAD, m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintKinsokuHead );
-	// s––‹Ö‘¥	//@@@ 2002.04.09 MIK
+	// è¡Œæœ«ç¦å‰‡	//@@@ 2002.04.09 MIK
 	CheckDlgButtonBool( GetHwnd(), IDC_CHECK_PS_KINSOKUTAIL, m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintKinsokuTail );
 
-	// ‰üs•¶š‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.13 MIK
+	// æ”¹è¡Œæ–‡å­—ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.13 MIK
 	CheckDlgButtonBool( GetHwnd(), IDC_CHECK_PS_KINSOKURET, m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintKinsokuRet );
-	// ‹å“Ç“_‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.17 MIK
+	// å¥èª­ç‚¹ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.17 MIK
 	CheckDlgButtonBool( GetHwnd(), IDC_CHECK_PS_KINSOKUKUTO, m_PrintSettingArr[m_nCurrentPrintSetting].m_bPrintKinsokuKuto );
 
-	// ƒJƒ‰[ˆóü
+	// ã‚«ãƒ©ãƒ¼å°åˆ·
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_COLORPRINT, 
 		m_PrintSettingArr[m_nCurrentPrintSetting].m_bColorPrint ? BST_CHECKED : BST_UNCHECKED);
 
-	/* ƒwƒbƒ_[ */
-	::DlgItem_SetText( GetHwnd(), IDC_EDIT_HEAD1, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[POS_LEFT] );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
-	::DlgItem_SetText( GetHwnd(), IDC_EDIT_HEAD2, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[POS_CENTER] );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
-	::DlgItem_SetText( GetHwnd(), IDC_EDIT_HEAD3, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[POS_RIGHT] );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
+	/* ãƒ˜ãƒƒãƒ€ãƒ¼ */
+	::DlgItem_SetText( GetHwnd(), IDC_EDIT_HEAD1, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[POS_LEFT] );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
+	::DlgItem_SetText( GetHwnd(), IDC_EDIT_HEAD2, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[POS_CENTER] );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
+	::DlgItem_SetText( GetHwnd(), IDC_EDIT_HEAD3, m_PrintSettingArr[m_nCurrentPrintSetting].m_szHeaderForm[POS_RIGHT] );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
 
-	/* ƒtƒbƒ^[ */
-	::DlgItem_SetText( GetHwnd(), IDC_EDIT_FOOT1, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[POS_LEFT] );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
-	::DlgItem_SetText( GetHwnd(), IDC_EDIT_FOOT2, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[POS_CENTER] );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
-	::DlgItem_SetText( GetHwnd(), IDC_EDIT_FOOT3, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[POS_RIGHT] );	//	100•¶š‚Å§ŒÀ‚µ‚È‚¢‚ÆBBB
+	/* ãƒ•ãƒƒã‚¿ãƒ¼ */
+	::DlgItem_SetText( GetHwnd(), IDC_EDIT_FOOT1, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[POS_LEFT] );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
+	::DlgItem_SetText( GetHwnd(), IDC_EDIT_FOOT2, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[POS_CENTER] );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
+	::DlgItem_SetText( GetHwnd(), IDC_EDIT_FOOT3, m_PrintSettingArr[m_nCurrentPrintSetting].m_szFooterForm[POS_RIGHT] );	//	100æ–‡å­—ã§åˆ¶é™ã—ãªã„ã¨ã€‚ã€‚ã€‚
 
-	// ƒwƒbƒ_ƒtƒHƒ“ƒg
+	// ãƒ˜ãƒƒãƒ€ãƒ•ã‚©ãƒ³ãƒˆ
 	SetFontName( IDC_STATIC_FONT_HEAD, IDC_CHECK_USE_FONT_HEAD,
 		m_PrintSettingArr[m_nCurrentPrintSetting].m_lfHeader,
 		m_PrintSettingArr[m_nCurrentPrintSetting].m_nHeaderPointSize );
-	// ƒtƒbƒ^ƒtƒHƒ“ƒg
+	// ãƒ•ãƒƒã‚¿ãƒ•ã‚©ãƒ³ãƒˆ
 	SetFontName( IDC_STATIC_FONT_FOOT, IDC_CHECK_USE_FONT_FOOT,
 		m_PrintSettingArr[m_nCurrentPrintSetting].m_lfFooter,
 		m_PrintSettingArr[m_nCurrentPrintSetting].m_nFooterPointSize );
@@ -744,7 +744,7 @@ const struct {
 	{ IDC_EDIT_MARGINRX,	0,	50 },	//!< mm
 };
 
-/* ƒXƒsƒ“ƒRƒ“ƒgƒ[ƒ‹‚Ìˆ— */
+/* ã‚¹ãƒ”ãƒ³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®å‡¦ç† */
 void CDlgPrintSetting::OnSpin( int nCtrlId, BOOL bDown )
 {
 	int		nData = 0;
@@ -769,14 +769,14 @@ void CDlgPrintSetting::OnSpin( int nCtrlId, BOOL bDown )
  		}else{
 			nData += nDiff;
  		}
-		/* “ü—Í’l(”’l)‚ÌƒGƒ‰[ƒ`ƒFƒbƒN‚ğ‚µ‚Ä³‚µ‚¢’l‚ğ•Ô‚· */
+		/* å…¥åŠ›å€¤(æ•°å€¤)ã®ã‚¨ãƒ©ãƒ¼ãƒã‚§ãƒƒã‚¯ã‚’ã—ã¦æ­£ã—ã„å€¤ã‚’è¿”ã™ */
 		nData = DataCheckAndCorrect( nCtrlIdEDIT, nData );
 		::SetDlgItemInt( GetHwnd(), nCtrlIdEDIT, nData, FALSE );
 	}
 }
 
 
-/* “ü—Í’l(”’l)‚ÌƒGƒ‰[ƒ`ƒFƒbƒN‚ğ‚µ‚Ä³‚µ‚¢’l‚ğ•Ô‚· */
+/* å…¥åŠ›å€¤(æ•°å€¤)ã®ã‚¨ãƒ©ãƒ¼ãƒã‚§ãƒƒã‚¯ã‚’ã—ã¦æ­£ã—ã„å€¤ã‚’è¿”ã™ */
 int CDlgPrintSetting::DataCheckAndCorrect( int nCtrlId, int nData )
 {
 	int nIdx = -1;
@@ -803,53 +803,53 @@ int CDlgPrintSetting::DataCheckAndCorrect( int nCtrlId, int nData )
 
 
 /*!
-	ˆóš‰Â”\s”‚ÆŒ…”‚ğŒvZ
-	@date 2013.05.05 aroka OnTimer‚©‚çˆÚ“®
-	@retval ˆóš‰Â”\—Ìˆæ‚ª‚ ‚ê‚Î TRUE  // 2013.05.20 aroka
+	å°å­—å¯èƒ½è¡Œæ•°ã¨æ¡æ•°ã‚’è¨ˆç®—
+	@date 2013.05.05 aroka OnTimerã‹ã‚‰ç§»å‹•
+	@retval å°å­—å¯èƒ½é ˜åŸŸãŒã‚ã‚Œã° TRUE  // 2013.05.20 aroka
 */
 BOOL CDlgPrintSetting::CalcPrintableLineAndColumn()
 {
-	int				nEnableColumns;		/* s‚ ‚½‚è‚Ì•¶š” */
-	int				nEnableLines;		/* c•ûŒü‚Ìs” */
-	MYDEVMODE		dmDummy;			// 2003.05.18 ‚©‚ë‚Æ Œ^•ÏX
-	short			nPaperAllWidth;		/* —p†• */
-	short			nPaperAllHeight;	/* —p†‚‚³ */
+	int				nEnableColumns;		/* è¡Œã‚ãŸã‚Šã®æ–‡å­—æ•° */
+	int				nEnableLines;		/* ç¸¦æ–¹å‘ã®è¡Œæ•° */
+	MYDEVMODE		dmDummy;			// 2003.05.18 ã‹ã‚ã¨ å‹å¤‰æ›´
+	short			nPaperAllWidth;		/* ç”¨ç´™å¹… */
+	short			nPaperAllHeight;	/* ç”¨ç´™é«˜ã• */
 	PRINTSETTING*	pPS;
 
-	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 	GetData();
 	pPS = &m_PrintSettingArr[m_nCurrentPrintSetting];
 
 	dmDummy.dmFields = DM_PAPERSIZE | DMORIENT_LANDSCAPE;
 	dmDummy.dmPaperSize = pPS->m_nPrintPaperSize;
 	dmDummy.dmOrientation = pPS->m_nPrintPaperOrientation;
-	/* —p†‚Ì•A‚‚³ */
+	/* ç”¨ç´™ã®å¹…ã€é«˜ã• */
 	if( !CPrint::GetPaperSize(
 		&nPaperAllWidth,
 		&nPaperAllHeight,
 		&dmDummy
 	) ){
-	// 2001.12.21 hor GetPaperSize¸”s‚Í‚»‚Ì‚Ü‚ÜI—¹
-	//	nPaperAllWidth = 210 * 10;		/* —p†• */
-	//	nPaperAllHeight = 297 * 10;		/* —p†‚‚³ */
+	// 2001.12.21 hor GetPaperSizeå¤±æ•—æ™‚ã¯ãã®ã¾ã¾çµ‚äº†
+	//	nPaperAllWidth = 210 * 10;		/* ç”¨ç´™å¹… */
+	//	nPaperAllHeight = 297 * 10;		/* ç”¨ç´™é«˜ã• */
 		return FALSE;
 	}
-	/* s‚ ‚½‚è‚Ì•¶š”(s”Ô†‚İ) */
-	nEnableColumns = CPrint::CalculatePrintableColumns( pPS, nPaperAllWidth, pPS->m_bPrintLineNumber?m_nLineNumberColumns:0 );	/* ˆóš‰Â”\Œ…”/ƒy[ƒW */
-	/* c•ûŒü‚Ìs” */
-	nEnableLines = CPrint::CalculatePrintableLines( pPS, nPaperAllHeight );			/* ˆóš‰Â”\s”/ƒy[ƒW */
+	/* è¡Œã‚ãŸã‚Šã®æ–‡å­—æ•°(è¡Œç•ªå·è¾¼ã¿) */
+	nEnableColumns = CPrint::CalculatePrintableColumns( pPS, nPaperAllWidth, pPS->m_bPrintLineNumber?m_nLineNumberColumns:0 );	/* å°å­—å¯èƒ½æ¡æ•°/ãƒšãƒ¼ã‚¸ */
+	/* ç¸¦æ–¹å‘ã®è¡Œæ•° */
+	nEnableLines = CPrint::CalculatePrintableLines( pPS, nPaperAllHeight );			/* å°å­—å¯èƒ½è¡Œæ•°/ãƒšãƒ¼ã‚¸ */
 
 	::SetDlgItemInt( GetHwnd(), IDC_STATIC_ENABLECOLUMNS, nEnableColumns, FALSE );
 	::SetDlgItemInt( GetHwnd(), IDC_STATIC_ENABLELINES, nEnableLines, FALSE );
 
-	// ƒtƒHƒ“ƒg‚Ìƒ|ƒCƒ“ƒg”	2013/5/9 Uchi
+	// ãƒ•ã‚©ãƒ³ãƒˆã®ãƒã‚¤ãƒ³ãƒˆæ•°	2013/5/9 Uchi
 	// 1pt = 1/72in = 25.4/72mm
 	int		nFontPoints = pPS->m_nPrintFontHeight * 720 / 254;
 	TCHAR	szFontPoints[20];
 	auto_sprintf_s( szFontPoints, _countof(szFontPoints), _T("%d.%dpt"), nFontPoints/10, nFontPoints%10 );
 	::DlgItem_SetText( GetHwnd(), IDC_STATIC_FONTSIZE, szFontPoints );
 
-	// ˆóš‰Â”\—Ìˆæ‚ª‚È‚¢ê‡‚Í OK ‚ğ‰Ÿ‚¹‚È‚­‚·‚é 2013.5.10 aroka
+	// å°å­—å¯èƒ½é ˜åŸŸãŒãªã„å ´åˆã¯ OK ã‚’æŠ¼ã›ãªãã™ã‚‹ 2013.5.10 aroka
 	if( nEnableColumns == 0 || nEnableLines == 0 ){
 		::EnableWindow( GetDlgItem( GetHwnd(), IDOK ), FALSE );
 		return FALSE;
@@ -860,8 +860,8 @@ BOOL CDlgPrintSetting::CalcPrintableLineAndColumn()
 }
 
 
-// s”‚ÆŒ…”‚ÌXV‚ğ—v‹iƒƒbƒZ[ƒWƒLƒ…[‚Éƒ|ƒXƒg‚·‚éj
-// ƒ_ƒCƒAƒƒO‰Šú‰»‚Ì“r’†‚Å EN_CHANGE ‚É”½‰‚·‚é‚ÆŒvZ‚ª‚¨‚©‚µ‚­‚È‚é‚½‚ßAŠÖ”ŒÄ‚Ño‚µ‚Å‚Í‚È‚­PostMessage‚Åˆ— 2013.5.5 aroka
+// è¡Œæ•°ã¨æ¡æ•°ã®æ›´æ–°ã‚’è¦æ±‚ï¼ˆãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚­ãƒ¥ãƒ¼ã«ãƒã‚¹ãƒˆã™ã‚‹ï¼‰
+// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°åˆæœŸåŒ–ã®é€”ä¸­ã§ EN_CHANGE ã«åå¿œã™ã‚‹ã¨è¨ˆç®—ãŒãŠã‹ã—ããªã‚‹ãŸã‚ã€é–¢æ•°å‘¼ã³å‡ºã—ã§ã¯ãªãPostMessageã§å‡¦ç† 2013.5.5 aroka
 void CDlgPrintSetting::UpdatePrintableLineAndColumn()
 {
 	m_bPrintableLinesAndColumnInvalid = true;
@@ -877,7 +877,7 @@ LPVOID CDlgPrintSetting::GetHelpIdTable(void)
 //@@@ 2002.01.18 add end
 
 
-// ƒtƒHƒ“ƒg–¼/g—pƒ{ƒ^ƒ“‚Ìİ’è
+// ãƒ•ã‚©ãƒ³ãƒˆå/ä½¿ç”¨ãƒœã‚¿ãƒ³ã®è¨­å®š
 void CDlgPrintSetting::SetFontName( int idTxt, int idUse, LOGFONT& lf, int nPointSize )
 {
 	TCHAR	szName[100];
@@ -888,23 +888,23 @@ void CDlgPrintSetting::SetFontName( int idTxt, int idUse, LOGFONT& lf, int nPoin
 	if (bUseFont) {
 		LOGFONT	lft;
 		lft = lf;
-		lft.lfHeight = m_nFontHeight;		// ƒtƒHƒ“ƒgƒTƒCƒY‚ğƒ_ƒCƒAƒƒO‚É‡‚¹‚é
+		lft.lfHeight = m_nFontHeight;		// ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºã‚’ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã«åˆã›ã‚‹
 
 		HFONT	hFontOld = (HFONT)::SendMessage(::GetDlgItem( GetHwnd(), idTxt ), WM_GETFONT, 0, 0 );
 
-		// ˜_—ƒtƒHƒ“ƒg‚ğì¬
+		// è«–ç†ãƒ•ã‚©ãƒ³ãƒˆã‚’ä½œæˆ
 		HFONT	hFont = ::CreateFontIndirect( &lft );
 		if (hFont) {
-			// ƒtƒHƒ“ƒg‚Ìİ’è
+			// ãƒ•ã‚©ãƒ³ãƒˆã®è¨­å®š
 			::SendMessage( ::GetDlgItem( GetHwnd(), idTxt ), WM_SETFONT, (WPARAM)hFont, MAKELPARAM(FALSE, 0) );
 		}
 		if (m_hFontDlg != hFontOld) {
-			// ŒÃ‚¢ƒtƒHƒ“ƒg‚Ì”jŠü
+			// å¤ã„ãƒ•ã‚©ãƒ³ãƒˆã®ç ´æ£„
 			::DeleteObject( hFontOld );
 		}
 
-		// ƒtƒHƒ“ƒg–¼/ƒTƒCƒY‚Ìì¬
-		int		nMM = MulDiv( nPointSize, 254, 720 );	// ƒtƒHƒ“ƒgƒTƒCƒYŒvZ(pt->1/10mm)
+		// ãƒ•ã‚©ãƒ³ãƒˆå/ã‚µã‚¤ã‚ºã®ä½œæˆ
+		int		nMM = MulDiv( nPointSize, 254, 720 );	// ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºè¨ˆç®—(pt->1/10mm)
 		auto_sprintf(szName, nPointSize%10 ? _T("%.32s(%.1fpt/%d.%dmm)") : _T("%.32s(%.0fpt/%d.%dmm)"),
 					lf.lfFaceName,
 					double(nPointSize)/10,

--- a/sakura_core/dlg/CDlgPrintSetting.h
+++ b/sakura_core/dlg/CDlgPrintSetting.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ˆóüİ’èƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief å°åˆ·è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
 */
@@ -34,9 +34,9 @@
 #include "config/maxdata.h" // MAX_PRINTSETTINGARR
 #include "print/CPrint.h" //PRINTSETTING
 
-/*!	ˆóüİ’èƒ_ƒCƒAƒƒO
+/*!	å°åˆ·è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 */
 class CDlgPrintSetting : public CDialog
 {
@@ -48,22 +48,22 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, int*, PRINTSETTING*, int );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, int*, PRINTSETTING*, int );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 private:
 	int				m_nCurrentPrintSetting;
 	PRINTSETTING	m_PrintSettingArr[MAX_PRINTSETTINGARR];
-	int				m_nLineNumberColumns;					// s”Ô†•\¦‚·‚éê‡‚ÌŒ…”
+	int				m_nLineNumberColumns;					// è¡Œç•ªå·è¡¨ç¤ºã™ã‚‹å ´åˆã®æ¡æ•°
 	bool			m_bPrintableLinesAndColumnInvalid;
-	HFONT			m_hFontDlg;								// ƒ_ƒCƒAƒƒO‚ÌƒtƒHƒ“ƒgƒnƒ“ƒhƒ‹
-	int				m_nFontHeight;							// ƒ_ƒCƒAƒƒO‚ÌƒtƒHƒ“ƒg‚ÌƒTƒCƒY
+	HFONT			m_hFontDlg;								// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ•ã‚©ãƒ³ãƒˆãƒãƒ³ãƒ‰ãƒ«
+	int				m_nFontHeight;							// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ•ã‚©ãƒ³ãƒˆã®ã‚µã‚¤ã‚º
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
-	void SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );
 	BOOL OnDestroy( void );
 	BOOL OnNotify( WPARAM,  LPARAM );
@@ -74,12 +74,12 @@ protected:
 	BOOL OnEnKillFocus( HWND hwndCtl, int wID );
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
 
-	void OnChangeSettingType( BOOL );	/* İ’è‚Ìƒ^ƒCƒv‚ª•Ï‚í‚Á‚½ */
-	void OnSpin( int , BOOL );	/* ƒXƒsƒ“ƒRƒ“ƒgƒ[ƒ‹‚Ìˆ— */
-	int DataCheckAndCorrect( int , int );	/* “ü—Í’l(”’l)‚ÌƒGƒ‰[ƒ`ƒFƒbƒN‚ğ‚µ‚Ä³‚µ‚¢’l‚ğ•Ô‚· */
-	BOOL CalcPrintableLineAndColumn();	/* s”‚ÆŒ…”‚ğŒvZ */
-	void UpdatePrintableLineAndColumn();	/* s”‚ÆŒ…”‚ÌŒvZ—v‹ */
-	void SetFontName( int idTxt, int idUse, LOGFONT& lf, int nPointSize );	// ƒtƒHƒ“ƒg–¼/g—pƒ{ƒ^ƒ“‚Ìİ’è
+	void OnChangeSettingType( BOOL );	/* è¨­å®šã®ã‚¿ã‚¤ãƒ—ãŒå¤‰ã‚ã£ãŸ */
+	void OnSpin( int , BOOL );	/* ã‚¹ãƒ”ãƒ³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®å‡¦ç† */
+	int DataCheckAndCorrect( int , int );	/* å…¥åŠ›å€¤(æ•°å€¤)ã®ã‚¨ãƒ©ãƒ¼ãƒã‚§ãƒƒã‚¯ã‚’ã—ã¦æ­£ã—ã„å€¤ã‚’è¿”ã™ */
+	BOOL CalcPrintableLineAndColumn();	/* è¡Œæ•°ã¨æ¡æ•°ã‚’è¨ˆç®— */
+	void UpdatePrintableLineAndColumn();	/* è¡Œæ•°ã¨æ¡æ•°ã®è¨ˆç®—è¦æ±‚ */
+	void SetFontName( int idTxt, int idUse, LOGFONT& lf, int nPointSize );	// ãƒ•ã‚©ãƒ³ãƒˆå/ä½¿ç”¨ãƒœã‚¿ãƒ³ã®è¨­å®š
 };
 
 

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒvƒƒtƒ@ƒCƒ‹ƒ}ƒl[ƒWƒƒ
+ï»¿/*!	@file
+	@brief ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ãƒãƒãƒ¼ã‚¸ãƒ£
 
 	@author Moca
 	@date 2013.12.31
@@ -38,16 +38,16 @@
 #include "sakura.hh"
 
 const DWORD p_helpids[] = {
-	IDC_LIST_PROFILE,				HIDC_LIST_PROFILE,				//ƒvƒƒtƒ@ƒCƒ‹ˆê——
-	IDC_CHECK_PROF_DEFSTART,		HIDC_CHECK_PROF_DEFSTART,		//ƒfƒtƒHƒ‹ƒgİ’è‚É‚µ‚Ä‹N“®
-	IDOK,							HIDOK_PROFILEMGR,				//‹N“®
-	IDCANCEL,						HIDCANCEL_PROFILEMGR,			//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_PROFILEMGR_BUTTON_HELP,	//ƒwƒ‹ƒv
-	IDC_BUTTON_PROF_CREATE,			HIDC_BUTTON_PROF_CREATE,		//V‹Kì¬
-	IDC_BUTTON_PROF_RENAME,			HIDC_BUTTON_PROF_RENAME,		//–¼‘O•ÏX
-	IDC_BUTTON_PROF_DELETE,			HIDC_BUTTON_PROF_DELETE,		//íœ
-	IDC_BUTTON_PROF_DEFSET,			HIDC_BUTTON_PROF_DEFSET,		//ƒfƒtƒHƒ‹ƒgİ’è
-	IDC_BUTTON_PROF_DEFCLEAR,		HIDC_BUTTON_PROF_DEFCLEAR,		//ƒfƒtƒHƒ‹ƒg‰ğœ
+	IDC_LIST_PROFILE,				HIDC_LIST_PROFILE,				//ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§
+	IDC_CHECK_PROF_DEFSTART,		HIDC_CHECK_PROF_DEFSTART,		//ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè¨­å®šã«ã—ã¦èµ·å‹•
+	IDOK,							HIDOK_PROFILEMGR,				//èµ·å‹•
+	IDCANCEL,						HIDCANCEL_PROFILEMGR,			//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_PROFILEMGR_BUTTON_HELP,	//ãƒ˜ãƒ«ãƒ—
+	IDC_BUTTON_PROF_CREATE,			HIDC_BUTTON_PROF_CREATE,		//æ–°è¦ä½œæˆ
+	IDC_BUTTON_PROF_RENAME,			HIDC_BUTTON_PROF_RENAME,		//åå‰å¤‰æ›´
+	IDC_BUTTON_PROF_DELETE,			HIDC_BUTTON_PROF_DELETE,		//å‰Šé™¤
+	IDC_BUTTON_PROF_DEFSET,			HIDC_BUTTON_PROF_DEFSET,		//ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè¨­å®š
+	IDC_BUTTON_PROF_DEFCLEAR,		HIDC_BUTTON_PROF_DEFCLEAR,		//ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè§£é™¤
 	0, 0
 };
 
@@ -57,7 +57,7 @@ CDlgProfileMgr::CDlgProfileMgr()
 	return;
 }
 
-/*! ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/*! ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgProfileMgr::DoModal( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam )
 {
 	return (int)CDialog::DoModal( hInstance, hwndParent, IDD_PROFILEMGR, lParam );
@@ -98,7 +98,7 @@ static std::tstring GetProfileMgrFileName(LPCTSTR profName = NULL)
 }
 
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgProfileMgr::SetData()
 {
 	SetData( -1 );
@@ -158,7 +158,7 @@ static bool MyList_GetText(HWND hwndList, int index, TCHAR* szText)
 }
 
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 int CDlgProfileMgr::GetData()
 {
 	return GetData(true);
@@ -230,7 +230,7 @@ BOOL CDlgProfileMgr::OnBnClicked( int wID )
 		break;
 
 	case IDC_BUTTON_HELP:
-		/* uŒŸõv‚Ìƒwƒ‹ƒv */
+		/* ã€Œæ¤œç´¢ã€ã®ãƒ˜ãƒ«ãƒ— */
 		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_PROFILEMGR) );
 		break;
 
@@ -388,7 +388,7 @@ void CDlgProfileMgr::RenameProf()
 		return;
 	}
 	if( 0 == auto_strcmp( szTextOld, szText ) ){
-		return; // –¢•ÏX
+		return; // æœªå¤‰æ›´
 	}
 	std::wstring strText = to_wchar(szText);
 	static const WCHAR szReservedChars[] = L"/\\*?<>&|:\"'\t";
@@ -410,13 +410,13 @@ void CDlgProfileMgr::RenameProf()
 	std::tstring strProfDir = GetProfileMgrFileName(szText);
 	if( IsFileExists(strProfDirOld.c_str(), false) ){
 		if( !IsFileExists(strProfDirOld.c_str(), true) ){
-			// ƒvƒƒtƒ@ƒCƒ‹–¼‚ÍƒfƒBƒŒƒNƒgƒŠ
+			// ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«åã¯ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª
 			if( FALSE == ::MoveFile( strProfDirOld.c_str(), strProfDir.c_str() ) ){
 				ErrorMessage( GetHwnd(), LS(STR_DLGPROFILE_ERR_RENAME) );
 				return;
 			}
 		}else{
-			// ‹Œƒvƒƒtƒ@ƒCƒ‹–¼‚Íƒtƒ@ƒCƒ‹‚¾‚Á‚½‚Ì‚ÅV‹Kƒvƒƒtƒ@ƒCƒ‹‚Æ‚µ‚Äì¬Šm”F
+			// æ—§ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«åã¯ãƒ•ã‚¡ã‚¤ãƒ«ã ã£ãŸã®ã§æ–°è¦ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ã¨ã—ã¦ä½œæˆç¢ºèª
 			if( IsFileExists(strProfDir.c_str(), true) ){
 				ErrorMessage( GetHwnd(), LS(STR_DLGPROFILE_ERR_FILE) );
 				return;
@@ -479,7 +479,7 @@ static bool IOProfSettings( SProfileSettings& settings, bool bWrite )
 	for(int i = 0; i < nCount; i++){
 		wchar_t szKey[64];
 		std::tstring strProfName;
-		swprintf( szKey, L"P[%d]", i + 1 ); // 1ŠJn
+		swprintf( szKey, L"P[%d]", i + 1 ); // 1é–‹å§‹
 		if( bWrite ){
 			strProfName = settings.m_vProfList[i];
 			std::wstring wstrProfName = to_wchar(strProfName.c_str());

--- a/sakura_core/dlg/CDlgProfileMgr.h
+++ b/sakura_core/dlg/CDlgProfileMgr.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒvƒƒtƒ@ƒCƒ‹ƒ}ƒl[ƒWƒƒ
+ï»¿/*!	@file
+	@brief ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ãƒãƒãƒ¼ã‚¸ãƒ£
 
 	@author Moca
 	@date 2013.12.31
@@ -52,17 +52,17 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int		DoModal( HINSTANCE, HWND, LPARAM );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int		DoModal( HINSTANCE, HWND, LPARAM );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 protected:
 
 	BOOL	OnBnClicked( int );
 	INT_PTR	DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );
 
-	void	SetData();	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	void	SetData( int );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int		GetData();	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-	int		GetData( bool );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void	SetData();	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	void	SetData( int );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int		GetData();	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+	int		GetData( bool );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 	LPVOID	GetHelpIdTable(void);
 
 	void	UpdateIni();

--- a/sakura_core/dlg/CDlgProperty.cpp
+++ b/sakura_core/dlg/CDlgProperty.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒtƒ@ƒCƒ‹ƒvƒƒpƒeƒBƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
 */
@@ -46,18 +46,18 @@
 #include "util/shell.h"
 #include "sakura_rc.h"
 
-// ƒvƒƒpƒeƒB CDlgProperty.cpp	//@@@ 2002.01.07 add start MIK
+// ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ CDlgProperty.cpp	//@@@ 2002.01.07 add start MIK
 #include "sakura.hh"
 const DWORD p_helpids[] = {	//12600
 	IDOK,					HIDOK_PROP,
-//	IDCANCEL,				HIDCANCEL_PROP,			// –¢g—p del 2008/7/4 Uchi
+//	IDCANCEL,				HIDCANCEL_PROP,			// æœªä½¿ç”¨ del 2008/7/4 Uchi
 	IDC_BUTTON_HELP,		HIDC_PROP_BUTTON_HELP,
 	IDC_EDIT_PROPERTY,		HIDC_PROP_EDIT1,		// IDC_EDIT1->IDC_EDIT_PROPERTY	2008/7/3 Uchi
 //	IDC_STATIC,				-1,
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgProperty::DoModal( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam )
 {
 	return (int)CDialog::DoModal( hInstance, hwndParent, IDD_PROPERTY_FILE, lParam );
@@ -67,26 +67,26 @@ BOOL CDlgProperty::OnBnClicked( int wID )
 {
 	switch( wID ){
 	case IDC_BUTTON_HELP:
-		/* uƒtƒ@ƒCƒ‹‚ÌƒvƒƒpƒeƒBv‚Ìƒwƒ‹ƒv */
-		//Stonee, 2001/03/12 ‘ælˆø”‚ğA‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_PROPERTY_FILE) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ã€Œãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã€ã®ãƒ˜ãƒ«ãƒ— */
+		//Stonee, 2001/03/12 ç¬¬å››å¼•æ•°ã‚’ã€æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_PROPERTY_FILE) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
-	case IDOK:			/* ‰ºŒŸõ */
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	case IDOK:			/* ä¸‹æ¤œç´¢ */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
-//	case IDCANCEL:							// –¢g—p del 2008/7/4 Uchi
+//	case IDCANCEL:							// æœªä½¿ç”¨ del 2008/7/4 Uchi
 //		::EndDialog( GetHwnd(), FALSE );
 //		return TRUE;
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
 
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 */
 void CDlgProperty::SetData( void )
 {
@@ -97,7 +97,7 @@ void CDlgProperty::SetData( void )
 	HANDLE			nFind;
 	WIN32_FIND_DATA	wfd;
 
-	//	Aug. 16, 2000 genta	‘SŠp‰»
+	//	Aug. 16, 2000 genta	å…¨è§’åŒ–
 	cmemProp.AppendString( LS(STR_DLGFLPROP_FILENAME) );
 	cmemProp.AppendString( pCEditDoc->m_cDocFile.GetFilePath() );
 	cmemProp.AppendString( _T("\r\n") );
@@ -126,7 +126,7 @@ void CDlgProperty::SetData( void )
 	cmemProp.AppendString( szWork );
 
 	if( CAppMode::getInstance()->IsViewMode() ){
-		cmemProp.AppendString( LS(STR_DLGFLPROP_VIEW_MODE) );	// 2009.04.11 ryoji uã‘‚«‹Ö~ƒ‚[ƒhv¨uƒrƒ…[ƒ‚[ƒhv
+		cmemProp.AppendString( LS(STR_DLGFLPROP_VIEW_MODE) );	// 2009.04.11 ryoji ã€Œä¸Šæ›¸ãç¦æ­¢ãƒ¢ãƒ¼ãƒ‰ã€â†’ã€Œãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ã€
 	}
 	if( pCEditDoc->m_cDocEditor.IsModified() ){
 		cmemProp.AppendString( LS(STR_DLGFLPROP_MODIFIED) );
@@ -247,7 +247,7 @@ void CDlgProperty::SetData( void )
 	char*					pBuf;
 	int						nBufLen;
 	CNativeT				ctext;
-	/* ƒƒ‚ƒŠŠm•Û & ƒtƒ@ƒCƒ‹“Ç‚İ‚İ */
+	/* ãƒ¡ãƒ¢ãƒªç¢ºä¿ & ãƒ•ã‚¡ã‚¤ãƒ«èª­ã¿è¾¼ã¿ */
 	hgData = NULL;
 	CBinaryInputStream in(pCEditDoc->m_cDocFile.GetFilePath());
 	if(!in){
@@ -266,7 +266,7 @@ void CDlgProperty::SetData( void )
 	in.Read( pBuf, nBufLen );
 	in.Close();
 
-	//CESI‚ÌƒfƒoƒbƒOî•ñ
+	//CESIã®ãƒ‡ãƒãƒƒã‚°æƒ…å ±
 	CESI::GetDebugInfo(pBuf,nBufLen,&ctext);
 	cmemProp.AppendNativeData(ctext);
 

--- a/sakura_core/dlg/CDlgProperty.h
+++ b/sakura_core/dlg/CDlgProperty.h
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ƒtƒ@ƒCƒ‹ƒvƒƒpƒeƒBƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
-	@date 1999/02/31 V‹Kì¬
-	@date 1999/12/05 Äì¬
+	@date 1999/02/31 æ–°è¦ä½œæˆ
+	@date 1999/12/05 å†ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -36,18 +36,18 @@ class CDlgProperty;
 
 #include "dlg/CDialog.h"
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 class CDlgProperty : public CDialog
 {
 public:
-	int DoModal( HINSTANCE, HWND, LPARAM  );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, LPARAM  );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL OnBnClicked( int );
-	void SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+	void SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
 };
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/dlg/CDlgReplace.cpp
+++ b/sakura_core/dlg/CDlgReplace.cpp
@@ -1,14 +1,14 @@
-/*!	@file
-	@brief ’uŠ·ƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
-	@date 2001/06/23 N.Nakatani ’PŒê’PˆÊ‚ÅŒŸõ‚·‚é‹@”\‚ğÀ‘•
+	@date 2001/06/23 N.Nakatani å˜èªå˜ä½ã§æ¤œç´¢ã™ã‚‹æ©Ÿèƒ½ã‚’å®Ÿè£…
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2001, genta, Stonee, hor, YAZAKI
 	Copyright (C) 2002, MIK, hor, novice, genta, aroka, YAZAKI
-	Copyright (C) 2006, ‚©‚ë‚Æ, ryoji
+	Copyright (C) 2006, ã‹ã‚ã¨, ryoji
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2012, Uchi
@@ -24,52 +24,52 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 
-//’uŠ· CDlgReplace.cpp	//@@@ 2002.01.07 add start MIK
+//ç½®æ› CDlgReplace.cpp	//@@@ 2002.01.07 add start MIK
 const DWORD p_helpids[] = {	//11900
-	IDC_BUTTON_SEARCHNEXT,			HIDC_REP_BUTTON_SEARCHNEXT,			//‰ºŒŸõ
-	IDC_BUTTON_SEARCHPREV,			HIDC_REP_BUTTON_SEARCHPREV,			//ãŒŸõ
-	IDC_BUTTON_REPALCE,				HIDC_REP_BUTTON_REPALCE,			//’uŠ·
-	IDC_BUTTON_REPALCEALL,			HIDC_REP_BUTTON_REPALCEALL,			//‘S’uŠ·
-	IDCANCEL,						HIDCANCEL_REP,						//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_REP_BUTTON_HELP,				//ƒwƒ‹ƒv
-	IDC_CHK_PASTE,					HIDC_REP_CHK_PASTE,					//ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯
-	IDC_CHK_WORD,					HIDC_REP_CHK_WORD,					//’PŒê’PˆÊ
-	IDC_CHK_LOHICASE,				HIDC_REP_CHK_LOHICASE,				//‘å•¶š¬•¶š
-	IDC_CHK_REGULAREXP,				HIDC_REP_CHK_REGULAREXP,			//³‹K•\Œ»
-	IDC_CHECK_NOTIFYNOTFOUND,		HIDC_REP_CHECK_NOTIFYNOTFOUND,		//Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚É’Ê’m
-	IDC_CHECK_bAutoCloseDlgReplace,	HIDC_REP_CHECK_bAutoCloseDlgReplace,	//©“®“I‚É•Â‚¶‚é
-	IDC_COMBO_TEXT,					HIDC_REP_COMBO_TEXT,				//’uŠ·‘O
-	IDC_COMBO_TEXT2,				HIDC_REP_COMBO_TEXT2,				//’uŠ·Œã
-	IDC_RADIO_REPLACE,				HIDC_REP_RADIO_REPLACE,				//’uŠ·‘ÎÛF’uŠ·
-	IDC_RADIO_INSERT,				HIDC_REP_RADIO_INSERT,				//’uŠ·‘ÎÛF‘}“ü
-	IDC_RADIO_ADD,					HIDC_REP_RADIO_ADD,					//’uŠ·‘ÎÛF’Ç‰Á
-	IDC_RADIO_LINEDELETE,			HIDC_REP_RADIO_LINEDELETE,			//’uŠ·‘ÎÛFsíœ
-	IDC_RADIO_SELECTEDAREA,			HIDC_REP_RADIO_SELECTEDAREA,		//”ÍˆÍF‘S‘Ì
-	IDC_RADIO_ALLAREA,				HIDC_REP_RADIO_ALLAREA,				//”ÍˆÍF‘I‘ğ”ÍˆÍ
-	IDC_STATIC_JRE32VER,			HIDC_REP_STATIC_JRE32VER,			//³‹K•\Œ»ƒo[ƒWƒ‡ƒ“
-	IDC_BUTTON_SETMARK,				HIDC_REP_BUTTON_SETMARK,			//2002.01.16 hor ŒŸõŠY“–s‚ğƒ}[ƒN
-	IDC_CHECK_SEARCHALL,			HIDC_REP_CHECK_SEARCHALL,			//2002.01.26 hor æ“ªi––”öj‚©‚çÄŒŸõ
-	IDC_CHECK_CONSECUTIVEALL,		HIDC_REP_CHECK_CONSECUTIVEALL,		//u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ	// 2007.01.16 ryoji
+	IDC_BUTTON_SEARCHNEXT,			HIDC_REP_BUTTON_SEARCHNEXT,			//ä¸‹æ¤œç´¢
+	IDC_BUTTON_SEARCHPREV,			HIDC_REP_BUTTON_SEARCHPREV,			//ä¸Šæ¤œç´¢
+	IDC_BUTTON_REPALCE,				HIDC_REP_BUTTON_REPALCE,			//ç½®æ›
+	IDC_BUTTON_REPALCEALL,			HIDC_REP_BUTTON_REPALCEALL,			//å…¨ç½®æ›
+	IDCANCEL,						HIDCANCEL_REP,						//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_REP_BUTTON_HELP,				//ãƒ˜ãƒ«ãƒ—
+	IDC_CHK_PASTE,					HIDC_REP_CHK_PASTE,					//ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘
+	IDC_CHK_WORD,					HIDC_REP_CHK_WORD,					//å˜èªå˜ä½
+	IDC_CHK_LOHICASE,				HIDC_REP_CHK_LOHICASE,				//å¤§æ–‡å­—å°æ–‡å­—
+	IDC_CHK_REGULAREXP,				HIDC_REP_CHK_REGULAREXP,			//æ­£è¦è¡¨ç¾
+	IDC_CHECK_NOTIFYNOTFOUND,		HIDC_REP_CHECK_NOTIFYNOTFOUND,		//è¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã«é€šçŸ¥
+	IDC_CHECK_bAutoCloseDlgReplace,	HIDC_REP_CHECK_bAutoCloseDlgReplace,	//è‡ªå‹•çš„ã«é–‰ã˜ã‚‹
+	IDC_COMBO_TEXT,					HIDC_REP_COMBO_TEXT,				//ç½®æ›å‰
+	IDC_COMBO_TEXT2,				HIDC_REP_COMBO_TEXT2,				//ç½®æ›å¾Œ
+	IDC_RADIO_REPLACE,				HIDC_REP_RADIO_REPLACE,				//ç½®æ›å¯¾è±¡ï¼šç½®æ›
+	IDC_RADIO_INSERT,				HIDC_REP_RADIO_INSERT,				//ç½®æ›å¯¾è±¡ï¼šæŒ¿å…¥
+	IDC_RADIO_ADD,					HIDC_REP_RADIO_ADD,					//ç½®æ›å¯¾è±¡ï¼šè¿½åŠ 
+	IDC_RADIO_LINEDELETE,			HIDC_REP_RADIO_LINEDELETE,			//ç½®æ›å¯¾è±¡ï¼šè¡Œå‰Šé™¤
+	IDC_RADIO_SELECTEDAREA,			HIDC_REP_RADIO_SELECTEDAREA,		//ç¯„å›²ï¼šå…¨ä½“
+	IDC_RADIO_ALLAREA,				HIDC_REP_RADIO_ALLAREA,				//ç¯„å›²ï¼šé¸æŠç¯„å›²
+	IDC_STATIC_JRE32VER,			HIDC_REP_STATIC_JRE32VER,			//æ­£è¦è¡¨ç¾ãƒãƒ¼ã‚¸ãƒ§ãƒ³
+	IDC_BUTTON_SETMARK,				HIDC_REP_BUTTON_SETMARK,			//2002.01.16 hor æ¤œç´¢è©²å½“è¡Œã‚’ãƒãƒ¼ã‚¯
+	IDC_CHECK_SEARCHALL,			HIDC_REP_CHECK_SEARCHALL,			//2002.01.26 hor å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢
+	IDC_CHECK_CONSECUTIVEALL,		HIDC_REP_CHECK_CONSECUTIVEALL,		//ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã—	// 2007.01.16 ryoji
 //	IDC_STATIC,						-1,
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
 
 CDlgReplace::CDlgReplace()
 {
-	m_sSearchOption.Reset();	// ŒŸõƒIƒvƒVƒ‡ƒ“
-	m_bConsecutiveAll = FALSE;	// u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ	// 2007.01.16 ryoji
-	m_bSelectedArea = FALSE;	// ‘I‘ğ”ÍˆÍ“à’uŠ·
-	m_nReplaceTarget = 0;		// ’uŠ·‘ÎÛ		// 2001.12.03 hor
-	m_nPaste = FALSE;			// “\‚è•t‚¯‚éH	// 2001.12.03 hor
-	m_nReplaceCnt = 0;			//‚·‚×‚Ä’uŠ·‚ÌÀsŒ‹‰Ê		// 2002.02.08 hor
-	m_bCanceled = false;		//‚·‚×‚Ä’uŠ·‚ğ’†’f‚µ‚½‚©	// 2002.02.08 hor
+	m_sSearchOption.Reset();	// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	m_bConsecutiveAll = FALSE;	// ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã—	// 2007.01.16 ryoji
+	m_bSelectedArea = FALSE;	// é¸æŠç¯„å›²å†…ç½®æ›
+	m_nReplaceTarget = 0;		// ç½®æ›å¯¾è±¡		// 2001.12.03 hor
+	m_nPaste = FALSE;			// è²¼ã‚Šä»˜ã‘ã‚‹ï¼Ÿ	// 2001.12.03 hor
+	m_nReplaceCnt = 0;			//ã™ã¹ã¦ç½®æ›ã®å®Ÿè¡Œçµæœ		// 2002.02.08 hor
+	m_bCanceled = false;		//ã™ã¹ã¦ç½®æ›ã‚’ä¸­æ–­ã—ãŸã‹	// 2002.02.08 hor
 	return;
 }
 
 /*!
-	ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒhƒƒbƒvƒ_ƒEƒ“ƒƒbƒZ[ƒW‚ğ•ß‘¨‚·‚é
+	ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ‰ãƒ­ãƒƒãƒ—ãƒ€ã‚¦ãƒ³ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’æ•æ‰ã™ã‚‹
 
-	@date 2013.03.24 novice V‹Kì¬
+	@date 2013.03.24 novice æ–°è¦ä½œæˆ
 */
 BOOL CDlgReplace::OnCbnDropDown( HWND hwndCtl, int wID )
 {
@@ -94,20 +94,20 @@ BOOL CDlgReplace::OnCbnDropDown( HWND hwndCtl, int wID )
 	return CDialog::OnCbnDropDown( hwndCtl, wID );
 }
 
-/* ƒ‚[ƒhƒŒƒXƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 HWND CDlgReplace::DoModeless( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam, BOOL bSelected )
 {
-	m_sSearchOption = m_pShareData->m_Common.m_sSearch.m_sSearchOption;		// ŒŸõƒIƒvƒVƒ‡ƒ“
-	m_bConsecutiveAll = m_pShareData->m_Common.m_sSearch.m_bConsecutiveAll;	// u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ	// 2007.01.16 ryoji
-	m_bSelectedArea = m_pShareData->m_Common.m_sSearch.m_bSelectedArea;		// ‘I‘ğ”ÍˆÍ“à’uŠ·
-	m_bNOTIFYNOTFOUND = m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND;	// ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦
+	m_sSearchOption = m_pShareData->m_Common.m_sSearch.m_sSearchOption;		// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	m_bConsecutiveAll = m_pShareData->m_Common.m_sSearch.m_bConsecutiveAll;	// ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã—	// 2007.01.16 ryoji
+	m_bSelectedArea = m_pShareData->m_Common.m_sSearch.m_bSelectedArea;		// é¸æŠç¯„å›²å†…ç½®æ›
+	m_bNOTIFYNOTFOUND = m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND;	// æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º
 	m_bSelected = bSelected;
-	m_ptEscCaretPos_PHY = ((CEditView*)lParam)->GetCaret().GetCaretLogicPos();	// ŒŸõ/’uŠ·ŠJn‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‘Ş”ğ
-	((CEditView*)lParam)->m_bSearch = TRUE;							// ŒŸõ/’uŠ·ŠJnˆÊ’u‚Ì“o˜^—L–³			02/07/28 ai
+	m_ptEscCaretPos_PHY = ((CEditView*)lParam)->GetCaret().GetCaretLogicPos();	// æ¤œç´¢/ç½®æ›é–‹å§‹æ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®é€€é¿
+	((CEditView*)lParam)->m_bSearch = TRUE;							// æ¤œç´¢/ç½®æ›é–‹å§‹ä½ç½®ã®ç™»éŒ²æœ‰ç„¡			02/07/28 ai
 	return CDialog::DoModeless( hInstance, hwndParent, IDD_REPLACE, lParam, SW_SHOW );
 }
 
-/* ƒ‚[ƒhƒŒƒXF’uŠ·EŒŸõ‘ÎÛ‚Æ‚È‚éƒrƒ…[‚Ì•ÏX */
+/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹æ™‚ï¼šç½®æ›ãƒ»æ¤œç´¢å¯¾è±¡ã¨ãªã‚‹ãƒ“ãƒ¥ãƒ¼ã®å¤‰æ›´ */
 void CDlgReplace::ChangeView( LPARAM pcEditView )
 {
 	m_lParam = pcEditView;
@@ -117,57 +117,57 @@ void CDlgReplace::ChangeView( LPARAM pcEditView )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgReplace::SetData( void )
 {
-	// ŒŸõ•¶š—ñ/’uŠ·Œã•¶š—ñƒŠƒXƒg‚Ìİ’è(ŠÖ”‰»)	2010/5/26 Uchi
+	// æ¤œç´¢æ–‡å­—åˆ—/ç½®æ›å¾Œæ–‡å­—åˆ—ãƒªã‚¹ãƒˆã®è¨­å®š(é–¢æ•°åŒ–)	2010/5/26 Uchi
 	SetCombosList();
 
-	/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
+	/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 	::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, m_sSearchOption.bLoHiCase );
 
 	// 2001/06/23 N.Nakatani
-	/* ’PŒê’PˆÊ‚Å’T‚· */
+	/* å˜èªå˜ä½ã§æ¢ã™ */
 	::CheckDlgButton( GetHwnd(), IDC_CHK_WORD, m_sSearchOption.bWordOnly );
 
-	/* u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ */	// 2007.01.16 ryoji
+	/* ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã— */	// 2007.01.16 ryoji
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_CONSECUTIVEALL, m_bConsecutiveAll );
 
 	// From Here Jun. 29, 2001 genta
-	// ³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ
-	// ˆ—ƒtƒ[‹y‚Ñ”»’èğŒ‚ÌŒ©’¼‚µB•K‚¸³‹K•\Œ»‚Ìƒ`ƒFƒbƒN‚Æ
-	// –³ŠÖŒW‚ÉCheckRegexpVersion‚ğ’Ê‰ß‚·‚é‚æ‚¤‚É‚µ‚½B
+	// æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—
+	// å‡¦ç†ãƒ•ãƒ­ãƒ¼åŠã³åˆ¤å®šæ¡ä»¶ã®è¦‹ç›´ã—ã€‚å¿…ãšæ­£è¦è¡¨ç¾ã®ãƒã‚§ãƒƒã‚¯ã¨
+	// ç„¡é–¢ä¿‚ã«CheckRegexpVersionã‚’é€šéã™ã‚‹ã‚ˆã†ã«ã—ãŸã€‚
 	if( CheckRegexpVersion( GetHwnd(), IDC_STATIC_JRE32VER, false )
 		&& m_sSearchOption.bRegularExp){
-		/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
+		/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 		::CheckDlgButton( GetHwnd(), IDC_CHK_REGULAREXP, 1 );
 
 		// 2001/06/23 N.Nakatani
-		/* ’PŒê’PˆÊ‚Å’T‚· */
+		/* å˜èªå˜ä½ã§æ¢ã™ */
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ), FALSE );
 	}
 	else {
 		::CheckDlgButton( GetHwnd(), IDC_CHK_REGULAREXP, 0 );
 
-		/*u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ */
+		/*ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã— */
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHECK_CONSECUTIVEALL ), FALSE );	// 2007.01.16 ryoji
 	}
 	// To Here Jun. 29, 2001 genta
 
-	/* ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦ */
+	/* æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º */
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_NOTIFYNOTFOUND, m_bNOTIFYNOTFOUND );
 
 
-	/* ’uŠ· ƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é */
+	/* ç½®æ› ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_bAutoCloseDlgReplace, m_pShareData->m_Common.m_sSearch.m_bAutoCloseDlgReplace );
 
-	/* æ“ªi––”öj‚©‚çÄŒŸõ 2002.01.26 hor */
+	/* å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ 2002.01.26 hor */
 	::CheckDlgButton( GetHwnd(), IDC_CHECK_SEARCHALL, m_pShareData->m_Common.m_sSearch.m_bSearchAll );
 
 	// From Here 2001.12.03 hor
-	// ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯‚éH
+	// ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘ã‚‹ï¼Ÿ
 	::CheckDlgButton( GetHwnd(), IDC_CHK_PASTE, m_nPaste );
-	// ’uŠ·‘ÎÛ
+	// ç½®æ›å¯¾è±¡
 	if(m_nReplaceTarget==0){
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_REPLACE, TRUE );
 	}else
@@ -189,13 +189,13 @@ void CDlgReplace::SetData( void )
 
 
 
-// ŒŸõ•¶š—ñ/’uŠ·Œã•¶š—ñƒŠƒXƒg‚Ìİ’è
+// æ¤œç´¢æ–‡å­—åˆ—/ç½®æ›å¾Œæ–‡å­—åˆ—ãƒªã‚¹ãƒˆã®è¨­å®š
 //	2010/5/26 Uchi
 void CDlgReplace::SetCombosList( void )
 {
 	HWND	hwndCombo;
 
-	/* ŒŸõ•¶š—ñ */
+	/* æ¤œç´¢æ–‡å­—åˆ— */
 	hwndCombo = ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT );
 	while (Combo_GetCount(hwndCombo) > 0) {
 		Combo_DeleteString( hwndCombo, 0);
@@ -208,7 +208,7 @@ void CDlgReplace::SetCombosList( void )
 		::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_strText.c_str() );
 	}
 
-	/* ’uŠ·Œã•¶š—ñ */
+	/* ç½®æ›å¾Œæ–‡å­—åˆ— */
 	hwndCombo = ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT2 );
 	while (Combo_GetCount(hwndCombo) > 0) {
 		Combo_DeleteString( hwndCombo, 0);
@@ -222,37 +222,37 @@ void CDlgReplace::SetCombosList( void )
 }
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-/* 0==ğŒ–¢“ü—Í  0‚æ‚è‘å‚«‚¢==³í   0‚æ‚è¬‚³‚¢==“ü—ÍƒGƒ‰[ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+/* 0==æ¡ä»¶æœªå…¥åŠ›  0ã‚ˆã‚Šå¤§ãã„==æ­£å¸¸   0ã‚ˆã‚Šå°ã•ã„==å…¥åŠ›ã‚¨ãƒ©ãƒ¼ */
 int CDlgReplace::GetData( void )
 {
-	/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
+	/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 	m_sSearchOption.bLoHiCase = (0!=IsDlgButtonChecked( GetHwnd(), IDC_CHK_LOHICASE ));
 
 	// 2001/06/23 N.Nakatani
-	/* ’PŒê’PˆÊ‚Å’T‚· */
+	/* å˜èªå˜ä½ã§æ¢ã™ */
 	m_sSearchOption.bWordOnly = (0!=IsDlgButtonChecked( GetHwnd(), IDC_CHK_WORD ));
 
-	/* u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ */	// 2007.01.16 ryoji
+	/* ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã— */	// 2007.01.16 ryoji
 	m_bConsecutiveAll = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_CONSECUTIVEALL );
 
-	/* ³‹K•\Œ» */
+	/* æ­£è¦è¡¨ç¾ */
 	m_sSearchOption.bRegularExp = (0!=IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ));
-	/* ‘I‘ğ”ÍˆÍ“à’uŠ· */
+	/* é¸æŠç¯„å›²å†…ç½®æ› */
 	m_bSelectedArea = ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_SELECTEDAREA );
-	/* ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦ */
+	/* æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º */
 	m_bNOTIFYNOTFOUND = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_NOTIFYNOTFOUND );
 
-	m_pShareData->m_Common.m_sSearch.m_bConsecutiveAll = m_bConsecutiveAll;	// 1==u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ	// 2007.01.16 ryoji
-	m_pShareData->m_Common.m_sSearch.m_bSelectedArea = m_bSelectedArea;		// ‘I‘ğ”ÍˆÍ“à’uŠ·
-	m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND = m_bNOTIFYNOTFOUND;	// ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦
+	m_pShareData->m_Common.m_sSearch.m_bConsecutiveAll = m_bConsecutiveAll;	// 1==ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã—	// 2007.01.16 ryoji
+	m_pShareData->m_Common.m_sSearch.m_bSelectedArea = m_bSelectedArea;		// é¸æŠç¯„å›²å†…ç½®æ›
+	m_pShareData->m_Common.m_sSearch.m_bNOTIFYNOTFOUND = m_bNOTIFYNOTFOUND;	// æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º
 
-	/* ŒŸõ•¶š—ñ */
+	/* æ¤œç´¢æ–‡å­—åˆ— */
 	int nBufferSize = ::GetWindowTextLength( GetItemHwnd(IDC_COMBO_TEXT) ) + 1;
 	std::vector<TCHAR> vText(nBufferSize);
 	::DlgItem_GetText( GetHwnd(), IDC_COMBO_TEXT, &vText[0], nBufferSize);
 	m_strText = to_wchar(&vText[0]);
-	/* ’uŠ·Œã•¶š—ñ */
+	/* ç½®æ›å¾Œæ–‡å­—åˆ— */
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_LINEDELETE ) ){
 		m_strText2 = L"";
 	}else{
@@ -262,30 +262,30 @@ int CDlgReplace::GetData( void )
 		m_strText2 = to_wchar(&vText[0]);
 	}
 
-	/* ’uŠ· ƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é */
+	/* ç½®æ› ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
 	m_pShareData->m_Common.m_sSearch.m_bAutoCloseDlgReplace = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_bAutoCloseDlgReplace );
 
-	/* æ“ªi––”öj‚©‚çÄŒŸõ 2002.01.26 hor */
+	/* å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ 2002.01.26 hor */
 	m_pShareData->m_Common.m_sSearch.m_bSearchAll = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_SEARCHALL );
 
 	if( 0 < m_strText.size() ){
-		/* ³‹K•\Œ»H */
+		/* æ­£è¦è¡¨ç¾ï¼Ÿ */
 		// From Here Jun. 26, 2001 genta
-		//	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ
+		//	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—
 		int nFlag = 0x00;
 		nFlag |= m_sSearchOption.bLoHiCase ? 0x01 : 0x00;
 		if( m_sSearchOption.bRegularExp && !CheckRegexpSyntax( m_strText.c_str(), GetHwnd(), true, nFlag ) ){
 			return -1;
 		}
-		// To Here Jun. 26, 2001 genta ³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ·‚µ‘Ö‚¦
+		// To Here Jun. 26, 2001 genta æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªå·®ã—æ›¿ãˆ
 
-		/* ŒŸõ•¶š—ñ */
-		//@@@ 2002.2.2 YAZAKI CShareData.AddToSearchKeyArr()’Ç‰Á‚É”º‚¤•ÏX
+		/* æ¤œç´¢æ–‡å­—åˆ— */
+		//@@@ 2002.2.2 YAZAKI CShareData.AddToSearchKeyArr()è¿½åŠ ã«ä¼´ã†å¤‰æ›´
 		if( m_strText.size() < _MAX_PATH ){
 			CSearchKeywordManager().AddToSearchKeyArr( m_strText.c_str() );
-			m_pShareData->m_Common.m_sSearch.m_sSearchOption = m_sSearchOption;		// ŒŸõƒIƒvƒVƒ‡ƒ“
+			m_pShareData->m_Common.m_sSearch.m_sSearchOption = m_sSearchOption;		// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 		}
-		// 2011.12.18 view‚É’¼Úİ’è
+		// 2011.12.18 viewã«ç›´æ¥è¨­å®š
 		CEditView*	pcEditView = (CEditView*)m_lParam;
 		if( pcEditView->m_strCurSearchKey == m_strText && pcEditView->m_sCurSearchOption == m_sSearchOption ){
 		}else{
@@ -295,18 +295,18 @@ int CDlgReplace::GetData( void )
 		}
 		pcEditView->m_nCurSearchKeySequence = GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence;
 
-		/* ’uŠ·Œã•¶š—ñ */
-		//@@@ 2002.2.2 YAZAKI CShareData.AddToReplaceKeyArr()’Ç‰Á‚É”º‚¤•ÏX
+		/* ç½®æ›å¾Œæ–‡å­—åˆ— */
+		//@@@ 2002.2.2 YAZAKI CShareData.AddToReplaceKeyArr()è¿½åŠ ã«ä¼´ã†å¤‰æ›´
 		if( m_strText2.size() < _MAX_PATH ){
 			CSearchKeywordManager().AddToReplaceKeyArr( m_strText2.c_str() );
 		}
 		m_nReplaceKeySequence = GetDllShareData().m_Common.m_sSearch.m_nReplaceKeySequence;
 
 		// From Here 2001.12.03 hor
-		// ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯‚éH
+		// ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘ã‚‹ï¼Ÿ
 		m_nPaste=IsDlgButtonChecked( GetHwnd(), IDC_CHK_PASTE );
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT2 ), !m_nPaste );
-		// ’uŠ·‘ÎÛ
+		// ç½®æ›å¯¾è±¡
 		m_nReplaceTarget=0;
 		if(::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_INSERT )){
 			m_nReplaceTarget=1;
@@ -322,7 +322,7 @@ int CDlgReplace::GetData( void )
 		
 		// To Here 2001.12.03 hor
 
-		// ŒŸõ•¶š—ñ/’uŠ·Œã•¶š—ñƒŠƒXƒg‚Ìİ’è	2010/5/26 Uchi
+		// æ¤œç´¢æ–‡å­—åˆ—/ç½®æ›å¾Œæ–‡å­—åˆ—ãƒªã‚¹ãƒˆã®è¨­å®š	2010/5/26 Uchi
 		if (!m_bModal) {
 			SetCombosList();
 		}
@@ -339,28 +339,28 @@ BOOL CDlgReplace::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 {
 	_SetHwnd( hwndDlg );
 	//	Jun. 26, 2001 genta
-	//	‚±‚ÌˆÊ’u‚Å³‹K•\Œ»‚Ì‰Šú‰»‚ğ‚·‚é•K—v‚Í‚È‚¢
-	//	‘¼‚Æ‚ÌˆêŠÑ«‚ğ•Û‚Â‚½‚ßíœ
+	//	ã“ã®ä½ç½®ã§æ­£è¦è¡¨ç¾ã®åˆæœŸåŒ–ã‚’ã™ã‚‹å¿…è¦ã¯ãªã„
+	//	ä»–ã¨ã®ä¸€è²«æ€§ã‚’ä¿ã¤ãŸã‚å‰Šé™¤
 
-	/* ƒ†[ƒU[‚ªƒRƒ“ƒ{ ƒ{ƒbƒNƒX‚ÌƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+	/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚³ãƒ³ãƒœ ãƒœãƒƒã‚¯ã‚¹ã®ã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 	//	Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT ), _MAX_PATH - 1 );
 	//	Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT2 ), _MAX_PATH - 1 );
 
-	/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒ†[ƒU[ ƒCƒ“ƒ^[ƒtƒFƒCƒX‚ğŠg’£ƒCƒ“ƒ^[ƒtƒF[ƒX‚É‚·‚é */
+	/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼ ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ã‚¤ã‚¹ã‚’æ‹¡å¼µã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã«ã™ã‚‹ */
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT ), TRUE );
 	Combo_SetExtendedUI( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT2 ), TRUE );
 
 
-	/* ƒeƒLƒXƒg‘I‘ğ’†‚© */
+	/* ãƒ†ã‚­ã‚¹ãƒˆé¸æŠä¸­ã‹ */
 	if( m_bSelected ){
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_SEARCHPREV ), FALSE );	// 2001.12.03 hor ƒRƒƒ“ƒg‰ğœ
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_SEARCHNEXT ), FALSE );	// 2001.12.03 hor ƒRƒƒ“ƒg‰ğœ
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_REPALCE ), FALSE );		// 2001.12.03 hor ƒRƒƒ“ƒg‰ğœ
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_SEARCHPREV ), FALSE );	// 2001.12.03 hor ã‚³ãƒ¡ãƒ³ãƒˆè§£é™¤
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_SEARCHNEXT ), FALSE );	// 2001.12.03 hor ã‚³ãƒ¡ãƒ³ãƒˆè§£é™¤
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_REPALCE ), FALSE );		// 2001.12.03 hor ã‚³ãƒ¡ãƒ³ãƒˆè§£é™¤
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_SELECTEDAREA, TRUE );
-//		::CheckDlgButton( GetHwnd(), IDC_RADIO_ALLAREA, FALSE );						// 2001.12.03 hor ƒRƒƒ“ƒg
+//		::CheckDlgButton( GetHwnd(), IDC_RADIO_ALLAREA, FALSE );						// 2001.12.03 hor ã‚³ãƒ¡ãƒ³ãƒˆ
 	}else{
-//		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_RADIO_SELECTEDAREA ), FALSE );	// 2001.12.03 hor ƒRƒƒ“ƒg
-//		::CheckDlgButton( GetHwnd(), IDC_RADIO_SELECTEDAREA, FALSE );					// 2001.12.03 hor ƒRƒƒ“ƒg
+//		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_RADIO_SELECTEDAREA ), FALSE );	// 2001.12.03 hor ã‚³ãƒ¡ãƒ³ãƒˆ
+//		::CheckDlgButton( GetHwnd(), IDC_RADIO_SELECTEDAREA, FALSE );					// 2001.12.03 hor ã‚³ãƒ¡ãƒ³ãƒˆ
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_ALLAREA, TRUE );
 	}
 
@@ -371,7 +371,7 @@ BOOL CDlgReplace::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	m_comboDelText2.pRecent = &m_cRecentReplace;
 	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT2), &m_comboDelText2);
 
-	// ƒtƒHƒ“ƒgİ’è	2012/11/27 Uchi
+	// ãƒ•ã‚©ãƒ³ãƒˆè¨­å®š	2012/11/27 Uchi
 	HFONT hFontOld = (HFONT)::SendMessageAny( GetItemHwnd( IDC_COMBO_TEXT ), WM_GETFONT, 0, 0 );
 	HFONT hFont = SetMainFont( GetItemHwnd( IDC_COMBO_TEXT ) );
 	m_cFontText.SetFont( hFontOld, hFont, GetItemHwnd( IDC_COMBO_TEXT ) );
@@ -380,7 +380,7 @@ BOOL CDlgReplace::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	hFont = SetMainFont( GetItemHwnd( IDC_COMBO_TEXT2 ) );
 	m_cFontText2.SetFont( hFontOld, hFont, GetItemHwnd( IDC_COMBO_TEXT2 ) );
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 
 }
@@ -404,7 +404,7 @@ BOOL CDlgReplace::OnBnClicked( int wID )
 
 	switch( wID ){
 	case IDC_CHK_PASTE:
-		/* ƒeƒLƒXƒg‚Ì“\‚è•t‚¯ */
+		/* ãƒ†ã‚­ã‚¹ãƒˆã®è²¼ã‚Šä»˜ã‘ */
 		if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_PASTE ) &&
 			!pcEditView->m_pcEditDoc->m_cDocEditor.IsEnablePaste() ){
 			OkMessage( GetHwnd(), LS(STR_DLGREPLC_CLIPBOARD) );
@@ -412,7 +412,7 @@ BOOL CDlgReplace::OnBnClicked( int wID )
 		}
 		::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_COMBO_TEXT2 ), !(::IsDlgButtonChecked( GetHwnd(), IDC_CHK_PASTE)) );
 		return TRUE;
-		// ’uŠ·‘ÎÛ
+		// ç½®æ›å¯¾è±¡
 	case IDC_RADIO_REPLACE:
 	case IDC_RADIO_INSERT:
 	case IDC_RADIO_ADD:
@@ -426,7 +426,7 @@ BOOL CDlgReplace::OnBnClicked( int wID )
 		}
 		return TRUE;
 	case IDC_RADIO_SELECTEDAREA:
-		/* ”ÍˆÍ”ÍˆÍ */
+		/* ç¯„å›²ç¯„å›² */
 		if( ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_ALLAREA ) ){
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_BUTTON_SEARCHPREV ), TRUE );
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_BUTTON_SEARCHNEXT ), TRUE );
@@ -438,7 +438,7 @@ BOOL CDlgReplace::OnBnClicked( int wID )
 		}
 		return TRUE;
 	case IDC_RADIO_ALLAREA:
-		/* ƒtƒ@ƒCƒ‹‘S‘Ì */
+		/* ãƒ•ã‚¡ã‚¤ãƒ«å…¨ä½“ */
 		if( ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_ALLAREA ) ){
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_BUTTON_SEARCHPREV ), TRUE );
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_BUTTON_SEARCHNEXT ), TRUE );
@@ -451,56 +451,56 @@ BOOL CDlgReplace::OnBnClicked( int wID )
 		return TRUE;
 // To Here 2001.12.03 hor
 	case IDC_BUTTON_HELP:
-		/* u’uŠ·v‚Ìƒwƒ‹ƒv */
-		//Stonee, 2001/03/12 ‘ælˆø”‚ğA‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_REPLACE_DIALOG) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ã€Œç½®æ›ã€ã®ãƒ˜ãƒ«ãƒ— */
+		//Stonee, 2001/03/12 ç¬¬å››å¼•æ•°ã‚’ã€æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_REPLACE_DIALOG) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
-//	case IDC_CHK_LOHICASE:	/* ‘å•¶š‚Æ¬•¶š‚ğ‹æ•Ê‚·‚é */
+//	case IDC_CHK_LOHICASE:	/* å¤§æ–‡å­—ã¨å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 //		MYTRACE( _T("IDC_CHK_LOHICASE\n") );
 //		return TRUE;
-//	case IDC_CHK_WORDONLY:	/* ˆê’v‚·‚é’PŒê‚Ì‚İŒŸõ */
+//	case IDC_CHK_WORDONLY:	/* ä¸€è‡´ã™ã‚‹å˜èªã®ã¿æ¤œç´¢ */
 //		MYTRACE( _T("IDC_CHK_WORDONLY\n") );
 //		break;
-	case IDC_CHK_REGULAREXP:	/* ³‹K•\Œ» */
+	case IDC_CHK_REGULAREXP:	/* æ­£è¦è¡¨ç¾ */
 //		MYTRACE( _T("IDC_CHK_REGULAREXP ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ) = %d\n"), ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ) );
 		if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_REGULAREXP ) ){
 			// From Here Jun. 26, 2001 genta
-			//	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦‚É”º‚¤ˆ—‚ÌŒ©’¼‚µ
+			//	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆã«ä¼´ã†å‡¦ç†ã®è¦‹ç›´ã—
 			if( !CheckRegexpVersion( GetHwnd(), IDC_STATIC_JRE32VER, true ) ){
 				::CheckDlgButton( GetHwnd(), IDC_CHK_REGULAREXP, 0 );
 			}else{
 			// To Here Jun. 26, 2001 genta
 
-				/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
+				/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 				//	Jan. 31, 2002 genta
-				//	‘å•¶šE¬•¶š‚Ì‹æ•Ê‚Í³‹K•\Œ»‚Ìİ’è‚ÉŠÖ‚í‚ç‚¸•Û‘¶‚·‚é
+				//	å¤§æ–‡å­—ãƒ»å°æ–‡å­—ã®åŒºåˆ¥ã¯æ­£è¦è¡¨ç¾ã®è¨­å®šã«é–¢ã‚ã‚‰ãšä¿å­˜ã™ã‚‹
 				//::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, 1 );
 				//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_LOHICASE ), FALSE );
 
 				// 2001/06/23 N.Nakatani
-				/* ’PŒê’PˆÊ‚Å’T‚· */
+				/* å˜èªå˜ä½ã§æ¢ã™ */
 				::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ), FALSE );
 
-				/*u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ */
+				/*ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã— */
 				::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHECK_CONSECUTIVEALL ), TRUE );	// 2007.01.16 ryoji
 			}
 		}else{
-			/* ‰p‘å•¶š‚Æ‰p¬•¶š‚ğ‹æ•Ê‚·‚é */
+			/* è‹±å¤§æ–‡å­—ã¨è‹±å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹ */
 			//::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_LOHICASE ), TRUE );
 			//	Jan. 31, 2002 genta
-			//	‘å•¶šE¬•¶š‚Ì‹æ•Ê‚Í³‹K•\Œ»‚Ìİ’è‚ÉŠÖ‚í‚ç‚¸•Û‘¶‚·‚é
+			//	å¤§æ–‡å­—ãƒ»å°æ–‡å­—ã®åŒºåˆ¥ã¯æ­£è¦è¡¨ç¾ã®è¨­å®šã«é–¢ã‚ã‚‰ãšä¿å­˜ã™ã‚‹
 			//::CheckDlgButton( GetHwnd(), IDC_CHK_LOHICASE, 0 );
 
 			// 2001/06/23 N.Nakatani
-			/* ’PŒê’PˆÊ‚Å’T‚· */
+			/* å˜èªå˜ä½ã§æ¢ã™ */
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHK_WORD ), TRUE );
 
-			/*u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ */
+			/*ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã— */
 			::EnableWindow( ::GetDlgItem( GetHwnd(), IDC_CHECK_CONSECUTIVEALL ), FALSE );	// 2007.01.16 ryoji
 		}
 		return TRUE;
-//	case IDOK:			/* ‰ºŒŸõ */
-//		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+//	case IDOK:			/* ä¸‹æ¤œç´¢ */
+//		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 //		nRet = GetData();
 //		if( 0 < nRet ){
 //			::EndDialog( hwndDlg, 2 );
@@ -511,46 +511,46 @@ BOOL CDlgReplace::OnBnClicked( int wID )
 //		return TRUE;
 
 
-	case IDC_BUTTON_SEARCHPREV:	/* ãŒŸõ */
+	case IDC_BUTTON_SEARCHPREV:	/* ä¸Šæ¤œç´¢ */
 		nRet = GetData();
 		if( 0 < nRet ){
 
-			// ŒŸõŠJnˆÊ’u‚ğ“o˜^ 02/07/28 ai start
+			// æ¤œç´¢é–‹å§‹ä½ç½®ã‚’ç™»éŒ² 02/07/28 ai start
 			if( FALSE != pcEditView->m_bSearch ){
 				pcEditView->m_ptSrchStartPos_PHY = m_ptEscCaretPos_PHY;
 				pcEditView->m_bSearch = FALSE;
 			}// 02/07/28 ai end
 
-			/* ƒRƒ}ƒ“ƒhƒR[ƒh‚É‚æ‚éˆ—U‚è•ª‚¯ */
-			/* ‘O‚ğŒŸõ */
+			/* ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã«ã‚ˆã‚‹å‡¦ç†æŒ¯ã‚Šåˆ†ã‘ */
+			/* å‰ã‚’æ¤œç´¢ */
 			pcEditView->GetCommander().HandleCommand( F_SEARCH_PREV, true, (LPARAM)GetHwnd(), 0, 0, 0 );
-			/* Ä•`‰æi0•¶š•ƒ}ƒbƒ`‚ÅƒLƒƒƒŒƒbƒg‚ğ•\¦‚·‚é‚½‚ßj */
-			pcEditView->Redraw();	// ‘O‰ñ0•¶š•ƒ}ƒbƒ`‚ÌÁ‹‚É‚à•K—v
+			/* å†æç”»ï¼ˆ0æ–‡å­—å¹…ãƒãƒƒãƒã§ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’è¡¨ç¤ºã™ã‚‹ãŸã‚ï¼‰ */
+			pcEditView->Redraw();	// å‰å›0æ–‡å­—å¹…ãƒãƒƒãƒã®æ¶ˆå»ã«ã‚‚å¿…è¦
 		}else if(nRet == 0){
 			OkMessage( GetHwnd(), LS(STR_DLGREPLC_STR) );
 		}
 		return TRUE;
-	case IDC_BUTTON_SEARCHNEXT:	/* ‰ºŒŸõ */
+	case IDC_BUTTON_SEARCHNEXT:	/* ä¸‹æ¤œç´¢ */
 		nRet = GetData();
 		if( 0 < nRet ){
 
-			// ŒŸõŠJnˆÊ’u‚ğ“o˜^ 02/07/28 ai start
+			// æ¤œç´¢é–‹å§‹ä½ç½®ã‚’ç™»éŒ² 02/07/28 ai start
 			if( FALSE != pcEditView->m_bSearch ){
 				pcEditView->m_ptSrchStartPos_PHY = m_ptEscCaretPos_PHY;
 				pcEditView->m_bSearch = FALSE;
 			}// 02/07/28 ai end
 
-			/* ƒRƒ}ƒ“ƒhƒR[ƒh‚É‚æ‚éˆ—U‚è•ª‚¯ */
-			/* Ÿ‚ğŒŸõ */
+			/* ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã«ã‚ˆã‚‹å‡¦ç†æŒ¯ã‚Šåˆ†ã‘ */
+			/* æ¬¡ã‚’æ¤œç´¢ */
 			pcEditView->GetCommander().HandleCommand( F_SEARCH_NEXT, true, (LPARAM)GetHwnd(), 0, 0, 0 );
-			/* Ä•`‰æi0•¶š•ƒ}ƒbƒ`‚ÅƒLƒƒƒŒƒbƒg‚ğ•\¦‚·‚é‚½‚ßj */
-			pcEditView->Redraw();	// ‘O‰ñ0•¶š•ƒ}ƒbƒ`‚ÌÁ‹‚É‚à•K—v
+			/* å†æç”»ï¼ˆ0æ–‡å­—å¹…ãƒãƒƒãƒã§ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’è¡¨ç¤ºã™ã‚‹ãŸã‚ï¼‰ */
+			pcEditView->Redraw();	// å‰å›0æ–‡å­—å¹…ãƒãƒƒãƒã®æ¶ˆå»ã«ã‚‚å¿…è¦
 		}else if(nRet == 0){
 			OkMessage( GetHwnd(), LS(STR_DLGREPLC_STR) );
 		}
 		return TRUE;
 
-	case IDC_BUTTON_SETMARK:	//2002.01.16 hor ŠY“–sƒ}[ƒN
+	case IDC_BUTTON_SETMARK:	//2002.01.16 hor è©²å½“è¡Œãƒãƒ¼ã‚¯
 		nRet = GetData();
 		if( 0 < nRet ){
 			pcEditView->GetCommander().HandleCommand( F_BOOKMARK_PATTERN, false, 0, 0, 0, 0 );
@@ -558,50 +558,50 @@ BOOL CDlgReplace::OnBnClicked( int wID )
 		}
 		return TRUE;
 
-	case IDC_BUTTON_REPALCE:	/* ’uŠ· */
+	case IDC_BUTTON_REPALCE:	/* ç½®æ› */
 		nRet = GetData();
 		if( 0 < nRet ){
 
-			// ’uŠ·ŠJnˆÊ’u‚ğ“o˜^ 02/07/28 ai start
+			// ç½®æ›é–‹å§‹ä½ç½®ã‚’ç™»éŒ² 02/07/28 ai start
 			if( FALSE != pcEditView->m_bSearch ){
 				pcEditView->m_ptSrchStartPos_PHY = m_ptEscCaretPos_PHY;
 				pcEditView->m_bSearch = FALSE;
 			}// 02/07/28 ai end
 
-			/* ’uŠ· */
-			//@@@ 2002.2.2 YAZAKI ’uŠ·ƒRƒ}ƒ“ƒh‚ğCEditView‚ÉVİ
-			//@@@ 2002/04/08 YAZAKI eƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹‚ğ“n‚·‚æ‚¤‚É•ÏXB
+			/* ç½®æ› */
+			//@@@ 2002.2.2 YAZAKI ç½®æ›ã‚³ãƒãƒ³ãƒ‰ã‚’CEditViewã«æ–°è¨­
+			//@@@ 2002/04/08 YAZAKI è¦ªã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ«ã‚’æ¸¡ã™ã‚ˆã†ã«å¤‰æ›´ã€‚
 			pcEditView->GetCommander().HandleCommand( F_REPLACE, true, (LPARAM)GetHwnd(), 0, 0, 0 );
-			/* Ä•`‰æ */
+			/* å†æç”» */
 			pcEditView->GetCommander().HandleCommand( F_REDRAW, true, 0, 0, 0, 0 );
 		}else if(nRet == 0){
 			OkMessage( GetHwnd(), LS(STR_DLGREPLC_STR) );
 		}
 		return TRUE;
-	case IDC_BUTTON_REPALCEALL:	/* ‚·‚×‚Ä’uŠ· */
+	case IDC_BUTTON_REPALCEALL:	/* ã™ã¹ã¦ç½®æ› */
 		nRet = GetData();
 		if( 0 < nRet ){
-			// ’uŠ·ŠJnˆÊ’u‚ğ“o˜^ 02/07/28 ai start
+			// ç½®æ›é–‹å§‹ä½ç½®ã‚’ç™»éŒ² 02/07/28 ai start
 			if( FALSE != pcEditView->m_bSearch ){
 				pcEditView->m_ptSrchStartPos_PHY = m_ptEscCaretPos_PHY;
 				pcEditView->m_bSearch = FALSE;
 			}// 02/07/28 ai end
 
-			/* ‚·‚×‚Äs’uŠ·‚Ìˆ’u‚Íu‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µƒIƒvƒVƒ‡ƒ“OFF‚Ìê‡‚É‚µ‚Äíœ 2007.01.16 ryoji */
+			/* ã™ã¹ã¦è¡Œç½®æ›æ™‚ã®å‡¦ç½®ã¯ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã—ã‚ªãƒ—ã‚·ãƒ§ãƒ³OFFã®å ´åˆã«ã—ã¦å‰Šé™¤ 2007.01.16 ryoji */
 			pcEditView->GetCommander().HandleCommand( F_REPLACE_ALL, true, 0, 0, 0, 0 );
 			pcEditView->GetCommander().HandleCommand( F_REDRAW, true, 0, 0, 0, 0 );
 
-			/* ƒAƒNƒeƒBƒu‚É‚·‚é */
+			/* ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹ */
 			ActivateFrameWindow( GetHwnd() );
 
 			TopOkMessage( GetHwnd(), LS(STR_DLGREPLC_REPLACE), m_nReplaceCnt);
 
 			if( !m_bCanceled ){
-				if( m_bModal ){		/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚© */
-					/* ’uŠ·ƒ_ƒCƒAƒƒO‚ğ•Â‚¶‚é */
+				if( m_bModal ){		/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‹ */
+					/* ç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’é–‰ã˜ã‚‹ */
 					::EndDialog( GetHwnd(), 0 );
 				}else{
-					/* ’uŠ· ƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é */
+					/* ç½®æ› ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
 					if( m_pShareData->m_Common.m_sSearch.m_bAutoCloseDlgReplace ){
 						::DestroyWindow( GetHwnd() );
 					}
@@ -617,17 +617,17 @@ BOOL CDlgReplace::OnBnClicked( int wID )
 //		return TRUE;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
 BOOL CDlgReplace::OnActivate( WPARAM wParam, LPARAM lParam )
 {
-	// 0•¶š•ƒ}ƒbƒ`•`‰æ‚ÌON/OFF	// 2009.11.29 ryoji
+	// 0æ–‡å­—å¹…ãƒãƒƒãƒæç”»ã®ON/OFF	// 2009.11.29 ryoji
 	CEditView*	pcEditView = (CEditView*)m_lParam;
 	CLayoutRange cRangeSel = pcEditView->GetSelectionInfo().m_sSelect;
 	if( cRangeSel.IsValid() && cRangeSel.IsLineOne() && cRangeSel.IsOne() )
-		pcEditView->InvalidateRect(NULL);	// ƒAƒNƒeƒBƒu‰»^”ñƒAƒNƒeƒBƒu‰»‚ªŠ®—¹‚µ‚Ä‚©‚çÄ•`‰æ
+		pcEditView->InvalidateRect(NULL);	// ã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–ï¼éã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–ãŒå®Œäº†ã—ã¦ã‹ã‚‰å†æç”»
 
 	return CDialog::OnActivate(wParam, lParam);
 }

--- a/sakura_core/dlg/CDlgReplace.h
+++ b/sakura_core/dlg/CDlgReplace.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ’uŠ·ƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
-	@date 1998/10/02  V‹Kì¬
+	@date 1998/10/02  æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -23,10 +23,10 @@
 #include "util/window.h"
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 /*!
-	@brief ’uŠ·ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+	@brief ç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 */
 class CDlgReplace : public CDialog
 {
@@ -38,23 +38,23 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	HWND DoModeless( HINSTANCE, HWND, LPARAM, BOOL );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
-	void ChangeView( LPARAM );	/* ƒ‚[ƒhƒŒƒXF’uŠ·EŒŸõ‘ÎÛ‚Æ‚È‚éƒrƒ…[‚Ì•ÏX */
+	HWND DoModeless( HINSTANCE, HWND, LPARAM, BOOL );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
+	void ChangeView( LPARAM );	/* ãƒ¢ãƒ¼ãƒ‰ãƒ¬ã‚¹æ™‚ï¼šç½®æ›ãƒ»æ¤œç´¢å¯¾è±¡ã¨ãªã‚‹ãƒ“ãƒ¥ãƒ¼ã®å¤‰æ›´ */
 
-	SSearchOption	m_sSearchOption;	// ŒŸõƒIƒvƒVƒ‡ƒ“
-	int				m_bConsecutiveAll;	/* u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ */	// 2007.01.16 ryoji
-	std::wstring	m_strText;	// ŒŸõ•¶š—ñ
-	std::wstring	m_strText2;	// ’uŠ·Œã•¶š—ñ
-	int				m_nReplaceKeySequence;	//’uŠ·ŒãƒV[ƒPƒ“ƒX
-	BOOL			m_bSelectedArea;	/* ‘I‘ğ”ÍˆÍ“à’uŠ· */
-	int				m_bNOTIFYNOTFOUND;				/* ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦ */
-	BOOL			m_bSelected;	/* ƒeƒLƒXƒg‘I‘ğ’†‚© */
-	int				m_nReplaceTarget;	/* ’uŠ·‘ÎÛ */	// 2001.12.03 hor
-	int				m_nPaste;			/* “\‚è•t‚¯H */	// 2001.12.03 hor
-	int				m_nReplaceCnt;		//‚·‚×‚Ä’uŠ·‚ÌÀsŒ‹‰Ê		// 2002.02.08 hor
-	bool			m_bCanceled;		//‚·‚×‚Ä’uŠ·‚Å’†’f‚µ‚½‚©	// 2002.02.08 hor
+	SSearchOption	m_sSearchOption;	// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	int				m_bConsecutiveAll;	/* ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã— */	// 2007.01.16 ryoji
+	std::wstring	m_strText;	// æ¤œç´¢æ–‡å­—åˆ—
+	std::wstring	m_strText2;	// ç½®æ›å¾Œæ–‡å­—åˆ—
+	int				m_nReplaceKeySequence;	//ç½®æ›å¾Œã‚·ãƒ¼ã‚±ãƒ³ã‚¹
+	BOOL			m_bSelectedArea;	/* é¸æŠç¯„å›²å†…ç½®æ› */
+	int				m_bNOTIFYNOTFOUND;				/* æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º */
+	BOOL			m_bSelected;	/* ãƒ†ã‚­ã‚¹ãƒˆé¸æŠä¸­ã‹ */
+	int				m_nReplaceTarget;	/* ç½®æ›å¯¾è±¡ */	// 2001.12.03 hor
+	int				m_nPaste;			/* è²¼ã‚Šä»˜ã‘ï¼Ÿ */	// 2001.12.03 hor
+	int				m_nReplaceCnt;		//ã™ã¹ã¦ç½®æ›ã®å®Ÿè¡Œçµæœ		// 2002.02.08 hor
+	bool			m_bCanceled;		//ã™ã¹ã¦ç½®æ›ã§ä¸­æ–­ã—ãŸã‹	// 2002.02.08 hor
 
-	CLogicPoint		m_ptEscCaretPos_PHY;	// ŒŸõ/’uŠ·ŠJn‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‘Ş”ğƒGƒŠƒA
+	CLogicPoint		m_ptEscCaretPos_PHY;	// æ¤œç´¢/ç½®æ›é–‹å§‹æ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®é€€é¿ã‚¨ãƒªã‚¢
 
 protected:
 	CRecentSearch			m_cRecentSearch;
@@ -65,7 +65,7 @@ protected:
 	CFontAutoDeleter		m_cFontText2;
 
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL OnCbnDropDown( HWND hwndCtl, int wID );
 	BOOL OnInitDialog( HWND, WPARAM, LPARAM );
@@ -74,9 +74,9 @@ protected:
 	BOOL OnActivate( WPARAM wParam, LPARAM lParam );	// 2009.11.29 ryoji
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
 
-	void SetData( void );		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	void SetCombosList( void );	/* ŒŸõ•¶š—ñ/’uŠ·Œã•¶š—ñƒŠƒXƒg‚Ìİ’è */
-	int GetData( void );		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void SetData( void );		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	void SetCombosList( void );	/* æ¤œç´¢æ–‡å­—åˆ—/ç½®æ›å¾Œæ–‡å­—åˆ—ãƒªã‚¹ãƒˆã®è¨­å®š */
+	int GetData( void );		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 };
 
 

--- a/sakura_core/dlg/CDlgSetCharSet.cpp
+++ b/sakura_core/dlg/CDlgSetCharSet.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief •¶šƒR[ƒhƒZƒbƒgİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Uchi
-	@date 2010/6/14  V‹Kì¬
+	@date 2010/6/14  æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2010, Uchi
@@ -19,13 +19,13 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 
-//•¶šƒR[ƒhƒZƒbƒgİ’è CDlgSetCharSet
+//æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆè¨­å®š CDlgSetCharSet
 const DWORD p_helpids[] = {
-	IDOK,							HIDOK_GREP,							//ŒŸõ
-	IDCANCEL,						HIDCANCEL_GREP,						//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,				HIDC_GREP_BUTTON_HELP,				//ƒwƒ‹ƒv
-	IDC_COMBO_CHARSET,				HIDC_OPENDLG_COMBO_CODE,			//•¶šƒR[ƒhƒZƒbƒg
-	IDC_CHECK_BOM,					HIDC_OPENDLG_CHECK_BOM,				//ğŒ
+	IDOK,							HIDOK_GREP,							//æ¤œç´¢
+	IDCANCEL,						HIDCANCEL_GREP,						//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,				HIDC_GREP_BUTTON_HELP,				//ãƒ˜ãƒ«ãƒ—
+	IDC_COMBO_CHARSET,				HIDC_OPENDLG_COMBO_CODE,			//æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
+	IDC_CHECK_BOM,					HIDC_OPENDLG_CHECK_BOM,				//æ¡ä»¶
 	IDC_CHECK_CP,					HIDC_OPENDLG_CHECK_CP,				//CP
 	0, 0
 };
@@ -34,17 +34,17 @@ const DWORD p_helpids[] = {
 
 CDlgSetCharSet::CDlgSetCharSet()
 {
-	m_pnCharSet = NULL;			// •¶šƒR[ƒhƒZƒbƒg
-	m_pbBom = NULL;				// •¶šƒR[ƒhƒZƒbƒg
+	m_pnCharSet = NULL;			// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
+	m_pbBom = NULL;				// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
 	m_bCP = false;
 }
 
 
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgSetCharSet::DoModal( HINSTANCE hInstance, HWND hwndParent, ECodeType* pnCharSet, bool* pbBom)
 {
-	m_pnCharSet = pnCharSet;	// •¶šƒR[ƒhƒZƒbƒg
+	m_pnCharSet = pnCharSet;	// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
 	m_pbBom = pbBom;			// BOM
 
 	return (int)CDialog::DoModal( hInstance, hwndParent, IDD_SETCHARSET, (LPARAM)NULL );
@@ -56,13 +56,13 @@ BOOL CDlgSetCharSet::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 {
 	_SetHwnd( hwndDlg );
 	
-	m_hwndCharSet = ::GetDlgItem( GetHwnd(), IDC_COMBO_CHARSET );	// •¶šƒR[ƒhƒZƒbƒgƒRƒ“ƒ{ƒ{ƒbƒNƒX
-	m_hwndCheckBOM = ::GetDlgItem( GetHwnd(), IDC_CHECK_BOM );		// BOMƒ`ƒFƒbƒNƒ{ƒbƒNƒX
+	m_hwndCharSet = ::GetDlgItem( GetHwnd(), IDC_COMBO_CHARSET );	// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹
+	m_hwndCheckBOM = ::GetDlgItem( GetHwnd(), IDC_CHECK_BOM );		// BOMãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹
 
-	// ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ìƒ†[ƒU[ ƒCƒ“ƒ^[ƒtƒFƒCƒX‚ğŠg’£ƒCƒ“ƒ^[ƒtƒF[ƒX‚É‚·‚é
+	// ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼ ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ã‚¤ã‚¹ã‚’æ‹¡å¼µã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã«ã™ã‚‹
 	Combo_SetExtendedUI( m_hwndCharSet, TRUE );
 
-	// •¶šƒR[ƒhƒZƒbƒg‘I‘ğƒRƒ“ƒ{ƒ{ƒbƒNƒX‰Šú‰»
+	// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆé¸æŠã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹åˆæœŸåŒ–
 	int i;
 	CCodeTypesForCombobox cCodeTypes;
 	Combo_ResetContent( m_hwndCharSet );
@@ -71,7 +71,7 @@ BOOL CDlgSetCharSet::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		Combo_SetItemData( m_hwndCharSet, idx, cCodeTypes.GetCode(i) );
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 }
 
@@ -88,11 +88,11 @@ BOOL CDlgSetCharSet::OnBnClicked( int wID )
 		}
 		return TRUE;
 	case IDC_BUTTON_HELP:
-		/* u•¶šƒR[ƒhƒZƒbƒgİ’èv‚Ìƒwƒ‹ƒv */
+		/* ã€Œæ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆè¨­å®šã€ã®ãƒ˜ãƒ«ãƒ— */
 		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_CHG_CHARSET) );
 		return TRUE;
 	case IDOK:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		if( GetData() ){
 			CloseDialog( TRUE );
 		}
@@ -102,13 +102,13 @@ BOOL CDlgSetCharSet::OnBnClicked( int wID )
 		return TRUE;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
 
 
-// BOM ‚Ìİ’è
+// BOM ã®è¨­å®š
 void CDlgSetCharSet::SetBOM( void )
 {
 	int 		nIdx;
@@ -136,7 +136,7 @@ void CDlgSetCharSet::SetBOM( void )
 
 
 
-// •¶šƒR[ƒh‘I‘ğ‚Ìˆ—
+// æ–‡å­—ã‚³ãƒ¼ãƒ‰é¸æŠæ™‚ã®å‡¦ç†
 BOOL CDlgSetCharSet::OnCbnSelChange( HWND hwndCtl, int wID )
 {
 	int 		nIdx;
@@ -144,7 +144,7 @@ BOOL CDlgSetCharSet::OnCbnSelChange( HWND hwndCtl, int wID )
 	WPARAM		fCheck;
 
 	switch (wID) {
-	//	•¶šƒR[ƒh‚Ì•ÏX‚ğBOMƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚É”½‰f
+	//	æ–‡å­—ã‚³ãƒ¼ãƒ‰ã®å¤‰æ›´ã‚’BOMãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã«åæ˜ 
 	case IDC_COMBO_CHARSET:
 		SetBOM();
 		nIdx = Combo_GetCurSel( hwndCtl );
@@ -178,10 +178,10 @@ LPVOID CDlgSetCharSet::GetHelpIdTable(void)
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgSetCharSet::SetData( void )
 {
-	// •¶šƒR[ƒhƒZƒbƒg
+	// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
 	int		nIdx, nCurIdx, nIdxOld;
 	ECodeType nCharSet;
 	CCodeTypesForCombobox cCodeTypes;
@@ -205,17 +205,17 @@ void CDlgSetCharSet::SetData( void )
 	}
 	Combo_SetCurSel( m_hwndCharSet, nCurIdx );
 
-	// BOM‚ğİ’è
+	// BOMã‚’è¨­å®š
 	SetBOM();
 }
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
-/* TRUE==³í  FALSE==“ü—ÍƒGƒ‰[  */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+/* TRUE==æ­£å¸¸  FALSE==å…¥åŠ›ã‚¨ãƒ©ãƒ¼  */
 int CDlgSetCharSet::GetData( void )
 {
-	// •¶šƒR[ƒhƒZƒbƒg
+	// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
 	int		nIdx;
 	nIdx = Combo_GetCurSel( m_hwndCharSet );
 	*m_pnCharSet = (ECodeType)Combo_GetItemData( m_hwndCharSet, nIdx );

--- a/sakura_core/dlg/CDlgSetCharSet.h
+++ b/sakura_core/dlg/CDlgSetCharSet.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief •¶šƒR[ƒhƒZƒbƒgİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Uchi
-	@date 2010/6/14  V‹Kì¬
+	@date 2010/6/14  æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2010, Uchi
@@ -16,7 +16,7 @@
 
 #include "dlg/CDialog.h"
 
-//! •¶šƒR[ƒhƒZƒbƒgİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+//! æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 class CDlgSetCharSet : public CDialog
 {
 public:
@@ -27,10 +27,10 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, ECodeType*, bool* );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, ECodeType*, bool* );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 
-	ECodeType*	m_pnCharSet;			// •¶šƒR[ƒhƒZƒbƒg
+	ECodeType*	m_pnCharSet;			// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
 	bool*		m_pbBom;				// BOM
 	bool		m_bCP;
 
@@ -39,17 +39,17 @@ public:
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL	OnInitDialog( HWND, WPARAM, LPARAM );
 	BOOL	OnBnClicked( int );
 	BOOL	OnCbnSelChange( HWND, int );
 	LPVOID	GetHelpIdTable( void );
 
-	void	SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int 	GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void	SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int 	GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 
-	void	SetBOM( void );		// BOM ‚Ìİ’è
+	void	SetBOM( void );		// BOM ã®è¨­å®š
 };
 
 

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ƒ^ƒOƒWƒƒƒ“ƒvƒŠƒXƒgƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒªã‚¹ãƒˆãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
 	@date 2003.4.13
-	@date 2005.03.31 MIK ƒL[ƒ[ƒhw’èTagJump‘Î‰‚Ì‚½‚ß‘å•‚É•ÏX
+	@date 2005.03.31 MIK ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®šTagJumpå¯¾å¿œã®ãŸã‚å¤§å¹…ã«å¤‰æ›´
 */
 /*
 	Copyright (C) 2003, MIK
@@ -47,11 +47,11 @@
 
 
 const DWORD p_helpids[] = {
-	IDC_LIST_TAGJUMP,		HIDC_LIST_TAGJUMPLIST,			//ƒtƒ@ƒCƒ‹
+	IDC_LIST_TAGJUMP,		HIDC_LIST_TAGJUMPLIST,			//ãƒ•ã‚¡ã‚¤ãƒ«
 	IDOK,					HIDC_TAGJUMPLIST_IDOK,			//OK
-	IDCANCEL,				HIDC_TAGJUMPLIST_IDCANCEL,		//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,		HIDC_BUTTON_TAGJUMPLIST_HELP,	//ƒwƒ‹ƒv
-	IDC_KEYWORD,			HDIC_TAGJUMPLIST_KEYWORD,		//ƒL[ƒ[ƒh
+	IDCANCEL,				HIDC_TAGJUMPLIST_IDCANCEL,		//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,		HIDC_BUTTON_TAGJUMPLIST_HELP,	//ãƒ˜ãƒ«ãƒ—
+	IDC_KEYWORD,			HDIC_TAGJUMPLIST_KEYWORD,		//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
 	IDC_CHECK_ICASE,		HIDC_CHECK_ICASE,
 	IDC_CHECK_ANYWHERE,		HIDC_CHECK_ANYWHERE,
 	IDC_BUTTON_NEXTTAG,		HIDC_BUTTON_NEXTTAG,
@@ -75,8 +75,8 @@ static const SAnchorList anchorList[] = {
 };
 
 
-//ƒ^ƒOƒtƒ@ƒCƒ‹‚ÌƒtƒH[ƒ}ƒbƒg	//	@@ 2005.03.31 MIK ’è”‰»
-//	@@ 2005.04.03 MIK ƒL[ƒ[ƒh‚É‹ó”’‚ªŠÜ‚Ü‚ê‚éê‡‚Ìl—¶
+//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ	//	@@ 2005.03.31 MIK å®šæ•°åŒ–
+//	@@ 2005.04.03 MIK ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã«ç©ºç™½ãŒå«ã¾ã‚Œã‚‹å ´åˆã®è€ƒæ…®
 #define TAG_FORMAT_2_A       "%[^\t\r\n]\t%[^\t\r\n]\t%d;\"\t%s\t%s"
 #define TAG_FORMAT_1_A       "%[^\t\r\n]\t%[^\t\r\n]\t%d"
 #define TAG_FILE_INFO_A      "%[^\t\r\n]\t%[^\t\r\n]\t%[^\t\r\n]"
@@ -84,13 +84,13 @@ static const SAnchorList anchorList[] = {
 // #define TAG_FORMAT_E_NAME_A  "%[^\x7f\r\n]\x7f%[^\x7ff\r\n\x01]\x01%d,%d"
 
 //	@@ 2005.03.31 MIK
-//ƒL[ƒ[ƒh‚ğ“ü—Í‚µ‚ÄŠY“–‚·‚éî•ñ‚ğ•\¦‚·‚é‚Ü‚Å‚ÌŠÔ(ƒ~ƒŠ•b)
+//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’å…¥åŠ›ã—ã¦è©²å½“ã™ã‚‹æƒ…å ±ã‚’è¡¨ç¤ºã™ã‚‹ã¾ã§ã®æ™‚é–“(ãƒŸãƒªç§’)
 #define TAGJUMP_TIMER_DELAY 700
 #define TAGJUMP_TIMER_DELAY_SHORT 50
 
 
 /*
-	ctags.exe ‚ªo—Í‚·‚éAŠg’£q‚Æ‘Î‰‚·‚éí—Ş
+	ctags.exe ãŒå‡ºåŠ›ã™ã‚‹ã€æ‹¡å¼µå­ã¨å¯¾å¿œã™ã‚‹ç¨®é¡
 */
 static const TCHAR *p_extentions[] = {
 	/*asm*/			_T("asm,s"),								_T("d=define,l=label,m=macro,t=type"),
@@ -153,10 +153,10 @@ CDlgTagJumpList::CDlgTagJumpList(bool bDirectTagJump)
 	  m_psFind0Match( NULL ),
 	  m_strOldKeyword( L"" )
 {
-	/* ƒTƒCƒY•ÏX‚ÉˆÊ’u‚ğ§Œä‚·‚éƒRƒ“ƒgƒ[ƒ‹” */
+	/* ã‚µã‚¤ã‚ºå¤‰æ›´æ™‚ã«ä½ç½®ã‚’åˆ¶å¾¡ã™ã‚‹ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«æ•° */
 	assert( _countof(anchorList) == _countof(m_rcItems) );
 
-	// 2010.07.22 Moca ƒy[ƒWƒ“ƒOÌ—p‚Å Å‘å’l‚ğ100¨50‚ÉŒ¸‚ç‚·
+	// 2010.07.22 Moca ãƒšãƒ¼ã‚¸ãƒ³ã‚°æ¡ç”¨ã§ æœ€å¤§å€¤ã‚’100â†’50ã«æ¸›ã‚‰ã™
 	m_pcList = new CSortedTagJumpList(50);
 	m_psFindPrev = new STagFindState();
 	m_psFind0Match = new STagFindState();
@@ -181,10 +181,10 @@ CDlgTagJumpList::~CDlgTagJumpList()
 }
 
 /*!
-	ƒ^ƒCƒ}[’â~
+	ã‚¿ã‚¤ãƒãƒ¼åœæ­¢
 
 	@author MIK
-	@date 2005.03.31 V‹Kì¬
+	@date 2005.03.31 æ–°è¦ä½œæˆ
 */
 void CDlgTagJumpList::StopTimer( void )
 {
@@ -195,13 +195,13 @@ void CDlgTagJumpList::StopTimer( void )
 }
 
 /*!
-	ƒ^ƒCƒ}[ŠJn
+	ã‚¿ã‚¤ãƒãƒ¼é–‹å§‹
 	
-	ƒL[ƒ[ƒhw’èCˆê’èŠúŠÔ•¶š“ü—Í‚ª‚È‚¯‚ê‚ÎƒŠƒXƒg‚ğXV‚·‚é‚½‚ß
-	uˆê’èŠúŠÔv‚ğŒv‚éƒ^ƒCƒ}[‚ª•K—v
+	ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®šæ™‚ï¼Œä¸€å®šæœŸé–“æ–‡å­—å…¥åŠ›ãŒãªã‘ã‚Œã°ãƒªã‚¹ãƒˆã‚’æ›´æ–°ã™ã‚‹ãŸã‚
+	ã€Œä¸€å®šæœŸé–“ã€ã‚’è¨ˆã‚‹ã‚¿ã‚¤ãƒãƒ¼ãŒå¿…è¦
 
 	@author MIK
-	@date 2005.03.31 V‹Kì¬
+	@date 2005.03.31 æ–°è¦ä½œæˆ
 */
 void CDlgTagJumpList::StartTimer( int nDelay = TAGJUMP_TIMER_DELAY )
 {
@@ -210,10 +210,10 @@ void CDlgTagJumpList::StartTimer( int nDelay = TAGJUMP_TIMER_DELAY )
 }
 
 /*!
-	ƒŠƒXƒg‚ÌƒNƒŠƒA
+	ãƒªã‚¹ãƒˆã®ã‚¯ãƒªã‚¢
 
 	@author MIK
-	@date 2005.03.31 V‹Kì¬
+	@date 2005.03.31 æ–°è¦ä½œæˆ
 */
 void CDlgTagJumpList::Empty( void )
 {
@@ -222,9 +222,9 @@ void CDlgTagJumpList::Empty( void )
 }
 
 /*
-	ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦
+	ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º
 
-	@param[in] lParam 0=ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv, 1=ƒL[ƒ[ƒh‚ğw’è‚µ‚Äƒ^ƒOƒWƒƒƒ“ƒv
+	@param[in] lParam 0=ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—, 1=ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’æŒ‡å®šã—ã¦ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—
 */
 int CDlgTagJumpList::DoModal(
 	HINSTANCE	hInstance,
@@ -237,7 +237,7 @@ int CDlgTagJumpList::DoModal(
 	return ret;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgTagJumpList::SetData( void )
 {
 	if( IsDirectTagJump() ){
@@ -251,7 +251,7 @@ void CDlgTagJumpList::SetData( void )
 			::DlgItem_SetText( GetHwnd(), IDC_KEYWORD, m_pszKeyword );
 		}
 	}
-	//	From Here 2005.04.03 MIK İ’è’l‚Ì“Ç‚İ‚İ
+	//	From Here 2005.04.03 MIK è¨­å®šå€¤ã®èª­ã¿è¾¼ã¿
 	else{
 		HWND hwndKey;
 		hwndKey = ::GetDlgItem( GetHwnd(), IDC_KEYWORD );
@@ -274,23 +274,23 @@ void CDlgTagJumpList::SetData( void )
 		}
 		cRecentTagJump.Terminate();
 	}
-	//	To Here 2005.04.03 MIK İ’è’l‚Ì“Ç‚İ‚İ
+	//	To Here 2005.04.03 MIK è¨­å®šå€¤ã®èª­ã¿è¾¼ã¿
 	
 
 	SetTextDir();
 
 	UpdateData(true);
 
-	// ”O‚Ì‚½‚ßã‚©‚çUpdateData‚ÌŒã‚ÉˆÚ“®
+	// å¿µã®ãŸã‚ä¸Šã‹ã‚‰UpdateDataã®å¾Œã«ç§»å‹•
 	if( ! IsDirectTagJump() ){
-		StartTimer( TAGJUMP_TIMER_DELAY_SHORT ); // Å‰‚Í‹K’èŠÔ‘Ò‚½‚È‚¢
+		StartTimer( TAGJUMP_TIMER_DELAY_SHORT ); // æœ€åˆã¯è¦å®šæ™‚é–“å¾…ãŸãªã„
 	}
 }
 
-/*! @brief JumpŒó•â‚ÌXV
+/*! @brief Jumpå€™è£œã®æ›´æ–°
 
 	@date 2005.03.31 MIK 
-		ƒ_ƒCƒAƒƒOOpenˆÈŠO‚É‚àXV‚ª•K—v‚È‚½‚ßSetData()‚æ‚è•ª—£
+		ãƒ€ã‚¤ã‚¢ãƒ­ã‚°Openæ™‚ä»¥å¤–ã«ã‚‚æ›´æ–°ãŒå¿…è¦ãªãŸã‚SetData()ã‚ˆã‚Šåˆ†é›¢
 */
 void CDlgTagJumpList::UpdateData( bool bInit )
 {
@@ -341,10 +341,10 @@ void CDlgTagJumpList::UpdateData( bool bInit )
 
 	const TCHAR* pszMsgText = NULL;
 
-	//	”‚ª‘½‚·‚¬‚éê‡‚ÍØ‚èÌ‚Ä‚½|‚ğ––”ö‚É‘}“ü
+	//	æ•°ãŒå¤šã™ãã‚‹å ´åˆã¯åˆ‡ã‚Šæ¨ã¦ãŸæ—¨ã‚’æœ«å°¾ã«æŒ¿å…¥
 //	if( m_pcList->IsOverflow() ){
-		// 2010.04.03 uŸvu‘Ovƒ{ƒ^ƒ“’Ç‰Á‚µ‚Ä Overflow‚µ‚È‚­‚È‚Á‚½
-//		pszMsgText = _T("(‚±‚êˆÈ~‚ÍØ‚èÌ‚Ä‚Ü‚µ‚½)");
+		// 2010.04.03 ã€Œæ¬¡ã€ã€Œå‰ã€ãƒœã‚¿ãƒ³è¿½åŠ ã—ã¦ Overflowã—ãªããªã£ãŸ
+//		pszMsgText = _T("(ã“ã‚Œä»¥é™ã¯åˆ‡ã‚Šæ¨ã¦ã¾ã—ãŸ)");
 //	}
 	if( (! bInit) && m_pcList->GetCount() == 0 ){
 		pszMsgText = LS(STR_DLGTAGJMP2);
@@ -364,7 +364,7 @@ void CDlgTagJumpList::UpdateData( bool bInit )
 	}
 
 	if( IsDirectTagJump() && 0 == m_nTop && ! m_bNextItem ){
-		// ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv‚ÅAƒy[ƒWƒ“ƒO‚Ì•K—v‚ª‚È‚¢‚Æ‚«‚Í”ñ•\¦
+		// ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã§ã€ãƒšãƒ¼ã‚¸ãƒ³ã‚°ã®å¿…è¦ãŒãªã„ã¨ãã¯éè¡¨ç¤º
 		::ShowWindow( GetItemHwnd( IDC_BUTTON_NEXTTAG ), SW_HIDE );
 		::ShowWindow( GetItemHwnd( IDC_BUTTON_PREVTAG ), SW_HIDE );
 	}else{
@@ -382,11 +382,11 @@ void CDlgTagJumpList::UpdateData( bool bInit )
 	return;
 }
 
-/*!	ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+/*!	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
-	@return TRUE: ³í, FALSE: “ü—ÍƒGƒ‰[
+	@return TRUE: æ­£å¸¸, FALSE: å…¥åŠ›ã‚¨ãƒ©ãƒ¼
 
-	@date 2005.04.03 MIK İ’è’l‚Ì•Û‘¶ˆ—’Ç‰Á
+	@date 2005.04.03 MIK è¨­å®šå€¤ã®ä¿å­˜å‡¦ç†è¿½åŠ 
 */
 int CDlgTagJumpList::GetData( void )
 {
@@ -395,12 +395,12 @@ int CDlgTagJumpList::GetData( void )
 	hwndList = ::GetDlgItem( GetHwnd(), IDC_LIST_TAGJUMP );
 	m_nIndex = ListView_GetNextItem( hwndList, -1, LVIS_SELECTED );
 
-	//	From Here 2005.04.03 MIK İ’è’l‚Ì•Û‘¶
+	//	From Here 2005.04.03 MIK è¨­å®šå€¤ã®ä¿å­˜
 	if( !IsDirectTagJump() )
 	{
 		m_pShareData->m_sTagJump.m_bTagJumpICase = m_bTagJumpICase;
 		m_pShareData->m_sTagJump.m_bTagJumpAnyWhere = m_bTagJumpAnyWhere;
-		// 2010.07.22 Œó•â‚ª‹ó‚Å‚àƒWƒƒƒ“ƒv‚Å•Â‚¶‚½‚Æ‚«‚ÍAƒIƒvƒVƒ‡ƒ“‚ğ•Û‘¶‚·‚é
+		// 2010.07.22 å€™è£œãŒç©ºã§ã‚‚ã‚¸ãƒ£ãƒ³ãƒ—ã§é–‰ã˜ãŸã¨ãã¯ã€ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã‚’ä¿å­˜ã™ã‚‹
 		if( m_nIndex == -1 || m_nIndex >= m_pcList->GetCapacity() ){
 			return FALSE;
 		}
@@ -409,7 +409,7 @@ int CDlgTagJumpList::GetData( void )
 		::DlgItem_GetText( GetHwnd(), IDC_KEYWORD, tmp, _countof( tmp ) );
 		SetKeyword( tmp );
 
-		//İ’è‚ğ•Û‘¶
+		//è¨­å®šã‚’ä¿å­˜
 		CRecentTagjumpKeyword cRecentTagJumpKeyword;
 		cRecentTagJumpKeyword.AppendItem( m_pszKeyword );
 		cRecentTagJumpKeyword.Terminate();
@@ -422,7 +422,7 @@ int CDlgTagJumpList::GetData( void )
 
 /*!
 	@date 2005.03.31 MIK
-		ŠK‘wƒJƒ‰ƒ€‚Ì’Ç‰ÁDƒL[ƒ[ƒhw’è—“‚Ì’Ç‰Á
+		éšå±¤ã‚«ãƒ©ãƒ ã®è¿½åŠ ï¼ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®šæ¬„ã®è¿½åŠ 
 */
 BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 {
@@ -455,10 +455,10 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		m_nHeight = rcDialog.bottom - rcDialog.top;
 	}
 
-	// ƒEƒBƒ“ƒhƒE‚ÌƒŠƒTƒCƒY
+	// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒªã‚µã‚¤ã‚º
 	SetDialogPosSize();
 
-	//ƒŠƒXƒgƒrƒ…[‚Ì•\¦ˆÊ’u‚ğæ“¾‚·‚éB
+	//ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®è¡¨ç¤ºä½ç½®ã‚’å–å¾—ã™ã‚‹ã€‚
 	hwndList = ::GetDlgItem( hwndDlg, IDC_LIST_TAGJUMP );
 	//ListView_DeleteAllItems( hwndList );
 	rc.left = rc.top = rc.right = rc.bottom = 0;
@@ -508,12 +508,12 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	col.iSubItem = 5;
 	ListView_InsertColumn( hwndList, 5, &col );
 
-	/* s‘I‘ğ */
+	/* è¡Œé¸æŠ */
 	lngStyle = ListView_GetExtendedListViewStyle( hwndList );
 	lngStyle |= LVS_EX_FULLROWSELECT;
 	ListView_SetExtendedListViewStyle( hwndList, lngStyle );
 
-	// ƒ_ƒCƒŒƒNƒgƒ^ƒuƒWƒƒƒ“ƒv‚Ì‚ÍAƒL[ƒ[ƒh‚ğ”ñ•\¦
+	// ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ãƒ–ã‚¸ãƒ£ãƒ³ãƒ—ã®æ™‚ã¯ã€ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’éè¡¨ç¤º
 	HWND hwndKey = GetItemHwnd( IDC_KEYWORD );
 	int nShowFlag = (IsDirectTagJump() ? SW_HIDE : SW_SHOW);
 	::ShowWindow( GetItemHwnd( IDC_STATIC_KEYWORD ), nShowFlag );
@@ -521,10 +521,10 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	::ShowWindow( GetItemHwnd( IDC_CHECK_ICASE ), nShowFlag );
 	::ShowWindow( GetItemHwnd( IDC_CHECK_ANYWHERE ), nShowFlag );
 	if( IsDirectTagJump() ){
-		//ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv
+		//ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—
 		bRet = TRUE;
 	}else{
-		//ƒL[ƒ[ƒhw’è
+		//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®š
 		::SetFocus( hwndKey );
 		bRet = FALSE;	//for set focus
 	}
@@ -533,7 +533,7 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	m_comboDel.pRecent = &m_cRecentKeyword;
 	SetComboBoxDeleter(hwndKey, &m_comboDel);
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	CDialog::OnInitDialog( GetHwnd(), wParam, lParam );
 	
 	return bRet;
@@ -544,13 +544,13 @@ BOOL CDlgTagJumpList::OnBnClicked( int wID )
 	switch( wID )
 	{
 	case IDC_BUTTON_HELP:
-		/* ƒwƒ‹ƒv */
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID( F_TAGJUMP_LIST ) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ãƒ˜ãƒ«ãƒ— */
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID( F_TAGJUMP_LIST ) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 
-	case IDOK:			/* ¶‰E‚É•\¦ */
+	case IDOK:			/* å·¦å³ã«è¡¨ç¤º */
 		StopTimer();
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		::EndDialog( GetHwnd(), (BOOL)GetData() );
 		return TRUE;
 
@@ -559,7 +559,7 @@ BOOL CDlgTagJumpList::OnBnClicked( int wID )
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
 
-	// From Here 2005.04.03 MIK ŒŸõğŒİ’è
+	// From Here 2005.04.03 MIK æ¤œç´¢æ¡ä»¶è¨­å®š
 	case IDC_CHECK_ICASE:
 		m_bTagJumpICase = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_ICASE ) == BST_CHECKED;
 		StartTimer( TAGJUMP_TIMER_DELAY_SHORT );
@@ -569,7 +569,7 @@ BOOL CDlgTagJumpList::OnBnClicked( int wID )
 		m_bTagJumpAnyWhere = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_ANYWHERE ) == BST_CHECKED;
 		StartTimer( TAGJUMP_TIMER_DELAY_SHORT );
 		return TRUE;
-	// To Here 2005.04.03 MIK ŒŸõğŒİ’è
+	// To Here 2005.04.03 MIK æ¤œç´¢æ¡ä»¶è¨­å®š
 
 	case IDC_BUTTON_NEXTTAG:
 		m_nTop += m_pcList->GetCapacity();
@@ -583,7 +583,7 @@ BOOL CDlgTagJumpList::OnBnClicked( int wID )
 		return TRUE;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
@@ -604,7 +604,7 @@ INT_PTR CDlgTagJumpList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPA
 
 BOOL CDlgTagJumpList::OnSize( WPARAM wParam, LPARAM lParam )
 {
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	CDialog::OnSize( wParam, lParam );
 
 	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcTagJumpDialog );
@@ -657,7 +657,7 @@ BOOL CDlgTagJumpList::OnNotify( WPARAM wParam, LPARAM lParam )
 
 	hwndList = GetDlgItem( GetHwnd(), IDC_LIST_TAGJUMP );
 
-	//	Œó•âˆê——ƒŠƒXƒgƒ{ƒbƒNƒX
+	//	å€™è£œä¸€è¦§ãƒªã‚¹ãƒˆãƒœãƒƒã‚¯ã‚¹
 	if( hwndList == pNMHDR->hwndFrom )
 	{
 		switch( pNMHDR->code )
@@ -669,14 +669,14 @@ BOOL CDlgTagJumpList::OnNotify( WPARAM wParam, LPARAM lParam )
 		}
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnNotify( wParam, lParam );
 }
 
 /*!
-	ƒ^ƒCƒ}[Œo‰ß
+	ã‚¿ã‚¤ãƒãƒ¼çµŒé
 
-	ƒ^ƒCƒ}[‚ğ’â~‚µCŒó•âƒŠƒXƒg‚ğXV‚·‚é
+	ã‚¿ã‚¤ãƒãƒ¼ã‚’åœæ­¢ã—ï¼Œå€™è£œãƒªã‚¹ãƒˆã‚’æ›´æ–°ã™ã‚‹
 */
 BOOL CDlgTagJumpList::OnTimer( WPARAM wParam )
 {
@@ -688,15 +688,15 @@ BOOL CDlgTagJumpList::OnTimer( WPARAM wParam )
 }
 
 /*!
-	ƒ^ƒCƒ}[Œo‰ß
+	ã‚¿ã‚¤ãƒãƒ¼çµŒé
 
-	ƒ^ƒCƒ}[‚ğŠJn‚µCŒó•âƒŠƒXƒg‚ğXV‚·‚é€”õ‚ğ‚·‚é
+	ã‚¿ã‚¤ãƒãƒ¼ã‚’é–‹å§‹ã—ï¼Œå€™è£œãƒªã‚¹ãƒˆã‚’æ›´æ–°ã™ã‚‹æº–å‚™ã‚’ã™ã‚‹
 */
 BOOL CDlgTagJumpList::OnCbnEditChange( HWND hwndCtl, int wID )
 {
 	StartTimer();
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnCbnEditChange( hwndCtl, wID );
 }
 
@@ -704,7 +704,7 @@ BOOL CDlgTagJumpList::OnCbnSelChange( HWND hwndCtl, int wID )
 {
 	StartTimer();
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnCbnSelChange( hwndCtl, wID );
 }
 
@@ -713,7 +713,7 @@ BOOL CDlgTagJumpList::OnEnChange( HWND hwndCtl, int wID )
 {
 	StartTimer();
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnEnChange( hwndCtl, wID );
 }
 #endif
@@ -726,7 +726,7 @@ LPVOID CDlgTagJumpList::GetHelpIdTable( void )
 #if 0
 bool CDlgTagJumpList::AddParamA( const ACHAR *s0, const ACHAR *s1, int n2, const ACHAR *s3, const ACHAR *s4, int depth, int fileBase )
 {
-	if( -1 == m_nIndex ) m_nIndex = 0;	//‹K’è’l
+	if( -1 == m_nIndex ) m_nIndex = 0;	//è¦å®šå€¤
 
 	ClearPrevFindInfo();
 	m_bNextItem = false;
@@ -747,8 +747,8 @@ bool CDlgTagJumpList::GetSelectedFullPathAndLine( TCHAR *fullPath, int count, in
 }
 
 /*
-	@param lineNum [out] ƒIƒvƒVƒ‡ƒ“
-	@param depth [out] ƒIƒvƒVƒ‡ƒ“
+	@param lineNum [out] ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	@param depth [out] ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 */
 bool CDlgTagJumpList::GetFullPathAndLine( int index, TCHAR *fullPath, int count, int *lineNum, int *depth )
 {
@@ -764,7 +764,7 @@ bool CDlgTagJumpList::GetFullPathAndLine( int index, TCHAR *fullPath, int count,
 		*depth = tempDepth;
 	}
 	const TCHAR* fileNamePath;
-	// ƒtƒ@ƒCƒ‹–¼AƒfƒBƒŒƒNƒgƒŠw’èAŠî€ƒtƒ@ƒCƒ‹ƒpƒXA‚Ì‡‚É“K—pB“r’†‚Åƒtƒ‹ƒpƒX‚È‚ç‚»‚Ì‚Ü‚ÜB
+	// ãƒ•ã‚¡ã‚¤ãƒ«åã€ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªæŒ‡å®šã€åŸºæº–ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã€ã®é †ã«é©ç”¨ã€‚é€”ä¸­ã§ãƒ•ãƒ«ãƒ‘ã‚¹ãªã‚‰ãã®ã¾ã¾ã€‚
 	if( dirFileName[0] ){
 		AddLastYenFromDirectoryPath( dirFileName );
 		const TCHAR	*p = fileName;
@@ -777,7 +777,7 @@ bool CDlgTagJumpList::GetFullPathAndLine( int index, TCHAR *fullPath, int count,
 		}else if( _istalpha( p[0] ) && p[1] == _T(':') ){
 			auto_strcpy( dirFileName, p );
 		}else{
-			// ‘Š‘ÎƒpƒXF˜AŒ‹‚·‚é
+			// ç›¸å¯¾ãƒ‘ã‚¹ï¼šé€£çµã™ã‚‹
 			auto_strcat( dirFileName, p );
 		}
 		fileNamePath = dirFileName;
@@ -794,7 +794,7 @@ bool CDlgTagJumpList::GetFullPathAndLine( int index, TCHAR *fullPath, int count,
 }
 
 /*!
-	@return u.extvŒ`®‚Ìƒ^ƒCƒvî•ñB free‚·‚é‚±‚Æ
+	@return ã€Œ.extã€å½¢å¼ã®ã‚¿ã‚¤ãƒ—æƒ…å ±ã€‚ freeã™ã‚‹ã“ã¨
 */
 TCHAR *CDlgTagJumpList::GetNameByType( const TCHAR type, const TCHAR *name )
 {
@@ -805,7 +805,7 @@ TCHAR *CDlgTagJumpList::GetNameByType( const TCHAR type, const TCHAR *name )
 	TCHAR	tmp[MAX_TAG_STRING_LENGTH];
 
 	p = _tcsrchr( name, _T('.') );
-	if( ! p ) p = _T(".c");	//Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚Í ".c" ‚Æ‘z’è‚·‚éB
+	if( ! p ) p = _T(".c");	//è¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã¯ ".c" ã¨æƒ³å®šã™ã‚‹ã€‚
 	p++;
 
 	for( i = 0; p_extentions[i]; i += 2 )
@@ -839,7 +839,7 @@ TCHAR *CDlgTagJumpList::GetNameByType( const TCHAR type, const TCHAR *name )
 }
 
 /*!
-	Šî€ƒtƒ@ƒCƒ‹–¼‚ğİ’è
+	åŸºæº–ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¨­å®š
 */
 void CDlgTagJumpList::SetFileName( const TCHAR *pszFileName )
 {
@@ -854,7 +854,7 @@ void CDlgTagJumpList::SetFileName( const TCHAR *pszFileName )
 }
 
 /*!
-	ŒŸõƒL[ƒ[ƒh‚Ìİ’è
+	æ¤œç´¢ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®è¨­å®š
 
 */
 void CDlgTagJumpList::SetKeyword( const wchar_t *pszKeyword )
@@ -889,16 +889,16 @@ typedef struct tagTagPathInfo {
 } TagPathInfo;
 
 /*!
-	“¾‚ç‚ê‚½Œó•â‚©‚çÅ‚àŠú‘Ò‚É‹ß‚¢‚Æv‚í‚ê‚é‚à‚Ì‚ğ
-	‘I‚Ño‚·D(‰Šú‘I‘ğˆÊ’uŒˆ’è‚Ì‚½‚ß)
+	å¾—ã‚‰ã‚ŒãŸå€™è£œã‹ã‚‰æœ€ã‚‚æœŸå¾…ã«è¿‘ã„ã¨æ€ã‚ã‚Œã‚‹ã‚‚ã®ã‚’
+	é¸ã³å‡ºã™ï¼(åˆæœŸé¸æŠä½ç½®æ±ºå®šã®ãŸã‚)
 
-	@return ‘I‘ğ‚³‚ê‚½ƒAƒCƒeƒ€‚Ìindex
+	@return é¸æŠã•ã‚ŒãŸã‚¢ã‚¤ãƒ†ãƒ ã®index
 
-	@date 2014.06.14 ƒtƒ@ƒCƒ‹–¼EŠg’£qˆÈŠO‚Éƒhƒ‰ƒCƒuEƒpƒX‚àl—¶‚·‚é‚æ‚¤‚É
+	@date 2014.06.14 ãƒ•ã‚¡ã‚¤ãƒ«åãƒ»æ‹¡å¼µå­ä»¥å¤–ã«ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ»ãƒ‘ã‚¹ã‚‚è€ƒæ…®ã™ã‚‹ã‚ˆã†ã«
 */
 int CDlgTagJumpList::SearchBestTag( void )
 {
-	if( m_pcList->GetCount() <= 0 ) return -1;	//‘I‚×‚Ü‚¹‚ñB
+	if( m_pcList->GetCount() <= 0 ) return -1;	//é¸ã¹ã¾ã›ã‚“ã€‚
 	if( NULL == m_pszFileName ) return 0;
 
 	std::auto_ptr<TagPathInfo> mem_lpPathInfo( new TagPathInfo );
@@ -927,7 +927,7 @@ int CDlgTagJumpList::SearchBestTag( void )
 
 	for( i = 0; i < count; i++ )
 	{
-		// ƒ^ƒO‚Ìƒtƒ@ƒCƒ‹–¼•”•ª‚ğƒtƒ‹ƒpƒX‚É‚·‚é
+		// ã‚¿ã‚°ã®ãƒ•ã‚¡ã‚¤ãƒ«åéƒ¨åˆ†ã‚’ãƒ•ãƒ«ãƒ‘ã‚¹ã«ã™ã‚‹
 		lpPathInfo->szFileNameDst[0] = _T('\0');
 		{
 			TCHAR szPath[_MAX_PATH];
@@ -948,21 +948,21 @@ int CDlgTagJumpList::SearchBestTag( void )
 		lpPathInfo->nExtDst = _tcslen(lpPathInfo->szExtDst);
 		
 		if(_tcsicmp(m_pszFileName, lpPathInfo->szFileNameDst) == 0){
-			return i;	//“¯ˆêƒtƒ@ƒCƒ‹‚ğŒ©‚Â‚¯‚½
+			return i;	//åŒä¸€ãƒ•ã‚¡ã‚¤ãƒ«ã‚’è¦‹ã¤ã‘ãŸ
 		}
 
 		if((nMatch1 == -1)
 		&& (_tcsicmp(lpPathInfo->szDriveSrc, lpPathInfo->szDriveDst) == 0)
 		&& (_tcsicmp(lpPathInfo->szPathSrc, lpPathInfo->szPathDst) == 0)
 		&& (_tcsicmp(lpPathInfo->szFileSrc, lpPathInfo->szFileDst) == 0)){
-			//ƒtƒ@ƒCƒ‹–¼‚Ü‚Åˆê’v
+			//ãƒ•ã‚¡ã‚¤ãƒ«åã¾ã§ä¸€è‡´
 			nMatch1 = i;
 		}
 
 		if((nMatch2 == -1)
 		&& (_tcsicmp(lpPathInfo->szDriveSrc, lpPathInfo->szDriveDst) == 0)
 		&& (_tcsicmp(lpPathInfo->szPathSrc, lpPathInfo->szPathDst) == 0)){
-			//ƒpƒX–¼‚Ü‚Åˆê’v
+			//ãƒ‘ã‚¹åã¾ã§ä¸€è‡´
 			nMatch2 = i;
 		}
 
@@ -993,13 +993,13 @@ int CDlgTagJumpList::SearchBestTag( void )
 		if((nMatch3 == -1)
 		&& (_tcsicmp(lpPathInfo->szFileSrc, lpPathInfo->szFileDst) == 0)
 		&& (_tcsicmp(lpPathInfo->szExtSrc, lpPathInfo->szExtDst) == 0)){
-			//ƒtƒ@ƒCƒ‹–¼EŠg’£q‚ªˆê’v
+			//ãƒ•ã‚¡ã‚¤ãƒ«åãƒ»æ‹¡å¼µå­ãŒä¸€è‡´
 			nMatch3 = i;
 		}
 
 		if((nMatch4 == -1)
 		&& (_tcsicmp(lpPathInfo->szFileSrc, lpPathInfo->szFileDst) == 0)){
-			//ƒtƒ@ƒCƒ‹–¼‚ªˆê’v
+			//ãƒ•ã‚¡ã‚¤ãƒ«åãŒä¸€è‡´
 			nMatch4 = i;
 		}
 	}
@@ -1016,7 +1016,7 @@ int CDlgTagJumpList::SearchBestTag( void )
 }
 
 /*!
-	@param bNewFind V‚µ‚¢ŒŸõğŒ(ŸE‘O‚Ì‚Æ‚«false)
+	@param bNewFind æ–°ã—ã„æ¤œç´¢æ¡ä»¶(æ¬¡ãƒ»å‰ã®ã¨ãfalse)
 */
 void CDlgTagJumpList::FindNext( bool bNewFind )
 {
@@ -1024,13 +1024,13 @@ void CDlgTagJumpList::FindNext( bool bNewFind )
 	szKey[0] = L'\0';
 	::DlgItem_GetText( GetHwnd(), IDC_KEYWORD, szKey, _countof( szKey ) );
 	if( bNewFind ){
-		// ‘O‰ñ‚ÌƒL[ƒ[ƒh‚©‚ç‚ÌiŒŸõ‚Ì‚Æ‚«‚ÅAtags‚ğƒXƒLƒbƒv‚Å‚«‚é‚Æ‚«‚ÍƒXƒLƒbƒv
+		// å‰å›ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‹ã‚‰ã®çµè¾¼æ¤œç´¢ã®ã¨ãã§ã€tagsã‚’ã‚¹ã‚­ãƒƒãƒ—ã§ãã‚‹ã¨ãã¯ã‚¹ã‚­ãƒƒãƒ—
 		if( -1 < m_psFind0Match->m_nDepth
 			&& (m_bTagJumpAnyWhere == m_bOldTagJumpAnyWhere || FALSE == m_bTagJumpAnyWhere)
 			&& (m_bTagJumpICase    == m_bOldTagJumpICase    || FALSE == m_bTagJumpICase)
 			&& 0 == wcsncmp( m_strOldKeyword.GetStringPtr(), szKey, m_strOldKeyword.GetStringLength() ) ){
-			// Œ³‚ÌƒL[ƒ[ƒh‚Å‚PŒ‚àƒqƒbƒg‚µ‚È‚¢tags‚ª‚ ‚é‚Ì‚Å”ò‚Î‚·
-			// ğŒ‚Í“¯‚¶‚©AŒµ‚µ‚­‚È‚é‚È‚ç–â‘è‚È‚¢
+			// å…ƒã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã§ï¼‘ä»¶ã‚‚ãƒ’ãƒƒãƒˆã—ãªã„tagsãŒã‚ã‚‹ã®ã§é£›ã°ã™
+			// æ¡ä»¶ã¯åŒã˜ã‹ã€å³ã—ããªã‚‹ãªã‚‰å•é¡Œãªã„
 		}else{
 			ClearPrevFindInfo();
 		}
@@ -1041,17 +1041,17 @@ void CDlgTagJumpList::FindNext( bool bNewFind )
 }
 
 /*!
-	ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒvŒŸõ(DoModal‘O‚ÉÀs)
+	ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ¤œç´¢(DoModalå‰ã«å®Ÿè¡Œ)
 */
 int CDlgTagJumpList::FindDirectTagJump()
 {
 	return find_key_core(
-		0,	// 0ŠJn
+		0,	// 0é–‹å§‹
 		m_pszKeyword,
-		false, // •”•ªˆê’v
-		true,  // Š®‘Sˆê’v
-		false, // ‘å¬‚ğ‹æ•Ê
-		true,  // ©“®ƒ‚[ƒh
+		false, // éƒ¨åˆ†ä¸€è‡´
+		true,  // å®Œå…¨ä¸€è‡´
+		false, // å¤§å°ã‚’åŒºåˆ¥
+		true,  // è‡ªå‹•ãƒ¢ãƒ¼ãƒ‰
 		m_pShareData->m_Common.m_sSearch.m_nTagJumpMode
 	);
 }
@@ -1075,25 +1075,25 @@ void CDlgTagJumpList::find_key( const wchar_t* keyword )
 }
 
 /*!
-	ƒ^ƒOƒtƒ@ƒCƒ‹‚©‚çƒL[ƒ[ƒh‚Éƒ}ƒbƒ`‚·‚éƒf[ƒ^‚ğ’Šo‚µCm_cList‚Éİ’è‚·‚é
+	ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã«ãƒãƒƒãƒã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã‚’æŠ½å‡ºã—ï¼Œm_cListã«è¨­å®šã™ã‚‹
 
-	@date 2007.03.13 genta ƒoƒbƒtƒ@ƒI[ƒo[ƒ‰ƒ“b’è‘Îˆ‚Åƒoƒbƒtƒ@ƒTƒCƒY•ÏX
-	@date 2010.04.02 Moca ‚¢‚ë‚¢‚ë•ÏXBSJIS‚Å“Ç‚ŞBƒy[ƒWƒ“ƒO, format=1‚Ì‰ğßAƒ^ƒOƒtƒ@ƒCƒ‹î•ñ‚Ì—˜—p
-		u‘Stags‚ÌŒŸõŒ‹‰Ê‚ğƒ\[ƒg‚µ‚Äæ“ª‚©‚çCapaticy‚Ü‚Åv‚ğutagsƒtƒ@ƒCƒ‹‡(=depth)‡AƒL[ƒ[ƒh‡v‚É•ÏX
-	@date 2010.07.21 find_key¨find_key_core‚É‚µ‚ÄACViewCommander::Command_TagJumpByTagsFile‚Æ“‡
+	@date 2007.03.13 genta ãƒãƒƒãƒ•ã‚¡ã‚ªãƒ¼ãƒãƒ¼ãƒ©ãƒ³æš«å®šå¯¾å‡¦ã§ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºå¤‰æ›´
+	@date 2010.04.02 Moca ã„ã‚ã„ã‚å¤‰æ›´ã€‚SJISã§èª­ã‚€ã€‚ãƒšãƒ¼ã‚¸ãƒ³ã‚°, format=1ã®è§£é‡ˆã€ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«æƒ…å ±ã®åˆ©ç”¨
+		ã€Œå…¨tagsã®æ¤œç´¢çµæœã‚’ã‚½ãƒ¼ãƒˆã—ã¦å…ˆé ­ã‹ã‚‰Capaticyã¾ã§ã€ã‚’ã€Œtagsãƒ•ã‚¡ã‚¤ãƒ«é †(=depth)é †ã€ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰é †ã€ã«å¤‰æ›´
+	@date 2010.07.21 find_keyâ†’find_key_coreã«ã—ã¦ã€CViewCommander::Command_TagJumpByTagsFileã¨çµ±åˆ
 */
 int CDlgTagJumpList::find_key_core(
 	int  nTop,
 	const wchar_t* keyword,
-	bool bTagJumpAnyWhere, // •”•ªˆê’v
-	bool bTagJumpExactMatch, // Š®‘Sˆê’v
+	bool bTagJumpAnyWhere, // éƒ¨åˆ†ä¸€è‡´
+	bool bTagJumpExactMatch, // å®Œå…¨ä¸€è‡´
 	bool bTagJumpICase,
-	bool bTagJumpICaseByTags, // Tagƒtƒ@ƒCƒ‹‘¤‚Ìƒ\[ƒg‚É]‚¤
+	bool bTagJumpICaseByTags, // Tagãƒ•ã‚¡ã‚¤ãƒ«å´ã®ã‚½ãƒ¼ãƒˆã«å¾“ã†
 	int  nDefaultNextMode
 ){
 	assert_warning( !(bTagJumpAnyWhere && bTagJumpExactMatch) );
 
-	// to_achar‚Íˆêƒoƒbƒtƒ@‚Å”j‰ó‚³‚ê‚é‰Â”\«‚ª‚ ‚é‚Ì‚ÅƒRƒs[
+	// to_acharã¯ä¸€æ™‚ãƒãƒƒãƒ•ã‚¡ã§ç ´å£Šã•ã‚Œã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹ã®ã§ã‚³ãƒ”ãƒ¼
 	CNativeA cmemKeyA = CNativeA(to_achar(keyword));
 	const ACHAR* paszKeyword = cmemKeyA.GetStringPtr();
 	int	length = cmemKeyA.GetStringLength();
@@ -1109,7 +1109,7 @@ int CDlgTagJumpList::find_key_core(
 		ClearPrevFindInfo();
 		return -1;
 	}
-	// ‰•œ•ÏŠ·‚µ‚Ä‚İ‚Äˆê’v‚µ‚È‚©‚Á‚½‚çAŒŸõƒL[‚É‚Íˆê’v‚µ‚È‚¢‚Æ‚¢‚¤‚±‚Æ‚É‚·‚é
+	// å¾€å¾©å¤‰æ›ã—ã¦ã¿ã¦ä¸€è‡´ã—ãªã‹ã£ãŸã‚‰ã€æ¤œç´¢ã‚­ãƒ¼ã«ã¯ä¸€è‡´ã—ãªã„ã¨ã„ã†ã“ã¨ã«ã™ã‚‹
 	if( 0 != wcscmp( to_wchar( paszKeyword ), keyword ) ){
 		ClearPrevFindInfo();
 		return -1;
@@ -1121,42 +1121,42 @@ int CDlgTagJumpList::find_key_core(
 	state.m_nMatchAll = 0;
 	state.m_nNextMode = nDefaultNextMode;
 	state.m_nLoop     = -1;
-	state.m_bJumpPath = false;	// eˆÈŠO‚ÌƒpƒX‚ÌˆÚ“®æw’è
+	state.m_bJumpPath = false;	// è¦ªä»¥å¤–ã®ãƒ‘ã‚¹ã®ç§»å‹•å…ˆæŒ‡å®š
 	state.m_szCurPath[0] = 0;
 	
-	// ‘O‰ñ‚ÌŒ‹‰Ê‚©‚çŒŸõ‘ÎÛtags‚ği‚é
+	// å‰å›ã®çµæœã‹ã‚‰æ¤œç´¢å¯¾è±¡tagsã‚’çµã‚‹
 	if( m_psFindPrev->m_nMatchAll <= nTop && -1 < m_psFindPrev->m_nMatchAll ){
-		// w’èƒy[ƒW‚ÌŒŸõ‚ğƒXƒLƒbƒv
+		// æŒ‡å®šãƒšãƒ¼ã‚¸ã®æ¤œç´¢ã‚’ã‚¹ã‚­ãƒƒãƒ—
 		state = *m_psFindPrev;
 		DEBUG_TRACE( _T("skip count  d:%d m:%d n:%d\n"), state.m_nDepth, state.m_nMatchAll, state.m_nNextMode );
 	}else if( 0 <= m_psFind0Match->m_nDepth ){
-		// depth‚ªó‚¢‡‚Éƒqƒbƒg‚µ‚È‚©‚Á‚½•ª‚ğƒXƒLƒbƒv
+		// depthãŒæµ…ã„é †ã«ãƒ’ãƒƒãƒˆã—ãªã‹ã£ãŸåˆ†ã‚’ã‚¹ã‚­ãƒƒãƒ—
 		state = *m_psFind0Match;
 		DEBUG_TRACE( _T("skip 0match d:%d m:%d n:%d\n"), state.m_nDepth, state.m_nMatchAll, state.m_nNextMode );
 	}else{
-		// ‰‰ñorg‚¦‚È‚¢‚Æ‚«‚ÍƒNƒŠƒA
+		// åˆå›orä½¿ãˆãªã„ã¨ãã¯ã‚¯ãƒªã‚¢
 		ClearPrevFindInfo();
-		// ƒtƒ@ƒCƒ‹–¼‚ğƒRƒs[‚µ‚½‚ ‚ÆAƒfƒBƒŒƒNƒgƒŠ(ÅŒã\)‚Ì‚İ‚É‚·‚é
+		// ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ã‚³ãƒ”ãƒ¼ã—ãŸã‚ã¨ã€ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª(æœ€å¾Œ\)ã®ã¿ã«ã™ã‚‹
 		_tcscpy( state.m_szCurPath, GetFilePath() );
 		state.m_szCurPath[ GetFileName() - GetFilePath() ] = _T('\0');
 		state.m_nLoop = m_nLoop;
 	}
 	
-	TCHAR	szTagFile[1024];		//ƒ^ƒOƒtƒ@ƒCƒ‹
-	TCHAR	szNextPath[1024];		//ŸŒŸõƒtƒHƒ‹ƒ_
-	ACHAR	szLineData[1024];		//sƒoƒbƒtƒ@
+	TCHAR	szTagFile[1024];		//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«
+	TCHAR	szNextPath[1024];		//æ¬¡æ¤œç´¢ãƒ•ã‚©ãƒ«ãƒ€
+	ACHAR	szLineData[1024];		//è¡Œãƒãƒƒãƒ•ã‚¡
 	ACHAR	s[4][1024];
 	int		n2;
 	szNextPath[0] = _T('\0');
 	vector_ex<std::tstring> seachDirs;
 
-	// ƒpƒX‚ÌJump‚ÅzŠÂ‚µ‚Ä‚¢‚éê‡‚ÉÅ‘å’l‚ğ‹K§‚·‚é
+	// ãƒ‘ã‚¹ã®Jumpã§å¾ªç’°ã—ã¦ã„ã‚‹å ´åˆã«æœ€å¤§å€¤ã‚’è¦åˆ¶ã™ã‚‹
 	for( ; state.m_nDepth <= state.m_nLoop && state.m_nDepth < (_MAX_PATH/2); state.m_nDepth++ )
 	{
-		// 0 Ÿ‚Ìƒtƒ@ƒCƒ‹‚ÍŒŸõ‚µ‚È‚¢
-		// 1 1‚Â‚Å‚àƒqƒbƒg‚µ‚½‚çŸ‚ÍŒŸõ‚µ‚È‚¢
-		// 2 Š®‘Sˆê’v‚Ì‚Æ‚«‚Í1‚É“¯‚¶B ‚»‚êˆÈŠO‚Í3‚É“¯‚¶
-		// 3 •K‚¸Ÿ‚àŒŸõ
+		// 0 æ¬¡ã®ãƒ•ã‚¡ã‚¤ãƒ«ã¯æ¤œç´¢ã—ãªã„
+		// 1 1ã¤ã§ã‚‚ãƒ’ãƒƒãƒˆã—ãŸã‚‰æ¬¡ã¯æ¤œç´¢ã—ãªã„
+		// 2 å®Œå…¨ä¸€è‡´ã®ã¨ãã¯1ã«åŒã˜ã€‚ ãã‚Œä»¥å¤–ã¯3ã«åŒã˜
+		// 3 å¿…ãšæ¬¡ã‚‚æ¤œç´¢
 		if( 0 == state.m_nNextMode ) break;
 		if( 1 == state.m_nNextMode && 0 < state.m_nMatchAll ) break;
 		if( 2 == state.m_nNextMode && bTagJumpExactMatch && 0 < state.m_nMatchAll ) break; 
@@ -1164,24 +1164,24 @@ int CDlgTagJumpList::find_key_core(
 		{
 			std::tstring curPath = state.m_szCurPath;
 			if( seachDirs.exist( curPath ) ){
-				// ŒŸõÏ‚İ =>I—¹
+				// æ¤œç´¢æ¸ˆã¿ =>çµ‚äº†
 				break;
 			}
 			seachDirs.push_back( curPath );
 		}
 
-		//ƒ^ƒOƒtƒ@ƒCƒ‹–¼‚ğì¬‚·‚éB
+		//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ä½œæˆã™ã‚‹ã€‚
 		auto_sprintf( szTagFile, _T("%ts%ts"), state.m_szCurPath, TAG_FILENAME_T );
 		DEBUG_TRACE( _T("tag: %ts\n"), szTagFile );
 		
-		//ƒ^ƒOƒtƒ@ƒCƒ‹‚ğŠJ‚­B
+		//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ãã€‚
 		FILE* fp = _tfopen( szTagFile, _T("rb") );
 		if( fp )
 		{
 			DEBUG_TRACE( _T("open tags\n") );
 			bool bSorted = true;
 			bool bFoldcase = false;
-			int  nTagFormat = 2; // 2‚Í1‚à“Ç‚ß‚é‚Ì‚ÅƒfƒtƒHƒ‹ƒg‚Í2
+			int  nTagFormat = 2; // 2ã¯1ã‚‚èª­ã‚ã‚‹ã®ã§ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã¯2
 			int  nLines = 0;
 			int  baseDirId = 0;
 			if( state.m_bJumpPath ){
@@ -1189,24 +1189,24 @@ int CDlgTagJumpList::find_key_core(
 			}
 			state.m_nNextMode = nDefaultNextMode;
 
-			// ƒoƒbƒtƒ@‚ÌŒã‚ë‚©‚ç2•¶š–Ú‚ª\0‚©‚Ç‚¤‚©‚ÅAs––‚Ü‚Å“Ç‚İ‚ñ‚¾‚©Šm”F‚·‚é
+			// ãƒãƒƒãƒ•ã‚¡ã®å¾Œã‚ã‹ã‚‰2æ–‡å­—ç›®ãŒ\0ã‹ã©ã†ã‹ã§ã€è¡Œæœ«ã¾ã§èª­ã¿è¾¼ã‚“ã ã‹ç¢ºèªã™ã‚‹
 			const int nLINEDATA_LAST_CHAR = _countof( szLineData ) - 2;
 			szLineData[nLINEDATA_LAST_CHAR] = '\0';
 			while( fgets( szLineData, _countof( szLineData ), fp ) )
 			{
 				nLines++;
 				int  nRet;
-				// fgets‚ªs‚·‚×‚Ä‚ğ“Ç‚İ‚ß‚Ä‚¢‚È‚¢ê‡‚Ìl—¶
+				// fgetsãŒè¡Œã™ã¹ã¦ã‚’èª­ã¿è¾¼ã‚ã¦ã„ãªã„å ´åˆã®è€ƒæ…®
 				if( '\0' != szLineData[nLINEDATA_LAST_CHAR]
 				    && '\n' != szLineData[nLINEDATA_LAST_CHAR] ){
-					// ‰üsƒR[ƒh‚Ü‚Å‚ğÌ‚Ä‚é
+					// æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã¾ã§ã‚’æ¨ã¦ã‚‹
 					int ch = fgetc( fp );
 					while( ch != '\n' && ch != EOF ){
 						ch = fgetc( fp );
 					}
 				}
 				if( 1 == nLines && szLineData[0] == '\x0c' ){
-					// etags‚È‚Ì‚ÅŸ‚Ìƒtƒ@ƒCƒ‹
+					// etagsãªã®ã§æ¬¡ã®ãƒ•ã‚¡ã‚¤ãƒ«
 					break;
 				}
 				if( '!' == szLineData[0] ){
@@ -1214,7 +1214,7 @@ int CDlgTagJumpList::find_key_core(
 						s[0][0] = s[1][0] = s[2][0] = 0;
 						nRet = sscanf(
 							szLineData, 
-							TAG_FILE_INFO_A,	//tagsƒtƒ@ƒCƒ‹î•ñ
+							TAG_FILE_INFO_A,	//tagsãƒ•ã‚¡ã‚¤ãƒ«æƒ…å ±
 							s[0], s[1], s[2]
 						);
 						if( nRet < 2 ) goto next_line;
@@ -1232,28 +1232,28 @@ int CDlgTagJumpList::find_key_core(
 								bTagJumpICase = bFoldcase;
 							}
 						}else if( 0 == strncmp_literal( pTag, "S_SEARCH_NEXT" ) ){
-							// “Æ©Šg’£:Ÿ‚ÉŒŸõ‚·‚étagƒtƒ@ƒCƒ‹‚Ìw’è
+							// ç‹¬è‡ªæ‹¡å¼µ:æ¬¡ã«æ¤œç´¢ã™ã‚‹tagãƒ•ã‚¡ã‚¤ãƒ«ã®æŒ‡å®š
 							if( '0' <= s[1][0] && s[1][0] <= '3' ){
 								n2 = atoi( s[1] );
 								if( 0 <= n2 && n2 <= 3 ){
 									state.m_nNextMode = n2;
 								}
 								if( 1 <= n2 && s[2][0] ){
-									// s[2] == â‘ÎƒpƒX(ƒfƒBƒŒƒNƒgƒŠ)
+									// s[2] == çµ¶å¯¾ãƒ‘ã‚¹(ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª)
 									TCHAR baseWork[1024];
 									CopyDirDir( baseWork, to_tchar(s[2]), state.m_szCurPath );
 									szNextPath[0] = 0;
 									if( !GetLongFileName( baseWork, szNextPath ) ){
-										// ƒGƒ‰[‚È‚ç•ÏŠ·‘O‚ğ“K—p
+										// ã‚¨ãƒ©ãƒ¼ãªã‚‰å¤‰æ›å‰ã‚’é©ç”¨
 										auto_strcpy( szNextPath, baseWork );
 									}
 								}
 							}
 						}else if( 0 == strncmp_literal( pTag, "S_FILE_BASEDIR" ) ){
 							TCHAR baseWork[1024];
-							// “Æ©Šg’£:ƒtƒ@ƒCƒ‹–¼‚ÌŠî€ƒfƒBƒŒƒNƒgƒŠ
+							// ç‹¬è‡ªæ‹¡å¼µ:ãƒ•ã‚¡ã‚¤ãƒ«åã®åŸºæº–ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª
 							if( state.m_bJumpPath ){
-								// ƒpƒXe“Ç‚İ‘Ö‚¦’†‚ÍA‘Š‘ÎƒpƒX‚¾‚Á‚½ê‡‚É˜AŒ‹‚ª•K—v
+								// ãƒ‘ã‚¹è¦ªèª­ã¿æ›¿ãˆä¸­ã¯ã€ç›¸å¯¾ãƒ‘ã‚¹ã ã£ãŸå ´åˆã«é€£çµãŒå¿…è¦
 								CopyDirDir( baseWork, to_tchar(s[1]), state.m_szCurPath );
 								baseDirId = cList.AddBaseDir( baseWork );
 							}else{
@@ -1263,27 +1263,27 @@ int CDlgTagJumpList::find_key_core(
 							}
 						}
 					}
-					goto next_line;	//ƒRƒƒ“ƒg‚È‚çƒXƒLƒbƒv
+					goto next_line;	//ã‚³ãƒ¡ãƒ³ãƒˆãªã‚‰ã‚¹ã‚­ãƒƒãƒ—
 				}
 				if( szLineData[0] < '!' ) goto next_line;
 				//chop( szLineData );
 
 				s[0][0] = s[1][0] = s[2][0] = s[3][0] = '\0';
 				n2 = 0;
-				//	@@ 2005.03.31 MIK TAG_FORMAT’è”‰»
+				//	@@ 2005.03.31 MIK TAG_FORMATå®šæ•°åŒ–
 				if( 2 == nTagFormat ){
 					nRet = sscanf(
 						szLineData, 
-						TAG_FORMAT_2_A,	//Šg’£tagsƒtƒH[ƒ}ƒbƒg
+						TAG_FORMAT_2_A,	//æ‹¡å¼µtagsãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ
 						s[0], s[1], &n2, s[2], s[3]
 						);
-					// 2010.04.02 nRet < 4 ‚ğ3‚É•ÏXB•W€ƒtƒH[ƒ}ƒbƒg‚à“Ç‚İ‚Ş
+					// 2010.04.02 nRet < 4 ã‚’3ã«å¤‰æ›´ã€‚æ¨™æº–ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆã‚‚èª­ã¿è¾¼ã‚€
 					if( nRet < 3 ) goto next_line;
-					if( n2 <= 0 ) goto next_line;	//s”Ô†•s³(-excmd=n‚ªw’è‚³‚ê‚Ä‚È‚¢‚©‚à)
+					if( n2 <= 0 ) goto next_line;	//è¡Œç•ªå·ä¸æ­£(-excmd=nãŒæŒ‡å®šã•ã‚Œã¦ãªã„ã‹ã‚‚)
 				}else{
 					nRet = sscanf(
 						szLineData, 
-						TAG_FORMAT_1_A,	//tagsƒtƒH[ƒ}ƒbƒg
+						TAG_FORMAT_1_A,	//tagsãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ
 						s[0], s[1], &n2
 						);
 					if( nRet < 2 ) goto next_line;
@@ -1299,14 +1299,14 @@ int CDlgTagJumpList::find_key_core(
 					}
 				}else{
 					if( bTagJumpExactMatch ){
-						// Š®‘Sˆê’v
+						// å®Œå…¨ä¸€è‡´
 						if( bTagJumpICase ){
 							cmp = auto_stricmp( s[0], paszKeyword );
 						}else{
 							cmp = auto_strcmp( s[0], paszKeyword );
 						}
 					}else{
-						// ‘O•ûˆê’v
+						// å‰æ–¹ä¸€è‡´
 						if( bTagJumpICase ){
 							cmp = my_strnicmp( s[0], paszKeyword, length );
 						}else{
@@ -1320,18 +1320,18 @@ int CDlgTagJumpList::find_key_core(
 						if( cList.GetCount() < nCap ){
 							cList.AddParamA( s[0], s[1], n2, s[2][0], s[3], state.m_nDepth, baseDirId );
 						}else{
-							// ’Tõ‘Å‚¿Ø‚è(Ÿƒy[ƒW‚Å‚â‚è’¼‚µ)
+							// æ¢ç´¢æ‰“ã¡åˆ‡ã‚Š(æ¬¡ãƒšãƒ¼ã‚¸ã§ã‚„ã‚Šç›´ã—)
 							m_bNextItem = true;
 							break;
 						}
 					}
 				}
 				else if( 0 < cmp ){
-					//	tags‚Íƒ\[ƒg‚³‚ê‚Ä‚¢‚é‚Ì‚ÅCæ“ª‚©‚ç‚Ìcase sensitive‚È
-					//	”äŠrŒ‹‰Ê‚É‚æ‚Á‚ÄŒŸõ‚Ì‚Íˆ—‚Ì‘Å‚¿Ø‚è‚ª‰Â”\
-					//	2005.04.05 MIK ƒoƒOC³
+					//	tagsã¯ã‚½ãƒ¼ãƒˆã•ã‚Œã¦ã„ã‚‹ã®ã§ï¼Œå…ˆé ­ã‹ã‚‰ã®case sensitiveãª
+					//	æ¯”è¼ƒçµæœã«ã‚ˆã£ã¦æ¤œç´¢ã®æ™‚ã¯å‡¦ç†ã®æ‰“ã¡åˆ‡ã‚ŠãŒå¯èƒ½
+					//	2005.04.05 MIK ãƒã‚°ä¿®æ­£
 					if( (!bTagJumpICase) && bSorted && (!bTagJumpAnyWhere) ) break;
-					// 2010.07.21 Foldcase‚à‘Å‚¿Ø‚éB‚½‚¾‚µtags‚ÆƒTƒNƒ‰‘¤‚Ìƒ\[ƒg‡‚ª“¯‚¶‚Å‚È‚¯‚ê‚Î‚È‚ç‚È‚¢
+					// 2010.07.21 Foldcaseæ™‚ã‚‚æ‰“ã¡åˆ‡ã‚‹ã€‚ãŸã ã—tagsã¨ã‚µã‚¯ãƒ©å´ã®ã‚½ãƒ¼ãƒˆé †ãŒåŒã˜ã§ãªã‘ã‚Œã°ãªã‚‰ãªã„
 					if( bTagJumpICase  && bFoldcase && (!bTagJumpAnyWhere) ) break;
 				}
 next_line:
@@ -1339,7 +1339,7 @@ next_line:
 				szLineData[nLINEDATA_LAST_CHAR] = '\0';
 			}
 
-			//ƒtƒ@ƒCƒ‹‚ğ•Â‚¶‚éB
+			//ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‰ã˜ã‚‹ã€‚
 			fclose( fp );
 			DEBUG_TRACE( _T("close m:%d\n "), state.m_nMatchAll );
 		}
@@ -1354,20 +1354,20 @@ next_line:
 			szNextPath[0] = 0;
 		}else{
 //			_tcscat( state.m_szCurPath, _T("..\\") );
-			//ƒJƒŒƒ“ƒgƒpƒX‚ğ1ŠK‘wã‚ÖB
+			//ã‚«ãƒ¬ãƒ³ãƒˆãƒ‘ã‚¹ã‚’1éšå±¤ä¸Šã¸ã€‚
 			DirUp( state.m_szCurPath );
 		}
 		
 		if( 0 != state.m_nMatchAll && false == m_bNextItem ){
-			// 0 ƒy[ƒW‚ß‚­‚è—p: ‘Å‚¿Ø‚ç‚ê‚Ä‚¢‚È‚¢‚Ì‚ÅŸ‚Ìƒy[ƒW‚Å‚ÍA‚±‚Ìtags‚ÌŸ‚©‚çŒŸõ‚Å‚«‚é
-			// (ÅŒã‚É’Ê‰ß‚µ‚½‚à‚Ì‚ğ•Û)
+			// 0 ãƒšãƒ¼ã‚¸ã‚ãã‚Šç”¨: æ‰“ã¡åˆ‡ã‚‰ã‚Œã¦ã„ãªã„ã®ã§æ¬¡ã®ãƒšãƒ¼ã‚¸ã§ã¯ã€ã“ã®tagsã®æ¬¡ã‹ã‚‰æ¤œç´¢ã§ãã‚‹
+			// (æœ€å¾Œã«é€šéã—ãŸã‚‚ã®ã‚’ä¿æŒ)
 			*m_psFindPrev = state;
 			++(m_psFindPrev->m_nDepth);
 			DEBUG_TRACE( _T("FindPrev udpate: d:%d m:%d n:%d L:%d j:%d\n") , m_psFindPrev->m_nDepth, m_psFindPrev->m_nMatchAll, m_psFindPrev->m_nNextMode, m_psFindPrev->m_nLoop, (int)m_psFindPrev->m_bJumpPath );
 		}
 		if( 0 == state.m_nMatchAll ){
-			// ƒL[ƒ[ƒhi‚İ—p: Ÿ‚Ìi‚è‚İŒŸõ‚Å‚ÍA‚±‚Ìtags‚ÌŸ‚©‚çŒŸõ‚Å‚«‚é
-			// (ÅŒã‚É’Ê‰ß‚µ‚½‚à‚Ì‚ğ•Û)
+			// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰çµè¾¼ã¿ç”¨: æ¬¡ã®çµã‚Šè¾¼ã¿æ¤œç´¢ã§ã¯ã€ã“ã®tagsã®æ¬¡ã‹ã‚‰æ¤œç´¢ã§ãã‚‹
+			// (æœ€å¾Œã«é€šéã—ãŸã‚‚ã®ã‚’ä¿æŒ)
 			*m_psFind0Match = state;
 			++(m_psFind0Match->m_nDepth);
 			DEBUG_TRACE( _T("Find0Match udpate: d:%d m:%d n:%d L:%d j:%d\n") , m_psFind0Match->m_nDepth, m_psFind0Match->m_nMatchAll, m_psFind0Match->m_nNextMode, m_psFind0Match->m_nLoop, (int)m_psFind0Match->m_bJumpPath );
@@ -1380,7 +1380,7 @@ next_line:
 }
 
 /*!
-	ƒpƒX‚©‚çƒtƒ@ƒCƒ‹–¼•”•ª‚Ì‚İ‚ğæ‚èo‚·D(2ƒoƒCƒg‘Î‰)
+	ãƒ‘ã‚¹ã‹ã‚‰ãƒ•ã‚¡ã‚¤ãƒ«åéƒ¨åˆ†ã®ã¿ã‚’å–ã‚Šå‡ºã™ï¼(2ãƒã‚¤ãƒˆå¯¾å¿œ)
 */
 const TCHAR* CDlgTagJumpList::GetFileName( void )
 {
@@ -1404,18 +1404,18 @@ int CDlgTagJumpList::CalcMaxUpDirectory( const TCHAR* p )
 {
 	int loop = CalcDirectoryDepth( p );
 	if( loop <  0 ) loop =  0;
-	if( loop > (_MAX_PATH/2) ) loop = (_MAX_PATH/2);	//\A\B\C...‚Ì‚æ‚¤‚È‚Æ‚«1ƒtƒHƒ‹ƒ_‚Å2•¶šÁ”ï‚·‚é‚Ì‚Å...
+	if( loop > (_MAX_PATH/2) ) loop = (_MAX_PATH/2);	//\A\B\C...ã®ã‚ˆã†ãªã¨ã1ãƒ•ã‚©ãƒ«ãƒ€ã§2æ–‡å­—æ¶ˆè²»ã™ã‚‹ã®ã§...
 	return loop;
 }
 
 /*!
 	
-	@date 2010.04.02 Moca Command_TagJumpByTagsFileKeyword‚©‚ç•ª—£EˆÚ“®
-	@param basePath [in,out] \•tƒfƒBƒŒƒNƒgƒŠƒpƒXâ‘ÎƒpƒX„§B‘‚«Š·‚í‚é‚Ì‚É’ˆÓ
-	@param fileName [in] ‘Š‘ÎEâ‘Îƒtƒ@ƒCƒ‹–¼ƒpƒX
-	@param depth    [in] fineName‚ªâ‘ÎƒpƒX‚Ì–³‹B1==1‚Âã‚ÌƒfƒBƒŒƒNƒgƒŠ
-	@retval pszOutput ¬Œ÷ uC:\dir1\filename.txtv‚ÌŒ`®(..\•t‰Á‚Í”p~)
-	@retval NULL   ¸”s
+	@date 2010.04.02 Moca Command_TagJumpByTagsFileKeywordã‹ã‚‰åˆ†é›¢ãƒ»ç§»å‹•
+	@param basePath [in,out] \ä»˜ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãƒ‘ã‚¹çµ¶å¯¾ãƒ‘ã‚¹æ¨å¥¨ã€‚æ›¸ãæ›ã‚ã‚‹ã®ã«æ³¨æ„
+	@param fileName [in] ç›¸å¯¾ãƒ»çµ¶å¯¾ãƒ•ã‚¡ã‚¤ãƒ«åãƒ‘ã‚¹
+	@param depth    [in] fineNameãŒçµ¶å¯¾ãƒ‘ã‚¹ã®æ™‚ç„¡è¦–ã€‚1==1ã¤ä¸Šã®ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª
+	@retval pszOutput æˆåŠŸ ã€ŒC:\dir1\filename.txtã€ã®å½¢å¼(..\ä»˜åŠ ã¯å»ƒæ­¢)
+	@retval NULL   å¤±æ•—
 */
 TCHAR* CDlgTagJumpList::GetFullPathFromDepth( TCHAR* pszOutput, int count,
 	TCHAR* basePath, const TCHAR* fileName, int depth )
@@ -1423,17 +1423,17 @@ TCHAR* CDlgTagJumpList::GetFullPathFromDepth( TCHAR* pszOutput, int count,
 	DEBUG_TRACE( _T("base  %ts\n"), basePath );
 	DEBUG_TRACE( _T("file  %ts\n"), fileName );
 	DEBUG_TRACE( _T("depth %d\n"),  depth );
-	//Š®‘SƒpƒX–¼‚ğì¬‚·‚éB
+	//å®Œå…¨ãƒ‘ã‚¹åã‚’ä½œæˆã™ã‚‹ã€‚
 	const TCHAR	*p = fileName;
-	if( p[0] == _T('\\') ){	//ƒhƒ‰ƒCƒu‚È‚µâ‘ÎƒpƒX‚©H
-		if( p[1] == _T('\\') ){	//ƒlƒbƒgƒ[ƒNƒpƒX‚©H
-			_tcscpy( pszOutput, p );	//‰½‚à‰ÁH‚µ‚È‚¢B
+	if( p[0] == _T('\\') ){	//ãƒ‰ãƒ©ã‚¤ãƒ–ãªã—çµ¶å¯¾ãƒ‘ã‚¹ã‹ï¼Ÿ
+		if( p[1] == _T('\\') ){	//ãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯ãƒ‘ã‚¹ã‹ï¼Ÿ
+			_tcscpy( pszOutput, p );	//ä½•ã‚‚åŠ å·¥ã—ãªã„ã€‚
 		}else{
-			//ƒhƒ‰ƒCƒu‰ÁH‚µ‚½‚Ù‚¤‚ª‚æ‚¢H
-			_tcscpy( pszOutput, p );	//‰½‚à‰ÁH‚µ‚È‚¢B
+			//ãƒ‰ãƒ©ã‚¤ãƒ–åŠ å·¥ã—ãŸã»ã†ãŒã‚ˆã„ï¼Ÿ
+			_tcscpy( pszOutput, p );	//ä½•ã‚‚åŠ å·¥ã—ãªã„ã€‚
 		}
-	}else if( _istalpha( p[0] ) && p[1] == _T(':') ){	//â‘ÎƒpƒX‚©H
-		_tcscpy( pszOutput, p );	//‰½‚à‰ÁH‚µ‚È‚¢B
+	}else if( _istalpha( p[0] ) && p[1] == _T(':') ){	//çµ¶å¯¾ãƒ‘ã‚¹ã‹ï¼Ÿ
+		_tcscpy( pszOutput, p );	//ä½•ã‚‚åŠ å·¥ã—ãªã„ã€‚
 	}else{
 		for( int i = 0; i < depth; i++ ){
 			//_tcscat( basePath, _T("..\\") );
@@ -1447,7 +1447,7 @@ TCHAR* CDlgTagJumpList::GetFullPathFromDepth( TCHAR* pszOutput, int count,
 }
 
 /*!
-	ƒfƒBƒŒƒNƒgƒŠ‚ÆƒfƒBƒŒƒNƒgƒŠ‚ğ˜AŒ‹‚·‚é
+	ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã¨ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’é€£çµã™ã‚‹
 */
 TCHAR* CDlgTagJumpList::CopyDirDir( TCHAR* dest, const TCHAR* target, const TCHAR* base )
 {
@@ -1463,14 +1463,14 @@ TCHAR* CDlgTagJumpList::CopyDirDir( TCHAR* dest, const TCHAR* target, const TCHA
 }
 
 /*
-	@param dir [in,out] ƒtƒHƒ‹ƒ_‚ÌƒpƒX 
+	@param dir [in,out] ãƒ•ã‚©ãƒ«ãƒ€ã®ãƒ‘ã‚¹ 
 	in == C:\dir\subdir\
 	out == C:\dir\
 */
 TCHAR* CDlgTagJumpList::DirUp( TCHAR* dir )
 {
 	CutLastYenFromDirectoryPath( dir );
-	const TCHAR *p = GetFileTitlePointer(dir); //ÅŒã‚Ì\‚ÌŸ‚Ì•¶š‚ğæ“¾ last_index_of('\\') + 1;
+	const TCHAR *p = GetFileTitlePointer(dir); //æœ€å¾Œã®\ã®æ¬¡ã®æ–‡å­—ã‚’å–å¾— last_index_of('\\') + 1;
 	if( 0 < p - dir){
 		dir[p - dir] = '\0';
 	}

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒ^ƒOƒWƒƒƒ“ƒvƒŠƒXƒgƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒªã‚¹ãƒˆãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
 	@date 2003.4.13
@@ -36,17 +36,17 @@
 #include "dlg/CDialog.h"
 #include "recent/CRecentTagjumpKeyword.h"
 
-//ƒ^ƒOƒtƒ@ƒCƒ‹–¼	//	@@ 2005.03.31 MIK ’è”‰»
+//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«å	//	@@ 2005.03.31 MIK å®šæ•°åŒ–
 #define TAG_FILENAME_T        _T("tags")
 
-// 2010.07.22 ‚¢‚­‚Â‚©cpp‚ÖˆÚ“®
+// 2010.07.22 ã„ãã¤ã‹cppã¸ç§»å‹•
 
 class CSortedTagJumpList;
 
-/*!	@brief ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒvŒó•âˆê——ƒ_ƒCƒAƒƒO
+/*!	@brief ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—å€™è£œä¸€è¦§ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
-	ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv‚Å•¡”‚ÌŒó•â‚ª‚ ‚éê‡‹y‚Ñ
-	ƒL[ƒ[ƒhw’èƒ^ƒOƒWƒƒƒ“ƒv‚Ì‚½‚ß‚Ìƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX§Œä
+	ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã§è¤‡æ•°ã®å€™è£œãŒã‚ã‚‹å ´åˆåŠã³
+	ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®šã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã®ãŸã‚ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹åˆ¶å¾¡
 */
 class CDlgTagJumpList : public CDialog
 {
@@ -60,10 +60,10 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, LPARAM );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
-	//	@@ 2005.03.31 MIK ŠK‘wƒpƒ‰ƒ[ƒ^‚ğ’Ç‰Á
-//	bool AddParamA( const ACHAR*, const ACHAR*, int, const ACHAR*, const ACHAR*, int depth, int baseDirId );	//“o˜^
+	//	@@ 2005.03.31 MIK éšå±¤ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã‚’è¿½åŠ 
+//	bool AddParamA( const ACHAR*, const ACHAR*, int, const ACHAR*, const ACHAR*, int depth, int baseDirId );	//ç™»éŒ²
 	void SetFileName( const TCHAR *pszFileName );
 	void SetKeyword( const wchar_t *pszKeyword );	//	@@ 2005.03.31 MIK
 	int  FindDirectTagJump();
@@ -72,7 +72,7 @@ public:
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL	OnInitDialog( HWND, WPARAM wParam, LPARAM lParam );
 	BOOL	OnBnClicked( int );
@@ -81,7 +81,7 @@ protected:
 	BOOL	OnMove( WPARAM wParam, LPARAM lParam );
 	BOOL	OnMinMaxInfo( LPARAM lParam );
 	BOOL	OnNotify( WPARAM wParam, LPARAM lParam );
-	//	@@ 2005.03.31 MIK ƒL[ƒ[ƒh“ü—ÍƒGƒŠƒA‚ÌƒCƒxƒ“ƒgˆ—
+	//	@@ 2005.03.31 MIK ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å…¥åŠ›ã‚¨ãƒªã‚¢ã®ã‚¤ãƒ™ãƒ³ãƒˆå‡¦ç†
 	BOOL	OnCbnSelChange( HWND hwndCtl, int wID );
 	BOOL	OnCbnEditChange( HWND hwndCtl, int wID );
 	//BOOL	OnEnChange( HWND hwndCtl, int wID );
@@ -92,12 +92,12 @@ private:
 	void	StopTimer( void );
 	void	StartTimer( int );
 
-	void	SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int		GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void	SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int		GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 	void	UpdateData( bool );	//	@@ 2005.03.31 MIK
 
-	TCHAR	*GetNameByType( const TCHAR type, const TCHAR *name );	//ƒ^ƒCƒv‚ğ–¼‘O‚É•ÏŠ·‚·‚éB
-	int		SearchBestTag( void );	//‚à‚Á‚Æ‚àŠm—¦‚Ì‚‚»‚¤‚ÈƒCƒ“ƒfƒbƒNƒX‚ğ•Ô‚·B
+	TCHAR	*GetNameByType( const TCHAR type, const TCHAR *name );	//ã‚¿ã‚¤ãƒ—ã‚’åå‰ã«å¤‰æ›ã™ã‚‹ã€‚
+	int		SearchBestTag( void );	//ã‚‚ã£ã¨ã‚‚ç¢ºç‡ã®é«˜ãã†ãªã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ã‚’è¿”ã™ã€‚
 	//	@@ 2005.03.31 MIK
 	const TCHAR *GetFileName( void );
 	const TCHAR *GetFilePath( void ){ return m_pszFileName != NULL ? m_pszFileName : _T(""); }
@@ -113,7 +113,7 @@ private:
 	bool GetFullPathAndLine( int index, TCHAR *fullPath, int count, int *lineNum, int *depth );
 
 
-	//! depth‚©‚çŠ®‘SƒpƒX–¼(‘Š‘ÎƒpƒX/â‘ÎƒpƒX)‚ğì¬‚·‚é
+	//! depthã‹ã‚‰å®Œå…¨ãƒ‘ã‚¹å(ç›¸å¯¾ãƒ‘ã‚¹/çµ¶å¯¾ãƒ‘ã‚¹)ã‚’ä½œæˆã™ã‚‹
 	static TCHAR* GetFullPathFromDepth( TCHAR*, int, TCHAR*, const TCHAR*, int );
 	static TCHAR* CopyDirDir( TCHAR* dest, const TCHAR* target, const TCHAR* base );
 public:
@@ -133,26 +133,26 @@ private:
 	
 	bool	m_bDirectTagJump;
 
-	int		m_nIndex;		//!< ‘I‘ğ‚³‚ê‚½—v‘f”Ô†
-	TCHAR	*m_pszFileName;	//!< •ÒW’†‚Ìƒtƒ@ƒCƒ‹–¼
-	wchar_t	*m_pszKeyword;	//!< ƒL[ƒ[ƒh(DoModal‚ÌlParam!=0‚ğw’è‚µ‚½ê‡‚Éw’è‚Å‚«‚é)
-	int		m_nLoop;		//!< ‚³‚©‚Ì‚Ú‚ê‚éŠK‘w”
-	CSortedTagJumpList*	m_pcList;	//!< ƒ^ƒOƒWƒƒƒ“ƒvî•ñ
-	UINT_PTR	m_nTimerId;		//!< ƒ^ƒCƒ}”Ô†
-	BOOL	m_bTagJumpICase;	//!< ‘å•¶š¬•¶š‚ğ“¯ˆê‹
-	BOOL	m_bTagJumpAnyWhere;	//!< •¶š—ñ‚Ì“r’†‚Éƒ}ƒbƒ`
-	BOOL	m_bTagJumpExactMatch; //!< Š®‘Sˆê’v(‰æ–Ê–³‚µ)
+	int		m_nIndex;		//!< é¸æŠã•ã‚ŒãŸè¦ç´ ç•ªå·
+	TCHAR	*m_pszFileName;	//!< ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«å
+	wchar_t	*m_pszKeyword;	//!< ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰(DoModalã®lParam!=0ã‚’æŒ‡å®šã—ãŸå ´åˆã«æŒ‡å®šã§ãã‚‹)
+	int		m_nLoop;		//!< ã•ã‹ã®ã¼ã‚Œã‚‹éšå±¤æ•°
+	CSortedTagJumpList*	m_pcList;	//!< ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±
+	UINT_PTR	m_nTimerId;		//!< ã‚¿ã‚¤ãƒç•ªå·
+	BOOL	m_bTagJumpICase;	//!< å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–
+	BOOL	m_bTagJumpAnyWhere;	//!< æ–‡å­—åˆ—ã®é€”ä¸­ã«ãƒãƒƒãƒ
+	BOOL	m_bTagJumpExactMatch; //!< å®Œå…¨ä¸€è‡´(ç”»é¢ç„¡ã—)
 
-	int 	m_nTop;			//!< ƒy[ƒW‚ß‚­‚è‚Ì•\¦‚Ìæ“ª(0ŠJn)
-	bool	m_bNextItem;	//!< ‚Ü‚¾Ÿ‚Éƒqƒbƒg‚·‚é‚à‚Ì‚ª‚ ‚é
+	int 	m_nTop;			//!< ãƒšãƒ¼ã‚¸ã‚ãã‚Šã®è¡¨ç¤ºã®å…ˆé ­(0é–‹å§‹)
+	bool	m_bNextItem;	//!< ã¾ã æ¬¡ã«ãƒ’ãƒƒãƒˆã™ã‚‹ã‚‚ã®ãŒã‚ã‚‹
 
-	// i‚è‚İŒŸõ—p
-	STagFindState* m_psFindPrev; //!< ‘O‰ñ‚ÌÅŒã‚ÉŒŸõ‚µ‚½ó‘Ô
-	STagFindState* m_psFind0Match; //!< ‘O‰ñ‚Ì1‚Â‚àHit‚µ‚È‚©‚Á‚½ÅŒã‚Ìtags
+	// çµã‚Šè¾¼ã¿æ¤œç´¢ç”¨
+	STagFindState* m_psFindPrev; //!< å‰å›ã®æœ€å¾Œã«æ¤œç´¢ã—ãŸçŠ¶æ…‹
+	STagFindState* m_psFind0Match; //!< å‰å›ã®1ã¤ã‚‚Hitã—ãªã‹ã£ãŸæœ€å¾Œã®tags
 
-	CNativeW	m_strOldKeyword;	//!< ‘O‰ñ‚ÌƒL[ƒ[ƒh
-	BOOL	m_bOldTagJumpICase;	//!< ‘O‰ñ‚Ì‘å•¶š¬•¶š‚ğ“¯ˆê‹
-	BOOL	m_bOldTagJumpAnyWhere;	//!< ‘O‰ñ‚Ì•¶š—ñ‚Ì“r’†‚Éƒ}ƒbƒ`
+	CNativeW	m_strOldKeyword;	//!< å‰å›ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+	BOOL	m_bOldTagJumpICase;	//!< å‰å›ã®å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–
+	BOOL	m_bOldTagJumpAnyWhere;	//!< å‰å›ã®æ–‡å­—åˆ—ã®é€”ä¸­ã«ãƒãƒƒãƒ
 
 	SComboBoxItemDeleter	m_comboDel;
 	CRecentTagjumpKeyword	m_cRecentKeyword;

--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒ^ƒOƒtƒ@ƒCƒ‹ì¬ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ä½œæˆãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
 	@date 2003.5.12
@@ -38,11 +38,11 @@
 #include "sakura.hh"
 
 const DWORD p_helpids[] = {	//13700
-	IDC_EDIT_TAG_MAKE_FOLDER,	HIDC_EDIT_TAG_MAKE_FOLDER,	//ƒ^ƒOì¬ƒtƒHƒ‹ƒ_
-	IDC_BUTTON_TAG_MAKE_REF,	HIDC_BUTTON_TAG_MAKE_REF,	//ŽQÆ
-	IDC_BUTTON_FOLDER_UP,		HIDC_BUTTON_TAG_MAKE_FOLDER_UP,	// ã
-	IDC_EDIT_TAG_MAKE_CMDLINE,	HIDC_EDIT_TAG_MAKE_CMDLINE,	//ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“
-	IDC_CHECK_TAG_MAKE_RECURSE,	HIDC_CHECK_TAG_MAKE_RECURSE,	//ƒTƒuƒtƒHƒ‹ƒ_‚à‘ÎÛ
+	IDC_EDIT_TAG_MAKE_FOLDER,	HIDC_EDIT_TAG_MAKE_FOLDER,	//ã‚¿ã‚°ä½œæˆãƒ•ã‚©ãƒ«ãƒ€
+	IDC_BUTTON_TAG_MAKE_REF,	HIDC_BUTTON_TAG_MAKE_REF,	//å‚ç…§
+	IDC_BUTTON_FOLDER_UP,		HIDC_BUTTON_TAG_MAKE_FOLDER_UP,	// ä¸Š
+	IDC_EDIT_TAG_MAKE_CMDLINE,	HIDC_EDIT_TAG_MAKE_CMDLINE,	//ã‚³ãƒžãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³
+	IDC_CHECK_TAG_MAKE_RECURSE,	HIDC_CHECK_TAG_MAKE_RECURSE,	//ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚å¯¾è±¡
 	IDOK,						HIDC_TAG_MAKE_IDOK,
 	IDCANCEL,					HIDC_TAG_MAKE_IDCANCEL,
 	IDC_BUTTON_HELP,			HIDC_BUTTON_TAG_MAKE_HELP,
@@ -58,12 +58,12 @@ CDlgTagsMake::CDlgTagsMake()
 	return;
 }
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\Ž¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgTagsMake::DoModal(
 	HINSTANCE		hInstance,
 	HWND			hwndParent,
 	LPARAM			lParam,
-	const TCHAR*	pszPath		//ƒpƒX
+	const TCHAR*	pszPath		//ãƒ‘ã‚¹
 )
 {
 	_tcscpy( m_szPath, pszPath );
@@ -76,11 +76,11 @@ BOOL CDlgTagsMake::OnBnClicked( int wID )
 	switch( wID )
 	{
 	case IDC_BUTTON_HELP:
-		/* ƒwƒ‹ƒv */
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_TAGS_MAKE) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ãƒ˜ãƒ«ãƒ— */
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_TAGS_MAKE) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 
-	case IDC_BUTTON_TAG_MAKE_REF:	/* ŽQÆ */
+	case IDC_BUTTON_TAG_MAKE_REF:	/* å‚ç…§ */
 		SelectFolder( GetHwnd() );
 		return TRUE;
 
@@ -96,7 +96,7 @@ BOOL CDlgTagsMake::OnBnClicked( int wID )
 		return TRUE;
 
 	case IDOK:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚ÌŽæ“¾ */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 		::EndDialog( GetHwnd(), GetData() );
 		return TRUE;
 
@@ -106,25 +106,25 @@ BOOL CDlgTagsMake::OnBnClicked( int wID )
 
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
 /*!
-	ƒtƒHƒ‹ƒ_‚ð‘I‘ð‚·‚é
+	ãƒ•ã‚©ãƒ«ãƒ€ã‚’é¸æŠžã™ã‚‹
 	
-	@param hwndDlg [in] ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹
+	@param hwndDlg [in] ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«
 */
 void CDlgTagsMake::SelectFolder( HWND hwndDlg )
 {
 	TCHAR	szPath[_MAX_PATH + 1];
 
-	/* ƒtƒHƒ‹ƒ_ */
+	/* ãƒ•ã‚©ãƒ«ãƒ€ */
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_TAG_MAKE_FOLDER, szPath, _MAX_PATH );
 
 	if( SelectDir( hwndDlg, LS(STR_DLGTAGMAK_SELECTDIR), szPath, szPath ) )
 	{
-		//––”ö‚É\\ƒ}[ƒN‚ð’Ç‰Á‚·‚éD
+		//æœ«å°¾ã«\\ãƒžãƒ¼ã‚¯ã‚’è¿½åŠ ã™ã‚‹ï¼Ž
 		int pos = _tcslen( szPath );
 		if( pos > 0 && szPath[ pos - 1 ] != _T('\\') )
 		{
@@ -136,18 +136,18 @@ void CDlgTagsMake::SelectFolder( HWND hwndDlg )
 	}
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚ÌÝ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgTagsMake::SetData( void )
 {
-	//ì¬ƒtƒHƒ‹ƒ_
+	//ä½œæˆãƒ•ã‚©ãƒ«ãƒ€
 	Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_EDIT_TAG_MAKE_FOLDER ), _countof( m_szPath ) );
 	::DlgItem_SetText( GetHwnd(), IDC_EDIT_TAG_MAKE_FOLDER, m_szPath );
 
-	//ƒIƒvƒVƒ‡ƒ“
+	//ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 	m_nTagsOpt = m_pShareData->m_nTagsOpt;
 	if( m_nTagsOpt & 0x0001 ) ::CheckDlgButton( GetHwnd(), IDC_CHECK_TAG_MAKE_RECURSE, TRUE );
 
-	//ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“
+	//ã‚³ãƒžãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³
 	Combo_LimitText( ::GetDlgItem( GetHwnd(), IDC_EDIT_TAG_MAKE_CMDLINE ), _countof( m_pShareData->m_szTagsCmdLine ) );
 	_tcscpy( m_szTagsCmdLine, m_pShareData->m_szTagsCmdLine );
 	::DlgItem_SetText( GetHwnd(), IDC_EDIT_TAG_MAKE_CMDLINE, m_pShareData->m_szTagsCmdLine );
@@ -155,11 +155,11 @@ void CDlgTagsMake::SetData( void )
 	return;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚ÌŽæ“¾ */
-/* TRUE==³í  FALSE==“ü—ÍƒGƒ‰[ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
+/* TRUE==æ­£å¸¸  FALSE==å…¥åŠ›ã‚¨ãƒ©ãƒ¼ */
 int CDlgTagsMake::GetData( void )
 {
-	//ƒtƒHƒ‹ƒ_
+	//ãƒ•ã‚©ãƒ«ãƒ€
 	::DlgItem_GetText( GetHwnd(), IDC_EDIT_TAG_MAKE_FOLDER, m_szPath, _countof( m_szPath ) );
 	int length = _tcslen( m_szPath );
 	if( length > 0 )
@@ -167,12 +167,12 @@ int CDlgTagsMake::GetData( void )
 		if( m_szPath[ length - 1 ] != _T('\\') ) _tcscat( m_szPath, _T("\\") );
 	}
 
-	//CTAGSƒIƒvƒVƒ‡ƒ“
+	//CTAGSã‚ªãƒ—ã‚·ãƒ§ãƒ³
 	m_nTagsOpt = 0;
 	if( ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_TAG_MAKE_RECURSE ) == BST_CHECKED ) m_nTagsOpt |= 0x0001;
 	m_pShareData->m_nTagsOpt = m_nTagsOpt;
 
-	//ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“
+	//ã‚³ãƒžãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³
 	::DlgItem_GetText( GetHwnd(), IDC_EDIT_TAG_MAKE_CMDLINE, m_szTagsCmdLine, _countof( m_szTagsCmdLine ) );
 	_tcscpy( m_pShareData->m_szTagsCmdLine, m_szTagsCmdLine );
 

--- a/sakura_core/dlg/CDlgTagsMake.h
+++ b/sakura_core/dlg/CDlgTagsMake.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒ^ƒOƒtƒ@ƒCƒ‹ì¬ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ä½œæˆãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
 	@date 2003.5.12
@@ -35,7 +35,7 @@ class CDlgTagsMake;
 
 #include "dlg/CDialog.h"
 /*!
-	@brief ƒ^ƒOƒtƒ@ƒCƒ‹ì¬ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+	@brief ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ä½œæˆãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 */
 class CDlgTagsMake : public CDialog
 {
@@ -48,21 +48,21 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM, const TCHAR* );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	int DoModal( HINSTANCE, HWND, LPARAM, const TCHAR* );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
-	TCHAR	m_szPath[_MAX_PATH+1];	/* ƒtƒHƒ‹ƒ_ */
-	TCHAR	m_szTagsCmdLine[_MAX_PATH];	/* ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“ƒIƒvƒVƒ‡ƒ“(ŒÂ•Ê) */
-	int		m_nTagsOpt;				/* CTAGSƒIƒvƒVƒ‡ƒ“(ƒ`ƒFƒbƒN) */
+	TCHAR	m_szPath[_MAX_PATH+1];	/* ãƒ•ã‚©ãƒ«ãƒ€ */
+	TCHAR	m_szTagsCmdLine[_MAX_PATH];	/* ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³ã‚ªãƒ—ã‚·ãƒ§ãƒ³(å€‹åˆ¥) */
+	int		m_nTagsOpt;				/* CTAGSã‚ªãƒ—ã‚·ãƒ§ãƒ³(ãƒã‚§ãƒƒã‚¯) */
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	BOOL	OnBnClicked( int );
 	LPVOID	GetHelpIdTable(void);
 
-	void	SetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	int		GetData( void );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+	void	SetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	int		GetData( void );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 
 private:
 	void SelectFolder( HWND hwndDlg );

--- a/sakura_core/dlg/CDlgWinSize.cpp
+++ b/sakura_core/dlg/CDlgWinSize.cpp
@@ -1,8 +1,8 @@
-/*! @file
-	@brief �E�B���h�E�̈ʒu�Ƒ傫���_�C�A���O
+﻿/*! @file
+	@brief ウィンドウの位置と大きさダイアログ
 
 	@author Moca
-	@date 2004/05/13 �쐬
+	@date 2004/05/13 作成
 */
 /*
 	Copyright (C) 2004, genta, Moca
@@ -36,19 +36,19 @@
 #include "sakura.hh"
 
 static const DWORD p_helpids[] = {	// 2006.10.10 ryoji
-	IDOK,						HIDOK_WINSIZE,				// ����
-	IDC_BUTTON_HELP,			HIDC_BUTTON_WINSIZE_HELP,	// �w���v
-	IDC_EDIT_WX,				HIDC_EDIT_WX,				// ��
-	IDC_EDIT_WY,				HIDC_EDIT_WY,				// ����
-	IDC_EDIT_SX,				HIDC_EDIT_SX,				// X���W
-	IDC_EDIT_SY,				HIDC_EDIT_SY,				// Y���W
+	IDOK,						HIDOK_WINSIZE,				// 閉じる
+	IDC_BUTTON_HELP,			HIDC_BUTTON_WINSIZE_HELP,	// ヘルプ
+	IDC_EDIT_WX,				HIDC_EDIT_WX,				// 幅
+	IDC_EDIT_WY,				HIDC_EDIT_WY,				// 高さ
+	IDC_EDIT_SX,				HIDC_EDIT_SX,				// X座標
+	IDC_EDIT_SY,				HIDC_EDIT_SY,				// Y座標
 //	IDC_CHECK_WINPOS,			HIDC_CHECK_WINPOS,
-	IDC_RADIO_WINSIZE_DEF,		HIDC_RADIO_WINSIZE_DEF,		// �傫��/�w�肵�Ȃ�
-	IDC_RADIO_WINSIZE_SAVE,		HIDC_RADIO_WINSIZE_SAVE,	// �傫��/�p������
-	IDC_RADIO_WINSIZE_SET,		HIDC_RADIO_WINSIZE_SET,		// �傫��/���ڎw��
-	IDC_RADIO_WINPOS_DEF,		HIDC_RADIO_WINPOS_DEF,		// �ʒu/�w�肵�Ȃ�
-	IDC_RADIO_WINPOS_SAVE,		HIDC_RADIO_WINPOS_SAVE, 	// �ʒu/�p������
-	IDC_RADIO_WINPOS_SET,		HIDC_RADIO_WINPOS_SET,  	// �ʒu/���ڎw��
+	IDC_RADIO_WINSIZE_DEF,		HIDC_RADIO_WINSIZE_DEF,		// 大きさ/指定しない
+	IDC_RADIO_WINSIZE_SAVE,		HIDC_RADIO_WINSIZE_SAVE,	// 大きさ/継承する
+	IDC_RADIO_WINSIZE_SET,		HIDC_RADIO_WINSIZE_SET,		// 大きさ/直接指定
+	IDC_RADIO_WINPOS_DEF,		HIDC_RADIO_WINPOS_DEF,		// 位置/指定しない
+	IDC_RADIO_WINPOS_SAVE,		HIDC_RADIO_WINPOS_SAVE, 	// 位置/継承する
+	IDC_RADIO_WINPOS_SET,		HIDC_RADIO_WINPOS_SET,  	// 位置/直接指定
 	IDC_COMBO_WINTYPE,			HIDC_COMBO_WINTYPE,
 	0, 0
 };
@@ -64,14 +64,14 @@ CDlgWinSize::~CDlgWinSize()
 }
 
 
-// !���[�_���_�C�A���O�̕\��
+// !モーダルダイアログの表示
 int CDlgWinSize::DoModal(
 	HINSTANCE		hInstance,
 	HWND			hwndParent,
-	EWinSizeMode&	eSaveWinSize,	//!< [in,out] �E�B���h�E�ʒu�p��
-	EWinSizeMode&	eSaveWinPos,	//!< [in,out] �E�B���h�E�T�C�Y�p��
-	int&			nWinSizeType,	//!< [in,out] �E�B���h�E�̎��s���̑傫��
-	RECT&			rc				//!< [in,out] ���A�����A���A��
+	EWinSizeMode&	eSaveWinSize,	//!< [in,out] ウィンドウ位置継承
+	EWinSizeMode&	eSaveWinPos,	//!< [in,out] ウィンドウサイズ継承
+	int&			nWinSizeType,	//!< [in,out] ウィンドウの実行時の大きさ
+	RECT&			rc				//!< [in,out] 幅、高さ、左、上
 )
 {
 	m_eSaveWinSize = eSaveWinSize;
@@ -86,19 +86,19 @@ int CDlgWinSize::DoModal(
 	return TRUE;
 }
 
-/*! ����������
+/*! 初期化処理
 */
 BOOL CDlgWinSize::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 {
 	_SetHwnd( hwndDlg );
 
-	Combo_AddString( ::GetDlgItem( GetHwnd(), IDC_COMBO_WINTYPE ), LSW( STR_DLGWINSZ_NORMAL ) );	//L"����"
-	Combo_AddString( ::GetDlgItem( GetHwnd(), IDC_COMBO_WINTYPE ), LSW( STR_DLGWINSZ_MAXIMIZE ) );	//L"�ő剻"
-	Combo_AddString( ::GetDlgItem( GetHwnd(), IDC_COMBO_WINTYPE ), LSW( STR_DLGWINSZ_MINIMIZE ) );	//L"(�ŏ���)"
+	Combo_AddString( ::GetDlgItem( GetHwnd(), IDC_COMBO_WINTYPE ), LSW( STR_DLGWINSZ_NORMAL ) );	//L"普通"
+	Combo_AddString( ::GetDlgItem( GetHwnd(), IDC_COMBO_WINTYPE ), LSW( STR_DLGWINSZ_MAXIMIZE ) );	//L"最大化"
+	Combo_AddString( ::GetDlgItem( GetHwnd(), IDC_COMBO_WINTYPE ), LSW( STR_DLGWINSZ_MINIMIZE ) );	//L"(最小化)"
 
 	UpDown_SetRange( ::GetDlgItem( GetHwnd(), IDC_SPIN_SX ), 30000, 0 );
 	UpDown_SetRange( ::GetDlgItem( GetHwnd(), IDC_SPIN_SY ), 30000, 0 );
-	// �E�B���h�E�̍��W�́A�}�C�i�X�l���L���B
+	// ウィンドウの座標は、マイナス値も有効。
 	UpDown_SetRange( ::GetDlgItem( GetHwnd(), IDC_SPIN_WX ), 30000, -30000 );
 	UpDown_SetRange( ::GetDlgItem( GetHwnd(), IDC_SPIN_WY ), 30000, -30000 );
 
@@ -109,8 +109,8 @@ BOOL CDlgWinSize::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 BOOL CDlgWinSize::OnBnClicked( int wID )
 {
 	switch( wID ){
-	case IDC_BUTTON_HELP:	// 2006/09/09 novice id�C��
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, HLP000286 );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+	case IDC_BUTTON_HELP:	// 2006/09/09 novice id修正
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, HLP000286 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 	case IDC_RADIO_WINPOS_DEF:
 	case IDC_RADIO_WINPOS_SAVE:
@@ -127,7 +127,7 @@ BOOL CDlgWinSize::OnBnClicked( int wID )
 	return CDialog::OnBnClicked( wID );
 }
 
-/*! @brief �_�C�A���O�{�b�N�X�Ƀf�[�^��ݒ�
+/*! @brief ダイアログボックスにデータを設定
 */
 void CDlgWinSize::SetData( void )
 {
@@ -173,7 +173,7 @@ void CDlgWinSize::SetData( void )
 }
 
 
-/*! �_�C�A���O�{�b�N�X�̃f�[�^��ǂݏo��
+/*! ダイアログボックスのデータを読み出す
 */
 int CDlgWinSize::GetData( void )
 {
@@ -217,7 +217,7 @@ int CDlgWinSize::GetData( void )
 }
 
 
-/*! ���p�\�E�s�̏�Ԃ��X�V����
+/*! 利用可能・不可の状態を更新する
 */
 void CDlgWinSize::RenewItemState( void )
 {

--- a/sakura_core/dlg/CDlgWinSize.h
+++ b/sakura_core/dlg/CDlgWinSize.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief �E�B���h�E�̈ʒu�Ƒ傫���_�C�A���O
+﻿/*!	@file
+	@brief ウィンドウの位置と大きさダイアログ
 
 	@author Moca
-	@date 2004/05/13 �쐬
+	@date 2004/05/13 作成
 */
 /*
 	Copyright (C) 2004, Moca
@@ -34,17 +34,17 @@
 #include "dlg/CDialog.h"
 #include "env/CommonSetting.h"
 
-/*!	@brief �ʒu�Ƒ傫���̐ݒ�_�C�A���O
+/*!	@brief 位置と大きさの設定ダイアログ
 
-	���ʐݒ�̃E�B���h�E�ݒ�ŁC�E�B���h�E�ʒu���w�肷�邽�߂ɕ⏕�I��
-	�g�p�����_�C�A���O�{�b�N�X
+	共通設定のウィンドウ設定で，ウィンドウ位置を指定するために補助的に
+	使用されるダイアログボックス
 */
 class CDlgWinSize : public CDialog
 {
 public:
 	CDlgWinSize();
 	~CDlgWinSize();
-	int DoModal( HINSTANCE, HWND, EWinSizeMode&, EWinSizeMode&, int&, RECT& );	//!< ���[�_���_�C�A���O�̕\��
+	int DoModal( HINSTANCE, HWND, EWinSizeMode&, EWinSizeMode&, int&, RECT& );	//!< モーダルダイアログの表示
 
 protected:
 
@@ -57,9 +57,9 @@ protected:
 	void RenewItemState( void );
 
 private:
-	EWinSizeMode	m_eSaveWinSize;	//!< �E�B���h�E�T�C�Y�̕ۑ�: 0/�f�t�H���g�C1/�p���C2/�w��
-	EWinSizeMode	m_eSaveWinPos;	//!< �E�B���h�E�ʒu�̕ۑ�: 0/�f�t�H���g�C1/�p���C2/�w��
-	int				m_nWinSizeType;	//!< �E�B���h�E�\�����@: 0/�W���C1/�ő剻�C2/�ŏ���
+	EWinSizeMode	m_eSaveWinSize;	//!< ウィンドウサイズの保存: 0/デフォルト，1/継承，2/指定
+	EWinSizeMode	m_eSaveWinPos;	//!< ウィンドウ位置の保存: 0/デフォルト，1/継承，2/指定
+	int				m_nWinSizeType;	//!< ウィンドウ表示方法: 0/標準，1/最大化，2/最小化
 	RECT			m_rc;
 };
 

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -1,15 +1,15 @@
-/*!	@file
-	@brief ƒEƒBƒ“ƒhƒEˆê——ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Moca
-	@date 2015.03.07 Moca CDlgWindowList.cpp‚ğŒ³‚Éì¬
+	@date 2015.03.07 Moca CDlgWindowList.cppã‚’å…ƒã«ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2001, Stonee, genta, JEPRO, YAZAKI
 	Copyright (C) 2002, aroka, MIK, Moca
 	Copyright (C) 2003, MIK, genta
-	Copyright (C) 2004, MIK, genta, ‚¶‚ã‚¤‚¶
+	Copyright (C) 2004, MIK, genta, ã˜ã‚…ã†ã˜
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2015, Moca
@@ -46,14 +46,14 @@ static const SAnchorList anchorList[] = {
 CDlgWindowList::CDlgWindowList()
 	: CDialog(true)
 {
-	/* ƒTƒCƒY•ÏX‚ÉˆÊ’u‚ğ§Œä‚·‚éƒRƒ“ƒgƒ[ƒ‹” */
+	/* ã‚µã‚¤ã‚ºå¤‰æ›´æ™‚ã«ä½ç½®ã‚’åˆ¶å¾¡ã™ã‚‹ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«æ•° */
 	assert(_countof(anchorList) == _countof(m_rcItems));
 	m_ptDefaultSize.x = -1;
 	m_ptDefaultSize.y = -1;
 	return;
 }
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgWindowList::DoModal(
 	HINSTANCE			hInstance,
 	HWND				hwndParent,
@@ -67,7 +67,7 @@ BOOL CDlgWindowList::OnBnClicked(int wID)
 {
 	switch(wID){
 	case IDC_BUTTON_HELP:
-		/* ƒwƒ‹ƒv */
+		/* ãƒ˜ãƒ«ãƒ— */
 		MyWinHelp(GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_DLGWINLIST));
 		return TRUE;
 	case IDC_BUTTON_SAVE:

--- a/sakura_core/dlg/CDlgWindowList.h
+++ b/sakura_core/dlg/CDlgWindowList.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief �t�@�C���ꗗ�_�C�A���O�{�b�N�X
+﻿/*!	@file
+	@brief ファイル一覧ダイアログボックス
 
 	@author Moca
 	@date 2015.03.07


### PR DESCRIPTION
dlg フォルダ内で単純変換して支障のないものだけを対象に変換を行いました。

## 手順
```
cd sakura_core/dlg
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
git checkout CDlgPluginOption.cpp
git chcekout CDlgFavorite.cpp
git checkout CDlgCtrlCode.cpp
git checkout CDlgOpenFile.cpp
```

5b47e20 の行削除は手動対応。

## 変換対象外のファイル
- CDlgPluginOption.cpp … `_T("\u2611")` が気になったので変換保留
- CDlgFavorite.cpp … `_T("▼")` は別途対応が必要と思われるので変換保留
- CDlgCtrlCode.cpp … `_T("・")` は別途対応が必要と思われるので変換保留
- CDlgOpenFile.cpp … `_T("変換なし"), // ダミー` が気になったので変換保留 (コメントにはダミーとあるけど本当にダミーかどうか精査が必要)

