### PR TITLE
テキストの折り返し方法のデフォルトを 「折り返さない」に変更

### DIFF
--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -153,7 +153,7 @@ void _DefaultConfig(STypeConfig* pType)
 /* タイプ別設定の規定値 */
 /************************/
 
-	pType->m_nTextWrapMethod = WRAP_SETTING_WIDTH;	// テキストの折り返し方法		// 2008.05.30 nasukoji
+	pType->m_nTextWrapMethod = WRAP_NO_TEXT_WRAP;	// テキストの折り返し方法		// 2008.05.30 nasukoji
 	pType->m_nMaxLineKetas = CKetaXInt(MAXLINEKETAS);	/* 折り返し桁数 */
 	pType->m_nColumnSpace = 0;					/* 文字と文字の隙間 */
 	pType->m_nLineSpace = 1;					/* 行間のすきま */


### PR DESCRIPTION
#258: テキストの折り返し方法のデフォルトを 「折り返さない」に変更