### PR TITLE
appveyor の成果物の zip 圧縮する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,10 +29,10 @@ build_script:
 
     echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
          %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
+    
+    call zipArtifacts.bat %PLATFORM% %CONFIGURATION%
 
     echo appveyor_yml
 
 artifacts:
-- path: '$(platform)\$(configuration)\*.exe'
-- path: '$(platform)\$(configuration)\*.dll'
-- path: '$(platform)\$(configuration)\*.pdb'
+- path: 'archive-$(platform)-$(configuration).zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,4 +35,4 @@ build_script:
     echo appveyor_yml
 
 artifacts:
-- path: 'archive-$(platform)-$(configuration).zip'
+- path: 'sakura-$(platform)-$(configuration).zip'

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -1,0 +1,7 @@
+set platform=%1
+set configuration=%2
+set OUTFILE=archive-%platform%-%configuration%.zip
+
+7z a %OUTFILE% %platform%\%configuration%\*.exe
+7z a %OUTFILE% %platform%\%configuration%\*.dll
+7z a %OUTFILE% %platform%\%configuration%\*.pdb

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -5,3 +5,4 @@ set OUTFILE=sakura-%platform%-%configuration%.zip
 7z a %OUTFILE% %platform%\%configuration%\*.exe
 7z a %OUTFILE% %platform%\%configuration%\*.dll
 7z a %OUTFILE% %platform%\%configuration%\*.pdb
+7z l %OUTFILE%

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -1,8 +1,24 @@
 set platform=%1
 set configuration=%2
+set WORKDIR=sakura-%platform%-%configuration%
 set OUTFILE=sakura-%platform%-%configuration%.zip
 
-7z a %OUTFILE% %platform%\%configuration%\*.exe
-7z a %OUTFILE% %platform%\%configuration%\*.dll
-7z a %OUTFILE% %platform%\%configuration%\*.pdb
+@rem cleanup for local testing
+if exist "%OUTFILE%" (
+	del %OUTFILE%
+)
+if exist "%WORKDIR%" (
+	rmdir /s /q %WORKDIR%
+)
+
+mkdir %WORKDIR%
+copy %platform%\%configuration%\*.exe %WORKDIR%\
+copy %platform%\%configuration%\*.dll %WORKDIR%\
+copy %platform%\%configuration%\*.pdb %WORKDIR%\
+
+7z a %OUTFILE%  -r %WORKDIR%
 7z l %OUTFILE%
+
+if exist %WORKDIR% (
+	rmdir /s /q %WORKDIR%
+)

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -1,6 +1,6 @@
 set platform=%1
 set configuration=%2
-set OUTFILE=archive-%platform%-%configuration%.zip
+set OUTFILE=sakura-%platform%-%configuration%.zip
 
 7z a %OUTFILE% %platform%\%configuration%\*.exe
 7z a %OUTFILE% %platform%\%configuration%\*.dll


### PR DESCRIPTION
#109: appveyor の成果物を圧縮するようにする

対応のメリット
- ダウンロード時間の短縮
- ダウンロードした成果物の exe を実行したときに Smart Screen でブロックされなくなる(みたい)

圧縮にかかる時間
- appveyor のログで確認する限り 2秒

call zipArtifacts.bat %PLATFORM% %CONFIGURATION% のログから
echo appveyor_yml までの時間で判断

