### PR TITLE
debug 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/debug/CRunningTimer.cpp
+++ b/sakura_core/debug/CRunningTimer.cpp
@@ -1,10 +1,10 @@
-/*!	@file
-	@brief ˆ—Š—vŠÔ‚ÌŒv‘ªƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief å‡¦ç†æ‰€è¦æ™‚é–“ã®è¨ˆæ¸¬ã‚¯ãƒ©ã‚¹
 
-	ƒfƒoƒbƒO–Ú“I‚Å—p‚¢‚é
+	ãƒ‡ãƒãƒƒã‚°ç›®çš„ã§ç”¨ã„ã‚‹
 
 	@author Norio Nakatani
-	@date 1998/03/06  V‹Kì¬
+	@date 1998/03/06  æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -62,7 +62,7 @@ DWORD CRunningTimer::Read()
 */
 void CRunningTimer::WriteTrace(const char* msg) const
 {
-	MYTRACE( _T("%3d:\"%hs\", %d‡_•b : %hs\n"), m_nDeapth, m_szText, timeGetTime() - m_nStartTime, msg );
+	MYTRACE( _T("%3d:\"%hs\", %dã‰ç§’ : %hs\n"), m_nDeapth, m_szText, timeGetTime() - m_nStartTime, msg );
 }
 #endif
 

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -1,10 +1,10 @@
-/*!	@file
-	@brief �������v���Ԃ̌v���N���X
+﻿/*!	@file
+	@brief 処理所要時間の計測クラス
 
-	�f�o�b�O�ړI�ŗp����
+	デバッグ目的で用いる
 
 	@author Norio Nakatani
-	@date 1998/03/06  �V�K�쐬
+	@date 1998/03/06  新規作成
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -35,20 +35,20 @@
 #define _CRUNNINGTIMER_H_
 
 #include <windows.h>
-// RunningTimer�Ōo�ߎ��Ԃ̑�����s���ꍇ�ɂ̓R�����g���O���Ă�������
+// RunningTimerで経過時間の測定を行う場合にはコメントを外してください
 //#define TIME_MEASURE
 
 /*-----------------------------------------------------------------------
-�N���X�̐錾
+クラスの宣言
 -----------------------------------------------------------------------*/
 /*!
-	@brief �������v���Ԃ̌v���N���X
+	@brief 処理所要時間の計測クラス
 
-	��`�̐؂�ւ��݂̂Ń^�C�}�[��ON/OFF���s����悤�ɂ��邽�߁C
-	���̃N���X�𒼐ڎg�킸�C���ɂ���MY_RUNNINGTIMER��MY_TRACETIME��
-	�g�����ƁD
+	定義の切り替えのみでタイマーのON/OFFを行えるようにするため，
+	このクラスを直接使わず，後ろにあるMY_RUNNINGTIMERとMY_TRACETIMEを
+	使うこと．
 
-	@date 2002/10/16  genta WriteTrace�y�у}�N���ǉ�
+	@date 2002/10/16  genta WriteTrace及びマクロ追加
 */
 class CRunningTimer
 {
@@ -60,7 +60,7 @@ public:
 	~CRunningTimer();
 
 	/*
-	|| �֐�
+	|| 関数
 	*/
 	void Reset();
 	DWORD Read();
@@ -69,8 +69,8 @@ public:
 
 protected:
 	DWORD	m_nStartTime;
-	char	m_szText[100];	//!< �^�C�}�[��
-	int		m_nDeapth;	//!< ���̃I�u�W�F�N�g�̃l�X�g�̐[��
+	char	m_szText[100];	//!< タイマー名
+	int		m_nDeapth;	//!< このオブジェクトのネストの深さ
 
 #ifdef _DEBUG
 	static int m_nNestCount;
@@ -78,7 +78,7 @@ protected:
 };
 
 //	Oct. 16, 2002 genta
-//	#ifdef _DEBUG�`#endif�Œ���͂܂Ȃ��Ă��ȒP�Ƀ^�C�}�[��ON/OFF���s�����߂̃}�N��
+//	#ifdef _DEBUG～#endifで逐一囲まなくても簡単にタイマーのON/OFFを行うためのマクロ
 #if defined(_DEBUG) && defined(TIME_MEASURE)
   #define MY_TRACETIME(c,m) (c).WriteTrace(m)
   #define MY_RUNNINGTIMER(c,m) CRunningTimer c(m)

--- a/sakura_core/debug/Debug1.cpp
+++ b/sakura_core/debug/Debug1.cpp
@@ -1,11 +1,11 @@
-/*!	@file
-	@brief ƒfƒoƒbƒO—pŠÖ”
+ï»¿/*!	@file
+	@brief ãƒ‡ãƒãƒƒã‚°ç”¨é–¢æ•°
 
 	@author Norio Nakatani
 
-	@date 2001/06/23 N.Nakatani DebugOut()‚É”÷–­`‚ÈC³
-	@date 2002/01/17 aroka Œ^‚ÌC³
-	@date 2013/03/03 Uchi MessageBox—pŠÖ”‚ğ•ª—£
+	@date 2001/06/23 N.Nakatani DebugOut()ã«å¾®å¦™ï½ãªä¿®æ­£
+	@date 2002/01/17 aroka å‹ã®ä¿®æ­£
+	@date 2013/03/03 Uchi MessageBoxç”¨é–¢æ•°ã‚’åˆ†é›¢
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -22,7 +22,7 @@
 #include "debug/Debug3.h"
 
 #if 0
-//ƒfƒoƒbƒOƒEƒHƒbƒ`—p‚ÌŒ^
+//ãƒ‡ãƒãƒƒã‚°ã‚¦ã‚©ãƒƒãƒç”¨ã®å‹
 struct TestArrayA{ char    a[100]; };
 struct TestArrayW{ wchar_t a[100]; };
 struct TestArrayI{ int     a[100]; };
@@ -37,35 +37,35 @@ void Test()
 #if defined(_DEBUG) || defined(USE_RELPRINT)
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                   ƒƒbƒZ[ƒWo—ÍFÀ‘•                      //
+//                   ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡ºåŠ›ï¼šå®Ÿè£…                      //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*! @brief ‘®•t‚«ƒfƒoƒbƒKo—Í
+/*! @brief æ›¸å¼ä»˜ããƒ‡ãƒãƒƒã‚¬å‡ºåŠ›
 
-	@param[in] lpFmt printf‚Ì‘®•t‚«•¶š—ñ
+	@param[in] lpFmt printfã®æ›¸å¼ä»˜ãæ–‡å­—åˆ—
 
-	ˆø”‚Å—^‚¦‚ç‚ê‚½î•ñ‚ğDebugString‚Æ‚µ‚Äo—Í‚·‚éD
+	å¼•æ•°ã§ä¸ãˆã‚‰ã‚ŒãŸæƒ…å ±ã‚’DebugStringã¨ã—ã¦å‡ºåŠ›ã™ã‚‹ï¼
 */
 #ifdef _UNICODE
 void DebugOutW( LPCWSTR lpFmt, ...)
 {
-	//®Œ`
+	//æ•´å½¢
 	static WCHAR szText[16000];
 	va_list argList;
 	va_start(argList, lpFmt);
 	int ret = tchar_vsnprintf_s( szText, _countof(szText), lpFmt, argList );
 
-	//o—Í
+	//å‡ºåŠ›
 	::OutputDebugStringW( szText );
 	if( -1 == ret ){
-		::OutputDebugStringW( L"(Ø‚èÌ‚Ä‚Ü‚µ‚½...)\n" );
+		::OutputDebugStringW( L"(åˆ‡ã‚Šæ¨ã¦ã¾ã—ãŸ...)\n" );
 	}
 #ifdef USE_DEBUGMON
 	DebugMonitor_Output(NULL, to_wchar(szText));
 #endif
 
-	//ƒEƒFƒCƒg
-	::Sleep(1);	// Norio Nakatani, 2001/06/23 ‘å—Ê‚ÉƒgƒŒ[ƒX‚·‚é‚Æ‚«‚Ì‚½‚ß‚É
+	//ã‚¦ã‚§ã‚¤ãƒˆ
+	::Sleep(1);	// Norio Nakatani, 2001/06/23 å¤§é‡ã«ãƒˆãƒ¬ãƒ¼ã‚¹ã™ã‚‹ã¨ãã®ãŸã‚ã«
 
 	va_end(argList);
 	return;
@@ -74,23 +74,23 @@ void DebugOutW( LPCWSTR lpFmt, ...)
 
 void DebugOutA( LPCSTR lpFmt, ...)
 {
-	//®Œ`
+	//æ•´å½¢
 	static CHAR szText[16000];
 	va_list argList;
 	va_start(argList, lpFmt);
 	int ret = tchar_vsnprintf_s( szText, _countof(szText), lpFmt, argList );
 
-	//o—Í
+	//å‡ºåŠ›
 	::OutputDebugStringA( szText );
 	if( -1 == ret ){
-		::OutputDebugStringA( "(Ø‚èÌ‚Ä‚Ü‚µ‚½...)\n" );
+		::OutputDebugStringA( "(åˆ‡ã‚Šæ¨ã¦ã¾ã—ãŸ...)\n" );
 	}
 #ifdef USE_DEBUGMON
 	DebugMonitor_Output(NULL, to_wchar(szText));
 #endif
 
-	//ƒEƒFƒCƒg
-	::Sleep(1);	// Norio Nakatani, 2001/06/23 ‘å—Ê‚ÉƒgƒŒ[ƒX‚·‚é‚Æ‚«‚Ì‚½‚ß‚É
+	//ã‚¦ã‚§ã‚¤ãƒˆ
+	::Sleep(1);	// Norio Nakatani, 2001/06/23 å¤§é‡ã«ãƒˆãƒ¬ãƒ¼ã‚¹ã™ã‚‹ã¨ãã®ãŸã‚ã«
 
 	va_end(argList);
 	return;

--- a/sakura_core/debug/Debug1.h
+++ b/sakura_core/debug/Debug1.h
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief �f�o�b�O�p�֐�
+﻿/*!	@file
+	@brief デバッグ用関数
 
 	@author Norio Nakatani
 
-	@date 2013/03/03 Uchi MessageBox�p�֐��𕪗�
+	@date 2013/03/03 Uchi MessageBox用関数を分離
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -16,7 +16,7 @@
 #define SAKURA_DEBUG1_587B8A50_4B0A_4E5E_A638_40FB1EC301CA_H_
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                   ���b�Z�[�W�o�́F����                      //
+//                   メッセージ出力：実装                      //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 #if defined(_DEBUG) || defined(USE_RELPRINT)
 void DebugOutW( LPCWSTR lpFmt, ...);
@@ -24,11 +24,11 @@ void DebugOutA( LPCSTR lpFmt, ...);
 #endif	// _DEBUG || USE_RELPRINT
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                 �f�o�b�O�p���b�Z�[�W�o��                    //
+//                 デバッグ用メッセージ出力                    //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 /*
-	MYTRACE�̓����[�X���[�h�ł̓R���p�C���G���[�ƂȂ�悤�ɂ��Ă���̂ŁC
-	MYTRACE���g���ꍇ�ɂ͕K��#ifdef _DEBUG �` #endif �ň͂ޕK�v������D
+	MYTRACEはリリースモードではコンパイルエラーとなるようにしてあるので，
+	MYTRACEを使う場合には必ず#ifdef _DEBUG ～ #endif で囲む必要がある．
 */
 #ifdef _DEBUG
 	#ifdef _UNICODE
@@ -40,7 +40,7 @@ void DebugOutA( LPCSTR lpFmt, ...);
 	#define MYTRACE   Do_not_use_the_MYTRACE_function_if_release_mode
 #endif
 
-//#ifdef _DEBUG�`#endif�ň͂܂Ȃ��Ă��ǂ���
+//#ifdef _DEBUG～#endifで囲まなくても良い版
 #ifdef _DEBUG
 	#ifdef _UNICODE
 	#define DEBUG_TRACE DebugOutW
@@ -54,7 +54,7 @@ void DebugOutA( LPCSTR lpFmt, ...);
 	inline void DEBUG_TRACE( ... ){}
 #endif
 
-//RELEASE�łł��o�͂���� (RELEASE�ł̂ݔ�������o�O���Ď�����ړI)
+//RELEASE版でも出力する版 (RELEASEでのみ発生するバグを監視する目的)
 #ifdef USE_RELPRINT
 	#ifdef _UNICODE
 	#define RELPRINT DebugOutW

--- a/sakura_core/debug/Debug2.cpp
+++ b/sakura_core/debug/Debug2.cpp
@@ -1,27 +1,27 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "debug/Debug2.h"
 
-//2007.08.30 kobake ’Ç‰Á
+//2007.08.30 kobake è¿½åŠ 
 
 #ifdef _DEBUG
-//!ƒfƒoƒbƒOƒƒbƒZ[ƒWo—Í
+//!ãƒ‡ãƒãƒƒã‚°ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡ºåŠ›
 void debug_output(const char* str, ...)
 {
 	static char buf[_MAX_PATH+150];
 	va_list mark;
 	va_start(mark,str);
-	// FILE–¼, LINE ® •ª•K—v
+	// FILEå, LINE å¼ åˆ†å¿…è¦
 	tchar_vsnprintf_s(buf,_countof(buf),str,mark);
 	va_end(mark);
 
-	//ƒfƒoƒbƒK‚Éo—Í
+	//ãƒ‡ãƒãƒƒã‚¬ã«å‡ºåŠ›
 	OutputDebugStringA(buf);
 }
 
-//!‹­§I—¹
+//!å¼·åˆ¶çµ‚äº†
 void debug_exit()
 {
-	MessageBox(NULL,_T("assert‚Æ‚©‚Éˆø‚ÁŠ|‚©‚Á‚½‚Û‚¢‚Å‚·"),GSTR_APPNAME,MB_OK);
+	MessageBox(NULL,_T("assertã¨ã‹ã«å¼•ã£æ›ã‹ã£ãŸã½ã„ã§ã™"),GSTR_APPNAME,MB_OK);
 	exit(1);
 }
 
@@ -38,6 +38,6 @@ void debug_exit2(const char* file, int line, const char* exp)
 void warning_point()
 {
 	int n;
-	n=0; //¦©‚±‚±‚ÉƒuƒŒ[ƒNƒ|ƒCƒ“ƒg‚ğİ‚¯‚Ä‚¨‚­‚ÆA”CˆÓƒ[ƒjƒ“ƒO‚ÅƒuƒŒ[ƒN‚Å‚«‚é
+	n=0; //â€»â†ã“ã“ã«ãƒ–ãƒ¬ãƒ¼ã‚¯ãƒã‚¤ãƒ³ãƒˆã‚’è¨­ã‘ã¦ãŠãã¨ã€ä»»æ„ãƒ¯ãƒ¼ãƒ‹ãƒ³ã‚°ã§ãƒ–ãƒ¬ãƒ¼ã‚¯ã§ãã‚‹
 }
 #endif	// _DEBUG

--- a/sakura_core/debug/Debug2.h
+++ b/sakura_core/debug/Debug2.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief assertŠÖ”
+ï»¿/*!	@file
+	@brief asserté–¢æ•°
 
 */
 /*
@@ -28,7 +28,7 @@
 #ifndef SAKURA_DEBUG2_69DB6343_0580_4F92_98D6_63216724B2D19_H_
 #define SAKURA_DEBUG2_69DB6343_0580_4F92_98D6_63216724B2D19_H_
 
-//2007.08.30 kobake ’Ç‰Á
+//2007.08.30 kobake è¿½åŠ 
 #ifdef assert
 #undef assert
 #endif

--- a/sakura_core/debug/Debug3.cpp
+++ b/sakura_core/debug/Debug3.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "debug/Debug3.h"
 #include "util/module.h"
 

--- a/sakura_core/debug/Debug3.h
+++ b/sakura_core/debug/Debug3.h
@@ -1,4 +1,4 @@
-/*!	@file
+﻿/*!	@file
 	@brief DebugMonitorLib用関数
 
 */


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/debug
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。