### PR TITLE
「ファイルの排他制御モード」のデフォルトを 「排他制御しない」に変更する

### DIFF
--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -360,7 +360,7 @@ bool CShareData::InitShareData()
 			CommonSetting_File& sFile = m_pShareData->m_Common.m_sFile;
 
 			//ファイルの排他制御
-			sFile.m_nFileShareMode = SHAREMODE_DENY_WRITE;	// ファイルの排他制御モード
+			sFile.m_nFileShareMode = SHAREMODE_NOT_EXCLUSIVE;	// ファイルの排他制御モード
 			sFile.m_bCheckFileTimeStamp = true;			// 更新の監視
 			sFile.m_nAutoloadDelay = 0;					// 自動読込時遅延
 			sFile.m_bUneditableIfUnwritable = true;		// 上書き禁止検出時は編集禁止にする


### PR DESCRIPTION
「ファイルの排他制御モード」のデフォルトを 「排他制御しない」に変更する (#260)

確認手順

- sakura.ini がない状態で起動する
- `設定` を選ぶ
- `共通設定` を選ぶ
- `ファイル` タブを選ぶ
- `排他制御` の項目が `しない` になっていることを確認する
- 任意のファイルを sakura editor で開く
- sakura editor 外で開いたファイルを更新する
- 変更を読み込むか確認するダイアログが表示されるのを確認する

![exclusive](https://user-images.githubusercontent.com/5567450/42760215-b3512e9c-8944-11e8-93fd-9f55ee0c816c.png)
