### PR TITLE
extmodule 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/extmodule/CBregexp.cpp
+++ b/sakura_core/extmodule/CBregexp.cpp
@@ -1,21 +1,21 @@
-/*!	@file
+ï»¿/*!	@file
 	@brief BREGEXP Library Handler
 
-	Perl5ŒİŠ·³‹K•\Œ»‚ğˆµ‚¤DLL‚Å‚ ‚éBREGEXP.DLL‚ğ—˜—p‚·‚é‚½‚ß‚ÌƒCƒ“ƒ^[ƒtƒF[ƒX
+	Perl5äº’æ›æ­£è¦è¡¨ç¾ã‚’æ‰±ã†DLLã§ã‚ã‚‹BREGEXP.DLLã‚’åˆ©ç”¨ã™ã‚‹ãŸã‚ã®ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 
 	@author genta
 	@date Jun. 10, 2001
-	@date 2002/2/1 hor		ReleaseCompileBuffer‚ğ“K‹X’Ç‰Á
-	@date Jul. 25, 2002 genta s“ªğŒ‚ğl—¶‚µ‚½ŒŸõ‚ğs‚¤‚æ‚¤‚ÉD(’uŠ·‚Í‚Ü‚¾)
-	@date 2003.05.22 ‚©‚ë‚Æ ³‹K‚È³‹K•\Œ»‚É‹ß‚Ã‚¯‚é
-	@date 2005.03.19 ‚©‚ë‚Æ ƒŠƒtƒ@ƒNƒ^ƒŠƒ“ƒOBƒNƒ‰ƒX“à•”‚ğ‰B•ÁB
+	@date 2002/2/1 hor		ReleaseCompileBufferã‚’é©å®œè¿½åŠ 
+	@date Jul. 25, 2002 genta è¡Œé ­æ¡ä»¶ã‚’è€ƒæ…®ã—ãŸæ¤œç´¢ã‚’è¡Œã†ã‚ˆã†ã«ï¼(ç½®æ›ã¯ã¾ã )
+	@date 2003.05.22 ã‹ã‚ã¨ æ­£è¦ãªæ­£è¦è¡¨ç¾ã«è¿‘ã¥ã‘ã‚‹
+	@date 2005.03.19 ã‹ã‚ã¨ ãƒªãƒ•ã‚¡ã‚¯ã‚¿ãƒªãƒ³ã‚°ã€‚ã‚¯ãƒ©ã‚¹å†…éƒ¨ã‚’éš è”½ã€‚
 */
 /*
 	Copyright (C) 2001-2002, genta
 	Copyright (C) 2002, novice, hor, Azumaiya
-	Copyright (C) 2003, ‚©‚ë‚Æ
-	Copyright (C) 2005, ‚©‚ë‚Æ
-	Copyright (C) 2006, ‚©‚ë‚Æ
+	Copyright (C) 2003, ã‹ã‚ã¨
+	Copyright (C) 2005, ã‹ã‚ã¨
+	Copyright (C) 2006, ã‹ã‚ã¨
 	Copyright (C) 2007, ryoji
 
 	This software is provided 'as-is', without any express or implied
@@ -49,7 +49,7 @@
 #include "env/DLLSHAREDATA.h"
 
 
-// CompileAs“ª’uŠ·(len=0)‚Ì‚Éƒ_ƒ~[•¶š—ñ(‚P‚Â‚É“ˆê) by ‚©‚ë‚Æ
+// Compileæ™‚ã€è¡Œé ­ç½®æ›(len=0)ã®æ™‚ã«ãƒ€ãƒŸãƒ¼æ–‡å­—åˆ—(ï¼‘ã¤ã«çµ±ä¸€) by ã‹ã‚ã¨
 const wchar_t CBregexp::m_tmpBuf[2] = L"\0";
 
 
@@ -65,58 +65,58 @@ CBregexp::CBregexp()
 
 CBregexp::~CBregexp()
 {
-	//ƒRƒ“ƒpƒCƒ‹ƒoƒbƒtƒ@‚ğ‰ğ•ú
+	//ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ãƒãƒƒãƒ•ã‚¡ã‚’è§£æ”¾
 	ReleaseCompileBuffer();
 }
 
 
-/*! @brief ŒŸõƒpƒ^[ƒ“‚ª“Á’è‚ÌŒŸõƒpƒ^[ƒ“‚©ƒ`ƒFƒbƒN‚·‚é
+/*! @brief æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ãŒç‰¹å®šã®æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã‹ãƒã‚§ãƒƒã‚¯ã™ã‚‹
 **
-** @param[in] szPattern ŒŸõƒpƒ^[ƒ“
+** @param[in] szPattern æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³
 **
-** @retval ŒŸõƒpƒ^[ƒ“•¶š—ñ’·
+** @retval æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³æ–‡å­—åˆ—é•·
 ** 
-** @date 2005.03.20 ‚©‚ë‚Æ ŠÖ”‚ÉØ‚èo‚µ
+** @date 2005.03.20 ã‹ã‚ã¨ é–¢æ•°ã«åˆ‡ã‚Šå‡ºã—
 */
 int CBregexp::CheckPattern(const wchar_t* szPattern)
 {
-	static const wchar_t TOP_MATCH[] = L"/^\\(*\\^/k";							//!< s“ªƒpƒ^[ƒ“‚Ìƒ`ƒFƒbƒN—pƒpƒ^[ƒ“
-	static const wchar_t DOL_MATCH[] = L"/\\\\\\$$/k";							//!< \$(s––ƒpƒ^[ƒ“‚Å‚È‚¢)ƒ`ƒFƒbƒN—pƒpƒ^[ƒ“
-	static const wchar_t BOT_MATCH[] = L"/\\$\\)*$/k";							//!< s––ƒpƒ^[ƒ“‚Ìƒ`ƒFƒbƒN—pƒpƒ^[ƒ“
-	static const wchar_t TAB_MATCH[] = L"/^\\(*\\^\\$\\)*$/k";					//!< "^$"ƒpƒ^[ƒ“‚©‚ğƒ`ƒFƒbƒN—pƒpƒ^[ƒ“
-	static const wchar_t LOOKAHEAD[] = L"/\\(\\?[=]/k";							//!< "(?=" æ“Ç‚İ ‚Ì‘¶İƒ`ƒFƒbƒNƒpƒ^[ƒ“
-	BREGEXP_W*	sReg = NULL;					//!< ƒRƒ“ƒpƒCƒ‹\‘¢‘Ì
-	wchar_t szMsg[80] = L"";					//!< ƒGƒ‰[ƒƒbƒZ[ƒW
-	int nLen;									//!< ŒŸõƒpƒ^[ƒ“‚Ì’·‚³
-	const wchar_t *szPatternEnd;				//!< ŒŸõƒpƒ^[ƒ“‚ÌI’[
+	static const wchar_t TOP_MATCH[] = L"/^\\(*\\^/k";							//!< è¡Œé ­ãƒ‘ã‚¿ãƒ¼ãƒ³ã®ãƒã‚§ãƒƒã‚¯ç”¨ãƒ‘ã‚¿ãƒ¼ãƒ³
+	static const wchar_t DOL_MATCH[] = L"/\\\\\\$$/k";							//!< \$(è¡Œæœ«ãƒ‘ã‚¿ãƒ¼ãƒ³ã§ãªã„)ãƒã‚§ãƒƒã‚¯ç”¨ãƒ‘ã‚¿ãƒ¼ãƒ³
+	static const wchar_t BOT_MATCH[] = L"/\\$\\)*$/k";							//!< è¡Œæœ«ãƒ‘ã‚¿ãƒ¼ãƒ³ã®ãƒã‚§ãƒƒã‚¯ç”¨ãƒ‘ã‚¿ãƒ¼ãƒ³
+	static const wchar_t TAB_MATCH[] = L"/^\\(*\\^\\$\\)*$/k";					//!< "^$"ãƒ‘ã‚¿ãƒ¼ãƒ³ã‹ã‚’ãƒã‚§ãƒƒã‚¯ç”¨ãƒ‘ã‚¿ãƒ¼ãƒ³
+	static const wchar_t LOOKAHEAD[] = L"/\\(\\?[=]/k";							//!< "(?=" å…ˆèª­ã¿ ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯ãƒ‘ã‚¿ãƒ¼ãƒ³
+	BREGEXP_W*	sReg = NULL;					//!< ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«æ§‹é€ ä½“
+	wchar_t szMsg[80] = L"";					//!< ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	int nLen;									//!< æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã®é•·ã•
+	const wchar_t *szPatternEnd;				//!< æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã®çµ‚ç«¯
 
-	m_ePatType = PAT_NORMAL;	//!<@ƒm[ƒ}ƒ‹‚ÍŠm’è
+	m_ePatType = PAT_NORMAL;	//!<ã€€ãƒãƒ¼ãƒãƒ«ã¯ç¢ºå®š
 	nLen = wcslen( szPattern );
 	szPatternEnd = szPattern + nLen;
-	// ƒpƒ^[ƒ“í•Ê‚Ìİ’è
+	// ãƒ‘ã‚¿ãƒ¼ãƒ³ç¨®åˆ¥ã®è¨­å®š
 	if( BMatch( TOP_MATCH, szPattern, szPatternEnd, &sReg, szMsg ) > 0 ) {
-		// s“ªƒpƒ^[ƒ“‚Éƒ}ƒbƒ`‚µ‚½
+		// è¡Œé ­ãƒ‘ã‚¿ãƒ¼ãƒ³ã«ãƒãƒƒãƒã—ãŸ
 		m_ePatType |= PAT_TOP;
 	}
 	BRegfree(sReg);
 	sReg = NULL;
 	if( BMatch( TAB_MATCH, szPattern, szPatternEnd, &sReg, szMsg ) > 0 ) {
-		// s“ªs––ƒpƒ^[ƒ“‚Éƒ}ƒbƒ`‚µ‚½
+		// è¡Œé ­è¡Œæœ«ãƒ‘ã‚¿ãƒ¼ãƒ³ã«ãƒãƒƒãƒã—ãŸ
 		m_ePatType |= PAT_TAB;
 	}
 	BRegfree(sReg);
 	sReg = NULL;
 	if( BMatch( DOL_MATCH, szPattern, szPatternEnd, &sReg, szMsg ) > 0 ) {
-		// s––‚Ì\$ ‚Éƒ}ƒbƒ`‚µ‚½
+		// è¡Œæœ«ã®\$ ã«ãƒãƒƒãƒã—ãŸ
 		// PAT_NORMAL
 	} else {
 		BRegfree(sReg);
 		sReg = NULL;
 		if( BMatch( BOT_MATCH, szPattern, szPatternEnd, &sReg, szMsg ) > 0 ) {
-			// s––ƒpƒ^[ƒ“‚Éƒ}ƒbƒ`‚µ‚½
+			// è¡Œæœ«ãƒ‘ã‚¿ãƒ¼ãƒ³ã«ãƒãƒƒãƒã—ãŸ
 			m_ePatType |= PAT_BOTTOM;
 		} else {
-			// ‚»‚Ì‘¼
+			// ãã®ä»–
 			// PAT_NORMAL
 		}
 	}
@@ -124,7 +124,7 @@ int CBregexp::CheckPattern(const wchar_t* szPattern)
 	sReg = NULL;
 	
 	if( BMatch( LOOKAHEAD, szPattern, szPattern + nLen, &sReg, szMsg ) > 0 ) {
-		// æ“Ç‚İƒpƒ^[ƒ“‚Éƒ}ƒbƒ`‚µ‚½
+		// å…ˆèª­ã¿ãƒ‘ã‚¿ãƒ¼ãƒ³ã«ãƒãƒƒãƒã—ãŸ
 		m_ePatType |= PAT_LOOKAHEAD;
 	}
 	BRegfree(sReg);
@@ -132,39 +132,39 @@ int CBregexp::CheckPattern(const wchar_t* szPattern)
 	return (nLen);
 }
 
-/*! @brief ƒ‰ƒCƒuƒ‰ƒŠ‚É“n‚·‚½‚ß‚ÌŒŸõE’uŠ·ƒpƒ^[ƒ“‚ğì¬‚·‚é
+/*! @brief ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã«æ¸¡ã™ãŸã‚ã®æ¤œç´¢ãƒ»ç½®æ›ãƒ‘ã‚¿ãƒ¼ãƒ³ã‚’ä½œæˆã™ã‚‹
 **
-** @note szPattern2: == NULL:ŒŸõ != NULL:’uŠ·
+** @note szPattern2: == NULL:æ¤œç´¢ != NULL:ç½®æ›
 **
-** @retval ƒ‰ƒCƒuƒ‰ƒŠ‚É“n‚·ŒŸõƒpƒ^[ƒ“‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğ•Ô‚·
-** @note •Ô‚·ƒ|ƒCƒ“ƒ^‚ÍAŒÄ‚Ño‚µ‘¤‚Å delete ‚·‚é‚±‚Æ
+** @retval ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã«æ¸¡ã™æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã™
+** @note è¿”ã™ãƒã‚¤ãƒ³ã‚¿ã¯ã€å‘¼ã³å‡ºã—å´ã§ delete ã™ã‚‹ã“ã¨
 ** 
-** @date 2003.05.03 ‚©‚ë‚Æ ŠÖ”‚ÉØ‚èo‚µ
+** @date 2003.05.03 ã‹ã‚ã¨ é–¢æ•°ã«åˆ‡ã‚Šå‡ºã—
 */
 wchar_t* CBregexp::MakePatternSub(
-	const wchar_t*	szPattern,	//!< ŒŸõƒpƒ^[ƒ“
-	const wchar_t*	szPattern2,	//!< ’uŠ·ƒpƒ^[ƒ“(NULL‚È‚çŒŸõ)
-	const wchar_t*	szAdd2,		//!< ’uŠ·ƒpƒ^[ƒ“‚ÌŒã‚ë‚É•t‚¯‰Á‚¦‚éƒpƒ^[ƒ“($1‚È‚Ç) 
-	int				nOption		//!< ŒŸõƒIƒvƒVƒ‡ƒ“
+	const wchar_t*	szPattern,	//!< æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³
+	const wchar_t*	szPattern2,	//!< ç½®æ›ãƒ‘ã‚¿ãƒ¼ãƒ³(NULLãªã‚‰æ¤œç´¢)
+	const wchar_t*	szAdd2,		//!< ç½®æ›ãƒ‘ã‚¿ãƒ¼ãƒ³ã®å¾Œã‚ã«ä»˜ã‘åŠ ãˆã‚‹ãƒ‘ã‚¿ãƒ¼ãƒ³($1ãªã©) 
+	int				nOption		//!< æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 ) 
 {
-	static const wchar_t DELIMITER = WCODE::BREGEXP_DELIMITER;	//!< ƒfƒŠƒ~ƒ^
-	int nLen;									//!< szPattern‚Ì’·‚³
-	int nLen2;									//!< szPattern2 + szAdd2 ‚Ì’·‚³
+	static const wchar_t DELIMITER = WCODE::BREGEXP_DELIMITER;	//!< ãƒ‡ãƒªãƒŸã‚¿
+	int nLen;									//!< szPatternã®é•·ã•
+	int nLen2;									//!< szPattern2 + szAdd2 ã®é•·ã•
 
-	// ŒŸõƒpƒ^[ƒ“ì¬
-	wchar_t *szNPattern;		//!< ƒ‰ƒCƒuƒ‰ƒŠ“n‚µ—p‚ÌŒŸõƒpƒ^[ƒ“•¶š—ñ
-	wchar_t *pPat;				//!< ƒpƒ^[ƒ“•¶š—ñ‘€ì—p‚Ìƒ|ƒCƒ“ƒ^
+	// æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ä½œæˆ
+	wchar_t *szNPattern;		//!< ãƒ©ã‚¤ãƒ–ãƒ©ãƒªæ¸¡ã—ç”¨ã®æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³æ–‡å­—åˆ—
+	wchar_t *pPat;				//!< ãƒ‘ã‚¿ãƒ¼ãƒ³æ–‡å­—åˆ—æ“ä½œç”¨ã®ãƒã‚¤ãƒ³ã‚¿
 
 	nLen = wcslen(szPattern);
 	if (szPattern2 == NULL) {
-		// ŒŸõ(BMatch)
-		szNPattern = new wchar_t[ nLen + 15 ];	//	15Fus///optionv‚ª—]—T‚Å‚Í‚¢‚é‚æ‚¤‚ÉB
+		// æ¤œç´¢(BMatch)æ™‚
+		szNPattern = new wchar_t[ nLen + 15 ];	//	15ï¼šã€Œs///optionã€ãŒä½™è£•ã§ã¯ã„ã‚‹ã‚ˆã†ã«ã€‚
 		pPat = szNPattern;
 		*pPat++ = L'm';
 	}
 	else {
-		// ’uŠ·(BSubst)
+		// ç½®æ›(BSubst)æ™‚
 		nLen2 = wcslen(szPattern2) + wcslen(szAdd2);
 		szNPattern = new wchar_t[ nLen + nLen2 + 15 ];
 		pPat = szNPattern;
@@ -178,15 +178,15 @@ wchar_t* CBregexp::MakePatternSub(
 		while (*szAdd2 != L'\0') { *pPat++ = *szAdd2++; }
 		*pPat++ = DELIMITER;
 	}
-	*pPat++ = L'k';			// Š¿š‘Î‰
-	*pPat++ = L'm';			// •¡”s‘Î‰(’A‚µAŒÄ‚Ño‚µ‘¤‚ª•¡”s‘Î‰‚Å‚È‚¢)
-	// 2006.01.22 ‚©‚ë‚Æ ˜_—‹t‚È‚Ì‚Å bIgnoreCase -> optCaseSensitive‚É•ÏX
-	if( !(nOption & optCaseSensitive) ) {		// 2002/2/1 hor IgnoreCase ƒIƒvƒVƒ‡ƒ“’Ç‰Á ƒ}[ƒWFaroka
-		*pPat++ = L'i';		// ‘å•¶š¬•¶š‚ğ“¯ˆê‹(–³‹)‚·‚é
+	*pPat++ = L'k';			// æ¼¢å­—å¯¾å¿œ
+	*pPat++ = L'm';			// è¤‡æ•°è¡Œå¯¾å¿œ(ä½†ã—ã€å‘¼ã³å‡ºã—å´ãŒè¤‡æ•°è¡Œå¯¾å¿œã§ãªã„)
+	// 2006.01.22 ã‹ã‚ã¨ è«–ç†é€†ãªã®ã§ bIgnoreCase -> optCaseSensitiveã«å¤‰æ›´
+	if( !(nOption & optCaseSensitive) ) {		// 2002/2/1 hor IgnoreCase ã‚ªãƒ—ã‚·ãƒ§ãƒ³è¿½åŠ  ãƒãƒ¼ã‚¸ï¼šaroka
+		*pPat++ = L'i';		// å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–(ç„¡è¦–)ã™ã‚‹
 	}
-	// 2006.01.22 ‚©‚ë‚Æ s’PˆÊ’uŠ·‚Ì‚½‚ß‚ÉA‘SˆæƒIƒvƒVƒ‡ƒ“’Ç‰Á
+	// 2006.01.22 ã‹ã‚ã¨ è¡Œå˜ä½ç½®æ›ã®ãŸã‚ã«ã€å…¨åŸŸã‚ªãƒ—ã‚·ãƒ§ãƒ³è¿½åŠ 
 	if( (nOption & optGlobal) ) {
-		*pPat++ = L'g';			// ‘Sˆæ(global)ƒIƒvƒVƒ‡ƒ“As’PˆÊ‚Ì’uŠ·‚ğ‚·‚é‚Ég—p‚·‚é
+		*pPat++ = L'g';			// å…¨åŸŸ(global)ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã€è¡Œå˜ä½ã®ç½®æ›ã‚’ã™ã‚‹æ™‚ã«ä½¿ç”¨ã™ã‚‹
 	}
 	if( (nOption & optExtend) ) {
 		*pPat++ = L'x';
@@ -213,52 +213,52 @@ wchar_t* CBregexp::MakePatternSub(
 
 
 /*! 
-** s––•¶š‚ÌˆÓ–¡‚ªƒ‰ƒCƒuƒ‰ƒŠ‚Å‚Í \nŒÅ’è‚È‚Ì‚ÅA
-** ‚±‚ê‚ğ‚²‚Ü‚©‚·‚½‚ß‚ÉAƒ‰ƒCƒuƒ‰ƒŠ‚É“n‚·‚½‚ß‚ÌŒŸõE’uŠ·ƒpƒ^[ƒ“‚ğH•v‚·‚é
+** è¡Œæœ«æ–‡å­—ã®æ„å‘³ãŒãƒ©ã‚¤ãƒ–ãƒ©ãƒªã§ã¯ \nå›ºå®šãªã®ã§ã€
+** ã“ã‚Œã‚’ã”ã¾ã‹ã™ãŸã‚ã«ã€ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã«æ¸¡ã™ãŸã‚ã®æ¤œç´¢ãƒ»ç½®æ›ãƒ‘ã‚¿ãƒ¼ãƒ³ã‚’å·¥å¤«ã™ã‚‹
 **
-** s––•¶š($)‚ªŒŸõƒpƒ^[ƒ“‚ÌÅŒã‚É‚ ‚èA‚»‚Ì’¼‘O‚ª [\r\n] ‚Å‚È‚¢ê‡‚ÉA
-** s––•¶š($)‚Ìè‘O‚É ([\r\n]+)‚ğ•â‚Á‚ÄA’uŠ·ƒpƒ^[ƒ“‚É $(nParen+1)‚ğ•â‚¤
-** ‚Æ‚¢‚¤ƒAƒ‹ƒSƒŠƒYƒ€‚ğ—p‚¢‚ÄA‚²‚Ü‚©‚·B
+** è¡Œæœ«æ–‡å­—($)ãŒæ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã®æœ€å¾Œã«ã‚ã‚Šã€ãã®ç›´å‰ãŒ [\r\n] ã§ãªã„å ´åˆã«ã€
+** è¡Œæœ«æ–‡å­—($)ã®æ‰‹å‰ã« ([\r\n]+)ã‚’è£œã£ã¦ã€ç½®æ›ãƒ‘ã‚¿ãƒ¼ãƒ³ã« $(nParen+1)ã‚’è£œã†
+** ã¨ã„ã†ã‚¢ãƒ«ã‚´ãƒªã‚ºãƒ ã‚’ç”¨ã„ã¦ã€ã”ã¾ã‹ã™ã€‚
 **
-** @note szPattern2: == NULL:ŒŸõ != NULL:’uŠ·
+** @note szPattern2: == NULL:æ¤œç´¢ != NULL:ç½®æ›
 ** 
-** @param[in] szPattern ŒŸõƒpƒ^[ƒ“
-** @param[in] szPattern2 ’uŠ·ƒpƒ^[ƒ“(NULL‚È‚çŒŸõ)
-** @param[in] nOption ŒŸõƒIƒvƒVƒ‡ƒ“
+** @param[in] szPattern æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³
+** @param[in] szPattern2 ç½®æ›ãƒ‘ã‚¿ãƒ¼ãƒ³(NULLãªã‚‰æ¤œç´¢)
+** @param[in] nOption æ¤œç´¢ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 **
-** @retval ƒ‰ƒCƒuƒ‰ƒŠ‚É“n‚·ŒŸõƒpƒ^[ƒ“‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğ•Ô‚·
-** @note •Ô‚·ƒ|ƒCƒ“ƒ^‚ÍAŒÄ‚Ño‚µ‘¤‚Å delete ‚·‚é‚±‚Æ
+** @retval ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã«æ¸¡ã™æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã™
+** @note è¿”ã™ãƒã‚¤ãƒ³ã‚¿ã¯ã€å‘¼ã³å‡ºã—å´ã§ delete ã™ã‚‹ã“ã¨
 **
-** @date 2003.05.03 ‚©‚ë‚Æ ŠÖ”‚ÉØ‚èo‚µ
+** @date 2003.05.03 ã‹ã‚ã¨ é–¢æ•°ã«åˆ‡ã‚Šå‡ºã—
 */
 wchar_t* CBregexp::MakePattern( const wchar_t* szPattern, const wchar_t* szPattern2, int nOption ) 
 {
 	using namespace WCODE;
-	static const wchar_t* szCRLF = CRLF;		//!< •œ‹AE‰üs
-	static const wchar_t szCR[] = {CR,0};				//!< •œ‹A
-	static const wchar_t szLF[] = {LF,0};				//!< ‰üs
-	static const wchar_t BOT_SUBST[] = L"s/\\$(\\)*)$/([\\\\r\\\\n]+)\\$$1/k";	//!< s––ƒpƒ^[ƒ“‚Ì’uŠ·—pƒpƒ^[ƒ“
-	int nLen;									//!< szPattern‚Ì’·‚³
-	BREGEXP_W*	sReg = NULL;					//!< ƒRƒ“ƒpƒCƒ‹\‘¢‘Ì
-	wchar_t szMsg[80] = L"";						//!< ƒGƒ‰[ƒƒbƒZ[ƒW
-	wchar_t szAdd2[5] = L"";						//!< s––‚ ‚è’uŠ·‚Ì $”š Ši”[—p
-	int nParens = 0;							//!< ŒŸõƒpƒ^[ƒ“(szPattern)’†‚ÌŠ‡ŒÊ‚Ì”(s––‚Ég—p)
-	wchar_t *szNPattern;							//!< ŒŸõƒpƒ^[ƒ“
+	static const wchar_t* szCRLF = CRLF;		//!< å¾©å¸°ãƒ»æ”¹è¡Œ
+	static const wchar_t szCR[] = {CR,0};				//!< å¾©å¸°
+	static const wchar_t szLF[] = {LF,0};				//!< æ”¹è¡Œ
+	static const wchar_t BOT_SUBST[] = L"s/\\$(\\)*)$/([\\\\r\\\\n]+)\\$$1/k";	//!< è¡Œæœ«ãƒ‘ã‚¿ãƒ¼ãƒ³ã®ç½®æ›ç”¨ãƒ‘ã‚¿ãƒ¼ãƒ³
+	int nLen;									//!< szPatternã®é•·ã•
+	BREGEXP_W*	sReg = NULL;					//!< ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«æ§‹é€ ä½“
+	wchar_t szMsg[80] = L"";						//!< ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	wchar_t szAdd2[5] = L"";						//!< è¡Œæœ«ã‚ã‚Šç½®æ›ã® $æ•°å­— æ ¼ç´ç”¨
+	int nParens = 0;							//!< æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³(szPattern)ä¸­ã®æ‹¬å¼§ã®æ•°(è¡Œæœ«æ™‚ã«ä½¿ç”¨)
+	wchar_t *szNPattern;							//!< æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³
 
 	nLen = CheckPattern( szPattern );
 	if( (m_ePatType & PAT_BOTTOM) != 0 ) {
-		bool bJustDollar = false;			// s––w’è‚Ì$‚Ì‚İ‚Å‚ ‚éƒtƒ‰ƒO($‚Ì‘O‚É \r\n‚ªw’è‚³‚ê‚Ä‚¢‚È‚¢)
+		bool bJustDollar = false;			// è¡Œæœ«æŒ‡å®šã®$ã®ã¿ã§ã‚ã‚‹ãƒ•ãƒ©ã‚°($ã®å‰ã« \r\nãŒæŒ‡å®šã•ã‚Œã¦ã„ãªã„)
 		szNPattern = MakePatternSub(szPattern, NULL, NULL, nOption);
 		int matched = BMatch( szNPattern, szCRLF, szCRLF+wcslen(szCRLF), &sReg, szMsg );
 		if( matched >= 0 ) {
-			// szNPattern‚ª•s³‚Èƒpƒ^[ƒ““™‚ÌƒGƒ‰[‚Å‚È‚©‚Á‚½
-			// ƒGƒ‰[‚É‚Í sReg‚ªNULL‚Ì‚Ü‚Ü‚È‚Ì‚ÅAsReg->nparens‚Ö‚ÌƒAƒNƒZƒX‚Í•s³
-			nParens = sReg->nparens;			// ƒIƒŠƒWƒiƒ‹‚ÌŒŸõ•¶š—ñ’†‚Ì()‚Ì”‚ğ‹L‰¯
+			// szNPatternãŒä¸æ­£ãªãƒ‘ã‚¿ãƒ¼ãƒ³ç­‰ã®ã‚¨ãƒ©ãƒ¼ã§ãªã‹ã£ãŸ
+			// ã‚¨ãƒ©ãƒ¼æ™‚ã«ã¯ sRegãŒNULLã®ã¾ã¾ãªã®ã§ã€sReg->nparensã¸ã®ã‚¢ã‚¯ã‚»ã‚¹ã¯ä¸æ­£
+			nParens = sReg->nparens;			// ã‚ªãƒªã‚¸ãƒŠãƒ«ã®æ¤œç´¢æ–‡å­—åˆ—ä¸­ã®()ã®æ•°ã‚’è¨˜æ†¶
 			if( matched > 0 ) {
 				if( sReg->startp[0] == &szCRLF[1] && sReg->endp[0] == &szCRLF[1] ) {
 					if( BMatch( NULL, szCR, szCR+wcslen(szCR), &sReg, szMsg ) > 0 && sReg->startp[0] == &szCR[1] && sReg->endp[0] == &szCR[1] ) {
 						if( BMatch( NULL, szLF, szLF+wcslen(szLF), &sReg, szMsg ) > 0 && sReg->startp[0] == &szLF[0] && sReg->endp[0] == &szLF[0] ) {
-							// ŒŸõ•¶š—ñ‚Í s––($)‚Ì‚İ‚¾‚Á‚½
+							// æ¤œç´¢æ–‡å­—åˆ—ã¯ è¡Œæœ«($)ã®ã¿ã ã£ãŸ
 							bJustDollar = true;
 						}
 					}
@@ -266,7 +266,7 @@ wchar_t* CBregexp::MakePattern( const wchar_t* szPattern, const wchar_t* szPatte
 			} else {
 				if( BMatch( NULL, szCR, szCR+wcslen(szCR), &sReg, szMsg ) <= 0 ) {
 					if( BMatch( NULL, szLF, szLF+wcslen(szLF), &sReg, szMsg ) <= 0 ) {
-						// ŒŸõ•¶š—ñ‚ÍA•¶š{s––($)‚¾‚Á‚½
+						// æ¤œç´¢æ–‡å­—åˆ—ã¯ã€æ–‡å­—ï¼‹è¡Œæœ«($)ã ã£ãŸ
 						bJustDollar = true;
 					}
 				}
@@ -277,15 +277,15 @@ wchar_t* CBregexp::MakePattern( const wchar_t* szPattern, const wchar_t* szPatte
 		delete [] szNPattern;
 
 		if( bJustDollar == true || (m_ePatType & PAT_TAB) != 0 ) {
-			// s––w’è‚Ì$ or s“ªs––w’è ‚È‚Ì‚ÅAŒŸõ•¶š—ñ‚ğ’uŠ·
+			// è¡Œæœ«æŒ‡å®šã®$ or è¡Œé ­è¡Œæœ«æŒ‡å®š ãªã®ã§ã€æ¤œç´¢æ–‡å­—åˆ—ã‚’ç½®æ›
 			if( BSubst( BOT_SUBST, szPattern, szPattern + nLen, &sReg, szMsg ) > 0 ) {
 				szPattern = sReg->outp;
 				if( szPattern2 != NULL ) {
-					// ’uŠ·ƒpƒ^[ƒ“‚à‚ ‚é‚Ì‚ÅA’uŠ·ƒpƒ^[ƒ“‚ÌÅŒã‚É $(nParens+1)‚ğ’Ç‰Á
+					// ç½®æ›ãƒ‘ã‚¿ãƒ¼ãƒ³ã‚‚ã‚ã‚‹ã®ã§ã€ç½®æ›ãƒ‘ã‚¿ãƒ¼ãƒ³ã®æœ€å¾Œã« $(nParens+1)ã‚’è¿½åŠ 
 					auto_sprintf( szAdd2, L"$%d", nParens + 1 );
 				}
 			}
-			// sReg->outp ‚Ìƒ|ƒCƒ“ƒ^‚ğQÆ‚µ‚Ä‚¢‚é‚Ì‚ÅAsReg‚ğ‰ğ•ú‚·‚é‚Ì‚ÍÅŒã‚É
+			// sReg->outp ã®ãƒã‚¤ãƒ³ã‚¿ã‚’å‚ç…§ã—ã¦ã„ã‚‹ã®ã§ã€sRegã‚’è§£æ”¾ã™ã‚‹ã®ã¯æœ€å¾Œã«
 		}
 	}
 
@@ -298,13 +298,13 @@ wchar_t* CBregexp::MakePattern( const wchar_t* szPattern, const wchar_t* szPatte
 
 
 /*!
-	CBregexp::MakePattern()‚Ì‘ã‘ÖB
-	* ƒGƒXƒP[ƒv‚³‚ê‚Ä‚¨‚ç‚¸A•¶šW‡‚Æ \Q...\E‚Ì’†‚É‚È‚¢ . ‚ğ [^\r\n] ‚É’uŠ·‚·‚éB
-	* ƒGƒXƒP[ƒv‚³‚ê‚Ä‚¨‚ç‚¸A•¶šW‡‚Æ \Q...\E‚Ì’†‚É‚È‚¢ $ ‚ğ (?<![\r\n])(?=\r|$) ‚É’uŠ·‚·‚éB
-	‚±‚ê‚Íu‰üsv‚ÌˆÓ–¡‚ğ LF ‚Ì‚İ(BREGEXP.DLL‚Ìd—l)‚©‚çACR, LF, CRLF ‚ÉŠg’£‚·‚é‚½‚ß‚Ì•ÏX‚Å‚ ‚éB
-	‚Ü‚½A$ ‚Í‰üs‚ÌŒã‚ëAs•¶š—ñ––”ö‚Éƒ}ƒbƒ`‚µ‚È‚­‚È‚éBÅŒã‚Ìˆês‚Ìê‡‚ğ‚Ì‚¼‚¢‚ÄA
-	³‹K•\Œ»DLL‚É—^‚¦‚ç‚ê‚é•¶š—ñ‚Ì––”ö‚Í•¶‘––‚Æ‚Í‚¢‚¦‚¸A$ ‚ªƒ}ƒbƒ`‚·‚é•K—v‚Í‚È‚¢‚¾‚ë‚¤B
-	$ ‚ªs•¶š—ñ––”ö‚Éƒ}ƒbƒ`‚µ‚È‚¢‚±‚Æ‚ÍAˆêŠ‡’uŠ·‚Å‚ÌŠú‘Ò‚µ‚È‚¢’uŠ·‚ğ–h‚®‚½‚ß‚É•K—v‚Å‚ ‚éB
+	CBregexp::MakePattern()ã®ä»£æ›¿ã€‚
+	* ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã•ã‚Œã¦ãŠã‚‰ãšã€æ–‡å­—é›†åˆã¨ \Q...\Eã®ä¸­ã«ãªã„ . ã‚’ [^\r\n] ã«ç½®æ›ã™ã‚‹ã€‚
+	* ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã•ã‚Œã¦ãŠã‚‰ãšã€æ–‡å­—é›†åˆã¨ \Q...\Eã®ä¸­ã«ãªã„ $ ã‚’ (?<![\r\n])(?=\r|$) ã«ç½®æ›ã™ã‚‹ã€‚
+	ã“ã‚Œã¯ã€Œæ”¹è¡Œã€ã®æ„å‘³ã‚’ LF ã®ã¿(BREGEXP.DLLã®ä»•æ§˜)ã‹ã‚‰ã€CR, LF, CRLF ã«æ‹¡å¼µã™ã‚‹ãŸã‚ã®å¤‰æ›´ã§ã‚ã‚‹ã€‚
+	ã¾ãŸã€$ ã¯æ”¹è¡Œã®å¾Œã‚ã€è¡Œæ–‡å­—åˆ—æœ«å°¾ã«ãƒãƒƒãƒã—ãªããªã‚‹ã€‚æœ€å¾Œã®ä¸€è¡Œã®å ´åˆã‚’ã®ãã„ã¦ã€
+	æ­£è¦è¡¨ç¾DLLã«ä¸ãˆã‚‰ã‚Œã‚‹æ–‡å­—åˆ—ã®æœ«å°¾ã¯æ–‡æ›¸æœ«ã¨ã¯ã„ãˆãšã€$ ãŒãƒãƒƒãƒã™ã‚‹å¿…è¦ã¯ãªã„ã ã‚ã†ã€‚
+	$ ãŒè¡Œæ–‡å­—åˆ—æœ«å°¾ã«ãƒãƒƒãƒã—ãªã„ã“ã¨ã¯ã€ä¸€æ‹¬ç½®æ›ã§ã®æœŸå¾…ã—ãªã„ç½®æ›ã‚’é˜²ããŸã‚ã«å¿…è¦ã§ã‚ã‚‹ã€‚
 */
 wchar_t* CBregexp::MakePatternAlternate( const wchar_t* const szSearch, const wchar_t* const szReplace, int nOption )
 {
@@ -313,7 +313,7 @@ wchar_t* CBregexp::MakePatternAlternate( const wchar_t* const szSearch, const wc
 	static const wchar_t szDotAlternative[] = L"[^\\r\\n]";
 	static const wchar_t szDollarAlternative[] = L"(?<![\\r\\n])(?=\\r|$)";
 
-	// ‚·‚×‚Ä‚Ì . ‚ğ [^\r\n] ‚ÖA‚·‚×‚Ä‚Ì $ ‚ğ (?<![\r\n])(?=\r|$) ‚Ö’uŠ·‚·‚é‚Æ‰¼’è‚µ‚ÄAstrModifiedSearch‚ÌÅ‘å’·‚ğŒˆ’è‚·‚éB
+	// ã™ã¹ã¦ã® . ã‚’ [^\r\n] ã¸ã€ã™ã¹ã¦ã® $ ã‚’ (?<![\r\n])(?=\r|$) ã¸ç½®æ›ã™ã‚‹ã¨ä»®å®šã—ã¦ã€strModifiedSearchã®æœ€å¤§é•·ã‚’æ±ºå®šã™ã‚‹ã€‚
 	std::wstring::size_type modifiedSearchSize = 0;
 	for( const wchar_t* p = szSearch; *p; ++p ) {
 		if( *p == L'.') {
@@ -329,21 +329,21 @@ wchar_t* CBregexp::MakePatternAlternate( const wchar_t* const szSearch, const wc
 	std::wstring strModifiedSearch;
 	strModifiedSearch.reserve( modifiedSearchSize );
 
-	// szSearch‚ğ strModifiedSearch‚ÖA‚Æ‚±‚ë‚Ç‚±‚ë’uŠ·‚µ‚È‚ª‚ç‡ŸƒRƒs[‚µ‚Ä‚¢‚­B
+	// szSearchã‚’ strModifiedSearchã¸ã€ã¨ã“ã‚ã©ã“ã‚ç½®æ›ã—ãªãŒã‚‰é †æ¬¡ã‚³ãƒ”ãƒ¼ã—ã¦ã„ãã€‚
 	enum State {
-		DEF = 0, /* DEFULT ˆê”ÔŠO‘¤ */
-		D_E,     /* DEFAULT_ESCAPED ˆê”ÔŠO‘¤‚Å \‚ÌŸ */
-		D_C,     /* DEFAULT_SMALL_C ˆê”ÔŠO‘¤‚Å \c‚ÌŸ */
-		CHA,     /* CHARSET •¶šƒNƒ‰ƒX‚Ì’† */
-		C_E,     /* CHARSET_ESCAPED •¶šƒNƒ‰ƒX‚Ì’†‚Å \‚ÌŸ */
-		C_C,     /* CHARSET_SMALL_C •¶šƒNƒ‰ƒX‚Ì’†‚Å \c‚ÌŸ */
-		QEE,     /* QEESCAPE \Q...\E‚Ì’† */
-		Q_E,     /* QEESCAPE_ESCAPED \Q...\E‚Ì’†‚Å \‚ÌŸ */
+		DEF = 0, /* DEFULT ä¸€ç•ªå¤–å´ */
+		D_E,     /* DEFAULT_ESCAPED ä¸€ç•ªå¤–å´ã§ \ã®æ¬¡ */
+		D_C,     /* DEFAULT_SMALL_C ä¸€ç•ªå¤–å´ã§ \cã®æ¬¡ */
+		CHA,     /* CHARSET æ–‡å­—ã‚¯ãƒ©ã‚¹ã®ä¸­ */
+		C_E,     /* CHARSET_ESCAPED æ–‡å­—ã‚¯ãƒ©ã‚¹ã®ä¸­ã§ \ã®æ¬¡ */
+		C_C,     /* CHARSET_SMALL_C æ–‡å­—ã‚¯ãƒ©ã‚¹ã®ä¸­ã§ \cã®æ¬¡ */
+		QEE,     /* QEESCAPE \Q...\Eã®ä¸­ */
+		Q_E,     /* QEESCAPE_ESCAPED \Q...\Eã®ä¸­ã§ \ã®æ¬¡ */
 		NUMBER_OF_STATE,
-		_EC = -1, /* ENTER CHARCLASS charsetLevel‚ğƒCƒ“ƒNƒŠƒƒ“ƒg‚µ‚Ä CHA‚Ö */
-		_XC = -2, /* EXIT CHARCLASS charsetLevel‚ğƒfƒNƒŠƒƒ“ƒg‚µ‚Ä CHA‚© DEF‚Ö */
-		_DT = -3, /* DOT (“Áê•¶š‚Æ‚µ‚Ä‚Ì)ƒhƒbƒg‚ğ’u‚«Š·‚¦‚é */
-		_DL = -4, /* DOLLAR (“Áê•¶š‚Æ‚µ‚Ä‚Ì)ƒhƒ‹‚ğ’u‚«Š·‚¦‚é */
+		_EC = -1, /* ENTER CHARCLASS charsetLevelã‚’ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ãƒˆã—ã¦ CHAã¸ */
+		_XC = -2, /* EXIT CHARCLASS charsetLevelã‚’ãƒ‡ã‚¯ãƒªãƒ¡ãƒ³ãƒˆã—ã¦ CHAã‹ DEFã¸ */
+		_DT = -3, /* DOT (ç‰¹æ®Šæ–‡å­—ã¨ã—ã¦ã®)ãƒ‰ãƒƒãƒˆã‚’ç½®ãæ›ãˆã‚‹ */
+		_DL = -4, /* DOLLAR (ç‰¹æ®Šæ–‡å­—ã¨ã—ã¦ã®)ãƒ‰ãƒ«ã‚’ç½®ãæ›ãˆã‚‹ */
 	};
 	enum CharClass {
 		OTHER = 0,
@@ -369,9 +369,9 @@ wchar_t* CBregexp::MakePatternAlternate( const wchar_t* const szSearch, const wc
 	/* Q_E */ {QEE,  QEE,   QEE,    QEE,   QEE,   DEF,   QEE,   QEE,   Q_E}
 	};
 	State state = DEF;
-	int charsetLevel = 0; // ƒuƒ‰ƒPƒbƒg‚Ì[‚³BPOSIXƒuƒ‰ƒPƒbƒg•\Œ»‚È‚ÇAƒGƒXƒP[ƒv‚³‚ê‚Ä‚¢‚È‚¢ [] ‚ª“ü‚êq‚É‚È‚é‚±‚Æ‚ª‚ ‚éB
+	int charsetLevel = 0; // ãƒ–ãƒ©ã‚±ãƒƒãƒˆã®æ·±ã•ã€‚POSIXãƒ–ãƒ©ã‚±ãƒƒãƒˆè¡¨ç¾ãªã©ã€ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã•ã‚Œã¦ã„ãªã„ [] ãŒå…¥ã‚Œå­ã«ãªã‚‹ã“ã¨ãŒã‚ã‚‹ã€‚
 	const wchar_t *left = szSearch, *right = szSearch;
-	for( ; *right; ++right ) { // CNativeW::GetSizeOfChar()‚Íg‚í‚È‚­‚Ä‚à‚¢‚¢‚©‚ÈH
+	for( ; *right; ++right ) { // CNativeW::GetSizeOfChar()ã¯ä½¿ã‚ãªãã¦ã‚‚ã„ã„ã‹ãªï¼Ÿ
 		const wchar_t ch = *right;
 		const CharClass charClass =
 			ch == L'.'  ? DOT:
@@ -405,39 +405,39 @@ wchar_t* CBregexp::MakePatternAlternate( const wchar_t* const szSearch, const wc
 				left = right + 1;
 				strModifiedSearch.append( szDollarAlternative );
 			break;
-			default: // ƒoƒOBenum State‚ÉŒ©“¦‚µ‚ª‚ ‚éB
+			default: // ãƒã‚°ã€‚enum Stateã«è¦‹é€ƒã—ãŒã‚ã‚‹ã€‚
 			break;
 		}
 	}
-	strModifiedSearch.append( left, right + 1 ); // right + 1 ‚Í '\0' ‚ÌŸ‚ğw‚·(–¾¦“I‚É '\0' ‚ğƒRƒs[)B
+	strModifiedSearch.append( left, right + 1 ); // right + 1 ã¯ '\0' ã®æ¬¡ã‚’æŒ‡ã™(æ˜ç¤ºçš„ã« '\0' ã‚’ã‚³ãƒ”ãƒ¼)ã€‚
 
 	return this->MakePatternSub( strModifiedSearch.data(), szReplace, L"", nOption );
 }
 
 
 /*!
-	JRE32‚ÌƒGƒ~ƒ…ƒŒ[ƒVƒ‡ƒ“ŠÖ”D‹ó‚Ì•¶š—ñ‚É‘Î‚µ‚ÄŒŸõE’uŠ·‚ğs‚¤‚±‚Æ‚É‚æ‚è
-	BREGEXP_W\‘¢‘Ì‚Ì¶¬‚Ì‚İ‚ğs‚¤D
+	JRE32ã®ã‚¨ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³é–¢æ•°ï¼ç©ºã®æ–‡å­—åˆ—ã«å¯¾ã—ã¦æ¤œç´¢ãƒ»ç½®æ›ã‚’è¡Œã†ã“ã¨ã«ã‚ˆã‚Š
+	BREGEXP_Wæ§‹é€ ä½“ã®ç”Ÿæˆã®ã¿ã‚’è¡Œã†ï¼
 
-	@param[in] szPattern0	ŒŸõor’uŠ·ƒpƒ^[ƒ“
-	@param[in] szPattern1	’uŠ·Œã•¶š—ñƒpƒ^[ƒ“(ŒŸõ‚ÍNULL)
-	@param[in] nOption		ŒŸõE’uŠ·ƒIƒvƒVƒ‡ƒ“
+	@param[in] szPattern0	æ¤œç´¢orç½®æ›ãƒ‘ã‚¿ãƒ¼ãƒ³
+	@param[in] szPattern1	ç½®æ›å¾Œæ–‡å­—åˆ—ãƒ‘ã‚¿ãƒ¼ãƒ³(æ¤œç´¢æ™‚ã¯NULL)
+	@param[in] nOption		æ¤œç´¢ãƒ»ç½®æ›ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 
-	@retval true ¬Œ÷
-	@retval false ¸”s
+	@retval true æˆåŠŸ
+	@retval false å¤±æ•—
 */
 bool CBregexp::Compile( const wchar_t *szPattern0, const wchar_t *szPattern1, int nOption, bool bKakomi )
 {
 
-	//	DLL‚ª—˜—p‰Â”\‚Å‚È‚¢‚Æ‚«‚ÍƒGƒ‰[I—¹
+	//	DLLãŒåˆ©ç”¨å¯èƒ½ã§ãªã„ã¨ãã¯ã‚¨ãƒ©ãƒ¼çµ‚äº†
 	if( !IsAvailable() )
 		return false;
 
-	//	BREGEXP_W\‘¢‘Ì‚Ì‰ğ•ú
+	//	BREGEXP_Wæ§‹é€ ä½“ã®è§£æ”¾
 	ReleaseCompileBuffer();
 
-	// ƒ‰ƒCƒuƒ‰ƒŠ‚É“n‚·ŒŸõƒpƒ^[ƒ“‚ğì¬
-	// •ÊŠÖ”‚Å‹¤’Êˆ—‚É•ÏX 2003.05.03 by ‚©‚ë‚Æ
+	// ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã«æ¸¡ã™æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã‚’ä½œæˆ
+	// åˆ¥é–¢æ•°ã§å…±é€šå‡¦ç†ã«å¤‰æ›´ 2003.05.03 by ã‹ã‚ã¨
 	wchar_t *szNPattern = NULL;
 	const wchar_t *pszNPattern = NULL;
 	if( bKakomi ){
@@ -446,74 +446,74 @@ bool CBregexp::Compile( const wchar_t *szPattern0, const wchar_t *szPattern1, in
 		szNPattern = MakePatternAlternate( szPattern0, szPattern1, nOption );
 		pszNPattern = szNPattern;
 	}
-	m_szMsg[0] = L'\0';		//!< ƒGƒ‰[‰ğœ
+	m_szMsg[0] = L'\0';		//!< ã‚¨ãƒ©ãƒ¼è§£é™¤
 	if (szPattern1 == NULL) {
-		// ŒŸõÀs
+		// æ¤œç´¢å®Ÿè¡Œ
 		BMatch( pszNPattern, m_tmpBuf, m_tmpBuf+1, &m_pRegExp, m_szMsg );
 	} else {
-		// ’uŠ·Às
+		// ç½®æ›å®Ÿè¡Œ
 		BSubst( pszNPattern, m_tmpBuf, m_tmpBuf+1, &m_pRegExp, m_szMsg );
 	}
 	delete [] szNPattern;
 
-	//	ƒƒbƒZ[ƒW‚ª‹ó•¶š—ñ‚Å‚È‚¯‚ê‚Î‰½‚ç‚©‚ÌƒGƒ‰[”­¶B
-	//	ƒTƒ“ƒvƒ‹ƒ\[ƒXQÆ
+	//	ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãŒç©ºæ–‡å­—åˆ—ã§ãªã‘ã‚Œã°ä½•ã‚‰ã‹ã®ã‚¨ãƒ©ãƒ¼ç™ºç”Ÿã€‚
+	//	ã‚µãƒ³ãƒ—ãƒ«ã‚½ãƒ¼ã‚¹å‚ç…§
 	if( m_szMsg[0] ){
 		ReleaseCompileBuffer();
 		return false;
 	}
 	
-	// s“ªğŒƒ`ƒFƒbƒN‚ÍAMakePattern‚Éæ‚è‚İ 2003.05.03 by ‚©‚ë‚Æ
+	// è¡Œé ­æ¡ä»¶ãƒã‚§ãƒƒã‚¯ã¯ã€MakePatternã«å–ã‚Šè¾¼ã¿ 2003.05.03 by ã‹ã‚ã¨
 
 	return true;
 }
 
 /*!
-	JRE32‚ÌƒGƒ~ƒ…ƒŒ[ƒVƒ‡ƒ“ŠÖ”DŠù‚É‚ ‚éƒRƒ“ƒpƒCƒ‹\‘¢‘Ì‚ğ—˜—p‚µ‚ÄŒŸõi1sj‚ğ
-	s‚¤D
+	JRE32ã®ã‚¨ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³é–¢æ•°ï¼æ—¢ã«ã‚ã‚‹ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«æ§‹é€ ä½“ã‚’åˆ©ç”¨ã—ã¦æ¤œç´¢ï¼ˆ1è¡Œï¼‰ã‚’
+	è¡Œã†ï¼
 
-	@param[in] target ŒŸõ‘ÎÛ—Ìˆææ“ªƒAƒhƒŒƒX
-	@param[in] len ŒŸõ‘ÎÛ—ÌˆæƒTƒCƒY
-	@param[in] nStart ŒŸõŠJnˆÊ’uD(æ“ª‚Í0)
+	@param[in] target æ¤œç´¢å¯¾è±¡é ˜åŸŸå…ˆé ­ã‚¢ãƒ‰ãƒ¬ã‚¹
+	@param[in] len æ¤œç´¢å¯¾è±¡é ˜åŸŸã‚µã‚¤ã‚º
+	@param[in] nStart æ¤œç´¢é–‹å§‹ä½ç½®ï¼(å…ˆé ­ã¯0)
 
 	@retval true Match
-	@retval false No Match ‚Ü‚½‚Í ƒGƒ‰[BƒGƒ‰[‚Í GetLastMessage()‚É‚æ‚è”»’è‰Â”\B
+	@retval false No Match ã¾ãŸã¯ ã‚¨ãƒ©ãƒ¼ã€‚ã‚¨ãƒ©ãƒ¼ã¯ GetLastMessage()ã«ã‚ˆã‚Šåˆ¤å®šå¯èƒ½ã€‚
 
 */
 bool CBregexp::Match( const wchar_t* target, int len, int nStart )
 {
-	int matched;		//!< ŒŸõˆê’v‚µ‚½‚©? >0:Match, 0:NoMatch, <0:Error
+	int matched;		//!< æ¤œç´¢ä¸€è‡´ã—ãŸã‹? >0:Match, 0:NoMatch, <0:Error
 
-	//	DLL‚ª—˜—p‰Â”\‚Å‚È‚¢‚Æ‚«A‚Ü‚½‚Í\‘¢‘Ì‚ª–¢İ’è‚Ì‚ÍƒGƒ‰[I—¹
+	//	DLLãŒåˆ©ç”¨å¯èƒ½ã§ãªã„ã¨ãã€ã¾ãŸã¯æ§‹é€ ä½“ãŒæœªè¨­å®šã®æ™‚ã¯ã‚¨ãƒ©ãƒ¼çµ‚äº†
 	if( (!IsAvailable()) || m_pRegExp == NULL ){
 		return false;
 	}
 
-	m_szMsg[0] = '\0';		//!< ƒGƒ‰[‰ğœ
-	// Šg’£ŠÖ”‚ª‚È‚¢ê‡‚ÍAs‚Ìæ“ª("^")‚ÌŒŸõ‚Ì“Á•Êˆ— by ‚©‚ë‚Æ
+	m_szMsg[0] = '\0';		//!< ã‚¨ãƒ©ãƒ¼è§£é™¤
+	// æ‹¡å¼µé–¢æ•°ãŒãªã„å ´åˆã¯ã€è¡Œã®å…ˆé ­("^")ã®æ¤œç´¢æ™‚ã®ç‰¹åˆ¥å‡¦ç† by ã‹ã‚ã¨
 	if (!ExistBMatchEx()) {
 		/*
-		** s“ª(^)‚Æƒ}ƒbƒ`‚·‚é‚Ì‚ÍAnStart=0‚Ì‚¾‚¯‚È‚Ì‚ÅA‚»‚êˆÈŠO‚Í false
+		** è¡Œé ­(^)ã¨ãƒãƒƒãƒã™ã‚‹ã®ã¯ã€nStart=0ã®æ™‚ã ã‘ãªã®ã§ã€ãã‚Œä»¥å¤–ã¯ false
 		*/
 		if( (m_ePatType & PAT_TOP) != 0 && nStart != 0 ) {
-			// nStart!=0‚Å‚àABMatch()‚É‚Æ‚Á‚Ä‚Ís“ª‚É‚È‚é‚Ì‚ÅA‚±‚±‚Åfalse‚É‚·‚é•K—v‚ª‚ ‚é
+			// nStart!=0ã§ã‚‚ã€BMatch()ã«ã¨ã£ã¦ã¯è¡Œé ­ã«ãªã‚‹ã®ã§ã€ã“ã“ã§falseã«ã™ã‚‹å¿…è¦ãŒã‚ã‚‹
 			return false;
 		}
-		//	ŒŸõ•¶š—ñNULL‚ğw’è‚·‚é‚Æ‘O‰ñ‚Æ“¯ˆê‚Ì•¶š—ñ‚ÆŒ©‚È‚³‚ê‚é
+		//	æ¤œç´¢æ–‡å­—åˆ—ï¼NULLã‚’æŒ‡å®šã™ã‚‹ã¨å‰å›ã¨åŒä¸€ã®æ–‡å­—åˆ—ã¨è¦‹ãªã•ã‚Œã‚‹
 		matched = BMatch( NULL, target + nStart, target + len, &m_pRegExp, m_szMsg );
 	} else {
-		//	ŒŸõ•¶š—ñNULL‚ğw’è‚·‚é‚Æ‘O‰ñ‚Æ“¯ˆê‚Ì•¶š—ñ‚ÆŒ©‚È‚³‚ê‚é
+		//	æ¤œç´¢æ–‡å­—åˆ—ï¼NULLã‚’æŒ‡å®šã™ã‚‹ã¨å‰å›ã¨åŒä¸€ã®æ–‡å­—åˆ—ã¨è¦‹ãªã•ã‚Œã‚‹
 		matched = BMatchEx( NULL, target, target + nStart, target + len, &m_pRegExp, m_szMsg );
 	}
 	m_szTarget = target;
 			
 	if ( matched < 0 || m_szMsg[0] ) {
-		// BMatchƒGƒ‰[
-		// ƒGƒ‰[ˆ—‚ğ‚µ‚Ä‚¢‚È‚©‚Á‚½‚Ì‚ÅAnStart>=len‚Ì‚æ‚¤‚Èê‡‚ÉAƒ}ƒbƒ`ˆµ‚¢‚É‚È‚è
-		// –³ŒÀ’uŠ·“™‚Ì•s‹ï‡‚É‚È‚Á‚Ä‚¢‚½ 2003.05.03 by ‚©‚ë‚Æ
+		// BMatchã‚¨ãƒ©ãƒ¼
+		// ã‚¨ãƒ©ãƒ¼å‡¦ç†ã‚’ã—ã¦ã„ãªã‹ã£ãŸã®ã§ã€nStart>=lenã®ã‚ˆã†ãªå ´åˆã«ã€ãƒãƒƒãƒæ‰±ã„ã«ãªã‚Š
+		// ç„¡é™ç½®æ›ç­‰ã®ä¸å…·åˆã«ãªã£ã¦ã„ãŸ 2003.05.03 by ã‹ã‚ã¨
 		return false;
 	} else if ( matched == 0 ) {
-		// ˆê’v‚µ‚È‚©‚Á‚½
+		// ä¸€è‡´ã—ãªã‹ã£ãŸ
 		return false;
 	}
 
@@ -523,41 +523,41 @@ bool CBregexp::Match( const wchar_t* target, int len, int nStart )
 
 //<< 2002/03/27 Azumaiya
 /*!
-	³‹K•\Œ»‚É‚æ‚é•¶š—ñ’uŠ·
-	Šù‚É‚ ‚éƒRƒ“ƒpƒCƒ‹\‘¢‘Ì‚ğ—˜—p‚µ‚Ä’uŠ·i1sj‚ğ
-	s‚¤D
+	æ­£è¦è¡¨ç¾ã«ã‚ˆã‚‹æ–‡å­—åˆ—ç½®æ›
+	æ—¢ã«ã‚ã‚‹ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«æ§‹é€ ä½“ã‚’åˆ©ç”¨ã—ã¦ç½®æ›ï¼ˆ1è¡Œï¼‰ã‚’
+	è¡Œã†ï¼
 
-	@param[in] szTarget ’uŠ·‘ÎÛƒf[ƒ^
-	@param[in] nLen ’uŠ·‘ÎÛƒf[ƒ^’·
-	@param[in] nStart ’uŠ·ŠJnˆÊ’u(0‚©‚çnLen–¢–)
+	@param[in] szTarget ç½®æ›å¯¾è±¡ãƒ‡ãƒ¼ã‚¿
+	@param[in] nLen ç½®æ›å¯¾è±¡ãƒ‡ãƒ¼ã‚¿é•·
+	@param[in] nStart ç½®æ›é–‹å§‹ä½ç½®(0ã‹ã‚‰nLenæœªæº€)
 
-	@retval ’uŠ·ŒÂ”
+	@retval ç½®æ›å€‹æ•°
 
-	@date	2007.01.16 ryoji –ß‚è’l‚ğ’uŠ·ŒÂ”‚É•ÏX
+	@date	2007.01.16 ryoji æˆ»ã‚Šå€¤ã‚’ç½®æ›å€‹æ•°ã«å¤‰æ›´
 */
 int CBregexp::Replace(const wchar_t *szTarget, int nLen, int nStart)
 {
 	int result;
-	//	DLL‚ª—˜—p‰Â”\‚Å‚È‚¢‚Æ‚«A‚Ü‚½‚Í\‘¢‘Ì‚ª–¢İ’è‚Ì‚ÍƒGƒ‰[I—¹
+	//	DLLãŒåˆ©ç”¨å¯èƒ½ã§ãªã„ã¨ãã€ã¾ãŸã¯æ§‹é€ ä½“ãŒæœªè¨­å®šã®æ™‚ã¯ã‚¨ãƒ©ãƒ¼çµ‚äº†
 	if( !IsAvailable() || m_pRegExp == NULL )
 	{
 		return false;
 	}
 
-	//	From Here 2003.05.03 ‚©‚ë‚Æ
-	// nLen‚ª‚O‚¾‚ÆABSubst()‚ª’uŠ·‚É¸”s‚µ‚Ä‚µ‚Ü‚¤‚Ì‚ÅA‘ã—pƒf[ƒ^(m_tmpBuf)‚ğg‚¤
+	//	From Here 2003.05.03 ã‹ã‚ã¨
+	// nLenãŒï¼ã ã¨ã€BSubst()ãŒç½®æ›ã«å¤±æ•—ã—ã¦ã—ã¾ã†ã®ã§ã€ä»£ç”¨ãƒ‡ãƒ¼ã‚¿(m_tmpBuf)ã‚’ä½¿ã†
 	//
-	// 2007.01.19 ryoji ‘ã—pƒf[ƒ^g—p‚ğƒRƒƒ“ƒgƒAƒEƒg
-	// g—p‚·‚é‚ÆŒ»ó‚Å‚ÍŒ‹‰Ê‚É‚PƒoƒCƒg—]•ª‚ÈƒSƒ~‚ª•t‰Á‚³‚ê‚é
-	// ’uŠ·‚É¸”s‚·‚é‚Ì‚ÍnLen‚ª‚O‚ÉŒÀ‚ç‚¸ nLen = nStart ‚Ì‚Æ‚«is“ªƒ}ƒbƒ`‚¾‚¯‘Îô‚µ‚Ä‚àDDDj
+	// 2007.01.19 ryoji ä»£ç”¨ãƒ‡ãƒ¼ã‚¿ä½¿ç”¨ã‚’ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆ
+	// ä½¿ç”¨ã™ã‚‹ã¨ç¾çŠ¶ã§ã¯çµæœã«ï¼‘ãƒã‚¤ãƒˆä½™åˆ†ãªã‚´ãƒŸãŒä»˜åŠ ã•ã‚Œã‚‹
+	// ç½®æ›ã«å¤±æ•—ã™ã‚‹ã®ã¯nLenãŒï¼ã«é™ã‚‰ãš nLen = nStart ã®ã¨ãï¼ˆè¡Œé ­ãƒãƒƒãƒã ã‘å¯¾ç­–ã—ã¦ã‚‚ï¼ï¼ï¼ï¼‰
 	//
 	//if( nLen == 0 ) {
 	//	szTarget = m_tmpBuf;
 	//	nLen = 1;
 	//}
-	//	To Here 2003.05.03 ‚©‚ë‚Æ
+	//	To Here 2003.05.03 ã‹ã‚ã¨
 
-	m_szMsg[0] = '\0';		//!< ƒGƒ‰[‰ğœ
+	m_szMsg[0] = '\0';		//!< ã‚¨ãƒ©ãƒ¼è§£é™¤
 	if (!ExistBSubstEx()) {
 		result = BSubst( NULL, szTarget + nStart, szTarget + nLen, &m_pRegExp, m_szMsg );
 	} else {
@@ -565,14 +565,14 @@ int CBregexp::Replace(const wchar_t *szTarget, int nLen, int nStart)
 	}
 	m_szTarget = szTarget;
 
-	//	ƒƒbƒZ[ƒW‚ª‹ó•¶š—ñ‚Å‚È‚¯‚ê‚Î‰½‚ç‚©‚ÌƒGƒ‰[”­¶B
-	//	ƒTƒ“ƒvƒ‹ƒ\[ƒXQÆ
+	//	ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãŒç©ºæ–‡å­—åˆ—ã§ãªã‘ã‚Œã°ä½•ã‚‰ã‹ã®ã‚¨ãƒ©ãƒ¼ç™ºç”Ÿã€‚
+	//	ã‚µãƒ³ãƒ—ãƒ«ã‚½ãƒ¼ã‚¹å‚ç…§
 	if( m_szMsg[0] ) {
 		return 0;
 	}
 
 	if( result < 0 ) {
-		// ’uŠ·‚·‚é‚à‚Ì‚ª‚È‚©‚Á‚½
+		// ç½®æ›ã™ã‚‹ã‚‚ã®ãŒãªã‹ã£ãŸ
 		return 0;
 	}
 	return result;
@@ -598,18 +598,18 @@ const TCHAR* CBregexp::GetLastMessage() const
 
 //	From Here Jun. 26, 2001 genta
 /*!
-	—^‚¦‚ç‚ê‚½³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì‰Šú‰»‚ğs‚¤D
-	ƒƒbƒZ[ƒWƒtƒ‰ƒO‚ªON‚Å‰Šú‰»‚É¸”s‚µ‚½‚Æ‚«‚ÍƒƒbƒZ[ƒW‚ğ•\¦‚·‚éD
+	ä¸ãˆã‚‰ã‚ŒãŸæ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®åˆæœŸåŒ–ã‚’è¡Œã†ï¼
+	ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒ•ãƒ©ã‚°ãŒONã§åˆæœŸåŒ–ã«å¤±æ•—ã—ãŸã¨ãã¯ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤ºã™ã‚‹ï¼
 
-	@retval true ‰Šú‰»¬Œ÷
-	@retval false ‰Šú‰»‚É¸”s
+	@retval true åˆæœŸåŒ–æˆåŠŸ
+	@retval false åˆæœŸåŒ–ã«å¤±æ•—
 
-	@date 2007.08.12 genta ‹¤’Êİ’è‚©‚çDLL–¼‚ğæ“¾‚·‚é
+	@date 2007.08.12 genta å…±é€šè¨­å®šã‹ã‚‰DLLåã‚’å–å¾—ã™ã‚‹
 */
 bool InitRegexp(
-	HWND		hWnd,			//!< [in] ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹Bƒo[ƒWƒ‡ƒ“”Ô†‚Ìİ’è‚ª•s—v‚Å‚ ‚ê‚ÎNULLB
-	CBregexp&	rRegexp,		//!< [in] ƒ`ƒFƒbƒN‚É—˜—p‚·‚éCBregexpƒNƒ‰ƒX‚Ö‚ÌQÆ
-	bool		bShowMessage	//!< [in] ‰Šú‰»¸”s‚ÉƒGƒ‰[ƒƒbƒZ[ƒW‚ğo‚·ƒtƒ‰ƒO
+	HWND		hWnd,			//!< [in] ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«ã€‚ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã®è¨­å®šãŒä¸è¦ã§ã‚ã‚Œã°NULLã€‚
+	CBregexp&	rRegexp,		//!< [in] ãƒã‚§ãƒƒã‚¯ã«åˆ©ç”¨ã™ã‚‹CBregexpã‚¯ãƒ©ã‚¹ã¸ã®å‚ç…§
+	bool		bShowMessage	//!< [in] åˆæœŸåŒ–å¤±æ•—æ™‚ã«ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å‡ºã™ãƒ•ãƒ©ã‚°
 )
 {
 	//	From Here 2007.08.12 genta
@@ -640,16 +640,16 @@ bool InitRegexp(
 }
 
 /*!
-	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì‘¶İ‚ğŠm”F‚µA‚ ‚ê‚Îƒo[ƒWƒ‡ƒ“î•ñ‚ğw’èƒRƒ“ƒ|[ƒlƒ“ƒg‚ÉƒZƒbƒg‚·‚éB
-	¸”s‚µ‚½ê‡‚É‚Í‹ó•¶š—ñ‚ğƒZƒbƒg‚·‚éB
+	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å­˜åœ¨ã‚’ç¢ºèªã—ã€ã‚ã‚Œã°ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±ã‚’æŒ‡å®šã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã«ã‚»ãƒƒãƒˆã™ã‚‹ã€‚
+	å¤±æ•—ã—ãŸå ´åˆã«ã¯ç©ºæ–‡å­—åˆ—ã‚’ã‚»ãƒƒãƒˆã™ã‚‹ã€‚
 
-	@retval true ƒo[ƒWƒ‡ƒ“”Ô†‚Ìİ’è‚É¬Œ÷
-	@retval false ³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì‰Šú‰»‚É¸”s
+	@retval true ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã®è¨­å®šã«æˆåŠŸ
+	@retval false æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®åˆæœŸåŒ–ã«å¤±æ•—
 */
 bool CheckRegexpVersion(
-	HWND	hWnd,			//!< [in] ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹Bƒo[ƒWƒ‡ƒ“”Ô†‚Ìİ’è‚ª•s—v‚Å‚ ‚ê‚ÎNULLB
-	int		nCmpId,			//!< [in] ƒo[ƒWƒ‡ƒ“•¶š—ñ‚ğİ’è‚·‚éƒRƒ“ƒ|[ƒlƒ“ƒgID
-	bool	bShowMessage	//!< [in] ‰Šú‰»¸”s‚ÉƒGƒ‰[ƒƒbƒZ[ƒW‚ğo‚·ƒtƒ‰ƒO
+	HWND	hWnd,			//!< [in] ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«ã€‚ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã®è¨­å®šãŒä¸è¦ã§ã‚ã‚Œã°NULLã€‚
+	int		nCmpId,			//!< [in] ãƒãƒ¼ã‚¸ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è¨­å®šã™ã‚‹ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆID
+	bool	bShowMessage	//!< [in] åˆæœŸåŒ–å¤±æ•—æ™‚ã«ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å‡ºã™ãƒ•ãƒ©ã‚°
 )
 {
 	CBregexp cRegexp;
@@ -667,15 +667,15 @@ bool CheckRegexpVersion(
 }
 
 /*!
-	³‹K•\Œ»‚ª‹K‘¥‚É]‚Á‚Ä‚¢‚é‚©‚ğƒ`ƒFƒbƒN‚·‚éB
+	æ­£è¦è¡¨ç¾ãŒè¦å‰‡ã«å¾“ã£ã¦ã„ã‚‹ã‹ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹ã€‚
 
-	@param szPattern [in] ƒ`ƒFƒbƒN‚·‚é³‹K•\Œ»
-	@param hWnd [in] ƒƒbƒZ[ƒWƒ{ƒbƒNƒX‚ÌeƒEƒBƒ“ƒhƒE
-	@param bShowMessage [in] ‰Šú‰»¸”s‚ÉƒGƒ‰[ƒƒbƒZ[ƒW‚ğo‚·ƒtƒ‰ƒO
-	@param nOption [in] ‘å•¶š‚Æ¬•¶š‚ğ–³‹‚µ‚Ä”äŠr‚·‚éƒtƒ‰ƒO // 2002/2/1 hor’Ç‰Á
+	@param szPattern [in] ãƒã‚§ãƒƒã‚¯ã™ã‚‹æ­£è¦è¡¨ç¾
+	@param hWnd [in] ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã®è¦ªã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	@param bShowMessage [in] åˆæœŸåŒ–å¤±æ•—æ™‚ã«ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å‡ºã™ãƒ•ãƒ©ã‚°
+	@param nOption [in] å¤§æ–‡å­—ã¨å°æ–‡å­—ã‚’ç„¡è¦–ã—ã¦æ¯”è¼ƒã™ã‚‹ãƒ•ãƒ©ã‚° // 2002/2/1 horè¿½åŠ 
 
-	@retval true ³‹K•\Œ»‚Í‹K‘¥’Ê‚è
-	@retval false •¶–@‚ÉŒë‚è‚ª‚ ‚éB‚Ü‚½‚ÍAƒ‰ƒCƒuƒ‰ƒŠ‚ªg—p‚Å‚«‚È‚¢B
+	@retval true æ­£è¦è¡¨ç¾ã¯è¦å‰‡é€šã‚Š
+	@retval false æ–‡æ³•ã«èª¤ã‚ŠãŒã‚ã‚‹ã€‚ã¾ãŸã¯ã€ãƒ©ã‚¤ãƒ–ãƒ©ãƒªãŒä½¿ç”¨ã§ããªã„ã€‚
 */
 bool CheckRegexpSyntax(
 	const wchar_t*	szPattern,
@@ -693,7 +693,7 @@ bool CheckRegexpSyntax(
 	if( nOption == -1 ){
 		nOption = CBregexp::optCaseSensitive;
 	}
-	if( !cRegexp.Compile( szPattern, NULL, nOption, bKakomi ) ){	// 2002/2/1 hor’Ç‰Á
+	if( !cRegexp.Compile( szPattern, NULL, nOption, bKakomi ) ){	// 2002/2/1 horè¿½åŠ 
 		if( bShowMessage ){
 			::MessageBox( hWnd, cRegexp.GetLastMessage(),
 				LS(STR_BREGONIG_TITLE), MB_OK | MB_ICONEXCLAMATION );

--- a/sakura_core/extmodule/CBregexp.h
+++ b/sakura_core/extmodule/CBregexp.h
@@ -1,21 +1,21 @@
-/*!	@file
+ï»¿/*!	@file
 	@brief BREGEXP Library Handler
 
-	Perl5ŒİŠ·³‹K•\Œ»‚ğˆµ‚¤DLL‚Å‚ ‚éBREGEXP.DLL‚ğ—˜—p‚·‚é‚½‚ß‚ÌƒCƒ“ƒ^[ƒtƒF[ƒX
+	Perl5äº’æ›æ­£è¦è¡¨ç¾ã‚’æ‰±ã†DLLã§ã‚ã‚‹BREGEXP.DLLã‚’åˆ©ç”¨ã™ã‚‹ãŸã‚ã®ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 
 	@author genta
 	@date Jun. 10, 2001
-	@date Jan. 05, 2002 genta ƒRƒƒ“ƒg’Ç‰Á
+	@date Jan. 05, 2002 genta ã‚³ãƒ¡ãƒ³ãƒˆè¿½åŠ 
 	@date 2002/2/1 hor
-	@date Jul. 25, 2002 genta s“ªğŒ‚Ìl—¶‚ğ’Ç‰Á
+	@date Jul. 25, 2002 genta è¡Œé ­æ¡ä»¶ã®è€ƒæ…®ã‚’è¿½åŠ 
 */
 /*
 	Copyright (C) 2001-2002, genta
 	Copyright (C) 2001, novice, hor
 	Copyright (C) 2002, novice, hor, Azumaiya
-	Copyright (C) 2003, ‚©‚ë‚Æ
-	Copyright (C) 2005, ‚©‚ë‚Æ, aroka
-	Copyright (C) 2006, ‚©‚ë‚Æ
+	Copyright (C) 2003, ã‹ã‚ã¨
+	Copyright (C) 2005, ã‹ã‚ã¨, aroka
+	Copyright (C) 2006, ã‹ã‚ã¨
 	Copyright (C) 2007, ryoji
 
 	This software is provided 'as-is', without any express or implied
@@ -45,107 +45,107 @@
 #include "CBregexpDll2.h"
 
 /*!
-	@brief PerlŒİŠ·³‹K•\Œ» BREGEXP.DLL ‚ğƒTƒ|[ƒg‚·‚éƒNƒ‰ƒX
+	@brief Perläº’æ›æ­£è¦è¡¨ç¾ BREGEXP.DLL ã‚’ã‚µãƒãƒ¼ãƒˆã™ã‚‹ã‚¯ãƒ©ã‚¹
 
-	DLL‚Ì“®“Iƒ[ƒh‚ğs‚¤‚½‚ßADllHandler‚ğŒp³‚µ‚Ä‚¢‚éB
+	DLLã®å‹•çš„ãƒ­ãƒ¼ãƒ‰ã‚’è¡Œã†ãŸã‚ã€DllHandlerã‚’ç¶™æ‰¿ã—ã¦ã„ã‚‹ã€‚
 
-	CJre‚É‹ß‚¢“®ì‚ğ‚³‚¹‚é‚½‚ßAƒoƒbƒtƒ@‚ğƒNƒ‰ƒX“à‚É1‚Â•Û‚µA
-	ƒf[ƒ^‚Ìİ’è‚ÆŒŸõ‚Ì‚Q‚Â‚ÌƒXƒeƒbƒv‚É•ªŠ„‚·‚é‚æ‚¤‚É‚µ‚Ä‚¢‚éB
-	JreƒGƒ~ƒ…ƒŒ[ƒVƒ‡ƒ“ŠÖ”‚ğg‚¤‚Æ‚«‚Í“ü‚êq‚É‚È‚ç‚È‚¢‚æ‚¤‚É’ˆÓ‚·‚é‚±‚ÆB
+	CJreã«è¿‘ã„å‹•ä½œã‚’ã•ã›ã‚‹ãŸã‚ã€ãƒãƒƒãƒ•ã‚¡ã‚’ã‚¯ãƒ©ã‚¹å†…ã«1ã¤ä¿æŒã—ã€
+	ãƒ‡ãƒ¼ã‚¿ã®è¨­å®šã¨æ¤œç´¢ã®ï¼’ã¤ã®ã‚¹ãƒ†ãƒƒãƒ—ã«åˆ†å‰²ã™ã‚‹ã‚ˆã†ã«ã—ã¦ã„ã‚‹ã€‚
+	Jreã‚¨ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³é–¢æ•°ã‚’ä½¿ã†ã¨ãã¯å…¥ã‚Œå­ã«ãªã‚‰ãªã„ã‚ˆã†ã«æ³¨æ„ã™ã‚‹ã“ã¨ã€‚
 
-	–{—ˆ‚Í‚±‚Ì‚æ‚¤‚È•”•ª‚Í•ÊƒNƒ‰ƒX‚Æ‚µ‚Ä•ª—£‚·‚×‚«‚¾‚ªA‚»‚Ìê‡‚±‚ÌƒNƒ‰ƒX‚ª
-	”jŠü‚³‚ê‚é‘O‚É‘S‚Ä‚ÌƒNƒ‰ƒX‚ğ”jŠü‚·‚é•K—v‚ª‚ ‚éB
-	‚»‚ÌˆÀ‘S«‚ğ•ÛØ‚·‚é‚Ì‚ª“ï‚µ‚¢‚½‚ßAŒ»“_‚Å‚Í—¼Ò‚ğ‚P‚Â‚ÌƒNƒ‰ƒX‚É“ü‚ê‚½B
+	æœ¬æ¥ã¯ã“ã®ã‚ˆã†ãªéƒ¨åˆ†ã¯åˆ¥ã‚¯ãƒ©ã‚¹ã¨ã—ã¦åˆ†é›¢ã™ã¹ãã ãŒã€ãã®å ´åˆã“ã®ã‚¯ãƒ©ã‚¹ãŒ
+	ç ´æ£„ã•ã‚Œã‚‹å‰ã«å…¨ã¦ã®ã‚¯ãƒ©ã‚¹ã‚’ç ´æ£„ã™ã‚‹å¿…è¦ãŒã‚ã‚‹ã€‚
+	ãã®å®‰å…¨æ€§ã‚’ä¿è¨¼ã™ã‚‹ã®ãŒé›£ã—ã„ãŸã‚ã€ç¾æ™‚ç‚¹ã§ã¯ä¸¡è€…ã‚’ï¼‘ã¤ã®ã‚¯ãƒ©ã‚¹ã«å…¥ã‚ŒãŸã€‚
 
-	@note ‚±‚ÌƒNƒ‰ƒX‚ÍThread Safe‚Å‚Í‚È‚¢B
+	@note ã“ã®ã‚¯ãƒ©ã‚¹ã¯Thread Safeã§ã¯ãªã„ã€‚
 
-	@date 2005.03.19 ‚©‚ë‚Æ ƒŠƒtƒ@ƒNƒ^ƒŠƒ“ƒOBƒNƒ‰ƒX“à•”‚ğ‰B•Á
-	@date 2006.01.22 ‚©‚ë‚Æ ƒIƒvƒVƒ‡ƒ“’Ç‰ÁE–¼Ì•ÏX(‘S‚Äs’uŠ·—pGlobalƒIƒvƒVƒ‡ƒ“’Ç‰Á‚Ì‚½‚ß)
+	@date 2005.03.19 ã‹ã‚ã¨ ãƒªãƒ•ã‚¡ã‚¯ã‚¿ãƒªãƒ³ã‚°ã€‚ã‚¯ãƒ©ã‚¹å†…éƒ¨ã‚’éš è”½
+	@date 2006.01.22 ã‹ã‚ã¨ ã‚ªãƒ—ã‚·ãƒ§ãƒ³è¿½åŠ ãƒ»åç§°å¤‰æ›´(å…¨ã¦è¡Œç½®æ›ç”¨Globalã‚ªãƒ—ã‚·ãƒ§ãƒ³è¿½åŠ ã®ãŸã‚)
 */
 class CBregexp : public CBregexpDll2{
 public:
 	CBregexp();
 	virtual ~CBregexp();
 
-	// 2006.01.22 ‚©‚ë‚Æ ƒIƒvƒVƒ‡ƒ“’Ç‰ÁE–¼Ì•ÏX
+	// 2006.01.22 ã‹ã‚ã¨ ã‚ªãƒ—ã‚·ãƒ§ãƒ³è¿½åŠ ãƒ»åç§°å¤‰æ›´
 	enum Option {
-		optNothing = 0,					//!< ƒIƒvƒVƒ‡ƒ“‚È‚µ
-		optCaseSensitive = 1,			//!< ‘å•¶š¬•¶š‹æ•ÊƒIƒvƒVƒ‡ƒ“(/i‚ğ‚Â‚¯‚È‚¢)
-		optGlobal = 2,					//!< ‘SˆæƒIƒvƒVƒ‡ƒ“(/g)
-		optExtend = 4,					//!< Šg’£³‹K•\Œ»(/x)
+		optNothing = 0,					//!< ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãªã—
+		optCaseSensitive = 1,			//!< å¤§æ–‡å­—å°æ–‡å­—åŒºåˆ¥ã‚ªãƒ—ã‚·ãƒ§ãƒ³(/iã‚’ã¤ã‘ãªã„)
+		optGlobal = 2,					//!< å…¨åŸŸã‚ªãƒ—ã‚·ãƒ§ãƒ³(/g)
+		optExtend = 4,					//!< æ‹¡å¼µæ­£è¦è¡¨ç¾(/x)
 		optASCII = 8,					//!< ASCII(/a)
 		optUnicode = 0x10,				//!< Unicode(/u)
 		optDefault = 0x20,				//!< Default(/d)
 		optLocale = 0x40,				//!< Locale(/l)
 		optR = 0x80,					//!< CRLF(/R)
 	};
-	//! ŒŸõƒpƒ^[ƒ“’è‹`
+	//! æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³å®šç¾©
 	enum Pattern {
-		PAT_UNKNOWN = 0,		//!< •s–¾i‰Šú’l)
-		PAT_NORMAL = 1,			//!< ’Êí
-		PAT_TOP = 2,			//!< s“ª"^"
-		PAT_BOTTOM = 4,			//!< s––"$"
-		PAT_TAB = 8,			//!< s“ªs––"^$"
-		PAT_LOOKAHEAD = 16		//!< æ“Ç‚İ"(?[=]"
+		PAT_UNKNOWN = 0,		//!< ä¸æ˜ï¼ˆåˆæœŸå€¤)
+		PAT_NORMAL = 1,			//!< é€šå¸¸
+		PAT_TOP = 2,			//!< è¡Œé ­"^"
+		PAT_BOTTOM = 4,			//!< è¡Œæœ«"$"
+		PAT_TAB = 8,			//!< è¡Œé ­è¡Œæœ«"^$"
+		PAT_LOOKAHEAD = 16		//!< å…ˆèª­ã¿"(?[=]"
 	};
 
-	//! DLL‚Ìƒo[ƒWƒ‡ƒ“î•ñ‚ğæ“¾
+	//! DLLã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±ã‚’å–å¾—
 	const TCHAR* GetVersionT(){ return IsAvailable() ? to_tchar(BRegexpVersion()) : _T(""); }
 
-	//	CJreƒGƒ~ƒ…ƒŒ[ƒVƒ‡ƒ“ŠÖ”
-	//!	ŒŸõƒpƒ^[ƒ“‚ÌƒRƒ“ƒpƒCƒ‹
-	// 2002/01/19 novice ³‹K•\Œ»‚É‚æ‚é•¶š—ñ’uŠ·
-	// 2002.01.26 hor    ’uŠ·Œã•¶š—ñ‚ğ•Êˆø”‚É
-	// 2002.02.01 hor    ‘å•¶š¬•¶š‚ğ–³‹‚·‚éƒIƒvƒVƒ‡ƒ“’Ç‰Á
-	//>> 2002/03/27 Azumaiya ³‹K•\Œ»’uŠ·‚ÉƒRƒ“ƒpƒCƒ‹ŠÖ”‚ğg‚¤Œ`®‚ğ’Ç‰Á
+	//	CJreã‚¨ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³é–¢æ•°
+	//!	æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã®ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«
+	// 2002/01/19 novice æ­£è¦è¡¨ç¾ã«ã‚ˆã‚‹æ–‡å­—åˆ—ç½®æ›
+	// 2002.01.26 hor    ç½®æ›å¾Œæ–‡å­—åˆ—ã‚’åˆ¥å¼•æ•°ã«
+	// 2002.02.01 hor    å¤§æ–‡å­—å°æ–‡å­—ã‚’ç„¡è¦–ã™ã‚‹ã‚ªãƒ—ã‚·ãƒ§ãƒ³è¿½åŠ 
+	//>> 2002/03/27 Azumaiya æ­£è¦è¡¨ç¾ç½®æ›ã«ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«é–¢æ•°ã‚’ä½¿ã†å½¢å¼ã‚’è¿½åŠ 
 	bool Compile(const wchar_t *szPattern, int nOption = 0) {
 		return Compile(szPattern, NULL, nOption);
 	}
-	bool Compile(const wchar_t *szPattern0, const wchar_t *szPattern1, int nOption = 0, bool bKakomi = false);	//!< Replace—p
-	bool Match(const wchar_t *szTarget, int nLen, int nStart = 0);						//!< ŒŸõ‚ğÀs‚·‚é
-	int Replace(const wchar_t *szTarget, int nLen, int nStart = 0);					//!< ’uŠ·‚ğÀs‚·‚é	// 2007.01.16 ryoji –ß‚è’l‚ğ’uŠ·ŒÂ”‚É•ÏX
+	bool Compile(const wchar_t *szPattern0, const wchar_t *szPattern1, int nOption = 0, bool bKakomi = false);	//!< Replaceç”¨
+	bool Match(const wchar_t *szTarget, int nLen, int nStart = 0);						//!< æ¤œç´¢ã‚’å®Ÿè¡Œã™ã‚‹
+	int Replace(const wchar_t *szTarget, int nLen, int nStart = 0);					//!< ç½®æ›ã‚’å®Ÿè¡Œã™ã‚‹	// 2007.01.16 ryoji æˆ»ã‚Šå€¤ã‚’ç½®æ›å€‹æ•°ã«å¤‰æ›´
 
 	//-----------------------------------------
-	// 2005.03.19 ‚©‚ë‚Æ ƒNƒ‰ƒX“à•”‚ğ‰B•Á
+	// 2005.03.19 ã‹ã‚ã¨ ã‚¯ãƒ©ã‚¹å†…éƒ¨ã‚’éš è”½
 	/*! @{
-		@name Œ‹‰Ê‚ğ“¾‚éƒƒ\ƒbƒh‚ğ’Ç‰Á‚µABREGEXP‚ğŠO•”‚©‚ç‰B‚·
+		@name çµæœã‚’å¾—ã‚‹ãƒ¡ã‚½ãƒƒãƒ‰ã‚’è¿½åŠ ã—ã€BREGEXPã‚’å¤–éƒ¨ã‹ã‚‰éš ã™
 	*/
 	/*!
-	    ŒŸõ‚Éˆê’v‚µ‚½•¶š—ñ‚Ìæ“ªˆÊ’u‚ğ•Ô‚·(•¶š—ñæ“ª‚È‚ç0)
-		@retval ŒŸõ‚Éˆê’v‚µ‚½•¶š—ñ‚Ìæ“ªˆÊ’u
+	    æ¤œç´¢ã«ä¸€è‡´ã—ãŸæ–‡å­—åˆ—ã®å…ˆé ­ä½ç½®ã‚’è¿”ã™(æ–‡å­—åˆ—å…ˆé ­ãªã‚‰0)
+		@retval æ¤œç´¢ã«ä¸€è‡´ã—ãŸæ–‡å­—åˆ—ã®å…ˆé ­ä½ç½®
 	*/
 	CLogicInt GetIndex(void)
 	{
 		return CLogicInt(m_pRegExp->startp[0] - m_szTarget);
 	}
 	/*!
-	    ŒŸõ‚Éˆê’v‚µ‚½•¶š—ñ‚ÌŸ‚ÌˆÊ’u‚ğ•Ô‚·
-		@retval ŒŸõ‚Éˆê’v‚µ‚½•¶š—ñ‚ÌŸ‚ÌˆÊ’u
+	    æ¤œç´¢ã«ä¸€è‡´ã—ãŸæ–‡å­—åˆ—ã®æ¬¡ã®ä½ç½®ã‚’è¿”ã™
+		@retval æ¤œç´¢ã«ä¸€è‡´ã—ãŸæ–‡å­—åˆ—ã®æ¬¡ã®ä½ç½®
 	*/
 	CLogicInt GetLastIndex(void)
 	{
 		return CLogicInt(m_pRegExp->endp[0] - m_szTarget);
 	}
 	/*!
-		ŒŸõ‚Éˆê’v‚µ‚½•¶š—ñ‚Ì’·‚³‚ğ•Ô‚·
-		@retval ŒŸõ‚Éˆê’v‚µ‚½•¶š—ñ‚Ì’·‚³
+		æ¤œç´¢ã«ä¸€è‡´ã—ãŸæ–‡å­—åˆ—ã®é•·ã•ã‚’è¿”ã™
+		@retval æ¤œç´¢ã«ä¸€è‡´ã—ãŸæ–‡å­—åˆ—ã®é•·ã•
 	*/
 	CLogicInt GetMatchLen(void)
 	{
 		return CLogicInt(m_pRegExp->endp[0] - m_pRegExp->startp[0]);
 	}
 	/*!
-		’uŠ·‚³‚ê‚½•¶š—ñ‚Ì’·‚³‚ğ•Ô‚·
-		@retval ’uŠ·‚³‚ê‚½•¶š—ñ‚Ì’·‚³
+		ç½®æ›ã•ã‚ŒãŸæ–‡å­—åˆ—ã®é•·ã•ã‚’è¿”ã™
+		@retval ç½®æ›ã•ã‚ŒãŸæ–‡å­—åˆ—ã®é•·ã•
 	*/
 	CLogicInt GetStringLen(void) {
-		// ’uŠ·Œã•¶š—ñ‚ª‚O•‚È‚ç outpAoutendp‚àNULL‚É‚È‚é
-		// NULLƒ|ƒCƒ“ƒ^‚Ìˆø‚«Z‚Í–â‘è‚È‚­‚O‚É‚È‚éB
-		// outendp‚Í '\0'‚È‚Ì‚ÅA•¶š—ñ’·‚Í +1•s—v
+		// ç½®æ›å¾Œæ–‡å­—åˆ—ãŒï¼å¹…ãªã‚‰ outpã€outendpã‚‚NULLã«ãªã‚‹
+		// NULLãƒã‚¤ãƒ³ã‚¿ã®å¼•ãç®—ã¯å•é¡Œãªãï¼ã«ãªã‚‹ã€‚
+		// outendpã¯ '\0'ãªã®ã§ã€æ–‡å­—åˆ—é•·ã¯ +1ä¸è¦
 
 		// Jun. 03, 2005 Karoto
-		//	’uŠ·Œã•¶š—ñ‚ª0•‚Ìê‡‚Éoutp‚ªNULL‚Å‚àoutendp‚ªNULL‚Å‚È‚¢ê‡‚ª‚ ‚é‚Ì‚ÅC
-		//	outp‚ÌNULLƒ`ƒFƒbƒN‚ª•K—v
+		//	ç½®æ›å¾Œæ–‡å­—åˆ—ãŒ0å¹…ã®å ´åˆã«outpãŒNULLã§ã‚‚outendpãŒNULLã§ãªã„å ´åˆãŒã‚ã‚‹ã®ã§ï¼Œ
+		//	outpã®NULLãƒã‚§ãƒƒã‚¯ãŒå¿…è¦
 
 		if (m_pRegExp->outp == NULL) {
 			return CLogicInt(0);
@@ -154,8 +154,8 @@ public:
 		}
 	}
 	/*!
-		’uŠ·‚³‚ê‚½•¶š—ñ‚ğ•Ô‚·
-		@retval ’uŠ·‚³‚ê‚½•¶š—ñ‚Ö‚Ìƒ|ƒCƒ“ƒ^
+		ç½®æ›ã•ã‚ŒãŸæ–‡å­—åˆ—ã‚’è¿”ã™
+		@retval ç½®æ›ã•ã‚ŒãŸæ–‡å­—åˆ—ã¸ã®ãƒã‚¤ãƒ³ã‚¿
 	*/
 	const wchar_t *GetString(void)
 	{
@@ -164,23 +164,23 @@ public:
 	/*! @} */
 	//-----------------------------------------
 
-	/*! BREGEXPƒƒbƒZ[ƒW‚ğæ“¾‚·‚é
-		@retval ƒƒbƒZ[ƒW‚Ö‚Ìƒ|ƒCƒ“ƒ^
+	/*! BREGEXPãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å–å¾—ã™ã‚‹
+		@retval ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¸ã®ãƒã‚¤ãƒ³ã‚¿
 	*/
 	const TCHAR* GetLastMessage() const;// { return m_szMsg; }
 
-	/*!	æ“Ç‚İƒpƒ^[ƒ“‚ª‘¶İ‚·‚é‚©‚ğ•Ô‚·
-		‚±‚ÌŠÖ”‚ÍAƒRƒ“ƒpƒCƒ‹Œã‚Å‚ ‚é‚±‚Æ‚ª‘O’ñ‚È‚Ì‚ÅAƒRƒ“ƒpƒCƒ‹‘O‚Ífalse
-		@retval true æ“Ç‚İ‚ª‚ ‚é
-		@retval false æ“Ç‚İ‚ª‚È‚¢ –”‚Í ƒRƒ“ƒpƒCƒ‹‘O
+	/*!	å…ˆèª­ã¿ãƒ‘ã‚¿ãƒ¼ãƒ³ãŒå­˜åœ¨ã™ã‚‹ã‹ã‚’è¿”ã™
+		ã“ã®é–¢æ•°ã¯ã€ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«å¾Œã§ã‚ã‚‹ã“ã¨ãŒå‰æãªã®ã§ã€ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«å‰ã¯false
+		@retval true å…ˆèª­ã¿ãŒã‚ã‚‹
+		@retval false å…ˆèª­ã¿ãŒãªã„ åˆã¯ ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«å‰
 	*/
 	bool IsLookAhead(void) {
 		return m_ePatType & PAT_LOOKAHEAD ? true : false;
 	}
-	/*!	ŒŸõƒpƒ^[ƒ“‚Éæ“Ç‚İ‚ªŠÜ‚Ü‚ê‚é‚©HiƒRƒ“ƒpƒCƒ‹‘O‚Å‚à”»•Ê‰Â”\j
-		@param[in] pattern ŒŸõƒpƒ^[ƒ“
-		@retval true æ“Ç‚İ‚ª‚ ‚é
-		@retval false æ“Ç‚İ‚ª‚È‚¢
+	/*!	æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã«å…ˆèª­ã¿ãŒå«ã¾ã‚Œã‚‹ã‹ï¼Ÿï¼ˆã‚³ãƒ³ãƒ‘ã‚¤ãƒ«å‰ã§ã‚‚åˆ¤åˆ¥å¯èƒ½ï¼‰
+		@param[in] pattern æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³
+		@retval true å…ˆèª­ã¿ãŒã‚ã‚‹
+		@retval false å…ˆèª­ã¿ãŒãªã„
 	*/
 	bool IsLookAhead(const wchar_t *pattern) {
 		CheckPattern(pattern);
@@ -190,10 +190,10 @@ public:
 protected:
 
 
-	//!	ƒRƒ“ƒpƒCƒ‹ƒoƒbƒtƒ@‚ğ‰ğ•ú‚·‚é
+	//!	ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ãƒãƒƒãƒ•ã‚¡ã‚’è§£æ”¾ã™ã‚‹
 	/*!
-		m_pcReg‚ğBRegfree()‚É“n‚µ‚Ä‰ğ•ú‚·‚éD‰ğ•úŒã‚ÍNULL‚ÉƒZƒbƒg‚·‚éD
-		Œ³XNULL‚È‚ç‰½‚à‚µ‚È‚¢
+		m_pcRegã‚’BRegfree()ã«æ¸¡ã—ã¦è§£æ”¾ã™ã‚‹ï¼è§£æ”¾å¾Œã¯NULLã«ã‚»ãƒƒãƒˆã™ã‚‹ï¼
+		å…ƒã€…NULLãªã‚‰ä½•ã‚‚ã—ãªã„
 	*/
 	void ReleaseCompileBuffer(void){
 		if( m_pRegExp ){
@@ -204,29 +204,29 @@ protected:
 	}
 
 private:
-	//	“à•”ŠÖ”
+	//	å†…éƒ¨é–¢æ•°
 
-	//! ŒŸõƒpƒ^[ƒ“ì¬
+	//! æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ä½œæˆ
 	int CheckPattern( const wchar_t* szPattern );
 	wchar_t* MakePatternSub( const wchar_t* szPattern, const wchar_t* szPattern2, const wchar_t* szAdd2, int nOption );
 	wchar_t* MakePattern( const wchar_t* szPattern, const wchar_t* szPattern2, int nOption );
 	wchar_t* MakePatternAlternate( const wchar_t* const szSearch, const wchar_t* const szReplace, int nOption );
 
-	//	ƒƒ“ƒo•Ï”
-	BREGEXP_W*			m_pRegExp;			//!< ƒRƒ“ƒpƒCƒ‹\‘¢‘Ì
-	int					m_ePatType;			//!< ŒŸõ•¶š—ñƒpƒ^[ƒ“í•Ê
-	const wchar_t*		m_szTarget;			//!< ‘ÎÛ•¶š—ñ‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	wchar_t				m_szMsg[80];		//!< BREGEXP_W‚©‚ç‚ÌƒƒbƒZ[ƒW‚ğ•Û‚·‚é
+	//	ãƒ¡ãƒ³ãƒå¤‰æ•°
+	BREGEXP_W*			m_pRegExp;			//!< ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«æ§‹é€ ä½“
+	int					m_ePatType;			//!< æ¤œç´¢æ–‡å­—åˆ—ãƒ‘ã‚¿ãƒ¼ãƒ³ç¨®åˆ¥
+	const wchar_t*		m_szTarget;			//!< å¯¾è±¡æ–‡å­—åˆ—ã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	wchar_t				m_szMsg[80];		//!< BREGEXP_Wã‹ã‚‰ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ä¿æŒã™ã‚‹
 
-	// Ã“Iƒƒ“ƒo•Ï”
-	static const wchar_t	m_tmpBuf[2];	//!< ƒ_ƒ~[•¶š—ñ
+	// é™çš„ãƒ¡ãƒ³ãƒå¤‰æ•°
+	static const wchar_t	m_tmpBuf[2];	//!< ãƒ€ãƒŸãƒ¼æ–‡å­—åˆ—
 };
 
 
 //	Jun. 26, 2001 genta
-//!	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒo[ƒWƒ‡ƒ“æ“¾
+//!	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³å–å¾—
 bool CheckRegexpVersion( HWND hWnd, int nCmpId, bool bShowMsg = false );
-bool CheckRegexpSyntax( const wchar_t* szPattern, HWND hWnd, bool bShowMessage, int nOption = -1, bool bKakomi = false );// 2002/2/1 hor’Ç‰Á
+bool CheckRegexpSyntax( const wchar_t* szPattern, HWND hWnd, bool bShowMessage, int nOption = -1, bool bKakomi = false );// 2002/2/1 horè¿½åŠ 
 bool InitRegexp( HWND hWnd, CBregexp& rRegexp, bool bShowMessage );
 
 

--- a/sakura_core/extmodule/CBregexpDll2.cpp
+++ b/sakura_core/extmodule/CBregexpDll2.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -33,11 +33,11 @@ CBregexpDll2::~CBregexpDll2()
 }
 
 /*!
-	@date 2001.07.05 genta ˆø”’Ç‰ÁB‚½‚¾‚µA‚±‚±‚Å‚Íg‚í‚È‚¢B
-	@date 2007.06.25 genta •¡”‚ÌDLL–¼‚É‘Î‰
-	@date 2007.09.13 genta ƒT[ƒ`ƒ‹[ƒ‹‚ğ•ÏX
-		@li w’è—L‚è‚Ìê‡‚Í‚»‚ê‚Ì‚İ‚ğ•Ô‚·
-		@li w’è–³‚µ(NULL‚Ü‚½‚Í‹ó•¶š—ñ)‚Ìê‡‚ÍBREGONIG, BREGEXP‚Ì‡‚Å‚İ‚é
+	@date 2001.07.05 genta å¼•æ•°è¿½åŠ ã€‚ãŸã ã—ã€ã“ã“ã§ã¯ä½¿ã‚ãªã„ã€‚
+	@date 2007.06.25 genta è¤‡æ•°ã®DLLåã«å¯¾å¿œ
+	@date 2007.09.13 genta ã‚µãƒ¼ãƒãƒ«ãƒ¼ãƒ«ã‚’å¤‰æ›´
+		@li æŒ‡å®šæœ‰ã‚Šã®å ´åˆã¯ãã‚Œã®ã¿ã‚’è¿”ã™
+		@li æŒ‡å®šç„¡ã—(NULLã¾ãŸã¯ç©ºæ–‡å­—åˆ—)ã®å ´åˆã¯BREGONIG, BREGEXPã®é †ã§è©¦ã¿ã‚‹
 */
 LPCTSTR CBregexpDll2::GetDllNameImp( int index )
 {
@@ -46,16 +46,16 @@ LPCTSTR CBregexpDll2::GetDllNameImp( int index )
 
 
 /*!
-	DLL‚Ì‰Šú‰»
+	DLLã®åˆæœŸåŒ–
 
-	ŠÖ”‚ÌƒAƒhƒŒƒX‚ğæ“¾‚µ‚Äƒƒ“ƒo‚É•ÛŠÇ‚·‚éD
+	é–¢æ•°ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‚’å–å¾—ã—ã¦ãƒ¡ãƒ³ãƒã«ä¿ç®¡ã™ã‚‹ï¼
 
-	@retval true ¬Œ÷
-	@retval false ƒAƒhƒŒƒXæ“¾‚É¸”s
+	@retval true æˆåŠŸ
+	@retval false ã‚¢ãƒ‰ãƒ¬ã‚¹å–å¾—ã«å¤±æ•—
 */
 bool CBregexpDll2::InitDllImp()
 {
-	//DLL“àŠÖ”–¼ƒŠƒXƒg
+	//DLLå†…é–¢æ•°åãƒªã‚¹ãƒˆ
 	const ImportTable table[] = {
 		{ &m_BMatch,			"BMatchW" },
 		{ &m_BSubst,			"BSubstW" },

--- a/sakura_core/extmodule/CBregexpDll2.h
+++ b/sakura_core/extmodule/CBregexpDll2.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -40,20 +40,20 @@ typedef struct bregexp {
 	int nparens;				/* number of parentheses */
 } BREGEXP_W;
 
-//!BREGONIG.DLL‚ğƒ‰ƒbƒv‚µ‚½‚à‚ÌB
-//2007.09.13 kobake ì¬
+//!BREGONIG.DLLã‚’ãƒ©ãƒƒãƒ—ã—ãŸã‚‚ã®ã€‚
+//2007.09.13 kobake ä½œæˆ
 class CBregexpDll2 : public CDllImp{
 public:
 	CBregexpDll2();
 	virtual ~CBregexpDll2();
 
 protected:
-	// CDllImpƒCƒ“ƒ^ƒtƒF[ƒX
-	virtual LPCTSTR GetDllNameImp(int nIndex); // Jul. 5, 2001 genta ƒCƒ“ƒ^[ƒtƒF[ƒX•ÏX‚É”º‚¤ˆø”’Ç‰Á
+	// CDllImpã‚¤ãƒ³ã‚¿ãƒ•ã‚§ãƒ¼ã‚¹
+	virtual LPCTSTR GetDllNameImp(int nIndex); // Jul. 5, 2001 genta ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹å¤‰æ›´ã«ä¼´ã†å¼•æ•°è¿½åŠ 
 	virtual bool InitDllImp();
 
 protected:
-	// DLLŠÖ”‚ÌŒ^
+	// DLLé–¢æ•°ã®å‹
 	typedef int            (__cdecl *BREGEXP_BMatchW2)        (const wchar_t* str, const wchar_t* target, const wchar_t* targetendp, BREGEXP_W** rxp, wchar_t* msg);
 	typedef int            (__cdecl *BREGEXP_BSubstW2)        (const wchar_t* str, const wchar_t* target, const wchar_t* targetendp, BREGEXP_W** rxp, wchar_t* msg);
 	typedef int            (__cdecl *BREGEXP_BTransW2)        (const wchar_t* str, wchar_t* target, wchar_t* targetendp, BREGEXP_W** rxp, wchar_t* msg);
@@ -64,7 +64,7 @@ protected:
 	typedef int            (__cdecl *BREGEXP_BSubstExW2)      (const wchar_t* str, const wchar_t* targetbeg, const wchar_t* target, const wchar_t* targetendp, BREGEXP_W** rxp, wchar_t* msg);
 
 public:
-	// UNICODEƒCƒ“ƒ^[ƒtƒF[ƒX‚ğ’ñ‹Ÿ‚·‚é
+	// UNICODEã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã‚’æä¾›ã™ã‚‹
 	int BMatch(const wchar_t* str, const wchar_t* target,const wchar_t* targetendp,BREGEXP_W** rxp,wchar_t* msg)
 	{
 		return m_BMatch(str,target,targetendp,rxp,msg);
@@ -98,12 +98,12 @@ public:
 		return m_BSubstEx(str,targetbeg,target,targetendp,rxp,msg);
 	}
 
-	// ŠÖ”‚ª‚ ‚é‚©‚Ç‚¤‚©
+	// é–¢æ•°ãŒã‚ã‚‹ã‹ã©ã†ã‹
 	bool ExistBMatchEx() const{ return m_BMatchEx!=NULL; }
 	bool ExistBSubstEx() const{ return m_BSubstEx!=NULL; }
 
 private:
-	//DLL“àŠÖ”ƒ|ƒCƒ“ƒ^
+	//DLLå†…é–¢æ•°ãƒã‚¤ãƒ³ã‚¿
 	BREGEXP_BMatchW2         m_BMatch;
 	BREGEXP_BSubstW2         m_BSubst;
 	BREGEXP_BTransW2         m_BTrans;

--- a/sakura_core/extmodule/CDllHandler.h
+++ b/sakura_core/extmodule/CDllHandler.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief DLL�̃��[�h�A�A�����[�h
+﻿/*!	@file
+	@brief DLLのロード、アンロード
 
 	@author genta
 	@date Jun. 10, 2001
@@ -36,14 +36,14 @@
 #include <string>
 #include "_main/global.h"
 
-/*! CDllImp �����b�v
-	CDllImp::DeinitDll ���ĂіY��Ȃ����߂̃w���p�I�N���X�B
-	���̂Ƃ���DeinitDll���g���Ă���ӏ��������̂ŁA���̃N���X�̏o�Ԃ͂���܂��񂪁B
-	2008.05.10 kobake �쐬
+/*! CDllImp をラップ
+	CDllImp::DeinitDll を呼び忘れないためのヘルパ的クラス。
+	今のところDeinitDllが使われている箇所が無いので、このクラスの出番はありませんが。
+	2008.05.10 kobake 作成
 */
 template <class DLLIMP> class CDllHandler{
 public:
-	//�R���X�g���N�^�E�f�X�g���N�^
+	//コンストラクタ・デストラクタ
 	CDllHandler()
 	{
 		m_pcDllImp = new DLLIMP();
@@ -51,14 +51,14 @@ public:
 	}
 	~CDllHandler()
 	{
-		m_pcDllImp->DeinitDll(true); //���I�������Ɏ��s���Ă������I��DLL���
+		m_pcDllImp->DeinitDll(true); //※終了処理に失敗しても強制的にDLL解放
 		delete m_pcDllImp;
 	}
 
-	//�A�N�Z�T
+	//アクセサ
 	DLLIMP* operator->(){ return m_pcDllImp; }
 
-	//! ���p��Ԃ̃`�F�b�N�ioperator�Łj
+	//! 利用状態のチェック（operator版）
 	bool operator!() const { return m_pcDllImp->IsAvailable(); }
 
 private:
@@ -66,32 +66,32 @@ private:
 };
 
 
-//!���ʒ萔
+//!結果定数
 enum EDllResult{
-	DLL_SUCCESS,		//����
-	DLL_LOADFAILURE,	//DLL���[�h���s
-	DLL_INITFAILURE,	//���������Ɏ��s
+	DLL_SUCCESS,		//成功
+	DLL_LOADFAILURE,	//DLLロード失敗
+	DLL_INITFAILURE,	//初期処理に失敗
 };
 
-//! DLL�̓��I��Load/Unload���s�����߂̃N���X
+//! DLLの動的なLoad/Unloadを行うためのクラス
 /*!
 	@author genta
 	@date Jun. 10, 2001 genta
-	@date 2001.07.05 genta InitDll: �����ǉ��B�p�X�̎w��ȂǂɎg����
-	@date Apr. 15, 2002 genta RegisterEntries�̒ǉ��B
-	@date 2007.06.25 genta InitDll: GetDllNameImp���g���悤�Ɏ�����ύX�D
-	@date 2001.07.05 genta GetDllName: �����ǉ��B�p�X�̎w��ȂǂɎg����
-	@date 2007.06.25 genta GetDllName: GetDllNameImp���g�p����ꍇ�͕K�{�ł͂Ȃ��̂ŁC
-										�������z�֐��͂�߂ăv���[�X�z���_�[��p�ӂ���D
-	@date 2008.05.10 kobake �����B�h���N���X�́A�`Imp���I�[�o�[���[�h����Ηǂ��Ƃ��������ł��B
+	@date 2001.07.05 genta InitDll: 引数追加。パスの指定などに使える
+	@date Apr. 15, 2002 genta RegisterEntriesの追加。
+	@date 2007.06.25 genta InitDll: GetDllNameImpを使うように実装を変更．
+	@date 2001.07.05 genta GetDllName: 引数追加。パスの指定などに使える
+	@date 2007.06.25 genta GetDllName: GetDllNameImpを使用する場合は必須ではないので，
+										純粋仮想関数はやめてプレースホルダーを用意する．
+	@date 2008.05.10 kobake 整理。派生クラスは、～Impをオーバーロードすれば良いという方式です。
 */
 class CDllImp{
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                            �^                               //
+	//                            型                               //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	/*!
-		�A�h���X�ƃG���g�����̑Ή��\�BRegisterEntries�Ŏg����B
+		アドレスとエントリ名の対応表。RegisterEntriesで使われる。
 		@author YAZAKI
 		@date 2002.01.26
 	*/
@@ -101,106 +101,106 @@ public:
 	};
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        �����Ɣj��                           //
+	//                        生成と破棄                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//�R���X�g���N�^�E�f�X�g���N�^
+	//コンストラクタ・デストラクタ
 	CDllImp();
 	virtual ~CDllImp();
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         DLL���[�h                           //
+	//                         DLLロード                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//! DLL�̊֐����Ăяo���邩��Ԃǂ���
+	//! DLLの関数を呼び出せるか状態どうか
 	virtual bool IsAvailable() const { return m_hInstance != NULL; }
 
-	//! DLL���[�h�Ə�������
+	//! DLLロードと初期処理
 	EDllResult InitDll(
-		LPCTSTR pszSpecifiedDllName = NULL	//!< [in] �N���X����`���Ă���DLL���ȊO��DLL��ǂݍ��݂����Ƃ��ɁA����DLL�����w��B
+		LPCTSTR pszSpecifiedDllName = NULL	//!< [in] クラスが定義しているDLL名以外のDLLを読み込みたいときに、そのDLL名を指定。
 	);
 
-	//! �I��������DLL�A�����[�h
+	//! 終了処理とDLLアンロード
 	bool DeinitDll(
-		bool force = false	//!< [in] �I�������Ɏ��s���Ă�DLL��������邩�ǂ���
+		bool force = false	//!< [in] 終了処理に失敗してもDLLを解放するかどうか
 	);
 
-	//! �C���X�^���X�n���h���̎擾
+	//! インスタンスハンドルの取得
 	HINSTANCE GetInstance() const { return m_hInstance; }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ����                              //
+	//                           属性                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//! ���[�h�ς�DLL�t�@�C�����̎擾�B���[�h����Ă��Ȃ� (�܂��̓��[�h�Ɏ��s����) �ꍇ�� NULL ��Ԃ��B
+	//! ロード済みDLLファイル名の取得。ロードされていない (またはロードに失敗した) 場合は NULL を返す。
 	LPCTSTR GetLoadedDllName() const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                  �I�[�o�[���[�h�\����                     //
+	//                  オーバーロード可能実装                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 protected:
-	//!	DLL�̏�����
+	//!	DLLの初期化
 	/*!
-		DLL�̃��[�h�ɐ�����������ɌĂяo�����D�G���g���|�C���g��
-		�m�F�Ȃǂ��s���D
+		DLLのロードに成功した直後に呼び出される．エントリポイントの
+		確認などを行う．
 
-		@retval true ����I��
-		@retval false �ُ�I��
+		@retval true 正常終了
+		@retval false 異常終了
 
-		@note false��Ԃ����ꍇ�́A�ǂݍ���DLL���������D
+		@note falseを返した場合は、読み込んだDLLを解放する．
 	*/
 	virtual bool InitDllImp() = 0;
 
-	//!	�֐��̏�����
+	//!	関数の初期化
 	/*!
-		DLL�̃A�����[�h���s�����O�ɌĂяo�����D�������̉���Ȃǂ�
-		�s���D
+		DLLのアンロードを行う直前に呼び出される．メモリの解放などを
+		行う．
 
-		@retval true ����I��
-		@retval false �ُ�I��
+		@retval true 正常終了
+		@retval false 異常終了
 
-		@note false��Ԃ����Ƃ���DLL��Unload�͍s���Ȃ��D
-		@par ����
-		�f�X�g���N�^����DeinitDll�y��DeinitDllImp���Ăяo���ꂽ�Ƃ���
-		�|�����[�t�B�Y�����s���Ȃ����߂ɃT�u�N���X��DeinitDllImp���Ăяo����Ȃ��B
-		���̂��߁A�T�u�N���X�̃f�X�g���N�^�ł�DeinitDllImp�𖾎��I�ɌĂяo���K�v������B
+		@note falseを返したときはDLLのUnloadは行われない．
+		@par 注意
+		デストラクタからDeinitDll及びDeinitDllImpが呼び出されたときは
+		ポリモーフィズムが行われないためにサブクラスのDeinitDllImpが呼び出されない。
+		そのため、サブクラスのデストラクタではDeinitDllImpを明示的に呼び出す必要がある。
 		
-		DeinitDll���f�X�g���N�^�ȊO����Ăяo�����ꍇ��DeinitDllImp�͉��z�֐��Ƃ���
-		�T�u�N���X�̂��̂��Ăяo����A�f�X�g���N�^�͓��R�Ăяo����Ȃ��̂�
-		DeinitDllImp���̂��͕̂K�v�ł���B
+		DeinitDllがデストラクタ以外から呼び出される場合はDeinitDllImpは仮想関数として
+		サブクラスのものが呼び出され、デストラクタは当然呼び出されないので
+		DeinitDllImpそのものは必要である。
 		
-		�f�X�g���N�^����DeinitDllImp���ĂԂƂ��́A����������Ă���Ƃ����ۏ؂��Ȃ��̂�
-		�Ăяo���O��IsAvailable�ɂ��m�F��K���s�����ƁB
+		デストラクタからDeinitDllImpを呼ぶときは、初期化されているという保証がないので
+		呼び出し前にIsAvailableによる確認を必ず行うこと。
 		
-		@date 2002.04.15 genta ���ӏ����ǉ�
+		@date 2002.04.15 genta 注意書き追加
 	*/
 	virtual bool DeinitDllImp();
 
-	//! DLL�t�@�C�����̎擾(����������)
+	//! DLLファイル名の取得(複数を順次)
 	/*!
-		DLL�t�@�C�����Ƃ��ĕ����̉\��������C���̂����̈�ł�
-		�����������̂��g�p����ꍇ�ɑΉ�����D
+		DLLファイル名として複数の可能性があり，そのうちの一つでも
+		見つかったものを使用する場合に対応する．
 		
-		�ԍ��ɉ����Ă��ꂼ��قȂ�t�@�C������Ԃ����Ƃ��ł���D
-		LoadLibrary()�����counter��0����1�����������ď��ɌĂт������D
-		�����DLL�̃��[�h�ɐ�������(����)���C�߂�l�Ƃ���NULL��Ԃ�(���s)
-		�܂ő�������D
+		番号に応じてそれぞれ異なるファイル名を返すことができる．
+		LoadLibrary()からはcounterを0から1ずつ増加させて順に呼びだされる．
+		それはDLLのロードに成功する(成功)か，戻り値としてNULLを返す(失敗)
+		まで続けられる．
 
-		@param[in] nIndex �C���f�b�N�X�D(0�`)
+		@param[in] nIndex インデックス．(0～)
 		
-		@return �����ɉ�����DLL��(LoadLibrary�ɓn��������)�C�܂���NULL�D
+		@return 引数に応じてDLL名(LoadLibraryに渡す文字列)，またはNULL．
 	*/
 	virtual LPCTSTR GetDllNameImp(int nIndex) = 0;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         �����⏕                            //
+	//                         実装補助                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 protected:
 	bool RegisterEntries(const ImportTable table[]);
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        �����o�ϐ�                           //
+	//                        メンバ変数                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 private:
 	HINSTANCE		m_hInstance;

--- a/sakura_core/extmodule/CHtmlHelp.cpp
+++ b/sakura_core/extmodule/CHtmlHelp.cpp
@@ -1,7 +1,7 @@
-/*!	@file
-	@brief HtmpHelp“®“Iƒ[ƒh
+ï»¿/*!	@file
+	@brief HtmpHelpå‹•çš„ãƒ­ãƒ¼ãƒ‰
 	
-	HTML Help ƒRƒ“ƒ|[ƒlƒ“ƒg‚Ö‚Ì“®“IƒAƒNƒZƒXƒNƒ‰ƒX
+	HTML Help ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã¸ã®å‹•çš„ã‚¢ã‚¯ã‚»ã‚¹ã‚¯ãƒ©ã‚¹
 
 	@author genta
 	@date Jul. 5, 2001
@@ -37,7 +37,7 @@ CHtmlHelp::~CHtmlHelp(void)
 {}
 
 /*!
-	HTML Help ‚Ìƒtƒ@ƒCƒ‹–¼‚ð“n‚·
+	HTML Help ã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’æ¸¡ã™
 */
 LPCTSTR CHtmlHelp::GetDllNameImp(int nIndex)
 {

--- a/sakura_core/extmodule/CHtmlHelp.h
+++ b/sakura_core/extmodule/CHtmlHelp.h
@@ -1,7 +1,7 @@
-/*!	@file
-	@brief HtmpHelp“®“Iƒ[ƒh
+ï»¿/*!	@file
+	@brief HtmpHelpå‹•çš„ãƒ­ãƒ¼ãƒ‰
 
-	HTML Help ƒRƒ“ƒ|[ƒlƒ“ƒg‚Ö‚Ì“®“IƒAƒNƒZƒXƒNƒ‰ƒX
+	HTML Help ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã¸ã®å‹•çš„ã‚¢ã‚¯ã‚»ã‚¹ã‚¯ãƒ©ã‚¹
 
 	@author genta
 	@date Jul. 5, 2001
@@ -37,16 +37,16 @@
 
 
 /*!
-	@brief HtmpHelp“®“Iƒ[ƒh
+	@brief HtmpHelpå‹•çš„ãƒ­ãƒ¼ãƒ‰
 
-	HTMLƒwƒ‹ƒvƒRƒ“ƒ|[ƒlƒ“ƒg‚Ì“®“Iƒ[ƒh‚ğƒTƒ|[ƒg‚·‚éƒNƒ‰ƒX
+	HTMLãƒ˜ãƒ«ãƒ—ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®å‹•çš„ãƒ­ãƒ¼ãƒ‰ã‚’ã‚µãƒãƒ¼ãƒˆã™ã‚‹ã‚¯ãƒ©ã‚¹
 */
 class CHtmlHelp : public CDllImp {
 public:
 	CHtmlHelp(){}
 	virtual ~CHtmlHelp();
 
-	//	HtmlHelp ‚ÌEntry Point
+	//	HtmlHelp ã®Entry Point
 	typedef HWND (WINAPI* Proc_HtmlHelp)(HWND, LPCTSTR, UINT, DWORD_PTR);
 	Proc_HtmlHelp HtmlHelp;
 

--- a/sakura_core/extmodule/CMigemo.cpp
+++ b/sakura_core/extmodule/CMigemo.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief C/Migemo ƒCƒ“ƒ^[ƒtƒF[ƒX
+ï»¿/*!	@file
+	@brief C/Migemo ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 
 	@author isearch
-	@date 2004.09.14 V‹Kì¬
+	@date 2004.09.14 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2004, isearch
@@ -24,12 +24,12 @@
 #include "util/module.h"
 #include "util/file.h"
 
-/*! @brief PCRE ƒƒ^ƒLƒƒƒ‰ƒNƒ^‚ÌƒGƒXƒP[ƒvˆ—‚ğs‚¤B
- iCMigemo::migemo_setproc_int2char ‚Ìˆø”‚Æ‚µ‚Äg—pj
- @param[in] in “ü—Í•¶šƒR[ƒh(unsigned int)
- @param[out] out o—ÍƒoƒCƒg—ñ(unsigned char*)
- @return o—Í‚³‚ê‚½•¶š—ñ‚ÌƒoƒCƒg”B
-  0‚ğ•Ô‚¹‚ÎƒfƒtƒHƒ‹ƒg‚ÌƒvƒƒV[ƒWƒƒ‚ªÀs‚³‚ê‚éB
+/*! @brief PCRE ãƒ¡ã‚¿ã‚­ãƒ£ãƒ©ã‚¯ã‚¿ã®ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—å‡¦ç†ã‚’è¡Œã†ã€‚
+ ï¼ˆCMigemo::migemo_setproc_int2char ã®å¼•æ•°ã¨ã—ã¦ä½¿ç”¨ï¼‰
+ @param[in] in å…¥åŠ›æ–‡å­—ã‚³ãƒ¼ãƒ‰(unsigned int)
+ @param[out] out å‡ºåŠ›ãƒã‚¤ãƒˆåˆ—(unsigned char*)
+ @return å‡ºåŠ›ã•ã‚ŒãŸæ–‡å­—åˆ—ã®ãƒã‚¤ãƒˆæ•°ã€‚
+  0ã‚’è¿”ã›ã°ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãŒå®Ÿè¡Œã•ã‚Œã‚‹ã€‚
 */
 static int __cdecl pcre_int2char(unsigned int in, unsigned char* out);	// 2009.04.30 miau
 
@@ -38,11 +38,11 @@ int __cdecl pcre_char2int_utf8(const unsigned char*, unsigned int*);
 int __cdecl pcre_int2char_utf8(unsigned int, unsigned char*);
 
 //-----------------------------------------
-//	DLL ‰Šú‰»ŠÖ”
+//	DLL åˆæœŸåŒ–é–¢æ•°
 //-----------------------------------------
 bool CMigemo::InitDllImp()
 {
-	//	static‚É‚µ‚Ä‚Í‚¢‚¯‚È‚¢‚ç‚µ‚¢
+	//	staticã«ã—ã¦ã¯ã„ã‘ãªã„ã‚‰ã—ã„
 	
 	const ImportTable table[] = {
 		{ &m_migemo_open              ,"migemo_open"              },
@@ -73,10 +73,10 @@ bool CMigemo::InitDllImp()
 	m_migemo_load_s             = (Proc_migemo_load_s)            m_migemo_load;
 	m_migemo_is_enable_s        = (Proc_migemo_is_enable_s)       m_migemo_is_enable;
 
-	// IA64/x64‚Í‘Î‰•s—v
+	// IA64/x64ã¯å¯¾å¿œä¸è¦
 #ifdef _WIN64
 #else
-	// ver 1.3 ˆÈ~‚Í stdcall
+	// ver 1.3 ä»¥é™ã¯ stdcall
 	DWORD dwVersionMS, dwVersionLS;
 	GetAppVersionInfo( GetInstance(), VS_VERSION_INFO, &dwVersionMS, &dwVersionLS );
 	
@@ -116,7 +116,7 @@ LPCTSTR CMigemo::GetDllNameImp(int nIndex)
 		}
 		else{
 			if(_IS_REL_PATH(szDll)){
-				GetInidirOrExedir(szDllName , szDll);	// 2007.05.21 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+				GetInidirOrExedir(szDllName , szDll);	// 2007.05.21 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 				szDll = szDllName;
 			}
 			return szDll;
@@ -287,18 +287,18 @@ int CMigemo::migemo_load_all()
 		TCHAR *ppath;
 		
 		if (szDict[0] == _T('\0')){
-			GetInidirOrExedir(path,_T("dict"));	// 2007.05.20 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+			GetInidirOrExedir(path,_T("dict"));	// 2007.05.20 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 		}
 		else{
 			if (_IS_REL_PATH(szDict)){
-				GetInidirOrExedir(path,szDict);	// 2007.05.19 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+				GetInidirOrExedir(path,szDict);	// 2007.05.19 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 			}else{
 				_tcscpy(path,szDict);
 			}
 		}
 		ppath = &path[_tcslen(path)];
 		*(ppath++) = _T('\\');
-		// ver1.3 utf8‘Î‰
+		// ver1.3 utf8å¯¾å¿œ
 		_tcscpy(ppath,_T("utf-8\\migemo-dict"));
 		if(fexist(path)){
 			_tcscpy(ppath,_T("utf-8\\"));
@@ -324,7 +324,7 @@ int CMigemo::migemo_load_all()
 		_tcscpy(ppath,_T("zen2han.dat"));
 		migemo_load_t(MIGEMO_DICTID_ZEN2HAN,path);
 
-		// 2011.12.11 Moca «‘“o˜^Œã‚Å‚È‚¢‚Æmigemo“à‘Ÿ‚Ì‚à‚Ì‚É•ÏX‚³‚ê‚Ä‚µ‚Ü‚¤
+		// 2011.12.11 Moca è¾æ›¸ç™»éŒ²å¾Œã§ãªã„ã¨migemoå†…è‡“ã®ã‚‚ã®ã«å¤‰æ›´ã•ã‚Œã¦ã—ã¾ã†
 		if( m_bUtf8 ){
 			migemo_setproc_char2int(pcre_char2int_utf8);
 			migemo_setproc_int2char(pcre_int2char_utf8);
@@ -358,10 +358,10 @@ int __cdecl pcre_char2int_sjis(const unsigned char* in, unsigned int* out)
 
 
 
-// C/Migemo ƒ\[ƒX’†‚Ì rxgen.c:default_int2char ‚ğŒ³‚Éì¬B	// 2009.04.30 miau
+// C/Migemo ã‚½ãƒ¼ã‚¹ä¸­ã® rxgen.c:default_int2char ã‚’å…ƒã«ä½œæˆã€‚	// 2009.04.30 miau
 static int __cdecl pcre_int2char(unsigned int in, unsigned char* out)
 {
-    /* out‚ÍÅ’á‚Å‚à16ƒoƒCƒg‚Í‚ ‚éA‚Æ‚¢‚¤‰¼’è‚ğ’u‚­ */
+    /* outã¯æœ€ä½ã§ã‚‚16ãƒã‚¤ãƒˆã¯ã‚ã‚‹ã€ã¨ã„ã†ä»®å®šã‚’ç½®ã */
     if (in >= 0x100)
     {
 	if (out)

--- a/sakura_core/extmodule/CMigemo.h
+++ b/sakura_core/extmodule/CMigemo.h
@@ -1,10 +1,10 @@
-/*!	@file
-	@brief MigemoŠÖ˜A
+ï»¿/*!	@file
+	@brief Migemoé–¢é€£
 
-	C/MigemoƒAƒNƒZƒXŠÖ”
+	C/Migemoã‚¢ã‚¯ã‚»ã‚¹é–¢æ•°
 
 	@author isearch
-	@date 2004.09.14 V‹Kì¬
+	@date 2004.09.14 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2004, isearch
@@ -15,7 +15,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 /*
-Migemo ‚Íƒ[ƒ}š‚Ì‚Ü‚Ü“ú–{Œê‚ğƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ŒŸõ‚·‚é‚½‚ß‚Ìƒc[ƒ‹‚Å‚·B
+Migemo ã¯ãƒ­ãƒ¼ãƒå­—ã®ã¾ã¾æ—¥æœ¬èªã‚’ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«æ¤œç´¢ã™ã‚‹ãŸã‚ã®ãƒ„ãƒ¼ãƒ«ã§ã™ã€‚
 */
 
 #ifndef _SAKURA_MIGEMO_H_
@@ -44,7 +44,7 @@ typedef int (__cdecl *MIGEMO_PROC_CHAR2INT)(const unsigned char*, unsigned int*)
 typedef int (__cdecl *MIGEMO_PROC_INT2CHAR)(unsigned int, unsigned char*);
 
 /**
- * MigemoƒIƒuƒWƒFƒNƒgBmigemo_open()‚Åì¬‚³‚êAmigemo_close‚Å”jŠü‚³‚ê‚éB
+ * Migemoã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã€‚migemo_open()ã§ä½œæˆã•ã‚Œã€migemo_closeã§ç ´æ£„ã•ã‚Œã‚‹ã€‚
  */
 typedef struct _migemo migemo;
 
@@ -61,8 +61,8 @@ public:
 
 	//	Entry Point
 protected:
-	//	Aug. 20, 2005 Aroka : Å“K‰»ƒIƒvƒVƒ‡ƒ“‚ÅƒfƒtƒHƒ‹ƒg‚ğ__fastcall‚É•ÏX‚µ‚Ä‚à
-	//	‰e‹¿‚ğó‚¯‚È‚¢‚æ‚¤‚É‚·‚éD
+	//	Aug. 20, 2005 Aroka : æœ€é©åŒ–ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã§ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã‚’__fastcallã«å¤‰æ›´ã—ã¦ã‚‚
+	//	å½±éŸ¿ã‚’å—ã‘ãªã„ã‚ˆã†ã«ã™ã‚‹ï¼
 	typedef migemo*        (__cdecl *Proc_migemo_open)            (char* dict);
 	typedef void           (__cdecl *Proc_migemo_close)           (migemo* object);
 	typedef unsigned char* (__cdecl *Proc_migemo_query)           (migemo* object, unsigned char* query);
@@ -108,7 +108,7 @@ protected:
 	Proc_migemo_is_enable_s           m_migemo_is_enable_s;
 
 	migemo* m_migemo;
-	// IA64/x64‚Í‘Î‰•s—v
+	// IA64/x64ã¯å¯¾å¿œä¸è¦
 #ifdef _WIN64
 	static const bool	m_bStdcall = true;
 #else

--- a/sakura_core/extmodule/CUxTheme.cpp
+++ b/sakura_core/extmodule/CUxTheme.cpp
@@ -1,7 +1,7 @@
-/*!	@file
-	@brief UxTheme “®“Iƒ[ƒh
+ï»¿/*!	@file
+	@brief UxTheme å‹•çš„ãƒ­ãƒ¼ãƒ‰
 
-	UxTheme (Windows thmeme manager) ‚Ö‚Ì“®“IƒAƒNƒZƒXƒNƒ‰ƒX
+	UxTheme (Windows thmeme manager) ã¸ã®å‹•çš„ã‚¢ã‚¯ã‚»ã‚¹ã‚¯ãƒ©ã‚¹
 
 	@author ryoji
 	@date Apr. 1, 2007
@@ -43,13 +43,13 @@ CUxTheme::~CUxTheme()
 }
 
 
-/*! DLL ‚Ìƒ[ƒh
+/*! DLL ã®ãƒ­ãƒ¼ãƒ‰
 
-	ˆê“x‚µ‚© LoadLibrary() Às‚µ‚È‚¢‚±‚ÆˆÈŠO‚Í CDllImp::Init() ‚Æ“¯‚¶
-	iUxTheme –¢‘Î‰ OS ‚Å‚Ì LoadLibrary() ¸”s‚ÌŒJ•Ô‚µ‚ğ–h‚®j
+	ä¸€åº¦ã—ã‹ LoadLibrary() å®Ÿè¡Œã—ãªã„ã“ã¨ä»¥å¤–ã¯ CDllImp::Init() ã¨åŒã˜
+	ï¼ˆUxTheme æœªå¯¾å¿œ OS ã§ã® LoadLibrary() å¤±æ•—ã®ç¹°è¿”ã—ã‚’é˜²ãï¼‰
 
 	@author ryoji
-	@date 2007.04.01 ryoji V‹K
+	@date 2007.04.01 ryoji æ–°è¦
 */
 bool CUxTheme::InitThemeDll( TCHAR* str )
 {
@@ -61,7 +61,7 @@ bool CUxTheme::InitThemeDll( TCHAR* str )
 }
 
 /*!
-	UxTheme ‚Ìƒtƒ@ƒCƒ‹–¼‚ğ“n‚·
+	UxTheme ã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’æ¸¡ã™
 */
 LPCTSTR CUxTheme::GetDllNameImp(int nIndex)
 {

--- a/sakura_core/extmodule/CUxTheme.h
+++ b/sakura_core/extmodule/CUxTheme.h
@@ -1,7 +1,7 @@
-/*!	@file
-	@brief UxTheme “®“Iƒ[ƒh
+ï»¿/*!	@file
+	@brief UxTheme å‹•çš„ãƒ­ãƒ¼ãƒ‰
 
-	UxTheme (Windows thmeme manager) ‚Ö‚Ì“®“IƒAƒNƒZƒXƒNƒ‰ƒX
+	UxTheme (Windows thmeme manager) ã¸ã®å‹•çš„ã‚¢ã‚¯ã‚»ã‚¹ã‚¯ãƒ©ã‚¹
 
 	@author ryoji
 	@date Apr. 1, 2007
@@ -62,9 +62,9 @@ enum TABITEMSTATES {
 #include "util/design_template.h"
 
 /*!
-	@brief UxTheme “®“Iƒ[ƒh
+	@brief UxTheme å‹•çš„ãƒ­ãƒ¼ãƒ‰
 
-	UxTheme ƒRƒ“ƒ|[ƒlƒ“ƒg‚Ì“®“Iƒ[ƒh‚ğƒTƒ|[ƒg‚·‚éƒNƒ‰ƒX
+	UxTheme ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®å‹•çš„ãƒ­ãƒ¼ãƒ‰ã‚’ã‚µãƒãƒ¼ãƒˆã™ã‚‹ã‚¯ãƒ©ã‚¹
 */
 class CUxTheme : public TSingleton<CUxTheme>, public CDllImp {
 	friend class TSingleton<CUxTheme>;


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/extmodule
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112
