### PR TITLE
[WIP] 常駐しないに設定した場合のコントロールプロセス起動処理に関する仕様見直し

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -555,6 +555,7 @@
     <ClInclude Include="..\sakura_core\_os\CDropTarget.h" />
     <ClInclude Include="..\sakura_core\_os\COsVersionInfo.h" />
     <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h" />
+    <ClInclude Include="..\sakura_core\_os\NtQueryProcessInformation.h" />
     <ClInclude Include="..\sakura_core\_os\OleTypes.h" />
     <ClInclude Include="..\sakura_core\_os\ProcessEntryIterator.h" />
   </ItemGroup>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -554,6 +554,7 @@
     <ClInclude Include="..\sakura_core\_os\CClipboard.h" />
     <ClInclude Include="..\sakura_core\_os\CDropTarget.h" />
     <ClInclude Include="..\sakura_core\_os\COsVersionInfo.h" />
+    <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h" />
     <ClInclude Include="..\sakura_core\_os\OleTypes.h" />
   </ItemGroup>
   <ItemGroup>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -556,6 +556,7 @@
     <ClInclude Include="..\sakura_core\_os\COsVersionInfo.h" />
     <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h" />
     <ClInclude Include="..\sakura_core\_os\OleTypes.h" />
+    <ClInclude Include="..\sakura_core\_os\ProcessEntryIterator.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\resource\auto_scroll_center.cur" />

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1088,6 +1088,9 @@
     <ClInclude Include="..\sakura_core\version.h">
       <Filter>Other Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h">
+      <Filter>Cpp Source Files\_os</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\sakura_core\Funccode_x.hsrc">

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1094,6 +1094,9 @@
     <ClInclude Include="..\sakura_core\_os\ProcessEntryIterator.h">
       <Filter>Cpp Source Files\_os</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\_os\NtQueryProcessInformation.h">
+      <Filter>Cpp Source Files\_os</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\sakura_core\Funccode_x.hsrc">

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1091,6 +1091,9 @@
     <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h">
       <Filter>Cpp Source Files\_os</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\_os\ProcessEntryIterator.h">
+      <Filter>Cpp Source Files\_os</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\sakura_core\Funccode_x.hsrc">

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -59,8 +59,10 @@ struct GrepInfo {
 */
 class CCommandLine  : public TSingleton<CCommandLine> {
 	friend class TSingleton<CCommandLine>;
+public:
 	CCommandLine();
 
+private:
 	static int CheckCommandLine(
 		LPTSTR	str,		//!< [in] 検証する文字列（先頭の-は含まない）
 		TCHAR**	arg,		//!< [out] 引数がある場合はその先頭へのポインタ

--- a/sakura_core/_main/CControlProcess.h
+++ b/sakura_core/_main/CControlProcess.h
@@ -49,6 +49,9 @@ protected:
 	virtual void OnExitProcess();
 
 private:
+	bool	IsEditorProcess(const std::wstring &profileName) const;
+
+private:
 	HANDLE			m_hMutex;				//!< アプリケーション実行検出用ミューテックス
 	HANDLE			m_hMutexCP;				//!< コントロールプロセスミューテックス
 	HANDLE			m_hEventCPInitialized;	//!< コントロールプロセス初期化完了イベント 2006.04.10 ryoji

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -476,7 +476,7 @@ LRESULT CControlTray::DispatchEvent(
 					}
 				}
 			}while( bDelFound );
-			if( bDelete && m_pShareData->m_sNodes.m_nEditArrNum == 0 ){
+			if( bDelete || m_pShareData->m_sNodes.m_nEditArrNum == 0 ){
 				PostMessageAny( hwnd, MYWM_DELETE_ME, 0, 0 );
 			}
 		}

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -29,6 +29,8 @@
 #include <io.h>
 #include <tchar.h>
 
+#include "_os\getMessageFromSystem.h"
+
 class CProcess;
 
 
@@ -217,6 +219,7 @@ bool CProcessFactory::IsExistControlProcess()
 	return false;	// コントロールプロセスは存在していないか、まだ CreateMutex() してない
 }
 
+
 //	From Here Aug. 28, 2001 genta
 /*!
 	@brief コントロールプロセスを起動する
@@ -275,19 +278,8 @@ bool CProcessFactory::StartControlProcess()
 	);
 	if( !bCreateResult ){
 		//	失敗
-		TCHAR* pMsg;
-		::FormatMessage( FORMAT_MESSAGE_ALLOCATE_BUFFER |
-						FORMAT_MESSAGE_IGNORE_INSERTS |
-						FORMAT_MESSAGE_FROM_SYSTEM,
-						NULL,
-						::GetLastError(),
-						MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-						(LPTSTR)&pMsg,
-						0,
-						NULL
-		);
-		ErrorMessage( NULL, _T("\'%ts\'\nプロセスの起動に失敗しました。\n%ts"), szEXE, pMsg );
-		::LocalFree( (HLOCAL)pMsg );	//	エラーメッセージバッファを解放
+		std::wstring msg(getMessageFromSystem(::GetLastError()));
+		ErrorMessage( NULL, _T("\'%ts\'\nプロセスの起動に失敗しました。\n%ts"), szEXE, msg.c_str() );
 		return false;
 	}
 

--- a/sakura_core/_os/NtQueryProcessInformation.h
+++ b/sakura_core/_os/NtQueryProcessInformation.h
@@ -1,0 +1,82 @@
+/*
+  Copyright (C) 2018, Sakura Editor Organization
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Sakura Editor Organization
+    https://sakura-editor.github.io/ 
+
+ */
+
+#pragma once
+
+#if !defined(_WINBASE_) || !defined(_WINNT_)
+#error Need to include windows.h before getMessageFromSystem.h
+#endif  /* !defined(_WINBASE_) || !defined(_WINNT_) */
+
+#include <Winternl.h> // internal APIs
+
+
+//ñºëOãÛä‘
+namespace sakura {
+	namespace _os {
+
+
+struct NtQueryInformationProcessT
+{
+	typedef NTSTATUS(NTAPI *pfn_NtQueryInformationProcess)(
+		_In_ HANDLE ProcessHandle,
+		_In_ PROCESSINFOCLASS ProcessInformationClass,
+		_Out_ PVOID ProcessInformation,
+		_In_ ULONG ProcessInformationLength,
+		_Out_opt_ PULONG ReturnLengt
+		);
+	pfn_NtQueryInformationProcess _pfn;
+
+	NtQueryInformationProcessT()
+		: _pfn(NULL) {
+		HMODULE ntdll = (HMODULE) ::GetModuleHandle(_T("ntdll"));
+		assert(ntdll);
+
+		_pfn = (pfn_NtQueryInformationProcess)::GetProcAddress(ntdll, "NtQueryInformationProcess");
+		assert(_pfn);
+	}
+	NTSTATUS NTAPI operator() (
+		_In_ HANDLE ProcessHandle,
+		_In_ PROCESSINFOCLASS ProcessInformationClass,
+		_Out_ PVOID ProcessInformation,
+		_In_ ULONG ProcessInformationLength,
+		_Out_opt_ PULONG ReturnLength
+		) const noexcept
+	{
+		NTSTATUS status = _pfn(
+			ProcessHandle,
+			ProcessInformationClass,
+			ProcessInformation,
+			ProcessInformationLength,
+			ReturnLength);
+		return status;
+	}
+};
+
+
+	}; // end of namespace _os
+}; // end of namespace sakura
+
+
+   //ñºëOãÛä‘Çà”éØÇπÇ∏Ç…àµÇ¶ÇÈÇÊÇ§Ç…usingÇµÇƒÇ®Ç≠ÅB
+using sakura::_os::NtQueryInformationProcessT;

--- a/sakura_core/_os/ProcessEntryIterator.h
+++ b/sakura_core/_os/ProcessEntryIterator.h
@@ -1,0 +1,142 @@
+/*
+  Copyright (C) 2018, Sakura Editor Organization
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Sakura Editor Organization
+    https://sakura-editor.github.io/ 
+
+ */
+
+#pragma once
+
+#ifndef _APISETHANDLE_
+#error Need to include windows.h before ProcessEntryIterator.h
+#endif  /* _APISETHANDLE_ */
+
+#include <iterator>
+#include <TlHelp32.h>
+
+
+//名前空間
+namespace sakura {
+	namespace _os {
+
+
+/*!
+ * @brief ProcessEntryIterator
+ *
+ * 構築した瞬間のスナップショットを元にプロセス情報を検索する単方向イテレータ。
+ *
+ * 後置インクリメントは提供しない。
+ * 比較演算子はループの終了判定以外の目的に使用しないこと。
+ *
+ * @author	berryzplus
+ * @date	2018/06/25 berryzplus	新規作成
+ */
+class ProcessEntryIterator : public std::iterator<std::input_iterator_tag, PROCESSENTRY32>
+{
+	typedef std::iterator<std::input_iterator_tag, PROCESSENTRY32>	_Mybase;
+	typedef ProcessEntryIterator									_Myt;
+
+private:
+	HANDLE				_hSnapshot;
+	PROCESSENTRY32		_sFoundData;
+
+public:
+	/*!
+	 * @brief 引数ありコンストラクタ(検索開始用)
+	 *
+	 * @param [in]		dwProcessId		プロセスID。
+	 */
+	ProcessEntryIterator(
+		_In_ DWORD dwProcessId
+	) noexcept
+		: _hSnapshot(INVALID_HANDLE_VALUE)
+	{
+		// プロセスのスナップショットを作成する
+		// これはwin xp以降のみ使える関数。32と付いてるが64兼用。
+		// https://msdn.microsoft.com/en-us/library/ms682489(v=vs.85).aspx
+		_hSnapshot = ::CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, dwProcessId);
+		if (_hSnapshot == INVALID_HANDLE_VALUE) {
+			return;
+		}
+
+		// 最初の検索を実行する
+		_sFoundData.dwSize = sizeof(decltype(_sFoundData));
+		if (!::Process32First(_hSnapshot, &_sFoundData)) {
+			Close();
+		}
+	}
+	//引数なしコンストラクタ(end構築用)
+	ProcessEntryIterator(void) noexcept
+		: _hSnapshot(INVALID_HANDLE_VALUE)
+	{
+	}
+	//デストラクタ
+	virtual ~ProcessEntryIterator(void) noexcept
+	{
+		Close();
+	}
+
+public:
+	//前置インクリメント
+	_Myt & operator++(void) noexcept
+	{
+		//検索ハンドルが有効な場合のみ
+		if (_hSnapshot != INVALID_HANDLE_VALUE)
+		{
+			//次を検索
+			if (!::Process32Next(_hSnapshot, &_sFoundData))
+			{
+				Close();
+			}
+		}
+		return (*this);
+	}
+	pointer   operator->(void) const noexcept { return const_cast< pointer >(&_sFoundData); }
+	reference operator* (void) const noexcept { return const_cast< reference >(_sFoundData); }
+	bool      operator==(const _Myt& rhs) const noexcept { return _hSnapshot == rhs._hSnapshot; }
+	bool      operator!=(const _Myt& rhs) const noexcept { return !(*this == rhs); }
+
+	ProcessEntryIterator(const _Myt& rhs) = delete;
+	_Myt& operator = (const _Myt& rhs) = delete;
+	_Myt operator++( int ) = delete;
+
+protected:
+	//検索が終わったときと、デストラクタが呼ばれたときに呼ばれる
+	void Close(void) noexcept
+	{
+		//検索ハンドルが無効なら何もしない
+		if (_hSnapshot == INVALID_HANDLE_VALUE)
+		{
+			return;
+		}
+
+		//有効な検索ハンドルが残っていれば閉じる
+		::CloseHandle(_hSnapshot);
+		_hSnapshot = INVALID_HANDLE_VALUE;
+	}
+};
+
+
+	}; // end of namespace _os
+}; // end of namespace sakura
+
+
+   //名前空間を意識せずに扱えるようにusingしておく。
+using sakura::_os::ProcessEntryIterator;

--- a/sakura_core/_os/getMessageFromSystem.h
+++ b/sakura_core/_os/getMessageFromSystem.h
@@ -1,0 +1,80 @@
+/*
+  Copyright (C) 2018, Sakura Editor Organization
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Sakura Editor Organization
+    https://sakura-editor.github.io/ 
+
+ */
+
+#pragma once
+
+#ifndef _STRING_
+#error Need to include string before getMessageFromSystem.h
+#endif  /* _STRING_ */
+
+#if !defined(_WINBASE_) || !defined(_WINNT_)
+#error Need to include windows.h before getMessageFromSystem.h
+#endif  /* !defined(_WINBASE_) || !defined(_WINNT_) */
+
+
+//名前空間
+namespace sakura {
+	namespace _os {
+
+
+/*!
+ * @brief システムメッセージを取得する
+ *
+ * @param [in]		dwMessageCode	メッセージコード。
+ *									::GetLastError()の戻り値を指定する。
+ * @param [in,opt]	dwLanguageId	言語識別子。
+ *									省略した場合、::FormatMessage()の挙動に準ずる。
+ * @retval msg						システムメッセージ。
+ *									該当するメッセージがない場合、空文字列を返す。
+ * @sa https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-formatmessage
+ * @date 2018/06/25 berryzplus		新規作成
+ */
+std::wstring getMessageFromSystem(
+	_In_ DWORD dwMessageCode,
+	_In_opt_ DWORD dwLanguageId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT)
+)
+{
+	HLOCAL pMsg = NULL;
+	DWORD length = ::FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM
+		| FORMAT_MESSAGE_ALLOCATE_BUFFER
+		| FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL,
+		dwMessageCode,
+		dwLanguageId,
+		(LPWSTR)&pMsg,
+		0,
+		NULL
+	);
+	std::wstring msg((LPCWSTR)pMsg, length);
+	::LocalFree(pMsg);
+	return std::move(msg);
+}
+
+
+	}; // end of namespace _os
+}; // end of namespace sakura
+
+
+//名前空間を意識せずに扱えるようにusingしておく。
+using sakura::_os::getMessageFromSystem;


### PR DESCRIPTION
共通設定→基本で「常駐しない」に設定しても、管理プロセスを単独で起動(```sakura -NOWIN```)すると常駐できてしまう不具合の対応 #135

エディタプロセスの終了監視で MYWM_DELETE_ME を送る条件を変更し、
管理プロセスを単独起動した場合にも「常駐しない」を実現できるようにする。

デバッグ目的で意図的にされた実装の可能性がある。
（エディタプロセスを起動中に止めると生死監視に応答できないので別の対策が必要。）

Release版にデバッグのための仕様を持ち込むのもおかしい気がするので修正したほうがよいと考えます。