### PR TITLE
solution のビルドをバッチファイルの中で行う

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,14 +21,7 @@ build_script:
 
     echo CONFIGURATION %CONFIGURATION%
 
-    set EXTRA_CMD=/verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-
-    set MSBUILD_EXE="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
-
-
-
-    echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
-         %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
+    call build-sln.bat %PLATFORM% %CONFIGURATION%
 
     call build-chm.bat
 

--- a/build-sln.bat
+++ b/build-sln.bat
@@ -11,8 +11,8 @@ if "%APPVEYOR%"=="True" (
 
 set MSBUILD_EXE="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
 
-@echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
-      %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
+@echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%      /t:"Clean","Rebuild"  %EXTRA_CMD%
+      %MSBUILD_EXE% %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%      /t:"Clean","Rebuild"  %EXTRA_CMD%
 if %errorlevel% neq 0 (echo error && exit /b 1)
 
 exit /b 0

--- a/build-sln.bat
+++ b/build-sln.bat
@@ -1,0 +1,18 @@
+set platform=%1
+set configuration=%2
+
+@rem https://www.appveyor.com/docs/environment-variables/
+
+if "%APPVEYOR%"=="True" (
+    set EXTRA_CMD=/verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+) else (
+    set EXTRA_CMD=
+)
+
+set MSBUILD_EXE="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
+
+@echo %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
+      %MSBUILD_EXE% %SLN_FILE% /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION%      /t:"Clean","Rebuild"  %EXTRA_CMD%
+if %errorlevel% neq 0 (echo error && exit /b 1)
+
+exit /b 0


### PR DESCRIPTION
#154: solution のビルドをバッチファイルの中で行う

- appveyor.yml  でやらずに別のバッチでやることによりメンテしやすくなる
- ローカルでテストしやすくなる。
