### PR TITLE
basis 配下のファイルを UTF-8 (BOM付) に単純変換

### DIFF
--- a/sakura_core/basis/CLaxInteger.cpp
+++ b/sakura_core/basis/CLaxInteger.cpp
@@ -1,3 +1,3 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "CLaxInteger.h"
 

--- a/sakura_core/basis/CLaxInteger.h
+++ b/sakura_core/basis/CLaxInteger.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -24,18 +24,18 @@
 #ifndef SAKURA_CLAXINTEGER_A4B639A5_3AD6_4C99_882B_4674CB0C155B9_H_
 #define SAKURA_CLAXINTEGER_A4B639A5_3AD6_4C99_882B_4674CB0C155B9_H_
 
-//!Œ^ƒ`ƒFƒbƒN‚ÌŠÉ‚¢®”Œ^
+//!å‹ãƒã‚§ãƒƒã‚¯ã®ç·©ã„æ•´æ•°å‹
 class CLaxInteger{
 private:
 	typedef CLaxInteger Me;
 
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CLaxInteger(){ m_value=0; }
 	CLaxInteger(const Me& rhs){ m_value=rhs.m_value; }
 	CLaxInteger(int value){ m_value=value; }
 
-	//ˆÃ–Ù‚Ì•ÏŠ·
+	//æš—é»™ã®å¤‰æ›
 	operator const int&() const{ return m_value; }
 	operator       int&()      { return m_value; }
 

--- a/sakura_core/basis/CMyPoint.cpp
+++ b/sakura_core/basis/CMyPoint.cpp
@@ -1,2 +1,2 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "CMyPoint.h"

--- a/sakura_core/basis/CMyPoint.h
+++ b/sakura_core/basis/CMyPoint.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -28,31 +28,31 @@
 
 class CMyPoint : public POINT{
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CMyPoint(){ x=0; y=0; }
 	CMyPoint(int _x,int _y){ x=_x; y=_y; }
 	CMyPoint(const POINT& rhs){ x=rhs.x; y=rhs.y; }
 
-	//Zp‰‰Zq
+	//ç®—è¡“æ¼”ç®—å­
 	CMyPoint& operator += (const POINT& rhs){ x+=rhs.x; y+=rhs.y; return *this; }
 	CMyPoint& operator -= (const POINT& rhs){ x-=rhs.x; y-=rhs.y; return *this; }
 	CMyPoint& operator *= (int n){ x*=n; y*=n; return *this; }
 	CMyPoint& operator /= (int n){ x/=n; y/=n; return *this; }
 
-	//Zp‰‰Zq‚Q
+	//ç®—è¡“æ¼”ç®—å­ï¼’
 	CMyPoint operator + (const POINT& rhs) const{ CMyPoint tmp=*this; tmp+=rhs; return tmp; }
 	CMyPoint operator - (const POINT& rhs) const{ CMyPoint tmp=*this; tmp-=rhs; return tmp; }
 	CMyPoint operator * (int n) const{ CMyPoint tmp=*this; tmp*=n; return tmp; }
 	CMyPoint operator / (int n) const{ CMyPoint tmp=*this; tmp/=n; return tmp; }
 
-	//‘ã“ü‰‰Zq
+	//ä»£å…¥æ¼”ç®—å­
 	CMyPoint& operator = (const POINT& rhs){ x=rhs.x; y=rhs.y; return *this; }
 
-	//”äŠr‰‰Zq
+	//æ¯”è¼ƒæ¼”ç®—å­
 	bool operator == (const POINT& rhs) const{ return x==rhs.x && y==rhs.y; }
 	bool operator != (const POINT& rhs) const{ return !this->operator==(rhs); }
 
-	//İ’è
+	//è¨­å®š
 	void Set(int _x,int _y){ x=_x; y=_y; }
 	void Set(const CMyPoint& pt){ x=pt.x; y=pt.y; }
 	void SetX(int _x){ x=_x; }
@@ -60,18 +60,18 @@ public:
 	void Offset(int _x,int _y){ x+=_x; y+=_y; }
 	void Offset(const CMyPoint& pt){ x+=pt.x; y+=pt.y; }
 
-	//æ“¾
+	//å–å¾—
 	int GetX() const{ return (int)x; }
 	int GetY() const{ return (int)y; }
 	CMyPoint Get() const{ return *this; }
 
-	//! x,y ‚¢‚¸‚ê‚©‚ª 0 ‚æ‚è¬‚³‚¢ê‡‚É true ‚ğ•Ô‚·
+	//! x,y ã„ãšã‚Œã‹ãŒ 0 ã‚ˆã‚Šå°ã•ã„å ´åˆã« true ã‚’è¿”ã™
 	bool HasNegative() const
 	{
 		return x<0 || y<0;
 	}
 
-	//! x,y ‚Ç‚¿‚ç‚à©‘R”‚Å‚ ‚ê‚Î true
+	//! x,y ã©ã¡ã‚‰ã‚‚è‡ªç„¶æ•°ã§ã‚ã‚Œã° true
 	bool BothNatural() const
 	{
 		return x>=0 && y>=0;
@@ -80,8 +80,8 @@ public:
 
 
 /*!
-	pt1 - pt2‚ÌŒ‹‰Ê‚ğ•Ô‚·
-	Y‚ğ—Dæ‚µ‚Ä”äŠrBY‚ª“¯ˆê‚È‚çAX‚Å”äŠrB
+	pt1 - pt2ã®çµæœã‚’è¿”ã™
+	Yã‚’å„ªå…ˆã—ã¦æ¯”è¼ƒã€‚YãŒåŒä¸€ãªã‚‰ã€Xã§æ¯”è¼ƒã€‚
 
 	@return <0 pt1 <  pt2
 	@return 0  pt1 == pt2
@@ -95,7 +95,7 @@ inline int PointCompare(const POINT_T& pt1,const POINT_T& pt2)
 }
 
 
-//! 2“_‚ğ‘ÎŠp‚Æ‚·‚é‹éŒ`‚ğ‹‚ß‚é
+//! 2ç‚¹ã‚’å¯¾è§’ã¨ã™ã‚‹çŸ©å½¢ã‚’æ±‚ã‚ã‚‹
 template <class POINT_T>
 inline void TwoPointToRect(
 	RECT*	prcRect,

--- a/sakura_core/basis/CMyRect.cpp
+++ b/sakura_core/basis/CMyRect.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "CMyRect.h"
 
 CMyRect MergeRect(const CMyRect& rc1, const CMyRect& rc2)

--- a/sakura_core/basis/CMyRect.h
+++ b/sakura_core/basis/CMyRect.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -29,7 +29,7 @@
 
 class CMyRect : public RECT{
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CMyRect()
 	{
 		SetLTRB(0,0,0,0);
@@ -44,9 +44,9 @@ public:
 		*p=rc;
 	}
 
-	//‰‰Zq
+	//æ¼”ç®—å­
 
-	//‘ã“ü
+	//ä»£å…¥
 	void SetLTRB(int l,int t,int r,int b)
 	{
 		left  =l;
@@ -76,7 +76,7 @@ public:
 	}
 
 
-	//ŒvZ
+	//è¨ˆç®—
 	int Width() const
 	{
 		return right-left;
@@ -85,12 +85,12 @@ public:
 	{
 		return bottom-top;
 	}
-	//!¶ãÀ•W (TopLeft)
+	//!å·¦ä¸Šåº§æ¨™ (TopLeft)
 	CMyPoint UpperLeft() const
 	{
 		return CMyPoint(left,top);
 	}
-	//!‰E‰ºÀ•W (BottomRight)
+	//!å³ä¸‹åº§æ¨™ (BottomRight)
 	CMyPoint LowerRight() const
 	{
 		return CMyPoint(right,bottom);
@@ -98,7 +98,7 @@ public:
 
 };
 
-//!CRect‡¬Brc1,rc2‚ğŠÜ‚ŞÅ¬‚Ì‹éŒ`‚ğ¶¬‚·‚éB
+//!CRectåˆæˆã€‚rc1,rc2ã‚’å«ã‚€æœ€å°ã®çŸ©å½¢ã‚’ç”Ÿæˆã™ã‚‹ã€‚
 CMyRect MergeRect(const CMyRect& rc1, const CMyRect& rc2);
 
 #endif /* SAKURA_CMYRECT_25A0FB5F_E06F_4F51_B046_E6951B95B0059_H_ */

--- a/sakura_core/basis/CMySize.cpp
+++ b/sakura_core/basis/CMySize.cpp
@@ -1,2 +1,2 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "CMySize.h"

--- a/sakura_core/basis/CMySize.h
+++ b/sakura_core/basis/CMySize.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -28,15 +28,15 @@
 
 class CMySize : public SIZE{
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
-	CMySize(){} //¦‰Šú‰»‚È‚µ
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
+	CMySize(){} //â€»åˆæœŸåŒ–ãªã—
 	CMySize(int _cx,int _cy){ cx=_cx; cy=_cy; }
 	CMySize(const SIZE& rhs){ cx=rhs.cx; cy=rhs.cy; }
 
-	//ŠÖ”
+	//é–¢æ•°
 	void Set(int _cx,int _cy){ cx=_cx; cy=_cy; }
 
-	//‰‰Zq
+	//æ¼”ç®—å­
 	bool operator == (const SIZE& rhs) const{ return cx==rhs.cx && cy==rhs.cy; }
 	bool operator != (const SIZE& rhs) const{ return !operator==(rhs); }
 };

--- a/sakura_core/basis/CMyString.cpp
+++ b/sakura_core/basis/CMyString.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "CMyString.h"
 #include "charset/charcode.h"
 #include "charset/CharPointer.h"
@@ -33,13 +33,13 @@ CMyString::~CMyString()
 /*
 CFilePath::CFilePath(const char* rhs)
 {
-	//Œ»“_‚Å‚ÍNULL‚ğó‚¯•t‚¯‚È‚¢
+	//ç¾æ™‚ç‚¹ã§ã¯NULLã‚’å—ã‘ä»˜ã‘ãªã„
 	assert(rhs);
 	_mbstotcs(m_tszPath, _countof(m_tszPath), rhs);
 }
 CFilePath::CFilePath(const wchar_t* rhs)
 {
-	//Œ»“_‚Å‚ÍNULL‚ğó‚¯•t‚¯‚È‚¢
+	//ç¾æ™‚ç‚¹ã§ã¯NULLã‚’å—ã‘ä»˜ã‘ãªã„
 	assert(rhs);
 	_wcstotcs(m_tszPath, _countof(m_tszPath), rhs);
 }

--- a/sakura_core/basis/CMyString.h
+++ b/sakura_core/basis/CMyString.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -31,7 +31,7 @@
 
 class CMyString{
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CMyString(WCHAR wc)								: m_wstr(1,wc),          m_str_cache(NULL) { }
 	CMyString(const WCHAR* szData=L"")				: m_wstr(szData),        m_str_cache(NULL) { }
 	CMyString(const WCHAR* pData, size_t nLength)	: m_wstr(pData,nLength), m_str_cache(NULL) { }
@@ -41,19 +41,19 @@ public:
 	CMyString(const CMyString& rhs) : m_wstr(rhs.c_wstr()), m_str_cache(NULL) { }
 	~CMyString();
 
-	//‰‰Zq
+	//æ¼”ç®—å­
 	operator const wchar_t* () const{ return c_wstr(); }
 	operator const char* () const{ return c_astr(); }
 	CMyString& operator = (const CMyString& rhs){ set(rhs); return *this; }
 
-	//İ’è
+	//è¨­å®š
 	void set(const wchar_t* wszData){ m_wstr=wszData; m_delete2(m_str_cache); }
 	void set(const wchar_t* wszData, int nLength){ m_wstr.assign(wszData, nLength); m_delete2(m_str_cache); }
 	void set(const char* szData);
 	void set(const char* szData, int nLength);
 	void set(const CMyString& cszData){ set(cszData.c_wstr()); }
 
-	//æ“¾
+	//å–å¾—
 	const wchar_t* c_wstr() const{ return m_wstr.c_str(); }
 	const char* c_astr() const;
 	int wlength() const{ return wcslen(c_wstr()); }
@@ -69,10 +69,10 @@ public:
 
 private:
 	std::wstring m_wstr;
-	mutable char* m_str_cache; //c_str—pƒLƒƒƒbƒVƒ…Bm_wstr‚ª•ÏX(set)‚³‚ê‚½‚ç‚±‚ê‚ğ‰ğ•ú‚µANULL‚É‚µ‚Ä‚¨‚­‚Ì‚ªƒ‹[ƒ‹B
+	mutable char* m_str_cache; //c_strç”¨ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã€‚m_wstrãŒå¤‰æ›´(set)ã•ã‚ŒãŸã‚‰ã“ã‚Œã‚’è§£æ”¾ã—ã€NULLã«ã—ã¦ãŠãã®ãŒãƒ«ãƒ¼ãƒ«ã€‚
 };
 
-//std::string ‚Ì TCHAR ‘Î‰—pƒ}ƒNƒ’è‹`
+//std::string ã® TCHAR å¯¾å¿œç”¨ãƒã‚¯ãƒ­å®šç¾©
 #ifdef _UNICODE
 #define tstring wstring
 #else
@@ -82,11 +82,11 @@ private:
 
 
 
-//‹¤’Êƒ}ƒNƒ
+//å…±é€šãƒã‚¯ãƒ­
 #define _FT _T
 #include "util/StaticType.h"
 
-//‹¤’ÊŒ^
+//å…±é€šå‹
 typedef StaticString<TCHAR,_MAX_PATH> SFilePath;
 typedef StaticString<TCHAR, MAX_GREP_PATH> SFilePathLong;
 class CFilePath : public StaticString<TCHAR,_MAX_PATH>{
@@ -107,7 +107,7 @@ public:
 		_tcscat( szDirPath, szDir );
 		return szDirPath;
 	}
-	//Šg’£q‚ğæ“¾‚·‚é
+	//æ‹¡å¼µå­ã‚’å–å¾—ã™ã‚‹
 	LPCTSTR GetExt( bool bWithoutDot = false ) const
 	{
 		const TCHAR* head = c_str();
@@ -119,7 +119,7 @@ public:
 			p--;
 		}
 		if(p>=head && *p==_T('.')){
-			return bWithoutDot ? p+1 : p;	//bWithoutDot==true‚È‚çƒhƒbƒg‚È‚µ‚ğ•Ô‚·
+			return bWithoutDot ? p+1 : p;	//bWithoutDot==trueãªã‚‰ãƒ‰ãƒƒãƒˆãªã—ã‚’è¿”ã™
 		}else{
 			return auto_strchr(head,_T('\0'));
 		}
@@ -127,7 +127,7 @@ public:
 };
 
 
-//$$ ‰¼
+//$$ ä»®
 class CCommandLineString{
 public:
 	CCommandLineString()

--- a/sakura_core/basis/CStrictInteger.cpp
+++ b/sakura_core/basis/CStrictInteger.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2007, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -23,9 +23,9 @@
 */
 
 #include "StdAfx.h"
-#if defined(_MSC_VER) && _MSC_VER>=1400 //VS2005�ȍ~�Ȃ�
+#if defined(_MSC_VER) && _MSC_VER>=1400 //VS2005以降なら
 #ifdef _DEBUG
-#define USE_STRICT_INT //��������R�����g�A�E�g����ƌ��i��int�������ɂȂ�܂��B�����[�X�r���h�ł͏�ɖ����B
+#define USE_STRICT_INT //←これをコメントアウトすると厳格なintが無効になります。リリースビルドでは常に無効。
 #endif
 #endif
 

--- a/sakura_core/basis/CStrictInteger.h
+++ b/sakura_core/basis/CStrictInteger.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ŒµŠi‚Á‚Õ‚è‚ğƒJƒXƒ^ƒ}ƒCƒY‰Â”\‚È®”ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief å³æ ¼ã£ã·ã‚Šã‚’ã‚«ã‚¹ã‚¿ãƒã‚¤ã‚ºå¯èƒ½ãªæ•´æ•°ã‚¯ãƒ©ã‚¹
 	       Integer class, which is static-type-checked strict and flexible at compile.
 
 	@author kobake
@@ -31,7 +31,7 @@
 #ifndef SAKURA_CSTRICTINTEGER_6F202774_0F82_4BB7_B107_37DE5443309E_H_
 #define SAKURA_CSTRICTINTEGER_6F202774_0F82_4BB7_B107_37DE5443309E_H_
 
-//intˆÈŠO‚Ì®”Œ^‚àint‚ÉƒLƒƒƒXƒg‚µ‚Äˆµ‚¤
+//intä»¥å¤–ã®æ•´æ•°å‹ã‚‚intã«ã‚­ãƒ£ã‚¹ãƒˆã—ã¦æ‰±ã†
 #define STRICTINT_OTHER_TYPE_AS_INT(TYPE) \
 	Me& operator += (TYPE rhs)			{ return operator += ((int)rhs); } \
 	Me& operator -= (TYPE rhs)			{ return operator -= ((int)rhs); } \
@@ -45,13 +45,13 @@
 	bool operator != (TYPE rhs) const	{ return operator != ((int)rhs); }
 
 
-//! ˆÃ–Ù‚Ì•ÏŠ·‚ğ‹–‚³‚È‚¢A®”ƒNƒ‰ƒX
+//! æš—é»™ã®å¤‰æ›ã‚’è¨±ã•ãªã„ã€æ•´æ•°ã‚¯ãƒ©ã‚¹
 template <
-	int STRICT_ID,			//!< Œ^‚ğ•ª‚¯‚é‚½‚ß‚Ì”’lB0 or 1B
-	bool ALLOW_CMP_INT,		//!< int‚Æ‚Ì”äŠr‚ğ‹–‚·‚©‚Ç‚¤‚©
-	bool ALLOW_ADDSUB_INT,	//!< int‚Æ‚Ì‰ÁŒ¸Z‚ğ‹–‚·‚©‚Ç‚¤‚©
-	bool ALLOW_CAST_INT,	//!< int‚Ö‚ÌˆÃ–Ù‚Ì•ÏŠ·‚ğ‹–‚·‚©‚Ç‚¤‚©
-	bool ALLOW_ASSIGNOP_INT	//!< int‚Ì‘ã“ü‚ğ‹–‚·‚©‚Ç‚¤‚©
+	int STRICT_ID,			//!< å‹ã‚’åˆ†ã‘ã‚‹ãŸã‚ã®æ•°å€¤ã€‚0 or 1ã€‚
+	bool ALLOW_CMP_INT,		//!< intã¨ã®æ¯”è¼ƒã‚’è¨±ã™ã‹ã©ã†ã‹
+	bool ALLOW_ADDSUB_INT,	//!< intã¨ã®åŠ æ¸›ç®—ã‚’è¨±ã™ã‹ã©ã†ã‹
+	bool ALLOW_CAST_INT,	//!< intã¸ã®æš—é»™ã®å¤‰æ›ã‚’è¨±ã™ã‹ã©ã†ã‹
+	bool ALLOW_ASSIGNOP_INT	//!< intã®ä»£å…¥ã‚’è¨±ã™ã‹ã©ã†ã‹
 >
 class CStrictInteger{
 private:
@@ -65,7 +65,7 @@ private:
 	static const int NOT_STRICT_ID = (1-STRICT_ID);
 
 private:
-	//!ƒSƒ~ƒNƒ‰ƒX
+	//!ã‚´ãƒŸã‚¯ãƒ©ã‚¹
 	class CDummy{
 	public:
 		CDummy();
@@ -74,19 +74,19 @@ private:
 	template<bool t, bool=false> struct ChooseIntOrDummy {
 		typedef int Type;
 	};
-	// ƒNƒ‰ƒX“à‚Åƒeƒ“ƒvƒŒ[ƒg‚Ì“Áê‰»‚ğ‚·‚é‚ÆG++‚É“{‚ç‚ê‚é‚Ì‚Å•”•ª“Áê‰»‚É‚·‚é
+	// ã‚¯ãƒ©ã‚¹å†…ã§ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã®ç‰¹æ®ŠåŒ–ã‚’ã™ã‚‹ã¨G++ã«æ€’ã‚‰ã‚Œã‚‹ã®ã§éƒ¨åˆ†ç‰¹æ®ŠåŒ–ã«ã™ã‚‹
 	template<bool _> struct ChooseIntOrDummy<false, _> {
 		typedef CDummy Type;
 	};
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CStrictInteger(){ m_value=0; }
 	CStrictInteger(const Me& rhs){ m_value=rhs.m_value; }
 
-	//int‚©‚ç‚Ì•ÏŠ·‚ÍAu–¾¦“I‚Éw’è‚µ‚½‚Æ‚«‚Ì‚İv‰Â”\
+	//intã‹ã‚‰ã®å¤‰æ›ã¯ã€ã€Œæ˜ç¤ºçš„ã«æŒ‡å®šã—ãŸã¨ãã®ã¿ã€å¯èƒ½
 	explicit CStrictInteger(int value){ m_value=value; }
 
-	//Zp‰‰Zq (‰ÁZAŒ¸Z‚Í“¯ƒNƒ‰ƒX“¯m‚Å‚µ‚©‹–‚³‚È‚¢)
+	//ç®—è¡“æ¼”ç®—å­ (åŠ ç®—ã€æ¸›ç®—ã¯åŒã‚¯ãƒ©ã‚¹åŒå£«ã§ã—ã‹è¨±ã•ãªã„)
 	Me& operator += (const Me& rhs)	{ m_value += rhs.m_value; return *this; }
 	Me& operator -= (const Me& rhs)	{ m_value -= rhs.m_value; return *this; }
 	Me& operator *= (int n)			{ m_value *= n; return *this; }
@@ -94,7 +94,7 @@ public:
 	Me& operator %= (int n)			{ m_value %= n; return *this; }
 	Me& operator %= (const Me& rhs)	{ m_value %= rhs.m_value; return *this; }
 
-	//Zp‰‰Zq‚Q (‰ÁZAŒ¸Z‚Í“¯ƒNƒ‰ƒX“¯m‚Å‚µ‚©‹–‚³‚È‚¢)
+	//ç®—è¡“æ¼”ç®—å­ï¼’ (åŠ ç®—ã€æ¸›ç®—ã¯åŒã‚¯ãƒ©ã‚¹åŒå£«ã§ã—ã‹è¨±ã•ãªã„)
 	Me operator + (const Me& rhs)	const{ Me ret=*this; return ret+=rhs; }
 	Me operator - (const Me& rhs)	const{ Me ret=*this; return ret-=rhs; }
 	Me operator * (int n)			const{ Me ret=*this; return ret*=n; }
@@ -102,19 +102,19 @@ public:
 	Me operator % (int n)			const{ Me ret=*this; return ret%=n; }
 	Me operator % (const Me& rhs)	const{ Me ret=*this; return ret%=rhs; }
 
-	//Zp‰‰Zq‚R
+	//ç®—è¡“æ¼”ç®—å­ï¼“
 	int operator ++ ()   { return ++m_value; }	//++c;
 	int operator ++ (int){ return m_value++; }	//c++;
 	int operator -- ()   { return --m_value; }	//--c;
 	int operator -- (int){ return m_value--; }	//c--;
 
-	//Zp‰‰Zq‚S
+	//ç®—è¡“æ¼”ç®—å­ï¼”
 	Me operator - () const{ return Me(-m_value); }
 
-	//‘ã“ü‰‰Zq
+	//ä»£å…¥æ¼”ç®—å­
 	Me& operator = (const Me& rhs){ m_value=rhs.m_value; return *this; }
 
-	//”äŠr‰‰Zq
+	//æ¯”è¼ƒæ¼”ç®—å­
 	bool operator <  (const Me& rhs) const{ return m_value <  rhs.m_value; }
 	bool operator <= (const Me& rhs) const{ return m_value <= rhs.m_value; }
 	bool operator >  (const Me& rhs) const{ return m_value >  rhs.m_value; }
@@ -122,19 +122,19 @@ public:
 	bool operator == (const Me& rhs) const{ return m_value == rhs.m_value; }
 	bool operator != (const Me& rhs) const{ return m_value != rhs.m_value; }
 
-	//ŠÖ”
+	//é–¢æ•°
 	int GetValue() const{ return m_value; }
 	void SetValue(int n){ m_value=n; }
 
-	//Int(CLaxInt)‚Ö‚Ì•ÏŠ·‚Íí‚É‹–‚·
+	//Int(CLaxInt)ã¸ã®å¤‰æ›ã¯å¸¸ã«è¨±ã™
 	operator Int() const{ return Int(m_value); }
 
-	//intˆÈŠO‚Ì®”Œ^‚àint‚ÉƒLƒƒƒXƒg‚µ‚Äˆµ‚¤
+	//intä»¥å¤–ã®æ•´æ•°å‹ã‚‚intã«ã‚­ãƒ£ã‚¹ãƒˆã—ã¦æ‰±ã†
 	STRICTINT_OTHER_TYPE_AS_INT(short)
 	STRICTINT_OTHER_TYPE_AS_INT(size_t)
 	STRICTINT_OTHER_TYPE_AS_INT(LONG)
 
-	// -- -- -- -- •Êí‚ÌCStrictInteger‚Æ‚Ì‰‰Z‚Íâ‘Î‹–‚³‚ñ(‚â‚è‚½‚«‚áint‚Å‚à‰î‚µ‚Ä‚­‚¾‚³‚¢) -- -- -- -- //
+	// -- -- -- -- åˆ¥ç¨®ã®CStrictIntegerã¨ã®æ¼”ç®—ã¯çµ¶å¯¾è¨±ã•ã‚“(ã‚„ã‚ŠãŸãã‚ƒintã§ã‚‚ä»‹ã—ã¦ãã ã•ã„) -- -- -- -- //
 private:
 	template <bool B0,bool B1,bool B2,bool B3> Me&  operator += (const CStrictInteger<NOT_STRICT_ID,B0,B1,B2,B3>&);
 	template <bool B0,bool B1,bool B2,bool B3> Me&  operator -= (const CStrictInteger<NOT_STRICT_ID,B0,B1,B2,B3>&);
@@ -149,7 +149,7 @@ private:
 	template <bool B0,bool B1,bool B2,bool B3> bool operator != (const CStrictInteger<NOT_STRICT_ID,B0,B1,B2,B3>&) const;
 
 
-	// -- -- -- -- ALLOW_ADDSUB_INT‚ªtrue‚Ìê‡‚ÍAint‚Æ‚Ì‰ÁŒ¸Z‚ğ‹–‚· -- -- -- -- //
+	// -- -- -- -- ALLOW_ADDSUB_INTãŒtrueã®å ´åˆã¯ã€intã¨ã®åŠ æ¸›ç®—ã‚’è¨±ã™ -- -- -- -- //
 private:
 	typedef typename ChooseIntOrDummy< ALLOW_ADDSUB_INT>::Type AddsubIntegerType;
 	typedef typename ChooseIntOrDummy<!ALLOW_ADDSUB_INT>::Type NotAddsubIntegerType;
@@ -159,14 +159,14 @@ public:
 	Me  operator +  (AddsubIntegerType rhs) const{ Me ret=*this; return ret+=rhs; }
 	Me  operator -  (AddsubIntegerType rhs) const{ Me ret=*this; return ret-=rhs; }
 private:
-	//¦ALLOW_ADDSUB_INT‚ªfalse‚Ìê‡‚ÍAprivateƒƒ“ƒo‚ğ’u‚­‚±‚Æ‚É‚æ‚èAu–¾¦“I‚Év‰ÁŒ¸Z‚ğ‹Ö~‚·‚éB
+	//â€»ALLOW_ADDSUB_INTãŒfalseã®å ´åˆã¯ã€privateãƒ¡ãƒ³ãƒã‚’ç½®ãã“ã¨ã«ã‚ˆã‚Šã€ã€Œæ˜ç¤ºçš„ã«ã€åŠ æ¸›ç®—ã‚’ç¦æ­¢ã™ã‚‹ã€‚
 	Me& operator += (NotAddsubIntegerType rhs);
 	Me& operator -= (NotAddsubIntegerType rhs);
 	Me  operator +  (NotAddsubIntegerType rhs) const;
 	Me  operator -  (NotAddsubIntegerType rhs) const;
 
 
-	// -- -- -- -- ALLOW_CMP_INT‚ªtrue‚Ìê‡‚ÍAint‚Æ‚Ì”äŠr‚ğ‹–‚· -- -- -- -- //
+	// -- -- -- -- ALLOW_CMP_INTãŒtrueã®å ´åˆã¯ã€intã¨ã®æ¯”è¼ƒã‚’è¨±ã™ -- -- -- -- //
 private:
 	typedef typename ChooseIntOrDummy< ALLOW_CMP_INT>::Type CmpIntegerType;
 	typedef typename ChooseIntOrDummy<!ALLOW_CMP_INT>::Type NotCmpIntegerType;
@@ -178,7 +178,7 @@ public:
 	bool operator == (CmpIntegerType rhs) const{ return m_value == rhs; }
 	bool operator != (CmpIntegerType rhs) const{ return m_value != rhs; }
 private:
-	//¦ALLOW_CMP_INT‚ªfalse‚Ìê‡‚ÍAprivateƒƒ“ƒo‚ğ’u‚­‚±‚Æ‚É‚æ‚èAu–¾¦“I‚Év”äŠr‚ğ‹Ö~‚·‚éB
+	//â€»ALLOW_CMP_INTãŒfalseã®å ´åˆã¯ã€privateãƒ¡ãƒ³ãƒã‚’ç½®ãã“ã¨ã«ã‚ˆã‚Šã€ã€Œæ˜ç¤ºçš„ã«ã€æ¯”è¼ƒã‚’ç¦æ­¢ã™ã‚‹ã€‚
 	bool operator <  (NotCmpIntegerType rhs) const;
 	bool operator <= (NotCmpIntegerType rhs) const;
 	bool operator >  (NotCmpIntegerType rhs) const;
@@ -187,36 +187,36 @@ private:
 	bool operator != (NotCmpIntegerType rhs) const;
 
 
-	// -- -- -- -- ALLOW_CAST_INT‚ªtrue‚Ìê‡‚ÍAint‚Ö‚ÌˆÃ–Ù‚Ì•ÏŠ·‚ğ‹–‚· -- -- -- -- //
+	// -- -- -- -- ALLOW_CAST_INTãŒtrueã®å ´åˆã¯ã€intã¸ã®æš—é»™ã®å¤‰æ›ã‚’è¨±ã™ -- -- -- -- //
 private:
 	typedef typename ChooseIntOrDummy< ALLOW_CAST_INT>::Type CastIntegerType;
 	typedef typename ChooseIntOrDummy<!ALLOW_CAST_INT>::Type NotCastIntegerType;
 public:
 	operator CastIntegerType() const{ return m_value; }
 private:
-	//¦ALLOW_CAST_INT‚ªfalse‚Ìê‡‚ÍAprivateƒƒ“ƒo‚ğ’u‚­‚±‚Æ‚É‚æ‚èAu–¾¦“I‚ÉvˆÃ–Ù•ÏŠ·‚ğ‹Ö~‚·‚éB
+	//â€»ALLOW_CAST_INTãŒfalseã®å ´åˆã¯ã€privateãƒ¡ãƒ³ãƒã‚’ç½®ãã“ã¨ã«ã‚ˆã‚Šã€ã€Œæ˜ç¤ºçš„ã«ã€æš—é»™å¤‰æ›ã‚’ç¦æ­¢ã™ã‚‹ã€‚
 	operator NotCastIntegerType() const;
 
 
-	// -- -- -- -- ALLOW_ASSIGNOP_INT‚ªtrue‚Ìê‡‚ÍAint‚Ì‘ã“ü‚ğ‹–‚· -- -- -- -- //
+	// -- -- -- -- ALLOW_ASSIGNOP_INTãŒtrueã®å ´åˆã¯ã€intã®ä»£å…¥ã‚’è¨±ã™ -- -- -- -- //
 private:
 	typedef typename ChooseIntOrDummy< ALLOW_ASSIGNOP_INT>::Type AssignIntegerType;
 	typedef typename ChooseIntOrDummy<!ALLOW_ASSIGNOP_INT>::Type NotAssignIntegerType;
 public:
 	Me& operator = (const AssignIntegerType& rhs){ m_value = rhs; return *this; }
 private:
-	//¦ALLOW_ASSIGNOP_INT‚ªfalse‚Ìê‡‚ÍAprivateƒƒ“ƒo‚ğ’u‚­‚±‚Æ‚É‚æ‚èAu–¾¦“I‚Év‘ã“ü‚ğ‹Ö~‚·‚éB
+	//â€»ALLOW_ASSIGNOP_INTãŒfalseã®å ´åˆã¯ã€privateãƒ¡ãƒ³ãƒã‚’ç½®ãã“ã¨ã«ã‚ˆã‚Šã€ã€Œæ˜ç¤ºçš„ã«ã€ä»£å…¥ã‚’ç¦æ­¢ã™ã‚‹ã€‚
 	Me& operator = (const NotAssignIntegerType&);
 
 
-	// -- -- -- -- ƒƒ“ƒo•Ï” -- -- -- -- //
+	// -- -- -- -- ãƒ¡ãƒ³ãƒå¤‰æ•° -- -- -- -- //
 private:
 	int m_value;
 };
 
 
 
-//¶•Ó‚ªint“™‚Ìê‡‚Ì‰‰Zq
+//å·¦è¾ºãŒintç­‰ã®å ´åˆã®æ¼”ç®—å­
 #define STRICTINT_LEFT_INT_CMP(TYPE) \
 	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <  (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs> lhs; } \
 	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <= (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs>=lhs; } \

--- a/sakura_core/basis/CStrictPoint.cpp
+++ b/sakura_core/basis/CStrictPoint.cpp
@@ -1,2 +1,2 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "CStrictPoint.h"

--- a/sakura_core/basis/CStrictPoint.h
+++ b/sakura_core/basis/CStrictPoint.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -24,7 +24,7 @@
 #ifndef SAKURA_CSTRICTPOINT_56029CB9_EAD4_489E_9300_5990D582337F_H_
 #define SAKURA_CSTRICTPOINT_56029CB9_EAD4_489E_9300_5990D582337F_H_
 
-//’PˆÊ‚ª–¾¦“I‚É‹æ•Ê‚³‚ê‚½ƒ|ƒCƒ“ƒgŒ^B¦POINT‚ÍŒp³‚µ‚È‚¢‚±‚Æ‚É‚µ‚½
+//å˜ä½ãŒæ˜ç¤ºçš„ã«åŒºåˆ¥ã•ã‚ŒãŸãƒã‚¤ãƒ³ãƒˆå‹ã€‚â€»POINTã¯ç¶™æ‰¿ã—ãªã„ã“ã¨ã«ã—ãŸ
 /*
 template <int TYPE> class CStrictPoint : public CMyPoint{
 public:
@@ -32,7 +32,7 @@ public:
 	CStrictPoint(int _x,int _y) : CMyPoint(_x,_y) { }
 	CStrictPoint(const CStrictPoint& rhs) : CMyPoint(rhs) { }
 
-	//¦POINT‚©‚ç‚Ì•ÏŠ·‚ÍAu–¾¦“I‚Éw’è‚³‚ê‚½‚Æ‚«‚Ì‚İv‹–‰Â‚·‚éB
+	//â€»POINTã‹ã‚‰ã®å¤‰æ›ã¯ã€ã€Œæ˜ç¤ºçš„ã«æŒ‡å®šã•ã‚ŒãŸã¨ãã®ã¿ã€è¨±å¯ã™ã‚‹ã€‚
 	explicit CStrictPoint(const POINT& rhs) : CMyPoint(rhs) { }
 };
 */
@@ -45,7 +45,7 @@ public:
 public:
 	using SUPER::x;
 	using SUPER::y;
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CStrictPoint(){ x=SuperIntType(0); y=SuperIntType(0); }
 	CStrictPoint(int _x,int _y){ x=SuperIntType(_x); y=SuperIntType(_y); }
 #ifdef USE_STRICT_INT
@@ -53,30 +53,30 @@ public:
 #endif
 	CStrictPoint(const SUPER& rhs){ x=rhs.x; y=rhs.y; }
 
-	//‘¼‚ÌŒ^‚©‚ç‚àAu–¾¦“I‚Éw’è‚·‚ê‚Îv•ÏŠ·‚ª‰Â”\
+	//ä»–ã®å‹ã‹ã‚‰ã‚‚ã€ã€Œæ˜ç¤ºçš„ã«æŒ‡å®šã™ã‚Œã°ã€å¤‰æ›ãŒå¯èƒ½
 	template <class SRC>
 	explicit CStrictPoint(const SRC& rhs){ x=(SuperIntType)rhs.x; y=(SuperIntType)rhs.y; }
 
-	//Zp‰‰Zq
+	//ç®—è¡“æ¼”ç®—å­
 	CStrictPoint& operator += (const SUPER& rhs){ x+=rhs.x; y+=rhs.y; return *this; }
 	CStrictPoint& operator -= (const SUPER& rhs){ x-=rhs.x; y-=rhs.y; return *this; }
 	CStrictPoint& operator *= (int n){ x*=n; y*=n; return *this; }
 	CStrictPoint& operator /= (int n){ x/=n; y/=n; return *this; }
 
-	//Zp‰‰Zq‚Q
+	//ç®—è¡“æ¼”ç®—å­ï¼’
 	CStrictPoint operator + (const SUPER& rhs) const{ CStrictPoint tmp=*this; tmp+=rhs; return tmp; }
 	CStrictPoint operator - (const SUPER& rhs) const{ CStrictPoint tmp=*this; tmp-=rhs; return tmp; }
 	CStrictPoint operator * (int n) const{ CStrictPoint tmp=*this; tmp*=n; return tmp; }
 	CStrictPoint operator / (int n) const{ CStrictPoint tmp=*this; tmp/=n; return tmp; }
 
-	//‘ã“ü‰‰Zq
+	//ä»£å…¥æ¼”ç®—å­
 	CStrictPoint& operator = (const SUPER& rhs){ x=rhs.x; y=rhs.y; return *this; }
 
-	//”äŠr‰‰Zq
+	//æ¯”è¼ƒæ¼”ç®—å­
 	bool operator == (const SUPER& rhs) const{ return x==rhs.x && y==rhs.y; }
 	bool operator != (const SUPER& rhs) const{ return !this->operator==(rhs); }
 
-	//İ’è
+	//è¨­å®š
 	void Clear(){ x=SuperIntType(0); y=SuperIntType(0); }
 	void Set(INT_TYPE _x, INT_TYPE _y){ x=SuperIntType(_x); y=SuperIntType(_y); }
 	void Set(const SUPER& pt){ x=pt.x; y=pt.y; }
@@ -85,26 +85,26 @@ public:
 	void Offset(int _x,int _y){ x+=_x; y+=_y; }
 	void Offset(const SUPER& pt){ x+=pt.x; y+=pt.y; }
 
-	//æ“¾
+	//å–å¾—
 	SuperIntType GetX() const{ return x; }
 	SuperIntType GetY() const{ return y; }
 	SUPER Get() const{ return *this; }
 	INT_TYPE GetX2() const{ return INT_TYPE(x); }
 	INT_TYPE GetY2() const{ return INT_TYPE(y); }
 
-	//! x,y ‚¢‚¸‚ê‚©‚ª 0 ‚æ‚è¬‚³‚¢ê‡‚É true ‚ğ•Ô‚·
+	//! x,y ã„ãšã‚Œã‹ãŒ 0 ã‚ˆã‚Šå°ã•ã„å ´åˆã« true ã‚’è¿”ã™
 	bool HasNegative() const
 	{
 		return x<0 || y<0;
 	}
 
-	//! x,y ‚Ç‚¿‚ç‚à©‘R”‚Å‚ ‚ê‚Î true
+	//! x,y ã©ã¡ã‚‰ã‚‚è‡ªç„¶æ•°ã§ã‚ã‚Œã° true
 	bool BothNatural() const
 	{
 		return x>=0 && y>=0;
 	}
 
-	//“Áê
+	//ç‰¹æ®Š
 	POINT GetPOINT() const
 	{
 		POINT pt={(Int)x,(Int)y};

--- a/sakura_core/basis/CStrictRange.cpp
+++ b/sakura_core/basis/CStrictRange.cpp
@@ -1,2 +1,2 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "CStrictRange.h"

--- a/sakura_core/basis/CStrictRange.h
+++ b/sakura_core/basis/CStrictRange.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -29,7 +29,7 @@ class CRangeBase{
 public:
 	typedef typename PointType::IntType IntType;
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CRangeBase()
 	{
 	}
@@ -43,7 +43,7 @@ public:
 		m_ptTo=_ptTo;
 	}
 
-	//‘ã“ü
+	//ä»£å…¥
 	CRangeBase& operator = (const CRangeBase& rhs)
 	{
 		m_ptFrom=rhs.m_ptFrom;
@@ -51,7 +51,7 @@ public:
 		return *this;
 	}
 
-	//”äŠr
+	//æ¯”è¼ƒ
 	bool operator == (const CRangeBase& rhs) const
 	{
 		return m_ptFrom == rhs.m_ptFrom && m_ptTo == rhs.m_ptTo;
@@ -61,8 +61,8 @@ public:
 		return !operator==(rhs);
 	}
 
-	//”»’è
-	//! 1•¶š‚µ‚©‘I‘ğ‚µ‚Ä‚È‚¢ó‘Ô‚È‚çtrue
+	//åˆ¤å®š
+	//! 1æ–‡å­—ã—ã‹é¸æŠã—ã¦ãªã„çŠ¶æ…‹ãªã‚‰true
 	bool IsOne() const
 	{
 		return m_ptFrom==m_ptTo;
@@ -71,12 +71,12 @@ public:
 	{
 		return m_ptFrom.y==m_ptTo.y;
 	}
-	bool IsValid() const //!—LŒø‚È”ÍˆÍ‚È‚çtrue
+	bool IsValid() const //!æœ‰åŠ¹ãªç¯„å›²ãªã‚‰true
 	{
 		return m_ptFrom.BothNatural() && m_ptTo.BothNatural();
 	}
 
-	//æ“¾
+	//å–å¾—
 	PointType GetFrom() const
 	{
 		return m_ptFrom;
@@ -86,7 +86,7 @@ public:
 		return m_ptTo;
 	}
 
-	//“Áê
+	//ç‰¹æ®Š
 	PointType* GetFromPointer()
 	{
 		return &m_ptFrom;
@@ -97,7 +97,7 @@ public:
 	}
 
 
-	//İ’è
+	//è¨­å®š
 	void Clear(int n)
 	{
 		m_ptFrom.Set(IntType(n),IntType(n));
@@ -147,7 +147,7 @@ public:
 		m_ptTo.y = nY;
 	}
 
-	//“Áêİ’è
+	//ç‰¹æ®Šè¨­å®š
 	void SetLine(IntType nY)					{ m_ptFrom.y = nY;     m_ptTo.y = nY;   }
 	void SetXs(IntType nXFrom, IntType nXTo)	{ m_ptFrom.x = nXFrom; m_ptTo.x = nXTo; }
 private:

--- a/sakura_core/basis/CStrictRect.cpp
+++ b/sakura_core/basis/CStrictRect.cpp
@@ -1,2 +1,2 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "CStrictRect.h"

--- a/sakura_core/basis/CStrictRect.h
+++ b/sakura_core/basis/CStrictRect.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -31,25 +31,25 @@ public:
 	typedef INT_TYPE	IntType;
 	typedef POINT_TYPE	PointType;
 public:
-	//ƒƒ“ƒo•Ï”‚ÍŒöŠJ
+	//ãƒ¡ãƒ³ãƒå¤‰æ•°ã¯å…¬é–‹
 	IntType left;
 	IntType top;
 	IntType right;
 	IntType bottom;
 
 public:
-	//!¶ãÀ•W (TopLeft)
+	//!å·¦ä¸Šåº§æ¨™ (TopLeft)
 	PointType UpperLeft() const
 	{
 		return PointType(left,top);
 	}
-	//!‰E‰ºÀ•W (BottomRight)
+	//!å³ä¸‹åº§æ¨™ (BottomRight)
 	PointType LowerRight() const
 	{
 		return PointType(right,bottom);
 	}
 
-	//!ƒqƒbƒgƒ`ƒFƒbƒN
+	//!ãƒ’ãƒƒãƒˆãƒã‚§ãƒƒã‚¯
 	bool PtInRect(const PointType& pt) const
 	{
 		return pt.x>=left && pt.x<right && pt.y>=top && pt.y<bottom;

--- a/sakura_core/basis/SakuraBasis.cpp
+++ b/sakura_core/basis/SakuraBasis.cpp
@@ -1,2 +1,2 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "SakuraBasis.h"

--- a/sakura_core/basis/SakuraBasis.h
+++ b/sakura_core/basis/SakuraBasis.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -27,41 +27,41 @@
 #include <Windows.h> //POINT,LONG
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      ‚PŸŒ³Œ^‚Ì’è‹`                         //
+//                      ï¼‘æ¬¡å…ƒå‹ã®å®šç¾©                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //
 #ifdef USE_STRICT_INT
-	// -- -- ŒµŠi‚Èint‚Å’PˆÊŒ^‚ğ’è‹` -- -- //
+	// -- -- å³æ ¼ãªintã§å˜ä½å‹ã‚’å®šç¾© -- -- //
 
 	#include "CStrictInteger.h"
 
-	//ƒƒWƒbƒN’PˆÊ
+	//ãƒ­ã‚¸ãƒƒã‚¯å˜ä½
 	typedef CStrictInteger <
-		0,		//!< Œ^‚ğ•ª‚¯‚é‚½‚ß‚Ì”’lB
-		true,	//!< int‚Æ‚Ì”äŠr‚ğ‹–‚·‚©‚Ç‚¤‚©
-		true,	//!< int‚Æ‚Ì‰ÁŒ¸Z‚ğ‹–‚·‚©‚Ç‚¤‚©
-		true,	//!< int‚Ö‚ÌˆÃ–Ù‚Ì•ÏŠ·‚ğ‹–‚·‚©‚Ç‚¤‚©
-		true	//!< int‚Ì‘ã“ü‚ğ‹–‚·‚©‚Ç‚¤‚©
+		0,		//!< å‹ã‚’åˆ†ã‘ã‚‹ãŸã‚ã®æ•°å€¤ã€‚
+		true,	//!< intã¨ã®æ¯”è¼ƒã‚’è¨±ã™ã‹ã©ã†ã‹
+		true,	//!< intã¨ã®åŠ æ¸›ç®—ã‚’è¨±ã™ã‹ã©ã†ã‹
+		true,	//!< intã¸ã®æš—é»™ã®å¤‰æ›ã‚’è¨±ã™ã‹ã©ã†ã‹
+		true	//!< intã®ä»£å…¥ã‚’è¨±ã™ã‹ã©ã†ã‹
 	>
 	CLogicInt;
 
-	//ƒŒƒCƒAƒEƒg’PˆÊ
+	//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½
 	typedef CStrictInteger <
-		1,		//!< Œ^‚ğ•ª‚¯‚é‚½‚ß‚Ì”’lB
-		true,	//!< int‚Æ‚Ì”äŠr‚ğ‹–‚·‚©‚Ç‚¤‚©
-		true,	//!< int‚Æ‚Ì‰ÁŒ¸Z‚ğ‹–‚·‚©‚Ç‚¤‚©
-		false,	//!< int‚Ö‚ÌˆÃ–Ù‚Ì•ÏŠ·‚ğ‹–‚·‚©‚Ç‚¤‚©
-		true	//!< int‚Ì‘ã“ü‚ğ‹–‚·‚©‚Ç‚¤‚©
+		1,		//!< å‹ã‚’åˆ†ã‘ã‚‹ãŸã‚ã®æ•°å€¤ã€‚
+		true,	//!< intã¨ã®æ¯”è¼ƒã‚’è¨±ã™ã‹ã©ã†ã‹
+		true,	//!< intã¨ã®åŠ æ¸›ç®—ã‚’è¨±ã™ã‹ã©ã†ã‹
+		false,	//!< intã¸ã®æš—é»™ã®å¤‰æ›ã‚’è¨±ã™ã‹ã©ã†ã‹
+		true	//!< intã®ä»£å…¥ã‚’è¨±ã™ã‹ã©ã†ã‹
 	>
 	CLayoutInt;
 
 #else
-	// -- -- ’Êí‚Ìint‚Å’PˆÊŒ^‚ğ’è‹`
+	// -- -- é€šå¸¸ã®intã§å˜ä½å‹ã‚’å®šç¾©
 
-	//ƒƒWƒbƒN’PˆÊ
+	//ãƒ­ã‚¸ãƒƒã‚¯å˜ä½
 	typedef int CLogicInt;
 
-	//ƒŒƒCƒAƒEƒg’PˆÊ
+	//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½
 	typedef int CLayoutInt;
 
 #endif
@@ -78,37 +78,37 @@ typedef int         CKetaXInt;
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      ‚QŸŒ³Œ^‚Ì’è‹`                         //
+//                      ï¼’æ¬¡å…ƒå‹ã®å®šç¾©                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //
 #include "CStrictRange.h"
 #include "CStrictPoint.h"
 #include "CStrictRect.h"
 
-//ƒƒWƒbƒN’PˆÊ
-struct SLogicPoint{ CLogicInt x; CLogicInt y; }; //Šî’ê\‘¢‘Ì
+//ãƒ­ã‚¸ãƒƒã‚¯å˜ä½
+struct SLogicPoint{ CLogicInt x; CLogicInt y; }; //åŸºåº•æ§‹é€ ä½“
 typedef CStrictPoint<SLogicPoint, CLogicInt>	CLogicPoint;
 typedef CRangeBase<CLogicPoint>					CLogicRange;
 typedef CStrictRect<CLogicInt, CLogicPoint>		CLogicRect;
 
-//ƒŒƒCƒAƒEƒg’PˆÊ
-struct SLayoutPoint{ CLayoutInt x; CLayoutInt y; }; //Šî’ê\‘¢‘Ì
+//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½
+struct SLayoutPoint{ CLayoutInt x; CLayoutInt y; }; //åŸºåº•æ§‹é€ ä½“
 typedef CStrictPoint<SLayoutPoint, CLayoutInt>	CLayoutPoint;
 typedef CRangeBase<CLayoutPoint>				CLayoutRange;
 typedef CStrictRect<CLayoutInt, CLayoutPoint>	CLayoutRect;
 
-//‚ä‚é‚¢’PˆÊ
+//ã‚†ã‚‹ã„å˜ä½
 #include "CMyPoint.h"
 typedef CRangeBase<CMyPoint>     SelectionRange;
 
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒc[ƒ‹                             //
+//                          ãƒ„ãƒ¼ãƒ«                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 #include "CMyRect.h"
 
-//•ÏŠ·ŠÖ”
+//å¤‰æ›é–¢æ•°
 template <class POINT_T>
 inline void TwoPointToRange(
 	CRangeBase<POINT_T>* prangeDst,
@@ -123,7 +123,7 @@ inline void TwoPointToRange(
 }
 
 
-//! 2“_‚ğ‘ÎŠp‚Æ‚·‚é‹éŒ`‚ğ‹‚ß‚é
+//! 2ç‚¹ã‚’å¯¾è§’ã¨ã™ã‚‹çŸ©å½¢ã‚’æ±‚ã‚ã‚‹
 template <class T, class INT_TYPE>
 inline void TwoPointToRect(
 	CStrictRect<INT_TYPE, CStrictPoint<T,INT_TYPE> >*	prcRect,

--- a/sakura_core/basis/primitive.h
+++ b/sakura_core/basis/primitive.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -24,7 +24,7 @@
 #ifndef SAKURA_PRIMITIVE_0AE619F1_2A04_42A0_92F6_72C9B845799E_H_
 #define SAKURA_PRIMITIVE_0AE619F1_2A04_42A0_92F6_72C9B845799E_H_
 
-// -- -- -- -- ˜_—Œ^ -- -- -- -- //
+// -- -- -- -- è«–ç†å‹ -- -- -- -- //
 
 // novice 2002/09/14
 #ifndef TRUE
@@ -40,21 +40,21 @@
 #endif
 
 
-// -- -- -- -- ’è” -- -- -- -- //
+// -- -- -- -- å®šæ•° -- -- -- -- //
 
 #ifndef NULL
 #define NULL 0
 #endif
 
 
-// -- -- -- -- •¶š -- -- -- -- //
+// -- -- -- -- æ–‡å­— -- -- -- -- //
 
-//char,wchar_t ‚Ì•Ï‚í‚è‚ÉA•Ê–¼‚Ì ACHAR,WCHAR ‚ğg‚¤‚ÆAƒ\[ƒX®Œ`‚ª‚µ‚â‚·‚¢ƒP[ƒX‚ª‚ ‚éB
+//char,wchar_t ã®å¤‰ã‚ã‚Šã«ã€åˆ¥åã® ACHAR,WCHAR ã‚’ä½¿ã†ã¨ã€ã‚½ãƒ¼ã‚¹æ•´å½¢ãŒã—ã‚„ã™ã„ã‚±ãƒ¼ã‚¹ãŒã‚ã‚‹ã€‚
 typedef char ACHAR;
 
 
-//TCHAR’Ç‰Á‹@”\
-//TCHAR‚Æ‹t‚Ì•¶šŒ^‚ğNOT_TCHAR‚Æ‚µ‚Ä’è‹`‚·‚é
+//TCHARè¿½åŠ æ©Ÿèƒ½
+//TCHARã¨é€†ã®æ–‡å­—å‹ã‚’NOT_TCHARã¨ã—ã¦å®šç¾©ã™ã‚‹
 #ifdef _UNICODE
 typedef char NOT_TCHAR;
 #else
@@ -62,30 +62,30 @@ typedef wchar_t NOT_TCHAR;
 #endif
 
 
-//WIN_CHAR (WinAPI‚É“n‚·‚Ì‚ÅA•K‚¸TCHAR‚Å‚È‚¯‚ê‚Î‚È‚ç‚È‚¢‚à‚Ì)
+//WIN_CHAR (WinAPIã«æ¸¡ã™ã®ã§ã€å¿…ãšTCHARã§ãªã‘ã‚Œã°ãªã‚‰ãªã„ã‚‚ã®)
 typedef TCHAR WIN_CHAR;
 #define _WINT(A) _T(A)
 
 
 //EDIT_CHAR
-typedef wchar_t WChar;      //ƒGƒfƒBƒ^‚Å—p‚¢‚éƒeƒLƒXƒgŠÇ—ƒf[ƒ^Œ^
+typedef wchar_t WChar;      //ã‚¨ãƒ‡ã‚£ã‚¿ã§ç”¨ã„ã‚‹ãƒ†ã‚­ã‚¹ãƒˆç®¡ç†ãƒ‡ãƒ¼ã‚¿å‹
 typedef wchar_t EDIT_CHAR;
 #define _EDITL(A) LTEXT(A)
 
 
-//•¶šƒR[ƒh•ÊA•¶šŒ^
-typedef unsigned char	uchar_t;		//  unsigned char ‚Ì•Ê–¼D
-typedef unsigned short	uchar16_t;		//  UTF-16 —pD
-typedef unsigned long	uchar32_t;		//  UTF-32 —pD
+//æ–‡å­—ã‚³ãƒ¼ãƒ‰åˆ¥ã€æ–‡å­—å‹
+typedef unsigned char	uchar_t;		//  unsigned char ã®åˆ¥åï¼
+typedef unsigned short	uchar16_t;		//  UTF-16 ç”¨ï¼
+typedef unsigned long	uchar32_t;		//  UTF-32 ç”¨ï¼
 typedef long			wchar32_t;
 
 
 
-// -- -- -- -- ‚»‚Ì‘¼ -- -- -- -- //
+// -- -- -- -- ãã®ä»– -- -- -- -- //
 
 typedef char KEYCODE;
 
-//intŒİŠ·
+//intäº’æ›
 #ifdef USE_STRICT_INT
 	#include "CLaxInteger.h"
 	typedef CLaxInteger Int;


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/basis
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112
