### PR TITLE
プロパティシートのコントロールの有効/無効制御を早めに実施

### DIFF
--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -77,8 +77,8 @@ static void SetDlgItemsEnableState(
 	HWND hwndLIST_RES,
 	HWND hwndCOMBO_FUNCKIND,
 	HWND hwndLIST_FUNC,
-	CFuncLookup& cLookup,
-	CommonSetting&	common
+	const CFuncLookup& cLookup,
+	const CommonSetting& common
 )
 {
 	int nIdx1 = Combo_GetCurSel( hwndCOMBO_MENU );

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -71,6 +71,62 @@ INT_PTR CALLBACK CPropCustmenu::DlgProc_page(
 }
 //	To Here Jun. 2, 2001 genta
 
+static void SetDlgItemsEnableState(
+	HWND hwndDlg,
+	HWND hwndCOMBO_MENU,
+	HWND hwndLIST_RES,
+	HWND hwndCOMBO_FUNCKIND,
+	HWND hwndLIST_FUNC,
+	CFuncLookup& cLookup,
+	CommonSetting&	common
+)
+{
+	int nIdx1 = Combo_GetCurSel( hwndCOMBO_MENU );
+	int nIdx2 = List_GetCurSel( hwndLIST_RES );
+	int nIdx3 = Combo_GetCurSel( hwndCOMBO_FUNCKIND );
+	int nIdx4 = List_GetCurSel( hwndLIST_FUNC );
+	int i = List_GetCount( hwndLIST_RES );
+	if( LB_ERR == nIdx2	){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELETE ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), FALSE );
+	}else{
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELETE ), TRUE );
+		if( nIdx2 <= 0 ){
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), FALSE );
+		}else{
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), TRUE );
+		}
+		if( nIdx2 + 1 >= i ){
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), FALSE );
+		}else{
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), TRUE );
+		}
+	}
+	if( LB_ERR == nIdx2 || LB_ERR == nIdx4 ){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), FALSE );
+	}else{
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), TRUE );
+	}
+	if( LB_ERR == nIdx4 ){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), FALSE );
+	}else{
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), TRUE );
+	}
+	if( MAX_CUSTOM_MENU_ITEMS <= common.m_sCustomMenu.m_nCustMenuItemNumArr[nIdx1] ){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERTSEPARATOR ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), FALSE );
+	}
+	if( CB_ERR != nIdx3 && LB_ERR != nIdx4 &&
+		cLookup.Pos2FuncCode( nIdx3, nIdx4 ) == 0 &&
+		!(nIdx3 == nSpecialFuncsNum && 0 <= nIdx4 && nIdx4 < nsFuncCode::nFuncList_Special_Num)
+	){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), FALSE );
+	}
+}
+
 /* Custom menu メッセージ処理 */
 INT_PTR CPropCustmenu::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
@@ -117,6 +173,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 		::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_COMBO_FUNCKIND, CBN_SELCHANGE ), (LPARAM)hwndCOMBO_FUNCKIND );
 
 		::SetTimer( hwndDlg, 1, 300, NULL );
+		SetDlgItemsEnableState( hwndDlg, hwndCOMBO_MENU, hwndLIST_RES, hwndCOMBO_FUNCKIND, hwndLIST_FUNC, m_cLookup, m_Common );
 
 		return TRUE;
 
@@ -547,50 +604,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 		break;
 
 	case WM_TIMER:
-		nIdx1 = Combo_GetCurSel( hwndCOMBO_MENU );
-		nIdx2 = List_GetCurSel( hwndLIST_RES );
-		nIdx3 = Combo_GetCurSel( hwndCOMBO_FUNCKIND );
-		nIdx4 = List_GetCurSel( hwndLIST_FUNC );
-		i = List_GetCount( hwndLIST_RES );
-		if( LB_ERR == nIdx2	){
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELETE ), FALSE );
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), FALSE );
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), FALSE );
-		}else{
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELETE ), TRUE );
-			if( nIdx2 <= 0 ){
-				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), FALSE );
-			}else{
-				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), TRUE );
-			}
-			if( nIdx2 + 1 >= i ){
-				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), FALSE );
-			}else{
-				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), TRUE );
-			}
-		}
-		if( LB_ERR == nIdx2 || LB_ERR == nIdx4 ){
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), FALSE );
-		}else{
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), TRUE );
-		}
-		if( LB_ERR == nIdx4 ){
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), FALSE );
-		}else{
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), TRUE );
-		}
-		if( MAX_CUSTOM_MENU_ITEMS <= m_Common.m_sCustomMenu.m_nCustMenuItemNumArr[nIdx1] ){
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERTSEPARATOR ), FALSE );
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), FALSE );
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), FALSE );
-		}
-		if( CB_ERR != nIdx3 && LB_ERR != nIdx4 &&
-		 	m_cLookup.Pos2FuncCode( nIdx3, nIdx4 ) == 0 &&
-			!(nIdx3 == nSpecialFuncsNum && 0 <= nIdx4 && nIdx4 < nsFuncCode::nFuncList_Special_Num)
-		){
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), FALSE );
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), FALSE );
-		}
+		SetDlgItemsEnableState( hwndDlg, hwndCOMBO_MENU, hwndLIST_RES, hwndCOMBO_FUNCKIND, hwndLIST_FUNC, m_cLookup, m_Common );
 		break;
 	case WM_DESTROY:
 		::KillTimer( hwndDlg, 1 );

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -192,7 +192,7 @@ static void SetDlgItemsEnableState(
 	HWND	hwndTreeRes,
 	HWND	hwndComboFuncKind,
 	HWND	hwndListFunc,
-	CFuncLookup& cLookup
+	const CFuncLookup& cLookup
 )
 {
 	HTREEITEM	nIdxMenu = TreeView_GetSelection( hwndTreeRes );

--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -129,6 +129,44 @@ int Listbox_ADDDATA(
 
 static int nToolBarListBoxTopMargin = 0;
 
+static void SetDlgItemsEnableState(
+	HWND	hwndDlg,
+	HWND	hwndResList,
+	HWND	hwndFuncList
+)
+{
+	int nIndex1 = List_GetCurSel( hwndResList );
+	int nIndex2 = List_GetCurSel( hwndFuncList );
+	int i = List_GetCount( hwndResList );
+	if( LB_ERR == nIndex1 ){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELETE ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), FALSE );
+	}else{
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELETE ), TRUE );
+		if( nIndex1 <= 0 ){
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), FALSE );
+		}else{
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), TRUE );
+		}
+		if( nIndex1 + 1 >= i ){
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), FALSE );
+		}else{
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), TRUE );
+		}
+	}
+	if( LB_ERR == nIndex1 || LB_ERR == nIndex2 ){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), FALSE );
+	}else{
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), TRUE );
+	}
+	if( LB_ERR == nIndex2 ){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), FALSE );
+	}else{
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), TRUE );
+	}
+
+}
 
 /* Toolbar メッセージ処理 */
 INT_PTR CPropToolbar::DispatchEvent(
@@ -186,6 +224,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 //	To Here Oct. 14, 2000
 
 		::SetTimer( hwndDlg, 1, 300, NULL );
+		SetDlgItemsEnableState( hwndDlg, hwndResList, hwndFuncList );
 
 		return TRUE;
 
@@ -402,36 +441,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 		break;
 
 	case WM_TIMER:
-		nIndex1 = List_GetCurSel( hwndResList );
-		nIndex2 = List_GetCurSel( hwndFuncList );
-		i = List_GetCount( hwndResList );
-		if( LB_ERR == nIndex1 ){
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELETE ), FALSE );
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), FALSE );
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), FALSE );
-		}else{
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELETE ), TRUE );
-			if( nIndex1 <= 0 ){
-				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), FALSE );
-			}else{
-				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_UP ), TRUE );
-			}
-			if( nIndex1 + 1 >= i ){
-				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), FALSE );
-			}else{
-				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DOWN ), TRUE );
-			}
-		}
-		if( LB_ERR == nIndex1 || LB_ERR == nIndex2 ){
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), FALSE );
-		}else{
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_INSERT ), TRUE );
-		}
-		if( LB_ERR == nIndex2 ){
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), FALSE );
-		}else{
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADD ), TRUE );
-		}
+		SetDlgItemsEnableState( hwndDlg, hwndResList, hwndFuncList );
 		break;
 
 	case WM_DESTROY:


### PR DESCRIPTION
共通設定のメインメニューとツールバーとカスタムメニューのプロパティシートのコントロールが無効化される処理を早めに行う事で、画面を初回表示した際にタイマー処理でコントロールが無効化されるのが目視出来てしまう現象を回避

- WM_TIMER メッセージ時に行う コントロールの有効/無効制御処理を新規に関数化（SetDlgItemsEnableState）
- WM_INITDIALOG メッセージ処理時に SetTimer した後にコントロールの有効/無効制御処理を実施する新規関数の呼び出しを追加