### PR TITLE
ログを別の ZIP に artifacts として含める

### DIFF
--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -89,6 +89,7 @@ set WORKDIR_LOG=%WORKDIR%\Log
 set WORKDIR_EXE=%WORKDIR%\EXE
 set WORKDIR_INST=%WORKDIR%\Installer
 set OUTFILE=%BASENAME%.zip
+set OUTFILE_LOG=%BASENAME%-Log.zip
 
 @rem cleanup for local testing
 if exist "%OUTFILE%" (
@@ -129,6 +130,9 @@ if exist "%HASHFILE%" (
 )
 7z a %OUTFILE%  -r %WORKDIR%
 7z l %OUTFILE%
+
+7z a %OUTFILE_LOG%  -r %WORKDIR_LOG%
+7z l %OUTFILE_LOG%
 
 if exist "%WORKDIR%" (
 	rmdir /s /q %WORKDIR%

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -95,6 +95,9 @@ set OUTFILE_LOG=%BASENAME%-Log.zip
 if exist "%OUTFILE%" (
 	del %OUTFILE%
 )
+if exist "%OUTFILE_LOG%" (
+	del %OUTFILE_LOG%
+)
 if exist "%WORKDIR%" (
 	rmdir /s /q %WORKDIR%
 )


### PR DESCRIPTION
ログを別の ZIP に artifacts として含める

EXE やインストーラではなく githash.h やログファイルだけをチェックしたい場合に
フルセットのダウンロードは時間がかかるので LOG ディレクトリだけを圧縮したものを
artifacts に含める。

### メモ

EXE やインストーラで使用してるフォルダ構造のまま圧縮しているので
少し無駄に階層構造がありますが、フラットな構造で圧縮することも可能です。
