### PR TITLE
macro 配下のいくつかのファイルを UTF-8 (BOM付) に単純変換

### DIFF
--- a/sakura_core/macro/CCookieManager.cpp
+++ b/sakura_core/macro/CCookieManager.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief Cookieƒ}ƒl[ƒWƒƒ
+ï»¿/*!	@file
+	@brief Cookieãƒãƒãƒ¼ã‚¸ãƒ£
 
 */
 /*

--- a/sakura_core/macro/CCookieManager.h
+++ b/sakura_core/macro/CCookieManager.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief Cookieƒ}ƒl[ƒWƒƒ
+ï»¿/*!	@file
+	@brief Cookieãƒãƒãƒ¼ã‚¸ãƒ£
 
 */
 /*

--- a/sakura_core/macro/CEditorIfObj.cpp
+++ b/sakura_core/macro/CEditorIfObj.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief EditorƒIƒuƒWƒFƒNƒg
+ï»¿/*!	@file
+	@brief Editorã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 
 */
 /*
@@ -30,24 +30,24 @@
 #include "macro/CMacro.h"
 #include "macro/CSMacroMgr.h"
 
-//ƒRƒ}ƒ“ƒhî•ñ‚ğæ“¾‚·‚é
+//ã‚³ãƒãƒ³ãƒ‰æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 MacroFuncInfoArray CEditorIfObj::GetMacroCommandInfo() const
 {
 	return CSMacroMgr::m_MacroFuncInfoCommandArr;
 }
-//ŠÖ”î•ñ‚ğæ“¾‚·‚é
+//é–¢æ•°æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 MacroFuncInfoArray CEditorIfObj::GetMacroFuncInfo() const
 {
 	return CSMacroMgr::m_MacroFuncInfoArr;
 }
 
-//ŠÖ”‚ğˆ—‚·‚é
+//é–¢æ•°ã‚’å‡¦ç†ã™ã‚‹
 bool CEditorIfObj::HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 {
 	return CMacro::HandleFunction( View, ID, Arguments, ArgSize, Result );
 }
 
-//ƒRƒ}ƒ“ƒh‚ğˆ—‚·‚é
+//ã‚³ãƒãƒ³ãƒ‰ã‚’å‡¦ç†ã™ã‚‹
 bool CEditorIfObj::HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize)
 {
 	return CMacro::HandleCommand( View, ID, Arguments, ArgLengths, ArgSize );

--- a/sakura_core/macro/CEditorIfObj.h
+++ b/sakura_core/macro/CEditorIfObj.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief EditorƒIƒuƒWƒFƒNƒg
+ï»¿/*!	@file
+	@brief Editorã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 
 */
 /*
@@ -34,15 +34,15 @@
 
 class CEditorIfObj : public CWSHIfObj
 {
-	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	// ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CEditorIfObj() : CWSHIfObj( L"Editor", true ){}
 
-	// À‘•
-	MacroFuncInfoArray GetMacroCommandInfo() const;	//ƒRƒ}ƒ“ƒhî•ñ‚ğæ“¾‚·‚é
-	MacroFuncInfoArray GetMacroFuncInfo() const;	//ŠÖ”î•ñ‚ğæ“¾‚·‚é
-	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result);	//ŠÖ”‚ğˆ—‚·‚é
-	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize);	//ƒRƒ}ƒ“ƒh‚ğˆ—‚·‚é
+	// å®Ÿè£…
+	MacroFuncInfoArray GetMacroCommandInfo() const;	//ã‚³ãƒãƒ³ãƒ‰æƒ…å ±ã‚’å–å¾—ã™ã‚‹
+	MacroFuncInfoArray GetMacroFuncInfo() const;	//é–¢æ•°æƒ…å ±ã‚’å–å¾—ã™ã‚‹
+	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result);	//é–¢æ•°ã‚’å‡¦ç†ã™ã‚‹
+	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize);	//ã‚³ãƒãƒ³ãƒ‰ã‚’å‡¦ç†ã™ã‚‹
 };
 
 

--- a/sakura_core/macro/CIfObj.cpp
+++ b/sakura_core/macro/CIfObj.cpp
@@ -1,13 +1,13 @@
-/*!	@file
-	@brief WSHƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒgŠî–{ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief WSHã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆåŸºæœ¬ã‚¯ãƒ©ã‚¹
 
-	@date 2009.10.29 syat CWSH.cpp‚©‚çØ‚èo‚µ
+	@date 2009.10.29 syat CWSH.cppã‹ã‚‰åˆ‡ã‚Šå‡ºã—
 
 	@par TODO
-	@li GetIDsOfNames‚ÌÅ“K‰» ¨ std::map‚ğg‚¦‚ÎŠy‚»‚¤c‚µ‚©‚µ„‚ÍSTL‚É‘a‚¢‚Ì‚Å(;_;
+	@li GetIDsOfNamesã®æœ€é©åŒ– â†’ std::mapã‚’ä½¿ãˆã°æ¥½ãã†â€¦ã—ã‹ã—ç§ã¯STLã«ç–ã„ã®ã§(;_;
 */
 /*
-	Copyright (C) 2002, ‹S, genta
+	Copyright (C) 2002, é¬¼, genta
 	Copyright (C) 2003, FILE
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, FILE, zenryaku
@@ -36,13 +36,13 @@
 #include "StdAfx.h"
 #include "macro/CIfObj.h"
 
-//ƒgƒŒ[ƒXƒƒbƒZ[ƒW—L–³
+//ãƒˆãƒ¬ãƒ¼ã‚¹ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸æœ‰ç„¡
 #if defined( _DEBUG ) && defined( _UNICODE )
 #define TEST
 #endif
 
 /////////////////////////////////////////////
-//ƒXƒNƒŠƒvƒg‚É“n‚³‚ê‚éƒIƒuƒWƒFƒNƒg‚ÌŒ^î•ñ
+//ã‚¹ã‚¯ãƒªãƒ—ãƒˆã«æ¸¡ã•ã‚Œã‚‹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã®å‹æƒ…å ±
 class CIfObjTypeInfo: public ImplementsIUnknown<ITypeInfo>
 {
 private:
@@ -130,8 +130,8 @@ public:
 	    /* [out] */ BSTR __RPC_FAR *pBstrHelpFile)
 	{
 		//	Feb. 08, 2004 genta
-		//	‚Æ‚è‚ ‚¦‚¸‘S•”NULL‚ğ•Ô‚· (î•ñ–³‚µ)
-		//	2014.02.12 Šeƒpƒ‰ƒ[ƒ^‚ğİ’è‚·‚é‚æ‚¤‚É
+		//	ã¨ã‚Šã‚ãˆãšå…¨éƒ¨NULLã‚’è¿”ã™ (æƒ…å ±ç„¡ã—)
+		//	2014.02.12 å„ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã‚’è¨­å®šã™ã‚‹ã‚ˆã†ã«
 		if( memid == -1 ){
 			if( pBstrName ){
 				*pBstrName = SysAllocString( m_sName.c_str() );
@@ -222,7 +222,7 @@ CIfObjTypeInfo::CIfObjTypeInfo(const CIfObj::CMethodInfoList& methods, const std
 				: ImplementsIUnknown<ITypeInfo>(), m_MethodsRef(methods), m_sName(sName)
 { 
 	ZeroMemory(&m_TypeAttr, sizeof(m_TypeAttr));
-	m_TypeAttr.cImplTypes = 0; //eƒNƒ‰ƒX‚ÌITypeInfo‚Ì”
+	m_TypeAttr.cImplTypes = 0; //è¦ªã‚¯ãƒ©ã‚¹ã®ITypeInfoã®æ•°
 	m_TypeAttr.cFuncs = (WORD)m_MethodsRef.size();
 }
 
@@ -254,22 +254,22 @@ HRESULT STDMETHODCALLTYPE CIfObjTypeInfo::GetNames(
 
 
 /////////////////////////////////////////////
-//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg
+//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 
-//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 CIfObj::CIfObj(const wchar_t* name, bool isGlobal)
 : ImplementsIUnknown<IDispatch>(), m_sName(name), m_isGlobal(isGlobal), m_Owner(0), m_Methods(), m_TypeInfo(NULL)
 { 
 };
 
-//ƒfƒXƒgƒ‰ƒNƒ^
+//ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 CIfObj::~CIfObj()
 {
 	if(m_TypeInfo != NULL)
 		m_TypeInfo->Release();
 }
 	
-//IUnknownÀ‘•
+//IUnknownå®Ÿè£…
 HRESULT STDMETHODCALLTYPE CIfObj::QueryInterface(REFIID iid, void ** ppvObject) 
 {
 	if(ppvObject == NULL) 
@@ -284,7 +284,7 @@ HRESULT STDMETHODCALLTYPE CIfObj::QueryInterface(REFIID iid, void ** ppvObject)
 		return E_NOINTERFACE;
 }
 
-//IDispatchÀ‘•
+//IDispatchå®Ÿè£…
 HRESULT STDMETHODCALLTYPE CIfObj::Invoke(
 				DISPID dispidMember,
 				REFIID riid,
@@ -337,13 +337,13 @@ HRESULT STDMETHODCALLTYPE CIfObj::GetIDsOfNames(
 	for(unsigned i = 0; i < cNames; ++i)
 	{
 #ifdef TEST
-		//‘å—Ê‚ÉƒƒbƒZ[ƒW‚ªo‚é‚Ì‚Å’ˆÓB
+		//å¤§é‡ã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãŒå‡ºã‚‹ã®ã§æ³¨æ„ã€‚
 		//DEBUG_TRACE( _T("GetIDsOfNames: %ls\n"), rgszNames[i] );
 #endif
 		size_t nSize = m_Methods.size();
 		for(size_t j = 0; j < nSize; ++j)
 		{
-			//	Nov. 10, 2003 FILE Win9X‚Å‚ÍA[lstrcmpiW]‚ª–³Œø‚Ì‚½‚ßA[_wcsicmp]‚ÉC³
+			//	Nov. 10, 2003 FILE Win9Xã§ã¯ã€[lstrcmpiW]ãŒç„¡åŠ¹ã®ãŸã‚ã€[_wcsicmp]ã«ä¿®æ­£
 			if(_wcsicmp(rgszNames[i], m_Methods[j].Name) == 0)
 			{
 				rgdispid[i] = j;
@@ -357,7 +357,7 @@ HRESULT STDMETHODCALLTYPE CIfObj::GetIDsOfNames(
 	return S_OK;
 }
 
-//Œ^î•ñ‚Éƒƒ\ƒbƒh‚ğ’Ç‰Á‚·‚é
+//å‹æƒ…å ±ã«ãƒ¡ã‚½ãƒƒãƒ‰ã‚’è¿½åŠ ã™ã‚‹
 void CIfObj::AddMethod(
 	const wchar_t*	Name,
 	int				ID,
@@ -368,15 +368,15 @@ void CIfObj::AddMethod(
 )
 {
 	/*
-		this->m_TypeInfo‚ª NULL‚Å‚È‚¯‚ê‚Î AddMethod()‚Í”½‰f‚³‚ê‚È‚¢B
+		this->m_TypeInfoãŒ NULLã§ãªã‘ã‚Œã° AddMethod()ã¯åæ˜ ã•ã‚Œãªã„ã€‚
 	*/
 	m_Methods.push_back(CMethodInfo());
 	CMethodInfo *Info = &m_Methods[m_Methods.size() - 1];
 	ZeroMemory(Info, sizeof(CMethodInfo));
 	Info->Desc.invkind = INVOKE_FUNC;
-	Info->Desc.cParams = (SHORT)ArgumentCount + 1; //–ß‚è’l‚Ì•ª
+	Info->Desc.cParams = (SHORT)ArgumentCount + 1; //æˆ»ã‚Šå€¤ã®åˆ†
 	Info->Desc.lprgelemdescParam = Info->Arguments;
-	//	Nov. 10, 2003 FILE Win9X‚Å‚ÍA[lstrcpyW]‚ª–³Œø‚Ì‚½‚ßA[wcscpy]‚ÉC³
+	//	Nov. 10, 2003 FILE Win9Xã§ã¯ã€[lstrcpyW]ãŒç„¡åŠ¹ã®ãŸã‚ã€[wcscpy]ã«ä¿®æ­£
 	assert( auto_strlen(Name)<_countof(Info->Name) );
 	wcscpy(Info->Name, Name);
 	Info->Method = Method;

--- a/sakura_core/macro/CIfObj.h
+++ b/sakura_core/macro/CIfObj.h
@@ -1,11 +1,11 @@
-/*!	@file
-	@brief WSHƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒgŠî–{ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief WSHã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆåŸºæœ¬ã‚¯ãƒ©ã‚¹
 
-	@date 2009.10.29 syat CWSH.h‚©‚çØ‚èo‚µ
+	@date 2009.10.29 syat CWSH.hã‹ã‚‰åˆ‡ã‚Šå‡ºã—
 
 */
 /*
-	Copyright (C) 2002, ‹S, genta
+	Copyright (C) 2002, é¬¼, genta
 	Copyright (C) 2009, syat
 
 	This software is provided 'as-is', without any express or implied
@@ -36,7 +36,7 @@
 #include "_os/OleTypes.h"
 class CEditView;
 
-//COMˆê”Ê
+//COMä¸€èˆ¬
 
 template<class Base>
 class ImplementsIUnknown: public Base
@@ -60,25 +60,25 @@ public:
 	virtual ~ImplementsIUnknown(){}
 };
 
-//WSHˆê”Ê
+//WSHä¸€èˆ¬
 
 class CIfObj;
 typedef HRESULT (CIfObj::*CIfObjMethod)(int ID, DISPPARAMS *Arguments, VARIANT* Result, void *Data);
 
-//CIfObj‚ª•K—v‚Æ‚·‚éWSHClient‚ÌƒCƒ“ƒ^ƒtƒF[ƒX
+//CIfObjãŒå¿…è¦ã¨ã™ã‚‹WSHClientã®ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹
 class IWSHClient
 {
 public:
 	virtual void* GetData() const = 0;
 };
 
-//ƒXƒNƒŠƒvƒg‚É“n‚³‚ê‚éƒIƒuƒWƒFƒNƒg
+//ã‚¹ã‚¯ãƒªãƒ—ãƒˆã«æ¸¡ã•ã‚Œã‚‹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 
 class CIfObj
 : public ImplementsIUnknown<IDispatch>
 {
 public:
-	// Œ^’è‹`
+	// å‹å®šç¾©
 	struct CMethodInfo
 	{
 		FUNCDESC		Desc;
@@ -89,19 +89,19 @@ public:
 	};
 	typedef std::vector<CMethodInfo> CMethodInfoList;
 
-	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	// ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CIfObj(const wchar_t* name, bool isGlobal);
 	virtual ~CIfObj();
 
-	// ƒtƒB[ƒ‹ƒhEƒAƒNƒZƒT
-	const std::wstring::value_type* Name() const { return this->m_sName.c_str(); } // ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg–¼
-	bool IsGlobal() const { return this->m_isGlobal; } //ƒIƒuƒWƒFƒNƒg–¼‚ÌÈ—ª‰Â”Û
-	IWSHClient* Owner() const { return this->m_Owner; } // ƒI[ƒi[IWSHClient
+	// ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ãƒ»ã‚¢ã‚¯ã‚»ã‚µ
+	const std::wstring::value_type* Name() const { return this->m_sName.c_str(); } // ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆå
+	bool IsGlobal() const { return this->m_isGlobal; } //ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆåã®çœç•¥å¯å¦
+	IWSHClient* Owner() const { return this->m_Owner; } // ã‚ªãƒ¼ãƒŠãƒ¼IWSHClient
 	std::wstring m_sName;
 	bool m_isGlobal;
 	IWSHClient *m_Owner;
 
-	// ‘€ì
+	// æ“ä½œ
 	void AddMethod(const wchar_t* Name, int ID, VARTYPE *ArgumentTypes,
 		int ArgumentCount, VARTYPE ResultType, CIfObjMethod Method);
 	void ReserveMethods(int Count)
@@ -109,7 +109,7 @@ public:
 		m_Methods.reserve(Count);
 	}
 
-	// À‘•
+	// å®Ÿè£…
 	virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void ** ppvObject);
 	virtual HRESULT STDMETHODCALLTYPE GetIDsOfNames(
 					REFIID riid,
@@ -134,8 +134,8 @@ public:
 					/* [out] */ UINT __RPC_FAR *pctinfo);
 
 private:
-	// ƒƒ“ƒo•Ï”
-	CMethodInfoList m_Methods;			//ƒƒ\ƒbƒhî•ñƒŠƒXƒg
+	// ãƒ¡ãƒ³ãƒå¤‰æ•°
+	CMethodInfoList m_Methods;			//ãƒ¡ã‚½ãƒƒãƒ‰æƒ…å ±ãƒªã‚¹ãƒˆ
 	ITypeInfo* m_TypeInfo;
 };
 

--- a/sakura_core/macro/CKeyMacroMgr.cpp
+++ b/sakura_core/macro/CKeyMacroMgr.cpp
@@ -1,10 +1,10 @@
-/*!	@file
-	@brief ƒL[ƒ{[ƒhƒ}ƒNƒ
+ï»¿/*!	@file
+	@brief ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­
 
 	@author Norio Nakatani
 
-	@date 20011229 aroka ƒoƒOC³AƒRƒƒ“ƒg’Ç‰Á
-	YAZAKI ‘g‘Ö‚¦
+	@date 20011229 aroka ãƒã‚°ä¿®æ­£ã€ã‚³ãƒ¡ãƒ³ãƒˆè¿½åŠ 
+	YAZAKI çµ„æ›¿ãˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -33,19 +33,19 @@ CKeyMacroMgr::CKeyMacroMgr()
 	m_pBot = NULL;
 //	m_nKeyMacroDataArrNum = 0;	2002.2.2 YAZAKI
 	//	Apr. 29, 2002 genta
-	//	m_nReady‚ÍCMacroManagerBase‚Ö
+	//	m_nReadyã¯CMacroManagerBaseã¸
 	return;
 }
 
 CKeyMacroMgr::~CKeyMacroMgr()
 {
-	/* ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚ğƒNƒŠƒA‚·‚é */
+	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹ */
 	ClearAll();
 	return;
 }
 
 
-/*! ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚ğƒNƒŠƒA‚·‚é */
+/*! ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹ */
 void CKeyMacroMgr::ClearAll( void )
 {
 	CMacro* p = m_pTop;
@@ -62,9 +62,9 @@ void CKeyMacroMgr::ClearAll( void )
 
 }
 
-/*! ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚Éƒf[ƒ^’Ç‰Á
-	‹@”\”Ô†‚ÆAˆø”‚Ğ‚Æ‚Â‚ğ’Ç‰Á”ÅB
-	@date 2002.2.2 YAZAKI pcEditView‚à“n‚·‚æ‚¤‚É‚µ‚½B
+/*! ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã«ãƒ‡ãƒ¼ã‚¿è¿½åŠ 
+	æ©Ÿèƒ½ç•ªå·ã¨ã€å¼•æ•°ã²ã¨ã¤ã‚’è¿½åŠ ç‰ˆã€‚
+	@date 2002.2.2 YAZAKI pcEditViewã‚‚æ¸¡ã™ã‚ˆã†ã«ã—ãŸã€‚
 */
 void CKeyMacroMgr::Append(
 	EFunctionCode	nFuncID,
@@ -77,8 +77,8 @@ void CKeyMacroMgr::Append(
 	Append(macro);
 }
 
-/*! ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚Éƒf[ƒ^’Ç‰Á
-	CMacro‚ğw’è‚µ‚Ä’Ç‰Á‚·‚é”Å
+/*! ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã«ãƒ‡ãƒ¼ã‚¿è¿½åŠ 
+	CMacroã‚’æŒ‡å®šã—ã¦è¿½åŠ ã™ã‚‹ç‰ˆ
 */
 void CKeyMacroMgr::Append( CMacro* macro )
 {
@@ -96,8 +96,8 @@ void CKeyMacroMgr::Append( CMacro* macro )
 
 
 
-/*! ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì•Û‘¶
-	ƒGƒ‰[ƒƒbƒZ[ƒW‚Ío‚µ‚Ü‚¹‚ñBŒÄ‚Ño‚µ‘¤‚Å‚æ‚«‚É‚Í‚©‚ç‚Á‚Ä‚­‚¾‚³‚¢B
+/*! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®ä¿å­˜
+	ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯å‡ºã—ã¾ã›ã‚“ã€‚å‘¼ã³å‡ºã—å´ã§ã‚ˆãã«ã¯ã‹ã‚‰ã£ã¦ãã ã•ã„ã€‚
 */
 BOOL CKeyMacroMgr::SaveKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath ) const
 {
@@ -106,10 +106,10 @@ BOOL CKeyMacroMgr::SaveKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath ) con
 		return FALSE;
 	}
 
-	//Å‰‚ÌƒRƒƒ“ƒg
+	//æœ€åˆã®ã‚³ãƒ¡ãƒ³ãƒˆ
 	out.WriteF(LSW(STR_ERR_DLGKEYMACMGR1));
 
-	//ƒ}ƒNƒ“à—e
+	//ãƒã‚¯ãƒ­å†…å®¹
 	CMacro* p = m_pTop;
 	while (p){
 		p->Save( hInstance, out );
@@ -122,11 +122,11 @@ BOOL CKeyMacroMgr::SaveKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath ) con
 
 
 
-/** ƒL[ƒ{[ƒhƒ}ƒNƒ‚ÌÀs
-	CMacro‚ÉˆÏ÷B
+/** ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®å®Ÿè¡Œ
+	CMacroã«å§”è­²ã€‚
 	
-	@date 2007.07.20 genta flags’Ç‰ÁDCMacro::Exec()‚É
-		FA_FROMMACRO‚ğŠÜ‚ß‚½’l‚ğ“n‚·D
+	@date 2007.07.20 genta flagsè¿½åŠ ï¼CMacro::Exec()ã«
+		FA_FROMMACROã‚’å«ã‚ãŸå€¤ã‚’æ¸¡ã™ï¼
 */
 bool CKeyMacroMgr::ExecKeyMacro( CEditView* pcEditView, int flags ) const
 {
@@ -143,12 +143,12 @@ bool CKeyMacroMgr::ExecKeyMacro( CEditView* pcEditView, int flags ) const
 	return bRet;
 }
 
-/*! ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì“Ç‚İ‚İ
-	ƒGƒ‰[ƒƒbƒZ[ƒW‚Ío‚µ‚Ü‚¹‚ñBŒÄ‚Ño‚µ‘¤‚Å‚æ‚«‚É‚Í‚©‚ç‚Á‚Ä‚­‚¾‚³‚¢B
+/*! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿
+	ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯å‡ºã—ã¾ã›ã‚“ã€‚å‘¼ã³å‡ºã—å´ã§ã‚ˆãã«ã¯ã‹ã‚‰ã£ã¦ãã ã•ã„ã€‚
 */
 BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 {
-	/* ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚ğƒNƒŠƒA‚·‚é */
+	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹ */
 	ClearAll();
 
 	CTextInputStream in( pszPath );
@@ -165,38 +165,38 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 	CMacro* macro = NULL;
 
 	//	Jun. 16, 2002 genta
-	m_nReady = true;	//	ƒGƒ‰[‚ª‚ ‚ê‚Îfalse‚É‚È‚é
+	m_nReady = true;	//	ã‚¨ãƒ©ãƒ¼ãŒã‚ã‚Œã°falseã«ãªã‚‹
 	std::tstring MACRO_ERROR_TITLE_string = LS(STR_ERR_DLGKEYMACMGR2);
 	const TCHAR* MACRO_ERROR_TITLE = MACRO_ERROR_TITLE_string.c_str();
 
-	int line = 1;	//	ƒGƒ‰[‚És”Ô†‚ğ’Ê’m‚·‚é‚½‚ßD1n‚Ü‚èD
+	int line = 1;	//	ã‚¨ãƒ©ãƒ¼æ™‚ã«è¡Œç•ªå·ã‚’é€šçŸ¥ã™ã‚‹ãŸã‚ï¼1å§‹ã¾ã‚Šï¼
 	for( ; in.Good() ; ++line ){
 		std::wstring strLine = in.ReadLineW();
-		const WCHAR* szLine = strLine.c_str(); // '\0'I’[•¶š—ñ‚ğæ“¾
+		const WCHAR* szLine = strLine.c_str(); // '\0'çµ‚ç«¯æ–‡å­—åˆ—ã‚’å–å¾—
 		using namespace WCODE;
 
 		int nLineLen = strLine.length();
-		// æs‚·‚é‹ó”’‚ğƒXƒLƒbƒv
+		// å…ˆè¡Œã™ã‚‹ç©ºç™½ã‚’ã‚¹ã‚­ãƒƒãƒ—
 		for( i = 0; i < nLineLen; ++i ){
 			if( szLine[i] != SPACE && szLine[i] != TAB ){
 				break;
 			}
 		}
 		nBgn = i;
-		//	Jun. 16, 2002 genta ‹ós‚ğ–³‹‚·‚é
+		//	Jun. 16, 2002 genta ç©ºè¡Œã‚’ç„¡è¦–ã™ã‚‹
 		if( nBgn == nLineLen || szLine[nBgn] == LTEXT('\0') ){
 			continue;
 		}
-		// ƒRƒƒ“ƒgs‚ÌŒŸo
-		//# ƒpƒtƒH[ƒ}ƒ“ƒXF'/'‚Ì‚Æ‚«‚¾‚¯‚Q•¶š–Ú‚ğƒeƒXƒg
+		// ã‚³ãƒ¡ãƒ³ãƒˆè¡Œã®æ¤œå‡º
+		//# ãƒ‘ãƒ•ã‚©ãƒ¼ãƒãƒ³ã‚¹ï¼š'/'ã®ã¨ãã ã‘ï¼’æ–‡å­—ç›®ã‚’ãƒ†ã‚¹ãƒˆ
 		if( szLine[nBgn] == LTEXT('/') && nBgn + 1 < nLineLen && szLine[nBgn + 1] == LTEXT('/') ){
 			continue;
 		}
 
-		// ŠÖ”–¼‚Ìæ“¾
-		szFuncName[0]='\0';// ‰Šú‰»
+		// é–¢æ•°åã®å–å¾—
+		szFuncName[0]='\0';// åˆæœŸåŒ–
 		for( ; i < nLineLen; ++i ){
-			//# ƒoƒbƒtƒ@ƒI[ƒo[ƒ‰ƒ“ƒ`ƒFƒbƒN
+			//# ãƒãƒƒãƒ•ã‚¡ã‚ªãƒ¼ãƒãƒ¼ãƒ©ãƒ³ãƒã‚§ãƒƒã‚¯
 			if( szLine[i] == LTEXT('(') && (i - nBgn)< _countof(szFuncName) ){
 				auto_memcpy( szFuncName, &szLine[nBgn], i - nBgn );
 				szFuncName[i - nBgn] = L'\0';
@@ -205,14 +205,14 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 				break;
 			}
 		}
-		// ŠÖ”–¼‚ÉS_‚ª•t‚¢‚Ä‚¢‚½‚ç
+		// é–¢æ•°åã«S_ãŒä»˜ã„ã¦ã„ãŸã‚‰
 
-		/* ŠÖ”–¼¨‹@”\IDC‹@”\–¼“ú–{Œê */
-		//@@@ 2002.2.2 YAZAKI ƒ}ƒNƒ‚ğCSMacroMgr‚É“ˆê
+		/* é–¢æ•°åâ†’æ©Ÿèƒ½IDï¼Œæ©Ÿèƒ½åæ—¥æœ¬èª */
+		//@@@ 2002.2.2 YAZAKI ãƒã‚¯ãƒ­ã‚’CSMacroMgrã«çµ±ä¸€
 		nFuncID = CSMacroMgr::GetFuncInfoByName( hInstance, szFuncName, szFuncNameJapanese );
 		if( -1 != nFuncID ){
 			macro = new CMacro( nFuncID );
-			// Jun. 16, 2002 genta ƒvƒƒgƒ^ƒCƒvƒ`ƒFƒbƒN—p‚É’Ç‰Á
+			// Jun. 16, 2002 genta ãƒ—ãƒ­ãƒˆã‚¿ã‚¤ãƒ—ãƒã‚§ãƒƒã‚¯ç”¨ã«è¿½åŠ 
 			int nArgs;
 			const MacroFuncInfo* mInfo= CSMacroMgr::GetFuncInfoByID( nFuncID );
 			int nArgSizeMax = _countof( mInfo->m_varArguments );
@@ -220,7 +220,7 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 				nArgSizeMax = mInfo->m_pData->m_nArgMaxSize;
 			}
 			for(nArgs = 0; szLine[i] ; ++nArgs ) {
-				// Jun. 16, 2002 genta ƒvƒƒgƒ^ƒCƒvƒ`ƒFƒbƒN
+				// Jun. 16, 2002 genta ãƒ—ãƒ­ãƒˆã‚¿ã‚¤ãƒ—ãƒã‚§ãƒƒã‚¯
 				if( nArgs >= nArgSizeMax ){
 					::MYMESSAGEBOX(
 						NULL,
@@ -245,11 +245,11 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 				while( szLine[i] == LTEXT(' ') || szLine[i] == LTEXT('\t') )
 					i++;
 
-				//@@@ 2002.2.2 YAZAKI PPA.DLLƒ}ƒNƒ‚É‚ ‚í‚¹‚Äd—l•ÏXB•¶š—ñ‚Í''‚ÅˆÍ‚ŞB
-				//	Jun. 16, 2002 genta double quotation‚à‹–—e‚·‚é
-				if( LTEXT('\'') == szLine[i] || LTEXT('\"') == szLine[i]  ){	//	'‚Ån‚Ü‚Á‚½‚ç•¶š—ñ‚¾‚æ‚«‚Á‚ÆB
-					// Jun. 16, 2002 genta ƒvƒƒgƒ^ƒCƒvƒ`ƒFƒbƒN
-					// Jun. 27, 2002 genta —]•ª‚Èˆø”‚ğ–³‹‚·‚é‚æ‚¤CVT_EMPTY‚ğ‹–—e‚·‚éD
+				//@@@ 2002.2.2 YAZAKI PPA.DLLãƒã‚¯ãƒ­ã«ã‚ã‚ã›ã¦ä»•æ§˜å¤‰æ›´ã€‚æ–‡å­—åˆ—ã¯''ã§å›²ã‚€ã€‚
+				//	Jun. 16, 2002 genta double quotationã‚‚è¨±å®¹ã™ã‚‹
+				if( LTEXT('\'') == szLine[i] || LTEXT('\"') == szLine[i]  ){	//	'ã§å§‹ã¾ã£ãŸã‚‰æ–‡å­—åˆ—ã ã‚ˆãã£ã¨ã€‚
+					// Jun. 16, 2002 genta ãƒ—ãƒ­ãƒˆã‚¿ã‚¤ãƒ—ãƒã‚§ãƒƒã‚¯
+					// Jun. 27, 2002 genta ä½™åˆ†ãªå¼•æ•°ã‚’ç„¡è¦–ã™ã‚‹ã‚ˆã†ï¼ŒVT_EMPTYã‚’è¨±å®¹ã™ã‚‹ï¼
 					if( type != VT_BSTR && 
 						type != VT_EMPTY ){
 						::MYMESSAGEBOX(
@@ -267,19 +267,19 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 					}
 					WCHAR cQuote = szLine[i];
 					++i;
-					nBgn = nEnd = i;	//	nBgn‚Íˆø”‚Ìæ“ª‚Ì•¶š
+					nBgn = nEnd = i;	//	nBgnã¯å¼•æ•°ã®å…ˆé ­ã®æ–‡å­—
 					//	Jun. 16, 2002 genta
-					//	s––‚ÌŒŸo‚Ì‚½‚ßCƒ‹[ƒv‰ñ”‚ğ1‘‚â‚µ‚½
-					for( ; i <= nLineLen; ++i ){		//	ÅŒã‚Ì•¶š+1‚Ü‚ÅƒXƒLƒƒƒ“
-						if( szLine[i] == LTEXT('\\') ){	// ƒGƒXƒP[ƒv‚ÌƒXƒLƒbƒv
+					//	è¡Œæœ«ã®æ¤œå‡ºã®ãŸã‚ï¼Œãƒ«ãƒ¼ãƒ—å›æ•°ã‚’1å¢—ã‚„ã—ãŸ
+					for( ; i <= nLineLen; ++i ){		//	æœ€å¾Œã®æ–‡å­—+1ã¾ã§ã‚¹ã‚­ãƒ£ãƒ³
+						if( szLine[i] == LTEXT('\\') ){	// ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã®ã‚¹ã‚­ãƒƒãƒ—
 							++i;
 							continue;
 						}
-						if( szLine[i] == cQuote ){	//	n‚Ü‚è‚Æ“¯‚¶quotation‚ÅI—¹B
-							nEnd = i;	//	nEnd‚ÍI‚í‚è‚ÌŸ‚Ì•¶ši'j
+						if( szLine[i] == cQuote ){	//	å§‹ã¾ã‚Šã¨åŒã˜quotationã§çµ‚äº†ã€‚
+							nEnd = i;	//	nEndã¯çµ‚ã‚ã‚Šã®æ¬¡ã®æ–‡å­—ï¼ˆ'ï¼‰
 							break;
 						}
-						if( i == nLineLen ){	//	s––‚É—ˆ‚Ä‚µ‚Ü‚Á‚½
+						if( i == nLineLen ){	//	è¡Œæœ«ã«æ¥ã¦ã—ã¾ã£ãŸ
 							::MYMESSAGEBOX(
 								NULL,
 								MB_OK | MB_ICONSTOP | MB_TOPMOST,
@@ -291,7 +291,7 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 								cQuote
 							);
 							m_nReady = false;
-							nEnd = i - 1;	//	nEnd‚ÍI‚í‚è‚ÌŸ‚Ì•¶ši'j
+							nEnd = i - 1;	//	nEndã¯çµ‚ã‚ã‚Šã®æ¬¡ã®æ–‡å­—ï¼ˆ'ï¼‰
 							break;
 						}
 					}
@@ -302,17 +302,17 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 
 					CNativeW cmemWork;
 					cmemWork.SetString( strLine.c_str() + nBgn, nEnd - nBgn );
-					// 2014.01.28 u"\\'"v‚Ì‚æ‚¤‚Èê‡‚Ì•s‹ï‡‚ğC³
-					cmemWork.Replace( L"\\\\", L"\\\1" ); // ˆê’uŠ·(Å‰‚É•K—v)
+					// 2014.01.28 ã€Œ"\\'"ã€ã®ã‚ˆã†ãªå ´åˆã®ä¸å…·åˆã‚’ä¿®æ­£
+					cmemWork.Replace( L"\\\\", L"\\\1" ); // ä¸€æ™‚ç½®æ›(æœ€åˆã«å¿…è¦)
 					cmemWork.Replace( LTEXT("\\\'"), LTEXT("\'") );
 
-					//	Jun. 16, 2002 genta double quotation‚àƒGƒXƒP[ƒv‰ğœ
+					//	Jun. 16, 2002 genta double quotationã‚‚ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—è§£é™¤
 					cmemWork.Replace( LTEXT("\\\""), LTEXT("\"") );
 					cmemWork.Replace( L"\\r", L"\r" );
 					cmemWork.Replace( L"\\n", L"\n" );
 					cmemWork.Replace( L"\\t", L"\t" );
 					{
-						// \uXXXX ’uŠ·
+						// \uXXXX ç½®æ›
 						size_t nLen = cmemWork.GetStringLength();
 						size_t nBegin = 0;
 						const wchar_t* p = cmemWork.GetStringPtr();
@@ -345,12 +345,12 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 							cmemWork.swap( cmemTemp );
 						}
 					}
-					cmemWork.Replace( L"\\\1", L"\\" ); // ˆê’uŠ·‚ğ\‚É–ß‚·(ÅŒã‚Å‚È‚¢‚Æ‚¢‚¯‚È‚¢)
-					macro->AddStringParam( cmemWork.GetStringPtr(), cmemWork.GetStringLength() );	//	ˆø”‚ğ•¶š—ñ‚Æ‚µ‚Ä’Ç‰Á
+					cmemWork.Replace( L"\\\1", L"\\" ); // ä¸€æ™‚ç½®æ›ã‚’\ã«æˆ»ã™(æœ€å¾Œã§ãªã„ã¨ã„ã‘ãªã„)
+					macro->AddStringParam( cmemWork.GetStringPtr(), cmemWork.GetStringLength() );	//	å¼•æ•°ã‚’æ–‡å­—åˆ—ã¨ã—ã¦è¿½åŠ 
 				}
- 				else if ( Is09(szLine[i]) || szLine[i] == L'-' ){	//	”š‚Ån‚Ü‚Á‚½‚ç”š—ñ‚¾(-‹L†‚àŠÜ‚Ş)B
-					// Jun. 16, 2002 genta ƒvƒƒgƒ^ƒCƒvƒ`ƒFƒbƒN
-					// Jun. 27, 2002 genta —]•ª‚Èˆø”‚ğ–³‹‚·‚é‚æ‚¤CVT_EMPTY‚ğ‹–—e‚·‚éD
+ 				else if ( Is09(szLine[i]) || szLine[i] == L'-' ){	//	æ•°å­—ã§å§‹ã¾ã£ãŸã‚‰æ•°å­—åˆ—ã (-è¨˜å·ã‚‚å«ã‚€)ã€‚
+					// Jun. 16, 2002 genta ãƒ—ãƒ­ãƒˆã‚¿ã‚¤ãƒ—ãƒã‚§ãƒƒã‚¯
+					// Jun. 27, 2002 genta ä½™åˆ†ãªå¼•æ•°ã‚’ç„¡è¦–ã™ã‚‹ã‚ˆã†ï¼ŒVT_EMPTYã‚’è¨±å®¹ã™ã‚‹ï¼
 					if( type != VT_I4 &&
 						type != VT_EMPTY){
 						::MYMESSAGEBOX(
@@ -366,15 +366,15 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 						m_nReady = false;
 						break;
 					}
-					nBgn = nEnd = i;	//	nBgn‚Íˆø”‚Ìæ“ª‚Ì•¶š
-					//	s––‚ÌŒŸo‚Ì‚½‚ßCƒ‹[ƒv‰ñ”‚ğ1‘‚â‚µ‚½
-					for( i = nBgn + 1; i <= nLineLen; ++i ){		//	ÅŒã‚Ì•¶š+1‚Ü‚ÅƒXƒLƒƒƒ“
-						if( Is09(szLine[i]) ){	// ‚Ü‚¾”’l
+					nBgn = nEnd = i;	//	nBgnã¯å¼•æ•°ã®å…ˆé ­ã®æ–‡å­—
+					//	è¡Œæœ«ã®æ¤œå‡ºã®ãŸã‚ï¼Œãƒ«ãƒ¼ãƒ—å›æ•°ã‚’1å¢—ã‚„ã—ãŸ
+					for( i = nBgn + 1; i <= nLineLen; ++i ){		//	æœ€å¾Œã®æ–‡å­—+1ã¾ã§ã‚¹ã‚­ãƒ£ãƒ³
+						if( Is09(szLine[i]) ){	// ã¾ã æ•°å€¤
 //							++i;
 							continue;
 						}
 						else {
-							nEnd = i;	//	”š‚ÌÅŒã‚Ì•¶š
+							nEnd = i;	//	æ•°å­—ã®æœ€å¾Œã®æ–‡å­—
 							i--;
 							break;
 						}
@@ -383,18 +383,18 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 					CNativeW cmemWork;
 					cmemWork.SetString( strLine.c_str() + nBgn, nEnd - nBgn );
 					// Jun. 16, 2002 genta
-					//	”š‚Ì’†‚Équotation‚Í“ü‚Á‚Ä‚¢‚È‚¢‚æ
+					//	æ•°å­—ã®ä¸­ã«quotationã¯å…¥ã£ã¦ã„ãªã„ã‚ˆ
 					//cmemWork.Replace( L"\\\'", L"\'" );
 					//cmemWork.Replace( L"\\\\", L"\\" );
-					macro->AddIntParam( _wtoi(cmemWork.GetStringPtr()) );	//	ˆø”‚ğ”š‚Æ‚µ‚Ä’Ç‰Á
+					macro->AddIntParam( _wtoi(cmemWork.GetStringPtr()) );	//	å¼•æ•°ã‚’æ•°å­—ã¨ã—ã¦è¿½åŠ 
 				}
 				//	Jun. 16, 2002 genta
 				else if( szLine[i] == LTEXT(')') ){
-					//	ˆø”–³‚µ
+					//	å¼•æ•°ç„¡ã—
 					break;
 				}
 				else {
-					//	Parse Error:•¶–@ƒGƒ‰[‚Á‚Û‚¢B
+					//	Parse Error:æ–‡æ³•ã‚¨ãƒ©ãƒ¼ã£ã½ã„ã€‚
 					//	Jun. 16, 2002 genta
 					nBgn = nEnd = i;
 					::MYMESSAGEBOX( NULL, MB_OK | MB_ICONSTOP | MB_TOPMOST, MACRO_ERROR_TITLE,
@@ -403,8 +403,8 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 					break;
 				}
 
-				for( ; i < nLineLen; ++i ){		//	ÅŒã‚Ì•¶š‚Ü‚ÅƒXƒLƒƒƒ“
-					if( szLine[i] == LTEXT(')') || szLine[i] == LTEXT(',') ){	//	,‚à‚µ‚­‚Í)‚ğ“Ç‚İ”ò‚Î‚·
+				for( ; i < nLineLen; ++i ){		//	æœ€å¾Œã®æ–‡å­—ã¾ã§ã‚¹ã‚­ãƒ£ãƒ³
+					if( szLine[i] == LTEXT(')') || szLine[i] == LTEXT(',') ){	//	,ã‚‚ã—ãã¯)ã‚’èª­ã¿é£›ã°ã™
 						i++;
 						break;
 					}
@@ -415,11 +415,11 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 			}
 			//	Jun. 16, 2002 genta
 			if( !m_nReady ){
-				//	‚Ç‚±‚©‚ÅƒGƒ‰[‚ª‚ ‚Á‚½‚ç‚µ‚¢
+				//	ã©ã“ã‹ã§ã‚¨ãƒ©ãƒ¼ãŒã‚ã£ãŸã‚‰ã—ã„
 				delete macro;
 				break;
 			}
-			/* ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚Éƒf[ƒ^’Ç‰Á */
+			/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã«ãƒ‡ãƒ¼ã‚¿è¿½åŠ  */
 			Append( macro );
 		}
 		else {
@@ -433,27 +433,27 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 	in.Close();
 
 	//	Jun. 16, 2002 genta
-	//	ƒ}ƒNƒ’†‚ÉƒGƒ‰[‚ª‚ ‚Á‚½‚çˆÙíI—¹‚Å‚«‚é‚æ‚¤‚É‚·‚éD
+	//	ãƒã‚¯ãƒ­ä¸­ã«ã‚¨ãƒ©ãƒ¼ãŒã‚ã£ãŸã‚‰ç•°å¸¸çµ‚äº†ã§ãã‚‹ã‚ˆã†ã«ã™ã‚‹ï¼
 	return m_nReady ? TRUE : FALSE;
 }
 
-/*! ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ•¶š—ñ‚©‚ç“Ç‚İ‚İ */
+/*! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’æ–‡å­—åˆ—ã‹ã‚‰èª­ã¿è¾¼ã¿ */
 BOOL CKeyMacroMgr::LoadKeyMacroStr( HINSTANCE hInstance, const TCHAR* pszCode )
 {
-	// ˆêƒtƒ@ƒCƒ‹–¼‚ğì¬
+	// ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ä½œæˆ
 	TCHAR szTempDir[_MAX_PATH];
 	TCHAR szTempFile[_MAX_PATH];
 	if( 0 == ::GetTempPath( _MAX_PATH, szTempDir ) )return FALSE;
 	if( 0 == ::GetTempFileName( szTempDir, _T("mac"), 0, szTempFile ) )return FALSE;
-	// ˆêƒtƒ@ƒCƒ‹‚É‘‚«‚Ş
+	// ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ã«æ›¸ãè¾¼ã‚€
 	CTextOutputStream out = CTextOutputStream( szTempFile );
 	out.WriteString( to_wchar( pszCode ) );
 	out.Close();
 
-	// ƒ}ƒNƒ“Ç‚İ‚İ
+	// ãƒã‚¯ãƒ­èª­ã¿è¾¼ã¿
 	BOOL bRet = LoadKeyMacro( hInstance, szTempFile );
 
-	::DeleteFile( szTempFile );			// ˆêƒtƒ@ƒCƒ‹íœ
+	::DeleteFile( szTempFile );			// ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«å‰Šé™¤
 
 	return bRet;
 }
@@ -462,10 +462,10 @@ BOOL CKeyMacroMgr::LoadKeyMacroStr( HINSTANCE hInstance, const TCHAR* pszCode )
 /*!
 	Factory
 
-	@param ext [in] ƒIƒuƒWƒFƒNƒg¶¬‚Ì”»’è‚Ég‚¤Šg’£q(¬•¶š)
+	@param ext [in] ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆç”Ÿæˆã®åˆ¤å®šã«ä½¿ã†æ‹¡å¼µå­(å°æ–‡å­—)
 
-	@date 2004-01-31 genta RegisterExt‚Ì”p~‚Ì‚½‚ßRegisterCreator‚É’u‚«Š·‚¦
-		‚»‚Ì‚½‚ßC‰ß‚Á‚½ƒIƒuƒWƒFƒNƒg¶¬‚ğs‚í‚È‚¢‚½‚ß‚ÉŠg’£qƒ`ƒFƒbƒN‚Í•K{D
+	@date 2004-01-31 genta RegisterExtã®å»ƒæ­¢ã®ãŸã‚RegisterCreatorã«ç½®ãæ›ãˆ
+		ãã®ãŸã‚ï¼Œéã£ãŸã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆç”Ÿæˆã‚’è¡Œã‚ãªã„ãŸã‚ã«æ‹¡å¼µå­ãƒã‚§ãƒƒã‚¯ã¯å¿…é ˆï¼
 */
 CMacroManagerBase* CKeyMacroMgr::Creator(const TCHAR* ext)
 {
@@ -475,13 +475,13 @@ CMacroManagerBase* CKeyMacroMgr::Creator(const TCHAR* ext)
 	return NULL;
 }
 
-/*!	CKeyMacroManager‚Ì“o˜^
+/*!	CKeyMacroManagerã®ç™»éŒ²
 
-	@date 2004.01.31 genta RegisterExt‚Ì”p~‚Ì‚½‚ßRegisterCreator‚É’u‚«Š·‚¦
+	@date 2004.01.31 genta RegisterExtã®å»ƒæ­¢ã®ãŸã‚RegisterCreatorã«ç½®ãæ›ãˆ
 */
 void CKeyMacroMgr::declare (void)
 {
-	//	í‚ÉÀs
+	//	å¸¸ã«å®Ÿè¡Œ
 	CMacroFactory::getInstance()->RegisterCreator( Creator );
 }
 //	To Here Apr. 29, 2002 genta

--- a/sakura_core/macro/CKeyMacroMgr.h
+++ b/sakura_core/macro/CKeyMacroMgr.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒL[ƒ{[ƒhƒ}ƒNƒ
+ï»¿/*!	@file
+	@brief ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­
 
 	@author Norio Nakatani
 */
@@ -24,11 +24,11 @@ class CMacro;
 //#define MAX_STRLEN			70
 //#define MAX_KEYMACRONUM		10000
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
-//! ƒL[ƒ{[ƒhƒ}ƒNƒ
+//! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­
 /*!
-	ƒL[ƒ{[ƒhƒ}ƒNƒƒNƒ‰ƒX
+	ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚¯ãƒ©ã‚¹
 */
 class CKeyMacroMgr : public CMacroManagerBase
 {
@@ -42,24 +42,24 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	void ClearAll( void );				/* ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚ğƒNƒŠƒA‚·‚é */
-	void Append( EFunctionCode, const LPARAM*, class CEditView* pcEditView );		/* ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚Éƒf[ƒ^’Ç‰Á */
-	void Append( class CMacro* macro );		/* ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚Éƒf[ƒ^’Ç‰Á */
+	void ClearAll( void );				/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹ */
+	void Append( EFunctionCode, const LPARAM*, class CEditView* pcEditView );		/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã«ãƒ‡ãƒ¼ã‚¿è¿½åŠ  */
+	void Append( class CMacro* macro );		/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã«ãƒ‡ãƒ¼ã‚¿è¿½åŠ  */
 	
-	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ‚Ü‚Æ‚ß‚Äæ‚èˆµ‚¤ */
-	BOOL SaveKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath) const;	/* CMacro‚Ì—ñ‚ğAƒL[ƒ{[ƒhƒ}ƒNƒ‚É•Û‘¶ */
-	//@@@2002.2.2 YAZAKI PPA.DLLƒAƒŠ/ƒiƒV‹¤‘¶‚Ì‚½‚ßvirtual‚ÉB
-	//	2007.07.20 genta flags’Ç‰Á
-	virtual bool ExecKeyMacro( class CEditView* pcEditView, int flags ) const;	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ÌÀs */
-	virtual BOOL LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath);		/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğƒtƒ@ƒCƒ‹‚©‚ç“Ç‚İ‚Ş */
-	virtual BOOL LoadKeyMacroStr( HINSTANCE hInstance, const TCHAR* pszCode);	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ•¶š—ñ‚©‚ç“Ç‚İ‚Ş */
+	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’ã¾ã¨ã‚ã¦å–ã‚Šæ‰±ã† */
+	BOOL SaveKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath) const;	/* CMacroã®åˆ—ã‚’ã€ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã«ä¿å­˜ */
+	//@@@2002.2.2 YAZAKI PPA.DLLã‚¢ãƒª/ãƒŠã‚·å…±å­˜ã®ãŸã‚virtualã«ã€‚
+	//	2007.07.20 genta flagsè¿½åŠ 
+	virtual bool ExecKeyMacro( class CEditView* pcEditView, int flags ) const;	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®å®Ÿè¡Œ */
+	virtual BOOL LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath);		/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰èª­ã¿è¾¼ã‚€ */
+	virtual BOOL LoadKeyMacroStr( HINSTANCE hInstance, const TCHAR* pszCode);	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’æ–‡å­—åˆ—ã‹ã‚‰èª­ã¿è¾¼ã‚€ */
 	
 	// Apr. 29, 2002 genta
 	static CMacroManagerBase* Creator(const TCHAR* ext);
 	static void declare(void);
 
 protected:
-	CMacro*	m_pTop;	//	æ“ª‚ÆI’[‚ğ•Û
+	CMacro*	m_pTop;	//	å…ˆé ­ã¨çµ‚ç«¯ã‚’ä¿æŒ
 	CMacro*	m_pBot;
 };
 

--- a/sakura_core/macro/CMacro.h
+++ b/sakura_core/macro/CMacro.h
@@ -1,14 +1,14 @@
-/*!	@file
-	@brief ƒL[ƒ{[ƒhƒ}ƒNƒ
+ï»¿/*!	@file
+	@brief ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­
 
-	CMacro‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚Ğ‚Æ‚Â‚ªA1ƒRƒ}ƒ“ƒh‚É‚È‚éB
+	CMacroã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã²ã¨ã¤ãŒã€1ã‚³ãƒãƒ³ãƒ‰ã«ãªã‚‹ã€‚
 
 	@author Norio Nakatani
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI
-	Copyright (C) 2003, ‹S
+	Copyright (C) 2003, é¬¼
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages
@@ -35,7 +35,7 @@
 #define SAKURA_CMACRO_500D8D68_B51E_4B8B_9752_2B130EA3310B_H_
 
 #include <Windows.h>
-#include <ObjIdl.h>  // VARIANT“™
+#include <ObjIdl.h>  // VARIANTç­‰
 #include "func/Funccode.h"
 
 class CTextOutputStream;
@@ -77,20 +77,20 @@ struct CMacroParam{
 	void SetIntParam( const int nParam );
 };
 
-/*! @brief ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì1ƒRƒ}ƒ“ƒh
+/*! @brief ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®1ã‚³ãƒãƒ³ãƒ‰
 
-	ˆø”‚ğƒŠƒXƒg\‘¢‚É‚µ‚ÄA‚¢‚­‚Â‚Å‚à‚Ä‚é‚æ‚¤‚É‚µ‚Ä‚İ‚Ü‚µ‚½B
-	ƒXƒ^ƒbƒN‚É‚·‚é‚Ì‚ª’Ê—á‚È‚Ì‚©‚à‚µ‚ê‚Ü‚¹‚ñi‚æ‚­‚í‚©‚è‚Ü‚¹‚ñjB
+	å¼•æ•°ã‚’ãƒªã‚¹ãƒˆæ§‹é€ ã«ã—ã¦ã€ã„ãã¤ã§ã‚‚æŒã¦ã‚‹ã‚ˆã†ã«ã—ã¦ã¿ã¾ã—ãŸã€‚
+	ã‚¹ã‚¿ãƒƒã‚¯ã«ã™ã‚‹ã®ãŒé€šä¾‹ãªã®ã‹ã‚‚ã—ã‚Œã¾ã›ã‚“ï¼ˆã‚ˆãã‚ã‹ã‚Šã¾ã›ã‚“ï¼‰ã€‚
 	
-	¡ŒãA§Œä\‘¢‚ª“ü‚Á‚Ä‚à¢‚ç‚È‚¢‚æ‚¤‚É‚µ‚æ‚¤‚Æv‚Á‚½‚Ì‚Å‚·‚ªAÁÜ‚µ‚Ü‚µ‚½B
+	ä»Šå¾Œã€åˆ¶å¾¡æ§‹é€ ãŒå…¥ã£ã¦ã‚‚å›°ã‚‰ãªã„ã‚ˆã†ã«ã—ã‚ˆã†ã¨æ€ã£ãŸã®ã§ã™ãŒã€æŒ«æŠ˜ã—ã¾ã—ãŸã€‚
 	
-	‚³‚ÄA‚±‚ÌƒNƒ‰ƒX‚ÍŸ‚Ì‚æ‚¤‚È‘O’ñ‚Å“®ì‚µ‚Ä‚¢‚éB
+	ã•ã¦ã€ã“ã®ã‚¯ãƒ©ã‚¹ã¯æ¬¡ã®ã‚ˆã†ãªå‰æã§å‹•ä½œã—ã¦ã„ã‚‹ã€‚
 
-	@li ˆø”‚ÌƒŠƒXƒg‚ğAm_pParamTop‚©‚ç‚ÌƒŠƒXƒg\‘¢‚Å•ÛB
-	@li ˆø”‚ğV‚½‚É’Ç‰Á‚·‚é‚É‚ÍAAddParam()‚ğg—p‚·‚éB
-	  AddParam‚É‚Ç‚ñ‚È’l‚ª“n‚³‚ê‚Ä‚à‚æ‚¢‚æ‚¤‚É€”õ‚·‚éƒRƒgB
-	  “n‚³‚ê‚½’l‚ª”’l‚È‚Ì‚©A•¶š—ñ‚Ö‚Ìƒ|ƒCƒ“ƒ^‚È‚Ì‚©‚ÍAm_nFuncIDi‹@”\ IDj‚É‚æ‚Á‚ÄA‚±‚ÌƒNƒ‰ƒX“à‚Å”»•Ê‚µA‚æ‚ë‚µ‚­‚â‚é‚±‚ÆB
-	@li ˆø”‚ÍACMacro“à•”‚Å‚Í‚·‚×‚Ä•¶š—ñ‚Å•Û‚·‚é‚±‚Æi”’l97‚ÍA"97"‚Æ‚µ‚Ä•Ûji‚¢‚Ü‚Ì‚Æ‚±‚ëj
+	@li å¼•æ•°ã®ãƒªã‚¹ãƒˆã‚’ã€m_pParamTopã‹ã‚‰ã®ãƒªã‚¹ãƒˆæ§‹é€ ã§ä¿æŒã€‚
+	@li å¼•æ•°ã‚’æ–°ãŸã«è¿½åŠ ã™ã‚‹ã«ã¯ã€AddParam()ã‚’ä½¿ç”¨ã™ã‚‹ã€‚
+	  AddParamã«ã©ã‚“ãªå€¤ãŒæ¸¡ã•ã‚Œã¦ã‚‚ã‚ˆã„ã‚ˆã†ã«æº–å‚™ã™ã‚‹ã‚³ãƒˆã€‚
+	  æ¸¡ã•ã‚ŒãŸå€¤ãŒæ•°å€¤ãªã®ã‹ã€æ–‡å­—åˆ—ã¸ã®ãƒã‚¤ãƒ³ã‚¿ãªã®ã‹ã¯ã€m_nFuncIDï¼ˆæ©Ÿèƒ½ IDï¼‰ã«ã‚ˆã£ã¦ã€ã“ã®ã‚¯ãƒ©ã‚¹å†…ã§åˆ¤åˆ¥ã—ã€ã‚ˆã‚ã—ãã‚„ã‚‹ã“ã¨ã€‚
+	@li å¼•æ•°ã¯ã€CMacroå†…éƒ¨ã§ã¯ã™ã¹ã¦æ–‡å­—åˆ—ã§ä¿æŒã™ã‚‹ã“ã¨ï¼ˆæ•°å€¤97ã¯ã€"97"ã¨ã—ã¦ä¿æŒï¼‰ï¼ˆã„ã¾ã®ã¨ã“ã‚ï¼‰
 */
 class CMacro
 {
@@ -98,17 +98,17 @@ public:
 	/*
 	||  Constructors
 	*/
-	CMacro( EFunctionCode nFuncID );	//	‹@”\ID‚ğw’è‚µ‚Ä‰Šú‰»
+	CMacro( EFunctionCode nFuncID );	//	æ©Ÿèƒ½IDã‚’æŒ‡å®šã—ã¦åˆæœŸåŒ–
 	~CMacro();
 	void ClearMacroParam();
 
 	void SetNext(CMacro* pNext){ m_pNext = pNext; }
 	CMacro* GetNext(){ return m_pNext; }
-	// 2007.07.20 genta : flags’Ç‰Á
-	bool Exec( CEditView* pcEditView, int flags ) const; //2007.09.30 kobake const’Ç‰Á
-	void Save( HINSTANCE hInstance, CTextOutputStream& out ) const; //2007.09.30 kobake const’Ç‰Á
+	// 2007.07.20 genta : flagsè¿½åŠ 
+	bool Exec( CEditView* pcEditView, int flags ) const; //2007.09.30 kobake constè¿½åŠ 
+	void Save( HINSTANCE hInstance, CTextOutputStream& out ) const; //2007.09.30 kobake constè¿½åŠ 
 	
-	void AddLParam( const LPARAM* lParam, const CEditView* pcEditView  );	//@@@ 2002.2.2 YAZAKI pcEditView‚à“n‚·
+	void AddLParam( const LPARAM* lParam, const CEditView* pcEditView  );	//@@@ 2002.2.2 YAZAKI pcEditViewã‚‚æ¸¡ã™
 	void AddStringParam( const WCHAR* szParam, int nLength = -1 );
 	void AddStringParam( const ACHAR* lParam ){ return AddStringParam(to_wchar(lParam)); }
 	void AddIntParam( const int nParam );
@@ -116,26 +116,26 @@ public:
 
 	static bool HandleCommand( CEditView *View, EFunctionCode ID, const WCHAR* Argument[], const int ArgLengths[], const int ArgSize );
 	static bool HandleFunction( CEditView *View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result);
-	//2009.10.29 syat HandleCommand‚ÆHandleFunction‚Ìˆø”‚ğ­‚µ‚»‚ë‚¦‚½
+	//2009.10.29 syat HandleCommandã¨HandleFunctionã®å¼•æ•°ã‚’å°‘ã—ãã‚ãˆãŸ
 #if 0
 	/*
 	||  Attributes & Operations
 	*/
-	static char* GetFuncInfoByID( HINSTANCE , int , char* , char* );	/* ‹@”\ID¨ŠÖ”–¼C‹@”\–¼“ú–{Œê */
-	static int GetFuncInfoByName( HINSTANCE , const char* , char* );	/* ŠÖ”–¼¨‹@”\IDC‹@”\–¼“ú–{Œê */
-	static BOOL CanFuncIsKeyMacro( int );	/* ƒL[ƒ}ƒNƒ‚É‹L˜^‰Â”\‚È‹@”\‚©‚Ç‚¤‚©‚ğ’²‚×‚é */
+	static char* GetFuncInfoByID( HINSTANCE , int , char* , char* );	/* æ©Ÿèƒ½IDâ†’é–¢æ•°åï¼Œæ©Ÿèƒ½åæ—¥æœ¬èª */
+	static int GetFuncInfoByName( HINSTANCE , const char* , char* );	/* é–¢æ•°åâ†’æ©Ÿèƒ½IDï¼Œæ©Ÿèƒ½åæ—¥æœ¬èª */
+	static BOOL CanFuncIsKeyMacro( int );	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã«è¨˜éŒ²å¯èƒ½ãªæ©Ÿèƒ½ã‹ã©ã†ã‹ã‚’èª¿ã¹ã‚‹ */
 #endif
 
 protected:
 	static WCHAR* GetParamAt(CMacroParam*, int);
 
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
-	EFunctionCode	m_nFuncID;		//	‹@”\ID
-	CMacroParam*	m_pParamTop;	//	ƒpƒ‰ƒ[ƒ^
+	EFunctionCode	m_nFuncID;		//	æ©Ÿèƒ½ID
+	CMacroParam*	m_pParamTop;	//	ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿
 	CMacroParam*	m_pParamBot;
-	CMacro*			m_pNext;		//	Ÿ‚Ìƒ}ƒNƒ‚Ö‚Ìƒ|ƒCƒ“ƒ^
+	CMacro*			m_pNext;		//	æ¬¡ã®ãƒã‚¯ãƒ­ã¸ã®ãƒã‚¤ãƒ³ã‚¿
 };
 
 

--- a/sakura_core/macro/CMacroFactory.cpp
+++ b/sakura_core/macro/CMacroFactory.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒ}ƒNƒí•ÊŠÇ—
+ï»¿/*!	@file
+	@brief ãƒã‚¯ãƒ­ç¨®åˆ¥ç®¡ç†
 
 	@author genta
 	@date 2002.4.29
@@ -39,13 +39,13 @@ CMacroFactory::CMacroFactory()
 {}
 
 /*!
-	—^‚¦‚ç‚ê‚½Šg’£q‚ğmap‚Ìkey‚É•ÏŠ·‚·‚é
+	ä¸ãˆã‚‰ã‚ŒãŸæ‹¡å¼µå­ã‚’mapã®keyã«å¤‰æ›ã™ã‚‹
 	
-	@param ext [in] Šg’£q
+	@param ext [in] æ‹¡å¼µå­
 	
 	@par Rule
-	@li NULL‚Í""‚É‚·‚éB
-	@li ƒAƒ‹ƒtƒ@ƒxƒbƒg‚Í¬•¶š‚É“ˆê
+	@li NULLã¯""ã«ã™ã‚‹ã€‚
+	@li ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆã¯å°æ–‡å­—ã«çµ±ä¸€
 */
 std::tstring CMacroFactory::Ext2Key(const TCHAR *ext)
 {
@@ -60,16 +60,16 @@ std::tstring CMacroFactory::Ext2Key(const TCHAR *ext)
 }
 
 /*!
-	Creator‚Ì“o˜^
+	Creatorã®ç™»éŒ²
 	
-	Šg’£q‚Ì‘Î‰‚ğ‰Šú‚É“o˜^‚µ‚È‚¢Creator‚ğ“o˜^‚·‚éD
-	‚½‚¾‚µCˆê’U‘Î‰‚ª‚í‚©‚Á‚½‚çŸ‰ñˆÈ~‚Í‘Î‰•\‚ªg‚í‚ê‚éD
+	æ‹¡å¼µå­ã®å¯¾å¿œã‚’åˆæœŸã«ç™»éŒ²ã—ãªã„Creatorã‚’ç™»éŒ²ã™ã‚‹ï¼
+	ãŸã ã—ï¼Œä¸€æ—¦å¯¾å¿œãŒã‚ã‹ã£ãŸã‚‰æ¬¡å›ä»¥é™ã¯å¯¾å¿œè¡¨ãŒä½¿ã‚ã‚Œã‚‹ï¼
 	
-	@param f [in] “o˜^‚·‚éFactoryŠÖ”
+	@param f [in] ç™»éŒ²ã™ã‚‹Factoryé–¢æ•°
 	
 	@sa CMacroFactory::RegisterExts
 
-	@date 2002.08.25 genta ’Ç‰Á
+	@date 2002.08.25 genta è¿½åŠ 
 */
 bool CMacroFactory::RegisterCreator( Creator f )
 {
@@ -82,24 +82,24 @@ bool CMacroFactory::RegisterCreator( Creator f )
 }
 
 /*!
-	Creator‚Ì“o˜^‰ğœ
+	Creatorã®ç™»éŒ²è§£é™¤
 	
-	@param f [in] “o˜^‰ğœ‚·‚éCreator
+	@param f [in] ç™»éŒ²è§£é™¤ã™ã‚‹Creator
 */
 bool CMacroFactory::Unregister( Creator f )
 {
-	//	Creator List‚©‚ç‚Ìíœ
+	//	Creator Listã‹ã‚‰ã®å‰Šé™¤
 	MacroEngineRep::iterator c_it = m_mMacroCreators.begin();
 	while( c_it != m_mMacroCreators.end() ){
 		if( *c_it == f ){
 			MacroEngineRep::iterator tmp_it;
 
-			//	‚¢‚«‚È‚èíœ‚·‚é‚Æiterator‚ª–³Œø‚É‚È‚é‚Ì‚ÅC
-			//	iterator‚ğ1‚Âi‚ß‚Ä‚©‚çŒ»İˆÊ’u‚ğíœ‚·‚éD
+			//	ã„ããªã‚Šå‰Šé™¤ã™ã‚‹ã¨iteratorãŒç„¡åŠ¹ã«ãªã‚‹ã®ã§ï¼Œ
+			//	iteratorã‚’1ã¤é€²ã‚ã¦ã‹ã‚‰ç¾åœ¨ä½ç½®ã‚’å‰Šé™¤ã™ã‚‹ï¼
 			tmp_it = c_it++;
 			m_mMacroCreators.erase( tmp_it );
-			//	d•¡“o˜^‚³‚ê‚Ä‚¢‚éê‡‚ğl—¶‚µ‚ÄC
-			//	1‚ÂŒ©‚Â‚©‚Á‚Ä‚àÅŒã‚Ü‚Åƒ`ƒFƒbƒN‚·‚é
+			//	é‡è¤‡ç™»éŒ²ã•ã‚Œã¦ã„ã‚‹å ´åˆã‚’è€ƒæ…®ã—ã¦ï¼Œ
+			//	1ã¤è¦‹ã¤ã‹ã£ã¦ã‚‚æœ€å¾Œã¾ã§ãƒã‚§ãƒƒã‚¯ã™ã‚‹
 		}
 		else {
 			++ c_it;
@@ -112,17 +112,17 @@ bool CMacroFactory::Unregister( Creator f )
 /*
 	Object Factory
 	
-	“o˜^‚³‚ê‚½Factory Object‚ğ‡‚ÉŒÄ‚Ño‚µ‚ÄA
-	Object‚ª“¾‚ç‚ê‚½‚ç‚»‚ê‚ğ•Ô‚·B
+	ç™»éŒ²ã•ã‚ŒãŸFactory Objectã‚’é †ã«å‘¼ã³å‡ºã—ã¦ã€
+	ObjectãŒå¾—ã‚‰ã‚ŒãŸã‚‰ãã‚Œã‚’è¿”ã™ã€‚
 
-	@pararm ext [in] Šg’£q
-	@return MacroƒIƒuƒWƒFƒNƒgB“KØ‚È‚à‚Ì‚ªŒ©‚Â‚©‚ç‚È‚¯‚ê‚ÎNULLB
+	@pararm ext [in] æ‹¡å¼µå­
+	@return Macroã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã€‚é©åˆ‡ãªã‚‚ã®ãŒè¦‹ã¤ã‹ã‚‰ãªã‘ã‚Œã°NULLã€‚
 */
 CMacroManagerBase* CMacroFactory::Create(const TCHAR* ext)
 {
 	std::tstring key = Ext2Key( ext );
 
-	//	Creator‚ğ‡‚É‚·
+	//	Creatorã‚’é †ã«è©¦ã™
 	for( MacroEngineRep::iterator c_it = m_mMacroCreators.begin();
 		c_it != m_mMacroCreators.end(); ++ c_it ){
 		CMacroManagerBase* pobj = (*c_it)(key.c_str());

--- a/sakura_core/macro/CMacroFactory.h
+++ b/sakura_core/macro/CMacroFactory.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒ}ƒNƒí•ÊŠÇ—
+ï»¿/*!	@file
+	@brief ãƒã‚¯ãƒ­ç¨®åˆ¥ç®¡ç†
 
 	@author genta
 	@date 2002.4.29
@@ -40,16 +40,16 @@
 class CMacroManagerBase;
 
 /*!
-	@brief ƒ}ƒNƒHandler¶¬ƒNƒ‰ƒX
+	@brief ãƒã‚¯ãƒ­Handlerç”Ÿæˆã‚¯ãƒ©ã‚¹
 	
-	@par ‰Šú‰»
-	CMacroManagerBase::declare() ‚É‚æ‚èCMacroEngine‚ÌCreater‚Ì“o˜^
-	RegisterEngine() ‹y‚Ñ ‘Î‰Šg’£q‚Ì“o˜^ RegisterExt() ‚ªŒÄ‚Ño‚³‚ê‚éD
+	@par åˆæœŸåŒ–
+	CMacroManagerBase::declare() ã«ã‚ˆã‚Šï¼ŒMacroEngineã®Createrã®ç™»éŒ²
+	RegisterEngine() åŠã³ å¯¾å¿œæ‹¡å¼µå­ã®ç™»éŒ² RegisterExt() ãŒå‘¼ã³å‡ºã•ã‚Œã‚‹ï¼
 	
-	@par ŒÄ‚Ño‚µ
-	CMacroFactory::Create()‚ğŠg’£q‚ğˆø”‚É‚µ‚ÄŒÄ‚Ño‚·‚Æ‘Î‰‚·‚é
-	ƒ}ƒNƒƒGƒ“ƒWƒ“‚ª•Ô‚³‚ê‚éD“¾‚ç‚ê‚½Engine‚É‘Î‚µ‚ÄLoadKeyMacro()‹y‚Ñ
-	ExecKeyMacro() ‚ğŒÄ‚Ño‚·‚±‚Æ‚Åƒ}ƒNƒ‚Ì“Ç‚İ‚İEÀs‚ªs‚í‚ê‚éD
+	@par å‘¼ã³å‡ºã—
+	CMacroFactory::Create()ã‚’æ‹¡å¼µå­ã‚’å¼•æ•°ã«ã—ã¦å‘¼ã³å‡ºã™ã¨å¯¾å¿œã™ã‚‹
+	ãƒã‚¯ãƒ­ã‚¨ãƒ³ã‚¸ãƒ³ãŒè¿”ã•ã‚Œã‚‹ï¼å¾—ã‚‰ã‚ŒãŸEngineã«å¯¾ã—ã¦LoadKeyMacro()åŠã³
+	ExecKeyMacro() ã‚’å‘¼ã³å‡ºã™ã“ã¨ã§ãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ãƒ»å®Ÿè¡ŒãŒè¡Œã‚ã‚Œã‚‹ï¼
 
 	Singleton
 */
@@ -62,7 +62,7 @@ public:
 
 	bool RegisterCreator( Creator );
 	// Jan. 31, 2004 genta
-	// ƒoƒCƒiƒŠƒTƒCƒYíŒ¸‚Ì‚½‚ßm_mMacroExts‚ğíœ
+	// ãƒã‚¤ãƒŠãƒªã‚µã‚¤ã‚ºå‰Šæ¸›ã®ãŸã‚m_mMacroExtsã‚’å‰Šé™¤
 	//bool RegisterExt( const char*, Creator );
 	bool Unregister( Creator );
 
@@ -72,16 +72,16 @@ private:
 	std::tstring Ext2Key(const TCHAR *ext);
 
 	// Jan. 31, 2004 genta
-	// ƒoƒCƒiƒŠƒTƒCƒYíŒ¸‚Ì‚½‚ßŠg’£q•Û—pmap‚ğíœ
+	// ãƒã‚¤ãƒŠãƒªã‚µã‚¤ã‚ºå‰Šæ¸›ã®ãŸã‚æ‹¡å¼µå­ä¿æŒç”¨mapã‚’å‰Šé™¤
 	//	typedef std::map<std::string, Creator> MacroTypeRep;
 	typedef std::list<Creator> MacroEngineRep;
 
 	// Jan. 31, 2004 genta
-	// ƒoƒCƒiƒŠƒTƒCƒYíŒ¸‚Ì‚½‚ß
-	//MacroTypeRep m_mMacroExts;	/*!< Šg’£q‘Î‰•\ */
+	// ãƒã‚¤ãƒŠãƒªã‚µã‚¤ã‚ºå‰Šæ¸›ã®ãŸã‚
+	//MacroTypeRep m_mMacroExts;	/*!< æ‹¡å¼µå­å¯¾å¿œè¡¨ */
 	/*!
-		CreatorƒŠƒXƒg
-		@date 2002.08.25 genta ’Ç‰Á
+		Creatorãƒªã‚¹ãƒˆ
+		@date 2002.08.25 genta è¿½åŠ 
 	*/
 	MacroEngineRep m_mMacroCreators;
 

--- a/sakura_core/macro/CMacroManagerBase.cpp
+++ b/sakura_core/macro/CMacroManagerBase.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒ}ƒNƒƒGƒ“ƒWƒ“
+ï»¿/*!	@file
+	@brief ãƒã‚¯ãƒ­ã‚¨ãƒ³ã‚¸ãƒ³
 
 	@author genta
 	@date 2002.4.29
@@ -59,7 +59,7 @@ void CMacroBeforeAfter::ExecKeyMacroAfter( class CEditView* pcEditView, int flag
 	}else{
 		COpeBlk* opeBlk = pcEditView->m_cCommander.GetOpeBlk();
 		if( opeBlk ){
-			opeBlk->SetRefCount(1); // ‹­§“I‚ÉƒŠƒZƒbƒg‚·‚é‚½‚ß1‚ğw’è
+			opeBlk->SetRefCount(1); // å¼·åˆ¶çš„ã«ãƒªã‚»ãƒƒãƒˆã™ã‚‹ãŸã‚1ã‚’æŒ‡å®š
 			pcEditView->SetUndoBuffer();
 		}
 	}
@@ -67,7 +67,7 @@ void CMacroBeforeAfter::ExecKeyMacroAfter( class CEditView* pcEditView, int flag
 }
 
 // CMacroManagerBase
-//	ƒfƒtƒHƒ‹ƒg‚ÌƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+//	ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 
 CMacroManagerBase::CMacroManagerBase()
  : m_nReady( false )

--- a/sakura_core/macro/CMacroManagerBase.h
+++ b/sakura_core/macro/CMacroManagerBase.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒ}ƒNƒƒGƒ“ƒWƒ“
+ï»¿/*!	@file
+	@brief ãƒã‚¯ãƒ­ã‚¨ãƒ³ã‚¸ãƒ³
 
 	@author genta
 	@date 2002.4.29
@@ -46,53 +46,53 @@ private:
 };
 
 /*!
-	@brief ƒ}ƒNƒ‚ğˆ—‚·‚éƒGƒ“ƒWƒ“•”•ª‚ÌŠî’êƒNƒ‰ƒX
+	@brief ãƒã‚¯ãƒ­ã‚’å‡¦ç†ã™ã‚‹ã‚¨ãƒ³ã‚¸ãƒ³éƒ¨åˆ†ã®åŸºåº•ã‚¯ãƒ©ã‚¹
 
 */
 class CMacroManagerBase : CMacroBeforeAfter {
 public:
 
-	/*! ƒL[ƒ{[ƒhƒ}ƒNƒ‚ÌÀs
+	/*! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®å®Ÿè¡Œ
 	
-		@param[in] pcEditView ƒ}ƒNƒÀs‘ÎÛ‚Ì•ÒWƒEƒBƒ“ƒhƒE
-		@param[in] flags ƒ}ƒNƒÀs‘®«D
+		@param[in] pcEditView ãƒã‚¯ãƒ­å®Ÿè¡Œå¯¾è±¡ã®ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+		@param[in] flags ãƒã‚¯ãƒ­å®Ÿè¡Œå±æ€§ï¼
 		
-		@date 2007.07.20 genta ƒ}ƒNƒÀs‘®«‚ğ“n‚·‚½‚ß‚Éflags‚ğ’Ç‰Á
+		@date 2007.07.20 genta ãƒã‚¯ãƒ­å®Ÿè¡Œå±æ€§ã‚’æ¸¡ã™ãŸã‚ã«flagsã‚’è¿½åŠ 
 	*/
 	virtual bool ExecKeyMacro( class CEditView* pcEditView, int flags ) const = 0;
 	virtual void ExecKeyMacro2( class CEditView* pcEditView, int flags );
 	
-	/*! ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğƒtƒ@ƒCƒ‹‚©‚ç“Ç‚İ‚Ş
+	/*! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰èª­ã¿è¾¼ã‚€
 
 		@param hInstance [in]
-		@param pszPath [in] ƒtƒ@ƒCƒ‹–¼
+		@param pszPath [in] ãƒ•ã‚¡ã‚¤ãƒ«å
 	*/
 	virtual BOOL LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath) = 0;
 
-	/*! ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ•¶š—ñ‚©‚ç“Ç‚İ‚Ş
+	/*! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’æ–‡å­—åˆ—ã‹ã‚‰èª­ã¿è¾¼ã‚€
 
 		@param hInstance [in]
-		@param pszCode [in] ƒ}ƒNƒƒR[ƒh
+		@param pszCode [in] ãƒã‚¯ãƒ­ã‚³ãƒ¼ãƒ‰
 	*/
 	virtual BOOL LoadKeyMacroStr( HINSTANCE hInstance, const TCHAR* pszCode ) = 0;
 
 	//static CMacroManagerBase* Creator( const char* str );
-	//ƒˆ‰¼‘zƒNƒ‰ƒX‚ÍÀ‘Ì‰»‚Å‚«‚È‚¢‚Ì‚ÅFactory‚Í•s—vB
-	//Œp³æƒNƒ‰ƒX‚Å‚Í•K—vB
+	//ç´”ç²‹ä»®æƒ³ã‚¯ãƒ©ã‚¹ã¯å®Ÿä½“åŒ–ã§ããªã„ã®ã§Factoryã¯ä¸è¦ã€‚
+	//ç¶™æ‰¿å…ˆã‚¯ãƒ©ã‚¹ã§ã¯å¿…è¦ã€‚
 	
-	//	ƒfƒXƒgƒ‰ƒNƒ^‚Ìvirtual‚ğ–Y‚ê‚¸‚É
+	//	ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã®virtualã‚’å¿˜ã‚Œãšã«
 	virtual ~CMacroManagerBase();
 	
 
 protected:
-	//!	LoadÏ‚İ‚©‚Ç‚¤‚©‚ğ•\‚·ƒtƒ‰ƒO true...LoadÏ‚İAfalse...–¢LoadB
+	//!	Loadæ¸ˆã¿ã‹ã©ã†ã‹ã‚’è¡¨ã™ãƒ•ãƒ©ã‚° true...Loadæ¸ˆã¿ã€false...æœªLoadã€‚
 	bool m_nReady;
 
 public:
-	/*!	LoadÏ‚İ‚©‚Ç‚¤‚©
+	/*!	Loadæ¸ˆã¿ã‹ã©ã†ã‹
 
-		@retval true LoadÏ‚İ
-		@retval false –¢Load
+		@retval true Loadæ¸ˆã¿
+		@retval false æœªLoad
 	*/
 	bool IsReady(){ return m_nReady; }
 

--- a/sakura_core/macro/CPPA.cpp
+++ b/sakura_core/macro/CPPA.cpp
@@ -1,10 +1,10 @@
-/*!	@file
+ï»¿/*!	@file
 	@brief PPA Library Handler
 
-	PPA.DLL‚ğ—˜—p‚·‚é‚½‚ß‚ÌƒCƒ“ƒ^[ƒtƒF[ƒX
+	PPA.DLLã‚’åˆ©ç”¨ã™ã‚‹ãŸã‚ã®ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 
 	@author YAZAKI
-	@date 2002”N1Œ26“ú
+	@date 2002å¹´1æœˆ26æ—¥
 */
 /*
 	Copyright (C) 2001, YAZAKI
@@ -61,10 +61,10 @@ CPPA::~CPPA()
 {
 }
 
-//	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+//	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 bool CPPA::Execute(CEditView* pcEditView, int flags )
 {
-	//PPA‚Ì‘½d‹N“®‹Ö~ 2008.10.22 syat
+	//PPAã®å¤šé‡èµ·å‹•ç¦æ­¢ 2008.10.22 syat
 	if ( CPPA::m_bIsRunning ) {
 		MYMESSAGEBOX( pcEditView->GetHwnd(), MB_OK, LS(STR_ERR_DLGPPA7), LS(STR_ERR_DLGPPA1) );
 		m_fnAbort();
@@ -80,15 +80,15 @@ bool CPPA::Execute(CEditView* pcEditView, int flags )
 	info.m_cMemDebug.SetString("");	//	2003.06.01 Moca
 	info.m_commandflags = flags | FA_FROMMACRO;	//	2007.07.22 genta
 	
-	//	Às‘O‚ÉƒCƒ“ƒXƒ^ƒ“ƒX‚ğ‘Ò”ğ‚·‚é
+	//	å®Ÿè¡Œå‰ã«ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã‚’å¾…é¿ã™ã‚‹
 	PpaExecInfo* old_instance = m_CurInstance;
 	m_CurInstance = &info;
 	m_fnExecute();
 	
-	//	ƒ}ƒNƒÀsŠ®—¹Œã‚Í‚±‚±‚É–ß‚Á‚Ä‚­‚é
+	//	ãƒã‚¯ãƒ­å®Ÿè¡Œå®Œäº†å¾Œã¯ã“ã“ã«æˆ»ã£ã¦ãã‚‹
 	m_CurInstance = old_instance;
 
-	//PPA‚Ì‘½d‹N“®‹Ö~ 2008.10.22 syat
+	//PPAã®å¤šé‡èµ·å‹•ç¦æ­¢ 2008.10.22 syat
 	CPPA::m_bIsRunning = false;
 	return !info.m_bError;
 }
@@ -99,20 +99,20 @@ LPCTSTR CPPA::GetDllNameImp(int nIndex)
 }
 
 /*!
-	DLL‚Ì‰Šú‰»
+	DLLã®åˆæœŸåŒ–
 
-	ŠÖ”‚ÌƒAƒhƒŒƒX‚ğæ“¾‚µ‚Äƒƒ“ƒo‚É•ÛŠÇ‚·‚éD
+	é–¢æ•°ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‚’å–å¾—ã—ã¦ãƒ¡ãƒ³ãƒã«ä¿ç®¡ã™ã‚‹ï¼
 
-	@retval true ¬Œ÷
-	@retval false ƒAƒhƒŒƒXæ“¾‚É¸”s
+	@retval true æˆåŠŸ
+	@retval false ã‚¢ãƒ‰ãƒ¬ã‚¹å–å¾—ã«å¤±æ•—
 */
 bool CPPA::InitDllImp()
 {
-	/* PPA.DLL‚ª‚Á‚Ä‚¢‚éŠÖ”‚ğ€”õ */
+	/* PPA.DLLãŒæŒã£ã¦ã„ã‚‹é–¢æ•°ã‚’æº–å‚™ */
 
-	//	Apr. 15, 2002 genta const‚ğ•t‚¯‚½
-	//	ƒAƒhƒŒƒX‚Ì“ü‚êêŠ‚ÍƒIƒuƒWƒFƒNƒg‚ÉˆË‘¶‚·‚é‚Ì‚Å
-	//	static”z—ñ‚É‚Í‚Å‚«‚È‚¢B
+	//	Apr. 15, 2002 genta constã‚’ä»˜ã‘ãŸ
+	//	ã‚¢ãƒ‰ãƒ¬ã‚¹ã®å…¥ã‚Œå ´æ‰€ã¯ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã«ä¾å­˜ã™ã‚‹ã®ã§
+	//	staticé…åˆ—ã«ã¯ã§ããªã„ã€‚
 	const ImportTable table[] = 
 	{
 		{ &m_fnExecute,		"Execute" },
@@ -161,7 +161,7 @@ bool CPPA::InitDllImp()
 	};
 
 	//	Apr. 15, 2002 genta
-	//	CDllImp‚Ì‹¤’ÊŠÖ”‰»‚µ‚½
+	//	CDllImpã®å…±é€šé–¢æ•°åŒ–ã—ãŸ
 	if( ! RegisterEntries(table) )
 		return false;
 
@@ -169,57 +169,57 @@ bool CPPA::InitDllImp()
 	SetStrFunc((void *)CPPA::stdStrFunc);
 	SetProc((void *)CPPA::stdProc);
 
-	// 2003.06.01 Moca ƒGƒ‰[ƒƒbƒZ[ƒW‚ğ’Ç‰Á
+	// 2003.06.01 Moca ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¿½åŠ 
 	SetErrProc((void *)CPPA::stdError);
-	SetStrObj((void *)CPPA::stdStrObj);	// UserErrorMes—p
+	SetStrObj((void *)CPPA::stdStrObj);	// UserErrorMesç”¨
 #if PPADLL_VER >= 123
 	SetFinishProc((void *)CPPA::stdFinishProc);
 #endif
 
-	SetDefine( "sakura-editor" );	// 2003.06.01 Moca SAKURAƒGƒfƒBƒ^—p“Æ©ŠÖ”‚ğ€”õ
-	AddStrObj( "UserErrorMes", "", FALSE, 2 ); // 2003.06.01 ƒfƒoƒbƒO—p•¶š—ñ•Ï”‚ğ—pˆÓ
+	SetDefine( "sakura-editor" );	// 2003.06.01 Moca SAKURAã‚¨ãƒ‡ã‚£ã‚¿ç”¨ç‹¬è‡ªé–¢æ•°ã‚’æº–å‚™
+	AddStrObj( "UserErrorMes", "", FALSE, 2 ); // 2003.06.01 ãƒ‡ãƒãƒƒã‚°ç”¨æ–‡å­—åˆ—å¤‰æ•°ã‚’ç”¨æ„
 
 	int i;
 	
-	//	Jun. 16, 2003 genta ˆêì‹ÆƒGƒŠƒA
+	//	Jun. 16, 2003 genta ä¸€æ™‚ä½œæ¥­ã‚¨ãƒªã‚¢
 	char buf[1024];
-	// ƒRƒ}ƒ“ƒh‚É’u‚«Š·‚¦‚ç‚ê‚È‚¢ŠÖ”  PPA–³‚µ‚Å‚Íg‚¦‚È‚¢BBB
+	// ã‚³ãƒãƒ³ãƒ‰ã«ç½®ãæ›ãˆã‚‰ã‚Œãªã„é–¢æ•° ï¼ PPAç„¡ã—ã§ã¯ä½¿ãˆãªã„ã€‚ã€‚ã€‚
 	for (i=0; CSMacroMgr::m_MacroFuncInfoArr[i].m_pszFuncName != NULL; i++) {
-		//	2003.06.08 Moca ƒƒ‚ƒŠ[ƒŠ[ƒN‚ÌC³
-		//	2003.06.16 genta ƒoƒbƒtƒ@‚ğŠO‚©‚ç—^‚¦‚é‚æ‚¤‚É
-		//	ŠÖ”“o˜^—p•¶š—ñ‚ğì¬‚·‚é
+		//	2003.06.08 Moca ãƒ¡ãƒ¢ãƒªãƒ¼ãƒªãƒ¼ã‚¯ã®ä¿®æ­£
+		//	2003.06.16 genta ãƒãƒƒãƒ•ã‚¡ã‚’å¤–ã‹ã‚‰ä¸ãˆã‚‹ã‚ˆã†ã«
+		//	é–¢æ•°ç™»éŒ²ç”¨æ–‡å­—åˆ—ã‚’ä½œæˆã™ã‚‹
 		GetDeclarations( CSMacroMgr::m_MacroFuncInfoArr[i], buf );
 		SetDefProc( buf );
 	}
 
-	// ƒRƒ}ƒ“ƒh‚É’u‚«Š·‚¦‚ç‚ê‚éŠÖ”  PPA–³‚µ‚Å‚àg‚¦‚éB
+	// ã‚³ãƒãƒ³ãƒ‰ã«ç½®ãæ›ãˆã‚‰ã‚Œã‚‹é–¢æ•° ï¼ PPAç„¡ã—ã§ã‚‚ä½¿ãˆã‚‹ã€‚
 	for (i=0; CSMacroMgr::m_MacroFuncInfoCommandArr[i].m_pszFuncName != NULL; i++) {
-		//	2003.06.08 Moca ƒƒ‚ƒŠ[ƒŠ[ƒN‚ÌC³
-		//	2003.06.16 genta ƒoƒbƒtƒ@‚ğŠO‚©‚ç—^‚¦‚é‚æ‚¤‚É
-		//	ŠÖ”“o˜^—p•¶š—ñ‚ğì¬‚·‚é
+		//	2003.06.08 Moca ãƒ¡ãƒ¢ãƒªãƒ¼ãƒªãƒ¼ã‚¯ã®ä¿®æ­£
+		//	2003.06.16 genta ãƒãƒƒãƒ•ã‚¡ã‚’å¤–ã‹ã‚‰ä¸ãˆã‚‹ã‚ˆã†ã«
+		//	é–¢æ•°ç™»éŒ²ç”¨æ–‡å­—åˆ—ã‚’ä½œæˆã™ã‚‹
 		GetDeclarations( CSMacroMgr::m_MacroFuncInfoCommandArr[i], buf );
 		SetDefProc( buf );
 	}
 	return true; 
 }
 
-/*! PPA‚ÉŠÖ”‚ğ“o˜^‚·‚é‚½‚ß‚Ì•¶š—ñ‚ğì¬‚·‚é
+/*! PPAã«é–¢æ•°ã‚’ç™»éŒ²ã™ã‚‹ãŸã‚ã®æ–‡å­—åˆ—ã‚’ä½œæˆã™ã‚‹
 
-	@param cMacroFuncInfo [in]	ƒ}ƒNƒƒf[ƒ^
-	@param szBuffer [out]		¶¬‚µ‚½•¶š—ñ‚ğ“ü‚ê‚éƒoƒbƒtƒ@‚Ö‚Ìƒ|ƒCƒ“ƒ^
+	@param cMacroFuncInfo [in]	ãƒã‚¯ãƒ­ãƒ‡ãƒ¼ã‚¿
+	@param szBuffer [out]		ç”Ÿæˆã—ãŸæ–‡å­—åˆ—ã‚’å…¥ã‚Œã‚‹ãƒãƒƒãƒ•ã‚¡ã¸ã®ãƒã‚¤ãƒ³ã‚¿
 
-	@note ƒoƒbƒtƒ@ƒTƒCƒY‚Í 9 + 3 + ƒƒ\ƒbƒh–¼‚Ì’·‚³ + 13 * 4 + 9 + 5 ‚ÍÅ’á•K—v
+	@note ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã¯ 9 + 3 + ãƒ¡ã‚½ãƒƒãƒ‰åã®é•·ã• + 13 * 4 + 9 + 5 ã¯æœ€ä½å¿…è¦
 
 	@date 2003.06.01 Moca
-				ƒXƒ^ƒeƒBƒbƒNƒƒ“ƒo‚É•ÏX
-				cMacroFuncInfo.m_pszData‚ğ‘‚«Š·‚¦‚È‚¢‚æ‚¤‚É•ÏX
+				ã‚¹ã‚¿ãƒ†ã‚£ãƒƒã‚¯ãƒ¡ãƒ³ãƒã«å¤‰æ›´
+				cMacroFuncInfo.m_pszDataã‚’æ›¸ãæ›ãˆãªã„ã‚ˆã†ã«å¤‰æ›´
 
-	@date 2003.06.16 genta –³‘Ê‚Ènew/delete‚ğ”ğ‚¯‚é‚½‚ßƒoƒbƒtƒ@‚ğŠO‚©‚ç—^‚¦‚é‚æ‚¤‚É
+	@date 2003.06.16 genta ç„¡é§„ãªnew/deleteã‚’é¿ã‘ã‚‹ãŸã‚ãƒãƒƒãƒ•ã‚¡ã‚’å¤–ã‹ã‚‰ä¸ãˆã‚‹ã‚ˆã†ã«
 */
 char* CPPA::GetDeclarations( const MacroFuncInfo& cMacroFuncInfo, char* szBuffer )
 {
-	char szType[20];			//	procedure/function—pƒoƒbƒtƒ@
-	char szReturn[20];			//	–ß‚è’lŒ^—pƒoƒbƒtƒ@
+	char szType[20];			//	procedure/functionç”¨ãƒãƒƒãƒ•ã‚¡
+	char szReturn[20];			//	æˆ»ã‚Šå€¤å‹ç”¨ãƒãƒƒãƒ•ã‚¡
 	if (cMacroFuncInfo.m_varResult == VT_EMPTY){
 		strcpy( szType, "procedure" );
 		szReturn[0] = '\0';
@@ -237,7 +237,7 @@ char* CPPA::GetDeclarations( const MacroFuncInfo& cMacroFuncInfo, char* szBuffer
 		}
 	}
 	
-	char szArguments[8][20];	//	ˆø”—pƒoƒbƒtƒ@
+	char szArguments[8][20];	//	å¼•æ•°ç”¨ãƒãƒƒãƒ•ã‚¡
 	int i;
 	for (i=0; i<8; i++){
 		VARTYPE type = VT_EMPTY;
@@ -263,10 +263,10 @@ char* CPPA::GetDeclarations( const MacroFuncInfo& cMacroFuncInfo, char* szBuffer
 			strcpy( szArguments[i], "u0: Unknown" );
 		}
 	}
-	if ( i > 0 ){	//	ˆø”‚ª‚ ‚Á‚½‚Æ‚«
+	if ( i > 0 ){	//	å¼•æ•°ãŒã‚ã£ãŸã¨ã
 		int j;
 		char szArgument[8*20];
-		// 2002.12.06 Moca Œ´ˆö•s–¾‚¾‚ªCstrcat‚ªVC6Pro‚Å‚¤‚Ü‚­“®‚©‚È‚©‚Á‚½‚½‚ßCstrcpy‚É‚µ‚Ä‚İ‚½‚ç“®‚¢‚½
+		// 2002.12.06 Moca åŸå› ä¸æ˜ã ãŒï¼ŒstrcatãŒVC6Proã§ã†ã¾ãå‹•ã‹ãªã‹ã£ãŸãŸã‚ï¼Œstrcpyã«ã—ã¦ã¿ãŸã‚‰å‹•ã„ãŸ
 		strcpy( szArgument, szArguments[0] );
 		for ( j=1; j<i; j++){
 			strcat( szArgument, "; " );
@@ -294,8 +294,8 @@ char* CPPA::GetDeclarations( const MacroFuncInfo& cMacroFuncInfo, char* szBuffer
 
 
 
-/*! ƒ†[ƒU[’è‹`•¶š—ñŒ^ƒIƒuƒWƒFƒNƒg
-	Œ»İ‚ÍAƒfƒoƒbƒO—p•¶š—ñ‚ğİ’è‚·‚éˆ×‚Ì‚İ
+/*! ãƒ¦ãƒ¼ã‚¶ãƒ¼å®šç¾©æ–‡å­—åˆ—å‹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
+	ç¾åœ¨ã¯ã€ãƒ‡ãƒãƒƒã‚°ç”¨æ–‡å­—åˆ—ã‚’è¨­å®šã™ã‚‹ç‚ºã®ã¿
 */
 void __stdcall CPPA::stdStrObj(const char* ObjName, int Index, BYTE GS_Mode, int* Err_CD, char** Value)
 {
@@ -318,16 +318,16 @@ void __stdcall CPPA::stdStrObj(const char* ObjName, int Index, BYTE GS_Mode, int
 }
 
 
-/*! ƒ†[ƒU[’è‹`ŠÖ”‚ÌƒGƒ‰[ƒƒbƒZ[ƒW‚Ìì¬
+/*! ãƒ¦ãƒ¼ã‚¶ãƒ¼å®šç¾©é–¢æ•°ã®ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®ä½œæˆ
 
-	stdProc, stdIntFunc, stdStrFunc ‚ªƒGƒ‰[ƒR[ƒh‚ğ•Ô‚µ‚½ê‡APPA‚©‚çŒÄ‚Ño‚³‚ê‚éB
-	ˆÙíI—¹/•s³ˆø”‚ÌƒGƒ‰[ƒƒbƒZ[ƒW‚ğ“Æ©‚Éw’è‚·‚éB
+	stdProc, stdIntFunc, stdStrFunc ãŒã‚¨ãƒ©ãƒ¼ã‚³ãƒ¼ãƒ‰ã‚’è¿”ã—ãŸå ´åˆã€PPAã‹ã‚‰å‘¼ã³å‡ºã•ã‚Œã‚‹ã€‚
+	ç•°å¸¸çµ‚äº†/ä¸æ­£å¼•æ•°æ™‚ã®ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ç‹¬è‡ªã«æŒ‡å®šã™ã‚‹ã€‚
 	@author Moca
-	@param Err_CD IN  0ˆÈŠOŠeƒR[ƒ‹ƒoƒbƒNŠÖ”‚ªİ’è‚µ‚½’l
-			 1ˆÈã FuncID + 1
-			 0     PPA‚ÌƒGƒ‰[
-			-1ˆÈ‰º ‚»‚Ì‘¼ƒ†[ƒU’è‹`ƒGƒ‰[
-	@param Err_Mes IN ƒGƒ‰[ƒƒbƒZ[ƒW
+	@param Err_CD IN  0ä»¥å¤–å„ã‚³ãƒ¼ãƒ«ãƒãƒƒã‚¯é–¢æ•°ãŒè¨­å®šã—ãŸå€¤
+			 1ä»¥ä¸Š FuncID + 1
+			 0     PPAã®ã‚¨ãƒ©ãƒ¼
+			-1ä»¥ä¸‹ ãã®ä»–ãƒ¦ãƒ¼ã‚¶å®šç¾©ã‚¨ãƒ©ãƒ¼
+	@param Err_Mes IN ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
 
 	@date 2003.06.01 Moca
 */
@@ -336,9 +336,9 @@ void __stdcall CPPA::stdError( int Err_CD, const char* Err_Mes )
 	if( false != m_CurInstance->m_bError ){
 		return;
 	}
-	m_CurInstance->m_bError = true; // ŠÖ”“à‚ÅŠÖ”‚ğŒÄ‚Ôê‡“™A2‰ñ•\¦‚³‚ê‚é‚Ì‚ğ–h‚®
+	m_CurInstance->m_bError = true; // é–¢æ•°å†…ã§é–¢æ•°ã‚’å‘¼ã¶å ´åˆç­‰ã€2å›è¡¨ç¤ºã•ã‚Œã‚‹ã®ã‚’é˜²ã
 
-	TCHAR szMes[2048]; // 2048‚ ‚ê‚Î‘«‚è‚é‚©‚Æ
+	TCHAR szMes[2048]; // 2048ã‚ã‚Œã°è¶³ã‚Šã‚‹ã‹ã¨
 	const TCHAR* pszErr;
 	pszErr = szMes;
 	if( 0 < Err_CD ){
@@ -366,8 +366,8 @@ void __stdcall CPPA::stdError( int Err_CD, const char* Err_Mes )
 			auto_sprintf( szMes, LS(STR_ERR_DLGPPA3), FuncID );
 		}
 	}else{
-		//	2007.07.26 genta : ƒlƒXƒgÀs‚µ‚½ê‡‚ÉPPA‚ª•s³‚Èƒ|ƒCƒ“ƒ^‚ğ“n‚·‰Â”\«‚ğl—¶D
-		//	ÀÛ‚É‚Í•s³‚ÈƒGƒ‰[‚Í‘S‚ÄPPA.DLL“à•”‚Åƒgƒ‰ƒbƒv‚³‚ê‚é‚æ‚¤‚¾‚ª”O‚Ì‚½‚ßD
+		//	2007.07.26 genta : ãƒã‚¹ãƒˆå®Ÿè¡Œã—ãŸå ´åˆã«PPAãŒä¸æ­£ãªãƒã‚¤ãƒ³ã‚¿ã‚’æ¸¡ã™å¯èƒ½æ€§ã‚’è€ƒæ…®ï¼
+		//	å®Ÿéš›ã«ã¯ä¸æ­£ãªã‚¨ãƒ©ãƒ¼ã¯å…¨ã¦PPA.DLLå†…éƒ¨ã§ãƒˆãƒ©ãƒƒãƒ—ã•ã‚Œã‚‹ã‚ˆã†ã ãŒå¿µã®ãŸã‚ï¼
 		if( IsBadStringPtrA( Err_Mes, 256 )){
 			pszErr = LS(STR_ERR_DLGPPA6);
 		}else{
@@ -395,9 +395,9 @@ void __stdcall CPPA::stdError( int Err_CD, const char* Err_Mes )
 
 
 //----------------------------------------------------------------------
-/** ƒvƒƒV[ƒWƒƒÀscallback
+/** ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£å®Ÿè¡Œcallback
 
-	@date 2007.07.20 genta Index‚Æˆê‚Éƒtƒ‰ƒO‚ğ“n‚·
+	@date 2007.07.20 genta Indexã¨ä¸€ç·’ã«ãƒ•ãƒ©ã‚°ã‚’æ¸¡ã™
 */
 void __stdcall CPPA::stdProc(
 	const char*		FuncName,
@@ -412,7 +412,7 @@ void __stdcall CPPA::stdProc(
 
 	*Err_CD = 0;
 
-	//Argument‚ğwchar_t[]‚É•ÏŠ· -> tmpArguments
+	//Argumentã‚’wchar_t[]ã«å¤‰æ› -> tmpArguments
 	WCHAR** tmpArguments2=new WCHAR*[ArgSize];
 	int* tmpArgLengths = new int[ArgSize];
 	for(int i=0;i<ArgSize;i++){
@@ -427,13 +427,13 @@ void __stdcall CPPA::stdProc(
 	}
 	const WCHAR** tmpArguments=(const WCHAR**)tmpArguments2;
 
-	//ˆ—
+	//å‡¦ç†
 	bool bRet = CMacro::HandleCommand( m_CurInstance->m_pcEditView, (EFunctionCode)(Index | m_CurInstance->m_commandflags), tmpArguments,tmpArgLengths, ArgSize );
 	if( !bRet ){
 		*Err_CD = Index + 1;
 	}
 
-	//tmpArguments‚ğ‰ğ•ú
+	//tmpArgumentsã‚’è§£æ”¾
 	for(int i=0;i<ArgSize;i++){
 		if(tmpArguments2[i]){
 			WCHAR* p=const_cast<WCHAR*>(tmpArguments2[i]);
@@ -446,9 +446,9 @@ void __stdcall CPPA::stdProc(
 
 //----------------------------------------------------------------------
 /*!
-	®”’l‚ğ•Ô‚·ŠÖ”‚ğˆ—‚·‚é
+	æ•´æ•°å€¤ã‚’è¿”ã™é–¢æ•°ã‚’å‡¦ç†ã™ã‚‹
 
-	PPA‚©‚çŒÄ‚Ñ‚¾‚³‚ê‚é
+	PPAã‹ã‚‰å‘¼ã³ã ã•ã‚Œã‚‹
 	@author Moca
 	@date 2003.02.24 Moca
 */
@@ -475,7 +475,7 @@ void __stdcall CPPA::stdIntFunc(
 			*ResultValue = Ret.uintVal;
 			break;
 		default:
-			*Err_CD = -2; // 2003.06.01 Moca ’l•ÏX
+			*Err_CD = -2; // 2003.06.01 Moca å€¤å¤‰æ›´
 		}
 		::VariantClear(&Ret);
 		return;
@@ -487,10 +487,10 @@ void __stdcall CPPA::stdIntFunc(
 
 //----------------------------------------------------------------------
 /*!
-	•¶š—ñ‚ğ•Ô‚·ŠÖ”‚ğˆ—‚·‚é
+	æ–‡å­—åˆ—ã‚’è¿”ã™é–¢æ•°ã‚’å‡¦ç†ã™ã‚‹
 
-	PPA‚©‚çŒÄ‚Ñ‚¾‚³‚ê‚é
-	@date 2003.02.24 Moca CallHandleFunction‘Î‰
+	PPAã‹ã‚‰å‘¼ã³ã ã•ã‚Œã‚‹
+	@date 2003.02.24 Moca CallHandleFunctionå¯¾å¿œ
 */
 void __stdcall CPPA::stdStrFunc(
 	const char* FuncName, const int Index,
@@ -521,9 +521,9 @@ void __stdcall CPPA::stdStrFunc(
 }
 
 /*!
-	ˆø”Œ^•ÏŠ·
+	å¼•æ•°å‹å¤‰æ›
 
-	•¶š—ñ‚Å—^‚¦‚ç‚ê‚½ˆø”‚ğVARIANT/BSTR‚É•ÏŠ·‚µ‚ÄCMacro::HandleFunction()‚ğŒÄ‚Ñ‚¾‚·
+	æ–‡å­—åˆ—ã§ä¸ãˆã‚‰ã‚ŒãŸå¼•æ•°ã‚’VARIANT/BSTRã«å¤‰æ›ã—ã¦CMacro::HandleFunction()ã‚’å‘¼ã³ã ã™
 	@author Moca
 */
 bool CPPA::CallHandleFunction(
@@ -594,13 +594,13 @@ bool CPPA::CallHandleFunction(
 #if PPADLL_VER >= 123
 
 /*!
-	PPAƒ}ƒNƒ‚ÌÀsI—¹‚ÉŒÄ‚Î‚ê‚é
+	PPAãƒã‚¯ãƒ­ã®å®Ÿè¡Œçµ‚äº†æ™‚ã«å‘¼ã°ã‚Œã‚‹
 	
 	@date 2003.06.01 Moca
 */
 void __stdcall CPPA::stdFinishProc()
 {
-	// 2007.07.26 genta : I—¹ˆ—‚Í•s—v
+	// 2007.07.26 genta : çµ‚äº†å‡¦ç†ã¯ä¸è¦
 }
 
 #endif

--- a/sakura_core/macro/CPPA.h
+++ b/sakura_core/macro/CPPA.h
@@ -1,10 +1,10 @@
-/*!	@file
+ï»¿/*!	@file
 	@brief PPA Library Handler
 
-	PPA.DLL‚ğ—˜—p‚·‚é‚½‚ß‚ÌƒCƒ“ƒ^[ƒtƒF[ƒX
+	PPA.DLLã‚’åˆ©ç”¨ã™ã‚‹ãŸã‚ã®ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 
 	@author YAZAKI
-	@date 2002”N1Œ26“ú
+	@date 2002å¹´1æœˆ26æ—¥
 */
 /*
 	Copyright (C) 2001, YAZAKI, genta
@@ -32,13 +32,13 @@
 		   distribution.
 */
 /*
-PPA(Poor-Pascal for Application)‚ÍDelphi/C++Builder—p‚ÌPascalƒCƒ“ƒ^ƒvƒŠƒ^ƒRƒ“ƒ|[ƒlƒ“ƒg‚Å‚·B
+PPA(Poor-Pascal for Application)ã¯Delphi/C++Builderç”¨ã®Pascalã‚¤ãƒ³ã‚¿ãƒ—ãƒªã‚¿ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã§ã™ã€‚
 */
 
 #ifndef _DLL_CPPA_H_
 #define _DLL_CPPA_H_
 
-#include <ObjIdl.h>  // VARIANT“™
+#include <ObjIdl.h>  // VARIANTç­‰
 #include <stdio.h>
 #include "macro/CSMacroMgr.h"
 #include "extmodule/CDllHandler.h"
@@ -46,24 +46,24 @@ PPA(Poor-Pascal for Application)‚ÍDelphi/C++Builder—p‚ÌPascalƒCƒ“ƒ^ƒvƒŠƒ^ƒRƒ“ƒ|
 #define PPADLL_VER 123
 
 /*
-PPA(Poor-Pascal for Application)‚ÍDelphi/C++Builder—p‚Ì
-PascalƒCƒ“ƒ^ƒvƒŠƒ^ƒRƒ“ƒ|[ƒlƒ“ƒg‚Å‚·B
-ƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚Éƒ}ƒNƒ‹@”\‚ğ“‹Ú‚·‚é–‚ğ–Ú“I‚Éì¬‚³‚ê‚Ä‚¢‚Ü‚·B
+PPA(Poor-Pascal for Application)ã¯Delphi/C++Builderç”¨ã®
+Pascalã‚¤ãƒ³ã‚¿ãƒ—ãƒªã‚¿ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã§ã™ã€‚
+ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã«ãƒã‚¯ãƒ­æ©Ÿèƒ½ã‚’æ­è¼‰ã™ã‚‹äº‹ã‚’ç›®çš„ã«ä½œæˆã•ã‚Œã¦ã„ã¾ã™ã€‚
 */
 
 /*!
-	@brief PPA.DLL ‚ğƒTƒ|[ƒg‚·‚éƒNƒ‰ƒX
+	@brief PPA.DLL ã‚’ã‚µãƒãƒ¼ãƒˆã™ã‚‹ã‚¯ãƒ©ã‚¹
 
-	DLL‚Ì“®“Iƒ[ƒh‚ğs‚¤‚½‚ßADllHandler‚ğŒp³‚µ‚Ä‚¢‚éB
+	DLLã®å‹•çš„ãƒ­ãƒ¼ãƒ‰ã‚’è¡Œã†ãŸã‚ã€DllHandlerã‚’ç¶™æ‰¿ã—ã¦ã„ã‚‹ã€‚
 
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 */
 class CPPA : public CDllImp {
 public:
 	CPPA();
 	virtual ~CPPA();
 
-	const char* GetVersion(){		//!< DLL‚Ìƒo[ƒWƒ‡ƒ“î•ñ‚ğæ“¾Bm_szMsg‚ğ‰ó‚·
+	const char* GetVersion(){		//!< DLLã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±ã‚’å–å¾—ã€‚m_szMsgã‚’å£Šã™
 		if ( IsAvailable() ){
 			auto_sprintf(m_szMsg, "PPA.DLL Version %d.%d", m_fnGetVersion() / 100, m_fnGetVersion() % 100);
 			return m_szMsg;
@@ -71,21 +71,21 @@ public:
 		return "";
 	}
 
-	//! PPAƒƒbƒZ[ƒW‚ğæ“¾‚·‚é
+	//! PPAãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å–å¾—ã™ã‚‹
 	const char* GetLastMessage(void) const { return m_szMsg; }
 
-	//	Jun. 16, 2003 genta ˆø”’Ç‰Á
+	//	Jun. 16, 2003 genta å¼•æ•°è¿½åŠ 
 	static char* GetDeclarations( const MacroFuncInfo&, char* buf );
 
 protected:
-	//	Jul. 5, 2001 genta ƒCƒ“ƒ^[ƒtƒF[ƒX•ÏX‚É”º‚¤ˆø”’Ç‰Á
+	//	Jul. 5, 2001 genta ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹å¤‰æ›´ã«ä¼´ã†å¼•æ•°è¿½åŠ 
 public:
 	virtual LPCTSTR GetDllNameImp(int nIndex);
 protected:
 	virtual bool InitDllImp();
 
 private:
-	//	DLL Interface‚Ìó‚¯M
+	//	DLL Interfaceã®å—ã‘çš¿
 	typedef void (WINAPI *PPA_Execute)();
 	typedef void (WINAPI *PPA_SetSource) (const char* ss);
 	typedef void (WINAPI *PPA_SetDeclare)(const char* ss);
@@ -113,7 +113,7 @@ private:
 	typedef BOOL (WINAPI *PPA_SetIntVar) (const char*, int);
 	typedef BOOL (WINAPI *PPA_SetStrVar) (const char*, const char*);
 
-	// ˆÈ‰º‚Í PPA.DLL Version 1.20 ‚Å’Ç‰Á‚³‚ê‚½ŠÖ” --
+	// ä»¥ä¸‹ã¯ PPA.DLL Version 1.20 ã§è¿½åŠ ã•ã‚ŒãŸé–¢æ•° --
 	#if PPADLL_VER >= 120
 	typedef void   (WINAPI *PPA_AddRealVar)(const char*, double, BOOL);
 	typedef void   (WINAPI *PPA_SetRealObj)(void* p);
@@ -124,7 +124,7 @@ private:
 	typedef DWORD  (WINAPI *PPA_GetArgReal)(int);
 	#endif // PPADLL_VER >= 120
 
-	// ˆÈ‰º‚Í PPA.DLL Version 1.23 ‚Å’Ç‰Á‚³‚ê‚½ŠÖ” --
+	// ä»¥ä¸‹ã¯ PPA.DLL Version 1.23 ã§è¿½åŠ ã•ã‚ŒãŸé–¢æ•° --
 	#if PPADLL_VER >= 123
 	typedef BYTE (WINAPI *PPA_IsRunning)();
 	typedef void (WINAPI *PPA_SetFinishProc)(void* p);	//	2003.06.01 Moca
@@ -174,7 +174,7 @@ private:
 
 public:
 	// exported
-	//	2007.07.22 genta : flags’Ç‰Á
+	//	2007.07.22 genta : flagsè¿½åŠ 
 	bool Execute(class CEditView* pcEditView, int flags );
 	void SetSource(const char* ss)
 		{ m_fnSetSource(ss); }
@@ -252,7 +252,7 @@ public:
 #endif
 
 private:
-	// ƒR[ƒ‹ƒoƒbƒNƒvƒƒV[ƒWƒƒŒQ
+	// ã‚³ãƒ¼ãƒ«ãƒãƒƒã‚¯ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ç¾¤
 	static void __stdcall stdStrObj(const char*, int, BYTE, int*, char**);	//	2003.06.01 Moca
 
 	static void __stdcall stdProc( const char* FuncName, const int Index, const char* Argument[], const int ArgSize, int* Err_CD);
@@ -264,33 +264,33 @@ private:
 	static void __stdcall stdError( int, const char* );	//	2003.06.01 Moca
 	static void __stdcall stdFinishProc();	//	2003.06.01 Moca
 
-	//	ƒƒ“ƒo•Ï”
-	char		m_szMsg[80];		//!< CPPA‚©‚ç‚ÌƒƒbƒZ[ƒW‚ğ•Û‚·‚é
+	//	ãƒ¡ãƒ³ãƒå¤‰æ•°
+	char		m_szMsg[80];		//!< CPPAã‹ã‚‰ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ä¿æŒã™ã‚‹
 
-	//	2007.07.26 genta : PPA‚ÌƒlƒXƒg‚ğ‹–—e‚·‚é‚½‚ß‚ÉC•Êƒf[ƒ^\‘¢‚Æ‚·‚éD
+	//	2007.07.26 genta : PPAã®ãƒã‚¹ãƒˆã‚’è¨±å®¹ã™ã‚‹ãŸã‚ã«ï¼Œåˆ¥ãƒ‡ãƒ¼ã‚¿æ§‹é€ ã¨ã™ã‚‹ï¼
 	
 	struct PpaExecInfo {
-		CNativeA		m_cMemRet;		//!< ƒR[ƒ‹ƒoƒbƒN‚©‚çDLL‚É“n‚·•¶š—ñ‚ğ•Û
+		CNativeA		m_cMemRet;		//!< ã‚³ãƒ¼ãƒ«ãƒãƒƒã‚¯ã‹ã‚‰DLLã«æ¸¡ã™æ–‡å­—åˆ—ã‚’ä¿æŒ
 		CEditView*		m_pcEditView;	//	2003.06.01 Moca
 		DLLSHAREDATA*	m_pShareData;	//	2003.06.01 Moca
-		bool			m_bError;		//!< ƒGƒ‰[‚ª2‰ñ•\¦‚³‚ê‚é‚Ì‚ğ–h‚®	2003.06.01 Moca
-		CNativeA		m_cMemDebug;	//!< ƒfƒoƒbƒO—p•Ï”UserErrorMes 2003.06.01 Moca
-		/** ƒIƒvƒVƒ‡ƒ“ƒtƒ‰ƒO
+		bool			m_bError;		//!< ã‚¨ãƒ©ãƒ¼ãŒ2å›è¡¨ç¤ºã•ã‚Œã‚‹ã®ã‚’é˜²ã	2003.06.01 Moca
+		CNativeA		m_cMemDebug;	//!< ãƒ‡ãƒãƒƒã‚°ç”¨å¤‰æ•°UserErrorMes 2003.06.01 Moca
+		/** ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ãƒ©ã‚°
 		
-			CEditView::HandleCommand()‚ÉƒRƒ}ƒ“ƒh‚Æˆê‚É“n‚·‚±‚Æ‚Å
-			ƒRƒ}ƒ“ƒh‚Ì‘f«‚ğ‹³‚¦‚éD
+			CEditView::HandleCommand()ã«ã‚³ãƒãƒ³ãƒ‰ã¨ä¸€ç·’ã«æ¸¡ã™ã“ã¨ã§
+			ã‚³ãƒãƒ³ãƒ‰ã®ç´ æ€§ã‚’æ•™ãˆã‚‹ï¼
 		*/
 		int				m_commandflags;	//!< 
 	};
-	//	2007.07.26 genta : Œ»İÀs’†‚ÌƒCƒ“ƒXƒ^ƒ“ƒX
+	//	2007.07.26 genta : ç¾åœ¨å®Ÿè¡Œä¸­ã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹
 	static PpaExecInfo* m_CurInstance;
-	//PPA‚Ì‘½d‹N“®‹Ö~ 2008.10.22 syat
-	static bool				m_bIsRunning;	//!< PPA‚ª“¯Às‚³‚ê‚é‚Ì‚ğ–h‚®
+	//PPAã®å¤šé‡èµ·å‹•ç¦æ­¢ 2008.10.22 syat
+	static bool				m_bIsRunning;	//!< PPAãŒåŒæ™‚å®Ÿè¡Œã•ã‚Œã‚‹ã®ã‚’é˜²ã
 
 
-/*	ŠÖ”–¼‚ÍCMacro‚ª‚ÂB
+/*	é–¢æ•°åã¯CMacroãŒæŒã¤ã€‚
 	static struct MacroFuncInfo	S_Table[];
-	static int					m_nFuncNum;	//	SAKURAƒGƒfƒBƒ^—pŠÖ”‚Ì”
+	static int					m_nFuncNum;	//	SAKURAã‚¨ãƒ‡ã‚£ã‚¿ç”¨é–¢æ•°ã®æ•°
 */
 };
 

--- a/sakura_core/macro/CPPAMacroMgr.cpp
+++ b/sakura_core/macro/CPPAMacroMgr.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒL[ƒ{[ƒhƒ}ƒNƒ
+ï»¿/*!	@file
+	@brief ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­
 
 	@author YAZAKI
-	@date 2002”N1Œ26“ú
+	@date 2002å¹´1æœˆ26æ—¥
 */
 /*
 	Copyright (C) 2002, YAZAKI, genta
@@ -29,11 +29,11 @@ CPPAMacroMgr::~CPPAMacroMgr()
 {
 }
 
-/** PPAƒ}ƒNƒ‚ÌÀs
+/** PPAãƒã‚¯ãƒ­ã®å®Ÿè¡Œ
 
-	PPA.DLL‚ÉAƒoƒbƒtƒ@“à—e‚ğ“n‚µ‚ÄÀsB
+	PPA.DLLã«ã€ãƒãƒƒãƒ•ã‚¡å†…å®¹ã‚’æ¸¡ã—ã¦å®Ÿè¡Œã€‚
 
-	@date 2007.07.20 genta flags’Ç‰Á
+	@date 2007.07.20 genta flagsè¿½åŠ 
 */
 bool CPPAMacroMgr::ExecKeyMacro( CEditView* pcEditView, int flags ) const
 {
@@ -41,8 +41,8 @@ bool CPPAMacroMgr::ExecKeyMacro( CEditView* pcEditView, int flags ) const
 	return m_cPPA.Execute(pcEditView, flags);
 }
 
-/*! ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì“Ç‚İ‚İiƒtƒ@ƒCƒ‹‚©‚çj
-	ƒGƒ‰[ƒƒbƒZ[ƒW‚Ío‚µ‚Ü‚¹‚ñBŒÄ‚Ño‚µ‘¤‚Å‚æ‚«‚É‚Í‚©‚ç‚Á‚Ä‚­‚¾‚³‚¢B
+/*! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ï¼ˆãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ï¼‰
+	ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯å‡ºã—ã¾ã›ã‚“ã€‚å‘¼ã³å‡ºã—å´ã§ã‚ˆãã«ã¯ã‹ã‚‰ã£ã¦ãã ã•ã„ã€‚
 */
 BOOL CPPAMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 {
@@ -54,7 +54,7 @@ BOOL CPPAMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 
 	CNativeW cmemWork;
 
-	// ƒoƒbƒtƒ@icmemWorkj‚Éƒtƒ@ƒCƒ‹“à—e‚ğ“Ç‚İ‚İAm_cPPA‚É“n‚·B
+	// ãƒãƒƒãƒ•ã‚¡ï¼ˆcmemWorkï¼‰ã«ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹ã‚’èª­ã¿è¾¼ã¿ã€m_cPPAã«æ¸¡ã™ã€‚
 	while( in ){
 		wstring szLine = in.ReadLineW();
 		szLine += L"\n";
@@ -62,18 +62,18 @@ BOOL CPPAMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath )
 	}
 	in.Close();
 
-	m_cBuffer.SetNativeData( cmemWork );	//	m_cBuffer‚ÉƒRƒs[
+	m_cBuffer.SetNativeData( cmemWork );	//	m_cBufferã«ã‚³ãƒ”ãƒ¼
 
 	m_nReady = true;
 	return TRUE;
 }
 
-/*! ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì“Ç‚İ‚İi•¶š—ñ‚©‚çj
-	ƒGƒ‰[ƒƒbƒZ[ƒW‚Ío‚µ‚Ü‚¹‚ñBŒÄ‚Ño‚µ‘¤‚Å‚æ‚«‚É‚Í‚©‚ç‚Á‚Ä‚­‚¾‚³‚¢B
+/*! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ï¼ˆæ–‡å­—åˆ—ã‹ã‚‰ï¼‰
+	ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯å‡ºã—ã¾ã›ã‚“ã€‚å‘¼ã³å‡ºã—å´ã§ã‚ˆãã«ã¯ã‹ã‚‰ã£ã¦ãã ã•ã„ã€‚
 */
 BOOL CPPAMacroMgr::LoadKeyMacroStr( HINSTANCE hInstance, const TCHAR* pszCode )
 {
-	m_cBuffer.SetNativeData( to_wchar( pszCode ) );	//	m_cBuffer‚ÉƒRƒs[
+	m_cBuffer.SetNativeData( to_wchar( pszCode ) );	//	m_cBufferã«ã‚³ãƒ”ãƒ¼
 
 	m_nReady = true;
 	return TRUE;
@@ -83,10 +83,10 @@ BOOL CPPAMacroMgr::LoadKeyMacroStr( HINSTANCE hInstance, const TCHAR* pszCode )
 /*!
 	@brief Factory
 
-	@param ext [in] ƒIƒuƒWƒFƒNƒg¶¬‚Ì”»’è‚Ég‚¤Šg’£q(¬•¶š)
+	@param ext [in] ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆç”Ÿæˆã®åˆ¤å®šã«ä½¿ã†æ‹¡å¼µå­(å°æ–‡å­—)
 
-	@date 2004.01.31 genta RegisterExt‚Ì”p~‚Ì‚½‚ßRegisterCreator‚É’u‚«Š·‚¦
-		‚»‚Ì‚½‚ßC‰ß‚Á‚½ƒIƒuƒWƒFƒNƒg¶¬‚ğs‚í‚È‚¢‚½‚ß‚ÉŠg’£qƒ`ƒFƒbƒN‚Í•K{D
+	@date 2004.01.31 genta RegisterExtã®å»ƒæ­¢ã®ãŸã‚RegisterCreatorã«ç½®ãæ›ãˆ
+		ãã®ãŸã‚ï¼Œéã£ãŸã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆç”Ÿæˆã‚’è¡Œã‚ãªã„ãŸã‚ã«æ‹¡å¼µå­ãƒã‚§ãƒƒã‚¯ã¯å¿…é ˆï¼
 
 */
 CMacroManagerBase* CPPAMacroMgr::Creator(const TCHAR* ext)
@@ -97,11 +97,11 @@ CMacroManagerBase* CPPAMacroMgr::Creator(const TCHAR* ext)
 	return NULL;
 }
 
-/*!	CPPAMacroManager‚Ì“o˜^
+/*!	CPPAMacroManagerã®ç™»éŒ²
 
-	PPA‚ª—˜—p‚Å‚«‚È‚¢‚Æ‚«‚Í‰½‚à‚µ‚È‚¢B
+	PPAãŒåˆ©ç”¨ã§ããªã„ã¨ãã¯ä½•ã‚‚ã—ãªã„ã€‚
 
-	@date 2004.01.31 genta RegisterExt‚Ì”p~‚Ì‚½‚ßRegisterCreator‚É’u‚«Š·‚¦
+	@date 2004.01.31 genta RegisterExtã®å»ƒæ­¢ã®ãŸã‚RegisterCreatorã«ç½®ãæ›ãˆ
 */
 void CPPAMacroMgr::declare (void)
 {

--- a/sakura_core/macro/CPPAMacroMgr.h
+++ b/sakura_core/macro/CPPAMacroMgr.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief PPA.DLLƒ}ƒNƒ
+ï»¿/*!	@file
+	@brief PPA.DLLãƒã‚¯ãƒ­
 
 	@author YAZAKI
-	@date 2002”N1Œ26“ú
+	@date 2002å¹´1æœˆ26æ—¥
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -21,9 +21,9 @@
 #include "CPPA.h"
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
-//! PPAƒ}ƒNƒ
+//! PPAãƒã‚¯ãƒ­
 class CPPAMacroMgr: public CMacroManagerBase
 {
 public:
@@ -34,11 +34,11 @@ public:
 	~CPPAMacroMgr();
 
 	/*
-	||	PPA.DLL‚ÉˆÏ÷‚·‚é•”•ª
+	||	PPA.DLLã«å§”è­²ã™ã‚‹éƒ¨åˆ†
 	*/
-	virtual bool ExecKeyMacro( class CEditView* pcEditView, int flags ) const;	/* PPAƒ}ƒNƒ‚ÌÀs */
-	virtual BOOL LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath);		/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğƒtƒ@ƒCƒ‹‚©‚ç“Ç‚İ‚İACMacro‚Ì—ñ‚É•ÏŠ· */
-	virtual BOOL LoadKeyMacroStr( HINSTANCE hInstance, const TCHAR* pszCode);	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ•¶š—ñ‚©‚ç“Ç‚İ‚İACMacro‚Ì—ñ‚É•ÏŠ· */
+	virtual bool ExecKeyMacro( class CEditView* pcEditView, int flags ) const;	/* PPAãƒã‚¯ãƒ­ã®å®Ÿè¡Œ */
+	virtual BOOL LoadKeyMacro( HINSTANCE hInstance, const TCHAR* pszPath);		/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰èª­ã¿è¾¼ã¿ã€CMacroã®åˆ—ã«å¤‰æ› */
+	virtual BOOL LoadKeyMacroStr( HINSTANCE hInstance, const TCHAR* pszCode);	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’æ–‡å­—åˆ—ã‹ã‚‰èª­ã¿è¾¼ã¿ã€CMacroã®åˆ—ã«å¤‰æ› */
 
 	static class CPPA m_cPPA;
 

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -1,10 +1,10 @@
-/*!	@file
-	@brief �}�N��
+﻿/*!	@file
+	@brief マクロ
 
 	@author Norio Nakatani
 	@author genta
-	@date Sep. 29, 2001 �쐬
-	@date 20011229 aroka �o�O�C���A�R�����g�ǉ�
+	@date Sep. 29, 2001 作成
+	@date 20011229 aroka バグ修正、コメント追加
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -14,7 +14,7 @@
 	Copyright (C) 2003, MIK, genta, Moca
 	Copyright (C) 2004, genta, zenryaku
 	Copyright (C) 2005, MIK, genta, maru, FILE
-	Copyright (C) 2006, �����, fon, ryoji
+	Copyright (C) 2006, かろと, fon, ryoji
 	Copyright (C) 2007, ryoji, maru
 	Copyright (C) 2008, nasukoji, ryoji
 	Copyright (C) 2011, nasukoji
@@ -42,446 +42,446 @@ MacroFuncInfoEx s_MacroInfoEx_s = {5, 5, s_MacroArgEx_s};
 
 MacroFuncInfo CSMacroMgr::m_MacroFuncInfoCommandArr[] = 
 {
-//	�@�\�ԍ�			�֐���			����				��Ɨp�o�b�t�@
+//	機能番号			関数名			引数				作業用バッファ
 
-	/* �t�@�C������n */
-	{F_FILENEW,						LTEXT("FileNew"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�V�K�쐬
-	// {F_FILEOPEN,					LTEXT("FileOpen"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J��
-	{F_FILEOPEN2,					LTEXT("FileOpen"),				{VT_BSTR,  VT_I4,    VT_I4,    VT_BSTR},	VT_EMPTY,	NULL}, //�J��2
-	{F_FILESAVE,					LTEXT("FileSave"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�㏑���ۑ�
-	{F_FILESAVEALL,					LTEXT("FileSaveAll"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�㏑���ۑ�
-	{F_FILESAVEAS_DIALOG,			LTEXT("FileSaveAsDialog"),		{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //���O��t���ĕۑ�(�_�C�A���O) 2013.05.02
-	{F_FILESAVEAS,					LTEXT("FileSaveAs"),			{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //���O��t���ĕۑ�
-	{F_FILECLOSE,					LTEXT("FileClose"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //����(����)	//Oct. 17, 2000 jepro �u�t�@�C�������v�Ƃ����L���v�V������ύX
-	{F_FILECLOSE_OPEN,				LTEXT("FileCloseOpen"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���ĊJ��
-	{F_FILE_REOPEN,					LTEXT("FileReopen"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J������	//Dec. 4, 2002 genta
-	{F_FILE_REOPEN_SJIS,			LTEXT("FileReopenSJIS"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //SJIS�ŊJ������
-	{F_FILE_REOPEN_JIS,				LTEXT("FileReopenJIS"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //JIS�ŊJ������
-	{F_FILE_REOPEN_EUC,				LTEXT("FileReopenEUC"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //EUC�ŊJ������
-	{F_FILE_REOPEN_LATIN1,			LTEXT("FileReopenLatin1"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Latin1�ŊJ������	// 2010/3/20 Uchi
-	{F_FILE_REOPEN_UNICODE,			LTEXT("FileReopenUNICODE"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Unicode�ŊJ������
-	{F_FILE_REOPEN_UNICODEBE,		LTEXT("FileReopenUNICODEBE"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //UnicodeBE�ŊJ������
-	{F_FILE_REOPEN_UTF8,			LTEXT("FileReopenUTF8"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //UTF-8�ŊJ������
-	{F_FILE_REOPEN_CESU8,			LTEXT("FileReopenCESU8"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //CESU-8�ŊJ������
-	{F_FILE_REOPEN_UTF7,			LTEXT("FileReopenUTF7"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //UTF-7�ŊJ������
-	{F_PRINT,						LTEXT("Print"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���
-//	{F_PRINT_DIALOG,				LTEXT("PrintDialog"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //����_�C�A���O
-	{F_PRINT_PREVIEW,				LTEXT("PrintPreview"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //����v���r���[
-	{F_PRINT_PAGESETUP,				LTEXT("PrintPageSetup"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //����y�[�W�ݒ�	//Sept. 14, 2000 jepro �u����̃y�[�W���C�A�E�g�̐ݒ�v����ύX
-	{F_OPEN_HfromtoC,				LTEXT("OpenHfromtoC"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //������C/C++�w�b�_(�\�[�X)���J��	//Feb. 7, 2001 JEPRO �ǉ�
-//	{F_OPEN_HHPP,					LTEXT("OpenHHpp"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //������C/C++�w�b�_�t�@�C�����J��	//Feb. 9, 2001 jepro�u.c�܂���.cpp�Ɠ�����.h���J���v����ύX		del 2008/6/23 Uchi
-//	{F_OPEN_CCPP,					LTEXT("OpenCCpp"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //������C/C++�\�[�X�t�@�C�����J��	//Feb. 9, 2001 jepro�u.h�Ɠ�����.c(�Ȃ����.cpp)���J���v����ύX	del 2008/6/23 Uchi
-	{F_ACTIVATE_SQLPLUS,			LTEXT("ActivateSQLPLUS"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* Oracle SQL*Plus���A�N�e�B�u�\�� */
-	{F_PLSQL_COMPILE_ON_SQLPLUS,	LTEXT("ExecSQLPLUS"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* Oracle SQL*Plus�Ŏ��s */
-	{F_BROWSE,						LTEXT("Browse"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�u���E�Y
-	{F_VIEWMODE,					LTEXT("ViewMode"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�r���[���[�h
-	{F_VIEWMODE,					LTEXT("ReadOnly"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�r���[���[�h(��)
-	{F_PROPERTY_FILE,				LTEXT("PropertyFile"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�t�@�C���̃v���p�e�B
-	{F_EXITALLEDITORS,				LTEXT("ExitAllEditors"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�ҏW�̑S�I��	// 2007.02.13 ryoji �ǉ�
-	{F_EXITALL,						LTEXT("ExitAll"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�T�N���G�f�B�^�̑S�I��	//Dec. 27, 2000 JEPRO �ǉ�
-	{F_PUTFILE,						LTEXT("PutFile"),				{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},   VT_EMPTY,	NULL}, // ��ƒ��t�@�C���̈ꎞ�o�� 2006.12.10 maru
-	{F_INSFILE,						LTEXT("InsFile"),				{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},   VT_EMPTY,	NULL}, // �L�����b�g�ʒu�Ƀt�@�C���}�� 2006.12.10 maru
+	/* ファイル操作系 */
+	{F_FILENEW,						LTEXT("FileNew"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //新規作成
+	// {F_FILEOPEN,					LTEXT("FileOpen"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //開く
+	{F_FILEOPEN2,					LTEXT("FileOpen"),				{VT_BSTR,  VT_I4,    VT_I4,    VT_BSTR},	VT_EMPTY,	NULL}, //開く2
+	{F_FILESAVE,					LTEXT("FileSave"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //上書き保存
+	{F_FILESAVEALL,					LTEXT("FileSaveAll"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //上書き保存
+	{F_FILESAVEAS_DIALOG,			LTEXT("FileSaveAsDialog"),		{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //名前を付けて保存(ダイアログ) 2013.05.02
+	{F_FILESAVEAS,					LTEXT("FileSaveAs"),			{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //名前を付けて保存
+	{F_FILECLOSE,					LTEXT("FileClose"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //閉じて(無題)	//Oct. 17, 2000 jepro 「ファイルを閉じる」というキャプションを変更
+	{F_FILECLOSE_OPEN,				LTEXT("FileCloseOpen"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //閉じて開く
+	{F_FILE_REOPEN,					LTEXT("FileReopen"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //開き直す	//Dec. 4, 2002 genta
+	{F_FILE_REOPEN_SJIS,			LTEXT("FileReopenSJIS"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //SJISで開き直す
+	{F_FILE_REOPEN_JIS,				LTEXT("FileReopenJIS"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //JISで開き直す
+	{F_FILE_REOPEN_EUC,				LTEXT("FileReopenEUC"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //EUCで開き直す
+	{F_FILE_REOPEN_LATIN1,			LTEXT("FileReopenLatin1"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Latin1で開き直す	// 2010/3/20 Uchi
+	{F_FILE_REOPEN_UNICODE,			LTEXT("FileReopenUNICODE"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Unicodeで開き直す
+	{F_FILE_REOPEN_UNICODEBE,		LTEXT("FileReopenUNICODEBE"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //UnicodeBEで開き直す
+	{F_FILE_REOPEN_UTF8,			LTEXT("FileReopenUTF8"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //UTF-8で開き直す
+	{F_FILE_REOPEN_CESU8,			LTEXT("FileReopenCESU8"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //CESU-8で開き直す
+	{F_FILE_REOPEN_UTF7,			LTEXT("FileReopenUTF7"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //UTF-7で開き直す
+	{F_PRINT,						LTEXT("Print"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //印刷
+//	{F_PRINT_DIALOG,				LTEXT("PrintDialog"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //印刷ダイアログ
+	{F_PRINT_PREVIEW,				LTEXT("PrintPreview"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //印刷プレビュー
+	{F_PRINT_PAGESETUP,				LTEXT("PrintPageSetup"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //印刷ページ設定	//Sept. 14, 2000 jepro 「印刷のページレイアウトの設定」から変更
+	{F_OPEN_HfromtoC,				LTEXT("OpenHfromtoC"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //同名のC/C++ヘッダ(ソース)を開く	//Feb. 7, 2001 JEPRO 追加
+//	{F_OPEN_HHPP,					LTEXT("OpenHHpp"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //同名のC/C++ヘッダファイルを開く	//Feb. 9, 2001 jepro「.cまたは.cppと同名の.hを開く」から変更		del 2008/6/23 Uchi
+//	{F_OPEN_CCPP,					LTEXT("OpenCCpp"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //同名のC/C++ソースファイルを開く	//Feb. 9, 2001 jepro「.hと同名の.c(なければ.cpp)を開く」から変更	del 2008/6/23 Uchi
+	{F_ACTIVATE_SQLPLUS,			LTEXT("ActivateSQLPLUS"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* Oracle SQL*Plusをアクティブ表示 */
+	{F_PLSQL_COMPILE_ON_SQLPLUS,	LTEXT("ExecSQLPLUS"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* Oracle SQL*Plusで実行 */
+	{F_BROWSE,						LTEXT("Browse"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ブラウズ
+	{F_VIEWMODE,					LTEXT("ViewMode"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ビューモード
+	{F_VIEWMODE,					LTEXT("ReadOnly"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ビューモード(旧)
+	{F_PROPERTY_FILE,				LTEXT("PropertyFile"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ファイルのプロパティ
+	{F_EXITALLEDITORS,				LTEXT("ExitAllEditors"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //編集の全終了	// 2007.02.13 ryoji 追加
+	{F_EXITALL,						LTEXT("ExitAll"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //サクラエディタの全終了	//Dec. 27, 2000 JEPRO 追加
+	{F_PUTFILE,						LTEXT("PutFile"),				{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},   VT_EMPTY,	NULL}, // 作業中ファイルの一時出力 2006.12.10 maru
+	{F_INSFILE,						LTEXT("InsFile"),				{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},   VT_EMPTY,	NULL}, // キャレット位置にファイル挿入 2006.12.10 maru
 
-	/* �ҏW�n */
-	{F_WCHAR,				LTEXT("Char"),					{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //��������
-	{F_IME_CHAR,			LTEXT("CharIme"),				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�S�p��������
-	{F_UNDO,				LTEXT("Undo"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���ɖ߂�(Undo)
-	{F_REDO,				LTEXT("Redo"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //��蒼��(Redo)
-	{F_DELETE,				LTEXT("Delete"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�폜
-	{F_DELETE_BACK,			LTEXT("DeleteBack"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\���O���폜
-	{F_WordDeleteToStart,	LTEXT("WordDeleteToStart"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P��̍��[�܂ō폜
-	{F_WordDeleteToEnd,		LTEXT("WordDeleteToEnd"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P��̉E�[�܂ō폜
-	{F_WordCut,				LTEXT("WordCut"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P��؂���
-	{F_WordDelete,			LTEXT("WordDelete"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P��폜
-	{F_LineCutToStart,		LTEXT("LineCutToStart"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�s���܂Ő؂���(���s�P��)
-	{F_LineCutToEnd,		LTEXT("LineCutToEnd"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�s���܂Ő؂���(���s�P��)
-	{F_LineDeleteToStart,	LTEXT("LineDeleteToStart"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�s���܂ō폜(���s�P��)
-	{F_LineDeleteToEnd,		LTEXT("LineDeleteToEnd"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�s���܂ō폜(���s�P��)
-	{F_CUT_LINE,			LTEXT("CutLine"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�s�؂���(�܂�Ԃ��P��)
-	{F_DELETE_LINE,			LTEXT("DeleteLine"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�s�폜(�܂�Ԃ��P��)
-	{F_DUPLICATELINE,		LTEXT("DuplicateLine"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�s�̓�d��(�܂�Ԃ��P��)
-	{F_INDENT_TAB,			LTEXT("IndentTab"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //TAB�C���f���g
-	{F_UNINDENT_TAB,		LTEXT("UnindentTab"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�tTAB�C���f���g
-	{F_INDENT_SPACE,		LTEXT("IndentSpace"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //SPACE�C���f���g
-	{F_UNINDENT_SPACE,		LTEXT("UnindentSpace"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�tSPACE�C���f���g
-//	{F_WORDSREFERENCE,		LTEXT("WordReference"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P�ꃊ�t�@�����X
-	{F_LTRIM,				LTEXT("LTrim"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //��(�擪)�̋󔒂��폜 2001.12.03 hor
-	{F_RTRIM,				LTEXT("RTrim"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�E(����)�̋󔒂��폜 2001.12.03 hor
-	{F_SORT_ASC,			LTEXT("SortAsc"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�I���s�̏����\�[�g 2001.12.06 hor
-	{F_SORT_DESC,			LTEXT("SortDesc"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�I���s�̍~���\�[�g 2001.12.06 hor
-	{F_MERGE,				LTEXT("Merge"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�I���s�̃}�[�W 2001.12.06 hor
+	/* 編集系 */
+	{F_WCHAR,				LTEXT("Char"),					{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //文字入力
+	{F_IME_CHAR,			LTEXT("CharIme"),				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //全角文字入力
+	{F_UNDO,				LTEXT("Undo"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //元に戻す(Undo)
+	{F_REDO,				LTEXT("Redo"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //やり直し(Redo)
+	{F_DELETE,				LTEXT("Delete"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //削除
+	{F_DELETE_BACK,			LTEXT("DeleteBack"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル前を削除
+	{F_WordDeleteToStart,	LTEXT("WordDeleteToStart"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //単語の左端まで削除
+	{F_WordDeleteToEnd,		LTEXT("WordDeleteToEnd"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //単語の右端まで削除
+	{F_WordCut,				LTEXT("WordCut"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //単語切り取り
+	{F_WordDelete,			LTEXT("WordDelete"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //単語削除
+	{F_LineCutToStart,		LTEXT("LineCutToStart"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //行頭まで切り取り(改行単位)
+	{F_LineCutToEnd,		LTEXT("LineCutToEnd"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //行末まで切り取り(改行単位)
+	{F_LineDeleteToStart,	LTEXT("LineDeleteToStart"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //行頭まで削除(改行単位)
+	{F_LineDeleteToEnd,		LTEXT("LineDeleteToEnd"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //行末まで削除(改行単位)
+	{F_CUT_LINE,			LTEXT("CutLine"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //行切り取り(折り返し単位)
+	{F_DELETE_LINE,			LTEXT("DeleteLine"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //行削除(折り返し単位)
+	{F_DUPLICATELINE,		LTEXT("DuplicateLine"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //行の二重化(折り返し単位)
+	{F_INDENT_TAB,			LTEXT("IndentTab"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //TABインデント
+	{F_UNINDENT_TAB,		LTEXT("UnindentTab"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //逆TABインデント
+	{F_INDENT_SPACE,		LTEXT("IndentSpace"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //SPACEインデント
+	{F_UNINDENT_SPACE,		LTEXT("UnindentSpace"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //逆SPACEインデント
+//	{F_WORDSREFERENCE,		LTEXT("WordReference"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //単語リファレンス
+	{F_LTRIM,				LTEXT("LTrim"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //左(先頭)の空白を削除 2001.12.03 hor
+	{F_RTRIM,				LTEXT("RTrim"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //右(末尾)の空白を削除 2001.12.03 hor
+	{F_SORT_ASC,			LTEXT("SortAsc"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //選択行の昇順ソート 2001.12.06 hor
+	{F_SORT_DESC,			LTEXT("SortDesc"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //選択行の降順ソート 2001.12.06 hor
+	{F_MERGE,				LTEXT("Merge"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //選択行のマージ 2001.12.06 hor
 
-	/* �J�[�\���ړ��n */
-	{F_UP,					LTEXT("Up"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\����ړ�
-	{F_DOWN,				LTEXT("Down"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\�����ړ�
-	{F_LEFT,				LTEXT("Left"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\�����ړ�
-	{F_RIGHT,				LTEXT("Right"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\���E�ړ�
-	{F_UP2,					LTEXT("Up2"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\����ړ�(�Q�s����)
-	{F_DOWN2,				LTEXT("Down2"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\�����ړ�(�Q�s����)
-	{F_WORDLEFT,			LTEXT("WordLeft"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P��̍��[�Ɉړ�
-	{F_WORDRIGHT,			LTEXT("WordRight"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P��̉E�[�Ɉړ�
-	{F_GOLINETOP,			LTEXT("GoLineTop"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�s���Ɉړ�(�܂�Ԃ��P��/���s�P��)
-	{F_GOLINEEND,			LTEXT("GoLineEnd"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�s���Ɉړ�(�܂�Ԃ��P��)
-	{F_HalfPageUp,			LTEXT("HalfPageUp"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���y�[�W�A�b�v	//Oct. 6, 2000 JEPRO ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-	{F_HalfPageDown,		LTEXT("HalfPageDown"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���y�[�W�_�E��	//Oct. 6, 2000 JEPRO ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-	{F_1PageUp,				LTEXT("PageUp"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P�y�[�W�A�b�v	//Oct. 10, 2000 JEPRO �]���̃y�[�W�A�b�v�𔼃y�[�W�A�b�v�Ɩ��̕ύX���P�y�[�W�A�b�v��ǉ�
-	{F_1PageUp,				LTEXT("1PageUp"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P�y�[�W�A�b�v	//Oct. 10, 2000 JEPRO �]���̃y�[�W�A�b�v�𔼃y�[�W�A�b�v�Ɩ��̕ύX���P�y�[�W�A�b�v��ǉ�
-	{F_1PageDown,			LTEXT("PageDown"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P�y�[�W�_�E��	//Oct. 10, 2000 JEPRO �]���̃y�[�W�_�E���𔼃y�[�W�_�E���Ɩ��̕ύX���P�y�[�W�_�E����ǉ�
-	{F_1PageDown,			LTEXT("1PageDown"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�P�y�[�W�_�E��	//Oct. 10, 2000 JEPRO �]���̃y�[�W�_�E���𔼃y�[�W�_�E���Ɩ��̕ύX���P�y�[�W�_�E����ǉ�
-	{F_GOFILETOP,			LTEXT("GoFileTop"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�t�@�C���̐擪�Ɉړ�
-	{F_GOFILEEND,			LTEXT("GoFileEnd"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�t�@�C���̍Ō�Ɉړ�
-	{F_CURLINECENTER,		LTEXT("CurLineCenter"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\���s���E�B���h�E������
-	{F_JUMPHIST_PREV,		LTEXT("MoveHistPrev"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�ړ�����: �O��
-	{F_JUMPHIST_NEXT,		LTEXT("MoveHistNext"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�ړ�����: ����
-	{F_JUMPHIST_SET,		LTEXT("MoveHistSet"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���݈ʒu���ړ������ɓo�^
-	{F_WndScrollDown,		LTEXT("F_WndScrollDown"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�e�L�X�g���P�s���փX�N���[��	// 2001/06/20 asa-o
-	{F_WndScrollUp,			LTEXT("F_WndScrollUp"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�e�L�X�g���P�s��փX�N���[��	// 2001/06/20 asa-o
-	{F_GONEXTPARAGRAPH,		LTEXT("GoNextParagraph"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̒i���ֈړ�
-	{F_GOPREVPARAGRAPH,		LTEXT("GoPrevParagraph"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O�̒i���ֈړ�
-	{F_MODIFYLINE_NEXT,		LTEXT("GoModifyLineNext"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̕ύX�s�ֈړ�
-	{F_MODIFYLINE_PREV,		LTEXT("GoModifyLinePrev"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O�̕ύX�s�ֈړ�
-	{F_MOVECURSOR,			LTEXT("MoveCursor"),		{VT_I4,    VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\���ړ�
-	{F_MOVECURSORLAYOUT,	LTEXT("MoveCursorLayout"),	{VT_I4,    VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //�J�[�\���ړ�(���C�A�E�g�P��)
-	{F_WHEELUP,				LTEXT("WheelUp"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�z�C�[���A�b�v
-	{F_WHEELDOWN,			LTEXT("WheelDown"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�z�C�[���_�E��
-	{F_WHEELLEFT,			LTEXT("WheelLeft"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�z�C�[����
-	{F_WHEELRIGHT,			LTEXT("WheelRight"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�z�C�[���E
-	{F_WHEELPAGEUP,			LTEXT("WheelPageUp"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�z�C�[���y�[�W�A�b�v
-	{F_WHEELPAGEDOWN,		LTEXT("WheelPageDown"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�z�C�[���y�[�W�_�E��
-	{F_WHEELPAGELEFT,		LTEXT("WheelPageLeft"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�z�C�[���y�[�W��
-	{F_WHEELPAGERIGHT,		LTEXT("WheelPageRight"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�z�C�[���y�[�W�E
+	/* カーソル移動系 */
+	{F_UP,					LTEXT("Up"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル上移動
+	{F_DOWN,				LTEXT("Down"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル下移動
+	{F_LEFT,				LTEXT("Left"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル左移動
+	{F_RIGHT,				LTEXT("Right"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル右移動
+	{F_UP2,					LTEXT("Up2"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル上移動(２行ごと)
+	{F_DOWN2,				LTEXT("Down2"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル下移動(２行ごと)
+	{F_WORDLEFT,			LTEXT("WordLeft"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //単語の左端に移動
+	{F_WORDRIGHT,			LTEXT("WordRight"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //単語の右端に移動
+	{F_GOLINETOP,			LTEXT("GoLineTop"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //行頭に移動(折り返し単位/改行単位)
+	{F_GOLINEEND,			LTEXT("GoLineEnd"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //行末に移動(折り返し単位)
+	{F_HalfPageUp,			LTEXT("HalfPageUp"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //半ページアップ	//Oct. 6, 2000 JEPRO 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+	{F_HalfPageDown,		LTEXT("HalfPageDown"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //半ページダウン	//Oct. 6, 2000 JEPRO 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+	{F_1PageUp,				LTEXT("PageUp"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //１ページアップ	//Oct. 10, 2000 JEPRO 従来のページアップを半ページアップと名称変更し１ページアップを追加
+	{F_1PageUp,				LTEXT("1PageUp"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //１ページアップ	//Oct. 10, 2000 JEPRO 従来のページアップを半ページアップと名称変更し１ページアップを追加
+	{F_1PageDown,			LTEXT("PageDown"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //１ページダウン	//Oct. 10, 2000 JEPRO 従来のページダウンを半ページダウンと名称変更し１ページダウンを追加
+	{F_1PageDown,			LTEXT("1PageDown"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //１ページダウン	//Oct. 10, 2000 JEPRO 従来のページダウンを半ページダウンと名称変更し１ページダウンを追加
+	{F_GOFILETOP,			LTEXT("GoFileTop"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ファイルの先頭に移動
+	{F_GOFILEEND,			LTEXT("GoFileEnd"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ファイルの最後に移動
+	{F_CURLINECENTER,		LTEXT("CurLineCenter"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル行をウィンドウ中央へ
+	{F_JUMPHIST_PREV,		LTEXT("MoveHistPrev"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //移動履歴: 前へ
+	{F_JUMPHIST_NEXT,		LTEXT("MoveHistNext"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //移動履歴: 次へ
+	{F_JUMPHIST_SET,		LTEXT("MoveHistSet"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //現在位置を移動履歴に登録
+	{F_WndScrollDown,		LTEXT("F_WndScrollDown"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //テキストを１行下へスクロール	// 2001/06/20 asa-o
+	{F_WndScrollUp,			LTEXT("F_WndScrollUp"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //テキストを１行上へスクロール	// 2001/06/20 asa-o
+	{F_GONEXTPARAGRAPH,		LTEXT("GoNextParagraph"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //次の段落へ移動
+	{F_GOPREVPARAGRAPH,		LTEXT("GoPrevParagraph"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //前の段落へ移動
+	{F_MODIFYLINE_NEXT,		LTEXT("GoModifyLineNext"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //次の変更行へ移動
+	{F_MODIFYLINE_PREV,		LTEXT("GoModifyLinePrev"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //前の変更行へ移動
+	{F_MOVECURSOR,			LTEXT("MoveCursor"),		{VT_I4,    VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル移動
+	{F_MOVECURSORLAYOUT,	LTEXT("MoveCursorLayout"),	{VT_I4,    VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //カーソル移動(レイアウト単位)
+	{F_WHEELUP,				LTEXT("WheelUp"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ホイールアップ
+	{F_WHEELDOWN,			LTEXT("WheelDown"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ホイールダウン
+	{F_WHEELLEFT,			LTEXT("WheelLeft"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ホイール左
+	{F_WHEELRIGHT,			LTEXT("WheelRight"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ホイール右
+	{F_WHEELPAGEUP,			LTEXT("WheelPageUp"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ホイールページアップ
+	{F_WHEELPAGEDOWN,		LTEXT("WheelPageDown"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ホイールページダウン
+	{F_WHEELPAGELEFT,		LTEXT("WheelPageLeft"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ホイールページ左
+	{F_WHEELPAGERIGHT,		LTEXT("WheelPageRight"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ホイールページ右
 
-	/* �I���n */	//Oct. 15, 2000 JEPRO �u�J�[�\���ړ��n�v�������Ȃ����̂Łu�I���n�v�Ƃ��ēƗ���(�T�u���j���[���͍\����ł��Ȃ��̂�)
-	{F_SELECTWORD,			LTEXT("SelectWord"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���݈ʒu�̒P��I��
-	{F_SELECTALL,			LTEXT("SelectAll"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���ׂđI��
-	{F_SELECTLINE,			LTEXT("SelectLine"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //1�s�I��	// 2007.10.13 nasukoji
-	{F_BEGIN_SEL,			LTEXT("BeginSelect"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�͈͑I���J�n Mar. 5, 2001 genta ���̏C��
-	{F_UP_SEL,				LTEXT("Up_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�J�[�\����ړ�
-	{F_DOWN_SEL,			LTEXT("Down_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�J�[�\�����ړ�
-	{F_LEFT_SEL,			LTEXT("Left_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�J�[�\�����ړ�
-	{F_RIGHT_SEL,			LTEXT("Right_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�J�[�\���E�ړ�
-	{F_UP2_SEL,				LTEXT("Up2_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�J�[�\����ړ�(�Q�s����)
-	{F_DOWN2_SEL,			LTEXT("Down2_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�J�[�\�����ړ�(�Q�s����)
-	{F_WORDLEFT_SEL,		LTEXT("WordLeft_Sel"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�P��̍��[�Ɉړ�
-	{F_WORDRIGHT_SEL,		LTEXT("WordRight_Sel"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�P��̉E�[�Ɉړ�
-	{F_GOLINETOP_SEL,		LTEXT("GoLineTop_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�s���Ɉړ�(�܂�Ԃ��P��/���s�P��)
-	{F_GOLINEEND_SEL,		LTEXT("GoLineEnd_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�s���Ɉړ�(�܂�Ԃ��P��)
-	{F_HalfPageUp_Sel,		LTEXT("HalfPageUp_Sel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)���y�[�W�A�b�v	//Oct. 6, 2000 JEPRO ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-	{F_HalfPageDown_Sel,	LTEXT("HalfPageDown_Sel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)���y�[�W�_�E��	//Oct. 6, 2000 JEPRO ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-	{F_1PageUp_Sel,			LTEXT("PageUp_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�P�y�[�W�A�b�v	//Oct. 10, 2000 JEPRO �]���̃y�[�W�A�b�v�𔼃y�[�W�A�b�v�Ɩ��̕ύX���P�y�[�W�A�b�v��ǉ�
-	{F_1PageUp_Sel,			LTEXT("1PageUp_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�P�y�[�W�A�b�v	//Oct. 10, 2000 JEPRO �]���̃y�[�W�A�b�v�𔼃y�[�W�A�b�v�Ɩ��̕ύX���P�y�[�W�A�b�v��ǉ�
-	{F_1PageDown_Sel,		LTEXT("PageDown_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�P�y�[�W�_�E��	//Oct. 10, 2000 JEPRO �]���̃y�[�W�_�E���𔼃y�[�W�_�E���Ɩ��̕ύX���P�y�[�W�_�E����ǉ�
-	{F_1PageDown_Sel,		LTEXT("1PageDown_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�P�y�[�W�_�E��	//Oct. 10, 2000 JEPRO �]���̃y�[�W�_�E���𔼃y�[�W�_�E���Ɩ��̕ύX���P�y�[�W�_�E����ǉ�
-	{F_GOFILETOP_SEL,		LTEXT("GoFileTop_Sel"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�t�@�C���̐擪�Ɉړ�
-	{F_GOFILEEND_SEL,		LTEXT("GoFileEnd_Sel"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�t�@�C���̍Ō�Ɉړ�
-	{F_GONEXTPARAGRAPH_SEL,	LTEXT("GoNextParagraph_Sel"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)���̒i���ֈړ�
-	{F_GOPREVPARAGRAPH_SEL,	LTEXT("GoPrevParagraph_Sel"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�O�̒i���ֈړ�
-	{F_MODIFYLINE_NEXT_SEL,	LTEXT("GoModifyLineNext_Sel"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)���̕ύX�s�ֈړ�
-	{F_MODIFYLINE_PREV_SEL,	LTEXT("GoModifyLinePrev_Sel"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(�͈͑I��)�O�̕ύX�s�ֈړ�
+	/* 選択系 */	//Oct. 15, 2000 JEPRO 「カーソル移動系」が多くなったので「選択系」として独立化(サブメニュー化は構造上できないので)
+	{F_SELECTWORD,			LTEXT("SelectWord"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //現在位置の単語選択
+	{F_SELECTALL,			LTEXT("SelectAll"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //すべて選択
+	{F_SELECTLINE,			LTEXT("SelectLine"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //1行選択	// 2007.10.13 nasukoji
+	{F_BEGIN_SEL,			LTEXT("BeginSelect"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //範囲選択開始 Mar. 5, 2001 genta 名称修正
+	{F_UP_SEL,				LTEXT("Up_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)カーソル上移動
+	{F_DOWN_SEL,			LTEXT("Down_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)カーソル下移動
+	{F_LEFT_SEL,			LTEXT("Left_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)カーソル左移動
+	{F_RIGHT_SEL,			LTEXT("Right_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)カーソル右移動
+	{F_UP2_SEL,				LTEXT("Up2_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)カーソル上移動(２行ごと)
+	{F_DOWN2_SEL,			LTEXT("Down2_Sel"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)カーソル下移動(２行ごと)
+	{F_WORDLEFT_SEL,		LTEXT("WordLeft_Sel"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)単語の左端に移動
+	{F_WORDRIGHT_SEL,		LTEXT("WordRight_Sel"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)単語の右端に移動
+	{F_GOLINETOP_SEL,		LTEXT("GoLineTop_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)行頭に移動(折り返し単位/改行単位)
+	{F_GOLINEEND_SEL,		LTEXT("GoLineEnd_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)行末に移動(折り返し単位)
+	{F_HalfPageUp_Sel,		LTEXT("HalfPageUp_Sel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)半ページアップ	//Oct. 6, 2000 JEPRO 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+	{F_HalfPageDown_Sel,	LTEXT("HalfPageDown_Sel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)半ページダウン	//Oct. 6, 2000 JEPRO 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+	{F_1PageUp_Sel,			LTEXT("PageUp_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)１ページアップ	//Oct. 10, 2000 JEPRO 従来のページアップを半ページアップと名称変更し１ページアップを追加
+	{F_1PageUp_Sel,			LTEXT("1PageUp_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)１ページアップ	//Oct. 10, 2000 JEPRO 従来のページアップを半ページアップと名称変更し１ページアップを追加
+	{F_1PageDown_Sel,		LTEXT("PageDown_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)１ページダウン	//Oct. 10, 2000 JEPRO 従来のページダウンを半ページダウンと名称変更し１ページダウンを追加
+	{F_1PageDown_Sel,		LTEXT("1PageDown_Sel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)１ページダウン	//Oct. 10, 2000 JEPRO 従来のページダウンを半ページダウンと名称変更し１ページダウンを追加
+	{F_GOFILETOP_SEL,		LTEXT("GoFileTop_Sel"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)ファイルの先頭に移動
+	{F_GOFILEEND_SEL,		LTEXT("GoFileEnd_Sel"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)ファイルの最後に移動
+	{F_GONEXTPARAGRAPH_SEL,	LTEXT("GoNextParagraph_Sel"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)次の段落へ移動
+	{F_GOPREVPARAGRAPH_SEL,	LTEXT("GoPrevParagraph_Sel"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)前の段落へ移動
+	{F_MODIFYLINE_NEXT_SEL,	LTEXT("GoModifyLineNext_Sel"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)次の変更行へ移動
+	{F_MODIFYLINE_PREV_SEL,	LTEXT("GoModifyLinePrev_Sel"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(範囲選択)前の変更行へ移動
 
-	/* ��`�I���n */	//Oct. 17, 2000 JEPRO (��`�I��)���V�݂��ꎟ�悱���ɂ���
-	{F_BEGIN_BOX,			LTEXT("BeginBoxSelect"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //��`�͈͑I���J�n
-	{F_UP_BOX,				LTEXT("Up_BoxSel"),				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�J�[�\����ړ�
-	{F_DOWN_BOX,			LTEXT("Down_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�J�[�\�����ړ�
-	{F_LEFT_BOX,			LTEXT("Left_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�J�[�\�����ړ�
-	{F_RIGHT_BOX,			LTEXT("Right_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�J�[�\���E�ړ�
-	{F_UP2_BOX,				LTEXT("Up2_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�J�[�\����ړ�(�Q�s����)
-	{F_DOWN2_BOX,			LTEXT("Down2_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�J�[�\�����ړ�(�Q�s����)
-	{F_WORDLEFT_BOX,		LTEXT("WordLeft_BoxSel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�P��̍��[�Ɉړ�
-	{F_WORDRIGHT_BOX,		LTEXT("WordRight_BoxSel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�P��̉E�[�Ɉړ�
-	{F_GOLOGICALLINETOP_BOX,LTEXT("GoLogicalLineTop_BoxSel"),{VT_I4,   VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�s���Ɉړ�(���s�P��)
-	{F_GOLINETOP_BOX,		LTEXT("GoLineTop_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�s���Ɉړ�(�܂�Ԃ��P��/���s�P��)
-	{F_GOLINEEND_BOX,		LTEXT("GoLineEnd_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�s���Ɉړ�(�܂�Ԃ��P��)
-	{F_HalfPageUp_BOX,		LTEXT("HalfPageUp_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)���y�[�W�A�b�v
-	{F_HalfPageDown_BOX,	LTEXT("HalfPageDown_BoxSel"),	{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)���y�[�W�_�E��
-	{F_1PageUp_BOX,			LTEXT("PageUp_BoxSel"),			{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�P�y�[�W�A�b�v
-	{F_1PageUp_BOX,			LTEXT("1PageUp_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�P�y�[�W�A�b�v
-	{F_1PageDown_BOX,		LTEXT("PageDown_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�P�y�[�W�_�E��
-	{F_1PageDown_BOX,		LTEXT("1PageDown_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�P�y�[�W�_�E��
-	{F_GOFILETOP_BOX,		LTEXT("GoFileTop_BoxSel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�t�@�C���̐擪�Ɉړ�
-	{F_GOFILEEND_BOX,		LTEXT("GoFileEnd_BoxSel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(��`�I��)�t�@�C���̍Ō�Ɉړ�
+	/* 矩形選択系 */	//Oct. 17, 2000 JEPRO (矩形選択)が新設され次第ここにおく
+	{F_BEGIN_BOX,			LTEXT("BeginBoxSelect"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //矩形範囲選択開始
+	{F_UP_BOX,				LTEXT("Up_BoxSel"),				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)カーソル上移動
+	{F_DOWN_BOX,			LTEXT("Down_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)カーソル下移動
+	{F_LEFT_BOX,			LTEXT("Left_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)カーソル左移動
+	{F_RIGHT_BOX,			LTEXT("Right_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)カーソル右移動
+	{F_UP2_BOX,				LTEXT("Up2_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)カーソル上移動(２行ごと)
+	{F_DOWN2_BOX,			LTEXT("Down2_BoxSel"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)カーソル下移動(２行ごと)
+	{F_WORDLEFT_BOX,		LTEXT("WordLeft_BoxSel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)単語の左端に移動
+	{F_WORDRIGHT_BOX,		LTEXT("WordRight_BoxSel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)単語の右端に移動
+	{F_GOLOGICALLINETOP_BOX,LTEXT("GoLogicalLineTop_BoxSel"),{VT_I4,   VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)行頭に移動(改行単位)
+	{F_GOLINETOP_BOX,		LTEXT("GoLineTop_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)行頭に移動(折り返し単位/改行単位)
+	{F_GOLINEEND_BOX,		LTEXT("GoLineEnd_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)行末に移動(折り返し単位)
+	{F_HalfPageUp_BOX,		LTEXT("HalfPageUp_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)半ページアップ
+	{F_HalfPageDown_BOX,	LTEXT("HalfPageDown_BoxSel"),	{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)半ページダウン
+	{F_1PageUp_BOX,			LTEXT("PageUp_BoxSel"),			{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)１ページアップ
+	{F_1PageUp_BOX,			LTEXT("1PageUp_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)１ページアップ
+	{F_1PageDown_BOX,		LTEXT("PageDown_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)１ページダウン
+	{F_1PageDown_BOX,		LTEXT("1PageDown_BoxSel"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)１ページダウン
+	{F_GOFILETOP_BOX,		LTEXT("GoFileTop_BoxSel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)ファイルの先頭に移動
+	{F_GOFILEEND_BOX,		LTEXT("GoFileEnd_BoxSel"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //(矩形選択)ファイルの最後に移動
 
-	/* �N���b�v�{�[�h�n */
-	{F_CUT,						LTEXT("Cut"),						{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�؂���(�I��͈͂��N���b�v�{�[�h�ɃR�s�[���č폜)
-	{F_COPY,					LTEXT("Copy"),						{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�R�s�[(�I��͈͂��N���b�v�{�[�h�ɃR�s�[)
-	{F_PASTE,					LTEXT("Paste"),						{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�\��t��(�N���b�v�{�[�h����\��t��)
-	{F_COPY_ADDCRLF,			LTEXT("CopyAddCRLF"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�܂�Ԃ��ʒu�ɉ��s�����ăR�s�[
-	{F_COPY_CRLF,				LTEXT("CopyCRLF"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //CRLF���s�ŃR�s�[(�I��͈͂����s�R�[�h=CRLF�ŃR�s�[)
-	{F_PASTEBOX,				LTEXT("PasteBox"),					{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //��`�\��t��(�N���b�v�{�[�h�����`�\��t��)
-	{F_INSBOXTEXT,				LTEXT("InsBoxText"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // ��`�e�L�X�g�}��
-	{F_INSTEXT_W,				LTEXT("InsText"),					{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // �e�L�X�g��\��t��
-	{F_ADDTAIL_W,				LTEXT("AddTail"),					{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // �Ō�Ƀe�L�X�g��ǉ�
-	{F_COPYLINES,				LTEXT("CopyLines"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�I��͈͓��S�s�R�s�[
-	{F_COPYLINESASPASSAGE,		LTEXT("CopyLinesAsPassage"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�I��͈͓��S�s���p���t���R�s�[
-	{F_COPYLINESWITHLINENUMBER,	LTEXT("CopyLinesWithLineNumber"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�I��͈͓��S�s�s�ԍ��t���R�s�[
-	{F_COPY_COLOR_HTML,			LTEXT("CopyColorHtml"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�I��͈͓��F�t��HTML�R�s�[
-	{F_COPY_COLOR_HTML_LINENUMBER,	LTEXT("CopyColorHtmlWithLineNumber"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�I��͈͓��s�ԍ��F�t��HTML�R�s�[
-	{F_COPYPATH,				LTEXT("CopyPath"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̃t�@�C���̃p�X�����N���b�v�{�[�h�ɃR�s�[
-	{F_COPYFNAME,				LTEXT("CopyFilename"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̃t�@�C�������N���b�v�{�[�h�ɃR�s�[ // 2002/2/3 aroka
-	{F_COPYTAG,					LTEXT("CopyTag"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̃t�@�C���̃p�X���ƃJ�[�\���ʒu���R�s�[	//Sept. 15, 2000 jepro ��Ɠ��������ɂȂ��Ă����̂��C��
-	{F_CREATEKEYBINDLIST,		LTEXT("CopyKeyBindList"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�L�[���蓖�Ĉꗗ���R�s�[	//Sept. 15, 2000 JEPRO �ǉ� //Dec. 25, 2000 ����
+	/* クリップボード系 */
+	{F_CUT,						LTEXT("Cut"),						{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //切り取り(選択範囲をクリップボードにコピーして削除)
+	{F_COPY,					LTEXT("Copy"),						{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //コピー(選択範囲をクリップボードにコピー)
+	{F_PASTE,					LTEXT("Paste"),						{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //貼り付け(クリップボードから貼り付け)
+	{F_COPY_ADDCRLF,			LTEXT("CopyAddCRLF"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //折り返し位置に改行をつけてコピー
+	{F_COPY_CRLF,				LTEXT("CopyCRLF"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //CRLF改行でコピー(選択範囲を改行コード=CRLFでコピー)
+	{F_PASTEBOX,				LTEXT("PasteBox"),					{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //矩形貼り付け(クリップボードから矩形貼り付け)
+	{F_INSBOXTEXT,				LTEXT("InsBoxText"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // 矩形テキスト挿入
+	{F_INSTEXT_W,				LTEXT("InsText"),					{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // テキストを貼り付け
+	{F_ADDTAIL_W,				LTEXT("AddTail"),					{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // 最後にテキストを追加
+	{F_COPYLINES,				LTEXT("CopyLines"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //選択範囲内全行コピー
+	{F_COPYLINESASPASSAGE,		LTEXT("CopyLinesAsPassage"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //選択範囲内全行引用符付きコピー
+	{F_COPYLINESWITHLINENUMBER,	LTEXT("CopyLinesWithLineNumber"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //選択範囲内全行行番号付きコピー
+	{F_COPY_COLOR_HTML,			LTEXT("CopyColorHtml"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //選択範囲内色付きHTMLコピー
+	{F_COPY_COLOR_HTML_LINENUMBER,	LTEXT("CopyColorHtmlWithLineNumber"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //選択範囲内行番号色付きHTMLコピー
+	{F_COPYPATH,				LTEXT("CopyPath"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //このファイルのパス名をクリップボードにコピー
+	{F_COPYFNAME,				LTEXT("CopyFilename"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //このファイル名をクリップボードにコピー // 2002/2/3 aroka
+	{F_COPYTAG,					LTEXT("CopyTag"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //このファイルのパス名とカーソル位置をコピー	//Sept. 15, 2000 jepro 上と同じ説明になっていたのを修正
+	{F_CREATEKEYBINDLIST,		LTEXT("CopyKeyBindList"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //キー割り当て一覧をコピー	//Sept. 15, 2000 JEPRO 追加 //Dec. 25, 2000 復活
 
-	/* �}���n */
-	{F_INS_DATE,				LTEXT("InsertDate"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // ���t�}��
-	{F_INS_TIME,				LTEXT("InsertTime"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // �����}��
-	{F_CTRL_CODE_DIALOG,		LTEXT("CtrlCodeDialog"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�R���g���[���R�[�h�̓���(�_�C�A���O)	//@@@ 2002.06.02 MIK
-	{F_CTRL_CODE,				LTEXT("CtrlCode"),				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�R���g���[���R�[�h�̓��� 2013.12.12
+	/* 挿入系 */
+	{F_INS_DATE,				LTEXT("InsertDate"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // 日付挿入
+	{F_INS_TIME,				LTEXT("InsertTime"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // 時刻挿入
+	{F_CTRL_CODE_DIALOG,		LTEXT("CtrlCodeDialog"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //コントロールコードの入力(ダイアログ)	//@@@ 2002.06.02 MIK
+	{F_CTRL_CODE,				LTEXT("CtrlCode"),				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //コントロールコードの入力 2013.12.12
 
-	/* �ϊ��n */
-	{F_TOLOWER,		 			LTEXT("ToLower"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //������
-	{F_TOUPPER,		 			LTEXT("ToUpper"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�啶��
-	{F_TOHANKAKU,		 		LTEXT("ToHankaku"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �S�p�����p */
-	{F_TOHANKATA,		 		LTEXT("ToHankata"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �S�p�J�^�J�i�����p�J�^�J�i */	//Aug. 29, 2002 ai
-	{F_TOZENEI,		 			LTEXT("ToZenEi"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ���p�p�����S�p�p�� */			//July. 30, 2001 Misaka
-	{F_TOHANEI,		 			LTEXT("ToHanEi"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �S�p�p�������p�p�� */
-	{F_TOZENKAKUKATA,	 		LTEXT("ToZenKata"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ���p�{�S�Ђ灨�S�p�E�J�^�J�i */	//Sept. 17, 2000 jepro �������u���p���S�p�J�^�J�i�v����ύX
-	{F_TOZENKAKUHIRA,	 		LTEXT("ToZenHira"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ���p�{�S�J�^���S�p�E�Ђ炪�� */	//Sept. 17, 2000 jepro �������u���p���S�p�Ђ炪�ȁv����ύX
-	{F_HANKATATOZENKATA,	LTEXT("HanKataToZenKata"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ���p�J�^�J�i���S�p�J�^�J�i */
-	{F_HANKATATOZENHIRA,	LTEXT("HanKataToZenHira"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ���p�J�^�J�i���S�p�Ђ炪�� */
-	{F_TABTOSPACE,				LTEXT("TABToSPACE"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* TAB���� */
-	{F_SPACETOTAB,				LTEXT("SPACEToTAB"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �󔒁�TAB */ //---- Stonee, 2001/05/27
-	{F_CODECNV_AUTO2SJIS,		LTEXT("AutoToSJIS"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �������ʁ�SJIS�R�[�h�ϊ� */
-	{F_CODECNV_EMAIL,			LTEXT("JIStoSJIS"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //E-Mail(JIS��SJIS)�R�[�h�ϊ�
-	{F_CODECNV_EUC2SJIS,		LTEXT("EUCtoSJIS"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //EUC��SJIS�R�[�h�ϊ�
-	{F_CODECNV_UNICODE2SJIS,	LTEXT("CodeCnvUNICODEtoSJIS"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Unicode��SJIS�R�[�h�ϊ�
-	{F_CODECNV_UNICODEBE2SJIS,	LTEXT("CodeCnvUNICODEBEtoSJIS"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // UnicodeBE��SJIS�R�[�h�ϊ�
-	{F_CODECNV_UTF82SJIS,		LTEXT("UTF8toSJIS"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* UTF-8��SJIS�R�[�h�ϊ� */
-	{F_CODECNV_UTF72SJIS,		LTEXT("UTF7toSJIS"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* UTF-7��SJIS�R�[�h�ϊ� */
-	{F_CODECNV_SJIS2JIS,		LTEXT("SJIStoJIS"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* SJIS��JIS�R�[�h�ϊ� */
-	{F_CODECNV_SJIS2EUC,		LTEXT("SJIStoEUC"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* SJIS��EUC�R�[�h�ϊ� */
-	{F_CODECNV_SJIS2UTF8,		LTEXT("SJIStoUTF8"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* SJIS��UTF-8�R�[�h�ϊ� */
-	{F_CODECNV_SJIS2UTF7,		LTEXT("SJIStoUTF7"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* SJIS��UTF-7�R�[�h�ϊ� */
-	{F_BASE64DECODE,	 		LTEXT("Base64Decode"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Base64�f�R�[�h���ĕۑ�
-	{F_UUDECODE,		 		LTEXT("Uudecode"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //uudecode���ĕۑ�	//Oct. 17, 2000 jepro �������u�I�𕔕���UUENCODE�f�R�[�h�v����ύX
+	/* 変換系 */
+	{F_TOLOWER,		 			LTEXT("ToLower"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //小文字
+	{F_TOUPPER,		 			LTEXT("ToUpper"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //大文字
+	{F_TOHANKAKU,		 		LTEXT("ToHankaku"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 全角→半角 */
+	{F_TOHANKATA,		 		LTEXT("ToHankata"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 全角カタカナ→半角カタカナ */	//Aug. 29, 2002 ai
+	{F_TOZENEI,		 			LTEXT("ToZenEi"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 半角英数→全角英数 */			//July. 30, 2001 Misaka
+	{F_TOHANEI,		 			LTEXT("ToHanEi"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 全角英数→半角英数 */
+	{F_TOZENKAKUKATA,	 		LTEXT("ToZenKata"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 半角＋全ひら→全角・カタカナ */	//Sept. 17, 2000 jepro 説明を「半角→全角カタカナ」から変更
+	{F_TOZENKAKUHIRA,	 		LTEXT("ToZenHira"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 半角＋全カタ→全角・ひらがな */	//Sept. 17, 2000 jepro 説明を「半角→全角ひらがな」から変更
+	{F_HANKATATOZENKATA,	LTEXT("HanKataToZenKata"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 半角カタカナ→全角カタカナ */
+	{F_HANKATATOZENHIRA,	LTEXT("HanKataToZenHira"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 半角カタカナ→全角ひらがな */
+	{F_TABTOSPACE,				LTEXT("TABToSPACE"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* TAB→空白 */
+	{F_SPACETOTAB,				LTEXT("SPACEToTAB"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 空白→TAB */ //---- Stonee, 2001/05/27
+	{F_CODECNV_AUTO2SJIS,		LTEXT("AutoToSJIS"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 自動判別→SJISコード変換 */
+	{F_CODECNV_EMAIL,			LTEXT("JIStoSJIS"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //E-Mail(JIS→SJIS)コード変換
+	{F_CODECNV_EUC2SJIS,		LTEXT("EUCtoSJIS"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //EUC→SJISコード変換
+	{F_CODECNV_UNICODE2SJIS,	LTEXT("CodeCnvUNICODEtoSJIS"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Unicode→SJISコード変換
+	{F_CODECNV_UNICODEBE2SJIS,	LTEXT("CodeCnvUNICODEBEtoSJIS"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // UnicodeBE→SJISコード変換
+	{F_CODECNV_UTF82SJIS,		LTEXT("UTF8toSJIS"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* UTF-8→SJISコード変換 */
+	{F_CODECNV_UTF72SJIS,		LTEXT("UTF7toSJIS"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* UTF-7→SJISコード変換 */
+	{F_CODECNV_SJIS2JIS,		LTEXT("SJIStoJIS"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* SJIS→JISコード変換 */
+	{F_CODECNV_SJIS2EUC,		LTEXT("SJIStoEUC"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* SJIS→EUCコード変換 */
+	{F_CODECNV_SJIS2UTF8,		LTEXT("SJIStoUTF8"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* SJIS→UTF-8コード変換 */
+	{F_CODECNV_SJIS2UTF7,		LTEXT("SJIStoUTF7"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* SJIS→UTF-7コード変換 */
+	{F_BASE64DECODE,	 		LTEXT("Base64Decode"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Base64デコードして保存
+	{F_UUDECODE,		 		LTEXT("Uudecode"),					{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //uudecodeして保存	//Oct. 17, 2000 jepro 説明を「選択部分をUUENCODEデコード」から変更
 
 
-	/* �����n */
-	{F_SEARCH_DIALOG,			LTEXT("SearchDialog"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //����(�P�ꌟ���_�C�A���O)
-	{F_SEARCH_NEXT,				LTEXT("SearchNext"),		{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //��������
-	{F_SEARCH_PREV,				LTEXT("SearchPrev"),		{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O������
-	{F_REPLACE_DIALOG,			LTEXT("ReplaceDialog"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�u��(�u���_�C�A���O)
-	{F_REPLACE,					LTEXT("Replace"),			{VT_BSTR,  VT_BSTR,  VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //�u��(���s)
-	{F_REPLACE_ALL,				LTEXT("ReplaceAll"),		{VT_BSTR,  VT_BSTR,  VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //���ׂĒu��(���s)
-	{F_SEARCH_CLEARMARK,		LTEXT("SearchClearMark"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�����}�[�N�̃N���A
-	{F_JUMP_SRCHSTARTPOS,		LTEXT("SearchStartPos"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�����J�n�ʒu�֖߂�			// 02/06/26 ai
+	/* 検索系 */
+	{F_SEARCH_DIALOG,			LTEXT("SearchDialog"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //検索(単語検索ダイアログ)
+	{F_SEARCH_NEXT,				LTEXT("SearchNext"),		{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //次を検索
+	{F_SEARCH_PREV,				LTEXT("SearchPrev"),		{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //前を検索
+	{F_REPLACE_DIALOG,			LTEXT("ReplaceDialog"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //置換(置換ダイアログ)
+	{F_REPLACE,					LTEXT("Replace"),			{VT_BSTR,  VT_BSTR,  VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //置換(実行)
+	{F_REPLACE_ALL,				LTEXT("ReplaceAll"),		{VT_BSTR,  VT_BSTR,  VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, //すべて置換(実行)
+	{F_SEARCH_CLEARMARK,		LTEXT("SearchClearMark"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //検索マークのクリア
+	{F_JUMP_SRCHSTARTPOS,		LTEXT("SearchStartPos"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //検索開始位置へ戻る			// 02/06/26 ai
 	{F_GREP,					LTEXT("Grep"),				{VT_BSTR,  VT_BSTR,  VT_BSTR,  VT_I4   },	VT_EMPTY,	&s_MacroInfoEx_i}, //Grep
-	{F_GREP_REPLACE,			LTEXT("GrepReplace"),		{VT_BSTR,  VT_BSTR,  VT_BSTR,  VT_BSTR },	VT_EMPTY,	&s_MacroInfoEx_ii}, //Grep�u��
-	{F_JUMP,					LTEXT("Jump"),				{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�w��s�w�W�����v
-	{F_OUTLINE,					LTEXT("Outline"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�A�E�g���C�����
-	{F_TAGJUMP,					LTEXT("TagJump"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�^�O�W�����v�@�\
-	{F_TAGJUMPBACK,				LTEXT("TagJumpBack"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�^�O�W�����v�o�b�N�@�\
-	{F_TAGS_MAKE,				LTEXT("TagMake"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�^�O�t�@�C���̍쐬	//@@@ 2003.04.13 MIK
-	{F_DIRECT_TAGJUMP,			LTEXT("DirectTagJump"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�_�C���N�g�^�O�W�����v�@�\	//@@@ 2003.04.15 MIK
-	{F_TAGJUMP_KEYWORD,			LTEXT("KeywordTagJump"),	{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�L�[���[�h���w�肵�ă_�C���N�g�^�O�W�����v�@�\ //@@@ 2005.03.31 MIK
-	{F_COMPARE,					LTEXT("Compare"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�t�@�C�����e��r
-	{F_DIFF_DIALOG,				LTEXT("DiffDialog"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF�����\��(�_�C�A���O)	//@@@ 2002.05.25 MIK
-	{F_DIFF,					LTEXT("Diff"),				{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF�����\��				//@@@ 2002.05.25 MIK	// 2005.10.03 maru
-	{F_DIFF_NEXT,				LTEXT("DiffNext"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF�����\��(����)			//@@@ 2002.05.25 MIK
-	{F_DIFF_PREV,				LTEXT("DiffPrev"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF�����\��(�O��)			//@@@ 2002.05.25 MIK
-	{F_DIFF_RESET,				LTEXT("DiffReset"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF�����\��(�S����)		//@@@ 2002.05.25 MIK
-	{F_BRACKETPAIR,				LTEXT("BracketPair"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�Ί��ʂ̌���
+	{F_GREP_REPLACE,			LTEXT("GrepReplace"),		{VT_BSTR,  VT_BSTR,  VT_BSTR,  VT_BSTR },	VT_EMPTY,	&s_MacroInfoEx_ii}, //Grep置換
+	{F_JUMP,					LTEXT("Jump"),				{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //指定行ヘジャンプ
+	{F_OUTLINE,					LTEXT("Outline"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //アウトライン解析
+	{F_TAGJUMP,					LTEXT("TagJump"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //タグジャンプ機能
+	{F_TAGJUMPBACK,				LTEXT("TagJumpBack"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //タグジャンプバック機能
+	{F_TAGS_MAKE,				LTEXT("TagMake"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //タグファイルの作成	//@@@ 2003.04.13 MIK
+	{F_DIRECT_TAGJUMP,			LTEXT("DirectTagJump"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ダイレクトタグジャンプ機能	//@@@ 2003.04.15 MIK
+	{F_TAGJUMP_KEYWORD,			LTEXT("KeywordTagJump"),	{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //キーワードを指定してダイレクトタグジャンプ機能 //@@@ 2005.03.31 MIK
+	{F_COMPARE,					LTEXT("Compare"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ファイル内容比較
+	{F_DIFF_DIALOG,				LTEXT("DiffDialog"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF差分表示(ダイアログ)	//@@@ 2002.05.25 MIK
+	{F_DIFF,					LTEXT("Diff"),				{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF差分表示				//@@@ 2002.05.25 MIK	// 2005.10.03 maru
+	{F_DIFF_NEXT,				LTEXT("DiffNext"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF差分表示(次へ)			//@@@ 2002.05.25 MIK
+	{F_DIFF_PREV,				LTEXT("DiffPrev"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF差分表示(前へ)			//@@@ 2002.05.25 MIK
+	{F_DIFF_RESET,				LTEXT("DiffReset"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //DIFF差分表示(全解除)		//@@@ 2002.05.25 MIK
+	{F_BRACKETPAIR,				LTEXT("BracketPair"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //対括弧の検索
 // From Here 2001.12.03 hor
-	{F_BOOKMARK_SET,			LTEXT("BookmarkSet"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�u�b�N�}�[�N�ݒ�E����
-	{F_BOOKMARK_NEXT,			LTEXT("BookmarkNext"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̃u�b�N�}�[�N��
-	{F_BOOKMARK_PREV,			LTEXT("BookmarkPrev"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O�̃u�b�N�}�[�N��
-	{F_BOOKMARK_RESET,			LTEXT("BookmarkReset"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�u�b�N�}�[�N�̑S����
-	{F_BOOKMARK_VIEW,			LTEXT("BookmarkView"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�u�b�N�}�[�N�̈ꗗ
+	{F_BOOKMARK_SET,			LTEXT("BookmarkSet"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ブックマーク設定・解除
+	{F_BOOKMARK_NEXT,			LTEXT("BookmarkNext"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //次のブックマークへ
+	{F_BOOKMARK_PREV,			LTEXT("BookmarkPrev"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //前のブックマークへ
+	{F_BOOKMARK_RESET,			LTEXT("BookmarkReset"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ブックマークの全解除
+	{F_BOOKMARK_VIEW,			LTEXT("BookmarkView"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ブックマークの一覧
 // To Here 2001.12.03 hor
-	{F_BOOKMARK_PATTERN,		LTEXT("BookmarkPattern"),	{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // 2002.01.16 hor �w��p�^�[���Ɉ�v����s���}�[�N
-	{F_FUNCLIST_NEXT,			LTEXT("FuncListNext"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̊֐����X�g�}�[�N��
-	{F_FUNCLIST_PREV,			LTEXT("FuncListPrev"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O�̊֐����X�g�}�[�N��
+	{F_BOOKMARK_PATTERN,		LTEXT("BookmarkPattern"),	{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // 2002.01.16 hor 指定パターンに一致する行をマーク
+	{F_FUNCLIST_NEXT,			LTEXT("FuncListNext"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //次の関数リストマークへ
+	{F_FUNCLIST_PREV,			LTEXT("FuncListPrev"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //前の関数リストマークへ
 
-	/* ���[�h�؂�ւ��n */
-	{F_CHGMOD_INS,				LTEXT("ChgmodINS"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�}���^�㏑�����[�h�؂�ւ�
-	{F_CHG_CHARSET,				LTEXT("ChgCharSet"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�����R�[�h�Z�b�g�w��		2010/6/14 Uchi
-	{F_CHGMOD_EOL,				LTEXT("ChgmodEOL"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���͉��s�R�[�h�w�� 2003.06.23 Moca
-	{F_CANCEL_MODE,				LTEXT("CancelMode"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�e�탂�[�h�̎�����
+	/* モード切り替え系 */
+	{F_CHGMOD_INS,				LTEXT("ChgmodINS"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //挿入／上書きモード切り替え
+	{F_CHG_CHARSET,				LTEXT("ChgCharSet"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //文字コードセット指定		2010/6/14 Uchi
+	{F_CHGMOD_EOL,				LTEXT("ChgmodEOL"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //入力改行コード指定 2003.06.23 Moca
+	{F_CANCEL_MODE,				LTEXT("CancelMode"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //各種モードの取り消し
 
-	/* �}�N���n */
-	{F_EXECEXTMACRO,			LTEXT("ExecExternalMacro"),	{VT_BSTR, VT_BSTR, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���O���w�肵�ă}�N�����s
+	/* マクロ系 */
+	{F_EXECEXTMACRO,			LTEXT("ExecExternalMacro"),	{VT_BSTR, VT_BSTR, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //名前を指定してマクロ実行
 
-	/* �ݒ�n */
-	{F_SHOWTOOLBAR,				LTEXT("ShowToolbar"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �c�[���o�[�̕\�� */
-	{F_SHOWFUNCKEY,				LTEXT("ShowFunckey"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �t�@���N�V�����L�[�̕\�� */
-	{F_SHOWTAB,					LTEXT("ShowTab"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �^�u�̕\�� */	//@@@ 2003.06.10 MIK
-	{F_SHOWSTATUSBAR,			LTEXT("ShowStatusbar"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �X�e�[�^�X�o�[�̕\�� */
-	{F_SHOWMINIMAP,				LTEXT("ShowMiniMap"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // �~�j�}�b�v�̕\��
-	{F_TYPE_LIST,				LTEXT("TypeList"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �^�C�v�ʐݒ�ꗗ */
-	{F_CHANGETYPE,				LTEXT("ChangeType"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�^�C�v�ʐݒ�ꎞ�K�p 2013.05.02
-	{F_OPTION_TYPE,				LTEXT("OptionType"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �^�C�v�ʐݒ� */
-	{F_OPTION,					LTEXT("OptionCommon"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ���ʐݒ� */
-	{F_FONT,					LTEXT("SelectFont"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �t�H���g�ݒ� */
-	{F_SETFONTSIZE,				LTEXT("SetFontSize"),		{VT_I4,    VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, /* �t�H���g�T�C�Y�ݒ� */
-	{F_WRAPWINDOWWIDTH,			LTEXT("WrapWindowWidth"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ���݂̃E�B���h�E���Ő܂�Ԃ� */	//Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH �� WRAPWINDOWWIDTH �ɕύX
-	{F_FAVORITE,				LTEXT("OptionFavorite"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �����̊Ǘ� */	//@@@ 2003.04.08 MIK
-	{F_SET_QUOTESTRING,			LTEXT("SetMsgQuoteStr"),	{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ���ʐݒ聨���������p���̐ݒ� */	//Jan. 29, 2005 genta
-	{F_TEXTWRAPMETHOD,			LTEXT("TextWrapMethod"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �e�L�X�g�̐܂�Ԃ����@ */	// 2008.05.30 nasukoji
-	{F_SELECT_COUNT_MODE,		LTEXT("SelectCountMode"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�����J�E���g���@
-	//	Oct. 9, 2001 genta �ǉ�
-	{F_EXECMD,					LTEXT("ExecCommand"),		{VT_BSTR,  VT_I4,    VT_BSTR,  VT_EMPTY},	VT_EMPTY,	NULL}, /* �O���R�}���h���s */
-	{F_EXECMD_DIALOG,			LTEXT("ExecCommandDialog"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O���R�}���h���s(�_�C�A���O)
+	/* 設定系 */
+	{F_SHOWTOOLBAR,				LTEXT("ShowToolbar"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ツールバーの表示 */
+	{F_SHOWFUNCKEY,				LTEXT("ShowFunckey"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ファンクションキーの表示 */
+	{F_SHOWTAB,					LTEXT("ShowTab"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* タブの表示 */	//@@@ 2003.06.10 MIK
+	{F_SHOWSTATUSBAR,			LTEXT("ShowStatusbar"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ステータスバーの表示 */
+	{F_SHOWMINIMAP,				LTEXT("ShowMiniMap"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // ミニマップの表示
+	{F_TYPE_LIST,				LTEXT("TypeList"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* タイプ別設定一覧 */
+	{F_CHANGETYPE,				LTEXT("ChangeType"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //タイプ別設定一時適用 2013.05.02
+	{F_OPTION_TYPE,				LTEXT("OptionType"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* タイプ別設定 */
+	{F_OPTION,					LTEXT("OptionCommon"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 共通設定 */
+	{F_FONT,					LTEXT("SelectFont"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* フォント設定 */
+	{F_SETFONTSIZE,				LTEXT("SetFontSize"),		{VT_I4,    VT_I4,    VT_I4,    VT_EMPTY},	VT_EMPTY,	NULL}, /* フォントサイズ設定 */
+	{F_WRAPWINDOWWIDTH,			LTEXT("WrapWindowWidth"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 現在のウィンドウ幅で折り返し */	//Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH を WRAPWINDOWWIDTH に変更
+	{F_FAVORITE,				LTEXT("OptionFavorite"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 履歴の管理 */	//@@@ 2003.04.08 MIK
+	{F_SET_QUOTESTRING,			LTEXT("SetMsgQuoteStr"),	{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 共通設定→書式→引用符の設定 */	//Jan. 29, 2005 genta
+	{F_TEXTWRAPMETHOD,			LTEXT("TextWrapMethod"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* テキストの折り返し方法 */	// 2008.05.30 nasukoji
+	{F_SELECT_COUNT_MODE,		LTEXT("SelectCountMode"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //文字カウント方法
+	//	Oct. 9, 2001 genta 追加
+	{F_EXECMD,					LTEXT("ExecCommand"),		{VT_BSTR,  VT_I4,    VT_BSTR,  VT_EMPTY},	VT_EMPTY,	NULL}, /* 外部コマンド実行 */
+	{F_EXECMD_DIALOG,			LTEXT("ExecCommandDialog"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //外部コマンド実行(ダイアログ)
 
-	/* �J�X�^�����j���[ */
-	{F_MENU_RBUTTON,			LTEXT("RMenu"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �E�N���b�N���j���[ */
-	{F_CUSTMENU_1,				LTEXT("CustMenu1"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[1 */
-	{F_CUSTMENU_2,				LTEXT("CustMenu2"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[2 */
-	{F_CUSTMENU_3,				LTEXT("CustMenu3"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[3 */
-	{F_CUSTMENU_4,				LTEXT("CustMenu4"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[4 */
-	{F_CUSTMENU_5,				LTEXT("CustMenu5"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[5 */
-	{F_CUSTMENU_6,				LTEXT("CustMenu6"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[6 */
-	{F_CUSTMENU_7,				LTEXT("CustMenu7"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[7 */
-	{F_CUSTMENU_8,				LTEXT("CustMenu8"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[8 */
-	{F_CUSTMENU_9,				LTEXT("CustMenu9"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[9 */
-	{F_CUSTMENU_10,				LTEXT("CustMenu10"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[10 */
-	{F_CUSTMENU_11,				LTEXT("CustMenu11"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[11 */
-	{F_CUSTMENU_12,				LTEXT("CustMenu12"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[12 */
-	{F_CUSTMENU_13,				LTEXT("CustMenu13"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[13 */
-	{F_CUSTMENU_14,				LTEXT("CustMenu14"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[14 */
-	{F_CUSTMENU_15,				LTEXT("CustMenu15"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[15 */
-	{F_CUSTMENU_16,				LTEXT("CustMenu16"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[16 */
-	{F_CUSTMENU_17,				LTEXT("CustMenu17"), 		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[17 */
-	{F_CUSTMENU_18,				LTEXT("CustMenu18"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[18 */
-	{F_CUSTMENU_19,				LTEXT("CustMenu19"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[19 */
-	{F_CUSTMENU_20,				LTEXT("CustMenu20"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[20 */
-	{F_CUSTMENU_21,				LTEXT("CustMenu21"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[21 */
-	{F_CUSTMENU_22,				LTEXT("CustMenu22"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[22 */
-	{F_CUSTMENU_23,				LTEXT("CustMenu23"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[23 */
-	{F_CUSTMENU_24,				LTEXT("CustMenu24"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �J�X�^�����j���[24 */
+	/* カスタムメニュー */
+	{F_MENU_RBUTTON,			LTEXT("RMenu"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 右クリックメニュー */
+	{F_CUSTMENU_1,				LTEXT("CustMenu1"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー1 */
+	{F_CUSTMENU_2,				LTEXT("CustMenu2"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー2 */
+	{F_CUSTMENU_3,				LTEXT("CustMenu3"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー3 */
+	{F_CUSTMENU_4,				LTEXT("CustMenu4"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー4 */
+	{F_CUSTMENU_5,				LTEXT("CustMenu5"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー5 */
+	{F_CUSTMENU_6,				LTEXT("CustMenu6"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー6 */
+	{F_CUSTMENU_7,				LTEXT("CustMenu7"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー7 */
+	{F_CUSTMENU_8,				LTEXT("CustMenu8"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー8 */
+	{F_CUSTMENU_9,				LTEXT("CustMenu9"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー9 */
+	{F_CUSTMENU_10,				LTEXT("CustMenu10"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー10 */
+	{F_CUSTMENU_11,				LTEXT("CustMenu11"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー11 */
+	{F_CUSTMENU_12,				LTEXT("CustMenu12"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー12 */
+	{F_CUSTMENU_13,				LTEXT("CustMenu13"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー13 */
+	{F_CUSTMENU_14,				LTEXT("CustMenu14"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー14 */
+	{F_CUSTMENU_15,				LTEXT("CustMenu15"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー15 */
+	{F_CUSTMENU_16,				LTEXT("CustMenu16"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー16 */
+	{F_CUSTMENU_17,				LTEXT("CustMenu17"), 		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー17 */
+	{F_CUSTMENU_18,				LTEXT("CustMenu18"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー18 */
+	{F_CUSTMENU_19,				LTEXT("CustMenu19"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー19 */
+	{F_CUSTMENU_20,				LTEXT("CustMenu20"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー20 */
+	{F_CUSTMENU_21,				LTEXT("CustMenu21"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー21 */
+	{F_CUSTMENU_22,				LTEXT("CustMenu22"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー22 */
+	{F_CUSTMENU_23,				LTEXT("CustMenu23"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー23 */
+	{F_CUSTMENU_24,				LTEXT("CustMenu24"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* カスタムメニュー24 */
 
-	/* �E�B���h�E�n */
-	{F_SPLIT_V,					LTEXT("SplitWinV"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�㉺�ɕ���	//Sept. 17, 2000 jepro �����́u�c�v���u�㉺�Ɂv�ɕύX
-	{F_SPLIT_H,					LTEXT("SplitWinH"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���E�ɕ���	//Sept. 17, 2000 jepro �����́u���v���u���E�Ɂv�ɕύX
-	{F_SPLIT_VH,				LTEXT("SplitWinVH"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�c���ɕ���	//Sept. 17, 2000 jepro �����Ɂu�Ɂv��ǉ�
-	{F_WINCLOSE,				LTEXT("WinClose"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�E�B���h�E�����
-	{F_WIN_CLOSEALL,			LTEXT("WinCloseAll"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���ׂẴE�B���h�E�����	//Oct. 17, 2000 JEPRO ���O��ύX(F_FILECLOSEALL��F_WIN_CLOSEALL)
-	{F_CASCADE,					LTEXT("CascadeWin"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�d�˂ĕ\��
-	{F_TILE_V,					LTEXT("TileWinV"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�㉺�ɕ��ׂĕ\��
-	{F_TILE_H,					LTEXT("TileWinH"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���E�ɕ��ׂĕ\��
-	{F_NEXTWINDOW,				LTEXT("NextWindow"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̃E�B���h�E
-	{F_PREVWINDOW,				LTEXT("PrevWindow"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O�̃E�B���h�E
-	{F_WINLIST,					LTEXT("WindowList"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�E�B���h�E�ꗗ�|�b�v�A�b�v�\��	// 2006.03.23 fon
-	{F_MAXIMIZE_V,				LTEXT("MaximizeV"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�c�����ɍő剻
-	{F_MAXIMIZE_H,				LTEXT("MaximizeH"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�������ɍő剻 //2001.02.10 by MIK
-	{F_MINIMIZE_ALL,			LTEXT("MinimizeAll"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���ׂčŏ���	//Sept. 17, 2000 jepro �����́u�S�āv���u���ׂāv�ɓ���
-	{F_REDRAW,					LTEXT("ReDraw"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�ĕ`��
-	{F_WIN_OUTPUT,				LTEXT("ActivateWinOutput"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�A�E�g�v�b�g�E�B���h�E�\��
-	{F_TRACEOUT,				LTEXT("TraceOut"),			{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�}�N���p�A�E�g�v�b�g�E�B���h�E�ɏo��	2006.04.26 maru
-	{F_TOPMOST,					LTEXT("WindowTopMost"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //��Ɏ�O�ɕ\��
-	{F_GROUPCLOSE,				LTEXT("GroupClose"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O���[�v�����	// 2007.06.20 ryoji
-	{F_NEXTGROUP,				LTEXT("NextGroup"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̃O���[�v	// 2007.06.20 ryoji
-	{F_PREVGROUP,				LTEXT("PrevGroup"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O�̃O���[�v	// 2007.06.20 ryoji
-	{F_TAB_MOVERIGHT,			LTEXT("TabMoveRight"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�^�u���E�Ɉړ�	// 2007.06.20 ryoji
-	{F_TAB_MOVELEFT,			LTEXT("TabMoveLeft"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�^�u�����Ɉړ�	// 2007.06.20 ryoji
-	{F_TAB_SEPARATE,			LTEXT("TabSeparate"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�V�K�O���[�v	// 2007.06.20 ryoji
-	{F_TAB_JOINTNEXT,			LTEXT("TabJointNext"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̃O���[�v�Ɉړ�	// 2007.06.20 ryoji
-	{F_TAB_JOINTPREV,			LTEXT("TabJointPrev"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�O�̃O���[�v�Ɉړ�	// 2007.06.20 ryoji
-	{F_TAB_CLOSEOTHER,			LTEXT("TabCloseOther"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //���̃^�u�ȊO�����	// 2010/3/14 Uchi
-	{F_TAB_CLOSELEFT,			LTEXT("TabCloseLeft"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�������ׂĕ���		// 2010/3/14 Uchi
-	{F_TAB_CLOSERIGHT,			LTEXT("TabCloseRight"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�E�����ׂĕ���		// 2010/3/14 Uchi
+	/* ウィンドウ系 */
+	{F_SPLIT_V,					LTEXT("SplitWinV"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //上下に分割	//Sept. 17, 2000 jepro 説明の「縦」を「上下に」に変更
+	{F_SPLIT_H,					LTEXT("SplitWinH"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //左右に分割	//Sept. 17, 2000 jepro 説明の「横」を「左右に」に変更
+	{F_SPLIT_VH,				LTEXT("SplitWinVH"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //縦横に分割	//Sept. 17, 2000 jepro 説明に「に」を追加
+	{F_WINCLOSE,				LTEXT("WinClose"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ウィンドウを閉じる
+	{F_WIN_CLOSEALL,			LTEXT("WinCloseAll"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //すべてのウィンドウを閉じる	//Oct. 17, 2000 JEPRO 名前を変更(F_FILECLOSEALL→F_WIN_CLOSEALL)
+	{F_CASCADE,					LTEXT("CascadeWin"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //重ねて表示
+	{F_TILE_V,					LTEXT("TileWinV"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //上下に並べて表示
+	{F_TILE_H,					LTEXT("TileWinH"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //左右に並べて表示
+	{F_NEXTWINDOW,				LTEXT("NextWindow"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //次のウィンドウ
+	{F_PREVWINDOW,				LTEXT("PrevWindow"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //前のウィンドウ
+	{F_WINLIST,					LTEXT("WindowList"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ウィンドウ一覧ポップアップ表示	// 2006.03.23 fon
+	{F_MAXIMIZE_V,				LTEXT("MaximizeV"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //縦方向に最大化
+	{F_MAXIMIZE_H,				LTEXT("MaximizeH"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //横方向に最大化 //2001.02.10 by MIK
+	{F_MINIMIZE_ALL,			LTEXT("MinimizeAll"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //すべて最小化	//Sept. 17, 2000 jepro 説明の「全て」を「すべて」に統一
+	{F_REDRAW,					LTEXT("ReDraw"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //再描画
+	{F_WIN_OUTPUT,				LTEXT("ActivateWinOutput"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //アウトプットウィンドウ表示
+	{F_TRACEOUT,				LTEXT("TraceOut"),			{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //マクロ用アウトプットウィンドウに出力	2006.04.26 maru
+	{F_TOPMOST,					LTEXT("WindowTopMost"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //常に手前に表示
+	{F_GROUPCLOSE,				LTEXT("GroupClose"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //グループを閉じる	// 2007.06.20 ryoji
+	{F_NEXTGROUP,				LTEXT("NextGroup"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //次のグループ	// 2007.06.20 ryoji
+	{F_PREVGROUP,				LTEXT("PrevGroup"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //前のグループ	// 2007.06.20 ryoji
+	{F_TAB_MOVERIGHT,			LTEXT("TabMoveRight"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //タブを右に移動	// 2007.06.20 ryoji
+	{F_TAB_MOVELEFT,			LTEXT("TabMoveLeft"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //タブを左に移動	// 2007.06.20 ryoji
+	{F_TAB_SEPARATE,			LTEXT("TabSeparate"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //新規グループ	// 2007.06.20 ryoji
+	{F_TAB_JOINTNEXT,			LTEXT("TabJointNext"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //次のグループに移動	// 2007.06.20 ryoji
+	{F_TAB_JOINTPREV,			LTEXT("TabJointPrev"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //前のグループに移動	// 2007.06.20 ryoji
+	{F_TAB_CLOSEOTHER,			LTEXT("TabCloseOther"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //このタブ以外を閉じる	// 2010/3/14 Uchi
+	{F_TAB_CLOSELEFT,			LTEXT("TabCloseLeft"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //左をすべて閉じる		// 2010/3/14 Uchi
+	{F_TAB_CLOSERIGHT,			LTEXT("TabCloseRight"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //右をすべて閉じる		// 2010/3/14 Uchi
 
-	/* �x�� */
-	{F_HOKAN,					LTEXT("Complete"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ���͕⊮ */	//Oct. 15, 2000 JEPRO �����ĂȂ������̂ŉp����t���ē���Ă݂�
-	{F_TOGGLE_KEY_SEARCH,		LTEXT("ToggleKeyHelpSearch"), {VT_I4, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�L�[���[�h�w���v�����\�� 2013.05.03
-	{F_HELP_CONTENTS,			LTEXT("HelpContents"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �w���v�ڎ� */			//Nov. 25, 2000 JEPRO �ǉ�
-	{F_HELP_SEARCH,				LTEXT("HelpSearch"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �w���v�L�[���[�h���� */	//Nov. 25, 2000 JEPRO �ǉ�
-	{F_MENU_ALLFUNC,			LTEXT("CommandList"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �R�}���h�ꗗ */
-	{F_EXTHELP1,				LTEXT("ExtHelp1"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �O���w���v�P */
-	//	Jul. 5, 2002 genta �����ǉ�
-	{F_EXTHTMLHELP,				LTEXT("ExtHtmlHelp"),		{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �O��HTML�w���v */
-	{F_ABOUT,					LTEXT("About"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* �o�[�W������� */	//Dec. 24, 2000 JEPRO �ǉ�
+	/* 支援 */
+	{F_HOKAN,					LTEXT("Complete"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 入力補完 */	//Oct. 15, 2000 JEPRO 入ってなかったので英名を付けて入れてみた
+	{F_TOGGLE_KEY_SEARCH,		LTEXT("ToggleKeyHelpSearch"), {VT_I4, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //キーワードヘルプ自動表示 2013.05.03
+	{F_HELP_CONTENTS,			LTEXT("HelpContents"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ヘルプ目次 */			//Nov. 25, 2000 JEPRO 追加
+	{F_HELP_SEARCH,				LTEXT("HelpSearch"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* ヘルプキーワード検索 */	//Nov. 25, 2000 JEPRO 追加
+	{F_MENU_ALLFUNC,			LTEXT("CommandList"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* コマンド一覧 */
+	{F_EXTHELP1,				LTEXT("ExtHelp1"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 外部ヘルプ１ */
+	//	Jul. 5, 2002 genta 引数追加
+	{F_EXTHTMLHELP,				LTEXT("ExtHtmlHelp"),		{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* 外部HTMLヘルプ */
+	{F_ABOUT,					LTEXT("About"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, /* バージョン情報 */	//Dec. 24, 2000 JEPRO 追加
 
-	/*�}�N���p*/
-	{F_STATUSMSG,				LTEXT("StatusMsg"),			{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //�X�e�[�^�X���b�Z�[�W
-	{F_MSGBEEP,					LTEXT("MsgBeep"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Beep��
-	{F_COMMITUNDOBUFFER,		LTEXT("CommitUndoBuffer"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL }, //OpeBlK�R�~�b�g
+	/*マクロ用*/
+	{F_STATUSMSG,				LTEXT("StatusMsg"),			{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //ステータスメッセージ
+	{F_MSGBEEP,					LTEXT("MsgBeep"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, //Beep音
+	{F_COMMITUNDOBUFFER,		LTEXT("CommitUndoBuffer"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL }, //OpeBlKコミット
 	{F_ADDREFUNDOBUFFER,		LTEXT("AddRefUndoBuffer"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL }, //OpeBlK AddRef
 	{F_SETUNDOBUFFER,			LTEXT("SetUndoBuffer"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL }, //OpeBlK Release
-	{F_APPENDUNDOBUFFERCURSOR,	L"AppendUndoBufferCursor",	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL }, //OpeBlK �ɃJ�[�\���ʒu��ǉ�
+	{F_APPENDUNDOBUFFERCURSOR,	L"AppendUndoBufferCursor",	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL }, //OpeBlK にカーソル位置を追加
 	{F_CLIPBOARDEMPTY,			LTEXT("ClipboardEmpty"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL},
-	{F_SETVIEWTOP,				L"SetViewTop",				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // �r���[�̏�̍s����ݒ�
-	{F_SETVIEWLEFT,				L"SetViewLeft",				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // �r���[�̍��[�̌�����ݒ�
+	{F_SETVIEWTOP,				L"SetViewTop",				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // ビューの上の行数を設定
+	{F_SETVIEWLEFT,				L"SetViewLeft",				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}, // ビューの左端の桁数を設定
 
-	//	�I�[
+	//	終端
 	//	Jun. 27, 2002 genta
-	//	�I�[�Ƃ��Ă͌����Č���Ȃ����̂��g���ׂ��Ȃ̂ŁC
-	//	FuncID��-1�ɕύX�D(0�͎g����)
+	//	終端としては決して現れないものを使うべきなので，
+	//	FuncIDを-1に変更．(0は使われる)
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 
 MacroFuncInfo CSMacroMgr::m_MacroFuncInfoArr[] = 
 {
-	//ID					�֐���							����										�߂�l�̌^	m_pszData
-	{F_GETFILENAME,			LTEXT("GetFilename"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //�t�@�C������Ԃ�
-	{F_GETSAVEFILENAME,		LTEXT("GetSaveFilename"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //�ۑ����̃t�@�C������Ԃ� 2006.09.04 ryoji
-	{F_GETSELECTED,			LTEXT("GetSelectedString"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //�I�𕔕�
-	{F_EXPANDPARAMETER,		LTEXT("ExpandParameter"),		{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //���ꕶ���̓W�J
-	{F_GETLINESTR,			LTEXT("GetLineStr"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, // �w��_���s�̎擾 2003.06.01 Moca
-	{F_GETLINECOUNT,		LTEXT("GetLineCount"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �S�_���s���̎擾 2003.06.01 Moca
-	{F_CHGTABWIDTH,			LTEXT("ChangeTabWidth"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�^�u�T�C�Y�ύX 2004.03.16 zenryaku
-	{F_ISTEXTSELECTED,		LTEXT("IsTextSelected"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�e�L�X�g���I������Ă��邩 2005.7.30 maru
-	{F_GETSELLINEFROM,		LTEXT("GetSelectLineFrom"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �I���J�n�s�̎擾 2005.7.30 maru
-	{F_GETSELCOLUMNFROM,	LTEXT("GetSelectColmFrom"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �I���J�n���̎擾 2005.7.30 maru
-	{F_GETSELCOLUMNFROM,	LTEXT("GetSelectColumnFrom"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �I���J�n���̎擾 2005.7.30 maru
-	{F_GETSELLINETO,		LTEXT("GetSelectLineTo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �I���I���s�̎擾 2005.7.30 maru
-	{F_GETSELCOLUMNTO,		LTEXT("GetSelectColmTo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �I���I�����̎擾 2005.7.30 maru
-	{F_GETSELCOLUMNTO,		LTEXT("GetSelectColumnTo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �I���I�����̎擾 2005.7.30 maru
-	{F_ISINSMODE,			LTEXT("IsInsMode"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �}���^�㏑�����[�h�̎擾 2005.7.30 maru
-	{F_GETCHARCODE,			LTEXT("GetCharCode"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �����R�[�h�擾 2005.07.31 maru
-	{F_GETLINECODE,			LTEXT("GetLineCode"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // ���s�R�[�h�擾 2005.08.05 maru
-	{F_ISPOSSIBLEUNDO,		LTEXT("IsPossibleUndo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // Undo�\�����ׂ� 2005.08.05 maru
-	{F_ISPOSSIBLEREDO,		LTEXT("IsPossibleRedo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // Redo�\�����ׂ� 2005.08.05 maru
-	{F_CHGWRAPCOLUMN,		LTEXT("ChangeWrapColm"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�܂�Ԃ����ύX 2008.06.19 ryoji
-	{F_CHGWRAPCOLUMN,		LTEXT("ChangeWrapColumn"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�܂�Ԃ����ύX 2008.06.19 ryoji
-	{F_ISCURTYPEEXT,		LTEXT("IsCurTypeExt"),			{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �w�肵���g���q�����݂̃^�C�v�ʐݒ�Ɋ܂܂�Ă��邩�ǂ����𒲂ׂ� 2006.09.04 ryoji
-	{F_ISSAMETYPEEXT,		LTEXT("IsSameTypeExt"),			{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // �Q�̊g���q�������^�C�v�ʐݒ�Ɋ܂܂�Ă��邩�ǂ����𒲂ׂ� 2006.09.04 ryoji
-	{F_INPUTBOX,			LTEXT("InputBox"),				{VT_BSTR,  VT_BSTR,  VT_I4,    VT_EMPTY},	VT_BSTR,	NULL }, //�e�L�X�g���̓_�C�A���O�̕\��
-	{F_MESSAGEBOX,			LTEXT("MessageBox"),			{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���b�Z�[�W�{�b�N�X�̕\��
-	{F_ERRORMSG,			LTEXT("ErrorMsg"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���b�Z�[�W�{�b�N�X�i�G���[�j�̕\��
-	{F_WARNMSG,				LTEXT("WarnMsg"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���b�Z�[�W�{�b�N�X�i�x���j�̕\��
-	{F_INFOMSG,				LTEXT("InfoMsg"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���b�Z�[�W�{�b�N�X�i���j�̕\��
-	{F_OKCANCELBOX,			LTEXT("OkCancelBox"),			{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���b�Z�[�W�{�b�N�X�i�m�F�FOK�^�L�����Z���j�̕\��
-	{F_YESNOBOX,			LTEXT("YesNoBox"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���b�Z�[�W�{�b�N�X�i�m�F�F�͂��^�������j�̕\��
-	{F_COMPAREVERSION,		LTEXT("CompareVersion"),		{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�o�[�W�����ԍ��̔�r
-	{F_MACROSLEEP,			LTEXT("Sleep"),					{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�w�肵�����ԁi�~���b�j��~
-	{F_FILEOPENDIALOG,		LTEXT("FileOpenDialog"),		{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //�t�@�C�����J���_�C�A���O�̕\��
-	{F_FILESAVEDIALOG,		LTEXT("FileSaveDialog"),		{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //�t�@�C����ۑ��_�C�A���O�̕\��
-	{F_FOLDERDIALOG,		LTEXT("FolderDialog"),			{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //�t�H���_���J���_�C�A���O�̕\��
-	{F_GETCLIPBOARD,		LTEXT("GetClipboard"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //�N���b�v�{�[�h�̕�������擾
-	{F_SETCLIPBOARD,		LTEXT("SetClipboard"),			{VT_I4,    VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�N���b�v�{�[�h�ɕ������ݒ�
-	{F_LAYOUTTOLOGICLINENUM,LTEXT("LayoutToLogicLineNum"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���W�b�N�s�ԍ��擾
-	{F_LOGICTOLAYOUTLINENUM,LTEXT("LogicToLayoutLineNum"),	{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���C�A�E�g�s�ԍ��擾
-	{F_LINECOLUMNTOINDEX,	LTEXT("LineColumnToIndex"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���W�b�N���ԍ��擾
-	{F_LINEINDEXTOCOLUMN,	LTEXT("LineIndexToColumn"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���C�A�E�g���ԍ��擾
-	{F_GETCOOKIE,			LTEXT("GetCookie"),				{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //Cookie�擾
-	{F_GETCOOKIEDEFAULT,	LTEXT("GetCookieDefault"),		{VT_BSTR,  VT_BSTR,  VT_BSTR,  VT_EMPTY},	VT_BSTR,	NULL }, //Cookie�擾�f�t�H���g�l
-	{F_SETCOOKIE,			LTEXT("SetCookie"),				{VT_BSTR,  VT_BSTR,  VT_BSTR,  VT_EMPTY},	VT_I4,		NULL }, //Cookie�ݒ�
-	{F_DELETECOOKIE,		LTEXT("DeleteCookie"),			{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //Cookie�폜
-	{F_GETCOOKIENAMES,		LTEXT("GetCookieNames"),		{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //Cookie���O�擾
-	{F_SETDRAWSWITCH,		LTEXT("SetDrawSwitch"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�ĕ`��X�C�b�`�ݒ�
-	{F_GETDRAWSWITCH,		LTEXT("GetDrawSwitch"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�ĕ`��X�C�b�`�擾
-	{F_ISSHOWNSTATUS,		LTEXT("IsShownStatus"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�X�e�[�^�X�o�[���\������Ă��邩
-	{F_GETSTRWIDTH,			LTEXT("GetStrWidth"),			{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�����񕝎擾
-	{F_GETSTRLAYOUTLENGTH,	LTEXT("GetStrLayoutLength"),	{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //������̃��C�A�E�g���擾
-	{F_GETDEFAULTCHARLENGTH,	L"GetDefaultCharLength",	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�f�t�H���g�������̎擾
-	{F_ISINCLUDECLIPBOARDFORMAT,L"IsIncludeClipboardFormat",{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�N���b�v�{�[�h�̌`���擾
-	{F_GETCLIPBOARDBYFORMAT,	L"GetClipboardByFormat",	{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},	VT_BSTR,	NULL }, //�N���b�v�{�[�h�̎w��`���Ŏ擾
-	{F_SETCLIPBOARDBYFORMAT,	L"SetClipboardByFormat",	{VT_BSTR,  VT_BSTR,  VT_I4,    VT_I4,    },	VT_I4,		NULL }, //�N���b�v�{�[�h�̎w��`���Őݒ�
-	{F_GETLINEATTRIBUTE,		L"GetLineAttribute",		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�s�����擾
-	{F_ISTEXTSELECTINGLOCK,		L"IsTextSelectingLock",		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�I����Ԃ̃��b�N���擾
-	{F_GETVIEWLINES,			L"GetViewLines",			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�r���[�̍s���擾
-	{F_GETVIEWCOLUMNS,			L"GetViewColumns",			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //�r���[�̗񐔎擾
-	{F_CREATEMENU,				L"CreateMenu",				{VT_I4,    VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //���j���[�쐬
+	//ID					関数名							引数										戻り値の型	m_pszData
+	{F_GETFILENAME,			LTEXT("GetFilename"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //ファイル名を返す
+	{F_GETSAVEFILENAME,		LTEXT("GetSaveFilename"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //保存時のファイル名を返す 2006.09.04 ryoji
+	{F_GETSELECTED,			LTEXT("GetSelectedString"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //選択部分
+	{F_EXPANDPARAMETER,		LTEXT("ExpandParameter"),		{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //特殊文字の展開
+	{F_GETLINESTR,			LTEXT("GetLineStr"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, // 指定論理行の取得 2003.06.01 Moca
+	{F_GETLINECOUNT,		LTEXT("GetLineCount"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 全論理行数の取得 2003.06.01 Moca
+	{F_CHGTABWIDTH,			LTEXT("ChangeTabWidth"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //タブサイズ変更 2004.03.16 zenryaku
+	{F_ISTEXTSELECTED,		LTEXT("IsTextSelected"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //テキストが選択されているか 2005.7.30 maru
+	{F_GETSELLINEFROM,		LTEXT("GetSelectLineFrom"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 選択開始行の取得 2005.7.30 maru
+	{F_GETSELCOLUMNFROM,	LTEXT("GetSelectColmFrom"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 選択開始桁の取得 2005.7.30 maru
+	{F_GETSELCOLUMNFROM,	LTEXT("GetSelectColumnFrom"),	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 選択開始桁の取得 2005.7.30 maru
+	{F_GETSELLINETO,		LTEXT("GetSelectLineTo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 選択終了行の取得 2005.7.30 maru
+	{F_GETSELCOLUMNTO,		LTEXT("GetSelectColmTo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 選択終了桁の取得 2005.7.30 maru
+	{F_GETSELCOLUMNTO,		LTEXT("GetSelectColumnTo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 選択終了桁の取得 2005.7.30 maru
+	{F_ISINSMODE,			LTEXT("IsInsMode"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 挿入／上書きモードの取得 2005.7.30 maru
+	{F_GETCHARCODE,			LTEXT("GetCharCode"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 文字コード取得 2005.07.31 maru
+	{F_GETLINECODE,			LTEXT("GetLineCode"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 改行コード取得 2005.08.05 maru
+	{F_ISPOSSIBLEUNDO,		LTEXT("IsPossibleUndo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // Undo可能か調べる 2005.08.05 maru
+	{F_ISPOSSIBLEREDO,		LTEXT("IsPossibleRedo"),		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // Redo可能か調べる 2005.08.05 maru
+	{F_CHGWRAPCOLUMN,		LTEXT("ChangeWrapColm"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //折り返し桁変更 2008.06.19 ryoji
+	{F_CHGWRAPCOLUMN,		LTEXT("ChangeWrapColumn"),		{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //折り返し桁変更 2008.06.19 ryoji
+	{F_ISCURTYPEEXT,		LTEXT("IsCurTypeExt"),			{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // 指定した拡張子が現在のタイプ別設定に含まれているかどうかを調べる 2006.09.04 ryoji
+	{F_ISSAMETYPEEXT,		LTEXT("IsSameTypeExt"),			{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, // ２つの拡張子が同じタイプ別設定に含まれているかどうかを調べる 2006.09.04 ryoji
+	{F_INPUTBOX,			LTEXT("InputBox"),				{VT_BSTR,  VT_BSTR,  VT_I4,    VT_EMPTY},	VT_BSTR,	NULL }, //テキスト入力ダイアログの表示
+	{F_MESSAGEBOX,			LTEXT("MessageBox"),			{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //メッセージボックスの表示
+	{F_ERRORMSG,			LTEXT("ErrorMsg"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //メッセージボックス（エラー）の表示
+	{F_WARNMSG,				LTEXT("WarnMsg"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //メッセージボックス（警告）の表示
+	{F_INFOMSG,				LTEXT("InfoMsg"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //メッセージボックス（情報）の表示
+	{F_OKCANCELBOX,			LTEXT("OkCancelBox"),			{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //メッセージボックス（確認：OK／キャンセル）の表示
+	{F_YESNOBOX,			LTEXT("YesNoBox"),				{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //メッセージボックス（確認：はい／いいえ）の表示
+	{F_COMPAREVERSION,		LTEXT("CompareVersion"),		{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //バージョン番号の比較
+	{F_MACROSLEEP,			LTEXT("Sleep"),					{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //指定した時間（ミリ秒）停止
+	{F_FILEOPENDIALOG,		LTEXT("FileOpenDialog"),		{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //ファイルを開くダイアログの表示
+	{F_FILESAVEDIALOG,		LTEXT("FileSaveDialog"),		{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //ファイルを保存ダイアログの表示
+	{F_FOLDERDIALOG,		LTEXT("FolderDialog"),			{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //フォルダを開くダイアログの表示
+	{F_GETCLIPBOARD,		LTEXT("GetClipboard"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //クリップボードの文字列を取得
+	{F_SETCLIPBOARD,		LTEXT("SetClipboard"),			{VT_I4,    VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //クリップボードに文字列を設定
+	{F_LAYOUTTOLOGICLINENUM,LTEXT("LayoutToLogicLineNum"),	{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //ロジック行番号取得
+	{F_LOGICTOLAYOUTLINENUM,LTEXT("LogicToLayoutLineNum"),	{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //レイアウト行番号取得
+	{F_LINECOLUMNTOINDEX,	LTEXT("LineColumnToIndex"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //ロジック桁番号取得
+	{F_LINEINDEXTOCOLUMN,	LTEXT("LineIndexToColumn"),		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //レイアウト桁番号取得
+	{F_GETCOOKIE,			LTEXT("GetCookie"),				{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //Cookie取得
+	{F_GETCOOKIEDEFAULT,	LTEXT("GetCookieDefault"),		{VT_BSTR,  VT_BSTR,  VT_BSTR,  VT_EMPTY},	VT_BSTR,	NULL }, //Cookie取得デフォルト値
+	{F_SETCOOKIE,			LTEXT("SetCookie"),				{VT_BSTR,  VT_BSTR,  VT_BSTR,  VT_EMPTY},	VT_I4,		NULL }, //Cookie設定
+	{F_DELETECOOKIE,		LTEXT("DeleteCookie"),			{VT_BSTR,  VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //Cookie削除
+	{F_GETCOOKIENAMES,		LTEXT("GetCookieNames"),		{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //Cookie名前取得
+	{F_SETDRAWSWITCH,		LTEXT("SetDrawSwitch"),			{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //再描画スイッチ設定
+	{F_GETDRAWSWITCH,		LTEXT("GetDrawSwitch"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //再描画スイッチ取得
+	{F_ISSHOWNSTATUS,		LTEXT("IsShownStatus"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //ステータスバーが表示されているか
+	{F_GETSTRWIDTH,			LTEXT("GetStrWidth"),			{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //文字列幅取得
+	{F_GETSTRLAYOUTLENGTH,	LTEXT("GetStrLayoutLength"),	{VT_BSTR,  VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //文字列のレイアウト幅取得
+	{F_GETDEFAULTCHARLENGTH,	L"GetDefaultCharLength",	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //デフォルト文字幅の取得
+	{F_ISINCLUDECLIPBOARDFORMAT,L"IsIncludeClipboardFormat",{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //クリップボードの形式取得
+	{F_GETCLIPBOARDBYFORMAT,	L"GetClipboardByFormat",	{VT_BSTR,  VT_I4,    VT_I4,    VT_EMPTY},	VT_BSTR,	NULL }, //クリップボードの指定形式で取得
+	{F_SETCLIPBOARDBYFORMAT,	L"SetClipboardByFormat",	{VT_BSTR,  VT_BSTR,  VT_I4,    VT_I4,    },	VT_I4,		NULL }, //クリップボードの指定形式で設定
+	{F_GETLINEATTRIBUTE,		L"GetLineAttribute",		{VT_I4,    VT_I4,    VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //行属性取得
+	{F_ISTEXTSELECTINGLOCK,		L"IsTextSelectingLock",		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //選択状態のロックを取得
+	{F_GETVIEWLINES,			L"GetViewLines",			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //ビューの行数取得
+	{F_GETVIEWCOLUMNS,			L"GetViewColumns",			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //ビューの列数取得
+	{F_CREATEMENU,				L"CreateMenu",				{VT_I4,    VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //メニュー作成
 
-	//	�I�[
+	//	終端
 	//	Jun. 27, 2002 genta
-	//	�I�[�Ƃ��Ă͌����Č���Ȃ����̂��g���ׂ��Ȃ̂ŁC
-	//	FuncID��-1�ɕύX�D(0�͎g����)
+	//	終端としては決して現れないものを使うべきなので，
+	//	FuncIDを-1に変更．(0は使われる)
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 
 /*!
-	@date 2002.02.17 YAZAKI CShareData�̃C���X�^���X�́ACProcess�ɂЂƂ���̂݁B
-	@date 2002.04.29 genta �I�u�W�F�N�g�̎��͎̂��s���܂Ő������Ȃ��B
+	@date 2002.02.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
+	@date 2002.04.29 genta オブジェクトの実体は実行時まで生成しない。
 */
 CSMacroMgr::CSMacroMgr()
 {
@@ -511,10 +511,10 @@ CSMacroMgr::~CSMacroMgr()
 	ClearAll();
 	
 	//	Jun. 16, 2002 genta
-	//	ClearAll�Ɠ��������������̂ō폜
+	//	ClearAllと同じ処理だったので削除
 }
 
-/*! �L�[�}�N���̃o�b�t�@���N���A���� */
+/*! キーマクロのバッファをクリアする */
 void CSMacroMgr::ClearAll( void )
 {
 	int i;
@@ -530,16 +530,16 @@ void CSMacroMgr::ClearAll( void )
 	m_pTempMacro = NULL;
 }
 
-/*! @brief�L�[�}�N���̃o�b�t�@�Ƀf�[�^�ǉ�
+/*! @briefキーマクロのバッファにデータ追加
 
-	@param mbuf [in] �ǂݍ��ݐ�}�N���o�b�t�@
+	@param mbuf [in] 読み込み先マクロバッファ
 	
-	@date 2002.06.16 genta �L�[�}�N���̑���Ή��̂��ߕύX
+	@date 2002.06.16 genta キーマクロの多種対応のため変更
 */
 int CSMacroMgr::Append(
 	int				idx,		//!<
-	EFunctionCode	nFuncID,	//!< [in] �@�\�ԍ�
-	const LPARAM*	lParams,	//!< [in] �p�����[�^�B
+	EFunctionCode	nFuncID,	//!< [in] 機能番号
+	const LPARAM*	lParams,	//!< [in] パラメータ。
 	CEditView*		pcEditView	//!< 
 )
 {
@@ -547,9 +547,9 @@ int CSMacroMgr::Append(
 	if (idx == STAND_KEYMACRO){
 		CKeyMacroMgr* pKeyMacro = dynamic_cast<CKeyMacroMgr*>( m_pKeyMacro );
 		if( pKeyMacro == NULL ){
-			//	1. ���̂��܂������ꍇ
-			//	2. CKeyMacroMgr�ȊO�̕��������Ă����ꍇ
-			//	������ɂ��Ă��Đ�������D
+			//	1. 実体がまだ無い場合
+			//	2. CKeyMacroMgr以外の物が入っていた場合
+			//	いずれにしても再生成する．
 			delete m_pKeyMacro;
 			m_pKeyMacro = new CKeyMacroMgr;
 			pKeyMacro = dynamic_cast<CKeyMacroMgr*>( m_pKeyMacro );
@@ -560,26 +560,26 @@ int CSMacroMgr::Append(
 }
 
 
-/*!	@brief �L�[�{�[�h�}�N���̎��s
+/*!	@brief キーボードマクロの実行
 
-	CShareData����t�@�C�������擾���A���s����B
+	CShareDataからファイル名を取得し、実行する。
 
-	@param hInstance [in] �C���X�^���X
-	@param hwndParent [in] �e�E�B���h�E��
-	@param pViewClass [in] macro���s�Ώۂ�View
-	@param idx [in] �}�N���ԍ��B
-	@param flags [in] �}�N�����s�t���O�DHandleCommand�ɓn���I�v�V�����D
+	@param hInstance [in] インスタンス
+	@param hwndParent [in] 親ウィンドウの
+	@param pViewClass [in] macro実行対象のView
+	@param idx [in] マクロ番号。
+	@param flags [in] マクロ実行フラグ．HandleCommandに渡すオプション．
 
-	@date 2007.07.16 genta flags�ǉ�
+	@date 2007.07.16 genta flags追加
 */
 BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int flags )
 {
 	if( idx == STAND_KEYMACRO ){
 		//	Jun. 16, 2002 genta
-		//	�L�[�}�N���ȊO�̃T�|�[�g�ɂ��NULL�̉\�����o�Ă����̂Ŕ���ǉ�
+		//	キーマクロ以外のサポートによりNULLの可能性が出てきたので判定追加
 		if( m_pKeyMacro != NULL ){
 			//	Sep. 15, 2005 FILE
-			//	Jul. 01, 2007 �}�N���̑��d���s���ɔ����Ē��O�̃}�N���ԍ���ޔ�
+			//	Jul. 01, 2007 マクロの多重実行時に備えて直前のマクロ番号を退避
 			int prevmacro = SetCurrentIdx( idx );
 			m_pKeyMacro->ExecKeyMacro2( pcEditView, flags );
 			SetCurrentIdx( prevmacro );
@@ -589,7 +589,7 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 			return FALSE;
 		}
 	}
-	if( idx == TEMP_KEYMACRO ){		// �ꎞ�}�N��
+	if( idx == TEMP_KEYMACRO ){		// 一時マクロ
 		if( m_pTempMacro != NULL ){
 			int prevmacro = SetCurrentIdx( idx );
 			m_pTempMacro->ExecKeyMacro2( pcEditView, flags );
@@ -600,15 +600,15 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 			return FALSE;
 		}
 	}
-	if( idx < 0 || MAX_CUSTMACRO <= idx )	//	�͈̓`�F�b�N
+	if( idx < 0 || MAX_CUSTMACRO <= idx )	//	範囲チェック
 		return FALSE;
 
-	/* �ǂݍ��ݑO���A����ǂݍ��ސݒ�̏ꍇ�́A�t�@�C����ǂݍ��݂Ȃ��� */
+	/* 読み込み前か、毎回読み込む設定の場合は、ファイルを読み込みなおす */
 	//	Apr. 29, 2002 genta
 	if( m_cSavedKeyMacro[idx] == NULL || CShareData::getInstance()->BeReloadWhenExecuteMacro( idx )){
-		//	CShareData����A�}�N���t�@�C�������擾
-		//	Jun. 08, 2003 Moca �Ăяo�����Ńp�X����p��
-		//	Jun. 16, 2003 genta ������������ƕύX
+		//	CShareDataから、マクロファイル名を取得
+		//	Jun. 08, 2003 Moca 呼び出し側でパス名を用意
+		//	Jun. 16, 2003 genta 書式をちょっと変更
 		TCHAR ptr[_MAX_PATH * 2];
 		int n = CShareData::getInstance()->GetMacroFilename( idx, ptr, _countof(ptr) );
 		if ( n <= 0 ){
@@ -620,7 +620,7 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 	}
 
 	//	Sep. 15, 2005 FILE
-	//	Jul. 01, 2007 �}�N���̑��d���s���ɔ����Ē��O�̃}�N���ԍ���ޔ�
+	//	Jul. 01, 2007 マクロの多重実行時に備えて直前のマクロ番号を退避
 	int prevmacro = SetCurrentIdx( idx );
 	SetCurrentIdx( idx );
 	m_cSavedKeyMacro[idx]->ExecKeyMacro2(pcEditView, flags);
@@ -629,14 +629,14 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 	return TRUE;
 }
 
-/*! �L�[�{�[�h�}�N���̓ǂݍ���
+/*! キーボードマクロの読み込み
 
-	@param idx [in] �ǂݍ��ݐ�}�N���o�b�t�@�ԍ�
-	@param pszPath [in] �}�N���t�@�C�����A�܂��̓R�[�h������
-	@param pszType [in] ��ʁBNULL�̏ꍇ�t�@�C������ǂݍ��ށBNULL�ȊO�̏ꍇ�͌���̊g���q
+	@param idx [in] 読み込み先マクロバッファ番号
+	@param pszPath [in] マクロファイル名、またはコード文字列
+	@param pszType [in] 種別。NULLの場合ファイルから読み込む。NULL以外の場合は言語の拡張子
 
-	�ǂݍ��݂Ɏ��s�����Ƃ��̓}�N���o�b�t�@�̃I�u�W�F�N�g�͉������C
-	NULL���ݒ肳���D
+	読み込みに失敗したときはマクロバッファのオブジェクトは解放され，
+	NULLが設定される．
 
 	@author Norio Nakatani, YAZAKI, genta
 */
@@ -648,26 +648,26 @@ BOOL CSMacroMgr::Load( int idx, HINSTANCE hInstance, const TCHAR* pszPath, const
 		DEBUG_TRACE( _T("CSMacroMgr::Load() Out of range: idx=%d Path=%ts\n"), idx, pszPath);
 	}
 
-	//	�o�b�t�@�N���A
+	//	バッファクリア
 	delete *ppMacro;
 	*ppMacro = NULL;
 	
 	const TCHAR *ext;
-	if( pszType == NULL ){				//�t�@�C���w��
-		//�t�@�C���̊g���q���擾����
+	if( pszType == NULL ){				//ファイル指定
+		//ファイルの拡張子を取得する
 		ext = _tcsrchr( pszPath, _T('.'));
-		//	Feb. 02, 2004 genta .�������ꍇ��ext==NULL�ƂȂ�̂�NULL�`�F�b�N�ǉ�
+		//	Feb. 02, 2004 genta .が無い場合にext==NULLとなるのでNULLチェック追加
 		if( ext != NULL ){
 			const TCHAR *chk = _tcsrchr( ext, _T('\\') );
-			if( chk != NULL ){	//	.�̂��Ƃ�\���������炻��͊g���q�̋�؂�ł͂Ȃ�
-								//	\��������2�o�C�g�ڂ̏ꍇ���g���q�ł͂Ȃ��B
+			if( chk != NULL ){	//	.のあとに\があったらそれは拡張子の区切りではない
+								//	\が漢字の2バイト目の場合も拡張子ではない。
 				ext = NULL;
 			}
 		}
 		if(ext != NULL){
 			++ext;
 		}
-	}else{								//�R�[�h�w��
+	}else{								//コード指定
 		ext = pszType;
 	}
 
@@ -686,7 +686,7 @@ BOOL CSMacroMgr::Load( int idx, HINSTANCE hInstance, const TCHAR* pszPath, const
 	}
 
 	//	From Here Jun. 16, 2002 genta
-	//	�ǂݍ��݃G���[���̓C���X�^���X�폜
+	//	読み込みエラー時はインスタンス削除
 	if( bRet ){
 		return TRUE;
 	}
@@ -698,12 +698,12 @@ BOOL CSMacroMgr::Load( int idx, HINSTANCE hInstance, const TCHAR* pszPath, const
 	return FALSE;
 }
 
-/** �}�N���I�u�W�F�N�g�����ׂĔj������(�L�[�{�[�h�}�N���ȊO)
+/** マクロオブジェクトをすべて破棄する(キーボードマクロ以外)
 
-	�}�N���̓o�^��ύX�����ꍇ�ɁC�ύX�O�̃}�N����
-	�����������s����Ă��܂��̂�h���D
+	マクロの登録を変更した場合に，変更前のマクロが
+	引き続き実行されてしまうのを防ぐ．
 
-	@date 2007.10.19 genta �V�K�쐬
+	@date 2007.10.19 genta 新規作成
 */
 void CSMacroMgr::UnloadAll(void)
 {
@@ -714,11 +714,11 @@ void CSMacroMgr::UnloadAll(void)
 
 }
 
-/*! �L�[�{�[�h�}�N���̕ۑ�
+/*! キーボードマクロの保存
 
-	@param idx [in] �ǂݍ��ݐ�}�N���o�b�t�@�ԍ�
-	@param pszPath [in] �}�N���t�@�C����
-	@param hInstance [in] �C���X�^���X�n���h��
+	@param idx [in] 読み込み先マクロバッファ番号
+	@param pszPath [in] マクロファイル名
+	@param hInstance [in] インスタンスハンドル
 
 	@author YAZAKI
 */
@@ -731,7 +731,7 @@ BOOL CSMacroMgr::Save( int idx, HINSTANCE hInstance, const TCHAR* pszPath )
 			return pKeyMacro->SaveKeyMacro(hInstance, pszPath );
 		}
 		//	Jun. 27, 2002 genta
-		//	��}�N���̏ꍇ�͐���I���ƌ��Ȃ��D
+		//	空マクロの場合は正常終了と見なす．
 		if( m_pKeyMacro == NULL ){
 			return TRUE;
 		}
@@ -744,9 +744,9 @@ BOOL CSMacroMgr::Save( int idx, HINSTANCE hInstance, const TCHAR* pszPath )
 }
 
 /*
-	�w�肳�ꂽ�}�N�����N���A����
+	指定されたマクロをクリアする
 	
-	@param idx [in] �}�N���ԍ�(0-), STAND_KEYMACRO�͕W���L�[�}�N���o�b�t�@��\���D
+	@param idx [in] マクロ番号(0-), STAND_KEYMACROは標準キーマクロバッファを表す．
 */
 void CSMacroMgr::Clear( int idx )
 {
@@ -761,20 +761,20 @@ void CSMacroMgr::Clear( int idx )
 ||  Attributes & Operations
 */
 /*
-	�w�肳�ꂽID�ɑΉ�����MacroInfo�\���̂ւ̃|�C���^��Ԃ��D
-	�Y������ID�ɑΉ�����\���̂��Ȃ����NULL��Ԃ��D
+	指定されたIDに対応するMacroInfo構造体へのポインタを返す．
+	該当するIDに対応する構造体がなければNULLを返す．
 
-	@param nFuncID [in] �@�\�ԍ�
-	@return �\���̂ւ̃|�C���^�D������Ȃ����NULL
+	@param nFuncID [in] 機能番号
+	@return 構造体へのポインタ．見つからなければNULL
 	
 	@date 2002.06.16 genta
-	@date 2003.02.24 m_MacroFuncInfoArr�������Ώۂɂ���
+	@date 2003.02.24 m_MacroFuncInfoArrも検索対象にする
 */
 const MacroFuncInfo* CSMacroMgr::GetFuncInfoByID( int nFuncID )
 {
 	int i;
 	//	Jun. 27, 2002 genta
-	//	�Ԑl���R�[�h0�Ƃ��ďE���Ă��܂��̂ŁC�z��T�C�Y�ɂ�锻�����߂��D
+	//	番人をコード0として拾ってしまうので，配列サイズによる判定をやめた．
 	for( i = 0; m_MacroFuncInfoCommandArr[i].m_pszFuncName != NULL; ++i ){
 		if( m_MacroFuncInfoCommandArr[i].m_nFuncID == nFuncID ){
 			return &m_MacroFuncInfoCommandArr[i];
@@ -789,24 +789,24 @@ const MacroFuncInfo* CSMacroMgr::GetFuncInfoByID( int nFuncID )
 }
 
 /*!
-	�@�\�ԍ�����֐����Ƌ@�\�����{����擾
+	機能番号から関数名と機能名日本語を取得
 	
-	@return ���������Ƃ���pszFuncName�D������Ȃ������Ƃ���NULL�D
+	@return 成功したときはpszFuncName．見つからなかったときはNULL．
 	
 	@note
-	���ꂼ��C������i�[�̈�̎w���悪NULL�̎��͕�������i�[���Ȃ��D
-	�������CpszFuncName��NULL�ɂ��Ă��܂��Ɩ߂�l�����NULL�ɂȂ���
-	�������肪�s���Ȃ��Ȃ�D
-	�e���ꃁ�b�Z�[�W���\�[�X�Ή��ɂ��@�\�������{��łȂ��ꍇ������	
+	それぞれ，文字列格納領域の指す先がNULLの時は文字列を格納しない．
+	ただし，pszFuncNameをNULLにしてしまうと戻り値が常にNULLになって
+	成功判定が行えなくなる．
+	各国語メッセージリソース対応により機能名が日本語でない場合がある	
 
-	@date 2002.06.16 genta �V�݂�GetFuncInfoById(int)������Ŏg���悤�ɁD
-	@date 2011.04.10 nasukoji �e���ꃁ�b�Z�[�W���\�[�X�Ή�
+	@date 2002.06.16 genta 新設のGetFuncInfoById(int)を内部で使うように．
+	@date 2011.04.10 nasukoji 各国語メッセージリソース対応
 */
 WCHAR* CSMacroMgr::GetFuncInfoByID(
-	HINSTANCE	hInstance,			//!< [in] ���\�[�X�擾�̂��߂�Instance Handle
-	int			nFuncID,			//!< [in] �@�\�ԍ�
-	WCHAR*		pszFuncName,		//!< [out] �֐����D���̐�ɂ͍Œ��֐����{1�o�C�g�̃��������K�v�D
-	WCHAR*		pszFuncNameJapanese	//!< [out] �@�\�����{��DNULL���e. ���̐�ɂ�256�o�C�g�̃��������K�v�D
+	HINSTANCE	hInstance,			//!< [in] リソース取得のためのInstance Handle
+	int			nFuncID,			//!< [in] 機能番号
+	WCHAR*		pszFuncName,		//!< [out] 関数名．この先には最長関数名＋1バイトのメモリが必要．
+	WCHAR*		pszFuncNameJapanese	//!< [out] 機能名日本語．NULL許容. この先には256バイトのメモリが必要．
 )
 {
 	const MacroFuncInfo* MacroInfo = GetFuncInfoByID( nFuncID );
@@ -822,7 +822,7 @@ WCHAR* CSMacroMgr::GetFuncInfoByID(
 				p++;
 			}
 		}
-		//	Jun. 16, 2002 genta NULL�̂Ƃ��͉������Ȃ��D
+		//	Jun. 16, 2002 genta NULLのときは何もしない．
 		if( pszFuncNameJapanese != NULL ){
 			wcsncpy( pszFuncNameJapanese, LSW( nFuncID ), 255 );
 		}
@@ -832,26 +832,26 @@ WCHAR* CSMacroMgr::GetFuncInfoByID(
 }
 
 /*!
-	�֐����iS_xxxx�j����@�\�ԍ��Ƌ@�\�����{����擾�D
-	�֐�����S_�Ŏn�܂�ꍇ�Ǝn�܂�Ȃ��ꍇ�̗����ɑΉ��D
+	関数名（S_xxxx）から機能番号と機能名日本語を取得．
+	関数名はS_で始まる場合と始まらない場合の両方に対応．
 
-	@return ���������Ƃ��͋@�\�ԍ��D������Ȃ������Ƃ���-1�D
+	@return 成功したときは機能番号．見つからなかったときは-1．
 	
 	@note
-	pszFuncNameJapanese �̎w���悪NULL�̎��͓��{�ꖼ���i�[���Ȃ��D
+	pszFuncNameJapanese の指す先がNULLの時は日本語名を格納しない．
 	
-	@date 2002.06.16 genta ���[�v���̕�����R�s�[��r��
+	@date 2002.06.16 genta ループ内の文字列コピーを排除
 */
 EFunctionCode CSMacroMgr::GetFuncInfoByName(
-	HINSTANCE		hInstance,				//!< [in]  ���\�[�X�擾�̂��߂�Instance Handle
-	const WCHAR*	pszFuncName,			//!< [in]  �֐���
-	WCHAR*			pszFuncNameJapanese		//!< [out] �@�\�����{��D���̐�ɂ�256�o�C�g�̃��������K�v�D
+	HINSTANCE		hInstance,				//!< [in]  リソース取得のためのInstance Handle
+	const WCHAR*	pszFuncName,			//!< [in]  関数名
+	WCHAR*			pszFuncNameJapanese		//!< [out] 機能名日本語．この先には256バイトのメモリが必要．
 )
 {
 	//	Jun. 16, 2002 genta
 	const WCHAR* normalizedFuncName;
 	
-	//	S_�Ŏn�܂��Ă��邩
+	//	S_で始まっているか
 	if( pszFuncName == NULL ){
 		return F_INVALID;
 	}
@@ -862,7 +862,7 @@ EFunctionCode CSMacroMgr::GetFuncInfoByName(
 		normalizedFuncName = pszFuncName;
 	}
 
-	// �R�}���h�֐�������
+	// コマンド関数を検索
 	for( int i = 0; m_MacroFuncInfoCommandArr[i].m_pszFuncName != NULL; ++i ){
 		if( 0 == auto_strcmp( normalizedFuncName, m_MacroFuncInfoCommandArr[i].m_pszFuncName )){
 			EFunctionCode nFuncID = EFunctionCode(m_MacroFuncInfoCommandArr[i].m_nFuncID);
@@ -873,7 +873,7 @@ EFunctionCode CSMacroMgr::GetFuncInfoByName(
 			return nFuncID;
 		}
 	}
-	// ��R�}���h�֐�������
+	// 非コマンド関数を検索
 	for( int i = 0; m_MacroFuncInfoArr[i].m_pszFuncName != NULL; ++i ){
 		if( 0 == auto_strcmp( normalizedFuncName, m_MacroFuncInfoArr[i].m_pszFuncName )){
 			EFunctionCode nFuncID = EFunctionCode(m_MacroFuncInfoArr[i].m_nFuncID);
@@ -887,330 +887,330 @@ EFunctionCode CSMacroMgr::GetFuncInfoByName(
 	return F_INVALID;
 }
 
-/* �L�[�}�N���ɋL�^�\�ȋ@�\���ǂ����𒲂ׂ� */
+/* キーマクロに記録可能な機能かどうかを調べる */
 BOOL CSMacroMgr::CanFuncIsKeyMacro( int nFuncID )
 {
 	switch( nFuncID ){
-	/* �t�@�C������n */
-//	case F_FILENEW					://�V�K�쐬
-//	case F_FILEOPEN					://�J��
-//	case F_FILESAVE					://�㏑���ۑ�
-//	case F_FILESAVEAS_DIALOG		://���O��t���ĕۑ�
-//	case F_FILECLOSE				://����(����)	//Oct. 17, 2000 jepro �u�t�@�C�������v�Ƃ����L���v�V������ύX
-//	case F_FILECLOSE_OPEN			://���ĊJ��
-	case F_FILE_REOPEN				://�J������	//Dec. 4, 2002 genta
-	case F_FILE_REOPEN_SJIS			://SJIS�ŊJ������
-	case F_FILE_REOPEN_JIS			://JIS�ŊJ������
-	case F_FILE_REOPEN_EUC			://EUC�ŊJ������
-	case F_FILE_REOPEN_LATIN1		://Latin1�ŊJ������	// 2010/3/20 Uchi
-	case F_FILE_REOPEN_UNICODE		://Unicode�ŊJ������
-	case F_FILE_REOPEN_UNICODEBE	://UnicodeBE�ŊJ������
-	case F_FILE_REOPEN_UTF8			://UTF-8�ŊJ������
-	case F_FILE_REOPEN_CESU8		://CESU-8�ŊJ������	// 2010/3/20 Uchi
-	case F_FILE_REOPEN_UTF7			://UTF-7�ŊJ������
-//	case F_PRINT					://���
-//	case F_PRINT_DIALOG				://����_�C�A���O
-//	case F_PRINT_PREVIEW			://����v���r���[
-//	case F_PRINT_PAGESETUP			://����y�[�W�ݒ�	//Sept. 14, 2000 jepro �u����̃y�[�W���C�A�E�g�̐ݒ�v����ύX
-//	case F_OPEN_HfromtoC:			://������C/C++�w�b�_(�\�[�X)���J��	//Feb. 9, 2001 JEPRO �ǉ�
-//	case F_OPEN_HHPP				://������C/C++�w�b�_�t�@�C�����J��	//Feb. 9, 2001 jepro�u.c�܂���.cpp�Ɠ�����.h���J���v����ύX
-//	case F_OPEN_CCPP				://������C/C++�\�[�X�t�@�C�����J��	//Feb. 9, 2001 jepro�u.h�Ɠ�����.c(�Ȃ����.cpp)���J���v����ύX
-//	case F_ACTIVATE_SQLPLUS			:/* Oracle SQL*Plus���A�N�e�B�u�\�� */
-//	case F_PLSQL_COMPILE_ON_SQLPLUS	:/* Oracle SQL*Plus�Ŏ��s */	//Sept. 17, 2000 jepro �����́u�R���p�C���v���u���s�v�ɓ���
-///	case F_BROWSE					://�u���E�Y
-//	case F_PROPERTY_FILE			://�t�@�C���̃v���p�e�B
-//	case F_EXITALLEDITORS			://�ҏW�̑S�I��	// 2007.02.13 ryoji �ǉ�
-//	case F_EXITALL					://�T�N���G�f�B�^�̑S�I��	//Dec. 27, 2000 JEPRO �ǉ�
-//	case F_PUTFILE					://��ƒ��t�@�C���̈ꎞ�o��	2006.12.10 maru
-//	case F_INSFILE					://�L�����b�g�ʒu�Ƀt�@�C���}��	2006.12.10 maru
+	/* ファイル操作系 */
+//	case F_FILENEW					://新規作成
+//	case F_FILEOPEN					://開く
+//	case F_FILESAVE					://上書き保存
+//	case F_FILESAVEAS_DIALOG		://名前を付けて保存
+//	case F_FILECLOSE				://閉じて(無題)	//Oct. 17, 2000 jepro 「ファイルを閉じる」というキャプションを変更
+//	case F_FILECLOSE_OPEN			://閉じて開く
+	case F_FILE_REOPEN				://開き直す	//Dec. 4, 2002 genta
+	case F_FILE_REOPEN_SJIS			://SJISで開き直す
+	case F_FILE_REOPEN_JIS			://JISで開き直す
+	case F_FILE_REOPEN_EUC			://EUCで開き直す
+	case F_FILE_REOPEN_LATIN1		://Latin1で開き直す	// 2010/3/20 Uchi
+	case F_FILE_REOPEN_UNICODE		://Unicodeで開き直す
+	case F_FILE_REOPEN_UNICODEBE	://UnicodeBEで開き直す
+	case F_FILE_REOPEN_UTF8			://UTF-8で開き直す
+	case F_FILE_REOPEN_CESU8		://CESU-8で開き直す	// 2010/3/20 Uchi
+	case F_FILE_REOPEN_UTF7			://UTF-7で開き直す
+//	case F_PRINT					://印刷
+//	case F_PRINT_DIALOG				://印刷ダイアログ
+//	case F_PRINT_PREVIEW			://印刷プレビュー
+//	case F_PRINT_PAGESETUP			://印刷ページ設定	//Sept. 14, 2000 jepro 「印刷のページレイアウトの設定」から変更
+//	case F_OPEN_HfromtoC:			://同名のC/C++ヘッダ(ソース)を開く	//Feb. 9, 2001 JEPRO 追加
+//	case F_OPEN_HHPP				://同名のC/C++ヘッダファイルを開く	//Feb. 9, 2001 jepro「.cまたは.cppと同名の.hを開く」から変更
+//	case F_OPEN_CCPP				://同名のC/C++ソースファイルを開く	//Feb. 9, 2001 jepro「.hと同名の.c(なければ.cpp)を開く」から変更
+//	case F_ACTIVATE_SQLPLUS			:/* Oracle SQL*Plusをアクティブ表示 */
+//	case F_PLSQL_COMPILE_ON_SQLPLUS	:/* Oracle SQL*Plusで実行 */	//Sept. 17, 2000 jepro 説明の「コンパイル」を「実行」に統一
+///	case F_BROWSE					://ブラウズ
+//	case F_PROPERTY_FILE			://ファイルのプロパティ
+//	case F_EXITALLEDITORS			://編集の全終了	// 2007.02.13 ryoji 追加
+//	case F_EXITALL					://サクラエディタの全終了	//Dec. 27, 2000 JEPRO 追加
+//	case F_PUTFILE					://作業中ファイルの一時出力	2006.12.10 maru
+//	case F_INSFILE					://キャレット位置にファイル挿入	2006.12.10 maru
 
 
-	/* �ҏW�n */
-	case F_WCHAR					://��������
-	case F_IME_CHAR					://�S�p��������
-	case F_UNDO						://���ɖ߂�(Undo)
-	case F_REDO						://��蒼��(Redo)
-	case F_DELETE					://�폜
-	case F_DELETE_BACK				://�J�[�\���O���폜
-	case F_WordDeleteToStart		://�P��̍��[�܂ō폜
-	case F_WordDeleteToEnd			://�P��̉E�[�܂ō폜
-	case F_WordCut					://�P��؂���
-	case F_WordDelete				://�P��폜
-	case F_LineCutToStart			://�s���܂Ő؂���(���s�P��)
-	case F_LineCutToEnd				://�s���܂Ő؂���(���s�P��)
-	case F_LineDeleteToStart		://�s���܂ō폜(���s�P��)
-	case F_LineDeleteToEnd			://�s���܂ō폜(���s�P��)
-	case F_CUT_LINE					://�s�؂���(�܂�Ԃ��P��)
-	case F_DELETE_LINE				://�s�폜(�܂�Ԃ��P��)
-	case F_DUPLICATELINE			://�s�̓�d��(�܂�Ԃ��P��)
-	case F_INDENT_TAB				://TAB�C���f���g
-	case F_UNINDENT_TAB				://�tTAB�C���f���g
-	case F_INDENT_SPACE				://SPACE�C���f���g
-	case F_UNINDENT_SPACE			://�tSPACE�C���f���g
+	/* 編集系 */
+	case F_WCHAR					://文字入力
+	case F_IME_CHAR					://全角文字入力
+	case F_UNDO						://元に戻す(Undo)
+	case F_REDO						://やり直し(Redo)
+	case F_DELETE					://削除
+	case F_DELETE_BACK				://カーソル前を削除
+	case F_WordDeleteToStart		://単語の左端まで削除
+	case F_WordDeleteToEnd			://単語の右端まで削除
+	case F_WordCut					://単語切り取り
+	case F_WordDelete				://単語削除
+	case F_LineCutToStart			://行頭まで切り取り(改行単位)
+	case F_LineCutToEnd				://行末まで切り取り(改行単位)
+	case F_LineDeleteToStart		://行頭まで削除(改行単位)
+	case F_LineDeleteToEnd			://行末まで削除(改行単位)
+	case F_CUT_LINE					://行切り取り(折り返し単位)
+	case F_DELETE_LINE				://行削除(折り返し単位)
+	case F_DUPLICATELINE			://行の二重化(折り返し単位)
+	case F_INDENT_TAB				://TABインデント
+	case F_UNINDENT_TAB				://逆TABインデント
+	case F_INDENT_SPACE				://SPACEインデント
+	case F_UNINDENT_SPACE			://逆SPACEインデント
 	case F_LTRIM					:// 2001.12.03 hor
 	case F_RTRIM					:// 2001.12.03 hor
 	case F_SORT_ASC					:// 2001.12.06 hor
 	case F_SORT_DESC				:// 2001.12.06 hor
 	case F_MERGE					:// 2001.12.06 hor
 
-	/* �J�[�\���ړ��n */
-	case F_UP						://�J�[�\����ړ�
-	case F_DOWN						://�J�[�\�����ړ�
-	case F_LEFT						://�J�[�\�����ړ�
-	case F_RIGHT					://�J�[�\���E�ړ�
-//	case F_ROLLDOWN					://�X�N���[���_�E��
-//	case F_ROLLUP					://�X�N���[���A�b�v
-	// 2014.01.15 (Half)Page[Up/down] ��L����
-	case F_HalfPageUp				://���y�[�W�A�b�v	//Oct. 6, 2000 JEPRO ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-	case F_HalfPageDown				://���y�[�W�_�E��	//Oct. 6, 2000 JEPRO ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-	case F_1PageUp					://�P�y�[�W�A�b�v	//Oct. 10, 2000 JEPRO �]���̃y�[�W�A�b�v�𔼃y�[�W�A�b�v�Ɩ��̕ύX���P�y�[�W�A�b�v��ǉ�
-	case F_1PageDown				://�P�y�[�W�_�E��	//Oct. 10, 2000 JEPRO �]���̃y�[�W�_�E���𔼃y�[�W�_�E���Ɩ��̕ύX���P�y�[�W�_�E����ǉ�
-	case F_UP2						://�J�[�\����ړ�(�Q�s����)
-	case F_DOWN2					://�J�[�\�����ړ�(�Q�s����)
-	case F_GOLINETOP				://�s���Ɉړ�(�܂�Ԃ��P��)
-	case F_GOLINEEND				://�s���Ɉړ�(�܂�Ԃ��P��)
-	case F_GOFILETOP				://�t�@�C���̐擪�Ɉړ�
-	case F_GOFILEEND				://�t�@�C���̍Ō�Ɉړ�
-	case F_WORDLEFT					://�P��̍��[�Ɉړ�
-	case F_WORDRIGHT				://�P��̉E�[�Ɉړ�
-	case F_CURLINECENTER			://�J�[�\���s���E�B���h�E������
-	case F_JUMPHIST_PREV			://�ړ�����: �O��
-	case F_JUMPHIST_NEXT			://�ړ�����: ����
-	case F_JUMPHIST_SET				://���݈ʒu���ړ������ɓo�^
-	case F_MODIFYLINE_NEXT			://���̕ύX�s�ֈړ�
-	case F_MODIFYLINE_PREV			://�O�̕ύX�s�ֈړ�
+	/* カーソル移動系 */
+	case F_UP						://カーソル上移動
+	case F_DOWN						://カーソル下移動
+	case F_LEFT						://カーソル左移動
+	case F_RIGHT					://カーソル右移動
+//	case F_ROLLDOWN					://スクロールダウン
+//	case F_ROLLUP					://スクロールアップ
+	// 2014.01.15 (Half)Page[Up/down] を有効化
+	case F_HalfPageUp				://半ページアップ	//Oct. 6, 2000 JEPRO 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+	case F_HalfPageDown				://半ページダウン	//Oct. 6, 2000 JEPRO 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+	case F_1PageUp					://１ページアップ	//Oct. 10, 2000 JEPRO 従来のページアップを半ページアップと名称変更し１ページアップを追加
+	case F_1PageDown				://１ページダウン	//Oct. 10, 2000 JEPRO 従来のページダウンを半ページダウンと名称変更し１ページダウンを追加
+	case F_UP2						://カーソル上移動(２行ごと)
+	case F_DOWN2					://カーソル下移動(２行ごと)
+	case F_GOLINETOP				://行頭に移動(折り返し単位)
+	case F_GOLINEEND				://行末に移動(折り返し単位)
+	case F_GOFILETOP				://ファイルの先頭に移動
+	case F_GOFILEEND				://ファイルの最後に移動
+	case F_WORDLEFT					://単語の左端に移動
+	case F_WORDRIGHT				://単語の右端に移動
+	case F_CURLINECENTER			://カーソル行をウィンドウ中央へ
+	case F_JUMPHIST_PREV			://移動履歴: 前へ
+	case F_JUMPHIST_NEXT			://移動履歴: 次へ
+	case F_JUMPHIST_SET				://現在位置を移動履歴に登録
+	case F_MODIFYLINE_NEXT			://次の変更行へ移動
+	case F_MODIFYLINE_PREV			://前の変更行へ移動
 
-	/* �I���n */	//Oct. 15, 2000 JEPRO �u�J�[�\���ړ��n�v�������Ȃ����̂œƗ�������(�I��)���ړ�(�T�u���j���[���͍\����ł��Ȃ��̂�)
-	case F_SELECTWORD				://���݈ʒu�̒P��I��
-	case F_SELECTALL				://���ׂđI��
-	case F_SELECTLINE				://1�s�I��	// 2007.10.06 nasukoji
-	case F_BEGIN_SEL				://�͈͑I���J�n
-	case F_UP_SEL					://(�͈͑I��)�J�[�\����ړ�
-	case F_DOWN_SEL					://(�͈͑I��)�J�[�\�����ړ�
-	case F_LEFT_SEL					://(�͈͑I��)�J�[�\�����ړ�
-	case F_RIGHT_SEL				://(�͈͑I��)�J�[�\���E�ړ�
-	case F_UP2_SEL					://(�͈͑I��)�J�[�\����ړ�(�Q�s����)
-	case F_DOWN2_SEL				://(�͈͑I��)�J�[�\�����ړ�(�Q�s����)
-	case F_WORDLEFT_SEL				://(�͈͑I��)�P��̍��[�Ɉړ�
-	case F_WORDRIGHT_SEL			://(�͈͑I��)�P��̉E�[�Ɉړ�
-	case F_GOLINETOP_SEL			://(�͈͑I��)�s���Ɉړ�(�܂�Ԃ��P��)
-	case F_GOLINEEND_SEL			://(�͈͑I��)�s���Ɉړ�(�܂�Ԃ��P��)
-//	case F_ROLLDOWN_SEL				://(�͈͑I��)�X�N���[���_�E��
-//	case F_ROLLUP_SEL				://(�͈͑I��)�X�N���[���A�b�v
-	// 2014.01.15 (Half)Page[Up/down] ��L����
-	case F_HalfPageUp_Sel			://(�͈͑I��)���y�[�W�A�b�v	//Oct. 6, 2000 JEPRO ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-	case F_HalfPageDown_Sel			://(�͈͑I��)���y�[�W�_�E��	//Oct. 6, 2000 JEPRO ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-	case F_1PageUp_Sel				://(�͈͑I��)�P�y�[�W�A�b�v	//Oct. 10, 2000 JEPRO �]���̃y�[�W�A�b�v�𔼃y�[�W�A�b�v�Ɩ��̕ύX���P�y�[�W�A�b�v��ǉ�
-	case F_1PageDown_Sel			://(�͈͑I��)�P�y�[�W�_�E��	//Oct. 10, 2000 JEPRO �]���̃y�[�W�_�E���𔼃y�[�W�_�E���Ɩ��̕ύX���P�y�[�W�_�E����ǉ�
-	case F_GOFILETOP_SEL			://(�͈͑I��)�t�@�C���̐擪�Ɉړ�
-	case F_GOFILEEND_SEL			://(�͈͑I��)�t�@�C���̍Ō�Ɉړ�
-	case F_MODIFYLINE_NEXT_SEL		://(�͈͑I��)���̕ύX�s�ֈړ�
-	case F_MODIFYLINE_PREV_SEL		://(�͈͑I��)�O�̕ύX�s�ֈړ�
+	/* 選択系 */	//Oct. 15, 2000 JEPRO 「カーソル移動系」が多くなったので独立化して(選択)を移動(サブメニュー化は構造上できないので)
+	case F_SELECTWORD				://現在位置の単語選択
+	case F_SELECTALL				://すべて選択
+	case F_SELECTLINE				://1行選択	// 2007.10.06 nasukoji
+	case F_BEGIN_SEL				://範囲選択開始
+	case F_UP_SEL					://(範囲選択)カーソル上移動
+	case F_DOWN_SEL					://(範囲選択)カーソル下移動
+	case F_LEFT_SEL					://(範囲選択)カーソル左移動
+	case F_RIGHT_SEL				://(範囲選択)カーソル右移動
+	case F_UP2_SEL					://(範囲選択)カーソル上移動(２行ごと)
+	case F_DOWN2_SEL				://(範囲選択)カーソル下移動(２行ごと)
+	case F_WORDLEFT_SEL				://(範囲選択)単語の左端に移動
+	case F_WORDRIGHT_SEL			://(範囲選択)単語の右端に移動
+	case F_GOLINETOP_SEL			://(範囲選択)行頭に移動(折り返し単位)
+	case F_GOLINEEND_SEL			://(範囲選択)行末に移動(折り返し単位)
+//	case F_ROLLDOWN_SEL				://(範囲選択)スクロールダウン
+//	case F_ROLLUP_SEL				://(範囲選択)スクロールアップ
+	// 2014.01.15 (Half)Page[Up/down] を有効化
+	case F_HalfPageUp_Sel			://(範囲選択)半ページアップ	//Oct. 6, 2000 JEPRO 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+	case F_HalfPageDown_Sel			://(範囲選択)半ページダウン	//Oct. 6, 2000 JEPRO 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+	case F_1PageUp_Sel				://(範囲選択)１ページアップ	//Oct. 10, 2000 JEPRO 従来のページアップを半ページアップと名称変更し１ページアップを追加
+	case F_1PageDown_Sel			://(範囲選択)１ページダウン	//Oct. 10, 2000 JEPRO 従来のページダウンを半ページダウンと名称変更し１ページダウンを追加
+	case F_GOFILETOP_SEL			://(範囲選択)ファイルの先頭に移動
+	case F_GOFILEEND_SEL			://(範囲選択)ファイルの最後に移動
+	case F_MODIFYLINE_NEXT_SEL		://(範囲選択)次の変更行へ移動
+	case F_MODIFYLINE_PREV_SEL		://(範囲選択)前の変更行へ移動
 
-	/* ��`�I���n */	//Oct. 17, 2000 JEPRO (��`�I��)���V�݂��ꎟ�悱���ɂ���
-//	case F_BOXSELALL				//��`�ł��ׂđI��
-	case F_BEGIN_BOX				://��`�͈͑I���J�n
+	/* 矩形選択系 */	//Oct. 17, 2000 JEPRO (矩形選択)が新設され次第ここにおく
+//	case F_BOXSELALL				//矩形ですべて選択
+	case F_BEGIN_BOX				://矩形範囲選択開始
 
-	case F_UP_BOX					://(��`�I��)�J�[�\����ړ�
-	case F_DOWN_BOX					://(��`�I��)�J�[�\�����ړ�
-	case F_LEFT_BOX					://(��`�I��)�J�[�\�����ړ�
-	case F_RIGHT_BOX				://(��`�I��)�J�[�\���E�ړ�
-	case F_UP2_BOX					://(��`�I��)�J�[�\����ړ�(�Q�s����)
-	case F_DOWN2_BOX				://(��`�I��)�J�[�\�����ړ�(�Q�s����)
-	case F_WORDLEFT_BOX				://(��`�I��)�P��̍��[�Ɉړ�
-	case F_WORDRIGHT_BOX			://(��`�I��)�P��̉E�[�Ɉړ�
-	case F_GOLOGICALLINETOP_BOX		://(��`�I��)�s���Ɉړ�(���s�P��)
-	case F_GOLINETOP_BOX			://(��`�I��)�s���Ɉړ�(�܂�Ԃ��P��)
-	case F_GOLINEEND_BOX			://(��`�I��)�s���Ɉړ�(�܂�Ԃ��P��)
-	case F_HalfPageUp_BOX			://(��`�I��)���y�[�W�A�b�v
-	case F_HalfPageDown_BOX			://(��`�I��)���y�[�W�_�E��
-	case F_1PageUp_BOX				://(��`�I��)�P�y�[�W�A�b�v
-	case F_1PageDown_BOX			://(��`�I��)�P�y�[�W�_�E��
-	case F_GOFILETOP_BOX			://(��`�I��)�t�@�C���̐擪�Ɉړ�
-	case F_GOFILEEND_BOX			://(��`�I��)�t�@�C���̍Ō�Ɉړ�
+	case F_UP_BOX					://(矩形選択)カーソル上移動
+	case F_DOWN_BOX					://(矩形選択)カーソル下移動
+	case F_LEFT_BOX					://(矩形選択)カーソル左移動
+	case F_RIGHT_BOX				://(矩形選択)カーソル右移動
+	case F_UP2_BOX					://(矩形選択)カーソル上移動(２行ごと)
+	case F_DOWN2_BOX				://(矩形選択)カーソル下移動(２行ごと)
+	case F_WORDLEFT_BOX				://(矩形選択)単語の左端に移動
+	case F_WORDRIGHT_BOX			://(矩形選択)単語の右端に移動
+	case F_GOLOGICALLINETOP_BOX		://(矩形選択)行頭に移動(改行単位)
+	case F_GOLINETOP_BOX			://(矩形選択)行頭に移動(折り返し単位)
+	case F_GOLINEEND_BOX			://(矩形選択)行末に移動(折り返し単位)
+	case F_HalfPageUp_BOX			://(矩形選択)半ページアップ
+	case F_HalfPageDown_BOX			://(矩形選択)半ページダウン
+	case F_1PageUp_BOX				://(矩形選択)１ページアップ
+	case F_1PageDown_BOX			://(矩形選択)１ページダウン
+	case F_GOFILETOP_BOX			://(矩形選択)ファイルの先頭に移動
+	case F_GOFILEEND_BOX			://(矩形選択)ファイルの最後に移動
 
-	/* �N���b�v�{�[�h�n */
-	case F_CUT						://�؂���(�I��͈͂��N���b�v�{�[�h�ɃR�s�[���č폜)
-	case F_COPY						://�R�s�[(�I��͈͂��N���b�v�{�[�h�ɃR�s�[)
-	case F_COPY_ADDCRLF				://�܂�Ԃ��ʒu�ɉ��s�����ăR�s�[
-	case F_COPY_CRLF				://CRLF���s�ŃR�s�[(�I��͈͂����s�R�[�h=CRLF�ŃR�s�[)
-	case F_PASTE					://�\��t��(�N���b�v�{�[�h����\��t��)
-	case F_PASTEBOX					://��`�\��t��(�N���b�v�{�[�h�����`�\��t��)
-	case F_INSTEXT_W					://�e�L�X�g��\��t��
-//	case F_ADDTAIL_W					://�Ō�Ƀe�L�X�g��ǉ�
-	case F_COPYLINES				://�I��͈͓��S�s�R�s�[
-	case F_COPYLINESASPASSAGE		://�I��͈͓��S�s���p���t���R�s�[
-	case F_COPYLINESWITHLINENUMBER 	://�I��͈͓��S�s�s�ԍ��t���R�s�[
-	case F_COPY_COLOR_HTML			://�I��͈͓��F�t��HTML�R�s�[
-	case F_COPY_COLOR_HTML_LINENUMBER://�I��͈͓��s�ԍ��F�t��HTML�R�s�[
-	case F_COPYPATH					://���̃t�@�C���̃p�X�����N���b�v�{�[�h�ɃR�s�[
-	case F_COPYTAG					://���̃t�@�C���̃p�X���ƃJ�[�\���ʒu���R�s�[	//Sept. 15, 2000 jepro ��Ɠ��������ɂȂ��Ă����̂��C��
-	case F_COPYFNAME				://���̃t�@�C�������N���b�v�{�[�h�ɃR�s�[ // 2002/2/3 aroka
-	case F_CREATEKEYBINDLIST		://�L�[���蓖�Ĉꗗ���R�s�[	//Sept. 15, 2000 JEPRO �ǉ�	//Dec. 25, 2000 ����
+	/* クリップボード系 */
+	case F_CUT						://切り取り(選択範囲をクリップボードにコピーして削除)
+	case F_COPY						://コピー(選択範囲をクリップボードにコピー)
+	case F_COPY_ADDCRLF				://折り返し位置に改行をつけてコピー
+	case F_COPY_CRLF				://CRLF改行でコピー(選択範囲を改行コード=CRLFでコピー)
+	case F_PASTE					://貼り付け(クリップボードから貼り付け)
+	case F_PASTEBOX					://矩形貼り付け(クリップボードから矩形貼り付け)
+	case F_INSTEXT_W					://テキストを貼り付け
+//	case F_ADDTAIL_W					://最後にテキストを追加
+	case F_COPYLINES				://選択範囲内全行コピー
+	case F_COPYLINESASPASSAGE		://選択範囲内全行引用符付きコピー
+	case F_COPYLINESWITHLINENUMBER 	://選択範囲内全行行番号付きコピー
+	case F_COPY_COLOR_HTML			://選択範囲内色付きHTMLコピー
+	case F_COPY_COLOR_HTML_LINENUMBER://選択範囲内行番号色付きHTMLコピー
+	case F_COPYPATH					://このファイルのパス名をクリップボードにコピー
+	case F_COPYTAG					://このファイルのパス名とカーソル位置をコピー	//Sept. 15, 2000 jepro 上と同じ説明になっていたのを修正
+	case F_COPYFNAME				://このファイル名をクリップボードにコピー // 2002/2/3 aroka
+	case F_CREATEKEYBINDLIST		://キー割り当て一覧をコピー	//Sept. 15, 2000 JEPRO 追加	//Dec. 25, 2000 復活
 
-	/* �}���n */
-	case F_INS_DATE					:// ���t�}��
-	case F_INS_TIME					:// �����}��
-//	case F_CTRL_CODE_DIALOG			://�R���g���[���R�[�h�̓���(�_�C�A���O)	//@@@ 2002.06.02 MIK
-	case F_CTRL_CODE				://�R���g���[���R�[�h�̓��� 2013.12.12
+	/* 挿入系 */
+	case F_INS_DATE					:// 日付挿入
+	case F_INS_TIME					:// 時刻挿入
+//	case F_CTRL_CODE_DIALOG			://コントロールコードの入力(ダイアログ)	//@@@ 2002.06.02 MIK
+	case F_CTRL_CODE				://コントロールコードの入力 2013.12.12
 
-	/* �ϊ��n */
-	case F_TOLOWER		 			://������
-	case F_TOUPPER		 			://�啶��
-	case F_TOHANKAKU		 		:/* �S�p�����p */
-	case F_TOHANKATA		 		:/* �S�p�J�^�J�i�����p�J�^�J�i */	//Aug. 29, 2002 ai
-	case F_TOZENEI			 		:/* ���p�p�����S�p�p�� */			//July. 30, 2001 Misaka
-	case F_TOHANEI			 		:/* �S�p�p�������p�p�� */
-	case F_TOZENKAKUKATA	 		:/* ���p�{�S�Ђ灨�S�p�E�J�^�J�i */	//Sept. 17, 2000 jepro �������u���p���S�p�J�^�J�i�v����ύX
-	case F_TOZENKAKUHIRA	 		:/* ���p�{�S�J�^���S�p�E�Ђ炪�� */	//Sept. 17, 2000 jepro �������u���p���S�p�Ђ炪�ȁv����ύX
-	case F_HANKATATOZENKATA			:/* ���p�J�^�J�i���S�p�J�^�J�i */
-	case F_HANKATATOZENHIRA			:/* ���p�J�^�J�i���S�p�Ђ炪�� */
-	case F_TABTOSPACE				:/* TAB���� */
-	case F_SPACETOTAB				:/* �󔒁�TAB */  //---- Stonee, 2001/05/27
-	case F_CODECNV_AUTO2SJIS		:/* �������ʁ�SJIS�R�[�h�ϊ� */
-	case F_CODECNV_EMAIL			://E-Mail(JIS��SJIS)�R�[�h�ϊ�
-	case F_CODECNV_EUC2SJIS			://EUC��SJIS�R�[�h�ϊ�
-	case F_CODECNV_UNICODE2SJIS		://Unicode��SJIS�R�[�h�ϊ�
-	case F_CODECNV_UNICODEBE2SJIS	://UnicodeBE��SJIS�R�[�h�ϊ�
-	case F_CODECNV_UTF82SJIS		:/* UTF-8��SJIS�R�[�h�ϊ� */
-	case F_CODECNV_UTF72SJIS		:/* UTF-7��SJIS�R�[�h�ϊ� */
-	case F_CODECNV_SJIS2JIS			:/* SJIS��JIS�R�[�h�ϊ� */
-	case F_CODECNV_SJIS2EUC			:/* SJIS��EUC�R�[�h�ϊ� */
-	case F_CODECNV_SJIS2UTF8		:/* SJIS��UTF-8�R�[�h�ϊ� */
-	case F_CODECNV_SJIS2UTF7		:/* SJIS��UTF-7�R�[�h�ϊ� */
-//	case F_BASE64DECODE	 			://Base64�f�R�[�h���ĕۑ�
-//	case F_UUDECODE		 			://uudecode���ĕۑ�	//Oct. 17, 2000 jepro �������u�I�𕔕���UUENCODE�f�R�[�h�v����ύX
+	/* 変換系 */
+	case F_TOLOWER		 			://小文字
+	case F_TOUPPER		 			://大文字
+	case F_TOHANKAKU		 		:/* 全角→半角 */
+	case F_TOHANKATA		 		:/* 全角カタカナ→半角カタカナ */	//Aug. 29, 2002 ai
+	case F_TOZENEI			 		:/* 半角英数→全角英数 */			//July. 30, 2001 Misaka
+	case F_TOHANEI			 		:/* 全角英数→半角英数 */
+	case F_TOZENKAKUKATA	 		:/* 半角＋全ひら→全角・カタカナ */	//Sept. 17, 2000 jepro 説明を「半角→全角カタカナ」から変更
+	case F_TOZENKAKUHIRA	 		:/* 半角＋全カタ→全角・ひらがな */	//Sept. 17, 2000 jepro 説明を「半角→全角ひらがな」から変更
+	case F_HANKATATOZENKATA			:/* 半角カタカナ→全角カタカナ */
+	case F_HANKATATOZENHIRA			:/* 半角カタカナ→全角ひらがな */
+	case F_TABTOSPACE				:/* TAB→空白 */
+	case F_SPACETOTAB				:/* 空白→TAB */  //---- Stonee, 2001/05/27
+	case F_CODECNV_AUTO2SJIS		:/* 自動判別→SJISコード変換 */
+	case F_CODECNV_EMAIL			://E-Mail(JIS→SJIS)コード変換
+	case F_CODECNV_EUC2SJIS			://EUC→SJISコード変換
+	case F_CODECNV_UNICODE2SJIS		://Unicode→SJISコード変換
+	case F_CODECNV_UNICODEBE2SJIS	://UnicodeBE→SJISコード変換
+	case F_CODECNV_UTF82SJIS		:/* UTF-8→SJISコード変換 */
+	case F_CODECNV_UTF72SJIS		:/* UTF-7→SJISコード変換 */
+	case F_CODECNV_SJIS2JIS			:/* SJIS→JISコード変換 */
+	case F_CODECNV_SJIS2EUC			:/* SJIS→EUCコード変換 */
+	case F_CODECNV_SJIS2UTF8		:/* SJIS→UTF-8コード変換 */
+	case F_CODECNV_SJIS2UTF7		:/* SJIS→UTF-7コード変換 */
+//	case F_BASE64DECODE	 			://Base64デコードして保存
+//	case F_UUDECODE		 			://uudecodeして保存	//Oct. 17, 2000 jepro 説明を「選択部分をUUENCODEデコード」から変更
 
-	/* �����n */
-//	case F_SEARCH_DIALOG			://����(�P�ꌟ���_�C�A���O)
-	case F_SEARCH_NEXT				://��������
-	case F_SEARCH_PREV				://�O������
-	case F_REPLACE					://�u��(���s)
-	case F_REPLACE_ALL				://���ׂĒu��(���s)
-	case F_SEARCH_CLEARMARK			://�����}�[�N�̃N���A
-	case F_JUMP_SRCHSTARTPOS		://�����J�n�ʒu�֖߂�		// 02/06/26 ai
+	/* 検索系 */
+//	case F_SEARCH_DIALOG			://検索(単語検索ダイアログ)
+	case F_SEARCH_NEXT				://次を検索
+	case F_SEARCH_PREV				://前を検索
+	case F_REPLACE					://置換(実行)
+	case F_REPLACE_ALL				://すべて置換(実行)
+	case F_SEARCH_CLEARMARK			://検索マークのクリア
+	case F_JUMP_SRCHSTARTPOS		://検索開始位置へ戻る		// 02/06/26 ai
 	case F_GREP						://Grep
-//	case F_JUMP_DIALOG				://�w��s�w�W�����v
-	case F_JUMP						://�w��s�փW�����v @@@ 2002.2.2 YAZAKI
-//	case F_OUTLINE					://�A�E�g���C�����
-	case F_TAGJUMP					://�^�O�W�����v�@�\
-	case F_TAGJUMPBACK				://�^�O�W�����v�o�b�N�@�\
-//	case F_TAGS_MAKE				://�^�O�t�@�C���̍쐬	//@@@ 2003.04.13 MIK
-//	case F_COMPARE					://�t�@�C�����e��r
-//	case F_DIFF_DIALOG				://DIFF�����\��(�_�C�A���O)	//@@@ 2002.05.25 MIK
-//	case F_DIFF						://DIFF�����\��				//@@@ 2002.05.25 MIK
-//	case F_DIFF_NEXT				://DIFF�����\��(����)		//@@@ 2002.05.25 MIK
-//	case F_DIFF_PREV				://DIFF�����\��(�O��)		//@@@ 2002.05.25 MIK
-//	case F_DIFF_RESET				://DIFF�����\��(�S����)		//@@@ 2002.05.25 MIK
-	case F_BRACKETPAIR				://�Ί��ʂ̌���
+//	case F_JUMP_DIALOG				://指定行ヘジャンプ
+	case F_JUMP						://指定行へジャンプ @@@ 2002.2.2 YAZAKI
+//	case F_OUTLINE					://アウトライン解析
+	case F_TAGJUMP					://タグジャンプ機能
+	case F_TAGJUMPBACK				://タグジャンプバック機能
+//	case F_TAGS_MAKE				://タグファイルの作成	//@@@ 2003.04.13 MIK
+//	case F_COMPARE					://ファイル内容比較
+//	case F_DIFF_DIALOG				://DIFF差分表示(ダイアログ)	//@@@ 2002.05.25 MIK
+//	case F_DIFF						://DIFF差分表示				//@@@ 2002.05.25 MIK
+//	case F_DIFF_NEXT				://DIFF差分表示(次へ)		//@@@ 2002.05.25 MIK
+//	case F_DIFF_PREV				://DIFF差分表示(前へ)		//@@@ 2002.05.25 MIK
+//	case F_DIFF_RESET				://DIFF差分表示(全解除)		//@@@ 2002.05.25 MIK
+	case F_BRACKETPAIR				://対括弧の検索
 // From Here 2001.12.03 hor
-	case F_BOOKMARK_SET				://�u�b�N�}�[�N�ݒ�E����
-	case F_BOOKMARK_NEXT			://���̃u�b�N�}�[�N��
-	case F_BOOKMARK_PREV			://�O�̃u�b�N�}�[�N��
-	case F_BOOKMARK_RESET			://�u�b�N�}�[�N�̑S����
-//	case F_BOOKMARK_VIEW			://�u�b�N�}�[�N�̈ꗗ
+	case F_BOOKMARK_SET				://ブックマーク設定・解除
+	case F_BOOKMARK_NEXT			://次のブックマークへ
+	case F_BOOKMARK_PREV			://前のブックマークへ
+	case F_BOOKMARK_RESET			://ブックマークの全解除
+//	case F_BOOKMARK_VIEW			://ブックマークの一覧
 // To Here 2001.12.03 hor
-	case F_BOOKMARK_PATTERN			://���������ĊY���s���}�[�N	// 2002.02.08 hor
-	case F_FUNCLIST_NEXT			://���̊֐����X�g�}�[�N��
-	case F_FUNCLIST_PREV			://�O�̊֐����X�g�}�[�N��
+	case F_BOOKMARK_PATTERN			://検索しして該当行をマーク	// 2002.02.08 hor
+	case F_FUNCLIST_NEXT			://次の関数リストマークへ
+	case F_FUNCLIST_PREV			://前の関数リストマークへ
 
-	/* ���[�h�؂�ւ��n */
-	case F_CHGMOD_INS				://�}���^�㏑�����[�h�؂�ւ�
-	case F_CHG_CHARSET				://�����R�[�h�Z�b�g�w��	2010/6/14 Uchi
-	case F_CHGMOD_EOL				://���͉��s�R�[�h�w��	2003.06.23 Moca
+	/* モード切り替え系 */
+	case F_CHGMOD_INS				://挿入／上書きモード切り替え
+	case F_CHG_CHARSET				://文字コードセット指定	2010/6/14 Uchi
+	case F_CHGMOD_EOL				://入力改行コード指定	2003.06.23 Moca
 
-	case F_CANCEL_MODE				://�e�탂�[�h�̎�����
+	case F_CANCEL_MODE				://各種モードの取り消し
 
-	/* �}�N���n */
-//	case F_RECKEYMACRO				://�L�[�}�N���̋L�^�J�n�^�I��
-//	case F_SAVEKEYMACRO				://�L�[�}�N���̕ۑ�
-//	case F_LOADKEYMACRO				://�L�[�}�N���̓ǂݍ���
-//	case F_EXECKEYMACRO				://�L�[�}�N���̎��s
-	case F_EXECEXTMACRO				://���O���w�肵�ă}�N�����s
+	/* マクロ系 */
+//	case F_RECKEYMACRO				://キーマクロの記録開始／終了
+//	case F_SAVEKEYMACRO				://キーマクロの保存
+//	case F_LOADKEYMACRO				://キーマクロの読み込み
+//	case F_EXECKEYMACRO				://キーマクロの実行
+	case F_EXECEXTMACRO				://名前を指定してマクロ実行
 
-	/* �ݒ�n */
-//	case F_SHOWTOOLBAR				:/* �c�[���o�[�̕\�� */
-//	case F_SHOWFUNCKEY				:/* �t�@���N�V�����L�[�̕\�� */
-//	case F_SHOWTAB					:/* �^�u�̕\�� */
-//	case F_SHOWSTATUSBAR			:/* �X�e�[�^�X�o�[�̕\�� */
-//	case F_TYPE_LIST				:/* �^�C�v�ʐݒ�ꗗ */
-//	case F_OPTION_TYPE				:/* �^�C�v�ʐݒ� */
-//	case F_OPTION					:/* ���ʐݒ� */
-//	case F_FONT						:/* �t�H���g�ݒ� */
-	case F_SETFONTSIZE				:// �t�H���g�T�C�Y�ݒ�
-//	case F_WRAPWINDOWWIDTH			:/* ���݂̃E�B���h�E���Ő܂�Ԃ� */	//Oct. 15, 2000 JEPRO
-//	case F_FAVORITE					:/* �����̊Ǘ� */	//@@@ 2003.04.08 MIK
-//	case F_TMPWRAPNOWRAP			:// �܂�Ԃ��Ȃ��i�ꎞ�ݒ�j		// 2008.05.30 nasukoji
-//	case F_TMPWRAPSETTING			:// �w�茅�Ő܂�Ԃ��i�ꎞ�ݒ�j	// 2008.05.30 nasukoji
-//	case F_TMPWRAPWINDOW			:// �E�[�Ő܂�Ԃ��i�ꎞ�ݒ�j		// 2008.05.30 nasukoji
-	case F_TEXTWRAPMETHOD			:// �e�L�X�g�̐܂�Ԃ����@			// 2008.05.30 nasukoji
-	case F_SELECT_COUNT_MODE		:// �����J�E���g�̕��@���擾�A�ݒ�	// 2009.07.06 syat
+	/* 設定系 */
+//	case F_SHOWTOOLBAR				:/* ツールバーの表示 */
+//	case F_SHOWFUNCKEY				:/* ファンクションキーの表示 */
+//	case F_SHOWTAB					:/* タブの表示 */
+//	case F_SHOWSTATUSBAR			:/* ステータスバーの表示 */
+//	case F_TYPE_LIST				:/* タイプ別設定一覧 */
+//	case F_OPTION_TYPE				:/* タイプ別設定 */
+//	case F_OPTION					:/* 共通設定 */
+//	case F_FONT						:/* フォント設定 */
+	case F_SETFONTSIZE				:// フォントサイズ設定
+//	case F_WRAPWINDOWWIDTH			:/* 現在のウィンドウ幅で折り返し */	//Oct. 15, 2000 JEPRO
+//	case F_FAVORITE					:/* 履歴の管理 */	//@@@ 2003.04.08 MIK
+//	case F_TMPWRAPNOWRAP			:// 折り返さない（一時設定）		// 2008.05.30 nasukoji
+//	case F_TMPWRAPSETTING			:// 指定桁で折り返す（一時設定）	// 2008.05.30 nasukoji
+//	case F_TMPWRAPWINDOW			:// 右端で折り返す（一時設定）		// 2008.05.30 nasukoji
+	case F_TEXTWRAPMETHOD			:// テキストの折り返し方法			// 2008.05.30 nasukoji
+	case F_SELECT_COUNT_MODE		:// 文字カウントの方法を取得、設定	// 2009.07.06 syat
 
-	case F_EXECMD					:/* �O���R�}���h���s */	//@@@2002.2.2 YAZAKI �ǉ�
+	case F_EXECMD					:/* 外部コマンド実行 */	//@@@2002.2.2 YAZAKI 追加
 
-	/* �J�X�^�����j���[ */
-//	case F_MENU_RBUTTON				:/* �E�N���b�N���j���[ */
-//	case F_CUSTMENU_1				:/* �J�X�^�����j���[1 */
-//	case F_CUSTMENU_2				:/* �J�X�^�����j���[2 */
-//	case F_CUSTMENU_3				:/* �J�X�^�����j���[3 */
-//	case F_CUSTMENU_4				:/* �J�X�^�����j���[4 */
-//	case F_CUSTMENU_5				:/* �J�X�^�����j���[5 */
-//	case F_CUSTMENU_6				:/* �J�X�^�����j���[6 */
-//	case F_CUSTMENU_7				:/* �J�X�^�����j���[7 */
-//	case F_CUSTMENU_8				:/* �J�X�^�����j���[8 */
-//	case F_CUSTMENU_9				:/* �J�X�^�����j���[9 */
-//	case F_CUSTMENU_10				:/* �J�X�^�����j���[10 */
-//	case F_CUSTMENU_11				:/* �J�X�^�����j���[11 */
-//	case F_CUSTMENU_12				:/* �J�X�^�����j���[12 */
-//	case F_CUSTMENU_13				:/* �J�X�^�����j���[13 */
-//	case F_CUSTMENU_14				:/* �J�X�^�����j���[14 */
-//	case F_CUSTMENU_15				:/* �J�X�^�����j���[15 */
-//	case F_CUSTMENU_16				:/* �J�X�^�����j���[16 */
-//	case F_CUSTMENU_17				:/* �J�X�^�����j���[17 */
-//	case F_CUSTMENU_18				:/* �J�X�^�����j���[18 */
-//	case F_CUSTMENU_19				:/* �J�X�^�����j���[19 */
-//	case F_CUSTMENU_20				:/* �J�X�^�����j���[20 */
-//	case F_CUSTMENU_21				:/* �J�X�^�����j���[21 */
-//	case F_CUSTMENU_22				:/* �J�X�^�����j���[22 */
-//	case F_CUSTMENU_23				:/* �J�X�^�����j���[23 */
-//	case F_CUSTMENU_24				:/* �J�X�^�����j���[24 */
+	/* カスタムメニュー */
+//	case F_MENU_RBUTTON				:/* 右クリックメニュー */
+//	case F_CUSTMENU_1				:/* カスタムメニュー1 */
+//	case F_CUSTMENU_2				:/* カスタムメニュー2 */
+//	case F_CUSTMENU_3				:/* カスタムメニュー3 */
+//	case F_CUSTMENU_4				:/* カスタムメニュー4 */
+//	case F_CUSTMENU_5				:/* カスタムメニュー5 */
+//	case F_CUSTMENU_6				:/* カスタムメニュー6 */
+//	case F_CUSTMENU_7				:/* カスタムメニュー7 */
+//	case F_CUSTMENU_8				:/* カスタムメニュー8 */
+//	case F_CUSTMENU_9				:/* カスタムメニュー9 */
+//	case F_CUSTMENU_10				:/* カスタムメニュー10 */
+//	case F_CUSTMENU_11				:/* カスタムメニュー11 */
+//	case F_CUSTMENU_12				:/* カスタムメニュー12 */
+//	case F_CUSTMENU_13				:/* カスタムメニュー13 */
+//	case F_CUSTMENU_14				:/* カスタムメニュー14 */
+//	case F_CUSTMENU_15				:/* カスタムメニュー15 */
+//	case F_CUSTMENU_16				:/* カスタムメニュー16 */
+//	case F_CUSTMENU_17				:/* カスタムメニュー17 */
+//	case F_CUSTMENU_18				:/* カスタムメニュー18 */
+//	case F_CUSTMENU_19				:/* カスタムメニュー19 */
+//	case F_CUSTMENU_20				:/* カスタムメニュー20 */
+//	case F_CUSTMENU_21				:/* カスタムメニュー21 */
+//	case F_CUSTMENU_22				:/* カスタムメニュー22 */
+//	case F_CUSTMENU_23				:/* カスタムメニュー23 */
+//	case F_CUSTMENU_24				:/* カスタムメニュー24 */
 
-	/* �E�B���h�E�n */
-//	case F_SPLIT_V					://�㉺�ɕ���	//Sept. 16, 2000 jepro �������u�c�v����u�㉺�Ɂv�ɕύX
-//	case F_SPLIT_H					://���E�ɕ���	//Sept. 16, 2000 jepro �������u���v����u���E�Ɂv�ɕύX
-//	case F_SPLIT_VH					://�c���ɕ���	//Sept. 17, 2000 jepro �����Ɂu�Ɂv��ǉ�
-//	case F_WINCLOSE					://�E�B���h�E�����
-//	case F_WIN_CLOSEALL				://���ׂẴE�B���h�E�����	//Oct. 17, 2000 JEPRO ���O��ύX(F_FILECLOSEALL��F_WIN_CLOSEALL)
-//	case F_NEXTWINDOW				://���̃E�B���h�E
-//	case F_PREVWINDOW				://�O�̃E�B���h�E
-//	case F_CASCADE					://�d�˂ĕ\��
-//	case F_TILE_V					://�㉺�ɕ��ׂĕ\��
-//	case F_TILE_H					://���E�ɕ��ׂĕ\��
-//	case F_MAXIMIZE_V				://�c�����ɍő剻
-//	case F_MINIMIZE_ALL				://���ׂčŏ���	//Sept. 17, 2000 jepro �����́u�S�āv���u���ׂāv�ɓ���
-	case F_REDRAW					://�ĕ`��
-	case F_WIN_OUTPUT				://�A�E�g�v�b�g�E�B���h�E�\��
-//	case F_TRACEOUT					://�}�N���p�A�E�g�v�b�g�E�B���h�E�ɕ\��	2006.04.26 maru
-	case F_TOPMOST					://��Ɏ�O�ɕ\��
-//	case F_GROUPCLOSE				://�O���[�v�����	// 2007.06.20 ryoji
-//	case F_NEXTGROUP				://���̃O���[�v	// 2007.06.20 ryoji
-//	case F_PREVGROUP				://�O�̃O���[�v	// 2007.06.20 ryoji
-//	case F_TAB_MOVERIGHT			://�^�u���E�Ɉړ�	// 2007.06.20 ryoji
-//	case F_TAB_MOVELEFT				://�^�u�����Ɉړ�	// 2007.06.20 ryoji
-//	case F_TAB_SEPARATE				://�V�K�O���[�v	// 2007.06.20 ryoji
-//	case F_TAB_JOINTNEXT			://���̃O���[�v�Ɉړ�	// 2007.06.20 ryoji
-//	case F_TAB_JOINTPREV			://�O�̃O���[�v�Ɉړ�	// 2007.06.20 ryoji
+	/* ウィンドウ系 */
+//	case F_SPLIT_V					://上下に分割	//Sept. 16, 2000 jepro 説明を「縦」から「上下に」に変更
+//	case F_SPLIT_H					://左右に分割	//Sept. 16, 2000 jepro 説明を「横」から「左右に」に変更
+//	case F_SPLIT_VH					://縦横に分割	//Sept. 17, 2000 jepro 説明に「に」を追加
+//	case F_WINCLOSE					://ウィンドウを閉じる
+//	case F_WIN_CLOSEALL				://すべてのウィンドウを閉じる	//Oct. 17, 2000 JEPRO 名前を変更(F_FILECLOSEALL→F_WIN_CLOSEALL)
+//	case F_NEXTWINDOW				://次のウィンドウ
+//	case F_PREVWINDOW				://前のウィンドウ
+//	case F_CASCADE					://重ねて表示
+//	case F_TILE_V					://上下に並べて表示
+//	case F_TILE_H					://左右に並べて表示
+//	case F_MAXIMIZE_V				://縦方向に最大化
+//	case F_MINIMIZE_ALL				://すべて最小化	//Sept. 17, 2000 jepro 説明の「全て」を「すべて」に統一
+	case F_REDRAW					://再描画
+	case F_WIN_OUTPUT				://アウトプットウィンドウ表示
+//	case F_TRACEOUT					://マクロ用アウトプットウィンドウに表示	2006.04.26 maru
+	case F_TOPMOST					://常に手前に表示
+//	case F_GROUPCLOSE				://グループを閉じる	// 2007.06.20 ryoji
+//	case F_NEXTGROUP				://次のグループ	// 2007.06.20 ryoji
+//	case F_PREVGROUP				://前のグループ	// 2007.06.20 ryoji
+//	case F_TAB_MOVERIGHT			://タブを右に移動	// 2007.06.20 ryoji
+//	case F_TAB_MOVELEFT				://タブを左に移動	// 2007.06.20 ryoji
+//	case F_TAB_SEPARATE				://新規グループ	// 2007.06.20 ryoji
+//	case F_TAB_JOINTNEXT			://次のグループに移動	// 2007.06.20 ryoji
+//	case F_TAB_JOINTPREV			://前のグループに移動	// 2007.06.20 ryoji
 
-	/* �x�� */
-//  case F_HOKAN					:/* ���͕⊮ */				//Oct. 15, 2000 JEPRO �����ĂȂ������̂œ���Ă݂�
-//	case F_HELP_CONTENTS			:/* �w���v�ڎ� */			//Dec. 25, 2000 JEPRO �ǉ�
-//	case F_HELP_SEARCH				:/* �w���v�L�[���[�h���� */	//Dec. 25, 2000 JEPRO �ǉ�
-//	case F_MENU_ALLFUNC				:/* �R�}���h�ꗗ */
-//	case F_EXTHELP1					:/* �O���w���v�P */
-//	case F_EXTHTMLHELP				:/* �O��HTML�w���v */
-//	case F_ABOUT					:/* �o�[�W������� */		//Dec. 25, 2000 JEPRO �ǉ�
+	/* 支援 */
+//  case F_HOKAN					:/* 入力補完 */				//Oct. 15, 2000 JEPRO 入ってなかったので入れてみた
+//	case F_HELP_CONTENTS			:/* ヘルプ目次 */			//Dec. 25, 2000 JEPRO 追加
+//	case F_HELP_SEARCH				:/* ヘルプキーワード検索 */	//Dec. 25, 2000 JEPRO 追加
+//	case F_MENU_ALLFUNC				:/* コマンド一覧 */
+//	case F_EXTHELP1					:/* 外部ヘルプ１ */
+//	case F_EXTHTMLHELP				:/* 外部HTMLヘルプ */
+//	case F_ABOUT					:/* バージョン情報 */		//Dec. 25, 2000 JEPRO 追加
 
-	/* ���̑� */
+	/* その他 */
 		return TRUE;
 	}
 	return FALSE;
@@ -1218,15 +1218,15 @@ BOOL CSMacroMgr::CanFuncIsKeyMacro( int nFuncID )
 }
 
 /*!
-	�}�N���ԍ�����Ή�����}�N���I�u�W�F�N�g�i�[�ʒu�ւ̃|�C���^�ւ̕ϊ�
+	マクロ番号から対応するマクロオブジェクト格納位置へのポインタへの変換
 	
-	@param idx [in] �}�N���ԍ�(0-), STAND_KEYMACRO�͕W���L�[�}�N���o�b�t�@�ATEMP_KEYMACRO�͈ꎞ�}�N���o�b�t�@��\���D
-	@return �I�u�W�F�N�g�ʒu�ւ̃|�C���^�D�}�N���ԍ����s���ȏꍇ��NULL�D
+	@param idx [in] マクロ番号(0-), STAND_KEYMACROは標準キーマクロバッファ、TEMP_KEYMACROは一時マクロバッファを表す．
+	@return オブジェクト位置へのポインタ．マクロ番号が不当な場合はNULL．
 */
 CMacroManagerBase** CSMacroMgr::Idx2Ptr(int idx)
 {
 	//	Jun. 16, 2002 genta
-	//	�L�[�}�N���ȊO�̃}�N����ǂݍ��߂�悤��
+	//	キーマクロ以外のマクロを読み込めるように
 	if ( idx == STAND_KEYMACRO ){
 		return &m_pKeyMacro;
 	}
@@ -1243,10 +1243,10 @@ CMacroManagerBase** CSMacroMgr::Idx2Ptr(int idx)
 }
 
 /*!
-	�L�[�{�[�h�}�N���̕ۑ����\���ǂ���
+	キーボードマクロの保存が可能かどうか
 	
-	@retval true �ۑ��\
-	@retval false �ۑ��s��
+	@retval true 保存可能
+	@retval false 保存不可
 */
 bool CSMacroMgr::IsSaveOk(void)
 {
@@ -1254,10 +1254,10 @@ bool CSMacroMgr::IsSaveOk(void)
 }
 
 /*!
-	�ꎞ�}�N������������
+	一時マクロを交換する
 	
-	@param newMacro [in] �V�����}�N���o�b�t�@�̃|�C���^�D
-	@return �O�̈ꎞ�}�N���o�b�t�@�̃|�C���^�D
+	@param newMacro [in] 新しいマクロバッファのポインタ．
+	@return 前の一時マクロバッファのポインタ．
 */
 CMacroManagerBase* CSMacroMgr::SetTempMacro( CMacroManagerBase *newMacro )
 {

--- a/sakura_core/macro/CSMacroMgr.h
+++ b/sakura_core/macro/CSMacroMgr.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒL[ƒ{[ƒhƒ}ƒNƒ(’¼ÚÀs—p)
+ï»¿/*!	@file
+	@brief ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­(ç›´æ¥å®Ÿè¡Œç”¨)
 
 	@author genta
-	@date Sep. 29, 2001 ì¬
+	@date Sep. 29, 2001 ä½œæˆ
 */
 /*
 	Copyright (C) 2001, genta
@@ -45,9 +45,9 @@
 class CEditView;
 
 
-const int STAND_KEYMACRO	= -1;	//!< •W€ƒ}ƒNƒ(ƒL[ƒ}ƒNƒ)
-const int TEMP_KEYMACRO		= -2;	//!< ˆêƒ}ƒNƒ(–¼‘O‚ğw’è‚µ‚Äƒ}ƒNƒÀs)
-const int INVALID_MACRO_IDX	= -3;	//!< –³Œø‚Èƒ}ƒNƒ‚ÌƒCƒ“ƒfƒbƒNƒX”Ô† @date Sep. 15, 2005 FILE
+const int STAND_KEYMACRO	= -1;	//!< æ¨™æº–ãƒã‚¯ãƒ­(ã‚­ãƒ¼ãƒã‚¯ãƒ­)
+const int TEMP_KEYMACRO		= -2;	//!< ä¸€æ™‚ãƒã‚¯ãƒ­(åå‰ã‚’æŒ‡å®šã—ã¦ãƒã‚¯ãƒ­å®Ÿè¡Œ)
+const int INVALID_MACRO_IDX	= -3;	//!< ç„¡åŠ¹ãªãƒã‚¯ãƒ­ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ç•ªå· @date Sep. 15, 2005 FILE
 
 struct MacroFuncInfoEx
 {
@@ -56,32 +56,32 @@ struct MacroFuncInfoEx
 	VARTYPE*	m_pVarArgEx;
 };
 
-//ƒ}ƒNƒŠÖ”î•ñ\‘¢‘Ì
-//	ŠÖ”–¼‚ÍCSMacroMgr‚ª‚Â
+//ãƒã‚¯ãƒ­é–¢æ•°æƒ…å ±æ§‹é€ ä½“
+//	é–¢æ•°åã¯CSMacroMgrãŒæŒã¤
 struct MacroFuncInfo {
 	int				m_nFuncID;
 	const WCHAR*	m_pszFuncName;
-	VARTYPE			m_varArguments[4];	//!< ˆø”‚ÌŒ^‚Ì”z—ñ
-	VARTYPE			m_varResult;		//!< –ß‚è’l‚ÌŒ^ VT_EMPTY‚È‚çprocedure‚Æ‚¢‚¤‚±‚Æ‚Å
+	VARTYPE			m_varArguments[4];	//!< å¼•æ•°ã®å‹ã®é…åˆ—
+	VARTYPE			m_varResult;		//!< æˆ»ã‚Šå€¤ã®å‹ VT_EMPTYãªã‚‰procedureã¨ã„ã†ã“ã¨ã§
 	MacroFuncInfoEx*	m_pData;
 };
-//ƒ}ƒNƒŠÖ”î•ñ\‘¢‘Ì”z—ñ
+//ãƒã‚¯ãƒ­é–¢æ•°æƒ…å ±æ§‹é€ ä½“é…åˆ—
 typedef MacroFuncInfo* MacroFuncInfoArray;
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 
-@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 -----------------------------------------------------------------------*/
 class CSMacroMgr
 {
-	//	ƒf[ƒ^‚ÌŒ^éŒ¾
-	CMacroManagerBase* m_cSavedKeyMacro[MAX_CUSTMACRO];	//	ƒL[ƒ}ƒNƒ‚ğƒJƒXƒ^ƒ€ƒƒjƒ…[‚Ì”‚¾‚¯ŠÇ—
+	//	ãƒ‡ãƒ¼ã‚¿ã®å‹å®£è¨€
+	CMacroManagerBase* m_cSavedKeyMacro[MAX_CUSTMACRO];	//	ã‚­ãƒ¼ãƒã‚¯ãƒ­ã‚’ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ•°ã ã‘ç®¡ç†
 	//	Jun. 16, 2002 genta
-	//	ƒL[ƒ}ƒNƒ‚É•W€ƒ}ƒNƒˆÈŠO‚Ìƒ}ƒNƒ‚ğ“Ç‚İ‚ß‚é‚æ‚¤‚É
-	CMacroManagerBase* m_pKeyMacro;	//	•W€‚Ìi•Û‘¶‚ª‚Å‚«‚éjƒL[ƒ}ƒNƒ‚àŠÇ—
+	//	ã‚­ãƒ¼ãƒã‚¯ãƒ­ã«æ¨™æº–ãƒã‚¯ãƒ­ä»¥å¤–ã®ãƒã‚¯ãƒ­ã‚’èª­ã¿è¾¼ã‚ã‚‹ã‚ˆã†ã«
+	CMacroManagerBase* m_pKeyMacro;	//	æ¨™æº–ã®ï¼ˆä¿å­˜ãŒã§ãã‚‹ï¼‰ã‚­ãƒ¼ãƒã‚¯ãƒ­ã‚‚ç®¡ç†
 
-	//@ˆêƒ}ƒNƒi–¼‘O‚ğw’è‚µ‚Äƒ}ƒNƒÀsj‚ğŠÇ—
+	//ã€€ä¸€æ™‚ãƒã‚¯ãƒ­ï¼ˆåå‰ã‚’æŒ‡å®šã—ã¦ãƒã‚¯ãƒ­å®Ÿè¡Œï¼‰ã‚’ç®¡ç†
 	CMacroManagerBase* m_pTempMacro;
 
 public:
@@ -96,34 +96,34 @@ public:
 	||  Attributes & Operations
 	*/
 	void Clear( int idx );
-	void ClearAll( void );	/* ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚ğƒNƒŠƒA‚·‚é */
+	void ClearAll( void );	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹ */
 
-	//! ƒL[ƒ{[ƒhƒ}ƒNƒ‚ÌÀs
+	//! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®å®Ÿè¡Œ
 	BOOL Exec( int idx, HINSTANCE hInstance, CEditView* pcEditView, int flags );
 	
-	//!	Às‰Â”\‚©HCShareData‚É–â‚¢‡‚í‚¹
+	//!	å®Ÿè¡Œå¯èƒ½ã‹ï¼ŸCShareDataã«å•ã„åˆã‚ã›
 	bool IsEnabled(int idx) const {
 		return ( 0 <= idx && idx < MAX_CUSTMACRO ) ?
 		m_pShareData->m_Common.m_sMacro.m_MacroTable[idx].IsEnabled() : false;
 	}
 	
-	//!	•\¦‚·‚é–¼‘O‚Ìæ“¾
+	//!	è¡¨ç¤ºã™ã‚‹åå‰ã®å–å¾—
 	const TCHAR* GetTitle(int idx) const
 	{
 		return ( 0 <= idx && idx < MAX_CUSTMACRO ) ?
 		m_pShareData->m_Common.m_sMacro.m_MacroTable[idx].GetTitle() : NULL;	// 2007.11.02 ryoji
 	}
 	
-	//!	•\¦–¼‚Ìæ“¾
+	//!	è¡¨ç¤ºåã®å–å¾—
 	const TCHAR* GetName(int idx) const
 	{
 		return ( 0 <= idx && idx < MAX_CUSTMACRO ) ?
 		m_pShareData->m_Common.m_sMacro.m_MacroTable[idx].m_szName : NULL;
 	}
 	
-	/*!	@brief ƒtƒ@ƒCƒ‹–¼‚Ìæ“¾
+	/*!	@brief ãƒ•ã‚¡ã‚¤ãƒ«åã®å–å¾—
 	
-		@param idx [in] ƒ}ƒNƒ”Ô†
+		@param idx [in] ãƒã‚¯ãƒ­ç•ªå·
 	*/
 	const TCHAR* GetFile(int idx) const
 	{
@@ -133,27 +133,27 @@ public:
 		m_sMacroPath.c_str() : NULL;
 	}
 
-	/*! ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì“Ç‚İ‚İ */
+	/*! ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ */
 	BOOL Load( int idx, HINSTANCE hInstance, const TCHAR* pszPath, const TCHAR* pszType );
 	BOOL Save( int idx, HINSTANCE hInstance, const TCHAR* pszPath );
 	void UnloadAll(void);
 
-	/*! ƒL[ƒ}ƒNƒ‚Ìƒoƒbƒtƒ@‚Éƒf[ƒ^’Ç‰Á */
+	/*! ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒãƒƒãƒ•ã‚¡ã«ãƒ‡ãƒ¼ã‚¿è¿½åŠ  */
 	int Append( int idx, EFunctionCode nFuncID, const LPARAM* lParams, CEditView* pcEditView );
 
 	/*
 	||  Attributes & Operations
 	*/
-	static WCHAR* GetFuncInfoByID( HINSTANCE , int , WCHAR* , WCHAR* );	/* ‹@”\ID¨ŠÖ”–¼C‹@”\–¼“ú–{Œê */
-	static EFunctionCode GetFuncInfoByName( HINSTANCE , const WCHAR* , WCHAR* );	/* ŠÖ”–¼¨‹@”\IDC‹@”\–¼“ú–{Œê */
-	static BOOL CanFuncIsKeyMacro( int );	/* ƒL[ƒ}ƒNƒ‚É‹L˜^‰Â”\‚È‹@”\‚©‚Ç‚¤‚©‚ğ’²‚×‚é */
+	static WCHAR* GetFuncInfoByID( HINSTANCE , int , WCHAR* , WCHAR* );	/* æ©Ÿèƒ½IDâ†’é–¢æ•°åï¼Œæ©Ÿèƒ½åæ—¥æœ¬èª */
+	static EFunctionCode GetFuncInfoByName( HINSTANCE , const WCHAR* , WCHAR* );	/* é–¢æ•°åâ†’æ©Ÿèƒ½IDï¼Œæ©Ÿèƒ½åæ—¥æœ¬èª */
+	static BOOL CanFuncIsKeyMacro( int );	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã«è¨˜éŒ²å¯èƒ½ãªæ©Ÿèƒ½ã‹ã©ã†ã‹ã‚’èª¿ã¹ã‚‹ */
 	
 	//	Jun. 16, 2002 genta
 	static const MacroFuncInfo* GetFuncInfoByID( int );
 	
 	bool IsSaveOk(void);
 
-	//	Sep. 15, 2005 FILE	Às’†ƒ}ƒNƒ‚ÌƒCƒ“ƒfƒbƒNƒX”Ô†‘€ì (INVALID_MACRO_IDX:–³Œø)
+	//	Sep. 15, 2005 FILE	å®Ÿè¡Œä¸­ãƒã‚¯ãƒ­ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ç•ªå·æ“ä½œ (INVALID_MACRO_IDX:ç„¡åŠ¹)
 	int GetCurrentIdx( void ) const {
 		return m_CurrentIdx;
 	}
@@ -163,23 +163,23 @@ public:
 		return oldIdx;
 	}
 
-	//  Oct. 22, 2008 syat ˆêƒ}ƒNƒ“±“ü
+	//  Oct. 22, 2008 syat ä¸€æ™‚ãƒã‚¯ãƒ­å°å…¥
 	CMacroManagerBase* SetTempMacro( CMacroManagerBase *newMacro );
 
 private:
 	DLLSHAREDATA*	m_pShareData;
 	CMacroManagerBase** Idx2Ptr(int idx);
 
-	/*!	Às’†ƒ}ƒNƒ‚ÌƒCƒ“ƒfƒbƒNƒX”Ô† (INVALID_MACRO_IDX:–³Œø)
+	/*!	å®Ÿè¡Œä¸­ãƒã‚¯ãƒ­ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ç•ªå· (INVALID_MACRO_IDX:ç„¡åŠ¹)
 		@date Sep. 15, 2005 FILE
 	*/
 	int m_CurrentIdx;
 
-	std::tstring	m_sMacroPath;	// Load‚µ‚½ƒ}ƒNƒ–¼
+	std::tstring	m_sMacroPath;	// Loadã—ãŸãƒã‚¯ãƒ­å
 
 public:
-	static MacroFuncInfo	m_MacroFuncInfoCommandArr[];	// ƒRƒ}ƒ“ƒhî•ñ(–ß‚è’l‚È‚µ)
-	static MacroFuncInfo	m_MacroFuncInfoArr[];		// ŠÖ”î•ñ(–ß‚è’l‚ ‚è)
+	static MacroFuncInfo	m_MacroFuncInfoCommandArr[];	// ã‚³ãƒãƒ³ãƒ‰æƒ…å ±(æˆ»ã‚Šå€¤ãªã—)
+	static MacroFuncInfo	m_MacroFuncInfoArr[];		// é–¢æ•°æƒ…å ±(æˆ»ã‚Šå€¤ã‚ã‚Š)
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(CSMacroMgr);

--- a/sakura_core/macro/CWSH.cpp
+++ b/sakura_core/macro/CWSH.cpp
@@ -1,11 +1,11 @@
-/*!	@file
+ï»¿/*!	@file
 	@brief WSH Handler
 
-	@author ‹S
-	@date 2002”N4Œ28“ú
+	@author é¬¼
+	@date 2002å¹´4æœˆ28æ—¥
 */
 /*
-	Copyright (C) 2002, ‹S, genta
+	Copyright (C) 2002, é¬¼, genta
 	Copyright (C) 2003, FILE
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, FILE, zenryaku
@@ -49,7 +49,7 @@
 #include "dlg/CDlgCancel.h"
 #include "sakura_rc.h"
 #ifndef SCRIPT_E_REPORTED
-#define	SCRIPT_E_REPORTED	0x80020101L	// ActivScp.h(VS2012)‚Æ“¯‚¶—l‚ÈŒ`‚É•ÏX
+#define	SCRIPT_E_REPORTED	0x80020101L	// ActivScp.h(VS2012)ã¨åŒã˜æ§˜ãªå½¢ã«å¤‰æ›´
 #endif
 
 #ifdef USE_JSCRIPT9
@@ -59,14 +59,14 @@ const GUID CLSID_JSScript9 =
 };
 #endif
 
-/* 2009.10.29 syat ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg•”•ª‚ğCWSHIfObj.h‚É•ª—£
+/* 2009.10.29 syat ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆéƒ¨åˆ†ã‚’CWSHIfObj.hã«åˆ†é›¢
 class CInterfaceObjectTypeInfo: public ImplementsIUnknown<ITypeInfo>
  */
 
 //IActiveScriptSite, IActiveScriptSiteWindow
 /*!
-	@date Sep. 15, 2005 FILE IActiveScriptSiteWindowÀ‘•D
-		ƒ}ƒNƒ‚ÅMsgBox‚ğg—p‰Â”\‚É‚·‚éD
+	@date Sep. 15, 2005 FILE IActiveScriptSiteWindowå®Ÿè£…ï¼
+		ãƒã‚¯ãƒ­ã§MsgBoxã‚’ä½¿ç”¨å¯èƒ½ã«ã™ã‚‹ï¼
 */
 class CWSHSite: public IActiveScriptSite, public IActiveScriptSiteWindow
 {
@@ -113,7 +113,7 @@ public:
 #ifdef TEST
 		cout << "GetLCID" << endl;
 #endif
-		return E_NOTIMPL; //ƒVƒXƒeƒ€ƒfƒtƒHƒ‹ƒg‚ğg—p
+		return E_NOTIMPL; //ã‚·ã‚¹ãƒ†ãƒ ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã‚’ä½¿ç”¨
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetItemInfo( 
@@ -125,11 +125,11 @@ public:
 #ifdef TEST
 		wcout << L"GetItemInfo:" << pstrName << endl;
 #endif
-		//w’è‚³‚ê‚½–¼‘O‚ÌƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg‚ğŒŸõ
+		//æŒ‡å®šã•ã‚ŒãŸåå‰ã®ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’æ¤œç´¢
 		const CWSHClient::List& objects = m_Client->GetInterfaceObjects();
 		for( CWSHClient::ListIter it = objects.begin(); it != objects.end(); it++ )
 		{
-			//	Nov. 10, 2003 FILE Win9X‚Å‚ÍA[lstrcmpiW]‚ª–³Œø‚Ì‚½‚ßA[_wcsicmp]‚ÉC³
+			//	Nov. 10, 2003 FILE Win9Xã§ã¯ã€[lstrcmpiW]ãŒç„¡åŠ¹ã®ãŸã‚ã€[_wcsicmp]ã«ä¿®æ­£
 			if( _wcsicmp( pstrName, (*it)->m_sName.c_str() ) == 0 )
 			{
 				if(dwReturnMask & SCRIPTINFO_IUNKNOWN)
@@ -175,8 +175,8 @@ public:
 		return S_OK; 
 	}
 
-	//	Nov. 3, 2002 ‹S
-	//	ƒGƒ‰[s”Ô†•\¦‘Î‰
+	//	Nov. 3, 2002 é¬¼
+	//	ã‚¨ãƒ©ãƒ¼è¡Œç•ªå·è¡¨ç¤ºå¯¾å¿œ
 	virtual HRESULT STDMETHODCALLTYPE OnScriptError(
 	  /* [in] */ IActiveScriptError *pscripterror)
 	{ 
@@ -192,7 +192,7 @@ public:
 			if(pscripterror->GetSourcePosition(&Context, &Line, &Pos) == S_OK)
 			{
 				wchar_t *Message = new wchar_t[SysStringLen(Info.bstrDescription) + 128];
-				//	Nov. 10, 2003 FILE Win9X‚Å‚ÍA[wsprintfW]‚ª–³Œø‚Ì‚½‚ßA[auto_sprintf]‚ÉC³
+				//	Nov. 10, 2003 FILE Win9Xã§ã¯ã€[wsprintfW]ãŒç„¡åŠ¹ã®ãŸã‚ã€[auto_sprintf]ã«ä¿®æ­£
 				const wchar_t* szDesc=Info.bstrDescription;
 				auto_sprintf(Message, L"[Line %d] %ls", Line + 1, szDesc);
 				SysReAllocString(&Info.bstrDescription, Message);
@@ -220,7 +220,7 @@ public:
 		return S_OK; 
 	}
 
-	//	Sep. 15, 2005 FILE IActiveScriptSiteWindowÀ‘•
+	//	Sep. 15, 2005 FILE IActiveScriptSiteWindowå®Ÿè£…
 	virtual HRESULT __stdcall GetWindow(
 	    /* [out] */ HWND *phwnd)
 	{
@@ -228,7 +228,7 @@ public:
 		return S_OK;
 	}
 
-	//	Sep. 15, 2005 FILE IActiveScriptSiteWindowÀ‘•
+	//	Sep. 15, 2005 FILE IActiveScriptSiteWindowå®Ÿè£…
 	virtual HRESULT __stdcall EnableModeless(
 	    /* [in] */ BOOL fEnable)
 	{
@@ -241,7 +241,7 @@ public:
 CWSHClient::CWSHClient(const wchar_t *AEngine, ScriptErrorHandler AErrorHandler, void *AData): 
 				m_OnError(AErrorHandler), m_Data(AData), m_Valid(false), m_Engine(NULL)
 { 
-	// 2010.08.28 DLL ƒCƒ“ƒWƒFƒNƒVƒ‡ƒ“‘Îô‚Æ‚µ‚ÄEXE‚ÌƒtƒHƒ‹ƒ_‚ÉˆÚ“®‚·‚é
+	// 2010.08.28 DLL ã‚¤ãƒ³ã‚¸ã‚§ã‚¯ã‚·ãƒ§ãƒ³å¯¾ç­–ã¨ã—ã¦EXEã®ãƒ•ã‚©ãƒ«ãƒ€ã«ç§»å‹•ã™ã‚‹
 	CCurrentDirectoryBackupPoint dirBack;
 	ChangeCurrentDirectoryToExeDir();
 	
@@ -275,7 +275,7 @@ CWSHClient::CWSHClient(const wchar_t *AEngine, ScriptErrorHandler AErrorHandler,
 
 CWSHClient::~CWSHClient()
 {
-	//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg‚ğ‰ğ•ú
+	//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’è§£æ”¾
 	for( ListIter it = m_IfObjArr.begin(); it != m_IfObjArr.end(); it++ ){
 		(*it)->Release();
 	}
@@ -284,7 +284,7 @@ CWSHClient::~CWSHClient()
 		m_Engine->Release();
 }
 
-// AbortMacroProc‚Ìƒpƒ‰ƒ[ƒ^\‘¢‘Ì
+// AbortMacroProcã®ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿æ§‹é€ ä½“
 typedef struct {
 	HANDLE hEvent;
 	IActiveScript *pEngine;				//ActiveScript
@@ -292,20 +292,20 @@ typedef struct {
 	CEditView *view;
 } SAbortMacroParam;
 
-// WSHƒ}ƒNƒÀs‚ğ’†~‚·‚éƒXƒŒƒbƒh
+// WSHãƒã‚¯ãƒ­å®Ÿè¡Œã‚’ä¸­æ­¢ã™ã‚‹ã‚¹ãƒ¬ãƒƒãƒ‰
 static unsigned __stdcall AbortMacroProc( LPVOID lpParameter )
 {
 	SAbortMacroParam* pParam = (SAbortMacroParam*) lpParameter;
 
-	//’â~ƒ_ƒCƒAƒƒO•\¦‘O‚É”•b‘Ò‚Â
+	//åœæ­¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°è¡¨ç¤ºå‰ã«æ•°ç§’å¾…ã¤
 	if(::WaitForSingleObject(pParam->hEvent, pParam->nCancelTimer * 1000) == WAIT_TIMEOUT){
-		//’â~ƒ_ƒCƒAƒƒO•\¦
+		//åœæ­¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°è¡¨ç¤º
 		DEBUG_TRACE(_T("AbortMacro: Show Dialog\n"));
 
 		MSG msg;
 		CDlgCancel cDlgCancel;
-		HWND hwndDlg = cDlgCancel.DoModeless(G_AppInstance(), NULL, IDD_MACRORUNNING);	// ƒGƒfƒBƒ^ƒrƒW[‚Å‚à•\¦‚Å‚«‚é‚æ‚¤Ae‚ğw’è‚µ‚È‚¢
-		// ƒ_ƒCƒAƒƒOƒ^ƒCƒgƒ‹‚Æƒtƒ@ƒCƒ‹–¼‚ğİ’è
+		HWND hwndDlg = cDlgCancel.DoModeless(G_AppInstance(), NULL, IDD_MACRORUNNING);	// ã‚¨ãƒ‡ã‚£ã‚¿ãƒ“ã‚¸ãƒ¼ã§ã‚‚è¡¨ç¤ºã§ãã‚‹ã‚ˆã†ã€è¦ªã‚’æŒ‡å®šã—ãªã„
+		// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚¿ã‚¤ãƒˆãƒ«ã¨ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¨­å®š
 		::SendMessage(hwndDlg, WM_SETTEXT, 0, (LPARAM)GSTR_APPNAME);
 		::SendMessage(GetDlgItem(hwndDlg, IDC_STATIC_CMD),
 			WM_SETTEXT, 0, (LPARAM)pParam->view->GetDocument()->m_cDocFile.GetFilePath());
@@ -324,7 +324,7 @@ static unsigned __stdcall AbortMacroProc( LPVOID lpParameter )
 					}
 				}
 			}else{
-				//MsgWaitForMultipleObjects‚É—^‚¦‚½ƒnƒ“ƒhƒ‹‚ÌƒGƒ‰[
+				//MsgWaitForMultipleObjectsã«ä¸ãˆãŸãƒãƒ³ãƒ‰ãƒ«ã®ã‚¨ãƒ©ãƒ¼
 				break;
 			}
 			if(!bCanceled && cDlgCancel.IsCanceled()){
@@ -377,7 +377,7 @@ bool CWSHClient::Execute(const wchar_t *AScript)
 			}
 			if( !bAddNamedItemError )
 			{
-				//ƒ}ƒNƒ’â~ƒXƒŒƒbƒh‚Ì‹N“®
+				//ãƒã‚¯ãƒ­åœæ­¢ã‚¹ãƒ¬ãƒƒãƒ‰ã®èµ·å‹•
 				SAbortMacroParam sThreadParam;
 				sThreadParam.pEngine = m_Engine;
 				sThreadParam.nCancelTimer = GetDllShareData().m_Common.m_sMacro.m_nMacroCancelTimer;
@@ -391,7 +391,7 @@ bool CWSHClient::Execute(const wchar_t *AScript)
 					DEBUG_TRACE(_T("Start AbortMacroProc 0x%08x\n"), nThreadId);
 				}
 
-				//ƒ}ƒNƒÀs
+				//ãƒã‚¯ãƒ­å®Ÿè¡Œ
 				if(m_Engine->SetScriptState(SCRIPTSTATE_STARTED) != S_OK)
 					Error(LSW(STR_ERR_CWSH07));
 				else
@@ -399,8 +399,8 @@ bool CWSHClient::Execute(const wchar_t *AScript)
 					HRESULT hr = Parser->ParseScriptText(AScript, 0, 0, 0, 0, 0, SCRIPTTEXT_ISVISIBLE, 0, 0);
 					if (hr == SCRIPT_E_REPORTED) {
 					/*
-						IActiveScriptSite->OnScriptError‚É’Ê’mÏ‚İB
-						’†’fƒƒbƒZ[ƒW‚ªŠù‚É•\¦‚³‚ê‚Ä‚é‚Í‚¸B
+						IActiveScriptSite->OnScriptErrorã«é€šçŸ¥æ¸ˆã¿ã€‚
+						ä¸­æ–­ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãŒæ—¢ã«è¡¨ç¤ºã•ã‚Œã¦ã‚‹ã¯ãšã€‚
 					*/
 					} else if(hr != S_OK) {
 						Error(LSW(STR_ERR_CWSH08));
@@ -412,7 +412,7 @@ bool CWSHClient::Execute(const wchar_t *AScript)
 				if( 0 < sThreadParam.nCancelTimer ){
 					::SetEvent(sThreadParam.hEvent);
 
-					//ƒ}ƒNƒ’â~ƒXƒŒƒbƒh‚ÌI—¹‘Ò‚¿
+					//ãƒã‚¯ãƒ­åœæ­¢ã‚¹ãƒ¬ãƒƒãƒ‰ã®çµ‚äº†å¾…ã¡
 					DEBUG_TRACE(_T("Waiting for AbortMacroProc to finish\n"));
 					::WaitForSingleObject(hThread, INFINITE); 
 					::CloseHandle(hThread);
@@ -441,7 +441,7 @@ void CWSHClient::Error(const wchar_t* Description)
 	SysFreeString(D);
 }
 
-//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg‚Ì’Ç‰Á
+//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã®è¿½åŠ 
 void CWSHClient::AddInterfaceObject( CIfObj* obj )
 {
 	if( !obj ) return;
@@ -453,8 +453,8 @@ void CWSHClient::AddInterfaceObject( CIfObj* obj )
 
 /////////////////////////////////////////////
 /*!
-	MacroCommand¨CWSHIfObj.cpp‚ÖˆÚ“®
-	CWSHMacroManager ¨@CWSHManager.cpp‚ÖˆÚ“®
+	MacroCommandâ†’CWSHIfObj.cppã¸ç§»å‹•
+	CWSHMacroManager â†’ã€€CWSHManager.cppã¸ç§»å‹•
 
 */
 

--- a/sakura_core/macro/CWSH.h
+++ b/sakura_core/macro/CWSH.h
@@ -1,14 +1,14 @@
-/*!	@file
+ï»¿/*!	@file
 	@brief WSH Handler
 
-	@author ‹S
-	@date 2002”N4Œ28“ú,5Œ3“ú,5Œ5“ú,5Œ6“ú,5Œ13“ú,5Œ16“ú
-	@date 2002.08.25 genta ƒŠƒ“ƒNƒGƒ‰[‰ñ”ğ‚Ì‚½‚ßCWSHManager.h‚ÉƒGƒfƒBƒ^‚Ì
-		ƒ}ƒNƒƒCƒ“ƒ^[ƒtƒF[ƒX•”‚ğ•ª—£D
-	@date 2009.10.29 syat ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg•”•ª‚ğCWSHIfObj.h‚É•ª—£
+	@author é¬¼
+	@date 2002å¹´4æœˆ28æ—¥,5æœˆ3æ—¥,5æœˆ5æ—¥,5æœˆ6æ—¥,5æœˆ13æ—¥,5æœˆ16æ—¥
+	@date 2002.08.25 genta ãƒªãƒ³ã‚¯ã‚¨ãƒ©ãƒ¼å›é¿ã®ãŸã‚CWSHManager.hã«ã‚¨ãƒ‡ã‚£ã‚¿ã®
+		ãƒã‚¯ãƒ­ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹éƒ¨ã‚’åˆ†é›¢ï¼
+	@date 2009.10.29 syat ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆéƒ¨åˆ†ã‚’CWSHIfObj.hã«åˆ†é›¢
 */
 /*
-	Copyright (C) 2002, ‹S, genta
+	Copyright (C) 2002, é¬¼, genta
 	Copyright (C) 2009, syat
 
 	This source code is designed for sakura editor.
@@ -20,10 +20,10 @@
 #define __WSH_H__
 
 #include <ActivScp.h>
-//ªMicrosoft Platform SDK ‚æ‚è
+//â†‘Microsoft Platform SDK ã‚ˆã‚Š
 #include "macro/CIfObj.h"
 
-/* 2009.10.29 syat ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg•”•ª‚ğCWSHIfObj.h‚É•ª—£
+/* 2009.10.29 syat ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆéƒ¨åˆ†ã‚’CWSHIfObj.hã«åˆ†é›¢
 template<class Base>
 class ImplementsIUnknown: public Base
 
@@ -34,26 +34,26 @@ typedef void (*ScriptErrorHandler)(BSTR Description, BSTR Source, void *Data);
 class CWSHClient : IWSHClient
 {
 public:
-	// Œ^’è‹`
-	typedef std::vector<CIfObj*> List;      // Š—L‚µ‚Ä‚¢‚éƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg‚ÌƒŠƒXƒg
-	typedef List::const_iterator ListIter;	// ‚»‚ÌƒCƒeƒŒ[ƒ^
+	// å‹å®šç¾©
+	typedef std::vector<CIfObj*> List;      // æ‰€æœ‰ã—ã¦ã„ã‚‹ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã®ãƒªã‚¹ãƒˆ
+	typedef List::const_iterator ListIter;	// ãã®ã‚¤ãƒ†ãƒ¬ãƒ¼ã‚¿
 
-	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	// ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CWSHClient(const wchar_t *AEngine, ScriptErrorHandler AErrorHandler, void *AData);
 	~CWSHClient();
 
-	// ƒtƒB[ƒ‹ƒhEƒAƒNƒZƒT
+	// ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ãƒ»ã‚¢ã‚¯ã‚»ã‚µ
 	ScriptErrorHandler m_OnError;
 	void *m_Data;
-	bool m_Valid; ///< true‚Ìê‡ƒXƒNƒŠƒvƒgƒGƒ“ƒWƒ“‚ªg—p‰Â”\Bfalse‚É‚È‚éê‡‚Í ScriptErrorHandler‚ÉƒGƒ‰[“à—e‚ª’Ê’m‚³‚ê‚Ä‚¢‚éB
+	bool m_Valid; ///< trueã®å ´åˆã‚¹ã‚¯ãƒªãƒ—ãƒˆã‚¨ãƒ³ã‚¸ãƒ³ãŒä½¿ç”¨å¯èƒ½ã€‚falseã«ãªã‚‹å ´åˆã¯ ScriptErrorHandlerã«ã‚¨ãƒ©ãƒ¼å†…å®¹ãŒé€šçŸ¥ã•ã‚Œã¦ã„ã‚‹ã€‚
 	virtual /*override*/ void* GetData() const { return this->m_Data; }
 	const List& GetInterfaceObjects() {	return this->m_IfObjArr; }
 
-	// ‘€ì
+	// æ“ä½œ
 	void AddInterfaceObject( CIfObj* obj );
 	bool Execute(const wchar_t *AScript);
-	void Error(BSTR Description, BSTR Source); ///< ScriptErrorHandler‚ğŒÄ‚Ño‚·B
-	void Error(const wchar_t* Description);          ///< ScriptErrorHandler‚ğŒÄ‚Ño‚·B
+	void Error(BSTR Description, BSTR Source); ///< ScriptErrorHandlerã‚’å‘¼ã³å‡ºã™ã€‚
+	void Error(const wchar_t* Description);          ///< ScriptErrorHandlerã‚’å‘¼ã³å‡ºã™ã€‚
 
 private:
 	IActiveScript *m_Engine;

--- a/sakura_core/macro/CWSHIfObj.cpp
+++ b/sakura_core/macro/CWSHIfObj.cpp
@@ -1,10 +1,10 @@
-/*!	@file
-	@brief WSHƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒgŠî–{ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief WSHã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆåŸºæœ¬ã‚¯ãƒ©ã‚¹
 
-	@date 2009.10.29 syat CWSH.cpp‚©‚çØ‚èo‚µ
+	@date 2009.10.29 syat CWSH.cppã‹ã‚‰åˆ‡ã‚Šå‡ºã—
 */
 /*
-	Copyright (C) 2002, ‹S, genta
+	Copyright (C) 2002, é¬¼, genta
 	Copyright (C) 2003, FILE
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, FILE, zenryaku
@@ -38,24 +38,24 @@
 #include "util/other_util.h" // auto_array_ptr
 
 
-//ƒRƒ}ƒ“ƒhEŠÖ”‚ğ€”õ‚·‚é
+//ã‚³ãƒãƒ³ãƒ‰ãƒ»é–¢æ•°ã‚’æº–å‚™ã™ã‚‹
 void CWSHIfObj::ReadyMethods( CEditView* pView, int flags )
 {
 	this->m_pView = pView;
-	//	 2007.07.20 genta : ƒRƒ}ƒ“ƒh‚É¬‚º‚Şƒtƒ‰ƒO‚ğ“n‚·
+	//	 2007.07.20 genta : ã‚³ãƒãƒ³ãƒ‰ã«æ··ãœè¾¼ã‚€ãƒ•ãƒ©ã‚°ã‚’æ¸¡ã™
 	ReadyCommands(GetMacroCommandInfo(), flags | FA_FROMMACRO );
 	ReadyCommands(GetMacroFuncInfo(), 0);
-	/* CWSHIfObj‚ğŒp³‚µ‚½ƒTƒuƒNƒ‰ƒX‚©‚çReadyMethods‚ğŒÄ‚Ño‚µ‚½ê‡A
-	 * ƒTƒuƒNƒ‰ƒX‚ÌGetMacroCommandInfo,GetMacroFuncInfo‚ªŒÄ‚Ño‚³‚ê‚éB */
+	/* CWSHIfObjã‚’ç¶™æ‰¿ã—ãŸã‚µãƒ–ã‚¯ãƒ©ã‚¹ã‹ã‚‰ReadyMethodsã‚’å‘¼ã³å‡ºã—ãŸå ´åˆã€
+	 * ã‚µãƒ–ã‚¯ãƒ©ã‚¹ã®GetMacroCommandInfo,GetMacroFuncInfoãŒå‘¼ã³å‡ºã•ã‚Œã‚‹ã€‚ */
 }
 
-/** WSHƒ}ƒNƒƒGƒ“ƒWƒ“‚ÖƒRƒ}ƒ“ƒh“o˜^‚ğs‚¤
+/** WSHãƒã‚¯ãƒ­ã‚¨ãƒ³ã‚¸ãƒ³ã¸ã‚³ãƒãƒ³ãƒ‰ç™»éŒ²ã‚’è¡Œã†
 
-	@date 2007.07.20 genta flags’Ç‰ÁDflag‚ÍƒRƒ}ƒ“ƒh“o˜^’iŠK‚Å¬‚º‚Ä‚¨‚­D
+	@date 2007.07.20 genta flagsè¿½åŠ ï¼flagã¯ã‚³ãƒãƒ³ãƒ‰ç™»éŒ²æ®µéšã§æ··ãœã¦ãŠãï¼
 */
 void CWSHIfObj::ReadyCommands(MacroFuncInfo *Info, int flags)
 {
-	while(Info->m_nFuncID != -1)	// Aug. 29, 2002 genta ”Ôl‚Ì’l‚ª•ÏX‚³‚ê‚½‚Ì‚Å‚±‚±‚à•ÏX
+	while(Info->m_nFuncID != -1)	// Aug. 29, 2002 genta ç•ªäººã®å€¤ãŒå¤‰æ›´ã•ã‚ŒãŸã®ã§ã“ã“ã‚‚å¤‰æ›´
 	{
 		wchar_t FuncName[256];
 		wcscpy(FuncName, Info->m_pszFuncName);
@@ -81,7 +81,7 @@ void CWSHIfObj::ReadyCommands(MacroFuncInfo *Info, int flags)
 				}
 			}
 		}
-		//	2007.07.21 genta : flag‚ğ‰Á‚¦‚½’l‚ğ“o˜^‚·‚é
+		//	2007.07.21 genta : flagã‚’åŠ ãˆãŸå€¤ã‚’ç™»éŒ²ã™ã‚‹
 		this->AddMethod(
 			FuncName,
 			(Info->m_nFuncID | flags),
@@ -89,8 +89,8 @@ void CWSHIfObj::ReadyCommands(MacroFuncInfo *Info, int flags)
 			ArgCount,
 			Info->m_varResult,
 			reinterpret_cast<CIfObjMethod>(&CWSHIfObj::MacroCommand)
-			/* CWSHIfObj‚ğŒp³‚µ‚½ƒTƒuƒNƒ‰ƒX‚©‚çReadyCommands‚ğŒÄ‚Ño‚µ‚½ê‡A
-			 * ƒTƒuƒNƒ‰ƒX‚ÌMacroCommand‚ªŒÄ‚Ño‚³‚ê‚éB */
+			/* CWSHIfObjã‚’ç¶™æ‰¿ã—ãŸã‚µãƒ–ã‚¯ãƒ©ã‚¹ã‹ã‚‰ReadyCommandsã‚’å‘¼ã³å‡ºã—ãŸå ´åˆã€
+			 * ã‚µãƒ–ã‚¯ãƒ©ã‚¹ã®MacroCommandãŒå‘¼ã³å‡ºã•ã‚Œã‚‹ã€‚ */
 		);
 		delete [] varArgTmp;
 		++Info;
@@ -98,10 +98,10 @@ void CWSHIfObj::ReadyCommands(MacroFuncInfo *Info, int flags)
 }
 
 /*!
-	ƒ}ƒNƒƒRƒ}ƒ“ƒh‚ÌÀs
+	ãƒã‚¯ãƒ­ã‚³ãƒãƒ³ãƒ‰ã®å®Ÿè¡Œ
 
-	@date 2005.06.27 zenryaku –ß‚è’l‚Ìó‚¯æ‚è‚ª–³‚­‚Ä‚àƒGƒ‰[‚É‚¹‚¸‚ÉŠÖ”‚ğÀs‚·‚é
-	@date 2013.06.07 Moca 5‚ÂˆÈã‚Ìˆø”‚Ì‚¸‚ê‚é‚Ì‚ğC³BNUL‚ğŠÜ‚Ş•¶š—ñ‘Î‰
+	@date 2005.06.27 zenryaku æˆ»ã‚Šå€¤ã®å—ã‘å–ã‚ŠãŒç„¡ãã¦ã‚‚ã‚¨ãƒ©ãƒ¼ã«ã›ãšã«é–¢æ•°ã‚’å®Ÿè¡Œã™ã‚‹
+	@date 2013.06.07 Moca 5ã¤ä»¥ä¸Šã®å¼•æ•°ã®æ™‚ãšã‚Œã‚‹ã®ã‚’ä¿®æ­£ã€‚NULã‚’å«ã‚€æ–‡å­—åˆ—å¯¾å¿œ
 */
 HRESULT CWSHIfObj::MacroCommand(int IntID, DISPPARAMS *Arguments, VARIANT* Result, void *Data)
 {
@@ -109,20 +109,20 @@ HRESULT CWSHIfObj::MacroCommand(int IntID, DISPPARAMS *Arguments, VARIANT* Resul
 	int ArgCount = Arguments->cArgs;
 
 	const EFunctionCode ID = static_cast<EFunctionCode>(IntID);
-	//	2007.07.22 genta : ƒRƒ}ƒ“ƒh‚Í‰ºˆÊ16ƒrƒbƒg‚Ì‚İ
+	//	2007.07.22 genta : ã‚³ãƒãƒ³ãƒ‰ã¯ä¸‹ä½16ãƒ“ãƒƒãƒˆã®ã¿
 	if(LOWORD(ID) >= F_FUNCTION_FIRST)
 	{
-		VARIANT ret; // 2005.06.27 zenryaku –ß‚è’l‚Ìó‚¯æ‚è‚ª–³‚­‚Ä‚àŠÖ”‚ğÀs‚·‚é
+		VARIANT ret; // 2005.06.27 zenryaku æˆ»ã‚Šå€¤ã®å—ã‘å–ã‚ŠãŒç„¡ãã¦ã‚‚é–¢æ•°ã‚’å®Ÿè¡Œã™ã‚‹
 		VariantInit(&ret);
 
-		// 2011.3.18 syat ˆø”‚Ì‡˜‚ğ³‚µ‚¢‡‚É‚·‚é
+		// 2011.3.18 syat å¼•æ•°ã®é †åºã‚’æ­£ã—ã„é †ã«ã™ã‚‹
 		auto_array_ptr<VARIANTARG> rgvargParam( new VARIANTARG[ArgCount] );
 		for(I = 0; I < ArgCount; I++){
 			::VariantInit(&rgvargParam[ArgCount - I - 1]);
 			::VariantCopy(&rgvargParam[ArgCount - I - 1], &Arguments->rgvarg[I]);
 		}
 
-		// 2009.9.5 syat HandleFunction‚ÍƒTƒuƒNƒ‰ƒX‚ÅƒI[ƒo[ƒ‰ƒCƒh‚·‚é
+		// 2009.9.5 syat HandleFunctionã¯ã‚µãƒ–ã‚¯ãƒ©ã‚¹ã§ã‚ªãƒ¼ãƒãƒ¼ãƒ©ã‚¤ãƒ‰ã™ã‚‹
 		bool r = HandleFunction(m_pView, ID, &rgvargParam[0], ArgCount, ret);
 		if(Result) {::VariantCopyInd(Result, &ret);}
 		VariantClear(&ret);
@@ -133,17 +133,17 @@ HRESULT CWSHIfObj::MacroCommand(int IntID, DISPPARAMS *Arguments, VARIANT* Resul
 	}
 	else
 	{
-		// Å’á4‚Â‚ÍŠm•Û
+		// æœ€ä½4ã¤ã¯ç¢ºä¿
 		int argCountMin = t_max(4, ArgCount);
-		//	Nov. 29, 2005 FILE ˆø”‚ğ•¶š—ñ‚Åæ“¾‚·‚é
+		//	Nov. 29, 2005 FILE å¼•æ•°ã‚’æ–‡å­—åˆ—ã§å–å¾—ã™ã‚‹
 		auto_array_ptr<LPWSTR> StrArgs( new LPWSTR[argCountMin] );
 		auto_array_ptr<int> strLengths( new int[argCountMin] );
 		for(I = ArgCount; I < argCountMin; I++ ){
 			StrArgs[I] = NULL;
 			strLengths[I] = 0;
 		}
-		WCHAR *S = NULL;								// ‰Šú‰»•K{
-		Variant varCopy;							// VT_BYREF‚¾‚Æ¢‚é‚Ì‚ÅƒRƒs[—p
+		WCHAR *S = NULL;								// åˆæœŸåŒ–å¿…é ˆ
+		Variant varCopy;							// VT_BYREFã ã¨å›°ã‚‹ã®ã§ã‚³ãƒ”ãƒ¼ç”¨
 		int Len;
 		for(I = 0; I < ArgCount; ++I)
 		{
@@ -157,14 +157,14 @@ HRESULT CWSHIfObj::MacroCommand(int IntID, DISPPARAMS *Arguments, VARIANT* Resul
 				S[0] = 0;
 				Len = 0;
 			}
-			StrArgs[ArgCount - I - 1] = S;			// DISPPARAMS‚Íˆø”‚Ì‡˜‚ª‹t“]‚µ‚Ä‚¢‚é‚½‚ß³‚µ‚¢‡‚É’¼‚·
+			StrArgs[ArgCount - I - 1] = S;			// DISPPARAMSã¯å¼•æ•°ã®é †åºãŒé€†è»¢ã—ã¦ã„ã‚‹ãŸã‚æ­£ã—ã„é †ã«ç›´ã™
 			strLengths[ArgCount - I - 1] = Len;
 		}
 
-		// 2009.10.29 syat HandleCommand‚ÍƒTƒuƒNƒ‰ƒX‚ÅƒI[ƒo[ƒ‰ƒCƒh‚·‚é
+		// 2009.10.29 syat HandleCommandã¯ã‚µãƒ–ã‚¯ãƒ©ã‚¹ã§ã‚ªãƒ¼ãƒãƒ¼ãƒ©ã‚¤ãƒ‰ã™ã‚‹
 		HandleCommand(m_pView, ID, const_cast<WCHAR const **>(&StrArgs[0]), &strLengths[0], ArgCount);
 
-		//	Nov. 29, 2005 FILE ”z—ñ‚Ì”jŠü‚È‚Ì‚ÅA[Š‡ŒÊ]‚ğ’Ç‰Á
+		//	Nov. 29, 2005 FILE é…åˆ—ã®ç ´æ£„ãªã®ã§ã€[æ‹¬å¼§]ã‚’è¿½åŠ 
 		for(int J = 0; J < ArgCount; ++J)
 			delete [] StrArgs[J];
 

--- a/sakura_core/macro/CWSHIfObj.h
+++ b/sakura_core/macro/CWSHIfObj.h
@@ -1,11 +1,11 @@
-/*!	@file
-	@brief WSHƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒgŠî–{ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief WSHã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆåŸºæœ¬ã‚¯ãƒ©ã‚¹
 
-	@date 2009.10.29 syat CWSH.h‚©‚çØ‚èo‚µ
+	@date 2009.10.29 syat CWSH.hã‹ã‚‰åˆ‡ã‚Šå‡ºã—
 
 */
 /*
-	Copyright (C) 2002, ‹S, genta
+	Copyright (C) 2002, é¬¼, genta
 	Copyright (C) 2009, syat
 
 	This software is provided 'as-is', without any express or implied
@@ -38,23 +38,23 @@
 #include "macro/CSMacroMgr.h" // MacroFuncInfo, MacroFuncInfoArray
 class CEditView;
 
-/* CWSHIfObj - ƒvƒ‰ƒOƒCƒ“‚âƒ}ƒNƒ‚ÉŒöŠJ‚·‚éƒIƒuƒWƒFƒNƒg
- * g—pã‚Ì’ˆÓ:
- *   1. ¶¬‚Ínew‚ÅB
- *      QÆƒJƒEƒ“ƒ^‚ğ‚Â‚Ì‚ÅA©“®•Ï”‚Å¶¬‚·‚é‚ÆƒXƒR[ƒv”²‚¯‚Ä‰ğ•ú‚³‚ê‚é‚Æ‚«‚Éƒq[ƒvƒGƒ‰[‚ªo‚Ü‚·B
- *   2. ¶¬‚µ‚½‚çAddRef()A•s—v‚É‚È‚Á‚½‚çRelease()‚ğŒÄ‚Ô‚±‚ÆB
- *   3. V‚µ‚¢IfObj‚ğì‚é‚ÍCWSHIfObj‚ğŒp³‚µAˆÈ‰º‚Ì4‚Â‚ğƒI[ƒo[ƒ‰ƒCƒh‚·‚é‚±‚ÆB
+/* CWSHIfObj - ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚„ãƒã‚¯ãƒ­ã«å…¬é–‹ã™ã‚‹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
+ * ä½¿ç”¨ä¸Šã®æ³¨æ„:
+ *   1. ç”Ÿæˆã¯newã§ã€‚
+ *      å‚ç…§ã‚«ã‚¦ãƒ³ã‚¿ã‚’æŒã¤ã®ã§ã€è‡ªå‹•å¤‰æ•°ã§ç”Ÿæˆã™ã‚‹ã¨ã‚¹ã‚³ãƒ¼ãƒ—æŠœã‘ã¦è§£æ”¾ã•ã‚Œã‚‹ã¨ãã«ãƒ’ãƒ¼ãƒ—ã‚¨ãƒ©ãƒ¼ãŒå‡ºã¾ã™ã€‚
+ *   2. ç”Ÿæˆã—ãŸã‚‰AddRef()ã€ä¸è¦ã«ãªã£ãŸã‚‰Release()ã‚’å‘¼ã¶ã“ã¨ã€‚
+ *   3. æ–°ã—ã„IfObjã‚’ä½œã‚‹æ™‚ã¯CWSHIfObjã‚’ç¶™æ‰¿ã—ã€ä»¥ä¸‹ã®4ã¤ã‚’ã‚ªãƒ¼ãƒãƒ¼ãƒ©ã‚¤ãƒ‰ã™ã‚‹ã“ã¨ã€‚
  *      GetMacroCommandInfo, GetMacroFuncInfo, HandleCommand, HandleFunction
  */
 class CWSHIfObj
 : public CIfObj
 {
 public:
-	// Œ^’è‹`
+	// å‹å®šç¾©
 	typedef std::list<CWSHIfObj*> List;
 	typedef List::const_iterator ListIter;
 
-	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	// ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CWSHIfObj(const wchar_t* name, bool isGlobal)
 	: CIfObj(name, isGlobal)
 	{}
@@ -62,17 +62,17 @@ public:
 	virtual void ReadyMethods( CEditView* pView, int flags );
 
 protected:
-	// ‘€ì
-	//	2007.07.20 genta : flags’Ç‰Á
-	//  2009.09.05 syat CWSHManager‚©‚çˆÚ“®
+	// æ“ä½œ
+	//	2007.07.20 genta : flagsè¿½åŠ 
+	//  2009.09.05 syat CWSHManagerã‹ã‚‰ç§»å‹•
 	void ReadyCommands(MacroFuncInfo *Info, int flags);
 	HRESULT MacroCommand(int ID, DISPPARAMS *Arguments, VARIANT* Result, void *Data);
 
-	// ”ñÀ‘•’ñ‹Ÿ
-	virtual bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result) = 0;	//ŠÖ”‚ğˆ—‚·‚é
-	virtual bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize) = 0;	//ƒRƒ}ƒ“ƒh‚ğˆ—‚·‚é
-	virtual MacroFuncInfoArray GetMacroCommandInfo() const = 0;	//ƒRƒ}ƒ“ƒhî•ñ‚ğæ“¾‚·‚é
-	virtual MacroFuncInfoArray GetMacroFuncInfo() const = 0;	//ŠÖ”î•ñ‚ğæ“¾‚·‚é
+	// éå®Ÿè£…æä¾›
+	virtual bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result) = 0;	//é–¢æ•°ã‚’å‡¦ç†ã™ã‚‹
+	virtual bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize) = 0;	//ã‚³ãƒãƒ³ãƒ‰ã‚’å‡¦ç†ã™ã‚‹
+	virtual MacroFuncInfoArray GetMacroCommandInfo() const = 0;	//ã‚³ãƒãƒ³ãƒ‰æƒ…å ±ã‚’å–å¾—ã™ã‚‹
+	virtual MacroFuncInfoArray GetMacroFuncInfo() const = 0;	//é–¢æ•°æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 
 	CEditView* m_pView;
 };

--- a/sakura_core/macro/CWSHManager.cpp
+++ b/sakura_core/macro/CWSHManager.cpp
@@ -1,10 +1,10 @@
-/*!	@file
+ï»¿/*!	@file
 	@brief WSH Manager
 
-	@date 2009.10.29 syat CWSH.cpp‚©‚çØ‚èo‚µ
+	@date 2009.10.29 syat CWSH.cppã‹ã‚‰åˆ‡ã‚Šå‡ºã—
 */
 /*
-	Copyright (C) 2002, ‹S, genta
+	Copyright (C) 2002, é¬¼, genta
 	Copyright (C) 2003, FILE
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, FILE, zenryaku
@@ -54,11 +54,11 @@ CWSHMacroManager::~CWSHMacroManager()
 {
 }
 
-/** WSHƒ}ƒNƒ‚ÌÀs
+/** WSHãƒã‚¯ãƒ­ã®å®Ÿè¡Œ
 
-	@param EditView [in] ‘€ì‘ÎÛEditView
+	@param EditView [in] æ“ä½œå¯¾è±¡EditView
 	
-	@date 2007.07.20 genta : flags’Ç‰Á
+	@date 2007.07.20 genta : flagsè¿½åŠ 
 */
 bool CWSHMacroManager::ExecKeyMacro(CEditView *EditView, int flags) const
 {
@@ -67,7 +67,7 @@ bool CWSHMacroManager::ExecKeyMacro(CEditView *EditView, int flags) const
 	bool bRet = false;
 	if(Engine->m_Valid)
 	{
-		//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg‚Ì“o˜^
+		//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã®ç™»éŒ²
 		CWSHIfObj* objEditor = new CEditorIfObj();
 		objEditor->ReadyMethods( EditView, flags );
 		Engine->AddInterfaceObject( objEditor );
@@ -83,14 +83,14 @@ bool CWSHMacroManager::ExecKeyMacro(CEditView *EditView, int flags) const
 }
 
 /*!
-	WSHƒ}ƒNƒ‚Ì“Ç‚İ‚İiƒtƒ@ƒCƒ‹‚©‚çj
+	WSHãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ï¼ˆãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ï¼‰
 
-	@param hInstance [in] ƒCƒ“ƒXƒ^ƒ“ƒXƒnƒ“ƒhƒ‹(–¢g—p)
-	@param pszPath   [in] ƒtƒ@ƒCƒ‹‚ÌƒpƒX
+	@param hInstance [in] ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ãƒãƒ³ãƒ‰ãƒ«(æœªä½¿ç”¨)
+	@param pszPath   [in] ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹
 */
 BOOL CWSHMacroManager::LoadKeyMacro(HINSTANCE hInstance, const TCHAR* pszPath)
 {
-	//ƒ\[ƒX“Ç‚İ‚İ -> m_Source
+	//ã‚½ãƒ¼ã‚¹èª­ã¿è¾¼ã¿ -> m_Source
 	m_Source=L"";
 	
 	CTextInputStream in(pszPath);
@@ -104,21 +104,21 @@ BOOL CWSHMacroManager::LoadKeyMacro(HINSTANCE hInstance, const TCHAR* pszPath)
 }
 
 /*!
-	WSHƒ}ƒNƒ‚Ì“Ç‚İ‚İi•¶š—ñ‚©‚çj
+	WSHãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ï¼ˆæ–‡å­—åˆ—ã‹ã‚‰ï¼‰
 
-	@param hInstance [in] ƒCƒ“ƒXƒ^ƒ“ƒXƒnƒ“ƒhƒ‹(–¢g—p)
-	@param pszCode   [in] ƒ}ƒNƒƒR[ƒh
+	@param hInstance [in] ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ãƒãƒ³ãƒ‰ãƒ«(æœªä½¿ç”¨)
+	@param pszCode   [in] ãƒã‚¯ãƒ­ã‚³ãƒ¼ãƒ‰
 */
 BOOL CWSHMacroManager::LoadKeyMacroStr(HINSTANCE hInstance, const TCHAR* pszCode)
 {
-	//ƒ\[ƒX“Ç‚İ‚İ -> m_Source
+	//ã‚½ãƒ¼ã‚¹èª­ã¿è¾¼ã¿ -> m_Source
 	m_Source = to_wchar( pszCode );
 	return TRUE;
 }
 
 CMacroManagerBase* CWSHMacroManager::Creator(const TCHAR* FileExt)
 {
-	TCHAR FileExtWithDot[1024], FileType[1024], EngineName[1024]; //1024‚ğ’´‚¦‚½‚çŒã‚Í’m‚è‚Ü‚¹‚ñ
+	TCHAR FileExtWithDot[1024], FileType[1024], EngineName[1024]; //1024ã‚’è¶…ãˆãŸã‚‰å¾Œã¯çŸ¥ã‚Šã¾ã›ã‚“
 	
 	_tcscpy( FileExtWithDot, _T(".") );
 	_tcscat( FileExtWithDot, FileExt );
@@ -138,23 +138,23 @@ CMacroManagerBase* CWSHMacroManager::Creator(const TCHAR* FileExt)
 
 void CWSHMacroManager::declare()
 {
-	//b’è
+	//æš«å®š
 	CMacroFactory::getInstance()->RegisterCreator(Creator);
 }
 
-//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg‚ğ’Ç‰Á‚·‚é
+//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’è¿½åŠ ã™ã‚‹
 void CWSHMacroManager::AddParam( CWSHIfObj* param )
 {
 	m_Params.push_back( param );
 }
 
-//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg’B‚ğ’Ç‰Á‚·‚é
+//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆé”ã‚’è¿½åŠ ã™ã‚‹
 void CWSHMacroManager::AddParam( CWSHIfObj::List& params )
 {
 	m_Params.insert( m_Params.end(), params.begin(), params.end() );
 }
 
-//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg‚ğíœ‚·‚é
+//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’å‰Šé™¤ã™ã‚‹
 void CWSHMacroManager::ClearParam()
 {
 	m_Params.clear();

--- a/sakura_core/macro/CWSHManager.h
+++ b/sakura_core/macro/CWSHManager.h
@@ -1,18 +1,18 @@
-/*!	@file
+ï»¿/*!	@file
 	@brief WSH Manager
 
-	@author ‹S, genta
-	@date 2002”N4Œ28“ú,5Œ3“ú,5Œ5“ú,5Œ6“ú,5Œ13“ú,5Œ16“ú
-	@date 2002.08.25 genta CWSH.h‚æ‚è•ª—£
+	@author é¬¼, genta
+	@date 2002å¹´4æœˆ28æ—¥,5æœˆ3æ—¥,5æœˆ5æ—¥,5æœˆ6æ—¥,5æœˆ13æ—¥,5æœˆ16æ—¥
+	@date 2002.08.25 genta CWSH.hã‚ˆã‚Šåˆ†é›¢
 
 	@par TODO
-	@li –¢’m‚ÌƒGƒ“ƒWƒ“‚É‘Î‰‚Å‚«‚é‚æ‚¤CMacroFactory‚ğ•ÏX ¨ —v‹c˜_
-	@li CEditView::HandleCommand‚ğg‚¤ ¨ CMacro::HandleCommand‚Å‚à‚È‚É‚©‚â‚Á‚Ä‚é‚æ‚¤‚È‚Ì‚Å‚¢‚¶‚ç‚È‚¢•û‚ªH
-	@li vector::reserve‚ğg‚¤ ¨ CSMacroMgr‚ÅŒÂ”‚ªéŒ¾‚³‚ê‚Ä–³‚¢‚Ì‚ÅŒ©‘—‚è
-	@li Ä•`‰æ‚Ì‘ã‚í‚è‚ÉShowEditCaret ¨ protected‚Å‚·‚æ[
+	@li æœªçŸ¥ã®ã‚¨ãƒ³ã‚¸ãƒ³ã«å¯¾å¿œã§ãã‚‹ã‚ˆã†CMacroFactoryã‚’å¤‰æ›´ â†’ è¦è­°è«–
+	@li CEditView::HandleCommandã‚’ä½¿ã† â†’ CMacro::HandleCommandã§ã‚‚ãªã«ã‹ã‚„ã£ã¦ã‚‹ã‚ˆã†ãªã®ã§ã„ã˜ã‚‰ãªã„æ–¹ãŒï¼Ÿ
+	@li vector::reserveã‚’ä½¿ã† â†’ CSMacroMgrã§å€‹æ•°ãŒå®£è¨€ã•ã‚Œã¦ç„¡ã„ã®ã§è¦‹é€ã‚Š
+	@li å†æç”»ã®ä»£ã‚ã‚Šã«ShowEditCaret â†’ protectedã§ã™ã‚ˆãƒ¼
 */
 /*
-	Copyright (C) 2002, ‹S, genta
+	Copyright (C) 2002, é¬¼, genta
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -37,7 +37,7 @@ public:
 	CWSHMacroManager(std::wstring const AEngineName);
 	virtual ~CWSHMacroManager();
 
-	//	2007.07.20 genta : flags’Ç‰Á
+	//	2007.07.20 genta : flagsè¿½åŠ 
 	virtual bool ExecKeyMacro(CEditView *EditView, int flags) const;
 	virtual BOOL LoadKeyMacro(HINSTANCE hInstance, const TCHAR* pszPath);
 	virtual BOOL LoadKeyMacroStr(HINSTANCE hInstance, const TCHAR* pszCode);
@@ -45,15 +45,15 @@ public:
 	static CMacroManagerBase* Creator(const TCHAR* FileExt);
 	static void declare();
 
-	void AddParam( CWSHIfObj* param );				//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg‚ğ’Ç‰Á‚·‚é
-	void AddParam( CWSHIfObj::List& params );		//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg’B‚ğ’Ç‰Á‚·‚é
-	void ClearParam();								//ƒCƒ“ƒ^ƒtƒF[ƒXƒIƒuƒWƒFƒNƒg‚ğíœ‚·‚é
+	void AddParam( CWSHIfObj* param );				//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’è¿½åŠ ã™ã‚‹
+	void AddParam( CWSHIfObj::List& params );		//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆé”ã‚’è¿½åŠ ã™ã‚‹
+	void ClearParam();								//ã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’å‰Šé™¤ã™ã‚‹
 protected:
 	std::wstring m_Source;
 	std::wstring m_EngineName;
 	CWSHIfObj::List m_Params;
-	//2009.10.29 syat CWSHIfObj‚ÖˆÚ“®
-	////	2007.07.20 genta : flags’Ç‰Á
+	//2009.10.29 syat CWSHIfObjã¸ç§»å‹•
+	////	2007.07.20 genta : flagsè¿½åŠ 
 	//static void ReadyCommands(CIfObj *Object, MacroFuncInfo *Info, int flags);
 };
 #endif


### PR DESCRIPTION
該当フォルダ内の文字コードを変換して支障のないものだけを対象に変換を行いました。

```
cd sakura_core/macro
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
git checkout CMacro.cpp … ANSI以外の文字定数・文字列定数があるので変換から除外
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
- ソースコードのUnicode化 #112
