### PR TITLE
Git情報がなくてもビルドできるようにする (Close #148)

### DIFF
--- a/sakura_core/version.h
+++ b/sakura_core/version.h
@@ -43,7 +43,15 @@
 #define ALPHA_VERSION_STR_WITH_SPACE ""
 #endif
 
+// バージョン情報埋め込み用 Git ハッシュ文字列 (存在しない場合には空文字列)
+#ifdef GIT_SHORT_COMMIT_HASH
+#define VER_GITHASH " (" GIT_SHORT_COMMIT_HASH ")"
+#else
+#define VER_GITHASH ""
+#endif
+
 // リソース埋め込み用バージョン文字列
-// e.g. "2.3.2.0 (4a0de579) UNICODE 64bit DEBUG"
-// e.g. "2.3.2.0 (4a0de579) UNICODE 64bit"
-#define RESOURCE_VERSION_STRING(_VersionString) _VersionString " (" GIT_SHORT_COMMIT_HASH ") " VER_CHARSET " " VER_PLATFORM SPACE_WHEN_DEBUG VER_CONFIG ALPHA_VERSION_STR_WITH_SPACE
+// e.g. "2.3.2.0 (4a0de579) UNICODE 64bit DEBUG" … デバッグビルド時の例
+// e.g. "2.3.2.0 (4a0de579) UNICODE 64bit"       … リリースビルド時の例
+// e.g. "2.3.2.0 UNICODE 64bit"                  … Git 情報無い場合の例
+#define RESOURCE_VERSION_STRING(_VersionString) _VersionString VER_GITHASH " " VER_CHARSET " " VER_PLATFORM SPACE_WHEN_DEBUG VER_CONFIG ALPHA_VERSION_STR_WITH_SPACE

--- a/sakura_core/version.h
+++ b/sakura_core/version.h
@@ -50,8 +50,8 @@
 #define VER_GIT_SHORTHASH ""
 #endif
 
-// リソース埋め込み用バージョン文字列
-// e.g. "2.3.2.0 (4a0de579) UNICODE 64bit DEBUG" … デバッグビルド時の例
-// e.g. "2.3.2.0 (4a0de579) UNICODE 64bit"       … リリースビルド時の例
-// e.g. "2.3.2.0 UNICODE 64bit"                  … Git 情報無い場合の例
+// リソース埋め込み用バージョン文字列 //
+// e.g. "2.3.2.0 (4a0de579) UNICODE 64bit DEBUG" … デバッグビルド時の例 //
+// e.g. "2.3.2.0 (4a0de579) UNICODE 64bit"       … リリースビルド時の例 //
+// e.g. "2.3.2.0 UNICODE 64bit"                  … Git 情報無い場合の例 //
 #define RESOURCE_VERSION_STRING(_VersionString) _VersionString VER_GIT_SHORTHASH " " VER_CHARSET " " VER_PLATFORM SPACE_WHEN_DEBUG VER_CONFIG ALPHA_VERSION_STR_WITH_SPACE

--- a/sakura_core/version.h
+++ b/sakura_core/version.h
@@ -45,13 +45,13 @@
 
 // バージョン情報埋め込み用 Git ハッシュ文字列 (存在しない場合には空文字列)
 #ifdef GIT_SHORT_COMMIT_HASH
-#define VER_GITHASH " (" GIT_SHORT_COMMIT_HASH ")"
+#define VER_GIT_SHORTHASH " (" GIT_SHORT_COMMIT_HASH ")"
 #else
-#define VER_GITHASH ""
+#define VER_GIT_SHORTHASH ""
 #endif
 
 // リソース埋め込み用バージョン文字列
 // e.g. "2.3.2.0 (4a0de579) UNICODE 64bit DEBUG" … デバッグビルド時の例
 // e.g. "2.3.2.0 (4a0de579) UNICODE 64bit"       … リリースビルド時の例
 // e.g. "2.3.2.0 UNICODE 64bit"                  … Git 情報無い場合の例
-#define RESOURCE_VERSION_STRING(_VersionString) _VersionString VER_GITHASH " " VER_CHARSET " " VER_PLATFORM SPACE_WHEN_DEBUG VER_CONFIG ALPHA_VERSION_STR_WITH_SPACE
+#define RESOURCE_VERSION_STRING(_VersionString) _VersionString VER_GIT_SHORTHASH " " VER_CHARSET " " VER_PLATFORM SPACE_WHEN_DEBUG VER_CONFIG ALPHA_VERSION_STR_WITH_SPACE


### PR DESCRIPTION
https://github.com/sakura-editor/sakura/issues/148

@yoshinrt 
> git コマンドが利用できない条件でビルドすると .rc でエラーになるようです．

これの修正です。

## ビルド結果例
<img width="273" alt="ver" src="https://user-images.githubusercontent.com/2929454/42121264-5f71ca06-7c66-11e8-8e13-d08b72d3565f.png">
