### PR TITLE
Git remote URL をバージョン情報に含める

### DIFF
--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -35,12 +35,17 @@ if "%GIT_ENABLED%" == "1" (
 	for /f "usebackq" %%s in (`git show -s --format^=%%h`) do (
 		set SHORT_COMMITID=%%s
 	)
+	for /f "usebackq" %%s in (`git config --get remote.origin.url`) do (
+		set GIT_URL=%%s
+	)
 ) else (
 	set SHORT_COMMITID=
 	set COMMITID=
+	set GIT_URL=
 )
 @echo SHORT_COMMITID: %SHORT_COMMITID%
 @echo COMMITID: %COMMITID%
+@echo GIT_URL: %GIT_URL%
 
 : Output gitrev.h
 set GITREV_H=..\sakura_core\gitrev.h
@@ -54,6 +59,11 @@ if "%SHORT_COMMITID%" == "" (
 	type nul                                              >> %GITREV_H%
 ) else (
 	echo #define GIT_SHORT_COMMIT_HASH "%SHORT_COMMITID%" >> %GITREV_H%
+)
+if "%GIT_URL%" == "" (
+	type nul                                              >> %GITREV_H%
+) else (
+	echo #define GIT_URL "%GIT_URL%"                      >> %GITREV_H%
 )
 
 ENDLOCAL

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -176,6 +176,9 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 #if defined(GIT_COMMIT_HASH)
 	cmemMsg.AppendString(_T("(GitHash " GIT_COMMIT_HASH ")\r\n"));
 #endif
+#if defined(GIT_URL)
+	cmemMsg.AppendString(_T("(GitURL " GIT_URL ")\r\n"));
+#endif
 	cmemMsg.AppendString( _T("\r\n") );
 
 	// 共有メモリ情報
@@ -241,6 +244,13 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	// URLウィンドウをサブクラス化する
 	m_UrlUrWnd.SetSubclassWindow( GetDlgItem( GetHwnd(), IDC_STATIC_URL_UR ) );
+	m_UrlGitWnd.SetSubclassWindow(GetDlgItem( GetHwnd(), IDC_STATIC_URL_GIT));
+#ifdef GIT_URL
+	::SetWindowText(::GetDlgItem(GetHwnd(), IDC_STATIC_URL_GIT), _T(GIT_URL));
+#else
+	ShowWindow(::GetDlgItem(GetHwnd(), IDC_STATIC_GIT_CAPTION), SW_HIDE);
+	ShowWindow(::GetDlgItem(GetHwnd(), IDC_STATIC_URL_GIT), SW_HIDE);
+#endif
 
 	//	Oct. 22, 2005 genta 原作者ホームページが無くなったので削除
 	//m_UrlOrgWnd.SubclassWindow( GetDlgItem( GetHwnd(), IDC_STATIC_URL_ORG ) );
@@ -270,6 +280,7 @@ BOOL CDlgAbout::OnStnClicked( int wID )
 	switch( wID ){
 	//	2006.07.27 genta 原作者連絡先のボタンを削除 (ヘルプから削除されているため)
 	case IDC_STATIC_URL_UR:
+	case IDC_STATIC_URL_GIT:
 //	case IDC_STATIC_URL_ORG:	del 2008/7/4 Uchi
 		//	Web Browserの起動
 		{

--- a/sakura_core/dlg/CDlgAbout.h
+++ b/sakura_core/dlg/CDlgAbout.h
@@ -53,6 +53,7 @@ protected:
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
 private:
 	CUrlWnd m_UrlUrWnd;
+	CUrlWnd m_UrlGitWnd;
 	CUrlWnd m_UrlOrgWnd;
 };
 

--- a/sakura_core/sakura_rc.h
+++ b/sakura_core/sakura_rc.h
@@ -794,6 +794,8 @@
 #define IDC_LIST_WINDOW                 1724
 #define IDC_BUTTON_SAVE                 1725
 #define IDC_BUTTON_CLOSE                1726
+#define IDC_STATIC_URL_GIT              1727
+#define IDC_STATIC_GIT_CAPTION          1728
 #define IDS_AUTHOR_PAGE                 4054
 #define IDS_ABOUT_DESCRIPTION           4056
 #define IDD_TYPELIST                    5000
@@ -836,7 +838,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        230
 #define _APS_NEXT_COMMAND_VALUE         4057
-#define _APS_NEXT_CONTROL_VALUE         1727
+#define _APS_NEXT_CONTROL_VALUE         1729
 #define _APS_NEXT_SYMED_VALUE           104
 #endif
 #endif

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -122,7 +122,11 @@ BEGIN
     LTEXT           "https://sakura-editor.github.io/",
                     IDC_STATIC_URL_UR,101,88,120,8,SS_NOTIFY | NOT WS_GROUP | 
                     WS_TABSTOP
-    EDITTEXT        IDC_EDIT_ABOUT,5,107,233,67,ES_MULTILINE | ES_READONLY | 
+    LTEXT           "Source URL:", IDC_STATIC_GIT_CAPTION,33,98,71,8,NOT WS_GROUP
+    LTEXT           "https://sakura-editor.github.io/",
+                    IDC_STATIC_URL_GIT,101,98,120,8,SS_NOTIFY | NOT WS_GROUP | 
+                    WS_TABSTOP
+    EDITTEXT        IDC_EDIT_ABOUT,5,111,233,63,ES_MULTILINE | ES_READONLY | 
                     WS_VSCROLL | NOT WS_TABSTOP
 END
 

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -123,7 +123,11 @@ BEGIN
     LTEXT           "https://sakura-editor.github.io/",
                     IDC_STATIC_URL_UR,101,88,120,8,SS_NOTIFY | NOT WS_GROUP | 
                     WS_TABSTOP
-    EDITTEXT        IDC_EDIT_ABOUT,5,107,233,67,ES_MULTILINE | ES_READONLY | 
+    LTEXT           "Source URL:", IDC_STATIC_GIT_CAPTION,33,98,71,8,NOT WS_GROUP
+    LTEXT           "https://sakura-editor.github.io/",
+                    IDC_STATIC_URL_GIT,101,98,120,8,SS_NOTIFY | NOT WS_GROUP | 
+                    WS_TABSTOP
+    EDITTEXT        IDC_EDIT_ABOUT,5,111,233,63,ES_MULTILINE | ES_READONLY | 
                     WS_VSCROLL | NOT WS_TABSTOP
 END
 


### PR DESCRIPTION
Git remote URL をバージョン情報に含める

-  `git config --get remote.origin.url` で remote URL を取得して gitrev.h に出力する
-  remote URL をバージョンダイアログに表示する
-  remote URL のリンク可能なテキストを表示する

