### PR TITLE
plugin 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/plugin/CComplementIfObj.h
+++ b/sakura_core/plugin/CComplementIfObj.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ComplementƒIƒuƒWƒFƒNƒg
+ï»¿/*!	@file
+	@brief Complementã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 
 */
 /*
@@ -34,16 +34,16 @@
 #include "util/ole_convert.h"
 
 class CComplementIfObj : public CWSHIfObj {
-	// Œ^’è‹`
+	// å‹å®šç¾©
 	enum FuncId {
-		F_OL_COMMAND_FIRST = 0,					//«ƒRƒ}ƒ“ƒh‚ÍˆÈ‰º‚É’Ç‰Á‚·‚é
-		F_OL_FUNCTION_FIRST = F_FUNCTION_FIRST,	//«ŠÖ”‚ÍˆÈ‰º‚É’Ç‰Á‚·‚é
-		F_CM_GETCURRENTWORD,					//•âŠ®‘ÎÛ‚Ì•¶š—ñ‚ğæ“¾
-		F_CM_GETOPTION,							//ƒIƒvƒVƒ‡ƒ“‚ğæ“¾
-		F_CM_ADDLIST,							//Œó•â‚É’Ç‰Á
+		F_OL_COMMAND_FIRST = 0,					//â†“ã‚³ãƒãƒ³ãƒ‰ã¯ä»¥ä¸‹ã«è¿½åŠ ã™ã‚‹
+		F_OL_FUNCTION_FIRST = F_FUNCTION_FIRST,	//â†“é–¢æ•°ã¯ä»¥ä¸‹ã«è¿½åŠ ã™ã‚‹
+		F_CM_GETCURRENTWORD,					//è£œå®Œå¯¾è±¡ã®æ–‡å­—åˆ—ã‚’å–å¾—
+		F_CM_GETOPTION,							//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã‚’å–å¾—
+		F_CM_ADDLIST,							//å€™è£œã«è¿½åŠ 
 	};
 
-	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	// ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CComplementIfObj( std::wstring& curWord, CHokanMgr* pMgr, int option )
 		: CWSHIfObj( L"Complement", false )
@@ -53,34 +53,34 @@ public:
 	{
 	}
 
-	// ƒfƒXƒgƒ‰ƒNƒ^
+	// ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	~CComplementIfObj(){}
 
-	// À‘•
+	// å®Ÿè£…
 public:
-	//ƒRƒ}ƒ“ƒhî•ñ‚ğæ“¾‚·‚é
+	//ã‚³ãƒãƒ³ãƒ‰æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 	MacroFuncInfoArray GetMacroCommandInfo() const{ return m_MacroFuncInfoCommandArr; }
-	//ŠÖ”î•ñ‚ğæ“¾‚·‚é
+	//é–¢æ•°æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 	MacroFuncInfoArray GetMacroFuncInfo() const{ return m_MacroFuncInfoArr; };
-	//ŠÖ”‚ğˆ—‚·‚é
+	//é–¢æ•°ã‚’å‡¦ç†ã™ã‚‹
 	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 	{
-		Variant varCopy;	// VT_BYREF‚¾‚Æ¢‚é‚Ì‚ÅƒRƒs[—p
+		Variant varCopy;	// VT_BYREFã ã¨å›°ã‚‹ã®ã§ã‚³ãƒ”ãƒ¼ç”¨
 
 		switch(LOWORD(ID)){
-		case F_CM_GETCURRENTWORD:	//•âŠ®‘ÎÛ‚Ì•¶š—ñ‚ğæ“¾
+		case F_CM_GETCURRENTWORD:	//è£œå®Œå¯¾è±¡ã®æ–‡å­—åˆ—ã‚’å–å¾—
 			{
 				SysString s( m_sCurrentWord.c_str(), m_sCurrentWord.length() );
 				Wrap( &Result )->Receive( s );
 			}
 			return true;
-		case F_CM_GETOPTION:	//ƒIƒvƒVƒ‡ƒ“‚ğæ“¾
+		case F_CM_GETOPTION:	//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã‚’å–å¾—
 			{
 				Wrap( &Result )->Receive( m_nOption );
 			}
 			return true;
-		case F_CM_ADDLIST:		//Œó•â‚É’Ç‰Á‚·‚é
+		case F_CM_ADDLIST:		//å€™è£œã«è¿½åŠ ã™ã‚‹
 			{
 				std::wstring keyword;
 				if( variant_to_wstr( Arguments[0], keyword ) != true) return false;
@@ -98,39 +98,39 @@ public:
 		}
 		return false;
 	}
-	//ƒRƒ}ƒ“ƒh‚ğˆ—‚·‚é
+	//ã‚³ãƒãƒ³ãƒ‰ã‚’å‡¦ç†ã™ã‚‹
 	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize)
 	{
 		return false;
 	}
 
-	// ƒƒ“ƒo•Ï”
+	// ãƒ¡ãƒ³ãƒå¤‰æ•°
 private:
 	std::wstring m_sCurrentWord;
 	CHokanMgr* m_pHokanMgr;
 	int m_nOption; // 0x01 == IgnoreCase
 
 private:
-	static MacroFuncInfo m_MacroFuncInfoCommandArr[];	// ƒRƒ}ƒ“ƒhî•ñ(–ß‚è’l‚È‚µ)
-	static MacroFuncInfo m_MacroFuncInfoArr[];	// ŠÖ”î•ñ(–ß‚è’l‚ ‚è)
+	static MacroFuncInfo m_MacroFuncInfoCommandArr[];	// ã‚³ãƒãƒ³ãƒ‰æƒ…å ±(æˆ»ã‚Šå€¤ãªã—)
+	static MacroFuncInfo m_MacroFuncInfoArr[];	// é–¢æ•°æƒ…å ±(æˆ»ã‚Šå€¤ã‚ã‚Š)
 };
 
-//ƒRƒ}ƒ“ƒhî•ñ
+//ã‚³ãƒãƒ³ãƒ‰æƒ…å ±
 MacroFuncInfo CComplementIfObj::m_MacroFuncInfoCommandArr[] = 
 {
-	//ID									ŠÖ”–¼							ˆø”										–ß‚è’l‚ÌŒ^	m_pszData
-	//	I’[
+	//ID									é–¢æ•°å							å¼•æ•°										æˆ»ã‚Šå€¤ã®å‹	m_pszData
+	//	çµ‚ç«¯
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 
-//ŠÖ”î•ñ
+//é–¢æ•°æƒ…å ±
 MacroFuncInfo CComplementIfObj::m_MacroFuncInfoArr[] = 
 {
-	//ID								ŠÖ”–¼				ˆø”										–ß‚è’l‚ÌŒ^	m_pszData
-	{EFunctionCode(F_CM_GETCURRENTWORD),L"GetCurrentWord",	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //•âŠ®‘ÎÛ‚Ì•¶š—ñ‚ğæ“¾
-	{EFunctionCode(F_CM_GETOPTION),		L"GetOption",		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //•âŠ®‘ÎÛ‚Ì•¶š—ñ‚ğæ“¾
-	{EFunctionCode(F_CM_ADDLIST),		L"AddList",			{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //Œó•â‚É’Ç‰Á‚·‚é
-	//	I’[
+	//ID								é–¢æ•°å				å¼•æ•°										æˆ»ã‚Šå€¤ã®å‹	m_pszData
+	{EFunctionCode(F_CM_GETCURRENTWORD),L"GetCurrentWord",	{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //è£œå®Œå¯¾è±¡ã®æ–‡å­—åˆ—ã‚’å–å¾—
+	{EFunctionCode(F_CM_GETOPTION),		L"GetOption",		{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //è£œå®Œå¯¾è±¡ã®æ–‡å­—åˆ—ã‚’å–å¾—
+	{EFunctionCode(F_CM_ADDLIST),		L"AddList",			{VT_BSTR,  VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //å€™è£œã«è¿½åŠ ã™ã‚‹
+	//	çµ‚ç«¯
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 

--- a/sakura_core/plugin/CDllPlugin.cpp
+++ b/sakura_core/plugin/CDllPlugin.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief DLLƒvƒ‰ƒOƒCƒ“ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief DLLãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -29,7 +29,7 @@
 #include "plugin/CDllPlugin.h"
 #include "view/CEditView.h"
 
-// ƒfƒXƒgƒ‰ƒNƒ^
+// ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 CDllPlugin::~CDllPlugin(void)
 {
 	for( CPlug::ArrayIter it = m_plugs.begin(); it != m_plugs.end(); it++ ){
@@ -37,38 +37,38 @@ CDllPlugin::~CDllPlugin(void)
 	}
 }
 
-// ƒvƒ‰ƒO‚Ì¶¬
-// CPlug‚Ì‘ã‚í‚è‚ÉCDllPlug‚ğì¬‚·‚é
+// ãƒ—ãƒ©ã‚°ã®ç”Ÿæˆ
+// CPlugã®ä»£ã‚ã‚Šã«CDllPlugã‚’ä½œæˆã™ã‚‹
 CPlug* CDllPlugin::CreatePlug( CPlugin& plugin, PlugId id, wstring sJack, wstring sHandler, wstring sLabel )
 {
 	CDllPlug *newPlug =  new CDllPlug( plugin, id, sJack, sHandler, sLabel );
 	return newPlug;
 }
 
-// ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚Ì“Ç‚İ‚İ
+// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®èª­ã¿è¾¼ã¿
 bool CDllPlugin::ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang )
 {
 	ReadPluginDefCommon( cProfile, cProfileMlang );
 
-	//DLL–¼‚Ì“Ç‚İ‚İ
+	//DLLåã®èª­ã¿è¾¼ã¿
 	cProfile->IOProfileData( PII_DLL, PII_DLL_NAME, m_sDllName );
 
-	//ƒvƒ‰ƒO‚Ì“Ç‚İ‚İ
+	//ãƒ—ãƒ©ã‚°ã®èª­ã¿è¾¼ã¿
 	ReadPluginDefPlug( cProfile, cProfileMlang );
 
-	//ƒRƒ}ƒ“ƒh‚Ì“Ç‚İ‚İ
+	//ã‚³ãƒãƒ³ãƒ‰ã®èª­ã¿è¾¼ã¿
 	ReadPluginDefCommand( cProfile, cProfileMlang );
 
-	//ƒIƒvƒVƒ‡ƒ“’è‹`‚Ì“Ç‚İ‚İ	// 2010/3/24 Uchi
+	//ã‚ªãƒ—ã‚·ãƒ§ãƒ³å®šç¾©ã®èª­ã¿è¾¼ã¿	// 2010/3/24 Uchi
 	ReadPluginDefOption( cProfile, cProfileMlang );
 
-	//•¶š—ñ’è‹`‚Ì“Ç‚İ‚İ
+	//æ–‡å­—åˆ—å®šç¾©ã®èª­ã¿è¾¼ã¿
 	ReadPluginDefString( cProfile, cProfileMlang );
 
 	return true;
 }
 
-// ƒvƒ‰ƒOÀs
+// ãƒ—ãƒ©ã‚°å®Ÿè¡Œ
 bool CDllPlugin::InvokePlug( CEditView* view, CPlug& plug_raw, CWSHIfObj::List& params )
 {
 	tstring dllPath = GetFilePath( to_tchar(m_sDllName.c_str()) );
@@ -80,7 +80,7 @@ bool CDllPlugin::InvokePlug( CEditView* view, CPlug& plug_raw, CWSHIfObj::List& 
 
 	CDllPlug& plug = *(static_cast<CDllPlug*>(&plug_raw));
 	if( ! plug.m_handler ){
-		//DLLŠÖ”‚Ìæ“¾
+		//DLLé–¢æ•°ã®å–å¾—
 		ImportTable imp[2] = {
 			{ &plug.m_handler, to_achar( plug.m_sHandler.c_str() ) },
 			{ NULL, 0 }
@@ -94,7 +94,7 @@ bool CDllPlugin::InvokePlug( CEditView* view, CPlug& plug_raw, CWSHIfObj::List& 
 	CMacroBeforeAfter ba;
 	int flags = FA_NONRECORD | FA_FROMMACRO;
 	ba.ExecKeyMacroBefore(view, flags);
-	//DLLŠÖ”‚ÌŒÄ‚Ño‚µ
+	//DLLé–¢æ•°ã®å‘¼ã³å‡ºã—
 	plug.m_handler();
 	ba.ExecKeyMacroAfter(view, flags, true);
 	

--- a/sakura_core/plugin/CDllPlugin.h
+++ b/sakura_core/plugin/CDllPlugin.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief DLLƒvƒ‰ƒOƒCƒ“ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief DLLãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -30,8 +30,8 @@
 
 #include "CPlugin.h"
 
-#define	PII_DLL							L"Dll"			//DLLî•ñ
-#define	PII_DLL_NAME					L"Name"			//–¼‘O
+#define	PII_DLL							L"Dll"			//DLLæƒ…å ±
+#define	PII_DLL_NAME					L"Name"			//åå‰
 
 typedef void (*DllPlugHandler)();
 
@@ -51,16 +51,16 @@ public:
 class CDllPlugin
 	: public CPlugin, public CDllImp
 {
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CDllPlugin( const tstring& sBaseDir ) : CPlugin( sBaseDir ), CDllImp() {
 	}
 
-	//ƒfƒXƒgƒ‰ƒNƒ^
+	//ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	~CDllPlugin(void);
 
-	//À‘•
+	//å®Ÿè£…
 public:
 	bool ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang );
 	bool ReadPluginOption( CDataProfile *cProfile ) {
@@ -79,7 +79,7 @@ public:
 		return _T("");
 	}
 
-	//ƒƒ“ƒo•Ï”
+	//ãƒ¡ãƒ³ãƒå¤‰æ•°
 private:
 	wstring m_sDllName;
 

--- a/sakura_core/plugin/CJackManager.cpp
+++ b/sakura_core/plugin/CJackManager.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒWƒƒƒbƒNŠÇ—ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief ã‚¸ãƒ£ãƒƒã‚¯ç®¡ç†ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -30,13 +30,13 @@
 #include "CPropertyManager.h"
 #include "typeprop/CPropTypes.h"
 
-//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 CJackManager::CJackManager()
 {
 	int i;
 
-	//ƒWƒƒƒbƒN’è‹`ˆê——
-	//“Y‚¦š‚ªEJack‚Ì’l‚Æ“¯‚¶‚Å‚ ‚é‚±‚ÆB
+	//ã‚¸ãƒ£ãƒƒã‚¯å®šç¾©ä¸€è¦§
+	//æ·»ãˆå­—ãŒEJackã®å€¤ã¨åŒã˜ã§ã‚ã‚‹ã“ã¨ã€‚
 	struct tagJackEntry {
 		EJack id;
 		const WCHAR* name;
@@ -73,13 +73,13 @@ CJackManager::CJackManager()
 	
 }
 
-//ƒWƒƒƒbƒN’è‹`ˆê——‚ğ•Ô‚·
+//ã‚¸ãƒ£ãƒƒã‚¯å®šç¾©ä¸€è¦§ã‚’è¿”ã™
 std::vector<JackDef> CJackManager::GetJackDef() const
 {
 	return m_Jacks;
 }
 
-//ƒvƒ‰ƒO‚ğƒWƒƒƒbƒN‚ÉŠÖ˜A•t‚¯‚é
+//ãƒ—ãƒ©ã‚°ã‚’ã‚¸ãƒ£ãƒƒã‚¯ã«é–¢é€£ä»˜ã‘ã‚‹
 ERegisterPlugResult CJackManager::RegisterPlug( wstring pszJack, CPlug* plug )
 {
 	EJack ppId = GetJackFromName( pszJack );
@@ -87,7 +87,7 @@ ERegisterPlugResult CJackManager::RegisterPlug( wstring pszJack, CPlug* plug )
 		return PPMGR_INVALID_NAME;
 	}
 
-	//‹@”\ID‚Ì¸‡‚É‚È‚é‚æ‚¤‚Éƒvƒ‰ƒO‚ğ“o˜^‚·‚é
+	//æ©Ÿèƒ½IDã®æ˜‡é †ã«ãªã‚‹ã‚ˆã†ã«ãƒ—ãƒ©ã‚°ã‚’ç™»éŒ²ã™ã‚‹
 	CPlug::Array& plugs = m_Jacks[ ppId ].plugs;
 	int plugid = plug->GetFunctionCode();
 	if( plugs.empty()  ||  (*(plugs.end() - 1))->GetFunctionCode() < plugid ){
@@ -102,15 +102,15 @@ ERegisterPlugResult CJackManager::RegisterPlug( wstring pszJack, CPlug* plug )
 	}
 
 	switch( ppId ){
-	case PP_OUTLINE:					//ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@‚ğ’Ç‰Á
+	case PP_OUTLINE:					//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³•ã‚’è¿½åŠ 
 		{
-			int nMethod = CPlug::GetOutlineType( plug->GetFunctionCode() );	// 2011/8/20 syat ƒvƒ‰ƒO•¡”‰»‚Ì‚½‚ßGetOutlineTyped—l•ÏX// 2010/5/1 Uchi ŠÖ”‰»
+			int nMethod = CPlug::GetOutlineType( plug->GetFunctionCode() );	// 2011/8/20 syat ãƒ—ãƒ©ã‚°è¤‡æ•°åŒ–ã®ãŸã‚GetOutlineTypeä»•æ§˜å¤‰æ›´// 2010/5/1 Uchi é–¢æ•°åŒ–
 			CPropTypesScreen::AddOutlineMethod( nMethod, plug->m_sLabel.c_str() );
 		}
 		break;
-	case PP_SMARTINDENT:				//ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒg•û–@‚ğ’Ç‰Á
+	case PP_SMARTINDENT:				//ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆæ–¹æ³•ã‚’è¿½åŠ 
 		{
-			int nMethod = CPlug::GetSmartIndentType( plug->GetFunctionCode() );	// 2011/8/20 syat ƒvƒ‰ƒO•¡”‰»‚Ì‚½‚ßGetOutlineTyped—l•ÏX// 2010/5/1 Uchi ŠÖ”‰»
+			int nMethod = CPlug::GetSmartIndentType( plug->GetFunctionCode() );	// 2011/8/20 syat ãƒ—ãƒ©ã‚°è¤‡æ•°åŒ–ã®ãŸã‚GetOutlineTypeä»•æ§˜å¤‰æ›´// 2010/5/1 Uchi é–¢æ•°åŒ–
 			CPropTypesScreen::AddSIndentMethod( nMethod, plug->m_sLabel.c_str() );
 		}
 		break;
@@ -124,19 +124,19 @@ ERegisterPlugResult CJackManager::RegisterPlug( wstring pszJack, CPlug* plug )
 	return PPMGR_REG_OK;
 }
 
-//ƒvƒ‰ƒO‚ÌŠÖ˜A•t‚¯‚ğ‰ğœ‚·‚é
+//ãƒ—ãƒ©ã‚°ã®é–¢é€£ä»˜ã‘ã‚’è§£é™¤ã™ã‚‹
 bool CJackManager::UnRegisterPlug( wstring pszJack, CPlug* plug )
 {
 	EJack ppId = GetJackFromName( pszJack );
 
 	switch( ppId ){
-	case PP_OUTLINE:					//ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@‚ğ’Ç‰Á
+	case PP_OUTLINE:					//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³•ã‚’è¿½åŠ 
 		{
 			int nMethod = CPlug::GetOutlineType( plug->GetFunctionCode() );
 			CPropTypesScreen::RemoveOutlineMethod( nMethod, plug->m_sLabel.c_str() );
 		}
 		break;
-	case PP_SMARTINDENT:				//ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒg•û–@‚ğ’Ç‰Á
+	case PP_SMARTINDENT:				//ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆæ–¹æ³•ã‚’è¿½åŠ 
 		{
 			int nMethod = CPlug::GetSmartIndentType( plug->GetFunctionCode() );
 			CPropTypesScreen::RemoveSIndentMethod( nMethod, plug->m_sLabel.c_str() );
@@ -160,7 +160,7 @@ bool CJackManager::UnRegisterPlug( wstring pszJack, CPlug* plug )
 	return true;
 }
 
-//ƒWƒƒƒbƒN–¼‚ğƒWƒƒƒbƒN”Ô†‚É•ÏŠ·‚·‚é
+//ã‚¸ãƒ£ãƒƒã‚¯åã‚’ã‚¸ãƒ£ãƒƒã‚¯ç•ªå·ã«å¤‰æ›ã™ã‚‹
 EJack CJackManager::GetJackFromName( wstring sName )
 {
 	unsigned int i;
@@ -172,15 +172,15 @@ EJack CJackManager::GetJackFromName( wstring sName )
 		}
 	}
 
-	//Œ©‚Â‚©‚ç‚È‚¢
+	//è¦‹ã¤ã‹ã‚‰ãªã„
 	return PP_NONE;
 }
 
-//—˜—p‰Â”\‚Èƒvƒ‰ƒO‚ğŒŸõ‚·‚é
+//åˆ©ç”¨å¯èƒ½ãªãƒ—ãƒ©ã‚°ã‚’æ¤œç´¢ã™ã‚‹
 bool CJackManager::GetUsablePlug(
-	EJack			jack,		//!< [in] ƒWƒƒƒbƒN”Ô†
-	PlugId			plugId,		//!< [in] ƒvƒ‰ƒOID
-	CPlug::Array*	plugs		//!< [out] —˜—p‰Â”\ƒvƒ‰ƒO‚ÌƒŠƒXƒg
+	EJack			jack,		//!< [in] ã‚¸ãƒ£ãƒƒã‚¯ç•ªå·
+	PlugId			plugId,		//!< [in] ãƒ—ãƒ©ã‚°ID
+	CPlug::Array*	plugs		//!< [out] åˆ©ç”¨å¯èƒ½ãƒ—ãƒ©ã‚°ã®ãƒªã‚¹ãƒˆ
 )
 {
 	for( auto it = m_Jacks[jack].plugs.begin(); it != m_Jacks[jack].plugs.end(); it++ ){
@@ -191,7 +191,7 @@ bool CJackManager::GetUsablePlug(
 	return true;
 }
 
-//ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh‚Ì‹@”\”Ô†‚ğ•Ô‚·
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰ã®æ©Ÿèƒ½ç•ªå·ã‚’è¿”ã™
 EFunctionCode CJackManager::GetCommandCode( int index ) const
 {
 	CPlug::Array commands = m_Jacks[ PP_COMMAND ].plugs;
@@ -203,7 +203,7 @@ EFunctionCode CJackManager::GetCommandCode( int index ) const
 	}
 }
 
-//ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh‚Ì–¼‘O‚ğ•Ô‚·
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰ã®åå‰ã‚’è¿”ã™
 int CJackManager::GetCommandName( int funccode, WCHAR* buf, int size ) const
 {
 	for( CPlug::ArrayIter it = m_Jacks[ PP_COMMAND ].plugs.begin(); it != m_Jacks[ PP_COMMAND ].plugs.end(); it++ ){
@@ -216,13 +216,13 @@ int CJackManager::GetCommandName( int funccode, WCHAR* buf, int size ) const
 	return -1;
 }
 
-//ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh‚Ì”‚ğ•Ô‚·
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰ã®æ•°ã‚’è¿”ã™
 int CJackManager::GetCommandCount() const
 {
 	return m_Jacks[ PP_COMMAND ].plugs.size();
 }
 
-//ID‚É‡’v‚·‚éƒRƒ}ƒ“ƒhƒvƒ‰ƒO‚ğ•Ô‚·
+//IDã«åˆè‡´ã™ã‚‹ã‚³ãƒãƒ³ãƒ‰ãƒ—ãƒ©ã‚°ã‚’è¿”ã™
 CPlug* CJackManager::GetCommandById( int id ) const
 {
 	const CPlug::Array& plugs = GetPlugs( PP_COMMAND );
@@ -231,11 +231,11 @@ CPlug* CJackManager::GetCommandById( int id ) const
 			return (*it);
 		}
 	}
-	assert_warning(false);	//ID‚É‡’v‚·‚éƒvƒ‰ƒO‚ª“o˜^‚³‚ê‚Ä‚¢‚È‚¢
+	assert_warning(false);	//IDã«åˆè‡´ã™ã‚‹ãƒ—ãƒ©ã‚°ãŒç™»éŒ²ã•ã‚Œã¦ã„ãªã„
 	return NULL;
 }
 
-//ƒvƒ‰ƒO‚ğ•Ô‚·
+//ãƒ—ãƒ©ã‚°ã‚’è¿”ã™
 const CPlug::Array& CJackManager::GetPlugs( EJack jack ) const
 {
 	return m_Jacks[ jack ].plugs;	

--- a/sakura_core/plugin/CJackManager.h
+++ b/sakura_core/plugin/CJackManager.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒWƒƒƒbƒNŠÇ—ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief ã‚¸ãƒ£ãƒƒã‚¯ç®¡ç†ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -33,14 +33,14 @@
 
 #define PP_COMMAND_STR	L"Command"
 
-// ƒWƒƒƒbƒNiƒvƒ‰ƒOƒCƒ“‰Â”\‰ÓŠj
+// ã‚¸ãƒ£ãƒƒã‚¯ï¼ˆï¼ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å¯èƒ½ç®‡æ‰€ï¼‰
 enum EJack {
 	PP_NONE			= -1,
 	PP_COMMAND		= 0,
 //	PP_INSTALL,
 //	PP_UNINSTALL,
-//	PP_APP_START,	// Œ»óƒGƒfƒBƒ^‚²‚Æ‚Éƒvƒ‰ƒOƒCƒ“ŠÇ—‚µ‚Ä‚¢‚é‚½‚ß
-//	PP_APP_END,		// ƒAƒvƒŠƒŒƒxƒ‹‚ÌƒCƒxƒ“ƒg‚Íˆµ‚¢‚É‚­‚¢
+//	PP_APP_START,	// ç¾çŠ¶ã‚¨ãƒ‡ã‚£ã‚¿ã”ã¨ã«ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç®¡ç†ã—ã¦ã„ã‚‹ãŸã‚
+//	PP_APP_END,		// ã‚¢ãƒ—ãƒªãƒ¬ãƒ™ãƒ«ã®ã‚¤ãƒ™ãƒ³ãƒˆã¯æ‰±ã„ã«ãã„
 	PP_EDITOR_START,
 	PP_EDITOR_END,
 	PP_DOCUMENT_OPEN,
@@ -52,54 +52,54 @@ enum EJack {
 	PP_COMPLEMENT,
 	PP_COMPLEMENTGLOBAL,
 
-	//ªƒWƒƒƒbƒN‚ğ’Ç‰Á‚·‚é‚Æ‚«‚Í‚±‚Ìs‚Ìã‚ÉB
-	PP_BUILTIN_JACK_COUNT	//‘g‚İ‚İƒWƒƒƒbƒN”
+	//â†‘ã‚¸ãƒ£ãƒƒã‚¯ã‚’è¿½åŠ ã™ã‚‹ã¨ãã¯ã“ã®è¡Œã®ä¸Šã«ã€‚
+	PP_BUILTIN_JACK_COUNT	//çµ„ã¿è¾¼ã¿ã‚¸ãƒ£ãƒƒã‚¯æ•°
 };
 
-// ƒWƒƒƒbƒN’è‹`\‘¢‘Ì
+// ã‚¸ãƒ£ãƒƒã‚¯å®šç¾©æ§‹é€ ä½“
 typedef struct tagJackDef {
 	EJack			ppId;
 	const WCHAR*	szName;
-	CPlug::Array		plugs;	//ƒWƒƒƒbƒN‚ÉŠÖ˜A•t‚¯‚ç‚ê‚½ƒvƒ‰ƒO
+	CPlug::Array		plugs;	//ã‚¸ãƒ£ãƒƒã‚¯ã«é–¢é€£ä»˜ã‘ã‚‰ã‚ŒãŸãƒ—ãƒ©ã‚°
 } JackDef;
 
-// ƒvƒ‰ƒO“o˜^Œ‹‰Ê
+// ãƒ—ãƒ©ã‚°ç™»éŒ²çµæœ
 enum ERegisterPlugResult {
-	PPMGR_REG_OK,				//ƒvƒ‰ƒOƒCƒ““o˜^¬Œ÷
-	PPMGR_INVALID_NAME,			//ƒWƒƒƒbƒN–¼‚ª•s³
-	PPMGR_CONFLICT				//w’è‚µ‚½ƒWƒƒƒbƒN‚Í•Ê‚Ìƒvƒ‰ƒOƒCƒ“‚ªÚ‘±‚µ‚Ä‚¢‚é
+	PPMGR_REG_OK,				//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²æˆåŠŸ
+	PPMGR_INVALID_NAME,			//ã‚¸ãƒ£ãƒƒã‚¯åãŒä¸æ­£
+	PPMGR_CONFLICT				//æŒ‡å®šã—ãŸã‚¸ãƒ£ãƒƒã‚¯ã¯åˆ¥ã®ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãŒæ¥ç¶šã—ã¦ã„ã‚‹
 };
 
 
-//ƒWƒƒƒbƒNŠÇ—ƒNƒ‰ƒX
+//ã‚¸ãƒ£ãƒƒã‚¯ç®¡ç†ã‚¯ãƒ©ã‚¹
 class CJackManager : public TSingleton<CJackManager>{
 	friend class TSingleton<CJackManager>;
 	CJackManager();
 
 	typedef std::wstring wstring;
 
-	//‘€ì
+	//æ“ä½œ
 public:
-	ERegisterPlugResult RegisterPlug( wstring pszJack, CPlug* plug );	//ƒvƒ‰ƒO‚ğƒWƒƒƒbƒN‚ÉŠÖ˜A•t‚¯‚é
-	bool UnRegisterPlug( wstring pszJack, CPlug* plug );	//ƒvƒ‰ƒO‚ÌŠÖ˜A•t‚¯‚ğ‰ğœ‚·‚é
-	bool GetUsablePlug( EJack jack, PlugId plugId, CPlug::Array* plugs );	//—˜—p‰Â”\‚Èƒvƒ‰ƒO‚ğŒŸõ‚·‚é
+	ERegisterPlugResult RegisterPlug( wstring pszJack, CPlug* plug );	//ãƒ—ãƒ©ã‚°ã‚’ã‚¸ãƒ£ãƒƒã‚¯ã«é–¢é€£ä»˜ã‘ã‚‹
+	bool UnRegisterPlug( wstring pszJack, CPlug* plug );	//ãƒ—ãƒ©ã‚°ã®é–¢é€£ä»˜ã‘ã‚’è§£é™¤ã™ã‚‹
+	bool GetUsablePlug( EJack jack, PlugId plugId, CPlug::Array* plugs );	//åˆ©ç”¨å¯èƒ½ãªãƒ—ãƒ©ã‚°ã‚’æ¤œç´¢ã™ã‚‹
 private:
-	EJack GetJackFromName( wstring sName );	//ƒWƒƒƒbƒN–¼‚ğƒWƒƒƒbƒN”Ô†‚É•ÏŠ·‚·‚é
+	EJack GetJackFromName( wstring sName );	//ã‚¸ãƒ£ãƒƒã‚¯åã‚’ã‚¸ãƒ£ãƒƒã‚¯ç•ªå·ã«å¤‰æ›ã™ã‚‹
 
-	//‘®«
+	//å±æ€§
 public:
-	std::vector<JackDef> GetJackDef() const;	//ƒWƒƒƒbƒN’è‹`ˆê——‚ğ•Ô‚·
-	EFunctionCode GetCommandCode( int index ) const;		//ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh‚Ì‹@”\ƒR[ƒh‚ğ•Ô‚·
-	int GetCommandName( int funccode, WCHAR* buf, int size ) const;	//ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh‚Ì–¼‘O‚ğ•Ô‚·
-	int GetCommandCount() const;	//ƒvƒ‰ƒOƒCƒ“ƒRƒ}ƒ“ƒh‚Ì”‚ğ•Ô‚·
-	CPlug* GetCommandById( int id ) const;	//ID‚É‡’v‚·‚éƒRƒ}ƒ“ƒhƒvƒ‰ƒO‚ğ•Ô‚·
-	const CPlug::Array& GetPlugs( EJack jack ) const;	//ƒvƒ‰ƒO‚ğ•Ô‚·
-	//TODO: ì‚è‚ªˆêŠÑ‚µ‚Ä‚È‚¢‚Ì‚Å®—‚·‚é syat
+	std::vector<JackDef> GetJackDef() const;	//ã‚¸ãƒ£ãƒƒã‚¯å®šç¾©ä¸€è¦§ã‚’è¿”ã™
+	EFunctionCode GetCommandCode( int index ) const;		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰ã®æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã‚’è¿”ã™
+	int GetCommandName( int funccode, WCHAR* buf, int size ) const;	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰ã®åå‰ã‚’è¿”ã™
+	int GetCommandCount() const;	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚³ãƒãƒ³ãƒ‰ã®æ•°ã‚’è¿”ã™
+	CPlug* GetCommandById( int id ) const;	//IDã«åˆè‡´ã™ã‚‹ã‚³ãƒãƒ³ãƒ‰ãƒ—ãƒ©ã‚°ã‚’è¿”ã™
+	const CPlug::Array& GetPlugs( EJack jack ) const;	//ãƒ—ãƒ©ã‚°ã‚’è¿”ã™
+	//TODO: ä½œã‚ŠãŒä¸€è²«ã—ã¦ãªã„ã®ã§æ•´ç†ã™ã‚‹ syat
 
-	//ƒƒ“ƒo•Ï”
+	//ãƒ¡ãƒ³ãƒå¤‰æ•°
 private:
 	DLLSHAREDATA* m_pShareData;
-	std::vector<JackDef> m_Jacks;	//ƒWƒƒƒbƒN’è‹`‚Ìˆê——
+	std::vector<JackDef> m_Jacks;	//ã‚¸ãƒ£ãƒƒã‚¯å®šç¾©ã®ä¸€è¦§
 };
 
 #endif /* SAKURA_CJACKMANAGER_6CC7B212_130B_46AF_9C88_05F554CDA34BO_H_ */

--- a/sakura_core/plugin/COutlineIfObj.h
+++ b/sakura_core/plugin/COutlineIfObj.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief OutlineƒIƒuƒWƒFƒNƒg
+ï»¿/*!	@file
+	@brief Outlineã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 
 */
 /*
@@ -32,22 +32,22 @@
 #include "outline/CFuncInfo.h"	// FUNCINFO_INFOMASK
 
 class COutlineIfObj : public CWSHIfObj {
-	// Œ^’è‹`
+	// åž‹å®šç¾©
 	enum FuncId {
-		F_OL_COMMAND_FIRST = 0,					//«ƒRƒ}ƒ“ƒh‚ÍˆÈ‰º‚É’Ç‰Á‚·‚é
-		F_OL_ADDFUNCINFO,						//ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚é
-		F_OL_ADDFUNCINFO2,						//ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚éi[‚³Žw’èj
-		F_OL_SETTITLE,							//ƒAƒEƒgƒ‰ƒCƒ“ƒ_ƒCƒAƒƒOƒ^ƒCƒgƒ‹‚ðŽw’è
-		F_OL_SETLISTTYPE,						//ƒAƒEƒgƒ‰ƒCƒ“ƒŠƒXƒgŽí•Ê‚ðŽw’è
-		F_OL_SETLABEL,							//ƒ‰ƒxƒ‹•¶Žš—ñ‚ðŽw’è
-		F_OL_ADDFUNCINFO3,						//ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚éiƒtƒ@ƒCƒ‹–¼j
-		F_OL_ADDFUNCINFO4,						//ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚éi[‚³Žw’èAƒtƒ@ƒCƒ‹–¼j
-		F_OL_FUNCTION_FIRST = F_FUNCTION_FIRST	//«ŠÖ”‚ÍˆÈ‰º‚É’Ç‰Á‚·‚é
+		F_OL_COMMAND_FIRST = 0,					//â†“ã‚³ãƒžãƒ³ãƒ‰ã¯ä»¥ä¸‹ã«è¿½åŠ ã™ã‚‹
+		F_OL_ADDFUNCINFO,						//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹
+		F_OL_ADDFUNCINFO2,						//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹ï¼ˆæ·±ã•æŒ‡å®šï¼‰
+		F_OL_SETTITLE,							//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚¿ã‚¤ãƒˆãƒ«ã‚’æŒ‡å®š
+		F_OL_SETLISTTYPE,						//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ãƒªã‚¹ãƒˆç¨®åˆ¥ã‚’æŒ‡å®š
+		F_OL_SETLABEL,							//ãƒ©ãƒ™ãƒ«æ–‡å­—åˆ—ã‚’æŒ‡å®š
+		F_OL_ADDFUNCINFO3,						//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹ï¼ˆãƒ•ã‚¡ã‚¤ãƒ«åï¼‰
+		F_OL_ADDFUNCINFO4,						//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹ï¼ˆæ·±ã•æŒ‡å®šã€ãƒ•ã‚¡ã‚¤ãƒ«åï¼‰
+		F_OL_FUNCTION_FIRST = F_FUNCTION_FIRST	//â†“é–¢æ•°ã¯ä»¥ä¸‹ã«è¿½åŠ ã™ã‚‹
 	};
 	typedef std::string string;
 	typedef std::wstring wstring;
 
-	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	// ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	COutlineIfObj( CFuncInfoArr& cFuncInfoArr )
 		: CWSHIfObj( L"Outline", false )
@@ -56,30 +56,30 @@ public:
 	{
 	}
 
-	// ƒfƒXƒgƒ‰ƒNƒ^
+	// ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	~COutlineIfObj(){}
 
-	// ŽÀ‘•
+	// å®Ÿè£…
 public:
-	//ƒRƒ}ƒ“ƒhî•ñ‚ðŽæ“¾‚·‚é
+	//ã‚³ãƒžãƒ³ãƒ‰æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 	MacroFuncInfoArray GetMacroCommandInfo() const{ return m_MacroFuncInfoCommandArr; }
-	//ŠÖ”î•ñ‚ðŽæ“¾‚·‚é
+	//é–¢æ•°æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 	MacroFuncInfoArray GetMacroFuncInfo() const{ return m_MacroFuncInfoArr; }
-	//ŠÖ”‚ðˆ—‚·‚é
+	//é–¢æ•°ã‚’å‡¦ç†ã™ã‚‹
 	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 	{
 		return false;
 	}
-	//ƒRƒ}ƒ“ƒh‚ðˆ—‚·‚é
+	//ã‚³ãƒžãƒ³ãƒ‰ã‚’å‡¦ç†ã™ã‚‹
 	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize)
 	{
 		switch ( LOWORD(ID) ) 
 		{
-		case F_OL_ADDFUNCINFO:			//ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚é
-		case F_OL_ADDFUNCINFO2:			//ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚éi[‚³Žw’èj
-		case F_OL_ADDFUNCINFO3:			//ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚éiƒtƒ@ƒCƒ‹–¼j
-		case F_OL_ADDFUNCINFO4:			//ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚éiƒtƒ@ƒCƒ‹–¼/[‚³Žw’èj
+		case F_OL_ADDFUNCINFO:			//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹
+		case F_OL_ADDFUNCINFO2:			//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹ï¼ˆæ·±ã•æŒ‡å®šï¼‰
+		case F_OL_ADDFUNCINFO3:			//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹ï¼ˆãƒ•ã‚¡ã‚¤ãƒ«åï¼‰
+		case F_OL_ADDFUNCINFO4:			//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹ï¼ˆãƒ•ã‚¡ã‚¤ãƒ«å/æ·±ã•æŒ‡å®šï¼‰
 			{
 				if( Arguments[0] == NULL )return false;
 				if( Arguments[1] == NULL )return false;
@@ -111,15 +111,15 @@ public:
 				}
 			}
 			break;
-		case F_OL_SETTITLE:				//ƒAƒEƒgƒ‰ƒCƒ“ƒ_ƒCƒAƒƒOƒ^ƒCƒgƒ‹‚ðŽw’è
+		case F_OL_SETTITLE:				//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚¿ã‚¤ãƒˆãƒ«ã‚’æŒ‡å®š
 			if( Arguments[0] == NULL )return false;
 			m_sOutlineTitle = to_tchar( Arguments[0] );
 			break;
-		case F_OL_SETLISTTYPE:			//ƒAƒEƒgƒ‰ƒCƒ“ƒŠƒXƒgŽí•Ê‚ðŽw’è
+		case F_OL_SETLISTTYPE:			//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ãƒªã‚¹ãƒˆç¨®åˆ¥ã‚’æŒ‡å®š
 			if( Arguments[0] == NULL )return false;
 			m_nListType = (EOutlineType)_wtol(Arguments[0]);
 			break;
-		case F_OL_SETLABEL:				//ƒ‰ƒxƒ‹•¶Žš—ñ‚ðŽw’è
+		case F_OL_SETLABEL:				//ãƒ©ãƒ™ãƒ«æ–‡å­—åˆ—ã‚’æŒ‡å®š
 			if( Arguments[0] == NULL || Arguments[1] == NULL ) return false;
 			{
 				std::wstring sLabel = Arguments[1];
@@ -132,40 +132,40 @@ public:
 		return true;
 	}
 
-	// ƒƒ“ƒo•Ï”
+	// ãƒ¡ãƒ³ãƒå¤‰æ•°
 public:
 	tstring m_sOutlineTitle;
 	EOutlineType m_nListType;
 private:
 	CFuncInfoArr& m_cFuncInfoArr;
-	static MacroFuncInfo m_MacroFuncInfoCommandArr[];	// ƒRƒ}ƒ“ƒhî•ñ(–ß‚è’l‚È‚µ)
-	static MacroFuncInfo m_MacroFuncInfoArr[];	// ŠÖ”î•ñ(–ß‚è’l‚ ‚è)
+	static MacroFuncInfo m_MacroFuncInfoCommandArr[];	// ã‚³ãƒžãƒ³ãƒ‰æƒ…å ±(æˆ»ã‚Šå€¤ãªã—)
+	static MacroFuncInfo m_MacroFuncInfoArr[];	// é–¢æ•°æƒ…å ±(æˆ»ã‚Šå€¤ã‚ã‚Š)
 };
 
 VARTYPE g_OutlineIfObj_MacroArgEx_s[] = {VT_BSTR};
 MacroFuncInfoEx g_OutlineIfObj_FuncInfoEx_s = {5, 5, g_OutlineIfObj_MacroArgEx_s};
 
-//ƒRƒ}ƒ“ƒhî•ñ
+//ã‚³ãƒžãƒ³ãƒ‰æƒ…å ±
 MacroFuncInfo COutlineIfObj::m_MacroFuncInfoCommandArr[] = 
 {
-	//ID									ŠÖ”–¼							ˆø”										–ß‚è’l‚ÌŒ^	m_pszData
-	{EFunctionCode(F_OL_ADDFUNCINFO),		LTEXT("AddFuncInfo"),			{VT_I4, VT_I4, VT_BSTR, VT_I4},				VT_EMPTY,	NULL }, //ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚é
-	{EFunctionCode(F_OL_ADDFUNCINFO2),		LTEXT("AddFuncInfo2"),			{VT_I4, VT_I4, VT_BSTR, VT_I4},				VT_EMPTY,	NULL }, //ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚éi[‚³Žw’èj
-	{EFunctionCode(F_OL_SETTITLE),			LTEXT("SetTitle"),				{VT_BSTR, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL },	//ƒAƒEƒgƒ‰ƒCƒ“ƒ_ƒCƒAƒƒOƒ^ƒCƒgƒ‹‚ðŽw’è
-	{EFunctionCode(F_OL_SETLISTTYPE),		LTEXT("SetListType"),			{VT_I4, VT_EMPTY, VT_EMPTY, VT_EMPTY},		VT_EMPTY,	NULL }, //ƒAƒEƒgƒ‰ƒCƒ“ƒŠƒXƒgŽí•Ê‚ðŽw’è
-	{EFunctionCode(F_OL_SETLABEL),			LTEXT("SetLabel"),				{VT_I4, VT_BSTR, VT_EMPTY, VT_EMPTY},		VT_EMPTY,	NULL }, //ƒ‰ƒxƒ‹•¶Žš—ñ‚ðŽw’è
-	{EFunctionCode(F_OL_ADDFUNCINFO3),		LTEXT("AddFuncInfo3"),			{VT_I4, VT_I4, VT_BSTR, VT_I4},				VT_EMPTY,	&g_OutlineIfObj_FuncInfoEx_s }, //ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚éiƒtƒ@ƒCƒ‹–¼j
-	{EFunctionCode(F_OL_ADDFUNCINFO4),		LTEXT("AddFuncInfo4"),			{VT_I4, VT_I4, VT_BSTR, VT_I4},				VT_EMPTY,	&g_OutlineIfObj_FuncInfoEx_s }, //ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‚É’Ç‰Á‚·‚éiƒtƒ@ƒCƒ‹–¼A[‚³Žw’èj
+	//ID									é–¢æ•°å							å¼•æ•°										æˆ»ã‚Šå€¤ã®åž‹	m_pszData
+	{EFunctionCode(F_OL_ADDFUNCINFO),		LTEXT("AddFuncInfo"),			{VT_I4, VT_I4, VT_BSTR, VT_I4},				VT_EMPTY,	NULL }, //ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹
+	{EFunctionCode(F_OL_ADDFUNCINFO2),		LTEXT("AddFuncInfo2"),			{VT_I4, VT_I4, VT_BSTR, VT_I4},				VT_EMPTY,	NULL }, //ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹ï¼ˆæ·±ã•æŒ‡å®šï¼‰
+	{EFunctionCode(F_OL_SETTITLE),			LTEXT("SetTitle"),				{VT_BSTR, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL },	//ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚¿ã‚¤ãƒˆãƒ«ã‚’æŒ‡å®š
+	{EFunctionCode(F_OL_SETLISTTYPE),		LTEXT("SetListType"),			{VT_I4, VT_EMPTY, VT_EMPTY, VT_EMPTY},		VT_EMPTY,	NULL }, //ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ãƒªã‚¹ãƒˆç¨®åˆ¥ã‚’æŒ‡å®š
+	{EFunctionCode(F_OL_SETLABEL),			LTEXT("SetLabel"),				{VT_I4, VT_BSTR, VT_EMPTY, VT_EMPTY},		VT_EMPTY,	NULL }, //ãƒ©ãƒ™ãƒ«æ–‡å­—åˆ—ã‚’æŒ‡å®š
+	{EFunctionCode(F_OL_ADDFUNCINFO3),		LTEXT("AddFuncInfo3"),			{VT_I4, VT_I4, VT_BSTR, VT_I4},				VT_EMPTY,	&g_OutlineIfObj_FuncInfoEx_s }, //ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹ï¼ˆãƒ•ã‚¡ã‚¤ãƒ«åï¼‰
+	{EFunctionCode(F_OL_ADDFUNCINFO4),		LTEXT("AddFuncInfo4"),			{VT_I4, VT_I4, VT_BSTR, VT_I4},				VT_EMPTY,	&g_OutlineIfObj_FuncInfoEx_s }, //ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžã«è¿½åŠ ã™ã‚‹ï¼ˆãƒ•ã‚¡ã‚¤ãƒ«åã€æ·±ã•æŒ‡å®šï¼‰
 
-	//	I’[
+	//	çµ‚ç«¯
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 
-//ŠÖ”î•ñ
+//é–¢æ•°æƒ…å ±
 MacroFuncInfo COutlineIfObj::m_MacroFuncInfoArr[] = 
 {
-	//ID									ŠÖ”–¼							ˆø”										–ß‚è’l‚ÌŒ^	m_pszData
-	//	I’[
+	//ID									é–¢æ•°å							å¼•æ•°										æˆ»ã‚Šå€¤ã®åž‹	m_pszData
+	//	çµ‚ç«¯
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 

--- a/sakura_core/plugin/CPlugin.cpp
+++ b/sakura_core/plugin/CPlugin.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒvƒ‰ƒOƒCƒ“Šî–{ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief ãƒ—ãƒ©ã‚°ã‚¤ãƒ³åŸºæœ¬ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -26,12 +26,12 @@
 		   distribution.
 */
 #include "StdAfx.h"
-#include <vector>		// wstring_split—p 2010/4/4 Uchi
+#include <vector>		// wstring_splitç”¨ 2010/4/4 Uchi
 #include "CPlugin.h"
 #include "CJackManager.h"
 
 /////////////////////////////////////////////
-// CPlug ƒƒ“ƒoŠÖ”
+// CPlug ãƒ¡ãƒ³ãƒé–¢æ•°
 bool CPlug::Invoke( CEditView* view, CWSHIfObj::List& params ){
 	return m_cPlugin.InvokePlug( view, *this, params );
 }
@@ -41,16 +41,16 @@ EFunctionCode CPlug::GetFunctionCode() const{
 }
 
 /////////////////////////////////////////////
-// CPlugin ƒƒ“ƒoŠÖ”
+// CPlugin ãƒ¡ãƒ³ãƒé–¢æ•°
 
-//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 CPlugin::CPlugin( const tstring& sBaseDir )
 	: m_sBaseDir( sBaseDir )
 {
 	m_nCommandCount = 0;
 }
 
-//ƒfƒXƒgƒ‰ƒNƒ^
+//ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 CPlugin::~CPlugin(void)
 {
 	for( CPluginOption::ArrayIter it = m_options.begin(); it != m_options.end(); it++ ){
@@ -58,7 +58,7 @@ CPlugin::~CPlugin(void)
 	}
 }
 
-//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌCommonƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Commonã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€
 bool CPlugin::ReadPluginDefCommon( CDataProfile *cProfile, CDataProfile *cProfileMlang )
 {
 	cProfile->IOProfileData( PII_PLUGIN, PII_PLUGIN_ID, m_sId );
@@ -84,8 +84,8 @@ bool CPlugin::ReadPluginDefCommon( CDataProfile *cProfile, CDataProfile *cProfil
 	return true;
 }
 
-//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌPlugƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş
-// @date 2011.08.20 syat PlugƒZƒNƒVƒ‡ƒ“‚à•¡”’è‹`‰Â”\‚Æ‚·‚é
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Plugã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€
+// @date 2011.08.20 syat Plugã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚‚è¤‡æ•°å®šç¾©å¯èƒ½ã¨ã™ã‚‹
 bool CPlugin::ReadPluginDefPlug( CDataProfile *cProfile, CDataProfile *cProfileMlang )
 {
 	unsigned int i;
@@ -102,7 +102,7 @@ bool CPlugin::ReadPluginDefPlug( CDataProfile *cProfile, CDataProfile *cProfileM
 			}
 			wstring sHandler;
 			if( cProfile->IOProfileData( PII_PLUG, (sKey + szIndex).c_str(), sHandler ) ){
-				//ƒ‰ƒxƒ‹‚Ìæ“¾
+				//ãƒ©ãƒ™ãƒ«ã®å–å¾—
 				wstring sKeyLabel = sKey + szIndex + L".Label";
 				wstring sLabel;
 				cProfile->IOProfileData( PII_PLUG, sKeyLabel.c_str(), sLabel );
@@ -110,13 +110,13 @@ bool CPlugin::ReadPluginDefPlug( CDataProfile *cProfile, CDataProfile *cProfileM
 					cProfileMlang->IOProfileData( PII_PLUG, sKeyLabel.c_str(), sLabel );
 				}
 				if (sLabel == L"") {
-					sLabel = sHandler;		// Label‚ª–³‚¯‚ê‚Îƒnƒ“ƒhƒ‰–¼‚Å‘ã—p
+					sLabel = sHandler;		// LabelãŒç„¡ã‘ã‚Œã°ãƒãƒ³ãƒ‰ãƒ©åã§ä»£ç”¨
 				}
 
 				CPlug *newPlug = CreatePlug( *this, nCount, jacks[i].szName, sHandler, sLabel );
 				m_plugs.push_back( newPlug );
 			}else{
-				break;		//’è‹`‚ª‚È‚¯‚ê‚Î“Ç‚İ‚İ‚ğI—¹
+				break;		//å®šç¾©ãŒãªã‘ã‚Œã°èª­ã¿è¾¼ã¿ã‚’çµ‚äº†
 			}
 		}
 	}
@@ -124,28 +124,28 @@ bool CPlugin::ReadPluginDefPlug( CDataProfile *cProfile, CDataProfile *cProfileM
 	return true;
 }
 
-//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌCommandƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Commandã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€
 bool CPlugin::ReadPluginDefCommand( CDataProfile *cProfile, CDataProfile *cProfileMlang )
 {
 	wstring sHandler;
 	WCHAR bufKey[64];
 
-	for( int nCount = 1; nCount < MAX_PLUG_CMD; nCount++ ){	//“Y‚¦š‚Í‚P‚©‚çn‚ß‚é
+	for( int nCount = 1; nCount < MAX_PLUG_CMD; nCount++ ){	//æ·»ãˆå­—ã¯ï¼‘ã‹ã‚‰å§‹ã‚ã‚‹
 		swprintf( bufKey, L"C[%d]", nCount );
 		if( cProfile->IOProfileData( PII_COMMAND, bufKey, sHandler ) ){
 			wstring sLabel;
 			wstring sIcon;
 
-			//ƒ‰ƒxƒ‹‚Ìæ“¾
+			//ãƒ©ãƒ™ãƒ«ã®å–å¾—
 			swprintf( bufKey, L"C[%d].Label", nCount );
 			cProfile->IOProfileData( PII_COMMAND, bufKey, sLabel );
 			if( cProfileMlang ){
 				cProfileMlang->IOProfileData( PII_COMMAND, bufKey, sLabel );
 			}
 			if (sLabel == L"") {
-				sLabel = sHandler;		// Label‚ª–³‚¯‚ê‚Îƒnƒ“ƒhƒ‰–¼‚Å‘ã—p
+				sLabel = sHandler;		// LabelãŒç„¡ã‘ã‚Œã°ãƒãƒ³ãƒ‰ãƒ©åã§ä»£ç”¨
 			}
-			//ƒAƒCƒRƒ“‚Ìæ“¾
+			//ã‚¢ã‚¤ã‚³ãƒ³ã®å–å¾—
 			swprintf( bufKey, L"C[%d].Icon", nCount );
 			cProfile->IOProfileData( PII_COMMAND, bufKey, sIcon );
 			if( cProfileMlang ){
@@ -154,14 +154,14 @@ bool CPlugin::ReadPluginDefCommand( CDataProfile *cProfile, CDataProfile *cProfi
 
 			AddCommand( sHandler.c_str(), sLabel.c_str(), sIcon.c_str(), false );
 		}else{
-			break;		//’è‹`‚ª‚È‚¯‚ê‚Î“Ç‚İ‚İ‚ğI—¹
+			break;		//å®šç¾©ãŒãªã‘ã‚Œã°èª­ã¿è¾¼ã¿ã‚’çµ‚äº†
 		}
 	}
 
 	return true;
 }
 
-//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌOptionƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş	// 2010/3/24 Uchi
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Optionã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€	// 2010/3/24 Uchi
 bool CPlugin::ReadPluginDefOption( CDataProfile *cProfile, CDataProfile *cProfileMlang )
 {
 	wstring sLabel;
@@ -174,42 +174,42 @@ bool CPlugin::ReadPluginDefOption( CDataProfile *cProfile, CDataProfile *cProfil
 	WCHAR bufKey[64];
 
 	sSection = L"";
-	for( int nCount = 1; nCount < MAX_PLUG_OPTION; nCount++ ){	//“Y‚¦š‚Í‚P‚©‚çn‚ß‚é
+	for( int nCount = 1; nCount < MAX_PLUG_OPTION; nCount++ ){	//æ·»ãˆå­—ã¯ï¼‘ã‹ã‚‰å§‹ã‚ã‚‹
 		sKey = sLabel = sType = sDefaultVal= L"";
-		//Key‚Ìæ“¾
+		//Keyã®å–å¾—
 		swprintf( bufKey, L"O[%d].Key", nCount );
 		if( cProfile->IOProfileData( PII_OPTION, bufKey, sKey ) ){
-			//Section‚Ìæ“¾
+			//Sectionã®å–å¾—
 			swprintf( bufKey, L"O[%d].Section", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sSection_wk );
-			if (!sSection_wk.empty()) {		// w’è‚ª–³‚¯‚ê‚Î‘O‚ğˆø‚«Œp‚®
+			if (!sSection_wk.empty()) {		// æŒ‡å®šãŒç„¡ã‘ã‚Œã°å‰ã‚’å¼•ãç¶™ã
 				sSection = sSection_wk;
 			}
-			//ƒ‰ƒxƒ‹‚Ìæ“¾
+			//ãƒ©ãƒ™ãƒ«ã®å–å¾—
 			swprintf( bufKey, L"O[%d].Label", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sLabel );
 			if( cProfileMlang ){
 				cProfileMlang->IOProfileData( PII_OPTION, bufKey, sLabel );
 			}
-			//Type‚Ìæ“¾
+			//Typeã®å–å¾—
 			swprintf( bufKey, L"O[%d].Type", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sType );
-			// €–Ú‘I‘ğŒó•â
+			// é …ç›®é¸æŠå€™è£œ
 			swprintf( bufKey, L"O[%d].Select", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sSelect );
 			if( cProfileMlang ){
 				cProfileMlang->IOProfileData( PII_OPTION, bufKey, sSelect );
 			}
-			// ƒfƒtƒHƒ‹ƒg’l
+			// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆå€¤
 			swprintf( bufKey, L"O[%d].Default", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sDefaultVal );
 
 			if (sSection.empty() || sKey.empty()) {
-				// İ’è‚ª–³‚©‚Á‚½‚ç–³‹
+				// è¨­å®šãŒç„¡ã‹ã£ãŸã‚‰ç„¡è¦–
 				continue;
 			}
 			if (sLabel.empty()) {
-				// Labelw’è‚ª–³‚¯‚ê‚ÎAKey‚Å‘ã—p
+				// LabelæŒ‡å®šãŒç„¡ã‘ã‚Œã°ã€Keyã§ä»£ç”¨
 				sLabel = sKey;
 			}
 
@@ -220,7 +220,7 @@ bool CPlugin::ReadPluginDefOption( CDataProfile *cProfile, CDataProfile *cProfil
 	return true;
 }
 
-//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_Šî€‚Ì‘Š‘ÎƒpƒX‚ğƒtƒ‹ƒpƒX‚É•ÏŠ·
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€åŸºæº–ã®ç›¸å¯¾ãƒ‘ã‚¹ã‚’ãƒ•ãƒ«ãƒ‘ã‚¹ã«å¤‰æ›
 CPlugin::tstring CPlugin::GetFilePath( const tstring& sFileName ) const
 {
 	return m_sBaseDir + _T("\\") + to_tchar( sFileName.c_str() );
@@ -231,13 +231,13 @@ CPlugin::tstring CPlugin::GetFolderName() const
 	return tstring(GetFileTitlePointer(m_sBaseDir.c_str()));
 }
 
-//ƒRƒ}ƒ“ƒh‚ğ’Ç‰Á‚·‚é
+//ã‚³ãƒãƒ³ãƒ‰ã‚’è¿½åŠ ã™ã‚‹
 int CPlugin::AddCommand( const WCHAR* handler, const WCHAR* label, const WCHAR* icon, bool doRegister )
 {
 	if( !handler ){ handler = L""; }
 	if( !label ){ label = L""; }
 
-	//ƒRƒ}ƒ“ƒhƒvƒ‰ƒOID‚Í1‚©‚çU‚é
+	//ã‚³ãƒãƒ³ãƒ‰ãƒ—ãƒ©ã‚°IDã¯1ã‹ã‚‰æŒ¯ã‚‹
 	m_nCommandCount++;
 	CPlug *newPlug = CreatePlug( *this, m_nCommandCount, PP_COMMAND_STR, wstring(handler), wstring(label) );
 	if( icon ){
@@ -252,8 +252,8 @@ int CPlugin::AddCommand( const WCHAR* handler, const WCHAR* label, const WCHAR* 
 	return newPlug->GetFunctionCode();
 }
 
-// •¶š—ñ•ªŠ„	2010/4/4 Uchi
-//	“Æ—§‚³‚¹‚½‚Ù‚¤‚ª‚¢‚¢‚Ì‚¾‚ª
+// æ–‡å­—åˆ—åˆ†å‰²	2010/4/4 Uchi
+//	ç‹¬ç«‹ã•ã›ãŸã»ã†ãŒã„ã„ã®ã ãŒ
 std::vector<std::wstring> wstring_split( std::wstring sTrg, wchar_t cSep )
 {
     std::vector<std::wstring>	splitVec;
@@ -270,14 +270,14 @@ std::vector<std::wstring> wstring_split( std::wstring sTrg, wchar_t cSep )
     return splitVec;
 }
 
-/*!	ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌStringƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş
+/*!	ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Stringã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€
 */
 bool CPlugin::ReadPluginDefString( CDataProfile *cProfile, CDataProfile *cProfileMlang )
 {
 	WCHAR bufKey[64];
 	m_aStrings.clear();
-	m_aStrings.push_back( wstring(L"") ); // 0”Ô–Úƒ_ƒ~[
-	for( int nCount = 1; nCount < MAX_PLUG_STRING; nCount++ ){	//“Y‚¦š‚Í‚P‚©‚çn‚ß‚é
+	m_aStrings.push_back( wstring(L"") ); // 0ç•ªç›®ãƒ€ãƒŸãƒ¼
+	for( int nCount = 1; nCount < MAX_PLUG_STRING; nCount++ ){	//æ·»ãˆå­—ã¯ï¼‘ã‹ã‚‰å§‹ã‚ã‚‹
 		wstring sVal = L"";
 		swprintf( bufKey, L"S[%d]", nCount );
 		if( cProfile->IOProfileData( PII_STRING, bufKey, sVal ) ){

--- a/sakura_core/plugin/CPlugin.h
+++ b/sakura_core/plugin/CPlugin.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒvƒ‰ƒOƒCƒ“Šî–{ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief ãƒ—ãƒ©ã‚°ã‚¤ãƒ³åŸºæœ¬ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -33,55 +33,55 @@
 #include "CDataProfile.h"
 #include "util/string_ex.h"
 
-//! ƒvƒ‰ƒOƒCƒ“‚ÌŠÇ—”Ô†index
+//! ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ç®¡ç†ç•ªå·index
 typedef int PluginId;
-//! ƒvƒ‰ƒO‚ÌŠÇ—”Ô† ƒvƒ‰ƒOƒCƒ“‚ÌƒRƒ}ƒ“ƒhƒvƒ‰ƒO‚²‚Æ‚ÉˆêˆÓB‚Ù‚©‚Í0
+//! ãƒ—ãƒ©ã‚°ã®ç®¡ç†ç•ªå· ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ã‚³ãƒãƒ³ãƒ‰ãƒ—ãƒ©ã‚°ã”ã¨ã«ä¸€æ„ã€‚ã»ã‹ã¯0
 typedef int PlugId;
 
-//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹–¼
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«å
 #define PII_FILENAME				_T("plugin.def")
 #define PII_L10NDIR					_T("local")
 #define PII_L10NFILEBASE			_T("plugin_")
 #define PII_L10NFILEEXT				_T(".def")
-//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹Šg’£qiƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹ŒÂ•ÊƒtƒHƒ‹ƒ_–¼{Šg’£qj
+//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«æ‹¡å¼µå­ï¼ˆã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ï¼å€‹åˆ¥ãƒ•ã‚©ãƒ«ãƒ€åï¼‹æ‹¡å¼µå­ï¼‰
 #define PII_OPTFILEEXT				_T(".ini")
 
-//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹EƒL[•¶š—ñ
-#define	PII_PLUGIN					L"Plugin"		//‹¤’Êî•ñ
-#define	PII_PLUGIN_ID				L"Id"			//IDFƒvƒ‰ƒOƒCƒ“ID
-#define	PII_PLUGIN_NAME				L"Name"			//–¼‘OFƒvƒ‰ƒOƒCƒ“–¼
-#define	PII_PLUGIN_DESCRIPTION		L"Description"	//à–¾FŠÈŒ‰‚Èà–¾
-#define	PII_PLUGIN_PLUGTYPE			L"Type"			//í•ÊFwsh / dll
-#define	PII_PLUGIN_AUTHOR			L"Author"		//ìÒF’˜ìŒ Ò–¼
-#define	PII_PLUGIN_VERSION			L"Version"		//ƒo[ƒWƒ‡ƒ“Fƒvƒ‰ƒOƒCƒ“‚Ìƒo[ƒWƒ‡ƒ“
-#define	PII_PLUGIN_URL				L"Url"			//”z•zURLF”z•zŒ³URL
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ã‚­ãƒ¼æ–‡å­—åˆ—
+#define	PII_PLUGIN					L"Plugin"		//å…±é€šæƒ…å ±
+#define	PII_PLUGIN_ID				L"Id"			//IDï¼šãƒ—ãƒ©ã‚°ã‚¤ãƒ³ID
+#define	PII_PLUGIN_NAME				L"Name"			//åå‰ï¼šãƒ—ãƒ©ã‚°ã‚¤ãƒ³å
+#define	PII_PLUGIN_DESCRIPTION		L"Description"	//èª¬æ˜ï¼šç°¡æ½”ãªèª¬æ˜
+#define	PII_PLUGIN_PLUGTYPE			L"Type"			//ç¨®åˆ¥ï¼šwsh / dll
+#define	PII_PLUGIN_AUTHOR			L"Author"		//ä½œè€…ï¼šè‘—ä½œæ¨©è€…å
+#define	PII_PLUGIN_VERSION			L"Version"		//ãƒãƒ¼ã‚¸ãƒ§ãƒ³ï¼šãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³
+#define	PII_PLUGIN_URL				L"Url"			//é…å¸ƒURLï¼šé…å¸ƒå…ƒURL
 
-#define PII_PLUG					L"Plug"			//ƒvƒ‰ƒOî•ñ
-#define PII_STRING					L"String"		//•¶š—ñî•ñ
+#define PII_PLUG					L"Plug"			//ãƒ—ãƒ©ã‚°æƒ…å ±
+#define PII_STRING					L"String"		//æ–‡å­—åˆ—æƒ…å ±
 
-#define PII_COMMAND					L"Command"		//ƒRƒ}ƒ“ƒhî•ñ
-#define PII_OPTION					L"Option"		//ƒIƒvƒVƒ‡ƒ“’è‹`î•ñ	// 2010/3/24 Uchi
+#define PII_COMMAND					L"Command"		//ã‚³ãƒãƒ³ãƒ‰æƒ…å ±
+#define PII_OPTION					L"Option"		//ã‚ªãƒ—ã‚·ãƒ§ãƒ³å®šç¾©æƒ…å ±	// 2010/3/24 Uchi
 
 
 class CPlugin;
 
-//ƒvƒ‰ƒOiƒvƒ‰ƒOƒCƒ““à‚Ìˆ—’PˆÊjƒNƒ‰ƒX
+//ãƒ—ãƒ©ã‚°ï¼ˆãƒ—ãƒ©ã‚°ã‚¤ãƒ³å†…ã®å‡¦ç†å˜ä½ï¼‰ã‚¯ãƒ©ã‚¹
 class CPlug
 {
-	//Œ^’è‹`
+	//å‹å®šç¾©
 protected:
 	typedef std::wstring wstring;
 public:
 	/*!
-	  CPlug::Array‚Ístd::vector‚È‚Ì‚ÅA—v‘f‚Ì’Ç‰Áíœiinsert/erasej‚ğ‚·‚é‚Æ
-	  ƒCƒeƒŒ[ƒ^‚ª–³Œø‚É‚È‚é‚±‚Æ‚ª‚ ‚éB‚»‚Ì‚½‚ß•Ï”‚ÉŠi”[‚µ‚½ƒCƒeƒŒ[ƒ^‚ğ
-	  insert/erase‚Ì‘æˆêˆø”‚Éw’è‚·‚é‚ÆAVC2005‚Åƒrƒ‹ƒhƒGƒ‰[‚ªo‚éB
-	  ‚©‚í‚è‚Ébegin/end‚©‚ç‚Ì‘Š‘ÎˆÊ’uw’è‚âAƒCƒ“ƒfƒbƒNƒXw’è‚ğg‚¤‚±‚ÆB
+	  CPlug::Arrayã¯std::vectorãªã®ã§ã€è¦ç´ ã®è¿½åŠ å‰Šé™¤ï¼ˆinsert/eraseï¼‰ã‚’ã™ã‚‹ã¨
+	  ã‚¤ãƒ†ãƒ¬ãƒ¼ã‚¿ãŒç„¡åŠ¹ã«ãªã‚‹ã“ã¨ãŒã‚ã‚‹ã€‚ãã®ãŸã‚å¤‰æ•°ã«æ ¼ç´ã—ãŸã‚¤ãƒ†ãƒ¬ãƒ¼ã‚¿ã‚’
+	  insert/eraseã®ç¬¬ä¸€å¼•æ•°ã«æŒ‡å®šã™ã‚‹ã¨ã€VC2005ã§ãƒ“ãƒ«ãƒ‰ã‚¨ãƒ©ãƒ¼ãŒå‡ºã‚‹ã€‚
+	  ã‹ã‚ã‚Šã«begin/endã‹ã‚‰ã®ç›¸å¯¾ä½ç½®æŒ‡å®šã‚„ã€ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹æŒ‡å®šã‚’ä½¿ã†ã“ã¨ã€‚
 	*/
-	typedef std::vector<CPlug*> Array;			//ƒvƒ‰ƒO‚ÌƒŠƒXƒg
-	typedef Array::const_iterator ArrayIter;	//‚»‚ÌƒCƒeƒŒ[ƒ^
+	typedef std::vector<CPlug*> Array;			//ãƒ—ãƒ©ã‚°ã®ãƒªã‚¹ãƒˆ
+	typedef Array::const_iterator ArrayIter;	//ãã®ã‚¤ãƒ†ãƒ¬ãƒ¼ã‚¿
 
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CPlug( CPlugin& plugin, PlugId id, wstring sJack, wstring sHandler, wstring sLabel )
 		: m_id( id )
@@ -91,31 +91,31 @@ public:
 		, m_cPlugin( plugin )
 	{
 	}
-	//ƒfƒXƒgƒ‰ƒNƒ^
+	//ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	virtual ~CPlug() {}
 
-	//‘€ì
+	//æ“ä½œ
 public:
-	bool Invoke( CEditView* view, CWSHIfObj::List& params );	//ƒvƒ‰ƒO‚ğÀs‚·‚é
+	bool Invoke( CEditView* view, CWSHIfObj::List& params );	//ãƒ—ãƒ©ã‚°ã‚’å®Ÿè¡Œã™ã‚‹
 
-	//‘®«
+	//å±æ€§
 public:
 	EFunctionCode GetFunctionCode() const;
 
-	//•â•ŠÖ”
+	//è£œåŠ©é–¢æ•°
 public:
-	// Plug Function”Ô†‚ÌŒvZ(ƒNƒ‰ƒXŠO‚Å‚àg‚¦‚éƒo[ƒWƒ‡ƒ“)
+	// Plug Functionç•ªå·ã®è¨ˆç®—(ã‚¯ãƒ©ã‚¹å¤–ã§ã‚‚ä½¿ãˆã‚‹ãƒãƒ¼ã‚¸ãƒ§ãƒ³)
 	// 2010/4/19 Uchi
-	// 2011/8/20 syat ŠÖ”ƒR[ƒh‚ÌŠ„‚è“–‚Ä’¼‚µ
+	// 2011/8/20 syat é–¢æ•°ã‚³ãƒ¼ãƒ‰ã®å‰²ã‚Šå½“ã¦ç›´ã—
 	static inline EFunctionCode GetPluginFunctionCode( PluginId nPluginId, PlugId nPlugId )
 	{
 		return static_cast<EFunctionCode>( (nPluginId%20 * 100) + (nPluginId/20 * 50) + nPlugId + F_PLUGCOMMAND_FIRST );
 	}
 
-	// PluginId”Ô†‚ÌŒvZ(ƒNƒ‰ƒXŠO‚Å‚àg‚¦‚éƒo[ƒWƒ‡ƒ“)
+	// PluginIdç•ªå·ã®è¨ˆç®—(ã‚¯ãƒ©ã‚¹å¤–ã§ã‚‚ä½¿ãˆã‚‹ãƒãƒ¼ã‚¸ãƒ§ãƒ³)
 	// 2010/4/19 Uchi
-	// 2011/8/20 syat ŠÖ”ƒR[ƒh‚ÌŠ„‚è“–‚Ä’¼‚µ
+	// 2011/8/20 syat é–¢æ•°ã‚³ãƒ¼ãƒ‰ã®å‰²ã‚Šå½“ã¦ç›´ã—
 	static inline PluginId GetPluginId( EFunctionCode nFunctionCode )
 	{
 		if (nFunctionCode >= F_PLUGCOMMAND_FIRST && nFunctionCode < F_PLUGCOMMAND_LAST) {
@@ -124,9 +124,9 @@ public:
 		return PluginId(-1);
 	}
 
-	// PluginNo”Ô†‚ÌŒvZ(ƒNƒ‰ƒXŠO‚Å‚àg‚¦‚éƒo[ƒWƒ‡ƒ“)
+	// PluginNoç•ªå·ã®è¨ˆç®—(ã‚¯ãƒ©ã‚¹å¤–ã§ã‚‚ä½¿ãˆã‚‹ãƒãƒ¼ã‚¸ãƒ§ãƒ³)
 	// 2010/6/24 Uchi
-	// 2011/8/20 syat ŠÖ”ƒR[ƒh‚ÌŠ„‚è“–‚Ä’¼‚µ
+	// 2011/8/20 syat é–¢æ•°ã‚³ãƒ¼ãƒ‰ã®å‰²ã‚Šå½“ã¦ç›´ã—
 	static inline PlugId GetPlugId( EFunctionCode nFunctionCode )
 	{
 		if (nFunctionCode >= F_PLUGCOMMAND_FIRST && nFunctionCode < F_PLUGCOMMAND_LAST) {
@@ -135,21 +135,21 @@ public:
 		return PlugId(-1);
 	}
 
-	/* PluginId, PlugId ‚Æ ŠÖ”ƒR[ƒh‚Ìƒ}ƒbƒsƒ“ƒO *****************************
-	 *   PluginId c ƒvƒ‰ƒOƒCƒ“‚Ì”Ô† 0`39
-	 *     PlugId c ƒvƒ‰ƒOƒCƒ““à‚Ìƒvƒ‰ƒO‚Ì”Ô† 0`49
+	/* PluginId, PlugId ã¨ é–¢æ•°ã‚³ãƒ¼ãƒ‰ã®ãƒãƒƒãƒ”ãƒ³ã‚° *****************************
+	 *   PluginId â€¦ ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ç•ªå· 0ï½39
+	 *     PlugId â€¦ ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å†…ã®ãƒ—ãƒ©ã‚°ã®ç•ªå· 0ï½49
 	 *
-	 *   ŠÖ”ƒR[ƒh 20000`21999   ()“à‚Í(PluginId, PlugId)‚ğ•\‚·
+	 *   é–¢æ•°ã‚³ãƒ¼ãƒ‰ 20000ï½21999   ()å†…ã¯(PluginId, PlugId)ã‚’è¡¨ã™
 	 *   +------------+------------+----+------------+
 	 *   |20000(0,0)  |20100(1,0)  |    |21900(19,0) |
-	 *   |  :         |  :         | c |  :         |
+	 *   |  :         |  :         | â€¦ |  :         |
 	 *   |20049(0,49) |20149(1,49) |    |21949(19,49)| 
 	 *   +------------+------------+----+------------+
 	 *   |20050(20,0) |20150(21,0) |    |21950(39,0) |
-	 *   |  :         |  :         | c |  :         |
+	 *   |  :         |  :         | â€¦ |  :         |
 	 *   |20099(20,49)|20199(21,49)|    |21999(39,49)| 
 	 *   +------------+------------+----+------------+
-	 *   ‚à‚µ‘«‚è‚È‚¯‚ê‚ÎA22000`23999‚ğ•¥‚¢o‚µ‚ÄH‚¢‚Â‚Ô‚·
+	 *   ã‚‚ã—è¶³ã‚Šãªã‘ã‚Œã°ã€22000ï½23999ã‚’æ‰•ã„å‡ºã—ã¦é£Ÿã„ã¤ã¶ã™
 	 *************************************************************************/
 	static EOutlineType GetOutlineType( EFunctionCode nFunctionCode ){
 		return static_cast<EOutlineType>(nFunctionCode);
@@ -159,29 +159,29 @@ public:
 		return static_cast<ESmartIndentType>(nFunctionCode);
 	}
 
-	//ƒƒ“ƒo•Ï”
+	//ãƒ¡ãƒ³ãƒå¤‰æ•°
 public:
-	const PlugId m_id;					//ƒvƒ‰ƒOID
-	const wstring m_sJack;				//ŠÖ˜A•t‚¯‚éƒWƒƒƒbƒN–¼
-	const wstring m_sHandler;			//ƒnƒ“ƒhƒ‰•¶š—ñiŠÖ”–¼j
-	const wstring m_sLabel;				//ƒ‰ƒxƒ‹•¶š—ñ
-	wstring m_sIcon;					//ƒAƒCƒRƒ“‚Ìƒtƒ@ƒCƒ‹ƒpƒX
-	CPlugin& m_cPlugin;					//eƒvƒ‰ƒOƒCƒ“
+	const PlugId m_id;					//ãƒ—ãƒ©ã‚°ID
+	const wstring m_sJack;				//é–¢é€£ä»˜ã‘ã‚‹ã‚¸ãƒ£ãƒƒã‚¯å
+	const wstring m_sHandler;			//ãƒãƒ³ãƒ‰ãƒ©æ–‡å­—åˆ—ï¼ˆé–¢æ•°åï¼‰
+	const wstring m_sLabel;				//ãƒ©ãƒ™ãƒ«æ–‡å­—åˆ—
+	wstring m_sIcon;					//ã‚¢ã‚¤ã‚³ãƒ³ã®ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹
+	CPlugin& m_cPlugin;					//è¦ªãƒ—ãƒ©ã‚°ã‚¤ãƒ³
 };
 
-// ƒIƒvƒVƒ‡ƒ“’è‹`	// 2010/3/24 Uchi
+// ã‚ªãƒ—ã‚·ãƒ§ãƒ³å®šç¾©	// 2010/3/24 Uchi
 std::vector<std::wstring> wstring_split( std::wstring, wchar_t );
 
 class CPluginOption
 {
-	//Œ^’è‹`
+	//å‹å®šç¾©
 protected:
 	typedef std::wstring wstring;
 public:
-	typedef std::vector<CPluginOption*> Array;	// ƒIƒvƒVƒ‡ƒ“‚ÌƒŠƒXƒg
-	typedef Array::const_iterator ArrayIter;	// ‚»‚ÌƒCƒeƒŒ[ƒ^
+	typedef std::vector<CPluginOption*> Array;	// ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã®ãƒªã‚¹ãƒˆ
+	typedef Array::const_iterator ArrayIter;	// ãã®ã‚¤ãƒ†ãƒ¬ãƒ¼ã‚¿
 
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CPluginOption( CPlugin* parent, wstring sLabel, wstring sSection, wstring sKey, wstring sType, wstring sSelects, wstring sDefaultVal, int index) 
 	{
@@ -189,7 +189,7 @@ public:
 		m_sLabel	= sLabel;
 		m_sSection	= sSection;
 		m_sKey		= sKey;
-		// ¬•¶š•ÏŠ·
+		// å°æ–‡å­—å¤‰æ›
 		std::transform( sType.begin (), sType.end (), sType.begin (), my_towlower2 );
 		m_sType		= sType;
 		m_sSelects	= sSelects;
@@ -197,11 +197,11 @@ public:
 		m_index		= index;
 	}
 
-	//ƒfƒXƒgƒ‰ƒNƒ^
+	//ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	~CPluginOption() {}
 
-	//‘€ì
+	//æ“ä½œ
 public:
 	wstring	GetLabel( void )	{ return m_sLabel; }
 	void	GetKey( wstring* sectin, wstring* key )	{ 
@@ -222,86 +222,86 @@ protected:
 	wstring		m_sSection;
 	wstring		m_sKey;
 	wstring		m_sType;
-	wstring		m_sSelects;		// ‘I‘ğŒó•â
+	wstring		m_sSelects;		// é¸æŠå€™è£œ
 	wstring		m_sDefaultVal;
 	int 		m_index; 
 };
 
 
-//ƒvƒ‰ƒOƒCƒ“ƒNƒ‰ƒX
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚¯ãƒ©ã‚¹
 
 class CPlugin
 {
-	//Œ^’è‹`
+	//å‹å®šç¾©
 protected:
 	typedef std::wstring wstring;
 	typedef std::string string;
 
 public:
-	typedef std::list<CPlugin*> List;		//ƒvƒ‰ƒOƒCƒ“‚ÌƒŠƒXƒg
-	typedef List::const_iterator ListIter;	//‚»‚ÌƒCƒeƒŒ[ƒ^
+	typedef std::list<CPlugin*> List;		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ãƒªã‚¹ãƒˆ
+	typedef List::const_iterator ListIter;	//ãã®ã‚¤ãƒ†ãƒ¬ãƒ¼ã‚¿
 
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CPlugin( const tstring& sBaseDir );
 
-	//ƒfƒXƒgƒ‰ƒNƒ^
+	//ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	virtual ~CPlugin(void);
 
-	//‘€ì
+	//æ“ä½œ
 public:
-	virtual int AddCommand( const WCHAR* handler, const WCHAR* label, const WCHAR* icon, bool doRegister );//ƒRƒ}ƒ“ƒh‚ğ’Ç‰Á‚·‚é
-	int 	GetCommandCount()	{ return m_nCommandCount; }			// ƒRƒ}ƒ“ƒh”‚ğ•Ô‚·	2010/7/4 Uchi
+	virtual int AddCommand( const WCHAR* handler, const WCHAR* label, const WCHAR* icon, bool doRegister );//ã‚³ãƒãƒ³ãƒ‰ã‚’è¿½åŠ ã™ã‚‹
+	int 	GetCommandCount()	{ return m_nCommandCount; }			// ã‚³ãƒãƒ³ãƒ‰æ•°ã‚’è¿”ã™	2010/7/4 Uchi
 
 protected:
-	bool ReadPluginDefCommon( CDataProfile *cProfile, CDataProfile *cProfileMlang );					//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌCommonƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş
-	bool ReadPluginDefPlug( CDataProfile *cProfile, CDataProfile *cProfileMlang );					//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌPlugƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş
-	bool ReadPluginDefCommand( CDataProfile *cProfile, CDataProfile *cProfileMlang );				//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌCommandƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş
-	bool ReadPluginDefOption( CDataProfile *cProfile, CDataProfile *cProfileMlang );					//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌOptionƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş	// 2010/3/24 Uchi
-	bool ReadPluginDefString( CDataProfile *cProfile, CDataProfile *cProfileMlang );					//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌStringƒZƒNƒVƒ‡ƒ“‚ğ“Ç‚İ‚Ş
+	bool ReadPluginDefCommon( CDataProfile *cProfile, CDataProfile *cProfileMlang );					//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Commonã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€
+	bool ReadPluginDefPlug( CDataProfile *cProfile, CDataProfile *cProfileMlang );					//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Plugã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€
+	bool ReadPluginDefCommand( CDataProfile *cProfile, CDataProfile *cProfileMlang );				//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Commandã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€
+	bool ReadPluginDefOption( CDataProfile *cProfile, CDataProfile *cProfileMlang );					//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Optionã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€	// 2010/3/24 Uchi
+	bool ReadPluginDefString( CDataProfile *cProfile, CDataProfile *cProfileMlang );					//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®Stringã‚»ã‚¯ã‚·ãƒ§ãƒ³ã‚’èª­ã¿è¾¼ã‚€
 
-	//CPlugƒCƒ“ƒXƒ^ƒ“ƒX‚Ìì¬BReadPluginDefPlug/Command ‚©‚çŒÄ‚Î‚ê‚éB
+	//CPlugã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ä½œæˆã€‚ReadPluginDefPlug/Command ã‹ã‚‰å‘¼ã°ã‚Œã‚‹ã€‚
 	virtual CPlug* CreatePlug( CPlugin& plugin, PlugId id, wstring sJack, wstring sHandler, wstring sLabel )
 	{
 		return new CPlug( plugin, id, sJack, sHandler, sLabel );
 	}
 
-//	void NormalizeExtList( const wstring& sExtList, wstring& sOut );	//ƒJƒ“ƒ}‹æØ‚èŠg’£qƒŠƒXƒg‚ğ³‹K‰»‚·‚é
+//	void NormalizeExtList( const wstring& sExtList, wstring& sOut );	//ã‚«ãƒ³ãƒåŒºåˆ‡ã‚Šæ‹¡å¼µå­ãƒªã‚¹ãƒˆã‚’æ­£è¦åŒ–ã™ã‚‹
 
-	//‘®«
+	//å±æ€§
 public:
-	tstring GetFilePath( const tstring& sFileName ) const;				//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_Šî€‚Ì‘Š‘ÎƒpƒX‚ğƒtƒ‹ƒpƒX‚É•ÏŠ·
-	tstring GetPluginDefPath() const{ return GetFilePath( PII_FILENAME ); }	//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ÌƒpƒX
-	tstring GetOptionPath() const{ return m_sOptionDir + PII_OPTFILEEXT; }	//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚ÌƒpƒX
-	tstring GetFolderName() const;	//ƒvƒ‰ƒOƒCƒ“‚ÌƒtƒHƒ‹ƒ_–¼‚ğæ“¾
-	virtual CPlug::Array GetPlugs() const = 0;								//ƒvƒ‰ƒO‚Ìˆê——
+	tstring GetFilePath( const tstring& sFileName ) const;				//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€åŸºæº–ã®ç›¸å¯¾ãƒ‘ã‚¹ã‚’ãƒ•ãƒ«ãƒ‘ã‚¹ã«å¤‰æ›
+	tstring GetPluginDefPath() const{ return GetFilePath( PII_FILENAME ); }	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹
+	tstring GetOptionPath() const{ return m_sOptionDir + PII_OPTFILEEXT; }	//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹
+	tstring GetFolderName() const;	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ãƒ•ã‚©ãƒ«ãƒ€åã‚’å–å¾—
+	virtual CPlug::Array GetPlugs() const = 0;								//ãƒ—ãƒ©ã‚°ã®ä¸€è¦§
 
-	//ƒƒ“ƒo•Ï”
+	//ãƒ¡ãƒ³ãƒå¤‰æ•°
 public:
-	PluginId m_id;				//!< ƒvƒ‰ƒOƒCƒ“”Ô†iƒGƒfƒBƒ^‚ª‚Ó‚é0`MAX_PLUGIN-1‚Ì”Ô†j
-	wstring m_sId;				//!< ƒvƒ‰ƒOƒCƒ“ID
-	wstring m_sName;			//!< ƒvƒ‰ƒOƒCƒ“˜a–¼
-	wstring m_sDescription;		//!< ƒvƒ‰ƒOƒCƒ“‚É‚Â‚¢‚Ä‚ÌŠÈ’P‚È‹Lq
-	wstring m_sAuthor;			//!< ìÒ
-	wstring m_sVersion;			//!< ƒo[ƒWƒ‡ƒ“
-	wstring m_sUrl;				//!< ”z•zURL
+	PluginId m_id;				//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç•ªå·ï¼ˆã‚¨ãƒ‡ã‚£ã‚¿ãŒãµã‚‹0ï½MAX_PLUGIN-1ã®ç•ªå·ï¼‰
+	wstring m_sId;				//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ID
+	wstring m_sName;			//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å’Œå
+	wstring m_sDescription;		//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã«ã¤ã„ã¦ã®ç°¡å˜ãªè¨˜è¿°
+	wstring m_sAuthor;			//!< ä½œè€…
+	wstring m_sVersion;			//!< ãƒãƒ¼ã‚¸ãƒ§ãƒ³
+	wstring m_sUrl;				//!< é…å¸ƒURL
 	tstring m_sBaseDir;
 	tstring m_sOptionDir;
-	tstring m_sLangName;		//!< Œ¾Œê–¼
-	CPluginOption::Array m_options;		// ƒIƒvƒVƒ‡ƒ“	// 2010/3/24 Uchi
-	std::vector<std::wstring> m_aStrings;	// •¶š—ñ
+	tstring m_sLangName;		//!< è¨€èªå
+	CPluginOption::Array m_options;		// ã‚ªãƒ—ã‚·ãƒ§ãƒ³	// 2010/3/24 Uchi
+	std::vector<std::wstring> m_aStrings;	// æ–‡å­—åˆ—
 private:
 	bool m_bLoaded;
 protected:
 	CPlug::Array m_plugs;
 	int m_nCommandCount;
 
-	//”ñÀ‘•’ñ‹Ÿ
+	//éå®Ÿè£…æä¾›
 public:
-	virtual bool InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& param ) =0;	//ƒvƒ‰ƒO‚ğÀs‚·‚é
-	virtual bool ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang ) =0;		//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Ş
-	virtual bool ReadPluginOption( CDataProfile *cProfile ) =0;		//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Ş
+	virtual bool InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& param ) =0;	//ãƒ—ãƒ©ã‚°ã‚’å®Ÿè¡Œã™ã‚‹
+	virtual bool ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang ) =0;		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã‚€
+	virtual bool ReadPluginOption( CDataProfile *cProfile ) =0;		//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã‚€
 };
 
 #endif /* SAKURA_CPLUGIN_E837BF6E_3F18_4A7E_89FD_F4DAE8DF9CFFD_H_ */

--- a/sakura_core/plugin/CPluginIfObj.h
+++ b/sakura_core/plugin/CPluginIfObj.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief PluginƒIƒuƒWƒFƒNƒg
+ï»¿/*!	@file
+	@brief Pluginã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 
 */
 /*
@@ -32,27 +32,27 @@
 #include "_os/OleTypes.h"
 #include "util/ole_convert.h"
 
-// cpp‚ÖˆÚ“®—\’è
+// cppã¸ç§»å‹•äºˆå®š
 #include "window/CEditWnd.h"
 #include "view/CEditView.h"
 
 class CPluginIfObj : public CWSHIfObj {
-	// Œ^’è‹`
+	// åž‹å®šç¾©
 	enum FuncId {
-		F_PL_COMMAND_FIRST = 0,					//«ƒRƒ}ƒ“ƒh‚ÍˆÈ‰º‚É’Ç‰Á‚·‚é
-		F_PL_SETOPTION,							//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚É’l‚ð‘‚­
-		F_PL_ADDCOMMAND,						//ƒRƒ}ƒ“ƒh‚ð’Ç‰Á‚·‚é
-		F_PL_FUNCTION_FIRST = F_FUNCTION_FIRST,	//«ŠÖ”‚ÍˆÈ‰º‚É’Ç‰Á‚·‚é
-		F_PL_GETPLUGINDIR,						//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_ƒpƒX‚ðŽæ“¾‚·‚é
-		F_PL_GETDEF,							//Ý’èƒtƒ@ƒCƒ‹‚©‚ç’l‚ð“Ç‚Þ
-		F_PL_GETOPTION,							//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚©‚ç’l‚ð“Ç‚Þ
-		F_PL_GETCOMMANDNO,						//ŽÀs’†ƒvƒ‰ƒO‚Ì”Ô†‚ðŽæ“¾‚·‚é
-		F_PL_GETSTRING,							//Ý’èƒtƒ@ƒCƒ‹‚©‚ç•¶Žš—ñ‚ð“Ç‚Ý‚¾‚·(‘½Œ¾Œê‘Î‰ž)
+		F_PL_COMMAND_FIRST = 0,					//â†“ã‚³ãƒžãƒ³ãƒ‰ã¯ä»¥ä¸‹ã«è¿½åŠ ã™ã‚‹
+		F_PL_SETOPTION,							//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã«å€¤ã‚’æ›¸ã
+		F_PL_ADDCOMMAND,						//ã‚³ãƒžãƒ³ãƒ‰ã‚’è¿½åŠ ã™ã‚‹
+		F_PL_FUNCTION_FIRST = F_FUNCTION_FIRST,	//â†“é–¢æ•°ã¯ä»¥ä¸‹ã«è¿½åŠ ã™ã‚‹
+		F_PL_GETPLUGINDIR,						//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹ã‚’å–å¾—ã™ã‚‹
+		F_PL_GETDEF,							//è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰å€¤ã‚’èª­ã‚€
+		F_PL_GETOPTION,							//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰å€¤ã‚’èª­ã‚€
+		F_PL_GETCOMMANDNO,						//å®Ÿè¡Œä¸­ãƒ—ãƒ©ã‚°ã®ç•ªå·ã‚’å–å¾—ã™ã‚‹
+		F_PL_GETSTRING,							//è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰æ–‡å­—åˆ—ã‚’èª­ã¿ã ã™(å¤šè¨€èªžå¯¾å¿œ)
 	};
 	typedef std::string string;
 	typedef std::wstring wstring;
 
-	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	// ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CPluginIfObj( CPlugin& cPlugin )
 		: CWSHIfObj( L"Plugin", false )
@@ -60,40 +60,40 @@ public:
 	{
 	}
 
-	// ƒfƒXƒgƒ‰ƒNƒ^
+	// ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	~CPluginIfObj(){}
 
-	// ‘€ì
+	// æ“ä½œ
 public:
 	void SetPlugIndex(int nIndex) { m_nPlugIndex = nIndex; }
-	// ŽÀ‘•
+	// å®Ÿè£…
 public:
-	//ƒRƒ}ƒ“ƒhî•ñ‚ðŽæ“¾‚·‚é
+	//ã‚³ãƒžãƒ³ãƒ‰æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 	MacroFuncInfoArray GetMacroCommandInfo() const
 	{
 		return m_MacroFuncInfoCommandArr;
 	}
-	//ŠÖ”î•ñ‚ðŽæ“¾‚·‚é
+	//é–¢æ•°æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 	MacroFuncInfoArray GetMacroFuncInfo() const
 	{
 		return m_MacroFuncInfoArr;
 	}
-	//ŠÖ”‚ðˆ—‚·‚é
+	//é–¢æ•°ã‚’å‡¦ç†ã™ã‚‹
 	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 	{
-		Variant varCopy;	// VT_BYREF‚¾‚Æ¢‚é‚Ì‚ÅƒRƒs[—p
+		Variant varCopy;	// VT_BYREFã ã¨å›°ã‚‹ã®ã§ã‚³ãƒ”ãƒ¼ç”¨
 
 		switch(LOWORD(ID))
 		{
-		case F_PL_GETPLUGINDIR:			//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_ƒpƒX‚ðŽæ“¾‚·‚é
+		case F_PL_GETPLUGINDIR:			//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹ã‚’å–å¾—ã™ã‚‹
 			{
 				SysString S(m_cPlugin.m_sBaseDir.c_str(), m_cPlugin.m_sBaseDir.size());
 				Wrap(&Result)->Receive(S);
 			}
 			return true;
-		case F_PL_GETDEF:				//Ý’èƒtƒ@ƒCƒ‹‚©‚ç’l‚ð“Ç‚Þ
-		case F_PL_GETOPTION:			//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚©‚ç’l‚ð“Ç‚Þ
+		case F_PL_GETDEF:				//è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰å€¤ã‚’èª­ã‚€
+		case F_PL_GETOPTION:			//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰å€¤ã‚’èª­ã‚€
 			{
 				CDataProfile cProfile;
 				wstring sSection;
@@ -110,7 +110,7 @@ public:
 				}
 				if (!cProfile.IOProfileData( sSection.c_str(), sKey.c_str(), sValue )
 					&& LOWORD(ID) == F_PL_GETOPTION ) {
-					// Ý’è‚³‚ê‚Ä‚¢‚È‚¯‚ê‚ÎƒfƒtƒHƒ‹ƒg‚ðŽæ“¾ 
+					// è¨­å®šã•ã‚Œã¦ã„ãªã‘ã‚Œã°ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã‚’å–å¾— 
 					CPluginOption::ArrayIter it;
 					for (it = m_cPlugin.m_options.begin(); it != m_cPlugin.m_options.end(); it++) {
 						wstring sSectionTmp;
@@ -127,7 +127,7 @@ public:
 				Wrap(&Result)->Receive(S);
 			}
 			return true;
-		case F_PL_GETCOMMANDNO:			//ŽÀs’†ƒvƒ‰ƒO‚Ì”Ô†‚ðŽæ“¾‚·‚é
+		case F_PL_GETCOMMANDNO:			//å®Ÿè¡Œä¸­ãƒ—ãƒ©ã‚°ã®ç•ªå·ã‚’å–å¾—ã™ã‚‹
 			{
 				Wrap(&Result)->Receive(m_nPlugIndex);
 			}
@@ -151,12 +151,12 @@ public:
 		}
 		return false;
 	}
-	//ƒRƒ}ƒ“ƒh‚ðˆ—‚·‚é
+	//ã‚³ãƒžãƒ³ãƒ‰ã‚’å‡¦ç†ã™ã‚‹
 	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize)
 	{
 		switch ( LOWORD(ID) ) 
 		{
-		case F_PL_SETOPTION:			//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚É’l‚ð‘‚­
+		case F_PL_SETOPTION:			//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã«å€¤ã‚’æ›¸ã
 			{
 				if( Arguments[0] == NULL )return false;
 				if( Arguments[1] == NULL )return false;
@@ -167,10 +167,10 @@ public:
 				cProfile.SetWritingMode();
 				wstring tmp(Arguments[2]);
 				cProfile.IOProfileData( Arguments[0], Arguments[1], tmp );
-				cProfile.WriteProfile( m_cPlugin.GetOptionPath().c_str(), (m_cPlugin.m_sName + L" ƒvƒ‰ƒOƒCƒ“Ý’èƒtƒ@ƒCƒ‹").c_str() );
+				cProfile.WriteProfile( m_cPlugin.GetOptionPath().c_str(), (m_cPlugin.m_sName + L" ãƒ—ãƒ©ã‚°ã‚¤ãƒ³è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«").c_str() );
 			}
 			break;
-		case F_PL_ADDCOMMAND:			//ƒRƒ}ƒ“ƒh‚ð’Ç‰Á‚·‚é
+		case F_PL_ADDCOMMAND:			//ã‚³ãƒžãƒ³ãƒ‰ã‚’è¿½åŠ ã™ã‚‹
 			{
 				int id = m_cPlugin.AddCommand( Arguments[0], Arguments[1], Arguments[2], true );
 				View->m_pcEditWnd->RegisterPluginCommand( id );
@@ -180,35 +180,35 @@ public:
 		return true;
 	}
 
-	// ƒƒ“ƒo•Ï”
+	// ãƒ¡ãƒ³ãƒå¤‰æ•°
 public:
 private:
 	CPlugin& m_cPlugin;
-	static MacroFuncInfo m_MacroFuncInfoCommandArr[];	// ƒRƒ}ƒ“ƒhî•ñ(–ß‚è’l‚È‚µ)
-	static MacroFuncInfo m_MacroFuncInfoArr[];	// ŠÖ”î•ñ(–ß‚è’l‚ ‚è)
-	int m_nPlugIndex;	//ŽÀs’†ƒvƒ‰ƒO‚Ì”Ô†
+	static MacroFuncInfo m_MacroFuncInfoCommandArr[];	// ã‚³ãƒžãƒ³ãƒ‰æƒ…å ±(æˆ»ã‚Šå€¤ãªã—)
+	static MacroFuncInfo m_MacroFuncInfoArr[];	// é–¢æ•°æƒ…å ±(æˆ»ã‚Šå€¤ã‚ã‚Š)
+	int m_nPlugIndex;	//å®Ÿè¡Œä¸­ãƒ—ãƒ©ã‚°ã®ç•ªå·
 };
 
-//ƒRƒ}ƒ“ƒhî•ñ
+//ã‚³ãƒžãƒ³ãƒ‰æƒ…å ±
 MacroFuncInfo CPluginIfObj::m_MacroFuncInfoCommandArr[] = 
 {
-	//ID									ŠÖ”–¼							ˆø”										–ß‚è’l‚ÌŒ^	m_pszData
-	{EFunctionCode(F_PL_SETOPTION),			LTEXT("SetOption"),				{VT_BSTR, VT_BSTR, VT_VARIANT, VT_EMPTY},	VT_EMPTY,	NULL }, //ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚É’l‚ð‘‚­
-	{EFunctionCode(F_PL_ADDCOMMAND),		LTEXT("AddCommand"),			{VT_BSTR, VT_BSTR, VT_BSTR, VT_EMPTY},		VT_EMPTY,	NULL }, //ƒRƒ}ƒ“ƒh‚ð’Ç‰Á‚·‚é
-	//	I’[
+	//ID									é–¢æ•°å							å¼•æ•°										æˆ»ã‚Šå€¤ã®åž‹	m_pszData
+	{EFunctionCode(F_PL_SETOPTION),			LTEXT("SetOption"),				{VT_BSTR, VT_BSTR, VT_VARIANT, VT_EMPTY},	VT_EMPTY,	NULL }, //ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã«å€¤ã‚’æ›¸ã
+	{EFunctionCode(F_PL_ADDCOMMAND),		LTEXT("AddCommand"),			{VT_BSTR, VT_BSTR, VT_BSTR, VT_EMPTY},		VT_EMPTY,	NULL }, //ã‚³ãƒžãƒ³ãƒ‰ã‚’è¿½åŠ ã™ã‚‹
+	//	çµ‚ç«¯
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 
-//ŠÖ”î•ñ
+//é–¢æ•°æƒ…å ±
 MacroFuncInfo CPluginIfObj::m_MacroFuncInfoArr[] = 
 {
-	//ID									ŠÖ”–¼							ˆø”										–ß‚è’l‚ÌŒ^	m_pszData
-	{EFunctionCode(F_PL_GETPLUGINDIR),		LTEXT("GetPluginDir"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_ƒpƒX‚ðŽæ“¾‚·‚é
-	{EFunctionCode(F_PL_GETDEF),			LTEXT("GetDef"),				{VT_BSTR, VT_BSTR, VT_EMPTY, VT_EMPTY},		VT_BSTR,	NULL }, //Ý’èƒtƒ@ƒCƒ‹‚©‚ç’l‚ð“Ç‚Þ
-	{EFunctionCode(F_PL_GETOPTION),			LTEXT("GetOption"),				{VT_BSTR, VT_BSTR, VT_EMPTY, VT_EMPTY},		VT_BSTR,	NULL }, //ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚©‚ç’l‚ð“Ç‚Þ
-	{EFunctionCode(F_PL_GETCOMMANDNO),		LTEXT("GetCommandNo"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚©‚ç’l‚ð“Ç‚Þ
-	{EFunctionCode(F_PL_GETSTRING),			LTEXT("GetString"),				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //Ý’èƒtƒ@ƒCƒ‹‚©‚ç•¶Žš—ñ‚ð“Ç‚Þ
-	//	I’[
+	//ID									é–¢æ•°å							å¼•æ•°										æˆ»ã‚Šå€¤ã®åž‹	m_pszData
+	{EFunctionCode(F_PL_GETPLUGINDIR),		LTEXT("GetPluginDir"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹ã‚’å–å¾—ã™ã‚‹
+	{EFunctionCode(F_PL_GETDEF),			LTEXT("GetDef"),				{VT_BSTR, VT_BSTR, VT_EMPTY, VT_EMPTY},		VT_BSTR,	NULL }, //è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰å€¤ã‚’èª­ã‚€
+	{EFunctionCode(F_PL_GETOPTION),			LTEXT("GetOption"),				{VT_BSTR, VT_BSTR, VT_EMPTY, VT_EMPTY},		VT_BSTR,	NULL }, //ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰å€¤ã‚’èª­ã‚€
+	{EFunctionCode(F_PL_GETCOMMANDNO),		LTEXT("GetCommandNo"),			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰å€¤ã‚’èª­ã‚€
+	{EFunctionCode(F_PL_GETSTRING),			LTEXT("GetString"),				{VT_I4,    VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰æ–‡å­—åˆ—ã‚’èª­ã‚€
+	//	çµ‚ç«¯
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 

--- a/sakura_core/plugin/CPluginManager.cpp
+++ b/sakura_core/plugin/CPluginManager.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒvƒ‰ƒOƒCƒ“ŠÇ—ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç®¡ç†ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -33,16 +33,16 @@
 #include "util/module.h"
 #include "io/CZipFile.h"
 
-//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 CPluginManager::CPluginManager()
 {
 
-	//pluginsƒtƒHƒ‹ƒ_‚ÌêŠ‚ğæ“¾
+	//pluginsãƒ•ã‚©ãƒ«ãƒ€ã®å ´æ‰€ã‚’å–å¾—
 	TCHAR szPluginPath[_MAX_PATH];
-	GetInidir( szPluginPath, _T("plugins\\") );	//ini‚Æ“¯‚¶ŠK‘w‚ÌpluginsƒtƒHƒ‹ƒ_‚ğŒŸõ
+	GetInidir( szPluginPath, _T("plugins\\") );	//iniã¨åŒã˜éšå±¤ã®pluginsãƒ•ã‚©ãƒ«ãƒ€ã‚’æ¤œç´¢
 	m_sBaseDir.append(szPluginPath);
 
-	//ExeƒtƒHƒ‹ƒ_”z‰ºpluginsƒtƒHƒ‹ƒ_‚ÌƒpƒX‚ğæ“¾
+	//Exeãƒ•ã‚©ãƒ«ãƒ€é…ä¸‹pluginsãƒ•ã‚©ãƒ«ãƒ€ã®ãƒ‘ã‚¹ã‚’å–å¾—
 	TCHAR	szPath[_MAX_PATH];
 	TCHAR	szFolder[_MAX_PATH];
 	TCHAR	szFname[_MAX_PATH];
@@ -54,7 +54,7 @@ CPluginManager::CPluginManager()
 	m_sExePluginDir.append(szPluginPath);
 }
 
-//‘Sƒvƒ‰ƒOƒCƒ“‚ğ‰ğ•ú‚·‚é
+//å…¨ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è§£æ”¾ã™ã‚‹
 void CPluginManager::UnloadAllPlugin()
 {
 	for( CPlugin::ListIter it = m_plugins.begin(); it != m_plugins.end(); it++ ){
@@ -65,11 +65,11 @@ void CPluginManager::UnloadAllPlugin()
 		delete *it;
 	}
 	
-	// 2010.08.04 Moca m_plugins.claer‚·‚é
+	// 2010.08.04 Moca m_plugins.claerã™ã‚‹
 	m_plugins.clear();
 }
 
-//V‹Kƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á‚·‚é
+//æ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ ã™ã‚‹
 bool CPluginManager::SearchNewPlugin( CommonSetting& common, HWND hWndOwner )
 {
 #ifdef _UNICODE
@@ -80,11 +80,11 @@ bool CPluginManager::SearchNewPlugin( CommonSetting& common, HWND hWndOwner )
 	CZipFile	cZipFile;
 
 
-	//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_‚Ì”z‰º‚ğŒŸõ
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ã®é…ä¸‹ã‚’æ¤œç´¢
 	WIN32_FIND_DATA wf;
 	hFind = FindFirstFile( (m_sBaseDir + _T("*")).c_str(), &wf );
 	if (hFind == INVALID_HANDLE_VALUE) {
-		//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_‚ª‘¶İ‚µ‚È‚¢
+		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ãŒå­˜åœ¨ã—ãªã„
 		if (!CreateDirectory(m_sBaseDir.c_str(), NULL)) {
 			InfoMessage( hWndOwner, _T("%ts"), LS(STR_PLGMGR_FOLDER));
 			return true;
@@ -93,7 +93,7 @@ bool CPluginManager::SearchNewPlugin( CommonSetting& common, HWND hWndOwner )
 	::FindClose(hFind);
 
 	bool	bCancel = false;
-	//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_‚Ì”z‰º‚ğŒŸõ
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ã®é…ä¸‹ã‚’æ¤œç´¢
 	bool bFindNewDir = SearchNewPluginDir(common, hWndOwner, m_sBaseDir, bCancel);
 	if (!bCancel && m_sBaseDir != m_sExePluginDir) {
 		bFindNewDir |= SearchNewPluginDir(common, hWndOwner, m_sExePluginDir, bCancel);
@@ -116,7 +116,7 @@ bool CPluginManager::SearchNewPlugin( CommonSetting& common, HWND hWndOwner )
 }
 
 
-//V‹Kƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á‚·‚é(‰º¿‚¯)
+//æ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ ã™ã‚‹(ä¸‹è«‹ã‘)
 bool CPluginManager::SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, const tstring& sSearchDir, bool& bCancel )
 {
 #ifdef _UNICODE
@@ -129,7 +129,7 @@ bool CPluginManager::SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, 
 	WIN32_FIND_DATA wf;
 	hFind = FindFirstFile( (sSearchDir + _T("*")).c_str(), &wf );
 	if (hFind == INVALID_HANDLE_VALUE) {
-		//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_‚ª‘¶İ‚µ‚È‚¢
+		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ãŒå­˜åœ¨ã—ãªã„
 		return false;
 	}
 	bool bFindNewDir = false;
@@ -139,8 +139,8 @@ bool CPluginManager::SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, 
 			_tcscmp(wf.cFileName, _T("."))!=0 && _tcscmp(wf.cFileName, _T(".."))!=0 &&
 			auto_stricmp(wf.cFileName, _T("unuse")) !=0 )
 		{
-			//ƒCƒ“ƒXƒg[ƒ‹Ï‚İƒ`ƒFƒbƒNBƒtƒHƒ‹ƒ_–¼ƒvƒ‰ƒOƒCƒ“ƒe[ƒuƒ‹‚Ì–¼‘O‚È‚çƒCƒ“ƒXƒg[ƒ‹‚µ‚È‚¢
-			// 2010.08.04 ‘å•¶š¬•¶š“¯ˆê‹‚É‚·‚é
+			//ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«æ¸ˆã¿ãƒã‚§ãƒƒã‚¯ã€‚ãƒ•ã‚©ãƒ«ãƒ€åï¼ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ†ãƒ¼ãƒ–ãƒ«ã®åå‰ãªã‚‰ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã—ãªã„
+			// 2010.08.04 å¤§æ–‡å­—å°æ–‡å­—åŒä¸€è¦–ã«ã™ã‚‹
 			bool isNotInstalled = true;
 			for( int iNo=0; iNo < MAX_PLUGIN; iNo++ ){
 				if( auto_stricmp( wf.cFileName, to_tchar( plugin_table[iNo].m_szName ) ) == 0 ){
@@ -150,7 +150,7 @@ bool CPluginManager::SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, 
 			}
 			if( !isNotInstalled ){ continue; }
 
-			// 2011.08.20 syat plugin.def‚ª‘¶İ‚µ‚È‚¢ƒtƒHƒ‹ƒ_‚Í”ò‚Î‚·
+			// 2011.08.20 syat plugin.defãŒå­˜åœ¨ã—ãªã„ãƒ•ã‚©ãƒ«ãƒ€ã¯é£›ã°ã™
 			if( ! IsFileExists( (sSearchDir + wf.cFileName + _T("\\") + PII_FILENAME).c_str(), true ) ){
 				continue;
 			}
@@ -177,7 +177,7 @@ bool CPluginManager::SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, 
 }
 
 
-//V‹Kƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á‚·‚é(‰º¿‚¯)Zip File
+//æ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ ã™ã‚‹(ä¸‹è«‹ã‘)Zip File
 bool CPluginManager::SearchNewPluginZip( CommonSetting& common, HWND hWndOwner, const tstring& sSearchDir, bool& bCancel )
 {
 #ifdef _UNICODE
@@ -193,7 +193,7 @@ bool CPluginManager::SearchNewPluginZip( CommonSetting& common, HWND hWndOwner, 
 
 	hFind = INVALID_HANDLE_VALUE;
 
-	// Zip File ŒŸõ‰ğ“€
+	// Zip File æ¤œç´¢è§£å‡
 	if (cZipFile.IsOk()) {
 		hFind = FindFirstFile( (sSearchDir + _T("*.zip")).c_str(), &wf );
 
@@ -213,7 +213,7 @@ bool CPluginManager::SearchNewPluginZip( CommonSetting& common, HWND hWndOwner, 
 }
 
 
-//Zipƒvƒ‰ƒOƒCƒ“‚ğ“±“ü‚·‚é
+//Zipãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å°å…¥ã™ã‚‹
 bool CPluginManager::InstZipPlugin( CommonSetting& common, HWND hWndOwner, const tstring& sZipFile, bool bInSearch )
 {
 #ifdef _UNICODE
@@ -223,18 +223,18 @@ bool CPluginManager::InstZipPlugin( CommonSetting& common, HWND hWndOwner, const
 	CZipFile		cZipFile;
 	TCHAR			msg[512];
 
-	// ZIPƒtƒ@ƒCƒ‹‚ªˆµ‚¦‚é‚©
+	// ZIPãƒ•ã‚¡ã‚¤ãƒ«ãŒæ‰±ãˆã‚‹ã‹
 	if (!cZipFile.IsOk()) {
 		auto_snprintf_s( msg, _countof(msg), LS(STR_PLGMGR_ERR_ZIP) );
 		InfoMessage( hWndOwner, _T("%ts"), msg);
 		return false;
 	}
 
-	//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_‚Ì‘¶İ‚ğŠm”F
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ã®å­˜åœ¨ã‚’ç¢ºèª
 	WIN32_FIND_DATA wf;
 	HANDLE		hFind;
 	if ((hFind = ::FindFirstFile( (m_sBaseDir + _T("*")).c_str(), &wf )) == INVALID_HANDLE_VALUE) {
-		//ƒvƒ‰ƒOƒCƒ“ƒtƒHƒ‹ƒ_‚ª‘¶İ‚µ‚È‚¢
+		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ•ã‚©ãƒ«ãƒ€ãŒå­˜åœ¨ã—ãªã„
 		if (m_sBaseDir == m_sExePluginDir) {
 			InfoMessage( hWndOwner, LS(STR_PLGMGR_ERR_FOLDER));
 			::FindClose(hFind);
@@ -254,7 +254,7 @@ bool CPluginManager::InstZipPlugin( CommonSetting& common, HWND hWndOwner, const
 	return CPluginManager::InstZipPluginSub( common, hWndOwner, sZipFile, sZipFile, false, bCancel );
 }
 
-//Zipƒvƒ‰ƒOƒCƒ“‚ğ“±“ü‚·‚é(‰º¿‚¯)
+//Zipãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å°å…¥ã™ã‚‹(ä¸‹è«‹ã‘)
 bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, const tstring& sZipFile, const tstring& sDispName, bool bInSearch, bool& bCancel )
 {
 	PluginRec*		plugin_table = common.m_sPlugin.m_PluginTable;
@@ -266,14 +266,14 @@ bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, co
 	bool			bSkip = false;
 	bool			bNewPlugin = false;
 
-	// Plugin ƒtƒHƒ‹ƒ_–¼‚Ìæ“¾,’è‹`ƒtƒ@ƒCƒ‹‚ÌŠm”F
+	// Plugin ãƒ•ã‚©ãƒ«ãƒ€åã®å–å¾—,å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®ç¢ºèª
 	if (bOk && !cZipFile.SetZip(sZipFile)) {
 		auto_snprintf_s( msg, _countof(msg), LS(STR_PLGMGR_INST_ZIP_ACCESS), sDispName.c_str() );
 		bOk = false;
 		bSkip = bInSearch;
 	}
 
-	// Plgin ƒtƒHƒ‹ƒ_–¼‚Ìæ“¾,’è‹`ƒtƒ@ƒCƒ‹‚ÌŠm”F
+	// Plgin ãƒ•ã‚©ãƒ«ãƒ€åã®å–å¾—,å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã®ç¢ºèª
 	if (bOk && !cZipFile.ChkPluginDef(PII_FILENAME, sFolderName)) {
 		auto_snprintf_s( msg, _countof(msg), LS(STR_PLGMGR_INST_ZIP_DEF), sDispName.c_str() );
 		bOk = false;
@@ -281,8 +281,8 @@ bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, co
 	}
 
 	if (!bInSearch) {
-		// ’P“ÆƒCƒ“ƒXƒg[ƒ‹
-		//ƒCƒ“ƒXƒg[ƒ‹Ï‚İƒ`ƒFƒbƒNB
+		// å˜ç‹¬ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«
+		//ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«æ¸ˆã¿ãƒã‚§ãƒƒã‚¯ã€‚
 		bool	isNotInstalled = true;
 		int		iNo;
 		if (bOk) {
@@ -298,15 +298,15 @@ bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, co
 			else {
 				if( ConfirmMessage( hWndOwner, LS(STR_PLGMGR_INST_ZIP_ALREADY),
 						sDispName.c_str() ) != IDYES ){
-					// Yes‚Å–³‚¢‚È‚çI—¹
+					// Yesã§ç„¡ã„ãªã‚‰çµ‚äº†
 					return false;
 				}
 			}
 		}
 	}
 	else {
-		// pluginsƒtƒHƒ‹ƒ_ŒŸõ’†
-		// ƒtƒHƒ‹ƒ_ ƒ`ƒFƒbƒNB‚·‚Å‚É‰ğ“€‚³‚ê‚Ä‚¢‚½‚È‚çƒCƒ“ƒXƒg[ƒ‹‚µ‚È‚¢(‘O’i‚ÅƒCƒ“ƒXƒg[ƒ‹Ï‚İˆ½‚Í‰Â”Û‚ğŠm”FÏ‚İ)
+		// pluginsãƒ•ã‚©ãƒ«ãƒ€æ¤œç´¢ä¸­
+		// ãƒ•ã‚©ãƒ«ãƒ€ ãƒã‚§ãƒƒã‚¯ã€‚ã™ã§ã«è§£å‡ã•ã‚Œã¦ã„ãŸãªã‚‰ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã—ãªã„(å‰æ®µã§ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«æ¸ˆã¿æˆ–ã¯å¯å¦ã‚’ç¢ºèªæ¸ˆã¿)
 		if (bOk && (fexist(to_tchar((m_sBaseDir + to_tchar(sFolderName.c_str())).c_str()))
 			|| fexist(to_tchar((m_sExePluginDir + to_tchar(sFolderName.c_str())).c_str()))) ) {
 			bOk = false;
@@ -328,7 +328,7 @@ bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, co
 		}
 	}
 
-	// Zip‰ğ“€
+	// Zipè§£å‡
 	if (bOk && !cZipFile.Unzip(m_sBaseDir)) {
 		auto_snprintf_s( msg, _countof(msg), LS(STR_PLGMGR_INST_ZIP_UNZIP), sDispName.c_str() );
 		bOk = false;
@@ -342,24 +342,24 @@ bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, co
 	}
 
 	if (!bOk && !bSkip) {
-		// ƒGƒ‰[ƒƒbƒZ[ƒWo—Í
+		// ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡ºåŠ›
 		WarningMessage( hWndOwner, _T("%s"), msg);
 	}
 
 	return bNewPlugin;
 }
 
-//ƒvƒ‰ƒOƒCƒ“‚Ì‰Šú“±“ü‚ğ‚·‚é
-//	common			‹¤—Lİ’è•Ï”
-//	pszPluginName	ƒvƒ‰ƒOƒCƒ“–¼
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®åˆæœŸå°å…¥ã‚’ã™ã‚‹
+//	common			å…±æœ‰è¨­å®šå¤‰æ•°
+//	pszPluginName	ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å
 //	hWndOwner		
-//	errorMsg		ƒGƒ‰[ƒƒbƒZ[ƒW‚ğ•Ô‚·
-//	bUodate			‚·‚Å‚É“o˜^‚µ‚Ä‚¢‚½ê‡AŠm”F‚¹‚¸ã‘‚«‚·‚é
+//	errorMsg		ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¿”ã™
+//	bUodate			ã™ã§ã«ç™»éŒ²ã—ã¦ã„ãŸå ´åˆã€ç¢ºèªã›ãšä¸Šæ›¸ãã™ã‚‹
 int CPluginManager::InstallPlugin( CommonSetting& common, const TCHAR* pszPluginName, HWND hWndOwner, std::wstring& errorMsg, bool bUpdate )
 {
-	CDataProfile cProfDef;				//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹
+	CDataProfile cProfDef;				//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«
 
-	//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Ş
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã‚€
 	cProfDef.SetReadingMode();
 	if( !cProfDef.ReadProfile( (m_sBaseDir + pszPluginName + _T("\\") + PII_FILENAME).c_str() )
 		&& !cProfDef.ReadProfile( (m_sExePluginDir + pszPluginName + _T("\\") + PII_FILENAME).c_str() ) ){
@@ -373,8 +373,8 @@ int CPluginManager::InstallPlugin( CommonSetting& common, const TCHAR* pszPlugin
 		errorMsg = LSW(STR_PLGMGR_INST_ID);
 		return -1;
 	}
-	//2010.08.04 IDg—p•s‰Â‚Ì•¶š‚ğŠm”F
-	//  ŒãXƒtƒ@ƒCƒ‹–¼‚âini‚Åg‚¤‚±‚Æ‚ğl‚¦‚Ä‚¢‚­‚Â‚©‹‘”Û‚·‚é
+	//2010.08.04 IDä½¿ç”¨ä¸å¯ã®æ–‡å­—ã‚’ç¢ºèª
+	//  å¾Œã€…ãƒ•ã‚¡ã‚¤ãƒ«åã‚„iniã§ä½¿ã†ã“ã¨ã‚’è€ƒãˆã¦ã„ãã¤ã‹æ‹’å¦ã™ã‚‹
 	static const WCHAR szReservedChars[] = L"/\\,[]*?<>&|;:=\" \t";
 	for( int x = 0; x < _countof(szReservedChars); ++x ){
 		if( sId.npos != sId.find(szReservedChars[x]) ){
@@ -387,19 +387,19 @@ int CPluginManager::InstallPlugin( CommonSetting& common, const TCHAR* pszPlugin
 		return -1;
 	}
 
-	//IDd•¡Eƒe[ƒuƒ‹‹ó‚«ƒ`ƒFƒbƒN
+	//IDé‡è¤‡ãƒ»ãƒ†ãƒ¼ãƒ–ãƒ«ç©ºããƒã‚§ãƒƒã‚¯
 	PluginRec* plugin_table = common.m_sPlugin.m_PluginTable;
 	int nEmpty = -1;
 	bool isDuplicate = false;
 	for( int iNo=0; iNo < MAX_PLUGIN; iNo++ ){
 		if( nEmpty == -1 && plugin_table[iNo].m_state == PLS_NONE ){
 			nEmpty = iNo;
-			// break ‚µ‚Ä‚Í‚¢‚¯‚È‚¢BŒã‚ë‚Å“¯ˆêID‚ª‚ ‚é‚©‚à
+			// break ã—ã¦ã¯ã„ã‘ãªã„ã€‚å¾Œã‚ã§åŒä¸€IDãŒã‚ã‚‹ã‹ã‚‚
 		}
-		if( wcscmp( sId.c_str(), plugin_table[iNo].m_szId ) == 0 ){	//IDˆê’v
+		if( wcscmp( sId.c_str(), plugin_table[iNo].m_szId ) == 0 ){	//IDä¸€è‡´
 			if (!bUpdate) {
 				const TCHAR* msg = LS(STR_PLGMGR_INST_NAME);
-				// 2010.08.04 íœ’†‚ÌID‚ÍŒ³‚ÌˆÊ’u‚Ö’Ç‰Á(•œŠˆ‚³‚¹‚é)
+				// 2010.08.04 å‰Šé™¤ä¸­ã®IDã¯å…ƒã®ä½ç½®ã¸è¿½åŠ (å¾©æ´»ã•ã›ã‚‹)
 				if( plugin_table[iNo].m_state != PLS_DELETED &&
 				  ConfirmMessage( hWndOwner, msg, static_cast<const TCHAR*>(pszPluginName), static_cast<const WCHAR*>(plugin_table[iNo].m_szName) ) != IDYES ){
 					errorMsg = LSW(STR_PLGMGR_INST_USERCANCEL);
@@ -423,7 +423,7 @@ int CPluginManager::InstallPlugin( CommonSetting& common, const TCHAR* pszPlugin
 	plugin_table[nEmpty].m_szId[ MAX_PLUGIN_ID-1 ] = '\0';
 	plugin_table[nEmpty].m_state = isDuplicate ? PLS_UPDATED : PLS_INSTALLED;
 
-	// ƒRƒ}ƒ“ƒh”‚Ìİ’è	2010/7/11 Uchi
+	// ã‚³ãƒãƒ³ãƒ‰æ•°ã®è¨­å®š	2010/7/11 Uchi
 	int			i;
 	WCHAR		szPlugKey[10];
 	wstring		sPlugCmd;
@@ -442,7 +442,7 @@ int CPluginManager::InstallPlugin( CommonSetting& common, const TCHAR* pszPlugin
 	return nEmpty;
 }
 
-//‘Sƒvƒ‰ƒOƒCƒ“‚ğ“Ç‚İ‚Ş
+//å…¨ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’èª­ã¿è¾¼ã‚€
 bool CPluginManager::LoadAllPlugin(CommonSetting* common)
 {
 #ifdef _UNICODE
@@ -472,25 +472,25 @@ bool CPluginManager::LoadAllPlugin(CommonSetting* common)
 		DEBUG_TRACE( _T("lang = %ts\n"), szLangName.c_str() );
 	}
 
-	//ƒvƒ‰ƒOƒCƒ“ƒe[ƒuƒ‹‚É“o˜^‚³‚ê‚½ƒvƒ‰ƒOƒCƒ“‚ğ“Ç‚İ‚Ş
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ†ãƒ¼ãƒ–ãƒ«ã«ç™»éŒ²ã•ã‚ŒãŸãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’èª­ã¿è¾¼ã‚€
 	PluginRec* plugin_table = pluginSetting.m_PluginTable;
 	for( int iNo=0; iNo < MAX_PLUGIN; iNo++ ){
 		if( plugin_table[iNo].m_szName[0] == '\0' ) continue;
-		// 2010.08.04 íœó‘Ô‚ğŒ©‚é(¡‚Ì‚Æ‚±‚ë•ÛŒ¯)
+		// 2010.08.04 å‰Šé™¤çŠ¶æ…‹ã‚’è¦‹ã‚‹(ä»Šã®ã¨ã“ã‚ä¿é™º)
 		if( plugin_table[iNo].m_state == PLS_DELETED ) continue;
-		if( NULL != GetPlugin( iNo ) ) continue; // 2013.05.31 “Ç‚İ‚İÏ‚İ
+		if( NULL != GetPlugin( iNo ) ) continue; // 2013.05.31 èª­ã¿è¾¼ã¿æ¸ˆã¿
 		std::tstring name = to_tchar(plugin_table[iNo].m_szName);
 		CPlugin* plugin = LoadPlugin( m_sBaseDir.c_str(), name.c_str(), szLangName.c_str() );
 		if( !plugin ){
 			plugin = LoadPlugin( m_sExePluginDir.c_str(), name.c_str(), szLangName.c_str() );
 		}
 		if( plugin ){
-			// —vŒŸ“¢Fplugin.def‚Ìid‚Æsakuraw.ini‚Ìid‚Ì•sˆê’vˆ—
+			// è¦æ¤œè¨ï¼šplugin.defã®idã¨sakuraw.iniã®idã®ä¸ä¸€è‡´å‡¦ç†
 			assert_warning( 0 == auto_strcmp( plugin_table[iNo].m_szId, plugin->m_sId.c_str() ) );
-			plugin->m_id = iNo;		//ƒvƒ‰ƒOƒCƒ“ƒe[ƒuƒ‹‚Ìs”Ô†‚ğID‚Æ‚·‚é
+			plugin->m_id = iNo;		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒ†ãƒ¼ãƒ–ãƒ«ã®è¡Œç•ªå·ã‚’IDã¨ã™ã‚‹
 			m_plugins.push_back( plugin );
 			plugin_table[iNo].m_state = PLS_LOADED;
-			// ƒRƒ}ƒ“ƒh”İ’è
+			// ã‚³ãƒãƒ³ãƒ‰æ•°è¨­å®š
 			plugin_table[iNo].m_nCmdNum = plugin->GetCommandCount();
 
 			RegisterPlugin( plugin );
@@ -500,46 +500,46 @@ bool CPluginManager::LoadAllPlugin(CommonSetting* common)
 	return true;
 }
 
-//ƒvƒ‰ƒOƒCƒ“‚ğ“Ç‚İ‚Ş
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’èª­ã¿è¾¼ã‚€
 CPlugin* CPluginManager::LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* pszPluginName, const TCHAR* pszLangName )
 {
 	TCHAR pszBasePath[_MAX_PATH];
 	TCHAR pszPath[_MAX_PATH];
 	std::tstring strMlang;
-	CDataProfile cProfDef;				//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹
-	CDataProfile cProfDefMLang;			//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹(L10N)
+	CDataProfile cProfDef;				//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«
+	CDataProfile cProfDefMLang;			//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«(L10N)
 	CDataProfile* pcProfDefMLang = &cProfDefMLang; 
-	CDataProfile cProfOption;			//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹
+	CDataProfile cProfOption;			//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«
 	CPlugin* plugin = NULL;
 
 #ifdef _UNICODE
 	DEBUG_TRACE(_T("Load Plugin %ts\n"),  pszPluginName );
 #endif
-	//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Ş
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã‚€
 	Concat_FolderAndFile( pszPluginDir, pszPluginName, pszBasePath );
 	Concat_FolderAndFile( pszBasePath, PII_FILENAME, pszPath );
 	cProfDef.SetReadingMode();
 	if( !cProfDef.ReadProfile( pszPath ) ){
-		//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ª‘¶İ‚µ‚È‚¢
+		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ãªã„
 		return NULL;
 	}
 #ifdef _UNICODE
-	DEBUG_TRACE(_T("  ’è‹`ƒtƒ@ƒCƒ‹“Ç %ts\n"),  pszPath );
+	DEBUG_TRACE(_T("  å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«èª­è¾¼ %ts\n"),  pszPath );
 #endif
 
-	//L10N’è‹`ƒtƒ@ƒCƒ‹‚ğ“Ç‚Ş
-	//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Ş base\pluginname\local\plugin_en_us.def
+	//L10Nå®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã‚€
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã‚€ base\pluginname\local\plugin_en_us.def
 	strMlang = std::tstring(pszBasePath) + _T("\\") + PII_L10NDIR + _T("\\") + PII_L10NFILEBASE + pszLangName + PII_L10NFILEEXT;
 	cProfDefMLang.SetReadingMode();
 	if( !cProfDefMLang.ReadProfile( strMlang.c_str() ) ){
-		//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ª‘¶İ‚µ‚È‚¢
+		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ãªã„
 		pcProfDefMLang = NULL;
 #ifdef _UNICODE
-		DEBUG_TRACE(_T("  L10N’è‹`ƒtƒ@ƒCƒ‹“Ç %ts Not Found\n"),  strMlang.c_str() );
+		DEBUG_TRACE(_T("  L10Nå®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«èª­è¾¼ %ts Not Found\n"),  strMlang.c_str() );
 #endif
 	}else{
 #ifdef _UNICODE
-		DEBUG_TRACE(_T("  L10N’è‹`ƒtƒ@ƒCƒ‹“Ç %ts\n"),  strMlang.c_str() );
+		DEBUG_TRACE(_T("  L10Nå®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«èª­è¾¼ %ts\n"),  strMlang.c_str() );
 #endif
 	}
 
@@ -557,23 +557,23 @@ CPlugin* CPluginManager::LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* psz
 	plugin->m_sLangName = pszLangName;
 	plugin->ReadPluginDef( &cProfDef, pcProfDefMLang );
 #ifdef _UNICODE
-	DEBUG_TRACE(_T("  ƒvƒ‰ƒOƒCƒ“ƒ^ƒCƒv %ls\n"), sPlugType.c_str() );
+	DEBUG_TRACE(_T("  ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚¿ã‚¤ãƒ— %ls\n"), sPlugType.c_str() );
 #endif
 
-	//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Ş
+	//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã‚€
 	cProfOption.SetReadingMode();
 	if( cProfOption.ReadProfile( plugin->GetOptionPath().c_str() ) ){
-		//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚ª‘¶İ‚·‚éê‡A“Ç‚İ‚Ş
+		//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã™ã‚‹å ´åˆã€èª­ã¿è¾¼ã‚€
 		plugin->ReadPluginOption( &cProfOption );
 	}
 #ifdef _UNICODE
-	DEBUG_TRACE(_T("  ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹“Ç %ts\n"),  plugin->GetOptionPath().c_str() );
+	DEBUG_TRACE(_T("  ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«èª­è¾¼ %ts\n"),  plugin->GetOptionPath().c_str() );
 #endif
 
 	return plugin;
 }
 
-//ƒvƒ‰ƒOƒCƒ“‚ğCJackManager‚É“o˜^‚·‚é
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’CJackManagerã«ç™»éŒ²ã™ã‚‹
 bool CPluginManager::RegisterPlugin( CPlugin* plugin )
 {
 	CJackManager* pJackMgr = CJackManager::getInstance();
@@ -586,7 +586,7 @@ bool CPluginManager::RegisterPlugin( CPlugin* plugin )
 	return true;
 }
 
-//ƒvƒ‰ƒOƒCƒ“‚ÌCJackManager‚Ì“o˜^‚ğ‰ğœ‚·‚é
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®CJackManagerã®ç™»éŒ²ã‚’è§£é™¤ã™ã‚‹
 bool CPluginManager::UnRegisterPlugin( CPlugin* plugin )
 {
 	CJackManager* pJackMgr = CJackManager::getInstance();
@@ -599,7 +599,7 @@ bool CPluginManager::UnRegisterPlugin( CPlugin* plugin )
 	return true;
 }
 
-//ƒvƒ‰ƒOƒCƒ“‚ğæ“¾‚·‚é
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å–å¾—ã™ã‚‹
 CPlugin* CPluginManager::GetPlugin( int id )
 {
 	for( CPlugin::ListIter plugin = m_plugins.begin() ; plugin != m_plugins.end(); plugin++ ){
@@ -608,13 +608,13 @@ CPlugin* CPluginManager::GetPlugin( int id )
 	return NULL;
 }
 
-//ƒvƒ‰ƒOƒCƒ“‚ğíœ‚·‚é
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å‰Šé™¤ã™ã‚‹
 void CPluginManager::UninstallPlugin( CommonSetting& common, int id )
 {
 	PluginRec* plugin_table = common.m_sPlugin.m_PluginTable;
 
-	// 2010.08.04 ‚±‚±‚Å‚ÍID‚ğ•Û‚·‚éBŒã‚ÅÄ“x’Ç‰Á‚·‚é‚Æ‚«‚É“¯‚¶ˆÊ’u‚É’Ç‰Á
-	// PLS_DELETED‚Ìm_szId/m_szName‚Íini‚ğ•Û‘¶‚·‚é‚Æíœ‚³‚ê‚Ü‚·
+	// 2010.08.04 ã“ã“ã§ã¯IDã‚’ä¿æŒã™ã‚‹ã€‚å¾Œã§å†åº¦è¿½åŠ ã™ã‚‹ã¨ãã«åŒã˜ä½ç½®ã«è¿½åŠ 
+	// PLS_DELETEDã®m_szId/m_szNameã¯iniã‚’ä¿å­˜ã™ã‚‹ã¨å‰Šé™¤ã•ã‚Œã¾ã™
 //	plugin_table[id].m_szId[0] = '\0';
 	plugin_table[id].m_szName[0] = '\0';
 	plugin_table[id].m_state = PLS_DELETED;

--- a/sakura_core/plugin/CPluginManager.h
+++ b/sakura_core/plugin/CPluginManager.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒvƒ‰ƒOƒCƒ“ŠÇ—ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç®¡ç†ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -36,40 +36,40 @@ class CPluginManager : public TSingleton<CPluginManager>{
 	friend class TSingleton<CPluginManager>;
 	CPluginManager();
 
-	// Œ^’è‹`
+	// å‹å®šç¾©
 private:
 	typedef std::wstring wstring;
 	typedef std::string string;
 
-	// ‘€ì
+	// æ“ä½œ
 public:
-	bool LoadAllPlugin(CommonSetting* common = NULL);				//‘Sƒvƒ‰ƒOƒCƒ“‚ğ“Ç‚İ‚Ş
-	void UnloadAllPlugin();				//‘Sƒvƒ‰ƒOƒCƒ“‚ğ‰ğ•ú‚·‚é
-	bool SearchNewPlugin( CommonSetting& common, HWND hWndOwner );		//V‹Kƒvƒ‰ƒOƒCƒ“‚ğ“±“ü‚·‚é
-	int InstallPlugin( CommonSetting& common, const TCHAR* pszPluginName, HWND hWndOwner, wstring& errorMsg, bool bUpdate = false );	//ƒvƒ‰ƒOƒCƒ“‚Ì‰Šú“±“ü‚ğ‚·‚é
-	bool InstZipPlugin( CommonSetting& common, HWND hWndOwner, const tstring& sZipName, bool bInSearch=false );		//Zipƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á‚·‚é
-	CPlugin* GetPlugin( int id );		//ƒvƒ‰ƒOƒCƒ“‚ğæ“¾‚·‚é
-	void UninstallPlugin( CommonSetting& common, int id );		//ƒvƒ‰ƒOƒCƒ“‚ğíœ‚·‚é
+	bool LoadAllPlugin(CommonSetting* common = NULL);				//å…¨ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’èª­ã¿è¾¼ã‚€
+	void UnloadAllPlugin();				//å…¨ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è§£æ”¾ã™ã‚‹
+	bool SearchNewPlugin( CommonSetting& common, HWND hWndOwner );		//æ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å°å…¥ã™ã‚‹
+	int InstallPlugin( CommonSetting& common, const TCHAR* pszPluginName, HWND hWndOwner, wstring& errorMsg, bool bUpdate = false );	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®åˆæœŸå°å…¥ã‚’ã™ã‚‹
+	bool InstZipPlugin( CommonSetting& common, HWND hWndOwner, const tstring& sZipName, bool bInSearch=false );		//Zipãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ ã™ã‚‹
+	CPlugin* GetPlugin( int id );		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å–å¾—ã™ã‚‹
+	void UninstallPlugin( CommonSetting& common, int id );		//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å‰Šé™¤ã™ã‚‹
 
 private:
-	CPlugin* LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* pszPluginName, const TCHAR* pszLangName );	//ƒvƒ‰ƒOƒCƒ“‚ğ“Ç‚İ‚Ş
-	bool RegisterPlugin( CPlugin* plugin );	//ƒvƒ‰ƒOƒCƒ“‚ğCJackManager‚É“o˜^‚·‚é
-	bool UnRegisterPlugin( CPlugin* plugin );	//ƒvƒ‰ƒOƒCƒ“‚ÌCJackManager‚Ì“o˜^‚ğ‰ğœ‚·‚é
+	CPlugin* LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* pszPluginName, const TCHAR* pszLangName );	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’èª­ã¿è¾¼ã‚€
+	bool RegisterPlugin( CPlugin* plugin );	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’CJackManagerã«ç™»éŒ²ã™ã‚‹
+	bool UnRegisterPlugin( CPlugin* plugin );	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®CJackManagerã®ç™»éŒ²ã‚’è§£é™¤ã™ã‚‹
 
-	//‘®«
+	//å±æ€§
 public:
-	//pluginsƒtƒHƒ‹ƒ_‚ÌƒpƒX
+	//pluginsãƒ•ã‚©ãƒ«ãƒ€ã®ãƒ‘ã‚¹
 	const tstring GetBaseDir() { return m_sBaseDir; }
 	const tstring GetExePluginDir() { return m_sExePluginDir; }
-	bool SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, const tstring& sSearchDir, bool& bCancel );		//V‹Kƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á‚·‚é(‰º¿‚¯)
-	bool SearchNewPluginZip( CommonSetting& common, HWND hWndOwner, const tstring& sSearchDir, bool& bCancel );		//V‹Kƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á‚·‚é(‰º¿‚¯)Zip File
-	bool InstZipPluginSub( CommonSetting& common, HWND hWndOwner, const tstring& sZipName, const tstring& sDispName, bool bInSearch, bool& bCancel );		//Zipƒvƒ‰ƒOƒCƒ“‚ğ“±“ü‚·‚é(‰º¿‚¯)
+	bool SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, const tstring& sSearchDir, bool& bCancel );		//æ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ ã™ã‚‹(ä¸‹è«‹ã‘)
+	bool SearchNewPluginZip( CommonSetting& common, HWND hWndOwner, const tstring& sSearchDir, bool& bCancel );		//æ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ ã™ã‚‹(ä¸‹è«‹ã‘)Zip File
+	bool InstZipPluginSub( CommonSetting& common, HWND hWndOwner, const tstring& sZipName, const tstring& sDispName, bool bInSearch, bool& bCancel );		//Zipãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å°å…¥ã™ã‚‹(ä¸‹è«‹ã‘)
 
-	// ƒƒ“ƒo•Ï”
+	// ãƒ¡ãƒ³ãƒå¤‰æ•°
 private:
 	CPlugin::List m_plugins;
-	tstring m_sBaseDir;					//pluginsƒtƒHƒ‹ƒ_‚ÌƒpƒX
-	tstring m_sExePluginDir;			//ExeƒtƒHƒ‹ƒ_”z‰ºpluginsƒtƒHƒ‹ƒ_‚ÌƒpƒX
+	tstring m_sBaseDir;					//pluginsãƒ•ã‚©ãƒ«ãƒ€ã®ãƒ‘ã‚¹
+	tstring m_sExePluginDir;			//Exeãƒ•ã‚©ãƒ«ãƒ€é…ä¸‹pluginsãƒ•ã‚©ãƒ«ãƒ€ã®ãƒ‘ã‚¹
 
 };
 

--- a/sakura_core/plugin/CSmartIndentIfObj.h
+++ b/sakura_core/plugin/CSmartIndentIfObj.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief SmartIndentƒIƒuƒWƒFƒNƒg
+ï»¿/*!	@file
+	@brief SmartIndentã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 
 */
 /*
@@ -31,19 +31,19 @@
 
 #include "macro/CWSHIfObj.h"
 
-// ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒg—pWSHƒIƒuƒWƒFƒNƒg
+// ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆç”¨WSHã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 class CSmartIndentIfObj : public CWSHIfObj
 {
-	// Œ^’è‹`
+	// å‹å®šç¾©
 	enum FuncId {
-		F_SI_COMMAND_FIRST = 0,					//«ƒRƒ}ƒ“ƒh‚ÍˆÈ‰º‚É’Ç‰Á‚·‚é
-		F_SI_FUNCTION_FIRST = F_FUNCTION_FIRST,	//«ŠÖ”‚ÍˆÈ‰º‚É’Ç‰Á‚·‚é
-		F_SI_GETCHAR							//‰Ÿ‰º‚µ‚½ƒL[‚ğæ“¾‚·‚é
+		F_SI_COMMAND_FIRST = 0,					//â†“ã‚³ãƒãƒ³ãƒ‰ã¯ä»¥ä¸‹ã«è¿½åŠ ã™ã‚‹
+		F_SI_FUNCTION_FIRST = F_FUNCTION_FIRST,	//â†“é–¢æ•°ã¯ä»¥ä¸‹ã«è¿½åŠ ã™ã‚‹
+		F_SI_GETCHAR							//æŠ¼ä¸‹ã—ãŸã‚­ãƒ¼ã‚’å–å¾—ã™ã‚‹
 	};
 	typedef std::string string;
 	typedef std::wstring wstring;
 
-	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	// ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CSmartIndentIfObj( wchar_t ch )
 		: CWSHIfObj( L"Indent", false )
@@ -51,36 +51,36 @@ public:
 	{
 	}
 
-	// ƒfƒXƒgƒ‰ƒNƒ^
+	// ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	~CSmartIndentIfObj(){}
 
-	// À‘•
+	// å®Ÿè£…
 public:
-	//ƒRƒ}ƒ“ƒhî•ñ‚ğæ“¾‚·‚é
+	//ã‚³ãƒãƒ³ãƒ‰æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 	MacroFuncInfoArray GetMacroCommandInfo() const{
 		static MacroFuncInfo macroFuncInfoArr[] = {
-			//	I’[
+			//	çµ‚ç«¯
 			{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 		};
 		return macroFuncInfoArr;
 	}
-	//ŠÖ”î•ñ‚ğæ“¾‚·‚é
+	//é–¢æ•°æƒ…å ±ã‚’å–å¾—ã™ã‚‹
 	MacroFuncInfoArray GetMacroFuncInfo() const{
 		static MacroFuncInfo macroFuncInfoNotCommandArr[] = {
-			//ID									ŠÖ”–¼							ˆø”										–ß‚è’l‚ÌŒ^	m_pszData
-			{EFunctionCode(F_SI_GETCHAR),			LTEXT("GetChar"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //‰Ÿ‰º‚µ‚½ƒL[‚ğæ“¾‚·‚é
-			//	I’[
+			//ID									é–¢æ•°å							å¼•æ•°										æˆ»ã‚Šå€¤ã®å‹	m_pszData
+			{EFunctionCode(F_SI_GETCHAR),			LTEXT("GetChar"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //æŠ¼ä¸‹ã—ãŸã‚­ãƒ¼ã‚’å–å¾—ã™ã‚‹
+			//	çµ‚ç«¯
 			{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 		};
 		return macroFuncInfoNotCommandArr;
 	}
-	//ŠÖ”‚ğˆ—‚·‚é
+	//é–¢æ•°ã‚’å‡¦ç†ã™ã‚‹
 	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 	{
 		switch ( LOWORD(ID) ) 
 		{
-		case F_SI_GETCHAR:						//‰Ÿ‰º‚µ‚½ƒL[‚ğæ“¾‚·‚é
+		case F_SI_GETCHAR:						//æŠ¼ä¸‹ã—ãŸã‚­ãƒ¼ã‚’å–å¾—ã™ã‚‹
 			{
 				wstring sValue;
 				sValue += m_wcChar;
@@ -91,13 +91,13 @@ public:
 		}
 		return false;
 	}
-	//ƒRƒ}ƒ“ƒh‚ğˆ—‚·‚é
+	//ã‚³ãƒãƒ³ãƒ‰ã‚’å‡¦ç†ã™ã‚‹
 	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize)
 	{
 		return false;
 	}
 
-	// ƒƒ“ƒo•Ï”
+	// ãƒ¡ãƒ³ãƒå¤‰æ•°
 public:
 	wchar_t m_wcChar;
 };

--- a/sakura_core/plugin/CWSHPlugin.cpp
+++ b/sakura_core/plugin/CWSHPlugin.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief WSHƒvƒ‰ƒOƒCƒ“ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief WSHãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -30,7 +30,7 @@
 #include "plugin/CPluginIfObj.h"
 #include "macro/CWSHManager.h"
 
-// ƒfƒXƒgƒ‰ƒNƒ^
+// ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 CWSHPlugin::~CWSHPlugin(void)
 {
 	for( CPlug::ArrayIter it = m_plugs.begin(); it != m_plugs.end(); it++ ){
@@ -38,36 +38,36 @@ CWSHPlugin::~CWSHPlugin(void)
 	}
 }
 
-//ƒvƒ‰ƒOƒCƒ“’è‹`ƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Ş
+//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã‚€
 bool CWSHPlugin::ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang )
 {
 	ReadPluginDefCommon( cProfile, cProfileMlang );
 
-	//WSHƒZƒNƒVƒ‡ƒ“‚Ì“Ç‚İ‚İ
+	//WSHã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®èª­ã¿è¾¼ã¿
 	cProfile->IOProfileData<bool>( PII_WSH, PII_WSH_USECACHE, m_bUseCache );
 
-	//ƒvƒ‰ƒO‚Ì“Ç‚İ‚İ
+	//ãƒ—ãƒ©ã‚°ã®èª­ã¿è¾¼ã¿
 	ReadPluginDefPlug( cProfile, cProfileMlang );
 
-	//ƒRƒ}ƒ“ƒh‚Ì“Ç‚İ‚İ
+	//ã‚³ãƒãƒ³ãƒ‰ã®èª­ã¿è¾¼ã¿
 	ReadPluginDefCommand( cProfile, cProfileMlang );
 
-	//ƒIƒvƒVƒ‡ƒ“’è‹`‚Ì“Ç‚İ‚İ	// 2010/3/24 Uchi
+	//ã‚ªãƒ—ã‚·ãƒ§ãƒ³å®šç¾©ã®èª­ã¿è¾¼ã¿	// 2010/3/24 Uchi
 	ReadPluginDefOption( cProfile, cProfileMlang );
 
-	//•¶š—ñ’è‹`‚Ì“Ç‚İ‚İ
+	//æ–‡å­—åˆ—å®šç¾©ã®èª­ã¿è¾¼ã¿
 	ReadPluginDefString( cProfile, cProfileMlang );
 
 	return true;
 }
 
-//ƒIƒvƒVƒ‡ƒ“ƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Ş
+//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ã‚’èª­ã¿è¾¼ã‚€
 bool CWSHPlugin::ReadPluginOption( CDataProfile *cProfile )
 {
 	return true;
 }
 
-//ƒvƒ‰ƒO‚ğÀs‚·‚é
+//ãƒ—ãƒ©ã‚°ã‚’å®Ÿè¡Œã™ã‚‹
 bool CWSHPlugin::InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& params )
 {
 	CWSHPlug& wshPlug = static_cast<CWSHPlug&>( plug );
@@ -90,12 +90,12 @@ bool CWSHPlugin::InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& para
 		pWsh = wshPlug.m_Wsh;
 	}
 
-	CPluginIfObj cPluginIfo(*this);		//PluginƒIƒuƒWƒFƒNƒg‚ğ’Ç‰Á
+	CPluginIfObj cPluginIfo(*this);		//Pluginã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’è¿½åŠ 
 	cPluginIfo.AddRef();
-	cPluginIfo.SetPlugIndex( plug.m_id );	//Às’†ƒvƒ‰ƒO”Ô†‚ğ’ñ‹Ÿ
+	cPluginIfo.SetPlugIndex( plug.m_id );	//å®Ÿè¡Œä¸­ãƒ—ãƒ©ã‚°ç•ªå·ã‚’æä¾›
 	pWsh->AddParam( &cPluginIfo );
 
-	pWsh->AddParam( params );			//ƒpƒ‰ƒ[ƒ^‚ğ’Ç‰Á
+	pWsh->AddParam( params );			//ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã‚’è¿½åŠ 
 
 	pWsh->ExecKeyMacro2( view, FA_NONRECORD | FA_FROMMACRO );
 
@@ -104,7 +104,7 @@ bool CWSHPlugin::InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& para
 	if( m_bUseCache ){
 		wshPlug.m_Wsh = pWsh;
 	}else{
-		// I‚í‚Á‚½‚çŠJ•ú
+		// çµ‚ã‚ã£ãŸã‚‰é–‹æ”¾
 		delete pWsh;
 	}
 

--- a/sakura_core/plugin/CWSHPlugin.h
+++ b/sakura_core/plugin/CWSHPlugin.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief WSHƒvƒ‰ƒOƒCƒ“ƒNƒ‰ƒX
+ï»¿/*!	@file
+	@brief WSHãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚¯ãƒ©ã‚¹
 
 */
 /*
@@ -31,8 +31,8 @@
 #include "plugin/CPlugin.h"
 #include "macro/CWSHManager.h"
 
-#define PII_WSH						L"Wsh"			//WSHƒZƒNƒVƒ‡ƒ“
-#define PII_WSH_USECACHE			L"UseCache"		//“Ç‚İ‚ñ‚¾ƒXƒNƒŠƒvƒg‚ğÄ—˜—p‚·‚é
+#define PII_WSH						L"Wsh"			//WSHã‚»ã‚¯ã‚·ãƒ§ãƒ³
+#define PII_WSH_USECACHE			L"UseCache"		//èª­ã¿è¾¼ã‚“ã ã‚¹ã‚¯ãƒªãƒ—ãƒˆã‚’å†åˆ©ç”¨ã™ã‚‹
 
 
 class CWSHPlug :
@@ -56,24 +56,24 @@ public:
 class CWSHPlugin :
 	public CPlugin
 {
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	CWSHPlugin( const tstring& sBaseDir ) : CPlugin( sBaseDir ) {
 		m_bUseCache = false;
 	}
 
-	//ƒfƒXƒgƒ‰ƒNƒ^
+	//ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 public:
 	~CWSHPlugin(void);
 
-	//‘€ì
-	//CPlugƒCƒ“ƒXƒ^ƒ“ƒX‚Ìì¬BReadPluginDefPlug/Command ‚©‚çŒÄ‚Î‚ê‚éB
+	//æ“ä½œ
+	//CPlugã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ä½œæˆã€‚ReadPluginDefPlug/Command ã‹ã‚‰å‘¼ã°ã‚Œã‚‹ã€‚
 	virtual CPlug* CreatePlug( CPlugin& plugin, PlugId id, wstring sJack, wstring sHandler, wstring sLabel )
 	{
 		return new CWSHPlug( plugin, id, sJack, sHandler, sLabel );
 	}
 
-	//À‘•
+	//å®Ÿè£…
 public:
 	bool ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang );
 	bool ReadPluginOption( CDataProfile *cProfile );
@@ -82,7 +82,7 @@ public:
 	}
 	bool InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& params );
 
-	//ƒƒ“ƒo•Ï”
+	//ãƒ¡ãƒ³ãƒå¤‰æ•°
 private:
 	bool m_bUseCache;
 


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/plugin
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。

主に動作影響について対応前後で挙動に変化がないことのご確認をいただけると助かります。
