### PR TITLE
preBuild: gitrev.h 生成時に git と .git の存在を明示的にチェック

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bat text eol=crlf

--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -1,18 +1,49 @@
 @echo off
 
+@echo =======================
+@echo preBuild
+@echo =======================
+
+@echo.
+@echo ---- HeaderMake ----
 HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_define.h -mode=define
 HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_enum.h -mode=enum -enum=EFunctionCode
+
+@echo.
+@echo ---- MakefileMake ----
 MakefileMake -file=..\sakura_core\Makefile -dir=..\sakura_core
 
+@echo.
+@echo ---- Make gitrev.h ----
+: Git enabled checking
+set GIT_ENABLED=1
+where git 1>nul 2>&1
+if not "%ERRORLEVEL%" == "0" (
+	set GIT_ENABLED=0
+	@echo NOTE: No git command
+)
+if not exist ..\.git (
+	set GIT_ENABLED=0
+	@echo NOTE: No .git directory
+)
+
+: Get git hash if git is enabled
+if "%GIT_ENABLED%" == "1" (
+	for /f "usebackq" %%s in (`git show -s --format^=%%H`) do (
+		set COMMITID=%%s
+	)
+	for /f "usebackq" %%s in (`git show -s --format^=%%h`) do (
+		set SHORT_COMMITID=%%s
+	)
+) else (
+	set SHORT_COMMITID=
+	set COMMITID=
+)
+@echo SHORT_COMMITID: %SHORT_COMMITID%
+@echo COMMITID: %COMMITID%
+
+: Output gitrev.h
 set GITREV_H=..\sakura_core\gitrev.h
-
-for /f "usebackq" %%s in (`git show -s --format^=%%H`) do (
-    set COMMITID=%%s
-)
-for /f "usebackq" %%s in (`git show -s --format^=%%h`) do (
-    set SHORT_COMMITID=%%s
-)
-
 type nul                                  > %GITREV_H%
 if "%COMMITID%" == "" (
 	type nul                                  >> %GITREV_H%


### PR DESCRIPTION
preBuild.bat における gitrev.h 生成時に git コマンドの存在と .git ディレクトリの存在を明示的にチェックする。

## 対応理由
GitHub から git コマンドを使わずに zip でソースコード一式をダウンロードしてビルドする人がいるため。

- zip でダウンロードする場合は内容物に .git ディレクトリは含まれない。
- zip でダウンロードする人の環境には git コマンドが無い可能性がある。

## 対応内容
- git コマンドと .git ディレクトリの存在チェック
- preBuild の処理の流れが分かるようにログ挿入
- git チェックアウト時（または zip ダウンロード時）に .bat の改行コードが CRLF になるように対応

## 注記
一応このPR対応前の状態で git, .git が無くても gitrev.h は生成されていることを確認しています（エラーログが出ていて気持ち悪いだけで .bat の動作に支障があるわけではなかった）。

ただ、エラーログが出ていると何かしら不具合が生じていそうな不安が生じかねないので本対応を入れました。

## 対応前の挙動
### git コマンドが無い場合の preBuild.bat ログのエラー出力
```
'git' is not recognized as an internal or external command,
operable program or batch file.
'git' is not recognized as an internal or external command,
operable program or batch file.
```

### .git ディレクトリが無い場合の preBuild.bat ログのエラー出力
```
fatal: your current branch 'master' does not have any commits yet
fatal: your current branch 'master' does not have any commits yet
```

## 対応後の挙動
### git コマンドが無い場合
```
---- Make gitrev.h ----
NOTE: No git command
SHORT_COMMITID:
COMMITID:
```
### .git ディレクトリが無い場合
```
---- Make gitrev.h ----
NOTE: No .git directory
SHORT_COMMITID:
COMMITID:
```

### git, .git が存在する場合
```
---- Make gitrev.h ----
SHORT_COMMITID: 96e0ab41
COMMITID: 96e0ab4182d77fb01bff046fe0c5fe66ed1ff504
```
