### PR TITLE
githash.h の末尾の空白を削除する

### DIFF
--- a/sakura/preBuild.bat
+++ b/sakura/preBuild.bat
@@ -172,6 +172,8 @@ if "%APPVEYOR_SHORTHASH_PR_HEAD%" == "" (
 	echo #define APPVEYOR_SHORTHASH_PR_HEAD     "%APPVEYOR_SHORTHASH_PR_HEAD%"  >> %GITHASH_H_TMP%
 )
 
+call removeTailSpace.bat %GITHASH_H_TMP%
+
 fc %GITHASH_H% %GITHASH_H_TMP% 1>nul 2>&1
 if "%ERRORLEVEL%" == "0" (
 	del %GITHASH_H_TMP%

--- a/sakura/removeTailSpace.bat
+++ b/sakura/removeTailSpace.bat
@@ -1,0 +1,19 @@
+@echo off
+
+set SED=C:\Program Files\Git\usr\bin\sed.exe
+set UNIX2DOS=C:\Program Files\Git\usr\bin\unix2dos.exe
+
+set TARGET=%1
+
+if exist "%SED%" (
+	@echo ---- removing tail spaces ----
+	"%SED%" --regexp-extended --in-place s/\s+$// "%TARGET%"
+)
+
+if exist "%UNIX2DOS%" (
+	@echo ---- converting EOL to DOS/Windows Format ----
+	"%UNIX2DOS%" "%TARGET%"
+)
+
+ENDLOCAL
+rem exit 0

--- a/sakura/removeTailSpace.bat
+++ b/sakura/removeTailSpace.bat
@@ -12,7 +12,7 @@ if exist "%SED%" (
 
 if exist "%UNIX2DOS%" (
 	@echo ---- converting EOL to DOS/Windows Format ----
-	"%UNIX2DOS%" "%TARGET%"
+	"%UNIX2DOS%" -q "%TARGET%"
 )
 
 ENDLOCAL


### PR DESCRIPTION
githash.h の末尾の空白を削除する

- sed で正規表現を使って末尾の空白を取り除く
- unix2dos で改行コードを UNIX 形式から DOS 形式に変換する
- 変換処理を行うバッチファイルは preBuild.bat などに合わせて lower camel Case にする。
 (https://ja.wikipedia.org/wiki/キャメルケース)
