### PR TITLE
solution のビルド用のバッチファイル修正

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,6 @@ platform:
 
 build_script:
 - cmd: >-
-    set SLN_FILE=sakura.sln
-
     echo PLATFORM      %PLATFORM%
 
     echo CONFIGURATION %CONFIGURATION%

--- a/build-sln.bat
+++ b/build-sln.bat
@@ -1,5 +1,6 @@
 set platform=%1
 set configuration=%2
+set SLN_FILE=sakura.sln
 
 @rem https://www.appveyor.com/docs/environment-variables/
 


### PR DESCRIPTION
#163 で solution のビルド用のバッチファイルを対応したが、
appveyor.yml でソリューション名を定義せず build-sln.bat 側で行う
