### PR TITLE
appveyor で clone に失敗する件の対策 (軽減策)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ init:
 - ps: Set-WinSystemLocale ja-JP
 - ps: Start-Sleep -s 5
 - ps: Restart-Computer
+- ps: Start-Sleep -s 5
 
 configuration:
   - Release


### PR DESCRIPTION
appveyor で clone に失敗する件の対策 (軽減策)

https://github.com/appveyor/ci/issues/2435#issuecomment-396124982 によると

`Upon closer inspection it looks like problem is mitigated by adding Start-Sleep -s 5 after restart. More of a documentation deficiency.` とある。

mitigated = 軽減 なので頻度が減るだけかも。

参考チケット
- https://github.com/appveyor/ci/issues/2433
- https://github.com/appveyor/ci/issues/2435
- https://github.com/appveyor/ci/issues/2435#issuecomment-396124982