### PR TITLE
一つのバッチファイルですべてのビルド～archive 作成まで行うようにする。

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,17 +15,7 @@ platform:
 
 build_script:
 - cmd: >-
-    echo PLATFORM      %PLATFORM%
-
-    echo CONFIGURATION %CONFIGURATION%
-
-    call build-sln.bat %PLATFORM% %CONFIGURATION%
-
-    call build-chm.bat
-
-    call build-installer.bat %PLATFORM% %CONFIGURATION%
-
-    call zipArtifacts.bat %PLATFORM% %CONFIGURATION%
+    call build-all.bat %PLATFORM% %CONFIGURATION%
 
     echo appveyor_yml
 

--- a/build-all.bat
+++ b/build-all.bat
@@ -3,21 +3,26 @@ set configuration=%2
 
 @echo PLATFORM      %PLATFORM%
 @echo CONFIGURATION %CONFIGURATION%
+@echo.
 
-@echo start build-sln.bat
+@echo ---- start build-sln.bat ----
 call build-sln.bat       %PLATFORM% %CONFIGURATION% || (echo error build-sln.bat       && exit /b 1)
-@echo end   build-sln.bat
+@echo ---- end   build-sln.bat ----
+@echo.
 
-@echo start build-chm.bat
+@echo ---- start build-chm.bat ----
 call build-chm.bat                                  || (echo error build-chm.bat       && exit /b 1)
-@echo end   build-chm.bat
+@echo ---- end   build-chm.bat ----
+@echo.
 
-@echo start build-installer.bat
+@echo ---- start build-installer.bat ----
 call build-installer.bat %PLATFORM% %CONFIGURATION% || (echo error build-installer.bat && exit /b 1)
-@echo end   build-installer.bat
+@echo ---- end   build-installer.bat ----
+@echo.
 
-@echo start zipArtifacts.bat
+@echo ---- start zipArtifacts.bat ----
 call zipArtifacts.bat    %PLATFORM% %CONFIGURATION% || (echo error zipArtifacts.bat    && exit /b 1)
-@echo end   zipArtifacts.bat
+@echo ---- end   zipArtifacts.bat ----
+@echo.
 
 exit /b 0

--- a/build-all.bat
+++ b/build-all.bat
@@ -1,0 +1,23 @@
+set platform=%1
+set configuration=%2
+
+@echo PLATFORM      %PLATFORM%
+@echo CONFIGURATION %CONFIGURATION%
+
+@echo start build-sln.bat
+call build-sln.bat       %PLATFORM% %CONFIGURATION% || (echo error build-sln.bat       && exit /b 1)
+@echo end   build-sln.bat
+
+@echo start build-chm.bat
+call build-chm.bat                                  || (echo error build-chm.bat       && exit /b 1)
+@echo end   build-chm.bat
+
+@echo start build-installer.bat
+call build-installer.bat %PLATFORM% %CONFIGURATION% || (echo error build-installer.bat && exit /b 1)
+@echo end   build-installer.bat
+
+@echo start zipArtifacts.bat
+call zipArtifacts.bat    %PLATFORM% %CONFIGURATION% || (echo error zipArtifacts.bat    && exit /b 1)
+@echo end   zipArtifacts.bat
+
+exit /b 0


### PR DESCRIPTION
一つのバッチファイルですべてのビルド～archive 作成まで行うようにする。

ビルドを行うために複数のバッチファイルの実行が必要なので
ローカルビルドをするのに手間がかかるので一つのバッチファイルで
行えるようにする。
