### PR TITLE
mfclike 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/mfclike/CMyWnd.cpp
+++ b/sakura_core/mfclike/CMyWnd.cpp
@@ -1,2 +1,2 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "CMyWnd.h"

--- a/sakura_core/mfclike/CMyWnd.h
+++ b/sakura_core/mfclike/CMyWnd.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,9 +25,9 @@
 #define SAKURA_CMYWND_2BBCE2D2_F4DC_4809_BFFE_476824F2E0ABR_H_
 
 /*
-	MFC‚ÌCWnd“I‚ÈƒNƒ‰ƒXB
+	MFCã®CWndçš„ãªã‚¯ãƒ©ã‚¹ã€‚
 
-	2008.01.26 kobake ì¬
+	2008.01.26 kobake ä½œæˆ
 */
 
 class CMyWnd{


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/mfclike
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112
