### PR TITLE
git情報が存在しないとき、バージョンダイアログにバージョン番号が表示されない＆文字化けする問題を修正

### DIFF
--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -166,16 +166,17 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	// バージョン&リビジョン情報
 	DWORD dwVersionMS, dwVersionLS;
 	GetAppVersionInfo( NULL, VS_VERSION_INFO, &dwVersionMS, &dwVersionLS );
-#if defined(GIT_COMMIT_HASH)
-	auto_sprintf(szMsg, _T("Ver. %d.%d.%d.%d\r\n(GitHash ") _T(GIT_COMMIT_HASH) _T(")\r\n"),
+	auto_sprintf(szMsg, _T("Ver. %d.%d.%d.%d\r\n"),
 		HIWORD(dwVersionMS),
 		LOWORD(dwVersionMS),
 		HIWORD(dwVersionLS),
 		LOWORD(dwVersionLS)
 	);
+	cmemMsg.AppendString(szMsg);
+#if defined(GIT_COMMIT_HASH)
+	auto_sprintf(szMsg, _T("(GitHash " GIT_COMMIT_HASH ")\r\n"));
+	cmemMsg.AppendString(szMsg);
 #endif
-	cmemMsg.AppendString( szMsg );
-
 	cmemMsg.AppendString( _T("\r\n") );
 
 	// 共有メモリ情報

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -174,8 +174,7 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	);
 	cmemMsg.AppendString(szMsg);
 #if defined(GIT_COMMIT_HASH)
-	auto_sprintf(szMsg, _T("(GitHash " GIT_COMMIT_HASH ")\r\n"));
-	cmemMsg.AppendString(szMsg);
+	cmemMsg.AppendString(_T("(GitHash " GIT_COMMIT_HASH ")\r\n"));
 #endif
 	cmemMsg.AppendString( _T("\r\n") );
 


### PR DESCRIPTION
git 情報が無い状態でビルドしたとき（git clone ではなく zip で入手したとき等）、バージョン情報ダイアログにバージョン番号が表示されない＆文字化け（というか未初期化バッファが展開されてしまう）が発生する問題を修正しました。

## 文字化け症状について
@arigayas さんからご報告いただいてました。

https://twitter.com/arigayas/status/1009446814041305093
> マージされたっぽいので早速ビルドしてみました。謎の文字にビックリしましたがビルド出来ましたww
![ari](https://user-images.githubusercontent.com/2929454/41667827-e238d91e-74e8-11e8-8341-465449805688.jpg)

## 修正後：git情報が有るときのバージョンダイアログの見た目
<img width="326" alt="with-git" src="https://user-images.githubusercontent.com/2929454/41667713-9d79e7f0-74e8-11e8-939d-de29ca3a4a1c.png">

## 修正後：git情報が無いときのバージョンダイアログの見た目
<img width="327" alt="without-git" src="https://user-images.githubusercontent.com/2929454/41667714-9f36cf54-74e8-11e8-8de4-f9b730ee402c.png">
