### PR TITLE
毎ビルドほぼすべての .cpp がリコンパイルされるのを修正

### DIFF
--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -55,59 +55,69 @@ if "%GIT_ENABLED%" == "1" (
 
 : Output githash.h
 set GITHASH_H=..\sakura_core\githash.h
-type nul                                  > %GITHASH_H%
-echo #pragma once                        >> %GITHASH_H%
+set GITHASH_H_TMP=%GITHASH_H%.tmp
+type nul                                  > %GITHASH_H_TMP%
+echo #pragma once                        >> %GITHASH_H_TMP%
 if "%COMMITID%" == "" (
-	type nul                                  >> %GITHASH_H%
+	type nul                                  >> %GITHASH_H_TMP%
 ) else (
-	echo #define GIT_COMMIT_HASH "%COMMITID%" >> %GITHASH_H%
+	echo #define GIT_COMMIT_HASH "%COMMITID%" >> %GITHASH_H_TMP%
 )
 if "%SHORT_COMMITID%" == "" (
-	type nul                                              >> %GITHASH_H%
+	type nul                                              >> %GITHASH_H_TMP%
 ) else (
-	echo #define GIT_SHORT_COMMIT_HASH "%SHORT_COMMITID%" >> %GITHASH_H%
+	echo #define GIT_SHORT_COMMIT_HASH "%SHORT_COMMITID%" >> %GITHASH_H_TMP%
 )
 if "%GIT_URL%" == "" (
-	type nul                                              >> %GITHASH_H%
+	type nul                                              >> %GITHASH_H_TMP%
 ) else (
-	echo #define GIT_URL "%GIT_URL%"                      >> %GITHASH_H%
+	echo #define GIT_URL "%GIT_URL%"                      >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_URL%" == "" (
-	type nul                                              >> %GITHASH_H%
+	type nul                                              >> %GITHASH_H_TMP%
 ) else (
-	echo #define APPVEYOR_URL "%APPVEYOR_URL%"            >> %GITHASH_H%
+	echo #define APPVEYOR_URL "%APPVEYOR_URL%"            >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_REPO_NAME%" == "" (
-	type nul                                                          >> %GITHASH_H%
+	type nul                                                          >> %GITHASH_H_TMP%
 ) else (
-	echo #define APPVEYOR_REPO_NAME "%APPVEYOR_REPO_NAME%"            >> %GITHASH_H%
+	echo #define APPVEYOR_REPO_NAME "%APPVEYOR_REPO_NAME%"            >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_ACCOUNT_NAME%" == "" (
-	type nul                                                          >> %GITHASH_H%
+	type nul                                                          >> %GITHASH_H_TMP%
 ) else (
-	echo #define APPVEYOR_ACCOUNT_NAME "%APPVEYOR_ACCOUNT_NAME%"      >> %GITHASH_H%
+	echo #define APPVEYOR_ACCOUNT_NAME "%APPVEYOR_ACCOUNT_NAME%"      >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_PROJECT_SLUG%" == "" (
-	type nul                                                          >> %GITHASH_H%
+	type nul                                                          >> %GITHASH_H_TMP%
 ) else (
-	echo #define APPVEYOR_PROJECT_SLUG "%APPVEYOR_PROJECT_SLUG%"      >> %GITHASH_H%
+	echo #define APPVEYOR_PROJECT_SLUG "%APPVEYOR_PROJECT_SLUG%"      >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_BUILD_VERSION%" == "" (
-	type nul                                                          >> %GITHASH_H%
+	type nul                                                          >> %GITHASH_H_TMP%
 ) else (
-	echo #define APPVEYOR_BUILD_VERSION "%APPVEYOR_BUILD_VERSION%"    >> %GITHASH_H%
+	echo #define APPVEYOR_BUILD_VERSION "%APPVEYOR_BUILD_VERSION%"    >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_BUILD_NUMBER%" == "" (
-	type nul                                                          >> %GITHASH_H%
+	type nul                                                          >> %GITHASH_H_TMP%
 ) else (
-	echo #define APPVEYOR_BUILD_NUMBER     "%APPVEYOR_BUILD_NUMBER%"      >> %GITHASH_H%
-	echo #define APPVEYOR_BUILD_NUMBER_INT  %APPVEYOR_BUILD_NUMBER%       >> %GITHASH_H%
+	echo #define APPVEYOR_BUILD_NUMBER     "%APPVEYOR_BUILD_NUMBER%"      >> %GITHASH_H_TMP%
+	echo #define APPVEYOR_BUILD_NUMBER_INT  %APPVEYOR_BUILD_NUMBER%       >> %GITHASH_H_TMP%
+)
+
+fc %GITHASH_H% %GITHASH_H_TMP% 1>nul 2>&1
+if "%ERRORLEVEL%" == "0" (
+	del %GITHASH_H_TMP%
+) else (
+	if exist %GITHASH_H% del %GITHASH_H%
+	move /y %GITHASH_H_TMP% %GITHASH_H%
+	@echo %GITHASH_H% updated.
 )
 
 ENDLOCAL

--- a/sakura_core/.gitignore
+++ b/sakura_core/.gitignore
@@ -1,3 +1,4 @@
 /githash.h
+/githash.h.tmp
 /Funccode_define.h
 /Funccode_enum.h


### PR DESCRIPTION
## 概要
preBuild.bat により githash.h のタイムスタンプが変わるため，毎ビルドほぼすべての .cpp がリコンパイルされるのを修正します．

## 再現手順

1. 一度ビルドします
1. 何でもいいのですが例として，sakura_core/CAutoReloadAgent.cpp を修正するなりしてタイムスタンプを変えます
1. ビルドします．PR 適用前は，関係ない .cpp もコンパイルされますが，PR 適用後は CAutoReloadAgent.cpp のみがコンパイルされます．