### PR TITLE
artifacts の名前に appveyor の名前を含める (構成要素の順序調整)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,4 +21,4 @@ build_script:
     echo appveyor_yml
 
 artifacts:
-- path: '*sakura-*$(platform)-$(configuration)*.zip'
+- path: 'sakura-*$(platform)-$(configuration)*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,4 +21,4 @@ build_script:
     echo appveyor_yml
 
 artifacts:
-- path: 'sakura-$(platform)-$(configuration)*.zip'
+- path: '*sakura-*$(platform)-$(configuration)*.zip'

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -10,6 +10,16 @@ if "%platform%" == "x64" (
 @rem ----------------------------------------------------------------
 @rem prepare environment variable
 @rem ----------------------------------------------------------------
+@echo checking APPVEYOR_ACCOUNT_NAME %APPVEYOR_ACCOUNT_NAME%
+set PREFIX=
+if "%APPVEYOR_ACCOUNT_NAME%" == "sakuraeditor" (
+	set PREFIX=
+) else if "%APPVEYOR_ACCOUNT_NAME%" == "" (
+	set PREFIX=
+) else (
+	set PREFIX=%APPVEYOR_ACCOUNT_NAME%-
+)
+
 @echo checking APPVEYOR_BUILD_NUMBER %APPVEYOR_BUILD_NUMBER%
 if not "%APPVEYOR_BUILD_NUMBER%" == "" (
 	set BUILD_NUMBER=build%APPVEYOR_BUILD_NUMBER%
@@ -43,7 +53,7 @@ if "%ALPHA%" == "1" (
 @rem ----------------------------------------------------------------
 @rem build BASENAME
 @rem ----------------------------------------------------------------
-set BASENAME=sakura
+set BASENAME=%PREFIX%sakura
 
 @echo adding platform and configuration
 set BASENAME=%BASENAME%-%platform%-%configuration%

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -97,6 +97,18 @@ if not "%RELEASE_PHASE%" == "" (
 )
 @echo BASENAME = %BASENAME%
 
+@rem ---------------------- BASENAME ---------------------------------
+@rem "sakura"
+@rem BUILD_ACCOUNT: (option) APPVEYOR_ACCOUNT_NAME
+@rem TAG_NAME     : (option) tag Name
+@rem PR_NAME      : (option) PRxxx (xxx is a PR number)
+@rem BUILD_NUMBER : (option) buildYYY or "buildLocal" (YYY is build number)
+@rem SHORTHASH    : (option) hash or "buildLocal" (hash is leading 8 charactors)
+@rem platform     : Platform ("Win32" or "x64")
+@rem configuration: Configuration ("Debug" or "Release")
+@rem RELEASE_PHASE: (option) "alpha" (x64 build only)
+@rem ----------------------------------------------------------------
+
 @echo on
 
 @rem ----------------------------------------------------------------

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -55,10 +55,6 @@ if "%ALPHA%" == "1" (
 @rem ----------------------------------------------------------------
 set BASENAME=%PREFIX%sakura
 
-@echo adding platform and configuration
-set BASENAME=%BASENAME%-%platform%-%configuration%
-@echo BASENAME = %BASENAME%
-
 @echo adding TAG_NAME
 if not "%TAG_NAME%" == "" (
 	set BASENAME=%BASENAME%-%TAG_NAME%
@@ -81,6 +77,10 @@ if not "%BUILD_NUMBER%" == "" (
 if not "%SHORTHASH%" == "" (
 	set BASENAME=%BASENAME%-%SHORTHASH%
 )
+@echo BASENAME = %BASENAME%
+
+@echo adding platform and configuration
+set BASENAME=%BASENAME%-%platform%-%configuration%
 @echo BASENAME = %BASENAME%
 
 @echo adding RELEASE_PHASE

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -11,18 +11,20 @@ if "%platform%" == "x64" (
 @rem prepare environment variable
 @rem ----------------------------------------------------------------
 @echo checking APPVEYOR_ACCOUNT_NAME %APPVEYOR_ACCOUNT_NAME%
-set PREFIX=
+set BUILD_ACCOUNT=
 if "%APPVEYOR_ACCOUNT_NAME%" == "sakuraeditor" (
-	set PREFIX=
+	set BUILD_ACCOUNT=
 ) else if "%APPVEYOR_ACCOUNT_NAME%" == "" (
-	set PREFIX=
+	set BUILD_ACCOUNT=
 ) else (
-	set PREFIX=%APPVEYOR_ACCOUNT_NAME%-
+	set BUILD_ACCOUNT=%APPVEYOR_ACCOUNT_NAME%
 )
 
 @echo checking APPVEYOR_BUILD_NUMBER %APPVEYOR_BUILD_NUMBER%
 if not "%APPVEYOR_BUILD_NUMBER%" == "" (
 	set BUILD_NUMBER=build%APPVEYOR_BUILD_NUMBER%
+) else (
+	set BUILD_NUMBER=buildLocal
 )
 
 @echo checking APPVEYOR_REPO_TAG_NAME %APPVEYOR_REPO_TAG_NAME%
@@ -53,7 +55,13 @@ if "%ALPHA%" == "1" (
 @rem ----------------------------------------------------------------
 @rem build BASENAME
 @rem ----------------------------------------------------------------
-set BASENAME=%PREFIX%sakura
+set BASENAME=sakura
+
+@echo adding BUILD_ACCOUNT
+if not "%BUILD_ACCOUNT%" == "" (
+	set BASENAME=%BASENAME%-%BUILD_ACCOUNT%
+)
+@echo BASENAME = %BASENAME%
 
 @echo adding TAG_NAME
 if not "%TAG_NAME%" == "" (


### PR DESCRIPTION
artifacts の名前に appveyor の名前を含める (構成要素の順序調整)

### 以下の表の順番で構成する。

| 構成要素     | 意味                   |元の変数名                  |必須                                  |
----           |----                    |----                        |----
|"sakara"      |prefix                  |なし                        |○                                    |
|BUILD_ACCOUNT |appveyor アカウント名   |APPVEYOR_ACCOUNT_NAME       |×  "sakuraeditor" の場合 またはローカルビルドの場合、なし                                  |
|TAG_NAME      |tag 名                  |APPVEYOR_REPO_TAG_NAME      |×                                    |
|PR_NAME       |PR 番号                 |APPVEYOR_PULL_REQUEST_NUMBER|×                                    |
|BUILD_NUMBER  |build Number            |APPVEYOR_BUILD_NUMBER       |○ (ローカルビルドの場合 "buildLocal")|
|SHORTHASH     |hash 値の先頭8文字      |APPVEYOR_REPO_COMMIT        |×                                    |
|platform      |CPU platform            |platform                    |○                                    |
|configuration |configuration           |configuration               |○                                    |
|RELEASE_PHASE |alpha バージョンかどうか|ALPHA                       |× (x64 のみ)                         |

### 影響範囲

- artifacts の zip ファイル名
- artifacts の zip ファイルの内部フォルダの名前


