### PR TITLE
HeaderMake と MakefileMake の出力先を変える 

### DIFF
--- a/HeaderMake/HeaderMake.vcxproj
+++ b/HeaderMake/HeaderMake.vcxproj
@@ -41,12 +41,12 @@
     <_ProjectFileVersion>15.0.27130.2020</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)sakura\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)sakura\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>

--- a/MakefileMake/MakefileMake.vcxproj
+++ b/MakefileMake/MakefileMake.vcxproj
@@ -41,12 +41,12 @@
     <_ProjectFileVersion>15.0.27130.2020</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)sakura\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)sakura\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>

--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -1,17 +1,22 @@
 @echo off
 set EXEDIR=%1
+set SRCDIR=..\sakura_core
+set DSTDIR=%SRCDIR%
+set MAKEFILEDIR=%SRCDIR%
+set TOPDIR=%SRCDIR%
+
 @echo =======================
 @echo preBuild
 @echo =======================
 
 @echo.
 @echo ---- HeaderMake ----
-%EXEDIR%HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_define.h -mode=define
-%EXEDIR%HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_enum.h -mode=enum -enum=EFunctionCode
+%EXEDIR%HeaderMake -in=%SRCDIR%\Funccode_x.hsrc -out=%DSTDIR%\Funccode_define.h -mode=define
+%EXEDIR%HeaderMake -in=%SRCDIR%\Funccode_x.hsrc -out=%DSTDIR%\Funccode_enum.h -mode=enum -enum=EFunctionCode
 
 @echo.
 @echo ---- MakefileMake ----
-%EXEDIR%MakefileMake -file=..\sakura_core\Makefile -dir=..\sakura_core
+%EXEDIR%MakefileMake -file=%MAKEFILEDIR%\Makefile -dir=%TOPDIR%
 
 @echo.
 @echo ---- Make githash.h ----

--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -1,17 +1,17 @@
 @echo off
-
+set EXEDIR=%1
 @echo =======================
 @echo preBuild
 @echo =======================
 
 @echo.
 @echo ---- HeaderMake ----
-HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_define.h -mode=define
-HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_enum.h -mode=enum -enum=EFunctionCode
+%EXEDIR%HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_define.h -mode=define
+%EXEDIR%HeaderMake -in=..\sakura_core\Funccode_x.hsrc -out=..\sakura_core\Funccode_enum.h -mode=enum -enum=EFunctionCode
 
 @echo.
 @echo ---- MakefileMake ----
-MakefileMake -file=..\sakura_core\Makefile -dir=..\sakura_core
+%EXEDIR%MakefileMake -file=..\sakura_core\Makefile -dir=..\sakura_core
 
 @echo.
 @echo ---- Make githash.h ----

--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -5,18 +5,29 @@ set DSTDIR=%SRCDIR%
 set MAKEFILEDIR=%SRCDIR%
 set TOPDIR=%SRCDIR%
 
+set EXE_HEADERMAKE=HeaderMake
+set EXE_MAKEFILEMAKE=MakefileMake
+
+if not "%EXEDIR%" == "" (
+	set HEADERMAKE=%EXEDIR%\%EXE_HEADERMAKE%
+	set MAKEFILEMAKE=%EXEDIR%\%EXE_MAKEFILEMAKE%
+) else (
+	set HEADERMAKE=%EXE_HEADERMAKE%
+	set MAKEFILEMAKE=%EXE_MAKEFILEMAKE%
+)
+
 @echo =======================
 @echo preBuild
 @echo =======================
 
 @echo.
 @echo ---- HeaderMake ----
-%EXEDIR%HeaderMake -in=%SRCDIR%\Funccode_x.hsrc -out=%DSTDIR%\Funccode_define.h -mode=define
-%EXEDIR%HeaderMake -in=%SRCDIR%\Funccode_x.hsrc -out=%DSTDIR%\Funccode_enum.h -mode=enum -enum=EFunctionCode
+%HEADERMAKE% -in=%SRCDIR%\Funccode_x.hsrc -out=%DSTDIR%\Funccode_define.h -mode=define
+%HEADERMAKE% -in=%SRCDIR%\Funccode_x.hsrc -out=%DSTDIR%\Funccode_enum.h -mode=enum -enum=EFunctionCode
 
 @echo.
 @echo ---- MakefileMake ----
-%EXEDIR%MakefileMake -file=%MAKEFILEDIR%\Makefile -dir=%TOPDIR%
+%MAKEFILEMAKE% -file=%MAKEFILEDIR%\Makefile -dir=%TOPDIR%
 
 @echo.
 @echo ---- Make githash.h ----

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -119,7 +119,7 @@
       <Command>call postBuild.bat "$(TargetPath).manifest"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)\</Command>
+      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -155,7 +155,7 @@
       <Command>call postBuild.bat "$(TargetPath).manifest"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)\</Command>
+      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -190,7 +190,7 @@
       <Command>call postBuild.bat "$(TargetPath).manifest"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)\</Command>
+      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -224,7 +224,7 @@
       <Command>call postBuild.bat "$(TargetPath).manifest"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)\</Command>
+      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -119,7 +119,7 @@
       <Command>call postBuild.bat "$(TargetPath).manifest"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>call preBuild.bat</Command>
+      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)\</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -155,7 +155,7 @@
       <Command>call postBuild.bat "$(TargetPath).manifest"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>call preBuild.bat</Command>
+      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)\</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -190,7 +190,7 @@
       <Command>call postBuild.bat "$(TargetPath).manifest"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>call preBuild.bat</Command>
+      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)\</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -224,7 +224,7 @@
       <Command>call postBuild.bat "$(TargetPath).manifest"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>call preBuild.bat</Command>
+      <Command>call preBuild.bat $(SolutionDir)Win32\$(Configuration)\</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
HeaderMake と MakefileMake の出力先を変える 

- HeaderMake.exe / MakefileMake.exe が sakura ディレクトリに出力されてあまりよろしくない
- Debug/Release をビルドする場合、Debug と Release が同じディレクトリに出力されるのはよろしくない。


