### PR TITLE
doc 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/doc/CBlockComment.cpp
+++ b/sakura_core/doc/CBlockComment.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğŠÇ—‚·‚é
+ï»¿/*!	@file
+	@brief ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ç®¡ç†ã™ã‚‹
 
 	@author Yazaki
-	@date 2002/09/17 V‹Kì¬
+	@date 2002/09/17 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -25,11 +25,11 @@ CBlockComment::CBlockComment()
 }
 
 /*!
-	ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğƒRƒs[‚·‚é
+	ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹
 */
 void CBlockComment::SetBlockCommentRule(
-	const wchar_t*	pszFrom,	//!< [in] ƒRƒƒ“ƒgŠJn•¶š—ñ
-	const wchar_t*	pszTo		//!< [in] ƒRƒƒ“ƒgI—¹•¶š—ñ
+	const wchar_t*	pszFrom,	//!< [in] ã‚³ãƒ¡ãƒ³ãƒˆé–‹å§‹æ–‡å­—åˆ—
+	const wchar_t*	pszTo		//!< [in] ã‚³ãƒ¡ãƒ³ãƒˆçµ‚äº†æ–‡å­—åˆ—
 )
 {
 	int nStrLen = wcslen( pszFrom );
@@ -53,26 +53,26 @@ void CBlockComment::SetBlockCommentRule(
 }
 
 /*!
-	n”Ô–Ú‚ÌƒuƒƒbƒNƒRƒƒ“ƒg‚ÌAnPos‚©‚ç‚Ì•¶š—ñ‚ªŠJn•¶š—ñ(From)‚É“–‚Ä‚Í‚Ü‚é‚©Šm”F‚·‚éB
+	nç•ªç›®ã®ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆã®ã€nPosã‹ã‚‰ã®æ–‡å­—åˆ—ãŒé–‹å§‹æ–‡å­—åˆ—(From)ã«å½“ã¦ã¯ã¾ã‚‹ã‹ç¢ºèªã™ã‚‹ã€‚
 
-	@retval true  ˆê’v‚µ‚½
-	@retval false ˆê’v‚µ‚È‚©‚Á‚½
+	@retval true  ä¸€è‡´ã—ãŸ
+	@retval false ä¸€è‡´ã—ãªã‹ã£ãŸ
 */
 bool CBlockComment::Match_CommentFrom(
-	int					nPos,		//!< [in] ’TõŠJnˆÊ’u
-	const CStringRef&	cStr		//!< [in] ’Tõ‘ÎÛ•¶š—ñ ¦’TõŠJnˆÊ’u‚Ìƒ|ƒCƒ“ƒ^‚Å‚Í‚È‚¢‚±‚Æ‚É’ˆÓ
+	int					nPos,		//!< [in] æ¢ç´¢é–‹å§‹ä½ç½®
+	const CStringRef&	cStr		//!< [in] æ¢ç´¢å¯¾è±¡æ–‡å­—åˆ— â€»æ¢ç´¢é–‹å§‹ä½ç½®ã®ãƒã‚¤ãƒ³ã‚¿ã§ã¯ãªã„ã“ã¨ã«æ³¨æ„
 	/*
-	int				nLineLen,	//!< [in] pLine‚Ì’·‚³
-	const wchar_t*	pLine		//!< [in] ’Tõs‚Ìæ“ªD
+	int				nLineLen,	//!< [in] pLineã®é•·ã•
+	const wchar_t*	pLine		//!< [in] æ¢ç´¢è¡Œã®å…ˆé ­ï¼
 	*/
 ) const
 {
 	if (
 		L'\0' != m_szBlockCommentFrom[0] &&
 		L'\0' != m_szBlockCommentTo[0]  &&
-		nPos <= cStr.GetLength() - m_nBlockFromLen &&	/* ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^(From) */
-		//0 == auto_memicmp( &cStr.GetPtr()[nPos], m_szBlockCommentFrom, m_nBlockFromLen )	//”ñASCII‚à‘å•¶š¬•¶š‚ğ‹æ•Ê‚µ‚È‚¢	//###locale ˆË‘¶
-		0 == wmemicmp_ascii( &cStr.GetPtr()[nPos], m_szBlockCommentFrom, m_nBlockFromLen )	//ASCII‚Ì‚İ‘å•¶š¬•¶š‚ğ‹æ•Ê‚µ‚È‚¢i‚‘¬j
+		nPos <= cStr.GetLength() - m_nBlockFromLen &&	/* ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿(From) */
+		//0 == auto_memicmp( &cStr.GetPtr()[nPos], m_szBlockCommentFrom, m_nBlockFromLen )	//éASCIIã‚‚å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã—ãªã„	//###locale ä¾å­˜
+		0 == wmemicmp_ascii( &cStr.GetPtr()[nPos], m_szBlockCommentFrom, m_nBlockFromLen )	//ASCIIã®ã¿å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã—ãªã„ï¼ˆé«˜é€Ÿï¼‰
 	){
 		return true;
 	}
@@ -80,22 +80,22 @@ bool CBlockComment::Match_CommentFrom(
 }
 
 /*!
-	n”Ô–Ú‚ÌƒuƒƒbƒNƒRƒƒ“ƒg‚ÌAŒãÒ(To)‚É“–‚Ä‚Í‚Ü‚é•¶š—ñ‚ğnPosˆÈ~‚©‚ç’T‚·
+	nç•ªç›®ã®ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆã®ã€å¾Œè€…(To)ã«å½“ã¦ã¯ã¾ã‚‹æ–‡å­—åˆ—ã‚’nPosä»¥é™ã‹ã‚‰æ¢ã™
 
-	@return “–‚Ä‚Í‚Ü‚Á‚½ˆÊ’u‚ğ•Ô‚·‚ªA“–‚Ä‚Í‚Ü‚ç‚È‚©‚Á‚½‚Æ‚«‚ÍAnLineLen‚ğ‚»‚Ì‚Ü‚Ü•Ô‚·B
+	@return å½“ã¦ã¯ã¾ã£ãŸä½ç½®ã‚’è¿”ã™ãŒã€å½“ã¦ã¯ã¾ã‚‰ãªã‹ã£ãŸã¨ãã¯ã€nLineLenã‚’ãã®ã¾ã¾è¿”ã™ã€‚
 */
 int CBlockComment::Match_CommentTo(
-	int					nPos,		//!< [in] ’TõŠJnˆÊ’u
-	const CStringRef&	cStr		//!< [in] ’Tõ‘ÎÛ•¶š—ñ ¦’TõŠJnˆÊ’u‚Ìƒ|ƒCƒ“ƒ^‚Å‚Í‚È‚¢‚±‚Æ‚É’ˆÓ
+	int					nPos,		//!< [in] æ¢ç´¢é–‹å§‹ä½ç½®
+	const CStringRef&	cStr		//!< [in] æ¢ç´¢å¯¾è±¡æ–‡å­—åˆ— â€»æ¢ç´¢é–‹å§‹ä½ç½®ã®ãƒã‚¤ãƒ³ã‚¿ã§ã¯ãªã„ã“ã¨ã«æ³¨æ„
 	/*
-	int				nLineLen,	//!< [in] pLine‚Ì’·‚³
-	const wchar_t*	pLine		//!< [in] ’Tõs‚Ìæ“ªD’TõŠJnˆÊ’u‚Ìƒ|ƒCƒ“ƒ^‚Å‚Í‚È‚¢‚±‚Æ‚É’ˆÓ
+	int				nLineLen,	//!< [in] pLineã®é•·ã•
+	const wchar_t*	pLine		//!< [in] æ¢ç´¢è¡Œã®å…ˆé ­ï¼æ¢ç´¢é–‹å§‹ä½ç½®ã®ãƒã‚¤ãƒ³ã‚¿ã§ã¯ãªã„ã“ã¨ã«æ³¨æ„
 	*/
 ) const
 {
 	for( int i = nPos; i <= cStr.GetLength() - m_nBlockToLen; ++i ){
-		//if( 0 == auto_memicmp( &cStr.GetPtr()[i], m_szBlockCommentTo, m_nBlockToLen ) ){	//”ñASCII‚à‘å•¶š¬•¶š‚ğ‹æ•Ê‚µ‚È‚¢	//###locale ˆË‘¶
-		if( 0 == wmemicmp_ascii( &cStr.GetPtr()[i], m_szBlockCommentTo, m_nBlockToLen ) ){	//ASCII‚Ì‚İ‘å•¶š¬•¶š‚ğ‹æ•Ê‚µ‚È‚¢i‚‘¬j
+		//if( 0 == auto_memicmp( &cStr.GetPtr()[i], m_szBlockCommentTo, m_nBlockToLen ) ){	//éASCIIã‚‚å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã—ãªã„	//###locale ä¾å­˜
+		if( 0 == wmemicmp_ascii( &cStr.GetPtr()[i], m_szBlockCommentTo, m_nBlockToLen ) ){	//ASCIIã®ã¿å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã—ãªã„ï¼ˆé«˜é€Ÿï¼‰
 			return i + m_nBlockToLen;
 		}
 	}

--- a/sakura_core/doc/CBlockComment.h
+++ b/sakura_core/doc/CBlockComment.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğŠÇ—‚·‚é
+ï»¿/*!	@file
+	@brief ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ç®¡ç†ã™ã‚‹
 
 	@author Yazaki
-	@date 2002/09/17 V‹Kì¬
+	@date 2002/09/17 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2002, Yazaki
@@ -24,37 +24,37 @@ enum ECommentType{
 };
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
-/*! ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğŠÇ—‚·‚é
+/*! ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ç®¡ç†ã™ã‚‹
 
-	@note CBlockCommentGroup‚ÍA‹¤—Lƒƒ‚ƒŠSTypeConfig‚ÉŠÜ‚Ü‚ê‚é‚Ì‚ÅAƒƒ“ƒo•Ï”‚Íí‚ÉÀ‘Ì‚ğ‚Á‚Ä‚¢‚È‚¯‚ê‚Î‚È‚ç‚È‚¢B
+	@note CBlockCommentGroupã¯ã€å…±æœ‰ãƒ¡ãƒ¢ãƒªSTypeConfigã«å«ã¾ã‚Œã‚‹ã®ã§ã€ãƒ¡ãƒ³ãƒå¤‰æ•°ã¯å¸¸ã«å®Ÿä½“ã‚’æŒã£ã¦ã„ãªã‘ã‚Œã°ãªã‚‰ãªã„ã€‚
 */
 #define BLOCKCOMMENT_NUM	2
 #define BLOCKCOMMENT_BUFFERSIZE	16
 
-//	2005.11.10 Moca ƒAƒNƒZƒXŠÖ”’Ç‰Á
+//	2005.11.10 Moca ã‚¢ã‚¯ã‚»ã‚¹é–¢æ•°è¿½åŠ 
 class CBlockComment{
 public:
-	//¶¬‚Æ”jŠü
+	//ç”Ÿæˆã¨ç ´æ£„
 	CBlockComment();
 
-	//İ’è
-	void SetBlockCommentRule( const wchar_t* pszFrom, const wchar_t* pszTo );	//	sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğƒRƒs[‚·‚é
+	//è¨­å®š
+	void SetBlockCommentRule( const wchar_t* pszFrom, const wchar_t* pszTo );	//	è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹
 
-	//”»’è
-	bool Match_CommentFrom( int nPos, const CStringRef& cStr ) const;	//	sƒRƒƒ“ƒg‚É’l‚·‚é‚©Šm”F‚·‚é
-	int Match_CommentTo( int nPos, const CStringRef& cStr ) const;	//	sƒRƒƒ“ƒg‚É’l‚·‚é‚©Šm”F‚·‚é
+	//åˆ¤å®š
+	bool Match_CommentFrom( int nPos, const CStringRef& cStr ) const;	//	è¡Œã‚³ãƒ¡ãƒ³ãƒˆã«å€¤ã™ã‚‹ã‹ç¢ºèªã™ã‚‹
+	int Match_CommentTo( int nPos, const CStringRef& cStr ) const;	//	è¡Œã‚³ãƒ¡ãƒ³ãƒˆã«å€¤ã™ã‚‹ã‹ç¢ºèªã™ã‚‹
 
-	//æ“¾
+	//å–å¾—
 	const wchar_t* getBlockCommentFrom() const{ return m_szBlockCommentFrom; }
 	const wchar_t* getBlockCommentTo() const{ return m_szBlockCommentTo; }
 	int getBlockFromLen() const { return m_nBlockFromLen; }
 	int getBlockToLen() const { return m_nBlockToLen; }
 
 private:
-	wchar_t	m_szBlockCommentFrom[BLOCKCOMMENT_BUFFERSIZE]; //!< ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^(From)
-	wchar_t	m_szBlockCommentTo[BLOCKCOMMENT_BUFFERSIZE];   //!< ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^(To)
+	wchar_t	m_szBlockCommentFrom[BLOCKCOMMENT_BUFFERSIZE]; //!< ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿(From)
+	wchar_t	m_szBlockCommentTo[BLOCKCOMMENT_BUFFERSIZE];   //!< ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿(To)
 	int		m_nBlockFromLen;
 	int		m_nBlockToLen;
 };

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -38,24 +38,24 @@ CDocEditor::CDocEditor(CEditDoc* pcDoc)
 , m_cNewLineCode( EOL_CRLF )		//	New Line Type
 , m_pcOpeBlk( NULL )
 , m_bInsMode( true )	// Oct. 2, 2005 genta
-, m_bIsDocModified( false )	/* •ÏXƒtƒ‰ƒO */ // Jan. 22, 2002 genta Œ^•ÏX
+, m_bIsDocModified( false )	/* å¤‰æ›´ãƒ•ãƒ©ã‚° */ // Jan. 22, 2002 genta åž‹å¤‰æ›´
 {
-	//	Oct. 2, 2005 genta ‘}“üƒ‚[ƒh
+	//	Oct. 2, 2005 genta æŒ¿å…¥ãƒ¢ãƒ¼ãƒ‰
 	this->SetInsMode( GetDllShareData().m_Common.m_sGeneral.m_bIsINSMode );
 }
 
 
-/*! •ÏXƒtƒ‰ƒO‚ÌÝ’è
+/*! å¤‰æ›´ãƒ•ãƒ©ã‚°ã®è¨­å®š
 
-	@param flag [in] Ý’è‚·‚é’lDtrue: •ÏX—L‚è / false: •ÏX–³‚µ
-	@param redraw [in] true: ƒ^ƒCƒgƒ‹‚ÌÄ•`‰æ‚ðs‚¤ / false: s‚í‚È‚¢
+	@param flag [in] è¨­å®šã™ã‚‹å€¤ï¼Žtrue: å¤‰æ›´æœ‰ã‚Š / false: å¤‰æ›´ç„¡ã—
+	@param redraw [in] true: ã‚¿ã‚¤ãƒˆãƒ«ã®å†æç”»ã‚’è¡Œã† / false: è¡Œã‚ãªã„
 	
 	@author genta
-	@date 2002.01.22 V‹Kì¬
+	@date 2002.01.22 æ–°è¦ä½œæˆ
 */
 void CDocEditor::SetModified( bool flag, bool redraw)
 {
-	if( m_bIsDocModified == flag )	//	•ÏX‚ª‚È‚¯‚ê‚Î‰½‚à‚µ‚È‚¢
+	if( m_bIsDocModified == flag )	//	å¤‰æ›´ãŒãªã‘ã‚Œã°ä½•ã‚‚ã—ãªã„
 		return;
 
 	m_bIsDocModified = flag;
@@ -65,7 +65,7 @@ void CDocEditor::SetModified( bool flag, bool redraw)
 
 void CDocEditor::OnBeforeLoad(SLoadInfo* sLoadInfo)
 {
-	//ƒrƒ…[‚ÌƒeƒLƒXƒg‘I‘ð‰ðœ
+	//ãƒ“ãƒ¥ãƒ¼ã®ãƒ†ã‚­ã‚¹ãƒˆé¸æŠžè§£é™¤
 	GetListeningDoc()->m_pcEditWnd->Views_DisableSelectArea(true);
 }
 
@@ -74,11 +74,11 @@ void CDocEditor::OnAfterLoad(const SLoadInfo& sLoadInfo)
 	CEditDoc* pcDoc = GetListeningDoc();
 
 	//	May 12, 2000 genta
-	//	•ÒW—p‰üsƒR[ƒh‚ÌÝ’è
+	//	ç·¨é›†ç”¨æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®è¨­å®š
 	{
 		const STypeConfig& type = pcDoc->m_cDocType.GetDocumentAttribute();
 		if ( pcDoc->m_cDocFile.GetCodeSet() == type.m_encoding.m_eDefaultCodetype ){
-			SetNewLineCode( type.m_encoding.m_eDefaultEoltype );	// 2011.01.24 ryoji ƒfƒtƒHƒ‹ƒgEOL
+			SetNewLineCode( type.m_encoding.m_eDefaultEoltype );	// 2011.01.24 ryoji ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆEOL
 		}
 		else{
 			SetNewLineCode( EOL_CRLF );
@@ -93,34 +93,34 @@ void CDocEditor::OnAfterLoad(const SLoadInfo& sLoadInfo)
 	}
 
 	//	Nov. 20, 2000 genta
-	//	IMEó‘Ô‚ÌÝ’è
+	//	IMEçŠ¶æ…‹ã®è¨­å®š
 	this->SetImeMode( pcDoc->m_cDocType.GetDocumentAttribute().m_nImeState );
 
-	// ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚Ì•ÏX
+	// ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®å¤‰æ›´
 	::SetCurrentDirectory( pcDoc->m_cDocFile.GetFilePathClass().GetDirPath().c_str() );
 
-	CAppMode::getInstance()->SetViewMode(sLoadInfo.bViewMode);		// ƒrƒ…[ƒ‚[ƒh	##‚±‚±‚àAƒAƒŠ‚©‚È
+	CAppMode::getInstance()->SetViewMode(sLoadInfo.bViewMode);		// ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰	##ã“ã“ã‚‚ã€ã‚¢ãƒªã‹ãª
 }
 
 void CDocEditor::OnAfterSave(const SSaveInfo& sSaveInfo)
 {
 	CEditDoc* pcDoc = GetListeningDoc();
 
-	this->SetModified(false,false);	//	Jan. 22, 2002 genta ŠÖ”‰» XVƒtƒ‰ƒO‚ÌƒNƒŠƒA
+	this->SetModified(false,false);	//	Jan. 22, 2002 genta é–¢æ•°åŒ– æ›´æ–°ãƒ•ãƒ©ã‚°ã®ã‚¯ãƒªã‚¢
 
-	/* Œ»ÝˆÊ’u‚Å–³•ÏX‚Èó‘Ô‚É‚È‚Á‚½‚±‚Æ‚ð’Ê’m */
+	/* ç¾åœ¨ä½ç½®ã§ç„¡å¤‰æ›´ãªçŠ¶æ…‹ã«ãªã£ãŸã“ã¨ã‚’é€šçŸ¥ */
 	this->m_cOpeBuf.SetNoModified();
 
-	// ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚Ì•ÏX
+	// ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®å¤‰æ›´
 	::SetCurrentDirectory( pcDoc->m_cDocFile.GetFilePathClass().GetDirPath().c_str() );
 }
 
 
 
 //	From Here Nov. 20, 2000 genta
-/*!	IMEó‘Ô‚ÌÝ’è
+/*!	IMEçŠ¶æ…‹ã®è¨­å®š
 	
-	@param mode [in] IME‚Ìƒ‚[ƒh
+	@param mode [in] IMEã®ãƒ¢ãƒ¼ãƒ‰
 	
 	@date Nov 20, 2000 genta
 */
@@ -130,9 +130,9 @@ void CDocEditor::SetImeMode( int mode )
 	HIMC	hIme;
 	HWND	hwnd = m_pcDocRef->m_pcEditWnd->GetActiveView().GetHwnd();
 
-	hIme = ImmGetContext( hwnd ); //######‘åä•vH // 2013.06.04 EditWnd‚©‚çView‚É•ÏX
+	hIme = ImmGetContext( hwnd ); //######å¤§ä¸ˆå¤«ï¼Ÿ // 2013.06.04 EditWndã‹ã‚‰Viewã«å¤‰æ›´
 
-	//	Å‰ºˆÊƒrƒbƒg‚ÍIMEŽ©g‚ÌOn/Off§Œä
+	//	æœ€ä¸‹ä½ãƒ“ãƒƒãƒˆã¯IMEè‡ªèº«ã®On/Offåˆ¶å¾¡
 	if( ( mode & 3 ) == 2 ){
 		ImmSetOpenStatus( hIme, FALSE );
 	}
@@ -161,7 +161,7 @@ void CDocEditor::SetImeMode( int mode )
 	if( ( mode & 3 ) == 1 ){
 		ImmSetOpenStatus( hIme, TRUE );
 	}
-	ImmReleaseContext( hwnd, hIme ); //######‘åä•vH
+	ImmReleaseContext( hwnd, hIme ); //######å¤§ä¸ˆå¤«ï¼Ÿ
 }
 //	To Here Nov. 20, 2000 genta
 
@@ -175,21 +175,21 @@ void CDocEditor::SetImeMode( int mode )
 
 
 /*!
-	––”ö‚És‚ð’Ç‰Á
+	æœ«å°¾ã«è¡Œã‚’è¿½åŠ 
 
 	@version 1.5
 
-	@param pData    [in] ’Ç‰Á‚·‚é•¶Žš—ñ‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	@param nDataLen [in] •¶Žš—ñ‚Ì’·‚³B•¶Žš’PˆÊB
-	@param cEol     [in] s––ƒR[ƒh
+	@param pData    [in] è¿½åŠ ã™ã‚‹æ–‡å­—åˆ—ã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	@param nDataLen [in] æ–‡å­—åˆ—ã®é•·ã•ã€‚æ–‡å­—å˜ä½ã€‚
+	@param cEol     [in] è¡Œæœ«ã‚³ãƒ¼ãƒ‰
 
 */
 void CDocEditAgent::AddLineStrX( const wchar_t* pData, int nDataLen )
 {
-	//ƒ`ƒF[ƒ““K—p
+	//ãƒã‚§ãƒ¼ãƒ³é©ç”¨
 	CDocLine* pDocLine = m_pcDocLineMgr->AddNewLine();
 
-	//ƒCƒ“ƒXƒ^ƒ“ƒXÝ’è
+	//ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹è¨­å®š
 	pDocLine->SetDocLineString(pData, nDataLen);
 }
 

--- a/sakura_core/doc/CDocEditor.h
+++ b/sakura_core/doc/CDocEditor.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -36,52 +36,52 @@ public:
 	CDocEditor(CEditDoc* pcDoc);
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ƒCƒxƒ“ƒg                            //
+	//                         ã‚¤ãƒ™ãƒ³ãƒˆ                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//ƒ[ƒh‘OŒã
+	//ãƒ­ãƒ¼ãƒ‰å‰å¾Œ
 	void OnBeforeLoad(SLoadInfo* sLoadInfo);
 	void OnAfterLoad(const SLoadInfo& sLoadInfo);
 
-	//ƒZ[ƒu‘OŒã
+	//ã‚»ãƒ¼ãƒ–å‰å¾Œ
 	void OnAfterSave(const SSaveInfo& sSaveInfo);
 
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ó‘Ô                              //
+	//                           çŠ¶æ…‹                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//	Jan. 22, 2002 genta Modified Flag‚Ìİ’è
+	//	Jan. 22, 2002 genta Modified Flagã®è¨­å®š
 	void SetModified( bool flag, bool redraw);
-	//! ƒtƒ@ƒCƒ‹‚ªC³’†‚©‚Ç‚¤‚©
+	//! ãƒ•ã‚¡ã‚¤ãƒ«ãŒä¿®æ­£ä¸­ã‹ã©ã†ã‹
 	bool IsModified() const { return m_bIsDocModified; }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           İ’è                              //
+	//                           è¨­å®š                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//	Nov. 20, 2000 genta
-	void SetImeMode(int mode);	//	IMEó‘Ô‚Ìİ’è
+	void SetImeMode(int mode);	//	IMEçŠ¶æ…‹ã®è¨­å®š
 
 	//	May 15, 2000 genta
 	CEol  GetNewLineCode() const { return m_cNewLineCode; }
 	void  SetNewLineCode(const CEol& t){ m_cNewLineCode = t; }
 
-	//	Oct. 2, 2005 genta ‘}“üƒ‚[ƒh‚Ìİ’è
+	//	Oct. 2, 2005 genta æŒ¿å…¥ãƒ¢ãƒ¼ãƒ‰ã®è¨­å®š
 	bool IsInsMode() const { return m_bInsMode; }
 	void SetInsMode(bool mode) { m_bInsMode = mode; }
 
-	//! Undo(Œ³‚É–ß‚·)‰Â”\‚Èó‘Ô‚©H */
+	//! Undo(å…ƒã«æˆ»ã™)å¯èƒ½ãªçŠ¶æ…‹ã‹ï¼Ÿ */
 	bool IsEnableUndo( void ) const
 	{
 		return m_cOpeBuf.IsEnableUndo();
 	}
 
-	//! Redo(‚â‚è’¼‚µ)‰Â”\‚Èó‘Ô‚©H
+	//! Redo(ã‚„ã‚Šç›´ã—)å¯èƒ½ãªçŠ¶æ…‹ã‹ï¼Ÿ
 	bool IsEnableRedo( void ) const
 	{
 		return m_cOpeBuf.IsEnableRedo();
 	}
 
-	//! ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯‰Â”\‚©H
+	//! ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘å¯èƒ½ã‹ï¼Ÿ
 	bool IsEnablePaste( void ) const
 	{
 		return CClipboard::HasValidData();
@@ -89,11 +89,11 @@ public:
 
 public:
 	CEditDoc*		m_pcDocRef;
-	CEol 			m_cNewLineCode;				//!< Enter‰Ÿ‰º‚É‘}“ü‚·‚é‰üsƒR[ƒhí•Ê
-	COpeBuf			m_cOpeBuf;					//!< ƒAƒ“ƒhƒDƒoƒbƒtƒ@
-	COpeBlk*		m_pcOpeBlk;					//!< ‘€ìƒuƒƒbƒN
-	int				m_nOpeBlkRedawCount;		//!< OpeBlk‚ÌÄ•`‰æ”ñ‘ÎÛ”
-	bool			m_bInsMode;					//!< ‘}“üEã‘‚«ƒ‚[ƒh Oct. 2, 2005 genta
+	CEol 			m_cNewLineCode;				//!< EnteræŠ¼ä¸‹æ™‚ã«æŒ¿å…¥ã™ã‚‹æ”¹è¡Œã‚³ãƒ¼ãƒ‰ç¨®åˆ¥
+	COpeBuf			m_cOpeBuf;					//!< ã‚¢ãƒ³ãƒ‰ã‚¥ãƒãƒƒãƒ•ã‚¡
+	COpeBlk*		m_pcOpeBlk;					//!< æ“ä½œãƒ–ãƒ­ãƒƒã‚¯
+	int				m_nOpeBlkRedawCount;		//!< OpeBlkã®å†æç”»éå¯¾è±¡æ•°
+	bool			m_bInsMode;					//!< æŒ¿å…¥ãƒ»ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰ Oct. 2, 2005 genta
 	bool			m_bIsDocModified;
 };
 
@@ -103,10 +103,10 @@ public:
 	CDocEditAgent(CDocLineMgr* pcDocLineMgr) : m_pcDocLineMgr(pcDocLineMgr) { }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ‘€ì                              //
+	//                           æ“ä½œ                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//	May 15, 2000 genta
-	void AddLineStrX( const wchar_t*, int );	/* ––”ö‚És‚ğ’Ç‰Á Ver1.5 */
+	void AddLineStrX( const wchar_t*, int );	/* æœ«å°¾ã«è¡Œã‚’è¿½åŠ  Ver1.5 */
 
 private:
 	CDocLineMgr* m_pcDocLineMgr;

--- a/sakura_core/doc/CDocFile.cpp
+++ b/sakura_core/doc/CDocFile.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2013, Uchi
 
@@ -26,9 +26,9 @@
 #include "CDocFile.h"
 
 /*
-	�ۑ����̃t�@�C���̃p�X�i�}�N���p�j�̎擾
+	保存時のファイルのパス（マクロ用）の取得
 
-	2017/5/17 CFile.h����ړ�
+	2017/5/17 CFile.hから移動
 */
 const TCHAR* CDocFile::GetSaveFilePath(void) const
 {

--- a/sakura_core/doc/CDocFile.h
+++ b/sakura_core/doc/CDocFile.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2013, Uchi
 
@@ -29,7 +29,7 @@
 #include "util/file.h"
 class CEditDoc;
 
-//####–{—ˆ‚Í‚±‚±‚É‚ ‚é‚×‚«‚Å‚Í–³‚¢
+//####æœ¬æ¥ã¯ã“ã“ã«ã‚ã‚‹ã¹ãã§ã¯ç„¡ã„
 struct SFileInfo{
 	friend class CDocFile;
 protected:
@@ -46,8 +46,8 @@ public:
 		bBomExist = bBomExistLoad = false;
 		cFileTime.ClearFILETIME();
 	}
-	void	SetCodeSet(ECodeType eSet, bool bBom)	{ eCharCode = eCharCodeLoad = eSet; bBomExist = bBomExistLoad = bBom; }	//!< •¶šƒR[ƒhƒZƒbƒg‚ğİ’è
-	void	SetBomExist(bool bBom)					{ bBomExist = bBomExistLoad = bBom; }	//!< BOM•t‰Á‚ğİ’è
+	void	SetCodeSet(ECodeType eSet, bool bBom)	{ eCharCode = eCharCodeLoad = eSet; bBomExist = bBomExistLoad = bBom; }	//!< æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã‚’è¨­å®š
+	void	SetBomExist(bool bBom)					{ bBomExist = bBomExistLoad = bBom; }	//!< BOMä»˜åŠ ã‚’è¨­å®š
 	void	SetFileTime( FILETIME& Time )			{ cFileTime.SetFILETIME( Time ); }
 };
 
@@ -56,27 +56,27 @@ class CDocFile : public CFile{
 public:
 	CDocFile(CEditDoc* pcDoc) : m_pcDocRef(pcDoc) {}
 
-	void			SetCodeSet(ECodeType eCodeSet , bool bBomExist)	{ m_sFileInfo.SetCodeSet(eCodeSet, bBomExist); }	//!< •¶šƒR[ƒhƒZƒbƒg‚ğİ’è
-	void			SetCodeSetChg(ECodeType eCodeSet , bool bBomExist)	{ m_sFileInfo.eCharCode = eCodeSet; m_sFileInfo.bBomExist = bBomExist; }	//!< •¶šƒR[ƒhƒZƒbƒg‚ğİ’è(•¶šƒR[ƒhw’è—p)
-	ECodeType		GetCodeSet() const			{ return m_sFileInfo.eCharCode; }		//!< •¶šƒR[ƒhƒZƒbƒg‚ğæ“¾
-	void			SetBomDefoult()				{ m_sFileInfo.bBomExist= CCodeTypeName( m_sFileInfo.eCharCode ).IsBomDefOn(); }	//!< BOM•t‰Á‚ÌƒfƒtƒHƒ‹ƒg’l‚ğİ’è‚·‚é
-	void			CancelChgCodeSet()			{ m_sFileInfo.eCharCode = m_sFileInfo.eCharCodeLoad; m_sFileInfo.bBomExist = m_sFileInfo.bBomExistLoad; }		//!< •¶šƒR[ƒhƒZƒbƒg1‚Ì•ÏX‚ğƒLƒƒƒ“ƒZƒ‹‚·‚é
-	bool			IsBomExist() const			{ return m_sFileInfo.bBomExist; }		//!< •Û‘¶‚ÉBOM‚ğ•t‰Á‚·‚é‚©‚Ç‚¤‚©‚ğæ“¾
-	bool			IsChgCodeSet() const		{ return (!IsFileTimeZero()) && ((m_sFileInfo.eCharCode != m_sFileInfo.eCharCodeLoad) || (m_sFileInfo.bBomExist != m_sFileInfo.bBomExistLoad)); }		//!< •¶šƒR[ƒhƒZƒbƒg‚ª•ÏX‚³‚ê‚½‚©H
+	void			SetCodeSet(ECodeType eCodeSet , bool bBomExist)	{ m_sFileInfo.SetCodeSet(eCodeSet, bBomExist); }	//!< æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã‚’è¨­å®š
+	void			SetCodeSetChg(ECodeType eCodeSet , bool bBomExist)	{ m_sFileInfo.eCharCode = eCodeSet; m_sFileInfo.bBomExist = bBomExist; }	//!< æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã‚’è¨­å®š(æ–‡å­—ã‚³ãƒ¼ãƒ‰æŒ‡å®šç”¨)
+	ECodeType		GetCodeSet() const			{ return m_sFileInfo.eCharCode; }		//!< æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã‚’å–å¾—
+	void			SetBomDefoult()				{ m_sFileInfo.bBomExist= CCodeTypeName( m_sFileInfo.eCharCode ).IsBomDefOn(); }	//!< BOMä»˜åŠ ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆå€¤ã‚’è¨­å®šã™ã‚‹
+	void			CancelChgCodeSet()			{ m_sFileInfo.eCharCode = m_sFileInfo.eCharCodeLoad; m_sFileInfo.bBomExist = m_sFileInfo.bBomExistLoad; }		//!< æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ1ã®å¤‰æ›´ã‚’ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã™ã‚‹
+	bool			IsBomExist() const			{ return m_sFileInfo.bBomExist; }		//!< ä¿å­˜æ™‚ã«BOMã‚’ä»˜åŠ ã™ã‚‹ã‹ã©ã†ã‹ã‚’å–å¾—
+	bool			IsChgCodeSet() const		{ return (!IsFileTimeZero()) && ((m_sFileInfo.eCharCode != m_sFileInfo.eCharCodeLoad) || (m_sFileInfo.bBomExist != m_sFileInfo.bBomExistLoad)); }		//!< æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆãŒå¤‰æ›´ã•ã‚ŒãŸã‹ï¼Ÿ
 
 	CFileTime&		GetFileTime()				{ return m_sFileInfo.cFileTime; }
 	void			ClearFileTime()				{ m_sFileInfo.cFileTime.ClearFILETIME(); }
-	bool			IsFileTimeZero() const		{ return m_sFileInfo.cFileTime.IsZero(); }	// V‹Kƒtƒ@ƒCƒ‹H
+	bool			IsFileTimeZero() const		{ return m_sFileInfo.cFileTime.IsZero(); }	// æ–°è¦ãƒ•ã‚¡ã‚¤ãƒ«ï¼Ÿ
 	const SYSTEMTIME	GetFileSysTime() const	{ return m_sFileInfo.cFileTime.GetSYSTEMTIME(); }
 	void			SetFileTime( FILETIME& Time )	{ m_sFileInfo.cFileTime.SetFILETIME( Time ); }
 
-	const TCHAR*	GetFileName() const{ return GetFileTitlePointer(GetFilePath()); }	//!< ƒtƒ@ƒCƒ‹–¼(ƒpƒX‚È‚µ)‚ğæ“¾
+	const TCHAR*	GetFileName() const{ return GetFileTitlePointer(GetFilePath()); }	//!< ãƒ•ã‚¡ã‚¤ãƒ«å(ãƒ‘ã‚¹ãªã—)ã‚’å–å¾—
 	const TCHAR*	GetSaveFilePath(void) const;
 	void			SetSaveFilePath(LPCTSTR pszPath){ m_szSaveFilePath.Assign(pszPath); }
 public: //####
 	CEditDoc*	m_pcDocRef;
 	SFileInfo	m_sFileInfo;
-	CFilePath	m_szSaveFilePath;	/* •Û‘¶‚Ìƒtƒ@ƒCƒ‹‚ÌƒpƒXiƒ}ƒNƒ—pj */	// 2006.09.04 ryoji
+	CFilePath	m_szSaveFilePath;	/* ä¿å­˜æ™‚ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹ï¼ˆãƒã‚¯ãƒ­ç”¨ï¼‰ */	// 2006.09.04 ryoji
 };
 
 #endif /* SAKURA_CDOCFILE_C6DA01C5_5BB2_4361_9B6A_648953CB9CA19_H_ */

--- a/sakura_core/doc/CDocFileOperation.h
+++ b/sakura_core/doc/CDocFileOperation.h
@@ -1,4 +1,4 @@
-/*
+Ôªø/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -33,20 +33,20 @@ class CDocFileOperation{
 public:
 	CDocFileOperation(CEditDoc* pcDoc) : m_pcDocRef(pcDoc) { }
 
-	//ÉçÉbÉN
+	//„É≠„ÉÉ„ÇØ
 	bool _ToDoLock() const;
 	void DoFileLock(bool bMsg = true);
 	void DoFileUnlock();
 	
-	//ÉçÅ[ÉhUI
+	//„É≠„Éº„ÉâUI
 	bool OpenFileDialog(
 		HWND				hwndParent,
-		const TCHAR*		pszOpenFolder,	//!< [in]  NULLà»äOÇéwíËÇ∑ÇÈÇ∆èâä˙ÉtÉHÉãÉ_ÇéwíËÇ≈Ç´ÇÈ
-		SLoadInfo*			pLoadInfo,		//!< [in,out] ÉçÅ[ÉhèÓïÒ
+		const TCHAR*		pszOpenFolder,	//!< [in]  NULL‰ª•Â§ñ„ÇíÊåáÂÆö„Åô„Çã„Å®ÂàùÊúü„Éï„Ç©„É´„ÉÄ„ÇíÊåáÂÆö„Åß„Åç„Çã
+		SLoadInfo*			pLoadInfo,		//!< [in,out] „É≠„Éº„ÉâÊÉÖÂ†±
 		std::vector<std::tstring>&	files
 	);
 
-	//ÉçÅ[ÉhÉtÉçÅ[
+	//„É≠„Éº„Éâ„Éï„É≠„Éº
 	bool DoLoadFlow(SLoadInfo* pLoadInfo);
 	bool FileLoad(
 		SLoadInfo*	pLoadInfo			//!< [in,out]
@@ -54,25 +54,25 @@ public:
 	bool FileLoadWithoutAutoMacro(
 		SLoadInfo*	pLoadInfo			//!< [in,out]
 	);
-	void ReloadCurrentFile(				//!< ìØàÍÉtÉ@ÉCÉãÇÃçƒÉIÅ[ÉvÉì Jul. 26, 2003 ryoji BOMÉIÉvÉVÉáÉìí«â¡
-		ECodeType	nCharCode			//!< [in] ï∂éöÉRÅ[ÉhéÌï 
+	void ReloadCurrentFile(				//!< Âêå‰∏Ä„Éï„Ç°„Ç§„É´„ÅÆÂÜç„Ç™„Éº„Éó„É≥ Jul. 26, 2003 ryoji BOM„Ç™„Éó„Ç∑„Éß„É≥ËøΩÂä†
+		ECodeType	nCharCode			//!< [in] ÊñáÂ≠ó„Ç≥„Éº„ÉâÁ®ÆÂà•
 	);
 
 	
-	//ÉZÅ[ÉuUI
-	bool SaveFileDialog(SSaveInfo* pSaveInfo);	//!<ÅuÉtÉ@ÉCÉãñºÇïtÇØÇƒï€ë∂ÅvÉ_ÉCÉAÉçÉO
-	bool SaveFileDialog(LPTSTR szPath);			//!<ÅuÉtÉ@ÉCÉãñºÇïtÇØÇƒï€ë∂ÅvÉ_ÉCÉAÉçÉO
+	//„Çª„Éº„ÉñUI
+	bool SaveFileDialog(SSaveInfo* pSaveInfo);	//!<„Äå„Éï„Ç°„Ç§„É´Âêç„Çí‰ªò„Åë„Å¶‰øùÂ≠ò„Äç„ÉÄ„Ç§„Ç¢„É≠„Ç∞
+	bool SaveFileDialog(LPTSTR szPath);			//!<„Äå„Éï„Ç°„Ç§„É´Âêç„Çí‰ªò„Åë„Å¶‰øùÂ≠ò„Äç„ÉÄ„Ç§„Ç¢„É≠„Ç∞
 
-	//ÉZÅ[ÉuÉtÉçÅ[
+	//„Çª„Éº„Éñ„Éï„É≠„Éº
 	bool DoSaveFlow(SSaveInfo* pSaveInfo);
-	bool FileSaveAs( const WCHAR* filename = NULL,ECodeType eCodeType = CODE_NONE, EEolType eEolType = EOL_NONE, bool bDialog = true);	//!< É_ÉCÉAÉçÉOÇ≈ÉtÉ@ÉCÉãñºÇì¸óÕÇ≥ÇπÅAï€ë∂ÅB	// 2006.12.30 ryoji
-	bool FileSave();			//!< è„èëÇ´ï€ë∂ÅBÉtÉ@ÉCÉãñºÇ™éwíËÇ≥ÇÍÇƒÇ¢Ç»Ç©Ç¡ÇΩÇÁÉ_ÉCÉAÉçÉOÇ≈ì¸óÕÇë£Ç∑ÅB	// 2006.12.30 ryoji
+	bool FileSaveAs( const WCHAR* filename = NULL,ECodeType eCodeType = CODE_NONE, EEolType eEolType = EOL_NONE, bool bDialog = true);	//!< „ÉÄ„Ç§„Ç¢„É≠„Ç∞„Åß„Éï„Ç°„Ç§„É´Âêç„ÇíÂÖ•Âäõ„Åï„Åõ„ÄÅ‰øùÂ≠ò„ÄÇ	// 2006.12.30 ryoji
+	bool FileSave();			//!< ‰∏äÊõ∏„Åç‰øùÂ≠ò„ÄÇ„Éï„Ç°„Ç§„É´Âêç„ÅåÊåáÂÆö„Åï„Çå„Å¶„ÅÑ„Å™„Åã„Å£„Åü„Çâ„ÉÄ„Ç§„Ç¢„É≠„Ç∞„ÅßÂÖ•Âäõ„Çí‰øÉ„Åô„ÄÇ	// 2006.12.30 ryoji
 
-	//ÉNÉçÅ[ÉY
-	bool FileClose();			//!< ï¬Ç∂Çƒ(ñ≥ëË)	// 2006.12.30 ryoji
+	//„ÇØ„É≠„Éº„Ç∫
+	bool FileClose();			//!< Èñâ„Åò„Å¶(ÁÑ°È°å)	// 2006.12.30 ryoji
 
-	//ÇªÇÃëº
-	void FileCloseOpen(				//!< ï¬Ç∂ÇƒäJÇ≠	// 2006.12.30 ryoji
+	//„Åù„ÅÆ‰ªñ
+	void FileCloseOpen(				//!< Èñâ„Åò„Å¶Èñã„Åè	// 2006.12.30 ryoji
 		const SLoadInfo& sLoadInfo = SLoadInfo(_T(""), CODE_AUTODETECT, false)
 	);
 

--- a/sakura_core/doc/CDocListener.cpp
+++ b/sakura_core/doc/CDocListener.cpp
@@ -1,11 +1,11 @@
-/*
-	Observerƒpƒ^[ƒ“‚ÌCEditDoc“Á‰»”ÅB
-	CDocSubject‚ÍŠÏ@‚³‚êACDocListner‚ÍŠÏ@‚ğs‚¤B
-	ŠÏ@‚ÌŠJn‚Í CDocListener::Listen ‚Ås‚¤B
+ï»¿/*
+	Observerãƒ‘ã‚¿ãƒ¼ãƒ³ã®CEditDocç‰¹åŒ–ç‰ˆã€‚
+	CDocSubjectã¯è¦³å¯Ÿã•ã‚Œã€CDocListnerã¯è¦³å¯Ÿã‚’è¡Œã†ã€‚
+	è¦³å¯Ÿã®é–‹å§‹ã¯ CDocListener::Listen ã§è¡Œã†ã€‚
 
 	$Note:
-		Listener (Observer) ‚Æ Subject ‚ÌƒŠƒŒ[ƒVƒ‡ƒ“ŠÇ—‚Í
-		ƒWƒFƒlƒŠƒbƒN‚È”Ä—pƒ‚ƒWƒ…[ƒ‹‚É•ª—£‚Å‚«‚éB
+		Listener (Observer) ã¨ Subject ã®ãƒªãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³ç®¡ç†ã¯
+		ã‚¸ã‚§ãƒãƒªãƒƒã‚¯ãªæ±ç”¨ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ã«åˆ†é›¢ã§ãã‚‹ã€‚
 */
 /*
 	Copyright (C) 2008, kobake
@@ -90,7 +90,7 @@ CDocSubject::~CDocSubject()
 	} \
 }
 
-//######‰¼
+//######ä»®
 #define CORE_NOTIFY2(NAME,ARGTYPE) ELoadResult CDocSubject::Notify##NAME(ARGTYPE a) \
 { \
 	int n = GetListenerCount(); \
@@ -125,11 +125,11 @@ DEF_NOTIFY(BeforeClose)
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                       CDocListener                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//(‘½)
+//(å¤š)
 
 CDocListener::CDocListener(CDocSubject* pcDoc)
 {
-	if(pcDoc==NULL)pcDoc = CEditDoc::GetInstance(0); //$$ ƒCƒ“ƒ`ƒL
+	if(pcDoc==NULL)pcDoc = CEditDoc::GetInstance(0); //$$ ã‚¤ãƒ³ãƒã‚­
 	assert( pcDoc );
 	Listen(pcDoc);
 }

--- a/sakura_core/doc/CDocListener.h
+++ b/sakura_core/doc/CDocListener.h
@@ -1,11 +1,11 @@
-/*
-	Observerƒpƒ^[ƒ“‚ÌCEditDoc“Á‰»”ÅB
-	CDocSubject‚ÍŠÏ@‚³‚êACDocListner‚ÍŠÏ@‚ğs‚¤B
-	ŠÏ@‚ÌŠJn‚Í CDocListener::Listen ‚Ås‚¤B
+ï»¿/*
+	Observerãƒ‘ã‚¿ãƒ¼ãƒ³ã®CEditDocç‰¹åŒ–ç‰ˆã€‚
+	CDocSubjectã¯è¦³å¯Ÿã•ã‚Œã€CDocListnerã¯è¦³å¯Ÿã‚’è¡Œã†ã€‚
+	è¦³å¯Ÿã®é–‹å§‹ã¯ CDocListener::Listen ã§è¡Œã†ã€‚
 
 	$Note:
-		Listener (Observer) ‚Æ Subject ‚ÌƒŠƒŒ[ƒVƒ‡ƒ“ŠÇ—‚Í
-		ƒWƒFƒlƒŠƒbƒN‚È”Ä—pƒ‚ƒWƒ…[ƒ‹‚É•ª—£‚Å‚«‚éB
+		Listener (Observer) ã¨ Subject ã®ãƒªãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³ç®¡ç†ã¯
+		ã‚¸ã‚§ãƒãƒªãƒƒã‚¯ãªæ±ç”¨ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ã«åˆ†é›¢ã§ãã‚‹ã€‚
 */
 /*
 	Copyright (C) 2008, kobake
@@ -45,41 +45,41 @@ class CDocListener;
 enum ESaveResult{
 	SAVED_OK,
 	SAVED_FAILURE,
-	SAVED_INTERRUPT,//!< ’†’f‚³‚ê‚½
-	SAVED_LOSESOME,	//!< •¶š‚Ìˆê•”‚ª¸‚í‚ê‚½
+	SAVED_INTERRUPT,//!< ä¸­æ–­ã•ã‚ŒãŸ
+	SAVED_LOSESOME,	//!< æ–‡å­—ã®ä¸€éƒ¨ãŒå¤±ã‚ã‚ŒãŸ
 };
 
 //###
 enum ELoadResult{
 	LOADED_OK,
 	LOADED_FAILURE,
-	LOADED_INTERRUPT,	//!< ’†’f‚³‚ê‚½
-	LOADED_LOSESOME,	//!< •¶š‚Ìˆê•”‚ª¸‚í‚ê‚½
+	LOADED_INTERRUPT,	//!< ä¸­æ–­ã•ã‚ŒãŸ
+	LOADED_LOSESOME,	//!< æ–‡å­—ã®ä¸€éƒ¨ãŒå¤±ã‚ã‚ŒãŸ
 
-	//“Áê
-	LOADED_NOIMPLEMENT,	//!< À‘•–³‚µ
+	//ç‰¹æ®Š
+	LOADED_NOIMPLEMENT,	//!< å®Ÿè£…ç„¡ã—
 };
 
 //###
 enum ECallbackResult{
-	CALLBACK_CONTINUE,			//!< ‘±‚¯‚é
-	CALLBACK_INTERRUPT,			//!< ’†’f
+	CALLBACK_CONTINUE,			//!< ç¶šã‘ã‚‹
+	CALLBACK_INTERRUPT,			//!< ä¸­æ–­
 };
 
 //###
 struct SLoadInfo
 {
-	//“ü—Í
+	//å…¥åŠ›
 	CFilePath	cFilePath;
 	ECodeType	eCharCode;
 	bool		bViewMode;
-	bool		bWritableNoMsg; //!< ‘‚«‚İ‹Ö~ƒƒbƒZ[ƒW‚ğ•\¦‚µ‚È‚¢
+	bool		bWritableNoMsg; //!< æ›¸ãè¾¼ã¿ç¦æ­¢ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤ºã—ãªã„
 	CTypeConfig	nType;
 
-	//ƒ‚[ƒh
-	bool		bRequestReload;	//ƒŠƒ[ƒh—v‹
+	//ãƒ¢ãƒ¼ãƒ‰
+	bool		bRequestReload;	//ãƒªãƒ­ãƒ¼ãƒ‰è¦æ±‚
 
-	//o—Í
+	//å‡ºåŠ›
 	bool		bOpened;
 
 	SLoadInfo()
@@ -103,51 +103,51 @@ struct SLoadInfo
 	{
 	}
 
-	//! ƒtƒ@ƒCƒ‹ƒpƒX‚Ì”äŠr
+	//! ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã®æ¯”è¼ƒ
 	bool IsSamePath(LPCTSTR pszPath) const;
 };
 
 struct SSaveInfo{
-	CFilePath	cFilePath;	//!< •Û‘¶ƒtƒ@ƒCƒ‹–¼
-	ECodeType	eCharCode;	//!< •Û‘¶•¶šƒR[ƒhƒZƒbƒg
-	bool		bBomExist;	//!< •Û‘¶BOM•t‰Á
-	bool		bChgCodeSet;//!< •¶šƒR[ƒhƒZƒbƒg•ÏX	2013/5/19 Uchi
-	CEol		cEol;		//!< •Û‘¶‰üsƒR[ƒh
+	CFilePath	cFilePath;	//!< ä¿å­˜ãƒ•ã‚¡ã‚¤ãƒ«å
+	ECodeType	eCharCode;	//!< ä¿å­˜æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
+	bool		bBomExist;	//!< ä¿å­˜æ™‚BOMä»˜åŠ 
+	bool		bChgCodeSet;//!< æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆå¤‰æ›´	2013/5/19 Uchi
+	CEol		cEol;		//!< ä¿å­˜æ”¹è¡Œã‚³ãƒ¼ãƒ‰
 
-	//ƒ‚[ƒh
-	bool		bOverwriteMode;	//!< ã‘‚«—v‹
+	//ãƒ¢ãƒ¼ãƒ‰
+	bool		bOverwriteMode;	//!< ä¸Šæ›¸ãè¦æ±‚
 
 	SSaveInfo() : cFilePath(_T("")), eCharCode(CODE_AUTODETECT), bBomExist(false), bChgCodeSet(false), cEol(EOL_NONE), bOverwriteMode(false) { }
 	SSaveInfo(const CFilePath& _cFilePath, ECodeType _eCodeType, const CEol& _cEol, bool _bBomExist)
 		: cFilePath(_cFilePath), eCharCode(_eCodeType), bBomExist(_bBomExist), bChgCodeSet(false), cEol(_cEol), bOverwriteMode(false) { }
 
-	//! ƒtƒ@ƒCƒ‹ƒpƒX‚Ì”äŠr
+	//! ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã®æ¯”è¼ƒ
 	bool IsSamePath(LPCTSTR pszPath) const;
 };
 
 
 class CProgressListener;
 
-//! •¡”‚ÌCProgressSubject‚©‚çƒEƒHƒbƒ`‚³‚ê‚é
+//! è¤‡æ•°ã®CProgressSubjectã‹ã‚‰ã‚¦ã‚©ãƒƒãƒã•ã‚Œã‚‹
 class CProgressSubject : public CSubjectT<CProgressListener>{
 public:
 	virtual ~CProgressSubject(){}
 	void NotifyProgress(int nPer);
 };
 
-//! 1‚Â‚ÌCProgressSubject‚ğƒEƒHƒbƒ`‚·‚é
+//! 1ã¤ã®CProgressSubjectã‚’ã‚¦ã‚©ãƒƒãƒã™ã‚‹
 class CProgressListener : public CListenerT<CProgressSubject>{
 public:
 	virtual ~CProgressListener(){}
 	virtual void OnProgress(int nPer)=0;
 };
 
-//Subject‚Í•¡”‚ÌListener‚©‚çŠÏ@‚³‚ê‚é
+//Subjectã¯è¤‡æ•°ã®Listenerã‹ã‚‰è¦³å¯Ÿã•ã‚Œã‚‹
 class CDocSubject : public CSubjectT<CDocListener>{
 public:
 	virtual ~CDocSubject();
 
-	//ƒ[ƒh‘OŒã
+	//ãƒ­ãƒ¼ãƒ‰å‰å¾Œ
 	ECallbackResult NotifyCheckLoad	(SLoadInfo* pLoadInfo);
 	void NotifyBeforeLoad			(SLoadInfo* sLoadInfo);
 	ELoadResult NotifyLoad			(const SLoadInfo& sLoadInfo);
@@ -155,7 +155,7 @@ public:
 	void NotifyAfterLoad			(const SLoadInfo& sLoadInfo);
 	void NotifyFinalLoad			(ELoadResult eLoadResult);
 
-	//ƒZ[ƒu‘OŒã
+	//ã‚»ãƒ¼ãƒ–å‰å¾Œ
 	ECallbackResult NotifyCheckSave	(SSaveInfo* pSaveInfo);
 	ECallbackResult NotifyPreBeforeSave(SSaveInfo* pSaveInfo);
 	void NotifyBeforeSave			(const SSaveInfo& sSaveInfo);
@@ -164,42 +164,42 @@ public:
 	void NotifyAfterSave			(const SSaveInfo& sSaveInfo);
 	void NotifyFinalSave			(ESaveResult eSaveResult);
 
-	//ƒNƒ[ƒY‘OŒã
+	//ã‚¯ãƒ­ãƒ¼ã‚ºå‰å¾Œ
 	ECallbackResult NotifyBeforeClose();
 };
 
-//Listener‚Í1‚Â‚ÌSubject‚ğŠÏ@‚·‚é
+//Listenerã¯1ã¤ã®Subjectã‚’è¦³å¯Ÿã™ã‚‹
 class CDocListener : public CListenerT<CDocSubject>{
 public:
 	CDocListener(CDocSubject* pcDoc = NULL);
 	virtual ~CDocListener();
 
-	// -- -- ‘®« -- -- //
+	// -- -- å±æ€§ -- -- //
 	CDocSubject* GetListeningDoc() const{ return GetListeningSubject(); }
 
-	// -- -- ŠeíƒCƒxƒ“ƒg -- -- //
-	//ƒ[ƒh‘OŒã
-	virtual ECallbackResult	OnCheckLoad	(SLoadInfo* pLoadInfo)		{ return CALLBACK_CONTINUE; }	//!< –{“–‚Éƒ[ƒh‚ğs‚¤‚©‚Ì”»’è‚ğs‚¤
-	virtual void			OnBeforeLoad(SLoadInfo* sLoadInfo){ return ; }	//!< ƒ[ƒh–‘Oˆ—
-	virtual ELoadResult		OnLoad		(const SLoadInfo& sLoadInfo){ return LOADED_NOIMPLEMENT; }	//!< ƒ[ƒhˆ—
-	virtual void			OnLoading	(int nPer)					{ return ; }	//!< ƒ[ƒhˆ—‚ÌŒo‰ßî•ñ‚ğóM
-	virtual void			OnAfterLoad	(const SLoadInfo& sLoadInfo){ return ; }	//!< ƒ[ƒh–Œãˆ—
-	virtual void			OnFinalLoad	(ELoadResult eLoadResult)	{ return ; }	//!< ƒ[ƒhƒtƒ[‚ÌÅŒã‚É•K‚¸ŒÄ‚Î‚ê‚é
+	// -- -- å„ç¨®ã‚¤ãƒ™ãƒ³ãƒˆ -- -- //
+	//ãƒ­ãƒ¼ãƒ‰å‰å¾Œ
+	virtual ECallbackResult	OnCheckLoad	(SLoadInfo* pLoadInfo)		{ return CALLBACK_CONTINUE; }	//!< æœ¬å½“ã«ãƒ­ãƒ¼ãƒ‰ã‚’è¡Œã†ã‹ã®åˆ¤å®šã‚’è¡Œã†
+	virtual void			OnBeforeLoad(SLoadInfo* sLoadInfo){ return ; }	//!< ãƒ­ãƒ¼ãƒ‰äº‹å‰å‡¦ç†
+	virtual ELoadResult		OnLoad		(const SLoadInfo& sLoadInfo){ return LOADED_NOIMPLEMENT; }	//!< ãƒ­ãƒ¼ãƒ‰å‡¦ç†
+	virtual void			OnLoading	(int nPer)					{ return ; }	//!< ãƒ­ãƒ¼ãƒ‰å‡¦ç†ã®çµŒéæƒ…å ±ã‚’å—ä¿¡
+	virtual void			OnAfterLoad	(const SLoadInfo& sLoadInfo){ return ; }	//!< ãƒ­ãƒ¼ãƒ‰äº‹å¾Œå‡¦ç†
+	virtual void			OnFinalLoad	(ELoadResult eLoadResult)	{ return ; }	//!< ãƒ­ãƒ¼ãƒ‰ãƒ•ãƒ­ãƒ¼ã®æœ€å¾Œã«å¿…ãšå‘¼ã°ã‚Œã‚‹
 
-	//ƒZ[ƒu‘OŒã
-	virtual ECallbackResult OnCheckSave	(SSaveInfo* pSaveInfo)		{ return CALLBACK_CONTINUE; }	//!< –{“–‚ÉƒZ[ƒu‚ğs‚¤‚©‚Ì”»’è‚ğs‚¤
-	virtual ECallbackResult OnPreBeforeSave	(SSaveInfo* pSaveInfo)	{ return CALLBACK_CONTINUE; }	//!< ƒZ[ƒu–‘O‚¨‚Ü‚¯ˆ— ($$ ‰¼)
-	virtual void			OnBeforeSave(const SSaveInfo& sSaveInfo){ return ; }	//!< ƒZ[ƒu–‘Oˆ—
-	virtual void			OnSave		(const SSaveInfo& sSaveInfo){ return ; }	//!< ƒZ[ƒuˆ—
-	virtual void			OnSaving	(int nPer)					{ return ; }	//!< ƒZ[ƒuˆ—‚ÌŒo‰ßî•ñ‚ğóM
-	virtual void			OnAfterSave	(const SSaveInfo& sSaveInfo){ return ; }	//!< ƒZ[ƒu–Œãˆ—
-	virtual void			OnFinalSave	(ESaveResult eSaveResult)	{ return ; }	//!< ƒZ[ƒuƒtƒ[‚ÌÅŒã‚É•K‚¸ŒÄ‚Î‚ê‚é
+	//ã‚»ãƒ¼ãƒ–å‰å¾Œ
+	virtual ECallbackResult OnCheckSave	(SSaveInfo* pSaveInfo)		{ return CALLBACK_CONTINUE; }	//!< æœ¬å½“ã«ã‚»ãƒ¼ãƒ–ã‚’è¡Œã†ã‹ã®åˆ¤å®šã‚’è¡Œã†
+	virtual ECallbackResult OnPreBeforeSave	(SSaveInfo* pSaveInfo)	{ return CALLBACK_CONTINUE; }	//!< ã‚»ãƒ¼ãƒ–äº‹å‰ãŠã¾ã‘å‡¦ç† ($$ ä»®)
+	virtual void			OnBeforeSave(const SSaveInfo& sSaveInfo){ return ; }	//!< ã‚»ãƒ¼ãƒ–äº‹å‰å‡¦ç†
+	virtual void			OnSave		(const SSaveInfo& sSaveInfo){ return ; }	//!< ã‚»ãƒ¼ãƒ–å‡¦ç†
+	virtual void			OnSaving	(int nPer)					{ return ; }	//!< ã‚»ãƒ¼ãƒ–å‡¦ç†ã®çµŒéæƒ…å ±ã‚’å—ä¿¡
+	virtual void			OnAfterSave	(const SSaveInfo& sSaveInfo){ return ; }	//!< ã‚»ãƒ¼ãƒ–äº‹å¾Œå‡¦ç†
+	virtual void			OnFinalSave	(ESaveResult eSaveResult)	{ return ; }	//!< ã‚»ãƒ¼ãƒ–ãƒ•ãƒ­ãƒ¼ã®æœ€å¾Œã«å¿…ãšå‘¼ã°ã‚Œã‚‹
 
-	//ƒNƒ[ƒY‘OŒã
+	//ã‚¯ãƒ­ãƒ¼ã‚ºå‰å¾Œ
 	virtual ECallbackResult OnBeforeClose()							{ return CALLBACK_CONTINUE; }
 };
 
-//GetListeningDoc‚Ì—˜•Ö«‚ğƒAƒbƒv
+//GetListeningDocã®åˆ©ä¾¿æ€§ã‚’ã‚¢ãƒƒãƒ—
 class CEditDoc;
 class CDocListenerEx : public CDocListener{
 public:

--- a/sakura_core/doc/CDocLocker.h
+++ b/sakura_core/doc/CDocLocker.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -30,20 +30,20 @@ class CDocLocker : public CDocListenerEx{
 public:
 	CDocLocker();
 
-	//ƒNƒŠƒA
+	//ã‚¯ãƒªã‚¢
 	void Clear(void) { m_bIsDocWritable = true; }
 
-	//ƒ[ƒh‘OŒã
+	//ãƒ­ãƒ¼ãƒ‰å‰å¾Œ
 	void OnAfterLoad(const SLoadInfo& sLoadInfo);
 	
-	//ƒZ[ƒu‘OŒã
+	//ã‚»ãƒ¼ãƒ–å‰å¾Œ
 	void OnBeforeSave(const SSaveInfo& sSaveInfo);
 	void OnAfterSave(const SSaveInfo& sSaveInfo);
 
-	//ó‘Ô
+	//çŠ¶æ…‹
 	bool IsDocWritable() const{ return m_bIsDocWritable; }
 
-	//ƒ`ƒFƒbƒN
+	//ãƒã‚§ãƒƒã‚¯
 	void CheckWritable(bool bMsg);
 
 private:

--- a/sakura_core/doc/CDocOutline.cpp
+++ b/sakura_core/doc/CDocOutline.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ
+ï»¿/*!	@file
+	@brief ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ
 
 	@author genta
-	@date	2004.08.08 ì¬
+	@date	2004.08.08 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -10,7 +10,7 @@
 	Copyright (C) 2001, genta
 	Copyright (C) 2002, frozen
 	Copyright (C) 2003, zenryaku
-	Copyright (C) 2005, genta, D.S.Koba, ‚¶‚ã‚¤‚¶
+	Copyright (C) 2005, genta, D.S.Koba, ã˜ã‚…ã†ã˜
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.
@@ -31,34 +31,34 @@
 
 
 
-/*! ƒ‹[ƒ‹ƒtƒ@ƒCƒ‹‚Ì1s‚ğŠÇ—‚·‚é\‘¢‘Ì
+/*! ãƒ«ãƒ¼ãƒ«ãƒ•ã‚¡ã‚¤ãƒ«ã®1è¡Œã‚’ç®¡ç†ã™ã‚‹æ§‹é€ ä½“
 
 	@date 2002.04.01 YAZAKI
-	@date 2007.11.29 kobake –¼‘O•ÏX: oneRule¨SOneRule
+	@date 2007.11.29 kobake åå‰å¤‰æ›´: oneRuleâ†’SOneRule
 */
 struct SOneRule {
 	wchar_t szMatch[256];
 	int		nLength;
-	wchar_t szText[256]; // RegexReplace‚Ì’uŠ·Œã•¶š—ñ
+	wchar_t szText[256]; // RegexReplaceæ™‚ã®ç½®æ›å¾Œæ–‡å­—åˆ—
 	wchar_t szGroupName[256];
 	int		nLv;
 	int		nRegexOption;
-	int		nRegexMode; // 0 ==uMode=Regexv, 1 == uMode=RegexReplacev
+	int		nRegexMode; // 0 ==ã€ŒMode=Regexã€, 1 == ã€ŒMode=RegexReplaceã€
 };
 
 
 
-/*! ƒ‹[ƒ‹ƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚İAƒ‹[ƒ‹\‘¢‘Ì‚Ì”z—ñ‚ğì¬‚·‚é
+/*! ãƒ«ãƒ¼ãƒ«ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã¿ã€ãƒ«ãƒ¼ãƒ«æ§‹é€ ä½“ã®é…åˆ—ã‚’ä½œæˆã™ã‚‹
 
 	@date 2002.04.01 YAZAKI
-	@date 2002.11.03 Moca ˆø”nMaxCount‚ğ’Ç‰ÁBƒoƒbƒtƒ@’·ƒ`ƒFƒbƒN‚ğ‚·‚é‚æ‚¤‚É•ÏX
-	@date 2013.06.02 _tfopen_absini,fgetws‚ğCTextInputStream_AbsIni‚É•ÏXBUTF-8‘Î‰BRegex‘Î‰
-	@date 2014.06.20 RegexReplace ³‹K•\Œ»’uŠ·ƒ‚[ƒh’Ç‰Á
+	@date 2002.11.03 Moca å¼•æ•°nMaxCountã‚’è¿½åŠ ã€‚ãƒãƒƒãƒ•ã‚¡é•·ãƒã‚§ãƒƒã‚¯ã‚’ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
+	@date 2013.06.02 _tfopen_absini,fgetwsã‚’CTextInputStream_AbsIniã«å¤‰æ›´ã€‚UTF-8å¯¾å¿œã€‚Regexå¯¾å¿œ
+	@date 2014.06.20 RegexReplace æ­£è¦è¡¨ç¾ç½®æ›ãƒ¢ãƒ¼ãƒ‰è¿½åŠ 
 */
 int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, int nMaxCount, bool& bRegex, std::wstring& title )
 {
-	// 2003.06.23 Moca ‘Š‘ÎƒpƒX‚ÍÀsƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚Æ‚µ‚ÄŠJ‚­
-	// 2007.05.19 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+	// 2003.06.23 Moca ç›¸å¯¾ãƒ‘ã‚¹ã¯å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã¨ã—ã¦é–‹ã
+	// 2007.05.19 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 	CTextInputStream_AbsIni	file = CTextInputStream_AbsIni( pszFilename );
 	if( !file.Good() ){
 		return 0;
@@ -77,11 +77,11 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 	title = L"";
 	int regexOption = CBregexp::optCaseSensitive;
 
-	// ’Êíƒ‚[ƒh
+	// é€šå¸¸ãƒ¢ãƒ¼ãƒ‰
 	// key1,key2 /// GroupName,Lv=1
-	// ³‹K•\Œ»ƒ‚[ƒh
+	// æ­£è¦è¡¨ç¾ãƒ¢ãƒ¼ãƒ‰
 	// RegexMode /// GroupName,Lv=1
-	// ³‹K•\Œ»’uŠ·ƒ‚[ƒh
+	// æ­£è¦è¡¨ç¾ç½®æ›ãƒ¢ãƒ¼ãƒ‰
 	// RegexReplace /// TitleReplace /// GroupName
 	while( file.Good() && nCount < nMaxCount ){
 		strLine = file.ReadLineW();
@@ -89,37 +89,37 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 		if( NULL != pszWork && 0 < strLine.length() && strLine[0] != cComment ){
 			int nLen = pszWork - strLine.c_str();
 			if( nLen < LINEREADBUFSIZE ){
-				// szLine == ukey1,key2v
+				// szLine == ã€Œkey1,key2ã€
 				wmemcpy(szLine, strLine.c_str(), nLen);
 				szLine[nLen] = L'\0';
 			}else{
-				// ‚±‚Ìs‚Í’·‚·‚¬‚é
+				// ã“ã®è¡Œã¯é•·ã™ãã‚‹
 				continue;
 			}
 			pszWork += nDelimitLen;
 
-			/* Å‰‚Ìƒg[ƒNƒ“‚ğæ“¾‚µ‚Ü‚·B */
+			/* æœ€åˆã®ãƒˆãƒ¼ã‚¯ãƒ³ã‚’å–å¾—ã—ã¾ã™ã€‚ */
 			const wchar_t* pszTextReplace = L"";
 			wchar_t* pszToken;
 			bool bTopDummy = false;
 			bool bRegexRep2 = false;
 			if( bRegex ){
-				// regex‚Ì‚Æ‚«‚Í,‹æØ‚è‚É‚µ‚È‚¢
+				// regexã®ã¨ãã¯,åŒºåˆ‡ã‚Šã«ã—ãªã„
 				pszToken = szLine;
 				if( szLine[0] == L'\0' ){
 					if( 0 < nCount ){
-						// ‹ó‚ÌKey ‚Í–³‹
+						// ç©ºã®Key ã¯ç„¡è¦–
 						pszToken = NULL;
 					}else{
-						// Å‰‚Ì—v‘f‚ª‹ó‚ÌKey‚¾‚Á‚½‚çƒ_ƒ~[—v‘f
+						// æœ€åˆã®è¦ç´ ãŒç©ºã®Keyã ã£ãŸã‚‰ãƒ€ãƒŸãƒ¼è¦ç´ 
 						bTopDummy = true;
 					}
 				}
 				if( bRegexReplace && pszToken ){
 					const wchar_t* pszGroupDel = wcsstr( pszWork, pszDelimit );
 					if( NULL != pszGroupDel && 0 < pszWork[0] != L'\0' ){
-						// pszWork = utitleRep /// groupv
-						// pszGroupDel = u /// groupv
+						// pszWork = ã€ŒtitleRep /// groupã€
+						// pszGroupDel = ã€Œ /// groupã€
 						int nTitleLen = pszGroupDel - pszWork; // Len == 0 OK
 						if( nTitleLen < _countof(szText) ){
 							wcsncpy_s(szText, _countof(szText), pszWork, nTitleLen);
@@ -152,7 +152,7 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 				pcOneRule[nCount].nLv = nLv;
 				pcOneRule[nCount].nLength = wcslen(pcOneRule[nCount].szMatch);
 				pcOneRule[nCount].nRegexOption = regexOption;
-				pcOneRule[nCount].nRegexMode = bRegexRep2 ? 1 : 0; // •¶š—ñ‚ª³‚µ‚¢‚¾‚¯ReplaceMode
+				pcOneRule[nCount].nRegexMode = bRegexRep2 ? 1 : 0; // æ–‡å­—åˆ—ãŒæ­£ã—ã„æ™‚ã ã‘ReplaceMode
 				nCount++;
 				if( bTopDummy || bRegex ){
 					pszToken = NULL;
@@ -207,17 +207,17 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 	return nCount;
 }
 
-/*! ƒ‹[ƒ‹ƒtƒ@ƒCƒ‹‚ğŒ³‚ÉAƒgƒsƒbƒNƒŠƒXƒg‚ğì¬
+/*! ãƒ«ãƒ¼ãƒ«ãƒ•ã‚¡ã‚¤ãƒ«ã‚’å…ƒã«ã€ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆã‚’ä½œæˆ
 
 	@date 2002.04.01 YAZAKI
-	@date 2002.11.03 Moca ƒlƒXƒg‚Ì[‚³‚ªÅ‘å’l‚ğ’´‚¦‚é‚Æƒoƒbƒtƒ@ƒI[ƒo[ƒ‰ƒ“‚·‚é‚Ì‚ğC³
-		Å‘å’lˆÈã‚Í’Ç‰Á‚¹‚¸‚É–³‹‚·‚é
-	@date 2007.11.29 kobake SOneRule test[1024] ‚ÅƒXƒ^ƒbƒN‚ªˆì‚ê‚Ä‚¢‚½‚Ì‚ğC³
+	@date 2002.11.03 Moca ãƒã‚¹ãƒˆã®æ·±ã•ãŒæœ€å¤§å€¤ã‚’è¶…ãˆã‚‹ã¨ãƒãƒƒãƒ•ã‚¡ã‚ªãƒ¼ãƒãƒ¼ãƒ©ãƒ³ã™ã‚‹ã®ã‚’ä¿®æ­£
+		æœ€å¤§å€¤ä»¥ä¸Šã¯è¿½åŠ ã›ãšã«ç„¡è¦–ã™ã‚‹
+	@date 2007.11.29 kobake SOneRule test[1024] ã§ã‚¹ã‚¿ãƒƒã‚¯ãŒæº¢ã‚Œã¦ã„ãŸã®ã‚’ä¿®æ­£
 */
 void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstring& sTitleOverride )
 {
-	/* ƒ‹[ƒ‹ƒtƒ@ƒCƒ‹‚Ì“à—e‚ğƒoƒbƒtƒ@‚É“Ç‚İ‚Ş */
-	auto_array_ptr<SOneRule> test(new SOneRule[1024]);	// 1024ŒÂ‹–‰ÂB 2007.11.29 kobake ƒXƒ^ƒbƒNg‚¢‚·‚¬‚È‚Ì‚ÅAƒq[ƒv‚ÉŠm•Û‚·‚é‚æ‚¤‚ÉC³B
+	/* ãƒ«ãƒ¼ãƒ«ãƒ•ã‚¡ã‚¤ãƒ«ã®å†…å®¹ã‚’ãƒãƒƒãƒ•ã‚¡ã«èª­ã¿è¾¼ã‚€ */
+	auto_array_ptr<SOneRule> test(new SOneRule[1024]);	// 1024å€‹è¨±å¯ã€‚ 2007.11.29 kobake ã‚¹ã‚¿ãƒƒã‚¯ä½¿ã„ã™ããªã®ã§ã€ãƒ’ãƒ¼ãƒ—ã«ç¢ºä¿ã™ã‚‹ã‚ˆã†ã«ä¿®æ­£ã€‚
 	bool bRegex;
 	std::wstring title;
 	int nCount = ReadRuleFile(m_pcDocRef->m_cDocType.GetDocumentAttribute().m_szOutlineRuleFilename, test.get(), 1024, bRegex, title );
@@ -228,14 +228,14 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 		sTitleOverride = to_tchar(title.c_str());
 	}
 
-	/*	ƒlƒXƒg‚Ì[‚³‚ÍA32ƒŒƒxƒ‹‚Ü‚ÅA‚Ğ‚Æ‚Â‚Ìƒwƒbƒ_‚ÍAÅ’·256•¶š‚Ü‚Å‹æ•Ê
-		i256•¶š‚Ü‚Å“¯‚¶‚¾‚Á‚½‚ç“¯‚¶‚à‚Ì‚Æ‚µ‚Äˆµ‚¢‚Ü‚·j
+	/*	ãƒã‚¹ãƒˆã®æ·±ã•ã¯ã€32ãƒ¬ãƒ™ãƒ«ã¾ã§ã€ã²ã¨ã¤ã®ãƒ˜ãƒƒãƒ€ã¯ã€æœ€é•·256æ–‡å­—ã¾ã§åŒºåˆ¥
+		ï¼ˆ256æ–‡å­—ã¾ã§åŒã˜ã ã£ãŸã‚‰åŒã˜ã‚‚ã®ã¨ã—ã¦æ‰±ã„ã¾ã™ï¼‰
 	*/
-	const int	nMaxStack = 32;	//	ƒlƒXƒg‚ÌÅ[
-	int			nDepth = 0;				//	‚¢‚Ü‚ÌƒAƒCƒeƒ€‚Ì[‚³‚ğ•\‚·”’lB
+	const int	nMaxStack = 32;	//	ãƒã‚¹ãƒˆã®æœ€æ·±
+	int			nDepth = 0;				//	ã„ã¾ã®ã‚¢ã‚¤ãƒ†ãƒ ã®æ·±ã•ã‚’è¡¨ã™æ•°å€¤ã€‚
 	wchar_t		pszStack[nMaxStack][256];
 	wchar_t		nLvStack[nMaxStack];
-	wchar_t		szTitle[256];			//	ˆê—Ìˆæ
+	wchar_t		szTitle[256];			//	ä¸€æ™‚é ˜åŸŸ
 	CBregexp*	pRegex = NULL;
 	if( bRegex ){
 		pRegex = new CBregexp[nCount];
@@ -269,8 +269,8 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 			}
 		}
 	}
-	// 1‚Â‚ß‚ª‹ós‚¾‚Á‚½ê‡‚ÍAƒ‹[ƒg—v‘f‚Æ‚·‚é
-	// €–Ú–¼‚ÍƒOƒ‹[ƒv–¼
+	// 1ã¤ã‚ãŒç©ºè¡Œã ã£ãŸå ´åˆã¯ã€ãƒ«ãƒ¼ãƒˆè¦ç´ ã¨ã™ã‚‹
+	// é …ç›®åã¯ã‚°ãƒ«ãƒ¼ãƒ—å
 	if( test[0].nLength == 0 ){
 		const wchar_t* g = test[0].szGroupName;
 		wcscpy(pszStack[0], g);
@@ -289,18 +289,18 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 	}
 	for( CLogicInt nLineCount = CLogicInt(0); nLineCount <  m_pcDocRef->m_cDocLineMgr.GetLineCount(); ++nLineCount )
 	{
-		//sæ“¾
+		//è¡Œå–å¾—
 		CLogicInt		nLineLen;
 		const wchar_t*	pLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLineCount)->GetDocLineStrWithEOL(&nLineLen);
 		if( NULL == pLine ){
 			break;
 		}
 
-		//s“ª‚Ì‹ó”’”ò‚Î‚µ
+		//è¡Œé ­ã®ç©ºç™½é£›ã°ã—
 		int		i = 0;
 		if( !bRegex ){
 			for( i = 0; i < nLineLen; ++i ){
-				if( pLine[i] == L' ' || pLine[i] == L'\t' || pLine[i] == L'@'){
+				if( pLine[i] == L' ' || pLine[i] == L'\t' || pLine[i] == L'ã€€'){
 					continue;
 				}
 				break;
@@ -310,7 +310,7 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 			}
 		}
 
-		//æ“ª•¶š‚ªŒ©o‚µ‹L†‚Ì‚¢‚¸‚ê‚©‚Å‚ ‚ê‚ÎAŸ‚Öi‚Ş
+		//å…ˆé ­æ–‡å­—ãŒè¦‹å‡ºã—è¨˜å·ã®ã„ãšã‚Œã‹ã§ã‚ã‚Œã°ã€æ¬¡ã¸é€²ã‚€
 		const wchar_t*		pszText = NULL;
 		std::wstring strText;
 		int		j;
@@ -324,8 +324,8 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 				}else{
 					if( 0 < test[j].nLength && 0 < pRegex[j].Replace( pLine, nLineLen, 0 ) ){
 						// pLine = "ABC123DEF"
-						// test‚ÌszMatch = "\d+"
-						// test‚ÌszText = "$&456"
+						// testã®szMatch = "\d+"
+						// testã®szText = "$&456"
 						// GetString() = "ABC123456DEF"
 						// pszText = "123456"
 						int nIndex = pRegex[j].GetIndex();
@@ -351,11 +351,11 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 			continue;
 		}
 
-		/*	ƒ‹[ƒ‹‚Éƒ}ƒbƒ`‚µ‚½s‚ÍAƒAƒEƒgƒ‰ƒCƒ“Œ‹‰Ê‚É•\¦‚·‚éB
+		/*	ãƒ«ãƒ¼ãƒ«ã«ãƒãƒƒãƒã—ãŸè¡Œã¯ã€ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³çµæœã«è¡¨ç¤ºã™ã‚‹ã€‚
 		*/
 
-		//s•¶š—ñ‚©‚ç‰üs‚ğæ‚èœ‚­ pLine -> pszText
-		// ³‹K•\Œ»’uŠ·‚Ì‚Æ‚«‚Íİ’èÏ‚İ
+		//è¡Œæ–‡å­—åˆ—ã‹ã‚‰æ”¹è¡Œã‚’å–ã‚Šé™¤ã pLine -> pszText
+		// æ­£è¦è¡¨ç¾ç½®æ›ã®ã¨ãã¯è¨­å®šæ¸ˆã¿
 		if( NULL == pszText ){
 			pszText = &pLine[i];
 			nLineLen -= i;
@@ -370,10 +370,10 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 		}
 
 		/*
-		  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-		  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-		  ¨
-		  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+		  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+		  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+		  â†’
+		  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 		*/
 		CLayoutPoint ptPos;
 		m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -381,7 +381,7 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 			&ptPos
 		);
 
-		/* nDepth‚ğŒvZ */
+		/* nDepthã‚’è¨ˆç®— */
 		int k;
 		bool bAppend = true;
 		for ( k = 0; k < nDepth; k++ ){
@@ -391,13 +391,13 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 			}
 		}
 		if ( k < nDepth ){
-			//	ƒ‹[ƒv“r’†‚Åbreak;‚µ‚Ä‚«‚½B¡‚Ü‚Å‚É“¯‚¶Œ©o‚µ‚ª‘¶İ‚µ‚Ä‚¢‚½B
-			//	‚Ì‚ÅA“¯‚¶ƒŒƒxƒ‹‚É‡‚í‚¹‚ÄAppendData.
+			//	ãƒ«ãƒ¼ãƒ—é€”ä¸­ã§break;ã—ã¦ããŸã€‚ï¼ä»Šã¾ã§ã«åŒã˜è¦‹å‡ºã—ãŒå­˜åœ¨ã—ã¦ã„ãŸã€‚
+			//	ã®ã§ã€åŒã˜ãƒ¬ãƒ™ãƒ«ã«åˆã‚ã›ã¦AppendData.
 			nDepth = k;
 		}
 		else if( nMaxStack > k ){
-			//	‚¢‚Ü‚Ü‚Å‚É“¯‚¶Œ©o‚µ‚ª‘¶İ‚µ‚È‚©‚Á‚½B
-			//	Lv‚ª‚‚¢ê‡‚ÍAˆê’v‚·‚é‚Ü‚Å‚³‚©‚Ì‚Ú‚é
+			//	ã„ã¾ã¾ã§ã«åŒã˜è¦‹å‡ºã—ãŒå­˜åœ¨ã—ãªã‹ã£ãŸã€‚
+			//	LvãŒé«˜ã„å ´åˆã¯ã€ä¸€è‡´ã™ã‚‹ã¾ã§ã•ã‹ã®ã¼ã‚‹
 			for ( k = nDepth - 1; 0 <= k ; k-- ){
 				if ( nLvStack[k] <= test[j].nLv ){
 					k++;
@@ -411,7 +411,7 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 			nLvStack[k] = test[j].nLv;
 			nDepth = k;
 		}else{
-			// 2002.11.03 Moca Å‘å’l‚ğ’´‚¦‚é‚Æƒoƒbƒtƒ@ƒI[ƒo[ƒ‰ƒ“‚·‚é‚©‚ç‹K§‚·‚é
+			// 2002.11.03 Moca æœ€å¤§å€¤ã‚’è¶…ãˆã‚‹ã¨ãƒãƒƒãƒ•ã‚¡ã‚ªãƒ¼ãƒãƒ¼ãƒ©ãƒ³ã™ã‚‹ã‹ã‚‰è¦åˆ¶ã™ã‚‹
 			// nDepth = nMaxStack;
 			bAppend = false;
 		}
@@ -427,12 +427,12 @@ void CDocOutline::MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr, std::tstri
 
 
 
-/*! ƒuƒbƒNƒ}[ƒNƒŠƒXƒgì¬i–³—–î—Ij
+/*! ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ãƒªã‚¹ãƒˆä½œæˆï¼ˆç„¡ç†çŸ¢ç†ï¼ï¼‰
 
-	@date 2001.12.03 hor   V‹Kì¬
-	@date 2002.01.19 aroka ‹ós‚ğƒ}[ƒN‘ÎÛ‚É‚·‚éƒtƒ‰ƒO bMarkUpBlankLineEnable ‚ğ“±“ü‚µ‚Ü‚µ‚½B
-	@date 2005.10.11 ryoji "‚@" ‚Ì‰E‚QƒoƒCƒg‚ª‘SŠp‹ó”’‚Æ”»’è‚³‚ê‚é–â‘è‚Ì‘Îˆ
-	@date 2005.11.03 genta •¶š—ñ’·C³D‰E’[‚ÌƒSƒ~‚ğœ‹
+	@date 2001.12.03 hor   æ–°è¦ä½œæˆ
+	@date 2002.01.19 aroka ç©ºè¡Œã‚’ãƒãƒ¼ã‚¯å¯¾è±¡ã«ã™ã‚‹ãƒ•ãƒ©ã‚° bMarkUpBlankLineEnable ã‚’å°å…¥ã—ã¾ã—ãŸã€‚
+	@date 2005.10.11 ryoji "ï½@" ã®å³ï¼’ãƒã‚¤ãƒˆãŒå…¨è§’ç©ºç™½ã¨åˆ¤å®šã•ã‚Œã‚‹å•é¡Œã®å¯¾å‡¦
+	@date 2005.11.03 genta æ–‡å­—åˆ—é•·ä¿®æ­£ï¼å³ç«¯ã®ã‚´ãƒŸã‚’é™¤å»
 */
 void CDocOutline::MakeFuncList_BookMark( CFuncInfoArr* pcFuncInfoArr )
 {
@@ -440,7 +440,7 @@ void CDocOutline::MakeFuncList_BookMark( CFuncInfoArr* pcFuncInfoArr )
 	CLogicInt		nLineLen;
 	CLogicInt		nLineCount;
 	int		leftspace, pos_wo_space, k;
-	BOOL	bMarkUpBlankLineEnable = GetDllShareData().m_Common.m_sOutline.m_bMarkUpBlankLineEnable;	//! ‹ós‚ğƒ}[ƒN‘ÎÛ‚É‚·‚éƒtƒ‰ƒO 20020119 aroka
+	BOOL	bMarkUpBlankLineEnable = GetDllShareData().m_Common.m_sOutline.m_bMarkUpBlankLineEnable;	//! ç©ºè¡Œã‚’ãƒãƒ¼ã‚¯å¯¾è±¡ã«ã™ã‚‹ãƒ•ãƒ©ã‚° 20020119 aroka
 	int		nNewLineLen	= m_pcDocRef->m_cDocEditor.m_cNewLineCode.GetLen();
 	CLogicInt	nLineLast	= m_pcDocRef->m_cDocLineMgr.GetLineCount();
 	int		nCharChars;
@@ -470,7 +470,7 @@ void CDocOutline::MakeFuncList_BookMark( CFuncInfoArr* pcFuncInfoArr )
 				continue;
 			}
 		}// RTrim
-		// 2005.10.11 ryoji ‰E‚©‚ç‘k‚é‚Ì‚Å‚Í‚È‚­¶‚©‚ç’T‚·‚æ‚¤‚ÉC³i"‚@" ‚Ì‰E‚QƒoƒCƒg‚ª‘SŠp‹ó”’‚Æ”»’è‚³‚ê‚é–â‘è‚Ì‘Îˆj
+		// 2005.10.11 ryoji å³ã‹ã‚‰é¡ã‚‹ã®ã§ã¯ãªãå·¦ã‹ã‚‰æ¢ã™ã‚ˆã†ã«ä¿®æ­£ï¼ˆ"ï½@" ã®å³ï¼’ãƒã‚¤ãƒˆãŒå…¨è§’ç©ºç™½ã¨åˆ¤å®šã•ã‚Œã‚‹å•é¡Œã®å¯¾å‡¦ï¼‰
 		k = pos_wo_space = leftspace;
 		bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 		while( k < nLineLen ){
@@ -485,7 +485,7 @@ void CDocOutline::MakeFuncList_BookMark( CFuncInfoArr* pcFuncInfoArr )
 			}
 			k += nCharChars;
 		}
-		//	Nov. 3, 2005 genta •¶š—ñ’·ŒvZ®‚ÌC³
+		//	Nov. 3, 2005 genta æ–‡å­—åˆ—é•·è¨ˆç®—å¼ã®ä¿®æ­£
 		std::wstring strText( &pLine[leftspace], pos_wo_space - leftspace );
 
 		CLayoutPoint ptXY;

--- a/sakura_core/doc/CDocOutline.h
+++ b/sakura_core/doc/CDocOutline.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -32,22 +32,22 @@ class CDocOutline{
 public:
 	CDocOutline(CEditDoc* pcDoc) : m_pcDocRef(pcDoc) { }
 	void	MakeFuncList_C( CFuncInfoArr*, EOutlineType& nOutlineType, const TCHAR* pszFileName,
-		bool bVisibleMemberFunc = true );					//!< C/C++ŠÖ”ƒŠƒXƒgì¬
-	void	MakeFuncList_PLSQL( CFuncInfoArr* );											//!< PL/SQLŠÖ”ƒŠƒXƒgì¬
-	void	MakeTopicList_txt( CFuncInfoArr* );												//!< ƒeƒLƒXƒgEƒgƒsƒbƒNƒŠƒXƒgì¬
-	void	MakeFuncList_Java( CFuncInfoArr* );												//!< JavaŠÖ”ƒŠƒXƒgì¬
-	void	MakeTopicList_cobol( CFuncInfoArr* );											//!< COBOL ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ
-	void	MakeTopicList_asm( CFuncInfoArr* );												//!< ƒAƒZƒ“ƒuƒ‰ ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ
-	void	MakeFuncList_Perl( CFuncInfoArr* );												//!< PerlŠÖ”ƒŠƒXƒgì¬	//	Sep. 8, 2000 genta
-	void	MakeFuncList_VisualBasic( CFuncInfoArr* );										//!< Visual BasicŠÖ”ƒŠƒXƒgì¬ //June 23, 2001 N.Nakatani
-	void	MakeFuncList_python( CFuncInfoArr* pcFuncInfoArr );								//!< Python ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ // 2007.02.08 genta
-	void	MakeFuncList_Erlang( CFuncInfoArr* pcFuncInfoArr );								//!< Erlang ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ // 2009.08.10 genta
-	void	MakeTopicList_wztxt(CFuncInfoArr*);												//!< ŠK‘w•t‚«ƒeƒLƒXƒg ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ // 2003.05.20 zenryaku
-	void	MakeTopicList_html(CFuncInfoArr*, bool bXml);									//!< HTML ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ // 2003.05.20 zenryaku
-	void	MakeTopicList_tex(CFuncInfoArr*);												//!< TeX ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ // 2003.07.20 naoh
-	void	MakeFuncList_RuleFile( CFuncInfoArr*, std::tstring& );											//!< ƒ‹[ƒ‹ƒtƒ@ƒCƒ‹‚ðŽg‚Á‚ÄƒŠƒXƒgì¬ 2002.04.01 YAZAKI
-	int		ReadRuleFile( const TCHAR*, SOneRule*, int, bool&, std::wstring& );	//!< ƒ‹[ƒ‹ƒtƒ@ƒCƒ‹“Çž 2002.04.01 YAZAKI
-	void	MakeFuncList_BookMark( CFuncInfoArr* );											//!< ƒuƒbƒNƒ}[ƒNƒŠƒXƒgì¬ //2001.12.03 hor
+		bool bVisibleMemberFunc = true );					//!< C/C++é–¢æ•°ãƒªã‚¹ãƒˆä½œæˆ
+	void	MakeFuncList_PLSQL( CFuncInfoArr* );											//!< PL/SQLé–¢æ•°ãƒªã‚¹ãƒˆä½œæˆ
+	void	MakeTopicList_txt( CFuncInfoArr* );												//!< ãƒ†ã‚­ã‚¹ãƒˆãƒ»ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆä½œæˆ
+	void	MakeFuncList_Java( CFuncInfoArr* );												//!< Javaé–¢æ•°ãƒªã‚¹ãƒˆä½œæˆ
+	void	MakeTopicList_cobol( CFuncInfoArr* );											//!< COBOL ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æž
+	void	MakeTopicList_asm( CFuncInfoArr* );												//!< ã‚¢ã‚»ãƒ³ãƒ–ãƒ© ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æž
+	void	MakeFuncList_Perl( CFuncInfoArr* );												//!< Perlé–¢æ•°ãƒªã‚¹ãƒˆä½œæˆ	//	Sep. 8, 2000 genta
+	void	MakeFuncList_VisualBasic( CFuncInfoArr* );										//!< Visual Basicé–¢æ•°ãƒªã‚¹ãƒˆä½œæˆ //June 23, 2001 N.Nakatani
+	void	MakeFuncList_python( CFuncInfoArr* pcFuncInfoArr );								//!< Python ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æž // 2007.02.08 genta
+	void	MakeFuncList_Erlang( CFuncInfoArr* pcFuncInfoArr );								//!< Erlang ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æž // 2009.08.10 genta
+	void	MakeTopicList_wztxt(CFuncInfoArr*);												//!< éšŽå±¤ä»˜ããƒ†ã‚­ã‚¹ãƒˆ ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æž // 2003.05.20 zenryaku
+	void	MakeTopicList_html(CFuncInfoArr*, bool bXml);									//!< HTML ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æž // 2003.05.20 zenryaku
+	void	MakeTopicList_tex(CFuncInfoArr*);												//!< TeX ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æž // 2003.07.20 naoh
+	void	MakeFuncList_RuleFile( CFuncInfoArr*, std::tstring& );											//!< ãƒ«ãƒ¼ãƒ«ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½¿ã£ã¦ãƒªã‚¹ãƒˆä½œæˆ 2002.04.01 YAZAKI
+	int		ReadRuleFile( const TCHAR*, SOneRule*, int, bool&, std::wstring& );	//!< ãƒ«ãƒ¼ãƒ«ãƒ•ã‚¡ã‚¤ãƒ«èª­è¾¼ 2002.04.01 YAZAKI
+	void	MakeFuncList_BookMark( CFuncInfoArr* );											//!< ãƒ–ãƒƒã‚¯ãƒžãƒ¼ã‚¯ãƒªã‚¹ãƒˆä½œæˆ //2001.12.03 hor
 private:
 	CEditDoc* m_pcDocRef;
 };

--- a/sakura_core/doc/CDocReader.cpp
+++ b/sakura_core/doc/CDocReader.cpp
@@ -1,12 +1,12 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "CDocReader.h"
 #include "logic/CDocLine.h"
 #include "logic/CDocLineMgr.h"
 
-/* ‘Ssƒf[ƒ^‚ğ•Ô‚·
-	‰üsƒR[ƒh‚ÍACFLF“ˆê‚³‚ê‚éB
-	@retval ‘Ssƒf[ƒ^Bfree‚ÅŠJ•ú‚µ‚È‚¯‚ê‚Î‚È‚ç‚È‚¢B
-	@note   Debug”Å‚ÌƒeƒXƒg‚É‚Ì‚İg—p‚µ‚Ä‚¢‚éB
+/* å…¨è¡Œãƒ‡ãƒ¼ã‚¿ã‚’è¿”ã™
+	æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã¯ã€CFLFçµ±ä¸€ã•ã‚Œã‚‹ã€‚
+	@retval å…¨è¡Œãƒ‡ãƒ¼ã‚¿ã€‚freeã§é–‹æ”¾ã—ãªã‘ã‚Œã°ãªã‚‰ãªã„ã€‚
+	@note   Debugç‰ˆã®ãƒ†ã‚¹ãƒˆã«ã®ã¿ä½¿ç”¨ã—ã¦ã„ã‚‹ã€‚
 */
 wchar_t* CDocReader::GetAllData(int* pnDataLen)
 {
@@ -18,7 +18,7 @@ wchar_t* CDocReader::GetAllData(int* pnDataLen)
 	nDataLen = 0;
 	while( NULL != pDocLine ){
 		//	Oct. 7, 2002 YAZAKI
-		nDataLen += pDocLine->GetLengthWithoutEOL() + 2;	//	\r\n‚ğ’Ç‰Á‚µ‚Ä•Ô‚·‚½‚ß+2‚·‚éB
+		nDataLen += pDocLine->GetLengthWithoutEOL() + 2;	//	\r\nã‚’è¿½åŠ ã—ã¦è¿”ã™ãŸã‚+2ã™ã‚‹ã€‚
 		pDocLine = pDocLine->GetNextLine();
 	}
 
@@ -56,13 +56,13 @@ const wchar_t* CDocReader::GetLineStr( CLogicInt nLine, CLogicInt* pnLineLen )
 		*pnLineLen = CLogicInt(0);
 		return NULL;
 	}
-	// 2002/2/10 aroka CMemory ‚Ìƒƒ“ƒo•Ï”‚É’¼ÚƒAƒNƒZƒX‚µ‚È‚¢(inline‰»‚³‚ê‚Ä‚¢‚é‚Ì‚Å‘¬“x“I‚È–â‘è‚Í‚È‚¢)
+	// 2002/2/10 aroka CMemory ã®ãƒ¡ãƒ³ãƒå¤‰æ•°ã«ç›´æ¥ã‚¢ã‚¯ã‚»ã‚¹ã—ãªã„(inlineåŒ–ã•ã‚Œã¦ã„ã‚‹ã®ã§é€Ÿåº¦çš„ãªå•é¡Œã¯ãªã„)
 	return pDocLine->GetDocLineStrWithEOL( pnLineLen );
 }
 
 
 /*!
-	w’è‚³‚ê‚½s”Ô†‚Ì•¶š—ñ‚Æ‰üsƒR[ƒh‚ğœ‚­’·‚³‚ğæ“¾
+	æŒ‡å®šã•ã‚ŒãŸè¡Œç•ªå·ã®æ–‡å­—åˆ—ã¨æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’é™¤ãé•·ã•ã‚’å–å¾—
 	
 	@author Moca
 	@date 2003.06.22
@@ -81,11 +81,11 @@ const wchar_t* CDocReader::GetLineStrWithoutEOL( CLogicInt nLine, int* pnLineLen
 
 
 
-/*! ‡ƒAƒNƒZƒXƒ‚[ƒhFæ“ªs‚ğ“¾‚é
+/*! é †ã‚¢ã‚¯ã‚»ã‚¹ãƒ¢ãƒ¼ãƒ‰ï¼šå…ˆé ­è¡Œã‚’å¾—ã‚‹
 
-	@param pnLineLen [out] s‚Ì’·‚³‚ª•Ô‚éB
-	@return 1s–Ú‚Ìæ“ª‚Ö‚Ìƒ|ƒCƒ“ƒ^B
-	ƒf[ƒ^‚ª1s‚à‚È‚¢‚Æ‚«‚ÍA’·‚³0Aƒ|ƒCƒ“ƒ^NULL‚ª•Ô‚éB
+	@param pnLineLen [out] è¡Œã®é•·ã•ãŒè¿”ã‚‹ã€‚
+	@return 1è¡Œç›®ã®å…ˆé ­ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã€‚
+	ãƒ‡ãƒ¼ã‚¿ãŒ1è¡Œã‚‚ãªã„ã¨ãã¯ã€é•·ã•0ã€ãƒã‚¤ãƒ³ã‚¿NULLãŒè¿”ã‚‹ã€‚
 
 */
 const wchar_t* CDocReader::GetFirstLinrStr( int* pnLineLen )
@@ -107,11 +107,11 @@ const wchar_t* CDocReader::GetFirstLinrStr( int* pnLineLen )
 
 
 /*!
-	‡ƒAƒNƒZƒXƒ‚[ƒhFŸ‚Ìs‚ğ“¾‚é
+	é †ã‚¢ã‚¯ã‚»ã‚¹ãƒ¢ãƒ¼ãƒ‰ï¼šæ¬¡ã®è¡Œã‚’å¾—ã‚‹
 
-	@param pnLineLen [out] s‚Ì’·‚³‚ª•Ô‚éB
-	@return Ÿs‚Ìæ“ª‚Ö‚Ìƒ|ƒCƒ“ƒ^B
-	GetFirstLinrStr()‚ªŒÄ‚Ño‚³‚ê‚Ä‚¢‚È‚¢‚ÆNULL‚ª•Ô‚é
+	@param pnLineLen [out] è¡Œã®é•·ã•ãŒè¿”ã‚‹ã€‚
+	@return æ¬¡è¡Œã®å…ˆé ­ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã€‚
+	GetFirstLinrStr()ãŒå‘¼ã³å‡ºã•ã‚Œã¦ã„ãªã„ã¨NULLãŒè¿”ã‚‹
 
 */
 const wchar_t* CDocReader::GetNextLinrStr( int* pnLineLen )

--- a/sakura_core/doc/CDocReader.h
+++ b/sakura_core/doc/CDocReader.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -31,11 +31,11 @@ class CDocReader{
 public:
 	CDocReader(const CDocLineMgr& pcDocLineMgr) : m_pcDocLineMgr(&pcDocLineMgr) { }
 
-	wchar_t* GetAllData(int* pnDataLen);	/* ‘Ssƒf[ƒ^‚ğ•Ô‚· */
+	wchar_t* GetAllData(int* pnDataLen);	/* å…¨è¡Œãƒ‡ãƒ¼ã‚¿ã‚’è¿”ã™ */
 	const wchar_t* GetLineStr( CLogicInt , CLogicInt* );
 	const wchar_t* GetLineStrWithoutEOL( CLogicInt , int* ); // 2003.06.22 Moca
-	const wchar_t* GetFirstLinrStr( int* );	/* ‡ƒAƒNƒZƒXƒ‚[ƒhFæ“ªs‚ğ“¾‚é */
-	const wchar_t* GetNextLinrStr( int* );	/* ‡ƒAƒNƒZƒXƒ‚[ƒhFŸ‚Ìs‚ğ“¾‚é */
+	const wchar_t* GetFirstLinrStr( int* );	/* é †ã‚¢ã‚¯ã‚»ã‚¹ãƒ¢ãƒ¼ãƒ‰ï¼šå…ˆé ­è¡Œã‚’å¾—ã‚‹ */
+	const wchar_t* GetNextLinrStr( int* );	/* é †ã‚¢ã‚¯ã‚»ã‚¹ãƒ¢ãƒ¼ãƒ‰ï¼šæ¬¡ã®è¡Œã‚’å¾—ã‚‹ */
 
 private:
 	const CDocLineMgr* m_pcDocLineMgr;

--- a/sakura_core/doc/CDocType.cpp
+++ b/sakura_core/doc/CDocType.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -36,24 +36,24 @@ CDocType::CDocType(CEditDoc* pcDoc)
 : m_pcDocRef(pcDoc)
 , m_nSettingType( 0 )			// Sep. 11, 2002 genta
 , m_typeConfig( GetDllShareData().m_TypeBasis )
-, m_nSettingTypeLocked( false )	//	�ݒ�l�ύX�\�t���O
+, m_nSettingTypeLocked( false )	//	設定値変更可能フラグ
 {
 }
 
-//! ������ʂ̐ݒ�
+//! 文書種別の設定
 void CDocType::SetDocumentType(CTypeConfig type, bool force, bool bTypeOnly )
 {
 	if( !m_nSettingTypeLocked || force ){
 		m_nSettingType = type;
 		if( false == CDocTypeManager().GetTypeConfig( m_nSettingType, m_typeConfig ) ){
-			// �폜����Ă�/�s��
+			// 削除されてる/不正
 			m_nSettingType = CDocTypeManager().GetDocumentTypeOfPath(m_pcDocRef->m_cDocFile.GetFilePath());
 			CDocTypeManager().GetTypeConfig( m_nSettingType, m_typeConfig );
 		}
-		if( bTypeOnly ) return;	// bTypeOnly == true �͓���P�[�X�i�ꎞ���p�j�Ɍ���
+		if( bTypeOnly ) return;	// bTypeOnly == true は特殊ケース（一時利用）に限定
 		UnlockDocumentType();
 	}else{
-		// �f�[�^�͍X�V���Ă���
+		// データは更新しておく
 		CTypeConfig temp = CDocTypeManager().GetDocumentTypeOfId( m_typeConfig.m_id );
 		if( temp.IsValidType() ){
 			m_nSettingType = temp;
@@ -68,7 +68,7 @@ void CDocType::SetDocumentType(CTypeConfig type, bool force, bool bTypeOnly )
 		if( bTypeOnly ) return;
 	}
 
-	// �^�C�v�ʐݒ�X�V�𔽉f
+	// タイプ別設定更新を反映
 	CColorStrategyPool::getInstance()->OnChangeSetting();
 	CFigureManager::getInstance()->OnChangeSetting();
 	this->SetDocumentIcon();	// Sep. 11, 2002 genta
@@ -91,17 +91,17 @@ void CDocType::SetDocumentTypeIdx( int id, bool force )
 	}
 }
 /*!
-	�A�C�R���̐ݒ�
+	アイコンの設定
 	
-	�^�C�v�ʐݒ�ɉ����ăE�B���h�E�A�C�R�����t�@�C���Ɋ֘A�Â���ꂽ���C
-	�܂��͕W���̂��̂ɐݒ肷��D
+	タイプ別設定に応じてウィンドウアイコンをファイルに関連づけられた物，
+	または標準のものに設定する．
 	
 	@author genta
 	@date 2002.09.10
 */
 void CDocType::SetDocumentIcon()
 {
-	if( CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode )	// Grep���[�h�̎��̓A�C�R����ύX���Ȃ�
+	if( CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode )	// Grepモードの時はアイコンを変更しない
 		return;
 	
 	HICON	hIconBig, hIconSmall;

--- a/sakura_core/doc/CDocType.h
+++ b/sakura_core/doc/CDocType.h
@@ -1,7 +1,7 @@
-/*
-	ƒhƒLƒ…ƒƒ“ƒgí•Ê‚ÌŠÇ—
+ï»¿/*
+	ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆç¨®åˆ¥ã®ç®¡ç†
 
-	2008.01`03 kobake ì¬
+	2008.01ï½03 kobake ä½œæˆ
 */
 /*
 	Copyright (C) 2008, kobake
@@ -34,38 +34,38 @@
 
 class CDocType{
 public:
-	//¶¬‚Æ”jŠü
+	//ç”Ÿæˆã¨ç ´æ£„
 	CDocType(CEditDoc* pcDoc);
 	
-	//ƒƒbƒN‹@”\	//	Nov. 29, 2000 genta İ’è‚Ìˆê•ÏX‚ÉŠg’£q‚É‚æ‚é‹­§“I‚Èİ’è•ÏX‚ğ–³Œø‚É‚·‚é
+	//ãƒ­ãƒƒã‚¯æ©Ÿèƒ½	//	Nov. 29, 2000 genta è¨­å®šã®ä¸€æ™‚å¤‰æ›´æ™‚ã«æ‹¡å¼µå­ã«ã‚ˆã‚‹å¼·åˆ¶çš„ãªè¨­å®šå¤‰æ›´ã‚’ç„¡åŠ¹ã«ã™ã‚‹
 	void LockDocumentType(){ m_nSettingTypeLocked = true; }
 	void UnlockDocumentType(){ m_nSettingTypeLocked = false; }
 	bool GetDocumentLockState(){ return m_nSettingTypeLocked; }
 	
-	// •¶‘í•Ê‚Ìİ’è‚Ææ“¾		// Nov. 23, 2000 genta
-	void SetDocumentType(CTypeConfig type, bool force, bool bTypeOnly = false);	//!< •¶‘í•Ê‚Ìİ’è
+	// æ–‡æ›¸ç¨®åˆ¥ã®è¨­å®šã¨å–å¾—		// Nov. 23, 2000 genta
+	void SetDocumentType(CTypeConfig type, bool force, bool bTypeOnly = false);	//!< æ–‡æ›¸ç¨®åˆ¥ã®è¨­å®š
 	void SetDocumentTypeIdx( int id = -1, bool force = false);
-	CTypeConfig GetDocumentType() const					//!< •¶‘í•Ê‚Ìæ“¾
+	CTypeConfig GetDocumentType() const					//!< æ–‡æ›¸ç¨®åˆ¥ã®å–å¾—
 	{
 		return m_nSettingType;
 	}
-	const STypeConfig& GetDocumentAttribute() const						//!< •¶‘í•Ê‚ÌÚ×î•ñ
+	const STypeConfig& GetDocumentAttribute() const						//!< æ–‡æ›¸ç¨®åˆ¥ã®è©³ç´°æƒ…å ±
 	{
 		return m_typeConfig;
 	}
-	STypeConfig& GetDocumentAttributeWrite()						//!< •¶‘í•Ê‚ÌÚ×î•ñ
+	STypeConfig& GetDocumentAttributeWrite()						//!< æ–‡æ›¸ç¨®åˆ¥ã®è©³ç´°æƒ…å ±
 	{
 		return m_typeConfig;
 	}
 
-	// Šg’£‹@”\
-	void SetDocumentIcon();	//ƒAƒCƒRƒ“‚Ìİ’è	//Sep. 10, 2002 genta
+	// æ‹¡å¼µæ©Ÿèƒ½
+	void SetDocumentIcon();	//ã‚¢ã‚¤ã‚³ãƒ³ã®è¨­å®š	//Sep. 10, 2002 genta
 
 private:
 	CEditDoc*				m_pcDocRef;
 	CTypeConfig				m_nSettingType;
 	STypeConfig				m_typeConfig;
-	bool					m_nSettingTypeLocked;		//!< •¶‘í•Ê‚Ìˆêİ’èó‘Ô
+	bool					m_nSettingTypeLocked;		//!< æ–‡æ›¸ç¨®åˆ¥ã®ä¸€æ™‚è¨­å®šçŠ¶æ…‹
 };
 
 #endif /* SAKURA_CDOCTYPE_BB51F346_E9F1_42DD_8B28_2F5BAFCE7CE09_H_ */

--- a/sakura_core/doc/CDocTypeSetting.cpp
+++ b/sakura_core/doc/CDocTypeSetting.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -22,24 +22,24 @@
 		   distribution.
 */
 
-// 2000.10.08 JEPRO  �w�i�F��^����RGB(255,255,255)��(255,251,240)�ɕύX(ῂ�������������)
-// 2000.12.09 Jepro  note: color setting (�ڍׂ� CshareData.h ���Q�Ƃ̂���)
-// 2000.09.04 JEPRO  �V���O���N�H�[�e�[�V����������ɐF�����蓖�Ă邪�F�����\���͂��Ȃ�
-// 2000.10.17 JEPRO  �F�����\������悤�ɕύX(�ŏ���FALSE��TRUE)
-// 2008.03.27 kobake �吮��
+// 2000.10.08 JEPRO  背景色を真っ白RGB(255,255,255)→(255,251,240)に変更(眩しさを押さえた)
+// 2000.12.09 Jepro  note: color setting (詳細は CshareData.h を参照のこと)
+// 2000.09.04 JEPRO  シングルクォーテーション文字列に色を割り当てるが色分け表示はしない
+// 2000.10.17 JEPRO  色分け表示するように変更(最初のFALSE→TRUE)
+// 2008.03.27 kobake 大整理
 
 #include "StdAfx.h"
 #include "CDocTypeSetting.h"
 
 
-//! �F�ݒ�(�ۑ��p)
+//! 色設定(保存用)
 struct ColorInfoIni {
-	int				m_nNameId;			//!< ���ږ�
-	ColorInfoBase	m_sColorInfo;		//!< �F�ݒ�
+	int				m_nNameId;			//!< 項目名
+	ColorInfoBase	m_sColorInfo;		//!< 色設定
 };
 
 static ColorInfoIni ColorInfo_DEFAULT[] = {
-//	���ږ�,									�\��,		����,		����,		�����F,					�w�i�F,
+//	項目名,									表示,		太字,		下線,		文字色,					背景色,
 	{ STR_COLOR_TEXT,						{ TRUE,		{ FALSE,	FALSE },	{ RGB(   0,   0,   0 ),	RGB( 255, 251, 240 ) } } },
 	{ STR_COLOR_RULER,						{ TRUE,		{ FALSE,	FALSE },	{ RGB(   0,   0,   0 ),	RGB( 239, 239, 239 ) } } },
 	{ STR_COLOR_CURSOR,						{ TRUE,		{ FALSE,	FALSE },	{ RGB(   0,   0,   0 ),	RGB( 255, 251, 240 ) } } },	// 2006.12.07 ryoji
@@ -51,7 +51,7 @@ static ColorInfoIni ColorInfo_DEFAULT[] = {
 	{ STR_COLOR_LINE_NO,					{ TRUE,		{ FALSE,	FALSE },	{ RGB(   0,   0, 255 ),	RGB( 239, 239, 239 ) } } },
 	{ STR_COLOR_LINE_NO_CHANGE,				{ TRUE,		{ TRUE,		FALSE },	{ RGB(   0,   0, 255 ),	RGB( 239, 239, 239 ) } } },
 	{ STR_COLOR_EVEN_LINE_BG,				{ FALSE,	{ FALSE,	FALSE },	{ RGB(   0,   0,   0 ),	RGB( 243, 243, 243 ) } } },	// 2013.12.30 Moca
-	{ STR_COLOR_TAB,						{ TRUE,		{ FALSE,	FALSE },	{ RGB( 128, 128, 128 ),	RGB( 255, 251, 240 ) } } },	//Jan. 19, 2001 JEPRO RGB(192,192,192)���Z���O���[�ɕύX
+	{ STR_COLOR_TAB,						{ TRUE,		{ FALSE,	FALSE },	{ RGB( 128, 128, 128 ),	RGB( 255, 251, 240 ) } } },	//Jan. 19, 2001 JEPRO RGB(192,192,192)より濃いグレーに変更
 	{ STR_COLOR_HALF_SPACE,					{ FALSE,	{ FALSE,	FALSE },	{ RGB( 192, 192, 192 ),	RGB( 255, 251, 240 ) } } }, //2002.04.28 Add by KK
 	{ STR_COLOR_FULL_SPACE,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 192, 192, 192 ),	RGB( 255, 251, 240 ) } } },
 	{ STR_COLOR_CTRL_CODE,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 255, 255,   0 ),	RGB( 255, 251, 240 ) } } },
@@ -59,7 +59,7 @@ static ColorInfoIni ColorInfo_DEFAULT[] = {
 	{ STR_COLOR_WRAP_MARK,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 255,   0, 255 ),	RGB( 255, 251, 240 ) } } },
 	{ STR_COLOR_VERT_LINE,					{ FALSE,	{ FALSE,	FALSE },	{ RGB( 192, 192, 192 ),	RGB( 255, 251, 240 ) } } }, //2005.11.08 Moca
 	{ STR_COLOR_EOF,						{ TRUE,		{ FALSE,	FALSE },	{ RGB(   0, 255, 255 ),	RGB(   0,   0,   0 ) } } },
-	{ STR_COLOR_NUMBER,						{ FALSE,	{ FALSE,	FALSE },	{ RGB( 235,   0,   0 ),	RGB( 255, 251, 240 ) } } },	//@@@ 2001.02.17 by MIK		//Mar. 7, 2001 JEPRO RGB(0,0,255)��ύX  Mar.10, 2001 �W���͐F�Ȃ���
+	{ STR_COLOR_NUMBER,						{ FALSE,	{ FALSE,	FALSE },	{ RGB( 235,   0,   0 ),	RGB( 255, 251, 240 ) } } },	//@@@ 2001.02.17 by MIK		//Mar. 7, 2001 JEPRO RGB(0,0,255)を変更  Mar.10, 2001 標準は色なしに
 	{ STR_COLOR_BRACKET,					{ FALSE,	{ TRUE,		FALSE },	{ RGB( 128,   0,   0 ),	RGB( 255, 251, 240 ) } } },	// 02/09/18 ai
 	{ STR_COLOR_SELECTED_AREA,				{ TRUE,		{ FALSE,	FALSE },	{ RGB(  49, 106, 197 ),	RGB(  49, 106, 197 ) } } },	//2011.05.18
 	{ STR_COLOR_SEARCH_WORD1,				{ TRUE,		{ FALSE,	FALSE },	{ RGB(   0,   0,   0 ),	RGB( 255, 255,   0 ) } } },
@@ -73,8 +73,8 @@ static ColorInfoIni ColorInfo_DEFAULT[] = {
 	{ STR_COLOR_HERE_DOCUMENT,				{ FALSE,	{ FALSE,	FALSE },	{ RGB( 128,   0,  64 ),	RGB( 255, 251, 240 ) } } },
 	{ STR_COLOR_URL,						{ TRUE,		{ FALSE,	TRUE  },	{ RGB(   0,   0, 255 ),	RGB( 255, 251, 240 ) } } },
 	{ STR_COLOR_KEYWORD1,					{ TRUE,		{ FALSE,	FALSE },	{ RGB(   0,   0, 255 ),	RGB( 255, 251, 240 ) } } },
-	{ STR_COLOR_KEYWORD2,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 255, 128,   0 ),	RGB( 255, 251, 240 ) } } },	//Dec. 4, 2000 MIK added	//Jan. 19, 2001 JEPRO �L�[���[�h1�Ƃ͈Ⴄ�F�ɕύX
-	{ STR_COLOR_KEYWORD3,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 255, 128,   0 ),	RGB( 255, 251, 240 ) } } },	//Dec. 4, 2000 MIK added	//Jan. 19, 2001 JEPRO �L�[���[�h1�Ƃ͈Ⴄ�F�ɕύX
+	{ STR_COLOR_KEYWORD2,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 255, 128,   0 ),	RGB( 255, 251, 240 ) } } },	//Dec. 4, 2000 MIK added	//Jan. 19, 2001 JEPRO キーワード1とは違う色に変更
+	{ STR_COLOR_KEYWORD3,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 255, 128,   0 ),	RGB( 255, 251, 240 ) } } },	//Dec. 4, 2000 MIK added	//Jan. 19, 2001 JEPRO キーワード1とは違う色に変更
 	{ STR_COLOR_KEYWORD4,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 255, 128,   0 ),	RGB( 255, 251, 240 ) } } },
 	{ STR_COLOR_KEYWORD5,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 255, 128,   0 ),	RGB( 255, 251, 240 ) } } },
 	{ STR_COLOR_KEYWORD6,					{ TRUE,		{ FALSE,	FALSE },	{ RGB( 255, 128,   0 ),	RGB( 255, 251, 240 ) } } },

--- a/sakura_core/doc/CDocTypeSetting.h
+++ b/sakura_core/doc/CDocTypeSetting.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,36 +25,36 @@
 #define SAKURA_CDOCTYPESETTING_28058D99_2101_4488_A634_832BD50A2F3C9_H_
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          Fİ’è                             //
+//                          è‰²è¨­å®š                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! ƒtƒHƒ“ƒg‘®«
+//! ãƒ•ã‚©ãƒ³ãƒˆå±æ€§
 struct SFontAttr{
-	bool		m_bBoldFont;		//!< ‘¾š
-	bool		m_bUnderLine;		//!< ‰ºü
+	bool		m_bBoldFont;		//!< å¤ªå­—
+	bool		m_bUnderLine;		//!< ä¸‹ç·š
 };
 
-//! F‘®«
+//! è‰²å±æ€§
 struct SColorAttr{
-	COLORREF	m_cTEXT;			//!< •¶šF
-	COLORREF	m_cBACK;			//!< ”wŒiF
+	COLORREF	m_cTEXT;			//!< æ–‡å­—è‰²
+	COLORREF	m_cBACK;			//!< èƒŒæ™¯è‰²
 };
 
-//! Fİ’è
+//! è‰²è¨­å®š
 struct ColorInfoBase{
-	bool		m_bDisp;			//!< •\¦
-	SFontAttr	m_sFontAttr;		//!< ƒtƒHƒ“ƒg‘®«
-	SColorAttr	m_sColorAttr;		//!< F‘®«
+	bool		m_bDisp;			//!< è¡¨ç¤º
+	SFontAttr	m_sFontAttr;		//!< ãƒ•ã‚©ãƒ³ãƒˆå±æ€§
+	SColorAttr	m_sColorAttr;		//!< è‰²å±æ€§
 };
 
-//! –¼‘O‚ÆƒCƒ“ƒfƒbƒNƒX•t‚«Fİ’è
+//! åå‰ã¨ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ä»˜ãè‰²è¨­å®š
 struct ColorInfo : public ColorInfoBase{
-	int			m_nColorIdx;		//!< ƒCƒ“ƒfƒbƒNƒX
-	TCHAR		m_szName[64];		//!< –¼‘O
+	int			m_nColorIdx;		//!< ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹
+	TCHAR		m_szName[64];		//!< åå‰
 };
 
 
-//ƒfƒtƒHƒ‹ƒgFİ’è
+//ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè‰²è¨­å®š
 void GetDefaultColorInfo( ColorInfo* pColorInfo, int nIndex );
 void GetDefaultColorInfoName( ColorInfo* pColorInfo, int nIndex );
 int GetDefaultColorInfoCount();
@@ -62,14 +62,14 @@ int GetDefaultColorInfoCount();
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           «‘                              //
+//                           è¾æ›¸                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //@@@ 2006.04.10 fon ADD-start
-const int DICT_ABOUT_LEN = 50; /*!< «‘‚Ìà–¾‚ÌÅ‘å’· -1 */
+const int DICT_ABOUT_LEN = 50; /*!< è¾æ›¸ã®èª¬æ˜ã®æœ€å¤§é•· -1 */
 struct KeyHelpInfo {
-	bool		m_bUse;						//!< «‘‚ğ g—p‚·‚é/‚µ‚È‚¢
-	TCHAR		m_szAbout[DICT_ABOUT_LEN];	//!< «‘‚Ìà–¾(«‘ƒtƒ@ƒCƒ‹‚Ì1s–Ú‚©‚ç¶¬)
-	SFilePath	m_szPath;					//!< ƒtƒ@ƒCƒ‹ƒpƒX
+	bool		m_bUse;						//!< è¾æ›¸ã‚’ ä½¿ç”¨ã™ã‚‹/ã—ãªã„
+	TCHAR		m_szAbout[DICT_ABOUT_LEN];	//!< è¾æ›¸ã®èª¬æ˜(è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ã®1è¡Œç›®ã‹ã‚‰ç”Ÿæˆ)
+	SFilePath	m_szPath;					//!< ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹
 };
 //@@@ 2006.04.10 fon ADD-end
 

--- a/sakura_core/doc/CDocVisitor.cpp
+++ b/sakura_core/doc/CDocVisitor.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "CDocVisitor.h"
 #include "doc/CEditDoc.h"
 #include "cmd/CViewCommander_inline.h"
@@ -7,12 +7,12 @@
 #include "COpeBlk.h"
 
 
-//! ‰üsƒR[ƒh‚ð“ˆê‚·‚é
+//! æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’çµ±ä¸€ã™ã‚‹
 void CDocVisitor::SetAllEol(CEol cEol)
 {
 	CEditView* pcView = &CEditWnd::getInstance()->GetActiveView();
 
-	//ƒAƒ“ƒhƒD‹L˜^ŠJŽn
+	//ã‚¢ãƒ³ãƒ‰ã‚¥è¨˜éŒ²é–‹å§‹
 	if(!pcView->m_bDoing_UndoRedo){
 		if(pcView->m_cCommander.GetOpeBlk() == NULL){
 			pcView->m_cCommander.SetOpeBlk(new COpeBlk());
@@ -20,7 +20,7 @@ void CDocVisitor::SetAllEol(CEol cEol)
 		pcView->m_cCommander.GetOpeBlk()->AddRef();
 	}
 
-	//ƒJ[ƒ\ƒ‹ˆÊ’u‹L‰¯
+	//ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®è¨˜æ†¶
 	CLayoutInt		nViewTopLine = pcView->GetTextArea().GetViewTopLine();
 	CLayoutInt		nViewLeftCol = pcView->GetTextArea().GetViewLeftCol();
 	CLayoutPoint	ptCaretPosXY = pcView->GetCaret().GetCaretLayoutPos();
@@ -28,14 +28,14 @@ void CDocVisitor::SetAllEol(CEol cEol)
 
 	bool bReplace = false;
 
-	//‰üsƒR[ƒh‚ð“ˆê‚·‚é
+	//æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’çµ±ä¸€ã™ã‚‹
 	if(cEol.IsValid()){
 		CLogicInt	nLine = CLogicInt(0);
 		COpeBlk* pcOpeBlk = pcView->m_bDoing_UndoRedo ? NULL : pcView->m_cCommander.GetOpeBlk();
 		for (;;) {
-			CDocLine* pcDocLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLine); //#######”ñŒø—¦
+			CDocLine* pcDocLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLine); //#######éžåŠ¹çŽ‡
 			if(!pcDocLine)break;
-			//‰üs‚ð’uŠ·
+			//æ”¹è¡Œã‚’ç½®æ›
 			if(pcDocLine->GetEol()!=EOL_NONE && pcDocLine->GetEol()!=cEol){
 				CLogicRange sRange;
 				sRange.SetFrom(CLogicPoint(pcDocLine->GetLengthWithoutEOL(),nLine));
@@ -52,7 +52,7 @@ void CDocVisitor::SetAllEol(CEol cEol)
 			}
 			nLine++;
 		}
-		//•ÒWŽž“ü—Í‰üsƒR[ƒh
+		//ç·¨é›†æ™‚å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰
 		CEditDoc::GetInstance(0)->m_cDocEditor.SetNewLineCode(cEol);
 	}
 
@@ -65,10 +65,10 @@ void CDocVisitor::SetAllEol(CEol cEol)
 			m_pcDocRef->m_cLayoutMgr.ClearLayoutLineWidth();
 		}
 	}
-	//ƒAƒ“ƒhƒD‹L˜^
+	//ã‚¢ãƒ³ãƒ‰ã‚¥è¨˜éŒ²
 	if(pcView->m_cCommander.GetOpeBlk()){
 		if(pcView->m_cCommander.GetOpeBlk()->GetNum()>0){
-			// ƒJ[ƒ\ƒ‹ˆÊ’u•œŒ³
+			// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¾©å…ƒ
 			pcView->GetTextArea().SetViewTopLine(nViewTopLine);
 			pcView->GetTextArea().SetViewLeftCol(nViewLeftCol);
 			pcView->GetCaret().MoveCursor( ptCaretPosXY, true );

--- a/sakura_core/doc/CDocVisitor.h
+++ b/sakura_core/doc/CDocVisitor.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -32,7 +32,7 @@ class CDocVisitor{
 public:
 	CDocVisitor(CEditDoc* pcDoc) : m_pcDocRef(pcDoc) { }
 
-	void SetAllEol(CEol cEol); //!< ‰üsƒR[ƒh‚ð“ˆê‚·‚é
+	void SetAllEol(CEol cEol); //!< æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’çµ±ä¸€ã™ã‚‹
 private:
 	CEditDoc* m_pcDocRef;
 };

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief •¶‘ŠÖ˜Aî•ñ‚ÌŠÇ—
+ï»¿/*!	@file
+	@brief æ–‡æ›¸é–¢é€£æƒ…å ±ã®ç®¡ç†
 
 	@author Norio Nakatani
-	@date	1998/03/13 ì¬
+	@date	1998/03/13 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -46,7 +46,7 @@
 #include <OleCtl.h>
 #include "doc/CEditDoc.h"
 #include "doc/logic/CDocLine.h" /// 2002/2/3 aroka
-#include "doc/layout/CLayout.h"	// 2007.08.22 ryoji ’Ç‰Á
+#include "doc/layout/CLayout.h"	// 2007.08.22 ryoji è¿½åŠ 
 #include "docplus/CModifyManager.h"
 #include "_main/global.h"
 #include "_main/CAppMode.h"
@@ -79,7 +79,7 @@
 
 #define IDT_ROLLMOUSE	1
 
-//! •ÒW‹Ö~ƒRƒ}ƒ“ƒh
+//! ç·¨é›†ç¦æ­¢ã‚³ãƒãƒ³ãƒ‰
 static const EFunctionCode EIsModificationForbidden[] = {
 	F_WCHAR,
 	F_IME_CHAR,
@@ -146,35 +146,35 @@ static const EFunctionCode EIsModificationForbidden[] = {
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ¶¬‚Æ”jŠü                           //
+//                        ç”Ÿæˆã¨ç ´æ£„                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 /*!
 	@note
-		m_pcEditWnd ‚ÍƒRƒ“ƒXƒgƒ‰ƒNƒ^“à‚Å‚Íg—p‚µ‚È‚¢‚±‚ÆD
+		m_pcEditWnd ã¯ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿å†…ã§ã¯ä½¿ç”¨ã—ãªã„ã“ã¨ï¼
 
-	@date 2000.05.12 genta ‰Šú‰»•û–@•ÏX
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
-	@date 2002.01.14 YAZAKI ˆóüƒvƒŒƒrƒ…[‚ğCPrintPreview‚É“Æ—§‚³‚¹‚½‚±‚Æ‚É‚æ‚é•ÏX
-	@date 2004.06.21 novice ƒ^ƒOƒWƒƒƒ“ƒv‹@”\’Ç‰Á
+	@date 2000.05.12 genta åˆæœŸåŒ–æ–¹æ³•å¤‰æ›´
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
+	@date 2002.01.14 YAZAKI å°åˆ·ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼ã‚’CPrintPreviewã«ç‹¬ç«‹ã•ã›ãŸã“ã¨ã«ã‚ˆã‚‹å¤‰æ›´
+	@date 2004.06.21 novice ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½è¿½åŠ 
 */
 CEditDoc::CEditDoc(CEditApp* pcApp)
-: m_cDocFile(this)					// warning C4355: 'this' : ƒx[ƒX ƒƒ“ƒo[‰Šú‰»qƒŠƒXƒg‚Åg—p‚³‚ê‚Ü‚µ‚½B
-, m_cDocFileOperation(this)			// warning C4355: 'this' : ƒx[ƒX ƒƒ“ƒo[‰Šú‰»qƒŠƒXƒg‚Åg—p‚³‚ê‚Ü‚µ‚½B
-, m_cDocEditor(this)				// warning C4355: 'this' : ƒx[ƒX ƒƒ“ƒo[‰Šú‰»qƒŠƒXƒg‚Åg—p‚³‚ê‚Ü‚µ‚½B
-, m_cDocType(this)					// warning C4355: 'this' : ƒx[ƒX ƒƒ“ƒo[‰Šú‰»qƒŠƒXƒg‚Åg—p‚³‚ê‚Ü‚µ‚½B
-, m_cDocOutline(this)				// warning C4355: 'this' : ƒx[ƒX ƒƒ“ƒo[‰Šú‰»qƒŠƒXƒg‚Åg—p‚³‚ê‚Ü‚µ‚½B
-, m_nCommandExecNum( 0 )			/* ƒRƒ}ƒ“ƒhÀs‰ñ” */
+: m_cDocFile(this)					// warning C4355: 'this' : ãƒ™ãƒ¼ã‚¹ ãƒ¡ãƒ³ãƒãƒ¼åˆæœŸåŒ–å­ãƒªã‚¹ãƒˆã§ä½¿ç”¨ã•ã‚Œã¾ã—ãŸã€‚
+, m_cDocFileOperation(this)			// warning C4355: 'this' : ãƒ™ãƒ¼ã‚¹ ãƒ¡ãƒ³ãƒãƒ¼åˆæœŸåŒ–å­ãƒªã‚¹ãƒˆã§ä½¿ç”¨ã•ã‚Œã¾ã—ãŸã€‚
+, m_cDocEditor(this)				// warning C4355: 'this' : ãƒ™ãƒ¼ã‚¹ ãƒ¡ãƒ³ãƒãƒ¼åˆæœŸåŒ–å­ãƒªã‚¹ãƒˆã§ä½¿ç”¨ã•ã‚Œã¾ã—ãŸã€‚
+, m_cDocType(this)					// warning C4355: 'this' : ãƒ™ãƒ¼ã‚¹ ãƒ¡ãƒ³ãƒãƒ¼åˆæœŸåŒ–å­ãƒªã‚¹ãƒˆã§ä½¿ç”¨ã•ã‚Œã¾ã—ãŸã€‚
+, m_cDocOutline(this)				// warning C4355: 'this' : ãƒ™ãƒ¼ã‚¹ ãƒ¡ãƒ³ãƒãƒ¼åˆæœŸåŒ–å­ãƒªã‚¹ãƒˆã§ä½¿ç”¨ã•ã‚Œã¾ã—ãŸã€‚
+, m_nCommandExecNum( 0 )			/* ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œå›æ•° */
 , m_hBackImg(NULL)
 {
 	MY_RUNNINGTIMER( cRunningTimer, "CEditDoc::CEditDoc" );
 
-	// ƒŒƒCƒAƒEƒgŠÇ—î•ñ‚Ì‰Šú‰»
+	// ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆç®¡ç†æƒ…å ±ã®åˆæœŸåŒ–
 	m_cLayoutMgr.Create( this, &m_cDocLineMgr );
 
-	// ƒŒƒCƒAƒEƒgî•ñ‚Ì•ÏX
-	// 2008.06.07 nasukoji	Ü‚è•Ô‚µ•û–@‚Ì’Ç‰Á‚É‘Î‰
-	// uw’èŒ…‚ÅÜ‚è•Ô‚·vˆÈŠO‚Ì‚ÍÜ‚è•Ô‚µ•‚ğMAXLINEKETAS‚Å‰Šú‰»‚·‚é
-	// u‰E’[‚ÅÜ‚è•Ô‚·v‚ÍA‚±‚ÌŒã‚ÌOnSize()‚ÅÄİ’è‚³‚ê‚é
+	// ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã®å¤‰æ›´
+	// 2008.06.07 nasukoji	æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã®è¿½åŠ ã«å¯¾å¿œ
+	// ã€ŒæŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™ã€ä»¥å¤–ã®æ™‚ã¯æŠ˜ã‚Šè¿”ã—å¹…ã‚’MAXLINEKETASã§åˆæœŸåŒ–ã™ã‚‹
+	// ã€Œå³ç«¯ã§æŠ˜ã‚Šè¿”ã™ã€ã¯ã€ã“ã®å¾Œã®OnSize()ã§å†è¨­å®šã•ã‚Œã‚‹
 	const STypeConfig& ref = m_cDocType.GetDocumentAttribute();
 	CKetaXInt nMaxLineKetas = ref.m_nMaxLineKetas;
 	if( ref.m_nTextWrapMethod != WRAP_SETTING_WIDTH ){
@@ -182,33 +182,33 @@ CEditDoc::CEditDoc(CEditApp* pcApp)
 	}
 	m_cLayoutMgr.SetLayoutInfo( true, false, ref, ref.m_nTabSpace, ref.m_nTsvMode, nMaxLineKetas, CLayoutXInt(1), NULL );
 
-	//	©“®•Û‘¶‚Ìİ’è	//	Aug, 21, 2000 genta
+	//	è‡ªå‹•ä¿å­˜ã®è¨­å®š	//	Aug, 21, 2000 genta
 	m_cAutoSaveAgent.ReloadAutoSaveParam();
 
-	//$$ CModifyManager ƒCƒ“ƒXƒ^ƒ“ƒX‚ğ¶¬
+	//$$ CModifyManager ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã‚’ç”Ÿæˆ
 	CModifyManager::getInstance();
 
-	//$$ CCodeChecker ƒCƒ“ƒXƒ^ƒ“ƒX‚ğ¶¬
+	//$$ CCodeChecker ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã‚’ç”Ÿæˆ
 	CCodeChecker::getInstance();
 
-	// 2008.06.07 nasukoji	ƒeƒLƒXƒg‚ÌÜ‚è•Ô‚µ•û–@‚ğ‰Šú‰»
-	m_nTextWrapMethodCur = m_cDocType.GetDocumentAttribute().m_nTextWrapMethod;	// Ü‚è•Ô‚µ•û–@
-	m_bTextWrapMethodCurTemp = false;									// ˆêİ’è“K—p’†‚ğ‰ğœ
+	// 2008.06.07 nasukoji	ãƒ†ã‚­ã‚¹ãƒˆã®æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã‚’åˆæœŸåŒ–
+	m_nTextWrapMethodCur = m_cDocType.GetDocumentAttribute().m_nTextWrapMethod;	// æŠ˜ã‚Šè¿”ã—æ–¹æ³•
+	m_bTextWrapMethodCurTemp = false;									// ä¸€æ™‚è¨­å®šé©ç”¨ä¸­ã‚’è§£é™¤
 	m_blfCurTemp = false;
 	m_nPointSizeCur = -1;
 	m_nPointSizeOrg = -1;
 	m_bTabSpaceCurTemp = false;
 
-	// •¶šƒR[ƒhí•Ê‚ğ‰Šú‰»
+	// æ–‡å­—ã‚³ãƒ¼ãƒ‰ç¨®åˆ¥ã‚’åˆæœŸåŒ–
 	m_cDocFile.SetCodeSet( ref.m_encoding.m_eDefaultCodetype, ref.m_encoding.m_bDefaultBom );
 	m_cDocEditor.m_cNewLineCode = ref.m_encoding.m_eDefaultEoltype;
 
-	// ”r‘¼§ŒäƒIƒvƒVƒ‡ƒ“‚ğ‰Šú‰»
+	// æ’ä»–åˆ¶å¾¡ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã‚’åˆæœŸåŒ–
 	m_cDocFile.SetShareMode( GetDllShareData().m_Common.m_sFile.m_nFileShareMode );
 
 #ifdef _DEBUG
 	{
-		// •ÒW‹Ö~ƒRƒ}ƒ“ƒh‚Ì•À‚Ñ‚ğƒ`ƒFƒbƒN
+		// ç·¨é›†ç¦æ­¢ã‚³ãƒãƒ³ãƒ‰ã®ä¸¦ã³ã‚’ãƒã‚§ãƒƒã‚¯
 		int i;
 		for ( i = 0; i < _countof(EIsModificationForbidden) - 1; i++){
 			assert( EIsModificationForbidden[i] <  EIsModificationForbidden[i+1] );
@@ -226,30 +226,30 @@ CEditDoc::~CEditDoc()
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ¶¬‚Æ”jŠü                           //
+//                        ç”Ÿæˆã¨ç ´æ£„                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void CEditDoc::Clear()
 {
-	// ƒtƒ@ƒCƒ‹‚Ì”r‘¼ƒƒbƒN‰ğœ
+	// ãƒ•ã‚¡ã‚¤ãƒ«ã®æ’ä»–ãƒ­ãƒƒã‚¯è§£é™¤
 	m_cDocFileOperation.DoFileUnlock();
 
-	// ‘‚İ‹Ö~‚ÌƒNƒŠƒA
+	// æ›¸è¾¼ã¿ç¦æ­¢ã®ã‚¯ãƒªã‚¢
 	m_cDocLocker.Clear();
 
-	// ƒAƒ“ƒhƒDEƒŠƒhƒDƒoƒbƒtƒ@‚ÌƒNƒŠƒA
+	// ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ãƒãƒƒãƒ•ã‚¡ã®ã‚¯ãƒªã‚¢
 	m_cDocEditor.m_cOpeBuf.ClearAll();
 
-	// ƒeƒLƒXƒgƒf[ƒ^‚ÌƒNƒŠƒA
+	// ãƒ†ã‚­ã‚¹ãƒˆãƒ‡ãƒ¼ã‚¿ã®ã‚¯ãƒªã‚¢
 	m_cDocLineMgr.DeleteAllLine();
 
-	// ƒtƒ@ƒCƒ‹ƒpƒX‚ÆƒAƒCƒRƒ“‚ÌƒNƒŠƒA
+	// ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã¨ã‚¢ã‚¤ã‚³ãƒ³ã®ã‚¯ãƒªã‚¢
 	SetFilePathAndIcon( _T("") );
 
-	// ƒtƒ@ƒCƒ‹‚Ìƒ^ƒCƒ€ƒXƒ^ƒ“ƒv‚ÌƒNƒŠƒA
+	// ãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚¿ã‚¤ãƒ ã‚¹ã‚¿ãƒ³ãƒ—ã®ã‚¯ãƒªã‚¢
 	m_cDocFile.ClearFileTime();
 
-	// uŠî–{v‚Ìƒ^ƒCƒv•Êİ’è‚ğ“K—p
+	// ã€ŒåŸºæœ¬ã€ã®ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚’é©ç”¨
 	m_cDocType.SetDocumentType( CDocTypeManager().GetDocumentTypeOfPath( m_cDocFile.GetFilePath() ), true );
 	m_blfCurTemp = false;
 	m_pcEditWnd->m_pcViewFontMiniMap->UpdateFont(&m_pcEditWnd->GetLogfont());
@@ -258,7 +258,7 @@ void CEditDoc::Clear()
 	InitCharWidthCache( m_pcEditWnd->GetLogfont() );
 	m_pcEditWnd->m_pcViewFont->UpdateFont(&m_pcEditWnd->GetLogfont());
 
-	// 2008.06.07 nasukoji	Ü‚è•Ô‚µ•û–@‚Ì’Ç‰Á‚É‘Î‰
+	// 2008.06.07 nasukoji	æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã®è¿½åŠ ã«å¯¾å¿œ
 	const STypeConfig& ref = m_cDocType.GetDocumentAttribute();
 	CKetaXInt nMaxLineKetas = ref.m_nMaxLineKetas;
 	if( ref.m_nTextWrapMethod != WRAP_SETTING_WIDTH ){
@@ -268,35 +268,35 @@ void CEditDoc::Clear()
 	m_pcEditWnd->ClearViewCaretPosInfo();
 }
 
-/* Šù‘¶ƒf[ƒ^‚ÌƒNƒŠƒA */
+/* æ—¢å­˜ãƒ‡ãƒ¼ã‚¿ã®ã‚¯ãƒªã‚¢ */
 void CEditDoc::InitDoc()
 {
-	CAppMode::getInstance()->SetViewMode(false);	// ƒrƒ…[ƒ‚[ƒh $$ ¡ŒãOnClearDoc‚ğ—pˆÓ‚µ‚½‚¢
+	CAppMode::getInstance()->SetViewMode(false);	// ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ $$ ä»Šå¾ŒOnClearDocã‚’ç”¨æ„ã—ãŸã„
 	CAppMode::getInstance()->m_szGrepKey[0] = L'\0';	//$$
 
-	CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode = false;	/* Grepƒ‚[ƒh */	//$$“¯ã
-	m_cAutoReloadAgent.m_eWatchUpdate = WU_QUERY; // Dec. 4, 2002 genta XVŠÄ‹•û–@ $$
+	CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode = false;	/* Grepãƒ¢ãƒ¼ãƒ‰ */	//$$åŒä¸Š
+	m_cAutoReloadAgent.m_eWatchUpdate = WU_QUERY; // Dec. 4, 2002 genta æ›´æ–°ç›£è¦–æ–¹æ³• $$
 
-	// 2005.06.24 Moca ƒoƒOC³
-	//	ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚Åu•Â‚¶‚Ä(–³‘è)v‚ğs‚Á‚Ä‚àƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚Ì‚Ü‚Ü
+	// 2005.06.24 Moca ãƒã‚°ä¿®æ­£
+	//	ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã§ã€Œé–‰ã˜ã¦(ç„¡é¡Œ)ã€ã‚’è¡Œã£ã¦ã‚‚ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã¾ã¾
 	if( CAppMode::getInstance()->IsDebugMode() ){
 		CAppMode::getInstance()->SetDebugModeOFF();
 	}
 
 //	Sep. 10, 2002 genta
-//	ƒAƒCƒRƒ“İ’è‚Íƒtƒ@ƒCƒ‹–¼İ’è‚Æˆê‘Ì‰»‚Ì‚½‚ß‚±‚±‚©‚ç‚Ííœ
+//	ã‚¢ã‚¤ã‚³ãƒ³è¨­å®šã¯ãƒ•ã‚¡ã‚¤ãƒ«åè¨­å®šã¨ä¸€ä½“åŒ–ã®ãŸã‚ã“ã“ã‹ã‚‰ã¯å‰Šé™¤
 
 	Clear();
 
-	/* •ÏXƒtƒ‰ƒO */
+	/* å¤‰æ›´ãƒ•ãƒ©ã‚° */
 	m_cDocEditor.SetModified(false,false);	//	Jan. 22, 2002 genta
 
-	/* •¶šƒR[ƒhí•Ê */
+	/* æ–‡å­—ã‚³ãƒ¼ãƒ‰ç¨®åˆ¥ */
 	const STypeConfig& ref = m_cDocType.GetDocumentAttribute();
 	m_cDocFile.SetCodeSet( ref.m_encoding.m_eDefaultCodetype, ref.m_encoding.m_bDefaultBom );
 	m_cDocEditor.m_cNewLineCode = ref.m_encoding.m_eDefaultEoltype;
 
-	//	Oct. 2, 2005 genta ‘}“üƒ‚[ƒh
+	//	Oct. 2, 2005 genta æŒ¿å…¥ãƒ¢ãƒ¼ãƒ‰
 	m_cDocEditor.SetInsMode( GetDllShareData().m_Common.m_sGeneral.m_bIsINSMode );
 
 	m_cCookie.DeleteAll(L"document");
@@ -341,7 +341,7 @@ void CEditDoc::SetBackgroundImage()
 		{
 			IPicture* iPicture = NULL;
 			IStream*  iStream = NULL;
-			//hGlobal‚ÌŠÇ—‚ğˆÚ÷
+			//hGlobalã®ç®¡ç†ã‚’ç§»è­²
 			if( S_OK != ::CreateStreamOnHGlobal(hGlobal, TRUE, &iStream) ){
 				GlobalFree(hGlobal);
 			}else{
@@ -374,25 +374,25 @@ void CEditDoc::SetBackgroundImage()
 	}
 }
 
-/* ‘Sƒrƒ…[‚Ì‰Šú‰»Fƒtƒ@ƒCƒ‹ƒI[ƒvƒ“/ƒNƒ[ƒY“™‚ÉAƒrƒ…[‚ğ‰Šú‰»‚·‚é */
+/* å…¨ãƒ“ãƒ¥ãƒ¼ã®åˆæœŸåŒ–ï¼šãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³/ã‚¯ãƒ­ãƒ¼ã‚ºæ™‚ç­‰ã«ã€ãƒ“ãƒ¥ãƒ¼ã‚’åˆæœŸåŒ–ã™ã‚‹ */
 void CEditDoc::InitAllView( void )
 {
 
-	m_nCommandExecNum = 0;	/* ƒRƒ}ƒ“ƒhÀs‰ñ” */
+	m_nCommandExecNum = 0;	/* ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œå›æ•° */
 
-	// 2008.05.30 nasukoji	ƒeƒLƒXƒg‚ÌÜ‚è•Ô‚µ•û–@‚ğ‰Šú‰»
-	m_nTextWrapMethodCur = m_cDocType.GetDocumentAttribute().m_nTextWrapMethod;	// Ü‚è•Ô‚µ•û–@
-	m_bTextWrapMethodCurTemp = false;									// ˆêİ’è“K—p’†‚ğ‰ğœ
+	// 2008.05.30 nasukoji	ãƒ†ã‚­ã‚¹ãƒˆã®æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã‚’åˆæœŸåŒ–
+	m_nTextWrapMethodCur = m_cDocType.GetDocumentAttribute().m_nTextWrapMethod;	// æŠ˜ã‚Šè¿”ã—æ–¹æ³•
+	m_bTextWrapMethodCurTemp = false;									// ä¸€æ™‚è¨­å®šé©ç”¨ä¸­ã‚’è§£é™¤
 	m_blfCurTemp = false;
 	m_bTabSpaceCurTemp = false;
 
-	// 2009.08.28 nasukoji	uÜ‚è•Ô‚³‚È‚¢v‚È‚çƒeƒLƒXƒgÅ‘å•‚ğZoA‚»‚êˆÈŠO‚Í•Ï”‚ğƒNƒŠƒA
+	// 2009.08.28 nasukoji	ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€ãªã‚‰ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’ç®—å‡ºã€ãã‚Œä»¥å¤–ã¯å¤‰æ•°ã‚’ã‚¯ãƒªã‚¢
 	if( m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP )
-		m_cLayoutMgr.CalculateTextWidth();		// ƒeƒLƒXƒgÅ‘å•‚ğZo‚·‚é
+		m_cLayoutMgr.CalculateTextWidth();		// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹
 	else
-		m_cLayoutMgr.ClearLayoutLineWidth();	// Šes‚ÌƒŒƒCƒAƒEƒgs’·‚Ì‹L‰¯‚ğƒNƒŠƒA‚·‚é
+		m_cLayoutMgr.ClearLayoutLineWidth();	// å„è¡Œã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œé•·ã®è¨˜æ†¶ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹
 
-	// CEditWnd‚Éˆø‰z‚µ
+	// CEditWndã«å¼•è¶Šã—
 	m_pcEditWnd->InitAllViews();
 
 	return;
@@ -400,10 +400,10 @@ void CEditDoc::InitAllView( void )
 
 
 
-/*! ƒEƒBƒ“ƒhƒE‚Ìì¬“™
+/*! ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä½œæˆç­‰
 
-	@date 2001.09.29 genta ƒ}ƒNƒƒNƒ‰ƒX‚ğ“n‚·‚æ‚¤‚É
-	@date 2002.01.03 YAZAKI m_tbMyButton‚È‚Ç‚ğCShareData‚©‚çCMenuDrawer‚ÖˆÚ“®‚µ‚½‚±‚Æ‚É‚æ‚éC³B
+	@date 2001.09.29 genta ãƒã‚¯ãƒ­ã‚¯ãƒ©ã‚¹ã‚’æ¸¡ã™ã‚ˆã†ã«
+	@date 2002.01.03 YAZAKI m_tbMyButtonãªã©ã‚’CShareDataã‹ã‚‰CMenuDrawerã¸ç§»å‹•ã—ãŸã“ã¨ã«ã‚ˆã‚‹ä¿®æ­£ã€‚
 */
 BOOL CEditDoc::Create( CEditWnd* pcEditWnd )
 {
@@ -424,15 +424,15 @@ BOOL CEditDoc::Create( CEditWnd* pcEditWnd )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           İ’è                              //
+//                           è¨­å®š                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /*!
-	ƒtƒ@ƒCƒ‹–¼‚Ìİ’è
+	ãƒ•ã‚¡ã‚¤ãƒ«åã®è¨­å®š
 	
-	ƒtƒ@ƒCƒ‹–¼‚ğİ’è‚·‚é‚Æ“¯‚ÉCƒEƒBƒ“ƒhƒEƒAƒCƒRƒ“‚ğ“KØ‚Éİ’è‚·‚éD
+	ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¨­å®šã™ã‚‹ã¨åŒæ™‚ã«ï¼Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚¢ã‚¤ã‚³ãƒ³ã‚’é©åˆ‡ã«è¨­å®šã™ã‚‹ï¼
 	
-	@param szFile [in] ƒtƒ@ƒCƒ‹‚ÌƒpƒX–¼
+	@param szFile [in] ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹å
 	
 	@author genta
 	@date 2002.09.09
@@ -451,25 +451,25 @@ void CEditDoc::SetFilePathAndIcon(const TCHAR* szFile)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           ‘®«                              //
+//                           å±æ€§                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! ƒhƒLƒ…ƒƒ“ƒg‚Ì•¶šƒR[ƒh‚ğæ“¾
+//! ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚’å–å¾—
 ECodeType CEditDoc::GetDocumentEncoding() const
 {
 	return m_cDocFile.GetCodeSet();
 }
 
-//! ƒhƒLƒ…ƒƒ“ƒg‚ÌBOM•t‰Á‚ğæ“¾
+//! ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã®BOMä»˜åŠ ã‚’å–å¾—
 bool CEditDoc::GetDocumentBomExist() const
 {
 	return m_cDocFile.IsBomExist();
 }
 
-//! ƒhƒLƒ…ƒƒ“ƒg‚Ì•¶šƒR[ƒh‚ğİ’è
+//! ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚’è¨­å®š
 void CEditDoc::SetDocumentEncoding(ECodeType eCharCode, bool bBom)
 {
-	if(!IsValidCodeOrCPType(eCharCode))return; //–³Œø‚È”ÍˆÍ‚ğó‚¯•t‚¯‚È‚¢
+	if(!IsValidCodeOrCPType(eCharCode))return; //ç„¡åŠ¹ãªç¯„å›²ã‚’å—ã‘ä»˜ã‘ãªã„
 
 	m_cDocFile.SetCodeSet( eCharCode, bBom );
 }
@@ -483,55 +483,55 @@ void CEditDoc::GetSaveInfo(SSaveInfo* pSaveInfo) const
 	pSaveInfo->eCharCode   = m_cDocFile.GetCodeSet();
 	pSaveInfo->bBomExist   = m_cDocFile.IsBomExist();
 	pSaveInfo->bChgCodeSet = m_cDocFile.IsChgCodeSet();
-	pSaveInfo->cEol        = m_cDocEditor.m_cNewLineCode; //•ÒW‰üsƒR[ƒh‚ğ•Û‘¶‰üsƒR[ƒh‚Æ‚µ‚Äİ’è
+	pSaveInfo->cEol        = m_cDocEditor.m_cNewLineCode; //ç·¨é›†æ™‚æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’ä¿å­˜æ™‚æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã¨ã—ã¦è¨­å®š
 }
 
 
-/* •ÒWƒtƒ@ƒCƒ‹î•ñ‚ğŠi”[ */
+/* ç·¨é›†ãƒ•ã‚¡ã‚¤ãƒ«æƒ…å ±ã‚’æ ¼ç´ */
 void CEditDoc::GetEditInfo(
 	EditInfo* pfi	//!< [out]
 ) const
 {
-	//ƒtƒ@ƒCƒ‹ƒpƒX
+	//ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹
 	_tcscpy(pfi->m_szPath, m_cDocFile.GetFilePath());
 
-	//•\¦ˆæ
-	pfi->m_nViewTopLine = m_pcEditWnd->GetActiveView().GetTextArea().GetViewTopLine();	/* •\¦ˆæ‚Ìˆê”Ôã‚Ìs(0ŠJn) */
-	pfi->m_nViewLeftCol = m_pcEditWnd->GetActiveView().GetTextArea().GetViewLeftCol();	/* •\¦ˆæ‚Ìˆê”Ô¶‚ÌŒ…(0ŠJn) */
+	//è¡¨ç¤ºåŸŸ
+	pfi->m_nViewTopLine = m_pcEditWnd->GetActiveView().GetTextArea().GetViewTopLine();	/* è¡¨ç¤ºåŸŸã®ä¸€ç•ªä¸Šã®è¡Œ(0é–‹å§‹) */
+	pfi->m_nViewLeftCol = m_pcEditWnd->GetActiveView().GetTextArea().GetViewLeftCol();	/* è¡¨ç¤ºåŸŸã®ä¸€ç•ªå·¦ã®æ¡(0é–‹å§‹) */
 
-	//ƒLƒƒƒŒƒbƒgˆÊ’u
+	//ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®
 	pfi->m_ptCursor.Set(m_pcEditWnd->GetActiveView().GetCaret().GetCaretLogicPos());
 
-	//Šeíó‘Ô
-	pfi->m_bIsModified = m_cDocEditor.IsModified();			/* •ÏXƒtƒ‰ƒO */
-	pfi->m_nCharCode = m_cDocFile.GetCodeSet();				/* •¶šƒR[ƒhí•Ê */
+	//å„ç¨®çŠ¶æ…‹
+	pfi->m_bIsModified = m_cDocEditor.IsModified();			/* å¤‰æ›´ãƒ•ãƒ©ã‚° */
+	pfi->m_nCharCode = m_cDocFile.GetCodeSet();				/* æ–‡å­—ã‚³ãƒ¼ãƒ‰ç¨®åˆ¥ */
 	pfi->m_bBom = GetDocumentBomExist();
 	pfi->m_nTypeId = m_cDocType.GetDocumentAttribute().m_id;
 
-	//GREPƒ‚[ƒh
+	//GREPãƒ¢ãƒ¼ãƒ‰
 	pfi->m_bIsGrep = CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode;
 	wcscpy( pfi->m_szGrepKey, CAppMode::getInstance()->m_szGrepKey );
 
-	//ƒfƒoƒbƒOƒ‚ƒjƒ^ (ƒAƒEƒgƒvƒbƒgƒEƒCƒ“ƒhƒE) ƒ‚[ƒh
+	//ãƒ‡ãƒãƒƒã‚°ãƒ¢ãƒ‹ã‚¿ (ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦) ãƒ¢ãƒ¼ãƒ‰
 	pfi->m_bIsDebug = CAppMode::getInstance()->IsDebugMode();
 }
 
 
-/*! @brief w’èƒRƒ}ƒ“ƒh‚É‚æ‚é‘‚«Š·‚¦‚ª‹Ö~‚³‚ê‚Ä‚¢‚é‚©‚Ç‚¤‚©
+/*! @brief æŒ‡å®šã‚³ãƒãƒ³ãƒ‰ã«ã‚ˆã‚‹æ›¸ãæ›ãˆãŒç¦æ­¢ã•ã‚Œã¦ã„ã‚‹ã‹ã©ã†ã‹
 
-	@retval true  ‹Ö~
-	@retval false ‹–‰Â
+	@retval true  ç¦æ­¢
+	@retval false è¨±å¯
 
-	@date 2000.08.14 genta V‹Kì¬
-	@date 2014.07.27 novice •ÒW‹Ö~‚Ìê‡‚ÌŒŸõ•û–@•ÏX
+	@date 2000.08.14 genta æ–°è¦ä½œæˆ
+	@date 2014.07.27 novice ç·¨é›†ç¦æ­¢ã®å ´åˆã®æ¤œç´¢æ–¹æ³•å¤‰æ›´
 */
 bool CEditDoc::IsModificationForbidden( EFunctionCode nCommand ) const
 {
-	//	•ÒW‰Â”\‚Ìê‡
+	//	ç·¨é›†å¯èƒ½ã®å ´åˆ
 	if( IsEditable() )
-		return false; // í‚É‘‚«Š·‚¦‹–‰Â
+		return false; // å¸¸ã«æ›¸ãæ›ãˆè¨±å¯
 
-	//	•ÒW‹Ö~‚Ìê‡(ƒoƒCƒiƒŠƒT[ƒ`)
+	//	ç·¨é›†ç¦æ­¢ã®å ´åˆ(ãƒã‚¤ãƒŠãƒªã‚µãƒ¼ãƒ)
 	{
 		int lbound = 0;
 		int ubound = _countof(EIsModificationForbidden) - 1;
@@ -554,14 +554,14 @@ bool CEditDoc::IsModificationForbidden( EFunctionCode nCommand ) const
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           ó‘Ô                              //
+//                           çŠ¶æ…‹                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*! @brief ‚±‚ÌƒEƒBƒ“ƒhƒE‚ÅV‚µ‚¢ƒtƒ@ƒCƒ‹‚ğŠJ‚¯‚é‚©
+/*! @brief ã“ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã§æ–°ã—ã„ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ã‚‹ã‹
 
-	V‚µ‚¢ƒEƒBƒ“ƒhƒE‚ğŠJ‚©‚¸‚ÉŒ»İ‚ÌƒEƒBƒ“ƒhƒE‚ğÄ—˜—p‚Å‚«‚é‚©‚Ç‚¤‚©‚ÌƒeƒXƒg‚ğs‚¤D
-	•ÏXÏ‚İCƒtƒ@ƒCƒ‹‚ğŠJ‚¢‚Ä‚¢‚éCGrepƒEƒBƒ“ƒhƒECƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚Ìê‡‚É‚Í
-	Ä—˜—p•s‰ÂD
+	æ–°ã—ã„ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã‹ãšã«ç¾åœ¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’å†åˆ©ç”¨ã§ãã‚‹ã‹ã©ã†ã‹ã®ãƒ†ã‚¹ãƒˆã‚’è¡Œã†ï¼
+	å¤‰æ›´æ¸ˆã¿ï¼Œãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã„ã¦ã„ã‚‹ï¼ŒGrepã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ï¼Œã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®å ´åˆã«ã¯
+	å†åˆ©ç”¨ä¸å¯ï¼
 
 	@author Moca
 	@date 2005.06.24 Moca
@@ -580,22 +580,22 @@ bool CEditDoc::IsAcceptLoad() const
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ƒCƒxƒ“ƒg                            //
+//                         ã‚¤ãƒ™ãƒ³ãƒˆ                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*! ƒRƒ}ƒ“ƒhƒR[ƒh‚É‚æ‚éˆ—U‚è•ª‚¯
+/*! ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã«ã‚ˆã‚‹å‡¦ç†æŒ¯ã‚Šåˆ†ã‘
 
-	@param[in] nCommand MAKELONG( ƒRƒ}ƒ“ƒhƒR[ƒhC‘—MŒ³¯•Êq )
+	@param[in] nCommand MAKELONG( ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ï¼Œé€ä¿¡å…ƒè­˜åˆ¥å­ )
 
-	@date 2006.05.19 genta ãˆÊ16bit‚É‘—MŒ³‚Ì¯•Êq‚ª“ü‚é‚æ‚¤‚É•ÏX
-	@date 2007.06.20 ryoji ƒOƒ‹[ƒv“à‚Å„‰ñ‚·‚é‚æ‚¤‚É•ÏX
+	@date 2006.05.19 genta ä¸Šä½16bitã«é€ä¿¡å…ƒã®è­˜åˆ¥å­ãŒå…¥ã‚‹ã‚ˆã†ã«å¤‰æ›´
+	@date 2007.06.20 ryoji ã‚°ãƒ«ãƒ¼ãƒ—å†…ã§å·¡å›ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
 */
 BOOL CEditDoc::HandleCommand( EFunctionCode nCommand )
 {
-	//	May. 19, 2006 genta ãˆÊ16bit‚É‘—MŒ³‚Ì¯•Êq‚ª“ü‚é‚æ‚¤‚É•ÏX‚µ‚½‚Ì‚Å
-	//	‰ºˆÊ16ƒrƒbƒg‚Ì‚İ‚ğæ‚èo‚·
+	//	May. 19, 2006 genta ä¸Šä½16bitã«é€ä¿¡å…ƒã®è­˜åˆ¥å­ãŒå…¥ã‚‹ã‚ˆã†ã«å¤‰æ›´ã—ãŸã®ã§
+	//	ä¸‹ä½16ãƒ“ãƒƒãƒˆã®ã¿ã‚’å–ã‚Šå‡ºã™
 	switch( LOWORD( nCommand )){
-	case F_PREVWINDOW:	//‘O‚ÌƒEƒBƒ“ƒhƒE
+	case F_PREVWINDOW:	//å‰ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
 		{
 			int nPane = m_pcEditWnd->m_cSplitterWnd.GetPrevPane();
 			if( -1 != nPane ){
@@ -605,7 +605,7 @@ BOOL CEditDoc::HandleCommand( EFunctionCode nCommand )
 			}
 		}
 		return TRUE;
-	case F_NEXTWINDOW:	//Ÿ‚ÌƒEƒBƒ“ƒhƒE
+	case F_NEXTWINDOW:	//æ¬¡ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
 		{
 			int nPane = m_pcEditWnd->m_cSplitterWnd.GetNextPane();
 			if( -1 != nPane ){
@@ -624,18 +624,18 @@ BOOL CEditDoc::HandleCommand( EFunctionCode nCommand )
 	}
 }
 
-/*!	ƒ^ƒCƒv•Êİ’è‚Ì“K—p‚ğ•ÏX
-	@date 2011.12.15 CViewCommander::Command_TYPE_LIST‚©‚çˆÚ“®
+/*!	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®é©ç”¨ã‚’å¤‰æ›´
+	@date 2011.12.15 CViewCommander::Command_TYPE_LISTã‹ã‚‰ç§»å‹•
 */
 void CEditDoc::OnChangeType()
 {
-	/* İ’è•ÏX‚ğ”½‰f‚³‚¹‚é */
-	m_bTextWrapMethodCurTemp = false;	// Ü‚è•Ô‚µ•û–@‚Ìˆêİ’è“K—p’†‚ğ‰ğœ	// 2008.06.08 ryoji
+	/* è¨­å®šå¤‰æ›´ã‚’åæ˜ ã•ã›ã‚‹ */
+	m_bTextWrapMethodCurTemp = false;	// æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã®ä¸€æ™‚è¨­å®šé©ç”¨ä¸­ã‚’è§£é™¤	// 2008.06.08 ryoji
 	m_blfCurTemp = false;
 	m_bTabSpaceCurTemp = false;
 	OnChangeSetting();
 
-	// V‹K‚Å–³•ÏX‚È‚çƒfƒtƒHƒ‹ƒg•¶šƒR[ƒh‚ğ“K—p‚·‚é	// 2011.01.24 ryoji
+	// æ–°è¦ã§ç„¡å¤‰æ›´ãªã‚‰ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚’é©ç”¨ã™ã‚‹	// 2011.01.24 ryoji
 	if( !m_cDocFile.GetFilePathClass().IsValidPath() ){
 		if( !m_cDocEditor.IsModified() && m_cDocLineMgr.GetLineCount() == 0 ){
 			const STypeConfig& types = m_cDocType.GetDocumentAttribute();
@@ -645,16 +645,16 @@ void CEditDoc::OnChangeType()
 		}
 	}
 
-	// 2006.09.01 ryoji ƒ^ƒCƒv•ÏXŒã©“®Àsƒ}ƒNƒ‚ğÀs‚·‚é
+	// 2006.09.01 ryoji ã‚¿ã‚¤ãƒ—å¤‰æ›´å¾Œè‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ã‚’å®Ÿè¡Œã™ã‚‹
 	RunAutoMacro( GetDllShareData().m_Common.m_sMacro.m_nMacroOnTypeChanged );
 }
 
-/*! ƒrƒ…[‚Éİ’è•ÏX‚ğ”½‰f‚³‚¹‚é
-	@param [in] bDoLayout ƒŒƒCƒAƒEƒgî•ñ‚ÌÄì¬
+/*! ãƒ“ãƒ¥ãƒ¼ã«è¨­å®šå¤‰æ›´ã‚’åæ˜ ã•ã›ã‚‹
+	@param [in] bDoLayout ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã®å†ä½œæˆ
 
-	@date 2004.06.09 Moca ƒŒƒCƒAƒEƒgÄ\’z’†‚ÉProgress Bar‚ğ•\¦‚·‚éD
-	@date 2008.05.30 nasukoji	ƒeƒLƒXƒg‚ÌÜ‚è•Ô‚µ•û–@‚Ì•ÏXˆ—‚ğ’Ç‰Á
-	@date 2013.04.22 novice ƒŒƒCƒAƒEƒgî•ñ‚ÌÄì¬‚ğİ’è‚Å‚«‚é‚æ‚¤‚É‚µ‚½
+	@date 2004.06.09 Moca ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå†æ§‹ç¯‰ä¸­ã«Progress Barã‚’è¡¨ç¤ºã™ã‚‹ï¼
+	@date 2008.05.30 nasukoji	ãƒ†ã‚­ã‚¹ãƒˆã®æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã®å¤‰æ›´å‡¦ç†ã‚’è¿½åŠ 
+	@date 2013.04.22 novice ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã®å†ä½œæˆã‚’è¨­å®šã§ãã‚‹ã‚ˆã†ã«ã—ãŸ
 */
 void CEditDoc::OnChangeSetting(
 	bool	bDoLayout,
@@ -668,31 +668,31 @@ void CEditDoc::OnChangeSetting(
 
 	if( NULL != pCEditWnd ){
 		hwndProgress = pCEditWnd->m_cStatusBar.GetProgressHwnd();
-		//	Status Bar‚ª•\¦‚³‚ê‚Ä‚¢‚È‚¢‚Æ‚«‚Ím_hwndProgressBar == NULL
+		//	Status BarãŒè¡¨ç¤ºã•ã‚Œã¦ã„ãªã„ã¨ãã¯m_hwndProgressBar == NULL
 	}
 
 	if( hwndProgress ){
 		::ShowWindow( hwndProgress, SW_SHOW );
 	}
 
-	/* ƒtƒ@ƒCƒ‹‚Ì”r‘¼ƒ‚[ƒh•ÏX */
+	/* ãƒ•ã‚¡ã‚¤ãƒ«ã®æ’ä»–ãƒ¢ãƒ¼ãƒ‰å¤‰æ›´ */
 	if( m_cDocFile.GetShareMode() != GetDllShareData().m_Common.m_sFile.m_nFileShareMode ){
 		m_cDocFile.SetShareMode( GetDllShareData().m_Common.m_sFile.m_nFileShareMode );
 
-		/* ƒtƒ@ƒCƒ‹‚Ì”r‘¼ƒƒbƒN‰ğœ */
+		/* ãƒ•ã‚¡ã‚¤ãƒ«ã®æ’ä»–ãƒ­ãƒƒã‚¯è§£é™¤ */
 		m_cDocFileOperation.DoFileUnlock();
 
-		// ƒtƒ@ƒCƒ‹‘‰Â”\‚Ìƒ`ƒFƒbƒNˆ—
+		// ãƒ•ã‚¡ã‚¤ãƒ«æ›¸è¾¼å¯èƒ½ã®ãƒã‚§ãƒƒã‚¯å‡¦ç†
 		bool bOld = m_cDocLocker.IsDocWritable();
-		m_cDocLocker.CheckWritable(bOld && !CAppMode::getInstance()->IsViewMode());	// ‘‰Â‚©‚ç•s‰Â‚É‘JˆÚ‚µ‚½‚Æ‚«‚¾‚¯ƒƒbƒZ[ƒW‚ğo‚·io‰ß‚¬‚é‚ÆŸT“©‚µ‚¢‚æ‚ËHj
+		m_cDocLocker.CheckWritable(bOld && !CAppMode::getInstance()->IsViewMode());	// æ›¸è¾¼å¯ã‹ã‚‰ä¸å¯ã«é·ç§»ã—ãŸã¨ãã ã‘ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å‡ºã™ï¼ˆå‡ºéãã‚‹ã¨é¬±é™¶ã—ã„ã‚ˆã­ï¼Ÿï¼‰
 
-		/* ƒtƒ@ƒCƒ‹‚Ì”r‘¼ƒƒbƒN */
+		/* ãƒ•ã‚¡ã‚¤ãƒ«ã®æ’ä»–ãƒ­ãƒƒã‚¯ */
 		if( m_cDocLocker.IsDocWritable() ){
 			m_cDocFileOperation.DoFileLock();
 		}
 	}
 
-	/* ‹¤—Lƒf[ƒ^\‘¢‘Ì‚ÌƒAƒhƒŒƒX‚ğ•Ô‚· */
+	/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿æ§‹é€ ä½“ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‚’è¿”ã™ */
 	CFileNameManager::getInstance()->TransformFileName_MakeCache();
 
 	CLogicPointEx* posSaveAry = NULL;
@@ -704,7 +704,7 @@ void CEditDoc::OnChangeSetting(
 		}
 	}else{
 		if( m_pcEditWnd->m_pPrintPreview ){
-			// ˆê“I‚Éİ’è‚ğ–ß‚·
+			// ä¸€æ™‚çš„ã«è¨­å®šã‚’æˆ»ã™
 			SelectCharWidthCache( CWM_FONT_EDIT, CWM_CACHE_NEUTRAL );
 		}
 		if( bDoLayout ){
@@ -712,7 +712,7 @@ void CEditDoc::OnChangeSetting(
 		}
 	}
 
-	// ‹Œî•ñ‚Ì•Û
+	// æ—§æƒ…å ±ã®ä¿æŒ
 	const int nTypeId = m_cDocType.GetDocumentAttribute().m_id;
 	const bool bFontTypeOld = m_cDocType.GetDocumentAttribute().m_bUseTypeFont;
 	int nFontPointSizeOld = m_nPointSizeOrg;
@@ -721,12 +721,12 @@ void CEditDoc::OnChangeSetting(
 	}
 	const CKetaXInt nTabSpaceOld = m_cDocType.GetDocumentAttribute().m_nTabSpace;
 
-	// •¶‘í•Ê
+	// æ–‡æ›¸ç¨®åˆ¥
 	m_cDocType.SetDocumentType( CDocTypeManager().GetDocumentTypeOfPath( m_cDocFile.GetFilePath() ), false );
 
 	const STypeConfig& ref = m_cDocType.GetDocumentAttribute();
 
-	// ƒ^ƒCƒv•Êİ’è‚Ìí—Ş‚ª•ÏX‚³‚ê‚½‚çAˆê“K—p‚ğŒ³‚É–ß‚·
+	// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®ç¨®é¡ãŒå¤‰æ›´ã•ã‚ŒãŸã‚‰ã€ä¸€æ™‚é©ç”¨ã‚’å…ƒã«æˆ»ã™
 	if( nTypeId != ref.m_id ){
 		m_blfCurTemp = false;
 		if( bDoLayout ){
@@ -735,21 +735,21 @@ void CEditDoc::OnChangeSetting(
 		}
 	}
 
-	// ƒtƒHƒ“ƒgƒTƒCƒY‚Ìˆêİ’è
+	// ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºã®ä¸€æ™‚è¨­å®š
 	if( m_blfCurTemp ){
 		if( bFontTypeOld != ref.m_bUseTypeFont ){
 			m_blfCurTemp = false;
 		}else if( nFontPointSizeOld != pCEditWnd->GetFontPointSize(false) ){
-			m_blfCurTemp = false; // ƒtƒHƒ“ƒgİ’è‚ª•ÏX‚³‚ê‚½BŒ³‚É–ß‚·
+			m_blfCurTemp = false; // ãƒ•ã‚©ãƒ³ãƒˆè¨­å®šãŒå¤‰æ›´ã•ã‚ŒãŸã€‚å…ƒã«æˆ»ã™
 		}else{
-			// ƒtƒHƒ“ƒg‚Ìí—Ş‚Ì•ÏX‚É’Ç‚·‚é
+			// ãƒ•ã‚©ãƒ³ãƒˆã®ç¨®é¡ã®å¤‰æ›´ã«è¿½éšã™ã‚‹
 			int lfHeight = m_lfCur.lfHeight;
 			m_lfCur = pCEditWnd->GetLogfont(false);
 			m_lfCur.lfHeight = lfHeight;
 		}
 	}
 
-	// ƒtƒHƒ“ƒgXV
+	// ãƒ•ã‚©ãƒ³ãƒˆæ›´æ–°
 	m_pcEditWnd->m_pcViewFont->UpdateFont(&m_pcEditWnd->GetLogfont());
 	m_pcEditWnd->m_pcViewFontMiniMap->UpdateFont(&m_pcEditWnd->GetLogfont());
 
@@ -761,51 +761,51 @@ void CEditDoc::OnChangeSetting(
 	CKetaXInt nTabSpace = ref.m_nTabSpace;
 	int nTsvMode = ref.m_nTsvMode;
 	if( bDoLayout ){
-		// 2008.06.07 nasukoji	Ü‚è•Ô‚µ•û–@‚Ì’Ç‰Á‚É‘Î‰
-		// Ü‚è•Ô‚µ•û–@‚Ìˆêİ’è‚Æƒ^ƒCƒv•Êİ’è‚ªˆê’v‚µ‚½‚çˆêİ’è“K—p’†‚Í‰ğœ
+		// 2008.06.07 nasukoji	æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã®è¿½åŠ ã«å¯¾å¿œ
+		// æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã®ä¸€æ™‚è¨­å®šã¨ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãŒä¸€è‡´ã—ãŸã‚‰ä¸€æ™‚è¨­å®šé©ç”¨ä¸­ã¯è§£é™¤
 		if( m_nTextWrapMethodCur == ref.m_nTextWrapMethod ){
 			if( m_nTextWrapMethodCur == WRAP_SETTING_WIDTH
 				&& m_cLayoutMgr.GetMaxLineKetas() != ref.m_nMaxLineKetas ){
-				// 2013.05.29 Ü‚è•Ô‚µ•‚ªˆá‚¤‚Ì‚Å‚»‚Ì‚Ü‚Ü‚É‚·‚é
+				// 2013.05.29 æŠ˜ã‚Šè¿”ã—å¹…ãŒé•ã†ã®ã§ãã®ã¾ã¾ã«ã™ã‚‹
 			}else if( bDoLayout ){
-				m_bTextWrapMethodCurTemp = false;		// ˆêİ’è“K—p’†‚ğ‰ğœ
+				m_bTextWrapMethodCurTemp = false;		// ä¸€æ™‚è¨­å®šé©ç”¨ä¸­ã‚’è§£é™¤
 			}
 		}
-		// ˆêİ’è“K—p’†‚Å‚È‚¯‚ê‚ÎÜ‚è•Ô‚µ•û–@•ÏX
+		// ä¸€æ™‚è¨­å®šé©ç”¨ä¸­ã§ãªã‘ã‚Œã°æŠ˜ã‚Šè¿”ã—æ–¹æ³•å¤‰æ›´
 		if( !m_bTextWrapMethodCurTemp )
-			m_nTextWrapMethodCur = ref.m_nTextWrapMethod;	// Ü‚è•Ô‚µ•û–@
+			m_nTextWrapMethodCur = ref.m_nTextWrapMethod;	// æŠ˜ã‚Šè¿”ã—æ–¹æ³•
 
-		// w’èŒ…‚ÅÜ‚è•Ô‚·Fƒ^ƒCƒv•Êİ’è‚ğg—p
-		// ‰E’[‚ÅÜ‚è•Ô‚·F‰¼‚ÉŒ»İ‚ÌÜ‚è•Ô‚µ•‚ğg—p
-		// ã‹LˆÈŠOFMAXLINEKETAS‚ğg—p
+		// æŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™ï¼šã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚’ä½¿ç”¨
+		// å³ç«¯ã§æŠ˜ã‚Šè¿”ã™ï¼šä»®ã«ç¾åœ¨ã®æŠ˜ã‚Šè¿”ã—å¹…ã‚’ä½¿ç”¨
+		// ä¸Šè¨˜ä»¥å¤–ï¼šMAXLINEKETASã‚’ä½¿ç”¨
 		switch( m_nTextWrapMethodCur ){
 		case WRAP_NO_TEXT_WRAP:
 			nMaxLineKetas = MAXLINEKETAS;
 			break;
 		case WRAP_SETTING_WIDTH:
 			if( m_bTextWrapMethodCurTemp ){
-				// 2013.05.29 Œ»İ‚Ìˆê“K—p‚ÌÜ‚è•Ô‚µ•‚ğg‚¤‚æ‚¤‚É
+				// 2013.05.29 ç¾åœ¨ã®ä¸€æ™‚é©ç”¨ã®æŠ˜ã‚Šè¿”ã—å¹…ã‚’ä½¿ã†ã‚ˆã†ã«
 				nMaxLineKetas = m_cLayoutMgr.GetMaxLineKetas();
 			}
 			break;
 		case WRAP_WINDOW_WIDTH:
-			nMaxLineKetas = m_cLayoutMgr.GetMaxLineKetas();	// Œ»İ‚ÌÜ‚è•Ô‚µ•
+			nMaxLineKetas = m_cLayoutMgr.GetMaxLineKetas();	// ç¾åœ¨ã®æŠ˜ã‚Šè¿”ã—å¹…
 			break;
 		}
 
 		if( m_bTabSpaceCurTemp ){
 			if( nTabSpaceOld != ref.m_nTabSpace ){
-				// ƒ^ƒCƒv•Êİ’è‚ª•ÏX‚³‚ê‚½‚Ì‚Åˆê“K—p‰ğœ
+				// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãŒå¤‰æ›´ã•ã‚ŒãŸã®ã§ä¸€æ™‚é©ç”¨è§£é™¤
 				m_bTabSpaceCurTemp = false;
 			}else{
-				// ˆê“K—pŒp‘±
+				// ä¸€æ™‚é©ç”¨ç¶™ç¶š
 				nTabSpace = m_cLayoutMgr.GetTabSpaceKetas();
 			}
 		}
 	}else{
-		// ƒŒƒCƒAƒEƒg‚ğÄ\’z‚µ‚È‚¢‚Ì‚ÅŒ³‚Ìİ’è‚ğˆÛ
-		nMaxLineKetas = m_cLayoutMgr.GetMaxLineKetas();	// Œ»İ‚ÌÜ‚è•Ô‚µ•
-		nTabSpace = m_cLayoutMgr.GetTabSpaceKetas();	// Œ»İ‚Ìƒ^ƒu•
+		// ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã‚’å†æ§‹ç¯‰ã—ãªã„ã®ã§å…ƒã®è¨­å®šã‚’ç¶­æŒ
+		nMaxLineKetas = m_cLayoutMgr.GetMaxLineKetas();	// ç¾åœ¨ã®æŠ˜ã‚Šè¿”ã—å¹…
+		nTabSpace = m_cLayoutMgr.GetTabSpaceKetas();	// ç¾åœ¨ã®ã‚¿ãƒ–å¹…
 	}
 	CProgressSubject* pOld = CEditApp::getInstance()->m_pcVisualProgress->CProgressListener::Listen(&m_cLayoutMgr);
 	m_cLayoutMgr.SetLayoutInfo( bDoLayout, bBlockingHook, ref, nTabSpace, nTsvMode, nMaxLineKetas, CLayoutXInt(-1), &m_pcEditWnd->GetLogfont() );
@@ -813,13 +813,13 @@ void CEditDoc::OnChangeSetting(
 	m_pcEditWnd->ClearViewCaretPosInfo();
 
 
-	// 2009.08.28 nasukoji	uÜ‚è•Ô‚³‚È‚¢v‚È‚çƒeƒLƒXƒgÅ‘å•‚ğZoA‚»‚êˆÈŠO‚Í•Ï”‚ğƒNƒŠƒA
+	// 2009.08.28 nasukoji	ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€ãªã‚‰ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’ç®—å‡ºã€ãã‚Œä»¥å¤–ã¯å¤‰æ•°ã‚’ã‚¯ãƒªã‚¢
 	if( m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP )
-		m_cLayoutMgr.CalculateTextWidth();		// ƒeƒLƒXƒgÅ‘å•‚ğZo‚·‚é
+		m_cLayoutMgr.CalculateTextWidth();		// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹
 	else
-		m_cLayoutMgr.ClearLayoutLineWidth();	// Šes‚ÌƒŒƒCƒAƒEƒgs’·‚Ì‹L‰¯‚ğƒNƒŠƒA‚·‚é
+		m_cLayoutMgr.ClearLayoutLineWidth();	// å„è¡Œã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œé•·ã®è¨˜æ†¶ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹
 
-	/* ƒrƒ…[‚Éİ’è•ÏX‚ğ”½‰f‚³‚¹‚é */
+	/* ãƒ“ãƒ¥ãƒ¼ã«è¨­å®šå¤‰æ›´ã‚’åæ˜ ã•ã›ã‚‹ */
 	int viewCount = m_pcEditWnd->GetAllViewCount();
 	for( i = 0; i < viewCount; ++i ){
 		m_pcEditWnd->GetView(i).OnChangeSetting();
@@ -836,48 +836,48 @@ void CEditDoc::OnChangeSetting(
 		::ShowWindow( hwndProgress, SW_HIDE );
 	}
 	if( m_pcEditWnd->m_pPrintPreview ){
-		// İ’è‚ğ–ß‚·
+		// è¨­å®šã‚’æˆ»ã™
 		SelectCharWidthCache( CWM_FONT_PRINT, CWM_CACHE_LOCAL );
 	}
 
-	// eƒEƒBƒ“ƒhƒE‚Ìƒ^ƒCƒgƒ‹‚ğXV
+	// è¦ªã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã‚¿ã‚¤ãƒˆãƒ«ã‚’æ›´æ–°
 	m_pcEditWnd->UpdateCaption();
 }
 
-/*! ƒtƒ@ƒCƒ‹‚ğ•Â‚¶‚é‚Æ‚«‚ÌMRU“o˜^ & •Û‘¶Šm”F • •Û‘¶Às
+/*! ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‰ã˜ã‚‹ã¨ãã®MRUç™»éŒ² & ä¿å­˜ç¢ºèª ï¼† ä¿å­˜å®Ÿè¡Œ
 
-	@retval TRUE: I—¹‚µ‚Ä—Ç‚¢ / FALSE: I—¹‚µ‚È‚¢
+	@retval TRUE: çµ‚äº†ã—ã¦è‰¯ã„ / FALSE: çµ‚äº†ã—ãªã„
 */
 BOOL CEditDoc::OnFileClose(bool bGrepNoConfirm)
 {
 	int			nRet;
 	int			nBool;
 
-	//ƒNƒ[ƒY–‘Oˆ—
+	//ã‚¯ãƒ­ãƒ¼ã‚ºäº‹å‰å‡¦ç†
 	ECallbackResult eBeforeCloseResult = NotifyBeforeClose();
 	if(eBeforeCloseResult==CALLBACK_INTERRUPT)return FALSE;
 
 
-	// ƒfƒoƒbƒOƒ‚ƒjƒ^ƒ‚[ƒh‚Ì‚Æ‚«‚Í•Û‘¶Šm”F‚µ‚È‚¢
+	// ãƒ‡ãƒãƒƒã‚°ãƒ¢ãƒ‹ã‚¿ãƒ¢ãƒ¼ãƒ‰ã®ã¨ãã¯ä¿å­˜ç¢ºèªã—ãªã„
 	if(CAppMode::getInstance()->IsDebugMode())return TRUE;
 
-	//GREPƒ‚[ƒh‚ÅA‚©‚ÂAuGREPƒ‚[ƒh‚Å•Û‘¶Šm”F‚·‚é‚©v‚ªOFF‚¾‚Á‚½‚çA•Û‘¶Šm”F‚µ‚È‚¢
-	// 2011.11.13 Grepƒ‚[ƒh‚ÅGrep’¼Œã‚Í"–¢•ÒW"ó‘Ô‚É‚È‚Á‚Ä‚¢‚é‚ª•Û‘¶Šm”F‚ª•K—v
+	//GREPãƒ¢ãƒ¼ãƒ‰ã§ã€ã‹ã¤ã€ã€ŒGREPãƒ¢ãƒ¼ãƒ‰ã§ä¿å­˜ç¢ºèªã™ã‚‹ã‹ã€ãŒOFFã ã£ãŸã‚‰ã€ä¿å­˜ç¢ºèªã—ãªã„
+	// 2011.11.13 Grepãƒ¢ãƒ¼ãƒ‰ã§Grepç›´å¾Œã¯"æœªç·¨é›†"çŠ¶æ…‹ã«ãªã£ã¦ã„ã‚‹ãŒä¿å­˜ç¢ºèªãŒå¿…è¦
 	if( CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode ){
-		if( bGrepNoConfirm ){ // Grep‚Å•Û‘¶Šm”F‚µ‚È‚¢ƒ‚[ƒh
+		if( bGrepNoConfirm ){ // Grepã§ä¿å­˜ç¢ºèªã—ãªã„ãƒ¢ãƒ¼ãƒ‰
 			return TRUE;
 		}
 		if( !GetDllShareData().m_Common.m_sSearch.m_bGrepExitConfirm ){
 			return TRUE;
 		}
 	}else{
-		//ƒeƒLƒXƒg,•¶šƒR[ƒhƒZƒbƒg‚ª•ÏX‚³‚ê‚Ä‚¢‚È‚¢ê‡‚Í•Û‘¶Šm”F‚µ‚È‚¢
+		//ãƒ†ã‚­ã‚¹ãƒˆ,æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆãŒå¤‰æ›´ã•ã‚Œã¦ã„ãªã„å ´åˆã¯ä¿å­˜ç¢ºèªã—ãªã„
 		if (!m_cDocEditor.IsModified() && !m_cDocFile.IsChgCodeSet()) {
 			return TRUE;
 		}
 	}
 
-	// -- -- •Û‘¶Šm”F -- -- //
+	// -- -- ä¿å­˜ç¢ºèª -- -- //
 	TCHAR szGrepTitle[90];
 	LPCTSTR pszTitle = m_cDocFile.GetFilePathClass().IsValidPath() ? m_cDocFile.GetFilePath() : NULL;
 	if( CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode ){
@@ -893,13 +893,13 @@ BOOL CEditDoc::OnFileClose(bool bGrepNoConfirm)
 	}
 	if( NULL == pszTitle ){
 		const EditNode* node = CAppNodeManager::getInstance()->GetEditNode( CEditWnd::getInstance()->GetHwnd() );
-		auto_sprintf( szGrepTitle, _T("%s%d"), LS(STR_NO_TITLE1), node->m_nId );	//(–³‘è)
+		auto_sprintf( szGrepTitle, _T("%s%d"), LS(STR_NO_TITLE1), node->m_nId );	//(ç„¡é¡Œ)
 		pszTitle = szGrepTitle;
 	}
-	/* ƒEƒBƒ“ƒhƒE‚ğƒAƒNƒeƒBƒu‚É‚·‚é */
+	/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹ */
 	HWND	hwndMainFrame = CEditWnd::getInstance()->GetHwnd();
 	ActivateFrameWindow( hwndMainFrame );
-	if( CAppMode::getInstance()->IsViewMode() ){	/* ƒrƒ…[ƒ‚[ƒh */
+	if( CAppMode::getInstance()->IsViewMode() ){	/* ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ */
 		ConfirmBeep();
 		nRet = ::MYMESSAGEBOX(
 			hwndMainFrame,
@@ -952,41 +952,41 @@ BOOL CEditDoc::OnFileClose(bool bGrepNoConfirm)
 		case IDCANCEL:
 		default:
 			if (m_cDocFile.IsChgCodeSet()) {
-				m_cDocFile.CancelChgCodeSet();	// •¶šƒR[ƒhƒZƒbƒg‚Ì•ÏX‚ğƒLƒƒƒ“ƒZƒ‹‚·‚é
-				this->m_pcEditWnd->GetActiveView().GetCaret().ShowCaretPosInfo();	// ƒXƒe[ƒ^ƒX•\¦
+				m_cDocFile.CancelChgCodeSet();	// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã®å¤‰æ›´ã‚’ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã™ã‚‹
+				this->m_pcEditWnd->GetActiveView().GetCaret().ShowCaretPosInfo();	// ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹è¡¨ç¤º
 			}
 			return FALSE;
 		}
 	}
 }
 
-/*!	@brief ƒ}ƒNƒ©“®Às
+/*!	@brief ãƒã‚¯ãƒ­è‡ªå‹•å®Ÿè¡Œ
 
-	@param type [in] ©“®Àsƒ}ƒNƒ”Ô†
+	@param type [in] è‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå·
 	@return
 
 	@author ryoji
-	@date 2006.09.01 ryoji ì¬
-	@date 2007.07.20 genta HandleCommand‚É’Ç‰Áî•ñ‚ğ“n‚·D
-		©“®Àsƒ}ƒNƒ‚Å”­s‚µ‚½ƒRƒ}ƒ“ƒh‚ÍƒL[ƒ}ƒNƒ‚É•Û‘¶‚µ‚È‚¢
+	@date 2006.09.01 ryoji ä½œæˆ
+	@date 2007.07.20 genta HandleCommandã«è¿½åŠ æƒ…å ±ã‚’æ¸¡ã™ï¼
+		è‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ã§ç™ºè¡Œã—ãŸã‚³ãƒãƒ³ãƒ‰ã¯ã‚­ãƒ¼ãƒã‚¯ãƒ­ã«ä¿å­˜ã—ãªã„
 */
 void CEditDoc::RunAutoMacro( int idx, LPCTSTR pszSaveFilePath )
 {
-	// ŠJƒtƒ@ƒCƒ‹^ƒ^ƒCƒv•ÏX‚ÍƒAƒEƒgƒ‰ƒCƒ“‚ğÄ‰ğÍ‚·‚é
+	// é–‹ãƒ•ã‚¡ã‚¤ãƒ«ï¼ã‚¿ã‚¤ãƒ—å¤‰æ›´æ™‚ã¯ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã‚’å†è§£æã™ã‚‹
 	if( pszSaveFilePath == NULL ){
 		m_pcEditWnd->m_cDlgFuncList.Refresh();
 	}
 
 	static bool bRunning = false;
 	if( bRunning )
-		return;	// Ä“ü‚èÀs‚Í‚µ‚È‚¢
+		return;	// å†å…¥ã‚Šå®Ÿè¡Œã¯ã—ãªã„
 
 	bRunning = true;
 	if( CEditApp::getInstance()->m_pcSMacroMgr->IsEnabled(idx) ){
-		if( !( ::GetAsyncKeyState(VK_SHIFT) & 0x8000 ) ){	// Shift ƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚È‚¯‚ê‚ÎÀs
+		if( !( ::GetAsyncKeyState(VK_SHIFT) & 0x8000 ) ){	// Shift ã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãªã‘ã‚Œã°å®Ÿè¡Œ
 			if( NULL != pszSaveFilePath )
 				m_cDocFile.SetSaveFilePath(pszSaveFilePath);
-			//	2007.07.20 genta ©“®Àsƒ}ƒNƒ‚Å”­s‚µ‚½ƒRƒ}ƒ“ƒh‚ÍƒL[ƒ}ƒNƒ‚É•Û‘¶‚µ‚È‚¢
+			//	2007.07.20 genta è‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ã§ç™ºè¡Œã—ãŸã‚³ãƒãƒ³ãƒ‰ã¯ã‚­ãƒ¼ãƒã‚¯ãƒ­ã«ä¿å­˜ã—ãªã„
 			HandleCommand((EFunctionCode)(( F_USERMACRO_0 + idx ) | FA_NONRECORD) );
 			m_cDocFile.SetSaveFilePath(_T(""));
 		}
@@ -994,12 +994,12 @@ void CEditDoc::RunAutoMacro( int idx, LPCTSTR pszSaveFilePath )
 	bRunning = false;
 }
 
-/*! (–³‘è)‚Ì‚ÌƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚ğİ’è‚·‚é
+/*! (ç„¡é¡Œ)ã®æ™‚ã®ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’è¨­å®šã™ã‚‹
 */
 void CEditDoc::SetCurDirNotitle()
 {
 	if( m_cDocFile.GetFilePathClass().IsValidPath() ){
-		return; // ƒtƒ@ƒCƒ‹‚ª‚ ‚é‚Æ‚«‚Í‰½‚à‚µ‚È‚¢
+		return; // ãƒ•ã‚¡ã‚¤ãƒ«ãŒã‚ã‚‹ã¨ãã¯ä½•ã‚‚ã—ãªã„
 	}
 	EOpenDialogDir eOpenDialogDir = GetDllShareData().m_Common.m_sEdit.m_eOpenDialogDir;
 	TCHAR szSelDir[_MAX_PATH];

--- a/sakura_core/doc/CEditDoc.h
+++ b/sakura_core/doc/CEditDoc.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief •¶‘ŠÖ˜Aî•ñ‚ÌŠÇ—
+ï»¿/*!	@file
+	@brief æ–‡æ›¸é–¢é€£æƒ…å ±ã®ç®¡ç†
 
 	@author Norio Nakatani
-	@date	1998/03/13 ì¬
+	@date	1998/03/13 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -66,67 +66,67 @@ class CFuncInfoArr;
 class CEditApp;
 
 /*!
-	•¶‘ŠÖ˜Aî•ñ‚ÌŠÇ—
+	æ–‡æ›¸é–¢é€£æƒ…å ±ã®ç®¡ç†
 
-	@date 2002.02.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
-	@date 2007.12.13 kobake GetDocumentEncodingì¬
-	@date 2007.12.13 kobake SetDocumentEncodingì¬
-	@date 2007.12.13 kobake IsViewModeì¬
+	@date 2002.02.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
+	@date 2007.12.13 kobake GetDocumentEncodingä½œæˆ
+	@date 2007.12.13 kobake SetDocumentEncodingä½œæˆ
+	@date 2007.12.13 kobake IsViewModeä½œæˆ
 */
 class CEditDoc
 : public CDocSubject
 , public TInstanceHolder<CEditDoc>
 {
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CEditDoc(CEditApp* pcApp);
 	~CEditDoc();
 
-	//‰Šú‰»
+	//åˆæœŸåŒ–
 	BOOL Create( CEditWnd* pcEditWnd );
-	void InitDoc();	/* Šù‘¶ƒf[ƒ^‚ÌƒNƒŠƒA */
-	void InitAllView();	/* ‘Sƒrƒ…[‚Ì‰Šú‰»Fƒtƒ@ƒCƒ‹ƒI[ƒvƒ“/ƒNƒ[ƒY“™‚ÉAƒrƒ…[‚ğ‰Šú‰»‚·‚é */
+	void InitDoc();	/* æ—¢å­˜ãƒ‡ãƒ¼ã‚¿ã®ã‚¯ãƒªã‚¢ */
+	void InitAllView();	/* å…¨ãƒ“ãƒ¥ãƒ¼ã®åˆæœŸåŒ–ï¼šãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³/ã‚¯ãƒ­ãƒ¼ã‚ºæ™‚ç­‰ã«ã€ãƒ“ãƒ¥ãƒ¼ã‚’åˆæœŸåŒ–ã™ã‚‹ */
 	void Clear();
 
-	//İ’è
+	//è¨­å®š
 	void SetFilePathAndIcon(const TCHAR* szFile);	// Sep. 9, 2002 genta
 
-	//‘®«
-	ECodeType	GetDocumentEncoding() const;				//!< ƒhƒLƒ…ƒƒ“ƒg‚Ì•¶šƒR[ƒh‚ğæ“¾
-	bool		GetDocumentBomExist() const;				//!< ƒhƒLƒ…ƒƒ“ƒg‚ÌBOM•t‰Á‚ğæ“¾
-	void		SetDocumentEncoding(ECodeType eCharCode, bool bBom);	//!< ƒhƒLƒ…ƒƒ“ƒg‚Ì•¶šƒR[ƒh‚ğİ’è
-	bool IsModificationForbidden( EFunctionCode nCommand ) const;	//!< w’èƒRƒ}ƒ“ƒh‚É‚æ‚é‘‚«Š·‚¦‚ª‹Ö~‚³‚ê‚Ä‚¢‚é‚©‚Ç‚¤‚©	//Aug. 14, 2000 genta
-	bool IsEditable() const { return !CAppMode::getInstance()->IsViewMode() && !(!m_cDocLocker.IsDocWritable() && GetDllShareData().m_Common.m_sFile.m_bUneditableIfUnwritable); }	//!< •ÒW‰Â”\‚©‚Ç‚¤‚©
-	void GetSaveInfo(SSaveInfo* pSaveInfo) const;			//!< ƒZ[ƒuî•ñ‚ğæ“¾
+	//å±æ€§
+	ECodeType	GetDocumentEncoding() const;				//!< ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚’å–å¾—
+	bool		GetDocumentBomExist() const;				//!< ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã®BOMä»˜åŠ ã‚’å–å¾—
+	void		SetDocumentEncoding(ECodeType eCharCode, bool bBom);	//!< ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚’è¨­å®š
+	bool IsModificationForbidden( EFunctionCode nCommand ) const;	//!< æŒ‡å®šã‚³ãƒãƒ³ãƒ‰ã«ã‚ˆã‚‹æ›¸ãæ›ãˆãŒç¦æ­¢ã•ã‚Œã¦ã„ã‚‹ã‹ã©ã†ã‹	//Aug. 14, 2000 genta
+	bool IsEditable() const { return !CAppMode::getInstance()->IsViewMode() && !(!m_cDocLocker.IsDocWritable() && GetDllShareData().m_Common.m_sFile.m_bUneditableIfUnwritable); }	//!< ç·¨é›†å¯èƒ½ã‹ã©ã†ã‹
+	void GetSaveInfo(SSaveInfo* pSaveInfo) const;			//!< ã‚»ãƒ¼ãƒ–æƒ…å ±ã‚’å–å¾—
 
-	//ó‘Ô
-	void GetEditInfo( EditInfo* ) const;	//!< •ÒWƒtƒ@ƒCƒ‹î•ñ‚ğæ“¾ //2007.10.24 kobake ŠÖ”–¼•ÏX: SetFileInfo¨GetEditInfo
-	bool IsAcceptLoad() const;				//!< ‚±‚ÌƒEƒBƒ“ƒhƒE‚Å(V‚µ‚¢ƒEƒBƒ“ƒhƒE‚ğŠJ‚©‚¸‚É)V‚µ‚¢ƒtƒ@ƒCƒ‹‚ğŠJ‚¯‚é‚©
+	//çŠ¶æ…‹
+	void GetEditInfo( EditInfo* ) const;	//!< ç·¨é›†ãƒ•ã‚¡ã‚¤ãƒ«æƒ…å ±ã‚’å–å¾— //2007.10.24 kobake é–¢æ•°åå¤‰æ›´: SetFileInfoâ†’GetEditInfo
+	bool IsAcceptLoad() const;				//!< ã“ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã§(æ–°ã—ã„ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã‹ãšã«)æ–°ã—ã„ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ã‚‹ã‹
 
-	//ƒCƒxƒ“ƒg
+	//ã‚¤ãƒ™ãƒ³ãƒˆ
 	BOOL HandleCommand( EFunctionCode );
 	void OnChangeType();
-	void OnChangeSetting(bool bDoLayout = true, bool bBlockingHook = true);		// ƒrƒ…[‚Éİ’è•ÏX‚ğ”½‰f‚³‚¹‚é
-	BOOL OnFileClose(bool);			/* ƒtƒ@ƒCƒ‹‚ğ•Â‚¶‚é‚Æ‚«‚ÌMRU“o˜^ & •Û‘¶Šm”F • •Û‘¶Às */
+	void OnChangeSetting(bool bDoLayout = true, bool bBlockingHook = true);		// ãƒ“ãƒ¥ãƒ¼ã«è¨­å®šå¤‰æ›´ã‚’åæ˜ ã•ã›ã‚‹
+	BOOL OnFileClose(bool);			/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‰ã˜ã‚‹ã¨ãã®MRUç™»éŒ² & ä¿å­˜ç¢ºèª ï¼† ä¿å­˜å®Ÿè¡Œ */
 
-	void RunAutoMacro( int idx, LPCTSTR pszSaveFilePath = NULL );	// 2006.09.01 ryoji ƒ}ƒNƒ©“®Às
+	void RunAutoMacro( int idx, LPCTSTR pszSaveFilePath = NULL );	// 2006.09.01 ryoji ãƒã‚¯ãƒ­è‡ªå‹•å®Ÿè¡Œ
 
 	void SetBackgroundImage();
 
 	void SetCurDirNotitle();
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                       ƒƒ“ƒo•Ï”ŒQ                          //
+	//                       ãƒ¡ãƒ³ãƒå¤‰æ•°ç¾¤                          //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//QÆ
+	//å‚ç…§
 	CEditWnd*		m_pcEditWnd;	//	Sep. 10, 2002
 
-	//ƒf[ƒ^\‘¢
+	//ãƒ‡ãƒ¼ã‚¿æ§‹é€ 
 	CDocLineMgr		m_cDocLineMgr;
 	CLayoutMgr		m_cLayoutMgr;
 
-	//Šeí‹@”\
+	//å„ç¨®æ©Ÿèƒ½
 public:
 	CDocFile			m_cDocFile;
 	CDocFileOperation	m_cDocFileOperation;
@@ -134,31 +134,31 @@ public:
 	CDocType			m_cDocType;
 	CCookieManager		m_cCookie;
 
-	//ƒwƒ‹ƒp
+	//ãƒ˜ãƒ«ãƒ‘
 public:
 	CBackupAgent		m_cBackupAgent;
-	CAutoSaveAgent		m_cAutoSaveAgent;		//!< ©“®•Û‘¶ŠÇ—
+	CAutoSaveAgent		m_cAutoSaveAgent;		//!< è‡ªå‹•ä¿å­˜ç®¡ç†
 	CAutoReloadAgent	m_cAutoReloadAgent;
 	CDocOutline			m_cDocOutline;
 	CDocLocker			m_cDocLocker;
 
-	//“®“Ió‘Ô
+	//å‹•çš„çŠ¶æ…‹
 public:
-	int				m_nCommandExecNum;			//!< ƒRƒ}ƒ“ƒhÀs‰ñ”
+	int				m_nCommandExecNum;			//!< ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œå›æ•°
 
-	//ŠÂ‹«î•ñ
+	//ç’°å¢ƒæƒ…å ±
 public:
-	CFuncLookup		m_cFuncLookup;				//!< ‹@”\–¼C‹@”\”Ô†‚È‚Ç‚Ìresolve
+	CFuncLookup		m_cFuncLookup;				//!< æ©Ÿèƒ½åï¼Œæ©Ÿèƒ½ç•ªå·ãªã©ã®resolve
 
-	//–¢®—•Ï”
+	//æœªæ•´ç†å¤‰æ•°
 public:
-	int				m_nTextWrapMethodCur;		// Ü‚è•Ô‚µ•û–@					// 2008.05.30 nasukoji
-	bool			m_bTextWrapMethodCurTemp;	// Ü‚è•Ô‚µ•û–@ˆêİ’è“K—p’†	// 2008.05.30 nasukoji
-	LOGFONT			m_lfCur;					// ˆêİ’èƒtƒHƒ“ƒg
-	int				m_nPointSizeCur;			// ˆêİ’èƒtƒHƒ“ƒgƒTƒCƒY
-	bool			m_blfCurTemp;				// ƒtƒHƒ“ƒgİ’è“K—p’†
-	int				m_nPointSizeOrg;			// Œ³‚ÌƒtƒHƒ“ƒgƒTƒCƒY
-	bool			m_bTabSpaceCurTemp;			// ƒ^ƒu•ˆêİ’è“K—p’†			// 2013.05.30 Moca
+	int				m_nTextWrapMethodCur;		// æŠ˜ã‚Šè¿”ã—æ–¹æ³•					// 2008.05.30 nasukoji
+	bool			m_bTextWrapMethodCurTemp;	// æŠ˜ã‚Šè¿”ã—æ–¹æ³•ä¸€æ™‚è¨­å®šé©ç”¨ä¸­	// 2008.05.30 nasukoji
+	LOGFONT			m_lfCur;					// ä¸€æ™‚è¨­å®šãƒ•ã‚©ãƒ³ãƒˆ
+	int				m_nPointSizeCur;			// ä¸€æ™‚è¨­å®šãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚º
+	bool			m_blfCurTemp;				// ãƒ•ã‚©ãƒ³ãƒˆè¨­å®šé©ç”¨ä¸­
+	int				m_nPointSizeOrg;			// å…ƒã®ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚º
+	bool			m_bTabSpaceCurTemp;			// ã‚¿ãƒ–å¹…ä¸€æ™‚è¨­å®šé©ç”¨ä¸­			// 2013.05.30 Moca
 
 	HBITMAP			m_hBackImg;
 	int				m_nBackImgWidth;

--- a/sakura_core/doc/CLineComment.cpp
+++ b/sakura_core/doc/CLineComment.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğŠÇ—‚·‚é
+ï»¿/*!	@file
+	@brief è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ç®¡ç†ã™ã‚‹
 
 	@author Yazaki
-	@date 2002/09/17 V‹Kì¬
+	@date 2002/09/17 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -24,10 +24,10 @@ CLineComment::CLineComment()
 }
 
 /*!
-	sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğƒRƒs[‚·‚é
-	@param n [in]           ƒRƒs[‘ÎÛ‚ÌƒRƒƒ“ƒg”Ô†
-	@param buffer [in]      ƒRƒƒ“ƒg•¶š—ñ
-	@param nCommentPos [in] ƒRƒƒ“ƒgˆÊ’uD-1‚Ì‚Æ‚«‚Íw’è–³‚µD
+	è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹
+	@param n [in]           ã‚³ãƒ”ãƒ¼å¯¾è±¡ã®ã‚³ãƒ¡ãƒ³ãƒˆç•ªå·
+	@param buffer [in]      ã‚³ãƒ¡ãƒ³ãƒˆæ–‡å­—åˆ—
+	@param nCommentPos [in] ã‚³ãƒ¡ãƒ³ãƒˆä½ç½®ï¼-1ã®ã¨ãã¯æŒ‡å®šç„¡ã—ï¼
 */
 void CLineComment::CopyTo( const int n, const wchar_t* buffer, int nCommentPos )
 {
@@ -49,11 +49,11 @@ bool CLineComment::Match( int nPos, const CStringRef& cStr ) const
 	int i;
 	for ( i=0; i<COMMENT_DELIMITER_NUM; i++ ){
 		if (
-			L'\0' != m_pszLineComment[i][0] &&	/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-			( m_nLineCommentPos[i] < 0 || nPos == m_nLineCommentPos[i] ) &&	//	ˆÊ’uw’èON.
-			nPos <= cStr.GetLength() - m_nLineCommentLen[i] &&	/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-			//0 == auto_memicmp( &cStr.GetPtr()[nPos], m_pszLineComment[i], m_nLineCommentLen[i] )	//”ñASCII‚à‘å•¶š¬•¶š‚ğ‹æ•Ê‚µ‚È‚¢	//###locale ˆË‘¶
-			0 == wmemicmp_ascii( &cStr.GetPtr()[nPos], m_pszLineComment[i], m_nLineCommentLen[i] )	//ASCII‚Ì‚İ‘å•¶š¬•¶š‚ğ‹æ•Ê‚µ‚È‚¢i‚‘¬j
+			L'\0' != m_pszLineComment[i][0] &&	/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+			( m_nLineCommentPos[i] < 0 || nPos == m_nLineCommentPos[i] ) &&	//	ä½ç½®æŒ‡å®šON.
+			nPos <= cStr.GetLength() - m_nLineCommentLen[i] &&	/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+			//0 == auto_memicmp( &cStr.GetPtr()[nPos], m_pszLineComment[i], m_nLineCommentLen[i] )	//éASCIIã‚‚å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã—ãªã„	//###locale ä¾å­˜
+			0 == wmemicmp_ascii( &cStr.GetPtr()[nPos], m_pszLineComment[i], m_nLineCommentLen[i] )	//ASCIIã®ã¿å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã—ãªã„ï¼ˆé«˜é€Ÿï¼‰
 		){
 			return true;
 		}

--- a/sakura_core/doc/CLineComment.h
+++ b/sakura_core/doc/CLineComment.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğŠÇ—‚·‚é
+ï»¿/*!	@file
+	@brief è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ç®¡ç†ã™ã‚‹
 
 	@author Yazaki
-	@date 2002/09/17 V‹Kì¬
+	@date 2002/09/17 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2002, Yazaki
@@ -18,25 +18,25 @@
 #include "_main/global.h"
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 #define COMMENT_DELIMITER_NUM	3
 #define COMMENT_DELIMITER_BUFFERSIZE	16
 
-/*! sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğŠÇ—‚·‚é
+/*! è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ç®¡ç†ã™ã‚‹
 
-	@note CLineComment‚ÍA‹¤—Lƒƒ‚ƒŠSTypeConfig‚ÉŠÜ‚Ü‚ê‚é‚Ì‚ÅAƒƒ“ƒo•Ï”‚Íí‚ÉÀ‘Ì‚ğ‚Á‚Ä‚¢‚È‚¯‚ê‚Î‚È‚ç‚È‚¢B
+	@note CLineCommentã¯ã€å…±æœ‰ãƒ¡ãƒ¢ãƒªSTypeConfigã«å«ã¾ã‚Œã‚‹ã®ã§ã€ãƒ¡ãƒ³ãƒå¤‰æ•°ã¯å¸¸ã«å®Ÿä½“ã‚’æŒã£ã¦ã„ãªã‘ã‚Œã°ãªã‚‰ãªã„ã€‚
 */
 class CLineComment
 {
 public:
 	/*
-	||  ConstructorsFƒRƒ“ƒpƒCƒ‰•W€‚ğg—pB
+	||  Constructorsï¼šã‚³ãƒ³ãƒ‘ã‚¤ãƒ©æ¨™æº–ã‚’ä½¿ç”¨ã€‚
 	*/
 	CLineComment();
 
-	void CopyTo( const int n, const wchar_t* buffer, int nCommentPos );	//	sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^‚ğƒRƒs[‚·‚é
-	bool Match( int nPos, const CStringRef& cStr ) const;	//	sƒRƒƒ“ƒg‚É’l‚·‚é‚©Šm”F‚·‚é
+	void CopyTo( const int n, const wchar_t* buffer, int nCommentPos );	//	è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹
+	bool Match( int nPos, const CStringRef& cStr ) const;	//	è¡Œã‚³ãƒ¡ãƒ³ãƒˆã«å€¤ã™ã‚‹ã‹ç¢ºèªã™ã‚‹
 
 	const wchar_t* getLineComment( const int n ){
 		return m_pszLineComment[n];
@@ -46,9 +46,9 @@ public:
 	}
 
 private:
-	wchar_t	m_pszLineComment[COMMENT_DELIMITER_NUM][COMMENT_DELIMITER_BUFFERSIZE];	//!< sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^
-	int		m_nLineCommentPos[COMMENT_DELIMITER_NUM];	//!< sƒRƒƒ“ƒg‚ÌŠJnˆÊ’u(•‰”‚Íw’è–³‚µ)
-	int		m_nLineCommentLen[COMMENT_DELIMITER_NUM];	//!< sƒRƒƒ“ƒg•¶š—ñ‚Ì’·‚³
+	wchar_t	m_pszLineComment[COMMENT_DELIMITER_NUM][COMMENT_DELIMITER_BUFFERSIZE];	//!< è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿
+	int		m_nLineCommentPos[COMMENT_DELIMITER_NUM];	//!< è¡Œã‚³ãƒ¡ãƒ³ãƒˆã®é–‹å§‹ä½ç½®(è² æ•°ã¯æŒ‡å®šç„¡ã—)
+	int		m_nLineCommentLen[COMMENT_DELIMITER_NUM];	//!< è¡Œã‚³ãƒ¡ãƒ³ãƒˆæ–‡å­—åˆ—ã®é•·ã•
 };
 
 

--- a/sakura_core/doc/layout/CLayout.cpp
+++ b/sakura_core/doc/layout/CLayout.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒeƒLƒXƒg‚ÌƒŒƒCƒAƒEƒgî•ñ
+ï»¿/*!	@file
+	@brief ãƒ†ã‚­ã‚¹ãƒˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±
 
 	@author Norio Nakatani
-	@date 1998/3/11 V‹Kì¬
+	@date 1998/3/11 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -15,7 +15,7 @@
 #include "CLayout.h"
 #include "CLayoutMgr.h"
 #include "charset/charcode.h"
-#include "extmodule/CBregexp.h" // CLayoutMgr‚Ì’è‹`‚Å•K—v
+#include "extmodule/CBregexp.h" // CLayoutMgrã®å®šç¾©ã§å¿…è¦
 
 
 
@@ -26,26 +26,26 @@ CLayout::~CLayout()
 
 void CLayout::DUMP( void )
 {
-	DEBUG_TRACE( _T("\n\n¡CLayout::DUMP()======================\n") );
-	DEBUG_TRACE( _T("m_ptLogicPos.y=%d\t\t‘Î‰ž‚·‚é˜_—s”Ô†\n"), m_ptLogicPos.y );
-	DEBUG_TRACE( _T("m_ptLogicPos.x=%d\t\t‘Î‰ž‚·‚é˜_—s‚Ìæ“ª‚©‚ç‚ÌƒIƒtƒZƒbƒg\n"), m_ptLogicPos.x );
-	DEBUG_TRACE( _T("m_nLength=%d\t\t‘Î‰ž‚·‚é˜_—s‚ÌƒnƒCƒg”\n"), (int)m_nLength );
-	DEBUG_TRACE( _T("m_nTypePrev=%d\t\tƒ^ƒCƒv 0=’Êí 1=sƒRƒƒ“ƒg 2=ƒuƒƒbƒNƒRƒƒ“ƒg 3=ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ 4=ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ \n"), m_nTypePrev );
+	DEBUG_TRACE( _T("\n\nâ– CLayout::DUMP()======================\n") );
+	DEBUG_TRACE( _T("m_ptLogicPos.y=%d\t\tå¯¾å¿œã™ã‚‹è«–ç†è¡Œç•ªå·\n"), m_ptLogicPos.y );
+	DEBUG_TRACE( _T("m_ptLogicPos.x=%d\t\tå¯¾å¿œã™ã‚‹è«–ç†è¡Œã®å…ˆé ­ã‹ã‚‰ã®ã‚ªãƒ•ã‚»ãƒƒãƒˆ\n"), m_ptLogicPos.x );
+	DEBUG_TRACE( _T("m_nLength=%d\t\tå¯¾å¿œã™ã‚‹è«–ç†è¡Œã®ãƒã‚¤ãƒˆæ•°\n"), (int)m_nLength );
+	DEBUG_TRACE( _T("m_nTypePrev=%d\t\tã‚¿ã‚¤ãƒ— 0=é€šå¸¸ 1=è¡Œã‚³ãƒ¡ãƒ³ãƒˆ 2=ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ 3=ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ— 4=ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ— \n"), m_nTypePrev );
 	DEBUG_TRACE( _T("======================\n") );
 	return;
 }
 
-//!ƒŒƒCƒAƒEƒg•‚ðŒvŽZB‰üs‚ÍŠÜ‚Ü‚È‚¢B
-//2007.10.11 kobake ì¬
-//2007.11.29 kobake ƒ^ƒu•‚ªŒvŽZ‚³‚ê‚Ä‚¢‚È‚©‚Á‚½‚Ì‚ðC³
-//2011.12.26 Moca ƒCƒ“ƒfƒ“ƒg‚ÍŠÜ‚Þ‚æ‚¤‚É•ÏX(À•W•ÏŠ·ƒoƒOC³)
+//!ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå¹…ã‚’è¨ˆç®—ã€‚æ”¹è¡Œã¯å«ã¾ãªã„ã€‚
+//2007.10.11 kobake ä½œæˆ
+//2007.11.29 kobake ã‚¿ãƒ–å¹…ãŒè¨ˆç®—ã•ã‚Œã¦ã„ãªã‹ã£ãŸã®ã‚’ä¿®æ­£
+//2011.12.26 Moca ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã¯å«ã‚€ã‚ˆã†ã«å¤‰æ›´(åº§æ¨™å¤‰æ›ãƒã‚°ä¿®æ­£)
 CLayoutInt CLayout::CalcLayoutWidth(const CLayoutMgr& cLayoutMgr) const
 {
-	//ƒ\[ƒX
+	//ã‚½ãƒ¼ã‚¹
 	const wchar_t* pText    = m_pCDocLine->GetPtr();
 	CLogicInt      nTextLen = m_pCDocLine->GetLengthWithoutEOL();
 
-	//ŒvŽZ
+	//è¨ˆç®—
 	CLayoutInt nWidth = GetIndent();
 	CLogicInt nLen = GetLogicPos().x + m_nLength; //EOL=0,1
 	for(CLogicInt i=m_ptLogicPos.GetX2();i<nLen;){
@@ -60,7 +60,7 @@ CLayoutInt CLayout::CalcLayoutWidth(const CLayoutMgr& cLayoutMgr) const
 	return nWidth;
 }
 
-//! ƒIƒtƒZƒbƒg’l‚ðƒŒƒCƒAƒEƒg’PˆÊ‚É•ÏŠ·‚µ‚ÄŽæ“¾B2007.10.17 kobake
+//! ã‚ªãƒ•ã‚»ãƒƒãƒˆå€¤ã‚’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã«å¤‰æ›ã—ã¦å–å¾—ã€‚2007.10.17 kobake
 CLayoutInt CLayout::CalcLayoutOffset(const CLayoutMgr& cLayoutMgr, CLogicInt nStartPos, CLayoutInt nStartOffset) const
 {
 	CLayoutInt nRet = nStartOffset;

--- a/sakura_core/doc/layout/CLayout.h
+++ b/sakura_core/doc/layout/CLayout.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒeƒLƒXƒg‚ÌƒŒƒCƒAƒEƒgî•ñ
+ï»¿/*!	@file
+	@brief ãƒ†ã‚­ã‚¹ãƒˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±
 
 	@author Norio Nakatani
-	@date 1998/3/11 V‹Kì¬
+	@date 1998/3/11 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -27,21 +27,21 @@ class CLayout;
 class CLayoutMgr;
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 class CLayout
 {
 protected:
-	friend class CLayoutMgr; //####‰¼
+	friend class CLayoutMgr; //####ä»®
 public:
 	/*
 	||  Constructors
 	*/
-	//2007.08.23 kobake ƒRƒ“ƒXƒgƒ‰ƒNƒ^‚Åƒƒ“ƒo•Ï”‚ğ‰Šú‰»‚·‚é‚æ‚¤‚É‚µ‚½
+	//2007.08.23 kobake ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã§ãƒ¡ãƒ³ãƒå¤‰æ•°ã‚’åˆæœŸåŒ–ã™ã‚‹ã‚ˆã†ã«ã—ãŸ
 	CLayout(
-		const CDocLine*	pcDocLine,		//!< Àƒf[ƒ^‚Ö‚ÌQÆ
-		CLogicPoint		ptLogicPos,		//!< Àƒf[ƒ^QÆˆÊ’u
-		CLogicInt		nLength,		//!< Àƒf[ƒ^“àƒf[ƒ^’·
+		const CDocLine*	pcDocLine,		//!< å®Ÿãƒ‡ãƒ¼ã‚¿ã¸ã®å‚ç…§
+		CLogicPoint		ptLogicPos,		//!< å®Ÿãƒ‡ãƒ¼ã‚¿å‚ç…§ä½ç½®
+		CLogicInt		nLength,		//!< å®Ÿãƒ‡ãƒ¼ã‚¿å†…ãƒ‡ãƒ¼ã‚¿é•·
 		EColorIndexType	nTypePrev,
 		CLayoutInt		nTypeIndent,
 		CLayoutColorInfo*		pColorInfo
@@ -50,30 +50,30 @@ public:
 		m_pPrev			= NULL;
 		m_pNext			= NULL;
 		m_pCDocLine		= pcDocLine;
-		m_ptLogicPos	= ptLogicPos;	// Àƒf[ƒ^QÆˆÊ’u
-		m_nLength		= nLength;		// Àƒf[ƒ^“àƒf[ƒ^’·
-		m_nTypePrev		= nTypePrev;	// ƒ^ƒCƒv 0=’Êí 1=sƒRƒƒ“ƒg 2=ƒuƒƒbƒNƒRƒƒ“ƒg 3=ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ 4=ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ
-		m_nIndent		= nTypeIndent;	// ‚±‚ÌƒŒƒCƒAƒEƒgs‚ÌƒCƒ“ƒfƒ“ƒg” @@@ 2002.09.23 YAZAKI
+		m_ptLogicPos	= ptLogicPos;	// å®Ÿãƒ‡ãƒ¼ã‚¿å‚ç…§ä½ç½®
+		m_nLength		= nLength;		// å®Ÿãƒ‡ãƒ¼ã‚¿å†…ãƒ‡ãƒ¼ã‚¿é•·
+		m_nTypePrev		= nTypePrev;	// ã‚¿ã‚¤ãƒ— 0=é€šå¸¸ 1=è¡Œã‚³ãƒ¡ãƒ³ãƒˆ 2=ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ 3=ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ— 4=ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—
+		m_nIndent		= nTypeIndent;	// ã“ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆæ•° @@@ 2002.09.23 YAZAKI
 		m_cExInfo.SetColorInfo(pColorInfo);
 	}
 	~CLayout();
 	void DUMP( void );
 	
-	// m_ptLogicPos.x‚Å•â³‚µ‚½‚ ‚Æ‚Ì•¶š—ñ‚ğ“¾‚é
+	// m_ptLogicPos.xã§è£œæ­£ã—ãŸã‚ã¨ã®æ–‡å­—åˆ—ã‚’å¾—ã‚‹
 	const wchar_t* GetPtr() const   { return m_pCDocLine->GetPtr() + m_ptLogicPos.x; }
-	CLogicInt GetLengthWithEOL() const    { return m_nLength;	}	//	‚½‚¾‚µEOL‚Íí‚É1•¶š‚ÆƒJƒEƒ“ƒgHH
+	CLogicInt GetLengthWithEOL() const    { return m_nLength;	}	//	ãŸã ã—EOLã¯å¸¸ã«1æ–‡å­—ã¨ã‚«ã‚¦ãƒ³ãƒˆï¼Ÿï¼Ÿ
 	CLogicInt GetLengthWithoutEOL() const { return m_nLength - (m_cEol.GetLen() ? 1 : 0);	}
-	//CLogicInt GetLength() const {	return m_nLength;	}	//	CMemoryIterator—piEOLŠÜ‚Şj
-	CLayoutInt GetIndent() const {	return m_nIndent;	}	//!< ‚±‚ÌƒŒƒCƒAƒEƒgs‚ÌƒCƒ“ƒfƒ“ƒgƒTƒCƒY‚ğæ“¾B’PˆÊ‚Í”¼Šp•¶šB	CMemoryIterator—p
+	//CLogicInt GetLength() const {	return m_nLength;	}	//	CMemoryIteratorç”¨ï¼ˆEOLå«ã‚€ï¼‰
+	CLayoutInt GetIndent() const {	return m_nIndent;	}	//!< ã“ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã‚µã‚¤ã‚ºã‚’å–å¾—ã€‚å˜ä½ã¯åŠè§’æ–‡å­—ã€‚	CMemoryIteratorç”¨
 
-	//æ“¾ƒCƒ“ƒ^[ƒtƒF[ƒX
-	CLogicInt GetLogicLineNo() const{ if(this)return m_ptLogicPos.GetY2(); else return CLogicInt(-1); } //$$$‚‘¬‰»
+	//å–å¾—ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
+	CLogicInt GetLogicLineNo() const{ if(this)return m_ptLogicPos.GetY2(); else return CLogicInt(-1); } //$$$é«˜é€ŸåŒ–
 	CLogicInt GetLogicOffset() const{ return m_ptLogicPos.GetX2(); }
 	CLogicPoint GetLogicPos() const{ return m_ptLogicPos; }
-	EColorIndexType GetColorTypePrev() const{ return m_nTypePrev; } //#########‰˜‚Á
-	CLayoutInt GetLayoutWidth() const{ return m_nLayoutWidth; }		// 2009.08.28 nasukoji	‚±‚ÌƒŒƒCƒAƒEƒgs‚Ì‰üs‚ğŠÜ‚ŞƒŒƒCƒAƒEƒg’·‚ğ•Ô‚·
+	EColorIndexType GetColorTypePrev() const{ return m_nTypePrev; } //#########æ±šã£
+	CLayoutInt GetLayoutWidth() const{ return m_nLayoutWidth; }		// 2009.08.28 nasukoji	ã“ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®æ”¹è¡Œã‚’å«ã‚€ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆé•·ã‚’è¿”ã™
 
-	//•ÏXƒCƒ“ƒ^[ƒtƒF[ƒX
+	//å¤‰æ›´ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 	void OffsetLogicLineNo(CLogicInt n){ m_ptLogicPos.y+=n; }
 	void SetColorTypePrev(EColorIndexType n)
 	{
@@ -81,16 +81,16 @@ public:
 	}
 	void SetLayoutWidth(CLayoutInt nWidth){ m_nLayoutWidth = nWidth; }
 
-	//!ƒŒƒCƒAƒEƒg•‚ğŒvZB‰üs‚ÍŠÜ‚Ü‚È‚¢B2007.10.11 kobake
+	//!ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå¹…ã‚’è¨ˆç®—ã€‚æ”¹è¡Œã¯å«ã¾ãªã„ã€‚2007.10.11 kobake
 	CLayoutInt CalcLayoutWidth(const CLayoutMgr& cLayoutMgr) const;
 
-	//! ƒIƒtƒZƒbƒg’l‚ğƒŒƒCƒAƒEƒg’PˆÊ‚É•ÏŠ·‚µ‚Äæ“¾B2007.10.17 kobake
+	//! ã‚ªãƒ•ã‚»ãƒƒãƒˆå€¤ã‚’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã«å¤‰æ›ã—ã¦å–å¾—ã€‚2007.10.17 kobake
 	CLayoutInt CalcLayoutOffset(const CLayoutMgr& cLayoutMgr, CLogicInt nStartPos = CLogicInt(0), CLayoutInt nStartOffset = CLayoutInt(0)) const;
 
-	//! •¶š—ñQÆ‚ğæ“¾
+	//! æ–‡å­—åˆ—å‚ç…§ã‚’å–å¾—
 	CStringRef GetStringRef() const{ return CStringRef(GetPtr(), GetLengthWithEOL()); }
 
-	//ƒ`ƒF[ƒ“‘®«
+	//ãƒã‚§ãƒ¼ãƒ³å±æ€§
 	CLayout* GetPrevLayout(){ return m_pPrev; }
 	const CLayout* GetPrevLayout() const{ return m_pPrev; }
 	CLayout* GetNextLayout(){ return m_pNext; }
@@ -98,10 +98,10 @@ public:
 	void _SetPrevLayout(CLayout* pcLayout){ m_pPrev = pcLayout; }
 	void _SetNextLayout(CLayout* pcLayout){ m_pNext = pcLayout; }
 
-	//Àƒf[ƒ^QÆ
-	const CDocLine* GetDocLineRef() const{ if(this)return m_pCDocLine; else return NULL; } //$$note:‚‘¬‰»
+	//å®Ÿãƒ‡ãƒ¼ã‚¿å‚ç…§
+	const CDocLine* GetDocLineRef() const{ if(this)return m_pCDocLine; else return NULL; } //$$note:é«˜é€ŸåŒ–
 
-	//‚»‚Ì‘¼‘®«QÆ
+	//ãã®ä»–å±æ€§å‚ç…§
 	const CEol& GetLayoutEol() const{ return m_cEol; }
 	const CLayoutColorInfo* GetColorInfo() const{ return m_cExInfo.GetColorInfo(); }
 	CLayoutExInfo* GetLayoutExInfo(){
@@ -112,17 +112,17 @@ private:
 	CLayout*			m_pPrev;
 	CLayout*			m_pNext;
 
-	//ƒf[ƒ^QÆ”ÍˆÍ
-	const CDocLine*		m_pCDocLine;		//!< Àƒf[ƒ^‚Ö‚ÌQÆ
-	CLogicPoint			m_ptLogicPos;		//!< ‘Î‰‚·‚éƒƒWƒbƒNQÆˆÊ’u
-	CLogicInt			m_nLength;			//!< ‚±‚ÌƒŒƒCƒAƒEƒgs‚Ì’·‚³B•¶š’PˆÊB
+	//ãƒ‡ãƒ¼ã‚¿å‚ç…§ç¯„å›²
+	const CDocLine*		m_pCDocLine;		//!< å®Ÿãƒ‡ãƒ¼ã‚¿ã¸ã®å‚ç…§
+	CLogicPoint			m_ptLogicPos;		//!< å¯¾å¿œã™ã‚‹ãƒ­ã‚¸ãƒƒã‚¯å‚ç…§ä½ç½®
+	CLogicInt			m_nLength;			//!< ã“ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®é•·ã•ã€‚æ–‡å­—å˜ä½ã€‚
 	
-	//‚»‚Ì‘¼‘®«
-	EColorIndexType		m_nTypePrev;		//!< ƒ^ƒCƒv 0=’Êí 1=sƒRƒƒ“ƒg 2=ƒuƒƒbƒNƒRƒƒ“ƒg 3=ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ 4=ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ
-	CLayoutInt			m_nIndent;			//!< ‚±‚ÌƒŒƒCƒAƒEƒgs‚ÌƒCƒ“ƒfƒ“ƒg” @@@ 2002.09.23 YAZAKI
+	//ãã®ä»–å±æ€§
+	EColorIndexType		m_nTypePrev;		//!< ã‚¿ã‚¤ãƒ— 0=é€šå¸¸ 1=è¡Œã‚³ãƒ¡ãƒ³ãƒˆ 2=ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ 3=ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ— 4=ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—
+	CLayoutInt			m_nIndent;			//!< ã“ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆæ•° @@@ 2002.09.23 YAZAKI
 	CEol				m_cEol;
-	CLayoutInt			m_nLayoutWidth;		//!< ‚±‚ÌƒŒƒCƒAƒEƒgs‚Ì‰üs‚ğŠÜ‚ŞƒŒƒCƒAƒEƒg’·iuÜ‚è•Ô‚³‚È‚¢v‘I‘ğ‚Ì‚İj	// 2009.08.28 nasukoji
-	CLayoutExInfo		m_cExInfo;			//!< F•ª‚¯Ú×î•ñ
+	CLayoutInt			m_nLayoutWidth;		//!< ã“ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®æ”¹è¡Œã‚’å«ã‚€ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆé•·ï¼ˆã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€é¸æŠæ™‚ã®ã¿ï¼‰	// 2009.08.28 nasukoji
+	CLayoutExInfo		m_cExInfo;			//!< è‰²åˆ†ã‘è©³ç´°æƒ…å ±
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(CLayout);

--- a/sakura_core/doc/layout/CLayoutExInfo.h
+++ b/sakura_core/doc/layout/CLayoutExInfo.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2011, Moca
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒeƒLƒXƒg‚ÌƒŒƒCƒAƒEƒgî•ñŠÇ—
+ï»¿/*!	@file
+	@brief ãƒ†ã‚­ã‚¹ãƒˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ç®¡ç†
 
 	@author Norio Nakatani
 */
@@ -33,23 +33,23 @@
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ¶¬‚Æ”jŠü                           //
+//                        ç”Ÿæˆã¨ç ´æ£„                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CLayoutMgr::CLayoutMgr()
-: m_getIndentOffset( &CLayoutMgr::getIndentOffset_Normal )	//	Oct. 1, 2002 genta	//	Nov. 16, 2002 ƒƒ“ƒo[ŠÖ”ƒ|ƒCƒ“ƒ^‚É‚ÍƒNƒ‰ƒX–¼‚ª•K—v
+: m_getIndentOffset( &CLayoutMgr::getIndentOffset_Normal )	//	Oct. 1, 2002 genta	//	Nov. 16, 2002 ãƒ¡ãƒ³ãƒãƒ¼é–¢æ•°ãƒã‚¤ãƒ³ã‚¿ã«ã¯ã‚¯ãƒ©ã‚¹åãŒå¿…è¦
 {
 	m_pcDocLineMgr = NULL;
 	m_pTypeConfig = NULL;
 	m_nMaxLineKetas = CKetaXInt(MAXLINEKETAS);
 	m_nTabSpace = CKetaXInt(4);
 	m_tsvInfo.m_nTsvMode = TSV_MODE_NONE;
-	m_pszKinsokuHead_1.clear();						/* s“ª‹Ö‘¥ */	//@@@ 2002.04.08 MIK
-	m_pszKinsokuTail_1.clear();						/* s––‹Ö‘¥ */	//@@@ 2002.04.08 MIK
-	m_pszKinsokuKuto_1.clear();						/* ‹å“Ç“_‚Ô‚ç‚³‚° */	//@@@ 2002.04.17 MIK
+	m_pszKinsokuHead_1.clear();						/* è¡Œé ­ç¦å‰‡ */	//@@@ 2002.04.08 MIK
+	m_pszKinsokuTail_1.clear();						/* è¡Œæœ«ç¦å‰‡ */	//@@@ 2002.04.08 MIK
+	m_pszKinsokuKuto_1.clear();						/* å¥èª­ç‚¹ã¶ã‚‰ã•ã’ */	//@@@ 2002.04.17 MIK
 
-	m_nTextWidth = CLayoutInt(0);			// ƒeƒLƒXƒgÅ‘å•‚Ì‹L‰¯		// 2009.08.28 nasukoji
-	m_nTextWidthMaxLine = CLayoutInt(0);	// Å‘å•‚ÌƒŒƒCƒAƒEƒgs		// 2009.08.28 nasukoji
+	m_nTextWidth = CLayoutInt(0);			// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã®è¨˜æ†¶		// 2009.08.28 nasukoji
+	m_nTextWidthMaxLine = CLayoutInt(0);	// æœ€å¤§å¹…ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ		// 2009.08.28 nasukoji
 
 	Init();
 }
@@ -58,22 +58,22 @@ CLayoutMgr::~CLayoutMgr()
 {
 	_Empty();
 
-	m_pszKinsokuHead_1.clear();	/* s“ª‹Ö‘¥ */
-	m_pszKinsokuTail_1.clear();	/* s––‹Ö‘¥ */	//@@@ 2002.04.08 MIK
-	m_pszKinsokuKuto_1.clear();	/* ‹å“Ç“_‚Ô‚ç‚³‚° */	//@@@ 2002.04.17 MIK
+	m_pszKinsokuHead_1.clear();	/* è¡Œé ­ç¦å‰‡ */
+	m_pszKinsokuTail_1.clear();	/* è¡Œæœ«ç¦å‰‡ */	//@@@ 2002.04.08 MIK
+	m_pszKinsokuKuto_1.clear();	/* å¥èª­ç‚¹ã¶ã‚‰ã•ã’ */	//@@@ 2002.04.17 MIK
 }
 
 
 /*
 ||
-|| sƒf[ƒ^ŠÇ—ƒNƒ‰ƒX‚Ìƒ|ƒCƒ“ƒ^‚ğ‰Šú‰»‚µ‚Ü‚·
+|| è¡Œãƒ‡ãƒ¼ã‚¿ç®¡ç†ã‚¯ãƒ©ã‚¹ã®ãƒã‚¤ãƒ³ã‚¿ã‚’åˆæœŸåŒ–ã—ã¾ã™
 ||
 */
 void CLayoutMgr::Create( CEditDoc* pcEditDoc, CDocLineMgr* pcDocLineMgr )
 {
 	_Empty();
 	Init();
-	//	Jun. 20, 2003 genta EditDoc‚Ö‚Ìƒ|ƒCƒ“ƒ^’Ç‰Á
+	//	Jun. 20, 2003 genta EditDocã¸ã®ãƒã‚¤ãƒ³ã‚¿è¿½åŠ 
 	m_pcEditDoc = pcEditDoc;
 	m_pcDocLineMgr = pcDocLineMgr;
 }
@@ -84,10 +84,10 @@ void CLayoutMgr::Init()
 	m_pLayoutBot = NULL;
 	m_nPrevReferLine = CLayoutInt(0);
 	m_pLayoutPrevRefer = NULL;
-	m_nLines = CLayoutInt(0);			/* ‘S•¨—s” */
+	m_nLines = CLayoutInt(0);			/* å…¨ç‰©ç†è¡Œæ•° */
 	m_nLineTypeBot = COLORIDX_DEFAULT;
 
-	// EOFƒŒƒCƒAƒEƒgˆÊ’u‹L‰¯	//2006.10.07 Moca
+	// EOFãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®è¨˜æ†¶	//2006.10.07 Moca
 	m_nEOFLine = CLayoutInt(-1);
 	m_nEOFColumn = CLayoutInt(-1);
 }
@@ -107,9 +107,9 @@ void CLayoutMgr::_Empty()
 
 
 
-/*! ƒŒƒCƒAƒEƒgî•ñ‚Ì•ÏX
-	@param bDoLayout [in] ƒŒƒCƒAƒEƒgî•ñ‚ÌÄì¬
-	@param refType [in] ƒ^ƒCƒv•Êİ’è
+/*! ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã®å¤‰æ›´
+	@param bDoLayout [in] ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã®å†ä½œæˆ
+	@param refType [in] ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š
 */
 void CLayoutMgr::SetLayoutInfo(
 	bool				bDoLayout,
@@ -127,7 +127,7 @@ void CLayoutMgr::SetLayoutInfo(
 	assert_warning( (!bDoLayout && m_nMaxLineKetas == nMaxLineKetas) || bDoLayout );
 	assert_warning( (!bDoLayout && m_nTabSpace == refType.m_nTabSpace) || bDoLayout );
 
-	//ƒ^ƒCƒv•Êİ’è
+	//ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š
 	m_pTypeConfig = &refType;
 	m_nMaxLineKetas = nMaxLineKetas;
 	m_nTabSpace = nTabSpace;
@@ -139,7 +139,7 @@ void CLayoutMgr::SetLayoutInfo(
 	m_nSpacing = refType.m_nColumnSpace;
 	if( nCharLayoutXPerKeta == -1 )
 	{
-		// View‚ª‚Á‚Ä‚éƒtƒHƒ“ƒgî•ñ‚ÍŒÃ‚¢A‚µ‚å‚¤‚ª‚È‚¢‚Ì‚Å©•ª‚Åì‚é
+		// ViewãŒæŒã£ã¦ã‚‹ãƒ•ã‚©ãƒ³ãƒˆæƒ…å ±ã¯å¤ã„ã€ã—ã‚‡ã†ãŒãªã„ã®ã§è‡ªåˆ†ã§ä½œã‚‹
 		HWND hwnd = NULL;
 		HDC hdc = ::GetDC(hwnd);
 		CViewFont viewFont(pLogfont);
@@ -150,17 +150,17 @@ void CLayoutMgr::SetLayoutInfo(
 	}else{
 		m_nCharLayoutXPerKeta = nCharLayoutXPerKeta;
 	}
-	// Å‘å•¶š•‚ÌŒvZ
+	// æœ€å¤§æ–‡å­—å¹…ã®è¨ˆç®—
 	m_tsvInfo.m_nMaxCharLayoutX = WCODE::CalcPxWidthByFont(L'W');
 	if (m_tsvInfo.m_nMaxCharLayoutX < m_nCharLayoutXPerKeta) {
 		m_tsvInfo.m_nMaxCharLayoutX = m_nCharLayoutXPerKeta;
 	}
 
-	//	Oct. 1, 2002 genta ƒ^ƒCƒv‚É‚æ‚Á‚Äˆ—ŠÖ”‚ğ•ÏX‚·‚é
-	//	”‚ª‘‚¦‚Ä‚«‚½‚çƒe[ƒuƒ‹‚É‚·‚×‚«
-	switch ( refType.m_nIndentLayout ){	/* Ü‚è•Ô‚µ‚Í2s–ÚˆÈ~‚ğš‰º‚°•\¦ */	//@@@ 2002.09.29 YAZAKI
+	//	Oct. 1, 2002 genta ã‚¿ã‚¤ãƒ—ã«ã‚ˆã£ã¦å‡¦ç†é–¢æ•°ã‚’å¤‰æ›´ã™ã‚‹
+	//	æ•°ãŒå¢—ãˆã¦ããŸã‚‰ãƒ†ãƒ¼ãƒ–ãƒ«ã«ã™ã¹ã
+	switch ( refType.m_nIndentLayout ){	/* æŠ˜ã‚Šè¿”ã—ã¯2è¡Œç›®ä»¥é™ã‚’å­—ä¸‹ã’è¡¨ç¤º */	//@@@ 2002.09.29 YAZAKI
 	case 1:
-		//	Nov. 16, 2002 ƒƒ“ƒo[ŠÖ”ƒ|ƒCƒ“ƒ^‚É‚ÍƒNƒ‰ƒX–¼‚ª•K—v
+		//	Nov. 16, 2002 ãƒ¡ãƒ³ãƒãƒ¼é–¢æ•°ãƒã‚¤ãƒ³ã‚¿ã«ã¯ã‚¯ãƒ©ã‚¹åãŒå¿…è¦
 		m_getIndentOffset = &CLayoutMgr::getIndentOffset_Tx2x;
 		break;
 	case 2:
@@ -171,17 +171,17 @@ void CLayoutMgr::SetLayoutInfo(
 		break;
 	}
 
-	//‹å“Ç“_‚Ô‚ç‰º‚°•¶š	// 2009.08.07 ryoji
-	//refType.m_szKinsokuKuto ¨ m_pszKinsokuKuto_1
+	//å¥èª­ç‚¹ã¶ã‚‰ä¸‹ã’æ–‡å­—	// 2009.08.07 ryoji
+	//refType.m_szKinsokuKuto â†’ m_pszKinsokuKuto_1
 	m_pszKinsokuKuto_1.clear();
-	if(refType.m_bKinsokuKuto){	// 2009.08.06 ryoji m_bKinsokuKuto‚ÅU‚è•ª‚¯‚é(Fix)
+	if(refType.m_bKinsokuKuto){	// 2009.08.06 ryoji m_bKinsokuKutoã§æŒ¯ã‚Šåˆ†ã‘ã‚‹(Fix)
 		for( const wchar_t* p = refType.m_szKinsokuKuto; *p; p++ ){
 			m_pszKinsokuKuto_1.push_back_unique(*p);
 		}
 	}
 
-	//s“ª‹Ö‘¥•¶š
-	//refType.m_szKinsokuHead ¨ (‹å“Ç“_ˆÈŠO) m_pszKinsokuHead_1
+	//è¡Œé ­ç¦å‰‡æ–‡å­—
+	//refType.m_szKinsokuHead â†’ (å¥èª­ç‚¹ä»¥å¤–) m_pszKinsokuHead_1
 	m_pszKinsokuHead_1.clear();
 	for( const wchar_t* p = refType.m_szKinsokuHead; *p; p++ ){
 		if(m_pszKinsokuKuto_1.exist(*p)){
@@ -192,14 +192,14 @@ void CLayoutMgr::SetLayoutInfo(
 		}
 	}
 
-	//s––‹Ö‘¥•¶š
-	//refType.m_szKinsokuTail ¨ m_pszKinsokuTail_1
+	//è¡Œæœ«ç¦å‰‡æ–‡å­—
+	//refType.m_szKinsokuTail â†’ m_pszKinsokuTail_1
 	m_pszKinsokuTail_1.clear();
 	for( const wchar_t* p = refType.m_szKinsokuTail; *p; p++ ){
 		m_pszKinsokuTail_1.push_back_unique(*p);
 	}
 
-	//ƒŒƒCƒAƒEƒg
+	//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆ
 	if( bDoLayout ){
 		_DoLayout(bBlockingHook);
 	}
@@ -209,9 +209,9 @@ void CLayoutMgr::SetLayoutInfo(
 
 
 /*!
-	@brief w’è‚³‚ê‚½•¨—s‚ÌƒŒƒCƒAƒEƒgî•ñ‚ğæ“¾
+	@brief æŒ‡å®šã•ã‚ŒãŸç‰©ç†è¡Œã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã‚’å–å¾—
 
-	@param nLineNum [in] •¨—s”Ô† (0`)
+	@param nLineNum [in] ç‰©ç†è¡Œç•ªå· (0ï½)
 */
 const CLayout* CLayoutMgr::SearchLineByLayoutY(
 	CLayoutInt nLineLayout
@@ -225,14 +225,14 @@ const CLayout* CLayoutMgr::SearchLineByLayoutY(
 		return NULL;
 	}
 
-	//	Mar. 19, 2003 Moca nLineNum‚ª•‰‚Ìê‡‚Ìƒ`ƒFƒbƒN‚ğ’Ç‰Á
+	//	Mar. 19, 2003 Moca nLineNumãŒè² ã®å ´åˆã®ãƒã‚§ãƒƒã‚¯ã‚’è¿½åŠ 
 	if( CLayoutInt(0) > nLineNum || nLineNum >= m_nLines ){
 		if( CLayoutInt(0) > nLineNum ){
 			DEBUG_TRACE( _T("CLayoutMgr::SearchLineByLayoutY() nLineNum = %d\n"), nLineNum );
 		}
 		return NULL;
 	}
-//	/*+++++++ ’á‘¬”Å +++++++++*/
+//	/*+++++++ ä½é€Ÿç‰ˆ +++++++++*/
 //	if( nLineNum < (m_nLines / 2) ){
 //		nCount = 0;
 //		pLayout = m_pLayoutTop;
@@ -260,8 +260,8 @@ const CLayout* CLayoutMgr::SearchLineByLayoutY(
 //	}
 
 
-	/*+++++++‚í‚¸‚©‚É‚‘¬”Å+++++++*/
-	// 2004.03.28 Moca m_pLayoutPrevRefer‚æ‚èATop,Bot‚Ì‚Ù‚¤‚ª‹ß‚¢ê‡‚ÍA‚»‚¿‚ç‚ğ—˜—p‚·‚é
+	/*+++++++ã‚ãšã‹ã«é«˜é€Ÿç‰ˆ+++++++*/
+	// 2004.03.28 Moca m_pLayoutPrevReferã‚ˆã‚Šã€Top,Botã®ã»ã†ãŒè¿‘ã„å ´åˆã¯ã€ãã¡ã‚‰ã‚’åˆ©ç”¨ã™ã‚‹
 	CLayoutInt nPrevToLineNumDiff = t_abs( m_nPrevReferLine - nLineNum );
 	if( m_pLayoutPrevRefer == NULL
 	  || nLineNum < nPrevToLineNumDiff
@@ -327,7 +327,7 @@ const CLayout* CLayoutMgr::SearchLineByLayoutY(
 }
 
 
-//@@@ 2002.09.23 YAZAKI CLayout*‚ğì¬‚·‚é‚Æ‚±‚ë‚Í•ª—£‚µ‚ÄAInsertLineNext()‚Æ‹¤’Ê‰»
+//@@@ 2002.09.23 YAZAKI CLayout*ã‚’ä½œæˆã™ã‚‹ã¨ã“ã‚ã¯åˆ†é›¢ã—ã¦ã€InsertLineNext()ã¨å…±é€šåŒ–
 void CLayoutMgr::AddLineBottom( CLayout* pLayout )
 {
 	if(	CLayoutInt(0) == m_nLines ){
@@ -343,32 +343,32 @@ void CLayoutMgr::AddLineBottom( CLayout* pLayout )
 	return;
 }
 
-//@@@ 2002.09.23 YAZAKI CLayout*‚ğì¬‚·‚é‚Æ‚±‚ë‚Í•ª—£‚µ‚ÄAAddLineBottom()‚Æ‹¤’Ê‰»
+//@@@ 2002.09.23 YAZAKI CLayout*ã‚’ä½œæˆã™ã‚‹ã¨ã“ã‚ã¯åˆ†é›¢ã—ã¦ã€AddLineBottom()ã¨å…±é€šåŒ–
 CLayout* CLayoutMgr::InsertLineNext( CLayout* pLayoutPrev, CLayout* pLayout )
 {
 	CLayout* pLayoutNext;
 
 	if(	CLayoutInt(0) == m_nLines ){
-		/* ‰ */
+		/* åˆ */
 		m_pLayoutBot = m_pLayoutTop = pLayout;
 		m_pLayoutTop->m_pPrev = NULL;
 		m_pLayoutTop->m_pNext = NULL;
 	}
 	else if( NULL == pLayoutPrev ){
-		/* æ“ª‚É‘}“ü */
+		/* å…ˆé ­ã«æŒ¿å…¥ */
 		m_pLayoutTop->m_pPrev = pLayout;
 		pLayout->m_pPrev = NULL;
 		pLayout->m_pNext = m_pLayoutTop;
 		m_pLayoutTop = pLayout;
 	}else
 	if( NULL == pLayoutPrev->GetNextLayout() ){
-		/* ÅŒã‚É‘}“ü */
+		/* æœ€å¾Œã«æŒ¿å…¥ */
 		m_pLayoutBot->m_pNext = pLayout;
 		pLayout->m_pPrev = m_pLayoutBot;
 		pLayout->m_pNext = NULL;
 		m_pLayoutBot = pLayout;
 	}else{
-		/* “r’†‚É‘}“ü */
+		/* é€”ä¸­ã«æŒ¿å…¥ */
 		pLayoutNext = pLayoutPrev->GetNextLayout();
 		pLayoutPrev->m_pNext = pLayout;
 		pLayoutNext->m_pPrev = pLayout;
@@ -379,9 +379,9 @@ CLayout* CLayoutMgr::InsertLineNext( CLayout* pLayoutPrev, CLayout* pLayout )
 	return pLayout;
 }
 
-/* CLayout‚ğì¬‚·‚é
+/* CLayoutã‚’ä½œæˆã™ã‚‹
 	@@@ 2002.09.23 YAZAKI
-	@date 2009.08.28 nasukoji	ƒŒƒCƒAƒEƒg’·‚ğˆø”‚É’Ç‰Á
+	@date 2009.08.28 nasukoji	ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆé•·ã‚’å¼•æ•°ã«è¿½åŠ 
 */
 CLayout* CLayoutMgr::CreateLayout(
 	CDocLine*		pCDocLine,
@@ -403,22 +403,22 @@ CLayout* CLayoutMgr::CreateLayout(
 	);
 
 	if( EOL_NONE == pCDocLine->GetEol() ){
-		pLayout->m_cEol.SetType( EOL_NONE );/* ‰üsƒR[ƒh‚Ìí—Ş */
+		pLayout->m_cEol.SetType( EOL_NONE );/* æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®ç¨®é¡ */
 	}else{
 		if( pLayout->GetLogicOffset() + pLayout->GetLengthWithEOL() >
 			pCDocLine->GetLengthWithEOL() - pCDocLine->GetEol().GetLen()
 		){
-			pLayout->m_cEol = pCDocLine->GetEol();/* ‰üsƒR[ƒh‚Ìí—Ş */
+			pLayout->m_cEol = pCDocLine->GetEol();/* æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®ç¨®é¡ */
 		}else{
-			pLayout->m_cEol = EOL_NONE;/* ‰üsƒR[ƒh‚Ìí—Ş */
+			pLayout->m_cEol = EOL_NONE;/* æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®ç¨®é¡ */
 		}
 	}
 
-	// 2009.08.28 nasukoji	uÜ‚è•Ô‚³‚È‚¢v‘I‘ğ‚Ì‚İƒŒƒCƒAƒEƒg’·‚ğ‹L‰¯‚·‚é
-	// uÜ‚è•Ô‚³‚È‚¢vˆÈŠO‚ÅŒvZ‚µ‚È‚¢‚Ì‚ÍƒpƒtƒH[ƒ}ƒ“ƒX’á‰º‚ğ–h‚®–Ú“I‚È‚Ì‚ÅA
-	// ƒpƒtƒH[ƒ}ƒ“ƒX‚Ì’á‰º‚ª‹C‚É‚È‚ç‚È‚¢’ö‚È‚ç‘S‚Ä‚ÌÜ‚è•Ô‚µ•û–@‚ÅŒvZ‚·‚é
-	// ‚æ‚¤‚É‚µ‚Ä‚à—Ç‚¢‚Æv‚¤B
-	// i‚»‚Ìê‡CLayoutMgr::CalculateTextWidth()‚ÌŒÄ‚Ño‚µ‰ÓŠ‚ğƒ`ƒFƒbƒNj
+	// 2009.08.28 nasukoji	ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€é¸æŠæ™‚ã®ã¿ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆé•·ã‚’è¨˜æ†¶ã™ã‚‹
+	// ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€ä»¥å¤–ã§è¨ˆç®—ã—ãªã„ã®ã¯ãƒ‘ãƒ•ã‚©ãƒ¼ãƒãƒ³ã‚¹ä½ä¸‹ã‚’é˜²ãç›®çš„ãªã®ã§ã€
+	// ãƒ‘ãƒ•ã‚©ãƒ¼ãƒãƒ³ã‚¹ã®ä½ä¸‹ãŒæ°—ã«ãªã‚‰ãªã„ç¨‹ãªã‚‰å…¨ã¦ã®æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã§è¨ˆç®—ã™ã‚‹
+	// ã‚ˆã†ã«ã—ã¦ã‚‚è‰¯ã„ã¨æ€ã†ã€‚
+	// ï¼ˆãã®å ´åˆCLayoutMgr::CalculateTextWidth()ã®å‘¼ã³å‡ºã—ç®‡æ‰€ã‚’ãƒã‚§ãƒƒã‚¯ï¼‰
 	pLayout->SetLayoutWidth( ( m_pcEditDoc->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP ) ? nPosX : CLayoutInt(0) );
 
 	return pLayout;
@@ -426,11 +426,11 @@ CLayout* CLayoutMgr::CreateLayout(
 
 
 /*
-|| w’è‚³‚ê‚½•¨—s‚Ìƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚Æ‚»‚Ì’·‚³‚ğ•Ô‚· Ver0
+|| æŒ‡å®šã•ã‚ŒãŸç‰©ç†è¡Œã®ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã¨ãã®é•·ã•ã‚’è¿”ã™ Ver0
 
-	@date 2002/2/10 aroka CMemory•ÏX
+	@date 2002/2/10 aroka CMemoryå¤‰æ›´
 */
-const wchar_t* CLayoutMgr::GetLineStr( CLayoutInt nLine, CLogicInt* pnLineLen ) const //#####‚¢‚ç‚ñ‚â‚ë
+const wchar_t* CLayoutMgr::GetLineStr( CLayoutInt nLine, CLogicInt* pnLineLen ) const //#####ã„ã‚‰ã‚“ã‚„ã‚
 {
 	const CLayout* pLayout;
 	if( NULL == ( pLayout = SearchLineByLayoutY( nLine )	) ){
@@ -440,8 +440,8 @@ const wchar_t* CLayoutMgr::GetLineStr( CLayoutInt nLine, CLogicInt* pnLineLen ) 
 	return pLayout->GetDocLineRef()->GetPtr() + pLayout->GetLogicOffset();
 }
 
-/*!	w’è‚³‚ê‚½•¨—s‚Ìƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚Æ‚»‚Ì’·‚³‚ğ•Ô‚· Ver1
-	@date 2002/03/24 YAZAKI GetLineStr( int nLine, int* pnLineLen )‚Æ“¯‚¶“®ì‚É•ÏXB
+/*!	æŒ‡å®šã•ã‚ŒãŸç‰©ç†è¡Œã®ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã¨ãã®é•·ã•ã‚’è¿”ã™ Ver1
+	@date 2002/03/24 YAZAKI GetLineStr( int nLine, int* pnLineLen )ã¨åŒã˜å‹•ä½œã«å¤‰æ›´ã€‚
 */
 const wchar_t* CLayoutMgr::GetLineStr( CLayoutInt nLine, CLogicInt* pnLineLen, const CLayout** ppcLayoutDes ) const
 {
@@ -453,7 +453,7 @@ const wchar_t* CLayoutMgr::GetLineStr( CLayoutInt nLine, CLogicInt* pnLineLen, c
 }
 
 /*
-|| w’è‚³‚ê‚½ˆÊ’u‚ªƒŒƒCƒAƒEƒgs‚Ì“r’†‚Ìs––‚©‚Ç‚¤‚©’²‚×‚é
+|| æŒ‡å®šã•ã‚ŒãŸä½ç½®ãŒãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®é€”ä¸­ã®è¡Œæœ«ã‹ã©ã†ã‹èª¿ã¹ã‚‹
 
 	@date 2002/4/27 MIK
 */
@@ -469,23 +469,23 @@ bool CLayoutMgr::IsEndOfLine(
 	}
 
 	if( EOL_NONE == pLayout->GetLayoutEol().GetType() )
-	{	/* ‚±‚Ìs‚É‰üs‚Í‚È‚¢ */
-		/* ‚±‚Ìs‚ÌÅŒã‚©H */
-		if( ptLinePos.x == (Int)pLayout->GetLengthWithEOL() ) return true; //$$ ’PˆÊ¬İ
+	{	/* ã“ã®è¡Œã«æ”¹è¡Œã¯ãªã„ */
+		/* ã“ã®è¡Œã®æœ€å¾Œã‹ï¼Ÿ */
+		if( ptLinePos.x == (Int)pLayout->GetLengthWithEOL() ) return true; //$$ å˜ä½æ··åœ¨
 	}
 
 	return false;
 }
 
-/*!	@brief ƒtƒ@ƒCƒ‹––”ö‚ÌƒŒƒCƒAƒEƒgˆÊ’u‚ğæ“¾‚·‚é
+/*!	@brief ãƒ•ã‚¡ã‚¤ãƒ«æœ«å°¾ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã‚’å–å¾—ã™ã‚‹
 
-	ƒtƒ@ƒCƒ‹––”ö‚Ü‚Å‘I‘ğ‚·‚éê‡‚É³Šm‚ÈˆÊ’uî•ñ‚ğ—^‚¦‚é‚½‚ß
+	ãƒ•ã‚¡ã‚¤ãƒ«æœ«å°¾ã¾ã§é¸æŠã™ã‚‹å ´åˆã«æ­£ç¢ºãªä½ç½®æƒ…å ±ã‚’ä¸ãˆã‚‹ãŸã‚
 
-	Šù‘¶‚ÌŠÖ”‚Å‚Í•¨—s‚©‚çƒŒƒCƒAƒEƒgˆÊ’u‚ğ•ÏŠ·‚·‚é•K—v‚ª‚ ‚èC
-	ˆ—‚É–³‘Ê‚ª‘½‚¢‚½‚ßCê—pŠÖ”‚ğì¬
+	æ—¢å­˜ã®é–¢æ•°ã§ã¯ç‰©ç†è¡Œã‹ã‚‰ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã‚’å¤‰æ›ã™ã‚‹å¿…è¦ãŒã‚ã‚Šï¼Œ
+	å‡¦ç†ã«ç„¡é§„ãŒå¤šã„ãŸã‚ï¼Œå°‚ç”¨é–¢æ•°ã‚’ä½œæˆ
 	
 	@date 2006.07.29 genta
-	@date 2006.10.01 Moca ƒƒ“ƒo‚Å•Û‚·‚é‚æ‚¤‚ÉBƒf[ƒ^•ÏX‚É‚ÍA_DoLayout/DoLayout_Range‚Å–³Œø‚É‚·‚éB
+	@date 2006.10.01 Moca ãƒ¡ãƒ³ãƒã§ä¿æŒã™ã‚‹ã‚ˆã†ã«ã€‚ãƒ‡ãƒ¼ã‚¿å¤‰æ›´æ™‚ã«ã¯ã€_DoLayout/DoLayout_Rangeã§ç„¡åŠ¹ã«ã™ã‚‹ã€‚
 */
 void CLayoutMgr::GetEndLayoutPos(
 	CLayoutPoint* ptLayoutEnd //[out]
@@ -498,7 +498,7 @@ void CLayoutMgr::GetEndLayoutPos(
 	}
 
 	if( CLayoutInt(0) == m_nLines || m_pLayoutBot == NULL ){
-		// ƒf[ƒ^‚ª‹ó
+		// ãƒ‡ãƒ¼ã‚¿ãŒç©º
 		ptLayoutEnd->x = CLayoutInt(0);
 		ptLayoutEnd->y = CLayoutInt(0);
 		m_nEOFColumn = ptLayoutEnd->x;
@@ -508,7 +508,7 @@ void CLayoutMgr::GetEndLayoutPos(
 
 	CLayout *btm = m_pLayoutBot;
 	if( btm->m_cEol != EOL_NONE ){
-		//	––”ö‚É‰üs‚ª‚ ‚é
+		//	æœ«å°¾ã«æ”¹è¡ŒãŒã‚ã‚‹
 		ptLayoutEnd->Set(CLayoutInt(0), GetLineCount());
 	}
 	else {
@@ -518,8 +518,8 @@ void CLayoutMgr::GetEndLayoutPos(
 			it.addDelta();
 		}
 		ptLayoutEnd->Set(it.getColumn(), GetLineCount() - CLayoutInt(1));
-		// [EOF]‚Ì‚İÜ‚è•Ô‚·‚Ì‚Í‚â‚ß‚é	// 2009.02.17 ryoji
-		//// 2006.10.01 Moca Start [EOF]‚Ì‚İ‚ÌƒŒƒCƒAƒEƒgsˆ—‚ª”²‚¯‚Ä‚¢‚½ƒoƒO‚ğC³
+		// [EOF]ã®ã¿æŠ˜ã‚Šè¿”ã™ã®ã¯ã‚„ã‚ã‚‹	// 2009.02.17 ryoji
+		//// 2006.10.01 Moca Start [EOF]ã®ã¿ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œå‡¦ç†ãŒæŠœã‘ã¦ã„ãŸãƒã‚°ã‚’ä¿®æ­£
 		//if( GetMaxLineKetas() <= ptLayoutEnd->GetX2() ){
 		//	ptLayoutEnd->SetX(CLayoutInt(0));
 		//	ptLayoutEnd->y++;
@@ -537,8 +537,8 @@ void CLayoutMgr::GetEndLayoutPos(
 
 
 
-/* ˜_—s‚Ìw’è”ÍˆÍ‚ÉŠY“–‚·‚éƒŒƒCƒAƒEƒgî•ñ‚ğíœ‚µ‚Ä */
-/* íœ‚µ‚½”ÍˆÍ‚Ì’¼‘O‚ÌƒŒƒCƒAƒEƒgî•ñ‚Ìƒ|ƒCƒ“ƒ^‚ğ•Ô‚· */
+/* è«–ç†è¡Œã®æŒ‡å®šç¯„å›²ã«è©²å½“ã™ã‚‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã‚’å‰Šé™¤ã—ã¦ */
+/* å‰Šé™¤ã—ãŸç¯„å›²ã®ç›´å‰ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã®ãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã™ */
 CLayout* CLayoutMgr::DeleteLayoutAsLogical(
 	CLayout*	pLayoutInThisArea,
 	CLayoutInt	nLineOf_pLayoutInThisArea,
@@ -553,7 +553,7 @@ CLayout* CLayoutMgr::DeleteLayoutAsLogical(
 	CLayout* pLayoutNext;
 
 	*pnDeleteLines = CLayoutInt(0);
-	if( CLayoutInt(0) == m_nLines){	/* ‘S•¨—s” */
+	if( CLayoutInt(0) == m_nLines){	/* å…¨ç‰©ç†è¡Œæ•° */
 		return NULL;
 	}
 	if( NULL == pLayoutInThisArea ){
@@ -565,7 +565,7 @@ CLayout* CLayoutMgr::DeleteLayoutAsLogical(
 	m_nPrevReferLine = nLineOf_pLayoutInThisArea - CLayoutInt(1);
 
 
-	/* ”ÍˆÍ“àæ“ª‚ÉŠY“–‚·‚éƒŒƒCƒAƒEƒgî•ñ‚ğƒT[ƒ` */
+	/* ç¯„å›²å†…å…ˆé ­ã«è©²å½“ã™ã‚‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã‚’ã‚µãƒ¼ãƒ */
 	pLayoutWork = pLayoutInThisArea->GetPrevLayout();
 	while( NULL != pLayoutWork && nLineFrom <= pLayoutWork->GetLogicLineNo()){
 		pLayoutWork = pLayoutWork->GetPrevLayout();
@@ -584,7 +584,7 @@ CLayout* CLayoutMgr::DeleteLayoutAsLogical(
 		}
 		pLayoutNext = pLayout->GetNextLayout();
 		if( NULL == pLayoutWork ){
-			/* æ“ªs‚Ìˆ— */
+			/* å…ˆé ­è¡Œã®å‡¦ç† */
 			m_pLayoutTop = pLayout->GetNextLayout();
 			if( NULL != pLayout->GetNextLayout() ){
 				pLayout->m_pNext->m_pPrev = NULL;
@@ -596,7 +596,7 @@ CLayout* CLayoutMgr::DeleteLayoutAsLogical(
 			}
 		}
 //		if( m_pLayoutPrevRefer == pLayout ){
-//			// 1999.12.22 ‘O‚É‚¸‚ç‚·‚¾‚¯‚Å‚æ‚¢‚Ì‚Å‚Í
+//			// 1999.12.22 å‰ã«ãšã‚‰ã™ã ã‘ã§ã‚ˆã„ã®ã§ã¯
 //			m_pLayoutPrevRefer = pLayout->GetPrevLayout();
 //			--m_nPrevReferLine;
 //		}
@@ -609,12 +609,12 @@ CLayout* CLayoutMgr::DeleteLayoutAsLogical(
 		}
 
 		if( m_pLayoutPrevRefer == pLayout ){
-			DEBUG_TRACE( _T("ƒoƒOƒoƒO\n") );
+			DEBUG_TRACE( _T("ãƒã‚°ãƒã‚°\n") );
 		}
 
 		delete pLayout;
 
-		m_nLines--;	/* ‘S•¨—s” */
+		m_nLines--;	/* å…¨ç‰©ç†è¡Œæ•° */
 		if( NULL == pLayoutNext ){
 			m_pLayoutBot = pLayoutWork;
 		}
@@ -628,9 +628,9 @@ CLayout* CLayoutMgr::DeleteLayoutAsLogical(
 
 
 
-/* w’ès‚æ‚èŒã‚Ìs‚ÌƒŒƒCƒAƒEƒgî•ñ‚É‚Â‚¢‚ÄA˜_—s”Ô†‚ğw’ès”‚¾‚¯ƒVƒtƒg‚·‚é */
-/* ˜_—s‚ªíœ‚³‚ê‚½ê‡‚Í‚O‚æ‚è¬‚³‚¢s” */
-/* ˜_—s‚ª‘}“ü‚³‚ê‚½ê‡‚Í‚O‚æ‚è‘å‚«‚¢s” */
+/* æŒ‡å®šè¡Œã‚ˆã‚Šå¾Œã®è¡Œã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã«ã¤ã„ã¦ã€è«–ç†è¡Œç•ªå·ã‚’æŒ‡å®šè¡Œæ•°ã ã‘ã‚·ãƒ•ãƒˆã™ã‚‹ */
+/* è«–ç†è¡ŒãŒå‰Šé™¤ã•ã‚ŒãŸå ´åˆã¯ï¼ã‚ˆã‚Šå°ã•ã„è¡Œæ•° */
+/* è«–ç†è¡ŒãŒæŒ¿å…¥ã•ã‚ŒãŸå ´åˆã¯ï¼ã‚ˆã‚Šå¤§ãã„è¡Œæ•° */
 void CLayoutMgr::ShiftLogicalLineNum( CLayout* pLayoutPrev, CLogicInt nShiftLines )
 {
 	MY_RUNNINGTIMER( cRunningTimer, "CLayoutMgr::ShiftLogicalLineNum" );
@@ -644,9 +644,9 @@ void CLayoutMgr::ShiftLogicalLineNum( CLayout* pLayoutPrev, CLogicInt nShiftLine
 	}else{
 		pLayout = pLayoutPrev->GetNextLayout();
 	}
-	/* ƒŒƒCƒAƒEƒgî•ñ‘S‘Ì‚ğXV‚·‚é(‚È‚ÈA‚È‚ñ‚Æ!!!) */
+	/* ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±å…¨ä½“ã‚’æ›´æ–°ã™ã‚‹(ãªãªã€ãªã‚“ã¨!!!) */
 	while( NULL != pLayout ){
-		pLayout->OffsetLogicLineNo(nShiftLines);	/* ‘Î‰‚·‚é˜_—s”Ô† */
+		pLayout->OffsetLogicLineNo(nShiftLines);	/* å¯¾å¿œã™ã‚‹è«–ç†è¡Œç•ªå· */
 		pLayout = pLayout->GetNextLayout();
 	}
 	return;
@@ -679,7 +679,7 @@ bool CLayoutMgr::ChangeLayoutParam(
 
 
 
-/* Œ»İˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ğ’²‚×‚é */
+/* ç¾åœ¨ä½ç½®ã®å˜èªã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 bool CLayoutMgr::WhereCurrentWord(
 	CLayoutInt		nLineNum,
 	CLogicInt		nIdx,
@@ -693,7 +693,7 @@ bool CLayoutMgr::WhereCurrentWord(
 		return false;
 	}
 
-	// Œ»İˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ğ’²‚×‚é -> ƒƒWƒbƒN’PˆÊpSelect, pcmemWord, pcmemWordLeft
+	// ç¾åœ¨ä½ç½®ã®å˜èªã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ -> ãƒ­ã‚¸ãƒƒã‚¯å˜ä½pSelect, pcmemWord, pcmemWordLeft
 	CLogicInt nFromX;
 	CLogicInt nToX;
 	bool nRetCode = CSearchAgent(m_pcDocLineMgr).WhereCurrentWord(
@@ -706,7 +706,7 @@ bool CLayoutMgr::WhereCurrentWord(
 	);
 
 	if( nRetCode ){
-		/* ˜_—ˆÊ’u¨ƒŒƒCƒAƒEƒgˆÊ’u•ÏŠ· */
+		/* è«–ç†ä½ç½®â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®å¤‰æ› */
 		CLayoutPoint ptFrom;
 		LogicToLayout( CLogicPoint(nFromX, pLayout->GetLogicLineNo()), &ptFrom, nLineNum );
 		pSelect->SetFrom(ptFrom);
@@ -723,7 +723,7 @@ bool CLayoutMgr::WhereCurrentWord(
 
 
 
-/* Œ»İˆÊ’u‚Ì¶‰E‚Ì’PŒê‚Ìæ“ªˆÊ’u‚ğ’²‚×‚é */
+/* ç¾åœ¨ä½ç½®ã®å·¦å³ã®å˜èªã®å…ˆé ­ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 int CLayoutMgr::PrevOrNextWord(
 	CLayoutInt		nLineNum,
 	CLogicInt		nIdx,
@@ -737,7 +737,7 @@ int CLayoutMgr::PrevOrNextWord(
 		return FALSE;
 	}
 
-	// Œ»İˆÊ’u‚Ì¶‰E‚Ì’PŒê‚Ìæ“ªˆÊ’u‚ğ’²‚×‚é
+	// ç¾åœ¨ä½ç½®ã®å·¦å³ã®å˜èªã®å…ˆé ­ä½ç½®ã‚’èª¿ã¹ã‚‹
 	CLogicInt	nPosNew;
 	int			nRetCode = CSearchAgent(m_pcDocLineMgr).PrevOrNextWord(
 		pLayout->GetLogicLineNo(),
@@ -748,7 +748,7 @@ int CLayoutMgr::PrevOrNextWord(
 	);
 
 	if( nRetCode ){
-		/* ˜_—ˆÊ’u¨ƒŒƒCƒAƒEƒgˆÊ’u•ÏŠ· */
+		/* è«–ç†ä½ç½®â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®å¤‰æ› */
 		LogicToLayout(
 			CLogicPoint(nPosNew,pLayout->GetLogicLineNo()),
 			pptLayoutNew,
@@ -762,15 +762,15 @@ int CLayoutMgr::PrevOrNextWord(
 
 
 
-//! ’PŒêŒŸõ
+//! å˜èªæ¤œç´¢
 /*
-	@retval 0 Œ©‚Â‚©‚ç‚È‚¢
+	@retval 0 è¦‹ã¤ã‹ã‚‰ãªã„
 */
 int CLayoutMgr::SearchWord(
-	CLayoutInt				nLine,				//!< [in] ŒŸõŠJnƒŒƒCƒAƒEƒgs
-	CLogicInt				nIdx,				//!< [in] ŒŸõŠJnƒf[ƒ^ˆÊ’u
-	ESearchDirection		eSearchDirection,	//!< [in] ŒŸõ•ûŒü
-	CLayoutRange*			pMatchRange,		//!< [out] ƒ}ƒbƒ`ƒŒƒCƒAƒEƒg”ÍˆÍ
+	CLayoutInt				nLine,				//!< [in] æ¤œç´¢é–‹å§‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
+	CLogicInt				nIdx,				//!< [in] æ¤œç´¢é–‹å§‹ãƒ‡ãƒ¼ã‚¿ä½ç½®
+	ESearchDirection		eSearchDirection,	//!< [in] æ¤œç´¢æ–¹å‘
+	CLayoutRange*			pMatchRange,		//!< [out] ãƒãƒƒãƒãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆç¯„å›²
 	const CSearchStringPattern&	pattern
 )
 {
@@ -781,7 +781,7 @@ int CLayoutMgr::SearchWord(
 		return FALSE;
 	}
 
-	// ’PŒêŒŸõ -> cLogicRange (ƒf[ƒ^ˆÊ’u)
+	// å˜èªæ¤œç´¢ -> cLogicRange (ãƒ‡ãƒ¼ã‚¿ä½ç½®)
 	CLogicRange cLogicRange;
 	nRetCode = CSearchAgent(m_pcDocLineMgr).SearchWord(
 		CLogicPoint(pLayout->GetLogicOffset() + nIdx, pLayout->GetLogicLineNo()),
@@ -790,7 +790,7 @@ int CLayoutMgr::SearchWord(
 		pattern
 	);
 
-	// ˜_—ˆÊ’u¨ƒŒƒCƒAƒEƒgˆÊ’u•ÏŠ·
+	// è«–ç†ä½ç½®â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®å¤‰æ›
 	// cLogicRange -> pMatchRange
 	if( nRetCode ){
 		LogicToLayout(
@@ -806,21 +806,21 @@ int CLayoutMgr::SearchWord(
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ’PˆÊ‚Ì•ÏŠ·                           //
+//                        å˜ä½ã®å¤‰æ›                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /*!
-	@brief ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ· •¨—¨ƒŒƒCƒAƒEƒg
+	@brief ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ› ç‰©ç†â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆ
 
-	•¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-	¨ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+	ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+	â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 
-	@param[in]  ptLogic   ƒƒWƒbƒNˆÊ’u
-	@param[out] pptLayout ƒŒƒCƒAƒEƒgˆÊ’u
-	@param[in]  nLineHint ƒŒƒCƒAƒEƒgY’l‚Ìƒqƒ“ƒgB‹‚ß‚é’l‚É‹ß‚¢’l‚ğ“n‚·‚Æ‚‘¬‚ÉŒŸõ‚Å‚«‚éB
+	@param[in]  ptLogic   ãƒ­ã‚¸ãƒƒã‚¯ä½ç½®
+	@param[out] pptLayout ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®
+	@param[in]  nLineHint ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆYå€¤ã®ãƒ’ãƒ³ãƒˆã€‚æ±‚ã‚ã‚‹å€¤ã«è¿‘ã„å€¤ã‚’æ¸¡ã™ã¨é«˜é€Ÿã«æ¤œç´¢ã§ãã‚‹ã€‚
 
-	@date 2004.06.16 Moca ƒCƒ“ƒfƒ“ƒg•\¦‚ÌÛ‚ÌTAB‚ğŠÜ‚Şs‚ÌÀ•W‚¸‚êC³
-	@date 2007.09.06 kobake ŠÖ”–¼‚ğCaretPos_Phys2Log‚©‚çLogicToLayout‚É•ÏX
+	@date 2004.06.16 Moca ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆè¡¨ç¤ºã®éš›ã®TABã‚’å«ã‚€è¡Œã®åº§æ¨™ãšã‚Œä¿®æ­£
+	@date 2007.09.06 kobake é–¢æ•°åã‚’CaretPos_Phys2Logã‹ã‚‰LogicToLayoutã«å¤‰æ›´
 */
 void CLayoutMgr::LogicToLayout(
 	const CLogicPoint&	ptLogic,
@@ -830,21 +830,21 @@ void CLayoutMgr::LogicToLayout(
 {
 	pptLayout->Clear();
 
-	if(GetLineCount()==0)return; //•ÏŠ·•s‰Â
+	if(GetLineCount()==0)return; //å¤‰æ›ä¸å¯
 
-	// ƒT[ƒ`ŠJn’n“_ -> pLayout, nCaretPosX, nCaretPosY
+	// ã‚µãƒ¼ãƒé–‹å§‹åœ°ç‚¹ -> pLayout, nCaretPosX, nCaretPosY
 	CLayoutInt		nCaretPosX = CLayoutInt(0);
 	CLayoutInt		nCaretPosY;
 	const CLayout*	pLayout;
-	// 2013.05.15 ƒqƒ“ƒgA‚ ‚è‚È‚µ‚Ìˆ—‚ğ“‡
+	// 2013.05.15 ãƒ’ãƒ³ãƒˆã€ã‚ã‚Šãªã—ã®å‡¦ç†ã‚’çµ±åˆ
 	{
 		nLineHint = t_min(GetLineCount() - 1, nLineHint);
 		nCaretPosY = t_max(CLayoutInt(ptLogic.y), nLineHint);
 
-		// 2013.05.12 m_pLayoutPrevRefer‚ğŒ©‚é
+		// 2013.05.12 m_pLayoutPrevReferã‚’è¦‹ã‚‹
 		if( nCaretPosY <= m_nPrevReferLine && m_pLayoutPrevRefer
 			&& m_pLayoutPrevRefer->GetLogicLineNo() <= ptLogic.y ){
-			// ƒqƒ“ƒg‚æ‚èŒ»İˆÊ’u‚Ì‚Ù‚¤‚ªŒã‚ë‚©“¯‚¶‚®‚ç‚¢‚Å‹ß‚¢
+			// ãƒ’ãƒ³ãƒˆã‚ˆã‚Šç¾åœ¨ä½ç½®ã®ã»ã†ãŒå¾Œã‚ã‹åŒã˜ãã‚‰ã„ã§è¿‘ã„
 			nCaretPosY = CLayoutInt(ptLogic.y - m_pLayoutPrevRefer->GetLogicLineNo()) + m_nPrevReferLine;
 			pLayout = SearchLineByLayoutY(nCaretPosY);
 		}else{
@@ -855,13 +855,13 @@ void CLayoutMgr::LogicToLayout(
 			return;
 		}
 
-		//ƒƒWƒbƒNY‚ª‚Å‚©‚·‚¬‚éê‡‚ÍAˆê’v‚·‚é‚Ü‚ÅƒfƒNƒŠƒƒ“ƒg (
+		//ãƒ­ã‚¸ãƒƒã‚¯YãŒã§ã‹ã™ãã‚‹å ´åˆã¯ã€ä¸€è‡´ã™ã‚‹ã¾ã§ãƒ‡ã‚¯ãƒªãƒ¡ãƒ³ãƒˆ (
 		while(pLayout->GetLogicLineNo() > ptLogic.GetY2()){
 			pLayout = pLayout->GetPrevLayout();
 			nCaretPosY--;
 		}
 
-		//ƒƒWƒbƒNY‚ª“¯‚¶‚ÅOffset‚ªs‚«‰ß‚¬‚Ä‚¢‚éê‡‚Í–ß‚é
+		//ãƒ­ã‚¸ãƒƒã‚¯YãŒåŒã˜ã§OffsetãŒè¡Œãéãã¦ã„ã‚‹å ´åˆã¯æˆ»ã‚‹
 		if(pLayout->GetLogicLineNo() == ptLogic.GetY2()){
 			while( pLayout && pLayout->GetPrevLayout() && pLayout->GetPrevLayout()->GetLogicLineNo() == ptLogic.GetY2()
 				&& ptLogic.x < pLayout->GetLogicOffset() ){
@@ -872,10 +872,10 @@ void CLayoutMgr::LogicToLayout(
 	}
 
 
-	//	Layout‚ğ‚P‚Â‚¸‚Âæ‚Éi‚ß‚È‚ª‚çptLogic.y‚ª•¨—s‚Éˆê’v‚·‚éLayout‚ğ’T‚·
+	//	Layoutã‚’ï¼‘ã¤ãšã¤å…ˆã«é€²ã‚ãªãŒã‚‰ptLogic.yãŒç‰©ç†è¡Œã«ä¸€è‡´ã™ã‚‹Layoutã‚’æ¢ã™
 	while( pLayout ){
 		if( ptLogic.GetY2() == pLayout->GetLogicLineNo() ){
-			// 2013.05.10 Moca ‚‘¬‰»
+			// 2013.05.10 Moca é«˜é€ŸåŒ–
 			const CLayout* pLayoutNext = pLayout->GetNextLayout();
 			if( pLayoutNext && ptLogic.GetY2() ==pLayoutNext->GetLogicLineNo()
 					&& pLayoutNext->GetLogicOffset() <= ptLogic.x ){
@@ -884,11 +884,11 @@ void CLayoutMgr::LogicToLayout(
 				continue;
 			}
 
-			//	2004.06.16 Moca ƒCƒ“ƒfƒ“ƒg•\¦‚ÌÛ‚ÉˆÊ’u‚ª‚¸‚ê‚é(TABˆÊ’u‚¸‚ê‚É‚æ‚é)
-			//	TAB•‚ğ³Šm‚ÉŒvZ‚·‚é‚É‚Í“–‰‚©‚çƒCƒ“ƒfƒ“ƒg•ª‚ğ‰Á‚¦‚Ä‚¨‚­•K—v‚ª‚ ‚éD
+			//	2004.06.16 Moca ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆè¡¨ç¤ºã®éš›ã«ä½ç½®ãŒãšã‚Œã‚‹(TABä½ç½®ãšã‚Œã«ã‚ˆã‚‹)
+			//	TABå¹…ã‚’æ­£ç¢ºã«è¨ˆç®—ã™ã‚‹ã«ã¯å½“åˆã‹ã‚‰ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆåˆ†ã‚’åŠ ãˆã¦ãŠãå¿…è¦ãŒã‚ã‚‹ï¼
 			nCaretPosX = pLayout->GetIndent();
 			const wchar_t*	pData;
-			pData = pLayout->GetDocLineRef()->GetPtr() + pLayout->GetLogicOffset(); // 2002/2/10 aroka CMemory•ÏX
+			pData = pLayout->GetDocLineRef()->GetPtr() + pLayout->GetLogicOffset(); // 2002/2/10 aroka CMemoryå¤‰æ›´
 			CLogicInt	nDataLen = (CLogicInt)pLayout->GetLengthWithEOL();
 
 			CLogicInt i;
@@ -897,12 +897,12 @@ void CLayoutMgr::LogicToLayout(
 					break;
 				}
 
-				//•¶šƒƒWƒbƒN• -> nCharChars
+				//æ–‡å­—ãƒ­ã‚¸ãƒƒã‚¯å¹… -> nCharChars
 				CLogicInt nCharChars = CNativeW::GetSizeOfChar( pData, nDataLen, i );
 				if( nCharChars == 0 )
 					nCharChars = CLogicInt(1);
 
-				//•¶šƒŒƒCƒAƒEƒg• -> nCharKetas
+				//æ–‡å­—ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå¹… -> nCharKetas
 				CLayoutInt nCharKetas;
 				if( pData[i] ==	WCODE::TAB || ( pData[i] == L',' && m_tsvInfo.m_nTsvMode == TSV_MODE_CSV) ){
 					nCharKetas = GetActualTsvSpace( nCaretPosX, pData[i] );
@@ -910,47 +910,47 @@ void CLayoutMgr::LogicToLayout(
 				else{
 					nCharKetas = GetLayoutXOfChar( pData, nDataLen, i );
 				}
-//				if( nCharKetas == 0 )				// íœ ƒTƒƒQ[ƒgƒyƒA‘Îô	2008/7/5 Uchi
+//				if( nCharKetas == 0 )				// å‰Šé™¤ ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢å¯¾ç­–	2008/7/5 Uchi
 //					nCharKetas = CLayoutInt(1);
 
-				//ƒŒƒCƒAƒEƒg‰ÁZ
+				//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆåŠ ç®—
 				nCaretPosX += nCharKetas;
 
-				//ƒƒWƒbƒN‰ÁZ
+				//ãƒ­ã‚¸ãƒƒã‚¯åŠ ç®—
 				if( pData[i] ==	WCODE::TAB ){
 					nCharChars = CLogicInt(1);
 				}
 				i += nCharChars - CLogicInt(1);
 			}
 			if( i < nDataLen ){
-				//	ptLogic.x, ptLogic.y‚ª‚±‚Ìs‚Ì’†‚ÉŒ©‚Â‚©‚Á‚½‚çƒ‹[ƒv‘Å‚¿Ø‚è
+				//	ptLogic.x, ptLogic.yãŒã“ã®è¡Œã®ä¸­ã«è¦‹ã¤ã‹ã£ãŸã‚‰ãƒ«ãƒ¼ãƒ—æ‰“ã¡åˆ‡ã‚Š
 				break;
 			}
 
 			if( !pLayout->GetNextLayout() ){
-				//	“–ŠYˆÊ’u‚É’B‚µ‚Ä‚¢‚È‚­‚Ä‚àCƒŒƒCƒAƒEƒg––”ö‚È‚çƒf[ƒ^––”ö‚ÌƒŒƒCƒAƒEƒgˆÊ’u‚ğ•Ô‚·D
+				//	å½“è©²ä½ç½®ã«é”ã—ã¦ã„ãªãã¦ã‚‚ï¼Œãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæœ«å°¾ãªã‚‰ãƒ‡ãƒ¼ã‚¿æœ«å°¾ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã‚’è¿”ã™ï¼
 				nCaretPosX = pLayout->CalcLayoutWidth(*this) + CLayoutInt(pLayout->GetLayoutEol().GetLen()>0?1+m_nSpacing:0);
 				break;
 			}
 
 			if( ptLogic.y < pLayout->m_pNext->GetLogicLineNo() ){
-				//	Ÿ‚ÌLayout‚ª“–ŠY•¨—s‚ğ‰ß‚¬‚Ä‚µ‚Ü‚¤ê‡‚Íƒf[ƒ^––”ö‚ÌƒŒƒCƒAƒEƒgˆÊ’u‚ğ•Ô‚·D
+				//	æ¬¡ã®LayoutãŒå½“è©²ç‰©ç†è¡Œã‚’éãã¦ã—ã¾ã†å ´åˆã¯ãƒ‡ãƒ¼ã‚¿æœ«å°¾ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã‚’è¿”ã™ï¼
 				nCaretPosX = pLayout->CalcLayoutWidth(*this) + CLayoutInt(pLayout->GetLayoutEol().GetLen()>0?1+m_nSpacing:0);
 				break;
 			}
 		}
 		if( ptLogic.GetY2() < pLayout->GetLogicLineNo() ){
-			//	‚Ó‚Â‚¤‚Í‚±‚±‚É‚Í—ˆ‚È‚¢‚Æv‚¤‚ª... (genta)
-			//	Layout‚Ìw‚·•¨—s‚ª’T‚µ‚Ä‚¢‚és‚æ‚èæ‚ğw‚µ‚Ä‚¢‚½‚ç‘Å‚¿Ø‚è
+			//	ãµã¤ã†ã¯ã“ã“ã«ã¯æ¥ãªã„ã¨æ€ã†ãŒ... (genta)
+			//	Layoutã®æŒ‡ã™ç‰©ç†è¡ŒãŒæ¢ã—ã¦ã„ã‚‹è¡Œã‚ˆã‚Šå…ˆã‚’æŒ‡ã—ã¦ã„ãŸã‚‰æ‰“ã¡åˆ‡ã‚Š
 			break;
 		}
 
-		//	Ÿ‚Ìs‚Öi‚Ş
+		//	æ¬¡ã®è¡Œã¸é€²ã‚€
 		nCaretPosY++;
 		pLayout = pLayout->GetNextLayout();
 	}
 
-	//	2004.06.16 Moca ƒCƒ“ƒfƒ“ƒg•\¦‚ÌÛ‚ÌˆÊ’u‚¸‚êC³
+	//	2004.06.16 Moca ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆè¡¨ç¤ºã®éš›ã®ä½ç½®ãšã‚Œä¿®æ­£
 	pptLayout->Set(
 		pLayout ? nCaretPosX : CLayoutInt(0),
 		nCaretPosY
@@ -958,23 +958,23 @@ void CLayoutMgr::LogicToLayout(
 }
 
 /*!
-	@brief ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·  ƒŒƒCƒAƒEƒg¨•¨—
+	@brief ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆâ†’ç‰©ç†
 
-	ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
-	¨•¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
+	ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
+	â†’ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
 
-	@date 2007.09.06 kobake ŠÖ”–¼‚ğCaretPos_Log2Phys¨LayoutToLogic‚É•ÏX
+	@date 2007.09.06 kobake é–¢æ•°åã‚’CaretPos_Log2Physâ†’LayoutToLogicã«å¤‰æ›´
 */
 void CLayoutMgr::LayoutToLogicEx(
-	const CLayoutPoint&	ptLayout,	//!< [in]  ƒŒƒCƒAƒEƒgˆÊ’u
-	CLogicPointEx*		pptLogic	//!< [out] ƒƒWƒbƒNˆÊ’u
+	const CLayoutPoint&	ptLayout,	//!< [in]  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®
+	CLogicPointEx*		pptLogic	//!< [out] ãƒ­ã‚¸ãƒƒã‚¯ä½ç½®
 ) const
 {
 	pptLogic->Set(CLogicInt(0), CLogicInt(0));
 	pptLogic->ext = 0;
 	pptLogic->haba = m_nCharLayoutXPerKeta;
 	if( ptLayout.GetY2() > m_nLines ){
-		//2007.10.11 kobake Y’l‚ªŠÔˆá‚Á‚Ä‚¢‚½‚Ì‚ÅC³
+		//2007.10.11 kobake Yå€¤ãŒé–“é•ã£ã¦ã„ãŸã®ã§ä¿®æ­£
 		//pptLogic->Set(0, m_nLines);
 		pptLogic->Set(CLogicInt(0), m_pcDocLineMgr->GetLineCount());
 		return;
@@ -984,7 +984,7 @@ void CLayoutMgr::LayoutToLogicEx(
 	const wchar_t*	pData;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ‚x’l‚ÌŒˆ’è                           //
+	//                        ï¼¹å€¤ã®æ±ºå®š                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	BOOL			bEOF = FALSE;
 	CLayoutInt		nX;
@@ -1003,7 +1003,7 @@ void CLayoutMgr::LayoutToLogicEx(
 					return;
 				}
 				else{
-					pptLogic->y = m_pcDocLineMgr->GetLineCount() - 1; // 2002/2/10 aroka CDocLineMgr•ÏX
+					pptLogic->y = m_pcDocLineMgr->GetLineCount() - 1; // 2002/2/10 aroka CDocLineMgrå¤‰æ›´
 					bEOF = TRUE;
 					// nX = CLayoutInt(MAXLINEKETAS);
 					nX = pcLayout->GetIndent();
@@ -1012,7 +1012,7 @@ void CLayoutMgr::LayoutToLogicEx(
 				}
 			}
 		}
-		//2007.10.11 kobake Y’l‚ªŠÔˆá‚Á‚Ä‚¢‚½‚Ì‚ÅC³
+		//2007.10.11 kobake Yå€¤ãŒé–“é•ã£ã¦ã„ãŸã®ã§ä¿®æ­£
 		//pptLogic->Set(0, m_nLines);
 		pptLogic->Set(CLogicInt(0), m_pcDocLineMgr->GetLineCount());
 		return;
@@ -1023,7 +1023,7 @@ void CLayoutMgr::LayoutToLogicEx(
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ‚w’l‚ÌŒˆ’è                           //
+	//                        ï¼¸å€¤ã®æ±ºå®š                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	pData = GetLineStr( ptLayout.GetY2(), &nDataLen );
 	nX = pcLayout ? pcLayout->GetIndent() : CLayoutInt(0);
@@ -1032,13 +1032,13 @@ checkloop:;
 	CLogicInt	i;
 	for( i = CLogicInt(0); i < nDataLen; ++i )
 	{
-		//•¶šƒƒWƒbƒN• -> nCharChars
+		//æ–‡å­—ãƒ­ã‚¸ãƒƒã‚¯å¹… -> nCharChars
 		CLogicInt	nCharChars;
 		nCharChars = CNativeW::GetSizeOfChar( pData, nDataLen, i );
 		if( nCharChars == 0 )
 			nCharChars = CLogicInt(1);
 		
-		//•¶šƒŒƒCƒAƒEƒg• -> nCharKetas
+		//æ–‡å­—ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå¹… -> nCharKetas
 		CLayoutInt	nCharKetas;
 		if( pData[i] == WCODE::TAB || (pData[i] == L',' && m_tsvInfo.m_nTsvMode == TSV_MODE_CSV ) ){
 			nCharKetas = GetActualTsvSpace( nX, pData[i] );
@@ -1046,16 +1046,16 @@ checkloop:;
 		else{
 			nCharKetas = GetLayoutXOfChar( pData, nDataLen, i );
 		}
-//		if( nCharKetas == 0 )				// íœ ƒTƒƒQ[ƒgƒyƒA‘Îô	2008/7/5 Uchi
+//		if( nCharKetas == 0 )				// å‰Šé™¤ ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢å¯¾ç­–	2008/7/5 Uchi
 //			nCharKetas = CLayoutInt(1);
 
-		//ƒŒƒCƒAƒEƒg‰ÁZ
+		//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆåŠ ç®—
 		if( nX + nCharKetas > ptLayout.GetX2() && !bEOF ){
 			break;
 		}
 		nX += nCharKetas;
 
-		//ƒƒWƒbƒN‰ÁZ
+		//ãƒ­ã‚¸ãƒƒã‚¯åŠ ç®—
 		if( pData[i] ==	WCODE::TAB ){
 			nCharChars = CLogicInt(1);
 		}
@@ -1078,10 +1078,10 @@ void CLayoutMgr::LayoutToLogic( const CLayoutPoint& ptLayout, CLogicPoint* pptLo
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ƒfƒoƒbƒO                            //
+//                         ãƒ‡ãƒãƒƒã‚°                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/* ƒeƒXƒg—p‚ÉƒŒƒCƒAƒEƒgî•ñ‚ğƒ_ƒ“ƒv */
+/* ãƒ†ã‚¹ãƒˆç”¨ã«ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã‚’ãƒ€ãƒ³ãƒ— */
 void CLayoutMgr::DUMP()
 {
 #ifdef _DEBUG

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -1,11 +1,11 @@
-/*!	@file
-	@brief ƒeƒLƒXƒg‚ÌƒŒƒCƒAƒEƒgî•ñŠÇ—
+ï»¿/*!	@file
+	@brief ãƒ†ã‚­ã‚¹ãƒˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ç®¡ç†
 
 	@author Norio Nakatani
-	@date 1998/03/06 V‹Kì¬
-	@date 1998/04/14 ƒf[ƒ^‚Ìíœ‚ğÀ‘•
-	@date 1999/12/20 ƒf[ƒ^‚Ì’uŠ·‚ğÀ‘•
-	@date 2009/08/28 nasukoji	CalTextWidthArg’è‹`’Ç‰ÁADoLayout_Range()‚Ìˆø”•ÏX
+	@date 1998/03/06 æ–°è¦ä½œæˆ
+	@date 1998/04/14 ãƒ‡ãƒ¼ã‚¿ã®å‰Šé™¤ã‚’å®Ÿè£…
+	@date 1999/12/20 ãƒ‡ãƒ¼ã‚¿ã®ç½®æ›ã‚’å®Ÿè£…
+	@date 2009/08/28 nasukoji	CalTextWidthArgå®šç¾©è¿½åŠ ã€DoLayout_Range()ã®å¼•æ•°å¤‰æ›´
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -45,56 +45,56 @@ class CEditDoc;// 2003/07/20 genta
 class CSearchStringPattern;
 class CColorStrategy;
 
-//! ƒŒƒCƒAƒEƒg’†‚Ì‹Ö‘¥ƒ^ƒCƒv	//@@@ 2002.04.20 MIK
+//! ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä¸­ã®ç¦å‰‡ã‚¿ã‚¤ãƒ—	//@@@ 2002.04.20 MIK
 enum EKinsokuType {
-	KINSOKU_TYPE_NONE = 0,			//!< ‚È‚µ
-	KINSOKU_TYPE_WORDWRAP,			//!< ‰p•¶ƒ[ƒhƒ‰ƒbƒv’†
-	KINSOKU_TYPE_KINSOKU_HEAD,		//!< s“ª‹Ö‘¥’†
-	KINSOKU_TYPE_KINSOKU_TAIL,		//!< s––‹Ö‘¥’†
-	KINSOKU_TYPE_KINSOKU_KUTO,		//!< ‹å“Ç“_‚Ô‚ç‰º‚°’†
+	KINSOKU_TYPE_NONE = 0,			//!< ãªã—
+	KINSOKU_TYPE_WORDWRAP,			//!< è‹±æ–‡ãƒ¯ãƒ¼ãƒ‰ãƒ©ãƒƒãƒ—ä¸­
+	KINSOKU_TYPE_KINSOKU_HEAD,		//!< è¡Œé ­ç¦å‰‡ä¸­
+	KINSOKU_TYPE_KINSOKU_TAIL,		//!< è¡Œæœ«ç¦å‰‡ä¸­
+	KINSOKU_TYPE_KINSOKU_KUTO,		//!< å¥èª­ç‚¹ã¶ã‚‰ä¸‹ã’ä¸­
 };
 
 struct LayoutReplaceArg {
-	CLayoutRange	sDelRange;		//!< [in]íœ”ÍˆÍBƒŒƒCƒAƒEƒg’PˆÊB
-	COpeLineData*	pcmemDeleted;	//!< [out]íœ‚³‚ê‚½ƒf[ƒ^
-	COpeLineData*	pInsData;		//!< [in,out]‘}“ü‚·‚éƒf[ƒ^
-	CLayoutInt		nAddLineNum;	//!< [out] Ä•`‰æƒqƒ“ƒg ƒŒƒCƒAƒEƒgs‚Ì‘Œ¸
-	CLayoutInt		nModLineFrom;	//!< [out] Ä•`‰æƒqƒ“ƒg •ÏX‚³‚ê‚½ƒŒƒCƒAƒEƒgsFrom(ƒŒƒCƒAƒEƒgs‚Ì‘Œ¸‚ª0‚Ì‚Æ‚«g‚¤)
-	CLayoutInt		nModLineTo;		//!< [out] Ä•`‰æƒqƒ“ƒg •ÏX‚³‚ê‚½ƒŒƒCƒAƒEƒgsTo(ƒŒƒCƒAƒEƒgs‚Ì‘Œ¸‚ª0‚Ì‚Æ‚«g‚¤)
-	CLayoutPoint	ptLayoutNew;	//!< [out]‘}“ü‚³‚ê‚½•”•ª‚ÌŸ‚ÌˆÊ’u‚ÌˆÊ’u(ƒŒƒCƒAƒEƒgŒ…ˆÊ’u, ƒŒƒCƒAƒEƒgs)
-	int				nDelSeq;		//!< [in]íœs‚ÌOpeƒV[ƒPƒ“ƒX
-	int				nInsSeq;		//!< [out]‘}“üs‚ÌŒ³‚ÌƒV[ƒPƒ“ƒX
+	CLayoutRange	sDelRange;		//!< [in]å‰Šé™¤ç¯„å›²ã€‚ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã€‚
+	COpeLineData*	pcmemDeleted;	//!< [out]å‰Šé™¤ã•ã‚ŒãŸãƒ‡ãƒ¼ã‚¿
+	COpeLineData*	pInsData;		//!< [in,out]æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿
+	CLayoutInt		nAddLineNum;	//!< [out] å†æç”»ãƒ’ãƒ³ãƒˆ ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®å¢—æ¸›
+	CLayoutInt		nModLineFrom;	//!< [out] å†æç”»ãƒ’ãƒ³ãƒˆ å¤‰æ›´ã•ã‚ŒãŸãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡ŒFrom(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®å¢—æ¸›ãŒ0ã®ã¨ãä½¿ã†)
+	CLayoutInt		nModLineTo;		//!< [out] å†æç”»ãƒ’ãƒ³ãƒˆ å¤‰æ›´ã•ã‚ŒãŸãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡ŒTo(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®å¢—æ¸›ãŒ0ã®ã¨ãä½¿ã†)
+	CLayoutPoint	ptLayoutNew;	//!< [out]æŒ¿å…¥ã•ã‚ŒãŸéƒ¨åˆ†ã®æ¬¡ã®ä½ç½®ã®ä½ç½®(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæ¡ä½ç½®, ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ)
+	int				nDelSeq;		//!< [in]å‰Šé™¤è¡Œã®Opeã‚·ãƒ¼ã‚±ãƒ³ã‚¹
+	int				nInsSeq;		//!< [out]æŒ¿å…¥è¡Œã®å…ƒã®ã‚·ãƒ¼ã‚±ãƒ³ã‚¹
 };
 
-// •ÒW‚ÌƒeƒLƒXƒgÅ‘å•Zo—p		// 2009.08.28 nasukoji
+// ç·¨é›†æ™‚ã®ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ç®—å‡ºç”¨		// 2009.08.28 nasukoji
 struct CalTextWidthArg {
-	CLayoutPoint	ptLayout;		//!< •ÒWŠJnˆÊ’u
-	CLayoutInt		nDelLines;		//!< íœ‚ÉŠÖŒW‚·‚és” - 1i•‰”‚Ìíœ‚È‚µj
-	CLayoutInt		nAllLinesOld;	//!< •ÒW‘O‚ÌƒeƒLƒXƒgs”
-	BOOL			bInsData;		//!< ’Ç‰Á•¶š—ñ‚ ‚è
+	CLayoutPoint	ptLayout;		//!< ç·¨é›†é–‹å§‹ä½ç½®
+	CLayoutInt		nDelLines;		//!< å‰Šé™¤ã«é–¢ä¿‚ã™ã‚‹è¡Œæ•° - 1ï¼ˆè² æ•°ã®æ™‚å‰Šé™¤ãªã—ï¼‰
+	CLayoutInt		nAllLinesOld;	//!< ç·¨é›†å‰ã®ãƒ†ã‚­ã‚¹ãƒˆè¡Œæ•°
+	BOOL			bInsData;		//!< è¿½åŠ æ–‡å­—åˆ—ã‚ã‚Š
 };
 
 class CLogicPointEx: public CLogicPoint{
 public:
-	CLayoutInt ext;	//!< ƒsƒNƒZƒ‹•
-	CLayoutXInt haba;	//!< extİ’è‚Ì‚P•¶š‚Ì•
+	CLayoutInt ext;	//!< ãƒ”ã‚¯ã‚»ãƒ«å¹…
+	CLayoutXInt haba;	//!< extè¨­å®šæ™‚ã®ï¼‘æ–‡å­—ã®å¹…
 };
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
-/*!	@brief ƒeƒLƒXƒg‚ÌƒŒƒCƒAƒEƒgî•ñŠÇ—
+/*!	@brief ãƒ†ã‚­ã‚¹ãƒˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ç®¡ç†
 
-	@date 2005.11.21 Moca F•ª‚¯î•ñ‚ğƒƒ“ƒo[‚ÖˆÚ“®D•s—v‚Æ‚È‚Á‚½ˆø”‚ğƒƒ“ƒoŠÖ”‚©‚çíœD
+	@date 2005.11.21 Moca è‰²åˆ†ã‘æƒ…å ±ã‚’ãƒ¡ãƒ³ãƒãƒ¼ã¸ç§»å‹•ï¼ä¸è¦ã¨ãªã£ãŸå¼•æ•°ã‚’ãƒ¡ãƒ³ãƒé–¢æ•°ã‹ã‚‰å‰Šé™¤ï¼
 */
-//2007.10.15 XYLogicalToLayout‚ğ”p~BLogicToLayout‚É“‡B
+//2007.10.15 XYLogicalToLayoutã‚’å»ƒæ­¢ã€‚LogicToLayoutã«çµ±åˆã€‚
 class CLayoutMgr : public CProgressSubject
 {
 private:
 	typedef CLayoutInt (CLayoutMgr::*CalcIndentProc)( CLayout* );
 
 public:
-	//¶¬‚Æ”jŠü
+	//ç”Ÿæˆã¨ç ´æ£„
 	CLayoutMgr();
 	~CLayoutMgr();
 	void Create( CEditDoc*, CDocLineMgr* );
@@ -103,10 +103,10 @@ public:
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ƒRƒ“ƒtƒBƒO                           //
+	//                        ã‚³ãƒ³ãƒ•ã‚£ã‚°                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//! ƒ^ƒu•‚Ìæ“¾
+	//! ã‚¿ãƒ–å¹…ã®å–å¾—
 	CLayoutInt GetTabSpace() const { return m_nTabSpace * m_nCharLayoutXPerKeta; }
 	CKetaXInt  GetTabSpaceKetas() const { return m_nTabSpace; }
 
@@ -116,33 +116,33 @@ public:
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                          QÆŒn                             //
+	//                          å‚ç…§ç³»                             //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//2007.10.09 kobake ŠÖ”–¼•ÏX: Search ¨ SearchLineByLayoutY
-	CLayoutInt		GetLineCount() const{ return m_nLines; }	/* ‘S•¨—s”‚ğ•Ô‚· */
-	const wchar_t*	GetLineStr( CLayoutInt nLine, CLogicInt* pnLineLen ) const;	/* w’è‚³‚ê‚½•¨—s‚Ìƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚Æ‚»‚Ì’·‚³‚ğ•Ô‚· */
-	const wchar_t*	GetLineStr( CLayoutInt nLine, CLogicInt* pnLineLen, const CLayout** ppcLayoutDes ) const;	/* w’è‚³‚ê‚½•¨—s‚Ìƒf[ƒ^‚Ö‚Ìƒ|ƒCƒ“ƒ^‚Æ‚»‚Ì’·‚³‚ğ•Ô‚· */
+	//2007.10.09 kobake é–¢æ•°åå¤‰æ›´: Search â†’ SearchLineByLayoutY
+	CLayoutInt		GetLineCount() const{ return m_nLines; }	/* å…¨ç‰©ç†è¡Œæ•°ã‚’è¿”ã™ */
+	const wchar_t*	GetLineStr( CLayoutInt nLine, CLogicInt* pnLineLen ) const;	/* æŒ‡å®šã•ã‚ŒãŸç‰©ç†è¡Œã®ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã¨ãã®é•·ã•ã‚’è¿”ã™ */
+	const wchar_t*	GetLineStr( CLayoutInt nLine, CLogicInt* pnLineLen, const CLayout** ppcLayoutDes ) const;	/* æŒ‡å®šã•ã‚ŒãŸç‰©ç†è¡Œã®ãƒ‡ãƒ¼ã‚¿ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã¨ãã®é•·ã•ã‚’è¿”ã™ */
 
-	//æ“ª‚Æ––”ö
+	//å…ˆé ­ã¨æœ«å°¾
 	CLayout*		GetTopLayout()		{ return m_pLayoutTop; }
 	CLayout*		GetBottomLayout()	{ return m_pLayoutBot; }
 	const CLayout*	GetTopLayout() const { return m_pLayoutTop; }
 	const CLayout*	GetBottomLayout() const { return m_pLayoutBot; }
 
-	//ƒŒƒCƒAƒEƒg‚ğ’T‚·
-	const CLayout*	SearchLineByLayoutY( CLayoutInt nLineLayout ) const;	/* w’è‚³‚ê‚½•¨—s‚ÌƒŒƒCƒAƒEƒgƒf[ƒ^(CLayout)‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğ•Ô‚· */
+	//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã‚’æ¢ã™
+	const CLayout*	SearchLineByLayoutY( CLayoutInt nLineLayout ) const;	/* æŒ‡å®šã•ã‚ŒãŸç‰©ç†è¡Œã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆãƒ‡ãƒ¼ã‚¿(CLayout)ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã™ */
 	CLayout*		SearchLineByLayoutY( CLayoutInt nLineLayout ){ return const_cast<CLayout*>(static_cast<const CLayoutMgr*>(this)->SearchLineByLayoutY(nLineLayout)); }
 
-	//ƒ[ƒh‚ğ’T‚·
-	bool			WhereCurrentWord( CLayoutInt , CLogicInt , CLayoutRange* pSelect, CNativeW*, CNativeW* );	/* Œ»İˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ğ’²‚×‚é */
+	//ãƒ¯ãƒ¼ãƒ‰ã‚’æ¢ã™
+	bool			WhereCurrentWord( CLayoutInt , CLogicInt , CLayoutRange* pSelect, CNativeW*, CNativeW* );	/* ç¾åœ¨ä½ç½®ã®å˜èªã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 
-	//”»’è
-	bool			IsEndOfLine( const CLayoutPoint& ptLinePos );	/* w’èˆÊ’u‚ªs––(‰üs•¶š‚Ì’¼‘O)‚©’²‚×‚é */	//@@@ 2002.04.18 MIK
+	//åˆ¤å®š
+	bool			IsEndOfLine( const CLayoutPoint& ptLinePos );	/* æŒ‡å®šä½ç½®ãŒè¡Œæœ«(æ”¹è¡Œæ–‡å­—ã®ç›´å‰)ã‹èª¿ã¹ã‚‹ */	//@@@ 2002.04.18 MIK
 
-	/*! Ÿ‚ÌTABˆÊ’u‚Ü‚Å‚Ì•
-		@param pos [in] Œ»İ‚ÌˆÊ’u
-		@return Ÿ‚ÌTABˆÊ’u‚Ü‚Å‚Ì•¶š”D1`TAB•
+	/*! æ¬¡ã®TABä½ç½®ã¾ã§ã®å¹…
+		@param pos [in] ç¾åœ¨ã®ä½ç½®
+		@return æ¬¡ã®TABä½ç½®ã¾ã§ã®æ–‡å­—æ•°ï¼1ï½TABå¹…
 	 */
 	CLayoutInt GetActualTabSpace(CLayoutInt pos) const {
 		CLayoutInt tabPadding = m_nCharLayoutXPerKeta - 1;
@@ -154,10 +154,10 @@ public:
 		return CMemoryIterator(pcLayout, this->GetTabSpace(), this->m_tsvInfo, this->GetWidthPerKeta(), this->GetCharSpacing());
 	}
 
-	/*! Ÿ‚ÌTAB‚Ü‚½‚ÍƒJƒ“ƒ}ˆÊ’u‚Ü‚Å‚Ì•
-		@param pos [in] Œ»İ‚ÌˆÊ’u
+	/*! æ¬¡ã®TABã¾ãŸã¯ã‚«ãƒ³ãƒä½ç½®ã¾ã§ã®å¹…
+		@param pos [in] ç¾åœ¨ã®ä½ç½®
 		@param 
-		@return Ÿ‚ÌTABˆÊ’u‚Ü‚Å‚Ì•¶š”D1`TAB•
+		@return æ¬¡ã®TABä½ç½®ã¾ã§ã®æ–‡å­—æ•°ï¼1ï½TABå¹…
 	 */
 	CLayoutInt GetActualTsvSpace(CLayoutInt pos, wchar_t ch) const {
 		CLayoutInt tabPadding = m_nCharLayoutXPerKeta - 1;
@@ -177,40 +177,40 @@ public:
 	}
 
 	//	Aug. 14, 2005 genta
-	// Sep. 07, 2007 kobake ŠÖ”–¼•ÏX GetMaxLineSize¨GetMaxLineKetas
+	// Sep. 07, 2007 kobake é–¢æ•°åå¤‰æ›´ GetMaxLineSizeâ†’GetMaxLineKetas
 	CKetaXInt GetMaxLineKetas() const { return m_nMaxLineKetas; }
 	CLayoutXInt GetMaxLineLayout() const { return m_nMaxLineKetas * m_nCharLayoutXPerKeta; }
 
-	// 2005.11.21 Moca ˆø—p•„‚ÌF•ª‚¯î•ñ‚ğˆø”‚©‚çœ‹
+	// 2005.11.21 Moca å¼•ç”¨ç¬¦ã®è‰²åˆ†ã‘æƒ…å ±ã‚’å¼•æ•°ã‹ã‚‰é™¤å»
 	bool ChangeLayoutParam( CKetaXInt nTabSize, int nTsvMode, CKetaXInt nMaxLineKetas );
 
 	// Jul. 29, 2006 genta
 	void GetEndLayoutPos(CLayoutPoint* ptLayoutEnd);
 
-	CLayoutInt GetMaxTextWidth(void) const { return m_nTextWidth; }		// 2009.08.28 nasukoji	ƒeƒLƒXƒgÅ‘å•‚ğ•Ô‚·
+	CLayoutInt GetMaxTextWidth(void) const { return m_nTextWidth; }		// 2009.08.28 nasukoji	ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’è¿”ã™
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ŒŸõ                              //
+	//                           æ¤œç´¢                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 protected:
-	int PrevOrNextWord( CLayoutInt, CLogicInt, CLayoutPoint* pptLayoutNew, BOOL, BOOL bStopsBothEnds );	/* Œ»İˆÊ’u‚Ì¶‰E‚Ì’PŒê‚Ìæ“ªˆÊ’u‚ğ’²‚×‚é */
+	int PrevOrNextWord( CLayoutInt, CLogicInt, CLayoutPoint* pptLayoutNew, BOOL, BOOL bStopsBothEnds );	/* ç¾åœ¨ä½ç½®ã®å·¦å³ã®å˜èªã®å…ˆé ­ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 public:
-	int PrevWord( CLayoutInt nLineNum, CLogicInt nIdx, CLayoutPoint* pptLayoutNew, BOOL bStopsBothEnds ){ return PrevOrNextWord(nLineNum, nIdx, pptLayoutNew, TRUE, bStopsBothEnds); }	/* Œ»İˆÊ’u‚Ì¶‰E‚Ì’PŒê‚Ìæ“ªˆÊ’u‚ğ’²‚×‚é */
-	int NextWord( CLayoutInt nLineNum, CLogicInt nIdx, CLayoutPoint* pptLayoutNew, BOOL bStopsBothEnds ){ return PrevOrNextWord(nLineNum, nIdx, pptLayoutNew, FALSE, bStopsBothEnds); }	/* Œ»İˆÊ’u‚Ì¶‰E‚Ì’PŒê‚Ìæ“ªˆÊ’u‚ğ’²‚×‚é */
+	int PrevWord( CLayoutInt nLineNum, CLogicInt nIdx, CLayoutPoint* pptLayoutNew, BOOL bStopsBothEnds ){ return PrevOrNextWord(nLineNum, nIdx, pptLayoutNew, TRUE, bStopsBothEnds); }	/* ç¾åœ¨ä½ç½®ã®å·¦å³ã®å˜èªã®å…ˆé ­ä½ç½®ã‚’èª¿ã¹ã‚‹ */
+	int NextWord( CLayoutInt nLineNum, CLogicInt nIdx, CLayoutPoint* pptLayoutNew, BOOL bStopsBothEnds ){ return PrevOrNextWord(nLineNum, nIdx, pptLayoutNew, FALSE, bStopsBothEnds); }	/* ç¾åœ¨ä½ç½®ã®å·¦å³ã®å˜èªã®å…ˆé ­ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 
-	int SearchWord( CLayoutInt nLine, CLogicInt nIdx, ESearchDirection eSearchDirection, CLayoutRange* pMatchRange, const CSearchStringPattern& );	/* ’PŒêŒŸõ */
+	int SearchWord( CLayoutInt nLine, CLogicInt nIdx, ESearchDirection eSearchDirection, CLayoutRange* pMatchRange, const CSearchStringPattern& );	/* å˜èªæ¤œç´¢ */
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ’PˆÊ‚Ì•ÏŠ·                           //
+	//                        å˜ä½ã®å¤‰æ›                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//!ƒƒWƒbƒN¨ƒŒƒCƒAƒEƒg
+	//!ãƒ­ã‚¸ãƒƒã‚¯â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆ
 	void LogicToLayoutEx( const CLogicPointEx& ptLogicEx, CLayoutPoint* pptLayout, CLayoutInt nLineHint = CLayoutInt(0) )
 	{
 		LogicToLayout( ptLogicEx, pptLayout, nLineHint );
 		if( 0 < ptLogicEx.ext ){
-			// •¶š•Š·Z‚ğ‚·‚é
+			// æ–‡å­—å¹…æ›ç®—ã‚’ã™ã‚‹
 			int ext = std::max(0, ::MulDiv((Int)ptLogicEx.ext, (Int)m_nCharLayoutXPerKeta, (Int)ptLogicEx.haba));
 			pptLayout->x += ext;
 		}
@@ -222,7 +222,7 @@ public:
 		LogicToLayout(rangeLogic.GetTo(), prangeLayout->GetToPointer());
 	}
 
-	//!ƒŒƒCƒAƒEƒg¨ƒƒWƒbƒN•ÏŠ·
+	//!ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆâ†’ãƒ­ã‚¸ãƒƒã‚¯å¤‰æ›
 	void LayoutToLogicEx( const CLayoutPoint& ptLayout, CLogicPointEx* pptLogicEx ) const;
 	void LayoutToLogic( const CLayoutPoint& ptLayout, CLogicPoint* pptLogic ) const;
 	void LayoutToLogic( const CLayoutRange& rangeLayout, CLogicRange* prangeLogic ) const
@@ -232,23 +232,23 @@ public:
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ƒfƒoƒbƒO                            //
+	//                         ãƒ‡ãƒãƒƒã‚°                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	void DUMP();	/* ƒeƒXƒg—p‚ÉƒŒƒCƒAƒEƒgî•ñ‚ğƒ_ƒ“ƒv */
+	void DUMP();	/* ãƒ†ã‚¹ãƒˆç”¨ã«ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã‚’ãƒ€ãƒ³ãƒ— */
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         •ÒW‚Æ‚©                            //
+	//                         ç·¨é›†ã¨ã‹                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	/*
-	|| XVŒn
+	|| æ›´æ–°ç³»
 	*/
-	/* ƒŒƒCƒAƒEƒgî•ñ‚Ì•ÏX
-		@date Jun. 01, 2001 JEPRO char* (sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^3—p)‚ğ1‚Â’Ç‰Á
-		@date 2002.04.13 MIK ‹Ö‘¥,‰üs•¶š‚ğ‚Ô‚ç‰º‚°‚é,‹å“Ç“_‚Ô‚ç‚³‚°‚ğ’Ç‰Á
-		@date 2002/04/27 YAZAKI STypeConfig‚ğ“n‚·‚æ‚¤‚É•ÏXB
+	/* ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã®å¤‰æ›´
+		@date Jun. 01, 2001 JEPRO char* (è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿3ç”¨)ã‚’1ã¤è¿½åŠ 
+		@date 2002.04.13 MIK ç¦å‰‡,æ”¹è¡Œæ–‡å­—ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹,å¥èª­ç‚¹ã¶ã‚‰ã•ã’ã‚’è¿½åŠ 
+		@date 2002/04/27 YAZAKI STypeConfigã‚’æ¸¡ã™ã‚ˆã†ã«å¤‰æ›´ã€‚
 	*/
 	void SetLayoutInfo(
 		bool			bDoLayout,
@@ -261,13 +261,13 @@ public:
 		const LOGFONT*	pLogfont
 	);
 
-	/* •¶š—ñ’uŠ· */
+	/* æ–‡å­—åˆ—ç½®æ› */
 	void ReplaceData_CLayoutMgr(
 		LayoutReplaceArg*	pArg
 	);
 
-	BOOL CalculateTextWidth( BOOL bCalLineLen = TRUE, CLayoutInt nStart = CLayoutInt(-1), CLayoutInt nEnd = CLayoutInt(-1) );	/* ƒeƒLƒXƒgÅ‘å•‚ğZo‚·‚é */		// 2009.08.28 nasukoji
-	void ClearLayoutLineWidth( void );				/* Šes‚ÌƒŒƒCƒAƒEƒgs’·‚Ì‹L‰¯‚ğƒNƒŠƒA‚·‚é */		// 2009.08.28 nasukoji
+	BOOL CalculateTextWidth( BOOL bCalLineLen = TRUE, CLayoutInt nStart = CLayoutInt(-1), CLayoutInt nEnd = CLayoutInt(-1) );	/* ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹ */		// 2009.08.28 nasukoji
+	void ClearLayoutLineWidth( void );				/* å„è¡Œã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œé•·ã®è¨˜æ†¶ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹ */		// 2009.08.28 nasukoji
 	CLayoutXInt GetLayoutXOfChar( const wchar_t* pData, int nDataLen, int i ) const {
 		CLayoutXInt nSpace = CLayoutXInt(0);
 		if( m_nSpacing ){
@@ -284,29 +284,29 @@ public:
 
 protected:
 	/*
-	||  QÆŒn
+	||  å‚ç…§ç³»
 	*/
-	const char* GetFirstLinrStr( int* );	/* ‡ƒAƒNƒZƒXƒ‚[ƒhFæ“ªs‚ğ“¾‚é */
-	const char* GetNextLinrStr( int* );	/* ‡ƒAƒNƒZƒXƒ‚[ƒhFŸ‚Ìs‚ğ“¾‚é */
+	const char* GetFirstLinrStr( int* );	/* é †ã‚¢ã‚¯ã‚»ã‚¹ãƒ¢ãƒ¼ãƒ‰ï¼šå…ˆé ­è¡Œã‚’å¾—ã‚‹ */
+	const char* GetNextLinrStr( int* );	/* é †ã‚¢ã‚¯ã‚»ã‚¹ãƒ¢ãƒ¼ãƒ‰ï¼šæ¬¡ã®è¡Œã‚’å¾—ã‚‹ */
 
 
 	/*
-	|| XVŒn
+	|| æ›´æ–°ç³»
 	*/
-	// 2005.11.21 Moca ˆø—p•„‚ÌF•ª‚¯î•ñ‚ğˆø”‚©‚çœ‹
+	// 2005.11.21 Moca å¼•ç”¨ç¬¦ã®è‰²åˆ†ã‘æƒ…å ±ã‚’å¼•æ•°ã‹ã‚‰é™¤å»
 public:
-	void _DoLayout(bool bBlockingHook);	/* Œ»İ‚ÌÜ‚è•Ô‚µ•¶š”‚É‡‚í‚¹‚Ä‘Sƒf[ƒ^‚ÌƒŒƒCƒAƒEƒgî•ñ‚ğÄ¶¬‚µ‚Ü‚· */
+	void _DoLayout(bool bBlockingHook);	/* ç¾åœ¨ã®æŠ˜ã‚Šè¿”ã—æ–‡å­—æ•°ã«åˆã‚ã›ã¦å…¨ãƒ‡ãƒ¼ã‚¿ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã‚’å†ç”Ÿæˆã—ã¾ã™ */
 protected:
-	// 2005.11.21 Moca ˆø—p•„‚ÌF•ª‚¯î•ñ‚ğˆø”‚©‚çœ‹
-	// 2009.08.28 nasukoji	ƒeƒLƒXƒgÅ‘å•Zo—pˆø”’Ç‰Á
-	CLayoutInt DoLayout_Range( CLayout* , CLogicInt, CLogicPoint, EColorIndexType, CLayoutColorInfo*, const CalTextWidthArg*, CLayoutInt* );	/* w’èƒŒƒCƒAƒEƒgs‚É‘Î‰‚·‚é˜_—s‚ÌŸ‚Ì˜_—s‚©‚çw’è˜_—s”‚¾‚¯ÄƒŒƒCƒAƒEƒg‚·‚é */
-	void CalculateTextWidth_Range( const CalTextWidthArg* pctwArg );	/* ƒeƒLƒXƒg‚ª•ÒW‚³‚ê‚½‚çÅ‘å•‚ğZo‚·‚é */	// 2009.08.28 nasukoji
-	CLayout* DeleteLayoutAsLogical( CLayout*, CLayoutInt, CLogicInt , CLogicInt, CLogicPoint, CLayoutInt* );	/* ˜_—s‚Ìw’è”ÍˆÍ‚ÉŠY“–‚·‚éƒŒƒCƒAƒEƒgî•ñ‚ğíœ */
-	void ShiftLogicalLineNum( CLayout* , CLogicInt );	/* w’ès‚æ‚èŒã‚Ìs‚ÌƒŒƒCƒAƒEƒgî•ñ‚É‚Â‚¢‚ÄA˜_—s”Ô†‚ğw’ès”‚¾‚¯ƒVƒtƒg‚·‚é */
+	// 2005.11.21 Moca å¼•ç”¨ç¬¦ã®è‰²åˆ†ã‘æƒ…å ±ã‚’å¼•æ•°ã‹ã‚‰é™¤å»
+	// 2009.08.28 nasukoji	ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ç®—å‡ºç”¨å¼•æ•°è¿½åŠ 
+	CLayoutInt DoLayout_Range( CLayout* , CLogicInt, CLogicPoint, EColorIndexType, CLayoutColorInfo*, const CalTextWidthArg*, CLayoutInt* );	/* æŒ‡å®šãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã«å¯¾å¿œã™ã‚‹è«–ç†è¡Œã®æ¬¡ã®è«–ç†è¡Œã‹ã‚‰æŒ‡å®šè«–ç†è¡Œæ•°ã ã‘å†ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã™ã‚‹ */
+	void CalculateTextWidth_Range( const CalTextWidthArg* pctwArg );	/* ãƒ†ã‚­ã‚¹ãƒˆãŒç·¨é›†ã•ã‚ŒãŸã‚‰æœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹ */	// 2009.08.28 nasukoji
+	CLayout* DeleteLayoutAsLogical( CLayout*, CLayoutInt, CLogicInt , CLogicInt, CLogicPoint, CLayoutInt* );	/* è«–ç†è¡Œã®æŒ‡å®šç¯„å›²ã«è©²å½“ã™ã‚‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã‚’å‰Šé™¤ */
+	void ShiftLogicalLineNum( CLayout* , CLogicInt );	/* æŒ‡å®šè¡Œã‚ˆã‚Šå¾Œã®è¡Œã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã«ã¤ã„ã¦ã€è«–ç†è¡Œç•ªå·ã‚’æŒ‡å®šè¡Œæ•°ã ã‘ã‚·ãƒ•ãƒˆã™ã‚‹ */
 
-	//•”•i
+	//éƒ¨å“
 	struct SLayoutWork{
-		//–ˆƒ‹[ƒv‰Šú‰»
+		//æ¯ãƒ«ãƒ¼ãƒ—åˆæœŸåŒ–
 		EKinsokuType	eKinsokuType;
 		CLogicInt		nPos;
 		CLogicInt		nBgn;
@@ -317,7 +317,7 @@ protected:
 		CLayoutInt		nIndent;
 		CLayout*		pLayoutCalculated;
 
-		//ƒ‹[ƒvŠO
+		//ãƒ«ãƒ¼ãƒ—å¤–
 		CDocLine*		pcDocLine;
 		CLayout*		pLayout;
 		CColorStrategy*	pcColorStrategy;
@@ -325,23 +325,23 @@ protected:
 		CLayoutExInfo	exInfoPrev;
 		CLogicInt		nCurLine;
 
-		//ƒ‹[ƒvŠO (DoLayout‚Ì‚İ)
+		//ãƒ«ãƒ¼ãƒ—å¤– (DoLayoutã®ã¿)
 //		CLogicInt		nLineNum;
 
-		//ƒ‹[ƒvŠO (DoLayout_Range‚Ì‚İ)
+		//ãƒ«ãƒ¼ãƒ—å¤– (DoLayout_Rangeã®ã¿)
 		bool			bNeedChangeCOMMENTMODE;
 		CLayoutInt		nModifyLayoutLinesNew;
 		
-		//ƒ‹[ƒvŠO (DoLayout_Rangeˆø”)
+		//ãƒ«ãƒ¼ãƒ—å¤– (DoLayout_Rangeå¼•æ•°)
 		CLayoutInt*		pnExtInsLineNum;
 		CLogicPoint		ptDelLogicalFrom;
 
-		//ŠÖ”
+		//é–¢æ•°
 		CLayout* _CreateLayout(CLayoutMgr* mgr);
 	};
-	//ŠÖ”ƒ|ƒCƒ“ƒ^
+	//é–¢æ•°ãƒã‚¤ãƒ³ã‚¿
 	typedef void (CLayoutMgr::*PF_OnLine)(SLayoutWork*);
-	//DoLayout—p
+	//DoLayoutç”¨
 	bool _DoKinsokuSkip(SLayoutWork* pWork, PF_OnLine pfOnLine);
 	void _DoWordWrap(SLayoutWork* pWork, PF_OnLine pfOnLine);
 	void _DoKutoBurasage(SLayoutWork* pWork);
@@ -349,89 +349,89 @@ protected:
 	void _DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine);
 	bool _DoTab(SLayoutWork* pWork, PF_OnLine pfOnLine);
 	void _MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine);
-	//DoLayout—pƒRƒA
+	//DoLayoutç”¨ã‚³ã‚¢
 	void _OnLine1(SLayoutWork* pWork);
-	//DoLayout_Range—pƒRƒA
+	//DoLayout_Rangeç”¨ã‚³ã‚¢
 	void _OnLine2(SLayoutWork* pWork);
 
 
 private:
 	bool _ExistKinsokuKuto(wchar_t wc) const{ return m_pszKinsokuKuto_1.exist(wc); }
 	bool _ExistKinsokuHead(wchar_t wc) const{ return m_pszKinsokuHead_1.exist(wc); }
-	bool IsKinsokuHead( wchar_t wc );	/*!< s“ª‹Ö‘¥•¶š‚ğƒ`ƒFƒbƒN‚·‚é */	//@@@ 2002.04.08 MIK
-	bool IsKinsokuTail( wchar_t wc );	/*!< s––‹Ö‘¥•¶š‚ğƒ`ƒFƒbƒN‚·‚é */	//@@@ 2002.04.08 MIK
-	bool IsKinsokuKuto( wchar_t wc );	/*!< ‹å“Ç“_•¶š‚ğƒ`ƒFƒbƒN‚·‚é */	//@@@ 2002.04.17 MIK
-	//	2005-08-20 D.S.Koba ‹Ö‘¥ŠÖ˜Aˆ—‚ÌŠÖ”‰»
-	/*! ‹å“Ç“_‚Ô‚ç‰º‚°‚Ìˆ—ˆÊ’u‚©
+	bool IsKinsokuHead( wchar_t wc );	/*!< è¡Œé ­ç¦å‰‡æ–‡å­—ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹ */	//@@@ 2002.04.08 MIK
+	bool IsKinsokuTail( wchar_t wc );	/*!< è¡Œæœ«ç¦å‰‡æ–‡å­—ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹ */	//@@@ 2002.04.08 MIK
+	bool IsKinsokuKuto( wchar_t wc );	/*!< å¥èª­ç‚¹æ–‡å­—ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹ */	//@@@ 2002.04.17 MIK
+	//	2005-08-20 D.S.Koba ç¦å‰‡é–¢é€£å‡¦ç†ã®é–¢æ•°åŒ–
+	/*! å¥èª­ç‚¹ã¶ã‚‰ä¸‹ã’ã®å‡¦ç†ä½ç½®ã‹
 		@date 2005-08-20 D.S.Koba
-		@date Sep. 3, 2005 genta Å“K‰»
+		@date Sep. 3, 2005 genta æœ€é©åŒ–
 	*/
 	bool IsKinsokuPosKuto(CLayoutInt nRest, CLayoutInt nCharChars ) const {
 		return nRest < nCharChars;
 	}
-	bool IsKinsokuPosHead(CLayoutInt, CLayoutInt, CLayoutInt);	//!< s“ª‹Ö‘¥‚Ìˆ—ˆÊ’u‚©
-	bool IsKinsokuPosTail(CLayoutInt, CLayoutInt, CLayoutInt);	//!< s––‹Ö‘¥‚Ìˆ—ˆÊ’u‚©
+	bool IsKinsokuPosHead(CLayoutInt, CLayoutInt, CLayoutInt);	//!< è¡Œé ­ç¦å‰‡ã®å‡¦ç†ä½ç½®ã‹
+	bool IsKinsokuPosTail(CLayoutInt, CLayoutInt, CLayoutInt);	//!< è¡Œæœ«ç¦å‰‡ã®å‡¦ç†ä½ç½®ã‹
 private:
-	//	Oct. 1, 2002 genta ƒCƒ“ƒfƒ“ƒg•ŒvZŠÖ”ŒQ
+	//	Oct. 1, 2002 genta ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…è¨ˆç®—é–¢æ•°ç¾¤
 	CLayoutInt getIndentOffset_Normal( CLayout* pLayoutPrev );
 	CLayoutInt getIndentOffset_Tx2x( CLayout* pLayoutPrev );
 	CLayoutInt getIndentOffset_LeftSpace( CLayout* pLayoutPrev );
 
 protected:
 	/*
-	|| À‘•ƒwƒ‹ƒpŒn
+	|| å®Ÿè£…ãƒ˜ãƒ«ãƒ‘ç³»
 	*/
 	//@@@ 2002.09.23 YAZAKI
-	// 2009.08.28 nasukoji	nPosXˆø”’Ç‰Á
+	// 2009.08.28 nasukoji	nPosXå¼•æ•°è¿½åŠ 
 	CLayout* CreateLayout( CDocLine* pCDocLine, CLogicPoint ptLogicPos, CLogicInt nLength, EColorIndexType nTypePrev, CLayoutInt nIndent, CLayoutInt nPosX, CLayoutColorInfo* );
 	CLayout* InsertLineNext( CLayout*, CLayout* );
 	void AddLineBottom( CLayout* );
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ƒƒ“ƒo•Ï”                           //
+	//                        ãƒ¡ãƒ³ãƒå¤‰æ•°                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	CDocLineMgr*			m_pcDocLineMgr;	/* sƒoƒbƒtƒ@ŠÇ—ƒ}ƒl[ƒWƒƒ */
+	CDocLineMgr*			m_pcDocLineMgr;	/* è¡Œãƒãƒƒãƒ•ã‚¡ç®¡ç†ãƒãƒãƒ¼ã‚¸ãƒ£ */
 	CTsvModeInfo			m_tsvInfo;
 
 protected:
 	// 2002.10.07 YAZAKI add m_nLineTypeBot
-	// 2007.09.07 kobake •Ï”–¼•ÏX: m_nMaxLineSize¨m_nMaxLineKetas
-	// 2007.10.08 kobake •Ï”–¼•ÏX: getIndentOffset¨m_getIndentOffset
+	// 2007.09.07 kobake å¤‰æ•°åå¤‰æ›´: m_nMaxLineSizeâ†’m_nMaxLineKetas
+	// 2007.10.08 kobake å¤‰æ•°åå¤‰æ›´: getIndentOffsetâ†’m_getIndentOffset
 
-	//QÆ
+	//å‚ç…§
 	CEditDoc*		m_pcEditDoc;
 
-	//Àƒf[ƒ^
+	//å®Ÿãƒ‡ãƒ¼ã‚¿
 	CLayout*				m_pLayoutTop;
 	CLayout*				m_pLayoutBot;
 
-	//ƒ^ƒCƒv•Êİ’è
+	//ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š
 	const STypeConfig*		m_pTypeConfig;
-	CKetaXInt				m_nMaxLineKetas;			//!< Ü‚è•Ô‚µŒ…”
-	CKetaXInt				m_nTabSpace;				//!< TAB‚Ì•¶š”
-	CLayoutXInt				m_nCharLayoutXPerKeta;		//!< CKetaXInt(1)‚ ‚½‚è‚ÌCLayoutXInt’l(Spacing“ü‚è)
-	CPixelXInt				m_nSpacing;					//!< 1•¶š‚¸‚Â‚ÌŠÔŠu(px)
-	vector_ex<wchar_t>		m_pszKinsokuHead_1;			//!< s“ª‹Ö‘¥•¶š	//@@@ 2002.04.08 MIK
-	vector_ex<wchar_t>		m_pszKinsokuTail_1;			//!< s––‹Ö‘¥•¶š	//@@@ 2002.04.08 MIK
-	vector_ex<wchar_t>		m_pszKinsokuKuto_1;			//!< ‹å“Ç“_‚Ô‚ç‚³‚°•¶š	//@@@ 2002.04.17 MIK
-	CalcIndentProc			m_getIndentOffset;			//!< Oct. 1, 2002 genta ƒCƒ“ƒfƒ“ƒg•ŒvZŠÖ”‚ğ•Û
+	CKetaXInt				m_nMaxLineKetas;			//!< æŠ˜ã‚Šè¿”ã—æ¡æ•°
+	CKetaXInt				m_nTabSpace;				//!< TABã®æ–‡å­—æ•°
+	CLayoutXInt				m_nCharLayoutXPerKeta;		//!< CKetaXInt(1)ã‚ãŸã‚Šã®CLayoutXIntå€¤(Spacingå…¥ã‚Š)
+	CPixelXInt				m_nSpacing;					//!< 1æ–‡å­—ãšã¤ã®é–“éš”(px)
+	vector_ex<wchar_t>		m_pszKinsokuHead_1;			//!< è¡Œé ­ç¦å‰‡æ–‡å­—	//@@@ 2002.04.08 MIK
+	vector_ex<wchar_t>		m_pszKinsokuTail_1;			//!< è¡Œæœ«ç¦å‰‡æ–‡å­—	//@@@ 2002.04.08 MIK
+	vector_ex<wchar_t>		m_pszKinsokuKuto_1;			//!< å¥èª­ç‚¹ã¶ã‚‰ã•ã’æ–‡å­—	//@@@ 2002.04.17 MIK
+	CalcIndentProc			m_getIndentOffset;			//!< Oct. 1, 2002 genta ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…è¨ˆç®—é–¢æ•°ã‚’ä¿æŒ
 
-	//ƒtƒ‰ƒO“™
-	EColorIndexType			m_nLineTypeBot;				//!< ƒ^ƒCƒv 0=’Êí 1=sƒRƒƒ“ƒg 2=ƒuƒƒbƒNƒRƒƒ“ƒg 3=ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ 4=ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ
+	//ãƒ•ãƒ©ã‚°ç­‰
+	EColorIndexType			m_nLineTypeBot;				//!< ã‚¿ã‚¤ãƒ— 0=é€šå¸¸ 1=è¡Œã‚³ãƒ¡ãƒ³ãƒˆ 2=ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ 3=ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ— 4=ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—
 	CLayoutExInfo			m_cLayoutExInfoBot;
-	CLayoutInt				m_nLines;					// ‘SƒŒƒCƒAƒEƒgs”
+	CLayoutInt				m_nLines;					// å…¨ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œæ•°
 
 	mutable CLayoutInt		m_nPrevReferLine;
 	mutable CLayout*		m_pLayoutPrevRefer;
 	
-	// EOFƒJ[ƒ\ƒ‹ˆÊ’u‚ğ‹L‰¯‚·‚é(_DoLayout/DoLayout_Range‚Å–³Œø‚É‚·‚é)	//2006.10.01 Moca
-	CLayoutInt				m_nEOFLine; //!< EOFs”
-	CLayoutInt				m_nEOFColumn; //!< EOF•ˆÊ’u
+	// EOFã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’è¨˜æ†¶ã™ã‚‹(_DoLayout/DoLayout_Rangeã§ç„¡åŠ¹ã«ã™ã‚‹)	//2006.10.01 Moca
+	CLayoutInt				m_nEOFLine; //!< EOFè¡Œæ•°
+	CLayoutInt				m_nEOFColumn; //!< EOFå¹…ä½ç½®
 
-	// ƒeƒLƒXƒgÅ‘å•‚ğ‹L‰¯iÜ‚è•Ô‚µˆÊ’uZo‚Ég—pj	// 2009.08.28 nasukoji
-	CLayoutInt				m_nTextWidth;				// ƒeƒLƒXƒgÅ‘å•‚Ì‹L‰¯
-	CLayoutInt				m_nTextWidthMaxLine;		// Å‘å•‚ÌƒŒƒCƒAƒEƒgs
+	// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’è¨˜æ†¶ï¼ˆæŠ˜ã‚Šè¿”ã—ä½ç½®ç®—å‡ºã«ä½¿ç”¨ï¼‰	// 2009.08.28 nasukoji
+	CLayoutInt				m_nTextWidth;				// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã®è¨˜æ†¶
+	CLayoutInt				m_nTextWidthMaxLine;		// æœ€å¤§å¹…ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(CLayoutMgr);

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "doc/CEditDoc.h" /// 2003/07/20 genta
 #include "doc/layout/CLayoutMgr.h"
 #include "doc/layout/CLayout.h"/// 2002/2/10 aroka
@@ -20,7 +20,7 @@ static bool _GetKeywordLength(
 	CLayoutInt*			p_nWordKetas	//!< [out]
 )
 {
-	//ƒL[ƒ[ƒh’·‚ğƒJƒEƒ“ƒg‚·‚é
+	//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰é•·ã‚’ã‚«ã‚¦ãƒ³ãƒˆã™ã‚‹
 	CLogicInt nWordBgn = nPos;
 	CLogicInt nWordLen = CLogicInt(0);
 	CLayoutInt nWordKetas = CLayoutInt(0);
@@ -32,7 +32,7 @@ static bool _GetKeywordLength(
 		nWordKetas+=k;
 		nPos++;
 	}
-	//Œ‹‰Ê
+	//çµæœ
 	if(nWordLen>0){
 		*p_nWordBgn = nWordBgn;
 		*p_nWordLen = nWordLen;
@@ -45,7 +45,7 @@ static bool _GetKeywordLength(
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      •”•iƒXƒe[ƒ^ƒX                         //
+//                      éƒ¨å“ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CLayout* CLayoutMgr::SLayoutWork::_CreateLayout(CLayoutMgr* mgr)
@@ -62,21 +62,21 @@ CLayout* CLayoutMgr::SLayoutWork::_CreateLayout(CLayoutMgr* mgr)
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           •”•i                              //
+//                           éƒ¨å“                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 bool CLayoutMgr::_DoKinsokuSkip(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
 	if( KINSOKU_TYPE_NONE != pWork->eKinsokuType )
 	{
-		//‹Ö‘¥ˆ—‚ÌÅŒã”ö‚É’B‚µ‚½‚ç‹Ö‘¥ˆ—’†‚ğ‰ğœ‚·‚é
+		//ç¦å‰‡å‡¦ç†ã®æœ€å¾Œå°¾ã«é”ã—ãŸã‚‰ç¦å‰‡å‡¦ç†ä¸­ã‚’è§£é™¤ã™ã‚‹
 		if( pWork->nPos >= pWork->nWordBgn + pWork->nWordLen )
 		{
 			if( pWork->eKinsokuType == KINSOKU_TYPE_KINSOKU_KUTO && pWork->nPos == pWork->nWordBgn + pWork->nWordLen )
 			{
 				int	nEol = pWork->pcDocLine->GetEol().GetLen();
 
-				if( ! (m_pTypeConfig->m_bKinsokuRet && (pWork->nPos == pWork->cLineStr.GetLength() - nEol) && nEol ) )	//‰üs•¶š‚ğ‚Ô‚ç‰º‚°‚é		//@@@ 2002.04.14 MIK
+				if( ! (m_pTypeConfig->m_bKinsokuRet && (pWork->nPos == pWork->cLineStr.GetLength() - nEol) && nEol ) )	//æ”¹è¡Œæ–‡å­—ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹		//@@@ 2002.04.14 MIK
 				{
 					(this->*pfOnLine)(pWork);
 				}
@@ -96,9 +96,9 @@ void CLayoutMgr::_DoWordWrap(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
 	if( pWork->eKinsokuType == KINSOKU_TYPE_NONE )
 	{
-		/* ‰p’PŒê‚Ìæ“ª‚© */
+		/* è‹±å˜èªã®å…ˆé ­ã‹ */
 		if( pWork->nPos >= pWork->nBgn && IS_KEYWORD_CHAR(pWork->cLineStr.At(pWork->nPos)) ){
-			// ƒL[ƒ[ƒh’·‚ğæ“¾
+			// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰é•·ã‚’å–å¾—
 			CLayoutInt nWordKetas = CLayoutInt(0);
 			_GetKeywordLength( *this,
 				pWork->cLineStr, pWork->nPos,
@@ -119,7 +119,7 @@ void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 {
 	if( (GetMaxLineLayout() - pWork->nPosX < 2) && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
-		// 2007.09.07 kobake   ƒŒƒCƒAƒEƒg‚ÆƒƒWƒbƒN‚Ì‹æ•Ê
+		// 2007.09.07 kobake   ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã¨ãƒ­ã‚¸ãƒƒã‚¯ã®åŒºåˆ¥
 		CLayoutInt nCharKetas = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
 
 		if( IsKinsokuPosKuto(GetMaxLineLayout() - pWork->nPosX, nCharKetas) && IsKinsokuKuto( pWork->cLineStr.At(pWork->nPos) ) )
@@ -133,19 +133,19 @@ void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 
 void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
-	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji ’Ç‰Á
+	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji è¿½åŠ 
 	 && (GetMaxLineLayout() - pWork->nPosX < 4)
-	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosX‚Ì‰ğß•ÏX‚Ì‚½‚ßCs“ªƒ`ƒFƒbƒN‚à•ÏX
+	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXã®è§£é‡ˆå¤‰æ›´ã®ãŸã‚ï¼Œè¡Œé ­ãƒã‚§ãƒƒã‚¯ã‚‚å¤‰æ›´
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
-		// 2007.09.07 kobake   ƒŒƒCƒAƒEƒg‚ÆƒƒWƒbƒN‚Ì‹æ•Ê
+		// 2007.09.07 kobake   ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã¨ãƒ­ã‚¸ãƒƒã‚¯ã®åŒºåˆ¥
 		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
 		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
 
 		if( IsKinsokuPosHead( GetMaxLineLayout() - pWork->nPosX, nCharKetas2, nCharKetas3 )
 		 && IsKinsokuHead( pWork->cLineStr.At(pWork->nPos+1) )
-		 && ! IsKinsokuHead( pWork->cLineStr.At(pWork->nPos) )	//1•¶š‘O‚ªs“ª‹Ö‘¥‚Å‚È‚¢
-		 && ! IsKinsokuKuto( pWork->cLineStr.At(pWork->nPos) ) )	//‹å“Ç“_‚Å‚È‚¢
+		 && ! IsKinsokuHead( pWork->cLineStr.At(pWork->nPos) )	//1æ–‡å­—å‰ãŒè¡Œé ­ç¦å‰‡ã§ãªã„
+		 && ! IsKinsokuKuto( pWork->cLineStr.At(pWork->nPos) ) )	//å¥èª­ç‚¹ã§ãªã„
 		{
 			pWork->nWordBgn = pWork->nPos;
 			pWork->nWordLen = 2;
@@ -158,11 +158,11 @@ void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 
 void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
-	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji ’Ç‰Á
+	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji è¿½åŠ 
 	 && (GetMaxLineKetas() - pWork->nPosX < 4)
-	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosX‚Ì‰ğß•ÏX‚Ì‚½‚ßCs“ªƒ`ƒFƒbƒN‚à•ÏX
+	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXã®è§£é‡ˆå¤‰æ›´ã®ãŸã‚ï¼Œè¡Œé ­ãƒã‚§ãƒƒã‚¯ã‚‚å¤‰æ›´
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
-	{	/* s––‹Ö‘¥‚·‚é && s––•t‹ß && s“ª‚Å‚È‚¢‚±‚Æ(–³ŒÀ‚É‹Ö‘¥‚µ‚Ä‚µ‚Ü‚¢‚»‚¤) */
+	{	/* è¡Œæœ«ç¦å‰‡ã™ã‚‹ && è¡Œæœ«ä»˜è¿‘ && è¡Œé ­ã§ãªã„ã“ã¨(ç„¡é™ã«ç¦å‰‡ã—ã¦ã—ã¾ã„ãã†) */
 		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
 		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
 
@@ -176,10 +176,10 @@ void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 	}
 }
 
-//Ü‚è•Ô‚·ê‡‚Ítrue‚ğ•Ô‚·
+//æŠ˜ã‚Šè¿”ã™å ´åˆã¯trueã‚’è¿”ã™
 bool CLayoutMgr::_DoTab(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
-	//	Sep. 23, 2002 genta ‚¹‚Á‚©‚­ì‚Á‚½‚Ì‚ÅŠÖ”‚ğg‚¤
+	//	Sep. 23, 2002 genta ã›ã£ã‹ãä½œã£ãŸã®ã§é–¢æ•°ã‚’ä½¿ã†
 	CLayoutInt nCharKetas = GetActualTabSpace( pWork->nPosX );
 	if( pWork->nPosX + nCharKetas > GetMaxLineLayout() ){
 		(this->*pfOnLine)(pWork);
@@ -192,12 +192,12 @@ bool CLayoutMgr::_DoTab(SLayoutWork* pWork, PF_OnLine pfOnLine)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          €ˆ—                             //
+//                          æº–å‡¦ç†                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
-	int	nEol = pWork->pcDocLine->GetEol().GetLen(); //########‚»‚Ì‚¤‚¿•s—v‚É‚È‚é
+	int	nEol = pWork->pcDocLine->GetEol().GetLen(); //########ãã®ã†ã¡ä¸è¦ã«ãªã‚‹
 	int nEol_1 = nEol - 1;
 	if( 0 >	nEol_1 ){
 		nEol_1 = 0;
@@ -207,29 +207,29 @@ void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 	if(pWork->pcColorStrategy)pWork->pcColorStrategy->InitStrategyStatus();
 	CColorStrategyPool& color = *CColorStrategyPool::getInstance();
 
-	//1ƒƒWƒbƒNs‚ğÁ‰»‚·‚é‚Ü‚Åƒ‹[ƒv
+	//1ãƒ­ã‚¸ãƒƒã‚¯è¡Œã‚’æ¶ˆåŒ–ã™ã‚‹ã¾ã§ãƒ«ãƒ¼ãƒ—
 	while( pWork->nPos < nLength ){
-		// ƒCƒ“ƒfƒ“ƒg•‚Í_OnLine‚ÅŒvZÏ‚İ‚È‚Ì‚Å‚±‚±‚©‚ç‚Ííœ
+		// ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…ã¯_OnLineã§è¨ˆç®—æ¸ˆã¿ãªã®ã§ã“ã“ã‹ã‚‰ã¯å‰Šé™¤
 
-		//‹Ö‘¥ˆ—’†‚È‚çƒXƒLƒbƒv‚·‚é	@@@ 2002.04.20 MIK
+		//ç¦å‰‡å‡¦ç†ä¸­ãªã‚‰ã‚¹ã‚­ãƒƒãƒ—ã™ã‚‹	@@@ 2002.04.20 MIK
 		if(_DoKinsokuSkip(pWork, pfOnLine)){ }
 		else{
-			// ‰p•¶ƒ[ƒhƒ‰ƒbƒv‚ğ‚·‚é
+			// è‹±æ–‡ãƒ¯ãƒ¼ãƒ‰ãƒ©ãƒƒãƒ—ã‚’ã™ã‚‹
 			if( m_pTypeConfig->m_bWordWrap ){
 				_DoWordWrap(pWork, pfOnLine);
 			}
 
-			// ‹å“Ç“_‚Ì‚Ô‚ç‚³‚°
+			// å¥èª­ç‚¹ã®ã¶ã‚‰ã•ã’
 			if( m_pTypeConfig->m_bKinsokuKuto ){
 				_DoKutoBurasage(pWork);
 			}
 
-			// s“ª‹Ö‘¥
+			// è¡Œé ­ç¦å‰‡
 			if( m_pTypeConfig->m_bKinsokuHead ){
 				_DoGyotoKinsoku(pWork, pfOnLine);
 			}
 
-			// s––‹Ö‘¥
+			// è¡Œæœ«ç¦å‰‡
 			if( m_pTypeConfig->m_bKinsokuTail ){
 				_DoGyomatsuKinsoku(pWork, pfOnLine);
 			}
@@ -247,16 +247,16 @@ void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 			if( pWork->nPos >= pWork->cLineStr.GetLength() ){
 				break;
 			}
-			// 2007.09.07 kobake   ƒƒWƒbƒN•‚ÆƒŒƒCƒAƒEƒg•‚ğ‹æ•Ê
+			// 2007.09.07 kobake   ãƒ­ã‚¸ãƒƒã‚¯å¹…ã¨ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå¹…ã‚’åŒºåˆ¥
 			CLayoutInt nCharKetas = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
-//			if( 0 == nCharKetas ){				// íœ ƒTƒƒQ[ƒgƒyƒA‘Îô	2008/7/5 Uchi
+//			if( 0 == nCharKetas ){				// å‰Šé™¤ ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢å¯¾ç­–	2008/7/5 Uchi
 //				nCharKetas = CLayoutInt(1);
 //			}
 
 			if( pWork->nPosX + nCharKetas > GetMaxLineLayout() ){
 				if( pWork->eKinsokuType != KINSOKU_TYPE_KINSOKU_KUTO )
 				{
-					if( ! (m_pTypeConfig->m_bKinsokuRet && (pWork->nPos == pWork->cLineStr.GetLength() - nEol) && nEol) )	//‰üs•¶š‚ğ‚Ô‚ç‰º‚°‚é		//@@@ 2002.04.14 MIK
+					if( ! (m_pTypeConfig->m_bKinsokuRet && (pWork->nPos == pWork->cLineStr.GetLength() - nEol) && nEol) )	//æ”¹è¡Œæ–‡å­—ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹		//@@@ 2002.04.14 MIK
 					{
 						(this->*pfOnLine)(pWork);
 						continue;
@@ -270,7 +270,7 @@ void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       –{ˆ—(‘S‘Ì)                          //
+//                       æœ¬å‡¦ç†(å…¨ä½“)                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void CLayoutMgr::_OnLine1(SLayoutWork* pWork)
@@ -280,29 +280,29 @@ void CLayoutMgr::_OnLine1(SLayoutWork* pWork)
 	pWork->colorPrev = pWork->pcColorStrategy->GetStrategyColorSafe();
 	pWork->exInfoPrev.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
 	pWork->nBgn = pWork->nPos;
-	// 2004.03.28 Moca pWork->nPosX‚ÍƒCƒ“ƒfƒ“ƒg•‚ğŠÜ‚Ş‚æ‚¤‚É•ÏX(TABˆÊ’u’²®‚Ì‚½‚ß)
+	// 2004.03.28 Moca pWork->nPosXã¯ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…ã‚’å«ã‚€ã‚ˆã†ã«å¤‰æ›´(TABä½ç½®èª¿æ•´ã®ãŸã‚)
 	pWork->nPosX = pWork->nIndent = (this->*m_getIndentOffset)( pWork->pLayout );
 }
 
 /*!
-	Œ»İ‚ÌÜ‚è•Ô‚µ•¶š”‚É‡‚í‚¹‚Ä‘Sƒf[ƒ^‚ÌƒŒƒCƒAƒEƒgî•ñ‚ğÄ¶¬‚µ‚Ü‚·
+	ç¾åœ¨ã®æŠ˜ã‚Šè¿”ã—æ–‡å­—æ•°ã«åˆã‚ã›ã¦å…¨ãƒ‡ãƒ¼ã‚¿ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã‚’å†ç”Ÿæˆã—ã¾ã™
 
-	@date 2004.04.03 Moca TAB‚ªg‚í‚ê‚é‚ÆÜ‚è•Ô‚µˆÊ’u‚ª‚¸‚ê‚é‚Ì‚ğ–h‚®‚½‚ßC
-		nPosX‚ªƒCƒ“ƒfƒ“ƒg‚ğŠÜ‚Ş•‚ğ•Û‚·‚é‚æ‚¤‚É•ÏXDm_nMaxLineKetas‚Í
-		ŒÅ’è’l‚Æ‚È‚Á‚½‚ªCŠù‘¶ƒR[ƒh‚Ì’u‚«Š·‚¦‚Í”ğ‚¯‚ÄÅ‰‚É’l‚ğ‘ã“ü‚·‚é‚æ‚¤‚É‚µ‚½D
+	@date 2004.04.03 Moca TABãŒä½¿ã‚ã‚Œã‚‹ã¨æŠ˜ã‚Šè¿”ã—ä½ç½®ãŒãšã‚Œã‚‹ã®ã‚’é˜²ããŸã‚ï¼Œ
+		nPosXãŒã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã‚’å«ã‚€å¹…ã‚’ä¿æŒã™ã‚‹ã‚ˆã†ã«å¤‰æ›´ï¼m_nMaxLineKetasã¯
+		å›ºå®šå€¤ã¨ãªã£ãŸãŒï¼Œæ—¢å­˜ã‚³ãƒ¼ãƒ‰ã®ç½®ãæ›ãˆã¯é¿ã‘ã¦æœ€åˆã«å€¤ã‚’ä»£å…¥ã™ã‚‹ã‚ˆã†ã«ã—ãŸï¼
 */
 void CLayoutMgr::_DoLayout(bool bBlockingHook)
 {
 	MY_RUNNINGTIMER( cRunningTimer, "CLayoutMgr::_DoLayout" );
 
-	/*	•\¦ã‚ÌXˆÊ’u
-		2004.03.28 Moca nPosX‚ÍƒCƒ“ƒfƒ“ƒg•‚ğŠÜ‚Ş‚æ‚¤‚É•ÏX(TABˆÊ’u’²®‚Ì‚½‚ß)
+	/*	è¡¨ç¤ºä¸Šã®Xä½ç½®
+		2004.03.28 Moca nPosXã¯ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…ã‚’å«ã‚€ã‚ˆã†ã«å¤‰æ›´(TABä½ç½®èª¿æ•´ã®ãŸã‚)
 	*/
 	int			nAllLineNum;
 
 	if( GetListenerCount() != 0 ){
 		NotifyProgress(0);
-		/* ˆ—’†‚Ìƒ†[ƒU[‘€ì‚ğ‰Â”\‚É‚·‚é */
+		/* å‡¦ç†ä¸­ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼æ“ä½œã‚’å¯èƒ½ã«ã™ã‚‹ */
 		if( bBlockingHook ){
 			if( !::BlockingHook( NULL ) )return;
 		}
@@ -312,9 +312,9 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 	Init();
 	
 	//	Nov. 16, 2002 genta
-	//	Ü‚è•Ô‚µ• <= TAB•‚Ì‚Æ‚«–³ŒÀƒ‹[ƒv‚·‚é‚Ì‚ğ”ğ‚¯‚é‚½‚ßC
-	//	TAB‚ªÜ‚è•Ô‚µ•ˆÈã‚Ì‚ÍTAB=4‚Æ‚µ‚Ä‚µ‚Ü‚¤
-	//	Ü‚è•Ô‚µ•‚ÌÅ¬’l=10‚È‚Ì‚Å‚±‚Ì’l‚Í–â‘è‚È‚¢
+	//	æŠ˜ã‚Šè¿”ã—å¹… <= TABå¹…ã®ã¨ãç„¡é™ãƒ«ãƒ¼ãƒ—ã™ã‚‹ã®ã‚’é¿ã‘ã‚‹ãŸã‚ï¼Œ
+	//	TABãŒæŠ˜ã‚Šè¿”ã—å¹…ä»¥ä¸Šã®æ™‚ã¯TAB=4ã¨ã—ã¦ã—ã¾ã†
+	//	æŠ˜ã‚Šè¿”ã—å¹…ã®æœ€å°å€¤=10ãªã®ã§ã“ã®å€¤ã¯å•é¡Œãªã„
 	if( GetTabSpaceKetas() >= GetMaxLineKetas() ){
 		m_nTabSpace = CKetaXInt(4);
 	}
@@ -323,7 +323,7 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 
 	SLayoutWork	_sWork;
 	SLayoutWork* pWork = &_sWork;
-	pWork->pcDocLine				= m_pcDocLineMgr->GetDocLineTop(); // 2002/2/10 aroka CDocLineMgr•ÏX
+	pWork->pcDocLine				= m_pcDocLineMgr->GetDocLineTop(); // 2002/2/10 aroka CDocLineMgrå¤‰æ›´
 	pWork->pLayout					= NULL;
 	pWork->pcColorStrategy			= NULL;
 	pWork->colorPrev				= COLORIDX_DEFAULT;
@@ -336,8 +336,8 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 		pWork->nPos			= CLogicInt(0);
 		pWork->nWordBgn		= CLogicInt(0);
 		pWork->nWordLen		= CLogicInt(0);
-		pWork->nPosX		= CLayoutInt(0);	// •\¦ã‚ÌXˆÊ’u
-		pWork->nIndent		= CLayoutInt(0);	// ƒCƒ“ƒfƒ“ƒg•
+		pWork->nPosX		= CLayoutInt(0);	// è¡¨ç¤ºä¸Šã®Xä½ç½®
+		pWork->nIndent		= CLayoutInt(0);	// ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…
 
 
 		_MakeOneLine(pWork, &CLayoutMgr::_OnLine1);
@@ -349,11 +349,11 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 			pWork->exInfoPrev.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
 		}
 
-		// Ÿ‚Ìs‚Ö
+		// æ¬¡ã®è¡Œã¸
 		pWork->nCurLine++;
 		pWork->pcDocLine = pWork->pcDocLine->GetNextLine();
 		
-		// ˆ—’†‚Ìƒ†[ƒU[‘€ì‚ğ‰Â”\‚É‚·‚é
+		// å‡¦ç†ä¸­ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼æ“ä½œã‚’å¯èƒ½ã«ã™ã‚‹
 		if( GetListenerCount()!=0 && 0 < nAllLineNum && 0 == ( pWork->nCurLine % 1024 ) ){
 			NotifyProgress(::MulDiv( pWork->nCurLine, 100 , nAllLineNum ) );
 			if( bBlockingHook ){
@@ -364,7 +364,7 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 // 2002/03/13 novice
 	}
 
-	// 2011.12.31 Bot‚ÌF•ª‚¯î•ñ‚ÍÅŒã‚Éİ’è
+	// 2011.12.31 Botã®è‰²åˆ†ã‘æƒ…å ±ã¯æœ€å¾Œã«è¨­å®š
 	m_nLineTypeBot = pWork->pcColorStrategy->GetStrategyColorSafe();
 	m_cLayoutExInfoBot.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
 
@@ -373,7 +373,7 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 
 	if( GetListenerCount()!=0 ){
 		NotifyProgress(0);
-		/* ˆ—’†‚Ìƒ†[ƒU[‘€ì‚ğ‰Â”\‚É‚·‚é */
+		/* å‡¦ç†ä¸­ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼æ“ä½œã‚’å¯èƒ½ã«ã™ã‚‹ */
 		if( bBlockingHook ){
 			if( !::BlockingHook( NULL ) )return;
 		}
@@ -383,17 +383,17 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     –{ˆ—(”ÍˆÍw’è)                        //
+//                     æœ¬å‡¦ç†(ç¯„å›²æŒ‡å®š)                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void CLayoutMgr::_OnLine2(SLayoutWork* pWork)
 {
-	//@@@ 2002.09.23 YAZAKI Å“K‰»
+	//@@@ 2002.09.23 YAZAKI æœ€é©åŒ–
 	if( pWork->bNeedChangeCOMMENTMODE ){
 		pWork->pLayout = pWork->pLayout->GetNextLayout();
 		pWork->pLayout->SetColorTypePrev(pWork->colorPrev);
 		pWork->pLayout->GetLayoutExInfo()->SetColorInfo(pWork->exInfoPrev.DetachColorInfo());
-		(*pWork->pnExtInsLineNum)++;								//	Ä•`‰æ‚µ‚Ä‚Ù‚µ‚¢s”+1
+		(*pWork->pnExtInsLineNum)++;								//	å†æç”»ã—ã¦ã»ã—ã„è¡Œæ•°+1
 	}
 	else {
 		pWork->pLayout = InsertLineNext( pWork->pLayout, pWork->_CreateLayout(this) );
@@ -402,7 +402,7 @@ void CLayoutMgr::_OnLine2(SLayoutWork* pWork)
 	pWork->exInfoPrev.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
 
 	pWork->nBgn = pWork->nPos;
-	// 2004.03.28 Moca pWork->nPosX‚ÍƒCƒ“ƒfƒ“ƒg•‚ğŠÜ‚Ş‚æ‚¤‚É•ÏX(TABˆÊ’u’²®‚Ì‚½‚ß)
+	// 2004.03.28 Moca pWork->nPosXã¯ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…ã‚’å«ã‚€ã‚ˆã†ã«å¤‰æ›´(TABä½ç½®èª¿æ•´ã®ãŸã‚)
 	pWork->nPosX = pWork->nIndent = (this->*m_getIndentOffset)( pWork->pLayout );
 	if( ( pWork->ptDelLogicalFrom.GetY2() == pWork->nCurLine && pWork->ptDelLogicalFrom.GetX2() < pWork->nPos ) ||
 		( pWork->ptDelLogicalFrom.GetY2() < pWork->nCurLine )
@@ -412,18 +412,18 @@ void CLayoutMgr::_OnLine2(SLayoutWork* pWork)
 }
 
 /*!
-	w’èƒŒƒCƒAƒEƒgs‚É‘Î‰‚·‚é˜_—s‚ÌŸ‚Ì˜_—s‚©‚çw’è˜_—s”‚¾‚¯ÄƒŒƒCƒAƒEƒg‚·‚é
+	æŒ‡å®šãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã«å¯¾å¿œã™ã‚‹è«–ç†è¡Œã®æ¬¡ã®è«–ç†è¡Œã‹ã‚‰æŒ‡å®šè«–ç†è¡Œæ•°ã ã‘å†ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã™ã‚‹
 	
 	@date 2002.10.07 YAZAKI rename from "DoLayout3_New"
-	@date 2004.04.03 Moca TAB‚ªg‚í‚ê‚é‚ÆÜ‚è•Ô‚µˆÊ’u‚ª‚¸‚ê‚é‚Ì‚ğ–h‚®‚½‚ßC
-		pWork->nPosX‚ªƒCƒ“ƒfƒ“ƒg‚ğŠÜ‚Ş•‚ğ•Û‚·‚é‚æ‚¤‚É•ÏXDm_nMaxLineKetas‚Í
-		ŒÅ’è’l‚Æ‚È‚Á‚½‚ªCŠù‘¶ƒR[ƒh‚Ì’u‚«Š·‚¦‚Í”ğ‚¯‚ÄÅ‰‚É’l‚ğ‘ã“ü‚·‚é‚æ‚¤‚É‚µ‚½D
-	@date 2009.08.28 nasukoji	ƒeƒLƒXƒgÅ‘å•‚ÌZo‚É‘Î‰
+	@date 2004.04.03 Moca TABãŒä½¿ã‚ã‚Œã‚‹ã¨æŠ˜ã‚Šè¿”ã—ä½ç½®ãŒãšã‚Œã‚‹ã®ã‚’é˜²ããŸã‚ï¼Œ
+		pWork->nPosXãŒã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã‚’å«ã‚€å¹…ã‚’ä¿æŒã™ã‚‹ã‚ˆã†ã«å¤‰æ›´ï¼m_nMaxLineKetasã¯
+		å›ºå®šå€¤ã¨ãªã£ãŸãŒï¼Œæ—¢å­˜ã‚³ãƒ¼ãƒ‰ã®ç½®ãæ›ãˆã¯é¿ã‘ã¦æœ€åˆã«å€¤ã‚’ä»£å…¥ã™ã‚‹ã‚ˆã†ã«ã—ãŸï¼
+	@date 2009.08.28 nasukoji	ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã®ç®—å‡ºã«å¯¾å¿œ
 
 	@note 2004.04.03 Moca
-		_DoLayout‚Æ‚Íˆá‚Á‚ÄƒŒƒCƒAƒEƒgî•ñ‚ªƒŠƒXƒg’†ŠÔ‚É‘}“ü‚³‚ê‚é‚½‚ßC
-		‘}“üŒã‚Ém_nLineTypeBot‚ÖƒRƒƒ“ƒgƒ‚[ƒh‚ğw’è‚µ‚Ä‚Í‚È‚ç‚È‚¢
-		‘ã‚í‚è‚ÉÅIs‚ÌƒRƒƒ“ƒgƒ‚[ƒh‚ğI—¹ŠÔÛ‚ÉŠm”F‚µ‚Ä‚¢‚éD
+		_DoLayoutã¨ã¯é•ã£ã¦ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ãŒãƒªã‚¹ãƒˆä¸­é–“ã«æŒ¿å…¥ã•ã‚Œã‚‹ãŸã‚ï¼Œ
+		æŒ¿å…¥å¾Œã«m_nLineTypeBotã¸ã‚³ãƒ¡ãƒ³ãƒˆãƒ¢ãƒ¼ãƒ‰ã‚’æŒ‡å®šã—ã¦ã¯ãªã‚‰ãªã„
+		ä»£ã‚ã‚Šã«æœ€çµ‚è¡Œã®ã‚³ãƒ¡ãƒ³ãƒˆãƒ¢ãƒ¼ãƒ‰ã‚’çµ‚äº†é–“éš›ã«ç¢ºèªã—ã¦ã„ã‚‹ï¼
 */
 CLayoutInt CLayoutMgr::DoLayout_Range(
 	CLayout*		pLayoutPrev,
@@ -439,8 +439,8 @@ CLayoutInt CLayoutMgr::DoLayout_Range(
 
 	CLogicInt	nLineNumWork = CLogicInt(0);
 
-	// 2006.12.01 Moca “r’†‚É‚Ü‚ÅÄ\’z‚µ‚½ê‡‚ÉEOFˆÊ’u‚ª‚¸‚ê‚½‚Ü‚Ü
-	//	XV‚³‚ê‚È‚¢‚Ì‚ÅC”ÍˆÍ‚É‚©‚©‚í‚ç‚¸•K‚¸ƒŠƒZƒbƒg‚·‚éD
+	// 2006.12.01 Moca é€”ä¸­ã«ã¾ã§å†æ§‹ç¯‰ã—ãŸå ´åˆã«EOFä½ç½®ãŒãšã‚ŒãŸã¾ã¾
+	//	æ›´æ–°ã•ã‚Œãªã„ã®ã§ï¼Œç¯„å›²ã«ã‹ã‹ã‚ã‚‰ãšå¿…ãšãƒªã‚»ãƒƒãƒˆã™ã‚‹ï¼
 	m_nEOFColumn = CLayoutInt(-1);
 	m_nEOFLine = CLayoutInt(-1);
 
@@ -458,7 +458,7 @@ CLayoutInt CLayoutMgr::DoLayout_Range(
 	}
 	pWork->pcDocLine				= m_pcDocLineMgr->GetLine( pWork->nCurLine );
 	pWork->nModifyLayoutLinesNew	= CLayoutInt(0);
-	//ˆø”
+	//å¼•æ•°
 	pWork->ptDelLogicalFrom		= _ptDelLogicalFrom;
 	pWork->pnExtInsLineNum		= _pnExtInsLineNum;
 
@@ -474,26 +474,26 @@ CLayoutInt CLayoutMgr::DoLayout_Range(
 		pWork->nPos			= CLogicInt(0);
 		pWork->nWordBgn		= CLogicInt(0);
 		pWork->nWordLen		= CLogicInt(0);
-		pWork->nPosX		= CLayoutInt(0);			// •\¦ã‚ÌXˆÊ’u
-		pWork->nIndent		= CLayoutInt(0);			// ƒCƒ“ƒfƒ“ƒg•
+		pWork->nPosX		= CLayoutInt(0);			// è¡¨ç¤ºä¸Šã®Xä½ç½®
+		pWork->nIndent		= CLayoutInt(0);			// ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…
 
 		_MakeOneLine(pWork, &CLayoutMgr::_OnLine2);
 
 		if( pWork->nPos - pWork->nBgn > 0 ){
 // 2002/03/13 novice
-			//@@@ 2002.09.23 YAZAKI Å“K‰»
+			//@@@ 2002.09.23 YAZAKI æœ€é©åŒ–
 			_OnLine2(pWork);
 		}
 
 		nLineNumWork++;
 		pWork->nCurLine++;
 
-		/* –Ú“I‚Ìs”(nLineNum)‚É’B‚µ‚½‚©A‚Ü‚½‚Í’Ê‚è‰ß‚¬‚½is”‚ª‘‚¦‚½j‚©Šm”F */
-		//@@@ 2002.09.23 YAZAKI Å“K‰»
+		/* ç›®çš„ã®è¡Œæ•°(nLineNum)ã«é”ã—ãŸã‹ã€ã¾ãŸã¯é€šã‚ŠéããŸï¼ˆï¼è¡Œæ•°ãŒå¢—ãˆãŸï¼‰ã‹ç¢ºèª */
+		//@@@ 2002.09.23 YAZAKI æœ€é©åŒ–
 		if( nLineNumWork >= nLineNum ){
 			if( pWork->pLayout && pWork->pLayout->GetNextLayout() ){
 				if( pWork->colorPrev != pWork->pLayout->GetNextLayout()->GetColorTypePrev() ){
-					//	COMMENTMODE‚ªˆÙ‚È‚és‚ª‘‚¦‚Ü‚µ‚½‚Ì‚ÅAŸ‚Ìs¨Ÿ‚Ìs‚ÆXV‚µ‚Ä‚¢‚«‚Ü‚·B
+					//	COMMENTMODEãŒç•°ãªã‚‹è¡ŒãŒå¢—ãˆã¾ã—ãŸã®ã§ã€æ¬¡ã®è¡Œâ†’æ¬¡ã®è¡Œã¨æ›´æ–°ã—ã¦ã„ãã¾ã™ã€‚
 					pWork->bNeedChangeCOMMENTMODE = true;
 				}else if( pWork->exInfoPrev.GetColorInfo() && pWork->pLayout->GetNextLayout()->GetColorInfo()
 				 && !pWork->exInfoPrev.GetColorInfo()->IsEqual(pWork->pLayout->GetNextLayout()->GetColorInfo()) ){
@@ -506,7 +506,7 @@ CLayoutInt CLayoutMgr::DoLayout_Range(
 					break;
 				}
 			}else{
-				break;	//	while( NULL != pWork->pcDocLine ) I—¹
+				break;	//	while( NULL != pWork->pcDocLine ) çµ‚äº†
 			}
 		}
 		pWork->pcDocLine = pWork->pcDocLine->GetNextLine();
@@ -514,16 +514,16 @@ CLayoutInt CLayoutMgr::DoLayout_Range(
 	}
 
 
-	// 2004.03.28 Moca EOF‚¾‚¯‚Ì˜_—s‚Ì’¼‘O‚Ìs‚ÌF•ª‚¯‚ªŠm”FEXV‚³‚ê‚½
+	// 2004.03.28 Moca EOFã ã‘ã®è«–ç†è¡Œã®ç›´å‰ã®è¡Œã®è‰²åˆ†ã‘ãŒç¢ºèªãƒ»æ›´æ–°ã•ã‚ŒãŸ
 	if( pWork->nCurLine == m_pcDocLineMgr->GetLineCount() ){
 		m_nLineTypeBot = pWork->pcColorStrategy->GetStrategyColorSafe();
 		m_cLayoutExInfoBot.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
 	}
 
-	// 2009.08.28 nasukoji	ƒeƒLƒXƒg‚ª•ÒW‚³‚ê‚½‚çÅ‘å•‚ğZo‚·‚é
+	// 2009.08.28 nasukoji	ãƒ†ã‚­ã‚¹ãƒˆãŒç·¨é›†ã•ã‚ŒãŸã‚‰æœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹
 	CalculateTextWidth_Range(pctwArg);
 
-// 1999.12.22 ƒŒƒCƒAƒEƒgî•ñ‚ª‚È‚­‚È‚é–ó‚Å‚Í‚È‚¢‚Ì‚Å
+// 1999.12.22 ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ãŒãªããªã‚‹è¨³ã§ã¯ãªã„ã®ã§
 //	m_nPrevReferLine = 0;
 //	m_pLayoutPrevRefer = NULL;
 //	m_pLayoutCurrent = NULL;
@@ -532,60 +532,60 @@ CLayoutInt CLayoutMgr::DoLayout_Range(
 }
 
 /*!
-	@brief ƒeƒLƒXƒg‚ª•ÒW‚³‚ê‚½‚çÅ‘å•‚ğZo‚·‚é
+	@brief ãƒ†ã‚­ã‚¹ãƒˆãŒç·¨é›†ã•ã‚ŒãŸã‚‰æœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹
 
-	@param[in] pctwArg ƒeƒLƒXƒgÅ‘å•Zo—p\‘¢‘Ì
+	@param[in] pctwArg ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ç®—å‡ºç”¨æ§‹é€ ä½“
 
-	@note uÜ‚è•Ô‚³‚È‚¢v‘I‘ğ‚Ì‚İƒeƒLƒXƒgÅ‘å•‚ğZo‚·‚éD
-	      •ÒW‚³‚ê‚½s‚Ì”ÍˆÍ‚É‚Â‚¢‚ÄZo‚·‚éi‰º‹L‚ğ–‚½‚·ê‡‚Í‘Ssj
-	      @íœs‚È‚µFÅ‘å•‚Ìs‚ğs“ªˆÈŠO‚É‚Ä‰üs•t‚«‚Å•ÒW‚µ‚½
-	      @íœs‚ ‚èFÅ‘å•‚Ìs‚ğŠÜ‚ñ‚Å•ÒW‚µ‚½
-	      pctwArg->nDelLines ‚ª•‰”‚Ì‚Ííœs‚È‚µD
+	@note ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€é¸æŠæ™‚ã®ã¿ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹ï¼
+	      ç·¨é›†ã•ã‚ŒãŸè¡Œã®ç¯„å›²ã«ã¤ã„ã¦ç®—å‡ºã™ã‚‹ï¼ˆä¸‹è¨˜ã‚’æº€ãŸã™å ´åˆã¯å…¨è¡Œï¼‰
+	      ã€€å‰Šé™¤è¡Œãªã—æ™‚ï¼šæœ€å¤§å¹…ã®è¡Œã‚’è¡Œé ­ä»¥å¤–ã«ã¦æ”¹è¡Œä»˜ãã§ç·¨é›†ã—ãŸ
+	      ã€€å‰Šé™¤è¡Œã‚ã‚Šæ™‚ï¼šæœ€å¤§å¹…ã®è¡Œã‚’å«ã‚“ã§ç·¨é›†ã—ãŸ
+	      pctwArg->nDelLines ãŒè² æ•°ã®æ™‚ã¯å‰Šé™¤è¡Œãªã—ï¼
 
-	@date 2009.08.28 nasukoji	V‹Kì¬
+	@date 2009.08.28 nasukoji	æ–°è¦ä½œæˆ
 */
 void CLayoutMgr::CalculateTextWidth_Range( const CalTextWidthArg* pctwArg )
 {
-	if( m_pcEditDoc->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP ){	// uÜ‚è•Ô‚³‚È‚¢v
-		CLayoutInt	nCalTextWidthLinesFrom(0);	// ƒeƒLƒXƒgÅ‘å•‚ÌZoŠJnƒŒƒCƒAƒEƒgs
-		CLayoutInt	nCalTextWidthLinesTo(0);	// ƒeƒLƒXƒgÅ‘å•‚ÌZoI—¹ƒŒƒCƒAƒEƒgs
-		BOOL bCalTextWidth        = TRUE;		// ƒeƒLƒXƒgÅ‘å•‚ÌZo—v‹‚ğON
-		CLayoutInt nInsLineNum    = m_nLines - pctwArg->nAllLinesOld;		// ’Ç‰Áíœs”
+	if( m_pcEditDoc->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP ){	// ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€
+		CLayoutInt	nCalTextWidthLinesFrom(0);	// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã®ç®—å‡ºé–‹å§‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
+		CLayoutInt	nCalTextWidthLinesTo(0);	// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã®ç®—å‡ºçµ‚äº†ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
+		BOOL bCalTextWidth        = TRUE;		// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã®ç®—å‡ºè¦æ±‚ã‚’ON
+		CLayoutInt nInsLineNum    = m_nLines - pctwArg->nAllLinesOld;		// è¿½åŠ å‰Šé™¤è¡Œæ•°
 
-		// íœs‚È‚µFÅ‘å•‚Ìs‚ğs“ªˆÈŠO‚É‚Ä‰üs•t‚«‚Å•ÒW‚µ‚½
-		// íœs‚ ‚èFÅ‘å•‚Ìs‚ğŠÜ‚ñ‚Å•ÒW‚µ‚½
+		// å‰Šé™¤è¡Œãªã—æ™‚ï¼šæœ€å¤§å¹…ã®è¡Œã‚’è¡Œé ­ä»¥å¤–ã«ã¦æ”¹è¡Œä»˜ãã§ç·¨é›†ã—ãŸ
+		// å‰Šé™¤è¡Œã‚ã‚Šæ™‚ï¼šæœ€å¤§å¹…ã®è¡Œã‚’å«ã‚“ã§ç·¨é›†ã—ãŸ
 
 		if(( pctwArg->nDelLines < CLayoutInt(0)  && Int(m_nTextWidth) &&
 		     Int(nInsLineNum) && Int(pctwArg->ptLayout.x) && m_nTextWidthMaxLine == pctwArg->ptLayout.y )||
 		   ( pctwArg->nDelLines >= CLayoutInt(0) && Int(m_nTextWidth) &&
 		     pctwArg->ptLayout.y <= m_nTextWidthMaxLine && m_nTextWidthMaxLine <= pctwArg->ptLayout.y + pctwArg->nDelLines ))
 		{
-			// ‘Sƒ‰ƒCƒ“‚ğ‘–¸‚·‚é
+			// å…¨ãƒ©ã‚¤ãƒ³ã‚’èµ°æŸ»ã™ã‚‹
 			nCalTextWidthLinesFrom = -1;
 			nCalTextWidthLinesTo   = -1;
-		}else if( Int(nInsLineNum) || Int(pctwArg->bInsData) ){		// ’Ç‰Áíœs ‚Ü‚½‚Í ’Ç‰Á•¶š—ñ‚ ‚è
-			// ’Ç‰Áíœs‚Ì‚İ‚ğ‘–¸‚·‚é
+		}else if( Int(nInsLineNum) || Int(pctwArg->bInsData) ){		// è¿½åŠ å‰Šé™¤è¡Œ ã¾ãŸã¯ è¿½åŠ æ–‡å­—åˆ—ã‚ã‚Š
+			// è¿½åŠ å‰Šé™¤è¡Œã®ã¿ã‚’èµ°æŸ»ã™ã‚‹
 			nCalTextWidthLinesFrom = pctwArg->ptLayout.y;
 
-			// ÅI“I‚É•ÒW‚³‚ê‚½s”i3síœ2s’Ç‰Á‚È‚ç2s’Ç‰Áj
-			// @1s‚ªMAXLINEKETAS‚ğ’´‚¦‚éê‡s”‚ª‡‚í‚È‚­‚È‚é‚ªA’´‚¦‚éê‡‚Í‚»‚Ìæ‚ÌŒvZ©‘Ì‚ª
-			// @•s—v‚È‚Ì‚ÅŒvZ‚ğÈ‚­‚½‚ß‚±‚Ì‚Ü‚Ü‚Æ‚·‚éB
+			// æœ€çµ‚çš„ã«ç·¨é›†ã•ã‚ŒãŸè¡Œæ•°ï¼ˆ3è¡Œå‰Šé™¤2è¡Œè¿½åŠ ãªã‚‰2è¡Œè¿½åŠ ï¼‰
+			// ã€€1è¡ŒãŒMAXLINEKETASã‚’è¶…ãˆã‚‹å ´åˆè¡Œæ•°ãŒåˆã‚ãªããªã‚‹ãŒã€è¶…ãˆã‚‹å ´åˆã¯ãã®å…ˆã®è¨ˆç®—è‡ªä½“ãŒ
+			// ã€€ä¸è¦ãªã®ã§è¨ˆç®—ã‚’çœããŸã‚ã“ã®ã¾ã¾ã¨ã™ã‚‹ã€‚
 			CLayoutInt nEditLines = nInsLineNum + ((pctwArg->nDelLines > 0) ? pctwArg->nDelLines : CLayoutInt(0));
 			nCalTextWidthLinesTo   = pctwArg->ptLayout.y + ((nEditLines > 0) ? nEditLines : CLayoutInt(0));
 
-			// Å‘å•‚Ìs‚ªã‰º‚·‚é‚Ì‚ğŒvZ
+			// æœ€å¤§å¹…ã®è¡ŒãŒä¸Šä¸‹ã™ã‚‹ã®ã‚’è¨ˆç®—
 			if( Int(m_nTextWidth) && Int(nInsLineNum) && m_nTextWidthMaxLine >= pctwArg->ptLayout.y )
 				m_nTextWidthMaxLine += nInsLineNum;
 		}else{
-			// Å‘å•ˆÈŠO‚Ìs‚ğ‰üs‚ğŠÜ‚Ü‚¸‚Éi1s“à‚Åj•ÒW‚µ‚½
-			bCalTextWidth = FALSE;		// ƒeƒLƒXƒgÅ‘å•‚ÌZo—v‹‚ğOFF
+			// æœ€å¤§å¹…ä»¥å¤–ã®è¡Œã‚’æ”¹è¡Œã‚’å«ã¾ãšã«ï¼ˆ1è¡Œå†…ã§ï¼‰ç·¨é›†ã—ãŸ
+			bCalTextWidth = FALSE;		// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã®ç®—å‡ºè¦æ±‚ã‚’OFF
 		}
 
 #if defined( _DEBUG ) && defined( _UNICODE )
 		static int testcount = 0;
 		testcount++;
 
-		// ƒeƒLƒXƒgÅ‘å•‚ğZo‚·‚é
+		// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹
 		if( bCalTextWidth ){
 //			MYTRACE_W( L"CLayoutMgr::DoLayout_Range(%d) nCalTextWidthLinesFrom=%d nCalTextWidthLinesTo=%d\n", testcount, nCalTextWidthLinesFrom, nCalTextWidthLinesTo );
 			CalculateTextWidth( FALSE, nCalTextWidthLinesFrom, nCalTextWidthLinesTo );
@@ -594,7 +594,7 @@ void CLayoutMgr::CalculateTextWidth_Range( const CalTextWidthArg* pctwArg )
 //			MYTRACE_W( L"CLayoutMgr::DoLayout_Range(%d) FALSE\n", testcount );
 		}
 #else
-		// ƒeƒLƒXƒgÅ‘å•‚ğZo‚·‚é
+		// ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹
 		if( bCalTextWidth )
 			CalculateTextWidth( FALSE, nCalTextWidthLinesFrom, nCalTextWidthLinesTo );
 #endif

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒeƒLƒXƒg‚ÌƒŒƒCƒAƒEƒgî•ñŠÇ—
+ï»¿/*!	@file
+	@brief ãƒ†ã‚­ã‚¹ãƒˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ç®¡ç†
 
 	@author Norio Nakatani
 */
@@ -28,12 +28,12 @@
 
 
 /*!
-	s“ª‹Ö‘¥•¶š‚ÉŠY“–‚·‚é‚©‚ğ’²‚×‚éD
+	è¡Œé ­ç¦å‰‡æ–‡å­—ã«è©²å½“ã™ã‚‹ã‹ã‚’èª¿ã¹ã‚‹ï¼
 
-	@param[in] pLine ’²‚×‚é•¶š‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	@param[in] length “–ŠY‰ÓŠ‚Ì•¶šƒTƒCƒY
-	@retval true ‹Ö‘¥•¶š‚ÉŠY“–
-	@retval false ‹Ö‘¥•¶š‚ÉŠY“–‚µ‚È‚¢
+	@param[in] pLine èª¿ã¹ã‚‹æ–‡å­—ã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	@param[in] length å½“è©²ç®‡æ‰€ã®æ–‡å­—ã‚µã‚¤ã‚º
+	@retval true ç¦å‰‡æ–‡å­—ã«è©²å½“
+	@retval false ç¦å‰‡æ–‡å­—ã«è©²å½“ã—ãªã„
 */
 bool CLayoutMgr::IsKinsokuHead( wchar_t wc )
 {
@@ -41,12 +41,12 @@ bool CLayoutMgr::IsKinsokuHead( wchar_t wc )
 }
 
 /*!
-	s––‹Ö‘¥•¶š‚ÉŠY“–‚·‚é‚©‚ğ’²‚×‚éD
+	è¡Œæœ«ç¦å‰‡æ–‡å­—ã«è©²å½“ã™ã‚‹ã‹ã‚’èª¿ã¹ã‚‹ï¼
 
-	@param[in] pLine ’²‚×‚é•¶š‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	@param[in] length “–ŠY‰ÓŠ‚Ì•¶šƒTƒCƒY
-	@retval true ‹Ö‘¥•¶š‚ÉŠY“–
-	@retval false ‹Ö‘¥•¶š‚ÉŠY“–‚µ‚È‚¢
+	@param[in] pLine èª¿ã¹ã‚‹æ–‡å­—ã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	@param[in] length å½“è©²ç®‡æ‰€ã®æ–‡å­—ã‚µã‚¤ã‚º
+	@retval true ç¦å‰‡æ–‡å­—ã«è©²å½“
+	@retval false ç¦å‰‡æ–‡å­—ã«è©²å½“ã—ãªã„
 */
 bool CLayoutMgr::IsKinsokuTail( wchar_t wc )
 {
@@ -55,12 +55,12 @@ bool CLayoutMgr::IsKinsokuTail( wchar_t wc )
 
 
 /*!
-	‹Ö‘¥‘ÎÛ‹å“Ç“_‚ÉŠY“–‚·‚é‚©‚ğ’²‚×‚éD
+	ç¦å‰‡å¯¾è±¡å¥èª­ç‚¹ã«è©²å½“ã™ã‚‹ã‹ã‚’èª¿ã¹ã‚‹ï¼
 
-	@param [in] pLine  ’²‚×‚é•¶š‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	@param [in] length “–ŠY‰ÓŠ‚Ì•¶šƒTƒCƒY
-	@retval true ‹Ö‘¥•¶š‚ÉŠY“–
-	@retval false ‹Ö‘¥•¶š‚ÉŠY“–‚µ‚È‚¢
+	@param [in] pLine  èª¿ã¹ã‚‹æ–‡å­—ã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	@param [in] length å½“è©²ç®‡æ‰€ã®æ–‡å­—ã‚µã‚¤ã‚º
+	@retval true ç¦å‰‡æ–‡å­—ã«è©²å½“
+	@retval false ç¦å‰‡æ–‡å­—ã«è©²å½“ã—ãªã„
 */
 bool CLayoutMgr::IsKinsokuKuto( wchar_t wc )
 {
@@ -68,31 +68,31 @@ bool CLayoutMgr::IsKinsokuKuto( wchar_t wc )
 }
 
 /*!
-	@date 2005-08-20 D.S.Koba _DoLayout()‚ÆDoLayout_Range()‚©‚ç•ª—£
+	@date 2005-08-20 D.S.Koba _DoLayout()ã¨DoLayout_Range()ã‹ã‚‰åˆ†é›¢
 */
 bool CLayoutMgr::IsKinsokuPosHead(
-	CLayoutInt nRest,		//!< [in] s‚Ìc‚è•¶š”
-	CLayoutInt nCharKetas,	//!< [in] Œ»İˆÊ’u‚Ì•¶šƒTƒCƒY
-	CLayoutInt nCharKetas2	//!< [in] Œ»İˆÊ’u‚ÌŸ‚Ì•¶šƒTƒCƒY
+	CLayoutInt nRest,		//!< [in] è¡Œã®æ®‹ã‚Šæ–‡å­—æ•°
+	CLayoutInt nCharKetas,	//!< [in] ç¾åœ¨ä½ç½®ã®æ–‡å­—ã‚µã‚¤ã‚º
+	CLayoutInt nCharKetas2	//!< [in] ç¾åœ¨ä½ç½®ã®æ¬¡ã®æ–‡å­—ã‚µã‚¤ã‚º
 )
 {
 	switch( (Int)nRest )
 	{
-	//    321012  «ƒ}ƒWƒbƒNƒiƒ“ƒo[
-	// 3 "‚éj" : 22 "j"‚Ì2ƒoƒCƒg–Ú‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
-	// 2  "Zj" : 12 "j"‚Ì2ƒoƒCƒg–Ú‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
-	// 2  "‚éj": 22 "j"‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
-	// 2  "‚é)" : 21 ")"‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
-	// 1   "Zj": 12 "j"‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
-	// 1   "Z)" : 11 ")"‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
-	//ª‰½•¶š‘O‚©H
-	// ¦‚½‚¾‚µA"‚éZ"•”•ª‚ª‹Ö‘¥‚È‚çˆ—‚µ‚È‚¢B
-	case 3:	// 3•¶š‘O
+	//    321012  â†“ãƒã‚¸ãƒƒã‚¯ãƒŠãƒ³ãƒãƒ¼
+	// 3 "ã‚‹ï¼‰" : 22 "ï¼‰"ã®2ãƒã‚¤ãƒˆç›®ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
+	// 2  "Zï¼‰" : 12 "ï¼‰"ã®2ãƒã‚¤ãƒˆç›®ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
+	// 2  "ã‚‹ï¼‰": 22 "ï¼‰"ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
+	// 2  "ã‚‹)" : 21 ")"ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
+	// 1   "Zï¼‰": 12 "ï¼‰"ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
+	// 1   "Z)" : 11 ")"ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
+	//â†‘ä½•æ–‡å­—å‰ã‹ï¼Ÿ
+	// â€»ãŸã ã—ã€"ã‚‹Z"éƒ¨åˆ†ãŒç¦å‰‡ãªã‚‰å‡¦ç†ã—ãªã„ã€‚
+	case 3:	// 3æ–‡å­—å‰
 		if( nCharKetas == 2 && nCharKetas2 == 2 ){
 			return true;
 		}
 		break;
-	case 2:	// 2•¶š‘O
+	case 2:	// 2æ–‡å­—å‰
 		if( nCharKetas == 2 ){
 			return true;
 		}
@@ -100,7 +100,7 @@ bool CLayoutMgr::IsKinsokuPosHead(
 			return true;
 		}
 		break;
-	case 1:	// 1•¶š‘O
+	case 1:	// 1æ–‡å­—å‰
 		if( nCharKetas == 1 ){
 			return true;
 		}
@@ -110,35 +110,35 @@ bool CLayoutMgr::IsKinsokuPosHead(
 }
 
 /*!
-	@date 2005-08-20 D.S.Koba _DoLayout()‚ÆDoLayout_Range()‚©‚ç•ª—£
+	@date 2005-08-20 D.S.Koba _DoLayout()ã¨DoLayout_Range()ã‹ã‚‰åˆ†é›¢
 */
 bool CLayoutMgr::IsKinsokuPosTail(
-	CLayoutInt nRest,		//!< [in] s‚Ìc‚è•¶š”
-	CLayoutInt nCharKetas,	//!< [in] Œ»İˆÊ’u‚Ì•¶šƒTƒCƒY
-	CLayoutInt nCharKetas2	//!< [in] Œ»İˆÊ’u‚ÌŸ‚Ì•¶šƒTƒCƒY
+	CLayoutInt nRest,		//!< [in] è¡Œã®æ®‹ã‚Šæ–‡å­—æ•°
+	CLayoutInt nCharKetas,	//!< [in] ç¾åœ¨ä½ç½®ã®æ–‡å­—ã‚µã‚¤ã‚º
+	CLayoutInt nCharKetas2	//!< [in] ç¾åœ¨ä½ç½®ã®æ¬¡ã®æ–‡å­—ã‚µã‚¤ã‚º
 )
 {
 	switch( (Int)nRest )
 	{
-	case 3:	// 3•¶š‘O
+	case 3:	// 3æ–‡å­—å‰
 		if( nCharKetas == 2 && nCharKetas2 == 2){
-			// "i‚ ": "‚ "‚Ì2ƒoƒCƒg–Ú‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
+			// "ï¼ˆã‚": "ã‚"ã®2ãƒã‚¤ãƒˆç›®ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
 			return true;
 		}
 		break;
-	case 2:	// 2•¶š‘O
+	case 2:	// 2æ–‡å­—å‰
 		if( nCharKetas == 2 ){
-			// "i‚ ": "‚ "‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
+			// "ï¼ˆã‚": "ã‚"ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
 			return true;
 		}
 		else if( nCharKetas == 1 && nCharKetas2 == 2){
-			// "(‚ ": "‚ "‚Ì2ƒoƒCƒg–Ú‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
+			// "(ã‚": "ã‚"ã®2ãƒã‚¤ãƒˆç›®ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
 			return true;
 		}
 		break;
-	case 1:	// 1•¶š‘O
+	case 1:	// 1æ–‡å­—å‰
 		if( nCharKetas == 1 ){
-			// "(‚ ": "‚ "‚ÅÜ‚è•Ô‚µ‚Ì‚Æ‚«
+			// "(ã‚": "ã‚"ã§æŠ˜ã‚Šè¿”ã—ã®ã¨ã
 			return true;
 		}
 		break;
@@ -148,12 +148,12 @@ bool CLayoutMgr::IsKinsokuPosTail(
 
 
 /*!
-	@brief s‚Ì’·‚³‚ğŒvZ‚·‚é (2s–ÚˆÈ~‚Ìš‰º‚°–³‚µ)
+	@brief è¡Œã®é•·ã•ã‚’è¨ˆç®—ã™ã‚‹ (2è¡Œç›®ä»¥é™ã®å­—ä¸‹ã’ç„¡ã—)
 	
-	š‰º‚°‚ğs‚í‚È‚¢‚Ì‚ÅCí‚É0‚ğ•Ô‚·D
-	ˆø”‚Íg‚í‚È‚¢D
+	å­—ä¸‹ã’ã‚’è¡Œã‚ãªã„ã®ã§ï¼Œå¸¸ã«0ã‚’è¿”ã™ï¼
+	å¼•æ•°ã¯ä½¿ã‚ãªã„ï¼
 	
-	@return 1s‚Ì•\¦•¶š” (í‚É0)
+	@return 1è¡Œã®è¡¨ç¤ºæ–‡å­—æ•° (å¸¸ã«0)
 	
 	@author genta
 	@date 2002.10.01
@@ -164,25 +164,25 @@ CLayoutInt CLayoutMgr::getIndentOffset_Normal( CLayout* )
 }
 
 /*!
-	@brief ƒCƒ“ƒfƒ“ƒg•‚ğŒvZ‚·‚é (Tx2x)
+	@brief ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…ã‚’è¨ˆç®—ã™ã‚‹ (Tx2x)
 	
-	‘O‚Ìs‚ÌÅŒã‚ÌTAB‚ÌˆÊ’u‚ğƒCƒ“ƒfƒ“ƒgˆÊ’u‚Æ‚µ‚Ä•Ô‚·D
-	‚½‚¾‚µCc‚è•‚ª6•¶š–¢–‚Ìê‡‚ÍƒCƒ“ƒfƒ“ƒg‚ğs‚í‚È‚¢D
+	å‰ã®è¡Œã®æœ€å¾Œã®TABã®ä½ç½®ã‚’ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆä½ç½®ã¨ã—ã¦è¿”ã™ï¼
+	ãŸã ã—ï¼Œæ®‹ã‚Šå¹…ãŒ6æ–‡å­—æœªæº€ã®å ´åˆã¯ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã‚’è¡Œã‚ãªã„ï¼
 	
 	@author Yazaki
-	@return ƒCƒ“ƒfƒ“ƒg‚·‚×‚«•¶š”
+	@return ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã™ã¹ãæ–‡å­—æ•°
 	
 	@date 2002.10.01 
-	@date 2002.10.07 YAZAKI –¼Ì•ÏX, ˆ—Œ©’¼‚µ
+	@date 2002.10.07 YAZAKI åç§°å¤‰æ›´, å‡¦ç†è¦‹ç›´ã—
 */
 CLayoutInt CLayoutMgr::getIndentOffset_Tx2x( CLayout* pLayoutPrev )
 {
-	//	‘O‚Ìs‚ª–³‚¢‚Æ‚«‚ÍAƒCƒ“ƒfƒ“ƒg•s—vB
+	//	å‰ã®è¡ŒãŒç„¡ã„ã¨ãã¯ã€ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆä¸è¦ã€‚
 	if ( pLayoutPrev == NULL ) return CLayoutInt(0);
 
 	CLayoutInt nIpos = pLayoutPrev->GetIndent();
 
-	//	‘O‚Ìs‚ªÜ‚è•Ô‚µs‚È‚ç‚Î‚»‚ê‚É‡‚í‚¹‚é
+	//	å‰ã®è¡ŒãŒæŠ˜ã‚Šè¿”ã—è¡Œãªã‚‰ã°ãã‚Œã«åˆã‚ã›ã‚‹
 	if( pLayoutPrev->GetLogicOffset() > 0 )
 		return nIpos;
 	
@@ -194,123 +194,123 @@ CLayoutInt CLayoutMgr::getIndentOffset_Tx2x( CLayout* pLayoutPrev )
 		}
 		it.addDelta();
 	}
-	// 2010.07.06 Moca TAB=8‚È‚Ç‚Ìê‡‚ÉÜ‚è•Ô‚·‚Æ–³ŒÀƒ‹[ƒv‚·‚é•s‹ï‡‚ÌC³. 6ŒÅ’è‚ğ m_nTabSpace + 2‚É•ÏX
+	// 2010.07.06 Moca TAB=8ãªã©ã®å ´åˆã«æŠ˜ã‚Šè¿”ã™ã¨ç„¡é™ãƒ«ãƒ¼ãƒ—ã™ã‚‹ä¸å…·åˆã®ä¿®æ­£. 6å›ºå®šã‚’ m_nTabSpace + 2ã«å¤‰æ›´
 	if ( GetMaxLineLayout() - nIpos < GetTabSpace() + (2 * m_nCharLayoutXPerKeta) ){
-		nIpos = t_max(CLayoutInt(0), GetMaxLineLayout() - (GetTabSpace() + (2 * m_nCharLayoutXPerKeta))); // 2013.05.12 Chg:0‚¾‚Á‚½‚Ì‚ğÅ‘å•‚É•ÏX
+		nIpos = t_max(CLayoutInt(0), GetMaxLineLayout() - (GetTabSpace() + (2 * m_nCharLayoutXPerKeta))); // 2013.05.12 Chg:0ã ã£ãŸã®ã‚’æœ€å¤§å¹…ã«å¤‰æ›´
 	}
-	return nIpos;	//	ƒCƒ“ƒfƒ“ƒg
+	return nIpos;	//	ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
 }
 
 /*!
-	@brief ƒCƒ“ƒfƒ“ƒg•‚ğŒvZ‚·‚é (ƒXƒy[ƒXš‰º‚°”Å)
+	@brief ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¹…ã‚’è¨ˆç®—ã™ã‚‹ (ã‚¹ãƒšãƒ¼ã‚¹å­—ä¸‹ã’ç‰ˆ)
 	
-	˜_—ss“ª‚ÌƒzƒƒCƒgƒXƒy[ƒX‚ÌI‚í‚èƒCƒ“ƒfƒ“ƒgˆÊ’u‚Æ‚µ‚Ä•Ô‚·D
-	‚½‚¾‚µCc‚è•‚ª6•¶š–¢–‚Ìê‡‚ÍƒCƒ“ƒfƒ“ƒg‚ğs‚í‚È‚¢D
+	è«–ç†è¡Œè¡Œé ­ã®ãƒ›ãƒ¯ã‚¤ãƒˆã‚¹ãƒšãƒ¼ã‚¹ã®çµ‚ã‚ã‚Šã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆä½ç½®ã¨ã—ã¦è¿”ã™ï¼
+	ãŸã ã—ï¼Œæ®‹ã‚Šå¹…ãŒ6æ–‡å­—æœªæº€ã®å ´åˆã¯ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã‚’è¡Œã‚ãªã„ï¼
 	
 	@author genta
-	@return ƒCƒ“ƒfƒ“ƒg‚·‚×‚«•¶š”
+	@return ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã™ã¹ãæ–‡å­—æ•°
 	
 	@date 2002.10.01 
 */
 CLayoutInt CLayoutMgr::getIndentOffset_LeftSpace( CLayout* pLayoutPrev )
 {
-	//	‘O‚Ìs‚ª–³‚¢‚Æ‚«‚ÍAƒCƒ“ƒfƒ“ƒg•s—vB
+	//	å‰ã®è¡ŒãŒç„¡ã„ã¨ãã¯ã€ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆä¸è¦ã€‚
 	if ( pLayoutPrev == NULL ) return CLayoutInt(0);
 
-	//	ƒCƒ“ƒfƒ“ƒg‚ÌŒvZ
+	//	ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã®è¨ˆç®—
 	CLayoutInt nIpos = pLayoutPrev->GetIndent();
 	
 	//	Oct. 5, 2002 genta
-	//	Ü‚è•Ô‚µ‚Ì3s–ÚˆÈ~‚Í1‚Â‘O‚Ìs‚ÌƒCƒ“ƒfƒ“ƒg‚É‡‚í‚¹‚éD
+	//	æŠ˜ã‚Šè¿”ã—ã®3è¡Œç›®ä»¥é™ã¯1ã¤å‰ã®è¡Œã®ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã«åˆã‚ã›ã‚‹ï¼
 	if( pLayoutPrev->GetLogicOffset() > 0 )
 		return nIpos;
 	
-	//	2002.10.07 YAZAKI ƒCƒ“ƒfƒ“ƒg‚ÌŒvZ
+	//	2002.10.07 YAZAKI ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã®è¨ˆç®—
 	CMemoryIterator it = CreateCMemoryIterator(pLayoutPrev);
 
-	//	Jul. 20, 2003 genta ©“®ƒCƒ“ƒfƒ“ƒg‚É€‚¶‚½“®ì‚É‚·‚é
+	//	Jul. 20, 2003 genta è‡ªå‹•ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã«æº–ã˜ãŸå‹•ä½œã«ã™ã‚‹
 	bool bZenSpace = m_pTypeConfig->m_bAutoIndent_ZENSPACE;
 	const wchar_t* szSpecialIndentChar = m_pTypeConfig->m_szIndentChars;
 	while( !it.end() ){
 		it.scanNext();
 		if ( it.getIndexDelta() == 1 && WCODE::IsIndentChar(it.getCurrentChar(),bZenSpace) )
 		{
-			//	ƒCƒ“ƒfƒ“ƒg‚ÌƒJƒEƒ“ƒg‚ğŒp‘±‚·‚é
+			//	ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã®ã‚«ã‚¦ãƒ³ãƒˆã‚’ç¶™ç¶šã™ã‚‹
 		}
-		//	Jul. 20, 2003 genta ƒCƒ“ƒfƒ“ƒg‘ÎÛ•¶š
+		//	Jul. 20, 2003 genta ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¯¾è±¡æ–‡å­—
 		else if( szSpecialIndentChar[0] != L'\0' ){
-			wchar_t buf[3]; // •¶š‚Ì’·‚³‚Í1 or 2
+			wchar_t buf[3]; // æ–‡å­—ã®é•·ã•ã¯1 or 2
 			wmemcpy( buf, it.getCurrentPos(), it.getIndexDelta() );
 			buf[ it.getIndexDelta() ] = L'\0';
 			if( NULL != wcsstr( szSpecialIndentChar, buf )){
-				//	ƒCƒ“ƒfƒ“ƒg‚ÌƒJƒEƒ“ƒg‚ğŒp‘±‚·‚é
+				//	ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã®ã‚«ã‚¦ãƒ³ãƒˆã‚’ç¶™ç¶šã™ã‚‹
 			}
 			else {
-				nIpos = it.getColumn();	//	I—¹
+				nIpos = it.getColumn();	//	çµ‚äº†
 				break;
 			}
 		}
 		else {
-			nIpos = it.getColumn();	//	I—¹
+			nIpos = it.getColumn();	//	çµ‚äº†
 			break;
 		}
 		it.addDelta();
 	}
 	if( it.end() ){
-		nIpos = it.getColumn();	//	I—¹
+		nIpos = it.getColumn();	//	çµ‚äº†
 	}
-	// 2010.07.06 Moca TAB=8‚È‚Ç‚Ìê‡‚ÉÜ‚è•Ô‚·‚Æ–³ŒÀƒ‹[ƒv‚·‚é•s‹ï‡‚ÌC³. 6ŒÅ’è‚ğ m_nTabSpace + 2‚É•ÏX
+	// 2010.07.06 Moca TAB=8ãªã©ã®å ´åˆã«æŠ˜ã‚Šè¿”ã™ã¨ç„¡é™ãƒ«ãƒ¼ãƒ—ã™ã‚‹ä¸å…·åˆã®ä¿®æ­£. 6å›ºå®šã‚’ m_nTabSpace + 2ã«å¤‰æ›´
 	if ( GetMaxLineLayout() - nIpos < GetTabSpace() + (2 * m_nCharLayoutXPerKeta) ){
-		nIpos = t_max(CLayoutInt(0), GetMaxLineLayout() - (GetTabSpace() + (2 * m_nCharLayoutXPerKeta))); // 2013.05.12 Chg:0‚¾‚Á‚½‚Ì‚ğÅ‘å•‚É•ÏX
+		nIpos = t_max(CLayoutInt(0), GetMaxLineLayout() - (GetTabSpace() + (2 * m_nCharLayoutXPerKeta))); // 2013.05.12 Chg:0ã ã£ãŸã®ã‚’æœ€å¤§å¹…ã«å¤‰æ›´
 	}
-	return nIpos;	//	ƒCƒ“ƒfƒ“ƒg
+	return nIpos;	//	ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
 }
 
 /*!
-	@brief  ƒeƒLƒXƒgÅ‘å•‚ğZo‚·‚é
+	@brief  ãƒ†ã‚­ã‚¹ãƒˆæœ€å¤§å¹…ã‚’ç®—å‡ºã™ã‚‹
 
-	w’è‚³‚ê‚½ƒ‰ƒCƒ“‚ğ‘–¸‚µ‚ÄƒeƒLƒXƒg‚ÌÅ‘å•‚ğì¬‚·‚éB
-	‘S‚Äíœ‚³‚ê‚½‚Í–¢Zoó‘Ô‚É–ß‚·B
+	æŒ‡å®šã•ã‚ŒãŸãƒ©ã‚¤ãƒ³ã‚’èµ°æŸ»ã—ã¦ãƒ†ã‚­ã‚¹ãƒˆã®æœ€å¤§å¹…ã‚’ä½œæˆã™ã‚‹ã€‚
+	å…¨ã¦å‰Šé™¤ã•ã‚ŒãŸæ™‚ã¯æœªç®—å‡ºçŠ¶æ…‹ã«æˆ»ã™ã€‚
 
-	@param bCalLineLen	[in] ŠeƒŒƒCƒAƒEƒgs‚Ì’·‚³‚ÌZo‚às‚¤
-	@param nStart		[in] ZoŠJnƒŒƒCƒAƒEƒgs
-	@param nEnd			[in] ZoI—¹ƒŒƒCƒAƒEƒgs
+	@param bCalLineLen	[in] å„ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®é•·ã•ã®ç®—å‡ºã‚‚è¡Œã†
+	@param nStart		[in] ç®—å‡ºé–‹å§‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
+	@param nEnd			[in] ç®—å‡ºçµ‚äº†ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
 
-	@retval TRUE Å‘å•‚ª•Ï‰»‚µ‚½
-	@retval FALSE Å‘å•‚ª•Ï‰»‚µ‚È‚©‚Á‚½
+	@retval TRUE æœ€å¤§å¹…ãŒå¤‰åŒ–ã—ãŸ
+	@retval FALSE æœ€å¤§å¹…ãŒå¤‰åŒ–ã—ãªã‹ã£ãŸ
 
-	@note nStart, nEnd‚ª—¼•û‚Æ‚à-1‚ÌA‘Sƒ‰ƒCƒ“‚ğ‘–¸‚·‚é
-		  ”ÍˆÍ‚ªw’è‚³‚ê‚Ä‚¢‚éê‡‚ÍÅ‘å•‚ÌŠg‘å‚Ì‚İƒ`ƒFƒbƒN‚·‚é
+	@note nStart, nEndãŒä¸¡æ–¹ã¨ã‚‚-1ã®æ™‚ã€å…¨ãƒ©ã‚¤ãƒ³ã‚’èµ°æŸ»ã™ã‚‹
+		  ç¯„å›²ãŒæŒ‡å®šã•ã‚Œã¦ã„ã‚‹å ´åˆã¯æœ€å¤§å¹…ã®æ‹¡å¤§ã®ã¿ãƒã‚§ãƒƒã‚¯ã™ã‚‹
 
-	@date 2009.08.28 nasukoji	V‹Kì¬
+	@date 2009.08.28 nasukoji	æ–°è¦ä½œæˆ
 */
 BOOL CLayoutMgr::CalculateTextWidth( BOOL bCalLineLen, CLayoutInt nStart, CLayoutInt nEnd )
 {
 	BOOL bRet = FALSE;
-	BOOL bOnlyExpansion = TRUE;		// Å‘å•‚ÌŠg‘å‚Ì‚İ‚ğƒ`ƒFƒbƒN‚·‚é
+	BOOL bOnlyExpansion = TRUE;		// æœ€å¤§å¹…ã®æ‹¡å¤§ã®ã¿ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹
 	CLayoutInt nMaxLen = CLayoutInt(0);
 	CLayoutInt nMaxLineNum = CLayoutInt(0);
 
-	CLayoutInt nLines = GetLineCount();		// ƒeƒLƒXƒg‚ÌƒŒƒCƒAƒEƒgs”
+	CLayoutInt nLines = GetLineCount();		// ãƒ†ã‚­ã‚¹ãƒˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œæ•°
 
-	// ŠJnEI—¹ˆÊ’u‚ª‚Ç‚¿‚ç‚àw’è‚³‚ê‚Ä‚¢‚È‚¢
+	// é–‹å§‹ãƒ»çµ‚äº†ä½ç½®ãŒã©ã¡ã‚‰ã‚‚æŒ‡å®šã•ã‚Œã¦ã„ãªã„
 	if( nStart < 0 && nEnd < 0 )
-		bOnlyExpansion = FALSE;		// Å‘å•‚ÌŠg‘åEk¬‚ğƒ`ƒFƒbƒN‚·‚é
+		bOnlyExpansion = FALSE;		// æœ€å¤§å¹…ã®æ‹¡å¤§ãƒ»ç¸®å°ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹
 
-	if( nStart < 0 )			// ZoŠJns‚Ìw’è‚È‚µ
+	if( nStart < 0 )			// ç®—å‡ºé–‹å§‹è¡Œã®æŒ‡å®šãªã—
 		nStart = 0;
-	else if( nStart > nLines )	// ”ÍˆÍƒI[ƒo[
+	else if( nStart > nLines )	// ç¯„å›²ã‚ªãƒ¼ãƒãƒ¼
 		nStart = nLines;
 	
-	if( nEnd < 0 || nEnd >= nLines )	// ZoI—¹s‚Ìw’è‚È‚µ ‚Ü‚½‚Í •¶‘s”ˆÈã
+	if( nEnd < 0 || nEnd >= nLines )	// ç®—å‡ºçµ‚äº†è¡Œã®æŒ‡å®šãªã— ã¾ãŸã¯ æ–‡æ›¸è¡Œæ•°ä»¥ä¸Š
 		nEnd = nLines;
 	else
-		nEnd++;					// ZoI—¹s‚ÌŸs
+		nEnd++;					// ç®—å‡ºçµ‚äº†è¡Œã®æ¬¡è¡Œ
 
 	CLayout* pLayout;
 
-	// ZoŠJnƒŒƒCƒAƒEƒgs‚ğ’T‚·
-	// 2013.05.13 SearchLineByLayoutY‚ğg‚¤
+	// ç®—å‡ºé–‹å§‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã‚’æ¢ã™
+	// 2013.05.13 SearchLineByLayoutYã‚’ä½¿ã†
 	if( nStart == 0 ){
 		pLayout = m_pLayoutTop;
 	}else{
@@ -318,7 +318,7 @@ BOOL CLayoutMgr::CalculateTextWidth( BOOL bCalLineLen, CLayoutInt nStart, CLayou
 	}
 #if 0
 	if( nStart * 2 < nLines ){
-		// ‘O•û‚©‚çƒT[ƒ`
+		// å‰æ–¹ã‹ã‚‰ã‚µãƒ¼ãƒ
 		CLayoutInt nCount = CLayoutInt(0);
 		pLayout = m_pLayoutTop;
 		while( NULL != pLayout ){
@@ -329,7 +329,7 @@ BOOL CLayoutMgr::CalculateTextWidth( BOOL bCalLineLen, CLayoutInt nStart, CLayou
 			nCount++;
 		}
 	}else{
-		// Œã•û‚©‚çƒT[ƒ`
+		// å¾Œæ–¹ã‹ã‚‰ã‚µãƒ¼ãƒ
 		CLayoutInt nCount = CLayoutInt( m_nLines - 1 );
 		pLayout = m_pLayoutBot;
 		while( NULL != pLayout ){
@@ -342,43 +342,43 @@ BOOL CLayoutMgr::CalculateTextWidth( BOOL bCalLineLen, CLayoutInt nStart, CLayou
 	}
 #endif
 
-	// ƒŒƒCƒAƒEƒgs‚ÌÅ‘å•‚ğæ‚èo‚·
+	// ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®æœ€å¤§å¹…ã‚’å–ã‚Šå‡ºã™
 	for( CLayoutInt i = nStart; i < nEnd; i++ ){
 		if( !pLayout )
 			break;
 
-		// ƒŒƒCƒAƒEƒgs‚Ì’·‚³‚ğZo‚·‚é
+		// ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®é•·ã•ã‚’ç®—å‡ºã™ã‚‹
 		if( bCalLineLen ){
 			CLayoutInt nWidth = pLayout->CalcLayoutWidth(*this) + CLayoutInt(pLayout->GetLayoutEol().GetLen()>0?1+m_nSpacing:0);
 			pLayout->SetLayoutWidth( nWidth );
 		}
 
-		// Å‘å•‚ğXV
+		// æœ€å¤§å¹…ã‚’æ›´æ–°
 		if( nMaxLen < pLayout->GetLayoutWidth() ){
 			nMaxLen = pLayout->GetLayoutWidth();
-			nMaxLineNum = i;		// Å‘å•‚ÌƒŒƒCƒAƒEƒgs
+			nMaxLineNum = i;		// æœ€å¤§å¹…ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
 
-			// ƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚ÌÅ‘å•‚Æ‚È‚Á‚½‚çZo‚Í’â~
+			// ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã®æœ€å¤§å¹…ã¨ãªã£ãŸã‚‰ç®—å‡ºã¯åœæ­¢
 			if( nMaxLen >= MAXLINEKETAS * GetWidthPerKeta() && !bCalLineLen )
 				break;
 		}
 
-		// Ÿ‚ÌƒŒƒCƒAƒEƒgs‚Ìƒf[ƒ^
+		// æ¬¡ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®ãƒ‡ãƒ¼ã‚¿
 		pLayout = pLayout->GetNextLayout();
 	}
 
-	// ƒeƒLƒXƒg‚Ì•‚Ì•Ï‰»‚ğƒ`ƒFƒbƒN
+	// ãƒ†ã‚­ã‚¹ãƒˆã®å¹…ã®å¤‰åŒ–ã‚’ãƒã‚§ãƒƒã‚¯
 	if( Int(nMaxLen) ){
-		// Å‘å•‚ªŠg‘å‚µ‚½ ‚Ü‚½‚Í Å‘å•‚ÌŠg‘å‚Ì‚İƒ`ƒFƒbƒN‚Å‚È‚¢
+		// æœ€å¤§å¹…ãŒæ‹¡å¤§ã—ãŸ ã¾ãŸã¯ æœ€å¤§å¹…ã®æ‹¡å¤§ã®ã¿ãƒã‚§ãƒƒã‚¯ã§ãªã„
 		if( m_nTextWidth < nMaxLen || !bOnlyExpansion ){
 			m_nTextWidthMaxLine = nMaxLineNum;
-			if( m_nTextWidth != nMaxLen ){	// Å‘å••Ï‰»‚ ‚è
+			if( m_nTextWidth != nMaxLen ){	// æœ€å¤§å¹…å¤‰åŒ–ã‚ã‚Š
 				m_nTextWidth = nMaxLen;
 				bRet = TRUE;
 			}
 		}
 	}else if( Int(m_nTextWidth) && !Int(nLines) ){
-		// ‘Síœ‚³‚ê‚½‚ç•‚Ì‹L‰¯‚ğƒNƒŠƒA
+		// å…¨å‰Šé™¤ã•ã‚ŒãŸã‚‰å¹…ã®è¨˜æ†¶ã‚’ã‚¯ãƒªã‚¢
 		m_nTextWidthMaxLine = 0;
 		m_nTextWidth = 0;
 		bRet = TRUE;
@@ -388,24 +388,24 @@ BOOL CLayoutMgr::CalculateTextWidth( BOOL bCalLineLen, CLayoutInt nStart, CLayou
 }
 
 /*!
-	@brief  Šes‚ÌƒŒƒCƒAƒEƒgs’·‚Ì‹L‰¯‚ğƒNƒŠƒA‚·‚é
+	@brief  å„è¡Œã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œé•·ã®è¨˜æ†¶ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹
 	
-	@note Ü‚è•Ô‚µ•û–@‚ªuÜ‚è•Ô‚³‚È‚¢vˆÈŠO‚Ì‚ÍAƒpƒtƒH[ƒ}ƒ“ƒX‚Ì’á‰º‚ğ
-		  –h~‚·‚é–Ú“I‚ÅŠes‚ÌƒŒƒCƒAƒEƒgs’·(m_nLayoutWidth)‚ğŒvZ‚µ‚Ä‚¢‚È‚¢B
-		  Œã‚ÅİŒv‚·‚él‚ªŒë‚Á‚Äg—p‚µ‚Ä‚µ‚Ü‚¤‚©‚à‚µ‚ê‚È‚¢‚Ì‚ÅuÜ‚è•Ô‚³‚È‚¢v
-		  ˆÈŠO‚Ì‚ÍƒNƒŠƒA‚µ‚Ä‚¨‚­B
-		  ƒpƒtƒH[ƒ}ƒ“ƒX‚Ì’á‰º‚ª‹C‚É‚È‚ç‚È‚¢’ö‚È‚çA‘S‚Ä‚ÌÜ‚è•Ô‚µ•û–@‚ÅŒvZ
-		  ‚·‚é‚æ‚¤‚É‚µ‚Ä‚à—Ç‚¢‚Æv‚¤B
+	@note æŠ˜ã‚Šè¿”ã—æ–¹æ³•ãŒã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€ä»¥å¤–ã®æ™‚ã¯ã€ãƒ‘ãƒ•ã‚©ãƒ¼ãƒãƒ³ã‚¹ã®ä½ä¸‹ã‚’
+		  é˜²æ­¢ã™ã‚‹ç›®çš„ã§å„è¡Œã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œé•·(m_nLayoutWidth)ã‚’è¨ˆç®—ã—ã¦ã„ãªã„ã€‚
+		  å¾Œã§è¨­è¨ˆã™ã‚‹äººãŒèª¤ã£ã¦ä½¿ç”¨ã—ã¦ã—ã¾ã†ã‹ã‚‚ã—ã‚Œãªã„ã®ã§ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€
+		  ä»¥å¤–ã®æ™‚ã¯ã‚¯ãƒªã‚¢ã—ã¦ãŠãã€‚
+		  ãƒ‘ãƒ•ã‚©ãƒ¼ãƒãƒ³ã‚¹ã®ä½ä¸‹ãŒæ°—ã«ãªã‚‰ãªã„ç¨‹ãªã‚‰ã€å…¨ã¦ã®æŠ˜ã‚Šè¿”ã—æ–¹æ³•ã§è¨ˆç®—
+		  ã™ã‚‹ã‚ˆã†ã«ã—ã¦ã‚‚è‰¯ã„ã¨æ€ã†ã€‚
 
-	@date 2009.08.28 nasukoji	V‹Kì¬
+	@date 2009.08.28 nasukoji	æ–°è¦ä½œæˆ
 */
 void CLayoutMgr::ClearLayoutLineWidth( void )
 {
 	CLayout* pLayout = m_pLayoutTop;
 
 	while( pLayout ){
-		pLayout->m_nLayoutWidth = 0;			// ƒŒƒCƒAƒEƒgs’·‚ğƒNƒŠƒA
-		pLayout = pLayout->GetNextLayout();		// Ÿ‚ÌƒŒƒCƒAƒEƒgs‚Ìƒf[ƒ^
+		pLayout->m_nLayoutWidth = 0;			// ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œé•·ã‚’ã‚¯ãƒªã‚¢
+		pLayout = pLayout->GetNextLayout();		// æ¬¡ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®ãƒ‡ãƒ¼ã‚¿
 		
 	}
 }

--- a/sakura_core/doc/layout/CLayoutMgr_New2.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New2.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief �e�L�X�g�̃��C�A�E�g���Ǘ�
+﻿/*!	@file
+	@brief テキストのレイアウト情報管理
 
 	@author Norio Nakatani
 */
@@ -21,14 +21,14 @@
 
 
 
-/* ������u�� */
+/* 文字列置換 */
 void CLayoutMgr::ReplaceData_CLayoutMgr(
 	LayoutReplaceArg*	pArg
 )
 {
-	CLayoutInt	nWork_nLines = m_nLines;	//�ύX�O�̑S�s���̕ۑ�	@@@ 2002.04.19 MIK
+	CLayoutInt	nWork_nLines = m_nLines;	//変更前の全行数の保存	@@@ 2002.04.19 MIK
 
-	/* �u���擪�ʒu�̃��C�A�E�g��� */
+	/* 置換先頭位置のレイアウト情報 */
 	EColorIndexType	nCurrentLineType = COLORIDX_DEFAULT;
 	CLayoutColorInfo*	colorInfo = NULL;
 	CLayoutInt		nLineWork = pArg->sDelRange.GetFrom().GetY2();
@@ -42,31 +42,31 @@ void CLayoutMgr::ReplaceData_CLayoutMgr(
 		nCurrentLineType = pLayoutWork->GetColorTypePrev();
 		colorInfo = pLayoutWork->GetLayoutExInfo()->DetachColorInfo();
 	}else if( GetLineCount() == pArg->sDelRange.GetFrom().GetY2() ){
-		// 2012.01.05 �ŏI�s��Redo/Undo�ł̐F�������������Ȃ��̂��C��
+		// 2012.01.05 最終行のRedo/Undoでの色分けが正しくないのを修正
 		nCurrentLineType = m_nLineTypeBot;
 		colorInfo = m_cLayoutExInfoBot.DetachColorInfo();
 	}
 
 
 	/*
-	||  �J�[�\���ʒu�ϊ�
-	||  ���C�A�E�g�ʒu(�s������̕\�����ʒu�A�܂�Ԃ�����s�ʒu) ��
-	||  �����ʒu(�s������̃o�C�g���A�܂�Ԃ������s�ʒu)
+	||  カーソル位置変換
+	||  レイアウト位置(行頭からの表示桁位置、折り返しあり行位置) →
+	||  物理位置(行頭からのバイト数、折り返し無し行位置)
 	*/
 	CLogicPoint ptFrom;
 	CLogicPoint ptTo;
 	LayoutToLogic( pArg->sDelRange.GetFrom(), &ptFrom );
 	LayoutToLogic( pArg->sDelRange.GetTo(), &ptTo );
 
-	/* �w��͈͂̃f�[�^��u��(�폜 & �f�[�^��}��)
-	  From���܂ވʒu����To�̒��O���܂ރf�[�^���폜����
-	  From�̈ʒu�փe�L�X�g��}������
+	/* 指定範囲のデータを置換(削除 & データを挿入)
+	  Fromを含む位置からToの直前を含むデータを削除する
+	  Fromの位置へテキストを挿入する
 	*/
 	DocLineReplaceArg DLRArg;
-	DLRArg.sDelRange.SetFrom(ptFrom);	//�폜�͈�from
-	DLRArg.sDelRange.SetTo(ptTo);		//�폜�͈�to
-	DLRArg.pcmemDeleted = pArg->pcmemDeleted;	// �폜���ꂽ�f�[�^��ۑ�
-	DLRArg.pInsData = pArg->pInsData;			// �}������f�[�^
+	DLRArg.sDelRange.SetFrom(ptFrom);	//削除範囲from
+	DLRArg.sDelRange.SetTo(ptTo);		//削除範囲to
+	DLRArg.pcmemDeleted = pArg->pcmemDeleted;	// 削除されたデータを保存
+	DLRArg.pInsData = pArg->pInsData;			// 挿入するデータ
 	DLRArg.nDelSeq = pArg->nDelSeq;
 	CSearchAgent(m_pcDocLineMgr).ReplaceData(
 		&DLRArg
@@ -74,9 +74,9 @@ void CLayoutMgr::ReplaceData_CLayoutMgr(
 	pArg->nInsSeq = DLRArg.nInsSeq;
 
 
-	/*--- �ύX���ꂽ�s�̃��C�A�E�g�����Đ��� ---*/
-	/* �_���s�̎w��͈͂ɊY�����郌�C�A�E�g�����폜���� */
-	/* �폜�����͈͂̒��O�̃��C�A�E�g���̃|�C���^��Ԃ� */
+	/*--- 変更された行のレイアウト情報を再生成 ---*/
+	/* 論理行の指定範囲に該当するレイアウト情報を削除して */
+	/* 削除した範囲の直前のレイアウト情報のポインタを返す */
 
 	CLayoutInt	nModifyLayoutLinesOld = CLayoutInt(0);
 	CLayout* pLayoutPrev;
@@ -94,9 +94,9 @@ void CLayoutMgr::ReplaceData_CLayoutMgr(
 			&nModifyLayoutLinesOld
 		);
 
-		/* �w��s����̍s�̃��C�A�E�g���ɂ��āA�_���s�ԍ����w��s�������V�t�g���� */
-		/* �_���s���폜���ꂽ�ꍇ�͂O��菬�����s�� */
-		/* �_���s���}�����ꂽ�ꍇ�͂O���傫���s�� */
+		/* 指定行より後の行のレイアウト情報について、論理行番号を指定行数だけシフトする */
+		/* 論理行が削除された場合は０より小さい行数 */
+		/* 論理行が挿入された場合は０より大きい行数 */
 		if( 0 != DLRArg.nInsLineNum - DLRArg.nDeletedLineNum ){
 			ShiftLogicalLineNum(
 				pLayoutPrev,
@@ -107,7 +107,7 @@ void CLayoutMgr::ReplaceData_CLayoutMgr(
 		pLayoutPrev = m_pLayoutBot;
 	}
 
-	/* �w�背�C�A�E�g�s�ɑΉ�����_���s�̎��̘_���s����w��_���s�������ă��C�A�E�g���� */
+	/* 指定レイアウト行に対応する論理行の次の論理行から指定論理行数だけ再レイアウトする */
 	CLogicInt	nRowNum;
 	if( NULL == pLayoutPrev ){
 		if( NULL == m_pLayoutTop ){
@@ -128,14 +128,14 @@ void CLayoutMgr::ReplaceData_CLayoutMgr(
 		}
 	}
 
-	// 2009.08.28 nasukoji	�e�L�X�g�ő啝�Z�o�p�̈�����ݒ�
+	// 2009.08.28 nasukoji	テキスト最大幅算出用の引数を設定
 	CalTextWidthArg ctwArg;
-	ctwArg.ptLayout     = pArg->sDelRange.GetFrom();		// �ҏW�J�n�ʒu
-	ctwArg.nDelLines    = pArg->sDelRange.GetTo().GetY2() - pArg->sDelRange.GetFrom().GetY2();	// �폜�s�� - 1
-	ctwArg.nAllLinesOld = nWork_nLines;								// �ҏW�O�̃e�L�X�g�s��
-	ctwArg.bInsData     = (pArg->pInsData && pArg->pInsData->size()) ? TRUE : FALSE;			// �ǉ�������̗L��
+	ctwArg.ptLayout     = pArg->sDelRange.GetFrom();		// 編集開始位置
+	ctwArg.nDelLines    = pArg->sDelRange.GetTo().GetY2() - pArg->sDelRange.GetFrom().GetY2();	// 削除行数 - 1
+	ctwArg.nAllLinesOld = nWork_nLines;								// 編集前のテキスト行数
+	ctwArg.bInsData     = (pArg->pInsData && pArg->pInsData->size()) ? TRUE : FALSE;			// 追加文字列の有無
 
-	/* �w�背�C�A�E�g�s�ɑΉ�����_���s�̎��̘_���s����w��_���s�������ă��C�A�E�g���� */
+	/* 指定レイアウト行に対応する論理行の次の論理行から指定論理行数だけ再レイアウトする */
 	CLayoutInt nAddInsLineNum;
 	pArg->nModLineTo = DoLayout_Range(
 		pLayoutPrev,
@@ -147,14 +147,14 @@ void CLayoutMgr::ReplaceData_CLayoutMgr(
 		&nAddInsLineNum
 	);
 
-	pArg->nAddLineNum = m_nLines - nWork_nLines;	//�ύX��̑S�s���Ƃ̍���	@@@ 2002.04.19 MIK
+	pArg->nAddLineNum = m_nLines - nWork_nLines;	//変更後の全行数との差分	@@@ 2002.04.19 MIK
 	if( 0 == pArg->nAddLineNum )
-		pArg->nAddLineNum = nModifyLayoutLinesOld - pArg->nModLineTo;	/* �ĕ`��q���g ���C�A�E�g�s�̑��� */
-	pArg->nModLineFrom = pArg->sDelRange.GetFrom().GetY2();	/* �ĕ`��q���g �ύX���ꂽ���C�A�E�g�sFrom */
-	pArg->nModLineTo += ( pArg->nModLineFrom - CLayoutInt(1) ) ;	/* �ĕ`��q���g �ύX���ꂽ���C�A�E�g�sTo */
+		pArg->nAddLineNum = nModifyLayoutLinesOld - pArg->nModLineTo;	/* 再描画ヒント レイアウト行の増減 */
+	pArg->nModLineFrom = pArg->sDelRange.GetFrom().GetY2();	/* 再描画ヒント 変更されたレイアウト行From */
+	pArg->nModLineTo += ( pArg->nModLineFrom - CLayoutInt(1) ) ;	/* 再描画ヒント 変更されたレイアウト行To */
 
-	//2007.10.18 kobake LayoutReplaceArg::ptLayoutNew�͂����ŎZ�o����̂�������
-	LogicToLayout(DLRArg.ptNewPos, &pArg->ptLayoutNew); // �}�����ꂽ�����̎��̈ʒu
+	//2007.10.18 kobake LayoutReplaceArg::ptLayoutNewはここで算出するのが正しい
+	LogicToLayout(DLRArg.ptNewPos, &pArg->ptLayoutNew); // 挿入された部分の次の位置
 }
 
 

--- a/sakura_core/doc/layout/CTsvModeInfo.cpp
+++ b/sakura_core/doc/layout/CTsvModeInfo.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2015, syat
 
 	This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@
 #include "doc/logic/CDocLine.h"
 #include "doc/logic/CDocLineMgr.h"
 
-// ƒ^ƒuˆÊ’u‚ğÄŒvZ‚·‚é
+// ã‚¿ãƒ–ä½ç½®ã‚’å†è¨ˆç®—ã™ã‚‹
 void CTsvModeInfo::CalcTabLength(CDocLineMgr* cDocLineMgr)
 {
 	int i;
@@ -87,7 +87,7 @@ void CTsvModeInfo::CalcTabLength(CDocLineMgr* cDocLineMgr)
 	}
 }
 
-// w’è‚µ‚½ƒŒƒCƒAƒEƒgˆÊ’u‚Ìƒ^ƒu•‚ğæ“¾iÜ‚è•Ô‚µ‚Íl—¶‚µ‚È‚¢j
+// æŒ‡å®šã—ãŸãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã®ã‚¿ãƒ–å¹…ã‚’å–å¾—ï¼ˆæŠ˜ã‚Šè¿”ã—ã¯è€ƒæ…®ã—ãªã„ï¼‰
 CLayoutInt CTsvModeInfo::GetActualTabLength(CLayoutInt pos, CLayoutInt px) const
 {
 	unsigned int i;

--- a/sakura_core/doc/layout/CTsvModeInfo.h
+++ b/sakura_core/doc/layout/CTsvModeInfo.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief TSVƒ‚[ƒhŠÇ—
+ï»¿/*!	@file
+	@brief TSVãƒ¢ãƒ¼ãƒ‰ç®¡ç†
 */
 /*
 	Copyright (C) 2015, syat
@@ -30,20 +30,20 @@
 #include <vector>
 #include "basis/SakuraBasis.h"
 
-// TSVƒ‚[ƒh
-#define TSV_MODE_NONE	0	// TSVƒ‚[ƒh‚È‚µ
-#define TSV_MODE_TSV	1	// TSVƒ‚[ƒh
-#define TSV_MODE_CSV	2	// CSVƒ‚[ƒh
+// TSVãƒ¢ãƒ¼ãƒ‰
+#define TSV_MODE_NONE	0	// TSVãƒ¢ãƒ¼ãƒ‰ãªã—
+#define TSV_MODE_TSV	1	// TSVãƒ¢ãƒ¼ãƒ‰
+#define TSV_MODE_CSV	2	// CSVãƒ¢ãƒ¼ãƒ‰
 
 class CDocLineMgr;
 
-// TSVƒ‚[ƒhî•ñ
+// TSVãƒ¢ãƒ¼ãƒ‰æƒ…å ±
 class CTsvModeInfo {
 	
 public:
-	void CalcTabLength(CDocLineMgr* cDocLineMgr);	// ƒ^ƒuˆÊ’u‚ğÄŒvZ‚·‚é
-	void CalcTabLength(LPCWSTR pLine);	// ƒ^ƒuˆÊ’u‚ğÄŒvZ‚·‚éiˆêsj
-	CLayoutInt GetActualTabLength(CLayoutInt pos, CLayoutInt px) const;	// w’è‚µ‚½ƒŒƒCƒAƒEƒgˆÊ’u‚Ìƒ^ƒu•‚ğæ“¾iÜ‚è•Ô‚µ‚Íl—¶‚µ‚È‚¢j
+	void CalcTabLength(CDocLineMgr* cDocLineMgr);	// ã‚¿ãƒ–ä½ç½®ã‚’å†è¨ˆç®—ã™ã‚‹
+	void CalcTabLength(LPCWSTR pLine);	// ã‚¿ãƒ–ä½ç½®ã‚’å†è¨ˆç®—ã™ã‚‹ï¼ˆä¸€è¡Œï¼‰
+	CLayoutInt GetActualTabLength(CLayoutInt pos, CLayoutInt px) const;	// æŒ‡å®šã—ãŸãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã®ã‚¿ãƒ–å¹…ã‚’å–å¾—ï¼ˆæŠ˜ã‚Šè¿”ã—ã¯è€ƒæ…®ã—ãªã„ï¼‰
 
 	int m_nTsvMode;
 	CLayoutInt m_nMaxCharLayoutX;

--- a/sakura_core/doc/logic/CDocLine.cpp
+++ b/sakura_core/doc/logic/CDocLine.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief •¶‘ƒf[ƒ^1s
+ï»¿/*!	@file
+	@brief æ–‡æ›¸ãƒ‡ãƒ¼ã‚¿1è¡Œ
 
 	@author Norio Nakatani
 */
@@ -25,9 +25,9 @@ CDocLine::~CDocLine()
 {
 }
 
-/* ‹ósiƒXƒy[ƒXAƒ^ƒuA‰üs‹L†‚Ì‚İ‚Ìsj‚©‚Ç‚¤‚©‚ğæ“¾‚·‚é
-	trueF‹ós‚¾B
-	falseF‹ós‚¶‚á‚È‚¢‚¼B
+/* ç©ºè¡Œï¼ˆã‚¹ãƒšãƒ¼ã‚¹ã€ã‚¿ãƒ–ã€æ”¹è¡Œè¨˜å·ã®ã¿ã®è¡Œï¼‰ã‹ã©ã†ã‹ã‚’å–å¾—ã™ã‚‹
+	trueï¼šç©ºè¡Œã ã€‚
+	falseï¼šç©ºè¡Œã˜ã‚ƒãªã„ãã€‚
 
 	2002/04/26 YAZAKI
 */
@@ -38,17 +38,17 @@ bool CDocLine::IsEmptyLine() const
 	int i;
 	for ( i = 0; i < nLineLen; i++ ){
 		if (pLine[i] != L' ' && pLine[i] != L'\t'){
-			return false;	//	ƒXƒy[ƒX‚Å‚àƒ^ƒu‚Å‚à‚È‚¢•¶š‚ª‚ ‚Á‚½‚çfalseB
+			return false;	//	ã‚¹ãƒšãƒ¼ã‚¹ã§ã‚‚ã‚¿ãƒ–ã§ã‚‚ãªã„æ–‡å­—ãŒã‚ã£ãŸã‚‰falseã€‚
 		}
 	}
-	return true;	//	‚·‚×‚ÄƒXƒy[ƒX‚©ƒ^ƒu‚¾‚¯‚¾‚Á‚½‚çtrueB
+	return true;	//	ã™ã¹ã¦ã‚¹ãƒšãƒ¼ã‚¹ã‹ã‚¿ãƒ–ã ã‘ã ã£ãŸã‚‰trueã€‚
 }
 
 void CDocLine::SetEol()
 {
 	const wchar_t* pData = m_cLine.GetStringPtr();
 	int nLength = m_cLine.GetStringLength();
-	//‰üsƒR[ƒhİ’è
+	//æ”¹è¡Œã‚³ãƒ¼ãƒ‰è¨­å®š
 	const wchar_t* p = &pData[nLength] - 1;
 	while(p>=pData && WCODE::IsLineDelimiter(*p, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol))p--;
 	p++;
@@ -80,12 +80,12 @@ void CDocLine::SetDocLineStringMove(CNativeW* pcDataFrom)
 
 void CDocLine::SetEol(const CEol& cEol, COpeBlk* pcOpeBlk)
 {
-	//‰üsƒR[ƒh‚ğíœ
+	//æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’å‰Šé™¤
 	for(int i=0;i<(Int)m_cEol.GetLen();i++){
 		m_cLine.Chop();
 	}
 
-	//‰üsƒR[ƒh‚ğ‘}“ü
+	//æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’æŒ¿å…¥
 	m_cEol = cEol;
 	m_cLine += cEol.GetValue2();
 }

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -1,10 +1,10 @@
-/*!	@file
-	@brief •¶‘ƒf[ƒ^1s
+ï»¿/*!	@file
+	@brief æ–‡æ›¸ãƒ‡ãƒ¼ã‚¿1è¡Œ
 
 	@author Norio Nakatani
 
-	@date 2001/12/03 hor ‚µ‚¨‚è(bookmark)‹@”\’Ç‰Á‚É”º‚¤ƒƒ“ƒo[’Ç‰Á
-	@date 2001/12/18 hor bookmark, C³ƒtƒ‰ƒO‚ÌƒAƒNƒZƒXŠÖ”‰»
+	@date 2001/12/03 hor ã—ãŠã‚Š(bookmark)æ©Ÿèƒ½è¿½åŠ ã«ä¼´ã†ãƒ¡ãƒ³ãƒãƒ¼è¿½åŠ 
+	@date 2001/12/18 hor bookmark, ä¿®æ­£ãƒ•ãƒ©ã‚°ã®ã‚¢ã‚¯ã‚»ã‚¹é–¢æ•°åŒ–
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -30,24 +30,24 @@
 class CDocLine;
 class COpeBlk;
 
-//!	•¶‘ƒf[ƒ^1s
+//!	æ–‡æ›¸ãƒ‡ãƒ¼ã‚¿1è¡Œ
 class CDocLine{
 protected:
-	friend class CDocLineMgr; //######‰¼
+	friend class CDocLineMgr; //######ä»®
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CDocLine();
 	~CDocLine();
 
-	//”»’è
-	bool			IsEmptyLine() const;		//	‚±‚ÌCDocLine‚ª‹ósiƒXƒy[ƒXAƒ^ƒuA‰üs‹L†‚Ì‚İ‚Ìsj‚©‚Ç‚¤‚©B
+	//åˆ¤å®š
+	bool			IsEmptyLine() const;		//	ã“ã®CDocLineãŒç©ºè¡Œï¼ˆã‚¹ãƒšãƒ¼ã‚¹ã€ã‚¿ãƒ–ã€æ”¹è¡Œè¨˜å·ã®ã¿ã®è¡Œï¼‰ã‹ã©ã†ã‹ã€‚
 
-	//ƒf[ƒ^æ“¾
-	CLogicInt		GetLengthWithoutEOL() const			{ return m_cLine.GetStringLength() - m_cEol.GetLen(); } //!< –ß‚è’l‚Í•¶š’PˆÊB
+	//ãƒ‡ãƒ¼ã‚¿å–å¾—
+	CLogicInt		GetLengthWithoutEOL() const			{ return m_cLine.GetStringLength() - m_cEol.GetLen(); } //!< æˆ»ã‚Šå€¤ã¯æ–‡å­—å˜ä½ã€‚
 	const wchar_t*	GetPtr() const						{ return m_cLine.GetStringPtr(); }
-	CLogicInt		GetLengthWithEOL() const			{ return m_cLine.GetStringLength(); }	//	CMemoryIterator—p
+	CLogicInt		GetLengthWithEOL() const			{ return m_cLine.GetStringLength(); }	//	CMemoryIteratorç”¨
 #ifdef USE_STRICT_INT
-	const wchar_t*	GetDocLineStrWithEOL(int* pnLen) const //###‰¼‚Ì–¼‘OA‰¼‚Ì‘Îˆ
+	const wchar_t*	GetDocLineStrWithEOL(int* pnLen) const //###ä»®ã®åå‰ã€ä»®ã®å¯¾å‡¦
 	{
 		CLogicInt n;
 		const wchar_t* p = GetDocLineStrWithEOL(&n);
@@ -55,7 +55,7 @@ public:
 		return p;
 	}
 #endif
-	const wchar_t*	GetDocLineStrWithEOL(CLogicInt* pnLen) const //###‰¼‚Ì–¼‘OA‰¼‚Ì‘Îˆ
+	const wchar_t*	GetDocLineStrWithEOL(CLogicInt* pnLen) const //###ä»®ã®åå‰ã€ä»®ã®å¯¾å‡¦
 	{
 		if(this){
 			*pnLen = GetLengthWithEOL(); return GetPtr();
@@ -64,7 +64,7 @@ public:
 			*pnLen = 0; return NULL;
 		}
 	}
-	CStringRef GetStringRefWithEOL() const //###‰¼‚Ì–¼‘OA‰¼‚Ì‘Îˆ
+	CStringRef GetStringRefWithEOL() const //###ä»®ã®åå‰ã€ä»®ã®å¯¾å‡¦
 	{
 		if(this){
 			return CStringRef(GetPtr(),GetLengthWithEOL());
@@ -75,17 +75,17 @@ public:
 	}
 	const CEol& GetEol() const{ return m_cEol; }
 	void SetEol(const CEol& cEol, COpeBlk* pcOpeBlk);
-	void SetEol(); // Œ»İ‚Ìƒoƒbƒtƒ@‚©‚çİ’è
+	void SetEol(); // ç¾åœ¨ã®ãƒãƒƒãƒ•ã‚¡ã‹ã‚‰è¨­å®š
 
-	const CNativeW& _GetDocLineDataWithEOL() const { return m_cLine; } //###‰¼
+	const CNativeW& _GetDocLineDataWithEOL() const { return m_cLine; } //###ä»®
 	CNativeW& _GetDocLineData() { return m_cLine; }
 
-	//ƒf[ƒ^İ’è
+	//ãƒ‡ãƒ¼ã‚¿è¨­å®š
 	void SetDocLineString(const wchar_t* pData, int nLength);
 	void SetDocLineString(const CNativeW& cData);
 	void SetDocLineStringMove(CNativeW* pcData);
 
-	//ƒ`ƒF[ƒ“‘®«
+	//ãƒã‚§ãƒ¼ãƒ³å±æ€§
 	CDocLine* GetPrevLine(){ return m_pPrev; }
 	const CDocLine* GetPrevLine() const { return m_pPrev; }
 	CDocLine* GetNextLine(){ return m_pNext; }
@@ -95,18 +95,18 @@ public:
 	
 
 private: //####
-	CDocLine*	m_pPrev;	//!< ˆê‚Â‘O‚Ì—v‘f
-	CDocLine*	m_pNext;	//!< ˆê‚ÂŒã‚Ì—v‘f
+	CDocLine*	m_pPrev;	//!< ä¸€ã¤å‰ã®è¦ç´ 
+	CDocLine*	m_pNext;	//!< ä¸€ã¤å¾Œã®è¦ç´ 
 private:
-	CNativeW	m_cLine;	//!< ƒf[ƒ^  2007.10.11 kobake ƒ|ƒCƒ“ƒ^‚Å‚Í‚È‚­AÀ‘Ì‚ğ‚Â‚æ‚¤‚É•ÏX
-	CEol		m_cEol;		//!< s––ƒR[ƒh
+	CNativeW	m_cLine;	//!< ãƒ‡ãƒ¼ã‚¿  2007.10.11 kobake ãƒã‚¤ãƒ³ã‚¿ã§ã¯ãªãã€å®Ÿä½“ã‚’æŒã¤ã‚ˆã†ã«å¤‰æ›´
+	CEol		m_cEol;		//!< è¡Œæœ«ã‚³ãƒ¼ãƒ‰
 public:
-	//Šg’£î•ñ $$•ª—£’†
+	//æ‹¡å¼µæƒ…å ± $$åˆ†é›¢ä¸­
 	struct MarkType{
-		CLineModified	m_cModified;	//•ÏXƒtƒ‰ƒO
-		CLineBookmarked	m_cBookmarked;	//ƒuƒbƒNƒ}[ƒN
-		CLineFuncList	m_cFuncList;	//ŠÖ”ƒŠƒXƒgƒ}[ƒN
-		CLineDiffed		m_cDiffmarked;	//DIFF·•ªî•ñ
+		CLineModified	m_cModified;	//å¤‰æ›´ãƒ•ãƒ©ã‚°
+		CLineBookmarked	m_cBookmarked;	//ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯
+		CLineFuncList	m_cFuncList;	//é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯
+		CLineDiffed		m_cDiffmarked;	//DIFFå·®åˆ†æƒ…å ±
 	};
 	MarkType m_sMark;
 

--- a/sakura_core/doc/logic/CDocLineMgr.cpp
+++ b/sakura_core/doc/logic/CDocLineMgr.cpp
@@ -1,20 +1,20 @@
-/*!	@file
-	@brief sƒf[ƒ^‚ÌŠÇ—
+ï»¿/*!	@file
+	@brief è¡Œãƒ‡ãƒ¼ã‚¿ã®ç®¡ç†
 
 	@author Norio Nakatani
-	@date 1998/03/05  V‹Kì¬
-	@date 2001/06/23 N.Nakatani ’PŒê’PˆÊ‚ÅŒŸõ‚·‚é‹@”\‚ğÀ‘•
-	@date 2001/06/23 N.Nakatani WhereCurrentWord()•ÏX WhereCurrentWord_2‚ğƒR[ƒ‹‚·‚é‚æ‚¤‚É‚µ‚½
-	@date 2005/09/25 D.S.Koba GetSizeOfChar‚Å‘‚«Š·‚¦
+	@date 1998/03/05  æ–°è¦ä½œæˆ
+	@date 2001/06/23 N.Nakatani å˜èªå˜ä½ã§æ¤œç´¢ã™ã‚‹æ©Ÿèƒ½ã‚’å®Ÿè£…
+	@date 2001/06/23 N.Nakatani WhereCurrentWord()å¤‰æ›´ WhereCurrentWord_2ã‚’ã‚³ãƒ¼ãƒ«ã™ã‚‹ã‚ˆã†ã«ã—ãŸ
+	@date 2005/09/25 D.S.Koba GetSizeOfCharã§æ›¸ãæ›ãˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2000, genta, ao
 	Copyright (C) 2001, genta, jepro, hor
 	Copyright (C) 2002, hor, aroka, MIK, Moca, genta, frozen, Azumaiya, YAZAKI
-	Copyright (C) 2003, Moca, ryoji, genta, ‚©‚ë‚Æ
+	Copyright (C) 2003, Moca, ryoji, genta, ã‹ã‚ã¨
 	Copyright (C) 2004, genta, Moca
-	Copyright (C) 2005, D.S.Koba, ryoji, ‚©‚ë‚Æ
+	Copyright (C) 2005, D.S.Koba, ryoji, ã‹ã‚ã¨
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -26,12 +26,12 @@
 #include <io.h>
 #include <list>
 #include "CDocLineMgr.h"
-#include "CDocLine.h"// 2002/2/10 aroka ƒwƒbƒ_®—
+#include "CDocLine.h"// 2002/2/10 aroka ãƒ˜ãƒƒãƒ€æ•´ç†
 #include "charset/charcode.h"
 #include "charset/CCodeFactory.h"
 #include "charset/CCodeBase.h"
 #include "charset/CCodeMediator.h"
-//	Jun. 26, 2001 genta	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦
+//	Jun. 26, 2001 genta	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆ
 #include "extmodule/CBregexp.h"
 #include "_main/global.h"
 
@@ -48,7 +48,7 @@
 #include "debug/CRunningTimer.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//               ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^                  //
+//               ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿                  //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CDocLineMgr::CDocLineMgr()
@@ -64,11 +64,11 @@ CDocLineMgr::~CDocLineMgr()
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      sƒf[ƒ^‚ÌŠÇ—                         //
+//                      è¡Œãƒ‡ãƒ¼ã‚¿ã®ç®¡ç†                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
-//! pPos‚Ì’¼‘O‚ÉV‚µ‚¢s‚ğ‘}“ü
+//! pPosã®ç›´å‰ã«æ–°ã—ã„è¡Œã‚’æŒ¿å…¥
 CDocLine* CDocLineMgr::InsertNewLine(CDocLine* pPos)
 {
 	CDocLine* pcDocLineNew = new CDocLine;
@@ -76,7 +76,7 @@ CDocLine* CDocLineMgr::InsertNewLine(CDocLine* pPos)
 	return pcDocLineNew;
 }
 
-//! Å‰º•”‚ÉV‚µ‚¢s‚ğ‘}“ü
+//! æœ€ä¸‹éƒ¨ã«æ–°ã—ã„è¡Œã‚’æŒ¿å…¥
 CDocLine* CDocLineMgr::AddNewLine()
 {
 	CDocLine* pcDocLineNew = new CDocLine;
@@ -84,7 +84,7 @@ CDocLine* CDocLineMgr::AddNewLine()
 	return pcDocLineNew;
 }
 
-//! ‘S‚Ä‚Ìs‚ğíœ‚·‚é
+//! å…¨ã¦ã®è¡Œã‚’å‰Šé™¤ã™ã‚‹
 void CDocLineMgr::DeleteAllLine()
 {
 	CDocLine* pDocLine = m_pDocLineTop;
@@ -97,10 +97,10 @@ void CDocLineMgr::DeleteAllLine()
 }
 
 
-//! s‚Ìíœ
+//! è¡Œã®å‰Šé™¤
 void CDocLineMgr::DeleteLine( CDocLine* pcDocLineDel )
 {
-	//PrevØ‚è—£‚µ
+	//Prevåˆ‡ã‚Šé›¢ã—
 	if( pcDocLineDel->GetPrevLine() ){
 		pcDocLineDel->GetPrevLine()->m_pNext = pcDocLineDel->GetNextLine();
 	}
@@ -108,7 +108,7 @@ void CDocLineMgr::DeleteLine( CDocLine* pcDocLineDel )
 		m_pDocLineTop = pcDocLineDel->GetNextLine();
 	}
 
-	//NextØ‚è—£‚µ
+	//Nextåˆ‡ã‚Šé›¢ã—
 	if( pcDocLineDel->GetNextLine() ){
 		pcDocLineDel->m_pNext->m_pPrev = pcDocLineDel->GetPrevLine();
 	}
@@ -116,32 +116,32 @@ void CDocLineMgr::DeleteLine( CDocLine* pcDocLineDel )
 		m_pDocLineBot = pcDocLineDel->GetPrevLine();
 	}
 	
-	//QÆØ‚è—£‚µ
+	//å‚ç…§åˆ‡ã‚Šé›¢ã—
 	if( m_pCodePrevRefer == pcDocLineDel ){
 		m_pCodePrevRefer = pcDocLineDel->GetNextLine();
 	}
 
-	//ƒf[ƒ^íœ
+	//ãƒ‡ãƒ¼ã‚¿å‰Šé™¤
 	delete pcDocLineDel;
 
-	//s”Œ¸Z
+	//è¡Œæ•°æ¸›ç®—
 	m_nLines--;
 	if( CLogicInt(0) == m_nLines ){
-		// ƒf[ƒ^‚ª‚È‚­‚È‚Á‚½
+		// ãƒ‡ãƒ¼ã‚¿ãŒãªããªã£ãŸ
 		_Init();
 	}
 }
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                   sƒf[ƒ^‚Ö‚ÌƒAƒNƒZƒX                      //
+//                   è¡Œãƒ‡ãƒ¼ã‚¿ã¸ã®ã‚¢ã‚¯ã‚»ã‚¹                      //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /*!
-	w’è‚³‚ê‚½”Ô†‚Ìs‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğ•Ô‚·
+	æŒ‡å®šã•ã‚ŒãŸç•ªå·ã®è¡Œã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã™
 
-	@param nLine [in] s”Ô†
-	@return sƒIƒuƒWƒFƒNƒg‚Ö‚Ìƒ|ƒCƒ“ƒ^BŠY“–s‚ª‚È‚¢ê‡‚ÍNULLB
+	@param nLine [in] è¡Œç•ªå·
+	@return è¡Œã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã¸ã®ãƒã‚¤ãƒ³ã‚¿ã€‚è©²å½“è¡ŒãŒãªã„å ´åˆã¯NULLã€‚
 */
 const CDocLine* CDocLineMgr::GetLine( CLogicInt nLine ) const
 {
@@ -150,11 +150,11 @@ const CDocLine* CDocLineMgr::GetLine( CLogicInt nLine ) const
 	if( CLogicInt(0) == m_nLines ){
 		return NULL;
 	}
-	// 2004.03.28 Moca nLine‚ª•‰‚Ìê‡‚Ìƒ`ƒFƒbƒN‚ğ’Ç‰Á
+	// 2004.03.28 Moca nLineãŒè² ã®å ´åˆã®ãƒã‚§ãƒƒã‚¯ã‚’è¿½åŠ 
 	if( CLogicInt(0) > nLine || nLine >= m_nLines ){
 		return NULL;
 	}
-	// 2004.03.28 Moca m_pCodePrevRefer‚æ‚èATop,Bot‚Ì‚Ù‚¤‚ª‹ß‚¢ê‡‚ÍA‚»‚¿‚ç‚ğ—˜—p‚·‚é
+	// 2004.03.28 Moca m_pCodePrevReferã‚ˆã‚Šã€Top,Botã®ã»ã†ãŒè¿‘ã„å ´åˆã¯ã€ãã¡ã‚‰ã‚’åˆ©ç”¨ã™ã‚‹
 	CLogicInt nPrevToLineNumDiff = t_abs( m_nPrevReferLine - nLine );
 	if( m_pCodePrevRefer == NULL
 	  || nLine < nPrevToLineNumDiff
@@ -240,7 +240,7 @@ const CDocLine* CDocLineMgr::GetLine( CLogicInt nLine ) const
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         À‘••â•                            //
+//                         å®Ÿè£…è£œåŠ©                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void CDocLineMgr::_Init()
@@ -251,11 +251,11 @@ void CDocLineMgr::_Init()
 	m_nPrevReferLine = CLogicInt(0);
 	m_pCodePrevRefer = NULL;
 	m_pDocLineCurrent = NULL;
-	CDiffManager::getInstance()->SetDiffUse(false);	/* DIFFg—p’† */	//@@@ 2002.05.25 MIK     //##Œã‚ÅCDocListener::OnClear (OnAfterClose) ‚ğì¬‚µA‚»‚±‚ÉˆÚ“®
+	CDiffManager::getInstance()->SetDiffUse(false);	/* DIFFä½¿ç”¨ä¸­ */	//@@@ 2002.05.25 MIK     //##å¾Œã§CDocListener::OnClear (OnAfterClose) ã‚’ä½œæˆã—ã€ãã“ã«ç§»å‹•
 }
 
-// -- -- ƒ`ƒF[ƒ“ŠÖ” -- -- // 2007.10.11 kobake ì¬
-//!Å‰º•”‚É‘}“ü
+// -- -- ãƒã‚§ãƒ¼ãƒ³é–¢æ•° -- -- // 2007.10.11 kobake ä½œæˆ
+//!æœ€ä¸‹éƒ¨ã«æŒ¿å…¥
 void CDocLineMgr::_PushBottom(CDocLine* pDocLineNew)
 {
 	if( !m_pDocLineTop ){
@@ -272,13 +272,13 @@ void CDocLineMgr::_PushBottom(CDocLine* pDocLineNew)
 	++m_nLines;
 }
 
-//!pPos‚Ì’¼‘O‚É‘}“üBpPos‚ÉNULL‚ğw’è‚µ‚½ê‡‚ÍAÅ‰º•”‚É’Ç‰ÁB
+//!pPosã®ç›´å‰ã«æŒ¿å…¥ã€‚pPosã«NULLã‚’æŒ‡å®šã—ãŸå ´åˆã¯ã€æœ€ä¸‹éƒ¨ã«è¿½åŠ ã€‚
 void CDocLineMgr::_InsertBeforePos(CDocLine* pDocLineNew, CDocLine* pPos)
 {
-	//New.Next‚ğİ’è
+	//New.Nextã‚’è¨­å®š
 	pDocLineNew->m_pNext = pPos;
 
-	//New.Prev, Other.Prev‚ğİ’è
+	//New.Prev, Other.Prevã‚’è¨­å®š
 	if(pPos){
 		pDocLineNew->m_pPrev = pPos->GetPrevLine();
 		pPos->m_pPrev = pDocLineNew;
@@ -288,7 +288,7 @@ void CDocLineMgr::_InsertBeforePos(CDocLine* pDocLineNew, CDocLine* pPos)
 		m_pDocLineBot = pDocLineNew;
 	}
 
-	//Other.Next‚ğİ’è
+	//Other.Nextã‚’è¨­å®š
 	if( pDocLineNew->GetPrevLine() ){
 		pDocLineNew->GetPrevLine()->m_pNext = pDocLineNew;
 	}
@@ -296,17 +296,17 @@ void CDocLineMgr::_InsertBeforePos(CDocLine* pDocLineNew, CDocLine* pPos)
 		m_pDocLineTop = pDocLineNew;
 	}
 
-	//s”‚ğ‰ÁZ
+	//è¡Œæ•°ã‚’åŠ ç®—
 	++m_nLines;
 }
 
-//! pPos‚Ì’¼Œã‚É‘}“üBpPos‚ÉNULL‚ğw’è‚µ‚½ê‡‚ÍAæ“ª‚É’Ç‰ÁB
+//! pPosã®ç›´å¾Œã«æŒ¿å…¥ã€‚pPosã«NULLã‚’æŒ‡å®šã—ãŸå ´åˆã¯ã€å…ˆé ­ã«è¿½åŠ ã€‚
 void CDocLineMgr::_InsertAfterPos(CDocLine* pDocLineNew, CDocLine* pPos)
 {
-	//New.Prev‚ğİ’è
+	//New.Prevã‚’è¨­å®š
 	pDocLineNew->m_pPrev = pPos;
 
-	//New.Next, Other.Next‚ğİ’è
+	//New.Next, Other.Nextã‚’è¨­å®š
 	if( pPos ){
 		pDocLineNew->m_pNext = pPos->GetNextLine();
 		pPos->m_pNext = pDocLineNew;
@@ -316,7 +316,7 @@ void CDocLineMgr::_InsertAfterPos(CDocLine* pDocLineNew, CDocLine* pPos)
 		m_pDocLineTop = pDocLineNew;
 	}
 
-	//Other.Prev‚ğİ’è
+	//Other.Prevã‚’è¨­å®š
 	if( pDocLineNew->GetNextLine() ){
 		pDocLineNew->m_pNext->m_pPrev = pDocLineNew;
 	}
@@ -324,20 +324,20 @@ void CDocLineMgr::_InsertAfterPos(CDocLine* pDocLineNew, CDocLine* pPos)
 		m_pDocLineBot = pDocLineNew;
 	}
 
-	//s”‚ğ‰ÁZ
+	//è¡Œæ•°ã‚’åŠ ç®—
 	m_nLines++;
 }
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ƒfƒoƒbƒO                            //
+//                         ãƒ‡ãƒãƒƒã‚°                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*!	@brief CDocLineMgrDEBUG—p
+/*!	@brief CDocLineMgrDEBUGç”¨
 
 	@date 2004.03.18 Moca
-		m_pDocLineCurrent‚Æm_pCodePrevRefer‚ªƒf[ƒ^ƒ`ƒF[ƒ“‚Ì
-		—v‘f‚ğw‚µ‚Ä‚¢‚é‚©‚ÌŒŸØ‹@”\‚ğ’Ç‰ÁD
+		m_pDocLineCurrentã¨m_pCodePrevReferãŒãƒ‡ãƒ¼ã‚¿ãƒã‚§ãƒ¼ãƒ³ã®
+		è¦ç´ ã‚’æŒ‡ã—ã¦ã„ã‚‹ã‹ã®æ¤œè¨¼æ©Ÿèƒ½ã‚’è¿½åŠ ï¼
 
 */
 void CDocLineMgr::DUMP()
@@ -350,7 +350,7 @@ void CDocLineMgr::DUMP()
 	CDocLine* pDocLineEnd = NULL;
 	pDocLine = m_pDocLineTop;
 
-	// ³“–«‚ğ’²‚×‚é
+	// æ­£å½“æ€§ã‚’èª¿ã¹ã‚‹
 	bool bIncludeCurrent = false;
 	bool bIncludePrevRefer = false;
 	CLogicInt nNum = CLogicInt(0);

--- a/sakura_core/doc/logic/CDocLineMgr.h
+++ b/sakura_core/doc/logic/CDocLineMgr.h
@@ -1,10 +1,10 @@
-/*!	@file
-	@brief sƒf[ƒ^‚ÌŠÇ—
+ï»¿/*!	@file
+	@brief è¡Œãƒ‡ãƒ¼ã‚¿ã®ç®¡ç†
 
 	@author Norio Nakatani
-	@date 1998/3/5  V‹Kì¬
-	@date 2001/06/23 N.Nakatani WhereCurrentWord_2()’Ç‰Á staticƒƒ“ƒo
-	@date 2001/12/03 hor ‚µ‚¨‚è(bookmark)‹@”\’Ç‰Á‚É”º‚¤ŠÖ”’Ç‰Á
+	@date 1998/3/5  æ–°è¦ä½œæˆ
+	@date 2001/06/23 N.Nakatani WhereCurrentWord_2()è¿½åŠ  staticãƒ¡ãƒ³ãƒ
+	@date 2001/12/03 hor ã—ãŠã‚Š(bookmark)æ©Ÿèƒ½è¿½åŠ ã«ä¼´ã†é–¢æ•°è¿½åŠ 
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -30,70 +30,70 @@ class CDocLine; // 2002/2/10 aroka
 class CBregexp; // 2002/2/10 aroka
 
 struct DocLineReplaceArg {
-	CLogicRange		sDelRange;			//!< [in] íœ”ÍˆÍBƒƒWƒbƒN’PˆÊB
-	COpeLineData*	pcmemDeleted;		//!< [out] íœ‚³‚ê‚½ƒf[ƒ^‚ğ•Û‘¶
-	COpeLineData*	pInsData;			//!< [in,out] ‘}“ü‚·‚éƒf[ƒ^(’†g‚ªˆÚ“®‚·‚é)
-	CLogicInt		nDeletedLineNum;	//!< [out] íœ‚µ‚½s‚Ì‘”
-	CLogicInt		nInsLineNum;		//!< [out] ‘}“ü‚É‚æ‚Á‚Ä‘‚¦‚½s‚Ì”
-	CLogicPoint		ptNewPos;			//!< [out] ‘}“ü‚³‚ê‚½•”•ª‚ÌŸ‚ÌˆÊ’u
-	int				nDelSeq;			//!< [in] íœs‚ÌOpeƒV[ƒPƒ“ƒX
-	int				nInsSeq;			//!< [out] ‘}“üs‚ÌŒ³‚ÌƒV[ƒPƒ“ƒX
+	CLogicRange		sDelRange;			//!< [in] å‰Šé™¤ç¯„å›²ã€‚ãƒ­ã‚¸ãƒƒã‚¯å˜ä½ã€‚
+	COpeLineData*	pcmemDeleted;		//!< [out] å‰Šé™¤ã•ã‚ŒãŸãƒ‡ãƒ¼ã‚¿ã‚’ä¿å­˜
+	COpeLineData*	pInsData;			//!< [in,out] æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿(ä¸­èº«ãŒç§»å‹•ã™ã‚‹)
+	CLogicInt		nDeletedLineNum;	//!< [out] å‰Šé™¤ã—ãŸè¡Œã®ç·æ•°
+	CLogicInt		nInsLineNum;		//!< [out] æŒ¿å…¥ã«ã‚ˆã£ã¦å¢—ãˆãŸè¡Œã®æ•°
+	CLogicPoint		ptNewPos;			//!< [out] æŒ¿å…¥ã•ã‚ŒãŸéƒ¨åˆ†ã®æ¬¡ã®ä½ç½®
+	int				nDelSeq;			//!< [in] å‰Šé™¤è¡Œã®Opeã‚·ãƒ¼ã‚±ãƒ³ã‚¹
+	int				nInsSeq;			//!< [out] æŒ¿å…¥è¡Œã®å…ƒã®ã‚·ãƒ¼ã‚±ãƒ³ã‚¹
 };
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
-//2007.09.30 kobake WhereCurrentWord_2 ‚ğ CWordParse ‚ÉˆÚ“®
+//2007.09.30 kobake WhereCurrentWord_2 ã‚’ CWordParse ã«ç§»å‹•
 class CDocLineMgr{
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CDocLineMgr();
 	~CDocLineMgr();
 
-	//ó‘Ô
-	CLogicInt GetLineCount() const{ return m_nLines; }	//!< ‘Ss”‚ğ•Ô‚·
+	//çŠ¶æ…‹
+	CLogicInt GetLineCount() const{ return m_nLines; }	//!< å…¨è¡Œæ•°ã‚’è¿”ã™
 
-	//sƒf[ƒ^‚Ö‚ÌƒAƒNƒZƒX
-	const CDocLine* GetLine( CLogicInt nLine ) const;						//!< w’ès‚ğæ“¾
+	//è¡Œãƒ‡ãƒ¼ã‚¿ã¸ã®ã‚¢ã‚¯ã‚»ã‚¹
+	const CDocLine* GetLine( CLogicInt nLine ) const;						//!< æŒ‡å®šè¡Œã‚’å–å¾—
 	CDocLine* GetLine( CLogicInt nLine ){
 		return const_cast<CDocLine*>(const_cast<CDocLine*>(static_cast<const CDocLineMgr*>(this)->GetLine( nLine )));
 	}
-	const CDocLine* GetDocLineTop() const { return m_pDocLineTop; }		//!< æ“ªs‚ğæ“¾
-	CDocLine* GetDocLineTop() { return m_pDocLineTop; }		//!< æ“ªs‚ğæ“¾
-	const CDocLine* GetDocLineBottom() const { return m_pDocLineBot; }	//!< ÅIs‚ğæ“¾
-	CDocLine* GetDocLineBottom() { return m_pDocLineBot; }	//!< ÅIs‚ğæ“¾
+	const CDocLine* GetDocLineTop() const { return m_pDocLineTop; }		//!< å…ˆé ­è¡Œã‚’å–å¾—
+	CDocLine* GetDocLineTop() { return m_pDocLineTop; }		//!< å…ˆé ­è¡Œã‚’å–å¾—
+	const CDocLine* GetDocLineBottom() const { return m_pDocLineBot; }	//!< æœ€çµ‚è¡Œã‚’å–å¾—
+	CDocLine* GetDocLineBottom() { return m_pDocLineBot; }	//!< æœ€çµ‚è¡Œã‚’å–å¾—
 
-	//sƒf[ƒ^‚ÌŠÇ—
-	CDocLine* InsertNewLine(CDocLine* pPos);	//!< pPos‚Ì’¼‘O‚ÉV‚µ‚¢s‚ğ‘}“ü
-	CDocLine* AddNewLine();						//!< Å‰º•”‚ÉV‚µ‚¢s‚ğ‘}“ü
-	void DeleteAllLine();						//!< ‘S‚Ä‚Ìs‚ğíœ‚·‚é
-	void DeleteLine( CDocLine* );				//!< s‚Ìíœ
+	//è¡Œãƒ‡ãƒ¼ã‚¿ã®ç®¡ç†
+	CDocLine* InsertNewLine(CDocLine* pPos);	//!< pPosã®ç›´å‰ã«æ–°ã—ã„è¡Œã‚’æŒ¿å…¥
+	CDocLine* AddNewLine();						//!< æœ€ä¸‹éƒ¨ã«æ–°ã—ã„è¡Œã‚’æŒ¿å…¥
+	void DeleteAllLine();						//!< å…¨ã¦ã®è¡Œã‚’å‰Šé™¤ã™ã‚‹
+	void DeleteLine( CDocLine* );				//!< è¡Œã®å‰Šé™¤
 
-	//ƒfƒoƒbƒO
+	//ãƒ‡ãƒãƒƒã‚°
 	void DUMP();
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         À‘••â•                            //
+	//                         å®Ÿè£…è£œåŠ©                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 protected:
 	void _Init();
-	// -- -- ƒ`ƒF[ƒ“ŠÖ” -- -- // 2007.10.11 kobake ì¬
-	void _PushBottom(CDocLine* pDocLineNew);             //!< Å‰º•”‚É‘}“ü
-	void _InsertBeforePos(CDocLine* pDocLineNew, CDocLine* pPos); //!< pPos‚Ì’¼‘O‚É‘}“ü
-	void _InsertAfterPos(CDocLine* pDocLineNew, CDocLine* pPos); //!< pPos‚Ì’¼Œã‚É‘}“ü
+	// -- -- ãƒã‚§ãƒ¼ãƒ³é–¢æ•° -- -- // 2007.10.11 kobake ä½œæˆ
+	void _PushBottom(CDocLine* pDocLineNew);             //!< æœ€ä¸‹éƒ¨ã«æŒ¿å…¥
+	void _InsertBeforePos(CDocLine* pDocLineNew, CDocLine* pPos); //!< pPosã®ç›´å‰ã«æŒ¿å…¥
+	void _InsertAfterPos(CDocLine* pDocLineNew, CDocLine* pPos); //!< pPosã®ç›´å¾Œã«æŒ¿å…¥
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ƒƒ“ƒo•Ï”                           //
+	//                        ãƒ¡ãƒ³ãƒå¤‰æ•°                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 private:
-	CDocLine*	m_pDocLineTop;		//!< Å‰‚Ìs
-	CDocLine*	m_pDocLineBot;		//!< ÅŒã‚Ìs(¦1s‚µ‚©‚È‚¢ê‡‚Ím_pDocLineTop‚Æ“™‚µ‚­‚È‚é)
-	CLogicInt	m_nLines;			//!< ‘Ss”
+	CDocLine*	m_pDocLineTop;		//!< æœ€åˆã®è¡Œ
+	CDocLine*	m_pDocLineBot;		//!< æœ€å¾Œã®è¡Œ(â€»1è¡Œã—ã‹ãªã„å ´åˆã¯m_pDocLineTopã¨ç­‰ã—ããªã‚‹)
+	CLogicInt	m_nLines;			//!< å…¨è¡Œæ•°
 
 public:
-	//$$ kobake’: ˆÈ‰ºAâ‘Î‚ÉØ‚è—£‚µ‚½‚¢iÅ’áØ‚è—£‚¹‚È‚­‚Ä‚àA•Ï”‚ÌˆÓ–¡‚ğƒRƒƒ“ƒg‚Å–¾Šm‚É‹L‚·‚×‚«j•Ï”ŒQ
-	mutable CDocLine*	m_pDocLineCurrent;	//!< ‡ƒAƒNƒZƒX‚ÌŒ»İˆÊ’u
+	//$$ kobakeæ³¨: ä»¥ä¸‹ã€çµ¶å¯¾ã«åˆ‡ã‚Šé›¢ã—ãŸã„ï¼ˆæœ€ä½åˆ‡ã‚Šé›¢ã›ãªãã¦ã‚‚ã€å¤‰æ•°ã®æ„å‘³ã‚’ã‚³ãƒ¡ãƒ³ãƒˆã§æ˜ç¢ºã«è¨˜ã™ã¹ãï¼‰å¤‰æ•°ç¾¤
+	mutable CDocLine*	m_pDocLineCurrent;	//!< é †ã‚¢ã‚¯ã‚»ã‚¹æ™‚ã®ç¾åœ¨ä½ç½®
 	mutable CLogicInt	m_nPrevReferLine;
 	mutable CDocLine*	m_pCodePrevRefer;
 


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/doc
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h

cd sakura_core/doc/layout
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h

cd sakura_core/doc/logic
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。（※ただし本 PR におけるマルチバイト文字列リテラルは TRACE 部のみです）
