### PR TITLE
appveyor で再起動したときにハングする問題の修正を試す

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-init:
+install:
 - ps: Set-WinSystemLocale ja-JP
 - ps: Start-Sleep -s 5
 - ps: Restart-Computer


### PR DESCRIPTION
appveyor で再起動したときにハングする問題の修正を試す

以下により `init:` の代わりに、`install:` を使う

https://github.com/appveyor/ci/issues/2456#issuecomment-399276236
`For now try switching the problematic sequence to install: instead of init:`

https://github.com/appveyor/ci/issues/2459
https://github.com/OwenMcDonnell/ProjectA/commit/c6fb53cd9a161f03b1433aaa146b03859272cc41
