### PR TITLE
markdown に TOC を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 # Sakura Editor
+
+<!-- TOC -->
+
+- [Sakura Editor](#sakura-editor)
+    - [Web Site](#web-site)
+    - [開発参加ポリシー](#開発参加ポリシー)
+    - [Build Requirements](#build-requirements)
+        - [Visual Studio Community 2017](#visual-studio-community-2017)
+            - [Visual Studio Install options required](#visual-studio-install-options-required)
+    - [How to build](#how-to-build)
+    - [CI Build (AppVeyor)](#ci-build-appveyor)
+        - [ビルドの仕組み](#ビルドの仕組み)
+        - [ビルド成果物を利用する上での注意事項](#ビルド成果物を利用する上での注意事項)
+        - [ビルド成果物](#ビルド成果物)
+
+<!-- /TOC -->
+
 [![Build status](https://ci.appveyor.com/api/projects/status/xlsp22h1q91mh96j/branch/master?svg=true)](https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master)
 
 A free Japanese text editor for Windows

--- a/appveyor.md
+++ b/appveyor.md
@@ -8,7 +8,7 @@
     - [呼び出し構造](#呼び出し構造)
     - [ビルドに使用するバッチファイルの引数](#ビルドに使用するバッチファイルの引数)
     - [バッチファイルの仕組み](#バッチファイルの仕組み)
-        - [sakura\preBuild.bat の構造](#sakura\prebuildbat-の構造)
+        - [preBuild.bat の構造](#prebuildbat-の構造)
             - [生成する環境変数](#生成する環境変数)
             - [処理の流れ](#処理の流れ)
         - [zipArtifacts.bat の構造](#zipartifactsbat-の構造)
@@ -88,7 +88,7 @@
 
 ## バッチファイルの仕組み
 
-### sakura\preBuild.bat の構造
+### preBuild.bat の構造
 
 #### 生成する環境変数
 

--- a/appveyor.md
+++ b/appveyor.md
@@ -1,5 +1,22 @@
 ﻿# appveyor でのビルド
 
+<!-- TOC -->
+
+- [appveyor でのビルド](#appveyor-でのビルド)
+    - [入力として使用する環境変数](#入力として使用する環境変数)
+    - [ビルドに使用するバッチファイル](#ビルドに使用するバッチファイル)
+    - [呼び出し構造](#呼び出し構造)
+    - [ビルドに使用するバッチファイルの引数](#ビルドに使用するバッチファイルの引数)
+    - [バッチファイルの仕組み](#バッチファイルの仕組み)
+        - [sakura\preBuild.bat の構造](#sakura\prebuildbat-の構造)
+            - [生成する環境変数](#生成する環境変数)
+            - [処理の流れ](#処理の流れ)
+        - [zipArtifacts.bat の構造](#zipartifactsbat-の構造)
+            - [生成する環境変数](#生成する環境変数-1)
+            - [処理の流れ](#処理の流れ-1)
+
+<!-- /TOC -->
+
 ## 入力として使用する環境変数
 
 | 環境変数 | 説明 |
@@ -71,7 +88,7 @@
 
 ## バッチファイルの仕組み
 
-### [sakura\preBuild.bat](sakura/preBuild.bat) の構造
+### sakura\preBuild.bat の構造
 
 #### 生成する環境変数
 
@@ -115,7 +132,7 @@
 | APPVEYOR_BUILD_URL                |APPVEYOR_BUILD_URL           |文字列   |
 
 
-### [zipArtifacts.bat](zipArtifacts.bat) の構造
+### zipArtifacts.bat の構造
 
 #### 生成する環境変数
 


### PR DESCRIPTION
markdown に TOC を追加

以下で確認できます。
https://github.com/m-tmatma/sakura/tree/feature/markdown-toc

- リンクが正しく動作しない部分を変更しています。
- コミットメッセージに `[ci skip]` を含めています。


