### PR TITLE
x64 のビルド警告を修正する準備のために発生している警告を csv にまとめる

### DIFF
--- a/build-sln.bat
+++ b/build-sln.bat
@@ -20,4 +20,8 @@ set MSBUILD_EXE="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\M
       %MSBUILD_EXE% %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%      /t:"Clean","Rebuild"  %EXTRA_CMD% %LOG_OPTION%
 if %errorlevel% neq 0 (echo error && exit /b 1)
 
+@echo call parse-buildlog.bat %LOG_FILE%
+      call parse-buildlog.bat %LOG_FILE%
+if %errorlevel% neq 0 (echo error && exit /b 1)
+
 exit /b 0

--- a/parse-buildlog.bat
+++ b/parse-buildlog.bat
@@ -1,0 +1,9 @@
+@echo off
+where python --version 1>nul 2>&1
+if not "%ERRORLEVEL%" == "0" (
+	@echo NOTE: No python command
+) else (
+	python parse-buildlog.py %1
+)
+@echo on
+exit /b 0

--- a/parse-buildlog.bat
+++ b/parse-buildlog.bat
@@ -6,4 +6,4 @@ if not "%ERRORLEVEL%" == "0" (
 	python parse-buildlog.py %1
 )
 @echo on
-exit /b 0
+exit /b %ERRORLEVEL%

--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -1,0 +1,95 @@
+import sys
+import re
+import os
+import csv
+
+infile = sys.argv[1]
+outfile = infile + '.csv'
+
+regLilePath  = r'(?P<filePath>[a-zA-Z]:([^(]+))'
+regLineNumer = r'\((?P<lineNumber>\d+)\)'
+regError     = r'\s*(?P<type>\w+)\s*(?P<code>\w+)\s*'
+regMessage   = r'(?P<message>.+)$'
+regEx        = regLilePath + regLineNumer + r':' + regError + r':' + regMessage
+regFromTo    = r"from '(?P<source>[^']+)' to '(?P<dest>[^']+)'"
+
+
+def customsort(x, y):
+	if x['key'] < y['key']:
+		return 1
+	elif x['key'] > y['key']:
+		return -1
+	else:
+		return 0
+
+data = []
+with open(infile, "r") as fin:
+	print "open " + infile
+	for line in fin:
+		text = line.replace('\n','')
+		text = text.replace('\r','')
+
+		match = re.search(regEx, text)
+		if match:
+			path       = match.group('filePath')
+			lineNumber = match.group('lineNumber')
+			type       = match.group('type')
+			code       = match.group('code')
+			message    = match.group('message')
+
+			entry = {}
+			entry['type'] = type
+			entry['code'] = code
+
+			match2 = re.search(regFromTo, text)
+			if match2:
+				source  = match2.group('source')
+				dest    = match2.group('dest')
+				entry['source'] = source
+				entry['dest']   = dest
+			else:
+				entry['source'] = r''
+				entry['dest']   = r''
+
+			entry['path']       = path
+			entry['lineNumber'] = lineNumber
+			entry['message']    = message
+
+			keys = [
+				'type',
+				'code',
+				'source',
+				'dest',
+				'path',
+				'lineNumber',
+				'message',
+			]
+
+			temp = []
+			for key in keys:
+				temp.append(entry[key])
+			entry['key'] = ' '.join(temp)
+			data.append(entry)
+
+data = sorted(data, cmp=customsort)
+
+with open(outfile, "wb") as fout:
+	fieldnames = [
+		'type',
+		'code',
+		'source',
+		'dest',
+		'path',
+		'lineNumber',
+		'message',
+	]
+	writer = csv.writer(fout)
+	writer.writerow(fieldnames)
+
+	for entry in data:
+		temp = []
+		for key in keys:
+			temp.append(entry[key])
+		writer.writerow(temp)
+
+	print "wrote " + outfile

--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -1,3 +1,4 @@
+﻿# -*- coding: utf-8 -*-
 import sys
 import re
 import os
@@ -6,11 +7,24 @@ import csv
 infile = sys.argv[1]
 outfile = infile + '.csv'
 
+# ファイル名に対する正規表現: 例 c:\hogehoge\hoge.c
 regLilePath  = r'(?P<filePath>[a-zA-Z]:([^(]+))'
+
+# 行番号に対する正規表現: 例 (100)
 regLineNumer = r'\((?P<lineNumber>\d+)\)'
+
+# エラーコードに対する正規表現: 例 warning C4267
 regError     = r'\s*(?P<type>\w+)\s+(?P<code>\w+)\s*'
+
+# エラーメッセージ: 例 'argument': conversion from 'size_t' to 'int', possible loss of data [C:\projects\sakura\sakura\sakura.vcxproj]
 regMessage   = r'(?P<message>.+)$'
+
+# 解析対象の正規表現
+# 例
+#   c:\projects\sakura\sakura_core\basis\cmystring.h(39): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [C:\projects\sakura\sakura\sakura.vcxproj]
 regEx        = regLilePath + regLineNumer + r':' + regError + r':' + regMessage
+
+# 型変換に対する警告メッセージ部分に対する正規表現: 例 'size_t' to 'int'
 regFromTo    = r"from '(?P<source>[^']+)' to '(?P<dest>[^']+)'"
 
 data = []
@@ -62,9 +76,11 @@ with open(infile, "r") as fin:
 			entry['key'] = ' '.join(temp)
 			data.append(entry)
 
+# ソート対象のハッシュ配列で 'key' というキーを元にソートする。
 from operator import itemgetter
 data = sorted(data, key=itemgetter('key'))
 
+# 解析結果を CSV ファイルに出力する
 with open(outfile, "w") as fout:
 	fieldnames = [
 		'type',

--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -13,18 +13,9 @@ regMessage   = r'(?P<message>.+)$'
 regEx        = regLilePath + regLineNumer + r':' + regError + r':' + regMessage
 regFromTo    = r"from '(?P<source>[^']+)' to '(?P<dest>[^']+)'"
 
-
-def customsort(x, y):
-	if x['key'] < y['key']:
-		return 1
-	elif x['key'] > y['key']:
-		return -1
-	else:
-		return 0
-
 data = []
 with open(infile, "r") as fin:
-	print "open " + infile
+	print ("open " + infile)
 	for line in fin:
 		text = line.replace('\n','')
 		text = text.replace('\r','')
@@ -71,9 +62,10 @@ with open(infile, "r") as fin:
 			entry['key'] = ' '.join(temp)
 			data.append(entry)
 
-data = sorted(data, cmp=customsort)
+from operator import itemgetter
+data = sorted(data, key=itemgetter('key'))
 
-with open(outfile, "wb") as fout:
+with open(outfile, "w") as fout:
 	fieldnames = [
 		'type',
 		'code',
@@ -83,7 +75,7 @@ with open(outfile, "wb") as fout:
 		'lineNumber',
 		'message',
 	]
-	writer = csv.writer(fout)
+	writer = csv.writer(fout, lineterminator='\n')
 	writer.writerow(fieldnames)
 
 	for entry in data:
@@ -92,4 +84,4 @@ with open(outfile, "wb") as fout:
 			temp.append(entry[key])
 		writer.writerow(temp)
 
-	print "wrote " + outfile
+	print ("wrote " + outfile)

--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -4,6 +4,10 @@ import re
 import os
 import csv
 
+if len(sys.argv) < 2:
+	print ("usage: " + sys.argv[0] + " <logfile name>")
+	sys.exit(1)
+
 infile = sys.argv[1]
 outfile = infile + '.csv'
 

--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -8,7 +8,7 @@ outfile = infile + '.csv'
 
 regLilePath  = r'(?P<filePath>[a-zA-Z]:([^(]+))'
 regLineNumer = r'\((?P<lineNumber>\d+)\)'
-regError     = r'\s*(?P<type>\w+)\s*(?P<code>\w+)\s*'
+regError     = r'\s*(?P<type>\w+)\s+(?P<code>\w+)\s*'
 regMessage   = r'(?P<message>.+)$'
 regEx        = regLilePath + regLineNumer + r':' + regError + r':' + regMessage
 regFromTo    = r"from '(?P<source>[^']+)' to '(?P<dest>[^']+)'"

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -42,8 +42,9 @@ if "%ALPHA%" == "1" (
 	copy installer\warning-alpha.txt   %WORKDIR%\
 )
 copy installer\Output\*.exe  %WORKDIR_INST%\
-copy msbuild-%platform%-%configuration%.log %WORKDIR_LOG%\
-copy sakura_core\githash.h                  %WORKDIR_LOG%\
+copy msbuild-%platform%-%configuration%.log     %WORKDIR_LOG%\
+copy msbuild-%platform%-%configuration%.log.csv %WORKDIR_LOG%\
+copy sakura_core\githash.h                      %WORKDIR_LOG%\
 
 7z a %OUTFILE%  -r %WORKDIR%
 7z l %OUTFILE%


### PR DESCRIPTION
x64 のビルド警告を修正する準備のために発生している msbuild-x64-Release.log 等のログ中
の警告を csv にまとめる

ただし、一部の処理は 英語のメッセージを前提にしている。
(型に言及しているメッセージで `from` と `to` のメッセージを解析している)
