### PR TITLE
githash.h で定義されないマクロに対して代わりにコメントを出力する

### DIFF
--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -87,85 +87,87 @@ set GITHASH_H_TMP=%GITHASH_H%.tmp
 type nul                                  > %GITHASH_H_TMP%
 echo #pragma once                        >> %GITHASH_H_TMP%
 if "%COMMITID%" == "" (
-	type nul                                  >> %GITHASH_H_TMP%
+	echo // GIT_COMMIT_HASH is not defined    >> %GITHASH_H_TMP%
 ) else (
 	echo #define GIT_COMMIT_HASH "%COMMITID%" >> %GITHASH_H_TMP%
 )
 if "%SHORT_COMMITID%" == "" (
-	type nul                                              >> %GITHASH_H_TMP%
+	echo // GIT_SHORT_COMMIT_HASH is not defined          >> %GITHASH_H_TMP%
 ) else (
 	echo #define GIT_SHORT_COMMIT_HASH "%SHORT_COMMITID%" >> %GITHASH_H_TMP%
 )
 if "%GIT_URL%" == "" (
-	type nul                                              >> %GITHASH_H_TMP%
+	echo // GIT_URL is not defined                        >> %GITHASH_H_TMP%
 ) else (
 	echo #define GIT_URL "%GIT_URL%"                      >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_URL%" == "" (
-	type nul                                              >> %GITHASH_H_TMP%
+	echo // APPVEYOR_URL is not defined                   >> %GITHASH_H_TMP%
 ) else (
 	echo #define APPVEYOR_URL "%APPVEYOR_URL%"            >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_REPO_NAME%" == "" (
-	type nul                                                          >> %GITHASH_H_TMP%
+	echo // APPVEYOR_REPO_NAME is not defined                         >> %GITHASH_H_TMP%
 ) else (
 	echo #define APPVEYOR_REPO_NAME "%APPVEYOR_REPO_NAME%"            >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_ACCOUNT_NAME%" == "" (
-	type nul                                                          >> %GITHASH_H_TMP%
+	echo // APPVEYOR_ACCOUNT_NAME is not defined                      >> %GITHASH_H_TMP%
 ) else (
 	echo #define APPVEYOR_ACCOUNT_NAME "%APPVEYOR_ACCOUNT_NAME%"      >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_PROJECT_SLUG%" == "" (
-	type nul                                                          >> %GITHASH_H_TMP%
+	echo // APPVEYOR_PROJECT_SLUG is not defined                      >> %GITHASH_H_TMP%
 ) else (
 	echo #define APPVEYOR_PROJECT_SLUG "%APPVEYOR_PROJECT_SLUG%"      >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_BUILD_VERSION%" == "" (
-	type nul                                                          >> %GITHASH_H_TMP%
+	echo // APPVEYOR_BUILD_VERSION is not defined                     >> %GITHASH_H_TMP%
 ) else (
 	echo #define APPVEYOR_BUILD_VERSION "%APPVEYOR_BUILD_VERSION%"    >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_BUILD_NUMBER%" == "" (
-	type nul                                                          >> %GITHASH_H_TMP%
+	echo // APPVEYOR_BUILD_NUMBER     is not defined                      >> %GITHASH_H_TMP%
+	echo // APPVEYOR_BUILD_NUMBER_INT is not defined                      >> %GITHASH_H_TMP%
 ) else (
 	echo #define APPVEYOR_BUILD_NUMBER     "%APPVEYOR_BUILD_NUMBER%"      >> %GITHASH_H_TMP%
 	echo #define APPVEYOR_BUILD_NUMBER_INT  %APPVEYOR_BUILD_NUMBER%       >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" (
-	type nul                                                                            >> %GITHASH_H_TMP%
+	echo // APPVEYOR_PULL_REQUEST_NUMBER     is not defined                             >> %GITHASH_H_TMP%
+	echo // APPVEYOR_PULL_REQUEST_NUMBER_INT is not defined                             >> %GITHASH_H_TMP%
 ) else (
 	echo #define APPVEYOR_PULL_REQUEST_NUMBER     "%APPVEYOR_PULL_REQUEST_NUMBER%"      >> %GITHASH_H_TMP%
 	echo #define APPVEYOR_PULL_REQUEST_NUMBER_INT  %APPVEYOR_PULL_REQUEST_NUMBER%       >> %GITHASH_H_TMP%
 )
 
 if "%GITHUB_COMMIT_URL%" == "" (
-	type nul                                                          >> %GITHASH_H_TMP%
+	echo // GITHUB_COMMIT_URL is not defined                          >> %GITHASH_H_TMP%
 ) else (
 	echo #define GITHUB_COMMIT_URL             "%GITHUB_COMMIT_URL%"  >> %GITHASH_H_TMP%
 )
 
 if "%GITHUB_COMMIT_URL_PR_HEAD%" == "" (
-	type nul                                                                    >> %GITHASH_H_TMP%
+	echo // GITHUB_COMMIT_URL_PR_HEAD is not defined                            >> %GITHASH_H_TMP%
 ) else (
 	echo #define GITHUB_COMMIT_URL_PR_HEAD     "%GITHUB_COMMIT_URL_PR_HEAD%"    >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_SHORTHASH%" == "" (
-	type nul                                                                    >> %GITHASH_H_TMP%
+	echo // APPVEYOR_SHORTHASH is not defined                                   >> %GITHASH_H_TMP%
 ) else (
 	echo #define APPVEYOR_SHORTHASH             "%APPVEYOR_SHORTHASH%"          >> %GITHASH_H_TMP%
 )
 
 if "%APPVEYOR_SHORTHASH_PR_HEAD%" == "" (
-	type nul                                                                    >> %GITHASH_H_TMP%
+	echo // APPVEYOR_SHORTHASH_PR_HEAD is not defined                           >> %GITHASH_H_TMP%
 ) else (
 	echo #define APPVEYOR_SHORTHASH_PR_HEAD     "%APPVEYOR_SHORTHASH_PR_HEAD%"  >> %GITHASH_H_TMP%
 )
@@ -173,10 +175,11 @@ if "%APPVEYOR_SHORTHASH_PR_HEAD%" == "" (
 fc %GITHASH_H% %GITHASH_H_TMP% 1>nul 2>&1
 if "%ERRORLEVEL%" == "0" (
 	del %GITHASH_H_TMP%
+	@echo %GITHASH_H% was not updated.
 ) else (
 	if exist %GITHASH_H% del %GITHASH_H%
 	move /y %GITHASH_H_TMP% %GITHASH_H%
-	@echo %GITHASH_H% updated.
+	@echo %GITHASH_H% was updated.
 )
 
 ENDLOCAL


### PR DESCRIPTION
githash.h で定義されないマクロに対して代わりにコメントを出力する

- githash.h でビルド条件により定義されなかったマクロをコメントに出力する。
- githash.h が更新されたか、されなかったかのログも修正、追加する。(ついでに修正。別 PR にするほどでもないので含めました。)
