### PR TITLE
mem 配下のいくつかのファイルを UTF-8 (BOM付) に単純変換

### DIFF
--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -1,15 +1,15 @@
-/*!	@file
-	ƒƒ‚ƒŠƒoƒbƒtƒ@ƒNƒ‰ƒX
+ï»¿/*!	@file
+	ãƒ¡ãƒ¢ãƒªãƒãƒƒãƒ•ã‚¡ã‚¯ãƒ©ã‚¹
 
 	@author Norio Nakatani
-	@date 1998/03/06 V‹Kì¬
+	@date 1998/03/06 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2000-2001, jepro, genta
 	Copyright (C) 2001, mik, misaka, Stonee, hor
 	Copyright (C) 2002, Moca, sui, aroka, genta
-	Copyright (C) 2003, genta, Moca, ‚©‚ë‚Æ
+	Copyright (C) 2003, genta, Moca, ã‹ã‚ã¨
 	Copyright (C) 2004, Moca
 	Copyright (C) 2005, Moca, D.S.Koba
 
@@ -39,7 +39,7 @@
 #include "_main/global.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//               ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^                  //
+//               ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿                  //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void CMemory::_init_members()
@@ -55,11 +55,11 @@ CMemory::CMemory()
 }
 
 /*
-	@note Ši”[ƒf[ƒ^‚É‚ÍNULL‚ğŠÜ‚Ş‚±‚Æ‚ª‚Å‚«‚é
+	@note æ ¼ç´ãƒ‡ãƒ¼ã‚¿ã«ã¯NULLã‚’å«ã‚€ã“ã¨ãŒã§ãã‚‹
 */
 CMemory::CMemory(
-	const void*	pData,			//!< Ši”[ƒf[ƒ^ƒAƒhƒŒƒX
-	int			nDataLenBytes	//!< Ši”[ƒf[ƒ^‚Ì—LŒø’·
+	const void*	pData,			//!< æ ¼ç´ãƒ‡ãƒ¼ã‚¿ã‚¢ãƒ‰ãƒ¬ã‚¹
+	int			nDataLenBytes	//!< æ ¼ç´ãƒ‡ãƒ¼ã‚¿ã®æœ‰åŠ¹é•·
 )
 {
 	_init_members();
@@ -82,7 +82,7 @@ CMemory::~CMemory()
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ‰‰Zq                             //
+//                          æ¼”ç®—å­                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 const CMemory& CMemory::operator = ( const CMemory& rhs )
@@ -97,14 +97,14 @@ const CMemory& CMemory::operator = ( const CMemory& rhs )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         À‘••â•                            //
+//                         å®Ÿè£…è£œåŠ©                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
 
 
 /*
-|| ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éiprotectƒƒ“ƒo
+|| ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ï¼ˆprotectãƒ¡ãƒ³ãƒ
 */
 void CMemory::_AddData( const void* pData, int nDataLen )
 {
@@ -114,7 +114,7 @@ void CMemory::_AddData( const void* pData, int nDataLen )
 	memcpy( &m_pRawData[m_nRawLen], pData, nDataLen );
 	m_nRawLen += nDataLen;
 	m_pRawData[m_nRawLen]   = '\0';
-	m_pRawData[m_nRawLen+1] = '\0'; //I’['\0'‚ğ2‚Â•t‰Á‚·‚é('\0''\0'==L'\0')B 2007.08.13 kobake ’Ç‰Á
+	m_pRawData[m_nRawLen+1] = '\0'; //çµ‚ç«¯'\0'ã‚’2ã¤ä»˜åŠ ã™ã‚‹('\0''\0'==L'\0')ã€‚ 2007.08.13 kobake è¿½åŠ 
 	return;
 }
 
@@ -131,7 +131,7 @@ void CMemory::_AddData( const void* pData, int nDataLen )
 
 
 
-/* “™‚µ‚¢“à—e‚© */
+/* ç­‰ã—ã„å†…å®¹ã‹ */
 int CMemory::IsEqual( CMemory& cmem1, CMemory& cmem2 )
 {
 	const char*	psz1;
@@ -165,12 +165,12 @@ int CMemory::IsEqual( CMemory& cmem1, CMemory& cmem2 )
 
 
 
-/* !ãˆÊƒoƒCƒg‚Æ‰ºˆÊƒoƒCƒg‚ğŒğŠ·‚·‚é
+/* !ä¸Šä½ãƒã‚¤ãƒˆã¨ä¸‹ä½ãƒã‚¤ãƒˆã‚’äº¤æ›ã™ã‚‹
 
 	@author Moca
 	@date 2002/5/27
 	
-	@note	nBufLen ‚ª2‚Ì”{”‚Å‚È‚¢‚Æ‚«‚ÍAÅŒã‚Ì1ƒoƒCƒg‚ÍŒğŠ·‚³‚ê‚È‚¢
+	@note	nBufLen ãŒ2ã®å€æ•°ã§ãªã„ã¨ãã¯ã€æœ€å¾Œã®1ãƒã‚¤ãƒˆã¯äº¤æ›ã•ã‚Œãªã„
 */
 void CMemory::SwapHLByte( char* pData, const int nDataLen ){
 	unsigned char *p;
@@ -187,7 +187,7 @@ void CMemory::SwapHLByte( char* pData, const int nDataLen ){
 	if( nBufLen < 2){
 		return;
 	}
-	// ‚‘¬‰»‚Ì‚½‚ß
+	// é«˜é€ŸåŒ–ã®ãŸã‚
 	pdwchar = (unsigned int*)pBuf;
 	if( (size_t)pBuf % 2 == 0){
 		if( (size_t)pBuf % 4 == 2 ){
@@ -211,12 +211,12 @@ void CMemory::SwapHLByte( char* pData, const int nDataLen ){
 }
 
 
-/* !ãˆÊƒoƒCƒg‚Æ‰ºˆÊƒoƒCƒg‚ğŒğŠ·‚·‚é
+/* !ä¸Šä½ãƒã‚¤ãƒˆã¨ä¸‹ä½ãƒã‚¤ãƒˆã‚’äº¤æ›ã™ã‚‹
 
 	@author Moca
 	@date 2002/5/27
 	
-	@note	nBufLen ‚ª2‚Ì”{”‚Å‚È‚¢‚Æ‚«‚ÍAÅŒã‚Ì1ƒoƒCƒg‚ÍŒğŠ·‚³‚ê‚È‚¢
+	@note	nBufLen ãŒ2ã®å€æ•°ã§ãªã„ã¨ãã¯ã€æœ€å¾Œã®1ãƒã‚¤ãƒˆã¯äº¤æ›ã•ã‚Œãªã„
 */
 void CMemory::SwapHLByte( void ){
 	char *pBuf;
@@ -238,7 +238,7 @@ void CMemory::SwapHLByte( void ){
 	if( nBufLen < 2){
 		return;
 	}
-	// ‚‘¬‰»‚Ì‚½‚ß
+	// é«˜é€ŸåŒ–ã®ãŸã‚
 	if( (size_t)pBuf % 2 == 0){
 		if( (size_t)pBuf % 4 == 2 ){
 			ctemp = pBuf[0];
@@ -276,7 +276,7 @@ bool CMemory::SwabHLByte( const CMemory& mem )
 	}
 	int nSize = mem.GetRawLength();
 	if( m_pRawData && nSize + 2 <= m_nDataBufSize ) {
-		// ƒf[ƒ^‚ª’Z‚¢‚Íƒoƒbƒtƒ@‚ÌÄ—˜—p
+		// ãƒ‡ãƒ¼ã‚¿ãŒçŸ­ã„æ™‚ã¯ãƒãƒƒãƒ•ã‚¡ã®å†åˆ©ç”¨
 		_SetRawLength(0);
 	}else{
 		_Empty();
@@ -295,24 +295,24 @@ bool CMemory::SwabHLByte( const CMemory& mem )
 
 
 /*
-|| ƒoƒbƒtƒ@ƒTƒCƒY‚Ì’²®
+|| ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã®èª¿æ•´
 */
 void CMemory::AllocBuffer( int nNewDataLen )
 {
 	int		nWorkLen;
 	char*	pWork = NULL;
 
-	// 2ƒoƒCƒg‘½‚­ƒƒ‚ƒŠŠm•Û‚µ‚Ä‚¨‚­('\0'‚Ü‚½‚ÍL'\0'‚ğ“ü‚ê‚é‚½‚ß) 2007.08.13 kobake •ÏX
-	nWorkLen = ((nNewDataLen + 2) + 7) & (~7); // 8Byte‚²‚Æ‚É®—ñ
+	// 2ãƒã‚¤ãƒˆå¤šããƒ¡ãƒ¢ãƒªç¢ºä¿ã—ã¦ãŠã('\0'ã¾ãŸã¯L'\0'ã‚’å…¥ã‚Œã‚‹ãŸã‚) 2007.08.13 kobake å¤‰æ›´
+	nWorkLen = ((nNewDataLen + 2) + 7) & (~7); // 8Byteã”ã¨ã«æ•´åˆ—
 
 	if( m_nDataBufSize == 0 ){
-		/* –¢Šm•Û‚Ìó‘Ô */
+		/* æœªç¢ºä¿ã®çŠ¶æ…‹ */
 		pWork = malloc_char( nWorkLen );
 		m_nDataBufSize = nWorkLen;
 	}else{
-		/* Œ»İ‚Ìƒoƒbƒtƒ@ƒTƒCƒY‚æ‚è‘å‚«‚­‚È‚Á‚½ê‡‚Ì‚İÄŠm•Û‚·‚é */
+		/* ç¾åœ¨ã®ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã‚ˆã‚Šå¤§ãããªã£ãŸå ´åˆã®ã¿å†ç¢ºä¿ã™ã‚‹ */
 		if( m_nDataBufSize < nWorkLen ){
-			// 2014.06.25 —LŒøƒf[ƒ^’·‚ª0‚Ìê‡‚Ífree & malloc
+			// 2014.06.25 æœ‰åŠ¹ãƒ‡ãƒ¼ã‚¿é•·ãŒ0ã®å ´åˆã¯free & malloc
 			if( m_nRawLen == 0 ){
 				free( m_pRawData );
 				m_pRawData = NULL;
@@ -332,7 +332,7 @@ void CMemory::AllocBuffer( int nNewDataLen )
 			LS(STR_ERR_DLGMEM1), nNewDataLen
 		);
 		if( NULL != m_pRawData && 0 != nWorkLen ){
-			/* ŒÃ‚¢ƒoƒbƒtƒ@‚ğ‰ğ•ú‚µ‚Ä‰Šú‰» */
+			/* å¤ã„ãƒãƒƒãƒ•ã‚¡ã‚’è§£æ”¾ã—ã¦åˆæœŸåŒ– */
 			_Empty();
 		}
 		return;
@@ -343,7 +343,7 @@ void CMemory::AllocBuffer( int nNewDataLen )
 
 
 
-/* ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é */
+/* ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹ */
 void CMemory::SetRawData( const void* pData, int nDataLen )
 {
 	_Empty();
@@ -352,7 +352,7 @@ void CMemory::SetRawData( const void* pData, int nDataLen )
 	return;
 }
 
-/* ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é */
+/* ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹ */
 void CMemory::SetRawData( const CMemory& pcmemData )
 {
 	const void*	pData;
@@ -364,10 +364,10 @@ void CMemory::SetRawData( const CMemory& pcmemData )
 	return;
 }
 
-/*! ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é */
+/*! ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹ */
 void CMemory::SetRawDataHoldBuffer( const void* pData, int nDataLen )
 {
-	// this d•¡•s‰Â
+	// this é‡è¤‡ä¸å¯
 	assert( m_pRawData != pData );
 	if( m_nRawLen != 0 ){
 		_SetRawLength(0);
@@ -377,7 +377,7 @@ void CMemory::SetRawDataHoldBuffer( const void* pData, int nDataLen )
 	return;
 }
 
-/*! ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é */
+/*! ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹ */
 void CMemory::SetRawDataHoldBuffer( const CMemory& pcmemData )
 {
 	if( this == &pcmemData ){
@@ -391,7 +391,7 @@ void CMemory::SetRawDataHoldBuffer( const CMemory& pcmemData )
 }
 
 
-/* ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éipublicƒƒ“ƒoj*/
+/* ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ï¼ˆpublicãƒ¡ãƒ³ãƒï¼‰*/
 void CMemory::AppendRawData( const void* pData, int nDataLenBytes )
 {
 	if(nDataLenBytes<=0)return;
@@ -399,7 +399,7 @@ void CMemory::AppendRawData( const void* pData, int nDataLenBytes )
 	_AddData( pData, nDataLenBytes );
 }
 
-/* ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éipublicƒƒ“ƒoj*/
+/* ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ï¼ˆpublicãƒ¡ãƒ³ãƒï¼‰*/
 void CMemory::AppendRawData( const CMemory* pcmemData )
 {
 	if( this == pcmemData ){
@@ -437,5 +437,5 @@ void CMemory::_SetRawLength(int nLength)
 	m_nRawLen = nLength;
 	assert(m_nRawLen <= m_nDataBufSize-2);
 	m_pRawData[m_nRawLen  ]=0;
-	m_pRawData[m_nRawLen+1]=0; //I’['\0'‚ğ2‚Â•t‰Á‚·‚é('\0''\0'==L'\0')B
+	m_pRawData[m_nRawLen+1]=0; //çµ‚ç«¯'\0'ã‚’2ã¤ä»˜åŠ ã™ã‚‹('\0''\0'==L'\0')ã€‚
 }

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒƒ‚ƒŠƒoƒbƒtƒ@ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief ãƒ¡ãƒ¢ãƒªãƒãƒƒãƒ•ã‚¡ã‚¯ãƒ©ã‚¹
 
 	@author Norio Nakatani
-	@date 1998/03/06 V‹Kì¬
+	@date 1998/03/06 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -34,15 +34,15 @@
 #ifndef _CMEMORY_H_
 #define _CMEMORY_H_
 
-/*! ƒtƒ@ƒCƒ‹•¶šƒR[ƒhƒZƒbƒg”»•Ê‚Ìæ“Ç‚İÅ‘åƒTƒCƒY */
+/*! ãƒ•ã‚¡ã‚¤ãƒ«æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆåˆ¤åˆ¥æ™‚ã®å…ˆèª­ã¿æœ€å¤§ã‚µã‚¤ã‚º */
 #define CheckKanjiCode_MAXREADLENGTH 16384
 
 #include "_main/global.h"
 
-//! ƒƒ‚ƒŠƒoƒbƒtƒ@ƒNƒ‰ƒX
+//! ãƒ¡ãƒ¢ãƒªãƒãƒƒãƒ•ã‚¡ã‚¯ãƒ©ã‚¹
 class CMemory
 {
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CMemory();
 	CMemory(const CMemory& rhs);
@@ -51,41 +51,41 @@ public:
 protected:
 	void _init_members();
 
-	//ƒCƒ“ƒ^[ƒtƒF[ƒX
+	//ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 public:
-	void AllocBuffer( int );                               //!< ƒoƒbƒtƒ@ƒTƒCƒY‚Ì’²®B•K—v‚É‰‚¶‚ÄŠg‘å‚·‚éB
-	void SetRawData( const void* pData, int nDataLen );    //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
-	void SetRawData( const CMemory& );                     //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
-	void SetRawDataHoldBuffer( const void* pData, int nDataLen );    //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é(ƒoƒbƒtƒ@‚ğ•Û)
-	void SetRawDataHoldBuffer( const CMemory& );                     //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é(ƒoƒbƒtƒ@‚ğ•Û)
-	void AppendRawData( const void* pData, int nDataLen ); //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚é
-	void AppendRawData( const CMemory* );                  //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚é
+	void AllocBuffer( int );                               //!< ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã®èª¿æ•´ã€‚å¿…è¦ã«å¿œã˜ã¦æ‹¡å¤§ã™ã‚‹ã€‚
+	void SetRawData( const void* pData, int nDataLen );    //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
+	void SetRawData( const CMemory& );                     //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
+	void SetRawDataHoldBuffer( const void* pData, int nDataLen );    //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹(ãƒãƒƒãƒ•ã‚¡ã‚’ä¿æŒ)
+	void SetRawDataHoldBuffer( const CMemory& );                     //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹(ãƒãƒƒãƒ•ã‚¡ã‚’ä¿æŒ)
+	void AppendRawData( const void* pData, int nDataLen ); //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹
+	void AppendRawData( const CMemory* );                  //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹
 	void Clean(){ _Empty(); }
 	void Clear(){ _Empty(); }
 
-	inline const void* GetRawPtr(int* pnLength) const;      //!< ƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚Æ’·‚³•Ô‚·
-	inline void* GetRawPtr(int* pnLength);                  //!< ƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚Æ’·‚³•Ô‚·
-	inline const void* GetRawPtr() const{ return m_pRawData; } //!< ƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğ•Ô‚·
-	inline void* GetRawPtr(){ return m_pRawData; }             //!< ƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğ•Ô‚·
-	int GetRawLength() const { return m_nRawLen; }                //!<ƒf[ƒ^’·‚ğ•Ô‚·BƒoƒCƒg’PˆÊB
+	inline const void* GetRawPtr(int* pnLength) const;      //!< ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã¨é•·ã•è¿”ã™
+	inline void* GetRawPtr(int* pnLength);                  //!< ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã¨é•·ã•è¿”ã™
+	inline const void* GetRawPtr() const{ return m_pRawData; } //!< ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã™
+	inline void* GetRawPtr(){ return m_pRawData; }             //!< ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã™
+	int GetRawLength() const { return m_nRawLen; }                //!<ãƒ‡ãƒ¼ã‚¿é•·ã‚’è¿”ã™ã€‚ãƒã‚¤ãƒˆå˜ä½ã€‚
 
-	// ‰‰Zq
+	// æ¼”ç®—å­
 	const CMemory& operator=( const CMemory& );
 
-	// ”äŠr
-	static int IsEqual( CMemory&, CMemory& );	/* “™‚µ‚¢“à—e‚© */
+	// æ¯”è¼ƒ
+	static int IsEqual( CMemory&, CMemory& );	/* ç­‰ã—ã„å†…å®¹ã‹ */
 
-	// •ÏŠ·ŠÖ”
-	static void SwapHLByte( char*, const int ); // ‰º‹LŠÖ”‚ÌstaticŠÖ””Å
-	void SwapHLByte();			// Byte‚ğŒğŠ·‚·‚é
-	bool SwabHLByte( const CMemory& ); // Byte‚ğŒğŠ·‚·‚é(ƒRƒs[”Å)
+	// å¤‰æ›é–¢æ•°
+	static void SwapHLByte( char*, const int ); // ä¸‹è¨˜é–¢æ•°ã®staticé–¢æ•°ç‰ˆ
+	void SwapHLByte();			// Byteã‚’äº¤æ›ã™ã‚‹
+	bool SwabHLByte( const CMemory& ); // Byteã‚’äº¤æ›ã™ã‚‹(ã‚³ãƒ”ãƒ¼ç‰ˆ)
 
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
-	void _Empty( void ); //!< ‰ğ•ú‚·‚éBm_pRawData‚ÍNULL‚É‚È‚éB
+	void _Empty( void ); //!< è§£æ”¾ã™ã‚‹ã€‚m_pRawDataã¯NULLã«ãªã‚‹ã€‚
 	void _AddData( const void*, int );
 public:
 	void _AppendSz(const char* str);
@@ -100,28 +100,28 @@ public:
 #ifdef _DEBUG
 protected:
 	typedef char* PCHAR;
-	PCHAR& _DebugGetPointerRef(){ return m_pRawData; } //ƒfƒoƒbƒO—pBƒoƒbƒtƒ@ƒ|ƒCƒ“ƒ^‚ÌQÆ‚ğ•Ô‚·B
+	PCHAR& _DebugGetPointerRef(){ return m_pRawData; } //ãƒ‡ãƒãƒƒã‚°ç”¨ã€‚ãƒãƒƒãƒ•ã‚¡ãƒã‚¤ãƒ³ã‚¿ã®å‚ç…§ã‚’è¿”ã™ã€‚
 #endif
 
-private: // 2002/2/10 aroka ƒAƒNƒZƒXŒ •ÏX
+private: // 2002/2/10 aroka ã‚¢ã‚¯ã‚»ã‚¹æ¨©å¤‰æ›´
 	/*
-	|| ƒƒ“ƒo•Ï”
+	|| ãƒ¡ãƒ³ãƒå¤‰æ•°
 	*/
-	char*	m_pRawData;		//ƒoƒbƒtƒ@
-	int		m_nRawLen;		//ƒf[ƒ^ƒTƒCƒY(m_nDataBufSizeˆÈ“à)BƒoƒCƒg’PˆÊB
-	int		m_nDataBufSize;	//ƒoƒbƒtƒ@ƒTƒCƒYBƒoƒCƒg’PˆÊB
+	char*	m_pRawData;		//ãƒãƒƒãƒ•ã‚¡
+	int		m_nRawLen;		//ãƒ‡ãƒ¼ã‚¿ã‚µã‚¤ã‚º(m_nDataBufSizeä»¥å†…)ã€‚ãƒã‚¤ãƒˆå˜ä½ã€‚
+	int		m_nDataBufSize;	//ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã€‚ãƒã‚¤ãƒˆå˜ä½ã€‚
 };
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     inlineŠÖ”‚ÌÀ‘•                        //
+//                     inlineé–¢æ•°ã®å®Ÿè£…                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-inline const void* CMemory::GetRawPtr(int* pnLength) const //!< ƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚Æ’·‚³•Ô‚·
+inline const void* CMemory::GetRawPtr(int* pnLength) const //!< ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã¨é•·ã•è¿”ã™
 {
 	if(pnLength) *pnLength = GetRawLength();
 	return m_pRawData;
 }
-inline void* CMemory::GetRawPtr(int* pnLength) //!< ƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚Æ’·‚³•Ô‚·
+inline void* CMemory::GetRawPtr(int* pnLength) //!< ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã¨é•·ã•è¿”ã™
 {
 	if(pnLength) *pnLength = GetRawLength();
 	return m_pRawData;

--- a/sakura_core/mem/CMemoryIterator.h
+++ b/sakura_core/mem/CMemoryIterator.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief CLayout‚ÆCDocLine‚ÌƒCƒeƒŒ[ƒ^
+ï»¿/*!	@file
+	@brief CLayoutã¨CDocLineã®ã‚¤ãƒ†ãƒ¬ãƒ¼ã‚¿
 
 	@author Yazaki
-	@date 2002/09/25 V‹Kì¬
+	@date 2002/09/25 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2002, Yazaki
@@ -21,18 +21,18 @@
 #include "doc/layout/CTsvModeInfo.h"
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
-// 2007.10.23 kobake ƒeƒ“ƒvƒŒ[ƒg‚Å‚ ‚é•K—v‚à–³‚¢‚Ì‚ÅA”ñƒeƒ“ƒvƒŒ[ƒg‚É•ÏXB
+// 2007.10.23 kobake ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã§ã‚ã‚‹å¿…è¦ã‚‚ç„¡ã„ã®ã§ã€éãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã«å¤‰æ›´ã€‚
 
 #include "doc/layout/CLayout.h"
 #include "doc/logic/CDocLine.h"
 
-//! ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğŠÇ—‚·‚é
+//! ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ç®¡ç†ã™ã‚‹
 class CMemoryIterator
 {
 public:
-	//CDocLine—pƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	//CDocLineç”¨ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CMemoryIterator( const CDocLine* pcT, CLayoutInt nTabSpace, const CTsvModeInfo& tsvInfo, CPixelXInt nCharDx, CPixelXInt nSpacing )
 	: m_pLine( pcT ? pcT->GetPtr() : NULL )
 	, m_nLineLen( pcT ? pcT->GetLengthWithEOL() : 0 )
@@ -46,7 +46,7 @@ public:
 		first();
 	}
 
-	//CLayout—pƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	//CLayoutç”¨ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CMemoryIterator( const CLayout* pcT, CLayoutInt nTabSpace, const CTsvModeInfo& tsvInfo, CPixelXInt nCharDx, CPixelXInt nSpacing )
 	: m_pLine( pcT ? pcT->GetPtr() : NULL )
 	, m_nLineLen( pcT ? pcT->GetLengthWithEOL() : 0 )
@@ -60,7 +60,7 @@ public:
 		first();
 	}
 
-	//! Œ…ˆÊ’u‚ğs‚Ìæ“ª‚ÉƒZƒbƒg
+	//! æ¡ä½ç½®ã‚’è¡Œã®å…ˆé ­ã«ã‚»ãƒƒãƒˆ
 	void first()
 	{
 		m_nIndex = CLogicInt(0);
@@ -69,26 +69,26 @@ public:
 		m_nColumn_Delta = CLayoutInt(0);
 	}
 
-	/*! s––‚©‚Ç‚¤‚©
-		@return true: s––, false: s––‚Å‚Í‚È‚¢
+	/*! è¡Œæœ«ã‹ã©ã†ã‹
+		@return true: è¡Œæœ«, false: è¡Œæœ«ã§ã¯ãªã„
 	 */
 	bool end() const
 	{
 		return (m_nLineLen <= m_nIndex);
 	}
 
-	//	Ÿ‚Ì•¶š‚ğŠm”F‚µ‚ÄŸ‚Ì•¶š‚Æ‚Ì·‚ğ‹‚ß‚é
+	//	æ¬¡ã®æ–‡å­—ã‚’ç¢ºèªã—ã¦æ¬¡ã®æ–‡å­—ã¨ã®å·®ã‚’æ±‚ã‚ã‚‹
 	void scanNext()
 	{
 		// 2005-09-02 D.S.Koba GetSizeOfChar
-		// 2007.09.04 kobake UNICODE‰»Fƒf[ƒ^‘•ª‚ÆŒ…‘•ª‚ğ•ÊX‚Ì’l‚Æ‚µ‚ÄŒvZ‚·‚éB
+		// 2007.09.04 kobake UNICODEåŒ–ï¼šãƒ‡ãƒ¼ã‚¿å¢—åˆ†ã¨æ¡å¢—åˆ†ã‚’åˆ¥ã€…ã®å€¤ã¨ã—ã¦è¨ˆç®—ã™ã‚‹ã€‚
 
-		//ƒf[ƒ^‘•ª‚ğŒvZ
+		//ãƒ‡ãƒ¼ã‚¿å¢—åˆ†ã‚’è¨ˆç®—
 		m_nIndex_Delta = CNativeW::GetSizeOfChar(m_pLine, m_nLineLen, m_nIndex);
 		if( 0 == m_nIndex_Delta )
 			m_nIndex_Delta = CLogicInt(1);
 
-		//Œ…‘•ª‚ğŒvZ
+		//æ¡å¢—åˆ†ã‚’è¨ˆç®—
 		if (m_pLine[m_nIndex] == WCODE::TAB){
 			if (m_tsvInfo.m_nTsvMode == TSV_MODE_TSV) {
 				m_nColumn_Delta = m_tsvInfo.GetActualTabLength(m_nColumn, m_tsvInfo.m_nMaxCharLayoutX);
@@ -106,18 +106,18 @@ public:
 			if( m_nSpacing ){
 				m_nColumn_Delta += CLayoutXInt(CNativeW::GetKetaOfChar(m_pLine, m_nLineLen, m_nIndex) * m_nSpacing);
 			}
-//			if( 0 == m_nColumn_Delta )				// íœ ƒTƒƒQ[ƒgƒyƒA‘Îô	2008/7/5 Uchi
+//			if( 0 == m_nColumn_Delta )				// å‰Šé™¤ ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢å¯¾ç­–	2008/7/5 Uchi
 //				m_nColumn_Delta = CLayoutInt(1);
 		}
 	}
 	
-	/*! —\‚ßŒvZ‚µ‚½·•ª‚ğŒ…ˆÊ’u‚É‰Á‚¦‚éD
+	/*! äºˆã‚è¨ˆç®—ã—ãŸå·®åˆ†ã‚’æ¡ä½ç½®ã«åŠ ãˆã‚‹ï¼
 		@sa scanNext()
 	 */
 	void addDelta(){
 		m_nColumn += m_nColumn_Delta;
 		m_nIndex += m_nIndex_Delta;
-	}	//	ƒ|ƒCƒ“ƒ^‚ğ‚¸‚ç‚·
+	}	//	ãƒã‚¤ãƒ³ã‚¿ã‚’ãšã‚‰ã™
 	
 	CLogicInt	getIndex()			const {	return m_nIndex;	}
 	CLayoutInt	getColumn()			const {	return m_nColumn;	}
@@ -126,28 +126,28 @@ public:
 
 	//	2002.10.07 YAZAKI
 	const wchar_t getCurrentChar(){	return m_pLine[m_nIndex];	}
-	//	Jul. 20, 2003 genta ’Ç‰Á
-	//	memcpy‚ğ‚·‚é‚Ì‚Éƒ|ƒCƒ“ƒ^‚ª‚Æ‚ê‚È‚¢‚Æ–Ê“|
+	//	Jul. 20, 2003 genta è¿½åŠ 
+	//	memcpyã‚’ã™ã‚‹ã®ã«ãƒã‚¤ãƒ³ã‚¿ãŒã¨ã‚Œãªã„ã¨é¢å€’
 	const wchar_t* getCurrentPos(){	return m_pLine + m_nIndex;	}
 
 
 private:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^‚Åó‚¯æ‚Á‚½ƒpƒ‰ƒ[ƒ^ (ŒÅ’è)
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã§å—ã‘å–ã£ãŸãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ (å›ºå®š)
 	const wchar_t*		m_pLine;
-	const int			m_nLineLen;  //ƒf[ƒ^’·B•¶š’PˆÊB
+	const int			m_nLineLen;  //ãƒ‡ãƒ¼ã‚¿é•·ã€‚æ–‡å­—å˜ä½ã€‚
 	const CLayoutInt	m_nTabSpace;
 	const CTsvModeInfo&	m_tsvInfo;
 	const CLayoutInt	m_nIndent;
 
-	const CPixelXInt	m_nSpacing;		//•¶šŒ„ŠÔ(px)
-	const CPixelXInt	m_nTabPadding;	//ƒ^ƒu•Å­’l-1
-	const CPixelXInt	m_nTabSpaceDx;	//ƒ^ƒu•ŒvZ—p(m_nTabSpace + m_nTabPadding - 1)
+	const CPixelXInt	m_nSpacing;		//æ–‡å­—éš™é–“(px)
+	const CPixelXInt	m_nTabPadding;	//ã‚¿ãƒ–å¹…æœ€å°‘å€¤-1
+	const CPixelXInt	m_nTabSpaceDx;	//ã‚¿ãƒ–å¹…è¨ˆç®—ç”¨(m_nTabSpace + m_nTabPadding - 1)
 
-	//ó‘Ô•Ï”
-	CLogicInt	m_nIndex;        //ƒf[ƒ^ˆÊ’uB•¶š’PˆÊB
-	CLayoutInt	m_nColumn;       //ƒŒƒCƒAƒEƒgˆÊ’uBŒ…(”¼Šp•)’PˆÊB
-	CLogicInt	m_nIndex_Delta;  //index‘•ª
-	CLayoutInt	m_nColumn_Delta; //column‘•ª
+	//çŠ¶æ…‹å¤‰æ•°
+	CLogicInt	m_nIndex;        //ãƒ‡ãƒ¼ã‚¿ä½ç½®ã€‚æ–‡å­—å˜ä½ã€‚
+	CLayoutInt	m_nColumn;       //ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã€‚æ¡(åŠè§’å¹…)å˜ä½ã€‚
+	CLogicInt	m_nIndex_Delta;  //indexå¢—åˆ†
+	CLayoutInt	m_nColumn_Delta; //columnå¢—åˆ†
 
 };
 

--- a/sakura_core/mem/CNative.cpp
+++ b/sakura_core/mem/CNative.cpp
@@ -1,7 +1,7 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "CNative.h"
 
-//! ‹ó‚Á‚Û‚É‚·‚é
+//! ç©ºã£ã½ã«ã™ã‚‹
 void CNative::Clear()
 {
 	this->SetRawData("",0);

--- a/sakura_core/mem/CNative.h
+++ b/sakura_core/mem/CNative.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,16 +26,16 @@
 
 #include "mem/CMemory.h"
 
-//¦CMemory‚ğprotectŒp³‚·‚é‚±‚Æ‚É‚æ‚èA‚ ‚Ü‚è©—R‚ÉCMemory‚ğg‚¦‚È‚¢‚æ‚¤‚É‚µ‚Ä‚¨‚­
+//â€»CMemoryã‚’protectç¶™æ‰¿ã™ã‚‹ã“ã¨ã«ã‚ˆã‚Šã€ã‚ã¾ã‚Šè‡ªç”±ã«CMemoryã‚’ä½¿ãˆãªã„ã‚ˆã†ã«ã—ã¦ãŠã
 class CNative : protected CMemory{
 public:
-	//CMemory*ƒ|ƒCƒ“ƒ^‚ğ“¾‚é
+	//CMemory*ãƒã‚¤ãƒ³ã‚¿ã‚’å¾—ã‚‹
 	CMemory* _GetMemory(){ return static_cast<CMemory*>(this); }
 	const CMemory* _GetMemory() const{ return static_cast<const CMemory*>(this); }
 
 public:
-	//”Ä—p
-	void Clear(); //!< ‹ó‚Á‚Û‚É‚·‚é
+	//æ±ç”¨
+	void Clear(); //!< ç©ºã£ã½ã«ã™ã‚‹
 };
 
 #include "mem/CNativeA.h"

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -33,18 +33,18 @@ public:
 	CNativeA(const char* szData);
 	CNativeA(const char* pData, int nLength);
 
-	//ƒlƒCƒeƒBƒuİ’è
-	void SetString( const char* pszData );                  //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
-	void SetString( const char* pData, int nDataLen );      //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚éBnDataLen‚Í•¶š’PˆÊB
-	void SetNativeData( const CNativeA& pcNative );         //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
-	void AppendString( const char* pszData );               //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚é
-	void AppendString( const char* pszData, int nLength );  //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éBnLength‚Í•¶š’PˆÊB
-	void AppendNativeData( const CNativeA& pcNative );      //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚é
-	void AllocStringBuffer( int nDataLen );            //!< (d—vFnDataLen‚Í•¶š’PˆÊ) ƒoƒbƒtƒ@ƒTƒCƒY‚Ì’²®B•K—v‚É‰‚¶‚ÄŠg‘å‚·‚éB
+	//ãƒã‚¤ãƒ†ã‚£ãƒ–è¨­å®š
+	void SetString( const char* pszData );                  //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
+	void SetString( const char* pData, int nDataLen );      //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹ã€‚nDataLenã¯æ–‡å­—å˜ä½ã€‚
+	void SetNativeData( const CNativeA& pcNative );         //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
+	void AppendString( const char* pszData );               //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹
+	void AppendString( const char* pszData, int nLength );  //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ã€‚nLengthã¯æ–‡å­—å˜ä½ã€‚
+	void AppendNativeData( const CNativeA& pcNative );      //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹
+	void AllocStringBuffer( int nDataLen );            //!< (é‡è¦ï¼šnDataLenã¯æ–‡å­—å˜ä½) ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã®èª¿æ•´ã€‚å¿…è¦ã«å¿œã˜ã¦æ‹¡å¤§ã™ã‚‹ã€‚
 
-	//ƒlƒCƒeƒBƒuæ“¾
+	//ãƒã‚¤ãƒ†ã‚£ãƒ–å–å¾—
 	int GetStringLength() const;
-	char operator[](int nIndex) const;                 //!< ”CˆÓˆÊ’u‚Ì•¶šæ“¾BnIndex‚Í•¶š’PˆÊB
+	char operator[](int nIndex) const;                 //!< ä»»æ„ä½ç½®ã®æ–‡å­—å–å¾—ã€‚nIndexã¯æ–‡å­—å˜ä½ã€‚
 	const char* GetStringPtr() const
 	{
 		return reinterpret_cast<const char*>(GetRawPtr());
@@ -53,45 +53,45 @@ public:
 	{
 		return reinterpret_cast<char*>(GetRawPtr());
 	}
-	const char* GetStringPtr(int* pnLength) const; //[out]pnLength‚Í•¶š’PˆÊB
+	const char* GetStringPtr(int* pnLength) const; //[out]pnLengthã¯æ–‡å­—å˜ä½ã€‚
 
-	//‰‰Zq
+	//æ¼”ç®—å­
 	const CNativeA& operator=( char );
 	const CNativeA& operator+=( char );
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           •ÏŠ·                              //
+	//                           å¤‰æ›                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//ƒlƒCƒeƒBƒu•ÏŠ·
-	void Replace( const char* pszFrom, const char* pszTo );   //!< •¶š—ñ’uŠ·
-	void Replace_j( const char* pszFrom, const char* pszTo ); //!< •¶š—ñ’uŠ·i“ú–{Œêl—¶”Åj
+	//ãƒã‚¤ãƒ†ã‚£ãƒ–å¤‰æ›
+	void Replace( const char* pszFrom, const char* pszTo );   //!< æ–‡å­—åˆ—ç½®æ›
+	void Replace_j( const char* pszFrom, const char* pszTo ); //!< æ–‡å­—åˆ—ç½®æ›ï¼ˆæ—¥æœ¬èªè€ƒæ…®ç‰ˆï¼‰
 	void ReplaceT( const char* pszFrom, const char* pszTo ){
 		Replace_j( pszFrom, pszTo );
 	}
 
-	//ˆê”ÊŠÖ”
-	void ToLower(); // ¨¬•¶š
-	void ToUpper(); // ¨‘å•¶š
+	//ä¸€èˆ¬é–¢æ•°
+	void ToLower(); // â†’å°æ–‡å­—
+	void ToUpper(); // â†’å¤§æ–‡å­—
 
-	void ToZenkaku( int, int );  // ”¼Šp¨‘SŠp
+	void ToZenkaku( int, int );  // åŠè§’â†’å…¨è§’
 
-	void TABToSPACE( int ); // TAB¨‹ó”’
-	void SPACEToTAB( int ); // ‹ó”’¨TAB  //---- Stonee, 2001/05/27
+	void TABToSPACE( int ); // TABâ†’ç©ºç™½
+	void SPACEToTAB( int ); // ç©ºç™½â†’TAB  //---- Stonee, 2001/05/27
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                  Œ^ŒÀ’èƒCƒ“ƒ^[ƒtƒF[ƒX                     //
+	//                  å‹é™å®šã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	// g—p‚Í‚Å‚«‚é‚¾‚¯T‚¦‚é‚Ì‚ª–]‚Ü‚µ‚¢B
-	// ‚Ğ‚Æ‚Â‚ÍƒI[ƒo[ƒwƒbƒh‚ğ—}‚¦‚éˆÓ–¡‚ÅB
-	// ‚Ğ‚Æ‚Â‚Í•ÏŠ·‚É‚æ‚éƒf[ƒ^‘r¸‚ğ—}‚¦‚éˆÓ–¡‚ÅB
+	// ä½¿ç”¨ã¯ã§ãã‚‹ã ã‘æ§ãˆã‚‹ã®ãŒæœ›ã¾ã—ã„ã€‚
+	// ã²ã¨ã¤ã¯ã‚ªãƒ¼ãƒãƒ¼ãƒ˜ãƒƒãƒ‰ã‚’æŠ‘ãˆã‚‹æ„å‘³ã§ã€‚
+	// ã²ã¨ã¤ã¯å¤‰æ›ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å–ªå¤±ã‚’æŠ‘ãˆã‚‹æ„å‘³ã§ã€‚
 
 	//WCHAR
 	void SetStringNew(const wchar_t* wszData, int nDataLen);
 	void SetStringNew(const wchar_t* wszData);
-	void AppendStringNew( const wchar_t* pszData );               //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚é
-	void AppendStringNew( const wchar_t* pszData, int nDataLen ); //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éBnDataLen‚Í•¶š’PˆÊB
+	void AppendStringNew( const wchar_t* pszData );               //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹
+	void AppendStringNew( const wchar_t* pszData, int nDataLen ); //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ã€‚nDataLenã¯æ–‡å­—å˜ä½ã€‚
 	void SetStringW(const wchar_t* pszData)				{ return SetStringNew(pszData); }
 	void SetStringW(const wchar_t* pData, int nLength)		{ return SetStringNew(pData,nLength); }
 	void AppendStringW(const wchar_t* pszData)				{ return AppendStringNew(pszData); }
@@ -108,10 +108,10 @@ public:
 #endif
 
 public:
-	// -- -- staticƒCƒ“ƒ^[ƒtƒF[ƒX -- -- //
-	static int GetSizeOfChar( const char* pData, int nDataLen, int nIdx ); //!< w’è‚µ‚½ˆÊ’u‚Ì•¶š‚ª‰½ƒoƒCƒg•¶š‚©‚ğ•Ô‚·
-	static const char* GetCharNext( const char* pData, int nDataLen, const char* pDataCurrent ); //!< ƒ|ƒCƒ“ƒ^‚Å¦‚µ‚½•¶š‚ÌŸ‚É‚ ‚é•¶š‚ÌˆÊ’u‚ğ•Ô‚µ‚Ü‚·
-	static const char* GetCharPrev( const char* pData, int nDataLen, const char* pDataCurrent ); //!< ƒ|ƒCƒ“ƒ^‚Å¦‚µ‚½•¶š‚Ì’¼‘O‚É‚ ‚é•¶š‚ÌˆÊ’u‚ğ•Ô‚µ‚Ü‚·
+	// -- -- staticã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ -- -- //
+	static int GetSizeOfChar( const char* pData, int nDataLen, int nIdx ); //!< æŒ‡å®šã—ãŸä½ç½®ã®æ–‡å­—ãŒä½•ãƒã‚¤ãƒˆæ–‡å­—ã‹ã‚’è¿”ã™
+	static const char* GetCharNext( const char* pData, int nDataLen, const char* pDataCurrent ); //!< ãƒã‚¤ãƒ³ã‚¿ã§ç¤ºã—ãŸæ–‡å­—ã®æ¬¡ã«ã‚ã‚‹æ–‡å­—ã®ä½ç½®ã‚’è¿”ã—ã¾ã™
+	static const char* GetCharPrev( const char* pData, int nDataLen, const char* pDataCurrent ); //!< ãƒã‚¤ãƒ³ã‚¿ã§ç¤ºã—ãŸæ–‡å­—ã®ç›´å‰ã«ã‚ã‚‹æ–‡å­—ã®ä½ç½®ã‚’è¿”ã—ã¾ã™
 };
 
 #endif /* SAKURA_CNATIVEA_B88E7301_8CD3_4DF8_8750_2FF92F357FA09_H_ */

--- a/sakura_core/mem/CNativeT.h
+++ b/sakura_core/mem/CNativeT.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -1,10 +1,10 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "mem/CNativeW.h"
 #include "CEol.h"
 #include "charset/CShiftJis.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//               ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^                  //
+//               ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿                  //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 CNativeW::CNativeW()
 #if _DEBUG
@@ -21,7 +21,7 @@ CNativeW::CNativeW(const CNativeW& rhs)
 	SetNativeData(rhs);
 }
 
-//! nDataLen‚Í•¶š’PˆÊB
+//! nDataLenã¯æ–‡å­—å˜ä½ã€‚
 CNativeW::CNativeW( const wchar_t* pData, int nDataLen )
 #if _DEBUG
 : m_pDebugData((PWCHAR&)_DebugGetPointerRef())
@@ -39,17 +39,17 @@ CNativeW::CNativeW( const wchar_t* pData)
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//              ƒlƒCƒeƒBƒuİ’èƒCƒ“ƒ^[ƒtƒF[ƒX                 //
+//              ãƒã‚¤ãƒ†ã‚£ãƒ–è¨­å®šã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                 //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
-// ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
+// ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
 void CNativeW::SetString( const wchar_t* pData, int nDataLen )
 {
 	CNative::SetRawData(pData,nDataLen * sizeof(wchar_t));
 }
 
-// ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
+// ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
 void CNativeW::SetString( const wchar_t* pszData )
 {
 	CNative::SetRawData(pszData,wcslen(pszData) * sizeof(wchar_t));
@@ -60,39 +60,39 @@ void CNativeW::SetStringHoldBuffer( const wchar_t* pData, int nDataLen )
 	CNative::SetRawDataHoldBuffer(pData, nDataLen * sizeof(wchar_t));
 }
 
-// ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
+// ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
 void CNativeW::SetNativeData( const CNativeW& pcNative )
 {
 	CNative::SetRawData(pcNative);
 }
 
-//! (d—vFnDataLen‚Í•¶š’PˆÊ) ƒoƒbƒtƒ@ƒTƒCƒY‚Ì’²®B•K—v‚É‰‚¶‚ÄŠg‘å‚·‚éB
+//! (é‡è¦ï¼šnDataLenã¯æ–‡å­—å˜ä½) ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã®èª¿æ•´ã€‚å¿…è¦ã«å¿œã˜ã¦æ‹¡å¤§ã™ã‚‹ã€‚
 void CNativeW::AllocStringBuffer( int nDataLen )
 {
 	CNative::AllocBuffer(nDataLen * sizeof(wchar_t));
 }
 
-//! ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚é
+//! ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹
 void CNativeW::AppendString( const wchar_t* pszData )
 {
 	CNative::AppendRawData(pszData,wcslen(pszData) * sizeof(wchar_t));
 }
 
-//! ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éBnLength‚Í•¶š’PˆÊB
+//! ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ã€‚nLengthã¯æ–‡å­—å˜ä½ã€‚
 void CNativeW::AppendString( const wchar_t* pszData, int nLength )
 {
 	CNative::AppendRawData(pszData, nLength * sizeof(wchar_t));
 }
 
-//! ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚é
+//! ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹
 void CNativeW::AppendNativeData( const CNativeW& cmemData )
 {
 	CNative::AppendRawData(cmemData.GetStringPtr(), cmemData.GetRawLength());
 }
 
-// -- -- char‚©‚ç‚ÌˆÚs—p -- -- //
+// -- -- charã‹ã‚‰ã®ç§»è¡Œç”¨ -- -- //
 
-//! ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚éBnDataLen‚Í•¶š’PˆÊB
+//! ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹ã€‚nDataLenã¯æ–‡å­—å˜ä½ã€‚
 void CNativeW::SetStringOld( const char* pData, int nDataLen )
 {
 	int nLen;
@@ -101,7 +101,7 @@ void CNativeW::SetStringOld( const char* pData, int nDataLen )
 	delete[] szTmp;
 }
 
-//! ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
+//! ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
 void CNativeW::SetStringOld( const char* pszData )
 {
 	SetStringOld(pszData,strlen(pszData));
@@ -115,7 +115,7 @@ void CNativeW::AppendStringOld( const char* pData, int nDataLen )
 	delete[] szTmp;
 }
 
-//! ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éBpszData‚ÍSJISB
+//! ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ã€‚pszDataã¯SJISã€‚
 void CNativeW::AppendStringOld( const char* pszData )
 {
 	AppendStringOld(pszData,strlen(pszData));
@@ -123,10 +123,10 @@ void CNativeW::AppendStringOld( const char* pszData )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//              ƒlƒCƒeƒBƒuæ“¾ƒCƒ“ƒ^[ƒtƒF[ƒX                 //
+//              ãƒã‚¤ãƒ†ã‚£ãƒ–å–å¾—ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                 //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-// GetAt()‚Æ“¯‹@”\
+// GetAt()ã¨åŒæ©Ÿèƒ½
 wchar_t CNativeW::operator[](int nIndex) const
 {
 	if( nIndex < GetStringLength() ){
@@ -137,7 +137,7 @@ wchar_t CNativeW::operator[](int nIndex) const
 }
 
 
-/* “™‚µ‚¢“à—e‚© */
+/* ç­‰ã—ã„å†…å®¹ã‹ */
 bool CNativeW::IsEqual( const CNativeW& cmem1, const CNativeW& cmem2 )
 {
 	if(&cmem1==&cmem2)return true;
@@ -159,10 +159,10 @@ bool CNativeW::IsEqual( const CNativeW& cmem1, const CNativeW& cmem2 )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//              ƒlƒCƒeƒBƒu•ÏŠ·ƒCƒ“ƒ^[ƒtƒF[ƒX                 //
+//              ãƒã‚¤ãƒ†ã‚£ãƒ–å¤‰æ›ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                 //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! •¶š—ñ’uŠ·
+//! æ–‡å­—åˆ—ç½®æ›
 void CNativeW::Replace( const wchar_t* pszFrom, const wchar_t* pszTo )
 {
 	int			nFromLen = wcslen( pszFrom );
@@ -210,19 +210,19 @@ void CNativeW::Replace( const wchar_t* pszFrom, int nFromLen, const wchar_t* psz
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                  staticƒCƒ“ƒ^[ƒtƒF[ƒX                     //
+//                  staticã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                     //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! w’è‚µ‚½ˆÊ’u‚Ì•¶š‚ªwchar_t‰½ŒÂ•ª‚©‚ğ•Ô‚·
+//! æŒ‡å®šã—ãŸä½ç½®ã®æ–‡å­—ãŒwchar_tä½•å€‹åˆ†ã‹ã‚’è¿”ã™
 CLogicInt CNativeW::GetSizeOfChar( const wchar_t* pData, int nDataLen, int nIdx )
 {
 	if( nIdx >= nDataLen )
 		return CLogicInt(0);
 
-	// ƒTƒƒQ[ƒgƒ`ƒFƒbƒN					2008/7/5 Uchi
+	// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒã‚§ãƒƒã‚¯					2008/7/5 Uchi
 	if (IsUTF16High(pData[nIdx])) {
 		if (nIdx + 1 < nDataLen && IsUTF16Low(pData[nIdx + 1])) {
-			// ƒTƒƒQ[ƒgƒyƒA 2ŒÂ•ª
+			// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢ 2å€‹åˆ†
 			return CLogicInt(2);
 		}
 	}
@@ -230,23 +230,23 @@ CLogicInt CNativeW::GetSizeOfChar( const wchar_t* pData, int nDataLen, int nIdx 
 	return CLogicInt(1);
 }
 
-//! w’è‚µ‚½ˆÊ’u‚Ì•¶š‚ª”¼Šp‰½ŒÂ•ª‚©‚ğ•Ô‚·
+//! æŒ‡å®šã—ãŸä½ç½®ã®æ–‡å­—ãŒåŠè§’ä½•å€‹åˆ†ã‹ã‚’è¿”ã™
 CKetaXInt CNativeW::GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx )
 {
-	//•¶š—ñ”ÍˆÍŠO‚È‚ç 0
+	//æ–‡å­—åˆ—ç¯„å›²å¤–ãªã‚‰ 0
 	if( nIdx >= nDataLen )
 		return CKetaXInt(0);
 
-	// ƒTƒƒQ[ƒgƒ`ƒFƒbƒN BMP ˆÈŠO‚Í‘SŠpˆµ‚¢		2008/7/5 Uchi
+	// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒã‚§ãƒƒã‚¯ BMP ä»¥å¤–ã¯å…¨è§’æ‰±ã„		2008/7/5 Uchi
 	if (IsUTF16High(pData[nIdx])) {
-		return CKetaXInt(2);	// ‰¼
+		return CKetaXInt(2);	// ä»®
 	}
 	if (IsUTF16Low(pData[nIdx])) {
 		if (nIdx > 0 && IsUTF16High(pData[nIdx - 1])) {
-			// ƒTƒƒQ[ƒgƒyƒAi‰ºˆÊj
+			// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢ï¼ˆä¸‹ä½ï¼‰
 			return CKetaXInt(0);
 		}
-		// ’P“Æiƒuƒ[ƒNƒ“ƒyƒAj
+		// å˜ç‹¬ï¼ˆãƒ–ãƒ­ãƒ¼ã‚¯ãƒ³ãƒšã‚¢ï¼‰
 		// return CKetaXInt(2);
 		 if( IsBinaryOnSurrogate(pData[nIdx]) )
 			return CKetaXInt(1);
@@ -254,40 +254,40 @@ CKetaXInt CNativeW::GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx 
 			return CKetaXInt(2);
 	}
 
-	//”¼Šp•¶š‚È‚ç 1
+	//åŠè§’æ–‡å­—ãªã‚‰ 1
 	if(WCODE::IsHankaku(pData[nIdx]) )
 		return CKetaXInt(1);
 
-	//‘SŠp•¶š‚È‚ç 2
+	//å…¨è§’æ–‡å­—ãªã‚‰ 2
 	else
 		return CKetaXInt(2);
 }
 
 
-//! w’è‚µ‚½ˆÊ’u‚Ì•¶š‚Ì•¶š•‚ğ•Ô‚·
+//! æŒ‡å®šã—ãŸä½ç½®ã®æ–‡å­—ã®æ–‡å­—å¹…ã‚’è¿”ã™
 CHabaXInt CNativeW::GetHabaOfChar( const wchar_t* pData, int nDataLen, int nIdx )
 {
-	//•¶š—ñ”ÍˆÍŠO‚È‚ç 0
+	//æ–‡å­—åˆ—ç¯„å›²å¤–ãªã‚‰ 0
 	if( nIdx >= nDataLen ){
 		return CHabaXInt(0);
 	}
-	// HACK:‰üsƒR[ƒh‚É‘Î‚µ‚Ä1‚ğ•Ô‚·
+	// HACK:æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã«å¯¾ã—ã¦1ã‚’è¿”ã™
 	if( WCODE::IsLineDelimiter(pData[nIdx], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 		return CHabaXInt(1);
 	}
 
-	// ƒTƒƒQ[ƒgƒ`ƒFƒbƒN
+	// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒã‚§ãƒƒã‚¯
 	if(IsUTF16High(pData[nIdx]) && nIdx + 1 < nDataLen && IsUTF16Low(pData[nIdx + 1])){
 		return CHabaXInt(WCODE::CalcPxWidthByFont2(pData + nIdx));
 	}else if(IsUTF16Low(pData[nIdx]) && 0 < nIdx && IsUTF16High(pData[nIdx - 1])) {
-		// ƒTƒƒQ[ƒgƒyƒAi‰ºˆÊj
-		return CHabaXInt(0); // •s³ˆÊ’u
+		// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢ï¼ˆä¸‹ä½ï¼‰
+		return CHabaXInt(0); // ä¸æ­£ä½ç½®
 	}
 	return CHabaXInt(WCODE::CalcPxWidthByFont(pData[nIdx]));
 }
 
-/* ƒ|ƒCƒ“ƒ^‚Å¦‚µ‚½•¶š‚ÌŸ‚É‚ ‚é•¶š‚ÌˆÊ’u‚ğ•Ô‚µ‚Ü‚· */
-/* Ÿ‚É‚ ‚é•¶š‚ªƒoƒbƒtƒ@‚ÌÅŒã‚ÌˆÊ’u‚ğ‰z‚¦‚éê‡‚Í&pData[nDataLen]‚ğ•Ô‚µ‚Ü‚· */
+/* ãƒã‚¤ãƒ³ã‚¿ã§ç¤ºã—ãŸæ–‡å­—ã®æ¬¡ã«ã‚ã‚‹æ–‡å­—ã®ä½ç½®ã‚’è¿”ã—ã¾ã™ */
+/* æ¬¡ã«ã‚ã‚‹æ–‡å­—ãŒãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã®ä½ç½®ã‚’è¶Šãˆã‚‹å ´åˆã¯&pData[nDataLen]ã‚’è¿”ã—ã¾ã™ */
 const wchar_t* CNativeW::GetCharNext( const wchar_t* pData, int nDataLen, const wchar_t* pDataCurrent )
 {
 	const wchar_t* pNext = pDataCurrent + 1;
@@ -296,7 +296,7 @@ const wchar_t* CNativeW::GetCharNext( const wchar_t* pData, int nDataLen, const 
 		return &pData[nDataLen];
 	}
 
-	// ƒTƒƒQ[ƒgƒyƒA‘Î‰	2008/7/6 Uchi
+	// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢å¯¾å¿œ	2008/7/6 Uchi
 	if (IsUTF16High(*pDataCurrent)) {
 		if (IsUTF16Low(*pNext)) {
 			pNext += 1;
@@ -306,8 +306,8 @@ const wchar_t* CNativeW::GetCharNext( const wchar_t* pData, int nDataLen, const 
 	return pNext;
 }
 
-/* ƒ|ƒCƒ“ƒ^‚Å¦‚µ‚½•¶š‚Ì’¼‘O‚É‚ ‚é•¶š‚ÌˆÊ’u‚ğ•Ô‚µ‚Ü‚· */
-/* ’¼‘O‚É‚ ‚é•¶š‚ªƒoƒbƒtƒ@‚Ìæ“ª‚ÌˆÊ’u‚ğ‰z‚¦‚éê‡‚ÍpData‚ğ•Ô‚µ‚Ü‚· */
+/* ãƒã‚¤ãƒ³ã‚¿ã§ç¤ºã—ãŸæ–‡å­—ã®ç›´å‰ã«ã‚ã‚‹æ–‡å­—ã®ä½ç½®ã‚’è¿”ã—ã¾ã™ */
+/* ç›´å‰ã«ã‚ã‚‹æ–‡å­—ãŒãƒãƒƒãƒ•ã‚¡ã®å…ˆé ­ã®ä½ç½®ã‚’è¶Šãˆã‚‹å ´åˆã¯pDataã‚’è¿”ã—ã¾ã™ */
 const wchar_t* CNativeW::GetCharPrev( const wchar_t* pData, int nDataLen, const wchar_t* pDataCurrent )
 {
 	const wchar_t* pPrev = pDataCurrent - 1;
@@ -315,7 +315,7 @@ const wchar_t* CNativeW::GetCharPrev( const wchar_t* pData, int nDataLen, const 
 		return pData;
 	}
 
-	// ƒTƒƒQ[ƒgƒyƒA‘Î‰	2008/7/6 Uchi
+	// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢å¯¾å¿œ	2008/7/6 Uchi
 	if (IsUTF16Low(*pPrev)) {
 		if (IsUTF16High(*(pPrev-1))) {
 			pPrev -= 1;
@@ -327,7 +327,7 @@ const wchar_t* CNativeW::GetCharPrev( const wchar_t* pData, int nDataLen, const 
 }
 
 
-//ShiftJIS‚É•ÏŠ·‚µ‚Ä•Ô‚·
+//ShiftJISã«å¤‰æ›ã—ã¦è¿”ã™
 const char* CNativeW::GetStringPtrOld() const
 {
 	return to_achar(GetStringPtr(),GetStringLength());

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -30,7 +30,7 @@
 #include "debug/Debug2.h" //assert
 
 
-//! •¶š—ñ‚Ö‚ÌQÆ‚ğæ“¾‚·‚éƒCƒ“ƒ^[ƒtƒF[ƒX
+//! æ–‡å­—åˆ—ã¸ã®å‚ç…§ã‚’å–å¾—ã™ã‚‹ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 class IStringRef{
 public:
 	virtual const wchar_t*	GetPtr()	const = 0;
@@ -38,7 +38,7 @@ public:
 };
 
 
-//! •¶š—ñ‚Ö‚ÌQÆ‚ğ•Û‚·‚éƒNƒ‰ƒX
+//! æ–‡å­—åˆ—ã¸ã®å‚ç…§ã‚’ä¿æŒã™ã‚‹ã‚¯ãƒ©ã‚¹
 class CStringRef : public IStringRef{
 public:
 	CStringRef() : m_pData(NULL), m_nDataLen(0) { }
@@ -46,7 +46,7 @@ public:
 	const wchar_t*	GetPtr()		const{ return m_pData;    }
 	int				GetLength()		const{ return m_nDataLen; }
 
-	//########•â•
+	//########è£œåŠ©
 	bool			IsValid()		const{ return m_pData!=NULL; }
 	wchar_t			At(int nIndex)	const{ assert(nIndex>=0 && nIndex<m_nDataLen); return m_pData[nIndex]; }
 private:
@@ -55,30 +55,30 @@ private:
 };
 
 
-//! UNICODE•¶š—ñŠÇ—ƒNƒ‰ƒX
+//! UNICODEæ–‡å­—åˆ—ç®¡ç†ã‚¯ãƒ©ã‚¹
 class CNativeW : public CNative{
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CNativeW();
 	CNativeW( const CNativeW& );
-	CNativeW( const wchar_t* pData, int nDataLen ); //!< nDataLen‚Í•¶š’PˆÊB
+	CNativeW( const wchar_t* pData, int nDataLen ); //!< nDataLenã¯æ–‡å­—å˜ä½ã€‚
 	CNativeW( const wchar_t* pData);
 
-	//ŠÇ—
-	void AllocStringBuffer( int nDataLen );                    //!< (d—vFnDataLen‚Í•¶š’PˆÊ) ƒoƒbƒtƒ@ƒTƒCƒY‚Ì’²®B•K—v‚É‰‚¶‚ÄŠg‘å‚·‚éB
+	//ç®¡ç†
+	void AllocStringBuffer( int nDataLen );                    //!< (é‡è¦ï¼šnDataLenã¯æ–‡å­—å˜ä½) ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã®èª¿æ•´ã€‚å¿…è¦ã«å¿œã˜ã¦æ‹¡å¤§ã™ã‚‹ã€‚
 
 	//WCHAR
-	void SetString( const wchar_t* pData, int nDataLen );      //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚éBnDataLen‚Í•¶š’PˆÊB
-	void SetString( const wchar_t* pszData );                  //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
+	void SetString( const wchar_t* pData, int nDataLen );      //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹ã€‚nDataLenã¯æ–‡å­—å˜ä½ã€‚
+	void SetString( const wchar_t* pszData );                  //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
 	void SetStringHoldBuffer( const wchar_t* pData, int nDataLen );
-	void AppendString( const wchar_t* pszData );               //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚é
-	void AppendString( const wchar_t* pszData, int nLength );  //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éBnLength‚Í•¶š’PˆÊB¬Œ÷‚·‚ê‚ÎtrueBƒƒ‚ƒŠŠm•Û‚É¸”s‚µ‚½‚çfalse‚ğ•Ô‚·B
+	void AppendString( const wchar_t* pszData );               //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹
+	void AppendString( const wchar_t* pszData, int nLength );  //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ã€‚nLengthã¯æ–‡å­—å˜ä½ã€‚æˆåŠŸã™ã‚Œã°trueã€‚ãƒ¡ãƒ¢ãƒªç¢ºä¿ã«å¤±æ•—ã—ãŸã‚‰falseã‚’è¿”ã™ã€‚
 
 	//CNativeW
-	void SetNativeData( const CNativeW& pcNative );            //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚é
-	void AppendNativeData( const CNativeW& );                  //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚é
+	void SetNativeData( const CNativeW& pcNative );            //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹
+	void AppendNativeData( const CNativeW& );                  //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹
 
-	//‰‰Zq
+	//æ¼”ç®—å­
 	const CNativeW& operator+=(wchar_t wch)				{ AppendString(&wch,1);   return *this; }
 	const CNativeW& operator=(wchar_t wch)				{ SetString(&wch,1);      return *this; }
 	const CNativeW& operator+=(const CNativeW& rhs)		{ AppendNativeData(rhs); return *this; }
@@ -86,9 +86,9 @@ public:
 	CNativeW operator+(const CNativeW& rhs) const		{ CNativeW tmp=*this; return tmp+=rhs; }
 
 
-	//ƒlƒCƒeƒBƒuæ“¾ƒCƒ“ƒ^[ƒtƒF[ƒX
-	wchar_t operator[](int nIndex) const;                    //!< ”CˆÓˆÊ’u‚Ì•¶šæ“¾BnIndex‚Í•¶š’PˆÊB
-	CLogicInt GetStringLength() const                        //!< •¶š—ñ’·‚ğ•Ô‚·B•¶š’PˆÊB
+	//ãƒã‚¤ãƒ†ã‚£ãƒ–å–å¾—ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
+	wchar_t operator[](int nIndex) const;                    //!< ä»»æ„ä½ç½®ã®æ–‡å­—å–å¾—ã€‚nIndexã¯æ–‡å­—å˜ä½ã€‚
+	CLogicInt GetStringLength() const                        //!< æ–‡å­—åˆ—é•·ã‚’è¿”ã™ã€‚æ–‡å­—å˜ä½ã€‚
 	{
 		return CLogicInt(CNative::GetRawLength() / sizeof(wchar_t));
 	}
@@ -100,13 +100,13 @@ public:
 	{
 		return reinterpret_cast<wchar_t*>(GetRawPtr());
 	}
-	const wchar_t* GetStringPtr(int* pnLength) const //[out]pnLength‚Í•¶š’PˆÊB
+	const wchar_t* GetStringPtr(int* pnLength) const //[out]pnLengthã¯æ–‡å­—å˜ä½ã€‚
 	{
 		*pnLength=GetStringLength();
 		return reinterpret_cast<const wchar_t*>(GetRawPtr());
 	}
 #ifdef USE_STRICT_INT
-	const wchar_t* GetStringPtr(CLogicInt* pnLength) const //[out]pnLength‚Í•¶š’PˆÊB
+	const wchar_t* GetStringPtr(CLogicInt* pnLength) const //[out]pnLengthã¯æ–‡å­—å˜ä½ã€‚
 	{
 		int n;
 		const wchar_t* p=GetStringPtr(&n);
@@ -115,12 +115,12 @@ public:
 	}
 #endif
 
-	//“Áê
+	//ç‰¹æ®Š
 	void _SetStringLength(int nLength)
 	{
 		_GetMemory()->_SetRawLength(nLength*sizeof(wchar_t));
 	}
-	//––”ö‚ğ1•¶ší‚é
+	//æœ«å°¾ã‚’1æ–‡å­—å‰Šã‚‹
 	void Chop()
 	{
 		int n = GetStringLength();
@@ -138,38 +138,38 @@ public:
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ”»’è                              //
+	//                           åˆ¤å®š                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	
-	//! “¯ˆê‚Ì•¶š—ñ‚È‚çtrue
+	//! åŒä¸€ã®æ–‡å­—åˆ—ãªã‚‰true
 	static bool IsEqual( const CNativeW& cmem1, const CNativeW& cmem2 );
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           •ÏŠ·                              //
+	//                           å¤‰æ›                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
-	void Replace( const wchar_t* pszFrom, const wchar_t* pszTo );   //!< •¶š—ñ’uŠ·
+	void Replace( const wchar_t* pszFrom, const wchar_t* pszTo );   //!< æ–‡å­—åˆ—ç½®æ›
 	void ReplaceT( const wchar_t* pszFrom, const wchar_t* pszTo ){
 		Replace( pszFrom, pszTo );
 	}
-	void Replace( const wchar_t* pszFrom, int nFromLen, const wchar_t* pszTo, int nToLen );   //!< •¶š—ñ’uŠ·
+	void Replace( const wchar_t* pszFrom, int nFromLen, const wchar_t* pszTo, int nToLen );   //!< æ–‡å­—åˆ—ç½®æ›
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                  Œ^ŒÀ’èƒCƒ“ƒ^[ƒtƒF[ƒX                     //
+	//                  å‹é™å®šã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	// g—p‚Í‚Å‚«‚é‚¾‚¯T‚¦‚é‚Ì‚ª–]‚Ü‚µ‚¢B
-	// ‚Ğ‚Æ‚Â‚ÍƒI[ƒo[ƒwƒbƒh‚ğ—}‚¦‚éˆÓ–¡‚ÅB
-	// ‚Ğ‚Æ‚Â‚Í•ÏŠ·‚É‚æ‚éƒf[ƒ^‘r¸‚ğ—}‚¦‚éˆÓ–¡‚ÅB
+	// ä½¿ç”¨ã¯ã§ãã‚‹ã ã‘æ§ãˆã‚‹ã®ãŒæœ›ã¾ã—ã„ã€‚
+	// ã²ã¨ã¤ã¯ã‚ªãƒ¼ãƒãƒ¼ãƒ˜ãƒƒãƒ‰ã‚’æŠ‘ãˆã‚‹æ„å‘³ã§ã€‚
+	// ã²ã¨ã¤ã¯å¤‰æ›ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å–ªå¤±ã‚’æŠ‘ãˆã‚‹æ„å‘³ã§ã€‚
 
 	//ACHAR
-	void SetStringOld( const char* pData, int nDataLen );    //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚éBpData‚ÍSJISBnDataLen‚Í•¶š’PˆÊB
-	void SetStringOld( const char* pszData );                //!< ƒoƒbƒtƒ@‚Ì“à—e‚ğ’u‚«Š·‚¦‚éBpszData‚ÍSJISB
-	void AppendStringOld( const char* pData, int nDataLen ); //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éBpszData‚ÍSJISB
-	void AppendStringOld( const char* pszData );             //!< ƒoƒbƒtƒ@‚ÌÅŒã‚Éƒf[ƒ^‚ğ’Ç‰Á‚·‚éBpszData‚ÍSJISB
-	const char* GetStringPtrOld() const; //ShiftJIS‚É•ÏŠ·‚µ‚Ä•Ô‚·
+	void SetStringOld( const char* pData, int nDataLen );    //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹ã€‚pDataã¯SJISã€‚nDataLenã¯æ–‡å­—å˜ä½ã€‚
+	void SetStringOld( const char* pszData );                //!< ãƒãƒƒãƒ•ã‚¡ã®å†…å®¹ã‚’ç½®ãæ›ãˆã‚‹ã€‚pszDataã¯SJISã€‚
+	void AppendStringOld( const char* pData, int nDataLen ); //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ã€‚pszDataã¯SJISã€‚
+	void AppendStringOld( const char* pszData );             //!< ãƒãƒƒãƒ•ã‚¡ã®æœ€å¾Œã«ãƒ‡ãƒ¼ã‚¿ã‚’è¿½åŠ ã™ã‚‹ã€‚pszDataã¯SJISã€‚
+	const char* GetStringPtrOld() const; //ShiftJISã«å¤‰æ›ã—ã¦è¿”ã™
 
 	//WCHAR
 	void SetStringW(const wchar_t* pszData)				{ return SetString(pszData); }
@@ -198,18 +198,18 @@ public:
 #if _DEBUG
 private:
 	typedef wchar_t* PWCHAR;
-	PWCHAR& m_pDebugData; //ƒfƒoƒbƒO—pBCMemory‚Ì“à—e‚ğwchar_t*Œ^‚ÅƒEƒHƒbƒ`‚·‚é‚½‚ß‚Ìƒ‚ƒm
+	PWCHAR& m_pDebugData; //ãƒ‡ãƒãƒƒã‚°ç”¨ã€‚CMemoryã®å†…å®¹ã‚’wchar_t*å‹ã§ã‚¦ã‚©ãƒƒãƒã™ã‚‹ãŸã‚ã®ãƒ¢ãƒ
 #endif
 
 public:
-	// -- -- staticƒCƒ“ƒ^[ƒtƒF[ƒX -- -- //
-	static CLogicInt GetSizeOfChar( const wchar_t* pData, int nDataLen, int nIdx ); //!< w’è‚µ‚½ˆÊ’u‚Ì•¶š‚ªwchar_t‰½ŒÂ•ª‚©‚ğ•Ô‚·
+	// -- -- staticã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ -- -- //
+	static CLogicInt GetSizeOfChar( const wchar_t* pData, int nDataLen, int nIdx ); //!< æŒ‡å®šã—ãŸä½ç½®ã®æ–‡å­—ãŒwchar_tä½•å€‹åˆ†ã‹ã‚’è¿”ã™
 	static CHabaXInt GetHabaOfChar( const wchar_t* pData, int nDataLen, int nIdx );
-	static CKetaXInt GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx ); //!< w’è‚µ‚½ˆÊ’u‚Ì•¶š‚ª”¼Šp‰½ŒÂ•ª‚©‚ğ•Ô‚·
-	static const wchar_t* GetCharNext( const wchar_t* pData, int nDataLen, const wchar_t* pDataCurrent ); //!< ƒ|ƒCƒ“ƒ^‚Å¦‚µ‚½•¶š‚ÌŸ‚É‚ ‚é•¶š‚ÌˆÊ’u‚ğ•Ô‚µ‚Ü‚·
-	static const wchar_t* GetCharPrev( const wchar_t* pData, int nDataLen, const wchar_t* pDataCurrent ); //!< ƒ|ƒCƒ“ƒ^‚Å¦‚µ‚½•¶š‚Ì’¼‘O‚É‚ ‚é•¶š‚ÌˆÊ’u‚ğ•Ô‚µ‚Ü‚·
+	static CKetaXInt GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx ); //!< æŒ‡å®šã—ãŸä½ç½®ã®æ–‡å­—ãŒåŠè§’ä½•å€‹åˆ†ã‹ã‚’è¿”ã™
+	static const wchar_t* GetCharNext( const wchar_t* pData, int nDataLen, const wchar_t* pDataCurrent ); //!< ãƒã‚¤ãƒ³ã‚¿ã§ç¤ºã—ãŸæ–‡å­—ã®æ¬¡ã«ã‚ã‚‹æ–‡å­—ã®ä½ç½®ã‚’è¿”ã—ã¾ã™
+	static const wchar_t* GetCharPrev( const wchar_t* pData, int nDataLen, const wchar_t* pDataCurrent ); //!< ãƒã‚¤ãƒ³ã‚¿ã§ç¤ºã—ãŸæ–‡å­—ã®ç›´å‰ã«ã‚ã‚‹æ–‡å­—ã®ä½ç½®ã‚’è¿”ã—ã¾ã™
 
-	static CKetaXInt GetKetaOfChar( const CStringRef& cStr, int nIdx ) //!< w’è‚µ‚½ˆÊ’u‚Ì•¶š‚ª”¼Šp‰½ŒÂ•ª‚©‚ğ•Ô‚·
+	static CKetaXInt GetKetaOfChar( const CStringRef& cStr, int nIdx ) //!< æŒ‡å®šã—ãŸä½ç½®ã®æ–‡å­—ãŒåŠè§’ä½•å€‹åˆ†ã‹ã‚’è¿”ã™
 	{
 		return GetKetaOfChar(cStr.GetPtr(), cStr.GetLength(), nIdx);
 	}

--- a/sakura_core/mem/CRecycledBuffer.cpp
+++ b/sakura_core/mem/CRecycledBuffer.cpp
@@ -1,2 +1,2 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "CRecycledBuffer.h"


### PR DESCRIPTION
該当フォルダ内の文字コードを変換しても支障のないものだけを対象に変換を行いました。

```
cd sakura_core/mem
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
git checkout CNativeA.cpp … ANSI以外の文字定数・文字列定数があるので変換から除外
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
- ソースコードのUnicode化 #112

## このフォルダを変換対象とした目的
#160 (CNativeT 関連) の対応の前段階として文字コードを変換しておきたい。