### PR TITLE
CGrepAgent::DoGrep のローカル変数初期化漏れ修正

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -231,7 +231,7 @@ DWORD CGrepAgent::DoGrep(
 		if( bGrepPaste ){
 			// 矩形・ラインモード貼り付けは未サポート
 			bool bColmnSelect;
-			bool bLineSelect;
+			bool bLineSelect = false;
 			if( !pcViewDst->MyGetClipboardData( cmemReplace, &bColmnSelect, GetDllShareData().m_Common.m_sEdit.m_bEnableLineModePaste? &bLineSelect: NULL ) ){
 				this->m_bGrepRunning = false;
 				pcViewDst->m_bDoing_UndoRedo = false;


### PR DESCRIPTION
#225 の発端となった初期化漏れの修正です．
「ラインモード貼付けを可能にする」off 時は bLineSelect = false であるべきなので，そのように初期化．

ちなみ初期化の方法は↓に合わせています．
(どちらも，ダイアログボックスのテキストボックスにクリップボードのデータを貼り付ける動作)
https://github.com/sakura-editor/sakura/blob/5da646982cda754f0b3f45810ebf43609afeb056/sakura_core/cmd/CViewCommander_Search.cpp#L868-L875