### PR TITLE
[x64] x64 版でバージョン情報にアルファ版の表示を行う (再作成)

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -16,6 +16,16 @@
 #define STRICT 1
 #endif
 
+#if _WIN64
+#define ALPHA_VERSION
+#endif
+
+#if defined(ALPHA_VERSION)
+#pragma message("----------------------------------------------------------------------------------------")
+#pragma message("---  This is an alpha version and under development. Be careful to use this version. ---")
+#pragma message("----------------------------------------------------------------------------------------")
+#endif
+
 #if defined(_MSC_VER) && _MSC_VER >= 1400
 
 //#pragma warning(disable: 4786)

--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -16,16 +16,6 @@
 #define STRICT 1
 #endif
 
-#if _WIN64
-#define ALPHA_VERSION
-#endif
-
-#if defined(ALPHA_VERSION)
-#pragma message("----------------------------------------------------------------------------------------")
-#pragma message("---  This is an alpha version and under development. Be careful to use this version. ---")
-#pragma message("----------------------------------------------------------------------------------------")
-#endif
-
 #if defined(_MSC_VER) && _MSC_VER >= 1400
 
 //#pragma warning(disable: 4786)

--- a/sakura_core/config/app_constants.h
+++ b/sakura_core/config/app_constants.h
@@ -24,6 +24,8 @@
 #ifndef SAKURA_APP_CONSTANTS_AD36E2CE_B62E_497D_806F_6B9738310127_H_
 #define SAKURA_APP_CONSTANTS_AD36E2CE_B62E_497D_806F_6B9738310127_H_
 
+#include "version.h"
+
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           –¼‘O                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/config/app_constants.h
+++ b/sakura_core/config/app_constants.h
@@ -41,7 +41,14 @@
 	#define _APP_NAME_2_(TYPE) TYPE("")
 #endif
 
-#define _GSTR_APPNAME_(TYPE)  _APP_NAME_(TYPE) _APP_NAME_2_(TYPE) //例:UNICODEデバッグ→_T("sakura(デバッグ版)")
+#ifdef ALPHA_VERSION
+	#define _APP_NAME_3_(TYPE) TYPE("(Alpha Version)")
+#else
+	#define _APP_NAME_3_(TYPE) TYPE("")
+#endif
+
+//例:UNICODEデバッグ→_T("sakura(デバッグ版)")
+#define _GSTR_APPNAME_(TYPE)  _APP_NAME_(TYPE) _APP_NAME_2_(TYPE) _APP_NAME_3_(TYPE)
 
 #define GSTR_APPNAME    (_GSTR_APPNAME_(_T)   )
 #define GSTR_APPNAME_A  (_GSTR_APPNAME_(ATEXT))

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -165,26 +165,35 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	// バージョン情報・コンフィグ情報 //
 #ifdef GIT_COMMIT_HASH
-#define VER_GITHASH "(GitHash " GIT_COMMIT_HASH ")\r\n"
-#else
-#define VER_GITHASH ""
+#define VER_GITHASH "(GitHash " GIT_COMMIT_HASH ")"
 #endif
 	DWORD dwVersionMS, dwVersionLS;
 	GetAppVersionInfo( NULL, VS_VERSION_INFO, &dwVersionMS, &dwVersionLS );
 	auto_sprintf(szMsg,
-		_T(
-			"v%d.%d.%d.%d  %hs  %hs\r\n"
-			"%hs"
-		),
-		HIWORD(dwVersionMS), LOWORD(dwVersionMS), HIWORD(dwVersionLS), LOWORD(dwVersionLS), // e.g. {2, 3, 2, 0}
-		VER_PLATFORM, // e.g. "64bit", "32bit"
-		VER_CONFIG, // e.g. "DEBUG", ""
-		VER_GITHASH // e.g. "(GitHash 4a0de5798394409af14ec69c310ba0c86efdfc05)\r\n", ""
+		_T("v%d.%d.%d.%d"),
+		HIWORD(dwVersionMS), LOWORD(dwVersionMS), HIWORD(dwVersionLS), LOWORD(dwVersionLS) // e.g. {2, 3, 2, 0}
 	);
+	
+	// 1行目
 	cmemMsg.AppendString( szMsg );
-#if defined(GIT_URL)
-	cmemMsg.AppendString(_T("(GitURL " GIT_URL ")\r\n"));
+	cmemMsg.AppendString( _T(" ") _T(VER_PLATFORM) );
+	cmemMsg.AppendString( _T(SPACE_WHEN_DEBUG) _T(VER_CONFIG) );
+#ifdef ALPHA_VERSION
+	cmemMsg.AppendString( _T(" ") _T(ALPHA_VERSION_STR));
 #endif
+	cmemMsg.AppendString( _T("\r\n") );
+
+	// 2行目
+#ifdef VER_GITHASH
+	cmemMsg.AppendString( _T(VER_GITHASH) _T("\r\n"));
+#endif
+
+	// 3行目
+#ifdef GIT_URL
+	cmemMsg.AppendString( _T("(GitURL ") _T(GIT_URL) _T(")\r\n"));
+#endif
+
+	// 段落区切り
 	cmemMsg.AppendString( _T("\r\n") );
 
 	// 共有メモリ情報

--- a/sakura_core/version.h
+++ b/sakura_core/version.h
@@ -26,14 +26,24 @@
 #define SPACE_WHEN_DEBUG ""
 #endif
 
+#if _WIN64
+#define ALPHA_VERSION
+#endif
+
+#if defined(ALPHA_VERSION)
+#pragma message("----------------------------------------------------------------------------------------")
+#pragma message("---  This is an alpha version and under development. Be careful to use this version. ---")
+#pragma message("----------------------------------------------------------------------------------------")
+#endif
+
 #ifdef ALPHA_VERSION
-#define ALPHA_VERSION_STR     "Alpha Version"
-#define ALPHA_VERSION_VER_STR " " ALPHA_VERSION_STR
+#define ALPHA_VERSION_STR            "Alpha Version"
+#define ALPHA_VERSION_STR_WITH_SPACE " " ALPHA_VERSION_STR
 #else
-#define ALPHA_VERSION_VER_STR ""
+#define ALPHA_VERSION_STR_WITH_SPACE ""
 #endif
 
 // リソース埋め込み用バージョン文字列
 // e.g. "2.3.2.0 (4a0de579) UNICODE 64bit DEBUG"
 // e.g. "2.3.2.0 (4a0de579) UNICODE 64bit"
-#define RESOURCE_VERSION_STRING(_VersionString) _VersionString " (" GIT_SHORT_COMMIT_HASH ") " VER_CHARSET " " VER_PLATFORM SPACE_WHEN_DEBUG VER_CONFIG ALPHA_VERSION_VER_STR
+#define RESOURCE_VERSION_STRING(_VersionString) _VersionString " (" GIT_SHORT_COMMIT_HASH ") " VER_CHARSET " " VER_PLATFORM SPACE_WHEN_DEBUG VER_CONFIG ALPHA_VERSION_STR_WITH_SPACE

--- a/sakura_core/version.h
+++ b/sakura_core/version.h
@@ -26,7 +26,14 @@
 #define SPACE_WHEN_DEBUG ""
 #endif
 
+#ifdef ALPHA_VERSION
+#define ALPHA_VERSION_STR     "Alpha Version"
+#define ALPHA_VERSION_VER_STR " " ALPHA_VERSION_STR
+#else
+#define ALPHA_VERSION_VER_STR ""
+#endif
+
 // リソース埋め込み用バージョン文字列
 // e.g. "2.3.2.0 (4a0de579) UNICODE 64bit DEBUG"
 // e.g. "2.3.2.0 (4a0de579) UNICODE 64bit"
-#define RESOURCE_VERSION_STRING(_VersionString) _VersionString " (" GIT_SHORT_COMMIT_HASH ") " VER_CHARSET " " VER_PLATFORM SPACE_WHEN_DEBUG VER_CONFIG
+#define RESOURCE_VERSION_STRING(_VersionString) _VersionString " (" GIT_SHORT_COMMIT_HASH ") " VER_CHARSET " " VER_PLATFORM SPACE_WHEN_DEBUG VER_CONFIG ALPHA_VERSION_VER_STR


### PR DESCRIPTION
x64 版でバージョン情報にアルファ版の表示を行う
#174 を捨てて x64 ブランチを元に作成し直した。

- x64 場合ウィンドウタイトルで (Alpha Version) と表示する。
- x64 場合バージョンダイアログに  Alpha Version と表示する。
- x64 場合リソースに  Alpha Version と表示する。

