### PR TITLE
[x64対応] MakefileMake に対する C4477 の警告修正

### DIFF
--- a/MakefileMake/MakefileMake.cpp
+++ b/MakefileMake/MakefileMake.cpp
@@ -386,7 +386,7 @@ int main(int argc, char* argv[])
 	fclose(out);
 #ifdef _DEBUG
 	// %d個のオブジェクトファイル名が出力されました
-	printf("... Wrote %d object file lines to tmpfile[%s].\n", file_list.size(), tmp_file);
+	printf("... Wrote %Id object file lines to tmpfile[%s].\n", file_list.size(), tmp_file);
 #endif
 
 	// ファイルの入換え


### PR DESCRIPTION
#89 で修正しなかった MakefileMake に対する C4477 の警告修正です。

※ MakefileMake は x64 ではビルドされないので、顕在化しない問題ではあります。


