### PR TITLE
「コントロールプロセスの起動に失敗しました。」の対策。

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -556,6 +556,7 @@
     <ClInclude Include="..\sakura_core\_os\COsVersionInfo.h" />
     <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h" />
     <ClInclude Include="..\sakura_core\_os\OleTypes.h" />
+    <ClInclude Include="..\sakura_core\_os\ProcessPriority.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\resource\auto_scroll_center.cur" />

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -554,6 +554,7 @@
     <ClInclude Include="..\sakura_core\_os\CClipboard.h" />
     <ClInclude Include="..\sakura_core\_os\CDropTarget.h" />
     <ClInclude Include="..\sakura_core\_os\COsVersionInfo.h" />
+    <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h" />
     <ClInclude Include="..\sakura_core\_os\OleTypes.h" />
   </ItemGroup>
   <ItemGroup>

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1088,6 +1088,9 @@
     <ClInclude Include="..\sakura_core\version.h">
       <Filter>Other Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h">
+      <Filter>Cpp Source Files\_os</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\sakura_core\Funccode_x.hsrc">

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1091,6 +1091,9 @@
     <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h">
       <Filter>Cpp Source Files\_os</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\_os\ProcessPriority.h">
+      <Filter>Cpp Source Files\_os</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\sakura_core\Funccode_x.hsrc">

--- a/sakura_core/_main/CControlProcess.cpp
+++ b/sakura_core/_main/CControlProcess.cpp
@@ -22,8 +22,8 @@
 #include "CCommandLine.h"
 #include "env/CShareData_IO.h"
 #include "debug/CRunningTimer.h"
+#include "_os\ProcessPriority.h"
 #include "sakura_rc.h"/// IDD_EXITTING 2002/2/10 aroka ヘッダ整理
-
 
 //-------------------------------------------------
 
@@ -44,13 +44,8 @@ bool CControlProcess::InitializeProcess()
 {
 	MY_RUNNINGTIMER( cRunningTimer, "CControlProcess::InitializeProcess" );
 
-	// プロセス優先度を取得する
-	DWORD dwPriority = ::GetPriorityClass(::GetCurrentProcess());
-
-	if (HIGH_PRIORITY_CLASS != dwPriority) {
-		// プロセス優先度を「高」にする
-		::SetPriorityClass(::GetCurrentProcess(), HIGH_PRIORITY_CLASS);
-	}
+	// プロセス優先度を「高」にする
+	ProcessPriority processPriority(HIGH_PRIORITY_CLASS);
 
 	// アプリケーション実行検出用(インストーラで使用)
 	m_hMutex = ::CreateMutex( NULL, FALSE, GSTR_MUTEX_SAKURA );
@@ -87,7 +82,7 @@ bool CControlProcess::InitializeProcess()
 	}
 	
 	// プロセス優先度を元に戻す
-	::SetPriorityClass(::GetCurrentProcess(), dwPriority);
+	processPriority.reset();
 
 	/* 共有メモリを初期化 */
 	if( !CProcess::InitializeProcess() ){

--- a/sakura_core/_main/CControlProcess.cpp
+++ b/sakura_core/_main/CControlProcess.cpp
@@ -44,6 +44,14 @@ bool CControlProcess::InitializeProcess()
 {
 	MY_RUNNINGTIMER( cRunningTimer, "CControlProcess::InitializeProcess" );
 
+	// プロセス優先度を取得する
+	DWORD dwPriority = ::GetPriorityClass(::GetCurrentProcess());
+
+	if (HIGH_PRIORITY_CLASS != dwPriority) {
+		// プロセス優先度を「高」にする
+		::SetPriorityClass(::GetCurrentProcess(), HIGH_PRIORITY_CLASS);
+	}
+
 	// アプリケーション実行検出用(インストーラで使用)
 	m_hMutex = ::CreateMutex( NULL, FALSE, GSTR_MUTEX_SAKURA );
 	if( NULL == m_hMutex ){
@@ -78,6 +86,9 @@ bool CControlProcess::InitializeProcess()
 		return false;
 	}
 	
+	// プロセス優先度を元に戻す
+	::SetPriorityClass(::GetCurrentProcess(), dwPriority);
+
 	/* 共有メモリを初期化 */
 	if( !CProcess::InitializeProcess() ){
 		return false;

--- a/sakura_core/_main/CControlProcess.cpp
+++ b/sakura_core/_main/CControlProcess.cpp
@@ -45,7 +45,7 @@ bool CControlProcess::InitializeProcess()
 	MY_RUNNINGTIMER( cRunningTimer, "CControlProcess::InitializeProcess" );
 
 	// プロセス優先度を「高」にする
-	ProcessPriority processPriority(HIGH_PRIORITY_CLASS);
+	sakura::_os::ProcessPriority processPriority(HIGH_PRIORITY_CLASS);
 
 	// アプリケーション実行検出用(インストーラで使用)
 	m_hMutex = ::CreateMutex( NULL, FALSE, GSTR_MUTEX_SAKURA );

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -335,16 +335,9 @@ bool CProcessFactory::WaitForInitializedControlProcess()
 	HANDLE hEvent;
 	hEvent = ::OpenEvent( EVENT_ALL_ACCESS, FALSE, strInitEvent.c_str() );
 	if( NULL == hEvent ){
-		// 動作中のコントロールプロセスを旧バージョンとみなし、イベントを待たずに処理を進める
-		//
-		// Note: Ver1.5.9.91以前のバージョンは初期化完了イベントを作らない。
-		// このため、コントロールプロセスが常駐していないときに複数ウィンドウをほぼ
-		// 同時に起動すると、競争に生き残れなかったコントロールプロセスの親プロセスや、
-		// 僅かに出遅れてコントロールプロセスを作成しなかったプロセスでも、
-		// コントロールプロセスの初期化処理を追い越してしまい、異常終了したり、
-		// 「タブバーが表示されない」のような問題が発生していた。
-		//
-		return true;
+		std::wstring msg(getMessageFromSystem(::GetLastError()));
+		TopErrorMessage( NULL, _T("エディタまたはシステムがビジー状態です。\nしばらく待って開きなおしてください。\n%ts"), msg.c_str());
+		return false;
 	}
 	DWORD dwRet;
 	dwRet = ::WaitForSingleObject( hEvent, 10000 );	// 最大10秒間待つ

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -317,9 +317,16 @@ bool CProcessFactory::StartControlProcess()
 */
 bool CProcessFactory::WaitForInitializedControlProcess()
 {
-		if( !IsExistControlProcess() ){
-			StartControlProcess();
+	// コントロールプロセスが起動しているかチェック
+	if (!IsExistControlProcess()) {
+		// コントロールプロセスを起動する
+		if (!StartControlProcess())
+		{
+			return false; //コントロールプロセスの起動に失敗
 		}
+		assert(IsExistControlProcess());
+	}
+
 	// 初期化完了イベントを待つ
 	//
 	// Note: コントロールプロセス側は多重起動防止用ミューテックスを ::CreateMutex() で

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -320,15 +320,6 @@ bool CProcessFactory::WaitForInitializedControlProcess()
 	}
 
 	// 初期化完了イベントを待つ
-	//
-	// Note: コントロールプロセス側は多重起動防止用ミューテックスを ::CreateMutex() で
-	// 作成するよりも先に初期化完了イベントを ::CreateEvent() で作成する。
-	//
-	if( !IsExistControlProcess() ){
-		// コントロールプロセスが多重起動防止用のミューテックス作成前に異常終了した場合など
-		return false;
-	}
-
 	std::tstring strProfileName = to_tchar(CCommandLine::getInstance()->GetProfileName());
 	std::tstring strInitEvent = GSTR_EVENT_SAKURA_CP_INITIALIZED;
 	strInitEvent += strProfileName;

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -74,9 +74,6 @@ CProcess* CProcessFactory::Create( HINSTANCE hInstance, LPCTSTR lpCmdLine )
 		}
 	}
 	else{
-		if( !IsExistControlProcess() ){
-			StartControlProcess();
-		}
 		if( WaitForInitializedControlProcess() ){	// 2006.04.10 ryoji コントロールプロセスの初期化完了待ち
 			process = new CNormalProcess( hInstance, lpCmdLine );
 		}
@@ -320,6 +317,9 @@ bool CProcessFactory::StartControlProcess()
 */
 bool CProcessFactory::WaitForInitializedControlProcess()
 {
+		if( !IsExistControlProcess() ){
+			StartControlProcess();
+		}
 	// 初期化完了イベントを待つ
 	//
 	// Note: コントロールプロセス側は多重起動防止用ミューテックスを ::CreateMutex() で

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -29,6 +29,8 @@
 #include <io.h>
 #include <tchar.h>
 
+#include "_os\getMessageFromSystem.h"
+
 class CProcess;
 
 
@@ -214,6 +216,7 @@ bool CProcessFactory::IsExistControlProcess()
 	return false;	// コントロールプロセスは存在していないか、まだ CreateMutex() してない
 }
 
+
 //	From Here Aug. 28, 2001 genta
 /*!
 	@brief コントロールプロセスを起動する
@@ -272,19 +275,8 @@ bool CProcessFactory::StartControlProcess()
 	);
 	if( !bCreateResult ){
 		//	失敗
-		TCHAR* pMsg;
-		::FormatMessage( FORMAT_MESSAGE_ALLOCATE_BUFFER |
-						FORMAT_MESSAGE_IGNORE_INSERTS |
-						FORMAT_MESSAGE_FROM_SYSTEM,
-						NULL,
-						::GetLastError(),
-						MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-						(LPTSTR)&pMsg,
-						0,
-						NULL
-		);
-		ErrorMessage( NULL, _T("\'%ts\'\nプロセスの起動に失敗しました。\n%ts"), szEXE, pMsg );
-		::LocalFree( (HLOCAL)pMsg );	//	エラーメッセージバッファを解放
+		std::wstring msg(getMessageFromSystem(::GetLastError()));
+		ErrorMessage( NULL, _T("\'%ts\'\nプロセスの起動に失敗しました。\n%ts"), szEXE, msg.c_str() );
 		return false;
 	}
 

--- a/sakura_core/_os/ProcessPriority.h
+++ b/sakura_core/_os/ProcessPriority.h
@@ -1,0 +1,87 @@
+/*
+  Copyright (C) 2018, Sakura Editor Organization
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Sakura Editor Organization
+    https://sakura-editor.github.io/ 
+
+ */
+
+#pragma once
+
+#ifndef _PROCESSTHREADSAPI_H_
+#error Need to include string before ProcessPriority.h
+#endif  /* _PROCESSTHREADSAPI_H_ */
+
+
+//名前空間
+namespace sakura {
+	namespace _os {
+
+
+/*!
+ * @brief プロセス優先度クラス
+ *   コンストラクタで優先度を設定し、デストラクタで元に戻す。
+ *
+ * @sa https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setpriorityclass
+ * @date 2018/07/02 berryzplus		新規作成
+ */
+class ProcessPriority {
+private:
+	HANDLE _hProcess;			//!< プロセスハンドル(キャッシュ)
+	DWORD _dwDefaultPriority;	//!< 変更前のプロセス優先度
+
+public:
+	ProcessPriority(_In_ DWORD dwDesiredPriority)
+		: _hProcess(::GetCurrentProcess())
+		, _dwDefaultPriority(::GetPriorityClass(_hProcess)) {
+		// プロセス優先度を設定する
+		set(dwDesiredPriority);
+	}
+	virtual ~ProcessPriority() {
+		reset();
+	}
+
+public:
+	//!プロセス優先度を設定する
+	void set(_In_ DWORD dwDesiredPriority) {
+		if (dwDesiredPriority != _dwDefaultPriority) {
+			BOOL bRet = ::SetPriorityClass(_hProcess, dwDesiredPriority);
+			assert(bRet && "SetPriorityClass failed.");
+		}
+	}
+	//!プロセス優先度を取得する
+	DWORD get() const {
+		return ::GetPriorityClass(_hProcess);
+	}
+	//!プロセス優先度を元に戻す
+	void reset() {
+		if (get() != _dwDefaultPriority) {
+			BOOL bRet = ::SetPriorityClass(_hProcess, _dwDefaultPriority);
+			assert(bRet && "SetPriorityClass failed.");
+		}
+	}
+};
+
+
+	}; // end of namespace _os
+}; // end of namespace sakura
+
+
+//名前空間を意識せずに扱えるようにusingしておく。
+using sakura::_os::ProcessPriority;

--- a/sakura_core/_os/ProcessPriority.h
+++ b/sakura_core/_os/ProcessPriority.h
@@ -36,12 +36,13 @@ namespace sakura {
 
 /*!
  * @brief プロセス優先度クラス
- *   コンストラクタで優先度を設定し、デストラクタで元に戻す。
+ *   コンストラクタで実行中プロセスのプロセス優先度を保存し、デストラクタで元に戻す。
  *
  * @sa https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setpriorityclass
  * @date 2018/07/02 berryzplus		新規作成
  */
-class ProcessPriority {
+class ProcessPriority
+{
 private:
 	HANDLE _hProcess;			//!< プロセスハンドル(キャッシュ)
 	DWORD _dwDefaultPriority;	//!< 変更前のプロセス優先度
@@ -49,39 +50,38 @@ private:
 public:
 	ProcessPriority(_In_ DWORD dwDesiredPriority)
 		: _hProcess(::GetCurrentProcess())
-		, _dwDefaultPriority(::GetPriorityClass(_hProcess)) {
+		, _dwDefaultPriority(::GetPriorityClass(_hProcess))
+	{
 		// プロセス優先度を設定する
 		set(dwDesiredPriority);
 	}
-	virtual ~ProcessPriority() {
+	virtual ~ProcessPriority()
+	{
 		reset();
 	}
 
 public:
 	//!プロセス優先度を設定する
-	void set(_In_ DWORD dwDesiredPriority) {
-		if (dwDesiredPriority != _dwDefaultPriority) {
-			BOOL bRet = ::SetPriorityClass(_hProcess, dwDesiredPriority);
-			assert(bRet && "SetPriorityClass failed.");
+	bool set(_In_ DWORD dwDesiredPriority)
+	{
+		BOOL bRet = FALSE;
+		if (get() != dwDesiredPriority) {
+			bRet = ::SetPriorityClass(_hProcess, dwDesiredPriority);
 		}
+		return bRet;
 	}
 	//!プロセス優先度を取得する
-	DWORD get() const {
+	DWORD get() const 
+	{
 		return ::GetPriorityClass(_hProcess);
 	}
 	//!プロセス優先度を元に戻す
-	void reset() {
-		if (get() != _dwDefaultPriority) {
-			BOOL bRet = ::SetPriorityClass(_hProcess, _dwDefaultPriority);
-			assert(bRet && "SetPriorityClass failed.");
-		}
+	void reset()
+	{
+		set(_dwDefaultPriority);
 	}
 };
 
 
 	}; // end of namespace _os
 }; // end of namespace sakura
-
-
-//名前空間を意識せずに扱えるようにusingしておく。
-using sakura::_os::ProcessPriority;

--- a/sakura_core/_os/getMessageFromSystem.h
+++ b/sakura_core/_os/getMessageFromSystem.h
@@ -1,0 +1,81 @@
+/*
+  Copyright (C) 2018, Sakura Editor Organization
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Sakura Editor Organization
+    https://sakura-editor.github.io/ 
+
+ */
+
+#pragma once
+
+#ifndef _STRING_
+#error Need to include string before getMessageFromSystem.h
+#endif  /* _STRING_ */
+
+#if !defined(_WINBASE_) || !defined(_WINNT_)
+#error Need to include windows.h before getMessageFromSystem.h
+#endif  /* !defined(_WINBASE_) || !defined(_WINNT_) */
+
+
+//名前空間
+namespace sakura {
+	namespace _os {
+
+
+/*!
+ * @brief システムメッセージを取得する
+ *
+ * @param [in]		dwMessageCode	メッセージコード。
+ *									::GetLastError()の戻り値を指定する。
+ * @param [in,opt]	dwLanguageId	言語識別子。
+ *									省略した場合、::FormatMessage()の挙動に準ずる。
+ * @retval msg						システムメッセージ。
+ *									該当するメッセージがない場合、空文字列を返す。
+ * @sa https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-formatmessage
+ * @date 2018/06/25 berryzplus		新規作成
+ */
+inline
+std::wstring getMessageFromSystem(
+	_In_ DWORD dwMessageCode,
+	_In_opt_ DWORD dwLanguageId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT)
+)
+{
+	HLOCAL pMsg = NULL;
+	DWORD length = ::FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM
+		| FORMAT_MESSAGE_ALLOCATE_BUFFER
+		| FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL,
+		dwMessageCode,
+		dwLanguageId,
+		(LPWSTR)&pMsg,
+		0,
+		NULL
+	);
+	std::wstring msg((LPCWSTR)pMsg, length);
+	::LocalFree(pMsg);
+	return std::move(msg);
+}
+
+
+	}; // end of namespace _os
+}; // end of namespace sakura
+
+
+//名前空間を意識せずに扱えるようにusingしておく。
+using sakura::_os::getMessageFromSystem;


### PR DESCRIPTION
「コントロールプロセスの起動に失敗しました。」の対策です。

原因：
サクラエディタの起動シーケンスが特殊だから。
（定石「WaitForInputIdle関数で待機」では失敗する）

対策：
すでに導入済みの初期化完了イベントを活用する。

対策内容詳細：
* 初期化処理の優先度を「高」にする
コントロールプロセス初期化処理のうち、ロック取得を行う部分の優先度を「高」にする。
優先度を高く設定することにより、不完全なロック状態となる可能性を軽減する。
* プロセス存在確認の判定位置を移動。
コントロールプロセスの初期化完了待ちメソッドの外で行っていたプロセス存在確認を中に移動。
* 初期化完了待ちメソッドに移動したコードブロックの整理
プロセス起動が失敗した場合にfalseを返すことが明確になるように修正した。
* getMessageFromSystem抽出
既存コードからの抜き出し関数。
FormatMessage関数でエラーメッセージを取得する定型処理。
* 初期化完了イベントをオープンできなかったときの挙動を変更。
変更前: 初期化完了イベントを作成しないバージョンとの互換性を保つためにtrueを返す。
変更後: システムエラーメッセージを表示してfalseを返す。
* 初期化完了待ちメソッドにあった判定文を除去。
旧処理のプロセス存在確認コードを除去。
* コントロールプロセス開始処理の待機条件を変更。
コントロールプロセスが利用可能になればtrueを返すように変更した。
* 初期化完了イベントのオープンをリトライするように変更。

残課題：
定石「WaitForInputIdle関数で待機」を使っている処理が他2箇所残っている。
（これについては待機する対象がエディタプロセスなので別件として上げる予定。）
