### PR TITLE
同期オブジェクトの作成順見直し

### DIFF
--- a/sakura_core/_main/CControlProcess.cpp
+++ b/sakura_core/_main/CControlProcess.cpp
@@ -54,17 +54,6 @@ bool CControlProcess::InitializeProcess()
 
 	std::tstring strProfileName = to_tchar(CCommandLine::getInstance()->GetProfileName());
 
-	// 初期化完了イベントを作成する
-	std::tstring strInitEvent = GSTR_EVENT_SAKURA_CP_INITIALIZED;
-	strInitEvent += strProfileName;
-	m_hEventCPInitialized = ::CreateEvent( NULL, TRUE, FALSE, strInitEvent.c_str() );
-	if( NULL == m_hEventCPInitialized )
-	{
-		ErrorBeep();
-		TopErrorMessage( NULL, _T("CreateEvent()失敗。\n終了します。") );
-		return false;
-	}
-
 	/* コントロールプロセスの目印 */
 	std::tstring strCtrlProcEvent = GSTR_MUTEX_SAKURA_CP;
 	strCtrlProcEvent += strProfileName;
@@ -78,6 +67,17 @@ bool CControlProcess::InitializeProcess()
 		return false;
 	}
 	
+	// 初期化完了イベントを作成する
+	std::tstring strInitEvent = GSTR_EVENT_SAKURA_CP_INITIALIZED;
+	strInitEvent += strProfileName;
+	m_hEventCPInitialized = ::CreateEvent( NULL, TRUE, FALSE, strInitEvent.c_str() );
+	if( NULL == m_hEventCPInitialized )
+	{
+		ErrorBeep();
+		TopErrorMessage( NULL, _T("CreateEvent()失敗。\n終了します。") );
+		return false;
+	}
+
 	/* 共有メモリを初期化 */
 	if( !CProcess::InitializeProcess() ){
 		return false;


### PR DESCRIPTION
同期オブジェクトの作成順見直しを提案します。

変数名 | 作成順 | 説明 |
---- | ---- | ---- |
m_hMutexCP | 3 -> 1 | コントロールプロセスの排他実行に使うロックオブジェクト。 |
m_hEventCPInitialized | 2 -> 2 | コントロールプロセスの準備完了待機に使うイベントオブジェクト。 | 
m_hMutex | 1 -> 3 | 外部プログラムからsakura.exeの実行を検出するためのマーカー。 |
 
他の修正と混ぜると優先順変更の意図がぼやけるので単体でPRします。
この修正単体では目に見える挙動の変化は起こりません。