### PR TITLE
msbuild のログファイルの解析結果を excel ファイルに変換して artifacts に含める

### DIFF
--- a/parse-buildlog.bat
+++ b/parse-buildlog.bat
@@ -1,4 +1,14 @@
 @echo off
+
+@rem -------------------------------------------------------
+@rem install openpyxl module on appveyor
+@rem -------------------------------------------------------
+if "%APPVEYOR%" == "True" (
+	call :openpyxl_install
+) else (
+	@echo skip 'pip install openpyxl --user'
+)
+
 where python --version 1>nul 2>&1
 if not "%ERRORLEVEL%" == "0" (
 	@echo NOTE: No python command
@@ -7,3 +17,15 @@ if not "%ERRORLEVEL%" == "0" (
 )
 @echo on
 exit /b %ERRORLEVEL%
+
+
+:openpyxl_install
+
+where pip 1>nul 2>&1
+if not "%ERRORLEVEL%" == "0" (
+	@echo NOTE: No pip command
+) else (
+	@echo NOTE: found pip command
+	pip install openpyxl --user
+)
+exit /b

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -151,6 +151,9 @@ if "%ALPHA%" == "1" (
 copy installer\Output\*.exe  %WORKDIR_INST%\
 copy msbuild-%platform%-%configuration%.log     %WORKDIR_LOG%\
 copy msbuild-%platform%-%configuration%.log.csv %WORKDIR_LOG%\
+if exist "msbuild-%platform%-%configuration%.log.xlsx" (
+	copy "msbuild-%platform%-%configuration%.log.xlsx" %WORKDIR_LOG%\
+)
 copy sakura_core\githash.h                      %WORKDIR_LOG%\
 
 set HASHFILE=sha256.txt


### PR DESCRIPTION
msbuild のログファイルの解析結果を excel ファイルに変換して artifacts に含める

openpyxl を利用するので appveyor 環境の場合、事前に以下を実行する。

`pip install openpyxl --user
`

### メモ

将来的に excel ファイル内に hyperlink を設定してエラーがー発生しているソースコードの行に
対して GitHub への permanent link を設定する予定です。


