### PR TITLE
[ボツ] x64 版でバージョン情報にアルファ版の表示を行う

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -16,6 +16,10 @@
 #define STRICT 1
 #endif
 
+#if _WIN64
+#define ALPHA_VERSION
+#endif
+
 #if defined(_MSC_VER) && _MSC_VER >= 1400
 
 //#pragma warning(disable: 4786)

--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -20,6 +20,12 @@
 #define ALPHA_VERSION
 #endif
 
+#if defined(ALPHA_VERSION)
+#pragma message("----------------------------------------------------------------------------------------")
+#pragma message("---  This is an alpha version and under development. Be careful to use this version. ---")
+#pragma message("----------------------------------------------------------------------------------------")
+#endif
+
 #if defined(_MSC_VER) && _MSC_VER >= 1400
 
 //#pragma warning(disable: 4786)

--- a/sakura_core/config/app_constants.h
+++ b/sakura_core/config/app_constants.h
@@ -41,7 +41,14 @@
 	#define _APP_NAME_2_(TYPE) TYPE("")
 #endif
 
-#define _GSTR_APPNAME_(TYPE)  _APP_NAME_(TYPE) _APP_NAME_2_(TYPE) //例:UNICODEデバッグ→_T("sakura(デバッグ版)")
+#if defined(ALPHA_VERSION)
+	#define _APP_NAME_3_(TYPE) TYPE("(Alpha Version)")
+#else
+	#define _APP_NAME_3_(TYPE) TYPE("")
+#endif
+
+//例:UNICODEデバッグ→_T("sakura(デバッグ版)")
+#define _GSTR_APPNAME_(TYPE)  _APP_NAME_(TYPE) _APP_NAME_2_(TYPE) _APP_NAME_3_(TYPE)
 
 #define GSTR_APPNAME    (_GSTR_APPNAME_(_T)   )
 #define GSTR_APPNAME_A  (_GSTR_APPNAME_(ATEXT))

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -166,13 +166,17 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	// バージョン&リビジョン情報
 	DWORD dwVersionMS, dwVersionLS;
 	GetAppVersionInfo( NULL, VS_VERSION_INFO, &dwVersionMS, &dwVersionLS );
-	auto_sprintf(szMsg, _T("Ver. %d.%d.%d.%d\r\n"),
+	auto_sprintf(szMsg, _T("Ver. %d.%d.%d.%d"),
 		HIWORD(dwVersionMS),
 		LOWORD(dwVersionMS),
 		HIWORD(dwVersionLS),
 		LOWORD(dwVersionLS)
 	);
 	cmemMsg.AppendString(szMsg);
+#if defined(ALPHA_VERSION)
+	cmemMsg.AppendString(_APP_NAME_3_(_T));
+#endif
+	cmemMsg.AppendString(_T("\r\n") );
 #if defined(GIT_COMMIT_HASH)
 	cmemMsg.AppendString(_T("(GitHash " GIT_COMMIT_HASH ")\r\n"));
 #endif


### PR DESCRIPTION
#162: x64 版でバージョン情報にアルファ版の表示を行う

実際に x64 で効果があることを確認するためにはローカルで
upstream の x64 ブランチをマージする必要があります。
