### PR TITLE
func 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/func/CFuncKeyWnd.cpp
+++ b/sakura_core/func/CFuncKeyWnd.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[ƒEƒBƒ“ƒhƒE
+ï»¿/*!	@file
+	@brief ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
 
 	@author Norio Nakatani
 */
@@ -52,30 +52,30 @@ LRESULT CALLBACK CFuncKeyWndProc(
 
 
 
-//	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+//	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 CFuncKeyWnd::CFuncKeyWnd()
 : CWnd(_T("::CFuncKeyWnd"))
 {
 	int		i;
 	LOGFONT	lf;
 	m_pcEditDoc = NULL;
-	/* ‹¤—Lƒf[ƒ^\‘¢‘Ì‚ÌƒAƒhƒŒƒX‚ğ•Ô‚· */
+	/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿æ§‹é€ ä½“ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‚’è¿”ã™ */
 	m_pShareData = &GetDllShareData();
 	m_nCurrentKeyState = -1;
 	for( i = 0; i < _countof(m_szFuncNameArr); ++i ){
 		m_szFuncNameArr[i][0] = LTEXT('\0');
 	}
-//	2002.11.04 Moca Open()‘¤‚Åİ’è
+//	2002.11.04 Moca Open()å´ã§è¨­å®š
 //	m_nButtonGroupNum = 4;
 
 	for( i = 0; i < _countof( m_hwndButtonArr ); ++i ){
 		m_hwndButtonArr[i] = NULL;
 	}
 
-	/* •\¦—pƒtƒHƒ“ƒg */
-	/* LOGFONT‚Ì‰Šú‰» */
+	/* è¡¨ç¤ºç”¨ãƒ•ã‚©ãƒ³ãƒˆ */
+	/* LOGFONTã®åˆæœŸåŒ– */
 	memset_raw( &lf, 0, sizeof(lf) );
-	lf.lfHeight			= DpiPointsToPixels(-9);	// 2009.10.01 ryoji ‚DPI‘Î‰iƒ|ƒCƒ“ƒg”‚©‚çZoj
+	lf.lfHeight			= DpiPointsToPixels(-9);	// 2009.10.01 ryoji é«˜DPIå¯¾å¿œï¼ˆãƒã‚¤ãƒ³ãƒˆæ•°ã‹ã‚‰ç®—å‡ºï¼‰
 	lf.lfWidth			= 0;
 	lf.lfEscapement		= 0;
 	lf.lfOrientation	= 0;
@@ -88,7 +88,7 @@ CFuncKeyWnd::CFuncKeyWnd()
 	lf.lfClipPrecision	= 0x2;
 	lf.lfQuality		= 0x1;
 	lf.lfPitchAndFamily	= 0x31;
-	_tcscpy( lf.lfFaceName, _T("‚l‚r ‚oƒSƒVƒbƒN") );
+	_tcscpy( lf.lfFaceName, _T("ï¼­ï¼³ ï¼°ã‚´ã‚·ãƒƒã‚¯") );
 	m_hFont = ::CreateFontIndirect( &lf );
 
 	m_bSizeBox = false;
@@ -103,7 +103,7 @@ CFuncKeyWnd::CFuncKeyWnd()
 
 CFuncKeyWnd::~CFuncKeyWnd()
 {
-	/* •\¦—pƒtƒHƒ“ƒg */
+	/* è¡¨ç¤ºç”¨ãƒ•ã‚©ãƒ³ãƒˆ */
 	::DeleteObject( m_hFont );
 	return;
 }
@@ -111,7 +111,7 @@ CFuncKeyWnd::~CFuncKeyWnd()
 
 
 
-/* ƒEƒBƒ“ƒhƒE ƒI[ƒvƒ“ */
+/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ ã‚ªãƒ¼ãƒ—ãƒ³ */
 HWND CFuncKeyWnd::Open( HINSTANCE hInstance, HWND hwndParent, CEditDoc* pCEditDoc, bool bSizeBox )
 {
 	LPCTSTR pszClassName = _T("CFuncKeyWnd");
@@ -121,13 +121,13 @@ HWND CFuncKeyWnd::Open( HINSTANCE hInstance, HWND hwndParent, CEditDoc* pCEditDo
 	m_hwndSizeBox = NULL;
 	m_nCurrentKeyState = -1;
 
-	// 2002.11.04 Moca •ÏX‚Å‚«‚é‚æ‚¤‚É
+	// 2002.11.04 Moca å¤‰æ›´ã§ãã‚‹ã‚ˆã†ã«
 	m_nButtonGroupNum = m_pShareData->m_Common.m_sWindow.m_nFUNCKEYWND_GroupNum;
 	if( 1 > m_nButtonGroupNum || 12 < m_nButtonGroupNum ){
 		m_nButtonGroupNum = 4;
 	}
 
-	/* ƒEƒBƒ“ƒhƒEƒNƒ‰ƒXì¬ */
+	/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚¯ãƒ©ã‚¹ä½œæˆ */
 	RegisterWC(
 		hInstance,
 		NULL,// Handle to the class icon.
@@ -138,16 +138,16 @@ HWND CFuncKeyWnd::Open( HINSTANCE hInstance, HWND hwndParent, CEditDoc* pCEditDo
 		pszClassName// Pointer to a null-terminated string or is an atom.
 	);
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒoŒÄ‚Ño‚µ */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒå‘¼ã³å‡ºã— */
 	CWnd::Create(
 		hwndParent,
 		0, // extended window style
 		pszClassName,	// Pointer to a null-terminated string or is an atom.
 		pszClassName, // pointer to window name
-		WS_CHILD/* | WS_VISIBLE*/ | WS_CLIPCHILDREN, // window style	// 2006.06.17 ryoji WS_CLIPCHILDREN ’Ç‰Á	// 2007.03.08 ryoji WS_VISIBLE œ‹
+		WS_CHILD/* | WS_VISIBLE*/ | WS_CLIPCHILDREN, // window style	// 2006.06.17 ryoji WS_CLIPCHILDREN è¿½åŠ 	// 2007.03.08 ryoji WS_VISIBLE é™¤å»
 		CW_USEDEFAULT, // horizontal position of window
 		0, // vertical position of window
-		0, // window width	// 2007.02.05 ryoji 100->0i”¼’[‚ÈƒTƒCƒY‚Åˆêu•\¦‚³‚ê‚é‚æ‚èŒ©‚¦‚È‚¢‚Ù‚¤‚ª‚¢‚¢j
+		0, // window width	// 2007.02.05 ryoji 100->0ï¼ˆåŠç«¯ãªã‚µã‚¤ã‚ºã§ä¸€ç¬è¡¨ç¤ºã•ã‚Œã‚‹ã‚ˆã‚Šè¦‹ãˆãªã„ã»ã†ãŒã„ã„ï¼‰
 		::GetSystemMetrics( SM_CYMENU ), // window height
 		NULL // handle to menu, or child-window identifier
 	);
@@ -171,11 +171,11 @@ HWND CFuncKeyWnd::Open( HINSTANCE hInstance, HWND hwndParent, CEditDoc* pCEditDo
 		);
 	}
 
-	/* ƒ{ƒ^ƒ“‚Ì¶¬ */
+	/* ãƒœã‚¿ãƒ³ã®ç”Ÿæˆ */
 	CreateButtons();
 
 	Timer_ONOFF( true ); // 20060126 aroka
-	OnTimer( GetHwnd(), WM_TIMER, IDT_FUNCWND, ::GetTickCount() );	// ‰‰ñXV	// 2006.12.20 ryoji
+	OnTimer( GetHwnd(), WM_TIMER, IDT_FUNCWND, ::GetTickCount() );	// åˆå›æ›´æ–°	// 2006.12.20 ryoji
 
 	return GetHwnd();
 }
@@ -183,7 +183,7 @@ HWND CFuncKeyWnd::Open( HINSTANCE hInstance, HWND hwndParent, CEditDoc* pCEditDo
 
 
 
-/* ƒEƒBƒ“ƒhƒE ƒNƒ[ƒY */
+/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ ã‚¯ãƒ­ãƒ¼ã‚º */
 void CFuncKeyWnd::Close( void )
 {
 	this->DestroyWindow();
@@ -193,12 +193,12 @@ void CFuncKeyWnd::Close( void )
 
 
 
-///* WM_SIZEˆ— */
+///* WM_SIZEå‡¦ç† */
 //void CFuncKeyWnd::OnSize(
 //	WPARAM	wParam,	// first message parameter
 //	LPARAM	lParam 	// second message parameter
 
-// WM_SIZEˆ—
+// WM_SIZEå‡¦ç†
 LRESULT CFuncKeyWnd::OnSize( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	int			nButtonWidth;
@@ -215,7 +215,7 @@ LRESULT CFuncKeyWnd::OnSize( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam 
 
 	nButtonNum = _countof( m_hwndButtonArr );
 
-	/* ƒ{ƒ^ƒ“‚ÌƒTƒCƒY‚ğŒvZ */
+	/* ãƒœã‚¿ãƒ³ã®ã‚µã‚¤ã‚ºã‚’è¨ˆç®— */
 	nButtonWidth = CalcButtonSize();
 
 	::GetWindowRect( GetHwnd(), &rcParent );
@@ -229,7 +229,7 @@ LRESULT CFuncKeyWnd::OnSize( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam 
 		::MoveWindow( m_hwndButtonArr[i], nX, 1, nButtonWidth, nButtonHeight, TRUE );
 		nX += nButtonWidth + 1;
 	}
-	::InvalidateRect( GetHwnd(), NULL, TRUE );	//Ä•`‰æ‚µ‚Ä‚ËB	//@@@ 2003.06.11 MIK
+	::InvalidateRect( GetHwnd(), NULL, TRUE );	//å†æç”»ã—ã¦ã­ã€‚	//@@@ 2003.06.11 MIK
 	return 0L;
 }
 
@@ -288,7 +288,7 @@ LRESULT CFuncKeyWnd::OnCommand( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 }
 
 
-// WM_TIMERƒ^ƒCƒ}[‚Ìˆ—
+// WM_TIMERã‚¿ã‚¤ãƒãƒ¼ã®å‡¦ç†
 LRESULT CFuncKeyWnd::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 // 	HWND hwnd,	// handle of window for timer messages
@@ -302,7 +302,7 @@ LRESULT CFuncKeyWnd::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 		return 0;
 	}
 
-	if( ::GetActiveWindow() != GetParentHwnd() && m_nCurrentKeyState != -1 ) {	//	2002/06/02 MIK	// 2006.12.20 ryoji ‰‰ñXV‚Íˆ—‚·‚é
+	if( ::GetActiveWindow() != GetParentHwnd() && m_nCurrentKeyState != -1 ) {	//	2002/06/02 MIK	// 2006.12.20 ryoji åˆå›æ›´æ–°ã¯å‡¦ç†ã™ã‚‹
 		return 0;
 	}
 
@@ -311,15 +311,15 @@ LRESULT CFuncKeyWnd::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 	int			i;
 
 // novice 2004/10/10
-	/* Shift,Ctrl,AltƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚½‚© */
+	/* Shift,Ctrl,Altã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãŸã‹ */
 	nIdx = getCtrlKeyState();
-	/* ALT,Shift,CtrlƒL[‚Ìó‘Ô‚ª•Ï‰»‚µ‚½‚© */
+	/* ALT,Shift,Ctrlã‚­ãƒ¼ã®çŠ¶æ…‹ãŒå¤‰åŒ–ã—ãŸã‹ */
 	if( nIdx != m_nCurrentKeyState ){
 		m_nTimerCount = TIMER_CHECKFUNCENABLE + 1;
 
-		/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚Ì‹@”\–¼‚ğæ“¾ */
+		/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®æ©Ÿèƒ½åã‚’å–å¾— */
 		for( i = 0; i < _countof( m_szFuncNameArr ); ++i ){
-			// 2007.02.22 ryoji CKeyBind::GetFuncCode()‚ğg‚¤
+			// 2007.02.22 ryoji CKeyBind::GetFuncCode()ã‚’ä½¿ã†
 			EFunctionCode	nFuncCode = CKeyBind::GetFuncCode(
 					(WORD)(((VK_F1 + i) | ((WORD)((BYTE)(nIdx))) << 8)),
 					m_pShareData->m_Common.m_sKeyBind.m_nKeyNameArrNum,
@@ -346,7 +346,7 @@ LRESULT CFuncKeyWnd::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 		nIdx != m_nCurrentKeyState
 	){
 		m_nTimerCount = 0;
-		/* ‹@”\‚ª—˜—p‰Â”\‚©’²‚×‚é */
+		/* æ©Ÿèƒ½ãŒåˆ©ç”¨å¯èƒ½ã‹èª¿ã¹ã‚‹ */
 		for( i = 0; i < _countof(	m_szFuncNameArr ); ++i ){
 			if( IsFuncEnable( (CEditDoc*)m_pcEditDoc, m_pShareData, m_nFuncCodeArr[i]  ) ){
 				::EnableWindow( m_hwndButtonArr[i], TRUE );
@@ -360,15 +360,15 @@ LRESULT CFuncKeyWnd::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 }
 
 
-// WM_DESTROYˆ—
+// WM_DESTROYå‡¦ç†
 LRESULT CFuncKeyWnd::OnDestroy( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	int i;
 
-	/* ƒ^ƒCƒ}[‚ğíœ */
+	/* ã‚¿ã‚¤ãƒãƒ¼ã‚’å‰Šé™¤ */
 	Timer_ONOFF( false ); // 20060126 aroka
 
-	/* ƒ{ƒ^ƒ“‚ğíœ */
+	/* ãƒœã‚¿ãƒ³ã‚’å‰Šé™¤ */
 	for( i = 0; i < _countof( m_hwndButtonArr ); ++i ){
 		if( NULL != m_hwndButtonArr[i] ){
 			::DestroyWindow( m_hwndButtonArr[i]	);
@@ -376,7 +376,7 @@ LRESULT CFuncKeyWnd::OnDestroy( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 		}
 	}
 
-	/* ƒTƒCƒYƒ{ƒbƒNƒX‚ğíœ */
+	/* ã‚µã‚¤ã‚ºãƒœãƒƒã‚¯ã‚¹ã‚’å‰Šé™¤ */
 	if( NULL != m_hwndSizeBox ){
 		::DestroyWindow( m_hwndSizeBox );
 		m_hwndSizeBox = NULL;
@@ -389,7 +389,7 @@ LRESULT CFuncKeyWnd::OnDestroy( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 
 
 
-/*! ƒ{ƒ^ƒ“‚ÌƒTƒCƒY‚ğŒvZ */
+/*! ãƒœã‚¿ãƒ³ã®ã‚µã‚¤ã‚ºã‚’è¨ˆç®— */
 int CFuncKeyWnd::CalcButtonSize( void )
 {
 	int			nButtonNum;
@@ -404,7 +404,7 @@ int CFuncKeyWnd::CalcButtonSize( void )
 //		return ( rc.right - rc.left - nButtonNum - ( (nButtonNum + m_nButtonGroupNum - 1) / m_nButtonGroupNum - 1 ) * 12 ) / nButtonNum;
 		nCxVScroll = 0;
 	}else{
-		/* ƒTƒCƒYƒ{ƒbƒNƒX‚ÌˆÊ’uAƒTƒCƒY•ÏX */
+		/* ã‚µã‚¤ã‚ºãƒœãƒƒã‚¯ã‚¹ã®ä½ç½®ã€ã‚µã‚¤ã‚ºå¤‰æ›´ */
 		nCyHScroll = ::GetSystemMetrics( SM_CYHSCROLL );
 		nCxVScroll = ::GetSystemMetrics( SM_CXVSCROLL );
 		::MoveWindow( m_hwndSizeBox,  rc.right - rc.left - nCxVScroll, rc.bottom - rc.top - nCyHScroll, nCxVScroll, nCyHScroll, TRUE );
@@ -418,8 +418,8 @@ int CFuncKeyWnd::CalcButtonSize( void )
 
 
 
-/*! ƒ{ƒ^ƒ“‚Ì¶¬
-	@date 2007.02.05 ryoji ƒ{ƒ^ƒ“‚Ì…•½ˆÊ’uE•‚Ìİ’èˆ—‚ğíœiOnSize‚ÅÄ”z’u‚³‚ê‚é‚Ì‚Å•s—vj
+/*! ãƒœã‚¿ãƒ³ã®ç”Ÿæˆ
+	@date 2007.02.05 ryoji ãƒœã‚¿ãƒ³ã®æ°´å¹³ä½ç½®ãƒ»å¹…ã®è¨­å®šå‡¦ç†ã‚’å‰Šé™¤ï¼ˆOnSizeã§å†é…ç½®ã•ã‚Œã‚‹ã®ã§ä¸è¦ï¼‰
 */
 void CFuncKeyWnd::CreateButtons( void )
 {
@@ -450,7 +450,7 @@ void CFuncKeyWnd::CreateButtons( void )
 			(HINSTANCE) GetWindowLongPtr(GetHwnd(), GWLP_HINSTANCE),	// Modified by KEITA for WIN64 2003.9.6
 			NULL				// pointer not needed
 		);
-		/* ƒtƒHƒ“ƒg•ÏX */
+		/* ãƒ•ã‚©ãƒ³ãƒˆå¤‰æ›´ */
 		::SendMessageAny( m_hwndButtonArr[i], WM_SETFONT, (WPARAM)m_hFont, MAKELPARAM(TRUE, 0) );
 	}
 	m_nCurrentKeyState = -1;
@@ -460,7 +460,7 @@ void CFuncKeyWnd::CreateButtons( void )
 
 
 
-/*! ƒTƒCƒYƒ{ƒbƒNƒX‚Ì•\¦^”ñ•\¦Ø‚è‘Ö‚¦ */
+/*! ã‚µã‚¤ã‚ºãƒœãƒƒã‚¯ã‚¹ã®è¡¨ç¤ºï¼éè¡¨ç¤ºåˆ‡ã‚Šæ›¿ãˆ */
 void CFuncKeyWnd::SizeBox_ONOFF( bool bSizeBox )
 {
 
@@ -498,20 +498,20 @@ void CFuncKeyWnd::SizeBox_ONOFF( bool bSizeBox )
 
 
 
-// ƒ^ƒCƒ}[‚ÌXV‚ğŠJn^’â~‚·‚éB 20060126 aroka
-// ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\¦‚Íƒ^ƒCƒ}[‚É‚æ‚èXV‚µ‚Ä‚¢‚é‚ªA
-// ƒAƒvƒŠ‚ÌƒtƒH[ƒJƒX‚ªŠO‚ê‚½‚Æ‚«‚ÉeƒEƒBƒ“ƒhƒE‚©‚çON/OFF‚ğ
-//	ŒÄ‚Ño‚µ‚Ä‚à‚ç‚¤‚±‚Æ‚É‚æ‚èA—]Œv‚È•‰‰×‚ğ’â~‚µ‚½‚¢B
+// ã‚¿ã‚¤ãƒãƒ¼ã®æ›´æ–°ã‚’é–‹å§‹ï¼åœæ­¢ã™ã‚‹ã€‚ 20060126 aroka
+// ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤ºã¯ã‚¿ã‚¤ãƒãƒ¼ã«ã‚ˆã‚Šæ›´æ–°ã—ã¦ã„ã‚‹ãŒã€
+// ã‚¢ãƒ—ãƒªã®ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ãŒå¤–ã‚ŒãŸã¨ãã«è¦ªã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‹ã‚‰ON/OFFã‚’
+//	å‘¼ã³å‡ºã—ã¦ã‚‚ã‚‰ã†ã“ã¨ã«ã‚ˆã‚Šã€ä½™è¨ˆãªè² è·ã‚’åœæ­¢ã—ãŸã„ã€‚
 void CFuncKeyWnd::Timer_ONOFF( bool bStart )
 {
 	if( NULL != GetHwnd() ){
 		if( bStart ){
-			/* ƒ^ƒCƒ}[‚ğ‹N“® */
+			/* ã‚¿ã‚¤ãƒãƒ¼ã‚’èµ·å‹• */
 			if( 0 == ::SetTimer( GetHwnd(), IDT_FUNCWND, TIMER_TIMEOUT, NULL ) ){
 				WarningMessage(	GetHwnd(), LS(STR_ERR_DLGFUNCKEYWN1) );
 			}
 		} else {
-			/* ƒ^ƒCƒ}[‚ğíœ */
+			/* ã‚¿ã‚¤ãƒãƒ¼ã‚’å‰Šé™¤ */
 			::KillTimer( GetHwnd(), IDT_FUNCWND );
 			m_nCurrentKeyState = -1;
 		}

--- a/sakura_core/func/CFuncKeyWnd.h
+++ b/sakura_core/func/CFuncKeyWnd.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[ƒEƒBƒ“ƒhƒE
+ï»¿/*!	@file
+	@brief ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
 
 	@author Norio Nakatani
 */
@@ -21,8 +21,8 @@
 struct DLLSHAREDATA;
 class CEditDoc; // 2002/2/10 aroka
 
-//! ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[ƒEƒBƒ“ƒhƒE
-//	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ð‚Æ‚Â‚ ‚é‚Ì‚ÝB
+//! ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+//	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 class CFuncKeyWnd : public CWnd
 {
 public:
@@ -32,43 +32,43 @@ public:
 	CFuncKeyWnd();
 	virtual ~CFuncKeyWnd();
 	/*
-	|| ƒƒ“ƒoŠÖ”
+	|| ãƒ¡ãƒ³ãƒé–¢æ•°
 	*/
-	HWND Open( HINSTANCE, HWND, CEditDoc*, bool );	/* ƒEƒBƒ“ƒhƒE ƒI[ƒvƒ“ */
-	void Close( void );	/* ƒEƒBƒ“ƒhƒE ƒNƒ[ƒY */
-	void SizeBox_ONOFF( bool );	/* ƒTƒCƒYƒ{ƒbƒNƒX‚Ì•\Ž¦^”ñ•\Ž¦Ø‚è‘Ö‚¦ */
-	void Timer_ONOFF( bool ); /* XV‚ÌŠJŽn^’âŽ~ 20060126 aroka */
+	HWND Open( HINSTANCE, HWND, CEditDoc*, bool );	/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ ã‚ªãƒ¼ãƒ—ãƒ³ */
+	void Close( void );	/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ ã‚¯ãƒ­ãƒ¼ã‚º */
+	void SizeBox_ONOFF( bool );	/* ã‚µã‚¤ã‚ºãƒœãƒƒã‚¯ã‚¹ã®è¡¨ç¤ºï¼éžè¡¨ç¤ºåˆ‡ã‚Šæ›¿ãˆ */
+	void Timer_ONOFF( bool ); /* æ›´æ–°ã®é–‹å§‹ï¼åœæ­¢ 20060126 aroka */
 	/*
-	|| ƒƒ“ƒo•Ï”
+	|| ãƒ¡ãƒ³ãƒå¤‰æ•°
 	*/
 private:
-	// 20060126 aroka ‚·‚×‚ÄPrivate‚É‚µ‚ÄA‰Šú‰»‡˜‚É‡‚í‚¹‚Ä•À‚×‘Ö‚¦
+	// 20060126 aroka ã™ã¹ã¦Privateã«ã—ã¦ã€åˆæœŸåŒ–é †åºã«åˆã‚ã›ã¦ä¸¦ã¹æ›¿ãˆ
 	CEditDoc*		m_pcEditDoc;
 	DLLSHAREDATA*	m_pShareData;
 	int				m_nCurrentKeyState;
 	WCHAR			m_szFuncNameArr[12][256];
 	HWND			m_hwndButtonArr[12];
-	HFONT			m_hFont;	/*!< •\Ž¦—pƒtƒHƒ“ƒg */
+	HFONT			m_hFont;	/*!< è¡¨ç¤ºç”¨ãƒ•ã‚©ãƒ³ãƒˆ */
 	bool			m_bSizeBox;
 	HWND			m_hwndSizeBox;
 	int				m_nTimerCount;
-	int				m_nButtonGroupNum; // Open‚Å‰Šú‰»
-	EFunctionCode	m_nFuncCodeArr[12]; // Open->CreateButtons‚Å‰Šú‰»
+	int				m_nButtonGroupNum; // Openã§åˆæœŸåŒ–
+	EFunctionCode	m_nFuncCodeArr[12]; // Open->CreateButtonsã§åˆæœŸåŒ–
 protected:
 	/*
-	|| ŽÀ‘•ƒwƒ‹ƒpŒn
+	|| å®Ÿè£…ãƒ˜ãƒ«ãƒ‘ç³»
 	*/
-	void CreateButtons( void );	/* ƒ{ƒ^ƒ“‚Ì¶¬ */
-	int CalcButtonSize( void );	/* ƒ{ƒ^ƒ“‚ÌƒTƒCƒY‚ðŒvŽZ */
+	void CreateButtons( void );	/* ãƒœã‚¿ãƒ³ã®ç”Ÿæˆ */
+	int CalcButtonSize( void );	/* ãƒœã‚¿ãƒ³ã®ã‚µã‚¤ã‚ºã‚’è¨ˆç®— */
 
-	/* ‰¼‘zŠÖ” */
-	virtual void AfterCreateWindow( void ){}	// ƒEƒBƒ“ƒhƒEì¬Œã‚Ìˆ—	// 2007.03.13 ryoji ‰ÂŽ‹‰»‚µ‚È‚¢
+	/* ä»®æƒ³é–¢æ•° */
+	virtual void AfterCreateWindow( void ){}	// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä½œæˆå¾Œã®å‡¦ç†	// 2007.03.13 ryoji å¯è¦–åŒ–ã—ãªã„
 
-	/* ‰¼‘zŠÖ” ƒƒbƒZ[ƒWˆ— Ú‚µ‚­‚ÍŽÀ‘•‚ðŽQÆ */
-	virtual LRESULT OnTimer( HWND, UINT, WPARAM, LPARAM );	// WM_TIMERƒ^ƒCƒ}[‚Ìˆ—
-	virtual LRESULT OnCommand( HWND, UINT, WPARAM, LPARAM );	// WM_COMMANDˆ—
-	virtual LRESULT OnSize( HWND, UINT, WPARAM, LPARAM );// WM_SIZEˆ—
-	virtual LRESULT OnDestroy( HWND, UINT, WPARAM, LPARAM );// WM_DESTROYˆ—
+	/* ä»®æƒ³é–¢æ•° ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† è©³ã—ãã¯å®Ÿè£…ã‚’å‚ç…§ */
+	virtual LRESULT OnTimer( HWND, UINT, WPARAM, LPARAM );	// WM_TIMERã‚¿ã‚¤ãƒžãƒ¼ã®å‡¦ç†
+	virtual LRESULT OnCommand( HWND, UINT, WPARAM, LPARAM );	// WM_COMMANDå‡¦ç†
+	virtual LRESULT OnSize( HWND, UINT, WPARAM, LPARAM );// WM_SIZEå‡¦ç†
+	virtual LRESULT OnDestroy( HWND, UINT, WPARAM, LPARAM );// WM_DESTROYå‡¦ç†
 };
 
 

--- a/sakura_core/func/CFuncLookup.cpp
+++ b/sakura_core/func/CFuncLookup.cpp
@@ -1,11 +1,11 @@
-/*!	@file
-	@brief •\¦—p•¶š—ñ“™‚Ìæ“¾
+ï»¿/*!	@file
+	@brief è¡¨ç¤ºç”¨æ–‡å­—åˆ—ç­‰ã®å–å¾—
 
-	‹@”\–¼C‹@”\•ª—ŞC‹@”\”Ô†‚È‚Ç‚Ì•ÏŠ·Dİ’è‰æ–Ê‚Å‚Ì•\¦—p•¶š—ñ‚ğ—pˆÓ‚·‚éD
+	æ©Ÿèƒ½åï¼Œæ©Ÿèƒ½åˆ†é¡ï¼Œæ©Ÿèƒ½ç•ªå·ãªã©ã®å¤‰æ›ï¼è¨­å®šç”»é¢ã§ã®è¡¨ç¤ºç”¨æ–‡å­—åˆ—ã‚’ç”¨æ„ã™ã‚‹ï¼
 
 	@author genta
-	@date Oct.  1, 2001 ƒ}ƒNƒ
-	@date Oct. 15, 2001 ƒJƒXƒ^ƒ€ƒƒjƒ…[
+	@date Oct.  1, 2001 ãƒã‚¯ãƒ­
+	@date Oct. 15, 2001 ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼
 */
 /*
 	Copyright (C) 2001, genta
@@ -36,20 +36,20 @@
 #include "func/CFuncLookup.h"
 #include "plugin/CJackManager.h"
 
-//	ƒIƒtƒZƒbƒg’l
+//	ã‚ªãƒ•ã‚»ãƒƒãƒˆå€¤
 const int LUOFFSET_MACRO = 0;
 const int LUOFFSET_CUSTMENU = 1;
 const int LUOFFSET_PLUGIN = 2;
 
-/*!	@brief •ª—Ş’†‚ÌˆÊ’u‚É‘Î‰‚·‚é‹@”\”Ô†‚ğ•Ô‚·D
+/*!	@brief åˆ†é¡ä¸­ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½ç•ªå·ã‚’è¿”ã™ï¼
 
-	@param category [in] •ª—Ş”Ô† (0-)
-	@param position [in] •ª—Ş’†‚Ìindex (0-)
-	@param bGetUnavailable [in] –¢“o˜^ƒ}ƒNƒ‚Å‚à‹@”\”Ô†‚ğ•Ô‚·
+	@param category [in] åˆ†é¡ç•ªå· (0-)
+	@param position [in] åˆ†é¡ä¸­ã®index (0-)
+	@param bGetUnavailable [in] æœªç™»éŒ²ãƒã‚¯ãƒ­ã§ã‚‚æ©Ÿèƒ½ç•ªå·ã‚’è¿”ã™
 
-	@retval ‹@”\”Ô†
+	@retval æ©Ÿèƒ½ç•ªå·
 
-	@date 2007.11.02 ryoji bGetUnavailableƒpƒ‰ƒ[ƒ^’Ç‰Á
+	@date 2007.11.02 ryoji bGetUnavailableãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿è¿½åŠ 
 */
 EFunctionCode CFuncLookup::Pos2FuncCode( int category, int position, bool bGetUnavailable ) const
 {
@@ -61,54 +61,54 @@ EFunctionCode CFuncLookup::Pos2FuncCode( int category, int position, bool bGetUn
 			return nsFuncCode::ppnFuncListArr[category][position];
 	}
 	else if( category == nsFuncCode::nFuncKindNum + LUOFFSET_MACRO ){
-		//	ƒL[Š„‚è“–‚Äƒ}ƒNƒ
+		//	ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ãƒã‚¯ãƒ­
 		if( position < MAX_CUSTMACRO ){
 			if( bGetUnavailable || m_pMacroRec[position].IsEnabled() )
 				return (EFunctionCode)(F_USERMACRO_0 + position);
 		}
 	}
 	else if( category == nsFuncCode::nFuncKindNum + LUOFFSET_CUSTMENU ){
-		//	ƒJƒXƒ^ƒ€ƒƒjƒ…[
+		//	ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼
 		if( position == 0 )
 			return F_MENU_RBUTTON;
 		else if( position < MAX_CUSTOM_MENU )
 			return (EFunctionCode)(F_CUSTMENU_BASE + position);
 	}
 	else if( category == nsFuncCode::nFuncKindNum + LUOFFSET_PLUGIN ){
-		//	ƒvƒ‰ƒOƒCƒ“
+		//	ãƒ—ãƒ©ã‚°ã‚¤ãƒ³
 		return CJackManager::getInstance()->GetCommandCode( position );
 	}
 	return F_DISABLE;
 }
 
-/*!	@brief •ª—Ş’†‚ÌˆÊ’u‚É‘Î‰‚·‚é‹@”\–¼Ì‚ğ•Ô‚·D
+/*!	@brief åˆ†é¡ä¸­ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½åç§°ã‚’è¿”ã™ï¼
 
-	@retval true w’è‚³‚ê‚½‹@”\”Ô†‚Í’è‹`‚³‚ê‚Ä‚¢‚é
-	@retval false w’è‚³‚ê‚½‹@”\”Ô†‚Í–¢’è‹`
+	@retval true æŒ‡å®šã•ã‚ŒãŸæ©Ÿèƒ½ç•ªå·ã¯å®šç¾©ã•ã‚Œã¦ã„ã‚‹
+	@retval false æŒ‡å®šã•ã‚ŒãŸæ©Ÿèƒ½ç•ªå·ã¯æœªå®šç¾©
 
-	@date 2007.11.02 ryoji ˆ—‚ğŠÈ‘f‰»
+	@date 2007.11.02 ryoji å‡¦ç†ã‚’ç°¡ç´ åŒ–
 */
 bool CFuncLookup::Pos2FuncName(
-	int		category,	//!< [in]  •ª—Ş”Ô† (0-)
-	int		position,	//!< [in]  •ª—Ş’†‚Ìindex (0-)
-	WCHAR*	ptr,		//!< [out] •¶š—ñ‚ğŠi”[‚·‚éƒoƒbƒtƒ@‚Ìæ“ª
-	int		bufsize		//!< [in]  •¶š—ñ‚ğŠi”[‚·‚éƒoƒbƒtƒ@‚ÌƒTƒCƒY
+	int		category,	//!< [in]  åˆ†é¡ç•ªå· (0-)
+	int		position,	//!< [in]  åˆ†é¡ä¸­ã®index (0-)
+	WCHAR*	ptr,		//!< [out] æ–‡å­—åˆ—ã‚’æ ¼ç´ã™ã‚‹ãƒãƒƒãƒ•ã‚¡ã®å…ˆé ­
+	int		bufsize		//!< [in]  æ–‡å­—åˆ—ã‚’æ ¼ç´ã™ã‚‹ãƒãƒƒãƒ•ã‚¡ã®ã‚µã‚¤ã‚º
 ) const
 {
 	int funccode = Pos2FuncCode( category, position );
 	return Funccode2Name( funccode, ptr, bufsize );
 }
 
-/*!	@brief ‹@”\”Ô†‚É‘Î‰‚·‚é‹@”\–¼Ì‚ğ•Ô‚·D
+/*!	@brief æ©Ÿèƒ½ç•ªå·ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½åç§°ã‚’è¿”ã™ï¼
 
-	@param funccode [in] ‹@”\”Ô†
-	@param ptr [out] •¶š—ñ‚ğŠi”[‚·‚éƒoƒbƒtƒ@‚Ìæ“ª
-	@param bufsize [in] •¶š—ñ‚ğŠi”[‚·‚éƒoƒbƒtƒ@‚ÌƒTƒCƒY
+	@param funccode [in] æ©Ÿèƒ½ç•ªå·
+	@param ptr [out] æ–‡å­—åˆ—ã‚’æ ¼ç´ã™ã‚‹ãƒãƒƒãƒ•ã‚¡ã®å…ˆé ­
+	@param bufsize [in] æ–‡å­—åˆ—ã‚’æ ¼ç´ã™ã‚‹ãƒãƒƒãƒ•ã‚¡ã®ã‚µã‚¤ã‚º
 
-	@retval true w’è‚³‚ê‚½‹@”\”Ô†‚Í’è‹`‚³‚ê‚Ä‚¢‚é
-	@retval false w’è‚³‚ê‚½‹@”\”Ô†‚Í–¢’è‹`
+	@retval true æŒ‡å®šã•ã‚ŒãŸæ©Ÿèƒ½ç•ªå·ã¯å®šç¾©ã•ã‚Œã¦ã„ã‚‹
+	@retval false æŒ‡å®šã•ã‚ŒãŸæ©Ÿèƒ½ç•ªå·ã¯æœªå®šç¾©
 
-	@date 2007.11.02 ryoji –¢“o˜^ƒ}ƒNƒ‚à•¶š—ñ‚ğŠi”[D–ß‚è’l‚ÌˆÓ–¡‚ğ•ÏXi•¶š—ñ‚Í•K‚¸Ši”[jD
+	@date 2007.11.02 ryoji æœªç™»éŒ²ãƒã‚¯ãƒ­ã‚‚æ–‡å­—åˆ—ã‚’æ ¼ç´ï¼æˆ»ã‚Šå€¤ã®æ„å‘³ã‚’å¤‰æ›´ï¼ˆæ–‡å­—åˆ—ã¯å¿…ãšæ ¼ç´ï¼‰ï¼
 */
 bool CFuncLookup::Funccode2Name( int funccode, WCHAR* ptr, int bufsize ) const
 {
@@ -143,40 +143,40 @@ bool CFuncLookup::Funccode2Name( int funccode, WCHAR* ptr, int bufsize ) const
 		if( ( pszStr = LSW( funccode ) )[0] != L'\0' ){
 			wcsncpy( ptr, pszStr, bufsize );
 			ptr[bufsize-1] = LTEXT('\0');
-			return true;	// ’è‹`‚³‚ê‚½ƒRƒ}ƒ“ƒh
+			return true;	// å®šç¾©ã•ã‚ŒãŸã‚³ãƒãƒ³ãƒ‰
 		}
 	}
 	else if( F_PLUGCOMMAND_FIRST <= funccode && funccode < F_PLUGCOMMAND_LAST ){
 		if( CJackManager::getInstance()->GetCommandName( funccode, ptr, bufsize ) > 0 ){
-			return true;	// ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh
+			return true;	// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰
 		}
 	}
 
-	// –¢’è‹`ƒRƒ}ƒ“ƒh(‚Ü‚½‚ÍŒ»İ‚ÌƒvƒƒZƒX‚Å‚Íƒ[ƒh‚³‚ê‚Ä‚¢‚È‚¢ƒvƒ‰ƒOƒCƒ“‚È‚Ç)
+	// æœªå®šç¾©ã‚³ãƒãƒ³ãƒ‰(ã¾ãŸã¯ç¾åœ¨ã®ãƒ—ãƒ­ã‚»ã‚¹ã§ã¯ãƒ­ãƒ¼ãƒ‰ã•ã‚Œã¦ã„ãªã„ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãªã©)
 	if( ( pszStr = LSW( funccode ) )[0] != L'\0' ){
 		wcsncpy( ptr, pszStr, bufsize );
 		ptr[bufsize-1] = LTEXT('\0');
 		return false;
 	}
 
-	// ‚È‚É‚©ƒRƒs[‚µ‚È‚¢‚Æƒ‹[ƒvˆ—‚È‚Ç‚Åˆê‚Â‘O‚Ì–¼‘O‚É‚È‚é‚±‚Æ‚ª‚ ‚é‚Ì‚Å(-- •s–¾ --)‚ğƒRƒs[‚µ‚Ä‚¨‚­
+	// ãªã«ã‹ã‚³ãƒ”ãƒ¼ã—ãªã„ã¨ãƒ«ãƒ¼ãƒ—å‡¦ç†ãªã©ã§ä¸€ã¤å‰ã®åå‰ã«ãªã‚‹ã“ã¨ãŒã‚ã‚‹ã®ã§(-- ä¸æ˜ --)ã‚’ã‚³ãƒ”ãƒ¼ã—ã¦ãŠã
 	if( ( pszStr = LSW( F_DISABLE ) )[0] != L'\0' ){
 		wcsncpy( ptr, pszStr, bufsize );
 		ptr[bufsize-1] = LTEXT('\0');
 		return false;
 	}
-	// ƒŠƒ\[ƒX‘S€–SƒK[ƒh
+	// ãƒªã‚½ãƒ¼ã‚¹å…¨æ­»äº¡ã‚¬ãƒ¼ãƒ‰
 	wcsncpy( ptr, L"unknown", bufsize );
 	ptr[bufsize-1] = LTEXT('\0');
 
 	return false;
 }
 
-/*!	@brief ‹@”\•ª—Ş”Ô†‚É‘Î‰‚·‚é‹@”\–¼Ì‚ğ•Ô‚·D
+/*!	@brief æ©Ÿèƒ½åˆ†é¡ç•ªå·ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½åç§°ã‚’è¿”ã™ï¼
 
-	@param category [in] ‹@”\•ª—Ş”Ô†
+	@param category [in] æ©Ÿèƒ½åˆ†é¡ç•ªå·
 	
-	@return NULL •ª—Ş–¼ÌDæ“¾‚É¸”s‚µ‚½‚çNULLD
+	@return NULL åˆ†é¡åç§°ï¼å–å¾—ã«å¤±æ•—ã—ãŸã‚‰NULLï¼
 */
 const TCHAR* CFuncLookup::Category2Name( int category ) const
 {
@@ -198,36 +198,36 @@ const TCHAR* CFuncLookup::Category2Name( int category ) const
 	return NULL;
 }
 
-/*!	@brief ComboBox‚É—˜—p‰Â”\‚È‹@”\•ª—Şˆê——‚ğ“o˜^‚·‚é
+/*!	@brief ComboBoxã«åˆ©ç”¨å¯èƒ½ãªæ©Ÿèƒ½åˆ†é¡ä¸€è¦§ã‚’ç™»éŒ²ã™ã‚‹
 
-	@param hComboBox [in(out)] ƒf[ƒ^‚ğİ’è‚·‚éƒRƒ“ƒ{ƒ{ƒbƒNƒX
+	@param hComboBox [in(out)] ãƒ‡ãƒ¼ã‚¿ã‚’è¨­å®šã™ã‚‹ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹
 */
 void CFuncLookup::SetCategory2Combo( HWND hComboBox ) const
 {
 	int i;
 
-	//	ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ğ‰Šú‰»‚·‚é
+	//	ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã‚’åˆæœŸåŒ–ã™ã‚‹
 	Combo_ResetContent( hComboBox );
 
-	//	ŒÅ’è‹@”\ƒŠƒXƒg
+	//	å›ºå®šæ©Ÿèƒ½ãƒªã‚¹ãƒˆ
 	for( i = 0; i < nsFuncCode::nFuncKindNum; ++i ){
 		Combo_AddString( hComboBox, LS( nsFuncCode::ppszFuncKind[i] ) );
 	}
 
-	//	ƒ†[ƒUƒ}ƒNƒ
+	//	ãƒ¦ãƒ¼ã‚¶ãƒã‚¯ãƒ­
 	Combo_AddString( hComboBox, LS( STR_ERR_DLGFUNCLKUP01 ) );
-	//	ƒJƒXƒ^ƒ€ƒƒjƒ…[
+	//	ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼
 	Combo_AddString( hComboBox, LS( STR_ERR_DLGFUNCLKUP02 ) );
-	//	ƒvƒ‰ƒOƒCƒ“
+	//	ãƒ—ãƒ©ã‚°ã‚¤ãƒ³
 	Combo_AddString( hComboBox, LS( STR_ERR_DLGFUNCLKUP19 ) );
 }
 
-/*!	@brief w’è‚³‚ê‚½•ª—Ş‚É‘®‚·‚é‹@”\ƒŠƒXƒg‚ğListBox‚É“o˜^‚·‚éD
+/*!	@brief æŒ‡å®šã•ã‚ŒãŸåˆ†é¡ã«å±ã™ã‚‹æ©Ÿèƒ½ãƒªã‚¹ãƒˆã‚’ListBoxã«ç™»éŒ²ã™ã‚‹ï¼
 	
-	@param hListBox [in(out)] ’l‚ğİ’è‚·‚éƒŠƒXƒgƒ{ƒbƒNƒX
-	@param category [in] ‹@”\•ª—Ş”Ô†
+	@param hListBox [in(out)] å€¤ã‚’è¨­å®šã™ã‚‹ãƒªã‚¹ãƒˆãƒœãƒƒã‚¯ã‚¹
+	@param category [in] æ©Ÿèƒ½åˆ†é¡ç•ªå·
 
-	@date 2007.11.02 ryoji –¢’è‹`ƒRƒ}ƒ“ƒh‚ÍœŠODˆ—‚àŠÈ‘f‰»D
+	@date 2007.11.02 ryoji æœªå®šç¾©ã‚³ãƒãƒ³ãƒ‰ã¯é™¤å¤–ï¼å‡¦ç†ã‚‚ç°¡ç´ åŒ–ï¼
 */
 void CFuncLookup::SetListItem( HWND hListBox, int category ) const
 {
@@ -235,7 +235,7 @@ void CFuncLookup::SetListItem( HWND hListBox, int category ) const
 	int n;
 	int i;
 
-	//	ƒŠƒXƒg‚ğ‰Šú‰»‚·‚é
+	//	ãƒªã‚¹ãƒˆã‚’åˆæœŸåŒ–ã™ã‚‹
 	List_ResetContent( hListBox );
 
 	n = GetItemCount( category );
@@ -248,9 +248,9 @@ void CFuncLookup::SetListItem( HWND hListBox, int category ) const
 }
 
 /*!
-	w’è•ª—Ş’†‚Ì‹@”\”‚ğæ“¾‚·‚éD
+	æŒ‡å®šåˆ†é¡ä¸­ã®æ©Ÿèƒ½æ•°ã‚’å–å¾—ã™ã‚‹ï¼
 	
-	@param category [in] ‹@”\•ª—Ş”Ô†
+	@param category [in] æ©Ÿèƒ½åˆ†é¡ç•ªå·
 */
 int CFuncLookup::GetItemCount(int category) const
 {
@@ -261,38 +261,38 @@ int CFuncLookup::GetItemCount(int category) const
 		return nsFuncCode::pnFuncListNumArr[category];
 	}
 	else if( category == nsFuncCode::nFuncKindNum + LUOFFSET_MACRO ){
-		//	ƒ}ƒNƒ
+		//	ãƒã‚¯ãƒ­
 		return MAX_CUSTMACRO;
 	}
 	else if( category == nsFuncCode::nFuncKindNum + LUOFFSET_CUSTMENU ){
-		//	ƒJƒXƒ^ƒ€ƒƒjƒ…[
+		//	ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼
 		return MAX_CUSTOM_MENU;
 	}
 	else if( category == nsFuncCode::nFuncKindNum + LUOFFSET_PLUGIN ){
-		//	ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh
+		//	ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰
 		return CJackManager::getInstance()->GetCommandCount();
 	}
 	return 0;
 }
 
-/*!	@brief ”Ô†‚É‘Î‰‚·‚éƒJƒXƒ^ƒ€ƒƒjƒ…[–¼Ì‚ğ•Ô‚·D
+/*!	@brief ç•ªå·ã«å¯¾å¿œã™ã‚‹ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼åç§°ã‚’è¿”ã™ï¼
 
-	@param index [in] ƒJƒXƒ^ƒ€ƒƒjƒ…[”Ô†
+	@param index [in] ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ç•ªå·
 	
-	@return NULL •ª—Ş–¼ÌDæ“¾‚É¸”s‚µ‚½‚çNULLD
+	@return NULL åˆ†é¡åç§°ï¼å–å¾—ã«å¤±æ•—ã—ãŸã‚‰NULLï¼
 */
 const WCHAR* CFuncLookup::Custmenu2Name( int index, WCHAR buf[], int bufSize ) const
 {
 	if( index < 0 || CUSTMENU_INDEX_FOR_TABWND < index )
 		return NULL;
 
-	// ‹¤’Êİ’è‚Å–¼Ì‚ğİ’è‚µ‚Ä‚¢‚ê‚Î‚»‚ê‚ğ•Ô‚·
+	// å…±é€šè¨­å®šã§åç§°ã‚’è¨­å®šã—ã¦ã„ã‚Œã°ãã‚Œã‚’è¿”ã™
 	if ( m_pCommon->m_sCustomMenu.m_szCustMenuNameArr[ index ][0] != '\0' ) {
 		wcscpyn( buf, m_pCommon->m_sCustomMenu.m_szCustMenuNameArr[ index ], bufSize );
 		return m_pCommon->m_sCustomMenu.m_szCustMenuNameArr[ index ];
 	}
 
-	// ‹¤’Êİ’è‚Å–¢İ’è‚Ìê‡AƒŠƒ\[ƒX‚ÌƒfƒtƒHƒ‹ƒg–¼‚ğ•Ô‚·
+	// å…±é€šè¨­å®šã§æœªè¨­å®šã®å ´åˆã€ãƒªã‚½ãƒ¼ã‚¹ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆåã‚’è¿”ã™
 	if( index == 0 ){
 		wcscpyn( buf, LSW( STR_CUSTMENU_RIGHT_CLICK ), bufSize );
 		return buf;

--- a/sakura_core/func/CFuncLookup.h
+++ b/sakura_core/func/CFuncLookup.h
@@ -1,7 +1,7 @@
-/*!	@file
-	@brief •\¦—p•¶š—ñ“™‚Ìæ“¾
+ï»¿/*!	@file
+	@brief è¡¨ç¤ºç”¨æ–‡å­—åˆ—ç­‰ã®å–å¾—
 
-	‹@”\–¼C‹@”\•ª—ŞC‹@”\”Ô†‚È‚Ç‚Ì•ÏŠ·Dİ’è‰æ–Ê‚Å‚Ì•\¦—p•¶š—ñ‚ğ—pˆÓ‚·‚éD
+	æ©Ÿèƒ½åï¼Œæ©Ÿèƒ½åˆ†é¡ï¼Œæ©Ÿèƒ½ç•ªå·ãªã©ã®å¤‰æ›ï¼è¨­å®šç”»é¢ã§ã®è¡¨ç¤ºç”¨æ–‡å­—åˆ—ã‚’ç”¨æ„ã™ã‚‹ï¼
 
 	@author genta
 	@date Oct. 1, 2001
@@ -42,26 +42,26 @@
 struct MacroRec;// 2007.11.02 ryoji
 struct CommonSetting;// 2002/2/10 aroka
 
-//! ƒ}ƒNƒî•ñ
+//! ãƒã‚¯ãƒ­æƒ…å ±
 struct MacroRec {
-	TCHAR	m_szName[MACRONAME_MAX];	//!< •\¦–¼
-	TCHAR	m_szFile[_MAX_PATH+1];	//!< ƒtƒ@ƒCƒ‹–¼(ƒfƒBƒŒƒNƒgƒŠ‚ğŠÜ‚Ü‚È‚¢)
-	bool	m_bReloadWhenExecute;	//	Às‚É“Ç‚İ‚İ‚È‚¨‚·‚©iƒfƒtƒHƒ‹ƒgonj
+	TCHAR	m_szName[MACRONAME_MAX];	//!< è¡¨ç¤ºå
+	TCHAR	m_szFile[_MAX_PATH+1];	//!< ãƒ•ã‚¡ã‚¤ãƒ«å(ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’å«ã¾ãªã„)
+	bool	m_bReloadWhenExecute;	//	å®Ÿè¡Œæ™‚ã«èª­ã¿è¾¼ã¿ãªãŠã™ã‹ï¼ˆãƒ‡ãƒ•ã‚©ãƒ«ãƒˆonï¼‰
 	
 	bool IsEnabled() const { return m_szFile[0] != _T('\0'); }
-	const TCHAR* GetTitle() const { return m_szName[0] == _T('\0') ? m_szFile: m_szName; }	// 2007.11.02 ryoji ’Ç‰Á
+	const TCHAR* GetTitle() const { return m_szName[0] == _T('\0') ? m_szFile: m_szName; }	// 2007.11.02 ryoji è¿½åŠ 
 };
 
 /*!
-	@brief •\¦—p•¶š—ñ“™‚Ìæ“¾
+	@brief è¡¨ç¤ºç”¨æ–‡å­—åˆ—ç­‰ã®å–å¾—
 
-	‹@”\C‹@”\•ª—Ş‚ÆˆÊ’uC‹@”\”Ô†C•¶š—ñ‚È‚Ç‚Ì‘Î‰‚ğW–ñ‚·‚éD
+	æ©Ÿèƒ½ï¼Œæ©Ÿèƒ½åˆ†é¡ã¨ä½ç½®ï¼Œæ©Ÿèƒ½ç•ªå·ï¼Œæ–‡å­—åˆ—ãªã©ã®å¯¾å¿œã‚’é›†ç´„ã™ã‚‹ï¼
 */
 class CFuncLookup {
 
 public:
-	//	Oct. 15, 2001 genta ˆø”’Ç‰Á
-	// 2007.11.02 ryoji ˆø”•ÏXiCSMacroMgr->MacroRecj
+	//	Oct. 15, 2001 genta å¼•æ•°è¿½åŠ 
+	// 2007.11.02 ryoji å¼•æ•°å¤‰æ›´ï¼ˆCSMacroMgr->MacroRecï¼‰
 //	CFuncLookup( HINSTANCE hInst, MacroRec* pMacroRec, CommonSetting* pCom )
 //		: m_pMacroRec( pMacroRec ), m_pCommon( pCom ) {}
 	CFuncLookup() : m_pMacroRec( NULL ){}
@@ -71,7 +71,7 @@ public:
 		m_pCommon = pCom;
 	}
 
-	EFunctionCode Pos2FuncCode( int category, int position, bool bGetUnavailable = true ) const;	// 2007.10.31 ryoji bGetUnavailableƒpƒ‰ƒ[ƒ^’Ç‰Á
+	EFunctionCode Pos2FuncCode( int category, int position, bool bGetUnavailable = true ) const;	// 2007.10.31 ryoji bGetUnavailableãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿è¿½åŠ 
 	bool Pos2FuncName( int category, int position, WCHAR* ptr, int bufsize ) const;
 	bool Funccode2Name( int funccode, WCHAR* ptr, int bufsize ) const ;
 	const TCHAR* Category2Name( int category ) const;
@@ -81,16 +81,16 @@ public:
 	void SetListItem( HWND hListBox, int category ) const;
 	
 	int GetCategoryCount(void) const {
-		return nsFuncCode::nFuncKindNum + 3;	//•ª—Ş{ŠO•”ƒ}ƒNƒ{ƒJƒXƒ^ƒ€ƒƒjƒ…[{ƒvƒ‰ƒOƒCƒ“
+		return nsFuncCode::nFuncKindNum + 3;	//åˆ†é¡ï¼‹å¤–éƒ¨ãƒã‚¯ãƒ­ï¼‹ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ï¼‹ãƒ—ãƒ©ã‚°ã‚¤ãƒ³
 	}
 	
 	int GetItemCount(int category) const;
 
 
 private:
-	MacroRec* m_pMacroRec;	//!< ƒ}ƒNƒî•ñ	// 2007.11.02 ryoji ƒƒ“ƒo•ÏXiCSMacroMgr->MacroRecj
+	MacroRec* m_pMacroRec;	//!< ãƒã‚¯ãƒ­æƒ…å ±	// 2007.11.02 ryoji ãƒ¡ãƒ³ãƒå¤‰æ›´ï¼ˆCSMacroMgr->MacroRecï¼‰
 	
-	CommonSetting* m_pCommon;	//! ‹¤’Êİ’èƒf[ƒ^—Ìˆæ‚Ö‚Ìƒ|ƒCƒ“ƒ^
+	CommonSetting* m_pCommon;	//! å…±é€šè¨­å®šãƒ‡ãƒ¼ã‚¿é ˜åŸŸã¸ã®ãƒã‚¤ãƒ³ã‚¿
 
 };
 

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ƒL[Š„‚è“–‚Ä‚ÉŠÖ‚·‚éƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ã«é–¢ã™ã‚‹ã‚¯ãƒ©ã‚¹
 
 	@author Norio Nakatani
-	@date 1998/03/25 V‹Kì¬
-	@date 1998/05/16 ƒNƒ‰ƒX“à‚Éƒf[ƒ^‚ğ‚½‚È‚¢‚æ‚¤‚É•ÏX
+	@date 1998/03/25 æ–°è¦ä½œæˆ
+	@date 1998/05/16 ã‚¯ãƒ©ã‚¹å†…ã«ãƒ‡ãƒ¼ã‚¿ã‚’æŒãŸãªã„ã‚ˆã†ã«å¤‰æ›´
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -21,7 +21,7 @@
 #include "env/CShareData.h"
 #include "macro/CSMacroMgr.h"// 2002/2/10 aroka
 
-//! KEYDATA‚Æ‚Ù‚Ú“¯‚¶
+//! KEYDATAã¨ã»ã¼åŒã˜
 struct KEYDATAINIT {
 	short			m_nKeyCode;			//!< Key Code (0 for non-keybord button)
 	union {
@@ -39,8 +39,8 @@ struct KEYDATAINIT {
 //					m_nFuncCodeArr[7]	// Shift + Ctrl + Alt + Key
 };
 
-//À‘••â•
-/* KEYDATA”z—ñ‚Éƒf[ƒ^‚ğƒZƒbƒg */
+//å®Ÿè£…è£œåŠ©
+/* KEYDATAé…åˆ—ã«ãƒ‡ãƒ¼ã‚¿ã‚’ã‚»ãƒƒãƒˆ */
 static void SetKeyNameArrVal(
 	DLLSHAREDATA*		pShareData,
 	int					nIdx,
@@ -60,8 +60,8 @@ CKeyBind::~CKeyBind()
 
 
 
-/*! Windows ƒAƒNƒZƒ‰ƒŒ[ƒ^‚Ìì¬
-	@date 2007.02.22 ryoji ƒfƒtƒHƒ‹ƒg‹@”\Š„‚è“–‚Ä‚ÉŠÖ‚·‚éˆ—‚ğ’Ç‰Á
+/*! Windows ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ã®ä½œæˆ
+	@date 2007.02.22 ryoji ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½å‰²ã‚Šå½“ã¦ã«é–¢ã™ã‚‹å‡¦ç†ã‚’è¿½åŠ 
 */
 HACCEL CKeyBind::CreateAccerelator(
 		int			nKeyNameArrNum,
@@ -72,7 +72,7 @@ HACCEL CKeyBind::CreateAccerelator(
 	HACCEL	hAccel;
 	int		j, k;
 
-	// ‹@”\‚ªŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚éƒL[‚Ì”‚ğƒJƒEƒ“ƒg -> nAccelArrNum
+	// æ©Ÿèƒ½ãŒå‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ã‚‹ã‚­ãƒ¼ã®æ•°ã‚’ã‚«ã‚¦ãƒ³ãƒˆ -> nAccelArrNum
 	int nAccelArrNum = 0;
 	for( int i = 0; i < nKeyNameArrNum; ++i ){
 		if( 0 != pKeyNameArr[i].m_nKeyCode ){
@@ -86,7 +86,7 @@ HACCEL CKeyBind::CreateAccerelator(
 
 
 	if( nAccelArrNum <= 0 ){
-		/* ‹@”\Š„‚è“–‚Ä‚ªƒ[ƒ */
+		/* æ©Ÿèƒ½å‰²ã‚Šå½“ã¦ãŒã‚¼ãƒ­ */
 		return NULL;
 	}
 	pAccelArr = new ACCEL[nAccelArrNum];
@@ -118,10 +118,10 @@ HACCEL CKeyBind::CreateAccerelator(
 
 
 
-/*! ƒAƒNƒ‰ƒZƒŒ[ƒ^¯•Êq‚É‘Î‰‚·‚éƒRƒ}ƒ“ƒh¯•Êq‚ğ•Ô‚·D
-	‘Î‰‚·‚éƒAƒNƒ‰ƒZƒŒ[ƒ^¯•Êq‚ª‚È‚¢ê‡‚Ü‚½‚Í‹@”\–¢Š„‚è“–‚Ä‚Ìê‡‚Í0‚ğ•Ô‚·D
+/*! ã‚¢ã‚¯ãƒ©ã‚»ãƒ¬ãƒ¼ã‚¿è­˜åˆ¥å­ã«å¯¾å¿œã™ã‚‹ã‚³ãƒãƒ³ãƒ‰è­˜åˆ¥å­ã‚’è¿”ã™ï¼
+	å¯¾å¿œã™ã‚‹ã‚¢ã‚¯ãƒ©ã‚»ãƒ¬ãƒ¼ã‚¿è­˜åˆ¥å­ãŒãªã„å ´åˆã¾ãŸã¯æ©Ÿèƒ½æœªå‰²ã‚Šå½“ã¦ã®å ´åˆã¯0ã‚’è¿”ã™ï¼
 
-	@date 2007.02.22 ryoji ƒfƒtƒHƒ‹ƒg‹@”\Š„‚è“–‚Ä‚ÉŠÖ‚·‚éˆ—‚ğ’Ç‰Á
+	@date 2007.02.22 ryoji ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½å‰²ã‚Šå½“ã¦ã«é–¢ã™ã‚‹å‡¦ç†ã‚’è¿½åŠ 
 */
 EFunctionCode CKeyBind::GetFuncCode(
 		WORD		nAccelCmd,
@@ -139,7 +139,7 @@ EFunctionCode CKeyBind::GetFuncCode(
 			}
 		}
 	}else{
-		// 2012.12.10 aroka ƒL[ƒR[ƒhŒŸõ‚Ìƒ‹[ƒv‚ğœ‹
+		// 2012.12.10 aroka ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰æ¤œç´¢æ™‚ã®ãƒ«ãƒ¼ãƒ—ã‚’é™¤å»
 		DLLSHAREDATA* pShareData = &GetDllShareData();
 		return GetFuncCodeAt( pKeyNameArr[pShareData->m_Common.m_sKeyBind.m_VKeyToKeyNameArr[nCmd]], nSts, bGetDefFuncCode );
 	}
@@ -152,18 +152,18 @@ EFunctionCode CKeyBind::GetFuncCode(
 
 
 /*!
-	@return ‹@”\‚ªŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚éƒL[ƒXƒgƒ[ƒN‚Ì”
+	@return æ©Ÿèƒ½ãŒå‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ã‚‹ã‚­ãƒ¼ã‚¹ãƒˆãƒ­ãƒ¼ã‚¯ã®æ•°
 	
-	@date Oct. 31, 2001 genta “®“I‚È‹@”\–¼‚É‘Î‰‚·‚é‚½‚ßˆø”’Ç‰Á
-	@date 2007.02.22 ryoji ƒfƒtƒHƒ‹ƒg‹@”\Š„‚è“–‚Ä‚ÉŠÖ‚·‚éˆ—‚ğ’Ç‰Á
+	@date Oct. 31, 2001 genta å‹•çš„ãªæ©Ÿèƒ½åã«å¯¾å¿œã™ã‚‹ãŸã‚å¼•æ•°è¿½åŠ 
+	@date 2007.02.22 ryoji ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½å‰²ã‚Šå½“ã¦ã«é–¢ã™ã‚‹å‡¦ç†ã‚’è¿½åŠ 
 */
 int CKeyBind::CreateKeyBindList(
-	HINSTANCE		hInstance,		//!< [in] ƒCƒ“ƒXƒ^ƒ“ƒXƒnƒ“ƒhƒ‹
+	HINSTANCE		hInstance,		//!< [in] ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ãƒãƒ³ãƒ‰ãƒ«
 	int				nKeyNameArrNum,	//!< [in]
 	KEYDATA*		pKeyNameArr,	//!< [out]
 	CNativeW&		cMemList,		//!<
-	CFuncLookup*	pcFuncLookup,	//!< [in] ‹@”\”Ô†¨–¼‘O‚Ì‘Î‰‚ğæ‚é
-	BOOL			bGetDefFuncCode //!< [in] ON:ƒfƒtƒHƒ‹ƒg‹@”\Š„‚è“–‚Ä‚ğg‚¤/OFF:g‚í‚È‚¢ ƒfƒtƒHƒ‹ƒg:TRUE
+	CFuncLookup*	pcFuncLookup,	//!< [in] æ©Ÿèƒ½ç•ªå·â†’åå‰ã®å¯¾å¿œã‚’å–ã‚‹
+	BOOL			bGetDefFuncCode //!< [in] ON:ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½å‰²ã‚Šå½“ã¦ã‚’ä½¿ã†/OFF:ä½¿ã‚ãªã„ ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆ:TRUE
 )
 {
 	int		i;
@@ -179,7 +179,7 @@ int CKeyBind::CreateKeyBindList(
 	const WCHAR*	pszCTRL  = LTEXT("Ctrl+");
 	const WCHAR*	pszALT   = LTEXT("Alt+");
 	const WCHAR*	pszTAB   = LTEXT("\t");
-	const WCHAR*	pszCR    = LTEXT("\r\n");	//\r=0x0d=CR‚ğ’Ç‰Á
+	const WCHAR*	pszCR    = LTEXT("\r\n");	//\r=0x0d=CRã‚’è¿½åŠ 
 
 
 	cMemList.AppendString( LSW(STR_ERR_DLGKEYBIND1) );
@@ -211,7 +211,7 @@ int CKeyBind::CreateKeyBindList(
 				}
 				szFuncName[0] = LTEXT('\0'); /*"---unknown()--"*/
 
-//				/* ‹@”\–¼“ú–{Œê */
+//				/* æ©Ÿèƒ½åæ—¥æœ¬èª */
 //				::LoadString(
 //					hInstance,
 //					pKeyNameArr[i].m_nFuncCodeArr[j],
@@ -220,8 +220,8 @@ int CKeyBind::CreateKeyBindList(
 				cMemList.AppendString( pszTAB );
 				cMemList.AppendString( szFuncNameJapanese );
 
-				/* ‹@”\ID¨ŠÖ”–¼C‹@”\–¼“ú–{Œê */
-				//@@@ 2002.2.2 YAZAKI ƒ}ƒNƒ‚ğCSMacroMgr‚É“ˆê
+				/* æ©Ÿèƒ½IDâ†’é–¢æ•°åï¼Œæ©Ÿèƒ½åæ—¥æœ¬èª */
+				//@@@ 2002.2.2 YAZAKI ãƒã‚¯ãƒ­ã‚’CSMacroMgrã«çµ±ä¸€
 				CSMacroMgr::GetFuncInfoByID(
 					hInstance,
 					iFunc,
@@ -229,22 +229,22 @@ int CKeyBind::CreateKeyBindList(
 					szFuncNameJapanese
 				);
 
-				/* ŠÖ”–¼ */
+				/* é–¢æ•°å */
 				cMemList.AppendString( pszTAB );
 				cMemList.AppendString( szFuncName );
 
-				/* ‹@”\”Ô† */
+				/* æ©Ÿèƒ½ç•ªå· */
 				cMemList.AppendString( pszTAB );
 				auto_sprintf( pszStr, LTEXT("%d"), iFunc );
 				cMemList.AppendString( pszStr );
 
-				/* ƒL[ƒ}ƒNƒ‚É‹L˜^‰Â”\‚È‹@”\‚©‚Ç‚¤‚©‚ğ’²‚×‚é */
+				/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã«è¨˜éŒ²å¯èƒ½ãªæ©Ÿèƒ½ã‹ã©ã†ã‹ã‚’èª¿ã¹ã‚‹ */
 				cMemList.AppendString( pszTAB );
-				//@@@ 2002.2.2 YAZAKI ƒ}ƒNƒ‚ğCSMacroMgr‚É“ˆê
+				//@@@ 2002.2.2 YAZAKI ãƒã‚¯ãƒ­ã‚’CSMacroMgrã«çµ±ä¸€
 				if( CSMacroMgr::CanFuncIsKeyMacro( iFunc ) ){
-					cMemList.AppendString( LTEXT("›") );
+					cMemList.AppendString( LTEXT("â—‹") );
 				}else{
-					cMemList.AppendString( LTEXT("~") );
+					cMemList.AppendString( LTEXT("Ã—") );
 				}
 
 
@@ -256,22 +256,22 @@ int CKeyBind::CreateKeyBindList(
 	return nValidKeys;
 }
 
-/** ‹@”\‚É‘Î‰‚·‚éƒL[–¼‚ÌƒT[ƒ`(•â•ŠÖ”)
+/** æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼åã®ã‚µãƒ¼ãƒ(è£œåŠ©é–¢æ•°)
 
-	—^‚¦‚ç‚ê‚½ƒVƒtƒgó‘Ô‚É‘Î‚µ‚ÄCw’è‚³‚ê‚½”ÍˆÍ‚ÌƒL[ƒGƒŠƒA‚©‚ç
-	“–ŠY‹@”\‚É‘Î‰‚·‚éƒL[‚ª‚ ‚é‚©‚ğ’²‚×CŒ©‚Â‚©‚Á‚½‚ç
-	‘Î‰‚·‚éƒL[•¶š—ñ‚ğƒZƒbƒg‚·‚éD
+	ä¸ãˆã‚‰ã‚ŒãŸã‚·ãƒ•ãƒˆçŠ¶æ…‹ã«å¯¾ã—ã¦ï¼ŒæŒ‡å®šã•ã‚ŒãŸç¯„å›²ã®ã‚­ãƒ¼ã‚¨ãƒªã‚¢ã‹ã‚‰
+	å½“è©²æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼ãŒã‚ã‚‹ã‹ã‚’èª¿ã¹ï¼Œè¦‹ã¤ã‹ã£ãŸã‚‰
+	å¯¾å¿œã™ã‚‹ã‚­ãƒ¼æ–‡å­—åˆ—ã‚’ã‚»ãƒƒãƒˆã™ã‚‹ï¼
 	
-	ŠÖ”‚©‚ço‚é‚Æ‚«‚É‚ÍŒŸõŠJnˆÊ’u(nKeyNameArrBegin)‚É
-	Ÿ‚Éˆ—‚·‚éindex‚ğİ’è‚·‚éD
+	é–¢æ•°ã‹ã‚‰å‡ºã‚‹ã¨ãã«ã¯æ¤œç´¢é–‹å§‹ä½ç½®(nKeyNameArrBegin)ã«
+	æ¬¡ã«å‡¦ç†ã™ã‚‹indexã‚’è¨­å®šã™ã‚‹ï¼
 
-	@param[in,out] nKeyNameArrBegin ’²¸ŠJnINDEX (I—¹‚É‚ÍŸ‰ñ‚ÌŠJnINDEX‚É‘‚«Š·‚¦‚ç‚ê‚é)
-	@param[in] nKeyNameArrBegin ’²¸I—¹INDEX + 1
-	@param[in] pKeyNameArr ƒL[”z—ñ
-	@param[in] nShiftState ƒVƒtƒgó‘Ô
-	@param[out] cMemList ƒL[•¶š—ñİ’èæ
-	@param[in]	nFuncId ŒŸõ‘ÎÛ‹@”\ID
-	@param[in]	bGetDefFuncCode •W€‹@”\‚ğæ“¾‚·‚é‚©‚Ç‚¤‚©
+	@param[in,out] nKeyNameArrBegin èª¿æŸ»é–‹å§‹INDEX (çµ‚äº†æ™‚ã«ã¯æ¬¡å›ã®é–‹å§‹INDEXã«æ›¸ãæ›ãˆã‚‰ã‚Œã‚‹)
+	@param[in] nKeyNameArrBegin èª¿æŸ»çµ‚äº†INDEX + 1
+	@param[in] pKeyNameArr ã‚­ãƒ¼é…åˆ—
+	@param[in] nShiftState ã‚·ãƒ•ãƒˆçŠ¶æ…‹
+	@param[out] cMemList ã‚­ãƒ¼æ–‡å­—åˆ—è¨­å®šå…ˆ
+	@param[in]	nFuncId æ¤œç´¢å¯¾è±¡æ©Ÿèƒ½ID
+	@param[in]	bGetDefFuncCode æ¨™æº–æ©Ÿèƒ½ã‚’å–å¾—ã™ã‚‹ã‹ã©ã†ã‹
 */
 bool CKeyBind::GetKeyStrSub(
 		int&		nKeyNameArrBegin,
@@ -309,10 +309,10 @@ bool CKeyBind::GetKeyStrSub(
 }
 
 
-/** ‹@”\‚É‘Î‰‚·‚éƒL[–¼‚Ìæ“¾
-	@date 2007.02.22 ryoji ƒfƒtƒHƒ‹ƒg‹@”\Š„‚è“–‚Ä‚ÉŠÖ‚·‚éˆ—‚ğ’Ç‰Á
-	@date 2007.11.04 genta ƒ}ƒEƒXƒNƒŠƒbƒN‚æ‚èƒL[Š„‚è“–‚Ä‚Ì—Dæ“x‚ğã‚°‚é
-	@date 2007.11.04 genta ‹¤’Ê‹@”\‚ÌƒTƒuƒ‹[ƒ`ƒ“‰»
+/** æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼åã®å–å¾—
+	@date 2007.02.22 ryoji ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½å‰²ã‚Šå½“ã¦ã«é–¢ã™ã‚‹å‡¦ç†ã‚’è¿½åŠ 
+	@date 2007.11.04 genta ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯ã‚ˆã‚Šã‚­ãƒ¼å‰²ã‚Šå½“ã¦ã®å„ªå…ˆåº¦ã‚’ä¸Šã’ã‚‹
+	@date 2007.11.04 genta å…±é€šæ©Ÿèƒ½ã®ã‚µãƒ–ãƒ«ãƒ¼ãƒãƒ³åŒ–
 */
 int CKeyBind::GetKeyStr(
 		HINSTANCE	hInstance,
@@ -327,18 +327,18 @@ int CKeyBind::GetKeyStr(
 	int		j;
 	cMemList.SetString(_T(""));
 
-	//	æ‚ÉƒL[•”•ª‚ğ’²¸‚·‚é
+	//	å…ˆã«ã‚­ãƒ¼éƒ¨åˆ†ã‚’èª¿æŸ»ã™ã‚‹
 	for( j = 0; j < 8; ++j ){
-		for( i = MOUSEFUNCTION_KEYBEGIN; i < nKeyNameArrNum; /* 1‚ğ‰Á‚¦‚Ä‚Í‚¢‚¯‚È‚¢ */ ){
+		for( i = MOUSEFUNCTION_KEYBEGIN; i < nKeyNameArrNum; /* 1ã‚’åŠ ãˆã¦ã¯ã„ã‘ãªã„ */ ){
 			if( GetKeyStrSub( i, nKeyNameArrNum, pKeyNameArr, j, cMemList, nFuncId, bGetDefFuncCode )){
 				return 1;
 			}
 		}
 	}
 
-	//	Œã‚Éƒ}ƒEƒX•”•ª‚ğ’²¸‚·‚é
+	//	å¾Œã«ãƒã‚¦ã‚¹éƒ¨åˆ†ã‚’èª¿æŸ»ã™ã‚‹
 	for( j = 0; j < 8; ++j ){
-		for( i = 0; i < MOUSEFUNCTION_KEYBEGIN; /* 1‚ğ‰Á‚¦‚Ä‚Í‚¢‚¯‚È‚¢ */ ){
+		for( i = 0; i < MOUSEFUNCTION_KEYBEGIN; /* 1ã‚’åŠ ãˆã¦ã¯ã„ã‘ãªã„ */ ){
 			if( GetKeyStrSub( i, nKeyNameArrNum, pKeyNameArr, j, cMemList, nFuncId, bGetDefFuncCode )){
 				return 1;
 			}
@@ -348,9 +348,9 @@ int CKeyBind::GetKeyStr(
 }
 
 
-/** ‹@”\‚É‘Î‰‚·‚éƒL[–¼‚Ìæ“¾(•¡”)
-	@date 2007.02.22 ryoji ƒfƒtƒHƒ‹ƒg‹@”\Š„‚è“–‚Ä‚ÉŠÖ‚·‚éˆ—‚ğ’Ç‰Á
-	@date 2007.11.04 genta ‹¤’Ê‹@”\‚ÌƒTƒuƒ‹[ƒ`ƒ“‰»
+/** æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼åã®å–å¾—(è¤‡æ•°)
+	@date 2007.02.22 ryoji ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½å‰²ã‚Šå½“ã¦ã«é–¢ã™ã‚‹å‡¦ç†ã‚’è¿½åŠ 
+	@date 2007.11.04 genta å…±é€šæ©Ÿèƒ½ã®ã‚µãƒ–ãƒ«ãƒ¼ãƒãƒ³åŒ–
 */
 int CKeyBind::GetKeyStrList(
 	HINSTANCE	hInstance,
@@ -388,8 +388,8 @@ int CKeyBind::GetKeyStrList(
 
 	nAssignedKeysNum = 0;
 	for( j = 0; j < 8; ++j ){
-		for( i = 0; i < nKeyNameArrNum; /* 1‚ğ‰Á‚¦‚Ä‚Í‚¢‚¯‚È‚¢ */ ){
-			//	2007.11.04 genta ‹¤’Ê‹@”\‚ÌƒTƒuƒ‹[ƒ`ƒ“‰»
+		for( i = 0; i < nKeyNameArrNum; /* 1ã‚’åŠ ãˆã¦ã¯ã„ã‘ãªã„ */ ){
+			//	2007.11.04 genta å…±é€šæ©Ÿèƒ½ã®ã‚µãƒ–ãƒ«ãƒ¼ãƒãƒ³åŒ–
 			if( GetKeyStrSub( i, nKeyNameArrNum, pKeyNameArr, j,
 					*((*pppcMemList)[nAssignedKeysNum]), nFuncId, bGetDefFuncCode )){
 				nAssignedKeysNum++;
@@ -402,12 +402,12 @@ int CKeyBind::GetKeyStrList(
 
 
 
-/*! ƒAƒNƒZƒXƒL[•t‚«‚Ì•¶š—ñ‚Ìì¬
-	@param sName ƒ‰ƒxƒ‹
-	@param sKey ƒAƒNƒZƒXƒL[
-	@return ƒAƒNƒZƒXƒL[•t‚«‚Ì•¶š—ñ
-	@data 2013.12.09 novice ƒAƒNƒZƒXƒL[‚Æ•¶š—ñ‚Ì”äŠr‚Å¬•¶š‚à—LŒø‚É‚·‚é
-	@date 2014.05.04 sLabel‚Ìƒoƒbƒtƒ@’·‚ğ300 => _MAX_PATH*2 + 30
+/*! ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ä»˜ãã®æ–‡å­—åˆ—ã®ä½œæˆ
+	@param sName ãƒ©ãƒ™ãƒ«
+	@param sKey ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼
+	@return ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ä»˜ãã®æ–‡å­—åˆ—
+	@data 2013.12.09 novice ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã¨æ–‡å­—åˆ—ã®æ¯”è¼ƒã§å°æ–‡å­—ã‚‚æœ‰åŠ¹ã«ã™ã‚‹
+	@date 2014.05.04 sLabelã®ãƒãƒƒãƒ•ã‚¡é•·ã‚’300 => _MAX_PATH*2 + 30
 */
 TCHAR*	CKeyBind::MakeMenuLabel(const TCHAR* sName, const TCHAR* sKey)
 {
@@ -421,22 +421,22 @@ TCHAR*	CKeyBind::MakeMenuLabel(const TCHAR* sName, const TCHAR* sKey)
 	else {
 		if( !GetDllShareData().m_Common.m_sMainMenu.m_bMainMenuKeyParentheses
 			  && (((p = auto_strchr( sName, sKey[0])) != NULL) || ((p = auto_strchr( sName, _totlower(sKey[0]))) != NULL)) ){
-			// ‰¢•¶•—Ag—p‚µ‚Ä‚¢‚é•¶š‚ğƒAƒNƒZƒXƒL[‚É
+			// æ¬§æ–‡é¢¨ã€ä½¿ç”¨ã—ã¦ã„ã‚‹æ–‡å­—ã‚’ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã«
 			auto_strcpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[p-sName] = _T('&');
 			auto_strcpy_s( sLabel + (p-sName) + 1, _countof(sLabel), p );
 		}
 		else if( (p = auto_strchr( sName, _T('(') )) != NULL
 			  && (p = auto_strchr( p, sKey[0] )) != NULL) {
-			// (•t‚»‚ÌŒã‚ÉƒAƒNƒZƒXƒL[
+			// (ä»˜ãã®å¾Œã«ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼
 			auto_strcpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[p-sName] = _T('&');
 			auto_strcpy_s( sLabel + (p-sName) + 1, _countof(sLabel), p );
 		}
 		else if (_tcscmp( sName + _tcslen(sName) - 3, _T("...") ) == 0) {
-			// ––”ö...
+			// æœ«å°¾...
 			auto_strcpy_s( sLabel, _countof(sLabel), sName );
-			sLabel[_tcslen(sName) - 3] = '\0';						// ––”ö‚Ì...‚ğæ‚é
+			sLabel[_tcslen(sName) - 3] = '\0';						// æœ«å°¾ã®...ã‚’å–ã‚‹
 			auto_strcat_s( sLabel, _countof(sLabel), _T("(&") );
 			auto_strcat_s( sLabel, _countof(sLabel), sKey );
 			auto_strcat_s( sLabel, _countof(sLabel), _T(")...") );
@@ -449,9 +449,9 @@ TCHAR*	CKeyBind::MakeMenuLabel(const TCHAR* sName, const TCHAR* sKey)
 	}
 }
 
-/*! ƒƒjƒ…[ƒ‰ƒxƒ‹‚Ìì¬
-	@date 2007.02.22 ryoji ƒfƒtƒHƒ‹ƒg‹@”\Š„‚è“–‚Ä‚ÉŠÖ‚·‚éˆ—‚ğ’Ç‰Á
-	2010/5/17	ƒAƒNƒZƒXƒL[‚Ì’Ç‰Á
+/*! ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒ©ãƒ™ãƒ«ã®ä½œæˆ
+	@date 2007.02.22 ryoji ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½å‰²ã‚Šå½“ã¦ã«é–¢ã™ã‚‹å‡¦ç†ã‚’è¿½åŠ 
+	2010/5/17	ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã®è¿½åŠ 
 	@date 2014.05.04 Moca LABEL_MAX=256 => nLabelSize
 */
 TCHAR* CKeyBind::GetMenuLabel(
@@ -459,7 +459,7 @@ TCHAR* CKeyBind::GetMenuLabel(
 		int			nKeyNameArrNum,
 		KEYDATA*	pKeyNameArr,
 		int			nFuncId,
-		TCHAR*      pszLabel,   //!< [in,out] ƒoƒbƒtƒ@‚Í256ˆÈã‚Æ‰¼’è
+		TCHAR*      pszLabel,   //!< [in,out] ãƒãƒƒãƒ•ã‚¡ã¯256ä»¥ä¸Šã¨ä»®å®š
 		const TCHAR*	pszKey,
 		BOOL		bKeyStr,
 		int			nLabelSize,
@@ -476,17 +476,17 @@ TCHAR* CKeyBind::GetMenuLabel(
 	if( _T('\0') == pszLabel[0] ){
 		_tcscpy( pszLabel, _T("-- undefined name --") );
 	}
-	// ƒAƒNƒZƒXƒL[‚Ì’Ç‰Á	2010/5/17 Uchi
+	// ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã®è¿½åŠ 	2010/5/17 Uchi
 	_tcsncpy_s( pszLabel, LABEL_MAX, MakeMenuLabel( pszLabel, pszKey ), _TRUNCATE );
 
-	/* ‹@”\‚É‘Î‰‚·‚éƒL[–¼‚ğ’Ç‰Á‚·‚é‚© */
+	/* æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼åã‚’è¿½åŠ ã™ã‚‹ã‹ */
 	if( bKeyStr ){
 		CNativeT    cMemAccessKey;
-		// 2010.07.11 Moca ƒƒjƒ…[ƒ‰ƒxƒ‹‚Ìu\tv‚Ì•t‰ÁğŒ•ÏX
-		// [ƒtƒ@ƒCƒ‹/ƒtƒHƒ‹ƒ_/ƒEƒBƒ“ƒhƒEˆê——ˆÈŠO]‚©‚ç[ƒAƒNƒZƒXƒL[‚ª‚ ‚é‚Æ‚«‚Ì‚İ]‚É•t‰Á‚·‚é‚æ‚¤‚É•ÏX
-		/* ‹@”\‚É‘Î‰‚·‚éƒL[–¼‚Ìæ“¾ */
+		// 2010.07.11 Moca ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒ©ãƒ™ãƒ«ã®ã€Œ\tã€ã®ä»˜åŠ æ¡ä»¶å¤‰æ›´
+		// [ãƒ•ã‚¡ã‚¤ãƒ«/ãƒ•ã‚©ãƒ«ãƒ€/ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§ä»¥å¤–]ã‹ã‚‰[ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ãŒã‚ã‚‹ã¨ãã®ã¿]ã«ä»˜åŠ ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
+		/* æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼åã®å–å¾— */
 		if( GetKeyStr( hInstance, nKeyNameArrNum, pKeyNameArr, cMemAccessKey, nFuncId, bGetDefFuncCode ) ){
-			// ƒoƒbƒtƒ@‚ª‘«‚è‚È‚¢‚Æ‚«‚Í“ü‚ê‚È‚¢
+			// ãƒãƒƒãƒ•ã‚¡ãŒè¶³ã‚Šãªã„ã¨ãã¯å…¥ã‚Œãªã„
 			if( _tcslen( pszLabel ) + (Int)cMemAccessKey.GetStringLength() + 1 < LABEL_MAX ){
 				_tcscat( pszLabel, _T("\t") );
 				_tcscat( pszLabel, cMemAccessKey.GetStringPtr() );
@@ -497,14 +497,14 @@ TCHAR* CKeyBind::GetMenuLabel(
 }
 
 
-/*! ƒL[‚ÌƒfƒtƒHƒ‹ƒg‹@”\‚ğæ“¾‚·‚é
+/*! ã‚­ãƒ¼ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½ã‚’å–å¾—ã™ã‚‹
 
-	@param nKeyCode [in] ƒL[ƒR[ƒh
-	@param nState [in] Shift,Ctrl,AltƒL[ó‘Ô
+	@param nKeyCode [in] ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰
+	@param nState [in] Shift,Ctrl,Altã‚­ãƒ¼çŠ¶æ…‹
 
-	@return ‹@”\”Ô†
+	@return æ©Ÿèƒ½ç•ªå·
 
-	@date 2007.02.22 ryoji V‹Kì¬
+	@date 2007.02.22 ryoji æ–°è¦ä½œæˆ
 */
 EFunctionCode CKeyBind::GetDefFuncCode( int nKeyCode, int nState )
 {
@@ -515,16 +515,16 @@ EFunctionCode CKeyBind::GetDefFuncCode( int nKeyCode, int nState )
 	EFunctionCode nDefFuncCode = F_DEFAULT;
 	if( nKeyCode == VK_F4 ){
 		if( nState == _CTRL ){
-			nDefFuncCode = F_FILECLOSE;	// •Â‚¶‚Ä(–³‘è)
+			nDefFuncCode = F_FILECLOSE;	// é–‰ã˜ã¦(ç„¡é¡Œ)
 			if( pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin ){
-				nDefFuncCode = F_WINCLOSE;	// •Â‚¶‚é
+				nDefFuncCode = F_WINCLOSE;	// é–‰ã˜ã‚‹
 			}
 		}
 		else if( nState == _ALT ){
-			nDefFuncCode = F_WINCLOSE;	// •Â‚¶‚é
+			nDefFuncCode = F_WINCLOSE;	// é–‰ã˜ã‚‹
 			if( pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin ){
 				if( !pShareData->m_Common.m_sTabBar.m_bTab_CloseOneWin ){
-					nDefFuncCode = F_GROUPCLOSE;	// ƒOƒ‹[ƒv‚ğ•Â‚¶‚é	// 2007.06.20 ryoji
+					nDefFuncCode = F_GROUPCLOSE;	// ã‚°ãƒ«ãƒ¼ãƒ—ã‚’é–‰ã˜ã‚‹	// 2007.06.20 ryoji
 				}
 			}
 		}
@@ -533,15 +533,15 @@ EFunctionCode CKeyBind::GetDefFuncCode( int nKeyCode, int nState )
 }
 
 
-/*! “Á’è‚ÌƒL[î•ñ‚©‚ç‹@”\ƒR[ƒh‚ğæ“¾‚·‚é
+/*! ç‰¹å®šã®ã‚­ãƒ¼æƒ…å ±ã‹ã‚‰æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã‚’å–å¾—ã™ã‚‹
 
-	@param KeyData [in] ƒL[î•ñ
-	@param nState [in] Shift,Ctrl,AltƒL[ó‘Ô
-	@param bGetDefFuncCode [in] ƒfƒtƒHƒ‹ƒg‹@”\‚ğæ“¾‚·‚é‚©‚Ç‚¤‚©
+	@param KeyData [in] ã‚­ãƒ¼æƒ…å ±
+	@param nState [in] Shift,Ctrl,Altã‚­ãƒ¼çŠ¶æ…‹
+	@param bGetDefFuncCode [in] ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½ã‚’å–å¾—ã™ã‚‹ã‹ã©ã†ã‹
 
-	@return ‹@”\”Ô†
+	@return æ©Ÿèƒ½ç•ªå·
 
-	@date 2007.03.07 ryoji ƒCƒ“ƒ‰ƒCƒ“ŠÖ”‚©‚ç’Êí‚ÌŠÖ”‚É•ÏXiBCC‚ÌÅ“K‰»ƒoƒO‘Îôj
+	@date 2007.03.07 ryoji ã‚¤ãƒ³ãƒ©ã‚¤ãƒ³é–¢æ•°ã‹ã‚‰é€šå¸¸ã®é–¢æ•°ã«å¤‰æ›´ï¼ˆBCCã®æœ€é©åŒ–ãƒã‚°å¯¾ç­–ï¼‰
 */
 EFunctionCode CKeyBind::GetFuncCodeAt( KEYDATA& KeyData, int nState, BOOL bGetDefFuncCode )
 {
@@ -567,134 +567,134 @@ EFunctionCode CKeyBind::GetFuncCodeAt( KEYDATA& KeyData, int nState, BOOL bGetDe
 
 
 //	Sep. 14, 2000 JEPRO
-//	Shift+F1 ‚ÉuƒRƒ}ƒ“ƒhˆê——v, Alt+F1 ‚Éuƒwƒ‹ƒv–ÚŸv, Shift+Alt+F1 ‚ÉuƒL[ƒ[ƒhŒŸõv‚ğ’Ç‰Á	//Nov. 25, 2000 JEPRO E‚µ‚Ä‚¢‚½‚Ì‚ğC³E•œŠˆ
-//Dec. 25, 2000 JEPRO Shift+Ctrl+F1 ‚Éuƒo[ƒWƒ‡ƒ“î•ñv‚ğ’Ç‰Á
-// 2001.12.03 hor F2‚ÉƒuƒbƒNƒ}[ƒNŠÖ˜A‚ğŠ„“–
-//Sept. 21, 2000 JEPRO	Ctrl+F3 ‚ÉuŒŸõƒ}[ƒN‚ÌƒNƒŠƒAv‚ğ’Ç‰Á
-//Aug. 12, 2002 ai	Ctrl+Shift+F3 ‚ÉuŒŸõŠJnˆÊ’u‚Ö–ß‚év‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Alt+F4 ‚ÉuƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚év, Shift+Alt+F4 ‚Éu‚·‚×‚Ä‚ÌƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚év‚ğ’Ç‰Á
-//	Ctrl+F4‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚½uc‰¡‚É•ªŠ„v‚ğu•Â‚¶‚Ä(–³‘è)v‚É•ÏX‚µ Shift+Ctrl+F4 ‚Éu•Â‚¶‚ÄŠJ‚­v‚ğ’Ç‰Á
-//Jan. 14, 2001 Ctrl+Alt+F4 ‚ÉuƒeƒLƒXƒgƒGƒfƒBƒ^‚Ì‘SI—¹v‚ğ’Ç‰Á
-//Jun. 2001uƒTƒNƒ‰ƒGƒfƒBƒ^‚Ì‘SI—¹v‚É‰üÌ
-//2006.10.21 ryoji Alt+F4 ‚É‚Í‰½‚àŠ„‚è“–‚Ä‚È‚¢iƒfƒtƒHƒ‹ƒg‚ÌƒVƒXƒeƒ€ƒRƒ}ƒ“ƒhu•Â‚¶‚év‚ªÀs‚³‚ê‚é‚æ‚¤‚Éj
-//2007.02.13 ryoji Shift+Ctrl+F4‚ğF_WIN_CLOSEALL‚©‚çF_EXITALLEDITORS‚É•ÏX
-//2007.02.22 ryoji Ctrl+F4 ‚Ö‚ÌŠ„‚è“–‚Ä‚ğíœiƒfƒtƒHƒ‹ƒg‚ÌƒRƒ}ƒ“ƒh‚ğÀsj
-//	Sep. 20, 2000 JEPRO Ctrl+F5 ‚ÉuŠO•”ƒRƒ}ƒ“ƒhÀsv‚ğ’Ç‰Á  ‚È‚¨ƒ}ƒNƒ–¼‚ÍCMMAND ‚©‚çCOMMAND ‚É•ÏXÏ‚İ
-//Oct. 28, 2000 F5 ‚ÍuÄ•`‰æv‚É•ÏX	//Jan. 14, 2001 Alt+F5 ‚Éuuudecode‚µ‚Ä•Û‘¶v, Ctrl+ Alt+F5 ‚ÉuTAB¨‹ó”’v‚ğ’Ç‰Á
-//	May 28, 2001 genta	S-C-A-F5‚ÉSPACE-to-TAB‚ğ’Ç‰Á
-//Jan. 14, 2001 JEPRO	Ctrl+F6 ‚Éu¬•¶šv, Alt+F6 ‚ÉuBase64ƒfƒR[ƒh‚µ‚Ä•Û‘¶v‚ğ’Ç‰Á
-// 2007.11.15 nasukoji	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒNEƒNƒAƒhƒ‰ƒvƒ‹ƒNƒŠƒbƒN‘Î‰
-//Jan. 14, 2001 JEPRO	Ctrl+F7 ‚Éu‘å•¶šv, Alt+F7 ‚ÉuUTF-7¨SJISƒR[ƒh•ÏŠ·v, Shift+Alt+F7 ‚ÉuSJIS¨UTF-7ƒR[ƒh•ÏŠ·v, Ctrl+Alt+F7 ‚ÉuUTF-7‚ÅŠJ‚«’¼‚·v‚ğ’Ç‰Á
-//Nov. 9, 2000 JEPRO	Shift+F8 ‚ÉuCRLF‰üs‚ÅƒRƒs[v‚ğ’Ç‰Á
-//Jan. 14, 2001 JEPRO	Ctrl+F8 ‚Éu‘SŠp¨”¼Špv, Alt+F8 ‚ÉuUTF-8¨SJISƒR[ƒh•ÏŠ·v, Shift+Alt+F8 ‚ÉuSJIS¨UTF-8ƒR[ƒh•ÏŠ·v, Ctrl+Alt+F8 ‚ÉuUTF-8‚ÅŠJ‚«’¼‚·v‚ğ’Ç‰Á
-//Jan. 14, 2001 JEPRO	Ctrl+F9 ‚Éu”¼Šp{‘S‚Ğ‚ç¨‘SŠpEƒJƒ^ƒJƒiv, Alt+F9 ‚ÉuUnicode¨SJISƒR[ƒh•ÏŠ·v, Ctrl+Alt+F9 ‚ÉuUnicode‚ÅŠJ‚«’¼‚·v‚ğ’Ç‰Á
-//Oct. 28, 2000 JEPRO F10 ‚ÉuSQL*Plus‚ÅÀsv‚ğ’Ç‰Á(F5‚©‚ç‚ÌˆÚ“®)
-//Jan. 14, 2001 JEPRO	Ctrl+F10 ‚Éu”¼Šp{‘SƒJƒ^¨‘SŠpE‚Ğ‚ç‚ª‚Èv, Alt+F10 ‚ÉuEUC¨SJISƒR[ƒh•ÏŠ·v, Shift+Alt+F10 ‚ÉuSJIS¨EUCƒR[ƒh•ÏŠ·v, Ctrl+Alt+F10 ‚ÉuEUC‚ÅŠJ‚«’¼‚·v‚ğ’Ç‰Á
-//Jan. 14, 2001 JEPRO	Shift+F11 ‚ÉuSQL*Plus‚ğƒAƒNƒeƒBƒu•\¦v, Ctrl+F11 ‚Éu”¼ŠpƒJƒ^ƒJƒi¨‘SŠpƒJƒ^ƒJƒiv, Alt+F11 ‚ÉuE-Mail(JIS¨SJIS)ƒR[ƒh•ÏŠ·v, Shift+Alt+F11 ‚ÉuSJIS¨JISƒR[ƒh•ÏŠ·v, Ctrl+Alt+F11 ‚ÉuJIS‚ÅŠJ‚«’¼‚·v‚ğ’Ç‰Á
-//Jan. 14, 2001 JEPRO	Ctrl+F12 ‚Éu”¼ŠpƒJƒ^ƒJƒi¨‘SŠp‚Ğ‚ç‚ª‚Èv, Alt+F12 ‚Éu©“®”»•Ê¨SJISƒR[ƒh•ÏŠ·v, Ctrl+Alt+F11 ‚ÉuSJIS‚ÅŠJ‚«’¼‚·v‚ğ’Ç‰Á
-//Sept. 1, 2000 JEPRO	Alt+Enter ‚Éuƒtƒ@ƒCƒ‹‚ÌƒvƒƒpƒeƒBv‚ğ’Ç‰Á	//Oct. 15, 2000 JEPRO Ctrl+Enter ‚Éuƒtƒ@ƒCƒ‹“à—e”äŠrv‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO ’·‚¢‚Ì‚Å–¼Ì‚ğŠÈ—ªŒ`‚É•ÏX(BackSpace¨BkSp)
-//Oct. 7, 2000 JEPRO –¼Ì‚ğVC++‚É‡‚í‚¹ŠÈ—ªŒ`‚É•ÏX(Insert¨Ins)
-//Oct. 7, 2000 JEPRO –¼Ì‚ğVC++‚É‡‚í‚¹ŠÈ—ªŒ`‚É•ÏX(Delete¨Del)
-//Jun. 26, 2001 JEPRO	Shift+Del ‚ÉuØ‚èæ‚èv‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Shift+Ctrl+Alt+ª‚Éuc•ûŒü‚ÉÅ‘å‰»v‚ğ’Ç‰Á
+//	Shift+F1 ã«ã€Œã‚³ãƒãƒ³ãƒ‰ä¸€è¦§ã€, Alt+F1 ã«ã€Œãƒ˜ãƒ«ãƒ—ç›®æ¬¡ã€, Shift+Alt+F1 ã«ã€Œã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æ¤œç´¢ã€ã‚’è¿½åŠ 	//Nov. 25, 2000 JEPRO æ®ºã—ã¦ã„ãŸã®ã‚’ä¿®æ­£ãƒ»å¾©æ´»
+//Dec. 25, 2000 JEPRO Shift+Ctrl+F1 ã«ã€Œãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±ã€ã‚’è¿½åŠ 
+// 2001.12.03 hor F2ã«ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯é–¢é€£ã‚’å‰²å½“
+//Sept. 21, 2000 JEPRO	Ctrl+F3 ã«ã€Œæ¤œç´¢ãƒãƒ¼ã‚¯ã®ã‚¯ãƒªã‚¢ã€ã‚’è¿½åŠ 
+//Aug. 12, 2002 ai	Ctrl+Shift+F3 ã«ã€Œæ¤œç´¢é–‹å§‹ä½ç½®ã¸æˆ»ã‚‹ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Alt+F4 ã«ã€Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹ã€, Shift+Alt+F4 ã«ã€Œã™ã¹ã¦ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹ã€ã‚’è¿½åŠ 
+//	Ctrl+F4ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ãŸã€Œç¸¦æ¨ªã«åˆ†å‰²ã€ã‚’ã€Œé–‰ã˜ã¦(ç„¡é¡Œ)ã€ã«å¤‰æ›´ã— Shift+Ctrl+F4 ã«ã€Œé–‰ã˜ã¦é–‹ãã€ã‚’è¿½åŠ 
+//Jan. 14, 2001 Ctrl+Alt+F4 ã«ã€Œãƒ†ã‚­ã‚¹ãƒˆã‚¨ãƒ‡ã‚£ã‚¿ã®å…¨çµ‚äº†ã€ã‚’è¿½åŠ 
+//Jun. 2001ã€Œã‚µã‚¯ãƒ©ã‚¨ãƒ‡ã‚£ã‚¿ã®å…¨çµ‚äº†ã€ã«æ”¹ç§°
+//2006.10.21 ryoji Alt+F4 ã«ã¯ä½•ã‚‚å‰²ã‚Šå½“ã¦ãªã„ï¼ˆãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®ã‚·ã‚¹ãƒ†ãƒ ã‚³ãƒãƒ³ãƒ‰ã€Œé–‰ã˜ã‚‹ã€ãŒå®Ÿè¡Œã•ã‚Œã‚‹ã‚ˆã†ã«ï¼‰
+//2007.02.13 ryoji Shift+Ctrl+F4ã‚’F_WIN_CLOSEALLã‹ã‚‰F_EXITALLEDITORSã«å¤‰æ›´
+//2007.02.22 ryoji Ctrl+F4 ã¸ã®å‰²ã‚Šå½“ã¦ã‚’å‰Šé™¤ï¼ˆãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®ã‚³ãƒãƒ³ãƒ‰ã‚’å®Ÿè¡Œï¼‰
+//	Sep. 20, 2000 JEPRO Ctrl+F5 ã«ã€Œå¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œã€ã‚’è¿½åŠ   ãªãŠãƒã‚¯ãƒ­åã¯CMMAND ã‹ã‚‰COMMAND ã«å¤‰æ›´æ¸ˆã¿
+//Oct. 28, 2000 F5 ã¯ã€Œå†æç”»ã€ã«å¤‰æ›´	//Jan. 14, 2001 Alt+F5 ã«ã€Œuudecodeã—ã¦ä¿å­˜ã€, Ctrl+ Alt+F5 ã«ã€ŒTABâ†’ç©ºç™½ã€ã‚’è¿½åŠ 
+//	May 28, 2001 genta	S-C-A-F5ã«SPACE-to-TABã‚’è¿½åŠ 
+//Jan. 14, 2001 JEPRO	Ctrl+F6 ã«ã€Œå°æ–‡å­—ã€, Alt+F6 ã«ã€ŒBase64ãƒ‡ã‚³ãƒ¼ãƒ‰ã—ã¦ä¿å­˜ã€ã‚’è¿½åŠ 
+// 2007.11.15 nasukoji	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãƒ»ã‚¯ã‚¢ãƒ‰ãƒ©ãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯å¯¾å¿œ
+//Jan. 14, 2001 JEPRO	Ctrl+F7 ã«ã€Œå¤§æ–‡å­—ã€, Alt+F7 ã«ã€ŒUTF-7â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Shift+Alt+F7 ã«ã€ŒSJISâ†’UTF-7ã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Ctrl+Alt+F7 ã«ã€ŒUTF-7ã§é–‹ãç›´ã™ã€ã‚’è¿½åŠ 
+//Nov. 9, 2000 JEPRO	Shift+F8 ã«ã€ŒCRLFæ”¹è¡Œã§ã‚³ãƒ”ãƒ¼ã€ã‚’è¿½åŠ 
+//Jan. 14, 2001 JEPRO	Ctrl+F8 ã«ã€Œå…¨è§’â†’åŠè§’ã€, Alt+F8 ã«ã€ŒUTF-8â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Shift+Alt+F8 ã«ã€ŒSJISâ†’UTF-8ã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Ctrl+Alt+F8 ã«ã€ŒUTF-8ã§é–‹ãç›´ã™ã€ã‚’è¿½åŠ 
+//Jan. 14, 2001 JEPRO	Ctrl+F9 ã«ã€ŒåŠè§’ï¼‹å…¨ã²ã‚‰â†’å…¨è§’ãƒ»ã‚«ã‚¿ã‚«ãƒŠã€, Alt+F9 ã«ã€ŒUnicodeâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Ctrl+Alt+F9 ã«ã€ŒUnicodeã§é–‹ãç›´ã™ã€ã‚’è¿½åŠ 
+//Oct. 28, 2000 JEPRO F10 ã«ã€ŒSQL*Plusã§å®Ÿè¡Œã€ã‚’è¿½åŠ (F5ã‹ã‚‰ã®ç§»å‹•)
+//Jan. 14, 2001 JEPRO	Ctrl+F10 ã«ã€ŒåŠè§’ï¼‹å…¨ã‚«ã‚¿â†’å…¨è§’ãƒ»ã²ã‚‰ãŒãªã€, Alt+F10 ã«ã€ŒEUCâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Shift+Alt+F10 ã«ã€ŒSJISâ†’EUCã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Ctrl+Alt+F10 ã«ã€ŒEUCã§é–‹ãç›´ã™ã€ã‚’è¿½åŠ 
+//Jan. 14, 2001 JEPRO	Shift+F11 ã«ã€ŒSQL*Plusã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–è¡¨ç¤ºã€, Ctrl+F11 ã«ã€ŒåŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã‚«ã‚¿ã‚«ãƒŠã€, Alt+F11 ã«ã€ŒE-Mail(JISâ†’SJIS)ã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Shift+Alt+F11 ã«ã€ŒSJISâ†’JISã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Ctrl+Alt+F11 ã«ã€ŒJISã§é–‹ãç›´ã™ã€ã‚’è¿½åŠ 
+//Jan. 14, 2001 JEPRO	Ctrl+F12 ã«ã€ŒåŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã²ã‚‰ãŒãªã€, Alt+F12 ã«ã€Œè‡ªå‹•åˆ¤åˆ¥â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›ã€, Ctrl+Alt+F11 ã«ã€ŒSJISã§é–‹ãç›´ã™ã€ã‚’è¿½åŠ 
+//Sept. 1, 2000 JEPRO	Alt+Enter ã«ã€Œãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã€ã‚’è¿½åŠ 	//Oct. 15, 2000 JEPRO Ctrl+Enter ã«ã€Œãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO é•·ã„ã®ã§åç§°ã‚’ç°¡ç•¥å½¢ã«å¤‰æ›´(BackSpaceâ†’BkSp)
+//Oct. 7, 2000 JEPRO åç§°ã‚’VC++ã«åˆã‚ã›ç°¡ç•¥å½¢ã«å¤‰æ›´(Insertâ†’Ins)
+//Oct. 7, 2000 JEPRO åç§°ã‚’VC++ã«åˆã‚ã›ç°¡ç•¥å½¢ã«å¤‰æ›´(Deleteâ†’Del)
+//Jun. 26, 2001 JEPRO	Shift+Del ã«ã€Œåˆ‡ã‚Šå–ã‚Šã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Shift+Ctrl+Alt+â†‘ã«ã€Œç¸¦æ–¹å‘ã«æœ€å¤§åŒ–ã€ã‚’è¿½åŠ 
 //Jun. 27, 2001 JEPRO
-//	Ctrl+ª‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚½uƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)v‚ğuƒeƒLƒXƒg‚ğ‚Ps‰º‚ÖƒXƒNƒ[ƒ‹v‚É•ÏX
-//2001.02.10 by MIK Shift+Ctrl+Alt+¨‚Éu‰¡•ûŒü‚ÉÅ‘å‰»v‚ğ’Ç‰Á
+//	Ctrl+â†‘ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ãŸã€Œã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)ã€ã‚’ã€Œãƒ†ã‚­ã‚¹ãƒˆã‚’ï¼‘è¡Œä¸‹ã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã€ã«å¤‰æ›´
+//2001.02.10 by MIK Shift+Ctrl+Alt+â†’ã«ã€Œæ¨ªæ–¹å‘ã«æœ€å¤§åŒ–ã€ã‚’è¿½åŠ 
 //Sept. 14, 2000 JEPRO
-//	Ctrl+«‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚½u‰EƒNƒŠƒbƒNƒƒjƒ…[v‚ğuƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)v‚É•ÏX
-//	‚»‚ê‚É•t‚µ‚Ä‚³‚ç‚Éu‰EƒNƒŠƒbƒNƒƒjƒ…[v‚ğCtrl{Alt{«‚É•ÏX
+//	Ctrl+â†“ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ãŸã€Œå³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã€ã‚’ã€Œã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)ã€ã«å¤‰æ›´
+//	ãã‚Œã«ä»˜éšã—ã¦ã•ã‚‰ã«ã€Œå³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã€ã‚’Ctrlï¼‹Altï¼‹â†“ã«å¤‰æ›´
 //Jun. 27, 2001 JEPRO
-//	Ctrl+«‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚½uƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)v‚ğuƒeƒLƒXƒg‚ğ‚Psã‚ÖƒXƒNƒ[ƒ‹v‚É•ÏX
-//Oct. 15, 2000 JEPRO Ctrl+PgUp, Shift+Ctrl+PgDn ‚É‚»‚ê‚¼‚êu‚Pƒy[ƒWƒ_ƒEƒ“v, u(‘I‘ğ)‚Pƒy[ƒWƒ_ƒEƒ“v‚ğ’Ç‰Á
-//Oct. 6, 2000 JEPRO –¼Ì‚ğPC-ATŒİŠ·‹@Œn‚ÉŒğŠ·(RollUp¨PgDn) //Oct. 10, 2000 JEPRO –¼Ì•ÏX
-//2001.12.03 hor 1Page/HalfPage “ü‘Ö‚¦
-//Oct. 15, 2000 JEPRO Ctrl+PgUp, Shift+Ctrl+PgDn ‚É‚»‚ê‚¼‚êu‚Pƒy[ƒWƒAƒbƒvv, u(‘I‘ğ)‚Pƒy[ƒWƒAƒbƒvv‚ğ’Ç‰Á
-//Oct. 6, 2000 JEPRO –¼Ì‚ğPC-ATŒİŠ·‹@Œn‚ÉŒğŠ·(RollDown¨PgUp) //Oct. 10, 2000 JEPRO –¼Ì•ÏX
-//2001.12.03 hor 1Page/HalfPage “ü‘Ö‚¦
-//Oct. 7, 2000 JEPRO –¼Ì‚ğVC++‚É‡‚í‚¹ŠÈ—ªŒ`‚É•ÏX(SpaceBar¨Space)
-//Oct. 7, 2000 JEPRO	Ctrl+0 ‚ğuƒ^ƒCƒv•Êİ’èˆê——v¨u–¢’è‹`v‚É•ÏX
-//Jan. 13, 2001 JEPRO	Alt+0 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[10v, Shift+Alt+0 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[20v‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+1 ‚ğuƒ^ƒCƒv•Êİ’èv¨uƒc[ƒ‹ƒo[‚Ì•\¦v‚É•ÏX
-//Jan. 13, 2001 JEPRO	Alt+1 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[1v, Shift+Alt+1 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[11v‚ğ’Ç‰Á
-//Jan. 19, 2001 JEPRO	Shift+Ctrl+1 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[21v‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+2 ‚ğu‹¤’Êİ’èv¨uƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚Ì•\¦v‚É•ÏX
-//Jan. 13, 2001 JEPRO	Alt+2 ‚ğuƒAƒEƒgƒvƒbƒgv¨uƒJƒXƒ^ƒ€ƒƒjƒ…[2v‚É•ÏX‚µuƒAƒEƒgƒvƒbƒgv‚Í Alt+O ‚ÉˆÚ“®, Shift+Alt+2 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[12v‚ğ’Ç‰Á
-//Jan. 19, 2001 JEPRO	Shift+Ctrl+2 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[22v‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+3 ‚ğuƒtƒHƒ“ƒgİ’èv¨uƒXƒe[ƒ^ƒXƒo[‚Ì•\¦v‚É•ÏX
-//Jan. 13, 2001 JEPRO	Alt+3 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[3v, Shift+Alt+3 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[13v‚ğ’Ç‰Á
-//Jan. 19, 2001 JEPRO	Shift+Ctrl+3 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[23v‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+4 ‚ğuƒc[ƒ‹ƒo[‚Ì•\¦v¨uƒ^ƒCƒv•Êİ’èˆê——v‚É•ÏX
-//Jan. 13, 2001 JEPRO	Alt+4 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[4v, Shift+Alt+4 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[14v‚ğ’Ç‰Á
-//Jan. 19, 2001 JEPRO	Shift+Ctrl+4 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[24v‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+5 ‚ğuƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚Ì•\¦v¨uƒ^ƒCƒv•Êİ’èv‚É•ÏX
-//Jan. 13, 2001 JEPRO	Alt+5 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[5v, Shift+Alt+5 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[15v‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+6 ‚ğuƒXƒe[ƒ^ƒXƒo[‚Ì•\¦v¨u‹¤’Êİ’èv‚É•ÏX
-//Jan. 13, 2001 JEPRO	Alt+6 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[6v, Shift+Alt+6 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[16v‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+7 ‚ÉuƒtƒHƒ“ƒgİ’èv‚ğ’Ç‰Á
-//Jan. 13, 2001 JEPRO	Alt+7 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[7v, Shift+Alt+7 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[17v‚ğ’Ç‰Á
-//Jan. 13, 2001 JEPRO	Alt+8 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[8v, Shift+Alt+8 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[18v‚ğ’Ç‰Á
-//Jan. 13, 2001 JEPRO	Alt+9 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[9v, Shift+Alt+9 ‚ÉuƒJƒXƒ^ƒ€ƒƒjƒ…[19v‚ğ’Ç‰Á
-//2001.12.06 hor Alt+A ‚ğuSORT_ASCv‚ÉŠ„“–
-//Jan. 13, 2001 JEPRO	Ctrl+B ‚Éuƒuƒ‰ƒEƒYv‚ğ’Ç‰Á
-//Jan. 16, 2001 JEPRO	SHift+Ctrl+C ‚Éu.h‚Æ“¯–¼‚Ì.c(‚È‚¯‚ê‚Î.cpp)‚ğŠJ‚­v‚ğ’Ç‰Á
-//Feb. 07, 2001 JEPRO	SHift+Ctrl+C ‚ğu.h‚Æ“¯–¼‚Ì.c(‚È‚¯‚ê‚Î.cpp)‚ğŠJ‚­v¨u“¯–¼‚ÌC/C++ƒwƒbƒ_(ƒ\[ƒX)‚ğŠJ‚­v‚É•ÏX
-//Jan. 16, 2001 JEPRO	Ctrl+D ‚Éu’PŒêØ‚èæ‚èv, Shift+Ctrl+D ‚Éu’PŒêíœv‚ğ’Ç‰Á
-//2001.12.06 hor Alt+D ‚ğuSORT_DESCv‚ÉŠ„“–
-//Oct. 7, 2000 JEPRO	Ctrl+Alt+E ‚Éud‚Ë‚Ä•\¦v‚ğ’Ç‰Á
-//Jan. 16, 2001	JEPRO	Ctrl+E ‚ÉusØ‚èæ‚è(Ü‚è•Ô‚µ’PˆÊ)v, Shift+Ctrl+E ‚Éusíœ(Ü‚è•Ô‚µ’PˆÊ)v‚ğ’Ç‰Á
-//Oct. 07, 2000 JEPRO	Ctrl+Alt+H ‚Éuã‰º‚É•À‚×‚Ä•\¦v‚ğ’Ç‰Á
-//Jan. 16, 2001 JEPRO	Ctrl+H ‚ğuƒJ[ƒ\ƒ‹‘O‚ğíœv¨uƒJ[ƒ\ƒ‹s‚ğƒEƒBƒ“ƒhƒE’†‰›‚Öv‚É•ÏX‚µ	Shift+Ctrl+H ‚Éu.c‚Ü‚½‚Í.cpp‚Æ“¯–¼‚Ì.h‚ğŠJ‚­v‚ğ’Ç‰Á
-//Feb. 07, 2001 JEPRO	SHift+Ctrl+H ‚ğu.c‚Ü‚½‚Í.cpp‚Æ“¯–¼‚Ì.h‚ğŠJ‚­v¨u“¯–¼‚ÌC/C++ƒwƒbƒ_(ƒ\[ƒX)‚ğŠJ‚­v‚É•ÏX
-//Jan. 21, 2001	JEPRO	Ctrl+I ‚Éus‚Ì“ñd‰»v‚ğ’Ç‰Á
-//Jan. 16, 2001	JEPRO	Ctrl+K ‚Éus––‚Ü‚ÅØ‚èæ‚è(‰üs’PˆÊ)v, Shift+Ctrl+E ‚Éus––‚Ü‚Åíœ(‰üs’PˆÊ)v‚ğ’Ç‰Á
-//Jan. 14, 2001 JEPRO	Ctrl+Alt+L ‚Éu¬•¶šv, Shift+Ctrl+Alt+L ‚Éu‘å•¶šv‚ğ’Ç‰Á
-//Jan. 16, 2001 Ctrl+L ‚ğuƒJ[ƒ\ƒ‹s‚ğƒEƒBƒ“ƒhƒE’†‰›‚Öv¨uƒL[ƒ}ƒNƒ‚Ì“Ç‚İ‚İv‚É•ÏX‚µuƒJ[ƒ\ƒ‹s‚ğƒEƒBƒ“ƒhƒE’†‰›‚Öv‚Í Ctrl+H ‚ÉˆÚ“®
-//2001.12.03 hor Alt+L ‚ğuLTRIMv‚ÉŠ„“–
-//Jan. 16, 2001 JEPRO	Ctrl+M ‚ÉuƒL[ƒ}ƒNƒ‚Ì•Û‘¶v‚ğ’Ç‰Á
-//2001.12.06 hor Alt+M ‚ğuMERGEv‚ÉŠ„“–
-//Oct. 20, 2000 JEPRO	Alt+N ‚ÉuˆÚ“®—š—ğ: Ÿ‚Öv‚ğ’Ç‰Á
-//Jan. 13, 2001 JEPRO	Alt+O ‚ÉuƒAƒEƒgƒvƒbƒgv‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+P ‚Éuˆóüv, Shift+Ctrl+P ‚ÉuˆóüƒvƒŒƒrƒ…[v, Ctrl+Alt+P ‚Éuƒy[ƒWİ’èv‚ğ’Ç‰Á
-//Oct. 20, 2000 JEPRO	Alt+P ‚ÉuˆÚ“®—š—ğ: ‘O‚Öv‚ğ’Ç‰Á
-//Jan. 24, 2001	JEPRO	Ctrl+Q ‚ÉuƒL[Š„‚è“–‚Äˆê——‚ğƒRƒs[v‚ğ’Ç‰Á
-//2001.12.03 hor Alt+R ‚ğuRTRIMv‚ÉŠ„“–
-//Oct. 7, 2000 JEPRO	Shift+Ctrl+S ‚Éu–¼‘O‚ğ•t‚¯‚Ä•Û‘¶v‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+Alt+T ‚Éu¶‰E‚É•À‚×‚Ä•\¦v‚ğ’Ç‰Á
-//Jan. 21, 2001	JEPRO	Ctrl+T ‚Éuƒ^ƒOƒWƒƒƒ“ƒvv, Shift+Ctrl+T ‚Éuƒ^ƒOƒWƒƒƒ“ƒvƒoƒbƒNv‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Ctrl+Alt+U ‚ÉuŒ»İ‚ÌƒEƒBƒ“ƒhƒE•‚ÅÜ‚è•Ô‚µv‚ğ’Ç‰Á
-//Jan. 16, 2001	JEPRO	Ctrl+U ‚Éus“ª‚Ü‚ÅØ‚èæ‚è(‰üs’PˆÊ)v, Shift+Ctrl+U ‚Éus“ª‚Ü‚Åíœ(‰üs’PˆÊ)v‚ğ’Ç‰Á
-//Jan. 13, 2001 JEPRO	Alt+X ‚ğuƒJƒXƒ^ƒ€ƒƒjƒ…[1v¨u–¢’è‹`v‚É•ÏX‚µuƒJƒXƒ^ƒ€ƒƒjƒ…[1v‚Í Alt+1 ‚ÉˆÚ“®
-//Oct. 7, 2000 JEPRO	Shift+Ctrl+- ‚Éuã‰º‚É•ªŠ„v‚ğ’Ç‰Á
-// 2002.02.08 hor Ctrl+-‚Éƒtƒ@ƒCƒ‹–¼‚ğƒRƒs[‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Shift+Ctrl+\ ‚Éu¶‰E‚É•ªŠ„v‚ğ’Ç‰Á
-//Sept. 20, 2000 JEPRO	Ctrl+@ ‚Éuƒtƒ@ƒCƒ‹“à—e”äŠrv‚ğ’Ç‰Á  //Oct. 15, 2000 JEPROu‘I‘ğ”ÍˆÍ“à‘SsƒRƒs[v‚É•ÏX
+//	Ctrl+â†“ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ãŸã€Œã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)ã€ã‚’ã€Œãƒ†ã‚­ã‚¹ãƒˆã‚’ï¼‘è¡Œä¸Šã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã€ã«å¤‰æ›´
+//Oct. 15, 2000 JEPRO Ctrl+PgUp, Shift+Ctrl+PgDn ã«ãã‚Œãã‚Œã€Œï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã€, ã€Œ(é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã€ã‚’è¿½åŠ 
+//Oct. 6, 2000 JEPRO åç§°ã‚’PC-ATäº’æ›æ©Ÿç³»ã«äº¤æ›(RollUpâ†’PgDn) //Oct. 10, 2000 JEPRO åç§°å¤‰æ›´
+//2001.12.03 hor 1Page/HalfPage å…¥æ›¿ãˆ
+//Oct. 15, 2000 JEPRO Ctrl+PgUp, Shift+Ctrl+PgDn ã«ãã‚Œãã‚Œã€Œï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—ã€, ã€Œ(é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—ã€ã‚’è¿½åŠ 
+//Oct. 6, 2000 JEPRO åç§°ã‚’PC-ATäº’æ›æ©Ÿç³»ã«äº¤æ›(RollDownâ†’PgUp) //Oct. 10, 2000 JEPRO åç§°å¤‰æ›´
+//2001.12.03 hor 1Page/HalfPage å…¥æ›¿ãˆ
+//Oct. 7, 2000 JEPRO åç§°ã‚’VC++ã«åˆã‚ã›ç°¡ç•¥å½¢ã«å¤‰æ›´(SpaceBarâ†’Space)
+//Oct. 7, 2000 JEPRO	Ctrl+0 ã‚’ã€Œã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šä¸€è¦§ã€â†’ã€Œæœªå®šç¾©ã€ã«å¤‰æ›´
+//Jan. 13, 2001 JEPRO	Alt+0 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼10ã€, Shift+Alt+0 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼20ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+1 ã‚’ã€Œã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã€â†’ã€Œãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã®è¡¨ç¤ºã€ã«å¤‰æ›´
+//Jan. 13, 2001 JEPRO	Alt+1 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼1ã€, Shift+Alt+1 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼11ã€ã‚’è¿½åŠ 
+//Jan. 19, 2001 JEPRO	Shift+Ctrl+1 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼21ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+2 ã‚’ã€Œå…±é€šè¨­å®šã€â†’ã€Œãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®è¡¨ç¤ºã€ã«å¤‰æ›´
+//Jan. 13, 2001 JEPRO	Alt+2 ã‚’ã€Œã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã€â†’ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼2ã€ã«å¤‰æ›´ã—ã€Œã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã€ã¯ Alt+O ã«ç§»å‹•, Shift+Alt+2 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼12ã€ã‚’è¿½åŠ 
+//Jan. 19, 2001 JEPRO	Shift+Ctrl+2 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼22ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+3 ã‚’ã€Œãƒ•ã‚©ãƒ³ãƒˆè¨­å®šã€â†’ã€Œã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã®è¡¨ç¤ºã€ã«å¤‰æ›´
+//Jan. 13, 2001 JEPRO	Alt+3 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼3ã€, Shift+Alt+3 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼13ã€ã‚’è¿½åŠ 
+//Jan. 19, 2001 JEPRO	Shift+Ctrl+3 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼23ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+4 ã‚’ã€Œãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã®è¡¨ç¤ºã€â†’ã€Œã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šä¸€è¦§ã€ã«å¤‰æ›´
+//Jan. 13, 2001 JEPRO	Alt+4 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼4ã€, Shift+Alt+4 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼14ã€ã‚’è¿½åŠ 
+//Jan. 19, 2001 JEPRO	Shift+Ctrl+4 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼24ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+5 ã‚’ã€Œãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®è¡¨ç¤ºã€â†’ã€Œã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã€ã«å¤‰æ›´
+//Jan. 13, 2001 JEPRO	Alt+5 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼5ã€, Shift+Alt+5 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼15ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+6 ã‚’ã€Œã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã®è¡¨ç¤ºã€â†’ã€Œå…±é€šè¨­å®šã€ã«å¤‰æ›´
+//Jan. 13, 2001 JEPRO	Alt+6 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼6ã€, Shift+Alt+6 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼16ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+7 ã«ã€Œãƒ•ã‚©ãƒ³ãƒˆè¨­å®šã€ã‚’è¿½åŠ 
+//Jan. 13, 2001 JEPRO	Alt+7 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼7ã€, Shift+Alt+7 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼17ã€ã‚’è¿½åŠ 
+//Jan. 13, 2001 JEPRO	Alt+8 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼8ã€, Shift+Alt+8 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼18ã€ã‚’è¿½åŠ 
+//Jan. 13, 2001 JEPRO	Alt+9 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼9ã€, Shift+Alt+9 ã«ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼19ã€ã‚’è¿½åŠ 
+//2001.12.06 hor Alt+A ã‚’ã€ŒSORT_ASCã€ã«å‰²å½“
+//Jan. 13, 2001 JEPRO	Ctrl+B ã«ã€Œãƒ–ãƒ©ã‚¦ã‚ºã€ã‚’è¿½åŠ 
+//Jan. 16, 2001 JEPRO	SHift+Ctrl+C ã«ã€Œ.hã¨åŒåã®.c(ãªã‘ã‚Œã°.cpp)ã‚’é–‹ãã€ã‚’è¿½åŠ 
+//Feb. 07, 2001 JEPRO	SHift+Ctrl+C ã‚’ã€Œ.hã¨åŒåã®.c(ãªã‘ã‚Œã°.cpp)ã‚’é–‹ãã€â†’ã€ŒåŒåã®C/C++ãƒ˜ãƒƒãƒ€(ã‚½ãƒ¼ã‚¹)ã‚’é–‹ãã€ã«å¤‰æ›´
+//Jan. 16, 2001 JEPRO	Ctrl+D ã«ã€Œå˜èªåˆ‡ã‚Šå–ã‚Šã€, Shift+Ctrl+D ã«ã€Œå˜èªå‰Šé™¤ã€ã‚’è¿½åŠ 
+//2001.12.06 hor Alt+D ã‚’ã€ŒSORT_DESCã€ã«å‰²å½“
+//Oct. 7, 2000 JEPRO	Ctrl+Alt+E ã«ã€Œé‡ã­ã¦è¡¨ç¤ºã€ã‚’è¿½åŠ 
+//Jan. 16, 2001	JEPRO	Ctrl+E ã«ã€Œè¡Œåˆ‡ã‚Šå–ã‚Š(æŠ˜ã‚Šè¿”ã—å˜ä½)ã€, Shift+Ctrl+E ã«ã€Œè¡Œå‰Šé™¤(æŠ˜ã‚Šè¿”ã—å˜ä½)ã€ã‚’è¿½åŠ 
+//Oct. 07, 2000 JEPRO	Ctrl+Alt+H ã«ã€Œä¸Šä¸‹ã«ä¸¦ã¹ã¦è¡¨ç¤ºã€ã‚’è¿½åŠ 
+//Jan. 16, 2001 JEPRO	Ctrl+H ã‚’ã€Œã‚«ãƒ¼ã‚½ãƒ«å‰ã‚’å‰Šé™¤ã€â†’ã€Œã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸­å¤®ã¸ã€ã«å¤‰æ›´ã—	Shift+Ctrl+H ã«ã€Œ.cã¾ãŸã¯.cppã¨åŒåã®.hã‚’é–‹ãã€ã‚’è¿½åŠ 
+//Feb. 07, 2001 JEPRO	SHift+Ctrl+H ã‚’ã€Œ.cã¾ãŸã¯.cppã¨åŒåã®.hã‚’é–‹ãã€â†’ã€ŒåŒåã®C/C++ãƒ˜ãƒƒãƒ€(ã‚½ãƒ¼ã‚¹)ã‚’é–‹ãã€ã«å¤‰æ›´
+//Jan. 21, 2001	JEPRO	Ctrl+I ã«ã€Œè¡Œã®äºŒé‡åŒ–ã€ã‚’è¿½åŠ 
+//Jan. 16, 2001	JEPRO	Ctrl+K ã«ã€Œè¡Œæœ«ã¾ã§åˆ‡ã‚Šå–ã‚Š(æ”¹è¡Œå˜ä½)ã€, Shift+Ctrl+E ã«ã€Œè¡Œæœ«ã¾ã§å‰Šé™¤(æ”¹è¡Œå˜ä½)ã€ã‚’è¿½åŠ 
+//Jan. 14, 2001 JEPRO	Ctrl+Alt+L ã«ã€Œå°æ–‡å­—ã€, Shift+Ctrl+Alt+L ã«ã€Œå¤§æ–‡å­—ã€ã‚’è¿½åŠ 
+//Jan. 16, 2001 Ctrl+L ã‚’ã€Œã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸­å¤®ã¸ã€â†’ã€Œã‚­ãƒ¼ãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ã€ã«å¤‰æ›´ã—ã€Œã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸­å¤®ã¸ã€ã¯ Ctrl+H ã«ç§»å‹•
+//2001.12.03 hor Alt+L ã‚’ã€ŒLTRIMã€ã«å‰²å½“
+//Jan. 16, 2001 JEPRO	Ctrl+M ã«ã€Œã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ä¿å­˜ã€ã‚’è¿½åŠ 
+//2001.12.06 hor Alt+M ã‚’ã€ŒMERGEã€ã«å‰²å½“
+//Oct. 20, 2000 JEPRO	Alt+N ã«ã€Œç§»å‹•å±¥æ­´: æ¬¡ã¸ã€ã‚’è¿½åŠ 
+//Jan. 13, 2001 JEPRO	Alt+O ã«ã€Œã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+P ã«ã€Œå°åˆ·ã€, Shift+Ctrl+P ã«ã€Œå°åˆ·ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼ã€, Ctrl+Alt+P ã«ã€Œãƒšãƒ¼ã‚¸è¨­å®šã€ã‚’è¿½åŠ 
+//Oct. 20, 2000 JEPRO	Alt+P ã«ã€Œç§»å‹•å±¥æ­´: å‰ã¸ã€ã‚’è¿½åŠ 
+//Jan. 24, 2001	JEPRO	Ctrl+Q ã«ã€Œã‚­ãƒ¼å‰²ã‚Šå½“ã¦ä¸€è¦§ã‚’ã‚³ãƒ”ãƒ¼ã€ã‚’è¿½åŠ 
+//2001.12.03 hor Alt+R ã‚’ã€ŒRTRIMã€ã«å‰²å½“
+//Oct. 7, 2000 JEPRO	Shift+Ctrl+S ã«ã€Œåå‰ã‚’ä»˜ã‘ã¦ä¿å­˜ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+Alt+T ã«ã€Œå·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤ºã€ã‚’è¿½åŠ 
+//Jan. 21, 2001	JEPRO	Ctrl+T ã«ã€Œã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã€, Shift+Ctrl+T ã«ã€Œã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒãƒƒã‚¯ã€ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Ctrl+Alt+U ã«ã€Œç¾åœ¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ã§æŠ˜ã‚Šè¿”ã—ã€ã‚’è¿½åŠ 
+//Jan. 16, 2001	JEPRO	Ctrl+U ã«ã€Œè¡Œé ­ã¾ã§åˆ‡ã‚Šå–ã‚Š(æ”¹è¡Œå˜ä½)ã€, Shift+Ctrl+U ã«ã€Œè¡Œé ­ã¾ã§å‰Šé™¤(æ”¹è¡Œå˜ä½)ã€ã‚’è¿½åŠ 
+//Jan. 13, 2001 JEPRO	Alt+X ã‚’ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼1ã€â†’ã€Œæœªå®šç¾©ã€ã«å¤‰æ›´ã—ã€Œã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼1ã€ã¯ Alt+1 ã«ç§»å‹•
+//Oct. 7, 2000 JEPRO	Shift+Ctrl+- ã«ã€Œä¸Šä¸‹ã«åˆ†å‰²ã€ã‚’è¿½åŠ 
+// 2002.02.08 hor Ctrl+-ã«ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ã‚³ãƒ”ãƒ¼ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Shift+Ctrl+\ ã«ã€Œå·¦å³ã«åˆ†å‰²ã€ã‚’è¿½åŠ 
+//Sept. 20, 2000 JEPRO	Ctrl+@ ã«ã€Œãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒã€ã‚’è¿½åŠ   //Oct. 15, 2000 JEPROã€Œé¸æŠç¯„å›²å†…å…¨è¡Œã‚³ãƒ”ãƒ¼ã€ã«å¤‰æ›´
 //	Aug. 16, 2000 genta
-//	”½‘ÎŒü‚«‚ÌŠ‡ŒÊ‚É‚àŠ‡ŒÊŒŸõ‚ğ’Ç‰Á
-//Oct. 7, 2000 JEPRO	Shift+Ctrl+; ‚Éuc‰¡‚É•ªŠ„v‚ğ’Ç‰Á	//Jan. 16, 2001	Alt+; ‚Éu“ú•t‘}“üv‚ğ’Ç‰Á
-//Sept. 14, 2000 JEPRO	Ctrl+: ‚Éu‘I‘ğ”ÍˆÍ“à‘Sss”Ô†•t‚«ƒRƒs[v‚ğ’Ç‰Á	//Jan. 16, 2001	Alt+: ‚Éu‘}“üv‚ğ’Ç‰Á
-//Sept. 14, 2000 JEPRO	Ctrl+. ‚Éu‘I‘ğ”ÍˆÍ“à‘Ssˆø—p•„•t‚«ƒRƒs[v‚ğ’Ç‰Á
-//	Nov. 15, 2000 genta PC/ATƒL[ƒ{[ƒh‚É‡‚í‚¹‚ÄƒL[ƒR[ƒh‚ğ•ÏX
-//	PC98‹~Ï‚Ì‚½‚ßC]—ˆ‚ÌƒL[ƒR[ƒh‚É‘Î‰‚·‚é€–Ú‚ğ’Ç‰ÁD
-//Oct. 7, 2000 JEPRO	’·‚­‚Ä•\¦‚µ‚«‚ê‚È‚¢Š‚ª‚Å‚Ä‚«‚Ä‚µ‚Ü‚¤‚Ì‚ÅƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒL[¨ƒAƒvƒŠƒL[‚É’Zk
-//2008.05.03 kobake ‰Â“Ç«‚ª’˜‚µ‚­’á‰º‚µ‚Ä‚¢‚½‚Ì‚ÅA‘®‚ğ®—B
-// 2008.05.30 nasukoji	Ctrl+Alt+S ‚Éuw’èŒ…‚ÅÜ‚è•Ô‚·v‚ğ’Ç‰Á
-// 2008.05.30 nasukoji	Ctrl+Alt+W ‚Éu‰E’[‚ÅÜ‚è•Ô‚·v‚ğ’Ç‰Á
-// 2008.05.30 nasukoji	Ctrl+Alt+X ‚ÉuÜ‚è•Ô‚³‚È‚¢v‚ğ’Ç‰Á
+//	åå¯¾å‘ãã®æ‹¬å¼§ã«ã‚‚æ‹¬å¼§æ¤œç´¢ã‚’è¿½åŠ 
+//Oct. 7, 2000 JEPRO	Shift+Ctrl+; ã«ã€Œç¸¦æ¨ªã«åˆ†å‰²ã€ã‚’è¿½åŠ 	//Jan. 16, 2001	Alt+; ã«ã€Œæ—¥ä»˜æŒ¿å…¥ã€ã‚’è¿½åŠ 
+//Sept. 14, 2000 JEPRO	Ctrl+: ã«ã€Œé¸æŠç¯„å›²å†…å…¨è¡Œè¡Œç•ªå·ä»˜ãã‚³ãƒ”ãƒ¼ã€ã‚’è¿½åŠ 	//Jan. 16, 2001	Alt+: ã«ã€Œæ™‚åˆ»æŒ¿å…¥ã€ã‚’è¿½åŠ 
+//Sept. 14, 2000 JEPRO	Ctrl+. ã«ã€Œé¸æŠç¯„å›²å†…å…¨è¡Œå¼•ç”¨ç¬¦ä»˜ãã‚³ãƒ”ãƒ¼ã€ã‚’è¿½åŠ 
+//	Nov. 15, 2000 genta PC/ATã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ã«åˆã‚ã›ã¦ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ã‚’å¤‰æ›´
+//	PC98æ•‘æ¸ˆã®ãŸã‚ï¼Œå¾“æ¥ã®ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ã«å¯¾å¿œã™ã‚‹é …ç›®ã‚’è¿½åŠ ï¼
+//Oct. 7, 2000 JEPRO	é•·ãã¦è¡¨ç¤ºã—ãã‚Œãªã„æ‰€ãŒã§ã¦ãã¦ã—ã¾ã†ã®ã§ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚­ãƒ¼â†’ã‚¢ãƒ—ãƒªã‚­ãƒ¼ã«çŸ­ç¸®
+//2008.05.03 kobake å¯èª­æ€§ãŒè‘—ã—ãä½ä¸‹ã—ã¦ã„ãŸã®ã§ã€æ›¸å¼ã‚’æ•´ç†ã€‚
+// 2008.05.30 nasukoji	Ctrl+Alt+S ã«ã€ŒæŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™ã€ã‚’è¿½åŠ 
+// 2008.05.30 nasukoji	Ctrl+Alt+W ã«ã€Œå³ç«¯ã§æŠ˜ã‚Šè¿”ã™ã€ã‚’è¿½åŠ 
+// 2008.05.30 nasukoji	Ctrl+Alt+X ã«ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€ã‚’è¿½åŠ 
 
 #define _SQL_RUN	F_PLSQL_COMPILE_ON_SQLPLUS
 #define _COPYWITHLINENUM	F_COPYLINESWITHLINENUMBER
 static const KEYDATAINIT	KeyDataInit[] = {
 //Sept. 1, 2000 Jepro note: key binding
-//Feb. 17, 2001 jepro note 2: ‡”Ô‚Í2i‚Å‰ºˆÊ3ƒrƒbƒg[Alt][Ctrl][Shift]‚Ì‘g‡‚¹‚Ì‡(‚»‚ê‚É2‚ğ‰Á‚¦‚½’l)
+//Feb. 17, 2001 jepro note 2: é †ç•ªã¯2é€²ã§ä¸‹ä½3ãƒ“ãƒƒãƒˆ[Alt][Ctrl][Shift]ã®çµ„åˆã›ã®é †(ãã‚Œã«2ã‚’åŠ ãˆãŸå€¤)
 //		0,		1,		 2(000), 3(001),4(010),	5(011),		6(100),	7(101),		8(110),		9(111)
 
-	/* ƒ}ƒEƒXƒ{ƒ^ƒ“ */
-	//keycode,			keyname,							‚È‚µ,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
-	{ VKEX_DBL_CLICK,	(LPCTSTR)STR_KEY_BIND_DBL_CLICK,	{ F_SELECTWORD,		F_SELECTWORD,		F_SELECTWORD,			F_SELECTWORD,		F_SELECTWORD,			F_SELECTWORD,		F_SELECTWORD,			F_SELECTWORD }, }, //Feb. 19, 2001 JEPRO Alt‚Æ‰EƒNƒŠƒbƒN‚Ì‘g‡‚¹‚ÍŒø‚©‚È‚¢‚Ì‚Å‰EƒNƒŠƒbƒNƒƒjƒ…[‚ÌƒL[Š„‚è“–‚Ä‚ğ‚Í‚¸‚µ‚½
+	/* ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³ */
+	//keycode,			keyname,							ãªã—,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
+	{ VKEX_DBL_CLICK,	(LPCTSTR)STR_KEY_BIND_DBL_CLICK,	{ F_SELECTWORD,		F_SELECTWORD,		F_SELECTWORD,			F_SELECTWORD,		F_SELECTWORD,			F_SELECTWORD,		F_SELECTWORD,			F_SELECTWORD }, }, //Feb. 19, 2001 JEPRO Altã¨å³ã‚¯ãƒªãƒƒã‚¯ã®çµ„åˆã›ã¯åŠ¹ã‹ãªã„ã®ã§å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ã‚’ã¯ãšã—ãŸ
 	{ VKEX_R_CLICK,		(LPCTSTR)STR_KEY_BIND_R_CLICK,		{ F_MENU_RBUTTON,	F_MENU_RBUTTON,		F_MENU_RBUTTON,			F_MENU_RBUTTON,		F_0,					F_0,				F_0,					F_0 }, },
-	{ VKEX_MDL_CLICK,	(LPCTSTR)STR_KEY_BIND_MID_CLICK,	{ F_AUTOSCROLL,		F_0,				F_0,					F_0,				F_0,					F_0,				F_0,					F_0 }, }, // novice 2004/10/11 ƒ}ƒEƒX’†ƒ{ƒ^ƒ“‘Î‰
-	{ VKEX_LSD_CLICK,	(LPCTSTR)STR_KEY_BIND_LSD_CLICK,	{ F_0,				F_0,				F_0,					F_0,				F_0,					F_0,				F_0,					F_0 }, }, // novice 2004/10/10 ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“‘Î‰
+	{ VKEX_MDL_CLICK,	(LPCTSTR)STR_KEY_BIND_MID_CLICK,	{ F_AUTOSCROLL,		F_0,				F_0,					F_0,				F_0,					F_0,				F_0,					F_0 }, }, // novice 2004/10/11 ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³å¯¾å¿œ
+	{ VKEX_LSD_CLICK,	(LPCTSTR)STR_KEY_BIND_LSD_CLICK,	{ F_0,				F_0,				F_0,					F_0,				F_0,					F_0,				F_0,					F_0 }, }, // novice 2004/10/10 ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³å¯¾å¿œ
 	{ VKEX_RSD_CLICK,	(LPCTSTR)STR_KEY_BIND_RSD_CLICK,	{ F_0,				F_0,				F_0,					F_0,				F_0,					F_0,				F_0,					F_0 }, },
 	{ VKEX_TRI_CLICK,	(LPCTSTR)STR_KEY_BIND_TRI_CLICK,	{ F_SELECTLINE,		F_SELECTLINE,		F_SELECTLINE,			F_SELECTLINE,		F_SELECTLINE,			F_SELECTLINE,		F_SELECTLINE,			F_SELECTLINE }, },
 	{ VKEX_QUA_CLICK,	(LPCTSTR)STR_KEY_BIND_QUA_CLICK,	{ F_SELECTALL,		F_SELECTALL,		F_SELECTALL,			F_SELECTALL,		F_SELECTALL,			F_SELECTALL,		F_SELECTALL,			F_SELECTALL }, },
@@ -703,8 +703,8 @@ static const KEYDATAINIT	KeyDataInit[] = {
 	{ VKEX_WHEEL_LEFT,	(LPCTSTR)STR_KEY_BIND_WHEEL_LEFT,	{ F_WHEELLEFT,		F_WHEELLEFT,		F_WHEELLEFT,			F_WHEELLEFT,		F_WHEELLEFT,			F_WHEELLEFT,		F_WHEELLEFT,			F_WHEELLEFT }, },
 	{ VKEX_WHEEL_RIGHT,	(LPCTSTR)STR_KEY_BIND_WHEEL_RIGHT,	{ F_WHEELRIGHT,		F_WHEELRIGHT,		F_WHEELRIGHT,			F_WHEELRIGHT,		F_WHEELRIGHT,			F_WHEELRIGHT,		F_WHEELRIGHT,			F_WHEELRIGHT }, },
 
-	/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[ */
-	//keycode,	keyname,			‚È‚µ,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
+	/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ */
+	//keycode,	keyname,			ãªã—,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
 	{ VK_F1,	_T("F1" ),			{ F_EXTHTMLHELP,	F_MENU_ALLFUNC,		F_EXTHELP1,				F_ABOUT,			F_HELP_CONTENTS,		F_HELP_SEARCH,		F_0,					F_0 }, },
 	{ VK_F2,	_T("F2" ),			{ F_BOOKMARK_NEXT,	F_BOOKMARK_PREV,	F_BOOKMARK_SET,			F_BOOKMARK_RESET,	F_BOOKMARK_VIEW,		F_0,				F_0,					F_0 }, },
 	{ VK_F3,	_T("F3" ),			{ F_SEARCH_NEXT,	F_SEARCH_PREV,		F_SEARCH_CLEARMARK,		F_JUMP_SRCHSTARTPOS,F_0,					F_0,				F_0,					F_0 }, },
@@ -730,8 +730,8 @@ static const KEYDATAINIT	KeyDataInit[] = {
 	{ VK_F23,	_T("F23"),			{ F_0,				F_0,				F_0,					F_0,				F_0,					F_0,				F_0,					F_0 }, },
 	{ VK_F24,	_T("F24"),			{ F_0,				F_0,				F_0,					F_0,				F_0,					F_0,				F_0,					F_0 }, },
 
-	/* “ÁêƒL[ */
-	//keycode,	keyname,			‚È‚µ,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
+	/* ç‰¹æ®Šã‚­ãƒ¼ */
+	//keycode,	keyname,			ãªã—,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
 	{ VK_TAB,	_T("Tab"),			{ F_INDENT_TAB,		F_UNINDENT_TAB,		F_NEXTWINDOW,			F_PREVWINDOW,		F_0,					F_0,				F_0,					F_0 }, },
 	{ VK_RETURN,_T("Enter"),		{ F_0,				F_0,				F_COMPARE,				F_0,				F_PROPERTY_FILE,		F_0,				F_0,					F_0 }, },
 	{ VK_ESCAPE,_T("Esc"),			{ F_CANCEL_MODE,	F_0,				F_0,					F_0,				F_0,					F_0,				F_0,					F_0 }, },
@@ -740,16 +740,16 @@ static const KEYDATAINIT	KeyDataInit[] = {
 	{ VK_DELETE,_T("Del"),			{ F_DELETE,			F_CUT,				F_WordDeleteToEnd,		F_0,				F_0,					F_0,				F_0,					F_0 }, },
 	{ VK_HOME,	_T("Home"),			{ F_GOLINETOP,		F_GOLINETOP_SEL,	F_GOFILETOP,			F_GOFILETOP_SEL,	F_GOLINETOP_BOX,		F_0,				F_GOFILETOP_BOX,		F_0 }, },
 	{ VK_END,	_T("End(Help)"),	{ F_GOLINEEND,		F_GOLINEEND_SEL,	F_GOFILEEND,			F_GOFILEEND_SEL,	F_GOLINEEND_BOX,		F_0,				F_GOFILEEND_BOX,		F_0 }, },
-	{ VK_LEFT,	_T("©"),			{ F_LEFT,			F_LEFT_SEL,			F_WORDLEFT,				F_WORDLEFT_SEL,		F_LEFT_BOX,				F_0,				F_WORDLEFT_BOX,			F_0 }, },
-	{ VK_UP,	_T("ª"),			{ F_UP,				F_UP_SEL,			F_WndScrollDown,		F_UP2_SEL,			F_UP_BOX,				F_0,				F_UP2_BOX,				F_MAXIMIZE_V },}, 
-	{ VK_RIGHT,	_T("¨"),			{ F_RIGHT,			F_RIGHT_SEL,		F_WORDRIGHT,			F_WORDRIGHT_SEL,	F_RIGHT_BOX,			F_0,				F_WORDRIGHT_BOX,		F_MAXIMIZE_H },}, 
-	{ VK_DOWN,	_T("«"),			{ F_DOWN,			F_DOWN_SEL,			F_WndScrollUp,			F_DOWN2_SEL,		F_DOWN_BOX,				F_0,				F_DOWN2_BOX,			F_MINIMIZE_ALL },}, 
+	{ VK_LEFT,	_T("â†"),			{ F_LEFT,			F_LEFT_SEL,			F_WORDLEFT,				F_WORDLEFT_SEL,		F_LEFT_BOX,				F_0,				F_WORDLEFT_BOX,			F_0 }, },
+	{ VK_UP,	_T("â†‘"),			{ F_UP,				F_UP_SEL,			F_WndScrollDown,		F_UP2_SEL,			F_UP_BOX,				F_0,				F_UP2_BOX,				F_MAXIMIZE_V },}, 
+	{ VK_RIGHT,	_T("â†’"),			{ F_RIGHT,			F_RIGHT_SEL,		F_WORDRIGHT,			F_WORDRIGHT_SEL,	F_RIGHT_BOX,			F_0,				F_WORDRIGHT_BOX,		F_MAXIMIZE_H },}, 
+	{ VK_DOWN,	_T("â†“"),			{ F_DOWN,			F_DOWN_SEL,			F_WndScrollUp,			F_DOWN2_SEL,		F_DOWN_BOX,				F_0,				F_DOWN2_BOX,			F_MINIMIZE_ALL },}, 
 	{ VK_NEXT,	_T("PgDn(RollUp)"),	{ F_1PageDown,		F_1PageDown_Sel,	F_HalfPageDown,			F_HalfPageDown_Sel,	F_1PageDown_BOX,		F_0,				F_HalfPageDown_BOX,		F_0 }, },
 	{ VK_PRIOR,	_T("PgUp(RollDn)"),	{ F_1PageUp,		F_1PageUp_Sel,		F_HalfPageUp,			F_HalfPageUp_Sel,	F_1PageUp_BOX,			F_0,				F_HalfPageUp_BOX,		F_0 }, },
 	{ VK_SPACE,	_T("Space"),		{ F_INDENT_SPACE,	F_UNINDENT_SPACE,	F_HOKAN,				F_0,				F_0,					F_0,				F_0,					F_0 }, },
 
-	/* ”š */
-	//keycode,	keyname,			‚È‚µ,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
+	/* æ•°å­— */
+	//keycode,	keyname,			ãªã—,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
 	{ '0',		_T("0"),			{ F_0,				F_0,				F_0,					F_0,				F_CUSTMENU_10,			F_CUSTMENU_20,		F_0,					F_0 }, },
 	{ '1',		_T("1"),			{ F_0,				F_0,				F_SHOWTOOLBAR,			F_CUSTMENU_21,		F_CUSTMENU_1,			F_CUSTMENU_11,		F_0,					F_0 }, },
 	{ '2',		_T("2"),			{ F_0,				F_0,				F_SHOWFUNCKEY,			F_CUSTMENU_22,		F_CUSTMENU_2,			F_CUSTMENU_12,		F_0,					F_0 }, },
@@ -761,8 +761,8 @@ static const KEYDATAINIT	KeyDataInit[] = {
 	{ '8',		_T("8"),			{ F_0,				F_0,				F_0,					F_0,				F_CUSTMENU_8,			F_CUSTMENU_18,		F_0,					F_0 }, },
 	{ '9',		_T("9"),			{ F_0,				F_0,				F_0,					F_0,				F_CUSTMENU_9,			F_CUSTMENU_19,		F_0,					F_0 }, },
 
-	/* ƒAƒ‹ƒtƒ@ƒxƒbƒg */
-	//keycode,	keyname,			‚È‚µ,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
+	/* ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆ */
+	//keycode,	keyname,			ãªã—,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
 	{ 'A',		_T("A"),			{ F_0,				F_0,				F_SELECTALL,			F_0,				F_SORT_ASC,				F_0,				F_0,					F_0 }, },
 	{ 'B',		_T("B"),			{ F_0,				F_0,				F_BROWSE,				F_0,				F_0,					F_0,				F_0,					F_0 }, },
 	{ 'C',		_T("C"),			{ F_0,				F_0,				F_COPY,					F_OPEN_HfromtoC,	F_0,					F_0,				F_0,					F_0 }, },
@@ -790,8 +790,8 @@ static const KEYDATAINIT	KeyDataInit[] = {
 	{ 'Y',		_T("Y"),			{ F_0,				F_0,				F_REDO,					F_0,				F_0,					F_0,				F_0,					F_0 }, },
 	{ 'Z',		_T("Z"),			{ F_0,				F_0,				F_UNDO,					F_0,				F_0,					F_0,				F_0,					F_0 }, },
 
-	/* ‹L† */
-	//keycode,	keyname,			‚È‚µ,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
+	/* è¨˜å· */
+	//keycode,	keyname,			ãªã—,				Shitf+,				Ctrl+,					Shift+Ctrl+,		Alt+,					Shit+Alt+,			Ctrl+Alt+,				Shift+Ctrl+Alt+
 	{ 0x00bd,	_T("-"),			{ F_0,				F_0,				F_COPYFNAME,			F_SPLIT_V,			F_0,					F_0,				F_0,					F_0 }, },
 	{ 0x00de,	(LPCTSTR)STR_KEY_BIND_HAT_ENG_QT,		{ F_0,				F_0,				F_COPYTAG,				F_0,				F_0,					F_0,				F_0,					F_0 }, },
 	{ 0x00dc,	_T("\\"),			{ F_0,				F_0,				F_COPYPATH,				F_SPLIT_H,			F_0,					F_0,				F_0,					F_0 }, },
@@ -809,50 +809,50 @@ static const KEYDATAINIT	KeyDataInit[] = {
 };
 
 const TCHAR* jpVKEXNames[] = {
-	_T("ƒ_ƒuƒ‹ƒNƒŠƒbƒN"),
-	_T("‰EƒNƒŠƒbƒN"),
-	_T("’†ƒNƒŠƒbƒN"),
-	_T("¶ƒTƒCƒhƒNƒŠƒbƒN"),
-	_T("‰EƒTƒCƒhƒNƒŠƒbƒN"),
-	_T("ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN"),
-	_T("ƒNƒAƒhƒ‰ƒvƒ‹ƒNƒŠƒbƒN"),
-	_T("ƒzƒC[ƒ‹ƒAƒbƒv"),
-	_T("ƒzƒC[ƒ‹ƒ_ƒEƒ“"),
-	_T("ƒzƒC[ƒ‹¶"),
-	_T("ƒzƒC[ƒ‹‰E")
+	_T("ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯"),
+	_T("å³ã‚¯ãƒªãƒƒã‚¯"),
+	_T("ä¸­ã‚¯ãƒªãƒƒã‚¯"),
+	_T("å·¦ã‚µã‚¤ãƒ‰ã‚¯ãƒªãƒƒã‚¯"),
+	_T("å³ã‚µã‚¤ãƒ‰ã‚¯ãƒªãƒƒã‚¯"),
+	_T("ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯"),
+	_T("ã‚¯ã‚¢ãƒ‰ãƒ©ãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯"),
+	_T("ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¢ãƒƒãƒ—"),
+	_T("ãƒ›ã‚¤ãƒ¼ãƒ«ãƒ€ã‚¦ãƒ³"),
+	_T("ãƒ›ã‚¤ãƒ¼ãƒ«å·¦"),
+	_T("ãƒ›ã‚¤ãƒ¼ãƒ«å³")
 };
 const int jpVKEXNamesLen = _countof( jpVKEXNames );
 
-/*!	@brief ‹¤—Lƒƒ‚ƒŠ‰Šú‰»/ƒL[Š„‚è“–‚Ä
+/*!	@brief å…±æœ‰ãƒ¡ãƒ¢ãƒªåˆæœŸåŒ–/ã‚­ãƒ¼å‰²ã‚Šå½“ã¦
 
-	ƒfƒtƒHƒ‹ƒgƒL[Š„‚è“–‚ÄŠÖ˜A‚Ì‰Šú‰»ˆ—
+	ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã‚­ãƒ¼å‰²ã‚Šå½“ã¦é–¢é€£ã®åˆæœŸåŒ–å‡¦ç†
 
-	@date 2005.01.30 genta CShareData::Init()‚©‚ç•ª—£
-	@date 2007.11.04 genta ƒL[İ’è”‚ªDLLSHARE‚Ì—Ìˆæ‚ğ’´‚¦‚½‚ç‹N“®‚Å‚«‚È‚¢‚æ‚¤‚É
+	@date 2005.01.30 genta CShareData::Init()ã‹ã‚‰åˆ†é›¢
+	@date 2007.11.04 genta ã‚­ãƒ¼è¨­å®šæ•°ãŒDLLSHAREã®é ˜åŸŸã‚’è¶…ãˆãŸã‚‰èµ·å‹•ã§ããªã„ã‚ˆã†ã«
 */
 bool CShareData::InitKeyAssign(DLLSHAREDATA* pShareData)
 {
 	/********************/
-	/* ‹¤’Êİ’è‚Ì‹K’è’l */
+	/* å…±é€šè¨­å®šã®è¦å®šå€¤ */
 	/********************/
 	const int	nKeyDataInitNum = _countof( KeyDataInit );
-	const int	KEYNAME_SIZE = _countof( pShareData->m_Common.m_sKeyBind.m_pKeyNameArr ) -1;// ÅŒã‚Ì‚P—v‘f‚Íƒ_ƒ~[—p‚É—\–ñ 2012.11.25 aroka
-	//	From Here 2007.11.04 genta ƒoƒbƒtƒ@ƒI[ƒo[ƒ‰ƒ“–h~
+	const int	KEYNAME_SIZE = _countof( pShareData->m_Common.m_sKeyBind.m_pKeyNameArr ) -1;// æœ€å¾Œã®ï¼‘è¦ç´ ã¯ãƒ€ãƒŸãƒ¼ç”¨ã«äºˆç´„ 2012.11.25 aroka
+	//	From Here 2007.11.04 genta ãƒãƒƒãƒ•ã‚¡ã‚ªãƒ¼ãƒãƒ¼ãƒ©ãƒ³é˜²æ­¢
 	assert( !(nKeyDataInitNum > KEYNAME_SIZE) );
 //	if( nKeyDataInitNum > KEYNAME_SIZE ) {
-//		PleaseReportToAuthor( NULL, _T("ƒL[İ’è”‚É‘Î‚µ‚ÄDLLSHARE::m_nKeyNameArr[]‚ÌƒTƒCƒY‚ª•s‘«‚µ‚Ä‚¢‚Ü‚·") );
+//		PleaseReportToAuthor( NULL, _T("ã‚­ãƒ¼è¨­å®šæ•°ã«å¯¾ã—ã¦DLLSHARE::m_nKeyNameArr[]ã®ã‚µã‚¤ã‚ºãŒä¸è¶³ã—ã¦ã„ã¾ã™") );
 //		return false;
 //	}
-	//	To Here 2007.11.04 genta ƒoƒbƒtƒ@ƒI[ƒo[ƒ‰ƒ“–h~
+	//	To Here 2007.11.04 genta ãƒãƒƒãƒ•ã‚¡ã‚ªãƒ¼ãƒãƒ¼ãƒ©ãƒ³é˜²æ­¢
 
-	// ƒ}ƒEƒXƒR[ƒh‚ÌŒÅ’è‚Æd•¡”rœ 2012.11.25 aroka
+	// ãƒã‚¦ã‚¹ã‚³ãƒ¼ãƒ‰ã®å›ºå®šã¨é‡è¤‡æ’é™¤ 2012.11.25 aroka
 	static const KEYDATAINIT	dummy[] = {
 		{ 0,		_T(""),				{ F_0,				F_0,				F_0,					F_0,				F_0,					F_0,				F_0,					F_0 } }
 	};
 
-	// ƒCƒ“ƒfƒbƒNƒX—pƒ_ƒ~[ì¬
+	// ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ç”¨ãƒ€ãƒŸãƒ¼ä½œæˆ
 	SetKeyNameArrVal( pShareData, KEYNAME_SIZE, &dummy[0] );
-	// ƒCƒ“ƒfƒbƒNƒXì¬ d•¡‚µ‚½ê‡‚Íæ“ª‚É‚ ‚é‚à‚Ì‚ğ—Dæ
+	// ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ä½œæˆ é‡è¤‡ã—ãŸå ´åˆã¯å…ˆé ­ã«ã‚ã‚‹ã‚‚ã®ã‚’å„ªå…ˆ
 	for( int ii = 0; ii< _countof(pShareData->m_Common.m_sKeyBind.m_VKeyToKeyNameArr); ii++ ){
 		pShareData->m_Common.m_sKeyBind.m_VKeyToKeyNameArr[ii] = KEYNAME_SIZE;
 	}
@@ -867,7 +867,7 @@ bool CShareData::InitKeyAssign(DLLSHAREDATA* pShareData)
 	return true;
 }
 
-/*!	@brief Œ¾Œê‘I‘ğŒã‚Ì•¶š—ñXVˆ— */
+/*!	@brief è¨€èªé¸æŠå¾Œã®æ–‡å­—åˆ—æ›´æ–°å‡¦ç† */
 void CShareData::RefreshKeyAssignString(DLLSHAREDATA* pShareData)
 {
 	const int	nKeyDataInitNum = _countof( KeyDataInit );
@@ -885,10 +885,10 @@ void CShareData::RefreshKeyAssignString(DLLSHAREDATA* pShareData)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         À‘••â•                            //
+//                         å®Ÿè£…è£œåŠ©                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*! KEYDATA”z—ñ‚Éƒf[ƒ^‚ğƒZƒbƒg */
+/*! KEYDATAé…åˆ—ã«ãƒ‡ãƒ¼ã‚¿ã‚’ã‚»ãƒƒãƒˆ */
 static void SetKeyNameArrVal(
 	DLLSHAREDATA*		pShareData,
 	int					nIdx,

--- a/sakura_core/func/CKeyBind.h
+++ b/sakura_core/func/CKeyBind.h
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ƒL[Š„‚è“–‚Ä‚ÉŠÖ‚·‚éƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ã«é–¢ã™ã‚‹ã‚¯ãƒ©ã‚¹
 
 	@author Norio Nakatani
-	@date 1998/03/25 V‹Kì¬
-	@date 1998/05/16 ƒNƒ‰ƒX“à‚Éƒf[ƒ^‚ğ‚½‚È‚¢‚æ‚¤‚É•ÏX
+	@date 1998/03/25 æ–°è¦ä½œæˆ
+	@date 1998/05/16 ã‚¯ãƒ©ã‚¹å†…ã«ãƒ‡ãƒ¼ã‚¿ã‚’æŒãŸãªã„ã‚ˆã†ã«å¤‰æ›´
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -20,47 +20,47 @@
 
 class CFuncLookup;
 
-//! ƒL[î•ñ‚ğ•Û‚·‚é
+//! ã‚­ãƒ¼æƒ…å ±ã‚’ä¿æŒã™ã‚‹
 struct KEYDATA {
-	/*! ƒL[ƒR[ƒh	*/
+	/*! ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰	*/
 	short			m_nKeyCode;
 	
-	/*!	ƒL[‚Ì–¼‘O	*/
+	/*!	ã‚­ãƒ¼ã®åå‰	*/
 	TCHAR			m_szKeyName[30];
 	
-	/*!	‘Î‰‚·‚é‹@”\”Ô†
+	/*!	å¯¾å¿œã™ã‚‹æ©Ÿèƒ½ç•ªå·
 
-		SHIFT, CTRL, ALT‚Ì‚R‚Â‚ÌƒVƒtƒgó‘Ô‚Ì‚»‚ê‚¼‚ê‚É‘Î‚µ‚Ä
-		‹@”\‚ğŠ„‚è“–‚Ä‚é‚½‚ßA”z—ñ‚É‚È‚Á‚Ä‚¢‚éB
+		SHIFT, CTRL, ALTã®ï¼“ã¤ã®ã‚·ãƒ•ãƒˆçŠ¶æ…‹ã®ãã‚Œãã‚Œã«å¯¾ã—ã¦
+		æ©Ÿèƒ½ã‚’å‰²ã‚Šå½“ã¦ã‚‹ãŸã‚ã€é…åˆ—ã«ãªã£ã¦ã„ã‚‹ã€‚
 	*/
 	EFunctionCode	m_nFuncCodeArr[8];
 };
 
-/*! ‰¼‘zƒL[ƒR[ƒh“Æ©Šg’£ */
-#define VKEX_DBL_CLICK		0x0100	// ƒ_ƒuƒ‹ƒNƒŠƒbƒN
-#define VKEX_R_CLICK		0x0101	// ‰EƒNƒŠƒbƒN
-#define VKEX_MDL_CLICK		0x0102	// ’†ƒNƒŠƒbƒN
-#define VKEX_LSD_CLICK		0x0103	// ¶ƒTƒCƒhƒNƒŠƒbƒN
-#define VKEX_RSD_CLICK		0x0104	// ‰EƒTƒCƒhƒNƒŠƒbƒN
+/*! ä»®æƒ³ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ç‹¬è‡ªæ‹¡å¼µ */
+#define VKEX_DBL_CLICK		0x0100	// ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯
+#define VKEX_R_CLICK		0x0101	// å³ã‚¯ãƒªãƒƒã‚¯
+#define VKEX_MDL_CLICK		0x0102	// ä¸­ã‚¯ãƒªãƒƒã‚¯
+#define VKEX_LSD_CLICK		0x0103	// å·¦ã‚µã‚¤ãƒ‰ã‚¯ãƒªãƒƒã‚¯
+#define VKEX_RSD_CLICK		0x0104	// å³ã‚µã‚¤ãƒ‰ã‚¯ãƒªãƒƒã‚¯
 
-#define VKEX_TRI_CLICK		0x0105	// ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN
-#define VKEX_QUA_CLICK		0x0106	// ƒNƒAƒhƒ‰ƒvƒ‹ƒNƒŠƒbƒN
+#define VKEX_TRI_CLICK		0x0105	// ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯
+#define VKEX_QUA_CLICK		0x0106	// ã‚¯ã‚¢ãƒ‰ãƒ©ãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯
 
-#define VKEX_WHEEL_UP		0x0107	// ƒzƒC[ƒ‹ƒAƒbƒv
-#define VKEX_WHEEL_DOWN		0x0108	// ƒzƒC[ƒ‹ƒ_ƒEƒ“
-#define VKEX_WHEEL_LEFT		0x0109	// ƒzƒC[ƒ‹¶
-#define VKEX_WHEEL_RIGHT	0x010A	// ƒzƒC[ƒ‹‰E
+#define VKEX_WHEEL_UP		0x0107	// ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¢ãƒƒãƒ—
+#define VKEX_WHEEL_DOWN		0x0108	// ãƒ›ã‚¤ãƒ¼ãƒ«ãƒ€ã‚¦ãƒ³
+#define VKEX_WHEEL_LEFT		0x0109	// ãƒ›ã‚¤ãƒ¼ãƒ«å·¦
+#define VKEX_WHEEL_RIGHT	0x010A	// ãƒ›ã‚¤ãƒ¼ãƒ«å³
 
 extern const TCHAR* jpVKEXNames[];
 extern const int jpVKEXNamesLen;
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 /*!
-	@brief ƒL[Š„‚è“–‚ÄŠÖ˜Aƒ‹[ƒ`ƒ“
+	@brief ã‚­ãƒ¼å‰²ã‚Šå½“ã¦é–¢é€£ãƒ«ãƒ¼ãƒãƒ³
 	
-	‚·‚×‚Ä‚ÌŠÖ”‚Ístatic‚Å•Û‚·‚éƒf[ƒ^‚Í‚È‚¢B
+	ã™ã¹ã¦ã®é–¢æ•°ã¯staticã§ä¿æŒã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã¯ãªã„ã€‚
 */
 class CKeyBind
 {
@@ -72,24 +72,24 @@ public:
 	~CKeyBind();
 
 	/*
-	||  QÆŒnƒƒ“ƒoŠÖ”
+	||  å‚ç…§ç³»ãƒ¡ãƒ³ãƒé–¢æ•°
 	*/
 	static HACCEL CreateAccerelator( int, KEYDATA* );
 	static EFunctionCode GetFuncCode( WORD nAccelCmd, int nKeyNameArrNum, KEYDATA* pKeyNameArr, BOOL bGetDefFuncCode = TRUE );
-	static EFunctionCode GetFuncCodeAt( KEYDATA& KeyData, int nState, BOOL bGetDefFuncCode = TRUE );	/* “Á’è‚ÌƒL[î•ñ‚©‚ç‹@”\ƒR[ƒh‚ğæ“¾‚·‚é */	// 2007.02.24 ryoji
-	static EFunctionCode GetDefFuncCode( int nKeyCode, int nState );	/* ƒL[‚ÌƒfƒtƒHƒ‹ƒg‹@”\‚ğæ“¾‚·‚é */	// 2007.02.22 ryoji
+	static EFunctionCode GetFuncCodeAt( KEYDATA& KeyData, int nState, BOOL bGetDefFuncCode = TRUE );	/* ç‰¹å®šã®ã‚­ãƒ¼æƒ…å ±ã‹ã‚‰æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã‚’å–å¾—ã™ã‚‹ */	// 2007.02.24 ryoji
+	static EFunctionCode GetDefFuncCode( int nKeyCode, int nState );	/* ã‚­ãƒ¼ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½ã‚’å–å¾—ã™ã‚‹ */	// 2007.02.22 ryoji
 
-	//! ƒL[Š„‚è“–‚Äˆê——‚ğì¬‚·‚é
+	//! ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ä¸€è¦§ã‚’ä½œæˆã™ã‚‹
 	static int CreateKeyBindList( HINSTANCE hInstance, int nKeyNameArrNum, KEYDATA* pKeyNameArr, CNativeW& cMemList, CFuncLookup* pcFuncLookup, BOOL bGetDefFuncCode = TRUE );
-	static int GetKeyStr( HINSTANCE hInstance, int nKeyNameArrNum, KEYDATA* pKeyNameArr, CNativeT& cMemList, int nFuncId, BOOL bGetDefFuncCode = TRUE );	/* ‹@”\‚É‘Î‰‚·‚éƒL[–¼‚Ìæ“¾ */
-	static int GetKeyStrList( HINSTANCE	hInstance, int nKeyNameArrNum,KEYDATA* pKeyNameArr, CNativeT*** pppcMemList, int nFuncId, BOOL bGetDefFuncCode = TRUE );	/* ‹@”\‚É‘Î‰‚·‚éƒL[–¼‚Ìæ“¾(•¡”) */
-	static TCHAR* GetMenuLabel( HINSTANCE hInstance, int nKeyNameArrNum, KEYDATA* pKeyNameArr, int nFuncId, TCHAR* pszLabel, const TCHAR* pszKey, BOOL bKeyStr, int nLabelSize, BOOL bGetDefFuncCode = TRUE );	/* ƒƒjƒ…[ƒ‰ƒxƒ‹‚Ìì¬ */	// add pszKey	2010/5/17 Uchi
+	static int GetKeyStr( HINSTANCE hInstance, int nKeyNameArrNum, KEYDATA* pKeyNameArr, CNativeT& cMemList, int nFuncId, BOOL bGetDefFuncCode = TRUE );	/* æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼åã®å–å¾— */
+	static int GetKeyStrList( HINSTANCE	hInstance, int nKeyNameArrNum,KEYDATA* pKeyNameArr, CNativeT*** pppcMemList, int nFuncId, BOOL bGetDefFuncCode = TRUE );	/* æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼åã®å–å¾—(è¤‡æ•°) */
+	static TCHAR* GetMenuLabel( HINSTANCE hInstance, int nKeyNameArrNum, KEYDATA* pKeyNameArr, int nFuncId, TCHAR* pszLabel, const TCHAR* pszKey, BOOL bKeyStr, int nLabelSize, BOOL bGetDefFuncCode = TRUE );	/* ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒ©ãƒ™ãƒ«ã®ä½œæˆ */	// add pszKey	2010/5/17 Uchi
 
 	static TCHAR* MakeMenuLabel(const TCHAR* sName, const TCHAR* sKey);
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
 	static bool GetKeyStrSub(int& nKeyNameArrBegin, int nKeyNameArrEnd, KEYDATA* pKeyNameArr,
 			int nShiftState, CNativeT& cMemList, int nFuncId, BOOL bGetDefFuncCode );

--- a/sakura_core/func/Funccode.cpp
+++ b/sakura_core/func/Funccode.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ‹@”\•ª—Ş’è‹`
+ï»¿/*!	@file
+	@brief æ©Ÿèƒ½åˆ†é¡å®šç¾©
 
 	@author Norio Nakatani
 */
@@ -38,10 +38,10 @@
 */
 
 //	Sept. 14, 2000 Jepro note: functions & commands list
-//	ƒL[ƒ[ƒhFƒRƒ}ƒ“ƒhˆê——‡˜
-//	‚±‚±‚É“o˜^‚³‚ê‚Ä‚¢‚éƒRƒ}ƒ“ƒh‚ª‹¤’Êİ’è‚Ì‹@”\í•Ê‚É•\¦‚³‚êAƒL[Š„‚è“–‚Ä‚É‚àİ’è‚Å‚«‚é‚æ‚¤‚É‚È‚é
-//	‚±‚Ìƒtƒ@ƒCƒ‹‚ÍuƒRƒ}ƒ“ƒhˆê——v‚Ìƒƒjƒ…[‚Ì‡”Ô‚â•\¦‚É‚àg‚í‚ê‚Ä‚¢‚é
-//	sakura_rc.rcƒtƒ@ƒCƒ‹‚Ì‰º‚Ì‚Ù‚¤‚É‚ ‚éString Table‚àQÆ‚Ì‚±‚Æ
+//	ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ï¼šã‚³ãƒãƒ³ãƒ‰ä¸€è¦§é †åº
+//	ã“ã“ã«ç™»éŒ²ã•ã‚Œã¦ã„ã‚‹ã‚³ãƒãƒ³ãƒ‰ãŒå…±é€šè¨­å®šã®æ©Ÿèƒ½ç¨®åˆ¥ã«è¡¨ç¤ºã•ã‚Œã€ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ã«ã‚‚è¨­å®šã§ãã‚‹ã‚ˆã†ã«ãªã‚‹
+//	ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã¯ã€Œã‚³ãƒãƒ³ãƒ‰ä¸€è¦§ã€ã®ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®é †ç•ªã‚„è¡¨ç¤ºã«ã‚‚ä½¿ã‚ã‚Œã¦ã„ã‚‹
+//	sakura_rc.rcãƒ•ã‚¡ã‚¤ãƒ«ã®ä¸‹ã®ã»ã†ã«ã‚ã‚‹String Tableã‚‚å‚ç…§ã®ã“ã¨
 
 #include "StdAfx.h"
 #include "func/Funccode.h"
@@ -61,459 +61,459 @@
 //using namespace nsFuncCode;
 
 const uint16_t nsFuncCode::ppszFuncKind[] = {
-//	"--–¢’è‹`--",	//Oct. 14, 2000 JEPRO u--–¢’è‹`--v‚ğ•\¦‚³‚¹‚È‚¢‚æ‚¤‚É•ÏX
-//	Oct. 16, 2000 JEPRO •\¦‚Ì‡”Ô‚ğƒƒjƒ…[ƒo[‚Ì‚»‚ê‚É‡‚í‚¹‚é‚æ‚¤‚É­‚µ“ü‚ê‘Ö‚¦‚½(‰º‚ÌŒÂ•Ê‚Ì‚à‚Ì‚à‘S•”)
-	STR_ERR_DLGFUNCLKUP04,	//_T("ƒtƒ@ƒCƒ‹‘€ìŒn"),
-	STR_ERR_DLGFUNCLKUP05,	//_T("•ÒWŒn"),
-	STR_ERR_DLGFUNCLKUP06,	//_T("ƒJ[ƒ\ƒ‹ˆÚ“®Œn"),
-	STR_ERR_DLGFUNCLKUP07,	//_T("‘I‘ğŒn"),		//Oct. 15, 2000 JEPRO uƒJ[ƒ\ƒ‹ˆÚ“®Œnv‚ª‘½‚­‚È‚Á‚½‚Ì‚Åu‘I‘ğŒnv‚Æ‚µ‚Ä“Æ—§‰»(ƒTƒuƒƒjƒ…[‰»‚Í\‘¢ã‚Å‚«‚È‚¢‚Ì‚Å)
-	STR_ERR_DLGFUNCLKUP08,	//_T("‹éŒ`‘I‘ğŒn"),	//Oct. 17, 2000 JEPRO u‘I‘ğŒnv‚Éˆê‚É‚·‚é‚Æ‘½‚­‚È‚è‚·‚¬‚é‚Ì‚Åu‹éŒ`‘I‘ğŒnv‚à“Æ—§‚³‚¹‚½
-	STR_ERR_DLGFUNCLKUP09,	//_T("ƒNƒŠƒbƒvƒ{[ƒhŒn"),
-	STR_ERR_DLGFUNCLKUP10,	//_T("‘}“üŒn"),
-	STR_ERR_DLGFUNCLKUP11,	//_T("•ÏŠ·Œn"),
-	STR_ERR_DLGFUNCLKUP12,	//_T("ŒŸõŒn"),
-	STR_ERR_DLGFUNCLKUP13,	//_T("ƒ‚[ƒhØ‚è‘Ö‚¦Œn"),
-	STR_ERR_DLGFUNCLKUP14,	//_T("İ’èŒn"),
-	STR_ERR_DLGFUNCLKUP15,	//("ƒ}ƒNƒŒn"),
-	//	Oct. 15, 2001 genta ƒJƒXƒ^ƒ€ƒƒjƒ…[‚Ì•¶š—ñ‚ğ‚Í“®“I‚É•ÏX‰Â”\‚É‚·‚é‚½‚ß‚±‚±‚©‚ç‚ÍŠO‚·D
-//	_T("ƒJƒXƒ^ƒ€ƒƒjƒ…["),	//Oct. 21, 2000 JEPRO u‚»‚Ì‘¼v‚©‚ç“Æ—§•ª—£‰»
-	STR_ERR_DLGFUNCLKUP16,	//_T("ƒEƒBƒ“ƒhƒEŒn"),
-	STR_ERR_DLGFUNCLKUP17,	//_T("x‰‡"),
-	STR_ERR_DLGFUNCLKUP18	//_T("‚»‚Ì‘¼")
+//	"--æœªå®šç¾©--",	//Oct. 14, 2000 JEPRO ã€Œ--æœªå®šç¾©--ã€ã‚’è¡¨ç¤ºã•ã›ãªã„ã‚ˆã†ã«å¤‰æ›´
+//	Oct. 16, 2000 JEPRO è¡¨ç¤ºã®é †ç•ªã‚’ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒãƒ¼ã®ãã‚Œã«åˆã‚ã›ã‚‹ã‚ˆã†ã«å°‘ã—å…¥ã‚Œæ›¿ãˆãŸ(ä¸‹ã®å€‹åˆ¥ã®ã‚‚ã®ã‚‚å…¨éƒ¨)
+	STR_ERR_DLGFUNCLKUP04,	//_T("ãƒ•ã‚¡ã‚¤ãƒ«æ“ä½œç³»"),
+	STR_ERR_DLGFUNCLKUP05,	//_T("ç·¨é›†ç³»"),
+	STR_ERR_DLGFUNCLKUP06,	//_T("ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³»"),
+	STR_ERR_DLGFUNCLKUP07,	//_T("é¸æŠç³»"),		//Oct. 15, 2000 JEPRO ã€Œã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³»ã€ãŒå¤šããªã£ãŸã®ã§ã€Œé¸æŠç³»ã€ã¨ã—ã¦ç‹¬ç«‹åŒ–(ã‚µãƒ–ãƒ¡ãƒ‹ãƒ¥ãƒ¼åŒ–ã¯æ§‹é€ ä¸Šã§ããªã„ã®ã§)
+	STR_ERR_DLGFUNCLKUP08,	//_T("çŸ©å½¢é¸æŠç³»"),	//Oct. 17, 2000 JEPRO ã€Œé¸æŠç³»ã€ã«ä¸€ç·’ã«ã™ã‚‹ã¨å¤šããªã‚Šã™ãã‚‹ã®ã§ã€ŒçŸ©å½¢é¸æŠç³»ã€ã‚‚ç‹¬ç«‹ã•ã›ãŸ
+	STR_ERR_DLGFUNCLKUP09,	//_T("ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ç³»"),
+	STR_ERR_DLGFUNCLKUP10,	//_T("æŒ¿å…¥ç³»"),
+	STR_ERR_DLGFUNCLKUP11,	//_T("å¤‰æ›ç³»"),
+	STR_ERR_DLGFUNCLKUP12,	//_T("æ¤œç´¢ç³»"),
+	STR_ERR_DLGFUNCLKUP13,	//_T("ãƒ¢ãƒ¼ãƒ‰åˆ‡ã‚Šæ›¿ãˆç³»"),
+	STR_ERR_DLGFUNCLKUP14,	//_T("è¨­å®šç³»"),
+	STR_ERR_DLGFUNCLKUP15,	//("ãƒã‚¯ãƒ­ç³»"),
+	//	Oct. 15, 2001 genta ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ–‡å­—åˆ—ã‚’ã¯å‹•çš„ã«å¤‰æ›´å¯èƒ½ã«ã™ã‚‹ãŸã‚ã“ã“ã‹ã‚‰ã¯å¤–ã™ï¼
+//	_T("ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼"),	//Oct. 21, 2000 JEPRO ã€Œãã®ä»–ã€ã‹ã‚‰ç‹¬ç«‹åˆ†é›¢åŒ–
+	STR_ERR_DLGFUNCLKUP16,	//_T("ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç³»"),
+	STR_ERR_DLGFUNCLKUP17,	//_T("æ”¯æ´"),
+	STR_ERR_DLGFUNCLKUP18	//_T("ãã®ä»–")
 };
 const int nsFuncCode::nFuncKindNum = _countof(nsFuncCode::ppszFuncKind);
 
 
-/* ƒtƒ@ƒCƒ‹‘€ìŒn */
-const EFunctionCode pnFuncList_File[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List5¨List_File)
-	F_FILENEW			,	//V‹Kì¬
-	F_FILENEW_NEWWINDOW	,	//V‹KƒEƒCƒ“ƒhƒE‚ğŠJ‚­
-	F_FILEOPEN			,	//ŠJ‚­
-	F_FILEOPEN_DROPDOWN	,	//ŠJ‚­(ƒhƒƒbƒvƒ_ƒEƒ“)
-	F_FILESAVE			,	//ã‘‚«•Û‘¶
-	F_FILESAVEAS_DIALOG	,	//–¼‘O‚ğ•t‚¯‚Ä•Û‘¶
-	F_FILESAVEALL		,	//‘S‚Äã‘‚«•Û‘¶	// Jan. 24, 2005 genta
-	F_FILECLOSE			,	//•Â‚¶‚Ä(–³‘è)	//Oct. 17, 2000 jepro uƒtƒ@ƒCƒ‹‚ğ•Â‚¶‚év‚Æ‚¢‚¤ƒLƒƒƒvƒVƒ‡ƒ“‚ğ•ÏX
-	F_FILECLOSE_OPEN	,	//•Â‚¶‚ÄŠJ‚­
-	F_WINCLOSE			,	//ƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚é	//Oct.17,2000 ƒRƒ}ƒ“ƒh–{‰Æ‚ÍuƒEƒBƒ“ƒhƒEŒnv	//Feb. 18, 2001	JEPRO ‰º‚©‚çˆÚ“®‚µ‚½
-	F_FILESAVECLOSE		,	//•Û‘¶‚µ‚Ä•Â‚¶‚é Feb. 28, 2004 genta
-	F_FILE_REOPEN		,	//ŠJ‚«’¼‚·	//Dec. 4, 2002 genta
-	F_FILE_REOPEN_SJIS		,//SJIS‚ÅŠJ‚«’¼‚·
-	F_FILE_REOPEN_JIS		,//JIS‚ÅŠJ‚«’¼‚·
-	F_FILE_REOPEN_EUC		,//EUC‚ÅŠJ‚«’¼‚·
-	F_FILE_REOPEN_LATIN1	,//Latin1‚ÅŠJ‚«’¼‚·	// 2010/3/20 Uchi
-	F_FILE_REOPEN_UNICODE	,//Unicode‚ÅŠJ‚«’¼‚·
-	F_FILE_REOPEN_UNICODEBE	,//UnicodeBE‚ÅŠJ‚«’¼‚·
-	F_FILE_REOPEN_UTF8		,//UTF-8‚ÅŠJ‚«’¼‚·
-	F_FILE_REOPEN_CESU8		,//CESU-8‚ÅŠJ‚«’¼‚·
-	F_FILE_REOPEN_UTF7		,//UTF-7‚ÅŠJ‚«’¼‚·
-	F_PRINT				,	//ˆóü
-	F_PRINT_PREVIEW		,	//ˆóüƒvƒŒƒrƒ…[
-	F_PRINT_PAGESETUP	,	//ˆóüƒy[ƒWİ’è	//Sept. 14, 2000 jepro uˆóü‚Ìƒy[ƒWƒŒƒCƒAƒEƒg‚Ìİ’èv‚©‚ç•ÏX
-	F_OPEN_HfromtoC		,	//“¯–¼‚ÌC/C++ƒwƒbƒ_(ƒ\[ƒX)‚ğŠJ‚­	//Feb. 7, 2001 JEPRO ’Ç‰Á
-//	F_OPEN_HHPP			,	//“¯–¼‚ÌC/C++ƒwƒbƒ_ƒtƒ@ƒCƒ‹‚ğŠJ‚­	//Feb. 9, 2001 jeprou.c‚Ü‚½‚Í.cpp‚Æ“¯–¼‚Ì.h‚ğŠJ‚­v‚©‚ç•ÏX		del 2008/6/23 Uchi
-//	F_OPEN_CCPP			,	//“¯–¼‚ÌC/C++ƒ\[ƒXƒtƒ@ƒCƒ‹‚ğŠJ‚­	//Feb. 9, 2001 jeprou.h‚Æ“¯–¼‚Ì.c(‚È‚¯‚ê‚Î.cpp)‚ğŠJ‚­v‚©‚ç•ÏX	del 2008/6/23 Uchi
-	F_ACTIVATE_SQLPLUS			,	/* Oracle SQL*Plus‚ğƒAƒNƒeƒBƒu•\¦ */	//Sept. 20, 2000 uƒRƒ“ƒpƒCƒ‹vJEPRO ƒAƒNƒeƒBƒu•\¦‚ğã‚ÉˆÚ“®‚µ‚½
-	F_PLSQL_COMPILE_ON_SQLPLUS	,	/* Oracle SQL*Plus‚ÅÀs */	//Sept. 20, 2000 jepro à–¾‚ÌuƒRƒ“ƒpƒCƒ‹v‚ğuÀsv‚É“ˆê
-	F_BROWSE			,	//ƒuƒ‰ƒEƒY
-	F_VIEWMODE			,	//ƒrƒ…[ƒ‚[ƒh
-	F_PROPERTY_FILE		,	/* ƒtƒ@ƒCƒ‹‚ÌƒvƒƒpƒeƒB */
-	F_PROFILEMGR		,	//ƒvƒƒtƒ@ƒCƒ‹ƒ}ƒl[ƒWƒƒ
-	F_EXITALLEDITORS	,	//•ÒW‚Ì‘SI—¹	// 2007.02.13 ryoji F_WIN_CLOSEALL¨F_EXITALLEDITORS
-	F_EXITALL				//ƒTƒNƒ‰ƒGƒfƒBƒ^‚Ì‘SI—¹	//Dec. 27, 2000 JEPRO ’Ç‰Á
+/* ãƒ•ã‚¡ã‚¤ãƒ«æ“ä½œç³» */
+const EFunctionCode pnFuncList_File[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List5â†’List_File)
+	F_FILENEW			,	//æ–°è¦ä½œæˆ
+	F_FILENEW_NEWWINDOW	,	//æ–°è¦ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã
+	F_FILEOPEN			,	//é–‹ã
+	F_FILEOPEN_DROPDOWN	,	//é–‹ã(ãƒ‰ãƒ­ãƒƒãƒ—ãƒ€ã‚¦ãƒ³)
+	F_FILESAVE			,	//ä¸Šæ›¸ãä¿å­˜
+	F_FILESAVEAS_DIALOG	,	//åå‰ã‚’ä»˜ã‘ã¦ä¿å­˜
+	F_FILESAVEALL		,	//å…¨ã¦ä¸Šæ›¸ãä¿å­˜	// Jan. 24, 2005 genta
+	F_FILECLOSE			,	//é–‰ã˜ã¦(ç„¡é¡Œ)	//Oct. 17, 2000 jepro ã€Œãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‰ã˜ã‚‹ã€ã¨ã„ã†ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³ã‚’å¤‰æ›´
+	F_FILECLOSE_OPEN	,	//é–‰ã˜ã¦é–‹ã
+	F_WINCLOSE			,	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹	//Oct.17,2000 ã‚³ãƒãƒ³ãƒ‰æœ¬å®¶ã¯ã€Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç³»ã€	//Feb. 18, 2001	JEPRO ä¸‹ã‹ã‚‰ç§»å‹•ã—ãŸ
+	F_FILESAVECLOSE		,	//ä¿å­˜ã—ã¦é–‰ã˜ã‚‹ Feb. 28, 2004 genta
+	F_FILE_REOPEN		,	//é–‹ãç›´ã™	//Dec. 4, 2002 genta
+	F_FILE_REOPEN_SJIS		,//SJISã§é–‹ãç›´ã™
+	F_FILE_REOPEN_JIS		,//JISã§é–‹ãç›´ã™
+	F_FILE_REOPEN_EUC		,//EUCã§é–‹ãç›´ã™
+	F_FILE_REOPEN_LATIN1	,//Latin1ã§é–‹ãç›´ã™	// 2010/3/20 Uchi
+	F_FILE_REOPEN_UNICODE	,//Unicodeã§é–‹ãç›´ã™
+	F_FILE_REOPEN_UNICODEBE	,//UnicodeBEã§é–‹ãç›´ã™
+	F_FILE_REOPEN_UTF8		,//UTF-8ã§é–‹ãç›´ã™
+	F_FILE_REOPEN_CESU8		,//CESU-8ã§é–‹ãç›´ã™
+	F_FILE_REOPEN_UTF7		,//UTF-7ã§é–‹ãç›´ã™
+	F_PRINT				,	//å°åˆ·
+	F_PRINT_PREVIEW		,	//å°åˆ·ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼
+	F_PRINT_PAGESETUP	,	//å°åˆ·ãƒšãƒ¼ã‚¸è¨­å®š	//Sept. 14, 2000 jepro ã€Œå°åˆ·ã®ãƒšãƒ¼ã‚¸ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã®è¨­å®šã€ã‹ã‚‰å¤‰æ›´
+	F_OPEN_HfromtoC		,	//åŒåã®C/C++ãƒ˜ãƒƒãƒ€(ã‚½ãƒ¼ã‚¹)ã‚’é–‹ã	//Feb. 7, 2001 JEPRO è¿½åŠ 
+//	F_OPEN_HHPP			,	//åŒåã®C/C++ãƒ˜ãƒƒãƒ€ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã	//Feb. 9, 2001 jeproã€Œ.cã¾ãŸã¯.cppã¨åŒåã®.hã‚’é–‹ãã€ã‹ã‚‰å¤‰æ›´		del 2008/6/23 Uchi
+//	F_OPEN_CCPP			,	//åŒåã®C/C++ã‚½ãƒ¼ã‚¹ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã	//Feb. 9, 2001 jeproã€Œ.hã¨åŒåã®.c(ãªã‘ã‚Œã°.cpp)ã‚’é–‹ãã€ã‹ã‚‰å¤‰æ›´	del 2008/6/23 Uchi
+	F_ACTIVATE_SQLPLUS			,	/* Oracle SQL*Plusã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–è¡¨ç¤º */	//Sept. 20, 2000 ã€Œã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ã€JEPRO ã‚¢ã‚¯ãƒ†ã‚£ãƒ–è¡¨ç¤ºã‚’ä¸Šã«ç§»å‹•ã—ãŸ
+	F_PLSQL_COMPILE_ON_SQLPLUS	,	/* Oracle SQL*Plusã§å®Ÿè¡Œ */	//Sept. 20, 2000 jepro èª¬æ˜ã®ã€Œã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ã€ã‚’ã€Œå®Ÿè¡Œã€ã«çµ±ä¸€
+	F_BROWSE			,	//ãƒ–ãƒ©ã‚¦ã‚º
+	F_VIEWMODE			,	//ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰
+	F_PROPERTY_FILE		,	/* ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ */
+	F_PROFILEMGR		,	//ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ãƒãƒãƒ¼ã‚¸ãƒ£
+	F_EXITALLEDITORS	,	//ç·¨é›†ã®å…¨çµ‚äº†	// 2007.02.13 ryoji F_WIN_CLOSEALLâ†’F_EXITALLEDITORS
+	F_EXITALL				//ã‚µã‚¯ãƒ©ã‚¨ãƒ‡ã‚£ã‚¿ã®å…¨çµ‚äº†	//Dec. 27, 2000 JEPRO è¿½åŠ 
 };
-const int nFincList_File_Num = _countof( pnFuncList_File );	//Oct. 16, 2000 JEPRO ”z—ñ–¼•ÏX(FuncList5¨FuncList_File)
+const int nFincList_File_Num = _countof( pnFuncList_File );	//Oct. 16, 2000 JEPRO é…åˆ—åå¤‰æ›´(FuncList5â†’FuncList_File)
 
 
-/* •ÒWŒn */
-const EFunctionCode pnFuncList_Edit[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List3¨List_Edit)
-	F_UNDO				,	//Œ³‚É–ß‚·(Undo)
-	F_REDO				,	//‚â‚è’¼‚µ(Redo)
-	F_DELETE			,	//íœ
-	F_DELETE_BACK		,	//ƒJ[ƒ\ƒ‹‘O‚ğíœ
-	F_WordDeleteToStart	,	//’PŒê‚Ì¶’[‚Ü‚Åíœ
-	F_WordDeleteToEnd	,	//’PŒê‚Ì‰E’[‚Ü‚Åíœ
-	F_WordCut			,	//’PŒêØ‚èæ‚è
-	F_WordDelete		,	//’PŒêíœ
-	F_LineCutToStart	,	//s“ª‚Ü‚ÅØ‚èæ‚è(‰üs’PˆÊ)
-	F_LineCutToEnd		,	//s––‚Ü‚ÅØ‚èæ‚è(‰üs’PˆÊ)
-	F_LineDeleteToStart	,	//s“ª‚Ü‚Åíœ(‰üs’PˆÊ)
-	F_LineDeleteToEnd	,	//s––‚Ü‚Åíœ(‰üs’PˆÊ)
-	F_CUT_LINE			,	//sØ‚èæ‚è(Ü‚è•Ô‚µ’PˆÊ)
-	F_DELETE_LINE		,	//síœ(Ü‚è•Ô‚µ’PˆÊ)
-	F_DUPLICATELINE		,	//s‚Ì“ñd‰»(Ü‚è•Ô‚µ’PˆÊ)
-	F_INDENT_TAB		,	//TABƒCƒ“ƒfƒ“ƒg
-	F_UNINDENT_TAB		,	//‹tTABƒCƒ“ƒfƒ“ƒg
-	F_INDENT_SPACE		,	//SPACEƒCƒ“ƒfƒ“ƒg
-	F_UNINDENT_SPACE	,	//‹tSPACEƒCƒ“ƒfƒ“ƒg
-	F_LTRIM				,	//¶(æ“ª)‚Ì‹ó”’‚ğíœ	2001.12.03 hor
-	F_RTRIM				,	//‰E(––”ö)‚Ì‹ó”’‚ğíœ	2001.12.03 hor
-	F_SORT_ASC			,	//‘I‘ğs‚Ì¸‡ƒ\[ƒg	2001.12.06 hor
-	F_SORT_DESC			,	//‘I‘ğs‚Ì~‡ƒ\[ƒg	2001.12.06 hor
-	F_MERGE				,	//‘I‘ğs‚Ìƒ}[ƒW		2001.12.06 hor
-	F_RECONVERT				//Ä•ÏŠ· 				2002.04.09 minfu
-//		F_WORDSREFERENCE		//’PŒêƒŠƒtƒ@ƒŒƒ“ƒX
+/* ç·¨é›†ç³» */
+const EFunctionCode pnFuncList_Edit[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List3â†’List_Edit)
+	F_UNDO				,	//å…ƒã«æˆ»ã™(Undo)
+	F_REDO				,	//ã‚„ã‚Šç›´ã—(Redo)
+	F_DELETE			,	//å‰Šé™¤
+	F_DELETE_BACK		,	//ã‚«ãƒ¼ã‚½ãƒ«å‰ã‚’å‰Šé™¤
+	F_WordDeleteToStart	,	//å˜èªã®å·¦ç«¯ã¾ã§å‰Šé™¤
+	F_WordDeleteToEnd	,	//å˜èªã®å³ç«¯ã¾ã§å‰Šé™¤
+	F_WordCut			,	//å˜èªåˆ‡ã‚Šå–ã‚Š
+	F_WordDelete		,	//å˜èªå‰Šé™¤
+	F_LineCutToStart	,	//è¡Œé ­ã¾ã§åˆ‡ã‚Šå–ã‚Š(æ”¹è¡Œå˜ä½)
+	F_LineCutToEnd		,	//è¡Œæœ«ã¾ã§åˆ‡ã‚Šå–ã‚Š(æ”¹è¡Œå˜ä½)
+	F_LineDeleteToStart	,	//è¡Œé ­ã¾ã§å‰Šé™¤(æ”¹è¡Œå˜ä½)
+	F_LineDeleteToEnd	,	//è¡Œæœ«ã¾ã§å‰Šé™¤(æ”¹è¡Œå˜ä½)
+	F_CUT_LINE			,	//è¡Œåˆ‡ã‚Šå–ã‚Š(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	F_DELETE_LINE		,	//è¡Œå‰Šé™¤(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	F_DUPLICATELINE		,	//è¡Œã®äºŒé‡åŒ–(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	F_INDENT_TAB		,	//TABã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
+	F_UNINDENT_TAB		,	//é€†TABã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
+	F_INDENT_SPACE		,	//SPACEã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
+	F_UNINDENT_SPACE	,	//é€†SPACEã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
+	F_LTRIM				,	//å·¦(å…ˆé ­)ã®ç©ºç™½ã‚’å‰Šé™¤	2001.12.03 hor
+	F_RTRIM				,	//å³(æœ«å°¾)ã®ç©ºç™½ã‚’å‰Šé™¤	2001.12.03 hor
+	F_SORT_ASC			,	//é¸æŠè¡Œã®æ˜‡é †ã‚½ãƒ¼ãƒˆ	2001.12.06 hor
+	F_SORT_DESC			,	//é¸æŠè¡Œã®é™é †ã‚½ãƒ¼ãƒˆ	2001.12.06 hor
+	F_MERGE				,	//é¸æŠè¡Œã®ãƒãƒ¼ã‚¸		2001.12.06 hor
+	F_RECONVERT				//å†å¤‰æ› 				2002.04.09 minfu
+//		F_WORDSREFERENCE		//å˜èªãƒªãƒ•ã‚¡ãƒ¬ãƒ³ã‚¹
 };
-const int nFincList_Edit_Num = _countof( pnFuncList_Edit );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List3¨List_Edit)
+const int nFincList_Edit_Num = _countof( pnFuncList_Edit );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List3â†’List_Edit)
 
 
-/* ƒJ[ƒ\ƒ‹ˆÚ“®Œn */
-const EFunctionCode pnFuncList_Move[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List1¨List_Move)
-	F_UP				,	//ƒJ[ƒ\ƒ‹ãˆÚ“®
-	F_DOWN				,	//ƒJ[ƒ\ƒ‹‰ºˆÚ“®
-	F_LEFT				,	//ƒJ[ƒ\ƒ‹¶ˆÚ“®
-	F_RIGHT				,	//ƒJ[ƒ\ƒ‹‰EˆÚ“®
-	F_UP2				,	//ƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)
-	F_DOWN2				,	//ƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)
-	F_WORDLEFT			,	//’PŒê‚Ì¶’[‚ÉˆÚ“®
-	F_WORDRIGHT			,	//’PŒê‚Ì‰E’[‚ÉˆÚ“®
-	F_GOLINETOP			,	//s“ª‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-	F_GOLINEEND			,	//s––‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-//	F_ROLLDOWN			,	//ƒXƒNƒ[ƒ‹ƒ_ƒEƒ“
-//	F_ROLLUP			,	//ƒXƒNƒ[ƒ‹ƒAƒbƒv
-	F_HalfPageUp		,	//”¼ƒy[ƒWƒAƒbƒv	//Oct. 6, 2000 JEPRO –¼Ì‚ğPC-ATŒİŠ·‹@Œn‚É•ÏX(ROLL¨PAGE) //Oct. 10, 2000 JEPRO –¼Ì•ÏX
-	F_HalfPageDown		,	//”¼ƒy[ƒWƒ_ƒEƒ“	//Oct. 6, 2000 JEPRO –¼Ì‚ğPC-ATŒİŠ·‹@Œn‚É•ÏX(ROLL¨PAGE) //Oct. 10, 2000 JEPRO –¼Ì•ÏX
-	F_1PageUp			,	//‚Pƒy[ƒWƒAƒbƒv	//Oct. 10, 2000 JEPRO ]—ˆ‚Ìƒy[ƒWƒAƒbƒv‚ğ”¼ƒy[ƒWƒAƒbƒv‚Æ–¼Ì•ÏX‚µ‚Pƒy[ƒWƒAƒbƒv‚ğ’Ç‰Á
-	F_1PageDown			,	//‚Pƒy[ƒWƒ_ƒEƒ“	//Oct. 10, 2000 JEPRO ]—ˆ‚Ìƒy[ƒWƒ_ƒEƒ“‚ğ”¼ƒy[ƒWƒ_ƒEƒ“‚Æ–¼Ì•ÏX‚µ‚Pƒy[ƒWƒ_ƒEƒ“‚ğ’Ç‰Á
-	F_GOFILETOP			,	//ƒtƒ@ƒCƒ‹‚Ìæ“ª‚ÉˆÚ“®
-	F_GOFILEEND			,	//ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®
-	F_CURLINECENTER		,	//ƒJ[ƒ\ƒ‹s‚ğƒEƒBƒ“ƒhƒE’†‰›‚Ö
-	F_JUMP_DIALOG		,	//w’èsƒwƒWƒƒƒ“ƒv	//Sept. 17, 2000 JEPRO ƒRƒ}ƒ“ƒh–{‰Æ‚ÍuŒŸõŒnv
-	F_JUMP_SRCHSTARTPOS	,	//ŒŸõŠJnˆÊ’u‚Ö–ß‚é	// 02/06/26 ai ƒRƒ}ƒ“ƒh–{‰Æ‚Í¢ŒŸõŒn£
-	F_JUMPHIST_PREV		,	//ˆÚ“®—š—ğ: ‘O‚Ö
-	F_JUMPHIST_NEXT		,	//ˆÚ“®—š—ğ: Ÿ‚Ö
-	F_JUMPHIST_SET		,	//Œ»İˆÊ’u‚ğˆÚ“®—š—ğ‚É“o˜^
-	F_WndScrollDown		,	//ƒeƒLƒXƒg‚ğ‚Ps‰º‚ÖƒXƒNƒ[ƒ‹	// 2001/06/20 asa-o
-	F_WndScrollUp		,	//ƒeƒLƒXƒg‚ğ‚Psã‚ÖƒXƒNƒ[ƒ‹	// 2001/06/20 asa-o
-	F_GONEXTPARAGRAPH	,	//Ÿ‚Ì’i—‚ÖˆÚ“®
-	F_GOPREVPARAGRAPH	,	//‘O‚Ì’i—‚ÖˆÚ“®
-	F_AUTOSCROLL		,	//ƒI[ƒgƒXƒNƒ[ƒ‹
-	F_WHEELUP			,	//ƒzƒC[ƒ‹ƒAƒbƒv
-	F_WHEELDOWN			,	//ƒzƒC[ƒ‹ƒ_ƒEƒ“
-	F_WHEELLEFT			,	//ƒzƒC[ƒ‹¶
-	F_WHEELRIGHT		,	//ƒzƒC[ƒ‹‰E
-	F_WHEELPAGEUP		,	//ƒzƒC[ƒ‹ƒy[ƒWƒAƒbƒv
-	F_WHEELPAGEDOWN		,	//ƒzƒC[ƒ‹ƒy[ƒWƒ_ƒEƒ“
-	F_WHEELPAGELEFT		,	//ƒzƒC[ƒ‹ƒy[ƒW¶
-	F_WHEELPAGERIGHT	,	//ƒzƒC[ƒ‹ƒy[ƒW‰E
-	F_MODIFYLINE_NEXT	,	//Ÿ‚Ì•ÏXs‚ÖˆÚ“®
-	F_MODIFYLINE_PREV	,	//‘O‚Ì•ÏXs‚ÖˆÚ“®
+/* ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³» */
+const EFunctionCode pnFuncList_Move[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List1â†’List_Move)
+	F_UP				,	//ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•
+	F_DOWN				,	//ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•
+	F_LEFT				,	//ã‚«ãƒ¼ã‚½ãƒ«å·¦ç§»å‹•
+	F_RIGHT				,	//ã‚«ãƒ¼ã‚½ãƒ«å³ç§»å‹•
+	F_UP2				,	//ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)
+	F_DOWN2				,	//ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)
+	F_WORDLEFT			,	//å˜èªã®å·¦ç«¯ã«ç§»å‹•
+	F_WORDRIGHT			,	//å˜èªã®å³ç«¯ã«ç§»å‹•
+	F_GOLINETOP			,	//è¡Œé ­ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	F_GOLINEEND			,	//è¡Œæœ«ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+//	F_ROLLDOWN			,	//ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ€ã‚¦ãƒ³
+//	F_ROLLUP			,	//ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚¢ãƒƒãƒ—
+	F_HalfPageUp		,	//åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—	//Oct. 6, 2000 JEPRO åç§°ã‚’PC-ATäº’æ›æ©Ÿç³»ã«å¤‰æ›´(ROLLâ†’PAGE) //Oct. 10, 2000 JEPRO åç§°å¤‰æ›´
+	F_HalfPageDown		,	//åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³	//Oct. 6, 2000 JEPRO åç§°ã‚’PC-ATäº’æ›æ©Ÿç³»ã«å¤‰æ›´(ROLLâ†’PAGE) //Oct. 10, 2000 JEPRO åç§°å¤‰æ›´
+	F_1PageUp			,	//ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—	//Oct. 10, 2000 JEPRO å¾“æ¥ã®ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—ã‚’åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—ã¨åç§°å¤‰æ›´ã—ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—ã‚’è¿½åŠ 
+	F_1PageDown			,	//ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³	//Oct. 10, 2000 JEPRO å¾“æ¥ã®ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã‚’åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã¨åç§°å¤‰æ›´ã—ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã‚’è¿½åŠ 
+	F_GOFILETOP			,	//ãƒ•ã‚¡ã‚¤ãƒ«ã®å…ˆé ­ã«ç§»å‹•
+	F_GOFILEEND			,	//ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•
+	F_CURLINECENTER		,	//ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸­å¤®ã¸
+	F_JUMP_DIALOG		,	//æŒ‡å®šè¡Œãƒ˜ã‚¸ãƒ£ãƒ³ãƒ—	//Sept. 17, 2000 JEPRO ã‚³ãƒãƒ³ãƒ‰æœ¬å®¶ã¯ã€Œæ¤œç´¢ç³»ã€
+	F_JUMP_SRCHSTARTPOS	,	//æ¤œç´¢é–‹å§‹ä½ç½®ã¸æˆ»ã‚‹	// 02/06/26 ai ã‚³ãƒãƒ³ãƒ‰æœ¬å®¶ã¯ï½¢æ¤œç´¢ç³»ï½£
+	F_JUMPHIST_PREV		,	//ç§»å‹•å±¥æ­´: å‰ã¸
+	F_JUMPHIST_NEXT		,	//ç§»å‹•å±¥æ­´: æ¬¡ã¸
+	F_JUMPHIST_SET		,	//ç¾åœ¨ä½ç½®ã‚’ç§»å‹•å±¥æ­´ã«ç™»éŒ²
+	F_WndScrollDown		,	//ãƒ†ã‚­ã‚¹ãƒˆã‚’ï¼‘è¡Œä¸‹ã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«	// 2001/06/20 asa-o
+	F_WndScrollUp		,	//ãƒ†ã‚­ã‚¹ãƒˆã‚’ï¼‘è¡Œä¸Šã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«	// 2001/06/20 asa-o
+	F_GONEXTPARAGRAPH	,	//æ¬¡ã®æ®µè½ã¸ç§»å‹•
+	F_GOPREVPARAGRAPH	,	//å‰ã®æ®µè½ã¸ç§»å‹•
+	F_AUTOSCROLL		,	//ã‚ªãƒ¼ãƒˆã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
+	F_WHEELUP			,	//ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¢ãƒƒãƒ—
+	F_WHEELDOWN			,	//ãƒ›ã‚¤ãƒ¼ãƒ«ãƒ€ã‚¦ãƒ³
+	F_WHEELLEFT			,	//ãƒ›ã‚¤ãƒ¼ãƒ«å·¦
+	F_WHEELRIGHT		,	//ãƒ›ã‚¤ãƒ¼ãƒ«å³
+	F_WHEELPAGEUP		,	//ãƒ›ã‚¤ãƒ¼ãƒ«ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—
+	F_WHEELPAGEDOWN		,	//ãƒ›ã‚¤ãƒ¼ãƒ«ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³
+	F_WHEELPAGELEFT		,	//ãƒ›ã‚¤ãƒ¼ãƒ«ãƒšãƒ¼ã‚¸å·¦
+	F_WHEELPAGERIGHT	,	//ãƒ›ã‚¤ãƒ¼ãƒ«ãƒšãƒ¼ã‚¸å³
+	F_MODIFYLINE_NEXT	,	//æ¬¡ã®å¤‰æ›´è¡Œã¸ç§»å‹•
+	F_MODIFYLINE_PREV	,	//å‰ã®å¤‰æ›´è¡Œã¸ç§»å‹•
 };
-const int nFincList_Move_Num = _countof( pnFuncList_Move );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List1¨List_Move)
+const int nFincList_Move_Num = _countof( pnFuncList_Move );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List1â†’List_Move)
 
 
-/* ‘I‘ğŒn */	//Oct. 15, 2000 JEPRO uƒJ[ƒ\ƒ‹ˆÚ“®Œnv‚©‚ç(‘I‘ğ)‚ğˆÚ“®
+/* é¸æŠç³» */	//Oct. 15, 2000 JEPRO ã€Œã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³»ã€ã‹ã‚‰(é¸æŠ)ã‚’ç§»å‹•
 const EFunctionCode pnFuncList_Select[] = {
-	F_SELECTWORD			,	//Œ»İˆÊ’u‚Ì’PŒê‘I‘ğ
-	F_SELECTALL				,	//‚·‚×‚Ä‘I‘ğ
-	F_SELECTLINE			,	//1s‘I‘ğ	// 2007.10.06 nasukoji
-	F_BEGIN_SEL				,	//”ÍˆÍ‘I‘ğŠJn
-	F_UP_SEL				,	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹ãˆÚ“®
-	F_DOWN_SEL				,	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹‰ºˆÚ“®
-	F_LEFT_SEL				,	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹¶ˆÚ“®
-	F_RIGHT_SEL				,	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹‰EˆÚ“®
-	F_UP2_SEL				,	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)
-	F_DOWN2_SEL				,	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)
-	F_WORDLEFT_SEL			,	//(”ÍˆÍ‘I‘ğ)’PŒê‚Ì¶’[‚ÉˆÚ“®
-	F_WORDRIGHT_SEL			,	//(”ÍˆÍ‘I‘ğ)’PŒê‚Ì‰E’[‚ÉˆÚ“®
-	F_GOLINETOP_SEL			,	//(”ÍˆÍ‘I‘ğ)s“ª‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-	F_GOLINEEND_SEL			,	//(”ÍˆÍ‘I‘ğ)s––‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-//	F_ROLLDOWN_SEL			,	//(”ÍˆÍ‘I‘ğ)ƒXƒNƒ[ƒ‹ƒ_ƒEƒ“
-//	F_ROLLUP_SEL			,	//(”ÍˆÍ‘I‘ğ)ƒXƒNƒ[ƒ‹ƒAƒbƒv
-	F_HalfPageUp_Sel		,	//(”ÍˆÍ‘I‘ğ)”¼ƒy[ƒWƒAƒbƒv	//Oct. 6, 2000 JEPRO –¼Ì‚ğPC-ATŒİŠ·‹@Œn‚É•ÏX(ROLL¨PAGE) //Oct. 10, 2000 JEPRO –¼Ì•ÏX
-	F_HalfPageDown_Sel		,	//(”ÍˆÍ‘I‘ğ)”¼ƒy[ƒWƒ_ƒEƒ“	//Oct. 6, 2000 JEPRO –¼Ì‚ğPC-ATŒİŠ·‹@Œn‚É•ÏX(ROLL¨PAGE) //Oct. 10, 2000 JEPRO –¼Ì•ÏX
-	F_1PageUp_Sel			,	//(”ÍˆÍ‘I‘ğ)‚Pƒy[ƒWƒAƒbƒv	//Oct. 10, 2000 JEPRO ]—ˆ‚Ìƒy[ƒWƒAƒbƒv‚ğ”¼ƒy[ƒWƒAƒbƒv‚Æ–¼Ì•ÏX‚µ‚Pƒy[ƒWƒAƒbƒv‚ğ’Ç‰Á
-	F_1PageDown_Sel			,	//(”ÍˆÍ‘I‘ğ)‚Pƒy[ƒWƒ_ƒEƒ“	//Oct. 10, 2000 JEPRO ]—ˆ‚Ìƒy[ƒWƒ_ƒEƒ“‚ğ”¼ƒy[ƒWƒ_ƒEƒ“‚Æ–¼Ì•ÏX‚µ‚Pƒy[ƒWƒ_ƒEƒ“‚ğ’Ç‰Á
-	F_GOFILETOP_SEL			,	//(”ÍˆÍ‘I‘ğ)ƒtƒ@ƒCƒ‹‚Ìæ“ª‚ÉˆÚ“®
-	F_GOFILEEND_SEL			,	//(”ÍˆÍ‘I‘ğ)ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®
-	F_GONEXTPARAGRAPH_SEL	,	//(”ÍˆÍ‘I‘ğ)Ÿ‚Ì’i—‚ÖˆÚ“®
-	F_GOPREVPARAGRAPH_SEL	,	//(”ÍˆÍ‘I‘ğ)‘O‚Ì’i—‚ÖˆÚ“®
-	F_MODIFYLINE_NEXT_SEL	,	//(”ÍˆÍ‘I‘ğ)Ÿ‚Ì•ÏXs‚ÖˆÚ“®
-	F_MODIFYLINE_PREV_SEL	,	//(”ÍˆÍ‘I‘ğ)‘O‚Ì•ÏXs‚ÖˆÚ“®
+	F_SELECTWORD			,	//ç¾åœ¨ä½ç½®ã®å˜èªé¸æŠ
+	F_SELECTALL				,	//ã™ã¹ã¦é¸æŠ
+	F_SELECTLINE			,	//1è¡Œé¸æŠ	// 2007.10.06 nasukoji
+	F_BEGIN_SEL				,	//ç¯„å›²é¸æŠé–‹å§‹
+	F_UP_SEL				,	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•
+	F_DOWN_SEL				,	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•
+	F_LEFT_SEL				,	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«å·¦ç§»å‹•
+	F_RIGHT_SEL				,	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«å³ç§»å‹•
+	F_UP2_SEL				,	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)
+	F_DOWN2_SEL				,	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)
+	F_WORDLEFT_SEL			,	//(ç¯„å›²é¸æŠ)å˜èªã®å·¦ç«¯ã«ç§»å‹•
+	F_WORDRIGHT_SEL			,	//(ç¯„å›²é¸æŠ)å˜èªã®å³ç«¯ã«ç§»å‹•
+	F_GOLINETOP_SEL			,	//(ç¯„å›²é¸æŠ)è¡Œé ­ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	F_GOLINEEND_SEL			,	//(ç¯„å›²é¸æŠ)è¡Œæœ«ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+//	F_ROLLDOWN_SEL			,	//(ç¯„å›²é¸æŠ)ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ€ã‚¦ãƒ³
+//	F_ROLLUP_SEL			,	//(ç¯„å›²é¸æŠ)ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚¢ãƒƒãƒ—
+	F_HalfPageUp_Sel		,	//(ç¯„å›²é¸æŠ)åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—	//Oct. 6, 2000 JEPRO åç§°ã‚’PC-ATäº’æ›æ©Ÿç³»ã«å¤‰æ›´(ROLLâ†’PAGE) //Oct. 10, 2000 JEPRO åç§°å¤‰æ›´
+	F_HalfPageDown_Sel		,	//(ç¯„å›²é¸æŠ)åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³	//Oct. 6, 2000 JEPRO åç§°ã‚’PC-ATäº’æ›æ©Ÿç³»ã«å¤‰æ›´(ROLLâ†’PAGE) //Oct. 10, 2000 JEPRO åç§°å¤‰æ›´
+	F_1PageUp_Sel			,	//(ç¯„å›²é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—	//Oct. 10, 2000 JEPRO å¾“æ¥ã®ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—ã‚’åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—ã¨åç§°å¤‰æ›´ã—ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—ã‚’è¿½åŠ 
+	F_1PageDown_Sel			,	//(ç¯„å›²é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³	//Oct. 10, 2000 JEPRO å¾“æ¥ã®ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã‚’åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã¨åç§°å¤‰æ›´ã—ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã‚’è¿½åŠ 
+	F_GOFILETOP_SEL			,	//(ç¯„å›²é¸æŠ)ãƒ•ã‚¡ã‚¤ãƒ«ã®å…ˆé ­ã«ç§»å‹•
+	F_GOFILEEND_SEL			,	//(ç¯„å›²é¸æŠ)ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•
+	F_GONEXTPARAGRAPH_SEL	,	//(ç¯„å›²é¸æŠ)æ¬¡ã®æ®µè½ã¸ç§»å‹•
+	F_GOPREVPARAGRAPH_SEL	,	//(ç¯„å›²é¸æŠ)å‰ã®æ®µè½ã¸ç§»å‹•
+	F_MODIFYLINE_NEXT_SEL	,	//(ç¯„å›²é¸æŠ)æ¬¡ã®å¤‰æ›´è¡Œã¸ç§»å‹•
+	F_MODIFYLINE_PREV_SEL	,	//(ç¯„å›²é¸æŠ)å‰ã®å¤‰æ›´è¡Œã¸ç§»å‹•
 };
 const int nFincList_Select_Num = _countof( pnFuncList_Select );
 
 
-/* ‹éŒ`‘I‘ğŒn */	//Oct. 17, 2000 JEPRO (‹éŒ`‘I‘ğ)‚ªVİ‚³‚êŸ‘æ‚±‚±‚É‚¨‚­
+/* çŸ©å½¢é¸æŠç³» */	//Oct. 17, 2000 JEPRO (çŸ©å½¢é¸æŠ)ãŒæ–°è¨­ã•ã‚Œæ¬¡ç¬¬ã“ã“ã«ãŠã
 const EFunctionCode pnFuncList_Box[] = {
-//	F_BOXSELALL			,	//‹éŒ`‚Å‚·‚×‚Ä‘I‘ğ
-	F_BEGIN_BOX			,	//‹éŒ`”ÍˆÍ‘I‘ğŠJn
-	F_UP_BOX			,	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹ãˆÚ“®
-	F_DOWN_BOX			,	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹‰ºˆÚ“®
-	F_LEFT_BOX			,	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹¶ˆÚ“®
-	F_RIGHT_BOX			,	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹‰EˆÚ“®
-	F_UP2_BOX			,	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)
-	F_DOWN2_BOX			,	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)
-	F_WORDLEFT_BOX		,	//(‹éŒ`‘I‘ğ)’PŒê‚Ì¶’[‚ÉˆÚ“®
-	F_WORDRIGHT_BOX		,	//(‹éŒ`‘I‘ğ)’PŒê‚Ì‰E’[‚ÉˆÚ“®
-	F_GOLOGICALLINETOP_BOX	,	//(‹éŒ`‘I‘ğ)s“ª‚ÉˆÚ“®(‰üs’PˆÊ)
-	F_GOLINETOP_BOX		,	//(‹éŒ`‘I‘ğ)s“ª‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-	F_GOLINEEND_BOX		,	//(‹éŒ`‘I‘ğ)s––‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-	F_HalfPageUp_BOX	,	//(‹éŒ`‘I‘ğ)”¼ƒy[ƒWƒAƒbƒv
-	F_HalfPageDown_BOX	,	//(‹éŒ`‘I‘ğ)”¼ƒy[ƒWƒ_ƒEƒ“
-	F_1PageUp_BOX		,	//(‹éŒ`‘I‘ğ)‚Pƒy[ƒWƒAƒbƒv
-	F_1PageDown_BOX		,	//(‹éŒ`‘I‘ğ)‚Pƒy[ƒWƒ_ƒEƒ“
-	F_GOFILETOP_BOX		,	//(‹éŒ`‘I‘ğ)ƒtƒ@ƒCƒ‹‚Ìæ“ª‚ÉˆÚ“®
-	F_GOFILEEND_BOX			//(‹éŒ`‘I‘ğ)ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®
+//	F_BOXSELALL			,	//çŸ©å½¢ã§ã™ã¹ã¦é¸æŠ
+	F_BEGIN_BOX			,	//çŸ©å½¢ç¯„å›²é¸æŠé–‹å§‹
+	F_UP_BOX			,	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•
+	F_DOWN_BOX			,	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•
+	F_LEFT_BOX			,	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«å·¦ç§»å‹•
+	F_RIGHT_BOX			,	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«å³ç§»å‹•
+	F_UP2_BOX			,	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)
+	F_DOWN2_BOX			,	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)
+	F_WORDLEFT_BOX		,	//(çŸ©å½¢é¸æŠ)å˜èªã®å·¦ç«¯ã«ç§»å‹•
+	F_WORDRIGHT_BOX		,	//(çŸ©å½¢é¸æŠ)å˜èªã®å³ç«¯ã«ç§»å‹•
+	F_GOLOGICALLINETOP_BOX	,	//(çŸ©å½¢é¸æŠ)è¡Œé ­ã«ç§»å‹•(æ”¹è¡Œå˜ä½)
+	F_GOLINETOP_BOX		,	//(çŸ©å½¢é¸æŠ)è¡Œé ­ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	F_GOLINEEND_BOX		,	//(çŸ©å½¢é¸æŠ)è¡Œæœ«ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	F_HalfPageUp_BOX	,	//(çŸ©å½¢é¸æŠ)åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—
+	F_HalfPageDown_BOX	,	//(çŸ©å½¢é¸æŠ)åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³
+	F_1PageUp_BOX		,	//(çŸ©å½¢é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—
+	F_1PageDown_BOX		,	//(çŸ©å½¢é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³
+	F_GOFILETOP_BOX		,	//(çŸ©å½¢é¸æŠ)ãƒ•ã‚¡ã‚¤ãƒ«ã®å…ˆé ­ã«ç§»å‹•
+	F_GOFILEEND_BOX			//(çŸ©å½¢é¸æŠ)ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•
 };
 const int nFincList_Box_Num = _countof( pnFuncList_Box );
 
 
-/* ƒNƒŠƒbƒvƒ{[ƒhŒn */
-const EFunctionCode pnFuncList_Clip[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List2¨List_Clip)
-	F_CUT						,	//Ø‚èæ‚è(‘I‘ğ”ÍˆÍ‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[‚µ‚Äíœ)
-	F_COPY						,	//ƒRƒs[(‘I‘ğ”ÍˆÍ‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[)
-	F_COPY_ADDCRLF				,	//Ü‚è•Ô‚µˆÊ’u‚É‰üs‚ğ‚Â‚¯‚ÄƒRƒs[(‘I‘ğ”ÍˆÍ‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[)
-	F_COPY_CRLF					,	//CRLF‰üs‚ÅƒRƒs[
-	F_PASTE						,	//“\‚è•t‚¯(ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯)
-	F_PASTEBOX					,	//‹éŒ`“\‚è•t‚¯(ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç‹éŒ`“\‚è•t‚¯)
-//	F_INSTEXT_W					,	//ƒeƒLƒXƒg‚ğ“\‚è•t‚¯		//Oct. 22, 2000 JEPRO ‚±‚±‚É’Ç‰Á‚µ‚½‚ª”ñŒö®‹@”\‚È‚Ì‚©•s–¾‚È‚Ì‚ÅƒRƒƒ“ƒgƒAƒEƒg‚É‚µ‚Ä‚¨‚­
-//	F_ADDTAIL_W					,	//ÅŒã‚ÉƒeƒLƒXƒg‚ğ’Ç‰Á		//Oct. 22, 2000 JEPRO ‚±‚±‚É’Ç‰Á‚µ‚½‚ª”ñŒö®‹@”\‚È‚Ì‚©•s–¾‚È‚Ì‚ÅƒRƒƒ“ƒgƒAƒEƒg‚É‚µ‚Ä‚¨‚­
-	F_COPYLINES					,	//‘I‘ğ”ÍˆÍ“à‘SsƒRƒs[
-	F_COPYLINESASPASSAGE		,	//‘I‘ğ”ÍˆÍ“à‘Ssˆø—p•„•t‚«ƒRƒs[
-	F_COPYLINESWITHLINENUMBER	,	//‘I‘ğ”ÍˆÍ“à‘Sss”Ô†•t‚«ƒRƒs[
-	F_COPY_COLOR_HTML			,	//‘I‘ğ”ÍˆÍ“àF•t‚«HTMLƒRƒs[
-	F_COPY_COLOR_HTML_LINENUMBER,	//‘I‘ğ”ÍˆÍ“às”Ô†F•t‚«HTMLƒRƒs[
-	F_COPYFNAME					,	//‚±‚Ìƒtƒ@ƒCƒ‹–¼‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[ //2002/2/3 aroka
-	F_COPYPATH					,	//‚±‚Ìƒtƒ@ƒCƒ‹‚ÌƒpƒX–¼‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[
-	F_COPYTAG					,	//‚±‚Ìƒtƒ@ƒCƒ‹‚ÌƒpƒX–¼‚ÆƒJ[ƒ\ƒ‹ˆÊ’u‚ğƒRƒs[	//Sept. 14, 2000 JEPRO ƒƒjƒ…[‚É‡‚í‚¹‚Ä‰º‚ÉˆÚ“®
-	F_CREATEKEYBINDLIST				//ƒL[Š„‚è“–‚Äˆê——‚ğƒRƒs[	//Sept. 15, 2000 JEPRO IDM_TEST‚Ì‚Ü‚Ü‚Å‚Í‚¤‚Ü‚­‚¢‚©‚È‚¢‚Ì‚ÅF‚É•Ï‚¦‚Ä“o˜^	//Dec. 25, 2000 •œŠˆ
+/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ç³» */
+const EFunctionCode pnFuncList_Clip[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List2â†’List_Clip)
+	F_CUT						,	//åˆ‡ã‚Šå–ã‚Š(é¸æŠç¯„å›²ã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼ã—ã¦å‰Šé™¤)
+	F_COPY						,	//ã‚³ãƒ”ãƒ¼(é¸æŠç¯„å›²ã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼)
+	F_COPY_ADDCRLF				,	//æŠ˜ã‚Šè¿”ã—ä½ç½®ã«æ”¹è¡Œã‚’ã¤ã‘ã¦ã‚³ãƒ”ãƒ¼(é¸æŠç¯„å›²ã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼)
+	F_COPY_CRLF					,	//CRLFæ”¹è¡Œã§ã‚³ãƒ”ãƒ¼
+	F_PASTE						,	//è²¼ã‚Šä»˜ã‘(ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘)
+	F_PASTEBOX					,	//çŸ©å½¢è²¼ã‚Šä»˜ã‘(ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰çŸ©å½¢è²¼ã‚Šä»˜ã‘)
+//	F_INSTEXT_W					,	//ãƒ†ã‚­ã‚¹ãƒˆã‚’è²¼ã‚Šä»˜ã‘		//Oct. 22, 2000 JEPRO ã“ã“ã«è¿½åŠ ã—ãŸãŒéå…¬å¼æ©Ÿèƒ½ãªã®ã‹ä¸æ˜ãªã®ã§ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã«ã—ã¦ãŠã
+//	F_ADDTAIL_W					,	//æœ€å¾Œã«ãƒ†ã‚­ã‚¹ãƒˆã‚’è¿½åŠ 		//Oct. 22, 2000 JEPRO ã“ã“ã«è¿½åŠ ã—ãŸãŒéå…¬å¼æ©Ÿèƒ½ãªã®ã‹ä¸æ˜ãªã®ã§ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã«ã—ã¦ãŠã
+	F_COPYLINES					,	//é¸æŠç¯„å›²å†…å…¨è¡Œã‚³ãƒ”ãƒ¼
+	F_COPYLINESASPASSAGE		,	//é¸æŠç¯„å›²å†…å…¨è¡Œå¼•ç”¨ç¬¦ä»˜ãã‚³ãƒ”ãƒ¼
+	F_COPYLINESWITHLINENUMBER	,	//é¸æŠç¯„å›²å†…å…¨è¡Œè¡Œç•ªå·ä»˜ãã‚³ãƒ”ãƒ¼
+	F_COPY_COLOR_HTML			,	//é¸æŠç¯„å›²å†…è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼
+	F_COPY_COLOR_HTML_LINENUMBER,	//é¸æŠç¯„å›²å†…è¡Œç•ªå·è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼
+	F_COPYFNAME					,	//ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼ //2002/2/3 aroka
+	F_COPYPATH					,	//ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹åã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼
+	F_COPYTAG					,	//ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹åã¨ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’ã‚³ãƒ”ãƒ¼	//Sept. 14, 2000 JEPRO ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«åˆã‚ã›ã¦ä¸‹ã«ç§»å‹•
+	F_CREATEKEYBINDLIST				//ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ä¸€è¦§ã‚’ã‚³ãƒ”ãƒ¼	//Sept. 15, 2000 JEPRO IDM_TESTã®ã¾ã¾ã§ã¯ã†ã¾ãã„ã‹ãªã„ã®ã§Fã«å¤‰ãˆã¦ç™»éŒ²	//Dec. 25, 2000 å¾©æ´»
 };
-const int nFincList_Clip_Num = _countof( pnFuncList_Clip );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List1¨List_Move)
+const int nFincList_Clip_Num = _countof( pnFuncList_Clip );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List1â†’List_Move)
 
 
-/* ‘}“üŒn */
+/* æŒ¿å…¥ç³» */
 const EFunctionCode pnFuncList_Insert[] = {
-	F_INS_DATE				,	// “ú•t‘}“ü
-	F_INS_TIME				,	// ‘}“ü
-	F_CTRL_CODE_DIALOG			//ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh‚Ì“ü—Í
+	F_INS_DATE				,	// æ—¥ä»˜æŒ¿å…¥
+	F_INS_TIME				,	// æ™‚åˆ»æŒ¿å…¥
+	F_CTRL_CODE_DIALOG			//ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰ã®å…¥åŠ›
 };
 const int nFincList_Insert_Num = _countof( pnFuncList_Insert );
 
 
-/* •ÏŠ·Œn */
-const EFunctionCode pnFuncList_Convert[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List6¨List_Convert)
-	F_TOLOWER				,	//¬•¶š
-	F_TOUPPER				,	//‘å•¶š
-	F_TOHANKAKU				,	/* ‘SŠp¨”¼Šp */
-	// From Here 2007.01.24 maru •À‚Ñ‡•ÏX
-	F_TOZENKAKUKATA			,	/* ”¼Šp{‘S‚Ğ‚ç¨‘SŠpEƒJƒ^ƒJƒi */	//Sept. 17, 2000 jepro à–¾‚ğu”¼Šp¨‘SŠpƒJƒ^ƒJƒiv‚©‚ç•ÏX
-	F_TOZENKAKUHIRA			,	/* ”¼Šp{‘SƒJƒ^¨‘SŠpE‚Ğ‚ç‚ª‚È */	//Sept. 17, 2000 jepro à–¾‚ğu”¼Šp¨‘SŠp‚Ğ‚ç‚ª‚Èv‚©‚ç•ÏX
-	F_TOZENEI				,	/* ”¼Šp‰p”¨‘SŠp‰p” */			//July. 30, 2001 Misaka
-	F_TOHANEI				,	/* ‘SŠp‰p”¨”¼Šp‰p” */
-	F_TOHANKATA				,	/* ‘SŠpƒJƒ^ƒJƒi¨”¼ŠpƒJƒ^ƒJƒi */	//Aug. 29, 2002 ai
-	// To Here 2007.01.24 maru •À‚Ñ‡•ÏX
-	F_HANKATATOZENKATA		,	/* ”¼ŠpƒJƒ^ƒJƒi¨‘SŠpƒJƒ^ƒJƒi */
-	F_HANKATATOZENHIRA		,	/* ”¼ŠpƒJƒ^ƒJƒi¨‘SŠp‚Ğ‚ç‚ª‚È */
-	F_TABTOSPACE			,	/* TAB¨‹ó”’ */
-	F_SPACETOTAB			,	/* ‹ó”’¨TAB */  //---- Stonee, 2001/05/27
-	F_CODECNV_AUTO2SJIS		,	/* ©“®”»•Ê¨SJISƒR[ƒh•ÏŠ· */
-	F_CODECNV_EMAIL			,	//E-Mail(JIS¨SJIS)ƒR[ƒh•ÏŠ·
-	F_CODECNV_EUC2SJIS		,	//EUC¨SJISƒR[ƒh•ÏŠ·
-	F_CODECNV_UNICODE2SJIS	,	//Unicode¨SJISƒR[ƒh•ÏŠ·
-	F_CODECNV_UNICODEBE2SJIS	,	//Unicode¨SJISƒR[ƒh•ÏŠ·
-	F_CODECNV_UTF82SJIS		,	/* UTF-8¨SJISƒR[ƒh•ÏŠ· */
-	F_CODECNV_UTF72SJIS		,	/* UTF-7¨SJISƒR[ƒh•ÏŠ· */
-	F_CODECNV_SJIS2JIS		,	/* SJIS¨JISƒR[ƒh•ÏŠ· */
-	F_CODECNV_SJIS2EUC		,	/* SJIS¨EUCƒR[ƒh•ÏŠ· */
-	F_CODECNV_SJIS2UTF8		,	/* SJIS¨UTF-8ƒR[ƒh•ÏŠ· */
-	F_CODECNV_SJIS2UTF7		,	/* SJIS¨UTF-7ƒR[ƒh•ÏŠ· */
-	F_BASE64DECODE			,	//Base64ƒfƒR[ƒh‚µ‚Ä•Û‘¶
-	F_UUDECODE					//uudecode‚µ‚Ä•Û‘¶
-	//Sept. 30, 2000JEPRO ƒRƒƒ“ƒgƒAƒEƒg‚³‚ê‚Ä‚ ‚Á‚½‚Ì‚ğ•œŠˆ‚³‚¹‚½(“®ì‚µ‚È‚¢‚Ì‚©‚àH)
-	//Oct. 17, 2000 jepro à–¾‚ğu‘I‘ğ•”•ª‚ğUUENCODEƒfƒR[ƒhv‚©‚ç•ÏX
+/* å¤‰æ›ç³» */
+const EFunctionCode pnFuncList_Convert[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List6â†’List_Convert)
+	F_TOLOWER				,	//å°æ–‡å­—
+	F_TOUPPER				,	//å¤§æ–‡å­—
+	F_TOHANKAKU				,	/* å…¨è§’â†’åŠè§’ */
+	// From Here 2007.01.24 maru ä¸¦ã³é †å¤‰æ›´
+	F_TOZENKAKUKATA			,	/* åŠè§’ï¼‹å…¨ã²ã‚‰â†’å…¨è§’ãƒ»ã‚«ã‚¿ã‚«ãƒŠ */	//Sept. 17, 2000 jepro èª¬æ˜ã‚’ã€ŒåŠè§’â†’å…¨è§’ã‚«ã‚¿ã‚«ãƒŠã€ã‹ã‚‰å¤‰æ›´
+	F_TOZENKAKUHIRA			,	/* åŠè§’ï¼‹å…¨ã‚«ã‚¿â†’å…¨è§’ãƒ»ã²ã‚‰ãŒãª */	//Sept. 17, 2000 jepro èª¬æ˜ã‚’ã€ŒåŠè§’â†’å…¨è§’ã²ã‚‰ãŒãªã€ã‹ã‚‰å¤‰æ›´
+	F_TOZENEI				,	/* åŠè§’è‹±æ•°â†’å…¨è§’è‹±æ•° */			//July. 30, 2001 Misaka
+	F_TOHANEI				,	/* å…¨è§’è‹±æ•°â†’åŠè§’è‹±æ•° */
+	F_TOHANKATA				,	/* å…¨è§’ã‚«ã‚¿ã‚«ãƒŠâ†’åŠè§’ã‚«ã‚¿ã‚«ãƒŠ */	//Aug. 29, 2002 ai
+	// To Here 2007.01.24 maru ä¸¦ã³é †å¤‰æ›´
+	F_HANKATATOZENKATA		,	/* åŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã‚«ã‚¿ã‚«ãƒŠ */
+	F_HANKATATOZENHIRA		,	/* åŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã²ã‚‰ãŒãª */
+	F_TABTOSPACE			,	/* TABâ†’ç©ºç™½ */
+	F_SPACETOTAB			,	/* ç©ºç™½â†’TAB */  //---- Stonee, 2001/05/27
+	F_CODECNV_AUTO2SJIS		,	/* è‡ªå‹•åˆ¤åˆ¥â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	F_CODECNV_EMAIL			,	//E-Mail(JISâ†’SJIS)ã‚³ãƒ¼ãƒ‰å¤‰æ›
+	F_CODECNV_EUC2SJIS		,	//EUCâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›
+	F_CODECNV_UNICODE2SJIS	,	//Unicodeâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›
+	F_CODECNV_UNICODEBE2SJIS	,	//Unicodeâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›
+	F_CODECNV_UTF82SJIS		,	/* UTF-8â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	F_CODECNV_UTF72SJIS		,	/* UTF-7â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	F_CODECNV_SJIS2JIS		,	/* SJISâ†’JISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	F_CODECNV_SJIS2EUC		,	/* SJISâ†’EUCã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	F_CODECNV_SJIS2UTF8		,	/* SJISâ†’UTF-8ã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	F_CODECNV_SJIS2UTF7		,	/* SJISâ†’UTF-7ã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	F_BASE64DECODE			,	//Base64ãƒ‡ã‚³ãƒ¼ãƒ‰ã—ã¦ä¿å­˜
+	F_UUDECODE					//uudecodeã—ã¦ä¿å­˜
+	//Sept. 30, 2000JEPRO ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã•ã‚Œã¦ã‚ã£ãŸã®ã‚’å¾©æ´»ã•ã›ãŸ(å‹•ä½œã—ãªã„ã®ã‹ã‚‚ï¼Ÿ)
+	//Oct. 17, 2000 jepro èª¬æ˜ã‚’ã€Œé¸æŠéƒ¨åˆ†ã‚’UUENCODEãƒ‡ã‚³ãƒ¼ãƒ‰ã€ã‹ã‚‰å¤‰æ›´
 };
-const int nFincList_Convert_Num = _countof( pnFuncList_Convert );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List6¨List_Convert)
+const int nFincList_Convert_Num = _countof( pnFuncList_Convert );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List6â†’List_Convert)
 
 
-/* ŒŸõŒn */
-const EFunctionCode pnFuncList_Search[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List4¨List_Search)
-	F_SEARCH_DIALOG		,	//ŒŸõ(’PŒêŒŸõƒ_ƒCƒAƒƒO)
-	F_SEARCH_BOX		,	//ŒŸõ(ƒ{ƒbƒNƒX)
-	F_SEARCH_NEXT		,	//Ÿ‚ğŒŸõ	//Sept. 16, 2000 JEPRO "Ÿ"‚ğ"‘O"‚Ì‘O‚ÉˆÚ“®
-	F_SEARCH_PREV		,	//‘O‚ğŒŸõ
-	F_REPLACE_DIALOG	,	//’uŠ·
-	F_SEARCH_CLEARMARK	,	//ŒŸõƒ}[ƒN‚ÌƒNƒŠƒA
-	F_JUMP_SRCHSTARTPOS	,	//ŒŸõŠJnˆÊ’u‚Ö–ß‚é	// 02/06/26 ai
+/* æ¤œç´¢ç³» */
+const EFunctionCode pnFuncList_Search[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List4â†’List_Search)
+	F_SEARCH_DIALOG		,	//æ¤œç´¢(å˜èªæ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°)
+	F_SEARCH_BOX		,	//æ¤œç´¢(ãƒœãƒƒã‚¯ã‚¹)
+	F_SEARCH_NEXT		,	//æ¬¡ã‚’æ¤œç´¢	//Sept. 16, 2000 JEPRO "æ¬¡"ã‚’"å‰"ã®å‰ã«ç§»å‹•
+	F_SEARCH_PREV		,	//å‰ã‚’æ¤œç´¢
+	F_REPLACE_DIALOG	,	//ç½®æ›
+	F_SEARCH_CLEARMARK	,	//æ¤œç´¢ãƒãƒ¼ã‚¯ã®ã‚¯ãƒªã‚¢
+	F_JUMP_SRCHSTARTPOS	,	//æ¤œç´¢é–‹å§‹ä½ç½®ã¸æˆ»ã‚‹	// 02/06/26 ai
 	F_GREP_DIALOG		,	//Grep
-	F_GREP_REPLACE_DLG	,	//Grep’uŠ·
-	F_JUMP_DIALOG		,	//w’èsƒwƒWƒƒƒ“ƒv
-	F_OUTLINE			,	//ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ
-	F_OUTLINE_TOGGLE	,	//ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ(toggle) // 20060201 aroka
-	F_FILETREE			,	//ƒtƒ@ƒCƒ‹ƒcƒŠ[	// 2012.06.20 Moca
-	F_TAGJUMP			,	//ƒ^ƒOƒWƒƒƒ“ƒv‹@”\
-	F_TAGJUMP_CLOSE		,	//•Â‚¶‚Äƒ^ƒOƒWƒƒƒ“ƒv(Œ³ƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚é) // Apr. 03, 2003 genta
-	F_TAGJUMPBACK		,	//ƒ^ƒOƒWƒƒƒ“ƒvƒoƒbƒN‹@”\
-	F_TAGS_MAKE			,	//ƒ^ƒOƒtƒ@ƒCƒ‹‚Ìì¬	//@@@ 2003.04.13 MIK
-	F_DIRECT_TAGJUMP	,	//ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv	//@@@ 2003.04.15 MIK
-	F_TAGJUMP_KEYWORD	,	//ƒL[ƒ[ƒh‚ğw’è‚µ‚Äƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv	//@@@ 2005.03.31 MIK
-	F_COMPARE			,	//ƒtƒ@ƒCƒ‹“à—e”äŠr
-	F_DIFF_DIALOG		,	//DIFF·•ª•\¦(ƒ_ƒCƒAƒƒO)
-	F_DIFF_NEXT			,	//Ÿ‚Ì·•ª‚Ö
-	F_DIFF_PREV			,	//‘O‚Ì·•ª‚Ö
-	F_DIFF_RESET		,	//·•ª‚Ì‘S‰ğœ
-	F_BRACKETPAIR		,	//‘ÎŠ‡ŒÊ‚ÌŒŸõ
-	F_BOOKMARK_SET		,	//ƒuƒbƒNƒ}[ƒNİ’èE‰ğœ
-	F_BOOKMARK_NEXT		,	//Ÿ‚ÌƒuƒbƒNƒ}[ƒN‚Ö
-	F_BOOKMARK_PREV		,	//‘O‚ÌƒuƒbƒNƒ}[ƒN‚Ö
-	F_BOOKMARK_RESET	,	//ƒuƒbƒNƒ}[ƒN‚Ì‘S‰ğœ
-	F_BOOKMARK_VIEW		,	//ƒuƒbƒNƒ}[ƒN‚Ìˆê——
-	F_ISEARCH_NEXT	    ,   //‘O•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ` //2004.10.13 isearch
-	F_ISEARCH_PREV		,	//Œã•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ` //2004.10.13 isearch
-	F_ISEARCH_REGEXP_NEXT,	//‘O•û³‹K•\Œ»ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`  //2004.10.13 isearch
-	F_ISEARCH_REGEXP_PREV,	//Œã•û³‹K•\Œ»ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`  //2004.10.13 isearch
-	F_ISEARCH_MIGEMO_NEXT,	//‘O•ûMIGEMOƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`    //2004.10.13 isearch
-	F_ISEARCH_MIGEMO_PREV,	//Œã•ûMIGEMOƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`    //2004.10.13 isearch
-	F_FUNCLIST_NEXT		,	//Ÿ‚ÌŠÖ”ƒŠƒXƒgƒ}[ƒN
-	F_FUNCLIST_PREV		,	//‘O‚ÌŠÖ”ƒŠƒXƒgƒ}[ƒN
+	F_GREP_REPLACE_DLG	,	//Grepç½®æ›
+	F_JUMP_DIALOG		,	//æŒ‡å®šè¡Œãƒ˜ã‚¸ãƒ£ãƒ³ãƒ—
+	F_OUTLINE			,	//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ
+	F_OUTLINE_TOGGLE	,	//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ(toggle) // 20060201 aroka
+	F_FILETREE			,	//ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼	// 2012.06.20 Moca
+	F_TAGJUMP			,	//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½
+	F_TAGJUMP_CLOSE		,	//é–‰ã˜ã¦ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—(å…ƒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹) // Apr. 03, 2003 genta
+	F_TAGJUMPBACK		,	//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒãƒƒã‚¯æ©Ÿèƒ½
+	F_TAGS_MAKE			,	//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆ	//@@@ 2003.04.13 MIK
+	F_DIRECT_TAGJUMP	,	//ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—	//@@@ 2003.04.15 MIK
+	F_TAGJUMP_KEYWORD	,	//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’æŒ‡å®šã—ã¦ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—	//@@@ 2005.03.31 MIK
+	F_COMPARE			,	//ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒ
+	F_DIFF_DIALOG		,	//DIFFå·®åˆ†è¡¨ç¤º(ãƒ€ã‚¤ã‚¢ãƒ­ã‚°)
+	F_DIFF_NEXT			,	//æ¬¡ã®å·®åˆ†ã¸
+	F_DIFF_PREV			,	//å‰ã®å·®åˆ†ã¸
+	F_DIFF_RESET		,	//å·®åˆ†ã®å…¨è§£é™¤
+	F_BRACKETPAIR		,	//å¯¾æ‹¬å¼§ã®æ¤œç´¢
+	F_BOOKMARK_SET		,	//ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯è¨­å®šãƒ»è§£é™¤
+	F_BOOKMARK_NEXT		,	//æ¬¡ã®ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã¸
+	F_BOOKMARK_PREV		,	//å‰ã®ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã¸
+	F_BOOKMARK_RESET	,	//ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã®å…¨è§£é™¤
+	F_BOOKMARK_VIEW		,	//ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã®ä¸€è¦§
+	F_ISEARCH_NEXT	    ,   //å‰æ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ //2004.10.13 isearch
+	F_ISEARCH_PREV		,	//å¾Œæ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ //2004.10.13 isearch
+	F_ISEARCH_REGEXP_NEXT,	//å‰æ–¹æ­£è¦è¡¨ç¾ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ  //2004.10.13 isearch
+	F_ISEARCH_REGEXP_PREV,	//å¾Œæ–¹æ­£è¦è¡¨ç¾ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ  //2004.10.13 isearch
+	F_ISEARCH_MIGEMO_NEXT,	//å‰æ–¹MIGEMOã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ    //2004.10.13 isearch
+	F_ISEARCH_MIGEMO_PREV,	//å¾Œæ–¹MIGEMOã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ    //2004.10.13 isearch
+	F_FUNCLIST_NEXT		,	//æ¬¡ã®é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯
+	F_FUNCLIST_PREV		,	//å‰ã®é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯
 };
-const int nFincList_Search_Num = _countof( pnFuncList_Search );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List4¨List_Search)
+const int nFincList_Search_Num = _countof( pnFuncList_Search );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List4â†’List_Search)
 
 
-/* ƒ‚[ƒhØ‚è‘Ö‚¦Œn */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List8¨List_Mode)
+/* ãƒ¢ãƒ¼ãƒ‰åˆ‡ã‚Šæ›¿ãˆç³» */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List8â†’List_Mode)
 const EFunctionCode pnFuncList_Mode[] = {
-	F_CHGMOD_INS		,	//‘}“ü^ã‘‚«ƒ‚[ƒhØ‚è‘Ö‚¦
-	F_CHG_CHARSET		,	//•¶šƒR[ƒhƒZƒbƒgw’è		2010/6/14 Uchi
-	F_CHGMOD_EOL_CRLF	,	//“ü—Í‰üsƒR[ƒhw’è(CRLF)	2003.06.23 Moca
-	F_CHGMOD_EOL_LF		,	//“ü—Í‰üsƒR[ƒhw’è(LF)	2003.06.23 Moca
-	F_CHGMOD_EOL_CR		,	//“ü—Í‰üsƒR[ƒhw’è(CR)	2003.06.23 Moca
-	F_CANCEL_MODE			//Šeíƒ‚[ƒh‚Ìæ‚èÁ‚µ
+	F_CHGMOD_INS		,	//æŒ¿å…¥ï¼ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰åˆ‡ã‚Šæ›¿ãˆ
+	F_CHG_CHARSET		,	//æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆæŒ‡å®š		2010/6/14 Uchi
+	F_CHGMOD_EOL_CRLF	,	//å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š(CRLF)	2003.06.23 Moca
+	F_CHGMOD_EOL_LF		,	//å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š(LF)	2003.06.23 Moca
+	F_CHGMOD_EOL_CR		,	//å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š(CR)	2003.06.23 Moca
+	F_CANCEL_MODE			//å„ç¨®ãƒ¢ãƒ¼ãƒ‰ã®å–ã‚Šæ¶ˆã—
 };
-const int nFincList_Mode_Num = _countof( pnFuncList_Mode );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List8¨List_Mode)
+const int nFincList_Mode_Num = _countof( pnFuncList_Mode );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List8â†’List_Mode)
 
 
-/* İ’èŒn */
-const EFunctionCode pnFuncList_Set[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List9¨List_Set)
-	F_SHOWTOOLBAR		,	/* ƒc[ƒ‹ƒo[‚Ì•\¦ */
-	F_SHOWFUNCKEY		,	/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚Ì•\¦ */	//Sept. 14, 2000 JEPRO ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ÆƒXƒe[ƒ^ƒXƒo[‚ğ“ü‚ê‘Ö‚¦
-	F_SHOWTAB			,	/* ƒ^ƒu‚Ì•\¦ */	//@@@ 2003.06.10 MIK
-	F_SHOWSTATUSBAR		,	/* ƒXƒe[ƒ^ƒXƒo[‚Ì•\¦ */
-	F_SHOWMINIMAP		,	// ƒ~ƒjƒ}ƒbƒv‚Ì•\¦
-	F_TYPE_LIST			,	/* ƒ^ƒCƒv•Êİ’èˆê—— */			//Sept. 17, 2000 JEPRO İ’èŒn‚É“ü‚Á‚Ä‚È‚©‚Á‚½‚Ì‚Å’Ç‰Á
-	F_OPTION_TYPE		,	/* ƒ^ƒCƒv•Êİ’è */
-	F_OPTION			,	/* ‹¤’Êİ’è */
-	F_FONT				,	/* ƒtƒHƒ“ƒgİ’è */
-	F_SETFONTSIZEUP		,	// ƒtƒHƒ“ƒgƒTƒCƒYŠg‘å
-	F_SETFONTSIZEDOWN	,	// ƒtƒHƒ“ƒgƒTƒCƒYk¬
-	F_WRAPWINDOWWIDTH	,	/* Œ»İ‚ÌƒEƒBƒ“ƒhƒE•‚ÅÜ‚è•Ô‚µ */	//Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH ‚ğ WRAPWINDOWWIDTH ‚É•ÏX
-	F_PRINT_PAGESETUP	,	//ˆóüƒy[ƒWİ’è				//Sept. 14, 2000 JEPRO uˆóü‚Ìƒy[ƒWƒŒƒCƒAƒEƒg‚Ìİ’èv‚ğuˆóüƒy[ƒWİ’èv‚É•ÏX	//Oct. 17, 2000 ƒRƒ}ƒ“ƒh–{‰Æ‚Íuƒtƒ@ƒCƒ‹‘€ìŒnv
-	F_FAVORITE			,	//—š—ğ‚ÌŠÇ—	//@@@ 2003.04.08 MIK
-	F_TMPWRAPNOWRAP		,	//Ü‚è•Ô‚³‚È‚¢iˆêİ’èj			// 2008.05.30 nasukoji
-	F_TMPWRAPSETTING	,	//w’èŒ…‚ÅÜ‚è•Ô‚·iˆêİ’èj		// 2008.05.30 nasukoji
-	F_TMPWRAPWINDOW		,	//‰E’[‚ÅÜ‚è•Ô‚·iˆêİ’èj		// 2008.05.30 nasukoji
-	F_SELECT_COUNT_MODE		//•¶šƒJƒEƒ“ƒgİ’è	// 2009.07.06 syat
+/* è¨­å®šç³» */
+const EFunctionCode pnFuncList_Set[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List9â†’List_Set)
+	F_SHOWTOOLBAR		,	/* ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã®è¡¨ç¤º */
+	F_SHOWFUNCKEY		,	/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®è¡¨ç¤º */	//Sept. 14, 2000 JEPRO ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã¨ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã‚’å…¥ã‚Œæ›¿ãˆ
+	F_SHOWTAB			,	/* ã‚¿ãƒ–ã®è¡¨ç¤º */	//@@@ 2003.06.10 MIK
+	F_SHOWSTATUSBAR		,	/* ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã®è¡¨ç¤º */
+	F_SHOWMINIMAP		,	// ãƒŸãƒ‹ãƒãƒƒãƒ—ã®è¡¨ç¤º
+	F_TYPE_LIST			,	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šä¸€è¦§ */			//Sept. 17, 2000 JEPRO è¨­å®šç³»ã«å…¥ã£ã¦ãªã‹ã£ãŸã®ã§è¿½åŠ 
+	F_OPTION_TYPE		,	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š */
+	F_OPTION			,	/* å…±é€šè¨­å®š */
+	F_FONT				,	/* ãƒ•ã‚©ãƒ³ãƒˆè¨­å®š */
+	F_SETFONTSIZEUP		,	// ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºæ‹¡å¤§
+	F_SETFONTSIZEDOWN	,	// ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºç¸®å°
+	F_WRAPWINDOWWIDTH	,	/* ç¾åœ¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ã§æŠ˜ã‚Šè¿”ã— */	//Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH ã‚’ WRAPWINDOWWIDTH ã«å¤‰æ›´
+	F_PRINT_PAGESETUP	,	//å°åˆ·ãƒšãƒ¼ã‚¸è¨­å®š				//Sept. 14, 2000 JEPRO ã€Œå°åˆ·ã®ãƒšãƒ¼ã‚¸ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã®è¨­å®šã€ã‚’ã€Œå°åˆ·ãƒšãƒ¼ã‚¸è¨­å®šã€ã«å¤‰æ›´	//Oct. 17, 2000 ã‚³ãƒãƒ³ãƒ‰æœ¬å®¶ã¯ã€Œãƒ•ã‚¡ã‚¤ãƒ«æ“ä½œç³»ã€
+	F_FAVORITE			,	//å±¥æ­´ã®ç®¡ç†	//@@@ 2003.04.08 MIK
+	F_TMPWRAPNOWRAP		,	//æŠ˜ã‚Šè¿”ã•ãªã„ï¼ˆä¸€æ™‚è¨­å®šï¼‰			// 2008.05.30 nasukoji
+	F_TMPWRAPSETTING	,	//æŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™ï¼ˆä¸€æ™‚è¨­å®šï¼‰		// 2008.05.30 nasukoji
+	F_TMPWRAPWINDOW		,	//å³ç«¯ã§æŠ˜ã‚Šè¿”ã™ï¼ˆä¸€æ™‚è¨­å®šï¼‰		// 2008.05.30 nasukoji
+	F_SELECT_COUNT_MODE		//æ–‡å­—ã‚«ã‚¦ãƒ³ãƒˆè¨­å®š	// 2009.07.06 syat
 };
-int		nFincList_Set_Num = _countof( pnFuncList_Set );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List9¨List_Set)
+int		nFincList_Set_Num = _countof( pnFuncList_Set );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List9â†’List_Set)
 
 
-/* ƒ}ƒNƒŒn */
-const EFunctionCode pnFuncList_Macro[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List10¨List_Macro)
-	F_RECKEYMACRO	,	/* ƒL[ƒ}ƒNƒ‚Ì‹L˜^ŠJn^I—¹ */
-	F_SAVEKEYMACRO	,	/* ƒL[ƒ}ƒNƒ‚Ì•Û‘¶ */
-	F_LOADKEYMACRO	,	/* ƒL[ƒ}ƒNƒ‚Ì“Ç‚İ‚İ */
-	F_EXECKEYMACRO	,	/* ƒL[ƒ}ƒNƒ‚ÌÀs */
-	F_EXECEXTMACRO	,	/* –¼‘O‚ğw’è‚µ‚Äƒ}ƒNƒÀs */
-//	From Here Sept. 20, 2000 JEPRO –¼ÌCMMAND‚ğCOMMAND‚É•ÏX
-//	F_EXECCMMAND		/* ŠO•”ƒRƒ}ƒ“ƒhÀs */
-	F_EXECMD_DIALOG		/* ŠO•”ƒRƒ}ƒ“ƒhÀs */
+/* ãƒã‚¯ãƒ­ç³» */
+const EFunctionCode pnFuncList_Macro[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List10â†’List_Macro)
+	F_RECKEYMACRO	,	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®è¨˜éŒ²é–‹å§‹ï¼çµ‚äº† */
+	F_SAVEKEYMACRO	,	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ä¿å­˜ */
+	F_LOADKEYMACRO	,	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ */
+	F_EXECKEYMACRO	,	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®å®Ÿè¡Œ */
+	F_EXECEXTMACRO	,	/* åå‰ã‚’æŒ‡å®šã—ã¦ãƒã‚¯ãƒ­å®Ÿè¡Œ */
+//	From Here Sept. 20, 2000 JEPRO åç§°CMMANDã‚’COMMANDã«å¤‰æ›´
+//	F_EXECCMMAND		/* å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œ */
+	F_EXECMD_DIALOG		/* å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œ */
 //	To Here Sept. 20, 2000
 
 };
-const int nFincList_Macro_Num = _countof( pnFuncList_Macro);	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List10¨List_Macro)
+const int nFincList_Macro_Num = _countof( pnFuncList_Macro);	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List10â†’List_Macro)
 
 
-/* ƒJƒXƒ^ƒ€ƒƒjƒ…[ */	//Oct. 21, 2000 JEPRO u‚»‚Ì‘¼v‚©‚ç•ª—£“Æ—§‰»
+/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */	//Oct. 21, 2000 JEPRO ã€Œãã®ä»–ã€ã‹ã‚‰åˆ†é›¢ç‹¬ç«‹åŒ–
 #if 0
 //	From Here Oct. 15, 2001 genta
-//	ƒJƒXƒ^ƒ€ƒƒjƒ…[‚Ì•¶š—ñ‚ğ“®“I‚É•ÏX‰Â”\‚É‚·‚é‚½‚ß‚±‚ê‚ÍíœD
+//	ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ–‡å­—åˆ—ã‚’å‹•çš„ã«å¤‰æ›´å¯èƒ½ã«ã™ã‚‹ãŸã‚ã“ã‚Œã¯å‰Šé™¤ï¼
 const EFunctionCode pnFuncList_Menu[] = {
-	F_MENU_RBUTTON				,	/* ‰EƒNƒŠƒbƒNƒƒjƒ…[ */
-	F_CUSTMENU_1				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[1 */
-	F_CUSTMENU_2				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[2 */
-	F_CUSTMENU_3				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[3 */
-	F_CUSTMENU_4				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[4 */
-	F_CUSTMENU_5				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[5 */
-	F_CUSTMENU_6				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[6 */
-	F_CUSTMENU_7				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[7 */
-	F_CUSTMENU_8				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[8 */
-	F_CUSTMENU_9				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[9 */
-	F_CUSTMENU_10				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[10 */
-	F_CUSTMENU_11				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[11 */
-	F_CUSTMENU_12				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[12 */
-	F_CUSTMENU_13				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[13 */
-	F_CUSTMENU_14				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[14 */
-	F_CUSTMENU_15				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[15 */
-	F_CUSTMENU_16				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[16 */
-	F_CUSTMENU_17				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[17 */
-	F_CUSTMENU_18				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[18 */
-	F_CUSTMENU_19				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[19 */
-	F_CUSTMENU_20				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[20 */
-	F_CUSTMENU_21				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[21 */
-	F_CUSTMENU_22				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[22 */
-	F_CUSTMENU_23				,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[23 */
-	F_CUSTMENU_24				 	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[24 */
+	F_MENU_RBUTTON				,	/* å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */
+	F_CUSTMENU_1				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼1 */
+	F_CUSTMENU_2				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼2 */
+	F_CUSTMENU_3				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼3 */
+	F_CUSTMENU_4				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼4 */
+	F_CUSTMENU_5				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼5 */
+	F_CUSTMENU_6				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼6 */
+	F_CUSTMENU_7				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼7 */
+	F_CUSTMENU_8				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼8 */
+	F_CUSTMENU_9				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼9 */
+	F_CUSTMENU_10				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼10 */
+	F_CUSTMENU_11				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼11 */
+	F_CUSTMENU_12				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼12 */
+	F_CUSTMENU_13				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼13 */
+	F_CUSTMENU_14				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼14 */
+	F_CUSTMENU_15				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼15 */
+	F_CUSTMENU_16				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼16 */
+	F_CUSTMENU_17				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼17 */
+	F_CUSTMENU_18				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼18 */
+	F_CUSTMENU_19				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼19 */
+	F_CUSTMENU_20				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼20 */
+	F_CUSTMENU_21				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼21 */
+	F_CUSTMENU_22				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼22 */
+	F_CUSTMENU_23				,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼23 */
+	F_CUSTMENU_24				 	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼24 */
 };
-const int nFincList_Menu_Num = _countof( pnFuncList_Menu );	//Oct. 21, 2000 JEPRO u‚»‚Ì‘¼v‚©‚ç•ª—£“Æ—§‰»
+const int nFincList_Menu_Num = _countof( pnFuncList_Menu );	//Oct. 21, 2000 JEPRO ã€Œãã®ä»–ã€ã‹ã‚‰åˆ†é›¢ç‹¬ç«‹åŒ–
 #endif
 
-/* ƒEƒBƒ“ƒhƒEŒn */
-const EFunctionCode pnFuncList_Win[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List7¨List_Win)
-	F_SPLIT_V			,	//ã‰º‚É•ªŠ„	//Sept. 17, 2000 jepro à–¾‚Ìucv‚ğuã‰º‚Év‚É•ÏX
-	F_SPLIT_H			,	//¶‰E‚É•ªŠ„	//Sept. 17, 2000 jepro à–¾‚Ìu‰¡v‚ğu¶‰E‚Év‚É•ÏX
-	F_SPLIT_VH			,	//c‰¡‚É•ªŠ„	//Sept. 17, 2000 jepro à–¾‚Éu‚Év‚ğ’Ç‰Á
-	F_WINCLOSE			,	//ƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚é
-	F_WIN_CLOSEALL		,	//‚·‚×‚Ä‚ÌƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚é	//Oct. 17, 2000 JEPRO –¼‘O‚ğ•ÏX(F_FILECLOSEALL¨F_WIN_CLOSEALL)
-	F_TAB_CLOSEOTHER	,	//‚±‚Ìƒ^ƒuˆÈŠO‚ğ•Â‚¶‚é	// 2008.11.22 syat
-	F_NEXTWINDOW		,	//Ÿ‚ÌƒEƒBƒ“ƒhƒE
-	F_PREVWINDOW		,	//‘O‚ÌƒEƒBƒ“ƒhƒE
- 	F_WINLIST			,	//ŠJ‚¢‚Ä‚¢‚éƒEƒBƒ“ƒhƒEˆê——ƒ|ƒbƒvƒAƒbƒv•\¦	// 2006.03.23 fon
-	F_DLGWINLIST		,	//ƒEƒBƒ“ƒhƒEˆê——•\¦
-	F_CASCADE			,	//d‚Ë‚Ä•\¦
-	F_TILE_V			,	//ã‰º‚É•À‚×‚Ä•\¦
-	F_TILE_H			,	//¶‰E‚É•À‚×‚Ä•\¦
-	F_TOPMOST			,	//í‚Éè‘O‚É•\¦
-	F_BIND_WINDOW		,	//Œ‹‡‚µ‚Ä•\¦	// 2006.04.22 ryoji
-	F_GROUPCLOSE		,	//ƒOƒ‹[ƒv‚ğ•Â‚¶‚é	// 2007.06.20 ryoji
-	F_NEXTGROUP			,	//Ÿ‚ÌƒOƒ‹[ƒv	// 2007.06.20 ryoji
-	F_PREVGROUP			,	//‘O‚ÌƒOƒ‹[ƒv	// 2007.06.20 ryoji
-	F_TAB_MOVERIGHT		,	//ƒ^ƒu‚ğ‰E‚ÉˆÚ“®	// 2007.06.20 ryoji
-	F_TAB_MOVELEFT		,	//ƒ^ƒu‚ğ¶‚ÉˆÚ“®	// 2007.06.20 ryoji
-	F_TAB_SEPARATE		,	//V‹KƒOƒ‹[ƒv	// 2007.06.20 ryoji
-	F_TAB_JOINTNEXT		,	//Ÿ‚ÌƒOƒ‹[ƒv‚ÉˆÚ“®	// 2007.06.20 ryoji
-	F_TAB_JOINTPREV		,	//‘O‚ÌƒOƒ‹[ƒv‚ÉˆÚ“®	// 2007.06.20 ryoji
-	F_TAB_CLOSELEFT 	,	//¶‚ğ‚·‚×‚Ä•Â‚¶‚é		// 2008.11.22 syat
-	F_TAB_CLOSERIGHT	,	//‰E‚ğ‚·‚×‚Ä•Â‚¶‚é		// 2008.11.22 syat
-	F_MAXIMIZE_V		,	//c•ûŒü‚ÉÅ‘å‰»
-	F_MAXIMIZE_H		,	//‰¡•ûŒü‚ÉÅ‘å‰» //2001.02.10 by MIK
-	F_MINIMIZE_ALL		,	//‚·‚×‚ÄÅ¬‰»	//Sept. 17, 2000 jepro à–¾‚Ìu‘S‚Äv‚ğu‚·‚×‚Äv‚É“ˆê
-	F_REDRAW			,	//Ä•`‰æ
-	F_WIN_OUTPUT		,	//ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE•\¦
+/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç³» */
+const EFunctionCode pnFuncList_Win[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List7â†’List_Win)
+	F_SPLIT_V			,	//ä¸Šä¸‹ã«åˆ†å‰²	//Sept. 17, 2000 jepro èª¬æ˜ã®ã€Œç¸¦ã€ã‚’ã€Œä¸Šä¸‹ã«ã€ã«å¤‰æ›´
+	F_SPLIT_H			,	//å·¦å³ã«åˆ†å‰²	//Sept. 17, 2000 jepro èª¬æ˜ã®ã€Œæ¨ªã€ã‚’ã€Œå·¦å³ã«ã€ã«å¤‰æ›´
+	F_SPLIT_VH			,	//ç¸¦æ¨ªã«åˆ†å‰²	//Sept. 17, 2000 jepro èª¬æ˜ã«ã€Œã«ã€ã‚’è¿½åŠ 
+	F_WINCLOSE			,	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹
+	F_WIN_CLOSEALL		,	//ã™ã¹ã¦ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹	//Oct. 17, 2000 JEPRO åå‰ã‚’å¤‰æ›´(F_FILECLOSEALLâ†’F_WIN_CLOSEALL)
+	F_TAB_CLOSEOTHER	,	//ã“ã®ã‚¿ãƒ–ä»¥å¤–ã‚’é–‰ã˜ã‚‹	// 2008.11.22 syat
+	F_NEXTWINDOW		,	//æ¬¡ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	F_PREVWINDOW		,	//å‰ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+ 	F_WINLIST			,	//é–‹ã„ã¦ã„ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§ãƒãƒƒãƒ—ã‚¢ãƒƒãƒ—è¡¨ç¤º	// 2006.03.23 fon
+	F_DLGWINLIST		,	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§è¡¨ç¤º
+	F_CASCADE			,	//é‡ã­ã¦è¡¨ç¤º
+	F_TILE_V			,	//ä¸Šä¸‹ã«ä¸¦ã¹ã¦è¡¨ç¤º
+	F_TILE_H			,	//å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º
+	F_TOPMOST			,	//å¸¸ã«æ‰‹å‰ã«è¡¨ç¤º
+	F_BIND_WINDOW		,	//çµåˆã—ã¦è¡¨ç¤º	// 2006.04.22 ryoji
+	F_GROUPCLOSE		,	//ã‚°ãƒ«ãƒ¼ãƒ—ã‚’é–‰ã˜ã‚‹	// 2007.06.20 ryoji
+	F_NEXTGROUP			,	//æ¬¡ã®ã‚°ãƒ«ãƒ¼ãƒ—	// 2007.06.20 ryoji
+	F_PREVGROUP			,	//å‰ã®ã‚°ãƒ«ãƒ¼ãƒ—	// 2007.06.20 ryoji
+	F_TAB_MOVERIGHT		,	//ã‚¿ãƒ–ã‚’å³ã«ç§»å‹•	// 2007.06.20 ryoji
+	F_TAB_MOVELEFT		,	//ã‚¿ãƒ–ã‚’å·¦ã«ç§»å‹•	// 2007.06.20 ryoji
+	F_TAB_SEPARATE		,	//æ–°è¦ã‚°ãƒ«ãƒ¼ãƒ—	// 2007.06.20 ryoji
+	F_TAB_JOINTNEXT		,	//æ¬¡ã®ã‚°ãƒ«ãƒ¼ãƒ—ã«ç§»å‹•	// 2007.06.20 ryoji
+	F_TAB_JOINTPREV		,	//å‰ã®ã‚°ãƒ«ãƒ¼ãƒ—ã«ç§»å‹•	// 2007.06.20 ryoji
+	F_TAB_CLOSELEFT 	,	//å·¦ã‚’ã™ã¹ã¦é–‰ã˜ã‚‹		// 2008.11.22 syat
+	F_TAB_CLOSERIGHT	,	//å³ã‚’ã™ã¹ã¦é–‰ã˜ã‚‹		// 2008.11.22 syat
+	F_MAXIMIZE_V		,	//ç¸¦æ–¹å‘ã«æœ€å¤§åŒ–
+	F_MAXIMIZE_H		,	//æ¨ªæ–¹å‘ã«æœ€å¤§åŒ– //2001.02.10 by MIK
+	F_MINIMIZE_ALL		,	//ã™ã¹ã¦æœ€å°åŒ–	//Sept. 17, 2000 jepro èª¬æ˜ã®ã€Œå…¨ã¦ã€ã‚’ã€Œã™ã¹ã¦ã€ã«çµ±ä¸€
+	F_REDRAW			,	//å†æç”»
+	F_WIN_OUTPUT		,	//ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦è¡¨ç¤º
 };
-const int nFincList_Win_Num = _countof( pnFuncList_Win );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List7¨List_Win)
+const int nFincList_Win_Num = _countof( pnFuncList_Win );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List7â†’List_Win)
 
 
-/* x‰‡ */
-const EFunctionCode pnFuncList_Support[] = {	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List11¨List_Support)
-	F_HOKAN						,	/* “ü—Í•âŠ® */
-	F_TOGGLE_KEY_SEARCH			,	/* ƒLƒƒƒŒƒbƒgˆÊ’u‚Ì’PŒê‚ğ«‘ŒŸõ‚·‚é‹@”\ON/OFF */	// 2006.03.24 fon
-//Sept. 15, 2000¨Nov. 25, 2000 JEPRO //ƒVƒ‡[ƒgƒJƒbƒgƒL[‚ª‚¤‚Ü‚­“­‚©‚È‚¢‚Ì‚ÅE‚µ‚Ä‚ ‚Á‚½‰º‚Ì2s‚ğC³E•œŠˆ
-	F_HELP_CONTENTS				,	/* ƒwƒ‹ƒv–ÚŸ */			//Nov. 25, 2000 JEPRO ’Ç‰Á
-	F_HELP_SEARCH				,	/* ƒwƒ‹ƒvƒL[ƒ[ƒhŒŸõ */	//Nov. 25, 2000 JEPRO ’Ç‰Á
-	F_MENU_ALLFUNC				,	/* ƒRƒ}ƒ“ƒhˆê—— */
-	F_EXTHELP1					,	/* ŠO•”ƒwƒ‹ƒv‚P */
-	F_EXTHTMLHELP				,	/* ŠO•”HTMLƒwƒ‹ƒv */
-	F_ABOUT							/* ƒo[ƒWƒ‡ƒ“î•ñ */	//Dec. 24, 2000 JEPRO ’Ç‰Á
+/* æ”¯æ´ */
+const EFunctionCode pnFuncList_Support[] = {	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List11â†’List_Support)
+	F_HOKAN						,	/* å…¥åŠ›è£œå®Œ */
+	F_TOGGLE_KEY_SEARCH			,	/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã®å˜èªã‚’è¾æ›¸æ¤œç´¢ã™ã‚‹æ©Ÿèƒ½ON/OFF */	// 2006.03.24 fon
+//Sept. 15, 2000â†’Nov. 25, 2000 JEPRO //ã‚·ãƒ§ãƒ¼ãƒˆã‚«ãƒƒãƒˆã‚­ãƒ¼ãŒã†ã¾ãåƒã‹ãªã„ã®ã§æ®ºã—ã¦ã‚ã£ãŸä¸‹ã®2è¡Œã‚’ä¿®æ­£ãƒ»å¾©æ´»
+	F_HELP_CONTENTS				,	/* ãƒ˜ãƒ«ãƒ—ç›®æ¬¡ */			//Nov. 25, 2000 JEPRO è¿½åŠ 
+	F_HELP_SEARCH				,	/* ãƒ˜ãƒ«ãƒ—ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æ¤œç´¢ */	//Nov. 25, 2000 JEPRO è¿½åŠ 
+	F_MENU_ALLFUNC				,	/* ã‚³ãƒãƒ³ãƒ‰ä¸€è¦§ */
+	F_EXTHELP1					,	/* å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘ */
+	F_EXTHTMLHELP				,	/* å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ— */
+	F_ABOUT							/* ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ± */	//Dec. 24, 2000 JEPRO è¿½åŠ 
 };
-const int nFincList_Support_Num = _countof( pnFuncList_Support );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List11¨List_Support)
+const int nFincList_Support_Num = _countof( pnFuncList_Support );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List11â†’List_Support)
 
 
-/* ‚»‚Ì‘¼ */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List12¨List_Others)
+/* ãã®ä»– */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List12â†’List_Others)
 const EFunctionCode pnFuncList_Others[] = {
-	F_DISABLE				//Oct. 21, 2000 JEPRO ‰½‚à‚È‚¢‚ÆƒGƒ‰[‚É‚È‚Á‚Ä‚µ‚Ü‚¤‚Ì‚Åƒ_ƒ~[‚Å[–¢’è‹`]‚ğ“ü‚ê‚Ä‚¨‚­
+	F_DISABLE				//Oct. 21, 2000 JEPRO ä½•ã‚‚ãªã„ã¨ã‚¨ãƒ©ãƒ¼ã«ãªã£ã¦ã—ã¾ã†ã®ã§ãƒ€ãƒŸãƒ¼ã§[æœªå®šç¾©]ã‚’å…¥ã‚Œã¦ãŠã
 };
-const int nFincList_Others_Num = _countof( pnFuncList_Others );	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List12¨List_Others)
+const int nFincList_Others_Num = _countof( pnFuncList_Others );	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List12â†’List_Others)
 
-// “Áê‹@”\
+// ç‰¹æ®Šæ©Ÿèƒ½
 const EFunctionCode nsFuncCode::pnFuncList_Special[] = {
 	F_WINDOW_LIST,
 	F_FILE_USED_RECENTLY,
@@ -528,466 +528,466 @@ const int nsFuncCode::nFuncList_Special_Num = (int)_countof(nsFuncCode::pnFuncLi
 
 
 const int nsFuncCode::pnFuncListNumArr[] = {
-//	nFincList_Undef_Num,	//Oct. 14, 2000 JEPRO u--–¢’è‹`--v‚ğ•\¦‚³‚¹‚È‚¢‚æ‚¤‚É•ÏX	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List0¨List_Undef)
-	nFincList_File_Num,		/* ƒtƒ@ƒCƒ‹‘€ìŒn */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List5¨List_File)
-	nFincList_Edit_Num,		/* •ÒWŒn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List3¨List_Edit)
-	nFincList_Move_Num,		/* ƒJ[ƒ\ƒ‹ˆÚ“®Œn */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List1¨List_Move)
-	nFincList_Select_Num,	/* ‘I‘ğŒn */			//Oct. 15, 2000 JEPRO uƒJ[ƒ\ƒ‹ˆÚ“®Œnv‚©‚ç(‘I‘ğ)‚ğˆÚ“®
-	nFincList_Box_Num,		/* ‹éŒ`‘I‘ğŒn */		//Oct. 17, 2000 JEPRO (‹éŒ`‘I‘ğ)‚ªVİ‚³‚êŸ‘æ‚±‚±‚É‚¨‚­
-	nFincList_Clip_Num,		/* ƒNƒŠƒbƒvƒ{[ƒhŒn */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List2¨List_Clip)
-	nFincList_Insert_Num,	/* ‘}“üŒn */
-	nFincList_Convert_Num,	/* •ÏŠ·Œn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List6¨List_Convert)
-	nFincList_Search_Num,	/* ŒŸõŒn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List4¨List_Search)
-	nFincList_Mode_Num,		/* ƒ‚[ƒhØ‚è‘Ö‚¦Œn */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List8¨List_Mode)
-	nFincList_Set_Num,		/* İ’èŒn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List9¨List_Set)
-	nFincList_Macro_Num,	/* ƒ}ƒNƒŒn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List10¨List_Macro)
-//	ƒJƒXƒ^ƒ€ƒƒjƒ…[‚Ì•¶š—ñ‚ğ“®“I‚É•ÏX‰Â”\‚É‚·‚é‚½‚ß‚±‚ê‚Ííœ
-//	nFincList_Menu_Num,		/* ƒJƒXƒ^ƒ€ƒƒjƒ…[ */	//Oct. 21, 2000 JEPRO u‚»‚Ì‘¼v‚©‚ç•ª—£“Æ—§‰»
-	nFincList_Win_Num,		/* ƒEƒBƒ“ƒhƒEŒn */		//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List7¨List_Win)
-	nFincList_Support_Num,	/* x‰‡ */				//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List11¨List_Support)
-	nFincList_Others_Num	/* ‚»‚Ì‘¼ */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List12¨List_Others)
+//	nFincList_Undef_Num,	//Oct. 14, 2000 JEPRO ã€Œ--æœªå®šç¾©--ã€ã‚’è¡¨ç¤ºã•ã›ãªã„ã‚ˆã†ã«å¤‰æ›´	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List0â†’List_Undef)
+	nFincList_File_Num,		/* ãƒ•ã‚¡ã‚¤ãƒ«æ“ä½œç³» */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List5â†’List_File)
+	nFincList_Edit_Num,		/* ç·¨é›†ç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List3â†’List_Edit)
+	nFincList_Move_Num,		/* ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³» */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List1â†’List_Move)
+	nFincList_Select_Num,	/* é¸æŠç³» */			//Oct. 15, 2000 JEPRO ã€Œã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³»ã€ã‹ã‚‰(é¸æŠ)ã‚’ç§»å‹•
+	nFincList_Box_Num,		/* çŸ©å½¢é¸æŠç³» */		//Oct. 17, 2000 JEPRO (çŸ©å½¢é¸æŠ)ãŒæ–°è¨­ã•ã‚Œæ¬¡ç¬¬ã“ã“ã«ãŠã
+	nFincList_Clip_Num,		/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ç³» */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List2â†’List_Clip)
+	nFincList_Insert_Num,	/* æŒ¿å…¥ç³» */
+	nFincList_Convert_Num,	/* å¤‰æ›ç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List6â†’List_Convert)
+	nFincList_Search_Num,	/* æ¤œç´¢ç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List4â†’List_Search)
+	nFincList_Mode_Num,		/* ãƒ¢ãƒ¼ãƒ‰åˆ‡ã‚Šæ›¿ãˆç³» */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List8â†’List_Mode)
+	nFincList_Set_Num,		/* è¨­å®šç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List9â†’List_Set)
+	nFincList_Macro_Num,	/* ãƒã‚¯ãƒ­ç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List10â†’List_Macro)
+//	ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ–‡å­—åˆ—ã‚’å‹•çš„ã«å¤‰æ›´å¯èƒ½ã«ã™ã‚‹ãŸã‚ã“ã‚Œã¯å‰Šé™¤
+//	nFincList_Menu_Num,		/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */	//Oct. 21, 2000 JEPRO ã€Œãã®ä»–ã€ã‹ã‚‰åˆ†é›¢ç‹¬ç«‹åŒ–
+	nFincList_Win_Num,		/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç³» */		//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List7â†’List_Win)
+	nFincList_Support_Num,	/* æ”¯æ´ */				//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List11â†’List_Support)
+	nFincList_Others_Num	/* ãã®ä»– */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List12â†’List_Others)
 };
 const EFunctionCode* nsFuncCode::ppnFuncListArr[] = {
-//	pnFuncList_Undef,	//Oct. 14, 2000 JEPRO u--–¢’è‹`--v‚ğ•\¦‚³‚¹‚È‚¢‚æ‚¤‚É•ÏX	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List0¨List_Undef)
-	pnFuncList_File,	/* ƒtƒ@ƒCƒ‹‘€ìŒn */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List5¨List_File)
-	pnFuncList_Edit,	/* •ÒWŒn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List3¨List_Edit)
-	pnFuncList_Move,	/* ƒJ[ƒ\ƒ‹ˆÚ“®Œn */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List1¨List_Move)
-	pnFuncList_Select,/* ‘I‘ğŒn */			//Oct. 15, 2000 JEPRO uƒJ[ƒ\ƒ‹ˆÚ“®Œnv‚©‚ç(‘I‘ğ)‚ğˆÚ“®  (‹éŒ`‘I‘ğ)‚ÍVİ‚³‚êŸ‘æ‚±‚±‚É‚¨‚­
-	pnFuncList_Box,	/* ‹éŒ`‘I‘ğŒn */		//Oct. 17, 2000 JEPRO (‹éŒ`‘I‘ğ)‚ªVİ‚³‚êŸ‘æ‚±‚±‚É‚¨‚­
-	pnFuncList_Clip,	/* ƒNƒŠƒbƒvƒ{[ƒhŒn */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List2¨List_Clip)
-	pnFuncList_Insert,/* ‘}“üŒn */
-	pnFuncList_Convert,/* •ÏŠ·Œn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List6¨List_Convert)
-	pnFuncList_Search,/* ŒŸõŒn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List4¨List_Search)
-	pnFuncList_Mode,	/* ƒ‚[ƒhØ‚è‘Ö‚¦Œn */	//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List8¨List_Mode)
-	pnFuncList_Set,	/* İ’èŒn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List9¨List_Set)
-	pnFuncList_Macro,	/* ƒ}ƒNƒŒn */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List10¨List_Macro)
-//	ƒJƒXƒ^ƒ€ƒƒjƒ…[‚Ì•¶š—ñ‚ğ“®“I‚É•ÏX‰Â”\‚É‚·‚é‚½‚ß‚±‚ê‚Ííœ
-//	pnFuncList_Menu,	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[ */	//Oct. 21, 2000 JEPROu‚»‚Ì‘¼v‚©‚ç•ª—£“Æ—§‰»
-	pnFuncList_Win,	/* ƒEƒBƒ“ƒhƒEŒn */		//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List7¨List_Win)
-	pnFuncList_Support,/* x‰‡ */				//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List11¨List_Support)
-	pnFuncList_Others	/* ‚»‚Ì‘¼ */			//Oct. 16, 2000 JEPRO •Ï”–¼•ÏX(List12¨List_Others)
+//	pnFuncList_Undef,	//Oct. 14, 2000 JEPRO ã€Œ--æœªå®šç¾©--ã€ã‚’è¡¨ç¤ºã•ã›ãªã„ã‚ˆã†ã«å¤‰æ›´	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List0â†’List_Undef)
+	pnFuncList_File,	/* ãƒ•ã‚¡ã‚¤ãƒ«æ“ä½œç³» */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List5â†’List_File)
+	pnFuncList_Edit,	/* ç·¨é›†ç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List3â†’List_Edit)
+	pnFuncList_Move,	/* ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³» */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List1â†’List_Move)
+	pnFuncList_Select,/* é¸æŠç³» */			//Oct. 15, 2000 JEPRO ã€Œã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³»ã€ã‹ã‚‰(é¸æŠ)ã‚’ç§»å‹•  (çŸ©å½¢é¸æŠ)ã¯æ–°è¨­ã•ã‚Œæ¬¡ç¬¬ã“ã“ã«ãŠã
+	pnFuncList_Box,	/* çŸ©å½¢é¸æŠç³» */		//Oct. 17, 2000 JEPRO (çŸ©å½¢é¸æŠ)ãŒæ–°è¨­ã•ã‚Œæ¬¡ç¬¬ã“ã“ã«ãŠã
+	pnFuncList_Clip,	/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ç³» */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List2â†’List_Clip)
+	pnFuncList_Insert,/* æŒ¿å…¥ç³» */
+	pnFuncList_Convert,/* å¤‰æ›ç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List6â†’List_Convert)
+	pnFuncList_Search,/* æ¤œç´¢ç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List4â†’List_Search)
+	pnFuncList_Mode,	/* ãƒ¢ãƒ¼ãƒ‰åˆ‡ã‚Šæ›¿ãˆç³» */	//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List8â†’List_Mode)
+	pnFuncList_Set,	/* è¨­å®šç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List9â†’List_Set)
+	pnFuncList_Macro,	/* ãƒã‚¯ãƒ­ç³» */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List10â†’List_Macro)
+//	ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ–‡å­—åˆ—ã‚’å‹•çš„ã«å¤‰æ›´å¯èƒ½ã«ã™ã‚‹ãŸã‚ã“ã‚Œã¯å‰Šé™¤
+//	pnFuncList_Menu,	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */	//Oct. 21, 2000 JEPROã€Œãã®ä»–ã€ã‹ã‚‰åˆ†é›¢ç‹¬ç«‹åŒ–
+	pnFuncList_Win,	/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç³» */		//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List7â†’List_Win)
+	pnFuncList_Support,/* æ”¯æ´ */				//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List11â†’List_Support)
+	pnFuncList_Others	/* ãã®ä»– */			//Oct. 16, 2000 JEPRO å¤‰æ•°åå¤‰æ›´(List12â†’List_Others)
 };
 const int nsFuncCode::nFincListNumArrNum = _countof( nsFuncCode::pnFuncListNumArr );
 
 
 
 
-//! ‹@”\”Ô†‚É‰‚¶‚Äƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ•Ô‚·
+//! æ©Ÿèƒ½ç•ªå·ã«å¿œã˜ã¦ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’è¿”ã™
 /*!
 	@author Stonee
 	@date	2001/02/23
-	@param nFuncID ‹@”\”Ô†
-	@return ƒwƒ‹ƒvƒgƒsƒbƒN”Ô†BŠY“–ID‚ª–³‚¢ê‡‚É‚Í0‚ğ•Ô‚·B
+	@param nFuncID æ©Ÿèƒ½ç•ªå·
+	@return ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã€‚è©²å½“IDãŒç„¡ã„å ´åˆã«ã¯0ã‚’è¿”ã™ã€‚
 
-	“à—e‚Ícase•¶‚Ì—…—ñB
+	å†…å®¹ã¯caseæ–‡ã®ç¾…åˆ—ã€‚
 
 	@par history
-	2001.12.22 YAZAKI sakura.hh‚ğQÆ‚·‚é‚æ‚¤‚É•ÏX
+	2001.12.22 YAZAKI sakura.hhã‚’å‚ç…§ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
 */
 int FuncID_To_HelpContextID( EFunctionCode nFuncID )
 {
 	switch( nFuncID ){
 
-	/* ƒtƒ@ƒCƒ‹‘€ìŒn */
-	case F_FILENEW:				return HLP000025;			//V‹Kì¬
-	case F_FILENEW_NEWWINDOW:	return HLP000339;			//V‹KƒEƒCƒ“ƒhƒE‚ÅŠJ‚­
-	case F_FILEOPEN:			return HLP000015;			//ŠJ‚­
-	case F_FILEOPEN_DROPDOWN:	return HLP000015;			//ŠJ‚­(ƒhƒƒbƒvƒ_ƒEƒ“)	//@@@ 2002.06.15 MIK
-	case F_FILESAVE:			return HLP000020;			//ã‘‚«•Û‘¶
-	case F_FILESAVEAS_DIALOG:	return HLP000021;			//–¼‘O‚ğ•t‚¯‚Ä•Û‘¶
-	case F_FILESAVEALL:			return HLP000313;			//‚·‚×‚Äã‘‚«•Û‘¶	// 2006.10.05 ryoji
-	case F_FILESAVECLOSE:		return HLP000287;			//•Û‘¶‚µ‚Ä•Â‚¶‚é	// 2006.10.05 ryoji
-	case F_FILECLOSE:			return HLP000017;			//•Â‚¶‚Ä(–³‘è)	//Oct. 17, 2000 jepro uƒtƒ@ƒCƒ‹‚ğ•Â‚¶‚év‚Æ‚¢‚¤ƒLƒƒƒvƒVƒ‡ƒ“‚ğ•ÏX
-	case F_FILECLOSE_OPEN:		return HLP000119;			//•Â‚¶‚ÄŠJ‚­
-	case F_FILE_REOPEN:			return HLP000283;			//ŠJ‚«’¼‚·	//@@@ 2003.06.15 MIK
-	case F_FILE_REOPEN_SJIS:	return HLP000156;			//SJIS‚ÅŠJ‚«’¼‚·
-	case F_FILE_REOPEN_JIS:		return HLP000157;			//JIS‚ÅŠJ‚«’¼‚·
-	case F_FILE_REOPEN_EUC:		return HLP000158;			//EUC‚ÅŠJ‚«’¼‚·
-	case F_FILE_REOPEN_LATIN1:	return HLP000341;			//Latin1‚ÅŠJ‚«’¼‚·	// 2010/3/20 Uchi //2013.05.02 HLP000156->HLP000341
-	case F_FILE_REOPEN_UNICODE:	return HLP000159;			//Unicode‚ÅŠJ‚«’¼‚·
-	case F_FILE_REOPEN_UNICODEBE:	return HLP000256;		//UnicodeBE‚ÅŠJ‚«’¼‚·
-	case F_FILE_REOPEN_UTF8:	return HLP000160;			//UTF-8‚ÅŠJ‚«’¼‚·
-	case F_FILE_REOPEN_CESU8:	return HLP000337;			//CESU-8‚ÅŠJ‚«’¼‚·		HLP000163->	2010/5/5 Uchi
-	case F_FILE_REOPEN_UTF7:	return HLP000161;			//UTF-7‚ÅŠJ‚«’¼‚·
-	case F_PRINT:				return HLP000162;			//ˆóü				//Sept. 14, 2000 jepro uˆóü‚Ìƒy[ƒWƒŒƒCƒAƒEƒg‚Ìİ’èv‚©‚ç•ÏX
-	case F_PRINT_PREVIEW:		return HLP000120;			//ˆóüƒvƒŒƒrƒ…[
-	case F_PRINT_PAGESETUP:		return HLP000122;			//ˆóüƒy[ƒWİ’è	//Sept. 14, 2000 jepro uˆóü‚Ìƒy[ƒWƒŒƒCƒAƒEƒg‚Ìİ’èv‚©‚ç•ÏX
-	case F_OPEN_HfromtoC:		return HLP000192;			//“¯–¼‚ÌC/C++ƒwƒbƒ_(ƒ\[ƒX)‚ğŠJ‚­	//Feb. 7, 2001 JEPRO ’Ç‰Á
-//	case F_OPEN_HHPP:			return HLP000024;			//“¯–¼‚ÌC/C++ƒwƒbƒ_ƒtƒ@ƒCƒ‹‚ğŠJ‚­	//Feb. 9, 2001 jeprou.c‚Ü‚½‚Í.cpp‚Æ“¯–¼‚Ì.h‚ğŠJ‚­v‚©‚ç•ÏX		del 2008/6/23 Uchi
-//	case F_OPEN_CCPP:			return HLP000026;			//“¯–¼‚ÌC/C++ƒ\[ƒXƒtƒ@ƒCƒ‹‚ğŠJ‚­	//Feb. 9, 2001 jeprou.h‚Æ“¯–¼‚Ì.c(‚È‚¯‚ê‚Î.cpp)‚ğŠJ‚­v‚©‚ç•ÏX	del 2008/6/23 Uchi
-	case F_ACTIVATE_SQLPLUS:	return HLP000132;			/* Oracle SQL*Plus‚ğƒAƒNƒeƒBƒu•\¦ */
-	case F_PLSQL_COMPILE_ON_SQLPLUS:	return HLP000027;	/* Oracle SQL*Plus‚ÅÀs */
-	case F_BROWSE:				return HLP000121;			//ƒuƒ‰ƒEƒY
-	case F_VIEWMODE:			return HLP000249;			//ƒrƒ…[ƒ‚[ƒh
-	case F_PROPERTY_FILE:		return HLP000022;			/* ƒtƒ@ƒCƒ‹‚ÌƒvƒƒpƒeƒB */
-	case F_PROFILEMGR:			return HLP000363;			//ƒvƒƒtƒ@ƒCƒ‹ƒ}ƒl[ƒWƒƒ
+	/* ãƒ•ã‚¡ã‚¤ãƒ«æ“ä½œç³» */
+	case F_FILENEW:				return HLP000025;			//æ–°è¦ä½œæˆ
+	case F_FILENEW_NEWWINDOW:	return HLP000339;			//æ–°è¦ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã§é–‹ã
+	case F_FILEOPEN:			return HLP000015;			//é–‹ã
+	case F_FILEOPEN_DROPDOWN:	return HLP000015;			//é–‹ã(ãƒ‰ãƒ­ãƒƒãƒ—ãƒ€ã‚¦ãƒ³)	//@@@ 2002.06.15 MIK
+	case F_FILESAVE:			return HLP000020;			//ä¸Šæ›¸ãä¿å­˜
+	case F_FILESAVEAS_DIALOG:	return HLP000021;			//åå‰ã‚’ä»˜ã‘ã¦ä¿å­˜
+	case F_FILESAVEALL:			return HLP000313;			//ã™ã¹ã¦ä¸Šæ›¸ãä¿å­˜	// 2006.10.05 ryoji
+	case F_FILESAVECLOSE:		return HLP000287;			//ä¿å­˜ã—ã¦é–‰ã˜ã‚‹	// 2006.10.05 ryoji
+	case F_FILECLOSE:			return HLP000017;			//é–‰ã˜ã¦(ç„¡é¡Œ)	//Oct. 17, 2000 jepro ã€Œãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‰ã˜ã‚‹ã€ã¨ã„ã†ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³ã‚’å¤‰æ›´
+	case F_FILECLOSE_OPEN:		return HLP000119;			//é–‰ã˜ã¦é–‹ã
+	case F_FILE_REOPEN:			return HLP000283;			//é–‹ãç›´ã™	//@@@ 2003.06.15 MIK
+	case F_FILE_REOPEN_SJIS:	return HLP000156;			//SJISã§é–‹ãç›´ã™
+	case F_FILE_REOPEN_JIS:		return HLP000157;			//JISã§é–‹ãç›´ã™
+	case F_FILE_REOPEN_EUC:		return HLP000158;			//EUCã§é–‹ãç›´ã™
+	case F_FILE_REOPEN_LATIN1:	return HLP000341;			//Latin1ã§é–‹ãç›´ã™	// 2010/3/20 Uchi //2013.05.02 HLP000156->HLP000341
+	case F_FILE_REOPEN_UNICODE:	return HLP000159;			//Unicodeã§é–‹ãç›´ã™
+	case F_FILE_REOPEN_UNICODEBE:	return HLP000256;		//UnicodeBEã§é–‹ãç›´ã™
+	case F_FILE_REOPEN_UTF8:	return HLP000160;			//UTF-8ã§é–‹ãç›´ã™
+	case F_FILE_REOPEN_CESU8:	return HLP000337;			//CESU-8ã§é–‹ãç›´ã™		HLP000163->	2010/5/5 Uchi
+	case F_FILE_REOPEN_UTF7:	return HLP000161;			//UTF-7ã§é–‹ãç›´ã™
+	case F_PRINT:				return HLP000162;			//å°åˆ·				//Sept. 14, 2000 jepro ã€Œå°åˆ·ã®ãƒšãƒ¼ã‚¸ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã®è¨­å®šã€ã‹ã‚‰å¤‰æ›´
+	case F_PRINT_PREVIEW:		return HLP000120;			//å°åˆ·ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼
+	case F_PRINT_PAGESETUP:		return HLP000122;			//å°åˆ·ãƒšãƒ¼ã‚¸è¨­å®š	//Sept. 14, 2000 jepro ã€Œå°åˆ·ã®ãƒšãƒ¼ã‚¸ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã®è¨­å®šã€ã‹ã‚‰å¤‰æ›´
+	case F_OPEN_HfromtoC:		return HLP000192;			//åŒåã®C/C++ãƒ˜ãƒƒãƒ€(ã‚½ãƒ¼ã‚¹)ã‚’é–‹ã	//Feb. 7, 2001 JEPRO è¿½åŠ 
+//	case F_OPEN_HHPP:			return HLP000024;			//åŒåã®C/C++ãƒ˜ãƒƒãƒ€ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã	//Feb. 9, 2001 jeproã€Œ.cã¾ãŸã¯.cppã¨åŒåã®.hã‚’é–‹ãã€ã‹ã‚‰å¤‰æ›´		del 2008/6/23 Uchi
+//	case F_OPEN_CCPP:			return HLP000026;			//åŒåã®C/C++ã‚½ãƒ¼ã‚¹ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã	//Feb. 9, 2001 jeproã€Œ.hã¨åŒåã®.c(ãªã‘ã‚Œã°.cpp)ã‚’é–‹ãã€ã‹ã‚‰å¤‰æ›´	del 2008/6/23 Uchi
+	case F_ACTIVATE_SQLPLUS:	return HLP000132;			/* Oracle SQL*Plusã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–è¡¨ç¤º */
+	case F_PLSQL_COMPILE_ON_SQLPLUS:	return HLP000027;	/* Oracle SQL*Plusã§å®Ÿè¡Œ */
+	case F_BROWSE:				return HLP000121;			//ãƒ–ãƒ©ã‚¦ã‚º
+	case F_VIEWMODE:			return HLP000249;			//ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰
+	case F_PROPERTY_FILE:		return HLP000022;			/* ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ */
+	case F_PROFILEMGR:			return HLP000363;			//ãƒ—ãƒ­ãƒ•ã‚¡ã‚¤ãƒ«ãƒãƒãƒ¼ã‚¸ãƒ£
 
-	case F_EXITALLEDITORS:	return HLP000030;				//•ÒW‚Ì‘SI—¹	// 2007.02.13 ryoji ’Ç‰Á
-	case F_EXITALL:			return HLP000028;				//ƒTƒNƒ‰ƒGƒfƒBƒ^‚Ì‘SI—¹	//Dec. 26, 2000 JEPRO F_‚É•ÏX
-
-
-	/* •ÒWŒn */
-	case F_UNDO:						return HLP000032;	//Œ³‚É–ß‚·(Undo)
-	case F_REDO:						return HLP000033;	//‚â‚è’¼‚µ(Redo)
-	case F_DELETE:						return HLP000041;	//íœ
-	case F_DELETE_BACK:					return HLP000042;	//ƒJ[ƒ\ƒ‹‘O‚ğíœ
-	case F_WordDeleteToStart:			return HLP000166;	//’PŒê‚Ì¶’[‚Ü‚Åíœ
-	case F_WordDeleteToEnd:				return HLP000167;	//’PŒê‚Ì‰E’[‚Ü‚Åíœ
-	case F_WordCut:						return HLP000169;	//’PŒêØ‚èæ‚è
-	case F_WordDelete:					return HLP000168;	//’PŒêíœ
-	case F_LineCutToStart:				return HLP000172;	//s“ª‚Ü‚ÅØ‚èæ‚è(‰üs’PˆÊ)
-	case F_LineCutToEnd:				return HLP000173;	//s––‚Ü‚ÅØ‚èæ‚è(‰üs’PˆÊ)
-	case F_LineDeleteToStart:			return HLP000170;	//s“ª‚Ü‚Åíœ(‰üs’PˆÊ)
-	case F_LineDeleteToEnd:				return HLP000171;	//s––‚Ü‚Åíœ(‰üs’PˆÊ)
-	case F_CUT_LINE:					return HLP000174;	//sØ‚èæ‚è(Ü‚è•Ô‚µ’PˆÊ)
-	case F_DELETE_LINE:					return HLP000137;	//síœ(Ü‚è•Ô‚µ’PˆÊ)
-	case F_DUPLICATELINE:				return HLP000043;	//s‚Ì“ñd‰»(Ü‚è•Ô‚µ’PˆÊ)
-	case F_INDENT_TAB:					return HLP000113;	//TABƒCƒ“ƒfƒ“ƒg
-	case F_UNINDENT_TAB:				return HLP000113;	//‹tTABƒCƒ“ƒfƒ“ƒg
-	case F_INDENT_SPACE:				return HLP000114;	//SPACEƒCƒ“ƒfƒ“ƒg
-	case F_UNINDENT_SPACE:				return HLP000114;	//‹tSPACEƒCƒ“ƒfƒ“ƒg
-	case F_RECONVERT:					return HLP000218;	//Ä•ÏŠ·
-//	case ORDSREFERENCE:					return ;	//’PŒêƒŠƒtƒ@ƒŒƒ“ƒX
+	case F_EXITALLEDITORS:	return HLP000030;				//ç·¨é›†ã®å…¨çµ‚äº†	// 2007.02.13 ryoji è¿½åŠ 
+	case F_EXITALL:			return HLP000028;				//ã‚µã‚¯ãƒ©ã‚¨ãƒ‡ã‚£ã‚¿ã®å…¨çµ‚äº†	//Dec. 26, 2000 JEPRO F_ã«å¤‰æ›´
 
 
-	/* ƒJ[ƒ\ƒ‹ˆÚ“®Œn */
-	case F_UP:				return HLP000289;	//ƒJ[ƒ\ƒ‹ãˆÚ“®	// 2006.10.11 ryoji
-	case F_DOWN:			return HLP000289;	//ƒJ[ƒ\ƒ‹‰ºˆÚ“®	// 2006.10.11 ryoji
-	case F_LEFT:			return HLP000289;	//ƒJ[ƒ\ƒ‹¶ˆÚ“®	// 2006.10.11 ryoji
-	case F_RIGHT:			return HLP000289;	//ƒJ[ƒ\ƒ‹‰EˆÚ“®	// 2006.10.11 ryoji
-	case F_UP2:				return HLP000220;	//ƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)
-	case F_DOWN2:			return HLP000221;	//ƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)
-	case F_WORDLEFT:		return HLP000222;	//’PŒê‚Ì¶’[‚ÉˆÚ“®
-	case F_WORDRIGHT:		return HLP000223;	//’PŒê‚Ì‰E’[‚ÉˆÚ“®
-	case F_GOLINETOP:		return HLP000224;	//s“ª‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-	case F_GOLINEEND:		return HLP000225;	//s––‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-//	case F_ROLLDOWN:		return ;	//ƒXƒNƒ[ƒ‹ƒ_ƒEƒ“
-//	case F_ROLLUP:			return ;	//ƒXƒNƒ[ƒ‹ƒAƒbƒv
-	case F_HalfPageUp:		return HLP000245;	//”¼ƒy[ƒWƒAƒbƒv	//Oct. 17, 2000 JEPRO ˆÈ‰ºu‚Pƒy[ƒWƒ_ƒEƒ“v‚Ü‚Å’Ç‰Á
-	case F_HalfPageDown:	return HLP000246;	//”¼ƒy[ƒWƒ_ƒEƒ“
-	case F_1PageUp:			return HLP000226;	//‚Pƒy[ƒWƒAƒbƒv
-	case F_1PageDown:		return HLP000227;	//‚Pƒy[ƒWƒ_ƒEƒ“
-	case F_GOFILETOP:		return HLP000228;	//ƒtƒ@ƒCƒ‹‚Ìæ“ª‚ÉˆÚ“®
-	case F_GOFILEEND:		return HLP000229;	//ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®
-	case F_CURLINECENTER:	return HLP000230;	//ƒJ[ƒ\ƒ‹s‚ğƒEƒBƒ“ƒhƒE’†‰›‚Ö
-	case F_JUMP_SRCHSTARTPOS:	return HLP000264; //ŒŸõŠJnˆÊ’u‚Ö–ß‚é
-	case F_JUMPHIST_PREV:		return HLP000231;	//ˆÚ“®—š—ğ: ‘O‚Ö	//Oct. 17, 2000 JEPRO ˆÈ‰ºuˆÚ“®—š—ğ:Ÿ‚Öv‚Ü‚Å’Ç‰Á
-	case F_JUMPHIST_NEXT:		return HLP000232;	//ˆÚ“®—š—ğ: Ÿ‚Ö
-	case F_JUMPHIST_SET:	return HLP000265;	//Œ»İˆÊ’u‚ğˆÚ“®—š—ğ‚É“o˜^
-	case F_WndScrollDown:	return HLP000198;	//ƒeƒLƒXƒg‚ğ‚Ps‰º‚ÖƒXƒNƒ[ƒ‹	//Jul. 05, 2001 JEPRO ’Ç‰Á
-	case F_WndScrollUp:		return HLP000199;	//ƒeƒLƒXƒg‚ğ‚Psã‚ÖƒXƒNƒ[ƒ‹	//Jul. 05, 2001 JEPRO ’Ç‰Á
-	case F_GONEXTPARAGRAPH:	return HLP000262;	//‘O‚Ì’i—‚ÖˆÚ“®
-	case F_GOPREVPARAGRAPH:	return HLP000263;	//‘O‚Ì’i—‚ÖˆÚ“®
-	case F_AUTOSCROLL:		return HLP000296;	//ƒI[ƒgƒXƒNƒ[ƒ‹
-	case F_SETFONTSIZEUP:	return HLP000359;	//ƒtƒHƒ“ƒgƒTƒCƒYŠg‘å
-	case F_SETFONTSIZEDOWN:	return HLP000360;	//ƒtƒHƒ“ƒgƒTƒCƒYk¬
-	case F_MODIFYLINE_NEXT:	return HLP000366;	//Ÿ‚Ì•ÏXs‚ÖˆÚ“®
-	case F_MODIFYLINE_PREV:	return HLP000367;	//‘O‚Ì•ÏXs‚ÖˆÚ“®
-
-	/* ‘I‘ğŒn */	//Oct. 15, 2000 JEPRO uƒJ[ƒ\ƒ‹ˆÚ“®Œnv‚©‚ç(‘I‘ğ)‚ğˆÚ“®
-	case F_SELECTWORD:		return HLP000045;	//Œ»İˆÊ’u‚Ì’PŒê‘I‘ğ
-	case F_SELECTALL:		return HLP000044;	//‚·‚×‚Ä‘I‘ğ
-	case F_SELECTLINE:		return HLP000108;	//1s‘I‘ğ	// 2007.10.06 nasukoji 2013.05.03 Moca
-	case F_BEGIN_SEL:		return HLP000233;	//”ÍˆÍ‘I‘ğŠJn
-	case F_UP_SEL:			return HLP000290;	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹ãˆÚ“®	// 2006.10.11 ryoji
-	case F_DOWN_SEL:		return HLP000290;	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹‰ºˆÚ“®	// 2006.10.11 ryoji
-	case F_LEFT_SEL:		return HLP000290;	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹¶ˆÚ“®	// 2006.10.11 ryoji
-	case F_RIGHT_SEL:		return HLP000290;	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹‰EˆÚ“®	// 2006.10.11 ryoji
-	case F_UP2_SEL:			return HLP000234;	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)
-	case F_DOWN2_SEL:		return HLP000235;	//(”ÍˆÍ‘I‘ğ)ƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)
-	case F_WORDLEFT_SEL:	return HLP000236;	//(”ÍˆÍ‘I‘ğ)’PŒê‚Ì¶’[‚ÉˆÚ“®
-	case F_WORDRIGHT_SEL:	return HLP000237;	//(”ÍˆÍ‘I‘ğ)’PŒê‚Ì‰E’[‚ÉˆÚ“®
-	case F_GONEXTPARAGRAPH_SEL:	return HLP000273;	//(”ÍˆÍ‘I‘ğ)‘O‚Ì’i—‚ÖˆÚ“®	//@@@ 2003.06.15 MIK
-	case F_GOPREVPARAGRAPH_SEL:	return HLP000274;	//(”ÍˆÍ‘I‘ğ)‘O‚Ì’i—‚ÖˆÚ“®	//@@@ 2003.06.15 MIK
-	case F_GOLINETOP_SEL:	return HLP000238;	//(”ÍˆÍ‘I‘ğ)s“ª‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-	case F_GOLINEEND_SEL:	return HLP000239;	//(”ÍˆÍ‘I‘ğ)s––‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-//	case F_ROLLDOWN_SEL:	return ;	//(”ÍˆÍ‘I‘ğ)ƒXƒNƒ[ƒ‹ƒ_ƒEƒ“
-//	case F_ROLLUP_SEL:		return ;	//(”ÍˆÍ‘I‘ğ)ƒXƒNƒ[ƒ‹ƒAƒbƒv
-	case F_HalfPageUp_Sel:	return HLP000247;	//(”ÍˆÍ‘I‘ğ)”¼ƒy[ƒWƒAƒbƒv		//Oct. 17, 2000 JEPRO ˆÈ‰ºu‚Pƒy[ƒWƒ_ƒEƒ“v‚Ü‚Å’Ç‰Á
-	case F_HalfPageDown_Sel:return HLP000248;	//(”ÍˆÍ‘I‘ğ)”¼ƒy[ƒWƒ_ƒEƒ“
-	case F_1PageUp_Sel:		return HLP000240;	//(”ÍˆÍ‘I‘ğ)‚Pƒy[ƒWƒAƒbƒv
-	case F_1PageDown_Sel:	return HLP000241;	//(”ÍˆÍ‘I‘ğ)‚Pƒy[ƒWƒ_ƒEƒ“
-	case F_GOFILETOP_SEL:	return HLP000242;	//(”ÍˆÍ‘I‘ğ)ƒtƒ@ƒCƒ‹‚Ìæ“ª‚ÉˆÚ“®
-	case F_GOFILEEND_SEL:	return HLP000243;	//(”ÍˆÍ‘I‘ğ)ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®
-	case F_MODIFYLINE_NEXT_SEL:	return HLP000369;	//(”ÍˆÍ‘I‘ğ)Ÿ‚Ì•ÏXs‚ÖˆÚ“®
-	case F_MODIFYLINE_PREV_SEL:	return HLP000370;	//(”ÍˆÍ‘I‘ğ)‘O‚Ì•ÏXs‚ÖˆÚ“®
+	/* ç·¨é›†ç³» */
+	case F_UNDO:						return HLP000032;	//å…ƒã«æˆ»ã™(Undo)
+	case F_REDO:						return HLP000033;	//ã‚„ã‚Šç›´ã—(Redo)
+	case F_DELETE:						return HLP000041;	//å‰Šé™¤
+	case F_DELETE_BACK:					return HLP000042;	//ã‚«ãƒ¼ã‚½ãƒ«å‰ã‚’å‰Šé™¤
+	case F_WordDeleteToStart:			return HLP000166;	//å˜èªã®å·¦ç«¯ã¾ã§å‰Šé™¤
+	case F_WordDeleteToEnd:				return HLP000167;	//å˜èªã®å³ç«¯ã¾ã§å‰Šé™¤
+	case F_WordCut:						return HLP000169;	//å˜èªåˆ‡ã‚Šå–ã‚Š
+	case F_WordDelete:					return HLP000168;	//å˜èªå‰Šé™¤
+	case F_LineCutToStart:				return HLP000172;	//è¡Œé ­ã¾ã§åˆ‡ã‚Šå–ã‚Š(æ”¹è¡Œå˜ä½)
+	case F_LineCutToEnd:				return HLP000173;	//è¡Œæœ«ã¾ã§åˆ‡ã‚Šå–ã‚Š(æ”¹è¡Œå˜ä½)
+	case F_LineDeleteToStart:			return HLP000170;	//è¡Œé ­ã¾ã§å‰Šé™¤(æ”¹è¡Œå˜ä½)
+	case F_LineDeleteToEnd:				return HLP000171;	//è¡Œæœ«ã¾ã§å‰Šé™¤(æ”¹è¡Œå˜ä½)
+	case F_CUT_LINE:					return HLP000174;	//è¡Œåˆ‡ã‚Šå–ã‚Š(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	case F_DELETE_LINE:					return HLP000137;	//è¡Œå‰Šé™¤(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	case F_DUPLICATELINE:				return HLP000043;	//è¡Œã®äºŒé‡åŒ–(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	case F_INDENT_TAB:					return HLP000113;	//TABã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
+	case F_UNINDENT_TAB:				return HLP000113;	//é€†TABã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
+	case F_INDENT_SPACE:				return HLP000114;	//SPACEã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
+	case F_UNINDENT_SPACE:				return HLP000114;	//é€†SPACEã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
+	case F_RECONVERT:					return HLP000218;	//å†å¤‰æ›
+//	case ORDSREFERENCE:					return ;	//å˜èªãƒªãƒ•ã‚¡ãƒ¬ãƒ³ã‚¹
 
 
-	/* ‹éŒ`‘I‘ğŒn */	//Oct. 17, 2000 JEPRO (‹éŒ`‘I‘ğ)‚ªVİ‚³‚êŸ‘æ‚±‚±‚É‚¨‚­
-//	case F_BOXSELALL:		return ;	//‹éŒ`‚Å‚·‚×‚Ä‘I‘ğ
-	case F_BEGIN_BOX:		return HLP000244;	//‹éŒ`”ÍˆÍ‘I‘ğŠJn
-	case F_UP_BOX:			return HLP000299;	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹ãˆÚ“®	//Oct. 17, 2000 JEPRO ˆÈ‰ºuƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®v‚Ü‚Å’Ç‰Á
-	case F_DOWN_BOX:		return HLP000299;	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹‰ºˆÚ“®
-	case F_LEFT_BOX:		return HLP000299;	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹¶ˆÚ“®
-	case F_RIGHT_BOX:		return HLP000299;	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹‰EˆÚ“®
-	case F_UP2_BOX:			return HLP000344;	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹ãˆÚ“®(‚Qs‚²‚Æ)
-	case F_DOWN2_BOX:		return HLP000345;	//(‹éŒ`‘I‘ğ)ƒJ[ƒ\ƒ‹‰ºˆÚ“®(‚Qs‚²‚Æ)
-	case F_WORDLEFT_BOX:	return HLP000346;	//(‹éŒ`‘I‘ğ)’PŒê‚Ì¶’[‚ÉˆÚ“®
-	case F_WORDRIGHT_BOX:	return HLP000347;	//(‹éŒ`‘I‘ğ)’PŒê‚Ì‰E’[‚ÉˆÚ“®
-	case F_GOLINETOP_BOX:	return HLP000350;	//(‹éŒ`‘I‘ğ)s“ª‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-	case F_GOLOGICALLINETOP_BOX:	return HLP000361;	//(‹éŒ`‘I‘ğ)s“ª‚ÉˆÚ“®(‰üs’PˆÊ)
-	case F_GOLINEEND_BOX:	return HLP000351;	//(‹éŒ`‘I‘ğ)s––‚ÉˆÚ“®(Ü‚è•Ô‚µ’PˆÊ)
-	case F_HalfPageUp_BOX:	return HLP000356;	//(‹éŒ`‘I‘ğ)”¼ƒy[ƒWƒAƒbƒv
-	case F_HalfPageDown_BOX:return HLP000357;	//(‹éŒ`‘I‘ğ)”¼ƒy[ƒWƒ_ƒEƒ“
-	case F_1PageUp_BOX:		return HLP000352;	//(‹éŒ`‘I‘ğ)‚Pƒy[ƒWƒAƒbƒv
-	case F_1PageDown_BOX:	return HLP000353;	//(‹éŒ`‘I‘ğ)‚Pƒy[ƒWƒ_ƒEƒ“
-	case F_GOFILETOP_BOX:	return HLP000354;	//(‹éŒ`‘I‘ğ)ƒtƒ@ƒCƒ‹‚Ìæ“ª‚ÉˆÚ“®
-	case F_GOFILEEND_BOX:	return HLP000355;	//(‹éŒ`‘I‘ğ)ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“®
-//	case F_GONEXTPARAGRAPH_BOX:	return HLP000348;	//(”ÍˆÍ‘I‘ğ)Ÿ‚Ì’i—‚Ö
-//	case F_GOPREVPARAGRAPH_BOX:	return HLP000349;	//(”ÍˆÍ‘I‘ğ)‘O‚Ì’i—‚Ö
+	/* ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³» */
+	case F_UP:				return HLP000289;	//ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•	// 2006.10.11 ryoji
+	case F_DOWN:			return HLP000289;	//ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•	// 2006.10.11 ryoji
+	case F_LEFT:			return HLP000289;	//ã‚«ãƒ¼ã‚½ãƒ«å·¦ç§»å‹•	// 2006.10.11 ryoji
+	case F_RIGHT:			return HLP000289;	//ã‚«ãƒ¼ã‚½ãƒ«å³ç§»å‹•	// 2006.10.11 ryoji
+	case F_UP2:				return HLP000220;	//ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)
+	case F_DOWN2:			return HLP000221;	//ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)
+	case F_WORDLEFT:		return HLP000222;	//å˜èªã®å·¦ç«¯ã«ç§»å‹•
+	case F_WORDRIGHT:		return HLP000223;	//å˜èªã®å³ç«¯ã«ç§»å‹•
+	case F_GOLINETOP:		return HLP000224;	//è¡Œé ­ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	case F_GOLINEEND:		return HLP000225;	//è¡Œæœ«ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+//	case F_ROLLDOWN:		return ;	//ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ€ã‚¦ãƒ³
+//	case F_ROLLUP:			return ;	//ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚¢ãƒƒãƒ—
+	case F_HalfPageUp:		return HLP000245;	//åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—	//Oct. 17, 2000 JEPRO ä»¥ä¸‹ã€Œï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã€ã¾ã§è¿½åŠ 
+	case F_HalfPageDown:	return HLP000246;	//åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³
+	case F_1PageUp:			return HLP000226;	//ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—
+	case F_1PageDown:		return HLP000227;	//ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³
+	case F_GOFILETOP:		return HLP000228;	//ãƒ•ã‚¡ã‚¤ãƒ«ã®å…ˆé ­ã«ç§»å‹•
+	case F_GOFILEEND:		return HLP000229;	//ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•
+	case F_CURLINECENTER:	return HLP000230;	//ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸­å¤®ã¸
+	case F_JUMP_SRCHSTARTPOS:	return HLP000264; //æ¤œç´¢é–‹å§‹ä½ç½®ã¸æˆ»ã‚‹
+	case F_JUMPHIST_PREV:		return HLP000231;	//ç§»å‹•å±¥æ­´: å‰ã¸	//Oct. 17, 2000 JEPRO ä»¥ä¸‹ã€Œç§»å‹•å±¥æ­´:æ¬¡ã¸ã€ã¾ã§è¿½åŠ 
+	case F_JUMPHIST_NEXT:		return HLP000232;	//ç§»å‹•å±¥æ­´: æ¬¡ã¸
+	case F_JUMPHIST_SET:	return HLP000265;	//ç¾åœ¨ä½ç½®ã‚’ç§»å‹•å±¥æ­´ã«ç™»éŒ²
+	case F_WndScrollDown:	return HLP000198;	//ãƒ†ã‚­ã‚¹ãƒˆã‚’ï¼‘è¡Œä¸‹ã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«	//Jul. 05, 2001 JEPRO è¿½åŠ 
+	case F_WndScrollUp:		return HLP000199;	//ãƒ†ã‚­ã‚¹ãƒˆã‚’ï¼‘è¡Œä¸Šã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«	//Jul. 05, 2001 JEPRO è¿½åŠ 
+	case F_GONEXTPARAGRAPH:	return HLP000262;	//å‰ã®æ®µè½ã¸ç§»å‹•
+	case F_GOPREVPARAGRAPH:	return HLP000263;	//å‰ã®æ®µè½ã¸ç§»å‹•
+	case F_AUTOSCROLL:		return HLP000296;	//ã‚ªãƒ¼ãƒˆã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
+	case F_SETFONTSIZEUP:	return HLP000359;	//ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºæ‹¡å¤§
+	case F_SETFONTSIZEDOWN:	return HLP000360;	//ãƒ•ã‚©ãƒ³ãƒˆã‚µã‚¤ã‚ºç¸®å°
+	case F_MODIFYLINE_NEXT:	return HLP000366;	//æ¬¡ã®å¤‰æ›´è¡Œã¸ç§»å‹•
+	case F_MODIFYLINE_PREV:	return HLP000367;	//å‰ã®å¤‰æ›´è¡Œã¸ç§»å‹•
 
-	/* ®Œ`Œn 2002/04/17 YAZAKI */
-	case F_LTRIM:		return HLP000210;	//¶(æ“ª)‚Ì‹ó”’‚ğíœ
-	case F_RTRIM:		return HLP000211;	//‰E(––”ö)‚Ì‹ó”’‚ğíœ
-	case F_SORT_ASC:	return HLP000212;	//‘I‘ğs‚Ì¸‡ƒ\[ƒg
-	case F_SORT_DESC:	return HLP000213;	//‘I‘ğs‚Ì~‡ƒ\[ƒg
-	case F_MERGE:		return HLP000214;	//‘I‘ğs‚Ìƒ}[ƒW
-
-	/* ƒNƒŠƒbƒvƒ{[ƒhŒn */
-	case F_CUT:				return HLP000034;			//Ø‚èæ‚è(‘I‘ğ”ÍˆÍ‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[‚µ‚Äíœ)
-	case F_COPY:			return HLP000035;			//ƒRƒs[(‘I‘ğ”ÍˆÍ‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[)
-	case F_COPY_ADDCRLF:	return HLP000219;			//Ü‚è•Ô‚µˆÊ’u‚É‰üs‚ğ‚Â‚¯‚ÄƒRƒs[(‘I‘ğ”ÍˆÍ‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[)
-	case F_COPY_CRLF:		return HLP000163;			//CRLF‰üs‚ÅƒRƒs[(‘I‘ğ”ÍˆÍ‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[)	//Feb. 23, 2001 JEPRO ”²‚¯‚Ä‚¢‚½‚Ì‚Å’Ç‰Á
-	case F_PASTE:			return HLP000039;			//“\‚è•t‚¯(ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯)
-	case F_PASTEBOX:		return HLP000040;			//‹éŒ`“\‚è•t‚¯(ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç‹éŒ`“\‚è•t‚¯)
-//	case F_INSTEXT_W:		return ;					// ƒeƒLƒXƒg‚ğ“\‚è•t‚¯
-	case F_COPYLINES:				return HLP000036;	//‘I‘ğ”ÍˆÍ“à‘SsƒRƒs[
-	case F_COPYLINESASPASSAGE:		return HLP000037;	//‘I‘ğ”ÍˆÍ“à‘Ssˆø—p•„•t‚«ƒRƒs[
-	case F_COPYLINESWITHLINENUMBER:	return HLP000038;	//‘I‘ğ”ÍˆÍ“à‘Sss”Ô†•t‚«ƒRƒs[
-	case F_COPY_COLOR_HTML:			return HLP000342;	//‘I‘ğ”ÍˆÍ“àF•t‚«HTMLƒRƒs[
-	case F_COPY_COLOR_HTML_LINENUMBER:	return HLP000343;	//‘I‘ğ”ÍˆÍ“às”Ô†F•t‚«HTMLƒRƒs[
-	case F_COPYPATH:		return HLP000056;			//‚±‚Ìƒtƒ@ƒCƒ‹‚ÌƒpƒX–¼‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[
-	case F_COPYTAG:			return HLP000175;			//‚±‚Ìƒtƒ@ƒCƒ‹‚ÌƒpƒX–¼‚ÆƒJ[ƒ\ƒ‹ˆÊ’u‚ğƒRƒs[	//Oct. 17, 2000 JEPRO ’Ç‰Á
-	case F_COPYFNAME:		return HLP000303;			//‚±‚Ìƒtƒ@ƒCƒ‹–¼‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[ // 2002/2/3 aroka
-//	case IDM_TEST_CREATEKEYBINDLIST:	return 57;	//ƒL[Š„‚è“–‚Äˆê——‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÖƒRƒs[	//Sept. 15, 2000 jeprouƒŠƒXƒgv‚ğuˆê——v‚É•ÏX
-	case F_CREATEKEYBINDLIST:		return HLP000057;	//ƒL[Š„‚è“–‚Äˆê——‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÖƒRƒs[	//Sept. 15, 2000 JEPRO uƒŠƒXƒgv‚ğuˆê——v‚É•ÏXAIDMQTEST‚ğF‚É•ÏX‚µ‚½‚ª‚¤‚Ü‚­‚¢‚©‚È‚¢‚Ì‚ÅE‚µ‚Ä‚ ‚é	//Dec. 25, 2000 •œŠˆ
-
-
-	/* ‘}“üŒn */
-	case F_INS_DATE:				return HLP000164;	// “ú•t‘}“ü
-	case F_INS_TIME:				return HLP000165;	// ‘}“ü
-	case F_CTRL_CODE_DIALOG:		return HLP000255;	/* ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh“ü—Í */
-
-
-	/* •ÏŠ·Œn */
-	case F_TOLOWER:					return HLP000047;	//¬•¶š
-	case F_TOUPPER:					return HLP000048;	//‘å•¶š
-	case F_TOHANKAKU:				return HLP000049;	/* ‘SŠp¨”¼Šp */
-	case F_TOHANKATA:				return HLP000258;	//‘SŠpƒJƒ^ƒJƒi¨”¼ŠpƒJƒ^ƒJƒi
-	case F_TOZENKAKUKATA:			return HLP000050;	/* ”¼Šp{‘S‚Ğ‚ç¨‘SŠpEƒJƒ^ƒJƒi */	//Sept. 17, 2000 jepro à–¾‚ğu”¼Šp¨‘SŠpƒJƒ^ƒJƒiv‚©‚ç•ÏX
-	case F_TOZENKAKUHIRA:			return HLP000051;	/* ”¼Šp{‘SƒJƒ^¨‘SŠpE‚Ğ‚ç‚ª‚È */	//Sept. 17, 2000 jepro à–¾‚ğu”¼Šp¨‘SŠp‚Ğ‚ç‚ª‚Èv‚©‚ç•ÏX
-	case F_HANKATATOZENKATA:	return HLP000123;	/* ”¼ŠpƒJƒ^ƒJƒi¨‘SŠpƒJƒ^ƒJƒi */
-	case F_HANKATATOZENHIRA:	return HLP000124;	/* ”¼ŠpƒJƒ^ƒJƒi¨‘SŠp‚Ğ‚ç‚ª‚È */
-	case F_TOZENEI:					return HLP000200;	/* ”¼Šp‰p”¨‘SŠp‰p” */			//July. 30, 2001 Misaka //Stonee, 2001/09/26 ”Ô†C³
-	case F_TOHANEI:					return HLP000215;	/* ‘SŠp‰p”¨”¼Šp‰p” */			//@@@ 2002.2.11 YAZAKI
-	case F_TABTOSPACE:				return HLP000182;	/* TAB¨‹ó”’ */
-	case F_SPACETOTAB:				return HLP000196;	/* ‹ó”’¨TAB */	//---- Stonee, 2001/05/27	//Jul. 03, 2001 JEPRO ”Ô†C³
-	case F_CODECNV_AUTO2SJIS:		return HLP000178;	/* ©“®”»•Ê¨SJISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_EMAIL:			return HLP000052;	//E-Mail(JIS¨SJIS)ƒR[ƒh•ÏŠ·
-	case F_CODECNV_EUC2SJIS:		return HLP000053;	//EUC¨SJISƒR[ƒh•ÏŠ·
-	case F_CODECNV_UNICODE2SJIS:	return HLP000179;	//Unicode¨SJISƒR[ƒh•ÏŠ·
-	case F_CODECNV_UNICODEBE2SJIS:	return HLP000257;	//UnicodeBE¨SJISƒR[ƒh•ÏŠ·
-	case F_CODECNV_UTF82SJIS:		return HLP000142;	/* UTF-8¨SJISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_UTF72SJIS:		return HLP000143; /* UTF-7¨SJISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_SJIS2JIS:		return HLP000117;	/* SJIS¨JISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_SJIS2EUC:		return HLP000118;	/* SJIS¨EUCƒR[ƒh•ÏŠ· */
-	case F_CODECNV_SJIS2UTF8:		return HLP000180;	/* SJIS¨UTF-8ƒR[ƒh•ÏŠ· */
-	case F_CODECNV_SJIS2UTF7:		return HLP000181;	/* SJIS¨UTF-7ƒR[ƒh•ÏŠ· */
-	case F_BASE64DECODE:			return HLP000054;	//Base64ƒfƒR[ƒh‚µ‚Ä•Û‘¶
-	case F_UUDECODE:				return HLP000055;	//uudecode‚µ‚Ä•Û‘¶	//Oct. 17, 2000 jepro à–¾‚ğu‘I‘ğ•”•ª‚ğUUENCODEƒfƒR[ƒhv‚©‚ç•ÏX
+	/* é¸æŠç³» */	//Oct. 15, 2000 JEPRO ã€Œã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ç³»ã€ã‹ã‚‰(é¸æŠ)ã‚’ç§»å‹•
+	case F_SELECTWORD:		return HLP000045;	//ç¾åœ¨ä½ç½®ã®å˜èªé¸æŠ
+	case F_SELECTALL:		return HLP000044;	//ã™ã¹ã¦é¸æŠ
+	case F_SELECTLINE:		return HLP000108;	//1è¡Œé¸æŠ	// 2007.10.06 nasukoji 2013.05.03 Moca
+	case F_BEGIN_SEL:		return HLP000233;	//ç¯„å›²é¸æŠé–‹å§‹
+	case F_UP_SEL:			return HLP000290;	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•	// 2006.10.11 ryoji
+	case F_DOWN_SEL:		return HLP000290;	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•	// 2006.10.11 ryoji
+	case F_LEFT_SEL:		return HLP000290;	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«å·¦ç§»å‹•	// 2006.10.11 ryoji
+	case F_RIGHT_SEL:		return HLP000290;	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«å³ç§»å‹•	// 2006.10.11 ryoji
+	case F_UP2_SEL:			return HLP000234;	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)
+	case F_DOWN2_SEL:		return HLP000235;	//(ç¯„å›²é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)
+	case F_WORDLEFT_SEL:	return HLP000236;	//(ç¯„å›²é¸æŠ)å˜èªã®å·¦ç«¯ã«ç§»å‹•
+	case F_WORDRIGHT_SEL:	return HLP000237;	//(ç¯„å›²é¸æŠ)å˜èªã®å³ç«¯ã«ç§»å‹•
+	case F_GONEXTPARAGRAPH_SEL:	return HLP000273;	//(ç¯„å›²é¸æŠ)å‰ã®æ®µè½ã¸ç§»å‹•	//@@@ 2003.06.15 MIK
+	case F_GOPREVPARAGRAPH_SEL:	return HLP000274;	//(ç¯„å›²é¸æŠ)å‰ã®æ®µè½ã¸ç§»å‹•	//@@@ 2003.06.15 MIK
+	case F_GOLINETOP_SEL:	return HLP000238;	//(ç¯„å›²é¸æŠ)è¡Œé ­ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	case F_GOLINEEND_SEL:	return HLP000239;	//(ç¯„å›²é¸æŠ)è¡Œæœ«ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+//	case F_ROLLDOWN_SEL:	return ;	//(ç¯„å›²é¸æŠ)ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ€ã‚¦ãƒ³
+//	case F_ROLLUP_SEL:		return ;	//(ç¯„å›²é¸æŠ)ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚¢ãƒƒãƒ—
+	case F_HalfPageUp_Sel:	return HLP000247;	//(ç¯„å›²é¸æŠ)åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—		//Oct. 17, 2000 JEPRO ä»¥ä¸‹ã€Œï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³ã€ã¾ã§è¿½åŠ 
+	case F_HalfPageDown_Sel:return HLP000248;	//(ç¯„å›²é¸æŠ)åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³
+	case F_1PageUp_Sel:		return HLP000240;	//(ç¯„å›²é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—
+	case F_1PageDown_Sel:	return HLP000241;	//(ç¯„å›²é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³
+	case F_GOFILETOP_SEL:	return HLP000242;	//(ç¯„å›²é¸æŠ)ãƒ•ã‚¡ã‚¤ãƒ«ã®å…ˆé ­ã«ç§»å‹•
+	case F_GOFILEEND_SEL:	return HLP000243;	//(ç¯„å›²é¸æŠ)ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•
+	case F_MODIFYLINE_NEXT_SEL:	return HLP000369;	//(ç¯„å›²é¸æŠ)æ¬¡ã®å¤‰æ›´è¡Œã¸ç§»å‹•
+	case F_MODIFYLINE_PREV_SEL:	return HLP000370;	//(ç¯„å›²é¸æŠ)å‰ã®å¤‰æ›´è¡Œã¸ç§»å‹•
 
 
-	/* ŒŸõŒn */
-	case F_SEARCH_DIALOG:		return HLP000059;	//ŒŸõ(’PŒêŒŸõƒ_ƒCƒAƒƒO)
-	case F_SEARCH_BOX:			return HLP000059;	//ŒŸõ(ƒ{ƒbƒNƒX) Jan. 13, 2003 MIK
-	case F_SEARCH_NEXT:			return HLP000061;	//Ÿ‚ğŒŸõ
-	case F_SEARCH_PREV:			return HLP000060;	//‘O‚ğŒŸõ
-	case F_REPLACE_DIALOG:		return HLP000062;	//’uŠ·(’uŠ·ƒ_ƒCƒAƒƒO)
-	case F_SEARCH_CLEARMARK:	return HLP000136;	//ŒŸõƒ}[ƒN‚ÌƒNƒŠƒA
+	/* çŸ©å½¢é¸æŠç³» */	//Oct. 17, 2000 JEPRO (çŸ©å½¢é¸æŠ)ãŒæ–°è¨­ã•ã‚Œæ¬¡ç¬¬ã“ã“ã«ãŠã
+//	case F_BOXSELALL:		return ;	//çŸ©å½¢ã§ã™ã¹ã¦é¸æŠ
+	case F_BEGIN_BOX:		return HLP000244;	//çŸ©å½¢ç¯„å›²é¸æŠé–‹å§‹
+	case F_UP_BOX:			return HLP000299;	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•	//Oct. 17, 2000 JEPRO ä»¥ä¸‹ã€Œãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•ã€ã¾ã§è¿½åŠ 
+	case F_DOWN_BOX:		return HLP000299;	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•
+	case F_LEFT_BOX:		return HLP000299;	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«å·¦ç§»å‹•
+	case F_RIGHT_BOX:		return HLP000299;	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«å³ç§»å‹•
+	case F_UP2_BOX:			return HLP000344;	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸Šç§»å‹•(ï¼’è¡Œã”ã¨)
+	case F_DOWN2_BOX:		return HLP000345;	//(çŸ©å½¢é¸æŠ)ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹•(ï¼’è¡Œã”ã¨)
+	case F_WORDLEFT_BOX:	return HLP000346;	//(çŸ©å½¢é¸æŠ)å˜èªã®å·¦ç«¯ã«ç§»å‹•
+	case F_WORDRIGHT_BOX:	return HLP000347;	//(çŸ©å½¢é¸æŠ)å˜èªã®å³ç«¯ã«ç§»å‹•
+	case F_GOLINETOP_BOX:	return HLP000350;	//(çŸ©å½¢é¸æŠ)è¡Œé ­ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	case F_GOLOGICALLINETOP_BOX:	return HLP000361;	//(çŸ©å½¢é¸æŠ)è¡Œé ­ã«ç§»å‹•(æ”¹è¡Œå˜ä½)
+	case F_GOLINEEND_BOX:	return HLP000351;	//(çŸ©å½¢é¸æŠ)è¡Œæœ«ã«ç§»å‹•(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	case F_HalfPageUp_BOX:	return HLP000356;	//(çŸ©å½¢é¸æŠ)åŠãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—
+	case F_HalfPageDown_BOX:return HLP000357;	//(çŸ©å½¢é¸æŠ)åŠãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³
+	case F_1PageUp_BOX:		return HLP000352;	//(çŸ©å½¢é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ã‚¢ãƒƒãƒ—
+	case F_1PageDown_BOX:	return HLP000353;	//(çŸ©å½¢é¸æŠ)ï¼‘ãƒšãƒ¼ã‚¸ãƒ€ã‚¦ãƒ³
+	case F_GOFILETOP_BOX:	return HLP000354;	//(çŸ©å½¢é¸æŠ)ãƒ•ã‚¡ã‚¤ãƒ«ã®å…ˆé ­ã«ç§»å‹•
+	case F_GOFILEEND_BOX:	return HLP000355;	//(çŸ©å½¢é¸æŠ)ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹•
+//	case F_GONEXTPARAGRAPH_BOX:	return HLP000348;	//(ç¯„å›²é¸æŠ)æ¬¡ã®æ®µè½ã¸
+//	case F_GOPREVPARAGRAPH_BOX:	return HLP000349;	//(ç¯„å›²é¸æŠ)å‰ã®æ®µè½ã¸
+
+	/* æ•´å½¢ç³» 2002/04/17 YAZAKI */
+	case F_LTRIM:		return HLP000210;	//å·¦(å…ˆé ­)ã®ç©ºç™½ã‚’å‰Šé™¤
+	case F_RTRIM:		return HLP000211;	//å³(æœ«å°¾)ã®ç©ºç™½ã‚’å‰Šé™¤
+	case F_SORT_ASC:	return HLP000212;	//é¸æŠè¡Œã®æ˜‡é †ã‚½ãƒ¼ãƒˆ
+	case F_SORT_DESC:	return HLP000213;	//é¸æŠè¡Œã®é™é †ã‚½ãƒ¼ãƒˆ
+	case F_MERGE:		return HLP000214;	//é¸æŠè¡Œã®ãƒãƒ¼ã‚¸
+
+	/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ç³» */
+	case F_CUT:				return HLP000034;			//åˆ‡ã‚Šå–ã‚Š(é¸æŠç¯„å›²ã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼ã—ã¦å‰Šé™¤)
+	case F_COPY:			return HLP000035;			//ã‚³ãƒ”ãƒ¼(é¸æŠç¯„å›²ã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼)
+	case F_COPY_ADDCRLF:	return HLP000219;			//æŠ˜ã‚Šè¿”ã—ä½ç½®ã«æ”¹è¡Œã‚’ã¤ã‘ã¦ã‚³ãƒ”ãƒ¼(é¸æŠç¯„å›²ã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼)
+	case F_COPY_CRLF:		return HLP000163;			//CRLFæ”¹è¡Œã§ã‚³ãƒ”ãƒ¼(é¸æŠç¯„å›²ã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼)	//Feb. 23, 2001 JEPRO æŠœã‘ã¦ã„ãŸã®ã§è¿½åŠ 
+	case F_PASTE:			return HLP000039;			//è²¼ã‚Šä»˜ã‘(ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘)
+	case F_PASTEBOX:		return HLP000040;			//çŸ©å½¢è²¼ã‚Šä»˜ã‘(ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰çŸ©å½¢è²¼ã‚Šä»˜ã‘)
+//	case F_INSTEXT_W:		return ;					// ãƒ†ã‚­ã‚¹ãƒˆã‚’è²¼ã‚Šä»˜ã‘
+	case F_COPYLINES:				return HLP000036;	//é¸æŠç¯„å›²å†…å…¨è¡Œã‚³ãƒ”ãƒ¼
+	case F_COPYLINESASPASSAGE:		return HLP000037;	//é¸æŠç¯„å›²å†…å…¨è¡Œå¼•ç”¨ç¬¦ä»˜ãã‚³ãƒ”ãƒ¼
+	case F_COPYLINESWITHLINENUMBER:	return HLP000038;	//é¸æŠç¯„å›²å†…å…¨è¡Œè¡Œç•ªå·ä»˜ãã‚³ãƒ”ãƒ¼
+	case F_COPY_COLOR_HTML:			return HLP000342;	//é¸æŠç¯„å›²å†…è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼
+	case F_COPY_COLOR_HTML_LINENUMBER:	return HLP000343;	//é¸æŠç¯„å›²å†…è¡Œç•ªå·è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼
+	case F_COPYPATH:		return HLP000056;			//ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹åã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼
+	case F_COPYTAG:			return HLP000175;			//ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹åã¨ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’ã‚³ãƒ”ãƒ¼	//Oct. 17, 2000 JEPRO è¿½åŠ 
+	case F_COPYFNAME:		return HLP000303;			//ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼ // 2002/2/3 aroka
+//	case IDM_TEST_CREATEKEYBINDLIST:	return 57;	//ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ä¸€è¦§ã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã¸ã‚³ãƒ”ãƒ¼	//Sept. 15, 2000 jeproã€Œãƒªã‚¹ãƒˆã€ã‚’ã€Œä¸€è¦§ã€ã«å¤‰æ›´
+	case F_CREATEKEYBINDLIST:		return HLP000057;	//ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ä¸€è¦§ã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã¸ã‚³ãƒ”ãƒ¼	//Sept. 15, 2000 JEPRO ã€Œãƒªã‚¹ãƒˆã€ã‚’ã€Œä¸€è¦§ã€ã«å¤‰æ›´ã€IDMï¼¿TESTã‚’Fã«å¤‰æ›´ã—ãŸãŒã†ã¾ãã„ã‹ãªã„ã®ã§æ®ºã—ã¦ã‚ã‚‹	//Dec. 25, 2000 å¾©æ´»
+
+
+	/* æŒ¿å…¥ç³» */
+	case F_INS_DATE:				return HLP000164;	// æ—¥ä»˜æŒ¿å…¥
+	case F_INS_TIME:				return HLP000165;	// æ™‚åˆ»æŒ¿å…¥
+	case F_CTRL_CODE_DIALOG:		return HLP000255;	/* ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰å…¥åŠ› */
+
+
+	/* å¤‰æ›ç³» */
+	case F_TOLOWER:					return HLP000047;	//å°æ–‡å­—
+	case F_TOUPPER:					return HLP000048;	//å¤§æ–‡å­—
+	case F_TOHANKAKU:				return HLP000049;	/* å…¨è§’â†’åŠè§’ */
+	case F_TOHANKATA:				return HLP000258;	//å…¨è§’ã‚«ã‚¿ã‚«ãƒŠâ†’åŠè§’ã‚«ã‚¿ã‚«ãƒŠ
+	case F_TOZENKAKUKATA:			return HLP000050;	/* åŠè§’ï¼‹å…¨ã²ã‚‰â†’å…¨è§’ãƒ»ã‚«ã‚¿ã‚«ãƒŠ */	//Sept. 17, 2000 jepro èª¬æ˜ã‚’ã€ŒåŠè§’â†’å…¨è§’ã‚«ã‚¿ã‚«ãƒŠã€ã‹ã‚‰å¤‰æ›´
+	case F_TOZENKAKUHIRA:			return HLP000051;	/* åŠè§’ï¼‹å…¨ã‚«ã‚¿â†’å…¨è§’ãƒ»ã²ã‚‰ãŒãª */	//Sept. 17, 2000 jepro èª¬æ˜ã‚’ã€ŒåŠè§’â†’å…¨è§’ã²ã‚‰ãŒãªã€ã‹ã‚‰å¤‰æ›´
+	case F_HANKATATOZENKATA:	return HLP000123;	/* åŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã‚«ã‚¿ã‚«ãƒŠ */
+	case F_HANKATATOZENHIRA:	return HLP000124;	/* åŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã²ã‚‰ãŒãª */
+	case F_TOZENEI:					return HLP000200;	/* åŠè§’è‹±æ•°â†’å…¨è§’è‹±æ•° */			//July. 30, 2001 Misaka //Stonee, 2001/09/26 ç•ªå·ä¿®æ­£
+	case F_TOHANEI:					return HLP000215;	/* å…¨è§’è‹±æ•°â†’åŠè§’è‹±æ•° */			//@@@ 2002.2.11 YAZAKI
+	case F_TABTOSPACE:				return HLP000182;	/* TABâ†’ç©ºç™½ */
+	case F_SPACETOTAB:				return HLP000196;	/* ç©ºç™½â†’TAB */	//---- Stonee, 2001/05/27	//Jul. 03, 2001 JEPRO ç•ªå·ä¿®æ­£
+	case F_CODECNV_AUTO2SJIS:		return HLP000178;	/* è‡ªå‹•åˆ¤åˆ¥â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_EMAIL:			return HLP000052;	//E-Mail(JISâ†’SJIS)ã‚³ãƒ¼ãƒ‰å¤‰æ›
+	case F_CODECNV_EUC2SJIS:		return HLP000053;	//EUCâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›
+	case F_CODECNV_UNICODE2SJIS:	return HLP000179;	//Unicodeâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›
+	case F_CODECNV_UNICODEBE2SJIS:	return HLP000257;	//UnicodeBEâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ›
+	case F_CODECNV_UTF82SJIS:		return HLP000142;	/* UTF-8â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_UTF72SJIS:		return HLP000143; /* UTF-7â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_SJIS2JIS:		return HLP000117;	/* SJISâ†’JISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_SJIS2EUC:		return HLP000118;	/* SJISâ†’EUCã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_SJIS2UTF8:		return HLP000180;	/* SJISâ†’UTF-8ã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_SJIS2UTF7:		return HLP000181;	/* SJISâ†’UTF-7ã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_BASE64DECODE:			return HLP000054;	//Base64ãƒ‡ã‚³ãƒ¼ãƒ‰ã—ã¦ä¿å­˜
+	case F_UUDECODE:				return HLP000055;	//uudecodeã—ã¦ä¿å­˜	//Oct. 17, 2000 jepro èª¬æ˜ã‚’ã€Œé¸æŠéƒ¨åˆ†ã‚’UUENCODEãƒ‡ã‚³ãƒ¼ãƒ‰ã€ã‹ã‚‰å¤‰æ›´
+
+
+	/* æ¤œç´¢ç³» */
+	case F_SEARCH_DIALOG:		return HLP000059;	//æ¤œç´¢(å˜èªæ¤œç´¢ãƒ€ã‚¤ã‚¢ãƒ­ã‚°)
+	case F_SEARCH_BOX:			return HLP000059;	//æ¤œç´¢(ãƒœãƒƒã‚¯ã‚¹) Jan. 13, 2003 MIK
+	case F_SEARCH_NEXT:			return HLP000061;	//æ¬¡ã‚’æ¤œç´¢
+	case F_SEARCH_PREV:			return HLP000060;	//å‰ã‚’æ¤œç´¢
+	case F_REPLACE_DIALOG:		return HLP000062;	//ç½®æ›(ç½®æ›ãƒ€ã‚¤ã‚¢ãƒ­ã‚°)
+	case F_SEARCH_CLEARMARK:	return HLP000136;	//æ¤œç´¢ãƒãƒ¼ã‚¯ã®ã‚¯ãƒªã‚¢
 	case F_GREP_DIALOG:			return HLP000067;	//Grep
-	case F_GREP_REPLACE_DLG:	return HLP000362;	//Grep’uŠ·
-	case F_JUMP_DIALOG:			return HLP000063;	//w’ès‚ÖƒWƒƒƒ“ƒv
-	case F_OUTLINE:				return HLP000064;	//ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ
-	case F_OUTLINE_TOGGLE:		return HLP000317;	//ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ(ƒgƒOƒ‹)	// 2006.10.11 ryoji
-	case F_TAGJUMP:				return HLP000065;	//ƒ^ƒOƒWƒƒƒ“ƒv‹@”\
-	case F_TAGJUMPBACK:			return HLP000066;	//ƒ^ƒOƒWƒƒƒ“ƒvƒoƒbƒN‹@”\
-	case F_TAGS_MAKE:			return HLP000280;	//ƒ^ƒOƒtƒ@ƒCƒ‹‚Ìì¬	//@@@ 2003.04.13 MIK
-	case F_TAGJUMP_LIST:		return HLP000281;	//ƒ^ƒOƒWƒƒƒ“ƒvˆê——	//@@@ 2003.04.17 MIK
-	case F_DIRECT_TAGJUMP:		return HLP000281;	//ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv	//@@@ 2003.04.17 MIK
-	case F_TAGJUMP_CLOSE:		return HLP000291;	//•Â‚¶‚Äƒ^ƒOƒWƒƒƒ“ƒv(Œ³ƒEƒBƒ“ƒhƒEClose)	// 2006.10.11 ryoji
-	case F_TAGJUMP_KEYWORD:		return HLP000310;	//ƒL[ƒ[ƒh‚ğw’è‚µ‚Äƒ^ƒOƒWƒƒƒ“ƒv	// 2006.10.05 ryoji
-	case F_COMPARE:				return HLP000116;	//ƒtƒ@ƒCƒ‹“à—e”äŠr
-	case F_DIFF_DIALOG:			return HLP000251;	//DIFF·•ª•\¦(ƒ_ƒCƒAƒƒO)	//@@@ 2002.05.25 MIK
-//	case F_DIFF:				return HLP000251;	//DIFF·•ª•\¦	//@@@ 2002.05.25 MIK
-	case F_DIFF_NEXT:			return HLP000252;	//Ÿ‚Ì·•ª‚Ö	//@@@ 2002.05.25 MIK
-	case F_DIFF_PREV:			return HLP000253;	//‘O‚Ì·•ª‚Ö	//@@@ 2002.05.25 MIK
-	case F_DIFF_RESET:			return HLP000254;	//·•ª‚Ì‘S‰ğœ	//@@@ 2002.05.25 MIK
-	case F_BRACKETPAIR:			return HLP000183;	//‘ÎŠ‡ŒÊ‚ÌŒŸõ	//Oct. 17, 2000 JEPRO ’Ç‰Á
-	case F_BOOKMARK_SET:		return HLP000205;	//ƒuƒbƒNƒ}[ƒNİ’èE‰ğœ
-	case F_BOOKMARK_NEXT:		return HLP000206;	//Ÿ‚ÌƒuƒbƒNƒ}[ƒN‚Ö
-	case F_BOOKMARK_PREV:		return HLP000207;	//‘O‚ÌƒuƒbƒNƒ}[ƒN‚Ö
-	case F_BOOKMARK_RESET:		return HLP000208;	//ƒuƒbƒNƒ}[ƒN‚Ì‘S‰ğœ
-	case F_BOOKMARK_VIEW:		return HLP000209;	//ƒuƒbƒNƒ}[ƒN‚Ìˆê——
-	case F_ISEARCH_NEXT:		return HLP000304;	//‘O•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`	// 2006.10.05 ryoji
-	case F_ISEARCH_PREV:		return HLP000305;	//Œã•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`	// 2006.10.05 ryoji
-	case F_ISEARCH_REGEXP_NEXT:	return HLP000306;	//³‹K•\Œ»‘O•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`	// 2006.10.05 ryoji
-	case F_ISEARCH_REGEXP_PREV:	return HLP000307;	//³‹K•\Œ»Œã•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`	// 2006.10.05 ryoji
-	case F_ISEARCH_MIGEMO_NEXT:	return HLP000308;	//MIGEMO‘O•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`	// 2006.10.05 ryoji
-	case F_ISEARCH_MIGEMO_PREV:	return HLP000309;	//MIGEMOŒã•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`	// 2006.10.05 ryoji
-	case F_FUNCLIST_NEXT:		return HLP000364;	//Ÿ‚ÌŠÖ”ƒŠƒXƒgƒ}[ƒN
-	case F_FUNCLIST_PREV:		return HLP000365;	//‘O‚ÌŠÖ”ƒŠƒXƒgƒ}[ƒN
-	case F_FILETREE:			return HLP000368;	//ƒtƒ@ƒCƒ‹ƒcƒŠ[
+	case F_GREP_REPLACE_DLG:	return HLP000362;	//Grepç½®æ›
+	case F_JUMP_DIALOG:			return HLP000063;	//æŒ‡å®šè¡Œã¸ã‚¸ãƒ£ãƒ³ãƒ—
+	case F_OUTLINE:				return HLP000064;	//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ
+	case F_OUTLINE_TOGGLE:		return HLP000317;	//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ(ãƒˆã‚°ãƒ«)	// 2006.10.11 ryoji
+	case F_TAGJUMP:				return HLP000065;	//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½
+	case F_TAGJUMPBACK:			return HLP000066;	//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒãƒƒã‚¯æ©Ÿèƒ½
+	case F_TAGS_MAKE:			return HLP000280;	//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆ	//@@@ 2003.04.13 MIK
+	case F_TAGJUMP_LIST:		return HLP000281;	//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ä¸€è¦§	//@@@ 2003.04.17 MIK
+	case F_DIRECT_TAGJUMP:		return HLP000281;	//ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—	//@@@ 2003.04.17 MIK
+	case F_TAGJUMP_CLOSE:		return HLP000291;	//é–‰ã˜ã¦ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—(å…ƒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦Close)	// 2006.10.11 ryoji
+	case F_TAGJUMP_KEYWORD:		return HLP000310;	//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’æŒ‡å®šã—ã¦ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—	// 2006.10.05 ryoji
+	case F_COMPARE:				return HLP000116;	//ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒ
+	case F_DIFF_DIALOG:			return HLP000251;	//DIFFå·®åˆ†è¡¨ç¤º(ãƒ€ã‚¤ã‚¢ãƒ­ã‚°)	//@@@ 2002.05.25 MIK
+//	case F_DIFF:				return HLP000251;	//DIFFå·®åˆ†è¡¨ç¤º	//@@@ 2002.05.25 MIK
+	case F_DIFF_NEXT:			return HLP000252;	//æ¬¡ã®å·®åˆ†ã¸	//@@@ 2002.05.25 MIK
+	case F_DIFF_PREV:			return HLP000253;	//å‰ã®å·®åˆ†ã¸	//@@@ 2002.05.25 MIK
+	case F_DIFF_RESET:			return HLP000254;	//å·®åˆ†ã®å…¨è§£é™¤	//@@@ 2002.05.25 MIK
+	case F_BRACKETPAIR:			return HLP000183;	//å¯¾æ‹¬å¼§ã®æ¤œç´¢	//Oct. 17, 2000 JEPRO è¿½åŠ 
+	case F_BOOKMARK_SET:		return HLP000205;	//ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯è¨­å®šãƒ»è§£é™¤
+	case F_BOOKMARK_NEXT:		return HLP000206;	//æ¬¡ã®ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã¸
+	case F_BOOKMARK_PREV:		return HLP000207;	//å‰ã®ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã¸
+	case F_BOOKMARK_RESET:		return HLP000208;	//ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã®å…¨è§£é™¤
+	case F_BOOKMARK_VIEW:		return HLP000209;	//ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã®ä¸€è¦§
+	case F_ISEARCH_NEXT:		return HLP000304;	//å‰æ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ	// 2006.10.05 ryoji
+	case F_ISEARCH_PREV:		return HLP000305;	//å¾Œæ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ	// 2006.10.05 ryoji
+	case F_ISEARCH_REGEXP_NEXT:	return HLP000306;	//æ­£è¦è¡¨ç¾å‰æ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ	// 2006.10.05 ryoji
+	case F_ISEARCH_REGEXP_PREV:	return HLP000307;	//æ­£è¦è¡¨ç¾å¾Œæ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ	// 2006.10.05 ryoji
+	case F_ISEARCH_MIGEMO_NEXT:	return HLP000308;	//MIGEMOå‰æ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ	// 2006.10.05 ryoji
+	case F_ISEARCH_MIGEMO_PREV:	return HLP000309;	//MIGEMOå¾Œæ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ	// 2006.10.05 ryoji
+	case F_FUNCLIST_NEXT:		return HLP000364;	//æ¬¡ã®é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯
+	case F_FUNCLIST_PREV:		return HLP000365;	//å‰ã®é–¢æ•°ãƒªã‚¹ãƒˆãƒãƒ¼ã‚¯
+	case F_FILETREE:			return HLP000368;	//ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼
 
-	/* ƒ‚[ƒhØ‚è‘Ö‚¦Œn */
-	case F_CHGMOD_INS:		return HLP000046;	//‘}“ü^ã‘‚«ƒ‚[ƒhØ‚è‘Ö‚¦
-	case F_CHG_CHARSET:		return HLP000297;	//•¶šƒR[ƒhƒZƒbƒgw’è	// 2010/6/14 Uchi
-	case F_CHGMOD_EOL_CRLF:	return HLP000285;	//“ü—Í‰üsƒR[ƒhw’è	// 2003.09.23 Moca
-	case F_CHGMOD_EOL_CR:	return HLP000285;	//“ü—Í‰üsƒR[ƒhw’è	// 2003.09.23 Moca
-	case F_CHGMOD_EOL_LF:	return HLP000285;	//“ü—Í‰üsƒR[ƒhw’è	// 2003.09.23 Moca
-	case F_CANCEL_MODE:		return HLP000194;	//Šeíƒ‚[ƒh‚Ìæ‚èÁ‚µ
+	/* ãƒ¢ãƒ¼ãƒ‰åˆ‡ã‚Šæ›¿ãˆç³» */
+	case F_CHGMOD_INS:		return HLP000046;	//æŒ¿å…¥ï¼ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰åˆ‡ã‚Šæ›¿ãˆ
+	case F_CHG_CHARSET:		return HLP000297;	//æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆæŒ‡å®š	// 2010/6/14 Uchi
+	case F_CHGMOD_EOL_CRLF:	return HLP000285;	//å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š	// 2003.09.23 Moca
+	case F_CHGMOD_EOL_CR:	return HLP000285;	//å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š	// 2003.09.23 Moca
+	case F_CHGMOD_EOL_LF:	return HLP000285;	//å…¥åŠ›æ”¹è¡Œã‚³ãƒ¼ãƒ‰æŒ‡å®š	// 2003.09.23 Moca
+	case F_CANCEL_MODE:		return HLP000194;	//å„ç¨®ãƒ¢ãƒ¼ãƒ‰ã®å–ã‚Šæ¶ˆã—
 
 
-	/* İ’èŒn */
-	case F_SHOWTOOLBAR:		return HLP000069;	/* ƒc[ƒ‹ƒo[‚Ì•\¦ */
-	case F_SHOWFUNCKEY:		return HLP000070;	/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚Ì•\¦ */
-	case F_SHOWTAB:			return HLP000282;	/* ƒ^ƒu‚Ì•\¦ */	//@@@ 2003.06.10 MIK
-	case F_SHOWSTATUSBAR:	return HLP000134;	/* ƒXƒe[ƒ^ƒXƒo[‚Ì•\¦ */
-	case F_SHOWMINIMAP:		return HLP000371;	// ƒ~ƒjƒ}ƒbƒv‚Ì•\¦
-	case F_TYPE_LIST:		return HLP000072;	/* ƒ^ƒCƒv•Êİ’èˆê—— */
-	case F_OPTION_TYPE:		return HLP000073;	/* ƒ^ƒCƒv•Êİ’è */
-	case F_OPTION:			return HLP000076;	/* ‹¤’Êİ’è */
-//From here İ’èƒ_ƒCƒAƒƒO—p‚ÌhelpƒgƒsƒbƒNID‚ğ’Ç‰Á  Stonee, 2001/05/18
-	case F_TYPE_SCREEN:		return HLP000074;	/* ƒ^ƒCƒv•Êİ’èwƒXƒNƒŠ[ƒ“x */
-	case F_TYPE_COLOR:		return HLP000075;	/* ƒ^ƒCƒv•Êİ’èwƒJƒ‰[x */
-	case F_TYPE_WINDOW:		return HLP000319;	/* ƒ^ƒCƒv•Êİ’èwƒEƒBƒ“ƒhƒEx */
-	case F_TYPE_HELPER:		return HLP000197;	/* ƒ^ƒCƒv•Êİ’èwx‰‡x */	//Jul. 03, 2001 JEPRO ’Ç‰Á
-	case F_TYPE_REGEX_KEYWORD:	return HLP000203;	/* ƒ^ƒCƒv•Êİ’èw³‹K•\Œ»ƒL[ƒ[ƒhx */	//@@@ 2001.11.17 add MIK
-	case F_TYPE_KEYHELP:	return HLP000315;	/* ƒ^ƒCƒv•Êİ’èwƒL[ƒ[ƒhƒwƒ‹ƒvx */	// 2006.10.06 ryoji ’Ç‰Á
-	case F_OPTION_GENERAL:	return HLP000081;	/* ‹¤’Êİ’èw‘S”Êx */
-	case F_OPTION_WINDOW:	return HLP000146;	/* ‹¤’Êİ’èwƒEƒBƒ“ƒhƒEx */
-	case F_OPTION_TAB:		return HLP000150;	/* ‹¤’Êİ’èwƒ^ƒuƒo[x */	// 2007.02.13 ryoji ’Ç‰Á
-	case F_OPTION_EDIT:		return HLP000144;	/* ‹¤’Êİ’èw•ÒWx */
-	case F_OPTION_FILE:		return HLP000083;	/* ‹¤’Êİ’èwƒtƒ@ƒCƒ‹x */
-	case F_OPTION_BACKUP:	return HLP000145;	/* ‹¤’Êİ’èwƒoƒbƒNƒAƒbƒvx */
-	case F_OPTION_FORMAT:	return HLP000082;	/* ‹¤’Êİ’èw‘®x */
-//	case F_OPTION_URL:		return HLP000147;	/* ‹¤’Êİ’èwƒNƒŠƒbƒJƒuƒ‹URLx */
-	case F_OPTION_GREP:		return HLP000148;	/* ‹¤’Êİ’èwGrepx */
-	case F_OPTION_KEYBIND:	return HLP000084;	/* ‹¤’Êİ’èwƒL[Š„‚è“–‚Äx */
-	case F_OPTION_CUSTMENU:	return HLP000087;	/* ‹¤’Êİ’èwƒJƒXƒ^ƒ€ƒƒjƒ…[x */
-	case F_OPTION_TOOLBAR:	return HLP000085;	/* ‹¤’Êİ’èwƒc[ƒ‹ƒo[x */
-	case F_OPTION_KEYWORD:	return HLP000086;	/* ‹¤’Êİ’èw‹­’²ƒL[ƒ[ƒhx */
-	case F_OPTION_HELPER:	return HLP000088;	/* ‹¤’Êİ’èwx‰‡x */
+	/* è¨­å®šç³» */
+	case F_SHOWTOOLBAR:		return HLP000069;	/* ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã®è¡¨ç¤º */
+	case F_SHOWFUNCKEY:		return HLP000070;	/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®è¡¨ç¤º */
+	case F_SHOWTAB:			return HLP000282;	/* ã‚¿ãƒ–ã®è¡¨ç¤º */	//@@@ 2003.06.10 MIK
+	case F_SHOWSTATUSBAR:	return HLP000134;	/* ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã®è¡¨ç¤º */
+	case F_SHOWMINIMAP:		return HLP000371;	// ãƒŸãƒ‹ãƒãƒƒãƒ—ã®è¡¨ç¤º
+	case F_TYPE_LIST:		return HLP000072;	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šä¸€è¦§ */
+	case F_OPTION_TYPE:		return HLP000073;	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š */
+	case F_OPTION:			return HLP000076;	/* å…±é€šè¨­å®š */
+//From here è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ç”¨ã®helpãƒˆãƒ”ãƒƒã‚¯IDã‚’è¿½åŠ   Stonee, 2001/05/18
+	case F_TYPE_SCREEN:		return HLP000074;	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã€ã‚¹ã‚¯ãƒªãƒ¼ãƒ³ã€ */
+	case F_TYPE_COLOR:		return HLP000075;	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã€ã‚«ãƒ©ãƒ¼ã€ */
+	case F_TYPE_WINDOW:		return HLP000319;	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã€ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã€ */
+	case F_TYPE_HELPER:		return HLP000197;	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã€æ”¯æ´ã€ */	//Jul. 03, 2001 JEPRO è¿½åŠ 
+	case F_TYPE_REGEX_KEYWORD:	return HLP000203;	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã€æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã€ */	//@@@ 2001.11.17 add MIK
+	case F_TYPE_KEYHELP:	return HLP000315;	/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã€ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã€ */	// 2006.10.06 ryoji è¿½åŠ 
+	case F_OPTION_GENERAL:	return HLP000081;	/* å…±é€šè¨­å®šã€å…¨èˆ¬ã€ */
+	case F_OPTION_WINDOW:	return HLP000146;	/* å…±é€šè¨­å®šã€ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã€ */
+	case F_OPTION_TAB:		return HLP000150;	/* å…±é€šè¨­å®šã€ã‚¿ãƒ–ãƒãƒ¼ã€ */	// 2007.02.13 ryoji è¿½åŠ 
+	case F_OPTION_EDIT:		return HLP000144;	/* å…±é€šè¨­å®šã€ç·¨é›†ã€ */
+	case F_OPTION_FILE:		return HLP000083;	/* å…±é€šè¨­å®šã€ãƒ•ã‚¡ã‚¤ãƒ«ã€ */
+	case F_OPTION_BACKUP:	return HLP000145;	/* å…±é€šè¨­å®šã€ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ã€ */
+	case F_OPTION_FORMAT:	return HLP000082;	/* å…±é€šè¨­å®šã€æ›¸å¼ã€ */
+//	case F_OPTION_URL:		return HLP000147;	/* å…±é€šè¨­å®šã€ã‚¯ãƒªãƒƒã‚«ãƒ–ãƒ«URLã€ */
+	case F_OPTION_GREP:		return HLP000148;	/* å…±é€šè¨­å®šã€Grepã€ */
+	case F_OPTION_KEYBIND:	return HLP000084;	/* å…±é€šè¨­å®šã€ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ã€ */
+	case F_OPTION_CUSTMENU:	return HLP000087;	/* å…±é€šè¨­å®šã€ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã€ */
+	case F_OPTION_TOOLBAR:	return HLP000085;	/* å…±é€šè¨­å®šã€ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã€ */
+	case F_OPTION_KEYWORD:	return HLP000086;	/* å…±é€šè¨­å®šã€å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã€ */
+	case F_OPTION_HELPER:	return HLP000088;	/* å…±é€šè¨­å®šã€æ”¯æ´ã€ */
 //To here  Stonee, 2001/05/18
-	case F_OPTION_MACRO:	return HLP000201;	/* ‹¤’Êİ’èwƒ}ƒNƒx */	//@@@ 2002.01.02
-	case F_OPTION_STATUSBAR: return HLP000147;	/* ‹¤’Êİ’èwƒXƒe[ƒ^ƒXƒo[x */	// 2010/5/6 Uchi
-	case F_OPTION_PLUGIN:	return HLP000151;	/* ‹¤’Êİ’èwƒvƒ‰ƒOƒCƒ“x */	// 2010/5/6 Uchi
-	case F_OPTION_FNAME:	return HLP000277;	/* ‹¤’Êİ’èwƒtƒ@ƒCƒ‹–¼•\¦xƒvƒƒpƒeƒB */	// 2002.12.09 Moca Add	//d•¡‰ñ”ğ
-	case F_OPTION_MAINMENU:	return HLP000152;	/* ‹¤’Êİ’èwƒƒCƒ“ƒƒjƒ…[x */	// 2010/5/6 Uchi
-	case F_FONT:			return HLP000071;	/* ƒtƒHƒ“ƒgİ’è */
-	case F_WRAPWINDOWWIDTH:	return HLP000184;	/* Œ»İ‚ÌƒEƒBƒ“ƒhƒE•‚ÅÜ‚è•Ô‚µ */	//Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH ‚ğ WRAPWINDOWWIDTH ‚É•ÏX	//Jul. 03, 2001 JEPRO ”Ô†C³
-	case F_FAVORITE:		return HLP000279;	/* —š—ğ‚ÌŠÇ— */	//@@@ 2003.04.08 MIK
-	case F_TMPWRAPNOWRAP:	return HLP000340;	// Ü‚è•Ô‚³‚È‚¢			// 2008.05.31 nasukoji
-	case F_TMPWRAPSETTING:	return HLP000340;	// w’èŒ…‚ÅÜ‚è•Ô‚·		// 2008.05.31 nasukoji
-	case F_TMPWRAPWINDOW:	return HLP000340;	// ‰E’[‚ÅÜ‚è•Ô‚·		// 2008.05.31 nasukoji
-	case F_SELECT_COUNT_MODE: return HLP000336;	// •¶šƒJƒEƒ“ƒg•û–@		// 2009.07.06 syat
+	case F_OPTION_MACRO:	return HLP000201;	/* å…±é€šè¨­å®šã€ãƒã‚¯ãƒ­ã€ */	//@@@ 2002.01.02
+	case F_OPTION_STATUSBAR: return HLP000147;	/* å…±é€šè¨­å®šã€ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã€ */	// 2010/5/6 Uchi
+	case F_OPTION_PLUGIN:	return HLP000151;	/* å…±é€šè¨­å®šã€ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã€ */	// 2010/5/6 Uchi
+	case F_OPTION_FNAME:	return HLP000277;	/* å…±é€šè¨­å®šã€ãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤ºã€ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ */	// 2002.12.09 Moca Add	//é‡è¤‡å›é¿
+	case F_OPTION_MAINMENU:	return HLP000152;	/* å…±é€šè¨­å®šã€ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã€ */	// 2010/5/6 Uchi
+	case F_FONT:			return HLP000071;	/* ãƒ•ã‚©ãƒ³ãƒˆè¨­å®š */
+	case F_WRAPWINDOWWIDTH:	return HLP000184;	/* ç¾åœ¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ã§æŠ˜ã‚Šè¿”ã— */	//Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH ã‚’ WRAPWINDOWWIDTH ã«å¤‰æ›´	//Jul. 03, 2001 JEPRO ç•ªå·ä¿®æ­£
+	case F_FAVORITE:		return HLP000279;	/* å±¥æ­´ã®ç®¡ç† */	//@@@ 2003.04.08 MIK
+	case F_TMPWRAPNOWRAP:	return HLP000340;	// æŠ˜ã‚Šè¿”ã•ãªã„			// 2008.05.31 nasukoji
+	case F_TMPWRAPSETTING:	return HLP000340;	// æŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™		// 2008.05.31 nasukoji
+	case F_TMPWRAPWINDOW:	return HLP000340;	// å³ç«¯ã§æŠ˜ã‚Šè¿”ã™		// 2008.05.31 nasukoji
+	case F_SELECT_COUNT_MODE: return HLP000336;	// æ–‡å­—ã‚«ã‚¦ãƒ³ãƒˆæ–¹æ³•		// 2009.07.06 syat
 
-	/* ƒ}ƒNƒ */
-	case F_RECKEYMACRO:		return HLP000125;	/* ƒL[ƒ}ƒNƒ‹L˜^ŠJn^I—¹ */
-	case F_SAVEKEYMACRO:	return HLP000127;	/* ƒL[ƒ}ƒNƒ•Û‘¶ */
-	case F_LOADKEYMACRO:	return HLP000128;	/* ƒL[ƒ}ƒNƒ“Ç‚İ‚İ */
-	case F_EXECKEYMACRO:	return HLP000126;	/* ƒL[ƒ}ƒNƒÀs */
-	case F_EXECEXTMACRO:	return HLP000332;	/* –¼‘O‚ğw’è‚µ‚Äƒ}ƒNƒÀs */
-//	From Here Sept. 20, 2000 JEPRO –¼ÌCMMAND‚ğCOMMAND‚É•ÏX
-//	case F_EXECCMMAND:		return 103; /* ŠO•”ƒRƒ}ƒ“ƒhÀs */
-	case F_EXECMD_DIALOG:	return HLP000103; /* ŠO•”ƒRƒ}ƒ“ƒhÀs */
+	/* ãƒã‚¯ãƒ­ */
+	case F_RECKEYMACRO:		return HLP000125;	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­è¨˜éŒ²é–‹å§‹ï¼çµ‚äº† */
+	case F_SAVEKEYMACRO:	return HLP000127;	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ä¿å­˜ */
+	case F_LOADKEYMACRO:	return HLP000128;	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­èª­ã¿è¾¼ã¿ */
+	case F_EXECKEYMACRO:	return HLP000126;	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­å®Ÿè¡Œ */
+	case F_EXECEXTMACRO:	return HLP000332;	/* åå‰ã‚’æŒ‡å®šã—ã¦ãƒã‚¯ãƒ­å®Ÿè¡Œ */
+//	From Here Sept. 20, 2000 JEPRO åç§°CMMANDã‚’COMMANDã«å¤‰æ›´
+//	case F_EXECCMMAND:		return 103; /* å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œ */
+	case F_EXECMD_DIALOG:	return HLP000103; /* å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œ */
 //	To Here Sept. 20, 2000
 
 
-	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[ */
-	case F_MENU_RBUTTON:	return HLP000195;	/* ‰EƒNƒŠƒbƒNƒƒjƒ…[ */
-	case F_CUSTMENU_1:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[1 */
-	case F_CUSTMENU_2:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[2 */
-	case F_CUSTMENU_3:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[3 */
-	case F_CUSTMENU_4:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[4 */
-	case F_CUSTMENU_5:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[5 */
-	case F_CUSTMENU_6:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[6 */
-	case F_CUSTMENU_7:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[7 */
-	case F_CUSTMENU_8:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[8 */
-	case F_CUSTMENU_9:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[9 */
-	case F_CUSTMENU_10:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[10 */
-	case F_CUSTMENU_11:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[11 */
-	case F_CUSTMENU_12:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[12 */
-	case F_CUSTMENU_13:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[13 */
-	case F_CUSTMENU_14:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[14 */
-	case F_CUSTMENU_15:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[15 */
-	case F_CUSTMENU_16:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[16 */
-	case F_CUSTMENU_17:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[17 */
-	case F_CUSTMENU_18:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[18 */
-	case F_CUSTMENU_19:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[19 */
-	case F_CUSTMENU_20:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[20 */
-	case F_CUSTMENU_21:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[21 */
-	case F_CUSTMENU_22:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[22 */
-	case F_CUSTMENU_23:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[23 */
-	case F_CUSTMENU_24:	return HLP000186;	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[24 */
+	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */
+	case F_MENU_RBUTTON:	return HLP000195;	/* å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */
+	case F_CUSTMENU_1:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼1 */
+	case F_CUSTMENU_2:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼2 */
+	case F_CUSTMENU_3:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼3 */
+	case F_CUSTMENU_4:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼4 */
+	case F_CUSTMENU_5:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼5 */
+	case F_CUSTMENU_6:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼6 */
+	case F_CUSTMENU_7:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼7 */
+	case F_CUSTMENU_8:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼8 */
+	case F_CUSTMENU_9:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼9 */
+	case F_CUSTMENU_10:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼10 */
+	case F_CUSTMENU_11:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼11 */
+	case F_CUSTMENU_12:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼12 */
+	case F_CUSTMENU_13:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼13 */
+	case F_CUSTMENU_14:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼14 */
+	case F_CUSTMENU_15:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼15 */
+	case F_CUSTMENU_16:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼16 */
+	case F_CUSTMENU_17:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼17 */
+	case F_CUSTMENU_18:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼18 */
+	case F_CUSTMENU_19:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼19 */
+	case F_CUSTMENU_20:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼20 */
+	case F_CUSTMENU_21:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼21 */
+	case F_CUSTMENU_22:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼22 */
+	case F_CUSTMENU_23:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼23 */
+	case F_CUSTMENU_24:	return HLP000186;	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼24 */
 
 
-	/* ƒEƒBƒ“ƒhƒEŒn */
-	case F_SPLIT_V:			return HLP000093;	//ã‰º‚É•ªŠ„	//Sept. 17, 2000 jepro à–¾‚Ìucv‚ğuã‰º‚Év‚É•ÏX
-	case F_SPLIT_H:			return HLP000094;	//¶‰E‚É•ªŠ„	//Sept. 17, 2000 jepro à–¾‚Ìu‰¡v‚ğu¶‰E‚Év‚É•ÏX
-	case F_SPLIT_VH:		return HLP000095;	//c‰¡‚É•ªŠ„	//Sept. 17, 2000 jepro à–¾‚Éu‚Év‚ğ’Ç‰Á
-	case F_WINCLOSE:		return HLP000018;	//ƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚é
-	case F_WIN_CLOSEALL:	return HLP000019;	//‚·‚×‚Ä‚ÌƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚é	//Oct. 17, 2000 JEPRO –¼‘O‚ğ•ÏX(F_FILECLOSEALL¨F_WIN_CLOSEALL)
-	case F_NEXTWINDOW:		return HLP000092;	//Ÿ‚ÌƒEƒBƒ“ƒhƒE
-	case F_PREVWINDOW:		return HLP000091;	//‘O‚ÌƒEƒBƒ“ƒhƒE
-	case F_WINLIST:			return HLP000314;	//ƒEƒBƒ“ƒhƒEˆê——	// 2006.10.05 ryoji
-	case F_DLGWINLIST:		return HLP000372;	//ƒEƒBƒ“ƒhƒEˆê——•\¦
-	case F_BIND_WINDOW:		return HLP000311;	//Œ‹‡‚µ‚Ä•\¦	// 2006.10.05 ryoji
-	case F_CASCADE:			return HLP000138;	//d‚Ë‚Ä•\¦
-	case F_TILE_V:			return HLP000140;	//ã‰º‚É•À‚×‚Ä•\¦
-	case F_TILE_H:			return HLP000139;	//¶‰E‚É•À‚×‚Ä•\¦
-	case F_TOPMOST:			return HLP000312;	//í‚Éè‘O‚É•\¦	// 2006.10.05 ryoji
-	case F_MAXIMIZE_V:		return HLP000141;	//c•ûŒü‚ÉÅ‘å‰»
-	case F_MAXIMIZE_H:		return HLP000098;	//‰¡•ûŒü‚ÉÅ‘å‰»	//2001.02.10 by MIK
-	case F_MINIMIZE_ALL:	return HLP000096;	//‚·‚×‚ÄÅ¬‰»	//Sept. 17, 2000 jepro à–¾‚Ìu‘S‚Äv‚ğu‚·‚×‚Äv‚É“ˆê
-	case F_REDRAW:			return HLP000187;	//Ä•`‰æ
-	case F_WIN_OUTPUT:		return HLP000188;	//ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE•\¦
-	case F_GROUPCLOSE:		return HLP000320;	//ƒOƒ‹[ƒv‚ğ•Â‚¶‚é	// 2007.06.20 ryoji
-	case F_NEXTGROUP:		return HLP000321;	//Ÿ‚ÌƒOƒ‹[ƒv	// 2007.06.20 ryoji
-	case F_PREVGROUP:		return HLP000322;	//‘O‚ÌƒOƒ‹[ƒv	// 2007.06.20 ryoji
-	case F_TAB_MOVERIGHT:	return HLP000323;	//ƒ^ƒu‚ğ‰E‚ÉˆÚ“®	// 2007.06.20 ryoji
-	case F_TAB_MOVELEFT:	return HLP000324;	//ƒ^ƒu‚ğ¶‚ÉˆÚ“®	// 2007.06.20 ryoji
-	case F_TAB_SEPARATE:	return HLP000325;	//V‹KƒOƒ‹[ƒv	// 2007.06.20 ryoji
-	case F_TAB_JOINTNEXT:	return HLP000326;	//Ÿ‚ÌƒOƒ‹[ƒv‚ÉˆÚ“®	// 2007.06.20 ryoji
-	case F_TAB_JOINTPREV:	return HLP000327;	//‘O‚ÌƒOƒ‹[ƒv‚ÉˆÚ“®	// 2007.06.20 ryoji
-	case F_TAB_CLOSEOTHER:	return HLP000333;	//‚±‚Ìƒ^ƒuˆÈŠO‚ğ•Â‚¶‚é	// 2009.07.07 syat
-	case F_TAB_CLOSELEFT:	return HLP000334;	//¶‚ğ‚·‚×‚Ä•Â‚¶‚é		// 2009.07.07 syat
-	case F_TAB_CLOSERIGHT:	return HLP000335;	//‰E‚ğ‚·‚×‚Ä•Â‚¶‚é		// 2009.07.07 syat
+	/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç³» */
+	case F_SPLIT_V:			return HLP000093;	//ä¸Šä¸‹ã«åˆ†å‰²	//Sept. 17, 2000 jepro èª¬æ˜ã®ã€Œç¸¦ã€ã‚’ã€Œä¸Šä¸‹ã«ã€ã«å¤‰æ›´
+	case F_SPLIT_H:			return HLP000094;	//å·¦å³ã«åˆ†å‰²	//Sept. 17, 2000 jepro èª¬æ˜ã®ã€Œæ¨ªã€ã‚’ã€Œå·¦å³ã«ã€ã«å¤‰æ›´
+	case F_SPLIT_VH:		return HLP000095;	//ç¸¦æ¨ªã«åˆ†å‰²	//Sept. 17, 2000 jepro èª¬æ˜ã«ã€Œã«ã€ã‚’è¿½åŠ 
+	case F_WINCLOSE:		return HLP000018;	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹
+	case F_WIN_CLOSEALL:	return HLP000019;	//ã™ã¹ã¦ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹	//Oct. 17, 2000 JEPRO åå‰ã‚’å¤‰æ›´(F_FILECLOSEALLâ†’F_WIN_CLOSEALL)
+	case F_NEXTWINDOW:		return HLP000092;	//æ¬¡ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	case F_PREVWINDOW:		return HLP000091;	//å‰ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	case F_WINLIST:			return HLP000314;	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§	// 2006.10.05 ryoji
+	case F_DLGWINLIST:		return HLP000372;	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¸€è¦§è¡¨ç¤º
+	case F_BIND_WINDOW:		return HLP000311;	//çµåˆã—ã¦è¡¨ç¤º	// 2006.10.05 ryoji
+	case F_CASCADE:			return HLP000138;	//é‡ã­ã¦è¡¨ç¤º
+	case F_TILE_V:			return HLP000140;	//ä¸Šä¸‹ã«ä¸¦ã¹ã¦è¡¨ç¤º
+	case F_TILE_H:			return HLP000139;	//å·¦å³ã«ä¸¦ã¹ã¦è¡¨ç¤º
+	case F_TOPMOST:			return HLP000312;	//å¸¸ã«æ‰‹å‰ã«è¡¨ç¤º	// 2006.10.05 ryoji
+	case F_MAXIMIZE_V:		return HLP000141;	//ç¸¦æ–¹å‘ã«æœ€å¤§åŒ–
+	case F_MAXIMIZE_H:		return HLP000098;	//æ¨ªæ–¹å‘ã«æœ€å¤§åŒ–	//2001.02.10 by MIK
+	case F_MINIMIZE_ALL:	return HLP000096;	//ã™ã¹ã¦æœ€å°åŒ–	//Sept. 17, 2000 jepro èª¬æ˜ã®ã€Œå…¨ã¦ã€ã‚’ã€Œã™ã¹ã¦ã€ã«çµ±ä¸€
+	case F_REDRAW:			return HLP000187;	//å†æç”»
+	case F_WIN_OUTPUT:		return HLP000188;	//ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦è¡¨ç¤º
+	case F_GROUPCLOSE:		return HLP000320;	//ã‚°ãƒ«ãƒ¼ãƒ—ã‚’é–‰ã˜ã‚‹	// 2007.06.20 ryoji
+	case F_NEXTGROUP:		return HLP000321;	//æ¬¡ã®ã‚°ãƒ«ãƒ¼ãƒ—	// 2007.06.20 ryoji
+	case F_PREVGROUP:		return HLP000322;	//å‰ã®ã‚°ãƒ«ãƒ¼ãƒ—	// 2007.06.20 ryoji
+	case F_TAB_MOVERIGHT:	return HLP000323;	//ã‚¿ãƒ–ã‚’å³ã«ç§»å‹•	// 2007.06.20 ryoji
+	case F_TAB_MOVELEFT:	return HLP000324;	//ã‚¿ãƒ–ã‚’å·¦ã«ç§»å‹•	// 2007.06.20 ryoji
+	case F_TAB_SEPARATE:	return HLP000325;	//æ–°è¦ã‚°ãƒ«ãƒ¼ãƒ—	// 2007.06.20 ryoji
+	case F_TAB_JOINTNEXT:	return HLP000326;	//æ¬¡ã®ã‚°ãƒ«ãƒ¼ãƒ—ã«ç§»å‹•	// 2007.06.20 ryoji
+	case F_TAB_JOINTPREV:	return HLP000327;	//å‰ã®ã‚°ãƒ«ãƒ¼ãƒ—ã«ç§»å‹•	// 2007.06.20 ryoji
+	case F_TAB_CLOSEOTHER:	return HLP000333;	//ã“ã®ã‚¿ãƒ–ä»¥å¤–ã‚’é–‰ã˜ã‚‹	// 2009.07.07 syat
+	case F_TAB_CLOSELEFT:	return HLP000334;	//å·¦ã‚’ã™ã¹ã¦é–‰ã˜ã‚‹		// 2009.07.07 syat
+	case F_TAB_CLOSERIGHT:	return HLP000335;	//å³ã‚’ã™ã¹ã¦é–‰ã˜ã‚‹		// 2009.07.07 syat
 
 
-	/* x‰‡ */
-	case F_HOKAN:			return HLP000111;	/* “ü—Í•âŠ®‹@”\ */
-	case F_TOGGLE_KEY_SEARCH:	return HLP000318;	//ƒLƒƒƒŒƒbƒgˆÊ’u«‘ŒŸõ‹@”\ON/OFF	// 2006.10.11 ryoji
-//Sept. 15, 2000¨Nov. 25, 2000 JEPRO	//ƒVƒ‡[ƒgƒJƒbƒgƒL[‚ª‚¤‚Ü‚­“­‚©‚È‚¢‚Ì‚ÅE‚µ‚Ä‚ ‚Á‚½‰º‚Ì2s‚ğC³E•œŠˆ
-	case F_HELP_CONTENTS:	return HLP000100;	//ƒwƒ‹ƒv–ÚŸ			//Nov. 25, 2000 JEPRO
-	case F_HELP_SEARCH:		return HLP000101;	//ƒwƒ‹ƒvƒL[ƒ[ƒhŒŸõ	//Nov. 25, 2000 JEPROuƒgƒsƒbƒN‚Ìv¨uƒL[ƒ[ƒhv‚É•ÏX
-	case F_MENU_ALLFUNC:	return HLP000189;	/* ƒRƒ}ƒ“ƒhˆê—— */
-	case F_EXTHELP1:		return HLP000190;	/* ŠO•”ƒwƒ‹ƒv‚P */
-	case F_EXTHTMLHELP:		return HLP000191;	/* ŠO•”HTMLƒwƒ‹ƒv */
-	case F_ABOUT:			return HLP000102;	//ƒo[ƒWƒ‡ƒ“î•ñ	//Dec. 24, 2000 JEPRO F_‚É•ÏX
+	/* æ”¯æ´ */
+	case F_HOKAN:			return HLP000111;	/* å…¥åŠ›è£œå®Œæ©Ÿèƒ½ */
+	case F_TOGGLE_KEY_SEARCH:	return HLP000318;	//ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®è¾æ›¸æ¤œç´¢æ©Ÿèƒ½ON/OFF	// 2006.10.11 ryoji
+//Sept. 15, 2000â†’Nov. 25, 2000 JEPRO	//ã‚·ãƒ§ãƒ¼ãƒˆã‚«ãƒƒãƒˆã‚­ãƒ¼ãŒã†ã¾ãåƒã‹ãªã„ã®ã§æ®ºã—ã¦ã‚ã£ãŸä¸‹ã®2è¡Œã‚’ä¿®æ­£ãƒ»å¾©æ´»
+	case F_HELP_CONTENTS:	return HLP000100;	//ãƒ˜ãƒ«ãƒ—ç›®æ¬¡			//Nov. 25, 2000 JEPRO
+	case F_HELP_SEARCH:		return HLP000101;	//ãƒ˜ãƒ«ãƒ—ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æ¤œç´¢	//Nov. 25, 2000 JEPROã€Œãƒˆãƒ”ãƒƒã‚¯ã®ã€â†’ã€Œã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã€ã«å¤‰æ›´
+	case F_MENU_ALLFUNC:	return HLP000189;	/* ã‚³ãƒãƒ³ãƒ‰ä¸€è¦§ */
+	case F_EXTHELP1:		return HLP000190;	/* å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘ */
+	case F_EXTHTMLHELP:		return HLP000191;	/* å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ— */
+	case F_ABOUT:			return HLP000102;	//ãƒãƒ¼ã‚¸ãƒ§ãƒ³æƒ…å ±	//Dec. 24, 2000 JEPRO F_ã«å¤‰æ›´
 
 
-	/* ‚»‚Ì‘¼ */
+	/* ãã®ä»– */
 
 	default:
 		// From Here 2003.09.23 Moca
 		if( IDM_SELMRU <= nFuncID && nFuncID < IDM_SELMRU + MAX_MRU ){
-			return HLP000029;	//Å‹ßg‚Á‚½ƒtƒ@ƒCƒ‹
+			return HLP000029;	//æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚¡ã‚¤ãƒ«
 		}else if( IDM_SELOPENFOLDER <= nFuncID && nFuncID < IDM_SELOPENFOLDER + MAX_OPENFOLDER ){
-			return HLP000023;	//Å‹ßg‚Á‚½ƒtƒHƒ‹ƒ_
+			return HLP000023;	//æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚©ãƒ«ãƒ€
 		}else if( IDM_SELWINDOW <= nFuncID && nFuncID < IDM_SELWINDOW + MAX_EDITWINDOWS ){
-			return HLP000097;	//ƒEƒBƒ“ƒhƒEƒŠƒXƒg
+			return HLP000097;	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒªã‚¹ãƒˆ
 		}else if( F_USERMACRO_0 <= nFuncID && nFuncID < F_USERMACRO_0 + MAX_CUSTMACRO ){
-			return HLP000202;	//“o˜^Ï‚İƒ}ƒNƒ	// 2006.10.08 ryoji
+			return HLP000202;	//ç™»éŒ²æ¸ˆã¿ãƒã‚¯ãƒ­	// 2006.10.08 ryoji
 		}
 		// To Here 2003.09.23 Moca
 		return 0;
@@ -998,17 +998,17 @@ int FuncID_To_HelpContextID( EFunctionCode nFuncID )
 
 
 
-/* ‹@”\‚ª—˜—p‰Â”\‚©’²‚×‚é */
+/* æ©Ÿèƒ½ãŒåˆ©ç”¨å¯èƒ½ã‹èª¿ã¹ã‚‹ */
 bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EFunctionCode nId )
 {
-	/* ‘‚«Š·‚¦‹Ö~‚Ì‚Æ‚«‚ğˆêŠ‡ƒ`ƒFƒbƒN */
+	/* æ›¸ãæ›ãˆç¦æ­¢ã®ã¨ãã‚’ä¸€æ‹¬ãƒã‚§ãƒƒã‚¯ */
 	if( pcEditDoc->IsModificationForbidden( nId ) )
 		return false;
 
 	switch( nId ){
-	case F_RECKEYMACRO:	/* ƒL[ƒ}ƒNƒ‚Ì‹L˜^ŠJn^I—¹ */
-		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì‹L˜^’† */
-			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ‹L˜^’†‚ÌƒEƒBƒ“ƒhƒE */
+	case F_RECKEYMACRO:	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®è¨˜éŒ²é–‹å§‹ï¼çµ‚äº† */
+		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ */
+			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’è¨˜éŒ²ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
 				return true;
 			}else{
 				return false;
@@ -1016,12 +1016,12 @@ bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EF
 		}else{
 			return true;
 		}
-	case F_SAVEKEYMACRO:	/* ƒL[ƒ}ƒNƒ‚Ì•Û‘¶ */
+	case F_SAVEKEYMACRO:	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®ä¿å­˜ */
 		//	Jun. 16, 2002 genta
-		//	ƒL[ƒ}ƒNƒƒGƒ“ƒWƒ“ˆÈŠO‚Ìƒ}ƒNƒ‚ğ“Ç‚İ‚ñ‚Å‚¢‚é‚Æ‚«‚Í
-		//	Às‚Í‚Å‚«‚é‚ª•Û‘¶‚Í‚Å‚«‚È‚¢D
-		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì‹L˜^’† */
-			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ‹L˜^’†‚ÌƒEƒBƒ“ƒhƒE */
+		//	ã‚­ãƒ¼ãƒã‚¯ãƒ­ã‚¨ãƒ³ã‚¸ãƒ³ä»¥å¤–ã®ãƒã‚¯ãƒ­ã‚’èª­ã¿è¾¼ã‚“ã§ã„ã‚‹ã¨ãã¯
+		//	å®Ÿè¡Œã¯ã§ãã‚‹ãŒä¿å­˜ã¯ã§ããªã„ï¼
+		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ */
+			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’è¨˜éŒ²ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
 				return true;
 			}else{
 				return false;
@@ -1029,24 +1029,24 @@ bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EF
 		}else{
 			return CEditApp::getInstance()->m_pcSMacroMgr->IsSaveOk();
 		}
-	case F_EXECKEYMACRO:	/* ƒL[ƒ}ƒNƒ‚ÌÀs */
-		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì‹L˜^’† */
-			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ‹L˜^’†‚ÌƒEƒBƒ“ƒhƒE */
+	case F_EXECKEYMACRO:	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®å®Ÿè¡Œ */
+		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ */
+			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’è¨˜éŒ²ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
 				return true;
 			}else{
 				return false;
 			}
 		}else{
-			//@@@ 2002.1.24 YAZAKI m_szKeyMacroFileName‚Éƒtƒ@ƒCƒ‹–¼‚ªƒRƒs[‚³‚ê‚Ä‚¢‚é‚©‚Ç‚¤‚©B
+			//@@@ 2002.1.24 YAZAKI m_szKeyMacroFileNameã«ãƒ•ã‚¡ã‚¤ãƒ«åãŒã‚³ãƒ”ãƒ¼ã•ã‚Œã¦ã„ã‚‹ã‹ã©ã†ã‹ã€‚
 			if (pShareData->m_Common.m_sMacro.m_szKeyMacroFileName[0] ) {
 				return true;
 			}else{
 				return false;
 			}
 		}
-	case F_LOADKEYMACRO:	/* ƒL[ƒ}ƒNƒ‚Ì“Ç‚İ‚İ */
-		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì‹L˜^’† */
-			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ‹L˜^’†‚ÌƒEƒBƒ“ƒhƒE */
+	case F_LOADKEYMACRO:	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®èª­ã¿è¾¼ã¿ */
+		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ */
+			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’è¨˜éŒ²ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
 				return true;
 			}else{
 				return false;
@@ -1054,14 +1054,14 @@ bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EF
 		}else{
 			return true;
 		}
-	case F_EXECEXTMACRO:	/* –¼‘O‚ğw’è‚µ‚Äƒ}ƒNƒÀs */
+	case F_EXECEXTMACRO:	/* åå‰ã‚’æŒ‡å®šã—ã¦ãƒã‚¯ãƒ­å®Ÿè¡Œ */
 		return true;
 
-	case F_SEARCH_CLEARMARK:	//ŒŸõƒ}[ƒN‚ÌƒNƒŠƒA
+	case F_SEARCH_CLEARMARK:	//æ¤œç´¢ãƒãƒ¼ã‚¯ã®ã‚¯ãƒªã‚¢
 		return true;
 
 	// 02/06/26 ai Start
-	case F_JUMP_SRCHSTARTPOS:	// ŒŸõŠJnˆÊ’u‚Ö–ß‚é
+	case F_JUMP_SRCHSTARTPOS:	// æ¤œç´¢é–‹å§‹ä½ç½®ã¸æˆ»ã‚‹
 		if( pcEditDoc->m_pcEditWnd->GetActiveView().m_ptSrchStartPos_PHY.BothNatural() ){
 			return true;
 		}else{
@@ -1069,24 +1069,24 @@ bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EF
 		}
 	// 02/06/26 ai End
 
-	case F_COMPARE:	/* ƒtƒ@ƒCƒ‹“à—e”äŠr */
+	case F_COMPARE:	/* ãƒ•ã‚¡ã‚¤ãƒ«å†…å®¹æ¯”è¼ƒ */
 		if( 2 <= pShareData->m_sNodes.m_nEditArrNum ){
 			return true;
 		}else{
 			return false;
 		}
 
-	case F_DIFF_NEXT:	/* Ÿ‚Ì·•ª‚Ö */	//@@@ 2002.05.25 MIK
-	case F_DIFF_PREV:	/* ‘O‚Ì·•ª‚Ö */	//@@@ 2002.05.25 MIK
-	case F_DIFF_RESET:	/* ·•ª‚Ì‘S‰ğœ */	//@@@ 2002.05.25 MIK
+	case F_DIFF_NEXT:	/* æ¬¡ã®å·®åˆ†ã¸ */	//@@@ 2002.05.25 MIK
+	case F_DIFF_PREV:	/* å‰ã®å·®åˆ†ã¸ */	//@@@ 2002.05.25 MIK
+	case F_DIFF_RESET:	/* å·®åˆ†ã®å…¨è§£é™¤ */	//@@@ 2002.05.25 MIK
 		if( !CDiffManager::getInstance()->IsDiffUse() ) return false;
 		return true;
-	case F_DIFF_DIALOG:	/* DIFF·•ª•\¦ */	//@@@ 2002.05.25 MIK
+	case F_DIFF_DIALOG:	/* DIFFå·®åˆ†è¡¨ç¤º */	//@@@ 2002.05.25 MIK
 		//if( pcEditDoc->IsModified() ) return false;
 		//if( ! pcEditDoc->m_cDocFile.GetFilePathClass().IsValidPath() ) return false;
 		return true;
 
-	case F_BEGIN_BOX:	//‹éŒ`”ÍˆÍ‘I‘ğŠJn
+	case F_BEGIN_BOX:	//çŸ©å½¢ç¯„å›²é¸æŠé–‹å§‹
 	case F_UP_BOX:
 	case F_DOWN_BOX:
 	case F_LEFT_BOX:
@@ -1104,46 +1104,46 @@ bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EF
 	case F_1PageDown_BOX:
 	case F_GOFILETOP_BOX:
 	case F_GOFILEEND_BOX:
-		if( pShareData->m_Common.m_sView.m_bFontIs_FIXED_PITCH ){	/* Œ»İ‚ÌƒtƒHƒ“ƒg‚ÍŒÅ’è•ƒtƒHƒ“ƒg‚Å‚ ‚é */
+		if( pShareData->m_Common.m_sView.m_bFontIs_FIXED_PITCH ){	/* ç¾åœ¨ã®ãƒ•ã‚©ãƒ³ãƒˆã¯å›ºå®šå¹…ãƒ•ã‚©ãƒ³ãƒˆã§ã‚ã‚‹ */
 			return true;
 		}else{
 			return false;
 		}
 	case F_PASTEBOX:
-		/* ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯‰Â”\‚©H */
+		/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘å¯èƒ½ã‹ï¼Ÿ */
 		if( pcEditDoc->m_cDocEditor.IsEnablePaste() && pShareData->m_Common.m_sView.m_bFontIs_FIXED_PITCH ){
 			return true;
 		}else{
 			return false;
 		}
 	case F_PASTE:
-		/* ƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯‰Â”\‚©H */
+		/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘å¯èƒ½ã‹ï¼Ÿ */
 		if( pcEditDoc->m_cDocEditor.IsEnablePaste() ){
 			return true;
 		}else{
 			return false;
 		}
 
-	case F_FILENEW:	/* V‹Kì¬ */
+	case F_FILENEW:	/* æ–°è¦ä½œæˆ */
 	case F_GREP_DIALOG:	/* Grep */
 	case F_GREP_REPLACE_DLG:
-		/* •ÒWƒEƒBƒ“ƒhƒE‚ÌãŒÀƒ`ƒFƒbƒN */
-		if( pShareData->m_sNodes.m_nEditArrNum >= MAX_EDITWINDOWS ){	//Å‘å’lC³	//@@@ 2003.05.31 MIK
+		/* ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä¸Šé™ãƒã‚§ãƒƒã‚¯ */
+		if( pShareData->m_sNodes.m_nEditArrNum >= MAX_EDITWINDOWS ){	//æœ€å¤§å€¤ä¿®æ­£	//@@@ 2003.05.31 MIK
 			return false;
 		}else{
 			return true;
 		}
 
-	case F_FILESAVE:	/* ã‘‚«•Û‘¶ */
-		if( !CAppMode::getInstance()->IsViewMode() ){	/* ƒrƒ…[ƒ‚[ƒh */
-			if( pcEditDoc->m_cDocEditor.IsModified() ){	/* •ÏXƒtƒ‰ƒO */
+	case F_FILESAVE:	/* ä¸Šæ›¸ãä¿å­˜ */
+		if( !CAppMode::getInstance()->IsViewMode() ){	/* ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ */
+			if( pcEditDoc->m_cDocEditor.IsModified() ){	/* å¤‰æ›´ãƒ•ãƒ©ã‚° */
 				return true;
 			}
-			else if (pcEditDoc->m_cDocFile.IsChgCodeSet()) {	// •¶šƒR[ƒh‚Ì•ÏX
+			else if (pcEditDoc->m_cDocFile.IsChgCodeSet()) {	// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã®å¤‰æ›´
 				return true;
 			}
 			else {
-				/* –³•ÏX‚Å‚àã‘‚«‚·‚é‚© */
+				/* ç„¡å¤‰æ›´ã§ã‚‚ä¸Šæ›¸ãã™ã‚‹ã‹ */
 				if( !pShareData->m_Common.m_sFile.m_bEnableUnmodifiedOverwrite ){
 					return false;
 				}else{
@@ -1153,79 +1153,79 @@ bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EF
 		}else{
 			return false;
 		}
-	case F_COPYLINES:				//‘I‘ğ”ÍˆÍ“à‘SsƒRƒs[
-	case F_COPYLINESASPASSAGE:		//‘I‘ğ”ÍˆÍ“à‘Ssˆø—p•„•t‚«ƒRƒs[
-	case F_COPYLINESWITHLINENUMBER:	//‘I‘ğ”ÍˆÍ“à‘Sss”Ô†•t‚«ƒRƒs[
-	case F_COPY_COLOR_HTML:				//‘I‘ğ”ÍˆÍ“àF•t‚«HTMLƒRƒs[
-	case F_COPY_COLOR_HTML_LINENUMBER:	//‘I‘ğ”ÍˆÍ“às”Ô†F•t‚«HTMLƒRƒs[
-		//ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚ê‚Îtrue
+	case F_COPYLINES:				//é¸æŠç¯„å›²å†…å…¨è¡Œã‚³ãƒ”ãƒ¼
+	case F_COPYLINESASPASSAGE:		//é¸æŠç¯„å›²å†…å…¨è¡Œå¼•ç”¨ç¬¦ä»˜ãã‚³ãƒ”ãƒ¼
+	case F_COPYLINESWITHLINENUMBER:	//é¸æŠç¯„å›²å†…å…¨è¡Œè¡Œç•ªå·ä»˜ãã‚³ãƒ”ãƒ¼
+	case F_COPY_COLOR_HTML:				//é¸æŠç¯„å›²å†…è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼
+	case F_COPY_COLOR_HTML_LINENUMBER:	//é¸æŠç¯„å›²å†…è¡Œç•ªå·è‰²ä»˜ãHTMLã‚³ãƒ”ãƒ¼
+		//ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚Œã°true
 		return pcEditDoc->m_pcEditWnd->GetActiveView().GetSelectionInfo().IsTextSelected();
 
-	case F_TOLOWER:					/* ¬•¶š */
-	case F_TOUPPER:					/* ‘å•¶š */
-	case F_TOHANKAKU:				/* ‘SŠp¨”¼Šp */
-	case F_TOHANKATA:				/* ‘SŠpƒJƒ^ƒJƒi¨”¼ŠpƒJƒ^ƒJƒi */	//Aug. 29, 2002 ai
-	case F_TOZENEI:					/* ”¼Šp‰p”¨‘SŠp‰p” */			//July. 30, 2001 Misaka
-	case F_TOHANEI:					/* ‘SŠp‰p”¨”¼Šp‰p” */
-	case F_TOZENKAKUKATA:			/* ”¼Šp{‘S‚Ğ‚ç¨‘SŠpEƒJƒ^ƒJƒi */	//Sept. 17, 2000 jepro à–¾‚ğu”¼Šp¨‘SŠpƒJƒ^ƒJƒiv‚©‚ç•ÏX
-	case F_TOZENKAKUHIRA:			/* ”¼Šp{‘SƒJƒ^¨‘SŠpE‚Ğ‚ç‚ª‚È */	//Sept. 17, 2000 jepro à–¾‚ğu”¼Šp¨‘SŠp‚Ğ‚ç‚ª‚Èv‚©‚ç•ÏX
-	case F_HANKATATOZENKATA:		/* ”¼ŠpƒJƒ^ƒJƒi¨‘SŠpƒJƒ^ƒJƒi */
-	case F_HANKATATOZENHIRA:		/* ”¼ŠpƒJƒ^ƒJƒi¨‘SŠp‚Ğ‚ç‚ª‚È */
-	case F_TABTOSPACE:				/* TAB¨‹ó”’ */
-	case F_SPACETOTAB:				/* ‹ó”’¨TAB */  //---- Stonee, 2001/05/27
-	case F_CODECNV_AUTO2SJIS:		/* ©“®”»•Ê¨SJISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_EMAIL:			/* E-Mail(JIS¨SJIS)ƒR[ƒh•ÏŠ· */
-	case F_CODECNV_EUC2SJIS:		/* EUC¨SJISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_UNICODE2SJIS:	/* Unicode¨SJISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_UNICODEBE2SJIS:	/* UnicodeBE¨SJISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_UTF82SJIS:		/* UTF-8¨SJISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_UTF72SJIS:		/* UTF-7¨SJISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_SJIS2JIS:		/* SJIS¨JISƒR[ƒh•ÏŠ· */
-	case F_CODECNV_SJIS2EUC:		/* SJIS¨EUCƒR[ƒh•ÏŠ· */
-	case F_CODECNV_SJIS2UTF8:		/* SJIS¨UTF-8ƒR[ƒh•ÏŠ· */
-	case F_CODECNV_SJIS2UTF7:		/* SJIS¨UTF-7ƒR[ƒh•ÏŠ· */
-	case F_BASE64DECODE:			/* Base64ƒfƒR[ƒh‚µ‚Ä•Û‘¶ */
-	case F_UUDECODE:				//uudecode‚µ‚Ä•Û‘¶	//Oct. 17, 2000 jepro à–¾‚ğu‘I‘ğ•”•ª‚ğUUENCODEƒfƒR[ƒhv‚©‚ç•ÏX
-		// ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚ê‚Îtrue
+	case F_TOLOWER:					/* å°æ–‡å­— */
+	case F_TOUPPER:					/* å¤§æ–‡å­— */
+	case F_TOHANKAKU:				/* å…¨è§’â†’åŠè§’ */
+	case F_TOHANKATA:				/* å…¨è§’ã‚«ã‚¿ã‚«ãƒŠâ†’åŠè§’ã‚«ã‚¿ã‚«ãƒŠ */	//Aug. 29, 2002 ai
+	case F_TOZENEI:					/* åŠè§’è‹±æ•°â†’å…¨è§’è‹±æ•° */			//July. 30, 2001 Misaka
+	case F_TOHANEI:					/* å…¨è§’è‹±æ•°â†’åŠè§’è‹±æ•° */
+	case F_TOZENKAKUKATA:			/* åŠè§’ï¼‹å…¨ã²ã‚‰â†’å…¨è§’ãƒ»ã‚«ã‚¿ã‚«ãƒŠ */	//Sept. 17, 2000 jepro èª¬æ˜ã‚’ã€ŒåŠè§’â†’å…¨è§’ã‚«ã‚¿ã‚«ãƒŠã€ã‹ã‚‰å¤‰æ›´
+	case F_TOZENKAKUHIRA:			/* åŠè§’ï¼‹å…¨ã‚«ã‚¿â†’å…¨è§’ãƒ»ã²ã‚‰ãŒãª */	//Sept. 17, 2000 jepro èª¬æ˜ã‚’ã€ŒåŠè§’â†’å…¨è§’ã²ã‚‰ãŒãªã€ã‹ã‚‰å¤‰æ›´
+	case F_HANKATATOZENKATA:		/* åŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã‚«ã‚¿ã‚«ãƒŠ */
+	case F_HANKATATOZENHIRA:		/* åŠè§’ã‚«ã‚¿ã‚«ãƒŠâ†’å…¨è§’ã²ã‚‰ãŒãª */
+	case F_TABTOSPACE:				/* TABâ†’ç©ºç™½ */
+	case F_SPACETOTAB:				/* ç©ºç™½â†’TAB */  //---- Stonee, 2001/05/27
+	case F_CODECNV_AUTO2SJIS:		/* è‡ªå‹•åˆ¤åˆ¥â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_EMAIL:			/* E-Mail(JISâ†’SJIS)ã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_EUC2SJIS:		/* EUCâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_UNICODE2SJIS:	/* Unicodeâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_UNICODEBE2SJIS:	/* UnicodeBEâ†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_UTF82SJIS:		/* UTF-8â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_UTF72SJIS:		/* UTF-7â†’SJISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_SJIS2JIS:		/* SJISâ†’JISã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_SJIS2EUC:		/* SJISâ†’EUCã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_SJIS2UTF8:		/* SJISâ†’UTF-8ã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_CODECNV_SJIS2UTF7:		/* SJISâ†’UTF-7ã‚³ãƒ¼ãƒ‰å¤‰æ› */
+	case F_BASE64DECODE:			/* Base64ãƒ‡ã‚³ãƒ¼ãƒ‰ã—ã¦ä¿å­˜ */
+	case F_UUDECODE:				//uudecodeã—ã¦ä¿å­˜	//Oct. 17, 2000 jepro èª¬æ˜ã‚’ã€Œé¸æŠéƒ¨åˆ†ã‚’UUENCODEãƒ‡ã‚³ãƒ¼ãƒ‰ã€ã‹ã‚‰å¤‰æ›´
+		// ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚Œã°true
 		return pcEditDoc->m_pcEditWnd->GetActiveView().GetSelectionInfo().IsTextSelected();
 
-	case F_CUT_LINE:	//sØ‚èæ‚è(Ü‚è•Ô‚µ’PˆÊ)
-	case F_DELETE_LINE:	//síœ(Ü‚è•Ô‚µ’PˆÊ)
-		// ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚È‚¯‚ê‚Îtrue
+	case F_CUT_LINE:	//è¡Œåˆ‡ã‚Šå–ã‚Š(æŠ˜ã‚Šè¿”ã—å˜ä½)
+	case F_DELETE_LINE:	//è¡Œå‰Šé™¤(æŠ˜ã‚Šè¿”ã—å˜ä½)
+		// ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ãªã‘ã‚Œã°true
 		return !pcEditDoc->m_pcEditWnd->GetActiveView().GetSelectionInfo().IsTextSelected();
 
-	case F_UNDO:		return pcEditDoc->m_cDocEditor.IsEnableUndo();	/* Undo(Œ³‚É–ß‚·)‰Â”\‚Èó‘Ô‚©H */
-	case F_REDO:		return pcEditDoc->m_cDocEditor.IsEnableRedo();	/* Redo(‚â‚è’¼‚µ)‰Â”\‚Èó‘Ô‚©H */
+	case F_UNDO:		return pcEditDoc->m_cDocEditor.IsEnableUndo();	/* Undo(å…ƒã«æˆ»ã™)å¯èƒ½ãªçŠ¶æ…‹ã‹ï¼Ÿ */
+	case F_REDO:		return pcEditDoc->m_cDocEditor.IsEnableRedo();	/* Redo(ã‚„ã‚Šç›´ã—)å¯èƒ½ãªçŠ¶æ…‹ã‹ï¼Ÿ */
 
 	case F_COPYPATH:
 	case F_COPYTAG:
 	case F_COPYFNAME:					// 2002/2/3 aroka
-	case F_OPEN_HfromtoC:				//“¯–¼‚ÌC/C++ƒwƒbƒ_(ƒ\[ƒX)‚ğŠJ‚­	//Feb. 7, 2001 JEPRO ’Ç‰Á
-//	case F_OPEN_HHPP:					//“¯–¼‚ÌC/C++ƒwƒbƒ_ƒtƒ@ƒCƒ‹‚ğŠJ‚­	//Feb. 9, 2001 jeprou.c‚Ü‚½‚Í.cpp‚Æ“¯–¼‚Ì.h‚ğŠJ‚­v‚©‚ç•ÏX		del 2008/6/23 Uchi
-//	case F_OPEN_CCPP:					//“¯–¼‚ÌC/C++ƒ\[ƒXƒtƒ@ƒCƒ‹‚ğŠJ‚­	//Feb. 9, 2001 jeprou.h‚Æ“¯–¼‚Ì.c(‚È‚¯‚ê‚Î.cpp)‚ğŠJ‚­v‚©‚ç•ÏX	del 2008/6/23 Uchi
-	case F_PLSQL_COMPILE_ON_SQLPLUS:	/* Oracle SQL*Plus‚ÅÀs */
-	case F_BROWSE:						//ƒuƒ‰ƒEƒY
-	//case F_VIEWMODE:					//ƒrƒ…[ƒ‚[ƒh	//	Sep. 10, 2002 genta í‚Ég‚¦‚é‚æ‚¤‚É
-	//case F_PROPERTY_FILE:				//ƒtƒ@ƒCƒ‹‚ÌƒvƒƒpƒeƒB	// 2009.04.11 ryoji ƒRƒƒ“ƒgƒAƒEƒg
-		return pcEditDoc->m_cDocFile.GetFilePathClass().IsValidPath();	// Œ»İ•ÒW’†‚Ìƒtƒ@ƒCƒ‹‚ÌƒpƒX–¼‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[‚Å‚«‚é‚©
+	case F_OPEN_HfromtoC:				//åŒåã®C/C++ãƒ˜ãƒƒãƒ€(ã‚½ãƒ¼ã‚¹)ã‚’é–‹ã	//Feb. 7, 2001 JEPRO è¿½åŠ 
+//	case F_OPEN_HHPP:					//åŒåã®C/C++ãƒ˜ãƒƒãƒ€ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã	//Feb. 9, 2001 jeproã€Œ.cã¾ãŸã¯.cppã¨åŒåã®.hã‚’é–‹ãã€ã‹ã‚‰å¤‰æ›´		del 2008/6/23 Uchi
+//	case F_OPEN_CCPP:					//åŒåã®C/C++ã‚½ãƒ¼ã‚¹ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã	//Feb. 9, 2001 jeproã€Œ.hã¨åŒåã®.c(ãªã‘ã‚Œã°.cpp)ã‚’é–‹ãã€ã‹ã‚‰å¤‰æ›´	del 2008/6/23 Uchi
+	case F_PLSQL_COMPILE_ON_SQLPLUS:	/* Oracle SQL*Plusã§å®Ÿè¡Œ */
+	case F_BROWSE:						//ãƒ–ãƒ©ã‚¦ã‚º
+	//case F_VIEWMODE:					//ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰	//	Sep. 10, 2002 genta å¸¸ã«ä½¿ãˆã‚‹ã‚ˆã†ã«
+	//case F_PROPERTY_FILE:				//ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£	// 2009.04.11 ryoji ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆ
+		return pcEditDoc->m_cDocFile.GetFilePathClass().IsValidPath();	// ç¾åœ¨ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹åã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼ã§ãã‚‹ã‹
 
-	case F_JUMPHIST_PREV:	//	ˆÚ“®—š—ğ: ‘O‚Ö
+	case F_JUMPHIST_PREV:	//	ç§»å‹•å±¥æ­´: å‰ã¸
 		if( pcEditDoc->m_pcEditWnd->GetActiveView().m_cHistory->CheckPrev() )
 			return true;
 		else
 			return false;
-	case F_JUMPHIST_NEXT:	//	ˆÚ“®—š—ğ: Ÿ‚Ö
+	case F_JUMPHIST_NEXT:	//	ç§»å‹•å±¥æ­´: æ¬¡ã¸
 		if( pcEditDoc->m_pcEditWnd->GetActiveView().m_cHistory->CheckNext() )
 			return true;
 		else
 			return false;
-	case F_JUMPHIST_SET:	//	Œ»İˆÊ’u‚ğˆÚ“®—š—ğ‚É“o˜^
+	case F_JUMPHIST_SET:	//	ç¾åœ¨ä½ç½®ã‚’ç§»å‹•å±¥æ­´ã«ç™»éŒ²
 		return true;
-	// 20100402 Moca (–³‘è)‚àƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv‚Å‚«‚é‚æ‚¤‚É
-	case F_DIRECT_TAGJUMP:	//ƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv	//@@@ 2003.04.15 MIK
-	case F_TAGJUMP_KEYWORD:	//ƒL[ƒ[ƒh‚ğw’è‚µ‚Äƒ_ƒCƒŒƒNƒgƒ^ƒOƒWƒƒƒ“ƒv	//@@@ 2005.03.31 MIK
-	//	2003.05.12 MIK ƒ^ƒOƒtƒ@ƒCƒ‹ì¬æ‚ğ‘I‚×‚é‚æ‚¤‚É‚µ‚½‚Ì‚ÅAí‚Éì¬‰Â”\‚Æ‚·‚é
-//	case F_TAGS_MAKE:	//ƒ^ƒOƒtƒ@ƒCƒ‹‚Ìì¬	//@@@ 2003.04.13 MIK
+	// 20100402 Moca (ç„¡é¡Œ)ã‚‚ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã§ãã‚‹ã‚ˆã†ã«
+	case F_DIRECT_TAGJUMP:	//ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—	//@@@ 2003.04.15 MIK
+	case F_TAGJUMP_KEYWORD:	//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’æŒ‡å®šã—ã¦ãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—	//@@@ 2005.03.31 MIK
+	//	2003.05.12 MIK ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ä½œæˆå…ˆã‚’é¸ã¹ã‚‹ã‚ˆã†ã«ã—ãŸã®ã§ã€å¸¸ã«ä½œæˆå¯èƒ½ã¨ã™ã‚‹
+//	case F_TAGS_MAKE:	//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆ	//@@@ 2003.04.13 MIK
 		if( false == CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode
 			&& pcEditDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 			return true;
@@ -1233,28 +1233,28 @@ bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EF
 			return false;
 		}
 	
-	//ƒ^ƒuƒ‚[ƒh‚ÍƒEƒCƒ“ƒhƒE•À‚×‘Ö‚¦‹Ö~‚Å‚·B	@@@ 2003.06.12 MIK
+	//ã‚¿ãƒ–ãƒ¢ãƒ¼ãƒ‰æ™‚ã¯ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ä¸¦ã¹æ›¿ãˆç¦æ­¢ã§ã™ã€‚	@@@ 2003.06.12 MIK
 	case F_TILE_H:
 	case F_TILE_V:
 	case F_CASCADE:
-		//Start 2004.07.15 Kazika ƒ^ƒuƒEƒBƒ“ƒh‚àÀs‰Â”\
+		//Start 2004.07.15 Kazika ã‚¿ãƒ–ã‚¦ã‚£ãƒ³ãƒ‰æ™‚ã‚‚å®Ÿè¡Œå¯èƒ½
 		return true;
 		//End 2004.07.15 Kazika
-	case F_BIND_WINDOW:	//2004.07.14 Kazika V‹K’Ç‰Á
-	case F_TAB_MOVERIGHT:	// 2007.06.20 ryoji ’Ç‰Á
-	case F_TAB_MOVELEFT:	// 2007.06.20 ryoji ’Ç‰Á
-	case F_TAB_CLOSELEFT:	// 2009.12.26 syat ’Ç‰Á
-	case F_TAB_CLOSERIGHT:	// 2009.12.26 syat ’Ç‰Á
-		//”ñƒ^ƒuƒ‚[ƒh‚ÍƒEƒBƒ“ƒhƒE‚ğŒ‹‡‚µ‚Ä•\¦‚Å‚«‚È‚¢
+	case F_BIND_WINDOW:	//2004.07.14 Kazika æ–°è¦è¿½åŠ 
+	case F_TAB_MOVERIGHT:	// 2007.06.20 ryoji è¿½åŠ 
+	case F_TAB_MOVELEFT:	// 2007.06.20 ryoji è¿½åŠ 
+	case F_TAB_CLOSELEFT:	// 2009.12.26 syat è¿½åŠ 
+	case F_TAB_CLOSERIGHT:	// 2009.12.26 syat è¿½åŠ 
+		//éã‚¿ãƒ–ãƒ¢ãƒ¼ãƒ‰æ™‚ã¯ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’çµåˆã—ã¦è¡¨ç¤ºã§ããªã„
 		return pShareData->m_Common.m_sTabBar.m_bDispTabWnd != FALSE;
-	case F_GROUPCLOSE:		// 2007.06.20 ryoji ’Ç‰Á
-	case F_NEXTGROUP:		// 2007.06.20 ryoji ’Ç‰Á
-	case F_PREVGROUP:		// 2007.06.20 ryoji ’Ç‰Á
+	case F_GROUPCLOSE:		// 2007.06.20 ryoji è¿½åŠ 
+	case F_NEXTGROUP:		// 2007.06.20 ryoji è¿½åŠ 
+	case F_PREVGROUP:		// 2007.06.20 ryoji è¿½åŠ 
 		return ( pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin );
-	case F_TAB_SEPARATE:	// 2007.06.20 ryoji ’Ç‰Á
-	case F_TAB_JOINTNEXT:	// 2007.06.20 ryoji ’Ç‰Á
-	case F_TAB_JOINTPREV:	// 2007.06.20 ryoji ’Ç‰Á
-	case F_FILENEW_NEWWINDOW:	// 2011.11.15 syat ’Ç‰Á
+	case F_TAB_SEPARATE:	// 2007.06.20 ryoji è¿½åŠ 
+	case F_TAB_JOINTNEXT:	// 2007.06.20 ryoji è¿½åŠ 
+	case F_TAB_JOINTPREV:	// 2007.06.20 ryoji è¿½åŠ 
+	case F_FILENEW_NEWWINDOW:	// 2011.11.15 syat è¿½åŠ 
 		return ( pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin );
 	}
 	return true;
@@ -1262,13 +1262,13 @@ bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EF
 
 
 
-/* ‹@”\‚ªƒ`ƒFƒbƒNó‘Ô‚©’²‚×‚é */
+/* æ©Ÿèƒ½ãŒãƒã‚§ãƒƒã‚¯çŠ¶æ…‹ã‹èª¿ã¹ã‚‹ */
 bool IsFuncChecked( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EFunctionCode nId )
 {
 	CEditWnd* pCEditWnd;
 	// Modified by KEITA for WIN64 2003.9.6
 	pCEditWnd = ( CEditWnd* )::GetWindowLongPtr( CEditWnd::getInstance()->GetHwnd(), GWLP_USERDATA );
-//@@@ 2002.01.14 YAZAKI ˆóüƒvƒŒƒrƒ…[‚ğCPrintPreview‚É“Æ—§‚³‚¹‚½‚±‚Æ‚É‚æ‚èAƒvƒŒƒrƒ…[”»’èíœ
+//@@@ 2002.01.14 YAZAKI å°åˆ·ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼ã‚’CPrintPreviewã«ç‹¬ç«‹ã•ã›ãŸã“ã¨ã«ã‚ˆã‚Šã€ãƒ—ãƒ¬ãƒ“ãƒ¥ãƒ¼åˆ¤å®šå‰Šé™¤
 	ECodeType eDocCode = pcEditDoc->GetDocumentEncoding();
 	switch( nId ){
 	case F_FILE_REOPEN_SJIS:		return CODE_SJIS == eDocCode;
@@ -1280,9 +1280,9 @@ bool IsFuncChecked( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, E
 	case F_FILE_REOPEN_UTF8:		return CODE_UTF8 == eDocCode;
 	case F_FILE_REOPEN_CESU8:		return CODE_CESU8 == eDocCode;
 	case F_FILE_REOPEN_UTF7:		return CODE_UTF7 == eDocCode;
-	case F_RECKEYMACRO:	/* ƒL[ƒ}ƒNƒ‚Ì‹L˜^ŠJn^I—¹ */
-		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚Ì‹L˜^’† */
-			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ğ‹L˜^’†‚ÌƒEƒBƒ“ƒhƒE */
+	case F_RECKEYMACRO:	/* ã‚­ãƒ¼ãƒã‚¯ãƒ­ã®è¨˜éŒ²é–‹å§‹ï¼çµ‚äº† */
+		if( pShareData->m_sFlags.m_bRecordingKeyMacro ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®è¨˜éŒ²ä¸­ */
+			if( pShareData->m_sFlags.m_hwndRecordingKeyMacro == CEditWnd::getInstance()->GetHwnd() ){	/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã‚’è¨˜éŒ²ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
 				return true;
 			}else{
 				return false;
@@ -1295,27 +1295,27 @@ bool IsFuncChecked( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, E
 	case F_SHOWTAB:				return pCEditWnd->m_cTabWnd.GetHwnd() != NULL;	//@@@ 2003.06.10 MIK
 	case F_SHOWSTATUSBAR:		return pCEditWnd->m_cStatusBar.GetStatusHwnd() != NULL;
 	case F_SHOWMINIMAP:			return pCEditWnd->GetMiniMap().GetHwnd() != NULL;
-	// 2008.05.30 nasukoji	ƒeƒLƒXƒg‚ÌÜ‚è•Ô‚µ•û–@
-	case F_TMPWRAPNOWRAP:		return ( pcEditDoc->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP );		// Ü‚è•Ô‚³‚È‚¢
-	case F_TMPWRAPSETTING:		return ( pcEditDoc->m_nTextWrapMethodCur == WRAP_SETTING_WIDTH );		// w’èŒ…‚ÅÜ‚è•Ô‚·
-	case F_TMPWRAPWINDOW:		return ( pcEditDoc->m_nTextWrapMethodCur == WRAP_WINDOW_WIDTH );		// ‰E’[‚ÅÜ‚è•Ô‚·
-	// 2009.07.06 syat  •¶šƒJƒEƒ“ƒg•û–@
+	// 2008.05.30 nasukoji	ãƒ†ã‚­ã‚¹ãƒˆã®æŠ˜ã‚Šè¿”ã—æ–¹æ³•
+	case F_TMPWRAPNOWRAP:		return ( pcEditDoc->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP );		// æŠ˜ã‚Šè¿”ã•ãªã„
+	case F_TMPWRAPSETTING:		return ( pcEditDoc->m_nTextWrapMethodCur == WRAP_SETTING_WIDTH );		// æŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™
+	case F_TMPWRAPWINDOW:		return ( pcEditDoc->m_nTextWrapMethodCur == WRAP_WINDOW_WIDTH );		// å³ç«¯ã§æŠ˜ã‚Šè¿”ã™
+	// 2009.07.06 syat  æ–‡å­—ã‚«ã‚¦ãƒ³ãƒˆæ–¹æ³•
 	case F_SELECT_COUNT_MODE:	return ( pCEditWnd->m_nSelectCountMode == SELECT_COUNT_TOGGLE ?
 											pShareData->m_Common.m_sStatusbar.m_bDispSelCountByByte != FALSE :
 											pCEditWnd->m_nSelectCountMode == SELECT_COUNT_BY_BYTE );
 	// Mar. 6, 2002 genta
-	case F_VIEWMODE:			return CAppMode::getInstance()->IsViewMode(); //ƒrƒ…[ƒ‚[ƒh
+	case F_VIEWMODE:			return CAppMode::getInstance()->IsViewMode(); //ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰
 	//	From Here 2003.06.23 Moca
 	case F_CHGMOD_EOL_CRLF:		return EOL_CRLF == pcEditDoc->m_cDocEditor.GetNewLineCode();
 	case F_CHGMOD_EOL_LF:		return EOL_LF == pcEditDoc->m_cDocEditor.GetNewLineCode();
 	case F_CHGMOD_EOL_CR:		return EOL_CR == pcEditDoc->m_cDocEditor.GetNewLineCode();
 	//	To Here 2003.06.23 Moca
 	//	2003.07.21 genta
-	case F_CHGMOD_INS:			return pcEditDoc->m_cDocEditor.IsInsMode();	//	Oct. 2, 2005 genta ‘}“üƒ‚[ƒh‚ÍƒhƒLƒ…ƒƒ“ƒg–ˆ‚É•âŠ®‚·‚é‚æ‚¤‚É•ÏX‚µ‚½
-	case F_TOGGLE_KEY_SEARCH:	return pShareData->m_Common.m_sSearch.m_bUseCaretKeyWord != FALSE;	//	2007.02.03 genta ƒL[ƒ[ƒhƒ|ƒbƒvƒAƒbƒv‚ÌON/OFFó‘Ô‚ğ”½‰f‚·‚é
-	case F_BIND_WINDOW:			return ((pShareData->m_Common.m_sTabBar.m_bDispTabWnd) && !(pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin));	//2004.07.14 Kazika ’Ç‰Á
+	case F_CHGMOD_INS:			return pcEditDoc->m_cDocEditor.IsInsMode();	//	Oct. 2, 2005 genta æŒ¿å…¥ãƒ¢ãƒ¼ãƒ‰ã¯ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆæ¯ã«è£œå®Œã™ã‚‹ã‚ˆã†ã«å¤‰æ›´ã—ãŸ
+	case F_TOGGLE_KEY_SEARCH:	return pShareData->m_Common.m_sSearch.m_bUseCaretKeyWord != FALSE;	//	2007.02.03 genta ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒãƒƒãƒ—ã‚¢ãƒƒãƒ—ã®ON/OFFçŠ¶æ…‹ã‚’åæ˜ ã™ã‚‹
+	case F_BIND_WINDOW:			return ((pShareData->m_Common.m_sTabBar.m_bDispTabWnd) && !(pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin));	//2004.07.14 Kazika è¿½åŠ 
 	case F_TOPMOST:				return ((DWORD)::GetWindowLongPtr( pCEditWnd->GetHwnd(), GWL_EXSTYLE ) & WS_EX_TOPMOST) != 0;	// 2004.09.21 Moca
-	// Jan. 10, 2004 genta ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`
+	// Jan. 10, 2004 genta ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ
 	case F_ISEARCH_NEXT:
 	case F_ISEARCH_PREV:
 	case F_ISEARCH_REGEXP_NEXT:
@@ -1323,8 +1323,8 @@ bool IsFuncChecked( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, E
 	case F_ISEARCH_MIGEMO_NEXT:
 	case F_ISEARCH_MIGEMO_PREV:
 		return pcEditDoc->m_pcEditWnd->GetActiveView().IsISearchEnabled( nId );
-	case F_OUTLINE_TOGGLE: // 20060201 aroka ƒAƒEƒgƒ‰ƒCƒ“ƒEƒBƒ“ƒhƒE
-		// ToDo:ƒuƒbƒNƒ}[ƒNƒŠƒXƒg‚ªo‚Ä‚¢‚é‚Æ‚«‚à‚Ö‚±‚ñ‚Å‚µ‚Ü‚¤B
+	case F_OUTLINE_TOGGLE: // 20060201 aroka ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+		// ToDo:ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ãƒªã‚¹ãƒˆãŒå‡ºã¦ã„ã‚‹ã¨ãã‚‚ã¸ã“ã‚“ã§ã—ã¾ã†ã€‚
 		return pcEditDoc->m_pcEditWnd->m_cDlgFuncList.GetHwnd() != NULL;
 	}
 	//End 2004.07.14 Kazika

--- a/sakura_core/func/Funccode.h
+++ b/sakura_core/func/Funccode.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief �@�\�ԍ���`
+﻿/*!	@file
+	@brief 機能番号定義
 
 	@author Norio Nakatani
 */
@@ -8,10 +8,10 @@
 	Copyright (C) 2000, jepro, genta
 	Copyright (C) 2001, jepro, MIK, Stonee, asa-o, Misaka, hor
 	Copyright (C) 2002, aroka, YAZAKI, minfu, MIK, ai, genta
-	Copyright (C) 2003, �S, genta, MIK, Moca
+	Copyright (C) 2003, 鬼, genta, MIK, Moca
 	Copyright (C) 2004, genta, zenryaku, kazika, Moca, isearch
 	Copyright (C) 2005, genta, MIK, maru
-	Copyright (C) 2006, aroka, �����, fon, ryoji
+	Copyright (C) 2006, aroka, かろと, fon, ryoji
 	Copyright (C) 2007, ryoji, genta
 
 	This software is provided 'as-is', without any express or implied
@@ -38,49 +38,49 @@
 #ifndef _FUNCCODE_H_
 #define _FUNCCODE_H_
 
-//Oct. 17, 2000 jepro  F_FILECLOSE:�u�t�@�C�������v�Ƃ����L���v�V������ύX
+//Oct. 17, 2000 jepro  F_FILECLOSE:「ファイルを閉じる」というキャプションを変更
 //Feb. 28, 2004 genta  F_FILESAVECLOSE
 //Jan. 24, 2005 genta  F_FILESAVEALL
 //Jan. 24, 2005 genta  F_FILESAVE_QUIET
-//2007.02.13    ryoji  F_EXITALLEDITORS�ǉ�
-//Sep. 14, 2000 jepro  F_PRINT_PAGESETUP:�u����̃y�[�W���C�A�E�g�̐ݒ�v����u����y�[�W�ݒ�v�ɕύX 
-//Feb.  9, 2001 jepro  F_OPEN_HHPP�u.c�܂���.cpp�Ɠ�����.h���J���v����ύX
-//Feb.  9, 2001 jepro  F_OPEN_CCPP�u.h�Ɠ�����.c(�Ȃ����.cpp)���J���v����ύX
-//Feb.  7, 2001 JEPRO  F_OPEN_HfromtoC �ǉ�
-//Sep. 17, 2000 jepro  F_PLSQL_COMPILE_ON_SQLPLUS �����́u�R���p�C���v���u���s�v�ɓ���
-//Dec. 27, 2000 JEPRO  F_EXITALL�ǉ�
-//2007.09.02 kobake �p�����[�^��wchar_t�ŗ��邱�Ƃ���������悤�A���O�� F_CHAR ���� F_WCHAR �ɕύX
+//2007.02.13    ryoji  F_EXITALLEDITORS追加
+//Sep. 14, 2000 jepro  F_PRINT_PAGESETUP:「印刷のページレイアウトの設定」から「印刷ページ設定」に変更 
+//Feb.  9, 2001 jepro  F_OPEN_HHPP「.cまたは.cppと同名の.hを開く」から変更
+//Feb.  9, 2001 jepro  F_OPEN_CCPP「.hと同名の.c(なければ.cpp)を開く」から変更
+//Feb.  7, 2001 JEPRO  F_OPEN_HfromtoC 追加
+//Sep. 17, 2000 jepro  F_PLSQL_COMPILE_ON_SQLPLUS 説明の「コンパイル」を「実行」に統一
+//Dec. 27, 2000 JEPRO  F_EXITALL追加
+//2007.09.02 kobake パラメータがwchar_tで来ることを示唆するよう、名前を F_CHAR から F_WCHAR に変更
 //2001.12.03 hor    F_LTRIM
 //2001.12.03 hor    F_RTRIM
 //2001.12.06 hor    F_SORT_ASC
 //2001.12.06 hor    F_SORT_DESC
 //2001.12.06 hor    F_MERGE
 //2002.04.09 minfu  F_RECONVERT
-//Dec. 4, 2002 genta F_FILE_REOPEN�`
-//Oct. 10, 2000 JEPRO F_ROLLDOWN     ���̔��y�[�W�A�b�v�ɖ��̕ύX
-//Oct. 10, 2000 JEPRO F_ROLLUP       ���̔��y�[�W�_�E���ɖ��̕ύX
-//Oct.  6, 2000 JEPRO F_HalfPageUp   ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-//Oct.  6, 2000 JEPRO F_HalfPageDown ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-//Oct. 10, 2000 JEPRO F_1PageUp      �]���̃y�[�W�A�b�v�𔼃y�[�W�A�b�v�Ɩ��̕ύX���P�y�[�W�A�b�v��ǉ�
-//Oct. 10, 2000 JEPRO F_1PageDown    �]���̃y�[�W�_�E���𔼃y�[�W�_�E���Ɩ��̕ύX���P�y�[�W�_�E����ǉ�
+//Dec. 4, 2002 genta F_FILE_REOPEN～
+//Oct. 10, 2000 JEPRO F_ROLLDOWN     下の半ページアップに名称変更
+//Oct. 10, 2000 JEPRO F_ROLLUP       下の半ページダウンに名称変更
+//Oct.  6, 2000 JEPRO F_HalfPageUp   名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+//Oct.  6, 2000 JEPRO F_HalfPageDown 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+//Oct. 10, 2000 JEPRO F_1PageUp      従来のページアップを半ページアップと名称変更し１ページアップを追加
+//Oct. 10, 2000 JEPRO F_1PageDown    従来のページダウンを半ページダウンと名称変更し１ページダウンを追加
 //2001/06/20 asa-o F_WndScrollDown
 //2001/06/20 asa-o F_WndScrollUp
-//Oct. 10, 2000 JEPRO F_ROLLDOWN_SEL     ���̔��y�[�W�A�b�v�ɖ��̕ύX
-//Oct. 10, 2000 JEPRO F_ROLLUP_SEL       ���̔��y�[�W�_�E���ɖ��̕ύX
-//Oct.  6, 2000 JEPRO F_HalfPageUp_Sel   ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-//Oct.  6, 2000 JEPRO F_HalfPageDown_Sel ���̂�PC-AT�݊��@�n�ɕύX(ROLL��PAGE) //Oct. 10, 2000 JEPRO ���̕ύX
-//Oct. 10, 2000 JEPRO F_1PageUp_Sel      �]���̃y�[�W�A�b�v�𔼃y�[�W�A�b�v�Ɩ��̕ύX���P�y�[�W�A�b�v��ǉ�
-//Oct. 10, 2000 JEPRO F_1PageDown_Sel    �]���̃y�[�W�_�E���𔼃y�[�W�_�E���Ɩ��̕ύX���P�y�[�W�_�E����ǉ�
+//Oct. 10, 2000 JEPRO F_ROLLDOWN_SEL     下の半ページアップに名称変更
+//Oct. 10, 2000 JEPRO F_ROLLUP_SEL       下の半ページダウンに名称変更
+//Oct.  6, 2000 JEPRO F_HalfPageUp_Sel   名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+//Oct.  6, 2000 JEPRO F_HalfPageDown_Sel 名称をPC-AT互換機系に変更(ROLL→PAGE) //Oct. 10, 2000 JEPRO 名称変更
+//Oct. 10, 2000 JEPRO F_1PageUp_Sel      従来のページアップを半ページアップと名称変更し１ページアップを追加
+//Oct. 10, 2000 JEPRO F_1PageDown_Sel    従来のページダウンを半ページダウンと名称変更し１ページダウンを追加
 //2002/2/3 aroka F_COPYFNAME
-//Sept. 15, 2000 JEPRO F_CREATEKEYBINDLIST ��̍s��IDM_TEST�̂܂܂ł͂��܂������Ȃ��̂�F�ɕς��ēo�^
+//Sept. 15, 2000 JEPRO F_CREATEKEYBINDLIST 上の行はIDM_TESTのままではうまくいかないのでFに変えて登録
 //2002.06.02     MIK    F_CTRL_CODE_DIALOG			
 //Aug. 29, 2002  ai     F_TOHANKATA				 	
-//Sep. 17, 2000  jepro  F_TOZENKAKUKATA �������u���p���S�p�J�^�J�i�v����ύX
-//Sep. 17, 2000  jepro  F_TOZENKAKUHIRA �������u���p���S�p�Ђ炪�ȁv����ύX
+//Sep. 17, 2000  jepro  F_TOZENKAKUKATA 説明を「半角→全角カタカナ」から変更
+//Sep. 17, 2000  jepro  F_TOZENKAKUHIRA 説明を「半角→全角ひらがな」から変更
 //Jly. 30, 2001  Misaka F_TOZENEI					
 //2002.2.11      YAZAKI F_TOHANEI							
 //2001/05/27     Stonee F_SPACETOTAB		
-//Oct. 17, 2000  jepro  F_UUDECODE �������u�I�𕔕���UUENCODE�f�R�[�h�v����ύX
+//Oct. 17, 2000  jepro  F_UUDECODE 説明を「選択部分をUUENCODEデコード」から変更
 //02/06/26 ai F_JUMP_SRCHSTARTPOS		
 //2002.06.15 MIK F_SEARCH_BOX			
 //20060201 aroka F_OUTLINE_TOGGLE	 
@@ -108,20 +108,20 @@
 //2006.04.26 maru F_TRACEOUT            	
 //2003.06.10 MIK F_SHOWTAB			 	
 //2003.04.08 MIK F_FAVORITE				
-//Stonee, 2001/05/18 �ݒ�_�C�A���O�p�̋@�\�ԍ���p�� F_TYPE_SCREEN�`F_OPTION_HELPER
-//Jul. 03, 2001 JEPRO �ǉ� F_TYPE_HELPER		 	
+//Stonee, 2001/05/18 設定ダイアログ用の機能番号を用意 F_TYPE_SCREEN～F_OPTION_HELPER
+//Jul. 03, 2001 JEPRO 追加 F_TYPE_HELPER		 	
 //2001.11.17 add MIK F_TYPE_REGEX_KEYWORD	 	
-//2006.10.06 ryoji �ǉ� F_TYPE_KEYHELP		 	
-//Feb. 11, 2007 genta �ǉ� F_OPTION_TAB		 
-//Oct. 7, 2000 JEPRO  F_WRAPWINDOWWIDTH  WRAPWINDIWWIDTH �� WRAPWINDOWWIDTH �ɕύX
-//Sept. 17, 2000 jepro �����́u�c�v���u�㉺�Ɂv�ɕύX F_SPLIT_V				
-//Sept. 17, 2000 jepro �����́u���v���u���E�Ɂv�ɕύX F_SPLIT_H				
-//Sept. 17, 2000 jepro �����Ɂu�Ɂv��ǉ� F_SPLIT_VH				
-//Oct. 17, 2000 JEPRO ���O��ύX(F_FILECLOSEALL��F_WIN_CLOSEALL) F_WIN_CLOSEALL			
+//2006.10.06 ryoji 追加 F_TYPE_KEYHELP		 	
+//Feb. 11, 2007 genta 追加 F_OPTION_TAB		 
+//Oct. 7, 2000 JEPRO  F_WRAPWINDOWWIDTH  WRAPWINDIWWIDTH を WRAPWINDOWWIDTH に変更
+//Sept. 17, 2000 jepro 説明の「縦」を「上下に」に変更 F_SPLIT_V				
+//Sept. 17, 2000 jepro 説明の「横」を「左右に」に変更 F_SPLIT_H				
+//Sept. 17, 2000 jepro 説明に「に」を追加 F_SPLIT_VH				
+//Oct. 17, 2000 JEPRO 名前を変更(F_FILECLOSEALL→F_WIN_CLOSEALL) F_WIN_CLOSEALL			
 //2004.07.14 kazika F_BIND_WINDOW			
 //2004-09-21 Moca F_TOPMOST			
 //2006.03.23 fon F_WINLIST			
-//Sept. 17, 2000 jepro �����́u�S�āv���u���ׂāv�ɓ��� F_MINIMIZE_ALL				
+//Sept. 17, 2000 jepro 説明の「全て」を「すべて」に統一 F_MINIMIZE_ALL				
 //2001.02.10 by MIK F_MAXIMIZE_H			
 //2007.06.20 ryoji F_GROUPCLOSE	
 //2007.06.20 ryoji F_NEXTGROUP			
@@ -132,11 +132,11 @@
 //2007.06.20 ryoji F_TAB_JOINTNEXT			
 //2007.06.20 ryoji F_TAB_JOINTPREV			
 //2006.03.24 fon F_TOGGLE_KEY_SEARCH		
-//Nov. 25, 2000 JEPRO �ǉ� F_HELP_CONTENTS			
-//Nov. 25, 2000 JEPRO �ǉ� F_HELP_SEARCH			
-//Dec. 24, 2000 JEPRO �ǉ� F_ABOUT					
+//Nov. 25, 2000 JEPRO 追加 F_HELP_CONTENTS			
+//Nov. 25, 2000 JEPRO 追加 F_HELP_SEARCH			
+//Dec. 24, 2000 JEPRO 追加 F_ABOUT					
 //Oct. 19, 2002 genta F_GETSELECTED
-//2003-02-21 �S F_EXPANDPARAMETER 
+//2003-02-21 鬼 F_EXPANDPARAMETER 
 //2003.06.25 Moca F_GETLINESTR       
 //2003.06.25 Moca F_GETLINECOUNT    
 //2004.03.16 zenryaku F_CHGTABWIDTH     
@@ -152,14 +152,14 @@
 //2005.08.05 maru F_ISPOSSIBLEREDO   
 
 /*
-�����̈�����
+引数の扱いは
   CEditView::HandleCommand
   CMacro::HandleFunction
   MacroFuncInfo CSMacroMgr::m_MacroFuncInfoArr[]
-���Q��
+を参照
 */
 
-//2007.09.30 kobake �@�\�ԍ��萔��񋓌^�ɕύX�B(�f�o�b�O�����₷�����邽��)
+//2007.09.30 kobake 機能番号定数を列挙型に変更。(デバッグをしやすくするため)
 #include "Funccode_enum.h"
 
 #ifndef UINT16
@@ -169,7 +169,7 @@
 typedef UINT16 uint16_t;
 #endif
 
-// �@�\�ꗗ�Ɋւ���f�[�^�錾
+// 機能一覧に関するデータ宣言
 namespace nsFuncCode{
 	extern const uint16_t		ppszFuncKind[];
 	extern const int			nFuncKindNum;
@@ -183,14 +183,14 @@ namespace nsFuncCode{
 ///////////////////////////////////////////////////////////////////////
 
 
-/*�@�\�ԍ��ɑΉ������w���v�g�s�b�NID��Ԃ�*/
+/*機能番号に対応したヘルプトピックIDを返す*/
 int FuncID_To_HelpContextID( EFunctionCode nFuncID );	//Stonee, 2001/02/23
 
 class CEditDoc;
 struct DLLSHAREDATA;
 
-//2007.10.30 kobake �@�\�`�F�b�N��CEditWnd���炱���ֈړ�
-bool IsFuncEnable( const CEditDoc*, const DLLSHAREDATA*, EFunctionCode );	/* �@�\�����p�\�����ׂ� */
-bool IsFuncChecked( const CEditDoc*, const DLLSHAREDATA*, EFunctionCode );	/* �@�\���`�F�b�N��Ԃ����ׂ� */
+//2007.10.30 kobake 機能チェックをCEditWndからここへ移動
+bool IsFuncEnable( const CEditDoc*, const DLLSHAREDATA*, EFunctionCode );	/* 機能が利用可能か調べる */
+bool IsFuncChecked( const CEditDoc*, const DLLSHAREDATA*, EFunctionCode );	/* 機能がチェック状態か調べる */
 
 #endif // _FUNCCODE_H_


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/func
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。

主に動作影響について対応前後で挙動に変化がないことのご確認をいただけると助かります。
