### PR TITLE
ビルドログの解析スクリプトをリファクタリング

### DIFF
--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -4,113 +4,128 @@ import re
 import os
 import csv
 
-if len(sys.argv) < 2:
-	print ("usage: " + sys.argv[0] + " <logfile name>")
-	sys.exit(1)
+# 解析結果を格納するハッシュのキー
+keys = [
+	'type',
+	'code',
+	'source',
+	'dest',
+	'path',
+	'lineNumber',
+	'message',
+]
 
-infile = sys.argv[1]
-outfile = infile + '.csv'
+# 解析結果を CSV に出力するときのフィールド名
+fieldnames = [
+	'type',
+	'code',
+	'source',
+	'dest',
+	'path',
+	'lineNumber',
+	'message',
+]
 
-# ファイル名に対する正規表現: 例 c:\hogehoge\hoge.c
-regLilePath  = r'(?P<filePath>[a-zA-Z]:([^(]+))'
+# infile: msbuild のビルドログ・ファイル名
+# 戻り値: ログの解析結果が入ったハッシュの配列
+def parse_buildlog(infile):
+	# ファイル名に対する正規表現: 例 c:\hogehoge\hoge.c
+	regLilePath  = r'(?P<filePath>[a-zA-Z]:([^(]+))'
 
-# 行番号に対する正規表現: 例 (100)
-regLineNumer = r'\((?P<lineNumber>\d+)\)'
+	# 行番号に対する正規表現: 例 (100)
+	regLineNumer = r'\((?P<lineNumber>\d+)\)'
 
-# エラーコードに対する正規表現: 例 warning C4267
-regError     = r'\s*(?P<type>\w+)\s+(?P<code>\w+)\s*'
+	# エラーコードに対する正規表現: 例 warning C4267
+	regError     = r'\s*(?P<type>\w+)\s+(?P<code>\w+)\s*'
 
-# エラーメッセージ: 例 'argument': conversion from 'size_t' to 'int', possible loss of data [C:\projects\sakura\sakura\sakura.vcxproj]
-regMessage   = r'(?P<message>.+)$'
+	# エラーメッセージ: 例 'argument': conversion from 'size_t' to 'int', possible loss of data [C:\projects\sakura\sakura\sakura.vcxproj]
+	regMessage   = r'(?P<message>.+)$'
 
-# 解析対象の正規表現
-# 例
-#   c:\projects\sakura\sakura_core\basis\cmystring.h(39): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [C:\projects\sakura\sakura\sakura.vcxproj]
-regEx        = regLilePath + regLineNumer + r':' + regError + r':' + regMessage
+	# 解析対象の正規表現
+	# 例
+	#   c:\projects\sakura\sakura_core\basis\cmystring.h(39): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [C:\projects\sakura\sakura\sakura.vcxproj]
+	regEx        = regLilePath + regLineNumer + r':' + regError + r':' + regMessage
 
-# 型変換に対する警告メッセージ部分に対する正規表現: 例 'size_t' to 'int'
-regFromTo    = r"from '(?P<source>[^']+)' to '(?P<dest>[^']+)'"
+	# 型変換に対する警告メッセージ部分に対する正規表現: 例 'size_t' to 'int'
+	regFromTo    = r"from '(?P<source>[^']+)' to '(?P<dest>[^']+)'"
 
-data = []
-with open(infile, "r") as fin:
-	print ("open " + infile)
-	for line in fin:
-		text = line.replace('\n','')
-		text = text.replace('\r','')
+	data = []
+	with open(infile, "r") as fin:
+		# msbuild-xxx-xxx.log のログに警告が重複して出現することに対する Workaround 用
+		duplicateCheck = {}
 
-		match = re.search(regEx, text)
-		if match:
-			path       = match.group('filePath')
-			lineNumber = match.group('lineNumber')
-			type       = match.group('type')
-			code       = match.group('code')
-			message    = match.group('message')
+		print ("open " + infile)
+		for line in fin:
+			text = line.replace('\n','')
+			text = text.replace('\r','')
 
-			entry = {}
-			entry['type'] = type
-			entry['code'] = code
+			match = re.search(regEx, text)
+			if match:
+				path       = match.group('filePath')
+				lineNumber = match.group('lineNumber')
+				type       = match.group('type')
+				code       = match.group('code')
+				message    = match.group('message')
 
-			match2 = re.search(regFromTo, text)
-			if match2:
-				source  = match2.group('source')
-				dest    = match2.group('dest')
-				entry['source'] = source
-				entry['dest']   = dest
-			else:
-				entry['source'] = r''
-				entry['dest']   = r''
+				entry = {}
+				entry['type'] = type
+				entry['code'] = code
 
-			entry['path']       = path
-			entry['lineNumber'] = lineNumber
-			entry['message']    = message
+				match2 = re.search(regFromTo, text)
+				if match2:
+					source  = match2.group('source')
+					dest    = match2.group('dest')
+					entry['source'] = source
+					entry['dest']   = dest
+				else:
+					entry['source'] = r''
+					entry['dest']   = r''
 
-			keys = [
-				'type',
-				'code',
-				'source',
-				'dest',
-				'path',
-				'lineNumber',
-				'message',
-			]
+				entry['path']       = path
+				entry['lineNumber'] = lineNumber
+				entry['message']    = message
 
-			temp = []
-			for key in keys:
-				temp.append(entry[key])
-			entry['key'] = ' '.join(temp)
-			data.append(entry)
+				temp = []
+				for key in keys:
+					temp.append(entry[key])
+				entry['key'] = ' '.join(temp)
 
-# ソート対象のハッシュ配列で 'key' というキーを元にソートする。
-from operator import itemgetter
-data = sorted(data, key=itemgetter('key'))
+				# msbuild-xxx-xxx.log のログに同じ警告が重複して出現することに対する Workaround
+				# entry['key'] で警告を一意に識別できるので同じ値の場合に CSV に出力しない
+				logKey = entry['key']
+				duplicateCheck[logKey] = duplicateCheck.get(logKey, 0) + 1
+				if duplicateCheck[logKey] == 1:
+					data.append(entry)
 
-# 解析結果を CSV ファイルに出力する
-with open(outfile, "w") as fout:
-	fieldnames = [
-		'type',
-		'code',
-		'source',
-		'dest',
-		'path',
-		'lineNumber',
-		'message',
-	]
-	writer = csv.writer(fout, lineterminator='\n')
-	writer.writerow(fieldnames)
+	# ソート対象のハッシュ配列で 'key' というキーを元にソートする。
+	from operator import itemgetter
+	data = sorted(data, key=itemgetter('key'))
 
-	# msbuild-xxx-xxx.log のログに警告が重複して出現することに対する Workaround 用
-	duplicateCheck = {}
+	return data
 
-	for entry in data:
-		# msbuild-xxx-xxx.log のログに同じ警告が重複して出現することに対する Workaround
-		# entry['key'] で警告を一意に識別できるので同じ値の場合に CSV に出力しない
-		logKey = entry['key']
-		duplicateCheck[logKey] = duplicateCheck.get(logKey, 0) + 1
+# outfile: 出力ファイル名
+# data   : ログの解析結果が入ったハッシュの配列 ( parse_buildlog() の戻り値 )
+def writeToCSV(outfile, data):
+	# 解析結果を CSV ファイルに出力する
+	with open(outfile, "w") as fout:
+		writer = csv.writer(fout, lineterminator='\n')
+		writer.writerow(fieldnames)
 
-		if duplicateCheck[logKey] == 1:
+		for entry in data:
 			temp = []
 			for key in keys:
 				temp.append(entry[key])
 			writer.writerow(temp)
 
-	print ("wrote " + outfile)
+		print ("wrote " + outfile)
+
+if __name__ == '__main__':
+	if len(sys.argv) < 2:
+		print ("usage: " + sys.argv[0] + " <logfile name>")
+		sys.exit(1)
+
+	infile = sys.argv[1]
+	outcsvfile = infile + '.csv'
+
+	data = parse_buildlog(infile)
+	writeToCSV(outcsvfile, data)

--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -15,17 +15,6 @@ logHashKeys = [
 	'message',
 ]
 
-# 解析結果を CSV に出力するときのフィールド名
-fieldnames = [
-	'type',
-	'code',
-	'source',
-	'dest',
-	'path',
-	'lineNumber',
-	'message',
-]
-
 # infile: msbuild のビルドログ・ファイル名
 # 戻り値: ログの解析結果が入ったハッシュの配列
 def parse_buildlog(infile):
@@ -109,7 +98,7 @@ def writeToCSV(outfile, data):
 	# 解析結果を CSV ファイルに出力する
 	with open(outfile, "w") as fout:
 		writer = csv.writer(fout, lineterminator='\n')
-		writer.writerow(fieldnames)
+		writer.writerow(logHashKeys)
 
 		for entry in data:
 			temp = []

--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -26,19 +26,6 @@ fieldnames = [
 	'message',
 ]
 
-# main 関数
-def main():
-	if len(sys.argv) < 2:
-		print ("usage: " + sys.argv[0] + " <logfile name>")
-		sys.exit(1)
-
-	infile = sys.argv[1]
-	outcsvfile = infile + '.csv'
-
-	data = parse_buildlog(infile)
-	writeToCSV(outcsvfile, data)
-
-
 # infile: msbuild のビルドログ・ファイル名
 # 戻り値: ログの解析結果が入ったハッシュの配列
 def parse_buildlog(infile):
@@ -131,6 +118,18 @@ def writeToCSV(outfile, data):
 			writer.writerow(temp)
 
 		print ("wrote " + outfile)
+
+# main 関数
+def main():
+	if len(sys.argv) < 2:
+		print ("usage: " + sys.argv[0] + " <logfile name>")
+		sys.exit(1)
+
+	infile = sys.argv[1]
+	outcsvfile = infile + '.csv'
+
+	data = parse_buildlog(infile)
+	writeToCSV(outcsvfile, data)
 
 if __name__ == '__main__':
 	main()

--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -5,7 +5,7 @@ import os
 import csv
 
 # 解析結果を格納するハッシュのキー
-keys = [
+logHashKeys = [
 	'type',
 	'code',
 	'source',
@@ -86,7 +86,7 @@ def parse_buildlog(infile):
 				entry['message']    = message
 
 				temp = []
-				for key in keys:
+				for key in logHashKeys:
 					temp.append(entry[key])
 				entry['key'] = ' '.join(temp)
 
@@ -113,7 +113,7 @@ def writeToCSV(outfile, data):
 
 		for entry in data:
 			temp = []
-			for key in keys:
+			for key in logHashKeys:
 				temp.append(entry[key])
 			writer.writerow(temp)
 

--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -26,6 +26,19 @@ fieldnames = [
 	'message',
 ]
 
+# main 関数
+def main():
+	if len(sys.argv) < 2:
+		print ("usage: " + sys.argv[0] + " <logfile name>")
+		sys.exit(1)
+
+	infile = sys.argv[1]
+	outcsvfile = infile + '.csv'
+
+	data = parse_buildlog(infile)
+	writeToCSV(outcsvfile, data)
+
+
 # infile: msbuild のビルドログ・ファイル名
 # 戻り値: ログの解析結果が入ったハッシュの配列
 def parse_buildlog(infile):
@@ -120,12 +133,4 @@ def writeToCSV(outfile, data):
 		print ("wrote " + outfile)
 
 if __name__ == '__main__':
-	if len(sys.argv) < 2:
-		print ("usage: " + sys.argv[0] + " <logfile name>")
-		sys.exit(1)
-
-	infile = sys.argv[1]
-	outcsvfile = infile + '.csv'
-
-	data = parse_buildlog(infile)
-	writeToCSV(outcsvfile, data)
+	main()


### PR DESCRIPTION
ビルドログの解析スクリプトをリファクタリング

- 関数に分かれていなかったのでメンテしにくかった。
- 関数に分けてメンテしやすくする。
- データの重複チェックはデータの解析時に行う。

※ WinMerge で空白を無視する設定にして比較するとレビューしやすいです。

