### PR TITLE
[WIP] プロファイル未指定なら-PROF=""を出さない

### DIFF
--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -494,7 +494,6 @@ void CCommandLine::ParseCommandLine( LPCTSTR pszCmdLineSrc, bool bResponse )
 				break;
 			case CMDLINEOPT_PROF:		// 2013.12.20 Moca ’Ç‰Á
 				m_cmProfile.SetStringT( arg );
-				m_bSetProfile = true;
 				break;
 			case CMDLINEOPT_PROFMGR:
 				m_bProfileMgr = true;
@@ -534,7 +533,6 @@ CCommandLine::CCommandLine()
 	m_bNoWindow				= false;
 	m_bWriteQuit			= false;
 	m_bProfileMgr			= false;
-	m_bSetProfile			= false;
 	m_gi.bGrepSubFolder		= false;
 	m_gi.sGrepSearchOption.Reset();
 	m_gi.bGrepCurFolder		= false;

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -92,7 +92,7 @@ public:
 	LPCWSTR GetProfileName() const{ return m_cmProfile.GetStringPtr(); }
 	bool IsSetProfile() const{ return m_bSetProfile; }
 	void SetProfileName(LPCWSTR s){
-		m_bSetProfile = true;
+		m_bSetProfile = (s && s[0]); // ˆø”s‚ª‹ó•¶š‚Å‚È‚¢ê‡‚Étrue
 		m_cmProfile.SetString(s);
 	}
 	bool IsProfileMgr() { return m_bProfileMgr; }

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -90,10 +90,9 @@ public:
 	LPCWSTR GetMacro() const{ return m_cmMacro.GetStringPtr(); }
 	LPCWSTR GetMacroType() const{ return m_cmMacroType.GetStringPtr(); }
 	LPCWSTR GetProfileName() const{ return m_cmProfile.GetStringPtr(); }
-	bool IsSetProfile() const{ return m_bSetProfile; }
+	bool IsSetProfile() const{ return *GetProfileName() != '\0'; } //有効な文字列がセットされていたらtrue
 	void SetProfileName(LPCWSTR s){
-		m_bSetProfile = (s && s[0]); // 引数sが空文字でない場合にtrue
-		m_cmProfile.SetString(s);
+		m_cmProfile.SetString(s ? s : L""); //NULL引数対策
 	}
 	bool IsProfileMgr() { return m_bProfileMgr; }
 	int GetFileNum(void) { return m_vFiles.size(); }
@@ -109,7 +108,6 @@ private:
 	bool		m_bNoWindow;		//! [out] TRUE: 編集Windowを開かない
 	bool		m_bWriteQuit;		//! [out] TRUE: 設定を保存して終了	// 2007.05.19 ryoji sakuext用に追加
 	bool		m_bProfileMgr;
-	bool		m_bSetProfile;
 	EditInfo	m_fi;				//!
 	GrepInfo	m_gi;				//!
 	bool		m_bViewMode;		//! [out] TRUE: Read Only


### PR DESCRIPTION
### 前提

サクラエディタのオプションに-PROFというのがあります。
プロファイルを指定した場合に通常とは別の設定ファイルを使えるようにする機能です。

何らかのプロファイルが指定されている場合には、
エディタやコントロールプロセスの起動時にプロファイル指定を引き継ぐ仕組みになっています。

### バグ内容

プロファイルが指定されていない場合、エディタやコントロールプロセスの起動コマンドラインに「 -PROF=""」が付いています。

### 確認方法

1. 対策前バージョン(v2.3.0など)と対策後バージョンのサクラエディタを同時に起動します。
2. タスクマネージャを開き、詳細タブを表示させます。
3. 「コマンドライン」列が非表示になっていたらヘッダ右クリックメニュー「列の選択」で表示させます。
4. コマンドライン列を見比べます。

変更前: sakura.exe -NOWIN -PROF=""
変更後: sakura.exe -NOWIN
※実際には sakura.exe 部分がフルパスになります。
