### PR TITLE
Windows10メニュー対応

### DIFF
--- a/installer/sakura.iss
+++ b/installer/sakura.iss
@@ -78,7 +78,7 @@ Root: HKCU; Subkey: "SOFTWARE\Classes\Applications\sakura.exe\shell\open\command
 
 [Icons]
 Name: "{group}\サクラエディタ";                                                Filename: "{app}\sakura.exe";                         Components: main; Check: isNotWin10; Tasks: startmenu;
-Name: "{group}\..\サクラエディタ";                                             Filename: "{app}\sakura.exe";                         Components: main; Check: isWin10;Tasks: startmenu;
+Name: "{userstartmenu}\サクラエディタ";                                        Filename: "{app}\sakura.exe";                         Components: main; Check: isWin10;Tasks: startmenu;
 Name: "{group}\ヘルプファイル";                                                Filename: "{app}\sakura.chm";                         Components: help; Tasks: startmenu;
 Name: "{group}\設定フォルダ";                                                  Filename: "%APPDATA%\sakura";                         Components: main; Check: isMultiUserEnabled; Tasks: startmenu;
 Name: "{userdesktop}\サクラエディタ";                                          Filename: "{app}\sakura.exe";                         Components: main; Tasks: desktopicon;

--- a/installer/sakura.iss
+++ b/installer/sakura.iss
@@ -160,15 +160,15 @@ begin
   Result := UsingWinNT and (( GetWindowsVersion shr 24) >= 5 );
 end;
 
-function IsWin10 : Boolean;
+function IsWin10OrLater : Boolean;
 var
   Version: TWindowsVersion;
   S: String;
 begin
   GetWindowsVersionEx(Version);
-  if (Version.Major = 10) and
-     (Version.Minor = 0) and
-     (Version.ProductType = VER_NT_WORKSTATION) then
+  if (Version.Major = 10)
+{     (Version.Minor = 0) and
+     (Version.ProductType = VER_NT_WORKSTATION) } then
   begin
     Result := True;
   end else begin
@@ -179,7 +179,7 @@ function InTopMenu( TopMenu : Boolean ) : Boolean;
 begin
   if ( TopMenu = True ) then
   begin
-    if ( IsWin10 = True ) then
+    if ( IsWin10OrLater = True ) then
     begin
       Result := True;
     end else begin

--- a/installer/sakura.iss
+++ b/installer/sakura.iss
@@ -1,3 +1,6 @@
+#define MyAppVer GetFileVersion("sakura\sakura.exe")
+#define MyAppVerH StringChange(MyAppVer, ".", "-")
+
 [Setup]
 AppName=サクラエディタ
 AppId=sakura editor
@@ -19,8 +22,8 @@ DisableStartupPrompt=no
 PrivilegesRequired=None
 
 ; エディタのバージョンに応じて書き換える場所
-OutputBaseFilename=sakura_install2-1-1-2
-VersionInfoVersion=2.1.1.2
+OutputBaseFilename=sakura_install{#MyAppVerH}
+VersionInfoVersion={#MyAppVer}
 
 ; OSバージョン制限
 MinVersion=0,5.0
@@ -74,7 +77,8 @@ Root: HKCU; Subkey: "SOFTWARE\Classes\*\shell\sakuraeditor\command"; ValueType: 
 Root: HKCU; Subkey: "SOFTWARE\Classes\Applications\sakura.exe\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\sakura.exe"" ""%1"""; Tasks: proglist; Flags: uninsdeletekey; Check: CheckPrivilege(false)
 
 [Icons]
-Name: "{group}\サクラエディタ";                                                Filename: "{app}\sakura.exe";                         Components: main; Tasks: startmenu;
+Name: "{group}\サクラエディタ";                                                Filename: "{app}\sakura.exe";                         Components: main; Check: isNotWin10; Tasks: startmenu;
+Name: "{group}\..\サクラエディタ";                                             Filename: "{app}\sakura.exe";                         Components: main; Check: isWin10;Tasks: startmenu;
 Name: "{group}\ヘルプファイル";                                                Filename: "{app}\sakura.chm";                         Components: help; Tasks: startmenu;
 Name: "{group}\設定フォルダ";                                                  Filename: "%APPDATA%\sakura";                         Components: main; Check: isMultiUserEnabled; Tasks: startmenu;
 Name: "{userdesktop}\サクラエディタ";                                          Filename: "{app}\sakura.exe";                         Components: main; Tasks: desktopicon;
@@ -156,6 +160,38 @@ begin
   Result := UsingWinNT and (( GetWindowsVersion shr 24) >= 5 );
 end;
 
+function IsWin10 : Boolean;
+var
+  Version: TWindowsVersion;
+  S: String;
+begin
+  GetWindowsVersionEx(Version);
+  if (Version.Major = 10) and
+     (Version.Minor = 0) and
+     (Version.ProductType = 1) then
+  begin
+    Result := True;
+    Exit;
+  end else begin
+    Result := False;
+  end;
+end;
+function IsNotWin10 : Boolean;
+var
+  Version: TWindowsVersion;
+  S: String;
+begin
+  GetWindowsVersionEx(Version);
+  if (Version.Major = 10) and
+     (Version.Minor = 0) and
+     (Version.ProductType = 1) then
+  begin
+    Result := False;
+    Exit;
+  end else begin
+    Result := True;
+  end;
+end;
 { **********************************
    Custom Wizard Page
   ********************************** }

--- a/installer/sakura.iss
+++ b/installer/sakura.iss
@@ -166,8 +166,8 @@ var
   S: String;
 begin
   GetWindowsVersionEx(Version);
-  if (Version.Major = 10)
-{     (Version.Minor = 0) and
+  if (Version.Major >= 10)
+{    and (Version.Minor = 0) and
      (Version.ProductType = VER_NT_WORKSTATION) } then
   begin
     Result := True;

--- a/installer/sakura.iss
+++ b/installer/sakura.iss
@@ -77,8 +77,8 @@ Root: HKCU; Subkey: "SOFTWARE\Classes\*\shell\sakuraeditor\command"; ValueType: 
 Root: HKCU; Subkey: "SOFTWARE\Classes\Applications\sakura.exe\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\sakura.exe"" ""%1"""; Tasks: proglist; Flags: uninsdeletekey; Check: CheckPrivilege(false)
 
 [Icons]
-Name: "{group}\サクラエディタ";                                                Filename: "{app}\sakura.exe";                         Components: main; Check: isNotWin10; Tasks: startmenu;
-Name: "{userstartmenu}\サクラエディタ";                                        Filename: "{app}\sakura.exe";                         Components: main; Check: isWin10;Tasks: startmenu;
+Name: "{group}\サクラエディタ";                                                Filename: "{app}\sakura.exe";                         Components: main; Check: InTopMenu(false); Tasks: startmenu;
+Name: "{userstartmenu}\サクラエディタ";                                        Filename: "{app}\sakura.exe";                         Components: main; Check: InTopMenu(true); Tasks: startmenu;
 Name: "{group}\ヘルプファイル";                                                Filename: "{app}\sakura.chm";                         Components: help; Tasks: startmenu;
 Name: "{group}\設定フォルダ";                                                  Filename: "%APPDATA%\sakura";                         Components: main; Check: isMultiUserEnabled; Tasks: startmenu;
 Name: "{userdesktop}\サクラエディタ";                                          Filename: "{app}\sakura.exe";                         Components: main; Tasks: desktopicon;
@@ -168,26 +168,23 @@ begin
   GetWindowsVersionEx(Version);
   if (Version.Major = 10) and
      (Version.Minor = 0) and
-     (Version.ProductType = 1) then
+     (Version.ProductType = VER_NT_WORKSTATION) then
   begin
     Result := True;
-    Exit;
   end else begin
     Result := False;
   end;
 end;
-function IsNotWin10 : Boolean;
-var
-  Version: TWindowsVersion;
-  S: String;
+function InTopMenu( TopMenu : Boolean ) : Boolean;
 begin
-  GetWindowsVersionEx(Version);
-  if (Version.Major = 10) and
-     (Version.Minor = 0) and
-     (Version.ProductType = 1) then
+  if ( TopMenu = True ) then
   begin
-    Result := False;
-    Exit;
+    if ( IsWin10 = True ) then
+    begin
+      Result := True;
+    end else begin
+      Result := False;
+    end
   end else begin
     Result := True;
   end;

--- a/installer/sakura.iss
+++ b/installer/sakura.iss
@@ -166,9 +166,7 @@ var
   S: String;
 begin
   GetWindowsVersionEx(Version);
-  if (Version.Major >= 10)
-{    and (Version.Minor = 0) and
-     (Version.ProductType = VER_NT_WORKSTATION) } then
+  if (Version.Major >= 10) then
   begin
     Result := True;
   end else begin

--- a/installer/sakura.iss
+++ b/installer/sakura.iss
@@ -163,7 +163,6 @@ end;
 function IsWin10OrLater : Boolean;
 var
   Version: TWindowsVersion;
-  S: String;
 begin
   GetWindowsVersionEx(Version);
   if (Version.Major >= 10) then
@@ -175,9 +174,9 @@ begin
 end;
 function InTopMenu( TopMenu : Boolean ) : Boolean;
 begin
-  if ( TopMenu = True ) then
+  if TopMenu then
   begin
-    if ( IsWin10OrLater = True ) then
+    if IsWin10OrLater then
     begin
       Result := True;
     end else begin


### PR DESCRIPTION
Windows10の場合に、sakura.exeのショートカットをグループ内ではなく、スタートメニュー直下に配置してアイコンを見つけやすくする対応。
#104 

あわせて、バージョン情報を自動取得し、issファイルをリリース時に更新不要にする修正。