### PR TITLE
appveyor の成果物をダウンロードしてエクスプローラで解凍して実行すると警告が出る

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master
 
 最新のビルド結果（バイナリ）はここから取得できます。  
 https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master/artifacts
+[`これ`](installer/warning.txt) を読んでからご利用ください。
 
 最新以外のビルド結果は以下から参照できます。  
 https://ci.appveyor.com/project/sakuraeditor/sakura/history

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Visual Studio Community 2017 で `sakura.sln` を開いてビルド。
 https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master
 
 最新のビルド結果（バイナリ）はここから取得できます。  
-https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master/artifacts
+https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master/artifacts  
 [`これ`](installer/warning.txt) を読んでからご利用ください。
 
 最新以外のビルド結果は以下から参照できます。  

--- a/installer/warning.txt
+++ b/installer/warning.txt
@@ -1,0 +1,12 @@
+﻿Appveyor で取得する実行ファイル、インストーラに関する注意事項です。
+
+この成果物を解凍するときには Windows 標準の機能で解凍せずに 
+7-Zip (https://sevenzip.osdn.jp/) 等のツールを使用して解凍してください。
+
+Windows 標準の機能で解凍した場合、実行ファイルまたはインストーラの起動時に
+SmartScreen という機能により警告が表示されます。
+
+7-Zip 等のツールで解凍することによりこの警告が表示されません。
+
+参考
+http://www.atmarkit.co.jp/ait/articles/1603/11/news050.html

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -1,6 +1,8 @@
 set platform=%1
 set configuration=%2
 set WORKDIR=sakura-%platform%-%configuration%
+set WORKDIR_EXE=%WORKDIR%\EXE
+set WORKDIR_INST=%WORKDIR%\Installer
 set OUTFILE=sakura-%platform%-%configuration%.zip
 
 @rem cleanup for local testing
@@ -12,16 +14,18 @@ if exist "%WORKDIR%" (
 )
 
 mkdir %WORKDIR%
-copy %platform%\%configuration%\*.exe %WORKDIR%\
-copy %platform%\%configuration%\*.dll %WORKDIR%\
-copy %platform%\%configuration%\*.pdb %WORKDIR%\
+mkdir %WORKDIR_EXE%
+mkdir %WORKDIR_INST%
+copy %platform%\%configuration%\*.exe %WORKDIR_EXE%\
+copy %platform%\%configuration%\*.dll %WORKDIR_EXE%\
+copy %platform%\%configuration%\*.pdb %WORKDIR_EXE%\
 
-copy help\macro\macro.chm    %WORKDIR%\
-copy help\plugin\plugin.chm  %WORKDIR%\
-copy help\sakura\sakura.chm  %WORKDIR%\
+copy help\macro\macro.chm    %WORKDIR_EXE%\
+copy help\plugin\plugin.chm  %WORKDIR_EXE%\
+copy help\sakura\sakura.chm  %WORKDIR_EXE%\
 
 copy installer\warning.txt   %WORKDIR%\
-copy installer\Output\*.exe  %WORKDIR%\
+copy installer\Output\*.exe  %WORKDIR_INST%\
 
 7z a %OUTFILE%  -r %WORKDIR%
 7z l %OUTFILE%

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -20,6 +20,7 @@ copy help\macro\macro.chm    %WORKDIR%\
 copy help\plugin\plugin.chm  %WORKDIR%\
 copy help\sakura\sakura.chm  %WORKDIR%\
 
+copy installer\warning.txt   %WORKDIR%\
 copy installer\Output\*.exe  %WORKDIR%\
 
 7z a %OUTFILE%  -r %WORKDIR%


### PR DESCRIPTION
 #166: appveyor の成果物をダウンロードしてエクスプローラで解凍して実行すると警告が出る
件に対して回避策のドキュメントを成果物に含める。

またファイルが多くて、ドキュメントが埋もれるのでサブフォルダに分ける。


