### PR TITLE
タイプ別一覧ダイアログのインポート機能バグ修正

### DIFF
--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -322,13 +322,14 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 	// 読み込み
 	CShareData_IO::ShareData_IO_Type_One( m_cProfile, m_Types, szSecTypes );
 
-	m_Types.m_nIdx = m_nIdx;
+	m_nIdx = m_Types.m_nIdx;
 	if (m_nIdx == 0) {
 		// 基本の場合の名前と拡張子を初期化
 		_tcscpy( m_Types.m_szTypeName, LS(STR_TYPE_NAME_BASIS) );
 		_tcscpy( m_Types.m_szTypeExts, _T("") );
 		m_Types.m_id = 0;
 	}else{
+		// 基本じゃなかった場合、id番号をランダムに仮採番(あとで振りなおす)
 		m_Types.m_id = (::GetTickCount() & 0x3fffffff) + m_nIdx * 0x10000;
 	}
 


### PR DESCRIPTION
タイプ別一覧画面のタイプリストを「基本」だけの状態でインポートすると、取り込んだ新規設定の名称が「基本」になり、削除できなくなる不具合への対応。 #134
原因は、読込んだ設定ファイルの設定IDを判定すべきところで、リストで選択されている設定IDを使っていたこと。
「基本」しかない状態でインポートを行わない限り異常な動作をしないのでこれまで顕在化しなかったと考えられる。
コードの意図がやや不明瞭なので、周辺コードにコメントも追加。