### PR TITLE
ファイル読み込みとgrepの高速化

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -716,9 +716,9 @@ int CGrepAgent::DoGrepTree(
 			);
 		}
 
+		// 定期的に grep 中のファイル名表示を更新
 		if( dwNow - m_dwTickUIFileName > UIFILENAME_INTERVAL_MILLISEC ){
 			m_dwTickUIFileName = dwNow;
-			//GREP実行！
 			::DlgItem_SetText( pcDlgCancel->GetHwnd(), IDC_STATIC_CURFILE, lpFileName );
 		}
 

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -22,14 +22,16 @@
 #include <deque>
 #include "sakura_rc.h"
 
-#define UICHECK_INTERVAL_MILLISEC 50	// UI確認の時間間隔
+#define UICHECK_INTERVAL_MILLISEC 100	// UI確認の時間間隔
 #define ADDTAIL_INTERVAL_MILLISEC 50	// 結果出力の時間間隔
+#define UIFILENAME_INTERVAL_MILLISEC 15	// Cancelダイアログのファイル名表示更新間隔
 
 CGrepAgent::CGrepAgent()
 : m_bGrepMode( false )			/* Grepモードか */
 , m_bGrepRunning( false )		/* Grep処理中 */
 , m_dwTickAddTail( 0 )
 , m_dwTickUICheck( 0 )
+, m_dwTickUIFileName( 0 )
 {
 }
 
@@ -714,8 +716,11 @@ int CGrepAgent::DoGrepTree(
 			);
 		}
 
-		//GREP実行！
-		::DlgItem_SetText( pcDlgCancel->GetHwnd(), IDC_STATIC_CURFILE, lpFileName );
+		if( dwNow - m_dwTickUIFileName > UIFILENAME_INTERVAL_MILLISEC ){
+			m_dwTickUIFileName = dwNow;
+			//GREP実行！
+			::DlgItem_SetText( pcDlgCancel->GetHwnd(), IDC_STATIC_CURFILE, lpFileName );
+		}
 
 		std::tstring currentFile = pszPath;
 		currentFile += _T("\\");

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -196,6 +196,7 @@ DWORD CGrepAgent::DoGrep(
 	//	Jun. 27, 2001 genta	正規表現ライブラリの差し替え
 	CBregexp	cRegexp;
 	CNativeW	cmemMessage;
+	CNativeW	cUnicodeBuffer;
 	int			nWork;
 	SGrepOption	sGrepOption;
 
@@ -203,6 +204,7 @@ DWORD CGrepAgent::DoGrep(
 	|| バッファサイズの調整
 	*/
 	cmemMessage.AllocStringBuffer( 4000 );
+	cUnicodeBuffer.AllocStringBuffer( 4000 );
 
 	pcViewDst->m_bDoing_UndoRedo		= true;
 
@@ -574,7 +576,8 @@ DWORD CGrepAgent::DoGrep(
 			0,
 			bOutputBaseFolder,
 			&nHitCount,
-			cmemMessage
+			cmemMessage,
+			cUnicodeBuffer
 		);
 		if( nTreeRet == -1 ){
 			nGrepTreeResult = -1;
@@ -671,7 +674,8 @@ int CGrepAgent::DoGrepTree(
 	int						nNest,				//!< [in] ネストレベル
 	bool&					bOutputBaseFolder,	//!< [i/o] ベースフォルダ名出力
 	int*					pnHitCount,			//!< [i/o] ヒット数の合計
-	CNativeW&				cmemMessage			//!< [i/o] Grep結果文字列
+	CNativeW&				cmemMessage,		//!< [i/o] Grep結果文字列
+	CNativeW&				cUnicodeBuffer
 )
 {
 	int			i;
@@ -741,7 +745,8 @@ int CGrepAgent::DoGrepTree(
 				(sGrepOption.bGrepSeparateFolder ? lpFileName : currentFile.c_str() + nBasePathLen + 1),
 				bOutputBaseFolder,
 				bOutputFolderName,
-				cmemMessage
+				cmemMessage,
+				cUnicodeBuffer
 			);
 		}else{
 			nRet = DoGrepFile(
@@ -760,7 +765,8 @@ int CGrepAgent::DoGrepTree(
 				(sGrepOption.bGrepSeparateFolder ? lpFileName : currentFile.c_str() + nBasePathLen + 1),
 				bOutputBaseFolder,
 				bOutputFolderName,
-				cmemMessage
+				cmemMessage,
+				cUnicodeBuffer
 			);
 		}
 
@@ -842,7 +848,8 @@ int CGrepAgent::DoGrepTree(
 				nNest + 1,
 				bOutputBaseFolder,
 				pnHitCount,
-				cmemMessage
+				cmemMessage,
+				cUnicodeBuffer
 			);
 			if( -1 == nGrepTreeResult ){
 				goto cancel_return;
@@ -1045,7 +1052,8 @@ int CGrepAgent::DoGrepFile(
 	const TCHAR*			pszRelPath,			//!< [in] 相対パス File.ext(bGrepSeparateFolder) または  SubFolder\File.ext(!bGrepSeparateFolder)
 	bool&					bOutputBaseFolder,	//!< 
 	bool&					bOutputFolderName,	//!< 
-	CNativeW&				cmemMessage			//!< [i/o] Grep結果文字列
+	CNativeW&				cmemMessage,		//!< [i/o] Grep結果文字列
+	CNativeW&				cUnicodeBuffer
 )
 {
 	int		nHitCount;
@@ -1205,7 +1213,6 @@ int CGrepAgent::DoGrepFile(
 	}
 
 	// 注意 : cfl.ReadLine が throw する可能性がある
-	CNativeW cUnicodeBuffer;
 	while( RESULT_FAILURE != cfl.ReadLine( &cUnicodeBuffer, &cEol ) )
 	{
 		const wchar_t*	pLine = cUnicodeBuffer.GetStringPtr();
@@ -1606,7 +1613,8 @@ int CGrepAgent::DoGrepReplaceFile(
 	const TCHAR*			pszRelPath,
 	bool&					bOutputBaseFolder,
 	bool&					bOutputFolderName,
-	CNativeW&				cmemMessage
+	CNativeW&				cmemMessage,
+	CNativeW&				cUnicodeBuffer
 )
 {
 	LONGLONG	nLine = 0;

--- a/sakura_core/CGrepAgent.h
+++ b/sakura_core/CGrepAgent.h
@@ -186,6 +186,7 @@ private:
 
 	DWORD m_dwTickAddTail;	// AddTail() を呼び出した時間
 	DWORD m_dwTickUICheck;	// 処理中にユーザーによるUI操作が行われていないか確認した時間
+	DWORD m_dwTickUIFileName;	// Cancelダイアログのファイル名表示更新を行った時間
 
 public: //$$ 仮
 	bool	m_bGrepMode;		//!< Grepモードか

--- a/sakura_core/CGrepAgent.h
+++ b/sakura_core/CGrepAgent.h
@@ -118,7 +118,8 @@ private:
 		int						nNest,				//!< [in] ネストレベル
 		bool&					bOutputBaseFolder,
 		int*					pnHitCount,			//!< [i/o] ヒット数の合計
-		CNativeW&				cmemMessage
+		CNativeW&				cmemMessage,
+		CNativeW&				cUnicodeBuffer
 	);
 
 	// Grep実行
@@ -138,7 +139,8 @@ private:
 		const TCHAR*			pszRelPath,
 		bool&					bOutputBaseFolder,
 		bool&					bOutputFolderName,
-		CNativeW&				cmemMessage
+		CNativeW&				cmemMessage,
+		CNativeW&				cUnicodeBuffer
 	);
 
 	int DoGrepReplaceFile(
@@ -158,7 +160,8 @@ private:
 		const TCHAR*			pszRelPath,
 		bool&					bOutputBaseFolder,
 		bool&					bOutputFolderName,
-		CNativeW&				cmemMessage
+		CNativeW&				cmemMessage,
+		CNativeW&				cUnicodeBuffer
 	);
 
 	// Grep結果をpszWorkに格納

--- a/sakura_core/charset/CESI.cpp
+++ b/sakura_core/charset/CESI.cpp
@@ -1027,7 +1027,7 @@ ECodeType CESI::AutoDetectByHTML( const char* pBuf, int nSize )
 	for( int i = 0; i + 14 < nSize; i++ ){
 		// 「<meta http-equiv="Content-Type" content="text/html; Charset=Shift_JIS">」
 		// 「<meta charset="utf-8">」
-		if( pBuf[i] == '<' && 0 == memicmp(pBuf + i + 1, "meta", 4) && IsXMLWhiteSpace(pBuf[i+5]) ){
+		if( pBuf[i] == '<' && 0 == memicmp(&pBuf[i+1], "meta", 4) && IsXMLWhiteSpace(pBuf[i+5]) ){
 			i += 5;
 			ECodeType encoding = CODE_NONE;
 			bool bContentType = false;

--- a/sakura_core/charset/CESI.cpp
+++ b/sakura_core/charset/CESI.cpp
@@ -1027,7 +1027,7 @@ ECodeType CESI::AutoDetectByHTML( const char* pBuf, int nSize )
 	for( int i = 0; i + 14 < nSize; i++ ){
 		// 「<meta http-equiv="Content-Type" content="text/html; Charset=Shift_JIS">」
 		// 「<meta charset="utf-8">」
-		if( 0 == memicmp(pBuf + i, "<meta", 5) && IsXMLWhiteSpace(pBuf[i+5]) ){
+		if( pBuf[i] == '<' && 0 == memicmp(pBuf + i + 1, "meta", 4) && IsXMLWhiteSpace(pBuf[i+5]) ){
 			i += 5;
 			ECodeType encoding = CODE_NONE;
 			bool bContentType = false;

--- a/sakura_core/charset/CShiftJis.cpp
+++ b/sakura_core/charset/CShiftJis.cpp
@@ -116,7 +116,7 @@ EConvertResult CShiftJis::SJISToUnicode( const CMemory& cSrc, CNativeW* pDstMem 
 	int nSrcLen;
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
 
-	if( (void*)&cSrc == (void*)pDstMem )
+	if( &cSrc == pDstMem->_GetMemory() )
 	{
 		// 変換先バッファサイズを設定してメモリ領域確保
 		wchar_t* pDst;

--- a/sakura_core/charset/CShiftJis.cpp
+++ b/sakura_core/charset/CShiftJis.cpp
@@ -116,25 +116,39 @@ EConvertResult CShiftJis::SJISToUnicode( const CMemory& cSrc, CNativeW* pDstMem 
 	int nSrcLen;
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
 
-	// 変換先バッファサイズを設定してメモリ領域確保
-	wchar_t* pDst;
-	try{
-		pDst = new wchar_t[nSrcLen];
-	}catch( ... ){
-		pDst = NULL;
+	if( (void*)&cSrc == (void*)pDstMem )
+	{
+		// 変換先バッファサイズを設定してメモリ領域確保
+		wchar_t* pDst;
+		try{
+			pDst = new wchar_t[nSrcLen];
+		}catch( ... ){
+			pDst = NULL;
+		}
+		if( pDst == NULL ){
+			return RESULT_FAILURE;
+		}
+
+		// 変換
+		int nDstLen = SjisToUni( pSrc, nSrcLen, pDst, &bError );
+
+		// pDstを更新
+		pDstMem->_GetMemory()->SetRawDataHoldBuffer( pDst, nDstLen*sizeof(wchar_t) );
+
+		// 後始末
+		delete [] pDst;
 	}
-	if( pDst == NULL ){
-		return RESULT_FAILURE;
+	else
+	{
+		// 変換先バッファサイズを設定してメモリ領域確保
+		pDstMem->AllocStringBuffer( nSrcLen + 1 );
+		wchar_t* pDst = pDstMem->GetStringPtr();
+
+		// 変換
+		int nDstLen = SjisToUni( pSrc, nSrcLen, pDst, &bError );
+
+		pDstMem->_SetStringLength( nDstLen );
 	}
-
-	// 変換
-	int nDstLen = SjisToUni( pSrc, nSrcLen, pDst, &bError );
-
-	// pDstを更新
-	pDstMem->_GetMemory()->SetRawDataHoldBuffer( pDst, nDstLen*sizeof(wchar_t) );
-
-	// 後始末
-	delete [] pDst;
 
 	if( bError == false ){
 		return RESULT_COMPLETE;

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -95,39 +95,41 @@ EConvertResult CUtf8::_UTF8ToUnicode( const CMemory& cSrc, CNativeW* pDstMem, bo
 	// データ取得
 	int nSrcLen;
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
- 
-	const char* psrc = pSrc;
-	int nsrclen = nSrcLen;
 
-//	CMemory cmem;
-//	// MIME ヘッダーデコード
-//	if( decodeMime == true ){
-//		bool bret = MIMEHeaderDecode( pSrc, nSrcLen, &cmem, CODE_UTF8 );
-//		if( bret == true ){
-//			psrc = reinterpret_cast<char*>( cmem.GetRawPtr() );
-//			nsrclen = cmem.GetRawLength();
-//		}
-//	}
+	if( (void*)&cSrc == (void*)pDstMem )
+	{
+		// 必要なバッファサイズを調べて確保する
+		wchar_t* pDst;
+		try{
+			pDst = new wchar_t[nSrcLen];
+		}catch( ... ){
+			pDst = NULL;
+		}
+		if( pDst == NULL ){
+			return RESULT_FAILURE;
+		}
 
-	// 必要なバッファサイズを調べて確保する
-	wchar_t* pDst;
-	try{
-		pDst = new wchar_t[nsrclen];
-	}catch( ... ){
-		pDst = NULL;
+		// 変換
+		int nDstLen = Utf8ToUni( pSrc, nSrcLen, pDst, bCESU8Mode );
+
+		// pDstMem を更新
+		pDstMem->_GetMemory()->SetRawDataHoldBuffer( pDst, nDstLen*sizeof(wchar_t) );
+
+		// 後始末
+		delete [] pDst;
 	}
-	if( pDst == NULL ){
-		return RESULT_FAILURE;
+	else
+	{
+		// 変換先バッファサイズを設定してメモリ領域確保
+		pDstMem->AllocStringBuffer( nSrcLen + 1 );
+		wchar_t* pDst = pDstMem->GetStringPtr();
+
+		// 変換
+		size_t nDstLen = Utf8ToUni(pSrc, nSrcLen, pDst, bCESU8Mode);
+
+		// pDstMem を更新
+		pDstMem->_SetStringLength( nDstLen );
 	}
-
-	// 変換
-	int nDstLen = Utf8ToUni( psrc, nsrclen, pDst, bCESU8Mode );
-
-	// pDstMem を更新
-	pDstMem->_GetMemory()->SetRawDataHoldBuffer( pDst, nDstLen*sizeof(wchar_t) );
-
-	// 後始末
-	delete [] pDst;
 
 	if( bError == false ){
 		return RESULT_COMPLETE;

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -96,7 +96,7 @@ EConvertResult CUtf8::_UTF8ToUnicode( const CMemory& cSrc, CNativeW* pDstMem, bo
 	int nSrcLen;
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
 
-	if( (void*)&cSrc == (void*)pDstMem )
+	if( &cSrc == pDstMem->_GetMemory() )
 	{
 		// 必要なバッファサイズを調べて確保する
 		wchar_t* pDst;


### PR DESCRIPTION
以下の変更を加えることで高速化しました。

- SJISやUTF8からUnicodeへの文字Encoding変換処理内におけるメモリ確保処理を必要な時にのみ限定
  - 出力先のバッファが引数に指定されている入力元のバッファと異なる場合はその変数を使うようにしました。入力元のバッファと出力先のバッファに同じインスタンスを指定して使っている箇所があるのでインスタンスのアドレス比較で同一かどうか判断しています。
  - UTF-7 や JIS については利用頻度が少ないと判断して手を入れていません。
- GREP処理においてUnicode変換先バッファを使いまわしてヒープマネージャの負担を低減
  - 引数を更に追加しました。まだ3桁ではないので許容範囲でしょうか…。
- `ESI::AutoDetectByHTML` 処理の高速化
  - これは結構効きました。
  - 始め山括弧（LEFT ANGLE BRACKET `<`）の文字一致判定を `memicmp` を呼ぶ前に実行する事で `memicmp` が実行される頻度を低減しました。
- Grep実行時に探索するファイル毎にCancelダイアログのファイル名表示を更新するのではなく、間隔をおいて更新するように変更
  - これに加えてUI確認の時間間隔も50ミリ秒から100ミリ秒に変更しました。

上記の変更を加える事で、サクラエディタのリポジトリ以下を `hWnd` で フィルタが `*.txt *.h *.cpp *.c *.cc *.hpp` で `サブフォルダからも検索する` にチェックを付けて検索を掛けた際の時間が下記のように速くなりました。

| `リアルタイムで表示する` 設定値 | 変更前 | 変更後 |
|----|----|----|
| OFF | 930 | 575 |
| ON | 2200 | 990 |
