### PR TITLE
docplus 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/docplus/CBookmarkManager.cpp
+++ b/sakura_core/docplus/CBookmarkManager.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "docplus/CBookmarkManager.h"
 #include "doc/logic/CDocLineMgr.h"
 #include "doc/logic/CDocLine.h"
@@ -9,7 +9,7 @@
 bool CBookmarkGetter::IsBookmarked() const{ return m_pcDocLine->m_sMark.m_cBookmarked; }
 void CBookmarkSetter::SetBookmark(bool bFlag){ m_pcDocLine->m_sMark.m_cBookmarked = bFlag; }
 
-//!ƒuƒbƒNƒ}[ƒN‚Ì‘S‰ğœ
+//!ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã®å…¨è§£é™¤
 /*
 	@date 2001.12.03 hor
 */
@@ -23,39 +23,39 @@ void CBookmarkManager::ResetAllBookMark( void )
 }
 
 
-//! ƒuƒbƒNƒ}[ƒNŒŸõ
+//! ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯æ¤œç´¢
 /*
 	@date 2001.12.03 hor
 */
 bool CBookmarkManager::SearchBookMark(
-	CLogicInt			nLineNum,		//!< ŒŸõŠJns
-	ESearchDirection	bPrevOrNext,	//!< ŒŸõ•ûŒü
-	CLogicInt*			pnLineNum 		//!< ƒ}ƒbƒ`s
+	CLogicInt			nLineNum,		//!< æ¤œç´¢é–‹å§‹è¡Œ
+	ESearchDirection	bPrevOrNext,	//!< æ¤œç´¢æ–¹å‘
+	CLogicInt*			pnLineNum 		//!< ãƒãƒƒãƒè¡Œ
 )
 {
 	CDocLine*	pDocLine;
 	CLogicInt	nLinePos=nLineNum;
 
-	// Œã•ûŒŸõ
+	// å¾Œæ–¹æ¤œç´¢
 	if( bPrevOrNext == SEARCH_BACKWARD ){
 		nLinePos--;
 		pDocLine = m_pcDocLineMgr->GetLine( nLinePos );
 		while( pDocLine ){
 			if(CBookmarkGetter(pDocLine).IsBookmarked()){
-				*pnLineNum = nLinePos;				/* ƒ}ƒbƒ`s */
+				*pnLineNum = nLinePos;				/* ãƒãƒƒãƒè¡Œ */
 				return true;
 			}
 			nLinePos--;
 			pDocLine = pDocLine->GetPrevLine();
 		}
 	}
-	// ‘O•ûŒŸõ
+	// å‰æ–¹æ¤œç´¢
 	else{
 		nLinePos++;
 		pDocLine = m_pcDocLineMgr->GetLine( nLinePos );
 		while( NULL != pDocLine ){
 			if(CBookmarkGetter(pDocLine).IsBookmarked()){
-				*pnLineNum = nLinePos;				/* ƒ}ƒbƒ`s */
+				*pnLineNum = nLinePos;				/* ãƒãƒƒãƒè¡Œ */
 				return true;
 			}
 			nLinePos++;
@@ -65,10 +65,10 @@ bool CBookmarkManager::SearchBookMark(
 	return false;
 }
 
-//! •¨—s”Ô†‚ÌƒŠƒXƒg‚©‚ç‚Ü‚Æ‚ß‚Äsƒ}[ƒN
+//! ç‰©ç†è¡Œç•ªå·ã®ãƒªã‚¹ãƒˆã‹ã‚‰ã¾ã¨ã‚ã¦è¡Œãƒãƒ¼ã‚¯
 /*
 	@date 2002.01.16 hor
-	@date 2014.04.24 Moca ver2 ·•ª32i”•û®‚É•ÏX
+	@date 2014.04.24 Moca ver2 å·®åˆ†32é€²æ•°æ–¹å¼ã«å¤‰æ›´
 */
 void CBookmarkManager::SetBookMarks( wchar_t* pMarkLines )
 {
@@ -78,9 +78,9 @@ void CBookmarkManager::SetBookMarks( wchar_t* pMarkLines )
 	p = pMarkLines;
 	if( p[0] == L':' ){
 		if( p[1] == L'0' ){
-			// ver2 Œ`® [0-9a-v] 0-31(I’[ƒo[ƒWƒ‡ƒ“) [w-zA-Z\+\-] 0-31
-			// 2”Ô–ÚˆÈ~‚ÍA”’l+1+‚Ğ‚Æ‚Â‘O‚Ì’l
-			// :00123x0 => 0,1,2,3,x0 => 0,(1+1),(2+2+1),(3+5+1),(32+9+1) => 0,2,5,9,42 => 1,3,6,10,43s–Ú
+			// ver2 å½¢å¼ [0-9a-v] 0-31(çµ‚ç«¯ãƒãƒ¼ã‚¸ãƒ§ãƒ³) [w-zA-Z\+\-] 0-31
+			// 2ç•ªç›®ä»¥é™ã¯ã€æ•°å€¤+1+ã²ã¨ã¤å‰ã®å€¤
+			// :00123x0 => 0,1,2,3,x0 => 0,(1+1),(2+2+1),(3+5+1),(32+9+1) => 0,2,5,9,42 => 1,3,6,10,43è¡Œç›®
 			// :0a => a, => 10, 11
 			p += 2;
 			int nLineNum = 0;
@@ -118,10 +118,10 @@ void CBookmarkManager::SetBookMarks( wchar_t* pMarkLines )
 				p++;
 			}
 		}else{
-			// •s–¾‚Èƒo[ƒWƒ‡ƒ“
+			// ä¸æ˜ãªãƒãƒ¼ã‚¸ãƒ§ãƒ³
 		}
 	}else{
-		// ‹ŒŒ`® s”Ô†,‹æØ‚è
+		// æ—§å½¢å¼ è¡Œç•ªå·,åŒºåˆ‡ã‚Š
 		while(wcstok(p, delim) != NULL) {
 			while(wcschr(delim, *p) != NULL)p++;
 			pCDocLine=m_pcDocLineMgr->GetLine( CLogicInt(_wtol(p)) );
@@ -132,15 +132,15 @@ void CBookmarkManager::SetBookMarks( wchar_t* pMarkLines )
 }
 
 
-//! sƒ}[ƒN‚³‚ê‚Ä‚é•¨—s”Ô†‚ÌƒŠƒXƒg‚ğì‚é
+//! è¡Œãƒãƒ¼ã‚¯ã•ã‚Œã¦ã‚‹ç‰©ç†è¡Œç•ªå·ã®ãƒªã‚¹ãƒˆã‚’ä½œã‚‹
 /*
 	@date 2002.01.16 hor
-	@date 2014.04.24 Moca ver2 ·•ª32i”•û®‚É•ÏX
+	@date 2014.04.24 Moca ver2 å·®åˆ†32é€²æ•°æ–¹å¼ã«å¤‰æ›´
 */
 LPCWSTR CBookmarkManager::GetBookMarks()
 {
 	const CDocLine*	pCDocLine;
-	static wchar_t szText[MAX_MARKLINES_LEN + 1];	//2002.01.17 // Feb. 17, 2003 genta static‚É
+	static wchar_t szText[MAX_MARKLINES_LEN + 1];	//2002.01.17 // Feb. 17, 2003 genta staticã«
 	wchar_t szBuff[10];
 	wchar_t szBuff2[10];
 	CLogicInt	nLinePos=CLogicInt(0);
@@ -201,7 +201,7 @@ LPCWSTR CBookmarkManager::GetBookMarks()
 
 
 
-//! ŒŸõğŒ‚ÉŠY“–‚·‚és‚ÉƒuƒbƒNƒ}[ƒN‚ğƒZƒbƒg‚·‚é
+//! æ¤œç´¢æ¡ä»¶ã«è©²å½“ã™ã‚‹è¡Œã«ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã‚’ã‚»ãƒƒãƒˆã™ã‚‹
 /*
 	@date 2002.01.16 hor
 */
@@ -214,14 +214,14 @@ void CBookmarkManager::MarkSearchWord(
 	const wchar_t*	pLine;
 	int			nLineLen;
 
-	/* 1==³‹K•\Œ» */
+	/* 1==æ­£è¦è¡¨ç¾ */
 	if( sSearchOption.bRegularExp ){
 		CBregexp*	pRegexp = pattern.GetRegexp();
 		pDocLine = m_pcDocLineMgr->GetLine( CLogicInt(0) );
 		while( pDocLine ){
 			if(!CBookmarkGetter(pDocLine).IsBookmarked()){
 				pLine = pDocLine->GetDocLineStrWithEOL( &nLineLen );
-				// 2005.03.19 ‚©‚ë‚Æ ‘O•ûˆê’vƒTƒ|[ƒg‚Ì‚½‚ß‚Ìƒƒ\ƒbƒh•ÏX
+				// 2005.03.19 ã‹ã‚ã¨ å‰æ–¹ä¸€è‡´ã‚µãƒãƒ¼ãƒˆã®ãŸã‚ã®ãƒ¡ã‚½ãƒƒãƒ‰å¤‰æ›´
 				if( pRegexp->Match( pLine, nLineLen, 0 ) ){
 					CBookmarkSetter(pDocLine).SetBookmark(true);
 				}
@@ -229,12 +229,12 @@ void CBookmarkManager::MarkSearchWord(
 			pDocLine = pDocLine->GetNextLine();
 		}
 	}
-	/* 1==’PŒê‚Ì‚İŒŸõ */
+	/* 1==å˜èªã®ã¿æ¤œç´¢ */
 	else if( sSearchOption.bWordOnly ){
 		const wchar_t*	pszPattern = pattern.GetKey();
 		const int	nPatternLen = pattern.GetLen();
-		// ŒŸõŒê‚ğ’PŒê‚É•ªŠ„‚µ‚Ä searchWords‚ÉŠi”[‚·‚éB
-		std::vector<std::pair<const wchar_t*, CLogicInt> > searchWords; // ’PŒê‚ÌŠJnˆÊ’u‚Æ’·‚³‚Ì”z—ñB
+		// æ¤œç´¢èªã‚’å˜èªã«åˆ†å‰²ã—ã¦ searchWordsã«æ ¼ç´ã™ã‚‹ã€‚
+		std::vector<std::pair<const wchar_t*, CLogicInt> > searchWords; // å˜èªã®é–‹å§‹ä½ç½®ã¨é•·ã•ã®é…åˆ—ã€‚
 		CSearchAgent::CreateWordList(searchWords, pszPattern, nPatternLen);
 
 		pDocLine = m_pcDocLineMgr->GetLine( CLogicInt(0) );
@@ -246,12 +246,12 @@ void CBookmarkManager::MarkSearchWord(
 					CBookmarkSetter(pDocLine).SetBookmark(true);
 				}
 			}
-			/* Ÿ‚Ìs‚ğŒ©‚És‚­ */
+			/* æ¬¡ã®è¡Œã‚’è¦‹ã«è¡Œã */
 			pDocLine = pDocLine->GetNextLine();
 		}
 	}
 	else{
-		/* ŒŸõğŒ‚Ìî•ñ */
+		/* æ¤œç´¢æ¡ä»¶ã®æƒ…å ± */
 		pDocLine = m_pcDocLineMgr->GetLine( CLogicInt(0) );
 		while( NULL != pDocLine ){
 			if(!CBookmarkGetter(pDocLine).IsBookmarked()){

--- a/sakura_core/docplus/CBookmarkManager.h
+++ b/sakura_core/docplus/CBookmarkManager.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -32,7 +32,7 @@ class CBregexp;
 
 #include "CSearchAgent.h"
 
-//! s‚É•t‰Á‚·‚éƒuƒbƒNƒ}[ƒNî•ñ
+//! è¡Œã«ä»˜åŠ ã™ã‚‹ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯æƒ…å ±
 class CLineBookmarked{
 public:
 	CLineBookmarked() : m_bBookmarked(false) { }
@@ -42,7 +42,7 @@ private:
 	bool m_bBookmarked;
 };
 
-//! s‚ÌƒuƒbƒNƒ}[ƒNî•ñ‚Ìæ“¾
+//! è¡Œã®ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯æƒ…å ±ã®å–å¾—
 class CBookmarkGetter{
 public:
 	CBookmarkGetter(const CDocLine* pcDocLine) : m_pcDocLine(pcDocLine) { }
@@ -51,7 +51,7 @@ private:
 	const CDocLine* m_pcDocLine;
 };
 
-//! s‚ÌƒuƒbƒNƒ}[ƒNî•ñ‚Ìæ“¾Eİ’è
+//! è¡Œã®ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯æƒ…å ±ã®å–å¾—ãƒ»è¨­å®š
 class CBookmarkSetter : public CBookmarkGetter{
 public:
 	CBookmarkSetter(CDocLine* pcDocLine) : CBookmarkGetter(pcDocLine), m_pcDocLine(pcDocLine) { }
@@ -60,16 +60,16 @@ private:
 	CDocLine* m_pcDocLine;
 };
 
-//! s‘S‘Ì‚ÌƒuƒbƒNƒ}[ƒNî•ñ‚ÌŠÇ—
+//! è¡Œå…¨ä½“ã®ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯æƒ…å ±ã®ç®¡ç†
 class CBookmarkManager{
 public:
 	CBookmarkManager(CDocLineMgr* pcDocLineMgr) : m_pcDocLineMgr(pcDocLineMgr) { }
 
-	void ResetAllBookMark();															//!< ƒuƒbƒNƒ}[ƒN‚Ì‘S‰ğœ
-	bool SearchBookMark( CLogicInt nLineNum, ESearchDirection , CLogicInt* pnLineNum );	//!< ƒuƒbƒNƒ}[ƒNŒŸõ
-	void SetBookMarks( wchar_t* );														//!< •¨—s”Ô†‚ÌƒŠƒXƒg‚©‚ç‚Ü‚Æ‚ß‚Äsƒ}[ƒN
-	LPCWSTR GetBookMarks();																//!< sƒ}[ƒN‚³‚ê‚Ä‚é•¨—s”Ô†‚ÌƒŠƒXƒg‚ğì‚é
-	void MarkSearchWord( const CSearchStringPattern& );			//!< ŒŸõğŒ‚ÉŠY“–‚·‚és‚ÉƒuƒbƒNƒ}[ƒN‚ğƒZƒbƒg‚·‚é
+	void ResetAllBookMark();															//!< ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã®å…¨è§£é™¤
+	bool SearchBookMark( CLogicInt nLineNum, ESearchDirection , CLogicInt* pnLineNum );	//!< ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯æ¤œç´¢
+	void SetBookMarks( wchar_t* );														//!< ç‰©ç†è¡Œç•ªå·ã®ãƒªã‚¹ãƒˆã‹ã‚‰ã¾ã¨ã‚ã¦è¡Œãƒãƒ¼ã‚¯
+	LPCWSTR GetBookMarks();																//!< è¡Œãƒãƒ¼ã‚¯ã•ã‚Œã¦ã‚‹ç‰©ç†è¡Œç•ªå·ã®ãƒªã‚¹ãƒˆã‚’ä½œã‚‹
+	void MarkSearchWord( const CSearchStringPattern& );			//!< æ¤œç´¢æ¡ä»¶ã«è©²å½“ã™ã‚‹è¡Œã«ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã‚’ã‚»ãƒƒãƒˆã™ã‚‹
 
 private:
 	CDocLineMgr* m_pcDocLineMgr;

--- a/sakura_core/docplus/CDiffManager.cpp
+++ b/sakura_core/docplus/CDiffManager.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "docplus/CDiffManager.h"
 #include "types/CTypeSupport.h"
 #include "window/CEditWnd.h"
@@ -9,32 +9,32 @@
 
 EDiffMark CDiffLineGetter::GetLineDiffMark() const{ return (EDiffMark)m_pcDocLine->m_sMark.m_cDiffmarked; }
 
-/*! s‚Ì·•ªƒ}[ƒN‚É‘Î‰‚µ‚½F‚ğ•Ô‚· -> pnColorIndex
+/*! è¡Œã®å·®åˆ†ãƒãƒ¼ã‚¯ã«å¯¾å¿œã—ãŸè‰²ã‚’è¿”ã™ -> pnColorIndex
 	
-	Fİ’è‚ª–³‚¢ê‡‚Í pnColorIndex ‚ğ•ÏX‚¹‚¸‚É false ‚ğ•Ô‚·B	
+	è‰²è¨­å®šãŒç„¡ã„å ´åˆã¯ pnColorIndex ã‚’å¤‰æ›´ã›ãšã« false ã‚’è¿”ã™ã€‚	
 */
 bool CDiffLineGetter::GetDiffColor(EColorIndexType* pnColorIndex) const
 {
 	EDiffMark type = GetLineDiffMark();
 	CEditView* pView = &CEditWnd::getInstance()->GetActiveView();
 
-	//DIFF·•ªƒ}[ƒN•\¦	//@@@ 2002.05.25 MIK
+	//DIFFå·®åˆ†ãƒãƒ¼ã‚¯è¡¨ç¤º	//@@@ 2002.05.25 MIK
 	if( type ){
 		switch( type ){
-		case MARK_DIFF_APPEND:	//’Ç‰Á
+		case MARK_DIFF_APPEND:	//è¿½åŠ 
 			if( CTypeSupport(pView,COLORIDX_DIFF_APPEND).IsDisp() ){
 				*pnColorIndex = COLORIDX_DIFF_APPEND;
 				return true;
 			}
 			break;
-		case MARK_DIFF_CHANGE:	//•ÏX
+		case MARK_DIFF_CHANGE:	//å¤‰æ›´
 			if( CTypeSupport(pView,COLORIDX_DIFF_CHANGE).IsDisp() ){
 				*pnColorIndex = COLORIDX_DIFF_CHANGE;
 				return true;
 			}
 			break;
-		case MARK_DIFF_DELETE:	//íœ
-		case MARK_DIFF_DEL_EX:	//íœ
+		case MARK_DIFF_DELETE:	//å‰Šé™¤
+		case MARK_DIFF_DEL_EX:	//å‰Šé™¤
 			if( CTypeSupport(pView,COLORIDX_DIFF_DELETE).IsDisp() ){
 				*pnColorIndex = COLORIDX_DIFF_DELETE;
 				return true;
@@ -46,15 +46,15 @@ bool CDiffLineGetter::GetDiffColor(EColorIndexType* pnColorIndex) const
 }
 
 
-/*! DIFFƒ}[ƒN•`‰æ
+/*! DIFFãƒãƒ¼ã‚¯æç”»
 
-	ˆø”‚Í‰¼Bi–³‘Ê‚Èˆø”‚ ‚è‚»‚¤j
+	å¼•æ•°ã¯ä»®ã€‚ï¼ˆç„¡é§„ãªå¼•æ•°ã‚ã‚Šãã†ï¼‰
 */
 bool CDiffLineGetter::DrawDiffMark(CGraphics& gr, int y, int nLineHeight, COLORREF color) const
 {
 	EDiffMark type = GetLineDiffMark();
 
-	if( type )	//DIFF·•ªƒ}[ƒN•\¦	//@@@ 2002.05.25 MIK
+	if( type )	//DIFFå·®åˆ†ãƒãƒ¼ã‚¯è¡¨ç¤º	//@@@ 2002.05.25 MIK
 	{
 		int	cy = y + nLineHeight / 2;
 
@@ -62,21 +62,21 @@ bool CDiffLineGetter::DrawDiffMark(CGraphics& gr, int y, int nLineHeight, COLORR
 
 		switch( type )
 		{
-		case MARK_DIFF_APPEND:	//’Ç‰Á
+		case MARK_DIFF_APPEND:	//è¿½åŠ 
 			::MoveToEx( gr, 3, cy, NULL );
 			::LineTo  ( gr, 6, cy );
 			::MoveToEx( gr, 4, cy - 2, NULL );
 			::LineTo  ( gr, 4, cy + 3 );
 			break;
 
-		case MARK_DIFF_CHANGE:	//•ÏX
+		case MARK_DIFF_CHANGE:	//å¤‰æ›´
 			::MoveToEx( gr, 3, cy - 4, NULL );
 			::LineTo  ( gr, 3, cy );
 			::MoveToEx( gr, 3, cy + 2, NULL );
 			::LineTo  ( gr, 3, cy + 3 );
 			break;
 
-		case MARK_DIFF_DELETE:	//íœ
+		case MARK_DIFF_DELETE:	//å‰Šé™¤
 			cy -= 3;
 			::MoveToEx( gr, 3, cy, NULL );
 			::LineTo  ( gr, 5, cy );
@@ -85,7 +85,7 @@ bool CDiffLineGetter::DrawDiffMark(CGraphics& gr, int y, int nLineHeight, COLORR
 			::LineTo  ( gr, 7, cy + 4 );
 			break;
 		
-		case MARK_DIFF_DEL_EX:	//íœ(EOF)
+		case MARK_DIFF_DEL_EX:	//å‰Šé™¤(EOF)
 			cy += 3;
 			::MoveToEx( gr, 3, cy, NULL );
 			::LineTo  ( gr, 5, cy );
@@ -113,7 +113,7 @@ void CDiffLineSetter::SetLineDiffMark(EDiffMark mark){ m_pcDocLine->m_sMark.m_cD
 //                       CDiffLineMgr                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*!	·•ª•\¦‚Ì‘S‰ğœ
+/*!	å·®åˆ†è¡¨ç¤ºã®å…¨è§£é™¤
 	@author	MIK
 	@date	2002.05.25
 */
@@ -129,19 +129,19 @@ void CDiffLineMgr::ResetAllDiffMark()
 	CDiffManager::getInstance()->SetDiffUse(false);
 }
 
-/*! ·•ªŒŸõ
+/*! å·®åˆ†æ¤œç´¢
 	@author	MIK
 	@date	2002.05.25
 */
 bool CDiffLineMgr::SearchDiffMark(
-	CLogicInt			nLineNum,		//!< ŒŸõŠJns
-	ESearchDirection	bPrevOrNext,	//!< ŒŸõ•ûŒü
-	CLogicInt*			pnLineNum 		//!< ƒ}ƒbƒ`s
+	CLogicInt			nLineNum,		//!< æ¤œç´¢é–‹å§‹è¡Œ
+	ESearchDirection	bPrevOrNext,	//!< æ¤œç´¢æ–¹å‘
+	CLogicInt*			pnLineNum 		//!< ãƒãƒƒãƒè¡Œ
 )
 {
 	CLogicInt	nLinePos = nLineNum;
 
-	// Œã•ûŒŸõ
+	// å¾Œæ–¹æ¤œç´¢
 	if( bPrevOrNext == SEARCH_BACKWARD )
 	{
 		nLinePos--;
@@ -150,14 +150,14 @@ bool CDiffLineMgr::SearchDiffMark(
 		{
 			if( CDiffLineGetter(pDocLine).GetLineDiffMark() != 0 )
 			{
-				*pnLineNum = nLinePos;				/* ƒ}ƒbƒ`s */
+				*pnLineNum = nLinePos;				/* ãƒãƒƒãƒè¡Œ */
 				return true;
 			}
 			nLinePos--;
 			pDocLine = pDocLine->GetPrevLine();
 		}
 	}
-	// ‘O•ûŒŸõ
+	// å‰æ–¹æ¤œç´¢
 	else
 	{
 		nLinePos++;
@@ -166,7 +166,7 @@ bool CDiffLineMgr::SearchDiffMark(
 		{
 			if( CDiffLineGetter(pDocLine).GetLineDiffMark() != 0 )
 			{
-				*pnLineNum = nLinePos;				/* ƒ}ƒbƒ`s */
+				*pnLineNum = nLinePos;				/* ãƒãƒƒãƒè¡Œ */
 				return true;
 			}
 			nLinePos++;
@@ -176,7 +176,7 @@ bool CDiffLineMgr::SearchDiffMark(
 	return false;
 }
 
-/*!	·•ªî•ñ‚ğs”ÍˆÍw’è‚Å“o˜^‚·‚éB
+/*!	å·®åˆ†æƒ…å ±ã‚’è¡Œç¯„å›²æŒ‡å®šã§ç™»éŒ²ã™ã‚‹ã€‚
 	@author	MIK
 	@date	2002/05/25
 */
@@ -186,7 +186,7 @@ void CDiffLineMgr::SetDiffMarkRange( EDiffMark nMode, CLogicInt nStartLine, CLog
 
 	if( nStartLine < CLogicInt(0) ) nStartLine = CLogicInt(0);
 
-	//ÅIs‚æ‚èŒã‚Éíœs‚ ‚è
+	//æœ€çµ‚è¡Œã‚ˆã‚Šå¾Œã«å‰Šé™¤è¡Œã‚ã‚Š
 	CLogicInt	nLines = m_pcDocLineMgr->GetLineCount();
 	if( nLines <= nEndLine )
 	{
@@ -195,7 +195,7 @@ void CDiffLineMgr::SetDiffMarkRange( EDiffMark nMode, CLogicInt nStartLine, CLog
 		if( pCDocLine ) CDiffLineSetter(pCDocLine).SetLineDiffMark(MARK_DIFF_DEL_EX);
 	}
 
-	//s”ÍˆÍ‚Éƒ}[ƒN‚ğ‚Â‚¯‚é
+	//è¡Œç¯„å›²ã«ãƒãƒ¼ã‚¯ã‚’ã¤ã‘ã‚‹
 	for( CLogicInt i = nStartLine; i <= nEndLine; i++ )
 	{
 		CDocLine*	pCDocLine = m_pcDocLineMgr->GetLine( i );

--- a/sakura_core/docplus/CDiffManager.h
+++ b/sakura_core/docplus/CDiffManager.h
@@ -1,5 +1,5 @@
-//@@@ 2002.05.25 MIK
-//2008.02.23 kobake ‘å®—
+ï»¿//@@@ 2002.05.25 MIK
+//2008.02.23 kobake å¤§æ•´ç†
 /*
 	Copyright (C) 2008, kobake
 
@@ -33,29 +33,29 @@ class CDocLine;
 class CDocLineMgr;
 class CGraphics;
 
-//! DIFFî•ñ’è”
+//! DIFFæƒ…å ±å®šæ•°
 enum EDiffMark{
-	MARK_DIFF_NONE		= 0,	//!< –³•ÏX
-	MARK_DIFF_APPEND	= 1,	//!< ’Ç‰Á
-	MARK_DIFF_CHANGE	= 2,	//!< •ÏX
-	MARK_DIFF_DELETE	= 3,	//!< íœ
-	MARK_DIFF_DEL_EX	= 4,	//!< íœ(EOFˆÈ~)
+	MARK_DIFF_NONE		= 0,	//!< ç„¡å¤‰æ›´
+	MARK_DIFF_APPEND	= 1,	//!< è¿½åŠ 
+	MARK_DIFF_CHANGE	= 2,	//!< å¤‰æ›´
+	MARK_DIFF_DELETE	= 3,	//!< å‰Šé™¤
+	MARK_DIFF_DEL_EX	= 4,	//!< å‰Šé™¤(EOFä»¥é™)
 };
 
-//! DIFF‹““®‚ÌŠÇ—
+//! DIFFæŒ™å‹•ã®ç®¡ç†
 class CDiffManager : public TSingleton<CDiffManager>{
 	friend class TSingleton<CDiffManager>;
 	CDiffManager(){}
 
 public:
 	void SetDiffUse(bool b){ m_bIsDiffUse = b; }
-	bool IsDiffUse() const{ return m_bIsDiffUse; }		//!< DIFFg—p’†
+	bool IsDiffUse() const{ return m_bIsDiffUse; }		//!< DIFFä½¿ç”¨ä¸­
 
 private:
-	bool	m_bIsDiffUse;		//!< DIFF·•ª•\¦À{’† @@@ 2002.05.25 MIK
+	bool	m_bIsDiffUse;		//!< DIFFå·®åˆ†è¡¨ç¤ºå®Ÿæ–½ä¸­ @@@ 2002.05.25 MIK
 };
 
-//! s‚É•t‰Á‚·‚éDIFFî•ñ
+//! è¡Œã«ä»˜åŠ ã™ã‚‹DIFFæƒ…å ±
 class CLineDiffed{
 public:
 	CLineDiffed() : m_nDiffed(MARK_DIFF_NONE) { }
@@ -65,7 +65,7 @@ private:
 	EDiffMark m_nDiffed;
 };
 
-//! s‚ÌDIFFî•ñæ“¾
+//! è¡Œã®DIFFæƒ…å ±å–å¾—
 class CDiffLineGetter{
 public:
 	CDiffLineGetter(const CDocLine* pcDocLine) : m_pcDocLine(pcDocLine) { }
@@ -76,7 +76,7 @@ private:
 	const CDocLine* m_pcDocLine;
 };
 
-//! s‚ÌDIFFî•ñİ’è
+//! è¡Œã®DIFFæƒ…å ±è¨­å®š
 class CDiffLineSetter{
 public:
 	CDiffLineSetter(CDocLine* pcDocLine) : m_pcDocLine(pcDocLine) { }
@@ -85,13 +85,13 @@ private:
 	CDocLine* m_pcDocLine;
 };
 
-//! s‘S‘Ì‚ÌDIFFî•ñŠÇ—
+//! è¡Œå…¨ä½“ã®DIFFæƒ…å ±ç®¡ç†
 class CDiffLineMgr{
 public:
 	CDiffLineMgr(CDocLineMgr* pcDocLineMgr) : m_pcDocLineMgr(pcDocLineMgr) { }
-	void ResetAllDiffMark();															//!< ·•ª•\¦‚Ì‘S‰ğœ
-	bool SearchDiffMark( CLogicInt , ESearchDirection , CLogicInt* );					//!< ·•ªŒŸõ
-	void SetDiffMarkRange( EDiffMark nMode, CLogicInt nStartLine, CLogicInt nEndLine );	//!< ·•ª”ÍˆÍ‚Ì“o˜^
+	void ResetAllDiffMark();															//!< å·®åˆ†è¡¨ç¤ºã®å…¨è§£é™¤
+	bool SearchDiffMark( CLogicInt , ESearchDirection , CLogicInt* );					//!< å·®åˆ†æ¤œç´¢
+	void SetDiffMarkRange( EDiffMark nMode, CLogicInt nStartLine, CLogicInt nEndLine );	//!< å·®åˆ†ç¯„å›²ã®ç™»éŒ²
 private:
 	CDocLineMgr* m_pcDocLineMgr;
 };

--- a/sakura_core/docplus/CFuncListManager.cpp
+++ b/sakura_core/docplus/CFuncListManager.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2014, Moca
 
@@ -41,38 +41,38 @@ void CFuncListManager::SetLineFuncList(CDocLine* pcDocLine, bool bFlag)
 	pcDocLine->m_sMark.m_cFuncList = bFlag;
 }
 
-/*! ·•ªŒŸõ
+/*! å·®åˆ†æ¤œç´¢
 	@author	MIK
 	@date	2002.05.25
 */
 bool CFuncListManager::SearchFuncListMark(
 	const CDocLineMgr*	pcDocLineMgr,
-	CLogicInt			nLineNum,		//!< ŒŸõŠJns
-	ESearchDirection	bPrevOrNext,	//!< ŒŸõ•ûŒü
-	CLogicInt*			pnLineNum 		//!< ƒ}ƒbƒ`s
+	CLogicInt			nLineNum,		//!< æ¤œç´¢é–‹å§‹è¡Œ
+	ESearchDirection	bPrevOrNext,	//!< æ¤œç´¢æ–¹å‘
+	CLogicInt*			pnLineNum 		//!< ãƒãƒƒãƒè¡Œ
 ) const
 {
 	CLogicInt	nLinePos = nLineNum;
 
 	if( bPrevOrNext == SEARCH_BACKWARD ){
-		//Œã•ûŒŸõ(ª)
+		//å¾Œæ–¹æ¤œç´¢(â†‘)
 		nLinePos--;
 		const CDocLine*	pDocLine = pcDocLineMgr->GetLine( nLinePos );
 		while( pDocLine ){
 			if( GetLineFuncList(pDocLine) ){
-				*pnLineNum = nLinePos;				/* ƒ}ƒbƒ`s */
+				*pnLineNum = nLinePos;				/* ãƒãƒƒãƒè¡Œ */
 				return true;
 			}
 			nLinePos--;
 			pDocLine = pDocLine->GetPrevLine();
 		}
 	}else{
-		//‘O•ûŒŸõ(«)
+		//å‰æ–¹æ¤œç´¢(â†“)
 		nLinePos++;
 		const CDocLine*	pDocLine = pcDocLineMgr->GetLine( nLinePos );
 		while( pDocLine ){
 			if( GetLineFuncList(pDocLine) ){
-				*pnLineNum = nLinePos;				/* ƒ}ƒbƒ`s */
+				*pnLineNum = nLinePos;				/* ãƒãƒƒãƒè¡Œ */
 				return true;
 			}
 			nLinePos++;
@@ -82,7 +82,7 @@ bool CFuncListManager::SearchFuncListMark(
 	return false;
 }
 
-/* ŠÖ”ƒŠƒXƒgƒ}[ƒN‚ğ‚·‚×‚ÄƒŠƒZƒbƒg */
+/* é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯ã‚’ã™ã¹ã¦ãƒªã‚»ãƒƒãƒˆ */
 void CFuncListManager::ResetAllFucListMark(CDocLineMgr* pcDocLineMgr, bool bFlag)
 {
 	CDocLine* pDocLine = pcDocLineMgr->GetDocLineTop();

--- a/sakura_core/docplus/CFuncListManager.h
+++ b/sakura_core/docplus/CFuncListManager.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2014, Moca
 
@@ -28,7 +28,7 @@
 class CDocLine;
 class CDocLineMgr;
 
-//! s‚É•t‰Á‚·‚éModifiedî•ñ
+//! è¡Œã«ä»˜åŠ ã™ã‚‹Modifiedæƒ…å ±
 class CLineFuncList{
 public:
 	CLineFuncList() : m_bFuncList(false) { }
@@ -42,17 +42,17 @@ private:
 	bool m_bFuncList;
 };
 
-//! s‘S‘Ì‚ÌFuncListî•ñƒAƒNƒZƒT
+//! è¡Œå…¨ä½“ã®FuncListæƒ…å ±ã‚¢ã‚¯ã‚»ã‚µ
 class CFuncListManager{
 public:
-	//ó‘Ô
+	//çŠ¶æ…‹
 	bool IsLineFuncList(const CDocLine* pcDocLine, bool bFlag) const;
 	bool GetLineFuncList(const CDocLine* pcDocLine) const;
 	void SetLineFuncList(CDocLine* pcDocLine, bool bFlag);
-	bool SearchFuncListMark(const CDocLineMgr*, CLogicInt, ESearchDirection, CLogicInt* ) const;					//!< ŠÖ”ƒŠƒXƒgƒ}[ƒNŒŸõ
+	bool SearchFuncListMark(const CDocLineMgr*, CLogicInt, ESearchDirection, CLogicInt* ) const;					//!< é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯æ¤œç´¢
 
-	//ˆêŠ‡‘€ì
-	void ResetAllFucListMark(CDocLineMgr* pcDocLineMgr, bool bFlag);	// ŠÖ”ƒŠƒXƒgƒ}[ƒN‚ğ‚·‚×‚ÄƒŠƒZƒbƒg
+	//ä¸€æ‹¬æ“ä½œ
+	void ResetAllFucListMark(CDocLineMgr* pcDocLineMgr, bool bFlag);	// é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯ã‚’ã™ã¹ã¦ãƒªã‚»ãƒƒãƒˆ
 };
 
 #endif /* SAKURA_CFUNCLISTMANAGER_H_ */

--- a/sakura_core/docplus/CModifyManager.cpp
+++ b/sakura_core/docplus/CModifyManager.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "docplus/CModifyManager.h"
 #include "doc/CEditDoc.h"
 #include "doc/logic/CDocLineMgr.h"
@@ -9,7 +9,7 @@ void CModifyManager::OnAfterSave(const SSaveInfo& sSaveInfo)
 {
 	CEditDoc* pcDoc = GetListeningDoc();
 
-	// �s�ύX��Ԃ����ׂă��Z�b�g
+	// 行変更状態をすべてリセット
 	CModifyVisitor().ResetAllModifyFlag(&pcDoc->m_cDocLineMgr, pcDoc->m_cDocEditor.m_cOpeBuf.GetCurrentPointer());
 }
 
@@ -28,19 +28,19 @@ void CModifyVisitor::SetLineModified(CDocLine* pcDocLine, int seq)
 	pcDocLine->m_sMark.m_cModified = seq;
 }
 
-/* �s�ύX��Ԃ����ׂă��Z�b�g */
+/* 行変更状態をすべてリセット */
 /*
-  �E�ύX�t���OCDocLine�I�u�W�F�N�g�쐬���ɂ�TRUE�ł���
-  �E�ύX�񐔂�CDocLine�I�u�W�F�N�g�쐬���ɂ�1�ł���
+  ・変更フラグCDocLineオブジェクト作成時にはTRUEである
+  ・変更回数はCDocLineオブジェクト作成時には1である
 
-  �t�@�C����ǂݍ��񂾂Ƃ��͕ύX�t���O�� FALSE�ɂ���
-  �t�@�C����ǂݍ��񂾂Ƃ��͕ύX�񐔂� 0�ɂ���
+  ファイルを読み込んだときは変更フラグを FALSEにする
+  ファイルを読み込んだときは変更回数を 0にする
 
-  �t�@�C�����㏑���������͕ύX�t���O�� FALSE�ɂ���
-  �t�@�C�����㏑���������͕ύX�񐔂͕ς��Ȃ�
+  ファイルを上書きした時は変更フラグを FALSEにする
+  ファイルを上書きした時は変更回数は変えない
 
-  �ύX�񐔂�Undo�����Ƃ���-1�����
-  �ύX�񐔂�0�ɂȂ����ꍇ�͕ύX�t���O��FALSE�ɂ���
+  変更回数はUndoしたときに-1される
+  変更回数が0になった場合は変更フラグをFALSEにする
 */
 void CModifyVisitor::ResetAllModifyFlag(CDocLineMgr* pcDocLineMgr, int seq)
 {

--- a/sakura_core/docplus/CModifyManager.h
+++ b/sakura_core/docplus/CModifyManager.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -30,7 +30,7 @@
 class CDocLine;
 class CDocLineMgr;
 
-//! ModifiedŠÇ—
+//! Modifiedç®¡ç†
 class CModifyManager : public TSingleton<CModifyManager>, public CDocListenerEx{
 	friend class TSingleton<CModifyManager>;
 	CModifyManager(){}
@@ -40,7 +40,7 @@ public:
 
 };
 
-//! s‚É•t‰Á‚·‚éModifiedî•ñ
+//! è¡Œã«ä»˜åŠ ã™ã‚‹Modifiedæƒ…å ±
 class CLineModified{
 public:
 	CLineModified() : m_nModifiedSeq(0) { }
@@ -54,16 +54,16 @@ private:
 	int m_nModifiedSeq;
 };
 
-//! s‘S‘Ì‚ÌModifiedî•ñƒAƒNƒZƒT
+//! è¡Œå…¨ä½“ã®Modifiedæƒ…å ±ã‚¢ã‚¯ã‚»ã‚µ
 class CModifyVisitor{
 public:
-	//ó‘Ô
+	//çŠ¶æ…‹
 	bool IsLineModified(const CDocLine* pcDocLine, int nSaveSeq) const;
 	int GetLineModifiedSeq(const CDocLine* pcDocLine) const;
 	void SetLineModified(CDocLine* pcDocLine, int nModifiedSeq);
 
-	//ˆêŠ‡‘€ì
-	void ResetAllModifyFlag(CDocLineMgr* pcDocLineMgr, int nSeq);	// s•ÏXó‘Ô‚ğ‚·‚×‚ÄƒŠƒZƒbƒg
+	//ä¸€æ‹¬æ“ä½œ
+	void ResetAllModifyFlag(CDocLineMgr* pcDocLineMgr, int nSeq);	// è¡Œå¤‰æ›´çŠ¶æ…‹ã‚’ã™ã¹ã¦ãƒªã‚»ãƒƒãƒˆ
 };
 
 #endif /* SAKURA_CMODIFYMANAGER_5129DDF8_A336_4B65_914B_22E626B7B520_H_ */


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/docplus
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112
