### PR TITLE
ALPHA_VERSION の定義を build_config.h に移動して  version.h の依存関係を減らす

### DIFF
--- a/sakura_core/config/app_constants.h
+++ b/sakura_core/config/app_constants.h
@@ -24,7 +24,7 @@
 #ifndef SAKURA_APP_CONSTANTS_AD36E2CE_B62E_497D_806F_6B9738310127_H_
 #define SAKURA_APP_CONSTANTS_AD36E2CE_B62E_497D_806F_6B9738310127_H_
 
-#include "version.h"
+#include "build_config.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           –¼‘O                              //

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -115,5 +115,9 @@ static const bool UNICODE_BOOL=false;
 	//‚»‚ê‚ÆAWinMain‚Ìæ“ª‚Å _CrtSetDbgFlag() ‚ğŒÄ‚Ô
 #endif
 
+#if _WIN64
+#define ALPHA_VERSION
+#endif
+
 #endif /* SAKURA_BUILD_CONFIG_26C6FCD0_99D7_4AF6_89C1_F34581417333_H_ */
 /*[EOF]*/

--- a/sakura_core/version.h
+++ b/sakura_core/version.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include "config/build_config.h"
 #include "githash.h"
 
 // バージョン定義 //
@@ -44,10 +45,6 @@
 #define SPACE_WHEN_DEBUG " "
 #else
 #define SPACE_WHEN_DEBUG ""
-#endif
-
-#if _WIN64
-#define ALPHA_VERSION
 #endif
 
 #if defined(ALPHA_VERSION)


### PR DESCRIPTION
ALPHA_VERSION の定義を build_config.h に移動して  version.h の依存関係を減らす