### PR TITLE
apiwrap 配下のファイルを UTF-8 (BOM付) に単純変換

### DIFF
--- a/sakura_core/apiwrap/CommonControl.h
+++ b/sakura_core/apiwrap/CommonControl.h
@@ -1,4 +1,4 @@
-/*
+Ôªø/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -24,12 +24,12 @@
 #ifndef SAKURA_COMMONCONTROL_D732DE4D_9F3E_4E17_B6B3_0C11AD0D9F4F_H_
 #define SAKURA_COMMONCONTROL_D732DE4D_9F3E_4E17_B6B3_0C11AD0D9F4F_H_
 
-#include <CommCtrl.h> // ÉRÉÇÉìÉRÉìÉgÉçÅ[Éã
+#include <CommCtrl.h> // „Ç≥„É¢„É≥„Ç≥„É≥„Éà„É≠„Éº„É´
 
 namespace ApiWrap
 {
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ÉXÉeÅ[É^ÉXÉoÅ[                         //
+	//                      „Çπ„ÉÜ„Éº„Çø„Çπ„Éê„Éº                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline LRESULT StatusBar_SetText(HWND hwndStatus, WPARAM opt, const TCHAR* str)
 	{
@@ -39,32 +39,32 @@ namespace ApiWrap
 	inline int StatusBar_SetParts(HWND hwndCtl, int num, int* positions)		{ return (int)(DWORD)::SendMessage(hwndCtl, SB_SETPARTS, (WPARAM)num, (LPARAM)positions); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      HotKey ÉRÉìÉgÉçÅ[Éã                    //
+	//                      HotKey „Ç≥„É≥„Éà„É≠„Éº„É´                    //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline LRESULT HotKey_GetHotKey(HWND hwndCtl)								{ return (LRESULT)::SendMessage(hwndCtl, HKM_GETHOTKEY, 0L, 0L); }
 	inline void HotKey_SetHotKey(HWND hwndCtl, DWORD vk_code, DWORD modifier)	{ ::SendMessage(hwndCtl, HKM_SETHOTKEY, MAKEWORD(vk_code, modifier), 0L); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                  ÉvÉçÉOÉåÉXÉoÅ[ ÉRÉìÉgÉçÅ[Éã                //
+	//                  „Éó„É≠„Ç∞„É¨„Çπ„Éê„Éº „Ç≥„É≥„Éà„É≠„Éº„É´                //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline int Progress_SetRange(HWND hwndCtl, int minimum, int maximum)	{ return (int)(DWORD)::SendMessage(hwndCtl, PBM_SETRANGE, 0L, MAKELPARAM(minimum, maximum)); }
 	inline int Progress_SetPos(HWND hwndCtl, int position)					{ return (int)(DWORD)::SendMessage(hwndCtl, PBM_SETPOS, (WPARAM)position, 0L); }
 	inline void Progress_SetMarquee(HWND hwndCtl, BOOL mode, int updateTime)	{ ::SendMessage(hwndCtl, PBM_SETMARQUEE, mode, updateTime); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      Up-Down ÉRÉìÉgÉçÅ[Éã                   //
+	//                      Up-Down „Ç≥„É≥„Éà„É≠„Éº„É´                   //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline LRESULT UpDown_SetRange(HWND hwndCtl, int upper, int lower)	{ return (LRESULT)(ULONG_PTR)::SendMessage(hwndCtl, UDM_SETRANGE, 0L, MAKELPARAM(upper, lower)); }
 	inline LRESULT UpDown_GetPos(HWND hwndCtl)							{ return (LRESULT)(ULONG_PTR)::SendMessage(hwndCtl, UDM_GETPOS, 0L, 0L); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      Rebar ÉRÉìÉgÉçÅ[Éã                     //
+	//                      Rebar „Ç≥„É≥„Éà„É≠„Éº„É´                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline int Rebar_InsertBand(HWND hwndCtl, int index, REBARBANDINFO* info)	{ return (int)(DWORD)::SendMessage(hwndCtl, RB_INSERTBAND, (WPARAM)index, (LPARAM)info); }
 	inline int Rebar_SetbarInfo(HWND hwndCtl, REBARINFO* info)					{ return (int)(DWORD)::SendMessage(hwndCtl, RB_SETBARINFO, 0L, (LPARAM)info); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      Toolbar ÉRÉìÉgÉçÅ[Éã                   //
+	//                      Toolbar „Ç≥„É≥„Éà„É≠„Éº„É´                   //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline BOOL Toolbar_AddButtons(HWND hwndCtl, int num, TBBUTTON* buttons)		{ return (BOOL)(DWORD)::SendMessage(hwndCtl, TB_ADDBUTTONS, (WPARAM)num, (LPARAM)buttons); }
 	inline void Toolbar_ButtonStructSize(HWND hwndCtl, int size)					{ ::SendMessage(hwndCtl, TB_BUTTONSTRUCTSIZE, (WPARAM)size, 0L); }
@@ -80,7 +80,7 @@ namespace ApiWrap
 	inline DWORD Toolbar_SetExtendedStyle(HWND hwndCtl, DWORD styles)				{ return (DWORD)::SendMessage(hwndCtl, TB_SETEXTENDEDSTYLE, 0L, (LPARAM)styles); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      Tooltip ÉRÉìÉgÉçÅ[Éã                   //
+	//                      Tooltip „Ç≥„É≥„Éà„É≠„Éº„É´                   //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline BOOL Tooltip_AddTool(HWND hwndCtl, TOOLINFO* info)			{ return (BOOL)(DWORD)::SendMessage(hwndCtl, TTM_ADDTOOL, 0L, (LPARAM)info); }
 	inline int Tooltip_SetMaxTipWidth(HWND hwndCtl, int width)			{ return (int)(DWORD)::SendMessage(hwndCtl, TTM_SETMAXTIPWIDTH, 0L, (LPARAM)width); }

--- a/sakura_core/apiwrap/StdApi.cpp
+++ b/sakura_core/apiwrap/StdApi.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include <vector>
 #include "StdApi.h"
 #include "charset/charcode.h"
@@ -8,19 +8,19 @@ using namespace std;
 
 #ifndef _UNICODE
 /*!
-	ƒƒCƒh•¶š—ñ‚©‚çƒ}ƒ‹ƒ`ƒoƒCƒg•¶š—ñ‚ğ¶¬‚·‚éB
-	ƒ}ƒ‹ƒ`ƒoƒCƒg•¶š—ñ‚Ì‚½‚ß‚ÉV‚µ‚¢ƒƒ‚ƒŠ—Ìˆæ‚ªŠm•Û‚³‚ê‚é‚Ì‚ÅA
-	g‚¢I‚í‚Á‚½‚çDestroyMbString‚ğŒÄ‚Ô‚±‚ÆI
+	ãƒ¯ã‚¤ãƒ‰æ–‡å­—åˆ—ã‹ã‚‰ãƒãƒ«ãƒãƒã‚¤ãƒˆæ–‡å­—åˆ—ã‚’ç”Ÿæˆã™ã‚‹ã€‚
+	ãƒãƒ«ãƒãƒã‚¤ãƒˆæ–‡å­—åˆ—ã®ãŸã‚ã«æ–°ã—ã„ãƒ¡ãƒ¢ãƒªé ˜åŸŸãŒç¢ºä¿ã•ã‚Œã‚‹ã®ã§ã€
+	ä½¿ã„çµ‚ã‚ã£ãŸã‚‰DestroyMbStringã‚’å‘¼ã¶ã“ã¨ï¼
 
-	@retval •ÏŠ·‚³‚ê‚½ACHAR•¶š—ñ
+	@retval å¤‰æ›ã•ã‚ŒãŸACHARæ–‡å­—åˆ—
 */
 static ACHAR* CreateMbString(
-	const WCHAR*	pWideString,	//!< [in]  Œ³‚ÌWCHAR•¶š—ñ
-	int				nWideLength,	//!< [in]  Œ³‚ÌWCHAR•¶š—ñ‚Ì’·‚³B•¶š’PˆÊB
-	int*			pnMbLength		//!< [out] •ÏŠ·‚³‚ê‚½ACHAR•¶š—ñ‚Ì’·‚³‚Ìó‚¯æ‚èæB•¶š’PˆÊB
+	const WCHAR*	pWideString,	//!< [in]  å…ƒã®WCHARæ–‡å­—åˆ—
+	int				nWideLength,	//!< [in]  å…ƒã®WCHARæ–‡å­—åˆ—ã®é•·ã•ã€‚æ–‡å­—å˜ä½ã€‚
+	int*			pnMbLength		//!< [out] å¤‰æ›ã•ã‚ŒãŸACHARæ–‡å­—åˆ—ã®é•·ã•ã®å—ã‘å–ã‚Šå…ˆã€‚æ–‡å­—å˜ä½ã€‚
 )
 {
-	//•K—v‚È—ÌˆæƒTƒCƒY‚ğæ“¾
+	//å¿…è¦ãªé ˜åŸŸã‚µã‚¤ã‚ºã‚’å–å¾—
 	int nNewLen=WideCharToMultiByte(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -32,10 +32,10 @@ static ACHAR* CreateMbString(
 		NULL
 	);
 
-	//—Ìˆæ‚ğŠm•Û
+	//é ˜åŸŸã‚’ç¢ºä¿
 	ACHAR* buf=new ACHAR[nNewLen+1];
 
-	//•ÏŠ·
+	//å¤‰æ›
 	nNewLen = WideCharToMultiByte(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -48,13 +48,13 @@ static ACHAR* CreateMbString(
 	);
 	buf[nNewLen]='\0';
 
-	//Œ‹‰Ê
+	//çµæœ
 	if(pnMbLength)*pnMbLength=nNewLen;
 	return buf;
 }
 
 /*!
-	CreateMbString ‚ÅŠm•Û‚µ‚½ƒ}ƒ‹ƒ`ƒoƒCƒg•¶š—ñ‚ğ‰ğ•ú‚·‚é
+	CreateMbString ã§ç¢ºä¿ã—ãŸãƒãƒ«ãƒãƒã‚¤ãƒˆæ–‡å­—åˆ—ã‚’è§£æ”¾ã™ã‚‹
 */
 static void DestroyMbString(ACHAR* pMbString)
 {
@@ -69,22 +69,22 @@ namespace ApiWrap{
 
 
 	/*!
-		MakeSureDirectoryPathExists ‚Ì UNICODE ”ÅB
-		szDirPath ‚Åw’è‚³‚ê‚½‚·‚×‚Ä‚ÌƒfƒBƒŒƒNƒgƒŠ‚ğì¬‚µ‚Ü‚·B
-		ƒfƒBƒŒƒNƒgƒŠ‚Ì‹Lq‚ÍAƒ‹[ƒg‚©‚çŠJn‚µ‚Ü‚·B
+		MakeSureDirectoryPathExists ã® UNICODE ç‰ˆã€‚
+		szDirPath ã§æŒ‡å®šã•ã‚ŒãŸã™ã¹ã¦ã®ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’ä½œæˆã—ã¾ã™ã€‚
+		ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®è¨˜è¿°ã¯ã€ãƒ«ãƒ¼ãƒˆã‹ã‚‰é–‹å§‹ã—ã¾ã™ã€‚
 
 		@param DirPath
-			—LŒø‚ÈƒpƒX–¼‚ğw’è‚·‚éAnull ‚ÅI‚í‚é•¶š—ñ‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğw’è‚µ‚Ü‚·B
-			ƒpƒX‚ÌÅŒã‚ÌƒRƒ“ƒ|[ƒlƒ“ƒg‚ªƒtƒ@ƒCƒ‹–¼‚Å‚Í‚È‚­ƒfƒBƒŒƒNƒgƒŠ‚Å‚ ‚éê‡A
-			•¶š—ñ‚ÌÅŒã‚É‰~‹L†i\j‚ğ‹Lq‚µ‚È‚¯‚ê‚Î‚È‚è‚Ü‚¹‚ñB 
+			æœ‰åŠ¹ãªãƒ‘ã‚¹åã‚’æŒ‡å®šã™ã‚‹ã€null ã§çµ‚ã‚ã‚‹æ–‡å­—åˆ—ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’æŒ‡å®šã—ã¾ã™ã€‚
+			ãƒ‘ã‚¹ã®æœ€å¾Œã®ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆãŒãƒ•ã‚¡ã‚¤ãƒ«åã§ã¯ãªããƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã§ã‚ã‚‹å ´åˆã€
+			æ–‡å­—åˆ—ã®æœ€å¾Œã«å††è¨˜å·ï¼ˆ\ï¼‰ã‚’è¨˜è¿°ã—ãªã‘ã‚Œã°ãªã‚Šã¾ã›ã‚“ã€‚ 
 
 		@returns
-			ŠÖ”‚ª¬Œ÷‚·‚é‚ÆATRUE ‚ª•Ô‚è‚Ü‚·B
-			ŠÖ”‚ª¸”s‚·‚é‚ÆAFALSE ‚ª•Ô‚è‚Ü‚·B
+			é–¢æ•°ãŒæˆåŠŸã™ã‚‹ã¨ã€TRUE ãŒè¿”ã‚Šã¾ã™ã€‚
+			é–¢æ•°ãŒå¤±æ•—ã™ã‚‹ã¨ã€FALSE ãŒè¿”ã‚Šã¾ã™ã€‚
 
 		@note
-			w’è‚³‚ê‚½ŠeƒfƒBƒŒƒNƒgƒŠ‚ª‚Ü‚¾‘¶İ‚µ‚È‚¢ê‡A‚»‚ê‚ç‚ÌƒfƒBƒŒƒNƒgƒŠ‚ğ‡‚Éì¬‚µ‚Ü‚·B
-			ˆê•”‚ÌƒfƒBƒŒƒNƒgƒŠ‚Ì‚İ‚ğì¬‚µ‚½ê‡A‚±‚ÌŠÖ”‚Í FALSE ‚ğ•Ô‚µ‚Ü‚·B
+			æŒ‡å®šã•ã‚ŒãŸå„ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãŒã¾ã å­˜åœ¨ã—ãªã„å ´åˆã€ãã‚Œã‚‰ã®ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’é †ã«ä½œæˆã—ã¾ã™ã€‚
+			ä¸€éƒ¨ã®ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®ã¿ã‚’ä½œæˆã—ãŸå ´åˆã€ã“ã®é–¢æ•°ã¯ FALSE ã‚’è¿”ã—ã¾ã™ã€‚
 
 		@author
 			kobake
@@ -97,19 +97,19 @@ namespace ApiWrap{
 		const wchar_t* p=szDirPath-1;
 		for (;;) {
 			p=wcschr(p+1,L'\\');
-			if(!p)break; //'\\'‚ğ‘–¸‚µI‚í‚Á‚½‚Ì‚ÅI—¹
+			if(!p)break; //'\\'ã‚’èµ°æŸ»ã—çµ‚ã‚ã£ãŸã®ã§çµ‚äº†
 
-			//æ“ª‚©‚çp‚Ü‚Å‚Ì•”•ª•¶š—ñ -> szBuf
+			//å…ˆé ­ã‹ã‚‰pã¾ã§ã®éƒ¨åˆ†æ–‡å­—åˆ— -> szBuf
 			wchar_t szBuf[_MAX_PATH];
 			wcsncpy_s(szBuf,_countof(szBuf),szDirPath,p-szDirPath);
 
-			//‘¶İ‚·‚é‚©
+			//å­˜åœ¨ã™ã‚‹ã‹
 			int nAcc = _waccess(szBuf,0);
-			if(nAcc==0)continue; //‘¶İ‚·‚é‚È‚çAŸ‚Ö
+			if(nAcc==0)continue; //å­˜åœ¨ã™ã‚‹ãªã‚‰ã€æ¬¡ã¸
 
-			//ƒfƒBƒŒƒNƒgƒŠì¬
+			//ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªä½œæˆ
 			int nDir = _wmkdir(szBuf);
-			if(nDir==-1)return FALSE; //ƒGƒ‰[‚ª”­¶‚µ‚½‚Ì‚ÅAFALSE‚ğ•Ô‚·
+			if(nDir==-1)return FALSE; //ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ãŸã®ã§ã€FALSEã‚’è¿”ã™
 		}
 		return TRUE;
 	}
@@ -118,12 +118,12 @@ namespace ApiWrap{
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//              WŒn•`‰æAPI (ANSI”Å‚Å‚à—˜—p‰Â”\)                //
+	//              Wç³»æç”»API (ANSIç‰ˆã§ã‚‚åˆ©ç”¨å¯èƒ½)                //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 	/*!
-		ANSI”Å‚Å‚àg‚¦‚éExtTextOutW_AnyBuildB
-		•¶š”§ŒÀ1024”¼Šp•¶šB(•¶šŠÔŠu”z—ñ‚ğ1024”¼Šp•¶š•ª‚µ‚©—pˆÓ‚µ‚Ä‚¢‚È‚¢‚½‚ß)
+		ANSIç‰ˆã§ã‚‚ä½¿ãˆã‚‹ExtTextOutW_AnyBuildã€‚
+		æ–‡å­—æ•°åˆ¶é™1024åŠè§’æ–‡å­—ã€‚(æ–‡å­—é–“éš”é…åˆ—ã‚’1024åŠè§’æ–‡å­—åˆ†ã—ã‹ç”¨æ„ã—ã¦ã„ãªã„ãŸã‚)
 	*/
 #ifdef _UNICODE
 #else
@@ -142,20 +142,20 @@ namespace ApiWrap{
 		if(cbCount>1024)return FALSE;
 
 		int nNewLength=0;
-		//ANSI•¶š—ñ‚ğ¶¬
+		//ANSIæ–‡å­—åˆ—ã‚’ç”Ÿæˆ
 		ACHAR* pNewString = CreateMbString(
 			lpwString,
 			cbCount==-1?wcslen(lpwString):cbCount,
 			&nNewLength
 		);
 
-		//•¶šŠÔŠu”z—ñ‚ğ¶¬
+		//æ–‡å­—é–“éš”é…åˆ—ã‚’ç”Ÿæˆ
 		int nHankakuDx;
 		const int* lpDxNew=NULL;
 		if(lpDx){
 			if(WCODE::IsHankaku(lpwString[0]))nHankakuDx=lpDx[0];
 			else nHankakuDx=lpDx[0]/2;
-			static int aDx[1024]={0}; //1024”¼Šp•¶š‚Ü‚Å
+			static int aDx[1024]={0}; //1024åŠè§’æ–‡å­—ã¾ã§
 			if(aDx[0]!=nHankakuDx){
 				for(int i=0;i<_countof(aDx);i++){
 					aDx[i]=nHankakuDx;
@@ -164,10 +164,10 @@ namespace ApiWrap{
 			lpDxNew=aDx;
 		}
 
-		//APIƒR[ƒ‹
+		//APIã‚³ãƒ¼ãƒ«
 		BOOL ret=::ExtTextOut(hdc,x,y,fuOptions,lprc,pNewString,nNewLength,lpDxNew);
 
-		//Œãn––
+		//å¾Œå§‹æœ«
 		DestroyMbString(pNewString);
 		DEBUG_SETPIXEL(hdc);
 		return ret;
@@ -202,7 +202,7 @@ namespace ApiWrap{
 		LPCWSTR lpsz
 	)
 	{
-		//$$ ƒTƒƒQ[ƒgƒyƒA–³‹
+		//$$ ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢ç„¡è¦–
 		if(*lpsz)return const_cast<LPWSTR>(lpsz+1);
 		else return const_cast<LPWSTR>(lpsz);
 	}
@@ -212,7 +212,7 @@ namespace ApiWrap{
 		LPCWSTR lpszCurrent
 	)
 	{
-		//$$ ƒTƒƒQ[ƒgƒyƒA–³‹
+		//$$ ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢ç„¡è¦–
 		if(lpszCurrent>lpszStart)return const_cast<LPWSTR>(lpszCurrent-1);
 		else return const_cast<LPWSTR>(lpszStart);
 	}
@@ -237,7 +237,7 @@ namespace ApiWrap{
 #endif
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//             ‚»‚Ì‘¼WŒnAPI (ANSI”Å‚Å‚à—˜—p‰Â”\)               //
+	//             ãã®ä»–Wç³»API (ANSIç‰ˆã§ã‚‚åˆ©ç”¨å¯èƒ½)               //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 #ifdef _UNICODE
@@ -246,56 +246,56 @@ namespace ApiWrap{
 		HINSTANCE	hInstance,
 		UINT		uID,
 		LPWSTR		lpBuffer,
-		int			nBufferCount	//!< ƒoƒbƒtƒ@‚ÌƒTƒCƒYB•¶š’PˆÊB
+		int			nBufferCount	//!< ãƒãƒƒãƒ•ã‚¡ã®ã‚µã‚¤ã‚ºã€‚æ–‡å­—å˜ä½ã€‚
 	)
 	{
-		//‚Ü‚¸‚ÍACHAR‚Åƒ[ƒh
+		//ã¾ãšã¯ACHARã§ãƒ­ãƒ¼ãƒ‰
 		int nTmpCnt = nBufferCount*2+2;
 		ACHAR* pTmp = new ACHAR[nTmpCnt];
 		int ret=LoadStringA(hInstance, uID, pTmp, nTmpCnt);
 
-		//WCHAR‚É•ÏŠ·
+		//WCHARã«å¤‰æ›
 		mbstowcs2(lpBuffer, pTmp, nBufferCount);
 		int ret2=wcslen(lpBuffer);
 
-		//Œãn––
+		//å¾Œå§‹æœ«
 		delete[] pTmp;
 
-		//Œ‹‰Ê
+		//çµæœ
 		return ret2;
 	}
 #endif
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                    •`‰æAPI •s‹ï‡ƒ‰ƒbƒv                     //
+	//                    æç”»API ä¸å…·åˆãƒ©ãƒƒãƒ—                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	/*
-		Vista‚ÅSetPixel‚ª“®‚©‚È‚¢‚½‚ßA‘ã‘ÖŠÖ”‚ğ—pˆÓB
+		Vistaã§SetPixelãŒå‹•ã‹ãªã„ãŸã‚ã€ä»£æ›¿é–¢æ•°ã‚’ç”¨æ„ã€‚
 
-		QlFhttp://forums.microsoft.com/MSDN-JA/ShowPost.aspx?PostID=3228018&SiteID=7
-		> Vista ‚Å Aero ‚ğ OFF ‚É‚·‚é‚Æ SetPixel ‚ª‚¤‚Ü‚­“®‚©‚È‚¢‚»‚¤‚Å‚·B
-		> ‚µ‚©‚àASP1 ‚Å‚àC³‚³‚ê‚Ä‚¢‚È‚¢‚Æ‚©B
+		å‚è€ƒï¼šhttp://forums.microsoft.com/MSDN-JA/ShowPost.aspx?PostID=3228018&SiteID=7
+		> Vista ã§ Aero ã‚’ OFF ã«ã™ã‚‹ã¨ SetPixel ãŒã†ã¾ãå‹•ã‹ãªã„ãã†ã§ã™ã€‚
+		> ã—ã‹ã‚‚ã€SP1 ã§ã‚‚ä¿®æ­£ã•ã‚Œã¦ã„ãªã„ã¨ã‹ã€‚
 	*/
 	void SetPixelSurely(HDC hdc,int x,int y,COLORREF c)
 	{
 		if (!IsWinVista_or_later()) {
-		//Vista‚æ‚è‘OFSetPixel’¼ŒÄ‚Ño‚µ
+		//Vistaã‚ˆã‚Šå‰ï¼šSetPixelç›´å‘¼ã³å‡ºã—
 			::SetPixel(hdc,x,y,c);
 		}
 		else {
-		//VistaˆÈ~FSetPixelƒGƒ~ƒ…ƒŒ[ƒg
+		//Vistaä»¥é™ï¼šSetPixelã‚¨ãƒŸãƒ¥ãƒ¬ãƒ¼ãƒˆ
 			static HPEN hPen = NULL;
 			static COLORREF clrPen = 0;
 			if(hPen && c!=clrPen){
 				DeleteObject(hPen);
 				hPen = NULL;
 			}
-			//ƒyƒ“¶¬
+			//ãƒšãƒ³ç”Ÿæˆ
 			if(!hPen){
 				hPen = CreatePen(PS_SOLID,1,clrPen = c);
 			}
-			//•`‰æ
+			//æç”»
 			HPEN hpnOld = (HPEN)SelectObject(hdc,hPen);
 			::MoveToEx(hdc,x,y,NULL);
 			::LineTo(hdc,x+1,y+1);

--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,10 +25,10 @@
 #define SAKURA_STDAPI_85471C2C_6AEE_410D_BD09_A59056A5BA68_H_
 
 
-//�����^�C����񃉃C�u�����ɃA�N�Z�X����Windows�w�b�_���Q�Ƃ���
-//c++�K�i�ւ̏������������Ȃ������߁AWindowsSDK������enum��typedef����R�[�h���{����B
+//ランタイム情報ライブラリにアクセスするWindowsヘッダを参照する
+//c++規格への準拠が厳しくなったため、WindowsSDKが無名enumをtypedefするコードが怒られる。
 #if defined(_MSC_VER) && _MSC_VER >= 1900
-	//�ꎞ�I�Ɍx���𖳌��ɂ��ăC���N���[�h����
+	//一時的に警告を無効にしてインクルードする
 	#pragma warning(push)
 	#pragma warning(disable:4091)
 	#include <ImageHlp.h> //MakeSureDirectoryPathExists
@@ -38,11 +38,11 @@
 #endif
 
 
-//�f�o�b�O�p�B
-//Vista����ExtTextOut�̌��ʂ������f����Ȃ��B���̊֐���p����Ƒ����f�����̂ŁA
-//�f�o�b�O���X�e�b�v���s����ۂɕ֗��ɂȂ�B�������A���R�d���Ȃ�B
+//デバッグ用。
+//VistaだとExtTextOutの結果が即反映されない。この関数を用いると即反映されるので、
+//デバッグ時ステップ実行する際に便利になる。ただし、当然重くなる。
 #ifdef _DEBUG
-#define DEBUG_SETPIXEL(hdc) SetPixel(hdc,-1,-1,0); //SetPixel������ƁA���ʂ������f�����B
+#define DEBUG_SETPIXEL(hdc) SetPixel(hdc,-1,-1,0); //SetPixelをすると、結果が即反映される。
 #else
 #define DEBUG_SETPIXEL(hdc)
 #endif
@@ -50,9 +50,9 @@
 namespace ApiWrap
 {
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//          W�n�����݂��Ȃ�API�̂��߂́A�V�����֐���`         //
+	//          W系が存在しないAPIのための、新しい関数定義         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//W�ł������̂ŁA����
+	//W版が無いので、自作
 	BOOL MakeSureDirectoryPathExistsW(LPCWSTR wszDirPath);
 #ifdef _UNICODE
 	#define MakeSureDirectoryPathExistsT MakeSureDirectoryPathExistsW
@@ -62,12 +62,12 @@ namespace ApiWrap
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//              W�n�`��API (ANSI�łł����p�\)                //
+	//              W系描画API (ANSI版でも利用可能)                //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 	/*!
-		ANSI�łł��g����ExtTextOutW_AnyBuild�B
-		����������1024���p�����B(�����Ԋu�z���1024���p�����������p�ӂ��Ă��Ȃ�����)
+		ANSI版でも使えるExtTextOutW_AnyBuild。
+		文字数制限1024半角文字。(文字間隔配列を1024半角文字分しか用意していないため)
 	*/
 #ifdef _UNICODE
 	inline BOOL ExtTextOutW_AnyBuild(
@@ -144,7 +144,7 @@ namespace ApiWrap
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//             ���̑�W�nAPI (ANSI�łł����p�\)               //
+	//             その他W系API (ANSI版でも利用可能)               //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 #ifdef _UNICODE
@@ -152,7 +152,7 @@ namespace ApiWrap
 		HINSTANCE	hInstance,
 		UINT		uID,
 		LPWSTR		lpBuffer,
-		int			nBufferCount	//!< �o�b�t�@�̃T�C�Y�B�����P�ʁB
+		int			nBufferCount	//!< バッファのサイズ。文字単位。
 	)
 	{
 		return ::LoadStringW(hInstance, uID, lpBuffer, nBufferCount);
@@ -162,44 +162,44 @@ namespace ApiWrap
 		HINSTANCE	hInstance,
 		UINT		uID,
 		LPWSTR		lpBuffer,
-		int			nBufferCount	//!< �o�b�t�@�̃T�C�Y�B�����P�ʁB
+		int			nBufferCount	//!< バッファのサイズ。文字単位。
 	);
 #endif
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                    �`��API �s����b�v                     //
+	//                    描画API 不具合ラップ                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//Vista��SetPixel�������Ȃ����߁A��֊֐���p�ӁB
+	//VistaでSetPixelが動かないため、代替関数を用意。
 	void SetPixelSurely(HDC hdc,int x,int y,COLORREF c);
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      �悭�g�������l                         //
+	//                      よく使う引数値                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//! �悭�g��ExtTextOutW_AnyBuild�̃I�v�V����
+	//! よく使うExtTextOutW_AnyBuildのオプション
 	inline UINT ExtTextOutOption()
 	{
 		return ETO_CLIPPED | ETO_OPAQUE;
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                       �悭�g���p�@                          //
+	//                       よく使う用法                          //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//! SHIFT�������Ă��邩�ǂ���
+	//! SHIFTを押しているかどうか
 	inline bool GetKeyState_Shift()
 	{
 		return (::GetKeyState(VK_SHIFT)&0x8000)!=0;
 	}
 
-	//! CTRL�������Ă��邩�ǂ���
+	//! CTRLを押しているかどうか
 	inline bool GetKeyState_Control()
 	{
 		return (::GetKeyState(VK_CONTROL)&0x8000)!=0;
 	}
 
-	//! ALT�������Ă��邩�ǂ���
+	//! ALTを押しているかどうか
 	inline bool GetKeyState_Alt()
 	{
 		return (::GetKeyState(VK_MENU)&0x8000)!=0;
@@ -207,11 +207,11 @@ namespace ApiWrap
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           �萔                              //
+	//                           定数                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//	Jun. 29, 2002 ������
-	//	Windows 95�΍�DProperty Sheet�̃T�C�Y��Windows95���F���ł��镨�ɌŒ肷��D
+	//	Jun. 29, 2002 こおり
+	//	Windows 95対策．Property SheetのサイズをWindows95が認識できる物に固定する．
 	#if defined(_WIN64) || defined(_UNICODE)
 		static const size_t sizeof_old_PROPSHEETHEADER = sizeof(PROPSHEETHEADER);
 	#else
@@ -219,8 +219,8 @@ namespace ApiWrap
 	#endif
 
 	//	Jan. 29, 2002 genta
-	//	Win95/NT���[������sizeof( MENUITEMINFO )
-	//	����ȊO�̒l��^����ƌÂ�OS�ł����Ɠ����Ă���Ȃ��D
+	//	Win95/NTが納得するsizeof( MENUITEMINFO )
+	//	これ以外の値を与えると古いOSでちゃんと動いてくれない．
 	#if defined(_WIN64) || defined(_UNICODE)
 		static const int SIZEOF_MENUITEMINFO = sizeof(MENUITEMINFO);
 	#else
@@ -229,21 +229,21 @@ namespace ApiWrap
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//             SendMessage,PostMessage�Ӗ��t��                 //
+	//             SendMessage,PostMessage意味付け                 //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	// �ߋ���UNICODE���̖��c�ł��B
-	// ���݂ƂȂ��ẮA���ɈӖ��͂���܂���B
+	// 過去のUNICODE化の名残です。
+	// 現在となっては、特に意味はありません。
 
-	//�����R�[�h�Ɋ֌W�̂Ȃ������� SendMessage �� SendMessageAny �ɍ����ւ��Ă����B
+	//文字コードに関係のなさそうな SendMessage は SendMessageAny に差し替えておく。
 	#define SendMessageAny SendMessage
 
-	//WM_COMMAND�n�� SendMessage �� SendMessageCmd �ɍ����ւ��Ă����B
+	//WM_COMMAND系の SendMessage は SendMessageCmd に差し替えておく。
 	#define SendMessageCmd SendMessage
 
-	//�����R�[�h�Ɋ֌W�̂Ȃ������� PostMessage �� PostMessageAny �ɍ����ւ��Ă����B
+	//文字コードに関係のなさそうな PostMessage は PostMessageAny に差し替えておく。
 	#define PostMessageAny PostMessage
 
-	//WM_COMMAND�n�� PostMessage �� PostMessageCmd �ɍ����ւ��Ă����B
+	//WM_COMMAND系の PostMessage は PostMessageCmd に差し替えておく。
 	#define PostMessageCmd PostMessage
 
 }
@@ -253,7 +253,7 @@ using namespace ApiWrap;
 
 
 //	Sep. 22, 2003 MIK
-//	�Â�SDK�΍�D�V����SDK�ł͕s�v
+//	古いSDK対策．新しいSDKでは不要
 #ifndef _WIN64
 #ifndef DWORD_PTR
 #define DWORD_PTR DWORD

--- a/sakura_core/apiwrap/StdControl.cpp
+++ b/sakura_core/apiwrap/StdControl.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "StdControl.h"
 #include "util/tchar_receive.h"
 
@@ -11,7 +11,7 @@ namespace ApiWrap{
 		LRESULT nCount = SendMessage( hwndList, LB_GETTEXTLEN, (WPARAM)nIndex, (LPARAM)0);
 		if( nCount == LB_ERR )
 			return LB_ERR;
-		return SendMessage( hwndList, LB_GETTEXT, (WPARAM)nIndex, (LPARAM)(TCHAR*)TcharReceiver<ACHAR>(str,nCount+1) );	// +1: NULL •¶š•ª
+		return SendMessage( hwndList, LB_GETTEXT, (WPARAM)nIndex, (LPARAM)(TCHAR*)TcharReceiver<ACHAR>(str,nCount+1) );	// +1: NULL æ–‡å­—åˆ†
 	}
 
 	LRESULT List_GetText(HWND hwndList, int nIndex, WCHAR* str)
@@ -19,7 +19,7 @@ namespace ApiWrap{
 		LRESULT nCount = SendMessage( hwndList, LB_GETTEXTLEN, (WPARAM)nIndex, (LPARAM)0);
 		if( nCount == LB_ERR )
 			return LB_ERR;
-		return SendMessage( hwndList, LB_GETTEXT, (WPARAM)nIndex, (LPARAM)(TCHAR*)TcharReceiver<WCHAR>(str,nCount+1) );	// +1: NULL •¶š•ª
+		return SendMessage( hwndList, LB_GETTEXT, (WPARAM)nIndex, (LPARAM)(TCHAR*)TcharReceiver<WCHAR>(str,nCount+1) );	// +1: NULL æ–‡å­—åˆ†
 	}
 
 	UINT DlgItem_GetText(HWND hwndDlg, int nIDDlgItem, ACHAR* str, int nMaxCount)
@@ -49,7 +49,7 @@ namespace ApiWrap{
 		return FALSE != ret;
 	}
 
-	// TreeView ‘SŠJ¥‘S•Â
+	// TreeView å…¨é–‹ï½¥å…¨é–‰
 	void TreeView_ExpandAll(HWND hwndTree, bool bExpand, int nMaxDepth)
 	{
 		HTREEITEM	htiCur;
@@ -60,7 +60,7 @@ namespace ApiWrap{
 
 		htiCur = htiItem = TreeView_GetSelection( hwndTree );
 		if (!bExpand && htiCur != NULL) {
-			// •Â‚¶‚é‚Íƒgƒbƒv‚É•ÏX
+			// é–‰ã˜ã‚‹æ™‚ã¯ãƒˆãƒƒãƒ—ã«å¤‰æ›´
 			for (htiNext = htiCur; htiNext !=  NULL; ) {
 				htiItem = htiNext;
 				htiNext = TreeView_GetParent( hwndTree, htiItem );
@@ -75,7 +75,7 @@ namespace ApiWrap{
 		HTREEITEM item = TreeView_GetRoot(hwndTree);
 		while( 0 < tree.size() || item != NULL ){
 			while(item != NULL && (int)tree.size() < nMaxDepth ){
-				// æ‚É“WŠJ‚µ‚Ä‚©‚çGetChild‚µ‚È‚¢‚ÆAƒtƒ@ƒCƒ‹ƒcƒŠ[‚ÌƒTƒuƒAƒCƒeƒ€‚ª“WŠJ‚³‚ê‚È‚¢
+				// å…ˆã«å±•é–‹ã—ã¦ã‹ã‚‰GetChildã—ãªã„ã¨ã€ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼ã®ã‚µãƒ–ã‚¢ã‚¤ãƒ†ãƒ ãŒå±•é–‹ã•ã‚Œãªã„
 				TreeView_Expand(hwndTree, item, bExpand ? TVE_EXPAND : TVE_COLLAPSE);
 				tree.push_back(item);
 				item = TreeView_GetChild(hwndTree, item);
@@ -85,7 +85,7 @@ namespace ApiWrap{
 			item = TreeView_GetNextSibling(hwndTree, item);
 		}
 
-		// ‘I‘ğˆÊ’u‚ğ–ß‚·
+		// é¸æŠä½ç½®ã‚’æˆ»ã™
 		if (htiCur == NULL) {
 			if (bExpand ) {
 				htiItem = TreeView_GetRoot( hwndTree );

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2007, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,14 +26,14 @@
 
 /*
 2007.09.17 kobake
-“à•”ƒR[ƒh‚ªWCHAR‚È‚Ì‚ÅAŒŸõƒL[ƒ[ƒh‚È‚Ç‚àWCHAR‚Å•Û‚·‚éB
-‚»‚Ì‚½‚ßAŒŸõƒ_ƒCƒAƒƒO‚ÌƒRƒ“ƒ{ƒ{ƒbƒNƒX‚È‚Ç‚ÉAWCHAR‚ğİ’è‚·‚éê–Ê‚ªo‚Ä‚­‚éB
-UNICODE”Å‚Å‚Í–â‘è–³‚¢‚ªAANSI”Å‚Å‚Íİ’è‚Ì‘O‚ÉƒR[ƒh•ÏŠ·‚·‚é•K—v‚ª‚ ‚éB
-ŒÄ‚Ño‚µ‘¤‚Å•ÏŠ·‚µ‚Ä‚à—Ç‚¢‚ªA•p“x‚ª‘½‚¢‚Ì‚ÅAWCHAR‚ğ’¼Úó‚¯æ‚éAPIƒ‰ƒbƒvŠÖ”‚ğ’ñ‹Ÿ‚·‚éB
+å†…éƒ¨ã‚³ãƒ¼ãƒ‰ãŒWCHARãªã®ã§ã€æ¤œç´¢ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãªã©ã‚‚WCHARã§ä¿æŒã™ã‚‹ã€‚
+ãã®ãŸã‚ã€æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ãªã©ã«ã€WCHARã‚’è¨­å®šã™ã‚‹å ´é¢ãŒå‡ºã¦ãã‚‹ã€‚
+UNICODEç‰ˆã§ã¯å•é¡Œç„¡ã„ãŒã€ANSIç‰ˆã§ã¯è¨­å®šã®å‰ã«ã‚³ãƒ¼ãƒ‰å¤‰æ›ã™ã‚‹å¿…è¦ãŒã‚ã‚‹ã€‚
+å‘¼ã³å‡ºã—å´ã§å¤‰æ›ã—ã¦ã‚‚è‰¯ã„ãŒã€é »åº¦ãŒå¤šã„ã®ã§ã€WCHARã‚’ç›´æ¥å—ã‘å–ã‚‹APIãƒ©ãƒƒãƒ—é–¢æ•°ã‚’æä¾›ã™ã‚‹ã€‚
 
-‚Ü‚½ASendMessage‚Ì’¼ÚŒÄ‚Ño‚µ‚ÍA‚Ç‚¤‚µ‚Ä‚àWPARAM,LPARAM‚Ö‚Ì‹­§ƒLƒƒƒXƒg‚ª¶‚¶‚é‚½‚ßA
-ƒRƒ“ƒpƒCƒ‰‚ÌŒ^ƒ`ƒFƒbƒN‚ª“­‚©‚¸Awchar_t, char‚Ì¬İ‚·‚éƒ\[ƒXƒR[ƒh‚Ì’†‚Å‚ÍƒoƒO‚Ì‰·°‚É‚È‚è‚â‚·‚¢B
-‚»‚¤‚¢‚Á‚½ˆÓ–¡‚Å‚àA‚±‚Ìƒtƒ@ƒCƒ‹“à‚Ìƒ‰ƒbƒvŠÖ”‚ğg‚¤‚±‚Æ‚ğ„§‚·‚éB
+ã¾ãŸã€SendMessageã®ç›´æ¥å‘¼ã³å‡ºã—ã¯ã€ã©ã†ã—ã¦ã‚‚WPARAM,LPARAMã¸ã®å¼·åˆ¶ã‚­ãƒ£ã‚¹ãƒˆãŒç”Ÿã˜ã‚‹ãŸã‚ã€
+ã‚³ãƒ³ãƒ‘ã‚¤ãƒ©ã®å‹ãƒã‚§ãƒƒã‚¯ãŒåƒã‹ãšã€wchar_t, charã®æ··åœ¨ã™ã‚‹ã‚½ãƒ¼ã‚¹ã‚³ãƒ¼ãƒ‰ã®ä¸­ã§ã¯ãƒã‚°ã®æ¸©åºŠã«ãªã‚Šã‚„ã™ã„ã€‚
+ãã†ã„ã£ãŸæ„å‘³ã§ã‚‚ã€ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«å†…ã®ãƒ©ãƒƒãƒ—é–¢æ•°ã‚’ä½¿ã†ã“ã¨ã‚’æ¨å¥¨ã™ã‚‹ã€‚
 */
 
 #include "../util/tchar_convert.h"
@@ -42,7 +42,7 @@ UNICODE”Å‚Å‚Í–â‘è–³‚¢‚ªAANSI”Å‚Å‚Íİ’è‚Ì‘O‚ÉƒR[ƒh•ÏŠ·‚·‚é•K—v‚ª‚ ‚éB
 namespace ApiWrap{
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ƒEƒBƒ“ƒhƒE‹¤’Ê                         //
+	//                      ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å…±é€š                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline BOOL Wnd_SetText(HWND hwnd, const ACHAR* str)
 	{
@@ -59,7 +59,7 @@ namespace ApiWrap{
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ƒRƒ“ƒ{ƒ{ƒbƒNƒX                         //
+	//                      ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline LRESULT Combo_AddString(HWND hwndCombo, const ACHAR* str)
 	{
@@ -103,7 +103,7 @@ namespace ApiWrap{
 	inline BOOL Combo_GetDroppedState(HWND hwndCtl)						{ return (BOOL)(DWORD)::SendMessage(hwndCtl, CB_GETDROPPEDSTATE, 0L, 0L ); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ƒŠƒXƒgƒ{ƒbƒNƒX                         //
+	//                      ãƒªã‚¹ãƒˆãƒœãƒƒã‚¯ã‚¹                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	LRESULT List_GetText(HWND hwndList, int nIndex, ACHAR* str);
 	LRESULT List_GetText(HWND hwndList, int nIndex, WCHAR* str);
@@ -142,7 +142,7 @@ namespace ApiWrap{
 	inline int List_SetTopIndex(HWND hwndCtl, int indexTop)				{ return (int)(DWORD)::SendMessage(hwndCtl, LB_SETTOPINDEX, (WPARAM)indexTop, 0L); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹                //
+	//                      ã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«                //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline void EditCtl_LimitText(HWND hwndCtl, int cchLimit)			{ ::SendMessage(hwndCtl, EM_LIMITTEXT, (WPARAM)(cchLimit), 0L); }
 	inline void EditCtl_SetSel(HWND hwndCtl, int ichStart, int ichEnd)	{ ::SendMessage(hwndCtl, EM_SETSEL, ichStart, ichEnd); }
@@ -150,18 +150,18 @@ namespace ApiWrap{
 	inline void EditCtl_ReplaceSel(HWND hwndCtl, const TCHAR* lpsz)		{ ::SendMessage(hwndCtl, EM_REPLACESEL, 0, (LPARAM)lpsz); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ƒ{ƒ^ƒ“ ƒRƒ“ƒgƒ[ƒ‹                    //
+	//                      ãƒœã‚¿ãƒ³ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«                    //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline int BtnCtl_GetCheck(HWND hwndCtl)							{ return (int)(DWORD)::SendMessage(hwndCtl, BM_GETCHECK, 0L, 0L); }
 	inline void BtnCtl_SetCheck(HWND hwndCtl, int check)				{ ::SendMessage(hwndCtl, BM_SETCHECK, (WPARAM)check, 0L); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ƒXƒ^ƒeƒBƒbƒN ƒRƒ“ƒgƒ[ƒ‹              //
+	//                      ã‚¹ã‚¿ãƒ†ã‚£ãƒƒã‚¯ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline HICON StCtl_SetIcon(HWND hwndCtl, HICON hIcon)				{ return (HICON)(UINT_PTR)::SendMessage(hwndCtl, STM_SETICON, (WPARAM)hIcon, 0L); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                       ƒ_ƒCƒAƒƒO“à                          //
+	//                       ãƒ€ã‚¤ã‚¢ãƒ­ã‚°å†…                          //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	inline BOOL DlgItem_SetText(HWND hwndDlg, int nIDDlgItem, const ACHAR* str)
 	{


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/apiwrap
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112