### PR TITLE
appveyor の 初期化処理での sleep を 5 秒から 10 秒に伸ばす (AppVeyorのジョブが途中で止まる問題への workaround)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@ version: 1.0.{build}
 image: Visual Studio 2017
 install:
 - ps: Set-WinSystemLocale ja-JP
-- ps: Start-Sleep -s 5
+- ps: Start-Sleep -s 10
 - ps: Restart-Computer
-- ps: Start-Sleep -s 5
+- ps: Start-Sleep -s 10
 
 configuration:
   - Release


### PR DESCRIPTION
#151: appveyor の 初期化処理での sleep を 5 秒から 10 秒に伸ばす。
AppVeyorのジョブが途中で止まる問題への workaround です。

参照: https://github.com/appveyor/ci/issues/2456#issuecomment-403299903
