### PR TITLE
Windows APIのエラーメッセージ取得処理の簡易化

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -554,6 +554,7 @@
     <ClInclude Include="..\sakura_core\_os\CClipboard.h" />
     <ClInclude Include="..\sakura_core\_os\CDropTarget.h" />
     <ClInclude Include="..\sakura_core\_os\COsVersionInfo.h" />
+    <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h" />
     <ClInclude Include="..\sakura_core\_os\OleTypes.h" />
   </ItemGroup>
   <ItemGroup>

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1088,6 +1088,9 @@
     <ClInclude Include="..\sakura_core\version.h">
       <Filter>Other Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\_os\getMessageFromSystem.h">
+      <Filter>Cpp Source Files\_os</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\sakura_core\Funccode_x.hsrc">

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -50,6 +50,7 @@
 #include "recent/CMRUFile.h"
 #include "recent/CMRUFolder.h"
 #include "_main/CCommandLine.h"
+#include "_os/getMessageFromSystem.h"
 #include "sakura_rc.h"
 
 #define IDT_EDITCHECK 2
@@ -1254,24 +1255,13 @@ bool CControlTray::OpenNewEditor(
 	);
 	if( !bCreateResult ){
 		//	失敗
-		TCHAR* pMsg;
-		FormatMessage( FORMAT_MESSAGE_ALLOCATE_BUFFER |
-						FORMAT_MESSAGE_IGNORE_INSERTS |
-						FORMAT_MESSAGE_FROM_SYSTEM,
-						NULL,
-						GetLastError(),
-						MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-						(LPTSTR)&pMsg,
-						0,
-						NULL
-		);
+		std::wstring msg(_os::getMessageFromSystem(::GetLastError()));
 		ErrorMessage(
 			hWndParent,
 			LS(STR_TRAY_CREATEPROC1),
 			szEXE,
-			pMsg
+			msg.c_str()
 		);
-		::LocalFree( (HLOCAL)pMsg );	//	エラーメッセージバッファを解放
 		return false;
 	}
 

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -1256,12 +1256,8 @@ bool CControlTray::OpenNewEditor(
 	if( !bCreateResult ){
 		//	失敗
 		std::wstring msg(_os::getMessageFromSystem(::GetLastError()));
-		ErrorMessage(
-			hWndParent,
-			LS(STR_TRAY_CREATEPROC1),
-			szEXE,
-			msg.c_str()
-		);
+		//"'%ts'\nプロセスの起動に失敗しました。\n%ts"
+		ErrorMessage(hWndParent,LS(STR_TRAY_CREATEPROC1),szEXE,msg.c_str());
 		return false;
 	}
 

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -29,6 +29,8 @@
 #include <io.h>
 #include <tchar.h>
 
+#include "_os\getMessageFromSystem.h"
+
 class CProcess;
 
 
@@ -217,6 +219,7 @@ bool CProcessFactory::IsExistControlProcess()
 	return false;	// コントロールプロセスは存在していないか、まだ CreateMutex() してない
 }
 
+
 //	From Here Aug. 28, 2001 genta
 /*!
 	@brief コントロールプロセスを起動する
@@ -275,19 +278,8 @@ bool CProcessFactory::StartControlProcess()
 	);
 	if( !bCreateResult ){
 		//	失敗
-		TCHAR* pMsg;
-		::FormatMessage( FORMAT_MESSAGE_ALLOCATE_BUFFER |
-						FORMAT_MESSAGE_IGNORE_INSERTS |
-						FORMAT_MESSAGE_FROM_SYSTEM,
-						NULL,
-						::GetLastError(),
-						MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-						(LPTSTR)&pMsg,
-						0,
-						NULL
-		);
-		ErrorMessage( NULL, _T("\'%ts\'\nプロセスの起動に失敗しました。\n%ts"), szEXE, pMsg );
-		::LocalFree( (HLOCAL)pMsg );	//	エラーメッセージバッファを解放
+		std::wstring msg(getMessageFromSystem(::GetLastError()));
+		ErrorMessage( NULL, _T("\'%ts\'\nプロセスの起動に失敗しました。\n%ts"), szEXE, msg.c_str() );
 		return false;
 	}
 

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -23,13 +23,13 @@
 #include "CCommandLine.h"
 #include "CControlTray.h"
 #include "_os/COsVersionInfo.h"
+#include "_os/getMessageFromSystem.h"
 #include "dlg/CDlgProfileMgr.h"
 #include "debug/CRunningTimer.h"
 #include "util/os.h"
 #include <io.h>
 #include <tchar.h>
 
-#include "_os\getMessageFromSystem.h"
 
 class CProcess;
 
@@ -278,7 +278,7 @@ bool CProcessFactory::StartControlProcess()
 	);
 	if( !bCreateResult ){
 		//	失敗
-		std::wstring msg(getMessageFromSystem(::GetLastError()));
+		std::wstring msg(_os::getMessageFromSystem(::GetLastError()));
 		ErrorMessage( NULL, _T("\'%ts\'\nプロセスの起動に失敗しました。\n%ts"), szEXE, msg.c_str() );
 		return false;
 	}

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -279,7 +279,8 @@ bool CProcessFactory::StartControlProcess()
 	if( !bCreateResult ){
 		//	失敗
 		std::wstring msg(_os::getMessageFromSystem(::GetLastError()));
-		ErrorMessage( NULL, _T("\'%ts\'\nプロセスの起動に失敗しました。\n%ts"), szEXE, msg.c_str() );
+		//"'%ts'\nプロセスの起動に失敗しました。\n%ts"
+		ErrorMessage( NULL, LS(STR_ERR_DLGPROCFACT3), szEXE, msg.c_str() );
 		return false;
 	}
 

--- a/sakura_core/_os/getMessageFromSystem.h
+++ b/sakura_core/_os/getMessageFromSystem.h
@@ -1,0 +1,81 @@
+/*
+  Copyright (C) 2018, Sakura Editor Organization
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Sakura Editor Organization
+    https://sakura-editor.github.io/ 
+
+ */
+
+#pragma once
+
+#ifndef _STRING_
+#error Need to include string before getMessageFromSystem.h
+#endif  /* _STRING_ */
+
+#if !defined(_WINBASE_) || !defined(_WINNT_)
+#error Need to include windows.h before getMessageFromSystem.h
+#endif  /* !defined(_WINBASE_) || !defined(_WINNT_) */
+
+
+//名前空間
+namespace sakura {
+	namespace _os {
+
+
+/*!
+ * @brief システムメッセージを取得する
+ *
+ * @param [in]		dwMessageCode	メッセージコード。
+ *									::GetLastError()の戻り値を指定する。
+ * @param [in,opt]	dwLanguageId	言語識別子。
+ *									省略した場合、::FormatMessage()の挙動に準ずる。
+ * @retval msg						システムメッセージ。
+ *									該当するメッセージがない場合、空文字列を返す。
+ * @sa https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-formatmessage
+ * @date 2018/06/25 berryzplus		新規作成
+ */
+inline
+std::wstring getMessageFromSystem(
+	_In_ DWORD dwMessageCode,
+	_In_opt_ DWORD dwLanguageId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT)
+)
+{
+	HLOCAL pMsg = NULL;
+	DWORD length = ::FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM
+		| FORMAT_MESSAGE_ALLOCATE_BUFFER
+		| FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL,
+		dwMessageCode,
+		dwLanguageId,
+		(LPWSTR)&pMsg,
+		0,
+		NULL
+	);
+	std::wstring msg((LPCWSTR)pMsg, length);
+	::LocalFree(pMsg);
+	return std::move(msg);
+}
+
+
+	}; // end of namespace _os
+}; // end of namespace sakura
+
+
+//名前空間を意識せずに扱えるようにusingしておく。
+using sakura::_os::getMessageFromSystem;

--- a/sakura_core/_os/getMessageFromSystem.h
+++ b/sakura_core/_os/getMessageFromSystem.h
@@ -33,18 +33,19 @@
 #endif  /* !defined(_WINBASE_) || !defined(_WINNT_) */
 
 
-//名前空間
-namespace sakura {
-	namespace _os {
+namespace _os {
 
 
 /*!
  * @brief システムメッセージを取得する
  *
+ *		Windows API呼出失敗時の定型処理を抽出したもの。
+ *
  * @param [in]		dwMessageCode	メッセージコード。
  *									::GetLastError()の戻り値を指定する。
  * @param [in,opt]	dwLanguageId	言語識別子。
- *									省略した場合、::FormatMessage()の挙動に準ずる。
+ *									省略した場合、ニュートラル言語。
+ *									詳細は::FormatMessage()のマニュアルを参照。
  * @retval msg						システムメッセージ。
  *									該当するメッセージがない場合、空文字列を返す。
  * @sa https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-formatmessage
@@ -73,9 +74,4 @@ std::wstring getMessageFromSystem(
 }
 
 
-	}; // end of namespace _os
-}; // end of namespace sakura
-
-
-//名前空間を意識せずに扱えるようにusingしておく。
-using sakura::_os::getMessageFromSystem;
+}; // end of namespace _os

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -43,6 +43,7 @@
 #include "env/DLLSHAREDATA.h"
 #include "env/CDocTypeManager.h"
 #include "CEditApp.h"
+#include "_os/getMessageFromSystem.h"
 #include "util/shell.h"
 #include "sakura_rc.h"
 
@@ -293,25 +294,13 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 
 	nRet = MyPropertySheet( &psh );	// 2007.05.24 ryoji 独自拡張プロパティシート
 	if( -1 == nRet ){
-		TCHAR*	pszMsgBuf;
-		::FormatMessage(
-			FORMAT_MESSAGE_ALLOCATE_BUFFER |
-			FORMAT_MESSAGE_FROM_SYSTEM |
-			FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL,
-			::GetLastError(),
-			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// デフォルト言語
-			(LPTSTR)&pszMsgBuf,
-			0,
-			NULL
-		);
+		std::wstring msg(_os::getMessageFromSystem(::GetLastError()));
 		PleaseReportToAuthor(
 			NULL,
 			LS(STR_ERR_DLGPROPCOMMON24),
 			psh.nStartPage,
-			pszMsgBuf
+			msg.c_str()
 		);
-		::LocalFree( pszMsgBuf );
 	}
 
 	return nRet;

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -295,12 +295,8 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 	nRet = MyPropertySheet( &psh );	// 2007.05.24 ryoji 独自拡張プロパティシート
 	if( -1 == nRet ){
 		std::wstring msg(_os::getMessageFromSystem(::GetLastError()));
-		PleaseReportToAuthor(
-			NULL,
-			LS(STR_ERR_DLGPROPCOMMON24),
-			psh.nStartPage,
-			msg.c_str()
-		);
+		//"CPropCommon::DoPropertySheet()内でエラーが出ました。\npsh.nStartPage=[%d]\n::PropertySheet()失敗\n\n%ts\n"
+		PleaseReportToAuthor(NULL, LS(STR_ERR_DLGPROPCOMMON24), psh.nStartPage, msg.c_str());
 	}
 
 	return nRet;

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -204,12 +204,8 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 
 	if( -1 == nRet ){
 		std::wstring msg(_os::getMessageFromSystem(::GetLastError()));
-		PleaseReportToAuthor(
-			NULL,
-			LS(STR_PROPTYPE_ERR),
-			psh.nStartPage,
-			msg.c_str()
-		);
+		//"CPropTypes::DoPropertySheet()内でエラーが出ました。\npsh.nStartPage=[%d]\n::PropertySheet()失敗。\n\n%ts\n"
+		PleaseReportToAuthor(NULL, LS(STR_PROPTYPE_ERR), psh.nStartPage, msg.c_str());
 	}
 
 	// カスタム色を共有メモリに設定

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -24,6 +24,7 @@
 #include "StdAfx.h"
 #include "CPropTypes.h"
 #include "CEditApp.h"
+#include "_os/getMessageFromSystem.h"
 #include "view/colors/EColorIndexType.h"
 #include "util/shell.h"
 #include "sakura_rc.h"
@@ -202,25 +203,13 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 	nRet = MyPropertySheet( &psh );	// 2007.05.24 ryoji 独自拡張プロパティシート
 
 	if( -1 == nRet ){
-		TCHAR*	pszMsgBuf;
-		::FormatMessage(
-			FORMAT_MESSAGE_ALLOCATE_BUFFER |
-			FORMAT_MESSAGE_FROM_SYSTEM |
-			FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL,
-			::GetLastError(),
-			MAKELANGID( LANG_NEUTRAL, SUBLANG_DEFAULT ), // デフォルト言語
-			(LPTSTR)&pszMsgBuf,
-			0,
-			NULL
-		);
+		std::wstring msg(_os::getMessageFromSystem(::GetLastError()));
 		PleaseReportToAuthor(
 			NULL,
 			LS(STR_PROPTYPE_ERR),
 			psh.nStartPage,
-			pszMsgBuf
+			msg.c_str()
 		);
-		::LocalFree( pszMsgBuf );
 	}
 
 	// カスタム色を共有メモリに設定


### PR DESCRIPTION
### 目的

Windowsからメッセージを取得する部分を抽出して関数化し、エラー処理が必要な箇所に簡単に埋め込めるようにします。

### 説明

Windows APIの多くは、失敗時に::GetLastError()でエラー原因を確認できるように作られています。
::GetLastError()の戻り値からメッセージを取得する手順は定型処理（≒簡単）ですが、利用する関数::FormatMessage()のパラメータが非常に多いことと、取得したメッセージ（メモリ）に後始末が必要なことからサクラエディタのソースコードではあまり使われていません。

このPull Requestでは、既存コードにあるメッセージ取得処理を抽出して新規関数を作ります。
