### PR TITLE
SVN Revision 利用箇所を削除し、代わりに GitHash を用いる

### DIFF
--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -173,13 +173,6 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		HIWORD(dwVersionLS),
 		LOWORD(dwVersionLS)
 	);
-#else
-	auto_sprintf( szMsg, _T("Ver. %d.%d.%d.%d (Rev.") _T(SVN_REV_STR) _T(")\r\n"),
-		HIWORD( dwVersionMS ),
-		LOWORD( dwVersionMS ),
-		HIWORD( dwVersionLS ),
-		LOWORD( dwVersionLS )
-	);
 #endif
 	cmemMsg.AppendString( szMsg );
 

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -5,7 +5,6 @@
 #ifndef SAKURA_LANG_RESOURCE
 	#include "sakura_rc.h"
 	#include "Funccode_define.h"
-	#include "svnrev.h"
 	#include "String_define.h"
 #else
 	#include "sakura_lang.h"

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -2814,8 +2814,8 @@ BEGIN
             VALUE "OriginalFilename", "sakura.exe\0"
             VALUE "ProductName", "Sakura Editor Language DLL\0"
             VALUE "ProductVersion", PR_VER_STR
-#if (SVN_REV != 0)
-                " (Rev." SVN_REV_STR ")"
+#if defined(GIT_SHORT_COMMIT_HASH)
+                " (GitHash " GIT_SHORT_COMMIT_HASH ")"
 #endif
 #ifdef _DEBUG
                 " Debug version"


### PR DESCRIPTION
SVN Revision を利用しているコードは全部削除したつもりでいましたが、まだ一部残っていたようなので、不要なところは削除、および必要に応じて代わりに GitHash に差し替える対応をしました。

## 対応前の不具合
ソースコード一式を git clone ではなく zip でダウンロードした場合に SVN Revision の依存が残っているせいでビルドが失敗するという報告をいただいていました。

https://twitter.com/arigayas/status/1009162151934623744
> @arigayas
> 興味本位で #サクラエディタ GitHub からソースコードのzipファイルでダウンロードしてビルドしてみたけど、失敗する。
> しかしC++の知識が皆無なので対処出来ない(苦笑)
> 
> C2146 構文エラー: ')' が、識別子 'LSVN_REV_STR' の前に必要です。    \sakura_core\dlg\cdlgabout.cpp    182

自分の環境でも試してみましたが、確かに同様のエラーが発生していました。

本PRの対応によりこのエラーは解消されます。