### PR TITLE
innosetup-5.6.1-unicode.exe 対応

### DIFF
--- a/installer/sakura.iss
+++ b/installer/sakura.iss
@@ -1,4 +1,9 @@
-﻿#define MyAppVer GetFileVersion("sakura\sakura.exe")
+﻿#if VER < EncodeVer(5,6,1)
+  #define MySendTo "{sendto}"
+#else
+  #define MySendTo "{usersendto}"
+#endif
+#define MyAppVer GetFileVersion("sakura\sakura.exe")
 #define MyAppVerH StringChange(MyAppVer, ".", "-")
 
 [Setup]
@@ -85,7 +90,7 @@ Name: "{userdesktop}\サクラエディタ";                                    
 Name: "{group}\アンインストール";                                              Filename: "{uninstallexe}";                           Tasks: startmenu;
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\サクラエディタ"; Filename: "{app}\sakura.exe";                         Components: main; Tasks: quicklaunch;
 Name: "{userstartup}\サクラエディタ常駐";                                      Filename: "{app}\sakura.exe";   Parameters: "-NOWIN"; Components: main; Tasks: startup;
-Name: "{sendto}\サクラエディタ";                                               Filename: "{app}\sakura.exe";                         Components: main; Tasks: sendto;
+Name: "{#MySendTo}\サクラエディタ";                                            Filename: "{app}\sakura.exe";                         Components: main; Tasks: sendto;
 
 [Run]
 FileName: "{app}\sakura.exe"; Description: "今すぐサクラエディタを起動"; WorkingDir: "{app}"; Flags: postinstall nowait skipifsilent; Check: CheckPrivilege(false);


### PR DESCRIPTION
#129:  innosetup-5.6.1-unicode.exe 対応

5.6.1 (2018-06-14) で以下の修正が入った。

```
The {sendto} constant has been renamed to {usersendto} and now can correctly 
trigger a used user areas warning.
It still returns the same directory: the path to the current user's Send To folder.
 (There is no common Send To folder.)
```

以下の情報を元に対応する
https://github.com/sakura-editor/sakura/issues/129#issuecomment-397869239
