### PR TITLE
リソースファイルのエンコーディングを UTF-8 (BOM無し) に変更

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -580,7 +580,12 @@
     <None Include="..\sakura_core\Funccode_x.hsrc" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\sakura_core\sakura_rc.rc" />
+    <ResourceCompile Include="..\sakura_core\sakura_rc.rc">
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/c 65001</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/c 65001</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/c 65001</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/c 65001</AdditionalOptions>
+    </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\sakura_core\apiwrap\StdApi.cpp" />

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -1,5 +1,8 @@
 ﻿//Microsoft Developer Studio generated resource script.
 //
+// CodePage: 65001 (UTF-8)
+#pragma code_page(65001)
+
 //#define SAKURA_LANG_RESOURCE
 
 #ifndef SAKURA_LANG_RESOURCE
@@ -29,7 +32,6 @@
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
 #ifdef _WIN32
 LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
-#pragma code_page(932)
 #endif //_WIN32
 
 #define	S_COPYRIGHT	"Copyright (C) 1998-2018  by Norio Nakatani & Collaborators"

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -1,4 +1,4 @@
-//Microsoft Developer Studio generated resource script.
+ï»¿//Microsoft Developer Studio generated resource script.
 //
 //#define SAKURA_LANG_RESOURCE
 
@@ -24,7 +24,7 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// “ú–{Œê resources
+// æ—¥æœ¬èªž resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
 #ifdef _WIN32
@@ -74,46 +74,46 @@ IDD_FIND DIALOGEX 30, 0, 284, 93
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_VISIBLE | WS_CAPTION | 
     WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ŒŸõ"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "æ¤œç´¢"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "ðŒ(&N)",IDC_STATIC,5,6,26,8
+    LTEXT           "æ¡ä»¶(&N)",IDC_STATIC,5,6,26,8
     COMBOBOX        IDC_COMBO_TEXT,34,4,183,150,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "’PŒê’PˆÊ‚Å’T‚·(&W)",IDC_CHK_WORD,"Button",
+    CONTROL         "å˜èªžå˜ä½ã§æŽ¢ã™(&W)",IDC_CHK_WORD,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,5,21,130,10
-    CONTROL         "‰p‘å•¶Žš‚Æ¬•¶Žš‚ð‹æ•Ê‚·‚é(&C)",IDC_CHK_LOHICASE,"Button",
+    CONTROL         "è‹±å¤§æ–‡å­—ã¨å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹(&C)",IDC_CHK_LOHICASE,"Button",
                     BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,5,32,130,10
-    CONTROL         "³‹K•\Œ»(&E)",IDC_CHK_REGULAREXP,"Button",
+    CONTROL         "æ­£è¦è¡¨ç¾(&E)",IDC_CHK_REGULAREXP,"Button",
                     BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,5,43,55,10
-    CONTROL         "Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ð•\Ž¦(&M)",
+    CONTROL         "è¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º(&M)",
                     IDC_CHECK_NOTIFYNOTFOUND,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,54,140,10
-    CONTROL         "ŒŸõƒ_ƒCƒAƒƒO‚ðŽ©“®“I‚É•Â‚¶‚é(&L)",
+    CONTROL         "æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹(&L)",
                     IDC_CHECK_bAutoCloseDlgFind,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,65,130,10
-    CONTROL         "æ“ªi––”öj‚©‚çÄŒŸõ‚·‚é(&Z)",IDC_CHECK_SEARCHALL,
+    CONTROL         "å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ã™ã‚‹(&Z)",IDC_CHECK_SEARCHALL,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,76,130,10
     LTEXT           "",IDC_STATIC_JRE32VER,62,43,154,10
-    PUSHBUTTON      "ãŒŸõ(&U)",IDC_BUTTON_SEARCHPREV,221,4,58,14,WS_GROUP
-    DEFPUSHBUTTON   "‰ºŒŸõ(&D)",IDC_BUTTON_SEARCHNEXT,221,20,58,14
-    PUSHBUTTON      "ŠY“–sƒ}[ƒN(&B)",IDC_BUTTON_SETMARK,221,38,58,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,221,57,58,14,WS_GROUP
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,221,73,58,14
+    PUSHBUTTON      "ä¸Šæ¤œç´¢(&U)",IDC_BUTTON_SEARCHPREV,221,4,58,14,WS_GROUP
+    DEFPUSHBUTTON   "ä¸‹æ¤œç´¢(&D)",IDC_BUTTON_SEARCHNEXT,221,20,58,14
+    PUSHBUTTON      "è©²å½“è¡Œãƒžãƒ¼ã‚¯(&B)",IDC_BUTTON_SETMARK,221,38,58,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,221,57,58,14,WS_GROUP
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,221,73,58,14
 END
 
 IDD_ABOUT DIALOG DISCARDABLE  0, 0, 245, 213
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "ƒo[ƒWƒ‡ƒ“î•ñ"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     DEFPUSHBUTTON   "&OK",IDOK,97,188,50,14
-    PUSHBUTTON      "î•ñ‚ðƒRƒs[(&C)",IDC_BUTTON_COPY,178,188,60,14
+    PUSHBUTTON      "æƒ…å ±ã‚’ã‚³ãƒ”ãƒ¼(&C)",IDC_BUTTON_COPY,178,188,60,14
     ICON            IDI_ICON_STD,IDC_STATIC_MYICON,5,5,20,20,SS_NOTIFY
     EDITTEXT        IDC_EDIT_VER,33,6,204,51,ES_MULTILINE | ES_READONLY | 
                     NOT WS_BORDER | NOT WS_TABSTOP
     LTEXT           S_COPYRIGHT,IDC_STATIC,33,61,205,8,NOT WS_GROUP | SS_NOPREFIX
-    LTEXT           "Œ´ìŽÒ: ‚½‚¯(’|ƒpƒ“ƒ_) ‚³‚ñ",IDC_STATIC,33,75,125,8,NOT 
+    LTEXT           "åŽŸä½œè€…: ãŸã‘(ç«¹ãƒ‘ãƒ³ãƒ€) ã•ã‚“",IDC_STATIC,33,75,125,8,NOT 
                     WS_GROUP
     LTEXT           "Project Sakura-Editor:",IDC_STATIC_URL_CAPTION,33,88,71,
                     8,NOT WS_GROUP
@@ -143,43 +143,43 @@ IDD_JUMP DIALOGEX 0, 0, 252, 121
 STYLE DS_MODALFRAME | DS_NOIDLEMSG | DS_SETFOREGROUND | DS_CENTER | 
     DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "Žw’ès‚ÖƒWƒƒƒ“ƒv"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "s”Ô†(&N)",IDC_STATIC,5,6,34,8
+    LTEXT           "è¡Œç•ªå·(&N)",IDC_STATIC,5,6,34,8
     EDITTEXT        IDC_EDIT_LINENUM,43,4,40,12
     CONTROL         "Spin1",IDC_SPIN_LINENUM,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,82,4,9,12
-    CONTROL         "Ü‚è•Ô‚µ’PˆÊ‚Ìs”Ô†(&R)",IDC_RADIO_LINENUM_LAYOUT,
+    CONTROL         "æŠ˜ã‚Šè¿”ã—å˜ä½ã®è¡Œç•ªå·(&R)",IDC_RADIO_LINENUM_LAYOUT,
                     "Button",BS_AUTORADIOBUTTON | WS_GROUP,94,5,97,10
-    CONTROL         "‰üs’PˆÊ‚Ìs”Ô†(&W)",IDC_RADIO_LINENUM_CRLF,"Button",
+    CONTROL         "æ”¹è¡Œå˜ä½ã®è¡Œç•ªå·(&W)",IDC_RADIO_LINENUM_CRLF,"Button",
                     BS_AUTORADIOBUTTON,94,20,87,10
-    CONTROL         "&PL/SQLƒRƒ“ƒpƒCƒ‹ƒGƒ‰[s‚ðˆ—‚·‚é",IDC_CHECK_PLSQL,
+    CONTROL         "&PL/SQLã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ã‚¨ãƒ©ãƒ¼è¡Œã‚’å‡¦ç†ã™ã‚‹",IDC_CHECK_PLSQL,
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,10,50,
                     137,10
-    LTEXT           "s–Ú‚ðƒuƒƒbƒN‚Ì&1s–Ú‚Æ‚·‚é",IDC_LABEL_PLSQL2,92,66,92,
+    LTEXT           "è¡Œç›®ã‚’ãƒ–ãƒ­ãƒƒã‚¯ã®&1è¡Œç›®ã¨ã™ã‚‹",IDC_LABEL_PLSQL2,92,66,92,
                     8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_PLSQL_E1,47,64,40,12
     CONTROL         "Spin1",IDC_SPIN_PLSQL_E1,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,87,64,9,
                     12
-    LTEXT           "ƒeƒLƒXƒg‚Ì",IDC_LABEL_PLSQL1,12,66,34,8,NOT WS_GROUP
-    LTEXT           "ŒŸo‚³‚ê‚½PL/SQLƒpƒbƒP[ƒW‚ÌƒuƒƒbƒN‚©‚ç‘I‘ð(&S)",
+    LTEXT           "ãƒ†ã‚­ã‚¹ãƒˆã®",IDC_LABEL_PLSQL1,12,66,34,8,NOT WS_GROUP
+    LTEXT           "æ¤œå‡ºã•ã‚ŒãŸPL/SQLãƒ‘ãƒƒã‚±ãƒ¼ã‚¸ã®ãƒ–ãƒ­ãƒƒã‚¯ã‹ã‚‰é¸æŠž(&S)",
                     IDC_LABEL_PLSQL3,12,81,166,8,NOT WS_GROUP
     COMBOBOX        IDC_COMBO_PLSQLBLOCKS,15,94,168,100,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    GROUPBOX        "PL/SQLƒRƒ“ƒpƒCƒ‹ƒGƒ‰[s",IDC_STATIC,5,35,184,80,
+    GROUPBOX        "PL/SQLã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ã‚¨ãƒ©ãƒ¼è¡Œ",IDC_STATIC,5,35,184,80,
                     WS_GROUP
-    DEFPUSHBUTTON   "ƒWƒƒƒ“ƒv(&J)",IDC_BUTTON_JUMP,197,5,50,14,WS_GROUP
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,197,24,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,197,101,50,14
+    DEFPUSHBUTTON   "ã‚¸ãƒ£ãƒ³ãƒ—(&J)",IDC_BUTTON_JUMP,197,5,50,14,WS_GROUP
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,197,24,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,197,101,50,14
 END
 
 IDD_FUNCLIST DIALOG DISCARDABLE  0, 0, 240, 289
 STYLE DS_MODALFRAME | DS_CENTER | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | 
     WS_CLIPCHILDREN | WS_CAPTION | WS_SYSMENU
 CAPTION "x"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     CONTROL         "Tree1",IDC_TREE_FL,"SysTreeView32",TVS_HASBUTTONS | 
                     TVS_HASLINES | TVS_LINESATROOT | TVS_SHOWSELALWAYS | 
@@ -187,21 +187,21 @@ BEGIN
     CONTROL         "List1",IDC_LIST_FL,"SysListView32",LVS_REPORT | 
                     LVS_SINGLESEL | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,0,
                     0,234,252
-    PUSHBUTTON      "¥",IDC_BUTTON_MENU,1,255,10,14,NOT WS_TABSTOP
-    CONTROL         "¡",IDC_BUTTON_WINSIZE,"Button",BS_AUTOCHECKBOX | 
+    PUSHBUTTON      "â–¼",IDC_BUTTON_MENU,1,255,10,14,NOT WS_TABSTOP
+    CONTROL         "â– ",IDC_BUTTON_WINSIZE,"Button",BS_AUTOCHECKBOX | 
                     BS_PUSHLIKE,12,255,10,14
-    PUSHBUTTON      "ƒRƒs[(&C)",IDC_BUTTON_COPY,24,255,50,14,WS_DISABLED
-    DEFPUSHBUTTON   "ƒWƒƒƒ“ƒv(&J)",IDOK,76,255,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,128,255,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,180,255,50,14
-    CONTROL         "Ž©“®“I‚É•Â‚¶‚é(&D)",IDC_CHECK_bAutoCloseDlgFuncList,
+    PUSHBUTTON      "ã‚³ãƒ”ãƒ¼(&C)",IDC_BUTTON_COPY,24,255,50,14,WS_DISABLED
+    DEFPUSHBUTTON   "ã‚¸ãƒ£ãƒ³ãƒ—(&J)",IDOK,76,255,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,128,255,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,180,255,50,14
+    CONTROL         "è‡ªå‹•çš„ã«é–‰ã˜ã‚‹(&D)",IDC_CHECK_bAutoCloseDlgFuncList,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,271,75,10
-    CONTROL         "ƒtƒH[ƒJƒX‚ðˆÚ‚·(&F)",IDC_CHECK_bFunclistSetFocusOnJump,
+    CONTROL         "ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã‚’ç§»ã™(&F)",IDC_CHECK_bFunclistSetFocusOnJump,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,82,271,77,10
-    CONTROL         "‹ós‚ð–³Ž‹‚·‚é(&B)",IDC_CHECK_bMarkUpBlankLineEnable,
+    CONTROL         "ç©ºè¡Œã‚’ç„¡è¦–ã™ã‚‹(&B)",IDC_CHECK_bMarkUpBlankLineEnable,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,160,271,76,10
-    LTEXT           "‡˜(&S)",IDC_STATIC_nSortType,3,6,28,8
-    PUSHBUTTON      "Ý’è(&S)",IDC_BUTTON_SETTING,3,3,35,14
+    LTEXT           "é †åº(&S)",IDC_STATIC_nSortType,3,6,28,8
+    PUSHBUTTON      "è¨­å®š(&S)",IDC_BUTTON_SETTING,3,3,35,14
     COMBOBOX        IDC_COMBO_nSortType,34,3,94,65,CBS_DROPDOWNLIST | 
                     CBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
 END
@@ -209,155 +209,155 @@ END
 IDD_GREP DIALOGEX 0, 0, 308, 171
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "GrepðŒ“ü—Í"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "Grepæ¡ä»¶å…¥åŠ›"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "ðŒ(&N)",IDC_STATIC,5,6,26,8
+    LTEXT           "æ¡ä»¶(&N)",IDC_STATIC,5,6,26,8
     COMBOBOX        IDC_COMBO_TEXT,46,4,257,120,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "ƒtƒ@ƒCƒ‹(&T)",IDC_STATIC,5,21,36,8,NOT WS_GROUP
+    LTEXT           "ãƒ•ã‚¡ã‚¤ãƒ«(&T)",IDC_STATIC,5,21,36,8,NOT WS_GROUP
     COMBOBOX        IDC_COMBO_FILE,46,19,257,120,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "ƒtƒHƒ‹ƒ_(&O)",IDC_STATIC,5,36,38,8
+    LTEXT           "ãƒ•ã‚©ãƒ«ãƒ€(&O)",IDC_STATIC,5,36,38,8
     COMBOBOX        IDC_COMBO_FOLDER,46,34,246,120,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "&...",IDC_BUTTON_FOLDER,293,34,9,13
-    PUSHBUTTON      "ã(&B)",IDC_BUTTON_FOLDER_UP,225,49,25,14
-    PUSHBUTTON      "Œ»ƒtƒHƒ‹ƒ_(&U)",IDC_BUTTON_CURRENTFOLDER,253,49,49,14,
+    PUSHBUTTON      "ä¸Š(&B)",IDC_BUTTON_FOLDER_UP,225,49,25,14
+    PUSHBUTTON      "ç¾ãƒ•ã‚©ãƒ«ãƒ€(&U)",IDC_BUTTON_CURRENTFOLDER,253,49,49,14,
                     BS_MULTILINE
-    CONTROL         "’PŒê’PˆÊ‚Å’T‚·(&W)",IDC_CHK_WORD,"Button",
+    CONTROL         "å˜èªžå˜ä½ã§æŽ¢ã™(&W)",IDC_CHK_WORD,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,5,52,73,10
-    CONTROL         "ƒTƒuƒtƒHƒ‹ƒ_‚©‚ç‚àŒŸõ‚·‚é(&S)",IDC_CHK_SUBFOLDER,
+    CONTROL         "ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‹ã‚‰ã‚‚æ¤œç´¢ã™ã‚‹(&S)",IDC_CHK_SUBFOLDER,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,63,113,10
-    CONTROL         "Œ»Ý•ÒW’†‚Ìƒtƒ@ƒCƒ‹‚©‚çŒŸõ(&Q)",IDC_CHK_FROMTHISTEXT,
+    CONTROL         "ç¾åœ¨ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰æ¤œç´¢(&Q)",IDC_CHK_FROMTHISTEXT,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,74,125,10
-    CONTROL         "‰p‘å•¶Žš‚Æ¬•¶Žš‚ð‹æ•Ê‚·‚é(&C)",IDC_CHK_LOHICASE,"Button",
+    CONTROL         "è‹±å¤§æ–‡å­—ã¨å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹(&C)",IDC_CHK_LOHICASE,"Button",
                     BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,5,85,119,10
-    CONTROL         "³‹K•\Œ»(&E)",IDC_CHK_REGULAREXP,"Button",
+    CONTROL         "æ­£è¦è¡¨ç¾(&E)",IDC_CHK_REGULAREXP,"Button",
                     BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,5,96,55,10
     LTEXT           "",IDC_STATIC_JRE32VER,18,105,159,8
-    CONTROL         "ƒtƒ@ƒCƒ‹–ˆÅ‰‚Ì‚ÝŒŸõ(&G)",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«æ¯Žæœ€åˆã®ã¿æ¤œç´¢(&G)",
                     IDC_CHECK_FILE_ONLY,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,116,119,10
-    CONTROL         "ƒx[ƒXƒtƒHƒ‹ƒ_•\Ž¦(&V)",
+    CONTROL         "ãƒ™ãƒ¼ã‚¹ãƒ•ã‚©ãƒ«ãƒ€è¡¨ç¤º(&V)",
                     IDC_CHECK_BASE_PATH,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,128,83,10
-    CONTROL         "ƒtƒHƒ‹ƒ_–ˆ‚É•\Ž¦(&Y)",
+    CONTROL         "ãƒ•ã‚©ãƒ«ãƒ€æ¯Žã«è¡¨ç¤º(&Y)",
                     IDC_CHECK_SEP_FOLDER,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,90,128,83,10
-    LTEXT           "•¶ŽšƒR[ƒhƒZƒbƒg(&A)",IDC_STATIC,16,142,62,8
+    LTEXT           "æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ(&A)",IDC_STATIC,16,142,62,8
     COMBOBOX        IDC_COMBO_CHARSET,80,140,65,101,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     CONTROL         "CP(&2)",IDC_CHECK_CP,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,148,142,30,10
-    CONTROL         "ƒtƒHƒ‹ƒ_‚Ì‰Šú’l‚ðƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_‚É‚·‚é(&D)",
+    CONTROL         "ãƒ•ã‚©ãƒ«ãƒ€ã®åˆæœŸå€¤ã‚’ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€ã«ã™ã‚‹(&D)",
                     IDC_CHK_DEFAULTFOLDER,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,156,164,10
-    CONTROL         "ŠY“–s(&L)",IDC_RADIO_OUTPUTLINE,"Button",
+    CONTROL         "è©²å½“è¡Œ(&L)",IDC_RADIO_OUTPUTLINE,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,185,73,48,10
-    CONTROL         "ŠY“–•”•ª(&P)",IDC_RADIO_OUTPUTMARKED,"Button",
+    CONTROL         "è©²å½“éƒ¨åˆ†(&P)",IDC_RADIO_OUTPUTMARKED,"Button",
                     BS_AUTORADIOBUTTON,185,85,56,10
-    CONTROL         "”ÛŠY“–s(&1)",IDC_RADIO_NOHIT,"Button",
+    CONTROL         "å¦è©²å½“è¡Œ(&1)",IDC_RADIO_NOHIT,"Button",
                     BS_AUTORADIOBUTTON,185,97,56,10
-    GROUPBOX        "Œ‹‰Êo—Í",IDC_STATIC,180,63,65,47,WS_GROUP
-    CONTROL         "ƒm[ƒ}ƒ‹(&M)",IDC_RADIO_OUTPUTSTYLE1,"Button",
+    GROUPBOX        "çµæžœå‡ºåŠ›",IDC_STATIC,180,63,65,47,WS_GROUP
+    CONTROL         "ãƒŽãƒ¼ãƒžãƒ«(&M)",IDC_RADIO_OUTPUTSTYLE1,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,185,124,54,10
-    CONTROL         "ƒtƒ@ƒCƒ‹–ˆi&Ij",IDC_RADIO_OUTPUTSTYLE2,"Button",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«æ¯Žï¼ˆ&Iï¼‰",IDC_RADIO_OUTPUTSTYLE2,"Button",
                     BS_AUTORADIOBUTTON,185,136,59,10
-    CONTROL         "Œ‹‰Ê‚Ì‚Ý(&Rj",IDC_RADIO_OUTPUTSTYLE3,"Button",
+    CONTROL         "çµæžœã®ã¿(&Rï¼‰",IDC_RADIO_OUTPUTSTYLE3,"Button",
                     BS_AUTORADIOBUTTON,185,148,59,10
-    GROUPBOX        "Œ‹‰Êo—ÍŒ`Ž®",IDC_STATIC,180,114,65,47,WS_GROUP
-    DEFPUSHBUTTON   "ŒŸõ(&F)",IDOK,253,88,49,14,WS_GROUP
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,253,130,49,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,253,147,49,14
+    GROUPBOX        "çµæžœå‡ºåŠ›å½¢å¼",IDC_STATIC,180,114,65,47,WS_GROUP
+    DEFPUSHBUTTON   "æ¤œç´¢(&F)",IDOK,253,88,49,14,WS_GROUP
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,253,130,49,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,253,147,49,14
 END
 
 IDD_GREP_REPLACE DIALOGEX 0, 0, 308, 193
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "Grep’uŠ·"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "Grepç½®æ›"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "’uŠ·‘O(&N)",IDC_STATIC,5,6,39,8
+    LTEXT           "ç½®æ›å‰(&N)",IDC_STATIC,5,6,39,8
     COMBOBOX        IDC_COMBO_TEXT,46,4,257,120,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "’uŠ·Œã(&Z)",IDC_STATIC,5,21,39,8
+    LTEXT           "ç½®æ›å¾Œ(&Z)",IDC_STATIC,5,21,39,8
     COMBOBOX        IDC_COMBO_TEXT2,46,19,257,120,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "ƒtƒ@ƒCƒ‹(&T)",IDC_STATIC,5,36,39,8,NOT WS_GROUP
+    LTEXT           "ãƒ•ã‚¡ã‚¤ãƒ«(&T)",IDC_STATIC,5,36,39,8,NOT WS_GROUP
     COMBOBOX        IDC_COMBO_FILE,46,34,257,120,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "ƒtƒHƒ‹ƒ_(&O)",IDC_STATIC,5,51,39,8
+    LTEXT           "ãƒ•ã‚©ãƒ«ãƒ€(&O)",IDC_STATIC,5,51,39,8
     COMBOBOX        IDC_COMBO_FOLDER,46,49,246,120,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "&...",IDC_BUTTON_FOLDER,293,49,9,13
-    PUSHBUTTON      "ã(&B)",IDC_BUTTON_FOLDER_UP,225,64,25,14
-    PUSHBUTTON      "Œ»ƒtƒHƒ‹ƒ_(&U)",IDC_BUTTON_CURRENTFOLDER,253,64,49,14,
+    PUSHBUTTON      "ä¸Š(&B)",IDC_BUTTON_FOLDER_UP,225,64,25,14
+    PUSHBUTTON      "ç¾ãƒ•ã‚©ãƒ«ãƒ€(&U)",IDC_BUTTON_CURRENTFOLDER,253,64,49,14,
                     BS_MULTILINE
-    CONTROL         "ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯‚é(&J)",IDC_CHK_PASTE,"Button",
+    CONTROL         "ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘ã‚‹(&J)",IDC_CHK_PASTE,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,5,67,116,10
-    CONTROL         "’PŒê’PˆÊ‚Å’T‚·(&W)",IDC_CHK_WORD,"Button",
+    CONTROL         "å˜èªžå˜ä½ã§æŽ¢ã™(&W)",IDC_CHK_WORD,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,5,78,116,10
-    CONTROL         "ƒTƒuƒtƒHƒ‹ƒ_‚©‚ç‚àŒŸõ‚·‚é(&S)",IDC_CHK_SUBFOLDER,
+    CONTROL         "ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‹ã‚‰ã‚‚æ¤œç´¢ã™ã‚‹(&S)",IDC_CHK_SUBFOLDER,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,89,116,10
-    CONTROL         "‰p‘å•¶Žš‚Æ¬•¶Žš‚ð‹æ•Ê‚·‚é(&C)",IDC_CHK_LOHICASE,"Button",
+    CONTROL         "è‹±å¤§æ–‡å­—ã¨å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹(&C)",IDC_CHK_LOHICASE,"Button",
                     BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,5,100,116,10
-    CONTROL         "³‹K•\Œ»(&E)",IDC_CHK_REGULAREXP,"Button",
+    CONTROL         "æ­£è¦è¡¨ç¾(&E)",IDC_CHK_REGULAREXP,"Button",
                     BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,5,111,55,10
     LTEXT           "",IDC_STATIC_JRE32VER,18,120,159,8
-    CONTROL         "ƒtƒ@ƒCƒ‹–ˆÅ‰‚Ì‚ÝŒŸõ(&G)",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«æ¯Žæœ€åˆã®ã¿æ¤œç´¢(&G)",
                     IDC_CHECK_FILE_ONLY,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,131,119,10
-    CONTROL         "ƒx[ƒXƒtƒHƒ‹ƒ_•\Ž¦(&V)",
+    CONTROL         "ãƒ™ãƒ¼ã‚¹ãƒ•ã‚©ãƒ«ãƒ€è¡¨ç¤º(&V)",
                     IDC_CHECK_BASE_PATH,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,142,85,10
-    CONTROL         "ƒtƒHƒ‹ƒ_–ˆ‚É•\Ž¦(&Y)",
+    CONTROL         "ãƒ•ã‚©ãƒ«ãƒ€æ¯Žã«è¡¨ç¤º(&Y)",
                     IDC_CHECK_SEP_FOLDER,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,92,142,85,10
-    LTEXT           "•¶ŽšƒR[ƒhƒZƒbƒg(&A)",IDC_STATIC,16,156,62,8
+    LTEXT           "æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ(&A)",IDC_STATIC,16,156,62,8
     COMBOBOX        IDC_COMBO_CHARSET,80,154,65,101,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     CONTROL         "CP(&2)",IDC_CHECK_CP,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,147,154,30,10
-    CONTROL         "ƒoƒbƒNƒAƒbƒvì¬(&K)",IDC_CHK_BACKUP,"Button",
+    CONTROL         "ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ä½œæˆ(&K)",IDC_CHK_BACKUP,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,5,167,164,10
-    CONTROL         "ƒtƒHƒ‹ƒ_‚Ì‰Šú’l‚ðƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_‚É‚·‚é(&D)",
+    CONTROL         "ãƒ•ã‚©ãƒ«ãƒ€ã®åˆæœŸå€¤ã‚’ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€ã«ã™ã‚‹(&D)",
                     IDC_CHK_DEFAULTFOLDER,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,178,164,10
-    CONTROL         "ŠY“–s(&L)",IDC_RADIO_OUTPUTLINE,"Button",
+    CONTROL         "è©²å½“è¡Œ(&L)",IDC_RADIO_OUTPUTLINE,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,185,91,56,10
-    CONTROL         "ŠY“–•”•ª(&P)",IDC_RADIO_OUTPUTMARKED,"Button",
+    CONTROL         "è©²å½“éƒ¨åˆ†(&P)",IDC_RADIO_OUTPUTMARKED,"Button",
                     BS_AUTORADIOBUTTON,185,101,56,10
-    GROUPBOX        "Œ‹‰Êo—Í",IDC_STATIC,180,79,65,35,WS_GROUP
-    CONTROL         "ƒm[ƒ}ƒ‹(&M)",IDC_RADIO_OUTPUTSTYLE1,"Button",
+    GROUPBOX        "çµæžœå‡ºåŠ›",IDC_STATIC,180,79,65,35,WS_GROUP
+    CONTROL         "ãƒŽãƒ¼ãƒžãƒ«(&M)",IDC_RADIO_OUTPUTSTYLE1,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,185,128,54,10
-    CONTROL         "ƒtƒ@ƒCƒ‹–ˆi&Ij",IDC_RADIO_OUTPUTSTYLE2,"Button",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«æ¯Žï¼ˆ&Iï¼‰",IDC_RADIO_OUTPUTSTYLE2,"Button",
                     BS_AUTORADIOBUTTON,185,140,59,10
-    CONTROL         "Œ‹‰Ê‚Ì‚Ý(&R)",IDC_RADIO_OUTPUTSTYLE3,"Button",
+    CONTROL         "çµæžœã®ã¿(&R)",IDC_RADIO_OUTPUTSTYLE3,"Button",
                     BS_AUTORADIOBUTTON,185,152,59,10
-    GROUPBOX        "Œ‹‰Êo—ÍŒ`Ž®",IDC_STATIC,180,118,65,47,WS_GROUP
-    DEFPUSHBUTTON   "’uŠ·(&F)",IDOK,253,87,49,14,WS_GROUP
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,253,150,49,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,253,167,49,14
+    GROUPBOX        "çµæžœå‡ºåŠ›å½¢å¼",IDC_STATIC,180,118,65,47,WS_GROUP
+    DEFPUSHBUTTON   "ç½®æ›(&F)",IDOK,253,87,49,14,WS_GROUP
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,253,150,49,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,253,167,49,14
 END
 
 IDD_GREPRUNNING DIALOGEX 0, 0, 293, 79
 STYLE DS_SETFOREGROUND | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "GrepŽÀs’†"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "Grepå®Ÿè¡Œä¸­"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "ŒŸõ‚µ‚Ä‚¢‚Ü‚·EEE",IDC_STATIC,5,5,61,8,NOT WS_GROUP
-    LTEXT           "ƒtƒ@ƒCƒ‹",IDC_STATIC,5,21,26,8,NOT WS_GROUP
+    LTEXT           "æ¤œç´¢ã—ã¦ã„ã¾ã™ãƒ»ãƒ»ãƒ»",IDC_STATIC,5,5,61,8,NOT WS_GROUP
+    LTEXT           "ãƒ•ã‚¡ã‚¤ãƒ«",IDC_STATIC,5,21,26,8,NOT WS_GROUP
     LTEXT           "IDC_STATIC_CURPATH",IDC_STATIC_CURFILE,36,20,252,10,NOT 
                     WS_GROUP
-    LTEXT           "ƒtƒHƒ‹ƒ_",IDC_STATIC,5,34,27,8,NOT WS_GROUP
+    LTEXT           "ãƒ•ã‚©ãƒ«ãƒ€",IDC_STATIC,5,34,27,8,NOT WS_GROUP
     EDITTEXT        IDC_STATIC_CURPATH,36,35,252,20,ES_MULTILINE | ES_READONLY | 
                     NOT WS_BORDER | NOT WS_TABSTOP
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,238,60,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,238,60,50,14
     LTEXT           "0",IDC_STATIC_HITCOUNT,76,5,44,8,NOT WS_GROUP,
                     WS_EX_RIGHT
-    LTEXT           "Œ‚Ý‚Â‚©‚è‚Ü‚µ‚½B",IDC_STATIC,122,5,60,8,NOT WS_GROUP
-    CONTROL         "ƒŠƒAƒ‹ƒ^ƒCƒ€•\Ž¦(&V)",IDC_CHECK_REALTIMEVIEW,"Button",
+    LTEXT           "ä»¶ã¿ã¤ã‹ã‚Šã¾ã—ãŸã€‚",IDC_STATIC,122,5,60,8,NOT WS_GROUP
+    CONTROL         "ãƒªã‚¢ãƒ«ã‚¿ã‚¤ãƒ è¡¨ç¤º(&V)",IDC_CHECK_REALTIMEVIEW,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,149,59,84,14
 END
 
@@ -365,91 +365,91 @@ IDD_REPLACE DIALOGEX 30, 0, 298, 149
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_VISIBLE | WS_CAPTION | 
     WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "’uŠ·"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ç½®æ›"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "’uŠ·‘O(&N)",IDC_STATIC,5,6,35,8
+    LTEXT           "ç½®æ›å‰(&N)",IDC_STATIC,5,6,35,8
     COMBOBOX        IDC_COMBO_TEXT,43,4,191,150,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "’uŠ·Œã(&P)",IDC_STATIC,5,21,34,8,NOT WS_GROUP
+    LTEXT           "ç½®æ›å¾Œ(&P)",IDC_STATIC,5,21,34,8,NOT WS_GROUP
     COMBOBOX        IDC_COMBO_TEXT2,43,19,191,150,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯‚é(&T)",IDC_CHK_PASTE,"Button",
+    CONTROL         "ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘ã‚‹(&T)",IDC_CHK_PASTE,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,5,41,116,10
-    CONTROL         "’PŒê’PˆÊ‚Å’T‚·(&W)",IDC_CHK_WORD,"Button",
+    CONTROL         "å˜èªžå˜ä½ã§æŽ¢ã™(&W)",IDC_CHK_WORD,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,5,52,78,10
-    CONTROL         "‰p‘å•¶Žš‚Æ¬•¶Žš‚ð‹æ•Ê‚·‚é(&C)",IDC_CHK_LOHICASE,"Button",
+    CONTROL         "è‹±å¤§æ–‡å­—ã¨å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹(&C)",IDC_CHK_LOHICASE,"Button",
                     BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,5,63,119,10
-    CONTROL         "³‹K•\Œ»(&E)",IDC_CHK_REGULAREXP,"Button",
+    CONTROL         "æ­£è¦è¡¨ç¾(&E)",IDC_CHK_REGULAREXP,"Button",
                     BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,5,74,55,10
     LTEXT           "",IDC_STATIC_JRE32VER,16,85,138,8
-    CONTROL         "u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ(&I)",
+    CONTROL         "ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã—(&I)",
                     IDC_CHECK_CONSECUTIVEALL,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,95,118,10
-    CONTROL         "Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ð•\Ž¦(&M)",
+    CONTROL         "è¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º(&M)",
                     IDC_CHECK_NOTIFYNOTFOUND,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,107,140,10
-    CONTROL         "’uŠ·ƒ_ƒCƒAƒƒO‚ðŽ©“®“I‚É•Â‚¶‚é(&L)",
+    CONTROL         "ç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹(&L)",
                     IDC_CHECK_bAutoCloseDlgReplace,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,5,118,128,10
-    CONTROL         "æ“ªi––”öj‚©‚çÄŒŸõ‚·‚é(&Z)",IDC_CHECK_SEARCHALL,
+    CONTROL         "å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ã™ã‚‹(&Z)",IDC_CHECK_SEARCHALL,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,129,113,10
-    GROUPBOX        "’uŠ·‘ÎÛ",IDC_STATIC,156,37,78,62,WS_GROUP
-    CONTROL         "‘I‘ð•¶Žš(&0)",IDC_RADIO_REPLACE,"Button",
+    GROUPBOX        "ç½®æ›å¯¾è±¡",IDC_STATIC,156,37,78,62,WS_GROUP
+    CONTROL         "é¸æŠžæ–‡å­—(&0)",IDC_RADIO_REPLACE,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,159,50,59,10
-    CONTROL         "‘I‘ðŽn“_(&1)‘}“ü",IDC_RADIO_INSERT,"Button",
+    CONTROL         "é¸æŠžå§‹ç‚¹(&1)æŒ¿å…¥",IDC_RADIO_INSERT,"Button",
                     BS_AUTORADIOBUTTON | WS_TABSTOP,159,61,71,10
-    CONTROL         "‘I‘ðI“_(&2)’Ç‰Á",IDC_RADIO_ADD,"Button",
+    CONTROL         "é¸æŠžçµ‚ç‚¹(&2)è¿½åŠ ",IDC_RADIO_ADD,"Button",
                     BS_AUTORADIOBUTTON | WS_TABSTOP,159,72,71,10
-    CONTROL         "síœ(&3)",IDC_RADIO_LINEDELETE,"Button",
+    CONTROL         "è¡Œå‰Šé™¤(&3)",IDC_RADIO_LINEDELETE,"Button",
                     BS_AUTORADIOBUTTON | WS_TABSTOP,159,83,71,10
-    GROUPBOX        "”ÍˆÍ",IDC_STATIC,156,103,78,37,WS_GROUP
-    CONTROL         "‘I‘ð”ÍˆÍ(&S)",IDC_RADIO_SELECTEDAREA,"Button",
+    GROUPBOX        "ç¯„å›²",IDC_STATIC,156,103,78,37,WS_GROUP
+    CONTROL         "é¸æŠžç¯„å›²(&S)",IDC_RADIO_SELECTEDAREA,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,159,115,57,10
-    CONTROL         "ƒtƒ@ƒCƒ‹‘S‘Ì(&O)",IDC_RADIO_ALLAREA,"Button",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«å…¨ä½“(&O)",IDC_RADIO_ALLAREA,"Button",
                     BS_AUTORADIOBUTTON | WS_TABSTOP,159,126,68,10
-    PUSHBUTTON      "ãŒŸõ(&U)",IDC_BUTTON_SEARCHPREV,237,4,58,14,WS_GROUP
-    DEFPUSHBUTTON   "‰ºŒŸõ(&D)",IDC_BUTTON_SEARCHNEXT,237,19,58,14
-    PUSHBUTTON      "ŠY“–sƒ}[ƒN(&B)",IDC_BUTTON_SETMARK,237,38,58,14
-    PUSHBUTTON      "’uŠ·(&R)",IDC_BUTTON_REPALCE,237,57,58,14
-    PUSHBUTTON      "‚·‚×‚Ä’uŠ·(&A)",IDC_BUTTON_REPALCEALL,237,73,58,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,237,110,58,14,WS_GROUP
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,237,127,58,14
+    PUSHBUTTON      "ä¸Šæ¤œç´¢(&U)",IDC_BUTTON_SEARCHPREV,237,4,58,14,WS_GROUP
+    DEFPUSHBUTTON   "ä¸‹æ¤œç´¢(&D)",IDC_BUTTON_SEARCHNEXT,237,19,58,14
+    PUSHBUTTON      "è©²å½“è¡Œãƒžãƒ¼ã‚¯(&B)",IDC_BUTTON_SETMARK,237,38,58,14
+    PUSHBUTTON      "ç½®æ›(&R)",IDC_BUTTON_REPALCE,237,57,58,14
+    PUSHBUTTON      "ã™ã¹ã¦ç½®æ›(&A)",IDC_BUTTON_REPALCEALL,237,73,58,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,237,110,58,14,WS_GROUP
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,237,127,58,14
 END
 
 IDD_REPLACERUNNING DIALOG DISCARDABLE  0, 0, 190, 35
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "’uŠ·’†"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ç½®æ›ä¸­"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "’uŠ·’†‚Å‚·EEEE",IDC_STATIC,5,5,55,8
+    LTEXT           "ç½®æ›ä¸­ã§ã™ãƒ»ãƒ»ãƒ»ãƒ»",IDC_STATIC,5,5,55,8
     CONTROL         "Progress1",IDC_PROGRESS_REPLACE,"msctls_progress32",
                     WS_BORDER,5,20,120,10
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,135,16,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,135,16,50,14
     RTEXT           "9999999999",IDC_STATIC_KENSUU,64,5,37,8,NOT WS_GROUP
-    LTEXT           "ŒÂ",IDC_STATIC,104,5,8,8,NOT WS_GROUP
+    LTEXT           "å€‹",IDC_STATIC,104,5,8,8,NOT WS_GROUP
 END
 
 IDD_PROPERTY_FILE DIALOGEX 0, 0, 270, 225
 STYLE DS_MODALFRAME | DS_SETFOREGROUND | DS_CENTER | WS_POPUP | WS_CAPTION | 
     WS_SYSMENU
-CAPTION "ƒtƒ@ƒCƒ‹‚ÌƒvƒƒpƒeƒB"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     EDITTEXT        IDC_EDIT_PROPERTY,5,5,260,200,ES_MULTILINE | ES_READONLY | 
                     WS_VSCROLL | NOT WS_TABSTOP
-    DEFPUSHBUTTON   "•Â‚¶‚é(&C)",IDOK,155,208,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,215,208,50,14
+    DEFPUSHBUTTON   "é–‰ã˜ã‚‹(&C)",IDOK,155,208,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,215,208,50,14
 END
 
 IDD_INPUT1 DIALOGEX 0, 0, 185, 55
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "”Ä—p“ü—Íƒ_ƒCƒAƒƒO"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "æ±Žç”¨å…¥åŠ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     EDITTEXT        IDC_EDIT_INPUT1,5,15,175,12,ES_AUTOHSCROLL
     DEFPUSHBUTTON   "&OK",IDOK,37,36,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,98,35,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,98,35,50,14
     LTEXT           "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
                     IDC_STATIC_MSG,6,5,175,8
 END
@@ -457,19 +457,19 @@ END
 IDD_COMPARE DIALOGEX 0, 0, 365, 165
 STYLE DS_MODALFRAME | WS_POPUP | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒtƒ@ƒCƒ‹“à—e”äŠr"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒ"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "”äŠr‚·‚éƒtƒ@ƒCƒ‹‚ð‰º‚©‚ç‘I‘ð‚µ‚Ä‚­‚¾‚³‚¢(&C):",
+    LTEXT           "æ¯”è¼ƒã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä¸‹ã‹ã‚‰é¸æŠžã—ã¦ãã ã•ã„(&C):",
                     IDC_STATIC,5,31,158,8
     LISTBOX         IDC_LIST_FILES,5,42,355,95,LBS_SORT | 
                     LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_HSCROLL | 
                     WS_TABSTOP
-    CONTROL         "¶‰E‚É•\Ž¦(&T)",IDC_CHECK_TILE_H,"Button",
+    CONTROL         "å·¦å³ã«è¡¨ç¤º(&T)",IDC_CHECK_TILE_H,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,293,30,66,10
     DEFPUSHBUTTON   "&OK",IDOK,184,145,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,244,145,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,304,145,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,244,145,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,304,145,50,14
     EDITTEXT        IDC_STATIC_COMPARESRC,7,7,355,20,ES_MULTILINE | 
                     ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | 
                     WS_VSCROLL,WS_EX_STATICEDGE
@@ -477,22 +477,22 @@ END
 
 IDD_PRINTPREVIEWBAR DIALOG DISCARDABLE  0, 0, 402, 32
 STYLE WS_CHILD
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    DEFPUSHBUTTON   "ˆóü(&P)...",IDOK,2,1,55,14
-    PUSHBUTTON      "ƒy[ƒWÝ’è(&S)...",IDC_BUTTON_PRINTSETTING,2,16,55,14
-    PUSHBUTTON      "‘O(&V)",IDC_BUTTON_PREVPAGE,60,1,30,14
-    PUSHBUTTON      "ŽŸ(&N)",IDC_BUTTON_NEXTPAGE,90,1,30,14
+    DEFPUSHBUTTON   "å°åˆ·(&P)...",IDOK,2,1,55,14
+    PUSHBUTTON      "ãƒšãƒ¼ã‚¸è¨­å®š(&S)...",IDC_BUTTON_PRINTSETTING,2,16,55,14
+    PUSHBUTTON      "å‰(&V)",IDC_BUTTON_PREVPAGE,60,1,30,14
+    PUSHBUTTON      "æ¬¡(&N)",IDC_BUTTON_NEXTPAGE,90,1,30,14
     PUSHBUTTON      "..&.",IDC_BUTTON_DIRECTPAGE,120,1,9,14
     LTEXT           "999/999",IDC_STATIC_PAGENUM,131,4,35,8
-    PUSHBUTTON      "k¬(&O)",IDC_BUTTON_ZOOMDOWN,60,16,30,14
-    PUSHBUTTON      "Šg‘å(&I)",IDC_BUTTON_ZOOMUP,90,16,30,14
+    PUSHBUTTON      "ç¸®å°(&O)",IDC_BUTTON_ZOOMDOWN,60,16,30,14
+    PUSHBUTTON      "æ‹¡å¤§(&I)",IDC_BUTTON_ZOOMUP,90,16,30,14
     LTEXT           "999/999",IDC_STATIC_ZOOM,131,19,35,8
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,167,1,39,14
-    CONTROL         "ŠŠ‚ç‚©(&A)",IDC_CHECK_ANTIALIAS,"Button",
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,167,1,39,14
+    CONTROL         "æ»‘ã‚‰ã‹(&A)",IDC_CHECK_ANTIALIAS,"Button",
                     BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,207,3,43,10
-    PUSHBUTTON      "–ß‚é(&Q)",IDCANCEL,167,16,39,14
-    PUSHBUTTON      "ƒvƒŠƒ“ƒ^(&R)",IDC_BUTTON_PRINTERSELECT,208,16,40,14
+    PUSHBUTTON      "æˆ»ã‚‹(&Q)",IDCANCEL,167,16,39,14
+    PUSHBUTTON      "ãƒ—ãƒªãƒ³ã‚¿(&R)",IDC_BUTTON_PRINTERSELECT,208,16,40,14
     ICON            IDI_PRINTER, IDC_STATIC, 251, 3, 11, 9, SS_REALSIZEIMAGE
     LTEXT           "Static",IDC_STATIC_PRNDEV,263,4,137,8
     LTEXT           "Static",IDC_STATIC_PAPER,251,19,149,8
@@ -502,116 +502,116 @@ IDD_PRINTSETTING DIALOGEX 0, 0, 302, 253
 STYLE DS_MODALFRAME | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | 
     WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ˆóüƒy[ƒWÝ’è"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "å°åˆ·ãƒšãƒ¼ã‚¸è¨­å®š"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "ƒy[ƒWÝ’è(&1)",IDC_STATIC,7,9,45,8
+    LTEXT           "ãƒšãƒ¼ã‚¸è¨­å®š(&1)",IDC_STATIC,7,9,45,8
     COMBOBOX        IDC_COMBO_SETTINGNAME,56,7,163,170,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "Ý’è–¼•ÏX(&2)...",IDC_BUTTON_EDITSETTINGNAME,224,7,69,14
-    GROUPBOX        "Ý’è",IDC_STATIC,4,22,289,204
-    RTEXT           "”¼ŠpƒtƒHƒ“ƒg(&F)",IDC_STATIC,7,37,45,8
+    PUSHBUTTON      "è¨­å®šåå¤‰æ›´(&2)...",IDC_BUTTON_EDITSETTINGNAME,224,7,69,14
+    GROUPBOX        "è¨­å®š",IDC_STATIC,4,22,289,204
+    RTEXT           "åŠè§’ãƒ•ã‚©ãƒ³ãƒˆ(&F)",IDC_STATIC,7,37,45,8
     COMBOBOX        IDC_COMBO_FONT_HAN,56,35,84,230,CBS_DROPDOWNLIST | 
                     CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    RTEXT           "‘SŠpƒtƒHƒ“ƒg(&K)",IDC_STATIC,7,52,45,8
+    RTEXT           "å…¨è§’ãƒ•ã‚©ãƒ³ãƒˆ(&K)",IDC_STATIC,7,52,45,8
     COMBOBOX        IDC_COMBO_FONT_ZEN,56,50,84,230,CBS_DROPDOWNLIST | 
                     CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    RTEXT           "ƒtƒHƒ“ƒg‚(&P)",IDC_STATIC,7,71,45,8
+    RTEXT           "ãƒ•ã‚©ãƒ³ãƒˆé«˜(&P)",IDC_STATIC,7,71,45,8
     EDITTEXT        IDC_EDIT_FONTHEIGHT,56,69,30,12,ES_AUTOHSCROLL
     CONTROL         "Spin1",IDC_SPIN_FONTHEIGHT,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,76,69,9,12
     LTEXT           "(1/10mm)",IDC_STATIC,88,71,32,8
     RTEXT           "144.5pt",IDC_STATIC_FONTSIZE,120,71,22,8
-    RTEXT           "s‘—‚è(&S)",IDC_STATIC,7,85,45,8
+    RTEXT           "è¡Œé€ã‚Š(&S)",IDC_STATIC,7,85,45,8
     EDITTEXT        IDC_EDIT_LINESPACE,56,83,30,12,ES_AUTOHSCROLL
     CONTROL         "Spin2",IDC_SPIN_LINESPACE,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,76,83,9,12
     LTEXT           "(%)",IDC_STATIC,88,85,10,8
-    RTEXT           "’i” (&C)",IDC_STATIC,7,99,45,8
+    RTEXT           "æ®µæ•° (&C)",IDC_STATIC,7,99,45,8
     EDITTEXT        IDC_EDIT_DANSUU,56,97,30,12,ES_AUTOHSCROLL
     CONTROL         "Spin3",IDC_SPIN_DANSUU,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,76,97,9,12
-    RTEXT           "’i‚ÌŒ„ŠÔ(&E)",IDC_STATIC,7,113,45,8
+    RTEXT           "æ®µã®éš™é–“(&E)",IDC_STATIC,7,113,45,8
     EDITTEXT        IDC_EDIT_DANSPACE,56,111,30,12,ES_AUTOHSCROLL
     CONTROL         "Spin4",IDC_SPIN_DANSPACE,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,76,111,9,12
     LTEXT           "(mm)",IDC_STATIC,88,113,17,8
-    RTEXT           "—pŽ†ƒTƒCƒY(&Z)",IDC_STATIC,7,131,45,8
+    RTEXT           "ç”¨ç´™ã‚µã‚¤ã‚º(&Z)",IDC_STATIC,7,131,45,8
     COMBOBOX        IDC_COMBO_PAPER,56,129,169,145,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    RTEXT           "—pŽ†‚ÌŒü‚«",IDC_STATIC,7,146,45,8
-    CONTROL         "c(&I)",IDC_RADIO_PORTRAIT,"Button",BS_AUTORADIOBUTTON | 
+    RTEXT           "ç”¨ç´™ã®å‘ã",IDC_STATIC,7,146,45,8
+    CONTROL         "ç¸¦(&I)",IDC_RADIO_PORTRAIT,"Button",BS_AUTORADIOBUTTON | 
                     WS_GROUP,58,145,40,10
-    CONTROL         "‰¡(&A)",IDC_RADIO_LANDSCAPE,"Button",BS_AUTORADIOBUTTON,
+    CONTROL         "æ¨ª(&A)",IDC_RADIO_LANDSCAPE,"Button",BS_AUTORADIOBUTTON,
                     102,145,40,10
-    RTEXT           "—]”’^ã(&T)",IDC_STATIC,7,163,45,8
+    RTEXT           "ä½™ç™½ï¼ä¸Š(&T)",IDC_STATIC,7,163,45,8
     EDITTEXT        IDC_EDIT_MARGINTY,56,161,30,12,ES_AUTOHSCROLL
     CONTROL         "Spin5",IDC_SPIN_MARGINTY,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,76,161,9,12
     LTEXT           "(mm)",IDC_STATIC,88,163,17,8
-    RTEXT           "‰º(&B)",IDC_STATIC,7,177,45,8
+    RTEXT           "ä¸‹(&B)",IDC_STATIC,7,177,45,8
     EDITTEXT        IDC_EDIT_MARGINBY,56,175,30,12,ES_AUTOHSCROLL
     CONTROL         "Spin6",IDC_SPIN_MARGINBY,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,76,175,9,12
     LTEXT           "(mm)",IDC_STATIC,88,177,17,8
-    RTEXT           "¶(&L)",IDC_STATIC,7,191,45,8
+    RTEXT           "å·¦(&L)",IDC_STATIC,7,191,45,8
     EDITTEXT        IDC_EDIT_MARGINLX,56,189,30,12,ES_AUTOHSCROLL
     CONTROL         "Spin7",IDC_SPIN_MARGINLX,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,76,189,9,12
     LTEXT           "(mm)",IDC_STATIC,88,191,17,8
-    RTEXT           "‰E(&R)",IDC_STATIC,7,205,45,8
+    RTEXT           "å³(&R)",IDC_STATIC,7,205,45,8
     EDITTEXT        IDC_EDIT_MARGINRX,56,202,30,12,ES_AUTOHSCROLL
     CONTROL         "Spin8",IDC_SPIN_MARGINRX,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,76,202,9,12
     LTEXT           "(mm)",IDC_STATIC,88,205,17,8
-    CONTROL         "s”Ô†‚ðˆóü(&N)",IDC_CHECK_LINENUMBER,"Button",
+    CONTROL         "è¡Œç•ªå·ã‚’å°åˆ·(&N)",IDC_CHECK_LINENUMBER,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,150,35,70,10
-    CONTROL         "‰p•¶ƒ[ƒhƒ‰ƒbƒv(&W)",IDC_CHECK_WORDWRAP,"Button",
+    CONTROL         "è‹±æ–‡ãƒ¯ãƒ¼ãƒ‰ãƒ©ãƒƒãƒ—(&W)",IDC_CHECK_WORDWRAP,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,150,49,78,10
-    CONTROL         "s“ª‹Ö‘¥",IDC_CHECK_PS_KINSOKUHEAD,"Button",
+    CONTROL         "è¡Œé ­ç¦å‰‡",IDC_CHECK_PS_KINSOKUHEAD,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,150,63,46,10
-    CONTROL         "s––‹Ö‘¥",IDC_CHECK_PS_KINSOKUTAIL,"Button",
+    CONTROL         "è¡Œæœ«ç¦å‰‡",IDC_CHECK_PS_KINSOKUTAIL,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,150,77,46,10
-    CONTROL         "‰üs‚Ô‚ç‰º‚°",IDC_CHECK_PS_KINSOKURET,"Button",
+    CONTROL         "æ”¹è¡Œã¶ã‚‰ä¸‹ã’",IDC_CHECK_PS_KINSOKURET,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,197,63,60,10
-    CONTROL         "‹å“Ç“_‚Ô‚ç‰º‚°",IDC_CHECK_PS_KINSOKUKUTO,"Button",
+    CONTROL         "å¥èª­ç‚¹ã¶ã‚‰ä¸‹ã’",IDC_CHECK_PS_KINSOKUKUTO,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,197,77,67,10
-    LTEXT           "s‚ ‚½‚è‚Ì•¶Žš”F",IDC_STATIC,150,96,65,8
-    LTEXT           "c•ûŒü‚Ìs”F",IDC_STATIC,150,110,65,8
+    LTEXT           "è¡Œã‚ãŸã‚Šã®æ–‡å­—æ•°ï¼š",IDC_STATIC,150,96,65,8
+    LTEXT           "ç¸¦æ–¹å‘ã®è¡Œæ•°ï¼š",IDC_STATIC,150,110,65,8
     RTEXT           "0",IDC_STATIC_ENABLECOLUMNS,215,96,20,8
     RTEXT           "0",IDC_STATIC_ENABLELINES,215,110,20,8
     GROUPBOX        "",IDC_STATIC,145,87,112,37
-    CONTROL         "ƒJƒ‰[ˆóü(&V)",IDC_CHECK_COLORPRINT,"Button",
+    CONTROL         "ã‚«ãƒ©ãƒ¼å°åˆ·(&V)",IDC_CHECK_COLORPRINT,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,150,145,61,10
-    LTEXT           "ƒwƒbƒ_[(&U)",IDC_STATIC,107,165,38,8
+    LTEXT           "ãƒ˜ãƒƒãƒ€ãƒ¼(&U)",IDC_STATIC,107,165,38,8
     EDITTEXT        IDC_EDIT_HEAD1,107,175,50,12,ES_AUTOHSCROLL
     EDITTEXT        IDC_EDIT_HEAD2,158,175,50,12,ES_AUTOHSCROLL
     EDITTEXT        IDC_EDIT_HEAD3,209,175,50,12,ES_AUTOHSCROLL
-    CONTROL         "Žg—p",IDC_CHECK_USE_FONT_HEAD,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "ä½¿ç”¨",IDC_CHECK_USE_FONT_HEAD,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,260,164,30,10
-    PUSHBUTTON      "ƒtƒHƒ“ƒg",IDC_BUTTON_FONT_HEAD,260,174,30,14
+    PUSHBUTTON      "ãƒ•ã‚©ãƒ³ãƒˆ",IDC_BUTTON_FONT_HEAD,260,174,30,14
     RTEXT           "Font(xxpt/xx.xmm)",IDC_STATIC_FONT_HEAD,145,161,114,14,
                     SS_CENTERIMAGE
-    LTEXT           "ƒtƒbƒ^[(&D)",IDC_STATIC,107,193,38,8
+    LTEXT           "ãƒ•ãƒƒã‚¿ãƒ¼(&D)",IDC_STATIC,107,193,38,8
     EDITTEXT        IDC_EDIT_FOOT1,107,203,50,12,ES_AUTOHSCROLL
     EDITTEXT        IDC_EDIT_FOOT2,158,203,50,12,ES_AUTOHSCROLL
     EDITTEXT        IDC_EDIT_FOOT3,209,203,50,12,ES_AUTOHSCROLL
-    CONTROL         "Žg—p",IDC_CHECK_USE_FONT_FOOT,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "ä½¿ç”¨",IDC_CHECK_USE_FONT_FOOT,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,260,192,30,10
-    PUSHBUTTON      "ƒtƒHƒ“ƒg",IDC_BUTTON_FONT_FOOT,260,202,30,14
+    PUSHBUTTON      "ãƒ•ã‚©ãƒ³ãƒˆ",IDC_BUTTON_FONT_FOOT,260,202,30,14
     RTEXT           "Font(xxpt/xx.xmm)",IDC_STATIC_FONT_FOOT,145,189,114,14,
                     SS_CENTERIMAGE
     DEFPUSHBUTTON   "&OK",IDOK,128,234,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,183,234,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,238,234,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,183,234,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,238,234,50,14
 END
 
 IDD_EXITING DIALOG DISCARDABLE  0, 0, 171, 30
 STYLE DS_MODALFRAME | DS_SETFOREGROUND | DS_CENTER | WS_POPUP | WS_VISIBLE
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     ICON            IDI_ICON_STD,IDC_STATIC,5,5,20,20
-    LTEXT           "I—¹‚µ‚Ä‚¢‚Ü‚·B ‚µ‚Î‚ç‚­‚¨‘Ò‚¿‚­‚¾‚³‚¢EEE",
+    LTEXT           "çµ‚äº†ã—ã¦ã„ã¾ã™ã€‚ ã—ã°ã‚‰ããŠå¾…ã¡ãã ã•ã„ãƒ»ãƒ»ãƒ»",
                     IDC_STATIC,30,10,137,8
 END
 
@@ -619,45 +619,45 @@ IDD_EXEC DIALOGEX 30, 0, 292, 137
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CENTERMOUSE | 
     DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒtƒ@ƒCƒ‹–¼‚ðŽw’è‚µ‚ÄŽÀs"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒ•ã‚¡ã‚¤ãƒ«åã‚’æŒ‡å®šã—ã¦å®Ÿè¡Œ"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "–¼‘O(&N)",IDC_STATIC,5,6,26,8
+    LTEXT           "åå‰(&N)",IDC_STATIC,5,6,26,8
     COMBOBOX        IDC_COMBO_m_szCommand,34,4,254,240,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_TABSTOP
     PUSHBUTTON      "&...",IDC_BUTTON_REFERENCE,278,20,9,12,WS_GROUP
-    CONTROL         "•W€o—Í‚ð“¾‚é(&S)",IDC_CHECK_GETSTDOUT,"Button",
+    CONTROL         "æ¨™æº–å‡ºåŠ›ã‚’å¾—ã‚‹(&S)",IDC_CHECK_GETSTDOUT,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,5,32,76,10
     COMBOBOX        IDC_COMBO_CODE_GET,16,43,73,10,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    CONTROL         "•W€“ü—Í‚É‘—‚é(&I)",IDC_CHECK_SENDSTDIN,"Button",
+    CONTROL         "æ¨™æº–å…¥åŠ›ã«é€ã‚‹(&I)",IDC_CHECK_SENDSTDIN,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,5,58,74,10
     COMBOBOX        IDC_COMBO_CODE_SEND,16,72,73,10,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    CONTROL         "ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE(&O)",IDC_RADIO_OUTPUT,"Button",
+    CONTROL         "ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦(&O)",IDC_RADIO_OUTPUT,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,102,51,93,10
-    CONTROL         "•ÒW’†‚ÌƒEƒBƒ“ƒhƒE(&C)",IDC_RADIO_EDITWINDOW,"Button",
+    CONTROL         "ç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦(&C)",IDC_RADIO_EDITWINDOW,"Button",
                     BS_AUTORADIOBUTTON | WS_TABSTOP,196,51,87,10
-    GROUPBOX        "•W€o—ÍƒŠƒ_ƒCƒŒƒNƒgæ",IDC_STATIC,98,39,190,29,
+    GROUPBOX        "æ¨™æº–å‡ºåŠ›ãƒªãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆå…ˆ",IDC_STATIC,98,39,190,29,
                     WS_GROUP
-    CONTROL         "ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ(&R)",IDC_CHECK_CUR_DIR,"Button",
+    CONTROL         "ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª(&R)",IDC_CHECK_CUR_DIR,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,5,86,93,10
     COMBOBOX        IDC_COMBO_CUR_DIR,16,100,263,240,CBS_DROPDOWN | 
                     CBS_AUTOHSCROLL | WS_TABSTOP
     PUSHBUTTON      "...",IDC_BUTTON_REFERENCE2,279,100,9,12,WS_GROUP
-    DEFPUSHBUTTON   "ŽÀs(&E)",IDOK,117,116,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,177,116,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,237,116,50,14
-    LTEXT           "[Note] $F‚Å•ÒW’†ƒtƒ@ƒCƒ‹–¼, $$‚Å$",IDC_STATIC,140,21,
+    DEFPUSHBUTTON   "å®Ÿè¡Œ(&E)",IDOK,117,116,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,177,116,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,237,116,50,14
+    LTEXT           "[Note] $Fã§ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«å, $$ã§$",IDC_STATIC,140,21,
                     134,8
 END
 
 IDD_EXECRUNNING DIALOG DISCARDABLE  0, 0, 270, 55
 STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "ƒRƒ}ƒ“ƒhŽÀs’†EEE"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œä¸­ãƒ»ãƒ»ãƒ»"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,207,36,59,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,207,36,59,14
     EDITTEXT        IDC_STATIC_CMD,5,5,260,23,ES_MULTILINE | ES_READONLY | 
                     NOT WS_BORDER | NOT WS_TABSTOP
 END
@@ -665,10 +665,10 @@ END
 IDD_MACRORUNNING DIALOG DISCARDABLE  0, 0, 270, 55
 STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION ""
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,207,5,59,14
-    LTEXT           "ƒ}ƒNƒŽÀs’†EEE",IDC_STATIC,5,5,200,23
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,207,5,59,14
+    LTEXT           "ãƒžã‚¯ãƒ­å®Ÿè¡Œä¸­ãƒ»ãƒ»ãƒ»",IDC_STATIC,5,5,200,23
     EDITTEXT        IDC_STATIC_CMD,5,28,260,23,ES_MULTILINE | ES_READONLY | 
                     NOT WS_BORDER | NOT WS_TABSTOP
 END
@@ -676,7 +676,7 @@ END
 IDD_HOKAN DIALOGEX 0, 0, 125, 100
 STYLE DS_SETFOREGROUND | DS_3DLOOK | WS_POPUP | WS_THICKFRAME
 EXSTYLE WS_EX_TOOLWINDOW
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     LISTBOX         IDC_LIST_WORDS,0,0,120,95,LBS_SORT | 
                     LBS_NOINTEGRALHEIGHT | LBS_WANTKEYBOARDINPUT | 
@@ -685,12 +685,12 @@ END
 
 IDD_PRINTING DIALOG DISCARDABLE  0, 0, 145, 75
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "ˆóü’†"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "å°åˆ·ä¸­"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,90,56,50,14
-    LTEXT           "ˆóü‚µ‚Ä‚¢‚Ü‚·EEEE",IDC_STATIC,25,10,65,8
-    LTEXT           "12/123•Å",IDC_STATIC_PROGRESS,25,43,100,8
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,90,56,50,14
+    LTEXT           "å°åˆ·ã—ã¦ã„ã¾ã™ãƒ»ãƒ»ãƒ»ãƒ»",IDC_STATIC,25,10,65,8
+    LTEXT           "12/123é ",IDC_STATIC_PROGRESS,25,43,100,8
     LTEXT           "CEditView.cpp",IDC_STATIC_JOBNAME,25,20,115,20
     ICON            IDI_PRINTER, IDC_STATIC, 10, 8, 11, 9, SS_REALSIZEIMAGE
 END
@@ -698,42 +698,42 @@ END
 IDD_FILEOPEN DIALOG DISCARDABLE  0, 0, 261, 66
 STYLE DS_3DLOOK | DS_CONTROL | WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | 
     WS_CLIPCHILDREN
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     LTEXT           "",IDC_STATIC_STC32,0,0,261,8
-    LTEXT           "•¶ŽšƒR[ƒhƒZƒbƒg(&C):",IDC_STATIC_CHARCODE,5,15,64,8
+    LTEXT           "æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ(&C):",IDC_STATIC_CHARCODE,5,15,64,8
     COMBOBOX        IDC_COMBO_CODE,71,13,50,126,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     CONTROL         "C&P",IDC_CHECK_CP,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,122,14,25,10
     CONTROL         "&BOM",IDC_CHECK_BOM,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,148,14,30,10
-    LTEXT           "‰üsƒR[ƒh(&E):",IDC_STATIC_EOL,181,15,45,8
+    LTEXT           "æ”¹è¡Œã‚³ãƒ¼ãƒ‰(&E):",IDC_STATIC_EOL,181,15,45,8
     COMBOBOX        IDC_COMBO_EOL,226,13,50,126,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Å‹ß‚Ìƒtƒ@ƒCƒ‹(&F):",IDC_STATIC,5,32,59,8
+    LTEXT           "æœ€è¿‘ã®ãƒ•ã‚¡ã‚¤ãƒ«(&F):",IDC_STATIC,5,32,59,8
     COMBOBOX        IDC_COMBO_MRU,71,30,185,236,CBS_DROPDOWNLIST | 
                     CBS_AUTOHSCROLL | CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Å‹ß‚ÌƒtƒHƒ‹ƒ_(&D):",IDC_STATIC,5,49,61,8
+    LTEXT           "æœ€è¿‘ã®ãƒ•ã‚©ãƒ«ãƒ€(&D):",IDC_STATIC,5,49,61,8
     COMBOBOX        IDC_COMBO_OPENFOLDER,71,46,185,236,CBS_DROPDOWNLIST | 
                     CBS_SORT | WS_VSCROLL | WS_TABSTOP
 END
 
 IDD_FILEUPDATEQUERY DIALOG DISCARDABLE  0, 0, 223, 107
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION
-CAPTION "ƒtƒ@ƒCƒ‹‚ªXV‚³‚ê‚Ü‚µ‚½"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒ•ã‚¡ã‚¤ãƒ«ãŒæ›´æ–°ã•ã‚Œã¾ã—ãŸ"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    PUSHBUTTON      "Ä“Çž(&R)",IDC_BTN_RELOAD,7,63,50,14
-    DEFPUSHBUTTON   "•Â‚¶‚é(&C)",IDC_BTN_CLOSE,59,63,50,14
-    PUSHBUTTON      "ˆÈŒã–¢•ÒW‚ÅÄ“Çž(&L)",IDC_BTN_AUTOLOAD, 114,63,102,14
-    PUSHBUTTON      "ˆÈŒã’Ê’mƒƒbƒZ[ƒW‚Ì‚Ý(&M)",IDC_BTN_NOTIFYONLY,7,81,102,
+    PUSHBUTTON      "å†èª­è¾¼(&R)",IDC_BTN_RELOAD,7,63,50,14
+    DEFPUSHBUTTON   "é–‰ã˜ã‚‹(&C)",IDC_BTN_CLOSE,59,63,50,14
+    PUSHBUTTON      "ä»¥å¾Œæœªç·¨é›†ã§å†èª­è¾¼(&L)",IDC_BTN_AUTOLOAD, 114,63,102,14
+    PUSHBUTTON      "ä»¥å¾Œé€šçŸ¥ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®ã¿(&M)",IDC_BTN_NOTIFYONLY,7,81,102,
                     14
-    PUSHBUTTON      "ˆÈŒãXV‚ðŠÄŽ‹‚µ‚È‚¢(&N)",IDC_BTN_NOSUPERVISION, 114,81,
+    PUSHBUTTON      "ä»¥å¾Œæ›´æ–°ã‚’ç›£è¦–ã—ãªã„(&N)",IDC_BTN_NOSUPERVISION, 114,81,
                     102,14
     EDITTEXT        IDC_UPDATEDFILENAME,7,7,209,25,ES_READONLY | 
                     NOT WS_TABSTOP | ES_MULTILINE
-    LTEXT           "‚±‚Ìƒtƒ@ƒCƒ‹‚ÍŠO•”‚ÌƒGƒfƒBƒ^“™‚Å•ÏX‚³‚ê‚Ä‚¢‚Ü‚·B",
+    LTEXT           "ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã¯å¤–éƒ¨ã®ã‚¨ãƒ‡ã‚£ã‚¿ç­‰ã§å¤‰æ›´ã•ã‚Œã¦ã„ã¾ã™ã€‚",
                     IDC_FILEUPDATEMSG,7,36,209,8
     LTEXT           "",IDC_QUERYRELOADMSG,7,48,209,8
 END
@@ -742,8 +742,8 @@ IDD_FAVORITE DIALOGEX 0, 0, 380, 274
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CAPTION | 
 WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "—š—ð‚Æ‚¨‹C‚É“ü‚è‚ÌŠÇ—"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "å±¥æ­´ã¨ãŠæ°—ã«å…¥ã‚Šã®ç®¡ç†"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     CONTROL         "List1",IDC_LIST_FAVORITE_FILE,"SysListView32",
                     LVS_REPORT | LVS_SHOWSELALWAYS | WS_BORDER | WS_TABSTOP,
@@ -770,19 +770,19 @@ BEGIN
                     LVS_SHOWSELALWAYS | WS_BORDER | WS_TABSTOP,25,127,243,79
     CONTROL         "List1",IDC_LIST_FAVORITE_CUR_DIR,"SysListView32",LVS_REPORT | 
                     LVS_SHOWSELALWAYS | WS_BORDER | WS_TABSTOP,25,127,243,79
-    PUSHBUTTON      "’Ç‰Á(&I)",IDC_BUTTON_ADD_FAVORITE,5,237,50,14
-    LTEXT           " —š—ð‚ÌíœF",IDC_STATIC_BUTTONS,65,237,45,14,
+    PUSHBUTTON      "è¿½åŠ (&I)",IDC_BUTTON_ADD_FAVORITE,5,237,50,14
+    LTEXT           " å±¥æ­´ã®å‰Šé™¤ï¼š",IDC_STATIC_BUTTONS,65,237,45,14,
                     SS_CENTERIMAGE
-    PUSHBUTTON      "‚·‚×‚Ä(&A)...",IDC_BUTTON_CLEAR,111,237,50,14
-    PUSHBUTTON      "‚¨‹C‚É“ü‚èˆÈŠO(&F)...",IDC_BUTTON_DELETE_NOFAVORATE,163,
+    PUSHBUTTON      "ã™ã¹ã¦(&A)...",IDC_BUTTON_CLEAR,111,237,50,14
+    PUSHBUTTON      "ãŠæ°—ã«å…¥ã‚Šä»¥å¤–(&F)...",IDC_BUTTON_DELETE_NOFAVORATE,163,
                     237,75,14
-    PUSHBUTTON      "‘¶Ý‚µ‚È‚¢€–Ú(&N)...",IDC_BUTTON_DELETE_NOTFOUND,241,237,
+    PUSHBUTTON      "å­˜åœ¨ã—ãªã„é …ç›®(&N)...",IDC_BUTTON_DELETE_NOTFOUND,241,237,
                     72,14
-    PUSHBUTTON      "‘I‘ð€–Ú(&D)",IDC_BUTTON_DELETE_SELECTED,315,237,58,14
-    DEFPUSHBUTTON   "•Â‚¶‚é(&C)",IDOK,260,255,50,14
+    PUSHBUTTON      "é¸æŠžé …ç›®(&D)",IDC_BUTTON_DELETE_SELECTED,315,237,58,14
+    DEFPUSHBUTTON   "é–‰ã˜ã‚‹(&C)",IDOK,260,255,50,14
     CONTROL         "Tab1",IDC_TAB_FAVORITE,"SysTabControl32",WS_TABSTOP,3,4,
                     374,15
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,320,255,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,320,255,50,14
     LTEXT           "Message",IDC_STATIC_FAVORITE_MSG,4,254,250,19
 END
 
@@ -790,57 +790,57 @@ IDD_TAGJUMPLIST DIALOGEX 0, 0, 410, 189
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_THICKFRAME | WS_CAPTION | 
 WS_SYSMENU | WS_CLIPCHILDREN
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒvˆê——"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ä¸€è¦§"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     LTEXT           "DIR",IDC_STATIC_BASEDIR,4,151,276,8,SS_NOPREFIX
-    LTEXT           "ƒL[ƒ[ƒh(&K)",IDC_STATIC_KEYWORD,4,162,100,8,SS_NOPREFIX
+    LTEXT           "ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰(&K)",IDC_STATIC_KEYWORD,4,162,100,8,SS_NOPREFIX
     COMBOBOX        IDC_KEYWORD,3,172,134,180,CBS_DROPDOWN | WS_VSCROLL | 
                     WS_TABSTOP
     CONTROL         "List1",IDC_LIST_TAGJUMP,"SysListView32",LVS_REPORT | 
                     LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | 
                     WS_BORDER | WS_TABSTOP,3,4,403,143
-    PUSHBUTTON      "‘O‚Ö(&P)",IDC_BUTTON_PREVTAG,296,152,50,14
-    PUSHBUTTON      "ŽŸ‚Ö(&N)",IDC_BUTTON_NEXTTAG,349,152,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,243,170,50,14
-    DEFPUSHBUTTON   "ƒWƒƒƒ“ƒv(&J)",IDOK,296,170,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,349,170,50,14
-    CONTROL         "‘å•¶Žš¬•¶Žš‚Ì“¯ˆêŽ‹(&F)",IDC_CHECK_ICASE,"Button",
+    PUSHBUTTON      "å‰ã¸(&P)",IDC_BUTTON_PREVTAG,296,152,50,14
+    PUSHBUTTON      "æ¬¡ã¸(&N)",IDC_BUTTON_NEXTTAG,349,152,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,243,170,50,14
+    DEFPUSHBUTTON   "ã‚¸ãƒ£ãƒ³ãƒ—(&J)",IDOK,296,170,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,349,170,50,14
+    CONTROL         "å¤§æ–‡å­—å°æ–‡å­—ã®åŒä¸€è¦–(&F)",IDC_CHECK_ICASE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,144,163,93,10
-    CONTROL         "•¶Žš—ñ‚Ì“r’†‚Éƒ}ƒbƒ`(&A)",IDC_CHECK_ANYWHERE,"Button",
+    CONTROL         "æ–‡å­—åˆ—ã®é€”ä¸­ã«ãƒžãƒƒãƒ(&A)",IDC_CHECK_ANYWHERE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,144,175,93,10
 END
 
 IDD_TAG_MAKE DIALOGEX 0, 0, 233, 85
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒ^ƒOƒtƒ@ƒCƒ‹‚Ìì¬"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆ"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "ƒ^ƒOì¬ƒtƒHƒ‹ƒ_",IDC_STATIC,7,7,65,8
+    LTEXT           "ã‚¿ã‚°ä½œæˆãƒ•ã‚©ãƒ«ãƒ€",IDC_STATIC,7,7,65,8
     EDITTEXT        IDC_EDIT_TAG_MAKE_FOLDER,7,18,201,12,ES_AUTOHSCROLL
     PUSHBUTTON      "...",IDC_BUTTON_TAG_MAKE_REF,211,17,15,12
-    PUSHBUTTON      "ã(&B)",IDC_BUTTON_FOLDER_UP,186,31,25,14
-    CONTROL         "ƒTƒuƒtƒHƒ‹ƒ_‚à‘ÎÛ‚É‚·‚é",
+    PUSHBUTTON      "ä¸Š(&B)",IDC_BUTTON_FOLDER_UP,186,31,25,14
+    CONTROL         "ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚å¯¾è±¡ã«ã™ã‚‹",
                     IDC_CHECK_TAG_MAKE_RECURSE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,7,34,107,10
-    LTEXT           "ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“ƒIƒvƒVƒ‡ƒ“",IDC_STATIC,7,49,86,8
+    LTEXT           "ã‚³ãƒžãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³ã‚ªãƒ—ã‚·ãƒ§ãƒ³",IDC_STATIC,7,49,86,8
     EDITTEXT        IDC_EDIT_TAG_MAKE_CMDLINE,96,47,130,12,ES_AUTOHSCROLL
-    DEFPUSHBUTTON   "ì¬(&O)",IDOK,68,64,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,122,64,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,176,64,50,14
+    DEFPUSHBUTTON   "ä½œæˆ(&O)",IDOK,68,64,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,122,64,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,176,64,50,14
 END
 
 IDD_OPERATIONRUNNING DIALOG DISCARDABLE  0, 0, 190, 35
 STYLE DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "ˆ—‚ÌŽÀs’†"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "å‡¦ç†ã®å®Ÿè¡Œä¸­"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "ˆ—’†‚Å‚·EEEE",IDC_STATIC_MSG,5,5,54,8,NOT 
+    LTEXT           "å‡¦ç†ä¸­ã§ã™ãƒ»ãƒ»ãƒ»ãƒ»",IDC_STATIC_MSG,5,5,54,8,NOT 
                     WS_GROUP
     CONTROL         "Progress1",IDC_PROGRESS,"msctls_progress32",WS_BORDER,5,
                     20,120,10
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,135,16,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,135,16,50,14
     RTEXT           "",IDC_STATIC_KENSUU,61,5,123,8,NOT WS_GROUP
 END
 
@@ -848,52 +848,52 @@ IDD_DIFF DIALOGEX 0, 0, 263, 303
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CAPTION | 
 WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "DIFF·•ª•\Ž¦"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "DIFFå·®åˆ†è¡¨ç¤º"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    GROUPBOX        "”äŠr‚·‚éƒtƒ@ƒCƒ‹",IDC_FRAME_DIFF_DST,7,47,249,138,
+    GROUPBOX        "æ¯”è¼ƒã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«",IDC_FRAME_DIFF_DST,7,47,249,138,
                     WS_GROUP
     EDITTEXT        IDC_EDIT_DIFF_DST,13,72,191,13,ES_AUTOHSCROLL
-    CONTROL         "ŠO•”ƒtƒ@ƒCƒ‹‚ðŽw’è",IDC_RADIO_DIFF_DST1,"Button",
+    CONTROL         "å¤–éƒ¨ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æŒ‡å®š",IDC_RADIO_DIFF_DST1,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,13,58,78,11
-    PUSHBUTTON      "ŽQÆ(&R)...",IDC_BUTTON_DIFF_DST,208,72,42,14,WS_GROUP
-    CONTROL         "‘¼‚Ì•ÒW’†‚Ìƒtƒ@ƒCƒ‹",IDC_RADIO_DIFF_DST2,"Button",
+    PUSHBUTTON      "å‚ç…§(&R)...",IDC_BUTTON_DIFF_DST,208,72,42,14,WS_GROUP
+    CONTROL         "ä»–ã®ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«",IDC_RADIO_DIFF_DST2,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,13,89,147,11
     LISTBOX         IDC_LIST_DIFF_FILES,13,102,236,77,LBS_SORT | 
                     LBS_USETABSTOPS | LBS_NOINTEGRALHEIGHT | 
                     LBS_DISABLENOSCROLL | WS_VSCROLL | WS_HSCROLL | 
                     WS_TABSTOP
-    CONTROL         "‘å•¶Žš¬•¶Žš‚Ì“¯ˆêŽ‹(&C)",IDC_CHECK_DIFF_OPT_CASE,
+    CONTROL         "å¤§æ–‡å­—å°æ–‡å­—ã®åŒä¸€è¦–(&C)",IDC_CHECK_DIFF_OPT_CASE,
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,7,191,
                     101,10
-    CONTROL         "‹ó”’–³Ž‹(&W)",IDC_CHECK_DIFF_OPT_SPACE,"Button",
+    CONTROL         "ç©ºç™½ç„¡è¦–(&W)",IDC_CHECK_DIFF_OPT_SPACE,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,7,203,64,10
-    CONTROL         "‹ó”’•ÏX–³Ž‹(&B)",IDC_CHECK_DIFF_OPT_SPCCHG,"Button",
+    CONTROL         "ç©ºç™½å¤‰æ›´ç„¡è¦–(&B)",IDC_CHECK_DIFF_OPT_SPCCHG,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,7,216,73,10
-    CONTROL         "‹ó”’s–³Ž‹(&L)",IDC_CHECK_DIFF_OPT_BLINE,"Button",
+    CONTROL         "ç©ºç™½è¡Œç„¡è¦–(&L)",IDC_CHECK_DIFF_OPT_BLINE,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,7,229,74,10
-    CONTROL         "ƒ^ƒu‹ó”’•ÏŠ·(&T)",IDC_CHECK_DIFF_OPT_TABSPC,"Button",
+    CONTROL         "ã‚¿ãƒ–ç©ºç™½å¤‰æ›(&T)",IDC_CHECK_DIFF_OPT_TABSPC,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,7,242,74,10
-    GROUPBOX        "•ÒW’†ƒtƒ@ƒCƒ‹‚ª...",IDC_FRAME_DIFF_FILE12,110,190,146,
+    GROUPBOX        "ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ãŒ...",IDC_FRAME_DIFF_FILE12,110,190,146,
                     26,WS_GROUP
-    CONTROL         "Vƒtƒ@ƒCƒ‹(&N)",IDC_RADIO_DIFF_FILE1,"Button",
+    CONTROL         "æ–°ãƒ•ã‚¡ã‚¤ãƒ«(&N)",IDC_RADIO_DIFF_FILE1,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP,119,201,59,10
-    CONTROL         "‹Œƒtƒ@ƒCƒ‹(&D)",IDC_RADIO_DIFF_FILE2,"Button",
+    CONTROL         "æ—§ãƒ•ã‚¡ã‚¤ãƒ«(&D)",IDC_RADIO_DIFF_FILE2,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP,183,201,59,10
-    GROUPBOX        "ŽŸ‚Ì·•ª(‘O‚Ì·•ª)‚ÖˆÚ“®Žž",IDC_FRAME_SEARCH_MSG,110,
+    GROUPBOX        "æ¬¡ã®å·®åˆ†(å‰ã®å·®åˆ†)ã¸ç§»å‹•æ™‚",IDC_FRAME_SEARCH_MSG,110,
                     221,146,41
-    CONTROL         "Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ð•\Ž¦(&M)",
+    CONTROL         "è¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º(&M)",
                     IDC_CHECK_NOTIFYNOTFOUND,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,114,232,140,10
-    CONTROL         "æ“ªi––”öj‚©‚çÄŒŸõ‚·‚é(&Z)",IDC_CHECK_SEARCHALL,
+    CONTROL         "å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ã™ã‚‹(&Z)",IDC_CHECK_SEARCHALL,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,114,245,130,10
-    CONTROL         "DIFF·•ª‚ª‚È‚¢‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ð•\Ž¦",
+    CONTROL         "DIFFå·®åˆ†ãŒãªã„ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º",
                     IDC_CHECK_DIFF_EXEC_STATE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,110,267,139,10
     DEFPUSHBUTTON   "&OK",IDOK,93,282,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,147,282,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,202,282,50,14
-    LTEXT           "•ÒW’†‚Ìƒtƒ@ƒCƒ‹",IDC_STATIC,7,7,61,8
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,147,282,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,202,282,50,14
+    LTEXT           "ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«",IDC_STATIC,7,7,61,8
     EDITTEXT        IDC_STATIC_DIFF_SRC,7,18,249,23,ES_MULTILINE | 
                     ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | 
                     WS_VSCROLL,WS_EX_STATICEDGE
@@ -902,247 +902,247 @@ END
 IDD_CTRLCODE DIALOGEX 0, 0, 179, 185
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     CONTROL         "List1",IDC_LIST_CTRLCODE,"SysListView32",LVS_REPORT | 
                     LVS_SINGLESEL | LVS_NOLABELWRAP | LVS_NOSORTHEADER | 
                     WS_BORDER | WS_TABSTOP,2,2,175,162
     DEFPUSHBUTTON   "&OK",IDOK,19,168,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,73,168,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,127,168,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,73,168,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,127,168,50,14
 END
 
 IDD_SETCHARSET DIALOGEX 0, 0, 186, 45
 STYLE DS_CENTER | DS_MODALFRAME | DS_SETFONT | WS_BORDER | WS_CAPTION | WS_DLGFRAME | WS_POPUP
-CAPTION "•¶ŽšƒR[ƒh‚ÌŽw’è"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "æ–‡å­—ã‚³ãƒ¼ãƒ‰ã®æŒ‡å®š"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "•¶ŽšƒR[ƒhƒZƒbƒg(&C):", IDC_STATIC, 5, 9, 64, 8
+    LTEXT           "æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ(&C):", IDC_STATIC, 5, 9, 64, 8
     COMBOBOX        IDC_COMBO_CHARSET, 71, 7, 50, 126, CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     AUTOCHECKBOX    "C&P", IDC_CHECK_CP, 71, 26, 25, 10
     AUTOCHECKBOX    "&BOM", IDC_CHECK_BOM, 96, 26, 30, 10
     DEFPUSHBUTTON   "&OK", IDOK, 129, 7, 50, 14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)", IDCANCEL, 129, 24, 50, 14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)", IDCANCEL, 129, 24, 50, 14
 END
 
 IDD_TYPELIST DIALOGEX 0, 0, 187, 280
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒ^ƒCƒv•ÊÝ’èˆê——"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šä¸€è¦§"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "‰º‚©‚çƒ^ƒCƒv‚ð‘I‘ð‚µ‚Ä‚­‚¾‚³‚¢(&T):",IDC_STATIC,5,5,111,8
+    LTEXT           "ä¸‹ã‹ã‚‰ã‚¿ã‚¤ãƒ—ã‚’é¸æŠžã—ã¦ãã ã•ã„(&T):",IDC_STATIC,5,5,111,8
     LISTBOX         IDC_LIST_TYPES,5,15,120,258,LBS_NOINTEGRALHEIGHT | 
                     WS_VSCROLL | WS_HSCROLL | WS_TABSTOP
-    DEFPUSHBUTTON   "Ý’è•ÏX(&S)...",IDOK,130,15,50,14
-    PUSHBUTTON      "ˆêŽž“K—p(&R)",IDC_BUTTON_TEMPCHANGE,130,31,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,130,50,50,14
-    PUSHBUTTON      "ƒCƒ“ƒ|[ƒg(&I)",IDC_BUTTON_IMPORT,130,79,50,14
-    PUSHBUTTON      "ƒGƒNƒXƒ|[ƒg(&E)",IDC_BUTTON_EXPORT,130,95,50,14
-    PUSHBUTTON      "‰Šú‰»(&N)",IDC_BUTTON_INITIALIZE,130,111,50,14
-    PUSHBUTTON      "•¡»(&C)",IDC_BUTTON_COPY_TYPE,130,127,50,14
-    PUSHBUTTON      "ª(&U)",IDC_BUTTON_UP_TYPE,130,143,50,14
-    PUSHBUTTON      "«(&O)",IDC_BUTTON_DOWN_TYPE,130,159,50,14
-    PUSHBUTTON      "’Ç‰Á(&A)",IDC_BUTTON_ADD_TYPE,130,175,50,14
-    PUSHBUTTON      "íœ(&D)",IDC_BUTTON_DEL_TYPE,130,191,50,14
-    CONTROL         "‰EƒNƒŠƒbƒNƒƒjƒ…[‚É’Ç‰Á",IDC_CHECK_EXT_RMENU,"Button",BS_AUTOCHECKBOX |
+    DEFPUSHBUTTON   "è¨­å®šå¤‰æ›´(&S)...",IDOK,130,15,50,14
+    PUSHBUTTON      "ä¸€æ™‚é©ç”¨(&R)",IDC_BUTTON_TEMPCHANGE,130,31,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,130,50,50,14
+    PUSHBUTTON      "ã‚¤ãƒ³ãƒãƒ¼ãƒˆ(&I)",IDC_BUTTON_IMPORT,130,79,50,14
+    PUSHBUTTON      "ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ(&E)",IDC_BUTTON_EXPORT,130,95,50,14
+    PUSHBUTTON      "åˆæœŸåŒ–(&N)",IDC_BUTTON_INITIALIZE,130,111,50,14
+    PUSHBUTTON      "è¤‡è£½(&C)",IDC_BUTTON_COPY_TYPE,130,127,50,14
+    PUSHBUTTON      "â†‘(&U)",IDC_BUTTON_UP_TYPE,130,143,50,14
+    PUSHBUTTON      "â†“(&O)",IDC_BUTTON_DOWN_TYPE,130,159,50,14
+    PUSHBUTTON      "è¿½åŠ (&A)",IDC_BUTTON_ADD_TYPE,130,175,50,14
+    PUSHBUTTON      "å‰Šé™¤(&D)",IDC_BUTTON_DEL_TYPE,130,191,50,14
+    CONTROL         "å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«è¿½åŠ ",IDC_CHECK_EXT_RMENU,"Button",BS_AUTOCHECKBOX |
                     BS_MULTILINE | WS_DISABLED | WS_TABSTOP,130,207,50,28
-    CONTROL         "ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚ÅŠJ‚­",IDC_CHECK_EXT_DBLCLICK,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§é–‹ã",IDC_CHECK_EXT_DBLCLICK,"Button",BS_AUTOCHECKBOX | 
                     BS_MULTILINE | WS_DISABLED | WS_TABSTOP,130,231,50,28
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,130,262,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,130,262,50,14
 END
 
 IDD_TYPE_ASCERTAIN DIALOGEX 0, 0, 187, 100
 STYLE DS_MODALFRAME | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | 
     WS_SYSMENU
-CAPTION "ƒCƒ“ƒ|[ƒgŠm”F"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ã‚¤ãƒ³ãƒãƒ¼ãƒˆç¢ºèª"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "“Çžæ:", IDC_STATIC, 7, 7, 33, 8
-    CONTROL         "V‹K’Ç‰Á(&A)", IDC_RADIO_TYPE_ADD,"Button",BS_AUTORADIOBUTTON,
+    LTEXT           "èª­è¾¼å…ˆ:", IDC_STATIC, 7, 7, 33, 8
+    CONTROL         "æ–°è¦è¿½åŠ (&A)", IDC_RADIO_TYPE_ADD,"Button",BS_AUTORADIOBUTTON,
                     36,7,45,8
-    CONTROL         "Šî–{", IDC_RADIO_TYPE_TO,"Button",BS_AUTORADIOBUTTON,
+    CONTROL         "åŸºæœ¬", IDC_RADIO_TYPE_TO,"Button",BS_AUTORADIOBUTTON,
                     86,7,135,8
-    LTEXT           "Vƒ^ƒCƒv–¼:", IDC_STATIC, 7, 27, 33, 8
-    LTEXT           "Šî–{", IDC_STATIC_TYPE_FILE, 45, 27, 135, 16
-    LTEXT           "F‘I‘ð(&C)", IDC_STATIC, 7, 47, 35, 8
+    LTEXT           "æ–°ã‚¿ã‚¤ãƒ—å:", IDC_STATIC, 7, 27, 33, 8
+    LTEXT           "åŸºæœ¬", IDC_STATIC_TYPE_FILE, 45, 27, 135, 16
+    LTEXT           "è‰²é¸æŠž(&C)", IDC_STATIC, 7, 47, 35, 8
     COMBOBOX        IDC_COMBO_COLORS, 44, 45, 100, 250, CBS_DROPDOWNLIST |
                     WS_VSCROLL | WS_TABSTOP
-    LTEXT           "ã‹LðŒ‚ÅƒCƒ“ƒ|[ƒg‚µ‚Ü‚·B‚æ‚ë‚µ‚¢‚Å‚·‚©H",
+    LTEXT           "ä¸Šè¨˜æ¡ä»¶ã§ã‚¤ãƒ³ãƒãƒ¼ãƒˆã—ã¾ã™ã€‚ã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ",
                     IDC_STATIC_MSG, 26, 64, 154, 8
     DEFPUSHBUTTON   "&OK", IDOK, 26, 79, 50, 14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)", IDCANCEL, 78, 79, 50, 14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)", IDC_BUTTON_HELP, 130, 79, 50, 14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)", IDCANCEL, 78, 79, 50, 14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)", IDC_BUTTON_HELP, 130, 79, 50, 14
 END
 
 IDD_PROP_SCREEN DIALOGEX 0, 0, 302, 244
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "Ý’è‚Ì–¼‘O(&N)",IDC_STATIC,5,6,49,8
+    LTEXT           "è¨­å®šã®åå‰(&N)",IDC_STATIC,5,6,49,8
     EDITTEXT        IDC_EDIT_TYPENAME,55,4,59,12,ES_AUTOHSCROLL
-    LTEXT           "ƒtƒ@ƒCƒ‹Šg’£Žq(&X)",IDC_STATIC,124,6,58,8
+    LTEXT           "ãƒ•ã‚¡ã‚¤ãƒ«æ‹¡å¼µå­(&X)",IDC_STATIC,124,6,58,8
     EDITTEXT        IDC_EDIT_TYPEEXTS,184,4,113,12,ES_AUTOHSCROLL
-    RTEXT           "Ü‚è•Ô‚µ•û–@(&<)",IDC_STATIC,8,34,56,8,NOT WS_GROUP
+    RTEXT           "æŠ˜ã‚Šè¿”ã—æ–¹æ³•(&<)",IDC_STATIC,8,34,56,8,NOT WS_GROUP
     COMBOBOX        IDC_COMBO_WRAPMETHOD,70,32,72,78,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    RTEXT           "Ü‚è•Ô‚µŒ…”(&R)",IDC_STATIC,8,49,56,8,NOT WS_GROUP
+    RTEXT           "æŠ˜ã‚Šè¿”ã—æ¡æ•°(&R)",IDC_STATIC,8,49,56,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_MAXLINELEN,70,48,40,12
     CONTROL         "Spin1",IDC_SPIN_MAXLINELEN,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,117,48,9,
                     12,WS_EX_TRANSPARENT
-    RTEXT           "•¶Žš‚ÌŠÔŠu(&C)",IDC_STATIC,8,64,56,8,NOT WS_GROUP
+    RTEXT           "æ–‡å­—ã®é–“éš”(&C)",IDC_STATIC,8,64,56,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_CHARSPACE,70,63,40,12
     CONTROL         "Spin1",IDC_SPIN_CHARSPACE,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,117,63,9,
                     12,WS_EX_TRANSPARENT
-    LTEXT           "ƒhƒbƒg",IDC_STATIC,114,64,18,8
-    RTEXT           "s‚ÌŠÔŠu(&L)",IDC_STATIC,8,79,56,8,NOT WS_GROUP
+    LTEXT           "ãƒ‰ãƒƒãƒˆ",IDC_STATIC,114,64,18,8
+    RTEXT           "è¡Œã®é–“éš”(&L)",IDC_STATIC,8,79,56,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_LINESPACE,70,78,40,12,ES_AUTOHSCROLL
     CONTROL         "Spin3",IDC_SPIN_LINESPACE,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,117,78,9,
                     12
-    LTEXT           "ƒhƒbƒg",IDC_STATIC,114,79,18,8
-    RTEXT           "TAB•(&T)",IDC_STATIC,8,94,56,8,NOT WS_GROUP
+    LTEXT           "ãƒ‰ãƒƒãƒˆ",IDC_STATIC,114,79,18,8
+    RTEXT           "TABå¹…(&T)",IDC_STATIC,8,94,56,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_TABSPACE,70,93,40,12,ES_AUTOHSCROLL
     CONTROL         "Spin3",IDC_SPIN_TABSPACE,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,117,93,7,
                     12
-    LTEXT           "T&AB•\Ž¦",IDC_STATIC,16,110,56,8,NOT WS_GROUP
+    LTEXT           "T&ABè¡¨ç¤º",IDC_STATIC,16,110,56,8,NOT WS_GROUP
     COMBOBOX        IDC_CHECK_TAB_ARROW,48,108,46,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     EDITTEXT        IDC_EDIT_TABVIEWSTRING,102,108,40,12,ES_AUTOHSCROLL
-    CONTROL         "S&PACE‚Ì‘}“ü",IDC_CHECK_INS_SPACE,"Button",
+    CONTROL         "S&PACEã®æŒ¿å…¥",IDC_CHECK_INS_SPACE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,70,123,57,10
     COMBOBOX        IDC_COMBO_TSV_MODE,16,123,46,40,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    GROUPBOX        "ƒŒƒCƒAƒEƒg",IDC_STATIC,3,22,145,117
-    CONTROL         "Ž©“®ƒCƒ“ƒfƒ“ƒg(&U)",IDC_CHECK_INDENT,"Button",
+    GROUPBOX        "ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆ",IDC_STATIC,3,22,145,117
+    CONTROL         "è‡ªå‹•ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ(&U)",IDC_CHECK_INDENT,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,8,154,72,10
-    CONTROL         "‘SŠp‹ó”’‚à(&Z)",IDC_CHECK_INDENT_WSPACE,"Button",
+    CONTROL         "å…¨è§’ç©ºç™½ã‚‚(&Z)",IDC_CHECK_INDENT_WSPACE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,83,154,61,10
-    LTEXT           "ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒg(&S)",IDC_STATIC,8,169,68,8
+    LTEXT           "ã‚¹ãƒžãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ(&S)",IDC_STATIC,8,169,68,8
     COMBOBOX        IDC_COMBO_SMARTINDENT,82,167,60,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    LTEXT           "‚»‚Ì‘¼‚ÌƒCƒ“ƒfƒ“ƒg‘ÎÛ•¶Žš(&I)",IDC_STATIC,8,183,120,8
+    LTEXT           "ãã®ä»–ã®ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¯¾è±¡æ–‡å­—(&I)",IDC_STATIC,8,183,120,8
     EDITTEXT        IDC_EDIT_INDENTCHARS,38,195,103,12,ES_AUTOHSCROLL
-    LTEXT           "Ü‚è•Ô‚µsƒCƒ“ƒfƒ“ƒg(&2)",IDC_STATIC,8,211,75,8
+    LTEXT           "æŠ˜ã‚Šè¿”ã—è¡Œã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ(&2)",IDC_STATIC,8,211,75,8
     COMBOBOX        IDC_COMBO_INDENTLAYOUT,87,209,54,63,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    CONTROL         "‰üsŽž‚É––”ö‚Ì‹ó”’‚ðíœ(&E)",IDC_CHECK_RTRIM_PREVLINE,
+    CONTROL         "æ”¹è¡Œæ™‚ã«æœ«å°¾ã®ç©ºç™½ã‚’å‰Šé™¤(&E)",IDC_CHECK_RTRIM_PREVLINE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,224,113,10
-    GROUPBOX        "ƒCƒ“ƒfƒ“ƒg",IDC_STATIC,3,143,145,97
-    CONTROL         "•W€ƒ‹[ƒ‹(&B)",IDC_RADIO_OUTLINEDEFAULT,"Button",
+    GROUPBOX        "ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ",IDC_STATIC,3,143,145,97
+    CONTROL         "æ¨™æº–ãƒ«ãƒ¼ãƒ«(&B)",IDC_RADIO_OUTLINEDEFAULT,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP,162,33,82,10
     COMBOBOX        IDC_COMBO_OUTLINES,173,46,81,85,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    CONTROL         "ƒ‹[ƒ‹ƒtƒ@ƒCƒ‹(&D)",IDC_RADIO_OUTLINERULEFILE,"Button",
+    CONTROL         "ãƒ«ãƒ¼ãƒ«ãƒ•ã‚¡ã‚¤ãƒ«(&D)",IDC_RADIO_OUTLINERULEFILE,"Button",
                     BS_AUTORADIOBUTTON,162,63,69,10
     EDITTEXT        IDC_EDIT_OUTLINERULEFILE,173,74,92,14,ES_AUTOHSCROLL
     PUSHBUTTON      "(&1)...",IDC_BUTTON_RULEFILE_REF,268,74,20,14
-    GROUPBOX        "ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ•û–@",IDC_STATIC,153,22,145,71
-    CONTROL         "Žg—p‚·‚é(&G)",IDC_CHECK_USETYPEFONT,"Button",
+    GROUPBOX        "ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžæ–¹æ³•",IDC_STATIC,153,22,145,71
+    CONTROL         "ä½¿ç”¨ã™ã‚‹(&G)",IDC_CHECK_USETYPEFONT,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,162,108,48,10
     LTEXT           "Font(nnpt)",IDC_STATIC_TYPEFONT,210,105,85,16,
                     SS_CENTERIMAGE
-    PUSHBUTTON      "ƒtƒHƒ“ƒg(&F)...",IDC_BUTTON_TYPEFONT,173,121,80,14
-    GROUPBOX        "ƒ^ƒCƒv•ÊƒtƒHƒ“ƒg",IDC_STATIC,153,97,145,42
-    CONTROL         "‰p•¶ƒ[ƒhƒ‰ƒbƒv(&W)",IDC_CHECK_WORDWRAP,"Button",
+    PUSHBUTTON      "ãƒ•ã‚©ãƒ³ãƒˆ(&F)...",IDC_BUTTON_TYPEFONT,173,121,80,14
+    GROUPBOX        "ã‚¿ã‚¤ãƒ—åˆ¥ãƒ•ã‚©ãƒ³ãƒˆ",IDC_STATIC,153,97,145,42
+    CONTROL         "è‹±æ–‡ãƒ¯ãƒ¼ãƒ‰ãƒ©ãƒƒãƒ—(&W)",IDC_CHECK_WORDWRAP,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,162,154,78,10
-    CONTROL         "‰üs‚Ô‚ç‰º‚°(&^)",IDC_CHECK_KINSOKURET,"Button",
+    CONTROL         "æ”¹è¡Œã¶ã‚‰ä¸‹ã’(&^)",IDC_CHECK_KINSOKURET,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,162,168,100,10
-    CONTROL         "‚Ô‚ç‰º‚°‚ð‰B‚·(&-)",IDC_CHECK_KINSOKUHIDE,"Button",
+    CONTROL         "ã¶ã‚‰ä¸‹ã’ã‚’éš ã™(&-)",IDC_CHECK_KINSOKUHIDE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,172,182,100,10
-    CONTROL         "‹å“Ç“_‚Ô‚ç‰º‚°(&\\)",IDC_CHECK_KINSOKUKUTO,"Button",
+    CONTROL         "å¥èª­ç‚¹ã¶ã‚‰ä¸‹ã’(&\\)",IDC_CHECK_KINSOKUKUTO,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,162,196,95,10
     EDITTEXT        IDC_EDIT_KINSOKUKUTO,258,195,30,12,ES_AUTOHSCROLL
-    CONTROL         "s“ª‹Ö‘¥(&[)",IDC_CHECK_KINSOKUHEAD,"Button",
+    CONTROL         "è¡Œé ­ç¦å‰‡(&[)",IDC_CHECK_KINSOKUHEAD,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,162,210,54,10
     EDITTEXT        IDC_EDIT_KINSOKUHEAD,218,209,70,12,ES_AUTOHSCROLL
-    CONTROL         "s––‹Ö‘¥(&])",IDC_CHECK_KINSOKUTAIL,"Button",
+    CONTROL         "è¡Œæœ«ç¦å‰‡(&])",IDC_CHECK_KINSOKUTAIL,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,162,224,54,10
     EDITTEXT        IDC_EDIT_KINSOKUTAIL,218,223,70,12,ES_AUTOHSCROLL
-    GROUPBOX        "‹Ö‘¥ˆ—",IDC_STATIC,153,143,145,97
+    GROUPBOX        "ç¦å‰‡å‡¦ç†",IDC_STATIC,153,143,145,97
 END
 
 IDD_PROP_COLOR DIALOGEX DISCARDABLE  0, 0, 302, 244
 STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    GROUPBOX        "FŽw’è(&L)",IDC_STATIC,3,6,148,204,WS_GROUP
+    GROUPBOX        "è‰²æŒ‡å®š(&L)",IDC_STATIC,3,6,148,204,WS_GROUP
     LISTBOX         IDC_LIST_COLORS,6,18,142,148,LBS_OWNERDRAWFIXED | 
                     WS_VSCROLL | WS_GROUP | WS_TABSTOP
-    CONTROL         "F•ª‚¯/•\Ž¦(&D)",IDC_CHECK_DISP,"Button",
+    CONTROL         "è‰²åˆ†ã‘/è¡¨ç¤º(&D)",IDC_CHECK_DISP,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,6,165,65,10
-    CONTROL         "‘¾Žš(&B)",IDC_CHECK_BOLD,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "å¤ªå­—(&B)",IDC_CHECK_BOLD,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,72,165,36,10
-    CONTROL         "‰ºü(&U)",IDC_CHECK_UNDERLINE,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "ä¸‹ç·š(&U)",IDC_CHECK_UNDERLINE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,112,165,36,10
-    LTEXT           "•¶ŽšF(C)",IDC_STATIC_MOZI,16,181,34,8
+    LTEXT           "æ–‡å­—è‰²(C)",IDC_STATIC_MOZI,16,181,34,8
     CONTROL         "&C",IDC_BUTTON_TEXTCOLOR,"Button",BS_OWNERDRAW | 
                     WS_TABSTOP,54,178,25,14
-    PUSHBUTTON      "•¶ŽšF“ˆê(&<)...",IDC_BUTTON_SAMETEXTCOLOR,84,178,58,
+    PUSHBUTTON      "æ–‡å­—è‰²çµ±ä¸€(&<)...",IDC_BUTTON_SAMETEXTCOLOR,84,178,58,
                     14
-    LTEXT           "”wŒiF(K)",IDC_STATIC_HAIKEI,16,196,33,8,NOT WS_GROUP
+    LTEXT           "èƒŒæ™¯è‰²(K)",IDC_STATIC_HAIKEI,16,196,33,8,NOT WS_GROUP
     CONTROL         "&K",IDC_BUTTON_BACKCOLOR,"Button",BS_OWNERDRAW | 
                     WS_TABSTOP,54,193,25,14
-    PUSHBUTTON      "”wŒiF“ˆê(&>)...",IDC_BUTTON_SAMEBKCOLOR,84,193,58,14
-    PUSHBUTTON      "ƒCƒ“ƒ|[ƒg(&I)...",IDC_BUTTON_IMPORT,25,215,60,14,
+    PUSHBUTTON      "èƒŒæ™¯è‰²çµ±ä¸€(&>)...",IDC_BUTTON_SAMEBKCOLOR,84,193,58,14
+    PUSHBUTTON      "ã‚¤ãƒ³ãƒãƒ¼ãƒˆ(&I)...",IDC_BUTTON_IMPORT,25,215,60,14,
                     WS_GROUP
-    PUSHBUTTON      "ƒGƒNƒXƒ|[ƒg(&X)...",IDC_BUTTON_EXPORT,88,215,60,14
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&1",IDC_STATIC,162,18,54,8
+    PUSHBUTTON      "ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ(&X)...",IDC_BUTTON_EXPORT,88,215,60,14
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&1",IDC_STATIC,162,18,54,8
     COMBOBOX        IDC_COMBO_SET,218,16,75,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    PUSHBUTTON      "&2`10...",IDC_BUTTON_KEYWORD_SELECT,218,31,75,14
-    PUSHBUTTON      "‹¤’ÊÝ’è(&C)...",IDC_BUTTON_EDITKEYWORD,218,47,75,14
-    GROUPBOX        "‹­’²ƒL[ƒ[ƒh",IDC_STATIC,156,6,142,60,WS_GROUP
-    LTEXT           "ƒuƒƒbƒNŒ^(&F)",IDC_STATIC,164,80,42,8
+    PUSHBUTTON      "&2ï½ž10...",IDC_BUTTON_KEYWORD_SELECT,218,31,75,14
+    PUSHBUTTON      "å…±é€šè¨­å®š(&C)...",IDC_BUTTON_EDITKEYWORD,218,47,75,14
+    GROUPBOX        "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰",IDC_STATIC,156,6,142,60,WS_GROUP
+    LTEXT           "ãƒ–ãƒ­ãƒƒã‚¯åž‹(&F)",IDC_STATIC,164,80,42,8
     EDITTEXT        IDC_EDIT_BLOCKCOMMENT_FROM,211,78,27,12,ES_AUTOHSCROLL
-    LTEXT           "`(&T)",IDC_STATIC,245,80,18,8,NOT WS_GROUP
+    LTEXT           "ï½ž(&T)",IDC_STATIC,245,80,18,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_BLOCKCOMMENT_TO,267,78,26,12,ES_AUTOHSCROLL
-    LTEXT           "ƒuƒƒbƒNŒ^(&A)",IDC_STATIC,164,94,42,8
+    LTEXT           "ãƒ–ãƒ­ãƒƒã‚¯åž‹(&A)",IDC_STATIC,164,94,42,8
     EDITTEXT        IDC_EDIT_BLOCKCOMMENT_FROM2,211,92,27,12,ES_AUTOHSCROLL
-    LTEXT           "`(&Z)",IDC_STATIC,245,94,18,8,NOT WS_GROUP
+    LTEXT           "ï½ž(&Z)",IDC_STATIC,245,94,18,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_BLOCKCOMMENT_TO2,267,92,26,12,ES_AUTOHSCROLL
-    LTEXT           "sŒ^(&M)",IDC_STATIC,164,110,27,8
+    LTEXT           "è¡Œåž‹(&M)",IDC_STATIC,164,110,27,8
     EDITTEXT        IDC_EDIT_LINECOMMENT,195,108,24,12,ES_AUTOHSCROLL
-    CONTROL         "Œ…(&P)",IDC_CHECK_LCPOS,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "æ¡(&P)",IDC_CHECK_LCPOS,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,223,109,33,10
     RTEXT           "&@",IDC_LABEL_LCPOS,256,110,8,8
     EDITTEXT        IDC_EDIT_LINECOMMENTPOS,267,108,26,12,ES_AUTOHSCROLL
     CONTROL         "",IDC_SPIN_LCColNum,"msctls_updown32",UDS_ALIGNRIGHT | 
                     UDS_AUTOBUDDY | UDS_ARROWKEYS,295,108,6,12
-    LTEXT           "sŒ^(&E)",IDC_STATIC,164,124,25,8
+    LTEXT           "è¡Œåž‹(&E)",IDC_STATIC,164,124,25,8
     EDITTEXT        IDC_EDIT_LINECOMMENT2,195,122,24,12,ES_AUTOHSCROLL
-    CONTROL         "Œ…(&O)",IDC_CHECK_LCPOS2,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "æ¡(&O)",IDC_CHECK_LCPOS2,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,223,123,34,10
     RTEXT           "&[",IDC_LABEL_LCPOS2,256,124,8,8
     EDITTEXT        IDC_EDIT_LINECOMMENTPOS2,267,122,26,12,ES_AUTOHSCROLL
     CONTROL         "",IDC_SPIN_LCColNum2,"msctls_updown32",UDS_ALIGNRIGHT | 
                     UDS_AUTOBUDDY | UDS_ARROWKEYS,295,122,6,12
-    LTEXT           "sŒ^(&G)",IDC_STATIC,164,138,26,8
+    LTEXT           "è¡Œåž‹(&G)",IDC_STATIC,164,138,26,8
     EDITTEXT        IDC_EDIT_LINECOMMENT3,195,136,24,12,ES_AUTOHSCROLL
-    CONTROL         "Œ…(&J)",IDC_CHECK_LCPOS3,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "æ¡(&J)",IDC_CHECK_LCPOS3,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,223,137,33,10
     RTEXT           "&]",IDC_LABEL_LCPOS3,256,138,8,8
     EDITTEXT        IDC_EDIT_LINECOMMENTPOS3,267,136,26,12,ES_AUTOHSCROLL
     CONTROL         "",IDC_SPIN_LCColNum3,"msctls_updown32",UDS_ALIGNRIGHT | 
                     UDS_AUTOBUDDY | UDS_ARROWKEYS,295,136,6,12
-    GROUPBOX        "ƒRƒƒ“ƒgƒXƒ^ƒCƒ‹",IDC_STATIC,156,68,142,85,WS_GROUP
-    GROUPBOX        "•¶Žš—ñƒGƒXƒP[ƒv(&Q)",IDC_STATIC,156,168,142,42,WS_GROUP
+    GROUPBOX        "ã‚³ãƒ¡ãƒ³ãƒˆã‚¹ã‚¿ã‚¤ãƒ«",IDC_STATIC,156,68,142,85,WS_GROUP
+    GROUPBOX        "æ–‡å­—åˆ—ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—(&Q)",IDC_STATIC,156,168,142,42,WS_GROUP
     COMBOBOX        IDC_COMBO_STRINGLITERAL,162,180,68,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    CONTROL         "s“à‚Ì‚Ý(&\\)",IDC_CHECK_STRINGLINEONLY,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "è¡Œå†…ã®ã¿(&\\)",IDC_CHECK_STRINGLINEONLY,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,233,180,64,10
-    CONTROL         "I—¹•¶Žš‚ª‚È‚¢ê‡s––‚Ü‚ÅF•ª‚¯(&N)",IDC_CHECK_STRINGENDLINE,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "çµ‚äº†æ–‡å­—ãŒãªã„å ´åˆè¡Œæœ«ã¾ã§è‰²åˆ†ã‘(&N)",IDC_CHECK_STRINGENDLINE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,162,194,133,10
-    LTEXT           "cüŒ…Žw’è(&3)",IDC_STATIC,164,218,46,8
+    LTEXT           "ç¸¦ç·šæ¡æŒ‡å®š(&3)",IDC_STATIC,164,218,46,8
     EDITTEXT        IDC_EDIT_VERTLINE,210,216,74,12,ES_AUTOHSCROLL
-    LTEXT           "*Œ…‚Ü‚½‚ÍStep(Begin,End)‚ÅƒRƒ“ƒ}‹æØ‚è",IDC_STATIC,165,
+    LTEXT           "*æ¡ã¾ãŸã¯Step(Begin,End)ã§ã‚³ãƒ³ãƒžåŒºåˆ‡ã‚Š",IDC_STATIC,165,
                     230,142,8
 END
 
@@ -1150,127 +1150,127 @@ IDD_PROP_SUPPORT DIALOGEX 0, 0, 302, 244
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "’PŒêƒtƒ@ƒCƒ‹(&W)",IDC_STATIC,8,17,53,8,NOT WS_GROUP
+    LTEXT           "å˜èªžãƒ•ã‚¡ã‚¤ãƒ«(&W)",IDC_STATIC,8,17,53,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_HOKANFILE,63,15,150,12,ES_AUTOHSCROLL | 
                     WS_GROUP
     PUSHBUTTON      "(&1)...",IDC_BUTTON_HOKANFILE_REF,215,14,19,14
     COMBOBOX        IDC_COMBO_HOKAN_TYPE,236,15,58,57,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    CONTROL         "‰p‘å•¶Žš¬•¶Žš‚ð“¯ˆêŽ‹(&I)",IDC_CHECK_HOKANLOHICASE,
+    CONTROL         "è‹±å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–(&I)",IDC_CHECK_HOKANLOHICASE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,31,110,10
-    LTEXT           "Œó•âF",IDC_STATIC,122,33,20,8,NOT WS_GROUP
-    CONTROL         "•ÒW’†‚Ìƒtƒ@ƒCƒ‹(&F)",IDC_CHECK_HOKANBYFILE,"Button",
+    LTEXT           "å€™è£œï¼š",IDC_STATIC,122,33,20,8,NOT WS_GROUP
+    CONTROL         "ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«(&F)",IDC_CHECK_HOKANBYFILE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,142,31,75,10
-    CONTROL         "‹­’²ƒL[ƒ[ƒh(&K)",IDC_CHECK_HOKANBYKEYWORD,"Button",
+    CONTROL         "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰(&K)",IDC_CHECK_HOKANBYKEYWORD,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,217,31,75,10
-    GROUPBOX        "“ü—Í•âŠ®‹@”\",IDC_STATIC,3,3,295,45,WS_GROUP
-    GROUPBOX        "ŠO•”ƒwƒ‹ƒv‚ÌÝ’è(&L)",IDC_STATIC,3,55,295,32,WS_GROUP
+    GROUPBOX        "å…¥åŠ›è£œå®Œæ©Ÿèƒ½",IDC_STATIC,3,3,295,45,WS_GROUP
+    GROUPBOX        "å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ã®è¨­å®š(&L)",IDC_STATIC,3,55,295,32,WS_GROUP
     EDITTEXT        IDC_EDIT_TYPEEXTHELP,8,68,264,12,ES_AUTOHSCROLL | 
                     WS_GROUP
     PUSHBUTTON      "(&2)...",IDC_BUTTON_TYPEOPENHELP,275,67,19,14
-    GROUPBOX        "ŠO•”HTMLƒwƒ‹ƒv‚ÌÝ’è(&P)",IDC_STATIC,3,95,295,45,
+    GROUPBOX        "å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—ã®è¨­å®š(&P)",IDC_STATIC,3,95,295,45,
                     WS_GROUP
     EDITTEXT        IDC_EDIT_TYPEEXTHTMLHELP,8,109,264,12,ES_AUTOHSCROLL | 
                     WS_GROUP
     PUSHBUTTON      "(&3)...",IDC_BUTTON_TYPEOPENEXTHTMLHELP,275,107,19,14
-    CONTROL         "ƒrƒ…[ƒA‚ð•¡”‹N“®‚µ‚È‚¢(&N)",
+    CONTROL         "ãƒ“ãƒ¥ãƒ¼ã‚¢ã‚’è¤‡æ•°èµ·å‹•ã—ãªã„(&N)",
                     IDC_CHECK_TYPEHTMLHELPISSINGLE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,125,109,10
-    CONTROL         "•Û‘¶Žž‚É‰üsƒR[ƒh‚Ì¬Ý‚ðŒx‚·‚é(&E)",IDC_CHECK_CHKENTERATEND,
+    CONTROL         "ä¿å­˜æ™‚ã«æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®æ··åœ¨ã‚’è­¦å‘Šã™ã‚‹(&E)",IDC_CHECK_CHKENTERATEND,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,145,146,10
-    CONTROL         "•¶Žš—ñ‚ð–³Ž‹‚·‚é(&S)",IDC_CHECK_INDENTCPPSTR,
+    CONTROL         "æ–‡å­—åˆ—ã‚’ç„¡è¦–ã™ã‚‹(&S)",IDC_CHECK_INDENTCPPSTR,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,171,146,10
-    CONTROL         "ƒRƒƒ“ƒg‚ð–³Ž‹‚·‚é(&C)",IDC_CHECK_INDENTCPPCMT,
+    CONTROL         "ã‚³ãƒ¡ãƒ³ãƒˆã‚’ç„¡è¦–ã™ã‚‹(&C)",IDC_CHECK_INDENTCPPCMT,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,158,171,130,10
-    CONTROL         "Undoƒoƒbƒtƒ@‚ð•ª‚¯‚é(&U)",IDC_CHECK_INDENTCPPUNDO,
+    CONTROL         "Undoãƒãƒƒãƒ•ã‚¡ã‚’åˆ†ã‘ã‚‹(&U)",IDC_CHECK_INDENTCPPUNDO,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,183,146,10
-    GROUPBOX        "C/C++ƒCƒ“ƒfƒ“ƒgÚ×Ý’è",IDC_STATIC,3,159,295,40,WS_GROUP
+    GROUPBOX        "C/C++ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆè©³ç´°è¨­å®š",IDC_STATIC,3,159,295,40,WS_GROUP
 END
 
 IDD_PROP_REGEX DIALOGEX 0, 0, 302, 244
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "³‹K•\Œ»ƒL[ƒ[ƒh‚ðŽg—p‚·‚é(&R)",IDC_CHECK_REGEX,
+    CONTROL         "æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ä½¿ç”¨ã™ã‚‹(&R)",IDC_CHECK_REGEX,
                     "Button",BS_AUTOCHECKBOX | BS_NOTIFY | WS_TABSTOP,5,5,
                     124,10
     RTEXT           "BREGONIG.DLL Version",IDC_LABEL_REGEX_VERSION,89,15,208,
                     10,NOT WS_GROUP,WS_EX_TRANSPARENT
-    GROUPBOX        "³‹K•\Œ»ƒL[ƒ[ƒh(&K)",IDC_FRAME_REGEX,3,24,295,169
+    GROUPBOX        "æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰(&K)",IDC_FRAME_REGEX,3,24,295,169
     CONTROL         "List5",IDC_LIST_REGEX,"SysListView32",LVS_REPORT | 
                     LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOLABELWRAP | 
                     LVS_ALIGNLEFT | LVS_NOSORTHEADER | WS_BORDER | 
                     WS_TABSTOP,8,33,243,118
-    LTEXT           "³‹K•\Œ»(&N)",IDC_LABEL_REGEX_KEYWORD,13,157,41,8,NOT 
+    LTEXT           "æ­£è¦è¡¨ç¾(&N)",IDC_LABEL_REGEX_KEYWORD,13,157,41,8,NOT 
                     WS_GROUP
     EDITTEXT        IDC_EDIT_REGEX,59,155,191,14,ES_AUTOHSCROLL
-    LTEXT           "FŽw’è(&C)",IDC_LABEL_REGEX_COLOR,20,174,34,8,NOT 
+    LTEXT           "è‰²æŒ‡å®š(&C)",IDC_LABEL_REGEX_COLOR,20,174,34,8,NOT 
                     WS_GROUP
     COMBOBOX        IDC_COMBO_REGEX_COLOR,59,172,128,180,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "‘}“ü(&S)",IDC_BUTTON_REGEX_INS,255,118,38,15
-    PUSHBUTTON      "’Ç‰Á(&A)",IDC_BUTTON_REGEX_ADD,255,136,38,15
-    PUSHBUTTON      "XV(&E)",IDC_BUTTON_REGEX_UPD,255,154,38,15
-    PUSHBUTTON      "íœ(&D)",IDC_BUTTON_REGEX_DEL,255,172,38,15
-    PUSHBUTTON      "æ“ª(&T)",IDC_BUTTON_REGEX_TOP,255,33,38,15
-    PUSHBUTTON      "ã‚Ö(&U)",IDC_BUTTON_REGEX_UP,255,51,38,15
-    PUSHBUTTON      "‰º‚Ö(&G)",IDC_BUTTON_REGEX_DOWN,255,69,38,15
-    PUSHBUTTON      "ÅI(&B)",IDC_BUTTON_REGEX_LAST,255,87,38,15
-    PUSHBUTTON      "ƒCƒ“ƒ|[ƒg(&I)...",IDC_BUTTON_REGEX_IMPORT,173,196,60,
+    PUSHBUTTON      "æŒ¿å…¥(&S)",IDC_BUTTON_REGEX_INS,255,118,38,15
+    PUSHBUTTON      "è¿½åŠ (&A)",IDC_BUTTON_REGEX_ADD,255,136,38,15
+    PUSHBUTTON      "æ›´æ–°(&E)",IDC_BUTTON_REGEX_UPD,255,154,38,15
+    PUSHBUTTON      "å‰Šé™¤(&D)",IDC_BUTTON_REGEX_DEL,255,172,38,15
+    PUSHBUTTON      "å…ˆé ­(&T)",IDC_BUTTON_REGEX_TOP,255,33,38,15
+    PUSHBUTTON      "ä¸Šã¸(&U)",IDC_BUTTON_REGEX_UP,255,51,38,15
+    PUSHBUTTON      "ä¸‹ã¸(&G)",IDC_BUTTON_REGEX_DOWN,255,69,38,15
+    PUSHBUTTON      "æœ€çµ‚(&B)",IDC_BUTTON_REGEX_LAST,255,87,38,15
+    PUSHBUTTON      "ã‚¤ãƒ³ãƒãƒ¼ãƒˆ(&I)...",IDC_BUTTON_REGEX_IMPORT,173,196,60,
                     14,WS_GROUP
-    PUSHBUTTON      "ƒGƒNƒXƒ|[ƒg(&X)...",IDC_BUTTON_REGEX_EXPORT,236,196,60,
+    PUSHBUTTON      "ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ(&X)...",IDC_BUTTON_REGEX_EXPORT,236,196,60,
                     14
-    LTEXT           "[FŽw’è]‚ÅuURLv‚ð‘I‘ð‚·‚é‚Æƒ}ƒbƒ`•¶Žš—ñ‚ªƒNƒŠƒbƒJƒuƒ‹‚É‚È‚è‚Ü‚·",
+    LTEXT           "[è‰²æŒ‡å®š]ã§ã€ŒURLã€ã‚’é¸æŠžã™ã‚‹ã¨ãƒžãƒƒãƒæ–‡å­—åˆ—ãŒã‚¯ãƒªãƒƒã‚«ãƒ–ãƒ«ã«ãªã‚Šã¾ã™",
                     IDC_STATIC,14,195,138,18
 END
 
 IDD_PROP_KEYHELP DIALOGEX 0, 0, 302, 244
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "ƒL[ƒ[ƒhƒwƒ‹ƒv‹@”\‚ðŽg‚¤(&K)",IDC_CHECK_KEYHELP,
+    CONTROL         "ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—æ©Ÿèƒ½ã‚’ä½¿ã†(&K)",IDC_CHECK_KEYHELP,
                     "Button",BS_AUTOCHECKBOX | BS_NOTIFY | WS_TABSTOP,5,6,
                     114,10
-    GROUPBOX        "Ž«‘ƒtƒ@ƒCƒ‹ˆê——(&L)",IDC_FRAME_KEYHELP,3,21,295,174
+    GROUPBOX        "è¾žæ›¸ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§(&L)",IDC_FRAME_KEYHELP,3,21,295,174
     CONTROL         "List5",IDC_LIST_KEYHELP,"SysListView32",LVS_REPORT | 
                     LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOLABELWRAP | 
                     LVS_ALIGNLEFT | LVS_NOSORTHEADER | WS_BORDER | 
                     WS_TABSTOP,8,33,238,118
-    LTEXT           "<Ž«‘‚Ìà–¾>",IDC_LABEL_KEYHELP_TITLE,10,159,50,8,NOT 
+    LTEXT           "<è¾žæ›¸ã®èª¬æ˜Ž>",IDC_LABEL_KEYHELP_TITLE,10,159,50,8,NOT 
                     WS_GROUP
-    LTEXT           "Ž«‘ƒtƒ@ƒCƒ‹‚ÌŠT—v",IDC_LABEL_KEYHELP_ABOUT,61,159,185,
+    LTEXT           "è¾žæ›¸ãƒ•ã‚¡ã‚¤ãƒ«ã®æ¦‚è¦",IDC_LABEL_KEYHELP_ABOUT,61,159,185,
                     8,NOT WS_GROUP,WS_EX_TRANSPARENT
-    LTEXT           "Ž«‘ƒtƒ@ƒCƒ‹",IDC_LABEL_KEYHELP_KEYWORD,13,173,41,8,NOT 
+    LTEXT           "è¾žæ›¸ãƒ•ã‚¡ã‚¤ãƒ«",IDC_LABEL_KEYHELP_KEYWORD,13,173,41,8,NOT 
                     WS_GROUP
     EDITTEXT        IDC_EDIT_KEYHELP,61,172,170,12,ES_AUTOHSCROLL
     PUSHBUTTON      "...",IDC_BUTTON_KEYHELP_REF,234,172,12,13,WS_GROUP
-    LTEXT           "ª—Dæ“x(‚)",IDC_LABEL_KEYHELP_PRIOR,249,33,44,8,NOT 
+    LTEXT           "â†‘å„ªå…ˆåº¦(é«˜)",IDC_LABEL_KEYHELP_PRIOR,249,33,44,8,NOT 
                     WS_GROUP
-    PUSHBUTTON      "‘}“ü(&S)",IDC_BUTTON_KEYHELP_INS,251,136,38,15
-    PUSHBUTTON      "XV(&E)",IDC_BUTTON_KEYHELP_UPD,251,154,38,15
-    PUSHBUTTON      "íœ(&D)",IDC_BUTTON_KEYHELP_DEL,251,172,38,15
-    PUSHBUTTON      "æ“ª(&T)",IDC_BUTTON_KEYHELP_TOP,251,44,38,15
-    PUSHBUTTON      "ã‚Ö(&U)",IDC_BUTTON_KEYHELP_UP,251,62,38,15
-    PUSHBUTTON      "‰º‚Ö(&G)",IDC_BUTTON_KEYHELP_DOWN,251,80,38,15
-    PUSHBUTTON      "ÅI(&B)",IDC_BUTTON_KEYHELP_LAST,251,98,38,15
-    PUSHBUTTON      "ƒCƒ“ƒ|[ƒg(&I)...",IDC_BUTTON_KEYHELP_IMPORT,173,199,60,
+    PUSHBUTTON      "æŒ¿å…¥(&S)",IDC_BUTTON_KEYHELP_INS,251,136,38,15
+    PUSHBUTTON      "æ›´æ–°(&E)",IDC_BUTTON_KEYHELP_UPD,251,154,38,15
+    PUSHBUTTON      "å‰Šé™¤(&D)",IDC_BUTTON_KEYHELP_DEL,251,172,38,15
+    PUSHBUTTON      "å…ˆé ­(&T)",IDC_BUTTON_KEYHELP_TOP,251,44,38,15
+    PUSHBUTTON      "ä¸Šã¸(&U)",IDC_BUTTON_KEYHELP_UP,251,62,38,15
+    PUSHBUTTON      "ä¸‹ã¸(&G)",IDC_BUTTON_KEYHELP_DOWN,251,80,38,15
+    PUSHBUTTON      "æœ€çµ‚(&B)",IDC_BUTTON_KEYHELP_LAST,251,98,38,15
+    PUSHBUTTON      "ã‚¤ãƒ³ãƒãƒ¼ãƒˆ(&I)...",IDC_BUTTON_KEYHELP_IMPORT,173,199,60,
                     14,WS_GROUP
-    PUSHBUTTON      "ƒGƒNƒXƒ|[ƒg(&X)...",IDC_BUTTON_KEYHELP_EXPORT,236,199,
+    PUSHBUTTON      "ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ(&X)...",IDC_BUTTON_KEYHELP_EXPORT,236,199,
                     60,14
-    CONTROL         "ƒqƒbƒg‚µ‚½ŽŸ‚ÌŽ«‘‚àŒŸõ(&A)",
+    CONTROL         "ãƒ’ãƒƒãƒˆã—ãŸæ¬¡ã®è¾žæ›¸ã‚‚æ¤œç´¢(&A)",
                     IDC_CHECK_KEYHELP_ALLSEARCH,"Button",BS_AUTOCHECKBOX | 
                     BS_NOTIFY | WS_TABSTOP,7,200,105,10
-    CONTROL         "ƒL[ƒ[ƒh‚à•\Ž¦‚·‚é(&W)",IDC_CHECK_KEYHELP_KEYDISP,
+    CONTROL         "ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚‚è¡¨ç¤ºã™ã‚‹(&W)",IDC_CHECK_KEYHELP_KEYDISP,
                     "Button",BS_AUTOCHECKBOX | BS_NOTIFY | WS_TABSTOP,7,212,
                     95,10
-    CONTROL         "‘I‘ð”ÍˆÍ‚Å‘O•ûˆê’vŒŸõ(&P)",IDC_CHECK_KEYHELP_PREFIX,
+    CONTROL         "é¸æŠžç¯„å›²ã§å‰æ–¹ä¸€è‡´æ¤œç´¢(&P)",IDC_CHECK_KEYHELP_PREFIX,
                     "Button",BS_AUTOCHECKBOX | BS_NOTIFY | WS_TABSTOP,7,224,
                     108,10
-    LTEXT           "‰EƒNƒŠƒbƒNƒƒjƒ…[(&R)",IDC_STATIC_MENU,120,225,70,8,NOT 
+    LTEXT           "å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼(&R)",IDC_STATIC_MENU,120,225,70,8,NOT 
                     WS_GROUP
     COMBOBOX        IDC_COMBO_MENU,192,223,60,180,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
@@ -1278,56 +1278,56 @@ END
 
 IDD_PROP_WINDOW DIALOGEX 0, 0, 302, 244
 STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "“ü—Íƒ‚[ƒh",IDC_STATIC,5,6,40,8
-    LTEXT           "‰üsƒR[ƒh(&E)",IDC_STATIC,8,34,46,8
+    LTEXT           "å…¥åŠ›ãƒ¢ãƒ¼ãƒ‰",IDC_STATIC,5,6,40,8
+    LTEXT           "æ”¹è¡Œã‚³ãƒ¼ãƒ‰(&E)",IDC_STATIC,8,34,46,8
     COMBOBOX        IDC_COMBO_DEFAULT_EOLTYPE,57,32,52,57,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     CONTROL         "&BOM",IDC_CHECK_DEFAULT_BOM,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,114,33,30,10
-    LTEXT           "•¶ŽšƒR[ƒh(&C)",IDC_STATIC,8,49,46,8
+    LTEXT           "æ–‡å­—ã‚³ãƒ¼ãƒ‰(&C)",IDC_STATIC,8,49,46,8
     COMBOBOX        IDC_COMBO_DEFAULT_CODETYPE,57,47,52,57,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     CONTROL         "C&P",IDC_CHECK_CP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,
                     114,48,25,10
-    CONTROL         "Ž©“®”»•ÊŽž‚ÉCESU-8 ‚ð—Dæ‚·‚é(&U)",
+    CONTROL         "è‡ªå‹•åˆ¤åˆ¥æ™‚ã«CESU-8 ã‚’å„ªå…ˆã™ã‚‹(&U)",
                     IDC_CHECK_PRIOR_CESU8,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,63,135,10
-    GROUPBOX        "ƒfƒtƒHƒ‹ƒg‚Ì•¶ŽšƒR[ƒh",IDC_STATIC,3,22,145,58
-    LTEXT           "ON/OFFó‘Ô(&M)",IDC_STATIC,169,34,55,8
+    GROUPBOX        "ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®æ–‡å­—ã‚³ãƒ¼ãƒ‰",IDC_STATIC,3,22,145,58
+    LTEXT           "ON/OFFçŠ¶æ…‹(&M)",IDC_STATIC,169,34,55,8
     COMBOBOX        IDC_COMBO_IMESWITCH,232,32,61,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    LTEXT           "“ü—Íƒ‚[ƒh(&D)",IDC_STATIC,179,49,45,8
+    LTEXT           "å…¥åŠ›ãƒ¢ãƒ¼ãƒ‰(&D)",IDC_STATIC,179,49,45,8
     COMBOBOX        IDC_COMBO_IMESTATE,232,47,61,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    GROUPBOX        "‹N“®Žž‚ÌIME (“ú–{Œê“ü—Í•ÏŠ·)",IDC_STATIC,153,22,145,58
+    GROUPBOX        "èµ·å‹•æ™‚ã®IME (æ—¥æœ¬èªžå…¥åŠ›å¤‰æ›)",IDC_STATIC,153,22,145,58
     CONTROL         "",IDC_STATIC,"Static",SS_ETCHEDFRAME,5,88,293,1
-    LTEXT           "ƒEƒBƒ“ƒhƒE",IDC_STATIC,5,96,36,8
-    CONTROL         "•¶‘ƒAƒCƒRƒ“‚ðŽg‚¤(&O)",IDC_CHECK_DOCICON,"Button",
+    LTEXT           "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦",IDC_STATIC,5,96,36,8
+    CONTROL         "æ–‡æ›¸ã‚¢ã‚¤ã‚³ãƒ³ã‚’ä½¿ã†(&O)",IDC_CHECK_DOCICON,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,8,107,86,10
-    CONTROL         "Ü‚è•Ô‚µ’PˆÊ(&R)",IDC_RADIO_LINENUM_LAYOUT,"Button",
+    CONTROL         "æŠ˜ã‚Šè¿”ã—å˜ä½(&R)",IDC_RADIO_LINENUM_LAYOUT,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP,8,134,60,10
-    CONTROL         "‰üs’PˆÊ(&W)",IDC_RADIO_LINENUM_CRLF,"Button",
+    CONTROL         "æ”¹è¡Œå˜ä½(&W)",IDC_RADIO_LINENUM_CRLF,"Button",
                     BS_AUTORADIOBUTTON,8,149,60,10
-    LTEXT           "Œ…”",IDC_STATIC,18,165,16,8
+    LTEXT           "æ¡æ•°",IDC_STATIC,18,165,16,8
     EDITTEXT        IDC_EDIT_LINENUMWIDTH,41,163,31,12,ES_AUTOHSCROLL
     CONTROL         "Spin3",IDC_SPIN_LINENUMWIDTH,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_ARROWKEYS | UDS_AUTOBUDDY,61,163,9,12
-    GROUPBOX        "s”Ô†‚Ì•\Ž¦",IDC_STATIC,4,122,70,59,WS_GROUP
-    CONTROL         "‚È‚µ(&N)",IDC_RADIO_LINETERMTYPE0,"Button",
+    GROUPBOX        "è¡Œç•ªå·ã®è¡¨ç¤º",IDC_STATIC,4,122,70,59,WS_GROUP
+    CONTROL         "ãªã—(&N)",IDC_RADIO_LINETERMTYPE0,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP,83,134,39,10
-    CONTROL         "cü(&V)",IDC_RADIO_LINETERMTYPE1,"Button",
+    CONTROL         "ç¸¦ç·š(&V)",IDC_RADIO_LINETERMTYPE1,"Button",
                     BS_AUTORADIOBUTTON,83,149,41,10
-    CONTROL         "”CˆÓ(&Y)",IDC_RADIO_LINETERMTYPE2,"Button",
+    CONTROL         "ä»»æ„(&Y)",IDC_RADIO_LINETERMTYPE2,"Button",
                     BS_AUTORADIOBUTTON,83,164,41,10
-    LTEXT           "”¼Šp(&S)",IDC_LABEL_LINETERMCHAR,93,178,26,8
+    LTEXT           "åŠè§’(&S)",IDC_LABEL_LINETERMCHAR,93,178,26,8
     EDITTEXT        IDC_EDIT_LINETERMCHAR,124,177,15,12,ES_AUTOHSCROLL
-    GROUPBOX        "s”Ô†‹æØ‚è",IDC_STATIC,78,122,70,80
+    GROUPBOX        "è¡Œç•ªå·åŒºåˆ‡ã‚Š",IDC_STATIC,78,122,70,80
 
     EDITTEXT        IDC_EDIT_BACKIMG_PATH,158,134,122,12,ES_AUTOHSCROLL
     PUSHBUTTON      "...",IDC_BUTTON_BACKIMG_PATH_SEL,282,134,12,12
-    LTEXT           "•\Ž¦ˆÊ’u",IDC_STATIC,158,150,40,8
+    LTEXT           "è¡¨ç¤ºä½ç½®",IDC_STATIC,158,150,40,8
     COMBOBOX        IDC_COMBO_BACKIMG_POS,158,163,39,180,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     LTEXT           "X",IDC_STATIC,200,165,8,8
@@ -1345,45 +1345,45 @@ BEGIN
                     WS_TABSTOP,276,164,10,10
     CONTROL         "",IDC_CHECK_BACKIMG_SCR_Y,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,276,179,10,10
-    GROUPBOX        "”wŒi‰æ‘œ",IDC_STATIC,153,122,145,80
+    GROUPBOX        "èƒŒæ™¯ç”»åƒ",IDC_STATIC,153,122,145,80
 END
 
 IDD_DIALOG_KEYWORD_SELECT DIALOGEX 0, 0, 177, 197
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "‹­’²ƒL[ƒ[ƒh‚ÌÝ’è"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®è¨­å®š"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     DEFPUSHBUTTON   "&OK",IDOK,31,176,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,91,176,50,14
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&1",IDC_STATIC,7,15,54,13
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,91,176,50,14
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&1",IDC_STATIC,7,15,54,13
     COMBOBOX        IDC_COMBO1,68,13,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&2",IDC_STATIC,7,31,54,13
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&2",IDC_STATIC,7,31,54,13
     COMBOBOX        IDC_COMBO2,68,29,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&3",IDC_STATIC,7,48,54,13
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&3",IDC_STATIC,7,48,54,13
     COMBOBOX        IDC_COMBO3,68,45,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&4",IDC_STATIC,7,63,54,13
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&4",IDC_STATIC,7,63,54,13
     COMBOBOX        IDC_COMBO4,68,61,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&5",IDC_STATIC,7,80,54,13
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&5",IDC_STATIC,7,80,54,13
     COMBOBOX        IDC_COMBO5,68,77,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&6",IDC_STATIC,7,95,54,13
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&6",IDC_STATIC,7,95,54,13
     COMBOBOX        IDC_COMBO6,68,93,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&7",IDC_STATIC,7,111,54,13
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&7",IDC_STATIC,7,111,54,13
     COMBOBOX        IDC_COMBO7,68,109,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&8",IDC_STATIC,7,126,54,13
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&8",IDC_STATIC,7,126,54,13
     COMBOBOX        IDC_COMBO8,68,125,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹­’²ƒL[ƒ[ƒh&9",IDC_STATIC,7,143,54,13
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰&9",IDC_STATIC,7,143,54,13
     COMBOBOX        IDC_COMBO9,68,141,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹­’²ƒL[ƒ[ƒh1&0",IDC_STATIC,7,159,58,8
+    LTEXT           "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰1&0",IDC_STATIC,7,159,58,8
     COMBOBOX        IDC_COMBO10,68,157,104,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
 END
@@ -1391,102 +1391,102 @@ END
 IDD_SAMECOLOR DIALOGEX 0, 0, 183, 206
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "•¶ŽšF“ˆê"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "æ–‡å­—è‰²çµ±ä¸€"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "“ˆêF",IDC_STATIC,7,13,24,8
+    LTEXT           "çµ±ä¸€è‰²",IDC_STATIC,7,13,24,8
     LTEXT           "Static",IDC_STATIC_COLOR,35,10,86,14,SS_CENTERIMAGE
-    LTEXT           "•ÏX‘ÎÛ‚ÌF(&C)‚ð‘I‚ñ‚Åƒ`ƒFƒbƒNó‘Ô‚É‚µ‚Ä‚­‚¾‚³‚¢",
+    LTEXT           "å¤‰æ›´å¯¾è±¡ã®è‰²(&C)ã‚’é¸ã‚“ã§ãƒã‚§ãƒƒã‚¯çŠ¶æ…‹ã«ã—ã¦ãã ã•ã„",
                     IDC_STATIC,7,29,166,8
     LISTBOX         IDC_LIST_COLORS,7,41,114,90,LBS_OWNERDRAWFIXED | 
                     LBS_HASSTRINGS | WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "‘Sƒ`ƒFƒbƒN(&A)",IDC_BUTTON_SELALL,125,70,49,14
-    PUSHBUTTON      "‘S‰ðœ(&N)",IDC_BUTTON_SELNOTING,125,89,49,14
+    PUSHBUTTON      "å…¨ãƒã‚§ãƒƒã‚¯(&A)",IDC_BUTTON_SELALL,125,70,49,14
+    PUSHBUTTON      "å…¨è§£é™¤(&N)",IDC_BUTTON_SELNOTING,125,89,49,14
     LISTBOX         IDC_LIST_ITEMINFO,7,143,114,35,LBS_NOINTEGRALHEIGHT | 
                     WS_VSCROLL | WS_HSCROLL
     DEFPUSHBUTTON   "&OK",IDOK,15,185,49,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,67,185,49,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,119,185,49,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,67,185,49,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,119,185,49,14
 END
 
 IDD_PROP_GENERAL DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    GROUPBOX        "ƒJ[ƒ\ƒ‹",IDC_STATIC,3,3,149,84
-    CONTROL         "ƒtƒŠ[ƒJ[ƒ\ƒ‹(&F)",IDC_CHECK_FREECARET,"Button",
+    GROUPBOX        "ã‚«ãƒ¼ã‚½ãƒ«",IDC_STATIC,3,3,149,84
+    CONTROL         "ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«(&F)",IDC_CHECK_FREECARET,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,8,14,120,10
-    CONTROL         "’PŒê’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚É\n’PŒê‚Ì—¼’[‚ÉŽ~‚Ü‚é(&B)",
+    CONTROL         "å˜èªžå˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«\nå˜èªžã®ä¸¡ç«¯ã«æ­¢ã¾ã‚‹(&B)",
                     IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_WORD,"Button",
                     BS_AUTOCHECKBOX | BS_TOP | BS_MULTILINE | WS_TABSTOP,8,
                     26,120,19
-    CONTROL         "’i—Ž’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚É\n’i—Ž‚Ì—¼’[‚ÉŽ~‚Ü‚é(&P)",
+    CONTROL         "æ®µè½å˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«\næ®µè½ã®ä¸¡ç«¯ã«æ­¢ã¾ã‚‹(&P)",
                     IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_PARAGRAPH,"Button",
                     BS_AUTOCHECKBOX | BS_TOP | BS_MULTILINE | WS_TABSTOP,8,
                     46,120,19
-    CONTROL         "ƒ}ƒEƒXƒNƒŠƒbƒN‚Å‚ÌƒAƒNƒeƒBƒu‰»‚Å‚Í\nƒJ[ƒ\ƒ‹‚ðˆÚ“®‚µ‚È‚¢(&O)",
+    CONTROL         "ãƒžã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯ã§ã®ã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–ã§ã¯\nã‚«ãƒ¼ã‚½ãƒ«ã‚’ç§»å‹•ã—ãªã„(&O)",
                     IDC_CHECK_NOMOVE_ACTIVATE_BY_MOUSE,"Button",
                     BS_AUTOCHECKBOX | BS_TOP | BS_MULTILINE | WS_TABSTOP,8,
                     66,133,19
-    GROUPBOX        "ƒJ[ƒ\ƒ‹Œ`ó",IDC_STATIC,3,89,149,24,WS_GROUP
-    CONTROL         "&Windows•—",IDC_RADIO_CARETTYPE0,"Button",
+    GROUPBOX        "ã‚«ãƒ¼ã‚½ãƒ«å½¢çŠ¶",IDC_STATIC,3,89,149,24,WS_GROUP
+    CONTROL         "&Windowsé¢¨",IDC_RADIO_CARETTYPE0,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,8,99,61,10
-    CONTROL         "MS-&DOS•—",IDC_RADIO_CARETTYPE1,"Button",
+    CONTROL         "MS-&DOSé¢¨",IDC_RADIO_CARETTYPE1,"Button",
                     BS_AUTORADIOBUTTON,69,99,61,10
-    GROUPBOX        "ƒ^ƒXƒNƒgƒŒƒC",IDC_STATIC,3,115,149,71,WS_GROUP
-    CONTROL         "ƒ^ƒXƒNƒgƒŒƒC‚ðŽg‚¤(&T)",IDC_CHECK_USETRAYICON,"Button",
+    GROUPBOX        "ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤",IDC_STATIC,3,115,149,71,WS_GROUP
+    CONTROL         "ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã‚’ä½¿ã†(&T)",IDC_CHECK_USETRAYICON,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,8,127,81,10
-    CONTROL         "ƒ^ƒXƒNƒgƒŒƒC‚Éí’“(&R)",IDC_CHECK_STAYTASKTRAY,"Button",
+    CONTROL         "ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã«å¸¸é§(&R)",IDC_CHECK_STAYTASKTRAY,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,8,141,104,10
-    LTEXT           "¶ƒNƒŠƒbƒNƒƒjƒ…[‚ÌƒVƒ‡[ƒgƒJƒbƒgƒL[(&K)",IDC_STATIC,
+    LTEXT           "å·¦ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®ã‚·ãƒ§ãƒ¼ãƒˆã‚«ãƒƒãƒˆã‚­ãƒ¼(&K)",IDC_STATIC,
                     8,157,131,8
     CONTROL         "HotKey1",IDC_HOTKEY_TRAYMENU,"msctls_hotkey32",
                     WS_BORDER | WS_TABSTOP,8,167,95,12
-    CONTROL         "“¯Žž‚É•¡”‚Ì•ÒW—pƒEƒBƒ“ƒhƒE‚ð\n•Â‚¶‚é‚Æ‚«Šm”F(&U)",
+    CONTROL         "åŒæ™‚ã«è¤‡æ•°ã®ç·¨é›†ç”¨ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’\né–‰ã˜ã‚‹ã¨ãç¢ºèª(&U)",
                     IDC_CHECK_CLOSEALLCONFIRM,"Button",BS_AUTOCHECKBOX | 
                     BS_TOP | BS_MULTILINE | WS_GROUP | WS_TABSTOP,8,193,124,
                     19
-    CONTROL         "ƒTƒNƒ‰ƒGƒfƒBƒ^‚Ì‘SI—¹‚Å•ÒW—p\nƒEƒBƒ“ƒhƒE‚ð•Â‚¶‚é‚Æ‚«Šm”F(&V)",
+    CONTROL         "ã‚µã‚¯ãƒ©ã‚¨ãƒ‡ã‚£ã‚¿ã®å…¨çµ‚äº†ã§ç·¨é›†ç”¨\nã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹ã¨ãç¢ºèª(&V)",
                     IDC_CHECK_EXITCONFIRM,"Button",BS_AUTOCHECKBOX | BS_TOP | 
                     BS_MULTILINE | WS_GROUP | WS_TABSTOP,8,212,124,19
-    GROUPBOX        "ƒXƒNƒ[ƒ‹",IDC_STATIC,158,3,130,125,WS_GROUP
-    LTEXT           "s”(&N)",IDC_STATIC,163,19,29,8,NOT WS_GROUP
+    GROUPBOX        "ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«",IDC_STATIC,158,3,130,125,WS_GROUP
+    LTEXT           "è¡Œæ•°(&N)",IDC_STATIC,163,19,29,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_REPEATEDSCROLLLINENUM,196,17,40,12,
                     ES_AUTOHSCROLL | WS_GROUP
     CONTROL         "Spin3",IDC_SPIN_REPEATEDSCROLLLINENUM,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,236,17,9,
                     12
-    CONTROL         "­‚µŠŠ‚ç‚©‚É‚·‚é(&S)",IDC_CHECK_REPEATEDSCROLLSMOOTH,
+    CONTROL         "å°‘ã—æ»‘ã‚‰ã‹ã«ã™ã‚‹(&S)",IDC_CHECK_REPEATEDSCROLLSMOOTH,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,163,33,80,10
-    LTEXT           "‘g‚Ý‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½Žž\nƒy[ƒWƒXƒNƒ[ƒ‹‚·‚é(&J)",
+    LTEXT           "çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚\nãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹(&J)",
                     IDC_STATIC,163,49,110,16,NOT WS_GROUP
     COMBOBOX        IDC_COMBO_WHEEL_PAGESCROLL,178,67,85,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    LTEXT           "‘g‚Ý‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½Žž\n‰¡ƒXƒNƒ[ƒ‹‚·‚é(&H)",
+    LTEXT           "çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚\næ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹(&H)",
                     IDC_STATIC,163,88,111,16,NOT WS_GROUP
     COMBOBOX        IDC_COMBO_WHEEL_HSCROLL,178,108,85,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    CONTROL         "‰æ–ÊƒLƒƒƒbƒVƒ…‚ðŽg‚¤(&G)",IDC_CHECK_MEMDC,"Button",
+    CONTROL         "ç”»é¢ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’ä½¿ã†(&G)",IDC_CHECK_MEMDC,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,163,134,96,16
-    GROUPBOX        "—š—ð",IDC_STATIC,158,152,130,82,WS_GROUP
-    LTEXT           "ƒtƒ@ƒCƒ‹‚Ì—š—ð&MAX",IDC_STATIC,163,167,74,8,NOT 
+    GROUPBOX        "å±¥æ­´",IDC_STATIC,158,152,130,82,WS_GROUP
+    LTEXT           "ãƒ•ã‚¡ã‚¤ãƒ«ã®å±¥æ­´&MAX",IDC_STATIC,163,167,74,8,NOT 
                     WS_GROUP
     EDITTEXT        IDC_EDIT_MAX_MRU_FILE,168,178,28,12,ES_AUTOHSCROLL | 
                     WS_GROUP
     CONTROL         "Spin1",IDC_SPIN_MAX_MRU_FILE,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,196,178,9,
                     12
-    PUSHBUTTON      "—š—ð‚ðƒNƒŠƒA(&C)...",IDC_BUTTON_CLEAR_MRU_FILE,208,177,
+    PUSHBUTTON      "å±¥æ­´ã‚’ã‚¯ãƒªã‚¢(&C)...",IDC_BUTTON_CLEAR_MRU_FILE,208,177,
                     61,14
-    LTEXT           "ƒtƒHƒ‹ƒ_‚Ì—š—ðMA&X",IDC_STATIC,163,200,74,8
+    LTEXT           "ãƒ•ã‚©ãƒ«ãƒ€ã®å±¥æ­´MA&X",IDC_STATIC,163,200,74,8
     EDITTEXT        IDC_EDIT_MAX_MRU_FOLDER,168,211,28,12,ES_AUTOHSCROLL | 
                     WS_GROUP
     CONTROL         "Spin1",IDC_SPIN_MAX_MRU_FOLDER,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,196,211,9,
                     12
-    PUSHBUTTON      "—š—ð‚ðƒNƒŠƒA(&L)...",IDC_BUTTON_CLEAR_MRU_FOLDER,208,
+    PUSHBUTTON      "å±¥æ­´ã‚’ã‚¯ãƒªã‚¢(&L)...",IDC_BUTTON_CLEAR_MRU_FOLDER,208,
                     210,61,14
 END
 
@@ -1494,68 +1494,68 @@ IDD_PROP_WIN DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "ƒc[ƒ‹ƒo[•\Ž¦(&T)",IDC_CHECK_DispTOOLBAR,"Button",
+    CONTROL         "ãƒ„ãƒ¼ãƒ«ãƒãƒ¼è¡¨ç¤º(&T)",IDC_CHECK_DispTOOLBAR,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,7,13,76,10
-    CONTROL         "ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\Ž¦(&K)",IDC_CHECK_DispFUNCKEYWND,
+    CONTROL         "ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤º(&K)",IDC_CHECK_DispFUNCKEYWND,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,25,96,10
-    CONTROL         "ƒXƒe[ƒ^ƒXƒo[•\Ž¦(&S)",IDC_CHECK_DispSTATUSBAR,"Button",
+    CONTROL         "ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼è¡¨ç¤º(&S)",IDC_CHECK_DispSTATUSBAR,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,7,37,88,10
-    CONTROL         "…•½ƒXƒNƒ[ƒ‹ƒo[(&R)",IDC_CHECK_bScrollBarHorz,"Button",
+    CONTROL         "æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼(&R)",IDC_CHECK_bScrollBarHorz,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,104,13,89,10
-    CONTROL         "ƒAƒCƒRƒ“•t‚«ƒƒjƒ…[(&I)",IDC_CHECK_bMenuIcon,"Button",
+    CONTROL         "ã‚¢ã‚¤ã‚³ãƒ³ä»˜ããƒ¡ãƒ‹ãƒ¥ãƒ¼(&I)",IDC_CHECK_bMenuIcon,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,195,13,87,10
-    PUSHBUTTON      "ˆÊ’u‚Æ‘å‚«‚³‚ÌÝ’è(&W)...",IDC_BUTTON_WINSIZE,202,33,83,
+    PUSHBUTTON      "ä½ç½®ã¨å¤§ãã•ã®è¨­å®š(&W)...",IDC_BUTTON_WINSIZE,202,33,83,
                     14
-    LTEXT           "ƒ^ƒuƒo[•\Ž¦‚Í\n[ƒ^ƒuƒo[]ƒ^ƒu‚É‚ ‚è‚Ü‚·",IDC_STATIC,
+    LTEXT           "ã‚¿ãƒ–ãƒãƒ¼è¡¨ç¤ºã¯\n[ã‚¿ãƒ–ãƒãƒ¼]ã‚¿ãƒ–ã«ã‚ã‚Šã¾ã™",IDC_STATIC,
                     111,30,83,17
-    GROUPBOX        "Šî–{Ý’è",IDC_STATIC,3,3,285,49,WS_GROUP
-    LTEXT           "ƒ‹[ƒ‰[‚Ì‚‚³(&E)",IDC_STATIC,7,68,58,8
+    GROUPBOX        "åŸºæœ¬è¨­å®š",IDC_STATIC,3,3,285,49,WS_GROUP
+    LTEXT           "ãƒ«ãƒ¼ãƒ©ãƒ¼ã®é«˜ã•(&E)",IDC_STATIC,7,68,58,8
     EDITTEXT        IDC_EDIT_nRulerHeight,101,66,28,12,ES_AUTOHSCROLL
     CONTROL         "Spin1",IDC_SPIN_nRulerHeight,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,124,66,10,
                     12
-    LTEXT           "ƒhƒbƒg",IDC_STATIC,133,68,17,8
-    LTEXT           "ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ(&P)",IDC_STATIC,7,81,91,8
+    LTEXT           "ãƒ‰ãƒƒãƒˆ",IDC_STATIC,133,68,17,8
+    LTEXT           "ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“(&P)",IDC_STATIC,7,81,91,8
     EDITTEXT        IDC_EDIT_nRulerBottomSpace,101,80,28,12,ES_AUTOHSCROLL
     CONTROL         "Spin1",IDC_SPIN_nRulerBottomSpace,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,124,79,10,
                     12
-    LTEXT           "ƒhƒbƒg",IDC_STATIC,133,81,17,8
-    LTEXT           "s”Ô†‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ(&L)",IDC_STATIC,7,96,86,8
+    LTEXT           "ãƒ‰ãƒƒãƒˆ",IDC_STATIC,133,81,17,8
+    LTEXT           "è¡Œç•ªå·ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“(&L)",IDC_STATIC,7,96,86,8
     EDITTEXT        IDC_EDIT_nLineNumberRightSpace,101,94,28,12,
                     ES_AUTOHSCROLL
     CONTROL         "Spin1",IDC_SPIN_nLineNumberRightSpace,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,124,94,10,
                     12
-    LTEXT           "ƒhƒbƒg",IDC_STATIC,133,96,17,8
-    GROUPBOX        "ƒ‹[ƒ‰[ / s”Ô†",IDC_STATIC,3,56,153,54
-    CONTROL         "‚’¼ƒXƒNƒ[ƒ‹‚Ì“¯Šú‚ð‚Æ‚é(&V)",
+    LTEXT           "ãƒ‰ãƒƒãƒˆ",IDC_STATIC,133,96,17,8
+    GROUPBOX        "ãƒ«ãƒ¼ãƒ©ãƒ¼ / è¡Œç•ªå·",IDC_STATIC,3,56,153,54
+    CONTROL         "åž‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸã‚’ã¨ã‚‹(&V)",
                     IDC_CHECK_SplitterWndVScroll,"Button",BS_AUTOCHECKBOX | 
                     WS_GROUP | WS_TABSTOP,8,126,115,10
-    CONTROL         "…•½ƒXƒNƒ[ƒ‹‚Ì“¯Šú‚ð‚Æ‚é(&H)",
+    CONTROL         "æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸã‚’ã¨ã‚‹(&H)",
                     IDC_CHECK_SplitterWndHScroll,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,139,116,10
-    GROUPBOX        "•ªŠ„ƒEƒBƒ“ƒhƒE",IDC_STATIC,3,114,153,39,WS_GROUP
-    LTEXT           "ˆÊ’u",IDC_STATIC,167,68,16,8
-    CONTROL         "ã(&O)",IDC_RADIO_FUNCKEYWND_PLACE1,"Button",
+    GROUPBOX        "åˆ†å‰²ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦",IDC_STATIC,3,114,153,39,WS_GROUP
+    LTEXT           "ä½ç½®",IDC_STATIC,167,68,16,8
+    CONTROL         "ä¸Š(&O)",IDC_RADIO_FUNCKEYWND_PLACE1,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,191,68,34,10
-    CONTROL         "‰º(&B)",IDC_RADIO_FUNCKEYWND_PLACE2,"Button",
+    CONTROL         "ä¸‹(&B)",IDC_RADIO_FUNCKEYWND_PLACE2,"Button",
                     BS_AUTORADIOBUTTON,227,68,34,10
-    LTEXT           "ƒOƒ‹[ƒvƒ{ƒ^ƒ“”(&G)",IDC_STATIC,167,81,67,10
+    LTEXT           "ã‚°ãƒ«ãƒ¼ãƒ—ãƒœã‚¿ãƒ³æ•°(&G)",IDC_STATIC,167,81,67,10
     EDITTEXT        IDC_EDIT_FUNCKEYWND_GROUPNUM,236,80,28,12,ES_AUTOHSCROLL | 
                     ES_NUMBER
     CONTROL         "Spin1",IDC_SPIN_FUNCKEYWND_GROUPNUM,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,262,80,10,
                     12
-    GROUPBOX        "ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[",IDC_STATIC,162,56,126,40
-    LTEXT           "ƒAƒNƒeƒBƒuŽž(&1)",IDC_STATIC,7,171,59,8
+    GROUPBOX        "ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼",IDC_STATIC,162,56,126,40
+    LTEXT           "ã‚¢ã‚¯ãƒ†ã‚£ãƒ–æ™‚(&1)",IDC_STATIC,7,171,59,8
     EDITTEXT        IDC_WINCAPTION_ACTIVE,67,168,216,14,ES_AUTOHSCROLL
-    LTEXT           "”ñƒAƒNƒeƒBƒuŽž(&2)",IDC_STATIC,7,188,58,8
+    LTEXT           "éžã‚¢ã‚¯ãƒ†ã‚£ãƒ–æ™‚(&2)",IDC_STATIC,7,188,58,8
     EDITTEXT        IDC_WINCAPTION_INACTIVE,67,185,216,14,ES_AUTOHSCROLL
-    GROUPBOX        "ƒ^ƒCƒgƒ‹ƒo[",IDC_STATIC,3,157,285,47
-    GROUPBOX        "Œ¾Œê",IDC_STATIC,162,100,126,40
+    GROUPBOX        "ã‚¿ã‚¤ãƒˆãƒ«ãƒãƒ¼",IDC_STATIC,3,157,285,47
+    GROUPBOX        "è¨€èªž",IDC_STATIC,162,100,126,40
     COMBOBOX        IDC_COMBO_LANGUAGE,178,118,105,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
 END
@@ -1563,102 +1563,102 @@ END
 IDD_PROP_TOOLBAR DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    RTEXT           "Ží•Ê(&K)",IDC_LABEL_MENUFUNCKIND,4,4,51,8
+    RTEXT           "ç¨®åˆ¥(&K)",IDC_LABEL_MENUFUNCKIND,4,4,51,8
     COMBOBOX        IDC_COMBO_FUNCKIND,56,2,70,170,CBS_DROPDOWNLIST | 
                     CBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "‹@”\(&F)",IDC_LABEL_MENUFUNC,3,15,40,8
+    LTEXT           "æ©Ÿèƒ½(&F)",IDC_LABEL_MENUFUNC,3,15,40,8
     LISTBOX         IDC_LIST_FUNC,3,25,123,199,LBS_OWNERDRAWFIXED | 
                     LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_HSCROLL | 
                     WS_TABSTOP
-    CONTROL         "ƒtƒ‰ƒbƒg‚Èƒ{ƒ^ƒ“(&L)",IDC_CHECK_TOOLBARISFLAT,"Button",
+    CONTROL         "ãƒ•ãƒ©ãƒƒãƒˆãªãƒœã‚¿ãƒ³(&L)",IDC_CHECK_TOOLBARISFLAT,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,202,2,73,10
-    LTEXT           "ƒc[ƒ‹ƒo[(&T)",IDC_LABEL_TOOLBAR,164,15,46,8
+    LTEXT           "ãƒ„ãƒ¼ãƒ«ãƒãƒ¼(&T)",IDC_LABEL_TOOLBAR,164,15,46,8
     LISTBOX         IDC_LIST_RES,164,25,123,199,LBS_OWNERDRAWFIXED | 
                     LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_HSCROLL | 
                     WS_TABSTOP
-    PUSHBUTTON      "íœ(&D)",IDC_BUTTON_DELETE,129,32,33,14,WS_GROUP
+    PUSHBUTTON      "å‰Šé™¤(&D)",IDC_BUTTON_DELETE,129,32,33,14,WS_GROUP
     PUSHBUTTON      "---(&S)",IDC_BUTTON_INSERTSEPARATOR,129,51,33,14
-    PUSHBUTTON      "¨(&A)",IDC_BUTTON_INSERT,129,71,33,14
+    PUSHBUTTON      "â†’(&A)",IDC_BUTTON_INSERT,129,71,33,14
     PUSHBUTTON      ">>(&B)",IDC_BUTTON_ADD,129,85,33,14
-    PUSHBUTTON      "ª(&U)",IDC_BUTTON_UP,129,105,33,14
-    PUSHBUTTON      "«(&O)",IDC_BUTTON_DOWN,129,119,33,14
-    PUSHBUTTON      "Ü•Ô(&W)",IDC_BUTTON_INSERTWRAP,129,151,33,14
+    PUSHBUTTON      "â†‘(&U)",IDC_BUTTON_UP,129,105,33,14
+    PUSHBUTTON      "â†“(&O)",IDC_BUTTON_DOWN,129,119,33,14
+    PUSHBUTTON      "æŠ˜è¿”(&W)",IDC_BUTTON_INSERTWRAP,129,151,33,14
 END
 
 IDD_PROP_TAB DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "ƒ^ƒuƒo[‚ð•\Ž¦‚·‚é(&D)",IDC_CHECK_DispTabWnd,"Button",
+    CONTROL         "ã‚¿ãƒ–ãƒãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹(&D)",IDC_CHECK_DispTabWnd,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,7,11,111,10
-    CONTROL         "ƒEƒBƒ“ƒhƒE‚ð‚Ü‚Æ‚ß‚ÄƒOƒ‹[ƒv‰»‚·‚é(&B)",
+    CONTROL         "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã¾ã¨ã‚ã¦ã‚°ãƒ«ãƒ¼ãƒ—åŒ–ã™ã‚‹(&B)",
                     IDC_CHECK_DispTabWndMultiWin,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,15,40,239,10
-    CONTROL         "ÅŒã‚Ìƒtƒ@ƒCƒ‹‚ð•Â‚¶‚½‚Æ‚«(–³‘è)•¶‘‚ðŽc‚·(&R)",
+    CONTROL         "æœ€å¾Œã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‰ã˜ãŸã¨ã(ç„¡é¡Œ)æ–‡æ›¸ã‚’æ®‹ã™(&R)",
                     IDC_CHECK_RetainEmptyWindow,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,24,53,226,10
-    CONTROL         "ƒEƒBƒ“ƒhƒE‚Ì•Â‚¶‚éƒ{ƒ^ƒ“‚ÍŒ»Ý‚Ìƒtƒ@ƒCƒ‹‚Ì‚Ý•Â‚¶‚é(&C)",
+    CONTROL         "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³ã¯ç¾åœ¨ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ã¿é–‰ã˜ã‚‹(&C)",
                     IDC_CHECK_CloseOneWin,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,24,66,226,10
-    CONTROL         "ŠO•”‚©‚ç‹N“®‚·‚é‚Æ‚«‚ÍV‚µ‚¢ƒEƒCƒ“ƒhƒE‚ÅŠJ‚­(&O)",
+    CONTROL         "å¤–éƒ¨ã‹ã‚‰èµ·å‹•ã™ã‚‹ã¨ãã¯æ–°ã—ã„ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã§é–‹ã(&O)",
                     IDC_CHECK_OpenNewWin,"Button",BS_AUTOCHECKBOX |
                     WS_TABSTOP,24,79,170,10
-    GROUPBOX        "“®ìƒ‚[ƒh",IDC_STATIC,7,27,280,68
-    CONTROL         "ƒAƒCƒRƒ“•\Ž¦(&I)",IDC_CHECK_DispTabIcon,"Button",
+    GROUPBOX        "å‹•ä½œãƒ¢ãƒ¼ãƒ‰",IDC_STATIC,7,27,280,68
+    CONTROL         "ã‚¢ã‚¤ã‚³ãƒ³è¡¨ç¤º(&I)",IDC_CHECK_DispTabIcon,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,15,115,63,10
-    CONTROL         "“™•(&E)",IDC_CHECK_SameTabWidth,"Button",
+    CONTROL         "ç­‰å¹…(&E)",IDC_CHECK_SameTabWidth,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,80,115,39,10
-    LTEXT           "•Â‚¶‚éƒ{ƒ^ƒ“(&X)",IDC_TextTabClose,124,116,48,8
+    LTEXT           "é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³(&X)",IDC_TextTabClose,124,116,48,8
     COMBOBOX        IDC_CHECK_DispTabClose,173,113,46,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "ƒtƒHƒ“ƒg(&F)...",IDC_BUTTON_TABFONT,232,113,51,14
+    PUSHBUTTON      "ãƒ•ã‚©ãƒ³ãƒˆ(&F)...",IDC_BUTTON_TABFONT,232,113,51,14
     RTEXT           "Font", IDC_STATIC_TABFONT,102,127,180,17,SS_RIGHT
-    CONTROL         "ƒ^ƒuˆê——‚ðƒ\[ƒg‚·‚é(&S)",IDC_CHECK_SortTabList,"Button",
+    CONTROL         "ã‚¿ãƒ–ä¸€è¦§ã‚’ã‚½ãƒ¼ãƒˆã™ã‚‹(&S)",IDC_CHECK_SortTabList,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,15,129,85,10
-    CONTROL         "‘½’i(&M)",IDC_CHECK_TAB_MULTILINE,"Button",
+    CONTROL         "å¤šæ®µ(&M)",IDC_CHECK_TAB_MULTILINE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,15,141,60,10
-    RTEXT           "•\Ž¦ˆÊ’u(&P)",IDC_TAB_POSITION,80,143,40,8
+    RTEXT           "è¡¨ç¤ºä½ç½®(&P)",IDC_TAB_POSITION,80,143,40,8
     COMBOBOX        IDC_COMBO_TAB_POSITION,124,140,46,80,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    LTEXT           "ƒ^ƒCƒgƒ‹(&T)",IDC_TextTabCaption,15,160,40,10
+    LTEXT           "ã‚¿ã‚¤ãƒˆãƒ«(&T)",IDC_TextTabCaption,15,160,40,10
     EDITTEXT        IDC_TABWND_CAPTION,56,157,226,14,ES_AUTOHSCROLL
-    GROUPBOX        "ƒ^ƒu‚ÌŠOŠÏ",IDC_STATIC,7,102,280,76,WS_GROUP
-    CONTROL         "ƒ}ƒEƒXƒzƒC[ƒ‹‚Åƒ^ƒuØ‘Ö(&W)",IDC_CHECK_ChgWndByWheel,
+    GROUPBOX        "ã‚¿ãƒ–ã®å¤–è¦³",IDC_STATIC,7,102,280,76,WS_GROUP
+    CONTROL         "ãƒžã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã§ã‚¿ãƒ–åˆ‡æ›¿(&W)",IDC_CHECK_ChgWndByWheel,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,196,127,10
-    GROUPBOX        "‚»‚Ì‘¼",IDC_STATIC,7,184,280,28,WS_GROUP
+    GROUPBOX        "ãã®ä»–",IDC_STATIC,7,184,280,28,WS_GROUP
 END
 
 IDD_PROP_STATUSBAR DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | WS_POPUP | WS_CAPTION | 
     WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    GROUPBOX        "•\Ž¦•¶ŽšƒR[ƒh‚ÌŽw’è",IDC_STATIC,3,3,285,92
-    CONTROL         "SJIS,Latin1“™‚Å•¶ŽšƒR[ƒh’l‚ðUnicode‚Å•\Ž¦‚·‚é(&S)",
+    GROUPBOX        "è¡¨ç¤ºæ–‡å­—ã‚³ãƒ¼ãƒ‰ã®æŒ‡å®š",IDC_STATIC,3,3,285,92
+    CONTROL         "SJIS,Latin1ç­‰ã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹(&S)",
                     IDC_CHECK_DISP_UNICODE_IN_SJIS,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,7,16,205,10
-    CONTROL         "JIS‚Å•¶ŽšƒR[ƒh’l‚ðUnicode‚Å•\Ž¦‚·‚é(&J)",
+    CONTROL         "JISã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹(&J)",
                     IDC_CHECK_DISP_UNICODE_IN_JIS,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,7,32,205,10
-    CONTROL         "EUC‚Å•¶ŽšƒR[ƒh’l‚ðUnicode‚Å•\Ž¦‚·‚é(&E)",
+    CONTROL         "EUCã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹(&E)",
                     IDC_CHECK_DISP_UNICODE_IN_EUC,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,7,48,205,10
-    CONTROL         "UTF-8‚¨‚æ‚ÑCESU-8‚ðƒR[ƒhƒ|ƒCƒ“ƒg‚Å•\Ž¦‚·‚é(&8)",
+    CONTROL         "UTF-8ãŠã‚ˆã³CESU-8ã‚’ã‚³ãƒ¼ãƒ‰ãƒã‚¤ãƒ³ãƒˆã§è¡¨ç¤ºã™ã‚‹(&8)",
                     IDC_CHECK_DISP_UTF8_CODEPOINT,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,7,64,205,10
-    CONTROL         "ƒTƒƒQ[ƒgƒyƒA‚ðƒR[ƒhƒ|ƒCƒ“ƒg‚Å•\Ž¦‚·‚é(&P)",
+    CONTROL         "ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢ã‚’ã‚³ãƒ¼ãƒ‰ãƒã‚¤ãƒ³ãƒˆã§è¡¨ç¤ºã™ã‚‹(&P)",
                     IDC_CHECK_DISP_SP_CODEPOINT,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,7,80,205,10
-    GROUPBOX        "•\Ž¦•¶Žš”‚ÌŽw’è",IDC_STATIC,3,98,285,47
-    CONTROL         "‘I‘ð•¶Žš”‚ð•¶Žš’PˆÊ‚Å‚Í‚È‚­ƒoƒCƒg’PˆÊ‚Å•\Ž¦‚·‚é(&B)@¦‚•‰‰×‚Ì‚½‚ß”ñ„§",
+    GROUPBOX        "è¡¨ç¤ºæ–‡å­—æ•°ã®æŒ‡å®š",IDC_STATIC,3,98,285,47
+    CONTROL         "é¸æŠžæ–‡å­—æ•°ã‚’æ–‡å­—å˜ä½ã§ã¯ãªããƒã‚¤ãƒˆå˜ä½ã§è¡¨ç¤ºã™ã‚‹(&B)ã€€â€»é«˜è² è·ã®ãŸã‚éžæŽ¨å¥¨",
                     IDC_CHECK_DISP_SELCOUNT_BY_BYTE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,7,112,274,10
-    CONTROL         "Œ»ÝŒ…‚ðƒ‹[ƒ‰[’PˆÊ‚Å‚Í‚È‚­•¶Žš’PˆÊ‚Å•\Ž¦‚·‚é(&C)",
+    CONTROL         "ç¾åœ¨æ¡ã‚’ãƒ«ãƒ¼ãƒ©ãƒ¼å˜ä½ã§ã¯ãªãæ–‡å­—å˜ä½ã§è¡¨ç¤ºã™ã‚‹(&C)",
                     IDC_CHECK_DISP_COL_BY_CHAR,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,7,128,274,10
 END
@@ -1667,236 +1667,236 @@ IDD_PROP_EDIT DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "Ü‚è•Ô‚µs‚É‰üs‚ð•t‚¯‚ÄƒRƒs[(&C)",
+    CONTROL         "æŠ˜ã‚Šè¿”ã—è¡Œã«æ”¹è¡Œã‚’ä»˜ã‘ã¦ã‚³ãƒ”ãƒ¼(&C)",
                     IDC_CHECK_ADDCRLFWHENCOPY,"Button",BS_AUTOCHECKBOX | 
                     WS_GROUP | WS_TABSTOP,8,16,143,10
-    CONTROL         "ƒRƒs[‚µ‚½‚ç‘I‘ð‰ðœ(&R)",
+    CONTROL         "ã‚³ãƒ”ãƒ¼ã—ãŸã‚‰é¸æŠžè§£é™¤(&R)",
                     IDC_CHECK_COPYnDISABLESELECTEDAREA,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,8,29,143,10
-    CONTROL         "‘I‘ð‚È‚µ‚ÅƒRƒs[‚ð‰Â”\‚É‚·‚é(&E)",
+    CONTROL         "é¸æŠžãªã—ã§ã‚³ãƒ”ãƒ¼ã‚’å¯èƒ½ã«ã™ã‚‹(&E)",
                     IDC_CHECK_bEnableNoSelectCopy,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,42,143,10
-    CONTROL         "ƒ‰ƒCƒ“ƒ‚[ƒh“\‚è•t‚¯‚ð‰Â”\‚É‚·‚é(&L)",
+    CONTROL         "ãƒ©ã‚¤ãƒ³ãƒ¢ãƒ¼ãƒ‰è²¼ã‚Šä»˜ã‘ã‚’å¯èƒ½ã«ã™ã‚‹(&L)",
                     IDC_CHECK_bEnableLineModePaste,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,55,143,10
-    CONTROL         "‰üsƒR[ƒh‚ð•ÏŠ·‚µ‚Ä“\‚è•t‚¯‚é(&P)",
+    CONTROL         "æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’å¤‰æ›ã—ã¦è²¼ã‚Šä»˜ã‘ã‚‹(&P)",
                     IDC_CHECK_CONVERTEOLPASTE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,68,143,10
-    GROUPBOX        "ƒRƒs[",IDC_STATIC,3,3,149,81,WS_GROUP
-    CONTROL         "ƒhƒ‰ƒbƒO && ƒhƒƒbƒv•ÒW‚·‚é(&D)",IDC_CHECK_DRAGDROP,
+    GROUPBOX        "ã‚³ãƒ”ãƒ¼",IDC_STATIC,3,3,149,81,WS_GROUP
+    CONTROL         "ãƒ‰ãƒ©ãƒƒã‚° && ãƒ‰ãƒ­ãƒƒãƒ—ç·¨é›†ã™ã‚‹(&D)",IDC_CHECK_DRAGDROP,
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,8,104,
                     143,10
-    CONTROL         "ƒhƒƒbƒvŒ³‚É‚·‚é(&S)",IDC_CHECK_DROPSOURCE,"Button",
+    CONTROL         "ãƒ‰ãƒ­ãƒƒãƒ—å…ƒã«ã™ã‚‹(&S)",IDC_CHECK_DROPSOURCE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,8,117,143,10
-    GROUPBOX        "ƒhƒ‰ƒbƒO && ƒhƒƒbƒv",IDC_STATIC,3,91,149,43,WS_GROUP
-    CONTROL         "‰üsƒR[ƒh‚Íã‘‚«‚µ‚È‚¢(&N)",
+    GROUPBOX        "ãƒ‰ãƒ©ãƒƒã‚° && ãƒ‰ãƒ­ãƒƒãƒ—",IDC_STATIC,3,91,149,43,WS_GROUP
+    CONTROL         "æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã¯ä¸Šæ›¸ãã—ãªã„(&N)",
                     IDC_CHECK_bNotOverWriteCRLF,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,156,143,10
-    CONTROL         "•¶Žš•‚É‡‚í‚¹‚ÄƒXƒy[ƒX‚ð‹l‚ß‚é(&F)",
+    CONTROL         "æ–‡å­—å¹…ã«åˆã‚ã›ã¦ã‚¹ãƒšãƒ¼ã‚¹ã‚’è©°ã‚ã‚‹(&F)",
                     IDC_CHECK_bOverWriteFixMode,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,169,143,10
-    CONTROL         "‹éŒ`“ü—Í‚Å‘I‘ð”ÍˆÍ‚ðíœ‚·‚é(&G)",
+    CONTROL         "çŸ©å½¢å…¥åŠ›ã§é¸æŠžç¯„å›²ã‚’å‰Šé™¤ã™ã‚‹(&G)",
                     IDC_CHECK_bOverWriteBoxDelete,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,182,143,10
-    GROUPBOX        "ã‘‚«ƒ‚[ƒh",IDC_STATIC,3,143,149,58,WS_GROUP
-    CONTROL         "ƒNƒŠƒbƒN‚Å&URL‚ð‘I‘ð‚·‚é",IDC_CHECK_bSelectClickedURL,
+    GROUPBOX        "ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰",IDC_STATIC,3,143,149,58,WS_GROUP
+    CONTROL         "ã‚¯ãƒªãƒƒã‚¯ã§&URLã‚’é¸æŠžã™ã‚‹",IDC_CHECK_bSelectClickedURL,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,161,18,120,10
-    GROUPBOX        "ƒNƒŠƒbƒJƒuƒ‹URL",IDC_STATIC,156,3,131,35,WS_GROUP
-    CONTROL         "ƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_(&U)",IDC_RADIO_CURDIR,"Button",
+    GROUPBOX        "ã‚¯ãƒªãƒƒã‚«ãƒ–ãƒ«URL",IDC_STATIC,156,3,131,35,WS_GROUP
+    CONTROL         "ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€(&U)",IDC_RADIO_CURDIR,"Button",
                     BS_AUTORADIOBUTTON,161,54,90,8
-    CONTROL         "Å‹ßŽg‚Á‚½ƒtƒHƒ‹ƒ_(&M)",IDC_RADIO_MRUDIR,"Button",
+    CONTROL         "æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚©ãƒ«ãƒ€(&M)",IDC_RADIO_MRUDIR,"Button",
                     BS_AUTORADIOBUTTON,161,69,90,8
-    CONTROL         "Žw’èƒtƒHƒ‹ƒ_(&F)",IDC_RADIO_SELDIR,"Button",
+    CONTROL         "æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€(&F)",IDC_RADIO_SELDIR,"Button",
                     BS_AUTORADIOBUTTON,161,84,90,8
     EDITTEXT        IDC_EDIT_FILEOPENDIR,161,100,111,12,ES_AUTOHSCROLL
     PUSHBUTTON      "...",IDC_BUTTON_FILEOPENDIR,273,100,9,12
-    GROUPBOX        "ƒtƒ@ƒCƒ‹ƒ_ƒCƒAƒƒO‚Ì‰ŠúˆÊ’u",IDC_STATIC,156,41,130,79,
+    GROUPBOX        "ãƒ•ã‚¡ã‚¤ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸä½ç½®",IDC_STATIC,156,41,130,79,
                     WS_GROUP
-    CONTROL         "‰üsƒR[ƒhNEL,PS,LS‚ð—LŒø‚É‚·‚é(&O)",
+    CONTROL         "æ”¹è¡Œã‚³ãƒ¼ãƒ‰NEL,PS,LSã‚’æœ‰åŠ¹ã«ã™ã‚‹(&O)",
                     IDC_CHECK_ENABLEEXTEOL,"Button",BS_AUTOCHECKBOX | WS_GROUP
                     | WS_TABSTOP,161,138,122,10
-    CONTROL         "‹éŒ`‘I‘ðˆÚ“®‚Å‘I‘ð‚ðƒƒbƒN‚·‚é(&B)",
+    CONTROL         "çŸ©å½¢é¸æŠžç§»å‹•ã§é¸æŠžã‚’ãƒ­ãƒƒã‚¯ã™ã‚‹(&B)",
                     IDC_CHECK_BOXSELECTLOCK,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,161,151,122,10
-    GROUPBOX        "‚»‚Ì‘¼",IDC_STATIC,156,125,131,42,WS_GROUP
+    GROUPBOX        "ãã®ä»–",IDC_STATIC,156,125,131,42,WS_GROUP
 END
 
 IDD_PROP_FILE DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | WS_POPUP | WS_CAPTION | 
     WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "”r‘¼§Œä(&H)",IDC_STATIC,8,16,48,10
+    LTEXT           "æŽ’ä»–åˆ¶å¾¡(&H)",IDC_STATIC,8,16,48,10
     COMBOBOX        IDC_COMBO_FILESHAREMODE,60,14,84,78,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    CONTROL         "XV‚ÌŠÄŽ‹(&W)",IDC_CHECK_bCheckFileTimeStamp,"Button",
+    CONTROL         "æ›´æ–°ã®ç›£è¦–(&W)",IDC_CHECK_bCheckFileTimeStamp,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,8,31,60,10
-    LTEXT           "Ž©“®“ÇžŽž’x‰„(&A)", IDC_LABEL_AUTOLOAD_DELAY,70,32,62,10
+    LTEXT           "è‡ªå‹•èª­è¾¼æ™‚é…å»¶(&A)", IDC_LABEL_AUTOLOAD_DELAY,70,32,62,10
     EDITTEXT        IDC_EDIT_AUTOLOAD_DELAY,130,30,30,12
     CONTROL         "Spin1",IDC_SPIN_AUTOLOAD_DELAY,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,150,30,9,12
-    CONTROL         "ã‘‚«‹ÖŽ~ŒŸoŽž‚Í•ÒW‹ÖŽ~‚É‚·‚é(&N)",
+    CONTROL         "ä¸Šæ›¸ãç¦æ­¢æ¤œå‡ºæ™‚ã¯ç·¨é›†ç¦æ­¢ã«ã™ã‚‹(&N)",
                     IDC_CHECK_bUneditableIfUnwritable,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,8,46,154,10
-    GROUPBOX        "ƒtƒ@ƒCƒ‹‚Ì”r‘¼§Œä",IDC_STATIC,3,3,163,57,WS_GROUP
-    CONTROL         "–³•ÏX‚Å‚àã‘‚«‚·‚é(&S)",
+    GROUPBOX        "ãƒ•ã‚¡ã‚¤ãƒ«ã®æŽ’ä»–åˆ¶å¾¡",IDC_STATIC,3,3,163,57,WS_GROUP
+    CONTROL         "ç„¡å¤‰æ›´ã§ã‚‚ä¸Šæ›¸ãã™ã‚‹(&S)",
                     IDC_CHECK_ENABLEUNMODIFIEDOVERWRITE,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,175,16,111,10
-    CONTROL         "Ž©“®“I‚É•Û‘¶‚·‚é(&U)",IDC_CHECK_AUTOSAVE,"Button",
+    CONTROL         "è‡ªå‹•çš„ã«ä¿å­˜ã™ã‚‹(&U)",IDC_CHECK_AUTOSAVE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,175,31,84,10
-    LTEXT           "ŠÔŠu‚Í(&I)",IDC_LABEL_AUTOSAVE,186,47,31,8,NOT WS_GROUP
+    LTEXT           "é–“éš”ã¯(&I)",IDC_LABEL_AUTOSAVE,186,47,31,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_AUTOBACKUP_INTERVAL,219,45,30,12
     CONTROL         "Spin1",IDC_SPIN_AUTOBACKUP_INTERVAL,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,266,45,9,12
-    LTEXT           "•ª‚²‚Æ",IDC_LABEL_AUTOSAVE2,250,47,21,8,NOT WS_GROUP
-    GROUPBOX        "ƒtƒ@ƒCƒ‹‚Ì•Û‘¶",IDC_STATIC,170,3,118,57,WS_GROUP
-    CONTROL         "V‹K‚©‚ç•Û‘¶Žž‚Í‘Sƒtƒ@ƒCƒ‹•\Ž¦(&O)",
+    LTEXT           "åˆ†ã”ã¨",IDC_LABEL_AUTOSAVE2,250,47,21,8,NOT WS_GROUP
+    GROUPBOX        "ãƒ•ã‚¡ã‚¤ãƒ«ã®ä¿å­˜",IDC_STATIC,170,3,118,57,WS_GROUP
+    CONTROL         "æ–°è¦ã‹ã‚‰ä¿å­˜æ™‚ã¯å…¨ãƒ•ã‚¡ã‚¤ãƒ«è¡¨ç¤º(&O)",
                     IDC_CHECK_NoFilterSaveNew,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,77,133,10
-    CONTROL         "V‹KˆÈŠO‚©‚ç•Û‘¶Žž‚Í‘Sƒtƒ@ƒCƒ‹•\Ž¦(&F)",
+    CONTROL         "æ–°è¦ä»¥å¤–ã‹ã‚‰ä¿å­˜æ™‚ã¯å…¨ãƒ•ã‚¡ã‚¤ãƒ«è¡¨ç¤º(&F)",
                     IDC_CHECK_NoFilterSaveFile,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,142,77,142,10
-    GROUPBOX        "u–¼‘O‚ð•t‚¯‚Ä•Û‘¶v‚Åƒtƒ@ƒCƒ‹‚ÌŽí—Þ‚ª[ƒ†[ƒU[Žw’è]‚Ì‚Æ‚«‚Ìƒtƒ@ƒCƒ‹ˆê——•\Ž¦",
+    GROUPBOX        "ã€Œåå‰ã‚’ä»˜ã‘ã¦ä¿å­˜ã€ã§ãƒ•ã‚¡ã‚¤ãƒ«ã®ç¨®é¡žãŒ[ãƒ¦ãƒ¼ã‚¶ãƒ¼æŒ‡å®š]ã®ã¨ãã®ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§è¡¨ç¤º",
                     IDC_STATIC,3,65,285,28
-    CONTROL         "ƒtƒ@ƒCƒ‹‚Ìƒhƒƒbƒv‚Íu•Â‚¶‚ÄŠJ‚­v‚É‚·‚é(&L)",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‰ãƒ­ãƒƒãƒ—ã¯ã€Œé–‰ã˜ã¦é–‹ãã€ã«ã™ã‚‹(&L)",
                     IDC_CHECK_bDropFileAndClose,"Button",BS_AUTOCHECKBOX | 
                     WS_GROUP | WS_TABSTOP,8,110,149,10
-    LTEXT           "ƒtƒ@ƒCƒ‹‚Ìƒhƒƒbƒv‚Íˆê“x‚É&MAX",IDC_LABEL_AUTOSAVE3,18,
+    LTEXT           "ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‰ãƒ­ãƒƒãƒ—ã¯ä¸€åº¦ã«&MAX",IDC_LABEL_AUTOSAVE3,18,
                     126,101,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_nDropFileNumMax,123,124,25,12,ES_AUTOHSCROLL
     CONTROL         "Spin1",IDC_SPIN_nDropFileNumMax,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,179,124,9,
                     12
-    LTEXT           "ŒÂ‚Ü‚Å‚Æ‚·‚é",IDC_LABEL_AUTOSAVE4,151,126,41,8,NOT 
+    LTEXT           "å€‹ã¾ã§ã¨ã™ã‚‹",IDC_LABEL_AUTOSAVE4,151,126,41,8,NOT 
                     WS_GROUP
-    LTEXT           "©’Fƒhƒƒbƒvƒtƒ@ƒCƒ‹‚Í1‚Â‚Ì‚Ý—LŒø",IDC_LANEL_NOTE,161,
+    LTEXT           "â†æ³¨ï¼šãƒ‰ãƒ­ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ã¯1ã¤ã®ã¿æœ‰åŠ¹",IDC_LANEL_NOTE,161,
                     111,106,8
-    CONTROL         "ƒtƒ@ƒCƒ‹‚ðŠJ‚¢‚½‚Æ‚«‚ÉƒJ[ƒ\ƒ‹ˆÊ’u‚ð•œŒ³‚·‚é(&C)",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã„ãŸã¨ãã«ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’å¾©å…ƒã™ã‚‹(&C)",
                     IDC_CHECK_RestoreCurPosition,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,140,174,10
-    CONTROL         "ƒtƒ@ƒCƒ‹‚ðŠJ‚¢‚½‚Æ‚«‚ÉƒuƒbƒNƒ}[ƒN‚ð•œŒ³‚·‚é(&B)",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã„ãŸã¨ãã«ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯ã‚’å¾©å…ƒã™ã‚‹(&B)",
                     IDC_CHECK_RestoreBookmarks,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,155,214,10
-    CONTROL         "ƒtƒ@ƒCƒ‹‚ðŠJ‚¢‚½‚Æ‚«‚ÉMIMEƒGƒ“ƒR[ƒh‚³‚ê‚½ƒwƒbƒ_‚ðƒfƒR[ƒh‚·‚é(&D)",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã„ãŸã¨ãã«MIMEã‚¨ãƒ³ã‚³ãƒ¼ãƒ‰ã•ã‚ŒãŸãƒ˜ãƒƒãƒ€ã‚’ãƒ‡ã‚³ãƒ¼ãƒ‰ã™ã‚‹(&D)",
                     IDC_CHECK_AutoMIMEDecode,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,169,231,10
-    CONTROL         "‘O‰ñ‚ÆˆÙ‚È‚é•¶ŽšƒR[ƒh‚Ì‚Æ‚«–â‚¢‡‚í‚¹‚ðs‚¤(&Q)",
+    CONTROL         "å‰å›žã¨ç•°ãªã‚‹æ–‡å­—ã‚³ãƒ¼ãƒ‰ã®ã¨ãå•ã„åˆã‚ã›ã‚’è¡Œã†(&Q)",
                     IDC_CHECK_QueryIfCodeChange,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,182,223,13
-    CONTROL         "ŠJ‚±‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹‚ª‘¶Ý‚µ‚È‚¢‚Æ‚«Œx‚·‚é(&E)",
+    CONTROL         "é–‹ã“ã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ãªã„ã¨ãè­¦å‘Šã™ã‚‹(&E)",
                     IDC_CHECK_AlertIfFileNotExist,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,198,223,10
-    CONTROL         "ŠJ‚±‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹‚ª‘å‚«‚¢ê‡‚ÉŒx‚·‚é(&T)",
+    CONTROL         "é–‹ã“ã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ãŒå¤§ãã„å ´åˆã«è­¦å‘Šã™ã‚‹(&T)",
                     IDC_CHECK_ALERT_IF_LARGEFILE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,214,167,10
     EDITTEXT        IDC_EDIT_ALERT_FILESIZE,181,212,30,12,ES_AUTOHSCROLL
     CONTROL         "Spin1",IDC_SPIN_ALERT_FILESIZE,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,240,211,9,
                     14
-    LTEXT           "MB‚©‚ç",IDC_STATIC,214,214,25,10
-    GROUPBOX        "ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“",IDC_STATIC,3,97,285,135,WS_GROUP
+    LTEXT           "MBã‹ã‚‰",IDC_STATIC,214,214,25,10
+    GROUPBOX        "ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³",IDC_STATIC,3,97,285,135,WS_GROUP
 END
 
 IDD_PROP_FNAME DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "’·‚¢ƒpƒX‚ÌÈ—ª•\Ž¦(&L)",IDC_CHECK_SHORTPATH,
+    CONTROL         "é•·ã„ãƒ‘ã‚¹ã®çœç•¥è¡¨ç¤º(&L)",IDC_CHECK_SHORTPATH,
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,6,3,
                     100,10
-    LTEXT           "•¶Žš”(&N)",IDC_STATIC,109,4,45,10
+    LTEXT           "æ–‡å­—æ•°(&N)",IDC_STATIC,109,4,45,10
     EDITTEXT        IDC_EDIT_SHORTMAXWIDTH,155,3,30,13,ES_NUMBER
-    GROUPBOX        "ƒtƒ@ƒCƒ‹–¼‚ÌŠÈˆÕ•\Ž¦(&I)",IDC_STATIC,6,20,282,180
+    GROUPBOX        "ãƒ•ã‚¡ã‚¤ãƒ«åã®ç°¡æ˜“è¡¨ç¤º(&I)",IDC_STATIC,6,20,282,180
     CONTROL         "List1",IDC_LIST_FNAME,"SysListView32",LVS_REPORT | 
                     LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_AUTOARRANGE | 
                     LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,12,35,230,117
-    LTEXT           "’uŠ·‘O(&F)",IDC_STATIC,13,161,37,10
+    LTEXT           "ç½®æ›å‰(&F)",IDC_STATIC,13,161,37,10
     EDITTEXT        IDC_EDIT_FNAME_FROM,50,160,191,13,ES_AUTOHSCROLL
-    LTEXT           "’uŠ·Œã(&R)",IDC_STATIC,13,180,37,10
+    LTEXT           "ç½®æ›å¾Œ(&R)",IDC_STATIC,13,180,37,10
     EDITTEXT        IDC_EDIT_FNAME_TO,50,177,191,13,ES_AUTOHSCROLL
-    PUSHBUTTON      "‘}“ü(&S)",IDC_BUTTON_FNAME_INS,245,123,38,15
-    PUSHBUTTON      "’Ç‰Á(&A)",IDC_BUTTON_FNAME_ADD,245,141,38,15
-    PUSHBUTTON      "XV(&E)",IDC_BUTTON_FNAME_UPD,245,159,38,15
-    PUSHBUTTON      "íœ(&D)",IDC_BUTTON_FNAME_DEL,245,177,38,15
-    PUSHBUTTON      "æ“ª(&T)",IDC_BUTTON_FNAME_TOP,245,43,38,15
-    PUSHBUTTON      "ã‚Ö(&U)",IDC_BUTTON_FNAME_UP,245,61,38,15
-    PUSHBUTTON      "‰º‚Ö(&G)",IDC_BUTTON_FNAME_DOWN,245,79,38,15
-    PUSHBUTTON      "ÅI(&B)",IDC_BUTTON_FNAME_LAST,245,97,38,15
+    PUSHBUTTON      "æŒ¿å…¥(&S)",IDC_BUTTON_FNAME_INS,245,123,38,15
+    PUSHBUTTON      "è¿½åŠ (&A)",IDC_BUTTON_FNAME_ADD,245,141,38,15
+    PUSHBUTTON      "æ›´æ–°(&E)",IDC_BUTTON_FNAME_UPD,245,159,38,15
+    PUSHBUTTON      "å‰Šé™¤(&D)",IDC_BUTTON_FNAME_DEL,245,177,38,15
+    PUSHBUTTON      "å…ˆé ­(&T)",IDC_BUTTON_FNAME_TOP,245,43,38,15
+    PUSHBUTTON      "ä¸Šã¸(&U)",IDC_BUTTON_FNAME_UP,245,61,38,15
+    PUSHBUTTON      "ä¸‹ã¸(&G)",IDC_BUTTON_FNAME_DOWN,245,79,38,15
+    PUSHBUTTON      "æœ€çµ‚(&B)",IDC_BUTTON_FNAME_LAST,245,97,38,15
 END
 
 IDD_PROP_BACKUP DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | WS_POPUP | WS_CAPTION | 
     WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    GROUPBOX        "ƒoƒbƒNƒAƒbƒv‚Ìì¬",IDC_STATIC,3,3,285,207,WS_GROUP
-    CONTROL         "•Û‘¶Žž‚ÉƒoƒbƒNƒAƒbƒv‚ðì¬‚·‚é(&K)",IDC_CHECK_BACKUP,
+    GROUPBOX        "ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã®ä½œæˆ",IDC_STATIC,3,3,285,207,WS_GROUP
+    CONTROL         "ä¿å­˜æ™‚ã«ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹(&K)",IDC_CHECK_BACKUP,
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,8,16,
                     136,10
 
-    CONTROL         "Ú×Ý’è‚·‚é(&A)",IDC_CHECK_BACKUP_ADVANCED,"Button",
+    CONTROL         "è©³ç´°è¨­å®šã™ã‚‹(&A)",IDC_CHECK_BACKUP_ADVANCED,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,12,32,79,10
     EDITTEXT        IDC_EDIT_BACKUPFILE,24,44,255,13,ES_AUTOHSCROLL
 
-    CONTROL         "Šg’£Žq‚ð .bak‚É•ÏX‚µ‚½‚à‚Ì(1¢‘ã &B)",
+    CONTROL         "æ‹¡å¼µå­ã‚’ .bakã«å¤‰æ›´ã—ãŸã‚‚ã®(1ä¸–ä»£ &B)",
                     IDC_RADIO_BACKUP_TYPE1,"Button",BS_AUTORADIOBUTTON | 
                     WS_GROUP,12,66,142,10
-    CONTROL         "Šg’£Žq‚ð˜A”Ô(.b00`b98)‚É•ÏX‚µ‚½‚à‚Ì(&G)",
+    CONTROL         "æ‹¡å¼µå­ã‚’é€£ç•ª(.b00ï½žb98)ã«å¤‰æ›´ã—ãŸã‚‚ã®(&G)",
                     IDC_RADIO_BACKUP_TYPE3,"Button",BS_AUTORADIOBUTTON,12,80,
                     156,10
-    CONTROL         "ƒtƒ@ƒCƒ‹–¼‚ÌŒã‚ë‚É•Û‘¶Žž‚Ì“ú•tEŽž‚ð•t‰Á‚µ‚½‚à‚Ì(&E)",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«åã®å¾Œã‚ã«ä¿å­˜æ™‚ã®æ—¥ä»˜ãƒ»æ™‚åˆ»ã‚’ä»˜åŠ ã—ãŸã‚‚ã®(&E)",
                     IDC_RADIO_BACKUP_DATETYPE1,"Button",BS_AUTORADIOBUTTON,
                     12,106,204,10
-    CONTROL         "ƒtƒ@ƒCƒ‹–¼‚ÌŒã‚ë‚É‘O‰ñ‚Ì•Û‘¶Žž‚Ì“ú•tEŽž‚ð•t‰Á‚µ‚½‚à‚Ì(&U)",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«åã®å¾Œã‚ã«å‰å›žã®ä¿å­˜æ™‚ã®æ—¥ä»˜ãƒ»æ™‚åˆ»ã‚’ä»˜åŠ ã—ãŸã‚‚ã®(&U)",
                     IDC_RADIO_BACKUP_DATETYPE2,"Button",BS_AUTORADIOBUTTON,
                     12,120,230,10
-    CONTROL         "Œ³‚ÌŠg’£Žq‚ð•Û‘¶(&R)",IDC_CHECK_BACKUP_RETAINEXT,"Button",
+    CONTROL         "å…ƒã®æ‹¡å¼µå­ã‚’ä¿å­˜(&R)",IDC_CHECK_BACKUP_RETAINEXT,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,162,66,96,10
-    LTEXT           "•Û‘¶‚·‚é¢‘ã”(1-99 &N)",IDC_LABEL_BACKUP_3,22,94,91,8
+    LTEXT           "ä¿å­˜ã™ã‚‹ä¸–ä»£æ•°(1-99 &N)",IDC_LABEL_BACKUP_3,22,94,91,8
     EDITTEXT        IDC_EDIT_BACKUP_3,106,92,28,12
     CONTROL         "Spin1",IDC_SPIN_BACKUP_GENS,"msctls_updown32",
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,154,92,9,
                     12
-    CONTROL         "¼—ï(&Y)",IDC_CHECK_BACKUP_YEAR,"Button",
+    CONTROL         "è¥¿æš¦(&Y)",IDC_CHECK_BACKUP_YEAR,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,22,132,35,10
-    CONTROL         "ŒŽ(&M)",IDC_CHECK_BACKUP_MONTH,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "æœˆ(&M)",IDC_CHECK_BACKUP_MONTH,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,60,132,34,10
-    CONTROL         "“ú(&D)",IDC_CHECK_BACKUP_DAY,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "æ—¥(&D)",IDC_CHECK_BACKUP_DAY,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,97,132,34,10
-    CONTROL         "Žž(&H)",IDC_CHECK_BACKUP_HOUR,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "æ™‚(&H)",IDC_CHECK_BACKUP_HOUR,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,134,132,34,10
-    CONTROL         "•ª(&I)",IDC_CHECK_BACKUP_MIN,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "åˆ†(&I)",IDC_CHECK_BACKUP_MIN,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,171,132,31,10
-    CONTROL         "•b(&S)",IDC_CHECK_BACKUP_SEC,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "ç§’(&S)",IDC_CHECK_BACKUP_SEC,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,205,132,33,10
 
     LTEXT           "",IDC_STATIC,12,60,271,83,NOT WS_VISIBLE
-    CONTROL         "•Û‘¶Žž‚Ì“ú•tEŽž‚ðŽg—p",IDC_RADIO_BACKUP_DATETYPE1A,
+    CONTROL         "ä¿å­˜æ™‚ã®æ—¥ä»˜ãƒ»æ™‚åˆ»ã‚’ä½¿ç”¨",IDC_RADIO_BACKUP_DATETYPE1A,
                     "Button",BS_AUTORADIOBUTTON | WS_GROUP,12,104,111,10
-    CONTROL         "‘O‰ñ‚Ìƒtƒ@ƒCƒ‹XVŽž‚Ì“ú•tEŽž‚ðŽg—p",
+    CONTROL         "å‰å›žã®ãƒ•ã‚¡ã‚¤ãƒ«æ›´æ–°æ™‚ã®æ—¥ä»˜ãƒ»æ™‚åˆ»ã‚’ä½¿ç”¨",
                     IDC_RADIO_BACKUP_DATETYPE2A,"Button",BS_AUTORADIOBUTTON,
                     12,118,149,10
-    LTEXT           "$x : xŒÂã‚ÌƒtƒHƒ‹ƒ_–¼(0-9)\r* : Šg’£Žq\r\r%Y/%m/%d : ”NŒŽ“ú %y¼—ï(2Œ…) \r%H:%M:%S: Žž•ª•b   \r%% : '%'‹L†\r",
+    LTEXT           "$x : xå€‹ä¸Šã®ãƒ•ã‚©ãƒ«ãƒ€å(0-9)\r* : æ‹¡å¼µå­\r\r%Y/%m/%d : å¹´æœˆæ—¥ %yè¥¿æš¦(2æ¡) \r%H:%M:%S: æ™‚åˆ†ç§’   \r%% : '%'è¨˜å·\r",
                     IDC_LABEL_BACKUP_HELP2,165,75,115,50,SS_SUNKEN
 
-    CONTROL         "Žw’èƒtƒHƒ‹ƒ_‚Éì¬‚·‚é(&P)",IDC_CHECK_BACKUPFOLDER,
+    CONTROL         "æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€ã«ä½œæˆã™ã‚‹(&P)",IDC_CHECK_BACKUPFOLDER,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,148,107,10
-    AUTOCHECKBOX    "ƒŠƒ€[ƒoƒuƒ‹ƒƒfƒBƒA‚Ì‚Ý(&L)", IDC_CHECK_BACKUP_FOLDER_RM,
+    AUTOCHECKBOX    "ãƒªãƒ ãƒ¼ãƒãƒ–ãƒ«ãƒ¡ãƒ‡ã‚£ã‚¢ã®ã¿(&L)", IDC_CHECK_BACKUP_FOLDER_RM,
                     120, 148, 133, 10
-    LTEXT           "ƒtƒHƒ‹ƒ_–¼(&F)",IDC_LABEL_BACKUP_4,24,162,87,8
+    LTEXT           "ãƒ•ã‚©ãƒ«ãƒ€å(&F)",IDC_LABEL_BACKUP_4,24,162,87,8
     EDITTEXT        IDC_EDIT_BACKUPFOLDER,73,160,195,12,ES_AUTOHSCROLL
     PUSHBUTTON      "&...",IDC_BUTTON_BACKUP_FOLDER_REF,271,160,9,12
-    CONTROL         "ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹‚ð‚²‚Ý” ‚É•ú‚èž‚Þ(&X)",
+    CONTROL         "ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã”ã¿ç®±ã«æ”¾ã‚Šè¾¼ã‚€(&X)",
                     IDC_CHECK_BACKUP_DUSTBOX,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,12,176,150,10
 
-    CONTROL         "ì¬‘O‚ÉŠm”F‚·‚é(&V)",IDC_CHECK_BACKUPDIALOG,"Button",
+    CONTROL         "ä½œæˆå‰ã«ç¢ºèªã™ã‚‹(&V)",IDC_CHECK_BACKUPDIALOG,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,12,196,104,10
 END
 
@@ -1904,32 +1904,32 @@ IDD_PROP_FORMAT DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "•W€(&S)",IDC_RADIO_DFORM_0,"Button",BS_AUTORADIOBUTTON | 
+    CONTROL         "æ¨™æº–(&S)",IDC_RADIO_DFORM_0,"Button",BS_AUTORADIOBUTTON | 
                     WS_GROUP,8,18,41,10
-    CONTROL         "ƒJƒXƒ^ƒ€(&C)",IDC_RADIO_DFORM_1,"Button",
+    CONTROL         "ã‚«ã‚¹ã‚¿ãƒ (&C)",IDC_RADIO_DFORM_1,"Button",
                     BS_AUTORADIOBUTTON,51,18,52,10
     LTEXT           "&D:",IDC_LABEL_DFORM,106,19,8,8
     EDITTEXT        IDC_EDIT_DFORM,115,17,82,12,ES_AUTOHSCROLL
-    GROUPBOX        "“ú•t‘Ž®",IDC_STATIC,3,3,199,35,WS_GROUP
-    LTEXT           "•\Ž¦—á",IDC_STATIC,209,7,27,8,NOT WS_GROUP
+    GROUPBOX        "æ—¥ä»˜æ›¸å¼",IDC_STATIC,3,3,199,35,WS_GROUP
+    LTEXT           "è¡¨ç¤ºä¾‹",IDC_STATIC,209,7,27,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_DFORM_EX,209,17,77,12,ES_AUTOHSCROLL | 
                     ES_READONLY | NOT WS_TABSTOP
-    CONTROL         "•W€(&N)",IDC_RADIO_TFORM_0,"Button",BS_AUTORADIOBUTTON | 
+    CONTROL         "æ¨™æº–(&N)",IDC_RADIO_TFORM_0,"Button",BS_AUTORADIOBUTTON | 
                     WS_GROUP,8,58,41,10
-    CONTROL         "ƒJƒXƒ^ƒ€(&U)",IDC_RADIO_TFORM_1,"Button",
+    CONTROL         "ã‚«ã‚¹ã‚¿ãƒ (&U)",IDC_RADIO_TFORM_1,"Button",
                     BS_AUTORADIOBUTTON,51,58,52,10
     LTEXT           "&T:",IDC_LABEL_TFORM,106,59,8,8
     EDITTEXT        IDC_EDIT_TFORM,115,57,82,12,ES_AUTOHSCROLL
-    GROUPBOX        "Žž‘Ž®",IDC_STATIC,3,43,199,35,WS_GROUP
-    LTEXT           "•\Ž¦—á",IDC_STATIC,209,47,27,8,NOT WS_GROUP
+    GROUPBOX        "æ™‚åˆ»æ›¸å¼",IDC_STATIC,3,43,199,35,WS_GROUP
+    LTEXT           "è¡¨ç¤ºä¾‹",IDC_STATIC,209,47,27,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_TFORM_EX,209,57,77,12,ES_AUTOHSCROLL | 
                     ES_READONLY | NOT WS_TABSTOP
-    GROUPBOX        "Œ©o‚µ‹L†(&R)",IDC_STATIC,3,83,283,52,WS_GROUP
+    GROUPBOX        "è¦‹å‡ºã—è¨˜å·(&R)",IDC_STATIC,3,83,283,52,WS_GROUP
     EDITTEXT        IDC_EDIT_MIDASHIKIGOU,8,95,272,31,ES_MULTILINE | 
                     ES_AUTOVSCROLL | WS_VSCROLL | WS_GROUP
-    GROUPBOX        "ˆø—p•„(&Q)",IDC_STATIC,3,140,283,32,WS_GROUP
+    GROUPBOX        "å¼•ç”¨ç¬¦(&Q)",IDC_STATIC,3,140,283,32,WS_GROUP
     EDITTEXT        IDC_EDIT_INYOUKIGOU,8,152,270,12,ES_AUTOHSCROLL | 
                     WS_GROUP
 END
@@ -1938,39 +1938,39 @@ IDD_PROP_GREP DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì•¶Žš—ñ‚ðƒfƒtƒHƒ‹ƒg‚ÌŒŸõ•¶Žš—ñ‚É‚·‚é(&C)",
+    CONTROL         "ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ–‡å­—åˆ—ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®æ¤œç´¢æ–‡å­—åˆ—ã«ã™ã‚‹(&C)",
                     IDC_CHECK_bCaretTextForSearch,"Button",BS_AUTOCHECKBOX | 
                     BS_TOP | WS_GROUP | WS_TABSTOP,8,21,204,10
-    CONTROL         "ŽŸE‘OŒŸõ‚Å‘¼‚Ìƒrƒ…[‚Å‚ÌŒŸõðŒ•ÏX‚ðˆø‚«Œp‚®(&I)",
+    CONTROL         "æ¬¡ãƒ»å‰æ¤œç´¢ã§ä»–ã®ãƒ“ãƒ¥ãƒ¼ã§ã®æ¤œç´¢æ¡ä»¶å¤‰æ›´ã‚’å¼•ãç¶™ã(&I)",
                     IDC_CHECK_INHERIT_KEY_OTHER_VIEW,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,35,209,10
-    LTEXT           "³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠŽw’è(&L)",IDC_LABEL_REGEXP,8,50,93,10
+    LTEXT           "æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªæŒ‡å®š(&L)",IDC_LABEL_REGEXP,8,50,93,10
     LTEXT           "",IDC_LABEL_REGEXP_VER,8,62,275,14
     EDITTEXT        IDC_EDIT_REGEXPLIB,110,47,162,13,ES_AUTOHSCROLL
-    GROUPBOX        "ŒŸõ^’uŠ·^Grep",IDC_STATIC,3,7,285,70,WS_GROUP
-    CONTROL         "Grepƒ‚[ƒh‚Å•Û‘¶Šm”F‚·‚é(&V)",
+    GROUPBOX        "æ¤œç´¢ï¼ç½®æ›ï¼Grep",IDC_STATIC,3,7,285,70,WS_GROUP
+    CONTROL         "Grepãƒ¢ãƒ¼ãƒ‰ã§ä¿å­˜ç¢ºèªã™ã‚‹(&V)",
                     IDC_CHECK_bGrepExitConfirm,"Button",BS_AUTOCHECKBOX | 
                     WS_GROUP | WS_TABSTOP,8,94,130,10
-    CONTROL         "ƒŠƒAƒ‹ƒ^ƒCƒ€‚Å•\Ž¦‚·‚é(&R)",IDC_CHECK_GREPREALTIME,
+    CONTROL         "ãƒªã‚¢ãƒ«ã‚¿ã‚¤ãƒ ã§è¡¨ç¤ºã™ã‚‹(&R)",IDC_CHECK_GREPREALTIME,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,106,111,10
     GROUPBOX        "Grep",IDC_STATIC,3,80,285,42,WS_GROUP
-    CONTROL         "ƒGƒ“ƒ^[ƒL[‚Åƒ^ƒOƒWƒƒƒ“ƒv(&E)",IDC_CHECK_GTJW_RETURN,
+    CONTROL         "ã‚¨ãƒ³ã‚¿ãƒ¼ã‚­ãƒ¼ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—(&E)",IDC_CHECK_GTJW_RETURN,
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,8,142,
                     109,10
-    CONTROL         "ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Åƒ^ƒOƒWƒƒƒ“ƒv(&W)",
+    CONTROL         "ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—(&W)",
                     IDC_CHECK_GTJW_LDBLCLK,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,154,115,10
-    GROUPBOX        "GrepŒ‹‰Ê‚©‚ç‚Ìƒ^ƒOƒWƒƒƒ“ƒv",IDC_STATIC,3,127,285,46,
+    GROUPBOX        "Grepçµæžœã‹ã‚‰ã®ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—",IDC_STATIC,3,127,285,46,
                     WS_GROUP
-    GROUPBOX        "ƒ^ƒOƒWƒƒƒ“ƒv",IDC_STATIC,3,178,285,52,
+    GROUPBOX        "ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—",IDC_STATIC,3,178,285,52,
                     WS_GROUP
-    LTEXT           "ƒ^ƒOƒtƒ@ƒCƒ‹‚ÌŒŸõ(&T):",IDC_STATIC,8,192,112,8
+    LTEXT           "ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®æ¤œç´¢(&T):",IDC_STATIC,8,192,112,8
     COMBOBOX        IDC_COMBO_TAGJUMP,124,190,156,100,CBS_DROPDOWNLIST | 
                     CBS_AUTOHSCROLL | CBS_NOINTEGRALHEIGHT | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "ƒL[ƒ[ƒhŽw’è‚Ìƒ^ƒOƒtƒ@ƒCƒ‹ŒŸõ(&K):",IDC_STATIC,8,210,112,8
+    LTEXT           "ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®šã®ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«æ¤œç´¢(&K):",IDC_STATIC,8,210,112,8
     COMBOBOX        IDC_COMBO_KEYWORD_TAGJUMP,124,208,156,100,CBS_DROPDOWNLIST | 
                     CBS_AUTOHSCROLL | CBS_NOINTEGRALHEIGHT | WS_VSCROLL | 
                     WS_TABSTOP
@@ -1979,24 +1979,24 @@ END
 IDD_PROP_KEYBIND DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    RTEXT           "Ží•Ê(&K)",IDC_LABEL_MENUFUNCKIND,4,4,51,8
+    RTEXT           "ç¨®åˆ¥(&K)",IDC_LABEL_MENUFUNCKIND,4,4,51,8
     COMBOBOX        IDC_COMBO_FUNCKIND,60,2,68,180,CBS_DROPDOWNLIST | 
                     CBS_AUTOHSCROLL | CBS_NOINTEGRALHEIGHT | WS_VSCROLL | 
                     WS_TABSTOP
-    LTEXT           "‹@”\(&F)",IDC_LABEL_MENUFUNC,3,18,41,8
+    LTEXT           "æ©Ÿèƒ½(&F)",IDC_LABEL_MENUFUNC,3,18,41,8
     LISTBOX         IDC_LIST_FUNC,3,28,124,143,LBS_NOINTEGRALHEIGHT | 
                     WS_VSCROLL | WS_HSCROLL | WS_TABSTOP
-    LTEXT           "‹@”\‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚éƒL[(&G)",IDC_LABEL_FUNCtoKEY,6,
+    LTEXT           "æ©Ÿèƒ½ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ã‚‹ã‚­ãƒ¼(&G)",IDC_LABEL_FUNCtoKEY,6,
                     175,113,8,NOT WS_GROUP
     LISTBOX         IDC_LIST_ASSIGNEDKEYS,3,184,124,33,LBS_SORT | 
                     LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_HSCROLL | 
                     WS_GROUP | WS_TABSTOP
-    PUSHBUTTON      "ƒCƒ“ƒ|[ƒg(&I)...",IDC_BUTTON_IMPORT,171,2,58,14,
+    PUSHBUTTON      "ã‚¤ãƒ³ãƒãƒ¼ãƒˆ(&I)...",IDC_BUTTON_IMPORT,171,2,58,14,
                     WS_GROUP
-    PUSHBUTTON      "ƒGƒNƒXƒ|[ƒg(&X)...",IDC_BUTTON_EXPORT,231,2,58,14
-    LTEXT           "ƒL[(&Y)",IDC_LABEL_KEYKIND,164,18,25,8
+    PUSHBUTTON      "ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ(&X)...",IDC_BUTTON_EXPORT,231,2,58,14
+    LTEXT           "ã‚­ãƒ¼(&Y)",IDC_LABEL_KEYKIND,164,18,25,8
     LISTBOX         IDC_LIST_KEY,165,28,124,164,LBS_NOINTEGRALHEIGHT | 
                     LBS_DISABLENOSCROLL | WS_VSCROLL | WS_TABSTOP
     CONTROL         "&Shift",IDC_CHECK_SHIFT,"Button",BS_AUTOCHECKBOX | 
@@ -2005,280 +2005,280 @@ BEGIN
                     WS_TABSTOP,134,53,25,10
     CONTROL         "A&Lt",IDC_CHECK_ALT,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,134,68,25,10
-    LTEXT           "ƒL[‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚é‹@”\",IDC_LABEL_KEYtoFUNC,166,
+    LTEXT           "ã‚­ãƒ¼ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ã‚‹æ©Ÿèƒ½",IDC_LABEL_KEYtoFUNC,166,
                     196,120,8
     EDITTEXT        IDC_EDIT_KEYSFUNC,164,205,118,12,ES_AUTOHSCROLL | 
                     ES_READONLY | WS_GROUP | NOT WS_TABSTOP
-    PUSHBUTTON      "Š„•t(&B)",IDC_BUTTON_ASSIGN,129,190,34,14,WS_GROUP
-    PUSHBUTTON      "‰ðœ(&R)",IDC_BUTTON_RELEASE,129,204,34,14
+    PUSHBUTTON      "å‰²ä»˜(&B)",IDC_BUTTON_ASSIGN,129,190,34,14,WS_GROUP
+    PUSHBUTTON      "è§£é™¤(&R)",IDC_BUTTON_RELEASE,129,204,34,14
 END
 
 IDD_PROP_CUSTMENU DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    RTEXT           "Ží•Ê(&K)",IDC_LABEL_MENUFUNCKIND,4,4,52,8
+    RTEXT           "ç¨®åˆ¥(&K)",IDC_LABEL_MENUFUNCKIND,4,4,52,8
     COMBOBOX        IDC_COMBO_FUNCKIND,60,2,68,180,CBS_DROPDOWNLIST | 
                     CBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "‹@”\(&F)",IDC_LABEL_MENUFUNC,3,16,40,8,NOT WS_GROUP
+    LTEXT           "æ©Ÿèƒ½(&F)",IDC_LABEL_MENUFUNC,3,16,40,8,NOT WS_GROUP
     LISTBOX         IDC_LIST_FUNC,3,27,124,178,LBS_NOINTEGRALHEIGHT | 
                     WS_VSCROLL | WS_HSCROLL | WS_TABSTOP
-    RTEXT           "‘I‘ð(&C)",IDC_LABEL_MENUCHOICE,187,4,31,8
+    RTEXT           "é¸æŠž(&C)",IDC_LABEL_MENUCHOICE,187,4,31,8
     COMBOBOX        IDC_COMBO_MENU,221,2,68,220,CBS_DROPDOWNLIST | 
                     CBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "ƒƒjƒ…[–¼(&N)",IDC_LABEL_MENUNAME,142,16,64,8,NOT 
+    LTEXT           "ãƒ¡ãƒ‹ãƒ¥ãƒ¼å(&N)",IDC_LABEL_MENUNAME,142,16,64,8,NOT 
                     WS_GROUP
     EDITTEXT        IDC_EDIT_MENUNAME,146,27,109,14,ES_AUTOHSCROLL
-    PUSHBUTTON      "Ý’è(&R)",IDC_BUTTON_MENUNAME,258,27,30,14
-    LTEXT           "ƒƒjƒ…[(&M)",IDC_LABEL_MENU,142,44,37,8,NOT WS_GROUP
+    PUSHBUTTON      "è¨­å®š(&R)",IDC_BUTTON_MENUNAME,258,27,30,14
+    LTEXT           "ãƒ¡ãƒ‹ãƒ¥ãƒ¼(&M)",IDC_LABEL_MENU,142,44,37,8,NOT WS_GROUP
     LISTBOX         IDC_LIST_RES,164,54,123,151,LBS_NOINTEGRALHEIGHT | 
                     WS_VSCROLL | WS_HSCROLL | WS_TABSTOP
-    PUSHBUTTON      "íœ(&D)",IDC_BUTTON_DELETE,130,62,30,14,WS_GROUP
+    PUSHBUTTON      "å‰Šé™¤(&D)",IDC_BUTTON_DELETE,130,62,30,14,WS_GROUP
     PUSHBUTTON      "---(&S)",IDC_BUTTON_INSERTSEPARATOR,130,81,30,14,
                     BS_MULTILINE
-    PUSHBUTTON      "¨(&A)",IDC_BUTTON_INSERT,128,101,34,14
+    PUSHBUTTON      "â†’(&A)",IDC_BUTTON_INSERT,128,101,34,14
     PUSHBUTTON      ">>(&B)",IDC_BUTTON_ADD,128,115,34,14,BS_MULTILINE
-    PUSHBUTTON      "ª(&U)",IDC_BUTTON_UP,128,135,34,14
-    PUSHBUTTON      "«(&O)",IDC_BUTTON_DOWN,128,149,34,14
-    LTEXT           "ªƒ_ƒuƒ‹ƒNƒŠƒbƒN‚ÅƒAƒNƒZƒXƒL[Ý’è‰Â",
+    PUSHBUTTON      "â†‘(&U)",IDC_BUTTON_UP,128,135,34,14
+    PUSHBUTTON      "â†“(&O)",IDC_BUTTON_DOWN,128,149,34,14
+    LTEXT           "â†‘ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼è¨­å®šå¯",
                     IDC_LABEL_MENUKEYCHANGE,174,208,114,8
-    CONTROL         "ƒTƒuƒƒjƒ…[‚Æ‚µ‚Ä•\Ž¦(&S)",IDC_CHECK_SUBMENU,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "ã‚µãƒ–ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã¨ã—ã¦è¡¨ç¤º(&S)",IDC_CHECK_SUBMENU,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,164,220,114,8
-    PUSHBUTTON      "ƒCƒ“ƒ|[ƒg(&I)...",IDC_BUTTON_IMPORT,3,208,58,14,
+    PUSHBUTTON      "ã‚¤ãƒ³ãƒãƒ¼ãƒˆ(&I)...",IDC_BUTTON_IMPORT,3,208,58,14,
                     WS_GROUP
-    PUSHBUTTON      "ƒGƒNƒXƒ|[ƒg(&X)...",IDC_BUTTON_EXPORT,64,208,58,14
+    PUSHBUTTON      "ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ(&X)...",IDC_BUTTON_EXPORT,64,208,58,14
 END
 
 IDD_PROP_KEYWORD DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "ƒZƒbƒg–¼(&N)",IDC_STATIC,3,6,37,8
+    LTEXT           "ã‚»ãƒƒãƒˆå(&N)",IDC_STATIC,3,6,37,8
     COMBOBOX        IDC_COMBO_SET,42,3,85,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    PUSHBUTTON      "ƒZƒbƒg’Ç‰Á(&M)...",IDC_BUTTON_ADDSET,181,5,53,14,
+    PUSHBUTTON      "ã‚»ãƒƒãƒˆè¿½åŠ (&M)...",IDC_BUTTON_ADDSET,181,5,53,14,
                     WS_GROUP
-    PUSHBUTTON      "ƒZƒbƒgíœ(&R)...",IDC_BUTTON_DELSET,236,5,52,14
-    GROUPBOX        "‹­’²ƒL[ƒ[ƒh(&K)",IDC_STATIC,3,20,285,217,WS_GROUP
+    PUSHBUTTON      "ã‚»ãƒƒãƒˆå‰Šé™¤(&R)...",IDC_BUTTON_DELSET,236,5,52,14
+    GROUPBOX        "å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰(&K)",IDC_STATIC,3,20,285,217,WS_GROUP
     CONTROL         "List5",IDC_LIST_KEYWORD,"SysListView32",LVS_LIST | 
                     LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_SORTASCENDING | 
                     LVS_EDITLABELS | LVS_ALIGNLEFT | LVS_NOCOLUMNHEADER | 
                     WS_BORDER | WS_TABSTOP,5,30,280,171
-    PUSHBUTTON      "’Ç‰Á(&A)...",IDC_BUTTON_ADDKEYWORD,8,203,40,14,WS_GROUP
-    PUSHBUTTON      "•ÒW(&E)...",IDC_BUTTON_EDITKEYWORD,50,203,40,14
-    PUSHBUTTON      "íœ(&D)",IDC_BUTTON_DELKEYWORD,92,203,40,14
-    CONTROL         "‰p‘å•¶Žš¬•¶Žš‹æ•Ê(&C)",IDC_CHECK_KEYWORDCASE,"Button",
+    PUSHBUTTON      "è¿½åŠ (&A)...",IDC_BUTTON_ADDKEYWORD,8,203,40,14,WS_GROUP
+    PUSHBUTTON      "ç·¨é›†(&E)...",IDC_BUTTON_EDITKEYWORD,50,203,40,14
+    PUSHBUTTON      "å‰Šé™¤(&D)",IDC_BUTTON_DELKEYWORD,92,203,40,14
+    CONTROL         "è‹±å¤§æ–‡å­—å°æ–‡å­—åŒºåˆ¥(&C)",IDC_CHECK_KEYWORDCASE,"Button",
                     BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,8,221,94,10
-    PUSHBUTTON      "ƒCƒ“ƒ|[ƒg(&I)...",IDC_BUTTON_IMPORT,166,220,58,14,
+    PUSHBUTTON      "ã‚¤ãƒ³ãƒãƒ¼ãƒˆ(&I)...",IDC_BUTTON_IMPORT,166,220,58,14,
                     WS_GROUP
-    PUSHBUTTON      "ƒGƒNƒXƒ|[ƒg(&X)...",IDC_BUTTON_EXPORT,227,220,58,14
-    RTEXT           "(Å‘å 100 •¶Žš   “o˜^” 9999 / 9999 ŒÂ)",
+    PUSHBUTTON      "ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ(&X)...",IDC_BUTTON_EXPORT,227,220,58,14
+    RTEXT           "(æœ€å¤§ 100 æ–‡å­—   ç™»éŒ²æ•° 9999 / 9999 å€‹)",
                     IDC_STATIC_KEYWORD_COUNT,135,205,142,8
-    PUSHBUTTON      "•ÏX(&H)",IDC_BUTTON_KEYSETRENAME,130,3,40,14
-    PUSHBUTTON      "®—(&O)",IDC_BUTTON_KEYCLEAN,104,220,45,14
+    PUSHBUTTON      "å¤‰æ›´(&H)",IDC_BUTTON_KEYSETRENAME,130,3,40,14
+    PUSHBUTTON      "æ•´ç†(&O)",IDC_BUTTON_KEYCLEAN,104,220,45,14
     PUSHBUTTON      "OK",IDOK,182,243,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,237,243,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,237,243,50,14
 END
 
 IDD_PROP_HELPER DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_3DLOOK | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     CONTROL         "&Enter",IDC_CHECK_m_bHokanKey_RETURN,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,59,15,33,10
     CONTROL         "&Tab",IDC_CHECK_m_bHokanKey_TAB,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,93,15,28,10
-    CONTROL         "¨(&R)",IDC_CHECK_m_bHokanKey_RIGHT,"Button",
+    CONTROL         "â†’(&R)",IDC_CHECK_m_bHokanKey_RIGHT,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,122,15,53,10
-    GROUPBOX        "“ü—Í•âŠ®‹@”\",IDC_STATIC,3,3,285,30,WS_GROUP
-    LTEXT           "Œó•âŒˆ’èƒL[",IDC_STATIC,7,17,45,8
-    GROUPBOX        "ŠO•”ƒwƒ‹ƒv‚ÌÝ’è(&L)",IDC_STATIC,3,37,285,32,WS_GROUP
+    GROUPBOX        "å…¥åŠ›è£œå®Œæ©Ÿèƒ½",IDC_STATIC,3,3,285,30,WS_GROUP
+    LTEXT           "å€™è£œæ±ºå®šã‚­ãƒ¼",IDC_STATIC,7,17,45,8
+    GROUPBOX        "å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ã®è¨­å®š(&L)",IDC_STATIC,3,37,285,32,WS_GROUP
     EDITTEXT        IDC_EDIT_EXTHELP1,8,50,253,12,ES_AUTOHSCROLL | WS_GROUP
     PUSHBUTTON      "(&1)...",IDC_BUTTON_OPENHELP1,264,49,19,14
-    GROUPBOX        "ŠO•”HTMLƒwƒ‹ƒv‚ÌÝ’è(&P)",IDC_STATIC,3,73,285,45,
+    GROUPBOX        "å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—ã®è¨­å®š(&P)",IDC_STATIC,3,73,285,45,
                     WS_GROUP
     EDITTEXT        IDC_EDIT_EXTHTMLHELP,8,89,253,12,ES_AUTOHSCROLL | 
                     WS_GROUP
     PUSHBUTTON      "(&2)...",IDC_BUTTON_OPENEXTHTMLHELP,264,88,19,14
-    CONTROL         "ƒrƒ…[ƒA‚ð•¡”‹N“®‚µ‚È‚¢(&N)",
+    CONTROL         "ãƒ“ãƒ¥ãƒ¼ã‚¢ã‚’è¤‡æ•°èµ·å‹•ã—ãªã„(&N)",
                     IDC_CHECK_HTMLHELPISSINGLE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,8,105,108,10
-    GROUPBOX        "ƒL[ƒ[ƒhƒwƒ‹ƒv",IDC_STATIC,3,123,285,33,WS_GROUP
+    GROUPBOX        "ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—",IDC_STATIC,3,123,285,33,WS_GROUP
     RTEXT           "Font",IDC_STATIC_KEYWORDHELPFONT,8,136,219,17,SS_RIGHT
-    PUSHBUTTON      "ƒtƒHƒ“ƒg(&F)...",IDC_BUTTON_KEYWORDHELPFONT,232,136,51,
+    PUSHBUTTON      "ãƒ•ã‚©ãƒ³ãƒˆ(&F)...",IDC_BUTTON_KEYWORDHELPFONT,232,136,51,
                     14
     LTEXT           "DLL(&M)",IDC_STATIC,7,172,26,8
     EDITTEXT        IDC_EDIT_MIGEMO_DLL,36,170,224,12,ES_AUTOHSCROLL | 
                     WS_GROUP
     PUSHBUTTON      "(&3)...",IDC_BUTTON_OPENMDLL,264,169,19,14
-    LTEXT           "Ž«‘(&I)",IDC_STATIC,7,188,25,8
+    LTEXT           "è¾žæ›¸(&I)",IDC_STATIC,7,188,25,8
     EDITTEXT        IDC_EDIT_MIGEMO_DICT,36,187,224,12,ES_AUTOHSCROLL
     PUSHBUTTON      "(&4)...",IDC_BUTTON_OPENMDICT,264,187,19,14
-    GROUPBOX        "migemoÝ’è",IDC_STATIC,3,159,285,47,WS_GROUP
+    GROUPBOX        "migemoè¨­å®š",IDC_STATIC,3,159,285,47,WS_GROUP
 END
 
 IDD_PROP_MACRO DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "ƒ}ƒNƒˆê——",IDC_STATIC,4,9,36,8
+    LTEXT           "ãƒžã‚¯ãƒ­ä¸€è¦§",IDC_STATIC,4,9,36,8
     EDITTEXT        IDC_MACRODIR,46,5,199,14,ES_AUTOHSCROLL
-    PUSHBUTTON      "ŽQÆ(&R)...",IDC_MACRODIRREF,254,5,34,14
+    PUSHBUTTON      "å‚ç…§(&R)...",IDC_MACRODIRREF,254,5,34,14
     CONTROL         "List1",IDC_MACROLIST,"SysListView32",LVS_REPORT | 
                     LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_AUTOARRANGE | 
                     LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,3,21,285,148
-    LTEXT           "–¼‘O(&N)",IDC_STATIC,6,179,32,8
+    LTEXT           "åå‰(&N)",IDC_STATIC,6,179,32,8
     EDITTEXT        IDC_MACRONAME,39,176,203,14,ES_AUTOHSCROLL
     LTEXT           "&File",IDC_STATIC,6,194,12,8
     COMBOBOX        IDC_MACROPATH,39,192,203,130,CBS_DROPDOWN | CBS_SORT | 
                     CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "ƒ}ƒNƒ‚ðŽÀs‚·‚é‚½‚Ñ‚Éƒtƒ@ƒCƒ‹‚ð“Ç‚Ýž‚Ý‚È‚¨‚·i&Lj",
+    CONTROL         "ãƒžã‚¯ãƒ­ã‚’å®Ÿè¡Œã™ã‚‹ãŸã³ã«ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã¿ãªãŠã™ï¼ˆ&Lï¼‰",
                     IDC_CHECK_RELOADWHENEXECUTE,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,6,211,175,10
-    LTEXT           "ƒLƒƒƒ“ƒZƒ‹Šm”F‘Ò‚¿ŽžŠÔ",IDC_STATIC,185,212,75,8
+    LTEXT           "ã‚­ãƒ£ãƒ³ã‚»ãƒ«ç¢ºèªå¾…ã¡æ™‚é–“",IDC_STATIC,185,212,75,8
     EDITTEXT        IDC_MACROCANCELTIMER,260,209,18,14,ES_AUTOHSCROLL
-    LTEXT           "•b",IDC_STATIC,280,212,8,8
-    LTEXT           "Ž©“®ŽÀs:",IDC_STATIC,6,225,34,8
-    CONTROL         "V‹K^ŠJƒtƒ@ƒCƒ‹Œã(&O)",IDC_CHECK_MacroOnOpened,"Button",
+    LTEXT           "ç§’",IDC_STATIC,280,212,8,8
+    LTEXT           "è‡ªå‹•å®Ÿè¡Œ:",IDC_STATIC,6,225,34,8
+    CONTROL         "æ–°è¦ï¼é–‹ãƒ•ã‚¡ã‚¤ãƒ«å¾Œ(&O)",IDC_CHECK_MacroOnOpened,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,44,224,89,10
-    CONTROL         "ƒ^ƒCƒv•ÏXŒã(&T)",IDC_CHECK_MacroOnTypeChanged,"Button",
+    CONTROL         "ã‚¿ã‚¤ãƒ—å¤‰æ›´å¾Œ(&T)",IDC_CHECK_MacroOnTypeChanged,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,135,224,72,10
-    CONTROL         "ƒtƒ@ƒCƒ‹•Û‘¶‘O(&S)",IDC_CHECK_MacroOnSave,"Button",
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«ä¿å­˜å‰(&S)",IDC_CHECK_MacroOnSave,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,212,224,69,10
     LTEXT           "Id:",IDC_STATIC,249,176,8,8
     COMBOBOX        IDC_COMBO_MACROID,260,174,28,129,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "Ý’è(&A)",IDC_MACRO_REG,250,190,38,14
+    PUSHBUTTON      "è¨­å®š(&A)",IDC_MACRO_REG,250,190,38,14
 END
 
 IDD_PROP_PLUGIN DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "ƒvƒ‰ƒOƒCƒ“‚ð—LŒø‚É‚·‚é(&E)",IDC_CHECK_PluginEnable,"Button",
+    CONTROL         "ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’æœ‰åŠ¹ã«ã™ã‚‹(&E)",IDC_CHECK_PluginEnable,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,6,9,100,10
-    PUSHBUTTON      "ZIPƒvƒ‰ƒOƒCƒ“‚ð“±“ü(&Z)", IDC_PLUGIN_INST_ZIP,192, 6, 96, 14
-    PUSHBUTTON      "ƒtƒHƒ‹ƒ_‚ðŠJ‚­(&F)",IDC_PLUGIN_OpenFolder,120,20,70,14
-    PUSHBUTTON      "V‹Kƒvƒ‰ƒOƒCƒ“‚ð’Ç‰Á(&I)",IDC_PLUGIN_SearchNew,192,20,96,14
-    LTEXT           "ƒvƒ‰ƒOƒCƒ“ˆê——",IDC_STATIC,4,28,50,8
+    PUSHBUTTON      "ZIPãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å°Žå…¥(&Z)", IDC_PLUGIN_INST_ZIP,192, 6, 96, 14
+    PUSHBUTTON      "ãƒ•ã‚©ãƒ«ãƒ€ã‚’é–‹ã(&F)",IDC_PLUGIN_OpenFolder,120,20,70,14
+    PUSHBUTTON      "æ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ (&I)",IDC_PLUGIN_SearchNew,192,20,96,14
+    LTEXT           "ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ä¸€è¦§",IDC_STATIC,4,28,50,8
     CONTROL         "List1",IDC_PLUGINLIST,"SysListView32",LVS_REPORT | 
                     LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_AUTOARRANGE | 
                     LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,3,41,285,108
-    LTEXT           "à–¾",IDC_STATIC,11,160,50,8
+    LTEXT           "èª¬æ˜Ž",IDC_STATIC,11,160,50,8
     LTEXT           "",IDC_LABEL_PLUGIN_Description,66,160,200,8
-    LTEXT           "ìŽÒ",IDC_STATIC,11,175,50,8
+    LTEXT           "ä½œè€…",IDC_STATIC,11,175,50,8
     LTEXT           "",IDC_LABEL_PLUGIN_Author,66,175,200,8
-    LTEXT           "ƒo[ƒWƒ‡ƒ“",IDC_STATIC,11,190,50,8
+    LTEXT           "ãƒãƒ¼ã‚¸ãƒ§ãƒ³",IDC_STATIC,11,190,50,8
     LTEXT           "",IDC_LABEL_PLUGIN_Version,66,190,100,8
-    PUSHBUTTON      "”z•zŒ³(&D)",IDC_PLUGIN_URL,186,187,80,14
-    PUSHBUTTON      "íœ(&R)",IDC_PLUGIN_Remove,6,205,80,14
-    PUSHBUTTON      "Ý’è(&P)",IDC_PLUGIN_OPTION,96,205,80,14
+    PUSHBUTTON      "é…å¸ƒå…ƒ(&D)",IDC_PLUGIN_URL,186,187,80,14
+    PUSHBUTTON      "å‰Šé™¤(&R)",IDC_PLUGIN_Remove,6,205,80,14
+    PUSHBUTTON      "è¨­å®š(&P)",IDC_PLUGIN_OPTION,96,205,80,14
     PUSHBUTTON      "ReadMe(&M)",IDC_PLUGIN_README,186,205,80,14
 END
 
 IDD_PROP_MAINMENU DIALOGEX 0, 0, 293, 240
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒƒCƒ“ƒƒjƒ…["
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    RTEXT           "Ží•Ê(&K)", IDC_LABEL_MENUFUNCKIND, 10, 6, 45, 8
+    RTEXT           "ç¨®åˆ¥(&K)", IDC_LABEL_MENUFUNCKIND, 10, 6, 45, 8
     COMBOBOX        IDC_COMBO_FUNCKIND, 57, 4, 70, 180,CBS_DROPDOWNLIST | 
                     CBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "‹@”\(&F)", IDC_LABEL_MENUFUNC, 4, 15, 40, 8
+    LTEXT           "æ©Ÿèƒ½(&F)", IDC_LABEL_MENUFUNC, 4, 15, 40, 8
     LISTBOX         IDC_LIST_FUNC, 4, 25, 123, 192,LBS_NOINTEGRALHEIGHT | 
                     WS_VSCROLL | WS_HSCROLL | WS_TABSTOP
-    AUTOCHECKBOX    "ƒAƒNƒZƒXƒL[‚ð•K‚¸( )•t‚Å•\Ž¦(&P)",
+    AUTOCHECKBOX    "ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã‚’å¿…ãš( )ä»˜ã§è¡¨ç¤º(&P)",
                     IDC_CHECK_KEY_PARENTHESES, 176, 4, 113, 10
-    LTEXT           "ƒƒjƒ…[(&M)", IDC_LABEL_MENU, 166, 15, 35, 8
+    LTEXT           "ãƒ¡ãƒ‹ãƒ¥ãƒ¼(&M)", IDC_LABEL_MENU, 166, 15, 35, 8
     CONTROL         "&Menu", IDC_TREE_RES, "SysTreeView32", 
                     WS_TABSTOP | WS_BORDER | TVS_HASBUTTONS | TVS_HASLINES | 
                     TVS_LINESATROOT | TVS_EDITLABELS | TVS_SHOWSELALWAYS, 
                     166, 25, 123, 192, WS_EX_ACCEPTFILES
-    PUSHBUTTON      "íœ(&D)", IDC_BUTTON_DELETE, 128, 25, 37, 14, WS_GROUP
-    PUSHBUTTON      "{(&N)", IDC_BUTTON_INSERT_NODE, 128, 44, 37, 14
+    PUSHBUTTON      "å‰Šé™¤(&D)", IDC_BUTTON_DELETE, 128, 25, 37, 14, WS_GROUP
+    PUSHBUTTON      "ï¼‹(&N)", IDC_BUTTON_INSERT_NODE, 128, 44, 37, 14
     PUSHBUTTON      "---(&S)", IDC_BUTTON_INSERTSEPARATOR, 128, 58, 37, 14
-    PUSHBUTTON      "ãË(&Q)", IDC_BUTTON_INSERT, 128, 72, 37, 14
-    PUSHBUTTON      "‰ºË(&A)", IDC_BUTTON_INSERT_A, 128, 86, 37, 14
+    PUSHBUTTON      "ä¸Šâ‡’(&Q)", IDC_BUTTON_INSERT, 128, 72, 37, 14
+    PUSHBUTTON      "ä¸‹â‡’(&A)", IDC_BUTTON_INSERT_A, 128, 86, 37, 14
     PUSHBUTTON      ">>(&B)", IDC_BUTTON_ADD, 128, 100, 37, 14
-    PUSHBUTTON      "ª(&U)", IDC_BUTTON_UP, 128, 118, 37, 14
-    PUSHBUTTON      "«(&O)", IDC_BUTTON_DOWN, 128, 132, 37, 14
-    PUSHBUTTON      "¨(&R)", IDC_BUTTON_RIGHT, 128, 146, 37, 14
-    PUSHBUTTON      "©(&L)", IDC_BUTTON_LEFT, 128, 160, 37, 14
-    PUSHBUTTON      "‘SŠJ(&H)", IDC_BUTTON_EXPAND, 128, 186, 37, 14
-    PUSHBUTTON      "‘S•Â(&Z)", IDC_BUTTON_COLLAPSE, 128, 200, 37, 14
-    PUSHBUTTON      "ƒCƒ“ƒ|[ƒg(&I)...", IDC_BUTTON_IMPORT, 4, 222, 58, 14, 
+    PUSHBUTTON      "â†‘(&U)", IDC_BUTTON_UP, 128, 118, 37, 14
+    PUSHBUTTON      "â†“(&O)", IDC_BUTTON_DOWN, 128, 132, 37, 14
+    PUSHBUTTON      "â†’(&R)", IDC_BUTTON_RIGHT, 128, 146, 37, 14
+    PUSHBUTTON      "â†(&L)", IDC_BUTTON_LEFT, 128, 160, 37, 14
+    PUSHBUTTON      "å…¨é–‹(&H)", IDC_BUTTON_EXPAND, 128, 186, 37, 14
+    PUSHBUTTON      "å…¨é–‰(&Z)", IDC_BUTTON_COLLAPSE, 128, 200, 37, 14
+    PUSHBUTTON      "ã‚¤ãƒ³ãƒãƒ¼ãƒˆ(&I)...", IDC_BUTTON_IMPORT, 4, 222, 58, 14, 
                     WS_GROUP
-    PUSHBUTTON      "ƒGƒNƒXƒ|[ƒg(&X)...", IDC_BUTTON_EXPORT, 64, 222, 58, 14
-    PUSHBUTTON      "ŒŸ¸(&T)", IDC_BUTTON_CHECK, 124, 222, 44, 14
-    PUSHBUTTON      "ƒNƒŠƒA(&C)", IDC_BUTTON_CLEAR, 196, 222, 44, 14, WS_GROUP
-    PUSHBUTTON      "‰ŠúÝ’è(&E)", IDC_BUTTON_INITIALIZE, 245, 222, 44, 14
+    PUSHBUTTON      "ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ(&X)...", IDC_BUTTON_EXPORT, 64, 222, 58, 14
+    PUSHBUTTON      "æ¤œæŸ»(&T)", IDC_BUTTON_CHECK, 124, 222, 44, 14
+    PUSHBUTTON      "ã‚¯ãƒªã‚¢(&C)", IDC_BUTTON_CLEAR, 196, 222, 44, 14, WS_GROUP
+    PUSHBUTTON      "åˆæœŸè¨­å®š(&E)", IDC_BUTTON_INITIALIZE, 245, 222, 44, 14
 END
 
 IDD_WINPOSSIZE DIALOGEX 0, 0, 177, 159
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒEƒBƒ“ƒhƒE‚ÌˆÊ’u‚Æ‘å‚«‚³"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä½ç½®ã¨å¤§ãã•"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    CONTROL         "Žw’è‚µ‚È‚¢(&D)",IDC_RADIO_WINPOS_DEF,"Button",
+    CONTROL         "æŒ‡å®šã—ãªã„(&D)",IDC_RADIO_WINPOS_DEF,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,15,19,61,10
-    CONTROL         "Œp³‚·‚é(&I)",IDC_RADIO_WINPOS_SAVE,"Button",
+    CONTROL         "ç¶™æ‰¿ã™ã‚‹(&I)",IDC_RADIO_WINPOS_SAVE,"Button",
                     BS_AUTORADIOBUTTON | WS_TABSTOP,15,32,52,10
-    CONTROL         "’¼ÚŽw’è(&S)",IDC_RADIO_WINPOS_SET,"Button",
+    CONTROL         "ç›´æŽ¥æŒ‡å®š(&S)",IDC_RADIO_WINPOS_SET,"Button",
                     BS_AUTORADIOBUTTON | WS_TABSTOP,15,45,56,10
-    LTEXT           "XÀ•W(&X)",IDC_STATIC,81,29,31,8,NOT WS_GROUP
+    LTEXT           "Xåº§æ¨™(&X)",IDC_STATIC,81,29,31,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_WX,115,25,33,14,ES_RIGHT | WS_GROUP
     CONTROL         "Spin1",IDC_SPIN_WX,"msctls_updown32",UDS_SETBUDDYINT | 
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | 
                     UDS_NOTHOUSANDS,148,25,10,14
-    LTEXT           "YÀ•W(&Y)",IDC_STATIC,81,43,31,8,NOT WS_GROUP
+    LTEXT           "Yåº§æ¨™(&Y)",IDC_STATIC,81,43,31,8,NOT WS_GROUP
     EDITTEXT        IDC_EDIT_WY,115,41,33,14,ES_RIGHT | WS_GROUP
     CONTROL         "Spin1",IDC_SPIN_WY,"msctls_updown32",UDS_SETBUDDYINT | 
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | 
                     UDS_NOTHOUSANDS,148,41,10,14
-    CONTROL         "Žw’è‚µ‚È‚¢(&E)",IDC_RADIO_WINSIZE_DEF,"Button",
+    CONTROL         "æŒ‡å®šã—ãªã„(&E)",IDC_RADIO_WINSIZE_DEF,"Button",
                     BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,15,79,60,10
-    CONTROL         "Œp³‚·‚é(&N)",IDC_RADIO_WINSIZE_SAVE,"Button",
+    CONTROL         "ç¶™æ‰¿ã™ã‚‹(&N)",IDC_RADIO_WINSIZE_SAVE,"Button",
                     BS_AUTORADIOBUTTON | WS_TABSTOP,15,91,55,10
-    CONTROL         "’¼ÚŽw’è(&T)",IDC_RADIO_WINSIZE_SET,"Button",
+    CONTROL         "ç›´æŽ¥æŒ‡å®š(&T)",IDC_RADIO_WINSIZE_SET,"Button",
                     BS_AUTORADIOBUTTON | WS_TABSTOP,15,103,56,10
     COMBOBOX        IDC_COMBO_WINTYPE,84,74,64,52,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_GROUP | WS_TABSTOP
-    LTEXT           "•(&W)",IDC_STATIC,84,94,20,8
+    LTEXT           "å¹…(&W)",IDC_STATIC,84,94,20,8
     EDITTEXT        IDC_EDIT_SX,115,91,33,14,ES_RIGHT | ES_NUMBER
     CONTROL         "Spin1",IDC_SPIN_SX,"msctls_updown32",UDS_SETBUDDYINT | 
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | 
                     UDS_NOTHOUSANDS,148,90,10,14
-    LTEXT           "‚‚³(&G)",IDC_STATIC,84,110,25,8
+    LTEXT           "é«˜ã•(&G)",IDC_STATIC,84,110,25,8
     EDITTEXT        IDC_EDIT_SY,115,108,33,14,ES_RIGHT | ES_NUMBER
     CONTROL         "Spin1",IDC_SPIN_SY,"msctls_updown32",UDS_SETBUDDYINT | 
                     UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | 
                     UDS_NOTHOUSANDS,148,108,10,14
-    DEFPUSHBUTTON   "•Â‚¶‚é(&C)",IDOK,26,138,50,14,WS_GROUP
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,110,137,54,15,WS_GROUP
-    GROUPBOX        "‹N“®Žž‚ÌˆÊ’u",IDC_STATIC,7,7,163,52
-    GROUPBOX        "‘å‚«‚³",IDC_STATIC,7,66,163,63
+    DEFPUSHBUTTON   "é–‰ã˜ã‚‹(&C)",IDOK,26,138,50,14,WS_GROUP
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,110,137,54,15,WS_GROUP
+    GROUPBOX        "èµ·å‹•æ™‚ã®ä½ç½®",IDC_STATIC,7,7,163,52
+    GROUPBOX        "å¤§ãã•",IDC_STATIC,7,66,163,63
 END
 
 IDD_PLUGIN_OPTION DIALOGEX 0, 0, 271, 255
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒvƒ‰ƒOƒCƒ“‚ÌÝ’è"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®è¨­å®š"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "ƒvƒ‰ƒOƒCƒ“‚ÌƒIƒvƒVƒ‡ƒ“‚ðÝ’è‚µ‚Ä‚­‚¾‚³‚¢", 
+    LTEXT           "ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã‚’è¨­å®šã—ã¦ãã ã•ã„", 
                     IDC_STATIC_MSG, 11, 7, 119, 8
     CONTROL         "List1", IDC_LIST_PLUGIN_OPTIONS, "SysListView32",
                     LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | 
                     LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,7,22,257,186
-    LTEXT           "’lF", IDC_STATIC, 11, 217, 21, 8
+    LTEXT           "å€¤ï¼š", IDC_STATIC, 11, 217, 21, 8
     EDITTEXT        IDC_EDIT_PLUGIN_OPTION, 36, 214, 228, 14, ES_AUTOHSCROLL
     EDITTEXT        IDC_EDIT_PLUGIN_OPTION_DIR, 36, 214, 205, 14, ES_AUTOHSCROLL
     PUSHBUTTON      "&...", IDC_BUTTON_PLUGIN_OPTION_DIR, 243, 214, 21, 14
@@ -2292,99 +2292,99 @@ BEGIN
                     CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "ReadMe(&M)", IDC_PLUGIN_README, 49, 234, 50, 14
     DEFPUSHBUTTON   "&OK", IDOK, 104, 234, 50, 14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)", IDCANCEL, 159, 234, 50, 14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)", IDC_BUTTON_HELP, 214, 234, 50, 14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)", IDCANCEL, 159, 234, 50, 14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)", IDC_BUTTON_HELP, 214, 234, 50, 14
 END
 
 IDD_PROFILEMGR DIALOGEX 0, 0, 191, 184
 STYLE DS_MODALFRAME | DS_CENTER | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒvƒƒtƒ@ƒCƒ‹ƒ}ƒl[ƒWƒƒ"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ãƒžãƒãƒ¼ã‚¸ãƒ£"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     LISTBOX         IDC_LIST_PROFILE,9,9,109,128,LBS_NOINTEGRALHEIGHT | 
                     WS_VSCROLL | WS_HSCROLL | WS_TABSTOP
-    CONTROL         "ƒfƒtƒHƒ‹ƒgÝ’è‚É‚µ‚Ä‹N“®(&E)",IDC_CHECK_PROF_DEFSTART,
+    CONTROL         "ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè¨­å®šã«ã—ã¦èµ·å‹•(&E)",IDC_CHECK_PROF_DEFSTART,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,143,150,10
-    DEFPUSHBUTTON   "‹N“®(&S)",IDOK,8,161,56,14
-    PUSHBUTTON      "•Â‚¶‚é(&X)",IDCANCEL,68,161,56,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,128,161,56,14
-    PUSHBUTTON      "V‹Kì¬(&N)",IDC_BUTTON_PROF_CREATE,125,8,61,14
-    PUSHBUTTON      "–¼‘O•ÏX(&R)",IDC_BUTTON_PROF_RENAME,125,25,61,14
-    PUSHBUTTON      "íœ(&D)",IDC_BUTTON_PROF_DELETE,125,42,61,14
-    PUSHBUTTON      "ƒfƒtƒHƒ‹ƒgÝ’è(&F)",IDC_BUTTON_PROF_DEFSET,125,62,61,14
-    PUSHBUTTON      "ƒfƒtƒHƒ‹ƒg‰ðœ(&C)",IDC_BUTTON_PROF_DEFCLEAR,125,79,61,14
+    DEFPUSHBUTTON   "èµ·å‹•(&S)",IDOK,8,161,56,14
+    PUSHBUTTON      "é–‰ã˜ã‚‹(&X)",IDCANCEL,68,161,56,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,128,161,56,14
+    PUSHBUTTON      "æ–°è¦ä½œæˆ(&N)",IDC_BUTTON_PROF_CREATE,125,8,61,14
+    PUSHBUTTON      "åå‰å¤‰æ›´(&R)",IDC_BUTTON_PROF_RENAME,125,25,61,14
+    PUSHBUTTON      "å‰Šé™¤(&D)",IDC_BUTTON_PROF_DELETE,125,42,61,14
+    PUSHBUTTON      "ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè¨­å®š(&F)",IDC_BUTTON_PROF_DEFSET,125,62,61,14
+    PUSHBUTTON      "ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè§£é™¤(&C)",IDC_BUTTON_PROF_DEFCLEAR,125,79,61,14
 END
 IDD_FILETREE DIALOGEX 0, 0, 291, 241
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒtƒ@ƒCƒ‹ƒcƒŠ[Ý’è"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼è¨­å®š"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
-    LTEXT           "Ý’èF‹¤’ÊÝ’è",IDC_STATIC_SETTFING_FROM,4,4,282,10
-    CONTROL         "ŠeƒtƒHƒ‹ƒ_‚ÌÝ’è‚ð“Ç‚Ýž‚Þ(&I)",IDC_CHECK_LOADINI,
+    LTEXT           "è¨­å®šï¼šå…±é€šè¨­å®š",IDC_STATIC_SETTFING_FROM,4,4,282,10
+    CONTROL         "å„ãƒ•ã‚©ãƒ«ãƒ€ã®è¨­å®šã‚’èª­ã¿è¾¼ã‚€(&I)",IDC_CHECK_LOADINI,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,16,120,9
-    LTEXT           "ƒfƒtƒHƒ‹ƒgÝ’èƒtƒ@ƒCƒ‹–¼(&J)",IDC_STATIC,4,28,110,8
+    LTEXT           "ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè¨­å®šãƒ•ã‚¡ã‚¤ãƒ«å(&J)",IDC_STATIC,4,28,110,8
     EDITTEXT        IDC_EDIT_DEFINI,13,39,124,13,ES_AUTOHSCROLL
     PUSHBUTTON      "...(&1)",IDC_BUTTON_REF1,137,39,17,13
-    PUSHBUTTON      "“Ç‚Ýž‚Ý(&V)",IDC_BUTTON_LOAD,108,53,47,14
+    PUSHBUTTON      "èª­ã¿è¾¼ã¿(&V)",IDC_BUTTON_LOAD,108,53,47,14
     CONTROL         "Grep(&G)",IDC_RADIO_GREP,"Button",BS_AUTORADIOBUTTON | 
                     WS_GROUP | WS_TABSTOP,6,72,56,8
-    CONTROL         "ƒtƒ@ƒCƒ‹(&F)",IDC_RADIO_FILE,"Button",BS_AUTORADIOBUTTON |
+    CONTROL         "ãƒ•ã‚¡ã‚¤ãƒ«(&F)",IDC_RADIO_FILE,"Button",BS_AUTORADIOBUTTON |
                     WS_TABSTOP,6,85,56,8
-    CONTROL         "ƒtƒHƒ‹ƒ_(&2)",IDC_RADIO_FOLDER,"Button",BS_AUTORADIOBUTTON |
+    CONTROL         "ãƒ•ã‚©ãƒ«ãƒ€(&2)",IDC_RADIO_FOLDER,"Button",BS_AUTORADIOBUTTON |
                     WS_TABSTOP,6,98,56,8
-    GROUPBOX        "Ží—Þ",IDC_STATIC,1,61,89,50,WS_GROUP
-    LTEXT           "ƒpƒX(&T)",IDC_STATIC_PATH,3,119,22,10
+    GROUPBOX        "ç¨®é¡ž",IDC_STATIC,1,61,89,50,WS_GROUP
+    LTEXT           "ãƒ‘ã‚¹(&T)",IDC_STATIC_PATH,3,119,22,10
     EDITTEXT        IDC_EDIT_PATH,38,117,122,13,ES_AUTOHSCROLL
     PUSHBUTTON      "&...",IDC_BUTTON_REF2,161,117,10,13
-    PUSHBUTTON      "¥(&3)",IDC_BUTTON_PATH_MENU,171,117,21,14
-    LTEXT           "ƒ‰ƒxƒ‹(&E)",IDC_STATIC,3,136,32,10
+    PUSHBUTTON      "â–¼(&3)",IDC_BUTTON_PATH_MENU,171,117,21,14
+    LTEXT           "ãƒ©ãƒ™ãƒ«(&E)",IDC_STATIC,3,136,32,10
     EDITTEXT        IDC_EDIT_LABEL,38,134,111,13,ES_AUTOHSCROLL
-    LTEXT           "ƒtƒ@ƒCƒ‹(&K)",IDC_STATIC_FILE,3,154,32,10
+    LTEXT           "ãƒ•ã‚¡ã‚¤ãƒ«(&K)",IDC_STATIC_FILE,3,154,32,10
     EDITTEXT        IDC_EDIT_FILE,38,151,111,13,ES_AUTOHSCROLL
-    CONTROL         "‰B‚µƒtƒ@ƒCƒ‹(&W)",IDC_CHECK_HIDDEN,"Button",
+    CONTROL         "éš ã—ãƒ•ã‚¡ã‚¤ãƒ«(&W)",IDC_CHECK_HIDDEN,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,10,181,87,8
-    CONTROL         "“Ç‚ÝŽæ‚èê—p(&Z)",IDC_CHECK_READONLY,"Button",
+    CONTROL         "èª­ã¿å–ã‚Šå°‚ç”¨(&Z)",IDC_CHECK_READONLY,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,10,193,87,8
-    CONTROL         "ƒVƒXƒeƒ€ƒtƒ@ƒCƒ‹(&S)",IDC_CHECK_SYSTEM,"Button",
+    CONTROL         "ã‚·ã‚¹ãƒ†ãƒ ãƒ•ã‚¡ã‚¤ãƒ«(&S)",IDC_CHECK_SYSTEM,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,10,205,87,8
-    GROUPBOX        "”ñ•\Ž¦‘®«",IDC_STATIC,4,169,100,51
-    PUSHBUTTON      "íœ(&4)",IDC_BUTTON_DELETE,156,17,36,14
-    PUSHBUTTON      "ãË(&Q)",IDC_BUTTON_INSERT,156,32,36,14
-    PUSHBUTTON      "‰ºË(&A)",IDC_BUTTON_INSERT_A,156,46,36,14
+    GROUPBOX        "éžè¡¨ç¤ºå±žæ€§",IDC_STATIC,4,169,100,51
+    PUSHBUTTON      "å‰Šé™¤(&4)",IDC_BUTTON_DELETE,156,17,36,14
+    PUSHBUTTON      "ä¸Šâ‡’(&Q)",IDC_BUTTON_INSERT,156,32,36,14
+    PUSHBUTTON      "ä¸‹â‡’(&A)",IDC_BUTTON_INSERT_A,156,46,36,14
     PUSHBUTTON      ">>(&B)",IDC_BUTTON_ADD,156,60,36,14
-    PUSHBUTTON      "XV(&P)",IDC_BUTTON_UPDATE,156,74,36,14
-    PUSHBUTTON      "ƒtƒ@ƒCƒ‹‘}“ü(&C)...",IDC_BUTTON_FILEADD,133,88,59,14
-    PUSHBUTTON      "ƒpƒX‚ÌˆêŠ‡’uŠ·(&N)...",IDC_BUTTON_REPLACE,111,102,81,14
-    PUSHBUTTON      "ª(&U)",IDC_BUTTON_UP,156,140,36,14
-    PUSHBUTTON      "«(&D)",IDC_BUTTON_DOWN,156,154,36,14
-    PUSHBUTTON      "¨(&R)",IDC_BUTTON_RIGHT,156,168,36,14
-    PUSHBUTTON      "©(&L)",IDC_BUTTON_LEFT,156,182,36,14
+    PUSHBUTTON      "æ›´æ–°(&P)",IDC_BUTTON_UPDATE,156,74,36,14
+    PUSHBUTTON      "ãƒ•ã‚¡ã‚¤ãƒ«æŒ¿å…¥(&C)...",IDC_BUTTON_FILEADD,133,88,59,14
+    PUSHBUTTON      "ãƒ‘ã‚¹ã®ä¸€æ‹¬ç½®æ›(&N)...",IDC_BUTTON_REPLACE,111,102,81,14
+    PUSHBUTTON      "â†‘(&U)",IDC_BUTTON_UP,156,140,36,14
+    PUSHBUTTON      "â†“(&D)",IDC_BUTTON_DOWN,156,154,36,14
+    PUSHBUTTON      "â†’(&R)",IDC_BUTTON_RIGHT,156,168,36,14
+    PUSHBUTTON      "â†(&L)",IDC_BUTTON_LEFT,156,182,36,14
     CONTROL         "",IDC_TREE_FL,"SysTreeView32",TVS_HASBUTTONS | 
                     TVS_HASLINES | TVS_LINESATROOT | TVS_SHOWSELALWAYS | 
                     WS_BORDER | WS_TABSTOP,193,17,94,202
-    PUSHBUTTON      "ƒCƒ“ƒ|[ƒg(&M)",IDC_BUTTON_IMPORT,5,225,50,14
-    PUSHBUTTON      "ƒGƒNƒXƒ|[ƒg(&Y)",IDC_BUTTON_EXPORT,59,225,50,14
+    PUSHBUTTON      "ã‚¤ãƒ³ãƒãƒ¼ãƒˆ(&M)",IDC_BUTTON_IMPORT,5,225,50,14
+    PUSHBUTTON      "ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ(&Y)",IDC_BUTTON_EXPORT,59,225,50,14
     DEFPUSHBUTTON   "&OK",IDOK,128,225,50,14
-    PUSHBUTTON      "ƒLƒƒƒ“ƒZƒ‹(&X)",IDCANCEL,183,225,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,238,225,50,14
+    PUSHBUTTON      "ã‚­ãƒ£ãƒ³ã‚»ãƒ«(&X)",IDCANCEL,183,225,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,238,225,50,14
 END
 
 IDD_WINLIST DIALOGEX 0, 0, 350, 250
 STYLE DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUP | WS_THICKFRAME |
 WS_CLIPCHILDREN | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "ƒEƒBƒ“ƒhƒEˆê——"
-FONT 9, "‚l‚r ‚oƒSƒVƒbƒN"
+CAPTION "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§"
+FONT 9, "ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯"
 BEGIN
     CONTROL         "", IDC_LIST_WINDOW, "SysListView32",
                     LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | 
                     LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,7,7,336,215
-    PUSHBUTTON      "ƒEƒBƒ“ƒhƒE‚ð•Â‚¶‚é(&C)",IDC_BUTTON_CLOSE,7,229,90,14
-    PUSHBUTTON      "ã‘‚«•Û‘¶(&S)",IDC_BUTTON_SAVE,112,229,50,14
+    PUSHBUTTON      "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹(&C)",IDC_BUTTON_CLOSE,7,229,90,14
+    PUSHBUTTON      "ä¸Šæ›¸ãä¿å­˜(&S)",IDC_BUTTON_SAVE,112,229,50,14
     DEFPUSHBUTTON   "&OK",IDOK,229,229,50,14
-    PUSHBUTTON      "ƒwƒ‹ƒv(&H)",IDC_BUTTON_HELP,286,229,50,14
+    PUSHBUTTON      "ãƒ˜ãƒ«ãƒ—(&H)",IDC_BUTTON_HELP,286,229,50,14
 END
 
 /////////////////////////////////////////////////////////////////////////////
@@ -2814,15 +2814,15 @@ BEGIN
     BEGIN
         BLOCK "041104b0"
         BEGIN
-            VALUE "Comments", "‚±‚Ìƒ\ƒtƒg‚ÍƒtƒŠ[ƒ\ƒtƒg‚Å‚·B\0"
+            VALUE "Comments", "ã“ã®ã‚½ãƒ•ãƒˆã¯ãƒ•ãƒªãƒ¼ã‚½ãƒ•ãƒˆã§ã™ã€‚\0"
             VALUE "CompanyName", "Project: Sakura-Editor\0"
-            VALUE "FileDescription", "ƒTƒNƒ‰ƒGƒfƒBƒ^\0"
+            VALUE "FileDescription", "ã‚µã‚¯ãƒ©ã‚¨ãƒ‡ã‚£ã‚¿\0"
             VALUE "FileVersion", FL_VER_STR
             VALUE "InternalName", "sakura\0"
             VALUE "LegalCopyright", S_COPYRIGHT
             VALUE "LegalTrademarks", " \0"
             VALUE "OriginalFilename", "sakura.exe\0"
-            VALUE "ProductName", "ƒTƒNƒ‰ƒGƒfƒBƒ^\0"
+            VALUE "ProductName", "ã‚µã‚¯ãƒ©ã‚¨ãƒ‡ã‚£ã‚¿\0"
             VALUE "ProductVersion", RESOURCE_VERSION_STRING(PR_VER_STR) // e.g. "2.3.2.0 (4a0de579) UNICODE 64bit DEBUG"
         END
     END
@@ -2899,1153 +2899,1153 @@ IDC_CURSOR_AUTOSCROLL_DOWN_RIGHT CURSOR DISCARDABLE "../resource/auto_scroll_dow
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_DISABLE               "-- •s–¾ --"
+    F_DISABLE               "-- ä¸æ˜Ž --"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-	F_FILE_TOPMENU			"ƒtƒ@ƒCƒ‹"
-    F_FILENEW               "V‹Kì¬"
-    F_FILENEW_NEWWINDOW		"V‹KƒEƒCƒ“ƒhƒE‚ðŠJ‚­"
-    F_FILEOPEN              "ŠJ‚­..."
-    F_FILESAVE              "ã‘‚«•Û‘¶"
-    F_FILESAVEAS_DIALOG     "–¼‘O‚ð•t‚¯‚Ä•Û‘¶..."
-    F_FILECLOSE             "•Â‚¶‚Ä(–³‘è)"
-    F_FILECLOSE_OPEN        "•Â‚¶‚ÄŠJ‚­..."
-    F_FILEOPEN_DROPDOWN     "ŠJ‚­(ƒhƒƒbƒvƒ_ƒEƒ“)..."
-    F_FILESAVECLOSE         "•Û‘¶‚µ‚Ä•Â‚¶‚é"
-    F_FILE_REOPEN_SJIS      "SJIS‚ÅŠJ‚«’¼‚·"
-	F_FILE_REOPEN_SUBMENU	"ŠJ‚«’¼‚·"
-	F_FILE_RCNTFILE_SUBMENU	"Å‹ßŽg‚Á‚½ƒtƒ@ƒCƒ‹"
-	F_FILE_RCNTFLDR_SUBMENU	"Å‹ßŽg‚Á‚½ƒtƒHƒ‹ƒ_"
+	F_FILE_TOPMENU			"ãƒ•ã‚¡ã‚¤ãƒ«"
+    F_FILENEW               "æ–°è¦ä½œæˆ"
+    F_FILENEW_NEWWINDOW		"æ–°è¦ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã"
+    F_FILEOPEN              "é–‹ã..."
+    F_FILESAVE              "ä¸Šæ›¸ãä¿å­˜"
+    F_FILESAVEAS_DIALOG     "åå‰ã‚’ä»˜ã‘ã¦ä¿å­˜..."
+    F_FILECLOSE             "é–‰ã˜ã¦(ç„¡é¡Œ)"
+    F_FILECLOSE_OPEN        "é–‰ã˜ã¦é–‹ã..."
+    F_FILEOPEN_DROPDOWN     "é–‹ã(ãƒ‰ãƒ­ãƒƒãƒ—ãƒ€ã‚¦ãƒ³)..."
+    F_FILESAVECLOSE         "ä¿å­˜ã—ã¦é–‰ã˜ã‚‹"
+    F_FILE_REOPEN_SJIS      "SJISã§é–‹ãç›´ã™"
+	F_FILE_REOPEN_SUBMENU	"é–‹ãç›´ã™"
+	F_FILE_RCNTFILE_SUBMENU	"æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚¡ã‚¤ãƒ«"
+	F_FILE_RCNTFLDR_SUBMENU	"æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚©ãƒ«ãƒ€"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_FILE_REOPEN_JIS       "JIS‚ÅŠJ‚«’¼‚·"
-    F_FILE_REOPEN_EUC       "EUC‚ÅŠJ‚«’¼‚·"
-    F_FILE_REOPEN_UNICODE   "UTF-16‚ÅŠJ‚«’¼‚·"
-    F_FILE_REOPEN_UTF8      "UTF-8‚ÅŠJ‚«’¼‚·"
-    F_FILE_REOPEN_UTF7      "UTF-7‚ÅŠJ‚«’¼‚·"
-    F_FILE_REOPEN_UNICODEBE "UTF-16BE‚ÅŠJ‚«’¼‚·"
-    F_FILE_REOPEN_CESU8     "CESU-8‚ÅŠJ‚«’¼‚·"
-    F_FILE_REOPEN_LATIN1    "Latin1‚ÅŠJ‚«’¼‚·"
-    F_FILE_REOPEN           "ŠJ‚«’¼‚·"
-    F_FILESAVEALL           "‚·‚×‚Äã‘‚«•Û‘¶"
+    F_FILE_REOPEN_JIS       "JISã§é–‹ãç›´ã™"
+    F_FILE_REOPEN_EUC       "EUCã§é–‹ãç›´ã™"
+    F_FILE_REOPEN_UNICODE   "UTF-16ã§é–‹ãç›´ã™"
+    F_FILE_REOPEN_UTF8      "UTF-8ã§é–‹ãç›´ã™"
+    F_FILE_REOPEN_UTF7      "UTF-7ã§é–‹ãç›´ã™"
+    F_FILE_REOPEN_UNICODEBE "UTF-16BEã§é–‹ãç›´ã™"
+    F_FILE_REOPEN_CESU8     "CESU-8ã§é–‹ãç›´ã™"
+    F_FILE_REOPEN_LATIN1    "Latin1ã§é–‹ãç›´ã™"
+    F_FILE_REOPEN           "é–‹ãç›´ã™"
+    F_FILESAVEALL           "ã™ã¹ã¦ä¸Šæ›¸ãä¿å­˜"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_PRINT                 "ˆóü..."
-    F_PRINT_PREVIEW         "ˆóüƒvƒŒƒrƒ…["
-    F_PRINT_PAGESETUP       "ˆóüƒy[ƒWÝ’è..."
+    F_PRINT                 "å°åˆ·..."
+    F_PRINT_PREVIEW         "å°åˆ·ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼"
+    F_PRINT_PAGESETUP       "å°åˆ·ãƒšãƒ¼ã‚¸è¨­å®š..."
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_OPEN_HfromtoC         "“¯–¼‚ÌC/C++ƒwƒbƒ_(ƒ\[ƒX)‚ðŠJ‚­"
-    F_ACTIVATE_SQLPLUS      "SQL*Plus‚ðƒAƒNƒeƒBƒu•\Ž¦"
-    F_PLSQL_COMPILE_ON_SQLPLUS "SQL*Plus‚ÅŽÀs"
+    F_OPEN_HfromtoC         "åŒåã®C/C++ãƒ˜ãƒƒãƒ€(ã‚½ãƒ¼ã‚¹)ã‚’é–‹ã"
+    F_ACTIVATE_SQLPLUS      "SQL*Plusã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–è¡¨ç¤º"
+    F_PLSQL_COMPILE_ON_SQLPLUS "SQL*Plusã§å®Ÿè¡Œ"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_BROWSE                "ƒuƒ‰ƒEƒY"
-    F_VIEWMODE              "ƒrƒ…[ƒ‚[ƒh"
-    F_PROPERTY_FILE         "ƒtƒ@ƒCƒ‹‚ÌƒvƒƒpƒeƒB"
-    F_PROFILEMGR            "ƒvƒƒtƒ@ƒCƒ‹ƒ}ƒl[ƒWƒƒ"
+    F_BROWSE                "ãƒ–ãƒ©ã‚¦ã‚º"
+    F_VIEWMODE              "ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰"
+    F_PROPERTY_FILE         "ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£"
+    F_PROFILEMGR            "ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ãƒžãƒãƒ¼ã‚¸ãƒ£"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_EXITALLEDITORS        "•ÒW‚Ì‘SI—¹"
-    F_EXITALL               "ƒTƒNƒ‰ƒGƒfƒBƒ^‚Ì‘SI—¹"
-    F_WCHAR                 "•¶Žš“ü—Í"
-    F_IME_CHAR              "‘SŠp•¶Žš“ü—Í"
+    F_EXITALLEDITORS        "ç·¨é›†ã®å…¨çµ‚äº†"
+    F_EXITALL               "ã‚µã‚¯ãƒ©ã‚¨ãƒ‡ã‚£ã‚¿ã®å…¨çµ‚äº†"
+    F_WCHAR                 "æ–‡å­—å…¥åŠ›"
+    F_IME_CHAR              "å…¨è§’æ–‡å­—å…¥åŠ›"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-	F_EDIT_TOPMENU			"•ÒW"
-    F_UNDO                  "Œ³‚É–ß‚·"
-    F_REDO                  "‚â‚è’¼‚µ"
-    F_DELETE                "íœ"
-    F_DELETE_BACK           "ƒJ[ƒ\ƒ‹‘O‚ðíœ"
+	F_EDIT_TOPMENU			"ç·¨é›†"
+    F_UNDO                  "å…ƒã«æˆ»ã™"
+    F_REDO                  "ã‚„ã‚Šç›´ã—"
+    F_DELETE                "å‰Šé™¤"
+    F_DELETE_BACK           "ã‚«ãƒ¼ã‚½ãƒ«å‰ã‚’å‰Šé™¤"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_WordDeleteToStart     "’PŒê‚Ì¶’[‚Ü‚Åíœ"
-    F_WordDeleteToEnd       "’PŒê‚Ì‰E’[‚Ü‚Åíœ"
-    F_WordCut               "’PŒêØ‚èŽæ‚è"
-    F_WordDelete            "’PŒêíœ"
+    F_WordDeleteToStart     "å˜èªžã®å·¦ç«¯ã¾ã§å‰Šé™¤"
+    F_WordDeleteToEnd       "å˜èªžã®å³ç«¯ã¾ã§å‰Šé™¤"
+    F_WordCut               "å˜èªžåˆ‡ã‚Šå–ã‚Š"
+    F_WordDelete            "å˜èªžå‰Šé™¤"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_LineCutToStart        "s“ª‚Ü‚ÅØ‚èŽæ‚è(‰üs’PˆÊ)"
-    F_LineCutToEnd          "s––‚Ü‚ÅØ‚èŽæ‚è(‰üs’PˆÊ)"
-    F_LineDeleteToStart     "s“ª‚Ü‚Åíœ(‰üs’PˆÊ)"
-    F_LineDeleteToEnd       "s––‚Ü‚Åíœ(‰üs’PˆÊ)"
-    F_CUT_LINE              "sØ‚èŽæ‚è(Ü‚è•Ô‚µ’PˆÊ)"
-    F_DELETE_LINE           "síœ(Ü‚è•Ô‚µ’PˆÊ)"
-    F_DUPLICATELINE         "s‚Ì“ñd‰»(Ü‚è•Ô‚µ’PˆÊ)"
+    F_LineCutToStart        "è¡Œé ­ã¾ã§åˆ‡ã‚Šå–ã‚Š(æ”¹è¡Œå˜ä½)"
+    F_LineCutToEnd          "è¡Œæœ«ã¾ã§åˆ‡ã‚Šå–ã‚Š(æ”¹è¡Œå˜ä½)"
+    F_LineDeleteToStart     "è¡Œé ­ã¾ã§å‰Šé™¤(æ”¹è¡Œå˜ä½)"
+    F_LineDeleteToEnd       "è¡Œæœ«ã¾ã§å‰Šé™¤(æ”¹è¡Œå˜ä½)"
+    F_CUT_LINE              "è¡Œåˆ‡ã‚Šå–ã‚Š(æŠ˜ã‚Šè¿”ã—å˜ä½)"
+    F_DELETE_LINE           "è¡Œå‰Šé™¤(æŠ˜ã‚Šè¿”ã—å˜ä½)"
+    F_DUPLICATELINE         "è¡Œã®äºŒé‡åŒ–(æŠ˜ã‚Šè¿”ã—å˜ä½)"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_INDENT_TAB            "TABƒCƒ“ƒfƒ“ƒg"
-    F_UNINDENT_TAB          "‹tTABƒCƒ“ƒfƒ“ƒg"
-    F_INDENT_SPACE          "SPACEƒCƒ“ƒfƒ“ƒg"
-    F_UNINDENT_SPACE        "‹tSPACEƒCƒ“ƒfƒ“ƒg"
+    F_INDENT_TAB            "TABã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ"
+    F_UNINDENT_TAB          "é€†TABã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ"
+    F_INDENT_SPACE          "SPACEã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ"
+    F_UNINDENT_SPACE        "é€†SPACEã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_LTRIM                 "¶(æ“ª)‚Ì‹ó”’‚ðíœ"
-    F_RTRIM                 "‰E(––”ö)‚Ì‹ó”’‚ðíœ"
-    F_SORT_ASC              "‘I‘ðs‚Ì¸‡ƒ\[ƒg"
-    F_SORT_DESC             "‘I‘ðs‚Ì~‡ƒ\[ƒg"
-    F_MERGE                 "˜A‘±‚µ‚½d•¡s‚Ìíœ(uniq)"
-    F_RECONVERT             "Ä•ÏŠ·"
+    F_LTRIM                 "å·¦(å…ˆé ­)ã®ç©ºç™½ã‚’å‰Šé™¤"
+    F_RTRIM                 "å³(æœ«å°¾)ã®ç©ºç™½ã‚’å‰Šé™¤"
+    F_SORT_ASC              "é¸æŠžè¡Œã®æ˜‡é †ã‚½ãƒ¼ãƒˆ"
+    F_SORT_DESC             "é¸æŠžè¡Œã®é™é †ã‚½ãƒ¼ãƒˆ"
+    F_MERGE                 "é€£ç¶šã—ãŸé‡è¤‡è¡Œã®å‰Šé™¤(uniq)"
+    F_RECONVERT             "å†å¤‰æ›"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_UP                    "ƒJ[ƒ\ƒ‹ãˆÚ“®"
-    F_DOWN                  "ƒJ[ƒ\ƒ‹‰ºˆÚ“®"
-    F_LEFT                  "ƒJ[ƒ\ƒ‹¶ˆÚ“®"
-    F_RIGHT                 "ƒJ[ƒ\ƒ‹‰EˆÚ“®"
-    F_UP2                   "ƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)"
-    F_DOWN2                 "ƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)"
+    F_UP                    "ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•"
+    F_DOWN                  "ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•"
+    F_LEFT                  "ã‚«ãƒ¼ã‚½ãƒ«å·¦ç§»å‹•"
+    F_RIGHT                 "ã‚«ãƒ¼ã‚½ãƒ«å³ç§»å‹•"
+    F_UP2                   "ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)"
+    F_DOWN2                 "ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_WORDLEFT              "’PŒê‚Ì¶’[‚ÉˆÚ“®"
-    F_WORDRIGHT             "’PŒê‚Ì‰E’[‚ÉˆÚ“®"
-    F_GOLINETOP             "s“ª‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)"
-    F_GOLINEEND             "s––‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)"
+    F_WORDLEFT              "å˜èªžã®å·¦ç«¯ã«ç§»å‹•"
+    F_WORDRIGHT             "å˜èªžã®å³ç«¯ã«ç§»å‹•"
+    F_GOLINETOP             "è¡Œé ­ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)"
+    F_GOLINEEND             "è¡Œæœ«ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_HalfPageUp            "”¼ƒy[ƒWƒAƒbƒv"
-    F_HalfPageDown          "”¼ƒy[ƒWƒ_ƒEƒ“"
-    F_1PageUp               "‚Pƒy[ƒWƒAƒbƒv"
-    F_1PageDown             "‚Pƒy[ƒWƒ_ƒEƒ“"
-    F_GOFILETOP             "ƒtƒ@ƒCƒ‹‚Ìæ“ª‚ÉˆÚ“®"
-    F_GOFILEEND             "ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®"
+    F_HalfPageUp            "åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—"
+    F_HalfPageDown          "åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³"
+    F_1PageUp               "ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—"
+    F_1PageDown             "ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³"
+    F_GOFILETOP             "ãƒ•ã‚¡ã‚¤ãƒ«ã®å…ˆé ­ã«ç§»å‹•"
+    F_GOFILEEND             "ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CURLINECENTER         "ƒJ[ƒ\ƒ‹s‚ðƒEƒBƒ“ƒhƒE’†‰›‚Ö"
+    F_CURLINECENTER         "ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸­å¤®ã¸"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_JUMPHIST_PREV         "ˆÚ“®—š—ð: ‘O‚Ö"
-    F_JUMPHIST_NEXT         "ˆÚ“®—š—ð: ŽŸ‚Ö"
-    F_JUMPHIST_SET          "Œ»ÝˆÊ’u‚ðˆÚ“®—š—ð‚É“o˜^"
-    F_WndScrollDown         "ƒeƒLƒXƒg‚ð‚Ps‰º‚ÖƒXƒNƒ[ƒ‹"
-    F_WndScrollUp           "ƒeƒLƒXƒg‚ð‚Psã‚ÖƒXƒNƒ[ƒ‹"
-    F_GONEXTPARAGRAPH       "ŽŸ‚Ì’i—Ž‚ÖˆÚ“®"
-    F_GOPREVPARAGRAPH       "‘O‚Ì’i—Ž‚ÖˆÚ“®"
-    F_AUTOSCROLL            "ƒI[ƒgƒXƒNƒ[ƒ‹"
-    F_WHEELUP               "ƒzƒC[ƒ‹ƒAƒbƒv"
-    F_WHEELDOWN             "ƒzƒC[ƒ‹ƒ_ƒEƒ“"
-    F_WHEELLEFT             "ƒzƒC[ƒ‹¶"
-    F_WHEELRIGHT            "ƒzƒC[ƒ‹‰E"
-    F_WHEELPAGEUP           "ƒzƒC[ƒ‹ƒy[ƒWƒAƒbƒv"
-    F_WHEELPAGEDOWN         "ƒzƒC[ƒ‹ƒy[ƒWƒ_ƒEƒ“"
-    F_WHEELPAGELEFT         "ƒzƒC[ƒ‹ƒy[ƒW¶"
-    F_WHEELPAGERIGHT        "ƒzƒC[ƒ‹ƒy[ƒW‰E"
-    F_MODIFYLINE_NEXT       "ŽŸ‚Ì•ÏXs‚Ö"
-    F_MODIFYLINE_PREV       "‘O‚Ì•ÏXs‚Ö"
+    F_JUMPHIST_PREV         "ç§»å‹•å±¥æ­´: å‰ã¸"
+    F_JUMPHIST_NEXT         "ç§»å‹•å±¥æ­´: æ¬¡ã¸"
+    F_JUMPHIST_SET          "ç¾åœ¨ä½ç½®ã‚’ç§»å‹•å±¥æ­´ã«ç™»éŒ²"
+    F_WndScrollDown         "ãƒ†ã‚­ã‚¹ãƒˆã‚’ï¼‘è¡Œä¸‹ã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«"
+    F_WndScrollUp           "ãƒ†ã‚­ã‚¹ãƒˆã‚’ï¼‘è¡Œä¸Šã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«"
+    F_GONEXTPARAGRAPH       "æ¬¡ã®æ®µè½ã¸ç§»å‹•"
+    F_GOPREVPARAGRAPH       "å‰ã®æ®µè½ã¸ç§»å‹•"
+    F_AUTOSCROLL            "ã‚ªãƒ¼ãƒˆã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«"
+    F_WHEELUP               "ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¢ãƒƒãƒ—"
+    F_WHEELDOWN             "ãƒ›ã‚¤ãƒ¼ãƒ«ãƒ€ã‚¦ãƒ³"
+    F_WHEELLEFT             "ãƒ›ã‚¤ãƒ¼ãƒ«å·¦"
+    F_WHEELRIGHT            "ãƒ›ã‚¤ãƒ¼ãƒ«å³"
+    F_WHEELPAGEUP           "ãƒ›ã‚¤ãƒ¼ãƒ«ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—"
+    F_WHEELPAGEDOWN         "ãƒ›ã‚¤ãƒ¼ãƒ«ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³"
+    F_WHEELPAGELEFT         "ãƒ›ã‚¤ãƒ¼ãƒ«ãƒšãƒ¼ã‚¸å·¦"
+    F_WHEELPAGERIGHT        "ãƒ›ã‚¤ãƒ¼ãƒ«ãƒšãƒ¼ã‚¸å³"
+    F_MODIFYLINE_NEXT       "æ¬¡ã®å¤‰æ›´è¡Œã¸"
+    F_MODIFYLINE_PREV       "å‰ã®å¤‰æ›´è¡Œã¸"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_SELECTWORD            "Œ»ÝˆÊ’u‚Ì’PŒê‘I‘ð"
-    F_SELECTALL             "‚·‚×‚Ä‘I‘ð"
-    F_SELECTLINE            "1s‘I‘ð"
-    F_BEGIN_SEL             "”ÍˆÍ‘I‘ðŠJŽn"
-    F_UP_SEL                "(‘I‘ð)ƒJ[ƒ\ƒ‹ãˆÚ“®"
-    F_DOWN_SEL              "(‘I‘ð)ƒJ[ƒ\ƒ‹‰ºˆÚ“®"
-    F_LEFT_SEL              "(‘I‘ð)ƒJ[ƒ\ƒ‹¶ˆÚ“®"
-    F_RIGHT_SEL             "(‘I‘ð)ƒJ[ƒ\ƒ‹‰EˆÚ“®"
-    F_UP2_SEL               "(‘I‘ð)ƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)"
+    F_SELECTWORD            "ç¾åœ¨ä½ç½®ã®å˜èªžé¸æŠž"
+    F_SELECTALL             "ã™ã¹ã¦é¸æŠž"
+    F_SELECTLINE            "1è¡Œé¸æŠž"
+    F_BEGIN_SEL             "ç¯„å›²é¸æŠžé–‹å§‹"
+    F_UP_SEL                "(é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•"
+    F_DOWN_SEL              "(é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•"
+    F_LEFT_SEL              "(é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«å·¦ç§»å‹•"
+    F_RIGHT_SEL             "(é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«å³ç§»å‹•"
+    F_UP2_SEL               "(é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_DOWN2_SEL             "(‘I‘ð)ƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)"
-    F_WORDLEFT_SEL          "(‘I‘ð)’PŒê‚Ì¶’[‚ÉˆÚ“®"
-    F_WORDRIGHT_SEL         "(‘I‘ð)’PŒê‚Ì‰E’[‚ÉˆÚ“®"
+    F_DOWN2_SEL             "(é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)"
+    F_WORDLEFT_SEL          "(é¸æŠž)å˜èªžã®å·¦ç«¯ã«ç§»å‹•"
+    F_WORDRIGHT_SEL         "(é¸æŠž)å˜èªžã®å³ç«¯ã«ç§»å‹•"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_GOLINETOP_SEL         "(‘I‘ð)s“ª‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)"
-    F_GOLINEEND_SEL         "(‘I‘ð)s––‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)"
-    F_HalfPageUp_Sel        "(‘I‘ð)”¼ƒy[ƒWƒAƒbƒv"
-    F_HalfPageDown_Sel      "(‘I‘ð)”¼ƒy[ƒWƒ_ƒEƒ“"
-    F_1PageUp_Sel           "(‘I‘ð)‚Pƒy[ƒWƒAƒbƒv"
-    F_1PageDown_Sel         "(‘I‘ð)‚Pƒy[ƒWƒ_ƒEƒ“"
+    F_GOLINETOP_SEL         "(é¸æŠž)è¡Œé ­ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)"
+    F_GOLINEEND_SEL         "(é¸æŠž)è¡Œæœ«ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)"
+    F_HalfPageUp_Sel        "(é¸æŠž)åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—"
+    F_HalfPageDown_Sel      "(é¸æŠž)åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³"
+    F_1PageUp_Sel           "(é¸æŠž)ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—"
+    F_1PageDown_Sel         "(é¸æŠž)ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_GOFILETOP_SEL         "(‘I‘ð)ƒtƒ@ƒCƒ‹‚Ìæ“ª‚ÉˆÚ“®"
-    F_GOFILEEND_SEL         "(‘I‘ð)ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®"
+    F_GOFILETOP_SEL         "(é¸æŠž)ãƒ•ã‚¡ã‚¤ãƒ«ã®å…ˆé ­ã«ç§»å‹•"
+    F_GOFILEEND_SEL         "(é¸æŠž)ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_GONEXTPARAGRAPH_SEL   "(‘I‘ð)ŽŸ‚Ì’i—Ž‚ÖˆÚ“®"
-    F_GOPREVPARAGRAPH_SEL   "(‘I‘ð)‘O‚Ì’i—Ž‚ÖˆÚ“®"
-    F_MODIFYLINE_NEXT_SEL   "(‘I‘ð)ŽŸ‚Ì•ÏXs‚Ö"
-    F_MODIFYLINE_PREV_SEL   "(‘I‘ð)‘O‚Ì•ÏXs‚Ö"
+    F_GONEXTPARAGRAPH_SEL   "(é¸æŠž)æ¬¡ã®æ®µè½ã¸ç§»å‹•"
+    F_GOPREVPARAGRAPH_SEL   "(é¸æŠž)å‰ã®æ®µè½ã¸ç§»å‹•"
+    F_MODIFYLINE_NEXT_SEL   "(é¸æŠž)æ¬¡ã®å¤‰æ›´è¡Œã¸"
+    F_MODIFYLINE_PREV_SEL   "(é¸æŠž)å‰ã®å¤‰æ›´è¡Œã¸"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_BEGIN_BOX             "‹éŒ`”ÍˆÍ‘I‘ðŠJŽn"
-    F_UP_BOX                "(‹éŒ`‘I‘ð)ƒJ[ƒ\ƒ‹ãˆÚ“®"
-    F_DOWN_BOX              "(‹éŒ`‘I‘ð)ƒJ[ƒ\ƒ‹‰ºˆÚ“®"
-    F_LEFT_BOX              "(‹éŒ`‘I‘ð)ƒJ[ƒ\ƒ‹¶ˆÚ“®"
-    F_RIGHT_BOX             "(‹éŒ`‘I‘ð)ƒJ[ƒ\ƒ‹‰EˆÚ“®"
-    F_UP2_BOX               "(‹éŒ`‘I‘ð)ƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)"
-    F_DOWN2_BOX             "(‹éŒ`‘I‘ð)ƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)"
-    F_WORDLEFT_BOX          "(‹éŒ`‘I‘ð)’PŒê‚Ì¶’[‚ÉˆÚ“®"
-    F_WORDRIGHT_BOX         "(‹éŒ`‘I‘ð)’PŒê‚Ì‰E’[‚ÉˆÚ“®"
-    F_GOLOGICALLINETOP_BOX  "(‹éŒ`‘I‘ð)s“ª‚ÉˆÚ“®(‰üs’PˆÊ)"
-    F_GOLINETOP_BOX         "(‹éŒ`‘I‘ð)s“ª‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)"
-    F_GOLINEEND_BOX         "(‹éŒ`‘I‘ð)s––‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)"
-    F_HalfPageUp_BOX        "(‹éŒ`‘I‘ð)”¼ƒy[ƒWƒAƒbƒv"
-    F_HalfPageDown_BOX      "(‹éŒ`‘I‘ð)”¼ƒy[ƒWƒ_ƒEƒ“"
-    F_1PageUp_BOX           "(‹éŒ`‘I‘ð)‚Pƒy[ƒWƒAƒbƒv"
-    F_1PageDown_BOX         "(‹éŒ`‘I‘ð)‚Pƒy[ƒWƒ_ƒEƒ“"
-    F_GOFILETOP_BOX         "(‹éŒ`‘I‘ð)ƒtƒ@ƒCƒ‹‚Ìæ“ª‚ÉˆÚ“®"
-    F_GOFILEEND_BOX         "(‹éŒ`‘I‘ð)ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®"
+    F_BEGIN_BOX             "çŸ©å½¢ç¯„å›²é¸æŠžé–‹å§‹"
+    F_UP_BOX                "(çŸ©å½¢é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•"
+    F_DOWN_BOX              "(çŸ©å½¢é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•"
+    F_LEFT_BOX              "(çŸ©å½¢é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«å·¦ç§»å‹•"
+    F_RIGHT_BOX             "(çŸ©å½¢é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«å³ç§»å‹•"
+    F_UP2_BOX               "(çŸ©å½¢é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)"
+    F_DOWN2_BOX             "(çŸ©å½¢é¸æŠž)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)"
+    F_WORDLEFT_BOX          "(çŸ©å½¢é¸æŠž)å˜èªžã®å·¦ç«¯ã«ç§»å‹•"
+    F_WORDRIGHT_BOX         "(çŸ©å½¢é¸æŠž)å˜èªžã®å³ç«¯ã«ç§»å‹•"
+    F_GOLOGICALLINETOP_BOX  "(çŸ©å½¢é¸æŠž)è¡Œé ­ã«ç§»å‹•(æ”¹è¡Œå˜ä½)"
+    F_GOLINETOP_BOX         "(çŸ©å½¢é¸æŠž)è¡Œé ­ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)"
+    F_GOLINEEND_BOX         "(çŸ©å½¢é¸æŠž)è¡Œæœ«ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)"
+    F_HalfPageUp_BOX        "(çŸ©å½¢é¸æŠž)åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—"
+    F_HalfPageDown_BOX      "(çŸ©å½¢é¸æŠž)åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³"
+    F_1PageUp_BOX           "(çŸ©å½¢é¸æŠž)ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—"
+    F_1PageDown_BOX         "(çŸ©å½¢é¸æŠž)ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³"
+    F_GOFILETOP_BOX         "(çŸ©å½¢é¸æŠž)ãƒ•ã‚¡ã‚¤ãƒ«ã®å…ˆé ­ã«ç§»å‹•"
+    F_GOFILEEND_BOX         "(çŸ©å½¢é¸æŠž)ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CUT                   "Ø‚èŽæ‚è"
-    F_COPY                  "ƒRƒs["
-    F_COPY_CRLF             "CRLF‰üs‚ÅƒRƒs["
-    F_PASTE                 "“\‚è•t‚¯"
-    F_PASTEBOX              "‹éŒ`“\‚è•t‚¯"
-    F_INSTEXT_W             "ƒeƒLƒXƒg‚ð“\‚è•t‚¯"
-	F_EDIT_INS_SUBMENU		"‘}“ü"
-	F_EDIT_HLV_SUBMENU		"‚“x‚È‘€ì"
-	F_EDIT_MOV_SUBMENU		"ˆÚ“®"
-	F_EDIT_SEL_SUBMENU		"‘I‘ð"
-	F_EDIT_BOX_SEL_SUBMENU	"‹éŒ`‘I‘ð"
-	F_EDIT_COS_SUBMENU		"®Œ`"
+    F_CUT                   "åˆ‡ã‚Šå–ã‚Š"
+    F_COPY                  "ã‚³ãƒ”ãƒ¼"
+    F_COPY_CRLF             "CRLFæ”¹è¡Œã§ã‚³ãƒ”ãƒ¼"
+    F_PASTE                 "è²¼ã‚Šä»˜ã‘"
+    F_PASTEBOX              "çŸ©å½¢è²¼ã‚Šä»˜ã‘"
+    F_INSTEXT_W             "ãƒ†ã‚­ã‚¹ãƒˆã‚’è²¼ã‚Šä»˜ã‘"
+	F_EDIT_INS_SUBMENU		"æŒ¿å…¥"
+	F_EDIT_HLV_SUBMENU		"é«˜åº¦ãªæ“ä½œ"
+	F_EDIT_MOV_SUBMENU		"ç§»å‹•"
+	F_EDIT_SEL_SUBMENU		"é¸æŠž"
+	F_EDIT_BOX_SEL_SUBMENU	"çŸ©å½¢é¸æŠž"
+	F_EDIT_COS_SUBMENU		"æ•´å½¢"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_COPY_ADDCRLF          "Ü‚è•Ô‚µˆÊ’u‚É‰üs‚ð‚Â‚¯‚ÄƒRƒs["
-    F_COPYLINES             "‘I‘ð”ÍˆÍ“à‘SsƒRƒs["
-    F_COPYLINESASPASSAGE    "‘I‘ð”ÍˆÍ“à‘Ssˆø—p•„•t‚«ƒRƒs["
-    F_COPYLINESWITHLINENUMBER "‘I‘ð”ÍˆÍ“à‘Sss”Ô†•t‚«ƒRƒs["
-    F_COPY_COLOR_HTML       "‘I‘ð”ÍˆÍ“àF•t‚«HTMLƒRƒs["
-    F_COPY_COLOR_HTML_LINENUMBER "‘I‘ð”ÍˆÍ“às”Ô†F•t‚«HTMLƒRƒs["
-    F_COPYPATH              "‚±‚Ìƒtƒ@ƒCƒ‹‚ÌƒpƒX–¼‚ðƒRƒs["
-    F_COPYTAG               "‚±‚Ìƒtƒ@ƒCƒ‹‚ÌƒpƒX–¼‚ÆƒJ[ƒ\ƒ‹ˆÊ’u‚ðƒRƒs["
-    F_COPYFNAME             "‚±‚Ìƒtƒ@ƒCƒ‹–¼‚ðƒRƒs["
+    F_COPY_ADDCRLF          "æŠ˜ã‚Šè¿”ã—ä½ç½®ã«æ”¹è¡Œã‚’ã¤ã‘ã¦ã‚³ãƒ”ãƒ¼"
+    F_COPYLINES             "é¸æŠžç¯„å›²å†…å…¨è¡Œã‚³ãƒ”ãƒ¼"
+    F_COPYLINESASPASSAGE    "é¸æŠžç¯„å›²å†…å…¨è¡Œå¼•ç”¨ç¬¦ä»˜ãã‚³ãƒ”ãƒ¼"
+    F_COPYLINESWITHLINENUMBER "é¸æŠžç¯„å›²å†…å…¨è¡Œè¡Œç•ªå·ä»˜ãã‚³ãƒ”ãƒ¼"
+    F_COPY_COLOR_HTML       "é¸æŠžç¯„å›²å†…è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼"
+    F_COPY_COLOR_HTML_LINENUMBER "é¸æŠžç¯„å›²å†…è¡Œç•ªå·è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼"
+    F_COPYPATH              "ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹åã‚’ã‚³ãƒ”ãƒ¼"
+    F_COPYTAG               "ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹åã¨ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’ã‚³ãƒ”ãƒ¼"
+    F_COPYFNAME             "ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ã‚³ãƒ”ãƒ¼"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CREATEKEYBINDLIST     "ƒL[Š„‚è“–‚Äˆê——‚ðƒRƒs["
+    F_CREATEKEYBINDLIST     "ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ä¸€è¦§ã‚’ã‚³ãƒ”ãƒ¼"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_INS_DATE              "“ú•t‘}“ü"
-    F_INS_TIME              "Žž‘}“ü"
-    F_CTRL_CODE_DIALOG      "ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh“ü—Í..."
+    F_INS_DATE              "æ—¥ä»˜æŒ¿å…¥"
+    F_INS_TIME              "æ™‚åˆ»æŒ¿å…¥"
+    F_CTRL_CODE_DIALOG      "ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰å…¥åŠ›..."
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CONVERT_TOPMENU		"•ÏŠ·"
-    F_TOLOWER               "¬•¶Žš"
-    F_TOUPPER               "‘å•¶Žš"
-    F_TOHANKAKU             "‘SŠp¨”¼Šp"
-    F_TOZENKAKUKATA         "”¼Šp{‘S‚Ð‚ç¨‘SŠpEƒJƒ^ƒJƒi"
-    F_TOZENKAKUHIRA         "”¼Šp{‘SƒJƒ^¨‘SŠpE‚Ð‚ç‚ª‚È"
-    F_HANKATATOZENKATA      "”¼ŠpƒJƒ^ƒJƒi¨‘SŠpƒJƒ^ƒJƒi"
-    F_HANKATATOZENHIRA      "”¼ŠpƒJƒ^ƒJƒi¨‘SŠp‚Ð‚ç‚ª‚È"
-    F_TOZENEI               "”¼Šp‰p”¨‘SŠp‰p”"
+    F_CONVERT_TOPMENU		"å¤‰æ›"
+    F_TOLOWER               "å°æ–‡å­—"
+    F_TOUPPER               "å¤§æ–‡å­—"
+    F_TOHANKAKU             "å…¨è§’â†’åŠè§’"
+    F_TOZENKAKUKATA         "åŠè§’ï¼‹å…¨ã²ã‚‰â†’å…¨è§’ãƒ»ã‚«ã‚¿ã‚«ãƒŠ"
+    F_TOZENKAKUHIRA         "åŠè§’ï¼‹å…¨ã‚«ã‚¿â†’å…¨è§’ãƒ»ã²ã‚‰ãŒãª"
+    F_HANKATATOZENKATA      "åŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã‚«ã‚¿ã‚«ãƒŠ"
+    F_HANKATATOZENHIRA      "åŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã²ã‚‰ãŒãª"
+    F_TOZENEI               "åŠè§’è‹±æ•°â†’å…¨è§’è‹±æ•°"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_TOHANEI               "‘SŠp‰p”¨”¼Šp‰p”"
-    F_TOHANKATA             "‘SŠpƒJƒ^ƒJƒi¨”¼ŠpƒJƒ^ƒJƒi"
-    F_TABTOSPACE            "TAB¨‹ó”’"
-    F_SPACETOTAB            "‹ó”’¨TAB"
-	F_CONV_ENCODE_SUBMENU	"•¶ŽšƒR[ƒh•ÏŠ·"
+    F_TOHANEI               "å…¨è§’è‹±æ•°â†’åŠè§’è‹±æ•°"
+    F_TOHANKATA             "å…¨è§’ã‚«ã‚¿ã‚«ãƒŠâ†’åŠè§’ã‚«ã‚¿ã‚«ãƒŠ"
+    F_TABTOSPACE            "TABâ†’ç©ºç™½"
+    F_SPACETOTAB            "ç©ºç™½â†’TAB"
+	F_CONV_ENCODE_SUBMENU	"æ–‡å­—ã‚³ãƒ¼ãƒ‰å¤‰æ›"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CODECNV_AUTO2SJIS     "Ž©“®”»•Ê¨SJISƒR[ƒh•ÏŠ·"
-    F_CODECNV_EMAIL         "E-Mail(JIS¨SJIS)ƒR[ƒh•ÏŠ·"
-    F_CODECNV_EUC2SJIS      "EUC¨SJISƒR[ƒh•ÏŠ·"
-    F_CODECNV_UNICODE2SJIS  "UTF-16¨SJISƒR[ƒh•ÏŠ·"
-    F_CODECNV_UTF82SJIS     "UTF-8¨SJISƒR[ƒh•ÏŠ·"
-    F_CODECNV_UTF72SJIS     "UTF-7¨SJISƒR[ƒh•ÏŠ·"
-    F_CODECNV_UNICODEBE2SJIS "UTF-16BE¨SJISƒR[ƒh•ÏŠ·"
-    F_CODECNV_SJIS2JIS      "SJIS¨JISƒR[ƒh•ÏŠ·"
-    F_CODECNV_SJIS2EUC      "SJIS¨EUCƒR[ƒh•ÏŠ·"
-    F_CODECNV_SJIS2UTF8     "SJIS¨UTF-8ƒR[ƒh•ÏŠ·"
-    F_CODECNV_SJIS2UTF7     "SJIS¨UTF-7ƒR[ƒh•ÏŠ·"
+    F_CODECNV_AUTO2SJIS     "è‡ªå‹•åˆ¤åˆ¥â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_EMAIL         "E-Mail(JISâ†’SJIS)ã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_EUC2SJIS      "EUCâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_UNICODE2SJIS  "UTF-16â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_UTF82SJIS     "UTF-8â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_UTF72SJIS     "UTF-7â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_UNICODEBE2SJIS "UTF-16BEâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_SJIS2JIS      "SJISâ†’JISã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_SJIS2EUC      "SJISâ†’EUCã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_SJIS2UTF8     "SJISâ†’UTF-8ã‚³ãƒ¼ãƒ‰å¤‰æ›"
+    F_CODECNV_SJIS2UTF7     "SJISâ†’UTF-7ã‚³ãƒ¼ãƒ‰å¤‰æ›"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_BASE64DECODE          "Base64ƒfƒR[ƒh‚µ‚Ä•Û‘¶"
+    F_BASE64DECODE          "Base64ãƒ‡ã‚³ãƒ¼ãƒ‰ã—ã¦ä¿å­˜"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_UUDECODE              "uudecode‚µ‚Ä•Û‘¶"
+    F_UUDECODE              "uudecodeã—ã¦ä¿å­˜"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_SEARCH_TOPMENU		"ŒŸõ"
-    F_SEARCH_DIALOG         "ŒŸõ..."
-    F_SEARCH_NEXT           "ŽŸ‚ðŒŸõ"
-    F_SEARCH_PREV           "‘O‚ðŒŸõ"
-    F_REPLACE_DIALOG        "’uŠ·..."
-    F_SEARCH_CLEARMARK      "ŒŸõƒ}[ƒN‚ÌØ‘Ö‚¦"
-    F_REPLACE               "’uŠ·"
-    F_REPLACE_ALL           "‚·‚×‚Ä’uŠ·"
-    F_SEARCH_BOX            "ŒŸõ (ƒ{ƒbƒNƒX)"
-    F_JUMP_SRCHSTARTPOS     "ŒŸõŠJŽnˆÊ’u‚Ö–ß‚é"
+    F_SEARCH_TOPMENU		"æ¤œç´¢"
+    F_SEARCH_DIALOG         "æ¤œç´¢..."
+    F_SEARCH_NEXT           "æ¬¡ã‚’æ¤œç´¢"
+    F_SEARCH_PREV           "å‰ã‚’æ¤œç´¢"
+    F_REPLACE_DIALOG        "ç½®æ›..."
+    F_SEARCH_CLEARMARK      "æ¤œç´¢ãƒžãƒ¼ã‚¯ã®åˆ‡æ›¿ãˆ"
+    F_REPLACE               "ç½®æ›"
+    F_REPLACE_ALL           "ã™ã¹ã¦ç½®æ›"
+    F_SEARCH_BOX            "æ¤œç´¢ (ãƒœãƒƒã‚¯ã‚¹)"
+    F_JUMP_SRCHSTARTPOS     "æ¤œç´¢é–‹å§‹ä½ç½®ã¸æˆ»ã‚‹"
     F_GREP_DIALOG           "Grep..."
     F_GREP                  "Grep"
-    F_GREP_REPLACE_DLG      "Grep’uŠ·..."
-    F_GREP_REPLACE          "Grep’uŠ·"
+    F_GREP_REPLACE_DLG      "Grepç½®æ›..."
+    F_GREP_REPLACE          "Grepç½®æ›"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_JUMP_DIALOG           "Žw’ès‚ÖƒWƒƒƒ“ƒv..."
-    F_JUMP                  "Žw’ès‚ÖƒWƒƒƒ“ƒv"
+    F_JUMP_DIALOG           "æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—..."
+    F_JUMP                  "æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_OUTLINE               "ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ..."
-    F_OUTLINE_TOGGLE        "ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ(ƒgƒOƒ‹)..."
-    F_TAGJUMP               "ƒ^ƒOƒWƒƒƒ“ƒv"
-    F_TAGJUMPBACK           "ƒ^ƒOƒWƒƒƒ“ƒvƒoƒbƒN"
-    F_TAGS_MAKE             "ƒ^ƒOƒtƒ@ƒCƒ‹‚Ìì¬..."
+    F_OUTLINE               "ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æž..."
+    F_OUTLINE_TOGGLE        "ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æž(ãƒˆã‚°ãƒ«)..."
+    F_TAGJUMP               "ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—"
+    F_TAGJUMPBACK           "ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒãƒƒã‚¯"
+    F_TAGS_MAKE             "ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆ..."
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_DIRECT_TAGJUMP        "ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv"
-    F_TAGJUMP_CLOSE         "•Â‚¶‚Äƒ^ƒOƒWƒƒƒ“ƒv"
-    F_TAGJUMP_KEYWORD       "ƒL[ƒ[ƒh‚ðŽw’è‚µ‚Äƒ^ƒOƒWƒƒƒ“ƒv..."
-    F_COMPARE               "ƒtƒ@ƒCƒ‹“à—e”äŠr..."
+    F_DIRECT_TAGJUMP        "ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—"
+    F_TAGJUMP_CLOSE         "é–‰ã˜ã¦ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—"
+    F_TAGJUMP_KEYWORD       "ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’æŒ‡å®šã—ã¦ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—..."
+    F_COMPARE               "ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒ..."
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_BRACKETPAIR           "‘ÎŠ‡ŒÊ‚ÌŒŸõ"
-    F_BOOKMARK_SET          "ƒuƒbƒNƒ}[ƒNÝ’èE‰ðœ"
-    F_BOOKMARK_NEXT         "ŽŸ‚ÌƒuƒbƒNƒ}[ƒN‚Ö"
-    F_BOOKMARK_PATTERN      "ŠY“–sƒ}[ƒN"
-    F_BOOKMARK_PREV         "‘O‚ÌƒuƒbƒNƒ}[ƒN‚Ö"
-    F_BOOKMARK_RESET        "ƒuƒbƒNƒ}[ƒN‚Ì‘S‰ðœ"
-    F_BOOKMARK_VIEW         "ƒuƒbƒNƒ}[ƒN‚Ìˆê——..."
+    F_BRACKETPAIR           "å¯¾æ‹¬å¼§ã®æ¤œç´¢"
+    F_BOOKMARK_SET          "ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯è¨­å®šãƒ»è§£é™¤"
+    F_BOOKMARK_NEXT         "æ¬¡ã®ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯ã¸"
+    F_BOOKMARK_PATTERN      "è©²å½“è¡Œãƒžãƒ¼ã‚¯"
+    F_BOOKMARK_PREV         "å‰ã®ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯ã¸"
+    F_BOOKMARK_RESET        "ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯ã®å…¨è§£é™¤"
+    F_BOOKMARK_VIEW         "ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯ã®ä¸€è¦§..."
 
-    F_BOOKMARK_SUBMENU      "ƒuƒbƒNƒ}[ƒN"
+    F_BOOKMARK_SUBMENU      "ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_DIFF_DIALOG           "DIFF·•ª•\Ž¦..."
-    F_DIFF                  "DIFF·•ª•\Ž¦"
-    F_DIFF_NEXT             "ŽŸ‚Ì·•ª‚Ö"
-    F_DIFF_PREV             "‘O‚Ì·•ª‚Ö"
-    F_DIFF_RESET            "·•ª•\Ž¦‚Ì‘S‰ðœ"
-    F_ISEARCH_NEXT          "‘O•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`"
-    F_ISEARCH_PREV          "Œã•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`"
-    F_ISEARCH_REGEXP_NEXT   "³‹K•\Œ»‘O•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`"
-    F_ISEARCH_REGEXP_PREV   "³‹K•\Œ»Œã•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`"
-    F_ISEARCH_MIGEMO_NEXT   "MIGEMO‘O•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`"
-    F_ISEARCH_MIGEMO_PREV   "MIGEMOŒã•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`"
-    F_FUNCLIST_NEXT         "ŽŸ‚ÌŠÖ”ƒŠƒXƒgƒ}[ƒN"
-    F_FUNCLIST_PREV         "‘O‚ÌŠÖ”ƒŠƒXƒgƒ}[ƒN"
-    F_FILETREE              "ƒtƒ@ƒCƒ‹ƒcƒŠ["
+    F_DIFF_DIALOG           "DIFFå·®åˆ†è¡¨ç¤º..."
+    F_DIFF                  "DIFFå·®åˆ†è¡¨ç¤º"
+    F_DIFF_NEXT             "æ¬¡ã®å·®åˆ†ã¸"
+    F_DIFF_PREV             "å‰ã®å·®åˆ†ã¸"
+    F_DIFF_RESET            "å·®åˆ†è¡¨ç¤ºã®å…¨è§£é™¤"
+    F_ISEARCH_NEXT          "å‰æ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ"
+    F_ISEARCH_PREV          "å¾Œæ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ"
+    F_ISEARCH_REGEXP_NEXT   "æ­£è¦è¡¨ç¾å‰æ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ"
+    F_ISEARCH_REGEXP_PREV   "æ­£è¦è¡¨ç¾å¾Œæ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ"
+    F_ISEARCH_MIGEMO_NEXT   "MIGEMOå‰æ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ"
+    F_ISEARCH_MIGEMO_PREV   "MIGEMOå¾Œæ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ"
+    F_FUNCLIST_NEXT         "æ¬¡ã®é–¢æ•°ãƒªã‚¹ãƒˆãƒžãƒ¼ã‚¯"
+    F_FUNCLIST_PREV         "å‰ã®é–¢æ•°ãƒªã‚¹ãƒˆãƒžãƒ¼ã‚¯"
+    F_FILETREE              "ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼"
 
-    F_ISEARCH_SUBMENU       "ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`"
+    F_ISEARCH_SUBMENU       "ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_OPTION_TOPMENU        "Ý’è"
-    F_CHGMOD_INS            "‘}“ü^ã‘‚«ƒ‚[ƒhØ‚è‘Ö‚¦"
-    F_CHG_CHARSET           "•¶ŽšƒR[ƒhƒZƒbƒgŽw’è..."
+    F_OPTION_TOPMENU        "è¨­å®š"
+    F_CHGMOD_INS            "æŒ¿å…¥ï¼ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰åˆ‡ã‚Šæ›¿ãˆ"
+    F_CHG_CHARSET           "æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆæŒ‡å®š..."
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CHGMOD_EOL_CRLF       "“ü—Í‰üsƒR[ƒhŽw’è(CRLF)"
-    F_CHGMOD_EOL_LF         "“ü—Í‰üsƒR[ƒhŽw’è(LF)"
-    F_CHGMOD_EOL_CR         "“ü—Í‰üsƒR[ƒhŽw’è(CR)"
-	F_CHGMOD_EOL_SUBMENU	"“ü—Í‰üsƒR[ƒhŽw’è"
+    F_CHGMOD_EOL_CRLF       "å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š(CRLF)"
+    F_CHGMOD_EOL_LF         "å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š(LF)"
+    F_CHGMOD_EOL_CR         "å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š(CR)"
+	F_CHGMOD_EOL_SUBMENU	"å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CANCEL_MODE           "ŠeŽíƒ‚[ƒh‚ÌŽæ‚èÁ‚µ"
-    F_SHOWTOOLBAR           "ƒc[ƒ‹ƒo[‚Ì•\Ž¦^”ñ•\Ž¦"
-    F_SHOWFUNCKEY           "ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚Ì•\Ž¦^”ñ•\Ž¦"
-    F_SHOWSTATUSBAR         "ƒXƒe[ƒ^ƒXƒo[‚Ì•\Ž¦^”ñ•\Ž¦"
-    F_SHOWTAB               "ƒ^ƒuƒo[‚Ì•\Ž¦^”ñ•\Ž¦"
-    F_SHOWMINIMAP           "ƒ~ƒjƒ}ƒbƒv‚Ì•\Ž¦^”ñ•\Ž¦"
+    F_CANCEL_MODE           "å„ç¨®ãƒ¢ãƒ¼ãƒ‰ã®å–ã‚Šæ¶ˆã—"
+    F_SHOWTOOLBAR           "ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã®è¡¨ç¤ºï¼éžè¡¨ç¤º"
+    F_SHOWFUNCKEY           "ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®è¡¨ç¤ºï¼éžè¡¨ç¤º"
+    F_SHOWSTATUSBAR         "ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã®è¡¨ç¤ºï¼éžè¡¨ç¤º"
+    F_SHOWTAB               "ã‚¿ãƒ–ãƒãƒ¼ã®è¡¨ç¤ºï¼éžè¡¨ç¤º"
+    F_SHOWMINIMAP           "ãƒŸãƒ‹ãƒžãƒƒãƒ—ã®è¡¨ç¤ºï¼éžè¡¨ç¤º"
 
-	F_SHOWTOOLBAR_ON		"ƒc[ƒ‹ƒo[‚ð•\Ž¦"
-	F_SHOWFUNCKEY_ON		"ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ð•\Ž¦"
-	F_SHOWTAB_ON			"ƒ^ƒuƒo[‚ð•\Ž¦"
-	F_SHOWSTATUSBAR_ON		"ƒXƒe[ƒ^ƒXƒo[‚ð•\Ž¦"
-    F_SHOWMINIMAP_ON        "ƒ~ƒjƒ}ƒbƒv‚ð•\Ž¦"
+	F_SHOWTOOLBAR_ON		"ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã‚’è¡¨ç¤º"
+	F_SHOWFUNCKEY_ON		"ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚’è¡¨ç¤º"
+	F_SHOWTAB_ON			"ã‚¿ãƒ–ãƒãƒ¼ã‚’è¡¨ç¤º"
+	F_SHOWSTATUSBAR_ON		"ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã‚’è¡¨ç¤º"
+    F_SHOWMINIMAP_ON        "ãƒŸãƒ‹ãƒžãƒƒãƒ—ã‚’è¡¨ç¤º"
 
-	F_SHOWTOOLBAR_OFF		"•\Ž¦’†‚Ìƒc[ƒ‹ƒo[‚ð‰B‚·"
-	F_SHOWFUNCKEY_OFF		"•\Ž¦’†‚Ìƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ð‰B‚·"
-	F_SHOWTAB_OFF			"•\Ž¦’†‚Ìƒ^ƒuƒo[‚ð‰B‚·"
-	F_SHOWSTATUSBAR_OFF		"•\Ž¦’†‚ÌƒXƒe[ƒ^ƒXƒo[‚ð‰B‚·"
-    F_SHOWMINIMAP_OFF       "•\Ž¦’†‚Ìƒ~ƒjƒ}ƒbƒv‚ð‰B‚·"
+	F_SHOWTOOLBAR_OFF		"è¡¨ç¤ºä¸­ã®ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã‚’éš ã™"
+	F_SHOWFUNCKEY_OFF		"è¡¨ç¤ºä¸­ã®ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚’éš ã™"
+	F_SHOWTAB_OFF			"è¡¨ç¤ºä¸­ã®ã‚¿ãƒ–ãƒãƒ¼ã‚’éš ã™"
+	F_SHOWSTATUSBAR_OFF		"è¡¨ç¤ºä¸­ã®ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã‚’éš ã™"
+    F_SHOWMINIMAP_OFF       "è¡¨ç¤ºä¸­ã®ãƒŸãƒ‹ãƒžãƒƒãƒ—ã‚’éš ã™"
 
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_TYPE_LIST             "ƒ^ƒCƒv•ÊÝ’èˆê——..."
-    F_OPTION_TYPE           "ƒ^ƒCƒv•ÊÝ’è..."
-    F_OPTION                "‹¤’ÊÝ’è..."
-    F_FAVORITE              "—š—ð‚ÌŠÇ—..."
+    F_TYPE_LIST             "ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šä¸€è¦§..."
+    F_OPTION_TYPE           "ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š..."
+    F_OPTION                "å…±é€šè¨­å®š..."
+    F_FAVORITE              "å±¥æ­´ã®ç®¡ç†..."
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_FONT                  "ƒtƒHƒ“ƒgÝ’è..."
-    F_SETFONTSIZE           "ƒtƒHƒ“ƒgƒTƒCƒYÝ’è"
-    F_SETFONTSIZEUP         "ƒtƒHƒ“ƒgƒTƒCƒYŠg‘å"
-    F_SETFONTSIZEDOWN       "ƒtƒHƒ“ƒgƒTƒCƒYk¬"
+    F_FONT                  "ãƒ•ã‚©ãƒ³ãƒˆè¨­å®š..."
+    F_SETFONTSIZE           "ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºè¨­å®š"
+    F_SETFONTSIZEUP         "ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºæ‹¡å¤§"
+    F_SETFONTSIZEDOWN       "ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºç¸®å°"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_WRAPWINDOWWIDTH       "Ü‚è•Ô‚µŒ…”"
-    F_TMPWRAPNOWRAP         "Ü‚è•Ô‚³‚È‚¢"
-    F_TMPWRAPSETTING        "Žw’èŒ…‚ÅÜ‚è•Ô‚·"
-    F_TMPWRAPWINDOW         "‰E’[‚ÅÜ‚è•Ô‚·"
-    F_SELECT_COUNT_MODE     "•¶ŽšƒJƒEƒ“ƒg•û–@"
+    F_WRAPWINDOWWIDTH       "æŠ˜ã‚Šè¿”ã—æ¡æ•°"
+    F_TMPWRAPNOWRAP         "æŠ˜ã‚Šè¿”ã•ãªã„"
+    F_TMPWRAPSETTING        "æŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™"
+    F_TMPWRAPWINDOW         "å³ç«¯ã§æŠ˜ã‚Šè¿”ã™"
+    F_SELECT_COUNT_MODE     "æ–‡å­—ã‚«ã‚¦ãƒ³ãƒˆæ–¹æ³•"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_TOOL_TOPMENU          "ƒc[ƒ‹"
-    F_RECKEYMACRO           "ƒL[ƒ}ƒNƒ‚Ì‹L˜^ŠJŽn^I—¹"
-    F_SAVEKEYMACRO          "ƒL[ƒ}ƒNƒ‚Ì•Û‘¶"
-    F_LOADKEYMACRO          "ƒL[ƒ}ƒNƒ‚Ì“Ç‚Ýž‚Ý"
-    F_EXECKEYMACRO          "ƒL[ƒ}ƒNƒ‚ÌŽÀs"
+    F_TOOL_TOPMENU          "ãƒ„ãƒ¼ãƒ«"
+    F_RECKEYMACRO           "ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²é–‹å§‹ï¼çµ‚äº†"
+    F_SAVEKEYMACRO          "ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®ä¿å­˜"
+    F_LOADKEYMACRO          "ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿"
+    F_EXECKEYMACRO          "ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®å®Ÿè¡Œ"
 
-    F_EXECEXTMACRO          "–¼‘O‚ðŽw’è‚µ‚Äƒ}ƒNƒŽÀs..."
+    F_EXECEXTMACRO          "åå‰ã‚’æŒ‡å®šã—ã¦ãƒžã‚¯ãƒ­å®Ÿè¡Œ..."
 
-    F_RECKEYMACRO_REC		"ƒL[ƒ}ƒNƒ‚Ì‹L˜^ŠJŽn"
-    F_SAVEKEYMACRO_REC		"ƒL[ƒ}ƒNƒ‚Ì•Û‘¶"
-    F_LOADKEYMACRO_REC		"ƒL[ƒ}ƒNƒ‚Ì“Ç‚Ýž‚Ý"
-    F_EXECKEYMACRO_REC		"ƒL[ƒ}ƒNƒ‚ÌŽÀs"
+    F_RECKEYMACRO_REC		"ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²é–‹å§‹"
+    F_SAVEKEYMACRO_REC		"ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®ä¿å­˜"
+    F_LOADKEYMACRO_REC		"ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿"
+    F_EXECKEYMACRO_REC		"ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®å®Ÿè¡Œ"
 
-    F_RECKEYMACRO_APPE		"ƒL[ƒ}ƒNƒ‚Ì‹L˜^I—¹"
-    F_SAVEKEYMACRO_APPE		"ƒL[ƒ}ƒNƒ‚Ì‹L˜^I—¹&&•Û‘¶"
-    F_LOADKEYMACRO_APPE		"ƒL[ƒ}ƒNƒ‚Ì‹L˜^I—¹&&“Ç‚Ýž‚Ý"
-    F_EXECKEYMACRO_APPE		"ƒL[ƒ}ƒNƒ‚Ì‹L˜^I—¹&&ŽÀs"
+    F_RECKEYMACRO_APPE		"ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²çµ‚äº†"
+    F_SAVEKEYMACRO_APPE		"ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²çµ‚äº†&&ä¿å­˜"
+    F_LOADKEYMACRO_APPE		"ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²çµ‚äº†&&èª­ã¿è¾¼ã¿"
+    F_EXECKEYMACRO_APPE		"ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²çµ‚äº†&&å®Ÿè¡Œ"
     
-	F_EXECKEYMACRO_REGD		"“o˜^Ï‚Ýƒ}ƒNƒ"
-	F_TOOL_CUSTOM_SUBMENU	"ƒJƒXƒ^ƒ€ƒƒjƒ…["
+	F_EXECKEYMACRO_REGD		"ç™»éŒ²æ¸ˆã¿ãƒžã‚¯ãƒ­"
+	F_TOOL_CUSTOM_SUBMENU	"ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_EXECMD_DIALOG         "ŠO•”ƒRƒ}ƒ“ƒhŽÀs..."
-    F_EXECMD                "ŠO•”ƒRƒ}ƒ“ƒhŽÀs"
+    F_EXECMD_DIALOG         "å¤–éƒ¨ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œ..."
+    F_EXECMD                "å¤–éƒ¨ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œ"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_WINDOW_TOPMENU        "ƒEƒBƒ“ƒhƒE"
-    F_SPLIT_V               "ã‰º‚É•ªŠ„^•ªŠ„‰ðœ"
-    F_SPLIT_V_ON            "ã‰º‚É•ªŠ„"
-    F_SPLIT_V_OFF           "ã‰º•ªŠ„‚Ì‰ðœ"
-    F_SPLIT_H               "¶‰E‚É•ªŠ„^•ªŠ„‰ðœ"
-    F_SPLIT_H_ON            "¶‰E‚É•ªŠ„"
-    F_SPLIT_H_OFF           "¶‰E•ªŠ„‚Ì‰ðœ"
+    F_WINDOW_TOPMENU        "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦"
+    F_SPLIT_V               "ä¸Šä¸‹ã«åˆ†å‰²ï¼åˆ†å‰²è§£é™¤"
+    F_SPLIT_V_ON            "ä¸Šä¸‹ã«åˆ†å‰²"
+    F_SPLIT_V_OFF           "ä¸Šä¸‹åˆ†å‰²ã®è§£é™¤"
+    F_SPLIT_H               "å·¦å³ã«åˆ†å‰²ï¼åˆ†å‰²è§£é™¤"
+    F_SPLIT_H_ON            "å·¦å³ã«åˆ†å‰²"
+    F_SPLIT_H_OFF           "å·¦å³åˆ†å‰²ã®è§£é™¤"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_SPLIT_VH              "c‰¡‚É•ªŠ„^•ªŠ„‰ðœ"
-	F_SPLIT_VH_ON           "c‰¡‚É•ªŠ„"
-	F_SPLIT_VH_OFF          "c‰¡•ªŠ„‚Ì‰ðœ"
+    F_SPLIT_VH              "ç¸¦æ¨ªã«åˆ†å‰²ï¼åˆ†å‰²è§£é™¤"
+	F_SPLIT_VH_ON           "ç¸¦æ¨ªã«åˆ†å‰²"
+	F_SPLIT_VH_OFF          "ç¸¦æ¨ªåˆ†å‰²ã®è§£é™¤"
 
-    F_WINCLOSE              "•Â‚¶‚é"
-    F_WIN_CLOSEALL          "‚·‚×‚Ä•Â‚¶‚é"
-    F_TAB_CLOSEOTHER        "‚±‚Ìƒ^ƒu^ƒEƒBƒ“ƒhƒEˆÈŠO‚ð•Â‚¶‚é"
-	F_TAB_CLOSEOTHER_TAB	"‚±‚Ìƒ^ƒuˆÈŠO‚ð•Â‚¶‚é"
-	F_TAB_CLOSEOTHER_WINDOW	"‚±‚ÌƒEƒBƒ“ƒhƒEˆÈŠO‚ð•Â‚¶‚é"
+    F_WINCLOSE              "é–‰ã˜ã‚‹"
+    F_WIN_CLOSEALL          "ã™ã¹ã¦é–‰ã˜ã‚‹"
+    F_TAB_CLOSEOTHER        "ã“ã®ã‚¿ãƒ–ï¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä»¥å¤–ã‚’é–‰ã˜ã‚‹"
+	F_TAB_CLOSEOTHER_TAB	"ã“ã®ã‚¿ãƒ–ä»¥å¤–ã‚’é–‰ã˜ã‚‹"
+	F_TAB_CLOSEOTHER_WINDOW	"ã“ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä»¥å¤–ã‚’é–‰ã˜ã‚‹"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CASCADE               "d‚Ë‚Ä•\Ž¦"
-    F_TILE_V                "ã‰º‚É•À‚×‚Ä•\Ž¦"
-    F_TILE_H                "¶‰E‚É•À‚×‚Ä•\Ž¦"
-    F_BIND_WINDOW           "ƒOƒ‹[ƒv‰»"
-    F_TOPMOST               "í‚ÉŽè‘O‚É•\Ž¦"
-	F_TOPMOST_REL			"í‚ÉŽè‘O‚ð‰ðœ"
-	F_TOPMOST_SET			"í‚ÉŽè‘O‚É•\Ž¦"
-    F_WINLIST               "ƒEƒBƒ“ƒhƒEˆê——..."
-    F_DLGWINLIST            "ƒEƒBƒ“ƒhƒEˆê——•\Ž¦..."
-    F_NEXTWINDOW            "ŽŸ‚ÌƒEƒBƒ“ƒhƒE"
-    F_PREVWINDOW            "‘O‚ÌƒEƒBƒ“ƒhƒE"
-    F_WINDOW_LIST_SUBMENU   "ƒEƒBƒ“ƒhƒEˆê——"
+    F_CASCADE               "é‡ã­ã¦è¡¨ç¤º"
+    F_TILE_V                "ä¸Šä¸‹ã«ä¸¦ã¹ã¦è¡¨ç¤º"
+    F_TILE_H                "å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º"
+    F_BIND_WINDOW           "ã‚°ãƒ«ãƒ¼ãƒ—åŒ–"
+    F_TOPMOST               "å¸¸ã«æ‰‹å‰ã«è¡¨ç¤º"
+	F_TOPMOST_REL			"å¸¸ã«æ‰‹å‰ã‚’è§£é™¤"
+	F_TOPMOST_SET			"å¸¸ã«æ‰‹å‰ã«è¡¨ç¤º"
+    F_WINLIST               "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§..."
+    F_DLGWINLIST            "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§è¡¨ç¤º..."
+    F_NEXTWINDOW            "æ¬¡ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦"
+    F_PREVWINDOW            "å‰ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦"
+    F_WINDOW_LIST_SUBMENU   "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_MAXIMIZE_V            "c•ûŒü‚ÉÅ‘å‰»"
-    F_MINIMIZE_ALL          "‚·‚×‚ÄÅ¬‰»"
-    F_MAXIMIZE_H            "‰¡•ûŒü‚ÉÅ‘å‰»"
+    F_MAXIMIZE_V            "ç¸¦æ–¹å‘ã«æœ€å¤§åŒ–"
+    F_MINIMIZE_ALL          "ã™ã¹ã¦æœ€å°åŒ–"
+    F_MAXIMIZE_H            "æ¨ªæ–¹å‘ã«æœ€å¤§åŒ–"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_REDRAW                "Ä•`‰æ"
-    F_WIN_OUTPUT            "ƒAƒEƒgƒvƒbƒg"
+    F_REDRAW                "å†æç”»"
+    F_WIN_OUTPUT            "ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆ"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_GROUPCLOSE            "ƒOƒ‹[ƒv‚ð•Â‚¶‚é"
-    F_NEXTGROUP             "ŽŸ‚ÌƒOƒ‹[ƒv"
-    F_PREVGROUP             "‘O‚ÌƒOƒ‹[ƒv"
-    F_TAB_MOVERIGHT         "ƒ^ƒu‚ð‰E‚ÉˆÚ“®"
-    F_TAB_MOVELEFT          "ƒ^ƒu‚ð¶‚ÉˆÚ“®"
-    F_TAB_SEPARATE          "V‹KƒOƒ‹[ƒv"
-    F_TAB_JOINTNEXT         "ŽŸ‚ÌƒOƒ‹[ƒv‚ÉˆÚ“®"
-    F_TAB_JOINTPREV         "‘O‚ÌƒOƒ‹[ƒv‚ÉˆÚ“®"
-    F_TAB_MANIP_SUBMENU     "ƒ^ƒu‚Ì‘€ì"
-	F_TAB_GROUPDEL			"ƒOƒ‹[ƒv‰»‚ð‰ðœ"			// LMP -- added
-	F_TAB_GROUPIZE			"ƒOƒ‹[ƒv‰»"				// LMP -- added
-    F_TAB_CLOSELEFT         "¶‚ð‚·‚×‚Ä•Â‚¶‚é"
-    F_TAB_CLOSERIGHT        "‰E‚ð‚·‚×‚Ä•Â‚¶‚é"
+    F_GROUPCLOSE            "ã‚°ãƒ«ãƒ¼ãƒ—ã‚’é–‰ã˜ã‚‹"
+    F_NEXTGROUP             "æ¬¡ã®ã‚°ãƒ«ãƒ¼ãƒ—"
+    F_PREVGROUP             "å‰ã®ã‚°ãƒ«ãƒ¼ãƒ—"
+    F_TAB_MOVERIGHT         "ã‚¿ãƒ–ã‚’å³ã«ç§»å‹•"
+    F_TAB_MOVELEFT          "ã‚¿ãƒ–ã‚’å·¦ã«ç§»å‹•"
+    F_TAB_SEPARATE          "æ–°è¦ã‚°ãƒ«ãƒ¼ãƒ—"
+    F_TAB_JOINTNEXT         "æ¬¡ã®ã‚°ãƒ«ãƒ¼ãƒ—ã«ç§»å‹•"
+    F_TAB_JOINTPREV         "å‰ã®ã‚°ãƒ«ãƒ¼ãƒ—ã«ç§»å‹•"
+    F_TAB_MANIP_SUBMENU     "ã‚¿ãƒ–ã®æ“ä½œ"
+	F_TAB_GROUPDEL			"ã‚°ãƒ«ãƒ¼ãƒ—åŒ–ã‚’è§£é™¤"			// LMP -- added
+	F_TAB_GROUPIZE			"ã‚°ãƒ«ãƒ¼ãƒ—åŒ–"				// LMP -- added
+    F_TAB_CLOSELEFT         "å·¦ã‚’ã™ã¹ã¦é–‰ã˜ã‚‹"
+    F_TAB_CLOSERIGHT        "å³ã‚’ã™ã¹ã¦é–‰ã˜ã‚‹"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_HOKAN                 "“ü—Í•âŠ®"
-    F_TOGGLE_KEY_SEARCH     "ƒL[ƒ[ƒhƒwƒ‹ƒvŽ©“®•\Ž¦"
-    F_TOGGLE_KEY_SEARCH_ON  "ƒL[ƒ[ƒhƒwƒ‹ƒvŽ©“®•\Ž¦‚·‚é"
-    F_TOGGLE_KEY_SEARCH_OFF "ƒL[ƒ[ƒhƒwƒ‹ƒvŽ©“®•\Ž¦‚µ‚È‚¢"
+    F_HOKAN                 "å…¥åŠ›è£œå®Œ"
+    F_TOGGLE_KEY_SEARCH     "ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—è‡ªå‹•è¡¨ç¤º"
+    F_TOGGLE_KEY_SEARCH_ON  "ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—è‡ªå‹•è¡¨ç¤ºã™ã‚‹"
+    F_TOGGLE_KEY_SEARCH_OFF "ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—è‡ªå‹•è¡¨ç¤ºã—ãªã„"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_HELP_TOPMENU          "ƒwƒ‹ƒv"
-    F_HELP_CONTENTS         "ƒwƒ‹ƒv–ÚŽŸ"
-    F_HELP_SEARCH           "ƒwƒ‹ƒvƒL[ƒ[ƒhŒŸõ"
-    F_MENU_ALLFUNC          "ƒRƒ}ƒ“ƒhˆê——"
-    F_EXTHELP1              "ŠO•”ƒwƒ‹ƒv‚P"
-    F_EXTHTMLHELP           "ŠO•”HTMLƒwƒ‹ƒv"
-    F_ABOUT                 "ƒo[ƒWƒ‡ƒ“î•ñ"
+    F_HELP_TOPMENU          "ãƒ˜ãƒ«ãƒ—"
+    F_HELP_CONTENTS         "ãƒ˜ãƒ«ãƒ—ç›®æ¬¡"
+    F_HELP_SEARCH           "ãƒ˜ãƒ«ãƒ—ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æ¤œç´¢"
+    F_MENU_ALLFUNC          "ã‚³ãƒžãƒ³ãƒ‰ä¸€è¦§"
+    F_EXTHELP1              "å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘"
+    F_EXTHTMLHELP           "å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—"
+    F_ABOUT                 "ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_MENU_RBUTTON          "‰EƒNƒŠƒbƒNƒƒjƒ…["
+    F_MENU_RBUTTON          "å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CUSTMENU_1            "ƒJƒXƒ^ƒ€ƒƒjƒ…[1"
-    F_CUSTMENU_2            "ƒJƒXƒ^ƒ€ƒƒjƒ…[2"
-    F_CUSTMENU_3            "ƒJƒXƒ^ƒ€ƒƒjƒ…[3"
+    F_CUSTMENU_1            "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼1"
+    F_CUSTMENU_2            "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼2"
+    F_CUSTMENU_3            "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼3"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CUSTMENU_4            "ƒJƒXƒ^ƒ€ƒƒjƒ…[4"
-    F_CUSTMENU_5            "ƒJƒXƒ^ƒ€ƒƒjƒ…[5"
-    F_CUSTMENU_6            "ƒJƒXƒ^ƒ€ƒƒjƒ…[6"
-    F_CUSTMENU_7            "ƒJƒXƒ^ƒ€ƒƒjƒ…[7"
-    F_CUSTMENU_8            "ƒJƒXƒ^ƒ€ƒƒjƒ…[8"
-    F_CUSTMENU_9            "ƒJƒXƒ^ƒ€ƒƒjƒ…[9"
-    F_CUSTMENU_10           "ƒJƒXƒ^ƒ€ƒƒjƒ…[10"
-    F_CUSTMENU_11           "ƒJƒXƒ^ƒ€ƒƒjƒ…[11"
-    F_CUSTMENU_12           "ƒJƒXƒ^ƒ€ƒƒjƒ…[12"
-    F_CUSTMENU_13           "ƒJƒXƒ^ƒ€ƒƒjƒ…[13"
-    F_CUSTMENU_14           "ƒJƒXƒ^ƒ€ƒƒjƒ…[14"
-    F_CUSTMENU_15           "ƒJƒXƒ^ƒ€ƒƒjƒ…[15"
-    F_CUSTMENU_16           "ƒJƒXƒ^ƒ€ƒƒjƒ…[16"
-    F_CUSTMENU_17           "ƒJƒXƒ^ƒ€ƒƒjƒ…[17"
-    F_CUSTMENU_18           "ƒJƒXƒ^ƒ€ƒƒjƒ…[18"
-    F_CUSTMENU_19           "ƒJƒXƒ^ƒ€ƒƒjƒ…[19"
+    F_CUSTMENU_4            "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼4"
+    F_CUSTMENU_5            "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼5"
+    F_CUSTMENU_6            "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼6"
+    F_CUSTMENU_7            "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼7"
+    F_CUSTMENU_8            "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼8"
+    F_CUSTMENU_9            "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼9"
+    F_CUSTMENU_10           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼10"
+    F_CUSTMENU_11           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼11"
+    F_CUSTMENU_12           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼12"
+    F_CUSTMENU_13           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼13"
+    F_CUSTMENU_14           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼14"
+    F_CUSTMENU_15           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼15"
+    F_CUSTMENU_16           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼16"
+    F_CUSTMENU_17           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼17"
+    F_CUSTMENU_18           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼18"
+    F_CUSTMENU_19           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼19"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CUSTMENU_20           "ƒJƒXƒ^ƒ€ƒƒjƒ…[20"
-    F_CUSTMENU_21           "ƒJƒXƒ^ƒ€ƒƒjƒ…[21"
-    F_CUSTMENU_22           "ƒJƒXƒ^ƒ€ƒƒjƒ…[22"
-    F_CUSTMENU_23           "ƒJƒXƒ^ƒ€ƒƒjƒ…[23"
-    F_CUSTMENU_24           "ƒ^ƒuƒƒjƒ…["
+    F_CUSTMENU_20           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼20"
+    F_CUSTMENU_21           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼21"
+    F_CUSTMENU_22           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼22"
+    F_CUSTMENU_23           "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼23"
+    F_CUSTMENU_24           "ã‚¿ãƒ–ãƒ¡ãƒ‹ãƒ¥ãƒ¼"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_MENU_NOT_USED_FIRST   "\\ƒc[ƒ‹ƒo[Ü•Ô\\"
+    F_MENU_NOT_USED_FIRST   "â€•â€•ãƒ„ãƒ¼ãƒ«ãƒãƒ¼æŠ˜è¿”â€•â€•"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CHGMOD_EOL            "“ü—Í‰üsƒR[ƒhŽw’è"
-    F_TEXTWRAPMETHOD        "Ü‚è•Ô‚µ•û–@"
+    F_CHGMOD_EOL            "å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š"
+    F_TEXTWRAPMETHOD        "æŠ˜ã‚Šè¿”ã—æ–¹æ³•"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_WINDOW_LIST           "ƒEƒBƒ“ƒhƒEƒŠƒXƒg"
-    F_FILE_USED_RECENTLY    "Å‹ßŽg‚Á‚½ƒtƒ@ƒCƒ‹"
-    F_FOLDER_USED_RECENTLY  "Å‹ßŽg‚Á‚½ƒtƒHƒ‹ƒ_"
-    F_CUSTMENU_LIST         "ƒJƒXƒ^ƒ€ƒƒjƒ…[ƒŠƒXƒg"
-    F_USERMACRO_LIST        "“o˜^Ï‚Ýƒ}ƒNƒƒŠƒXƒg"
-    F_PLUGIN_LIST           "ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒhƒŠƒXƒg"
+    F_WINDOW_LIST           "ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆ"
+    F_FILE_USED_RECENTLY    "æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚¡ã‚¤ãƒ«"
+    F_FOLDER_USED_RECENTLY  "æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚©ãƒ«ãƒ€"
+    F_CUSTMENU_LIST         "ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒªã‚¹ãƒˆ"
+    F_USERMACRO_LIST        "ç™»éŒ²æ¸ˆã¿ãƒžã‚¯ãƒ­ãƒªã‚¹ãƒˆ"
+    F_PLUGIN_LIST           "ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒžãƒ³ãƒ‰ãƒªã‚¹ãƒˆ"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
     IDS_AUTHOR_PAGE         "https://sakura-editor.github.io/"
-    IDS_ABOUT_DESCRIPTION   "‚±‚Ìƒ\ƒtƒgƒEƒFƒA‚ÍuƒeƒLƒXƒgƒGƒfƒBƒ^(‹¤“¯ŠJ”­”Å)v‚ð‰üÌ‚µ‚½‚à‚Ì‚Å‚·D\r\n¤—pE”ñ¤—p‚ð–â‚í‚¸–³ž‚Å—˜—p‚Å‚«‚Ü‚·‚ªCƒ\[ƒXƒR[ƒh‚Ì’˜ìŒ ‚ÍŠe‰ÓŠ‚ð‹Lq‚µ‚½l‚ª—¯•Û‚µ‚Ä‚¢‚Ü‚·D\r\n‚±‚Ìƒ\ƒtƒgƒEƒFƒA‚Í–³•ÛØ‚Å‚·D\r\n"
+    IDS_ABOUT_DESCRIPTION   "ã“ã®ã‚½ãƒ•ãƒˆã‚¦ã‚§ã‚¢ã¯ã€Œãƒ†ã‚­ã‚¹ãƒˆã‚¨ãƒ‡ã‚£ã‚¿(å…±åŒé–‹ç™ºç‰ˆ)ã€ã‚’æ”¹ç§°ã—ãŸã‚‚ã®ã§ã™ï¼Ž\r\nå•†ç”¨ãƒ»éžå•†ç”¨ã‚’å•ã‚ãšç„¡å„Ÿã§åˆ©ç”¨ã§ãã¾ã™ãŒï¼Œã‚½ãƒ¼ã‚¹ã‚³ãƒ¼ãƒ‰ã®è‘—ä½œæ¨©ã¯å„ç®‡æ‰€ã‚’è¨˜è¿°ã—ãŸäººãŒç•™ä¿ã—ã¦ã„ã¾ã™ï¼Ž\r\nã“ã®ã‚½ãƒ•ãƒˆã‚¦ã‚§ã‚¢ã¯ç„¡ä¿è¨¼ã§ã™ï¼Ž\r\n"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-	STR_SQLERR_EXEC_BUT_NOT_RUN	"Oracle SQL*Plus‚ÅŽÀs‚µ‚Ü‚·B\n\n\nOracle SQL*Plus‚ª‹N“®‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB\n"
-	STR_SQLERR_ACTV_BUT_NOT_RUN	"Oracle SQL*Plus‚ðƒAƒNƒeƒBƒu•\Ž¦‚µ‚Ü‚·B\n\n\nOracle SQL*Plus‚ª‹N“®‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB\n"
-	STR_ERR_CMPERR				"”äŠræ‚Ìƒtƒ@ƒCƒ‹\n%ts\n%dƒoƒCƒg‚ð’´‚¦‚és‚ª‚ ‚è‚Ü‚·B\n”äŠr‚Å‚«‚Ü‚¹‚ñB"
+	STR_SQLERR_EXEC_BUT_NOT_RUN	"Oracle SQL*Plusã§å®Ÿè¡Œã—ã¾ã™ã€‚\n\n\nOracle SQL*PlusãŒèµ·å‹•ã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚\n"
+	STR_SQLERR_ACTV_BUT_NOT_RUN	"Oracle SQL*Plusã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–è¡¨ç¤ºã—ã¾ã™ã€‚\n\n\nOracle SQL*PlusãŒèµ·å‹•ã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚\n"
+	STR_ERR_CMPERR				"æ¯”è¼ƒå…ˆã®ãƒ•ã‚¡ã‚¤ãƒ«\n%ts\n%dãƒã‚¤ãƒˆã‚’è¶…ãˆã‚‹è¡ŒãŒã‚ã‚Šã¾ã™ã€‚\næ¯”è¼ƒã§ãã¾ã›ã‚“ã€‚"
 
-	STR_NO_TITLE1				"(–³‘è)"
-	STR_NO_TITLE2				"–³‘è"
-	STR_PREVIEW_ONLY			"(ˆóüƒvƒŒƒrƒ…[‚Å‚Ì‚ÝŽg—p‚Å‚«‚Ü‚·)"
-	STR_NOT_SAVED				"(•Û‘¶‚³‚ê‚Ä‚¢‚Ü‚¹‚ñ)"
-	STR_MAXWINDOW				"•ÒWƒEƒBƒ“ƒhƒE”‚ÌãŒÀ‚Í%d‚Å‚·B\n‚±‚êˆÈã‚Í“¯Žž‚ÉŠJ‚¯‚Ü‚¹‚ñB"
+	STR_NO_TITLE1				"(ç„¡é¡Œ)"
+	STR_NO_TITLE2				"ç„¡é¡Œ"
+	STR_PREVIEW_ONLY			"(å°åˆ·ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼ã§ã®ã¿ä½¿ç”¨ã§ãã¾ã™)"
+	STR_NOT_SAVED				"(ä¿å­˜ã•ã‚Œã¦ã„ã¾ã›ã‚“)"
+	STR_MAXWINDOW				"ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦æ•°ã®ä¸Šé™ã¯%dã§ã™ã€‚\nã“ã‚Œä»¥ä¸Šã¯åŒæ™‚ã«é–‹ã‘ã¾ã›ã‚“ã€‚"
 
 	// CCommandLine.cpp - cant map properly	
-	STR_CMDLINE_PARSECMD1		"%ls\r\nã‹L‚Ìƒtƒ@ƒCƒ‹–¼‚Í•s³‚Å‚·Bƒtƒ@ƒCƒ‹–¼‚É \\ / : * ? "" < > | ‚Ì•¶Žš‚ÍŽg‚¦‚Ü‚¹‚ñB "
+	STR_CMDLINE_PARSECMD1		"%ls\r\nä¸Šè¨˜ã®ãƒ•ã‚¡ã‚¤ãƒ«åã¯ä¸æ­£ã§ã™ã€‚ãƒ•ã‚¡ã‚¤ãƒ«åã« \\ / : * ? "" < > | ã®æ–‡å­—ã¯ä½¿ãˆã¾ã›ã‚“ã€‚ "
 
 	// CControlProcess.cpp
-	STR_ERR_CTRLMTX1			"CreateMutex()Ž¸”sB\nI—¹‚µ‚Ü‚·B"
-	STR_ERR_CTRLMTX2			"CreateEvent()Ž¸”sB\nI—¹‚µ‚Ü‚·B"
-	STR_ERR_CTRLMTX3			"ƒEƒBƒ“ƒhƒE‚Ìì¬‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\n‹N“®‚Å‚«‚Ü‚¹‚ñB"
-	STR_ERR_CTRLMTX4			"SetEvent()Ž¸”sB\nI—¹‚µ‚Ü‚·B"
+	STR_ERR_CTRLMTX1			"CreateMutex()å¤±æ•—ã€‚\nçµ‚äº†ã—ã¾ã™ã€‚"
+	STR_ERR_CTRLMTX2			"CreateEvent()å¤±æ•—ã€‚\nçµ‚äº†ã—ã¾ã™ã€‚"
+	STR_ERR_CTRLMTX3			"ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä½œæˆã«å¤±æ•—ã—ã¾ã—ãŸã€‚\nèµ·å‹•ã§ãã¾ã›ã‚“ã€‚"
+	STR_ERR_CTRLMTX4			"SetEvent()å¤±æ•—ã€‚\nçµ‚äº†ã—ã¾ã™ã€‚"
 	
 	// CDlgCtrlCode.cpp
-	STR_DLGCTRLCODE_CODE		"ƒR[ƒh"
-	STR_DLGCTRLCODE_SYMBOL		"•\‹L"
-	STR_DLGCTRLCODE_NAME		"–¼‘O"
-	STR_DLGCTRLCODE_DESC		"à–¾"
+	STR_DLGCTRLCODE_CODE		"ã‚³ãƒ¼ãƒ‰"
+	STR_DLGCTRLCODE_SYMBOL		"è¡¨è¨˜"
+	STR_DLGCTRLCODE_NAME		"åå‰"
+	STR_DLGCTRLCODE_DESC		"èª¬æ˜Ž"
 
-	STR_ERR_DLGCTL5				"‹ó•¶Žš"			// Codes for p_ctrl_list
-	STR_ERR_DLGCTL6				"ƒwƒbƒ_ŠJŽn"   
-	STR_ERR_DLGCTL7				"ƒeƒLƒXƒgŠJŽn" 
-	STR_ERR_DLGCTL8				"ƒeƒLƒXƒgI—¹" 
-	STR_ERR_DLGCTL9				"“]‘—I—¹"     
-	STR_ERR_DLGCTL10			"Æ‰ï"         
-	STR_ERR_DLGCTL11			"ŽóMOK"       
-	STR_ERR_DLGCTL12			"Œx(ƒxƒ‹)"   
-	STR_ERR_DLGCTL13			"Œã‘Þ"         
-	STR_ERR_DLGCTL14			"ƒ^ƒu"         
-	STR_ERR_DLGCTL15			"‰üs"         	
-	STR_ERR_DLGCTL16			"‚’¼ƒ^ƒu"     
-	STR_ERR_DLGCTL17			"‰üƒy[ƒW"     	
-	STR_ERR_DLGCTL18			"•œ‹A"         
-	STR_ERR_DLGCTL19			"ƒVƒtƒgƒAƒEƒg" 
-	STR_ERR_DLGCTL20			"ƒVƒtƒgƒCƒ“"
-	STR_ERR_DLGCTL21			"ƒf[ƒ^ƒŠƒ“ƒNƒGƒXƒP[ƒv"
-	STR_ERR_DLGCTL22			"‘•’u§Œä1"    
-	STR_ERR_DLGCTL23			"‘•’u§Œä2"    
-	STR_ERR_DLGCTL24			"‘•’u§Œä3"    
-	STR_ERR_DLGCTL25			"‘•’u§Œä4"    
-	STR_ERR_DLGCTL26			"ŽóMŽ¸”s"     
-	STR_ERR_DLGCTL27			"“¯Šú"         
-	STR_ERR_DLGCTL28			"“]‘—ƒuƒƒbƒNI—¹"
-	STR_ERR_DLGCTL29			"ƒLƒƒƒ“ƒZƒ‹"   
-	STR_ERR_DLGCTL30			"ƒƒfƒBƒAI—¹" 
-	STR_ERR_DLGCTL31			"’uŠ·"         
-	STR_ERR_DLGCTL32			"ƒGƒXƒP[ƒv"   
-	STR_ERR_DLGCTL33			"ƒtƒH[ƒ€‹æØ" 
-	STR_ERR_DLGCTL34			"ƒOƒ‹[ƒv‹æØ" 
-	STR_ERR_DLGCTL35			"ƒŒƒR[ƒh‹æØ" 
-	STR_ERR_DLGCTL36			"ƒ†ƒjƒbƒg‹æØ" 
-	STR_ERR_DLGCTL37			"íœ"         
+	STR_ERR_DLGCTL5				"ç©ºæ–‡å­—"			// Codes for p_ctrl_list
+	STR_ERR_DLGCTL6				"ãƒ˜ãƒƒãƒ€é–‹å§‹"   
+	STR_ERR_DLGCTL7				"ãƒ†ã‚­ã‚¹ãƒˆé–‹å§‹" 
+	STR_ERR_DLGCTL8				"ãƒ†ã‚­ã‚¹ãƒˆçµ‚äº†" 
+	STR_ERR_DLGCTL9				"è»¢é€çµ‚äº†"     
+	STR_ERR_DLGCTL10			"ç…§ä¼š"         
+	STR_ERR_DLGCTL11			"å—ä¿¡OK"       
+	STR_ERR_DLGCTL12			"è­¦å‘Š(ãƒ™ãƒ«)"   
+	STR_ERR_DLGCTL13			"å¾Œé€€"         
+	STR_ERR_DLGCTL14			"ã‚¿ãƒ–"         
+	STR_ERR_DLGCTL15			"æ”¹è¡Œ"         	
+	STR_ERR_DLGCTL16			"åž‚ç›´ã‚¿ãƒ–"     
+	STR_ERR_DLGCTL17			"æ”¹ãƒšãƒ¼ã‚¸"     	
+	STR_ERR_DLGCTL18			"å¾©å¸°"         
+	STR_ERR_DLGCTL19			"ã‚·ãƒ•ãƒˆã‚¢ã‚¦ãƒˆ" 
+	STR_ERR_DLGCTL20			"ã‚·ãƒ•ãƒˆã‚¤ãƒ³"
+	STR_ERR_DLGCTL21			"ãƒ‡ãƒ¼ã‚¿ãƒªãƒ³ã‚¯ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—"
+	STR_ERR_DLGCTL22			"è£…ç½®åˆ¶å¾¡1"    
+	STR_ERR_DLGCTL23			"è£…ç½®åˆ¶å¾¡2"    
+	STR_ERR_DLGCTL24			"è£…ç½®åˆ¶å¾¡3"    
+	STR_ERR_DLGCTL25			"è£…ç½®åˆ¶å¾¡4"    
+	STR_ERR_DLGCTL26			"å—ä¿¡å¤±æ•—"     
+	STR_ERR_DLGCTL27			"åŒæœŸ"         
+	STR_ERR_DLGCTL28			"è»¢é€ãƒ–ãƒ­ãƒƒã‚¯çµ‚äº†"
+	STR_ERR_DLGCTL29			"ã‚­ãƒ£ãƒ³ã‚»ãƒ«"   
+	STR_ERR_DLGCTL30			"ãƒ¡ãƒ‡ã‚£ã‚¢çµ‚äº†" 
+	STR_ERR_DLGCTL31			"ç½®æ›"         
+	STR_ERR_DLGCTL32			"ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—"   
+	STR_ERR_DLGCTL33			"ãƒ•ã‚©ãƒ¼ãƒ åŒºåˆ‡" 
+	STR_ERR_DLGCTL34			"ã‚°ãƒ«ãƒ¼ãƒ—åŒºåˆ‡" 
+	STR_ERR_DLGCTL35			"ãƒ¬ã‚³ãƒ¼ãƒ‰åŒºåˆ‡" 
+	STR_ERR_DLGCTL36			"ãƒ¦ãƒ‹ãƒƒãƒˆåŒºåˆ‡" 
+	STR_ERR_DLGCTL37			"å‰Šé™¤"         
 
 	// CDlgFavorite.cpp
-	STR_DLGFAV_FILE				"ƒtƒ@ƒCƒ‹"
-	STR_DLGFAV_FOLDER			"ƒtƒHƒ‹ƒ_"
-	STR_DLGFAV_FF_EXCLUDE		"ƒtƒ@ƒCƒ‹EƒtƒHƒ‹ƒ_œŠO"
-	STR_DLGFAV_SEARCH			"ŒŸõ"
-	STR_DLGFAV_REPLACE			"’uŠ·"
-	STR_DLGFAV_GREP_FILE		"GREPƒtƒ@ƒCƒ‹"
-	STR_DLGFAV_GREP_FOLDER		"GREPƒtƒHƒ‹ƒ_"
-	STR_DLGFAV_EXT_COMMAND		"ƒRƒ}ƒ“ƒh"
-	STR_DLGFAV_CURRENT_DIR		"ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ"
-	STR_DLGFAV_HIDDEN			"(”ñ•\Ž¦)"
-	STR_DLGFAV_FAVORITE			"‚¨‹C‚É“ü‚è"
-	STR_DLGFAV_CONF_DEL_FAV		"Å‹ßŽg‚Á‚½%ts‚Ì—š—ð‚ðíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H\n"
-	STR_DLGFAV_CONF_DEL_NOTFAV	"Å‹ßŽg‚Á‚½%ts‚Ì—š—ð‚Ì‚¨‹C‚É“ü‚èˆÈŠO‚ðíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H"
-	STR_DLGFAV_CONF_DEL_PATH	"Å‹ßŽg‚Á‚½%ts‚Ì‘¶Ý‚µ‚È‚¢ƒpƒX‚ðíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H"
-	STR_DLGFAV_DELIMITER		"A"
-	STR_DLGFAV_FAV_REFRESH		"—š—ð(%ts)‚ªXV‚³‚ê‚½‚½‚ß•ÒW’†î•ñ‚ð”jŠü‚µÄ•\Ž¦‚µ‚Ü‚µ‚½B"
-	STR_DLGFAV_ADD				"’Ç‰Á"
-	STR_DLGFAV_ADD_PROMPT		"’Ç‰Á‚·‚é•¶Žš—ñ‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_DLGFAV_EDIT				"•ÒW"
-	STR_DLGFAV_EDIT_PROMPT		"•ÒW‚·‚é•¶Žš—ñ‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_DLGFAV_MENU_EDIT		"•ÒW(&E)"
-	STR_DLGFAV_MENU_ADD			"V‹K’Ç‰Á(&I)"
-	STR_DLGFAV_MENU_EXCLUDE		"œŠOƒŠƒXƒg‚É’Ç‰Á(&L)"
-	STR_DLGFAV_MENU_DEL_ALL		"‚·‚×‚Äíœ(&A)"
-	STR_DLGFAV_MENU_DEL_NOTFAV	"‚¨‹C‚É“ü‚èˆÈŠOíœ(&F)"
-	STR_DLGFAV_MENU_DEL_INVALID	"‘¶Ý‚µ‚È‚¢€–Úíœ(&N)"
-	STR_DLGFAV_MENU_DEL_SEL		"‘I‘ð€–Úíœ(&D)"
-	STR_DLGFAV_LIST_LIMIT_OVER	"œŠOƒŠƒXƒg‚ª‚¢‚Á‚Ï‚¢‚Å’Ç‰Á‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½B"
+	STR_DLGFAV_FILE				"ãƒ•ã‚¡ã‚¤ãƒ«"
+	STR_DLGFAV_FOLDER			"ãƒ•ã‚©ãƒ«ãƒ€"
+	STR_DLGFAV_FF_EXCLUDE		"ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ãƒ•ã‚©ãƒ«ãƒ€é™¤å¤–"
+	STR_DLGFAV_SEARCH			"æ¤œç´¢"
+	STR_DLGFAV_REPLACE			"ç½®æ›"
+	STR_DLGFAV_GREP_FILE		"GREPãƒ•ã‚¡ã‚¤ãƒ«"
+	STR_DLGFAV_GREP_FOLDER		"GREPãƒ•ã‚©ãƒ«ãƒ€"
+	STR_DLGFAV_EXT_COMMAND		"ã‚³ãƒžãƒ³ãƒ‰"
+	STR_DLGFAV_CURRENT_DIR		"ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª"
+	STR_DLGFAV_HIDDEN			"(éžè¡¨ç¤º)"
+	STR_DLGFAV_FAVORITE			"ãŠæ°—ã«å…¥ã‚Š"
+	STR_DLGFAV_CONF_DEL_FAV		"æœ€è¿‘ä½¿ã£ãŸ%tsã®å±¥æ­´ã‚’å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ\n"
+	STR_DLGFAV_CONF_DEL_NOTFAV	"æœ€è¿‘ä½¿ã£ãŸ%tsã®å±¥æ­´ã®ãŠæ°—ã«å…¥ã‚Šä»¥å¤–ã‚’å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
+	STR_DLGFAV_CONF_DEL_PATH	"æœ€è¿‘ä½¿ã£ãŸ%tsã®å­˜åœ¨ã—ãªã„ãƒ‘ã‚¹ã‚’å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
+	STR_DLGFAV_DELIMITER		"ã€"
+	STR_DLGFAV_FAV_REFRESH		"å±¥æ­´(%ts)ãŒæ›´æ–°ã•ã‚ŒãŸãŸã‚ç·¨é›†ä¸­æƒ…å ±ã‚’ç ´æ£„ã—å†è¡¨ç¤ºã—ã¾ã—ãŸã€‚"
+	STR_DLGFAV_ADD				"è¿½åŠ "
+	STR_DLGFAV_ADD_PROMPT		"è¿½åŠ ã™ã‚‹æ–‡å­—åˆ—ã‚’å…¥åŠ›ã—ã¦ãã ã•ã„ã€‚"
+	STR_DLGFAV_EDIT				"ç·¨é›†"
+	STR_DLGFAV_EDIT_PROMPT		"ç·¨é›†ã™ã‚‹æ–‡å­—åˆ—ã‚’å…¥åŠ›ã—ã¦ãã ã•ã„ã€‚"
+	STR_DLGFAV_MENU_EDIT		"ç·¨é›†(&E)"
+	STR_DLGFAV_MENU_ADD			"æ–°è¦è¿½åŠ (&I)"
+	STR_DLGFAV_MENU_EXCLUDE		"é™¤å¤–ãƒªã‚¹ãƒˆã«è¿½åŠ (&L)"
+	STR_DLGFAV_MENU_DEL_ALL		"ã™ã¹ã¦å‰Šé™¤(&A)"
+	STR_DLGFAV_MENU_DEL_NOTFAV	"ãŠæ°—ã«å…¥ã‚Šä»¥å¤–å‰Šé™¤(&F)"
+	STR_DLGFAV_MENU_DEL_INVALID	"å­˜åœ¨ã—ãªã„é …ç›®å‰Šé™¤(&N)"
+	STR_DLGFAV_MENU_DEL_SEL		"é¸æŠžé …ç›®å‰Šé™¤(&D)"
+	STR_DLGFAV_LIST_LIMIT_OVER	"é™¤å¤–ãƒªã‚¹ãƒˆãŒã„ã£ã±ã„ã§è¿½åŠ ã§ãã¾ã›ã‚“ã§ã—ãŸã€‚"
 
 	// CDlgFileUpdateQuery.cpp
-	STR_ERR_DLGUPQRY1			"Äƒ[ƒh‚ðs‚¤‚Æ•ÏX‚ªŽ¸‚í‚ê‚Ü‚·‚ª‚æ‚ë‚µ‚¢‚Å‚·‚©?"
-	STR_ERR_DLGUPQRY2			"Äƒ[ƒh‚µ‚Ü‚·‚©?"
+	STR_ERR_DLGUPQRY1			"å†ãƒ­ãƒ¼ãƒ‰ã‚’è¡Œã†ã¨å¤‰æ›´ãŒå¤±ã‚ã‚Œã¾ã™ãŒã‚ˆã‚ã—ã„ã§ã™ã‹?"
+	STR_ERR_DLGUPQRY2			"å†ãƒ­ãƒ¼ãƒ‰ã—ã¾ã™ã‹?"
 
 	// CDlgFind.cpp
-	STR_DLGFIND1				"ŒŸõðŒ‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_DLGFIND1				"æ¤œç´¢æ¡ä»¶ã‚’æŒ‡å®šã—ã¦ãã ã•ã„ã€‚"
 
 	// CDlgFuncList.cpp
-	STR_DLGFNCLST_TITLE_CPP		"C++ ƒƒ\ƒbƒhƒcƒŠ["
-	STR_DLGFNCLST_TITLE_RULE	"ƒ‹[ƒ‹ƒtƒ@ƒCƒ‹" 
-	STR_DLGFNCLST_TITLE_WZ		"WZŠK‘w•tƒeƒLƒXƒg"
-	STR_DLGFNCLST_TITLE_TEXT	"ƒeƒLƒXƒg ƒgƒsƒbƒNƒcƒŠ["
-	STR_DLGFNCLST_TITLE_JAVA	"Java ƒƒ\ƒbƒhƒcƒŠ["
-	STR_DLGFNCLST_TITLE_PYTHON	"Python ƒƒ\ƒbƒhƒcƒŠ["
-	STR_DLGFNCLST_TITLE_COBOL	"COBOL ƒAƒEƒgƒ‰ƒCƒ“"
-	STR_DLGFNCLST_TITLE_VB		"Visual Basic ƒAƒEƒgƒ‰ƒCƒ“"
-	STR_DLGFNCLST_TITLE_C		"C ŠÖ”ˆê——"
-	STR_DLGFNCLST_TITLE_PLSQL	"PL/SQL ŠÖ”ˆê——"
-	STR_DLGFNCLST_TITLE_ASM		"ƒAƒZƒ“ƒuƒ‰ ƒAƒEƒgƒ‰ƒCƒ“"
-	STR_DLGFNCLST_TITLE_PERL	"Perl ŠÖ”ˆê——"
-	STR_DLGFNCLST_TITLE_ERLANG	"Erlang ŠÖ”ˆê——"
-	STR_DLGFNCLST_TITLE_BOOK	"ƒuƒbƒNƒ}[ƒN"
+	STR_DLGFNCLST_TITLE_CPP		"C++ ãƒ¡ã‚½ãƒƒãƒ‰ãƒ„ãƒªãƒ¼"
+	STR_DLGFNCLST_TITLE_RULE	"ãƒ«ãƒ¼ãƒ«ãƒ•ã‚¡ã‚¤ãƒ«" 
+	STR_DLGFNCLST_TITLE_WZ		"WZéšŽå±¤ä»˜ãƒ†ã‚­ã‚¹ãƒˆ"
+	STR_DLGFNCLST_TITLE_TEXT	"ãƒ†ã‚­ã‚¹ãƒˆ ãƒˆãƒ”ãƒƒã‚¯ãƒ„ãƒªãƒ¼"
+	STR_DLGFNCLST_TITLE_JAVA	"Java ãƒ¡ã‚½ãƒƒãƒ‰ãƒ„ãƒªãƒ¼"
+	STR_DLGFNCLST_TITLE_PYTHON	"Python ãƒ¡ã‚½ãƒƒãƒ‰ãƒ„ãƒªãƒ¼"
+	STR_DLGFNCLST_TITLE_COBOL	"COBOL ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³"
+	STR_DLGFNCLST_TITLE_VB		"Visual Basic ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³"
+	STR_DLGFNCLST_TITLE_C		"C é–¢æ•°ä¸€è¦§"
+	STR_DLGFNCLST_TITLE_PLSQL	"PL/SQL é–¢æ•°ä¸€è¦§"
+	STR_DLGFNCLST_TITLE_ASM		"ã‚¢ã‚»ãƒ³ãƒ–ãƒ© ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³"
+	STR_DLGFNCLST_TITLE_PERL	"Perl é–¢æ•°ä¸€è¦§"
+	STR_DLGFNCLST_TITLE_ERLANG	"Erlang é–¢æ•°ä¸€è¦§"
+	STR_DLGFNCLST_TITLE_BOOK	"ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯"
 
-	STR_DLGFNCLST_REMARK01		"éŒ¾"
-	STR_DLGFNCLST_REMARK02		"ŠÖ”éŒ¾"
-	STR_DLGFNCLST_REMARK03		"ƒvƒƒV[ƒWƒƒéŒ¾"
-	STR_DLGFNCLST_REMARK04		"ŠÖ”"
-	STR_DLGFNCLST_REMARK05		"ƒvƒƒV[ƒWƒƒ"
-	STR_DLGFNCLST_REMARK06		"¡ƒpƒbƒP[ƒWŽd—l•”"
-	STR_DLGFNCLST_REMARK07		"¡ƒpƒbƒP[ƒW–{‘Ì•”"
+	STR_DLGFNCLST_REMARK01		"å®£è¨€"
+	STR_DLGFNCLST_REMARK02		"é–¢æ•°å®£è¨€"
+	STR_DLGFNCLST_REMARK03		"ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£å®£è¨€"
+	STR_DLGFNCLST_REMARK04		"é–¢æ•°"
+	STR_DLGFNCLST_REMARK05		"ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£"
+	STR_DLGFNCLST_REMARK06		"â– ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸ä»•æ§˜éƒ¨"
+	STR_DLGFNCLST_REMARK07		"â– ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸æœ¬ä½“éƒ¨"
 	STR_DLGFNCLST_REMARK08		"PROC"
-	STR_DLGFNCLST_REMARK09		"ƒ‰ƒxƒ‹"
+	STR_DLGFNCLST_REMARK09		"ãƒ©ãƒ™ãƒ«"
 	STR_DLGFNCLST_REMARK10		"ENDP"
 
-	STR_DLGFNCLST_SORTTYPE1		"ƒfƒtƒHƒ‹ƒg"
-	STR_DLGFNCLST_SORTTYPE1_2	"ƒfƒtƒHƒ‹ƒg(~‡)"
-	STR_DLGFNCLST_SORTTYPE2		"ƒAƒ‹ƒtƒ@ƒxƒbƒg‡"
-	STR_DLGFNCLST_SORTTYPE2_2	"ƒAƒ‹ƒtƒ@ƒxƒbƒg(~‡)"
+	STR_DLGFNCLST_SORTTYPE1		"ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆ"
+	STR_DLGFNCLST_SORTTYPE1_2	"ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆ(é™é †)"
+	STR_DLGFNCLST_SORTTYPE2		"ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆé †"
+	STR_DLGFNCLST_SORTTYPE2_2	"ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆ(é™é †)"
 
 	// NOT complete....
-	STR_DLGFNCLST_APND_DECLARE		"(éŒ¾)" 
-	STR_DLGFNCLST_APND_CLASS		" ƒNƒ‰ƒX"
-	STR_DLGFNCLST_APND_STRUCT		" \‘¢‘Ì"
-	STR_DLGFNCLST_APND_ENUM			" —ñ‹“‘Ì"
-	STR_DLGFNCLST_APND_UNION		" ‹¤—p‘Ì"
-	STR_DLGFNCLST_APND_NAMESPACE	" –¼‘O‹óŠÔ"
-	STR_DLGFNCLST_APND_INTERFACE	" ƒCƒ“ƒ^[ƒtƒF[ƒX"
-	STR_DLGFNCLST_APND_GLOBAL		"ƒOƒ[ƒoƒ‹"
+	STR_DLGFNCLST_APND_DECLARE		"(å®£è¨€)" 
+	STR_DLGFNCLST_APND_CLASS		" ã‚¯ãƒ©ã‚¹"
+	STR_DLGFNCLST_APND_STRUCT		" æ§‹é€ ä½“"
+	STR_DLGFNCLST_APND_ENUM			" åˆ—æŒ™ä½“"
+	STR_DLGFNCLST_APND_UNION		" å…±ç”¨ä½“"
+	STR_DLGFNCLST_APND_NAMESPACE	" åå‰ç©ºé–“"
+	STR_DLGFNCLST_APND_INTERFACE	" ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹"
+	STR_DLGFNCLST_APND_GLOBAL		"ã‚°ãƒ­ãƒ¼ãƒãƒ«"
 
-	STR_DLGFNCLST_VB_STATIC		"Ã“I "
-	STR_DLGFNCLST_VB_PRIVATE	"ƒvƒ‰ƒCƒx[ƒg"
-	STR_DLGFNCLST_VB_FRIEND		"ƒtƒŒƒ“ƒh"
-	STR_DLGFNCLST_VB_PUBLIC		"ƒpƒuƒŠƒbƒN"
-	STR_DLGFNCLST_VB_FUNCTION	"ŠÖ”"
-	STR_DLGFNCLST_VB_PROC		"ƒvƒƒV[ƒWƒƒ"
-	STR_DLGFNCLST_VB_PROPGET	"ƒvƒƒpƒeƒB Žæ“¾"
-	STR_DLGFNCLST_VB_PROPLET	"ƒvƒƒpƒeƒB Ý’è"
-	STR_DLGFNCLST_VB_PROPSET	"ƒvƒƒpƒeƒB ŽQÆ"
-	STR_DLGFNCLST_VB_CONST		"’è”"
-	STR_DLGFNCLST_VB_ENUM		"—ñ‹“Œ^"
-	STR_DLGFNCLST_VB_TYPE		"ƒ†[ƒU’è‹`Œ^"
-	STR_DLGFNCLST_VB_EVENT		"ƒCƒxƒ“ƒg"
-	STR_DLGFNCLST_VB_DECL		"éŒ¾"
+	STR_DLGFNCLST_VB_STATIC		"é™çš„ "
+	STR_DLGFNCLST_VB_PRIVATE	"ãƒ—ãƒ©ã‚¤ãƒ™ãƒ¼ãƒˆ"
+	STR_DLGFNCLST_VB_FRIEND		"ãƒ•ãƒ¬ãƒ³ãƒ‰"
+	STR_DLGFNCLST_VB_PUBLIC		"ãƒ‘ãƒ–ãƒªãƒƒã‚¯"
+	STR_DLGFNCLST_VB_FUNCTION	"é–¢æ•°"
+	STR_DLGFNCLST_VB_PROC		"ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£"
+	STR_DLGFNCLST_VB_PROPGET	"ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ å–å¾—"
+	STR_DLGFNCLST_VB_PROPLET	"ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ è¨­å®š"
+	STR_DLGFNCLST_VB_PROPSET	"ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ å‚ç…§"
+	STR_DLGFNCLST_VB_CONST		"å®šæ•°"
+	STR_DLGFNCLST_VB_ENUM		"åˆ—æŒ™åž‹"
+	STR_DLGFNCLST_VB_TYPE		"ãƒ¦ãƒ¼ã‚¶å®šç¾©åž‹"
+	STR_DLGFNCLST_VB_EVENT		"ã‚¤ãƒ™ãƒ³ãƒˆ"
+	STR_DLGFNCLST_VB_DECL		"å®£è¨€"
 
-	STR_DLGFNCLST_LIST_TEXT		"ƒeƒLƒXƒg"
-	STR_DLGFNCLST_LIST_TEXT_M	"ƒeƒLƒXƒg *"
-	STR_DLGFNCLST_LIST_FUNC		"ŠÖ”–¼"
-	STR_DLGFNCLST_LIST_FUNC_M	"ŠÖ”–¼ *"
-	STR_DLGFNCLST_LIST_LINE		"s"
-	STR_DLGFNCLST_LIST_LINE_M	"s *"
-	STR_DLGFNCLST_LIST_COL		"Œ…"
-	STR_DLGFNCLST_LIST_COL_M	"Œ… *"
+	STR_DLGFNCLST_LIST_TEXT		"ãƒ†ã‚­ã‚¹ãƒˆ"
+	STR_DLGFNCLST_LIST_TEXT_M	"ãƒ†ã‚­ã‚¹ãƒˆ *"
+	STR_DLGFNCLST_LIST_FUNC		"é–¢æ•°å"
+	STR_DLGFNCLST_LIST_FUNC_M	"é–¢æ•°å *"
+	STR_DLGFNCLST_LIST_LINE		"è¡Œ"
+	STR_DLGFNCLST_LIST_LINE_M	"è¡Œ *"
+	STR_DLGFNCLST_LIST_COL		"æ¡"
+	STR_DLGFNCLST_LIST_COL_M	"æ¡ *"
 	STR_DLGFNCLST_LIST_M		"*"
 
-	STR_DLGFNCLST_TIP_CLOSE		"•Â‚¶‚é"
-	STR_DLGFNCLST_TIP_WIN		"ƒEƒBƒ“ƒhƒE‚ÌˆÊ’u"
-	STR_DLGFNCLST_TIP_UPDATE	"XV"
+	STR_DLGFNCLST_TIP_CLOSE		"é–‰ã˜ã‚‹"
+	STR_DLGFNCLST_TIP_WIN		"ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä½ç½®"
+	STR_DLGFNCLST_TIP_UPDATE	"æ›´æ–°"
 
-	STR_DLGFNCLST_MENU_UPDATE	"XV(&U)"
-	STR_DLGFNCLST_MENU_COPY		"ƒRƒs[(&C)"
-	STR_DLGFNCLST_MENU_EXPAND	"‚·‚×‚Ä“WŠJ(&E)"
-	STR_DLGFNCLST_MENU_COLLAPSE	"‚·‚×‚Äk¬(&O)"
-	STR_DLGFNCLST_MENU_BOOK_DEL	"ƒuƒbƒNƒ}[ƒNíœ(&D)"
-	STR_DLGFNCLST_MENU_BOOK_ALL_DEL	"ƒuƒbƒNƒ}[ƒN‘Síœ(&A)"
-	STR_DLGFNCLST_MENU_WINPOS	"ƒEƒBƒ“ƒhƒE‚ÌˆÊ’u(&W)"
-	STR_DLGFNCLST_MENU_LEFTDOC	"¶ƒhƒbƒLƒ“ƒO(&L)"
-	STR_DLGFNCLST_MENU_RIGHTDOC	"‰EƒhƒbƒLƒ“ƒO(&R)"
-	STR_DLGFNCLST_MENU_TOPDOC	"ãƒhƒbƒLƒ“ƒO(&T)"
-	STR_DLGFNCLST_MENU_BOTDOC	"‰ºƒhƒbƒLƒ“ƒO(&B)"
-	STR_DLGFNCLST_MENU_FLOATING	"ƒtƒ[ƒeƒBƒ“ƒO(&F)"
-	STR_DLGFNCLST_MENU_NODOCK	"ƒhƒbƒLƒ“ƒO‹ÖŽ~(&I)"
-	STR_DLGFNCLST_MENU_SYNC		"ƒhƒbƒLƒ“ƒO”z’u‚ð“¯Šú(&S)"
-	STR_DLGFNCLST_MENU_INHERIT	"ƒhƒbƒLƒ“ƒO”z’u‚ð‹¤’ÊŒp³(&C)"
-	STR_DLGFNCLST_MENU_TYPE		"ƒhƒbƒLƒ“ƒO”z’u‚ðƒ^ƒCƒv•ÊŒp³(&Y)"
-	STR_DLGFNCLST_MENU_UNIFY	"Œp³î•ñ‚ð“ˆê(&U)"
-	STR_DLGFNCLST_MENU_CLOSE	"•Â‚¶‚é(&X)"
+	STR_DLGFNCLST_MENU_UPDATE	"æ›´æ–°(&U)"
+	STR_DLGFNCLST_MENU_COPY		"ã‚³ãƒ”ãƒ¼(&C)"
+	STR_DLGFNCLST_MENU_EXPAND	"ã™ã¹ã¦å±•é–‹(&E)"
+	STR_DLGFNCLST_MENU_COLLAPSE	"ã™ã¹ã¦ç¸®å°(&O)"
+	STR_DLGFNCLST_MENU_BOOK_DEL	"ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯å‰Šé™¤(&D)"
+	STR_DLGFNCLST_MENU_BOOK_ALL_DEL	"ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯å…¨å‰Šé™¤(&A)"
+	STR_DLGFNCLST_MENU_WINPOS	"ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä½ç½®(&W)"
+	STR_DLGFNCLST_MENU_LEFTDOC	"å·¦ãƒ‰ãƒƒã‚­ãƒ³ã‚°(&L)"
+	STR_DLGFNCLST_MENU_RIGHTDOC	"å³ãƒ‰ãƒƒã‚­ãƒ³ã‚°(&R)"
+	STR_DLGFNCLST_MENU_TOPDOC	"ä¸Šãƒ‰ãƒƒã‚­ãƒ³ã‚°(&T)"
+	STR_DLGFNCLST_MENU_BOTDOC	"ä¸‹ãƒ‰ãƒƒã‚­ãƒ³ã‚°(&B)"
+	STR_DLGFNCLST_MENU_FLOATING	"ãƒ•ãƒ­ãƒ¼ãƒ†ã‚£ãƒ³ã‚°(&F)"
+	STR_DLGFNCLST_MENU_NODOCK	"ãƒ‰ãƒƒã‚­ãƒ³ã‚°ç¦æ­¢(&I)"
+	STR_DLGFNCLST_MENU_SYNC		"ãƒ‰ãƒƒã‚­ãƒ³ã‚°é…ç½®ã‚’åŒæœŸ(&S)"
+	STR_DLGFNCLST_MENU_INHERIT	"ãƒ‰ãƒƒã‚­ãƒ³ã‚°é…ç½®ã‚’å…±é€šç¶™æ‰¿(&C)"
+	STR_DLGFNCLST_MENU_TYPE		"ãƒ‰ãƒƒã‚­ãƒ³ã‚°é…ç½®ã‚’ã‚¿ã‚¤ãƒ—åˆ¥ç¶™æ‰¿(&Y)"
+	STR_DLGFNCLST_MENU_UNIFY	"ç¶™æ‰¿æƒ…å ±ã‚’çµ±ä¸€(&U)"
+	STR_DLGFNCLST_MENU_CLOSE	"é–‰ã˜ã‚‹(&X)"
 
-	STR_DLGFNCLST_UNIFY			"Œ»Ý‚Ì‰æ–Ê‚ÌƒhƒbƒLƒ“ƒO”z’uî•ñ‚ð‚·‚×‚Ä‚Ì‹¤’ÊÝ’èEƒ^ƒCƒv•ÊÝ’è‚ÉƒRƒs[‚µ‚Ä“ˆê‚µ‚Ü‚·B\niŒ»ÝŠJ‚¢‚Ä‚¢‚é‘¼‰æ–Ê‚Ìó‘Ô‚à“ˆê‚µ‚Ü‚·Bj\n"
+	STR_DLGFNCLST_UNIFY			"ç¾åœ¨ã®ç”»é¢ã®ãƒ‰ãƒƒã‚­ãƒ³ã‚°é…ç½®æƒ…å ±ã‚’ã™ã¹ã¦ã®å…±é€šè¨­å®šãƒ»ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã«ã‚³ãƒ”ãƒ¼ã—ã¦çµ±ä¸€ã—ã¾ã™ã€‚\nï¼ˆç¾åœ¨é–‹ã„ã¦ã„ã‚‹ä»–ç”»é¢ã®çŠ¶æ…‹ã‚‚çµ±ä¸€ã—ã¾ã™ã€‚ï¼‰\n"
 
 
 	// CDlgGrep.cpp
-	STR_DLGGREP1				"ŒŸõ‚·‚éƒtƒHƒ‹ƒ_‚ð‘I‚ñ‚Å‚­‚¾‚³‚¢"
-	STR_DLGGREP2				"ƒtƒ@ƒCƒ‹Žw’è‚ÌƒtƒHƒ‹ƒ_•”•ª‚É‚ÍƒƒCƒ‹ƒhƒJ[ƒh‚ÍŽg‚¦‚Ü‚¹‚ñB"
-	STR_DLGGREP3				"ƒtƒ@ƒCƒ‹Žw’è‚É‚Íƒtƒ‹ƒpƒX‚ÍŽg‚¦‚Ü‚¹‚ñ"
-	STR_DLGGREP4				"ŒŸõ‘ÎÛƒtƒHƒ‹ƒ_‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_DLGGREP5				"ŒŸõ‘ÎÛƒtƒHƒ‹ƒ_‚ª³‚µ‚­‚ ‚è‚Ü‚¹‚ñB"
-	STR_DLGGREP6				"ŒŸõ‘ÎÛƒtƒHƒ‹ƒ_‚ª’·‚·‚¬‚Ü‚·B"
+	STR_DLGGREP1				"æ¤œç´¢ã™ã‚‹ãƒ•ã‚©ãƒ«ãƒ€ã‚’é¸ã‚“ã§ãã ã•ã„"
+	STR_DLGGREP2				"ãƒ•ã‚¡ã‚¤ãƒ«æŒ‡å®šã®ãƒ•ã‚©ãƒ«ãƒ€éƒ¨åˆ†ã«ã¯ãƒ¯ã‚¤ãƒ«ãƒ‰ã‚«ãƒ¼ãƒ‰ã¯ä½¿ãˆã¾ã›ã‚“ã€‚"
+	STR_DLGGREP3				"ãƒ•ã‚¡ã‚¤ãƒ«æŒ‡å®šã«ã¯ãƒ•ãƒ«ãƒ‘ã‚¹ã¯ä½¿ãˆã¾ã›ã‚“"
+	STR_DLGGREP4				"æ¤œç´¢å¯¾è±¡ãƒ•ã‚©ãƒ«ãƒ€ã‚’æŒ‡å®šã—ã¦ãã ã•ã„ã€‚"
+	STR_DLGGREP5				"æ¤œç´¢å¯¾è±¡ãƒ•ã‚©ãƒ«ãƒ€ãŒæ­£ã—ãã‚ã‚Šã¾ã›ã‚“ã€‚"
+	STR_DLGGREP6				"æ¤œç´¢å¯¾è±¡ãƒ•ã‚©ãƒ«ãƒ€ãŒé•·ã™ãŽã¾ã™ã€‚"
 
 	// CDlgJump.cpp
-	STR_DLGJUMP1				"³‚µ‚­s”Ô†‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_DLGJUMP_PSLQL			"%d s  %ts  ƒpƒbƒP[ƒWŽd—l•”"
+	STR_DLGJUMP1				"æ­£ã—ãè¡Œç•ªå·ã‚’å…¥åŠ›ã—ã¦ãã ã•ã„ã€‚"
+	STR_DLGJUMP_PSLQL			"%d è¡Œ  %ts  ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸ä»•æ§˜éƒ¨"
 
 	// CDlgOpenFile.cpp
-	STR_DLGOPNFL1				"•ÏŠ·‚È‚µ"				// Max 32 bytes.
-	STR_DLGOPNFL2				" ‚ÍŠù‚É‘¶Ý‚µ‚Ü‚·B\r\nã‘‚«‚µ‚Ü‚·‚©H"
-	STR_DLGOPNFL3				"–¼‘O‚ð•t‚¯‚Ä•Û‘¶"
-	STR_DLGOPNFL_EXTNAME1		"ƒ†[ƒU[Žw’è"
-	STR_DLGOPNFL_EXTNAME2		"ƒeƒLƒXƒgƒtƒ@ƒCƒ‹"
-	STR_DLGOPNFL_EXTNAME3		"‚·‚×‚Ä‚Ìƒtƒ@ƒCƒ‹"
-	STR_DLGOPNFL_ERR1			"ƒ_ƒCƒAƒƒO‚ªŠJ‚¯‚Ü‚¹‚ñB\n\nƒGƒ‰[:%ts"
+	STR_DLGOPNFL1				"å¤‰æ›ãªã—"				// Max 32 bytes.
+	STR_DLGOPNFL2				" ã¯æ—¢ã«å­˜åœ¨ã—ã¾ã™ã€‚\r\nä¸Šæ›¸ãã—ã¾ã™ã‹ï¼Ÿ"
+	STR_DLGOPNFL3				"åå‰ã‚’ä»˜ã‘ã¦ä¿å­˜"
+	STR_DLGOPNFL_EXTNAME1		"ãƒ¦ãƒ¼ã‚¶ãƒ¼æŒ‡å®š"
+	STR_DLGOPNFL_EXTNAME2		"ãƒ†ã‚­ã‚¹ãƒˆãƒ•ã‚¡ã‚¤ãƒ«"
+	STR_DLGOPNFL_EXTNAME3		"ã™ã¹ã¦ã®ãƒ•ã‚¡ã‚¤ãƒ«"
+	STR_DLGOPNFL_ERR1			"ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãŒé–‹ã‘ã¾ã›ã‚“ã€‚\n\nã‚¨ãƒ©ãƒ¼:%ts"
 
 	// CDlgPluginOption.cpp
-	STR_DLGPLUGINOPT_LOAD		"ƒvƒ‰ƒOƒCƒ“‚ªƒ[ƒh‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB"
-	STR_DLGPLUGINOPT_TITLE		"%ls ƒvƒ‰ƒOƒCƒ“‚ÌÝ’è"
-	STR_DLGPLUGINOPT_INIHEAD	" ƒvƒ‰ƒOƒCƒ“Ý’èƒtƒ@ƒCƒ‹"
-	STR_DLGPLUGINOPT_OPTION		"Žw’è‚Å‚«‚éƒIƒvƒVƒ‡ƒ“‚ª‚ ‚è‚Ü‚¹‚ñ"
-	STR_DLGPLUGINOPT_LIST1		"€–Ú"
-	STR_DLGPLUGINOPT_LIST2		"’l"
-	STR_DLGPLUGINOPT_SELECT		"%ts‚Ì‘I‘ð"
+	STR_DLGPLUGINOPT_LOAD		"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãŒãƒ­ãƒ¼ãƒ‰ã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚"
+	STR_DLGPLUGINOPT_TITLE		"%ls ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®è¨­å®š"
+	STR_DLGPLUGINOPT_INIHEAD	" ãƒ—ãƒ©ã‚°ã‚¤ãƒ³è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«"
+	STR_DLGPLUGINOPT_OPTION		"æŒ‡å®šã§ãã‚‹ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãŒã‚ã‚Šã¾ã›ã‚“"
+	STR_DLGPLUGINOPT_LIST1		"é …ç›®"
+	STR_DLGPLUGINOPT_LIST2		"å€¤"
+	STR_DLGPLUGINOPT_SELECT		"%tsã®é¸æŠž"
 
 	// CDlgPrintSetting.cpp
-	STR_DLGPRNST1				"Ý’è–¼‚Ì•ÏX" 
-	STR_DLGPRNST2				"Ý’è‚Ì–¼Ì‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_DLGPRNST1				"è¨­å®šåã®å¤‰æ›´" 
+	STR_DLGPRNST2				"è¨­å®šã®åç§°ã‚’å…¥åŠ›ã—ã¦ãã ã•ã„ã€‚"
 
 	// CDlgProperty.cpp
-	STR_DLGFLPROP_FILENAME		"ƒtƒ@ƒCƒ‹–¼  "
-	STR_DLGFLPROP_FILETYPE		"Ý’è‚Ìƒ^ƒCƒv  "
-	STR_DLGFLPROP_ENCODING		"•¶ŽšƒR[ƒh  "
-	STR_DLGFLPROP_WITH_BOM		" BOM •t"
-	STR_DLGFLPROP_LINE_COUNT	"s”  %ds\r\n"
-	STR_DLGFLPROP_LAYOUT_LINE	"ƒŒƒCƒAƒEƒgs”  %ds\r\n"
-	STR_DLGFLPROP_VIEW_MODE		"ƒrƒ…[ƒ‚[ƒh‚ÅŠJ‚¢‚Ä‚¢‚Ü‚·B\r\n"
-	STR_DLGFLPROP_MODIFIED		"•ÏX‚³‚ê‚Ä‚¢‚Ü‚·B\r\n"
-	STR_DLGFLPROP_NOT_MODIFIED	"•ÏX‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB\r\n"
-	STR_DLGFLPROP_CMD_COUNT		"\r\nƒRƒ}ƒ“ƒhŽÀs‰ñ”    %d‰ñ\r\n"
-	STR_DLGFLPROP_FILE_INFO		"--ƒtƒ@ƒCƒ‹î•ñ-----------------\r\n"
-	STR_DLGFLPROP_W_LOCK		"‚ ‚È‚½‚Í‚±‚Ìƒtƒ@ƒCƒ‹‚ðA‘¼ƒvƒƒZƒX‚©‚ç‚Ìã‘‚«‹ÖŽ~ƒ‚[ƒh‚ÅƒƒbƒN‚µ‚Ä‚¢‚Ü‚·B\r\n"
-	STR_DLGFLPROP_RW_LOCK		"‚ ‚È‚½‚Í‚±‚Ìƒtƒ@ƒCƒ‹‚ðA‘¼ƒvƒƒZƒX‚©‚ç‚Ì“Ç‚Ý‘‚«‹ÖŽ~ƒ‚[ƒh‚ÅƒƒbƒN‚µ‚Ä‚¢‚Ü‚·B\r\n"
-	STR_DLGFLPROP_LOCK			"‚ ‚È‚½‚Í‚±‚Ìƒtƒ@ƒCƒ‹‚ðƒƒbƒN‚µ‚Ä‚¢‚Ü‚·B\r\n"
-	STR_DLGFLPROP_NOT_LOCK		"‚ ‚È‚½‚Í‚±‚Ìƒtƒ@ƒCƒ‹‚ðƒƒbƒN‚µ‚Ä‚¢‚Ü‚¹‚ñB\r\n"
-	STR_DLGFLPROP_ATTRIBUTES	"ƒtƒ@ƒCƒ‹‘®«  "
-	STR_DLGFLPROP_AT_ARCHIVE	"/ƒA[ƒJƒCƒu"
-	STR_DLGFLPROP_AT_COMPRESS	"/ˆ³k"
-	STR_DLGFLPROP_AT_FOLDER		"/ƒtƒHƒ‹ƒ_"
-	STR_DLGFLPROP_AT_HIDDEN		"/‰B‚µ"
-	STR_DLGFLPROP_AT_NORMAL		"/ƒm[ƒ}ƒ‹"
-	STR_DLGFLPROP_AT_OFFLINE	"/ƒIƒtƒ‰ƒCƒ“"
-	STR_DLGFLPROP_AT_READONLY	"/“Ç‚ÝŽæ‚èê—p"
-	STR_DLGFLPROP_AT_SYSTEM		"/ƒVƒXƒeƒ€"
-	STR_DLGFLPROP_AT_TEMP		"/ƒeƒ“ƒ|ƒ‰ƒŠ"
-	STR_DLGFLPROP_CREATE_DT		"ì¬“úŽž  "
-	STR_DLGFLPROP_YMDHMS		"%d”N%dŒŽ%d“ú %02d:%02d:%02d"
-	STR_DLGFLPROP_UPDATE_DT		"XV“úŽž  "
-	STR_DLGFLPROP_ACCESS_DT		"ƒAƒNƒZƒX“úŽž  "
-	STR_DLGFLPROP_DOS_NAME		"MS-DOSƒtƒ@ƒCƒ‹–¼  %ts\r\n"
-	STR_DLGFLPROP_FILE_SIZE		"ƒtƒ@ƒCƒ‹ƒTƒCƒY  %d ƒoƒCƒg\r\n"
+	STR_DLGFLPROP_FILENAME		"ãƒ•ã‚¡ã‚¤ãƒ«å  "
+	STR_DLGFLPROP_FILETYPE		"è¨­å®šã®ã‚¿ã‚¤ãƒ—  "
+	STR_DLGFLPROP_ENCODING		"æ–‡å­—ã‚³ãƒ¼ãƒ‰  "
+	STR_DLGFLPROP_WITH_BOM		" BOM ä»˜"
+	STR_DLGFLPROP_LINE_COUNT	"è¡Œæ•°  %dè¡Œ\r\n"
+	STR_DLGFLPROP_LAYOUT_LINE	"ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œæ•°  %dè¡Œ\r\n"
+	STR_DLGFLPROP_VIEW_MODE		"ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ã§é–‹ã„ã¦ã„ã¾ã™ã€‚\r\n"
+	STR_DLGFLPROP_MODIFIED		"å¤‰æ›´ã•ã‚Œã¦ã„ã¾ã™ã€‚\r\n"
+	STR_DLGFLPROP_NOT_MODIFIED	"å¤‰æ›´ã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚\r\n"
+	STR_DLGFLPROP_CMD_COUNT		"\r\nã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œå›žæ•°    %då›ž\r\n"
+	STR_DLGFLPROP_FILE_INFO		"--ãƒ•ã‚¡ã‚¤ãƒ«æƒ…å ±-----------------\r\n"
+	STR_DLGFLPROP_W_LOCK		"ã‚ãªãŸã¯ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã€ä»–ãƒ—ãƒ­ã‚»ã‚¹ã‹ã‚‰ã®ä¸Šæ›¸ãç¦æ­¢ãƒ¢ãƒ¼ãƒ‰ã§ãƒ­ãƒƒã‚¯ã—ã¦ã„ã¾ã™ã€‚\r\n"
+	STR_DLGFLPROP_RW_LOCK		"ã‚ãªãŸã¯ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã€ä»–ãƒ—ãƒ­ã‚»ã‚¹ã‹ã‚‰ã®èª­ã¿æ›¸ãç¦æ­¢ãƒ¢ãƒ¼ãƒ‰ã§ãƒ­ãƒƒã‚¯ã—ã¦ã„ã¾ã™ã€‚\r\n"
+	STR_DLGFLPROP_LOCK			"ã‚ãªãŸã¯ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ãƒ­ãƒƒã‚¯ã—ã¦ã„ã¾ã™ã€‚\r\n"
+	STR_DLGFLPROP_NOT_LOCK		"ã‚ãªãŸã¯ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ãƒ­ãƒƒã‚¯ã—ã¦ã„ã¾ã›ã‚“ã€‚\r\n"
+	STR_DLGFLPROP_ATTRIBUTES	"ãƒ•ã‚¡ã‚¤ãƒ«å±žæ€§  "
+	STR_DLGFLPROP_AT_ARCHIVE	"/ã‚¢ãƒ¼ã‚«ã‚¤ãƒ–"
+	STR_DLGFLPROP_AT_COMPRESS	"/åœ§ç¸®"
+	STR_DLGFLPROP_AT_FOLDER		"/ãƒ•ã‚©ãƒ«ãƒ€"
+	STR_DLGFLPROP_AT_HIDDEN		"/éš ã—"
+	STR_DLGFLPROP_AT_NORMAL		"/ãƒŽãƒ¼ãƒžãƒ«"
+	STR_DLGFLPROP_AT_OFFLINE	"/ã‚ªãƒ•ãƒ©ã‚¤ãƒ³"
+	STR_DLGFLPROP_AT_READONLY	"/èª­ã¿å–ã‚Šå°‚ç”¨"
+	STR_DLGFLPROP_AT_SYSTEM		"/ã‚·ã‚¹ãƒ†ãƒ "
+	STR_DLGFLPROP_AT_TEMP		"/ãƒ†ãƒ³ãƒãƒ©ãƒª"
+	STR_DLGFLPROP_CREATE_DT		"ä½œæˆæ—¥æ™‚  "
+	STR_DLGFLPROP_YMDHMS		"%då¹´%dæœˆ%dæ—¥ %02d:%02d:%02d"
+	STR_DLGFLPROP_UPDATE_DT		"æ›´æ–°æ—¥æ™‚  "
+	STR_DLGFLPROP_ACCESS_DT		"ã‚¢ã‚¯ã‚»ã‚¹æ—¥æ™‚  "
+	STR_DLGFLPROP_DOS_NAME		"MS-DOSãƒ•ã‚¡ã‚¤ãƒ«å  %ts\r\n"
+	STR_DLGFLPROP_FILE_SIZE		"ãƒ•ã‚¡ã‚¤ãƒ«ã‚µã‚¤ã‚º  %d ãƒã‚¤ãƒˆ\r\n"
 
 	// CDlgReplace.cpp
-	STR_DLGREPLC_CLIPBOARD		"ƒNƒŠƒbƒvƒ{[ƒh‚É—LŒø‚Èƒf[ƒ^‚ª‚ ‚è‚Ü‚¹‚ñI"
-	STR_DLGREPLC_STR			"•¶Žš—ñ‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_DLGREPLC_REPLACE		"%d‰ÓŠ‚ð’uŠ·‚µ‚Ü‚µ‚½B"
-	STR_DLGREPLC_REPSTR			"’uŠ·ðŒ‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_DLGREPLC_CLIPBOARD		"ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«æœ‰åŠ¹ãªãƒ‡ãƒ¼ã‚¿ãŒã‚ã‚Šã¾ã›ã‚“ï¼"
+	STR_DLGREPLC_STR			"æ–‡å­—åˆ—ã‚’æŒ‡å®šã—ã¦ãã ã•ã„ã€‚"
+	STR_DLGREPLC_REPLACE		"%dç®‡æ‰€ã‚’ç½®æ›ã—ã¾ã—ãŸã€‚"
+	STR_DLGREPLC_REPSTR			"ç½®æ›æ¡ä»¶ã‚’æŒ‡å®šã—ã¦ãã ã•ã„ã€‚"
 
 	// CDlgSameColor.cpp
-	STR_DLGSMCLR_BTN1			"•¶ŽšF“ˆê"
-	STR_DLGSMCLR_BTN2			"”wŒiF“ˆê"
+	STR_DLGSMCLR_BTN1			"æ–‡å­—è‰²çµ±ä¸€"
+	STR_DLGSMCLR_BTN2			"èƒŒæ™¯è‰²çµ±ä¸€"
 
 	// CDlgTagJumpList.cpp
-	STR_DLGTAGJMP1				"(’Ê’m)"
-	STR_DLGTAGJMP2				"(Œó•â‚ÍŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½)"
-	STR_DLGTAGJMP_LIST1			"ƒL[ƒ[ƒh"
-	STR_DLGTAGJMP_LIST2			"ŠK‘w"
-	STR_DLGTAGJMP_LIST3			"s”Ô†"
-	STR_DLGTAGJMP_LIST4			"Ží—Þ"
-	STR_DLGTAGJMP_LIST5			"ƒtƒ@ƒCƒ‹–¼"
-	STR_DLGTAGJMP_LIST6			"”õl"
-	STR_DLGTAGJMP3				"ƒL[ƒ[ƒh ŒŸõ’†..."
+	STR_DLGTAGJMP1				"(é€šçŸ¥)"
+	STR_DLGTAGJMP2				"(å€™è£œã¯è¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã§ã—ãŸ)"
+	STR_DLGTAGJMP_LIST1			"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰"
+	STR_DLGTAGJMP_LIST2			"éšŽå±¤"
+	STR_DLGTAGJMP_LIST3			"è¡Œç•ªå·"
+	STR_DLGTAGJMP_LIST4			"ç¨®é¡ž"
+	STR_DLGTAGJMP_LIST5			"ãƒ•ã‚¡ã‚¤ãƒ«å"
+	STR_DLGTAGJMP_LIST6			"å‚™è€ƒ"
+	STR_DLGTAGJMP3				"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ æ¤œç´¢ä¸­..."
 
 	// CDlgTagsMake.cpp
-	STR_DLGTAGMAK_SELECTDIR		"ƒ^ƒOì¬ƒtƒHƒ‹ƒ_‚Ì‘I‘ð"
+	STR_DLGTAGMAK_SELECTDIR		"ã‚¿ã‚°ä½œæˆãƒ•ã‚©ãƒ«ãƒ€ã®é¸æŠž"
 
 	// CDlgWinSize.cpp
-	STR_DLGWINSZ_NORMAL			"•’Ê"
-	STR_DLGWINSZ_MAXIMIZE		"Å‘å‰»"
-	STR_DLGWINSZ_MINIMIZE		"(Å¬‰»)"
+	STR_DLGWINSZ_NORMAL			"æ™®é€š"
+	STR_DLGWINSZ_MAXIMIZE		"æœ€å¤§åŒ–"
+	STR_DLGWINSZ_MINIMIZE		"(æœ€å°åŒ–)"
 
 	// CDlgProfileMgr.cpp
-	STR_DLGPROFILE_ERR_WRITE		"ƒvƒƒtƒB[ƒ‹Ý’è‚Ì‘‚«ž‚Ý‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_DLGPROFILE_NEW_PROF_TITLE	"V‹Kƒvƒƒtƒ@ƒCƒ‹–¼"
-	STR_DLGPROFILE_NEW_PROF_MSG		"ƒvƒƒtƒ@ƒCƒ‹–¼‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢"
-	STR_DLGPROFILE_ERR_INVALID_CHAR	"—˜—p‚Å‚«‚È‚¢•¶Žš‚ªŠÜ‚Ü‚ê‚Ä‚¢‚Ü‚·B"
-	STR_DLGPROFILE_ERR_ALREADY		"‚·‚Å‚É“¯‚¶–¼‘O‚Ìƒvƒƒtƒ@ƒCƒ‹‚ª‚ ‚è‚Ü‚·B"
-	STR_DLGPROFILE_ERR_FILE			"“¯–¼‚Ìƒtƒ@ƒCƒ‹‚ª‚ ‚é‚½‚ßì¬‚Å‚«‚Ü‚¹‚ñB"
-	STR_DLGPROFILE_RENAME_TITLE		"ƒvƒƒtƒ@ƒCƒ‹–¼‚Ì•ÏX"
-	STR_DLGPROFILE_RENAME_MSG		"ƒvƒƒtƒ@ƒCƒ‹–¼‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢"
-	STR_DLGPROFILE_ERR_RENAME		"–¼‘O‚Ì•ÏX‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\nƒvƒƒtƒ@ƒCƒ‹‚Í—˜—p’†‚Ì‰Â”\«‚ª‚ ‚è‚Ü‚·B"
+	STR_DLGPROFILE_ERR_WRITE		"ãƒ—ãƒ­ãƒ•ã‚£ãƒ¼ãƒ«è¨­å®šã®æ›¸ãè¾¼ã¿ã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_DLGPROFILE_NEW_PROF_TITLE	"æ–°è¦ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«å"
+	STR_DLGPROFILE_NEW_PROF_MSG		"ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«åã‚’å…¥åŠ›ã—ã¦ãã ã•ã„"
+	STR_DLGPROFILE_ERR_INVALID_CHAR	"åˆ©ç”¨ã§ããªã„æ–‡å­—ãŒå«ã¾ã‚Œã¦ã„ã¾ã™ã€‚"
+	STR_DLGPROFILE_ERR_ALREADY		"ã™ã§ã«åŒã˜åå‰ã®ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ãŒã‚ã‚Šã¾ã™ã€‚"
+	STR_DLGPROFILE_ERR_FILE			"åŒåã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒã‚ã‚‹ãŸã‚ä½œæˆã§ãã¾ã›ã‚“ã€‚"
+	STR_DLGPROFILE_RENAME_TITLE		"ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«åã®å¤‰æ›´"
+	STR_DLGPROFILE_RENAME_MSG		"ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«åã‚’å…¥åŠ›ã—ã¦ãã ã•ã„"
+	STR_DLGPROFILE_ERR_RENAME		"åå‰ã®å¤‰æ›´ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\nãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ã¯åˆ©ç”¨ä¸­ã®å¯èƒ½æ€§ãŒã‚ã‚Šã¾ã™ã€‚"
 
 	// CDocOutline.cpp
-	STR_DOCOUTLINE_REGEX		"³‹K•\Œ»ƒ‹[ƒ‹\n%ls\n‚ÅƒGƒ‰[‚ª”­¶‚µ‚Ü‚µ‚½B\n%ts"
+	STR_DOCOUTLINE_REGEX		"æ­£è¦è¡¨ç¾ãƒ«ãƒ¼ãƒ«\n%ls\nã§ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚\n%ts"
 
 	// CDocLineMgr.cpp
-	STR_ERR_DLGDOCLM1			"%ls\n‚Æ‚¢‚¤ƒtƒ@ƒCƒ‹‚ðŠJ‚¯‚Ü‚¹‚ñB\nƒtƒ@ƒCƒ‹‚ª‘¶Ý‚µ‚Ü‚¹‚ñB"
-	STR_ERR_DLGDOCLM2			"'%ls'\n‚Æ‚¢‚¤ƒtƒ@ƒCƒ‹‚ðŠJ‚¯‚Ü‚¹‚ñB\n“Ç‚Ýž‚ÝƒAƒNƒZƒXŒ ‚ª‚ ‚è‚Ü‚¹‚ñB"
-	STR_ERR_DLGDOCLM3			"'%ls'\n‚Æ‚¢‚¤ƒtƒ@ƒCƒ‹‚ðŠJ‚¯‚Ü‚¹‚ñB\n‘¼‚ÌƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚ÅŽg—p‚³‚ê‚Ä‚¢‚é‰Â”\«‚ª‚ ‚è‚Ü‚·B"
-	STR_ERR_DLGDOCLM4			"'%ls'‚Æ‚¢‚¤ƒtƒ@ƒCƒ‹‚Ì“Ç‚Ýž‚Ý’†‚ÉƒGƒ‰[‚ª”­¶‚µ‚Ü‚µ‚½B\nƒtƒ@ƒCƒ‹‚Ì“Ç‚Ýž‚Ý‚ð’†Ž~‚µ‚Ü‚·B"
-	STR_ERR_DLGDOCLM5			"'%ls'\nƒtƒ@ƒCƒ‹‚ð•Û‘¶‚Å‚«‚Ü‚¹‚ñB\nƒpƒX‚ª‘¶Ý‚µ‚È‚¢‚©A‘¼‚ÌƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚ÅŽg—p‚³‚ê‚Ä‚¢‚é‰Â”\«‚ª‚ ‚è‚Ü‚·B"
-	STR_ERR_DLGDOCLM6			"CDocLineMgr::GetAllData()\nƒƒ‚ƒŠŠm•Û‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\n%dƒoƒCƒg"
+	STR_ERR_DLGDOCLM1			"%ls\nã¨ã„ã†ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ã¾ã›ã‚“ã€‚\nãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ã¾ã›ã‚“ã€‚"
+	STR_ERR_DLGDOCLM2			"'%ls'\nã¨ã„ã†ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ã¾ã›ã‚“ã€‚\nèª­ã¿è¾¼ã¿ã‚¢ã‚¯ã‚»ã‚¹æ¨©ãŒã‚ã‚Šã¾ã›ã‚“ã€‚"
+	STR_ERR_DLGDOCLM3			"'%ls'\nã¨ã„ã†ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ã¾ã›ã‚“ã€‚\nä»–ã®ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã§ä½¿ç”¨ã•ã‚Œã¦ã„ã‚‹å¯èƒ½æ€§ãŒã‚ã‚Šã¾ã™ã€‚"
+	STR_ERR_DLGDOCLM4			"'%ls'ã¨ã„ã†ãƒ•ã‚¡ã‚¤ãƒ«ã®èª­ã¿è¾¼ã¿ä¸­ã«ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚\nãƒ•ã‚¡ã‚¤ãƒ«ã®èª­ã¿è¾¼ã¿ã‚’ä¸­æ­¢ã—ã¾ã™ã€‚"
+	STR_ERR_DLGDOCLM5			"'%ls'\nãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä¿å­˜ã§ãã¾ã›ã‚“ã€‚\nãƒ‘ã‚¹ãŒå­˜åœ¨ã—ãªã„ã‹ã€ä»–ã®ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã§ä½¿ç”¨ã•ã‚Œã¦ã„ã‚‹å¯èƒ½æ€§ãŒã‚ã‚Šã¾ã™ã€‚"
+	STR_ERR_DLGDOCLM6			"CDocLineMgr::GetAllData()\nãƒ¡ãƒ¢ãƒªç¢ºä¿ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\n%dãƒã‚¤ãƒˆ"
 
 	// CDocLineMgr_New.cpp
-	STR_ERR_DLGDOCLMN1			"sakura: ìŽÒ‚É‹³‚¦‚Ä—~‚µ‚¢ƒGƒ‰["
+	STR_ERR_DLGDOCLMN1			"sakura: ä½œè€…ã«æ•™ãˆã¦æ¬²ã—ã„ã‚¨ãƒ©ãƒ¼"
 
 	// CDropTarget.cpp
-	STR_ERR_DLGDRPTGT1			"::RegisterDragDrop()\nŽ¸”s"
+	STR_ERR_DLGDRPTGT1			"::RegisterDragDrop()\nå¤±æ•—"
 
 	// CControlTray.cpp
-	STR_TRAY_CREATE				"CControlTray::Create()\nƒEƒBƒ“ƒhƒEƒNƒ‰ƒX‚ð“o˜^‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½B"
-	STR_TRAY_TYPE_NAME			"Ý’è%d"
-	STR_TRAY_EXTHELP1			"ŠO•”ƒwƒ‹ƒv‚P‚ªÝ’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB\n¡‚·‚®Ý’è‚µ‚Ü‚·‚©?"
-	STR_TRAY_RESPONSEFILE		"ƒŒƒXƒ|ƒ“ƒXƒtƒ@ƒCƒ‹‚Ìì¬‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_TRAY_CREATEPROC1		"'%ts'\nƒvƒƒZƒX‚Ì‹N“®‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\n%ts"
-	STR_TRAY_CREATEPROC2		"'%ts'\nƒvƒƒZƒX‚Ì‹N“®‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_TRAY_EXITALL			"Œ»ÝŠJ‚¢‚Ä‚¢‚é•ÒW—p‚ÌƒEƒBƒ“ƒhƒE‚ð‚·‚×‚Ä•Â‚¶‚ÄI—¹‚µ‚Ü‚·‚©?"
-	STR_TRAY_ACCELTABLE			"CControlTray::CreateAccelTbl()\nƒAƒNƒZƒ‰ƒŒ[ƒ^ ƒe[ƒuƒ‹‚ªì¬‚Å‚«‚Ü‚¹‚ñB\nƒVƒXƒeƒ€ƒŠƒ\[ƒX‚ª•s‘«‚µ‚Ä‚¢‚Ü‚·B"
+	STR_TRAY_CREATE				"CControlTray::Create()\nã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚¯ãƒ©ã‚¹ã‚’ç™»éŒ²ã§ãã¾ã›ã‚“ã§ã—ãŸã€‚"
+	STR_TRAY_TYPE_NAME			"è¨­å®š%d"
+	STR_TRAY_EXTHELP1			"å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘ãŒè¨­å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚\nä»Šã™ãè¨­å®šã—ã¾ã™ã‹?"
+	STR_TRAY_RESPONSEFILE		"ãƒ¬ã‚¹ãƒãƒ³ã‚¹ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_TRAY_CREATEPROC1		"'%ts'\nãƒ—ãƒ­ã‚»ã‚¹ã®èµ·å‹•ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\n%ts"
+	STR_TRAY_CREATEPROC2		"'%ts'\nãƒ—ãƒ­ã‚»ã‚¹ã®èµ·å‹•ã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_TRAY_EXITALL			"ç¾åœ¨é–‹ã„ã¦ã„ã‚‹ç·¨é›†ç”¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã™ã¹ã¦é–‰ã˜ã¦çµ‚äº†ã—ã¾ã™ã‹?"
+	STR_TRAY_ACCELTABLE			"CControlTray::CreateAccelTbl()\nã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ ãƒ†ãƒ¼ãƒ–ãƒ«ãŒä½œæˆã§ãã¾ã›ã‚“ã€‚\nã‚·ã‚¹ãƒ†ãƒ ãƒªã‚½ãƒ¼ã‚¹ãŒä¸è¶³ã—ã¦ã„ã¾ã™ã€‚"
 
 
 	// CEditDoc.cpp
-	STR_LOADAGENT_ERR_OPEN		"'%ts'\n‚Æ‚¢‚¤ƒtƒ@ƒCƒ‹‚ðŠJ‚¯‚Ü‚¹‚ñB\n“Ç‚Ýž‚ÝƒAƒNƒZƒXŒ ‚ª‚ ‚è‚Ü‚¹‚ñB"
-	STR_LOADAGENT_BIG_FILE		"ƒtƒ@ƒCƒ‹ƒTƒCƒY‚ª%dMBˆÈã‚ ‚è‚Ü‚·BŠJ‚«‚Ü‚·‚©H"
-	STR_SAVEAGENT_VIEW_FILE		"ƒrƒ…[ƒ‚[ƒh‚Å‚Í“¯ˆêƒtƒ@ƒCƒ‹‚Ö‚Ì•Û‘¶‚Í‚Å‚«‚Ü‚¹‚ñB"
-	STR_SAVEAGENT_OTHER			"'%ts'\nƒtƒ@ƒCƒ‹‚ð•Û‘¶‚Å‚«‚Ü‚¹‚ñB\n‘¼‚ÌƒEƒBƒ“ƒhƒE‚ÅŽg—p’†‚Å‚·B"
-	STR_ERR_DLGEDITDOC5			"•¶ŽšƒR[ƒhî•ñ"
-	STR_ERR_DLGEDITDOC6			"%ts\n\n‚±‚Ìƒtƒ@ƒCƒ‹‚ð•¶ŽšƒR[ƒh %ts ‚ÅŠJ‚±‚¤‚Æ‚µ‚Ä‚¢‚Ü‚·‚ªA‘O‰ñ‚Í•Ê‚Ì•¶ŽšƒR[ƒh %ts ‚ÅŠJ‚©‚ê‚Ä‚¢‚Ü‚·B\n‘O‰ñ‚Æ“¯‚¶•¶ŽšƒR[ƒh‚ðŽg‚¢‚Ü‚·‚©H\n\nE[‚Í‚¢(Y)]  %ts\nE[‚¢‚¢‚¦(N)]%ts\n"
-	STR_NOT_EXSIST_SAVE			"%ts\n‚Æ‚¢‚¤ƒtƒ@ƒCƒ‹‚Í‘¶Ý‚µ‚Ü‚¹‚ñB\n\nƒtƒ@ƒCƒ‹‚ð•Û‘¶‚µ‚½‚Æ‚«‚ÉAƒfƒBƒXƒNã‚É‚±‚Ìƒtƒ@ƒCƒ‹‚ªì¬‚³‚ê‚Ü‚·B"
-	STR_BACKUP_ERR_TITLE		"ƒtƒ@ƒCƒ‹•Û‘¶"
-	STR_BACKUP_ERR_MSG			"ƒoƒbƒNƒAƒbƒv‚Ìì¬‚ÉŽ¸”s‚µ‚Ü‚µ‚½DŒ³ƒtƒ@ƒCƒ‹‚Ö‚Ìã‘‚«‚ðŒp‘±‚µ‚Äs‚¢‚Ü‚·‚©D"
-	STR_BACKUP_ERR_PATH_CRETE	"ƒoƒbƒNƒAƒbƒvæ‚ÌƒpƒXì¬’†‚ÉƒGƒ‰[‚É‚È‚è‚Ü‚µ‚½B\nƒpƒX‚ª’·‚·‚¬‚é‚©•s³‚È‘Ž®‚Å‚·B\nƒoƒbƒNƒAƒbƒv‚ðì¬‚¹‚¸‚Éã‘‚«•Û‘¶‚µ‚Ä‚æ‚ë‚µ‚¢‚Å‚·‚©H"
-	STR_BACKUP_CONFORM_TITLE1		"ƒoƒbƒNƒAƒbƒvì¬‚ÌŠm”F"
-	STR_BACKUP_CONFORM_MSG1		"•ÏX‚³‚ê‚é‘O‚ÉAƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹‚ðì¬‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H  [‚¢‚¢‚¦(N)] ‚ð‘I‚Ô‚Æì¬‚¹‚¸‚Éã‘‚«i‚Ü‚½‚Í–¼‘O‚ð•t‚¯‚Äj•Û‘¶‚É‚È‚è‚Ü‚·B\n\n%ts\n    «\n%ts\n\nì¬‚µ‚½ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹‚ð‚²‚Ý” ‚É•ú‚èž‚Ý‚Ü‚·B\n"
-	STR_BACKUP_CONFORM_TITLE2		"ƒoƒbƒNƒAƒbƒvì¬‚ÌŠm”F"
-	STR_BACKUP_CONFORM_MSG2		"•ÏX‚³‚ê‚é‘O‚ÉAƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹‚ðì¬‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H  [‚¢‚¢‚¦(N)] ‚ð‘I‚Ô‚Æì¬‚¹‚¸‚Éã‘‚«i‚Ü‚½‚Í–¼‘O‚ð•t‚¯‚Äj•Û‘¶‚É‚È‚è‚Ü‚·B\n\n%ts\n    «\n%ts\n\n"
-	STR_BACKUP_ERR_DELETE		"íœŽ¸”s"
-	STR_BACKUP_ERR_MOVE			"ˆÚ“®Ž¸”s"
-	STR_ERR_DLGEDITDOC21		"%ts\n‚ÍŒ»Ý‘¼‚ÌƒvƒƒZƒX‚É‚æ‚Á‚Ä‘ž‚Ý‚ª‹ÖŽ~‚³‚ê‚Ä‚¢‚Ü‚·B"
+	STR_LOADAGENT_ERR_OPEN		"'%ts'\nã¨ã„ã†ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ã¾ã›ã‚“ã€‚\nèª­ã¿è¾¼ã¿ã‚¢ã‚¯ã‚»ã‚¹æ¨©ãŒã‚ã‚Šã¾ã›ã‚“ã€‚"
+	STR_LOADAGENT_BIG_FILE		"ãƒ•ã‚¡ã‚¤ãƒ«ã‚µã‚¤ã‚ºãŒ%dMBä»¥ä¸Šã‚ã‚Šã¾ã™ã€‚é–‹ãã¾ã™ã‹ï¼Ÿ"
+	STR_SAVEAGENT_VIEW_FILE		"ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ã§ã¯åŒä¸€ãƒ•ã‚¡ã‚¤ãƒ«ã¸ã®ä¿å­˜ã¯ã§ãã¾ã›ã‚“ã€‚"
+	STR_SAVEAGENT_OTHER			"'%ts'\nãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä¿å­˜ã§ãã¾ã›ã‚“ã€‚\nä»–ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã§ä½¿ç”¨ä¸­ã§ã™ã€‚"
+	STR_ERR_DLGEDITDOC5			"æ–‡å­—ã‚³ãƒ¼ãƒ‰æƒ…å ±"
+	STR_ERR_DLGEDITDOC6			"%ts\n\nã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æ–‡å­—ã‚³ãƒ¼ãƒ‰ %ts ã§é–‹ã“ã†ã¨ã—ã¦ã„ã¾ã™ãŒã€å‰å›žã¯åˆ¥ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ %ts ã§é–‹ã‹ã‚Œã¦ã„ã¾ã™ã€‚\nå‰å›žã¨åŒã˜æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚’ä½¿ã„ã¾ã™ã‹ï¼Ÿ\n\nãƒ»[ã¯ã„(Y)]  ï¼%ts\nãƒ»[ã„ã„ãˆ(N)]ï¼%ts\n"
+	STR_NOT_EXSIST_SAVE			"%ts\nã¨ã„ã†ãƒ•ã‚¡ã‚¤ãƒ«ã¯å­˜åœ¨ã—ã¾ã›ã‚“ã€‚\n\nãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä¿å­˜ã—ãŸã¨ãã«ã€ãƒ‡ã‚£ã‚¹ã‚¯ä¸Šã«ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒä½œæˆã•ã‚Œã¾ã™ã€‚"
+	STR_BACKUP_ERR_TITLE		"ãƒ•ã‚¡ã‚¤ãƒ«ä¿å­˜"
+	STR_BACKUP_ERR_MSG			"ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã®ä½œæˆã«å¤±æ•—ã—ã¾ã—ãŸï¼Žå…ƒãƒ•ã‚¡ã‚¤ãƒ«ã¸ã®ä¸Šæ›¸ãã‚’ç¶™ç¶šã—ã¦è¡Œã„ã¾ã™ã‹ï¼Ž"
+	STR_BACKUP_ERR_PATH_CRETE	"ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—å…ˆã®ãƒ‘ã‚¹ä½œæˆä¸­ã«ã‚¨ãƒ©ãƒ¼ã«ãªã‚Šã¾ã—ãŸã€‚\nãƒ‘ã‚¹ãŒé•·ã™ãŽã‚‹ã‹ä¸æ­£ãªæ›¸å¼ã§ã™ã€‚\nãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã›ãšã«ä¸Šæ›¸ãä¿å­˜ã—ã¦ã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
+	STR_BACKUP_CONFORM_TITLE1		"ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ä½œæˆã®ç¢ºèª"
+	STR_BACKUP_CONFORM_MSG1		"å¤‰æ›´ã•ã‚Œã‚‹å‰ã«ã€ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½œæˆã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ  [ã„ã„ãˆ(N)] ã‚’é¸ã¶ã¨ä½œæˆã›ãšã«ä¸Šæ›¸ãï¼ˆã¾ãŸã¯åå‰ã‚’ä»˜ã‘ã¦ï¼‰ä¿å­˜ã«ãªã‚Šã¾ã™ã€‚\n\n%ts\n    â†“\n%ts\n\nä½œæˆã—ãŸãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã”ã¿ç®±ã«æ”¾ã‚Šè¾¼ã¿ã¾ã™ã€‚\n"
+	STR_BACKUP_CONFORM_TITLE2		"ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ä½œæˆã®ç¢ºèª"
+	STR_BACKUP_CONFORM_MSG2		"å¤‰æ›´ã•ã‚Œã‚‹å‰ã«ã€ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½œæˆã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ  [ã„ã„ãˆ(N)] ã‚’é¸ã¶ã¨ä½œæˆã›ãšã«ä¸Šæ›¸ãï¼ˆã¾ãŸã¯åå‰ã‚’ä»˜ã‘ã¦ï¼‰ä¿å­˜ã«ãªã‚Šã¾ã™ã€‚\n\n%ts\n    â†“\n%ts\n\n"
+	STR_BACKUP_ERR_DELETE		"å‰Šé™¤å¤±æ•—"
+	STR_BACKUP_ERR_MOVE			"ç§»å‹•å¤±æ•—"
+	STR_ERR_DLGEDITDOC21		"%ts\nã¯ç¾åœ¨ä»–ã®ãƒ—ãƒ­ã‚»ã‚¹ã«ã‚ˆã£ã¦æ›¸è¾¼ã¿ãŒç¦æ­¢ã•ã‚Œã¦ã„ã¾ã™ã€‚"
 
-	STR_EXCLU_NO_EXCLUSIVE		"‚µ‚È‚¢"
-	STR_EXCLU_DENY_WRITE		"ã‘‚«‚ð‹ÖŽ~‚·‚é"
-	STR_EXCLU_DENY_READWRITE	"“Ç‚Ý‘‚«‚ð‹ÖŽ~‚·‚é"
-	STR_EXCLU_UNDEFINED			"–¢’è‹`‚Ìƒ‚[ƒhi–â‘è‚ª‚ ‚è‚Ü‚·j"
-	STR_FILE_LOCK_ERR			"%ts\n‚ð%ts‚ÅƒƒbƒN‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½B\nŒ»Ý‚±‚Ìƒtƒ@ƒCƒ‹‚É‘Î‚·‚é”r‘¼§Œä‚Í–³Œø‚Æ‚È‚è‚Ü‚·B"
+	STR_EXCLU_NO_EXCLUSIVE		"ã—ãªã„"
+	STR_EXCLU_DENY_WRITE		"ä¸Šæ›¸ãã‚’ç¦æ­¢ã™ã‚‹"
+	STR_EXCLU_DENY_READWRITE	"èª­ã¿æ›¸ãã‚’ç¦æ­¢ã™ã‚‹"
+	STR_EXCLU_UNDEFINED			"æœªå®šç¾©ã®ãƒ¢ãƒ¼ãƒ‰ï¼ˆå•é¡ŒãŒã‚ã‚Šã¾ã™ï¼‰"
+	STR_FILE_LOCK_ERR			"%ts\nã‚’%tsã§ãƒ­ãƒƒã‚¯ã§ãã¾ã›ã‚“ã§ã—ãŸã€‚\nç¾åœ¨ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã«å¯¾ã™ã‚‹æŽ’ä»–åˆ¶å¾¡ã¯ç„¡åŠ¹ã¨ãªã‚Šã¾ã™ã€‚"
 
-	STR_TITLE_GREP				"yGrepz%ls%ts"
-	STR_ERR_DLGEDITDOC30		"%ts\n‚Í•ÏX‚³‚ê‚Ä‚¢‚Ü‚·B •Â‚¶‚é‘O‚É•Û‘¶‚µ‚Ü‚·‚©H\n\nƒrƒ…[ƒ‚[ƒh‚ÅŠJ‚¢‚Ä‚¢‚é‚Ì‚ÅA–¼‘O‚ð•t‚¯‚Ä•Û‘¶‚·‚ê‚Î‚¢‚¢‚ÆŽv‚¢‚Ü‚·B\n"
-	STR_CHANGE_CHARSET			"%ts\n‚ÍƒeƒLƒXƒg‚Ì•ÏX‚Í—L‚è‚Ü‚¹‚ñ‚ªA\n•¶ŽšƒR[ƒhƒZƒbƒg‚ª•ÏX‚³‚ê‚Ä‚¢‚Ü‚·B\n•Â‚¶‚é‘O‚É•Û‘¶‚µ‚Ü‚·‚©H"
-	STR_ERR_DLGEDITDOC31		"%ts\n‚Í•ÏX‚³‚ê‚Ä‚¢‚Ü‚·B •Â‚¶‚é‘O‚É•Û‘¶‚µ‚Ü‚·‚©H"
-	STR_AUTORELOAD_NOFITY		"šƒtƒ@ƒCƒ‹XV %02d:%02d:%02d"
+	STR_TITLE_GREP				"ã€Grepã€‘%ls%ts"
+	STR_ERR_DLGEDITDOC30		"%ts\nã¯å¤‰æ›´ã•ã‚Œã¦ã„ã¾ã™ã€‚ é–‰ã˜ã‚‹å‰ã«ä¿å­˜ã—ã¾ã™ã‹ï¼Ÿ\n\nãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ã§é–‹ã„ã¦ã„ã‚‹ã®ã§ã€åå‰ã‚’ä»˜ã‘ã¦ä¿å­˜ã™ã‚Œã°ã„ã„ã¨æ€ã„ã¾ã™ã€‚\n"
+	STR_CHANGE_CHARSET			"%ts\nã¯ãƒ†ã‚­ã‚¹ãƒˆã®å¤‰æ›´ã¯æœ‰ã‚Šã¾ã›ã‚“ãŒã€\næ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆãŒå¤‰æ›´ã•ã‚Œã¦ã„ã¾ã™ã€‚\né–‰ã˜ã‚‹å‰ã«ä¿å­˜ã—ã¾ã™ã‹ï¼Ÿ"
+	STR_ERR_DLGEDITDOC31		"%ts\nã¯å¤‰æ›´ã•ã‚Œã¦ã„ã¾ã™ã€‚ é–‰ã˜ã‚‹å‰ã«ä¿å­˜ã—ã¾ã™ã‹ï¼Ÿ"
+	STR_AUTORELOAD_NOFITY		"â˜…ãƒ•ã‚¡ã‚¤ãƒ«æ›´æ–° %02d:%02d:%02d"
 
 	// CType_Cpp.cpp
-	STR_OUTLINE_CPP_NONAME		"–³–¼"
-	STR_OUTLINE_CPP_DEFPOS		"::’è‹`ˆÊ’u"
+	STR_OUTLINE_CPP_NONAME		"ç„¡å"
+	STR_OUTLINE_CPP_DEFPOS		"::å®šç¾©ä½ç½®"
 
 	// CType_Python.cpp
-	STR_OUTLINE_PYTHON_UNDEFINED	"–¼Ì–¢’è"
-	STR_OUTLINE_PYTHON_CLASS		" ƒNƒ‰ƒX"
+	STR_OUTLINE_PYTHON_UNDEFINED	"åç§°æœªå®š"
+	STR_OUTLINE_PYTHON_CLASS		" ã‚¯ãƒ©ã‚¹"
 
 	// CType_Java.cpp
-	STR_OUTLINE_JAVA_DEFPOS		"’è‹`ˆÊ’u"
+	STR_OUTLINE_JAVA_DEFPOS		"å®šç¾©ä½ç½®"
 
 	// CType_Erlang.cpp
-	STR_OUTLINE_ERLANG_SCANARGS	"COutlineErlang::ScanArgs –¢’m‚ÌŠ‡ŒÊ"
+	STR_OUTLINE_ERLANG_SCANARGS	"COutlineErlang::ScanArgs æœªçŸ¥ã®æ‹¬å¼§"
 
 	// Caret.cpp
-	STR_CARET_WITHBOM			" BOM•t"
+	STR_CARET_WITHBOM			" BOMä»˜"
 
 	// CEditView.cpp
-	STR_VIEW_TIMER				"CEditView::Create()\nƒ^ƒCƒ}[‚ª‹N“®‚Å‚«‚Ü‚¹‚ñB\nƒVƒXƒeƒ€ƒŠƒ\[ƒX‚ª•s‘«‚µ‚Ä‚¢‚é‚Ì‚©‚à‚µ‚ê‚Ü‚¹‚ñB"
-	STR_ERR_DLGEDITVW2			"‘å"
-	STR_ERR_DLGEDITVW5			"\n--------------------\n¡"
-	STR_ERR_DLGEDITVW6			"¡"
-	STR_MENU_KEYWORDINFO		"ƒL[ƒ[ƒh‚Ìà–¾‚ðƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs["
-	STR_MENU_OPENKEYWORDDIC		"ƒL[ƒ[ƒhŽ«‘‚ðŠJ‚­"
-	STR_STATUS_ROW_COL			"%5d s %4d Œ…"
-	STR_INS_MODE_INS			"‘}“ü"
-	STR_INS_MODE_OVR			"ã‘"
-	STR_GREP_SEARCH_CONDITION	"\r\n ŒŸõðŒ  "
-	STR_GREP_SEARCH_FILE		"uƒtƒ@ƒCƒ‹ŒŸõv\r\n"
-	STR_GREP_SEARCH_TARGET		"ŒŸõ‘ÎÛ   "
-	STR_GREP_REPLACE_TO			"’uŠ·Œã     "
-	STR_GREP_PASTE_CLIPBOAD		"(ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯)"
-	STR_GREP_SEARCH_FOLDER		"ƒtƒHƒ‹ƒ_   "
-	STR_GREP_SUBFOLDER_YES		"    (ƒTƒuƒtƒHƒ‹ƒ_‚àŒŸõ)\r\n"
-	STR_GREP_SUBFOLDER_NO		"    (ƒTƒuƒtƒHƒ‹ƒ_‚ðŒŸõ‚µ‚È‚¢)\r\n"
-	STR_GREP_COMPLETE_WORD		"    (’PŒê’PˆÊ‚Å’T‚·)\r\n"
-	STR_GREP_CASE_SENSITIVE		"    (‰p‘å•¶Žš¬•¶Žš‚ð‹æ•Ê‚·‚é)\r\n"
-	STR_GREP_IGNORE_CASE		"    (‰p‘å•¶Žš¬•¶Žš‚ð‹æ•Ê‚µ‚È‚¢)\r\n"
-	STR_GREP_REGEX_DLL			"    (³‹K•\Œ»:"
-	STR_GREP_CHARSET_AUTODETECT	"    (•¶ŽšƒR[ƒhƒZƒbƒg‚ÌŽ©“®”»•Ê)\r\n"
-	STR_GREP_CHARSET			"    (•¶ŽšƒR[ƒhƒZƒbƒgF"
-	STR_GREP_SHOW_MATCH_LINE	"    (ˆê’v‚µ‚½s‚ðo—Í)\r\n"
-	STR_GREP_SHOW_FIRST_LINE	"    (ˆê’v‚µ‚½s‚ÌÅ‰‚Ì‰ÓŠ‚Ì‚Ýo—Í)\r\n"
-	STR_GREP_SHOW_MATCH_AREA	"    (ˆê’v‚µ‚½‰ÓŠ‚Ì‚Ýo—Í)\r\n"
-	STR_GREP_SHOW_MATCH_NOHITLINE	"    (ˆê’v‚µ‚È‚©‚Á‚½s‚ðo—Í)\r\n"
-	STR_GREP_SHOW_FIRST_MATCH	"    (ƒtƒ@ƒCƒ‹–ˆÅ‰‚Ì‚ÝŒŸõ)\r\n"
-	STR_GREP_SUSPENDED			"’†’f‚µ‚Ü‚µ‚½B\r\n"
-	STR_GREP_REPLACE_COUNT		"%d ŒÂ‚ð’uŠ·‚µ‚Ü‚µ‚½B\r\n"
-	STR_GREP_MATCH_COUNT		"%d ŒÂ‚ªŒŸõ‚³‚ê‚Ü‚µ‚½B\r\n"
-	STR_GREP_RUNNINNG			"Grep‚Ìˆ—’†‚Å‚·B\n"
-	STR_GREP_ERR_ENUMKEYS0		"(•s–¾)"
-	STR_GREP_ERR_ENUMKEYS1		"ƒtƒ@ƒCƒ‹Žw’è‚ÌƒtƒHƒ‹ƒ_•”•ª‚É‚ÍƒƒCƒ‹ƒhƒJ[ƒh‚ÍŽg‚¦‚Ü‚¹‚ñ"
-	STR_GREP_ERR_ENUMKEYS2		"ƒtƒ@ƒCƒ‹Žw’è‚É‚Íƒtƒ‹ƒpƒX‚ÍŽg‚¦‚Ü‚¹‚ñ"
-	STR_GREP_TIMER				"ˆ—ŽžŠÔ: %dƒ~ƒŠ•b\r\n"
+	STR_VIEW_TIMER				"CEditView::Create()\nã‚¿ã‚¤ãƒžãƒ¼ãŒèµ·å‹•ã§ãã¾ã›ã‚“ã€‚\nã‚·ã‚¹ãƒ†ãƒ ãƒªã‚½ãƒ¼ã‚¹ãŒä¸è¶³ã—ã¦ã„ã‚‹ã®ã‹ã‚‚ã—ã‚Œã¾ã›ã‚“ã€‚"
+	STR_ERR_DLGEDITVW2			"å¤§"
+	STR_ERR_DLGEDITVW5			"\n--------------------\nâ– "
+	STR_ERR_DLGEDITVW6			"â– "
+	STR_MENU_KEYWORDINFO		"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®èª¬æ˜Žã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼"
+	STR_MENU_OPENKEYWORDDIC		"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾žæ›¸ã‚’é–‹ã"
+	STR_STATUS_ROW_COL			"%5d è¡Œ %4d æ¡"
+	STR_INS_MODE_INS			"æŒ¿å…¥"
+	STR_INS_MODE_OVR			"ä¸Šæ›¸"
+	STR_GREP_SEARCH_CONDITION	"\r\nâ–¡æ¤œç´¢æ¡ä»¶  "
+	STR_GREP_SEARCH_FILE		"ã€Œãƒ•ã‚¡ã‚¤ãƒ«æ¤œç´¢ã€\r\n"
+	STR_GREP_SEARCH_TARGET		"æ¤œç´¢å¯¾è±¡   "
+	STR_GREP_REPLACE_TO			"ç½®æ›å¾Œ     "
+	STR_GREP_PASTE_CLIPBOAD		"(ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘)"
+	STR_GREP_SEARCH_FOLDER		"ãƒ•ã‚©ãƒ«ãƒ€   "
+	STR_GREP_SUBFOLDER_YES		"    (ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚æ¤œç´¢)\r\n"
+	STR_GREP_SUBFOLDER_NO		"    (ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚’æ¤œç´¢ã—ãªã„)\r\n"
+	STR_GREP_COMPLETE_WORD		"    (å˜èªžå˜ä½ã§æŽ¢ã™)\r\n"
+	STR_GREP_CASE_SENSITIVE		"    (è‹±å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã™ã‚‹)\r\n"
+	STR_GREP_IGNORE_CASE		"    (è‹±å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã—ãªã„)\r\n"
+	STR_GREP_REGEX_DLL			"    (æ­£è¦è¡¨ç¾:"
+	STR_GREP_CHARSET_AUTODETECT	"    (æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã®è‡ªå‹•åˆ¤åˆ¥)\r\n"
+	STR_GREP_CHARSET			"    (æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆï¼š"
+	STR_GREP_SHOW_MATCH_LINE	"    (ä¸€è‡´ã—ãŸè¡Œã‚’å‡ºåŠ›)\r\n"
+	STR_GREP_SHOW_FIRST_LINE	"    (ä¸€è‡´ã—ãŸè¡Œã®æœ€åˆã®ç®‡æ‰€ã®ã¿å‡ºåŠ›)\r\n"
+	STR_GREP_SHOW_MATCH_AREA	"    (ä¸€è‡´ã—ãŸç®‡æ‰€ã®ã¿å‡ºåŠ›)\r\n"
+	STR_GREP_SHOW_MATCH_NOHITLINE	"    (ä¸€è‡´ã—ãªã‹ã£ãŸè¡Œã‚’å‡ºåŠ›)\r\n"
+	STR_GREP_SHOW_FIRST_MATCH	"    (ãƒ•ã‚¡ã‚¤ãƒ«æ¯Žæœ€åˆã®ã¿æ¤œç´¢)\r\n"
+	STR_GREP_SUSPENDED			"ä¸­æ–­ã—ã¾ã—ãŸã€‚\r\n"
+	STR_GREP_REPLACE_COUNT		"%d å€‹ã‚’ç½®æ›ã—ã¾ã—ãŸã€‚\r\n"
+	STR_GREP_MATCH_COUNT		"%d å€‹ãŒæ¤œç´¢ã•ã‚Œã¾ã—ãŸã€‚\r\n"
+	STR_GREP_RUNNINNG			"Grepã®å‡¦ç†ä¸­ã§ã™ã€‚\n"
+	STR_GREP_ERR_ENUMKEYS0		"(ä¸æ˜Ž)"
+	STR_GREP_ERR_ENUMKEYS1		"ãƒ•ã‚¡ã‚¤ãƒ«æŒ‡å®šã®ãƒ•ã‚©ãƒ«ãƒ€éƒ¨åˆ†ã«ã¯ãƒ¯ã‚¤ãƒ«ãƒ‰ã‚«ãƒ¼ãƒ‰ã¯ä½¿ãˆã¾ã›ã‚“"
+	STR_GREP_ERR_ENUMKEYS2		"ãƒ•ã‚¡ã‚¤ãƒ«æŒ‡å®šã«ã¯ãƒ•ãƒ«ãƒ‘ã‚¹ã¯ä½¿ãˆã¾ã›ã‚“"
+	STR_GREP_TIMER				"å‡¦ç†æ™‚é–“: %dãƒŸãƒªç§’\r\n"
 	STR_GREP_ERR_FILEOPEN		"file open error [%ts]\r\n"
-	STR_GREP_ERR_FILEREAD		"ƒtƒ@ƒCƒ‹‚Ì“Ç‚Ýž‚Ý’†‚ÉƒGƒ‰[‚ª”­¶‚µ‚Ü‚µ‚½B[%ts]\r\n"
-	STR_GREP_ERR_FILEWRITE		"‘‚«ž‚ß‚Ü‚¹‚ñ‚Å‚µ‚½B [%ts]\r\n"
-	STR_GREP_REP_ERR_DELETE		"ƒtƒ@ƒCƒ‹‚Ìíœ‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_GREP_REP_ERR_REPLACE	"ƒtƒ@ƒCƒ‹‚Ì’u‚«Š·‚¦‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
+	STR_GREP_ERR_FILEREAD		"ãƒ•ã‚¡ã‚¤ãƒ«ã®èª­ã¿è¾¼ã¿ä¸­ã«ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚[%ts]\r\n"
+	STR_GREP_ERR_FILEWRITE		"æ›¸ãè¾¼ã‚ã¾ã›ã‚“ã§ã—ãŸã€‚ [%ts]\r\n"
+	STR_GREP_REP_ERR_DELETE		"ãƒ•ã‚¡ã‚¤ãƒ«ã®å‰Šé™¤ã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_GREP_REP_ERR_REPLACE	"ãƒ•ã‚¡ã‚¤ãƒ«ã®ç½®ãæ›ãˆã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
 
 	// CEditView_ExecCmd.cpp
-	STR_EDITVIEW_EXECCMD_ERR	"ƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_EDITVIEW_EXECCMD_STOP	"\r\n’†’f‚µ‚Ü‚µ‚½B\r\n"
-	STR_EDITVIEW_EXECCMD_RET	"\r\nI—¹ƒR[ƒh: %d\r\n"
+	STR_EDITVIEW_EXECCMD_ERR	"ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_EDITVIEW_EXECCMD_STOP	"\r\nä¸­æ–­ã—ã¾ã—ãŸã€‚\r\n"
+	STR_EDITVIEW_EXECCMD_RET	"\r\nçµ‚äº†ã‚³ãƒ¼ãƒ‰: %d\r\n"
 
 	// CEditView_CmdHokan.cpp
-	STR_ERR_DLGEDITVWHOKAN1		"•âŠ®Œó•âˆê——ƒtƒ@ƒCƒ‹‚ªÝ’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB\n¡‚·‚®Ý’è‚µ‚Ü‚·‚©?"
-	STR_SUPPORT_NOT_COMPLITE	"•âŠ®‘ÎÛ‚ª‚ ‚è‚Ü‚¹‚ñ"
+	STR_ERR_DLGEDITVWHOKAN1		"è£œå®Œå€™è£œä¸€è¦§ãƒ•ã‚¡ã‚¤ãƒ«ãŒè¨­å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚\nä»Šã™ãè¨­å®šã—ã¾ã™ã‹?"
+	STR_SUPPORT_NOT_COMPLITE	"è£œå®Œå¯¾è±¡ãŒã‚ã‚Šã¾ã›ã‚“"
 
 	// CEditView_Cmdisrch.cpp
-	STR_EDITVWISRCH_REGEX		"³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚ªŽg—p‚Å‚«‚Ü‚¹‚ñB"
-	STR_EDITVWISRCH_MIGEGO1		"MIGEMO.DLL‚ªŽg—p‚Å‚«‚Ü‚¹‚ñB"
-	STR_EDITVWISRCH_MIGEGO2		"MIGEMO‚ÍŽg—p‚Å‚«‚Ü‚¹‚ñB"
-	STR_EDITVWISRCH_NOMATCH		" (Œ©‚Â‚©‚è‚Ü‚¹‚ñ)"
+	STR_EDITVWISRCH_REGEX		"æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªãŒä½¿ç”¨ã§ãã¾ã›ã‚“ã€‚"
+	STR_EDITVWISRCH_MIGEGO1		"MIGEMO.DLLãŒä½¿ç”¨ã§ãã¾ã›ã‚“ã€‚"
+	STR_EDITVWISRCH_MIGEGO2		"MIGEMOã¯ä½¿ç”¨ã§ãã¾ã›ã‚“ã€‚"
+	STR_EDITVWISRCH_NOMATCH		" (è¦‹ã¤ã‹ã‚Šã¾ã›ã‚“)"
 
 	// CEditView_Command.cpp
-	STR_ERR_MACRO1				"ƒ}ƒNƒ %d (%ts) ‚ÌŽÀs‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_ERR_SRPREV1				"£––”ö‚©‚çÄŒŸõ‚µ‚Ü‚µ‚½"
-	STR_ERR_SRPREV2				"¢Œ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½"
-	STR_ERR_SRPREV3				"Œã•û(ª) ‚É•¶Žš—ñ '%ls' ‚ª‚P‚Â‚àŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_ERR_SRNEXT1				"¥æ“ª‚©‚çÄŒŸõ‚µ‚Ü‚µ‚½"
-	STR_ERR_SRNEXT2				"¤Œ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½"
-	STR_ERR_SRNEXT3				"‘O•û(«) ‚É•¶Žš—ñ '%ls' ‚ª‚P‚Â‚àŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_ERR_UNINDENT1			"š‹tƒCƒ“ƒfƒ“ƒg‚Í‘I‘ðŽž‚Ì‚Ý"
-	STR_ERR_TAGJMP1				"ƒ^ƒOƒWƒƒƒ“ƒv‚Å‚«‚Ü‚¹‚ñ"
-	STR_ERR_TAGJMPBK1			"ƒ^ƒOƒWƒƒƒ“ƒvƒoƒbƒN‚Å‚«‚Ü‚¹‚ñ"
-	STR_ERR_MACROERR1			"ƒ}ƒNƒ‚Ì“Ç‚Ýž‚Ý‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\n\n%ts"
-	STR_ERR_CEDITVIEW_CMD01		"ŠO•”ƒwƒ‹ƒv‚P‚ªÝ’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB\n¡‚·‚®Ý’è‚µ‚Ü‚·‚©?"
-	STR_ERR_CEDITVIEW_CMD02		"ŠO•”HTMLƒwƒ‹ƒv‚ªÝ’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB\n¡‚·‚®Ý’è‚µ‚Ü‚·‚©?"
-	STR_ERR_CEDITVIEW_CMD03		"ƒ^ƒOì¬ƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B\n\nCTAGS.EXE ‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_ERR_CEDITVIEW_CMD04		"ƒ^ƒOì¬ƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B\n\n%ts"
-	STR_ERR_CEDITVIEW_CMD05		"ƒ^ƒOƒtƒ@ƒCƒ‹‚ðì¬’†‚Å‚·B"
-	STR_ERR_CEDITVIEW_CMD06		"ƒ^ƒOì¬ƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B\n\n%hs"
-	STR_ERR_CEDITVIEW_CMD07		"ƒ^ƒOƒtƒ@ƒCƒ‹‚Ìì¬‚ªI—¹‚µ‚Ü‚µ‚½B"
-	STR_ERR_CEDITVIEW_CMD08		"C/C++ƒwƒbƒ_ƒtƒ@ƒCƒ‹‚ÌƒI[ƒvƒ“‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_ERR_CEDITVIEW_CMD09		"C/C++ƒ\[ƒXƒtƒ@ƒCƒ‹‚ÌƒI[ƒvƒ“‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_ERR_CEDITVIEW_CMD10		"ƒNƒŠƒbƒvƒ{[ƒh‚É—LŒø‚Èƒf[ƒ^‚ª‚ ‚è‚Ü‚¹‚ñI"
-	STR_ERR_CEDITVIEW_CMD11		"ÅŒã‚Ü‚Å’uŠ·‚µ‚Ü‚µ‚½B"
-	STR_ERR_CEDITVIEW_CMD14		"ƒtƒ@ƒCƒ‹‚Ì‘‚«ž‚Ý‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\n\n%ts"
-	STR_ERR_CEDITVIEW_CMD16		"ƒtƒ@ƒCƒ‹‚Ì‘‚«ž‚Ý‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\n\n%ts"
-	STR_ERR_CEDITVIEW_CMD18		"%ts\n‚Í•ÏX‚³‚ê‚Ä‚¢‚Ü‚·B Oracle SQL*Plus‚ÅŽÀs‚·‚é‘O‚É•Û‘¶‚µ‚Ü‚·‚©H"
-	STR_ERR_CEDITVIEW_CMD20		"Oracle SQL*Plus‚©‚ç‚Ì”½‰ž‚ª‚ ‚è‚Ü‚¹‚ñB\n‚µ‚Î‚ç‚­‘Ò‚Á‚Ä‚©‚çÄ‚ÑŽÀs‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_ERR_CEDITVIEW_CMD21		"SQL‚ðƒtƒ@ƒCƒ‹‚É•Û‘¶‚µ‚È‚¢‚ÆOracle SQL*Plus‚ÅŽÀs‚Å‚«‚Ü‚¹‚ñB\n"
-	STR_ERR_CEDITVIEW_CMD22		"ˆÙ‚È‚é‰ÓŠ‚ÍŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½B"
-	STR_ERR_CEDITVIEW_CMD23		"ˆÙ‚È‚é‰ÓŠ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½B"
-	STR_ERR_CEDITVIEW_CMD24		"ƒ}ƒNƒƒtƒ@ƒCƒ‹‚ðì¬‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½B\nƒtƒ@ƒCƒ‹–¼‚ÌŽæ“¾ƒGƒ‰[ nRet=%d"
-	STR_ERR_CEDITVIEW_CMD25		"ƒ}ƒNƒƒtƒ@ƒCƒ‹‚ðì¬‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½B\n\n%ts"
-	STR_ERR_CEDITVIEW_CMD26		"•Û‘¶‰Â”\‚Èƒ}ƒNƒ‚ª‚ ‚è‚Ü‚¹‚ñDƒL[ƒ{[ƒhƒ}ƒNƒˆÈŠO‚Í•Û‘¶‚Å‚«‚Ü‚¹‚ñD"
-	STR_ERR_CEDITVIEW_CMD27		"ƒ}ƒNƒƒtƒ@ƒCƒ‹‚ðì¬‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½B\n\n%ts"
-	STR_ERR_CEDITVIEW_CMD28		"ƒtƒ@ƒCƒ‹‚ðŠJ‚¯‚Ü‚¹‚ñ‚Å‚µ‚½B\n\n%ts"
-	STR_ERR_CEDITVIEW_CMD29		"%ts\n\n‚±‚Ìƒtƒ@ƒCƒ‹‚Í•ÏX‚³‚ê‚Ä‚¢‚Ü‚·B\nÄƒ[ƒh‚ðs‚¤‚Æ•ÏX‚ªŽ¸‚í‚ê‚Ü‚·‚ªA‚æ‚ë‚µ‚¢‚Å‚·‚©?"
+	STR_ERR_MACRO1				"ãƒžã‚¯ãƒ­ %d (%ts) ã®å®Ÿè¡Œã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_ERR_SRPREV1				"â–²æœ«å°¾ã‹ã‚‰å†æ¤œç´¢ã—ã¾ã—ãŸ"
+	STR_ERR_SRPREV2				"â–³è¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã§ã—ãŸ"
+	STR_ERR_SRPREV3				"å¾Œæ–¹(â†‘) ã«æ–‡å­—åˆ— '%ls' ãŒï¼‘ã¤ã‚‚è¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_ERR_SRNEXT1				"â–¼å…ˆé ­ã‹ã‚‰å†æ¤œç´¢ã—ã¾ã—ãŸ"
+	STR_ERR_SRNEXT2				"â–½è¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã§ã—ãŸ"
+	STR_ERR_SRNEXT3				"å‰æ–¹(â†“) ã«æ–‡å­—åˆ— '%ls' ãŒï¼‘ã¤ã‚‚è¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_ERR_UNINDENT1			"â˜…é€†ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã¯é¸æŠžæ™‚ã®ã¿"
+	STR_ERR_TAGJMP1				"ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã§ãã¾ã›ã‚“"
+	STR_ERR_TAGJMPBK1			"ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒãƒƒã‚¯ã§ãã¾ã›ã‚“"
+	STR_ERR_MACROERR1			"ãƒžã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\n\n%ts"
+	STR_ERR_CEDITVIEW_CMD01		"å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘ãŒè¨­å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚\nä»Šã™ãè¨­å®šã—ã¾ã™ã‹?"
+	STR_ERR_CEDITVIEW_CMD02		"å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—ãŒè¨­å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚\nä»Šã™ãè¨­å®šã—ã¾ã™ã‹?"
+	STR_ERR_CEDITVIEW_CMD03		"ã‚¿ã‚°ä½œæˆã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚\n\nCTAGS.EXE ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_ERR_CEDITVIEW_CMD04		"ã‚¿ã‚°ä½œæˆã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚\n\n%ts"
+	STR_ERR_CEDITVIEW_CMD05		"ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½œæˆä¸­ã§ã™ã€‚"
+	STR_ERR_CEDITVIEW_CMD06		"ã‚¿ã‚°ä½œæˆã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚\n\n%hs"
+	STR_ERR_CEDITVIEW_CMD07		"ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆãŒçµ‚äº†ã—ã¾ã—ãŸã€‚"
+	STR_ERR_CEDITVIEW_CMD08		"C/C++ãƒ˜ãƒƒãƒ€ãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚ªãƒ¼ãƒ—ãƒ³ã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_ERR_CEDITVIEW_CMD09		"C/C++ã‚½ãƒ¼ã‚¹ãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚ªãƒ¼ãƒ—ãƒ³ã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_ERR_CEDITVIEW_CMD10		"ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«æœ‰åŠ¹ãªãƒ‡ãƒ¼ã‚¿ãŒã‚ã‚Šã¾ã›ã‚“ï¼"
+	STR_ERR_CEDITVIEW_CMD11		"æœ€å¾Œã¾ã§ç½®æ›ã—ã¾ã—ãŸã€‚"
+	STR_ERR_CEDITVIEW_CMD14		"ãƒ•ã‚¡ã‚¤ãƒ«ã®æ›¸ãè¾¼ã¿ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\n\n%ts"
+	STR_ERR_CEDITVIEW_CMD16		"ãƒ•ã‚¡ã‚¤ãƒ«ã®æ›¸ãè¾¼ã¿ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\n\n%ts"
+	STR_ERR_CEDITVIEW_CMD18		"%ts\nã¯å¤‰æ›´ã•ã‚Œã¦ã„ã¾ã™ã€‚ Oracle SQL*Plusã§å®Ÿè¡Œã™ã‚‹å‰ã«ä¿å­˜ã—ã¾ã™ã‹ï¼Ÿ"
+	STR_ERR_CEDITVIEW_CMD20		"Oracle SQL*Plusã‹ã‚‰ã®åå¿œãŒã‚ã‚Šã¾ã›ã‚“ã€‚\nã—ã°ã‚‰ãå¾…ã£ã¦ã‹ã‚‰å†ã³å®Ÿè¡Œã—ã¦ãã ã•ã„ã€‚"
+	STR_ERR_CEDITVIEW_CMD21		"SQLã‚’ãƒ•ã‚¡ã‚¤ãƒ«ã«ä¿å­˜ã—ãªã„ã¨Oracle SQL*Plusã§å®Ÿè¡Œã§ãã¾ã›ã‚“ã€‚\n"
+	STR_ERR_CEDITVIEW_CMD22		"ç•°ãªã‚‹ç®‡æ‰€ã¯è¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã§ã—ãŸã€‚"
+	STR_ERR_CEDITVIEW_CMD23		"ç•°ãªã‚‹ç®‡æ‰€ãŒè¦‹ã¤ã‹ã‚Šã¾ã—ãŸã€‚"
+	STR_ERR_CEDITVIEW_CMD24		"ãƒžã‚¯ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½œæˆã§ãã¾ã›ã‚“ã§ã—ãŸã€‚\nãƒ•ã‚¡ã‚¤ãƒ«åã®å–å¾—ã‚¨ãƒ©ãƒ¼ nRet=%d"
+	STR_ERR_CEDITVIEW_CMD25		"ãƒžã‚¯ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½œæˆã§ãã¾ã›ã‚“ã§ã—ãŸã€‚\n\n%ts"
+	STR_ERR_CEDITVIEW_CMD26		"ä¿å­˜å¯èƒ½ãªãƒžã‚¯ãƒ­ãŒã‚ã‚Šã¾ã›ã‚“ï¼Žã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒžã‚¯ãƒ­ä»¥å¤–ã¯ä¿å­˜ã§ãã¾ã›ã‚“ï¼Ž"
+	STR_ERR_CEDITVIEW_CMD27		"ãƒžã‚¯ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½œæˆã§ãã¾ã›ã‚“ã§ã—ãŸã€‚\n\n%ts"
+	STR_ERR_CEDITVIEW_CMD28		"ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ã¾ã›ã‚“ã§ã—ãŸã€‚\n\n%ts"
+	STR_ERR_CEDITVIEW_CMD29		"%ts\n\nã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã¯å¤‰æ›´ã•ã‚Œã¦ã„ã¾ã™ã€‚\nå†ãƒ­ãƒ¼ãƒ‰ã‚’è¡Œã†ã¨å¤‰æ›´ãŒå¤±ã‚ã‚Œã¾ã™ãŒã€ã‚ˆã‚ã—ã„ã§ã™ã‹?"
 
 	// FIXME -- possibly some left over text in the form of square blocks in the TAGList
 	// inside funciton Command_EXTHELP1
 
 	// CEditView_Command_New.cpp
-	STR_BOOKMARK_NEXT_NOT_FOUND	"‘O•û(«) ‚ÉƒuƒbƒNƒ}[ƒN‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_BOOKMARK_PREV_NOT_FOUND	"Œã•û(ª) ‚ÉƒuƒbƒNƒ}[ƒN‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_FUCLIST_NEXT_NOT_FOUND	"‘O•û(«) ‚ÉŠÖ”‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_FUCLIST_PREV_NOT_FOUND	"Œã•û(ª) ‚ÉŠÖ”‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_ERR_DLGEDITVWCMDNW7		"%ds‚ðƒ}[ƒW‚µ‚Ü‚µ‚½B"
-	STR_ERR_DLGEDITVWCMDNW8		"ƒ}[ƒW‰Â”\‚Ès‚ª‚Ý‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½B"
-	STR_SAVEAGENT_OTHER_APP		"'%ts'\nƒtƒ@ƒCƒ‹‚ð•Û‘¶‚Å‚«‚Ü‚¹‚ñB\nƒpƒX‚ª‘¶Ý‚µ‚È‚¢‚©A‘¼‚ÌƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚ÅŽg—p‚³‚ê‚Ä‚¢‚é‰Â”\«‚ª‚ ‚è‚Ü‚·B"
-	STR_ERR_DLGEDITVWCMDNW11	"ƒtƒ@ƒCƒ‹‚Ì‘‚«ž‚Ý’†‚ÉƒGƒ‰[‚ª”­¶‚µ‚Ü‚µ‚½B"
-	STR_ERR_DLGEDITVWCMDNW12	"ƒtƒ@ƒCƒ‹‚Ì“Ç‚Ýž‚Ý’†‚ÉƒGƒ‰[‚ª”­¶‚µ‚Ü‚µ‚½B"
+	STR_BOOKMARK_NEXT_NOT_FOUND	"å‰æ–¹(â†“) ã«ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_BOOKMARK_PREV_NOT_FOUND	"å¾Œæ–¹(â†‘) ã«ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_FUCLIST_NEXT_NOT_FOUND	"å‰æ–¹(â†“) ã«é–¢æ•°ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_FUCLIST_PREV_NOT_FOUND	"å¾Œæ–¹(â†‘) ã«é–¢æ•°ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_ERR_DLGEDITVWCMDNW7		"%dè¡Œã‚’ãƒžãƒ¼ã‚¸ã—ã¾ã—ãŸã€‚"
+	STR_ERR_DLGEDITVWCMDNW8		"ãƒžãƒ¼ã‚¸å¯èƒ½ãªè¡ŒãŒã¿ã¤ã‹ã‚Šã¾ã›ã‚“ã§ã—ãŸã€‚"
+	STR_SAVEAGENT_OTHER_APP		"'%ts'\nãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä¿å­˜ã§ãã¾ã›ã‚“ã€‚\nãƒ‘ã‚¹ãŒå­˜åœ¨ã—ãªã„ã‹ã€ä»–ã®ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã§ä½¿ç”¨ã•ã‚Œã¦ã„ã‚‹å¯èƒ½æ€§ãŒã‚ã‚Šã¾ã™ã€‚"
+	STR_ERR_DLGEDITVWCMDNW11	"ãƒ•ã‚¡ã‚¤ãƒ«ã®æ›¸ãè¾¼ã¿ä¸­ã«ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚"
+	STR_ERR_DLGEDITVWCMDNW12	"ãƒ•ã‚¡ã‚¤ãƒ«ã®èª­ã¿è¾¼ã¿ä¸­ã«ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚"
 
 	// CEditView_Diff.cpp
-	STR_ERR_DLGEDITVWDIFF1		"·•ªƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B\n\n”äŠr‚·‚éƒtƒ@ƒCƒ‹‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_ERR_DLGEDITVWDIFF2		"·•ªƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B\n\nDIFF.EXE ‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_ERR_DLGEDITVWDIFF3		"·•ªƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B\n\n%ls"
-	STR_ERR_DLGEDITVWDIFF4		"DIFF·•ª‚ðs‚¨‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹‚ÍƒoƒCƒiƒŠƒtƒ@ƒCƒ‹‚Å‚·B"
-	STR_ERR_DLGEDITVWDIFF5		"DIFF·•ª‚ÍŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½B"
-	STR_DIFF_NEXT_NOT_FOUND		"‘O•û(«) ‚É·•ª‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_DIFF_PREV_NOT_FOUND		"Œã•û(ª) ‚É·•ª‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_DIFF_FAILED				"·•ªƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_DIFF_FAILED_TEMP		"·•ªƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B\n\nˆêŽžƒtƒ@ƒCƒ‹‚ðì¬‚Å‚«‚Ü‚¹‚ñB"
-	STR_DIFF_FAILED_LONG		"·•ªƒRƒ}ƒ“ƒhŽÀs‚ÍŽ¸”s‚µ‚Ü‚µ‚½B\n\ns‚ª’·‚·‚¬‚Ü‚·B"
-	STR_MODLINE_NEXT_NOT_FOUND	"‘O•û(«) ‚É•ÏXs‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
-	STR_MODLINE_PREV_NOT_FOUND	"Œã•û(ª) ‚É•ÏXs‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB"
+	STR_ERR_DLGEDITVWDIFF1		"å·®åˆ†ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚\n\næ¯”è¼ƒã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_ERR_DLGEDITVWDIFF2		"å·®åˆ†ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚\n\nDIFF.EXE ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_ERR_DLGEDITVWDIFF3		"å·®åˆ†ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚\n\n%ls"
+	STR_ERR_DLGEDITVWDIFF4		"DIFFå·®åˆ†ã‚’è¡ŒãŠã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ã¯ãƒã‚¤ãƒŠãƒªãƒ•ã‚¡ã‚¤ãƒ«ã§ã™ã€‚"
+	STR_ERR_DLGEDITVWDIFF5		"DIFFå·®åˆ†ã¯è¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã§ã—ãŸã€‚"
+	STR_DIFF_NEXT_NOT_FOUND		"å‰æ–¹(â†“) ã«å·®åˆ†ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_DIFF_PREV_NOT_FOUND		"å¾Œæ–¹(â†‘) ã«å·®åˆ†ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_DIFF_FAILED				"å·®åˆ†ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_DIFF_FAILED_TEMP		"å·®åˆ†ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚\n\nä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½œæˆã§ãã¾ã›ã‚“ã€‚"
+	STR_DIFF_FAILED_LONG		"å·®åˆ†ã‚³ãƒžãƒ³ãƒ‰å®Ÿè¡Œã¯å¤±æ•—ã—ã¾ã—ãŸã€‚\n\nè¡ŒãŒé•·ã™ãŽã¾ã™ã€‚"
+	STR_MODLINE_NEXT_NOT_FOUND	"å‰æ–¹(â†“) ã«å¤‰æ›´è¡ŒãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
+	STR_MODLINE_PREV_NOT_FOUND	"å¾Œæ–¹(â†‘) ã«å¤‰æ›´è¡ŒãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚"
 
 	// CEditView_Mouse.cpp
-	STR_VIEW_MOUSE_BUG			"ƒoƒO‚Á‚Ä‚é"
-	STR_VIEW_MOUSE_MENU_PATH	"ƒpƒX–¼“\‚è•t‚¯(&P)"
-	STR_VIEW_MOUSE_MENU_FILE	"ƒtƒ@ƒCƒ‹–¼“\‚è•t‚¯(&F)"
-	STR_VIEW_MOUSE_MENU_OPEN	"ƒtƒ@ƒCƒ‹‚ðŠJ‚­(&O)"
-	STR_VIEW_MOUSE_MENU_CANCEL	"ƒLƒƒƒ“ƒZƒ‹"
+	STR_VIEW_MOUSE_BUG			"ãƒã‚°ã£ã¦ã‚‹"
+	STR_VIEW_MOUSE_MENU_PATH	"ãƒ‘ã‚¹åè²¼ã‚Šä»˜ã‘(&P)"
+	STR_VIEW_MOUSE_MENU_FILE	"ãƒ•ã‚¡ã‚¤ãƒ«åè²¼ã‚Šä»˜ã‘(&F)"
+	STR_VIEW_MOUSE_MENU_OPEN	"ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã(&O)"
+	STR_VIEW_MOUSE_MENU_CANCEL	"ã‚­ãƒ£ãƒ³ã‚»ãƒ«"
 
 	// CEditView_New.cpp -- no words, going to ignore for now ( just block [], ... etc )
 
@@ -4054,51 +4054,51 @@ BEGIN
 	// CEditView_New3.cpp -- no words, going to ignore for now ( just block [], ... etc )
 
 	// CEditWnd.cpp
-	STR_ERR_DLGEDITWND01		"CEditWnd::CreateAccelTbl()\nƒAƒNƒZƒ‰ƒŒ[ƒ^ ƒe[ƒuƒ‹‚ªì¬‚Å‚«‚Ü‚¹‚ñB\nƒVƒXƒeƒ€ƒŠƒ\[ƒX‚ª•s‘«‚µ‚Ä‚¢‚Ü‚·B"
-	STR_ERR_DLGEDITWND02		"ƒGƒfƒBƒ^ŠÔ‚Ì‘Î˜b‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\nŒ ŒÀƒŒƒxƒ‹‚ÌˆÙ‚È‚éƒGƒfƒBƒ^‚ªŠù‚É‹N“®‚µ‚Ä‚¢‚é‰Â”\«‚ª‚ ‚è‚Ü‚·B"
-	STR_ERR_DLGEDITWND03		"CEditWnd::Create()\nƒ^ƒCƒ}[‚ª‹N“®‚Å‚«‚Ü‚¹‚ñB\nƒVƒXƒeƒ€ƒŠƒ\[ƒX‚ª•s‘«‚µ‚Ä‚¢‚é‚Ì‚©‚à‚µ‚ê‚Ü‚¹‚ñB"
-	STR_ERR_DLGEDITWND04		"Rebar ‚Ìì¬‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_ERR_DLGEDITWND05		"ƒc[ƒ‹ƒo[‚Ìì¬‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_EDITWND_MENU_NEL		"“ü—Í‰üsƒR[ƒhŽw’è(&NEL)"
-	STR_EDITWND_MENU_LS			"“ü—Í‰üsƒR[ƒhŽw’è(L&S)"
-	STR_EDITWND_MENU_PS			"“ü—Í‰üsƒR[ƒhŽw’è(&PS)"
-	STR_ERR_DLGEDITWND13		"•¶Žš:\t\t%ls (%ts)\n\nSJIS:\t\t%ts\nJIS:\t\t%ts\nEUC:\t\t%ts\nLatin1:\t\t%ts\nUTF-16:\t\t%ts\nUTF-8:\t\t%ts\nCESU-8:\t\t%ts"
-	STR_ERR_DLGEDITWND14		"ˆóüƒvƒŒƒrƒ…[‚ðŽÀs‚·‚é‘O‚ÉAƒvƒŠƒ“ƒ^‚ðƒCƒ“ƒXƒg[ƒ‹‚µ‚Ä‚­‚¾‚³‚¢B\n"
+	STR_ERR_DLGEDITWND01		"CEditWnd::CreateAccelTbl()\nã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ ãƒ†ãƒ¼ãƒ–ãƒ«ãŒä½œæˆã§ãã¾ã›ã‚“ã€‚\nã‚·ã‚¹ãƒ†ãƒ ãƒªã‚½ãƒ¼ã‚¹ãŒä¸è¶³ã—ã¦ã„ã¾ã™ã€‚"
+	STR_ERR_DLGEDITWND02		"ã‚¨ãƒ‡ã‚£ã‚¿é–“ã®å¯¾è©±ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\næ¨©é™ãƒ¬ãƒ™ãƒ«ã®ç•°ãªã‚‹ã‚¨ãƒ‡ã‚£ã‚¿ãŒæ—¢ã«èµ·å‹•ã—ã¦ã„ã‚‹å¯èƒ½æ€§ãŒã‚ã‚Šã¾ã™ã€‚"
+	STR_ERR_DLGEDITWND03		"CEditWnd::Create()\nã‚¿ã‚¤ãƒžãƒ¼ãŒèµ·å‹•ã§ãã¾ã›ã‚“ã€‚\nã‚·ã‚¹ãƒ†ãƒ ãƒªã‚½ãƒ¼ã‚¹ãŒä¸è¶³ã—ã¦ã„ã‚‹ã®ã‹ã‚‚ã—ã‚Œã¾ã›ã‚“ã€‚"
+	STR_ERR_DLGEDITWND04		"Rebar ã®ä½œæˆã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_ERR_DLGEDITWND05		"ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã®ä½œæˆã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_EDITWND_MENU_NEL		"å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š(&NEL)"
+	STR_EDITWND_MENU_LS			"å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š(L&S)"
+	STR_EDITWND_MENU_PS			"å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š(&PS)"
+	STR_ERR_DLGEDITWND13		"æ–‡å­—:\t\t%ls (%ts)\n\nSJIS:\t\t%ts\nJIS:\t\t%ts\nEUC:\t\t%ts\nLatin1:\t\t%ts\nUTF-16:\t\t%ts\nUTF-8:\t\t%ts\nCESU-8:\t\t%ts"
+	STR_ERR_DLGEDITWND14		"å°åˆ·ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼ã‚’å®Ÿè¡Œã™ã‚‹å‰ã«ã€ãƒ—ãƒªãƒ³ã‚¿ã‚’ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã—ã¦ãã ã•ã„ã€‚\n"
 
-	//		const char*	pszLabel[7] = { "", "99999 s 9999 —ñ", "CRLF", "0000", "UTF-16", "REC", "ã‘" };	//Oct. 30, 2000 JEPRO ç–œs‚à—v‚ç‚ñ
+	//		const char*	pszLabel[7] = { "", "99999 è¡Œ 9999 åˆ—", "CRLF", "0000", "UTF-16", "REC", "ä¸Šæ›¸" };	//Oct. 30, 2000 JEPRO åƒä¸‡è¡Œã‚‚è¦ã‚‰ã‚“
 	STR_ERR_DLGEDITWND19		""
 	STR_ERR_DLGEDITWND20		"99999 L 9999 C"
-//	STR_ERR_DLGEDITWND20		"99999 s 9999 —ñ"
+//	STR_ERR_DLGEDITWND20		"99999 è¡Œ 9999 åˆ—"
 	STR_ERR_DLGEDITWND21		"CFLF"
 	STR_ERR_DLGEDITWND22		"0000"
-	STR_ERR_DLGEDITWND23		"UTF-16 BOM•t"
+	STR_ERR_DLGEDITWND23		"UTF-16 BOMä»˜"
 	STR_ERR_DLGEDITWND24		"REC"
-	STR_ERR_DLGEDITWND25		"ã‘"
-	STR_WRAP_WIDTH_FULL			"Ü‚è•Ô‚µŒ…”: %d Œ…iÅ‘åj"
-	STR_WRAP_WIDTH_WINDOW		"Ü‚è•Ô‚µŒ…”: %d Œ…i‰E’[j"
-	STR_WRAP_WIDTH_FIXED		"Ü‚è•Ô‚µŒ…”: %d Œ…iŽw’èj"
+	STR_ERR_DLGEDITWND25		"ä¸Šæ›¸"
+	STR_WRAP_WIDTH_FULL			"æŠ˜ã‚Šè¿”ã—æ¡æ•°: %d æ¡ï¼ˆæœ€å¤§ï¼‰"
+	STR_WRAP_WIDTH_WINDOW		"æŠ˜ã‚Šè¿”ã—æ¡æ•°: %d æ¡ï¼ˆå³ç«¯ï¼‰"
+	STR_WRAP_WIDTH_FIXED		"æŠ˜ã‚Šè¿”ã—æ¡æ•°: %d æ¡ï¼ˆæŒ‡å®šï¼‰"
 
 	// CEol.cpp
 
 	// CESI.cpp
-	STR_ESI_CHARCODE_DETECT		"--•¶ŽšƒR[ƒh’²¸Œ‹‰Ê-----------\r\n"
-	STR_ESI_RESULT_STATE		"”»•ÊŒ‹‰Ê‚Ìó‘Ô\r\n"
-	STR_ESI_NO_INFO				"\t”»•ÊŒ‹‰Ê‚ðŽæ“¾‚Å‚«‚Ü‚¹‚ñB\r\n"
-	STR_ESI_DETECTED			"\t‚¨‚»‚ç‚­³í‚É”»’è‚³‚ê‚Ü‚µ‚½B\r\n"
-	STR_ESI_NO_DETECTED			"\tƒR[ƒh‚ðŒŸo‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½B\r\n"
-	STR_ESI_DOC_TYPE			"•¶‘Ží•Ê\r\n"
-	STR_ESI_DEFAULT_CHARCODE	"ƒfƒtƒHƒ‹ƒg•¶ŽšƒR[ƒh\r\n"
-	STR_ESI_SAMPLE_LEN			"ƒTƒ“ƒvƒ‹ƒf[ƒ^’·\r\n"
-	STR_ESI_SAMPLE_LEN_FORMAT	"\t%d ƒoƒCƒg\r\n"
-	STR_ESI_BYTES_AND_POINTS	"ŒÅ—LƒoƒCƒg”‚Æƒ|ƒCƒ“ƒg”\r\n"
-	STR_ESI_UTF16LE_B_AND_P		"\t\tUTF16LE ŒÅ—LƒoƒCƒg” %d,\tƒ|ƒCƒ“ƒg” %d\r\n"
-	STR_ESI_UTF16BE_B_AND_P		"\t\tUTF16BE ŒÅ—LƒoƒCƒg” %d,\tƒ|ƒCƒ“ƒg” %d\r\n"
-	STR_ESI_BOM					"\t\tBOM ‚Ì„‘ªŒ‹‰Ê@"
-	STR_ESI_BOM_UNKNOWN			"•s–¾\r\n"
-	STR_ESI_MBC_OTHER_UNICODE	"\tMBC ‚Æ ã‹LˆÈŠO‚Ì UNICODE ƒtƒ@ƒ~ƒŠ\r\n"
-	STR_ESI_OTHER_B_AND_P		"\t\t%d.%ts\tŒÅ—LƒoƒCƒg” %d\tƒ|ƒCƒ“ƒg” %d\r\n"
-	STR_ESI_EUC_ZENKAKU			"\t\tEEUC‘SŠpƒJƒi‚©‚È/EUC‘SŠp\t%6.3f\r\n"
-	STR_ESI_RESULT				"”»’èŒ‹‰Ê\r\n"
+	STR_ESI_CHARCODE_DETECT		"--æ–‡å­—ã‚³ãƒ¼ãƒ‰èª¿æŸ»çµæžœ-----------\r\n"
+	STR_ESI_RESULT_STATE		"åˆ¤åˆ¥çµæžœã®çŠ¶æ…‹\r\n"
+	STR_ESI_NO_INFO				"\tåˆ¤åˆ¥çµæžœã‚’å–å¾—ã§ãã¾ã›ã‚“ã€‚\r\n"
+	STR_ESI_DETECTED			"\tãŠãã‚‰ãæ­£å¸¸ã«åˆ¤å®šã•ã‚Œã¾ã—ãŸã€‚\r\n"
+	STR_ESI_NO_DETECTED			"\tã‚³ãƒ¼ãƒ‰ã‚’æ¤œå‡ºã§ãã¾ã›ã‚“ã§ã—ãŸã€‚\r\n"
+	STR_ESI_DOC_TYPE			"æ–‡æ›¸ç¨®åˆ¥\r\n"
+	STR_ESI_DEFAULT_CHARCODE	"ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ–‡å­—ã‚³ãƒ¼ãƒ‰\r\n"
+	STR_ESI_SAMPLE_LEN			"ã‚µãƒ³ãƒ—ãƒ«ãƒ‡ãƒ¼ã‚¿é•·\r\n"
+	STR_ESI_SAMPLE_LEN_FORMAT	"\t%d ãƒã‚¤ãƒˆ\r\n"
+	STR_ESI_BYTES_AND_POINTS	"å›ºæœ‰ãƒã‚¤ãƒˆæ•°ã¨ãƒã‚¤ãƒ³ãƒˆæ•°\r\n"
+	STR_ESI_UTF16LE_B_AND_P		"\t\tUTF16LE å›ºæœ‰ãƒã‚¤ãƒˆæ•° %d,\tãƒã‚¤ãƒ³ãƒˆæ•° %d\r\n"
+	STR_ESI_UTF16BE_B_AND_P		"\t\tUTF16BE å›ºæœ‰ãƒã‚¤ãƒˆæ•° %d,\tãƒã‚¤ãƒ³ãƒˆæ•° %d\r\n"
+	STR_ESI_BOM					"\t\tBOM ã®æŽ¨æ¸¬çµæžœã€€"
+	STR_ESI_BOM_UNKNOWN			"ä¸æ˜Ž\r\n"
+	STR_ESI_MBC_OTHER_UNICODE	"\tMBC ã¨ ä¸Šè¨˜ä»¥å¤–ã® UNICODE ãƒ•ã‚¡ãƒŸãƒª\r\n"
+	STR_ESI_OTHER_B_AND_P		"\t\t%d.%ts\tå›ºæœ‰ãƒã‚¤ãƒˆæ•° %d\tãƒã‚¤ãƒ³ãƒˆæ•° %d\r\n"
+	STR_ESI_EUC_ZENKAKU			"\t\tãƒ»EUCå…¨è§’ã‚«ãƒŠã‹ãª/EUCå…¨è§’\t%6.3f\r\n"
+	STR_ESI_RESULT				"åˆ¤å®šçµæžœ\r\n"
 
 	// CFileExt.cpp
 
@@ -4109,30 +4109,30 @@ BEGIN
 	// CFuncInfo.cpp
 
 	// CFuncInfoArr.cpp
-	STR_ERR_DLGFUNCKEYWN1		"CFuncKeyWnd::Open()\nƒ^ƒCƒ}[‚ª‹N“®‚Å‚«‚Ü‚¹‚ñB\nƒVƒXƒeƒ€ƒŠƒ\[ƒX‚ª•s‘«‚µ‚Ä‚¢‚é‚Ì‚©‚à‚µ‚ê‚Ü‚¹‚ñB"
+	STR_ERR_DLGFUNCKEYWN1		"CFuncKeyWnd::Open()\nã‚¿ã‚¤ãƒžãƒ¼ãŒèµ·å‹•ã§ãã¾ã›ã‚“ã€‚\nã‚·ã‚¹ãƒ†ãƒ ãƒªã‚½ãƒ¼ã‚¹ãŒä¸è¶³ã—ã¦ã„ã‚‹ã®ã‹ã‚‚ã—ã‚Œã¾ã›ã‚“ã€‚"
 
 	// CFuncLookup.cpp
-	STR_ERR_DLGFUNCLKUP01		"ŠO•”ƒ}ƒNƒ"
-	STR_ERR_DLGFUNCLKUP02		"ƒJƒXƒ^ƒ€ƒƒjƒ…["
-	STR_ERR_DLGFUNCLKUP03		"ƒ}ƒNƒ %d (–¢“o˜^)"
-	STR_ERR_DLGFUNCLKUP19		"ƒvƒ‰ƒOƒCƒ“"
+	STR_ERR_DLGFUNCLKUP01		"å¤–éƒ¨ãƒžã‚¯ãƒ­"
+	STR_ERR_DLGFUNCLKUP02		"ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼"
+	STR_ERR_DLGFUNCLKUP03		"ãƒžã‚¯ãƒ­ %d (æœªç™»éŒ²)"
+	STR_ERR_DLGFUNCLKUP19		"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³"
 
 	// Related Commands Menu
-	STR_ERR_DLGFUNCLKUP04		"ƒtƒ@ƒCƒ‹‘€ìŒn"
-	STR_ERR_DLGFUNCLKUP05		"•ÒWŒn"
-	STR_ERR_DLGFUNCLKUP06		"ƒJ[ƒ\ƒ‹ˆÚ“®Œn"
-	STR_ERR_DLGFUNCLKUP07		"‘I‘ðŒn"		//Oct. 15, 2000 JEPRO uƒJ[ƒ\ƒ‹ˆÚ“®Œnv‚ª‘½‚­‚È‚Á‚½‚Ì‚Åu‘I‘ðŒnv‚Æ‚µ‚Ä“Æ—§‰»(ƒTƒuƒƒjƒ…[‰»‚Í\‘¢ã‚Å‚«‚È‚¢‚Ì‚Å)
-	STR_ERR_DLGFUNCLKUP08		"‹éŒ`‘I‘ðŒn"	//Oct. 17, 2000 JEPRO u‘I‘ðŒnv‚Éˆê‚É‚·‚é‚Æ‘½‚­‚È‚è‚·‚¬‚é‚Ì‚Åu‹éŒ`‘I‘ðŒnv‚à“Æ—§‚³‚¹‚½
-	STR_ERR_DLGFUNCLKUP09		"ƒNƒŠƒbƒvƒ{[ƒhŒn"
-	STR_ERR_DLGFUNCLKUP10		"‘}“üŒn"
-	STR_ERR_DLGFUNCLKUP11		"•ÏŠ·Œn"
-	STR_ERR_DLGFUNCLKUP12		"ŒŸõŒn"
-	STR_ERR_DLGFUNCLKUP13		"ƒ‚[ƒhØ‚è‘Ö‚¦Œn"
-	STR_ERR_DLGFUNCLKUP14		"Ý’èŒn"
-	STR_ERR_DLGFUNCLKUP15		"ƒ}ƒNƒŒn"
-	STR_ERR_DLGFUNCLKUP16		"ƒEƒBƒ“ƒhƒEŒn"
-	STR_ERR_DLGFUNCLKUP17		"Žx‰‡"
-	STR_ERR_DLGFUNCLKUP18		"‚»‚Ì‘¼"
+	STR_ERR_DLGFUNCLKUP04		"ãƒ•ã‚¡ã‚¤ãƒ«æ“ä½œç³»"
+	STR_ERR_DLGFUNCLKUP05		"ç·¨é›†ç³»"
+	STR_ERR_DLGFUNCLKUP06		"ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³»"
+	STR_ERR_DLGFUNCLKUP07		"é¸æŠžç³»"		//Oct. 15, 2000 JEPRO ã€Œã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³»ã€ãŒå¤šããªã£ãŸã®ã§ã€Œé¸æŠžç³»ã€ã¨ã—ã¦ç‹¬ç«‹åŒ–(ã‚µãƒ–ãƒ¡ãƒ‹ãƒ¥ãƒ¼åŒ–ã¯æ§‹é€ ä¸Šã§ããªã„ã®ã§)
+	STR_ERR_DLGFUNCLKUP08		"çŸ©å½¢é¸æŠžç³»"	//Oct. 17, 2000 JEPRO ã€Œé¸æŠžç³»ã€ã«ä¸€ç·’ã«ã™ã‚‹ã¨å¤šããªã‚Šã™ãŽã‚‹ã®ã§ã€ŒçŸ©å½¢é¸æŠžç³»ã€ã‚‚ç‹¬ç«‹ã•ã›ãŸ
+	STR_ERR_DLGFUNCLKUP09		"ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ç³»"
+	STR_ERR_DLGFUNCLKUP10		"æŒ¿å…¥ç³»"
+	STR_ERR_DLGFUNCLKUP11		"å¤‰æ›ç³»"
+	STR_ERR_DLGFUNCLKUP12		"æ¤œç´¢ç³»"
+	STR_ERR_DLGFUNCLKUP13		"ãƒ¢ãƒ¼ãƒ‰åˆ‡ã‚Šæ›¿ãˆç³»"
+	STR_ERR_DLGFUNCLKUP14		"è¨­å®šç³»"
+	STR_ERR_DLGFUNCLKUP15		"ãƒžã‚¯ãƒ­ç³»"
+	STR_ERR_DLGFUNCLKUP16		"ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç³»"
+	STR_ERR_DLGFUNCLKUP17		"æ”¯æ´"
+	STR_ERR_DLGFUNCLKUP18		"ãã®ä»–"
 
 	// charchode.cpp
 
@@ -4143,18 +4143,18 @@ BEGIN
 	// CImageListMgr.cpp
 
 	// CKeyBind.cpp
-	STR_ERR_DLGKEYBIND1			"ƒL[\t‹@”\–¼\tŠÖ”–¼\t‹@”\”Ô†\tƒL[ƒ}ƒNƒ‹L˜^‰Â/•s‰Â"
-	STR_ERR_DLGKEYBIND2			"---–¼‘O‚ª’è‹`‚³‚ê‚Ä‚¢‚È‚¢-----"
+	STR_ERR_DLGKEYBIND1			"ã‚­ãƒ¼\tæ©Ÿèƒ½å\té–¢æ•°å\tæ©Ÿèƒ½ç•ªå·\tã‚­ãƒ¼ãƒžã‚¯ãƒ­è¨˜éŒ²å¯/ä¸å¯"
+	STR_ERR_DLGKEYBIND2			"---åå‰ãŒå®šç¾©ã•ã‚Œã¦ã„ãªã„-----"
 
 	// CKeyMacroMgr.cpp
-	STR_ERR_DLGKEYMACMGR1		"//ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ìƒtƒ@ƒCƒ‹\r\n"
-	STR_ERR_DLGKEYMACMGR2		"Macro“Ç‚Ýž‚ÝƒGƒ‰["
-	STR_ERR_DLGKEYMACMGR3		"Line %d: Column %d: ˆø”‚ª‘½‚·‚¬‚Ü‚·\n"
-	STR_ERR_DLGKEYMACMGR4		"Line %d: Column %d\r\nŠÖ”%ls‚Ì%d”Ô–Ú‚Ìˆø”‚É•¶Žš—ñ‚Í’u‚¯‚Ü‚¹‚ñD"
-	STR_ERR_DLGKEYMACMGR5		"Line %d:\r\nŠÖ”%ls‚Ì%d”Ô–Ú‚Ìˆø”‚ÌI‚í‚è‚É%lc‚ª‚ ‚è‚Ü‚¹‚ñD"
-	STR_ERR_DLGKEYMACMGR6		"Line %d: Column %d\r\nŠÖ”%ls‚Ì%d”Ô–Ú‚Ìˆø”‚É”’l‚Í’u‚¯‚Ü‚¹‚ñD"
+	STR_ERR_DLGKEYMACMGR1		"//ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒžã‚¯ãƒ­ã®ãƒ•ã‚¡ã‚¤ãƒ«\r\n"
+	STR_ERR_DLGKEYMACMGR2		"Macroèª­ã¿è¾¼ã¿ã‚¨ãƒ©ãƒ¼"
+	STR_ERR_DLGKEYMACMGR3		"Line %d: Column %d: å¼•æ•°ãŒå¤šã™ãŽã¾ã™\n"
+	STR_ERR_DLGKEYMACMGR4		"Line %d: Column %d\r\né–¢æ•°%lsã®%dç•ªç›®ã®å¼•æ•°ã«æ–‡å­—åˆ—ã¯ç½®ã‘ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGKEYMACMGR5		"Line %d:\r\né–¢æ•°%lsã®%dç•ªç›®ã®å¼•æ•°ã®çµ‚ã‚ã‚Šã«%lcãŒã‚ã‚Šã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGKEYMACMGR6		"Line %d: Column %d\r\né–¢æ•°%lsã®%dç•ªç›®ã®å¼•æ•°ã«æ•°å€¤ã¯ç½®ã‘ã¾ã›ã‚“ï¼Ž"
 	STR_ERR_DLGKEYMACMGR7		"Line %d: Column %d: Syntax Error\n"
-	STR_ERR_DLGKEYMACMGR8		"Line %d: %ls‚Í‘¶Ý‚µ‚È‚¢ŠÖ”‚Å‚·D\n"
+	STR_ERR_DLGKEYMACMGR8		"Line %d: %lsã¯å­˜åœ¨ã—ãªã„é–¢æ•°ã§ã™ï¼Ž\n"
 
 	// CKeyWordSetMgr.cpp
 
@@ -4171,24 +4171,24 @@ BEGIN
 	// CLineComment.cpp
 
 	// CMacro.cpp
-	STR_ERR_DLGMACRO01			"CMacro::GetFuncInfoByID()‚ÉAƒoƒO‚ª‚ ‚é‚Ì‚ÅƒGƒ‰[‚ªo‚Ü‚µ‚½‚Ÿ‚Ÿ‚Ÿ‚Ÿ‚Ÿ‚Ÿ‚ ‚ ‚ \r\n"
-	STR_ERR_DLGMACRO02			"MacroŽÀsƒGƒ‰["
-	STR_ERR_DLGMACRO03			"‘}“ü‚·‚×‚«•¶ŽšƒR[ƒh‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO03_1		"“ü—Í‰üsƒR[ƒh‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO04			"ˆø”(•¶Žš—ñ)‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO05			"ƒWƒƒƒ“ƒvæs”Ô†‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO06			"ƒ}[ƒNs‚Ìƒpƒ^[ƒ“‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO07			"ˆø”(•¶Žš—ñ)‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO08			"ƒtƒ@ƒCƒ‹–¼‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO09			"’uŠ·Œ³ƒpƒ^[ƒ“‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO10			"’uŠ·æƒpƒ^[ƒ“‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO11			"GREPƒpƒ^[ƒ“‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO12			"ƒtƒ@ƒCƒ‹Ží•Ê‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO13			"ŒŸõæƒtƒHƒ‹ƒ_‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO14			"“Ç‚Ýž‚Ýƒtƒ@ƒCƒ‹–¼‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO15			"•Û‘¶ƒtƒ@ƒCƒ‹–¼‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
-	STR_ERR_DLGMACRO16			"”’l‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢D"
-	STR_ERR_DLGMACRO17			"GREP’uŠ·Œã‚ªŽw’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñD"
+	STR_ERR_DLGMACRO01			"CMacro::GetFuncInfoByID()ã«ã€ãƒã‚°ãŒã‚ã‚‹ã®ã§ã‚¨ãƒ©ãƒ¼ãŒå‡ºã¾ã—ãŸããããããã‚ã‚ã‚\r\n"
+	STR_ERR_DLGMACRO02			"Macroå®Ÿè¡Œã‚¨ãƒ©ãƒ¼"
+	STR_ERR_DLGMACRO03			"æŒ¿å…¥ã™ã¹ãæ–‡å­—ã‚³ãƒ¼ãƒ‰ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO03_1		"å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO04			"å¼•æ•°(æ–‡å­—åˆ—)ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO05			"ã‚¸ãƒ£ãƒ³ãƒ—å…ˆè¡Œç•ªå·ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO06			"ãƒžãƒ¼ã‚¯è¡Œã®ãƒ‘ã‚¿ãƒ¼ãƒ³ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO07			"å¼•æ•°(æ–‡å­—åˆ—)ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO08			"ãƒ•ã‚¡ã‚¤ãƒ«åãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO09			"ç½®æ›å…ƒãƒ‘ã‚¿ãƒ¼ãƒ³ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO10			"ç½®æ›å…ˆãƒ‘ã‚¿ãƒ¼ãƒ³ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO11			"GREPãƒ‘ã‚¿ãƒ¼ãƒ³ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO12			"ãƒ•ã‚¡ã‚¤ãƒ«ç¨®åˆ¥ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO13			"æ¤œç´¢å…ˆãƒ•ã‚©ãƒ«ãƒ€ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO14			"èª­ã¿è¾¼ã¿ãƒ•ã‚¡ã‚¤ãƒ«åãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO15			"ä¿å­˜ãƒ•ã‚¡ã‚¤ãƒ«åãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
+	STR_ERR_DLGMACRO16			"æ•°å€¤ã‚’æŒ‡å®šã—ã¦ãã ã•ã„ï¼Ž"
+	STR_ERR_DLGMACRO17			"GREPç½®æ›å¾ŒãŒæŒ‡å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ï¼Ž"
 
 	// CMacroFactory.cpp
 	
@@ -4197,7 +4197,7 @@ BEGIN
 	// CMarkMgr.cpp
 
 	// CMemory.cpp
-	STR_ERR_DLGMEM1				"CMemory::AllocBuffer(nNewDataLen==%d)\nƒƒ‚ƒŠŠm•Û‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\n"
+	STR_ERR_DLGMEM1				"CMemory::AllocBuffer(nNewDataLen==%d)\nãƒ¡ãƒ¢ãƒªç¢ºä¿ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\n"
 
 	// CMenuDrawer.cpp
 
@@ -4208,201 +4208,201 @@ BEGIN
 	// CMRUFolder.cpp
 
 	// CNormalProcess.cpp
-	STR_ERR_DLGNRMPROC1			"CreateMutex()Ž¸”sB\nI—¹‚µ‚Ü‚·B"
-	STR_ERR_DLGNRMPROC2			"ƒGƒfƒBƒ^‚Ü‚½‚ÍƒVƒXƒeƒ€‚ªƒrƒW[ó‘Ô‚Å‚·B\n‚µ‚Î‚ç‚­‘Ò‚Á‚ÄŠJ‚«‚È‚¨‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_ERR_DLGNRMPROC1			"CreateMutex()å¤±æ•—ã€‚\nçµ‚äº†ã—ã¾ã™ã€‚"
+	STR_ERR_DLGNRMPROC2			"ã‚¨ãƒ‡ã‚£ã‚¿ã¾ãŸã¯ã‚·ã‚¹ãƒ†ãƒ ãŒãƒ“ã‚¸ãƒ¼çŠ¶æ…‹ã§ã™ã€‚\nã—ã°ã‚‰ãå¾…ã£ã¦é–‹ããªãŠã—ã¦ãã ã•ã„ã€‚"
 
 	// COpe.cpp
 
 	// COpeBlk.cpp
 	
 	// CPPA.cpp
-	STR_ERR_DLGPPA1				"PPAŽÀs’†‚ÉV‚½‚ÉPPAƒ}ƒNƒ‚ðŒÄ‚Ño‚·‚±‚Æ‚Í‚Å‚«‚Ü‚¹‚ñ"
-	STR_ERR_DLGPPA2				"ŠÖ”‚ÌŽÀsƒGƒ‰[\n%hs"
-	STR_ERR_DLGPPA3				"•s–¾‚ÈŠÖ”‚ÌŽÀsƒGƒ‰[(ƒoƒO‚Å‚·)\nFunc_ID=%d"
-	STR_ERR_DLGPPA4				"Ú×•s–¾‚ÌƒGƒ‰["
-	STR_ERR_DLGPPA5				"–¢’è‹`‚ÌƒGƒ‰[\nError_CD=%d\n%ts"
-	STR_ERR_DLGPPA6				"ƒGƒ‰[î•ñ‚ª•s³"
-	STR_ERR_DLGPPA7				"PPAŽÀsƒGƒ‰["
+	STR_ERR_DLGPPA1				"PPAå®Ÿè¡Œä¸­ã«æ–°ãŸã«PPAãƒžã‚¯ãƒ­ã‚’å‘¼ã³å‡ºã™ã“ã¨ã¯ã§ãã¾ã›ã‚“"
+	STR_ERR_DLGPPA2				"é–¢æ•°ã®å®Ÿè¡Œã‚¨ãƒ©ãƒ¼\n%hs"
+	STR_ERR_DLGPPA3				"ä¸æ˜Žãªé–¢æ•°ã®å®Ÿè¡Œã‚¨ãƒ©ãƒ¼(ãƒã‚°ã§ã™)\nFunc_ID=%d"
+	STR_ERR_DLGPPA4				"è©³ç´°ä¸æ˜Žã®ã‚¨ãƒ©ãƒ¼"
+	STR_ERR_DLGPPA5				"æœªå®šç¾©ã®ã‚¨ãƒ©ãƒ¼\nError_CD=%d\n%ts"
+	STR_ERR_DLGPPA6				"ã‚¨ãƒ©ãƒ¼æƒ…å ±ãŒä¸æ­£"
+	STR_ERR_DLGPPA7				"PPAå®Ÿè¡Œã‚¨ãƒ©ãƒ¼"
 
 	// CPPAMacroMgr.cpp
 
 	// CPrint.cpp
-	STR_ERR_CPRINT01			"OpenPrinter()‚ÉŽ¸”sB\nƒvƒŠƒ“ƒ^ƒfƒoƒCƒX–¼=[%ts]"
-	STR_ERR_CPRINT02			"StartDoc()‚ÉŽ¸”sB\nƒvƒŠƒ“ƒ^ƒfƒoƒCƒX–¼=[%ts]"
-	STR_ERR_CPRINT03			"•s–¾"
+	STR_ERR_CPRINT01			"OpenPrinter()ã«å¤±æ•—ã€‚\nãƒ—ãƒªãƒ³ã‚¿ãƒ‡ãƒã‚¤ã‚¹å=[%ts]"
+	STR_ERR_CPRINT02			"StartDoc()ã«å¤±æ•—ã€‚\nãƒ—ãƒªãƒ³ã‚¿ãƒ‡ãƒã‚¤ã‚¹å=[%ts]"
+	STR_ERR_CPRINT03			"ä¸æ˜Ž"
 
 
 	// CPrintPreview.cpp
-	STR_ERR_DLGPRNPRVW1			"‰¡"
-	STR_ERR_DLGPRNPRVW2			"c"
-	STR_ERR_DLGPRNPRVW3			"Œ»Ý‚ÌƒvƒŠƒ“ƒ^ %ts ‚Å‚ÍA\nŽw’è‚³‚ê‚½—pŽ† %ts ‚ÍŽg—p‚Å‚«‚Ü‚¹‚ñB\n—˜—p‰Â”\‚È—pŽ† %ts ‚É•ÏX‚µ‚Ü‚µ‚½B"
-	STR_ERR_DLGPRNPRVW3_1		"ˆóüƒy[ƒWÝ’èƒGƒ‰[:ˆóŽš‰Â”\—Ìˆæ‚ª‚ ‚è‚Ü‚¹‚ñ"
-	STR_ERR_DLGPRNPRVW4			"•\Ž¦‚·‚éƒy[ƒW”Ô†‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢B(1 - %d)"
-	STR_ERR_DLGPRNPRVW5			"ƒvƒŒƒrƒ…[ƒy[ƒWŽw’è"
-	STR_ERR_DLGPRNPRVW6			"%d/%d•Å"
-	STR_ERR_DLGPRNPRVW7			"ˆóü‚·‚éƒy[ƒW‚ª‚ ‚è‚Ü‚¹‚ñB"
+	STR_ERR_DLGPRNPRVW1			"æ¨ª"
+	STR_ERR_DLGPRNPRVW2			"ç¸¦"
+	STR_ERR_DLGPRNPRVW3			"ç¾åœ¨ã®ãƒ—ãƒªãƒ³ã‚¿ %ts ã§ã¯ã€\næŒ‡å®šã•ã‚ŒãŸç”¨ç´™ %ts ã¯ä½¿ç”¨ã§ãã¾ã›ã‚“ã€‚\nåˆ©ç”¨å¯èƒ½ãªç”¨ç´™ %ts ã«å¤‰æ›´ã—ã¾ã—ãŸã€‚"
+	STR_ERR_DLGPRNPRVW3_1		"å°åˆ·ãƒšãƒ¼ã‚¸è¨­å®šã‚¨ãƒ©ãƒ¼:å°å­—å¯èƒ½é ˜åŸŸãŒã‚ã‚Šã¾ã›ã‚“"
+	STR_ERR_DLGPRNPRVW4			"è¡¨ç¤ºã™ã‚‹ãƒšãƒ¼ã‚¸ç•ªå·ã‚’æŒ‡å®šã—ã¦ãã ã•ã„ã€‚(1 - %d)"
+	STR_ERR_DLGPRNPRVW5			"ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼ãƒšãƒ¼ã‚¸æŒ‡å®š"
+	STR_ERR_DLGPRNPRVW6			"%d/%dé "
+	STR_ERR_DLGPRNPRVW7			"å°åˆ·ã™ã‚‹ãƒšãƒ¼ã‚¸ãŒã‚ã‚Šã¾ã›ã‚“ã€‚"
 
 	// CProcess.cpp
-	STR_ERR_DLGPROCESS1			"ˆÙ‚È‚éƒo[ƒWƒ‡ƒ“‚ÌƒGƒfƒBƒ^‚ð“¯Žž‚É‹N“®‚·‚é‚±‚Æ‚Í‚Å‚«‚Ü‚¹‚ñB"
+	STR_ERR_DLGPROCESS1			"ç•°ãªã‚‹ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã®ã‚¨ãƒ‡ã‚£ã‚¿ã‚’åŒæ™‚ã«èµ·å‹•ã™ã‚‹ã“ã¨ã¯ã§ãã¾ã›ã‚“ã€‚"
 	
 	// CProcessFactory.cpp
-	STR_ERR_DLGPROCFACT1		"‚±‚ÌƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚ðŽÀs‚·‚é‚É‚ÍA\nWindows95ˆÈã ‚Ü‚½‚Í WindowsNT4.0ˆÈã‚ÌOS‚ª•K—v‚Å‚·B\nƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚ðI—¹‚µ‚Ü‚·B"
-	STR_ERR_DLGPROCFACT2		"OS‚Ìƒo[ƒWƒ‡ƒ“‚ªŽæ“¾‚Å‚«‚Ü‚¹‚ñB\nƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚ðI—¹‚µ‚Ü‚·B"
-	STR_ERR_DLGPROCFACT3		"'%ts'\nƒvƒƒZƒX‚Ì‹N“®‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\n%ts"
-	STR_ERR_DLGPROCFACT4		"'%ls'\nƒRƒ“ƒgƒ[ƒ‹ƒvƒƒZƒX‚Ì‹N“®‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
-	STR_ERR_DLGPROCFACT5		"ƒGƒfƒBƒ^‚Ü‚½‚ÍƒVƒXƒeƒ€‚ªƒrƒW[ó‘Ô‚Å‚·B\n‚µ‚Î‚ç‚­‘Ò‚Á‚ÄŠJ‚«‚È‚¨‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_ERR_DLGPROCFACT1		"ã“ã®ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚’å®Ÿè¡Œã™ã‚‹ã«ã¯ã€\nWindows95ä»¥ä¸Š ã¾ãŸã¯ WindowsNT4.0ä»¥ä¸Šã®OSãŒå¿…è¦ã§ã™ã€‚\nã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚’çµ‚äº†ã—ã¾ã™ã€‚"
+	STR_ERR_DLGPROCFACT2		"OSã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³ãŒå–å¾—ã§ãã¾ã›ã‚“ã€‚\nã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚’çµ‚äº†ã—ã¾ã™ã€‚"
+	STR_ERR_DLGPROCFACT3		"'%ts'\nãƒ—ãƒ­ã‚»ã‚¹ã®èµ·å‹•ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\n%ts"
+	STR_ERR_DLGPROCFACT4		"'%ls'\nã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ãƒ—ãƒ­ã‚»ã‚¹ã®èµ·å‹•ã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
+	STR_ERR_DLGPROCFACT5		"ã‚¨ãƒ‡ã‚£ã‚¿ã¾ãŸã¯ã‚·ã‚¹ãƒ†ãƒ ãŒãƒ“ã‚¸ãƒ¼çŠ¶æ…‹ã§ã™ã€‚\nã—ã°ã‚‰ãå¾…ã£ã¦é–‹ããªãŠã—ã¦ãã ã•ã„ã€‚"
 
 	// CProfile.cpp
 
 	// CPropComBackup.cpp
-	STR_PROPCOMBK_SEL_FOLDER	"ƒoƒbƒNƒAƒbƒv‚ðì¬‚·‚éƒtƒHƒ‹ƒ_‚ð‘I‚ñ‚Å‚­‚¾‚³‚¢"
-	STR_PROPCOMBK_DUSTBOX		"(ƒSƒ~” )"
+	STR_PROPCOMBK_SEL_FOLDER	"ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹ãƒ•ã‚©ãƒ«ãƒ€ã‚’é¸ã‚“ã§ãã ã•ã„"
+	STR_PROPCOMBK_DUSTBOX		"(ã‚´ãƒŸç®±)"
 
 	// CPropComCustmenu.cpp
-	STR_PROPCOMCUSTMENU_SEP		" „Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ"
-	STR_PROPCOMCUSTMENU_AC1		"ƒƒjƒ…[ƒAƒCƒeƒ€‚ÌƒAƒNƒZƒXƒL[Ý’è"
-	STR_PROPCOMCUSTMENU_AC2		"ƒL[‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_PROPCOMCUSTMENU_SEP		" â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€"
+	STR_PROPCOMCUSTMENU_AC1		"ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã‚¢ã‚¤ãƒ†ãƒ ã®ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼è¨­å®š"
+	STR_PROPCOMCUSTMENU_AC2		"ã‚­ãƒ¼ã‚’å…¥åŠ›ã—ã¦ãã ã•ã„ã€‚"
 	// Has a HEADER #define, should we also fix this?
 
 	// CPropComEdit.cpp
-	STR_PROPEDIT_SELECT_DIR		"ƒtƒ@ƒCƒ‹ƒ_ƒCƒAƒƒO‚ÌŽw’èƒtƒHƒ‹ƒ_‚Ì‘I‘ð"
+	STR_PROPEDIT_SELECT_DIR		"ãƒ•ã‚¡ã‚¤ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€ã®é¸æŠž"
 
 	// CPropComFile.cpp
-	STR_PROPCOMFNM_LIST1		"’uŠ·‘O"
-	STR_PROPCOMFNM_LIST2		"’uŠ·Œã"
-	STR_PROPCOMFNM_ERR_REG		"‚±‚êˆÈã“o˜^‚Å‚«‚Ü‚¹‚ñB"
+	STR_PROPCOMFNM_LIST1		"ç½®æ›å‰"
+	STR_PROPCOMFNM_LIST2		"ç½®æ›å¾Œ"
+	STR_PROPCOMFNM_ERR_REG		"ã“ã‚Œä»¥ä¸Šç™»éŒ²ã§ãã¾ã›ã‚“ã€‚"
 
 	// CPropComFormat.cpp
 	// Has static date-time string
 
 	// CPropComGeneral.cpp
-	STR_PROPCOMGEN_FILE1		"Å‹ßŽg‚Á‚½ƒtƒ@ƒCƒ‹‚Ì—š—ð‚ðíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H\n"
-	STR_PROPCOMGEN_FILE2		"Å‹ßŽg‚Á‚½ƒtƒ@ƒCƒ‹‚Ì—š—ð‚ðíœ‚µ‚Ü‚µ‚½B\n"
-	STR_PROPCOMGEN_DIR1			"Å‹ßŽg‚Á‚½ƒtƒHƒ‹ƒ_‚Ì—š—ð‚ðíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H\n"
-	STR_PROPCOMGEN_DIR2			"Å‹ßŽg‚Á‚½ƒtƒHƒ‹ƒ_‚Ì—š—ð‚ðíœ‚µ‚Ü‚µ‚½B\n"
+	STR_PROPCOMGEN_FILE1		"æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚¡ã‚¤ãƒ«ã®å±¥æ­´ã‚’å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ\n"
+	STR_PROPCOMGEN_FILE2		"æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚¡ã‚¤ãƒ«ã®å±¥æ­´ã‚’å‰Šé™¤ã—ã¾ã—ãŸã€‚\n"
+	STR_PROPCOMGEN_DIR1			"æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚©ãƒ«ãƒ€ã®å±¥æ­´ã‚’å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ\n"
+	STR_PROPCOMGEN_DIR2			"æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚©ãƒ«ãƒ€ã®å±¥æ­´ã‚’å‰Šé™¤ã—ã¾ã—ãŸã€‚\n"
 
 	// CPropComGrep.cpp 
-	STR_PROPCOMGREP_DLL			"³‹K•\Œ»‚ÍŽg—p‚Å‚«‚Ü‚¹‚ñ"
-	STR_TAGJUMP_0				"ŽŸ‚Ìƒtƒ@ƒCƒ‹‚ðŒŸõ‚µ‚È‚¢"
-	STR_TAGJUMP_1				"ƒqƒbƒg‚µ‚½‚çŽŸ‚Ìƒtƒ@ƒCƒ‹‚ðŒŸõ‚µ‚È‚¢"
-	STR_TAGJUMP_2				"Š®‘Sˆê’v‚Åƒqƒbƒg‚µ‚½‚çŽŸ‚Ìƒtƒ@ƒCƒ‹‚ðŒŸõ‚µ‚È‚¢"
-	STR_TAGJUMP_3				"ŽŸ‚Ìƒtƒ@ƒCƒ‹‚ðŒŸõ‚·‚é"
+	STR_PROPCOMGREP_DLL			"æ­£è¦è¡¨ç¾ã¯ä½¿ç”¨ã§ãã¾ã›ã‚“"
+	STR_TAGJUMP_0				"æ¬¡ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æ¤œç´¢ã—ãªã„"
+	STR_TAGJUMP_1				"ãƒ’ãƒƒãƒˆã—ãŸã‚‰æ¬¡ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æ¤œç´¢ã—ãªã„"
+	STR_TAGJUMP_2				"å®Œå…¨ä¸€è‡´ã§ãƒ’ãƒƒãƒˆã—ãŸã‚‰æ¬¡ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æ¤œç´¢ã—ãªã„"
+	STR_TAGJUMP_3				"æ¬¡ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æ¤œç´¢ã™ã‚‹"
 
 	// CPropComHelper.cpp
-	STR_PROPCOMHELP_MIGEMODIR	"ŒŸõ‚·‚éƒtƒHƒ‹ƒ_‚ð‘I‚ñ‚Å‚­‚¾‚³‚¢"
+	STR_PROPCOMHELP_MIGEMODIR	"æ¤œç´¢ã™ã‚‹ãƒ•ã‚©ãƒ«ãƒ€ã‚’é¸ã‚“ã§ãã ã•ã„"
 	
 	// CPropComKeybind.cpp
 	// STR_KEYDATA_HEAD... 
-	STR_PROPCOMKEYBIND_UNASSIGN	"–¢Š„•t"
+	STR_PROPCOMKEYBIND_UNASSIGN	"æœªå‰²ä»˜"
 	
 	// CPropComKeyword.cpp
-	STR_PROPCOMKEYWORD_ERR_LEN	"ƒL[ƒ[ƒh‚Ì’·‚³‚Í%dƒoƒCƒg‚Ü‚Å‚Å‚·B"
-	STR_PROPCOMKEYWORD_SETMAX	"ƒZƒbƒg‚Í%dŒÂ‚Ü‚Å‚µ‚©“o˜^‚Å‚«‚Ü‚¹‚ñB\n"
-	STR_PROPCOMKEYWORD_SETNAME1	"ƒL[ƒ[ƒh‚ÌƒZƒbƒg’Ç‰Á"
-	STR_PROPCOMKEYWORD_SETNAME2	"ƒZƒbƒg–¼‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_PROPCOMKEYWORD_SETDEL	"u%lsv‚ÌƒZƒbƒg‚ðíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H\níœ‚µ‚æ‚¤‚Æ‚·‚éƒZƒbƒg‚ÍAˆÈ‰º‚Ìƒtƒ@ƒCƒ‹ƒ^ƒCƒv‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚Ü‚·B\níœ‚µ‚½ƒZƒbƒg‚Í–³Œø‚É‚È‚è‚Ü‚·B\n\n%ts"
-	STR_PROPCOMKEYWORD_RENAME1	"ƒZƒbƒg‚Ì–¼Ì•ÏX"
-	STR_PROPCOMKEYWORD_RENAME2	"ƒZƒbƒg–¼‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_PROPCOMKEYWORD_KEYMAX	"“o˜^‚Å‚«‚éƒL[ƒ[ƒh”‚ªãŒÀ‚É’B‚µ‚Ä‚¢‚Ü‚·B\n"
-	STR_PROPCOMKEYWORD_KEYADD1	"ƒL[ƒ[ƒh’Ç‰Á"
-	STR_PROPCOMKEYWORD_KEYADD2	"ƒL[ƒ[ƒh‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_PROPCOMKEYWORD_KEYEDIT1	"ƒL[ƒ[ƒh•ÒW"
-	STR_PROPCOMKEYWORD_KEYEDIT2	"ƒL[ƒ[ƒh‚ð•ÒW‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_PROPCOMKEYWORD_DEL		"Œ»Ý‚ÌÝ’è‚Å‚Í‹­’²ƒL[ƒ[ƒh‚Æ‚µ‚Ä•\Ž¦‚Å‚«‚È‚¢ƒL[ƒ[ƒh‚ðíœ‚µ‚Ü‚·‚©H"
-	STR_PROPCOMKEYWORD_INFO		"(Å‘å %d •¶Žš, “o˜^” %d, ‹ó‚« %d ŒÂ)"
+	STR_PROPCOMKEYWORD_ERR_LEN	"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®é•·ã•ã¯%dãƒã‚¤ãƒˆã¾ã§ã§ã™ã€‚"
+	STR_PROPCOMKEYWORD_SETMAX	"ã‚»ãƒƒãƒˆã¯%då€‹ã¾ã§ã—ã‹ç™»éŒ²ã§ãã¾ã›ã‚“ã€‚\n"
+	STR_PROPCOMKEYWORD_SETNAME1	"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®ã‚»ãƒƒãƒˆè¿½åŠ "
+	STR_PROPCOMKEYWORD_SETNAME2	"ã‚»ãƒƒãƒˆåã‚’å…¥åŠ›ã—ã¦ãã ã•ã„ã€‚"
+	STR_PROPCOMKEYWORD_SETDEL	"ã€Œ%lsã€ã®ã‚»ãƒƒãƒˆã‚’å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ\nå‰Šé™¤ã—ã‚ˆã†ã¨ã™ã‚‹ã‚»ãƒƒãƒˆã¯ã€ä»¥ä¸‹ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚¿ã‚¤ãƒ—ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ã¾ã™ã€‚\nå‰Šé™¤ã—ãŸã‚»ãƒƒãƒˆã¯ç„¡åŠ¹ã«ãªã‚Šã¾ã™ã€‚\n\n%ts"
+	STR_PROPCOMKEYWORD_RENAME1	"ã‚»ãƒƒãƒˆã®åç§°å¤‰æ›´"
+	STR_PROPCOMKEYWORD_RENAME2	"ã‚»ãƒƒãƒˆåã‚’å…¥åŠ›ã—ã¦ãã ã•ã„ã€‚"
+	STR_PROPCOMKEYWORD_KEYMAX	"ç™»éŒ²ã§ãã‚‹ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æ•°ãŒä¸Šé™ã«é”ã—ã¦ã„ã¾ã™ã€‚\n"
+	STR_PROPCOMKEYWORD_KEYADD1	"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¿½åŠ "
+	STR_PROPCOMKEYWORD_KEYADD2	"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’å…¥åŠ›ã—ã¦ãã ã•ã„ã€‚"
+	STR_PROPCOMKEYWORD_KEYEDIT1	"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ç·¨é›†"
+	STR_PROPCOMKEYWORD_KEYEDIT2	"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ç·¨é›†ã—ã¦ãã ã•ã„ã€‚"
+	STR_PROPCOMKEYWORD_DEL		"ç¾åœ¨ã®è¨­å®šã§ã¯å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã¨ã—ã¦è¡¨ç¤ºã§ããªã„ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’å‰Šé™¤ã—ã¾ã™ã‹ï¼Ÿ"
+	STR_PROPCOMKEYWORD_INFO		"(æœ€å¤§ %d æ–‡å­—, ç™»éŒ²æ•° %d, ç©ºã %d å€‹)"
 
 	// CPropComMacro.cpp
-	STR_PROPCOMMACR_LIST1		"”Ô†"
-	STR_PROPCOMMACR_LIST2		"ƒ}ƒNƒ–¼"
-	STR_PROPCOMMACR_LIST3		"ƒtƒ@ƒCƒ‹–¼"
-	STR_PROPCOMMACR_LIST4		"ŽÀsŽž‚É“Ç‚Ýž‚Ý"
-	STR_PROPCOMMACR_LIST5		"Ž©“®ŽÀs"
-	STR_PROPCOMMACR_SEL_DIR		"MacroƒfƒBƒŒƒNƒgƒŠ‚Ì‘I‘ð"
+	STR_PROPCOMMACR_LIST1		"ç•ªå·"
+	STR_PROPCOMMACR_LIST2		"ãƒžã‚¯ãƒ­å"
+	STR_PROPCOMMACR_LIST3		"ãƒ•ã‚¡ã‚¤ãƒ«å"
+	STR_PROPCOMMACR_LIST4		"å®Ÿè¡Œæ™‚ã«èª­ã¿è¾¼ã¿"
+	STR_PROPCOMMACR_LIST5		"è‡ªå‹•å®Ÿè¡Œ"
+	STR_PROPCOMMACR_SEL_DIR		"Macroãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®é¸æŠž"
 
 	// CPropComMainMenu.cpp
-	STR_SPECIAL_FUNC			"“Á•Ê‹@”\"
-	STR_PROPCOMMAINMENU_EDIT	"•ÒW‚µ‚Ä‚­‚¾‚³‚¢"
-	STR_PROPCOMMAINMENU_SEP		"\\\\\\\\\\"
-	STR_PROPCOMMAINMENU_ACCKEY1	"ƒƒjƒ…[ƒAƒCƒeƒ€‚ÌƒAƒNƒZƒXƒL[Ý’è"
-	STR_PROPCOMMAINMENU_ACCKEY2	"ƒL[‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_PROPCOMMAINMENU_CLEAR	"ƒƒjƒ…[‚ÌÝ’è‚ðƒNƒŠƒA‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H"
-	STR_PROPCOMMAINMENU_INIT	"ƒƒjƒ…[‚ÌÝ’è‚ð‰Šúó‘Ô‚É–ß‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H"
-	STR_PROPCOMMAINMENU_DEL		"‘I‘ð‚µ‚Ä‚¢‚é€–Ú‚ð‰ºˆÊ€–Ú‚²‚Æíœ‚µ‚Ü‚·B\n‚æ‚ë‚µ‚¢‚Å‚·‚©H"
-	STR_PROPCOMMAINMENU_OK		"–â‘è‚ ‚è‚Ü‚¹‚ñ‚Å‚µ‚½B"
-	STR_PROPCOMMAINMENU_ERR1	"ƒƒjƒ…[Ý’è‚ÌŽæ“¾‚ÉŽ¸”s‚µ‚Ü‚µ‚½"
-	STR_PROPCOMMAINMENU_ERR2	"w‹¤’ÊÝ’èx‚ª—L‚è‚Ü‚¹‚ñB\n"
-	STR_PROPCOMMAINMENU_ERR3	"ƒgƒbƒvƒŒƒxƒ‹‚Ì€–Ú”‚ª‘½‚·‚¬‚Ü‚·B\n"
-	STR_PROPCOMMAINMENU_ERR4	"“o˜^€–Ú”‚ª‘½‚·‚¬‚Ü‚·B\n"
-	STR_PROPCOMMAINMENU_ERR5	"d•¡‚µ‚½ƒAƒNƒZƒXƒL[‚ª‚ ‚è‚Ü‚·B\n"
-	STR_PROPCOMMAINMENU_ERR6	"–¢Ý’è‚ÌƒAƒNƒZƒXƒL[‚ª‚ ‚è‚Ü‚·B\n"
+	STR_SPECIAL_FUNC			"ç‰¹åˆ¥æ©Ÿèƒ½"
+	STR_PROPCOMMAINMENU_EDIT	"ç·¨é›†ã—ã¦ãã ã•ã„"
+	STR_PROPCOMMAINMENU_SEP		"â€•â€•â€•â€•â€•â€•â€•â€•â€•â€•"
+	STR_PROPCOMMAINMENU_ACCKEY1	"ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã‚¢ã‚¤ãƒ†ãƒ ã®ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼è¨­å®š"
+	STR_PROPCOMMAINMENU_ACCKEY2	"ã‚­ãƒ¼ã‚’å…¥åŠ›ã—ã¦ãã ã•ã„ã€‚"
+	STR_PROPCOMMAINMENU_CLEAR	"ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®è¨­å®šã‚’ã‚¯ãƒªã‚¢ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
+	STR_PROPCOMMAINMENU_INIT	"ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®è¨­å®šã‚’åˆæœŸçŠ¶æ…‹ã«æˆ»ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
+	STR_PROPCOMMAINMENU_DEL		"é¸æŠžã—ã¦ã„ã‚‹é …ç›®ã‚’ä¸‹ä½é …ç›®ã”ã¨å‰Šé™¤ã—ã¾ã™ã€‚\nã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
+	STR_PROPCOMMAINMENU_OK		"å•é¡Œã‚ã‚Šã¾ã›ã‚“ã§ã—ãŸã€‚"
+	STR_PROPCOMMAINMENU_ERR1	"ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šã®å–å¾—ã«å¤±æ•—ã—ã¾ã—ãŸ"
+	STR_PROPCOMMAINMENU_ERR2	"ã€Žå…±é€šè¨­å®šã€ãŒæœ‰ã‚Šã¾ã›ã‚“ã€‚\n"
+	STR_PROPCOMMAINMENU_ERR3	"ãƒˆãƒƒãƒ—ãƒ¬ãƒ™ãƒ«ã®é …ç›®æ•°ãŒå¤šã™ãŽã¾ã™ã€‚\n"
+	STR_PROPCOMMAINMENU_ERR4	"ç™»éŒ²é …ç›®æ•°ãŒå¤šã™ãŽã¾ã™ã€‚\n"
+	STR_PROPCOMMAINMENU_ERR5	"é‡è¤‡ã—ãŸã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ãŒã‚ã‚Šã¾ã™ã€‚\n"
+	STR_PROPCOMMAINMENU_ERR6	"æœªè¨­å®šã®ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ãŒã‚ã‚Šã¾ã™ã€‚\n"
 
 	// CPropCommon.cpp
-	STR_PROPCOMMON				"‹¤’ÊÝ’è"
-	STR_PROPCOMMON_GENERAL		"‘S”Ê"
-	STR_PROPCOMMON_WINDOW		"ƒEƒBƒ“ƒhƒE"
-	STR_PROPCOMMON_TABS			"ƒ^ƒuƒo["
-	STR_PROPCOMMON_EDITING		"•ÒW"
-	STR_PROPCOMMON_FILE			"ƒtƒ@ƒCƒ‹"
-	STR_PROPCOMMON_BACKUP		"ƒoƒbƒNƒAƒbƒv"
-	STR_PROPCOMMON_FORMAT		"‘Ž®"
-	STR_PROPCOMMON_SEARCH		"ŒŸõ"
-	STR_PROPCOMMON_KEYS			"ƒL[Š„‚è“–‚Ä"
-	STR_PROPCOMMON_CUSTMENU		"ƒJƒXƒ^ƒ€ƒƒjƒ…["
-	STR_PROPCOMMON_TOOLBAR		"ƒc[ƒ‹ƒo["
-	STR_PROPCOMMON_KEYWORD		"‹­’²ƒL[ƒ[ƒh"
-	STR_PROPCOMMON_SUPPORT		"Žx‰‡"
-	STR_PROPCOMMON_MACRO		"ƒ}ƒNƒ"
-	STR_PROPCOMMON_FILENAME		"ƒtƒ@ƒCƒ‹–¼•\Ž¦"
-	STR_PROPCOMMON_PLUGIN		"ƒvƒ‰ƒOƒCƒ“"
-	STR_PROPCOMMON_MAINMENU		"ƒƒCƒ“ƒƒjƒ…["
-	STR_PROPCOMMON_STATBAR		"ƒXƒe[ƒ^ƒXƒo["
+	STR_PROPCOMMON				"å…±é€šè¨­å®š"
+	STR_PROPCOMMON_GENERAL		"å…¨èˆ¬"
+	STR_PROPCOMMON_WINDOW		"ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦"
+	STR_PROPCOMMON_TABS			"ã‚¿ãƒ–ãƒãƒ¼"
+	STR_PROPCOMMON_EDITING		"ç·¨é›†"
+	STR_PROPCOMMON_FILE			"ãƒ•ã‚¡ã‚¤ãƒ«"
+	STR_PROPCOMMON_BACKUP		"ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—"
+	STR_PROPCOMMON_FORMAT		"æ›¸å¼"
+	STR_PROPCOMMON_SEARCH		"æ¤œç´¢"
+	STR_PROPCOMMON_KEYS			"ã‚­ãƒ¼å‰²ã‚Šå½“ã¦"
+	STR_PROPCOMMON_CUSTMENU		"ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼"
+	STR_PROPCOMMON_TOOLBAR		"ãƒ„ãƒ¼ãƒ«ãƒãƒ¼"
+	STR_PROPCOMMON_KEYWORD		"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰"
+	STR_PROPCOMMON_SUPPORT		"æ”¯æ´"
+	STR_PROPCOMMON_MACRO		"ãƒžã‚¯ãƒ­"
+	STR_PROPCOMMON_FILENAME		"ãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤º"
+	STR_PROPCOMMON_PLUGIN		"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³"
+	STR_PROPCOMMON_MAINMENU		"ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼"
+	STR_PROPCOMMON_STATBAR		"ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼"
 
 	// General Settings::File Tab
-	STR_SCROLL_WITH_NO_KEY		"‘g‚Ý‡‚í‚¹‚È‚µ"
-	STR_SCROLL_WITH_MID_BTN		"ƒ}ƒEƒX’†ƒ{ƒ^ƒ“"
-	STR_SCROLL_WITH_SIDE_1_BTN	"ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“1"
-	STR_SCROLL_WITH_SIDE_2_BTN	"ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“2"
-	STR_SCROLL_WITH_CTRL_KEY	"CONTROLƒL["
-	STR_SCROLL_WITH_SHIFT_KEY	"SHIFTƒL["
+	STR_SCROLL_WITH_NO_KEY		"çµ„ã¿åˆã‚ã›ãªã—"
+	STR_SCROLL_WITH_MID_BTN		"ãƒžã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³"
+	STR_SCROLL_WITH_SIDE_1_BTN	"ãƒžã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³1"
+	STR_SCROLL_WITH_SIDE_2_BTN	"ãƒžã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³2"
+	STR_SCROLL_WITH_CTRL_KEY	"CONTROLã‚­ãƒ¼"
+	STR_SCROLL_WITH_SHIFT_KEY	"SHIFTã‚­ãƒ¼"
 
-	STR_ERR_DLGPROPCOMMON24		"CPropCommon::DoPropertySheet()“à‚ÅƒGƒ‰[‚ªo‚Ü‚µ‚½B\npsh.nStartPage=[%d]\n::PropertySheet()Ž¸”s\n\n%ts\n"
+	STR_ERR_DLGPROPCOMMON24		"CPropCommon::DoPropertySheet()å†…ã§ã‚¨ãƒ©ãƒ¼ãŒå‡ºã¾ã—ãŸã€‚\npsh.nStartPage=[%d]\n::PropertySheet()å¤±æ•—\n\n%ts\n"
 
 	// CPropCOmPlugin.cpp
-	STR_PROPCOMPLG_ERR1			"ƒvƒ‰ƒOƒCƒ“‚Í‚±‚ÌƒEƒBƒ“ƒhƒE‚Å“Ç‚Ýž‚Ü‚ê‚Ä‚¢‚È‚¢‚©AƒtƒHƒ‹ƒ_‚ªˆÙ‚È‚é‚½‚ß\nÝ’è‚ð•ÏX‚Å‚«‚Ü‚¹‚ñ"
-	STR_PROPCOMPLG_ERR2			"ReadMeƒtƒ@ƒCƒ‹‚ªŠJ‚¯‚Ü‚¹‚ñ"
-	STR_PROPCOMPLG_ERR3			"ReadMeƒtƒ@ƒCƒ‹‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ "
-	STR_PROPCOMPLG_STATE1		"’Ç‰Á"
-	STR_PROPCOMPLG_STATE2		"XV"
-	STR_PROPCOMPLG_STATE3		"’âŽ~"
-	STR_PROPCOMPLG_STATE4		"‰Ò“­"
-	STR_PROPCOMPLG_STATE5		"íœ"
-	STR_PROPCOMPLG_STATE6		"–¢’è‹`"
-	STR_PROPCOMPLG_LOAD			"“Çž"
-	STR_PROPCOMPLG_LIST1		"”Ô†"
-	STR_PROPCOMPLG_LIST2		"ƒvƒ‰ƒOƒCƒ“–¼"
-	STR_PROPCOMPLG_LIST3		"ó‘Ô"
-	STR_PROPCOMPLG_LIST4		"“Çž"
-	STR_PROPCOMPLG_LIST5		"ƒtƒHƒ‹ƒ_"
-	STR_PROPCOMPLG_DELETE		"%ls ‚ðíœ‚µ‚Ü‚·‚©"
+	STR_PROPCOMPLG_ERR1			"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã¯ã“ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã§èª­ã¿è¾¼ã¾ã‚Œã¦ã„ãªã„ã‹ã€ãƒ•ã‚©ãƒ«ãƒ€ãŒç•°ãªã‚‹ãŸã‚\nè¨­å®šã‚’å¤‰æ›´ã§ãã¾ã›ã‚“"
+	STR_PROPCOMPLG_ERR2			"ReadMeãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‹ã‘ã¾ã›ã‚“"
+	STR_PROPCOMPLG_ERR3			"ReadMeãƒ•ã‚¡ã‚¤ãƒ«ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ "
+	STR_PROPCOMPLG_STATE1		"è¿½åŠ "
+	STR_PROPCOMPLG_STATE2		"æ›´æ–°"
+	STR_PROPCOMPLG_STATE3		"åœæ­¢"
+	STR_PROPCOMPLG_STATE4		"ç¨¼åƒ"
+	STR_PROPCOMPLG_STATE5		"å‰Šé™¤"
+	STR_PROPCOMPLG_STATE6		"æœªå®šç¾©"
+	STR_PROPCOMPLG_LOAD			"èª­è¾¼"
+	STR_PROPCOMPLG_LIST1		"ç•ªå·"
+	STR_PROPCOMPLG_LIST2		"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å"
+	STR_PROPCOMPLG_LIST3		"çŠ¶æ…‹"
+	STR_PROPCOMPLG_LIST4		"èª­è¾¼"
+	STR_PROPCOMPLG_LIST5		"ãƒ•ã‚©ãƒ«ãƒ€"
+	STR_PROPCOMPLG_DELETE		"%ls ã‚’å‰Šé™¤ã—ã¾ã™ã‹"
 	
 	// CPropComTab.cpp
-	STR_PROPCOMTAB_DISP_NO		"‚È‚µ"
-	STR_PROPCOMTAB_DISP_ALLWAYS	"í‚É•\Ž¦"
-	STR_PROPCOMTAB_DISP_AUTO	"Ž©“®•\Ž¦"
-	STR_PROPCOMTAB_TAB_POS_TOP		"ã"
-	STR_PROPCOMTAB_TAB_POS_BOTTOM	"‰º"
-	STR_PROPCOMTAB_TAB_POS_LEFT		"‰E"
-	STR_PROPCOMTAB_TAB_POS_RIGHT	"¶"
+	STR_PROPCOMTAB_DISP_NO		"ãªã—"
+	STR_PROPCOMTAB_DISP_ALLWAYS	"å¸¸ã«è¡¨ç¤º"
+	STR_PROPCOMTAB_DISP_AUTO	"è‡ªå‹•è¡¨ç¤º"
+	STR_PROPCOMTAB_TAB_POS_TOP		"ä¸Š"
+	STR_PROPCOMTAB_TAB_POS_BOTTOM	"ä¸‹"
+	STR_PROPCOMTAB_TAB_POS_LEFT		"å³"
+	STR_PROPCOMTAB_TAB_POS_RIGHT	"å·¦"
 
 	// CPropComToolbar.cpp
-	STR_PROPCOMTOOL_ERR01		"Toolbar Dialog: —v‘f‚Ì‘}“ü‚ÉŽ¸”s‚µ‚Ü‚µ‚½B(%d:%d)"
-	STR_PROPCOMTOOL_ERR02		"Toolbar Dialog: INS: ’l‚ÌÝ’è‚ÉŽ¸”s‚µ‚Ü‚µ‚½B:%d"
-	STR_PROPCOMTOOL_ERR03		"Toolbar Dialog: —v‘f‚Ì’Ç‰Á‚ÉŽ¸”s‚µ‚Ü‚µ‚½B(%d:%d)"
-	STR_PROPCOMTOOL_ERR04		"Toolbar Dialog: ADD: ’l‚ÌÝ’è‚ÉŽ¸”s‚µ‚Ü‚µ‚½B:%d"
-	STR_PROPCOMTOOL_ERR05		"Toolbar Dialog: —v‘f‚Ì’Ç‰Á‚ÉŽ¸”s‚µ‚Ü‚µ‚½B:%d"
-	STR_PROPCOMTOOL_ITEM1		"„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ„Ÿ"
-	STR_PROPCOMTOOL_ITEM2		"\\ƒc[ƒ‹ƒo[Ü•Ô\\"
-	STR_PROPCOMTOOL_ITEM3		"„Ÿ„Ÿ„Ÿ„Ÿ•s@–¾„Ÿ„Ÿ„Ÿ„Ÿ"
+	STR_PROPCOMTOOL_ERR01		"Toolbar Dialog: è¦ç´ ã®æŒ¿å…¥ã«å¤±æ•—ã—ã¾ã—ãŸã€‚(%d:%d)"
+	STR_PROPCOMTOOL_ERR02		"Toolbar Dialog: INS: å€¤ã®è¨­å®šã«å¤±æ•—ã—ã¾ã—ãŸã€‚:%d"
+	STR_PROPCOMTOOL_ERR03		"Toolbar Dialog: è¦ç´ ã®è¿½åŠ ã«å¤±æ•—ã—ã¾ã—ãŸã€‚(%d:%d)"
+	STR_PROPCOMTOOL_ERR04		"Toolbar Dialog: ADD: å€¤ã®è¨­å®šã«å¤±æ•—ã—ã¾ã—ãŸã€‚:%d"
+	STR_PROPCOMTOOL_ERR05		"Toolbar Dialog: è¦ç´ ã®è¿½åŠ ã«å¤±æ•—ã—ã¾ã—ãŸã€‚:%d"
+	STR_PROPCOMTOOL_ITEM1		"â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€"
+	STR_PROPCOMTOOL_ITEM2		"â€•â€•ãƒ„ãƒ¼ãƒ«ãƒãƒ¼æŠ˜è¿”â€•â€•"
+	STR_PROPCOMTOOL_ITEM3		"â”€â”€â”€â”€ä¸ã€€æ˜Žâ”€â”€â”€â”€"
 
 	// CPropComWin.cpp
 
@@ -4412,124 +4412,124 @@ BEGIN
 	STR_OUTLINE_JAVA			"Java"
 	STR_OUTLINE_COBOL			"COBOL"
 	STR_OUTLINE_PERL			"Perl"	
-	STR_OUTLINE_ASM				"ƒAƒZƒ“ƒuƒ‰"
+	STR_OUTLINE_ASM				"ã‚¢ã‚»ãƒ³ãƒ–ãƒ©"
 	STR_OUTLINE_VB				"Visual Basic"
 	STR_OUTLINE_PYTHON			"Python"
 	STR_OUTLINE_ERLANG			"Erlang"
-	STR_OUTLINE_WZ				"WZŠK‘w•tƒeƒLƒXƒg"
+	STR_OUTLINE_WZ				"WZéšŽå±¤ä»˜ãƒ†ã‚­ã‚¹ãƒˆ"
 	STR_OUTLINE_HTML			"HTML"
 	STR_OUTLINE_TEX				"TeX"
-	STR_OUTLINE_TEXT			"ƒeƒLƒXƒg"
-	STR_TAB_SYMBOL_CHARA		"•¶ŽšŽw’è"
-	STR_TAB_SYMBOL_SHORT_ARROW	"’Z‚¢–îˆó"
-	STR_TAB_SYMBOL_LONG_ARROW	"’·‚¢–îˆó"
-	STR_SMART_INDENT_NONE		"‚È‚µ"				// smart indent
+	STR_OUTLINE_TEXT			"ãƒ†ã‚­ã‚¹ãƒˆ"
+	STR_TAB_SYMBOL_CHARA		"æ–‡å­—æŒ‡å®š"
+	STR_TAB_SYMBOL_SHORT_ARROW	"çŸ­ã„çŸ¢å°"
+	STR_TAB_SYMBOL_LONG_ARROW	"é•·ã„çŸ¢å°"
+	STR_SMART_INDENT_NONE		"ãªã—"				// smart indent
 	STR_SMART_INDENT_C_CPP		"C/C++"
-	STR_WRAP_INDENT_NONE		"‚È‚µ"				// ident
+	STR_WRAP_INDENT_NONE		"ãªã—"				// ident
 	STR_WRAP_INDENT_TX2X		"tx2x"
-	STR_WRAP_INDENT_BOL			"˜_—sæ“ª"
-	STR_WRAP_METHOD_NO_WRAP		"Ü‚è•Ô‚³‚È‚¢"		// wrap method
-	STR_WRAP_METHOD_SPEC_WIDTH	"Žw’èŒ…‚ÅÜ‚è•Ô‚·"
-	STR_WRAP_METHOD_WIN_WIDTH	"‰E’[‚ÅÜ‚è•Ô‚·"
+	STR_WRAP_INDENT_BOL			"è«–ç†è¡Œå…ˆé ­"
+	STR_WRAP_METHOD_NO_WRAP		"æŠ˜ã‚Šè¿”ã•ãªã„"		// wrap method
+	STR_WRAP_METHOD_SPEC_WIDTH	"æŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™"
+	STR_WRAP_METHOD_WIN_WIDTH	"å³ç«¯ã§æŠ˜ã‚Šè¿”ã™"
 
 	// File Type Settings Tab names
-	STR_PROPTYPE				"ƒ^ƒCƒv•ÊÝ’è"
-	STR_PROPTYPE_SCREEN			"ƒXƒNƒŠ[ƒ“"					// Property Sheet
-	STR_PROPTYPE_COLOR			"ƒJƒ‰["
-	STR_PROPTYPE_SUPPORT		"Žx‰‡"
-	STR_PROPTYPE_REGEX_KEYWORD	"³‹K•\Œ»ƒL[ƒ[ƒh"
-	STR_PROPTYPE_KEYWORD_HELP	"ƒL[ƒ[ƒhƒwƒ‹ƒv"
-	STR_PROPTYPE_WINDOW			"ƒEƒBƒ“ƒhƒE"
-	STR_PROPTYPE_ERR			"CPropTypes::DoPropertySheet()“à‚ÅƒGƒ‰[‚ªo‚Ü‚µ‚½B\npsh.nStartPage=[%d]\n::PropertySheet()Ž¸”sB\n\n%ts\n"
+	STR_PROPTYPE				"ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š"
+	STR_PROPTYPE_SCREEN			"ã‚¹ã‚¯ãƒªãƒ¼ãƒ³"					// Property Sheet
+	STR_PROPTYPE_COLOR			"ã‚«ãƒ©ãƒ¼"
+	STR_PROPTYPE_SUPPORT		"æ”¯æ´"
+	STR_PROPTYPE_REGEX_KEYWORD	"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰"
+	STR_PROPTYPE_KEYWORD_HELP	"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—"
+	STR_PROPTYPE_WINDOW			"ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦"
+	STR_PROPTYPE_ERR			"CPropTypes::DoPropertySheet()å†…ã§ã‚¨ãƒ©ãƒ¼ãŒå‡ºã¾ã—ãŸã€‚\npsh.nStartPage=[%d]\n::PropertySheet()å¤±æ•—ã€‚\n\n%ts\n"
 
 	// CPropTypesScreen.cpp
-	STR_TSV_MODE_NONE			"’Êí"
+	STR_TSV_MODE_NONE			"é€šå¸¸"
 	STR_TSV_MODE_TSV			"TSV"
 	STR_TSV_MODE_CSV			"CSV"
 
 	// CPropTypesColor.cpp
-	STR_STRINGESC_CPP			"C/C++Œ¾Œê•— \\"""
-	STR_STRINGESC_PLSQL			"PL/SQL•—    """""
-	STR_STRINGESC_HTML			"HTML/XML•—  ="""""
-	STR_STRINGESC_CSHARP		"C#•—        @"""""
-	STR_STRINGESC_PYTHON		"Python•—    """""""
+	STR_STRINGESC_CPP			"C/C++è¨€èªžé¢¨ \\"""
+	STR_STRINGESC_PLSQL			"PL/SQLé¢¨    """""
+	STR_STRINGESC_HTML			"HTML/XMLé¢¨  ="""""
+	STR_STRINGESC_CSHARP		"C#é¢¨        @"""""
+	STR_STRINGESC_PYTHON		"Pythoné¢¨    """""""
 
 	// CPropTypesKeyHelp.cpp
-	STR_PROPTYPKEYHELP_DIC			"   Ž«‘ƒtƒ@ƒCƒ‹"
-	STR_PROPTYPKEYHELP_INFO			"Ž«‘‚Ìà–¾"
-	STR_PROPTYPKEYHELP_PATH			"ƒpƒX"
-	STR_PROPTYPKEYHELP_LINE1		"Ž«‘ƒtƒ@ƒCƒ‹‚Ì‚Ps–Ú‚Ì•¶Žš—ñ"
-	STR_PROPTYPKEYHELP_DICPATH		"ƒL[ƒ[ƒhŽ«‘ƒtƒ@ƒCƒ‹ ƒpƒX"
-	STR_PROPTYPKEYHELP_ERR_REG1		"‚±‚êˆÈã“o˜^‚Å‚«‚Ü‚¹‚ñB"
-	STR_PROPTYPKEYHELP_SELECT		"XV‚·‚éŽ«‘‚ðƒŠƒXƒg‚©‚ç‘I‘ð‚µ‚Ä‚­‚¾‚³‚¢B"
-	STR_PROPTYPKEYHELP_ERR_REG2		"Šù‚É“o˜^Ï‚Ý‚ÌŽ«‘‚Å‚·B"
-	STR_PROPTYPKEYHELP_ERR_OPEN		"ƒtƒ@ƒCƒ‹‚ðŠJ‚¯‚Ü‚¹‚ñ‚Å‚µ‚½B\n\n%ts"
+	STR_PROPTYPKEYHELP_DIC			"   è¾žæ›¸ãƒ•ã‚¡ã‚¤ãƒ«"
+	STR_PROPTYPKEYHELP_INFO			"è¾žæ›¸ã®èª¬æ˜Ž"
+	STR_PROPTYPKEYHELP_PATH			"ãƒ‘ã‚¹"
+	STR_PROPTYPKEYHELP_LINE1		"è¾žæ›¸ãƒ•ã‚¡ã‚¤ãƒ«ã®ï¼‘è¡Œç›®ã®æ–‡å­—åˆ—"
+	STR_PROPTYPKEYHELP_DICPATH		"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾žæ›¸ãƒ•ã‚¡ã‚¤ãƒ« ãƒ‘ã‚¹"
+	STR_PROPTYPKEYHELP_ERR_REG1		"ã“ã‚Œä»¥ä¸Šç™»éŒ²ã§ãã¾ã›ã‚“ã€‚"
+	STR_PROPTYPKEYHELP_SELECT		"æ›´æ–°ã™ã‚‹è¾žæ›¸ã‚’ãƒªã‚¹ãƒˆã‹ã‚‰é¸æŠžã—ã¦ãã ã•ã„ã€‚"
+	STR_PROPTYPKEYHELP_ERR_REG2		"æ—¢ã«ç™»éŒ²æ¸ˆã¿ã®è¾žæ›¸ã§ã™ã€‚"
+	STR_PROPTYPKEYHELP_ERR_OPEN		"ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ã¾ã›ã‚“ã§ã—ãŸã€‚\n\n%ts"
 
 	// CPropTypesRegex.cpp
-	STR_PROPTYPEREGEX_LIST1			"ƒL[ƒ[ƒh"
-	STR_PROPTYPEREGEX_LIST2			"FŽw’è"
-	STR_PROPTYPEREGEX_NOUSE			"³‹K•\Œ»ƒL[ƒ[ƒh‚ÍŽg‚¦‚Ü‚¹‚ñB"
-	STR_PROPTYPEREGEX_NOTFOUND		"³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB\n\n³‹K•\Œ»ƒL[ƒ[ƒh‚Í‹@”\‚µ‚Ü‚¹‚ñ‚ªA‚»‚ê‚Å‚à—LŒø‚É‚µ‚Ü‚·‚©H"
-	STR_PROPTYPEREGEX_NOREG			"‚±‚êˆÈã“o˜^‚Å‚«‚Ü‚¹‚ñB"
-	STR_PROPTYPEREGEX_ALREADY		"“¯‚¶ƒL[ƒ[ƒh‚Å“o˜^Ï‚Ý‚Å‚·B"
-	STR_PROPTYPEREGEX_KAKOMI		"³‹K•\Œ»ƒL[ƒ[ƒh‚ð / ‚Æ /k ‚ÅˆÍ‚Á‚Ä‚­‚¾‚³‚¢B\nƒL[ƒ[ƒh‚É / ‚ª‚ ‚éê‡‚Í m# ‚Æ #k ‚ÅˆÍ‚Á‚Ä‚­‚¾‚³‚¢B"
-	STR_PROPTYPEREGEX_INVALID		"‘Ž®‚ª³‚µ‚­‚È‚¢‚©A³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB\n\n“o˜^‚µ‚Ü‚·‚©H"
-	STR_PROPTYPEREGEX_FULL			"‚±‚êˆÈã“o˜^‚Å‚«‚Ü‚¹‚ñB\nƒL[ƒ[ƒh—Ìˆæ‚ª‚¢‚Á‚Ï‚¢‚Å‚·B"
-	STR_PROPTYPEREGEX_NOSEL			"ƒL[ƒ[ƒh‚ª‘I‘ð‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB"
+	STR_PROPTYPEREGEX_LIST1			"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰"
+	STR_PROPTYPEREGEX_LIST2			"è‰²æŒ‡å®š"
+	STR_PROPTYPEREGEX_NOUSE			"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã¯ä½¿ãˆã¾ã›ã‚“ã€‚"
+	STR_PROPTYPEREGEX_NOTFOUND		"æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚\n\næ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã¯æ©Ÿèƒ½ã—ã¾ã›ã‚“ãŒã€ãã‚Œã§ã‚‚æœ‰åŠ¹ã«ã—ã¾ã™ã‹ï¼Ÿ"
+	STR_PROPTYPEREGEX_NOREG			"ã“ã‚Œä»¥ä¸Šç™»éŒ²ã§ãã¾ã›ã‚“ã€‚"
+	STR_PROPTYPEREGEX_ALREADY		"åŒã˜ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã§ç™»éŒ²æ¸ˆã¿ã§ã™ã€‚"
+	STR_PROPTYPEREGEX_KAKOMI		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ / ã¨ /k ã§å›²ã£ã¦ãã ã•ã„ã€‚\nã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã« / ãŒã‚ã‚‹å ´åˆã¯ m# ã¨ #k ã§å›²ã£ã¦ãã ã•ã„ã€‚"
+	STR_PROPTYPEREGEX_INVALID		"æ›¸å¼ãŒæ­£ã—ããªã„ã‹ã€æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚\n\nç™»éŒ²ã—ã¾ã™ã‹ï¼Ÿ"
+	STR_PROPTYPEREGEX_FULL			"ã“ã‚Œä»¥ä¸Šç™»éŒ²ã§ãã¾ã›ã‚“ã€‚\nã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰é ˜åŸŸãŒã„ã£ã±ã„ã§ã™ã€‚"
+	STR_PROPTYPEREGEX_NOSEL			"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãŒé¸æŠžã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚"
 
-	STR_KEYHELP_RMENU_NONE			"•\Ž¦‚µ‚È‚¢"
-	STR_KEYHELP_RMENU_TOP			"æ“ª‚É•\Ž¦"
-	STR_KEYHELP_RMENU_BOTTOM		"––”ö‚É•\Ž¦"
+	STR_KEYHELP_RMENU_NONE			"è¡¨ç¤ºã—ãªã„"
+	STR_KEYHELP_RMENU_TOP			"å…ˆé ­ã«è¡¨ç¤º"
+	STR_KEYHELP_RMENU_BOTTOM		"æœ«å°¾ã«è¡¨ç¤º"
 
 	// CPropTypesWindow.cpp
-	STR_IME_STATE_DEF				"•W€Ý’è"			// ime state
-	STR_IME_STATE_FULL				"‘SŠp"
-	STR_IME_STATE_FULLHIRA			"‘SŠp‚Ð‚ç‚ª‚È"
-	STR_IME_STATE_FULLKATA			"‘SŠpƒJƒ^ƒJƒi"
-	STR_IME_STATE_NO				"–³•ÏŠ·"
-	STR_IME_SWITCH_DONTSET			"‚»‚Ì‚Ü‚Ü"			// ime switch
-	STR_IME_SWITCH_ON				"í‚ÉON" 
-	STR_IME_SWITCH_OFF				"í‚ÉOFF" 
-	STR_IMAGE_POS1					"¶ã"
-	STR_IMAGE_POS2					"‰Eã"
-	STR_IMAGE_POS3					"¶‰º"
-	STR_IMAGE_POS4					"‰E‰º"
-	STR_IMAGE_POS5					"’†‰›"
-	STR_IMAGE_POS6					"’†‰›ã"
-	STR_IMAGE_POS7					"’†‰›‰º"
-	STR_IMAGE_POS8					"’†‰›¶"
-	STR_IMAGE_POS9					"’†‰›‰E"
+	STR_IME_STATE_DEF				"æ¨™æº–è¨­å®š"			// ime state
+	STR_IME_STATE_FULL				"å…¨è§’"
+	STR_IME_STATE_FULLHIRA			"å…¨è§’ã²ã‚‰ãŒãª"
+	STR_IME_STATE_FULLKATA			"å…¨è§’ã‚«ã‚¿ã‚«ãƒŠ"
+	STR_IME_STATE_NO				"ç„¡å¤‰æ›"
+	STR_IME_SWITCH_DONTSET			"ãã®ã¾ã¾"			// ime switch
+	STR_IME_SWITCH_ON				"å¸¸ã«ON" 
+	STR_IME_SWITCH_OFF				"å¸¸ã«OFF" 
+	STR_IMAGE_POS1					"å·¦ä¸Š"
+	STR_IMAGE_POS2					"å³ä¸Š"
+	STR_IMAGE_POS3					"å·¦ä¸‹"
+	STR_IMAGE_POS4					"å³ä¸‹"
+	STR_IMAGE_POS5					"ä¸­å¤®"
+	STR_IMAGE_POS6					"ä¸­å¤®ä¸Š"
+	STR_IMAGE_POS7					"ä¸­å¤®ä¸‹"
+	STR_IMAGE_POS8					"ä¸­å¤®å·¦"
+	STR_IMAGE_POS9					"ä¸­å¤®å³"
 	
 	// CDlgTypeAscertain.cpp
-	STR_DLGTYPEASC_IMPORT			"--‚»‚Ì‚Ü‚ÜƒCƒ“ƒ|[ƒg--"
+	STR_DLGTYPEASC_IMPORT			"--ãã®ã¾ã¾ã‚¤ãƒ³ãƒãƒ¼ãƒˆ--"
 
 	// CDlgTypeList.cpp
-	STR_DLGTYPELIST_ERR1			"ŠÖ˜A•t‚¯‚ÉŽ¸”s‚µ‚Ü‚µ‚½\n"
-	STR_DLGTYPELIST_ERR2			"ŠÖ˜A•t‚¯‰ðœ‚ÉŽ¸”s‚µ‚Ü‚µ‚½\n"
-	STR_DLGTYPELIST_INIT1			"%ts ‚ð‰Šú‰»‚µ‚Ü‚·B ‚æ‚ë‚µ‚¢‚Å‚·‚©H"
-	STR_DLGTYPELIST_SETNAME			"Ý’è%d"
-	STR_DLGTYPELIST_INIT2			"%ts ‚ð‰Šú‰»‚µ‚Ü‚µ‚½B"
-	STR_DLGTYPELIST_DEL				"%ts ‚ðíœ‚µ‚Ü‚·B ‚æ‚ë‚µ‚¢‚Å‚·‚©H"
-	STR_DLGTYPELIST_ACC				"Windows‚ÌŠÖ˜A•t‚¯Ý’è‚ð•ÏX‚µ‚æ‚¤‚Æ‚µ‚Ä‚¢‚Ü‚·B\n‚±‚Ì‘€ì‚Í“¯‚¶Ý’è‚ð—˜—p‚·‚é‘¼‚Ìƒ\ƒtƒg‚É‚à‰e‹¿‚ð—^‚¦‚é‰Â”\«‚ª‚ ‚è‚Ü‚·B\nŽÀŽ{‚µ‚Ü‚·‚©H"
+	STR_DLGTYPELIST_ERR1			"é–¢é€£ä»˜ã‘ã«å¤±æ•—ã—ã¾ã—ãŸ\n"
+	STR_DLGTYPELIST_ERR2			"é–¢é€£ä»˜ã‘è§£é™¤ã«å¤±æ•—ã—ã¾ã—ãŸ\n"
+	STR_DLGTYPELIST_INIT1			"%ts ã‚’åˆæœŸåŒ–ã—ã¾ã™ã€‚ ã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
+	STR_DLGTYPELIST_SETNAME			"è¨­å®š%d"
+	STR_DLGTYPELIST_INIT2			"%ts ã‚’åˆæœŸåŒ–ã—ã¾ã—ãŸã€‚"
+	STR_DLGTYPELIST_DEL				"%ts ã‚’å‰Šé™¤ã—ã¾ã™ã€‚ ã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
+	STR_DLGTYPELIST_ACC				"Windowsã®é–¢é€£ä»˜ã‘è¨­å®šã‚’å¤‰æ›´ã—ã‚ˆã†ã¨ã—ã¦ã„ã¾ã™ã€‚\nã“ã®æ“ä½œã¯åŒã˜è¨­å®šã‚’åˆ©ç”¨ã™ã‚‹ä»–ã®ã‚½ãƒ•ãƒˆã«ã‚‚å½±éŸ¿ã‚’ä¸Žãˆã‚‹å¯èƒ½æ€§ãŒã‚ã‚Šã¾ã™ã€‚\nå®Ÿæ–½ã—ã¾ã™ã‹ï¼Ÿ"
 
 	// CImpExpManager.cpp
-	STR_IMPEXP_ERR_FILEOPEN			"ƒtƒ@ƒCƒ‹‚ðŠJ‚¯‚Ü‚¹‚ñ‚Å‚µ‚½B\n\n"
-	STR_IMPEXP_ERR_EXPORT			"ƒGƒNƒXƒ|[ƒgo—ˆ‚Ü‚¹‚ñ‚Å‚µ‚½B\n\n"
-	STR_IMPEXP_OK_EXPORT			"ƒtƒ@ƒCƒ‹‚ðƒGƒNƒXƒ|[ƒg‚µ‚Ü‚µ‚½B\n\n"
-	STR_IMPEXP_OK_IMPORT			"ƒtƒ@ƒCƒ‹‚ðƒCƒ“ƒ|[ƒg‚µ‚Ü‚µ‚½B\n\n"
-	STR_IMPEXP_ERR_COLOR_OLD		"FÝ’èƒtƒ@ƒCƒ‹‚ÌŒ`Ž®‚ªˆá‚¢‚Ü‚·BŒÃ‚¢Œ`Ž®‚ÍƒTƒ|[ƒg‚³‚ê‚È‚­‚È‚è‚Ü‚µ‚½B\n"
-	STR_IMPEXP_ERR_TYPE				"•s³‚ÈŒ`Ž®‚Å‚·B\nƒCƒ“ƒ|[ƒg‚ð’†Ž~‚µ‚Ü‚·"
-	STR_IMPEXP_VER					"ƒGƒNƒXƒ|[ƒg‚µ‚½ %ls(%ls/%d) ‚Æƒo[ƒWƒ‡ƒ“‚ªˆÙ‚È‚è‚Ü‚·B\n\nƒCƒ“ƒ|[ƒg‚µ‚Ä‚à‚æ‚ë‚µ‚¢‚Å‚·‚©H"
-	STR_IMPEXP_REGEX1				"ƒL[ƒ[ƒh”‚ªãŒÀ‚É’B‚µ‚½‚½‚ßØ‚èŽÌ‚Ä‚Ü‚µ‚½B"
-	STR_IMPEXP_REGEX2				"ƒL[ƒ[ƒh—Ìˆæ‚ª‚¢‚Á‚Ï‚¢‚È‚½‚ßØ‚èŽÌ‚Ä‚Ü‚µ‚½B"
-	STR_IMPEXP_REGEX3				"•s³‚ÈƒL[ƒ[ƒh‚ð–³Ž‹‚µ‚Ü‚µ‚½B"
-	STR_IMPEXP_DIC_NOTFOUND			"yŽ«‘ƒtƒ@ƒCƒ‹‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñz"
-	STR_IMPEXP_DIC_LENGTH			"Ž«‘‚Ìà–¾‚Í%d•¶ŽšˆÈ“à‚É‚µ‚Ä‚­‚¾‚³‚¢B\n"
-	STR_IMPEXP_DIC_RECORD			"ˆê•”‚Ìƒf[ƒ^‚ª“Ç‚Ýž‚ß‚Ü‚¹‚ñ‚Å‚µ‚½\n•s³‚Ès”: %d"
-	STR_IMPEXP_KEY_FORMAT			"ƒL[Ý’èƒtƒ@ƒCƒ‹‚ÌŒ`Ž®‚ªˆá‚¢‚Ü‚·B\n\n"
-	STR_IMPEXP_CUSTMENU_FORMAT		"ƒJƒXƒ^ƒ€ƒƒjƒ…[Ý’èƒtƒ@ƒCƒ‹‚ÌŒ`Ž®‚ªˆá‚¢‚Ü‚·B\n\n"
-	STR_IMPEXP_KEYWORD				"ƒL[ƒ[ƒh‚Ì”‚ªãŒÀ‚É’B‚µ‚½‚½‚ßA‚¢‚­‚Â‚©‚ÌƒL[ƒ[ƒh‚ð’Ç‰Á‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½B"
-	STR_IMPEXP_MEINMENU				"ƒƒCƒ“ƒƒjƒ…[Ý’èƒtƒ@ƒCƒ‹‚ÌŒ`Ž®‚ªˆá‚¢‚Ü‚·B\n\n"
+	STR_IMPEXP_ERR_FILEOPEN			"ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ã¾ã›ã‚“ã§ã—ãŸã€‚\n\n"
+	STR_IMPEXP_ERR_EXPORT			"ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆå‡ºæ¥ã¾ã›ã‚“ã§ã—ãŸã€‚\n\n"
+	STR_IMPEXP_OK_EXPORT			"ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã—ã¾ã—ãŸã€‚\n\n"
+	STR_IMPEXP_OK_IMPORT			"ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã‚¤ãƒ³ãƒãƒ¼ãƒˆã—ã¾ã—ãŸã€‚\n\n"
+	STR_IMPEXP_ERR_COLOR_OLD		"è‰²è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã®å½¢å¼ãŒé•ã„ã¾ã™ã€‚å¤ã„å½¢å¼ã¯ã‚µãƒãƒ¼ãƒˆã•ã‚Œãªããªã‚Šã¾ã—ãŸã€‚\n"
+	STR_IMPEXP_ERR_TYPE				"ä¸æ­£ãªå½¢å¼ã§ã™ã€‚\nã‚¤ãƒ³ãƒãƒ¼ãƒˆã‚’ä¸­æ­¢ã—ã¾ã™"
+	STR_IMPEXP_VER					"ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã—ãŸ %ls(%ls/%d) ã¨ãƒãƒ¼ã‚¸ãƒ§ãƒ³ãŒç•°ãªã‚Šã¾ã™ã€‚\n\nã‚¤ãƒ³ãƒãƒ¼ãƒˆã—ã¦ã‚‚ã‚ˆã‚ã—ã„ã§ã™ã‹ï¼Ÿ"
+	STR_IMPEXP_REGEX1				"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æ•°ãŒä¸Šé™ã«é”ã—ãŸãŸã‚åˆ‡ã‚Šæ¨ã¦ã¾ã—ãŸã€‚"
+	STR_IMPEXP_REGEX2				"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰é ˜åŸŸãŒã„ã£ã±ã„ãªãŸã‚åˆ‡ã‚Šæ¨ã¦ã¾ã—ãŸã€‚"
+	STR_IMPEXP_REGEX3				"ä¸æ­£ãªã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ç„¡è¦–ã—ã¾ã—ãŸã€‚"
+	STR_IMPEXP_DIC_NOTFOUND			"ã€è¾žæ›¸ãƒ•ã‚¡ã‚¤ãƒ«ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‘"
+	STR_IMPEXP_DIC_LENGTH			"è¾žæ›¸ã®èª¬æ˜Žã¯%dæ–‡å­—ä»¥å†…ã«ã—ã¦ãã ã•ã„ã€‚\n"
+	STR_IMPEXP_DIC_RECORD			"ä¸€éƒ¨ã®ãƒ‡ãƒ¼ã‚¿ãŒèª­ã¿è¾¼ã‚ã¾ã›ã‚“ã§ã—ãŸ\nä¸æ­£ãªè¡Œæ•°: %d"
+	STR_IMPEXP_KEY_FORMAT			"ã‚­ãƒ¼è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã®å½¢å¼ãŒé•ã„ã¾ã™ã€‚\n\n"
+	STR_IMPEXP_CUSTMENU_FORMAT		"ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã®å½¢å¼ãŒé•ã„ã¾ã™ã€‚\n\n"
+	STR_IMPEXP_KEYWORD				"ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®æ•°ãŒä¸Šé™ã«é”ã—ãŸãŸã‚ã€ã„ãã¤ã‹ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’è¿½åŠ ã§ãã¾ã›ã‚“ã§ã—ãŸã€‚"
+	STR_IMPEXP_MEINMENU				"ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã®å½¢å¼ãŒé•ã„ã¾ã™ã€‚\n\n"
 
 	// CRecent.cpp
 
@@ -4538,99 +4538,99 @@ BEGIN
 	// CRunningTimer.cpp
 
 	// CShareData.cpp
-	STR_ERR_CSHAREDATA01			"CreateFileMapping()‚ÉŽ¸”s‚µ‚Ü‚µ‚½"
-	STR_ERR_CSHAREDATA02			"—\Šú‚¹‚ÊƒGƒ‰["
+	STR_ERR_CSHAREDATA01			"CreateFileMapping()ã«å¤±æ•—ã—ã¾ã—ãŸ"
+	STR_ERR_CSHAREDATA02			"äºˆæœŸã›ã¬ã‚¨ãƒ©ãƒ¼"
 
 	// Common Prop::Tab/Title bar
-	STR_ERR_CSHAREDATA10			"${w?yGrepz$h$:yƒAƒEƒgƒvƒbƒgz$:$f$}${U?(XV)$}${R?(“Ç‚Ý‚Æ‚èê—p)$:(ã‘‚«‹ÖŽ~)$}${M?yƒL[ƒ}ƒNƒ‚Ì‹L˜^’†z$}"
-	STR_CUSTMENU_RIGHT_CLICK		"‰EƒNƒŠƒbƒNƒƒjƒ…["
-	STR_CUSTMENU_CUSTOM				"ƒƒjƒ…[%d"
-	STR_CUSTMENU_TAB				"ƒ^ƒuƒƒjƒ…["
-	STR_ERR_CSHAREDATA14			"‚P‚Q‚R‚S‚T‚U‚V‚W‚X‚Oi(m[uwy¡ £¢¥¤Ÿž›œ˜E¦™š‘æ‡@‡A‡B‡C‡D‡E‡F‡G‡H‡I‡J‡K‡L‡M‡N‡O‡P‡Q‡R‡S‡T‡U‡V‡W‡X‡Y‡Z‡[‡\‡]ˆê“ñŽOŽlŒÜ˜ZŽµ”ª‹ã\ˆë“óŽQŒÞ"
-	STR_ERR_CSHAREDATA15			"yyyy'”N'M'ŒŽ'd'“ú('dddd')'"
-	STR_ERR_CSHAREDATA16			"tthh'Žž'mm'•ª'ss'•b'"
-	STR_ERR_CSHAREDATA17			"${w?$h$:ƒAƒEƒgƒvƒbƒg$:${I?$f$:$N$}$}${U?(XV)$} - sakura $V ${R?(“Ç‚Ý‚Æ‚èê—p)$:iã‘‚«‹ÖŽ~j$}${M?  yƒL[ƒ}ƒNƒ‚Ì‹L˜^’†z$}"
-	STR_ERR_CSHAREDATA18			"${w?$h$:ƒAƒEƒgƒvƒbƒg$:$f$}${U?(XV)$} - sakura $V ${R?(“Ç‚Ý‚Æ‚èê—p)$:iã‘‚«‹ÖŽ~j$}${M?  yƒL[ƒ}ƒNƒ‚Ì‹L˜^’†z$}"
-	STR_ERR_CSHAREDATA19			"“¯Žž‚É•¡”‚Ì•ÒW—pƒEƒBƒ“ƒhƒE‚ð•Â‚¶‚æ‚¤‚Æ‚µ‚Ä‚¢‚Ü‚·B‚±‚ê‚ç‚ð•Â‚¶‚Ü‚·‚©?"
-	STR_ERR_CSHAREDATA20			"%ts\n\n\nŠù‚ÉŠJ‚¢‚Ä‚¢‚éƒtƒ@ƒCƒ‹‚ðˆá‚¤•¶ŽšƒR[ƒh‚ÅŠJ‚­ê‡‚ÍA\nƒtƒ@ƒCƒ‹ƒƒjƒ…[‚©‚çuŠJ‚«’¼‚·v‚ðŽg—p‚µ‚Ä‚­‚¾‚³‚¢B\n\nŒ»Ý‚Ì•¶ŽšƒR[ƒhƒZƒbƒg=[%ts]\nV‚µ‚¢•¶ŽšƒR[ƒhƒZƒbƒg=[%ts]"
-	STR_ERR_CSHAREDATA21			"%ts\n\n‘½dƒI[ƒvƒ“‚ÌŠm”F‚Å•s–¾‚È•¶ŽšƒR[ƒh‚ªŽw’è‚³‚ê‚Ü‚µ‚½B\n\nŒ»Ý‚Ì•¶ŽšƒR[ƒhƒZƒbƒg=%d [%ts]\nV‚µ‚¢•¶ŽšƒR[ƒhƒZƒbƒg=%d [%ts]"
-	STR_ERR_CSHAREDATA22			"•s–¾" // relates to above two [%s]
+	STR_ERR_CSHAREDATA10			"${w?ã€Grepã€‘$h$:ã€ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã€‘$:$f$}${U?(æ›´æ–°)$}${R?(èª­ã¿ã¨ã‚Šå°‚ç”¨)$:(ä¸Šæ›¸ãç¦æ­¢)$}${M?ã€ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ã€‘$}"
+	STR_CUSTMENU_RIGHT_CLICK		"å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼"
+	STR_CUSTMENU_CUSTOM				"ãƒ¡ãƒ‹ãƒ¥ãƒ¼%d"
+	STR_CUSTMENU_TAB				"ã‚¿ãƒ–ãƒ¡ãƒ‹ãƒ¥ãƒ¼"
+	STR_ERR_CSHAREDATA14			"ï¼‘ï¼’ï¼“ï¼”ï¼•ï¼–ï¼—ï¼˜ï¼™ï¼ï¼ˆ(ï¼»[ã€Œã€Žã€â– â–¡â–²â–³â–¼â–½â—†â—‡â—‹â—Žâ—Â§ãƒ»â€»â˜†â˜…ç¬¬â‘ â‘¡â‘¢â‘£â‘¤â‘¥â‘¦â‘§â‘¨â‘©â‘ªâ‘«â‘¬â‘­â‘®â‘¯â‘°â‘±â‘²â‘³â… â…¡â…¢â…£â…¤â…¥â…¦â…§â…¨â…©ä¸€äºŒä¸‰å››äº”å…­ä¸ƒå…«ä¹åå£±å¼å‚ä¼"
+	STR_ERR_CSHAREDATA15			"yyyy'å¹´'M'æœˆ'd'æ—¥('dddd')'"
+	STR_ERR_CSHAREDATA16			"tthh'æ™‚'mm'åˆ†'ss'ç§’'"
+	STR_ERR_CSHAREDATA17			"${w?$h$:ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆ$:${I?$f$:$N$}$}${U?(æ›´æ–°)$} - sakura $V ${R?(èª­ã¿ã¨ã‚Šå°‚ç”¨)$:ï¼ˆä¸Šæ›¸ãç¦æ­¢ï¼‰$}${M?  ã€ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ã€‘$}"
+	STR_ERR_CSHAREDATA18			"${w?$h$:ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆ$:$f$}${U?(æ›´æ–°)$} - sakura $V ${R?(èª­ã¿ã¨ã‚Šå°‚ç”¨)$:ï¼ˆä¸Šæ›¸ãç¦æ­¢ï¼‰$}${M?  ã€ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ã€‘$}"
+	STR_ERR_CSHAREDATA19			"åŒæ™‚ã«è¤‡æ•°ã®ç·¨é›†ç”¨ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚ˆã†ã¨ã—ã¦ã„ã¾ã™ã€‚ã“ã‚Œã‚‰ã‚’é–‰ã˜ã¾ã™ã‹?"
+	STR_ERR_CSHAREDATA20			"%ts\n\n\næ—¢ã«é–‹ã„ã¦ã„ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é•ã†æ–‡å­—ã‚³ãƒ¼ãƒ‰ã§é–‹ãå ´åˆã¯ã€\nãƒ•ã‚¡ã‚¤ãƒ«ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã‹ã‚‰ã€Œé–‹ãç›´ã™ã€ã‚’ä½¿ç”¨ã—ã¦ãã ã•ã„ã€‚\n\nç¾åœ¨ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ=[%ts]\næ–°ã—ã„æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ=[%ts]"
+	STR_ERR_CSHAREDATA21			"%ts\n\nå¤šé‡ã‚ªãƒ¼ãƒ—ãƒ³ã®ç¢ºèªã§ä¸æ˜Žãªæ–‡å­—ã‚³ãƒ¼ãƒ‰ãŒæŒ‡å®šã•ã‚Œã¾ã—ãŸã€‚\n\nç¾åœ¨ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ=%d [%ts]\næ–°ã—ã„æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ=%d [%ts]"
+	STR_ERR_CSHAREDATA22			"ä¸æ˜Ž" // relates to above two [%s]
 
 	// Key settings dialog box ( loop so must be N items long in a row )
-	STR_KEY_BIND_DBL_CLICK			"ƒ_ƒuƒ‹ƒNƒŠƒbƒN"
-	STR_KEY_BIND_R_CLICK			"‰EƒNƒŠƒbƒN"
-	STR_KEY_BIND_MID_CLICK			"’†ƒNƒŠƒbƒN"
-	STR_KEY_BIND_LSD_CLICK			"¶ƒTƒCƒhƒNƒŠƒbƒN"
-	STR_KEY_BIND_RSD_CLICK			"‰EƒTƒCƒhƒNƒŠƒbƒN"
-	STR_KEY_BIND_TRI_CLICK			"ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN"
-	STR_KEY_BIND_QUA_CLICK			"ƒNƒAƒhƒ‰ƒvƒ‹ƒNƒŠƒbƒN"
-	STR_KEY_BIND_WHEEL_UP			"ƒzƒC[ƒ‹ƒAƒbƒv"
-	STR_KEY_BIND_WHEEL_DOWN			"ƒzƒC[ƒ‹ƒ_ƒEƒ“"
-	STR_KEY_BIND_WHEEL_LEFT			"ƒzƒC[ƒ‹¶"
-	STR_KEY_BIND_WHEEL_RIGHT		"ƒzƒC[ƒ‹‰E"
-	STR_KEY_BIND_HAT_ENG_QT			"^(‰pŒê')"
-	STR_KEY_BIND_AT_ENG_BQ			"@(‰pŒê`)"
-	STR_KEY_BIND_APLI				"ƒAƒvƒŠƒL["
+	STR_KEY_BIND_DBL_CLICK			"ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯"
+	STR_KEY_BIND_R_CLICK			"å³ã‚¯ãƒªãƒƒã‚¯"
+	STR_KEY_BIND_MID_CLICK			"ä¸­ã‚¯ãƒªãƒƒã‚¯"
+	STR_KEY_BIND_LSD_CLICK			"å·¦ã‚µã‚¤ãƒ‰ã‚¯ãƒªãƒƒã‚¯"
+	STR_KEY_BIND_RSD_CLICK			"å³ã‚µã‚¤ãƒ‰ã‚¯ãƒªãƒƒã‚¯"
+	STR_KEY_BIND_TRI_CLICK			"ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯"
+	STR_KEY_BIND_QUA_CLICK			"ã‚¯ã‚¢ãƒ‰ãƒ©ãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯"
+	STR_KEY_BIND_WHEEL_UP			"ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¢ãƒƒãƒ—"
+	STR_KEY_BIND_WHEEL_DOWN			"ãƒ›ã‚¤ãƒ¼ãƒ«ãƒ€ã‚¦ãƒ³"
+	STR_KEY_BIND_WHEEL_LEFT			"ãƒ›ã‚¤ãƒ¼ãƒ«å·¦"
+	STR_KEY_BIND_WHEEL_RIGHT		"ãƒ›ã‚¤ãƒ¼ãƒ«å³"
+	STR_KEY_BIND_HAT_ENG_QT			"^(è‹±èªž')"
+	STR_KEY_BIND_AT_ENG_BQ			"@(è‹±èªž`)"
+	STR_KEY_BIND_APLI				"ã‚¢ãƒ—ãƒªã‚­ãƒ¼"
 
 	// Color Names in the Settings Color Box
-	STR_COLOR_TEXT					"ƒeƒLƒXƒg"
-	STR_COLOR_RULER					"ƒ‹[ƒ‰["
-	STR_COLOR_CURSOR				"ƒJ[ƒ\ƒ‹"
-	STR_COLOR_CURSOR_IMEON			"ƒJ[ƒ\ƒ‹(IME ON)"
-	STR_COLOR_CURSOR_LINE_BG		"ƒJ[ƒ\ƒ‹s‚Ì”wŒiF"
-	STR_COLOR_CURSOR_LINE			"ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“"
-	STR_COLOR_CURSOR_COLUMN			"ƒJ[ƒ\ƒ‹ˆÊ’ucü"
-	STR_COLOR_NOTE_LINE				"ƒm[ƒgü"
-	STR_COLOR_LINE_NO				"s”Ô†"
-	STR_COLOR_LINE_NO_CHANGE		"s”Ô†(•ÏXs)"
-	STR_COLOR_EVEN_LINE_BG			"‹ô”s‚Ì”wŒiF"
-	STR_COLOR_TAB					"TAB‹L†"
-	STR_COLOR_HALF_SPACE			"”¼Šp‹ó”’"
-	STR_COLOR_FULL_SPACE			"“ú–{Œê‹ó”’"
-	STR_COLOR_CTRL_CODE				"ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh"
-	STR_COLOR_CR					"‰üs‹L†"
-	STR_COLOR_WRAP_MARK				"Ü‚è•Ô‚µ‹L†"
-	STR_COLOR_VERT_LINE				"Žw’èŒ…cü"
-	STR_COLOR_EOF					"EOF‹L†"
-	STR_COLOR_NUMBER				"”¼Šp”’l"
-	STR_COLOR_BRACKET				"‘ÎŠ‡ŒÊ‚Ì‹­’²•\Ž¦"
-	STR_COLOR_SELECTED_AREA			"‘I‘ð”ÍˆÍ"
-	STR_COLOR_SEARCH_WORD1			"ŒŸõ•¶Žš—ñ"
-	STR_COLOR_SEARCH_WORD2			"ŒŸõ•¶Žš—ñ2"
-	STR_COLOR_SEARCH_WORD3			"ŒŸõ•¶Žš—ñ3"
-	STR_COLOR_SEARCH_WORD4			"ŒŸõ•¶Žš—ñ4"
-	STR_COLOR_SEARCH_WORD5			"ŒŸõ•¶Žš—ñ5"
-	STR_COLOR_COMMENT				"ƒRƒƒ“ƒg"
-	STR_COLOR_SINGLE_QUOTE			"ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ"
-	STR_COLOR_DOUBLE_QUOTE			"ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ"
-	STR_COLOR_HERE_DOCUMENT			"ƒqƒAƒhƒLƒ…ƒƒ“ƒg"
+	STR_COLOR_TEXT					"ãƒ†ã‚­ã‚¹ãƒˆ"
+	STR_COLOR_RULER					"ãƒ«ãƒ¼ãƒ©ãƒ¼"
+	STR_COLOR_CURSOR				"ã‚«ãƒ¼ã‚½ãƒ«"
+	STR_COLOR_CURSOR_IMEON			"ã‚«ãƒ¼ã‚½ãƒ«(IME ON)"
+	STR_COLOR_CURSOR_LINE_BG		"ã‚«ãƒ¼ã‚½ãƒ«è¡Œã®èƒŒæ™¯è‰²"
+	STR_COLOR_CURSOR_LINE			"ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³"
+	STR_COLOR_CURSOR_COLUMN			"ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·š"
+	STR_COLOR_NOTE_LINE				"ãƒŽãƒ¼ãƒˆç·š"
+	STR_COLOR_LINE_NO				"è¡Œç•ªå·"
+	STR_COLOR_LINE_NO_CHANGE		"è¡Œç•ªå·(å¤‰æ›´è¡Œ)"
+	STR_COLOR_EVEN_LINE_BG			"å¶æ•°è¡Œã®èƒŒæ™¯è‰²"
+	STR_COLOR_TAB					"TABè¨˜å·"
+	STR_COLOR_HALF_SPACE			"åŠè§’ç©ºç™½"
+	STR_COLOR_FULL_SPACE			"æ—¥æœ¬èªžç©ºç™½"
+	STR_COLOR_CTRL_CODE				"ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰"
+	STR_COLOR_CR					"æ”¹è¡Œè¨˜å·"
+	STR_COLOR_WRAP_MARK				"æŠ˜ã‚Šè¿”ã—è¨˜å·"
+	STR_COLOR_VERT_LINE				"æŒ‡å®šæ¡ç¸¦ç·š"
+	STR_COLOR_EOF					"EOFè¨˜å·"
+	STR_COLOR_NUMBER				"åŠè§’æ•°å€¤"
+	STR_COLOR_BRACKET				"å¯¾æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤º"
+	STR_COLOR_SELECTED_AREA			"é¸æŠžç¯„å›²"
+	STR_COLOR_SEARCH_WORD1			"æ¤œç´¢æ–‡å­—åˆ—"
+	STR_COLOR_SEARCH_WORD2			"æ¤œç´¢æ–‡å­—åˆ—2"
+	STR_COLOR_SEARCH_WORD3			"æ¤œç´¢æ–‡å­—åˆ—3"
+	STR_COLOR_SEARCH_WORD4			"æ¤œç´¢æ–‡å­—åˆ—4"
+	STR_COLOR_SEARCH_WORD5			"æ¤œç´¢æ–‡å­—åˆ—5"
+	STR_COLOR_COMMENT				"ã‚³ãƒ¡ãƒ³ãƒˆ"
+	STR_COLOR_SINGLE_QUOTE			"ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—"
+	STR_COLOR_DOUBLE_QUOTE			"ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—"
+	STR_COLOR_HERE_DOCUMENT			"ãƒ’ã‚¢ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ"
 	STR_COLOR_URL					"URL"
 
-	STR_COLOR_KEYWORD1				"‹­’²ƒL[ƒ[ƒh1"
-	STR_COLOR_KEYWORD2				"‹­’²ƒL[ƒ[ƒh2"
-	STR_COLOR_KEYWORD3				"‹­’²ƒL[ƒ[ƒh3"
-	STR_COLOR_KEYWORD4				"‹­’²ƒL[ƒ[ƒh4"
-	STR_COLOR_KEYWORD5				"‹­’²ƒL[ƒ[ƒh5"
-	STR_COLOR_KEYWORD6				"‹­’²ƒL[ƒ[ƒh6"
-	STR_COLOR_KEYWORD7				"‹­’²ƒL[ƒ[ƒh7"
-	STR_COLOR_KEYWORD8				"‹­’²ƒL[ƒ[ƒh8"
-	STR_COLOR_KEYWORD9				"‹­’²ƒL[ƒ[ƒh9"
-	STR_COLOR_KEYWORD10				"‹­’²ƒL[ƒ[ƒh10"
-	STR_COLOR_REGEX_KEYWORD1		"³‹K•\Œ»ƒL[ƒ[ƒh1"
-	STR_COLOR_REGEX_KEYWORD2		"³‹K•\Œ»ƒL[ƒ[ƒh2"
-	STR_COLOR_REGEX_KEYWORD3		"³‹K•\Œ»ƒL[ƒ[ƒh3"
-	STR_COLOR_REGEX_KEYWORD4		"³‹K•\Œ»ƒL[ƒ[ƒh4"
-	STR_COLOR_REGEX_KEYWORD5		"³‹K•\Œ»ƒL[ƒ[ƒh5"
-	STR_COLOR_REGEX_KEYWORD6		"³‹K•\Œ»ƒL[ƒ[ƒh6"
-	STR_COLOR_REGEX_KEYWORD7		"³‹K•\Œ»ƒL[ƒ[ƒh7"
-	STR_COLOR_REGEX_KEYWORD8		"³‹K•\Œ»ƒL[ƒ[ƒh8"
-	STR_COLOR_REGEX_KEYWORD9		"³‹K•\Œ»ƒL[ƒ[ƒh9"
-	STR_COLOR_REGEX_KEYWORD10		"³‹K•\Œ»ƒL[ƒ[ƒh10"
-	STR_COLOR_DIFF_ADD				"DIFF·•ª•\Ž¦(’Ç‰Á)"
-	STR_COLOR_DIFF_CNG				"DIFF·•ª•\Ž¦(•ÏX)"
-	STR_COLOR_DIFF_DEL				"DIFF·•ª•\Ž¦(íœ)"
-	STR_COLOR_BOOKMARK				"ƒuƒbƒNƒ}[ƒN"
-	STR_COLOR_PAGEVIEW				"•\Ž¦”ÍˆÍ(ƒ~ƒjƒ}ƒbƒv)"
+	STR_COLOR_KEYWORD1				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰1"
+	STR_COLOR_KEYWORD2				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰2"
+	STR_COLOR_KEYWORD3				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰3"
+	STR_COLOR_KEYWORD4				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰4"
+	STR_COLOR_KEYWORD5				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰5"
+	STR_COLOR_KEYWORD6				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰6"
+	STR_COLOR_KEYWORD7				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰7"
+	STR_COLOR_KEYWORD8				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰8"
+	STR_COLOR_KEYWORD9				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰9"
+	STR_COLOR_KEYWORD10				"å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰10"
+	STR_COLOR_REGEX_KEYWORD1		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰1"
+	STR_COLOR_REGEX_KEYWORD2		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰2"
+	STR_COLOR_REGEX_KEYWORD3		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰3"
+	STR_COLOR_REGEX_KEYWORD4		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰4"
+	STR_COLOR_REGEX_KEYWORD5		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰5"
+	STR_COLOR_REGEX_KEYWORD6		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰6"
+	STR_COLOR_REGEX_KEYWORD7		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰7"
+	STR_COLOR_REGEX_KEYWORD8		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰8"
+	STR_COLOR_REGEX_KEYWORD9		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰9"
+	STR_COLOR_REGEX_KEYWORD10		"æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰10"
+	STR_COLOR_DIFF_ADD				"DIFFå·®åˆ†è¡¨ç¤º(è¿½åŠ )"
+	STR_COLOR_DIFF_CNG				"DIFFå·®åˆ†è¡¨ç¤º(å¤‰æ›´)"
+	STR_COLOR_DIFF_DEL				"DIFFå·®åˆ†è¡¨ç¤º(å‰Šé™¤)"
+	STR_COLOR_BOOKMARK				"ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯"
+	STR_COLOR_PAGEVIEW				"è¡¨ç¤ºç¯„å›²(ãƒŸãƒ‹ãƒžãƒƒãƒ—)"
 
 	// ... could be many places left in this file I think, but couldnt decide if they should STAY as JPZ or not eg |*
 
@@ -4640,14 +4640,14 @@ BEGIN
 	// CSplitBoxWnd.cpp
 	
 	// CSplitterWnd.cpp
-	STR_ERR_CSPLITTER01				"SplitterWndƒNƒ‰ƒX‚Ì“o˜^‚ÉŽ¸”s‚µ‚Ü‚µ‚½B"
+	STR_ERR_CSPLITTER01				"SplitterWndã‚¯ãƒ©ã‚¹ã®ç™»éŒ²ã«å¤±æ•—ã—ã¾ã—ãŸã€‚"
 
 	// CTabWnd.cpp
-	STR_TABWND_LR_INFO				"¶ƒNƒŠƒbƒN: ƒ^ƒu–¼ˆê——\n‰EƒNƒŠƒbƒN: ƒpƒX–¼ˆê——"
-	STR_TABWND_CLOSETAB				"ƒ^ƒu‚ð•Â‚¶‚é"
-	STR_TABWND_SHOWALL				"‚·‚×‚Ä•\Ž¦(&A)"	// Menus 
-	STR_TABWND_SHOWTABNAME			"ƒ^ƒu–¼ˆê——‚ÉØ‘Ö‚¦‚é(&W)"  // •\Ž¦Ø‘Öƒƒjƒ…[
-	STR_TABWND_SHOWPATHNAME			"ƒpƒX–¼ˆê——‚ÉØ‘Ö‚¦‚é(&W)"  // •\Ž¦Ø‘Öƒƒjƒ…[
+	STR_TABWND_LR_INFO				"å·¦ã‚¯ãƒªãƒƒã‚¯: ã‚¿ãƒ–åä¸€è¦§\nå³ã‚¯ãƒªãƒƒã‚¯: ãƒ‘ã‚¹åä¸€è¦§"
+	STR_TABWND_CLOSETAB				"ã‚¿ãƒ–ã‚’é–‰ã˜ã‚‹"
+	STR_TABWND_SHOWALL				"ã™ã¹ã¦è¡¨ç¤º(&A)"	// Menus 
+	STR_TABWND_SHOWTABNAME			"ã‚¿ãƒ–åä¸€è¦§ã«åˆ‡æ›¿ãˆã‚‹(&W)"  // è¡¨ç¤ºåˆ‡æ›¿ãƒ¡ãƒ‹ãƒ¥ãƒ¼
+	STR_TABWND_SHOWPATHNAME			"ãƒ‘ã‚¹åä¸€è¦§ã«åˆ‡æ›¿ãˆã‚‹(&W)"  // è¡¨ç¤ºåˆ‡æ›¿ãƒ¡ãƒ‹ãƒ¥ãƒ¼
 
 	// CTipWnd.cpp
 
@@ -4658,36 +4658,36 @@ BEGIN
 	// CWnd.cpp
 
 	// CWSH.cpp
-	STR_ERR_CWSH01					"Žw–¼‚ÌƒXƒNƒŠƒvƒgƒGƒ“ƒWƒ“‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ"
-	STR_ERR_CWSH02					"Žw–¼‚ÌƒXƒNƒŠƒvƒgƒGƒ“ƒWƒ“‚ªì¬‚Å‚«‚Ü‚¹‚ñ"
-	STR_ERR_CWSH03					"ƒTƒCƒg‚ð“o˜^‚Å‚«‚Ü‚¹‚ñ"
-	STR_ERR_CWSH04					"ƒp[ƒT‚ðŽæ“¾‚Å‚«‚Ü‚¹‚ñ"
-	STR_ERR_CWSH05					"‰Šú‰»‚Å‚«‚Ü‚¹‚ñ"
-	STR_ERR_CWSH06					"ƒIƒuƒWƒFƒNƒg‚ð“n‚¹‚È‚©‚Á‚½"
-	STR_ERR_CWSH07					"ó‘Ô•ÏXƒGƒ‰["
-	STR_ERR_CWSH08					"ŽÀs‚ÉŽ¸”s‚µ‚Ü‚µ‚½"
-	STR_ERR_CWSH09					"ƒ}ƒNƒ‚ÌŽÀs‚ð’†’f‚µ‚Ü‚µ‚½B"
+	STR_ERR_CWSH01					"æŒ‡åã®ã‚¹ã‚¯ãƒªãƒ—ãƒˆã‚¨ãƒ³ã‚¸ãƒ³ãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“"
+	STR_ERR_CWSH02					"æŒ‡åã®ã‚¹ã‚¯ãƒªãƒ—ãƒˆã‚¨ãƒ³ã‚¸ãƒ³ãŒä½œæˆã§ãã¾ã›ã‚“"
+	STR_ERR_CWSH03					"ã‚µã‚¤ãƒˆã‚’ç™»éŒ²ã§ãã¾ã›ã‚“"
+	STR_ERR_CWSH04					"ãƒ‘ãƒ¼ã‚µã‚’å–å¾—ã§ãã¾ã›ã‚“"
+	STR_ERR_CWSH05					"åˆæœŸåŒ–ã§ãã¾ã›ã‚“"
+	STR_ERR_CWSH06					"ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’æ¸¡ã›ãªã‹ã£ãŸ"
+	STR_ERR_CWSH07					"çŠ¶æ…‹å¤‰æ›´ã‚¨ãƒ©ãƒ¼"
+	STR_ERR_CWSH08					"å®Ÿè¡Œã«å¤±æ•—ã—ã¾ã—ãŸ"
+	STR_ERR_CWSH09					"ãƒžã‚¯ãƒ­ã®å®Ÿè¡Œã‚’ä¸­æ–­ã—ã¾ã—ãŸã€‚"
 
 	// Debug.cpp
 	// CONAINTS STRINGS... only for debug, so ignoring.
 
 	// etc_uty.cpp
 	// CONTAINS a few STRINGS...
-	STR_ERR_ETCUTY01				"ƒVƒXƒeƒ€ "
-	STR_ERR_ETCUTY02				"ƒ†[ƒU[ "
-	STR_ERR_ETCUTY03				"%tsƒŠƒ\[ƒX‚ª‹É’[‚É•s‘«‚µ‚Ä‚¢‚Ü‚·B\n\
-‚±‚Ì‚Ü‚Ü%ts‚ð‹N“®‚·‚é‚ÆA³í‚É“®ì‚µ‚È‚¢‰Â”\«‚ª‚ ‚è‚Ü‚·B\n\
-V‚µ‚¢%ts‚Ì‹N“®‚ð’†’f‚µ‚Ü‚·B\n\
+	STR_ERR_ETCUTY01				"ã‚·ã‚¹ãƒ†ãƒ  "
+	STR_ERR_ETCUTY02				"ãƒ¦ãƒ¼ã‚¶ãƒ¼ "
+	STR_ERR_ETCUTY03				"%tsãƒªã‚½ãƒ¼ã‚¹ãŒæ¥µç«¯ã«ä¸è¶³ã—ã¦ã„ã¾ã™ã€‚\n\
+ã“ã®ã¾ã¾%tsã‚’èµ·å‹•ã™ã‚‹ã¨ã€æ­£å¸¸ã«å‹•ä½œã—ãªã„å¯èƒ½æ€§ãŒã‚ã‚Šã¾ã™ã€‚\n\
+æ–°ã—ã„%tsã®èµ·å‹•ã‚’ä¸­æ–­ã—ã¾ã™ã€‚\n\
 \n\
-ƒVƒXƒeƒ€ ƒŠƒ\[ƒX\tŽc‚è  %d%%\n\
-User ƒŠƒ\[ƒX\tŽc‚è  %d%%\n\
-GDI ƒŠƒ\[ƒX\tŽc‚è  %d%%\n\n"
-	STR_SHELL_HHCTRL				"HHCTRL.OCX‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñB\r\nHTMLƒwƒ‹ƒv‚ð—˜—p‚·‚é‚É‚ÍHHCTRL.OCX‚ª•K—v‚Å‚·B\r\n"
-	STR_SHELL_INFO					"î•ñ"
-	STR_SHELL_MENU_OPEN				"ŠJ‚­(&O)..."
-	STR_SHELL_MENU_IMPEXP			"ƒCƒ“ƒ|[ƒg^ƒGƒNƒXƒ|[ƒg‚Ì‹N“_ƒŠƒZƒbƒg(&R)"
-	STR_SHELL_IMPEXPDIR				"ŠeŽíÝ’è‚ÌƒCƒ“ƒ|[ƒg^ƒGƒNƒXƒ|[ƒg—pƒtƒ@ƒCƒ‹‘I‘ð‰æ–Ê‚Ì\n‰Šú•\Ž¦ƒtƒHƒ‹ƒ_‚ðÝ’èƒtƒHƒ‹ƒ_‚É–ß‚µ‚Ü‚·B"
-	STR_SHELL_INIFOLDER				"Ý’èƒtƒHƒ‹ƒ_(&/) >>"
+ã‚·ã‚¹ãƒ†ãƒ  ãƒªã‚½ãƒ¼ã‚¹\tæ®‹ã‚Š  %d%%\n\
+User ãƒªã‚½ãƒ¼ã‚¹\tæ®‹ã‚Š  %d%%\n\
+GDI ãƒªã‚½ãƒ¼ã‚¹\tæ®‹ã‚Š  %d%%\n\n"
+	STR_SHELL_HHCTRL				"HHCTRL.OCXãŒè¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã€‚\r\nHTMLãƒ˜ãƒ«ãƒ—ã‚’åˆ©ç”¨ã™ã‚‹ã«ã¯HHCTRL.OCXãŒå¿…è¦ã§ã™ã€‚\r\n"
+	STR_SHELL_INFO					"æƒ…å ±"
+	STR_SHELL_MENU_OPEN				"é–‹ã(&O)..."
+	STR_SHELL_MENU_IMPEXP			"ã‚¤ãƒ³ãƒãƒ¼ãƒˆï¼ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã®èµ·ç‚¹ãƒªã‚»ãƒƒãƒˆ(&R)"
+	STR_SHELL_IMPEXPDIR				"å„ç¨®è¨­å®šã®ã‚¤ãƒ³ãƒãƒ¼ãƒˆï¼ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆç”¨ãƒ•ã‚¡ã‚¤ãƒ«é¸æŠžç”»é¢ã®\nåˆæœŸè¡¨ç¤ºãƒ•ã‚©ãƒ«ãƒ€ã‚’è¨­å®šãƒ•ã‚©ãƒ«ãƒ€ã«æˆ»ã—ã¾ã™ã€‚"
+	STR_SHELL_INIFOLDER				"è¨­å®šãƒ•ã‚©ãƒ«ãƒ€(&/) >>"
 
 	// Funccode.cpp
 	// CONTAINS one array with Japanese, ppszFuncKind.
@@ -4700,7 +4700,7 @@ GDI ƒŠƒ\[ƒX\tŽc‚è  %d%%\n\n"
 	// gm_pszCodeComboNameArr contains the string "Automatic" as its first entry.
 	//   - CDlgGrep.cpp
 	//   - CDlgOpenFile.cpp
-	STR_ERR_GLOBAL01				"Ž©“®‘I‘ð"
+	STR_ERR_GLOBAL01				"è‡ªå‹•é¸æŠž"
 
 	// my_icmp.cpp
 
@@ -4711,112 +4711,112 @@ GDI ƒŠƒ\[ƒX\tŽc‚è  %d%%\n\n"
 	// WinMain.cpp
 
 	// CCdoeChecker.cpp
-	STR_CODECHECKER_EOL_UNIFY		"‰üsƒR[ƒh‚ª¬Ý‚µ‚Ä‚¢‚Ü‚·B\r\nŒ»Ý‚Ì“ü—Í‰üsƒR[ƒh %ts ‚É“ˆê‚µ‚Ü‚·‚©H"
-	STR_CODECHECKER_CONFORM_LOSESOME	"•¶ŽšƒGƒ“ƒR[ƒh %ts ‚Å•Û‘¶‚µ‚æ‚¤‚Æ‚µ‚Ä‚¢‚Ü‚·‚ªA\r\n•¶ŽšƒR[ƒh•ÏŠ·‚É‚æ‚èˆê•”‚Ì•¶Žšî•ñ‚ªŽ¸‚í‚ê‚Ü‚·B\r\n•Û‘¶ˆ—‚ð‘±s‚µ‚Ü‚·‚©H\nÅ‰‚ÌêŠ %ds %ts •¶Žš[%ls]%ts\nƒLƒƒƒ“ƒZƒ‹=ŠY“–ˆÊ’u‚ÉˆÚ“®"
-	STR_CODECHECKER_LOSESOME_SAVE	"ˆê•”‚Ì•¶Žšî•ñ‚ªAƒZ[ƒuŽž‚Ì•ÏŠ·‚É‚æ‚èŽ¸‚í‚ê‚Ü‚µ‚½"
-	STR_CODECHECKER_LOSESOME_ROAD	"ˆê•”‚Ì•¶Žšî•ñ‚ªAƒ[ƒhŽž‚Ì•ÏŠ·‚É‚æ‚èŽ¸‚í‚ê‚Ü‚µ‚½"
-	STR_CONVERT_ERR					"•ÏŠ·‚ÅƒGƒ‰[‚ª”­¶‚µ‚Ü‚µ‚½"
+	STR_CODECHECKER_EOL_UNIFY		"æ”¹è¡Œã‚³ãƒ¼ãƒ‰ãŒæ··åœ¨ã—ã¦ã„ã¾ã™ã€‚\r\nç¾åœ¨ã®å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰ %ts ã«çµ±ä¸€ã—ã¾ã™ã‹ï¼Ÿ"
+	STR_CODECHECKER_CONFORM_LOSESOME	"æ–‡å­—ã‚¨ãƒ³ã‚³ãƒ¼ãƒ‰ %ts ã§ä¿å­˜ã—ã‚ˆã†ã¨ã—ã¦ã„ã¾ã™ãŒã€\r\næ–‡å­—ã‚³ãƒ¼ãƒ‰å¤‰æ›ã«ã‚ˆã‚Šä¸€éƒ¨ã®æ–‡å­—æƒ…å ±ãŒå¤±ã‚ã‚Œã¾ã™ã€‚\r\nä¿å­˜å‡¦ç†ã‚’ç¶šè¡Œã—ã¾ã™ã‹ï¼Ÿ\næœ€åˆã®å ´æ‰€ %dè¡Œ %ts æ–‡å­—[%ls]%ts\nã‚­ãƒ£ãƒ³ã‚»ãƒ«=è©²å½“ä½ç½®ã«ç§»å‹•"
+	STR_CODECHECKER_LOSESOME_SAVE	"ä¸€éƒ¨ã®æ–‡å­—æƒ…å ±ãŒã€ã‚»ãƒ¼ãƒ–æ™‚ã®å¤‰æ›ã«ã‚ˆã‚Šå¤±ã‚ã‚Œã¾ã—ãŸ"
+	STR_CODECHECKER_LOSESOME_ROAD	"ä¸€éƒ¨ã®æ–‡å­—æƒ…å ±ãŒã€ãƒ­ãƒ¼ãƒ‰æ™‚ã®å¤‰æ›ã«ã‚ˆã‚Šå¤±ã‚ã‚Œã¾ã—ãŸ"
+	STR_CONVERT_ERR					"å¤‰æ›ã§ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ã¾ã—ãŸ"
 
-	STR_DLGABOUT_APPNAME			"ƒTƒNƒ‰ƒGƒfƒBƒ^"
+	STR_DLGABOUT_APPNAME			"ã‚µã‚¯ãƒ©ã‚¨ãƒ‡ã‚£ã‚¿"
 
-	STR_DLGEXEC_SELECT_CURDIR		"ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚ð‘I‚ñ‚Å‚­‚¾‚³‚¢"
+	STR_DLGEXEC_SELECT_CURDIR		"ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’é¸ã‚“ã§ãã ã•ã„"
 
-	STR_MENU_UNKOWN					"%ts •s–¾(‰ž“š‚È‚µ)"
-	STR_MENU_GREP					"%ts yGrepz""%ts%ts"""
-	STR_MENU_OUTPUT					"%ts ƒAƒEƒgƒvƒbƒg"
+	STR_MENU_UNKOWN					"%ts ä¸æ˜Ž(å¿œç­”ãªã—)"
+	STR_MENU_GREP					"%ts ã€Grepã€‘""%ts%ts"""
+	STR_MENU_OUTPUT					"%ts ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆ"
 
-	STR_PRINT_WAITING				"ˆóüˆ—‚ÌI—¹‚ð‘Ò‹@‚µ‚Ä‚¢‚Ü‚·EEE"
+	STR_PRINT_WAITING				"å°åˆ·å‡¦ç†ã®çµ‚äº†ã‚’å¾…æ©Ÿã—ã¦ã„ã¾ã™ãƒ»ãƒ»ãƒ»"
 	
-	// Ý’è’l‚Ì•ÏŠ·
-	STR_TAB_CAPTION_OUTPUT			"yGrepz"
-	STR_TAB_CAPTION_GREP			"yƒAƒEƒgƒvƒbƒgz"
-	STR_CAPTION_ACTIVE_OUTPUT		"ƒAƒEƒgƒvƒbƒg"
-	STR_CAPTION_ACTIVE_UPDATE		"(XV)"
-	STR_CAPTION_ACTIVE_VIEW			"(ƒrƒ…[ƒ‚[ƒh)"
-	STR_CAPTION_ACTIVE_OVERWRITE	"(ã‘‚«‹ÖŽ~)"
-	STR_CAPTION_ACTIVE_KEYMACRO		"yƒL[ƒ}ƒNƒ‚Ì‹L˜^’†z"
-	STR_DATA_FORMAT					"yyyy'”N'M'ŒŽ'd'“ú('dddd')'"
-	STR_TIME_FORMAT					"tthh'Žž'mm'•ª'ss'•b'"
-	STR_TRANSNAME_COMDESKTOP		"‹¤—LƒfƒXƒNƒgƒbƒv\\"
-	STR_TRANSNAME_COMDOC			"‹¤—LƒhƒLƒ…ƒƒ“ƒg\\"
-	STR_TRANSNAME_DESKTOP			"ƒfƒXƒNƒgƒbƒv\\"
-	STR_TRANSNAME_MYDOC				"ƒ}ƒCƒhƒLƒ…ƒƒ“ƒg\\"
-	STR_TRANSNAME_IE				"IEƒLƒƒƒbƒVƒ…\\"
+	// è¨­å®šå€¤ã®å¤‰æ›
+	STR_TAB_CAPTION_OUTPUT			"ã€Grepã€‘"
+	STR_TAB_CAPTION_GREP			"ã€ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã€‘"
+	STR_CAPTION_ACTIVE_OUTPUT		"ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆ"
+	STR_CAPTION_ACTIVE_UPDATE		"(æ›´æ–°)"
+	STR_CAPTION_ACTIVE_VIEW			"(ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰)"
+	STR_CAPTION_ACTIVE_OVERWRITE	"(ä¸Šæ›¸ãç¦æ­¢)"
+	STR_CAPTION_ACTIVE_KEYMACRO		"ã€ã‚­ãƒ¼ãƒžã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ã€‘"
+	STR_DATA_FORMAT					"yyyy'å¹´'M'æœˆ'd'æ—¥('dddd')'"
+	STR_TIME_FORMAT					"tthh'æ™‚'mm'åˆ†'ss'ç§’'"
+	STR_TRANSNAME_COMDESKTOP		"å…±æœ‰ãƒ‡ã‚¹ã‚¯ãƒˆãƒƒãƒ—\\"
+	STR_TRANSNAME_COMDOC			"å…±æœ‰ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ\\"
+	STR_TRANSNAME_DESKTOP			"ãƒ‡ã‚¹ã‚¯ãƒˆãƒƒãƒ—\\"
+	STR_TRANSNAME_MYDOC				"ãƒžã‚¤ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ\\"
+	STR_TRANSNAME_IE				"IEã‚­ãƒ£ãƒƒã‚·ãƒ¥\\"
 	STR_TRANSNAME_TEMP				"TEMP\\"
-	STR_TRANSNAME_APPDATA			"ƒAƒvƒŠƒf[ƒ^\\"
-	STR_PRINT_SET_NAME				"ˆóüÝ’è"
-	STR_TYPE_NAME_BASIS				"Šî–{"
-	STR_TYPE_NAME_RICHTEXT			"ƒŠƒbƒ`ƒeƒLƒXƒg"
-	STR_TYPE_NAME_TEXT				"ƒeƒLƒXƒg"
-	STR_TYPE_NAME_DOS				"MS-DOSƒoƒbƒ`ƒtƒ@ƒCƒ‹"
-	STR_TYPE_NAME_ASM				"ƒAƒZƒ“ƒuƒ‰"
-	STR_TYPE_NAME_INI				"Ý’èƒtƒ@ƒCƒ‹"
+	STR_TRANSNAME_APPDATA			"ã‚¢ãƒ—ãƒªãƒ‡ãƒ¼ã‚¿\\"
+	STR_PRINT_SET_NAME				"å°åˆ·è¨­å®š"
+	STR_TYPE_NAME_BASIS				"åŸºæœ¬"
+	STR_TYPE_NAME_RICHTEXT			"ãƒªãƒƒãƒãƒ†ã‚­ã‚¹ãƒˆ"
+	STR_TYPE_NAME_TEXT				"ãƒ†ã‚­ã‚¹ãƒˆ"
+	STR_TYPE_NAME_DOS				"MS-DOSãƒãƒƒãƒãƒ•ã‚¡ã‚¤ãƒ«"
+	STR_TYPE_NAME_ASM				"ã‚¢ã‚»ãƒ³ãƒ–ãƒ©"
+	STR_TYPE_NAME_INI				"è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«"
 
 	// CBregexp.cpp
 #ifdef _M_IA64
-	STR_BREGONIG_LOAD				"bregonig.dll ‚Ìƒ[ƒh‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\r\n³‹K•\Œ»‚ð—˜—p‚·‚é‚É‚Í Unicode/IA64 ”Å‚Ì bregonig.dll ‚ª•K—v‚Å‚·B\r\n“üŽè•û–@‚Íƒwƒ‹ƒv‚ðŽQÆ‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_BREGONIG_LOAD				"bregonig.dll ã®ãƒ­ãƒ¼ãƒ‰ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\r\næ­£è¦è¡¨ç¾ã‚’åˆ©ç”¨ã™ã‚‹ã«ã¯ Unicode/IA64 ç‰ˆã® bregonig.dll ãŒå¿…è¦ã§ã™ã€‚\r\nå…¥æ‰‹æ–¹æ³•ã¯ãƒ˜ãƒ«ãƒ—ã‚’å‚ç…§ã—ã¦ãã ã•ã„ã€‚"
 #elif defined(_M_AMD64)
-	STR_BREGONIG_LOAD				"bregonig.dll ‚Ìƒ[ƒh‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\r\n³‹K•\Œ»‚ð—˜—p‚·‚é‚É‚Í Unicode/x64 ”Å‚Ì bregonig.dll ‚ª•K—v‚Å‚·B\r\n“üŽè•û–@‚Íƒwƒ‹ƒv‚ðŽQÆ‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_BREGONIG_LOAD				"bregonig.dll ã®ãƒ­ãƒ¼ãƒ‰ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\r\næ­£è¦è¡¨ç¾ã‚’åˆ©ç”¨ã™ã‚‹ã«ã¯ Unicode/x64 ç‰ˆã® bregonig.dll ãŒå¿…è¦ã§ã™ã€‚\r\nå…¥æ‰‹æ–¹æ³•ã¯ãƒ˜ãƒ«ãƒ—ã‚’å‚ç…§ã—ã¦ãã ã•ã„ã€‚"
 #else
-	STR_BREGONIG_LOAD				"bregonig.dll ‚Ìƒ[ƒh‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\r\n³‹K•\Œ»‚ð—˜—p‚·‚é‚É‚Í Unicode ”Å‚Ì bregonig.dll ‚ª•K—v‚Å‚·B\r\n“üŽè•û–@‚Íƒwƒ‹ƒv‚ðŽQÆ‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_BREGONIG_LOAD				"bregonig.dll ã®ãƒ­ãƒ¼ãƒ‰ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\r\næ­£è¦è¡¨ç¾ã‚’åˆ©ç”¨ã™ã‚‹ã«ã¯ Unicode ç‰ˆã® bregonig.dll ãŒå¿…è¦ã§ã™ã€‚\r\nå…¥æ‰‹æ–¹æ³•ã¯ãƒ˜ãƒ«ãƒ—ã‚’å‚ç…§ã—ã¦ãã ã•ã„ã€‚"
 #endif
 #ifdef _M_IA64
-	STR_BREGONIG_INIT				"bregonig.dll ‚Ì—˜—p‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\r\n³‹K•\Œ»‚ð—˜—p‚·‚é‚É‚Í Unicode/IA64 ”Å‚Ì bregonig.dll ‚ª•K—v‚Å‚·B\r\n“üŽè•û–@‚Íƒwƒ‹ƒv‚ðŽQÆ‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_BREGONIG_INIT				"bregonig.dll ã®åˆ©ç”¨ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\r\næ­£è¦è¡¨ç¾ã‚’åˆ©ç”¨ã™ã‚‹ã«ã¯ Unicode/IA64 ç‰ˆã® bregonig.dll ãŒå¿…è¦ã§ã™ã€‚\r\nå…¥æ‰‹æ–¹æ³•ã¯ãƒ˜ãƒ«ãƒ—ã‚’å‚ç…§ã—ã¦ãã ã•ã„ã€‚"
 #elif defined(_M_AMD64)
-	STR_BREGONIG_INIT				"bregonig.dll ‚Ì—˜—p‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\r\n³‹K•\Œ»‚ð—˜—p‚·‚é‚É‚Í Unicode/x64 ”Å‚Ì bregonig.dll ‚ª•K—v‚Å‚·B\r\n“üŽè•û–@‚Íƒwƒ‹ƒv‚ðŽQÆ‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_BREGONIG_INIT				"bregonig.dll ã®åˆ©ç”¨ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\r\næ­£è¦è¡¨ç¾ã‚’åˆ©ç”¨ã™ã‚‹ã«ã¯ Unicode/x64 ç‰ˆã® bregonig.dll ãŒå¿…è¦ã§ã™ã€‚\r\nå…¥æ‰‹æ–¹æ³•ã¯ãƒ˜ãƒ«ãƒ—ã‚’å‚ç…§ã—ã¦ãã ã•ã„ã€‚"
 #else
-	STR_BREGONIG_INIT				"bregonig.dll ‚Ì—˜—p‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\r\n³‹K•\Œ»‚ð—˜—p‚·‚é‚É‚Í Unicode ”Å‚Ì bregonig.dll ‚ª•K—v‚Å‚·B\r\n“üŽè•û–@‚Íƒwƒ‹ƒv‚ðŽQÆ‚µ‚Ä‚­‚¾‚³‚¢B"
+	STR_BREGONIG_INIT				"bregonig.dll ã®åˆ©ç”¨ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\r\næ­£è¦è¡¨ç¾ã‚’åˆ©ç”¨ã™ã‚‹ã«ã¯ Unicode ç‰ˆã® bregonig.dll ãŒå¿…è¦ã§ã™ã€‚\r\nå…¥æ‰‹æ–¹æ³•ã¯ãƒ˜ãƒ«ãƒ—ã‚’å‚ç…§ã—ã¦ãã ã•ã„ã€‚"
 #endif
-	STR_BREGONIG_ERROR				"bregonig.dll ‚Ìƒ[ƒh‚Å—\Šú‚¹‚ÊƒGƒ‰[‚ª”­¶‚µ‚Ü‚µ‚½B"
-	STR_BREGONIG_TITLE				"³‹K•\Œ»ƒGƒ‰["
+	STR_BREGONIG_ERROR				"bregonig.dll ã®ãƒ­ãƒ¼ãƒ‰ã§äºˆæœŸã›ã¬ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚"
+	STR_BREGONIG_TITLE				"æ­£è¦è¡¨ç¾ã‚¨ãƒ©ãƒ¼"
 
 	// CDllPlugin.cpp
-	STR_DLLPLG_TITLE				"DLLƒvƒ‰ƒOƒCƒ“"
-	STR_DLLPLG_INIT_ERR1			"DLL‚Ì“Ç‚Ýž‚Ý‚ÉŽ¸”s‚µ‚Ü‚µ‚½\n%ts\n%ls"
-	STR_DLLPLG_INIT_ERR2			"DLL‚Ì“Ç‚Ýž‚Ý‚ÉŽ¸”s‚µ‚Ü‚µ‚½"
+	STR_DLLPLG_TITLE				"DLLãƒ—ãƒ©ã‚°ã‚¤ãƒ³"
+	STR_DLLPLG_INIT_ERR1			"DLLã®èª­ã¿è¾¼ã¿ã«å¤±æ•—ã—ã¾ã—ãŸ\n%ts\n%ls"
+	STR_DLLPLG_INIT_ERR2			"DLLã®èª­ã¿è¾¼ã¿ã«å¤±æ•—ã—ã¾ã—ãŸ"
 
 	// CPluginManager.cpp
-	STR_PLGMGR_FOLDER				"ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_‚ðì¬o—ˆ‚Ü‚¹‚ñ"
-	STR_PLGMGR_CANCEL				"ƒLƒƒƒ“ƒZƒ‹‚³‚ê‚Ü‚µ‚½"
-	STR_PLGMGR_NEWPLUGIN			"V‚µ‚¢ƒvƒ‰ƒOƒCƒ“‚ÍŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½"
-	STR_PLGMGR_INSTALL				"ƒvƒ‰ƒOƒCƒ“u%tsv‚ðƒCƒ“ƒXƒg[ƒ‹‚µ‚Ü‚·‚©H"
-	STR_PLGMGR_INSTALL_ERR			"ƒvƒ‰ƒOƒCƒ“u%tsv‚ðƒCƒ“ƒXƒg[ƒ‹‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½\n——RF%ls"
-	STR_PLGMGR_ERR_ZIP				"ZIPƒtƒ@ƒCƒ‹‚Íˆµ‚¦‚Ü‚¹‚ñ"
-	STR_PLGMGR_ERR_FOLDER			"ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_‚ª‚ ‚è‚Ü‚¹‚ñ"
-	STR_PLGMGR_ERR_CREATEDIR		"ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_‚ðì¬o—ˆ‚Ü‚¹‚ñ"
-	STR_PLGMGR_INST_ZIP_ACCESS		"ZIPƒtƒ@ƒCƒ‹u%tsv‚ÉƒAƒNƒZƒXo—ˆ‚Ü‚¹‚ñ"
-	STR_PLGMGR_INST_ZIP_DEF			"ZIPƒtƒ@ƒCƒ‹u%tsv‚É‚Íƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹iplugin.defj‚ª‚ ‚è‚Ü‚¹‚ñ"
-	STR_PLGMGR_INST_ZIP_ALREADY		"u%tsv‚ÍŠù‚ÉƒCƒ“ƒXƒg[ƒ‹‚³‚ê‚Ä‚¢‚Ü‚·\nã‘‚«‚µ‚Ü‚·‚©H"
-	STR_PLGMGR_INST_ZIP_INST		"ZIPƒvƒ‰ƒOƒCƒ“u%tsv‚ðu%tsv‚ÉƒCƒ“ƒXƒg[ƒ‹‚µ‚Ü‚·‚©H"
-	STR_PLGMGR_INST_ZIP_UNZIP		"ZIPƒvƒ‰ƒOƒCƒ“u%tsv‚Ì‰ð“€‚ÉŽ¸”s‚µ‚Ü‚µ‚½"
-	STR_PLGMGR_INST_ZIP_ERR			"ƒvƒ‰ƒOƒCƒ“u%tsv‚ðƒCƒ“ƒXƒg[ƒ‹‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚½\n——RF%ls"
-	STR_PLGMGR_INST_DEF				"ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹iplugin.defj‚ª‚ ‚è‚Ü‚¹‚ñ"
-	STR_PLGMGR_INST_ID				"Plugin.ID‚ª‚ ‚è‚Ü‚¹‚ñ"
-	STR_PLGMGR_INST_RESERVE1		"Plugin.ID‚É"""
-	STR_PLGMGR_INST_RESERVE2		"""‚ÍŽg—p‚Å‚«‚Ü‚¹‚ñ"
-	STR_PLGMGR_INST_IDNUM			"Plugin.ID‚Ìæ“ª‚É”Žš‚ÍŽg—p‚Å‚«‚Ü‚¹‚ñ"
-	STR_PLGMGR_INST_NAME			"“¯‚¶ƒvƒ‰ƒOƒCƒ“‚ª•Ê‚Ì–¼‘O‚ÅƒCƒ“ƒXƒg[ƒ‹‚³‚ê‚Ä‚¢‚Ü‚·Bã‘‚«‚µ‚Ü‚·‚©H\n@‚Í‚¢@¨@V‚µ‚¢u%tsv‚ðŽg—p\n@‚¢‚¢‚¦¨@ƒCƒ“ƒXƒg[ƒ‹Ï‚Ý‚Ìu%lsv‚ðŽg—p"
-	STR_PLGMGR_INST_USERCANCEL		"ƒ†[ƒUƒLƒƒƒ“ƒZƒ‹"
-	STR_PLGMGR_INST_MAX				"ƒvƒ‰ƒOƒCƒ“‚ð‚±‚êˆÈã“o˜^‚Å‚«‚Ü‚¹‚ñ"
+	STR_PLGMGR_FOLDER				"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ã‚’ä½œæˆå‡ºæ¥ã¾ã›ã‚“"
+	STR_PLGMGR_CANCEL				"ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã•ã‚Œã¾ã—ãŸ"
+	STR_PLGMGR_NEWPLUGIN			"æ–°ã—ã„ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã¯è¦‹ã¤ã‹ã‚Šã¾ã›ã‚“ã§ã—ãŸ"
+	STR_PLGMGR_INSTALL				"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã€Œ%tsã€ã‚’ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã—ã¾ã™ã‹ï¼Ÿ"
+	STR_PLGMGR_INSTALL_ERR			"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã€Œ%tsã€ã‚’ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã§ãã¾ã›ã‚“ã§ã—ãŸ\nç†ç”±ï¼š%ls"
+	STR_PLGMGR_ERR_ZIP				"ZIPãƒ•ã‚¡ã‚¤ãƒ«ã¯æ‰±ãˆã¾ã›ã‚“"
+	STR_PLGMGR_ERR_FOLDER			"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ãŒã‚ã‚Šã¾ã›ã‚“"
+	STR_PLGMGR_ERR_CREATEDIR		"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ã‚’ä½œæˆå‡ºæ¥ã¾ã›ã‚“"
+	STR_PLGMGR_INST_ZIP_ACCESS		"ZIPãƒ•ã‚¡ã‚¤ãƒ«ã€Œ%tsã€ã«ã‚¢ã‚¯ã‚»ã‚¹å‡ºæ¥ã¾ã›ã‚“"
+	STR_PLGMGR_INST_ZIP_DEF			"ZIPãƒ•ã‚¡ã‚¤ãƒ«ã€Œ%tsã€ã«ã¯ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ï¼ˆplugin.defï¼‰ãŒã‚ã‚Šã¾ã›ã‚“"
+	STR_PLGMGR_INST_ZIP_ALREADY		"ã€Œ%tsã€ã¯æ—¢ã«ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã•ã‚Œã¦ã„ã¾ã™\nä¸Šæ›¸ãã—ã¾ã™ã‹ï¼Ÿ"
+	STR_PLGMGR_INST_ZIP_INST		"ZIPãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã€Œ%tsã€ã‚’ã€Œ%tsã€ã«ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã—ã¾ã™ã‹ï¼Ÿ"
+	STR_PLGMGR_INST_ZIP_UNZIP		"ZIPãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã€Œ%tsã€ã®è§£å‡ã«å¤±æ•—ã—ã¾ã—ãŸ"
+	STR_PLGMGR_INST_ZIP_ERR			"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã€Œ%tsã€ã‚’ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã§ãã¾ã›ã‚“ã§ã—ãŸ\nç†ç”±ï¼š%ls"
+	STR_PLGMGR_INST_DEF				"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ï¼ˆplugin.defï¼‰ãŒã‚ã‚Šã¾ã›ã‚“"
+	STR_PLGMGR_INST_ID				"Plugin.IDãŒã‚ã‚Šã¾ã›ã‚“"
+	STR_PLGMGR_INST_RESERVE1		"Plugin.IDã«"""
+	STR_PLGMGR_INST_RESERVE2		"""ã¯ä½¿ç”¨ã§ãã¾ã›ã‚“"
+	STR_PLGMGR_INST_IDNUM			"Plugin.IDã®å…ˆé ­ã«æ•°å­—ã¯ä½¿ç”¨ã§ãã¾ã›ã‚“"
+	STR_PLGMGR_INST_NAME			"åŒã˜ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãŒåˆ¥ã®åå‰ã§ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã•ã‚Œã¦ã„ã¾ã™ã€‚ä¸Šæ›¸ãã—ã¾ã™ã‹ï¼Ÿ\nã€€ã¯ã„ã€€â†’ã€€æ–°ã—ã„ã€Œ%tsã€ã‚’ä½¿ç”¨\nã€€ã„ã„ãˆâ†’ã€€ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«æ¸ˆã¿ã®ã€Œ%lsã€ã‚’ä½¿ç”¨"
+	STR_PLGMGR_INST_USERCANCEL		"ãƒ¦ãƒ¼ã‚¶ã‚­ãƒ£ãƒ³ã‚»ãƒ«"
+	STR_PLGMGR_INST_MAX				"ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ã“ã‚Œä»¥ä¸Šç™»éŒ²ã§ãã¾ã›ã‚“"
 
-	STR_WSHPLUG_LOADMACRO			"ƒ}ƒNƒ‚Ì“Ç‚Ýž‚Ý‚ÉŽ¸”s‚µ‚Ü‚µ‚½B\n\n%ts"
-	STR_FILESAVE_CONVERT_ERROR		"'%ts'\nƒtƒ@ƒCƒ‹‚ð•Û‘¶‚Å‚«‚Ü‚¹‚ñB\n•ÏŠ·ƒGƒ‰[‚ª”­¶‚µ‚Ü‚µ‚½B"
+	STR_WSHPLUG_LOADMACRO			"ãƒžã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ã«å¤±æ•—ã—ã¾ã—ãŸã€‚\n\n%ts"
+	STR_FILESAVE_CONVERT_ERROR		"'%ts'\nãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä¿å­˜ã§ãã¾ã›ã‚“ã€‚\nå¤‰æ›ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚"
 
-	STR_FILETREE_FROM_COMMON		"Ý’è: ‹¤’ÊÝ’è"
-	STR_FILETREE_FROM_TYPE			"Ý’è: ƒ^ƒCƒv•ÊÝ’è"
-	STR_FILETREE_FROM_FILE			"Ý’è: %ts"
-	STR_FILETREE_CURDIR				"<ƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_>"
-	STR_FILETREE_MAXCOUNT			"Å‘å”(%d)‚ð’´‚¦‚½‚½‚ßØ‚èŽÌ‚Ä‚Ü‚µ‚½"
-	STR_FILETREE_MENU_ROOT			"INIƒ‹[ƒg(&I)"
-	STR_FILETREE_MENU_MYDOC			"ƒ}ƒC ƒhƒLƒ…ƒƒ“ƒg(&Y)"
-	STR_FILETREE_MENU_MYMUSIC		"ƒ}ƒC ƒ~ƒ…[ƒWƒbƒN(&M)"
-	STR_FILETREE_MENU_MYVIDEO		"ƒ}ƒC ƒrƒfƒI(&V)"
-	STR_FILETREE_MENU_DESK			"ƒfƒXƒNƒgƒbƒv(&D)"
+	STR_FILETREE_FROM_COMMON		"è¨­å®š: å…±é€šè¨­å®š"
+	STR_FILETREE_FROM_TYPE			"è¨­å®š: ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š"
+	STR_FILETREE_FROM_FILE			"è¨­å®š: %ts"
+	STR_FILETREE_CURDIR				"<ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€>"
+	STR_FILETREE_MAXCOUNT			"æœ€å¤§æ•°(%d)ã‚’è¶…ãˆãŸãŸã‚åˆ‡ã‚Šæ¨ã¦ã¾ã—ãŸ"
+	STR_FILETREE_MENU_ROOT			"INIãƒ«ãƒ¼ãƒˆ(&I)"
+	STR_FILETREE_MENU_MYDOC			"ãƒžã‚¤ ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ(&Y)"
+	STR_FILETREE_MENU_MYMUSIC		"ãƒžã‚¤ ãƒŸãƒ¥ãƒ¼ã‚¸ãƒƒã‚¯(&M)"
+	STR_FILETREE_MENU_MYVIDEO		"ãƒžã‚¤ ãƒ“ãƒ‡ã‚ª(&V)"
+	STR_FILETREE_MENU_DESK			"ãƒ‡ã‚¹ã‚¯ãƒˆãƒƒãƒ—(&D)"
 	STR_FILETREE_MENU_TEMP			"Temp(&T)"
 	STR_FILETREE_MENU_SAKURA		"sakura(&S)"
-	STR_FILETREE_MENU_SAKURADATA	"sakuraƒf[ƒ^(&A)"
-	STR_FILETREE_REPLACE_PATH_FROM	"’uŠ·Œ³ƒpƒX‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢"
-	STR_FILETREE_REPLACE_PATH_TO	"’uŠ·æ•¶Žš—ñ‚ðŽw’è‚µ‚Ä‚­‚¾‚³‚¢"
+	STR_FILETREE_MENU_SAKURADATA	"sakuraãƒ‡ãƒ¼ã‚¿(&A)"
+	STR_FILETREE_REPLACE_PATH_FROM	"ç½®æ›å…ƒãƒ‘ã‚¹ã‚’æŒ‡å®šã—ã¦ãã ã•ã„"
+	STR_FILETREE_REPLACE_PATH_TO	"ç½®æ›å…ˆæ–‡å­—åˆ—ã‚’æŒ‡å®šã—ã¦ãã ã•ã„"
 
 END
 
@@ -4841,7 +4841,7 @@ IDR_MENU1               ID_RC_TYPE_INI          "../resource/MainMenu.ini"
 
 #endif	// ! SAKURA_LANG_RESOURCE
 
-#endif    // “ú–{Œê resources
+#endif    // æ—¥æœ¬èªž resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -1,5 +1,6 @@
-﻿//Microsoft Developer Studio generated resource script.
-//
+//Microsoft Developer Studio generated resource script.
+
+// このファイルのエンコーディングは UTF-8 です.
 // CodePage: 65001 (UTF-8)
 #pragma code_page(65001)
 

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -1,6 +1,8 @@
 //Microsoft Developer Studio generated resource script.
 
-// このファイルのエンコーディングは UTF-8 です.
+// このファイルのエンコーディングは UTF-8 (BOM無し) です.
+// ※ BOM を付けると Visual Studio のリソースエディタで開けなくなってしまう.
+
 // CodePage: 65001 (UTF-8)
 #pragma code_page(65001)
 

--- a/sakura_lang_en_US/sakura_lang_en_US.vcxproj
+++ b/sakura_lang_en_US/sakura_lang_en_US.vcxproj
@@ -258,7 +258,12 @@
     </Bscmake>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ResourceCompile Include="sakura_lang_rc.rc" />
+    <ResourceCompile Include="sakura_lang_rc.rc">
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/c 65001</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/c 65001</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/c 65001</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/c 65001</AdditionalOptions>
+    </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="sakura_lang.h" />

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -1,4 +1,4 @@
-//Microsoft Developer Studio generated resource script.
+Ôªø//Microsoft Developer Studio generated resource script.
 //
 #define SAKURA_LANG_RESOURCE
 
@@ -115,7 +115,7 @@ BEGIN
     EDITTEXT        IDC_EDIT_VER,33,6,204,51,ES_MULTILINE | ES_READONLY | 
                     NOT WS_BORDER | NOT WS_TABSTOP
     LTEXT           S_COPYRIGHT,IDC_STATIC,33,61,205,8,NOT WS_GROUP | SS_NOPREFIX
-    LTEXT           "Original Author: Take-san(í|ÉpÉìÉ_) Ç≥ÇÒ",IDC_STATIC,33,75,125,8,NOT 
+    LTEXT           "Original Author: Take-san(Á´π„Éë„É≥„ÉÄ) „Åï„Çì",IDC_STATIC,33,75,125,8,NOT 
                     WS_GROUP
     LTEXT           "Project Sakura-Editor:",IDC_STATIC_URL_CAPTION,33,88,71,
                     8,NOT WS_GROUP
@@ -189,8 +189,8 @@ BEGIN
     CONTROL         "List1",IDC_LIST_FL,"SysListView32",LVS_REPORT | 
                     LVS_SINGLESEL | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,0,
                     0,234,252
-    PUSHBUTTON      "Å•",IDC_BUTTON_MENU,1,255,10,14,NOT WS_TABSTOP
-    CONTROL         "Å°",IDC_BUTTON_WINSIZE,"Button",BS_AUTOCHECKBOX | 
+    PUSHBUTTON      "‚ñº",IDC_BUTTON_MENU,1,255,10,14,NOT WS_TABSTOP
+    CONTROL         "‚ñ†",IDC_BUTTON_WINSIZE,"Button",BS_AUTOCHECKBOX | 
                     BS_PUSHLIKE,12,255,10,14
     PUSHBUTTON      "&Copy",IDC_BUTTON_COPY,24,255,50,14,WS_DISABLED
     DEFPUSHBUTTON   "&Jump",IDOK,76,255,50,14
@@ -348,7 +348,7 @@ STYLE DS_SETFOREGROUND | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Grep Running..."
 FONT 9, "Tahoma"
 BEGIN
-    LTEXT           "SearchingÅEÅEÅE",IDC_STATIC,5,5,61,8,NOT WS_GROUP
+    LTEXT           "Searching„Éª„Éª„Éª",IDC_STATIC,5,5,61,8,NOT WS_GROUP
     LTEXT           "File",IDC_STATIC,5,21,26,8,NOT WS_GROUP
     LTEXT           "IDC_STATIC_CURPATH",IDC_STATIC_CURFILE,36,20,252,10,NOT 
                     WS_GROUP
@@ -1099,7 +1099,7 @@ BEGIN
     LTEXT           "Keyword Set &1",IDC_STATIC,162,18,54,8
     COMBOBOX        IDC_COMBO_SET,218,16,75,180,CBS_DROPDOWNLIST | WS_VSCROLL | 
                     WS_TABSTOP
-    PUSHBUTTON      "Set &2Å`10...",IDC_BUTTON_KEYWORD_SELECT,218,31,75,14
+    PUSHBUTTON      "Set &2ÔΩû10...",IDC_BUTTON_KEYWORD_SELECT,218,31,75,14
     PUSHBUTTON      "Keyword Setting(&C)...",IDC_BUTTON_EDITKEYWORD,218,47,75,14
     GROUPBOX        "Keyword Highlighting",IDC_STATIC,156,6,142,60,WS_GROUP
     LTEXT           "Block(&F)",IDC_STATIC,164,80,42,8
@@ -1162,7 +1162,7 @@ BEGIN
                     WS_VSCROLL | WS_TABSTOP
     CONTROL         "Case &Insensitive",IDC_CHECK_HOKANLOHICASE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,31,90,10
-    LTEXT           "CandidateÅF",IDC_STATIC,102,32,30,8,NOT WS_GROUP
+    LTEXT           "CandidateÔºö",IDC_STATIC,102,32,30,8,NOT WS_GROUP
     CONTROL         "In current &file",IDC_CHECK_HOKANBYFILE,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,142,31,68,10
     CONTROL         "From &Keyword Set",IDC_CHECK_HOKANBYKEYWORD,"Button",
@@ -1188,7 +1188,7 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,158,171,130,10
     CONTROL         "When Undo, separate from editing(&U)",IDC_CHECK_INDENTCPPUNDO,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,183,146,10
-    GROUPBOX        "C/C++Å@Indent Settings",IDC_STATIC,3,159,295,40,WS_GROUP
+    GROUPBOX        "C/C++„ÄÄIndent Settings",IDC_STATIC,3,159,295,40,WS_GROUP
 END
 
 IDD_PROP_REGEX DIALOGEX 0, 0, 302, 244
@@ -1250,7 +1250,7 @@ BEGIN
                     WS_GROUP
     EDITTEXT        IDC_EDIT_KEYHELP,61,172,170,12,ES_AUTOHSCROLL
     PUSHBUTTON      "...",IDC_BUTTON_KEYHELP_REF,234,172,12,13,WS_GROUP
-    LTEXT           "Å™ Priority (Top)",IDC_LABEL_KEYHELP_PRIOR,249,33,44,8,NOT 
+    LTEXT           "‚Üë Priority (Top)",IDC_LABEL_KEYHELP_PRIOR,249,33,44,8,NOT 
                     WS_GROUP
     PUSHBUTTON      "In&sert",IDC_BUTTON_KEYHELP_INS,251,136,38,15
     PUSHBUTTON      "Updat&e",IDC_BUTTON_KEYHELP_UPD,251,154,38,15
@@ -1849,7 +1849,7 @@ BEGIN
     CONTROL         "Save once as .&bak",
                     IDC_RADIO_BACKUP_TYPE1,"Button",BS_AUTORADIOBUTTON | 
                     WS_GROUP,12,66,142,10
-    CONTROL         "Save repeatedly as (.b00Å`b98)(&G)",
+    CONTROL         "Save repeatedly as (.b00ÔΩûb98)(&G)",
                     IDC_RADIO_BACKUP_TYPE3,"Button",BS_AUTORADIOBUTTON,12,80,
                     156,10
     CONTROL         "App&end backup date/time to file name",
@@ -2324,7 +2324,7 @@ EXSTYLE WS_EX_CONTEXTHELP
 CAPTION "File Tree Setting"
 FONT 9, "Tahoma"
 BEGIN
-    LTEXT           "SettingÅFCommon",IDC_STATIC_SETTFING_FROM,4,4,282,10
+    LTEXT           "SettingÔºöCommon",IDC_STATIC_SETTFING_FROM,4,4,282,10
     CONTROL         "Load &Ini from foldres",IDC_CHECK_LOADINI,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,16,120,9
     LTEXT           "Default Setting File(&J)",IDC_STATIC,4,28,110,8
@@ -2341,7 +2341,7 @@ BEGIN
     LTEXT           "Pa&th",IDC_STATIC_PATH,3,119,22,10
     EDITTEXT        IDC_EDIT_PATH,38,117,122,13,ES_AUTOHSCROLL
     PUSHBUTTON      "&...",IDC_BUTTON_REF2,161,117,10,13
-    PUSHBUTTON      "Å•(&3)",IDC_BUTTON_PATH_MENU,171,117,21,14
+    PUSHBUTTON      "‚ñº(&3)",IDC_BUTTON_PATH_MENU,171,117,21,14
     LTEXT           "Lab&el",IDC_STATIC,3,136,32,10
     EDITTEXT        IDC_EDIT_LABEL,38,134,111,13,ES_AUTOHSCROLL
     LTEXT           "File(&K)",IDC_STATIC_FILE,3,154,32,10
@@ -3153,8 +3153,8 @@ STRINGTABLE DISCARDABLE
 BEGIN
     F_COPY_ADDCRLF          "Copy adding CRLF"
     F_COPYLINES             "Copy selected lines"
-    F_COPYLINESASPASSAGE    "Copy selected as passage"			// ëIëîÕàÕì‡ëSçsà¯ópïÑïtÇ´ÉRÉsÅ[" <<--check
-	F_COPYLINESWITHLINENUMBER "Copy selected with line nr"		// ëIëîÕàÕì‡ëSçsçsî‘çÜïtÇ´ÉRÉsÅ[" <<--check
+    F_COPYLINESASPASSAGE    "Copy selected as passage"			// ÈÅ∏ÊäûÁØÑÂõ≤ÂÜÖÂÖ®Ë°åÂºïÁî®Á¨¶‰ªò„Åç„Ç≥„Éî„Éº" <<--check
+	F_COPYLINESWITHLINENUMBER "Copy selected with line nr"		// ÈÅ∏ÊäûÁØÑÂõ≤ÂÜÖÂÖ®Ë°åË°åÁï™Âè∑‰ªò„Åç„Ç≥„Éî„Éº" <<--check
     F_COPY_COLOR_HTML       "Copy selected with HTML markup"
     F_COPY_COLOR_HTML_LINENUMBER "Copy selected with line nr && HTML"
     F_COPYPATH              "Copy this file's path"
@@ -3179,36 +3179,36 @@ BEGIN
     F_CONVERT_TOPMENU		"Convert"
     F_TOLOWER               "Lower case"
     F_TOUPPER               "Upper case"
-    F_TOHANKAKU             "Full Height Å® Half Height"
-    F_TOZENKAKUKATA         "Half Height + Hiragana Å® Full/Katakana"
-    F_TOZENKAKUHIRA         "Half Height + Katakana Å® Full/Hiragana"
-    F_HANKATATOZENKATA      "Half Height Katakana Å® Full Katakana"
-    F_HANKATATOZENHIRA      "Half Katakana Å® Full Hiragana"
-    F_TOZENEI               "Half Alphabetic Å® Full Alphabetic"
+    F_TOHANKAKU             "Full Height ‚Üí Half Height"
+    F_TOZENKAKUKATA         "Half Height + Hiragana ‚Üí Full/Katakana"
+    F_TOZENKAKUHIRA         "Half Height + Katakana ‚Üí Full/Hiragana"
+    F_HANKATATOZENKATA      "Half Height Katakana ‚Üí Full Katakana"
+    F_HANKATATOZENHIRA      "Half Katakana ‚Üí Full Hiragana"
+    F_TOZENEI               "Half Alphabetic ‚Üí Full Alphabetic"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_TOHANEI               "Full Alphabetic Å® Half Alphabetic"
-    F_TOHANKATA             "Full Katakana Å® Half Katakana"
-    F_TABTOSPACE            "TABÅ®Spaces"
-    F_SPACETOTAB            "SpacesÅ®TAB"
+    F_TOHANEI               "Full Alphabetic ‚Üí Half Alphabetic"
+    F_TOHANKATA             "Full Katakana ‚Üí Half Katakana"
+    F_TABTOSPACE            "TAB‚ÜíSpaces"
+    F_SPACETOTAB            "Spaces‚ÜíTAB"
 	F_CONV_ENCODE_SUBMENU	"Change Encoding"
 END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_CODECNV_AUTO2SJIS     "Automatic Å® SJIS Code"
-    F_CODECNV_EMAIL         "E-Mail(JISÅ®SJIS) Code"
-    F_CODECNV_EUC2SJIS      "EUCÅ®SJIS Code"
-    F_CODECNV_UNICODE2SJIS  "UTF-16Å®SJIS Code"
-    F_CODECNV_UTF82SJIS     "UTF-8Å®SJIS Code"
-    F_CODECNV_UTF72SJIS     "UTF-7Å®SJIS Code"
-    F_CODECNV_UNICODEBE2SJIS "UTF-16 BEÅ®SJIS Code"
-    F_CODECNV_SJIS2JIS      "SJISÅ®JIS Code"
-    F_CODECNV_SJIS2EUC      "SJISÅ®EUC Code"
-    F_CODECNV_SJIS2UTF8     "SJISÅ®UTF-8 Code"
-    F_CODECNV_SJIS2UTF7     "SJISÅ®UTF-7 Code"
+    F_CODECNV_AUTO2SJIS     "Automatic ‚Üí SJIS Code"
+    F_CODECNV_EMAIL         "E-Mail(JIS‚ÜíSJIS) Code"
+    F_CODECNV_EUC2SJIS      "EUC‚ÜíSJIS Code"
+    F_CODECNV_UNICODE2SJIS  "UTF-16‚ÜíSJIS Code"
+    F_CODECNV_UTF82SJIS     "UTF-8‚ÜíSJIS Code"
+    F_CODECNV_UTF72SJIS     "UTF-7‚ÜíSJIS Code"
+    F_CODECNV_UNICODEBE2SJIS "UTF-16 BE‚ÜíSJIS Code"
+    F_CODECNV_SJIS2JIS      "SJIS‚ÜíJIS Code"
+    F_CODECNV_SJIS2EUC      "SJIS‚ÜíEUC Code"
+    F_CODECNV_SJIS2UTF8     "SJIS‚ÜíUTF-8 Code"
+    F_CODECNV_SJIS2UTF7     "SJIS‚ÜíUTF-7 Code"
 END
 
 STRINGTABLE DISCARDABLE 
@@ -3448,7 +3448,7 @@ BEGIN
     F_PREVGROUP             "Prev group"
     F_TAB_MOVERIGHT         "Move tab Right"
     F_TAB_MOVELEFT          "Move tab Left"
-    F_TAB_SEPARATE          "New Tab Group" // "êVãKÉOÉãÅ[Év"
+    F_TAB_SEPARATE          "New Tab Group" // "Êñ∞Ë¶è„Ç∞„É´„Éº„Éó"
     F_TAB_JOINTNEXT         "Move to next group"
     F_TAB_JOINTPREV         "Move to prev group"
     F_TAB_MANIP_SUBMENU     "Tab control"				// LMP -- added
@@ -3520,7 +3520,7 @@ END
 
 STRINGTABLE DISCARDABLE 
 BEGIN
-    F_MENU_NOT_USED_FIRST   "--Tool Bar Break--" //"Å\Å\ÉcÅ[ÉãÉoÅ[ê‹ï‘Å\Å\"
+    F_MENU_NOT_USED_FIRST   "--Tool Bar Break--" //"‚Äï‚Äï„ÉÑ„Éº„É´„Éê„ÉºÊäòËøî‚Äï‚Äï"
 END
 
 STRINGTABLE DISCARDABLE 
@@ -3550,7 +3550,7 @@ BEGIN
     STR_SQLERR_EXEC_BUT_NOT_RUN	"Trying to execute in Oracle SQL*Plus\n\n\nOracle SQL*Plus is not running\n"
     STR_SQLERR_ACTV_BUT_NOT_RUN	"Trying to activate Oracle SQL*Plus\n\n\nOracle SQL*Plus is not running\n"
 	STR_ERR_CMPERR				"Comparison destination folder\n%ts\nhas a %d byte line \ncan not perform comparison."			// FIXME - ok?
-//	STR_ERR_CMPERR				"î‰ärêÊÇÃÉtÉ@ÉCÉã\n%s\n%dÉoÉCÉgÇí¥Ç¶ÇÈçsÇ™Ç†ÇËÇ‹Ç∑ÅB\nî‰ärÇ≈Ç´Ç‹ÇπÇÒÅB"
+//	STR_ERR_CMPERR				"ÊØîËºÉÂÖà„ÅÆ„Éï„Ç°„Ç§„É´\n%s\n%d„Éê„Ç§„Éà„ÇíË∂Ö„Åà„ÇãË°å„Åå„ÅÇ„Çä„Åæ„Åô„ÄÇ\nÊØîËºÉ„Åß„Åç„Åæ„Åõ„Çì„ÄÇ"
 
 	STR_NO_TITLE1				"(No Title)"
 	STR_NO_TITLE2				"No Title"
@@ -3664,8 +3664,8 @@ BEGIN
 	STR_DLGFNCLST_REMARK03		"Procedure Declaration"
 	STR_DLGFNCLST_REMARK04		"Function"
 	STR_DLGFNCLST_REMARK05		"Procedure"
-	STR_DLGFNCLST_REMARK06		"Å°Package Specification"
-	STR_DLGFNCLST_REMARK07		"Å°Package Body"
+	STR_DLGFNCLST_REMARK06		"‚ñ†Package Specification"
+	STR_DLGFNCLST_REMARK07		"‚ñ†Package Body"
 	STR_DLGFNCLST_REMARK08		"PROC"
 	STR_DLGFNCLST_REMARK09		"LABEL"
 	STR_DLGFNCLST_REMARK10		"ENDP"
@@ -3733,7 +3733,7 @@ BEGIN
 	STR_DLGFNCLST_MENU_UNIFY	"&Unify inheriting info"
 	STR_DLGFNCLST_MENU_CLOSE	"Close(&X)"
 
-	STR_DLGFNCLST_UNIFY			"åªç›ÇÃâÊñ ÇÃÉhÉbÉLÉìÉOîzíuèÓïÒÇÇ∑Ç◊ÇƒÇÃã§í ê›íËÅEÉ^ÉCÉvï ê›íËÇ…ÉRÉsÅ[ÇµÇƒìùàÍÇµÇ‹Ç∑ÅB\nÅiåªç›äJÇ¢ÇƒÇ¢ÇÈëºâÊñ ÇÃèÛë‘Ç‡ìùàÍÇµÇ‹Ç∑ÅBÅj\n"
+	STR_DLGFNCLST_UNIFY			"ÁèæÂú®„ÅÆÁîªÈù¢„ÅÆ„Éâ„ÉÉ„Ç≠„É≥„Ç∞ÈÖçÁΩÆÊÉÖÂ†±„Çí„Åô„Åπ„Å¶„ÅÆÂÖ±ÈÄöË®≠ÂÆö„Éª„Çø„Ç§„ÉóÂà•Ë®≠ÂÆö„Å´„Ç≥„Éî„Éº„Åó„Å¶Áµ±‰∏Ä„Åó„Åæ„Åô„ÄÇ\nÔºàÁèæÂú®Èñã„ÅÑ„Å¶„ÅÑ„Çã‰ªñÁîªÈù¢„ÅÆÁä∂ÊÖã„ÇÇÁµ±‰∏Ä„Åó„Åæ„Åô„ÄÇÔºâ\n"
 
 
 	// CDlgGrep.cpp
@@ -3883,9 +3883,9 @@ BEGIN
 	STR_BACKUP_ERR_MSG		"Failed to create backup..  Continue to overwrite the original file?"		// Continue with original file
 	STR_BACKUP_ERR_PATH_CRETE	"error in the path of creating the backup destination.\nPath is too long or invalid format.\nContinue to overwire teh original file?"
 	STR_BACKUP_CONFORM_TITLE1		"Confirming creation of backup"												// Dialog Title for message below
-	STR_BACKUP_CONFORM_MSG1		"Creating a backup before updating.\nOK?  [(N)o] = No backup, just overwrite (or save as).\n\n%ts\n    Å´\n%ts\n\nBackup file will be sent to the Trashcan\n"
+	STR_BACKUP_CONFORM_MSG1		"Creating a backup before updating.\nOK?  [(N)o] = No backup, just overwrite (or save as).\n\n%ts\n    ‚Üì\n%ts\n\nBackup file will be sent to the Trashcan\n"
 	STR_BACKUP_CONFORM_TITLE2		"Confirming creation of backup"												// Dialog Title fo rmessage below
-	STR_BACKUP_CONFORM_MSG2		"Creating a backup before updating.\nOK?  [(N)o] = No backup, just overwrite (or save as).\n\n%ts\n    Å´\n%ts\n\n"
+	STR_BACKUP_CONFORM_MSG2		"Creating a backup before updating.\nOK?  [(N)o] = No backup, just overwrite (or save as).\n\n%ts\n    ‚Üì\n%ts\n\n"
 	STR_BACKUP_ERR_DELETE		"failed to delete"
 	STR_BACKUP_ERR_MOVE			"failed to move"
 	STR_ERR_DLGEDITDOC21		"%ts\nis currently prohibited from writing by another process."
@@ -3900,7 +3900,7 @@ BEGIN
 	STR_ERR_DLGEDITDOC30		"%ts\nhas been altered. Save before closing? \n\nDue to opening as view-mode it is suggested to save under a different name.\n"
 	STR_CHANGE_CHARSET			"%ts\nis no change.\nhowever change encoding.\nSave before closing?"
 	STR_ERR_DLGEDITDOC31		"%ts\nhas been altered. Save before closing?"
-	STR_AUTORELOAD_NOFITY		"ÅöFile Updated at %02d:%02d:%02d"
+	STR_AUTORELOAD_NOFITY		"‚òÖFile Updated at %02d:%02d:%02d"
 
 	// CType_Cpp.cpp
 	STR_OUTLINE_CPP_NONAME		"No Name"
@@ -3921,15 +3921,15 @@ BEGIN
 
 	// CEditView.cpp
 	STR_VIEW_TIMER				"CEditView::Create()\nTimer could not start up.\nPossible insufficiency of system resources."
-	STR_ERR_DLGEDITVW2			"ëÂ"													// Used in get Extents
-	STR_ERR_DLGEDITVW5			"\n--------------------\nÅ°"
-	STR_ERR_DLGEDITVW6			"Å°"
+	STR_ERR_DLGEDITVW2			"Â§ß"													// Used in get Extents
+	STR_ERR_DLGEDITVW5			"\n--------------------\n‚ñ†"
+	STR_ERR_DLGEDITVW6			"‚ñ†"
 	STR_MENU_KEYWORDINFO		"Copy Keyword description to clipboard"				// Right click menu
 	STR_MENU_OPENKEYWORDDIC		"Open keyword dictionary"							// Right click menu
 	STR_STATUS_ROW_COL			"%5d Ln %4d Col"
 	STR_INS_MODE_INS			"INS"													// Insert mode
 	STR_INS_MODE_OVR			"OVR"													// Overwrite mode
-	STR_GREP_SEARCH_CONDITION	"\r\nÅ† Search Conditions  "							// Output from GREP resuilts
+	STR_GREP_SEARCH_CONDITION	"\r\n‚ñ° Search Conditions  "							// Output from GREP resuilts
 	STR_GREP_SEARCH_FILE		"<File Search>\r\n"
 	STR_GREP_SEARCH_TARGET		"Search Target   "
 	STR_GREP_REPLACE_TO			"Repalce To      "
@@ -3979,13 +3979,13 @@ BEGIN
 
 	// CEditView_Command.cpp
 	STR_ERR_MACRO1				"Macro %d (%ts) failed to execute."
-	STR_ERR_SRPREV1				"Å£Restarted search from bottom"
-	STR_ERR_SRPREV2				"Å¢Not Found"
-	STR_ERR_SRPREV3				"Reverse searching (Å™) for '%ls' found no further instances."
-	STR_ERR_SRNEXT1				"Å•Restarted search from top"
-	STR_ERR_SRNEXT2				"Å§Not Found"
-	STR_ERR_SRNEXT3				"Forward searching (Å´) for '%ls' found no further instances."
-	STR_ERR_UNINDENT1			"ÅöReverse indent only works on selected text"
+	STR_ERR_SRPREV1				"‚ñ≤Restarted search from bottom"
+	STR_ERR_SRPREV2				"‚ñ≥Not Found"
+	STR_ERR_SRPREV3				"Reverse searching (‚Üë) for '%ls' found no further instances."
+	STR_ERR_SRNEXT1				"‚ñºRestarted search from top"
+	STR_ERR_SRNEXT2				"‚ñΩNot Found"
+	STR_ERR_SRNEXT3				"Forward searching (‚Üì) for '%ls' found no further instances."
+	STR_ERR_UNINDENT1			"‚òÖReverse indent only works on selected text"
 	STR_ERR_TAGJMP1				"Cant Tag-Jump"
 	STR_ERR_TAGJMPBK1			"Cant Bookmark Tag-Jump"
 	STR_ERR_MACROERR1			"Failed to open Macro.\n\n%ts"
@@ -4018,10 +4018,10 @@ BEGIN
 	// inside funciton Command_EXTHELP1
 
 	// CEditView_Command_New.cpp
-	STR_BOOKMARK_NEXT_NOT_FOUND	"Forward (Å´) bookmark wasnt found."
-	STR_BOOKMARK_PREV_NOT_FOUND	"Previous (Å™) bookmark wasnt found."
-	STR_FUCLIST_NEXT_NOT_FOUND	"Forward (Å´) Function wasnt found."
-	STR_FUCLIST_PREV_NOT_FOUND	"Previous (Å™) Function wasnt found."
+	STR_BOOKMARK_NEXT_NOT_FOUND	"Forward (‚Üì) bookmark wasnt found."
+	STR_BOOKMARK_PREV_NOT_FOUND	"Previous (‚Üë) bookmark wasnt found."
+	STR_FUCLIST_NEXT_NOT_FOUND	"Forward (‚Üì) Function wasnt found."
+	STR_FUCLIST_PREV_NOT_FOUND	"Previous (‚Üë) Function wasnt found."
 	STR_ERR_DLGEDITVWCMDNW7		"%d line was successfully merged."												// Edit Menu::Cosmtik::Merge lines option
 	STR_ERR_DLGEDITVWCMDNW8		"There were no lines of text that could be merged in your selection."			// Edit Menu::Cosmtik::Merge lines option
 	STR_SAVEAGENT_OTHER_APP		"'%ts'\nCould not save the file.\nPath may not be correct, or the file is in use by another application."
@@ -4034,13 +4034,13 @@ BEGIN
 	STR_ERR_DLGEDITVWDIFF3		"DIFF command failed.\n\n%ls"
 	STR_ERR_DLGEDITVWDIFF4		"The file to be used for comparison appears to be a binary file."
 	STR_ERR_DLGEDITVWDIFF5		"No differences were found by DIFF"
-	STR_DIFF_NEXT_NOT_FOUND		"Forwards (Å´) searching didnt find differences"
-	STR_DIFF_PREV_NOT_FOUND		"Backward (Å™) searching didnt find differences"
+	STR_DIFF_NEXT_NOT_FOUND		"Forwards (‚Üì) searching didnt find differences"
+	STR_DIFF_PREV_NOT_FOUND		"Backward (‚Üë) searching didnt find differences"
 	STR_DIFF_FAILED				"DIFF command failed."
 	STR_DIFF_FAILED_TEMP		"DIFF command failed.\n\nCouldnt create temporary file."
 	STR_DIFF_FAILED_LONG		"DIFF command failed.\n\nLine was too long."
-	STR_MODLINE_NEXT_NOT_FOUND	"Forward (Å´) Modified Line wasnt found."
-	STR_MODLINE_PREV_NOT_FOUND	"Previous (Å™) Modified Line wasnt found."
+	STR_MODLINE_NEXT_NOT_FOUND	"Forward (‚Üì) Modified Line wasnt found."
+	STR_MODLINE_PREV_NOT_FOUND	"Previous (‚Üë) Modified Line wasnt found."
 
 	// CEditView_New.cpp -- no words, going to ignore for now ( just block [], ... etc )
 
@@ -4069,10 +4069,10 @@ BEGIN
 
 	STR_ERR_DLGEDITWND14		"Before using Print Preview please install a printer driver.\n"
 
-	//		const char*	pszLabel[7] = { "", "99999 çs 9999 óÒ", "CRLF", "0000", "UTF-16", "REC", "è„èë" };	//Oct. 30, 2000 JEPRO êÁñúçsÇ‡óvÇÁÇÒ
+	//		const char*	pszLabel[7] = { "", "99999 Ë°å 9999 Âàó", "CRLF", "0000", "UTF-16", "REC", "‰∏äÊõ∏" };	//Oct. 30, 2000 JEPRO ÂçÉ‰∏áË°å„ÇÇË¶Å„Çâ„Çì
 	STR_ERR_DLGEDITWND19		""
 	STR_ERR_DLGEDITWND20		"99999 L 9999 C"
-//	STR_ERR_DLGEDITWND20		"99999 çs 9999 óÒ"
+//	STR_ERR_DLGEDITWND20		"99999 Ë°å 9999 Âàó"
 	STR_ERR_DLGEDITWND21		"CFLF"
 	STR_ERR_DLGEDITWND22		"0000"
 	STR_ERR_DLGEDITWND23		"UTF-16 BOM"
@@ -4473,7 +4473,7 @@ BEGIN
 
 	// CPropTypesRegex.cpp
 	STR_PROPTYPEREGEX_LIST1			"Keyword"
-	STR_PROPTYPEREGEX_LIST2			"Color Index"						// LMP - not sure êFéwíË
+	STR_PROPTYPEREGEX_LIST2			"Color Index"						// LMP - not sure Ëâ≤ÊåáÂÆö
 	STR_PROPTYPEREGEX_NOUSE			"Cannot use Regular Expression"
 	STR_PROPTYPEREGEX_NOTFOUND		"RegEx library cannot be found\n\nRegular Expression functionality cant be used, do you want to enable it anyway?"
 	STR_PROPTYPEREGEX_NOREG			"Cannot register any further keywords."
@@ -4548,17 +4548,17 @@ BEGIN
 	STR_ERR_CSHAREDATA02			"Unexpected error"
 
 									// Common Prop::Tab/Title bar
-	STR_ERR_CSHAREDATA10			"${w?ÅyGrepÅz$h$:ÅyOutputÅz$:$f$}${U?(Changed)$}${R?(Read Only)$:(Write Protected)$}${M?ÅyRecording MacroÅz$}"
+	STR_ERR_CSHAREDATA10			"${w?„ÄêGrep„Äë$h$:„ÄêOutput„Äë$:$f$}${U?(Changed)$}${R?(Read Only)$:(Write Protected)$}${M?„ÄêRecording Macro„Äë$}"
 	STR_CUSTMENU_RIGHT_CLICK		"Right Click Menu"
 	STR_CUSTMENU_CUSTOM				"Menu%d"
 	STR_CUSTMENU_TAB				"Tab Menu"
-	STR_ERR_CSHAREDATA14			"ÇPÇQÇRÇSÇTÇUÇVÇWÇXÇOÅi(Åm[ÅuÅwÅyÅ°Å†Å£Å¢Å•Å§ÅüÅûÅõÅùÅúÅòÅEÅ¶ÅôÅöëÊá@áAáBáCáDáEáFáGáHáIáJáKáLáMáNáOáPáQáRáSáTáUáVáWáXáYáZá[á\á]àÍìÒéOélå‹òZéµî™ã„è\àÎìÛéQåﬁ"
+	STR_ERR_CSHAREDATA14			"ÔºëÔºíÔºìÔºîÔºïÔºñÔºóÔºòÔºôÔºêÔºà(Ôºª[„Äå„Äé„Äê‚ñ†‚ñ°‚ñ≤‚ñ≥‚ñº‚ñΩ‚óÜ‚óá‚óã‚óé‚óè¬ß„Éª‚Äª‚òÜ‚òÖÁ¨¨‚ë†‚ë°‚ë¢‚ë£‚ë§‚ë•‚ë¶‚ëß‚ë®‚ë©‚ë™‚ë´‚ë¨‚ë≠‚ëÆ‚ëØ‚ë∞‚ë±‚ë≤‚ë≥‚Ö†‚Ö°‚Ö¢‚Ö£‚Ö§‚Ö•‚Ö¶‚Öß‚Ö®‚Ö©‰∏Ä‰∫å‰∏âÂõõ‰∫îÂÖ≠‰∏ÉÂÖ´‰πùÂçÅÂ£±ÂºêÂèÇ‰ºç"
 	STR_ERR_CSHAREDATA15			"yyyy'Y'M'M'd'D('dddd')'"
 	STR_ERR_CSHAREDATA16			"tthh'H'mm'M'ss'S'"
-	STR_ERR_CSHAREDATA17			"${w?$h$:Output$:${I?$f$:$N$}$}${U?(Changed)$} - sakura $V ${R?(Read Only)$:(Write Protected)$}${M?  ÅyRecording MacroÅz$}"
-	STR_ERR_CSHAREDATA18			"${w?$h$:Output$:$f$}${U?(Changed)$} - sakura $V ${R?(Read Only)$:(Write Protected)$}${M?  ÅyRecording MacroÅz$}"
+	STR_ERR_CSHAREDATA17			"${w?$h$:Output$:${I?$f$:$N$}$}${U?(Changed)$} - sakura $V ${R?(Read Only)$:(Write Protected)$}${M?  „ÄêRecording Macro„Äë$}"
+	STR_ERR_CSHAREDATA18			"${w?$h$:Output$:$f$}${U?(Changed)$} - sakura $V ${R?(Read Only)$:(Write Protected)$}${M?  „ÄêRecording Macro„Äë$}"
 	STR_ERR_CSHAREDATA19			"Attempting to close multiple editor windows, sure you want to do this?"			// Displayed if you try to close edit whith many open windows
-	STR_ERR_CSHAREDATA20			"%ts\n\n\nIn the case you want to re-open a file with a different encoding\nsChooseÅuRe-Open with EncodingÅvfrom the file menu please.\n\nCurrent Character Encoding set=[%ts]\nNew Character Encoding=[%ts]" // See Resource F_FILE_REOPEN_SUBMENU
+	STR_ERR_CSHAREDATA20			"%ts\n\n\nIn the case you want to re-open a file with a different encoding\nsChoose„ÄåRe-Open with Encoding„Äçfrom the file menu please.\n\nCurrent Character Encoding set=[%ts]\nNew Character Encoding=[%ts]" // See Resource F_FILE_REOPEN_SUBMENU
 	STR_ERR_CSHAREDATA21			"%ts\n\nUnclear character encoding found during opening multiple documents.\n\nCurrent Char Encoding=%d [%ts]\nNew Char Encoding=%d [%ts]"
 	STR_ERR_CSHAREDATA22			"unknown" // relates to above two [%s]
 
@@ -4803,7 +4803,7 @@ GDI Resource\tRemaining  %d%%\n\n"
 	STR_PLGMGR_INST_RESERVE1		"Do'nt Use  """
 	STR_PLGMGR_INST_RESERVE2		""" in Plugin.ID"
 	STR_PLGMGR_INST_IDNUM			"Plugin.ID of Head charcter not use numbers"
-	STR_PLGMGR_INST_NAME			"The same plugin has been installed under a different name. Are you sure Overwite?\nÅ@YesÅ@->Å@Use newÅu%tsÅv\nÅ@NoÅ®Å@Use installedÅu%lsÅv"
+	STR_PLGMGR_INST_NAME			"The same plugin has been installed under a different name. Are you sure Overwite?\n„ÄÄYes„ÄÄ->„ÄÄUse new„Äå%ts„Äç\n„ÄÄNo‚Üí„ÄÄUse installed„Äå%ls„Äç"
 	STR_PLGMGR_INST_USERCANCEL		"User Cancel"
 	STR_PLGMGR_INST_MAX				"Plugin can not register any more"
 
@@ -4814,7 +4814,7 @@ GDI Resource\tRemaining  %d%%\n\n"
 	STR_FILETREE_FROM_TYPE			"Setting: Types"
 	STR_FILETREE_FROM_FILE			"Setting: %ts"
 	STR_FILETREE_CURDIR				"<Cur Folder>"
-	STR_FILETREE_MAXCOUNT			"ç≈ëÂêî(%d)Çí¥Ç¶ÇΩÇΩÇﬂêÿÇËéÃÇƒÇ‹ÇµÇΩ"
+	STR_FILETREE_MAXCOUNT			"ÊúÄÂ§ßÊï∞(%d)„ÇíË∂Ö„Åà„Åü„Åü„ÇÅÂàá„ÇäÊç®„Å¶„Åæ„Åó„Åü"
 	STR_FILETREE_MENU_ROOT			"&Ini Root"
 	STR_FILETREE_MENU_MYDOC			"M&y Document"
 	STR_FILETREE_MENU_MYMUSIC		"My &Music"

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -1,5 +1,8 @@
 ﻿//Microsoft Developer Studio generated resource script.
 //
+// CodePage: 65001 (UTF-8)
+#pragma code_page(65001)
+
 #define SAKURA_LANG_RESOURCE
 
 #ifndef SAKURA_LANG_RESOURCE
@@ -31,7 +34,6 @@
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
 #ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
-#pragma code_page(932)
 #endif //_WIN32
 
 #define	S_COPYRIGHT	"Copyright (C) 2011-2018  by Lucien & Collaborators"

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -1,5 +1,6 @@
-﻿//Microsoft Developer Studio generated resource script.
-//
+//Microsoft Developer Studio generated resource script.
+
+// このファイルのエンコーディングは UTF-8 です.
 // CodePage: 65001 (UTF-8)
 #pragma code_page(65001)
 

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -1,6 +1,8 @@
 //Microsoft Developer Studio generated resource script.
 
-// このファイルのエンコーディングは UTF-8 です.
+// このファイルのエンコーディングは UTF-8 (BOM無し) です.
+// ※ BOM を付けると Visual Studio のリソースエディタで開けなくなってしまう.
+
 // CodePage: 65001 (UTF-8)
 #pragma code_page(65001)
 


### PR DESCRIPTION
リソースファイルで SJIS 以外の文字列表現が扱えるように、ファイルエンコーディングを UTF-8 (BOM無し) に変更します。

※ BOM があるとリソースエディタで開けなくなるのであえて付けない。

## 対応内容
- .rc のファイルエンコーディングを UTF-8 (BOM無し) に変更
- .rc ファイルの先頭で`#pragma code_page(65001)` を宣言
- .rc のビルドオプションとして `/c 65001` を追加

## NOTE
この PR は当初 UTF-16 で対応する方針で進めていましたが、途中から UTF-8 にする方針に変更されました。そのため、本 PR 前半のコメントは UTF-16 方針時に対するコメントとなっています。