### PR TITLE
clone_folder 指定を削除する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-clone_folder: C:\projects\$(APPVEYOR_ACCOUNT_NAME)\$(APPVEYOR_PROJECT_NAME)_$(APPVEYOR_BUILD_VERSION)
 init:
 - ps: Set-WinSystemLocale ja-JP
 - ps: Start-Sleep -s 5


### PR DESCRIPTION
clone_folder  の指定は #43 に効果がなかったので clone_folder 指定を削除する
(#96 で対策を入れた。)