### PR TITLE
env 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/env/CAppNodeManager.cpp
+++ b/sakura_core/env/CAppNodeManager.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒm[ƒhƒ}ƒl[ƒWƒƒ
+ï»¿/*!	@file
+	@brief ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ãƒãƒ¼ãƒ‰ãƒãƒãƒ¼ã‚¸ãƒ£
 
 	@author kobake
 */
@@ -40,68 +40,68 @@
 #include "_main/CMutex.h"
 
 
-// GetOpenedWindowArr—pÃ“I•Ï”^\‘¢‘Ì
-static BOOL s_bSort;	// ƒ\[ƒgw’è
-static BOOL s_bGSort;	// ƒOƒ‹[ƒvw’è
+// GetOpenedWindowArrç”¨é™çš„å¤‰æ•°ï¼æ§‹é€ ä½“
+static BOOL s_bSort;	// ã‚½ãƒ¼ãƒˆæŒ‡å®š
+static BOOL s_bGSort;	// ã‚°ãƒ«ãƒ¼ãƒ—æŒ‡å®š
 
-/*! @brief CShareData::m_pEditArr•ÛŒì—pMutex
+/*! @brief CShareData::m_pEditArrä¿è­·ç”¨Mutex
 
-	•¡”‚ÌƒGƒfƒBƒ^‚ª”ñ“¯Šú‚ÉˆêÄ“®ì‚µ‚Ä‚¢‚é‚Æ‚«‚Å‚àACShareData::m_pEditArr‚ğ
-	ˆÀ‘S‚É‘€ì‚Å‚«‚é‚æ‚¤‘€ì’†‚ÍMutex‚ğLock()‚·‚éB
+	è¤‡æ•°ã®ã‚¨ãƒ‡ã‚£ã‚¿ãŒéåŒæœŸã«ä¸€æ–‰å‹•ä½œã—ã¦ã„ã‚‹ã¨ãã§ã‚‚ã€CShareData::m_pEditArrã‚’
+	å®‰å…¨ã«æ“ä½œã§ãã‚‹ã‚ˆã†æ“ä½œä¸­ã¯Mutexã‚’Lock()ã™ã‚‹ã€‚
 
-	@pari”ñ“¯ŠúˆêÄ“®ì‚Ì—áj
-		‘½”‚ÌƒEƒBƒ“ƒhƒE‚ğ•\¦‚µ‚Ä‚¢‚ÄƒOƒ‹[ƒv‰»‚ğ—LŒø‚É‚µ‚½ƒ^ƒXƒNƒo[‚ÅuƒOƒ‹[ƒv‚ğ•Â‚¶‚év‘€ì‚ğ‚µ‚½‚Æ‚«
+	@parï¼ˆéåŒæœŸä¸€æ–‰å‹•ä½œã®ä¾‹ï¼‰
+		å¤šæ•°ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¡¨ç¤ºã—ã¦ã„ã¦ã‚°ãƒ«ãƒ¼ãƒ—åŒ–ã‚’æœ‰åŠ¹ã«ã—ãŸã‚¿ã‚¹ã‚¯ãƒãƒ¼ã§ã€Œã‚°ãƒ«ãƒ¼ãƒ—ã‚’é–‰ã˜ã‚‹ã€æ“ä½œã‚’ã—ãŸã¨ã
 
-	@pari•ÛŒì‚·‚é‰ÓŠ‚Ì—áj
-		CShareData::AddEditWndList(): ƒGƒ“ƒgƒŠ‚Ì’Ç‰Á^•À‚Ñ‘Ö‚¦
-		CShareData::DeleteEditWndList(): ƒGƒ“ƒgƒŠ‚Ìíœ
-		CShareData::GetOpenedWindowArr(): ”z—ñ‚ÌƒRƒs[ì¬
+	@parï¼ˆä¿è­·ã™ã‚‹ç®‡æ‰€ã®ä¾‹ï¼‰
+		CShareData::AddEditWndList(): ã‚¨ãƒ³ãƒˆãƒªã®è¿½åŠ ï¼ä¸¦ã³æ›¿ãˆ
+		CShareData::DeleteEditWndList(): ã‚¨ãƒ³ãƒˆãƒªã®å‰Šé™¤
+		CShareData::GetOpenedWindowArr(): é…åˆ—ã®ã‚³ãƒ”ãƒ¼ä½œæˆ
 
-	‰ºè‚É‚Ç‚±‚É‚Å‚à“ü‚ê‚é‚ÆƒfƒbƒhƒƒbƒN‚·‚éŠëŒ¯‚ª‚ ‚é‚Ì‚Å“ü‚ê‚é‚Æ‚«‚ÍTd‚ÉB
-	iLock()ŠúŠÔ’†‚ÉSendMessage()‚È‚Ç‚Å‘¼ƒEƒBƒ“ƒhƒE‚Ì‘€ì‚ğ‚·‚é‚ÆŠëŒ¯«‘åj
-	CShareData::m_pEditArr‚ğ’¼ÚQÆ‚µ‚½‚è•ÏX‚·‚é‚æ‚¤‚È‰ÓŠ‚É‚Íöİ“I‚ÈŠëŒ¯‚ª‚ ‚é‚ªA
-	‘Î˜bŒ^‚Å‡Ÿ‘€ì‚µ‚Ä‚¢‚é”ÍˆÍ‚Å‚ ‚ê‚Î‚Ü‚¸–â‘è‚Í‹N‚«‚È‚¢B
+	ä¸‹æ‰‹ã«ã©ã“ã«ã§ã‚‚å…¥ã‚Œã‚‹ã¨ãƒ‡ãƒƒãƒ‰ãƒ­ãƒƒã‚¯ã™ã‚‹å±é™ºãŒã‚ã‚‹ã®ã§å…¥ã‚Œã‚‹ã¨ãã¯æ…é‡ã«ã€‚
+	ï¼ˆLock()æœŸé–“ä¸­ã«SendMessage()ãªã©ã§ä»–ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®æ“ä½œã‚’ã™ã‚‹ã¨å±é™ºæ€§å¤§ï¼‰
+	CShareData::m_pEditArrã‚’ç›´æ¥å‚ç…§ã—ãŸã‚Šå¤‰æ›´ã™ã‚‹ã‚ˆã†ãªç®‡æ‰€ã«ã¯æ½œåœ¨çš„ãªå±é™ºãŒã‚ã‚‹ãŒã€
+	å¯¾è©±å‹ã§é †æ¬¡æ“ä½œã—ã¦ã„ã‚‹ç¯„å›²ã§ã‚ã‚Œã°ã¾ãšå•é¡Œã¯èµ·ããªã„ã€‚
 
-	@date 2007.07.05 ryoji V‹K“±“ü
-	@date 2007.07.07 genta CShareData‚Ìƒƒ“ƒo‚ÖˆÚ“®
+	@date 2007.07.05 ryoji æ–°è¦å°å…¥
+	@date 2007.07.07 genta CShareDataã®ãƒ¡ãƒ³ãƒã¸ç§»å‹•
 */
 static CMutex g_cEditArrMutex( FALSE, GSTR_MUTEX_SAKURA_EDITARR );
 
-// GetOpenedWindowArr—pƒ\[ƒgŠÖ”
+// GetOpenedWindowArrç”¨ã‚½ãƒ¼ãƒˆé–¢æ•°
 static int __cdecl cmpGetOpenedWindowArr(const void *e1, const void *e2)
 {
-	// ˆÙ‚È‚éƒOƒ‹[ƒv‚Ì‚Æ‚«‚ÍƒOƒ‹[ƒv”äŠr‚·‚é
+	// ç•°ãªã‚‹ã‚°ãƒ«ãƒ¼ãƒ—ã®ã¨ãã¯ã‚°ãƒ«ãƒ¼ãƒ—æ¯”è¼ƒã™ã‚‹
 	int nGroup1;
 	int nGroup2;
 
 	if( s_bGSort )
 	{
-		// ƒIƒŠƒWƒiƒ‹‚ÌƒOƒ‹[ƒv”Ô†‚Ì‚Ù‚¤‚ğŒ©‚é
+		// ã‚ªãƒªã‚¸ãƒŠãƒ«ã®ã‚°ãƒ«ãƒ¼ãƒ—ç•ªå·ã®ã»ã†ã‚’è¦‹ã‚‹
 		nGroup1 = ((EditNodeEx*)e1)->p->m_nGroup;
 		nGroup2 = ((EditNodeEx*)e2)->p->m_nGroup;
 	}
 	else
 	{
-		// ƒOƒ‹[ƒv‚ÌMRU”Ô†‚Ì‚Ù‚¤‚ğŒ©‚é
+		// ã‚°ãƒ«ãƒ¼ãƒ—ã®MRUç•ªå·ã®ã»ã†ã‚’è¦‹ã‚‹
 		nGroup1 = ((EditNodeEx*)e1)->nGroupMru;
 		nGroup2 = ((EditNodeEx*)e2)->nGroupMru;
 	}
 	if( nGroup1 != nGroup2 )
 	{
-		return nGroup1 - nGroup2;	// ƒOƒ‹[ƒv”äŠr
+		return nGroup1 - nGroup2;	// ã‚°ãƒ«ãƒ¼ãƒ—æ¯”è¼ƒ
 	}
 
-	// ƒOƒ‹[ƒv”äŠr‚ªs‚í‚ê‚È‚©‚Á‚½‚Æ‚«‚ÍƒEƒBƒ“ƒhƒE”äŠr‚·‚é
+	// ã‚°ãƒ«ãƒ¼ãƒ—æ¯”è¼ƒãŒè¡Œã‚ã‚Œãªã‹ã£ãŸã¨ãã¯ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦æ¯”è¼ƒã™ã‚‹
 	if( s_bSort )
-		return ( ((EditNodeEx*)e1)->p->m_nIndex - ((EditNodeEx*)e2)->p->m_nIndex );	// ƒEƒBƒ“ƒhƒE”Ô†”äŠr
-	return ( ((EditNodeEx*)e1)->p - ((EditNodeEx*)e2)->p );	// ƒEƒBƒ“ƒhƒEMRU”äŠriƒ\[ƒg‚µ‚È‚¢j
+		return ( ((EditNodeEx*)e1)->p->m_nIndex - ((EditNodeEx*)e2)->p->m_nIndex );	// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç•ªå·æ¯”è¼ƒ
+	return ( ((EditNodeEx*)e1)->p - ((EditNodeEx*)e2)->p );	// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦MRUæ¯”è¼ƒï¼ˆã‚½ãƒ¼ãƒˆã—ãªã„ï¼‰
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ƒOƒ‹[ƒv                            //
+//                         ã‚°ãƒ«ãƒ¼ãƒ—                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/** w’èˆÊ’u‚Ì•ÒWƒEƒBƒ“ƒhƒEî•ñ‚ğæ“¾‚·‚é
+/** æŒ‡å®šä½ç½®ã®ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 
 	@date 2007.06.20 ryoji
 */
@@ -130,12 +130,12 @@ EditNode* CAppNodeGroupHandle::GetEditNodeAt( int nIndex )
 }
 
 
-/** •ÒWƒEƒBƒ“ƒhƒEƒŠƒXƒg‚Ö‚Ì“o˜^
+/** ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆã¸ã®ç™»éŒ²
 
-	@param hWnd   [in] “o˜^‚·‚é•ÒWƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹
+	@param hWnd   [in] ç™»éŒ²ã™ã‚‹ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ«
 
-	@date 2003.06.28 MIK CRecent—˜—p‚Å‘‚«Š·‚¦
-	@date 2007.06.20 ryoji V‹KƒEƒBƒ“ƒhƒE‚É‚ÍƒOƒ‹[ƒvID‚ğ•t—^‚·‚é
+	@date 2003.06.28 MIK CRecentåˆ©ç”¨ã§æ›¸ãæ›ãˆ
+	@date 2007.06.20 ryoji æ–°è¦ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«ã¯ã‚°ãƒ«ãƒ¼ãƒ—IDã‚’ä»˜ä¸ã™ã‚‹
 */
 BOOL CAppNodeGroupHandle::AddEditWndList( HWND hWnd )
 {
@@ -149,16 +149,16 @@ BOOL CAppNodeGroupHandle::AddEditWndList( HWND hWnd )
 	memset_raw( &sMyEditNode, 0, sizeof( sMyEditNode ) );
 	sMyEditNode.m_hWnd = hWnd;
 
-	{	// 2007.07.07 genta Lock—Ìˆæ
+	{	// 2007.07.07 genta Locké ˜åŸŸ
 		LockGuard<CMutex> guard( g_cEditArrMutex );
 
 		CRecentEditNode	cRecentEditNode;
 
-		//“o˜^Ï‚İ‚©H
+		//ç™»éŒ²æ¸ˆã¿ã‹ï¼Ÿ
 		nIndex = cRecentEditNode.FindItemByHwnd( hWnd );
 		if( -1 != nIndex )
 		{
-			//‚à‚¤‚±‚êˆÈã“o˜^‚Å‚«‚È‚¢‚©H
+			//ã‚‚ã†ã“ã‚Œä»¥ä¸Šç™»éŒ²ã§ããªã„ã‹ï¼Ÿ
 			if( cRecentEditNode.GetItemCount() >= cRecentEditNode.GetArrayCount() )
 			{
 				cRecentEditNode.Terminate();
@@ -166,7 +166,7 @@ BOOL CAppNodeGroupHandle::AddEditWndList( HWND hWnd )
 			}
 			nSubCommand = TWNT_ORDER;
 
-			//ˆÈ‘O‚Ìî•ñ‚ğƒRƒs[‚·‚éB
+			//ä»¥å‰ã®æƒ…å ±ã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹ã€‚
 			p = cRecentEditNode.GetItem( nIndex );
 			if( p )
 			{
@@ -174,23 +174,23 @@ BOOL CAppNodeGroupHandle::AddEditWndList( HWND hWnd )
 			}
 		}
 
-		/* ƒEƒBƒ“ƒhƒE˜A”Ô */
+		/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦é€£ç•ª */
 
 		if( 0 == ::GetWindowLongPtr( hWnd, sizeof(LONG_PTR) ) )
 		{
 			pShare->m_sNodes.m_nSequences++;
 			::SetWindowLongPtr( hWnd, sizeof(LONG_PTR) , (LONG_PTR)pShare->m_sNodes.m_nSequences );
 
-			//˜A”Ô‚ğXV‚·‚éB
+			//é€£ç•ªã‚’æ›´æ–°ã™ã‚‹ã€‚
 			sMyEditNode.m_nIndex = pShare->m_sNodes.m_nSequences;
 			sMyEditNode.m_nId = -1;
 
-			/* ƒ^ƒuƒOƒ‹[ƒv˜A”Ô */
+			/* ã‚¿ãƒ–ã‚°ãƒ«ãƒ¼ãƒ—é€£ç•ª */
 			if( m_nGroup > 0 )
 			{
-				sMyEditNode.m_nGroup = m_nGroup;	// w’è‚ÌƒOƒ‹[ƒv
+				sMyEditNode.m_nGroup = m_nGroup;	// æŒ‡å®šã®ã‚°ãƒ«ãƒ¼ãƒ—
 				if (pShare->m_sNodes.m_nGroupSequences < m_nGroup ) {
-					// w’èƒOƒ‹[ƒv‚ªŒ»İ‚ÌGroup Sequences‚ğ’´‚¦‚Ä‚¢‚½ê‡‚Ì•â³
+					// æŒ‡å®šã‚°ãƒ«ãƒ¼ãƒ—ãŒç¾åœ¨ã®Group Sequencesã‚’è¶…ãˆã¦ã„ãŸå ´åˆã®è£œæ­£
 					pShare->m_sNodes.m_nGroupSequences = m_nGroup;
 				}
 			}
@@ -198,36 +198,36 @@ BOOL CAppNodeGroupHandle::AddEditWndList( HWND hWnd )
 			{
 				p = cRecentEditNode.GetItem( 0 );
 				if( NULL == p )
-					sMyEditNode.m_nGroup = ++pShare->m_sNodes.m_nGroupSequences;	// V‹KƒOƒ‹[ƒv
+					sMyEditNode.m_nGroup = ++pShare->m_sNodes.m_nGroupSequences;	// æ–°è¦ã‚°ãƒ«ãƒ¼ãƒ—
 				else
-					sMyEditNode.m_nGroup = p->m_nGroup;	// Å‹ßƒAƒNƒeƒBƒu‚ÌƒOƒ‹[ƒv
+					sMyEditNode.m_nGroup = p->m_nGroup;	// æœ€è¿‘ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã®ã‚°ãƒ«ãƒ¼ãƒ—
 			}
 
 			sMyEditNode.m_showCmdRestore = ::IsZoomed(hWnd)? SW_SHOWMAXIMIZED: SW_SHOWNORMAL;
 			sMyEditNode.m_bClosing = FALSE;
 		}
 
-		//’Ç‰Á‚Ü‚½‚Íæ“ª‚ÉˆÚ“®‚·‚éB
+		//è¿½åŠ ã¾ãŸã¯å…ˆé ­ã«ç§»å‹•ã™ã‚‹ã€‚
 		cRecentEditNode.AppendItem( &sMyEditNode );
 		cRecentEditNode.Terminate();
-	}	// 2007.07.07 genta Lock—ÌˆæI‚í‚è
+	}	// 2007.07.07 genta Locké ˜åŸŸçµ‚ã‚ã‚Š
 
-	//ƒEƒCƒ“ƒhƒE“o˜^ƒƒbƒZ[ƒW‚ğƒuƒ[ƒhƒLƒƒƒXƒg‚·‚éB
+	//ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ç™»éŒ²ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ãƒ–ãƒ­ãƒ¼ãƒ‰ã‚­ãƒ£ã‚¹ãƒˆã™ã‚‹ã€‚
 	CAppNodeGroupHandle(hWnd).PostMessageToAllEditors( MYWM_TAB_WINDOW_NOTIFY, (WPARAM)nSubCommand, (LPARAM)hWnd, hWnd );
 
 	return TRUE;
 }
 
 
-/** •ÒWƒEƒBƒ“ƒhƒEƒŠƒXƒg‚©‚ç‚Ìíœ
+/** ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆã‹ã‚‰ã®å‰Šé™¤
 
-	@date 2003.06.28 MIK CRecent—˜—p‚Å‘‚«Š·‚¦
-	@date 2007.07.05 ryoji mutex‚Å•ÛŒì
+	@date 2003.06.28 MIK CRecentåˆ©ç”¨ã§æ›¸ãæ›ãˆ
+	@date 2007.07.05 ryoji mutexã§ä¿è­·
 */
 void CAppNodeGroupHandle::DeleteEditWndList( HWND hWnd )
 {
-	//ƒEƒCƒ“ƒhƒE‚ğƒŠƒXƒg‚©‚çíœ‚·‚éB
-	{	// 2007.07.07 genta Lock—Ìˆæ
+	//ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã‚’ãƒªã‚¹ãƒˆã‹ã‚‰å‰Šé™¤ã™ã‚‹ã€‚
+	{	// 2007.07.07 genta Locké ˜åŸŸ
 		LockGuard<CMutex> guard( g_cEditArrMutex );
 
 		CRecentEditNode	cRecentEditNode;
@@ -235,25 +235,25 @@ void CAppNodeGroupHandle::DeleteEditWndList( HWND hWnd )
 		cRecentEditNode.Terminate();
 	}
 
-	//ƒEƒCƒ“ƒhƒEíœƒƒbƒZ[ƒW‚ğƒuƒ[ƒhƒLƒƒƒXƒg‚·‚éB
+	//ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦å‰Šé™¤ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ãƒ–ãƒ­ãƒ¼ãƒ‰ã‚­ãƒ£ã‚¹ãƒˆã™ã‚‹ã€‚
 	CAppNodeGroupHandle(m_nGroup).PostMessageToAllEditors( MYWM_TAB_WINDOW_NOTIFY, (WPARAM)TWNT_DEL, (LPARAM)hWnd, hWnd);
 }
 
-/** ‚¢‚­‚Â‚©‚ÌƒEƒBƒ“ƒhƒE‚ÖI—¹—v‹‚ğo‚·
+/** ã„ãã¤ã‹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸çµ‚äº†è¦æ±‚ã‚’å‡ºã™
 
-	@param pWndArr [in] EditNode‚Ì”z—ñBm_hWnd‚ªNULL‚Ì—v‘f‚Íˆ—‚µ‚È‚¢
-	@param nArrCnt [in] pWndArr‚Ì’·‚³
-	@param bExit [in] TRUE: •ÒW‚Ì‘SI—¹ / FALSE: ‚·‚×‚Ä•Â‚¶‚é
-	@param bCheckConfirm [in] FALSE:•¡”ƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚é‚Æ‚«‚ÌŒx‚ğo‚³‚È‚¢ / TRUE:Œx‚ğo‚·iİ’è‚É‚æ‚éj
-	@param hWndFrom [in] I—¹—v‹Œ³‚ÌƒEƒBƒ“ƒhƒEiŒxƒƒbƒZ[ƒW‚Ìe‚Æ‚È‚éj
+	@param pWndArr [in] EditNodeã®é…åˆ—ã€‚m_hWndãŒNULLã®è¦ç´ ã¯å‡¦ç†ã—ãªã„
+	@param nArrCnt [in] pWndArrã®é•·ã•
+	@param bExit [in] TRUE: ç·¨é›†ã®å…¨çµ‚äº† / FALSE: ã™ã¹ã¦é–‰ã˜ã‚‹
+	@param bCheckConfirm [in] FALSE:è¤‡æ•°ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹ã¨ãã®è­¦å‘Šã‚’å‡ºã•ãªã„ / TRUE:è­¦å‘Šã‚’å‡ºã™ï¼ˆè¨­å®šã«ã‚ˆã‚‹ï¼‰
+	@param hWndFrom [in] çµ‚äº†è¦æ±‚å…ƒã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ï¼ˆè­¦å‘Šãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®è¦ªã¨ãªã‚‹ï¼‰
 
-	@date 2007.02.13 ryoji u•ÒW‚Ì‘SI—¹v‚ğ¦‚·ˆø”(bExit)‚ğ’Ç‰Á
-	@date 2007.06.22 ryoji nGroupˆø”‚ğ’Ç‰Á
-	@date 2008.11.22 syat ‘S‚Ä¨‚¢‚­‚Â‚©‚É•ÏXB•¡”ƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚é‚ÌŒxƒƒbƒZ[ƒW‚ğ’Ç‰Á
+	@date 2007.02.13 ryoji ã€Œç·¨é›†ã®å…¨çµ‚äº†ã€ã‚’ç¤ºã™å¼•æ•°(bExit)ã‚’è¿½åŠ 
+	@date 2007.06.22 ryoji nGroupå¼•æ•°ã‚’è¿½åŠ 
+	@date 2008.11.22 syat å…¨ã¦â†’ã„ãã¤ã‹ã«å¤‰æ›´ã€‚è¤‡æ•°ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹æ™‚ã®è­¦å‘Šãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¿½åŠ 
 */
 BOOL CAppNodeGroupHandle::RequestCloseEditor( EditNode* pWndArr, int nArrCnt, BOOL bExit, BOOL bCheckConfirm, HWND hWndFrom )
 {
-	/* ƒNƒ[ƒY‘ÎÛƒEƒBƒ“ƒhƒE‚ğ’²‚×‚é */
+	/* ã‚¯ãƒ­ãƒ¼ã‚ºå¯¾è±¡ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’èª¿ã¹ã‚‹ */
 	int iGroup = -1;
 	HWND hWndLast = NULL;
 	int nCloseCount = 0;
@@ -262,17 +262,17 @@ BOOL CAppNodeGroupHandle::RequestCloseEditor( EditNode* pWndArr, int nArrCnt, BO
 			if( IsSakuraMainWindow(pWndArr[i].m_hWnd) ){
 				nCloseCount++;
 				if( iGroup == -1 ){
-					iGroup = pWndArr[i].m_nGroup;	// Å‰‚É•Â‚¶‚éƒOƒ‹[ƒv
+					iGroup = pWndArr[i].m_nGroup;	// æœ€åˆã«é–‰ã˜ã‚‹ã‚°ãƒ«ãƒ¼ãƒ—
 					hWndLast = pWndArr[i].m_hWnd;
 				}
 				else if( iGroup == pWndArr[i].m_nGroup ){
-					hWndLast = pWndArr[i].m_hWnd;	// Å‰‚É•Â‚¶‚éƒOƒ‹[ƒv‚ÌÅŒã‚ÌƒEƒBƒ“ƒhƒE
+					hWndLast = pWndArr[i].m_hWnd;	// æœ€åˆã«é–‰ã˜ã‚‹ã‚°ãƒ«ãƒ¼ãƒ—ã®æœ€å¾Œã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
 				}
 			}
 		}
 	}
 
-	if( bCheckConfirm && GetDllShareData().m_Common.m_sGeneral.m_bCloseAllConfirm ){	//[‚·‚×‚Ä•Â‚¶‚é]‚Å‘¼‚É•ÒW—p‚ÌƒEƒBƒ“ƒhƒE‚ª‚ ‚ê‚ÎŠm”F‚·‚é
+	if( bCheckConfirm && GetDllShareData().m_Common.m_sGeneral.m_bCloseAllConfirm ){	//[ã™ã¹ã¦é–‰ã˜ã‚‹]ã§ä»–ã«ç·¨é›†ç”¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒã‚ã‚Œã°ç¢ºèªã™ã‚‹
 		if( 1 < nCloseCount ){
 			if( IDYES != ::MYMESSAGEBOX(
 				hWndFrom,
@@ -285,43 +285,43 @@ BOOL CAppNodeGroupHandle::RequestCloseEditor( EditNode* pWndArr, int nArrCnt, BO
 		}
 	}
 
-	// ƒAƒNƒeƒBƒu‰»§ŒäƒEƒBƒ“ƒhƒE‚ğŒˆ‚ß‚é
-	// EƒƒbƒZ[ƒW‚ğ•\¦‚µ‚Ä‚¢‚È‚¢ŠÔ‚Í‚±‚Ì§ŒäƒEƒBƒ“ƒhƒE‚ğƒAƒNƒeƒBƒu‚É•Û‚Â‚æ‚¤‚É‚·‚é
-	// E•Â‚¶‚ç‚ê‚éƒGƒfƒBƒ^‚ª•Û‘¶Šm”F‚ÌƒƒbƒZ[ƒW‚ğ•\¦‚·‚éê‡‚ÍA‚±‚Ì§ŒäƒEƒBƒ“ƒhƒE‚ÉƒAƒNƒeƒBƒu‰»—v‹iMYWM_ALLOWACTIVATEj‚ğo‚µ‚ÄƒAƒNƒeƒBƒu‚É‚µ‚Ä‚à‚ç‚¤
-	// Eƒ^ƒuƒOƒ‹[ƒv•\¦‚©‚Ç‚¤‚©‚È‚Ç‚ÌğŒ‚É‰‚¶‚ÄA‚¿‚ç‚Â‚«‚ğÅ¬ŒÀ‚É‚·‚é‚Ì‚É“s‡‚Ì—Ç‚¢ƒEƒBƒ“ƒhƒE‚ğ‚±‚±‚Å‘I‘ğ‚µ‚Ä‚¨‚­
+	// ã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–åˆ¶å¾¡ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’æ±ºã‚ã‚‹
+	// ãƒ»ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤ºã—ã¦ã„ãªã„é–“ã¯ã“ã®åˆ¶å¾¡ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ä¿ã¤ã‚ˆã†ã«ã™ã‚‹
+	// ãƒ»é–‰ã˜ã‚‰ã‚Œã‚‹ã‚¨ãƒ‡ã‚£ã‚¿ãŒä¿å­˜ç¢ºèªã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤ºã™ã‚‹å ´åˆã¯ã€ã“ã®åˆ¶å¾¡ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«ã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–è¦æ±‚ï¼ˆMYWM_ALLOWACTIVATEï¼‰ã‚’å‡ºã—ã¦ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã—ã¦ã‚‚ã‚‰ã†
+	// ãƒ»ã‚¿ãƒ–ã‚°ãƒ«ãƒ¼ãƒ—è¡¨ç¤ºã‹ã©ã†ã‹ãªã©ã®æ¡ä»¶ã«å¿œã˜ã¦ã€ã¡ã‚‰ã¤ãã‚’æœ€å°é™ã«ã™ã‚‹ã®ã«éƒ½åˆã®è‰¯ã„ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã“ã“ã§é¸æŠã—ã¦ãŠã
 	HWND hWndActive;
 	bool bTabGroup = (GetDllShareData().m_Common.m_sTabBar.m_bDispTabWnd && !GetDllShareData().m_Common.m_sTabBar.m_bDispTabWndMultiWin);
 	if( bTabGroup ){
-		hWndActive = hWndLast;	// ÅŒã‚É•Â‚¶‚éƒEƒBƒ“ƒhƒE‚ª’S“–
+		hWndActive = hWndLast;	// æœ€å¾Œã«é–‰ã˜ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒæ‹…å½“
 	}else{
-		hWndActive = GetDllShareData().m_sHandles.m_hwndTray;	// ƒ^ƒXƒNƒgƒŒƒC‚ª’S“–
+		hWndActive = GetDllShareData().m_sHandles.m_hwndTray;	// ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ãŒæ‹…å½“
 	}
 
-	// ƒAƒNƒeƒBƒu‰»§ŒäƒEƒCƒ“ƒhƒE‚ğƒAƒNƒeƒBƒu‚É‚µ‚Ä‚¨‚­
+	// ã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–åˆ¶å¾¡ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã—ã¦ãŠã
 	if( IsSakuraMainWindow(hWndActive) ){
-		ActivateFrameWindow(hWndActive);	// ƒGƒfƒBƒ^ƒEƒBƒ“ƒhƒE
+		ActivateFrameWindow(hWndActive);	// ã‚¨ãƒ‡ã‚£ã‚¿ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
 	}else{
-		::SetForegroundWindow(hWndActive);	// ƒ^ƒXƒNƒgƒŒƒC
+		::SetForegroundWindow(hWndActive);	// ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤
 	}
 
-	// ƒGƒfƒBƒ^‚Ö‚ÌI—¹—v‹
+	// ã‚¨ãƒ‡ã‚£ã‚¿ã¸ã®çµ‚äº†è¦æ±‚
 	for( int i = 0; i < nArrCnt; i++ ){
 		if( m_nGroup == 0 || m_nGroup == pWndArr[i].m_nGroup ){
 			if( IsSakuraMainWindow(pWndArr[i].m_hWnd) ){
-				// ƒ^ƒuƒOƒ‹[ƒv•\¦‚ÅŸ‚É•Â‚¶‚é‚Ì‚ªƒAƒNƒeƒBƒu‰»§ŒäƒEƒBƒ“ƒhƒE‚Ìê‡A
-				// ƒAƒNƒeƒBƒu‰»§ŒäƒEƒBƒ“ƒhƒE‚ğŸ‚ÌƒOƒ‹[ƒv‚ÌÅŒã‚ÌƒEƒBƒ“ƒhƒE‚ÉØ‘Ö‚¦‚é
+				// ã‚¿ãƒ–ã‚°ãƒ«ãƒ¼ãƒ—è¡¨ç¤ºã§æ¬¡ã«é–‰ã˜ã‚‹ã®ãŒã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–åˆ¶å¾¡ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®å ´åˆã€
+				// ã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–åˆ¶å¾¡ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’æ¬¡ã®ã‚°ãƒ«ãƒ¼ãƒ—ã®æœ€å¾Œã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«åˆ‡æ›¿ãˆã‚‹
 				if( bTabGroup && pWndArr[i].m_hWnd == hWndActive ){
 					iGroup = -1;
-					hWndActive = ( IsSakuraMainWindow(hWndFrom) )? hWndFrom: NULL;	// ˆê”ÔÅŒã—p
+					hWndActive = ( IsSakuraMainWindow(hWndFrom) )? hWndFrom: NULL;	// ä¸€ç•ªæœ€å¾Œç”¨
 					for( int j = i + 1; j < nArrCnt; j++ ){
 						if( m_nGroup == 0 || m_nGroup == pWndArr[j].m_nGroup ){
 							if( IsSakuraMainWindow(pWndArr[j].m_hWnd) ){
 								if( iGroup == -1 ){
-									iGroup = pWndArr[j].m_nGroup;	// Ÿ‚É•Â‚¶‚éƒOƒ‹[ƒv
+									iGroup = pWndArr[j].m_nGroup;	// æ¬¡ã«é–‰ã˜ã‚‹ã‚°ãƒ«ãƒ¼ãƒ—
 									hWndActive = pWndArr[j].m_hWnd;
 								}
 								else if( iGroup == pWndArr[j].m_nGroup ){
-									hWndActive = pWndArr[j].m_hWnd;	// Ÿ‚É•Â‚¶‚éƒOƒ‹[ƒv‚ÌÅŒã‚ÌƒEƒBƒ“ƒhƒE
+									hWndActive = pWndArr[j].m_hWnd;	// æ¬¡ã«é–‰ã˜ã‚‹ã‚°ãƒ«ãƒ¼ãƒ—ã®æœ€å¾Œã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
 								}
 								else{
 									break;
@@ -332,8 +332,8 @@ BOOL CAppNodeGroupHandle::RequestCloseEditor( EditNode* pWndArr, int nArrCnt, BO
 				}
 				DWORD dwPid;
 				::GetWindowThreadProcessId(pWndArr[i].m_hWnd, &dwPid);
-				::SendMessage(hWndActive, MYWM_ALLOWACTIVATE, dwPid, 0);	// ƒAƒNƒeƒBƒu‰»‚Ì‹–‰Â‚ğˆË—Š‚·‚é
-				if( !::SendMessage( pWndArr[i].m_hWnd, MYWM_CLOSE, bExit ? PM_CLOSE_EXIT : 0, (LPARAM)hWndActive ) ){	// 2007.02.13 ryoji bExit‚ğˆø‚«Œp‚®
+				::SendMessage(hWndActive, MYWM_ALLOWACTIVATE, dwPid, 0);	// ã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–ã®è¨±å¯ã‚’ä¾é ¼ã™ã‚‹
+				if( !::SendMessage( pWndArr[i].m_hWnd, MYWM_CLOSE, bExit ? PM_CLOSE_EXIT : 0, (LPARAM)hWndActive ) ){	// 2007.02.13 ryoji bExitã‚’å¼•ãç¶™ã
 					return FALSE;
 				}
 			}
@@ -344,12 +344,12 @@ BOOL CAppNodeGroupHandle::RequestCloseEditor( EditNode* pWndArr, int nArrCnt, BO
 }
 
 
-/** Œ»İ‚Ì•ÒWƒEƒBƒ“ƒhƒE‚Ì”‚ğ’²‚×‚é
+/** ç¾åœ¨ã®ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®æ•°ã‚’èª¿ã¹ã‚‹
 
-	@param bExcludeClosing [in] I—¹’†‚Ì•ÒWƒEƒBƒ“ƒhƒE‚ÍƒJƒEƒ“ƒg‚µ‚È‚¢
+	@param bExcludeClosing [in] çµ‚äº†ä¸­ã®ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¯ã‚«ã‚¦ãƒ³ãƒˆã—ãªã„
 
-	@date 2007.06.22 ryoji nGroupˆø”‚ğ’Ç‰Á
-	@date 2008.04.19 ryoji bExcludeClosingˆø”‚ğ’Ç‰Á
+	@date 2007.06.22 ryoji nGroupå¼•æ•°ã‚’è¿½åŠ 
+	@date 2008.04.19 ryoji bExcludeClosingå¼•æ•°ã‚’è¿½åŠ 
 */
 int CAppNodeGroupHandle::GetEditorWindowsNum( bool bExcludeClosing/* = true */ )
 {
@@ -373,16 +373,16 @@ int CAppNodeGroupHandle::GetEditorWindowsNum( bool bExcludeClosing/* = true */ )
 }
 
 
-/** ‘S•ÒWƒEƒBƒ“ƒhƒE‚ÖƒƒbƒZ[ƒW‚ğƒ|ƒXƒg‚·‚é
+/** å…¨ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ãƒã‚¹ãƒˆã™ã‚‹
 
-	@date 2005.01.24 genta hWndLast == NULL‚Ì‚Æ‚«‘S‚­ƒƒbƒZ[ƒW‚ª‘—‚ç‚ê‚È‚©‚Á‚½
-	@date 2007.06.22 ryoji nGroupˆø”‚ğ’Ç‰ÁAƒOƒ‹[ƒv’PˆÊ‚Å‡”Ô‚É‘—‚é
+	@date 2005.01.24 genta hWndLast == NULLã®ã¨ãå…¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãŒé€ã‚‰ã‚Œãªã‹ã£ãŸ
+	@date 2007.06.22 ryoji nGroupå¼•æ•°ã‚’è¿½åŠ ã€ã‚°ãƒ«ãƒ¼ãƒ—å˜ä½ã§é †ç•ªã«é€ã‚‹
 */
 BOOL CAppNodeGroupHandle::PostMessageToAllEditors(
-	UINT		uMsg,		/*!< ƒ|ƒXƒg‚·‚éƒƒbƒZ[ƒW */
-	WPARAM		wParam,		/*!< ‘æ1ƒƒbƒZ[ƒW ƒpƒ‰ƒ[ƒ^ */
-	LPARAM		lParam,		/*!< ‘æ2ƒƒbƒZ[ƒW ƒpƒ‰ƒ[ƒ^ */
-	HWND		hWndLast	/*!< ÅŒã‚É‘—‚è‚½‚¢ƒEƒBƒ“ƒhƒE */
+	UINT		uMsg,		/*!< ãƒã‚¹ãƒˆã™ã‚‹ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ */
+	WPARAM		wParam,		/*!< ç¬¬1ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ */
+	LPARAM		lParam,		/*!< ç¬¬2ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ */
+	HWND		hWndLast	/*!< æœ€å¾Œã«é€ã‚ŠãŸã„ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
 )
 {
 	EditNode*	pWndArr;
@@ -394,25 +394,25 @@ BOOL CAppNodeGroupHandle::PostMessageToAllEditors(
 		return TRUE;
 	}
 
-	// hWndLastˆÈŠO‚Ö‚ÌƒƒbƒZ[ƒW
+	// hWndLastä»¥å¤–ã¸ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
 	for( i = 0; i < n; ++i ){
-		//	Jan. 24, 2005 genta hWndLast == NULL‚Ì‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ª‘—‚ç‚ê‚é‚æ‚¤‚É
+		//	Jan. 24, 2005 genta hWndLast == NULLã®ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãŒé€ã‚‰ã‚Œã‚‹ã‚ˆã†ã«
 		if( hWndLast == NULL || hWndLast != pWndArr[i].m_hWnd ){
 			if( m_nGroup == 0 || m_nGroup == pWndArr[i].m_nGroup ){
 				if( IsSakuraMainWindow( pWndArr[i].m_hWnd ) ){
-					/* ƒƒbƒZ[ƒW‚ğƒ|ƒXƒg */
+					/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ãƒã‚¹ãƒˆ */
 					::PostMessage( pWndArr[i].m_hWnd, uMsg, wParam, lParam );
 				}
 			}
 		}
 	}
 
-	// hWndLast‚Ö‚ÌƒƒbƒZ[ƒW
+	// hWndLastã¸ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
 	for( i = 0; i < n; ++i ){
 		if( hWndLast == pWndArr[i].m_hWnd ){
 			if( m_nGroup == 0 || m_nGroup == pWndArr[i].m_nGroup ){
 				if( IsSakuraMainWindow( pWndArr[i].m_hWnd ) ){
-					/* ƒƒbƒZ[ƒW‚ğƒ|ƒXƒg */
+					/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ãƒã‚¹ãƒˆ */
 					::PostMessage( pWndArr[i].m_hWnd, uMsg, wParam, lParam );
 				}
 			}
@@ -423,16 +423,16 @@ BOOL CAppNodeGroupHandle::PostMessageToAllEditors(
 	return TRUE;
 }
 
-/** ‘S•ÒWƒEƒBƒ“ƒhƒE‚ÖƒƒbƒZ[ƒW‚ğ‘—‚é
+/** å…¨ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’é€ã‚‹
 
-	@date 2005.01.24 genta m_hWndLast == NULL‚Ì‚Æ‚«‘S‚­ƒƒbƒZ[ƒW‚ª‘—‚ç‚ê‚È‚©‚Á‚½
-	@date 2007.06.22 ryoji nGroupˆø”‚ğ’Ç‰ÁAƒOƒ‹[ƒv’PˆÊ‚Å‡”Ô‚É‘—‚é
+	@date 2005.01.24 genta m_hWndLast == NULLã®ã¨ãå…¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãŒé€ã‚‰ã‚Œãªã‹ã£ãŸ
+	@date 2007.06.22 ryoji nGroupå¼•æ•°ã‚’è¿½åŠ ã€ã‚°ãƒ«ãƒ¼ãƒ—å˜ä½ã§é †ç•ªã«é€ã‚‹
 */
 BOOL CAppNodeGroupHandle::SendMessageToAllEditors(
-	UINT		uMsg,		/* ƒ|ƒXƒg‚·‚éƒƒbƒZ[ƒW */
-	WPARAM		wParam,		/* ‘æ1ƒƒbƒZ[ƒW ƒpƒ‰ƒ[ƒ^ */
-	LPARAM		lParam,		/* ‘æ2ƒƒbƒZ[ƒW ƒpƒ‰ƒ[ƒ^ */
-	HWND		hWndLast	/* ÅŒã‚É‘—‚è‚½‚¢ƒEƒBƒ“ƒhƒE */
+	UINT		uMsg,		/* ãƒã‚¹ãƒˆã™ã‚‹ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ */
+	WPARAM		wParam,		/* ç¬¬1ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ */
+	LPARAM		lParam,		/* ç¬¬2ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ */
+	HWND		hWndLast	/* æœ€å¾Œã«é€ã‚ŠãŸã„ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
 )
 {
 	EditNode*	pWndArr;
@@ -444,25 +444,25 @@ BOOL CAppNodeGroupHandle::SendMessageToAllEditors(
 		return TRUE;
 	}
 
-	// hWndLastˆÈŠO‚Ö‚ÌƒƒbƒZ[ƒW
+	// hWndLastä»¥å¤–ã¸ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
 	for( i = 0; i < n; ++i ){
-		//	Jan. 24, 2005 genta hWndLast == NULL‚Ì‚Æ‚«‚ÉƒƒbƒZ[ƒW‚ª‘—‚ç‚ê‚é‚æ‚¤‚É
+		//	Jan. 24, 2005 genta hWndLast == NULLã®ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãŒé€ã‚‰ã‚Œã‚‹ã‚ˆã†ã«
 		if( hWndLast == NULL || hWndLast != pWndArr[i].m_hWnd ){
 			if( m_nGroup == 0 || m_nGroup == pWndArr[i].m_nGroup ){
 				if( IsSakuraMainWindow( pWndArr[i].m_hWnd ) ){
-					/* ƒƒbƒZ[ƒW‚ğ‘—‚é */
+					/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’é€ã‚‹ */
 					::SendMessage( pWndArr[i].m_hWnd, uMsg, wParam, lParam );
 				}
 			}
 		}
 	}
 
-	// hWndLast‚Ö‚ÌƒƒbƒZ[ƒW
+	// hWndLastã¸ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
 	for( i = 0; i < n; ++i ){
 		if( hWndLast == pWndArr[i].m_hWnd ){
 			if( m_nGroup == 0 || m_nGroup == pWndArr[i].m_nGroup ){
 				if( IsSakuraMainWindow( pWndArr[i].m_hWnd ) ){
-					/* ƒƒbƒZ[ƒW‚ğ‘—‚é */
+					/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’é€ã‚‹ */
 					::SendMessage( pWndArr[i].m_hWnd, uMsg, wParam, lParam );
 				}
 			}
@@ -473,10 +473,10 @@ BOOL CAppNodeGroupHandle::SendMessageToAllEditors(
 	return TRUE;
 }
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ƒ}ƒl[ƒWƒƒ                           //
+//                        ãƒãƒãƒ¼ã‚¸ãƒ£                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/** ƒOƒ‹[ƒv‚ğIDƒŠƒZƒbƒg‚·‚é
+/** ã‚°ãƒ«ãƒ¼ãƒ—ã‚’IDãƒªã‚»ãƒƒãƒˆã™ã‚‹
 
 	@date 2007.06.20 ryoji
 */
@@ -494,14 +494,14 @@ void CAppNodeManager::ResetGroupId()
 	}
 }
 
-/** •ÒWƒEƒBƒ“ƒhƒEî•ñ‚ğæ“¾‚·‚é
+/** ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 
 	@date 2007.06.20 ryoji
 
-	@warning ‚±‚ÌŠÖ”‚Ím_pEditArr“à‚Ì—v‘f‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğ•Ô‚·D
-	m_pEditArr‚ª•ÏX‚³‚ê‚½Œã‚Å‚ÍƒAƒNƒZƒX‚µ‚È‚¢‚æ‚¤’ˆÓ‚ª•K—vD
+	@warning ã“ã®é–¢æ•°ã¯m_pEditArrå†…ã®è¦ç´ ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã™ï¼
+	m_pEditArrãŒå¤‰æ›´ã•ã‚ŒãŸå¾Œã§ã¯ã‚¢ã‚¯ã‚»ã‚¹ã—ãªã„ã‚ˆã†æ³¨æ„ãŒå¿…è¦ï¼
 
-	@note NULL‚ğ•Ô‚·ê‡‚ª‚ ‚é‚Ì‚Å–ß‚è’l‚Ìƒ`ƒFƒbƒN‚ª•K—v‚Å‚·
+	@note NULLã‚’è¿”ã™å ´åˆãŒã‚ã‚‹ã®ã§æˆ»ã‚Šå€¤ã®ãƒã‚§ãƒƒã‚¯ãŒå¿…è¦ã§ã™
 */
 EditNode* CAppNodeManager::GetEditNode( HWND hWnd )
 {
@@ -521,7 +521,7 @@ EditNode* CAppNodeManager::GetEditNode( HWND hWnd )
 
 
 
-//! –³‘è”Ô†æ“¾
+//! ç„¡é¡Œç•ªå·å–å¾—
 int CAppNodeManager::GetNoNameNumber( HWND hWnd )
 {
 	DLLSHAREDATA* pShare = &GetDllShareData();
@@ -538,29 +538,29 @@ int CAppNodeManager::GetNoNameNumber( HWND hWnd )
 
 
 
-/** Œ»İŠJ‚¢‚Ä‚¢‚é•ÒWƒEƒBƒ“ƒhƒE‚Ì”z—ñ‚ğ•Ô‚·
+/** ç¾åœ¨é–‹ã„ã¦ã„ã‚‹ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é…åˆ—ã‚’è¿”ã™
 
-	@param[out] ppEditNode ”z—ñ‚ğó‚¯æ‚éƒ|ƒCƒ“ƒ^
-		–ß‚è’l‚ª0‚Ìê‡‚ÍNULL‚ª•Ô‚³‚ê‚é‚ªC‚»‚ê‚ğŠú‘Ò‚µ‚È‚¢‚±‚ÆD
-		‚Ü‚½C•s—v‚É‚È‚Á‚½‚çdelete []‚µ‚È‚­‚Ä‚Í‚È‚ç‚È‚¢D
-	@param[in] bSort TRUE: ƒ\[ƒg‚ ‚è / FALSE: ƒ\[ƒg–³‚µ
-	@param[in]bGSort TRUE: ƒOƒ‹[ƒvƒ\[ƒg‚ ‚è / FALSE: ƒOƒ‹[ƒvƒ\[ƒg–³‚µ
+	@param[out] ppEditNode é…åˆ—ã‚’å—ã‘å–ã‚‹ãƒã‚¤ãƒ³ã‚¿
+		æˆ»ã‚Šå€¤ãŒ0ã®å ´åˆã¯NULLãŒè¿”ã•ã‚Œã‚‹ãŒï¼Œãã‚Œã‚’æœŸå¾…ã—ãªã„ã“ã¨ï¼
+		ã¾ãŸï¼Œä¸è¦ã«ãªã£ãŸã‚‰delete []ã—ãªãã¦ã¯ãªã‚‰ãªã„ï¼
+	@param[in] bSort TRUE: ã‚½ãƒ¼ãƒˆã‚ã‚Š / FALSE: ã‚½ãƒ¼ãƒˆç„¡ã—
+	@param[in]bGSort TRUE: ã‚°ãƒ«ãƒ¼ãƒ—ã‚½ãƒ¼ãƒˆã‚ã‚Š / FALSE: ã‚°ãƒ«ãƒ¼ãƒ—ã‚½ãƒ¼ãƒˆç„¡ã—
 
-	‚à‚Æ‚Ì•ÒWƒEƒBƒ“ƒhƒEƒŠƒXƒg‚Íƒ\[ƒg‚µ‚È‚¯‚ê‚ÎƒEƒBƒ“ƒhƒE‚ÌMRU‡‚É•À‚ñ‚Å‚¢‚é
+	ã‚‚ã¨ã®ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆã¯ã‚½ãƒ¼ãƒˆã—ãªã‘ã‚Œã°ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®MRUé †ã«ä¸¦ã‚“ã§ã„ã‚‹
 	-------------------------------------------------
-	bSort	bGSort	ˆ—Œ‹‰Ê
+	bSort	bGSort	å‡¦ç†çµæœ
 	-------------------------------------------------
-	FALSE	FALSE	ƒOƒ‹[ƒvMRU‡|ƒEƒBƒ“ƒhƒEMRU‡
-	TRUE	FALSE	ƒOƒ‹[ƒvMRU‡|ƒEƒBƒ“ƒhƒE”Ô†‡
-	FALSE	TRUE	ƒOƒ‹[ƒv”Ô†‡|ƒEƒBƒ“ƒhƒEMRU‡
-	TRUE	TRUE	ƒOƒ‹[ƒv”Ô†‡|ƒEƒBƒ“ƒhƒE”Ô†‡
+	FALSE	FALSE	ã‚°ãƒ«ãƒ¼ãƒ—MRUé †ï¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦MRUé †
+	TRUE	FALSE	ã‚°ãƒ«ãƒ¼ãƒ—MRUé †ï¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç•ªå·é †
+	FALSE	TRUE	ã‚°ãƒ«ãƒ¼ãƒ—ç•ªå·é †ï¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦MRUé †
+	TRUE	TRUE	ã‚°ãƒ«ãƒ¼ãƒ—ç•ªå·é †ï¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç•ªå·é †
 	-------------------------------------------------
 
-	@return ”z—ñ‚Ì—v‘f”‚ğ•Ô‚·
-	@note —v‘f”>0 ‚Ìê‡‚ÍŒÄ‚Ño‚µ‘¤‚Å”z—ñ‚ğdelete []‚µ‚Ä‚­‚¾‚³‚¢
+	@return é…åˆ—ã®è¦ç´ æ•°ã‚’è¿”ã™
+	@note è¦ç´ æ•°>0 ã®å ´åˆã¯å‘¼ã³å‡ºã—å´ã§é…åˆ—ã‚’delete []ã—ã¦ãã ã•ã„
 
-	@date 2003.06.28 MIK CRecent—˜—p‚Å‘‚«Š·‚¦
-	@date 2007.06.20 ryoji bGroupˆø”’Ç‰ÁAƒ\[ƒgˆ—‚ğ©‘O‚Ì‚à‚Ì‚©‚çqsort‚É•ÏX
+	@date 2003.06.28 MIK CRecentåˆ©ç”¨ã§æ›¸ãæ›ãˆ
+	@date 2007.06.20 ryoji bGroupå¼•æ•°è¿½åŠ ã€ã‚½ãƒ¼ãƒˆå‡¦ç†ã‚’è‡ªå‰ã®ã‚‚ã®ã‹ã‚‰qsortã«å¤‰æ›´
 */
 int CAppNodeManager::GetOpenedWindowArr( EditNode** ppEditNode, BOOL bSort, BOOL bGSort/* = FALSE */ )
 {
@@ -572,27 +572,27 @@ int CAppNodeManager::GetOpenedWindowArr( EditNode** ppEditNode, BOOL bSort, BOOL
 	return nRet;
 }
 
-// GetOpenedWindowArrŠÖ”ƒRƒAˆ—•”
+// GetOpenedWindowArré–¢æ•°ã‚³ã‚¢å‡¦ç†éƒ¨
 int CAppNodeManager::_GetOpenedWindowArrCore( EditNode** ppEditNode, BOOL bSort, BOOL bGSort/* = FALSE */ )
 {
 	DLLSHAREDATA* pShare = &GetDllShareData();
 
-	//•ÒWƒEƒCƒ“ƒhƒE”‚ğæ“¾‚·‚éB
-	EditNodeEx*	pNode;	// ƒ\[ƒgˆ——p‚ÌŠg’£ƒŠƒXƒg
-	int		nRowNum;	//•ÒWƒEƒCƒ“ƒhƒE”
+	//ç·¨é›†ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦æ•°ã‚’å–å¾—ã™ã‚‹ã€‚
+	EditNodeEx*	pNode;	// ã‚½ãƒ¼ãƒˆå‡¦ç†ç”¨ã®æ‹¡å¼µãƒªã‚¹ãƒˆ
+	int		nRowNum;	//ç·¨é›†ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦æ•°
 	int		i;
 
-	//•ÒWƒEƒCƒ“ƒhƒE”‚ğæ“¾‚·‚éB
+	//ç·¨é›†ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦æ•°ã‚’å–å¾—ã™ã‚‹ã€‚
 	*ppEditNode = NULL;
 	if( pShare->m_sNodes.m_nEditArrNum <= 0 )
 		return 0;
 
-	//•ÒWƒEƒCƒ“ƒhƒEƒŠƒXƒgŠi”[—Ìˆæ‚ğì¬‚·‚éB
+	//ç·¨é›†ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆæ ¼ç´é ˜åŸŸã‚’ä½œæˆã™ã‚‹ã€‚
 	*ppEditNode = new EditNode[ pShare->m_sNodes.m_nEditArrNum ];
 	if( NULL == *ppEditNode )
 		return 0;
 
-	// Šg’£ƒŠƒXƒg‚ğì¬‚·‚é
+	// æ‹¡å¼µãƒªã‚¹ãƒˆã‚’ä½œæˆã™ã‚‹
 	pNode = new EditNodeEx[ pShare->m_sNodes.m_nEditArrNum ];
 	if( NULL == pNode )
 	{
@@ -601,14 +601,14 @@ int CAppNodeManager::_GetOpenedWindowArrCore( EditNode** ppEditNode, BOOL bSort,
 		return 0;
 	}
 
-	// Šg’£ƒŠƒXƒg‚ÌŠe—v‘f‚É•ÒWƒEƒBƒ“ƒhƒEƒŠƒXƒg‚ÌŠe—v‘f‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğŠi”[‚·‚é
+	// æ‹¡å¼µãƒªã‚¹ãƒˆã®å„è¦ç´ ã«ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆã®å„è¦ç´ ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’æ ¼ç´ã™ã‚‹
 	nRowNum = 0;
 	for( i = 0; i < pShare->m_sNodes.m_nEditArrNum; i++ )
 	{
 		if( IsSakuraMainWindow( pShare->m_sNodes.m_pEditArr[ i ].m_hWnd ) )
 		{
-			pNode[ nRowNum ].p = &pShare->m_sNodes.m_pEditArr[ i ];	// ƒ|ƒCƒ“ƒ^Ši”[
-			pNode[ nRowNum ].nGroupMru = -1;	// ƒOƒ‹[ƒv’PˆÊ‚ÌMRU”Ô†‰Šú‰»
+			pNode[ nRowNum ].p = &pShare->m_sNodes.m_pEditArr[ i ];	// ãƒã‚¤ãƒ³ã‚¿æ ¼ç´
+			pNode[ nRowNum ].nGroupMru = -1;	// ã‚°ãƒ«ãƒ¼ãƒ—å˜ä½ã®MRUç•ªå·åˆæœŸåŒ–
 			nRowNum++;
 		}
 	}
@@ -620,10 +620,10 @@ int CAppNodeManager::_GetOpenedWindowArrCore( EditNode** ppEditNode, BOOL bSort,
 		return 0;
 	}
 
-	// Šg’£ƒŠƒXƒgã‚ÅƒOƒ‹[ƒv’PˆÊ‚ÌMRU”Ô†‚ğ‚Â‚¯‚é
+	// æ‹¡å¼µãƒªã‚¹ãƒˆä¸Šã§ã‚°ãƒ«ãƒ¼ãƒ—å˜ä½ã®MRUç•ªå·ã‚’ã¤ã‘ã‚‹
 	if( !bGSort )
 	{
-		int iGroupMru = 0;	// ƒOƒ‹[ƒv’PˆÊ‚ÌMRU”Ô†
+		int iGroupMru = 0;	// ã‚°ãƒ«ãƒ¼ãƒ—å˜ä½ã®MRUç•ªå·
 		int nGroup = -1;
 		for( i = 0; i < nRowNum; i++ )
 		{
@@ -631,9 +631,9 @@ int CAppNodeManager::_GetOpenedWindowArrCore( EditNode** ppEditNode, BOOL bSort,
 			{
 				nGroup = pNode[ i ].p->m_nGroup;
 				iGroupMru++;
-				pNode[ i ].nGroupMru = iGroupMru;	// MRU”Ô†•t—^
+				pNode[ i ].nGroupMru = iGroupMru;	// MRUç•ªå·ä»˜ä¸
 
-				// “¯ˆêƒOƒ‹[ƒv‚ÌƒEƒBƒ“ƒhƒE‚É“¯‚¶MRU”Ô†‚ğ‚Â‚¯‚é
+				// åŒä¸€ã‚°ãƒ«ãƒ¼ãƒ—ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«åŒã˜MRUç•ªå·ã‚’ã¤ã‘ã‚‹
 				int j;
 				for( j = i + 1; j < nRowNum; j++ )
 				{
@@ -644,21 +644,21 @@ int CAppNodeManager::_GetOpenedWindowArrCore( EditNode** ppEditNode, BOOL bSort,
 		}
 	}
 
-	// Šg’£ƒŠƒXƒg‚ğƒ\[ƒg‚·‚é
-	// Note. ƒOƒ‹[ƒv‚ª‚PŒÂ‚¾‚¯‚Ìê‡‚Í]—ˆibGSort ˆø”–³‚µj‚Æ“¯‚¶Œ‹‰Ê‚ª“¾‚ç‚ê‚é
-	//       iƒOƒ‹[ƒv‰»‚·‚éİ’è‚Å‚È‚¯‚ê‚ÎƒOƒ‹[ƒv‚Í‚PŒÂj
+	// æ‹¡å¼µãƒªã‚¹ãƒˆã‚’ã‚½ãƒ¼ãƒˆã™ã‚‹
+	// Note. ã‚°ãƒ«ãƒ¼ãƒ—ãŒï¼‘å€‹ã ã‘ã®å ´åˆã¯å¾“æ¥ï¼ˆbGSort å¼•æ•°ç„¡ã—ï¼‰ã¨åŒã˜çµæœãŒå¾—ã‚‰ã‚Œã‚‹
+	//       ï¼ˆã‚°ãƒ«ãƒ¼ãƒ—åŒ–ã™ã‚‹è¨­å®šã§ãªã‘ã‚Œã°ã‚°ãƒ«ãƒ¼ãƒ—ã¯ï¼‘å€‹ï¼‰
 	s_bSort = bSort;
 	s_bGSort = bGSort;
 	qsort( pNode, nRowNum, sizeof(EditNodeEx), cmpGetOpenedWindowArr );
 
-	// Šg’£ƒŠƒXƒg‚Ìƒ\[ƒgŒ‹‰Ê‚ğ‚à‚Æ‚É•ÒWƒEƒCƒ“ƒhƒEƒŠƒXƒgŠi”[—Ìˆæ‚ÉŒ‹‰Ê‚ğŠi”[‚·‚é
+	// æ‹¡å¼µãƒªã‚¹ãƒˆã®ã‚½ãƒ¼ãƒˆçµæœã‚’ã‚‚ã¨ã«ç·¨é›†ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆæ ¼ç´é ˜åŸŸã«çµæœã‚’æ ¼ç´ã™ã‚‹
 	for( i = 0; i < nRowNum; i++ )
 	{
 		(*ppEditNode)[i] = *pNode[i].p;
 
-		//ƒCƒ“ƒfƒbƒNƒX‚ğ•t‚¯‚éB
-		//‚±‚ÌƒCƒ“ƒfƒbƒNƒX‚Í m_pEditArr ‚Ì”z—ñ”Ô†‚Å‚·B
-		(*ppEditNode)[i].m_nIndex = pNode[i].p - pShare->m_sNodes.m_pEditArr;	// ƒ|ƒCƒ“ƒ^Œ¸Z”z—ñ”Ô†
+		//ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ã‚’ä»˜ã‘ã‚‹ã€‚
+		//ã“ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ã¯ m_pEditArr ã®é…åˆ—ç•ªå·ã§ã™ã€‚
+		(*ppEditNode)[i].m_nIndex = pNode[i].p - pShare->m_sNodes.m_pEditArr;	// ãƒã‚¤ãƒ³ã‚¿æ¸›ç®—ï¼é…åˆ—ç•ªå·
 	}
 
 	delete []pNode;
@@ -666,13 +666,13 @@ int CAppNodeManager::_GetOpenedWindowArrCore( EditNode** ppEditNode, BOOL bSort,
 	return nRowNum;
 }
 
-/** ƒEƒBƒ“ƒhƒE‚Ì•À‚Ñ‘Ö‚¦
+/** ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä¸¦ã³æ›¿ãˆ
 
-	@param[in] hwndSrc ˆÚ“®‚·‚éƒEƒBƒ“ƒhƒE
-	@param[in] hwndDst ˆÚ“®æƒEƒBƒ“ƒhƒE
+	@param[in] hwndSrc ç§»å‹•ã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	@param[in] hwndDst ç§»å‹•å…ˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
 
 	@author ryoji
-	@date 2007.07.07 genta ƒEƒBƒ“ƒhƒE”z—ñ‘€ì•”‚ğCTabWnd‚æ‚èˆÚ“®
+	@date 2007.07.07 genta ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦é…åˆ—æ“ä½œéƒ¨ã‚’CTabWndã‚ˆã‚Šç§»å‹•
 */
 bool CAppNodeManager::ReorderTab( HWND hwndSrc, HWND hwndDst )
 {
@@ -685,7 +685,7 @@ bool CAppNodeManager::ReorderTab( HWND hwndSrc, HWND hwndDst )
 	int nSrcTab = -1;
 	int nDstTab = -1;
 	LockGuard<CMutex> guard( g_cEditArrMutex );
-	nCount = _GetOpenedWindowArrCore( &p, TRUE );	// ƒƒbƒN‚Í©•ª‚Å‚â‚Á‚Ä‚¢‚é‚Ì‚Å’¼ÚƒRƒA•”ŒÄ‚Ño‚µ
+	nCount = _GetOpenedWindowArrCore( &p, TRUE );	// ãƒ­ãƒƒã‚¯ã¯è‡ªåˆ†ã§ã‚„ã£ã¦ã„ã‚‹ã®ã§ç›´æ¥ã‚³ã‚¢éƒ¨å‘¼ã³å‡ºã—
 	for( i = 0; i < nCount; i++ )
 	{
 		if( hwndSrc == p[i].m_hWnd )
@@ -700,7 +700,7 @@ bool CAppNodeManager::ReorderTab( HWND hwndSrc, HWND hwndDst )
 		return false;
 	}
 
-	// ƒ^ƒu‚Ì‡˜‚ğ“ü‚ê‘Ö‚¦‚é‚½‚ß‚ÉƒEƒBƒ“ƒhƒE‚ÌƒCƒ“ƒfƒbƒNƒX‚ğ“ü‚ê‘Ö‚¦‚é
+	// ã‚¿ãƒ–ã®é †åºã‚’å…¥ã‚Œæ›¿ãˆã‚‹ãŸã‚ã«ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ã‚’å…¥ã‚Œæ›¿ãˆã‚‹
 	int nArr0, nArr1;
 	int	nIndex;
 
@@ -708,7 +708,7 @@ bool CAppNodeManager::ReorderTab( HWND hwndSrc, HWND hwndDst )
 	nIndex = pShare->m_sNodes.m_pEditArr[ nArr0 ].m_nIndex;
 	if( nSrcTab < nDstTab )
 	{
-		// ƒ^ƒu¶•ûŒüƒ[ƒe[ƒg
+		// ã‚¿ãƒ–å·¦æ–¹å‘ãƒ­ãƒ¼ãƒ†ãƒ¼ãƒˆ
 		for( i = nDstTab - 1; i >= nSrcTab; i-- )
 		{
 			nArr1 = p[ i ].m_nIndex;
@@ -718,7 +718,7 @@ bool CAppNodeManager::ReorderTab( HWND hwndSrc, HWND hwndDst )
 	}
 	else
 	{
-		// ƒ^ƒu‰E•ûŒüƒ[ƒe[ƒg
+		// ã‚¿ãƒ–å³æ–¹å‘ãƒ­ãƒ¼ãƒ†ãƒ¼ãƒˆ
 		for( i = nDstTab + 1; i <= nSrcTab; i++ )
 		{
 			nArr1 = p[ i ].m_nIndex;
@@ -732,17 +732,17 @@ bool CAppNodeManager::ReorderTab( HWND hwndSrc, HWND hwndDst )
 	return true;
 }
 
-/** ƒ^ƒuˆÚ“®‚É”º‚¤ƒEƒBƒ“ƒhƒEˆ—
+/** ã‚¿ãƒ–ç§»å‹•ã«ä¼´ã†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å‡¦ç†
 
-	@param[in] hwndSrc ˆÚ“®‚·‚éƒEƒBƒ“ƒhƒE
-	@param[in] hwndDst ˆÚ“®æƒEƒBƒ“ƒhƒEDV‹K“Æ—§‚ÍNULLD
-	@param[in] bSrcIsTop ˆÚ“®‚·‚éƒEƒBƒ“ƒhƒE‚ª‰Â‹ƒEƒBƒ“ƒhƒE‚È‚çtrue
-	@param[in] notifygroups ƒ^ƒu‚ÌXV‚ª•K—v‚ÈƒOƒ‹[ƒv‚ÌƒOƒ‹[ƒvIDDint[2]‚ğŒÄ‚Ño‚µŒ³‚Å—pˆÓ‚·‚éD
+	@param[in] hwndSrc ç§»å‹•ã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	@param[in] hwndDst ç§»å‹•å…ˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ï¼æ–°è¦ç‹¬ç«‹æ™‚ã¯NULLï¼
+	@param[in] bSrcIsTop ç§»å‹•ã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒå¯è¦–ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãªã‚‰true
+	@param[in] notifygroups ã‚¿ãƒ–ã®æ›´æ–°ãŒå¿…è¦ãªã‚°ãƒ«ãƒ¼ãƒ—ã®ã‚°ãƒ«ãƒ¼ãƒ—IDï¼int[2]ã‚’å‘¼ã³å‡ºã—å…ƒã§ç”¨æ„ã™ã‚‹ï¼
 
-	@return XV‚³‚ê‚½hwndDst (ˆÚ“®æ‚ªŠù‚É•Â‚¶‚ç‚ê‚½ê‡‚È‚Ç‚ÉNULL‚É•ÏX‚³‚ê‚é‚±‚Æ‚ª‚ ‚é)
+	@return æ›´æ–°ã•ã‚ŒãŸhwndDst (ç§»å‹•å…ˆãŒæ—¢ã«é–‰ã˜ã‚‰ã‚ŒãŸå ´åˆãªã©ã«NULLã«å¤‰æ›´ã•ã‚Œã‚‹ã“ã¨ãŒã‚ã‚‹)
 
 	@author ryoji
-	@date 2007.07.07 genta CTabWnd::SeparateGroup()‚æ‚è“Æ—§
+	@date 2007.07.07 genta CTabWnd::SeparateGroup()ã‚ˆã‚Šç‹¬ç«‹
 */
 HWND CAppNodeManager::SeparateGroup( HWND hwndSrc, HWND hwndDst, bool bSrcIsTop, int notifygroups[] )
 {
@@ -757,18 +757,18 @@ HWND CAppNodeManager::SeparateGroup( HWND hwndSrc, HWND hwndDst, bool bSrcIsTop,
 	if( pDstEditNode == NULL )
 	{
 		hwndDst = NULL;
-		nDstGroup = ++pShare->m_sNodes.m_nGroupSequences;	// V‹KƒOƒ‹[ƒv
+		nDstGroup = ++pShare->m_sNodes.m_nGroupSequences;	// æ–°è¦ã‚°ãƒ«ãƒ¼ãƒ—
 	}
 	else
 	{
-		nDstGroup = pDstEditNode->m_nGroup;	// Šù‘¶ƒOƒ‹[ƒv
+		nDstGroup = pDstEditNode->m_nGroup;	// æ—¢å­˜ã‚°ãƒ«ãƒ¼ãƒ—
 	}
 
 	pSrcEditNode->m_nGroup = nDstGroup;
-	pSrcEditNode->m_nIndex = ++pShare->m_sNodes.m_nSequences;	// ƒ^ƒu•À‚Ñ‚ÌÅŒãi‹N“®‡‚ÌÅŒãj‚É‚à‚Á‚Ä‚¢‚­
+	pSrcEditNode->m_nIndex = ++pShare->m_sNodes.m_nSequences;	// ã‚¿ãƒ–ä¸¦ã³ã®æœ€å¾Œï¼ˆèµ·å‹•é †ã®æœ€å¾Œï¼‰ã«ã‚‚ã£ã¦ã„ã
 
-	// ”ñ•\¦‚Ìƒ^ƒu‚ğŠù‘¶ƒOƒ‹[ƒv‚ÉˆÚ“®‚·‚é‚Æ‚«‚Í”ñ•\¦‚Ì‚Ü‚Ü‚É‚·‚é‚Ì‚Å
-	// “à•”î•ñ‚àæ“ª‚É‚Í‚È‚ç‚È‚¢‚æ‚¤A•K—v‚È‚çæ“ªƒEƒBƒ“ƒhƒE‚ÆˆÊ’u‚ğŒğŠ·‚·‚éB
+	// éè¡¨ç¤ºã®ã‚¿ãƒ–ã‚’æ—¢å­˜ã‚°ãƒ«ãƒ¼ãƒ—ã«ç§»å‹•ã™ã‚‹ã¨ãã¯éè¡¨ç¤ºã®ã¾ã¾ã«ã™ã‚‹ã®ã§
+	// å†…éƒ¨æƒ…å ±ã‚‚å…ˆé ­ã«ã¯ãªã‚‰ãªã„ã‚ˆã†ã€å¿…è¦ãªã‚‰å…ˆé ­ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¨ä½ç½®ã‚’äº¤æ›ã™ã‚‹ã€‚
 	if( !bSrcIsTop && pDstEditNode != NULL )
 	{
 		if( pSrcEditNode < pDstEditNode )
@@ -789,12 +789,12 @@ HWND CAppNodeManager::SeparateGroup( HWND hwndSrc, HWND hwndDst, bool bSrcIsTop,
 
 
 
-/** “¯ˆêƒOƒ‹[ƒv‚©‚Ç‚¤‚©‚ğ’²‚×‚é
+/** åŒä¸€ã‚°ãƒ«ãƒ¼ãƒ—ã‹ã©ã†ã‹ã‚’èª¿ã¹ã‚‹
 
-	@param[in] hWnd1 ”äŠr‚·‚éƒEƒBƒ“ƒhƒE1
-	@param[in] hWnd2 ”äŠr‚·‚éƒEƒBƒ“ƒhƒE2
+	@param[in] hWnd1 æ¯”è¼ƒã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦1
+	@param[in] hWnd2 æ¯”è¼ƒã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦2
 	
-	@return 2‚Â‚ÌƒEƒBƒ“ƒhƒE‚ª“¯ˆêƒOƒ‹[ƒv‚É‘®‚µ‚Ä‚¢‚ê‚Îtrue
+	@return 2ã¤ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒåŒä¸€ã‚°ãƒ«ãƒ¼ãƒ—ã«å±ã—ã¦ã„ã‚Œã°true
 
 	@date 2007.06.20 ryoji
 */
@@ -812,24 +812,24 @@ bool CAppNodeManager::IsSameGroup( HWND hWnd1, HWND hWnd2 )
 	return false;
 }
 
-/* ‹ó‚¢‚Ä‚¢‚éƒOƒ‹[ƒv”Ô†‚ğæ“¾‚·‚é */
+/* ç©ºã„ã¦ã„ã‚‹ã‚°ãƒ«ãƒ¼ãƒ—ç•ªå·ã‚’å–å¾—ã™ã‚‹ */
 int CAppNodeManager::GetFreeGroupId( void )
 {
 	DLLSHAREDATA* pShare = &GetDllShareData();
 
-	return ++pShare->m_sNodes.m_nGroupSequences;	// V‹KƒOƒ‹[ƒv
+	return ++pShare->m_sNodes.m_nGroupSequences;	// æ–°è¦ã‚°ãƒ«ãƒ¼ãƒ—
 }
 
 
-// Close ‚µ‚½‚ÌŸ‚ÌWindow‚ğæ“¾‚·‚é
-//  (ƒ^ƒu‚Ü‚Æ‚ß•\¦‚Ìê‡)
+// Close ã—ãŸæ™‚ã®æ¬¡ã®Windowã‚’å–å¾—ã™ã‚‹
+//  (ã‚¿ãƒ–ã¾ã¨ã‚è¡¨ç¤ºã®å ´åˆ)
 //
-//	@param hWndCur [in] Close‘ÎÛ‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹
-//	@retval ƒNƒ[ƒYŒãˆÚ“®‚·‚éƒEƒBƒ“ƒhƒE
-//			NULL‚Íƒ^ƒu‚Ü‚Æ‚ß•\¦‚Å–³‚¢‚©ƒOƒ‹[ƒv‚É‘¼‚ÉƒEƒBƒ“ƒhƒE‚ª–³‚¢ê‡
+//	@param hWndCur [in] Closeå¯¾è±¡ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«
+//	@retval ã‚¯ãƒ­ãƒ¼ã‚ºå¾Œç§»å‹•ã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+//			NULLã¯ã‚¿ãƒ–ã¾ã¨ã‚è¡¨ç¤ºã§ç„¡ã„ã‹ã‚°ãƒ«ãƒ¼ãƒ—ã«ä»–ã«ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒç„¡ã„å ´åˆ
 //
 //	@date 2013.04.10 Uchi
-//	@date 2013.10.25 Moca Ÿ‚ÌƒEƒBƒ“ƒhƒE‚Íu1‚Â‘O‚ÌƒAƒNƒeƒBƒu‚Èƒ^ƒuv‚É‚·‚é
+//	@date 2013.10.25 Moca æ¬¡ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¯ã€Œ1ã¤å‰ã®ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ãªã‚¿ãƒ–ã€ã«ã™ã‚‹
 //
 HWND CAppNodeManager::GetNextTab(HWND hWndCur)
 {
@@ -840,7 +840,7 @@ HWND CAppNodeManager::GetNextTab(HWND hWndCur)
 		int			nGroup = 0;
 		bool		bFound = false;
 		EditNode*	p = NULL;
-//		int			nCount = CAppNodeManager::getInstance()->GetOpenedWindowArr( &p, TRUE );	// ƒ^ƒu‚Ì•À‚Ñ‡ƒ\[ƒgiƒeƒXƒg—pj
+//		int			nCount = CAppNodeManager::getInstance()->GetOpenedWindowArr( &p, TRUE );	// ã‚¿ãƒ–ã®ä¸¦ã³é †ã‚½ãƒ¼ãƒˆï¼ˆãƒ†ã‚¹ãƒˆç”¨ï¼‰
 		int			nCount = CAppNodeManager::getInstance()->GetOpenedWindowArr( &p, FALSE, FALSE );
 		if ( nCount > 1 ) {
 			// search Group No.

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -29,17 +29,17 @@
 
 class CAppNodeGroupHandle;
 
-//! •ÒWƒEƒBƒ“ƒhƒEƒm[ƒh
+//! ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ¼ãƒ‰
 struct EditNode {
 	int				m_nIndex;
-	int				m_nGroup;					//!< ƒOƒ‹[ƒvID								//@@@ 2007.06.20 ryoji
+	int				m_nGroup;					//!< ã‚°ãƒ«ãƒ¼ãƒ—ID								//@@@ 2007.06.20 ryoji
 	HWND			m_hWnd;
-	int				m_nId;						//!< –³‘èId
-	WIN_CHAR		m_szTabCaption[_MAX_PATH];	//!< ƒ^ƒuƒEƒCƒ“ƒhƒE—pFƒLƒƒƒvƒVƒ‡ƒ“–¼		//@@@ 2003.05.31 MIK
-	SFilePath		m_szFilePath;				//!< ƒ^ƒuƒEƒCƒ“ƒhƒE—pFƒtƒ@ƒCƒ‹–¼			//@@@ 2006.01.28 ryoji
-	bool			m_bIsGrep;					//!< Grep‚ÌƒEƒBƒ“ƒhƒE‚©						//@@@ 2006.01.28 ryoji
-	UINT			m_showCmdRestore;			//!< Œ³‚ÌƒTƒCƒY‚É–ß‚·‚Æ‚«‚ÌƒTƒCƒYí•Ê		//@@@ 2007.06.20 ryoji
-	BOOL			m_bClosing;					//!< I—¹’†‚©iuÅŒã‚Ìƒtƒ@ƒCƒ‹‚ğ•Â‚¶‚Ä‚à(–³‘è)‚ğc‚·v—pj	//@@@ 2007.06.20 ryoji
+	int				m_nId;						//!< ç„¡é¡ŒId
+	WIN_CHAR		m_szTabCaption[_MAX_PATH];	//!< ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ç”¨ï¼šã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³å		//@@@ 2003.05.31 MIK
+	SFilePath		m_szFilePath;				//!< ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ç”¨ï¼šãƒ•ã‚¡ã‚¤ãƒ«å			//@@@ 2006.01.28 ryoji
+	bool			m_bIsGrep;					//!< Grepã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‹						//@@@ 2006.01.28 ryoji
+	UINT			m_showCmdRestore;			//!< å…ƒã®ã‚µã‚¤ã‚ºã«æˆ»ã™ã¨ãã®ã‚µã‚¤ã‚ºç¨®åˆ¥		//@@@ 2007.06.20 ryoji
+	BOOL			m_bClosing;					//!< çµ‚äº†ä¸­ã‹ï¼ˆã€Œæœ€å¾Œã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‰ã˜ã¦ã‚‚(ç„¡é¡Œ)ã‚’æ®‹ã™ã€ç”¨ï¼‰	//@@@ 2007.06.20 ryoji
 
 	HWND GetHwnd() const{ return GetSafeHwnd(); }
 	HWND GetSafeHwnd() const{ if(this)return m_hWnd; else return NULL; }
@@ -49,24 +49,24 @@ struct EditNode {
 	bool IsTopInGroup() const;
 };
 
-//! Šg’£\‘¢‘Ì
+//! æ‹¡å¼µæ§‹é€ ä½“
 struct EditNodeEx{
-	EditNode*	p;			//!< •ÒWƒEƒBƒ“ƒhƒE”z—ñ—v‘f‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	int			nGroupMru;	//!< ƒOƒ‹[ƒv’PˆÊ‚ÌMRU”Ô†
+	EditNode*	p;			//!< ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦é…åˆ—è¦ç´ ã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	int			nGroupMru;	//!< ã‚°ãƒ«ãƒ¼ãƒ—å˜ä½ã®MRUç•ªå·
 };
 
 
-//! ‹¤—Lƒƒ‚ƒŠ“à\‘¢‘Ì
+//! å…±æœ‰ãƒ¡ãƒ¢ãƒªå†…æ§‹é€ ä½“
 struct SShare_Nodes{
-	int					m_nEditArrNum;	//short->int‚ÉC³	//@@@ 2003.05.31 MIK
-	EditNode			m_pEditArr[MAX_EDITWINDOWS];	//Å‘å’lC³	@@@ 2003.05.31 MIK
-	LONG				m_nSequences;	/* ƒEƒBƒ“ƒhƒE˜A”Ô */
-	LONG				m_nNonameSequences;	/* –³‘è˜A”Ô */
-	LONG				m_nGroupSequences;	// ƒ^ƒuƒOƒ‹[ƒv˜A”Ô	// 2007.06.20 ryoji
+	int					m_nEditArrNum;	//short->intã«ä¿®æ­£	//@@@ 2003.05.31 MIK
+	EditNode			m_pEditArr[MAX_EDITWINDOWS];	//æœ€å¤§å€¤ä¿®æ­£	@@@ 2003.05.31 MIK
+	LONG				m_nSequences;	/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦é€£ç•ª */
+	LONG				m_nNonameSequences;	/* ç„¡é¡Œé€£ç•ª */
+	LONG				m_nGroupSequences;	// ã‚¿ãƒ–ã‚°ãƒ«ãƒ¼ãƒ—é€£ç•ª	// 2007.06.20 ryoji
 };
 
 
-//! ƒm[ƒhƒAƒNƒZƒT
+//! ãƒãƒ¼ãƒ‰ã‚¢ã‚¯ã‚»ã‚µ
 class CAppNodeHandle{
 public:
 	CAppNodeHandle(HWND hwnd);
@@ -75,24 +75,24 @@ private:
 	EditNode* m_pNodeRef;
 };
 
-//! ƒOƒ‹[ƒvƒAƒNƒZƒT
+//! ã‚°ãƒ«ãƒ¼ãƒ—ã‚¢ã‚¯ã‚»ã‚µ
 class CAppNodeGroupHandle{
 public:
 	CAppNodeGroupHandle(int nGroupId) : m_nGroup(nGroupId) { }
 	CAppNodeGroupHandle(HWND hwnd){ m_nGroup = CAppNodeHandle(hwnd)->GetGroup(); }
 
 	EditNode* GetTopEditNode(){ return GetEditNodeAt(0); }	//
-	EditNode* GetEditNodeAt( int nIndex );					//!< w’èˆÊ’u‚Ì•ÒWƒEƒBƒ“ƒhƒEî•ñ‚ğæ“¾‚·‚é
-	BOOL AddEditWndList( HWND );							//!< •ÒWƒEƒBƒ“ƒhƒE‚Ì“o˜^	// 2007.06.26 ryoji nGroupˆø”’Ç‰Á
-	void DeleteEditWndList( HWND );							//!< •ÒWƒEƒBƒ“ƒhƒEƒŠƒXƒg‚©‚ç‚Ìíœ
+	EditNode* GetEditNodeAt( int nIndex );					//!< æŒ‡å®šä½ç½®ã®ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦æƒ…å ±ã‚’å–å¾—ã™ã‚‹
+	BOOL AddEditWndList( HWND );							//!< ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ç™»éŒ²	// 2007.06.26 ryoji nGroupå¼•æ•°è¿½åŠ 
+	void DeleteEditWndList( HWND );							//!< ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆã‹ã‚‰ã®å‰Šé™¤
 	BOOL RequestCloseEditor( EditNode* pWndArr, int nArrCnt, BOOL bExit, BOOL bCheckConfirm, HWND hWndFrom );
-															//!< ‚¢‚­‚Â‚©‚ÌƒEƒBƒ“ƒhƒE‚ÖI—¹—v‹‚ğo‚·	// 2007.02.13 ryoji u•ÒW‚Ì‘SI—¹v‚ğ¦‚·ˆø”(bExit)‚ğ’Ç‰Á	// 2007.06.20 ryoji nGroupˆø”’Ç‰Á
+															//!< ã„ãã¤ã‹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸çµ‚äº†è¦æ±‚ã‚’å‡ºã™	// 2007.02.13 ryoji ã€Œç·¨é›†ã®å…¨çµ‚äº†ã€ã‚’ç¤ºã™å¼•æ•°(bExit)ã‚’è¿½åŠ 	// 2007.06.20 ryoji nGroupå¼•æ•°è¿½åŠ 
 
-	int GetEditorWindowsNum( bool bExcludeClosing = true );				/* Œ»İ‚Ì•ÒWƒEƒBƒ“ƒhƒE‚Ì”‚ğ’²‚×‚é */	// 2007.06.20 ryoji nGroupˆø”’Ç‰Á	// 2008.04.19 ryoji bExcludeClosingˆø”’Ç‰Á
+	int GetEditorWindowsNum( bool bExcludeClosing = true );				/* ç¾åœ¨ã®ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®æ•°ã‚’èª¿ã¹ã‚‹ */	// 2007.06.20 ryoji nGroupå¼•æ•°è¿½åŠ 	// 2008.04.19 ryoji bExcludeClosingå¼•æ•°è¿½åŠ 
 
-	//‘SƒEƒBƒ“ƒhƒEˆêŠ‡‘€ì
-	BOOL PostMessageToAllEditors( UINT uMsg, WPARAM wParam, LPARAM lParam, HWND hWndLast );	/* ‘S•ÒWƒEƒBƒ“ƒhƒE‚ÖƒƒbƒZ[ƒW‚ğƒ|ƒXƒg‚·‚é */	// 2007.06.20 ryoji nGroupˆø”’Ç‰Á
-	BOOL SendMessageToAllEditors( UINT uMsg, WPARAM wParam, LPARAM lParam, HWND hWndLast );	/* ‘S•ÒWƒEƒBƒ“ƒhƒE‚ÖƒƒbƒZ[ƒW‚ğ‘—‚é‚·‚é */	// 2007.06.20 ryoji nGroupˆø”’Ç‰Á
+	//å…¨ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€æ‹¬æ“ä½œ
+	BOOL PostMessageToAllEditors( UINT uMsg, WPARAM wParam, LPARAM lParam, HWND hWndLast );	/* å…¨ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ãƒã‚¹ãƒˆã™ã‚‹ */	// 2007.06.20 ryoji nGroupå¼•æ•°è¿½åŠ 
+	BOOL SendMessageToAllEditors( UINT uMsg, WPARAM wParam, LPARAM lParam, HWND hWndLast );	/* å…¨ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’é€ã‚‹ã™ã‚‹ */	// 2007.06.20 ryoji nGroupå¼•æ•°è¿½åŠ 
 
 public:
 	bool operator==(const CAppNodeGroupHandle& rhs) const{ return m_nGroup==rhs.m_nGroup; }
@@ -109,27 +109,27 @@ class CAppNodeManager : public TSingleton<CAppNodeManager>{
 	CAppNodeManager(){}
 
 public:
-	//ƒOƒ‹[ƒv
-	void ResetGroupId();									/* ƒOƒ‹[ƒv‚ğIDƒŠƒZƒbƒg‚·‚é */
+	//ã‚°ãƒ«ãƒ¼ãƒ—
+	void ResetGroupId();									/* ã‚°ãƒ«ãƒ¼ãƒ—ã‚’IDãƒªã‚»ãƒƒãƒˆã™ã‚‹ */
 
-	//ƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹ ¨ ƒm[ƒh@•ÏŠ·
-	EditNode* GetEditNode( HWND hWnd );							/* •ÒWƒEƒBƒ“ƒhƒEî•ñ‚ğæ“¾‚·‚é */
+	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ« â†’ ãƒãƒ¼ãƒ‰ã€€å¤‰æ›
+	EditNode* GetEditNode( HWND hWnd );							/* ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦æƒ…å ±ã‚’å–å¾—ã™ã‚‹ */
 	int GetNoNameNumber( HWND );
 
-	//ƒ^ƒu
-	bool ReorderTab( HWND hSrcTab, HWND hDstTab );				/* ƒ^ƒuˆÚ“®‚É”º‚¤ƒEƒBƒ“ƒhƒE‚Ì•À‚Ñ‘Ö‚¦ 2007.07.07 genta */
-	HWND SeparateGroup( HWND hwndSrc, HWND hwndDst, bool bSrcIsTop, int notifygroups[] );/* ƒ^ƒu•ª—£‚É”º‚¤ƒEƒBƒ“ƒhƒEˆ— 2007.07.07 genta */
+	//ã‚¿ãƒ–
+	bool ReorderTab( HWND hSrcTab, HWND hDstTab );				/* ã‚¿ãƒ–ç§»å‹•ã«ä¼´ã†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä¸¦ã³æ›¿ãˆ 2007.07.07 genta */
+	HWND SeparateGroup( HWND hwndSrc, HWND hwndDst, bool bSrcIsTop, int notifygroups[] );/* ã‚¿ãƒ–åˆ†é›¢ã«ä¼´ã†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å‡¦ç† 2007.07.07 genta */
 
-	//‘‡î•ñ
-	int GetOpenedWindowArr( EditNode** , BOOL, BOOL bGSort = FALSE );				/* Œ»İŠJ‚¢‚Ä‚¢‚é•ÒWƒEƒBƒ“ƒhƒE‚Ì”z—ñ‚ğ•Ô‚· */
+	//ç·åˆæƒ…å ±
+	int GetOpenedWindowArr( EditNode** , BOOL, BOOL bGSort = FALSE );				/* ç¾åœ¨é–‹ã„ã¦ã„ã‚‹ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é…åˆ—ã‚’è¿”ã™ */
 
 protected:
-	int _GetOpenedWindowArrCore( EditNode** , BOOL, BOOL bGSort = FALSE );			/* Œ»İŠJ‚¢‚Ä‚¢‚é•ÒWƒEƒBƒ“ƒhƒE‚Ì”z—ñ‚ğ•Ô‚·iƒRƒAˆ—•”j */
+	int _GetOpenedWindowArrCore( EditNode** , BOOL, BOOL bGSort = FALSE );			/* ç¾åœ¨é–‹ã„ã¦ã„ã‚‹ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é…åˆ—ã‚’è¿”ã™ï¼ˆã‚³ã‚¢å‡¦ç†éƒ¨ï¼‰ */
 
 public:
-	static bool IsSameGroup( HWND hWnd1, HWND hWnd2 );					/* “¯ˆêƒOƒ‹[ƒv‚©‚Ç‚¤‚©‚ğ’²‚×‚é */
-	int GetFreeGroupId( void );											/* ‹ó‚¢‚Ä‚¢‚éƒOƒ‹[ƒv”Ô†‚ğæ“¾‚·‚é */
-	HWND GetNextTab(HWND hWndCur);										// Close ‚µ‚½‚ÌŸ‚ÌWindow‚ğæ“¾‚·‚é(ƒ^ƒu‚Ü‚Æ‚ß•\¦‚Ìê‡)	2013/4/10 Uchi
+	static bool IsSameGroup( HWND hWnd1, HWND hWnd2 );					/* åŒä¸€ã‚°ãƒ«ãƒ¼ãƒ—ã‹ã©ã†ã‹ã‚’èª¿ã¹ã‚‹ */
+	int GetFreeGroupId( void );											/* ç©ºã„ã¦ã„ã‚‹ã‚°ãƒ«ãƒ¼ãƒ—ç•ªå·ã‚’å–å¾—ã™ã‚‹ */
+	HWND GetNextTab(HWND hWndCur);										// Close ã—ãŸæ™‚ã®æ¬¡ã®Windowã‚’å–å¾—ã™ã‚‹(ã‚¿ãƒ–ã¾ã¨ã‚è¡¨ç¤ºã®å ´åˆ)	2013/4/10 Uchi
 };
 
 

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -31,25 +31,25 @@
 #include "CFileExt.h"
 #include <Shlwapi.h>	// PathMatchSpec
 
-const TCHAR* CDocTypeManager::m_typeExtSeps = _T(" ;,");	// ƒ^ƒCƒv•ÊŠg’£q ‹æØ‚è•¶š
-const TCHAR* CDocTypeManager::m_typeExtWildcards = _T("*?");	// ƒ^ƒCƒv•ÊŠg’£q ƒƒCƒ‹ƒhƒJ[ƒh
+const TCHAR* CDocTypeManager::m_typeExtSeps = _T(" ;,");	// ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ åŒºåˆ‡ã‚Šæ–‡å­—
+const TCHAR* CDocTypeManager::m_typeExtWildcards = _T("*?");	// ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ ãƒ¯ã‚¤ãƒ«ãƒ‰ã‚«ãƒ¼ãƒ‰
 
 static CMutex g_cDocTypeMutex( FALSE, GSTR_MUTEX_SAKURA_DOCTYPE );
 
 
 /*!
-	ƒtƒ@ƒCƒ‹–¼‚©‚çAƒhƒLƒ…ƒƒ“ƒgƒ^ƒCƒvi”’lj‚ğæ“¾‚·‚é
+	ãƒ•ã‚¡ã‚¤ãƒ«åã‹ã‚‰ã€ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚¿ã‚¤ãƒ—ï¼ˆæ•°å€¤ï¼‰ã‚’å–å¾—ã™ã‚‹
 	
-	@param pszFilePath [in] ƒtƒ@ƒCƒ‹–¼
+	@param pszFilePath [in] ãƒ•ã‚¡ã‚¤ãƒ«å
 	
-	Šg’£q‚ğØ‚èo‚µ‚Ä GetDocumentTypeOfExt ‚É“n‚·‚¾‚¯D
-	@date 2014.12.06 syat ƒƒCƒ‹ƒhƒJ[ƒh‘Î‰B‚QdŠg’£q‘Î‰‚ğ‚â‚ß‚é
+	æ‹¡å¼µå­ã‚’åˆ‡ã‚Šå‡ºã—ã¦ GetDocumentTypeOfExt ã«æ¸¡ã™ã ã‘ï¼
+	@date 2014.12.06 syat ãƒ¯ã‚¤ãƒ«ãƒ‰ã‚«ãƒ¼ãƒ‰å¯¾å¿œã€‚ï¼’é‡æ‹¡å¼µå­å¯¾å¿œã‚’ã‚„ã‚ã‚‹
 */
 CTypeConfig CDocTypeManager::GetDocumentTypeOfPath( const TCHAR* pszFilePath )
 {
 	int		i;
 
-	// ƒtƒ@ƒCƒ‹–¼‚ğ’Šo
+	// ãƒ•ã‚¡ã‚¤ãƒ«åã‚’æŠ½å‡º
 	const TCHAR* pszFileName = pszFilePath;
 	const TCHAR* pszSep = _tcsrchr(pszFilePath, _T('\\'));
 	if (pszSep) {
@@ -60,7 +60,7 @@ CTypeConfig CDocTypeManager::GetDocumentTypeOfPath( const TCHAR* pszFilePath )
 		const STypeConfigMini* mini;
 		GetTypeConfigMini(CTypeConfig(i), &mini);
 		if (IsFileNameMatch(mini->m_szTypeExts, pszFileName)) {
-			return CTypeConfig(i);	//	”Ô†
+			return CTypeConfig(i);	//	ç•ªå·
 		}
 	}
 	return CTypeConfig(0);
@@ -68,15 +68,15 @@ CTypeConfig CDocTypeManager::GetDocumentTypeOfPath( const TCHAR* pszFilePath )
 
 
 /*!
-	Šg’£q‚©‚çAƒhƒLƒ…ƒƒ“ƒgƒ^ƒCƒvi”’lj‚ğæ“¾‚·‚é
+	æ‹¡å¼µå­ã‹ã‚‰ã€ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚¿ã‚¤ãƒ—ï¼ˆæ•°å€¤ï¼‰ã‚’å–å¾—ã™ã‚‹
 	
-	@param pszExt [in] Šg’£q (æ“ª‚Ì.‚ÍŠÜ‚Ü‚È‚¢)
+	@param pszExt [in] æ‹¡å¼µå­ (å…ˆé ­ã®.ã¯å«ã¾ãªã„)
 	
-	w’è‚³‚ê‚½Šg’£q‚Ì‘®‚·‚é•¶‘ƒ^ƒCƒv”Ô†‚ğ•Ô‚·D
-	‚Æ‚è‚ ‚¦‚¸¡‚Ì‚Æ‚±‚ë‚Íƒ^ƒCƒv‚ÍŠg’£q‚Ì‚İ‚ÉˆË‘¶‚·‚é‚Æ‰¼’è‚µ‚Ä‚¢‚éD
-	ƒtƒ@ƒCƒ‹‘S‘Ì‚ÌŒ`®‚É‘Î‰‚³‚¹‚é‚Æ‚«‚ÍC‚Ü‚½l‚¦’¼‚·D
-	@date 2012.10.22 Moca ‚QdŠg’£q, Šg’£q‚È‚µ‚É‘Î‰
-	@date 2014.12.06 syat GetDocumentTypeOfPath‚É“‡
+	æŒ‡å®šã•ã‚ŒãŸæ‹¡å¼µå­ã®å±ã™ã‚‹æ–‡æ›¸ã‚¿ã‚¤ãƒ—ç•ªå·ã‚’è¿”ã™ï¼
+	ã¨ã‚Šã‚ãˆãšä»Šã®ã¨ã“ã‚ã¯ã‚¿ã‚¤ãƒ—ã¯æ‹¡å¼µå­ã®ã¿ã«ä¾å­˜ã™ã‚‹ã¨ä»®å®šã—ã¦ã„ã‚‹ï¼
+	ãƒ•ã‚¡ã‚¤ãƒ«å…¨ä½“ã®å½¢å¼ã«å¯¾å¿œã•ã›ã‚‹ã¨ãã¯ï¼Œã¾ãŸè€ƒãˆç›´ã™ï¼
+	@date 2012.10.22 Moca ï¼’é‡æ‹¡å¼µå­, æ‹¡å¼µå­ãªã—ã«å¯¾å¿œ
+	@date 2014.12.06 syat GetDocumentTypeOfPathã«çµ±åˆ
 */
 CTypeConfig CDocTypeManager::GetDocumentTypeOfExt( const TCHAR* pszExt )
 {
@@ -94,7 +94,7 @@ CTypeConfig CDocTypeManager::GetDocumentTypeOfId( int id )
 			return CTypeConfig(i);
 		}
 	}
-	return CTypeConfig(-1);	//	ƒnƒYƒŒ
+	return CTypeConfig(-1);	//	ãƒã‚ºãƒ¬
 }
 
 bool CDocTypeManager::GetTypeConfig(CTypeConfig cDocumentType, STypeConfig& type)
@@ -128,12 +128,12 @@ bool CDocTypeManager::SetTypeConfig(CTypeConfig cDocumentType, const STypeConfig
 	return false;
 }
 
-/*! ƒ^ƒCƒv•Êİ’è(mini)æ“¾
-	@param cDocumentType [in] ƒhƒLƒ…ƒƒ“ƒgƒ^ƒCƒv
-	@param type [out] ƒ^ƒCƒv•Êİ’è(mini)
+/*! ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š(mini)å–å¾—
+	@param cDocumentType [in] ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚¿ã‚¤ãƒ—
+	@param type [out] ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š(mini)
 
-	@retval true  ³í
-	@retval false ˆÙí
+	@retval true  æ­£å¸¸
+	@retval false ç•°å¸¸
 */
 bool CDocTypeManager::GetTypeConfigMini(CTypeConfig cDocumentType, const STypeConfigMini** type)
 {
@@ -158,10 +158,10 @@ bool CDocTypeManager::DelTypeConfig(CTypeConfig cDocumentType)
 }
 
 /*!
-	ƒ^ƒCƒv•ÊŠg’£q‚Éƒtƒ@ƒCƒ‹–¼‚ªƒ}ƒbƒ`‚·‚é‚©
+	ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ã«ãƒ•ã‚¡ã‚¤ãƒ«åãŒãƒãƒƒãƒã™ã‚‹ã‹
 	
-	@param pszTypeExts [in] ƒ^ƒCƒv•ÊŠg’£qiƒƒCƒ‹ƒhƒJ[ƒh‚ğŠÜ‚Şj
-	@param pszFileName [in] ƒtƒ@ƒCƒ‹–¼
+	@param pszTypeExts [in] ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ï¼ˆãƒ¯ã‚¤ãƒ«ãƒ‰ã‚«ãƒ¼ãƒ‰ã‚’å«ã‚€ï¼‰
+	@param pszFileName [in] ãƒ•ã‚¡ã‚¤ãƒ«å
 */
 bool CDocTypeManager::IsFileNameMatch(const TCHAR* pszTypeExts, const TCHAR* pszFileName)
 {
@@ -190,11 +190,11 @@ bool CDocTypeManager::IsFileNameMatch(const TCHAR* pszTypeExts, const TCHAR* psz
 }
 
 /*!
-	ƒ^ƒCƒv•ÊŠg’£q‚Ìæ“ªŠg’£q‚ğæ“¾‚·‚é
+	ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ã®å…ˆé ­æ‹¡å¼µå­ã‚’å–å¾—ã™ã‚‹
 	
-	@param pszTypeExts [in] ƒ^ƒCƒv•ÊŠg’£qiƒƒCƒ‹ƒhƒJ[ƒh‚ğŠÜ‚Şj
-	@param szFirstExt  [out] æ“ªŠg’£q
-	@param nBuffSize   [in] æ“ªŠg’£q‚Ìƒoƒbƒtƒ@ƒTƒCƒY
+	@param pszTypeExts [in] ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ï¼ˆãƒ¯ã‚¤ãƒ«ãƒ‰ã‚«ãƒ¼ãƒ‰ã‚’å«ã‚€ï¼‰
+	@param szFirstExt  [out] å…ˆé ­æ‹¡å¼µå­
+	@param nBuffSize   [in] å…ˆé ­æ‹¡å¼µå­ã®ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚º
 */
 void CDocTypeManager::GetFirstExt(const TCHAR* pszTypeExts, TCHAR szFirstExt[], int nBuffSize)
 {
@@ -214,19 +214,19 @@ void CDocTypeManager::GetFirstExt(const TCHAR* pszTypeExts, TCHAR szFirstExt[], 
 	return;
 }
 
-/*! ƒ^ƒCƒv•Êİ’è‚ÌŠg’£qƒŠƒXƒg‚ğƒ_ƒCƒAƒƒO—pƒŠƒXƒg‚É•ÏŠ·‚·‚é
-	@param pszSrcExt [in]  Šg’£qƒŠƒXƒg —áu.c .cpp;.hv
-	@param pszDstExt [out] Šg’£qƒŠƒXƒg —áu*.c;*.cpp;*.hv
-	@param szExt [in] ƒŠƒXƒg‚Ìæ“ª‚É‚·‚éŠg’£q —áu.hv
+/*! ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®æ‹¡å¼µå­ãƒªã‚¹ãƒˆã‚’ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ç”¨ãƒªã‚¹ãƒˆã«å¤‰æ›ã™ã‚‹
+	@param pszSrcExt [in]  æ‹¡å¼µå­ãƒªã‚¹ãƒˆ ä¾‹ã€Œ.c .cpp;.hã€
+	@param pszDstExt [out] æ‹¡å¼µå­ãƒªã‚¹ãƒˆ ä¾‹ã€Œ*.c;*.cpp;*.hã€
+	@param szExt [in] ãƒªã‚¹ãƒˆã®å…ˆé ­ã«ã™ã‚‹æ‹¡å¼µå­ ä¾‹ã€Œ.hã€
 
-	@date 2014.12.06 syat CFileExt‚©‚çˆÚ“®
+	@date 2014.12.06 syat CFileExtã‹ã‚‰ç§»å‹•
 */
 bool CDocTypeManager::ConvertTypesExtToDlgExt( const TCHAR *pszSrcExt, const TCHAR* szExt, TCHAR *pszDstExt )
 {
 	TCHAR	*token;
 	TCHAR	*p;
 
-	//	2003.08.14 MIK NULL‚¶‚á‚È‚­‚Äfalse
+	//	2003.08.14 MIK NULLã˜ã‚ƒãªãã¦false
 	if( NULL == pszSrcExt ) return false;
 	if( NULL == pszDstExt ) return false;
 
@@ -234,7 +234,7 @@ bool CDocTypeManager::ConvertTypesExtToDlgExt( const TCHAR *pszSrcExt, const TCH
 	_tcscpy( pszDstExt, _T("") );
 
 	if (szExt != NULL && szExt[0] != _T('\0')) {
-		// ƒtƒ@ƒCƒ‹ƒpƒX‚ª‚ ‚èAŠg’£q‚ ‚è‚Ìê‡Aƒgƒbƒv‚Éw’è
+		// ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ãŒã‚ã‚Šã€æ‹¡å¼µå­ã‚ã‚Šã®å ´åˆã€ãƒˆãƒƒãƒ—ã«æŒ‡å®š
 		_tcscpy(pszDstExt, _T("*"));
 		_tcscat(pszDstExt, szExt);
 	}
@@ -244,7 +244,7 @@ bool CDocTypeManager::ConvertTypesExtToDlgExt( const TCHAR *pszSrcExt, const TCH
 	{
 		if (szExt == NULL || szExt[0] == _T('\0') || auto_stricmp(token, szExt + 1) != 0) {
 			if( pszDstExt[0] != '\0' ) _tcscat( pszDstExt, _T(";") );
-			// Šg’£qw’è‚È‚µA‚Ü‚½‚Íƒ}ƒbƒ`‚µ‚½Šg’£q‚Å‚È‚¢
+			// æ‹¡å¼µå­æŒ‡å®šãªã—ã€ã¾ãŸã¯ãƒãƒƒãƒã—ãŸæ‹¡å¼µå­ã§ãªã„
 			if (_tcspbrk(token, m_typeExtWildcards) == NULL) {
 				if (_T('.') == *token) _tcscat(pszDstExt, _T("*"));
 				else                 _tcscat(pszDstExt, _T("*."));
@@ -254,6 +254,6 @@ bool CDocTypeManager::ConvertTypesExtToDlgExt( const TCHAR *pszSrcExt, const TCH
 
 		token = _tcstok( NULL, m_typeExtSeps );
 	}
-	free( p );	// 2003.05.20 MIK ƒƒ‚ƒŠ‰ğ•ú˜R‚ê
+	free( p );	// 2003.05.20 MIK ãƒ¡ãƒ¢ãƒªè§£æ”¾æ¼ã‚Œ
 	return true;
 }

--- a/sakura_core/env/CDocTypeManager.h
+++ b/sakura_core/env/CDocTypeManager.h
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -29,15 +29,15 @@
 
 #include "DLLSHAREDATA.h"
 
-//! ƒhƒLƒ…ƒƒ“ƒgƒ^ƒCƒvŠÇ—
+//! ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚¿ã‚¤ãƒ—ç®¡ç†
 class CDocTypeManager{
 public:
 	CDocTypeManager()
 	{
 		m_pShareData = &GetDllShareData();
 	}
-	CTypeConfig GetDocumentTypeOfPath( const TCHAR* pszFilePath );	/* ƒtƒ@ƒCƒ‹ƒpƒX‚ğ“n‚µ‚ÄAƒhƒLƒ…ƒƒ“ƒgƒ^ƒCƒvi”’lj‚ğæ“¾‚·‚é */
-	CTypeConfig GetDocumentTypeOfExt( const TCHAR* pszExt );		/* Šg’£q‚ğ“n‚µ‚ÄAƒhƒLƒ…ƒƒ“ƒgƒ^ƒCƒvi”’lj‚ğæ“¾‚·‚é */
+	CTypeConfig GetDocumentTypeOfPath( const TCHAR* pszFilePath );	/* ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã‚’æ¸¡ã—ã¦ã€ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚¿ã‚¤ãƒ—ï¼ˆæ•°å€¤ï¼‰ã‚’å–å¾—ã™ã‚‹ */
+	CTypeConfig GetDocumentTypeOfExt( const TCHAR* pszExt );		/* æ‹¡å¼µå­ã‚’æ¸¡ã—ã¦ã€ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚¿ã‚¤ãƒ—ï¼ˆæ•°å€¤ï¼‰ã‚’å–å¾—ã™ã‚‹ */
 	CTypeConfig GetDocumentTypeOfId( int id );
 
 	bool GetTypeConfig(CTypeConfig cDocumentType, STypeConfig& type);
@@ -46,12 +46,12 @@ public:
 	bool AddTypeConfig(CTypeConfig cDocumentType);
 	bool DelTypeConfig(CTypeConfig cDocumentType);
 
-	static bool IsFileNameMatch(const TCHAR* pszTypeExts, const TCHAR* pszFileName);	// ƒ^ƒCƒv•ÊŠg’£q‚Éƒtƒ@ƒCƒ‹–¼‚ªƒ}ƒbƒ`‚·‚é‚©
-	static void GetFirstExt(const TCHAR* pszTypeExts, TCHAR szFirstExt[], int nBuffSize);	// ƒ^ƒCƒv•ÊŠg’£q‚Ìæ“ªŠg’£q‚ğæ“¾‚·‚é
-	static bool ConvertTypesExtToDlgExt( const TCHAR *pszSrcExt, const TCHAR* szExt, TCHAR *pszDstExt );	// ƒ^ƒCƒv•Êİ’è‚ÌŠg’£qƒŠƒXƒg‚ğƒ_ƒCƒAƒƒO—pƒŠƒXƒg‚É•ÏŠ·‚·‚é
+	static bool IsFileNameMatch(const TCHAR* pszTypeExts, const TCHAR* pszFileName);	// ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ã«ãƒ•ã‚¡ã‚¤ãƒ«åãŒãƒãƒƒãƒã™ã‚‹ã‹
+	static void GetFirstExt(const TCHAR* pszTypeExts, TCHAR szFirstExt[], int nBuffSize);	// ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ã®å…ˆé ­æ‹¡å¼µå­ã‚’å–å¾—ã™ã‚‹
+	static bool ConvertTypesExtToDlgExt( const TCHAR *pszSrcExt, const TCHAR* szExt, TCHAR *pszDstExt );	// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®æ‹¡å¼µå­ãƒªã‚¹ãƒˆã‚’ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ç”¨ãƒªã‚¹ãƒˆã«å¤‰æ›ã™ã‚‹
 
-	static const TCHAR* m_typeExtSeps;			// ƒ^ƒCƒv•ÊŠg’£q‚Ì‹æØ‚è•¶š
-	static const TCHAR* m_typeExtWildcards;		// ƒ^ƒCƒv•ÊŠg’£q‚ÌƒƒCƒ‹ƒhƒJ[ƒh
+	static const TCHAR* m_typeExtSeps;			// ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ã®åŒºåˆ‡ã‚Šæ–‡å­—
+	static const TCHAR* m_typeExtWildcards;		// ã‚¿ã‚¤ãƒ—åˆ¥æ‹¡å¼µå­ã®ãƒ¯ã‚¤ãƒ«ãƒ‰ã‚«ãƒ¼ãƒ‰
 
 private:
 	DLLSHAREDATA* m_pShareData;

--- a/sakura_core/env/CFileNameManager.cpp
+++ b/sakura_core/env/CFileNameManager.cpp
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -26,7 +26,7 @@
 */
 
 #include "StdAfx.h"
-#include <ShlObj.h> //CSIDL_PROFILE“™
+#include <ShlObj.h> //CSIDL_PROFILEç­‰
 
 #include "DLLSHAREDATA.h"
 #include "CFileNameManager.h"
@@ -41,16 +41,16 @@
 #include "_os/COsVersionInfo.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      ƒtƒ@ƒCƒ‹–¼ŠÇ—                         //
+//                      ãƒ•ã‚¡ã‚¤ãƒ«åç®¡ç†                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
-/*!	‹¤—Lƒf[ƒ^‚Ìİ’è‚É]‚Á‚ÄƒpƒX‚ğk¬•\‹L‚É•ÏŠ·‚·‚é
-	@param pszSrc   [in]  ƒtƒ@ƒCƒ‹–¼
-	@param pszDest  [out] •ÏŠ·Œã‚Ìƒtƒ@ƒCƒ‹–¼‚ÌŠi”[æ
-	@param nDestLen [in]  I’[‚ÌNULL‚ğŠÜ‚ŞpszDest‚ÌTCHAR’PˆÊ‚Ì’·‚³ _MAX_PATH ‚Ü‚Å
-	@date 2003.01.27 Moca V‹Kì¬
-	@note ˜A‘±‚µ‚ÄŒÄ‚Ño‚·ê‡‚Ì‚½‚ßA“WŠJÏ‚İƒƒ^•¶š—ñ‚ğƒLƒƒƒbƒVƒ…‚µ‚Ä‚‘¬‰»‚µ‚Ä‚¢‚éB
+/*!	å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®è¨­å®šã«å¾“ã£ã¦ãƒ‘ã‚¹ã‚’ç¸®å°è¡¨è¨˜ã«å¤‰æ›ã™ã‚‹
+	@param pszSrc   [in]  ãƒ•ã‚¡ã‚¤ãƒ«å
+	@param pszDest  [out] å¤‰æ›å¾Œã®ãƒ•ã‚¡ã‚¤ãƒ«åã®æ ¼ç´å…ˆ
+	@param nDestLen [in]  çµ‚ç«¯ã®NULLã‚’å«ã‚€pszDestã®TCHARå˜ä½ã®é•·ã• _MAX_PATH ã¾ã§
+	@date 2003.01.27 Moca æ–°è¦ä½œæˆ
+	@note é€£ç¶šã—ã¦å‘¼ã³å‡ºã™å ´åˆã®ãŸã‚ã€å±•é–‹æ¸ˆã¿ãƒ¡ã‚¿æ–‡å­—åˆ—ã‚’ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã—ã¦é«˜é€ŸåŒ–ã—ã¦ã„ã‚‹ã€‚
 */
 LPTSTR CFileNameManager::GetTransformFileNameFast( LPCTSTR pszSrc, LPTSTR pszDest, int nDestLen, HDC hDC, bool bFitMode, int cchMaxWidth )
 {
@@ -88,17 +88,17 @@ LPTSTR CFileNameManager::GetTransformFileNameFast( LPCTSTR pszSrc, LPTSTR pszDes
 	}else if( nPxWidth != -1 ){
 		GetShortViewPath( pszDest, nDestLen, pszSrc, hDC, nPxWidth, bFitMode );
 	}else{
-		// •ÏŠ·‚·‚é•K—v‚ª‚È‚¢ ƒRƒs[‚¾‚¯‚·‚é
+		// å¤‰æ›ã™ã‚‹å¿…è¦ãŒãªã„ ã‚³ãƒ”ãƒ¼ã ã‘ã™ã‚‹
 		_tcsncpy( pszDest, pszSrc, nDestLen - 1 );
 		pszDest[nDestLen - 1] = '\0';
 	}
 	return pszDest;
 }
 
-/*!	“WŠJÏ‚İƒƒ^•¶š—ñ‚ÌƒLƒƒƒbƒVƒ…‚ğì¬EXV‚·‚é
-	@retval —LŒø‚È“WŠJÏ‚İ’uŠ·‘O•¶š—ñ‚Ì”
-	@date 2003.01.27 Moca V‹Kì¬
-	@date 2003.06.23 Moca ŠÖ”–¼•ÏX
+/*!	å±•é–‹æ¸ˆã¿ãƒ¡ã‚¿æ–‡å­—åˆ—ã®ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’ä½œæˆãƒ»æ›´æ–°ã™ã‚‹
+	@retval æœ‰åŠ¹ãªå±•é–‹æ¸ˆã¿ç½®æ›å‰æ–‡å­—åˆ—ã®æ•°
+	@date 2003.01.27 Moca æ–°è¦ä½œæˆ
+	@date 2003.06.23 Moca é–¢æ•°åå¤‰æ›´
 */
 int CFileNameManager::TransformFileName_MakeCache( void ){
 	int i;
@@ -107,7 +107,7 @@ int CFileNameManager::TransformFileName_MakeCache( void ){
 		if( L'\0' != m_pShareData->m_Common.m_sFileName.m_szTransformFileNameFrom[i][0] ){
 			if( ExpandMetaToFolder( m_pShareData->m_Common.m_sFileName.m_szTransformFileNameFrom[i],
 			 m_szTransformFileNameFromExp[nCount], _MAX_PATH ) ){
-				// m_szTransformFileNameTo‚Æm_szTransformFileNameFromExp‚Ì”Ô†‚ª‚¸‚ê‚é‚±‚Æ‚ª‚ ‚é‚Ì‚Å‹L˜^‚µ‚Ä‚¨‚­
+				// m_szTransformFileNameToã¨m_szTransformFileNameFromExpã®ç•ªå·ãŒãšã‚Œã‚‹ã“ã¨ãŒã‚ã‚‹ã®ã§è¨˜éŒ²ã—ã¦ãŠã
 				m_nTransformFileNameOrgId[nCount] = i;
 				nCount++;
 			}
@@ -118,9 +118,9 @@ int CFileNameManager::TransformFileName_MakeCache( void ){
 }
 
 
-/*!	ƒtƒ@ƒCƒ‹EƒtƒHƒ‹ƒ_–¼‚ğ’uŠ·‚µ‚ÄAŠÈˆÕ•\¦–¼‚ğæ“¾‚·‚é
-	@date 2002.11.27 Moca V‹Kì¬
-	@note ‘å¬•¶š‚ğ‹æ•Ê‚µ‚È‚¢BnDestLen‚É’B‚µ‚½‚Æ‚«‚ÍŒã‚ë‚ğØ‚èÌ‚Ä‚ç‚ê‚é
+/*!	ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ãƒ•ã‚©ãƒ«ãƒ€åã‚’ç½®æ›ã—ã¦ã€ç°¡æ˜“è¡¨ç¤ºåã‚’å–å¾—ã™ã‚‹
+	@date 2002.11.27 Moca æ–°è¦ä½œæˆ
+	@note å¤§å°æ–‡å­—ã‚’åŒºåˆ¥ã—ãªã„ã€‚nDestLenã«é”ã—ãŸã¨ãã¯å¾Œã‚ã‚’åˆ‡ã‚Šæ¨ã¦ã‚‰ã‚Œã‚‹
 */
 LPCTSTR CFileNameManager::GetFilePathFormat( LPCTSTR pszSrc, LPTSTR pszDest, int nDestLen, LPCTSTR pszFrom, LPCTSTR pszTo )
 {
@@ -148,14 +148,14 @@ LPCTSTR CFileNameManager::GetFilePathFormat( LPCTSTR pszSrc, LPTSTR pszDest, int
 			i += nFromLen - 1;
 		}else{
 #if defined(_MBCS)
-// SJIS ê—pˆ—
+// SJIS å°‚ç”¨å‡¦ç†
 			if( _IS_SJIS_1( (unsigned char)pszSrc[i] ) && i + 1 < nSrcLen && _IS_SJIS_2( (unsigned char)pszSrc[i + 1] ) ){
 				if( j + 1 < nDestLen ){
 					pszDest[j] = pszSrc[i];
 					j++;
 					i++;
 				}else{
-					// SJIS‚ÌæsƒoƒCƒg‚¾‚¯ƒRƒs[‚³‚ê‚é‚Ì‚ğ–h‚®
+					// SJISã®å…ˆè¡Œãƒã‚¤ãƒˆã ã‘ã‚³ãƒ”ãƒ¼ã•ã‚Œã‚‹ã®ã‚’é˜²ã
 					break;// goto end_of_func;
 				}
 			}
@@ -170,14 +170,14 @@ LPCTSTR CFileNameManager::GetFilePathFormat( LPCTSTR pszSrc, LPTSTR pszDest, int
 }
 
 
-/*!	%MYDOC%‚È‚Ç‚Ìƒpƒ‰ƒ[ƒ^w’è‚ğÀÛ‚ÌƒpƒX–¼‚É•ÏŠ·‚·‚é
+/*!	%MYDOC%ãªã©ã®ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿æŒ‡å®šã‚’å®Ÿéš›ã®ãƒ‘ã‚¹åã«å¤‰æ›ã™ã‚‹
 
-	@param pszSrc  [in]  •ÏŠ·‘O•¶š—ñ
-	@param pszDes  [out] •ÏŠ·Œã•¶š—ñ
-	@param nDesLen [in]  pszDes‚ÌNULL‚ğŠÜ‚ŞTCHAR’PˆÊ‚Ì’·‚³
-	@retval true  ³í‚É•ÏŠ·‚Å‚«‚½
-	@retval false ƒoƒbƒtƒ@‚ª‘«‚è‚È‚©‚Á‚½C‚Ü‚½‚ÍƒGƒ‰[BpszDes‚Í•s’è
-	@date 2002.11.27 Moca ì¬ŠJn
+	@param pszSrc  [in]  å¤‰æ›å‰æ–‡å­—åˆ—
+	@param pszDes  [out] å¤‰æ›å¾Œæ–‡å­—åˆ—
+	@param nDesLen [in]  pszDesã®NULLã‚’å«ã‚€TCHARå˜ä½ã®é•·ã•
+	@retval true  æ­£å¸¸ã«å¤‰æ›ã§ããŸ
+	@retval false ãƒãƒƒãƒ•ã‚¡ãŒè¶³ã‚Šãªã‹ã£ãŸï¼Œã¾ãŸã¯ã‚¨ãƒ©ãƒ¼ã€‚pszDesã¯ä¸å®š
+	@date 2002.11.27 Moca ä½œæˆé–‹å§‹
 */
 bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nDesLen )
 {
@@ -220,7 +220,7 @@ bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nD
 			continue;
 		}
 
-		// %% ‚Í %
+		// %% ã¯ %
 		if( _T('%') == ps[1] ){
 			*pd = _T('%');
 			pd++;
@@ -238,17 +238,17 @@ bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nD
 			ps++;
 			// %SAKURA%
 			if( 0 == auto_strnicmp( _T("SAKURA%"), ps, 7 ) ){
-				// exe‚Ì‚ ‚éƒtƒHƒ‹ƒ_
+				// exeã®ã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€
 				GetExedir( szPath );
 				nMetaLen = 6;
 			}
 			// %SAKURADATA%	// 2007.06.06 ryoji
 			else if( 0 == auto_strnicmp( _T("SAKURADATA%"), ps, 11 ) ){
-				// ini‚Ì‚ ‚éƒtƒHƒ‹ƒ_
+				// iniã®ã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€
 				GetInidir( szPath );
 				nMetaLen = 10;
 			}
-			// ƒƒ^•¶š—ñ‚Á‚Û‚¢
+			// ãƒ¡ã‚¿æ–‡å­—åˆ—ã£ã½ã„
 			else if( NULL != (pStr = _tcschr( ps, _T('%') ) )){
 				nMetaLen = pStr - ps;
 				if( nMetaLen < _MAX_PATH ){
@@ -260,10 +260,10 @@ bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nD
 					return false;
 				}
 #ifdef _USE_META_ALIAS
-				// ƒƒ^•¶š—ñ‚ªƒGƒCƒŠƒAƒX–¼‚È‚ç‘‚«Š·‚¦‚é
+				// ãƒ¡ã‚¿æ–‡å­—åˆ—ãŒã‚¨ã‚¤ãƒªã‚¢ã‚¹åãªã‚‰æ›¸ãæ›ãˆã‚‹
 				const MetaAlias* pAlias;
 				for( pAlias = &AliasList[0]; nMetaLen < pAlias->nLenth; pAlias++ )
-					; // “Ç‚İ”ò‚Î‚·
+					; // èª­ã¿é£›ã°ã™
 				for( ; nMetaLen == pAlias->nLenth; pAlias++ ){
 					if( 0 == auto_stricmp( pAlias->szAlias, szMeta ) ){
 						_tcscpy( szMeta, pAlias->szOrig );
@@ -271,7 +271,7 @@ bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nD
 					}
 				}
 #endif
-				// ’¼ÚƒŒƒWƒXƒgƒŠ‚Å’²‚×‚é
+				// ç›´æ¥ãƒ¬ã‚¸ã‚¹ãƒˆãƒªã§èª¿ã¹ã‚‹
 				szPath[0] = _T('\0');
 				bFolderPath = ReadRegistry( HKEY_CURRENT_USER,
 					_T("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders"),
@@ -283,7 +283,7 @@ bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nD
 				}
 				if( false == bFolderPath || _T('\0') == szPath[0] ){
 					pStr = _tgetenv( szMeta );
-					// ŠÂ‹«•Ï”
+					// ç’°å¢ƒå¤‰æ•°
 					if( NULL != pStr ){
 						nPathLen = _tcslen( pStr );
 						if( nPathLen < _MAX_PATH ){
@@ -293,7 +293,7 @@ bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nD
 							return false;
 						}
 					}
-					// –¢’è‹`‚Ìƒƒ^•¶š—ñ‚Í “ü—Í‚³‚ê‚½%...%‚ğC‚»‚Ì‚Ü‚Ü•¶š‚Æ‚µ‚Äˆ—‚·‚é
+					// æœªå®šç¾©ã®ãƒ¡ã‚¿æ–‡å­—åˆ—ã¯ å…¥åŠ›ã•ã‚ŒãŸ%...%ã‚’ï¼Œãã®ã¾ã¾æ–‡å­—ã¨ã—ã¦å‡¦ç†ã™ã‚‹
 					else if(  pd + ( nMetaLen + 2 ) < pd_end ){
 						*pd = _T('%');
 						auto_memcpy( &pd[1], ps, nMetaLen );
@@ -307,14 +307,14 @@ bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nD
 					}
 				}
 			}else{
-				// %...%‚ÌI‚í‚è‚Ì%‚ª‚È‚¢ ‚Æ‚è‚ ‚¦‚¸C%‚ğƒRƒs[
+				// %...%ã®çµ‚ã‚ã‚Šã®%ãŒãªã„ ã¨ã‚Šã‚ãˆãšï¼Œ%ã‚’ã‚³ãƒ”ãƒ¼
 				*pd = _T('%');
 				pd++;
-				ps--; // æ‚Éps++‚µ‚Ä‚µ‚Ü‚Á‚½‚Ì‚Å–ß‚·
+				ps--; // å…ˆã«ps++ã—ã¦ã—ã¾ã£ãŸã®ã§æˆ»ã™
 				continue;
 			}
 
-			// ƒƒ“ƒOƒtƒ@ƒCƒ‹–¼‚É‚·‚é
+			// ãƒ­ãƒ³ã‚°ãƒ•ã‚¡ã‚¤ãƒ«åã«ã™ã‚‹
 			nPathLen = _tcslen( szPath );
 			LPTSTR pStr2 = szPath;
 			if( nPathLen < _MAX_PATH && 0 != nPathLen ){
@@ -323,12 +323,12 @@ bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nD
 				}
 			}
 
-			// ÅŒã‚ÌƒtƒHƒ‹ƒ_‹æØ‚è‹L†‚ğíœ‚·‚é
-			// [A:\]‚È‚Ç‚Ìƒ‹[ƒg‚Å‚ ‚Á‚Ä‚àíœ
+			// æœ€å¾Œã®ãƒ•ã‚©ãƒ«ãƒ€åŒºåˆ‡ã‚Šè¨˜å·ã‚’å‰Šé™¤ã™ã‚‹
+			// [A:\]ãªã©ã®ãƒ«ãƒ¼ãƒˆã§ã‚ã£ã¦ã‚‚å‰Šé™¤
 			for(nPathLen = 0; pStr2[nPathLen] != _T('\0'); nPathLen++ ){
 #ifdef _MBCS
 				if( _IS_SJIS_1( (unsigned char)pStr2[nPathLen] ) && _IS_SJIS_2( (unsigned char)pStr2[nPathLen + 1] ) ){
-					// SJIS“Ç‚İ”ò‚Î‚µ
+					// SJISèª­ã¿é£›ã°ã—
 					nPathLen++; // 2003/01/17 sui
 				}else
 #endif
@@ -347,7 +347,7 @@ bool CFileNameManager::ExpandMetaToFolder( LPCTSTR pszSrc, LPTSTR pszDes, int nD
 				return false;
 			}
 		}else{
-			// ÅŒã‚Ì•¶š‚ª%‚¾‚Á‚½
+			// æœ€å¾Œã®æ–‡å­—ãŒ%ã ã£ãŸ
 			*pd = *ps;
 			pd++;
 		}
@@ -387,9 +387,9 @@ static void GetAccessKeyLabelByIndex(TCHAR* pszLabel, bool bEspaceAmp, int index
 }
 
 /*
-	@param editInfo      ƒEƒBƒ“ƒhƒEî•ñBNUL‚Å•s–¾ˆµ‚¢
-	@param index         ‚¢‚Â‚à0origin‚Åw’èB -1‚Å”ñ•\¦
-	@param bZeroOrigin   ƒAƒNƒZƒXƒL[‚ğ0‚©‚çU‚é
+	@param editInfo      ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦æƒ…å ±ã€‚NULã§ä¸æ˜æ‰±ã„
+	@param index         ã„ã¤ã‚‚0originã§æŒ‡å®šã€‚ -1ã§éè¡¨ç¤º
+	@param bZeroOrigin   ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã‚’0ã‹ã‚‰æŒ¯ã‚‹
 */
 bool CFileNameManager::GetMenuFullLabel(
 	TCHAR* pszOutput, int nBuffSize, bool bEspaceAmp,
@@ -406,16 +406,16 @@ bool CFileNameManager::GetMenuFullLabel(
 	}else if( pfi->m_bIsGrep ){
 		
 		GetAccessKeyLabelByIndex( szAccKey, bEspaceAmp, index, bAccKeyZeroOrigin );
-		//pfi->m_szGrepKeyShort ¨ cmemDes
+		//pfi->m_szGrepKeyShort â†’ cmemDes
 		CNativeW	cmemDes;
 		int nGrepKeyLen = wcslen(pfi->m_szGrepKey);
 		const int GREPKEY_LIMIT_LEN = 64;
-		// CSakuraEnvironment::ExpandParameter ‚Å‚Í 32•¶š§ŒÀ
-		// ƒƒjƒ…[‚Í 64•¶š§ŒÀ
+		// CSakuraEnvironment::ExpandParameter ã§ã¯ 32æ–‡å­—åˆ¶é™
+		// ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã¯ 64æ–‡å­—åˆ¶é™
 		LimitStringLengthW( pfi->m_szGrepKey, nGrepKeyLen, GREPKEY_LIMIT_LEN, cmemDes );
 		
 		const TCHAR* pszKey;
-		TCHAR szMenu2[GREPKEY_LIMIT_LEN*2*2+1]; // WCHAR=>ACHAR‚Å2”{A&‚Å2”{
+		TCHAR szMenu2[GREPKEY_LIMIT_LEN*2*2+1]; // WCHAR=>ACHARã§2å€ã€&ã§2å€
 		if( bEspaceAmp ){
 			dupamp( cmemDes.GetStringT(), szMenu2 );
 			pszKey = szMenu2;
@@ -423,10 +423,10 @@ bool CFileNameManager::GetMenuFullLabel(
 			pszKey = cmemDes.GetStringT();
 		}
 
-		//szMenu‚ğì‚é
+		//szMenuã‚’ä½œã‚‹
 		//	Jan. 19, 2002 genta
-		//	&‚Ìd•¡ˆ—‚ğ’Ç‰Á‚µ‚½‚½‚ßŒp‘±”»’è‚ğáŠ±•ÏX
-		//	20100729 ExpandParameter‚É‚ ‚í‚¹‚ÄAEEE‚ğ...‚É•ÏX
+		//	&ã®é‡è¤‡å‡¦ç†ã‚’è¿½åŠ ã—ãŸãŸã‚ç¶™ç¶šåˆ¤å®šã‚’è‹¥å¹²å¤‰æ›´
+		//	20100729 ExpandParameterã«ã‚ã‚ã›ã¦ã€ãƒ»ãƒ»ãƒ»ã‚’...ã«å¤‰æ›´
 		ret = auto_snprintf_s( pszOutput, nBuffSize, LS(STR_MENU_GREP),
 			szAccKey, pszKey,
 			( nGrepKeyLen > cmemDes.GetStringLength() ) ? _T("..."):_T("")
@@ -455,9 +455,9 @@ bool CFileNameManager::GetMenuFullLabel(
 	if( pszFile[0] ){
 		this->GetTransformFileNameFast( pszFile, szFileName, _MAX_PATH, hDC );
 
-		// szFileName ¨ szMenu2
+		// szFileName â†’ szMenu2
 		//	Jan. 19, 2002 genta
-		//	ƒƒjƒ…[•¶š—ñ‚Ì&‚ğl—¶
+		//	ãƒ¡ãƒ‹ãƒ¥ãƒ¼æ–‡å­—åˆ—ã®&ã‚’è€ƒæ…®
 		if( bEspaceAmp ){
 			dupamp( szFileName, szMenu2 );
 			pszName = szMenu2;
@@ -482,7 +482,7 @@ bool CFileNameManager::GetMenuFullLabel(
 	}
 	
 	int ret = auto_snprintf_s( pszOutput, nBuffSize, _T("%ts%ts%ts %ts%ts"),
-		szAccKey, (bFavorite ? _T("š ") : _T("")), pszName,
+		szAccKey, (bFavorite ? _T("â˜… ") : _T("")), pszName,
 		(bModified ? _T("*"):_T(" ")), pszCharset
 	);
 	return 0 < ret;
@@ -490,16 +490,16 @@ bool CFileNameManager::GetMenuFullLabel(
 
 
 /**
-	\¬İ’èƒtƒ@ƒCƒ‹‚©‚çiniƒtƒ@ƒCƒ‹–¼‚ğæ“¾‚·‚é
+	æ§‹æˆè¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰iniãƒ•ã‚¡ã‚¤ãƒ«åã‚’å–å¾—ã™ã‚‹
 
-	sakura.exe.ini‚©‚çsakura.ini‚ÌŠi”[ƒtƒHƒ‹ƒ_‚ğæ“¾‚µAƒtƒ‹ƒpƒX–¼‚ğ•Ô‚·
+	sakura.exe.iniã‹ã‚‰sakura.iniã®æ ¼ç´ãƒ•ã‚©ãƒ«ãƒ€ã‚’å–å¾—ã—ã€ãƒ•ãƒ«ãƒ‘ã‚¹åã‚’è¿”ã™
 
-	@param[out] pszPrivateIniFile ƒ}ƒ‹ƒ`ƒ†[ƒU—p‚Ìiniƒtƒ@ƒCƒ‹ƒpƒX
-	@param[out] pszIniFile EXEŠî€‚Ìiniƒtƒ@ƒCƒ‹ƒpƒX
+	@param[out] pszPrivateIniFile ãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶ç”¨ã®iniãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹
+	@param[out] pszIniFile EXEåŸºæº–ã®iniãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹
 
 	@author ryoji
-	@date 2007.09.04 ryoji V‹Kì¬
-	@date 2008.05.05 novice GetModuleHandle(NULL)¨NULL‚É•ÏX
+	@date 2007.09.04 ryoji æ–°è¦ä½œæˆ
+	@date 2008.05.05 novice GetModuleHandle(NULL)â†’NULLã«å¤‰æ›´
 */
 void CFileNameManager::GetIniFileNameDirect( LPTSTR pszPrivateIniFile, LPTSTR pszIniFile, LPCTSTR pszProfName )
 {
@@ -521,9 +521,9 @@ void CFileNameManager::GetIniFileNameDirect( LPTSTR pszPrivateIniFile, LPTSTR ps
 		auto_snprintf_s( pszIniFile, _MAX_PATH - 1, _T("%ts%ts%ts\\%ts%ts"), szDrive, szDir, pszProfName, szFname, _T(".ini") );
 	}
 
-	// ƒ}ƒ‹ƒ`ƒ†[ƒU—p‚Ìiniƒtƒ@ƒCƒ‹ƒpƒX
-	//		exe‚Æ“¯‚¶ƒtƒHƒ‹ƒ_‚É’u‚©‚ê‚½ƒ}ƒ‹ƒ`ƒ†[ƒU\¬İ’èƒtƒ@ƒCƒ‹isakura.exe.inij‚Ì“à—e
-	//		‚É]‚Á‚Äƒ}ƒ‹ƒ`ƒ†[ƒU—p‚Ìiniƒtƒ@ƒCƒ‹ƒpƒX‚ğŒˆ‚ß‚é
+	// ãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶ç”¨ã®iniãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹
+	//		exeã¨åŒã˜ãƒ•ã‚©ãƒ«ãƒ€ã«ç½®ã‹ã‚ŒãŸãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶æ§‹æˆè¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ï¼ˆsakura.exe.iniï¼‰ã®å†…å®¹
+	//		ã«å¾“ã£ã¦ãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶ç”¨ã®iniãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã‚’æ±ºã‚ã‚‹
 	pszPrivateIniFile[0] = _T('\0');
 	if( IsWin2000_or_later() ){
 		auto_snprintf_s( szPath, _MAX_PATH - 1, _T("%ts%ts%ts%ts"), szDrive, szDir, szFname, _T(".exe.ini") );
@@ -532,16 +532,16 @@ void CFileNameManager::GetIniFileNameDirect( LPTSTR pszPrivateIniFile, LPTSTR ps
 			int nFolder = ::GetPrivateProfileInt(_T("Settings"), _T("UserRootFolder"), 0, szPath );
 			switch( nFolder ){
 			case 1:
-				nFolder = CSIDL_PROFILE;			// ƒ†[ƒU‚Ìƒ‹[ƒgƒtƒHƒ‹ƒ_
+				nFolder = CSIDL_PROFILE;			// ãƒ¦ãƒ¼ã‚¶ã®ãƒ«ãƒ¼ãƒˆãƒ•ã‚©ãƒ«ãƒ€
 				break;
 			case 2:
-				nFolder = CSIDL_PERSONAL;			// ƒ†[ƒU‚ÌƒhƒLƒ…ƒƒ“ƒgƒtƒHƒ‹ƒ_
+				nFolder = CSIDL_PERSONAL;			// ãƒ¦ãƒ¼ã‚¶ã®ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€
 				break;
 			case 3:
-				nFolder = CSIDL_DESKTOPDIRECTORY;	// ƒ†[ƒU‚ÌƒfƒXƒNƒgƒbƒvƒtƒHƒ‹ƒ_
+				nFolder = CSIDL_DESKTOPDIRECTORY;	// ãƒ¦ãƒ¼ã‚¶ã®ãƒ‡ã‚¹ã‚¯ãƒˆãƒƒãƒ—ãƒ•ã‚©ãƒ«ãƒ€
 				break;
 			default:
-				nFolder = CSIDL_APPDATA;			// ƒ†[ƒU‚ÌƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒf[ƒ^ƒtƒHƒ‹ƒ_
+				nFolder = CSIDL_APPDATA;			// ãƒ¦ãƒ¼ã‚¶ã®ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ãƒ‡ãƒ¼ã‚¿ãƒ•ã‚©ãƒ«ãƒ€
 				break;
 			}
 			::GetPrivateProfileString(_T("Settings"), _T("UserSubFolder"), _T("sakura"), szDir, _MAX_DIR, szPath );
@@ -559,23 +559,23 @@ void CFileNameManager::GetIniFileNameDirect( LPTSTR pszPrivateIniFile, LPTSTR ps
 }
 
 /**
-	iniƒtƒ@ƒCƒ‹–¼‚Ìæ“¾
+	iniãƒ•ã‚¡ã‚¤ãƒ«åã®å–å¾—
 
-	‹¤—Lƒf[ƒ^‚©‚çsakura.ini‚ÌŠi”[ƒtƒHƒ‹ƒ_‚ğæ“¾‚µAƒtƒ‹ƒpƒX–¼‚ğ•Ô‚·
-	i‹¤—Lƒf[ƒ^–¢İ’è‚Ì‚Æ‚«‚Í‹¤—Lƒf[ƒ^İ’è‚ğs‚¤j
+	å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã‹ã‚‰sakura.iniã®æ ¼ç´ãƒ•ã‚©ãƒ«ãƒ€ã‚’å–å¾—ã—ã€ãƒ•ãƒ«ãƒ‘ã‚¹åã‚’è¿”ã™
+	ï¼ˆå…±æœ‰ãƒ‡ãƒ¼ã‚¿æœªè¨­å®šã®ã¨ãã¯å…±æœ‰ãƒ‡ãƒ¼ã‚¿è¨­å®šã‚’è¡Œã†ï¼‰
 
-	@param[out] pszIniFileName iniƒtƒ@ƒCƒ‹–¼iƒtƒ‹ƒpƒXj
-	@param[in] bRead true: “Ç‚İ‚İ / false: ‘‚«‚İ
+	@param[out] pszIniFileName iniãƒ•ã‚¡ã‚¤ãƒ«åï¼ˆãƒ•ãƒ«ãƒ‘ã‚¹ï¼‰
+	@param[in] bRead true: èª­ã¿è¾¼ã¿ / false: æ›¸ãè¾¼ã¿
 
 	@author ryoji
-	@date 2007.05.19 ryoji V‹Kì¬
+	@date 2007.05.19 ryoji æ–°è¦ä½œæˆ
 */
 void CFileNameManager::GetIniFileName( LPTSTR pszIniFileName, LPCTSTR pszProfName, BOOL bRead/*=FALSE*/ )
 {
 	if( !m_pShareData->m_sFileNameManagement.m_IniFolder.m_bInit ){
-		m_pShareData->m_sFileNameManagement.m_IniFolder.m_bInit = true;			// ‰Šú‰»Ïƒtƒ‰ƒO
-		m_pShareData->m_sFileNameManagement.m_IniFolder.m_bReadPrivate = false;	// ƒ}ƒ‹ƒ`ƒ†[ƒU—pini‚©‚ç‚Ì“Ç‚İo‚µƒtƒ‰ƒO
-		m_pShareData->m_sFileNameManagement.m_IniFolder.m_bWritePrivate = false;	// ƒ}ƒ‹ƒ`ƒ†[ƒU—pini‚Ö‚Ì‘‚«‚İƒtƒ‰ƒO
+		m_pShareData->m_sFileNameManagement.m_IniFolder.m_bInit = true;			// åˆæœŸåŒ–æ¸ˆãƒ•ãƒ©ã‚°
+		m_pShareData->m_sFileNameManagement.m_IniFolder.m_bReadPrivate = false;	// ãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶ç”¨iniã‹ã‚‰ã®èª­ã¿å‡ºã—ãƒ•ãƒ©ã‚°
+		m_pShareData->m_sFileNameManagement.m_IniFolder.m_bWritePrivate = false;	// ãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶ç”¨iniã¸ã®æ›¸ãè¾¼ã¿ãƒ•ãƒ©ã‚°
 
 		GetIniFileNameDirect( m_pShareData->m_sFileNameManagement.m_IniFolder.m_szPrivateIniFile, m_pShareData->m_sFileNameManagement.m_IniFolder.m_szIniFile, pszProfName );
 		if( m_pShareData->m_sFileNameManagement.m_IniFolder.m_szPrivateIniFile[0] != _T('\0') ){
@@ -584,7 +584,7 @@ void CFileNameManager::GetIniFileName( LPTSTR pszIniFileName, LPCTSTR pszProfNam
 			if( CCommandLine::getInstance()->IsNoWindow() && CCommandLine::getInstance()->IsWriteQuit() )
 				m_pShareData->m_sFileNameManagement.m_IniFolder.m_bWritePrivate = false;
 
-			// ƒ}ƒ‹ƒ`ƒ†[ƒU—p‚ÌiniƒtƒHƒ‹ƒ_‚ğì¬‚µ‚Ä‚¨‚­
+			// ãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶ç”¨ã®iniãƒ•ã‚©ãƒ«ãƒ€ã‚’ä½œæˆã—ã¦ãŠã
 			if( m_pShareData->m_sFileNameManagement.m_IniFolder.m_bWritePrivate ){
 				TCHAR szPath[_MAX_PATH];
 				TCHAR szDrive[_MAX_DRIVE];

--- a/sakura_core/env/CFileNameManager.h
+++ b/sakura_core/env/CFileNameManager.h
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -27,7 +27,7 @@
 #ifndef SAKURA_CFILENAMEMANAGER_862D56B4_E24F_49AB_AABD_0924391CB6F4_H_
 #define SAKURA_CFILENAMEMANAGER_862D56B4_E24F_49AB_AABD_0924391CB6F4_H_
 
-// —væs’è‹`
+// è¦å…ˆè¡Œå®šç¾©
 // #include "DLLSHAREDATA.h"
 
 #include "util/design_template.h"
@@ -35,23 +35,23 @@
 
 struct EditInfo;
 
-//! iniƒtƒHƒ‹ƒ_İ’è	// 2007.05.31 ryoji
+//! iniãƒ•ã‚©ãƒ«ãƒ€è¨­å®š	// 2007.05.31 ryoji
 struct IniFolder {
-	bool m_bInit;							// ‰Šú‰»Ïƒtƒ‰ƒO
-	bool m_bReadPrivate;					// ƒ}ƒ‹ƒ`ƒ†[ƒU—pini‚©‚ç‚Ì“Ç‚İo‚µƒtƒ‰ƒO
-	bool m_bWritePrivate;					// ƒ}ƒ‹ƒ`ƒ†[ƒU—pini‚Ö‚Ì‘‚«‚İƒtƒ‰ƒO
-	TCHAR m_szIniFile[_MAX_PATH];			// EXEŠî€‚Ìiniƒtƒ@ƒCƒ‹ƒpƒX
-	TCHAR m_szPrivateIniFile[_MAX_PATH];	// ƒ}ƒ‹ƒ`ƒ†[ƒU—p‚Ìiniƒtƒ@ƒCƒ‹ƒpƒX
-};	/* iniƒtƒHƒ‹ƒ_İ’è */
+	bool m_bInit;							// åˆæœŸåŒ–æ¸ˆãƒ•ãƒ©ã‚°
+	bool m_bReadPrivate;					// ãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶ç”¨iniã‹ã‚‰ã®èª­ã¿å‡ºã—ãƒ•ãƒ©ã‚°
+	bool m_bWritePrivate;					// ãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶ç”¨iniã¸ã®æ›¸ãè¾¼ã¿ãƒ•ãƒ©ã‚°
+	TCHAR m_szIniFile[_MAX_PATH];			// EXEåŸºæº–ã®iniãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹
+	TCHAR m_szPrivateIniFile[_MAX_PATH];	// ãƒãƒ«ãƒãƒ¦ãƒ¼ã‚¶ç”¨ã®iniãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹
+};	/* iniãƒ•ã‚©ãƒ«ãƒ€è¨­å®š */
 
 
-//‹¤—Lƒƒ‚ƒŠ“à\‘¢‘Ì
+//å…±æœ‰ãƒ¡ãƒ¢ãƒªå†…æ§‹é€ ä½“
 struct SShare_FileNameManagement{
-	IniFolder			m_IniFolder;	/**** iniƒtƒHƒ‹ƒ_İ’è ****/
+	IniFolder			m_IniFolder;	/**** iniãƒ•ã‚©ãƒ«ãƒ€è¨­å®š ****/
 };
 
 
-//!ƒtƒ@ƒCƒ‹–¼ŠÇ—
+//!ãƒ•ã‚¡ã‚¤ãƒ«åç®¡ç†
 class CFileNameManager : public TSingleton<CFileNameManager>{
 	friend class TSingleton<CFileNameManager>;
 	CFileNameManager()
@@ -61,13 +61,13 @@ class CFileNameManager : public TSingleton<CFileNameManager>{
 	}
 
 public:
-	//ƒtƒ@ƒCƒ‹–¼ŠÖ˜A
+	//ãƒ•ã‚¡ã‚¤ãƒ«åé–¢é€£
 	LPTSTR GetTransformFileNameFast( LPCTSTR, LPTSTR, int nDestLen, HDC hDC, bool bFitMode = true, int cchMaxWidth = 0 );	// 2002.11.24 Moca Add
 	int TransformFileName_MakeCache( void );
 	static LPCTSTR GetFilePathFormat( LPCTSTR, LPTSTR, int, LPCTSTR, LPCTSTR );
 	static bool ExpandMetaToFolder( LPCTSTR, LPTSTR, int );
 
-	//ƒƒjƒ…[—Ş‚Ìƒtƒ@ƒCƒ‹–¼ì¬
+	//ãƒ¡ãƒ‹ãƒ¥ãƒ¼é¡ã®ãƒ•ã‚¡ã‚¤ãƒ«åä½œæˆ
 	bool GetMenuFullLabel_WinList(TCHAR* pszOutput, int nBuffSize, const EditInfo* editInfo, int id, int index, HDC hDC){
 		return GetMenuFullLabel(pszOutput, nBuffSize, true, editInfo, id, false, index, false, hDC);
 	}
@@ -89,14 +89,14 @@ public:
 	
 	static TCHAR GetAccessKeyByIndex(int index, bool bZeroOrigin);
 
-	static void GetIniFileNameDirect( LPTSTR pszPrivateIniFile, LPTSTR pszIniFile, LPCTSTR pszProfName );	/* \¬İ’èƒtƒ@ƒCƒ‹‚©‚çiniƒtƒ@ƒCƒ‹–¼‚ğæ“¾‚·‚é */	// 2007.09.04 ryoji
-	void GetIniFileName( LPTSTR pszIniFileName, LPCTSTR pszProfName, BOOL bRead = FALSE );	/* iniƒtƒ@ƒCƒ‹–¼‚Ìæ“¾ */	// 2007.05.19 ryoji
+	static void GetIniFileNameDirect( LPTSTR pszPrivateIniFile, LPTSTR pszIniFile, LPCTSTR pszProfName );	/* æ§‹æˆè¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰iniãƒ•ã‚¡ã‚¤ãƒ«åã‚’å–å¾—ã™ã‚‹ */	// 2007.09.04 ryoji
+	void GetIniFileName( LPTSTR pszIniFileName, LPCTSTR pszProfName, BOOL bRead = FALSE );	/* iniãƒ•ã‚¡ã‚¤ãƒ«åã®å–å¾— */	// 2007.05.19 ryoji
 
 private:
 	DLLSHAREDATA* m_pShareData;
 
-	// ƒtƒ@ƒCƒ‹–¼ŠÈˆÕ•\¦—pƒLƒƒƒbƒVƒ…
-	int		m_nTransformFileNameCount; // —LŒø”
+	// ãƒ•ã‚¡ã‚¤ãƒ«åç°¡æ˜“è¡¨ç¤ºç”¨ã‚­ãƒ£ãƒƒã‚·ãƒ¥
+	int		m_nTransformFileNameCount; // æœ‰åŠ¹æ•°
 	TCHAR	m_szTransformFileNameFromExp[MAX_TRANSFORM_FILENAME][_MAX_PATH];
 	int		m_nTransformFileNameOrgId[MAX_TRANSFORM_FILENAME];
 };

--- a/sakura_core/env/CFormatManager.cpp
+++ b/sakura_core/env/CFormatManager.cpp
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -30,14 +30,14 @@
 
 #include "CFormatManager.h"
 
-/*! “ú•t‚ğƒtƒH[ƒ}ƒbƒg
-	systimeFƒf[ƒ^
+/*! æ—¥ä»˜ã‚’ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ
+	systimeï¼šæ™‚åˆ»ãƒ‡ãƒ¼ã‚¿
 	
-	pszDestFƒtƒH[ƒ}ƒbƒgÏ‚İƒeƒLƒXƒgŠi”[—pƒoƒbƒtƒ@
-	nDestLenFpszDest‚Ì’·‚³
+	pszDestï¼šãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆæ¸ˆã¿ãƒ†ã‚­ã‚¹ãƒˆæ ¼ç´ç”¨ãƒãƒƒãƒ•ã‚¡
+	nDestLenï¼špszDestã®é•·ã•
 	
-	pszDateFormatF
-		ƒJƒXƒ^ƒ€‚Ì‚Æ‚«‚ÌƒtƒH[ƒ}ƒbƒg
+	pszDateFormatï¼š
+		ã‚«ã‚¹ã‚¿ãƒ ã®ã¨ãã®ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ
 */
 const TCHAR* CFormatManager::MyGetDateFormat( const SYSTEMTIME& systime, TCHAR* pszDest, int nDestLen )
 {
@@ -73,7 +73,7 @@ const TCHAR* CFormatManager::MyGetDateFormat(
 
 
 
-/* ‚ğƒtƒH[ƒ}ƒbƒg */
+/* æ™‚åˆ»ã‚’ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ */
 const TCHAR* CFormatManager::MyGetTimeFormat( const SYSTEMTIME& systime, TCHAR* pszDest, int nDestLen )
 {
 	return MyGetTimeFormat(
@@ -85,7 +85,7 @@ const TCHAR* CFormatManager::MyGetTimeFormat( const SYSTEMTIME& systime, TCHAR* 
 	);
 }
 
-/* ‚ğƒtƒH[ƒ}ƒbƒg */
+/* æ™‚åˆ»ã‚’ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ */
 const TCHAR* CFormatManager::MyGetTimeFormat(
 	const SYSTEMTIME&	systime,
 	TCHAR*			pszDest,

--- a/sakura_core/env/CFormatManager.h
+++ b/sakura_core/env/CFormatManager.h
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -27,22 +27,22 @@
 #ifndef SAKURA_CFORMATMANAGER_7FC73E49_281C_4417_BBBC_DE176142E6BC9_H_
 #define SAKURA_CFORMATMANAGER_7FC73E49_281C_4417_BBBC_DE176142E6BC9_H_
 
-// —væs’è‹`
+// è¦å…ˆè¡Œå®šç¾©
 // #include "DLLSHAREDATA.h"
 
-//!‘®ŠÇ—
+//!æ›¸å¼ç®¡ç†
 class CFormatManager{
 public:
 	CFormatManager()
 	{
 		m_pShareData = &GetDllShareData();
 	}
-	//‘® //@@@ 2002.2.9 YAZAKI
-	// ‹¤—LDLLSHAREDATAˆË‘¶
+	//æ›¸å¼ //@@@ 2002.2.9 YAZAKI
+	// å…±æœ‰DLLSHAREDATAä¾å­˜
 	const TCHAR* MyGetDateFormat( const SYSTEMTIME& systime, TCHAR* pszDest, int nDestLen );
 	const TCHAR* MyGetTimeFormat( const SYSTEMTIME& systime, TCHAR* pszDest, int nDestLen );
 
-	// ‹¤—LDLLSHAREDATA”ñˆË‘¶
+	// å…±æœ‰DLLSHAREDATAéä¾å­˜
 	const TCHAR* MyGetDateFormat( const SYSTEMTIME& systime, TCHAR* pszDest, int nDestLen, int nDateFormatType, const TCHAR* szDateFormat );
 	const TCHAR* MyGetTimeFormat( const SYSTEMTIME& systime, TCHAR* pszDest, int nDestLen, int nTimeFormatType, const TCHAR* szTimeFormat );
 private:

--- a/sakura_core/env/CHelpManager.cpp
+++ b/sakura_core/env/CHelpManager.cpp
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -32,22 +32,22 @@
 #include "env/CDocTypeManager.h"
 
 
-/*!	ŠO•”Winƒwƒ‹ƒv‚ªİ’è‚³‚ê‚Ä‚¢‚é‚©Šm”FB
+/*!	å¤–éƒ¨Winãƒ˜ãƒ«ãƒ—ãŒè¨­å®šã•ã‚Œã¦ã„ã‚‹ã‹ç¢ºèªã€‚
 */
 bool CHelpManager::ExtWinHelpIsSet( const STypeConfig* type )
 {
 	if (m_pShareData->m_Common.m_sHelper.m_szExtHelp[0] != L'\0'){
-		return true;	//	‹¤’Êİ’è‚Éİ’è‚³‚ê‚Ä‚¢‚é
+		return true;	//	å…±é€šè¨­å®šã«è¨­å®šã•ã‚Œã¦ã„ã‚‹
 	}
 	if (type && type->m_szExtHelp[0] != L'\0'){
-		return true;	//	ƒ^ƒCƒv•Êİ’è‚Éİ’è‚³‚ê‚Ä‚¢‚éB
+		return true;	//	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã«è¨­å®šã•ã‚Œã¦ã„ã‚‹ã€‚
 	}
 	return false;
 }
 
-/*!	İ’è‚³‚ê‚Ä‚¢‚éŠO•”Winƒwƒ‹ƒv‚Ìƒtƒ@ƒCƒ‹–¼‚ğ•Ô‚·B
-	ƒ^ƒCƒv•Êİ’è‚Éƒtƒ@ƒCƒ‹–¼‚ªİ’è‚³‚ê‚Ä‚¢‚ê‚ÎA‚»‚Ìƒtƒ@ƒCƒ‹–¼‚ğ•Ô‚µ‚Ü‚·B
-	‚»‚¤‚Å‚È‚¯‚ê‚ÎA‹¤’Êİ’è‚Ìƒtƒ@ƒCƒ‹–¼‚ğ•Ô‚µ‚Ü‚·B
+/*!	è¨­å®šã•ã‚Œã¦ã„ã‚‹å¤–éƒ¨Winãƒ˜ãƒ«ãƒ—ã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¿”ã™ã€‚
+	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã«ãƒ•ã‚¡ã‚¤ãƒ«åãŒè¨­å®šã•ã‚Œã¦ã„ã‚Œã°ã€ãã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¿”ã—ã¾ã™ã€‚
+	ãã†ã§ãªã‘ã‚Œã°ã€å…±é€šè¨­å®šã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¿”ã—ã¾ã™ã€‚
 */
 const TCHAR* CHelpManager::GetExtWinHelp( const STypeConfig* type )
 {
@@ -58,22 +58,22 @@ const TCHAR* CHelpManager::GetExtWinHelp( const STypeConfig* type )
 	return m_pShareData->m_Common.m_sHelper.m_szExtHelp;
 }
 
-/*!	ŠO•”HTMLƒwƒ‹ƒv‚ªİ’è‚³‚ê‚Ä‚¢‚é‚©Šm”FB
+/*!	å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—ãŒè¨­å®šã•ã‚Œã¦ã„ã‚‹ã‹ç¢ºèªã€‚
 */
 bool CHelpManager::ExtHTMLHelpIsSet( const STypeConfig* type )
 {
 	if (m_pShareData->m_Common.m_sHelper.m_szExtHtmlHelp[0] != L'\0'){
-		return true;	//	‹¤’Êİ’è‚Éİ’è‚³‚ê‚Ä‚¢‚é
+		return true;	//	å…±é€šè¨­å®šã«è¨­å®šã•ã‚Œã¦ã„ã‚‹
 	}
 	if (type && type->m_szExtHtmlHelp[0] != L'\0'){
-		return true;	//	ƒ^ƒCƒv•Êİ’è‚Éİ’è‚³‚ê‚Ä‚¢‚éB
+		return true;	//	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã«è¨­å®šã•ã‚Œã¦ã„ã‚‹ã€‚
 	}
 	return false;
 }
 
-/*!	İ’è‚³‚ê‚Ä‚¢‚éŠO•”Winƒwƒ‹ƒv‚Ìƒtƒ@ƒCƒ‹–¼‚ğ•Ô‚·B
-	ƒ^ƒCƒv•Êİ’è‚Éƒtƒ@ƒCƒ‹–¼‚ªİ’è‚³‚ê‚Ä‚¢‚ê‚ÎA‚»‚Ìƒtƒ@ƒCƒ‹–¼‚ğ•Ô‚µ‚Ü‚·B
-	‚»‚¤‚Å‚È‚¯‚ê‚ÎA‹¤’Êİ’è‚Ìƒtƒ@ƒCƒ‹–¼‚ğ•Ô‚µ‚Ü‚·B
+/*!	è¨­å®šã•ã‚Œã¦ã„ã‚‹å¤–éƒ¨Winãƒ˜ãƒ«ãƒ—ã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¿”ã™ã€‚
+	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã«ãƒ•ã‚¡ã‚¤ãƒ«åãŒè¨­å®šã•ã‚Œã¦ã„ã‚Œã°ã€ãã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¿”ã—ã¾ã™ã€‚
+	ãã†ã§ãªã‘ã‚Œã°ã€å…±é€šè¨­å®šã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¿”ã—ã¾ã™ã€‚
 */
 const TCHAR* CHelpManager::GetExtHTMLHelp( const STypeConfig* type )
 {
@@ -84,7 +84,7 @@ const TCHAR* CHelpManager::GetExtHTMLHelp( const STypeConfig* type )
 	return m_pShareData->m_Common.m_sHelper.m_szExtHtmlHelp;
 }
 
-/*!	ƒrƒ…[ƒA‚ğ•¡”‹N“®‚µ‚È‚¢‚ªON‚©‚ğ•Ô‚·B
+/*!	ãƒ“ãƒ¥ãƒ¼ã‚¢ã‚’è¤‡æ•°èµ·å‹•ã—ãªã„ãŒONã‹ã‚’è¿”ã™ã€‚
 */
 bool CHelpManager::HTMLHelpIsSingle( const STypeConfig* type )
 {

--- a/sakura_core/env/CHelpManager.h
+++ b/sakura_core/env/CHelpManager.h
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ���番��
+﻿/*
+	2008.05.18 kobake CShareData から分離
 */
 /*
 	Copyright (C) 2008, kobake
@@ -27,23 +27,23 @@
 #ifndef SAKURA_CHELPMANAGER_979D10EB_B07B_466F_BB28_AB5A7259E2EA9_H_
 #define SAKURA_CHELPMANAGER_979D10EB_B07B_466F_BB28_AB5A7259E2EA9_H_
 
-// �v��s��`
+// 要先行定義
 // #include "DLLSHAREDATA.h"
 
 
-//!�w���v�Ǘ�
+//!ヘルプ管理
 class CHelpManager{
 public:
 	CHelpManager()
 	{
 		m_pShareData = &GetDllShareData();
 	}
-	//�w���v�֘A	//@@@ 2002.2.3 YAZAKI
-	bool			ExtWinHelpIsSet( const STypeConfig* pType = NULL );		//	�^�C�v��nType�̂Ƃ��ɁA�O���w���v���ݒ肳��Ă��邩�B
-	const TCHAR*	GetExtWinHelp( const STypeConfig* pType = NULL );		//	�^�C�v��nType�̂Ƃ��́A�O���w���v�t�@�C�������擾�B
-	bool			ExtHTMLHelpIsSet( const STypeConfig* pType = NULL );	//	�^�C�v��nType�̂Ƃ��ɁA�O��HTML�w���v���ݒ肳��Ă��邩�B
-	const TCHAR*	GetExtHTMLHelp( const STypeConfig* pType = NULL );		//	�^�C�v��nType�̂Ƃ��́A�O��HTML�w���v�t�@�C�������擾�B
-	bool			HTMLHelpIsSingle( const STypeConfig* pType = NULL );	//	�^�C�v��nType�̂Ƃ��́A�O��HTML�w���v�u�r���[�A�𕡐��N�����Ȃ��v��ON�����擾�B
+	//ヘルプ関連	//@@@ 2002.2.3 YAZAKI
+	bool			ExtWinHelpIsSet( const STypeConfig* pType = NULL );		//	タイプがnTypeのときに、外部ヘルプが設定されているか。
+	const TCHAR*	GetExtWinHelp( const STypeConfig* pType = NULL );		//	タイプがnTypeのときの、外部ヘルプファイル名を取得。
+	bool			ExtHTMLHelpIsSet( const STypeConfig* pType = NULL );	//	タイプがnTypeのときに、外部HTMLヘルプが設定されているか。
+	const TCHAR*	GetExtHTMLHelp( const STypeConfig* pType = NULL );		//	タイプがnTypeのときの、外部HTMLヘルプファイル名を取得。
+	bool			HTMLHelpIsSingle( const STypeConfig* pType = NULL );	//	タイプがnTypeのときの、外部HTMLヘルプ「ビューアを複数起動しない」がONかを取得。
 private:
 	DLLSHAREDATA* m_pShareData;
 };

--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake, ryoji
 	Copyright (C) 2012, Uchi
 
@@ -69,57 +69,57 @@ static SExpParamName SExpParamNameTable[] = {
 };
 wchar_t* ExParam_LongName( wchar_t* q, wchar_t* q_max, EExpParamName eLongParam );
 
-/*!	$x�̓W�J
+/*!	$xの展開
 
-	���ꕶ���͈ȉ��̒ʂ�
-	@li $  $���g
-	@li A  �A�v����
-	@li F  �J���Ă���t�@�C���̃t���p�X�B���O���Ȃ����(����)�B
-	@li f  �J���Ă���t�@�C���̖��O�i�t�@�C����+�g���q�̂݁j
-	@li g  �J���Ă���t�@�C���̖��O�i�g���q�����j
-	@li /  �J���Ă���t�@�C���̖��O�i�t���p�X�B�p�X�̋�؂肪/�j
-	@li N  �J���Ă���t�@�C���̖��O(�ȈՕ\��)
-	@li n  ����̒ʂ��ԍ�
-	@li E  �J���Ă���t�@�C���̂���t�H���_�̖��O(�ȈՕ\��)
-	@li e  �J���Ă���t�@�C���̂���t�H���_�̖��O
-	@li B  �^�C�v�ʐݒ�̖��O
-	@li b  �J���Ă���t�@�C���̊g���q
-	@li Q  ����y�[�W�ݒ�̖��O
-	@li C  ���ݑI�𒆂̃e�L�X�g
-	@li x  ���݂̕������ʒu(�擪����̃o�C�g��1�J�n)
-	@li y  ���݂̕����s�ʒu(1�J�n)
-	@li d  ���݂̓��t(���ʐݒ�̓��t����)
-	@li t  ���݂̎���(���ʐݒ�̎�������)
-	@li p  ���݂̃y�[�W
-	@li P  ���y�[�W
-	@li D  �t�@�C���̃^�C���X�^���v(���ʐݒ�̓��t����)
-	@li T  �t�@�C���̃^�C���X�^���v(���ʐݒ�̎�������)
-	@li V  �G�f�B�^�̃o�[�W����������
-	@li h  Grep�����L�[�̐擪32byte
-	@li S  �T�N���G�f�B�^�̃t���p�X
-	@li I  ini�t�@�C���̃t���p�X
-	@li M  ���ݎ��s���Ă���}�N���t�@�C���p�X
-	@li <profile> �v���t�@�C����
+	特殊文字は以下の通り
+	@li $  $自身
+	@li A  アプリ名
+	@li F  開いているファイルのフルパス。名前がなければ(無題)。
+	@li f  開いているファイルの名前（ファイル名+拡張子のみ）
+	@li g  開いているファイルの名前（拡張子除く）
+	@li /  開いているファイルの名前（フルパス。パスの区切りが/）
+	@li N  開いているファイルの名前(簡易表示)
+	@li n  無題の通し番号
+	@li E  開いているファイルのあるフォルダの名前(簡易表示)
+	@li e  開いているファイルのあるフォルダの名前
+	@li B  タイプ別設定の名前
+	@li b  開いているファイルの拡張子
+	@li Q  印刷ページ設定の名前
+	@li C  現在選択中のテキスト
+	@li x  現在の物理桁位置(先頭からのバイト数1開始)
+	@li y  現在の物理行位置(1開始)
+	@li d  現在の日付(共通設定の日付書式)
+	@li t  現在の時刻(共通設定の時刻書式)
+	@li p  現在のページ
+	@li P  総ページ
+	@li D  ファイルのタイムスタンプ(共通設定の日付書式)
+	@li T  ファイルのタイムスタンプ(共通設定の時刻書式)
+	@li V  エディタのバージョン文字列
+	@li h  Grep検索キーの先頭32byte
+	@li S  サクラエディタのフルパス
+	@li I  iniファイルのフルパス
+	@li M  現在実行しているマクロファイルパス
+	@li <profile> プロファイル名
 
-	@date 2003.04.03 genta wcsncpy_ex�����ɂ��for���̍팸
-	@date 2005.09.15 FILE ���ꕶ��S, M�ǉ�
-	@date 2007.09.21 kobake ���ꕶ��A(�A�v����)��ǉ�
-	@date 2008.05.05 novice GetModuleHandle(NULL)��NULL�ɕύX
-	@date 2012.10.11 Moca ���ꕶ��n�ǉ�
+	@date 2003.04.03 genta wcsncpy_ex導入によるfor文の削減
+	@date 2005.09.15 FILE 特殊文字S, M追加
+	@date 2007.09.21 kobake 特殊文字A(アプリ名)を追加
+	@date 2008.05.05 novice GetModuleHandle(NULL)→NULLに変更
+	@date 2012.10.11 Moca 特殊文字n追加
 */
 void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszBuffer, int nBufferLen)
 {
 	const CEditDoc* pcDoc = CEditDoc::GetInstance(0); //###
 
-	// Apr. 03, 2003 genta �Œ蕶������܂Ƃ߂�
-	const wstring	PRINT_PREVIEW_ONLY		= LSW( STR_PREVIEW_ONLY );	//L"(����v���r���[�ł̂ݎg�p�ł��܂�)";
+	// Apr. 03, 2003 genta 固定文字列をまとめる
+	const wstring	PRINT_PREVIEW_ONLY		= LSW( STR_PREVIEW_ONLY );	//L"(印刷プレビューでのみ使用できます)";
 	const int		PRINT_PREVIEW_ONLY_LEN	= PRINT_PREVIEW_ONLY.length();
-	const wstring	NO_TITLE				= LSW( STR_NO_TITLE1 );	//L"(����)";
+	const wstring	NO_TITLE				= LSW( STR_NO_TITLE1 );	//L"(無題)";
 	const int		NO_TITLE_LEN			= NO_TITLE.length();
-	const wstring	NOT_SAVED				= LSW( STR_NOT_SAVED );	//L"(�ۑ�����Ă��܂���)";
+	const wstring	NOT_SAVED				= LSW( STR_NOT_SAVED );	//L"(保存されていません)";
 	const int		NOT_SAVED_LEN			= NOT_SAVED.length();
 
-	const wchar_t *p, *r;	//	p�F�ړI�̃o�b�t�@�Br�F��Ɨp�̃|�C���^�B
+	const wchar_t *p, *r;	//	p：目的のバッファ。r：作業用のポインタ。
 	wchar_t *q, *q_max;
 
 	for( p = pszSource, q = pszBuffer, q_max = pszBuffer + nBufferLen; *p != '\0' && q < q_max;){
@@ -131,11 +131,11 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 		case L'$':	//	 $$ -> $
 			*q++ = *p++;
 			break;
-		case L'A':	//�A�v����
+		case L'A':	//アプリ名
 			q = wcs_pushW( q, q_max - q, GSTR_APPNAME_W, wcslen(GSTR_APPNAME_W) );
 			++p;
 			break;
-		case L'F':	//	�J���Ă���t�@�C���̖��O�i�t���p�X�j
+		case L'F':	//	開いているファイルの名前（フルパス）
 			if ( !pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 				q = wcs_pushW( q, q_max - q, NO_TITLE.c_str(), NO_TITLE_LEN );
 				++p;
@@ -146,38 +146,38 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				++p;
 			}
 			break;
-		case L'f':	//	�J���Ă���t�@�C���̖��O�i�t�@�C����+�g���q�̂݁j
+		case L'f':	//	開いているファイルの名前（ファイル名+拡張子のみ）
 			// Oct. 28, 2001 genta
-			//	�t�@�C�����݂̂�n���o�[�W����
-			//	�|�C���^�𖖔���
+			//	ファイル名のみを渡すバージョン
+			//	ポインタを末尾に
 			if ( ! pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 				q = wcs_pushW( q, q_max - q, NO_TITLE.c_str(), NO_TITLE_LEN );
 				++p;
 			} 
 			else {
-				// 2002.10.13 Moca �t�@�C����(�p�X�Ȃ�)���擾�B���{��Ή�
-				//	����\\�������ɂ����Ă����̌��ɂ�\0������̂ŃA�N�Z�X�ᔽ�ɂ͂Ȃ�Ȃ��B
+				// 2002.10.13 Moca ファイル名(パスなし)を取得。日本語対応
+				//	万一\\が末尾にあってもその後ろには\0があるのでアクセス違反にはならない。
 				q = wcs_pushT( q, q_max - q, pcDoc->m_cDocFile.GetFileName());
 				++p;
 			}
 			break;
-		case L'g':	//	�J���Ă���t�@�C���̖��O�i�g���q�������t�@�C�����̂݁j
+		case L'g':	//	開いているファイルの名前（拡張子を除くファイル名のみ）
 			//	From Here Sep. 16, 2002 genta
 			if ( ! pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 				q = wcs_pushW( q, q_max - q, NO_TITLE.c_str(), NO_TITLE_LEN );
 				++p;
 			} 
 			else {
-				//	�|�C���^�𖖔���
+				//	ポインタを末尾に
 				const wchar_t *dot_position, *end_of_path;
-				r = to_wchar(pcDoc->m_cDocFile.GetFileName()); // 2002.10.13 Moca �t�@�C����(�p�X�Ȃ�)���擾�B���{��Ή�
+				r = to_wchar(pcDoc->m_cDocFile.GetFileName()); // 2002.10.13 Moca ファイル名(パスなし)を取得。日本語対応
 				end_of_path = dot_position =
 					r + wcslen( r );
-				//	��납��.��T��
+				//	後ろから.を探す
 				for( --dot_position ; dot_position > r && *dot_position != '.'
 					; --dot_position )
 					;
-				//	r�Ɠ����ꏊ�܂ōs���Ă��܂�����.����������
+				//	rと同じ場所まで行ってしまった⇔.が無かった
 				if( dot_position == r )
 					dot_position = end_of_path;
 
@@ -186,14 +186,14 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			break;
 			//	To Here Sep. 16, 2002 genta
-		case L'/':	//	�J���Ă���t�@�C���̖��O�i�t���p�X�B�p�X�̋�؂肪/�j
+		case L'/':	//	開いているファイルの名前（フルパス。パスの区切りが/）
 			// Oct. 28, 2001 genta
 			if ( !pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 				q = wcs_pushW( q, q_max - q, NO_TITLE.c_str(), NO_TITLE_LEN );
 				++p;
 			} 
 			else {
-				//	�p�X�̋�؂�Ƃ���'/'���g���o�[�W����
+				//	パスの区切りとして'/'を使うバージョン
 				for( r = to_wchar(pcDoc->m_cDocFile.GetFilePath()); *r != L'\0' && q < q_max; ++r, ++q ){
 					if( *r == L'\\' )
 						*q = L'/';
@@ -204,7 +204,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			break;
 		//	From Here 2003/06/21 Moca
-		case L'N':	//	�J���Ă���t�@�C���̖��O(�ȈՕ\��)
+		case L'N':	//	開いているファイルの名前(簡易表示)
 			if( !pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 				q = wcs_pushW( q, q_max - q, NO_TITLE.c_str(), NO_TITLE_LEN );
 				++p;
@@ -236,12 +236,12 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			++p;
 			break;
-		case L'E':	// �J���Ă���t�@�C���̂���t�H���_�̖��O(�ȈՕ\��)	2012/12/2 Uchi
+		case L'E':	// 開いているファイルのあるフォルダの名前(簡易表示)	2012/12/2 Uchi
 			if( !pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 				q = wcs_pushW( q, q_max - q, NO_TITLE.c_str(), NO_TITLE_LEN );
 			}
 			else {
-				WCHAR	buff[_MAX_PATH];		// \�̏����������WCHAR
+				WCHAR	buff[_MAX_PATH];		// \の処理をする為WCHAR
 				WCHAR*	pEnd;
 				WCHAR*	p;
 
@@ -253,11 +253,11 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 					}
 				}
 				if (pEnd != NULL) {
-					// �Ō��\�̌�ŏI�[
+					// 最後の\の後で終端
 					*(pEnd+1) = '\0';
 				}
 
-				// �ȈՕ\���ɕϊ�
+				// 簡易表示に変換
 				TCHAR szText[1024];
 				NONCLIENTMETRICS met;
 				met.cbSize = CCSIZEOF_STRUCT(NONCLIENTMETRICS, lfMessageFont);
@@ -268,7 +268,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			++p;
 			break;
-		case L'e':	// �J���Ă���t�@�C���̂���t�H���_�̖��O		2012/12/2 Uchi
+		case L'e':	// 開いているファイルのあるフォルダの名前		2012/12/2 Uchi
 			if( !pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 				q = wcs_pushW( q, q_max - q, NO_TITLE.c_str(), NO_TITLE_LEN );
 			}
@@ -289,32 +289,32 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			++p;
 			break;
 		//	From Here Jan. 15, 2002 hor
-		case L'B':	// �^�C�v�ʐݒ�̖��O			2013/03/28 Uchi
+		case L'B':	// タイプ別設定の名前			2013/03/28 Uchi
 			{
 				const STypeConfig&	sTypeCongig = pcDoc->m_cDocType.GetDocumentAttribute();
-				if (sTypeCongig.m_nIdx > 0) {	// ��{�͕\�����Ȃ�
+				if (sTypeCongig.m_nIdx > 0) {	// 基本は表示しない
 					q = wcs_pushT( q, q_max - q, sTypeCongig.m_szTypeName);
 				}
 				++p;
 			}
 			break;
-		case L'b':	// �J���Ă���t�@�C���̊g���q	2013/03/28 Uchi
+		case L'b':	// 開いているファイルの拡張子	2013/03/28 Uchi
 			if ( pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
-				//	�|�C���^�𖖔���
+				//	ポインタを末尾に
 				const wchar_t	*dot_position, *end_of_path;
 				r = to_wchar(pcDoc->m_cDocFile.GetFileName());
 				end_of_path = dot_position = r + wcslen( r );
-				//	��납��.��T��
+				//	後ろから.を探す
 				while (--dot_position >= r && *dot_position != L'.')
 					;
-				//	.�𔭌�(�g���q�L��)
+				//	.を発見(拡張子有り)
 				if (*dot_position == L'.') {
 					q = wcs_pushW( q, q_max - q, dot_position +1, end_of_path - dot_position -1 );
 				}
 			}
 			++p;
 			break;
-		case L'Q':	// ����y�[�W�ݒ�̖��O			2013/03/28 Uchi
+		case L'Q':	// 印刷ページ設定の名前			2013/03/28 Uchi
 			{
 				PRINTSETTING*	ps = &GetDllShareData().m_PrintSettingArr[
 					 pcDoc->m_cDocType.GetDocumentAttribute().m_nCurrentPrintSetting];
@@ -322,7 +322,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				++p;
 			}
 			break;
-		case L'C':	//	���ݑI�𒆂̃e�L�X�g
+		case L'C':	//	現在選択中のテキスト
 			{
 				CNativeW cmemCurText;
 				GetMainWindow()->GetActiveView().GetCurrentTextForSearch( cmemCurText );
@@ -333,7 +333,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 		//	To Here Jan. 15, 2002 hor
 			break;
 		//	From Here 2002/12/04 Moca
-		case L'x':	//	���݂̕������ʒu(�擪����̃o�C�g��1�J�n)
+		case L'x':	//	現在の物理桁位置(先頭からのバイト数1開始)
 			{
 				wchar_t szText[11];
 				_itow( GetMainWindow()->GetActiveView().GetCaret().GetCaretLogicPos().x + 1, szText, 10 );
@@ -341,7 +341,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				++p;
 			}
 			break;
-		case L'y':	//	���݂̕����s�ʒu(1�J�n)
+		case L'y':	//	現在の物理行位置(1開始)
 			{
 				wchar_t szText[11];
 				_itow( GetMainWindow()->GetActiveView().GetCaret().GetCaretLogicPos().y + 1, szText, 10 );
@@ -350,7 +350,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			break;
 		//	To Here 2002/12/04 Moca
-		case L'd':	//	���ʐݒ�̓��t����
+		case L'd':	//	共通設定の日付書式
 			{
 				TCHAR szText[1024];
 				SYSTEMTIME systime;
@@ -360,7 +360,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				++p;
 			}
 			break;
-		case L't':	//	���ʐݒ�̎�������
+		case L't':	//	共通設定の時刻書式
 			{
 				TCHAR szText[1024];
 				SYSTEMTIME systime;
@@ -370,7 +370,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				++p;
 			}
 			break;
-		case L'p':	//	���݂̃y�[�W
+		case L'p':	//	現在のページ
 			{
 				CEditWnd*	pcEditWnd = GetMainWindow();	//	Sep. 10, 2002 genta
 				if (pcEditWnd->m_pPrintPreview){
@@ -385,7 +385,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				}
 			}
 			break;
-		case L'P':	//	���y�[�W
+		case L'P':	//	総ページ
 			{
 				CEditWnd*	pcEditWnd = GetMainWindow();	//	Sep. 10, 2002 genta
 				if (pcEditWnd->m_pPrintPreview){
@@ -400,7 +400,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				}
 			}
 			break;
-		case L'D':	//	�^�C���X�^���v
+		case L'D':	//	タイムスタンプ
 			if (!pcDoc->m_cDocFile.IsFileTimeZero()){
 				TCHAR szText[1024];
 				CFormatManager().MyGetDateFormat(
@@ -416,7 +416,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				++p;
 			}
 			break;
-		case L'T':	//	�^�C���X�^���v
+		case L'T':	//	タイムスタンプ
 			if (!pcDoc->m_cDocFile.IsFileTimeZero()){
 				TCHAR szText[1024];
 				CFormatManager().MyGetTimeFormat(
@@ -435,8 +435,8 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 		case L'V':	// Apr. 4, 2003 genta
 			// Version number
 			{
-				wchar_t buf[28]; // 6(�����܂�WORD�̍ő咷) * 4 + 4(�Œ蕔��)
-				//	2004.05.13 Moca �o�[�W�����ԍ��́A�v���Z�X���ƂɎ擾����
+				wchar_t buf[28]; // 6(符号含むWORDの最大長) * 4 + 4(固定部分)
+				//	2004.05.13 Moca バージョン番号は、プロセスごとに取得する
 				DWORD dwVersionMS, dwVersionLS;
 				GetAppVersionInfo( NULL, VS_VERSION_INFO, &dwVersionMS, &dwVersionLS );
 				int len = auto_sprintf( buf, L"%d.%d.%d.%d",
@@ -450,11 +450,11 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			break;
 		case L'h':	//	Apr. 4, 2003 genta
-			//	Grep Key������ MAX 32����
-			//	���g��SetParentCaption()���ڐA
+			//	Grep Key文字列 MAX 32文字
+			//	中身はSetParentCaption()より移植
 			{
 				CNativeW	cmemDes;
-				// m_szGrepKey �� cmemDes
+				// m_szGrepKey → cmemDes
 				LimitStringLengthW( CAppMode::getInstance()->m_szGrepKey, wcslen( CAppMode::getInstance()->m_szGrepKey ), (q_max - q > 32 ? 32 : q_max - q - 3), cmemDes );
 				if( (int)wcslen( CAppMode::getInstance()->m_szGrepKey ) > cmemDes.GetStringLength() ){
 					cmemDes.AppendString(L"...");
@@ -464,7 +464,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			break;
 		case L'S':	//	Sep. 15, 2005 FILE
-			//	�T�N���G�f�B�^�̃t���p�X
+			//	サクラエディタのフルパス
 			{
 				SFilePath	szPath;
 
@@ -474,7 +474,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			break;
 		case 'I':	//	May. 19, 2007 ryoji
-			//	ini�t�@�C���̃t���p�X
+			//	iniファイルのフルパス
 			{
 				TCHAR	szPath[_MAX_PATH + 1];
 				std::tstring strProfileName = to_tchar(CCommandLine::getInstance()->GetProfileName());
@@ -484,9 +484,9 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			break;
 		case 'M':	//	Sep. 15, 2005 FILE
-			//	���ݎ��s���Ă���}�N���t�@�C���p�X�̎擾
+			//	現在実行しているマクロファイルパスの取得
 			{
-				// ���s���}�N���̃C���f�b�N�X�ԍ� (INVALID_MACRO_IDX:���� / STAND_KEYMACRO:�W���}�N��)
+				// 実行中マクロのインデックス番号 (INVALID_MACRO_IDX:無効 / STAND_KEYMACRO:標準マクロ)
 				CSMacroMgr* pcSMacroMgr = CEditApp::getInstance()->m_pcSMacroMgr;
 				switch( pcSMacroMgr->GetCurrentIdx() ){
 				case INVALID_MACRO_IDX:
@@ -514,10 +514,10 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 			}
 			break;
 		//	Mar. 31, 2003 genta
-		//	��������
+		//	条件分岐
 		//	${cond:string1$:string2$:string3$}
 		//	
-		case L'{':	// ��������
+		case L'{':	// 条件分岐
 			{
 				int cond;
 				cond = _ExParam_Evaluate( p + 1 );
@@ -528,12 +528,12 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				p = _ExParam_SkipCond( p + 1, cond );
 			}
 			break;
-		case L':':	// ��������̒���
-			//	��������̖����܂�SKIP
+		case L':':	// 条件分岐の中間
+			//	条件分岐の末尾までSKIP
 			p = _ExParam_SkipCond( p + 1, -1 );
 			break;
-		case L'}':	// ��������̖���
-			//	���ɂ��邱�Ƃ͂Ȃ�
+		case L'}':	// 条件分岐の末尾
+			//	特にすることはない
 			++p;
 			break;
 		case L'<':
@@ -570,49 +570,49 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 
 
 
-/*! @brief �����̓ǂݔ�΂�
+/*! @brief 処理の読み飛ばし
 
-	��������̍\�� ${cond:A0$:A1$:A2$:..$} �ɂ����āC
-	�w�肵���ԍ��ɑΉ�����ʒu�̐擪�ւ̃|�C���^��Ԃ��D
-	�w��ԍ��ɑΉ����镨���������$}�̎��̃|�C���^��Ԃ��D
+	条件分岐の構文 ${cond:A0$:A1$:A2$:..$} において，
+	指定した番号に対応する位置の先頭へのポインタを返す．
+	指定番号に対応する物が無ければ$}の次のポインタを返す．
 
-	${���o�ꂵ���ꍇ�ɂ̓l�X�g�ƍl����$}�܂œǂݔ�΂��D
+	${が登場した場合にはネストと考えて$}まで読み飛ばす．
 
-	@param pszSource [in] �X�L�������J�n���镶����̐擪�Dcond:�̎��̃A�h���X��n���D
-	@param part [in] �ړ�����ԍ����ǂݔ�΂�$:�̐��D-1��^����ƍŌ�܂œǂݔ�΂��D
+	@param pszSource [in] スキャンを開始する文字列の先頭．cond:の次のアドレスを渡す．
+	@param part [in] 移動する番号＝読み飛ばす$:の数．-1を与えると最後まで読み飛ばす．
 
-	@return �ړ���̃|�C���^�D�Y���̈�̐擪�����邢��$}�̒���D
+	@return 移動後のポインタ．該当領域の先頭かあるいは$}の直後．
 
 	@author genta
-	@date 2003.03.31 genta �쐬
+	@date 2003.03.31 genta 作成
 */
 const wchar_t* CSakuraEnvironment::_ExParam_SkipCond(const wchar_t* pszSource, int part)
 {
 	if( part == 0 )
 		return pszSource;
 	
-	int nest = 0;	// ����q�̃��x��
-	bool next = true;	// �p���t���O
+	int nest = 0;	// 入れ子のレベル
+	bool next = true;	// 継続フラグ
 	const wchar_t *p;
 	for( p = pszSource; next && *p != L'\0'; ++p ) {
-		if( *p == L'$' && p[1] != L'\0' ){ // $�������Ȃ疳��
+		if( *p == L'$' && p[1] != L'\0' ){ // $が末尾なら無視
 			switch( *(++p)){
-			case L'{':	// ����q�̊J�n
+			case L'{':	// 入れ子の開始
 				++nest;
 				break;
 			case L'}':
 				if( nest == 0 ){
-					//	�I���|�C���g�ɒB����
+					//	終了ポイントに達した
 					next = false; 
 				}
 				else {
-					//	�l�X�g���x����������
+					//	ネストレベルを下げる
 					--nest;
 				}
 				break;
 			case L':':
-				if( nest == 0 && --part == 0){ // ����q�łȂ��ꍇ�̂�
-					//	�ړI�̃|�C���g
+				if( nest == 0 && --part == 0){ // 入れ子でない場合のみ
+					//	目的のポイント
 					next = false;
 				}
 				break;
@@ -622,17 +622,17 @@ const wchar_t* CSakuraEnvironment::_ExParam_SkipCond(const wchar_t* pszSource, i
 	return p;
 }
 
-/*!	@brief �����̕]��
+/*!	@brief 条件の評価
 
-	@param pCond [in] ������ʐ擪�D'?'�܂ł������ƌ��Ȃ��ĕ]������
-	@return �]���̒l
+	@param pCond [in] 条件種別先頭．'?'までを条件と見なして評価する
+	@return 評価の値
 
 	@note
-	�|�C���^�̓ǂݔ�΂���Ƃ͍s��Ȃ��̂ŁC'?'�܂ł̓ǂݔ�΂���
-	�Ăяo�����ŕʓr�s���K�v������D
+	ポインタの読み飛ばし作業は行わないので，'?'までの読み飛ばしは
+	呼び出し側で別途行う必要がある．
 
 	@author genta
-	@date 2003.03.31 genta �쐬
+	@date 2003.03.31 genta 作成
 
 */
 int CSakuraEnvironment::_ExParam_Evaluate( const wchar_t* pCond )
@@ -640,17 +640,17 @@ int CSakuraEnvironment::_ExParam_Evaluate( const wchar_t* pCond )
 	const CEditDoc* pcDoc = CEditDoc::GetInstance(0); //###
 
 	switch( *pCond ){
-	case L'R': // $R �r���[���[�h����ѓǂݎ���p����
+	case L'R': // $R ビューモードおよび読み取り専用属性
 		if( CAppMode::getInstance()->IsViewMode() ){
-			return 0; // �r���[���[�h
+			return 0; // ビューモード
 		}
 		else if( !CEditDoc::GetInstance(0)->m_cDocLocker.IsDocWritable() ){
-			return 1; // �㏑���֎~
+			return 1; // 上書き禁止
 		}
 		else{
-			return 2; // ��L�ȊO
+			return 2; // 上記以外
 		}
-	case L'w': // $w Grep���[�h/Output Mode
+	case L'w': // $w Grepモード/Output Mode
 		if( CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode ){
 			return 0;
 		}else if( CAppMode::getInstance()->IsDebugMode() ){
@@ -658,27 +658,27 @@ int CSakuraEnvironment::_ExParam_Evaluate( const wchar_t* pCond )
 		}else {
 			return 2;
 		}
-	case L'M': // $M �L�[�{�[�h�}�N���̋L�^��
-		if( GetDllShareData().m_sFlags.m_bRecordingKeyMacro && GetDllShareData().m_sFlags.m_hwndRecordingKeyMacro==CEditWnd::getInstance()->GetHwnd() ){ /* �E�B���h�E */
+	case L'M': // $M キーボードマクロの記録中
+		if( GetDllShareData().m_sFlags.m_bRecordingKeyMacro && GetDllShareData().m_sFlags.m_hwndRecordingKeyMacro==CEditWnd::getInstance()->GetHwnd() ){ /* ウィンドウ */
 			return 0;
 		}else {
 			return 1;
 		}
-	case L'U': // $U �X�V
+	case L'U': // $U 更新
 		if( pcDoc->m_cDocEditor.IsModified()){
 			return 0;
 		}
 		else {
 			return 1;
 		}
-	case L'N': // $N �V�K/(����)		2012/12/2 Uchi
+	case L'N': // $N 新規/(無題)		2012/12/2 Uchi
 		if (!pcDoc->m_cDocFile.GetFilePathClass().IsValidPath()) {
 			return 0;
 		}
 		else {
 			return 1;
 		}
-	case L'I': // $I �A�C�R��������Ă��邩
+	case L'I': // $I アイコン化されているか
 		if( ::IsIconic( CEditWnd::getInstance()->GetHwnd() )){
 			return 0;
 		} else {
@@ -690,7 +690,7 @@ int CSakuraEnvironment::_ExParam_Evaluate( const wchar_t* pCond )
 	return 0;
 }
 
-/*! �������O�̐ݒ� */
+/*! 長い名前の設定 */
 wchar_t* ExParam_LongName( wchar_t* q, wchar_t* q_max, EExpParamName eLongParam )
 {
 	switch( eLongParam ){
@@ -707,10 +707,10 @@ wchar_t* ExParam_LongName( wchar_t* q, wchar_t* q_max, EExpParamName eLongParam 
 	return q;
 }
 
-/*!	@brief �����t�H���_�擾
+/*!	@brief 初期フォルダ取得
 
-	@param bControlProcess [in] true�̂Ƃ���OPENDIALOGDIR_CUR->OPENDIALOGDIR_MRU�ɕύX
-	@return �����t�H���_
+	@param bControlProcess [in] trueのときはOPENDIALOGDIR_CUR->OPENDIALOGDIR_MRUに変更
+	@return 初期フォルダ
 */
 std::tstring CSakuraEnvironment::GetDlgInitialDir(bool bControlProcess)
 {
@@ -778,13 +778,13 @@ void CSakuraEnvironment::ResolvePath(TCHAR* pszPath)
 	// pszPath -> pSrc
 	TCHAR* pSrc = pszPath;
 
-	// �V���[�g�J�b�g(.lnk)�̉���: pSrc -> szBuf -> pSrc
+	// ショートカット(.lnk)の解決: pSrc -> szBuf -> pSrc
 	TCHAR szBuf[_MAX_PATH];
 	if( ResolveShortcutLink( NULL, pSrc, szBuf ) ){
 		pSrc = szBuf;
 	}
 
-	// �����O�t�@�C�������擾����: pSrc -> szBuf2 -> pSrc
+	// ロングファイル名を取得する: pSrc -> szBuf2 -> pSrc
 	TCHAR szBuf2[_MAX_PATH];
 	if( ::GetLongFileName( pSrc, szBuf2 ) ){
 		pSrc = szBuf2;
@@ -798,15 +798,15 @@ void CSakuraEnvironment::ResolvePath(TCHAR* pszPath)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      �E�B���h�E�Ǘ�                         //
+//                      ウィンドウ管理                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
-/* �w��E�B���h�E���A�ҏW�E�B���h�E�̃t���[���E�B���h�E���ǂ������ׂ� */
+/* 指定ウィンドウが、編集ウィンドウのフレームウィンドウかどうか調べる */
 BOOL IsSakuraMainWindow( HWND hWnd )
 {
 	TCHAR	szClassName[64];
-	if( hWnd == NULL ){	// 2007.06.20 ryoji �����ǉ�
+	if( hWnd == NULL ){	// 2007.06.20 ryoji 条件追加
 		return FALSE;
 	}
 	if( !::IsWindow( hWnd ) ){

--- a/sakura_core/env/CSakuraEnvironment.h
+++ b/sakura_core/env/CSakuraEnvironment.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -34,15 +34,15 @@ public:
 	static void ExpandParameter(const wchar_t* pszSource, wchar_t* pszBuffer, int nBufferLen);
 	static std::tstring GetDlgInitialDir(bool bControlProcess = false);
 
-	static void ResolvePath(TCHAR* pszPath); //!< ƒVƒ‡[ƒgƒJƒbƒg‚Ì‰ðŒˆ‚Æƒƒ“ƒOƒtƒ@ƒCƒ‹–¼‚Ö•ÏŠ·‚ðs‚¤B
+	static void ResolvePath(TCHAR* pszPath); //!< ã‚·ãƒ§ãƒ¼ãƒˆã‚«ãƒƒãƒˆã®è§£æ±ºã¨ãƒ­ãƒ³ã‚°ãƒ•ã‚¡ã‚¤ãƒ«åã¸å¤‰æ›ã‚’è¡Œã†ã€‚
 private:
-	static const wchar_t* _ExParam_SkipCond(const wchar_t* pszSource, int part); // Mar. 31, 2003 genta ExpandParameter•â•ŠÖ”
+	static const wchar_t* _ExParam_SkipCond(const wchar_t* pszSource, int part); // Mar. 31, 2003 genta ExpandParameterè£œåŠ©é–¢æ•°
 	static int _ExParam_Evaluate( const wchar_t* pCond );
 };
 
 
-//ƒEƒBƒ“ƒhƒEŠÇ—
-/* Žw’èƒEƒBƒ“ƒhƒE‚ªA•ÒWƒEƒBƒ“ƒhƒE‚ÌƒtƒŒ[ƒ€ƒEƒBƒ“ƒhƒE‚©‚Ç‚¤‚©’²‚×‚é */
+//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç®¡ç†
+/* æŒ‡å®šã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒã€ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒ•ãƒ¬ãƒ¼ãƒ ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‹ã©ã†ã‹èª¿ã¹ã‚‹ */
 BOOL IsSakuraMainWindow( HWND hWnd );
 
 

--- a/sakura_core/env/CSearchKeywordManager.cpp
+++ b/sakura_core/env/CSearchKeywordManager.cpp
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -32,7 +32,7 @@
 #include "recent/CRecent.h"
 
 
-/*!	m_aSearchKeys‚ÉpszSearchKey‚ğ’Ç‰Á‚·‚éB
+/*!	m_aSearchKeysã«pszSearchKeyã‚’è¿½åŠ ã™ã‚‹ã€‚
 	YAZAKI
 */
 void CSearchKeywordManager::AddToSearchKeyArr( const wchar_t* pszSearchKey )
@@ -43,7 +43,7 @@ void CSearchKeywordManager::AddToSearchKeyArr( const wchar_t* pszSearchKey )
 	GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence++;
 }
 
-/*!	m_aReplaceKeys‚ÉpszReplaceKey‚ğ’Ç‰Á‚·‚é
+/*!	m_aReplaceKeysã«pszReplaceKeyã‚’è¿½åŠ ã™ã‚‹
 	YAZAKI
 */
 void CSearchKeywordManager::AddToReplaceKeyArr( const wchar_t* pszReplaceKey )
@@ -56,7 +56,7 @@ void CSearchKeywordManager::AddToReplaceKeyArr( const wchar_t* pszReplaceKey )
 	return;
 }
 
-/*!	m_aGrepFiles‚ÉpszGrepFile‚ğ’Ç‰Á‚·‚é
+/*!	m_aGrepFilesã«pszGrepFileã‚’è¿½åŠ ã™ã‚‹
 	YAZAKI
 */
 void CSearchKeywordManager::AddToGrepFileArr( const TCHAR* pszGrepFile )
@@ -66,7 +66,7 @@ void CSearchKeywordManager::AddToGrepFileArr( const TCHAR* pszGrepFile )
 	cRecentGrepFile.Terminate();
 }
 
-/*!	m_aGrepFolders.size()‚ÉpszGrepFolder‚ğ’Ç‰Á‚·‚é
+/*!	m_aGrepFolders.size()ã«pszGrepFolderã‚’è¿½åŠ ã™ã‚‹
 	YAZAKI
 */
 void CSearchKeywordManager::AddToGrepFolderArr( const TCHAR* pszGrepFolder )

--- a/sakura_core/env/CSearchKeywordManager.h
+++ b/sakura_core/env/CSearchKeywordManager.h
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -27,20 +27,20 @@
 #ifndef SAKURA_CSEARCHKEYWORDMANAGER_6D883D8B_3076_423C_BADA_B4C5DCB3E6E5_H_
 #define SAKURA_CSEARCHKEYWORDMANAGER_6D883D8B_3076_423C_BADA_B4C5DCB3E6E5_H_
 
-// —væs’è‹`
+// è¦å…ˆè¡Œå®šç¾©
 // #include "DLLSHAREDATA.h"
 
 
-//‹¤—Lƒƒ‚ƒŠ“à\‘¢‘Ì
+//å…±æœ‰ãƒ¡ãƒ¢ãƒªå†…æ§‹é€ ä½“
 struct SShare_SearchKeywords{
-	// -- -- ŒŸõƒL[ -- -- //
+	// -- -- æ¤œç´¢ã‚­ãƒ¼ -- -- //
 	StaticVector< StaticString<WCHAR, _MAX_PATH>, MAX_SEARCHKEY,  const WCHAR*>	m_aSearchKeys;
 	StaticVector< StaticString<WCHAR, _MAX_PATH>, MAX_REPLACEKEY, const WCHAR*>	m_aReplaceKeys;
 	StaticVector< StaticString<TCHAR, MAX_GREP_PATH>, MAX_GREPFILE,   const TCHAR*>	m_aGrepFiles;
 	StaticVector< StaticString<TCHAR, MAX_GREP_PATH>, MAX_GREPFOLDER, const TCHAR*>	m_aGrepFolders;
 };
 
-//! ŒŸõƒL[ƒ[ƒhŠÇ—
+//! æ¤œç´¢ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ç®¡ç†
 class CSearchKeywordManager{
 public:
 	CSearchKeywordManager()
@@ -48,10 +48,10 @@ public:
 		m_pShareData = &GetDllShareData();
 	}
 	//@@@ 2002.2.2 YAZAKI
-	void		AddToSearchKeyArr( const wchar_t* pszSearchKey );	//	m_aSearchKeys‚ÉpszSearchKey‚ğ’Ç‰Á‚·‚é
-	void		AddToReplaceKeyArr( const wchar_t* pszReplaceKey );	//	m_aReplaceKeys‚ÉpszReplaceKey‚ğ’Ç‰Á‚·‚é
-	void		AddToGrepFileArr( const TCHAR* pszGrepFile );		//	m_aGrepFiles‚ÉpszGrepFile‚ğ’Ç‰Á‚·‚é
-	void		AddToGrepFolderArr( const TCHAR* pszGrepFolder );	//	m_aGrepFolders.size()‚ÉpszGrepFolder‚ğ’Ç‰Á‚·‚é
+	void		AddToSearchKeyArr( const wchar_t* pszSearchKey );	//	m_aSearchKeysã«pszSearchKeyã‚’è¿½åŠ ã™ã‚‹
+	void		AddToReplaceKeyArr( const wchar_t* pszReplaceKey );	//	m_aReplaceKeysã«pszReplaceKeyã‚’è¿½åŠ ã™ã‚‹
+	void		AddToGrepFileArr( const TCHAR* pszGrepFile );		//	m_aGrepFilesã«pszGrepFileã‚’è¿½åŠ ã™ã‚‹
+	void		AddToGrepFolderArr( const TCHAR* pszGrepFolder );	//	m_aGrepFolders.size()ã«pszGrepFolderã‚’è¿½åŠ ã™ã‚‹
 private:
 	DLLSHAREDATA* m_pShareData;
 };

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒvƒƒZƒXŠÔ‹¤—Lƒf[ƒ^‚Ö‚ÌƒAƒNƒZƒX
+ï»¿/*!	@file
+	@brief ãƒ—ãƒ­ã‚»ã‚¹é–“å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã¸ã®ã‚¢ã‚¯ã‚»ã‚¹
 
 	@author Norio Nakatani
-	@date 1998/05/26  V‹Kì¬
+	@date 1998/05/26  æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -11,7 +11,7 @@
 	Copyright (C) 2002, genta, ai, Moca, MIK, YAZAKI, hor, KK, aroka
 	Copyright (C) 2003, Moca, aroka, MIK, genta, wmlhq, sui
 	Copyright (C) 2004, Moca, novice, genta, isearch, MIK
-	Copyright (C) 2005, Moca, MIK, genta, ryoji, ‚è‚ñ‚², aroka
+	Copyright (C) 2005, Moca, MIK, genta, ryoji, ã‚Šã‚“ã”, aroka
 	Copyright (C) 2006, aroka, ryoji, genta
 	Copyright (C) 2007, ryoji, genta, maru
 	Copyright (C) 2008, ryoji, Uchi, nasukoji
@@ -50,8 +50,8 @@ struct ARRHEAD {
 
 const unsigned int uShareDataVersion = N_SHAREDATA_VERSION;
 
-//	CShareData_new2.cpp‚Æ“‡
-//@@@ 2002.01.03 YAZAKI m_tbMyButton‚È‚Ç‚ğCShareData‚©‚çCMenuDrawer‚ÖˆÚ“®
+//	CShareData_new2.cppã¨çµ±åˆ
+//@@@ 2002.01.03 YAZAKI m_tbMyButtonãªã©ã‚’CShareDataã‹ã‚‰CMenuDrawerã¸ç§»å‹•
 CShareData::CShareData()
 {
 	m_hFileMap   = NULL;
@@ -60,13 +60,13 @@ CShareData::CShareData()
 }
 
 /*!
-	‹¤—Lƒƒ‚ƒŠ—Ìˆæ‚ª‚ ‚éê‡‚ÍƒvƒƒZƒX‚ÌƒAƒhƒŒƒX‹óŠÔ‚©‚ç¤
-	‚·‚Å‚Éƒ}ƒbƒv‚³‚ê‚Ä‚¢‚éƒtƒ@ƒCƒ‹ ƒrƒ…[‚ğƒAƒ“ƒ}ƒbƒv‚·‚éB
+	å…±æœ‰ãƒ¡ãƒ¢ãƒªé ˜åŸŸãŒã‚ã‚‹å ´åˆã¯ãƒ—ãƒ­ã‚»ã‚¹ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ç©ºé–“ã‹ã‚‰ï½¤
+	ã™ã§ã«ãƒãƒƒãƒ—ã•ã‚Œã¦ã„ã‚‹ãƒ•ã‚¡ã‚¤ãƒ« ãƒ“ãƒ¥ãƒ¼ã‚’ã‚¢ãƒ³ãƒãƒƒãƒ—ã™ã‚‹ã€‚
 */
 CShareData::~CShareData()
 {
 	if( m_pShareData ){
-		/* ƒvƒƒZƒX‚ÌƒAƒhƒŒƒX‹óŠÔ‚©‚ç¤ ‚·‚Å‚Éƒ}ƒbƒv‚³‚ê‚Ä‚¢‚éƒtƒ@ƒCƒ‹ ƒrƒ…[‚ğƒAƒ“ƒ}ƒbƒv‚µ‚Ü‚· */
+		/* ãƒ—ãƒ­ã‚»ã‚¹ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ç©ºé–“ã‹ã‚‰ï½¤ ã™ã§ã«ãƒãƒƒãƒ—ã•ã‚Œã¦ã„ã‚‹ãƒ•ã‚¡ã‚¤ãƒ« ãƒ“ãƒ¥ãƒ¼ã‚’ã‚¢ãƒ³ãƒãƒƒãƒ—ã—ã¾ã™ */
 		SetDllShareData( NULL );
 		::UnmapViewOfFile( m_pShareData );
 		m_pShareData = NULL;
@@ -91,18 +91,18 @@ CMutex& CShareData::GetMutexShareWork(){
 	return g_cMutexShareWork;
 }
 
-//! CShareDataƒNƒ‰ƒX‚Ì‰Šú‰»ˆ—
+//! CShareDataã‚¯ãƒ©ã‚¹ã®åˆæœŸåŒ–å‡¦ç†
 /*!
-	CShareDataƒNƒ‰ƒX‚ğ—˜—p‚·‚é‘O‚É•K‚¸ŒÄ‚Ño‚·‚±‚ÆB
+	CShareDataã‚¯ãƒ©ã‚¹ã‚’åˆ©ç”¨ã™ã‚‹å‰ã«å¿…ãšå‘¼ã³å‡ºã™ã“ã¨ã€‚
 
-	@retval true ‰Šú‰»¬Œ÷
-	@retval false ‰Šú‰»¸”s
+	@retval true åˆæœŸåŒ–æˆåŠŸ
+	@retval false åˆæœŸåŒ–å¤±æ•—
 
-	@note Šù‚É‘¶İ‚·‚é‹¤—Lƒƒ‚ƒŠ‚Ìƒo[ƒWƒ‡ƒ“‚ª‚±‚ÌƒGƒfƒBƒ^‚ªg‚¤‚à‚Ì‚Æ
-	ˆÙ‚È‚éê‡‚Í’v–½“IƒGƒ‰[‚ğ–h‚®‚½‚ß‚Éfalse‚ğ•Ô‚µ‚Ü‚·BCProcess::Initialize()
-	‚ÅInit()‚É¸”s‚·‚é‚ÆƒƒbƒZ[ƒW‚ğo‚µ‚ÄƒGƒfƒBƒ^‚Ì‹N“®‚ğ’†~‚µ‚Ü‚·B
+	@note æ—¢ã«å­˜åœ¨ã™ã‚‹å…±æœ‰ãƒ¡ãƒ¢ãƒªã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³ãŒã“ã®ã‚¨ãƒ‡ã‚£ã‚¿ãŒä½¿ã†ã‚‚ã®ã¨
+	ç•°ãªã‚‹å ´åˆã¯è‡´å‘½çš„ã‚¨ãƒ©ãƒ¼ã‚’é˜²ããŸã‚ã«falseã‚’è¿”ã—ã¾ã™ã€‚CProcess::Initialize()
+	ã§Init()ã«å¤±æ•—ã™ã‚‹ã¨ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å‡ºã—ã¦ã‚¨ãƒ‡ã‚£ã‚¿ã®èµ·å‹•ã‚’ä¸­æ­¢ã—ã¾ã™ã€‚
 
-	@date 2018/06/01 d—l•ÏX https://github.com/sakura-editor/sakura/issues/29
+	@date 2018/06/01 ä»•æ§˜å¤‰æ›´ https://github.com/sakura-editor/sakura/issues/29
 */
 bool CShareData::InitShareData()
 {
@@ -110,7 +110,7 @@ bool CShareData::InitShareData()
 
 	m_hwndTraceOutSource = NULL;	// 2006.06.26 ryoji
 
-	/* ƒtƒ@ƒCƒ‹ƒ}ƒbƒsƒ“ƒOƒIƒuƒWƒFƒNƒg */
+	/* ãƒ•ã‚¡ã‚¤ãƒ«ãƒãƒƒãƒ”ãƒ³ã‚°ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ */
 	{
 		std::tstring strProfileName = to_tchar(CCommandLine::getInstance()->GetProfileName());
 		std::tstring strShareDataName = GSTR_SHAREDATA;
@@ -127,16 +127,16 @@ bool CShareData::InitShareData()
 	if( NULL == m_hFileMap ){
 		::MessageBox(
 			NULL,
-			_T("CreateFileMapping()‚É¸”s‚µ‚Ü‚µ‚½"),
-			_T("—\Šú‚¹‚ÊƒGƒ‰["),
+			_T("CreateFileMapping()ã«å¤±æ•—ã—ã¾ã—ãŸ"),
+			_T("äºˆæœŸã›ã¬ã‚¨ãƒ©ãƒ¼"),
 			MB_OK | MB_APPLMODAL | MB_ICONSTOP
 		);
 		return false;
 	}
 
 	if( GetLastError() != ERROR_ALREADY_EXISTS ){
-		/* ƒIƒuƒWƒFƒNƒg‚ª‘¶İ‚µ‚Ä‚¢‚È‚©‚Á‚½ê‡ */
-		/* ƒtƒ@ƒCƒ‹‚Ìƒrƒ…[‚ğ¤ ŒÄ‚Ño‚µ‘¤ƒvƒƒZƒX‚ÌƒAƒhƒŒƒX‹óŠÔ‚Éƒ}ƒbƒv‚µ‚Ü‚· */
+		/* ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆãŒå­˜åœ¨ã—ã¦ã„ãªã‹ã£ãŸå ´åˆ */
+		/* ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ“ãƒ¥ãƒ¼ã‚’ï½¤ å‘¼ã³å‡ºã—å´ãƒ—ãƒ­ã‚»ã‚¹ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ç©ºé–“ã«ãƒãƒƒãƒ—ã—ã¾ã™ */
 		m_pShareData = (DLLSHAREDATA*)::MapViewOfFile(
 			m_hFileMap,
 			FILE_MAP_ALL_ACCESS,
@@ -147,7 +147,7 @@ bool CShareData::InitShareData()
 		CreateTypeSettings();
 		SetDllShareData( m_pShareData );
 
-		// 2007.05.19 ryoji Àsƒtƒ@ƒCƒ‹ƒtƒHƒ‹ƒ_->İ’èƒtƒ@ƒCƒ‹ƒtƒHƒ‹ƒ_‚É•ÏX
+		// 2007.05.19 ryoji å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ãƒ•ã‚©ãƒ«ãƒ€->è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ãƒ•ã‚©ãƒ«ãƒ€ã«å¤‰æ›´
 		TCHAR	szIniFolder[_MAX_PATH];
 		m_pShareData->m_sFileNameManagement.m_IniFolder.m_bInit = false;
 		GetInidir( szIniFolder );
@@ -156,17 +156,17 @@ bool CShareData::InitShareData()
 		m_pShareData->m_vStructureVersion = uShareDataVersion;
 		m_pShareData->m_nSize = sizeof(*m_pShareData);
 
-		// 2004.05.13 Moca ƒŠƒ\[ƒX‚©‚ç»•iƒo[ƒWƒ‡ƒ“‚Ìæ“¾
+		// 2004.05.13 Moca ãƒªã‚½ãƒ¼ã‚¹ã‹ã‚‰è£½å“ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã®å–å¾—
 		GetAppVersionInfo( NULL, VS_VERSION_INFO,
 			&m_pShareData->m_sVersion.m_dwProductVersionMS, &m_pShareData->m_sVersion.m_dwProductVersionLS );
 
-		m_pShareData->m_sFlags.m_bEditWndChanging = FALSE;	// •ÒWƒEƒBƒ“ƒhƒEØ‘Ö’†	// 2007.04.03 ryoji
-		m_pShareData->m_sFlags.m_bRecordingKeyMacro = FALSE;		/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì‹L˜^’† */
-		m_pShareData->m_sFlags.m_hwndRecordingKeyMacro = NULL;	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ‹L˜^’†‚ÌƒEƒBƒ“ƒhƒE */
+		m_pShareData->m_sFlags.m_bEditWndChanging = FALSE;	// ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ‡æ›¿ä¸­	// 2007.04.03 ryoji
+		m_pShareData->m_sFlags.m_bRecordingKeyMacro = FALSE;		/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ */
+		m_pShareData->m_sFlags.m_hwndRecordingKeyMacro = NULL;	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’è¨˜éŒ²ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
 
-		m_pShareData->m_sNodes.m_nSequences = 0;					/* ƒEƒBƒ“ƒhƒE˜A”Ô */
+		m_pShareData->m_sNodes.m_nSequences = 0;					/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦é€£ç•ª */
 		m_pShareData->m_sNodes.m_nNonameSequences = 0;
-		m_pShareData->m_sNodes.m_nGroupSequences = 0;			/* ƒ^ƒuƒOƒ‹[ƒv˜A”Ô */	// 2007.06.20 ryoji
+		m_pShareData->m_sNodes.m_nGroupSequences = 0;			/* ã‚¿ãƒ–ã‚°ãƒ«ãƒ¼ãƒ—é€£ç•ª */	// 2007.06.20 ryoji
 		m_pShareData->m_sNodes.m_nEditArrNum = 0;
 
 		m_pShareData->m_sHandles.m_hwndTray = NULL;
@@ -177,19 +177,19 @@ bool CShareData::InitShareData()
 			m_pShareData->m_dwCustColors[i] = RGB( 255, 255, 255 );
 		}
 
-//@@@ 2001.12.26 YAZAKI MRUƒŠƒXƒg‚ÍACMRU‚ÉˆË—Š‚·‚é
+//@@@ 2001.12.26 YAZAKI MRUãƒªã‚¹ãƒˆã¯ã€CMRUã«ä¾é ¼ã™ã‚‹
 		CMRUFile cMRU;
 		cMRU.ClearAll();
-//@@@ 2001.12.26 YAZAKI OPENFOLDERƒŠƒXƒg‚ÍACMRUFolder‚É‚·‚×‚ÄˆË—Š‚·‚é
+//@@@ 2001.12.26 YAZAKI OPENFOLDERãƒªã‚¹ãƒˆã¯ã€CMRUFolderã«ã™ã¹ã¦ä¾é ¼ã™ã‚‹
 		CMRUFolder cMRUFolder;
 		cMRUFolder.ClearAll();
 
-//	From Here Sept. 19, 2000 JEPRO ƒRƒƒ“ƒgƒAƒEƒg‚É‚È‚Á‚Ä‚¢‚½‰‚ß‚ÌƒuƒƒbƒN‚ğ•œŠˆ‚µ‚»‚Ì‰º‚ğƒRƒƒ“ƒgƒAƒEƒg
-//	MS ƒSƒVƒbƒN•W€ƒXƒ^ƒCƒ‹10pt‚Éİ’è
-//		/* LOGFONT‚Ì‰Šú‰» */
+//	From Here Sept. 19, 2000 JEPRO ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã«ãªã£ã¦ã„ãŸåˆã‚ã®ãƒ–ãƒ­ãƒƒã‚¯ã‚’å¾©æ´»ã—ãã®ä¸‹ã‚’ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆ
+//	MS ã‚´ã‚·ãƒƒã‚¯æ¨™æº–ã‚¹ã‚¿ã‚¤ãƒ«10ptã«è¨­å®š
+//		/* LOGFONTã®åˆæœŸåŒ– */
 		LOGFONT lf;
 		memset_raw( &lf, 0, sizeof( lf ) );
-		lf.lfHeight			= DpiPointsToPixels(-10);	// 2009.10.01 ryoji ‚DPI‘Î‰iƒ|ƒCƒ“ƒg”‚©‚çZoj
+		lf.lfHeight			= DpiPointsToPixels(-10);	// 2009.10.01 ryoji é«˜DPIå¯¾å¿œï¼ˆãƒã‚¤ãƒ³ãƒˆæ•°ã‹ã‚‰ç®—å‡ºï¼‰
 		lf.lfWidth				= 0;
 		lf.lfEscapement		= 0;
 		lf.lfOrientation		= 0;
@@ -202,13 +202,13 @@ bool CShareData::InitShareData()
 		lf.lfClipPrecision		= 0x2;
 		lf.lfQuality			= 0x1;
 		lf.lfPitchAndFamily	= 0x31;
-		_tcscpy( lf.lfFaceName, _T("‚l‚r ƒSƒVƒbƒN") );
+		_tcscpy( lf.lfFaceName, _T("ï¼­ï¼³ ã‚´ã‚·ãƒƒã‚¯") );
 
-		// LoadShareData‚ÅƒtƒHƒ“ƒg‚ª•Ï‚í‚é‰Â”\«‚ª‚ ‚é‚Ì‚ÅA‚±‚±‚Å‚Í•s—v // 2013.04.08 aroka
+		// LoadShareDataã§ãƒ•ã‚©ãƒ³ãƒˆãŒå¤‰ã‚ã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹ã®ã§ã€ã“ã“ã§ã¯ä¸è¦ // 2013.04.08 aroka
 		//InitCharWidthCacheCommon();								// 2008/5/17 Uchi
 
-		// ƒL[ƒ[ƒhƒwƒ‹ƒv‚ÌƒtƒHƒ“ƒg ai 02/05/21 Add S
-		LOGFONT lfIconTitle;	// ƒGƒNƒXƒvƒ[ƒ‰‚Ìƒtƒ@ƒCƒ‹–¼•\¦‚Ég—p‚³‚ê‚éƒtƒHƒ“ƒg
+		// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã®ãƒ•ã‚©ãƒ³ãƒˆ ai 02/05/21 Add S
+		LOGFONT lfIconTitle;	// ã‚¨ã‚¯ã‚¹ãƒ—ãƒ­ãƒ¼ãƒ©ã®ãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤ºã«ä½¿ç”¨ã•ã‚Œã‚‹ãƒ•ã‚©ãƒ³ãƒˆ
 		::SystemParametersInfo(
 			SPI_GETICONTITLELOGFONT,				// system parameter to query or set
 			sizeof(LOGFONT),						// depends on action to be taken
@@ -217,111 +217,111 @@ bool CShareData::InitShareData()
 		);
 		// ai 02/05/21 Add E
 
-		INT		nIconPointSize = lfIconTitle.lfHeight >=0 ? lfIconTitle.lfHeight : DpiPixelsToPoints( -lfIconTitle.lfHeight, 10 );	// ƒtƒHƒ“ƒgƒTƒCƒYi1/10ƒ|ƒCƒ“ƒg’PˆÊj
+		INT		nIconPointSize = lfIconTitle.lfHeight >=0 ? lfIconTitle.lfHeight : DpiPixelsToPoints( -lfIconTitle.lfHeight, 10 );	// ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºï¼ˆ1/10ãƒã‚¤ãƒ³ãƒˆå˜ä½ï¼‰
 //	To Here Sept. 19,2000
 
-		// [‘S”Ê]ƒ^ƒu
+		// [å…¨èˆ¬]ã‚¿ãƒ–
 		{
 			CommonSetting_General& sGeneral = m_pShareData->m_Common.m_sGeneral;
 
-			sGeneral.m_nMRUArrNum_MAX = 15;	/* ƒtƒ@ƒCƒ‹‚Ì—š—ğMAX */	//Oct. 14, 2000 JEPRO ­‚µ‘‚â‚µ‚½(10¨15)
-			sGeneral.m_nOPENFOLDERArrNum_MAX = 15;	/* ƒtƒHƒ‹ƒ_‚Ì—š—ğMAX */	//Oct. 14, 2000 JEPRO ­‚µ‘‚â‚µ‚½(10¨15)
+			sGeneral.m_nMRUArrNum_MAX = 15;	/* ãƒ•ã‚¡ã‚¤ãƒ«ã®å±¥æ­´MAX */	//Oct. 14, 2000 JEPRO å°‘ã—å¢—ã‚„ã—ãŸ(10â†’15)
+			sGeneral.m_nOPENFOLDERArrNum_MAX = 15;	/* ãƒ•ã‚©ãƒ«ãƒ€ã®å±¥æ­´MAX */	//Oct. 14, 2000 JEPRO å°‘ã—å¢—ã‚„ã—ãŸ(10â†’15)
 
-			sGeneral.m_nCaretType = 0;					/* ƒJ[ƒ\ƒ‹‚Ìƒ^ƒCƒv 0=win 1=dos */
-			sGeneral.m_bIsINSMode = true;				/* ‘}“ü^ã‘‚«ƒ‚[ƒh */
-			sGeneral.m_bIsFreeCursorMode = false;		/* ƒtƒŠ[ƒJ[ƒ\ƒ‹ƒ‚[ƒh‚© */	//Oct. 29, 2000 JEPRO u‚È‚µv‚É•ÏX
+			sGeneral.m_nCaretType = 0;					/* ã‚«ãƒ¼ã‚½ãƒ«ã®ã‚¿ã‚¤ãƒ— 0=win 1=dos */
+			sGeneral.m_bIsINSMode = true;				/* æŒ¿å…¥ï¼ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰ */
+			sGeneral.m_bIsFreeCursorMode = false;		/* ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ãƒ¢ãƒ¼ãƒ‰ã‹ */	//Oct. 29, 2000 JEPRO ã€Œãªã—ã€ã«å¤‰æ›´
 
-			sGeneral.m_bStopsBothEndsWhenSearchWord = FALSE;	/* ’PŒê’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚ÉA’PŒê‚Ì—¼’[‚Å~‚Ü‚é‚© */
-			sGeneral.m_bStopsBothEndsWhenSearchParagraph = FALSE;	/* ’PŒê’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚ÉA’PŒê‚Ì—¼’[‚Å~‚Ü‚é‚© */
+			sGeneral.m_bStopsBothEndsWhenSearchWord = FALSE;	/* å˜èªå˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«ã€å˜èªã®ä¸¡ç«¯ã§æ­¢ã¾ã‚‹ã‹ */
+			sGeneral.m_bStopsBothEndsWhenSearchParagraph = FALSE;	/* å˜èªå˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«ã€å˜èªã®ä¸¡ç«¯ã§æ­¢ã¾ã‚‹ã‹ */
 
-			sGeneral.m_bCloseAllConfirm = FALSE;		/* [‚·‚×‚Ä•Â‚¶‚é]‚Å‘¼‚É•ÒW—p‚ÌƒEƒBƒ“ƒhƒE‚ª‚ ‚ê‚ÎŠm”F‚·‚é */	// 2006.12.25 ryoji
-			sGeneral.m_bExitConfirm = FALSE;			/* I—¹‚ÌŠm”F‚ğ‚·‚é */
-			sGeneral.m_nRepeatedScrollLineNum = CLayoutInt(3);	/* ƒL[ƒŠƒs[ƒg‚ÌƒXƒNƒ[ƒ‹s” */
-			sGeneral.m_nRepeatedMoveCaretNum = 2;		// ƒL[ƒŠƒs[ƒg‚Ì¶‰EˆÚ“®”
-			sGeneral.m_nRepeatedScroll_Smooth = FALSE;	/* ƒL[ƒŠƒs[ƒg‚ÌƒXƒNƒ[ƒ‹‚ğŠŠ‚ç‚©‚É‚·‚é‚© */
-			sGeneral.m_nPageScrollByWheel = 0;			/* ƒL[/ƒ}ƒEƒXƒ{ƒ^ƒ“ + ƒzƒC[ƒ‹ƒXƒNƒ[ƒ‹‚Åƒy[ƒWƒXƒNƒ[ƒ‹‚·‚é */	// 2009.01.17 nasukoji
-			sGeneral.m_nHorizontalScrollByWheel = 0;	/* ƒL[/ƒ}ƒEƒXƒ{ƒ^ƒ“ + ƒzƒC[ƒ‹ƒXƒNƒ[ƒ‹‚Å‰¡ƒXƒNƒ[ƒ‹‚·‚é */		// 2009.01.17 nasukoji
+			sGeneral.m_bCloseAllConfirm = FALSE;		/* [ã™ã¹ã¦é–‰ã˜ã‚‹]ã§ä»–ã«ç·¨é›†ç”¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒã‚ã‚Œã°ç¢ºèªã™ã‚‹ */	// 2006.12.25 ryoji
+			sGeneral.m_bExitConfirm = FALSE;			/* çµ‚äº†æ™‚ã®ç¢ºèªã‚’ã™ã‚‹ */
+			sGeneral.m_nRepeatedScrollLineNum = CLayoutInt(3);	/* ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•° */
+			sGeneral.m_nRepeatedMoveCaretNum = 2;		// ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®å·¦å³ç§»å‹•æ•°
+			sGeneral.m_nRepeatedScroll_Smooth = FALSE;	/* ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚’æ»‘ã‚‰ã‹ã«ã™ã‚‹ã‹ */
+			sGeneral.m_nPageScrollByWheel = 0;			/* ã‚­ãƒ¼/ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³ + ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã§ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹ */	// 2009.01.17 nasukoji
+			sGeneral.m_nHorizontalScrollByWheel = 0;	/* ã‚­ãƒ¼/ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³ + ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã§æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹ */		// 2009.01.17 nasukoji
 
-			sGeneral.m_bUseTaskTray = TRUE;				/* ƒ^ƒXƒNƒgƒŒƒC‚ÌƒAƒCƒRƒ“‚ğg‚¤ */
-			sGeneral.m_bStayTaskTray = FALSE;			/* ƒ^ƒXƒNƒgƒŒƒC‚ÌƒAƒCƒRƒ“‚ğí’“ */
-			sGeneral.m_wTrayMenuHotKeyCode = L'Z';		/* ƒ^ƒXƒNƒgƒŒƒC¶ƒNƒŠƒbƒNƒƒjƒ…[ ƒL[ */
-			sGeneral.m_wTrayMenuHotKeyMods = HOTKEYF_ALT | HOTKEYF_CONTROL;	/* ƒ^ƒXƒNƒgƒŒƒC¶ƒNƒŠƒbƒNƒƒjƒ…[ ƒL[ */
+			sGeneral.m_bUseTaskTray = TRUE;				/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã®ã‚¢ã‚¤ã‚³ãƒ³ã‚’ä½¿ã† */
+			sGeneral.m_bStayTaskTray = FALSE;			/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã®ã‚¢ã‚¤ã‚³ãƒ³ã‚’å¸¸é§ */
+			sGeneral.m_wTrayMenuHotKeyCode = L'Z';		/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤å·¦ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ ã‚­ãƒ¼ */
+			sGeneral.m_wTrayMenuHotKeyMods = HOTKEYF_ALT | HOTKEYF_CONTROL;	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤å·¦ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ ã‚­ãƒ¼ */
 
-			sGeneral.m_bDispExitingDialog = FALSE;		/* I—¹ƒ_ƒCƒAƒƒO‚ğ•\¦‚·‚é */
+			sGeneral.m_bDispExitingDialog = FALSE;		/* çµ‚äº†ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è¡¨ç¤ºã™ã‚‹ */
 
-			sGeneral.m_bNoCaretMoveByActivation = FALSE;	/* ƒ}ƒEƒXƒNƒŠƒbƒN‚É‚ÄƒAƒNƒeƒBƒx[ƒg‚³‚ê‚½‚ÍƒJ[ƒ\ƒ‹ˆÊ’u‚ğˆÚ“®‚µ‚È‚¢ 2007.10.02 nasukoji (add by genta) */
+			sGeneral.m_bNoCaretMoveByActivation = FALSE;	/* ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯ã«ã¦ã‚¢ã‚¯ãƒ†ã‚£ãƒ™ãƒ¼ãƒˆã•ã‚ŒãŸæ™‚ã¯ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’ç§»å‹•ã—ãªã„ 2007.10.02 nasukoji (add by genta) */
 		}
 
-		// [ƒEƒBƒ“ƒhƒE]ƒ^ƒu
+		// [ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦]ã‚¿ãƒ–
 		{
 			CommonSetting_Window& sWindow = m_pShareData->m_Common.m_sWindow;
 
-			sWindow.m_bDispTOOLBAR = TRUE;			/* Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒc[ƒ‹ƒo[‚ğ•\¦‚·‚é */
-			sWindow.m_bDispSTATUSBAR = TRUE;			/* Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒXƒe[ƒ^ƒXƒo[‚ğ•\¦‚·‚é */
-			sWindow.m_bDispFUNCKEYWND = FALSE;		/* Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ğ•\¦‚·‚é */
-			sWindow.m_bDispMiniMap = false;			// ƒ~ƒjƒ}ƒbƒv‚ğ•\¦‚·‚é
-			sWindow.m_nFUNCKEYWND_Place = 1;			/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\¦ˆÊ’u^0:ã 1:‰º */
-			sWindow.m_nFUNCKEYWND_GroupNum = 4;			// 2002/11/04 Moca ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ÌƒOƒ‹[ƒvƒ{ƒ^ƒ“”
+			sWindow.m_bDispTOOLBAR = TRUE;			/* æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ããƒ„ãƒ¼ãƒ«ãƒãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ */
+			sWindow.m_bDispSTATUSBAR = TRUE;			/* æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ãã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ */
+			sWindow.m_bDispFUNCKEYWND = FALSE;		/* æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ããƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ */
+			sWindow.m_bDispMiniMap = false;			// ãƒŸãƒ‹ãƒãƒƒãƒ—ã‚’è¡¨ç¤ºã™ã‚‹
+			sWindow.m_nFUNCKEYWND_Place = 1;			/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤ºä½ç½®ï¼0:ä¸Š 1:ä¸‹ */
+			sWindow.m_nFUNCKEYWND_GroupNum = 4;			// 2002/11/04 Moca ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®ã‚°ãƒ«ãƒ¼ãƒ—ãƒœã‚¿ãƒ³æ•°
 			sWindow.m_nMiniMapFontSize = -1;
 			sWindow.m_nMiniMapQuality = NONANTIALIASED_QUALITY;
 			sWindow.m_nMiniMapWidth = 150;
 
-			sWindow.m_bSplitterWndHScroll = TRUE;	// 2001/06/20 asa-o •ªŠ„ƒEƒBƒ“ƒhƒE‚Ì…•½ƒXƒNƒ[ƒ‹‚Ì“¯Šú‚ğ‚Æ‚é
-			sWindow.m_bSplitterWndVScroll = TRUE;	// 2001/06/20 asa-o •ªŠ„ƒEƒBƒ“ƒhƒE‚Ì‚’¼ƒXƒNƒ[ƒ‹‚Ì“¯Šú‚ğ‚Æ‚é
+			sWindow.m_bSplitterWndHScroll = TRUE;	// 2001/06/20 asa-o åˆ†å‰²ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸã‚’ã¨ã‚‹
+			sWindow.m_bSplitterWndVScroll = TRUE;	// 2001/06/20 asa-o åˆ†å‰²ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸã‚’ã¨ã‚‹
 
-			// 2001/06/14 asa-o •âŠ®‚ÆƒL[ƒ[ƒhƒwƒ‹ƒv‚Íƒ^ƒCƒv•Ê‚ÉˆÚ“®‚µ‚½‚Ì‚Åíœ
-			//	2004.05.13 Moca ƒEƒBƒ“ƒhƒEƒTƒCƒYŒÅ’èw’è’Ç‰Á‚É”º‚¤w’è•û–@•ÏX
-			sWindow.m_eSaveWindowSize = WINSIZEMODE_SAVE;	// ƒEƒBƒ“ƒhƒEƒTƒCƒYŒp³
+			// 2001/06/14 asa-o è£œå®Œã¨ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã¯ã‚¿ã‚¤ãƒ—åˆ¥ã«ç§»å‹•ã—ãŸã®ã§å‰Šé™¤
+			//	2004.05.13 Moca ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚µã‚¤ã‚ºå›ºå®šæŒ‡å®šè¿½åŠ ã«ä¼´ã†æŒ‡å®šæ–¹æ³•å¤‰æ›´
+			sWindow.m_eSaveWindowSize = WINSIZEMODE_SAVE;	// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚µã‚¤ã‚ºç¶™æ‰¿
 			sWindow.m_nWinSizeType = SIZE_RESTORED;
 			sWindow.m_nWinSizeCX = CW_USEDEFAULT;
 			sWindow.m_nWinSizeCY = 0;
 		
-			sWindow.m_bScrollBarHorz = TRUE;				/* …•½ƒXƒNƒ[ƒ‹ƒo[‚ğg‚¤ */
-			//	2004.05.13 Moca ƒEƒBƒ“ƒhƒEˆÊ’u
-			sWindow.m_eSaveWindowPos = WINSIZEMODE_DEF;		// ƒEƒBƒ“ƒhƒEˆÊ’uŒÅ’èEŒp³
+			sWindow.m_bScrollBarHorz = TRUE;				/* æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã‚’ä½¿ã† */
+			//	2004.05.13 Moca ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä½ç½®
+			sWindow.m_eSaveWindowPos = WINSIZEMODE_DEF;		// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä½ç½®å›ºå®šãƒ»ç¶™æ‰¿
 			sWindow.m_nWinPosX = CW_USEDEFAULT;
 			sWindow.m_nWinPosY = 0;
 
-			sWindow.m_nRulerHeight = 13;					/* ƒ‹[ƒ‰[‚Ì‚‚³ */
-			sWindow.m_nRulerBottomSpace = 0;				/* ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ */
-			sWindow.m_nRulerType = 0;					/* ƒ‹[ƒ‰[‚Ìƒ^ƒCƒv */
-			sWindow.m_nLineNumRightSpace = 0;			/* s”Ô†‚Ì‰E‚ÌŒ„ŠÔ */
-			sWindow.m_nVertLineOffset = -1;			// 2005.11.10 Moca w’èŒ…cü
-			sWindow.m_bUseCompatibleBMP = TRUE;		// 2007.09.09 Moca ‰æ–ÊƒLƒƒƒbƒVƒ…‚ğg‚¤	// 2009.06.09 ryoji FALSE->TRUE
+			sWindow.m_nRulerHeight = 13;					/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã®é«˜ã• */
+			sWindow.m_nRulerBottomSpace = 0;				/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“ */
+			sWindow.m_nRulerType = 0;					/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚¿ã‚¤ãƒ— */
+			sWindow.m_nLineNumRightSpace = 0;			/* è¡Œç•ªå·ã®å³ã®éš™é–“ */
+			sWindow.m_nVertLineOffset = -1;			// 2005.11.10 Moca æŒ‡å®šæ¡ç¸¦ç·š
+			sWindow.m_bUseCompatibleBMP = TRUE;		// 2007.09.09 Moca ç”»é¢ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’ä½¿ã†	// 2009.06.09 ryoji FALSE->TRUE
 
-			sWindow.m_bMenuIcon = TRUE;		/* ƒƒjƒ…[‚ÉƒAƒCƒRƒ“‚ğ•\¦‚·‚é */
+			sWindow.m_bMenuIcon = TRUE;		/* ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«ã‚¢ã‚¤ã‚³ãƒ³ã‚’è¡¨ç¤ºã™ã‚‹ */
 
-			//	Apr. 05, 2003 genta ƒEƒBƒ“ƒhƒEƒLƒƒƒvƒVƒ‡ƒ“‚Ì‰Šú’l
-			//	Aug. 16, 2003 genta $N(ƒtƒ@ƒCƒ‹–¼È—ª•\¦)‚ğƒfƒtƒHƒ‹ƒg‚É•ÏX
+			//	Apr. 05, 2003 genta ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³ã®åˆæœŸå€¤
+			//	Aug. 16, 2003 genta $N(ãƒ•ã‚¡ã‚¤ãƒ«åçœç•¥è¡¨ç¤º)ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã«å¤‰æ›´
 			_tcscpy( sWindow.m_szWindowCaptionActive, 
-				_T("${w?$h$:ƒAƒEƒgƒvƒbƒg$:${I?$f$n$:$N$n$}$}${U?(XV)$} -")
-				_T(" $A $V ${R?(ƒrƒ…[ƒ‚[ƒh)$:(ã‘‚«‹Ö~)$}${M?  yƒL[ƒ}ƒNƒ‚Ì‹L˜^’†z$} $<profile>") );
+				_T("${w?$h$:ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆ$:${I?$f$n$:$N$n$}$}${U?(æ›´æ–°)$} -")
+				_T(" $A $V ${R?(ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰)$:(ä¸Šæ›¸ãç¦æ­¢)$}${M?  ã€ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ã€‘$} $<profile>") );
 			_tcscpy( sWindow.m_szWindowCaptionInactive, 
-				_T("${w?$h$:ƒAƒEƒgƒvƒbƒg$:$f$n$}${U?(XV)$} -")
-				_T(" $A $V ${R?(ƒrƒ…[ƒ‚[ƒh)$:(ã‘‚«‹Ö~)$}${M?  yƒL[ƒ}ƒNƒ‚Ì‹L˜^’†z$} $<profile>") );
+				_T("${w?$h$:ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆ$:$f$n$}${U?(æ›´æ–°)$} -")
+				_T(" $A $V ${R?(ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰)$:(ä¸Šæ›¸ãç¦æ­¢)$}${M?  ã€ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ã€‘$} $<profile>") );
 		}
 
-		// [ƒ^ƒuƒo[]ƒ^ƒu
+		// [ã‚¿ãƒ–ãƒãƒ¼]ã‚¿ãƒ–
 		{
 			CommonSetting_TabBar& sTabBar = m_pShareData->m_Common.m_sTabBar;
 
-			sTabBar.m_bDispTabWnd = FALSE;			//ƒ^ƒuƒEƒCƒ“ƒhƒE•\¦	//@@@ 2003.05.31 MIK
-			sTabBar.m_bDispTabWndMultiWin = FALSE;	//ƒ^ƒuƒEƒCƒ“ƒhƒE•\¦	//@@@ 2003.05.31 MIK
+			sTabBar.m_bDispTabWnd = FALSE;			//ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦è¡¨ç¤º	//@@@ 2003.05.31 MIK
+			sTabBar.m_bDispTabWndMultiWin = FALSE;	//ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦è¡¨ç¤º	//@@@ 2003.05.31 MIK
 			wcscpy(	//@@@ 2003.06.13 MIK
 				sTabBar.m_szTabWndCaption,
-				L"${w?yGrepz$h$:yƒAƒEƒgƒvƒbƒgz$:$f$n$}${U?(XV)$}${R?(ƒrƒ…[ƒ‚[ƒh)$:(ã‘‚«‹Ö~)$}${M?yƒL[ƒ}ƒNƒ‚Ì‹L˜^’†z$}"
+				L"${w?ã€Grepã€‘$h$:ã€ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã€‘$:$f$n$}${U?(æ›´æ–°)$}${R?(ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰)$:(ä¸Šæ›¸ãç¦æ­¢)$}${M?ã€ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ã€‘$}"
 			);
-			sTabBar.m_bSameTabWidth = FALSE;			//ƒ^ƒu‚ğ“™•‚É‚·‚é			//@@@ 2006.01.28 ryoji
-			sTabBar.m_bDispTabIcon = FALSE;			//ƒ^ƒu‚ÉƒAƒCƒRƒ“‚ğ•\¦‚·‚é	//@@@ 2006.01.28 ryoji
-			sTabBar.m_bDispTabClose = DISPTABCLOSE_NO;	//ƒ^ƒu‚É•Â‚¶‚éƒ{ƒ^ƒ“‚ğ•\¦‚·‚é	//@@@ 2012.04.14 syat
-			sTabBar.m_bSortTabList = TRUE;			//ƒ^ƒuˆê——‚ğƒ\[ƒg‚·‚é		//@@@ 2006.05.10 ryoji
-			sTabBar.m_bTab_RetainEmptyWin = TRUE;	// ÅŒã‚Ìƒtƒ@ƒCƒ‹‚ª•Â‚¶‚ç‚ê‚½‚Æ‚«(–³‘è)‚ğc‚·	// 2007.02.11 genta
-			sTabBar.m_bTab_CloseOneWin = FALSE;	// ƒ^ƒuƒ‚[ƒh‚Å‚àƒEƒBƒ“ƒhƒE‚Ì•Â‚¶‚éƒ{ƒ^ƒ“‚ÅŒ»İ‚Ìƒtƒ@ƒCƒ‹‚Ì‚İ•Â‚¶‚é	// 2007.02.11 genta
-			sTabBar.m_bTab_ListFull = FALSE;			//ƒ^ƒuˆê——‚ğƒtƒ‹ƒpƒX•\¦‚·‚é	//@@@ 2007.02.28 ryoji
-			sTabBar.m_bChgWndByWheel = FALSE;		//ƒ}ƒEƒXƒzƒC[ƒ‹‚ÅƒEƒBƒ“ƒhƒEØ‘Ö	//@@@ 2006.03.26 ryoji
-			sTabBar.m_bNewWindow = FALSE;			// ŠO•”‚©‚ç‹N“®‚·‚é‚Æ‚«‚ÍV‚µ‚¢ƒEƒCƒ“ƒhƒE‚ÅŠJ‚­
-			sTabBar.m_bTabMultiLine = false;		// ƒ^ƒu‘½’i
-			sTabBar.m_eTabPosition = TabPosition_Top;		//ƒ^ƒuˆÊ’u
+			sTabBar.m_bSameTabWidth = FALSE;			//ã‚¿ãƒ–ã‚’ç­‰å¹…ã«ã™ã‚‹			//@@@ 2006.01.28 ryoji
+			sTabBar.m_bDispTabIcon = FALSE;			//ã‚¿ãƒ–ã«ã‚¢ã‚¤ã‚³ãƒ³ã‚’è¡¨ç¤ºã™ã‚‹	//@@@ 2006.01.28 ryoji
+			sTabBar.m_bDispTabClose = DISPTABCLOSE_NO;	//ã‚¿ãƒ–ã«é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³ã‚’è¡¨ç¤ºã™ã‚‹	//@@@ 2012.04.14 syat
+			sTabBar.m_bSortTabList = TRUE;			//ã‚¿ãƒ–ä¸€è¦§ã‚’ã‚½ãƒ¼ãƒˆã™ã‚‹		//@@@ 2006.05.10 ryoji
+			sTabBar.m_bTab_RetainEmptyWin = TRUE;	// æœ€å¾Œã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‰ã˜ã‚‰ã‚ŒãŸã¨ã(ç„¡é¡Œ)ã‚’æ®‹ã™	// 2007.02.11 genta
+			sTabBar.m_bTab_CloseOneWin = FALSE;	// ã‚¿ãƒ–ãƒ¢ãƒ¼ãƒ‰ã§ã‚‚ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³ã§ç¾åœ¨ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ã¿é–‰ã˜ã‚‹	// 2007.02.11 genta
+			sTabBar.m_bTab_ListFull = FALSE;			//ã‚¿ãƒ–ä¸€è¦§ã‚’ãƒ•ãƒ«ãƒ‘ã‚¹è¡¨ç¤ºã™ã‚‹	//@@@ 2007.02.28 ryoji
+			sTabBar.m_bChgWndByWheel = FALSE;		//ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã§ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ‡æ›¿	//@@@ 2006.03.26 ryoji
+			sTabBar.m_bNewWindow = FALSE;			// å¤–éƒ¨ã‹ã‚‰èµ·å‹•ã™ã‚‹ã¨ãã¯æ–°ã—ã„ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã§é–‹ã
+			sTabBar.m_bTabMultiLine = false;		// ã‚¿ãƒ–å¤šæ®µ
+			sTabBar.m_eTabPosition = TabPosition_Top;		//ã‚¿ãƒ–ä½ç½®
 
 			sTabBar.m_lf = lfIconTitle;
 			sTabBar.m_nPointSize = nIconPointSize;
@@ -330,145 +330,145 @@ bool CShareData::InitShareData()
 			sTabBar.m_nTabMinWidthOnMulti = 100;
 		}
 
-		// [•ÒW]ƒ^ƒu
+		// [ç·¨é›†]ã‚¿ãƒ–
 		{
 			CommonSetting_Edit& sEdit = m_pShareData->m_Common.m_sEdit;
 
-			sEdit.m_bAddCRLFWhenCopy = false;			/* Ü‚è•Ô‚µs‚É‰üs‚ğ•t‚¯‚ÄƒRƒs[ */
+			sEdit.m_bAddCRLFWhenCopy = false;			/* æŠ˜ã‚Šè¿”ã—è¡Œã«æ”¹è¡Œã‚’ä»˜ã‘ã¦ã‚³ãƒ”ãƒ¼ */
 
-			sEdit.m_bUseOLE_DragDrop = TRUE;			/* OLE‚É‚æ‚éƒhƒ‰ƒbƒO & ƒhƒƒbƒv‚ğg‚¤ */
-			sEdit.m_bUseOLE_DropSource = TRUE;			/* OLE‚É‚æ‚éƒhƒ‰ƒbƒOŒ³‚É‚·‚é‚© */
-			sEdit.m_bSelectClickedURL = TRUE;			/* URL‚ªƒNƒŠƒbƒN‚³‚ê‚½‚ç‘I‘ğ‚·‚é‚© */
-			sEdit.m_bCopyAndDisablSelection = FALSE;	/* ƒRƒs[‚µ‚½‚ç‘I‘ğ‰ğœ */
-			sEdit.m_bEnableNoSelectCopy = TRUE;		/* ‘I‘ğ‚È‚µ‚ÅƒRƒs[‚ğ‰Â”\‚É‚·‚é */	// 2007.11.18 ryoji
-			sEdit.m_bEnableLineModePaste = true;		/* ƒ‰ƒCƒ“ƒ‚[ƒh“\‚è•t‚¯‚ğ‰Â”\‚É‚·‚é */	// 2007.10.08 ryoji
-			sEdit.m_bConvertEOLPaste = false;			/* ‰üsƒR[ƒh‚ğ•ÏŠ·‚µ‚Ä“\‚è•t‚¯‚é */	// 2009.02.28 salarm
+			sEdit.m_bUseOLE_DragDrop = TRUE;			/* OLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚° & ãƒ‰ãƒ­ãƒƒãƒ—ã‚’ä½¿ã† */
+			sEdit.m_bUseOLE_DropSource = TRUE;			/* OLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚°å…ƒã«ã™ã‚‹ã‹ */
+			sEdit.m_bSelectClickedURL = TRUE;			/* URLãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸã‚‰é¸æŠã™ã‚‹ã‹ */
+			sEdit.m_bCopyAndDisablSelection = FALSE;	/* ã‚³ãƒ”ãƒ¼ã—ãŸã‚‰é¸æŠè§£é™¤ */
+			sEdit.m_bEnableNoSelectCopy = TRUE;		/* é¸æŠãªã—ã§ã‚³ãƒ”ãƒ¼ã‚’å¯èƒ½ã«ã™ã‚‹ */	// 2007.11.18 ryoji
+			sEdit.m_bEnableLineModePaste = true;		/* ãƒ©ã‚¤ãƒ³ãƒ¢ãƒ¼ãƒ‰è²¼ã‚Šä»˜ã‘ã‚’å¯èƒ½ã«ã™ã‚‹ */	// 2007.10.08 ryoji
+			sEdit.m_bConvertEOLPaste = false;			/* æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’å¤‰æ›ã—ã¦è²¼ã‚Šä»˜ã‘ã‚‹ */	// 2009.02.28 salarm
 			sEdit.m_bEnableExtEol = false;
 			sEdit.m_bBoxSelectLock = true;
 
-			sEdit.m_bNotOverWriteCRLF = TRUE;			/* ‰üs‚Íã‘‚«‚µ‚È‚¢ */
-			sEdit.m_bOverWriteFixMode = false;			// •¶š•‚É‡‚í‚¹‚ÄƒXƒy[ƒX‚ğ‹l‚ß‚é
+			sEdit.m_bNotOverWriteCRLF = TRUE;			/* æ”¹è¡Œã¯ä¸Šæ›¸ãã—ãªã„ */
+			sEdit.m_bOverWriteFixMode = false;			// æ–‡å­—å¹…ã«åˆã‚ã›ã¦ã‚¹ãƒšãƒ¼ã‚¹ã‚’è©°ã‚ã‚‹
 
 			sEdit.m_bOverWriteBoxDelete = false;
 			sEdit.m_eOpenDialogDir = OPENDIALOGDIR_CUR;
 			auto_strcpy(sEdit.m_OpenDialogSelDir, _T("%Personal%\\"));
-			sEdit.m_bAutoColumnPaste = TRUE;			/* ‹éŒ`ƒRƒs[‚ÌƒeƒLƒXƒg‚Íí‚É‹éŒ`“\‚è•t‚¯ */
+			sEdit.m_bAutoColumnPaste = TRUE;			/* çŸ©å½¢ã‚³ãƒ”ãƒ¼ã®ãƒ†ã‚­ã‚¹ãƒˆã¯å¸¸ã«çŸ©å½¢è²¼ã‚Šä»˜ã‘ */
 		}
 
-		// [ƒtƒ@ƒCƒ‹]ƒ^ƒu
+		// [ãƒ•ã‚¡ã‚¤ãƒ«]ã‚¿ãƒ–
 		{
 			CommonSetting_File& sFile = m_pShareData->m_Common.m_sFile;
 
-			//ƒtƒ@ƒCƒ‹‚Ì”r‘¼§Œä
-			sFile.m_nFileShareMode = SHAREMODE_NOT_EXCLUSIVE;	// ƒtƒ@ƒCƒ‹‚Ì”r‘¼§Œäƒ‚[ƒh
-			sFile.m_bCheckFileTimeStamp = true;			// XV‚ÌŠÄ‹
-			sFile.m_nAutoloadDelay = 0;					// ©“®“Ç’x‰„
-			sFile.m_bUneditableIfUnwritable = true;		// ã‘‚«‹Ö~ŒŸo‚Í•ÒW‹Ö~‚É‚·‚é
+			//ãƒ•ã‚¡ã‚¤ãƒ«ã®æ’ä»–åˆ¶å¾¡
+			sFile.m_nFileShareMode = SHAREMODE_NOT_EXCLUSIVE;	// ãƒ•ã‚¡ã‚¤ãƒ«ã®æ’ä»–åˆ¶å¾¡ãƒ¢ãƒ¼ãƒ‰
+			sFile.m_bCheckFileTimeStamp = true;			// æ›´æ–°ã®ç›£è¦–
+			sFile.m_nAutoloadDelay = 0;					// è‡ªå‹•èª­è¾¼æ™‚é…å»¶
+			sFile.m_bUneditableIfUnwritable = true;		// ä¸Šæ›¸ãç¦æ­¢æ¤œå‡ºæ™‚ã¯ç·¨é›†ç¦æ­¢ã«ã™ã‚‹
 
-			//ƒtƒ@ƒCƒ‹‚Ì•Û‘¶
-			sFile.m_bEnableUnmodifiedOverwrite = false;	// –³•ÏX‚Å‚àã‘‚«‚·‚é‚©
+			//ãƒ•ã‚¡ã‚¤ãƒ«ã®ä¿å­˜
+			sFile.m_bEnableUnmodifiedOverwrite = false;	// ç„¡å¤‰æ›´ã§ã‚‚ä¸Šæ›¸ãã™ã‚‹ã‹
 
-			// u–¼‘O‚ğ•t‚¯‚Ä•Û‘¶v‚Åƒtƒ@ƒCƒ‹‚Ìí—Ş‚ª[ƒ†[ƒUw’è]‚Ì‚Æ‚«‚Ìƒtƒ@ƒCƒ‹ˆê——•\¦	//ƒtƒ@ƒCƒ‹•Û‘¶ƒ_ƒCƒAƒƒO‚ÌƒtƒBƒ‹ƒ^İ’è	// 2006.11.16 ryoji
-			sFile.m_bNoFilterSaveNew = true;		// V‹K‚©‚ç•Û‘¶‚Í‘Sƒtƒ@ƒCƒ‹•\¦
-			sFile.m_bNoFilterSaveFile = true;		// V‹KˆÈŠO‚©‚ç•Û‘¶‚Í‘Sƒtƒ@ƒCƒ‹•\¦
+			// ã€Œåå‰ã‚’ä»˜ã‘ã¦ä¿å­˜ã€ã§ãƒ•ã‚¡ã‚¤ãƒ«ã®ç¨®é¡ãŒ[ãƒ¦ãƒ¼ã‚¶æŒ‡å®š]ã®ã¨ãã®ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§è¡¨ç¤º	//ãƒ•ã‚¡ã‚¤ãƒ«ä¿å­˜ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ•ã‚£ãƒ«ã‚¿è¨­å®š	// 2006.11.16 ryoji
+			sFile.m_bNoFilterSaveNew = true;		// æ–°è¦ã‹ã‚‰ä¿å­˜æ™‚ã¯å…¨ãƒ•ã‚¡ã‚¤ãƒ«è¡¨ç¤º
+			sFile.m_bNoFilterSaveFile = true;		// æ–°è¦ä»¥å¤–ã‹ã‚‰ä¿å­˜æ™‚ã¯å…¨ãƒ•ã‚¡ã‚¤ãƒ«è¡¨ç¤º
 
-			//ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“
-			sFile.m_bDropFileAndClose = false;		// ƒtƒ@ƒCƒ‹‚ğƒhƒƒbƒv‚µ‚½‚Æ‚«‚Í•Â‚¶‚ÄŠJ‚­
-			sFile.m_nDropFileNumMax = 8;			// ˆê“x‚Éƒhƒƒbƒv‰Â”\‚Èƒtƒ@ƒCƒ‹”
-			sFile.m_bRestoreCurPosition = true;	// ƒJ[ƒ\ƒ‹ˆÊ’u•œŒ³	//	Oct. 27, 2000 genta
-			sFile.m_bRestoreBookmarks = true;		// ƒuƒbƒNƒ}[ƒN•œŒ³	//2002.01.16 hor
-			sFile.m_bAutoMIMEdecode = false;		// ƒtƒ@ƒCƒ‹“Ç‚İ‚İ‚ÉMIME‚ÌƒfƒR[ƒh‚ğs‚¤‚©	//Jul. 13, 2001 JEPRO
-			sFile.m_bQueryIfCodeChange = true;		// ‘O‰ñ‚ÆˆÙ‚È‚é•¶šƒR[ƒh‚Ì‚É–â‚¢‡‚í‚¹‚ğs‚¤‚©	Oct. 03, 2004 genta
-			sFile.m_bAlertIfFileNotExist = false;	// ŠJ‚±‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹‚ª‘¶İ‚µ‚È‚¢‚Æ‚«Œx‚·‚é	Oct. 09, 2004 genta
-			sFile.m_bAlertIfLargeFile = false;		// ŠJ‚±‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹‚ª‘å‚«‚¢ê‡‚ÉŒx‚·‚é
-			sFile.m_nAlertFileSize = 10;			// Œx‚ğn‚ß‚éƒtƒ@ƒCƒ‹ƒTƒCƒYiMB’PˆÊj
+			//ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³
+			sFile.m_bDropFileAndClose = false;		// ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ãƒ‰ãƒ­ãƒƒãƒ—ã—ãŸã¨ãã¯é–‰ã˜ã¦é–‹ã
+			sFile.m_nDropFileNumMax = 8;			// ä¸€åº¦ã«ãƒ‰ãƒ­ãƒƒãƒ—å¯èƒ½ãªãƒ•ã‚¡ã‚¤ãƒ«æ•°
+			sFile.m_bRestoreCurPosition = true;	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¾©å…ƒ	//	Oct. 27, 2000 genta
+			sFile.m_bRestoreBookmarks = true;		// ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯å¾©å…ƒ	//2002.01.16 hor
+			sFile.m_bAutoMIMEdecode = false;		// ãƒ•ã‚¡ã‚¤ãƒ«èª­ã¿è¾¼ã¿æ™‚ã«MIMEã®ãƒ‡ã‚³ãƒ¼ãƒ‰ã‚’è¡Œã†ã‹	//Jul. 13, 2001 JEPRO
+			sFile.m_bQueryIfCodeChange = true;		// å‰å›ã¨ç•°ãªã‚‹æ–‡å­—ã‚³ãƒ¼ãƒ‰ã®æ™‚ã«å•ã„åˆã‚ã›ã‚’è¡Œã†ã‹	Oct. 03, 2004 genta
+			sFile.m_bAlertIfFileNotExist = false;	// é–‹ã“ã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ãªã„ã¨ãè­¦å‘Šã™ã‚‹	Oct. 09, 2004 genta
+			sFile.m_bAlertIfLargeFile = false;		// é–‹ã“ã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ãŒå¤§ãã„å ´åˆã«è­¦å‘Šã™ã‚‹
+			sFile.m_nAlertFileSize = 10;			// è­¦å‘Šã‚’å§‹ã‚ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ã‚µã‚¤ã‚ºï¼ˆMBå˜ä½ï¼‰
 		}
 
-		// [ƒoƒbƒNƒAƒbƒv]ƒ^ƒu
+		// [ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—]ã‚¿ãƒ–
 		{
 			CommonSetting_Backup& sBackup = m_pShareData->m_Common.m_sBackup;
 
-			sBackup.m_bBackUp = false;										/* ƒoƒbƒNƒAƒbƒv‚Ìì¬ */
-			sBackup.m_bBackUpDialog = true;									/* ƒoƒbƒNƒAƒbƒv‚Ìì¬‘O‚ÉŠm”F */
-			sBackup.m_bBackUpFolder = false;								/* w’èƒtƒHƒ‹ƒ_‚ÉƒoƒbƒNƒAƒbƒv‚ğì¬‚·‚é */
-			sBackup.m_szBackUpFolder[0] = L'\0';							/* ƒoƒbƒNƒAƒbƒv‚ğì¬‚·‚éƒtƒHƒ‹ƒ_ */
-			sBackup.m_nBackUpType = 2;										/* ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼‚Ìƒ^ƒCƒv 1=(.bak) 2=*_“ú•t.* */
-			sBackup.m_nBackUpType_Opt1 = BKUP_YEAR | BKUP_MONTH | BKUP_DAY;	/* ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼F“ú•t */
-			sBackup.m_nBackUpType_Opt2 = ('b' << 16 ) + 10;					/* ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼F˜A”Ô‚Ì”‚Ææ“ª•¶š */
-			sBackup.m_nBackUpType_Opt3 = 5;									/* ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FOption3 */
-			sBackup.m_nBackUpType_Opt4 = 0;									/* ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FOption4 */
-			sBackup.m_nBackUpType_Opt5 = 0;									/* ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FOption5 */
-			sBackup.m_nBackUpType_Opt6 = 0;									/* ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FOption6 */
-			sBackup.m_bBackUpDustBox = false;								/* ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹‚ğ‚²‚İ” ‚É•ú‚è‚Ş */	//@@@ 2001.12.11 add MIK
-			sBackup.m_bBackUpPathAdvanced = false;							/* 20051107 aroka ƒoƒbƒNƒAƒbƒvæƒtƒHƒ‹ƒ_‚ğÚ×İ’è‚·‚é */
-			sBackup.m_szBackUpPathAdvanced[0] = _T('\0');					/* 20051107 aroka ƒoƒbƒNƒAƒbƒv‚ğì¬‚·‚éƒtƒHƒ‹ƒ_‚ÌÚ×İ’è */
+			sBackup.m_bBackUp = false;										/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã®ä½œæˆ */
+			sBackup.m_bBackUpDialog = true;									/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã®ä½œæˆå‰ã«ç¢ºèª */
+			sBackup.m_bBackUpFolder = false;								/* æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€ã«ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹ */
+			sBackup.m_szBackUpFolder[0] = L'\0';							/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹ãƒ•ã‚©ãƒ«ãƒ€ */
+			sBackup.m_nBackUpType = 2;										/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åã®ã‚¿ã‚¤ãƒ— 1=(.bak) 2=*_æ—¥ä»˜.* */
+			sBackup.m_nBackUpType_Opt1 = BKUP_YEAR | BKUP_MONTH | BKUP_DAY;	/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šæ—¥ä»˜ */
+			sBackup.m_nBackUpType_Opt2 = ('b' << 16 ) + 10;					/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šé€£ç•ªã®æ•°ã¨å…ˆé ­æ–‡å­— */
+			sBackup.m_nBackUpType_Opt3 = 5;									/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šOption3 */
+			sBackup.m_nBackUpType_Opt4 = 0;									/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šOption4 */
+			sBackup.m_nBackUpType_Opt5 = 0;									/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šOption5 */
+			sBackup.m_nBackUpType_Opt6 = 0;									/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šOption6 */
+			sBackup.m_bBackUpDustBox = false;								/* ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã”ã¿ç®±ã«æ”¾ã‚Šè¾¼ã‚€ */	//@@@ 2001.12.11 add MIK
+			sBackup.m_bBackUpPathAdvanced = false;							/* 20051107 aroka ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—å…ˆãƒ•ã‚©ãƒ«ãƒ€ã‚’è©³ç´°è¨­å®šã™ã‚‹ */
+			sBackup.m_szBackUpPathAdvanced[0] = _T('\0');					/* 20051107 aroka ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹ãƒ•ã‚©ãƒ«ãƒ€ã®è©³ç´°è¨­å®š */
 		}
 
-		// [‘®]ƒ^ƒu
+		// [æ›¸å¼]ã‚¿ãƒ–
 		{
 			CommonSetting_Format& sFormat = m_pShareData->m_Common.m_sFormat;
 
-			/* Œ©o‚µ‹L† */
-			wcscpy( sFormat.m_szMidashiKigou, L"‚P‚Q‚R‚S‚T‚U‚V‚W‚X‚Oi(m[uwy¡ £¢¥¤Ÿ›œ˜E¦™š‘æ‡@‡A‡B‡C‡D‡E‡F‡G‡H‡I‡J‡K‡L‡M‡N‡O‡P‡Q‡R‡S‡T‡U‡V‡W‡X‡Y‡Z‡[‡\‡]ˆê“ñOlŒÜ˜Zµ”ª‹ã\ˆë“óQŒŞ" );
-			/* ˆø—p•„ */
-			wcscpy( sFormat.m_szInyouKigou, L"> " );		/* ˆø—p•„ */
+			/* è¦‹å‡ºã—è¨˜å· */
+			wcscpy( sFormat.m_szMidashiKigou, L"ï¼‘ï¼’ï¼“ï¼”ï¼•ï¼–ï¼—ï¼˜ï¼™ï¼ï¼ˆ(ï¼»[ã€Œã€ã€â– â–¡â–²â–³â–¼â–½â—†â—‡â—‹â—â—Â§ãƒ»â€»â˜†â˜…ç¬¬â‘ â‘¡â‘¢â‘£â‘¤â‘¥â‘¦â‘§â‘¨â‘©â‘ªâ‘«â‘¬â‘­â‘®â‘¯â‘°â‘±â‘²â‘³â… â…¡â…¢â…£â…¤â…¥â…¦â…§â…¨â…©ä¸€äºŒä¸‰å››äº”å…­ä¸ƒå…«ä¹åå£±å¼å‚ä¼" );
+			/* å¼•ç”¨ç¬¦ */
+			wcscpy( sFormat.m_szInyouKigou, L"> " );		/* å¼•ç”¨ç¬¦ */
 
 			/*
-				‘®w’èq‚ÌˆÓ–¡‚ÍWindows SDK‚ÌGetDateFormat(), GetTimeFormat()‚ğQÆ‚Ì‚±‚Æ
+				æ›¸å¼æŒ‡å®šå­ã®æ„å‘³ã¯Windows SDKã®GetDateFormat(), GetTimeFormat()ã‚’å‚ç…§ã®ã“ã¨
 			*/
 
-			sFormat.m_nDateFormatType = 0;	//“ú•t‘®‚Ìƒ^ƒCƒv
-			_tcscpy( sFormat.m_szDateFormat, _T("yyyy\'”N\'M\'Œ\'d\'“ú(\'dddd\')\'") );	//“ú•t‘®
-			sFormat.m_nTimeFormatType = 0;	//‘®‚Ìƒ^ƒCƒv
-			_tcscpy( sFormat.m_szTimeFormat, _T("tthh\'\'mm\'•ª\'ss\'•b\'")  );			//‘®
+			sFormat.m_nDateFormatType = 0;	//æ—¥ä»˜æ›¸å¼ã®ã‚¿ã‚¤ãƒ—
+			_tcscpy( sFormat.m_szDateFormat, _T("yyyy\'å¹´\'M\'æœˆ\'d\'æ—¥(\'dddd\')\'") );	//æ—¥ä»˜æ›¸å¼
+			sFormat.m_nTimeFormatType = 0;	//æ™‚åˆ»æ›¸å¼ã®ã‚¿ã‚¤ãƒ—
+			_tcscpy( sFormat.m_szTimeFormat, _T("tthh\'æ™‚\'mm\'åˆ†\'ss\'ç§’\'")  );			//æ™‚åˆ»æ›¸å¼
 		}
 
-		// [ŒŸõ]ƒ^ƒu
+		// [æ¤œç´¢]ã‚¿ãƒ–
 		{
 			CommonSetting_Search& sSearch = m_pShareData->m_Common.m_sSearch;
 
-			sSearch.m_sSearchOption.Reset();			// ŒŸõƒIƒvƒVƒ‡ƒ“
-			sSearch.m_bConsecutiveAll = 0;			// u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ	// 2007.01.16 ryoji
-			sSearch.m_bSelectedArea = FALSE;			// ‘I‘ğ”ÍˆÍ“à’uŠ·
-			sSearch.m_bNOTIFYNOTFOUND = TRUE;		/* ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦ */
+			sSearch.m_sSearchOption.Reset();			// æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+			sSearch.m_bConsecutiveAll = 0;			// ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã—	// 2007.01.16 ryoji
+			sSearch.m_bSelectedArea = FALSE;			// é¸æŠç¯„å›²å†…ç½®æ›
+			sSearch.m_bNOTIFYNOTFOUND = TRUE;		/* æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º */
 
-			sSearch.m_bGrepSubFolder = TRUE;			/* Grep: ƒTƒuƒtƒHƒ‹ƒ_‚àŒŸõ */
-			sSearch.m_nGrepOutputLineType = 1;			// Grep: s‚ğo—Í/ŠY“–•”•ª/”Ûƒ}ƒbƒ`s ‚ğo—Í
-			sSearch.m_nGrepOutputStyle = 1;			/* Grep: o—ÍŒ`® */
+			sSearch.m_bGrepSubFolder = TRUE;			/* Grep: ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚æ¤œç´¢ */
+			sSearch.m_nGrepOutputLineType = 1;			// Grep: è¡Œã‚’å‡ºåŠ›/è©²å½“éƒ¨åˆ†/å¦ãƒãƒƒãƒè¡Œ ã‚’å‡ºåŠ›
+			sSearch.m_nGrepOutputStyle = 1;			/* Grep: å‡ºåŠ›å½¢å¼ */
 			sSearch.m_bGrepOutputFileOnly = false;
 			sSearch.m_bGrepOutputBaseFolder = false;
 			sSearch.m_bGrepSeparateFolder = false;
 			sSearch.m_bGrepBackup = true;
 
-			sSearch.m_bGrepDefaultFolder=FALSE;		/* Grep: ƒtƒHƒ‹ƒ_‚Ì‰Šú’l‚ğƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_‚É‚·‚é */
-			sSearch.m_nGrepCharSet = CODE_AUTODETECT;	/* Grep: •¶šƒR[ƒhƒZƒbƒg */
-			sSearch.m_bGrepRealTimeView = FALSE;		/* 2003.06.28 Moca GrepŒ‹‰Ê‚ÌƒŠƒAƒ‹ƒ^ƒCƒ€•\¦ */
-			sSearch.m_bCaretTextForSearch = TRUE;		/* 2006.08.23 ryoji ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì•¶š—ñ‚ğƒfƒtƒHƒ‹ƒg‚ÌŒŸõ•¶š—ñ‚É‚·‚é */
+			sSearch.m_bGrepDefaultFolder=FALSE;		/* Grep: ãƒ•ã‚©ãƒ«ãƒ€ã®åˆæœŸå€¤ã‚’ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€ã«ã™ã‚‹ */
+			sSearch.m_nGrepCharSet = CODE_AUTODETECT;	/* Grep: æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
+			sSearch.m_bGrepRealTimeView = FALSE;		/* 2003.06.28 Moca Grepçµæœã®ãƒªã‚¢ãƒ«ã‚¿ã‚¤ãƒ è¡¨ç¤º */
+			sSearch.m_bCaretTextForSearch = TRUE;		/* 2006.08.23 ryoji ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ–‡å­—åˆ—ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®æ¤œç´¢æ–‡å­—åˆ—ã«ã™ã‚‹ */
 			sSearch.m_bInheritKeyOtherView = true;
-			sSearch.m_szRegexpLib[0] = _T('\0');		/* 2007.08.12 genta ³‹K•\Œ»DLL */
-			sSearch.m_bGTJW_RETURN = TRUE;				/* ƒGƒ“ƒ^[ƒL[‚Åƒ^ƒOƒWƒƒƒ“ƒv */
-			sSearch.m_bGTJW_LDBLCLK = TRUE;			/* ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Åƒ^ƒOƒWƒƒƒ“ƒv */
+			sSearch.m_szRegexpLib[0] = _T('\0');		/* 2007.08.12 genta æ­£è¦è¡¨ç¾DLL */
+			sSearch.m_bGTJW_RETURN = TRUE;				/* ã‚¨ãƒ³ã‚¿ãƒ¼ã‚­ãƒ¼ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ— */
+			sSearch.m_bGTJW_LDBLCLK = TRUE;			/* ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ— */
 
-			sSearch.m_bGrepExitConfirm = FALSE;			/* Grepƒ‚[ƒh‚Å•Û‘¶Šm”F‚·‚é‚© */
+			sSearch.m_bGrepExitConfirm = FALSE;			/* Grepãƒ¢ãƒ¼ãƒ‰ã§ä¿å­˜ç¢ºèªã™ã‚‹ã‹ */
 
-			sSearch.m_bAutoCloseDlgFind = TRUE;			/* ŒŸõƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é */
-			sSearch.m_bSearchAll		 = FALSE;			/* ŒŸõ^’uŠ·^ƒuƒbƒNƒ}[ƒN  æ“ªi––”öj‚©‚çÄŒŸõ 2002.01.26 hor */
-			sSearch.m_bAutoCloseDlgReplace = TRUE;		/* ’uŠ· ƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é */
+			sSearch.m_bAutoCloseDlgFind = TRUE;			/* æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
+			sSearch.m_bSearchAll		 = FALSE;			/* æ¤œç´¢ï¼ç½®æ›ï¼ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯  å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ 2002.01.26 hor */
+			sSearch.m_bAutoCloseDlgReplace = TRUE;		/* ç½®æ› ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
 
-			sSearch.m_nTagJumpMode = 1;				//ƒ^ƒOƒWƒƒƒ“ƒvƒ‚[ƒh
-			sSearch.m_nTagJumpModeKeyword = 3;			//ƒ^ƒOƒWƒƒƒ“ƒvƒ‚[ƒh
+			sSearch.m_nTagJumpMode = 1;				//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒ¢ãƒ¼ãƒ‰
+			sSearch.m_nTagJumpModeKeyword = 3;			//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒ¢ãƒ¼ãƒ‰
 		}
 
-		// [ƒL[Š„‚è“–‚Ä]ƒ^ƒu
+		// [ã‚­ãƒ¼å‰²ã‚Šå½“ã¦]ã‚¿ãƒ–
 		{
-			//	Jan. 30, 2005 genta ŠÖ”‚Æ‚µ‚Ä“Æ—§
-			//	2007.11.04 genta –ß‚è’lƒ`ƒFƒbƒNDfalse‚È‚ç‹N“®’†’fD
+			//	Jan. 30, 2005 genta é–¢æ•°ã¨ã—ã¦ç‹¬ç«‹
+			//	2007.11.04 genta æˆ»ã‚Šå€¤ãƒã‚§ãƒƒã‚¯ï¼falseãªã‚‰èµ·å‹•ä¸­æ–­ï¼
 			if( ! InitKeyAssign( m_pShareData )){
 				return false;
 			}
 		}
 
-		// [ƒJƒXƒ^ƒ€ƒƒjƒ…[]ƒ^ƒu
+		// [ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼]ã‚¿ãƒ–
 		{
 			CommonSetting_CustomMenu& sCustomMenu = m_pShareData->m_Common.m_sCustomMenu;
 
@@ -486,84 +486,84 @@ bool CShareData::InitShareData()
 			InitPopupMenu( m_pShareData );
 		}
 
-		// [ƒc[ƒ‹ƒo[]ƒ^ƒu
+		// [ãƒ„ãƒ¼ãƒ«ãƒãƒ¼]ã‚¿ãƒ–
 		{
-			//	Jan. 30, 2005 genta ŠÖ”‚Æ‚µ‚Ä“Æ—§
+			//	Jan. 30, 2005 genta é–¢æ•°ã¨ã—ã¦ç‹¬ç«‹
 			InitToolButtons( m_pShareData );
 		}
 
-		// [‹­’²ƒL[ƒ[ƒh]ƒ^ƒu
+		// [å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰]ã‚¿ãƒ–
 		{
 			InitKeyword( m_pShareData );
 		}
 
-		// [x‰‡]ƒ^ƒu
+		// [æ”¯æ´]ã‚¿ãƒ–
 		{
 			CommonSetting_Helper& sHelper = m_pShareData->m_Common.m_sHelper;
 
 			sHelper.m_lf = lfIconTitle;
-			sHelper.m_nPointSize = nIconPointSize;	// ƒtƒHƒ“ƒgƒTƒCƒYi1/10ƒ|ƒCƒ“ƒg’PˆÊj ¦ŒÃ‚¢ƒo[ƒWƒ‡ƒ“‚©‚ç‚ÌˆÚs‚ğl—¶‚µ‚Ä–³Œø’l‚Å‰Šú‰»	// 2009.10.01 ryoji
+			sHelper.m_nPointSize = nIconPointSize;	// ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºï¼ˆ1/10ãƒã‚¤ãƒ³ãƒˆå˜ä½ï¼‰ â€»å¤ã„ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã‹ã‚‰ã®ç§»è¡Œã‚’è€ƒæ…®ã—ã¦ç„¡åŠ¹å€¤ã§åˆæœŸåŒ–	// 2009.10.01 ryoji
 
-			sHelper.m_szExtHelp[0] = L'\0';			// ŠO•”ƒwƒ‹ƒv‚P
-			sHelper.m_szExtHtmlHelp[0] = L'\0';		// ŠO•”HTMLƒwƒ‹ƒv
+			sHelper.m_szExtHelp[0] = L'\0';			// å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘
+			sHelper.m_szExtHtmlHelp[0] = L'\0';		// å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—
 		
 			sHelper.m_szMigemoDll[0] = L'\0';			/* migemo dll */
 			sHelper.m_szMigemoDict[0] = L'\0';		/* migemo dict */
 
-			sHelper.m_bHtmlHelpIsSingle = true;		/* HtmlHelpƒrƒ…[ƒA‚Í‚Ğ‚Æ‚Â */
+			sHelper.m_bHtmlHelpIsSingle = true;		/* HtmlHelpãƒ“ãƒ¥ãƒ¼ã‚¢ã¯ã²ã¨ã¤ */
 
-			sHelper.m_bHokanKey_RETURN	= TRUE;			/* VK_RETURN •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø */
-			sHelper.m_bHokanKey_TAB		= FALSE;		/* VK_TAB   •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø */
-			sHelper.m_bHokanKey_RIGHT	= TRUE;			/* VK_RIGHT •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø */
-			sHelper.m_bHokanKey_SPACE	= FALSE;		/* VK_SPACE •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø */
+			sHelper.m_bHokanKey_RETURN	= TRUE;			/* VK_RETURN è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹ */
+			sHelper.m_bHokanKey_TAB		= FALSE;		/* VK_TAB   è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹ */
+			sHelper.m_bHokanKey_RIGHT	= TRUE;			/* VK_RIGHT è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹ */
+			sHelper.m_bHokanKey_SPACE	= FALSE;		/* VK_SPACE è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹ */
 		}
 
-		// [ƒAƒEƒgƒ‰ƒCƒ“]ƒ^ƒu
+		// [ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³]ã‚¿ãƒ–
 		{
 			CommonSetting_OutLine& sOutline = m_pShareData->m_Common.m_sOutline;
 
-			sOutline.m_nOutlineDockSet = 0;					/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ‚ÌƒhƒbƒLƒ“ƒOˆÊ’uŒp³•û–@ */
-			sOutline.m_bOutlineDockSync = TRUE;				/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ‚ÌƒhƒbƒLƒ“ƒOˆÊ’u‚ğ“¯Šú‚·‚é */
-			sOutline.m_bOutlineDockDisp = FALSE;				/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•\¦‚Ì—L–³ */
-			sOutline.m_eOutlineDockSide = DOCKSIDE_FLOAT;		/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒhƒbƒLƒ“ƒO”z’u */
-			sOutline.m_cxOutlineDockLeft		=	0;	// ƒAƒEƒgƒ‰ƒCƒ“‚Ì¶ƒhƒbƒLƒ“ƒO•
-			sOutline.m_cyOutlineDockTop		=	0;	// ƒAƒEƒgƒ‰ƒCƒ“‚ÌãƒhƒbƒLƒ“ƒO‚
-			sOutline.m_cxOutlineDockRight		=	0;	// ƒAƒEƒgƒ‰ƒCƒ“‚Ì‰EƒhƒbƒLƒ“ƒO•
-			sOutline.m_cyOutlineDockBottom		=	0;	// ƒAƒEƒgƒ‰ƒCƒ“‚Ì‰ºƒhƒbƒLƒ“ƒO‚
+			sOutline.m_nOutlineDockSet = 0;					/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã®ãƒ‰ãƒƒã‚­ãƒ³ã‚°ä½ç½®ç¶™æ‰¿æ–¹æ³• */
+			sOutline.m_bOutlineDockSync = TRUE;				/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã®ãƒ‰ãƒƒã‚­ãƒ³ã‚°ä½ç½®ã‚’åŒæœŸã™ã‚‹ */
+			sOutline.m_bOutlineDockDisp = FALSE;				/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æè¡¨ç¤ºã®æœ‰ç„¡ */
+			sOutline.m_eOutlineDockSide = DOCKSIDE_FLOAT;		/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æãƒ‰ãƒƒã‚­ãƒ³ã‚°é…ç½® */
+			sOutline.m_cxOutlineDockLeft		=	0;	// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®å·¦ãƒ‰ãƒƒã‚­ãƒ³ã‚°å¹…
+			sOutline.m_cyOutlineDockTop		=	0;	// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®ä¸Šãƒ‰ãƒƒã‚­ãƒ³ã‚°é«˜
+			sOutline.m_cxOutlineDockRight		=	0;	// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®å³ãƒ‰ãƒƒã‚­ãƒ³ã‚°å¹…
+			sOutline.m_cyOutlineDockBottom		=	0;	// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®ä¸‹ãƒ‰ãƒƒã‚­ãƒ³ã‚°é«˜
 			sOutline.m_nDockOutline = OUTLINE_TEXT;
-			sOutline.m_bAutoCloseDlgFuncList = FALSE;		/* ƒAƒEƒgƒ‰ƒCƒ“ ƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é */	//Nov. 18, 2000 JEPRO TRUE¨FALSE ‚É•ÏX
-			sOutline.m_bMarkUpBlankLineEnable	=	FALSE;	//ƒAƒEƒgƒ‰ƒCƒ“ƒ_ƒCƒAƒƒO‚ÅƒuƒbƒNƒ}[ƒN‚Ì‹ós‚ğ–³‹			2002.02.08 aroka,hor
-			sOutline.m_bFunclistSetFocusOnJump	=	FALSE;	//ƒAƒEƒgƒ‰ƒCƒ“ƒ_ƒCƒAƒƒO‚ÅƒWƒƒƒ“ƒv‚µ‚½‚çƒtƒH[ƒJƒX‚ğˆÚ‚·	2002.02.08 hor
+			sOutline.m_bAutoCloseDlgFuncList = FALSE;		/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */	//Nov. 18, 2000 JEPRO TRUEâ†’FALSE ã«å¤‰æ›´
+			sOutline.m_bMarkUpBlankLineEnable	=	FALSE;	//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã§ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã®ç©ºè¡Œã‚’ç„¡è¦–			2002.02.08 aroka,hor
+			sOutline.m_bFunclistSetFocusOnJump	=	FALSE;	//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã§ã‚¸ãƒ£ãƒ³ãƒ—ã—ãŸã‚‰ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã‚’ç§»ã™	2002.02.08 hor
 
 			InitFileTree( &sOutline.m_sFileTree );
 			sOutline.m_sFileTreeDefIniName = _T("_sakurafiletree.ini");
 		}
 
-		// [ƒtƒ@ƒCƒ‹“à—e”äŠr]ƒ^ƒu
+		// [ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒ]ã‚¿ãƒ–
 		{
 			CommonSetting_Compare& sCompare = m_pShareData->m_Common.m_sCompare;
 
-			sCompare.m_bCompareAndTileHorz = TRUE;		/* •¶‘”äŠrŒãA¶‰E‚É•À‚×‚Ä•\¦ */
+			sCompare.m_bCompareAndTileHorz = TRUE;		/* æ–‡æ›¸æ¯”è¼ƒå¾Œã€å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º */
 		}
 
-		// [ƒrƒ…[]ƒ^ƒu
+		// [ãƒ“ãƒ¥ãƒ¼]ã‚¿ãƒ–
 		{
 			CommonSetting_View& sView = m_pShareData->m_Common.m_sView;
 
 			sView.m_lf = lf;
-			sView.m_nPointSize = 0;	// ƒtƒHƒ“ƒgƒTƒCƒYi1/10ƒ|ƒCƒ“ƒg’PˆÊj ¦ŒÃ‚¢ƒo[ƒWƒ‡ƒ“‚©‚ç‚ÌˆÚs‚ğl—¶‚µ‚Ä–³Œø’l‚Å‰Šú‰»	// 2009.10.01 ryoji
+			sView.m_nPointSize = 0;	// ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºï¼ˆ1/10ãƒã‚¤ãƒ³ãƒˆå˜ä½ï¼‰ â€»å¤ã„ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã‹ã‚‰ã®ç§»è¡Œã‚’è€ƒæ…®ã—ã¦ç„¡åŠ¹å€¤ã§åˆæœŸåŒ–	// 2009.10.01 ryoji
 
-			sView.m_bFontIs_FIXED_PITCH = TRUE;				/* Œ»İ‚ÌƒtƒHƒ“ƒg‚ÍŒÅ’è•ƒtƒHƒ“ƒg‚Å‚ ‚é */
+			sView.m_bFontIs_FIXED_PITCH = TRUE;				/* ç¾åœ¨ã®ãƒ•ã‚©ãƒ³ãƒˆã¯å›ºå®šå¹…ãƒ•ã‚©ãƒ³ãƒˆã§ã‚ã‚‹ */
 		}
 
-		// [ƒ}ƒNƒ]ƒ^ƒu
+		// [ãƒã‚¯ãƒ­]ã‚¿ãƒ–
 		{
 			CommonSetting_Macro& sMacro = m_pShareData->m_Common.m_sMacro;
 
-			sMacro.m_szKeyMacroFileName[0] = _T('\0');	/* ƒL[ƒ[ƒhƒ}ƒNƒ‚Ìƒtƒ@ƒCƒ‹–¼ */ //@@@ 2002.1.24 YAZAKI
+			sMacro.m_szKeyMacroFileName[0] = _T('\0');	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®ãƒ•ã‚¡ã‚¤ãƒ«å */ //@@@ 2002.1.24 YAZAKI
 
 			//	From Here Sep. 14, 2001 genta
-			//	Macro“o˜^‚Ì‰Šú‰»
+			//	Macroç™»éŒ²ã®åˆæœŸåŒ–
 			MacroRec *mptr = sMacro.m_MacroTable;
 			for( int i = 0; i < MAX_CUSTMACRO; ++i, ++mptr ){
 				mptr->m_szName[0] = L'\0';
@@ -572,47 +572,47 @@ bool CShareData::InitShareData()
 			}
 			//	To Here Sep. 14, 2001 genta
 
-			_tcscpy( sMacro.m_szMACROFOLDER, szIniFolder );	/* ƒ}ƒNƒ—pƒtƒHƒ‹ƒ_ */
+			_tcscpy( sMacro.m_szMACROFOLDER, szIniFolder );	/* ãƒã‚¯ãƒ­ç”¨ãƒ•ã‚©ãƒ«ãƒ€ */
 
-			sMacro.m_nMacroOnOpened = -1;	/* ƒI[ƒvƒ“Œã©“®Àsƒ}ƒNƒ”Ô† */	//@@@ 2006.09.01 ryoji
-			sMacro.m_nMacroOnTypeChanged = -1;	/* ƒ^ƒCƒv•ÏXŒã©“®Àsƒ}ƒNƒ”Ô† */	//@@@ 2006.09.01 ryoji
-			sMacro.m_nMacroOnSave = -1;	/* •Û‘¶‘O©“®Àsƒ}ƒNƒ”Ô† */	//@@@ 2006.09.01 ryoji
-			sMacro.m_nMacroCancelTimer = 10;	// ƒ}ƒNƒ’â~ƒ_ƒCƒAƒƒO•\¦‘Ò‚¿ŠÔ(•b)	// 2011.08.04 syat
+			sMacro.m_nMacroOnOpened = -1;	/* ã‚ªãƒ¼ãƒ—ãƒ³å¾Œè‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå· */	//@@@ 2006.09.01 ryoji
+			sMacro.m_nMacroOnTypeChanged = -1;	/* ã‚¿ã‚¤ãƒ—å¤‰æ›´å¾Œè‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå· */	//@@@ 2006.09.01 ryoji
+			sMacro.m_nMacroOnSave = -1;	/* ä¿å­˜å‰è‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå· */	//@@@ 2006.09.01 ryoji
+			sMacro.m_nMacroCancelTimer = 10;	// ãƒã‚¯ãƒ­åœæ­¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°è¡¨ç¤ºå¾…ã¡æ™‚é–“(ç§’)	// 2011.08.04 syat
 		}
 
-		// [ƒtƒ@ƒCƒ‹–¼•\¦]ƒ^ƒu
+		// [ãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤º]ã‚¿ãƒ–
 		{
 			CommonSetting_FileName& sFileName = m_pShareData->m_Common.m_sFileName;
 
 			sFileName.m_bTransformShortPath = true;
-			sFileName.m_nTransformShortMaxWidth = 100; // 100'x'•
+			sFileName.m_nTransformShortMaxWidth = 100; // 100'x'å¹…
 
 			for( int i = 0; i < MAX_TRANSFORM_FILENAME; ++i ){
 				sFileName.m_szTransformFileNameFrom[i][0] = _T('\0');
 				sFileName.m_szTransformFileNameTo[i][0] = _T('\0');
 			}
 			_tcscpy( sFileName.m_szTransformFileNameFrom[0], _T("%DeskTop%\\") );
-			_tcscpy( sFileName.m_szTransformFileNameTo[0],   _T("ƒfƒXƒNƒgƒbƒv\\") );
+			_tcscpy( sFileName.m_szTransformFileNameTo[0],   _T("ãƒ‡ã‚¹ã‚¯ãƒˆãƒƒãƒ—\\") );
 			_tcscpy( sFileName.m_szTransformFileNameFrom[1], _T("%Personal%\\") );
-			_tcscpy( sFileName.m_szTransformFileNameTo[1],   _T("ƒ}ƒCƒhƒLƒ…ƒƒ“ƒg\\") );
+			_tcscpy( sFileName.m_szTransformFileNameTo[1],   _T("ãƒã‚¤ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ\\") );
 			_tcscpy( sFileName.m_szTransformFileNameFrom[2], _T("%Cache%\\Content.IE5\\") );
-			_tcscpy( sFileName.m_szTransformFileNameTo[2],   _T("IEƒLƒƒƒbƒVƒ…\\") );
+			_tcscpy( sFileName.m_szTransformFileNameTo[2],   _T("IEã‚­ãƒ£ãƒƒã‚·ãƒ¥\\") );
 			_tcscpy( sFileName.m_szTransformFileNameFrom[3], _T("%TEMP%\\") );
 			_tcscpy( sFileName.m_szTransformFileNameTo[3],   _T("TEMP\\") );
 			_tcscpy( sFileName.m_szTransformFileNameFrom[4], _T("%Common DeskTop%\\") );
-			_tcscpy( sFileName.m_szTransformFileNameTo[4],   _T("‹¤—LƒfƒXƒNƒgƒbƒv\\") );
+			_tcscpy( sFileName.m_szTransformFileNameTo[4],   _T("å…±æœ‰ãƒ‡ã‚¹ã‚¯ãƒˆãƒƒãƒ—\\") );
 			_tcscpy( sFileName.m_szTransformFileNameFrom[5], _T("%Common Documents%\\") );
-			_tcscpy( sFileName.m_szTransformFileNameTo[5],   _T("‹¤—LƒhƒLƒ…ƒƒ“ƒg\\") );
-			_tcscpy( sFileName.m_szTransformFileNameFrom[6], _T("%AppData%\\") );	// 2007.05.19 ryoji ’Ç‰Á
-			_tcscpy( sFileName.m_szTransformFileNameTo[6],   _T("ƒAƒvƒŠƒf[ƒ^\\") );	// 2007.05.19 ryoji ’Ç‰Á
+			_tcscpy( sFileName.m_szTransformFileNameTo[5],   _T("å…±æœ‰ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ\\") );
+			_tcscpy( sFileName.m_szTransformFileNameFrom[6], _T("%AppData%\\") );	// 2007.05.19 ryoji è¿½åŠ 
+			_tcscpy( sFileName.m_szTransformFileNameTo[6],   _T("ã‚¢ãƒ—ãƒªãƒ‡ãƒ¼ã‚¿\\") );	// 2007.05.19 ryoji è¿½åŠ 
 			sFileName.m_nTransformFileNameArrNum = 7;
 		}
 
-		// [‚»‚Ì‘¼]ƒ^ƒu
+		// [ãã®ä»–]ã‚¿ãƒ–
 		{
 			CommonSetting_Others& sOthers = m_pShareData->m_Common.m_sOthers;
 
-			::SetRect( &sOthers.m_rcOpenDialog, 0, 0, 0, 0 );	/* uŠJ‚­vƒ_ƒCƒAƒƒO‚ÌƒTƒCƒY‚ÆˆÊ’u */
+			::SetRect( &sOthers.m_rcOpenDialog, 0, 0, 0, 0 );	/* ã€Œé–‹ãã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚µã‚¤ã‚ºã¨ä½ç½® */
 			::SetRect( &sOthers.m_rcCompareDialog, 0, 0, 0, 0 );
 			::SetRect( &sOthers.m_rcDiffDialog, 0, 0, 0, 0 );
 			::SetRect( &sOthers.m_rcFavoriteDialog, 0, 0, 0, 0 );
@@ -622,33 +622,33 @@ bool CShareData::InitShareData()
 			sOthers.m_bIniReadOnly = false;
 		}
 
-		// [ƒXƒe[ƒ^ƒXƒo[]ƒ^ƒu
+		// [ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼]ã‚¿ãƒ–
 		{
 			CommonSetting_Statusbar& sStatusbar = m_pShareData->m_Common.m_sStatusbar;
 
-			// •\¦•¶šƒR[ƒh‚Ìw’è		2008/6/21	Uchi
-			sStatusbar.m_bDispUniInSjis		= FALSE;	// SJIS‚Å•¶šƒR[ƒh’l‚ğUnicode‚Å•\¦‚·‚é
-			sStatusbar.m_bDispUniInJis			= FALSE;	// JIS‚Å•¶šƒR[ƒh’l‚ğUnicode‚Å•\¦‚·‚é
-			sStatusbar.m_bDispUniInEuc			= FALSE;	// EUC‚Å•¶šƒR[ƒh’l‚ğUnicode‚Å•\¦‚·‚é
-			sStatusbar.m_bDispUtf8Codepoint	= TRUE;		// UTF-8‚ğƒR[ƒhƒ|ƒCƒ“ƒg‚Å•\¦‚·‚é
-			sStatusbar.m_bDispSPCodepoint		= TRUE;		// ƒTƒƒQ[ƒgƒyƒA‚ğƒR[ƒhƒ|ƒCƒ“ƒg‚Å•\¦‚·‚é
-			sStatusbar.m_bDispSelCountByByte	= FALSE;	// ‘I‘ğ•¶š”‚ğ•¶š’PˆÊ‚Å‚Í‚È‚­ƒoƒCƒg’PˆÊ‚Å•\¦‚·‚é
-			sStatusbar.m_bDispColByChar = FALSE; // Œ»İŒ…‚ğƒ‹[ƒ‰[’PˆÊ‚Å‚Í‚È‚­•¶š’PˆÊ‚Å•\¦‚·‚é
+			// è¡¨ç¤ºæ–‡å­—ã‚³ãƒ¼ãƒ‰ã®æŒ‡å®š		2008/6/21	Uchi
+			sStatusbar.m_bDispUniInSjis		= FALSE;	// SJISã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹
+			sStatusbar.m_bDispUniInJis			= FALSE;	// JISã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹
+			sStatusbar.m_bDispUniInEuc			= FALSE;	// EUCã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹
+			sStatusbar.m_bDispUtf8Codepoint	= TRUE;		// UTF-8ã‚’ã‚³ãƒ¼ãƒ‰ãƒã‚¤ãƒ³ãƒˆã§è¡¨ç¤ºã™ã‚‹
+			sStatusbar.m_bDispSPCodepoint		= TRUE;		// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢ã‚’ã‚³ãƒ¼ãƒ‰ãƒã‚¤ãƒ³ãƒˆã§è¡¨ç¤ºã™ã‚‹
+			sStatusbar.m_bDispSelCountByByte	= FALSE;	// é¸æŠæ–‡å­—æ•°ã‚’æ–‡å­—å˜ä½ã§ã¯ãªããƒã‚¤ãƒˆå˜ä½ã§è¡¨ç¤ºã™ã‚‹
+			sStatusbar.m_bDispColByChar = FALSE; // ç¾åœ¨æ¡ã‚’ãƒ«ãƒ¼ãƒ©ãƒ¼å˜ä½ã§ã¯ãªãæ–‡å­—å˜ä½ã§è¡¨ç¤ºã™ã‚‹
 		}
 
-		// [ƒvƒ‰ƒOƒCƒ“]ƒ^ƒu
+		// [ãƒ—ãƒ©ã‚°ã‚¤ãƒ³]ã‚¿ãƒ–
 		{
 			CommonSetting_Plugin& sPlugin = m_pShareData->m_Common.m_sPlugin;
 
-			sPlugin.m_bEnablePlugin			= FALSE;	// ƒvƒ‰ƒOƒCƒ“‚ğg—p‚·‚é
+			sPlugin.m_bEnablePlugin			= FALSE;	// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ä½¿ç”¨ã™ã‚‹
 			for( int nPlugin=0; nPlugin < MAX_PLUGIN; nPlugin++ ){
-				sPlugin.m_PluginTable[nPlugin].m_szName[0]	= L'\0';	// ƒvƒ‰ƒOƒCƒ“–¼
-				sPlugin.m_PluginTable[nPlugin].m_szId[0]	= L'\0';	// ƒvƒ‰ƒOƒCƒ“ID
-				sPlugin.m_PluginTable[nPlugin].m_state = PLS_NONE;		// ƒvƒ‰ƒOƒCƒ“ó‘Ô
+				sPlugin.m_PluginTable[nPlugin].m_szName[0]	= L'\0';	// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å
+				sPlugin.m_PluginTable[nPlugin].m_szId[0]	= L'\0';	// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ID
+				sPlugin.m_PluginTable[nPlugin].m_state = PLS_NONE;		// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³çŠ¶æ…‹
 			}
 		}
 
-		// [ƒƒCƒ“ƒƒjƒ…[]ƒ^ƒu
+		// [ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼]ã‚¿ãƒ–
 		{
 			CDataProfile	cProfile;
 			std::vector<std::wstring> data;
@@ -663,22 +663,22 @@ bool CShareData::InitShareData()
 		}
 
 		{
-			/* m_PrintSettingArr[0]‚ğİ’è‚µ‚ÄAc‚è‚Ì1`7‚ÉƒRƒs[‚·‚éB
-				•K—v‚É‚È‚é‚Ü‚Å’x‚ç‚¹‚é‚½‚ß‚ÉACPrint‚ÉACShareData‚ğ‘€ì‚·‚éŒ ŒÀ‚ğ—^‚¦‚éB
+			/* m_PrintSettingArr[0]ã‚’è¨­å®šã—ã¦ã€æ®‹ã‚Šã®1ï½7ã«ã‚³ãƒ”ãƒ¼ã™ã‚‹ã€‚
+				å¿…è¦ã«ãªã‚‹ã¾ã§é…ã‚‰ã›ã‚‹ãŸã‚ã«ã€CPrintã«ã€CShareDataã‚’æ“ä½œã™ã‚‹æ¨©é™ã‚’ä¸ãˆã‚‹ã€‚
 				YAZAKI.
 			*/
 			{
 				/*
-					2006.08.16 Moca ‰Šú‰»’PˆÊ‚ğ PRINTSETTING‚É•ÏXBCShareData‚É‚ÍˆË‘¶‚µ‚È‚¢B
+					2006.08.16 Moca åˆæœŸåŒ–å˜ä½ã‚’ PRINTSETTINGã«å¤‰æ›´ã€‚CShareDataã«ã¯ä¾å­˜ã—ãªã„ã€‚
 				*/
 				TCHAR szSettingName[64];
 				int i = 0;
-				auto_sprintf( szSettingName, _T("ˆóüİ’è %d"), i + 1 );
-				CPrint::SettingInitialize( m_pShareData->m_PrintSettingArr[0], szSettingName );	//	‰Šú‰»–½—ßB
+				auto_sprintf( szSettingName, _T("å°åˆ·è¨­å®š %d"), i + 1 );
+				CPrint::SettingInitialize( m_pShareData->m_PrintSettingArr[0], szSettingName );	//	åˆæœŸåŒ–å‘½ä»¤ã€‚
 			}
 			for( int i = 1; i < MAX_PRINTSETTINGARR; ++i ){
 				m_pShareData->m_PrintSettingArr[i] = m_pShareData->m_PrintSettingArr[0];
-				auto_sprintf( m_pShareData->m_PrintSettingArr[i].m_szPrintSettingName, _T("ˆóüİ’è %d"), i + 1 );	/* ˆóüİ’è‚Ì–¼‘O */
+				auto_sprintf( m_pShareData->m_PrintSettingArr[i].m_szPrintSettingName, _T("å°åˆ·è¨­å®š %d"), i + 1 );	/* å°åˆ·è¨­å®šã®åå‰ */
 			}
 		}
 
@@ -689,11 +689,11 @@ bool CShareData::InitShareData()
 			m_pShareData->m_sSearchKeywords.m_aGrepFiles.push_back(_T("*.*"));
 			m_pShareData->m_sSearchKeywords.m_aGrepFolders.clear();
 
-			// 2004/06/21 novice ƒ^ƒOƒWƒƒƒ“ƒv‹@”\’Ç‰Á
+			// 2004/06/21 novice ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½è¿½åŠ 
 			m_pShareData->m_sTagJump.m_TagJumpNum = 0;
-			// 2004.06.22 Moca ƒ^ƒOƒWƒƒƒ“ƒv‚Ìæ“ª
+			// 2004.06.22 Moca ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã®å…ˆé ­
 			m_pShareData->m_sTagJump.m_TagJumpTop = 0;
-			//From Here 2005.04.03 MIK ƒL[ƒ[ƒhw’èƒ^ƒOƒWƒƒƒ“ƒv‚ÌHistory•ÛŠÇ
+			//From Here 2005.04.03 MIK ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®šã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã®Historyä¿ç®¡
 			m_pShareData->m_sTagJump.m_aTagJumpKeywords.clear();
 			m_pShareData->m_sTagJump.m_bTagJumpICase = FALSE;
 			m_pShareData->m_sTagJump.m_bTagJumpAnyWhere = FALSE;
@@ -701,23 +701,23 @@ bool CShareData::InitShareData()
 
 			m_pShareData->m_sHistory.m_aExceptMRU.clear();
 
-			_tcscpy( m_pShareData->m_sHistory.m_szIMPORTFOLDER, szIniFolder );	/* İ’èƒCƒ“ƒ|[ƒg—pƒtƒHƒ‹ƒ_ */
+			_tcscpy( m_pShareData->m_sHistory.m_szIMPORTFOLDER, szIniFolder );	/* è¨­å®šã‚¤ãƒ³ãƒãƒ¼ãƒˆç”¨ãƒ•ã‚©ãƒ«ãƒ€ */
 
 			m_pShareData->m_sHistory.m_aCommands.clear();
 			m_pShareData->m_sHistory.m_aCurDirs.clear();
 
-			m_pShareData->m_nExecFlgOpt = 1;	/* ŠO•”ƒRƒ}ƒ“ƒhÀs‚Ìu•W€o—Í‚ğ“¾‚év */	// 2006.12.03 maru ƒIƒvƒVƒ‡ƒ“‚ÌŠg’£‚Ì‚½‚ß
+			m_pShareData->m_nExecFlgOpt = 1;	/* å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œã®ã€Œæ¨™æº–å‡ºåŠ›ã‚’å¾—ã‚‹ã€ */	// 2006.12.03 maru ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã®æ‹¡å¼µã®ãŸã‚
 
-			m_pShareData->m_nDiffFlgOpt = 0;	/* DIFF·•ª•\¦ */	//@@@ 2002.05.27 MIK
+			m_pShareData->m_nDiffFlgOpt = 0;	/* DIFFå·®åˆ†è¡¨ç¤º */	//@@@ 2002.05.27 MIK
 
 			m_pShareData->m_szTagsCmdLine[0] = _T('\0');	/* CTAGS */	//@@@ 2003.05.12 MIK
 			m_pShareData->m_nTagsOpt = 0;	/* CTAGS */	//@@@ 2003.05.12 MIK
 
-			m_pShareData->m_bLineNumIsCRLF_ForJump = true;	/* w’ès‚ÖƒWƒƒƒ“ƒv‚Ìu‰üs’PˆÊ‚Ìs”Ô†v‚©uÜ‚è•Ô‚µ’PˆÊ‚Ìs”Ô†v‚© */
+			m_pShareData->m_bLineNumIsCRLF_ForJump = true;	/* æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—ã®ã€Œæ”¹è¡Œå˜ä½ã®è¡Œç•ªå·ã€ã‹ã€ŒæŠ˜ã‚Šè¿”ã—å˜ä½ã®è¡Œç•ªå·ã€ã‹ */
 		}
 	}else{
-		/* ƒIƒuƒWƒFƒNƒg‚ª‚·‚Å‚É‘¶İ‚·‚éê‡ */
-		/* ƒtƒ@ƒCƒ‹‚Ìƒrƒ…[‚ğ¤ ŒÄ‚Ño‚µ‘¤ƒvƒƒZƒX‚ÌƒAƒhƒŒƒX‹óŠÔ‚Éƒ}ƒbƒv‚µ‚Ü‚· */
+		/* ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆãŒã™ã§ã«å­˜åœ¨ã™ã‚‹å ´åˆ */
+		/* ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ“ãƒ¥ãƒ¼ã‚’ï½¤ å‘¼ã³å‡ºã—å´ãƒ—ãƒ­ã‚»ã‚¹ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ç©ºé–“ã«ãƒãƒƒãƒ—ã—ã¾ã™ */
 		m_pShareData = (DLLSHAREDATA*)::MapViewOfFile(
 			m_hFileMap,
 			FILE_MAP_ALL_ACCESS,
@@ -731,11 +731,11 @@ bool CShareData::InitShareData()
 		InitCharWidthCache(m_pShareData->m_Common.m_sView.m_lf);	// 2008/5/15 Uchi
 
 		//	From Here Oct. 27, 2000 genta
-		//	2014.01.08 Moca ƒTƒCƒYƒ`ƒFƒbƒN’Ç‰Á
+		//	2014.01.08 Moca ã‚µã‚¤ã‚ºãƒã‚§ãƒƒã‚¯è¿½åŠ 
 		if( m_pShareData->m_vStructureVersion != uShareDataVersion ||
 			m_pShareData->m_nSize != sizeof(*m_pShareData) ){
-			//	‚±‚Ì‹¤—Lƒf[ƒ^—Ìˆæ‚Íg‚¦‚È‚¢D
-			//	ƒnƒ“ƒhƒ‹‚ğ‰ğ•ú‚·‚é
+			//	ã“ã®å…±æœ‰ãƒ‡ãƒ¼ã‚¿é ˜åŸŸã¯ä½¿ãˆãªã„ï¼
+			//	ãƒãƒ³ãƒ‰ãƒ«ã‚’è§£æ”¾ã™ã‚‹
 			SetDllShareData( NULL );
 			::UnmapViewOfFile( m_pShareData );
 			m_pShareData = NULL;
@@ -801,11 +801,11 @@ static void ConvertLangValueImpl( char* pBuf, size_t chBufSize, int nStrId, std:
 
 
 /*!
-	‘Û‰»‘Î‰‚Ì‚½‚ß‚Ì•¶š—ñ‚ğ•ÏX‚·‚é
+	å›½éš›åŒ–å¯¾å¿œã®ãŸã‚ã®æ–‡å­—åˆ—ã‚’å¤‰æ›´ã™ã‚‹
 
-	1. 1‰ñ–ÚŒÄ‚Ño‚µAsetValues‚ğtrue‚É‚µ‚ÄAvalues‚É‹Œİ’è‚ÌŒ¾Œê•¶š—ñ‚ğ“Ç‚İ‚İ
-	2. SelectLangŒÄ‚Ño‚µ
-	3. 2‰ñ–ÚŒÄ‚Ño‚µAvalues‚ğg‚Á‚ÄVİ’è‚ÌŒ¾Œê‚É‘‚«Š·‚¦
+	1. 1å›ç›®å‘¼ã³å‡ºã—ã€setValuesã‚’trueã«ã—ã¦ã€valuesã«æ—§è¨­å®šã®è¨€èªæ–‡å­—åˆ—ã‚’èª­ã¿è¾¼ã¿
+	2. SelectLangå‘¼ã³å‡ºã—
+	3. 2å›ç›®å‘¼ã³å‡ºã—ã€valuesã‚’ä½¿ã£ã¦æ–°è¨­å®šã®è¨€èªã«æ›¸ãæ›ãˆ
 */
 void CShareData::ConvertLangValues(std::vector<std::wstring>& values, bool bSetValues)
 {
@@ -884,38 +884,38 @@ void CShareData::ConvertLangValues(std::vector<std::wstring>& values, bool bSetV
 }
 
 /*!
-	@brief	w’èƒtƒ@ƒCƒ‹‚ªŠJ‚©‚ê‚Ä‚¢‚é‚©’²‚×‚é
+	@brief	æŒ‡å®šãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‹ã‹ã‚Œã¦ã„ã‚‹ã‹èª¿ã¹ã‚‹
 	
-	w’è‚Ìƒtƒ@ƒCƒ‹‚ªŠJ‚©‚ê‚Ä‚¢‚éê‡‚ÍŠJ‚¢‚Ä‚¢‚éƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹‚ğ•Ô‚·
+	æŒ‡å®šã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‹ã‹ã‚Œã¦ã„ã‚‹å ´åˆã¯é–‹ã„ã¦ã„ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ«ã‚’è¿”ã™
 
-	@retval	TRUE ‚·‚Å‚ÉŠJ‚¢‚Ä‚¢‚½
-	@retval	FALSE ŠJ‚¢‚Ä‚¢‚È‚©‚Á‚½
+	@retval	TRUE ã™ã§ã«é–‹ã„ã¦ã„ãŸ
+	@retval	FALSE é–‹ã„ã¦ã„ãªã‹ã£ãŸ
 */
 BOOL CShareData::IsPathOpened( const TCHAR* pszPath, HWND* phwndOwner )
 {
 	EditInfo*	pfi;
 	*phwndOwner = NULL;
 
-	//	2007.10.01 genta ‘Š‘ÎƒpƒX‚ğâ‘ÎƒpƒX‚É•ÏŠ·
-	//	•ÏŠ·‚µ‚È‚¢‚ÆIsPathOpened‚Å³‚µ‚¢Œ‹‰Ê‚ª“¾‚ç‚ê‚¸C
-	//	“¯ˆêƒtƒ@ƒCƒ‹‚ğ•¡”ŠJ‚­‚±‚Æ‚ª‚ ‚éD
+	//	2007.10.01 genta ç›¸å¯¾ãƒ‘ã‚¹ã‚’çµ¶å¯¾ãƒ‘ã‚¹ã«å¤‰æ›
+	//	å¤‰æ›ã—ãªã„ã¨IsPathOpenedã§æ­£ã—ã„çµæœãŒå¾—ã‚‰ã‚Œãšï¼Œ
+	//	åŒä¸€ãƒ•ã‚¡ã‚¤ãƒ«ã‚’è¤‡æ•°é–‹ãã“ã¨ãŒã‚ã‚‹ï¼
 	TCHAR	szBuf[_MAX_PATH];
 	if( GetLongFileName( pszPath, szBuf )){
 		pszPath = szBuf;
 	}
 
-	// Œ»İ‚Ì•ÒWƒEƒBƒ“ƒhƒE‚Ì”‚ğ’²‚×‚é
+	// ç¾åœ¨ã®ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®æ•°ã‚’èª¿ã¹ã‚‹
 	if( 0 == CAppNodeGroupHandle(0).GetEditorWindowsNum() ){
 		return FALSE;
 	}
 	
 	for( int i = 0; i < m_pShareData->m_sNodes.m_nEditArrNum; ++i ){
 		if( IsSakuraMainWindow( m_pShareData->m_sNodes.m_pEditArr[i].m_hWnd ) ){
-			// ƒgƒŒƒC‚©‚çƒGƒfƒBƒ^‚Ö‚Ì•ÒWƒtƒ@ƒCƒ‹–¼—v‹’Ê’m
+			// ãƒˆãƒ¬ã‚¤ã‹ã‚‰ã‚¨ãƒ‡ã‚£ã‚¿ã¸ã®ç·¨é›†ãƒ•ã‚¡ã‚¤ãƒ«åè¦æ±‚é€šçŸ¥
 			::SendMessageAny( m_pShareData->m_sNodes.m_pEditArr[i].m_hWnd, MYWM_GETFILEINFO, 1, 0 );
 			pfi = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
-			// “¯ˆêƒpƒX‚Ìƒtƒ@ƒCƒ‹‚ªŠù‚ÉŠJ‚©‚ê‚Ä‚¢‚é‚©
+			// åŒä¸€ãƒ‘ã‚¹ã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒæ—¢ã«é–‹ã‹ã‚Œã¦ã„ã‚‹ã‹
 			if( 0 == _tcsicmp( pfi->m_szPath, pszPath ) ){
 				*phwndOwner = m_pShareData->m_sNodes.m_pEditArr[i].m_hWnd;
 				return TRUE;
@@ -926,28 +926,28 @@ BOOL CShareData::IsPathOpened( const TCHAR* pszPath, HWND* phwndOwner )
 }
 
 /*!
-	@brief	w’èƒtƒ@ƒCƒ‹‚ªŠJ‚©‚ê‚Ä‚¢‚é‚©’²‚×‚Â‚ÂA‘½dƒI[ƒvƒ“‚Ì•¶šƒR[ƒhÕ“Ë‚àŠm”F
+	@brief	æŒ‡å®šãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‹ã‹ã‚Œã¦ã„ã‚‹ã‹èª¿ã¹ã¤ã¤ã€å¤šé‡ã‚ªãƒ¼ãƒ—ãƒ³æ™‚ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰è¡çªã‚‚ç¢ºèª
 
-	‚à‚µ‚·‚Å‚ÉŠJ‚¢‚Ä‚¢‚ê‚ÎƒAƒNƒeƒBƒu‚É‚µ‚ÄAƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹‚ğ•Ô‚·B
-	‚³‚ç‚ÉA•¶šƒR[ƒh‚ªˆÙ‚È‚é‚Æ‚«‚Ìƒ[ƒjƒ“ƒO‚àˆ—‚·‚éB
-	‚ ‚¿‚±‚¿‚ÉU‚ç‚Î‚Á‚½‘½dƒI[ƒvƒ“ˆ—‚ğWŒ‹‚³‚¹‚é‚Ì‚ª–Ú“IB
+	ã‚‚ã—ã™ã§ã«é–‹ã„ã¦ã„ã‚Œã°ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã—ã¦ã€ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ«ã‚’è¿”ã™ã€‚
+	ã•ã‚‰ã«ã€æ–‡å­—ã‚³ãƒ¼ãƒ‰ãŒç•°ãªã‚‹ã¨ãã®ãƒ¯ãƒ¼ãƒ‹ãƒ³ã‚°ã‚‚å‡¦ç†ã™ã‚‹ã€‚
+	ã‚ã¡ã“ã¡ã«æ•£ã‚‰ã°ã£ãŸå¤šé‡ã‚ªãƒ¼ãƒ—ãƒ³å‡¦ç†ã‚’é›†çµã•ã›ã‚‹ã®ãŒç›®çš„ã€‚
 
-	@retval	ŠJ‚©‚ê‚Ä‚¢‚éê‡‚ÍŠJ‚¢‚Ä‚¢‚éƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹
+	@retval	é–‹ã‹ã‚Œã¦ã„ã‚‹å ´åˆã¯é–‹ã„ã¦ã„ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ«
 
-	@note	CEditDoc::FileLoad‚Éæ—§‚Á‚ÄÀs‚³‚ê‚é‚±‚Æ‚à‚ ‚é‚ªA
-			CEditDoc::FileLoad‚©‚ç‚àÀs‚³‚ê‚é•K—v‚ª‚ ‚é‚±‚Æ‚É’ˆÓB
-			(ƒtƒHƒ‹ƒ_w’è‚Ìê‡‚âCEditDoc::FileLoad‚ª’¼ÚÀs‚³‚ê‚éê‡‚à‚ ‚é‚½‚ß)
+	@note	CEditDoc::FileLoadã«å…ˆç«‹ã£ã¦å®Ÿè¡Œã•ã‚Œã‚‹ã“ã¨ã‚‚ã‚ã‚‹ãŒã€
+			CEditDoc::FileLoadã‹ã‚‰ã‚‚å®Ÿè¡Œã•ã‚Œã‚‹å¿…è¦ãŒã‚ã‚‹ã“ã¨ã«æ³¨æ„ã€‚
+			(ãƒ•ã‚©ãƒ«ãƒ€æŒ‡å®šã®å ´åˆã‚„CEditDoc::FileLoadãŒç›´æ¥å®Ÿè¡Œã•ã‚Œã‚‹å ´åˆã‚‚ã‚ã‚‹ãŸã‚)
 
-	@retval	TRUE ‚·‚Å‚ÉŠJ‚¢‚Ä‚¢‚½
-	@retval	FALSE ŠJ‚¢‚Ä‚¢‚È‚©‚Á‚½
+	@retval	TRUE ã™ã§ã«é–‹ã„ã¦ã„ãŸ
+	@retval	FALSE é–‹ã„ã¦ã„ãªã‹ã£ãŸ
 
-	@date 2007.03.12 maru V‹Kì¬
+	@date 2007.03.12 maru æ–°è¦ä½œæˆ
 */
 BOOL CShareData::ActiveAlreadyOpenedWindow( const TCHAR* pszPath, HWND* phwndOwner, ECodeType nCharCode )
 {
 	if( IsPathOpened( pszPath, phwndOwner ) ){
 		
-		//•¶šƒR[ƒh‚Ìˆê’vŠm”F
+		//æ–‡å­—ã‚³ãƒ¼ãƒ‰ã®ä¸€è‡´ç¢ºèª
 		EditInfo*		pfi;
 		::SendMessageAny( *phwndOwner, MYWM_GETFILEINFO, 0, 0 );
 		pfi = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
@@ -978,10 +978,10 @@ BOOL CShareData::ActiveAlreadyOpenedWindow( const TCHAR* pszPath, HWND* phwndOwn
 			}
 		}
 
-		// ŠJ‚¢‚Ä‚¢‚éƒEƒBƒ“ƒhƒE‚ğƒAƒNƒeƒBƒu‚É‚·‚é
+		// é–‹ã„ã¦ã„ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹
 		ActivateFrameWindow( *phwndOwner );
 
-		// MRUƒŠƒXƒg‚Ö‚Ì“o˜^
+		// MRUãƒªã‚¹ãƒˆã¸ã®ç™»éŒ²
 		CMRUFile().Add( pfi );
 		return TRUE;
 	}
@@ -1004,11 +1004,11 @@ BOOL CShareData::ActiveAlreadyOpenedWindow( const TCHAR* pszPath, HWND* phwndOwn
 
 
 /*!
-	ƒAƒEƒgƒvƒbƒgƒEƒCƒ“ƒhƒE‚Éo—Í(‘®•t)
+	ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã«å‡ºåŠ›(æ›¸å¼ä»˜)
 
-	ƒAƒEƒgƒvƒbƒgƒEƒCƒ“ƒhƒE‚ª–³‚¯‚ê‚ÎƒI[ƒvƒ“‚·‚é
-	@param lpFmt [in] ‘®w’è•¶š—ñ(wchar_t”Å)
-	@date 2010.02.22 Moca auto_vsprintf‚©‚ç tchar_vsnprintf_s ‚É•ÏX.’·‚·‚¬‚é‚Æ‚«‚ÍØ‚è‹l‚ß‚ç‚ê‚é
+	ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ãŒç„¡ã‘ã‚Œã°ã‚ªãƒ¼ãƒ—ãƒ³ã™ã‚‹
+	@param lpFmt [in] æ›¸å¼æŒ‡å®šæ–‡å­—åˆ—(wchar_tç‰ˆ)
+	@date 2010.02.22 Moca auto_vsprintfã‹ã‚‰ tchar_vsnprintf_s ã«å¤‰æ›´.é•·ã™ãã‚‹ã¨ãã¯åˆ‡ã‚Šè©°ã‚ã‚‰ã‚Œã‚‹
 */
 void CShareData::TraceOut( LPCTSTR lpFmt, ... )
 {
@@ -1024,10 +1024,10 @@ void CShareData::TraceOut( LPCTSTR lpFmt, ... )
 		to_wchar(lpFmt), argList );
 	va_end( argList );
 	if( -1 == ret ){
-		// Ø‚è‹l‚ß‚ç‚ê‚½
+		// åˆ‡ã‚Šè©°ã‚ã‚‰ã‚ŒãŸ
 		ret = auto_strlen( m_pShareData->m_sWorkBuffer.GetWorkBuffer<WCHAR>() );
 	}else if( ret < 0 ){
-		// •ÛŒìƒR[ƒh:ó‚¯‘¤‚ÍwParam¨size_t‚Å•„†‚È‚µ‚Ì‚½‚ß
+		// ä¿è­·ã‚³ãƒ¼ãƒ‰:å—ã‘å´ã¯wParamâ†’size_tã§ç¬¦å·ãªã—ã®ãŸã‚
 		ret = 0;
 	}
 	DWORD_PTR dwMsgResult;
@@ -1036,13 +1036,13 @@ void CShareData::TraceOut( LPCTSTR lpFmt, ... )
 }
 
 /*!
-	ƒAƒEƒgƒvƒbƒgƒEƒCƒ“ƒhƒE‚Éo—Í(•¶š—ñw’è)
+	ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã«å‡ºåŠ›(æ–‡å­—åˆ—æŒ‡å®š)
 
-	’·‚¢ê‡‚Í•ªŠ„‚µ‚Ä‘—‚é
-	ƒAƒEƒgƒvƒbƒgƒEƒCƒ“ƒhƒE‚ª–³‚¯‚ê‚ÎƒI[ƒvƒ“‚·‚é
-	@param  pStr  o—Í‚·‚é•¶š—ñ
-	@param  len   pStr‚Ì•¶š”(I’[NUL‚ğŠÜ‚Ü‚È‚¢) -1‚Å©“®ŒvZ
-	@date 2010.05.11 Moca Vİ
+	é•·ã„å ´åˆã¯åˆ†å‰²ã—ã¦é€ã‚‹
+	ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ãŒç„¡ã‘ã‚Œã°ã‚ªãƒ¼ãƒ—ãƒ³ã™ã‚‹
+	@param  pStr  å‡ºåŠ›ã™ã‚‹æ–‡å­—åˆ—
+	@param  len   pStrã®æ–‡å­—æ•°(çµ‚ç«¯NULã‚’å«ã¾ãªã„) -1ã§è‡ªå‹•è¨ˆç®—
+	@date 2010.05.11 Moca æ–°è¨­
 */
 void CShareData::TraceOutString( const wchar_t* pStr, int len )
 {
@@ -1052,13 +1052,13 @@ void CShareData::TraceOutString( const wchar_t* pStr, int len )
 	if( -1 == len ){
 		len = wcslen(pStr);
 	}
-	// m_sWorkBuffer‚¬‚è‚¬‚è‚Å‚à–â‘è‚È‚¢‚¯‚ê‚ÇA”O‚Ì‚½‚ß\0I’[‚É‚·‚é‚½‚ß‚É—]—T‚ğ‚Æ‚é
-	// -1 ‚æ‚è 8,4ƒoƒCƒg‹«ŠE‚Ì‚Ù‚¤‚ªƒRƒs[‚ª‘‚¢‚Í‚¸‚È‚Ì‚ÅA-4‚É‚·‚é
+	// m_sWorkBufferãã‚Šãã‚Šã§ã‚‚å•é¡Œãªã„ã‘ã‚Œã©ã€å¿µã®ãŸã‚\0çµ‚ç«¯ã«ã™ã‚‹ãŸã‚ã«ä½™è£•ã‚’ã¨ã‚‹
+	// -1 ã‚ˆã‚Š 8,4ãƒã‚¤ãƒˆå¢ƒç•Œã®ã»ã†ãŒã‚³ãƒ”ãƒ¼ãŒæ—©ã„ã¯ãšãªã®ã§ã€-4ã«ã™ã‚‹
 	const int buffLen = (int)m_pShareData->m_sWorkBuffer.GetWorkBufferCount<WCHAR>() - 4;
 	wchar_t*  pOutBuffer = m_pShareData->m_sWorkBuffer.GetWorkBuffer<WCHAR>();
 	int outPos = 0;
 	if(0 == len){
-		// 0‚Ì‚Æ‚«‚Í‰½‚à’Ç‰Á‚µ‚È‚¢‚ªAƒJ[ƒ\ƒ‹ˆÚ“®‚ª”­¶‚·‚é
+		// 0ã®ã¨ãã¯ä½•ã‚‚è¿½åŠ ã—ãªã„ãŒã€ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ãŒç™ºç”Ÿã™ã‚‹
 		LockGuard<CMutex> guard( CShareData::GetMutexShareWork() );
 		pOutBuffer[0] = L'\0';
 		::SendMessage( m_pShareData->m_sHandles.m_hwndDebug, MYWM_ADDSTRINGLEN_W, 0, 0 );
@@ -1066,12 +1066,12 @@ void CShareData::TraceOutString( const wchar_t* pStr, int len )
 		while(outPos < len){
 			int outLen = buffLen;
 			if(len - outPos < buffLen){
-				// c‚è‘S•”
+				// æ®‹ã‚Šå…¨éƒ¨
 				outLen = len - outPos;
 			}
-			// ‚ ‚Ü‚è‚ª1•¶šˆÈã‚ ‚é
+			// ã‚ã¾ã‚ŠãŒ1æ–‡å­—ä»¥ä¸Šã‚ã‚‹
 			if( outPos + outLen < len ){
-				// CRLF(\r\n)‚ÆUTF-16‚ª•ª—£‚³‚ê‚È‚¢‚æ‚¤‚É
+				// CRLF(\r\n)ã¨UTF-16ãŒåˆ†é›¢ã•ã‚Œãªã„ã‚ˆã†ã«
 				if( (pStr[outPos + outLen - 1] == WCODE::CR && pStr[outPos + outLen] == WCODE::LF)
 					|| (IsUtf16SurrogHi( pStr[outPos + outLen - 1] ) && IsUtf16SurrogLow( pStr[outPos + outLen] )) ){
 					--outLen;
@@ -1083,7 +1083,7 @@ void CShareData::TraceOutString( const wchar_t* pStr, int len )
 			DWORD_PTR	dwMsgResult;
 			if( 0 == ::SendMessageTimeout( m_pShareData->m_sHandles.m_hwndDebug, MYWM_ADDSTRINGLEN_W, outLen, 0,
 				SMTO_NORMAL, 10000, &dwMsgResult ) ){
-				// ƒGƒ‰[‚©ƒ^ƒCƒ€ƒAƒEƒg
+				// ã‚¨ãƒ©ãƒ¼ã‹ã‚¿ã‚¤ãƒ ã‚¢ã‚¦ãƒˆ
 				break;
 			}
 			outPos += outLen;
@@ -1092,11 +1092,11 @@ void CShareData::TraceOutString( const wchar_t* pStr, int len )
 }
 
 /*
-	ƒfƒoƒbƒOƒEƒBƒ“ƒhƒE‚ğ•\¦
-	@param hwnd V‹KƒEƒBƒ“ƒhƒE‚Ì‚Æ‚«‚ÌƒfƒoƒbƒOƒEƒBƒ“ƒhƒE‚ÌŠ‘®ƒOƒ‹[ƒv
-	@param bAllwaysActive •\¦Ï‚İƒEƒBƒ“ƒhƒE‚Å‚àƒAƒNƒeƒBƒu‚É‚·‚é
-	@return true:•\¦‚Å‚«‚½B‚Ü‚½‚Í‚·‚Å‚É•\¦‚³‚ê‚Ä‚¢‚éB
-	@date 2010.05.11 Moca TraceOut‚©‚ç•ª—£
+	ãƒ‡ãƒãƒƒã‚°ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¡¨ç¤º
+	@param hwnd æ–°è¦ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã¨ãã®ãƒ‡ãƒãƒƒã‚°ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®æ‰€å±ã‚°ãƒ«ãƒ¼ãƒ—
+	@param bAllwaysActive è¡¨ç¤ºæ¸ˆã¿ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã§ã‚‚ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹
+	@return true:è¡¨ç¤ºã§ããŸã€‚ã¾ãŸã¯ã™ã§ã«è¡¨ç¤ºã•ã‚Œã¦ã„ã‚‹ã€‚
+	@date 2010.05.11 Moca TraceOutã‹ã‚‰åˆ†é›¢
 */
 bool CShareData::OpenDebugWindow( HWND hwnd, bool bAllwaysActive )
 {
@@ -1105,30 +1105,30 @@ bool CShareData::OpenDebugWindow( HWND hwnd, bool bAllwaysActive )
 	|| !IsSakuraMainWindow( m_pShareData->m_sHandles.m_hwndDebug )
 	){
 		// 2007.06.26 ryoji
-		// ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚ğì¬Œ³‚Æ“¯‚¶ƒOƒ‹[ƒv‚Éì¬‚·‚é‚½‚ß‚É m_hwndTraceOutSource ‚ğg‚Á‚Ä‚¢‚Ü‚·
-		// im_hwndTraceOutSource ‚Í CEditWnd::Create() ‚Å—\‚ßİ’èj
-		// ‚¿‚å‚Á‚Æ•sŠ†D‚¾‚¯‚ÇATraceOut() ‚Ìˆø”‚É‚¢‚¿‚¢‚¿‹N“®Œ³‚ğw’è‚·‚é‚Ì‚àDDD
-		// 2010.05.11 Moca m_hwndTraceOutSource‚ÍˆË‘R‚Æ‚µ‚Äg‚Á‚Ä‚¢‚Ü‚·‚ªˆø”‚É‚µ‚Ü‚µ‚½
+		// ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ä½œæˆå…ƒã¨åŒã˜ã‚°ãƒ«ãƒ¼ãƒ—ã«ä½œæˆã™ã‚‹ãŸã‚ã« m_hwndTraceOutSource ã‚’ä½¿ã£ã¦ã„ã¾ã™
+		// ï¼ˆm_hwndTraceOutSource ã¯ CEditWnd::Create() ã§äºˆã‚è¨­å®šï¼‰
+		// ã¡ã‚‡ã£ã¨ä¸æ°å¥½ã ã‘ã©ã€TraceOut() ã®å¼•æ•°ã«ã„ã¡ã„ã¡èµ·å‹•å…ƒã‚’æŒ‡å®šã™ã‚‹ã®ã‚‚ï¼ï¼ï¼
+		// 2010.05.11 Moca m_hwndTraceOutSourceã¯ä¾ç„¶ã¨ã—ã¦ä½¿ã£ã¦ã„ã¾ã™ãŒå¼•æ•°ã«ã—ã¾ã—ãŸ
 		SLoadInfo sLoadInfo;
 		sLoadInfo.cFilePath = _T("");
 		// CODE_SJIS->CODE_UNICODE	2008/6/8 Uchi
-		// CODE_UNICODE->CODE_NONE	2010.05.11 Moca ƒfƒtƒHƒ‹ƒg•¶šƒR[ƒh‚Åİ’è‚Å‚«‚é‚æ‚¤‚É–³w’è‚É•ÏX
+		// CODE_UNICODE->CODE_NONE	2010.05.11 Moca ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ–‡å­—ã‚³ãƒ¼ãƒ‰ã§è¨­å®šã§ãã‚‹ã‚ˆã†ã«ç„¡æŒ‡å®šã«å¤‰æ›´
 		sLoadInfo.eCharCode = CODE_NONE;
 		sLoadInfo.bViewMode = false;
 		ret = CControlTray::OpenNewEditor( NULL, hwnd, sLoadInfo, _T("-DEBUGMODE"), true );
-		//	2001/06/23 N.Nakatani ‘‹‚ªo‚é‚Ü‚ÅƒEƒGƒCƒg‚ğ‚©‚¯‚é‚æ‚¤‚ÉC³
-		//ƒAƒEƒgƒvƒbƒgƒEƒCƒ“ƒhƒE‚ªo—ˆ‚é‚Ü‚Å5•b‚®‚ç‚¢‘Ò‚ÂB
-		//	Jun. 25, 2001 genta OpenNewEditor‚Ì“¯Šú‹@”\‚ğ—˜—p‚·‚é‚æ‚¤‚É•ÏX
-		bAllwaysActive = true; // V‚µ‚­ì‚Á‚½‚Æ‚«‚Íactive
+		//	2001/06/23 N.Nakatani çª“ãŒå‡ºã‚‹ã¾ã§ã‚¦ã‚¨ã‚¤ãƒˆã‚’ã‹ã‘ã‚‹ã‚ˆã†ã«ä¿®æ­£
+		//ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ãŒå‡ºæ¥ã‚‹ã¾ã§5ç§’ãã‚‰ã„å¾…ã¤ã€‚
+		//	Jun. 25, 2001 genta OpenNewEditorã®åŒæœŸæ©Ÿèƒ½ã‚’åˆ©ç”¨ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
+		bAllwaysActive = true; // æ–°ã—ãä½œã£ãŸã¨ãã¯active
 	}
-	/* ŠJ‚¢‚Ä‚¢‚éƒEƒBƒ“ƒhƒE‚ğƒAƒNƒeƒBƒu‚É‚·‚é */
+	/* é–‹ã„ã¦ã„ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹ */
 	if(ret && bAllwaysActive){
 		ActivateFrameWindow( m_pShareData->m_sHandles.m_hwndDebug );
 	}
 	return ret;
 }
 
-/* iniƒtƒ@ƒCƒ‹‚Ì•Û‘¶æ‚ªƒ†[ƒU•Êİ’èƒtƒHƒ‹ƒ_‚©‚Ç‚¤‚© */	// 2007.05.25 ryoji
+/* iniãƒ•ã‚¡ã‚¤ãƒ«ã®ä¿å­˜å…ˆãŒãƒ¦ãƒ¼ã‚¶åˆ¥è¨­å®šãƒ•ã‚©ãƒ«ãƒ€ã‹ã©ã†ã‹ */	// 2007.05.25 ryoji
 BOOL CShareData::IsPrivateSettings( void ){
 	return m_pShareData->m_sFileNameManagement.m_IniFolder.m_bWritePrivate;
 }
@@ -1137,30 +1137,30 @@ BOOL CShareData::IsPrivateSettings( void ){
 
 /*
 	CShareData::CheckMRUandOPENFOLDERList
-	MRU‚ÆOPENFOLDERƒŠƒXƒg‚Ì‘¶İƒ`ƒFƒbƒN‚È‚Ç
-	‘¶İ‚µ‚È‚¢ƒtƒ@ƒCƒ‹‚âƒtƒHƒ‹ƒ_‚ÍMRU‚âOPENFOLDERƒŠƒXƒg‚©‚çíœ‚·‚é
+	MRUã¨OPENFOLDERãƒªã‚¹ãƒˆã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯ãªã©
+	å­˜åœ¨ã—ãªã„ãƒ•ã‚¡ã‚¤ãƒ«ã‚„ãƒ•ã‚©ãƒ«ãƒ€ã¯MRUã‚„OPENFOLDERãƒªã‚¹ãƒˆã‹ã‚‰å‰Šé™¤ã™ã‚‹
 
-	@note Œ»İ‚Íg‚í‚ê‚Ä‚¢‚È‚¢‚æ‚¤‚¾B
+	@note ç¾åœ¨ã¯ä½¿ã‚ã‚Œã¦ã„ãªã„ã‚ˆã†ã ã€‚
 	@par History
-	2001.12.26 íœ‚µ‚½BiYAZAKIj
+	2001.12.26 å‰Šé™¤ã—ãŸã€‚ï¼ˆYAZAKIï¼‰
 	
 */
-/*!	idx‚Åw’è‚µ‚½ƒ}ƒNƒƒtƒ@ƒCƒ‹–¼iƒtƒ‹ƒpƒXj‚ğæ“¾‚·‚éD
+/*!	idxã§æŒ‡å®šã—ãŸãƒã‚¯ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«åï¼ˆãƒ•ãƒ«ãƒ‘ã‚¹ï¼‰ã‚’å–å¾—ã™ã‚‹ï¼
 
-	@param pszPath [in]	ƒpƒX–¼‚Ìo—ÍæD’·‚³‚Ì‚İ‚ğ’m‚è‚½‚¢‚Æ‚«‚ÍNULL‚ğ“ü‚ê‚éD
-	@param idx [in]		ƒ}ƒNƒ”Ô†
-	@param nBufLen [in]	pszPath‚Åw’è‚³‚ê‚½ƒoƒbƒtƒ@‚Ìƒoƒbƒtƒ@ƒTƒCƒY
+	@param pszPath [in]	ãƒ‘ã‚¹åã®å‡ºåŠ›å…ˆï¼é•·ã•ã®ã¿ã‚’çŸ¥ã‚ŠãŸã„ã¨ãã¯NULLã‚’å…¥ã‚Œã‚‹ï¼
+	@param idx [in]		ãƒã‚¯ãƒ­ç•ªå·
+	@param nBufLen [in]	pszPathã§æŒ‡å®šã•ã‚ŒãŸãƒãƒƒãƒ•ã‚¡ã®ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚º
 
-	@retval >0 : ƒpƒX–¼‚Ì’·‚³D
-	@retval  0 : ƒGƒ‰[C‚»‚Ìƒ}ƒNƒ‚Íg‚¦‚È‚¢Cƒtƒ@ƒCƒ‹–¼‚ªw’è‚³‚ê‚Ä‚¢‚È‚¢D
-	@retval <0 : ƒoƒbƒtƒ@•s‘«D•K—v‚Èƒoƒbƒtƒ@ƒTƒCƒY‚Í -(–ß‚è’l)+1
+	@retval >0 : ãƒ‘ã‚¹åã®é•·ã•ï¼
+	@retval  0 : ã‚¨ãƒ©ãƒ¼ï¼Œãã®ãƒã‚¯ãƒ­ã¯ä½¿ãˆãªã„ï¼Œãƒ•ã‚¡ã‚¤ãƒ«åãŒæŒ‡å®šã•ã‚Œã¦ã„ãªã„ï¼
+	@retval <0 : ãƒãƒƒãƒ•ã‚¡ä¸è¶³ï¼å¿…è¦ãªãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã¯ -(æˆ»ã‚Šå€¤)+1
 
 	@author YAZAKI
-	@date 2003.06.08 Moca ƒ[ƒJƒ‹•Ï”‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğ•Ô‚³‚È‚¢‚æ‚¤‚Éd—l•ÏX
-	@date 2003.06.14 genta •¶š—ñ’·Cƒ|ƒCƒ“ƒ^‚Ìƒ`ƒFƒbƒN‚ğ’Ç‰Á
-	@date 2003.06.24 Moca idx‚ª-1‚Ì‚Æ‚«AƒL[ƒ}ƒNƒ‚Ìƒtƒ‹ƒpƒX‚ğ•Ô‚·.
+	@date 2003.06.08 Moca ãƒ­ãƒ¼ã‚«ãƒ«å¤‰æ•°ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã•ãªã„ã‚ˆã†ã«ä»•æ§˜å¤‰æ›´
+	@date 2003.06.14 genta æ–‡å­—åˆ—é•·ï¼Œãƒã‚¤ãƒ³ã‚¿ã®ãƒã‚§ãƒƒã‚¯ã‚’è¿½åŠ 
+	@date 2003.06.24 Moca idxãŒ-1ã®ã¨ãã€ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’è¿”ã™.
 	
-	@note idx‚Í³Šm‚È‚à‚Ì‚Å‚È‚¯‚ê‚Î‚È‚ç‚È‚¢B(“à•”‚Å³“–«ƒ`ƒFƒbƒN‚ğs‚Á‚Ä‚¢‚È‚¢)
+	@note idxã¯æ­£ç¢ºãªã‚‚ã®ã§ãªã‘ã‚Œã°ãªã‚‰ãªã„ã€‚(å†…éƒ¨ã§æ­£å½“æ€§ãƒã‚§ãƒƒã‚¯ã‚’è¡Œã£ã¦ã„ãªã„)
 */
 int CShareData::GetMacroFilename( int idx, TCHAR *pszPath, int nBufLen )
 {
@@ -1174,32 +1174,32 @@ int CShareData::GetMacroFilename( int idx, TCHAR *pszPath, int nBufLen )
 	}else{
 		pszFile = m_pShareData->m_Common.m_sMacro.m_MacroTable[idx].m_szFile;
 	}
-	if( pszFile[0] == _T('\0') ){	//	ƒtƒ@ƒCƒ‹–¼‚ª–³‚¢
+	if( pszFile[0] == _T('\0') ){	//	ãƒ•ã‚¡ã‚¤ãƒ«åãŒç„¡ã„
 		if( pszPath != NULL ){
 			pszPath[0] = _T('\0');
 		}
 		return 0;
 	}
 	ptr = pszFile;
-	int nLen = _tcslen( ptr ); // Jul. 21, 2003 genta wcslen‘ÎÛ‚ªŒë‚Á‚Ä‚¢‚½‚½‚ßƒ}ƒNƒÀs‚ª‚Å‚«‚È‚¢
+	int nLen = _tcslen( ptr ); // Jul. 21, 2003 genta wcslenå¯¾è±¡ãŒèª¤ã£ã¦ã„ãŸãŸã‚ãƒã‚¯ãƒ­å®Ÿè¡ŒãŒã§ããªã„
 
-	if( !_IS_REL_PATH( pszFile )	// â‘ÎƒpƒX
-		|| m_pShareData->m_Common.m_sMacro.m_szMACROFOLDER[0] == _T('\0') ){	//	ƒtƒHƒ‹ƒ_w’è‚È‚µ
+	if( !_IS_REL_PATH( pszFile )	// çµ¶å¯¾ãƒ‘ã‚¹
+		|| m_pShareData->m_Common.m_sMacro.m_szMACROFOLDER[0] == _T('\0') ){	//	ãƒ•ã‚©ãƒ«ãƒ€æŒ‡å®šãªã—
 		if( pszPath == NULL || nBufLen <= nLen ){
 			return -nLen;
 		}
 		_tcscpy( pszPath, pszFile );
 		return nLen;
 	}
-	else {	//	ƒtƒHƒ‹ƒ_w’è‚ ‚è
-		//	‘Š‘ÎƒpƒX¨â‘ÎƒpƒX
+	else {	//	ãƒ•ã‚©ãƒ«ãƒ€æŒ‡å®šã‚ã‚Š
+		//	ç›¸å¯¾ãƒ‘ã‚¹â†’çµ¶å¯¾ãƒ‘ã‚¹
 		int nFolderSep = AddLastChar( m_pShareData->m_Common.m_sMacro.m_szMACROFOLDER, _countof2(m_pShareData->m_Common.m_sMacro.m_szMACROFOLDER), _T('\\') );
 		int nAllLen;
 		TCHAR *pszDir;
 		TCHAR szDir[_MAX_PATH + _countof2( m_pShareData->m_Common.m_sMacro.m_szMACROFOLDER )];
 
-		 // 2003.06.24 Moca ƒtƒHƒ‹ƒ_‚à‘Š‘ÎƒpƒX‚È‚çÀsƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX
-		// 2007.05.19 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+		 // 2003.06.24 Moca ãƒ•ã‚©ãƒ«ãƒ€ã‚‚ç›¸å¯¾ãƒ‘ã‚¹ãªã‚‰å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹
+		// 2007.05.19 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 		if( _IS_REL_PATH( m_pShareData->m_Common.m_sMacro.m_szMACROFOLDER ) ){
 			GetInidirOrExedir( szDir, m_pShareData->m_Common.m_sMacro.m_szMACROFOLDER );
 			pszDir = szDir;
@@ -1224,8 +1224,8 @@ int CShareData::GetMacroFilename( int idx, TCHAR *pszPath, int nBufLen )
 
 }
 
-/*!	idx‚Åw’è‚µ‚½ƒ}ƒNƒ‚Ìm_bReloadWhenExecute‚ğæ“¾‚·‚éB
-	idx‚Í³Šm‚È‚à‚Ì‚Å‚È‚¯‚ê‚Î‚È‚ç‚È‚¢B
+/*!	idxã§æŒ‡å®šã—ãŸãƒã‚¯ãƒ­ã®m_bReloadWhenExecuteã‚’å–å¾—ã™ã‚‹ã€‚
+	idxã¯æ­£ç¢ºãªã‚‚ã®ã§ãªã‘ã‚Œã°ãªã‚‰ãªã„ã€‚
 	YAZAKI
 */
 bool CShareData::BeReloadWhenExecuteMacro( int idx )
@@ -1239,53 +1239,53 @@ bool CShareData::BeReloadWhenExecuteMacro( int idx )
 
 
 
-/*!	@brief ‹¤—Lƒƒ‚ƒŠ‰Šú‰»/ƒc[ƒ‹ƒo[
+/*!	@brief å…±æœ‰ãƒ¡ãƒ¢ãƒªåˆæœŸåŒ–/ãƒ„ãƒ¼ãƒ«ãƒãƒ¼
 
-	ƒc[ƒ‹ƒo[ŠÖ˜A‚Ì‰Šú‰»ˆ—
+	ãƒ„ãƒ¼ãƒ«ãƒãƒ¼é–¢é€£ã®åˆæœŸåŒ–å‡¦ç†
 
 	@author genta
-	@date 2005.01.30 genta CShareData::Init()‚©‚ç•ª—£D
-		ˆê‚Â‚¸‚Âİ’è‚µ‚È‚¢‚Åˆê‹C‚Éƒf[ƒ^“]‘—‚·‚é‚æ‚¤‚ÉD
+	@date 2005.01.30 genta CShareData::Init()ã‹ã‚‰åˆ†é›¢ï¼
+		ä¸€ã¤ãšã¤è¨­å®šã—ãªã„ã§ä¸€æ°—ã«ãƒ‡ãƒ¼ã‚¿è»¢é€ã™ã‚‹ã‚ˆã†ã«ï¼
 */
 void CShareData::InitToolButtons(DLLSHAREDATA* pShareData)
 {
-		/* ƒc[ƒ‹ƒo[ƒ{ƒ^ƒ“\‘¢‘Ì */
+		/* ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ãƒœã‚¿ãƒ³æ§‹é€ ä½“ */
 //Sept. 16, 2000 JEPRO
-//	CShareData_new2.cpp‚Å‚Å‚«‚é‚¾‚¯Œn‚²‚Æ‚ÉW‚Ü‚é‚æ‚¤‚ÉƒAƒCƒRƒ“‚Ì‡”Ô‚ğ‘å•‚É“ü‚ê‘Ö‚¦‚½‚Ì‚É”º‚¢ˆÈ‰º‚Ì‰Šúİ’è’l‚ğ•ÏX
-	// 2010.06.26 Moca “à—e‚Í CMenuDrawer::FindToolbarNoFromCommandId ‚Ì–ß‚è’l‚Å‚·
+//	CShareData_new2.cppã§ã§ãã‚‹ã ã‘ç³»ã”ã¨ã«é›†ã¾ã‚‹ã‚ˆã†ã«ã‚¢ã‚¤ã‚³ãƒ³ã®é †ç•ªã‚’å¤§å¹…ã«å…¥ã‚Œæ›¿ãˆãŸã®ã«ä¼´ã„ä»¥ä¸‹ã®åˆæœŸè¨­å®šå€¤ã‚’å¤‰æ›´
+	// 2010.06.26 Moca å†…å®¹ã¯ CMenuDrawer::FindToolbarNoFromCommandId ã®æˆ»ã‚Šå€¤ã§ã™
 	static const int DEFAULT_TOOL_BUTTONS[] = {
-		1,	//V‹Kì¬
-		25,		//ƒtƒ@ƒCƒ‹‚ğŠJ‚­(DropDown)
-		3,		//ã‘‚«•Û‘¶		//Sept. 16, 2000 JEPRO 3¨11‚É•ÏX	//Oct. 25, 2000 11¨3
-		4,		//–¼‘O‚ğ•t‚¯‚Ä•Û‘¶	//Sept. 19, 2000 JEPRO ’Ç‰Á
+		1,	//æ–°è¦ä½œæˆ
+		25,		//ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã(DropDown)
+		3,		//ä¸Šæ›¸ãä¿å­˜		//Sept. 16, 2000 JEPRO 3â†’11ã«å¤‰æ›´	//Oct. 25, 2000 11â†’3
+		4,		//åå‰ã‚’ä»˜ã‘ã¦ä¿å­˜	//Sept. 19, 2000 JEPRO è¿½åŠ 
 		0,
 
-		33,	//Œ³‚É–ß‚·(Undo)	//Sept. 16, 2000 JEPRO 7¨19‚É•ÏX	//Oct. 25, 2000 19¨33
-		34,	//‚â‚è’¼‚µ(Redo)	//Sept. 16, 2000 JEPRO 8¨20‚É•ÏX	//Oct. 25, 2000 20¨34
+		33,	//å…ƒã«æˆ»ã™(Undo)	//Sept. 16, 2000 JEPRO 7â†’19ã«å¤‰æ›´	//Oct. 25, 2000 19â†’33
+		34,	//ã‚„ã‚Šç›´ã—(Redo)	//Sept. 16, 2000 JEPRO 8â†’20ã«å¤‰æ›´	//Oct. 25, 2000 20â†’34
 		0,
 
-		87,	//ˆÚ“®—š—ğ: ‘O‚Ö	//Dec. 24, 2000 JEPRO ’Ç‰Á
-		88,	//ˆÚ“®—š—ğ: Ÿ‚Ö	//Dec. 24, 2000 JEPRO ’Ç‰Á
+		87,	//ç§»å‹•å±¥æ­´: å‰ã¸	//Dec. 24, 2000 JEPRO è¿½åŠ 
+		88,	//ç§»å‹•å±¥æ­´: æ¬¡ã¸	//Dec. 24, 2000 JEPRO è¿½åŠ 
 		0,
 
-		225,	//ŒŸõ		//Sept. 16, 2000 JEPRO 9¨22‚É•ÏX	//Oct. 25, 2000 22¨225
-		226,	//Ÿ‚ğŒŸõ	//Sept. 16, 2000 JEPRO 16¨23‚É•ÏX	//Oct. 25, 2000 23¨226
-		227,	//‘O‚ğŒŸõ	//Sept. 16, 2000 JEPRO 17¨24‚É•ÏX	//Oct. 25, 2000 24¨227
-		228,	//’uŠ·		// Oct. 7, 2000 JEPRO ’Ç‰Á
-		229,	//ŒŸõƒ}[ƒN‚ÌƒNƒŠƒA	//Sept. 16, 2000 JEPRO 41¨25‚É•ÏX(Oct. 7, 2000 25¨26)	//Oct. 25, 2000 25¨229
-		230,	//Grep		//Sept. 16, 2000 JEPRO 14¨31‚É•ÏX	//Oct. 25, 2000 31¨230
-		232,	//ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ	//Dec. 24, 2000 JEPRO ’Ç‰Á
+		225,	//æ¤œç´¢		//Sept. 16, 2000 JEPRO 9â†’22ã«å¤‰æ›´	//Oct. 25, 2000 22â†’225
+		226,	//æ¬¡ã‚’æ¤œç´¢	//Sept. 16, 2000 JEPRO 16â†’23ã«å¤‰æ›´	//Oct. 25, 2000 23â†’226
+		227,	//å‰ã‚’æ¤œç´¢	//Sept. 16, 2000 JEPRO 17â†’24ã«å¤‰æ›´	//Oct. 25, 2000 24â†’227
+		228,	//ç½®æ›		// Oct. 7, 2000 JEPRO è¿½åŠ 
+		229,	//æ¤œç´¢ãƒãƒ¼ã‚¯ã®ã‚¯ãƒªã‚¢	//Sept. 16, 2000 JEPRO 41â†’25ã«å¤‰æ›´(Oct. 7, 2000 25â†’26)	//Oct. 25, 2000 25â†’229
+		230,	//Grep		//Sept. 16, 2000 JEPRO 14â†’31ã«å¤‰æ›´	//Oct. 25, 2000 31â†’230
+		232,	//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ	//Dec. 24, 2000 JEPRO è¿½åŠ 
 		0,
 
-		264,	//ƒ^ƒCƒv•Êİ’èˆê——	//Sept. 16, 2000 JEPRO ’Ç‰Á
-		265,	//ƒ^ƒCƒv•Êİ’è		//Sept. 16, 2000 JEPRO 18¨36‚É•ÏX	//Oct. 25, 2000 36¨265
-		266,	//‹¤’Êİ’è			//Sept. 16, 2000 JEPRO 10¨37‚É•ÏX à–¾‚ğuİ’èƒvƒƒpƒeƒBƒV[ƒgv‚©‚ç•ÏX	//Oct. 25, 2000 37¨266
-		0,		//Oct. 8, 2000 jepro Ÿs‚Ì‚½‚ß‚É’Ç‰Á
-		346,	//ƒRƒ}ƒ“ƒhˆê——	//Oct. 8, 2000 JEPRO ’Ç‰Á
+		264,	//ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šä¸€è¦§	//Sept. 16, 2000 JEPRO è¿½åŠ 
+		265,	//ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š		//Sept. 16, 2000 JEPRO 18â†’36ã«å¤‰æ›´	//Oct. 25, 2000 36â†’265
+		266,	//å…±é€šè¨­å®š			//Sept. 16, 2000 JEPRO 10â†’37ã«å¤‰æ›´ èª¬æ˜ã‚’ã€Œè¨­å®šãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆã€ã‹ã‚‰å¤‰æ›´	//Oct. 25, 2000 37â†’266
+		0,		//Oct. 8, 2000 jepro æ¬¡è¡Œã®ãŸã‚ã«è¿½åŠ 
+		346,	//ã‚³ãƒãƒ³ãƒ‰ä¸€è¦§	//Oct. 8, 2000 JEPRO è¿½åŠ 
 	};
 
-	//	ƒc[ƒ‹ƒo[ƒAƒCƒRƒ“”‚ÌÅ‘å’l‚ğ’´‚¦‚È‚¢‚½‚ß‚Ì‚¨‚Ü‚¶‚È‚¢
-	//	Å‘å’l‚ğ’´‚¦‚Ä’è‹`‚µ‚æ‚¤‚Æ‚·‚é‚Æ‚±‚±‚ÅƒRƒ“ƒpƒCƒ‹ƒGƒ‰[‚É‚È‚è‚Ü‚·D
+	//	ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã‚¢ã‚¤ã‚³ãƒ³æ•°ã®æœ€å¤§å€¤ã‚’è¶…ãˆãªã„ãŸã‚ã®ãŠã¾ã˜ãªã„
+	//	æœ€å¤§å€¤ã‚’è¶…ãˆã¦å®šç¾©ã—ã‚ˆã†ã¨ã™ã‚‹ã¨ã“ã“ã§ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ã‚¨ãƒ©ãƒ¼ã«ãªã‚Šã¾ã™ï¼
 	char dummy[ _countof(DEFAULT_TOOL_BUTTONS) < MAX_TOOLBAR_BUTTON_ITEMS ? 1:0 ];
 	dummy[0]=0;
 
@@ -1295,26 +1295,26 @@ void CShareData::InitToolButtons(DLLSHAREDATA* pShareData)
 		sizeof(DEFAULT_TOOL_BUTTONS)
 	);
 
-	/* ƒc[ƒ‹ƒo[ƒ{ƒ^ƒ“‚Ì” */
+	/* ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ãƒœã‚¿ãƒ³ã®æ•° */
 	pShareData->m_Common.m_sToolBar.m_nToolBarButtonNum = _countof(DEFAULT_TOOL_BUTTONS);
-	pShareData->m_Common.m_sToolBar.m_bToolBarIsFlat = !IsVisualStyle();			/* ƒtƒ‰ƒbƒgƒc[ƒ‹ƒo[‚É‚·‚é^‚µ‚È‚¢ */	// 2006.06.23 ryoji ƒrƒWƒ…ƒAƒ‹ƒXƒ^ƒCƒ‹‚Å‚Í‰Šú’l‚ğƒm[ƒ}ƒ‹‚É‚·‚é
+	pShareData->m_Common.m_sToolBar.m_bToolBarIsFlat = !IsVisualStyle();			/* ãƒ•ãƒ©ãƒƒãƒˆãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã«ã™ã‚‹ï¼ã—ãªã„ */	// 2006.06.23 ryoji ãƒ“ã‚¸ãƒ¥ã‚¢ãƒ«ã‚¹ã‚¿ã‚¤ãƒ«ã§ã¯åˆæœŸå€¤ã‚’ãƒãƒ¼ãƒãƒ«ã«ã™ã‚‹
 	
 }
 
 
-/*!	@brief ‹¤—Lƒƒ‚ƒŠ‰Šú‰»/ƒ|ƒbƒvƒAƒbƒvƒƒjƒ…[
+/*!	@brief å…±æœ‰ãƒ¡ãƒ¢ãƒªåˆæœŸåŒ–/ãƒãƒƒãƒ—ã‚¢ãƒƒãƒ—ãƒ¡ãƒ‹ãƒ¥ãƒ¼
 
-	ƒ|ƒbƒvƒAƒbƒvƒƒjƒ…[‚Ì‰Šú‰»ˆ—
+	ãƒãƒƒãƒ—ã‚¢ãƒƒãƒ—ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®åˆæœŸåŒ–å‡¦ç†
 
-	@date 2005.01.30 genta CShareData::Init()‚©‚ç•ª—£D
+	@date 2005.01.30 genta CShareData::Init()ã‹ã‚‰åˆ†é›¢ï¼
 */
 void CShareData::InitPopupMenu(DLLSHAREDATA* pShareData)
 {
-	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[ ‹K’è’l */
+	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ è¦å®šå€¤ */
 	
 	CommonSetting_CustomMenu& rMenu = m_pShareData->m_Common.m_sCustomMenu;
 
-	/* ‰EƒNƒŠƒbƒNƒƒjƒ…[ */
+	/* å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */
 	int n = 0;
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_UNDO;
 	rMenu.m_nCustMenuItemKeyArr [0][n] = 'U';
@@ -1340,13 +1340,13 @@ void CShareData::InitPopupMenu(DLLSHAREDATA* pShareData)
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_0;
 	rMenu.m_nCustMenuItemKeyArr [0][n] = '\0';
 	n++;
-	rMenu.m_nCustMenuItemFuncArr[0][n] = F_COPY_CRLF;	//Nov. 9, 2000 JEPRO uCRLF‰üs‚ÅƒRƒs[v‚ğ’Ç‰Á
+	rMenu.m_nCustMenuItemFuncArr[0][n] = F_COPY_CRLF;	//Nov. 9, 2000 JEPRO ã€ŒCRLFæ”¹è¡Œã§ã‚³ãƒ”ãƒ¼ã€ã‚’è¿½åŠ 
 	rMenu.m_nCustMenuItemKeyArr [0][n] = 'L';
 	n++;
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_COPY_ADDCRLF;
 	rMenu.m_nCustMenuItemKeyArr [0][n] = 'H';
 	n++;
-	rMenu.m_nCustMenuItemFuncArr[0][n] = F_PASTEBOX;	//Nov. 9, 2000 JEPRO u‹éŒ`“\‚è•t‚¯v‚ğ•œŠˆ
+	rMenu.m_nCustMenuItemFuncArr[0][n] = F_PASTEBOX;	//Nov. 9, 2000 JEPRO ã€ŒçŸ©å½¢è²¼ã‚Šä»˜ã‘ã€ã‚’å¾©æ´»
 	rMenu.m_nCustMenuItemKeyArr [0][n] = 'X';
 	n++;
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_0;
@@ -1356,16 +1356,16 @@ void CShareData::InitPopupMenu(DLLSHAREDATA* pShareData)
 	rMenu.m_nCustMenuItemKeyArr [0][n] = 'A';
 	n++;
 
-	rMenu.m_nCustMenuItemFuncArr[0][n] = F_0;		//Oct. 3, 2000 JEPRO ˆÈ‰º‚Éuƒ^ƒOƒWƒƒƒ“ƒvv‚Æuƒ^ƒOƒWƒƒƒ“ƒvƒoƒbƒNv‚ğ’Ç‰Á
+	rMenu.m_nCustMenuItemFuncArr[0][n] = F_0;		//Oct. 3, 2000 JEPRO ä»¥ä¸‹ã«ã€Œã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã€ã¨ã€Œã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒãƒƒã‚¯ã€ã‚’è¿½åŠ 
 	rMenu.m_nCustMenuItemKeyArr [0][n] = '\0';
 	n++;
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_TAGJUMP;
-	rMenu.m_nCustMenuItemKeyArr [0][n] = 'G';		//Nov. 9, 2000 JEPRO uƒRƒs[v‚ÆƒoƒbƒeƒBƒ“ƒO‚µ‚Ä‚¢‚½ƒAƒNƒZƒXƒL[‚ğ•ÏX(T¨G)
+	rMenu.m_nCustMenuItemKeyArr [0][n] = 'G';		//Nov. 9, 2000 JEPRO ã€Œã‚³ãƒ”ãƒ¼ã€ã¨ãƒãƒƒãƒ†ã‚£ãƒ³ã‚°ã—ã¦ã„ãŸã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã‚’å¤‰æ›´(Tâ†’G)
 	n++;
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_TAGJUMPBACK;
 	rMenu.m_nCustMenuItemKeyArr [0][n] = 'B';
 	n++;
-	rMenu.m_nCustMenuItemFuncArr[0][n] = F_0;		//Oct. 15, 2000 JEPRO ˆÈ‰º‚Éu‘I‘ğ”ÍˆÍ“à‘SsƒRƒs[v‚Æuˆø—p•„•t‚«ƒRƒs[v‚ğ’Ç‰Á
+	rMenu.m_nCustMenuItemFuncArr[0][n] = F_0;		//Oct. 15, 2000 JEPRO ä»¥ä¸‹ã«ã€Œé¸æŠç¯„å›²å†…å…¨è¡Œã‚³ãƒ”ãƒ¼ã€ã¨ã€Œå¼•ç”¨ç¬¦ä»˜ãã‚³ãƒ”ãƒ¼ã€ã‚’è¿½åŠ 
 	rMenu.m_nCustMenuItemKeyArr [0][n] = '\0';
 	n++;
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_COPYLINES;
@@ -1381,18 +1381,18 @@ void CShareData::InitPopupMenu(DLLSHAREDATA* pShareData)
 	rMenu.m_nCustMenuItemKeyArr [0][n] = '\\';
 	n++;
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_PROPERTY_FILE;
-	rMenu.m_nCustMenuItemKeyArr [0][n] = 'F';		//Nov. 9, 2000 JEPRO u‚â‚è’¼‚µv‚ÆƒoƒbƒeƒBƒ“ƒO‚µ‚Ä‚¢‚½ƒAƒNƒZƒXƒL[‚ğ•ÏX(R¨F)
+	rMenu.m_nCustMenuItemKeyArr [0][n] = 'F';		//Nov. 9, 2000 JEPRO ã€Œã‚„ã‚Šç›´ã—ã€ã¨ãƒãƒƒãƒ†ã‚£ãƒ³ã‚°ã—ã¦ã„ãŸã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã‚’å¤‰æ›´(Râ†’F)
 	n++;
 	rMenu.m_nCustMenuItemNumArr[0] = n;
 
-	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[‚P */
+	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ï¼‘ */
 	rMenu.m_nCustMenuItemNumArr[1] = 7;
 	rMenu.m_nCustMenuItemFuncArr[1][0] = F_FILEOPEN;
-	rMenu.m_nCustMenuItemKeyArr [1][0] = 'O';		//Sept. 14, 2000 JEPRO ‚Å‚«‚é‚¾‚¯•W€İ’è’l‚É‡‚í‚¹‚é‚æ‚¤‚É•ÏX (F¨O)
+	rMenu.m_nCustMenuItemKeyArr [1][0] = 'O';		//Sept. 14, 2000 JEPRO ã§ãã‚‹ã ã‘æ¨™æº–è¨­å®šå€¤ã«åˆã‚ã›ã‚‹ã‚ˆã†ã«å¤‰æ›´ (Fâ†’O)
 	rMenu.m_nCustMenuItemFuncArr[1][1] = F_FILESAVE;
 	rMenu.m_nCustMenuItemKeyArr [1][1] = 'S';
 	rMenu.m_nCustMenuItemFuncArr[1][2] = F_NEXTWINDOW;
-	rMenu.m_nCustMenuItemKeyArr [1][2] = 'N';		//Sept. 14, 2000 JEPRO ‚Å‚«‚é‚¾‚¯•W€İ’è’l‚É‡‚í‚¹‚é‚æ‚¤‚É•ÏX (O¨N)
+	rMenu.m_nCustMenuItemKeyArr [1][2] = 'N';		//Sept. 14, 2000 JEPRO ã§ãã‚‹ã ã‘æ¨™æº–è¨­å®šå€¤ã«åˆã‚ã›ã‚‹ã‚ˆã†ã«å¤‰æ›´ (Oâ†’N)
 	rMenu.m_nCustMenuItemFuncArr[1][3] = F_TOLOWER;
 	rMenu.m_nCustMenuItemKeyArr [1][3] = 'L';
 	rMenu.m_nCustMenuItemFuncArr[1][4] = F_TOUPPER;
@@ -1402,7 +1402,7 @@ void CShareData::InitPopupMenu(DLLSHAREDATA* pShareData)
 	rMenu.m_nCustMenuItemFuncArr[1][6] = F_WINCLOSE;
 	rMenu.m_nCustMenuItemKeyArr [1][6] = 'C';
 
-	/* ƒ^ƒuƒƒjƒ…[ */	//@@@ 2003.06.14 MIK
+	/* ã‚¿ãƒ–ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */	//@@@ 2003.06.14 MIK
 	n = 0;
 	rMenu.m_nCustMenuItemFuncArr[CUSTMENU_INDEX_FOR_TABWND][n] = F_FILESAVE;
 	rMenu.m_nCustMenuItemKeyArr [CUSTMENU_INDEX_FOR_TABWND][n] = 'S';
@@ -1458,7 +1458,7 @@ void CShareData::InitPopupMenu(DLLSHAREDATA* pShareData)
 	rMenu.m_nCustMenuItemNumArr[CUSTMENU_INDEX_FOR_TABWND] = n;
 }
 
-/* Œ¾Œê‘I‘ğŒã‚É‹¤—Lƒƒ‚ƒŠ“à‚Ì•¶š—ñ‚ğXV‚·‚é */
+/* è¨€èªé¸æŠå¾Œã«å…±æœ‰ãƒ¡ãƒ¢ãƒªå†…ã®æ–‡å­—åˆ—ã‚’æ›´æ–°ã™ã‚‹ */
 void CShareData::RefreshString()
 {
 

--- a/sakura_core/env/CShareData.h
+++ b/sakura_core/env/CShareData.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒvƒƒZƒXŠÔ‹¤—Lƒf[ƒ^‚Ö‚ÌƒAƒNƒZƒX
+ï»¿/*!	@file
+	@brief ãƒ—ãƒ­ã‚»ã‚¹é–“å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã¸ã®ã‚¢ã‚¯ã‚»ã‚¹
 
 	@author Norio Nakatani
-	@date 1998/05/26  V‹Kì¬
+	@date 1998/05/26  æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -20,13 +20,13 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
-//2007.09.23 kobake m_nSEARCHKEYArrNum,      m_szSEARCHKEYArr      ‚ğ m_aSearchKeys      ‚É‚Ü‚Æ‚ß‚Ü‚µ‚½
-//2007.09.23 kobake m_nREPLACEKEYArrNum,     m_szREPLACEKEYArr     ‚ğ m_aReplaceKeys     ‚É‚Ü‚Æ‚ß‚Ü‚µ‚½
-//2007.09.23 kobake m_nGREPFILEArrNum,       m_szGREPFILEArr       ‚ğ m_aGrepFiles       ‚É‚Ü‚Æ‚ß‚Ü‚µ‚½
-//2007.09.23 kobake m_nGREPFOLDERArrNum,     m_szGREPFOLDERArr     ‚ğ m_aGrepFolders     ‚É‚Ü‚Æ‚ß‚Ü‚µ‚½
-//2007.09.23 kobake m_szCmdArr,              m_nCmdArrNum          ‚ğ m_aCommands        ‚É‚Ü‚Æ‚ß‚Ü‚µ‚½
-//2007.09.23 kobake m_nTagJumpKeywordArrNum, m_szTagJumpKeywordArr ‚ğ m_aTagJumpKeywords ‚É‚Ü‚Æ‚ß‚Ü‚µ‚½
-//2007.12.13 kobake DLLSHAREDATA‚Ö‚ÌŠÈˆÕƒAƒNƒZƒT‚ğ—pˆÓ
+//2007.09.23 kobake m_nSEARCHKEYArrNum,      m_szSEARCHKEYArr      ã‚’ m_aSearchKeys      ã«ã¾ã¨ã‚ã¾ã—ãŸ
+//2007.09.23 kobake m_nREPLACEKEYArrNum,     m_szREPLACEKEYArr     ã‚’ m_aReplaceKeys     ã«ã¾ã¨ã‚ã¾ã—ãŸ
+//2007.09.23 kobake m_nGREPFILEArrNum,       m_szGREPFILEArr       ã‚’ m_aGrepFiles       ã«ã¾ã¨ã‚ã¾ã—ãŸ
+//2007.09.23 kobake m_nGREPFOLDERArrNum,     m_szGREPFOLDERArr     ã‚’ m_aGrepFolders     ã«ã¾ã¨ã‚ã¾ã—ãŸ
+//2007.09.23 kobake m_szCmdArr,              m_nCmdArrNum          ã‚’ m_aCommands        ã«ã¾ã¨ã‚ã¾ã—ãŸ
+//2007.09.23 kobake m_nTagJumpKeywordArrNum, m_szTagJumpKeywordArr ã‚’ m_aTagJumpKeywords ã«ã¾ã¨ã‚ã¾ã—ãŸ
+//2007.12.13 kobake DLLSHAREDATAã¸ã®ç°¡æ˜“ã‚¢ã‚¯ã‚»ã‚µã‚’ç”¨æ„
 
 
 #ifndef SAKURA_ENV_CSHAREDATA_H_
@@ -36,25 +36,25 @@
 
 class CShareData;
 
-// 2010.04.19 Moca DLLSHAREDATAŠÖ˜A‚ÍDLLSHAREDATA.h“™Å’áŒÀ•K—v‚ÈêŠ‚ÖˆÚ“®
-// CShareData.h‚ÍA©•ª‚ÌInterface‚µ‚©’ñ‹Ÿ‚µ‚Ü‚¹‚ñB•Ê‚ÉDLLSHAREDATA.h‚ğinclude‚·‚é‚±‚ÆB
+// 2010.04.19 Moca DLLSHAREDATAé–¢é€£ã¯DLLSHAREDATA.hç­‰æœ€ä½é™å¿…è¦ãªå ´æ‰€ã¸ç§»å‹•
+// CShareData.hã¯ã€è‡ªåˆ†ã®Interfaceã—ã‹æä¾›ã—ã¾ã›ã‚“ã€‚åˆ¥ã«DLLSHAREDATA.hã‚’includeã™ã‚‹ã“ã¨ã€‚
 struct DLLSHAREDATA;
 struct STypeConfig;
 class CMutex;
 
-/*!	@brief ‹¤—Lƒf[ƒ^‚ÌŠÇ—
+/*!	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®ç®¡ç†
 
-	CShareData‚ÍCProcess‚Ìƒƒ“ƒo‚Å‚ ‚é‚½‚ßC—¼Ò‚Ìõ–½‚Í“¯ˆê‚Å‚·D
-	–{—ˆ‚ÍCProcessƒIƒuƒWƒFƒNƒg‚ğ’Ê‚¶‚ÄƒAƒNƒZƒX‚·‚é‚×‚«‚Å‚·‚ªC
-	CProcess“à‚Ìƒf[ƒ^—Ìˆæ‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğstatic•Ï”‚É•Û‘¶‚·‚é‚±‚Æ‚Å
-	Singleton‚Ì‚æ‚¤‚É‚Ç‚±‚©‚ç‚Å‚àƒAƒNƒZƒX‚Å‚«‚é\‘¢‚É‚È‚Á‚Ä‚¢‚Ü‚·D
+	CShareDataã¯CProcessã®ãƒ¡ãƒ³ãƒã§ã‚ã‚‹ãŸã‚ï¼Œä¸¡è€…ã®å¯¿å‘½ã¯åŒä¸€ã§ã™ï¼
+	æœ¬æ¥ã¯CProcessã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’é€šã˜ã¦ã‚¢ã‚¯ã‚»ã‚¹ã™ã‚‹ã¹ãã§ã™ãŒï¼Œ
+	CProcesså†…ã®ãƒ‡ãƒ¼ã‚¿é ˜åŸŸã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’staticå¤‰æ•°ã«ä¿å­˜ã™ã‚‹ã“ã¨ã§
+	Singletonã®ã‚ˆã†ã«ã©ã“ã‹ã‚‰ã§ã‚‚ã‚¢ã‚¯ã‚»ã‚¹ã§ãã‚‹æ§‹é€ ã«ãªã£ã¦ã„ã¾ã™ï¼
 
-	‹¤—Lƒƒ‚ƒŠ‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğm_pShareData‚É•Û‚µ‚Ü‚·D‚±‚Ìƒƒ“ƒo‚Í
-	ŒöŠJ‚³‚ê‚Ä‚¢‚Ü‚·‚ªCCShareData‚É‚æ‚Á‚ÄMap/Unmap‚³‚ê‚é‚½‚ß‚É
-	ChareData‚ÌÁ–Å‚É‚æ‚Á‚Äƒ|ƒCƒ“ƒ^m_pShareData‚à–³Œø‚É‚È‚é‚±‚Æ‚É
-	’ˆÓ‚µ‚Ä‚­‚¾‚³‚¢D
+	å…±æœ‰ãƒ¡ãƒ¢ãƒªã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’m_pShareDataã«ä¿æŒã—ã¾ã™ï¼ã“ã®ãƒ¡ãƒ³ãƒã¯
+	å…¬é–‹ã•ã‚Œã¦ã„ã¾ã™ãŒï¼ŒCShareDataã«ã‚ˆã£ã¦Map/Unmapã•ã‚Œã‚‹ãŸã‚ã«
+	ChareDataã®æ¶ˆæ»…ã«ã‚ˆã£ã¦ãƒã‚¤ãƒ³ã‚¿m_pShareDataã‚‚ç„¡åŠ¹ã«ãªã‚‹ã“ã¨ã«
+	æ³¨æ„ã—ã¦ãã ã•ã„ï¼
 
-	@date 2002.01.03 YAZAKI m_tbMyButton‚È‚Ç‚ğCShareData‚©‚çCMenuDrawer‚ÖˆÚ“®‚µ‚½‚±‚Æ‚É‚æ‚éC³B
+	@date 2002.01.03 YAZAKI m_tbMyButtonãªã©ã‚’CShareDataã‹ã‚‰CMenuDrawerã¸ç§»å‹•ã—ãŸã“ã¨ã«ã‚ˆã‚‹ä¿®æ­£ã€‚
 */
 class CShareData : public TSingleton<CShareData>
 {
@@ -66,43 +66,43 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	bool InitShareData();	/* CShareDataƒNƒ‰ƒX‚Ì‰Šú‰»ˆ— */
-	void RefreshString();	/* Œ¾Œê‘I‘ğŒã‚É‹¤—Lƒƒ‚ƒŠ“à‚Ì•¶š—ñ‚ğXV‚·‚é */
+	bool InitShareData();	/* CShareDataã‚¯ãƒ©ã‚¹ã®åˆæœŸåŒ–å‡¦ç† */
+	void RefreshString();	/* è¨€èªé¸æŠå¾Œã«å…±æœ‰ãƒ¡ãƒ¢ãƒªå†…ã®æ–‡å­—åˆ—ã‚’æ›´æ–°ã™ã‚‹ */
 	
-	//MRUŒn
-	BOOL IsPathOpened( const TCHAR* pszPath, HWND* phwndOwner ); /* w’èƒtƒ@ƒCƒ‹‚ªŠJ‚©‚ê‚Ä‚¢‚é‚©’²‚×‚é */
-	BOOL ActiveAlreadyOpenedWindow( const TCHAR* pszPath, HWND* phwndOwner, ECodeType nCharCode );/* w’èƒtƒ@ƒCƒ‹‚ªŠJ‚©‚ê‚Ä‚¢‚é‚©’²‚×‚Â‚ÂA‘½dƒI[ƒvƒ“‚Ì•¶šƒR[ƒhÕ“Ë‚àŠm”F */	// 2007.03.16
+	//MRUç³»
+	BOOL IsPathOpened( const TCHAR* pszPath, HWND* phwndOwner ); /* æŒ‡å®šãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‹ã‹ã‚Œã¦ã„ã‚‹ã‹èª¿ã¹ã‚‹ */
+	BOOL ActiveAlreadyOpenedWindow( const TCHAR* pszPath, HWND* phwndOwner, ECodeType nCharCode );/* æŒ‡å®šãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‹ã‹ã‚Œã¦ã„ã‚‹ã‹èª¿ã¹ã¤ã¤ã€å¤šé‡ã‚ªãƒ¼ãƒ—ãƒ³æ™‚ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰è¡çªã‚‚ç¢ºèª */	// 2007.03.16
 
-	//ƒfƒoƒbƒO  ¡‚Íå‚Éƒ}ƒNƒEŠO•”ƒRƒ}ƒ“ƒhÀs—p
-	void TraceOut( LPCTSTR lpFmt, ...);	/* ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚Éo—Í(printfƒtƒH[ƒ}ƒbƒg) */
-	void TraceOutString( const wchar_t* pszStr, int len = -1);	/* ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚Éo—Í(–¢‰ÁH•¶š—ñ) */
-	void SetTraceOutSource( HWND hwnd ){ m_hwndTraceOutSource = hwnd; }	/* TraceOut‹N“®Œ³ƒEƒBƒ“ƒhƒE‚Ìİ’è */
-	bool OpenDebugWindow( HWND hwnd, bool bAllwaysActive );	//!<  ƒfƒoƒbƒOƒEƒBƒ“ƒhƒE‚ğŠJ‚­
+	//ãƒ‡ãƒãƒƒã‚°  ä»Šã¯ä¸»ã«ãƒã‚¯ãƒ­ãƒ»å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œç”¨
+	void TraceOut( LPCTSTR lpFmt, ...);	/* ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«å‡ºåŠ›(printfãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ) */
+	void TraceOutString( const wchar_t* pszStr, int len = -1);	/* ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«å‡ºåŠ›(æœªåŠ å·¥æ–‡å­—åˆ—) */
+	void SetTraceOutSource( HWND hwnd ){ m_hwndTraceOutSource = hwnd; }	/* TraceOutèµ·å‹•å…ƒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®è¨­å®š */
+	bool OpenDebugWindow( HWND hwnd, bool bAllwaysActive );	//!<  ãƒ‡ãƒãƒƒã‚°ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã
 
 	BOOL IsPrivateSettings( void );
 
 
-	//ƒ}ƒNƒŠÖ˜A
-	int			GetMacroFilename( int idx, TCHAR* pszPath, int nBufLen ); // idx‚Åw’è‚µ‚½ƒ}ƒNƒƒtƒ@ƒCƒ‹–¼iƒtƒ‹ƒpƒXj‚ğæ“¾‚·‚é	//	Jun. 14, 2003 genta ˆø”’Ç‰ÁD‘®•ÏX
-	bool		BeReloadWhenExecuteMacro( int idx );	//	idx‚Åw’è‚µ‚½ƒ}ƒNƒ‚ÍAÀs‚·‚é‚½‚Ñ‚Éƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Şİ’è‚©H
+	//ãƒã‚¯ãƒ­é–¢é€£
+	int			GetMacroFilename( int idx, TCHAR* pszPath, int nBufLen ); // idxã§æŒ‡å®šã—ãŸãƒã‚¯ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«åï¼ˆãƒ•ãƒ«ãƒ‘ã‚¹ï¼‰ã‚’å–å¾—ã™ã‚‹	//	Jun. 14, 2003 genta å¼•æ•°è¿½åŠ ï¼æ›¸å¼å¤‰æ›´
+	bool		BeReloadWhenExecuteMacro( int idx );	//	idxã§æŒ‡å®šã—ãŸãƒã‚¯ãƒ­ã¯ã€å®Ÿè¡Œã™ã‚‹ãŸã³ã«ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã‚€è¨­å®šã‹ï¼Ÿ
 
-	//ƒ^ƒCƒv•Êİ’è(ƒRƒ“ƒgƒ[ƒ‹ƒvƒƒZƒXê—p)
+	//ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š(ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ãƒ—ãƒ­ã‚»ã‚¹å°‚ç”¨)
 	void CreateTypeSettings();
 	std::vector<STypeConfig*>& GetTypeSettings();
 
-	// ‘Û‰»‘Î‰‚Ì‚½‚ß‚Ì•¶š—ñ‚ğ•ÏX‚·‚é(ƒRƒ“ƒgƒ[ƒ‹ƒvƒƒZƒXê—p)
+	// å›½éš›åŒ–å¯¾å¿œã®ãŸã‚ã®æ–‡å­—åˆ—ã‚’å¤‰æ›´ã™ã‚‹(ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ãƒ—ãƒ­ã‚»ã‚¹å°‚ç”¨)
 	void ConvertLangValues(std::vector<std::wstring>& values, bool bSetValues);
 
 	static CMutex& GetMutexShareWork();
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 
-	//	Jan. 30, 2005 genta ‰Šú‰»ŠÖ”‚Ì•ªŠ„
+	//	Jan. 30, 2005 genta åˆæœŸåŒ–é–¢æ•°ã®åˆ†å‰²
 	void InitKeyword(DLLSHAREDATA*);
-	bool InitKeyAssign(DLLSHAREDATA*); // 2007.11.04 genta ‹N“®’†~‚Ì‚½‚ß’l‚ğ•Ô‚·
+	bool InitKeyAssign(DLLSHAREDATA*); // 2007.11.04 genta èµ·å‹•ä¸­æ­¢ã®ãŸã‚å€¤ã‚’è¿”ã™
 	void RefreshKeyAssignString(DLLSHAREDATA*);
 	void InitToolButtons(DLLSHAREDATA*);
 	void InitTypeConfigs(DLLSHAREDATA*, std::vector<STypeConfig*>&);
@@ -112,11 +112,11 @@ public:
 	static void InitFileTree(SFileTree*);
 
 private:
-	CSelectLang m_cSelectLang;			// ƒƒbƒZ[ƒWƒŠƒ\[ƒXDLL“Ç‚İ‚İ—piƒvƒƒZƒX‚É1ŒÂj		// 2011.04.10 nasukoji
+	CSelectLang m_cSelectLang;			// ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒªã‚½ãƒ¼ã‚¹DLLèª­ã¿è¾¼ã¿ç”¨ï¼ˆãƒ—ãƒ­ã‚»ã‚¹ã«1å€‹ï¼‰		// 2011.04.10 nasukoji
 	HANDLE			m_hFileMap;
 	DLLSHAREDATA*	m_pShareData;
-	std::vector<STypeConfig*>* 	m_pvTypeSettings;	//	(ƒRƒ“ƒgƒ[ƒ‹ƒvƒƒZƒX‚Ì‚İ)
-	HWND			m_hwndTraceOutSource;	// TraceOutA()‹N“®Œ³ƒEƒBƒ“ƒhƒEi‚¢‚¿‚¢‚¿‹N“®Œ³‚ğw’è‚µ‚È‚­‚Ä‚·‚Ş‚æ‚¤‚Éj
+	std::vector<STypeConfig*>* 	m_pvTypeSettings;	//	(ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ãƒ—ãƒ­ã‚»ã‚¹ã®ã¿)
+	HWND			m_hwndTraceOutSource;	// TraceOutA()èµ·å‹•å…ƒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ï¼ˆã„ã¡ã„ã¡èµ·å‹•å…ƒã‚’æŒ‡å®šã—ãªãã¦ã™ã‚€ã‚ˆã†ã«ï¼‰
 
 };
 

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1,4 +1,4 @@
-//2008.XX.XX kobake CShareData‚©‚ç•ª—£
+ï»¿//2008.XX.XX kobake CShareDataã‹ã‚‰åˆ†é›¢
 /*
 	Copyright (C) 2008, kobake
 
@@ -50,25 +50,25 @@ void SetValueLimit(T& target, int maxval)
 	SetValueLimit( target, 0, maxval );
 }
 
-/* ‹¤—Lƒf[ƒ^‚Ìƒ[ƒh */
+/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®ãƒ­ãƒ¼ãƒ‰ */
 bool CShareData_IO::LoadShareData()
 {
 	return ShareData_IO_2( true );
 }
 
-/* ‹¤—Lƒf[ƒ^‚Ì•Û‘¶ */
+/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®ä¿å­˜ */
 void CShareData_IO::SaveShareData()
 {
 	ShareData_IO_2( false );
 }
 
 /*!
-	‹¤—Lƒf[ƒ^‚Ì“Ç‚İ‚İ/•Û‘¶ 2
+	å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®èª­ã¿è¾¼ã¿/ä¿å­˜ 2
 
-	@param[in] bRead true: “Ç‚İ‚İ / false: ‘‚«‚İ
+	@param[in] bRead true: èª­ã¿è¾¼ã¿ / false: æ›¸ãè¾¼ã¿
 
-	@date 2004-01-11 D.S.Koba CProfile•ÏX‚É‚æ‚éƒR[ƒhŠÈ—ª‰»
-	@date 2005-04-05 D.S.Koba ŠeƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í‚ğŠÖ”‚Æ‚µ‚Ä•ª—£
+	@date 2004-01-11 D.S.Koba CProfileå¤‰æ›´ã«ã‚ˆã‚‹ã‚³ãƒ¼ãƒ‰ç°¡ç•¥åŒ–
+	@date 2005-04-05 D.S.Koba å„ã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›ã‚’é–¢æ•°ã¨ã—ã¦åˆ†é›¢
 */
 bool CShareData_IO::ShareData_IO_2( bool bRead )
 {
@@ -86,21 +86,21 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 
 	std::tstring strProfileName = to_tchar(CCommandLine::getInstance()->GetProfileName());
 	TCHAR	szIniFileName[_MAX_PATH + 1];
-	CFileNameManager::getInstance()->GetIniFileName( szIniFileName, strProfileName.c_str(), bRead );	// 2007.05.19 ryoji iniƒtƒ@ƒCƒ‹–¼‚ğæ“¾‚·‚é
+	CFileNameManager::getInstance()->GetIniFileName( szIniFileName, strProfileName.c_str(), bRead );	// 2007.05.19 ryoji iniãƒ•ã‚¡ã‚¤ãƒ«åã‚’å–å¾—ã™ã‚‹
 
-//	MYTRACE( _T("Iniƒtƒ@ƒCƒ‹ˆ—-1 Š—vŠÔ(ƒ~ƒŠ•b) = %d\n"), cRunningTimer.Read() );
+//	MYTRACE( _T("Iniãƒ•ã‚¡ã‚¤ãƒ«å‡¦ç†-1 æ‰€è¦æ™‚é–“(ãƒŸãƒªç§’) = %d\n"), cRunningTimer.Read() );
 
 
 	if( bRead ){
 		if( !cProfile.ReadProfile( szIniFileName ) ){
-			/* İ’èƒtƒ@ƒCƒ‹‚ª‘¶İ‚µ‚È‚¢ */
+			/* è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ãªã„ */
 			return false;
 		}
 
-		// ƒo[ƒWƒ‡ƒ“ƒAƒbƒv‚ÍƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹‚ğì¬‚·‚é	// 2011.01.28 ryoji
+		// ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã‚¢ãƒƒãƒ—æ™‚ã¯ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½œæˆã™ã‚‹	// 2011.01.28 ryoji
 		TCHAR iniVer[256];
 		DWORD mH, mL, lH, lL;
-		mH = mL = lH = lL = 0;	// ¦ ŒÃ`‚¢ ini ‚¾‚Æ "szVersion" ‚Í–³‚¢
+		mH = mL = lH = lL = 0;	// â€» å¤ï½ã„ ini ã ã¨ "szVersion" ã¯ç„¡ã„
 		if( cProfile.IOProfileData( LTEXT("Other"), LTEXT("szVersion"), MakeStringBufferT(iniVer) ) )
 			_stscanf( iniVer, _T("%u.%u.%u.%u"), &mH, &mL, &lH, &lL );
 		DWORD dwMS = (DWORD)MAKELONG(mL, mH);
@@ -115,7 +115,7 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 			::CopyFile(szIniFileName, szBkFileName, FALSE);
 		}
 	}
-//	MYTRACE( _T("Iniƒtƒ@ƒCƒ‹ˆ— 0 Š—vŠÔ(ƒ~ƒŠ•b) = %d\n"), cRunningTimer.Read() );
+//	MYTRACE( _T("Iniãƒ•ã‚¡ã‚¤ãƒ«å‡¦ç† 0 æ‰€è¦æ™‚é–“(ãƒŸãƒªç§’) = %d\n"), cRunningTimer.Read() );
 
 	CMenuDrawer* pcMenuDrawer = new CMenuDrawer; // 2010/7/4 Uchi
 
@@ -151,23 +151,23 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 	pcMenuDrawer = NULL;
 
 	if( !bRead ){
-		// 2014.12.08 sakura.ini‚Ì“Ç‚İæ‚èê—p
+		// 2014.12.08 sakura.iniã®èª­ã¿å–ã‚Šå°‚ç”¨
 		if( !GetDllShareData().m_Common.m_sOthers.m_bIniReadOnly ){
-			cProfile.WriteProfile( szIniFileName, LTEXT(" sakura.ini ƒeƒLƒXƒgƒGƒfƒBƒ^İ’èƒtƒ@ƒCƒ‹") );
+			cProfile.WriteProfile( szIniFileName, LTEXT(" sakura.ini ãƒ†ã‚­ã‚¹ãƒˆã‚¨ãƒ‡ã‚£ã‚¿è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«") );
 		}
 	}
 
-//	MYTRACE( _T("Iniƒtƒ@ƒCƒ‹ˆ— 8 Š—vŠÔ(ƒ~ƒŠ•b) = %d\n"), cRunningTimer.Read() );
-//	MYTRACE( _T("Iniƒtƒ@ƒCƒ‹ˆ— Š—vŠÔ(ƒ~ƒŠ•b) = %d\n"), cRunningTimerStart.Read() );
+//	MYTRACE( _T("Iniãƒ•ã‚¡ã‚¤ãƒ«å‡¦ç† 8 æ‰€è¦æ™‚é–“(ãƒŸãƒªç§’) = %d\n"), cRunningTimer.Read() );
+//	MYTRACE( _T("Iniãƒ•ã‚¡ã‚¤ãƒ«å‡¦ç† æ‰€è¦æ™‚é–“(ãƒŸãƒªç§’) = %d\n"), cRunningTimerStart.Read() );
 
 	return true;
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌMruƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Mruã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B“Ç‚İ‚İ‚Ì‰Šú‰»‚ğC³
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚èª­ã¿è¾¼ã¿æ™‚ã®åˆæœŸåŒ–ã‚’ä¿®æ­£
 */
 void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 {
@@ -202,20 +202,20 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].szMark2"), i );
 		if( !cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pfiWork->m_szMarkLines) ) ){
 			if( cProfile.IsReadingMode() ){
-				auto_sprintf( szKeyName, LTEXT("MRU[%02d].szMark"), i ); // ‹ŒverŒİŠ·
+				auto_sprintf( szKeyName, LTEXT("MRU[%02d].szMark"), i ); // æ—§veräº’æ›
 				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pfiWork->m_szMarkLines) );
 			}
 		}
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].nType"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pfiWork->m_nTypeId );
-		//‚¨‹C‚É“ü‚è	//@@@ 2003.04.08 MIK
+		//ãŠæ°—ã«å…¥ã‚Š	//@@@ 2003.04.08 MIK
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].bFavorite"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_bMRUArrFavorite[i] );
 	}
-	//@@@ 2001.12.26 YAZAKI c‚è‚Ìm_fiMRUArr‚ğ‰Šú‰»B
+	//@@@ 2001.12.26 YAZAKI æ®‹ã‚Šã®m_fiMRUArrã‚’åˆæœŸåŒ–ã€‚
 	if ( cProfile.IsReadingMode() ){
 		EditInfo	fiInit;
-		//	c‚è‚ğfiInit‚Å‰Šú‰»‚µ‚Ä‚¨‚­B
+		//	æ®‹ã‚Šã‚’fiInitã§åˆæœŸåŒ–ã—ã¦ãŠãã€‚
 		fiInit.m_nCharCode = CODE_DEFAULT;
 		fiInit.m_nViewLeftCol = CLayoutInt(0);
 		fiInit.m_nViewTopLine = CLayoutInt(0);
@@ -224,7 +224,7 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		fiInit.m_szMarkLines[0] = L'\0';	// 2002.01.16 hor
 		for( ; i < MAX_MRU; ++i){
 			pShare->m_sHistory.m_fiMRUArr[i] = fiInit;
-			pShare->m_sHistory.m_bMRUArrFavorite[i] = false;	//‚¨‹C‚É“ü‚è	//@@@ 2003.04.08 MIK
+			pShare->m_sHistory.m_bMRUArrFavorite[i] = false;	//ãŠæ°—ã«å…¥ã‚Š	//@@@ 2003.04.08 MIK
 		}
 	}
 
@@ -234,16 +234,16 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, LTEXT("MRUFOLDER[%02d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_szOPENFOLDERArr[i] );
-		//‚¨‹C‚É“ü‚è	//@@@ 2003.04.08 MIK
+		//ãŠæ°—ã«å…¥ã‚Š	//@@@ 2003.04.08 MIK
 		wcscat( szKeyName, LTEXT(".bFavorite") );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_bOPENFOLDERArrFavorite[i] );
 	}
-	//“Ç‚İ‚İ‚Íc‚è‚ğ‰Šú‰»
+	//èª­ã¿è¾¼ã¿æ™‚ã¯æ®‹ã‚Šã‚’åˆæœŸåŒ–
 	if ( cProfile.IsReadingMode() ){
 		for (; i< MAX_OPENFOLDER; ++i){
 			// 2005.04.05 D.S.Koba
 			pShare->m_sHistory.m_szOPENFOLDERArr[i][0] = L'\0';
-			pShare->m_sHistory.m_bOPENFOLDERArrFavorite[i] = false;	//‚¨‹C‚É“ü‚è	//@@@ 2003.04.08 MIK
+			pShare->m_sHistory.m_bOPENFOLDERArrFavorite[i] = false;	//ãŠæ°—ã«å…¥ã‚Š	//@@@ 2003.04.08 MIK
 		}
 	}
 	
@@ -257,10 +257,10 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌKeysƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Keysã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B“Ç‚İ‚İ‚Ì‰Šú‰»‚ğC³
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚èª­ã¿è¾¼ã¿æ™‚ã®åˆæœŸåŒ–ã‚’ä¿®æ­£
 */
 void CShareData_IO::ShareData_IO_Keys( CDataProfile& cProfile )
 {
@@ -289,10 +289,10 @@ void CShareData_IO::ShareData_IO_Keys( CDataProfile& cProfile )
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌGrepƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Grepã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B“Ç‚İ‚İ‚Ì‰Šú‰»‚ğC³
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚èª­ã¿è¾¼ã¿æ™‚ã®åˆæœŸåŒ–ã‚’ä¿®æ­£
 */
 void CShareData_IO::ShareData_IO_Grep( CDataProfile& cProfile )
 {
@@ -321,27 +321,27 @@ void CShareData_IO::ShareData_IO_Grep( CDataProfile& cProfile )
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌFoldersƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Foldersã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
 */
 void CShareData_IO::ShareData_IO_Folders( CDataProfile& cProfile )
 {
 	DLLSHAREDATA* pShare = &GetDllShareData();
 
 	const WCHAR* pszSecName = LTEXT("Folders");
-	/* ƒ}ƒNƒ—pƒtƒHƒ‹ƒ_ */
+	/* ãƒã‚¯ãƒ­ç”¨ãƒ•ã‚©ãƒ«ãƒ€ */
 	cProfile.IOProfileData( pszSecName, LTEXT("szMACROFOLDER"), pShare->m_Common.m_sMacro.m_szMACROFOLDER );
-	/* İ’èƒCƒ“ƒ|[ƒg—pƒtƒHƒ‹ƒ_ */
+	/* è¨­å®šã‚¤ãƒ³ãƒãƒ¼ãƒˆç”¨ãƒ•ã‚©ãƒ«ãƒ€ */
 	cProfile.IOProfileData( pszSecName, LTEXT("szIMPORTFOLDER"), pShare->m_sHistory.m_szIMPORTFOLDER );
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌCmdƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Cmdã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B“Ç‚İ‚İ‚Ì‰Šú‰»‚ğC³
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚èª­ã¿è¾¼ã¿æ™‚ã®åˆæœŸåŒ–ã‚’ä¿®æ­£
 */
 void CShareData_IO::ShareData_IO_Cmd( CDataProfile& cProfile )
 {
@@ -369,10 +369,10 @@ void CShareData_IO::ShareData_IO_Cmd( CDataProfile& cProfile )
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌNicknameƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Nicknameã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B“Ç‚İ‚İ‚Ì‰Šú‰»‚ğC³
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚èª­ã¿è¾¼ã¿æ™‚ã®åˆæœŸåŒ–ã‚’ä¿®æ­£
 */
 void CShareData_IO::ShareData_IO_Nickname( CDataProfile& cProfile )
 {
@@ -393,7 +393,7 @@ void CShareData_IO::ShareData_IO_Nickname( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("To%02d"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferT(pShare->m_Common.m_sFileName.m_szTransformFileNameTo[i]) );
 	}
-	// “Ç‚İ‚İCc‚è‚ğNULL‚ÅÄ‰Šú‰»
+	// èª­ã¿è¾¼ã¿æ™‚ï¼Œæ®‹ã‚Šã‚’NULLã§å†åˆæœŸåŒ–
 	if( cProfile.IsReadingMode() ){
 		for( ; i < MAX_TRANSFORM_FILENAME; i++ ){
 			pShare->m_Common.m_sFileName.m_szTransformFileNameFrom[i][0] = L'\0';
@@ -432,10 +432,10 @@ static bool ShareData_IO_RECT( CDataProfile& cProfile, const WCHAR* pszSecName, 
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌCommonƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Commonã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
 */
 void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 {
@@ -447,7 +447,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 
 	cProfile.IOProfileData( pszSecName, LTEXT("nCaretType")				, common.m_sGeneral.m_nCaretType );
 	//	Oct. 2, 2005 genta
-	//	‰Šú’l‚ğ‘}“üƒ‚[ƒh‚ÉŒÅ’è‚·‚é‚½‚ßCİ’è‚Ì“Ç‚İ‘‚«‚ğ‚â‚ß‚é
+	//	åˆæœŸå€¤ã‚’æŒ¿å…¥ãƒ¢ãƒ¼ãƒ‰ã«å›ºå®šã™ã‚‹ãŸã‚ï¼Œè¨­å®šã®èª­ã¿æ›¸ãã‚’ã‚„ã‚ã‚‹
 	//cProfile.IOProfileData( pszSecName, LTEXT("bIsINSMode")				, common.m_bIsINSMode );
 	cProfile.IOProfileData( pszSecName, LTEXT("bIsFreeCursorMode")		, common.m_sGeneral.m_bIsFreeCursorMode );
 	
@@ -466,7 +466,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("nRepeatedScroll_Smooth")	, common.m_sGeneral.m_nRepeatedScroll_Smooth );
 	cProfile.IOProfileData( pszSecName, LTEXT("nPageScrollByWheel")	, common.m_sGeneral.m_nPageScrollByWheel );					// 2009.01.17 nasukoji
 	cProfile.IOProfileData( pszSecName, LTEXT("nHorizontalScrollByWheel")	, common.m_sGeneral.m_nHorizontalScrollByWheel );	// 2009.01.17 nasukoji
-	cProfile.IOProfileData( pszSecName, LTEXT("bCloseAllConfirm")		, common.m_sGeneral.m_bCloseAllConfirm );	/* [‚·‚×‚Ä•Â‚¶‚é]‚Å‘¼‚É•ÒW—p‚ÌƒEƒBƒ“ƒhƒE‚ª‚ ‚ê‚ÎŠm”F‚·‚é */	// 2006.12.25 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("bCloseAllConfirm")		, common.m_sGeneral.m_bCloseAllConfirm );	/* [ã™ã¹ã¦é–‰ã˜ã‚‹]ã§ä»–ã«ç·¨é›†ç”¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒã‚ã‚Œã°ç¢ºèªã™ã‚‹ */	// 2006.12.25 ryoji
 	cProfile.IOProfileData( pszSecName, LTEXT("bExitConfirm")			, common.m_sGeneral.m_bExitConfirm );
 	cProfile.IOProfileData( pszSecName, LTEXT("bSearchRegularExp")	, common.m_sSearch.m_sSearchOption.bRegularExp );
 	cProfile.IOProfileData( pszSecName, LTEXT("bSearchLoHiCase")		, common.m_sSearch.m_sSearchOption.bLoHiCase );
@@ -485,15 +485,15 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bGrepDefaultFolder")		, common.m_sSearch.m_bGrepDefaultFolder );
 	cProfile.IOProfileData( pszSecName, LTEXT("bGrepBackup")			, common.m_sSearch.m_bGrepBackup );
 	
-	// 2002/09/21 Moca ’Ç‰Á
+	// 2002/09/21 Moca è¿½åŠ 
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nGrepCharSet")	, common.m_sSearch.m_nGrepCharSet );
 	cProfile.IOProfileData( pszSecName, LTEXT("bGrepRealTime")			, common.m_sSearch.m_bGrepRealTimeView ); // 2003.06.16 Moca
-	cProfile.IOProfileData( pszSecName, LTEXT("bCaretTextForSearch")	, common.m_sSearch.m_bCaretTextForSearch );	// 2006.08.23 ryoji ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì•¶š—ñ‚ğƒfƒtƒHƒ‹ƒg‚ÌŒŸõ•¶š—ñ‚É‚·‚é
+	cProfile.IOProfileData( pszSecName, LTEXT("bCaretTextForSearch")	, common.m_sSearch.m_bCaretTextForSearch );	// 2006.08.23 ryoji ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ–‡å­—åˆ—ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®æ¤œç´¢æ–‡å­—åˆ—ã«ã™ã‚‹
 	cProfile.IOProfileData( pszSecName, LTEXT("m_bInheritKeyOtherView")	, common.m_sSearch.m_bInheritKeyOtherView );
 	cProfile.IOProfileData( pszSecName, LTEXT("nTagJumpMode")			, common.m_sSearch.m_nTagJumpMode );
 	cProfile.IOProfileData( pszSecName, LTEXT("nTagJumpModeKeyword")	, common.m_sSearch.m_nTagJumpModeKeyword );
 	
-	/* ³‹K•\Œ»DLL 2007.08.12 genta */
+	/* æ­£è¦è¡¨ç¾DLL 2007.08.12 genta */
 	cProfile.IOProfileData( pszSecName, LTEXT("szRegexpLib")			, MakeStringBufferT(common.m_sSearch.m_szRegexpLib) );
 	cProfile.IOProfileData( pszSecName, LTEXT("bGTJW_RETURN")			, common.m_sSearch.m_bGTJW_RETURN );
 	cProfile.IOProfileData( pszSecName, LTEXT("bGTJW_LDBLCLK")			, common.m_sSearch.m_bGTJW_LDBLCLK );
@@ -506,7 +506,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 		int	nDummy;
 		int	nCharChars;
 		nDummy = _tcslen( common.m_sBackup.m_szBackUpFolder );
-		/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ªu”¼Šp‚©‚Â'\\'v‚Å‚È‚¢ê‡‚ÍA•t‰Á‚·‚é */
+		/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒã€ŒåŠè§’ã‹ã¤'\\'ã€ã§ãªã„å ´åˆã¯ã€ä»˜åŠ ã™ã‚‹ */
 		nCharChars = &common.m_sBackup.m_szBackUpFolder[nDummy]
 			- CNativeT::GetCharPrev( common.m_sBackup.m_szBackUpFolder, nDummy, &common.m_sBackup.m_szBackUpFolder[nDummy] );
 		if( 1 == nCharChars && common.m_sBackup.m_szBackUpFolder[nDummy - 1] == '\\' ){
@@ -519,7 +519,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 		int	nDummy;
 		int	nCharChars;
 		nDummy = _tcslen( common.m_sBackup.m_szBackUpFolder );
-		/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ªu”¼Šp‚©‚Â'\\'v‚Å‚È‚¢ê‡‚ÍA•t‰Á‚·‚é */
+		/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒã€ŒåŠè§’ã‹ã¤'\\'ã€ã§ãªã„å ´åˆã¯ã€ä»˜åŠ ã™ã‚‹ */
 		nCharChars = &common.m_sBackup.m_szBackUpFolder[nDummy]
 			- CNativeT::GetCharPrev( common.m_sBackup.m_szBackUpFolder, nDummy, &common.m_sBackup.m_szBackUpFolder[nDummy] );
 		if( 1 == nCharChars && common.m_sBackup.m_szBackUpFolder[nDummy - 1] == '\\' ){
@@ -560,26 +560,26 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispFUNCKEYWND")		, common.m_sWindow.m_bDispFUNCKEYWND );
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispMiniMap")			, common.m_sWindow.m_bDispMiniMap );
 	cProfile.IOProfileData( pszSecName, LTEXT("nFUNCKEYWND_Place")		, common.m_sWindow.m_nFUNCKEYWND_Place );
-	cProfile.IOProfileData( pszSecName, LTEXT("nFUNCKEYWND_GroupNum")	, common.m_sWindow.m_nFUNCKEYWND_GroupNum );		// 2002/11/04 Moca ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ÌƒOƒ‹[ƒvƒ{ƒ^ƒ“”
+	cProfile.IOProfileData( pszSecName, LTEXT("nFUNCKEYWND_GroupNum")	, common.m_sWindow.m_nFUNCKEYWND_GroupNum );		// 2002/11/04 Moca ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®ã‚°ãƒ«ãƒ¼ãƒ—ãƒœã‚¿ãƒ³æ•°
 	cProfile.IOProfileData( pszSecName, LTEXT("szLanguageDll")			, MakeStringBufferT( common.m_sWindow.m_szLanguageDll ) );
 	cProfile.IOProfileData( pszSecName, LTEXT("nMiniMapFontSize")		, common.m_sWindow.m_nMiniMapFontSize );
 	cProfile.IOProfileData( pszSecName, LTEXT("nMiniMapQuality")		, common.m_sWindow.m_nMiniMapQuality );
 	cProfile.IOProfileData( pszSecName, LTEXT("nMiniMapWidth")			, common.m_sWindow.m_nMiniMapWidth );
 	
-	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabWnd")			, common.m_sTabBar.m_bDispTabWnd );	//ƒ^ƒuƒEƒCƒ“ƒhƒE	//@@@ 2003.05.31 MIK
-	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabWndMultiWin")	, common.m_sTabBar.m_bDispTabWndMultiWin );	//ƒ^ƒuƒEƒCƒ“ƒhƒE	//@@@ 2003.05.31 MIK
+	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabWnd")			, common.m_sTabBar.m_bDispTabWnd );	//ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦	//@@@ 2003.05.31 MIK
+	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabWndMultiWin")	, common.m_sTabBar.m_bDispTabWndMultiWin );	//ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦	//@@@ 2003.05.31 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("szTabWndCaption")		, MakeStringBufferW(common.m_sTabBar.m_szTabWndCaption) );	//@@@ 2003.06.13 MIK
-	cProfile.IOProfileData( pszSecName, LTEXT("bSameTabWidth")			, common.m_sTabBar.m_bSameTabWidth );	// 2006.01.28 ryoji ƒ^ƒu‚ğ“™•‚É‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabIcon")			, common.m_sTabBar.m_bDispTabIcon );	// 2006.01.28 ryoji ƒ^ƒu‚ÉƒAƒCƒRƒ“‚ğ•\¦‚·‚é
+	cProfile.IOProfileData( pszSecName, LTEXT("bSameTabWidth")			, common.m_sTabBar.m_bSameTabWidth );	// 2006.01.28 ryoji ã‚¿ãƒ–ã‚’ç­‰å¹…ã«ã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabIcon")			, common.m_sTabBar.m_bDispTabIcon );	// 2006.01.28 ryoji ã‚¿ãƒ–ã«ã‚¢ã‚¤ã‚³ãƒ³ã‚’è¡¨ç¤ºã™ã‚‹
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bDispTabClose")	, common.m_sTabBar.m_bDispTabClose );	// 2012.04.14 syat
-	cProfile.IOProfileData( pszSecName, LTEXT("bSortTabList")			, common.m_sTabBar.m_bSortTabList );	// 2006.05.10 ryoji ƒ^ƒuˆê——‚ğƒ\[ƒg‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("bTab_RetainEmptyWin")	, common.m_sTabBar.m_bTab_RetainEmptyWin );	// ÅŒã‚Ìƒtƒ@ƒCƒ‹‚ª•Â‚¶‚ç‚ê‚½‚Æ‚«(–³‘è)‚ğc‚·	// 2007.02.11 genta
-	cProfile.IOProfileData( pszSecName, LTEXT("bTab_CloseOneWin")	, common.m_sTabBar.m_bTab_CloseOneWin );	// ƒ^ƒuƒ‚[ƒh‚Å‚àƒEƒBƒ“ƒhƒE‚Ì•Â‚¶‚éƒ{ƒ^ƒ“‚ÅŒ»İ‚Ìƒtƒ@ƒCƒ‹‚Ì‚İ•Â‚¶‚é	// 2007.02.11 genta
-	cProfile.IOProfileData( pszSecName, LTEXT("bTab_ListFull")			, common.m_sTabBar.m_bTab_ListFull );	// ƒ^ƒuˆê——‚ğƒtƒ‹ƒpƒX•\¦‚·‚é	// 2007.02.28 ryoji
-	cProfile.IOProfileData( pszSecName, LTEXT("bChgWndByWheel")		, common.m_sTabBar.m_bChgWndByWheel );	// 2006.03.26 ryoji ƒ}ƒEƒXƒzƒC[ƒ‹‚ÅƒEƒBƒ“ƒhƒEØ‚è‘Ö‚¦
-	cProfile.IOProfileData( pszSecName, LTEXT("bNewWindow")			, common.m_sTabBar.m_bNewWindow );	// ŠO•”‚©‚ç‹N“®‚·‚é‚Æ‚«‚ÍV‚µ‚¢ƒEƒCƒ“ƒhƒE‚ÅŠJ‚­
-	cProfile.IOProfileData( pszSecName, L"bTabMultiLine"			, common.m_sTabBar.m_bTabMultiLine );	// ƒ^ƒu‘½’i
-	cProfile.IOProfileData_WrapInt( pszSecName, L"eTabPosition"		, common.m_sTabBar.m_eTabPosition );	// ƒ^ƒuˆÊ’u
+	cProfile.IOProfileData( pszSecName, LTEXT("bSortTabList")			, common.m_sTabBar.m_bSortTabList );	// 2006.05.10 ryoji ã‚¿ãƒ–ä¸€è¦§ã‚’ã‚½ãƒ¼ãƒˆã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("bTab_RetainEmptyWin")	, common.m_sTabBar.m_bTab_RetainEmptyWin );	// æœ€å¾Œã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‰ã˜ã‚‰ã‚ŒãŸã¨ã(ç„¡é¡Œ)ã‚’æ®‹ã™	// 2007.02.11 genta
+	cProfile.IOProfileData( pszSecName, LTEXT("bTab_CloseOneWin")	, common.m_sTabBar.m_bTab_CloseOneWin );	// ã‚¿ãƒ–ãƒ¢ãƒ¼ãƒ‰ã§ã‚‚ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³ã§ç¾åœ¨ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ã¿é–‰ã˜ã‚‹	// 2007.02.11 genta
+	cProfile.IOProfileData( pszSecName, LTEXT("bTab_ListFull")			, common.m_sTabBar.m_bTab_ListFull );	// ã‚¿ãƒ–ä¸€è¦§ã‚’ãƒ•ãƒ«ãƒ‘ã‚¹è¡¨ç¤ºã™ã‚‹	// 2007.02.28 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("bChgWndByWheel")		, common.m_sTabBar.m_bChgWndByWheel );	// 2006.03.26 ryoji ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã§ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ‡ã‚Šæ›¿ãˆ
+	cProfile.IOProfileData( pszSecName, LTEXT("bNewWindow")			, common.m_sTabBar.m_bNewWindow );	// å¤–éƒ¨ã‹ã‚‰èµ·å‹•ã™ã‚‹ã¨ãã¯æ–°ã—ã„ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã§é–‹ã
+	cProfile.IOProfileData( pszSecName, L"bTabMultiLine"			, common.m_sTabBar.m_bTabMultiLine );	// ã‚¿ãƒ–å¤šæ®µ
+	cProfile.IOProfileData_WrapInt( pszSecName, L"eTabPosition"		, common.m_sTabBar.m_eTabPosition );	// ã‚¿ãƒ–ä½ç½®
 
 	ShareData_IO_Sub_LogFont( cProfile, pszSecName, L"lfTabFont", L"lfTabFontPs", L"lfTabFaceName",
 		common.m_sTabBar.m_lf, common.m_sTabBar.m_nPointSize );
@@ -588,22 +588,22 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("nTabMinWidth")			, common.m_sTabBar.m_nTabMinWidth );
 	cProfile.IOProfileData( pszSecName, LTEXT("nTabMinWidthOnMulti")	, common.m_sTabBar.m_nTabMinWidthOnMulti );
 
-	// 2001/06/20 asa-o •ªŠ„ƒEƒBƒ“ƒhƒE‚ÌƒXƒNƒ[ƒ‹‚Ì“¯Šú‚ğ‚Æ‚é
+	// 2001/06/20 asa-o åˆ†å‰²ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸã‚’ã¨ã‚‹
 	cProfile.IOProfileData( pszSecName, LTEXT("bSplitterWndHScroll")	, common.m_sWindow.m_bSplitterWndHScroll );
 	cProfile.IOProfileData( pszSecName, LTEXT("bSplitterWndVScroll")	, common.m_sWindow.m_bSplitterWndVScroll );
 	
 	cProfile.IOProfileData( pszSecName, LTEXT("szMidashiKigou")		, MakeStringBufferW(common.m_sFormat.m_szMidashiKigou) );
 	cProfile.IOProfileData( pszSecName, LTEXT("szInyouKigou")			, MakeStringBufferW(common.m_sFormat.m_szInyouKigou) );
 	
-	// 2001/06/14 asa-o •âŠ®‚ÆƒL[ƒ[ƒhƒwƒ‹ƒv‚Íƒ^ƒCƒv•Ê‚ÉˆÚ“®‚µ‚½‚Ì‚ÅíœF‚Rs
-	// 2002/09/21 Moca bGrepKanjiCode_AutoDetect ‚Í bGrepCharSet‚É“‡‚µ‚½‚Ì‚Åíœ
-	// 2001/06/19 asa-o ƒ^ƒCƒv•Ê‚ÉˆÚ“®‚µ‚½‚Ì‚ÅíœF1s
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bSaveWindowSize"), common.m_sWindow.m_eSaveWindowSize );	//#####ƒtƒ‰ƒO–¼‚ªŒƒ‚µ‚­‚«‚à‚¢
+	// 2001/06/14 asa-o è£œå®Œã¨ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã¯ã‚¿ã‚¤ãƒ—åˆ¥ã«ç§»å‹•ã—ãŸã®ã§å‰Šé™¤ï¼šï¼“è¡Œ
+	// 2002/09/21 Moca bGrepKanjiCode_AutoDetect ã¯ bGrepCharSetã«çµ±åˆã—ãŸã®ã§å‰Šé™¤
+	// 2001/06/19 asa-o ã‚¿ã‚¤ãƒ—åˆ¥ã«ç§»å‹•ã—ãŸã®ã§å‰Šé™¤ï¼š1è¡Œ
+	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bSaveWindowSize"), common.m_sWindow.m_eSaveWindowSize );	//#####ãƒ•ãƒ©ã‚°åãŒæ¿€ã—ããã‚‚ã„
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinSizeType")			, common.m_sWindow.m_nWinSizeType );
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinSizeCX")				, common.m_sWindow.m_nWinSizeCX );
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinSizeCY")				, common.m_sWindow.m_nWinSizeCY );
-	// 2004.03.30 Moca *nWinPos*‚ğ’Ç‰Á
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nSaveWindowPos")	, common.m_sWindow.m_eSaveWindowPos );	//#####ƒtƒ‰ƒO–¼‚ª‚«‚à‚¢
+	// 2004.03.30 Moca *nWinPos*ã‚’è¿½åŠ 
+	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nSaveWindowPos")	, common.m_sWindow.m_eSaveWindowPos );	//#####ãƒ•ãƒ©ã‚°åãŒãã‚‚ã„
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinPosX")				, common.m_sWindow.m_nWinPosX );
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinPosY")				, common.m_sWindow.m_nWinPosY );
 	cProfile.IOProfileData( pszSecName, LTEXT("bTaskTrayUse")			, common.m_sGeneral.m_bUseTaskTray );
@@ -616,59 +616,59 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispExitingDialog")			, common.m_sGeneral.m_bDispExitingDialog );
 	cProfile.IOProfileData( pszSecName, LTEXT("bEnableUnmodifiedOverwrite")	, common.m_sFile.m_bEnableUnmodifiedOverwrite );
 	cProfile.IOProfileData( pszSecName, LTEXT("bSelectClickedURL")			, common.m_sEdit.m_bSelectClickedURL );
-	cProfile.IOProfileData( pszSecName, LTEXT("bGrepExitConfirm")			, common.m_sSearch.m_bGrepExitConfirm );/* Grepƒ‚[ƒh‚Å•Û‘¶Šm”F‚·‚é‚© */
-//	cProfile.IOProfileData( pszSecName, LTEXT("bRulerDisp")					, common.m_bRulerDisp );/* ƒ‹[ƒ‰[•\¦ */
-	cProfile.IOProfileData( pszSecName, LTEXT("nRulerHeight")				, common.m_sWindow.m_nRulerHeight );/* ƒ‹[ƒ‰[‚‚³ */
-	cProfile.IOProfileData( pszSecName, LTEXT("nRulerBottomSpace")			, common.m_sWindow.m_nRulerBottomSpace );/* ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ */
-	cProfile.IOProfileData( pszSecName, LTEXT("nRulerType")					, common.m_sWindow.m_nRulerType );/* ƒ‹[ƒ‰[‚Ìƒ^ƒCƒv */
-	//	Sep. 18, 2002 genta ’Ç‰Á
-	cProfile.IOProfileData( pszSecName, LTEXT("nLineNumberRightSpace")		, common.m_sWindow.m_nLineNumRightSpace );/* s”Ô†‚Ì‰E‘¤‚ÌŒ„ŠÔ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bGrepExitConfirm")			, common.m_sSearch.m_bGrepExitConfirm );/* Grepãƒ¢ãƒ¼ãƒ‰ã§ä¿å­˜ç¢ºèªã™ã‚‹ã‹ */
+//	cProfile.IOProfileData( pszSecName, LTEXT("bRulerDisp")					, common.m_bRulerDisp );/* ãƒ«ãƒ¼ãƒ©ãƒ¼è¡¨ç¤º */
+	cProfile.IOProfileData( pszSecName, LTEXT("nRulerHeight")				, common.m_sWindow.m_nRulerHeight );/* ãƒ«ãƒ¼ãƒ©ãƒ¼é«˜ã• */
+	cProfile.IOProfileData( pszSecName, LTEXT("nRulerBottomSpace")			, common.m_sWindow.m_nRulerBottomSpace );/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“ */
+	cProfile.IOProfileData( pszSecName, LTEXT("nRulerType")					, common.m_sWindow.m_nRulerType );/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚¿ã‚¤ãƒ— */
+	//	Sep. 18, 2002 genta è¿½åŠ 
+	cProfile.IOProfileData( pszSecName, LTEXT("nLineNumberRightSpace")		, common.m_sWindow.m_nLineNumRightSpace );/* è¡Œç•ªå·ã®å³å´ã®éš™é–“ */
 	cProfile.IOProfileData( pszSecName, LTEXT("nVertLineOffset")			, common.m_sWindow.m_nVertLineOffset ); // 2005.11.10 Moca
 	cProfile.IOProfileData( pszSecName, LTEXT("bUseCompotibleBMP")			, common.m_sWindow.m_bUseCompatibleBMP ); // 2007.09.09 Moca
-	cProfile.IOProfileData( pszSecName, LTEXT("bCopyAndDisablSelection")	, common.m_sEdit.m_bCopyAndDisablSelection );/* ƒRƒs[‚µ‚½‚ç‘I‘ğ‰ğœ */
-	cProfile.IOProfileData( pszSecName, LTEXT("bEnableNoSelectCopy")		, common.m_sEdit.m_bEnableNoSelectCopy );/* ‘I‘ğ‚È‚µ‚ÅƒRƒs[‚ğ‰Â”\‚É‚·‚é */	// 2007.11.18 ryoji
-	cProfile.IOProfileData( pszSecName, LTEXT("bEnableLineModePaste")		, common.m_sEdit.m_bEnableLineModePaste );/* ƒ‰ƒCƒ“ƒ‚[ƒh“\‚è•t‚¯‚ğ‰Â”\‚É‚·‚é */	// 2007.10.08 ryoji
-	cProfile.IOProfileData( pszSecName, LTEXT("bConvertEOLPaste")			, common.m_sEdit.m_bConvertEOLPaste );	/* ‰üsƒR[ƒh‚ğ•ÏŠ·‚µ‚Ä“\‚è•t‚¯‚é */	// 2009.02.28 salarm
+	cProfile.IOProfileData( pszSecName, LTEXT("bCopyAndDisablSelection")	, common.m_sEdit.m_bCopyAndDisablSelection );/* ã‚³ãƒ”ãƒ¼ã—ãŸã‚‰é¸æŠè§£é™¤ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bEnableNoSelectCopy")		, common.m_sEdit.m_bEnableNoSelectCopy );/* é¸æŠãªã—ã§ã‚³ãƒ”ãƒ¼ã‚’å¯èƒ½ã«ã™ã‚‹ */	// 2007.11.18 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("bEnableLineModePaste")		, common.m_sEdit.m_bEnableLineModePaste );/* ãƒ©ã‚¤ãƒ³ãƒ¢ãƒ¼ãƒ‰è²¼ã‚Šä»˜ã‘ã‚’å¯èƒ½ã«ã™ã‚‹ */	// 2007.10.08 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("bConvertEOLPaste")			, common.m_sEdit.m_bConvertEOLPaste );	/* æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’å¤‰æ›ã—ã¦è²¼ã‚Šä»˜ã‘ã‚‹ */	// 2009.02.28 salarm
 	cProfile.IOProfileData( pszSecName, LTEXT("bEnableExtEol")				, common.m_sEdit.m_bEnableExtEol );
 	
-	cProfile.IOProfileData( pszSecName, LTEXT("bHtmlHelpIsSingle")			, common.m_sHelper.m_bHtmlHelpIsSingle );/* HtmlHelpƒrƒ…[ƒA‚Í‚Ğ‚Æ‚Â */
-	cProfile.IOProfileData( pszSecName, LTEXT("bCompareAndTileHorz")		, common.m_sCompare.m_bCompareAndTileHorz );/* •¶‘”äŠrŒãA¶‰E‚É•À‚×‚Ä•\¦ */	//Oct. 10, 2000 JEPRO ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ğƒ{ƒ^ƒ“‰»‚·‚ê‚Î‚±‚Ìs‚Í•s—v‚Ì‚Í‚¸
-	cProfile.IOProfileData( pszSecName, LTEXT("bDropFileAndClose")			, common.m_sFile.m_bDropFileAndClose );/* ƒtƒ@ƒCƒ‹‚ğƒhƒƒbƒv‚µ‚½‚Æ‚«‚Í•Â‚¶‚ÄŠJ‚­ */
-	cProfile.IOProfileData( pszSecName, LTEXT("nDropFileNumMax")			, common.m_sFile.m_nDropFileNumMax );/* ˆê“x‚Éƒhƒƒbƒv‰Â”\‚Èƒtƒ@ƒCƒ‹” */
-	cProfile.IOProfileData( pszSecName, LTEXT("bCheckFileTimeStamp")		, common.m_sFile.m_bCheckFileTimeStamp );/* XV‚ÌŠÄ‹ */
-	cProfile.IOProfileData( pszSecName, LTEXT("nAutoloadDelay")				, common.m_sFile.m_nAutoloadDelay );/* ©“®“Ç’x‰„ */
-	cProfile.IOProfileData( pszSecName, LTEXT("bUneditableIfUnwritable")	, common.m_sFile.m_bUneditableIfUnwritable );/* ã‘‚«‹Ö~ŒŸo‚Í•ÒW‹Ö~‚É‚·‚é */
-	cProfile.IOProfileData( pszSecName, LTEXT("bNotOverWriteCRLF")			, common.m_sEdit.m_bNotOverWriteCRLF );/* ‰üs‚Íã‘‚«‚µ‚È‚¢ */
-	cProfile.IOProfileData( pszSecName, LTEXT("bOverWriteFixMode")			, common.m_sEdit.m_bOverWriteFixMode );// •¶š•‚É‡‚í‚¹‚ÄƒXƒy[ƒX‚ğ‹l‚ß‚é
+	cProfile.IOProfileData( pszSecName, LTEXT("bHtmlHelpIsSingle")			, common.m_sHelper.m_bHtmlHelpIsSingle );/* HtmlHelpãƒ“ãƒ¥ãƒ¼ã‚¢ã¯ã²ã¨ã¤ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bCompareAndTileHorz")		, common.m_sCompare.m_bCompareAndTileHorz );/* æ–‡æ›¸æ¯”è¼ƒå¾Œã€å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º */	//Oct. 10, 2000 JEPRO ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã‚’ãƒœã‚¿ãƒ³åŒ–ã™ã‚Œã°ã“ã®è¡Œã¯ä¸è¦ã®ã¯ãš
+	cProfile.IOProfileData( pszSecName, LTEXT("bDropFileAndClose")			, common.m_sFile.m_bDropFileAndClose );/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ãƒ‰ãƒ­ãƒƒãƒ—ã—ãŸã¨ãã¯é–‰ã˜ã¦é–‹ã */
+	cProfile.IOProfileData( pszSecName, LTEXT("nDropFileNumMax")			, common.m_sFile.m_nDropFileNumMax );/* ä¸€åº¦ã«ãƒ‰ãƒ­ãƒƒãƒ—å¯èƒ½ãªãƒ•ã‚¡ã‚¤ãƒ«æ•° */
+	cProfile.IOProfileData( pszSecName, LTEXT("bCheckFileTimeStamp")		, common.m_sFile.m_bCheckFileTimeStamp );/* æ›´æ–°ã®ç›£è¦– */
+	cProfile.IOProfileData( pszSecName, LTEXT("nAutoloadDelay")				, common.m_sFile.m_nAutoloadDelay );/* è‡ªå‹•èª­è¾¼æ™‚é…å»¶ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bUneditableIfUnwritable")	, common.m_sFile.m_bUneditableIfUnwritable );/* ä¸Šæ›¸ãç¦æ­¢æ¤œå‡ºæ™‚ã¯ç·¨é›†ç¦æ­¢ã«ã™ã‚‹ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bNotOverWriteCRLF")			, common.m_sEdit.m_bNotOverWriteCRLF );/* æ”¹è¡Œã¯ä¸Šæ›¸ãã—ãªã„ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bOverWriteFixMode")			, common.m_sEdit.m_bOverWriteFixMode );// æ–‡å­—å¹…ã«åˆã‚ã›ã¦ã‚¹ãƒšãƒ¼ã‚¹ã‚’è©°ã‚ã‚‹
 	cProfile.IOProfileData( pszSecName, LTEXT("bOverWriteBoxDelete")		, common.m_sEdit.m_bOverWriteBoxDelete );
-	cProfile.IOProfileData( pszSecName, LTEXT("bAutoCloseDlgFind")			, common.m_sSearch.m_bAutoCloseDlgFind );/* ŒŸõƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é */
-	cProfile.IOProfileData( pszSecName, LTEXT("bAutoCloseDlgFuncList")		, common.m_sOutline.m_bAutoCloseDlgFuncList );/* ƒAƒEƒgƒ‰ƒCƒ“ ƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é */
-	cProfile.IOProfileData( pszSecName, LTEXT("bAutoCloseDlgReplace")		, common.m_sSearch.m_bAutoCloseDlgReplace );/* ’uŠ· ƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é */
-	cProfile.IOProfileData( pszSecName, LTEXT("bAutoColmnPaste")			, common.m_sEdit.m_bAutoColumnPaste );/* ‹éŒ`ƒRƒs[‚ÌƒeƒLƒXƒg‚Íí‚É‹éŒ`“\‚è•t‚¯ */ // 2013.5.23 aroka iniƒtƒ@ƒCƒ‹‚Ìtypo–¢C³
-	cProfile.IOProfileData( pszSecName, LTEXT("NoCaretMoveByActivation")	, common.m_sGeneral.m_bNoCaretMoveByActivation );/* ƒ}ƒEƒXƒNƒŠƒbƒN‚É‚ÄƒAƒNƒeƒBƒx[ƒg‚³‚ê‚½‚ÍƒJ[ƒ\ƒ‹ˆÊ’u‚ğˆÚ“®‚µ‚È‚¢ 2007.10.02 nasukoji (add by genta) */
-	cProfile.IOProfileData( pszSecName, LTEXT("bScrollBarHorz")				, common.m_sWindow.m_bScrollBarHorz );/* …•½ƒXƒNƒ[ƒ‹ƒo[‚ğg‚¤ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bAutoCloseDlgFind")			, common.m_sSearch.m_bAutoCloseDlgFind );/* æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bAutoCloseDlgFuncList")		, common.m_sOutline.m_bAutoCloseDlgFuncList );/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bAutoCloseDlgReplace")		, common.m_sSearch.m_bAutoCloseDlgReplace );/* ç½®æ› ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bAutoColmnPaste")			, common.m_sEdit.m_bAutoColumnPaste );/* çŸ©å½¢ã‚³ãƒ”ãƒ¼ã®ãƒ†ã‚­ã‚¹ãƒˆã¯å¸¸ã«çŸ©å½¢è²¼ã‚Šä»˜ã‘ */ // 2013.5.23 aroka iniãƒ•ã‚¡ã‚¤ãƒ«ã®typoæœªä¿®æ­£
+	cProfile.IOProfileData( pszSecName, LTEXT("NoCaretMoveByActivation")	, common.m_sGeneral.m_bNoCaretMoveByActivation );/* ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯ã«ã¦ã‚¢ã‚¯ãƒ†ã‚£ãƒ™ãƒ¼ãƒˆã•ã‚ŒãŸæ™‚ã¯ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’ç§»å‹•ã—ãªã„ 2007.10.02 nasukoji (add by genta) */
+	cProfile.IOProfileData( pszSecName, LTEXT("bScrollBarHorz")				, common.m_sWindow.m_bScrollBarHorz );/* æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã‚’ä½¿ã† */
 
-	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_RETURN")			, common.m_sHelper.m_bHokanKey_RETURN );/* VK_RETURN •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø */
-	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_TAB")				, common.m_sHelper.m_bHokanKey_TAB );/* VK_TAB    •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø */
-	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_RIGHT")			, common.m_sHelper.m_bHokanKey_RIGHT );/* VK_RIGHT  •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø */
-	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_SPACE")			, common.m_sHelper.m_bHokanKey_SPACE );/* VK_SPACE  •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø */
+	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_RETURN")			, common.m_sHelper.m_bHokanKey_RETURN );/* VK_RETURN è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_TAB")				, common.m_sHelper.m_bHokanKey_TAB );/* VK_TAB    è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_RIGHT")			, common.m_sHelper.m_bHokanKey_RIGHT );/* VK_RIGHT  è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹ */
+	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_SPACE")			, common.m_sHelper.m_bHokanKey_SPACE );/* VK_SPACE  è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹ */
 	
-	cProfile.IOProfileData( pszSecName, LTEXT("nDateFormatType")			, common.m_sFormat.m_nDateFormatType );/* “ú•t‘®‚Ìƒ^ƒCƒv */
-	cProfile.IOProfileData( pszSecName, LTEXT("szDateFormat")				, MakeStringBufferT(common.m_sFormat.m_szDateFormat) );//“ú•t‘®
-	cProfile.IOProfileData( pszSecName, LTEXT("nTimeFormatType")			, common.m_sFormat.m_nTimeFormatType );/* ‘®‚Ìƒ^ƒCƒv */
-	cProfile.IOProfileData( pszSecName, LTEXT("szTimeFormat")				, MakeStringBufferT(common.m_sFormat.m_szTimeFormat) );//‘®
+	cProfile.IOProfileData( pszSecName, LTEXT("nDateFormatType")			, common.m_sFormat.m_nDateFormatType );/* æ—¥ä»˜æ›¸å¼ã®ã‚¿ã‚¤ãƒ— */
+	cProfile.IOProfileData( pszSecName, LTEXT("szDateFormat")				, MakeStringBufferT(common.m_sFormat.m_szDateFormat) );//æ—¥ä»˜æ›¸å¼
+	cProfile.IOProfileData( pszSecName, LTEXT("nTimeFormatType")			, common.m_sFormat.m_nTimeFormatType );/* æ™‚åˆ»æ›¸å¼ã®ã‚¿ã‚¤ãƒ— */
+	cProfile.IOProfileData( pszSecName, LTEXT("szTimeFormat")				, MakeStringBufferT(common.m_sFormat.m_szTimeFormat) );//æ™‚åˆ»æ›¸å¼
 	
-	cProfile.IOProfileData( pszSecName, LTEXT("bMenuIcon")					, common.m_sWindow.m_bMenuIcon );//ƒƒjƒ…[‚ÉƒAƒCƒRƒ“‚ğ•\¦‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("bAutoMIMEdecode")			, common.m_sFile.m_bAutoMIMEdecode );//ƒtƒ@ƒCƒ‹“Ç‚İ‚İ‚ÉMIME‚Ìdecode‚ğs‚¤‚©
-	cProfile.IOProfileData( pszSecName, LTEXT("bQueryIfCodeChange")			, common.m_sFile.m_bQueryIfCodeChange );//	Oct. 03, 2004 genta ‘O‰ñ‚ÆˆÙ‚È‚é•¶šƒR[ƒh‚Ì‚Æ‚«‚É–â‚¢‡‚í‚¹‚ğs‚¤‚©
-	cProfile.IOProfileData( pszSecName, LTEXT("bAlertIfFileNotExist")		, common.m_sFile.m_bAlertIfFileNotExist );// Oct. 09, 2004 genta ŠJ‚±‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹‚ª‘¶İ‚µ‚È‚¢‚Æ‚«Œx‚·‚é
+	cProfile.IOProfileData( pszSecName, LTEXT("bMenuIcon")					, common.m_sWindow.m_bMenuIcon );//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«ã‚¢ã‚¤ã‚³ãƒ³ã‚’è¡¨ç¤ºã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("bAutoMIMEdecode")			, common.m_sFile.m_bAutoMIMEdecode );//ãƒ•ã‚¡ã‚¤ãƒ«èª­ã¿è¾¼ã¿æ™‚ã«MIMEã®decodeã‚’è¡Œã†ã‹
+	cProfile.IOProfileData( pszSecName, LTEXT("bQueryIfCodeChange")			, common.m_sFile.m_bQueryIfCodeChange );//	Oct. 03, 2004 genta å‰å›ã¨ç•°ãªã‚‹æ–‡å­—ã‚³ãƒ¼ãƒ‰ã®ã¨ãã«å•ã„åˆã‚ã›ã‚’è¡Œã†ã‹
+	cProfile.IOProfileData( pszSecName, LTEXT("bAlertIfFileNotExist")		, common.m_sFile.m_bAlertIfFileNotExist );// Oct. 09, 2004 genta é–‹ã“ã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ãªã„ã¨ãè­¦å‘Šã™ã‚‹
 	
-	cProfile.IOProfileData( pszSecName, LTEXT("bNoFilterSaveNew")			, common.m_sFile.m_bNoFilterSaveNew );	// V‹K‚©‚ç•Û‘¶‚Í‘Sƒtƒ@ƒCƒ‹•\¦	// 2006.11.16 ryoji
-	cProfile.IOProfileData( pszSecName, LTEXT("bNoFilterSaveFile")			, common.m_sFile.m_bNoFilterSaveFile );	// V‹KˆÈŠO‚©‚ç•Û‘¶‚Í‘Sƒtƒ@ƒCƒ‹•\¦	// 2006.11.16 ryoji
-	cProfile.IOProfileData( pszSecName, LTEXT("bAlertIfLargeFile")			, common.m_sFile.m_bAlertIfLargeFile );	// ŠJ‚±‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹‚ª‘å‚«‚¢ê‡‚ÉŒx‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("nAlertFileSize")				, common.m_sFile.m_nAlertFileSize );	// Œx‚ğŠJn‚·‚éƒtƒ@ƒCƒ‹ƒTƒCƒY(MB’PˆÊ)
+	cProfile.IOProfileData( pszSecName, LTEXT("bNoFilterSaveNew")			, common.m_sFile.m_bNoFilterSaveNew );	// æ–°è¦ã‹ã‚‰ä¿å­˜æ™‚ã¯å…¨ãƒ•ã‚¡ã‚¤ãƒ«è¡¨ç¤º	// 2006.11.16 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("bNoFilterSaveFile")			, common.m_sFile.m_bNoFilterSaveFile );	// æ–°è¦ä»¥å¤–ã‹ã‚‰ä¿å­˜æ™‚ã¯å…¨ãƒ•ã‚¡ã‚¤ãƒ«è¡¨ç¤º	// 2006.11.16 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("bAlertIfLargeFile")			, common.m_sFile.m_bAlertIfLargeFile );	// é–‹ã“ã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ãŒå¤§ãã„å ´åˆã«è­¦å‘Šã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("nAlertFileSize")				, common.m_sFile.m_nAlertFileSize );	// è­¦å‘Šã‚’é–‹å§‹ã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ã‚µã‚¤ã‚º(MBå˜ä½)
 	
-	/* uŠJ‚­vƒ_ƒCƒAƒƒO‚ÌƒTƒCƒY‚ÆˆÊ’u */
+	/* ã€Œé–‹ãã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚µã‚¤ã‚ºã¨ä½ç½® */
 	ShareData_IO_RECT( cProfile,  pszSecName, LTEXT("rcOpenDialog"), common.m_sOthers.m_rcOpenDialog );
 	ShareData_IO_RECT( cProfile,  pszSecName, LTEXT("rcCompareDialog"), common.m_sOthers.m_rcCompareDialog );
 	ShareData_IO_RECT( cProfile,  pszSecName, LTEXT("rcDiffDialog"), common.m_sOthers.m_rcDiffDialog );
@@ -680,11 +680,11 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bMarkUpBlankLineEnable")	, common.m_sOutline.m_bMarkUpBlankLineEnable );
 	cProfile.IOProfileData( pszSecName, LTEXT("bFunclistSetFocusOnJump")	, common.m_sOutline.m_bFunclistSetFocusOnJump );
 	
-	//	Apr. 05, 2003 genta ƒEƒBƒ“ƒhƒEƒLƒƒƒvƒVƒ‡ƒ“‚ÌƒJƒXƒ^ƒ}ƒCƒY
+	//	Apr. 05, 2003 genta ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³ã®ã‚«ã‚¹ã‚¿ãƒã‚¤ã‚º
 	cProfile.IOProfileData( pszSecName, LTEXT("szWinCaptionActive") , MakeStringBufferT(common.m_sWindow.m_szWindowCaptionActive) );
 	cProfile.IOProfileData( pszSecName, LTEXT("szWinCaptionInactive"), MakeStringBufferT(common.m_sWindow.m_szWindowCaptionInactive) );
 	
-	// ƒAƒEƒgƒ‰ƒCƒ“/ƒgƒsƒbƒNƒŠƒXƒg ‚ÌˆÊ’u‚ÆƒTƒCƒY‚ğ‹L‰¯  20060201 aroka
+	// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³/ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆ ã®ä½ç½®ã¨ã‚µã‚¤ã‚ºã‚’è¨˜æ†¶  20060201 aroka
 	cProfile.IOProfileData( pszSecName, LTEXT("bRememberOutlineWindowPos"), common.m_sOutline.m_bRememberOutlineWindowPos);
 	if( common.m_sOutline.m_bRememberOutlineWindowPos ){
 		cProfile.IOProfileData( pszSecName, LTEXT("widthOutlineWindow")	, common.m_sOutline.m_widthOutlineWindow);
@@ -727,9 +727,9 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 }
 
 
-// ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh‚ğ–¼‘O‚©‚ç‹@”\”Ô†‚Ö•ÏŠ·
+// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰ã‚’åå‰ã‹ã‚‰æ©Ÿèƒ½ç•ªå·ã¸å¤‰æ›
 EFunctionCode GetPlugCmdInfoByName(
-	const WCHAR*	pszFuncName			//!< [in]  ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh–¼
+	const WCHAR*	pszFuncName			//!< [in]  ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰å
 )
 {
 	CommonSetting_Plugin& plugin = GetDllShareData().m_Common.m_sPlugin;
@@ -762,17 +762,17 @@ EFunctionCode GetPlugCmdInfoByName(
 	nNo = _wtoi( psCmdName );
 
 	if (nId < 0 || nNo <= 0 || nNo >= MAX_PLUG_CMD) {
-		// ƒvƒ‰ƒOƒCƒ“‚ª‚È‚¢/”Ô†‚ª‚¨‚©‚µ‚¢
+		// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãŒãªã„/ç•ªå·ãŒãŠã‹ã—ã„
 		return F_INVALID;
 	}
 	
 	return CPlug::GetPluginFunctionCode( nId, nNo );
 }
 
-// ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh‚ğ‹@”\”Ô†‚©‚ç–¼‘O‚Ö•ÏŠ·
+// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰ã‚’æ©Ÿèƒ½ç•ªå·ã‹ã‚‰åå‰ã¸å¤‰æ›
 bool GetPlugCmdInfoByFuncCode(
-	EFunctionCode	eFuncCode,				//!< [in]  ‹@”\ƒR[ƒh
-	WCHAR*			pszFuncName				//!< [out] ‹@”\–¼D‚±‚Ìæ‚É‚ÍMAX_PLUGIN_ID + 20•¶š‚Ìƒƒ‚ƒŠ‚ª•K—vD
+	EFunctionCode	eFuncCode,				//!< [in]  æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰
+	WCHAR*			pszFuncName				//!< [out] æ©Ÿèƒ½åï¼ã“ã®å…ˆã«ã¯MAX_PLUGIN_ID + 20æ–‡å­—ã®ãƒ¡ãƒ¢ãƒªãŒå¿…è¦ï¼
 )
 {
 	CommonSetting_Plugin& plugin = GetDllShareData().m_Common.m_sPlugin;
@@ -791,10 +791,10 @@ bool GetPlugCmdInfoByFuncCode(
 }
 
 
-/*! ƒvƒ‰ƒOƒCƒ“–¼or‹@”\”Ô†•¶š—ñ‚ğEFunctionCode‚É‚·‚é
+/*! ãƒ—ãƒ©ã‚°ã‚¤ãƒ³åoræ©Ÿèƒ½ç•ªå·æ–‡å­—åˆ—ã‚’EFunctionCodeã«ã™ã‚‹
 
-	@param[in]	pszFuncName		ƒvƒ‰ƒOƒCƒ“–¼or‹@”\”Ô†•¶š—ñ
-	@return ‹@”\ƒR[ƒh
+	@param[in]	pszFuncName		ãƒ—ãƒ©ã‚°ã‚¤ãƒ³åoræ©Ÿèƒ½ç•ªå·æ–‡å­—åˆ—
+	@return æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰
 */
 static EFunctionCode GetFunctionStrToFunctionCode(const WCHAR* pszFuncName)
 {
@@ -802,7 +802,7 @@ static EFunctionCode GetFunctionStrToFunctionCode(const WCHAR* pszFuncName)
 	if (pszFuncName == NULL) {
 		n = F_DEFAULT;
 	}else if (wcschr(pszFuncName, L'/') != NULL) {
-		// Plugin–¼
+		// Pluginå
 		n = GetPlugCmdInfoByName(pszFuncName);
 	}else if (WCODE::Is09(pszFuncName[0]) 
 	  && (pszFuncName[1] == L'\0' || WCODE::Is09(pszFuncName[1]))) {
@@ -817,11 +817,11 @@ static EFunctionCode GetFunctionStrToFunctionCode(const WCHAR* pszFuncName)
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌToolbarƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in]		bRead		true: “Ç‚İ‚İ / false: ‘‚«‚İ
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Toolbarã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in]		bRead		true: èª­ã¿è¾¼ã¿ / false: æ›¸ãè¾¼ã¿
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B“Ç‚İ‚İ‚Ì‰Šú‰»‚ğC³
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚èª­ã¿è¾¼ã¿æ™‚ã®åˆæœŸåŒ–ã‚’ä¿®æ­£
 */
 void CShareData_IO::ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* pcMenuDrawer )
 {
@@ -845,17 +845,17 @@ void CShareData_IO::ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* p
 		auto_sprintf( szKeyName, LTEXT("nTBB[%03d]"), i );
 		// Plugin String Parametor
 		if( cProfile.IsReadingMode() ){
-			//“Ç‚İ‚İ
+			//èª­ã¿è¾¼ã¿
 			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szText) );
 			if (wcschr(szText, L'/') == NULL) {
-				// ”Ô†
+				// ç•ªå·
 				toolbar.m_nToolBarButtonIdxArr[i] = _wtoi( szText );
 			}
 			else {
 				// Plugin
 				eFunc = GetPlugCmdInfoByName( szText );
 				if ( eFunc == F_INVALID ) {
-					toolbar.m_nToolBarButtonIdxArr[i] = -1;		// –¢‰ğŒˆ
+					toolbar.m_nToolBarButtonIdxArr[i] = -1;		// æœªè§£æ±º
 				}
 				else {
 					toolbar.m_nToolBarButtonIdxArr[i] = pcMenuDrawer->FindToolbarNoFromCommandId( eFunc, false );
@@ -863,8 +863,8 @@ void CShareData_IO::ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* p
 			}
 		}
 		else {
-			//‘‚«‚İ
-			if (toolbar.m_nToolBarButtonIdxArr[i] <= MAX_TOOLBAR_ICON_COUNT + 1) {	// +1‚ÍƒZƒpƒŒ[ƒ^•ª
+			//æ›¸ãè¾¼ã¿
+			if (toolbar.m_nToolBarButtonIdxArr[i] <= MAX_TOOLBAR_ICON_COUNT + 1) {	// +1ã¯ã‚»ãƒ‘ãƒ¬ãƒ¼ã‚¿åˆ†
 				cProfile.IOProfileData( pszSecName, szKeyName, toolbar.m_nToolBarButtonIdxArr[i] );	
 			}
 			else {
@@ -882,7 +882,7 @@ void CShareData_IO::ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* p
 			}
 		}
 	}
-	//“Ç‚İ‚İ‚Íc‚è‚ğ‰Šú‰»
+	//èª­ã¿è¾¼ã¿æ™‚ã¯æ®‹ã‚Šã‚’åˆæœŸåŒ–
 	if( cProfile.IsReadingMode() ){
 		for(; i< MAX_TOOLBAR_BUTTON_ITEMS; ++i){
 			toolbar.m_nToolBarButtonIdxArr[i] = 0;
@@ -891,10 +891,10 @@ void CShareData_IO::ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* p
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌCustMenuƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®CustMenuã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2010.08.21 Moca ‹ŒShareData_IO_CustMenu‚ğIO_CustMenu‚É•ÏX
+	@date 2010.08.21 Moca æ—§ShareData_IO_CustMenuã‚’IO_CustMenuã«å¤‰æ›´
 */
 void CShareData_IO::ShareData_IO_CustMenu( CDataProfile& cProfile )
 {
@@ -902,12 +902,12 @@ void CShareData_IO::ShareData_IO_CustMenu( CDataProfile& cProfile )
 }
 
 /*!
-	@brief CustMenu‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
-	@param[in,out]	menu	“üo—Í‘ÎÛ
-	@param	bOutCmdName	o—Í‚Éƒ}ƒNƒ–¼‚Åo—Í
+	@brief CustMenuã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
+	@param[in,out]	menu	å…¥å‡ºåŠ›å¯¾è±¡
+	@param	bOutCmdName	å‡ºåŠ›æ™‚ã«ãƒã‚¯ãƒ­åã§å‡ºåŠ›
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
 */
 void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMenu& menu, bool bOutCmdName)
 {
@@ -920,7 +920,7 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 
 	for( i = 0; i < MAX_CUSTOM_MENU; ++i ){
 		auto_sprintf( szKeyName, LTEXT("szCMN[%02d]"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(menu.m_szCustMenuNameArr[i]) );	//	Oct. 15, 2001 genta Å‘å’·w’è
+		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(menu.m_szCustMenuNameArr[i]) );	//	Oct. 15, 2001 genta æœ€å¤§é•·æŒ‡å®š
 		auto_sprintf( szKeyName, LTEXT("bCMPOP[%02d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, menu.m_bCustMenuPopupArr[i] );
 		auto_sprintf( szKeyName, LTEXT("nCMIN[%02d]"), i );
@@ -928,7 +928,7 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 		SetValueLimit( menu.m_nCustMenuItemNumArr[i], _countof(menu.m_nCustMenuItemFuncArr[0]) );
 		int nSize = menu.m_nCustMenuItemNumArr[i];
 		for( j = 0; j < nSize; ++j ){
-			// start ƒ}ƒNƒ–¼‚Å‚àİ’è‚Å‚«‚é‚æ‚¤‚É 2008/5/24 Uchi
+			// start ãƒã‚¯ãƒ­åã§ã‚‚è¨­å®šã§ãã‚‹ã‚ˆã†ã« 2008/5/24 Uchi
 			auto_sprintf( szKeyName, LTEXT("nCMIF[%02d][%02d]"), i, j );
 			if (cProfile.IsReadingMode()) {
 				cProfile.IOProfileData(pszSecName, szKeyName, MakeStringBufferW(szFuncName));
@@ -967,10 +967,10 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌFontƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Fontã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
 */
 void CShareData_IO::ShareData_IO_Font( CDataProfile& cProfile )
 {
@@ -985,7 +985,7 @@ void CShareData_IO::ShareData_IO_Font( CDataProfile& cProfile )
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌKeyBindƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®KeyBindã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
 */
 void CShareData_IO::ShareData_IO_KeyBind( CDataProfile& cProfile )
 {
@@ -994,14 +994,14 @@ void CShareData_IO::ShareData_IO_KeyBind( CDataProfile& cProfile )
 }
 
 /*!
-	@brief KeyBindƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
-	@param[in,out]	sKeyBind	ƒL[Š„‚è“–‚Äİ’è
+	@brief KeyBindã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
+	@param[in,out]	sKeyBind	ã‚­ãƒ¼å‰²ã‚Šå½“ã¦è¨­å®š
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
-	@date 2010.08.21 Moca ShareData_IO_KeyBind‚ğIO_KeyBind‚É–¼Ì•ÏX
-	@date 2012.11.20 aroka ˆø”‚ğ CommonSetting_KeyBind ‚É•ÏX
-	@date 2012.11.25 aroka ƒ}ƒEƒXƒR[ƒh‚ÌŒÅ’è‚Æd•¡”rœ
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
+	@date 2010.08.21 Moca ShareData_IO_KeyBindã‚’IO_KeyBindã«åç§°å¤‰æ›´
+	@date 2012.11.20 aroka å¼•æ•°ã‚’ CommonSetting_KeyBind ã«å¤‰æ›´
+	@date 2012.11.25 aroka ãƒã‚¦ã‚¹ã‚³ãƒ¼ãƒ‰ã®å›ºå®šã¨é‡è¤‡æ’é™¤
 */
 void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& sKeyBind, bool bOutCmdName)
 {
@@ -1012,16 +1012,16 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 //	int		nSize = m_pShareData->m_nKeyNameArrNum;
 	WCHAR	szWork[MAX_PLUGIN_ID+20+4];
 	bool	bOldVer = false;
-	const int KEYNAME_SIZE = _countof(sKeyBind.m_pKeyNameArr)-1;// ÅŒã‚Ì‚P—v‘f‚Íƒ_ƒ~[—p‚É—\–ñ 2012.11.25 aroka
-	int nKeyNameArrUsed = sKeyBind.m_nKeyNameArrNum; // g—pÏ‚İ—Ìˆæ
+	const int KEYNAME_SIZE = _countof(sKeyBind.m_pKeyNameArr)-1;// æœ€å¾Œã®ï¼‘è¦ç´ ã¯ãƒ€ãƒŸãƒ¼ç”¨ã«äºˆç´„ 2012.11.25 aroka
+	int nKeyNameArrUsed = sKeyBind.m_nKeyNameArrNum; // ä½¿ç”¨æ¸ˆã¿é ˜åŸŸ
 
 	if( cProfile.IsReadingMode() ){ 
 		if (!cProfile.IOProfileData( szSecName, L"KeyBind[000]", MakeStringBufferW(szKeyData) ) ) {
 			bOldVer = true;
 		}
 		else {
-			// VƒXƒ^ƒCƒ‹‚ÌImport‚ÍŠ„‚è“–‚Ä•\ƒTƒCƒY‚¬‚è‚¬‚è‚Ü‚Å“Ç‚İ‚Ş
-			// ‹ŒƒXƒ^ƒCƒ‹‚Í‰Šú’l‚Æˆê’v‚µ‚È‚¢KeyName‚ÍÌ‚Ä‚é‚Ì‚Åƒf[ƒ^”‚É•Ï‰»‚È‚µ
+			// æ–°ã‚¹ã‚¿ã‚¤ãƒ«ã®Importã¯å‰²ã‚Šå½“ã¦è¡¨ã‚µã‚¤ã‚ºãã‚Šãã‚Šã¾ã§èª­ã¿è¾¼ã‚€
+			// æ—§ã‚¹ã‚¿ã‚¤ãƒ«ã¯åˆæœŸå€¤ã¨ä¸€è‡´ã—ãªã„KeyNameã¯æ¨ã¦ã‚‹ã®ã§ãƒ‡ãƒ¼ã‚¿æ•°ã«å¤‰åŒ–ãªã—
 			sKeyBind.m_nKeyNameArrNum = KEYNAME_SIZE;
 		}
 	}
@@ -1048,7 +1048,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 					keydata.m_nFuncCodeArr[7]	= (EFunctionCode)buf[7];
 				}
 			}
-			else {		// Vƒo[ƒWƒ‡ƒ“(ƒL[Š„‚è“–‚Ä‚ÌImport,export ‚Ì‡‚í‚¹‚½)	2008/5/25 Uchi
+			else {		// æ–°ãƒãƒ¼ã‚¸ãƒ§ãƒ³(ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ã®Import,export ã®åˆã‚ã›ãŸ)	2008/5/25 Uchi
 				KEYDATA tmpKeydata;
 				auto_sprintf(szKeyName, L"KeyBind[%03d]", i);
 				if( cProfile.IOProfileData( szSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
@@ -1057,7 +1057,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 					int		nRes;
 
 					p = szKeyData;
-					// keycodeæ“¾
+					// keycodeå–å¾—
 					int keycode;
 					pn = auto_strchr(p,',');
 					if (pn == NULL)	continue;
@@ -1067,11 +1067,11 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 					tmpKeydata.m_nKeyCode = (short)keycode;
 					p = pn+1;
 
-					//Œã‚É‘±‚­ƒg[ƒNƒ“ 
+					//å¾Œã«ç¶šããƒˆãƒ¼ã‚¯ãƒ³ 
 					for (int j = 0; j < 8; j++) {
 						EFunctionCode n;
-						//‹@”\–¼‚ğ”’l‚É’u‚«Š·‚¦‚éB(”’l‚Ì‹@”\–¼‚à‚ ‚é‚©‚à)
-						//@@@ 2002.2.2 YAZAKI ƒ}ƒNƒ‚ğCSMacroMgr‚É“ˆê
+						//æ©Ÿèƒ½åã‚’æ•°å€¤ã«ç½®ãæ›ãˆã‚‹ã€‚(æ•°å€¤ã®æ©Ÿèƒ½åã‚‚ã‚ã‚‹ã‹ã‚‚)
+						//@@@ 2002.2.2 YAZAKI ãƒã‚¯ãƒ­ã‚’CSMacroMgrã«çµ±ä¸€
 						pn = auto_strchr(p,',');
 						if (pn == NULL)	break;
 						*pn = 0;
@@ -1083,8 +1083,8 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 					auto_strncpy(tmpKeydata.m_szKeyName, to_tchar(p), _countof(tmpKeydata.m_szKeyName)-1);
 					tmpKeydata.m_szKeyName[_countof(tmpKeydata.m_szKeyName)-1] = '\0';
 
-					if( tmpKeydata.m_nKeyCode <= 0 ){ // ƒ}ƒEƒXƒR[ƒh‚Íæ“ª‚ÉŒÅ’è‚³‚ê‚Ä‚¢‚é KeyCode‚ª“¯‚¶‚È‚Ì‚ÅKeyName‚Å”»•Ê
-						// 2013.10.23 syat ƒ}ƒEƒX‚ÌƒL[ƒR[ƒh‚ğŠg’£‰¼‘zƒL[ƒR[ƒh‚É•ÏXBˆÈ‰º‚ÍŒİŠ·«‚Ì‚½‚ßc‚·B
+					if( tmpKeydata.m_nKeyCode <= 0 ){ // ãƒã‚¦ã‚¹ã‚³ãƒ¼ãƒ‰ã¯å…ˆé ­ã«å›ºå®šã•ã‚Œã¦ã„ã‚‹ KeyCodeãŒåŒã˜ãªã®ã§KeyNameã§åˆ¤åˆ¥
+						// 2013.10.23 syat ãƒã‚¦ã‚¹ã®ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ã‚’æ‹¡å¼µä»®æƒ³ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ã«å¤‰æ›´ã€‚ä»¥ä¸‹ã¯äº’æ›æ€§ã®ãŸã‚æ®‹ã™ã€‚
 						for( int im=0; im< jpVKEXNamesLen; im++ ){
 							if( _tcscmp( tmpKeydata.m_szKeyName, jpVKEXNames[im] ) == 0 ){
 								_tcscpy( tmpKeydata.m_szKeyName, sKeyBind.m_pKeyNameArr[im].m_szKeyName );
@@ -1093,12 +1093,12 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 						}
 					}
 					else{
-						// Š„‚è“–‚ÄÏ‚İƒL[ƒR[ƒh‚Íã‘‚«
+						// å‰²ã‚Šå½“ã¦æ¸ˆã¿ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ã¯ä¸Šæ›¸ã
 						int idx = sKeyBind.m_VKeyToKeyNameArr[tmpKeydata.m_nKeyCode];
 						if( idx != KEYNAME_SIZE ){
 							_tcscpy( tmpKeydata.m_szKeyName, sKeyBind.m_pKeyNameArr[idx].m_szKeyName );
 							sKeyBind.m_pKeyNameArr[idx] = tmpKeydata;
-						}else{// –¢Š„‚è“–‚ÄƒL[ƒR[ƒh‚Í––”ö‚É’Ç‰Á
+						}else{// æœªå‰²ã‚Šå½“ã¦ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ã¯æœ«å°¾ã«è¿½åŠ 
 							if( nKeyNameArrUsed >= KEYNAME_SIZE ){}
 							else{
 								_tcscpy( tmpKeydata.m_szKeyName, sKeyBind.m_pKeyNameArr[nKeyNameArrUsed].m_szKeyName );
@@ -1122,7 +1122,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 		//	);
 		//	cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
 
-// start Vƒo[ƒWƒ‡ƒ“	2008/5/25 Uchi
+// start æ–°ãƒãƒ¼ã‚¸ãƒ§ãƒ³	2008/5/25 Uchi
 			KEYDATA& keydata = sKeyBind.m_pKeyNameArr[i];
 			auto_sprintf(szKeyName, L"KeyBind[%03d]", i);
 			auto_sprintf(szKeyData, L"%04x", keydata.m_nKeyCode);
@@ -1135,8 +1135,8 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 				}
 				else {
 					if (bOutCmdName) {
-						//@@@ 2002.2.2 YAZAKI ƒ}ƒNƒ‚ğCSMacroMgr‚É“ˆê
-						// 2010.06.30 Moca “ú–{Œê–¼‚ğæ“¾‚µ‚È‚¢‚æ‚¤‚É
+						//@@@ 2002.2.2 YAZAKI ãƒã‚¯ãƒ­ã‚’CSMacroMgrã«çµ±ä¸€
+						// 2010.06.30 Moca æ—¥æœ¬èªåã‚’å–å¾—ã—ãªã„ã‚ˆã†ã«
 						WCHAR	*p = CSMacroMgr::GetFuncInfoByID(
 							0,
 							keydata.m_nFuncCodeArr[j],
@@ -1174,10 +1174,10 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌPrintƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Printã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
 */
 void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 {
@@ -1247,14 +1247,14 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferT(printsetting.m_szPrintFontFaceHan) );
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szFFZ")	, i );
 		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferT(printsetting.m_szPrintFontFaceZen) );
-		// ƒwƒbƒ_/ƒtƒbƒ^
+		// ãƒ˜ãƒƒãƒ€/ãƒ•ãƒƒã‚¿
 		for( j = 0; j < 3; ++j ){
 			auto_sprintf( szKeyName, LTEXT("PS[%02d].szHF[%d]") , i, j );
 			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szHeaderForm[j]) );
 			auto_sprintf( szKeyName, LTEXT("PS[%02d].szFTF[%d]"), i, j );
 			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szFooterForm[j]) );
 		}
-		{ // ƒwƒbƒ_/ƒtƒbƒ^ ƒtƒHƒ“ƒgİ’è
+		{ // ãƒ˜ãƒƒãƒ€/ãƒ•ãƒƒã‚¿ ãƒ•ã‚©ãƒ³ãƒˆè¨­å®š
 			WCHAR	szKeyName2[64];
 			WCHAR	szKeyName3[64];
 			auto_sprintf( szKeyName,  LTEXT("PS[%02d].lfHeader"),			i );
@@ -1276,7 +1276,7 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szOutput"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferT(printsetting.m_mdmDevMode.m_szPrinterOutputName) );
 
-		// 2002.02.16 hor ‚Æ‚è‚ ‚¦‚¸‹Œİ’è‚ğ•ÏŠ·‚µ‚Æ‚­
+		// 2002.02.16 hor ã¨ã‚Šã‚ãˆãšæ—§è¨­å®šã‚’å¤‰æ›ã—ã¨ã
 		if(0==wcscmp(printsetting.m_szHeaderForm[0],_EDITL("&f")) &&
 		   0==wcscmp(printsetting.m_szFooterForm[0],_EDITL("&C- &P -"))
 		){
@@ -1285,23 +1285,23 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 			auto_strcpy( printsetting.m_szFooterForm[1], _EDITL("- $p -") );
 		}
 
-		//‹Ö‘¥	//@@@ 2002.04.09 MIK
+		//ç¦å‰‡	//@@@ 2002.04.09 MIK
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].bKinsokuHead"), i ); cProfile.IOProfileData( pszSecName, szKeyName, printsetting.m_bPrintKinsokuHead );
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].bKinsokuTail"), i ); cProfile.IOProfileData( pszSecName, szKeyName, printsetting.m_bPrintKinsokuTail );
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].bKinsokuRet"),  i ); cProfile.IOProfileData( pszSecName, szKeyName, printsetting.m_bPrintKinsokuRet );	//@@@ 2002.04.13 MIK
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].bKinsokuKuto"), i ); cProfile.IOProfileData( pszSecName, szKeyName, printsetting.m_bPrintKinsokuKuto );	//@@@ 2002.04.17 MIK
 
-		//ƒJƒ‰[ˆóü
+		//ã‚«ãƒ©ãƒ¼å°åˆ·
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].bColorPrint"), i ); cProfile.IOProfileData( pszSecName, szKeyName, printsetting.m_bColorPrint );	// 2013/4/26 Uchi
 	}
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌSTypeConfigƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®STypeConfigã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
-	@date 2010/04/17 Uchi ƒ‹[ƒv“à‚ğShareData_IO_Type_One‚É•ª—£B
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
+	@date 2010/04/17 Uchi ãƒ«ãƒ¼ãƒ—å†…ã‚’ShareData_IO_Type_Oneã«åˆ†é›¢ã€‚
 */
 void CShareData_IO::ShareData_IO_Types( CDataProfile& cProfile )
 {
@@ -1311,10 +1311,10 @@ void CShareData_IO::ShareData_IO_Types( CDataProfile& cProfile )
 	
 	int nCountOld = pShare->m_nTypesCount;
 	if( !cProfile.IOProfileData( L"Other", LTEXT("nTypesCount"), pShare->m_nTypesCount ) ){
-		pShare->m_nTypesCount = 30; // ‹Œƒo[ƒWƒ‡ƒ““Ç‚İ‚İ—p
+		pShare->m_nTypesCount = 30; // æ—§ãƒãƒ¼ã‚¸ãƒ§ãƒ³èª­ã¿è¾¼ã¿ç”¨
 	}
 	SetValueLimit( pShare->m_nTypesCount, 1, MAX_TYPES );
-	// ’FƒRƒ“ƒgƒ[ƒ‹ƒvƒƒZƒXê—p
+	// æ³¨ï¼šã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ãƒ—ãƒ­ã‚»ã‚¹å°‚ç”¨
 	std::vector<STypeConfig*>& types = CShareData::getInstance()->GetTypeSettings();
 	for( i = GetDllShareData().m_nTypesCount; i < nCountOld; i++ ){
 		delete types[i];
@@ -1323,7 +1323,7 @@ void CShareData_IO::ShareData_IO_Types( CDataProfile& cProfile )
 	types.resize(pShare->m_nTypesCount);
 	for( i = nCountOld; i < pShare->m_nTypesCount; i++ ){
 		types[i] = new STypeConfig();
-		*types[i] = *types[0]; // Šî–{‚ğƒRƒs[
+		*types[i] = *types[0]; // åŸºæœ¬ã‚’ã‚³ãƒ”ãƒ¼
 		auto_sprintf( types[i]->m_szTypeName, LS(STR_TRAY_TYPE_NAME), i );
 		types[i]->m_nIdx = i;
 		types[i]->m_id = i;
@@ -1345,7 +1345,7 @@ void CShareData_IO::ShareData_IO_Types( CDataProfile& cProfile )
 		}
 	}
 	if( cProfile.IsReadingMode() ){
-		// Idd•¡ƒ`ƒFƒbƒNAXV
+		// Idé‡è¤‡ãƒã‚§ãƒƒã‚¯ã€æ›´æ–°
 		for( i = 0; i < pShare->m_nTypesCount - 1; i++ ){
 			STypeConfig& type = *(types[i]);
 			for( int k = i + 1; k < pShare->m_nTypesCount; k++ ){
@@ -1360,12 +1360,12 @@ void CShareData_IO::ShareData_IO_Types( CDataProfile& cProfile )
 }
 
 /*!
-@brief ‹¤—Lƒf[ƒ^‚ÌSTypeConfigƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í(‚PŒÂ•ª)
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
-	@param[in]		type		ƒ^ƒCƒv•Ê
-	@param[in]		pszSecName	ƒZƒNƒVƒ‡ƒ“–¼
+@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®STypeConfigã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›(ï¼‘å€‹åˆ†)
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
+	@param[in]		type		ã‚¿ã‚¤ãƒ—åˆ¥
+	@param[in]		pszSecName	ã‚»ã‚¯ã‚·ãƒ§ãƒ³å
 
-	@date 2010/04/17 Uchi ShareData_IO_TypesOne‚©‚ç•ª—£B
+	@date 2010/04/17 Uchi ShareData_IO_TypesOneã‹ã‚‰åˆ†é›¢ã€‚
 */
 void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& types, const WCHAR* pszSecName)
 {
@@ -1394,7 +1394,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 			types.m_nCurrentPrintSetting	= buf[10];
 			types.m_nTsvMode				= buf[11];
 		}
-		// Ü‚è•Ô‚µ•‚ÌÅ¬’l‚Í10B­‚È‚­‚Æ‚à‚S‚È‚¢‚Æƒnƒ“ƒOƒAƒbƒv‚·‚éB // 20050818 aroka
+		// æŠ˜ã‚Šè¿”ã—å¹…ã®æœ€å°å€¤ã¯10ã€‚å°‘ãªãã¨ã‚‚ï¼”ãªã„ã¨ãƒãƒ³ã‚°ã‚¢ãƒƒãƒ—ã™ã‚‹ã€‚ // 20050818 aroka
 		if( types.m_nMaxLineKetas < CKetaXInt(MINLINEKETAS) ){
 			types.m_nMaxLineKetas = CKetaXInt(MINLINEKETAS);
 		}
@@ -1429,7 +1429,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("nKeywordSelect9"),  types.m_nKeyWordSetIdx[8] );
 	cProfile.IOProfileData( pszSecName, LTEXT("nKeywordSelect10"), types.m_nKeyWordSetIdx[9] );
 
-	/* sŠÔ‚Ì‚·‚«‚Ü */
+	/* è¡Œé–“ã®ã™ãã¾ */
 	cProfile.IOProfileData( pszSecName, LTEXT("nLineSpace"), types.m_nLineSpace );
 	if( cProfile.IsReadingMode() ){
 		if( types.m_nLineSpace < -LINESPACE_MAX ){
@@ -1440,7 +1440,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		}
 	}
 
-	/* s”Ô†‚ÌÅ¬Œ…” */	// ‰Á’Ç 2014.08.02 katze
+	/* è¡Œç•ªå·ã®æœ€å°æ¡æ•° */	// åŠ è¿½ 2014.08.02 katze
 	cProfile.IOProfileData( pszSecName, LTEXT("nLineNumWidth"), types.m_nLineNumWidth );
 	if( cProfile.IsReadingMode() ){
 		if( types.m_nLineNumWidth < LINENUMWIDTH_MIN ){
@@ -1470,8 +1470,8 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	if( cProfile.IsReadingMode() ){
 		//	Block Comment
 		wchar_t buffer[2][ BLOCKCOMMENT_BUFFERSIZE ];
-		//	2004.10.02 Moca ‘Î‚É‚È‚éƒRƒƒ“ƒgİ’è‚ª‚Æ‚à‚É“Ç‚İ‚Ü‚ê‚½‚Æ‚«‚¾‚¯—LŒø‚Èİ’è‚ÆŒ©‚È‚·D
-		//	ƒuƒƒbƒNƒRƒƒ“ƒg‚Ìn‚Ü‚è‚ÆI‚í‚èDsƒRƒƒ“ƒg‚Ì‹L†‚ÆŒ…ˆÊ’u
+		//	2004.10.02 Moca å¯¾ã«ãªã‚‹ã‚³ãƒ¡ãƒ³ãƒˆè¨­å®šãŒã¨ã‚‚ã«èª­ã¿è¾¼ã¾ã‚ŒãŸã¨ãã ã‘æœ‰åŠ¹ãªè¨­å®šã¨è¦‹ãªã™ï¼
+		//	ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆã®å§‹ã¾ã‚Šã¨çµ‚ã‚ã‚Šï¼è¡Œã‚³ãƒ¡ãƒ³ãƒˆã®è¨˜å·ã¨æ¡ä½ç½®
 		bool bRet1, bRet2;
 		buffer[0][0] = buffer[1][0] = L'\0';
 		bRet1 = cProfile.IOProfileData( pszSecName, LTEXT("szBlockCommentFrom"), MakeStringBufferW(buffer[0]) );			
@@ -1499,8 +1499,8 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		if( bRet1 && bRet2 ) types.m_cLineComment.CopyTo( 1, lbuf, pos );
 
 		lbuf[0] = L'\0'; pos = -1;
-		bRet1 = cProfile.IOProfileData( pszSecName, LTEXT("szLineComment3")		, MakeStringBufferW(lbuf) );	//Jun. 01, 2001 JEPRO ’Ç‰Á
-		bRet2 = cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn3"), pos );	//Jun. 01, 2001 JEPRO ’Ç‰Á
+		bRet1 = cProfile.IOProfileData( pszSecName, LTEXT("szLineComment3")		, MakeStringBufferW(lbuf) );	//Jun. 01, 2001 JEPRO è¿½åŠ 
+		bRet2 = cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn3"), pos );	//Jun. 01, 2001 JEPRO è¿½åŠ 
 		if( bRet1 && bRet2 ) types.m_cLineComment.CopyTo( 2, lbuf, pos );
 	}
 	else { // write
@@ -1522,7 +1522,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		cProfile.IOProfileData( pszSecName, LTEXT("szLineComment2")		,
 			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cLineComment.getLineComment(1))) );
 		cProfile.IOProfileData( pszSecName, LTEXT("szLineComment3")		,
-			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cLineComment.getLineComment(2))) );	//Jun. 01, 2001 JEPRO ’Ç‰Á
+			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cLineComment.getLineComment(2))) );	//Jun. 01, 2001 JEPRO è¿½åŠ 
 
 		//	From here May 12, 2001 genta
 		int pos;
@@ -1531,7 +1531,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		pos = types.m_cLineComment.getLineCommentPos( 1 );
 		cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn2"), pos );
 		pos = types.m_cLineComment.getLineCommentPos( 2 );
-		cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn3"), pos );	//Jun. 01, 2001 JEPRO ’Ç‰Á
+		cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn3"), pos );	//Jun. 01, 2001 JEPRO è¿½åŠ 
 		//	To here May 12, 2001 genta
 
 	}
@@ -1540,8 +1540,8 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("szIndentChars")		, MakeStringBufferW(types.m_szIndentChars) );
 	cProfile.IOProfileData( pszSecName, LTEXT("cLineTermChar")		, types.m_cLineTermChar );
 
-	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockDisp")			, types.m_bOutlineDockDisp );/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•\¦‚Ì—L–³ */
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOutlineDockSide")	, types.m_eOutlineDockSide );/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒhƒbƒLƒ“ƒO”z’u */
+	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockDisp")			, types.m_bOutlineDockDisp );/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æè¡¨ç¤ºã®æœ‰ç„¡ */
+	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOutlineDockSide")	, types.m_eOutlineDockSide );/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æãƒ‰ãƒƒã‚­ãƒ³ã‚°é…ç½® */
 	{
 		const WCHAR* pszKeyName = LTEXT("xyOutlineDock");
 		const WCHAR* pszForm = LTEXT("%d,%d,%d,%d");
@@ -1567,30 +1567,30 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 			cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData) );
 		}
 	}
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDockOutline")	, 	types.m_nDockOutline );/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDefaultOutline")	, types.m_eDefaultOutline );/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
-	cProfile.IOProfileData( pszSecName, LTEXT("szOutlineRuleFilename")	, types.m_szOutlineRuleFilename );/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ‹[ƒ‹ƒtƒ@ƒCƒ‹ */
-	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineSortCol")		, types.m_nOutlineSortCol );/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ\[ƒg—ñ”Ô† */
-	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineSortDesc")		, types.m_bOutlineSortDesc );/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ\[ƒg~‡ */
-	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineSortType")		, types.m_nOutlineSortType );/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ\[ƒgŠî€ */
+	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDockOutline")	, 	types.m_nDockOutline );/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
+	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDefaultOutline")	, types.m_eDefaultOutline );/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
+	cProfile.IOProfileData( pszSecName, LTEXT("szOutlineRuleFilename")	, types.m_szOutlineRuleFilename );/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æãƒ«ãƒ¼ãƒ«ãƒ•ã‚¡ã‚¤ãƒ« */
+	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineSortCol")		, types.m_nOutlineSortCol );/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã‚½ãƒ¼ãƒˆåˆ—ç•ªå· */
+	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineSortDesc")		, types.m_bOutlineSortDesc );/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã‚½ãƒ¼ãƒˆé™é † */
+	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineSortType")		, types.m_nOutlineSortType );/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã‚½ãƒ¼ãƒˆåŸºæº– */
 	ShareData_IO_FileTree( cProfile, types.m_sFileTree, pszSecName );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nSmartIndent")		, types.m_eSmartIndent );/* ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒgí•Ê */
+	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nSmartIndent")		, types.m_eSmartIndent );/* ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆç¨®åˆ¥ */
 	cProfile.IOProfileData( pszSecName, LTEXT("bIndentCppStringIgnore")		, types.m_bIndentCppStringIgnore );
 	cProfile.IOProfileData( pszSecName, LTEXT("bIndentCppCommentIgnore")	, types.m_bIndentCppCommentIgnore );
 	cProfile.IOProfileData( pszSecName, LTEXT("bIndentCppUndoSep")	, types.m_bIndentCppUndoSep );
 	//	Nov. 20, 2000 genta
-	cProfile.IOProfileData( pszSecName, LTEXT("nImeState")			, types.m_nImeState );	//	IME§Œä
+	cProfile.IOProfileData( pszSecName, LTEXT("nImeState")			, types.m_nImeState );	//	IMEåˆ¶å¾¡
 
-	//	2001/06/14 Start By asa-o: ƒ^ƒCƒv•Ê‚Ì•âŠ®ƒtƒ@ƒCƒ‹
-	//	Oct. 5, 2002 genta _countof()‚ÅŒë‚Á‚Äƒ|ƒCƒ“ƒ^‚ÌƒTƒCƒY‚ğæ“¾‚µ‚Ä‚¢‚½‚Ì‚ğC³
-	cProfile.IOProfileData( pszSecName, LTEXT("szHokanFile")		, types.m_szHokanFile );		//	•âŠ®ƒtƒ@ƒCƒ‹
+	//	2001/06/14 Start By asa-o: ã‚¿ã‚¤ãƒ—åˆ¥ã®è£œå®Œãƒ•ã‚¡ã‚¤ãƒ«
+	//	Oct. 5, 2002 genta _countof()ã§èª¤ã£ã¦ãƒã‚¤ãƒ³ã‚¿ã®ã‚µã‚¤ã‚ºã‚’å–å¾—ã—ã¦ã„ãŸã®ã‚’ä¿®æ­£
+	cProfile.IOProfileData( pszSecName, LTEXT("szHokanFile")		, types.m_szHokanFile );		//	è£œå®Œãƒ•ã‚¡ã‚¤ãƒ«
 	//	2001/06/14 End
-	cProfile.IOProfileData( pszSecName, LTEXT("nHokanType")			, types.m_nHokanType );		//	•âŠ®í•Ê
+	cProfile.IOProfileData( pszSecName, LTEXT("nHokanType")			, types.m_nHokanType );		//	è£œå®Œç¨®åˆ¥
 
 	//	2001/06/19 asa-o
 	cProfile.IOProfileData( pszSecName, LTEXT("bHokanLoHiCase")		, types.m_bHokanLoHiCase );
 
-	//	2003.06.23 Moca ƒtƒ@ƒCƒ‹“à‚©‚ç‚Ì“ü—Í•âŠ®‹@”\
+	//	2003.06.23 Moca ãƒ•ã‚¡ã‚¤ãƒ«å†…ã‹ã‚‰ã®å…¥åŠ›è£œå®Œæ©Ÿèƒ½
 	cProfile.IOProfileData( pszSecName, LTEXT("bUseHokanByFile")		, types.m_bUseHokanByFile );
 	cProfile.IOProfileData( pszSecName, LTEXT("bUseHokanByKeyword")		, types.m_bUseHokanByKeyword );
 
@@ -1610,10 +1610,10 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("bRTrimPrevLine")			, types.m_bRTrimPrevLine );			// 2005.10.08 ryoji
 	cProfile.IOProfileData( pszSecName, LTEXT("nIndentLayout")			, types.m_nIndentLayout );
 
-	/* Fİ’è I/O */
+	/* è‰²è¨­å®š I/O */
 	IO_ColorSet( &cProfile, pszSecName, types.m_ColorInfoArr  );
 
-	// 2010.09.17 ”wŒi‰æ‘œ
+	// 2010.09.17 èƒŒæ™¯ç”»åƒ
 	cProfile.IOProfileData( pszSecName, L"bgImgPath", types.m_szBackImgPath );
 	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgPos", types.m_backImgPos );
 	cProfile.IOProfileData( pszSecName, L"bgImgScrollX",   types.m_backImgScrollX );
@@ -1623,7 +1623,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgPosOffsetX",  types.m_backImgPosOffset.x );
 	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgPosOffsetY",  types.m_backImgPosOffset.y );
 
-	// 2005.11.08 Moca w’èŒ…cü
+	// 2005.11.08 Moca æŒ‡å®šæ¡ç¸¦ç·š
 	for(j = 0; j < MAX_VERTLINES; j++ ){
 		auto_sprintf( szKeyName, LTEXT("nVertLineIdx%d"), j + 1 );
 		cProfile.IOProfileData( pszSecName, szKeyName, types.m_nVertLineIdx[j] );
@@ -1634,9 +1634,9 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, L"nNoteLineOffset", types.m_nNoteLineOffset );
 
 //@@@ 2001.11.17 add start MIK
-	{	//³‹K•\Œ»ƒL[ƒ[ƒh
+	{	//æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
 		WCHAR	*p;
-		cProfile.IOProfileData( pszSecName, LTEXT("bUseRegexKeyword"), types.m_bUseRegexKeyword );/* ³‹K•\Œ»ƒL[ƒ[ƒhg—p‚·‚é‚©H */
+		cProfile.IOProfileData( pszSecName, LTEXT("bUseRegexKeyword"), types.m_bUseRegexKeyword );/* æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ä½¿ç”¨ã™ã‚‹ã‹ï¼Ÿ */
 		wchar_t* pKeyword = types.m_RegexKeywordList;
 		int nPos = 0;
 		int nKeywordSize = _countof(types.m_RegexKeywordList);
@@ -1653,7 +1653,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 					{
 						*p = LTEXT('\0');
 						types.m_RegexKeywordArr[j].m_nColorIndex = GetColorIndexByName(to_tchar(szKeyData));	//@@@ 2002.04.30
-						if( types.m_RegexKeywordArr[j].m_nColorIndex == -1 )	//–¼‘O‚Å‚È‚¢
+						if( types.m_RegexKeywordArr[j].m_nColorIndex == -1 )	//åå‰ã§ãªã„
 							types.m_RegexKeywordArr[j].m_nColorIndex = _wtoi(szKeyData);
 						p++;
 						if( 0 < nKeywordSize - nPos - 1 ){
@@ -1669,11 +1669,11 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 						}
 					}
 				}else{
-					// 2010.06.18 Moca ’l‚ª‚È‚¢ê‡‚ÍI—¹
+					// 2010.06.18 Moca å€¤ãŒãªã„å ´åˆã¯çµ‚äº†
 					break;
 				}
 			}
-			// 2002.02.08 hor –¢’è‹`’l‚ğ–³‹
+			// 2002.02.08 hor æœªå®šç¾©å€¤ã‚’ç„¡è¦–
 			else if(pKeyword[nPos])
 			{
 				auto_sprintf( szKeyData, LTEXT("%ls,%ls"),
@@ -1689,7 +1689,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	}
 //@@@ 2001.11.17 add end MIK
 
-	/* ‹Ö‘¥ */
+	/* ç¦å‰‡ */
 	cProfile.IOProfileData( pszSecName, LTEXT("bKinsokuHead")	, types.m_bKinsokuHead );
 	cProfile.IOProfileData( pszSecName, LTEXT("bKinsokuTail")	, types.m_bKinsokuTail );
 	cProfile.IOProfileData( pszSecName, LTEXT("bKinsokuRet")	, types.m_bKinsokuRet );	//@@@ 2002.04.13 MIK
@@ -1698,20 +1698,20 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuHead")	, MakeStringBufferW(types.m_szKinsokuHead) );
 	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuTail")	, MakeStringBufferW(types.m_szKinsokuTail) );
 	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuKuto")	, MakeStringBufferW(types.m_szKinsokuKuto) );	// 2009.08.07 ryoji
-	cProfile.IOProfileData( pszSecName, LTEXT("bUseDocumentIcon")	, types.m_bUseDocumentIcon );	// Sep. 19 ,2002 genta •Ï”–¼Œë‚èC³
+	cProfile.IOProfileData( pszSecName, LTEXT("bUseDocumentIcon")	, types.m_bUseDocumentIcon );	// Sep. 19 ,2002 genta å¤‰æ•°åèª¤ã‚Šä¿®æ­£
 
 //@@@ 2006.04.10 fon ADD-start
-	{	/* ƒL[ƒ[ƒh«‘ */
+	{	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾æ›¸ */
 		WCHAR	*pH, *pT;	/* <pH>keyword<pT> */
-		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyWordHelp"), types.m_bUseKeyWordHelp );	/* ƒL[ƒ[ƒh«‘‘I‘ğ‚ğg—p‚·‚é‚©H */
-//		cProfile.IOProfileData( pszSecName, LTEXT("nKeyHelpNum"), types.m_nKeyHelpNum );				/* “o˜^«‘” */
-		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpAllSearch"), types.m_bUseKeyHelpAllSearch );	/* ƒqƒbƒg‚µ‚½Ÿ‚Ì«‘‚àŒŸõ(&A) */
-		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpKeyDisp"), types.m_bUseKeyHelpKeyDisp );		/* 1s–Ú‚ÉƒL[ƒ[ƒh‚à•\¦‚·‚é(&W) */
-		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpPrefix"), types.m_bUseKeyHelpPrefix );		/* ‘I‘ğ”ÍˆÍ‚Å‘O•ûˆê’vŒŸõ(&P) */
+		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyWordHelp"), types.m_bUseKeyWordHelp );	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾æ›¸é¸æŠã‚’ä½¿ç”¨ã™ã‚‹ã‹ï¼Ÿ */
+//		cProfile.IOProfileData( pszSecName, LTEXT("nKeyHelpNum"), types.m_nKeyHelpNum );				/* ç™»éŒ²è¾æ›¸æ•° */
+		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpAllSearch"), types.m_bUseKeyHelpAllSearch );	/* ãƒ’ãƒƒãƒˆã—ãŸæ¬¡ã®è¾æ›¸ã‚‚æ¤œç´¢(&A) */
+		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpKeyDisp"), types.m_bUseKeyHelpKeyDisp );		/* 1è¡Œç›®ã«ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚‚è¡¨ç¤ºã™ã‚‹(&W) */
+		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpPrefix"), types.m_bUseKeyHelpPrefix );		/* é¸æŠç¯„å›²ã§å‰æ–¹ä¸€è‡´æ¤œç´¢(&P) */
 		cProfile.IOProfileData_WrapInt(pszSecName, LTEXT("nKeyHelpRMenuShowType"), types.m_eKeyHelpRMenuShowType);
 		for(j = 0; j < MAX_KEYHELP_FILE; j++){
 			auto_sprintf( szKeyName, LTEXT("KDct[%02d]"), j );
-			/* “Ç‚İo‚µ */
+			/* èª­ã¿å‡ºã— */
 			if( cProfile.IsReadingMode() ){
 				types.m_KeyHelpArr[j].m_bUse = false;
 				types.m_KeyHelpArr[j].m_szAbout[0] = _T('\0');
@@ -1728,12 +1728,12 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 							pH = pT+1;
 							if( L'\0' != (*pH) ){
 								_wcstotcs( types.m_KeyHelpArr[j].m_szPath, pH, _countof2(types.m_KeyHelpArr[j].m_szPath) );
-								types.m_nKeyHelpNum = j+1;	// ini‚É•Û‘¶‚¹‚¸‚ÉA“Ç‚İo‚¹‚½ƒtƒ@ƒCƒ‹•ª‚ğ«‘”‚Æ‚·‚é
+								types.m_nKeyHelpNum = j+1;	// iniã«ä¿å­˜ã›ãšã«ã€èª­ã¿å‡ºã›ãŸãƒ•ã‚¡ã‚¤ãƒ«åˆ†ã‚’è¾æ›¸æ•°ã¨ã™ã‚‹
 							}
 						}
 					}
 				}
-			}/* ‘‚«‚İ */
+			}/* æ›¸ãè¾¼ã¿ */
 			else{
 				if(types.m_KeyHelpArr[j].m_szPath[0] != _T('\0')){
 					auto_sprintf( szKeyData, LTEXT("%d,%ts,%ts"),
@@ -1745,7 +1745,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 				}
 			}
 		}
-		/* ‹Œƒo[ƒWƒ‡ƒ“iniƒtƒ@ƒCƒ‹‚Ì“Ç‚İo‚µƒTƒ|[ƒg */
+		/* æ—§ãƒãƒ¼ã‚¸ãƒ§ãƒ³iniãƒ•ã‚¡ã‚¤ãƒ«ã®èª­ã¿å‡ºã—ã‚µãƒãƒ¼ãƒˆ */
 		if( cProfile.IsReadingMode() ){
 			SFilePath tmp;
 			if(cProfile.IOProfileData( pszSecName, LTEXT("szKeyWordHelpFile"), tmp )){
@@ -1755,10 +1755,10 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	}
 //@@@ 2006.04.10 fon ADD-end
 
-	// •Û‘¶‚É‰üsƒR[ƒh‚Ì¬İ‚ğŒx‚·‚é	2013/4/14 Uchi
+	// ä¿å­˜æ™‚ã«æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®æ··åœ¨ã‚’è­¦å‘Šã™ã‚‹	2013/4/14 Uchi
 	cProfile.IOProfileData( pszSecName, LTEXT("bChkEnterAtEnd")	, types.m_bChkEnterAtEnd );
 
-	{ // ƒtƒHƒ“ƒgİ’è
+	{ // ãƒ•ã‚©ãƒ³ãƒˆè¨­å®š
 		cProfile.IOProfileData( pszSecName, LTEXT("bUseTypeFont"), types.m_bUseTypeFont );
 		ShareData_IO_Sub_LogFont( cProfile, pszSecName, L"lf", L"nPointSize", L"lfFaceName",
 			types.m_lf, types.m_nPointSize );
@@ -1766,11 +1766,11 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌKeyWordsƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in]		bRead		true: “Ç‚İ‚İ / false: ‘‚«‚İ
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®KeyWordsã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in]		bRead		true: èª­ã¿è¾¼ã¿ / false: æ›¸ãè¾¼ã¿
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
 */
 void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 {
@@ -1786,15 +1786,15 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("nCurrentKeyWordSetIdx")	, pCKeyWordSetMgr->m_nCurrentKeyWordSetIdx );
 	bool bIOSuccess = cProfile.IOProfileData( pszSecName, LTEXT("nKeyWordSetNum"), nKeyWordSetNum );
 	if( cProfile.IsReadingMode() ){
-		// nKeyWordSetNum ‚ª“Ç‚İ‚ß‚Ä‚¢‚ê‚ÎA‚·‚×‚Ä‚Ìî•ñ‚ª‚»‚ë‚Á‚Ä‚¢‚é‚Æ‰¼’è‚µ‚Äˆ—‚ği‚ß‚é
+		// nKeyWordSetNum ãŒèª­ã¿è¾¼ã‚ã¦ã„ã‚Œã°ã€ã™ã¹ã¦ã®æƒ…å ±ãŒãã‚ã£ã¦ã„ã‚‹ã¨ä»®å®šã—ã¦å‡¦ç†ã‚’é€²ã‚ã‚‹
 		if( bIOSuccess ){
-			// 2004.11.25 Moca ƒL[ƒ[ƒhƒZƒbƒg‚Ìî•ñ‚ÍA’¼Ú‘‚«Š·‚¦‚È‚¢‚ÅŠÖ”‚ğ—˜—p‚·‚é
-			// ‰Šúİ’è‚³‚ê‚Ä‚¢‚é‚½‚ßAæ‚Éíœ‚µ‚È‚¢‚ÆŒÅ’èƒƒ‚ƒŠ‚ÌŠm•Û‚É¸”s‚·‚é‰Â”\«‚ª‚ ‚é
+			// 2004.11.25 Moca ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã®æƒ…å ±ã¯ã€ç›´æ¥æ›¸ãæ›ãˆãªã„ã§é–¢æ•°ã‚’åˆ©ç”¨ã™ã‚‹
+			// åˆæœŸè¨­å®šã•ã‚Œã¦ã„ã‚‹ãŸã‚ã€å…ˆã«å‰Šé™¤ã—ãªã„ã¨å›ºå®šãƒ¡ãƒ¢ãƒªã®ç¢ºä¿ã«å¤±æ•—ã™ã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 			pCKeyWordSetMgr->ResetAllKeyWordSet();
 			for( i = 0; i < nKeyWordSetNum; ++i ){
 				bool bKEYWORDCASE = false;
 				int nKeyWordNum = 0;
-				//’l‚Ìæ“¾
+				//å€¤ã®å–å¾—
 				auto_sprintf( szKeyName, LTEXT("szSN[%02d]"), i );
 				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
 				auto_sprintf( szKeyName, LTEXT("nCASE[%02d]"), i );
@@ -1802,10 +1802,10 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 				auto_sprintf( szKeyName, LTEXT("nKWN[%02d]"), i );
 				cProfile.IOProfileData( pszSecName, szKeyName, nKeyWordNum );
 
-				//’Ç‰Á
+				//è¿½åŠ 
 				pCKeyWordSetMgr->AddKeyWordSet( szKeyData, bKEYWORDCASE, nKeyWordNum );
 				auto_sprintf( szKeyName, LTEXT("szKW[%02d]"), i );
-				std::wstring sValue;	// wstring ‚Ì‚Ü‚Üó‚¯‚éiŒÃ‚¢ ini ƒtƒ@ƒCƒ‹‚ÌƒL[ƒ[ƒh‚Í’†g‚ª NULL •¶š‹æØ‚è‚È‚Ì‚Å StringBufferW ‚Å‚Í NG ‚¾‚Á‚½j
+				std::wstring sValue;	// wstring ã®ã¾ã¾å—ã‘ã‚‹ï¼ˆå¤ã„ ini ãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã¯ä¸­èº«ãŒ NULL æ–‡å­—åŒºåˆ‡ã‚Šãªã®ã§ StringBufferW ã§ã¯ NG ã ã£ãŸï¼‰
 				if( cProfile.IOProfileData( pszSecName, szKeyName, sValue ) ){
 					pCKeyWordSetMgr->SetKeyWordArr( i, nKeyWordNum, sValue.c_str() );
 				}
@@ -1829,10 +1829,10 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 			nMemLen ++;
 			auto_sprintf( szKeyName, LTEXT("szKW[%02d].Size"), i );
 			cProfile.IOProfileData( pszSecName, szKeyName, nMemLen );
-			wchar_t* pszMem = new wchar_t[nMemLen + 1];	//	May 25, 2003 genta ‹æØ‚è‚ğTAB‚É•ÏX‚µ‚½‚Ì‚ÅCÅŒã‚Ì\0‚Ì•ª‚ğ’Ç‰Á
+			wchar_t* pszMem = new wchar_t[nMemLen + 1];	//	May 25, 2003 genta åŒºåˆ‡ã‚Šã‚’TABã«å¤‰æ›´ã—ãŸã®ã§ï¼Œæœ€å¾Œã®\0ã®åˆ†ã‚’è¿½åŠ 
 			wchar_t* pMem = pszMem;
 			for( j = 0; j < pCKeyWordSetMgr->m_nKeyWordNumArr[i]; ++j ){
-				//	May 25, 2003 genta ‹æØ‚è‚ğTAB‚É•ÏX
+				//	May 25, 2003 genta åŒºåˆ‡ã‚Šã‚’TABã«å¤‰æ›´
 				int kwlen = wcslen( pCKeyWordSetMgr->GetKeyWord( i, j ) );
 				auto_memcpy( pMem, pCKeyWordSetMgr->GetKeyWord( i, j ), kwlen );
 				pMem += kwlen;
@@ -1847,10 +1847,10 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌMacroƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Macroã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
 */
 void CShareData_IO::ShareData_IO_Macro( CDataProfile& cProfile )
 {
@@ -1861,8 +1861,8 @@ void CShareData_IO::ShareData_IO_Macro( CDataProfile& cProfile )
 	WCHAR	szKeyName[64];
 	for( i = 0; i < MAX_CUSTMACRO; ++i ){
 		MacroRec& macrorec = pShare->m_Common.m_sMacro.m_MacroTable[i];
-		//	Oct. 4, 2001 genta ‚ ‚Ü‚èˆÓ–¡‚ª‚È‚³‚»‚¤‚È‚Ì‚ÅíœF3s
-		// 2002.02.08 hor –¢’è‹`’l‚ğ–³‹
+		//	Oct. 4, 2001 genta ã‚ã¾ã‚Šæ„å‘³ãŒãªã•ãã†ãªã®ã§å‰Šé™¤ï¼š3è¡Œ
+		// 2002.02.08 hor æœªå®šç¾©å€¤ã‚’ç„¡è¦–
 		if( !cProfile.IsReadingMode() && macrorec.m_szName[0] == _T('\0') && macrorec.m_szFile[0] == _T('\0') ) continue;
 		auto_sprintf( szKeyName, LTEXT("Name[%03d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferT(macrorec.m_szName) );
@@ -1871,15 +1871,15 @@ void CShareData_IO::ShareData_IO_Macro( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("ReloadWhenExecute[%03d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, macrorec.m_bReloadWhenExecute );
 	}
-	cProfile.IOProfileData( pszSecName, LTEXT("nMacroOnOpened"), pShare->m_Common.m_sMacro.m_nMacroOnOpened );	/* ƒI[ƒvƒ“Œã©“®Àsƒ}ƒNƒ”Ô† */	//@@@ 2006.09.01 ryoji
-	cProfile.IOProfileData( pszSecName, LTEXT("nMacroOnTypeChanged"), pShare->m_Common.m_sMacro.m_nMacroOnTypeChanged );	/* ƒ^ƒCƒv•ÏXŒã©“®Àsƒ}ƒNƒ”Ô† */	//@@@ 2006.09.01 ryoji
-	cProfile.IOProfileData( pszSecName, LTEXT("nMacroOnSave"), pShare->m_Common.m_sMacro.m_nMacroOnSave );	/* •Û‘¶‘O©“®Àsƒ}ƒNƒ”Ô† */	//@@@ 2006.09.01 ryoji
-	cProfile.IOProfileData( pszSecName, LTEXT("nMacroCancelTimer"), pShare->m_Common.m_sMacro.m_nMacroCancelTimer );	// ƒ}ƒNƒ’â~ƒ_ƒCƒAƒƒO•\¦‘Ò‚¿ŠÔ	// 2011.08.04 syat
+	cProfile.IOProfileData( pszSecName, LTEXT("nMacroOnOpened"), pShare->m_Common.m_sMacro.m_nMacroOnOpened );	/* ã‚ªãƒ¼ãƒ—ãƒ³å¾Œè‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå· */	//@@@ 2006.09.01 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("nMacroOnTypeChanged"), pShare->m_Common.m_sMacro.m_nMacroOnTypeChanged );	/* ã‚¿ã‚¤ãƒ—å¤‰æ›´å¾Œè‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå· */	//@@@ 2006.09.01 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("nMacroOnSave"), pShare->m_Common.m_sMacro.m_nMacroOnSave );	/* ä¿å­˜å‰è‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå· */	//@@@ 2006.09.01 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("nMacroCancelTimer"), pShare->m_Common.m_sMacro.m_nMacroCancelTimer );	// ãƒã‚¯ãƒ­åœæ­¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°è¡¨ç¤ºå¾…ã¡æ™‚é–“	// 2011.08.04 syat
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌStatusbarƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Statusbarã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
 	@date 2008/6/21 Uchi
 */
@@ -1888,19 +1888,19 @@ void CShareData_IO::ShareData_IO_Statusbar( CDataProfile& cProfile )
 	const WCHAR* pszSecName = LTEXT("Statusbar");
 	CommonSetting_Statusbar& statusbar = GetDllShareData().m_Common.m_sStatusbar;
 
-	// •\¦•¶šƒR[ƒh‚Ìw’è
-	cProfile.IOProfileData( pszSecName, LTEXT("DispUnicodeInSjis")			, statusbar.m_bDispUniInSjis);		// SJIS‚Å•¶šƒR[ƒh’l‚ğUnicode‚Å•\¦‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("DispUnicodeInJis")			, statusbar.m_bDispUniInJis);		// JIS‚Å•¶šƒR[ƒh’l‚ğUnicode‚Å•\¦‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("DispUnicodeInEuc")			, statusbar.m_bDispUniInEuc);		// EUC‚Å•¶šƒR[ƒh’l‚ğUnicode‚Å•\¦‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("DispUtf8Codepoint")			, statusbar.m_bDispUtf8Codepoint);	// UTF-8‚ğƒR[ƒhƒ|ƒCƒ“ƒg‚Å•\¦‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("DispSurrogatePairCodepoint")	, statusbar.m_bDispSPCodepoint);	// ƒTƒƒQ[ƒgƒyƒA‚ğƒR[ƒhƒ|ƒCƒ“ƒg‚Å•\¦‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("DispSelectCountByByte")		, statusbar.m_bDispSelCountByByte);	// ‘I‘ğ•¶š”‚ğ•¶š’PˆÊ‚Å‚Í‚È‚­ƒoƒCƒg’PˆÊ‚Å•\¦‚·‚é
-	cProfile.IOProfileData( pszSecName, LTEXT("DispColByChar")				, statusbar.m_bDispColByChar);		// Œ»İŒ…‚ğƒ‹[ƒ‰[’PˆÊ‚Å‚Í‚È‚­•¶š’PˆÊ‚Å•\¦‚·‚é
+	// è¡¨ç¤ºæ–‡å­—ã‚³ãƒ¼ãƒ‰ã®æŒ‡å®š
+	cProfile.IOProfileData( pszSecName, LTEXT("DispUnicodeInSjis")			, statusbar.m_bDispUniInSjis);		// SJISã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("DispUnicodeInJis")			, statusbar.m_bDispUniInJis);		// JISã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("DispUnicodeInEuc")			, statusbar.m_bDispUniInEuc);		// EUCã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("DispUtf8Codepoint")			, statusbar.m_bDispUtf8Codepoint);	// UTF-8ã‚’ã‚³ãƒ¼ãƒ‰ãƒã‚¤ãƒ³ãƒˆã§è¡¨ç¤ºã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("DispSurrogatePairCodepoint")	, statusbar.m_bDispSPCodepoint);	// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢ã‚’ã‚³ãƒ¼ãƒ‰ãƒã‚¤ãƒ³ãƒˆã§è¡¨ç¤ºã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("DispSelectCountByByte")		, statusbar.m_bDispSelCountByByte);	// é¸æŠæ–‡å­—æ•°ã‚’æ–‡å­—å˜ä½ã§ã¯ãªããƒã‚¤ãƒˆå˜ä½ã§è¡¨ç¤ºã™ã‚‹
+	cProfile.IOProfileData( pszSecName, LTEXT("DispColByChar")				, statusbar.m_bDispColByChar);		// ç¾åœ¨æ¡ã‚’ãƒ«ãƒ¼ãƒ©ãƒ¼å˜ä½ã§ã¯ãªãæ–‡å­—å˜ä½ã§è¡¨ç¤ºã™ã‚‹
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌPluginƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Pluginã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
 	@date 2009/11/30 syat
 */
@@ -1910,16 +1910,16 @@ void CShareData_IO::ShareData_IO_Plugin( CDataProfile& cProfile, CMenuDrawer* pc
 	CommonSetting& common = GetDllShareData().m_Common;
 	CommonSetting_Plugin& plugin = GetDllShareData().m_Common.m_sPlugin;
 
-	cProfile.IOProfileData( pszSecName, LTEXT("EnablePlugin"), plugin.m_bEnablePlugin);		// ƒvƒ‰ƒOƒCƒ“‚ğg—p‚·‚é
+	cProfile.IOProfileData( pszSecName, LTEXT("EnablePlugin"), plugin.m_bEnablePlugin);		// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ä½¿ç”¨ã™ã‚‹
 
-	//ƒvƒ‰ƒOƒCƒ“ƒe[ƒuƒ‹
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ†ãƒ¼ãƒ–ãƒ«
 	int		i;
 	int		j;
 	WCHAR	szKeyName[64];
 	for( i = 0; i < MAX_PLUGIN; ++i ){
 		PluginRec& pluginrec = common.m_sPlugin.m_PluginTable[i];
 
-		// 2010.08.04 Moca ‘‚«‚İ’¼‘O‚Éíœƒtƒ‰ƒO‚Åíœˆµ‚¢‚É‚·‚é
+		// 2010.08.04 Moca æ›¸ãè¾¼ã¿ç›´å‰ã«å‰Šé™¤ãƒ•ãƒ©ã‚°ã§å‰Šé™¤æ‰±ã„ã«ã™ã‚‹
 		if( pluginrec.m_state == PLS_DELETED ){
 			pluginrec.m_szName[0] = L'\0';
 			pluginrec.m_szId[0] = L'\0';
@@ -1931,7 +1931,7 @@ void CShareData_IO::ShareData_IO_Plugin( CDataProfile& cProfile, CMenuDrawer* pc
 		auto_sprintf( szKeyName, LTEXT("P[%02d].CmdNum"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pluginrec.m_nCmdNum );	// 2010/7/4 Uchi
 		pluginrec.m_state = ( pluginrec.m_szId[0] == '\0' ? PLS_NONE : PLS_STOPPED );
-		// Command ‰¼İ’è	// 2010/7/4 Uchi
+		// Command ä»®è¨­å®š	// 2010/7/4 Uchi
 		if (pluginrec.m_szId[0] != '\0' && pluginrec.m_nCmdNum >0) {
 			for (j = 1; j <= pluginrec.m_nCmdNum; j++) {
 				pcMenuDrawer->AddToolButton( CMenuDrawer::TOOLBAR_ICON_PLUGCOMMAND_DEFAULT, CPlug::GetPluginFunctionCode(i, j) );
@@ -1954,10 +1954,10 @@ void CShareData_IO::ShareData_IO_MainMenu( CDataProfile& cProfile )
 {
 	IO_MainMenu( cProfile, GetDllShareData().m_Common.m_sMainMenu, false );		// 2010/5/15 Uchi
 
-	// 2015.02.26 Moca ƒƒCƒ“ƒƒjƒ…[©“®XV
+	// 2015.02.26 Moca ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼è‡ªå‹•æ›´æ–°
 	const WCHAR*	pszSecName = LTEXT("MainMenu");
 	int& nVersion = GetDllShareData().m_Common.m_sMainMenu.m_nVersion;
-	// ¦ƒƒjƒ…[’è‹`‚ğ’Ç‰Á‚µ‚½‚çnCurrentVer‚ğC³
+	// â€»ãƒ¡ãƒ‹ãƒ¥ãƒ¼å®šç¾©ã‚’è¿½åŠ ã—ãŸã‚‰nCurrentVerã‚’ä¿®æ­£
 	const int nCurrentVer = 2;
 	nVersion = nCurrentVer;
 	if( cProfile.IOProfileData(pszSecName, LTEXT("nMainMenuVer"), nVersion) ){
@@ -1965,38 +1965,38 @@ void CShareData_IO::ShareData_IO_MainMenu( CDataProfile& cProfile )
 		if( cProfile.IsReadingMode() ){
 			int menuNum;
 			if( cProfile.IOProfileData(pszSecName, LTEXT("nMainMenuNum"), menuNum) ){
-				// ƒƒCƒ“ƒƒjƒ…[‚ª’è‹`‚³‚ê‚Ä‚¢‚½
-				nVersion = 0; // ‹Œ’è‹`‚ÍVer0
+				// ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãŒå®šç¾©ã•ã‚Œã¦ã„ãŸ
+				nVersion = 0; // æ—§å®šç¾©ã¯Ver0
 			}else{
-				// ƒƒCƒ“ƒƒjƒ…[‚·‚ç‚È‚¢ŒÃ‚¢ƒo[ƒWƒ‡ƒ“‚©‚ç‚ÌƒAƒbƒvƒf[ƒg‚Å‚ÍAÅVƒƒjƒ…[‚É‚È‚é‚Ì‚ÅƒpƒX
+				// ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã™ã‚‰ãªã„å¤ã„ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã‹ã‚‰ã®ã‚¢ãƒƒãƒ—ãƒ‡ãƒ¼ãƒˆã§ã¯ã€æœ€æ–°ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«ãªã‚‹ã®ã§ãƒ‘ã‚¹
 			}
 		}
 	}
 	if( cProfile.IsReadingMode() && nVersion < nCurrentVer ){
 		CommonSetting_MainMenu& mainmenu = GetDllShareData().m_Common.m_sMainMenu;
 		SMainMenuAddItemInfo addInfos[] = {
-			{1, F_FILENEW_NEWWINDOW, F_FILENEW, L'M', false, false},	// V‚µ‚¢ƒEƒCƒ“ƒhƒE‚ğŠJ‚­
-			{1, F_CHG_CHARSET, F_TOGGLE_KEY_SEARCH, L'A', false, false},	// •¶šƒR[ƒh•ÏX
-			{1, F_CHG_CHARSET, F_VIEWMODE, L'A', false, false}, 	// •¶šƒR[ƒh•ÏX(Sub)
-			{1, F_FILE_REOPEN_LATIN1, F_FILE_REOPEN_EUC, L'L', false, false}, 	// Latin1‚ÅŠJ‚«’¼‚·
-			{1, F_FILE_REOPEN_LATIN1, F_FILE_REOPEN, L'L', false, false}, 	// Latin1‚ÅŠJ‚«’¼‚·(Sub)
-			{1, F_COPY_COLOR_HTML, F_COPYLINESWITHLINENUMBER, L'C', false, false}, 	// ‘I‘ğ”ÍˆÍ“àF•t‚«HTMLƒRƒs[
-			{1, F_COPY_COLOR_HTML_LINENUMBER, F_COPY_COLOR_HTML, L'F', false, false}, 	// ‘I‘ğ”ÍˆÍ“às”Ô†F•t‚«HTMLƒRƒs[
-			// ‹éŒ`‘I‘ğ—Ş‚ÍÈ—ª...
-			{1, F_GREP_REPLACE_DLG, F_GREP_DIALOG, L'\0', false, false}, 	// Grep’uŠ·
-			{1, F_FILETREE, F_OUTLINE, L'E', false, false}, 	// ƒtƒ@ƒCƒ‹ƒcƒŠ[•\¦
-			{1, F_FILETREE, F_OUTLINE_TOGGLE, L'E', false, false}, 	// ƒtƒ@ƒCƒ‹ƒcƒŠ[•\¦(Sub)
-			{1, F_SHOWMINIMAP, F_SHOWSTATUSBAR, L'N', false, false}, 	// ƒ~ƒjƒ}ƒbƒv•\¦
-			{1, F_SHOWMINIMAP, F_SHOWTAB, L'N', false, false}, 	// ƒ~ƒjƒ}ƒbƒv•\¦(Sub)
-			{1, F_SHOWMINIMAP, F_SHOWFUNCKEY, L'N', false, false}, 	// ƒ~ƒjƒ}ƒbƒv•\¦(Sub)
-			{1, F_SHOWMINIMAP, F_SHOWTOOLBAR, L'N', false, false}, 	// ƒ~ƒjƒ}ƒbƒv•\¦(Sub)
-			{1, F_FUNCLIST_NEXT, F_JUMPHIST_SET, L'\0', true, false}, 	// Ÿ‚ÌŠÖ”ƒŠƒXƒgƒ}[ƒN(ƒZƒpƒŒ[ƒ^’Ç‰Á)
-			{1, F_FUNCLIST_PREV, F_FUNCLIST_NEXT, L'\0', false, false}, 	// ‘O‚ÌŠÖ”ƒŠƒXƒgƒ}[ƒN
-			{1, F_MODIFYLINE_NEXT, F_FUNCLIST_PREV, L'\0', false, false}, 	// Ÿ‚Ì•ÏXs‚Ö
-			{1, F_MODIFYLINE_PREV, F_MODIFYLINE_NEXT, L'\0', false, false}, 	// ‘O‚Ì•ÏXs‚Ö
-			{1, F_MODIFYLINE_NEXT_SEL, F_GOFILEEND_SEL, L'\0', true, false}, 	// (‘I‘ğ)Ÿ‚Ì•ÏXs‚Ö
-			{1, F_MODIFYLINE_PREV_SEL, F_MODIFYLINE_NEXT_SEL, L'\0', false, false}, 	// (‘I‘ğ)‘O‚Ì•ÏXs‚Ö
-			{2, F_DLGWINLIST, F_WIN_OUTPUT, L'D', false, false}, 	// ƒEƒCƒ“ƒhƒEˆê——•\¦
+			{1, F_FILENEW_NEWWINDOW, F_FILENEW, L'M', false, false},	// æ–°ã—ã„ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã
+			{1, F_CHG_CHARSET, F_TOGGLE_KEY_SEARCH, L'A', false, false},	// æ–‡å­—ã‚³ãƒ¼ãƒ‰å¤‰æ›´
+			{1, F_CHG_CHARSET, F_VIEWMODE, L'A', false, false}, 	// æ–‡å­—ã‚³ãƒ¼ãƒ‰å¤‰æ›´(Sub)
+			{1, F_FILE_REOPEN_LATIN1, F_FILE_REOPEN_EUC, L'L', false, false}, 	// Latin1ã§é–‹ãç›´ã™
+			{1, F_FILE_REOPEN_LATIN1, F_FILE_REOPEN, L'L', false, false}, 	// Latin1ã§é–‹ãç›´ã™(Sub)
+			{1, F_COPY_COLOR_HTML, F_COPYLINESWITHLINENUMBER, L'C', false, false}, 	// é¸æŠç¯„å›²å†…è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼
+			{1, F_COPY_COLOR_HTML_LINENUMBER, F_COPY_COLOR_HTML, L'F', false, false}, 	// é¸æŠç¯„å›²å†…è¡Œç•ªå·è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼
+			// çŸ©å½¢é¸æŠé¡ã¯çœç•¥...
+			{1, F_GREP_REPLACE_DLG, F_GREP_DIALOG, L'\0', false, false}, 	// Grepç½®æ›
+			{1, F_FILETREE, F_OUTLINE, L'E', false, false}, 	// ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼è¡¨ç¤º
+			{1, F_FILETREE, F_OUTLINE_TOGGLE, L'E', false, false}, 	// ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼è¡¨ç¤º(Sub)
+			{1, F_SHOWMINIMAP, F_SHOWSTATUSBAR, L'N', false, false}, 	// ãƒŸãƒ‹ãƒãƒƒãƒ—è¡¨ç¤º
+			{1, F_SHOWMINIMAP, F_SHOWTAB, L'N', false, false}, 	// ãƒŸãƒ‹ãƒãƒƒãƒ—è¡¨ç¤º(Sub)
+			{1, F_SHOWMINIMAP, F_SHOWFUNCKEY, L'N', false, false}, 	// ãƒŸãƒ‹ãƒãƒƒãƒ—è¡¨ç¤º(Sub)
+			{1, F_SHOWMINIMAP, F_SHOWTOOLBAR, L'N', false, false}, 	// ãƒŸãƒ‹ãƒãƒƒãƒ—è¡¨ç¤º(Sub)
+			{1, F_FUNCLIST_NEXT, F_JUMPHIST_SET, L'\0', true, false}, 	// æ¬¡ã®é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯(ã‚»ãƒ‘ãƒ¬ãƒ¼ã‚¿è¿½åŠ )
+			{1, F_FUNCLIST_PREV, F_FUNCLIST_NEXT, L'\0', false, false}, 	// å‰ã®é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯
+			{1, F_MODIFYLINE_NEXT, F_FUNCLIST_PREV, L'\0', false, false}, 	// æ¬¡ã®å¤‰æ›´è¡Œã¸
+			{1, F_MODIFYLINE_PREV, F_MODIFYLINE_NEXT, L'\0', false, false}, 	// å‰ã®å¤‰æ›´è¡Œã¸
+			{1, F_MODIFYLINE_NEXT_SEL, F_GOFILEEND_SEL, L'\0', true, false}, 	// (é¸æŠ)æ¬¡ã®å¤‰æ›´è¡Œã¸
+			{1, F_MODIFYLINE_PREV_SEL, F_MODIFYLINE_NEXT_SEL, L'\0', false, false}, 	// (é¸æŠ)å‰ã®å¤‰æ›´è¡Œã¸
+			{2, F_DLGWINLIST, F_WIN_OUTPUT, L'D', false, false}, 	// ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ä¸€è¦§è¡¨ç¤º
 		};
 		for( int i = 0; i < _countof(addInfos); i++ ){
 			SMainMenuAddItemInfo& item = addInfos[i];
@@ -2018,10 +2018,10 @@ void CShareData_IO::ShareData_IO_MainMenu( CDataProfile& cProfile )
 				nAddSep++;
 			}
 			if( k == mainmenu.m_nMainMenuNum && mainmenu.m_nMainMenuNum + nAddSep < _countof(mainmenu.m_cMainMenuTbl) ){
-				// ƒƒjƒ…[“à‚É‚Ü‚¾’Ç‰Á‚³‚ê‚Ä‚¢‚È‚¢‚Ì‚Å’Ç‰Á‚·‚é
+				// ãƒ¡ãƒ‹ãƒ¥ãƒ¼å†…ã«ã¾ã è¿½åŠ ã•ã‚Œã¦ã„ãªã„ã®ã§è¿½åŠ ã™ã‚‹
 				for( int r = 0; r < mainmenu.m_nMainMenuNum; r++ ){
 					if( pcMenuTlb[r].m_nFunc == item.m_nPrevFuncCode && 0 < pcMenuTlb[r].m_nLevel ){
-						// ’Ç‰Á•ªŒã‚ë‚É‚¸‚ç‚·
+						// è¿½åŠ åˆ†å¾Œã‚ã«ãšã‚‰ã™
 						for( int n = mainmenu.m_nMainMenuNum - 1; r < n; n-- ){
 							pcMenuTlb[n + 1 + nAddSep] = pcMenuTlb[n];
 						}
@@ -2069,13 +2069,13 @@ void CShareData_IO::ShareData_IO_MainMenu( CDataProfile& cProfile )
 
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌMainMenuƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
-	@param[in,out]	mainmenu	‹¤’Êİ’èMainMenuƒNƒ‰ƒX
-	@param[in]		bOutCmdName	o—ÍA–¼‘O‚Åo—Í
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®MainMenuã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
+	@param[in,out]	mainmenu	å…±é€šè¨­å®šMainMenuã‚¯ãƒ©ã‚¹
+	@param[in]		bOutCmdName	å‡ºåŠ›æ™‚ã€åå‰ã§å‡ºåŠ›
 
 	@date 2010/5/15 Uchi
-	@date 2014.11.21 Moca pData’Ç‰ÁBƒf[ƒ^‚Ì‚İ‚Ìƒ^ƒCƒv‚ğ’Ç‰Á
+	@date 2014.11.21 Moca pDataè¿½åŠ ã€‚ãƒ‡ãƒ¼ã‚¿ã®ã¿ã®ã‚¿ã‚¤ãƒ—ã‚’è¿½åŠ 
 */
 void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstring>* pData, CommonSetting_MainMenu& mainmenu, bool bOutCmdName)
 {
@@ -2115,18 +2115,18 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 	}
 
 	if (cProfile.IsReadingMode()) {
-		// Top Level ‰Šú‰»
+		// Top Level åˆæœŸåŒ–
 		memset( mainmenu.m_nMenuTopIdx, -1, sizeof(mainmenu.m_nMenuTopIdx) );
 	}
 
 	nIdx = 0;
 	for (int i = 0; i < mainmenu.m_nMainMenuNum; i++) {
-		//ƒƒCƒ“ƒƒjƒ…[ƒe[ƒuƒ‹
+		//ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒ†ãƒ¼ãƒ–ãƒ«
 		pcMenu = &mainmenu.m_cMainMenuTbl[i];
 
 		auto_sprintf( szKeyName, LTEXT("MM[%03d]"), i );
 		if (cProfile.IsReadingMode()) {
-			// “Ç‚İ‚İ‰Šú‰»
+			// èª­ã¿è¾¼ã¿æ™‚åˆæœŸåŒ–
 			pcMenu->m_nType    = T_NODE;
 			pcMenu->m_nFunc    = F_INVALID;
 			pcMenu->m_nLevel   = 0;
@@ -2134,14 +2134,14 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 			pcMenu->m_sKey[0]  = L'\0';
 			pcMenu->m_sKey[1]  = L'\0';
 
-			// “Ç‚İo‚µ
+			// èª­ã¿å‡ºã—
 			if( pData ){
 				wcscpy(szLine, data[dataNum++].c_str());
 			}else{
 				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW( szLine ) );
 			}
 
-			// ƒŒƒxƒ‹
+			// ãƒ¬ãƒ™ãƒ«
 			p = szLine;
 			pn = wcschr( p, L',' );
 			if (pn != NULL)		*pn++ = L'\0';
@@ -2150,7 +2150,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 				continue;
 			}
 
-			// í—Ş
+			// ç¨®é¡
 			p = pn;
 			pn = wcschr( p, L',' );
 			if (pn != NULL)		*pn++ = L'\0';
@@ -2159,7 +2159,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 				continue;
 			}
 			
-			// ‹@”\(ƒ}ƒNƒ–¼‘Î‰)
+			// æ©Ÿèƒ½(ãƒã‚¯ãƒ­åå¯¾å¿œ)
 			p = pn;
 			pn = wcschr( p, L',' );
 			if (pn != NULL)		*pn++ = L'\0';
@@ -2169,10 +2169,10 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 				continue;
 			}
 
-			// ƒAƒNƒZƒXƒL[
+			// ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼
 			p = pn;
 			if ( *p == L',' ) {
-				// Key ‚È‚µ or ,
+				// Key ãªã— or ,
 				if ( p[1] == L',') {
 					// Key = ,
 					pcMenu->m_sKey[0]  = *p++;
@@ -2185,7 +2185,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 				continue;
 			}
 
-			// •\¦–¼
+			// è¡¨ç¤ºå
 			p++;
 			auto_strcpy_s( pcMenu->m_sName, MAX_MAIN_MENU_NAME_LEN+1, p );
 		}
@@ -2195,7 +2195,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 			}
 			else {
 				if (bOutCmdName) {
-					// ƒ}ƒNƒ–¼‘Î‰
+					// ãƒã‚¯ãƒ­åå¯¾å¿œ
 					p = CSMacroMgr::GetFuncInfoByID(
 						G_AppInstance(),
 						pcMenu->m_nFunc,
@@ -2207,8 +2207,8 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 					auto_sprintf( szFuncName, L"%d", pcMenu->m_nFunc );
 				}
 			}
-			// ‘‚«‚İ
-			// ƒ‰ƒxƒ‹•ÒWŒã‚Ìƒm[ƒh‚Íƒm[ƒh–¼‚ğo—Í‚·‚é 2012.10.14 syat Še‘Œê‘Î‰
+			// æ›¸ãè¾¼ã¿
+			// ãƒ©ãƒ™ãƒ«ç·¨é›†å¾Œã®ãƒãƒ¼ãƒ‰ã¯ãƒãƒ¼ãƒ‰åã‚’å‡ºåŠ›ã™ã‚‹ 2012.10.14 syat å„å›½èªå¯¾å¿œ
 			auto_sprintf( szLine, L"%d,%d,%ls,%ls,%ls", 
 				pcMenu->m_nLevel, 
 				pcMenu->m_nType, 
@@ -2219,7 +2219,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 		}
 
 		if (cProfile.IsReadingMode() && pcMenu->m_nLevel == 0) {
-			// Top Levelİ’è
+			// Top Levelè¨­å®š
 			if (nIdx < MAX_MAINMENU_TOP) {
 				mainmenu.m_nMenuTopIdx[nIdx++] = i;
 			}
@@ -2228,36 +2228,36 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 }
 
 /*!
-	@brief ‹¤—Lƒf[ƒ^‚ÌOtherƒZƒNƒVƒ‡ƒ“‚Ì“üo—Í
-	@param[in,out]	cProfile	INIƒtƒ@ƒCƒ‹“üo—ÍƒNƒ‰ƒX
+	@brief å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®Otherã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®å…¥å‡ºåŠ›
+	@param[in,out]	cProfile	INIãƒ•ã‚¡ã‚¤ãƒ«å…¥å‡ºåŠ›ã‚¯ãƒ©ã‚¹
 
-	@date 2005-04-07 D.S.Koba ShareData_IO_2‚©‚ç•ª—£B
+	@date 2005-04-07 D.S.Koba ShareData_IO_2ã‹ã‚‰åˆ†é›¢ã€‚
 */
 void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 {
 	DLLSHAREDATA* pShare = &GetDllShareData();
 
-	const WCHAR* pszSecName = LTEXT("Other");	//ƒZƒNƒVƒ‡ƒ“‚ğ1ŒÂì¬‚µ‚½B2003.05.12 MIK
+	const WCHAR* pszSecName = LTEXT("Other");	//ã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’1å€‹ä½œæˆã—ãŸã€‚2003.05.12 MIK
 	int		i;	
 	WCHAR	szKeyName[64];
 
-	/* **** ‚»‚Ì‘¼‚Ìƒ_ƒCƒAƒƒO **** */
-	/* ŠO•”ƒRƒ}ƒ“ƒhÀs‚Ìu•W€o—Í‚ğ“¾‚év */
-	if(!cProfile.IOProfileData( pszSecName, LTEXT("nExecFlgOpt")	, pShare->m_nExecFlgOpt ) ){ //	2006.12.03 maru ƒIƒvƒVƒ‡ƒ“Šg’£
+	/* **** ãã®ä»–ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚° **** */
+	/* å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œã®ã€Œæ¨™æº–å‡ºåŠ›ã‚’å¾—ã‚‹ã€ */
+	if(!cProfile.IOProfileData( pszSecName, LTEXT("nExecFlgOpt")	, pShare->m_nExecFlgOpt ) ){ //	2006.12.03 maru ã‚ªãƒ—ã‚·ãƒ§ãƒ³æ‹¡å¼µ
 		cProfile.IOProfileData( pszSecName, LTEXT("bGetStdout")		, pShare->m_nExecFlgOpt );
 	}
 
-	/* w’ès‚ÖƒWƒƒƒ“ƒv‚Ìu‰üs’PˆÊ‚Ìs”Ô†v‚©uÜ‚è•Ô‚µ’PˆÊ‚Ìs”Ô†v‚© */
+	/* æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—ã®ã€Œæ”¹è¡Œå˜ä½ã®è¡Œç•ªå·ã€ã‹ã€ŒæŠ˜ã‚Šè¿”ã—å˜ä½ã®è¡Œç•ªå·ã€ã‹ */
 	cProfile.IOProfileData( pszSecName, LTEXT("bLineNumIsCRLF")	, pShare->m_bLineNumIsCRLF_ForJump );
 	
-	/* DIFF·•ª•\¦ */	//@@@ 2002.05.27 MIK
+	/* DIFFå·®åˆ†è¡¨ç¤º */	//@@@ 2002.05.27 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("nDiffFlgOpt")	, pShare->m_nDiffFlgOpt );
 	
 	/* CTAGS */	//@@@ 2003.05.12 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("nTagsOpt")		, pShare->m_nTagsOpt );
 	cProfile.IOProfileData( pszSecName, LTEXT("szTagsCmdLine")	, MakeStringBufferT(pShare->m_szTagsCmdLine) );
 	
-	//From Here 2005.04.03 MIK ƒL[ƒ[ƒhw’èƒ^ƒOƒWƒƒƒ“ƒv
+	//From Here 2005.04.03 MIK ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®šã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—
 	cProfile.IOProfileData( pszSecName, LTEXT("_TagJumpKeyword_Counts"), pShare->m_sTagJump.m_aTagJumpKeywords._GetSizeRef() );
 	pShare->m_sHistory.m_aCommands.SetSizeLimit();
 	int nSize = pShare->m_sTagJump.m_aTagJumpKeywords.size();
@@ -2270,9 +2270,9 @@ void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 	}
 	cProfile.IOProfileData( pszSecName, LTEXT("m_bTagJumpICase")		, pShare->m_sTagJump.m_bTagJumpICase );
 	cProfile.IOProfileData( pszSecName, LTEXT("m_bTagJumpAnyWhere")		, pShare->m_sTagJump.m_bTagJumpAnyWhere );
-	//From Here 2005.04.03 MIK ƒL[ƒ[ƒhw’èƒ^ƒOƒWƒƒƒ“ƒv‚Ì
+	//From Here 2005.04.03 MIK ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®šã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã®
 
-	//	MIK ƒo[ƒWƒ‡ƒ“î•ñi‘‚«‚İ‚Ì‚İj
+	//	MIK ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±ï¼ˆæ›¸ãè¾¼ã¿ã®ã¿ï¼‰
 	if( ! cProfile.IsReadingMode() ){
 		TCHAR	iniVer[256];
 		auto_sprintf( iniVer, _T("%d.%d.%d.%d"), 
@@ -2282,7 +2282,7 @@ void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 					LOWORD( pShare->m_sVersion.m_dwProductVersionLS ) );
 		cProfile.IOProfileData( pszSecName, LTEXT("szVersion"), MakeStringBufferT(iniVer) );
 
-		// ‹¤—Lƒƒ‚ƒŠƒo[ƒWƒ‡ƒ“	2010/5/20 Uchi
+		// å…±æœ‰ãƒ¡ãƒ¢ãƒªãƒãƒ¼ã‚¸ãƒ§ãƒ³	2010/5/20 Uchi
 		int		nStructureVersion;
 		nStructureVersion = int(pShare->m_vStructureVersion);
 		cProfile.IOProfileData( pszSecName, LTEXT("vStructureVersion"), nStructureVersion );
@@ -2291,14 +2291,14 @@ void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 }
 
 /*!
-	@brief Fİ’è I/O
+	@brief è‰²è¨­å®š I/O
 
-	w’è‚³‚ê‚½Fİ’è‚ğw’è‚³‚ê‚½ƒZƒNƒVƒ‡ƒ“‚É‘‚«‚ŞB‚Ü‚½‚Í
-	w’è‚³‚ê‚½ƒZƒNƒVƒ‡ƒ“‚©‚ç‚¢‚ëİ’è‚ğ“Ç‚İ‚ŞB
+	æŒ‡å®šã•ã‚ŒãŸè‰²è¨­å®šã‚’æŒ‡å®šã•ã‚ŒãŸã‚»ã‚¯ã‚·ãƒ§ãƒ³ã«æ›¸ãè¾¼ã‚€ã€‚ã¾ãŸã¯
+	æŒ‡å®šã•ã‚ŒãŸã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‹ã‚‰ã„ã‚è¨­å®šã‚’èª­ã¿è¾¼ã‚€ã€‚
 
-	@param[in,out]	pcProfile		‘‚«o‚µA“Ç‚İ‚İæProfile object (“üo—Í•ûŒü‚ÍbRead‚ÉˆË‘¶)
-	@param[in]		pszSecName		ƒZƒNƒVƒ‡ƒ“–¼
-	@param[in,out]	pColorInfoArr	‘‚«o‚µA“Ç‚İ‚İ‘ÎÛ‚ÌFİ’è‚Ö‚Ìƒ|ƒCƒ“ƒ^ (“üo—Í•ûŒü‚ÍbRead‚ÉˆË‘¶)
+	@param[in,out]	pcProfile		æ›¸ãå‡ºã—ã€èª­ã¿è¾¼ã¿å…ˆProfile object (å…¥å‡ºåŠ›æ–¹å‘ã¯bReadã«ä¾å­˜)
+	@param[in]		pszSecName		ã‚»ã‚¯ã‚·ãƒ§ãƒ³å
+	@param[in,out]	pColorInfoArr	æ›¸ãå‡ºã—ã€èª­ã¿è¾¼ã¿å¯¾è±¡ã®è‰²è¨­å®šã¸ã®ãƒã‚¤ãƒ³ã‚¿ (å…¥å‡ºåŠ›æ–¹å‘ã¯bReadã«ä¾å­˜)
 */
 void CShareData_IO::IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecName, ColorInfo* pColorInfoArr )
 {
@@ -2320,13 +2320,13 @@ void CShareData_IO::IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecNam
 			}
 			else{
 				// 2006.12.07 ryoji
-				// sakura Ver1.5.13.1 ˆÈ‘O‚Ìiniƒtƒ@ƒCƒ‹‚ğ“Ç‚ñ‚¾‚Æ‚«‚ÉƒLƒƒƒŒƒbƒg‚ªƒeƒLƒXƒg”wŒiF‚Æ“¯‚¶‚É‚È‚é‚Æ
-				// ‚¿‚å‚Á‚Æ¢‚é‚Ì‚ÅƒLƒƒƒŒƒbƒgF‚ª“Ç‚ß‚È‚¢‚Æ‚«‚ÍƒLƒƒƒŒƒbƒgF‚ğƒeƒLƒXƒgF‚Æ“¯‚¶‚É‚·‚é
+				// sakura Ver1.5.13.1 ä»¥å‰ã®iniãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã‚“ã ã¨ãã«ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒãƒ†ã‚­ã‚¹ãƒˆèƒŒæ™¯è‰²ã¨åŒã˜ã«ãªã‚‹ã¨
+				// ã¡ã‚‡ã£ã¨å›°ã‚‹ã®ã§ã‚­ãƒ£ãƒ¬ãƒƒãƒˆè‰²ãŒèª­ã‚ãªã„ã¨ãã¯ã‚­ãƒ£ãƒ¬ãƒƒãƒˆè‰²ã‚’ãƒ†ã‚­ã‚¹ãƒˆè‰²ã¨åŒã˜ã«ã™ã‚‹
 				if( COLORIDX_CARET == j )
 					pColorInfoArr[j].m_sColorAttr.m_cTEXT = pColorInfoArr[COLORIDX_TEXT].m_sColorAttr.m_cTEXT;
 			}
 			// 2006.12.18 ryoji
-			// –µ‚İ’è‚ª‚ ‚ê‚ÎC•œ‚·‚é
+			// çŸ›ç›¾è¨­å®šãŒã‚ã‚Œã°ä¿®å¾©ã™ã‚‹
 			unsigned int fAttribute = g_ColorAttributeArr[j].fAttribute;
 			if( 0 != (fAttribute & COLOR_ATTRIB_FORCE_DISP) )
 				pColorInfoArr[j].m_bDisp = true;
@@ -2351,7 +2351,7 @@ void CShareData_IO::IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecNam
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         À‘••â•                            //
+//                         å®Ÿè£…è£œåŠ©                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 void ShareData_IO_Sub_LogFont( CDataProfile& cProfile, const WCHAR* pszSecName,
 	const WCHAR* pszKeyLf, const WCHAR* pszKeyPointSize, const WCHAR* pszKeyFaceName, LOGFONT& lf, INT& nPointSize )
@@ -2378,12 +2378,12 @@ void ShareData_IO_Sub_LogFont( CDataProfile& cProfile, const WCHAR* pszSecName,
 			lf.lfQuality		= (BYTE)buf[11];
 			lf.lfPitchAndFamily	= (BYTE)buf[12];
 			if( nPointSize != 0 ){
-				// DPI•ÏX‚µ‚Ä‚àƒtƒHƒ“ƒg‚Ìƒ|ƒCƒ“ƒgƒTƒCƒY‚ª•Ï‚í‚ç‚È‚¢‚æ‚¤‚É
-				// ƒ|ƒCƒ“ƒg”‚©‚çƒsƒNƒZƒ‹”‚É•ÏŠ·‚·‚é
-				lf.lfHeight = -DpiPointsToPixels( abs(nPointSize), 10 );	// pointSize: 1/10ƒ|ƒCƒ“ƒg’PˆÊ‚ÌƒTƒCƒY
+				// DPIå¤‰æ›´ã—ã¦ã‚‚ãƒ•ã‚©ãƒ³ãƒˆã®ãƒã‚¤ãƒ³ãƒˆã‚µã‚¤ã‚ºãŒå¤‰ã‚ã‚‰ãªã„ã‚ˆã†ã«
+				// ãƒã‚¤ãƒ³ãƒˆæ•°ã‹ã‚‰ãƒ”ã‚¯ã‚»ãƒ«æ•°ã«å¤‰æ›ã™ã‚‹
+				lf.lfHeight = -DpiPointsToPixels( abs(nPointSize), 10 );	// pointSize: 1/10ãƒã‚¤ãƒ³ãƒˆå˜ä½ã®ã‚µã‚¤ã‚º
 			}else{
-				// ‰‰ñ‚Ü‚½‚ÍŒÃ‚¢ƒo[ƒWƒ‡ƒ“‚©‚ç‚ÌXV‚Íƒ|ƒCƒ“ƒg”‚ğƒsƒNƒZƒ‹”‚©‚ç‹tZ‚µ‚Ä‰¼İ’è
-				nPointSize = DpiPixelsToPoints( abs(lf.lfHeight), 10 );		// i]—ˆƒtƒHƒ“ƒgƒ_ƒCƒAƒƒO‚Å¬”“_‚Íw’è•s‰Âj
+				// åˆå›ã¾ãŸã¯å¤ã„ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã‹ã‚‰ã®æ›´æ–°æ™‚ã¯ãƒã‚¤ãƒ³ãƒˆæ•°ã‚’ãƒ”ã‚¯ã‚»ãƒ«æ•°ã‹ã‚‰é€†ç®—ã—ã¦ä»®è¨­å®š
+				nPointSize = DpiPixelsToPoints( abs(lf.lfHeight), 10 );		// ï¼ˆå¾“æ¥ãƒ•ã‚©ãƒ³ãƒˆãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã§å°æ•°ç‚¹ã¯æŒ‡å®šä¸å¯ï¼‰
 			}
 		}
 	}else{

--- a/sakura_core/env/CShareData_IO.h
+++ b/sakura_core/env/CShareData_IO.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -32,17 +32,17 @@ struct CommonSetting_KeyBind;	// defined CommonSetting.h
 struct ColorInfo; // defined doc/CDocTypeSetting.h
 struct SFileTree;
 
-// 2008.XX.XX kobake CShareData‚©‚ç•ª—£
-// 2008.05.24 Uchi   ShareData_IO_CustMenu, ShareData_IO_KeyBind  move ExportAImport‚Ég—p
-// 2010.08.21 Moca ƒAƒNƒZƒXŒ AŠÖ”–¼‚Ì®—
+// 2008.XX.XX kobake CShareDataã‹ã‚‰åˆ†é›¢
+// 2008.05.24 Uchi   ShareData_IO_CustMenu, ShareData_IO_KeyBind  move Exportã€Importã«ä½¿ç”¨
+// 2010.08.21 Moca ã‚¢ã‚¯ã‚»ã‚¹æ¨©ã€é–¢æ•°åã®æ•´ç†
 class CShareData_IO{
 public:
-	//ƒZ[ƒuEƒ[ƒh
-	static bool LoadShareData();	/* ‹¤—Lƒf[ƒ^‚Ìƒ[ƒh */
-	static void SaveShareData();	/* ‹¤—Lƒf[ƒ^‚Ì•Û‘¶ */
+	//ã‚»ãƒ¼ãƒ–ãƒ»ãƒ­ãƒ¼ãƒ‰
+	static bool LoadShareData();	/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®ãƒ­ãƒ¼ãƒ‰ */
+	static void SaveShareData();	/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®ä¿å­˜ */
 
 protected:
-	static bool ShareData_IO_2( bool );	/* ‹¤—Lƒf[ƒ^‚Ì•Û‘¶ */
+	static bool ShareData_IO_2( bool );	/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã®ä¿å­˜ */
 
 	// Feb. 12, 2006 D.S.Koba
 	static void ShareData_IO_Mru( CDataProfile& );
@@ -68,7 +68,7 @@ protected:
 public:
 	static void ShareData_IO_FileTree( CDataProfile&, SFileTree&, const WCHAR* );
 	static void ShareData_IO_FileTreeItem( CDataProfile&, SFileTreeItem&, const WCHAR*, int i );
-	static void ShareData_IO_Type_One( CDataProfile&, STypeConfig& , const WCHAR* );	// 2010/04/12 Uchi •ª—£
+	static void ShareData_IO_Type_One( CDataProfile&, STypeConfig& , const WCHAR* );	// 2010/04/12 Uchi åˆ†é›¢
 
 public:
 	static void IO_CustMenu( CDataProfile&, CommonSetting_CustomMenu&, bool );
@@ -78,7 +78,7 @@ public:
 	}
 	static void IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstring>* pData,
 		CommonSetting_MainMenu& mainmenu, bool bOutCmdName);
-	static void IO_ColorSet( CDataProfile* , const WCHAR* , ColorInfo* );	/* Fİ’è I/O */ // Feb. 12, 2006 D.S.Koba
+	static void IO_ColorSet( CDataProfile* , const WCHAR* , ColorInfo* );	/* è‰²è¨­å®š I/O */ // Feb. 12, 2006 D.S.Koba
 };
 
 #endif /* SAKURA_CSHAREDATA_IO_AA81C249_631D_40B0_AAFF_2F163748954B9_H_ */

--- a/sakura_core/env/CTagJumpManager.cpp
+++ b/sakura_core/env/CTagJumpManager.cpp
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -32,16 +32,16 @@
 
 
 /*!
-	@brief ƒ^ƒOƒWƒƒƒ“ƒvî•ñ‚Ì•Û‘¶
+	@brief ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±ã®ä¿å­˜
 
-	ƒ^ƒOƒWƒƒƒ“ƒv‚·‚é‚Æ‚«‚ÉAƒ^ƒOƒWƒƒƒ“ƒvæ‚Ìî•ñ‚ğ•Û‘¶‚·‚éB
+	ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã™ã‚‹ã¨ãã«ã€ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—å…ˆã®æƒ…å ±ã‚’ä¿å­˜ã™ã‚‹ã€‚
 
-	@param[in] pTagJump •Û‘¶‚·‚éƒ^ƒOƒWƒƒƒ“ƒvî•ñ
-	@retval true	•Û‘¶¬Œ÷
-	@retval false	•Û‘¶¸”s
+	@param[in] pTagJump ä¿å­˜ã™ã‚‹ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±
+	@retval true	ä¿å­˜æˆåŠŸ
+	@retval false	ä¿å­˜å¤±æ•—
 
-	@date 2004/06/21 V‹Kì¬
-	@date 2004/06/22 Moca ˆê”t‚É‚È‚Á‚½‚çˆê”ÔŒÃ‚¢î•ñ‚ğíœ‚µ‚»‚±‚ÉV‚µ‚¢î•ñ‚ğ“ü‚ê‚é
+	@date 2004/06/21 æ–°è¦ä½œæˆ
+	@date 2004/06/22 Moca ä¸€æ¯ã«ãªã£ãŸã‚‰ä¸€ç•ªå¤ã„æƒ…å ±ã‚’å‰Šé™¤ã—ãã“ã«æ–°ã—ã„æƒ…å ±ã‚’å…¥ã‚Œã‚‹
 */
 void CTagJumpManager::PushTagJump(const TagJump *pTagJump)
 {
@@ -58,16 +58,16 @@ void CTagJumpManager::PushTagJump(const TagJump *pTagJump)
 
 
 /*!
-	@brief ƒ^ƒOƒWƒƒƒ“ƒvî•ñ‚ÌQÆ
+	@brief ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±ã®å‚ç…§
 
-	ƒ^ƒOƒWƒƒƒ“ƒvƒoƒbƒN‚·‚é‚Æ‚«‚ÉAƒ^ƒOƒWƒƒƒ“ƒvŒ³‚Ìî•ñ‚ğQÆ‚·‚éB
+	ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒãƒƒã‚¯ã™ã‚‹ã¨ãã«ã€ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—å…ƒã®æƒ…å ±ã‚’å‚ç…§ã™ã‚‹ã€‚
 
-	@param[out] pTagJump QÆ‚·‚éƒ^ƒOƒWƒƒƒ“ƒvî•ñ
-	@retval true	QÆ¬Œ÷
-	@retval false	QÆ¸”s
+	@param[out] pTagJump å‚ç…§ã™ã‚‹ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±
+	@retval true	å‚ç…§æˆåŠŸ
+	@retval false	å‚ç…§å¤±æ•—
 
-	@date 2004/06/21 V‹Kì¬
-	@date 2004/06/22 Moca SetTagJump•ÏX‚É‚æ‚éC³
+	@date 2004/06/21 æ–°è¦ä½œæˆ
+	@date 2004/06/22 Moca SetTagJumpå¤‰æ›´ã«ã‚ˆã‚‹ä¿®æ­£
 */
 bool CTagJumpManager::PopTagJump(TagJump *pTagJump)
 {

--- a/sakura_core/env/CTagJumpManager.h
+++ b/sakura_core/env/CTagJumpManager.h
@@ -1,5 +1,5 @@
-/*
-	2008.05.18 kobake CShareData ‚©‚ç•ª—£
+ï»¿/*
+	2008.05.18 kobake CShareData ã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 2008, kobake
@@ -27,35 +27,35 @@
 #ifndef SAKURA_CTAGJUMPMANAGER_A826CC13_50FF_44A9_813D_CC5B918410A7_H_
 #define SAKURA_CTAGJUMPMANAGER_A826CC13_50FF_44A9_813D_CC5B918410A7_H_
 
-// —væs’è‹`
+// è¦å…ˆè¡Œå®šç¾©
 // #define DLLSHAREDATA.h
 
 
-// 2004/06/21 novice ƒ^ƒOƒWƒƒƒ“ƒv‹@”\’Ç‰Á
-//! ƒ^ƒOƒWƒƒƒ“ƒvî•ñ
+// 2004/06/21 novice ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½è¿½åŠ 
+//! ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±
 struct TagJump {
-	HWND		hwndReferer;				//!< QÆŒ³ƒEƒBƒ“ƒhƒE
-	CLogicPoint	point;						//!< ƒ‰ƒCƒ“, ƒJƒ‰ƒ€
+	HWND		hwndReferer;				//!< å‚ç…§å…ƒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	CLogicPoint	point;						//!< ãƒ©ã‚¤ãƒ³, ã‚«ãƒ©ãƒ 
 };
 
 
-//‹¤—Lƒƒ‚ƒŠ“à\‘¢‘Ì
-//2004/06/21 ƒ^ƒOƒWƒƒƒ“ƒv‹@”\’Ç‰Á
-//2005.04.03 MIK ƒL[ƒ[ƒhw’èƒ^ƒOƒWƒƒƒ“ƒv
+//å…±æœ‰ãƒ¡ãƒ¢ãƒªå†…æ§‹é€ ä½“
+//2004/06/21 ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½è¿½åŠ 
+//2005.04.03 MIK ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æŒ‡å®šã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—
 struct SShare_TagJump{
-	//Œ^
+	//å‹
 	typedef StaticVector<
 		StaticString<WCHAR, _MAX_PATH>,
 		MAX_TAGJUMP_KEYWORD
 	>					ATagJumpKeywords;
 
-	//ƒf[ƒ^
-	int					m_TagJumpNum;					//!< ƒ^ƒOƒWƒƒƒ“ƒvî•ñ‚Ì—LŒøƒf[ƒ^”
-	int					m_TagJumpTop;					//!< ƒXƒ^ƒbƒN‚Ìˆê”Ôã‚ÌˆÊ’u
-	TagJump				m_TagJump[MAX_TAGJUMPNUM];		//!< ƒ^ƒOƒWƒƒƒ“ƒvî•ñ
+	//ãƒ‡ãƒ¼ã‚¿
+	int					m_TagJumpNum;					//!< ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±ã®æœ‰åŠ¹ãƒ‡ãƒ¼ã‚¿æ•°
+	int					m_TagJumpTop;					//!< ã‚¹ã‚¿ãƒƒã‚¯ã®ä¸€ç•ªä¸Šã®ä½ç½®
+	TagJump				m_TagJump[MAX_TAGJUMPNUM];		//!< ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±
 	ATagJumpKeywords	m_aTagJumpKeywords;
-	BOOL				m_bTagJumpICase;				//!< ‘å•¶š¬•¶š‚ğ“¯ˆê‹
-	BOOL				m_bTagJumpAnyWhere;				//!< •¶š—ñ‚Ì“r’†‚Éƒ}ƒbƒ`
+	BOOL				m_bTagJumpICase;				//!< å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–
+	BOOL				m_bTagJumpAnyWhere;				//!< æ–‡å­—åˆ—ã®é€”ä¸­ã«ãƒãƒƒãƒ
 };
 
 
@@ -65,9 +65,9 @@ public:
 	{
 		m_pShareData = &GetDllShareData();
 	}
-	//ƒ^ƒOƒWƒƒƒ“ƒvŠÖ˜A	// 2004/06/21 novice ƒ^ƒOƒWƒƒƒ“ƒv‹@”\’Ç‰Á
-	void PushTagJump(const TagJump *);		//!< ƒ^ƒOƒWƒƒƒ“ƒvî•ñ‚Ì•Û‘¶
-	bool PopTagJump(TagJump *);				//!< ƒ^ƒOƒWƒƒƒ“ƒvî•ñ‚ÌQÆ
+	//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—é–¢é€£	// 2004/06/21 novice ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½è¿½åŠ 
+	void PushTagJump(const TagJump *);		//!< ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±ã®ä¿å­˜
+	bool PopTagJump(TagJump *);				//!< ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±ã®å‚ç…§
 private:
 	DLLSHAREDATA* m_pShareData;
 };

--- a/sakura_core/env/CommonSetting.cpp
+++ b/sakura_core/env/CommonSetting.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -27,16 +27,16 @@
 #include <vector>
 using namespace std;
 
-//CommonValueŠÇ—
+//CommonValueç®¡ç†
 struct CommonValueInfo{
 	enum EType{
 		TYPE_UNKNOWN,
-		TYPE_ASTR,    //char•¶š—ñ (I’[NULL)
-		TYPE_WSTR,    //wchar_t•¶š—ñ (I’[NULL)
+		TYPE_ASTR,    //charæ–‡å­—åˆ— (çµ‚ç«¯NULL)
+		TYPE_WSTR,    //wchar_tæ–‡å­—åˆ— (çµ‚ç«¯NULL)
 	};
 
-	void* m_pValue;     //!< ’l‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	int   m_nValueSize; //!< ’l‚ÌƒTƒCƒYBƒoƒCƒg’PˆÊB
+	void* m_pValue;     //!< å€¤ã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	int   m_nValueSize; //!< å€¤ã®ã‚µã‚¤ã‚ºã€‚ãƒã‚¤ãƒˆå˜ä½ã€‚
 	char  m_szEntryKey[32];
 	EType m_eType;
 
@@ -50,11 +50,11 @@ struct CommonValueInfo{
 	{
 		printf("%hs=",m_szEntryKey);
 
-		//int‚Æ“¯‚¶ƒTƒCƒY‚È‚çint‚Æ‚µ‚Äo—Í
+		//intã¨åŒã˜ã‚µã‚¤ã‚ºãªã‚‰intã¨ã—ã¦å‡ºåŠ›
 		if(m_nValueSize==sizeof(int)){
 			printf("%d\n",*((int*)m_pValue));
 		}
-		//‚»‚êˆÈŠO‚È‚çƒoƒCƒiƒŠo—Í
+		//ãã‚Œä»¥å¤–ãªã‚‰ãƒã‚¤ãƒŠãƒªå‡ºåŠ›
 		else{
 			for(int i=0;i<m_nValueSize;i++){
 				printf("%%%02X",((BYTE*)m_pValue)[i]);
@@ -71,7 +71,7 @@ void CommonValue_AllSave()
 	}
 }
 
-//CommonValue ¦virtualg‚¤‚Ì‹Ö~
+//CommonValue â€»virtualä½¿ã†ã®ç¦æ­¢
 template <class T>
 class CommonValue{
 private:
@@ -82,7 +82,7 @@ public:
 	}
 	void Regist(const char* szEntryKey)
 	{
-		//CommonValueƒŠƒXƒg‚É©•ª‚ğ’Ç‰Á
+		//CommonValueãƒªã‚¹ãƒˆã«è‡ªåˆ†ã‚’è¿½åŠ 
 		g_commonvalues.push_back(CommonValueInfo(&m_value,sizeof(m_value),szEntryKey));
 	}
 	Me& operator = (const T& rhs){ m_value=rhs; return *this; }

--- a/sakura_core/env/CommonSetting.h
+++ b/sakura_core/env/CommonSetting.h
@@ -1,4 +1,4 @@
-//2007.09.28 kobake Common®—
+ï»¿//2007.09.28 kobake Commonæ•´ç†
 /*
 	Copyright (C) 2008, kobake
 
@@ -30,138 +30,138 @@
 #include "func/CFuncLookup.h" //MacroRec
 #include "io/CFile.h" //EShareMode
 
-// Apr. 05, 2003 genta WindowCaption—p—Ìˆæi•ÏŠ·‘Oj‚Ì’·‚³
+// Apr. 05, 2003 genta WindowCaptionç”¨é ˜åŸŸï¼ˆå¤‰æ›å‰ï¼‰ã®é•·ã•
 static const int MAX_CAPTION_CONF_LEN = 256;
 
 static const int MAX_DATETIMEFOREMAT_LEN	= 100;
 static const int MAX_CUSTOM_MENU			=  25;
 static const int MAX_CUSTOM_MENU_NAME_LEN	=  32;
 static const int MAX_CUSTOM_MENU_ITEMS		=  48;
-static const int MAX_TOOLBAR_BUTTON_ITEMS	= 512;	//ƒc[ƒ‹ƒo[‚É“o˜^‰Â”\‚Èƒ{ƒ^ƒ“Å‘å”	
-static const int MAX_TOOLBAR_ICON_X			=  32;	//ƒAƒCƒRƒ“BMP‚ÌŒ…”
-static const int MAX_TOOLBAR_ICON_Y			=  15;	//ƒAƒCƒRƒ“BMP‚Ì’i”
+static const int MAX_TOOLBAR_BUTTON_ITEMS	= 512;	//ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã«ç™»éŒ²å¯èƒ½ãªãƒœã‚¿ãƒ³æœ€å¤§æ•°	
+static const int MAX_TOOLBAR_ICON_X			=  32;	//ã‚¢ã‚¤ã‚³ãƒ³BMPã®æ¡æ•°
+static const int MAX_TOOLBAR_ICON_Y			=  15;	//ã‚¢ã‚¤ã‚³ãƒ³BMPã®æ®µæ•°
 static const int MAX_TOOLBAR_ICON_COUNT		= MAX_TOOLBAR_ICON_X * MAX_TOOLBAR_ICON_Y; // =480
-//Oct. 22, 2000 JEPRO ƒAƒCƒRƒ“‚ÌÅ‘å“o˜^”‚ğ128ŒÂ‘‚â‚µ‚½(256¨384)	
-//2010/3/14 Uchi ƒAƒCƒRƒ“‚ÌÅ‘å“o˜^”‚ğ32ŒÂ‘‚â‚µ‚½(384¨416)
-//2010/6/26 syat ƒAƒCƒRƒ“‚ÌÅ‘å“o˜^”‚ğ15’i‚É‘‚â‚µ‚½(416¨480)
+//Oct. 22, 2000 JEPRO ã‚¢ã‚¤ã‚³ãƒ³ã®æœ€å¤§ç™»éŒ²æ•°ã‚’128å€‹å¢—ã‚„ã—ãŸ(256â†’384)	
+//2010/3/14 Uchi ã‚¢ã‚¤ã‚³ãƒ³ã®æœ€å¤§ç™»éŒ²æ•°ã‚’32å€‹å¢—ã‚„ã—ãŸ(384â†’416)
+//2010/6/26 syat ã‚¢ã‚¤ã‚³ãƒ³ã®æœ€å¤§ç™»éŒ²æ•°ã‚’15æ®µã«å¢—ã‚„ã—ãŸ(416â†’480)
 
 
-// ‹Œ”Å‚Æˆá‚¢AboolŒ^g‚¦‚é‚æ‚¤‚É‚µ‚Ä‚ ‚è‚Ü‚· by kobake
+// æ—§ç‰ˆã¨é•ã„ã€boolå‹ä½¿ãˆã‚‹ã‚ˆã†ã«ã—ã¦ã‚ã‚Šã¾ã™ by kobake
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           ‘S”Ê                              //
+//                           å…¨èˆ¬                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_General
 {
 	//	Jul. 3, 2000 genta
-	//	ƒAƒNƒZƒXŠÖ”(ŠÈˆÕ)
-	//	int‚ğƒrƒbƒg’PˆÊ‚É•ªŠ„‚µ‚Äg‚¤
-	//	‰º4bit‚ğCaretType‚É“–‚Ä‚Ä‚¨‚­(«—ˆ‚Ì—\–ñ‚Å‘½‚ß‚Éæ‚Á‚Ä‚¨‚­)
+	//	ã‚¢ã‚¯ã‚»ã‚¹é–¢æ•°(ç°¡æ˜“)
+	//	intã‚’ãƒ“ãƒƒãƒˆå˜ä½ã«åˆ†å‰²ã—ã¦ä½¿ã†
+	//	ä¸‹4bitã‚’CaretTypeã«å½“ã¦ã¦ãŠã(å°†æ¥ã®äºˆç´„ã§å¤šã‚ã«å–ã£ã¦ãŠã)
 	int		GetCaretType(void) const { return m_nCaretType & 0xf; }
 	void	SetCaretType(const int f){ m_nCaretType &= ~0xf; m_nCaretType |= f & 0xf; }
 
-	//ƒJ[ƒ\ƒ‹
-	int		m_nCaretType;							//!< ƒJ[ƒ\ƒ‹‚Ìƒ^ƒCƒv 0=win 1=dos 
-	bool	m_bIsINSMode;							//!< ‘}“ü^ã‘‚«ƒ‚[ƒh
-	bool	m_bIsFreeCursorMode;					//!< ƒtƒŠ[ƒJ[ƒ\ƒ‹ƒ‚[ƒh‚©
-	BOOL	m_bStopsBothEndsWhenSearchWord;			//!< ’PŒê’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚ÉA’PŒê‚Ì—¼’[‚Å~‚Ü‚é‚©
-	BOOL	m_bStopsBothEndsWhenSearchParagraph;	//!< ’i—’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚ÉA’i—‚Ì—¼’[‚Å~‚Ü‚é‚©
-	BOOL	m_bNoCaretMoveByActivation;				//!< ƒ}ƒEƒXƒNƒŠƒbƒN‚É‚ÄƒAƒNƒeƒBƒx[ƒg‚³‚ê‚½‚ÍƒJ[ƒ\ƒ‹ˆÊ’u‚ğˆÚ“®‚µ‚È‚¢  2007.10.02 nasukoji (add by genta)
+	//ã‚«ãƒ¼ã‚½ãƒ«
+	int		m_nCaretType;							//!< ã‚«ãƒ¼ã‚½ãƒ«ã®ã‚¿ã‚¤ãƒ— 0=win 1=dos 
+	bool	m_bIsINSMode;							//!< æŒ¿å…¥ï¼ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰
+	bool	m_bIsFreeCursorMode;					//!< ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ãƒ¢ãƒ¼ãƒ‰ã‹
+	BOOL	m_bStopsBothEndsWhenSearchWord;			//!< å˜èªå˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«ã€å˜èªã®ä¸¡ç«¯ã§æ­¢ã¾ã‚‹ã‹
+	BOOL	m_bStopsBothEndsWhenSearchParagraph;	//!< æ®µè½å˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«ã€æ®µè½ã®ä¸¡ç«¯ã§æ­¢ã¾ã‚‹ã‹
+	BOOL	m_bNoCaretMoveByActivation;				//!< ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯ã«ã¦ã‚¢ã‚¯ãƒ†ã‚£ãƒ™ãƒ¼ãƒˆã•ã‚ŒãŸæ™‚ã¯ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’ç§»å‹•ã—ãªã„  2007.10.02 nasukoji (add by genta)
 
-	//ƒXƒNƒ[ƒ‹
-	CLayoutInt		m_nRepeatedScrollLineNum;		//!< ƒL[ƒŠƒs[ƒg‚ÌƒXƒNƒ[ƒ‹s”
-	int		m_nRepeatedMoveCaretNum;				//!< ƒL[ƒŠƒs[ƒg‚Ì¶‰EˆÚ“®”
-	BOOL	m_nRepeatedScroll_Smooth;				//!< ƒL[ƒŠƒs[ƒg‚ÌƒXƒNƒ[ƒ‹‚ğŠŠ‚ç‚©‚É‚·‚é‚©
-	int		m_nPageScrollByWheel;					//!< ƒL[/ƒ}ƒEƒXƒ{ƒ^ƒ“ + ƒzƒC[ƒ‹ƒXƒNƒ[ƒ‹‚Åƒy[ƒWUP/DOWN‚·‚é	// 2009.01.17 nasukoji
-	int		m_nHorizontalScrollByWheel;				//!< ƒL[/ƒ}ƒEƒXƒ{ƒ^ƒ“ + ƒzƒC[ƒ‹ƒXƒNƒ[ƒ‹‚Å‰¡ƒXƒNƒ[ƒ‹‚·‚é	// 2009.01.17 nasukoji
+	//ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
+	CLayoutInt		m_nRepeatedScrollLineNum;		//!< ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•°
+	int		m_nRepeatedMoveCaretNum;				//!< ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®å·¦å³ç§»å‹•æ•°
+	BOOL	m_nRepeatedScroll_Smooth;				//!< ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚’æ»‘ã‚‰ã‹ã«ã™ã‚‹ã‹
+	int		m_nPageScrollByWheel;					//!< ã‚­ãƒ¼/ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³ + ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã§ãƒšãƒ¼ã‚¸UP/DOWNã™ã‚‹	// 2009.01.17 nasukoji
+	int		m_nHorizontalScrollByWheel;				//!< ã‚­ãƒ¼/ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³ + ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã§æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹	// 2009.01.17 nasukoji
 
-	//ƒ^ƒXƒNƒgƒŒƒC
-	BOOL	m_bUseTaskTray;					//!< ƒ^ƒXƒNƒgƒŒƒC‚ÌƒAƒCƒRƒ“‚ğg‚¤
-	BOOL	m_bStayTaskTray;				//!< ƒ^ƒXƒNƒgƒŒƒC‚ÌƒAƒCƒRƒ“‚ğí’“
-	WORD	m_wTrayMenuHotKeyCode;			//!< ƒ^ƒXƒNƒgƒŒƒC¶ƒNƒŠƒbƒNƒƒjƒ…[ ƒL[
-	WORD	m_wTrayMenuHotKeyMods;			//!< ƒ^ƒXƒNƒgƒŒƒC¶ƒNƒŠƒbƒNƒƒjƒ…[ ƒL[
+	//ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤
+	BOOL	m_bUseTaskTray;					//!< ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã®ã‚¢ã‚¤ã‚³ãƒ³ã‚’ä½¿ã†
+	BOOL	m_bStayTaskTray;				//!< ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã®ã‚¢ã‚¤ã‚³ãƒ³ã‚’å¸¸é§
+	WORD	m_wTrayMenuHotKeyCode;			//!< ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤å·¦ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ ã‚­ãƒ¼
+	WORD	m_wTrayMenuHotKeyMods;			//!< ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤å·¦ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ ã‚­ãƒ¼
 
-	//—š—ğ
-	int		m_nMRUArrNum_MAX;				//!< ƒtƒ@ƒCƒ‹‚Ì—š—ğMAX
-	int		m_nOPENFOLDERArrNum_MAX;		//!< ƒtƒHƒ‹ƒ_‚Ì—š—ğMAX
+	//å±¥æ­´
+	int		m_nMRUArrNum_MAX;				//!< ãƒ•ã‚¡ã‚¤ãƒ«ã®å±¥æ­´MAX
+	int		m_nOPENFOLDERArrNum_MAX;		//!< ãƒ•ã‚©ãƒ«ãƒ€ã®å±¥æ­´MAX
 
-	//ƒm[ƒJƒeƒSƒŠ
-	BOOL	m_bCloseAllConfirm;				//!< [‚·‚×‚Ä•Â‚¶‚é]‚Å‘¼‚É•ÒW—p‚ÌƒEƒBƒ“ƒhƒE‚ª‚ ‚ê‚ÎŠm”F‚·‚é	// 2006.12.25 ryoji
-	BOOL	m_bExitConfirm;					//!< I—¹‚ÌŠm”F‚ğ‚·‚é
+	//ãƒãƒ¼ã‚«ãƒ†ã‚´ãƒª
+	BOOL	m_bCloseAllConfirm;				//!< [ã™ã¹ã¦é–‰ã˜ã‚‹]ã§ä»–ã«ç·¨é›†ç”¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒã‚ã‚Œã°ç¢ºèªã™ã‚‹	// 2006.12.25 ryoji
+	BOOL	m_bExitConfirm;					//!< çµ‚äº†æ™‚ã®ç¢ºèªã‚’ã™ã‚‹
 
-	//INI“àİ’è‚Ì‚İ
-	BOOL	m_bDispExitingDialog;			//!< I—¹ƒ_ƒCƒAƒƒO‚ğ•\¦‚·‚é
+	//INIå†…è¨­å®šã®ã¿
+	BOOL	m_bDispExitingDialog;			//!< çµ‚äº†ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è¡¨ç¤ºã™ã‚‹
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ƒEƒBƒ“ƒhƒE                           //
+//                        ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //	2004.05.13 Moca
-//! ƒEƒBƒ“ƒhƒEƒTƒCƒYEˆÊ’u‚Ì§Œä•û–@
+//! ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚µã‚¤ã‚ºãƒ»ä½ç½®ã®åˆ¶å¾¡æ–¹æ³•
 enum EWinSizeMode{
-	WINSIZEMODE_DEF		= 0, //!< w’è‚È‚µ
-	WINSIZEMODE_SAVE	= 1, //!< Œp³(•Û‘¶)
-	WINSIZEMODE_SET		= 2  //!< ’¼Úw’è(ŒÅ’è)
+	WINSIZEMODE_DEF		= 0, //!< æŒ‡å®šãªã—
+	WINSIZEMODE_SAVE	= 1, //!< ç¶™æ‰¿(ä¿å­˜)
+	WINSIZEMODE_SET		= 2  //!< ç›´æ¥æŒ‡å®š(å›ºå®š)
 };
 
 struct CommonSetting_Window
 {
-	//Šî–{İ’è
-	BOOL			m_bDispTOOLBAR;				//!< Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒc[ƒ‹ƒo[‚ğ•\¦‚·‚é
-	BOOL			m_bDispSTATUSBAR;			//!< Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒXƒe[ƒ^ƒXƒo[‚ğ•\¦‚·‚é
-	BOOL			m_bDispFUNCKEYWND;			//!< Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ğ•\¦‚·‚é
-	bool			m_bDispMiniMap;				//!< ƒ~ƒjƒ}ƒbƒv‚ğ•\¦‚·‚é
-	BOOL			m_bMenuIcon;				//!< ƒƒjƒ…[‚ÉƒAƒCƒRƒ“‚ğ•\¦‚·‚é (ƒAƒCƒRƒ“•t‚«ƒƒjƒ…[)
-	BOOL			m_bScrollBarHorz;			//!< …•½ƒXƒNƒ[ƒ‹ƒo[‚ğg‚¤
-	BOOL			m_bUseCompatibleBMP;		//!< Äì‰æ—pŒİŠ·ƒrƒbƒgƒ}ƒbƒv‚ğg‚¤ 2007.09.09 Moca
+	//åŸºæœ¬è¨­å®š
+	BOOL			m_bDispTOOLBAR;				//!< æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ããƒ„ãƒ¼ãƒ«ãƒãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹
+	BOOL			m_bDispSTATUSBAR;			//!< æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ãã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹
+	BOOL			m_bDispFUNCKEYWND;			//!< æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ããƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹
+	bool			m_bDispMiniMap;				//!< ãƒŸãƒ‹ãƒãƒƒãƒ—ã‚’è¡¨ç¤ºã™ã‚‹
+	BOOL			m_bMenuIcon;				//!< ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«ã‚¢ã‚¤ã‚³ãƒ³ã‚’è¡¨ç¤ºã™ã‚‹ (ã‚¢ã‚¤ã‚³ãƒ³ä»˜ããƒ¡ãƒ‹ãƒ¥ãƒ¼)
+	BOOL			m_bScrollBarHorz;			//!< æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã‚’ä½¿ã†
+	BOOL			m_bUseCompatibleBMP;		//!< å†ä½œç”»ç”¨äº’æ›ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—ã‚’ä½¿ã† 2007.09.09 Moca
 
-	//ˆÊ’u‚Æ‘å‚«‚³‚Ìİ’è
-	EWinSizeMode	m_eSaveWindowSize;			//!< ƒEƒBƒ“ƒhƒEƒTƒCƒYŒp³EŒÅ’è EWinSizeMode‚É‡‚¸‚é 2004.05.13 Moca
-	int				m_nWinSizeType;				//!< ‘å‚«‚³‚Ìw’è
-	int				m_nWinSizeCX;				//!< ’¼Úw’è •
-	int				m_nWinSizeCY;				//!< ’¼Úw’è ‚‚³
-	EWinSizeMode	m_eSaveWindowPos;			//!< ƒEƒBƒ“ƒhƒEˆÊ’uŒp³EŒÅ’è EWinSizeMode‚É‡‚¸‚é 2004.05.13 Moca
-	int				m_nWinPosX;					//!< ’¼Úw’è XÀ•W
-	int				m_nWinPosY;					//!< ’¼Úw’è YÀ•W
+	//ä½ç½®ã¨å¤§ãã•ã®è¨­å®š
+	EWinSizeMode	m_eSaveWindowSize;			//!< ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚µã‚¤ã‚ºç¶™æ‰¿ãƒ»å›ºå®š EWinSizeModeã«é †ãšã‚‹ 2004.05.13 Moca
+	int				m_nWinSizeType;				//!< å¤§ãã•ã®æŒ‡å®š
+	int				m_nWinSizeCX;				//!< ç›´æ¥æŒ‡å®š å¹…
+	int				m_nWinSizeCY;				//!< ç›´æ¥æŒ‡å®š é«˜ã•
+	EWinSizeMode	m_eSaveWindowPos;			//!< ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä½ç½®ç¶™æ‰¿ãƒ»å›ºå®š EWinSizeModeã«é †ãšã‚‹ 2004.05.13 Moca
+	int				m_nWinPosX;					//!< ç›´æ¥æŒ‡å®š Xåº§æ¨™
+	int				m_nWinPosY;					//!< ç›´æ¥æŒ‡å®š Yåº§æ¨™
 
-	//ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[
-	int				m_nFUNCKEYWND_Place;		//!< ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\¦ˆÊ’u^0:ã 1:‰º
-	int				m_nFUNCKEYWND_GroupNum;		//!< 2002/11/04 Moca ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ÌƒOƒ‹[ƒvƒ{ƒ^ƒ“”
+	//ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼
+	int				m_nFUNCKEYWND_Place;		//!< ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤ºä½ç½®ï¼0:ä¸Š 1:ä¸‹
+	int				m_nFUNCKEYWND_GroupNum;		//!< 2002/11/04 Moca ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®ã‚°ãƒ«ãƒ¼ãƒ—ãƒœã‚¿ãƒ³æ•°
 
-	//ƒ‹[ƒ‰[Es”Ô†
-	int				m_nRulerHeight;				//!< ƒ‹[ƒ‰[‚‚³
-	int				m_nRulerBottomSpace;		//!< ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ
-	int				m_nRulerType;				//!< ƒ‹[ƒ‰[‚Ìƒ^ƒCƒv $$$–¢g—p‚Á‚Û‚¢
-	int				m_nLineNumRightSpace;		//!< s”Ô†‚Ì‰E‚ÌƒXƒy[ƒX Sep. 18, 2002 genta
+	//ãƒ«ãƒ¼ãƒ©ãƒ¼ãƒ»è¡Œç•ªå·
+	int				m_nRulerHeight;				//!< ãƒ«ãƒ¼ãƒ©ãƒ¼é«˜ã•
+	int				m_nRulerBottomSpace;		//!< ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“
+	int				m_nRulerType;				//!< ãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚¿ã‚¤ãƒ— $$$æœªä½¿ç”¨ã£ã½ã„
+	int				m_nLineNumRightSpace;		//!< è¡Œç•ªå·ã®å³ã®ã‚¹ãƒšãƒ¼ã‚¹ Sep. 18, 2002 genta
 
-	//•ªŠ„ƒEƒBƒ“ƒhƒE
-	BOOL			m_bSplitterWndHScroll;		//!< •ªŠ„ƒEƒBƒ“ƒhƒE‚Ì…•½ƒXƒNƒ[ƒ‹‚Ì“¯Šú‚ğ‚Æ‚é 2001/06/20 asa-o
-	BOOL			m_bSplitterWndVScroll;		//!< •ªŠ„ƒEƒBƒ“ƒhƒE‚Ì‚’¼ƒXƒNƒ[ƒ‹‚Ì“¯Šú‚ğ‚Æ‚é 2001/06/20 asa-o
+	//åˆ†å‰²ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	BOOL			m_bSplitterWndHScroll;		//!< åˆ†å‰²ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸã‚’ã¨ã‚‹ 2001/06/20 asa-o
+	BOOL			m_bSplitterWndVScroll;		//!< åˆ†å‰²ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸã‚’ã¨ã‚‹ 2001/06/20 asa-o
 
-	//ƒ^ƒCƒgƒ‹ƒo[
-	TCHAR			m_szWindowCaptionActive  [MAX_CAPTION_CONF_LEN];	//!< ƒ^ƒCƒgƒ‹ƒo[(ƒAƒNƒeƒBƒu)
-	TCHAR			m_szWindowCaptionInactive[MAX_CAPTION_CONF_LEN];	//!< ƒ^ƒCƒgƒ‹ƒo[(”ñƒAƒNƒeƒBƒu)
+	//ã‚¿ã‚¤ãƒˆãƒ«ãƒãƒ¼
+	TCHAR			m_szWindowCaptionActive  [MAX_CAPTION_CONF_LEN];	//!< ã‚¿ã‚¤ãƒˆãƒ«ãƒãƒ¼(ã‚¢ã‚¯ãƒ†ã‚£ãƒ–æ™‚)
+	TCHAR			m_szWindowCaptionInactive[MAX_CAPTION_CONF_LEN];	//!< ã‚¿ã‚¤ãƒˆãƒ«ãƒãƒ¼(éã‚¢ã‚¯ãƒ†ã‚£ãƒ–æ™‚)
 
-	//INI“àİ’è‚Ì‚İ
-	int				m_nVertLineOffset;			//!< cü‚Ì•`‰æÀ•WƒIƒtƒZƒbƒg 2005.11.10 Moca
+	//INIå†…è¨­å®šã®ã¿
+	int				m_nVertLineOffset;			//!< ç¸¦ç·šã®æç”»åº§æ¨™ã‚ªãƒ•ã‚»ãƒƒãƒˆ 2005.11.10 Moca
 
-	//Œ¾Œê‘I‘ğ
-	TCHAR			m_szLanguageDll[MAX_PATH];	//!< Œ¾ŒêDLLƒtƒ@ƒCƒ‹–¼
+	//è¨€èªé¸æŠ
+	TCHAR			m_szLanguageDll[MAX_PATH];	//!< è¨€èªDLLãƒ•ã‚¡ã‚¤ãƒ«å
 
-	//ƒ~ƒjƒ}ƒbƒv
+	//ãƒŸãƒ‹ãƒãƒƒãƒ—
 	int				m_nMiniMapFontSize;
 	int				m_nMiniMapQuality;
 	int				m_nMiniMapWidth;
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ƒ^ƒuƒo[                            //
+//                         ã‚¿ãƒ–ãƒãƒ¼                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//! •Â‚¶‚éƒ{ƒ^ƒ“
+//! é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³
 enum EDispTabClose{
-	DISPTABCLOSE_NO			= 0, //!< ‚È‚µ
-	DISPTABCLOSE_ALLWAYS	= 1, //!< í‚É•\¦
-	DISPTABCLOSE_AUTO		= 2  //!< ©“®•\¦
+	DISPTABCLOSE_NO			= 0, //!< ãªã—
+	DISPTABCLOSE_ALLWAYS	= 1, //!< å¸¸ã«è¡¨ç¤º
+	DISPTABCLOSE_AUTO		= 2  //!< è‡ªå‹•è¡¨ç¤º
 };
 
 enum ETabPosition{
@@ -174,127 +174,127 @@ enum ETabPosition{
 
 struct CommonSetting_TabBar
 {
-	BOOL		m_bDispTabWnd;					//!< ƒ^ƒuƒEƒCƒ“ƒhƒE•\¦‚·‚é	//@@@ 2003.05.31 MIK
-	BOOL		m_bDispTabWndMultiWin;			//!< ƒ^ƒu‚ğ‚Ü‚Æ‚ß‚È‚¢	//@@@ 2003.05.31 MIK
-	BOOL		m_bTab_RetainEmptyWin;			//!< ÅŒã‚Ì•¶‘‚ª•Â‚¶‚ç‚ê‚½‚Æ‚«(–³‘è)‚ğc‚·
-	BOOL		m_bTab_CloseOneWin;				//!< ƒ^ƒuƒ‚[ƒh‚Å‚àƒEƒBƒ“ƒhƒE‚Ì•Â‚¶‚éƒ{ƒ^ƒ“‚ÅŒ»İ‚Ìƒtƒ@ƒCƒ‹‚Ì‚İ•Â‚¶‚é
-	BOOL		m_bNewWindow;					//!< ŠO•”‚©‚ç‹N“®‚·‚é‚Æ‚«‚ÍV‚µ‚¢ƒEƒCƒ“ƒhƒE‚ÅŠJ‚­
-	bool		m_bTabMultiLine;				//!< ƒ^ƒu‘½’i
-	ETabPosition	m_eTabPosition;				//!<ƒ^ƒuˆÊ’u
+	BOOL		m_bDispTabWnd;					//!< ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦è¡¨ç¤ºã™ã‚‹	//@@@ 2003.05.31 MIK
+	BOOL		m_bDispTabWndMultiWin;			//!< ã‚¿ãƒ–ã‚’ã¾ã¨ã‚ãªã„	//@@@ 2003.05.31 MIK
+	BOOL		m_bTab_RetainEmptyWin;			//!< æœ€å¾Œã®æ–‡æ›¸ãŒé–‰ã˜ã‚‰ã‚ŒãŸã¨ã(ç„¡é¡Œ)ã‚’æ®‹ã™
+	BOOL		m_bTab_CloseOneWin;				//!< ã‚¿ãƒ–ãƒ¢ãƒ¼ãƒ‰ã§ã‚‚ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³ã§ç¾åœ¨ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ã¿é–‰ã˜ã‚‹
+	BOOL		m_bNewWindow;					//!< å¤–éƒ¨ã‹ã‚‰èµ·å‹•ã™ã‚‹ã¨ãã¯æ–°ã—ã„ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã§é–‹ã
+	bool		m_bTabMultiLine;				//!< ã‚¿ãƒ–å¤šæ®µ
+	ETabPosition	m_eTabPosition;				//!<ã‚¿ãƒ–ä½ç½®
 
-	wchar_t		m_szTabWndCaption[MAX_CAPTION_CONF_LEN];	//!< ƒ^ƒuƒEƒCƒ“ƒhƒEƒLƒƒƒvƒVƒ‡ƒ“	//@@@ 2003.06.13 MIK
-	BOOL		m_bSameTabWidth;				//!< ƒ^ƒu‚ğ“™•‚É‚·‚é			//@@@ 2006.01.28 ryoji
-	BOOL		m_bDispTabIcon;					//!< ƒ^ƒu‚ÉƒAƒCƒRƒ“‚ğ•\¦‚·‚é	//@@@ 2006.01.28 ryoji
-	EDispTabClose	m_bDispTabClose;			//!< ƒ^ƒu‚É•Â‚¶‚éƒ{ƒ^ƒ“‚ğ•\¦‚·‚é	//@@@ 2012.04.14 syat
-	BOOL		m_bSortTabList;					//!< ƒ^ƒuˆê——‚ğƒ\[ƒg‚·‚é	//@@@ 2006.03.23 fon
-	BOOL		m_bTab_ListFull;				//!< ƒ^ƒuˆê——‚ğƒtƒ‹ƒpƒX•\¦‚·‚é	//@@@ 2007.02.28 ryoji
+	wchar_t		m_szTabWndCaption[MAX_CAPTION_CONF_LEN];	//!< ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³	//@@@ 2003.06.13 MIK
+	BOOL		m_bSameTabWidth;				//!< ã‚¿ãƒ–ã‚’ç­‰å¹…ã«ã™ã‚‹			//@@@ 2006.01.28 ryoji
+	BOOL		m_bDispTabIcon;					//!< ã‚¿ãƒ–ã«ã‚¢ã‚¤ã‚³ãƒ³ã‚’è¡¨ç¤ºã™ã‚‹	//@@@ 2006.01.28 ryoji
+	EDispTabClose	m_bDispTabClose;			//!< ã‚¿ãƒ–ã«é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³ã‚’è¡¨ç¤ºã™ã‚‹	//@@@ 2012.04.14 syat
+	BOOL		m_bSortTabList;					//!< ã‚¿ãƒ–ä¸€è¦§ã‚’ã‚½ãƒ¼ãƒˆã™ã‚‹	//@@@ 2006.03.23 fon
+	BOOL		m_bTab_ListFull;				//!< ã‚¿ãƒ–ä¸€è¦§ã‚’ãƒ•ãƒ«ãƒ‘ã‚¹è¡¨ç¤ºã™ã‚‹	//@@@ 2007.02.28 ryoji
 
-	BOOL		m_bChgWndByWheel;				//!< ƒ}ƒEƒXƒzƒC[ƒ‹‚ÅƒEƒBƒ“ƒhƒEØ‚è‘Ö‚¦	//@@@ 2006.03.26 ryoji
+	BOOL		m_bChgWndByWheel;				//!< ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã§ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ‡ã‚Šæ›¿ãˆ	//@@@ 2006.03.26 ryoji
 
-	LOGFONT		m_lf;							//!< ƒ^ƒuƒtƒHƒ“ƒg // 2011.12.01 Moca
-	INT			m_nPointSize;					//!< ƒtƒHƒ“ƒgƒTƒCƒYi1/10ƒ|ƒCƒ“ƒg’PˆÊj
-	int			m_nTabMaxWidth;					//!< ƒ^ƒu•‚ÌÅ‘å’l
-	int			m_nTabMinWidth;					//!< ƒ^ƒu•‚ÌÅ¬’l
-	int			m_nTabMinWidthOnMulti;			//!< ƒ^ƒu•‚ÌÅ¬’l(ƒ^ƒu‘½’i)
+	LOGFONT		m_lf;							//!< ã‚¿ãƒ–ãƒ•ã‚©ãƒ³ãƒˆ // 2011.12.01 Moca
+	INT			m_nPointSize;					//!< ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºï¼ˆ1/10ãƒã‚¤ãƒ³ãƒˆå˜ä½ï¼‰
+	int			m_nTabMaxWidth;					//!< ã‚¿ãƒ–å¹…ã®æœ€å¤§å€¤
+	int			m_nTabMinWidth;					//!< ã‚¿ãƒ–å¹…ã®æœ€å°å€¤
+	int			m_nTabMinWidthOnMulti;			//!< ã‚¿ãƒ–å¹…ã®æœ€å°å€¤(ã‚¿ãƒ–å¤šæ®µæ™‚)
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           •ÒW                              //
+//                           ç·¨é›†                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//! ƒtƒ@ƒCƒ‹ƒ_ƒCƒAƒƒO‚Ì‰ŠúˆÊ’u
+//! ãƒ•ã‚¡ã‚¤ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸä½ç½®
 enum EOpenDialogDir{
-	OPENDIALOGDIR_CUR, //!< ƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_
-	OPENDIALOGDIR_MRU, //!< Å‹ßg‚Á‚½ƒtƒHƒ‹ƒ_
-	OPENDIALOGDIR_SEL, //!< w’èƒtƒHƒ‹ƒ_
+	OPENDIALOGDIR_CUR, //!< ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€
+	OPENDIALOGDIR_MRU, //!< æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚©ãƒ«ãƒ€
+	OPENDIALOGDIR_SEL, //!< æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€
 };
 
 struct CommonSetting_Edit
 {
-	//ƒRƒs[
-	bool	m_bAddCRLFWhenCopy;			//!< Ü‚è•Ô‚µs‚É‰üs‚ğ•t‚¯‚ÄƒRƒs[
-	BOOL	m_bEnableNoSelectCopy;		//!< ‘I‘ğ‚È‚µ‚ÅƒRƒs[‚ğ‰Â”\‚É‚·‚é 2007.11.18 ryoji
-	BOOL	m_bCopyAndDisablSelection;	//!< ƒRƒs[‚µ‚½‚ç‘I‘ğ‰ğœ
-	bool	m_bEnableLineModePaste;		//!< ƒ‰ƒCƒ“ƒ‚[ƒh“\‚è•t‚¯‚ğ‰Â”\‚É‚·‚é  2007.10.08 ryoji
-	bool	m_bConvertEOLPaste;			//!< ‰üsƒR[ƒh‚ğ•ÏŠ·‚µ‚Ä“\‚è•t‚¯‚é  2009.2.28 salarm
+	//ã‚³ãƒ”ãƒ¼
+	bool	m_bAddCRLFWhenCopy;			//!< æŠ˜ã‚Šè¿”ã—è¡Œã«æ”¹è¡Œã‚’ä»˜ã‘ã¦ã‚³ãƒ”ãƒ¼
+	BOOL	m_bEnableNoSelectCopy;		//!< é¸æŠãªã—ã§ã‚³ãƒ”ãƒ¼ã‚’å¯èƒ½ã«ã™ã‚‹ 2007.11.18 ryoji
+	BOOL	m_bCopyAndDisablSelection;	//!< ã‚³ãƒ”ãƒ¼ã—ãŸã‚‰é¸æŠè§£é™¤
+	bool	m_bEnableLineModePaste;		//!< ãƒ©ã‚¤ãƒ³ãƒ¢ãƒ¼ãƒ‰è²¼ã‚Šä»˜ã‘ã‚’å¯èƒ½ã«ã™ã‚‹  2007.10.08 ryoji
+	bool	m_bConvertEOLPaste;			//!< æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’å¤‰æ›ã—ã¦è²¼ã‚Šä»˜ã‘ã‚‹  2009.2.28 salarm
 
-	//ƒhƒ‰ƒbƒO•ƒhƒƒbƒv
-	BOOL	m_bUseOLE_DragDrop;			//!< OLE‚É‚æ‚éƒhƒ‰ƒbƒO & ƒhƒƒbƒv‚ğg‚¤
-	BOOL	m_bUseOLE_DropSource;		//!< OLE‚É‚æ‚éƒhƒ‰ƒbƒOŒ³‚É‚·‚é‚©
+	//ãƒ‰ãƒ©ãƒƒã‚°ï¼†ãƒ‰ãƒ­ãƒƒãƒ—
+	BOOL	m_bUseOLE_DragDrop;			//!< OLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚° & ãƒ‰ãƒ­ãƒƒãƒ—ã‚’ä½¿ã†
+	BOOL	m_bUseOLE_DropSource;		//!< OLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚°å…ƒã«ã™ã‚‹ã‹
 
-	//ã‘‚«ƒ‚[ƒh
-	BOOL	m_bNotOverWriteCRLF;		//!< ‰üs‚Íã‘‚«‚µ‚È‚¢
-	bool	m_bOverWriteFixMode;		//!< •¶š•‚É‡‚í‚¹‚ÄƒXƒy[ƒX‚ğ‹l‚ß‚é
-	bool	m_bOverWriteBoxDelete;		//!< ã‘‚«ƒ‚[ƒh‚Å‚Ì‹éŒ`“ü—Í‚Å‘I‘ğ”ÍˆÍ‚ğíœ‚·‚é
+	//ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰
+	BOOL	m_bNotOverWriteCRLF;		//!< æ”¹è¡Œã¯ä¸Šæ›¸ãã—ãªã„
+	bool	m_bOverWriteFixMode;		//!< æ–‡å­—å¹…ã«åˆã‚ã›ã¦ã‚¹ãƒšãƒ¼ã‚¹ã‚’è©°ã‚ã‚‹
+	bool	m_bOverWriteBoxDelete;		//!< ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰ã§ã®çŸ©å½¢å…¥åŠ›ã§é¸æŠç¯„å›²ã‚’å‰Šé™¤ã™ã‚‹
 
-	//ƒNƒŠƒbƒJƒuƒ‹URL
-	BOOL	m_bJumpSingleClickURL;		//!< URL‚ÌƒVƒ“ƒOƒ‹ƒNƒŠƒbƒN‚ÅJump $$$–¢g—p
-	BOOL	m_bSelectClickedURL;		//!< URL‚ªƒNƒŠƒbƒN‚³‚ê‚½‚ç‘I‘ğ‚·‚é‚©
+	//ã‚¯ãƒªãƒƒã‚«ãƒ–ãƒ«URL
+	BOOL	m_bJumpSingleClickURL;		//!< URLã®ã‚·ãƒ³ã‚°ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§Jump $$$æœªä½¿ç”¨
+	BOOL	m_bSelectClickedURL;		//!< URLãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸã‚‰é¸æŠã™ã‚‹ã‹
 
-	EOpenDialogDir	m_eOpenDialogDir;	//!< ƒtƒ@ƒCƒ‹ƒ_ƒCƒAƒƒO‚Ì‰ŠúˆÊ’u
-	SFilePath	m_OpenDialogSelDir;		//!< w’èƒtƒHƒ‹ƒ_
+	EOpenDialogDir	m_eOpenDialogDir;	//!< ãƒ•ã‚¡ã‚¤ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸä½ç½®
+	SFilePath	m_OpenDialogSelDir;		//!< æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€
 
-	bool	m_bEnableExtEol;			//!< NEL,PS,LS‚ğ‰üsƒR[ƒh‚Æ‚µ‚Ä—˜—p‚·‚é
-	bool	m_bBoxSelectLock;			//!< (‹éŒ`‘I‘ğ)ˆÚ“®‚ÅƒƒbƒN‚·‚é
+	bool	m_bEnableExtEol;			//!< NEL,PS,LSã‚’æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã¨ã—ã¦åˆ©ç”¨ã™ã‚‹
+	bool	m_bBoxSelectLock;			//!< (çŸ©å½¢é¸æŠ)ç§»å‹•ã§ãƒ­ãƒƒã‚¯ã™ã‚‹
 
-	// (ƒ_ƒCƒAƒƒO€–Ú–³‚µ)
-	BOOL	m_bAutoColumnPaste;			//!< ‹éŒ`ƒRƒs[‚ÌƒeƒLƒXƒg‚Íí‚É‹éŒ`“\‚è•t‚¯
+	// (ãƒ€ã‚¤ã‚¢ãƒ­ã‚°é …ç›®ç„¡ã—)
+	BOOL	m_bAutoColumnPaste;			//!< çŸ©å½¢ã‚³ãƒ”ãƒ¼ã®ãƒ†ã‚­ã‚¹ãƒˆã¯å¸¸ã«çŸ©å½¢è²¼ã‚Šä»˜ã‘
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ƒtƒ@ƒCƒ‹                            //
+//                         ãƒ•ã‚¡ã‚¤ãƒ«                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_File
 {
 public:
-	// ƒJ[ƒ\ƒ‹ˆÊ’u‚ğ•œŒ³‚·‚é‚©‚Ç‚¤‚©  Oct. 27, 2000 genta
+	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’å¾©å…ƒã™ã‚‹ã‹ã©ã†ã‹  Oct. 27, 2000 genta
 	bool	GetRestoreCurPosition() const		{ return m_bRestoreCurPosition; }
 	void	SetRestoreCurPosition(bool i)		{ m_bRestoreCurPosition = i; }
 
-	// ƒuƒbƒNƒ}[ƒN‚ğ•œŒ³‚·‚é‚©‚Ç‚¤‚©  2002.01.16 hor
+	// ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã‚’å¾©å…ƒã™ã‚‹ã‹ã©ã†ã‹  2002.01.16 hor
 	bool	GetRestoreBookmarks() const			{ return m_bRestoreBookmarks; }
 	void	SetRestoreBookmarks(bool i)			{ m_bRestoreBookmarks = i; }
 
-	// ƒtƒ@ƒCƒ‹“Ç‚İ‚İ‚ÉMIME‚Ìdecode‚ğs‚¤‚©  Nov. 12, 2000 genta
+	// ãƒ•ã‚¡ã‚¤ãƒ«èª­ã¿è¾¼ã¿æ™‚ã«MIMEã®decodeã‚’è¡Œã†ã‹  Nov. 12, 2000 genta
 	bool	GetAutoMIMEdecode() const			{ return m_bAutoMIMEdecode; }
 	void	SetAutoMIMEdecode(bool i)			{ m_bAutoMIMEdecode = i; }
 
-	// ‘O‰ñ‚Æ•¶šƒR[ƒh‚ªˆÙ‚È‚é‚Æ‚«‚É–â‚¢‡‚í‚¹‚ğs‚¤  Oct. 03, 2004 genta
+	// å‰å›ã¨æ–‡å­—ã‚³ãƒ¼ãƒ‰ãŒç•°ãªã‚‹ã¨ãã«å•ã„åˆã‚ã›ã‚’è¡Œã†  Oct. 03, 2004 genta
 	bool	GetQueryIfCodeChange() const		{ return m_bQueryIfCodeChange; }
 	void	SetQueryIfCodeChange(bool i)		{ m_bQueryIfCodeChange = i; }
 	
-	// ŠJ‚±‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹‚ª‘¶İ‚µ‚È‚¢‚Æ‚«Œx‚·‚é  Oct. 09, 2004 genta
+	// é–‹ã“ã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ãªã„ã¨ãè­¦å‘Šã™ã‚‹  Oct. 09, 2004 genta
 	bool	GetAlertIfFileNotExist() const		{ return m_bAlertIfFileNotExist; }
 	void	SetAlertIfFileNotExist(bool i)		{ m_bAlertIfFileNotExist = i; }
 
 public:
-	//ƒtƒ@ƒCƒ‹‚Ì”r‘¼§Œä
-	EShareMode		m_nFileShareMode;		//!< ƒtƒ@ƒCƒ‹‚Ì”r‘¼§Œäƒ‚[ƒh
-	bool			m_bCheckFileTimeStamp;	//!< XV‚ÌŠÄ‹
-	int 			m_nAutoloadDelay;		//!< ©“®“Ç’x‰„
-	bool			m_bUneditableIfUnwritable;	//!< ã‘‚«‹Ö~ŒŸo‚Í•ÒW‹Ö~‚É‚·‚é
+	//ãƒ•ã‚¡ã‚¤ãƒ«ã®æ’ä»–åˆ¶å¾¡
+	EShareMode		m_nFileShareMode;		//!< ãƒ•ã‚¡ã‚¤ãƒ«ã®æ’ä»–åˆ¶å¾¡ãƒ¢ãƒ¼ãƒ‰
+	bool			m_bCheckFileTimeStamp;	//!< æ›´æ–°ã®ç›£è¦–
+	int 			m_nAutoloadDelay;		//!< è‡ªå‹•èª­è¾¼æ™‚é…å»¶
+	bool			m_bUneditableIfUnwritable;	//!< ä¸Šæ›¸ãç¦æ­¢æ¤œå‡ºæ™‚ã¯ç·¨é›†ç¦æ­¢ã«ã™ã‚‹
 
-	//ƒtƒ@ƒCƒ‹‚Ì•Û‘¶
-	bool	m_bEnableUnmodifiedOverwrite;	//!< –³•ÏX‚Å‚àã‘‚«‚·‚é‚©
+	//ãƒ•ã‚¡ã‚¤ãƒ«ã®ä¿å­˜
+	bool	m_bEnableUnmodifiedOverwrite;	//!< ç„¡å¤‰æ›´ã§ã‚‚ä¸Šæ›¸ãã™ã‚‹ã‹
 
-	//u–¼‘O‚ğ•t‚¯‚Ä•Û‘¶v‚Åƒtƒ@ƒCƒ‹‚Ìí—Ş‚ª[ƒ†[ƒU[w’è]‚Ì‚Æ‚«‚Ìƒtƒ@ƒCƒ‹ˆê——•\¦
-	//ƒtƒ@ƒCƒ‹•Û‘¶ƒ_ƒCƒAƒƒO‚ÌƒtƒBƒ‹ƒ^İ’è	// 2006.11.16 ryoji
-	bool	m_bNoFilterSaveNew;				//!< V‹K‚©‚ç•Û‘¶‚Í‘Sƒtƒ@ƒCƒ‹•\¦
-	bool	m_bNoFilterSaveFile;			//!< V‹KˆÈŠO‚©‚ç•Û‘¶‚Í‘Sƒtƒ@ƒCƒ‹•\¦
+	//ã€Œåå‰ã‚’ä»˜ã‘ã¦ä¿å­˜ã€ã§ãƒ•ã‚¡ã‚¤ãƒ«ã®ç¨®é¡ãŒ[ãƒ¦ãƒ¼ã‚¶ãƒ¼æŒ‡å®š]ã®ã¨ãã®ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§è¡¨ç¤º
+	//ãƒ•ã‚¡ã‚¤ãƒ«ä¿å­˜ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ•ã‚£ãƒ«ã‚¿è¨­å®š	// 2006.11.16 ryoji
+	bool	m_bNoFilterSaveNew;				//!< æ–°è¦ã‹ã‚‰ä¿å­˜æ™‚ã¯å…¨ãƒ•ã‚¡ã‚¤ãƒ«è¡¨ç¤º
+	bool	m_bNoFilterSaveFile;			//!< æ–°è¦ä»¥å¤–ã‹ã‚‰ä¿å­˜æ™‚ã¯å…¨ãƒ•ã‚¡ã‚¤ãƒ«è¡¨ç¤º
 
-	//ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“
-	bool	m_bDropFileAndClose;			//!< ƒtƒ@ƒCƒ‹‚ğƒhƒƒbƒv‚µ‚½‚Æ‚«‚Í•Â‚¶‚ÄŠJ‚­
-	int		m_nDropFileNumMax;				//!< ˆê“x‚Éƒhƒƒbƒv‰Â”\‚Èƒtƒ@ƒCƒ‹”
-	bool	m_bRestoreCurPosition;			//!< ƒtƒ@ƒCƒ‹‚ğŠJ‚¢‚½‚Æ‚«ƒJ[ƒ\ƒ‹ˆÊ’u‚ğ•œŒ³‚·‚é‚©
-	bool	m_bRestoreBookmarks;			//!< ƒuƒbƒNƒ}[ƒN‚ğ•œŒ³‚·‚é‚©‚Ç‚¤‚© 2002.01.16 hor
-	bool	m_bAutoMIMEdecode;				//!< ƒtƒ@ƒCƒ‹“Ç‚İ‚İ‚ÉMIME‚Ìdecode‚ğs‚¤‚©
-	bool	m_bQueryIfCodeChange;			//!< ‘O‰ñ‚Æ•¶šƒR[ƒh‚ªˆÙ‚È‚é‚Æ‚«‚É–â‚¢‡‚í‚¹‚ğs‚¤ Oct. 03, 2004 genta
-	bool	m_bAlertIfFileNotExist;			//!< ŠJ‚±‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹‚ª‘¶İ‚µ‚È‚¢‚Æ‚«Œx‚·‚é Oct. 09, 2004 genta
-	bool	m_bAlertIfLargeFile;			//!< ŠJ‚±‚¤‚Æ‚µ‚½ƒtƒ@ƒCƒ‹ƒTƒCƒY‚ª‘å‚«‚¢ê‡‚ÉŒx‚·‚é
-	int		m_nAlertFileSize;				//!< Œx‚ğn‚ß‚éƒtƒ@ƒCƒ‹ƒTƒCƒY(MB)
+	//ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³
+	bool	m_bDropFileAndClose;			//!< ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ãƒ‰ãƒ­ãƒƒãƒ—ã—ãŸã¨ãã¯é–‰ã˜ã¦é–‹ã
+	int		m_nDropFileNumMax;				//!< ä¸€åº¦ã«ãƒ‰ãƒ­ãƒƒãƒ—å¯èƒ½ãªãƒ•ã‚¡ã‚¤ãƒ«æ•°
+	bool	m_bRestoreCurPosition;			//!< ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã„ãŸã¨ãã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’å¾©å…ƒã™ã‚‹ã‹
+	bool	m_bRestoreBookmarks;			//!< ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã‚’å¾©å…ƒã™ã‚‹ã‹ã©ã†ã‹ 2002.01.16 hor
+	bool	m_bAutoMIMEdecode;				//!< ãƒ•ã‚¡ã‚¤ãƒ«èª­ã¿è¾¼ã¿æ™‚ã«MIMEã®decodeã‚’è¡Œã†ã‹
+	bool	m_bQueryIfCodeChange;			//!< å‰å›ã¨æ–‡å­—ã‚³ãƒ¼ãƒ‰ãŒç•°ãªã‚‹ã¨ãã«å•ã„åˆã‚ã›ã‚’è¡Œã† Oct. 03, 2004 genta
+	bool	m_bAlertIfFileNotExist;			//!< é–‹ã“ã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ãªã„ã¨ãè­¦å‘Šã™ã‚‹ Oct. 09, 2004 genta
+	bool	m_bAlertIfLargeFile;			//!< é–‹ã“ã†ã¨ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ã‚µã‚¤ã‚ºãŒå¤§ãã„å ´åˆã«è­¦å‘Šã™ã‚‹
+	int		m_nAlertFileSize;				//!< è­¦å‘Šã‚’å§‹ã‚ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ã‚µã‚¤ã‚º(MB)
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       ƒoƒbƒNƒAƒbƒv                          //
+//                       ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 //	Aug. 15, 2000 genta
@@ -315,127 +315,127 @@ struct CommonSetting_Backup
 {
 public:
 	//	Aug. 15, 2000 genta
-	//	Backupİ’è‚ÌƒAƒNƒZƒXŠÖ”
+	//	Backupè¨­å®šã®ã‚¢ã‚¯ã‚»ã‚¹é–¢æ•°
 	int		GetBackupType(void) const			{ return m_nBackUpType; }
 	void	SetBackupType(int n)				{ m_nBackUpType = n; }
 
 	bool	GetBackupOpt(EBackupOptionFlag flag) const			{ return ( flag & m_nBackUpType_Opt1 ) == flag; }
 	void	SetBackupOpt(EBackupOptionFlag flag, bool value)	{ m_nBackUpType_Opt1 = value ? ( flag | m_nBackUpType_Opt1) :  ((~flag) & m_nBackUpType_Opt1 ); }
 
-	//	ƒoƒbƒNƒAƒbƒv”
+	//	ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—æ•°
 	int		GetBackupCount(void) const			{ return m_nBackUpType_Opt2 & 0xffff; }
 	void	SetBackupCount(int value)			{ m_nBackUpType_Opt2 = (m_nBackUpType_Opt2 & 0xffff0000) | ( value & 0xffff ); }
 
-	//	ƒoƒbƒNƒAƒbƒv‚ÌŠg’£qæ“ª•¶š(1•¶š)
+	//	ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã®æ‹¡å¼µå­å…ˆé ­æ–‡å­—(1æ–‡å­—)
 	TCHAR	GetBackupExtChar(void) const		{ return (TCHAR)(( m_nBackUpType_Opt2 >> 16 ) & 0xff) ; }
 	void	SetBackupExtChar(int value)			{ m_nBackUpType_Opt2 = (m_nBackUpType_Opt2 & 0xff00ffff) | (( value & 0xff ) << 16 ); }
 
 	//	Aug. 21, 2000 genta
-	//	©“®Backup
+	//	è‡ªå‹•Backup
 	bool	IsAutoBackupEnabled(void) const		{ return GetBackupOpt( BKUP_AUTO ); }
 	void	EnableAutoBackup(bool flag)			{ SetBackupOpt( BKUP_AUTO, flag ); }
 
 	int		GetAutoBackupInterval(void) const	{ return m_nBackUpType_Opt3; }
 	void	SetAutoBackupInterval(int i)		{ m_nBackUpType_Opt3 = i; }
 
-	//	BackupÚ×İ’è‚ÌƒAƒNƒZƒXŠÖ”
+	//	Backupè©³ç´°è¨­å®šã®ã‚¢ã‚¯ã‚»ã‚¹é–¢æ•°
 	int		GetBackupTypeAdv(void) const { return m_nBackUpType_Opt4; }
 	void	SetBackupTypeAdv(int n){ m_nBackUpType_Opt4 = n; }
 
 public:
-	bool		m_bBackUp;					//!< •Û‘¶‚ÉƒoƒbƒNƒAƒbƒv‚ğì¬‚·‚é
-	bool		m_bBackUpDialog;			//!< ƒoƒbƒNƒAƒbƒv‚Ìì¬‘O‚ÉŠm”F
-	bool		m_bBackUpFolder;			//!< w’èƒtƒHƒ‹ƒ_‚ÉƒoƒbƒNƒAƒbƒv‚ğì¬‚·‚é
-	bool		m_bBackUpFolderRM;			//!< w’èƒtƒHƒ‹ƒ_‚ÉƒoƒbƒNƒAƒbƒv‚ğì¬‚·‚é(ƒŠƒ€[ƒoƒuƒ‹ƒƒfƒBƒA‚Ì‚İ)
-	SFilePath	m_szBackUpFolder;			//!< ƒoƒbƒNƒAƒbƒv‚ğì¬‚·‚éƒtƒHƒ‹ƒ_
-	int 		m_nBackUpType;				//!< ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼‚Ìƒ^ƒCƒv 1=(.bak) 2=*_“ú•t.*
-	int 		m_nBackUpType_Opt1;			//!< ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FƒIƒvƒVƒ‡ƒ“1
-	int 		m_nBackUpType_Opt2;			//!< ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FƒIƒvƒVƒ‡ƒ“2
-	int 		m_nBackUpType_Opt3;			//!< ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FƒIƒvƒVƒ‡ƒ“3
-	int 		m_nBackUpType_Opt4;			//!< ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FƒIƒvƒVƒ‡ƒ“4
-	int 		m_nBackUpType_Opt5;			//!< ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FƒIƒvƒVƒ‡ƒ“5
-	int 		m_nBackUpType_Opt6;			//!< ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹–¼FƒIƒvƒVƒ‡ƒ“6
-	bool		m_bBackUpDustBox;			//!< ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹‚ğ‚²‚İ” ‚É•ú‚è‚Ş	//@@@ 2001.12.11 add MIK
-	bool		m_bBackUpPathAdvanced;		//!< ƒoƒbƒNƒAƒbƒvæƒtƒHƒ‹ƒ_‚ğÚ×İ’è‚·‚é 20051107 aroka
-	SFilePath	m_szBackUpPathAdvanced;		//!< ƒoƒbƒNƒAƒbƒv‚ğì¬‚·‚éƒtƒHƒ‹ƒ_‚ÌÚ×İ’è 20051107 aroka
+	bool		m_bBackUp;					//!< ä¿å­˜æ™‚ã«ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹
+	bool		m_bBackUpDialog;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã®ä½œæˆå‰ã«ç¢ºèª
+	bool		m_bBackUpFolder;			//!< æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€ã«ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹
+	bool		m_bBackUpFolderRM;			//!< æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€ã«ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹(ãƒªãƒ ãƒ¼ãƒãƒ–ãƒ«ãƒ¡ãƒ‡ã‚£ã‚¢ã®ã¿)
+	SFilePath	m_szBackUpFolder;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹ãƒ•ã‚©ãƒ«ãƒ€
+	int 		m_nBackUpType;				//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åã®ã‚¿ã‚¤ãƒ— 1=(.bak) 2=*_æ—¥ä»˜.*
+	int 		m_nBackUpType_Opt1;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šã‚ªãƒ—ã‚·ãƒ§ãƒ³1
+	int 		m_nBackUpType_Opt2;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šã‚ªãƒ—ã‚·ãƒ§ãƒ³2
+	int 		m_nBackUpType_Opt3;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šã‚ªãƒ—ã‚·ãƒ§ãƒ³3
+	int 		m_nBackUpType_Opt4;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šã‚ªãƒ—ã‚·ãƒ§ãƒ³4
+	int 		m_nBackUpType_Opt5;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šã‚ªãƒ—ã‚·ãƒ§ãƒ³5
+	int 		m_nBackUpType_Opt6;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«åï¼šã‚ªãƒ—ã‚·ãƒ§ãƒ³6
+	bool		m_bBackUpDustBox;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã”ã¿ç®±ã«æ”¾ã‚Šè¾¼ã‚€	//@@@ 2001.12.11 add MIK
+	bool		m_bBackUpPathAdvanced;		//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—å…ˆãƒ•ã‚©ãƒ«ãƒ€ã‚’è©³ç´°è¨­å®šã™ã‚‹ 20051107 aroka
+	SFilePath	m_szBackUpPathAdvanced;		//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹ãƒ•ã‚©ãƒ«ãƒ€ã®è©³ç´°è¨­å®š 20051107 aroka
 };
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           ‘®                              //
+//                           æ›¸å¼                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_Format
 {
-	//“ú•t‘®
-	int			m_nDateFormatType;							//!< “ú•t‘®‚Ìƒ^ƒCƒv
-	TCHAR		m_szDateFormat[MAX_DATETIMEFOREMAT_LEN];	//!< “ú•t‘®
+	//æ—¥ä»˜æ›¸å¼
+	int			m_nDateFormatType;							//!< æ—¥ä»˜æ›¸å¼ã®ã‚¿ã‚¤ãƒ—
+	TCHAR		m_szDateFormat[MAX_DATETIMEFOREMAT_LEN];	//!< æ—¥ä»˜æ›¸å¼
 
-	//‘®
-	int			m_nTimeFormatType;							//!< ‘®‚Ìƒ^ƒCƒv
-	TCHAR		m_szTimeFormat[MAX_DATETIMEFOREMAT_LEN];	//!< ‘®
+	//æ™‚åˆ»æ›¸å¼
+	int			m_nTimeFormatType;							//!< æ™‚åˆ»æ›¸å¼ã®ã‚¿ã‚¤ãƒ—
+	TCHAR		m_szTimeFormat[MAX_DATETIMEFOREMAT_LEN];	//!< æ™‚åˆ»æ›¸å¼
 
-	//Œ©o‚µ‹L†
-	wchar_t		m_szMidashiKigou[256];						//!< Œ©o‚µ‹L†
+	//è¦‹å‡ºã—è¨˜å·
+	wchar_t		m_szMidashiKigou[256];						//!< è¦‹å‡ºã—è¨˜å·
 
-	//ˆø—p•„
-	wchar_t		m_szInyouKigou[32];							//!< ˆø—p•„
+	//å¼•ç”¨ç¬¦
+	wchar_t		m_szInyouKigou[32];							//!< å¼•ç”¨ç¬¦
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           ŒŸõ                              //
+//                           æ¤œç´¢                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_Search
 {
-	int				m_nSearchKeySequence;		//!< ŒŸõƒV[ƒPƒ“ƒX(–¢•Û‘¶)
-	SSearchOption	m_sSearchOption;			//!< ŒŸõ^’uŠ·  ğŒ
+	int				m_nSearchKeySequence;		//!< æ¤œç´¢ã‚·ãƒ¼ã‚±ãƒ³ã‚¹(æœªä¿å­˜)
+	SSearchOption	m_sSearchOption;			//!< æ¤œç´¢ï¼ç½®æ›  æ¡ä»¶
 
-	int				m_nReplaceKeySequence;		//!< ’uŠ·ŒãƒV[ƒPƒ“ƒX(–¢•Û‘¶)
-	int				m_bConsecutiveAll;			//!< u‚·‚×‚Ä’uŠ·v‚Í’uŠ·‚ÌŒJ•Ô‚µ	// 2007.01.16 ryoji
-	int				m_bNOTIFYNOTFOUND;			//!< ŒŸõ^’uŠ·  Œ©‚Â‚©‚ç‚È‚¢‚Æ‚«ƒƒbƒZ[ƒW‚ğ•\¦
-	int				m_bSelectedArea;			//!< ’uŠ·  ‘I‘ğ”ÍˆÍ“à’uŠ·
+	int				m_nReplaceKeySequence;		//!< ç½®æ›å¾Œã‚·ãƒ¼ã‚±ãƒ³ã‚¹(æœªä¿å­˜)
+	int				m_bConsecutiveAll;			//!< ã€Œã™ã¹ã¦ç½®æ›ã€ã¯ç½®æ›ã®ç¹°è¿”ã—	// 2007.01.16 ryoji
+	int				m_bNOTIFYNOTFOUND;			//!< æ¤œç´¢ï¼ç½®æ›  è¦‹ã¤ã‹ã‚‰ãªã„ã¨ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤º
+	int				m_bSelectedArea;			//!< ç½®æ›  é¸æŠç¯„å›²å†…ç½®æ›
 
-	int				m_bGrepSubFolder;			//!< Grep: ƒTƒuƒtƒHƒ‹ƒ_‚àŒŸõ
-	int				m_nGrepOutputLineType;		//!< Grep: s‚ğo—Í/ŠY“–•”•ª/”Ûƒ}ƒbƒ`s ‚ğo—Í
-	int				m_nGrepOutputStyle;			//!< Grep: o—ÍŒ`®
-	int				m_bGrepDefaultFolder;		//!< Grep: ƒtƒHƒ‹ƒ_‚Ì‰Šú’l‚ğƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_‚É‚·‚é
-	ECodeType		m_nGrepCharSet;				//!< Grep: •¶šƒR[ƒhƒZƒbƒg // 2002/09/20 Moca Add
-	bool			m_bGrepOutputFileOnly;		//!< Grep: ƒtƒ@ƒCƒ‹–ˆÅ‰‚Ì‚İŒŸõ
-	bool			m_bGrepOutputBaseFolder;	//!< Grep: ƒx[ƒXƒtƒHƒ‹ƒ_•\¦
-	bool			m_bGrepSeparateFolder;		//!< Grep: ƒtƒHƒ‹ƒ_–ˆ‚É•\¦
-	bool			m_bGrepBackup;				//!< Grep: ƒoƒbƒNƒAƒbƒvì¬
+	int				m_bGrepSubFolder;			//!< Grep: ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€ã‚‚æ¤œç´¢
+	int				m_nGrepOutputLineType;		//!< Grep: è¡Œã‚’å‡ºåŠ›/è©²å½“éƒ¨åˆ†/å¦ãƒãƒƒãƒè¡Œ ã‚’å‡ºåŠ›
+	int				m_nGrepOutputStyle;			//!< Grep: å‡ºåŠ›å½¢å¼
+	int				m_bGrepDefaultFolder;		//!< Grep: ãƒ•ã‚©ãƒ«ãƒ€ã®åˆæœŸå€¤ã‚’ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€ã«ã™ã‚‹
+	ECodeType		m_nGrepCharSet;				//!< Grep: æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ // 2002/09/20 Moca Add
+	bool			m_bGrepOutputFileOnly;		//!< Grep: ãƒ•ã‚¡ã‚¤ãƒ«æ¯æœ€åˆã®ã¿æ¤œç´¢
+	bool			m_bGrepOutputBaseFolder;	//!< Grep: ãƒ™ãƒ¼ã‚¹ãƒ•ã‚©ãƒ«ãƒ€è¡¨ç¤º
+	bool			m_bGrepSeparateFolder;		//!< Grep: ãƒ•ã‚©ãƒ«ãƒ€æ¯ã«è¡¨ç¤º
+	bool			m_bGrepBackup;				//!< Grep: ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ä½œæˆ
 
-	BOOL			m_bCaretTextForSearch;		//!< ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì•¶š—ñ‚ğƒfƒtƒHƒ‹ƒg‚ÌŒŸõ•¶š—ñ‚É‚·‚é 2006.08.23 ryoji
-	bool			m_bInheritKeyOtherView;		//!< ŸE‘OŒŸõ‚Å‘¼‚Ìƒrƒ…[‚ÌŒŸõğŒ‚ğˆø‚«Œp‚®
-	TCHAR			m_szRegexpLib[_MAX_PATH];	//!< g—p‚·‚é³‹K•\Œ»DLL  2007.08.22 genta
+	BOOL			m_bCaretTextForSearch;		//!< ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ–‡å­—åˆ—ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®æ¤œç´¢æ–‡å­—åˆ—ã«ã™ã‚‹ 2006.08.23 ryoji
+	bool			m_bInheritKeyOtherView;		//!< æ¬¡ãƒ»å‰æ¤œç´¢ã§ä»–ã®ãƒ“ãƒ¥ãƒ¼ã®æ¤œç´¢æ¡ä»¶ã‚’å¼•ãç¶™ã
+	TCHAR			m_szRegexpLib[_MAX_PATH];	//!< ä½¿ç”¨ã™ã‚‹æ­£è¦è¡¨ç¾DLL  2007.08.22 genta
 
 	//Grep
-	BOOL			m_bGrepExitConfirm;			//!< Grepƒ‚[ƒh‚Å•Û‘¶Šm”F‚·‚é‚©
-	BOOL			m_bGrepRealTimeView;		//!< GrepŒ‹‰Ê‚ÌƒŠƒAƒ‹ƒ^ƒCƒ€•\¦ 2003.06.16 Moca
+	BOOL			m_bGrepExitConfirm;			//!< Grepãƒ¢ãƒ¼ãƒ‰ã§ä¿å­˜ç¢ºèªã™ã‚‹ã‹
+	BOOL			m_bGrepRealTimeView;		//!< Grepçµæœã®ãƒªã‚¢ãƒ«ã‚¿ã‚¤ãƒ è¡¨ç¤º 2003.06.16 Moca
 
-	BOOL			m_bGTJW_RETURN;				//!< ƒGƒ“ƒ^[ƒL[‚Åƒ^ƒOƒWƒƒƒ“ƒv
-	BOOL			m_bGTJW_LDBLCLK;			//!< ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Åƒ^ƒOƒWƒƒƒ“ƒv
+	BOOL			m_bGTJW_RETURN;				//!< ã‚¨ãƒ³ã‚¿ãƒ¼ã‚­ãƒ¼ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—
+	BOOL			m_bGTJW_LDBLCLK;			//!< ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—
 
-	//ŒŸõE’uŠ·ƒ_ƒCƒAƒƒO
-	BOOL			m_bAutoCloseDlgFind;		//!< ŒŸõƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é
-	BOOL			m_bAutoCloseDlgReplace;		//!< ’uŠ· ƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é
-	BOOL			m_bSearchAll;				//!< æ“ªi––”öj‚©‚çÄŒŸõ 2002.01.26 hor
+	//æ¤œç´¢ãƒ»ç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
+	BOOL			m_bAutoCloseDlgFind;		//!< æ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹
+	BOOL			m_bAutoCloseDlgReplace;		//!< ç½®æ› ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹
+	BOOL			m_bSearchAll;				//!< å…ˆé ­ï¼ˆæœ«å°¾ï¼‰ã‹ã‚‰å†æ¤œç´¢ 2002.01.26 hor
 
-	int				m_nTagJumpMode;				//!< ƒ^ƒOƒWƒƒƒ“ƒvƒ‚[ƒh(0-3)
-	int				m_nTagJumpModeKeyword;		//!< ƒ^ƒOƒWƒƒƒ“ƒvƒ‚[ƒh(0-3)
+	int				m_nTagJumpMode;				//!< ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒ¢ãƒ¼ãƒ‰(0-3)
+	int				m_nTagJumpModeKeyword;		//!< ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒ¢ãƒ¼ãƒ‰(0-3)
 
-	//INI“àİ’è‚Ì‚İ
-	BOOL			m_bUseCaretKeyWord;			//!< ƒLƒƒƒŒƒbƒgˆÊ’u‚Ì’PŒê‚ğ«‘ŒŸõ		// 2006.03.24 fon
+	//INIå†…è¨­å®šã®ã¿
+	BOOL			m_bUseCaretKeyWord;			//!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã®å˜èªã‚’è¾æ›¸æ¤œç´¢		// 2006.03.24 fon
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       ƒL[Š„‚è“–‚Ä                          //
+//                       ã‚­ãƒ¼å‰²ã‚Šå½“ã¦                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_KeyBind
 {
-	// ƒL[Š„‚è“–‚Ä
-	int					m_nKeyNameArrNum;			//!< ƒL[Š„‚è“–‚Ä•\‚Ì—LŒøƒf[ƒ^”
-	KEYDATA				m_pKeyNameArr[100+1];		//!< ƒL[Š„‚è“–‚Ä•\ –¢Š„‚è“–‚ÄƒL[ƒR[ƒh—p‚Éƒ_ƒ~[‚ğ’Ç‰Á
-	BYTE				m_VKeyToKeyNameArr[256+10];	//!< ƒL[ƒR[ƒh¨Š„‚è“–‚Ä•\ƒCƒ“ƒfƒbƒNƒX // 2012.11.25 aroka
+	// ã‚­ãƒ¼å‰²ã‚Šå½“ã¦
+	int					m_nKeyNameArrNum;			//!< ã‚­ãƒ¼å‰²ã‚Šå½“ã¦è¡¨ã®æœ‰åŠ¹ãƒ‡ãƒ¼ã‚¿æ•°
+	KEYDATA				m_pKeyNameArr[100+1];		//!< ã‚­ãƒ¼å‰²ã‚Šå½“ã¦è¡¨ æœªå‰²ã‚Šå½“ã¦ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ç”¨ã«ãƒ€ãƒŸãƒ¼ã‚’è¿½åŠ 
+	BYTE				m_VKeyToKeyNameArr[256+10];	//!< ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰â†’å‰²ã‚Šå½“ã¦è¡¨ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ // 2012.11.25 aroka
 };
 
 
@@ -443,7 +443,7 @@ struct CommonSetting_KeyBind
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒJƒXƒ^ƒ€ƒƒjƒ…[                        //
+//                     ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_CustomMenu
 {
@@ -456,90 +456,90 @@ struct CommonSetting_CustomMenu
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ƒc[ƒ‹ƒo[                           //
+//                        ãƒ„ãƒ¼ãƒ«ãƒãƒ¼                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_ToolBar
 {
-	int			m_nToolBarButtonNum;								//!< ƒc[ƒ‹ƒo[ƒ{ƒ^ƒ“‚Ì”
-	int			m_nToolBarButtonIdxArr[MAX_TOOLBAR_BUTTON_ITEMS];	//!< ƒc[ƒ‹ƒo[ƒ{ƒ^ƒ“\‘¢‘Ì
-	int			m_bToolBarIsFlat;									//!< ƒtƒ‰ƒbƒgƒc[ƒ‹ƒo[‚É‚·‚é^‚µ‚È‚¢
+	int			m_nToolBarButtonNum;								//!< ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ãƒœã‚¿ãƒ³ã®æ•°
+	int			m_nToolBarButtonIdxArr[MAX_TOOLBAR_BUTTON_ITEMS];	//!< ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ãƒœã‚¿ãƒ³æ§‹é€ ä½“
+	int			m_bToolBarIsFlat;									//!< ãƒ•ãƒ©ãƒƒãƒˆãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã«ã™ã‚‹ï¼ã—ãªã„
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      ‹­’²ƒL[ƒ[ƒh                         //
+//                      å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_SpecialKeyword
 {
-	// ‹­’²ƒL[ƒ[ƒhİ’è
-	CKeyWordSetMgr		m_CKeyWordSetMgr;					//!< ‹­’²ƒL[ƒ[ƒh
-	char				m_szKeyWordSetDir[MAX_PATH];		//!< ‹­’²ƒL[ƒ[ƒhƒtƒ@ƒCƒ‹‚ÌƒfƒBƒŒƒNƒgƒŠ
+	// å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¨­å®š
+	CKeyWordSetMgr		m_CKeyWordSetMgr;					//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+	char				m_szKeyWordSetDir[MAX_PATH];		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           x‰‡                              //
+//                           æ”¯æ´                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_Helper
 {
-	//“ü—Í•âŠ®‹@”\
-	BOOL		m_bHokanKey_RETURN;				//!< VK_RETURN	•âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø
-	BOOL		m_bHokanKey_TAB;				//!< VK_TAB		•âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø
-	BOOL		m_bHokanKey_RIGHT;				//!< VK_RIGHT	•âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø
-	BOOL		m_bHokanKey_SPACE;				//!< VK_SPACE	•âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø $$$‚Ù‚Ú–¢g—p
+	//å…¥åŠ›è£œå®Œæ©Ÿèƒ½
+	BOOL		m_bHokanKey_RETURN;				//!< VK_RETURN	è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹
+	BOOL		m_bHokanKey_TAB;				//!< VK_TAB		è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹
+	BOOL		m_bHokanKey_RIGHT;				//!< VK_RIGHT	è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹
+	BOOL		m_bHokanKey_SPACE;				//!< VK_SPACE	è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹ $$$ã»ã¼æœªä½¿ç”¨
 
-	//ŠO•”ƒwƒ‹ƒv‚Ìİ’è
-	TCHAR		m_szExtHelp[_MAX_PATH];			//!< ŠO•”ƒwƒ‹ƒv‚P
+	//å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ã®è¨­å®š
+	TCHAR		m_szExtHelp[_MAX_PATH];			//!< å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘
 
-	//ŠO•”HTMLƒwƒ‹ƒv‚Ìİ’è
-	TCHAR		m_szExtHtmlHelp[_MAX_PATH];		//!< ŠO•”HTMLƒwƒ‹ƒv
-	bool		m_bHtmlHelpIsSingle;			//!< HtmlHelpƒrƒ…[ƒA‚Í‚Ğ‚Æ‚Â (ƒrƒ…[ƒA‚ğ•¡”‹N“®‚µ‚È‚¢)
+	//å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—ã®è¨­å®š
+	TCHAR		m_szExtHtmlHelp[_MAX_PATH];		//!< å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—
+	bool		m_bHtmlHelpIsSingle;			//!< HtmlHelpãƒ“ãƒ¥ãƒ¼ã‚¢ã¯ã²ã¨ã¤ (ãƒ“ãƒ¥ãƒ¼ã‚¢ã‚’è¤‡æ•°èµ·å‹•ã—ãªã„)
 
-	//migemoİ’è
+	//migemoè¨­å®š
 	TCHAR		m_szMigemoDll[_MAX_PATH];		//!< migemo dll
 	TCHAR		m_szMigemoDict[_MAX_PATH];		//!< migemo dict
 
-	//ƒL[ƒ[ƒhƒwƒ‹ƒv
-	LOGFONT		m_lf;							//!< ƒL[ƒ[ƒhƒwƒ‹ƒv‚ÌƒtƒHƒ“ƒgî•ñ		// ai 02/05/21 Add
-	INT			m_nPointSize;					//!< ƒL[ƒ[ƒhƒwƒ‹ƒv‚ÌƒtƒHƒ“ƒgƒTƒCƒYi1/10ƒ|ƒCƒ“ƒg’PˆÊj	// 2009.10.01 ryoji
+	//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—
+	LOGFONT		m_lf;							//!< ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã®ãƒ•ã‚©ãƒ³ãƒˆæƒ…å ±		// ai 02/05/21 Add
+	INT			m_nPointSize;					//!< ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã®ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºï¼ˆ1/10ãƒã‚¤ãƒ³ãƒˆå˜ä½ï¼‰	// 2009.10.01 ryoji
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒ}ƒNƒ                             //
+//                          ãƒã‚¯ãƒ­                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_Macro
 {
-	TCHAR			m_szKeyMacroFileName[MAX_PATH];	//!< ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ìƒtƒ@ƒCƒ‹–¼
-	MacroRec		m_MacroTable[MAX_CUSTMACRO];	//!< ƒL[Š„‚è“–‚Ä—pƒ}ƒNƒƒe[ƒuƒ‹		Sep. 14, 2001 genta
-	SFilePath		m_szMACROFOLDER;				//!< ƒ}ƒNƒ—pƒtƒHƒ‹ƒ_
-	int				m_nMacroOnOpened;				//!< ƒI[ƒvƒ“Œã©“®Àsƒ}ƒNƒ”Ô†	@@@ 2006.09.01 ryoji
-	int				m_nMacroOnTypeChanged;			//!< ƒ^ƒCƒv•ÏXŒã©“®Àsƒ}ƒNƒ”Ô†	@@@ 2006.09.01 ryoji
-	int				m_nMacroOnSave;					//!< •Û‘¶‘O©“®Àsƒ}ƒNƒ”Ô†	@@@ 2006.09.01 ryoji
-	int				m_nMacroCancelTimer;			//!< ƒ}ƒNƒ’â~ƒ_ƒCƒAƒƒO•\¦‘Ò‚¿ŠÔ	@@@ 2011.08.04 syat
+	TCHAR			m_szKeyMacroFileName[MAX_PATH];	//!< ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®ãƒ•ã‚¡ã‚¤ãƒ«å
+	MacroRec		m_MacroTable[MAX_CUSTMACRO];	//!< ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ç”¨ãƒã‚¯ãƒ­ãƒ†ãƒ¼ãƒ–ãƒ«		Sep. 14, 2001 genta
+	SFilePath		m_szMACROFOLDER;				//!< ãƒã‚¯ãƒ­ç”¨ãƒ•ã‚©ãƒ«ãƒ€
+	int				m_nMacroOnOpened;				//!< ã‚ªãƒ¼ãƒ—ãƒ³å¾Œè‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå·	@@@ 2006.09.01 ryoji
+	int				m_nMacroOnTypeChanged;			//!< ã‚¿ã‚¤ãƒ—å¤‰æ›´å¾Œè‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå·	@@@ 2006.09.01 ryoji
+	int				m_nMacroOnSave;					//!< ä¿å­˜å‰è‡ªå‹•å®Ÿè¡Œãƒã‚¯ãƒ­ç•ªå·	@@@ 2006.09.01 ryoji
+	int				m_nMacroCancelTimer;			//!< ãƒã‚¯ãƒ­åœæ­¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°è¡¨ç¤ºå¾…ã¡æ™‚é–“	@@@ 2011.08.04 syat
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      ƒtƒ@ƒCƒ‹–¼•\¦                         //
+//                      ãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤º                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_FileName
 {
-	bool		m_bTransformShortPath;											//!< ƒtƒ@ƒCƒ‹–¼‚ÌÈ—ª•\‹L
-	int			m_nTransformShortMaxWidth;										//!< ƒtƒ@ƒCƒ‹–¼‚ÌÈ—ª•\‹L‚ÌÅ‘å’·
-	int			m_nTransformFileNameArrNum;										//!< ƒtƒ@ƒCƒ‹–¼‚ÌŠÈˆÕ•\¦“o˜^”
-	TCHAR		m_szTransformFileNameFrom[MAX_TRANSFORM_FILENAME][_MAX_PATH];	//!< ƒtƒ@ƒCƒ‹–¼‚ÌŠÈˆÕ•\¦•ÏŠ·‘O•¶š—ñ
-	TCHAR		m_szTransformFileNameTo[MAX_TRANSFORM_FILENAME][_MAX_PATH];		//!< ƒtƒ@ƒCƒ‹–¼‚ÌŠÈˆÕ•\¦•ÏŠ·Œã•¶š—ñ	//@@@ 2003.04.08 MIK
+	bool		m_bTransformShortPath;											//!< ãƒ•ã‚¡ã‚¤ãƒ«åã®çœç•¥è¡¨è¨˜
+	int			m_nTransformShortMaxWidth;										//!< ãƒ•ã‚¡ã‚¤ãƒ«åã®çœç•¥è¡¨è¨˜ã®æœ€å¤§é•·
+	int			m_nTransformFileNameArrNum;										//!< ãƒ•ã‚¡ã‚¤ãƒ«åã®ç°¡æ˜“è¡¨ç¤ºç™»éŒ²æ•°
+	TCHAR		m_szTransformFileNameFrom[MAX_TRANSFORM_FILENAME][_MAX_PATH];	//!< ãƒ•ã‚¡ã‚¤ãƒ«åã®ç°¡æ˜“è¡¨ç¤ºå¤‰æ›å‰æ–‡å­—åˆ—
+	TCHAR		m_szTransformFileNameTo[MAX_TRANSFORM_FILENAME][_MAX_PATH];		//!< ãƒ•ã‚¡ã‚¤ãƒ«åã®ç°¡æ˜“è¡¨ç¤ºå¤‰æ›å¾Œæ–‡å­—åˆ—	//@@@ 2003.04.08 MIK
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       ƒAƒEƒgƒ‰ƒCƒ“                          //
+//                       ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! ƒhƒbƒLƒ“ƒO”z’u
+//! ãƒ‰ãƒƒã‚­ãƒ³ã‚°é…ç½®
 enum EDockSide{
-	DOCKSIDE_FLOAT,				//!< ƒtƒ[ƒeƒBƒ“ƒO
-	DOCKSIDE_LEFT,				//!< ¶ƒhƒbƒLƒ“ƒO
-	DOCKSIDE_TOP,				//!< ãƒhƒbƒLƒ“ƒO
-	DOCKSIDE_RIGHT,				//!< ‰EƒhƒbƒLƒ“ƒO
-	DOCKSIDE_BOTTOM,			//!< ‰ºƒhƒbƒLƒ“ƒO
-	DOCKSIDE_UNDOCKABLE = -1,	//!< ƒhƒbƒLƒ“ƒO‹Ö~
+	DOCKSIDE_FLOAT,				//!< ãƒ•ãƒ­ãƒ¼ãƒ†ã‚£ãƒ³ã‚°
+	DOCKSIDE_LEFT,				//!< å·¦ãƒ‰ãƒƒã‚­ãƒ³ã‚°
+	DOCKSIDE_TOP,				//!< ä¸Šãƒ‰ãƒƒã‚­ãƒ³ã‚°
+	DOCKSIDE_RIGHT,				//!< å³ãƒ‰ãƒƒã‚­ãƒ³ã‚°
+	DOCKSIDE_BOTTOM,			//!< ä¸‹ãƒ‰ãƒƒã‚­ãƒ³ã‚°
+	DOCKSIDE_UNDOCKABLE = -1,	//!< ãƒ‰ãƒƒã‚­ãƒ³ã‚°ç¦æ­¢
 };
 
 enum EFileTreeItemType{
@@ -551,15 +551,15 @@ enum EFileTreeItemType{
 struct SFileTreeItem{
 public:
 	EFileTreeItemType m_eFileTreeItemType;
-	SFilePath	m_szTargetPath;	//!< ƒtƒHƒ‹ƒ_orƒtƒ@ƒCƒ‹ƒpƒX
-	StaticString<TCHAR,_MAX_PATH> m_szLabelName; //!< ƒ‰ƒxƒ‹–¼(""‚Ì‚Æ‚«‚Íƒtƒ@ƒCƒ‹–¼‚ğg‚¤)
-	int  m_nDepth;	//!< ŠK‘w
+	SFilePath	m_szTargetPath;	//!< ãƒ•ã‚©ãƒ«ãƒ€orãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹
+	StaticString<TCHAR,_MAX_PATH> m_szLabelName; //!< ãƒ©ãƒ™ãƒ«å(""ã®ã¨ãã¯ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ä½¿ã†)
+	int  m_nDepth;	//!< éšå±¤
 
-	// Grepƒ^ƒCƒvTreeItem
-	StaticString<TCHAR,_MAX_PATH>	m_szTargetFile;	//!< ƒtƒ@ƒCƒ‹ˆê——
-	bool		m_bIgnoreHidden;		//!< ‰B‚µƒtƒ@ƒCƒ‹‚ğœ‚­
-	bool		m_bIgnoreReadOnly;		//!< “Ç‚İæ‚èê—pƒtƒ@ƒCƒ‹‚ğœ‚­
-	bool		m_bIgnoreSystem;		//!< ƒVƒXƒeƒ€ƒtƒ@ƒCƒ‹‚ğœ‚­
+	// Grepã‚¿ã‚¤ãƒ—TreeItem
+	StaticString<TCHAR,_MAX_PATH>	m_szTargetFile;	//!< ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§
+	bool		m_bIgnoreHidden;		//!< éš ã—ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é™¤ã
+	bool		m_bIgnoreReadOnly;		//!< èª­ã¿å–ã‚Šå°‚ç”¨ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é™¤ã
+	bool		m_bIgnoreSystem;		//!< ã‚·ã‚¹ãƒ†ãƒ ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é™¤ã
 
 	SFileTreeItem()
 		: m_eFileTreeItemType(EFileTreeItemType_Grep)
@@ -571,184 +571,184 @@ public:
 };
 
 struct SFileTree{
-	bool		m_bProject;			//!< ƒvƒƒWƒFƒNƒgƒtƒ@ƒCƒ‹ƒ‚[ƒh
-	SFilePath	m_szProjectIni;		//!< ƒfƒtƒHƒ‹ƒginiƒpƒX
-	int			m_nItemCount;		//!< ƒtƒ@ƒCƒ‹ƒpƒX”
-	SFileTreeItem	m_aItems[20];	//!< ƒcƒŠ[ƒAƒCƒeƒ€
+	bool		m_bProject;			//!< ãƒ—ãƒ­ã‚¸ã‚§ã‚¯ãƒˆãƒ•ã‚¡ã‚¤ãƒ«ãƒ¢ãƒ¼ãƒ‰
+	SFilePath	m_szProjectIni;		//!< ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆiniãƒ‘ã‚¹
+	int			m_nItemCount;		//!< ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹æ•°
+	SFileTreeItem	m_aItems[20];	//!< ãƒ„ãƒªãƒ¼ã‚¢ã‚¤ãƒ†ãƒ 
 };
 
 struct CommonSetting_OutLine
 {
-	// 20060201 aroka ƒAƒEƒgƒ‰ƒCƒ“/ƒgƒsƒbƒNƒŠƒXƒg ‚ÌˆÊ’u‚ÆƒTƒCƒY‚ğ‹L‰¯
-	int			m_bRememberOutlineWindowPos;//!< ƒAƒEƒgƒ‰ƒCƒ“/ƒgƒsƒbƒNƒŠƒXƒg ‚ÌˆÊ’u‚ÆƒTƒCƒY‚ğ‹L‰¯‚·‚é
-	int			m_widthOutlineWindow;		//!< ƒAƒEƒgƒ‰ƒCƒ“/ƒgƒsƒbƒNƒŠƒXƒg ‚ÌƒTƒCƒY(•)
-	int			m_heightOutlineWindow;		//!< ƒAƒEƒgƒ‰ƒCƒ“/ƒgƒsƒbƒNƒŠƒXƒg ‚ÌƒTƒCƒY(‚‚³)
-	int			m_xOutlineWindowPos;        //!< ƒAƒEƒgƒ‰ƒCƒ“/ƒgƒsƒbƒNƒŠƒXƒg ‚ÌˆÊ’u(XÀ•W)
-	int			m_yOutlineWindowPos;		//!< ƒAƒEƒgƒ‰ƒCƒ“/ƒgƒsƒbƒNƒŠƒXƒg ‚ÌˆÊ’u(YÀ•W)
+	// 20060201 aroka ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³/ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆ ã®ä½ç½®ã¨ã‚µã‚¤ã‚ºã‚’è¨˜æ†¶
+	int			m_bRememberOutlineWindowPos;//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³/ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆ ã®ä½ç½®ã¨ã‚µã‚¤ã‚ºã‚’è¨˜æ†¶ã™ã‚‹
+	int			m_widthOutlineWindow;		//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³/ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆ ã®ã‚µã‚¤ã‚º(å¹…)
+	int			m_heightOutlineWindow;		//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³/ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆ ã®ã‚µã‚¤ã‚º(é«˜ã•)
+	int			m_xOutlineWindowPos;        //!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³/ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆ ã®ä½ç½®(Xåº§æ¨™)
+	int			m_yOutlineWindowPos;		//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³/ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆ ã®ä½ç½®(Yåº§æ¨™)
 
-	int			m_nOutlineDockSet;			//!< ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ‚ÌƒhƒbƒLƒ“ƒOˆÊ’uŒp³•û–@(0:‹¤’Êİ’è, 1:ƒ^ƒCƒv•Êİ’è)
-	BOOL		m_bOutlineDockSync;			//!< ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ‚ÌƒhƒbƒLƒ“ƒOˆÊ’u‚ğ“¯Šú‚·‚é
-	BOOL		m_bOutlineDockDisp;			//!< ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•\¦‚Ì—L–³
-	EDockSide	m_eOutlineDockSide;			//!< ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒhƒbƒLƒ“ƒO”z’u
-	int			m_cxOutlineDockLeft;		//!< ƒAƒEƒgƒ‰ƒCƒ“‚Ì¶ƒhƒbƒLƒ“ƒO•
-	int			m_cyOutlineDockTop;			//!< ƒAƒEƒgƒ‰ƒCƒ“‚ÌãƒhƒbƒLƒ“ƒO‚
-	int			m_cxOutlineDockRight;		//!< ƒAƒEƒgƒ‰ƒCƒ“‚Ì‰EƒhƒbƒLƒ“ƒO•
-	int			m_cyOutlineDockBottom;		//!< ƒAƒEƒgƒ‰ƒCƒ“‚Ì‰ºƒhƒbƒLƒ“ƒO‚
-	int			m_nDockOutline;				//!< ƒAƒEƒgƒ‰ƒCƒ“ƒ^ƒCƒv
+	int			m_nOutlineDockSet;			//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã®ãƒ‰ãƒƒã‚­ãƒ³ã‚°ä½ç½®ç¶™æ‰¿æ–¹æ³•(0:å…±é€šè¨­å®š, 1:ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š)
+	BOOL		m_bOutlineDockSync;			//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã®ãƒ‰ãƒƒã‚­ãƒ³ã‚°ä½ç½®ã‚’åŒæœŸã™ã‚‹
+	BOOL		m_bOutlineDockDisp;			//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æè¡¨ç¤ºã®æœ‰ç„¡
+	EDockSide	m_eOutlineDockSide;			//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æãƒ‰ãƒƒã‚­ãƒ³ã‚°é…ç½®
+	int			m_cxOutlineDockLeft;		//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®å·¦ãƒ‰ãƒƒã‚­ãƒ³ã‚°å¹…
+	int			m_cyOutlineDockTop;			//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®ä¸Šãƒ‰ãƒƒã‚­ãƒ³ã‚°é«˜
+	int			m_cxOutlineDockRight;		//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®å³ãƒ‰ãƒƒã‚­ãƒ³ã‚°å¹…
+	int			m_cyOutlineDockBottom;		//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®ä¸‹ãƒ‰ãƒƒã‚­ãƒ³ã‚°é«˜
+	int			m_nDockOutline;				//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã‚¿ã‚¤ãƒ—
 
-	//IDD_FUNCLIST (ƒc[ƒ‹ - ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ)
-	BOOL		m_bAutoCloseDlgFuncList;	//!< ƒAƒEƒgƒ‰ƒCƒ“ƒ_ƒCƒAƒƒO‚ğ©“®“I‚É•Â‚¶‚é
-	BOOL		m_bFunclistSetFocusOnJump;	//!< ƒtƒH[ƒJƒX‚ğˆÚ‚· 2002.02.08 hor
-	BOOL		m_bMarkUpBlankLineEnable;	//!< ‹ós‚ğ–³‹‚·‚é 2002.02.08 aroka,hor
+	//IDD_FUNCLIST (ãƒ„ãƒ¼ãƒ« - ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ)
+	BOOL		m_bAutoCloseDlgFuncList;	//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’è‡ªå‹•çš„ã«é–‰ã˜ã‚‹
+	BOOL		m_bFunclistSetFocusOnJump;	//!< ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã‚’ç§»ã™ 2002.02.08 hor
+	BOOL		m_bMarkUpBlankLineEnable;	//!< ç©ºè¡Œã‚’ç„¡è¦–ã™ã‚‹ 2002.02.08 aroka,hor
 
-	SFileTree	m_sFileTree;				//!< ƒtƒ@ƒCƒ‹ƒcƒŠ[İ’è
-	SFilePath	m_sFileTreeDefIniName;		//!< ƒtƒ@ƒCƒ‹ƒcƒŠ[İ’è‚ÌƒfƒtƒHƒ‹ƒgƒtƒ@ƒCƒ‹–¼(GUI‚È‚µ)
+	SFileTree	m_sFileTree;				//!< ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼è¨­å®š
+	SFilePath	m_sFileTreeDefIniName;		//!< ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼è¨­å®šã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆãƒ•ã‚¡ã‚¤ãƒ«å(GUIãªã—)
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒtƒ@ƒCƒ‹“à—e”äŠr                        //
+//                     ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒ                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_Compare
 {
-	//ƒtƒ@ƒCƒ‹“à—e”äŠrƒ_ƒCƒAƒƒO
-	BOOL		m_bCompareAndTileHorz;		//!< •¶‘”äŠrŒãA¶‰E‚É•À‚×‚Ä•\¦
+	//ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒãƒ€ã‚¤ã‚¢ãƒ­ã‚°
+	BOOL		m_bCompareAndTileHorz;		//!< æ–‡æ›¸æ¯”è¼ƒå¾Œã€å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒrƒ…[                             //
+//                          ãƒ“ãƒ¥ãƒ¼                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_View
 {
-	//INI“àİ’è‚Ì‚İ
-	LOGFONT		m_lf;						//!< Œ»İ‚ÌƒtƒHƒ“ƒgî•ñ
-	BOOL		m_bFontIs_FIXED_PITCH;		//!< Œ»İ‚ÌƒtƒHƒ“ƒg‚ÍŒÅ’è•ƒtƒHƒ“ƒg‚Å‚ ‚é
-	INT			m_nPointSize;				//!< ƒtƒHƒ“ƒgƒTƒCƒYi1/10ƒ|ƒCƒ“ƒg’PˆÊj	// 2009.10.01 ryoji
+	//INIå†…è¨­å®šã®ã¿
+	LOGFONT		m_lf;						//!< ç¾åœ¨ã®ãƒ•ã‚©ãƒ³ãƒˆæƒ…å ±
+	BOOL		m_bFontIs_FIXED_PITCH;		//!< ç¾åœ¨ã®ãƒ•ã‚©ãƒ³ãƒˆã¯å›ºå®šå¹…ãƒ•ã‚©ãƒ³ãƒˆã§ã‚ã‚‹
+	INT			m_nPointSize;				//!< ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºï¼ˆ1/10ãƒã‚¤ãƒ³ãƒˆå˜ä½ï¼‰	// 2009.10.01 ryoji
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ‚»‚Ì‘¼                             //
+//                          ãã®ä»–                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 struct CommonSetting_Others
 {
-	//INI“àİ’è‚Ì‚İ
-	RECT		m_rcOpenDialog;				//!< uŠJ‚­vƒ_ƒCƒAƒƒO‚ÌƒTƒCƒY‚ÆˆÊ’u
-	RECT		m_rcCompareDialog;			//!< uƒtƒ@ƒCƒ‹”äŠrvƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒTƒCƒY‚ÆˆÊ’u
-	RECT		m_rcDiffDialog;				//!< uDIFF·•ª•\¦vƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒTƒCƒY‚ÆˆÊ’u
-	RECT		m_rcFavoriteDialog;			//!< u—š—ğ‚Æ‚¨‹C‚É“ü‚è‚ÌŠÇ—vƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒTƒCƒY‚ÆˆÊ’u
-	RECT		m_rcTagJumpDialog;			//!< uƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒvŒó•âˆê——vƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒTƒCƒY‚ÆˆÊ’u
-	RECT		m_rcWindowListDialog;		//!< uƒEƒBƒ“ƒhƒEˆê——vƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒTƒCƒY‚ÆˆÊ’u
+	//INIå†…è¨­å®šã®ã¿
+	RECT		m_rcOpenDialog;				//!< ã€Œé–‹ãã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚µã‚¤ã‚ºã¨ä½ç½®
+	RECT		m_rcCompareDialog;			//!< ã€Œãƒ•ã‚¡ã‚¤ãƒ«æ¯”è¼ƒã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚µã‚¤ã‚ºã¨ä½ç½®
+	RECT		m_rcDiffDialog;				//!< ã€ŒDIFFå·®åˆ†è¡¨ç¤ºã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚µã‚¤ã‚ºã¨ä½ç½®
+	RECT		m_rcFavoriteDialog;			//!< ã€Œå±¥æ­´ã¨ãŠæ°—ã«å…¥ã‚Šã®ç®¡ç†ã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚µã‚¤ã‚ºã¨ä½ç½®
+	RECT		m_rcTagJumpDialog;			//!< ã€Œãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—å€™è£œä¸€è¦§ã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚µã‚¤ã‚ºã¨ä½ç½®
+	RECT		m_rcWindowListDialog;		//!< ã€Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§ã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚µã‚¤ã‚ºã¨ä½ç½®
 
-	bool		m_bIniReadOnly;				//!< sakura.ini‚Ì“Ç‚İæ‚èê—p
+	bool		m_bIniReadOnly;				//!< sakura.iniã®èª­ã¿å–ã‚Šå°‚ç”¨
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒXƒe[ƒ^ƒXƒo[                     //
+//                          ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼                     //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //	2008/6/21	Uchi
 struct CommonSetting_Statusbar
 {
-	// ¦•¶šƒR[ƒh‚Ìw’è
-	BOOL		m_bDispUniInSjis;				//!< SJIS‚Å•¶šƒR[ƒh’l‚ğUnicode‚Å•\¦‚·‚é
-	BOOL		m_bDispUniInJis;				//!< JIS‚Å•¶šƒR[ƒh’l‚ğUnicode‚Å•\¦‚·‚é
-	BOOL		m_bDispUniInEuc;				//!< EUC‚Å•¶šƒR[ƒh’l‚ğUnicode‚Å•\¦‚·‚é
-	BOOL		m_bDispUtf8Codepoint;			//!< UTF-8‚ğƒR[ƒhƒ|ƒCƒ“ƒg‚Å•\¦‚·‚é
-	BOOL		m_bDispSPCodepoint;				//!< ƒTƒƒQ[ƒgƒyƒA‚ğƒR[ƒhƒ|ƒCƒ“ƒg‚Å•\¦‚·‚é
-	BOOL		m_bDispSelCountByByte;			//!< ‘I‘ğ•¶š”‚ğ•¶š’PˆÊ‚Å‚Í‚È‚­ƒoƒCƒg’PˆÊ‚Å•\¦‚·‚é
-	BOOL		m_bDispColByChar;				//!< Œ»İŒ…‚ğƒ‹[ƒ‰[’PˆÊ‚Å‚Í‚È‚­•¶š’PˆÊ‚Å•\¦‚·‚é
+	// ç¤ºæ–‡å­—ã‚³ãƒ¼ãƒ‰ã®æŒ‡å®š
+	BOOL		m_bDispUniInSjis;				//!< SJISã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹
+	BOOL		m_bDispUniInJis;				//!< JISã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹
+	BOOL		m_bDispUniInEuc;				//!< EUCã§æ–‡å­—ã‚³ãƒ¼ãƒ‰å€¤ã‚’Unicodeã§è¡¨ç¤ºã™ã‚‹
+	BOOL		m_bDispUtf8Codepoint;			//!< UTF-8ã‚’ã‚³ãƒ¼ãƒ‰ãƒã‚¤ãƒ³ãƒˆã§è¡¨ç¤ºã™ã‚‹
+	BOOL		m_bDispSPCodepoint;				//!< ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢ã‚’ã‚³ãƒ¼ãƒ‰ãƒã‚¤ãƒ³ãƒˆã§è¡¨ç¤ºã™ã‚‹
+	BOOL		m_bDispSelCountByByte;			//!< é¸æŠæ–‡å­—æ•°ã‚’æ–‡å­—å˜ä½ã§ã¯ãªããƒã‚¤ãƒˆå˜ä½ã§è¡¨ç¤ºã™ã‚‹
+	BOOL		m_bDispColByChar;				//!< ç¾åœ¨æ¡ã‚’ãƒ«ãƒ¼ãƒ©ãƒ¼å˜ä½ã§ã¯ãªãæ–‡å­—å˜ä½ã§è¡¨ç¤ºã™ã‚‹
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ƒvƒ‰ƒOƒCƒ“                           //
+//                        ãƒ—ãƒ©ã‚°ã‚¤ãƒ³                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! ƒvƒ‰ƒOƒCƒ“ó‘Ô
+//! ãƒ—ãƒ©ã‚°ã‚¤ãƒ³çŠ¶æ…‹
 enum EPluginState {
-	PLS_NONE,			//!< ƒvƒ‰ƒOƒCƒ“ƒe[ƒuƒ‹‚É“o˜^‚ª‚È‚¢
-	PLS_INSTALLED,		//!< ’Ç‰Á‚³‚ê‚½
-	PLS_UPDATED,		//!< XV‚³‚ê‚½
-	PLS_STOPPED,		//!< ’â~‚µ‚Ä‚¢‚é
-	PLS_LOADED,			//!< “Ç‚İ‚Ü‚ê‚½
-	PLS_DELETED			//!< íœ‚³‚ê‚½
+	PLS_NONE,			//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ†ãƒ¼ãƒ–ãƒ«ã«ç™»éŒ²ãŒãªã„
+	PLS_INSTALLED,		//!< è¿½åŠ ã•ã‚ŒãŸ
+	PLS_UPDATED,		//!< æ›´æ–°ã•ã‚ŒãŸ
+	PLS_STOPPED,		//!< åœæ­¢ã—ã¦ã„ã‚‹
+	PLS_LOADED,			//!< èª­ã¿è¾¼ã¾ã‚ŒãŸ
+	PLS_DELETED			//!< å‰Šé™¤ã•ã‚ŒãŸ
 };
 
 struct PluginRec
 {
-	WCHAR			m_szId[MAX_PLUGIN_ID];		//!< ƒvƒ‰ƒOƒCƒ“ID
-	WCHAR			m_szName[MAX_PLUGIN_NAME];	//!< ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_/İ’èƒtƒ@ƒCƒ‹–¼
-	EPluginState	m_state;					//!< ƒvƒ‰ƒOƒCƒ“ó‘ÔBİ’èƒtƒ@ƒCƒ‹‚É•Û‘¶‚¹‚¸ƒƒ‚ƒŠã‚Ì‚İB
-	int 			m_nCmdNum;					//!< ƒvƒ‰ƒOƒCƒ“ ƒRƒ}ƒ“ƒh‚Ì”	// 2010/7/3 Uchi
+	WCHAR			m_szId[MAX_PLUGIN_ID];		//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ID
+	WCHAR			m_szName[MAX_PLUGIN_NAME];	//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€/è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«å
+	EPluginState	m_state;					//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³çŠ¶æ…‹ã€‚è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã«ä¿å­˜ã›ãšãƒ¡ãƒ¢ãƒªä¸Šã®ã¿ã€‚
+	int 			m_nCmdNum;					//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ ã‚³ãƒãƒ³ãƒ‰ã®æ•°	// 2010/7/3 Uchi
 };
 
 struct CommonSetting_Plugin
 {
-	BOOL			m_bEnablePlugin;			//!< ƒvƒ‰ƒOƒCƒ“‚ğg—p‚·‚é‚©‚Ç‚¤‚©
-	PluginRec		m_PluginTable[MAX_PLUGIN];	//!< ƒvƒ‰ƒOƒCƒ“ƒe[ƒuƒ‹
+	BOOL			m_bEnablePlugin;			//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ä½¿ç”¨ã™ã‚‹ã‹ã©ã†ã‹
+	PluginRec		m_PluginTable[MAX_PLUGIN];	//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ†ãƒ¼ãƒ–ãƒ«
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ƒƒCƒ“ƒƒjƒ…[                       //
+//                        ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//! ƒƒCƒ“ƒƒjƒ…[í—Ş
+//! ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ç¨®é¡
 enum EMainMenuType {
 	T_NODE,			//!< Node
-	T_LEAF,			//!< ‹@”\ƒRƒ}ƒ“ƒh
-	T_SEPARATOR,	//!< ‹æØü
-	T_SPECIAL,		//!< “Áê‹@”\ƒRƒ}ƒ“ƒh
+	T_LEAF,			//!< æ©Ÿèƒ½ã‚³ãƒãƒ³ãƒ‰
+	T_SEPARATOR,	//!< åŒºåˆ‡ç·š
+	T_SPECIAL,		//!< ç‰¹æ®Šæ©Ÿèƒ½ã‚³ãƒãƒ³ãƒ‰
 }; 
 
 class CMainMenu {
 public:
-	EMainMenuType	m_nType;		//!< í—Ş
+	EMainMenuType	m_nType;		//!< ç¨®é¡
 	EFunctionCode	m_nFunc;		//!< Function
-	WCHAR			m_sKey[2];		//!< ƒAƒNƒZƒXƒL[
-	WCHAR			m_sName[MAX_MAIN_MENU_NAME_LEN+1];	//!< –¼‘O
-	int 			m_nLevel;		//!< ƒŒƒxƒ‹
+	WCHAR			m_sKey[2];		//!< ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼
+	WCHAR			m_sName[MAX_MAIN_MENU_NAME_LEN+1];	//!< åå‰
+	int 			m_nLevel;		//!< ãƒ¬ãƒ™ãƒ«
 };
 
 struct CommonSetting_MainMenu
 {
-	int				m_nVersion;							//!< ƒƒCƒ“ƒƒjƒ…[ƒo[ƒWƒ‡ƒ“
-	int				m_nMenuTopIdx[MAX_MAINMENU_TOP];	//!< ƒƒCƒ“ƒƒjƒ…[ƒgƒbƒvƒŒƒxƒ‹
-	int 			m_nMainMenuNum;						//!< ƒƒCƒ“ƒƒjƒ…[ƒf[ƒ^‚Ì”
-	CMainMenu		m_cMainMenuTbl[MAX_MAINMENU];		//!< ƒƒCƒ“ƒƒjƒ…[ƒf[ƒ^
-	bool 			m_bMainMenuKeyParentheses;			//!< ƒAƒNƒZƒXƒL[‚ğ( )•t‚Å•\¦
+	int				m_nVersion;							//!< ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒãƒ¼ã‚¸ãƒ§ãƒ³
+	int				m_nMenuTopIdx[MAX_MAINMENU_TOP];	//!< ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒˆãƒƒãƒ—ãƒ¬ãƒ™ãƒ«
+	int 			m_nMainMenuNum;						//!< ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒ‡ãƒ¼ã‚¿ã®æ•°
+	CMainMenu		m_cMainMenuTbl[MAX_MAINMENU];		//!< ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒ‡ãƒ¼ã‚¿
+	bool 			m_bMainMenuKeyParentheses;			//!< ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã‚’( )ä»˜ã§è¡¨ç¤º
 };
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                                                             //
-//                          ‚Ü‚Æ‚ß                             //
+//                          ã¾ã¨ã‚                             //
 //                                                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! ‹¤’Êİ’è
+//! å…±é€šè¨­å®š
 struct CommonSetting
 {
-	CommonSetting_General			m_sGeneral;			//!< ‘S”Ê
-	CommonSetting_Window			m_sWindow;			//!< ƒEƒBƒ“ƒhƒE
-	CommonSetting_TabBar			m_sTabBar;			//!< ƒ^ƒuƒo[
-	CommonSetting_Edit				m_sEdit;			//!< •ÒW
-	CommonSetting_File				m_sFile;			//!< ƒtƒ@ƒCƒ‹
-	CommonSetting_Backup			m_sBackup;			//!< ƒoƒbƒNƒAƒbƒv
-	CommonSetting_Format			m_sFormat;			//!< ‘®
-	CommonSetting_Search			m_sSearch;			//!< ŒŸõ
-	CommonSetting_KeyBind			m_sKeyBind;			//!< ƒL[Š„‚è“–‚Ä
+	CommonSetting_General			m_sGeneral;			//!< å…¨èˆ¬
+	CommonSetting_Window			m_sWindow;			//!< ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	CommonSetting_TabBar			m_sTabBar;			//!< ã‚¿ãƒ–ãƒãƒ¼
+	CommonSetting_Edit				m_sEdit;			//!< ç·¨é›†
+	CommonSetting_File				m_sFile;			//!< ãƒ•ã‚¡ã‚¤ãƒ«
+	CommonSetting_Backup			m_sBackup;			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—
+	CommonSetting_Format			m_sFormat;			//!< æ›¸å¼
+	CommonSetting_Search			m_sSearch;			//!< æ¤œç´¢
+	CommonSetting_KeyBind			m_sKeyBind;			//!< ã‚­ãƒ¼å‰²ã‚Šå½“ã¦
 	//
-	CommonSetting_CustomMenu		m_sCustomMenu;		//!< ƒJƒXƒ^ƒ€ƒƒjƒ…[
-	CommonSetting_ToolBar			m_sToolBar;			//!< ƒc[ƒ‹ƒo[
-	CommonSetting_SpecialKeyword	m_sSpecialKeyword;	//!< ‹­’²ƒL[ƒ[ƒh
-	CommonSetting_Helper			m_sHelper;			//!< x‰‡
-	CommonSetting_Macro				m_sMacro;			//!< ƒ}ƒNƒ
-	CommonSetting_FileName			m_sFileName;		//!< ƒtƒ@ƒCƒ‹–¼•\¦
+	CommonSetting_CustomMenu		m_sCustomMenu;		//!< ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼
+	CommonSetting_ToolBar			m_sToolBar;			//!< ãƒ„ãƒ¼ãƒ«ãƒãƒ¼
+	CommonSetting_SpecialKeyword	m_sSpecialKeyword;	//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+	CommonSetting_Helper			m_sHelper;			//!< æ”¯æ´
+	CommonSetting_Macro				m_sMacro;			//!< ãƒã‚¯ãƒ­
+	CommonSetting_FileName			m_sFileName;		//!< ãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤º
 	//
-	CommonSetting_OutLine			m_sOutline;			//!< ƒAƒEƒgƒ‰ƒCƒ“
-	CommonSetting_Compare			m_sCompare;			//!< ƒtƒ@ƒCƒ‹“à—e”äŠr
-	CommonSetting_View				m_sView;			//!< ƒrƒ…[
-	CommonSetting_Others			m_sOthers;			//!< ‚»‚Ì‘¼
+	CommonSetting_OutLine			m_sOutline;			//!< ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³
+	CommonSetting_Compare			m_sCompare;			//!< ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒ
+	CommonSetting_View				m_sView;			//!< ãƒ“ãƒ¥ãƒ¼
+	CommonSetting_Others			m_sOthers;			//!< ãã®ä»–
 	//
-	CommonSetting_Statusbar			m_sStatusbar;		//!< ƒXƒe[ƒ^ƒXƒo[		// 2008/6/21 Uchi
-	CommonSetting_Plugin			m_sPlugin;			//!< ƒvƒ‰ƒOƒCƒ“ 2009/11/30 syat
-	CommonSetting_MainMenu			m_sMainMenu;		//!< ƒƒCƒ“ƒƒjƒ…[		// 2010/5/15 Uchi
+	CommonSetting_Statusbar			m_sStatusbar;		//!< ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼		// 2008/6/21 Uchi
+	CommonSetting_Plugin			m_sPlugin;			//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ 2009/11/30 syat
+	CommonSetting_MainMenu			m_sMainMenu;		//!< ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼		// 2010/5/15 Uchi
 };
 
 #endif /* SAKURA_COMMONSETTING_7C01A3F3_AD50_4AEA_84D6_0798DB67F40C_H_ */

--- a/sakura_core/env/DLLSHAREDATA.cpp
+++ b/sakura_core/env/DLLSHAREDATA.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -31,7 +31,7 @@
 #include "util/window.h"
 #include "sakura_rc.h"
 
-//GetDllShareData—pƒOƒ[ƒoƒ‹•Ï”
+//GetDllShareDataç”¨ã‚°ãƒ­ãƒ¼ãƒãƒ«å¤‰æ•°
 DLLSHAREDATA* g_theDLLSHAREDATA = NULL;
 
 static CMutex g_cKeywordMutex( FALSE, GSTR_MUTEX_SAKURA_KEYWORD );
@@ -74,9 +74,9 @@ public:
 		::ShowWindow(hwndCancelButton, SW_HIDE);
 		::ShowWindow(hwndKensuu, SW_HIDE);
 		if( GetComctl32Version() >= PACKVERSION(6, 0) ){
-			// ƒ}[ƒL[‚É‚·‚é(CommCtrl 6.0ˆÈã)
+			// ãƒãƒ¼ã‚­ãƒ¼ã«ã™ã‚‹(CommCtrl 6.0ä»¥ä¸Š)
 			HWND hwndProgress = GetItemHwnd(IDC_PROGRESS);
-			// ƒXƒ^ƒCƒ‹•ÏX+ƒƒbƒZ[ƒW‚Å‚È‚¢‚Æ‹@”\‚µ‚È‚¢
+			// ã‚¹ã‚¿ã‚¤ãƒ«å¤‰æ›´+ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã§ãªã„ã¨æ©Ÿèƒ½ã—ãªã„
 			LONG_PTR style = ::GetWindowLongPtr(hwndProgress, GWL_STYLE);
 			::SetWindowLongPtr(hwndProgress, GWL_STYLE, style | PBS_MARQUEE);
 			Progress_SetMarquee(hwndProgress, TRUE, 100);
@@ -88,7 +88,7 @@ public:
 	}
 };
 
-// count‚ª0‚¾‚Á‚½‚çLock‚µ‚Ä•Ô‚·
+// countãŒ0ã ã£ãŸã‚‰Lockã—ã¦è¿”ã™
 static int GetCountIf0Lock( CShareDataLockCounter** ppLock )
 {
 	LockGuard<CMutex> guard(g_cKeywordMutex);

--- a/sakura_core/env/DLLSHAREDATA.h
+++ b/sakura_core/env/DLLSHAREDATA.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,13 +25,13 @@
 #define SAKURA_DLLSHAREDATA_3A6DD7E0_90DC_4219_8570_F5C1B8B6A306_H_
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ƒAƒNƒZƒT                            //
+//                         ã‚¢ã‚¯ã‚»ã‚µ                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! ‚Ç‚±‚©‚ç‚Å‚àƒAƒNƒZƒX‚Å‚«‚éA‹¤—Lƒf[ƒ^ƒAƒNƒZƒTB2007.10.30 kobake
+//! ã©ã“ã‹ã‚‰ã§ã‚‚ã‚¢ã‚¯ã‚»ã‚¹ã§ãã‚‹ã€å…±æœ‰ãƒ‡ãƒ¼ã‚¿ã‚¢ã‚¯ã‚»ã‚µã€‚2007.10.30 kobake
 struct DLLSHAREDATA;
 
-//DLLSHAREDATA‚Ö‚ÌŠÈˆÕƒAƒNƒZƒT
+//DLLSHAREDATAã¸ã®ç°¡æ˜“ã‚¢ã‚¯ã‚»ã‚µ
 inline DLLSHAREDATA& GetDllShareData()
 {
 	extern DLLSHAREDATA* g_theDLLSHAREDATA;
@@ -50,7 +50,7 @@ inline DLLSHAREDATA& GetDllShareData(bool bNullCheck)
 	return *g_theDLLSHAREDATA;
 }
 
-//DLLSHAREDATA‚ğŠm•Û‚µ‚½‚çA‚Ü‚¸‚±‚ê‚ğŒÄ‚ÔB”jŠü‚·‚é‘O‚É‚àŒÄ‚ÔB
+//DLLSHAREDATAã‚’ç¢ºä¿ã—ãŸã‚‰ã€ã¾ãšã“ã‚Œã‚’å‘¼ã¶ã€‚ç ´æ£„ã™ã‚‹å‰ã«ã‚‚å‘¼ã¶ã€‚
 inline void SetDllShareData(DLLSHAREDATA* pShareData)
 {
 	extern DLLSHAREDATA* g_theDLLSHAREDATA;
@@ -59,15 +59,15 @@ inline void SetDllShareData(DLLSHAREDATA* pShareData)
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                    ‹¤—Lƒƒ‚ƒŠ\¬—v‘f                       //
+//                    å…±æœ‰ãƒ¡ãƒ¢ãƒªæ§‹æˆè¦ç´                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-// 2010.04.19 Moca CShareData‚©‚çDLLSHAREDATAƒƒ“ƒo‚Ìinclude‚ğDLLSHAREDATA.h‚ÉˆÚ“®
+// 2010.04.19 Moca CShareDataã‹ã‚‰DLLSHAREDATAãƒ¡ãƒ³ãƒã®includeã‚’DLLSHAREDATA.hã«ç§»å‹•
 
 #include "config/maxdata.h"
 
 #include "env/CAppNodeManager.h"	//SShare_Nodes
-//2007.09.28 kobake Common\‘¢‘Ì‚ğCShareData.h‚©‚ç•ª—£
+//2007.09.28 kobake Commonæ§‹é€ ä½“ã‚’CShareData.hã‹ã‚‰åˆ†é›¢
 #include "env/CommonSetting.h"
 #include "env/CSearchKeywordManager.h"	//SShare_SearchKeywords
 #include "env/CTagJumpManager.h"		//SShare_TagJump
@@ -82,21 +82,21 @@ inline void SetDllShareData(DLLSHAREDATA* pShareData)
 
 
 
-//! ‹¤—Lƒtƒ‰ƒO
+//! å…±æœ‰ãƒ•ãƒ©ã‚°
 struct SShare_Flags{
-	BOOL				m_bEditWndChanging;				// •ÒWƒEƒBƒ“ƒhƒEØ‘Ö’†	// 2007.04.03 ryoji
+	BOOL				m_bEditWndChanging;				// ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ‡æ›¿ä¸­	// 2007.04.03 ryoji
 	/*	@@@ 2002.1.24 YAZAKI
-		ƒL[ƒ{[ƒhƒ}ƒNƒ‚ÍA‹L˜^I—¹‚µ‚½“_‚Åƒtƒ@ƒCƒ‹um_szKeyMacroFileNamev‚É‘‚«o‚·‚±‚Æ‚É‚·‚éB
-		m_bRecordingKeyMacro‚ªTRUE‚Ì‚Æ‚«‚ÍAƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì‹L˜^’†‚È‚Ì‚ÅAm_szKeyMacroFileName‚ÉƒAƒNƒZƒX‚µ‚Ä‚Í‚È‚ç‚È‚¢B
+		ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã¯ã€è¨˜éŒ²çµ‚äº†ã—ãŸæ™‚ç‚¹ã§ãƒ•ã‚¡ã‚¤ãƒ«ã€Œm_szKeyMacroFileNameã€ã«æ›¸ãå‡ºã™ã“ã¨ã«ã™ã‚‹ã€‚
+		m_bRecordingKeyMacroãŒTRUEã®ã¨ãã¯ã€ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ãªã®ã§ã€m_szKeyMacroFileNameã«ã‚¢ã‚¯ã‚»ã‚¹ã—ã¦ã¯ãªã‚‰ãªã„ã€‚
 	*/
-	BOOL				m_bRecordingKeyMacro;		/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì‹L˜^’† */
-	HWND				m_hwndRecordingKeyMacro;	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ‹L˜^’†‚ÌƒEƒBƒ“ƒhƒE */
+	BOOL				m_bRecordingKeyMacro;		/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ */
+	HWND				m_hwndRecordingKeyMacro;	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’è¨˜éŒ²ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
 };
 
-//! ‹¤—Lƒ[ƒNƒoƒbƒtƒ@
+//! å…±æœ‰ãƒ¯ãƒ¼ã‚¯ãƒãƒƒãƒ•ã‚¡
 struct SShare_WorkBuffer{
-	//2007.09.16 kobake charŒ^‚¾‚ÆAí‚É•¶š—ñ‚Å‚ ‚é‚Æ‚¢‚¤Œë‰ğ‚ğµ‚­‚Ì‚ÅABYTEŒ^‚É•ÏXB•Ï”–¼‚à•ÏXB
-	//           UNICODE”Å‚Å‚ÍA—]•ª‚É—Ìˆæ‚ğg‚¤‚±‚Æ‚ª—\‘z‚³‚ê‚é‚½‚ßAANSI”Å‚Ì2”{Šm•ÛB
+	//2007.09.16 kobake charå‹ã ã¨ã€å¸¸ã«æ–‡å­—åˆ—ã§ã‚ã‚‹ã¨ã„ã†èª¤è§£ã‚’æ‹›ãã®ã§ã€BYTEå‹ã«å¤‰æ›´ã€‚å¤‰æ•°åã‚‚å¤‰æ›´ã€‚
+	//           UNICODEç‰ˆã§ã¯ã€ä½™åˆ†ã«é ˜åŸŸã‚’ä½¿ã†ã“ã¨ãŒäºˆæƒ³ã•ã‚Œã‚‹ãŸã‚ã€ANSIç‰ˆã®2å€ç¢ºä¿ã€‚
 private:
 	BYTE				m_pWork[32000*sizeof(TCHAR)];
 public:
@@ -107,19 +107,19 @@ public:
 	size_t GetWorkBufferCount(){ return sizeof(m_pWork)/sizeof(T); }
 
 public:
-	EditInfo			m_EditInfo_MYWM_GETFILEINFO;	//MYWM_GETFILEINFOƒf[ƒ^ó‚¯“n‚µ—p	####”ü‚µ‚­‚È‚¢
-	CLogicPoint			m_LogicPoint;					//!< ƒJ[ƒ\ƒ‹ˆÊ’u
+	EditInfo			m_EditInfo_MYWM_GETFILEINFO;	//MYWM_GETFILEINFOãƒ‡ãƒ¼ã‚¿å—ã‘æ¸¡ã—ç”¨	####ç¾ã—ããªã„
+	CLogicPoint			m_LogicPoint;					//!< ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
 	STypeConfig			m_TypeConfig;
 };
 
-//! ‹¤—Lƒnƒ“ƒhƒ‹
+//! å…±æœ‰ãƒãƒ³ãƒ‰ãƒ«
 struct SShare_Handles{
 	HWND				m_hwndTray;
 	HWND				m_hwndDebug;
 	HACCEL				m_hAccel;
 };
 
-//! EXEî•ñ
+//! EXEæƒ…å ±
 struct SShare_Version{
 	DWORD				m_dwProductVersionMS;
 	DWORD				m_dwProductVersionLS;
@@ -127,60 +127,60 @@ struct SShare_Version{
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                   ‹¤—Lƒƒ‚ƒŠ\‘¢‘Ì–{‘Ì                      //
+//                   å…±æœ‰ãƒ¡ãƒ¢ãƒªæ§‹é€ ä½“æœ¬ä½“                      //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 struct DLLSHAREDATA{
-	// -- -- ƒo[ƒWƒ‡ƒ“ -- -- //
+	// -- -- ãƒãƒ¼ã‚¸ãƒ§ãƒ³ -- -- //
 	/*!
-		ƒf[ƒ^\‘¢ Version	//	Oct. 27, 2000 genta
-		ƒf[ƒ^\‘¢‚ÌˆÙ‚È‚éƒo[ƒWƒ‡ƒ“‚Ì“¯‹N“®‚ğ–h‚®‚½‚ß
-		•K‚¸æ“ª‚É‚È‚­‚Ä‚Í‚È‚ç‚È‚¢D
+		ãƒ‡ãƒ¼ã‚¿æ§‹é€  Version	//	Oct. 27, 2000 genta
+		ãƒ‡ãƒ¼ã‚¿æ§‹é€ ã®ç•°ãªã‚‹ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã®åŒæ™‚èµ·å‹•ã‚’é˜²ããŸã‚
+		å¿…ãšå…ˆé ­ã«ãªãã¦ã¯ãªã‚‰ãªã„ï¼
 	*/
 	unsigned int				m_vStructureVersion;
 	unsigned int				m_nSize;
 
-	// -- -- ”ñ•Û‘¶‘ÎÛ -- -- //
-	SShare_Version				m_sVersion;	//¦“Ç‚Ís‚í‚È‚¢‚ªA‘‚Ís‚¤
+	// -- -- éä¿å­˜å¯¾è±¡ -- -- //
+	SShare_Version				m_sVersion;	//â€»èª­è¾¼ã¯è¡Œã‚ãªã„ãŒã€æ›¸è¾¼ã¯è¡Œã†
 	SShare_WorkBuffer			m_sWorkBuffer;
 	SShare_Flags				m_sFlags;
 	SShare_Nodes				m_sNodes;
 	SShare_Handles				m_sHandles;
 
-	SCharWidthCache				m_sCharWidth;							//!< •¶š”¼Šp‘SŠpƒLƒƒƒbƒVƒ…
-	DWORD						m_dwCustColors[16];						//!< ƒtƒHƒ“ƒgDialogƒJƒXƒ^ƒ€ƒpƒŒƒbƒg
+	SCharWidthCache				m_sCharWidth;							//!< æ–‡å­—åŠè§’å…¨è§’ã‚­ãƒ£ãƒƒã‚·ãƒ¥
+	DWORD						m_dwCustColors[16];						//!< ãƒ•ã‚©ãƒ³ãƒˆDialogã‚«ã‚¹ã‚¿ãƒ ãƒ‘ãƒ¬ãƒƒãƒˆ
 
-	// ƒvƒ‰ƒOƒCƒ“
-	short						m_PlugCmdIcon[MAX_PLUGIN*MAX_PLUG_CMD];	//!< ƒvƒ‰ƒOƒCƒ“ ƒRƒ}ƒ“ƒh ICON ”Ô†	// 2010/7/3 Uchi
-	int							m_maxTBNum;								//!< ƒc[ƒ‹ƒo[ƒ{ƒ^ƒ“ Å‘å’l		// 2010/7/5 Uchi
+	// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³
+	short						m_PlugCmdIcon[MAX_PLUGIN*MAX_PLUG_CMD];	//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ ã‚³ãƒãƒ³ãƒ‰ ICON ç•ªå·	// 2010/7/3 Uchi
+	int							m_maxTBNum;								//!< ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ãƒœã‚¿ãƒ³ æœ€å¤§å€¤		// 2010/7/5 Uchi
 
-	// -- -- •Û‘¶‘ÎÛ -- -- //
-	//İ’è
-	CommonSetting				m_Common;								// ‹¤’Êİ’è
-	int							m_nTypesCount;	// ƒ^ƒCƒv•Êİ’è”
-	STypeConfig					m_TypeBasis;							// ƒ^ƒCƒv•Êİ’è: ‹¤’Ê
-	STypeConfigMini				m_TypeMini[MAX_TYPES];					// ƒ^ƒCƒv•Êİ’è(mini)
-	PRINTSETTING				m_PrintSettingArr[MAX_PRINTSETTINGARR];	// ˆóüƒy[ƒWİ’è
-	int							m_nLockCount;	//!< ƒƒbƒNƒJƒEƒ“ƒg
+	// -- -- ä¿å­˜å¯¾è±¡ -- -- //
+	//è¨­å®š
+	CommonSetting				m_Common;								// å…±é€šè¨­å®š
+	int							m_nTypesCount;	// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šæ•°
+	STypeConfig					m_TypeBasis;							// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š: å…±é€š
+	STypeConfigMini				m_TypeMini[MAX_TYPES];					// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š(mini)
+	PRINTSETTING				m_PrintSettingArr[MAX_PRINTSETTINGARR];	// å°åˆ·ãƒšãƒ¼ã‚¸è¨­å®š
+	int							m_nLockCount;	//!< ãƒ­ãƒƒã‚¯ã‚«ã‚¦ãƒ³ãƒˆ
 	
-	//‚»‚Ì‘¼
+	//ãã®ä»–
 	SShare_SearchKeywords		m_sSearchKeywords;
 	SShare_TagJump				m_sTagJump;
 	SShare_FileNameManagement	m_sFileNameManagement;
 	SShare_History				m_sHistory;
 
-	//ŠO•”ƒRƒ}ƒ“ƒhÀsƒ_ƒCƒAƒƒO‚ÌƒIƒvƒVƒ‡ƒ“
-	int							m_nExecFlgOpt;				/* ŠO•”ƒRƒ}ƒ“ƒhÀsƒIƒvƒVƒ‡ƒ“ */	//	2006.12.03 maru ƒIƒvƒVƒ‡ƒ“‚ÌŠg’£‚Ì‚½‚ß
-	//DIFF·•ª•\¦ƒ_ƒCƒAƒƒO‚ÌƒIƒvƒVƒ‡ƒ“
-	int							m_nDiffFlgOpt;				/* DIFF·•ª•\¦ */	//@@@ 2002.05.27 MIK
-	//ƒ^ƒOƒtƒ@ƒCƒ‹‚Ìì¬ƒ_ƒCƒAƒƒO‚ÌƒIƒvƒVƒ‡ƒ“
-	TCHAR						m_szTagsCmdLine[_MAX_PATH];	/* TAGSƒRƒ}ƒ“ƒhƒ‰ƒCƒ“ƒIƒvƒVƒ‡ƒ“ */	//@@@ 2003.05.12 MIK
-	int							m_nTagsOpt;					/* TAGSƒIƒvƒVƒ‡ƒ“(ƒ`ƒFƒbƒN) */	//@@@ 2003.05.12 MIK
+	//å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	int							m_nExecFlgOpt;				/* å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œã‚ªãƒ—ã‚·ãƒ§ãƒ³ */	//	2006.12.03 maru ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã®æ‹¡å¼µã®ãŸã‚
+	//DIFFå·®åˆ†è¡¨ç¤ºãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	int							m_nDiffFlgOpt;				/* DIFFå·®åˆ†è¡¨ç¤º */	//@@@ 2002.05.27 MIK
+	//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	TCHAR						m_szTagsCmdLine[_MAX_PATH];	/* TAGSã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³ã‚ªãƒ—ã‚·ãƒ§ãƒ³ */	//@@@ 2003.05.12 MIK
+	int							m_nTagsOpt;					/* TAGSã‚ªãƒ—ã‚·ãƒ§ãƒ³(ãƒã‚§ãƒƒã‚¯) */	//@@@ 2003.05.12 MIK
 
 
-	// -- -- ƒeƒ“ƒ|ƒ‰ƒŠ -- -- //
-	//w’ès‚ÖƒWƒƒƒ“ƒvƒ_ƒCƒAƒƒO‚ÌƒIƒvƒVƒ‡ƒ“
-	bool						m_bLineNumIsCRLF_ForJump;			/* w’ès‚ÖƒWƒƒƒ“ƒv‚Ìu‰üs’PˆÊ‚Ìs”Ô†v‚©uÜ‚è•Ô‚µ’PˆÊ‚Ìs”Ô†v‚© */
+	// -- -- ãƒ†ãƒ³ãƒãƒ©ãƒª -- -- //
+	//æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	bool						m_bLineNumIsCRLF_ForJump;			/* æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—ã®ã€Œæ”¹è¡Œå˜ä½ã®è¡Œç•ªå·ã€ã‹ã€ŒæŠ˜ã‚Šè¿”ã—å˜ä½ã®è¡Œç•ªå·ã€ã‹ */
 };
 
 class CShareDataLockCounter{


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/env
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。

主に動作影響について対応前後で挙動に変化がないことのご確認をいただけると助かります。
