### PR TITLE
エディタ設定：インデント設定と行末スペース削り

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+﻿root = true
+
+[*.{cpp,h,hh,hsrc}]
+# インデントスタイル：タブ文字で4スペース幅
+indent_style = tab
+indent_size = 4
+
+# 行末のスペースは自動的に削る
+trim_trailing_whitespace = true


### PR DESCRIPTION
.editorconfig 設置により、以下の設定を行います。

- Visual Studio においてインデントをタブ文字固定にする
- Visual Studio においてタブ文字を4スペース幅で表示させる
- Visual Studio において行末スペースは自動的に削られるようにする
- GitHub 上のコード表示においてタブ文字が4スペース幅の表示させる

## 主な目的
サクラエディタは経緯的に Visual Studio でコーディングを行ってきた人が多く、Visual Studio ではインデントがタブ文字でありタブ文字が4スペース幅で表示されることが多い（デフォルト）ため、GitHub 上でもその設定が強制されるようにプロジェクトのエディタ設定を行う。これにより今後もコーディングスタイルが安定することが期待できる。

さらに大きな利点としては既存コードのタブ文字が GitHub 上でも4スペース幅表示になるため、手元での Visual Studio でのタブ文字表示幅と同じ見た目でコードを見ることができる。（手元とブラウザ表示で変なズレが出にくくなる）

## 例
### 設定適用前
https://github.com/kobake/sakura/blob/b118103375f7a5e2d534c945f841b6def25ffb32/sakura_core/CRegexKeyword.h#L86-L101

### 設定適用後
https://github.com/kobake/sakura/blob/fa43e940b0fb2d12a7339baa6466983028441e8f/sakura_core/CRegexKeyword.h#L86-L101
