### PR TITLE
prop 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/prop/CPropComBackup.cpp
+++ b/sakura_core/prop/CPropComBackup.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ���ʐݒ�_�C�A���O�{�b�N�X�A�u�o�b�N�A�b�v�v�y�[�W
+﻿/*!	@file
+	@brief 共通設定ダイアログボックス、「バックアップ」ページ
 
 	@author Norio Nakatani
 */
@@ -27,31 +27,31 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//10000
-	IDC_BUTTON_BACKUP_FOLDER_REF,	HIDC_BUTTON_BACKUP_FOLDER_REF,	//�o�b�N�A�b�v�t�H���_�Q��
-	IDC_CHECK_BACKUP,				HIDC_CHECK_BACKUP,				//�o�b�N�A�b�v�̍쐬
-	IDC_CHECK_BACKUP_YEAR,			HIDC_CHECK_BACKUP_YEAR,			//�o�b�N�A�b�v�t�@�C�����i����N�j
-	IDC_CHECK_BACKUP_MONTH,			HIDC_CHECK_BACKUP_MONTH,		//�o�b�N�A�b�v�t�@�C�����i���j
-	IDC_CHECK_BACKUP_DAY,			HIDC_CHECK_BACKUP_DAY,			//�o�b�N�A�b�v�t�@�C�����i���j
-	IDC_CHECK_BACKUP_HOUR,			HIDC_CHECK_BACKUP_HOUR,			//�o�b�N�A�b�v�t�@�C�����i���j
-	IDC_CHECK_BACKUP_MIN,			HIDC_CHECK_BACKUP_MIN,			//�o�b�N�A�b�v�t�@�C�����i���j
-	IDC_CHECK_BACKUP_SEC,			HIDC_CHECK_BACKUP_SEC,			//�o�b�N�A�b�v�t�@�C�����i�b�j
-	IDC_CHECK_BACKUPDIALOG,			HIDC_CHECK_BACKUPDIALOG,		//�쐬�O�Ɋm�F
-	IDC_CHECK_BACKUPFOLDER,			HIDC_CHECK_BACKUPFOLDER,		//�w��t�H���_�ɍ쐬
-	IDC_CHECK_BACKUP_FOLDER_RM,		HIDC_CHECK_BACKUP_FOLDER_RM,	//�w��t�H���_�ɍ쐬(�����[�o�u�����f�B�A�̂�)
-	IDC_CHECK_BACKUP_DUSTBOX,		HIDC_CHECK_BACKUP_DUSTBOX,		//�o�b�N�A�b�v�t�@�C�������ݔ��ɕ��荞��	//@@@ 2001.12.11 add MIK
-	IDC_EDIT_BACKUPFOLDER,			HIDC_EDIT_BACKUPFOLDER,			//�ۑ��t�H���_��
-	IDC_EDIT_BACKUP_3,				HIDC_EDIT_BACKUP_3,				//���㐔
-	IDC_RADIO_BACKUP_TYPE1,			HIDC_RADIO_BACKUP_TYPE1,		//�o�b�N�A�b�v�̎�ށi�g���q�j
-//	IDC_RADIO_BACKUP_TYPE2,			HIDC_RADIO_BACKUP_TYPE2NEWHID,		//�o�b�N�A�b�v�̎�ށi���t�E�����j // 2002.11.09 Moca HID��.._TYPE3�Ƌt������	// Jun.  5, 2004 genta �p�~
-	IDC_RADIO_BACKUP_TYPE3,			HIDC_RADIO_BACKUP_TYPE3NEWHID,		//�o�b�N�A�b�v�̎�ށi�A�ԁj// 2002.11.09 Moca HID��.._TYPE2�Ƌt������
-	IDC_RADIO_BACKUP_DATETYPE1,		HIDC_RADIO_BACKUP_DATETYPE1,	//�t����������̎�ށi�쐬�����j	//Jul. 05, 2001 JEPRO �ǉ�
-	IDC_RADIO_BACKUP_DATETYPE2,		HIDC_RADIO_BACKUP_DATETYPE2,	//�t����������̎�ށi�X�V�����j	//Jul. 05, 2001 JEPRO �ǉ�
-	IDC_SPIN_BACKUP_GENS,			HIDC_EDIT_BACKUP_3,				//�ۑ����鐢�㐔�̃X�s��
-	IDC_CHECK_BACKUP_RETAINEXT,		HIDC_CHECK_BACKUP_RETAINEXT,	//���̊g���q��ۑ�	// 2006.08.06 ryoji
-	IDC_CHECK_BACKUP_ADVANCED,		HIDC_CHECK_BACKUP_ADVANCED,		//�ڍאݒ�	// 2006.08.06 ryoji
-	IDC_EDIT_BACKUPFILE,			HIDC_EDIT_BACKUPFILE,			//�ڍאݒ�̃G�f�B�b�g�{�b�N�X	// 2006.08.06 ryoji
-	IDC_RADIO_BACKUP_DATETYPE1A,	HIDC_RADIO_BACKUP_DATETYPE1A,	//�t����������̎�ށi�쐬�����j���ڍאݒ�ON�p	// 2009.02.20 ryoji
-	IDC_RADIO_BACKUP_DATETYPE2A,	HIDC_RADIO_BACKUP_DATETYPE2A,	//�t����������̎�ށi�X�V�����j���ڍאݒ�ON�p	// 2009.02.20 ryoji
+	IDC_BUTTON_BACKUP_FOLDER_REF,	HIDC_BUTTON_BACKUP_FOLDER_REF,	//バックアップフォルダ参照
+	IDC_CHECK_BACKUP,				HIDC_CHECK_BACKUP,				//バックアップの作成
+	IDC_CHECK_BACKUP_YEAR,			HIDC_CHECK_BACKUP_YEAR,			//バックアップファイル名（西暦年）
+	IDC_CHECK_BACKUP_MONTH,			HIDC_CHECK_BACKUP_MONTH,		//バックアップファイル名（月）
+	IDC_CHECK_BACKUP_DAY,			HIDC_CHECK_BACKUP_DAY,			//バックアップファイル名（日）
+	IDC_CHECK_BACKUP_HOUR,			HIDC_CHECK_BACKUP_HOUR,			//バックアップファイル名（時）
+	IDC_CHECK_BACKUP_MIN,			HIDC_CHECK_BACKUP_MIN,			//バックアップファイル名（分）
+	IDC_CHECK_BACKUP_SEC,			HIDC_CHECK_BACKUP_SEC,			//バックアップファイル名（秒）
+	IDC_CHECK_BACKUPDIALOG,			HIDC_CHECK_BACKUPDIALOG,		//作成前に確認
+	IDC_CHECK_BACKUPFOLDER,			HIDC_CHECK_BACKUPFOLDER,		//指定フォルダに作成
+	IDC_CHECK_BACKUP_FOLDER_RM,		HIDC_CHECK_BACKUP_FOLDER_RM,	//指定フォルダに作成(リムーバブルメディアのみ)
+	IDC_CHECK_BACKUP_DUSTBOX,		HIDC_CHECK_BACKUP_DUSTBOX,		//バックアップファイルをごみ箱に放り込む	//@@@ 2001.12.11 add MIK
+	IDC_EDIT_BACKUPFOLDER,			HIDC_EDIT_BACKUPFOLDER,			//保存フォルダ名
+	IDC_EDIT_BACKUP_3,				HIDC_EDIT_BACKUP_3,				//世代数
+	IDC_RADIO_BACKUP_TYPE1,			HIDC_RADIO_BACKUP_TYPE1,		//バックアップの種類（拡張子）
+//	IDC_RADIO_BACKUP_TYPE2,			HIDC_RADIO_BACKUP_TYPE2NEWHID,		//バックアップの種類（日付・時刻） // 2002.11.09 Moca HIDが.._TYPE3と逆だった	// Jun.  5, 2004 genta 廃止
+	IDC_RADIO_BACKUP_TYPE3,			HIDC_RADIO_BACKUP_TYPE3NEWHID,		//バックアップの種類（連番）// 2002.11.09 Moca HIDが.._TYPE2と逆だった
+	IDC_RADIO_BACKUP_DATETYPE1,		HIDC_RADIO_BACKUP_DATETYPE1,	//付加する日時の種類（作成日時）	//Jul. 05, 2001 JEPRO 追加
+	IDC_RADIO_BACKUP_DATETYPE2,		HIDC_RADIO_BACKUP_DATETYPE2,	//付加する日時の種類（更新日時）	//Jul. 05, 2001 JEPRO 追加
+	IDC_SPIN_BACKUP_GENS,			HIDC_EDIT_BACKUP_3,				//保存する世代数のスピン
+	IDC_CHECK_BACKUP_RETAINEXT,		HIDC_CHECK_BACKUP_RETAINEXT,	//元の拡張子を保存	// 2006.08.06 ryoji
+	IDC_CHECK_BACKUP_ADVANCED,		HIDC_CHECK_BACKUP_ADVANCED,		//詳細設定	// 2006.08.06 ryoji
+	IDC_EDIT_BACKUPFILE,			HIDC_EDIT_BACKUPFILE,			//詳細設定のエディットボックス	// 2006.08.06 ryoji
+	IDC_RADIO_BACKUP_DATETYPE1A,	HIDC_RADIO_BACKUP_DATETYPE1A,	//付加する日時の種類（作成日時）※詳細設定ON用	// 2009.02.20 ryoji
+	IDC_RADIO_BACKUP_DATETYPE2A,	HIDC_RADIO_BACKUP_DATETYPE2A,	//付加する日時の種類（更新日時）※詳細設定ON用	// 2009.02.20 ryoji
 //	IDC_STATIC,						-1,
 	0, 0
 };
@@ -59,10 +59,10 @@ static const DWORD p_helpids[] = {	//10000
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg �_�C�A���O�{�b�N�X��Window Handle
-	@param uMsg ���b�Z�[�W
-	@param wParam �p�����[�^1
-	@param lParam �p�����[�^2
+	@param hwndDlg ダイアログボックスのWindow Handle
+	@param uMsg メッセージ
+	@param wParam パラメータ1
+	@param lParam パラメータ2
 */
 INT_PTR CALLBACK CPropBackup::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -72,7 +72,7 @@ INT_PTR CALLBACK CPropBackup::DlgProc_page(
 //	To Here Jun. 2, 2001 genta
 
 
-/* ���b�Z�[�W���� */
+/* メッセージ処理 */
 INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	WORD		wNotifyCode;
@@ -81,21 +81,21 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 	NM_UPDOWN*	pMNUD;
 	int			idCtrl;
 //	int			nVal;
-	int			nVal;	//Sept.21, 2000 JEPRO �X�s���v�f���������̂ŕ���������
+	int			nVal;	//Sept.21, 2000 JEPRO スピン要素を加えたので復活させた
 //	int			nDummy;
 //	int			nCharChars;
 
 	switch( uMsg ){
 
 	case WM_INITDIALOG:
-		/* �_�C�A���O�f�[�^�̐ݒ� Backup */
+		/* ダイアログデータの設定 Backup */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ���[�U�[���G�f�B�b�g �R���g���[���ɓ��͂ł���e�L�X�g�̒����𐧌����� */
-		//	Oct. 5, 2002 genta �o�b�N�A�b�v�t�H���_���̓��̓T�C�Y���w��
-		//	Oct. 8, 2002 genta �Ō�ɕt�������\�̗̈���c�����߃o�b�t�@�T�C�Y-1�������͂����Ȃ�
+		/* ユーザーがエディット コントロールに入力できるテキストの長さを制限する */
+		//	Oct. 5, 2002 genta バックアップフォルダ名の入力サイズを指定
+		//	Oct. 8, 2002 genta 最後に付加される\の領域を残すためバッファサイズ-1しか入力させない
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_BACKUPFOLDER ), _countof2(m_Common.m_sBackup.m_szBackUpFolder) - 1 - 1 );
 		// 20051107 aroka
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_BACKUPFILE ), _countof2(m_Common.m_sBackup.m_szBackUpPathAdvanced) - 1 - 1 );
@@ -112,10 +112,10 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 				OnHelp( hwndDlg, IDD_PROP_BACKUP );
 				return TRUE;
 			case PSN_KILLACTIVE:
-				/* �_�C�A���O�f�[�^�̎擾 Backup */
+				/* ダイアログデータの取得 Backup */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+//@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_BACKUP;
 				return TRUE;
@@ -123,7 +123,7 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 			break;
 
 		case IDC_SPIN_BACKUP_GENS:
-			/* �o�b�N�A�b�v�t�@�C���̐��㐔 */
+			/* バックアップファイルの世代数 */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_BACKUP_3, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -140,26 +140,26 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_BACKUP_3, nVal, FALSE );
 			return TRUE;
 		}
-//****	To Here Sept. 21, 2000 JEPRO �_�C�A���O�v�f�ɃX�s��������̂ňȉ���WM_NOTIFY���R�����g�A�E�g�ɂ����ɏC����u����
+//****	To Here Sept. 21, 2000 JEPRO ダイアログ要素にスピンを入れるので以下のWM_NOTIFYをコメントアウトにし下に修正を置いた
 		break;
 
 	case WM_COMMAND:
-		wNotifyCode	= HIWORD(wParam);	/* �ʒm�R�[�h */
-		wID			= LOWORD(wParam);	/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
+		wNotifyCode	= HIWORD(wParam);	/* 通知コード */
+		wID			= LOWORD(wParam);	/* 項目ID､ コントロールID､ またはアクセラレータID */
 		switch( wNotifyCode ){
-		/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+		/* ボタン／チェックボックスがクリックされた */
 		case BN_CLICKED:
 			switch( wID ){
 			case IDC_RADIO_BACKUP_TYPE1:
 				//	Aug. 16, 2000 genta
-				//	�o�b�N�A�b�v�����ǉ�
+				//	バックアップ方式追加
 			case IDC_RADIO_BACKUP_TYPE3:
 			case IDC_CHECK_BACKUP:
 			case IDC_CHECK_BACKUPFOLDER:
 				//	Aug. 21, 2000 genta
 			case IDC_CHECK_AUTOSAVE:
-			//	Jun.  5, 2004 genta IDC_RADIO_BACKUP_TYPE2��p�~���āC
-			//	IDC_RADIO_BACKUP_DATETYPE1, IDC_RADIO_BACKUP_DATETYPE2�𓯗�Ɏ����Ă���
+			//	Jun.  5, 2004 genta IDC_RADIO_BACKUP_TYPE2を廃止して，
+			//	IDC_RADIO_BACKUP_DATETYPE1, IDC_RADIO_BACKUP_DATETYPE2を同列に持ってきた
 			case IDC_RADIO_BACKUP_DATETYPE1:
 			case IDC_RADIO_BACKUP_DATETYPE2:
 			// 20051107 aroka
@@ -168,9 +168,9 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 				UpdateBackupFile( hwndDlg );
 				EnableBackupInput(hwndDlg);
 				return TRUE;
-			case IDC_BUTTON_BACKUP_FOLDER_REF:	/* �t�H���_�Q�� */
+			case IDC_BUTTON_BACKUP_FOLDER_REF:	/* フォルダ参照 */
 				{
-					/* �o�b�N�A�b�v���쐬����t�H���_ */
+					/* バックアップを作成するフォルダ */
 					TCHAR		szFolder[_MAX_PATH];
 					::DlgItem_GetText( hwndDlg, IDC_EDIT_BACKUPFOLDER, szFolder, _countof( szFolder ));
 
@@ -181,15 +181,15 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 					UpdateBackupFile( hwndDlg );
 				}
 				return TRUE;
-			default: // 20051107 aroka Default�� �ǉ�
+			default: // 20051107 aroka Default節 追加
 				GetData( hwndDlg );
 				UpdateBackupFile( hwndDlg );
 			}
 			break;	/* BN_CLICKED */
-		case EN_CHANGE: // 20051107 aroka �t�H���_���ύX���ꂽ�烊�A���^�C���ɃG�f�B�b�g�{�b�N�X�����X�V
+		case EN_CHANGE: // 20051107 aroka フォルダが変更されたらリアルタイムにエディットボックス内を更新
 			switch( wID ){
 			case IDC_EDIT_BACKUPFOLDER:
-				// 2009.02.21 ryoji ����\���ǉ������̂ŁC1�����]�T���݂�K�v������D
+				// 2009.02.21 ryoji 後ろに\が追加されるので，1文字余裕をみる必要がある．
 				::DlgItem_GetText( hwndDlg, IDC_EDIT_BACKUPFOLDER, m_Common.m_sBackup.m_szBackUpFolder, _countof2(m_Common.m_sBackup.m_szBackUpFolder) - 1 );
 				UpdateBackupFile( hwndDlg );
 				break;
@@ -202,7 +202,7 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -212,7 +212,7 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -221,38 +221,38 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 }
 
 
-/*! �_�C�A���O�f�[�^�̐ݒ�
-	@date 2004.06.05 genta ���̊g���q���c���ݒ��ǉ��D
-		�����w��Ń`�F�b�N�{�b�N�X���󗓂Ŏc��Ɛݒ肳��Ȃ���������邽�߁C
+/*! ダイアログデータの設定
+	@date 2004.06.05 genta 元の拡張子を残す設定を追加．
+		日時指定でチェックボックスが空欄で残ると設定されない問題を避けるため，
 		IDC_RADIO_BACKUP_TYPE2
-		��p�~���ă��C�A�E�g�ύX
+		を廃止してレイアウト変更
 */
 void CPropBackup::SetData( HWND hwndDlg )
 {
 //	BOOL	bRet;
 
-//	BOOL				m_bGrepExitConfirm;	/* Grep���[�h�ŕۑ��m�F���邩 */
+//	BOOL				m_bGrepExitConfirm;	/* Grepモードで保存確認するか */
 
 
-	/* �o�b�N�A�b�v�̍쐬 */
+	/* バックアップの作成 */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUP, m_Common.m_sBackup.m_bBackUp );
-	/* �o�b�N�A�b�v�̍쐬�O�Ɋm�F */
+	/* バックアップの作成前に確認 */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUPDIALOG, m_Common.m_sBackup.m_bBackUpDialog );
-//	/* �w��t�H���_�Ƀo�b�N�A�b�v���쐬���� */ //	20051107 aroka �u�o�b�N�A�b�v�̍쐬�v�ɘA��������
+//	/* 指定フォルダにバックアップを作成する */ //	20051107 aroka 「バックアップの作成」に連動させる
 //	::CheckDlgButton( hwndDlg, IDC_CHECK_BACKUPFOLDER, .m_sBackup.m_bBackUpFolder );
 
-	/* �o�b�N�A�b�v�t�@�C�����̃^�C�v 1=(.bak) 2=*_���t.* */
-	//	Jun.  5, 2004 genta ���̊g���q���c���ݒ�(5,6)��ǉ��D
+	/* バックアップファイル名のタイプ 1=(.bak) 2=*_日付.* */
+	//	Jun.  5, 2004 genta 元の拡張子を残す設定(5,6)を追加．
 	switch( m_Common.m_sBackup.GetBackupType() ){
 	case 2:
-		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_DATETYPE1, 1 );	// �t��������t�̃^�C�v(������)
+		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_DATETYPE1, 1 );	// 付加する日付のタイプ(現時刻)
 		break;
 	case 3:
 	case 6:
 		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_TYPE3, 1 );
 		break;
 	case 4:
-		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_DATETYPE2, 1 );	// �t��������t�̃^�C�v(�O��̕ۑ�����)
+		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_DATETYPE2, 1 );	// 付加する日付のタイプ(前回の保存時刻)
 		break;
 	case 5:
 	case 1:
@@ -261,47 +261,47 @@ void CPropBackup::SetData( HWND hwndDlg )
 		break;
 	}
 	
-	//	Jun.  5, 2004 genta ���̊g���q���c���ݒ�(5,6)��ǉ��D
+	//	Jun.  5, 2004 genta 元の拡張子を残す設定(5,6)を追加．
 	::CheckDlgButton( hwndDlg, IDC_CHECK_BACKUP_RETAINEXT,
 		( m_Common.m_sBackup.GetBackupType() == 5 || m_Common.m_sBackup.GetBackupType() == 6 ) ? 1 : 0
 	 );
 
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̔N */
+	/* バックアップファイル名：日付の年 */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUP_YEAR, m_Common.m_sBackup.GetBackupOpt(BKUP_YEAR) );
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̌� */
+	/* バックアップファイル名：日付の月 */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUP_MONTH, m_Common.m_sBackup.GetBackupOpt(BKUP_MONTH) );
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̓� */
+	/* バックアップファイル名：日付の日 */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUP_DAY, m_Common.m_sBackup.GetBackupOpt(BKUP_DAY) );
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̎� */
+	/* バックアップファイル名：日付の時 */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUP_HOUR, m_Common.m_sBackup.GetBackupOpt(BKUP_HOUR) );
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̕� */
+	/* バックアップファイル名：日付の分 */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUP_MIN, m_Common.m_sBackup.GetBackupOpt(BKUP_MIN) );
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̕b */
+	/* バックアップファイル名：日付の秒 */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUP_SEC, m_Common.m_sBackup.GetBackupOpt(BKUP_SEC) );
 
-	/* �w��t�H���_�Ƀo�b�N�A�b�v���쐬���� */ // 20051107 aroka �ړ��F�A���Ώۂɂ���B
+	/* 指定フォルダにバックアップを作成する */ // 20051107 aroka 移動：連動対象にする。
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUPFOLDER, m_Common.m_sBackup.m_bBackUpFolder );
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BACKUP_FOLDER_RM, m_Common.m_sBackup.m_bBackUpFolderRM );	// 2010/5/27 Uchi
 
-	/* �o�b�N�A�b�v���쐬����t�H���_ */
+	/* バックアップを作成するフォルダ */
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_BACKUPFOLDER, m_Common.m_sBackup.m_szBackUpFolder );
 
-	/* �o�b�N�A�b�v�t�@�C�������ݔ��ɕ��荞�� */	//@@@ 2001.12.11 add MIK
+	/* バックアップファイルをごみ箱に放り込む */	//@@@ 2001.12.11 add MIK
 	::CheckDlgButton( hwndDlg, IDC_CHECK_BACKUP_DUSTBOX, m_Common.m_sBackup.m_bBackUpDustBox?BST_CHECKED:BST_UNCHECKED );	//@@@ 2001.12.11 add MIK
 
-	/* �o�b�N�A�b�v��t�H���_���ڍאݒ肷�� */ // 20051107 aroka
+	/* バックアップ先フォルダを詳細設定する */ // 20051107 aroka
 	::CheckDlgButton( hwndDlg, IDC_CHECK_BACKUP_ADVANCED, m_Common.m_sBackup.m_bBackUpPathAdvanced?BST_CHECKED:BST_UNCHECKED );
 
-	/* �o�b�N�A�b�v���쐬����t�H���_�̏ڍאݒ� */ // 20051107 aroka
+	/* バックアップを作成するフォルダの詳細設定 */ // 20051107 aroka
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_BACKUPFILE, m_Common.m_sBackup.m_szBackUpPathAdvanced );
 
-	/* �o�b�N�A�b�v���쐬����t�H���_�̏ڍאݒ� */ // 20051128 aroka
+	/* バックアップを作成するフォルダの詳細設定 */ // 20051128 aroka
 	switch( m_Common.m_sBackup.GetBackupTypeAdv() ){
 	case 2:
-		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_DATETYPE1A, 1 );	// �t��������t�̃^�C�v(������)
+		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_DATETYPE1A, 1 );	// 付加する日付のタイプ(現時刻)
 		break;
 	case 4:
-		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_DATETYPE2A, 1 );	// �t��������t�̃^�C�v(�O��̕ۑ�����)
+		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_DATETYPE2A, 1 );	// 付加する日付のタイプ(前回の保存時刻)
 		break;
 	default:
 		::CheckDlgButton( hwndDlg, IDC_RADIO_BACKUP_DATETYPE1A, 1 );
@@ -329,20 +329,20 @@ void CPropBackup::SetData( HWND hwndDlg )
 
 
 
-/* �_�C�A���O�f�[�^�̎擾 */
+/* ダイアログデータの取得 */
 int CPropBackup::GetData( HWND hwndDlg )
 {
-	/* �o�b�N�A�b�v�̍쐬 */
+	/* バックアップの作成 */
 	m_Common.m_sBackup.m_bBackUp = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_BACKUP );
-	/* �o�b�N�A�b�v�̍쐬�O�Ɋm�F */
+	/* バックアップの作成前に確認 */
 	m_Common.m_sBackup.m_bBackUpDialog = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_BACKUPDIALOG );
-//	/* �w��t�H���_�Ƀo�b�N�A�b�v���쐬���� */ // 20051107 aroka �u�o�b�N�A�b�v�̍쐬�v�ɘA��������
+//	/* 指定フォルダにバックアップを作成する */ // 20051107 aroka 「バックアップの作成」に連動させる
 //	m_Common.m_sBackup.m_bBackUpFolder = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUPFOLDER );
 
 
-	/* �o�b�N�A�b�v�t�@�C�����̃^�C�v 1=(.bak) 2=*_���t.* */
+	/* バックアップファイル名のタイプ 1=(.bak) 2=*_日付.* */
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_BACKUP_TYPE1 ) ){
-		//	Jun.  5, 2005 genta �g���q���c���p�^�[����ǉ�
+		//	Jun.  5, 2005 genta 拡張子を残すパターンを追加
 		if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUP_RETAINEXT )){
 			m_Common.m_sBackup.SetBackupType(5);
 		}
@@ -351,12 +351,12 @@ int CPropBackup::GetData( HWND hwndDlg )
 		}
 	}
 //	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_BACKUP_TYPE2 ) ){
-		// 2001/06/05 Start by asa-o: ���t�̃^�C�v
+		// 2001/06/05 Start by asa-o: 日付のタイプ
 		if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_BACKUP_DATETYPE1 ) ){
-			m_Common.m_sBackup.SetBackupType(2);	// ������
+			m_Common.m_sBackup.SetBackupType(2);	// 現時刻
 		}
 		if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_BACKUP_DATETYPE2 ) ){
-			m_Common.m_sBackup.SetBackupType(4);	// �O��̕ۑ�����
+			m_Common.m_sBackup.SetBackupType(4);	// 前回の保存時刻
 		}
 		// 2001/06/05 End
 //	}
@@ -372,46 +372,46 @@ int CPropBackup::GetData( HWND hwndDlg )
 		}
 	}
 
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̔N */
+	/* バックアップファイル名：日付の年 */
 	m_Common.m_sBackup.SetBackupOpt(BKUP_YEAR, ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUP_YEAR ) == BST_CHECKED);
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̌� */
+	/* バックアップファイル名：日付の月 */
 	m_Common.m_sBackup.SetBackupOpt(BKUP_MONTH, ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUP_MONTH ) == BST_CHECKED);
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̓� */
+	/* バックアップファイル名：日付の日 */
 	m_Common.m_sBackup.SetBackupOpt(BKUP_DAY, ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUP_DAY ) == BST_CHECKED);
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̎� */
+	/* バックアップファイル名：日付の時 */
 	m_Common.m_sBackup.SetBackupOpt(BKUP_HOUR, ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUP_HOUR ) == BST_CHECKED);
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̕� */
+	/* バックアップファイル名：日付の分 */
 	m_Common.m_sBackup.SetBackupOpt(BKUP_MIN, ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUP_MIN ) == BST_CHECKED);
-	/* �o�b�N�A�b�v�t�@�C�����F���t�̕b */
+	/* バックアップファイル名：日付の秒 */
 	m_Common.m_sBackup.SetBackupOpt(BKUP_SEC, ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUP_SEC ) == BST_CHECKED);
 
-	/* �w��t�H���_�Ƀo�b�N�A�b�v���쐬���� */ // 20051107 aroka �ړ�
+	/* 指定フォルダにバックアップを作成する */ // 20051107 aroka 移動
 	m_Common.m_sBackup.m_bBackUpFolder = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_BACKUPFOLDER );
 	m_Common.m_sBackup.m_bBackUpFolderRM = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_BACKUP_FOLDER_RM );	// 2010/5/27 Uchi
 
-	/* �o�b�N�A�b�v���쐬����t�H���_ */
-	//	Oct. 5, 2002 genta �T�C�Y��sizeof()�Ŏw��
-	//	Oct. 8, 2002 genta ����\���ǉ������̂ŁC1�����]�T������K�v������D
+	/* バックアップを作成するフォルダ */
+	//	Oct. 5, 2002 genta サイズをsizeof()で指定
+	//	Oct. 8, 2002 genta 後ろに\が追加されるので，1文字余裕を見る必要がある．
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_BACKUPFOLDER, m_Common.m_sBackup.m_szBackUpFolder, _countof2(m_Common.m_sBackup.m_szBackUpFolder) - 1);
 
-	/* �o�b�N�A�b�v�t�@�C�������ݔ��ɕ��荞�� */	//@@@ 2001.12.11 add MIK
+	/* バックアップファイルをごみ箱に放り込む */	//@@@ 2001.12.11 add MIK
 	m_Common.m_sBackup.m_bBackUpDustBox = (BST_CHECKED==::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUP_DUSTBOX ));	//@@@ 2001.12.11 add MIK
 
-	/* �w��t�H���_�Ƀo�b�N�A�b�v���쐬����ڍאݒ� */ // 20051107 aroka
+	/* 指定フォルダにバックアップを作成する詳細設定 */ // 20051107 aroka
 	m_Common.m_sBackup.m_bBackUpPathAdvanced = (BST_CHECKED==::IsDlgButtonChecked( hwndDlg, IDC_CHECK_BACKUP_ADVANCED ));
-	/* �o�b�N�A�b�v���쐬����t�H���_ */ // 20051107 aroka
+	/* バックアップを作成するフォルダ */ // 20051107 aroka
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_BACKUPFILE, m_Common.m_sBackup.m_szBackUpPathAdvanced, _countof2( m_Common.m_sBackup.m_szBackUpPathAdvanced ) - 1);
 
-	// 20051128 aroka �ڍאݒ�̓��t�̃^�C�v
+	// 20051128 aroka 詳細設定の日付のタイプ
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_BACKUP_DATETYPE1A ) ){
-		m_Common.m_sBackup.SetBackupTypeAdv(2);	// ������
+		m_Common.m_sBackup.SetBackupTypeAdv(2);	// 現時刻
 	}
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_BACKUP_DATETYPE2A ) ){
-		m_Common.m_sBackup.SetBackupTypeAdv(4);	// �O��̕ۑ�����
+		m_Common.m_sBackup.SetBackupTypeAdv(4);	// 前回の保存時刻
 	}
 
 	//	From Here Aug. 16, 2000 genta
-	//	���㐔�̎擾
+	//	世代数の取得
 	int	 nN;
 	nN = ::GetDlgItemInt( hwndDlg, IDC_EDIT_BACKUP_3, NULL, FALSE );	//	Oct. 29, 2001 genta
 
@@ -431,24 +431,24 @@ int CPropBackup::GetData( HWND hwndDlg )
 }
 
 //	From Here Aug. 16, 2000 genta
-/*!	�`�F�b�N��Ԃɉ����ă_�C�A���O�{�b�N�X�v�f��Enable/Disable��
-	�K�؂ɐݒ肷��
+/*!	チェック状態に応じてダイアログボックス要素のEnable/Disableを
+	適切に設定する
 
-	@date 2004.06.05 genta ���̊g���q���c���ݒ��ǉ��D
-		�����w��Ń`�F�b�N�{�b�N�X���󗓂Ŏc��Ɛݒ肳��Ȃ���������邽�߁C
+	@date 2004.06.05 genta 元の拡張子を残す設定を追加．
+		日時指定でチェックボックスが空欄で残ると設定されない問題を避けるため，
 		IDC_RADIO_BACKUP_TYPE2
-		��p�~���ă��C�A�E�g�ύX
-	@date 2005.11.07 aroka ���C�A�E�g�ɍ��킹�ď��������ւ��A�C���f���g�𐮗�
-	@date 2005.11.21 aroka �ڍאݒ胂�[�h�̐����ǉ�
-	@date 2009.02.20 ryoji IDC_LABEL_BACKUP_HELP�ɂ��ʃR���g���[���B����p�~�Aif�������ShowEnable�t���O����ɒu�������Ċȑf�����ĉ��L���C���B
-	                       �EVista Aero���Əڍאݒ�ON�ɂ��Ă��ڍאݒ�OFF���ڂ���ʂ�������Ȃ�
-	                       �E�ڍאݒ�OFF���ڂ���\���ł͂Ȃ������̂ŉB��Ă��Ă�Tooltip�w���v���\�������
-	                       �E�ڍאݒ�ON�Ȃ̂Ƀo�b�N�A�b�v�쐬OFF���Əڍאݒ�OFF���ڂ̂ق����\�������
+		を廃止してレイアウト変更
+	@date 2005.11.07 aroka レイアウトに合わせて順序を入れ替え、インデントを整理
+	@date 2005.11.21 aroka 詳細設定モードの制御を追加
+	@date 2009.02.20 ryoji IDC_LABEL_BACKUP_HELPによる別コントロール隠しを廃止、if文制御をShowEnableフラグ制御に置き換えて簡素化して下記問題修正。
+	                       ・Vista Aeroだと詳細設定ONにしても詳細設定OFF項目が画面から消えない
+	                       ・詳細設定OFF項目が非表示ではなかったので隠れていてもTooltipヘルプが表示される
+	                       ・詳細設定ONなのにバックアップ作成OFFだと詳細設定OFF項目のほうが表示される
 */
 static inline void ShowEnable(HWND hWnd, BOOL bShow, BOOL bEnable)
 {
 	::ShowWindow( hWnd, bShow? SW_SHOW: SW_HIDE );
-	::EnableWindow( hWnd, bEnable && bShow );		// bShow=false,bEnable=true�̏ꍇ�V���[�g�J�b�g�L�[���ςȓ���������̂ŏC��	2010/5/27 Uchi
+	::EnableWindow( hWnd, bEnable && bShow );		// bShow=false,bEnable=trueの場合ショートカットキーが変な動きをするので修正	2010/5/27 Uchi
 }
 
 void CPropBackup::EnableBackupInput(HWND hwndDlg)
@@ -471,8 +471,8 @@ void CPropBackup::EnableBackupInput(HWND hwndDlg)
 	SHOWENABLE( IDC_RADIO_BACKUP_DATETYPE2,	!bAdvanced, bBackup );
 	SHOWENABLE( IDC_LABEL_BACKUP_3,			!bAdvanced, bBackup && bType3);
 	SHOWENABLE( IDC_EDIT_BACKUP_3,			!bAdvanced, bBackup && bType3);
-	SHOWENABLE( IDC_SPIN_BACKUP_GENS,		!bAdvanced, bBackup && bType3 );	//	20051107 aroka �ǉ�
-	SHOWENABLE( IDC_CHECK_BACKUP_RETAINEXT,	!bAdvanced, bBackup && (bType1 || bType3) );	//	Jun.  5, 2005 genta �ǉ�
+	SHOWENABLE( IDC_SPIN_BACKUP_GENS,		!bAdvanced, bBackup && bType3 );	//	20051107 aroka 追加
+	SHOWENABLE( IDC_CHECK_BACKUP_RETAINEXT,	!bAdvanced, bBackup && (bType1 || bType3) );	//	Jun.  5, 2005 genta 追加
 	SHOWENABLE( IDC_CHECK_BACKUP_YEAR,		!bAdvanced, bBackup && (bDate1 || bDate2) );
 	SHOWENABLE( IDC_CHECK_BACKUP_MONTH,		!bAdvanced, bBackup && (bDate1 || bDate2) );
 	SHOWENABLE( IDC_CHECK_BACKUP_DAY,		!bAdvanced, bBackup && (bDate1 || bDate2) );
@@ -480,21 +480,21 @@ void CPropBackup::EnableBackupInput(HWND hwndDlg)
 	SHOWENABLE( IDC_CHECK_BACKUP_MIN,		!bAdvanced, bBackup && (bDate1 || bDate2) );
 	SHOWENABLE( IDC_CHECK_BACKUP_SEC,		!bAdvanced, bBackup && (bDate1 || bDate2) );
 
-	// �ڍאݒ�
+	// 詳細設定
 	SHOWENABLE( IDC_EDIT_BACKUPFILE,		TRUE, bBackup && bAdvanced );
-//	SHOWENABLE( IDC_LABEL_BACKUP_HELP,		bAdvanced, bBackup );	// �s���̂܂ܕ��u�i���R���g���[���B���̕����͔p�~�j 2009.02.20 ryoji
+//	SHOWENABLE( IDC_LABEL_BACKUP_HELP,		bAdvanced, bBackup );	// 不可視のまま放置（他コントロール隠しの方式は廃止） 2009.02.20 ryoji
 	SHOWENABLE( IDC_LABEL_BACKUP_HELP2,		bAdvanced, bBackup );
 	SHOWENABLE( IDC_RADIO_BACKUP_DATETYPE1A,	bAdvanced, bBackup );
 	SHOWENABLE( IDC_RADIO_BACKUP_DATETYPE2A,	bAdvanced, bBackup );
 
 	SHOWENABLE( IDC_CHECK_BACKUPFOLDER,		TRUE, bBackup );
-	SHOWENABLE( IDC_LABEL_BACKUP_4,			TRUE, bBackup && bFolder );	// added Sept. 6, JEPRO �t�H���_�w�肵���Ƃ�����Enable�ɂȂ�悤�ɕύX
+	SHOWENABLE( IDC_LABEL_BACKUP_4,			TRUE, bBackup && bFolder );	// added Sept. 6, JEPRO フォルダ指定したときだけEnableになるように変更
 	SHOWENABLE( IDC_CHECK_BACKUP_FOLDER_RM,	TRUE, bBackup && bFolder );	// 2010/5/27 Uchi
 	SHOWENABLE( IDC_EDIT_BACKUPFOLDER,		TRUE, bBackup && bFolder );
 	SHOWENABLE( IDC_BUTTON_BACKUP_FOLDER_REF,	TRUE, bBackup && bFolder );
 	SHOWENABLE( IDC_CHECK_BACKUP_DUSTBOX,	TRUE, bBackup );	//@@@ 2001.12.11 add MIK
 
-	// �쐬�O�Ɋm�F
+	// 作成前に確認
 	SHOWENABLE( IDC_CHECK_BACKUPDIALOG,		TRUE, bBackup );
 
 	#undef SHOWENABLE
@@ -502,17 +502,17 @@ void CPropBackup::EnableBackupInput(HWND hwndDlg)
 //	To Here Aug. 16, 2000 genta
 
 
-/*!	�o�b�N�A�b�v�t�@�C���̏ڍאݒ�G�f�B�b�g�{�b�N�X��K�؂ɍX�V����
+/*!	バックアップファイルの詳細設定エディットボックスを適切に更新する
 
-	@date 2005.11.07 aroka �V�K�ǉ�
+	@date 2005.11.07 aroka 新規追加
 
-	@note �ڍאݒ�؂�ւ����̃f�t�H���g���I�v�V�����ɍ��킹�邽�߁A
-		m_szBackUpPathAdvanced ���X�V����
+	@note 詳細設定切り替え時のデフォルトをオプションに合わせるため、
+		m_szBackUpPathAdvanced を更新する
 */
-void CPropBackup::UpdateBackupFile(HWND hwndDlg)	//	�o�b�N�A�b�v�t�@�C���̏ڍאݒ�
+void CPropBackup::UpdateBackupFile(HWND hwndDlg)	//	バックアップファイルの詳細設定
 {
 	wchar_t temp[MAX_PATH];
-	/* �o�b�N�A�b�v���쐬����t�@�C�� */ // 20051107 aroka
+	/* バックアップを作成するファイル */ // 20051107 aroka
 	if( !m_Common.m_sBackup.m_bBackUp ){
 		temp[0] = LTEXT('\0');
 	}
@@ -540,26 +540,26 @@ void CPropBackup::UpdateBackupFile(HWND hwndDlg)	//	�o�b�N�A�b�v�t�@�C���̏ڍא�
 		case 6: // .*.b??
 			wcscat( temp, LTEXT("$0.*.b??") );
 			break;
-		case 2:	//	���t�C����
-		case 4:	//	���t�C����
+		case 2:	//	日付，時刻
+		case 4:	//	日付，時刻
 			wcscat( temp, LTEXT("$0_") );
 
-			if( m_Common.m_sBackup.GetBackupOpt(BKUP_YEAR) ){	/* �o�b�N�A�b�v�t�@�C�����F���t�̔N */
+			if( m_Common.m_sBackup.GetBackupOpt(BKUP_YEAR) ){	/* バックアップファイル名：日付の年 */
 				wcscat( temp, LTEXT("%Y") );
 			}
-			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MONTH) ){	/* �o�b�N�A�b�v�t�@�C�����F���t�̌� */
+			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MONTH) ){	/* バックアップファイル名：日付の月 */
 				wcscat( temp, LTEXT("%m") );
 			}
-			if( m_Common.m_sBackup.GetBackupOpt(BKUP_DAY) ){	/* �o�b�N�A�b�v�t�@�C�����F���t�̓� */
+			if( m_Common.m_sBackup.GetBackupOpt(BKUP_DAY) ){	/* バックアップファイル名：日付の日 */
 				wcscat( temp, LTEXT("%d") );
 			}
-			if( m_Common.m_sBackup.GetBackupOpt(BKUP_HOUR) ){	/* �o�b�N�A�b�v�t�@�C�����F���t�̎� */
+			if( m_Common.m_sBackup.GetBackupOpt(BKUP_HOUR) ){	/* バックアップファイル名：日付の時 */
 				wcscat( temp, LTEXT("%H") );
 			}
-			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MIN) ){	/* �o�b�N�A�b�v�t�@�C�����F���t�̕� */
+			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MIN) ){	/* バックアップファイル名：日付の分 */
 				wcscat( temp, LTEXT("%M") );
 			}
-			if( m_Common.m_sBackup.GetBackupOpt(BKUP_SEC) ){	/* �o�b�N�A�b�v�t�@�C�����F���t�̕b */
+			if( m_Common.m_sBackup.GetBackupOpt(BKUP_SEC) ){	/* バックアップファイル名：日付の秒 */
 				wcscat( temp, LTEXT("%S") );
 			}
 
@@ -569,7 +569,7 @@ void CPropBackup::UpdateBackupFile(HWND hwndDlg)	//	�o�b�N�A�b�v�t�@�C���̏ڍא�
 			break;
 		}
 	}
-	if( !m_Common.m_sBackup.m_bBackUpPathAdvanced ){	// �ڍאݒ胂�[�h�łȂ��Ƃ����������X�V����
+	if( !m_Common.m_sBackup.m_bBackUpPathAdvanced ){	// 詳細設定モードでないときだけ自動更新する
 		auto_sprintf( m_Common.m_sBackup.m_szBackUpPathAdvanced, _T("%ls"), temp );
 		::DlgItem_SetText( hwndDlg, IDC_EDIT_BACKUPFILE, m_Common.m_sBackup.m_szBackUpPathAdvanced );
 	}

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	���ʐݒ�_�C�A���O�{�b�N�X�A�u�J�X�^�����j���[�v�y�[�W
+﻿/*!	@file
+	共通設定ダイアログボックス、「カスタムメニュー」ページ
 
 	@author Norio Nakatani
 */
@@ -28,25 +28,25 @@
 
 using namespace std;
 
-static	int 	nSpecialFuncsNum;		// ���ʋ@�\�̃R���{�{�b�N�X���ł̔ԍ�
+static	int 	nSpecialFuncsNum;		// 特別機能のコンボボックス内での番号
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//10100
-	IDC_BUTTON_DELETE,				HIDC_BUTTON_DELETE,				//���j���[����@�\�폜
-	IDC_BUTTON_INSERTSEPARATOR,		HIDC_BUTTON_INSERTSEPARATOR,	//�Z�p���[�^�}��
-	IDC_BUTTON_INSERT,				HIDC_BUTTON_INSERT,				//���j���[�֋@�\�}��
-	IDC_BUTTON_ADD,					HIDC_BUTTON_ADD,				//���j���[�֋@�\�ǉ�
-	IDC_BUTTON_UP,					HIDC_BUTTON_UP,					//���j���[�̋@�\����ֈړ�
-	IDC_BUTTON_DOWN,				HIDC_BUTTON_DOWN,				//���j���[�̋@�\�����ֈړ�
-	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT,				//�C���|�[�g
-	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT,				//�G�N�X�|�[�g
-	IDC_COMBO_FUNCKIND,				HIDC_COMBO_FUNCKIND,			//�@�\�̎��
-	IDC_COMBO_MENU,					HIDC_COMBO_MENU,				//���j���[�̎��
-	IDC_EDIT_MENUNAME,				HIDC_EDIT_MENUNAME,				//���j���[��		// 2009.02.20 ryoji
-	IDC_BUTTON_MENUNAME,			HIDC_BUTTON_MENUNAME,			//���j���[���ݒ�	// 2009.02.20 ryoji
-	IDC_LIST_FUNC,					HIDC_LIST_FUNC,					//�@�\�ꗗ
-	IDC_LIST_RES,					HIDC_LIST_RES,					//���j���[�ꗗ
-	IDC_CHECK_SUBMENU,				HIDC_CHECK_SUBMENU,				//�T�u���j���[�Ƃ��ĕ\��
+	IDC_BUTTON_DELETE,				HIDC_BUTTON_DELETE,				//メニューから機能削除
+	IDC_BUTTON_INSERTSEPARATOR,		HIDC_BUTTON_INSERTSEPARATOR,	//セパレータ挿入
+	IDC_BUTTON_INSERT,				HIDC_BUTTON_INSERT,				//メニューへ機能挿入
+	IDC_BUTTON_ADD,					HIDC_BUTTON_ADD,				//メニューへ機能追加
+	IDC_BUTTON_UP,					HIDC_BUTTON_UP,					//メニューの機能を上へ移動
+	IDC_BUTTON_DOWN,				HIDC_BUTTON_DOWN,				//メニューの機能を下へ移動
+	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT,				//インポート
+	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT,				//エクスポート
+	IDC_COMBO_FUNCKIND,				HIDC_COMBO_FUNCKIND,			//機能の種別
+	IDC_COMBO_MENU,					HIDC_COMBO_MENU,				//メニューの種別
+	IDC_EDIT_MENUNAME,				HIDC_EDIT_MENUNAME,				//メニュー名		// 2009.02.20 ryoji
+	IDC_BUTTON_MENUNAME,			HIDC_BUTTON_MENUNAME,			//メニュー名設定	// 2009.02.20 ryoji
+	IDC_LIST_FUNC,					HIDC_LIST_FUNC,					//機能一覧
+	IDC_LIST_RES,					HIDC_LIST_RES,					//メニュー一覧
+	IDC_CHECK_SUBMENU,				HIDC_CHECK_SUBMENU,				//サブメニューとして表示
 //	IDC_LABEL_MENUFUNCKIND,			-1,
 //	IDC_LABEL_MENUCHOICE,			-1,
 //	IDC_LABEL_MENUFUNC,				-1,
@@ -59,10 +59,10 @@ static const DWORD p_helpids[] = {	//10100
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg �_�C�A���O�{�b�N�X��Window Handle
-	@param uMsg ���b�Z�[�W
-	@param wParam �p�����[�^1
-	@param lParam �p�����[�^2
+	@param hwndDlg ダイアログボックスのWindow Handle
+	@param uMsg メッセージ
+	@param wParam パラメータ1
+	@param lParam パラメータ2
 */
 INT_PTR CALLBACK CPropCustmenu::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -127,7 +127,7 @@ static void SetDlgItemsEnableState(
 	}
 }
 
-/* Custom menu ���b�Z�[�W���� */
+/* Custom menu メッセージ処理 */
 INT_PTR CPropCustmenu::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
 	UINT	uMsg,		// message
@@ -158,18 +158,18 @@ INT_PTR CPropCustmenu::DispatchEvent(
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* �_�C�A���O�f�[�^�̐ݒ� Custom menu */
+		/* ダイアログデータの設定 Custom menu */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* �R���g���[���̃n���h�����擾 */
+		/* コントロールのハンドルを取得 */
 		hwndCOMBO_FUNCKIND = ::GetDlgItem( hwndDlg, IDC_COMBO_FUNCKIND );
 		hwndLIST_FUNC = ::GetDlgItem( hwndDlg, IDC_LIST_FUNC );
 		hwndCOMBO_MENU = ::GetDlgItem( hwndDlg, IDC_COMBO_MENU );
 		hwndLIST_RES = ::GetDlgItem( hwndDlg, IDC_LIST_RES );
 
-		/* �L�[�I�����̏��� */
+		/* キー選択時の処理 */
 		::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_COMBO_FUNCKIND, CBN_SELCHANGE ), (LPARAM)hwndCOMBO_FUNCKIND );
 
 		::SetTimer( hwndDlg, 1, 300, NULL );
@@ -185,14 +185,14 @@ INT_PTR CPropCustmenu::DispatchEvent(
 			return TRUE;
 		case PSN_KILLACTIVE:
 //			MYTRACE( _T("Custom menu PSN_KILLACTIVE\n") );
-			/* �_�C�A���O�f�[�^�̎擾 Custom menu */
+			/* ダイアログデータの取得 Custom menu */
 			GetData( hwndDlg );
 			return TRUE;
-//@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+//@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPCOM_PAGENUM_CUSTMENU;
 
-			// �\�����X�V����i�}�N���ݒ��ʂł̃}�N�����ύX�𔽉f�j	// 2007.11.02 ryoji
+			// 表示を更新する（マクロ設定画面でのマクロ名変更を反映）	// 2007.11.02 ryoji
 			nIdx1 = Combo_GetCurSel( hwndCOMBO_MENU );
 			nIdx2 = List_GetCurSel( hwndLIST_RES );
 			nIdx3 = Combo_GetCurSel( hwndCOMBO_FUNCKIND );
@@ -214,36 +214,36 @@ INT_PTR CPropCustmenu::DispatchEvent(
 		break;
 
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* �ʒm�R�[�h */
-		wID = LOWORD(wParam);			/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
-		hwndCtl = (HWND) lParam;		/* �R���g���[���̃n���h�� */
+		wNotifyCode = HIWORD(wParam);	/* 通知コード */
+		wID = LOWORD(wParam);			/* 項目ID､ コントロールID､ またはアクセラレータID */
+		hwndCtl = (HWND) lParam;		/* コントロールのハンドル */
 
 		switch( wNotifyCode ){
-		/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+		/* ボタン／チェックボックスがクリックされた */
 		case BN_CLICKED:
 			switch( wID ){
-			case IDC_BUTTON_IMPORT:	/* �C���|�[�g */
-				/* �J�X�^�����j���[�ݒ���C���|�[�g���� */
+			case IDC_BUTTON_IMPORT:	/* インポート */
+				/* カスタムメニュー設定をインポートする */
 				Import( hwndDlg );
 				return TRUE;
-			case IDC_BUTTON_EXPORT:	/* �G�N�X�|�[�g */
-				/* �J�X�^�����j���[�ݒ���G�N�X�|�[�g���� */
+			case IDC_BUTTON_EXPORT:	/* エクスポート */
+				/* カスタムメニュー設定をエクスポートする */
 				Export( hwndDlg );
 				return TRUE;
 			case IDC_BUTTON_MENUNAME:
 				WCHAR buf[ MAX_CUSTOM_MENU_NAME_LEN + 1 ];
-				//	���j���[������̐ݒ�
+				//	メニュー文字列の設定
 				nIdx1 = Combo_GetCurSel( hwndCOMBO_MENU );
 				if( CB_ERR == nIdx1 ){
 					break;
 				}
 				::DlgItem_GetText( hwndDlg, IDC_EDIT_MENUNAME,
 					m_Common.m_sCustomMenu.m_szCustMenuNameArr[nIdx1], MAX_CUSTOM_MENU_NAME_LEN );
-				//	Combo Box���ύX �폜���ēo�^
+				//	Combo Boxも変更 削除＆再登録
 				Combo_DeleteString( hwndCOMBO_MENU, nIdx1 );
 				Combo_InsertString( hwndCOMBO_MENU, nIdx1,
 					m_cLookup.Custmenu2Name( nIdx1, buf, _countof(buf) ) );
-				// �폜����ƑI�������������̂ŁC���ɖ߂�
+				// 削除すると選択が解除されるので，元に戻す
 				Combo_SetCurSel( hwndCOMBO_MENU, nIdx1 );
 				return TRUE;
 			}
@@ -301,7 +301,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					KEYCODE keycode[3]={0}; _tctomb(szKey, keycode);
 					m_Common.m_sCustomMenu.m_nCustMenuItemKeyArr[nIdx1][nIdx2] = keycode[0];
 				}
-//@@@ 2002.01.08 YAZAKI �J�X�^�����j���[�ŃA�N�Z�X�L�[�����������A���J�b�R ( �����j���[���ڂɈ��c��o�O�C��
+//@@@ 2002.01.08 YAZAKI カスタムメニューでアクセスキーを消した時、左カッコ ( がメニュー項目に一回残るバグ修正
 				if (m_Common.m_sCustomMenu.m_nCustMenuItemKeyArr[nIdx1][nIdx2]){
 					auto_sprintf( szLabel2, LTEXT("%ts(%hc)"),
 						szLabel,
@@ -331,7 +331,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					break;
 				}
 
-				/* �L�[ */
+				/* キー */
 				if( '\0' == m_Common.m_sCustomMenu.m_nCustMenuItemKeyArr[nIdx1][nIdx2] ||
 					' '  == m_Common.m_sCustomMenu.m_nCustMenuItemKeyArr[nIdx1][nIdx2] ){
 				}else{
@@ -345,7 +345,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 				nIdx3 = Combo_GetCurSel( hwndCOMBO_FUNCKIND );
 
 				if (nIdx3 == nSpecialFuncsNum) {
-					// �@�\�ꗗ�ɓ���@�\���Z�b�g
+					// 機能一覧に特殊機能をセット
 					List_ResetContent( hwndLIST_FUNC );
 					for (i = 0; i < nsFuncCode::nFuncList_Special_Num; i++) {
 						List_AddString( hwndLIST_FUNC, LS( nsFuncCode::pnFuncList_Special[i] ) );
@@ -353,7 +353,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 				}
 				else {
 					// Oct. 3, 2001 genta
-					// ��p���[�`���ɒu������
+					// 専用ルーチンに置き換え
 					m_cLookup.SetListItem( hwndLIST_FUNC, nIdx3 );
 				}
 				return TRUE;
@@ -361,7 +361,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 		}else{
 			EFunctionCode	eFuncCode = F_0;
 			switch( wNotifyCode ){
-			/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+			/* ボタン／チェックボックスがクリックされた */
 			case BN_CLICKED:
 				switch( wID ){
 				case IDC_BUTTON_INSERTSEPARATOR:
@@ -378,7 +378,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					if( LB_ERR == nIdx2 ){
 						nIdx2 = 0;
 					}
-					nIdx2 = List_InsertString( hwndLIST_RES, nIdx2, LSW(STR_PROPCOMCUSTMENU_SEP) );	//Oct. 18, 2000 JEPRO �u�c�[���o�[�v�^�u�Ŏg���Ă���Z�p���[�^�Ɠ�������ɓ��ꂵ��
+					nIdx2 = List_InsertString( hwndLIST_RES, nIdx2, LSW(STR_PROPCOMCUSTMENU_SEP) );	//Oct. 18, 2000 JEPRO 「ツールバー」タブで使っているセパレータと同じ線種に統一した
 					if( nIdx2 == LB_ERR || nIdx2 == LB_ERRSPACE ){
 						break;
 					}
@@ -461,7 +461,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					}
 					//	Oct. 3, 2001 genta
 					if (nIdx3 == nSpecialFuncsNum) {
-						// ����@�\
+						// 特殊機能
 						eFuncCode = nsFuncCode::pnFuncList_Special[nIdx4];
 					}else{
 						eFuncCode = m_cLookup.Pos2FuncCode( nIdx3, nIdx4 );
@@ -509,7 +509,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					List_GetText( hwndLIST_FUNC, nIdx4, szLabel );
 					eFuncCode = F_DISABLE;
 					if (nIdx3 == nSpecialFuncsNum) {
-						// ����@�\
+						// 特殊機能
 						if( 0 <= nIdx4 && nIdx4 < nsFuncCode::nFuncList_Special_Num ){
 							eFuncCode = nsFuncCode::pnFuncList_Special[nIdx4];
 						}
@@ -614,7 +614,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -624,7 +624,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -635,7 +635,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 
 
 
-/* �_�C�A���O�f�[�^�̐ݒ� Custom menu */
+/* ダイアログデータの設定 Custom menu */
 void CPropCustmenu::SetData( HWND hwndDlg )
 {
 	HWND		hwndCOMBO_MENU;
@@ -643,25 +643,25 @@ void CPropCustmenu::SetData( HWND hwndDlg )
 	int			i;
 	WCHAR		buf[ MAX_CUSTOM_MENU_NAME_LEN + 1 ];
 
-	/* �@�\��ʈꗗ�ɕ�������Z�b�g�i�R���{�{�b�N�X�j */
+	/* 機能種別一覧に文字列をセット（コンボボックス） */
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_FUNCKIND );
 	m_cLookup.SetCategory2Combo( hwndCombo );	//	Oct. 3, 2001 genta
-	// ���ʋ@�\�ǉ�
+	// 特別機能追加
 	nSpecialFuncsNum = Combo_AddString( hwndCombo, LS( STR_SPECIAL_FUNC ) );
 
-	/* ��ʂ̐擪�̍��ڂ�I���i�R���{�{�b�N�X�j*/
-	Combo_SetCurSel( hwndCombo, 0 );	//Oct. 14, 2000 JEPRO �u--����`--�v��\�������Ȃ��悤�ɑ匳 Funcode.cpp �ŕύX���Ă���
+	/* 種別の先頭の項目を選択（コンボボックス）*/
+	Combo_SetCurSel( hwndCombo, 0 );	//Oct. 14, 2000 JEPRO 「--未定義--」を表示させないように大元 Funcode.cpp で変更してある
 
-	/* ���j���[�ꗗ�ɕ�������Z�b�g�i�R���{�{�b�N�X�j*/
+	/* メニュー一覧に文字列をセット（コンボボックス）*/
 	hwndCOMBO_MENU = ::GetDlgItem( hwndDlg, IDC_COMBO_MENU );
 	for( i = 0; i < MAX_CUSTOM_MENU; ++i ){
 		Combo_AddString( hwndCOMBO_MENU, m_cLookup.Custmenu2Name( i, buf, _countof( buf ) ) );
 	}
-	/* ���j���[�ꗗ�̐擪�̍��ڂ�I���i�R���{�{�b�N�X�j*/
+	/* メニュー一覧の先頭の項目を選択（コンボボックス）*/
 	Combo_SetCurSel( hwndCOMBO_MENU, 0 );
 	SetDataMenuList( hwndDlg, 0 );
 
-//	/* �J�X�^�����j���[�̐擪�̍��ڂ�I���i���X�g�{�b�N�X�j*/	//Oct. 8, 2000 JEPRO �������R�����g�A�E�g����Ɛ擪���ڂ��I������Ȃ��Ȃ�
+//	/* カスタムメニューの先頭の項目を選択（リストボックス）*/	//Oct. 8, 2000 JEPRO ここをコメントアウトすると先頭項目が選択されなくなる
 	HWND hwndLIST_RES = ::GetDlgItem( hwndDlg, IDC_LIST_RES );
 	List_SetCurSel( hwndLIST_RES, 0 );
 }
@@ -672,20 +672,20 @@ void CPropCustmenu::SetDataMenuList(HWND hwndDlg, int nIdx)
 	WCHAR		szLabel[300];
 	WCHAR		szLabel2[300+4];
 
-	/* ���j���[���ڈꗗ�ɕ�������Z�b�g�i���X�g�{�b�N�X�j*/
+	/* メニュー項目一覧に文字列をセット（リストボックス）*/
 	HWND hwndLIST_RES = ::GetDlgItem( hwndDlg, IDC_LIST_RES );
 //	hwndEDIT_KEY = ::GetDlgItem( hwndDlg, IDC_EDIT_KEY );
 	List_ResetContent( hwndLIST_RES );
 	for( i = 0; i < m_Common.m_sCustomMenu.m_nCustMenuItemNumArr[nIdx]; ++i ){
 		if( 0 == m_Common.m_sCustomMenu.m_nCustMenuItemFuncArr[nIdx][i] ){
-			auto_strncpy( szLabel, LSW(STR_PROPCOMCUSTMENU_SEP), _countof(szLabel) - 1 );	//Oct. 18, 2000 JEPRO �u�c�[���o�[�v�^�u�Ŏg���Ă���Z�p���[�^�Ɠ�������ɓ��ꂵ��
+			auto_strncpy( szLabel, LSW(STR_PROPCOMCUSTMENU_SEP), _countof(szLabel) - 1 );	//Oct. 18, 2000 JEPRO 「ツールバー」タブで使っているセパレータと同じ線種に統一した
 			szLabel[_countof(szLabel) - 1] = L'\0';
 		}else{
 			EFunctionCode code = m_Common.m_sCustomMenu.m_nCustMenuItemFuncArr[nIdx][i];
 			//	Oct. 3, 2001 genta
 			m_cLookup.Funccode2Name( code, szLabel, 256 );
 		}
-		/* �L�[ */
+		/* キー */
 		if( '\0' == m_Common.m_sCustomMenu.m_nCustMenuItemKeyArr[nIdx][i] ){
 			auto_strcpy( szLabel2, szLabel );
 		}else{
@@ -697,7 +697,7 @@ void CPropCustmenu::SetDataMenuList(HWND hwndDlg, int nIdx)
 		::List_AddString( hwndLIST_RES, szLabel2 );
 	}
 	
-	//	Oct. 15, 2001 genta ���j���[����ݒ�
+	//	Oct. 15, 2001 genta メニュー名を設定
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_MENUNAME, m_Common.m_sCustomMenu.m_szCustMenuNameArr[nIdx] );
 
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_SUBMENU, m_Common.m_sCustomMenu.m_bCustMenuPopupArr[nIdx] );
@@ -706,7 +706,7 @@ void CPropCustmenu::SetDataMenuList(HWND hwndDlg, int nIdx)
 
 
 
-/* �_�C�A���O�f�[�^�̎擾 Custom menu */
+/* ダイアログデータの取得 Custom menu */
 int CPropCustmenu::GetData( HWND hwndDlg )
 {
 	return TRUE;
@@ -716,30 +716,30 @@ int CPropCustmenu::GetData( HWND hwndDlg )
 
 
 
-/* �J�X�^�����j���[�ݒ���C���|�[�g���� */
+/* カスタムメニュー設定をインポートする */
 void CPropCustmenu::Import( HWND hwndDlg )
 {
 	CImpExpCustMenu	cImpExpCustMenu( m_Common );
 
-	// �C���|�[�g
+	// インポート
 	if (!cImpExpCustMenu.ImportUI( G_AppInstance(), hwndDlg )) {
-		// �C���|�[�g�����Ă��Ȃ�
+		// インポートをしていない
 		return;
 	}
 	
-	// ��ʍX�V
+	// 画面更新
 	HWND	hwndCtrl = ::GetDlgItem( hwndDlg, IDC_COMBO_MENU );
 	::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_COMBO_MENU, CBN_SELCHANGE ), (LPARAM)hwndCtrl );
 }
 
-/* �J�X�^�����j���[�ݒ���G�N�X�|�[�g���� */
+/* カスタムメニュー設定をエクスポートする */
 void CPropCustmenu::Export( HWND hwndDlg )
 {
 	CImpExpCustMenu	cImpExpCustMenu( m_Common );
 
-	// �G�N�X�|�[�g
+	// エクスポート
 	if (!cImpExpCustMenu.ExportUI( G_AppInstance(), hwndDlg )) {
-		// �G�N�X�|�[�g�����Ă��Ȃ�
+		// エクスポートをしていない
 		return;
 	}
 }

--- a/sakura_core/prop/CPropComEdit.cpp
+++ b/sakura_core/prop/CPropComEdit.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAu•ÒWvƒy[ƒW
+ï»¿/*!	@file
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œç·¨é›†ã€ãƒšãƒ¼ã‚¸
 
 	@author Norio Nakatani
 */
@@ -27,25 +27,25 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//10210
-	IDC_CHECK_ADDCRLFWHENCOPY,			HIDC_CHECK_ADDCRLFWHENCOPY,				//Ü‚è•Ô‚µs‚É‰üs‚ğ•t‚¯‚ÄƒRƒs[
-	IDC_CHECK_COPYnDISABLESELECTEDAREA,	HIDC_CHECK_COPYnDISABLESELECTEDAREA,	//ƒRƒs[‚µ‚½‚ç‘I‘ğ‰ğœ
-	IDC_CHECK_bEnableNoSelectCopy,		HIDC_CHECK_bEnableNoSelectCopy,			//‘I‘ğ‚È‚µ‚ÅƒRƒs[‚ğ‰Â”\‚É‚·‚é	// 2007.11.18 ryoji
-	IDC_CHECK_bEnableLineModePaste,		HIDC_CHECK_bEnableLineModePaste,		//ƒ‰ƒCƒ“ƒ‚[ƒh“\‚è•t‚¯‚ğ‰Â”\‚É‚·‚é	// 2007.10.08 ryoji
-	IDC_CHECK_DRAGDROP,					HIDC_CHECK_DRAGDROP,					//Drag&Drop•ÒW‚·‚é
-	IDC_CHECK_DROPSOURCE,				HIDC_CHECK_DROPSOURCE,					//ƒhƒƒbƒvŒ³‚É‚·‚é
-	IDC_CHECK_bNotOverWriteCRLF,		HIDC_CHECK_bNotOverWriteCRLF,			//ã‘‚«ƒ‚[ƒh
-	IDC_CHECK_bOverWriteFixMode,		HIDC_CHECK_bOverWriteFixMode,			//•¶š•‚É‡‚í‚¹‚ÄƒXƒy[ƒX‚ğ‹l‚ß‚é
-	IDC_CHECK_bOverWriteBoxDelete,		HIDC_CHECK_bOverWriteBoxDelete,			//‹éŒ`“ü—Í‚Å‘I‘ğ”ÍˆÍ‚ğíœ‚·‚é
-	//	2007.02.11 genta ƒNƒŠƒbƒJƒuƒ‹URL‚ğ‚±‚Ìƒy[ƒW‚ÉˆÚ“®
-	IDC_CHECK_bSelectClickedURL,	HIDC_CHECK_bSelectClickedURL,	//ƒNƒŠƒbƒJƒuƒ‹URL
-	IDC_CHECK_CONVERTEOLPASTE,			HIDC_CHECK_CONVERTEOLPASTE,			//‰üsƒR[ƒh‚ğ•ÏŠ·‚µ‚Ä“\‚è•t‚¯‚é
-	IDC_RADIO_CURDIR,					HIDC_RADIO_CURDIR,						//ƒJƒŒƒ“ƒgƒtƒHƒ‹ƒ_
-	IDC_RADIO_MRUDIR,					HIDC_RADIO_MRUDIR,						//Å‹ßg‚Á‚½ƒtƒHƒ‹ƒ_
-	IDC_RADIO_SELDIR,					HIDC_RADIO_SELDIR,						//w’èƒtƒHƒ‹ƒ_
-	IDC_EDIT_FILEOPENDIR,				HIDC_EDIT_FILEOPENDIR,					//w’èƒtƒHƒ‹ƒ_ƒpƒX
-	IDC_BUTTON_FILEOPENDIR, 			HIDC_EDIT_FILEOPENDIR,					//w’èƒtƒHƒ‹ƒ_ƒpƒX
-	IDC_CHECK_ENABLEEXTEOL,				HIDC_CHECK_ENABLEEXTEOL,				//‰üsƒR[ƒhNEL,PS,LS‚ğ—LŒø‚É‚·‚é
-	IDC_CHECK_BOXSELECTLOCK,			HIDC_CHECK_BOXSELECTLOCK,				//‹éŒ`‘I‘ğˆÚ“®‚Å‘I‘ğ‚ğƒƒbƒN‚·‚é
+	IDC_CHECK_ADDCRLFWHENCOPY,			HIDC_CHECK_ADDCRLFWHENCOPY,				//æŠ˜ã‚Šè¿”ã—è¡Œã«æ”¹è¡Œã‚’ä»˜ã‘ã¦ã‚³ãƒ”ãƒ¼
+	IDC_CHECK_COPYnDISABLESELECTEDAREA,	HIDC_CHECK_COPYnDISABLESELECTEDAREA,	//ã‚³ãƒ”ãƒ¼ã—ãŸã‚‰é¸æŠè§£é™¤
+	IDC_CHECK_bEnableNoSelectCopy,		HIDC_CHECK_bEnableNoSelectCopy,			//é¸æŠãªã—ã§ã‚³ãƒ”ãƒ¼ã‚’å¯èƒ½ã«ã™ã‚‹	// 2007.11.18 ryoji
+	IDC_CHECK_bEnableLineModePaste,		HIDC_CHECK_bEnableLineModePaste,		//ãƒ©ã‚¤ãƒ³ãƒ¢ãƒ¼ãƒ‰è²¼ã‚Šä»˜ã‘ã‚’å¯èƒ½ã«ã™ã‚‹	// 2007.10.08 ryoji
+	IDC_CHECK_DRAGDROP,					HIDC_CHECK_DRAGDROP,					//Drag&Dropç·¨é›†ã™ã‚‹
+	IDC_CHECK_DROPSOURCE,				HIDC_CHECK_DROPSOURCE,					//ãƒ‰ãƒ­ãƒƒãƒ—å…ƒã«ã™ã‚‹
+	IDC_CHECK_bNotOverWriteCRLF,		HIDC_CHECK_bNotOverWriteCRLF,			//ä¸Šæ›¸ããƒ¢ãƒ¼ãƒ‰
+	IDC_CHECK_bOverWriteFixMode,		HIDC_CHECK_bOverWriteFixMode,			//æ–‡å­—å¹…ã«åˆã‚ã›ã¦ã‚¹ãƒšãƒ¼ã‚¹ã‚’è©°ã‚ã‚‹
+	IDC_CHECK_bOverWriteBoxDelete,		HIDC_CHECK_bOverWriteBoxDelete,			//çŸ©å½¢å…¥åŠ›ã§é¸æŠç¯„å›²ã‚’å‰Šé™¤ã™ã‚‹
+	//	2007.02.11 genta ã‚¯ãƒªãƒƒã‚«ãƒ–ãƒ«URLã‚’ã“ã®ãƒšãƒ¼ã‚¸ã«ç§»å‹•
+	IDC_CHECK_bSelectClickedURL,	HIDC_CHECK_bSelectClickedURL,	//ã‚¯ãƒªãƒƒã‚«ãƒ–ãƒ«URL
+	IDC_CHECK_CONVERTEOLPASTE,			HIDC_CHECK_CONVERTEOLPASTE,			//æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’å¤‰æ›ã—ã¦è²¼ã‚Šä»˜ã‘ã‚‹
+	IDC_RADIO_CURDIR,					HIDC_RADIO_CURDIR,						//ã‚«ãƒ¬ãƒ³ãƒˆãƒ•ã‚©ãƒ«ãƒ€
+	IDC_RADIO_MRUDIR,					HIDC_RADIO_MRUDIR,						//æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚©ãƒ«ãƒ€
+	IDC_RADIO_SELDIR,					HIDC_RADIO_SELDIR,						//æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€
+	IDC_EDIT_FILEOPENDIR,				HIDC_EDIT_FILEOPENDIR,					//æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹
+	IDC_BUTTON_FILEOPENDIR, 			HIDC_EDIT_FILEOPENDIR,					//æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹
+	IDC_CHECK_ENABLEEXTEOL,				HIDC_CHECK_ENABLEEXTEOL,				//æ”¹è¡Œã‚³ãƒ¼ãƒ‰NEL,PS,LSã‚’æœ‰åŠ¹ã«ã™ã‚‹
+	IDC_CHECK_BOXSELECTLOCK,			HIDC_CHECK_BOXSELECTLOCK,				//çŸ©å½¢é¸æŠç§»å‹•ã§é¸æŠã‚’ãƒ­ãƒƒã‚¯ã™ã‚‹
 //	IDC_STATIC,							-1,
 	0, 0
 };
@@ -53,10 +53,10 @@ static const DWORD p_helpids[] = {	//10210
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropEdit::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -65,7 +65,7 @@ INT_PTR CALLBACK CPropEdit::DlgProc_page(
 }
 //	To Here Jun. 2, 2001 genta
 
-/* ƒƒbƒZ[ƒWˆ— */
+/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropEdit::DispatchEvent(
     HWND		hwndDlg,	// handle to dialog box
     UINT		uMsg,		// message
@@ -83,22 +83,22 @@ INT_PTR CPropEdit::DispatchEvent(
 
 	case WM_INITDIALOG:
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_FILEOPENDIR ), _MAX_PATH - 1 );
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Edit */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Edit */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒ†[ƒU[‚ªƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+		/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 
 		return TRUE;
 	case WM_COMMAND:
-		wNotifyCode	= HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID			= LOWORD(wParam);	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+		wNotifyCode	= HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID			= LOWORD(wParam);	/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 		switch( wNotifyCode ){
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 			switch( wID ){
-			case IDC_CHECK_DRAGDROP:	/* ƒ^ƒXƒNƒgƒŒƒC‚ğg‚¤ */
+			case IDC_CHECK_DRAGDROP:	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã‚’ä½¿ã† */
 				if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DRAGDROP ) ){
 					::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_DROPSOURCE ), TRUE );
 				}
@@ -138,11 +138,11 @@ INT_PTR CPropEdit::DispatchEvent(
 		case PSN_KILLACTIVE:
 			DEBUG_TRACE( _T("Edit PSN_KILLACTIVE\n") );
 
-			/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Edit */
+			/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Edit */
 			GetData( hwndDlg );
 			return TRUE;
 
-		case PSN_SETACTIVE: //@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+		case PSN_SETACTIVE: //@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 			m_nPageNum = ID_PROPCOM_PAGENUM_EDIT;
 			return TRUE;
 		}
@@ -152,7 +152,7 @@ INT_PTR CPropEdit::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -162,7 +162,7 @@ INT_PTR CPropEdit::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -171,10 +171,10 @@ INT_PTR CPropEdit::DispatchEvent(
 }
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CPropEdit::SetData( HWND hwndDlg )
 {
-	/* ƒhƒ‰ƒbƒO & ƒhƒƒbƒv•ÒW */
+	/* ãƒ‰ãƒ©ãƒƒã‚° & ãƒ‰ãƒ­ãƒƒãƒ—ç·¨é›† */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DRAGDROP, m_Common.m_sEdit.m_bUseOLE_DragDrop );
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DRAGDROP ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_DROPSOURCE ), TRUE );
@@ -186,34 +186,34 @@ void CPropEdit::SetData( HWND hwndDlg )
 	/* DropSource */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DROPSOURCE, m_Common.m_sEdit.m_bUseOLE_DropSource );
 
-	/* Ü‚è•Ô‚µs‚É‰üs‚ğ•t‚¯‚ÄƒRƒs[ */
+	/* æŠ˜ã‚Šè¿”ã—è¡Œã«æ”¹è¡Œã‚’ä»˜ã‘ã¦ã‚³ãƒ”ãƒ¼ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_ADDCRLFWHENCOPY, m_Common.m_sEdit.m_bAddCRLFWhenCopy ? BST_CHECKED : BST_UNCHECKED );
 
-	/* ƒRƒs[‚µ‚½‚ç‘I‘ğ‰ğœ */
+	/* ã‚³ãƒ”ãƒ¼ã—ãŸã‚‰é¸æŠè§£é™¤ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_COPYnDISABLESELECTEDAREA, m_Common.m_sEdit.m_bCopyAndDisablSelection );
 
-	/* ‘I‘ğ‚È‚µ‚ÅƒRƒs[‚ğ‰Â”\‚É‚·‚é */	// 2007.11.18 ryoji
+	/* é¸æŠãªã—ã§ã‚³ãƒ”ãƒ¼ã‚’å¯èƒ½ã«ã™ã‚‹ */	// 2007.11.18 ryoji
 	::CheckDlgButton( hwndDlg, IDC_CHECK_bEnableNoSelectCopy, m_Common.m_sEdit.m_bEnableNoSelectCopy );
 
-	/* ƒ‰ƒCƒ“ƒ‚[ƒh“\‚è•t‚¯‚ğ‰Â”\‚É‚·‚é */	// 2007.10.08 ryoji
+	/* ãƒ©ã‚¤ãƒ³ãƒ¢ãƒ¼ãƒ‰è²¼ã‚Šä»˜ã‘ã‚’å¯èƒ½ã«ã™ã‚‹ */	// 2007.10.08 ryoji
 	::CheckDlgButton( hwndDlg, IDC_CHECK_bEnableLineModePaste, m_Common.m_sEdit.m_bEnableLineModePaste ? BST_CHECKED : BST_UNCHECKED );
 
-	/* ‰üs‚Íã‘‚«‚µ‚È‚¢ */
+	/* æ”¹è¡Œã¯ä¸Šæ›¸ãã—ãªã„ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_bNotOverWriteCRLF, m_Common.m_sEdit.m_bNotOverWriteCRLF );
 
-	// •¶š•‚É‡‚í‚¹‚ÄƒXƒy[ƒX‚ğ‹l‚ß‚é
+	// æ–‡å­—å¹…ã«åˆã‚ã›ã¦ã‚¹ãƒšãƒ¼ã‚¹ã‚’è©°ã‚ã‚‹
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_bOverWriteFixMode, m_Common.m_sEdit.m_bOverWriteFixMode );
 
-	// ‹éŒ`“ü—Í‚Å‘I‘ğ”ÍˆÍ‚ğíœ‚·‚é
+	// çŸ©å½¢å…¥åŠ›ã§é¸æŠç¯„å›²ã‚’å‰Šé™¤ã™ã‚‹
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_bOverWriteBoxDelete, m_Common.m_sEdit.m_bOverWriteBoxDelete );
 
-	//	URL‚ªƒNƒŠƒbƒN‚³‚ê‚½‚ç‘I‘ğ‚·‚é‚© */	// 2007.02.11 genta ‚±‚Ìƒy[ƒW‚ÖˆÚ“®
+	//	URLãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸã‚‰é¸æŠã™ã‚‹ã‹ */	// 2007.02.11 genta ã“ã®ãƒšãƒ¼ã‚¸ã¸ç§»å‹•
 	::CheckDlgButton( hwndDlg, IDC_CHECK_bSelectClickedURL, m_Common.m_sEdit.m_bSelectClickedURL );
 
-	/*	‰üsƒR[ƒh‚ğ•ÏŠ·‚µ‚Ä“\‚è•t‚¯‚é */	// 2009.02.28 salarm
+	/*	æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’å¤‰æ›ã—ã¦è²¼ã‚Šä»˜ã‘ã‚‹ */	// 2009.02.28 salarm
 	::CheckDlgButton( hwndDlg, IDC_CHECK_CONVERTEOLPASTE, m_Common.m_sEdit.m_bConvertEOLPaste ? BST_CHECKED : BST_UNCHECKED );
 
-	// ƒtƒ@ƒCƒ‹ƒ_ƒCƒAƒƒO‚Ì‰ŠúˆÊ’u
+	// ãƒ•ã‚¡ã‚¤ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸä½ç½®
 	if( m_Common.m_sEdit.m_eOpenDialogDir == OPENDIALOGDIR_CUR ){
 		::CheckDlgButton( hwndDlg, IDC_RADIO_CURDIR, TRUE );
 	}
@@ -225,9 +225,9 @@ void CPropEdit::SetData( HWND hwndDlg )
 	}
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_FILEOPENDIR, m_Common.m_sEdit.m_OpenDialogSelDir );
 
-	// ‰üsƒR[ƒhNEL,PS,LS‚ğ—LŒø‚É‚·‚é
+	// æ”¹è¡Œã‚³ãƒ¼ãƒ‰NEL,PS,LSã‚’æœ‰åŠ¹ã«ã™ã‚‹
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_ENABLEEXTEOL, m_Common.m_sEdit.m_bEnableExtEol );
-	// ‹éŒ`‘I‘ğˆÚ“®‚Å‘I‘ğ‚ğƒƒbƒN‚·‚é
+	// çŸ©å½¢é¸æŠç§»å‹•ã§é¸æŠã‚’ãƒ­ãƒƒã‚¯ã™ã‚‹
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_BOXSELECTLOCK, m_Common.m_sEdit.m_bBoxSelectLock );
 
 	EnableEditPropInput( hwndDlg );
@@ -235,39 +235,39 @@ void CPropEdit::SetData( HWND hwndDlg )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 int CPropEdit::GetData( HWND hwndDlg )
 {
-	/* ƒhƒ‰ƒbƒO & ƒhƒƒbƒv•ÒW */
+	/* ãƒ‰ãƒ©ãƒƒã‚° & ãƒ‰ãƒ­ãƒƒãƒ—ç·¨é›† */
 	m_Common.m_sEdit.m_bUseOLE_DragDrop = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DRAGDROP );
 	/* DropSource */
 	m_Common.m_sEdit.m_bUseOLE_DropSource = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DROPSOURCE );
 
-	/* Ü‚è•Ô‚µs‚É‰üs‚ğ•t‚¯‚ÄƒRƒs[ */
+	/* æŠ˜ã‚Šè¿”ã—è¡Œã«æ”¹è¡Œã‚’ä»˜ã‘ã¦ã‚³ãƒ”ãƒ¼ */
 	m_Common.m_sEdit.m_bAddCRLFWhenCopy = (0 != ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_ADDCRLFWHENCOPY ));
 
-	/* ƒRƒs[‚µ‚½‚ç‘I‘ğ‰ğœ */
+	/* ã‚³ãƒ”ãƒ¼ã—ãŸã‚‰é¸æŠè§£é™¤ */
 	m_Common.m_sEdit.m_bCopyAndDisablSelection = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_COPYnDISABLESELECTEDAREA );
 
-	/* ‘I‘ğ‚È‚µ‚ÅƒRƒs[‚ğ‰Â”\‚É‚·‚é */	// 2007.11.18 ryoji
+	/* é¸æŠãªã—ã§ã‚³ãƒ”ãƒ¼ã‚’å¯èƒ½ã«ã™ã‚‹ */	// 2007.11.18 ryoji
 	m_Common.m_sEdit.m_bEnableNoSelectCopy = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_bEnableNoSelectCopy );
 
-	/* ƒ‰ƒCƒ“ƒ‚[ƒh“\‚è•t‚¯‚ğ‰Â”\‚É‚·‚é */	// 2007.10.08 ryoji
+	/* ãƒ©ã‚¤ãƒ³ãƒ¢ãƒ¼ãƒ‰è²¼ã‚Šä»˜ã‘ã‚’å¯èƒ½ã«ã™ã‚‹ */	// 2007.10.08 ryoji
 	m_Common.m_sEdit.m_bEnableLineModePaste = (0 != ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_bEnableLineModePaste ));
 
-	/* ‰üs‚Íã‘‚«‚µ‚È‚¢ */
+	/* æ”¹è¡Œã¯ä¸Šæ›¸ãã—ãªã„ */
 	m_Common.m_sEdit.m_bNotOverWriteCRLF = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_bNotOverWriteCRLF );
 
-	// •¶š•‚É‡‚í‚¹‚ÄƒXƒy[ƒX‚ğ‹l‚ß‚é
+	// æ–‡å­—å¹…ã«åˆã‚ã›ã¦ã‚¹ãƒšãƒ¼ã‚¹ã‚’è©°ã‚ã‚‹
 	m_Common.m_sEdit.m_bOverWriteFixMode = IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_bOverWriteFixMode );
 
-	// ‹éŒ`“ü—Í‚Å‘I‘ğ”ÍˆÍ‚ğíœ‚·‚é
+	// çŸ©å½¢å…¥åŠ›ã§é¸æŠç¯„å›²ã‚’å‰Šé™¤ã™ã‚‹
 	m_Common.m_sEdit.m_bOverWriteBoxDelete = IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_bOverWriteBoxDelete );
 
-	/* URL‚ªƒNƒŠƒbƒN‚³‚ê‚½‚ç‘I‘ğ‚·‚é‚© */	// 2007.02.11 genta ‚±‚Ìƒy[ƒW‚ÖˆÚ“®
+	/* URLãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸã‚‰é¸æŠã™ã‚‹ã‹ */	// 2007.02.11 genta ã“ã®ãƒšãƒ¼ã‚¸ã¸ç§»å‹•
 	m_Common.m_sEdit.m_bSelectClickedURL = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_bSelectClickedURL );
 
-	//	‰üsƒR[ƒh‚ğ•ÏŠ·‚µ‚Ä“\‚è•t‚¯‚é */	// 2009.02.28 salarm
+	//	æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’å¤‰æ›ã—ã¦è²¼ã‚Šä»˜ã‘ã‚‹ */	// 2009.02.28 salarm
 	m_Common.m_sEdit.m_bConvertEOLPaste = (0 != ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_CONVERTEOLPASTE ));
 
 	if( ::IsDlgButtonChecked(hwndDlg, IDC_RADIO_CURDIR) ){
@@ -281,24 +281,24 @@ int CPropEdit::GetData( HWND hwndDlg )
 	}
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_FILEOPENDIR, m_Common.m_sEdit.m_OpenDialogSelDir, _countof2(m_Common.m_sEdit.m_OpenDialogSelDir) );
 
-	// ‰üsƒR[ƒhNEL,PS,LS‚ğ—LŒø‚É‚·‚é
+	// æ”¹è¡Œã‚³ãƒ¼ãƒ‰NEL,PS,LSã‚’æœ‰åŠ¹ã«ã™ã‚‹
 	m_Common.m_sEdit.m_bEnableExtEol = IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_ENABLEEXTEOL );
-	// ‹éŒ`‘I‘ğˆÚ“®‚Å‘I‘ğ‚ğƒƒbƒN‚·‚é
+	// çŸ©å½¢é¸æŠç§»å‹•ã§é¸æŠã‚’ãƒ­ãƒƒã‚¯ã™ã‚‹
 	m_Common.m_sEdit.m_bBoxSelectLock = IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_BOXSELECTLOCK );
 
 	return TRUE;
 }
 
-/*!	ƒ`ƒFƒbƒNó‘Ô‚É‰‚¶‚Äƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX—v‘f‚ÌEnable/Disable‚ğ
-	“KØ‚Éİ’è‚·‚é
+/*!	ãƒã‚§ãƒƒã‚¯çŠ¶æ…‹ã«å¿œã˜ã¦ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹è¦ç´ ã®Enable/Disableã‚’
+	é©åˆ‡ã«è¨­å®šã™ã‚‹
 
-	@param hwndDlg ƒvƒƒpƒeƒBƒV[ƒg‚ÌWindow Handle
+	@param hwndDlg ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆã®Window Handle
 
-	@date 2013.03.31 novice V‹Kì¬
+	@date 2013.03.31 novice æ–°è¦ä½œæˆ
 */
 void CPropEdit::EnableEditPropInput( HWND hwndDlg )
 {
-	// w’èƒtƒHƒ‹ƒ_
+	// æŒ‡å®šãƒ•ã‚©ãƒ«ãƒ€
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_SELDIR ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_FILEOPENDIR ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_FILEOPENDIR ), TRUE );

--- a/sakura_core/prop/CPropComFile.cpp
+++ b/sakura_core/prop/CPropComFile.cpp
@@ -1,5 +1,5 @@
-/*! @file
-	@brief ���ʐݒ�_�C�A���O�{�b�N�X�A�u�����v�y�[�W
+﻿/*! @file
+	@brief 共通設定ダイアログボックス、「書式」ページ
 
 	@author Norio Nakatani
 */
@@ -24,42 +24,42 @@
 
 
 static const DWORD p_helpids[] = {	//01310
-	IDC_COMBO_FILESHAREMODE,				HIDC_COMBO_FILESHAREMODE,				//�r������
-	IDC_CHECK_bCheckFileTimeStamp,			HIDC_CHECK_bCheckFileTimeStamp,			//�X�V�̊Ď�
-	IDC_EDIT_AUTOLOAD_DELAY,				HIDC_EDIT_AUTOLOAD_DELAY,				//�����Ǎ����x��
+	IDC_COMBO_FILESHAREMODE,				HIDC_COMBO_FILESHAREMODE,				//排他制御
+	IDC_CHECK_bCheckFileTimeStamp,			HIDC_CHECK_bCheckFileTimeStamp,			//更新の監視
+	IDC_EDIT_AUTOLOAD_DELAY,				HIDC_EDIT_AUTOLOAD_DELAY,				//自動読込時遅延
 	IDC_SPIN_AUTOLOAD_DELAY,				HIDC_EDIT_AUTOLOAD_DELAY,
-	IDC_CHECK_bUneditableIfUnwritable,		HIDC_CHECK_bUneditableIfUnwritable,		//�㏑���֎~���o���͕ҏW�֎~�ɂ���
-	IDC_CHECK_ENABLEUNMODIFIEDOVERWRITE,	HIDC_CHECK_ENABLEUNMODIFIEDOVERWRITE,	//���ύX�ł��㏑��
-	IDC_CHECK_AUTOSAVE,						HIDC_CHECK_AUTOSAVE,					//�����I�ɕۑ�
-	IDC_CHECK_bDropFileAndClose,			HIDC_CHECK_bDropFileAndClose,			//���ĊJ��
-	IDC_CHECK_RestoreCurPosition,			HIDC_CHECK_RestoreCurPosition,			//�J�[�\���ʒu�̕���
-	IDC_CHECK_AutoMIMEDecode,				HIDC_CHECK_AutoMIMEDecode,				//MIME�f�R�[�h
-	IDC_EDIT_AUTOBACKUP_INTERVAL,			HIDC_EDIT_AUTOBACKUP_INTERVAL,			//�����ۑ��Ԋu
-	IDC_EDIT_nDropFileNumMax,				HIDC_EDIT_nDropFileNumMax,				//�t�@�C���h���b�v�ő吔
+	IDC_CHECK_bUneditableIfUnwritable,		HIDC_CHECK_bUneditableIfUnwritable,		//上書き禁止検出時は編集禁止にする
+	IDC_CHECK_ENABLEUNMODIFIEDOVERWRITE,	HIDC_CHECK_ENABLEUNMODIFIEDOVERWRITE,	//無変更でも上書き
+	IDC_CHECK_AUTOSAVE,						HIDC_CHECK_AUTOSAVE,					//自動的に保存
+	IDC_CHECK_bDropFileAndClose,			HIDC_CHECK_bDropFileAndClose,			//閉じて開く
+	IDC_CHECK_RestoreCurPosition,			HIDC_CHECK_RestoreCurPosition,			//カーソル位置の復元
+	IDC_CHECK_AutoMIMEDecode,				HIDC_CHECK_AutoMIMEDecode,				//MIMEデコード
+	IDC_EDIT_AUTOBACKUP_INTERVAL,			HIDC_EDIT_AUTOBACKUP_INTERVAL,			//自動保存間隔
+	IDC_EDIT_nDropFileNumMax,				HIDC_EDIT_nDropFileNumMax,				//ファイルドロップ最大数
 	IDC_SPIN_AUTOBACKUP_INTERVAL,			HIDC_EDIT_AUTOBACKUP_INTERVAL,
 	IDC_SPIN_nDropFileNumMax,				HIDC_EDIT_nDropFileNumMax,
-	IDC_CHECK_RestoreBookmarks,				HIDC_CHECK_RestoreBookmarks,			// 2002.01.16 hor �u�b�N�}�[�N�̕���
-	IDC_CHECK_QueryIfCodeChange,			HIDC_CHECK_QueryIfCodeChange,			//�O��ƈقȂ镶���R�[�h�̂Ƃ��₢���킹���s��	// 2006.08.06 ryoji
-	IDC_CHECK_AlertIfFileNotExist,			HIDC_CHECK_AlertIfFileNotExist,			//�J�����Ƃ����t�@�C�������݂��Ȃ��Ƃ��x������	// 2006.08.06 ryoji
-	IDC_CHECK_ALERT_IF_LARGEFILE,			HIDC_CHECK_ALERT_IF_LARGEFILE,			//�J�����Ƃ����t�@�C�����傫���ꍇ�Ɍx������
-	IDC_CHECK_NoFilterSaveNew,				HIDC_CHECK_NoFilterSaveNew,				// �V�K����ۑ����͑S�t�@�C���\��	// 2006.11.16 ryoji
-	IDC_CHECK_NoFilterSaveFile,				HIDC_CHECK_NoFilterSaveFile,			// �V�K�ȊO����ۑ����͑S�t�@�C���\��	// 2006.11.16 ryoji
+	IDC_CHECK_RestoreBookmarks,				HIDC_CHECK_RestoreBookmarks,			// 2002.01.16 hor ブックマークの復元
+	IDC_CHECK_QueryIfCodeChange,			HIDC_CHECK_QueryIfCodeChange,			//前回と異なる文字コードのとき問い合わせを行う	// 2006.08.06 ryoji
+	IDC_CHECK_AlertIfFileNotExist,			HIDC_CHECK_AlertIfFileNotExist,			//開こうとしたファイルが存在しないとき警告する	// 2006.08.06 ryoji
+	IDC_CHECK_ALERT_IF_LARGEFILE,			HIDC_CHECK_ALERT_IF_LARGEFILE,			//開こうとしたファイルが大きい場合に警告する
+	IDC_CHECK_NoFilterSaveNew,				HIDC_CHECK_NoFilterSaveNew,				// 新規から保存時は全ファイル表示	// 2006.11.16 ryoji
+	IDC_CHECK_NoFilterSaveFile,				HIDC_CHECK_NoFilterSaveFile,			// 新規以外から保存時は全ファイル表示	// 2006.11.16 ryoji
 //	IDC_STATIC,								-1,
 	0, 0
 };
 
 TYPE_NAME_ID<EShareMode> ShareModeArr[] = {
-	{ SHAREMODE_NOT_EXCLUSIVE,	STR_EXCLU_NO_EXCLUSIVE },	//_T("���Ȃ�") },
-	{ SHAREMODE_DENY_WRITE,		STR_EXCLU_DENY_WRITE },		//_T("�㏑�����֎~����") },
-	{ SHAREMODE_DENY_READWRITE,	STR_EXCLU_DENY_READWRITE },	//_T("�ǂݏ������֎~����") },
+	{ SHAREMODE_NOT_EXCLUSIVE,	STR_EXCLU_NO_EXCLUSIVE },	//_T("しない") },
+	{ SHAREMODE_DENY_WRITE,		STR_EXCLU_DENY_WRITE },		//_T("上書きを禁止する") },
+	{ SHAREMODE_DENY_READWRITE,	STR_EXCLU_DENY_READWRITE },	//_T("読み書きを禁止する") },
 };
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg �_�C�A���O�{�b�N�X��Window Handle
-	@param uMsg ���b�Z�[�W
-	@param wParam �p�����[�^1
-	@param lParam �p�����[�^2
+	@param hwndDlg ダイアログボックスのWindow Handle
+	@param uMsg メッセージ
+	@param wParam パラメータ1
+	@param lParam パラメータ2
 */
 INT_PTR CALLBACK CPropFile::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -68,7 +68,7 @@ INT_PTR CALLBACK CPropFile::DlgProc_page(
 }
 //	To Here Jun. 2, 2001 genta
 
-/*! �t�@�C���y�[�W ���b�Z�[�W���� */
+/*! ファイルページ メッセージ処理 */
 INT_PTR CPropFile::DispatchEvent(
 	HWND	hwndDlg,	//!< handle to dialog box
 	UINT	uMsg,	//!< message
@@ -82,17 +82,17 @@ INT_PTR CPropFile::DispatchEvent(
 	NM_UPDOWN*	pMNUD;
 	int			idCtrl;
 //	int			nVal;
-	int			nVal;	//Sept.21, 2000 JEPRO �X�s���v�f���������̂ŕ���������
+	int			nVal;	//Sept.21, 2000 JEPRO スピン要素を加えたので復活させた
 //	char		szFolder[_MAX_PATH];
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* �_�C�A���O�f�[�^�̐ݒ� File */
+		/* ダイアログデータの設定 File */
 		SetData( hwndDlg );
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
 		return TRUE;
-//****	From Here Sept. 21, 2000 JEPRO �_�C�A���O�v�f�ɃX�s��������̂ňȉ���WM_NOTIFY���R�����g�A�E�g�ɂ����ɏC����u����
+//****	From Here Sept. 21, 2000 JEPRO ダイアログ要素にスピンを入れるので以下のWM_NOTIFYをコメントアウトにし下に修正を置いた
 //	case WM_NOTIFY:
 //		idCtrl = (int)wParam;
 //		pNMHDR = (NMHDR*)lParam;
@@ -105,7 +105,7 @@ INT_PTR CPropFile::DispatchEvent(
 //				return TRUE;
 //			case PSN_KILLACTIVE:
 ////				MYTRACE( _T("p2 PSN_KILLACTIVE\n") );
-//				/* �_�C�A���O�f�[�^�̎擾 p2 */
+//				/* ダイアログデータの取得 p2 */
 //				GetData_p2( hwndDlg );
 //				return TRUE;
 //			}
@@ -124,17 +124,17 @@ INT_PTR CPropFile::DispatchEvent(
 				return TRUE;
 			case PSN_KILLACTIVE:
 //				MYTRACE( _T("File PSN_KILLACTIVE\n") );
-				/* �_�C�A���O�f�[�^�̎擾 File */
+				/* ダイアログデータの取得 File */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+//@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_FILE;
 				return TRUE;
 			}
 			break;
 		case IDC_SPIN_AUTOLOAD_DELAY:
-			// �����Ǎ����x��
+			// 自動読込時遅延
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_AUTOLOAD_DELAY, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -148,7 +148,7 @@ INT_PTR CPropFile::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_AUTOLOAD_DELAY, nVal, FALSE );
 			return TRUE;
 		case IDC_SPIN_nDropFileNumMax:
-			/* ��x�Ƀh���b�v�\�ȃt�@�C���� */
+			/* 一度にドロップ可能なファイル数 */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_nDropFileNumMax, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -168,7 +168,7 @@ INT_PTR CPropFile::DispatchEvent(
 			/*NOTREACHED*/
 //			break;
 		case IDC_SPIN_AUTOBACKUP_INTERVAL:
-			/* �o�b�N�A�b�v�Ԋu */
+			/* バックアップ間隔 */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_AUTOBACKUP_INTERVAL, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -185,7 +185,7 @@ INT_PTR CPropFile::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_AUTOBACKUP_INTERVAL, nVal, FALSE );
 			return TRUE;
 		case IDC_SPIN_ALERT_FILESIZE:
-			/* �t�@�C���̌x���T�C�Y */
+			/* ファイルの警告サイズ */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_ALERT_FILESIZE, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -197,7 +197,7 @@ INT_PTR CPropFile::DispatchEvent(
 				nVal = 1;
 			}
 			if( nVal > 2048 ){
-				nVal = 2048;  // �ő� 2GB �܂�
+				nVal = 2048;  // 最大 2GB まで
 			}
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_ALERT_FILESIZE, nVal, FALSE );
 			return TRUE;
@@ -205,24 +205,24 @@ INT_PTR CPropFile::DispatchEvent(
 //			break;
 //@@@ 2001.03.21 End by MIK
 		}
-//****	To Here Sept. 21, 2000 JEPRO �_�C�A���O�v�f�ɃX�s��������̂�WM_NOTIFY���R�����g�A�E�g�ɂ����̉��ɏC����u����
+//****	To Here Sept. 21, 2000 JEPRO ダイアログ要素にスピンを入れるのでWM_NOTIFYをコメントアウトにしその下に修正を置いた
 		break;
 
 	case WM_COMMAND:
-		wNotifyCode	= HIWORD(wParam);	/* �ʒm�R�[�h */
-		wID			= LOWORD(wParam);	/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
+		wNotifyCode	= HIWORD(wParam);	/* 通知コード */
+		wID			= LOWORD(wParam);	/* 項目ID､ コントロールID､ またはアクセラレータID */
 
-		if( wID == IDC_COMBO_FILESHAREMODE && wNotifyCode == CBN_SELCHANGE ){	// �R���{�{�b�N�X�̑I��ύX
+		if( wID == IDC_COMBO_FILESHAREMODE && wNotifyCode == CBN_SELCHANGE ){	// コンボボックスの選択変更
 			EnableFilePropInput(hwndDlg);
 			break;
 		}
 
 		switch( wNotifyCode ){
-		/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+		/* ボタン／チェックボックスがクリックされた */
 		case BN_CLICKED:
 			switch( wID ){
-			case IDC_CHECK_bCheckFileTimeStamp:	// �X�V�̊Ď�
-			case IDC_CHECK_bDropFileAndClose:/* �t�@�C�����h���b�v�����Ƃ��͕��ĊJ�� */
+			case IDC_CHECK_bCheckFileTimeStamp:	// 更新の監視
+			case IDC_CHECK_bDropFileAndClose:/* ファイルをドロップしたときは閉じて開く */
 			case IDC_CHECK_AUTOSAVE:
 			case IDC_CHECK_ALERT_IF_LARGEFILE:
 				EnableFilePropInput(hwndDlg);
@@ -236,7 +236,7 @@ INT_PTR CPropFile::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -246,7 +246,7 @@ INT_PTR CPropFile::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -258,18 +258,18 @@ INT_PTR CPropFile::DispatchEvent(
 
 
 
-/*! �t�@�C���y�[�W: �_�C�A���O�f�[�^�̐ݒ�
-	���L����������f�[�^��ǂݏo���Ċe�R���g���[���ɒl��ݒ肷��B
+/*! ファイルページ: ダイアログデータの設定
+	共有メモリからデータを読み出して各コントロールに値を設定する。
 
-	@par �o�b�N�A�b�v���㐔���Ó��Ȓl���ǂ����̃`�F�b�N���s���B�s�K�؂Ȓl�̎���
-	�ł��߂��K�؂Ȓl��ݒ肷��B
+	@par バックアップ世代数が妥当な値かどうかのチェックも行う。不適切な値の時は
+	最も近い適切な値を設定する。
 
-	@param hwndDlg �v���p�e�B�y�[�W��Window Handle
+	@param hwndDlg プロパティページのWindow Handle
 */
 void CPropFile::SetData( HWND hwndDlg )
 {
 	/*--- File ---*/
-	/* �t�@�C���̔r�����䃂�[�h */
+	/* ファイルの排他制御モード */
 	HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_FILESHAREMODE );
 	Combo_ResetContent( hwndCombo );
 	int		nSelPos = 0;
@@ -281,25 +281,25 @@ void CPropFile::SetData( HWND hwndDlg )
 	}
 	Combo_SetCurSel( hwndCombo, nSelPos );
 
-	/* �X�V�̊Ď� */
+	/* 更新の監視 */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_bCheckFileTimeStamp, m_Common.m_sFile.m_bCheckFileTimeStamp );
 
-	// �����Ǎ����x��
+	// 自動読込時遅延
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_AUTOLOAD_DELAY, m_Common.m_sFile.m_nAutoloadDelay, FALSE );
 
-	/* �㏑���֎~���o���͕ҏW�֎~�ɂ��� */
+	/* 上書き禁止検出時は編集禁止にする */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_bUneditableIfUnwritable, m_Common.m_sFile.m_bUneditableIfUnwritable );
 
-	/* ���ύX�ł��㏑�����邩 */
+	/* 無変更でも上書きするか */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_ENABLEUNMODIFIEDOVERWRITE, m_Common.m_sFile.m_bEnableUnmodifiedOverwrite );
 
-	/* �t�@�C�����h���b�v�����Ƃ��͕��ĊJ�� */
+	/* ファイルをドロップしたときは閉じて開く */
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_bDropFileAndClose, m_Common.m_sFile.m_bDropFileAndClose );
-	/* ��x�Ƀh���b�v�\�ȃt�@�C���� */
+	/* 一度にドロップ可能なファイル数 */
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_nDropFileNumMax, m_Common.m_sFile.m_nDropFileNumMax, FALSE );
 
 	//	From Here Aug. 21, 2000 genta
-	//	�����ۑ��̗L���E����
+	//	自動保存の有効・無効
 	::CheckDlgButton( hwndDlg, IDC_CHECK_AUTOSAVE, m_Common.m_sBackup.IsAutoBackupEnabled() );
 
 	TCHAR buf[6];
@@ -313,72 +313,72 @@ void CPropFile::SetData( HWND hwndDlg )
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_AUTOBACKUP_INTERVAL, buf );
 	//	To Here Aug. 21, 2000 genta
 
-	//	Oct. 27, 2000 genta	�J�[�\���ʒu�����t���O
+	//	Oct. 27, 2000 genta	カーソル位置復元フラグ
 	::CheckDlgButton( hwndDlg, IDC_CHECK_RestoreCurPosition, m_Common.m_sFile.GetRestoreCurPosition() );
-	// 2002.01.16 hor �u�b�N�}�[�N�����t���O
+	// 2002.01.16 hor ブックマーク復元フラグ
 	::CheckDlgButton( hwndDlg, IDC_CHECK_RestoreBookmarks, m_Common.m_sFile.GetRestoreBookmarks() );
-	//	Nov. 12, 2000 genta	MIME Decode�t���O
+	//	Nov. 12, 2000 genta	MIME Decodeフラグ
 	::CheckDlgButton( hwndDlg, IDC_CHECK_AutoMIMEDecode, m_Common.m_sFile.GetAutoMIMEdecode() );
-	//	Oct. 03, 2004 genta �O��ƈقȂ镶���R�[�h�̂Ƃ��ɖ₢���킹���s�����ǂ����̃t���O
+	//	Oct. 03, 2004 genta 前回と異なる文字コードのときに問い合わせを行うかどうかのフラグ
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_QueryIfCodeChange, m_Common.m_sFile.GetQueryIfCodeChange() );
-	//	Oct. 09, 2004 genta �J�����Ƃ����t�@�C�������݂��Ȃ��Ƃ��x�����邩�ǂ����̃t���O
+	//	Oct. 09, 2004 genta 開こうとしたファイルが存在しないとき警告するかどうかのフラグ
 	::CheckDlgButton( hwndDlg, IDC_CHECK_AlertIfFileNotExist, m_Common.m_sFile.GetAlertIfFileNotExist() );
-	//	�t�@�C���T�C�Y���傫���ꍇ�Ɍx�����o��
+	//	ファイルサイズが大きい場合に警告を出す
 	::CheckDlgButton( hwndDlg, IDC_CHECK_ALERT_IF_LARGEFILE, m_Common.m_sFile.m_bAlertIfLargeFile );
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_ALERT_FILESIZE, m_Common.m_sFile.m_nAlertFileSize, FALSE );
 
-	// �t�@�C���ۑ��_�C�A���O�̃t�B���^�ݒ�	// 2006.11.16 ryoji
-	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_NoFilterSaveNew, m_Common.m_sFile.m_bNoFilterSaveNew );	// �V�K����ۑ����͑S�t�@�C���\��
-	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_NoFilterSaveFile, m_Common.m_sFile.m_bNoFilterSaveFile );	// �V�K�ȊO����ۑ����͑S�t�@�C���\��
+	// ファイル保存ダイアログのフィルタ設定	// 2006.11.16 ryoji
+	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_NoFilterSaveNew, m_Common.m_sFile.m_bNoFilterSaveNew );	// 新規から保存時は全ファイル表示
+	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_NoFilterSaveFile, m_Common.m_sFile.m_bNoFilterSaveFile );	// 新規以外から保存時は全ファイル表示
 
 	EnableFilePropInput(hwndDlg);
 	return;
 }
 
-/*! �t�@�C���y�[�W �_�C�A���O�f�[�^�̎擾
-	�_�C�A���O�{�b�N�X�ɐݒ肳�ꂽ�f�[�^�����L�������ɔ��f������
+/*! ファイルページ ダイアログデータの取得
+	ダイアログボックスに設定されたデータを共有メモリに反映させる
 
-	@par �o�b�N�A�b�v���㐔���Ó��Ȓl���ǂ����̃`�F�b�N���s���B�s�K�؂Ȓl�̎���
-	�ł��߂��K�؂Ȓl��ݒ肷��B
+	@par バックアップ世代数が妥当な値かどうかのチェックも行う。不適切な値の時は
+	最も近い適切な値を設定する。
 
-	@param hwndDlg �v���p�e�B�y�[�W��Window Handle
-	@return ���TRUE
+	@param hwndDlg プロパティページのWindow Handle
+	@return 常にTRUE
 */
 int CPropFile::GetData( HWND hwndDlg )
 {
-	/* �t�@�C���̔r�����䃂�[�h */
+	/* ファイルの排他制御モード */
 	HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_FILESHAREMODE );
 	int		nSelPos = Combo_GetCurSel( hwndCombo );
 	m_Common.m_sFile.m_nFileShareMode = ShareModeArr[nSelPos].nMethod;
 
-	/* �X�V�̊Ď� */
+	/* 更新の監視 */
 	m_Common.m_sFile.m_bCheckFileTimeStamp = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_bCheckFileTimeStamp );
 
-	// �����Ǎ����x��
+	// 自動読込時遅延
 	m_Common.m_sFile.m_nAutoloadDelay = ::GetDlgItemInt( hwndDlg, IDC_EDIT_AUTOLOAD_DELAY, NULL, FALSE );
 
-	/* �㏑���֎~���o���͕ҏW�֎~�ɂ��� */
+	/* 上書き禁止検出時は編集禁止にする */
 	m_Common.m_sFile.m_bUneditableIfUnwritable = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_bUneditableIfUnwritable );
 
-	/* ���ύX�ł��㏑�����邩 */
+	/* 無変更でも上書きするか */
 	m_Common.m_sFile.m_bEnableUnmodifiedOverwrite = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_ENABLEUNMODIFIEDOVERWRITE );
 
-	/* �t�@�C�����h���b�v�����Ƃ��͕��ĊJ�� */
+	/* ファイルをドロップしたときは閉じて開く */
 	m_Common.m_sFile.m_bDropFileAndClose = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_bDropFileAndClose );
-	/* ��x�Ƀh���b�v�\�ȃt�@�C���� */
+	/* 一度にドロップ可能なファイル数 */
 	m_Common.m_sFile.m_nDropFileNumMax = ::GetDlgItemInt( hwndDlg, IDC_EDIT_nDropFileNumMax, NULL, FALSE );
 	if( 1 > m_Common.m_sFile.m_nDropFileNumMax ){
 		m_Common.m_sFile.m_nDropFileNumMax = 1;
 	}
-	if( 99 < m_Common.m_sFile.m_nDropFileNumMax ){	//Sept. 21, 2000, JEPRO 16���傫���Ƃ���99�Ɛ�������Ă����̂��C��(16��99�ƕύX)
+	if( 99 < m_Common.m_sFile.m_nDropFileNumMax ){	//Sept. 21, 2000, JEPRO 16より大きいときに99と制限されていたのを修正(16→99と変更)
 		m_Common.m_sFile.m_nDropFileNumMax = 99;
 	}
 
 	//	From Here Aug. 16, 2000 genta
-	//	�����ۑ����s�����ǂ���
+	//	自動保存を行うかどうか
 	m_Common.m_sBackup.EnableAutoBackup( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_AUTOSAVE ) != FALSE );
 
-	//	�����ۑ��Ԋu�̎擾
+	//	自動保存間隔の取得
 	TCHAR szNumBuf[/*6*/ 7];	//@@@ 2001.03.21 by MIK
 	int	 nN;
 	TCHAR *pDigit;
@@ -398,17 +398,17 @@ int CPropFile::GetData( HWND hwndDlg )
 
 	//	To Here Aug. 16, 2000 genta
 
-	//	Oct. 27, 2000 genta	�J�[�\���ʒu�����t���O
+	//	Oct. 27, 2000 genta	カーソル位置復元フラグ
 	m_Common.m_sFile.SetRestoreCurPosition( ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_RestoreCurPosition ) );
-	// 2002.01.16 hor �u�b�N�}�[�N�����t���O
+	// 2002.01.16 hor ブックマーク復元フラグ
 	m_Common.m_sFile.SetRestoreBookmarks( ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_RestoreBookmarks ) );
-	//	Nov. 12, 2000 genta	MIME Decode�t���O
+	//	Nov. 12, 2000 genta	MIME Decodeフラグ
 	m_Common.m_sFile.SetAutoMIMEdecode( ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_AutoMIMEDecode ) );
-	//	Oct. 03, 2004 genta �O��ƈقȂ镶���R�[�h�̂Ƃ��ɖ₢���킹���s�����ǂ����̃t���O
+	//	Oct. 03, 2004 genta 前回と異なる文字コードのときに問い合わせを行うかどうかのフラグ
 	m_Common.m_sFile.SetQueryIfCodeChange( ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_QueryIfCodeChange ) );
-	//	Oct. 03, 2004 genta �O��ƈقȂ镶���R�[�h�̂Ƃ��ɖ₢���킹���s�����ǂ����̃t���O
+	//	Oct. 03, 2004 genta 前回と異なる文字コードのときに問い合わせを行うかどうかのフラグ
 	m_Common.m_sFile.SetAlertIfFileNotExist( ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_AlertIfFileNotExist ) );
-	// �J�����Ƃ����t�@�C�����傫���ꍇ�Ɍx������
+	// 開こうとしたファイルが大きい場合に警告する
 	m_Common.m_sFile.m_bAlertIfLargeFile = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_ALERT_IF_LARGEFILE );
 	m_Common.m_sFile.m_nAlertFileSize = ::GetDlgItemInt( hwndDlg, IDC_EDIT_ALERT_FILESIZE, NULL, FALSE );
 	if( m_Common.m_sFile.m_nAlertFileSize < 1 ){
@@ -418,36 +418,36 @@ int CPropFile::GetData( HWND hwndDlg )
 		m_Common.m_sFile.m_nAlertFileSize = 2048;
 	}
 
-	// �t�@�C���ۑ��_�C�A���O�̃t�B���^�ݒ�	// 2006.11.16 ryoji
-	m_Common.m_sFile.m_bNoFilterSaveNew = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_NoFilterSaveNew );	// �V�K����ۑ����͑S�t�@�C���\��
-	m_Common.m_sFile.m_bNoFilterSaveFile = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_NoFilterSaveFile );	// �V�K�ȊO����ۑ����͑S�t�@�C���\��
+	// ファイル保存ダイアログのフィルタ設定	// 2006.11.16 ryoji
+	m_Common.m_sFile.m_bNoFilterSaveNew = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_NoFilterSaveNew );	// 新規から保存時は全ファイル表示
+	m_Common.m_sFile.m_bNoFilterSaveFile = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_NoFilterSaveFile );	// 新規以外から保存時は全ファイル表示
 
 	return TRUE;
 }
 
 //	From Here Aug. 21, 2000 genta
-/*!	�`�F�b�N��Ԃɉ����ă_�C�A���O�{�b�N�X�v�f��Enable/Disable��
-	�K�؂ɐݒ肷��
+/*!	チェック状態に応じてダイアログボックス要素のEnable/Disableを
+	適切に設定する
 
-	@param hwndDlg �v���p�e�B�V�[�g��Window Handle
+	@param hwndDlg プロパティシートのWindow Handle
 */
 void CPropFile::EnableFilePropInput(HWND hwndDlg)
 {
 
-	//	Drop���̓���
+	//	Drop時の動作
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_bDropFileAndClose ) ){
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE3 ), FALSE );	// added Sept. 6, JEPRO �����ۑ��ɂ����Ƃ�����Enable�ɂȂ�悤�ɕύX
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE4 ), FALSE );	// added Sept. 6, JEPRO	����
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE3 ), FALSE );	// added Sept. 6, JEPRO 自動保存にしたときだけEnableになるように変更
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE4 ), FALSE );	// added Sept. 6, JEPRO	同上
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_nDropFileNumMax ), FALSE );
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_nDropFileNumMax ), FALSE );// added Oct. 6, JEPRO �t�@�C���I�[�v�����u���ĊJ���v�ɂ����Ƃ���Disable�ɂȂ�悤�ɕύX
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_nDropFileNumMax ), FALSE );// added Oct. 6, JEPRO ファイルオープンを「閉じて開く」にしたときはDisableになるように変更
 	}else{
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE3 ), TRUE );	// added Sept. 6, JEPRO	����
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE4 ), TRUE );	// added Sept. 6, JEPRO	����
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE3 ), TRUE );	// added Sept. 6, JEPRO	同上
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE4 ), TRUE );	// added Sept. 6, JEPRO	同上
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_nDropFileNumMax ), TRUE );
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_nDropFileNumMax ), TRUE );// added Oct. 6, JEPRO �t�@�C���I�[�v�����u�����t�@�C���h���b�v�v�ɂ����Ƃ�����Enable�ɂȂ�悤�ɕύX
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_nDropFileNumMax ), TRUE );// added Oct. 6, JEPRO ファイルオープンを「複数ファイルドロップ」にしたときだけEnableになるように変更
 	}
 
-	//	�r�����邩�ǂ���
+	//	排他するかどうか
 	int nSelPos = Combo_GetCurSel( ::GetDlgItem( hwndDlg, IDC_COMBO_FILESHAREMODE ) );
 	if( ShareModeArr[nSelPos].nMethod == SHAREMODE_NOT_EXCLUSIVE ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_bCheckFileTimeStamp ), TRUE );
@@ -468,20 +468,20 @@ void CPropFile::EnableFilePropInput(HWND hwndDlg)
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_AUTOLOAD_DELAY ),  FALSE );
 	}
 
-	//	�����ۑ�
+	//	自動保存
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_AUTOSAVE ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_AUTOBACKUP_INTERVAL ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE ), TRUE );
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE2 ), TRUE );	//Sept. 6, 2000 JEPRO �����ۑ��ɂ����Ƃ�����Enable�ɂȂ�悤�ɕύX
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE2 ), TRUE );	//Sept. 6, 2000 JEPRO 自動保存にしたときだけEnableになるように変更
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_AUTOBACKUP_INTERVAL ), TRUE );	//@@@ 2001.03.21 by MIK
 	}else{
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_AUTOBACKUP_INTERVAL ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE ), FALSE );
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE2 ), FALSE );	//Sept. 6, 2000 JEPRO ����
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_AUTOSAVE2 ), FALSE );	//Sept. 6, 2000 JEPRO 同上
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_AUTOBACKUP_INTERVAL ), FALSE );	//@@@ 2001.03.21 by MIK
 	}
 
-	// �u�J�����Ƃ����t�@�C�����傫���ꍇ�Ɍx�����o���v
+	// 「開こうとしたファイルが大きい場合に警告を出す」
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_ALERT_IF_LARGEFILE ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_ALERT_FILESIZE ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_ALERT_FILESIZE ), TRUE );

--- a/sakura_core/prop/CPropComFileName.cpp
+++ b/sakura_core/prop/CPropComFileName.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAuƒtƒ@ƒCƒ‹–¼•\¦vƒy[ƒW
+ï»¿/*!	@file
+	å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤ºã€ãƒšãƒ¼ã‚¸
 
 	@author Moca
-	@date 2002.12.09 Moca CPropTypesRegex.cpp‚ğQl‚É‚µ‚Äì¬
+	@date 2002.12.09 Moca CPropTypesRegex.cppã‚’å‚è€ƒã«ã—ã¦ä½œæˆ
 */
 /*
 	Copyright (C) 2001, MIK
@@ -42,18 +42,18 @@
 static const DWORD p_helpids[] = {	//13400
 	IDC_CHECK_SHORTPATH,	HIDC_CHECK_FNAME_SHORTPATH,
 	IDC_EDIT_SHORTMAXWIDTH,	HIDC_EDIT_FNAME_SHORTMAXWIDTH,
-	IDC_LIST_FNAME,			HIDC_LIST_FNAME, 		// ƒtƒ@ƒCƒ‹–¼’uŠ·ƒŠƒXƒg
-	IDC_EDIT_FNAME_FROM,	HIDC_EDIT_FNAME_FROM,	// ’uŠ·‘O
-	IDC_EDIT_FNAME_TO,		HIDC_EDIT_FNAME_TO,		// ’uŠ·Œã
-	IDC_BUTTON_FNAME_INS,	HIDC_BUTTON_FNAME_INS,	// ‘}“ü
-	IDC_BUTTON_FNAME_ADD,	HIDC_BUTTON_FNAME_ADD,	// ’Ç‰Á
-	IDC_BUTTON_FNAME_UPD,	HIDC_BUTTON_FNAME_UPD,	// XV
-	IDC_BUTTON_FNAME_DEL,	HIDC_BUTTON_FNAME_DEL,	// íœ
-	IDC_BUTTON_FNAME_TOP,	HIDC_BUTTON_FNAME_TOP,	// æ“ª
-	IDC_BUTTON_FNAME_UP,	HIDC_BUTTON_FNAME_UP,	// ã‚Ö
-	IDC_BUTTON_FNAME_DOWN,	HIDC_BUTTON_FNAME_DOWN,	// ‰º‚Ö
-	IDC_BUTTON_FNAME_LAST,	HIDC_BUTTON_FNAME_LAST,	// ÅI
-//	IDC_CHECK_FNAME,		HIDC_CHECK_FNAME,	// ƒtƒ@ƒCƒ‹–¼‚ğŠÈˆÕ•\¦‚·‚é
+	IDC_LIST_FNAME,			HIDC_LIST_FNAME, 		// ãƒ•ã‚¡ã‚¤ãƒ«åç½®æ›ãƒªã‚¹ãƒˆ
+	IDC_EDIT_FNAME_FROM,	HIDC_EDIT_FNAME_FROM,	// ç½®æ›å‰
+	IDC_EDIT_FNAME_TO,		HIDC_EDIT_FNAME_TO,		// ç½®æ›å¾Œ
+	IDC_BUTTON_FNAME_INS,	HIDC_BUTTON_FNAME_INS,	// æŒ¿å…¥
+	IDC_BUTTON_FNAME_ADD,	HIDC_BUTTON_FNAME_ADD,	// è¿½åŠ 
+	IDC_BUTTON_FNAME_UPD,	HIDC_BUTTON_FNAME_UPD,	// æ›´æ–°
+	IDC_BUTTON_FNAME_DEL,	HIDC_BUTTON_FNAME_DEL,	// å‰Šé™¤
+	IDC_BUTTON_FNAME_TOP,	HIDC_BUTTON_FNAME_TOP,	// å…ˆé ­
+	IDC_BUTTON_FNAME_UP,	HIDC_BUTTON_FNAME_UP,	// ä¸Šã¸
+	IDC_BUTTON_FNAME_DOWN,	HIDC_BUTTON_FNAME_DOWN,	// ä¸‹ã¸
+	IDC_BUTTON_FNAME_LAST,	HIDC_BUTTON_FNAME_LAST,	// æœ€çµ‚
+//	IDC_CHECK_FNAME,		HIDC_CHECK_FNAME,	// ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ç°¡æ˜“è¡¨ç¤ºã™ã‚‹
 	0, 0 // 
 };
 
@@ -97,14 +97,14 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 			col.iSubItem = 1;
 			ListView_InsertColumn( hListView, 1, &col );
 
-			// Apr. 28, 2003 Moca ‰Šú‰»˜R‚êC³
-			// ƒ_ƒCƒAƒƒO‚ğŠJ‚¢‚½‚Æ‚«‚ÉƒŠƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚Ä‚àƒtƒB[ƒ‹ƒh‚ª‹ó‚Ìê‡‚ª‚ ‚Á‚½
+			// Apr. 28, 2003 Moca åˆæœŸåŒ–æ¼ã‚Œä¿®æ­£
+			// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’é–‹ã„ãŸã¨ãã«ãƒªã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã¦ã‚‚ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ãŒç©ºã®å ´åˆãŒã‚ã£ãŸ
 			m_nLastPos_FILENAME = -1;
 
-			// ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
+			// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
 			SetData( hwndDlg );
 
-			// ƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é
+			// ã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹
 			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_SHORTMAXWIDTH ), 4 );
 			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_FNAME_FROM ), _MAX_PATH - 1 );
 			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_FNAME_TO ),   _MAX_PATH - 1 );
@@ -122,7 +122,7 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 				case LVN_ITEMCHANGED:
 					hListView = GetDlgItem( hwndDlg, IDC_LIST_FNAME );
 					nIndex = ListView_GetNextItem( hListView, -1, LVNI_SELECTED );
-					// –¢‘I‘ğ
+					// æœªé¸æŠ
 					if( -1 == nIndex ){
 						::DlgItem_SetText( hwndDlg, IDC_EDIT_FNAME_FROM, _T("") );
 						::DlgItem_SetText( hwndDlg, IDC_EDIT_FNAME_TO, _T("") );
@@ -133,8 +133,8 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 						::DlgItem_SetText( hwndDlg, IDC_EDIT_FNAME_TO, szTo );
 					}
 					else{
-						// nIndex == m_nLastPos_FILENAME‚Ì‚Æ‚«
-						// ƒŠƒXƒg¨ƒGƒfƒBƒbƒgƒ{ƒbƒNƒX‚Éƒf[ƒ^‚ğƒRƒs[‚·‚é‚Æ[XV]‚ª‚¤‚Ü‚­‚¤‚Ü‚­“®ì‚µ‚È‚¢
+						// nIndex == m_nLastPos_FILENAMEã®ã¨ã
+						// ãƒªã‚¹ãƒˆâ†’ã‚¨ãƒ‡ã‚£ãƒƒãƒˆãƒœãƒƒã‚¯ã‚¹ã«ãƒ‡ãƒ¼ã‚¿ã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹ã¨[æ›´æ–°]ãŒã†ã¾ãã†ã¾ãå‹•ä½œã—ãªã„
 					}
 					m_nLastPos_FILENAME = nIndex;
 					break;
@@ -146,10 +146,10 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 					OnHelp( hwndDlg, IDD_PROP_FNAME );
 					return TRUE;
 				case PSN_KILLACTIVE:
-					// ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+					// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 					GetData( hwndDlg );
 					return TRUE;
-	//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+	//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 				case PSN_SETACTIVE:
 					m_nPageNum = ID_PROPCOM_PAGENUM_FILENAME;
 					return TRUE;
@@ -161,21 +161,21 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 
 	case WM_COMMAND:
 		{
-			WORD	wNotifyCode = HIWORD(wParam);	// ’Ê’mƒR[ƒh
-			WORD	wID = LOWORD(wParam);			// €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID
+			WORD	wNotifyCode = HIWORD(wParam);	// é€šçŸ¥ã‚³ãƒ¼ãƒ‰
+			WORD	wID = LOWORD(wParam);			// é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID
 			int		nCount;
 
 			switch( wNotifyCode ){
-			// ƒ{ƒ^ƒ“‚ªƒNƒŠƒbƒN‚³‚ê‚½
+			// ãƒœã‚¿ãƒ³ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ
 			case BN_CLICKED:
 				hListView = GetDlgItem( hwndDlg, IDC_LIST_FNAME );
 				nIndex = ListView_GetNextItem( hListView, -1, LVNI_SELECTED );
 				switch( wID ){
-				case IDC_BUTTON_FNAME_INS:	// ‘}“ü
-					// ‘I‘ğ’†‚ÌƒL[‚ğ’T‚·
+				case IDC_BUTTON_FNAME_INS:	// æŒ¿å…¥
+					// é¸æŠä¸­ã®ã‚­ãƒ¼ã‚’æ¢ã™
 					nCount = ListView_GetItemCount( hListView );
 					if( -1 == nIndex ){
-						// ‘I‘ğ’†‚Å‚È‚¯‚ê‚ÎÅŒã‚É’Ç‰Á
+						// é¸æŠä¸­ã§ãªã‘ã‚Œã°æœ€å¾Œã«è¿½åŠ 
 						nIndex = nCount;
 					}
 					::DlgItem_GetText( hwndDlg, IDC_EDIT_FNAME_FROM, szFrom, _MAX_PATH );
@@ -185,7 +185,7 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 						return TRUE;
 					}
 					break;
-				case IDC_BUTTON_FNAME_ADD:	// ’Ç‰Á
+				case IDC_BUTTON_FNAME_ADD:	// è¿½åŠ 
 					nCount = ListView_GetItemCount( hListView );
 
 					::DlgItem_GetText( hwndDlg, IDC_EDIT_FNAME_FROM, szFrom, _MAX_PATH );
@@ -196,7 +196,7 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 					}
 					break;
 
-				case IDC_BUTTON_FNAME_UPD:	// XV
+				case IDC_BUTTON_FNAME_UPD:	// æ›´æ–°
 					if( -1 != nIndex ){
 						::DlgItem_GetText( hwndDlg, IDC_EDIT_FNAME_FROM, szFrom, _MAX_PATH );
 						::DlgItem_GetText( hwndDlg, IDC_EDIT_FNAME_TO,   szTo,   _MAX_PATH );
@@ -204,7 +204,7 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 							return TRUE;
 						}
 					}else{
-						// –¢‘I‘ğ‚ÅƒŠƒXƒg‚É‚Ğ‚Æ‚Â‚à€–Ú‚ª‚È‚¢ê‡‚Í’Ç‰Á‚µ‚Ä‚¨‚­
+						// æœªé¸æŠã§ãƒªã‚¹ãƒˆã«ã²ã¨ã¤ã‚‚é …ç›®ãŒãªã„å ´åˆã¯è¿½åŠ ã—ã¦ãŠã
 						if( 0 == ListView_GetItemCount( hListView ) ){
 							if( -1 != SetListViewItem_FILENAME( hListView, 0, szFrom, szTo, true ) ){
 								return TRUE;
@@ -212,29 +212,29 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 						}
 					}
 					break;
-				case IDC_BUTTON_FNAME_DEL:	// íœ
+				case IDC_BUTTON_FNAME_DEL:	// å‰Šé™¤
 					if( -1 != nIndex ){
-						ListView_DeleteItem( hListView, nIndex );	//ŒÃ‚¢ƒL[‚ğíœ
+						ListView_DeleteItem( hListView, nIndex );	//å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤
 						ListView_SetItemState( hListView, nIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 						return TRUE;
 					}
 					break;
-				case IDC_BUTTON_FNAME_TOP:	// æ“ª
+				case IDC_BUTTON_FNAME_TOP:	// å…ˆé ­
 					if( -1 != MoveListViewItem_FILENAME( hListView, nIndex, 0 ) ){
 						return TRUE;
 					}
 					break;
-				case IDC_BUTTON_FNAME_UP: 	// ã‚Ö
+				case IDC_BUTTON_FNAME_UP: 	// ä¸Šã¸
 					if( -1 != MoveListViewItem_FILENAME( hListView, nIndex, nIndex - 1 ) ){
 						return TRUE;
 					}
 					break;
-				case IDC_BUTTON_FNAME_DOWN:	// ‰º‚Ö
+				case IDC_BUTTON_FNAME_DOWN:	// ä¸‹ã¸
 					if( -1 != MoveListViewItem_FILENAME( hListView, nIndex, nIndex + 1 ) ){
 						return TRUE;
 					}
 					break;
-				case IDC_BUTTON_FNAME_LAST:	// ÅI
+				case IDC_BUTTON_FNAME_LAST:	// æœ€çµ‚
 					nCount = ListView_GetItemCount( hListView );
 					if( -1 != MoveListViewItem_FILENAME( hListView, nIndex, nCount - 1 ) ){
 						return TRUE;
@@ -252,7 +252,7 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 //@@@ 2001.02.04 End
@@ -260,7 +260,7 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -271,9 +271,9 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 
 
 /*!
-	ƒ_ƒCƒAƒƒOã‚ÌƒRƒ“ƒgƒ[ƒ‹‚Éƒf[ƒ^‚ğİ’è‚·‚é
+	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ä¸Šã®ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«ãƒ‡ãƒ¼ã‚¿ã‚’è¨­å®šã™ã‚‹
 
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«
 */
 void CPropFileName::SetData( HWND hwndDlg )
 {
@@ -284,11 +284,11 @@ void CPropFileName::SetData( HWND hwndDlg )
 	::CheckDlgButtonBool( hwndDlg, IDC_CHECK_SHORTPATH, m_Common.m_sFileName.m_bTransformShortPath );
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_SHORTMAXWIDTH, m_Common.m_sFileName.m_nTransformShortMaxWidth, FALSE );
 
-	// ƒtƒ@ƒCƒ‹–¼’uŠ·ƒŠƒXƒg
+	// ãƒ•ã‚¡ã‚¤ãƒ«åç½®æ›ãƒªã‚¹ãƒˆ
 	HWND hListView = ::GetDlgItem( hwndDlg, IDC_LIST_FNAME );
-	ListView_DeleteAllItems( hListView ); // ƒŠƒXƒg‚ğ‹ó‚É‚·‚é
+	ListView_DeleteAllItems( hListView ); // ãƒªã‚¹ãƒˆã‚’ç©ºã«ã™ã‚‹
 
-	// ƒŠƒXƒg‚Éƒf[ƒ^‚ğƒZƒbƒg
+	// ãƒªã‚¹ãƒˆã«ãƒ‡ãƒ¼ã‚¿ã‚’ã‚»ãƒƒãƒˆ
 	for( i = 0, nIndex = 0; i < m_Common.m_sFileName.m_nTransformFileNameArrNum; i++ ){
 		if( '\0' == m_Common.m_sFileName.m_szTransformFileNameFrom[i][0] ) continue;
 
@@ -309,11 +309,11 @@ void CPropFileName::SetData( HWND hwndDlg )
 		nIndex++;
 	}
 
-	// ˆê”Ôã‚ğ‘I‘ğ‚µ‚Ä‚¨‚­
+	// ä¸€ç•ªä¸Šã‚’é¸æŠã—ã¦ãŠã
 	if( 0 != nIndex ){
 		ListView_SetItemState( hListView, 0, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 	}
-	//	ƒŠƒXƒgƒrƒ…[‚Ìs‘I‘ğ‚ğ‰Â”\‚É‚·‚éD
+	//	ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®è¡Œé¸æŠã‚’å¯èƒ½ã«ã™ã‚‹ï¼
 	DWORD dwStyle;
 	dwStyle = ListView_GetExtendedListViewStyle( hListView );
 	dwStyle |= LVS_EX_FULLROWSELECT;
@@ -323,9 +323,9 @@ void CPropFileName::SetData( HWND hwndDlg )
 }
 
 /*!
-	ƒ_ƒCƒAƒƒOã‚ÌƒRƒ“ƒgƒ[ƒ‹‚©‚çƒf[ƒ^‚ğæ“¾‚µ‚Äƒƒ‚ƒŠ‚ÉŠi”[‚·‚é
+	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ä¸Šã®ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‹ã‚‰ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾—ã—ã¦ãƒ¡ãƒ¢ãƒªã«æ ¼ç´ã™ã‚‹
 
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«
 */
 
 int CPropFileName::GetData( HWND hwndDlg )
@@ -337,7 +337,7 @@ int CPropFileName::GetData( HWND hwndDlg )
 	m_Common.m_sFileName.m_bTransformShortPath = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_SHORTPATH );
 	m_Common.m_sFileName.m_nTransformShortMaxWidth = ::GetDlgItemInt( hwndDlg, IDC_EDIT_SHORTMAXWIDTH, NULL, FALSE );
 
-	// ƒtƒ@ƒCƒ‹–¼’uŠ·ƒŠƒXƒg
+	// ãƒ•ã‚¡ã‚¤ãƒ«åç½®æ›ãƒªã‚¹ãƒˆ
 	HWND hListView = ::GetDlgItem( hwndDlg, IDC_LIST_FNAME );
 	m_Common.m_sFileName.m_nTransformFileNameArrNum = ListView_GetItemCount( hListView );
 
@@ -345,7 +345,7 @@ int CPropFileName::GetData( HWND hwndDlg )
 		if( nIndex < m_Common.m_sFileName.m_nTransformFileNameArrNum ){
 			ListView_GetItemText( hListView, nIndex, 0, m_Common.m_sFileName.m_szTransformFileNameFrom[nCount], _MAX_PATH );
 
-			// ’uŠ·‘O•¶š—ñ‚ªNULL‚¾‚Á‚½‚çÌ‚Ä‚é
+			// ç½®æ›å‰æ–‡å­—åˆ—ãŒNULLã ã£ãŸã‚‰æ¨ã¦ã‚‹
 			if( L'\0' == m_Common.m_sFileName.m_szTransformFileNameFrom[nCount][0] ){
 				m_Common.m_sFileName.m_szTransformFileNameTo[nIndex][0] = L'\0';
 			}else{
@@ -371,7 +371,7 @@ int CPropFileName::SetListViewItem_FILENAME( HWND hListView, int nIndex, LPTSTR 
 
 	nCount = ListView_GetItemCount( hListView );
 
-	// ‚±‚êˆÈã’Ç‰Á‚Å‚«‚È‚¢
+	// ã“ã‚Œä»¥ä¸Šè¿½åŠ ã§ããªã„
 	if( bInsMode && MAX_TRANSFORM_FILENAME <= nCount ){
 		ErrorMessage( GetParent( hListView ), LS(STR_PROPCOMFNM_ERR_REG) );
 		return -1;
@@ -432,7 +432,7 @@ int CPropFileName::MoveListViewItem_FILENAME( HWND hListView, int nIndex, int nI
 	}
 
 	GetListViewItem_FILENAME( hListView, nIndex, szFrom, szTo );
-	ListView_DeleteItem( hListView, nIndex );	//ŒÃ‚¢ƒL[‚ğíœ
+	ListView_DeleteItem( hListView, nIndex );	//å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤
 	SetListViewItem_FILENAME( hListView, nIndex2, szFrom, szTo, true );
 	return nIndex2;
 }

--- a/sakura_core/prop/CPropComFormat.cpp
+++ b/sakura_core/prop/CPropComFormat.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAu‘®vƒy[ƒW
+ï»¿/*!	@file
+	å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œæ›¸å¼ã€ãƒšãƒ¼ã‚¸
 
 	@author Norio Nakatani
 */
@@ -18,7 +18,7 @@
 #include "StdAfx.h"
 #include "prop/CPropCommon.h"
 #include "util/shell.h"
-#include "env/DLLSHAREDATA.h" // CFormatManager.h‚æ‚è‘O‚É•K—v
+#include "env/DLLSHAREDATA.h" // CFormatManager.hã‚ˆã‚Šå‰ã«å¿…è¦
 #include "env/CFormatManager.h"
 #include "sakura_rc.h"
 #include "sakura.hh"
@@ -26,16 +26,16 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//10400
-	IDC_EDIT_DFORM,						HIDC_EDIT_DFORM,		//“ú•t‘®
-	IDC_EDIT_TFORM,						HIDC_EDIT_TFORM,		//‘®
-	IDC_EDIT_DFORM_EX,					HIDC_EDIT_DFORM_EX,		//“ú•t‘®i•\¦—áj
-	IDC_EDIT_TFORM_EX,					HIDC_EDIT_TFORM_EX,		//‘®i•\¦—áj
-	IDC_EDIT_MIDASHIKIGOU,				HIDC_EDIT_MIDASHIKIGOU,	//Œ©o‚µ‹L†
-	IDC_EDIT_INYOUKIGOU,				HIDC_EDIT_INYOUKIGOU,	//ˆø—p•„
-	IDC_RADIO_DFORM_0,					HIDC_RADIO_DFORM_0,		//“ú•t‘®i•W€j
-	IDC_RADIO_DFORM_1,					HIDC_RADIO_DFORM_1,		//“ú•t‘®iƒJƒXƒ^ƒ€j
-	IDC_RADIO_TFORM_0,					HIDC_RADIO_TFORM_0,		//‘®i•W€j
-	IDC_RADIO_TFORM_1,					HIDC_RADIO_TFORM_1,		//‘®iƒJƒXƒ^ƒ€j
+	IDC_EDIT_DFORM,						HIDC_EDIT_DFORM,		//æ—¥ä»˜æ›¸å¼
+	IDC_EDIT_TFORM,						HIDC_EDIT_TFORM,		//æ™‚åˆ»æ›¸å¼
+	IDC_EDIT_DFORM_EX,					HIDC_EDIT_DFORM_EX,		//æ—¥ä»˜æ›¸å¼ï¼ˆè¡¨ç¤ºä¾‹ï¼‰
+	IDC_EDIT_TFORM_EX,					HIDC_EDIT_TFORM_EX,		//æ™‚åˆ»æ›¸å¼ï¼ˆè¡¨ç¤ºä¾‹ï¼‰
+	IDC_EDIT_MIDASHIKIGOU,				HIDC_EDIT_MIDASHIKIGOU,	//è¦‹å‡ºã—è¨˜å·
+	IDC_EDIT_INYOUKIGOU,				HIDC_EDIT_INYOUKIGOU,	//å¼•ç”¨ç¬¦
+	IDC_RADIO_DFORM_0,					HIDC_RADIO_DFORM_0,		//æ—¥ä»˜æ›¸å¼ï¼ˆæ¨™æº–ï¼‰
+	IDC_RADIO_DFORM_1,					HIDC_RADIO_DFORM_1,		//æ—¥ä»˜æ›¸å¼ï¼ˆã‚«ã‚¹ã‚¿ãƒ ï¼‰
+	IDC_RADIO_TFORM_0,					HIDC_RADIO_TFORM_0,		//æ™‚åˆ»æ›¸å¼ï¼ˆæ¨™æº–ï¼‰
+	IDC_RADIO_TFORM_1,					HIDC_RADIO_TFORM_1,		//æ™‚åˆ»æ›¸å¼ï¼ˆã‚«ã‚¹ã‚¿ãƒ ï¼‰
 //	IDC_STATIC,							-1,
 	0, 0
 };
@@ -43,11 +43,11 @@ static const DWORD p_helpids[] = {	//10400
 
 //@@@ 2002.01.12 add start
 static const char *p_date_form[] = {
-	"yyyy'”N'M'Œ'd'“ú'",
-	"yyyy'”N'M'Œ'd'“ú('dddd')'",
-	"yyyy'”N'MM'Œ'dd'“ú'",
-	"yyyy'”N'M'Œ'd'“ú' dddd",
-	"yyyy'”N'MM'Œ'dd'“ú' dddd",
+	"yyyy'å¹´'M'æœˆ'd'æ—¥'",
+	"yyyy'å¹´'M'æœˆ'd'æ—¥('dddd')'",
+	"yyyy'å¹´'MM'æœˆ'dd'æ—¥'",
+	"yyyy'å¹´'M'æœˆ'd'æ—¥' dddd",
+	"yyyy'å¹´'MM'æœˆ'dd'æ—¥' dddd",
 	"yyyy/MM/dd",
 	"yy/MM/dd",
 	"yy/M/d",
@@ -62,7 +62,7 @@ static const char *p_date_form[] = {
 
 static const char *p_time_form[] = {
 	"hh:mm:ss",
-	"tthh''mm'•ª'ss'•b'",
+	"tthh'æ™‚'mm'åˆ†'ss'ç§’'",
 	"H:mm:ss",
 	"HH:mm:ss",
 	"tt h:mm:ss",
@@ -73,10 +73,10 @@ static const char *p_time_form[] = {
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropFormat::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -87,10 +87,10 @@ INT_PTR CALLBACK CPropFormat::DlgProc_page(
 
 void CPropFormat::ChangeDateExample( HWND hwndDlg )
 {
-	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Format */
+	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Format */
 	GetData( hwndDlg );
 
-	/* “ú•t‚ğƒtƒH[ƒ}ƒbƒg */
+	/* æ—¥ä»˜ã‚’ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ */
 	TCHAR szText[1024];
 	SYSTEMTIME systime;
 	::GetLocalTime( &systime );
@@ -100,10 +100,10 @@ void CPropFormat::ChangeDateExample( HWND hwndDlg )
 }
 void CPropFormat::ChangeTimeExample( HWND hwndDlg )
 {
-	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Format */
+	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Format */
 	GetData( hwndDlg );
 
-	/* ‚ğƒtƒH[ƒ}ƒbƒg */
+	/* æ™‚åˆ»ã‚’ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ */
 	TCHAR szText[1024];
 	SYSTEMTIME systime;
 	::GetLocalTime( &systime );
@@ -113,7 +113,7 @@ void CPropFormat::ChangeTimeExample( HWND hwndDlg )
 }
 
 
-/* Format ƒƒbƒZ[ƒWˆ— */
+/* Format ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropFormat::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
 	UINT	uMsg,	// message
@@ -130,7 +130,7 @@ INT_PTR CPropFormat::DispatchEvent(
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Format */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Format */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
@@ -138,24 +138,24 @@ INT_PTR CPropFormat::DispatchEvent(
 		ChangeDateExample( hwndDlg );
 		ChangeTimeExample( hwndDlg );
 
-		/* Œ©o‚µ‹L† */
+		/* è¦‹å‡ºã—è¨˜å· */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_MIDASHIKIGOU ), _countof(m_Common.m_sFormat.m_szMidashiKigou) - 1 );
 
-		/* ˆø—p•„ */
+		/* å¼•ç”¨ç¬¦ */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_INYOUKIGOU ), _countof(m_Common.m_sFormat.m_szInyouKigou) - 1 );
 
-		/* “ú•t‘® */
+		/* æ—¥ä»˜æ›¸å¼ */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_DFORM ), _countof(m_Common.m_sFormat.m_szDateFormat) - 1 );
 
-		/* ‘® */
+		/* æ™‚åˆ»æ›¸å¼ */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_TFORM ), _countof(m_Common.m_sFormat.m_szTimeFormat) - 1 );
 
 
 
 		return TRUE;
 	case WM_COMMAND:
-		wNotifyCode	= HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID			= LOWORD(wParam);	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+		wNotifyCode	= HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID			= LOWORD(wParam);	/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 		switch( wNotifyCode ){
 		case EN_CHANGE:
 			if( IDC_EDIT_DFORM == wID ){
@@ -168,15 +168,15 @@ INT_PTR CPropFormat::DispatchEvent(
 			}
 			break;
 
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 			switch( wID ){
 			case IDC_RADIO_DFORM_0:
 			case IDC_RADIO_DFORM_1:
 				ChangeDateExample( hwndDlg );
 			//	From Here Sept. 10, 2000 JEPRO
-			//	“ú•t‘® 0=•W€ 1=ƒJƒXƒ^ƒ€
-			//	“ú•t‘®‚ğƒJƒXƒ^ƒ€‚É‚·‚é‚Æ‚«‚¾‚¯‘®w’è•¶š“ü—Í‚ğEnable‚Éİ’è
+			//	æ—¥ä»˜æ›¸å¼ 0=æ¨™æº– 1=ã‚«ã‚¹ã‚¿ãƒ 
+			//	æ—¥ä»˜æ›¸å¼ã‚’ã‚«ã‚¹ã‚¿ãƒ ã«ã™ã‚‹ã¨ãã ã‘æ›¸å¼æŒ‡å®šæ–‡å­—å…¥åŠ›ã‚’Enableã«è¨­å®š
 				EnableFormatPropInput( hwndDlg );
 			//	To Here Sept. 10, 2000
 				return 0;
@@ -184,8 +184,8 @@ INT_PTR CPropFormat::DispatchEvent(
 			case IDC_RADIO_TFORM_1:
 				ChangeTimeExample( hwndDlg );
 			//	From Here Sept. 10, 2000 JEPRO
-			//	‘® 0=•W€ 1=ƒJƒXƒ^ƒ€
-			//	‘®‚ğƒJƒXƒ^ƒ€‚É‚·‚é‚Æ‚«‚¾‚¯‘®w’è•¶š“ü—Í‚ğEnable‚Éİ’è
+			//	æ™‚åˆ»æ›¸å¼ 0=æ¨™æº– 1=ã‚«ã‚¹ã‚¿ãƒ 
+			//	æ™‚åˆ»æ›¸å¼ã‚’ã‚«ã‚¹ã‚¿ãƒ ã«ã™ã‚‹ã¨ãã ã‘æ›¸å¼æŒ‡å®šæ–‡å­—å…¥åŠ›ã‚’Enableã«è¨­å®š
 				EnableFormatPropInput( hwndDlg );
 			//	To Here Sept. 10, 2000
 				return 0;
@@ -211,10 +211,10 @@ INT_PTR CPropFormat::DispatchEvent(
 				return TRUE;
 			case PSN_KILLACTIVE:
 //				MYTRACE( _T("Format PSN_KILLACTIVE\n") );
-				/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Format */
+				/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Format */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_FORMAT;
 				return TRUE;
@@ -233,7 +233,7 @@ INT_PTR CPropFormat::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -243,7 +243,7 @@ INT_PTR CPropFormat::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -255,38 +255,38 @@ INT_PTR CPropFormat::DispatchEvent(
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Format */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Format */
 void CPropFormat::SetData( HWND hwndDlg )
 {
 
-	/* Œ©o‚µ‹L† */
+	/* è¦‹å‡ºã—è¨˜å· */
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_MIDASHIKIGOU, m_Common.m_sFormat.m_szMidashiKigou );
 
-	/* ˆø—p•„ */
+	/* å¼•ç”¨ç¬¦ */
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_INYOUKIGOU, m_Common.m_sFormat.m_szInyouKigou );
 
 
-	//“ú•t‘®‚Ìƒ^ƒCƒv
+	//æ—¥ä»˜æ›¸å¼ã®ã‚¿ã‚¤ãƒ—
 	if( 0 == m_Common.m_sFormat.m_nDateFormatType ){
 		::CheckDlgButton( hwndDlg, IDC_RADIO_DFORM_0, BST_CHECKED );
 	}else{
 		::CheckDlgButton( hwndDlg, IDC_RADIO_DFORM_1, BST_CHECKED );
 	}
-	//“ú•t‘®
+	//æ—¥ä»˜æ›¸å¼
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_DFORM, m_Common.m_sFormat.m_szDateFormat );
 
-	//‘®‚Ìƒ^ƒCƒv
+	//æ™‚åˆ»æ›¸å¼ã®ã‚¿ã‚¤ãƒ—
 	if( 0 == m_Common.m_sFormat.m_nTimeFormatType ){
 		::CheckDlgButton( hwndDlg, IDC_RADIO_TFORM_0, BST_CHECKED );
 	}else{
 		::CheckDlgButton( hwndDlg, IDC_RADIO_TFORM_1, BST_CHECKED );
 	}
-	//‘®
+	//æ™‚åˆ»æ›¸å¼
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_TFORM, m_Common.m_sFormat.m_szTimeFormat );
 
 	//	From Here Sept. 10, 2000 JEPRO
-	//	“ú•t/‘® 0=•W€ 1=ƒJƒXƒ^ƒ€
-	//	“ú•t/‘®‚ğƒJƒXƒ^ƒ€‚É‚·‚é‚Æ‚«‚¾‚¯‘®w’è•¶š“ü—Í‚ğEnable‚Éİ’è
+	//	æ—¥ä»˜/æ™‚åˆ»æ›¸å¼ 0=æ¨™æº– 1=ã‚«ã‚¹ã‚¿ãƒ 
+	//	æ—¥ä»˜/æ™‚åˆ»æ›¸å¼ã‚’ã‚«ã‚¹ã‚¿ãƒ ã«ã™ã‚‹ã¨ãã ã‘æ›¸å¼æŒ‡å®šæ–‡å­—å…¥åŠ›ã‚’Enableã«è¨­å®š
 	EnableFormatPropInput( hwndDlg );
 	//	To Here Sept. 10, 2000
 
@@ -296,39 +296,39 @@ void CPropFormat::SetData( HWND hwndDlg )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Format */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Format */
 int CPropFormat::GetData( HWND hwndDlg )
 {
-	/* Œ©o‚µ‹L† */
+	/* è¦‹å‡ºã—è¨˜å· */
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_MIDASHIKIGOU, m_Common.m_sFormat.m_szMidashiKigou, _countof(m_Common.m_sFormat.m_szMidashiKigou) );
 
-//	/* ŠO•”ƒwƒ‹ƒv‚P */
+//	/* å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘ */
 //	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHELP1, m_Common.m_sFormat.m_szExtHelp1, MAX_PATH - 1 );
 //
-//	/* ŠO•”HTMLƒwƒ‹ƒv */
+//	/* å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ— */
 //	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHTMLHELP, m_Common.m_sFormat.m_szExtHtmlHelp, MAX_PATH - 1 );
 
-	/* ˆø—p•„ */
+	/* å¼•ç”¨ç¬¦ */
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_INYOUKIGOU, m_Common.m_sFormat.m_szInyouKigou, _countof(m_Common.m_sFormat.m_szInyouKigou) );
 
 
-	//“ú•t‘®‚Ìƒ^ƒCƒv
+	//æ—¥ä»˜æ›¸å¼ã®ã‚¿ã‚¤ãƒ—
 	if( BST_CHECKED == ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_DFORM_0 ) ){
 		m_Common.m_sFormat.m_nDateFormatType = 0;
 	}else{
 		m_Common.m_sFormat.m_nDateFormatType = 1;
 	}
-	//“ú•t‘®
+	//æ—¥ä»˜æ›¸å¼
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_DFORM, m_Common.m_sFormat.m_szDateFormat, _countof( m_Common.m_sFormat.m_szDateFormat ));
 
-	//‘®‚Ìƒ^ƒCƒv
+	//æ™‚åˆ»æ›¸å¼ã®ã‚¿ã‚¤ãƒ—
 	if( BST_CHECKED == ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_TFORM_0 ) ){
 		m_Common.m_sFormat.m_nTimeFormatType = 0;
 	}else{
 		m_Common.m_sFormat.m_nTimeFormatType = 1;
 	}
 
-	//‘®
+	//æ™‚åˆ»æ›¸å¼
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_TFORM, m_Common.m_sFormat.m_szTimeFormat, _countof( m_Common.m_sFormat.m_szTimeFormat ));
 
 	return TRUE;
@@ -339,11 +339,11 @@ int CPropFormat::GetData( HWND hwndDlg )
 
 
 //	From Here Sept. 10, 2000 JEPRO
-//	ƒ`ƒFƒbƒNó‘Ô‚É‰‚¶‚Äƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX—v‘f‚ÌEnable/Disable‚ğ
-//	“KØ‚Éİ’è‚·‚é
+//	ãƒã‚§ãƒƒã‚¯çŠ¶æ…‹ã«å¿œã˜ã¦ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹è¦ç´ ã®Enable/Disableã‚’
+//	é©åˆ‡ã«è¨­å®šã™ã‚‹
 void CPropFormat::EnableFormatPropInput( HWND hwndDlg )
 {
-	//	“ú•t‘®‚ğƒJƒXƒ^ƒ€‚É‚·‚é‚©‚Ç‚¤‚©
+	//	æ—¥ä»˜æ›¸å¼ã‚’ã‚«ã‚¹ã‚¿ãƒ ã«ã™ã‚‹ã‹ã©ã†ã‹
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_DFORM_1 ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_DFORM ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_DFORM ), TRUE );
@@ -352,7 +352,7 @@ void CPropFormat::EnableFormatPropInput( HWND hwndDlg )
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_DFORM ), FALSE );
 	}
 
-	//	‘®‚ğƒJƒXƒ^ƒ€‚É‚·‚é‚©‚Ç‚¤‚©
+	//	æ™‚åˆ»æ›¸å¼ã‚’ã‚«ã‚¹ã‚¿ãƒ ã«ã™ã‚‹ã‹ã©ã†ã‹
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_TFORM_1 ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_TFORM ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_TFORM ), TRUE );

--- a/sakura_core/prop/CPropComGeneral.cpp
+++ b/sakura_core/prop/CPropComGeneral.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAu‘S”Êvƒy[ƒW
+ï»¿/*!	@file
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œå…¨èˆ¬ã€ãƒšãƒ¼ã‚¸
 
 	@author Uchi
-	@date 2010/5/9 CPropCommon.c‚æ‚è•ª—£
+	@date 2010/5/9 CPropCommon.cã‚ˆã‚Šåˆ†é›¢
 */
 /*
 	Copyright (C) 2010, Uchi
@@ -22,50 +22,50 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 TYPE_NAME_ID<int> SpecialScrollModeArr[] = {
-	{ 0,						STR_SCROLL_WITH_NO_KEY },		//_T("‘g‚İ‡‚í‚¹‚È‚µ") },
-	{ MOUSEFUNCTION_CENTER,		STR_SCROLL_WITH_MID_BTN },		//_T("ƒ}ƒEƒX’†ƒ{ƒ^ƒ“") },
-	{ MOUSEFUNCTION_LEFTSIDE,	STR_SCROLL_WITH_SIDE_1_BTN },	//_T("ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“1") },
-	{ MOUSEFUNCTION_RIGHTSIDE,	STR_SCROLL_WITH_SIDE_2_BTN },	//_T("ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“2") },
-	{ VK_CONTROL,				STR_SCROLL_WITH_CTRL_KEY },	//_T("CONTROLƒL[") },
-	{ VK_SHIFT,					STR_SCROLL_WITH_SHIFT_KEY },	//_T("SHIFTƒL[") },
+	{ 0,						STR_SCROLL_WITH_NO_KEY },		//_T("çµ„ã¿åˆã‚ã›ãªã—") },
+	{ MOUSEFUNCTION_CENTER,		STR_SCROLL_WITH_MID_BTN },		//_T("ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³") },
+	{ MOUSEFUNCTION_LEFTSIDE,	STR_SCROLL_WITH_SIDE_1_BTN },	//_T("ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³1") },
+	{ MOUSEFUNCTION_RIGHTSIDE,	STR_SCROLL_WITH_SIDE_2_BTN },	//_T("ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³2") },
+	{ VK_CONTROL,				STR_SCROLL_WITH_CTRL_KEY },	//_T("CONTROLã‚­ãƒ¼") },
+	{ VK_SHIFT,					STR_SCROLL_WITH_SHIFT_KEY },	//_T("SHIFTã‚­ãƒ¼") },
 };
 
 static const DWORD p_helpids[] = {	//10900
-	IDC_BUTTON_CLEAR_MRU_FILE,		HIDC_BUTTON_CLEAR_MRU_FILE,			//—š—ğ‚ğƒNƒŠƒAiƒtƒ@ƒCƒ‹j
-	IDC_BUTTON_CLEAR_MRU_FOLDER,	HIDC_BUTTON_CLEAR_MRU_FOLDER,		//—š—ğ‚ğƒNƒŠƒAiƒtƒHƒ‹ƒ_j
-	IDC_CHECK_FREECARET,			HIDC_CHECK_FREECARET,				//ƒtƒŠ[ƒJ[ƒ\ƒ‹
-//DEL	IDC_CHECK_INDENT,				HIDC_CHECK_INDENT,					//©“®ƒCƒ“ƒfƒ“ƒg Fƒ^ƒCƒv•Ê‚ÖˆÚ“®
-//DEL	IDC_CHECK_INDENT_WSPACE,		HIDC_CHECK_INDENT_WSPACE,			//‘SŠp‹ó”’‚àƒCƒ“ƒfƒ“ƒg Fƒ^ƒCƒv•Ê‚ÖˆÚ“®
-	IDC_CHECK_USETRAYICON,			HIDC_CHECK_USETRAYICON,				//ƒ^ƒXƒNƒgƒŒƒC‚ğg‚¤
-	IDC_CHECK_STAYTASKTRAY,			HIDC_CHECK_STAYTASKTRAY,			//ƒ^ƒXƒNƒgƒŒƒC‚Éí’“
-	IDC_CHECK_REPEATEDSCROLLSMOOTH,	HIDC_CHECK_REPEATEDSCROLLSMOOTH,	//­‚µŠŠ‚ç‚©‚É‚·‚é
-	IDC_CHECK_CLOSEALLCONFIRM,		HIDC_CHECK_CLOSEALLCONFIRM,			//[‚·‚×‚Ä•Â‚¶‚é]‚Å‘¼‚É•ÒW—p‚ÌƒEƒBƒ“ƒhƒE‚ª‚ ‚ê‚ÎŠm”F‚·‚é	// 2006.12.25 ryoji
-	IDC_CHECK_EXITCONFIRM,			HIDC_CHECK_EXITCONFIRM,				//I—¹‚ÌŠm”F
-	IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_WORD, HIDC_CHECK_STOPS_WORD, //’PŒê’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚É’PŒê‚Ì—¼’[‚É~‚Ü‚é
-	IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_PARAGRAPH, HIDC_CHECK_STOPS_PARAGRAPH, // ’i—’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚É’i—‚Ì—¼’[‚É~‚Ü‚é
-	IDC_CHECK_NOMOVE_ACTIVATE_BY_MOUSE, HIDC_CHECK_NOMOVE_ACTIVATE_BY_MOUSE,	// ƒ}ƒEƒXƒNƒŠƒbƒN‚ÅƒAƒNƒeƒBƒu‚É‚È‚Á‚½‚Æ‚«‚ÍƒJ[ƒ\ƒ‹‚ğƒNƒŠƒbƒNˆÊ’u‚ÉˆÚ“®‚µ‚È‚¢ 2007.10.08 genta
-	IDC_HOTKEY_TRAYMENU,			HIDC_HOTKEY_TRAYMENU,				//¶ƒNƒŠƒbƒNƒƒjƒ…[‚ÌƒVƒ‡[ƒgƒJƒbƒgƒL[
-	IDC_EDIT_REPEATEDSCROLLLINENUM,	HIDC_EDIT_REPEATEDSCROLLLINENUM,	//ƒXƒNƒ[ƒ‹s”
-	IDC_EDIT_MAX_MRU_FILE,			HIDC_EDIT_MAX_MRU_FILE,				//ƒtƒ@ƒCƒ‹—š—ğ‚ÌÅ‘å”
-	IDC_EDIT_MAX_MRU_FOLDER,		HIDC_EDIT_MAX_MRU_FOLDER,			//ƒtƒHƒ‹ƒ_—š—ğ‚ÌÅ‘å”
-	IDC_RADIO_CARETTYPE0,			HIDC_RADIO_CARETTYPE0,				//ƒJ[ƒ\ƒ‹Œ`óiWindows•—j
-	IDC_RADIO_CARETTYPE1,			HIDC_RADIO_CARETTYPE1,				//ƒJ[ƒ\ƒ‹Œ`óiMS-DOS•—j
+	IDC_BUTTON_CLEAR_MRU_FILE,		HIDC_BUTTON_CLEAR_MRU_FILE,			//å±¥æ­´ã‚’ã‚¯ãƒªã‚¢ï¼ˆãƒ•ã‚¡ã‚¤ãƒ«ï¼‰
+	IDC_BUTTON_CLEAR_MRU_FOLDER,	HIDC_BUTTON_CLEAR_MRU_FOLDER,		//å±¥æ­´ã‚’ã‚¯ãƒªã‚¢ï¼ˆãƒ•ã‚©ãƒ«ãƒ€ï¼‰
+	IDC_CHECK_FREECARET,			HIDC_CHECK_FREECARET,				//ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«
+//DEL	IDC_CHECK_INDENT,				HIDC_CHECK_INDENT,					//è‡ªå‹•ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ ï¼šã‚¿ã‚¤ãƒ—åˆ¥ã¸ç§»å‹•
+//DEL	IDC_CHECK_INDENT_WSPACE,		HIDC_CHECK_INDENT_WSPACE,			//å…¨è§’ç©ºç™½ã‚‚ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ ï¼šã‚¿ã‚¤ãƒ—åˆ¥ã¸ç§»å‹•
+	IDC_CHECK_USETRAYICON,			HIDC_CHECK_USETRAYICON,				//ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã‚’ä½¿ã†
+	IDC_CHECK_STAYTASKTRAY,			HIDC_CHECK_STAYTASKTRAY,			//ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã«å¸¸é§
+	IDC_CHECK_REPEATEDSCROLLSMOOTH,	HIDC_CHECK_REPEATEDSCROLLSMOOTH,	//å°‘ã—æ»‘ã‚‰ã‹ã«ã™ã‚‹
+	IDC_CHECK_CLOSEALLCONFIRM,		HIDC_CHECK_CLOSEALLCONFIRM,			//[ã™ã¹ã¦é–‰ã˜ã‚‹]ã§ä»–ã«ç·¨é›†ç”¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒã‚ã‚Œã°ç¢ºèªã™ã‚‹	// 2006.12.25 ryoji
+	IDC_CHECK_EXITCONFIRM,			HIDC_CHECK_EXITCONFIRM,				//çµ‚äº†ã®ç¢ºèª
+	IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_WORD, HIDC_CHECK_STOPS_WORD, //å˜èªå˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«å˜èªã®ä¸¡ç«¯ã«æ­¢ã¾ã‚‹
+	IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_PARAGRAPH, HIDC_CHECK_STOPS_PARAGRAPH, // æ®µè½å˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«æ®µè½ã®ä¸¡ç«¯ã«æ­¢ã¾ã‚‹
+	IDC_CHECK_NOMOVE_ACTIVATE_BY_MOUSE, HIDC_CHECK_NOMOVE_ACTIVATE_BY_MOUSE,	// ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯ã§ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ãªã£ãŸã¨ãã¯ã‚«ãƒ¼ã‚½ãƒ«ã‚’ã‚¯ãƒªãƒƒã‚¯ä½ç½®ã«ç§»å‹•ã—ãªã„ 2007.10.08 genta
+	IDC_HOTKEY_TRAYMENU,			HIDC_HOTKEY_TRAYMENU,				//å·¦ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®ã‚·ãƒ§ãƒ¼ãƒˆã‚«ãƒƒãƒˆã‚­ãƒ¼
+	IDC_EDIT_REPEATEDSCROLLLINENUM,	HIDC_EDIT_REPEATEDSCROLLLINENUM,	//ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•°
+	IDC_EDIT_MAX_MRU_FILE,			HIDC_EDIT_MAX_MRU_FILE,				//ãƒ•ã‚¡ã‚¤ãƒ«å±¥æ­´ã®æœ€å¤§æ•°
+	IDC_EDIT_MAX_MRU_FOLDER,		HIDC_EDIT_MAX_MRU_FOLDER,			//ãƒ•ã‚©ãƒ«ãƒ€å±¥æ­´ã®æœ€å¤§æ•°
+	IDC_RADIO_CARETTYPE0,			HIDC_RADIO_CARETTYPE0,				//ã‚«ãƒ¼ã‚½ãƒ«å½¢çŠ¶ï¼ˆWindowsé¢¨ï¼‰
+	IDC_RADIO_CARETTYPE1,			HIDC_RADIO_CARETTYPE1,				//ã‚«ãƒ¼ã‚½ãƒ«å½¢çŠ¶ï¼ˆMS-DOSé¢¨ï¼‰
 	IDC_SPIN_REPEATEDSCROLLLINENUM,	HIDC_EDIT_REPEATEDSCROLLLINENUM,
 	IDC_SPIN_MAX_MRU_FILE,			HIDC_EDIT_MAX_MRU_FILE,
 	IDC_SPIN_MAX_MRU_FOLDER,		HIDC_EDIT_MAX_MRU_FOLDER,
-	IDC_CHECK_MEMDC,				HIDC_CHECK_MEMDC,					//‰æ–ÊƒLƒƒƒbƒVƒ…‚ğg‚¤
-	IDC_COMBO_WHEEL_PAGESCROLL,		HIDC_COMBO_WHEEL_PAGESCROLL,		// ‘g‚İ‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½ƒy[ƒWƒXƒNƒ[ƒ‹‚·‚é		// 2009.01.17 nasukoji
-	IDC_COMBO_WHEEL_HSCROLL,		HIDC_COMBO_WHEEL_HSCROLL,			// ‘g‚İ‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½‰¡ƒXƒNƒ[ƒ‹‚·‚é			// 2009.01.17 nasukoji
+	IDC_CHECK_MEMDC,				HIDC_CHECK_MEMDC,					//ç”»é¢ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’ä½¿ã†
+	IDC_COMBO_WHEEL_PAGESCROLL,		HIDC_COMBO_WHEEL_PAGESCROLL,		// çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹		// 2009.01.17 nasukoji
+	IDC_COMBO_WHEEL_HSCROLL,		HIDC_COMBO_WHEEL_HSCROLL,			// çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹			// 2009.01.17 nasukoji
 //	IDC_STATIC,						-1,
 	0, 0
 };
 //@@@ 2001.02.04 End
 
 /*!
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropGeneral::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -74,7 +74,7 @@ INT_PTR CALLBACK CPropGeneral::DlgProc_page(
 }
 
 
-/* General ƒƒbƒZ[ƒWˆ— */
+/* General ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropGeneral::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
 	UINT	uMsg,		// message
@@ -94,27 +94,27 @@ INT_PTR CPropGeneral::DispatchEvent(
 	switch( uMsg ){
 
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è General */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š General */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒ†[ƒU[‚ªƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+		/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 
 		return TRUE;
 	case WM_COMMAND:
-		wNotifyCode	= HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID			= LOWORD(wParam);	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
-//		hwndCtl		= (HWND) lParam;	/* ƒRƒ“ƒgƒ[ƒ‹‚Ìƒnƒ“ƒhƒ‹ */
+		wNotifyCode	= HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID			= LOWORD(wParam);	/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
+//		hwndCtl		= (HWND) lParam;	/* ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®ãƒãƒ³ãƒ‰ãƒ« */
 		switch( wNotifyCode ){
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 			switch( wID ){
 
-			case IDC_CHECK_USETRAYICON:	/* ƒ^ƒXƒNƒgƒŒƒC‚ğg‚¤ */
+			case IDC_CHECK_USETRAYICON:	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã‚’ä½¿ã† */
 			// From Here 2001.12.03 hor
-			//		‘€ì‚µ‚É‚­‚¢‚Á‚Ä•]”»‚¾‚Á‚½‚Ì‚Åƒ^ƒXƒNƒgƒŒƒCŠÖŒW‚ÌEnable§Œä‚ğ‚â‚ß‚Ü‚µ‚½
-			//@@@ YAZAKI 2001.12.31 IDC_CHECKSTAYTASKTRAY‚ÌƒAƒNƒeƒBƒuA”ñƒAƒNƒeƒBƒu‚Ì‚İ§ŒäB
+			//		æ“ä½œã—ã«ãã„ã£ã¦è©•åˆ¤ã ã£ãŸã®ã§ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤é–¢ä¿‚ã®Enableåˆ¶å¾¡ã‚’ã‚„ã‚ã¾ã—ãŸ
+			//@@@ YAZAKI 2001.12.31 IDC_CHECKSTAYTASKTRAYã®ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã€éã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã®ã¿åˆ¶å¾¡ã€‚
 				if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_USETRAYICON ) ){
 					::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_STAYTASKTRAY ), TRUE );
 				}else{
@@ -123,16 +123,16 @@ INT_PTR CPropGeneral::DispatchEvent(
 			// To Here 2001.12.03 hor
 				return TRUE;
 
-			case IDC_CHECK_STAYTASKTRAY:	/* ƒ^ƒXƒNƒgƒŒƒC‚Éí’“ */
+			case IDC_CHECK_STAYTASKTRAY:	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã«å¸¸é§ */
 				return TRUE;
 
 			case IDC_BUTTON_CLEAR_MRU_FILE:
-				/* ƒtƒ@ƒCƒ‹‚Ì—š—ğ‚ğƒNƒŠƒA */
+				/* ãƒ•ã‚¡ã‚¤ãƒ«ã®å±¥æ­´ã‚’ã‚¯ãƒªã‚¢ */
 				if( IDCANCEL == ::MYMESSAGEBOX( hwndDlg, MB_OKCANCEL | MB_ICONQUESTION, GSTR_APPNAME,
 					LS(STR_PROPCOMGEN_FILE1) ) ){
 					return TRUE;
 				}
-//@@@ 2001.12.26 YAZAKI MRUƒŠƒXƒg‚ÍACMRU‚ÉˆË—Š‚·‚é
+//@@@ 2001.12.26 YAZAKI MRUãƒªã‚¹ãƒˆã¯ã€CMRUã«ä¾é ¼ã™ã‚‹
 //				m_pShareData->m_sHistory.m_nMRUArrNum = 0;
 				{
 					CMRUFile cMRU;
@@ -141,15 +141,15 @@ INT_PTR CPropGeneral::DispatchEvent(
 				InfoMessage( hwndDlg, LS(STR_PROPCOMGEN_FILE2) );
 				return TRUE;
 			case IDC_BUTTON_CLEAR_MRU_FOLDER:
-				/* ƒtƒHƒ‹ƒ_‚Ì—š—ğ‚ğƒNƒŠƒA */
+				/* ãƒ•ã‚©ãƒ«ãƒ€ã®å±¥æ­´ã‚’ã‚¯ãƒªã‚¢ */
 				if( IDCANCEL == ::MYMESSAGEBOX( hwndDlg, MB_OKCANCEL | MB_ICONQUESTION, GSTR_APPNAME,
 					LS(STR_PROPCOMGEN_DIR1) ) ){
 					return TRUE;
 				}
-//@@@ 2001.12.26 YAZAKI OPENFOLDERƒŠƒXƒg‚ÍACMRUFolder‚É‚·‚×‚ÄˆË—Š‚·‚é
+//@@@ 2001.12.26 YAZAKI OPENFOLDERãƒªã‚¹ãƒˆã¯ã€CMRUFolderã«ã™ã¹ã¦ä¾é ¼ã™ã‚‹
 //				m_pShareData->m_sHistory.m_nOPENFOLDERArrNum = 0;
 				{
-					CMRUFolder cMRUFolder;	//	MRUƒŠƒXƒg‚Ì‰Šú‰»Bƒ‰ƒxƒ‹“à‚¾‚Æ–â‘è‚ ‚èH
+					CMRUFolder cMRUFolder;	//	MRUãƒªã‚¹ãƒˆã®åˆæœŸåŒ–ã€‚ãƒ©ãƒ™ãƒ«å†…ã ã¨å•é¡Œã‚ã‚Šï¼Ÿ
 					cMRUFolder.ClearAll();
 				}
 				InfoMessage( hwndDlg, LS(STR_PROPCOMGEN_DIR2) );
@@ -157,13 +157,13 @@ INT_PTR CPropGeneral::DispatchEvent(
 
 			}
 			break;	/* BN_CLICKED */
-		// 2009.01.12 nasukoji	ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ÌƒŠƒXƒg‚Ì€–Ú‚ª‘I‘ğ‚³‚ê‚½
+		// 2009.01.12 nasukoji	ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒªã‚¹ãƒˆã®é …ç›®ãŒé¸æŠã•ã‚ŒãŸ
 		case CBN_SELENDOK:
 			HWND	hwndCombo;
 			int		nSelPos;
 
 			switch( wID ){
-			// ‘g‚İ‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½ƒy[ƒWƒXƒNƒ[ƒ‹‚·‚é
+			// çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹
 			case IDC_COMBO_WHEEL_PAGESCROLL:
 				hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WHEEL_PAGESCROLL );
 				nSelPos = Combo_GetCurSel( hwndCombo );
@@ -172,7 +172,7 @@ INT_PTR CPropGeneral::DispatchEvent(
 					Combo_SetCurSel( hwndCombo, 0 );
 				}
 				return TRUE;
-			// ‘g‚İ‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½‰¡ƒXƒNƒ[ƒ‹‚·‚é
+			// çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹
 			case IDC_COMBO_WHEEL_HSCROLL:
 				hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WHEEL_HSCROLL );
 				nSelPos = Combo_GetCurSel( hwndCombo );
@@ -191,7 +191,7 @@ INT_PTR CPropGeneral::DispatchEvent(
 		pMNUD  = (NM_UPDOWN*)lParam;
 		switch( idCtrl ){
 		case IDC_SPIN_REPEATEDSCROLLLINENUM:
-			/* ƒL[ƒŠƒs[ƒg‚ÌƒXƒNƒ[ƒ‹s” */
+			/* ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•° */
 //			MYTRACE( _T("IDC_SPIN_REPEATEDSCROLLLINENUM\n") );
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_REPEATEDSCROLLLINENUM, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
@@ -209,7 +209,7 @@ INT_PTR CPropGeneral::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_REPEATEDSCROLLLINENUM, nVal, FALSE );
 			return TRUE;
 		case IDC_SPIN_MAX_MRU_FILE:
-			/* ƒtƒ@ƒCƒ‹‚Ì—š—ğMAX */
+			/* ãƒ•ã‚¡ã‚¤ãƒ«ã®å±¥æ­´MAX */
 //			MYTRACE( _T("IDC_SPIN_MAX_MRU_FILE\n") );
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_MAX_MRU_FILE, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
@@ -227,7 +227,7 @@ INT_PTR CPropGeneral::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_MAX_MRU_FILE, nVal, FALSE );
 			return TRUE;
 		case IDC_SPIN_MAX_MRU_FOLDER:
-			/* ƒtƒHƒ‹ƒ_‚Ì—š—ğMAX */
+			/* ãƒ•ã‚©ãƒ«ãƒ€ã®å±¥æ­´MAX */
 //			MYTRACE( _T("IDC_SPIN_MAX_MRU_FOLDER\n") );
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_MAX_MRU_FOLDER, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
@@ -251,12 +251,12 @@ INT_PTR CPropGeneral::DispatchEvent(
 				return TRUE;
 			case PSN_KILLACTIVE:
 //				MYTRACE( _T("General PSN_KILLACTIVE\n") );
-				/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ General */
+				/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— General */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 			case PSN_SETACTIVE:
-				m_nPageNum = ID_PROPCOM_PAGENUM_GENERAL;	//Oct. 25, 2000 JEPRO ZENPAN1¨ZENPAN ‚É•ÏX(QÆ‚µ‚Ä‚¢‚é‚Ì‚ÍCPropCommon.cpp‚Ì‚İ‚Ì1‰ÓŠ)
+				m_nPageNum = ID_PROPCOM_PAGENUM_GENERAL;	//Oct. 25, 2000 JEPRO ZENPAN1â†’ZENPAN ã«å¤‰æ›´(å‚ç…§ã—ã¦ã„ã‚‹ã®ã¯CPropCommon.cppã®ã¿ã®1ç®‡æ‰€)
 				return TRUE;
 			}
 			break;
@@ -273,7 +273,7 @@ INT_PTR CPropGeneral::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -283,7 +283,7 @@ INT_PTR CPropGeneral::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -295,11 +295,11 @@ INT_PTR CPropGeneral::DispatchEvent(
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è General */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š General */
 void CPropGeneral::SetData( HWND hwndDlg )
 {
 
-	/* ƒJ[ƒ\ƒ‹‚Ìƒ^ƒCƒv 0=win 1=dos  */
+	/* ã‚«ãƒ¼ã‚½ãƒ«ã®ã‚¿ã‚¤ãƒ— 0=win 1=dos  */
 	if( 0 == m_Common.m_sGeneral.GetCaretType() ){
 		::CheckDlgButton( hwndDlg, IDC_RADIO_CARETTYPE0, TRUE );
 		::CheckDlgButton( hwndDlg, IDC_RADIO_CARETTYPE1, FALSE );
@@ -309,31 +309,31 @@ void CPropGeneral::SetData( HWND hwndDlg )
 	}
 
 
-	/* ƒtƒŠ[ƒJ[ƒ\ƒ‹ƒ‚[ƒh */
+	/* ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ãƒ¢ãƒ¼ãƒ‰ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_FREECARET, m_Common.m_sGeneral.m_bIsFreeCursorMode ? 1 : 0 );
 
-	/* ’PŒê’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚ÉA’PŒê‚Ì—¼’[‚Å~‚Ü‚é‚© */
+	/* å˜èªå˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«ã€å˜èªã®ä¸¡ç«¯ã§æ­¢ã¾ã‚‹ã‹ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_WORD, m_Common.m_sGeneral.m_bStopsBothEndsWhenSearchWord );
 
-	/* ’i—’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚ÉA’i—‚Ì—¼’[‚Å~‚Ü‚é‚© */
+	/* æ®µè½å˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«ã€æ®µè½ã®ä¸¡ç«¯ã§æ­¢ã¾ã‚‹ã‹ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_PARAGRAPH, m_Common.m_sGeneral.m_bStopsBothEndsWhenSearchParagraph );
 
-	//	2007.10.08 genta ƒ}ƒEƒXƒNƒŠƒbƒN‚ÅƒAƒNƒeƒBƒu‚É‚È‚Á‚½‚Æ‚«‚ÍƒJ[ƒ\ƒ‹‚ğƒNƒŠƒbƒNˆÊ’u‚ÉˆÚ“®‚µ‚È‚¢ (2007.10.02 by nasukoji)
+	//	2007.10.08 genta ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯ã§ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ãªã£ãŸã¨ãã¯ã‚«ãƒ¼ã‚½ãƒ«ã‚’ã‚¯ãƒªãƒƒã‚¯ä½ç½®ã«ç§»å‹•ã—ãªã„ (2007.10.02 by nasukoji)
 	::CheckDlgButton( hwndDlg, IDC_CHECK_NOMOVE_ACTIVATE_BY_MOUSE, m_Common.m_sGeneral.m_bNoCaretMoveByActivation );
 
-	/* [‚·‚×‚Ä•Â‚¶‚é]‚Å‘¼‚É•ÒW—p‚ÌƒEƒBƒ“ƒhƒE‚ª‚ ‚ê‚ÎŠm”F‚·‚é */	// 2006.12.25 ryoji
+	/* [ã™ã¹ã¦é–‰ã˜ã‚‹]ã§ä»–ã«ç·¨é›†ç”¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒã‚ã‚Œã°ç¢ºèªã™ã‚‹ */	// 2006.12.25 ryoji
 	::CheckDlgButton( hwndDlg, IDC_CHECK_CLOSEALLCONFIRM, m_Common.m_sGeneral.m_bCloseAllConfirm );
 
-	/* I—¹‚ÌŠm”F‚ğ‚·‚é */
+	/* çµ‚äº†æ™‚ã®ç¢ºèªã‚’ã™ã‚‹ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_EXITCONFIRM, m_Common.m_sGeneral.m_bExitConfirm );
 
-	/* ƒL[ƒŠƒs[ƒg‚ÌƒXƒNƒ[ƒ‹s” */
+	/* ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•° */
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_REPEATEDSCROLLLINENUM, (Int)m_Common.m_sGeneral.m_nRepeatedScrollLineNum, FALSE );
 
-	/* ƒL[ƒŠƒs[ƒg‚ÌƒXƒNƒ[ƒ‹‚ğŠŠ‚ç‚©‚É‚·‚é‚© */
+	/* ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚’æ»‘ã‚‰ã‹ã«ã™ã‚‹ã‹ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_REPEATEDSCROLLSMOOTH, m_Common.m_sGeneral.m_nRepeatedScroll_Smooth );
 
-	// 2009.01.17 nasukoji	‘g‚İ‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½ƒy[ƒWƒXƒNƒ[ƒ‹‚·‚é
+	// 2009.01.17 nasukoji	çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹
 	HWND	hwndCombo;
 	int		nSelPos;
 	int		i;
@@ -343,48 +343,48 @@ void CPropGeneral::SetData( HWND hwndDlg )
 	nSelPos = 0;
 	for( i = 0; i < _countof( SpecialScrollModeArr ); ++i ){
 		Combo_InsertString( hwndCombo, i, LS( SpecialScrollModeArr[i].nNameId ) );
-		if( SpecialScrollModeArr[i].nMethod == m_Common.m_sGeneral.m_nPageScrollByWheel ){	// ƒy[ƒWƒXƒNƒ[ƒ‹‚Æ‚·‚é‘g‚İ‡‚í‚¹‘€ì
+		if( SpecialScrollModeArr[i].nMethod == m_Common.m_sGeneral.m_nPageScrollByWheel ){	// ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã¨ã™ã‚‹çµ„ã¿åˆã‚ã›æ“ä½œ
 			nSelPos = i;
 		}
 	}
 	Combo_SetCurSel( hwndCombo, nSelPos );
 
-	// 2009.01.12 nasukoji	‘g‚İ‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½‰¡ƒXƒNƒ[ƒ‹‚·‚é
+	// 2009.01.12 nasukoji	çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WHEEL_HSCROLL );
 	Combo_ResetContent( hwndCombo );
 	nSelPos = 0;
 	for( i = 0; i < _countof( SpecialScrollModeArr ); ++i ){
 		Combo_InsertString( hwndCombo, i, LS( SpecialScrollModeArr[i].nNameId ) );
-		if( SpecialScrollModeArr[i].nMethod == m_Common.m_sGeneral.m_nHorizontalScrollByWheel ){	// ‰¡ƒXƒNƒ[ƒ‹‚Æ‚·‚é‘g‚İ‡‚í‚¹‘€ì
+		if( SpecialScrollModeArr[i].nMethod == m_Common.m_sGeneral.m_nHorizontalScrollByWheel ){	// æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã¨ã™ã‚‹çµ„ã¿åˆã‚ã›æ“ä½œ
 			nSelPos = i;
 		}
 	}
 	Combo_SetCurSel( hwndCombo, nSelPos );
 
-	// 2007.09.09 Moca ‰æ–ÊƒLƒƒƒbƒVƒ…İ’è’Ç‰Á
-	// ‰æ–ÊƒLƒƒƒbƒVƒ…‚ğg‚¤
+	// 2007.09.09 Moca ç”»é¢ã‚­ãƒ£ãƒƒã‚·ãƒ¥è¨­å®šè¿½åŠ 
+	// ç”»é¢ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’ä½¿ã†
 	::CheckDlgButton( hwndDlg, IDC_CHECK_MEMDC, m_Common.m_sWindow.m_bUseCompatibleBMP );
 
-	/* ƒtƒ@ƒCƒ‹‚Ì—š—ğMAX */
+	/* ãƒ•ã‚¡ã‚¤ãƒ«ã®å±¥æ­´MAX */
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_MAX_MRU_FILE, m_Common.m_sGeneral.m_nMRUArrNum_MAX, FALSE );
 
-	/* ƒtƒHƒ‹ƒ_‚Ì—š—ğMAX */
+	/* ãƒ•ã‚©ãƒ«ãƒ€ã®å±¥æ­´MAX */
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_MAX_MRU_FOLDER, m_Common.m_sGeneral.m_nOPENFOLDERArrNum_MAX, FALSE );
 
-	/* ƒ^ƒXƒNƒgƒŒƒC‚ğg‚¤ */
+	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã‚’ä½¿ã† */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_USETRAYICON, m_Common.m_sGeneral.m_bUseTaskTray );
 // From Here 2001.12.03 hor
-//@@@ YAZAKI 2001.12.31 ‚±‚±‚Í§Œä‚·‚éB
+//@@@ YAZAKI 2001.12.31 ã“ã“ã¯åˆ¶å¾¡ã™ã‚‹ã€‚
 	if( m_Common.m_sGeneral.m_bUseTaskTray ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_STAYTASKTRAY ), TRUE );
 	}else{
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_STAYTASKTRAY ), FALSE );
 	}
 // To Here 2001.12.03 hor
-	/* ƒ^ƒXƒNƒgƒŒƒC‚Éí’“ */
+	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã«å¸¸é§ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_STAYTASKTRAY, m_Common.m_sGeneral.m_bStayTaskTray );
 
-	/* ƒ^ƒXƒNƒgƒŒƒC¶ƒNƒŠƒbƒNƒƒjƒ…[‚ÌƒVƒ‡[ƒgƒJƒbƒg */
+	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤å·¦ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®ã‚·ãƒ§ãƒ¼ãƒˆã‚«ãƒƒãƒˆ */
 	HotKey_SetHotKey( ::GetDlgItem( hwndDlg, IDC_HOTKEY_TRAYMENU ), m_Common.m_sGeneral.m_wTrayMenuHotKeyCode, m_Common.m_sGeneral.m_wTrayMenuHotKeyMods );
 
 	return;
@@ -394,10 +394,10 @@ void CPropGeneral::SetData( HWND hwndDlg )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ General */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— General */
 int CPropGeneral::GetData( HWND hwndDlg )
 {
-	/* ƒJ[ƒ\ƒ‹‚Ìƒ^ƒCƒv 0=win 1=dos  */
+	/* ã‚«ãƒ¼ã‚½ãƒ«ã®ã‚¿ã‚¤ãƒ— 0=win 1=dos  */
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_CARETTYPE0 ) ){
 		m_Common.m_sGeneral.SetCaretType(0);
 	}
@@ -405,24 +405,24 @@ int CPropGeneral::GetData( HWND hwndDlg )
 		m_Common.m_sGeneral.SetCaretType(1);
 	}
 
-	/* ƒtƒŠ[ƒJ[ƒ\ƒ‹ƒ‚[ƒh */
+	/* ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ãƒ¢ãƒ¼ãƒ‰ */
 	m_Common.m_sGeneral.m_bIsFreeCursorMode = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_FREECARET ) != 0;
 
-	/* ’PŒê’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚ÉA’PŒê‚Ì—¼’[‚Å~‚Ü‚é‚© */
+	/* å˜èªå˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«ã€å˜èªã®ä¸¡ç«¯ã§æ­¢ã¾ã‚‹ã‹ */
 	m_Common.m_sGeneral.m_bStopsBothEndsWhenSearchWord = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_WORD );
-	//	2007.10.08 genta ƒ}ƒEƒXƒNƒŠƒbƒN‚ÅƒAƒNƒeƒBƒu‚É‚È‚Á‚½‚Æ‚«‚ÍƒJ[ƒ\ƒ‹‚ğƒNƒŠƒbƒNˆÊ’u‚ÉˆÚ“®‚µ‚È‚¢ (2007.10.02 by nasukoji)
+	//	2007.10.08 genta ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯ã§ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ãªã£ãŸã¨ãã¯ã‚«ãƒ¼ã‚½ãƒ«ã‚’ã‚¯ãƒªãƒƒã‚¯ä½ç½®ã«ç§»å‹•ã—ãªã„ (2007.10.02 by nasukoji)
 	m_Common.m_sGeneral.m_bNoCaretMoveByActivation = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_NOMOVE_ACTIVATE_BY_MOUSE );
 
-	/* ’i—’PˆÊ‚ÅˆÚ“®‚·‚é‚Æ‚«‚ÉA’i—‚Ì—¼’[‚Å~‚Ü‚é‚© */
+	/* æ®µè½å˜ä½ã§ç§»å‹•ã™ã‚‹ã¨ãã«ã€æ®µè½ã®ä¸¡ç«¯ã§æ­¢ã¾ã‚‹ã‹ */
 	m_Common.m_sGeneral.m_bStopsBothEndsWhenSearchParagraph = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_STOPS_BOTH_ENDS_WHEN_SEARCH_PARAGRAPH );
 
-	/* [‚·‚×‚Ä•Â‚¶‚é]‚Å‘¼‚É•ÒW—p‚ÌƒEƒBƒ“ƒhƒE‚ª‚ ‚ê‚ÎŠm”F‚·‚é */	// 2006.12.25 ryoji
+	/* [ã™ã¹ã¦é–‰ã˜ã‚‹]ã§ä»–ã«ç·¨é›†ç”¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒã‚ã‚Œã°ç¢ºèªã™ã‚‹ */	// 2006.12.25 ryoji
 	m_Common.m_sGeneral.m_bCloseAllConfirm = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_CLOSEALLCONFIRM );
 
-	/* I—¹‚ÌŠm”F‚ğ‚·‚é */
+	/* çµ‚äº†æ™‚ã®ç¢ºèªã‚’ã™ã‚‹ */
 	m_Common.m_sGeneral.m_bExitConfirm = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_EXITCONFIRM );
 
-	/* ƒL[ƒŠƒs[ƒg‚ÌƒXƒNƒ[ƒ‹s” */
+	/* ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•° */
 	m_Common.m_sGeneral.m_nRepeatedScrollLineNum = (CLayoutInt)::GetDlgItemInt( hwndDlg, IDC_EDIT_REPEATEDSCROLLLINENUM, NULL, FALSE );
 	if( m_Common.m_sGeneral.m_nRepeatedScrollLineNum < CLayoutInt(1) ){
 		m_Common.m_sGeneral.m_nRepeatedScrollLineNum = CLayoutInt(1);
@@ -431,27 +431,27 @@ int CPropGeneral::GetData( HWND hwndDlg )
 		m_Common.m_sGeneral.m_nRepeatedScrollLineNum = CLayoutInt(10);
 	}
 
-	/* ƒL[ƒŠƒs[ƒg‚ÌƒXƒNƒ[ƒ‹‚ğŠŠ‚ç‚©‚É‚·‚é‚© */
+	/* ã‚­ãƒ¼ãƒªãƒ”ãƒ¼ãƒˆæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚’æ»‘ã‚‰ã‹ã«ã™ã‚‹ã‹ */
 	m_Common.m_sGeneral.m_nRepeatedScroll_Smooth = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_REPEATEDSCROLLSMOOTH );
 
-	// 2009.01.17 nasukoji	‘g‚İ‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½ƒy[ƒWƒXƒNƒ[ƒ‹‚·‚é
+	// 2009.01.17 nasukoji	çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹
 	HWND	hwndCombo;
 	int		nSelPos;
 
-	// 2007.09.09 Moca ‰æ–ÊƒLƒƒƒbƒVƒ…İ’è’Ç‰Á
-	// ‰æ–ÊƒLƒƒƒbƒVƒ…‚ğg‚¤
+	// 2007.09.09 Moca ç”»é¢ã‚­ãƒ£ãƒƒã‚·ãƒ¥è¨­å®šè¿½åŠ 
+	// ç”»é¢ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’ä½¿ã†
 	m_Common.m_sWindow.m_bUseCompatibleBMP = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_MEMDC );
 
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WHEEL_PAGESCROLL );
 	nSelPos = Combo_GetCurSel( hwndCombo );
-	m_Common.m_sGeneral.m_nPageScrollByWheel = SpecialScrollModeArr[nSelPos].nMethod;		// ƒy[ƒWƒXƒNƒ[ƒ‹‚Æ‚·‚é‘g‚İ‡‚í‚¹‘€ì
+	m_Common.m_sGeneral.m_nPageScrollByWheel = SpecialScrollModeArr[nSelPos].nMethod;		// ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã¨ã™ã‚‹çµ„ã¿åˆã‚ã›æ“ä½œ
 
-	// 2009.01.17 nasukoji	‘g‚İ‡‚í‚¹‚ÄƒzƒC[ƒ‹‘€ì‚µ‚½‰¡ƒXƒNƒ[ƒ‹‚·‚é
+	// 2009.01.17 nasukoji	çµ„ã¿åˆã‚ã›ã¦ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã—ãŸæ™‚æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WHEEL_HSCROLL );
 	nSelPos = Combo_GetCurSel( hwndCombo );
-	m_Common.m_sGeneral.m_nHorizontalScrollByWheel = SpecialScrollModeArr[nSelPos].nMethod;	// ‰¡ƒXƒNƒ[ƒ‹‚Æ‚·‚é‘g‚İ‡‚í‚¹‘€ì
+	m_Common.m_sGeneral.m_nHorizontalScrollByWheel = SpecialScrollModeArr[nSelPos].nMethod;	// æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã¨ã™ã‚‹çµ„ã¿åˆã‚ã›æ“ä½œ
 
-	/* ƒtƒ@ƒCƒ‹‚Ì—š—ğMAX */
+	/* ãƒ•ã‚¡ã‚¤ãƒ«ã®å±¥æ­´MAX */
 	m_Common.m_sGeneral.m_nMRUArrNum_MAX = ::GetDlgItemInt( hwndDlg, IDC_EDIT_MAX_MRU_FILE, NULL, FALSE );
 	if( m_Common.m_sGeneral.m_nMRUArrNum_MAX < 0 ){
 		m_Common.m_sGeneral.m_nMRUArrNum_MAX = 0;
@@ -460,13 +460,13 @@ int CPropGeneral::GetData( HWND hwndDlg )
 		m_Common.m_sGeneral.m_nMRUArrNum_MAX = MAX_MRU;
 	}
 
-	{	//—š—ğ‚ÌŠÇ—	//@@@ 2003.04.09 MIK
+	{	//å±¥æ­´ã®ç®¡ç†	//@@@ 2003.04.09 MIK
 		CRecentFile	cRecentFile;
 		cRecentFile.UpdateView();
 		cRecentFile.Terminate();
 	}
 
-	/* ƒtƒHƒ‹ƒ_‚Ì—š—ğMAX */
+	/* ãƒ•ã‚©ãƒ«ãƒ€ã®å±¥æ­´MAX */
 	m_Common.m_sGeneral.m_nOPENFOLDERArrNum_MAX = ::GetDlgItemInt( hwndDlg, IDC_EDIT_MAX_MRU_FOLDER, NULL, FALSE );
 	if( m_Common.m_sGeneral.m_nOPENFOLDERArrNum_MAX < 0 ){
 		m_Common.m_sGeneral.m_nOPENFOLDERArrNum_MAX = 0;
@@ -475,24 +475,24 @@ int CPropGeneral::GetData( HWND hwndDlg )
 		m_Common.m_sGeneral.m_nOPENFOLDERArrNum_MAX = MAX_OPENFOLDER;
 	}
 
-	{	//—š—ğ‚ÌŠÇ—	//@@@ 2003.04.09 MIK
+	{	//å±¥æ­´ã®ç®¡ç†	//@@@ 2003.04.09 MIK
 		CRecentFolder	cRecentFolder;
 		cRecentFolder.UpdateView();
 		cRecentFolder.Terminate();
 	}
 
-	/* ƒ^ƒXƒNƒgƒŒƒC‚ğg‚¤ */
+	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã‚’ä½¿ã† */
 	m_Common.m_sGeneral.m_bUseTaskTray = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_USETRAYICON );
-//@@@ YAZAKI 2001.12.31 m_bUseTaskTray‚Éˆø‚«‚Ã‚ç‚ê‚é‚æ‚¤‚ÉB
+//@@@ YAZAKI 2001.12.31 m_bUseTaskTrayã«å¼•ãã¥ã‚‰ã‚Œã‚‹ã‚ˆã†ã«ã€‚
 	if( m_Common.m_sGeneral.m_bUseTaskTray ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_STAYTASKTRAY ), TRUE );
 	}else{
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_STAYTASKTRAY ), FALSE );
 	}
-	/* ƒ^ƒXƒNƒgƒŒƒC‚Éí’“ */
+	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤ã«å¸¸é§ */
 	m_Common.m_sGeneral.m_bStayTaskTray = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_STAYTASKTRAY );
 
-	/* ƒ^ƒXƒNƒgƒŒƒC¶ƒNƒŠƒbƒNƒƒjƒ…[‚ÌƒVƒ‡[ƒgƒJƒbƒg */
+	/* ã‚¿ã‚¹ã‚¯ãƒˆãƒ¬ã‚¤å·¦ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®ã‚·ãƒ§ãƒ¼ãƒˆã‚«ãƒƒãƒˆ */
 	LRESULT	lResult;
 	lResult = HotKey_GetHotKey( ::GetDlgItem( hwndDlg, IDC_HOTKEY_TRAYMENU ) );
 	m_Common.m_sGeneral.m_wTrayMenuHotKeyCode = LOBYTE( lResult );

--- a/sakura_core/prop/CPropComGrep.cpp
+++ b/sakura_core/prop/CPropComGrep.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAuŒŸõvƒy[ƒW
+ï»¿/*!	@file
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œæ¤œç´¢ã€ãƒšãƒ¼ã‚¸
 
 	@author Norio Nakatani
 */
@@ -16,7 +16,7 @@
 
 #include "StdAfx.h"
 #include "prop/CPropCommon.h"
-#include "extmodule/CBregexp.h"	// 2007.08/12 genta ƒo[ƒWƒ‡ƒ“æ“¾
+#include "extmodule/CBregexp.h"	// 2007.08/12 genta ãƒãƒ¼ã‚¸ãƒ§ãƒ³å–å¾—
 #include "util/shell.h"
 #include "util/window.h"
 #include "sakura_rc.h"
@@ -24,17 +24,17 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//10500
-	IDC_EDIT_REGEXPLIB,				HIDC_EDIT_REGEXPLIB,	//³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‘I‘ğ	// 2007.09.02 genta
+	IDC_EDIT_REGEXPLIB,				HIDC_EDIT_REGEXPLIB,	//æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªé¸æŠ	// 2007.09.02 genta
 	IDC_LABEL_REGEXP,				HIDC_EDIT_REGEXPLIB,
-	IDC_LABEL_REGEXP_VER,			HIDC_LABEL_REGEXPVER,	//³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠƒo[ƒWƒ‡ƒ“	// 2007.09.02 genta
-	IDC_CHECK_bCaretTextForSearch,	HIDC_CHECK_bCaretTextForSearch,	//ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì•¶š—ñ‚ğƒfƒtƒHƒ‹ƒg‚ÌŒŸõ•¶š—ñ‚É‚·‚é	// 2006.08.23 ryoji
-	IDC_CHECK_INHERIT_KEY_OTHER_VIEW, HIDC_CHECK_INHERIT_KEY_OTHER_VIEW,	// ŸE‘OŒŸõ‚Å‘¼‚Ìƒrƒ…[‚ÌŒŸõğŒ‚ğˆø‚«Œp‚®	// 2011.12.18 Moca
-	IDC_CHECK_bGrepExitConfirm,		HIDC_CHECK_bGrepExitConfirm,	//GREP‚Ì•Û‘¶Šm”F
-	IDC_CHECK_GTJW_RETURN,			HIDC_CHECK_GTJW_RETURN,			//ƒ^ƒOƒWƒƒƒ“ƒviƒGƒ“ƒ^[ƒL[j
-	IDC_CHECK_GTJW_LDBLCLK,			HIDC_CHECK_GTJW_LDBLCLK,		//ƒ^ƒOƒWƒƒƒ“ƒviƒ_ƒuƒ‹ƒNƒŠƒbƒNj
-	IDC_CHECK_GREPREALTIME,			HIDC_CHECK_GREPREALTIME,		//ƒŠƒAƒ‹ƒ^ƒCƒ€‚Å•\¦‚·‚é	// 2006.08.08 ryoji
-	IDC_COMBO_TAGJUMP,				HIDC_COMBO_TAGJUMP,				//ƒ^ƒOƒtƒ@ƒCƒ‹‚ÌŒŸõ
-	IDC_COMBO_KEYWORD_TAGJUMP,		HIDC_COMBO_KEYWORD_TAGJUMP,		//ƒ^ƒOƒtƒ@ƒCƒ‹‚ÌŒŸõ
+	IDC_LABEL_REGEXP_VER,			HIDC_LABEL_REGEXPVER,	//æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªãƒãƒ¼ã‚¸ãƒ§ãƒ³	// 2007.09.02 genta
+	IDC_CHECK_bCaretTextForSearch,	HIDC_CHECK_bCaretTextForSearch,	//ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ–‡å­—åˆ—ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®æ¤œç´¢æ–‡å­—åˆ—ã«ã™ã‚‹	// 2006.08.23 ryoji
+	IDC_CHECK_INHERIT_KEY_OTHER_VIEW, HIDC_CHECK_INHERIT_KEY_OTHER_VIEW,	// æ¬¡ãƒ»å‰æ¤œç´¢ã§ä»–ã®ãƒ“ãƒ¥ãƒ¼ã®æ¤œç´¢æ¡ä»¶ã‚’å¼•ãç¶™ã	// 2011.12.18 Moca
+	IDC_CHECK_bGrepExitConfirm,		HIDC_CHECK_bGrepExitConfirm,	//GREPã®ä¿å­˜ç¢ºèª
+	IDC_CHECK_GTJW_RETURN,			HIDC_CHECK_GTJW_RETURN,			//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ï¼ˆã‚¨ãƒ³ã‚¿ãƒ¼ã‚­ãƒ¼ï¼‰
+	IDC_CHECK_GTJW_LDBLCLK,			HIDC_CHECK_GTJW_LDBLCLK,		//ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ï¼ˆãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ï¼‰
+	IDC_CHECK_GREPREALTIME,			HIDC_CHECK_GREPREALTIME,		//ãƒªã‚¢ãƒ«ã‚¿ã‚¤ãƒ ã§è¡¨ç¤ºã™ã‚‹	// 2006.08.08 ryoji
+	IDC_COMBO_TAGJUMP,				HIDC_COMBO_TAGJUMP,				//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®æ¤œç´¢
+	IDC_COMBO_KEYWORD_TAGJUMP,		HIDC_COMBO_KEYWORD_TAGJUMP,		//ã‚¿ã‚°ãƒ•ã‚¡ã‚¤ãƒ«ã®æ¤œç´¢
 //	IDC_STATIC,						-1,
 	0, 0
 };
@@ -42,10 +42,10 @@ static const DWORD p_helpids[] = {	//10500
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropGrep::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -54,7 +54,7 @@ INT_PTR CALLBACK CPropGrep::DlgProc_page(
 }
 //	To Here Jun. 2, 2001 genta
 
-/* ƒƒbƒZ[ƒWˆ— */
+/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropGrep::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 //	WORD		wNotifyCode;
@@ -67,12 +67,12 @@ INT_PTR CPropGrep::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
 	switch( uMsg ){
 
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Grep */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Grep */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒ†[ƒU[‚ªƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+		/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 
 		return TRUE;
 	case WM_NOTIFY:
@@ -84,10 +84,10 @@ INT_PTR CPropGrep::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
 				OnHelp( hwndDlg, IDD_PROP_GREP );
 				return TRUE;
 			case PSN_KILLACTIVE:
-				/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Grep */
+				/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Grep */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_GREP;
 				return TRUE;
@@ -96,7 +96,7 @@ INT_PTR CPropGrep::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
 //		}
 		break;	/* WM_NOTIFY */
 	case WM_COMMAND:
-		//	2007.08.12 genta ³‹K•\Œ»DLL‚Ì•ÏX‚É‰‚¶‚ÄVersion‚ğÄæ“¾‚·‚é
+		//	2007.08.12 genta æ­£è¦è¡¨ç¾DLLã®å¤‰æ›´ã«å¿œã˜ã¦Versionã‚’å†å–å¾—ã™ã‚‹
 		if( wParam == MAKEWPARAM( IDC_EDIT_REGEXPLIB, EN_KILLFOCUS )){
 			SetRegexpVersion( hwndDlg );
 		}
@@ -106,7 +106,7 @@ INT_PTR CPropGrep::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -116,7 +116,7 @@ INT_PTR CPropGrep::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -129,28 +129,28 @@ struct tagTagJumpMode{
 	DWORD	m_nNameID;
 };
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CPropGrep::SetData( HWND hwndDlg )
 {
-	/* 2006.08.23 ryoji ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì•¶š—ñ‚ğƒfƒtƒHƒ‹ƒg‚ÌŒŸõ•¶š—ñ‚É‚·‚é */
+	/* 2006.08.23 ryoji ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ–‡å­—åˆ—ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®æ¤œç´¢æ–‡å­—åˆ—ã«ã™ã‚‹ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_bCaretTextForSearch, m_Common.m_sSearch.m_bCaretTextForSearch );
 
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_INHERIT_KEY_OTHER_VIEW, m_Common.m_sSearch.m_bInheritKeyOtherView );
 
-	/* Grepƒ‚[ƒh‚Å•Û‘¶Šm”F‚·‚é‚© */
+	/* Grepãƒ¢ãƒ¼ãƒ‰ã§ä¿å­˜ç¢ºèªã™ã‚‹ã‹ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_bGrepExitConfirm, m_Common.m_sSearch.m_bGrepExitConfirm );
 
-	/* GrepŒ‹‰Ê‚ÌƒŠƒAƒ‹ƒ^ƒCƒ€•\¦ */
-	::CheckDlgButton( hwndDlg, IDC_CHECK_GREPREALTIME, m_Common.m_sSearch.m_bGrepRealTimeView );	// 2006.08.08 ryoji IDC³
+	/* Grepçµæœã®ãƒªã‚¢ãƒ«ã‚¿ã‚¤ãƒ è¡¨ç¤º */
+	::CheckDlgButton( hwndDlg, IDC_CHECK_GREPREALTIME, m_Common.m_sSearch.m_bGrepRealTimeView );	// 2006.08.08 ryoji IDä¿®æ­£
 
 
-	/* Grepƒ‚[ƒh: ƒGƒ“ƒ^[ƒL[‚Åƒ^ƒOƒWƒƒƒ“ƒv */
+	/* Grepãƒ¢ãƒ¼ãƒ‰: ã‚¨ãƒ³ã‚¿ãƒ¼ã‚­ãƒ¼ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ— */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_GTJW_RETURN, m_Common.m_sSearch.m_bGTJW_RETURN );
 
-	/* Grepƒ‚[ƒh: ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Åƒ^ƒOƒWƒƒƒ“ƒv */
+	/* Grepãƒ¢ãƒ¼ãƒ‰: ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ— */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_GTJW_LDBLCLK, m_Common.m_sSearch.m_bGTJW_LDBLCLK );
 
-	//	2007.08.12 genta ³‹K•\Œ»DLL
+	//	2007.08.12 genta æ­£è¦è¡¨ç¾DLL
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_REGEXPLIB ), _countof(m_Common.m_sSearch.m_szRegexpLib ) - 1 );
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_REGEXPLIB, m_Common.m_sSearch.m_szRegexpLib);
 	SetRegexpVersion( hwndDlg );
@@ -197,27 +197,27 @@ void CPropGrep::SetData( HWND hwndDlg )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 int CPropGrep::GetData( HWND hwndDlg )
 {
-	/* 2006.08.23 ryoji ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì•¶š—ñ‚ğƒfƒtƒHƒ‹ƒg‚ÌŒŸõ•¶š—ñ‚É‚·‚é */
+	/* 2006.08.23 ryoji ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ–‡å­—åˆ—ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®æ¤œç´¢æ–‡å­—åˆ—ã«ã™ã‚‹ */
 	m_Common.m_sSearch.m_bCaretTextForSearch = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_bCaretTextForSearch );
 
 	m_Common.m_sSearch.m_bInheritKeyOtherView = IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_INHERIT_KEY_OTHER_VIEW );
 
-	/* Grepƒ‚[ƒh‚Å•Û‘¶Šm”F‚·‚é‚© */
+	/* Grepãƒ¢ãƒ¼ãƒ‰ã§ä¿å­˜ç¢ºèªã™ã‚‹ã‹ */
 	m_Common.m_sSearch.m_bGrepExitConfirm = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_bGrepExitConfirm );
 
-	/* GrepŒ‹‰Ê‚ÌƒŠƒAƒ‹ƒ^ƒCƒ€•\¦ */
-	m_Common.m_sSearch.m_bGrepRealTimeView = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_GREPREALTIME );	// 2006.08.08 ryoji IDC³
+	/* Grepçµæœã®ãƒªã‚¢ãƒ«ã‚¿ã‚¤ãƒ è¡¨ç¤º */
+	m_Common.m_sSearch.m_bGrepRealTimeView = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_GREPREALTIME );	// 2006.08.08 ryoji IDä¿®æ­£
 
-	/* Grepƒ‚[ƒh: ƒGƒ“ƒ^[ƒL[‚Åƒ^ƒOƒWƒƒƒ“ƒv */
+	/* Grepãƒ¢ãƒ¼ãƒ‰: ã‚¨ãƒ³ã‚¿ãƒ¼ã‚­ãƒ¼ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ— */
 	m_Common.m_sSearch.m_bGTJW_RETURN = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_GTJW_RETURN );
 
-	/* Grepƒ‚[ƒh: ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Åƒ^ƒOƒWƒƒƒ“ƒv */
+	/* Grepãƒ¢ãƒ¼ãƒ‰: ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ— */
 	m_Common.m_sSearch.m_bGTJW_LDBLCLK = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_GTJW_LDBLCLK );
 
-	//	2007.08.12 genta ³‹K•\Œ»DLL
+	//	2007.08.12 genta æ­£è¦è¡¨ç¾DLL
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_REGEXPLIB, m_Common.m_sSearch.m_szRegexpLib, _countof( m_Common.m_sSearch.m_szRegexpLib ));
 
 	HWND hwndCombo = ::GetDlgItem(hwndDlg, IDC_COMBO_TAGJUMP);

--- a/sakura_core/prop/CPropComHelper.cpp
+++ b/sakura_core/prop/CPropComHelper.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAux‰‡vƒy[ƒW
+ï»¿/*!	@file
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œæ”¯æ´ã€ãƒšãƒ¼ã‚¸
 
 	@author Norio Nakatani
 */
@@ -47,23 +47,23 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//10600
-	IDC_BUTTON_OPENHELP1,			HIDC_BUTTON_OPENHELP1,			//ŠO•”ƒwƒ‹ƒvƒtƒ@ƒCƒ‹QÆ
-	IDC_BUTTON_OPENEXTHTMLHELP,		HIDC_BUTTON_OPENEXTHTMLHELP,	//ŠO•”HTMLƒtƒ@ƒCƒ‹QÆ
-//	IDC_CHECK_USEHOKAN,				HIDC_CHECK_USEHOKAN,			//’€Ÿ“ü—Í•âŠ®
-	IDC_CHECK_m_bHokanKey_RETURN,	HIDC_CHECK_m_bHokanKey_RETURN,	//Œó•âŒˆ’èƒL[iEnterj
-	IDC_CHECK_m_bHokanKey_TAB,		HIDC_CHECK_m_bHokanKey_TAB,		//Œó•âŒˆ’èƒL[iTabj
-	IDC_CHECK_m_bHokanKey_RIGHT,	HIDC_CHECK_m_bHokanKey_RIGHT,	//Œó•âŒˆ’èƒL[i¨j
-//	IDC_CHECK_m_bHokanKey_SPACE,	HIDC_CHECK_m_bHokanKey_SPACE,	//Œó•âŒˆ’èƒL[iSpacej
-	IDC_CHECK_HTMLHELPISSINGLE,		HIDC_CHECK_HTMLHELPISSINGLE,	//ƒrƒ…[ƒA‚Ì•¡”‹N“®
-	IDC_EDIT_EXTHELP1,				HIDC_EDIT_EXTHELP1,				//ŠO•”ƒwƒ‹ƒvƒtƒ@ƒCƒ‹–¼
-	IDC_EDIT_EXTHTMLHELP,			HIDC_EDIT_EXTHTMLHELP,			//ŠO•”HTMLƒwƒ‹ƒvƒtƒ@ƒCƒ‹–¼
-	//	2007.02.04 genta ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì’PŒê‚Ì«‘ŒŸõ‚Í‹¤’Êİ’è‚©‚çŠO‚µ‚½
-	//IDC_CHECK_CLICKKEYSEARCH,		HIDC_CHECK_CLICKKEYSEARCH,		//ƒLƒƒƒŒƒbƒgˆÊ’u‚Ì’PŒê‚ğ«‘ŒŸõ	// 2006.03.24 fon
-	IDC_BUTTON_KEYWORDHELPFONT,		HIDC_BUTTON_KEYWORDHELPFONT,	//ƒL[ƒ[ƒhƒwƒ‹ƒv‚ÌƒtƒHƒ“ƒg
-	IDC_EDIT_MIGEMO_DLL,			HIDC_EDIT_MIGEMO_DLL,			//Migemo DLLƒtƒ@ƒCƒ‹–¼	// 2006.08.06 ryoji
-	IDC_BUTTON_OPENMDLL,			HIDC_BUTTON_OPENMDLL,			//Migemo DLLƒtƒ@ƒCƒ‹QÆ	// 2006.08.06 ryoji
-	IDC_EDIT_MIGEMO_DICT,			HIDC_EDIT_MIGEMO_DICT,			//Migemo «‘ƒtƒ@ƒCƒ‹–¼	// 2006.08.06 ryoji
-	IDC_BUTTON_OPENMDICT,			HIDC_BUTTON_OPENMDICT,			//Migemo «‘ƒtƒ@ƒCƒ‹QÆ	// 2006.08.06 ryoji
+	IDC_BUTTON_OPENHELP1,			HIDC_BUTTON_OPENHELP1,			//å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ãƒ•ã‚¡ã‚¤ãƒ«å‚ç…§
+	IDC_BUTTON_OPENEXTHTMLHELP,		HIDC_BUTTON_OPENEXTHTMLHELP,	//å¤–éƒ¨HTMLãƒ•ã‚¡ã‚¤ãƒ«å‚ç…§
+//	IDC_CHECK_USEHOKAN,				HIDC_CHECK_USEHOKAN,			//é€æ¬¡å…¥åŠ›è£œå®Œ
+	IDC_CHECK_m_bHokanKey_RETURN,	HIDC_CHECK_m_bHokanKey_RETURN,	//å€™è£œæ±ºå®šã‚­ãƒ¼ï¼ˆEnterï¼‰
+	IDC_CHECK_m_bHokanKey_TAB,		HIDC_CHECK_m_bHokanKey_TAB,		//å€™è£œæ±ºå®šã‚­ãƒ¼ï¼ˆTabï¼‰
+	IDC_CHECK_m_bHokanKey_RIGHT,	HIDC_CHECK_m_bHokanKey_RIGHT,	//å€™è£œæ±ºå®šã‚­ãƒ¼ï¼ˆâ†’ï¼‰
+//	IDC_CHECK_m_bHokanKey_SPACE,	HIDC_CHECK_m_bHokanKey_SPACE,	//å€™è£œæ±ºå®šã‚­ãƒ¼ï¼ˆSpaceï¼‰
+	IDC_CHECK_HTMLHELPISSINGLE,		HIDC_CHECK_HTMLHELPISSINGLE,	//ãƒ“ãƒ¥ãƒ¼ã‚¢ã®è¤‡æ•°èµ·å‹•
+	IDC_EDIT_EXTHELP1,				HIDC_EDIT_EXTHELP1,				//å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ãƒ•ã‚¡ã‚¤ãƒ«å
+	IDC_EDIT_EXTHTMLHELP,			HIDC_EDIT_EXTHTMLHELP,			//å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—ãƒ•ã‚¡ã‚¤ãƒ«å
+	//	2007.02.04 genta ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®å˜èªã®è¾æ›¸æ¤œç´¢ã¯å…±é€šè¨­å®šã‹ã‚‰å¤–ã—ãŸ
+	//IDC_CHECK_CLICKKEYSEARCH,		HIDC_CHECK_CLICKKEYSEARCH,		//ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã®å˜èªã‚’è¾æ›¸æ¤œç´¢	// 2006.03.24 fon
+	IDC_BUTTON_KEYWORDHELPFONT,		HIDC_BUTTON_KEYWORDHELPFONT,	//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã®ãƒ•ã‚©ãƒ³ãƒˆ
+	IDC_EDIT_MIGEMO_DLL,			HIDC_EDIT_MIGEMO_DLL,			//Migemo DLLãƒ•ã‚¡ã‚¤ãƒ«å	// 2006.08.06 ryoji
+	IDC_BUTTON_OPENMDLL,			HIDC_BUTTON_OPENMDLL,			//Migemo DLLãƒ•ã‚¡ã‚¤ãƒ«å‚ç…§	// 2006.08.06 ryoji
+	IDC_EDIT_MIGEMO_DICT,			HIDC_EDIT_MIGEMO_DICT,			//Migemo è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«å	// 2006.08.06 ryoji
+	IDC_BUTTON_OPENMDICT,			HIDC_BUTTON_OPENMDICT,			//Migemo è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«å‚ç…§	// 2006.08.06 ryoji
 //	IDC_STATIC,						-1,
 	0, 0
 };
@@ -71,10 +71,10 @@ static const DWORD p_helpids[] = {	//10600
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropHelper::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -83,7 +83,7 @@ INT_PTR CALLBACK CPropHelper::DlgProc_page(
 }
 //	To Here Jun. 2, 2001 genta
 
-/* Helper ƒƒbƒZ[ƒWˆ— */
+/* Helper ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropHelper::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
 	UINT	uMsg,		// message
@@ -97,43 +97,43 @@ INT_PTR CPropHelper::DispatchEvent(
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Helper */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Helper */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒ†[ƒU[‚ªƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
-		/* ŠO•”ƒwƒ‹ƒv‚P */
+		/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
+		/* å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘ */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_EXTHELP1 ), _MAX_PATH - 1 );
-		/* ŠO•”HTMLƒwƒ‹ƒv */
+		/* å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ— */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_EXTHTMLHELP ), _MAX_PATH - 1 );
 
 		return TRUE;
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID			= LOWORD(wParam);	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+		wNotifyCode = HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID			= LOWORD(wParam);	/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 		switch( wNotifyCode ){
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
-			/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Helper */
+			/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Helper */
 			GetData( hwndDlg );
 			switch( wID ){
-			case IDC_BUTTON_OPENHELP1:	/* ŠO•”ƒwƒ‹ƒv‚P‚ÌuQÆ...vƒ{ƒ^ƒ“ */
+			case IDC_BUTTON_OPENHELP1:	/* å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘ã®ã€Œå‚ç…§...ã€ãƒœã‚¿ãƒ³ */
 				{
-					// 2003.06.23 Moca ‘Š‘ÎƒpƒX‚ÍÀsƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX
-					// 2007.05.21 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+					// 2003.06.23 Moca ç›¸å¯¾ãƒ‘ã‚¹ã¯å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹
+					// 2007.05.21 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 					CDlgOpenFile::SelectFile(hwndDlg, GetDlgItem(hwndDlg, IDC_EDIT_EXTHELP1), _T("*.hlp;*.chm;*.col"), true, EFITER_NONE);
 				}
 				return TRUE;
-			case IDC_BUTTON_OPENEXTHTMLHELP:	/* ŠO•”HTMLƒwƒ‹ƒv‚ÌuQÆ...vƒ{ƒ^ƒ“ */
+			case IDC_BUTTON_OPENEXTHTMLHELP:	/* å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ—ã®ã€Œå‚ç…§...ã€ãƒœã‚¿ãƒ³ */
 				{
-					// 2003.06.23 Moca ‘Š‘ÎƒpƒX‚ÍÀsƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX
-					// 2007.05.21 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+					// 2003.06.23 Moca ç›¸å¯¾ãƒ‘ã‚¹ã¯å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹
+					// 2007.05.21 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 					CDlgOpenFile::SelectFile(hwndDlg, GetDlgItem(hwndDlg, IDC_EDIT_EXTHTMLHELP), _T("*.chm;*.col"), true, EFITER_NONE);
 				}
 				return TRUE;
 			// ai 02/05/21 Add S
-			case IDC_BUTTON_KEYWORDHELPFONT:	/* ƒL[ƒ[ƒhƒwƒ‹ƒv‚ÌuƒtƒHƒ“ƒgvƒ{ƒ^ƒ“ */
+			case IDC_BUTTON_KEYWORDHELPFONT:	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã®ã€Œãƒ•ã‚©ãƒ³ãƒˆã€ãƒœã‚¿ãƒ³ */
 				{
 					LOGFONT   lf = m_Common.m_sHelper.m_lf;
 					INT nPointSize = m_Common.m_sHelper.m_nPointSize;
@@ -141,7 +141,7 @@ INT_PTR CPropHelper::DispatchEvent(
 					if( MySelectFont( &lf, &nPointSize, hwndDlg, false) ){
 						m_Common.m_sHelper.m_lf = lf;
 						m_Common.m_sHelper.m_nPointSize = nPointSize;	// 2009.10.01 ryoji
-						// ƒL[ƒ[ƒhƒwƒ‹ƒv ƒtƒHƒ“ƒg•\¦	// 2013/4/24 Uchi
+						// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ— ãƒ•ã‚©ãƒ³ãƒˆè¡¨ç¤º	// 2013/4/24 Uchi
 						HFONT hFont = SetFontLabel( hwndDlg, IDC_STATIC_KEYWORDHELPFONT, m_Common.m_sHelper.m_lf, m_Common.m_sHelper.m_nPointSize);
 						if(m_hKeywordHelpFont != NULL){
 							::DeleteObject( m_hKeywordHelpFont );
@@ -151,25 +151,25 @@ INT_PTR CPropHelper::DispatchEvent(
 				}
 				return TRUE;
 			// ai 02/05/21 Add E
-			case IDC_BUTTON_OPENMDLL:	/* MIGEMODLLêŠw’èuQÆ...vƒ{ƒ^ƒ“ */
+			case IDC_BUTTON_OPENMDLL:	/* MIGEMODLLå ´æ‰€æŒ‡å®šã€Œå‚ç…§...ã€ãƒœã‚¿ãƒ³ */
 				{
-					// 2003.06.23 Moca ‘Š‘ÎƒpƒX‚ÍÀsƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX
-					// 2007.05.21 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+					// 2003.06.23 Moca ç›¸å¯¾ãƒ‘ã‚¹ã¯å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹
+					// 2007.05.21 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 					CDlgOpenFile::SelectFile(hwndDlg, GetDlgItem(hwndDlg, IDC_EDIT_MIGEMO_DLL), _T("*.dll"), true, EFITER_NONE);
 				}
 				return TRUE;
-			case IDC_BUTTON_OPENMDICT:	/* MigemoDictêŠw’èuQÆ...vƒ{ƒ^ƒ“ */
+			case IDC_BUTTON_OPENMDICT:	/* MigemoDictå ´æ‰€æŒ‡å®šã€Œå‚ç…§...ã€ãƒœã‚¿ãƒ³ */
 				{
 					TCHAR	szPath[_MAX_PATH];
-					/* ŒŸõƒtƒHƒ‹ƒ_ */
-					// 2007.05.27 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+					/* æ¤œç´¢ãƒ•ã‚©ãƒ«ãƒ€ */
+					// 2007.05.27 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 					if( _IS_REL_PATH( m_Common.m_sHelper.m_szMigemoDict ) ){
 						GetInidirOrExedir( szPath, m_Common.m_sHelper.m_szMigemoDict, TRUE );
 					}else{
 						_tcscpy( szPath, m_Common.m_sHelper.m_szMigemoDict );
 					}
 					if( SelectDir( hwndDlg, LS(STR_PROPCOMHELP_MIGEMODIR), szPath, szPath ) ){
-						_tcscpy( m_Common.m_sHelper.m_szMigemoDict, GetRelPath(szPath) ); // 2015.03.03 ‰Â”\‚È‚ç‘Š‘ÎƒpƒX‚É‚·‚é
+						_tcscpy( m_Common.m_sHelper.m_szMigemoDict, GetRelPath(szPath) ); // 2015.03.03 å¯èƒ½ãªã‚‰ç›¸å¯¾ãƒ‘ã‚¹ã«ã™ã‚‹
 						::DlgItem_SetText( hwndDlg, IDC_EDIT_MIGEMO_DICT, m_Common.m_sHelper.m_szMigemoDict );
 					}
 				}
@@ -190,10 +190,10 @@ INT_PTR CPropHelper::DispatchEvent(
 				return TRUE;
 			case PSN_KILLACTIVE:
 //				MYTRACE( _T("Helper PSN_KILLACTIVE\n") );
-				/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Helper */
+				/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Helper */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_HELPER;
 				return TRUE;
@@ -212,7 +212,7 @@ INT_PTR CPropHelper::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -222,12 +222,12 @@ INT_PTR CPropHelper::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.12.22 End
 
 	case WM_DESTROY:
-		// ƒL[ƒ[ƒhƒwƒ‹ƒv ƒtƒHƒ“ƒg”jŠü	// 2013/4/24 Uchi
+		// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ— ãƒ•ã‚©ãƒ³ãƒˆç ´æ£„	// 2013/4/24 Uchi
 		if (m_hKeywordHelpFont != NULL) {
 			::DeleteObject( m_hKeywordHelpFont );
 			m_hKeywordHelpFont = NULL;
@@ -237,24 +237,24 @@ INT_PTR CPropHelper::DispatchEvent(
 	return FALSE;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Helper */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Helper */
 void CPropHelper::SetData( HWND hwndDlg )
 {
-	/* •âŠ®Œó•âŒˆ’èƒL[ */
-	::CheckDlgButton( hwndDlg, IDC_CHECK_m_bHokanKey_RETURN, m_Common.m_sHelper.m_bHokanKey_RETURN );	//VK_RETURN •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø
-	::CheckDlgButton( hwndDlg, IDC_CHECK_m_bHokanKey_TAB, m_Common.m_sHelper.m_bHokanKey_TAB );		//VK_TAB    •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø
-	::CheckDlgButton( hwndDlg, IDC_CHECK_m_bHokanKey_RIGHT, m_Common.m_sHelper.m_bHokanKey_RIGHT );	//VK_RIGHT  •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø
+	/* è£œå®Œå€™è£œæ±ºå®šã‚­ãƒ¼ */
+	::CheckDlgButton( hwndDlg, IDC_CHECK_m_bHokanKey_RETURN, m_Common.m_sHelper.m_bHokanKey_RETURN );	//VK_RETURN è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹
+	::CheckDlgButton( hwndDlg, IDC_CHECK_m_bHokanKey_TAB, m_Common.m_sHelper.m_bHokanKey_TAB );		//VK_TAB    è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹
+	::CheckDlgButton( hwndDlg, IDC_CHECK_m_bHokanKey_RIGHT, m_Common.m_sHelper.m_bHokanKey_RIGHT );	//VK_RIGHT  è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹
 
-	/* ŠO•”ƒwƒ‹ƒv‚P */
+	/* å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘ */
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_EXTHELP1, m_Common.m_sHelper.m_szExtHelp );
 
-	/* ŠO•”HTMLƒwƒ‹ƒv */
+	/* å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ— */
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_EXTHTMLHELP, m_Common.m_sHelper.m_szExtHtmlHelp );
 
-	/* HtmlHelpƒrƒ…[ƒA‚Í‚Ğ‚Æ‚Â */
+	/* HtmlHelpãƒ“ãƒ¥ãƒ¼ã‚¢ã¯ã²ã¨ã¤ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_HTMLHELPISSINGLE, m_Common.m_sHelper.m_bHtmlHelpIsSingle ? BST_CHECKED : BST_UNCHECKED );
 
-	// ƒL[ƒ[ƒhƒwƒ‹ƒv ƒtƒHƒ“ƒg	// 2013/4/24 Uchi
+	// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ— ãƒ•ã‚©ãƒ³ãƒˆ	// 2013/4/24 Uchi
 	m_hKeywordHelpFont = SetFontLabel( hwndDlg, IDC_STATIC_KEYWORDHELPFONT, m_Common.m_sHelper.m_lf, m_Common.m_sHelper.m_nPointSize);
 
 	//migemo dict
@@ -263,21 +263,21 @@ void CPropHelper::SetData( HWND hwndDlg )
 }
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Helper */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Helper */
 int CPropHelper::GetData( HWND hwndDlg )
 {
-	/* •âŠ®Œó•âŒˆ’èƒL[ */
-	m_Common.m_sHelper.m_bHokanKey_RETURN = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_m_bHokanKey_RETURN );//VK_RETURN •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø
-	m_Common.m_sHelper.m_bHokanKey_TAB = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_m_bHokanKey_TAB );		//VK_TAB    •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø
-	m_Common.m_sHelper.m_bHokanKey_RIGHT = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_m_bHokanKey_RIGHT );	//VK_RIGHT  •âŠ®Œˆ’èƒL[‚ª—LŒø/–³Œø
+	/* è£œå®Œå€™è£œæ±ºå®šã‚­ãƒ¼ */
+	m_Common.m_sHelper.m_bHokanKey_RETURN = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_m_bHokanKey_RETURN );//VK_RETURN è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹
+	m_Common.m_sHelper.m_bHokanKey_TAB = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_m_bHokanKey_TAB );		//VK_TAB    è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹
+	m_Common.m_sHelper.m_bHokanKey_RIGHT = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_m_bHokanKey_RIGHT );	//VK_RIGHT  è£œå®Œæ±ºå®šã‚­ãƒ¼ãŒæœ‰åŠ¹/ç„¡åŠ¹
 
-	/* ŠO•”ƒwƒ‹ƒv‚P */
+	/* å¤–éƒ¨ãƒ˜ãƒ«ãƒ—ï¼‘ */
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHELP1, m_Common.m_sHelper.m_szExtHelp, _countof( m_Common.m_sHelper.m_szExtHelp ));
 
-	/* ŠO•”HTMLƒwƒ‹ƒv */
+	/* å¤–éƒ¨HTMLãƒ˜ãƒ«ãƒ— */
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHTMLHELP, m_Common.m_sHelper.m_szExtHtmlHelp, _countof( m_Common.m_sHelper.m_szExtHtmlHelp ));
 
-	/* HtmlHelpƒrƒ…[ƒA‚Í‚Ğ‚Æ‚Â */
+	/* HtmlHelpãƒ“ãƒ¥ãƒ¼ã‚¢ã¯ã²ã¨ã¤ */
 	m_Common.m_sHelper.m_bHtmlHelpIsSingle = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_HTMLHELPISSINGLE ) != 0;
 
 	//migemo dict

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAuƒL[ƒoƒCƒ“ƒhvƒy[ƒW
+ï»¿/*!	@file
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œã‚­ãƒ¼ãƒã‚¤ãƒ³ãƒ‰ã€ãƒšãƒ¼ã‚¸
 
 	@author Norio Nakatani
 */
@@ -31,18 +31,18 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//10700
-	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT_KEYBIND,		//ƒCƒ“ƒ|[ƒg
-	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT_KEYBIND,		//ƒGƒNƒXƒ|[ƒg
-	IDC_BUTTON_ASSIGN,				HIDC_BUTTON_ASSIGN,				//ƒL[Š„‚è“–‚Ä
-	IDC_BUTTON_RELEASE,				HIDC_BUTTON_RELEASE,			//ƒL[‰ğœ
-	IDC_CHECK_SHIFT,				HIDC_CHECK_SHIFT,				//ShiftƒL[
-	IDC_CHECK_CTRL,					HIDC_CHECK_CTRL,				//CtrlƒL[
-	IDC_CHECK_ALT,					HIDC_CHECK_ALT,					//AltƒL[
-	IDC_COMBO_FUNCKIND,				HIDC_COMBO_FUNCKIND_KEYBIND,	//‹@”\‚Ìí•Ê
-	IDC_EDIT_KEYSFUNC,				HIDC_EDIT_KEYSFUNC,				//ƒL[‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚é‹@”\
-	IDC_LIST_FUNC,					HIDC_LIST_FUNC_KEYBIND,			//‹@”\ˆê——
-	IDC_LIST_KEY,					HIDC_LIST_KEY,					//ƒL[ˆê——
-	IDC_LIST_ASSIGNEDKEYS,			HIDC_LIST_ASSIGNEDKEYS,			//‹@”\‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚éƒL[
+	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT_KEYBIND,		//ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT_KEYBIND,		//ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
+	IDC_BUTTON_ASSIGN,				HIDC_BUTTON_ASSIGN,				//ã‚­ãƒ¼å‰²ã‚Šå½“ã¦
+	IDC_BUTTON_RELEASE,				HIDC_BUTTON_RELEASE,			//ã‚­ãƒ¼è§£é™¤
+	IDC_CHECK_SHIFT,				HIDC_CHECK_SHIFT,				//Shiftã‚­ãƒ¼
+	IDC_CHECK_CTRL,					HIDC_CHECK_CTRL,				//Ctrlã‚­ãƒ¼
+	IDC_CHECK_ALT,					HIDC_CHECK_ALT,					//Altã‚­ãƒ¼
+	IDC_COMBO_FUNCKIND,				HIDC_COMBO_FUNCKIND_KEYBIND,	//æ©Ÿèƒ½ã®ç¨®åˆ¥
+	IDC_EDIT_KEYSFUNC,				HIDC_EDIT_KEYSFUNC,				//ã‚­ãƒ¼ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ã‚‹æ©Ÿèƒ½
+	IDC_LIST_FUNC,					HIDC_LIST_FUNC_KEYBIND,			//æ©Ÿèƒ½ä¸€è¦§
+	IDC_LIST_KEY,					HIDC_LIST_KEY,					//ã‚­ãƒ¼ä¸€è¦§
+	IDC_LIST_ASSIGNEDKEYS,			HIDC_LIST_ASSIGNEDKEYS,			//æ©Ÿèƒ½ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ã‚‹ã‚­ãƒ¼
 	IDC_LABEL_MENUFUNCKIND,			(DWORD)-1,
 	IDC_LABEL_MENUFUNC,				(DWORD)-1,
 	IDC_LABEL_KEYKIND,				(DWORD)-1,
@@ -55,10 +55,10 @@ static const DWORD p_helpids[] = {	//10700
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropKeybind::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -67,14 +67,14 @@ INT_PTR CALLBACK CPropKeybind::DlgProc_page(
 }
 //	To Here Jun. 2, 2001 genta
 
-/* From Here Oct. 13, 2000 Studio C‚ÅMr.ƒR[ƒq[‚É‹³‚í‚Á‚½‚â‚è•û‚Å‚·‚ª‚¤‚Ü‚­‚¢‚Á‚Ä‚Ü‚¹‚ñ */
-// ƒEƒBƒ“ƒhƒEƒvƒƒV[ƒWƒƒ‚Ì’†‚ÅEEE
+/* From Here Oct. 13, 2000 Studio Cã§Mr.ã‚³ãƒ¼ãƒ’ãƒ¼æ°ã«æ•™ã‚ã£ãŸã‚„ã‚Šæ–¹ã§ã™ãŒã†ã¾ãã„ã£ã¦ã¾ã›ã‚“ */
+// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ã®ä¸­ã§ãƒ»ãƒ»ãƒ»
 LRESULT CALLBACK CPropComKeybindWndProc( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	switch( uMsg ) {
-	// WM_CTLCOLORSTATIC ƒƒbƒZ[ƒW‚É‘Î‚µ‚Ä
+	// WM_CTLCOLORSTATIC ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã«å¯¾ã—ã¦
 	case WM_CTLCOLORSTATIC:
-	// ”’F‚Ìƒuƒ‰ƒVƒnƒ“ƒhƒ‹‚ğ•Ô‚·
+	// ç™½è‰²ã®ãƒ–ãƒ©ã‚·ãƒãƒ³ãƒ‰ãƒ«ã‚’è¿”ã™
 		return (LRESULT)GetStockObject(WHITE_BRUSH);
 //	default:
 //		break;
@@ -89,7 +89,7 @@ LRESULT CALLBACK CPropComKeybindWndProc( HWND hwndDlg, UINT uMsg, WPARAM wParam,
 
 
 
-/* Keybind ƒƒbƒZ[ƒWˆ— */
+/* Keybind ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropKeybind::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
 	UINT	uMsg,	// message
@@ -123,12 +123,12 @@ INT_PTR CPropKeybind::DispatchEvent(
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Keybind */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Keybind */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒRƒ“ƒgƒ[ƒ‹‚Ìƒnƒ“ƒhƒ‹‚ğæ“¾ */
+		/* ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®ãƒãƒ³ãƒ‰ãƒ«ã‚’å–å¾— */
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_FUNCKIND );
 		hwndFuncList = ::GetDlgItem( hwndDlg, IDC_LIST_FUNC );
 		hwndAssignedkeyList = ::GetDlgItem( hwndDlg, IDC_LIST_ASSIGNEDKEYS );
@@ -139,11 +139,11 @@ INT_PTR CPropKeybind::DispatchEvent(
 //		hwndLIST_KEYSFUNC = ::GetDlgItem( hwndDlg, IDC_LIST_KEYSFUNC );
 		hwndEDIT_KEYSFUNC = ::GetDlgItem( hwndDlg, IDC_EDIT_KEYSFUNC );
 
-		/* ƒL[‘I‘ğ‚Ìˆ— */
-//	From Here Oct. 14, 2000 JEPRO ‚í‚©‚è‚É‚­‚¢‚Ì‚Å‘I‘ğ‚µ‚È‚¢‚æ‚¤‚É•ÏX	//Oct. 17, 2000 JEPRO •œŠˆI
-//	/* ƒL[ƒŠƒXƒg‚Ìæ“ª‚Ì€–Ú‚ğ‘I‘ğiƒŠƒXƒgƒ{ƒbƒNƒXj*/
-		List_SetCurSel( hwndKeyList, 0 );	//Oct. 14, 2000 JEPRO ‚±‚±‚ğƒRƒƒ“ƒgƒAƒEƒg‚·‚é‚Ææ“ª€–Ú‚ª‘I‘ğ‚³‚ê‚È‚­‚È‚é
-		::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_KEY, LBN_SELCHANGE ), (LPARAM)hwndKeyList );	//Oct. 14, 2000 JEPRO ‚±‚±‚Í‚Ç‚Á‚¿‚Å‚à‚¢‚¢H(‚í‚©‚ç‚ñ)
+		/* ã‚­ãƒ¼é¸æŠæ™‚ã®å‡¦ç† */
+//	From Here Oct. 14, 2000 JEPRO ã‚ã‹ã‚Šã«ãã„ã®ã§é¸æŠã—ãªã„ã‚ˆã†ã«å¤‰æ›´	//Oct. 17, 2000 JEPRO å¾©æ´»ï¼
+//	/* ã‚­ãƒ¼ãƒªã‚¹ãƒˆã®å…ˆé ­ã®é …ç›®ã‚’é¸æŠï¼ˆãƒªã‚¹ãƒˆãƒœãƒƒã‚¯ã‚¹ï¼‰*/
+		List_SetCurSel( hwndKeyList, 0 );	//Oct. 14, 2000 JEPRO ã“ã“ã‚’ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã™ã‚‹ã¨å…ˆé ­é …ç›®ãŒé¸æŠã•ã‚Œãªããªã‚‹
+		::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_KEY, LBN_SELCHANGE ), (LPARAM)hwndKeyList );	//Oct. 14, 2000 JEPRO ã“ã“ã¯ã©ã£ã¡ã§ã‚‚ã„ã„ï¼Ÿ(ã‚ã‹ã‚‰ã‚“)
 //	To Here Oct. 14, 2000
 		::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_COMBO_FUNCKIND, CBN_SELCHANGE ), (LPARAM)hwndCombo );
 
@@ -155,19 +155,19 @@ INT_PTR CPropKeybind::DispatchEvent(
 		pNMHDR = (NMHDR*)lParam;
 		switch( pNMHDR->code ){
 		case PSN_HELP:
-//			OnHelp( hwndDlg, IDD_PROP1P5 );		// Sept. 9, 2000 JEPRO ÀÛ‚ÌID–¼‚É•ÏX
+//			OnHelp( hwndDlg, IDD_PROP1P5 );		// Sept. 9, 2000 JEPRO å®Ÿéš›ã®IDåã«å¤‰æ›´
 			OnHelp( hwndDlg, IDD_PROP_KEYBIND );
 			return TRUE;
 		case PSN_KILLACTIVE:
 //			MYTRACE( _T("Keybind PSN_KILLACTIVE\n") );
-			/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Keybind */
+			/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Keybind */
 			GetData( hwndDlg );
 			return TRUE;
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPCOM_PAGENUM_KEYBOARD;
 
-			// •\¦‚ğXV‚·‚éiƒ}ƒNƒİ’è‰æ–Ê‚Å‚Ìƒ}ƒNƒ–¼•ÏX‚ğ”½‰fj	// 2007.11.02 ryoji
+			// è¡¨ç¤ºã‚’æ›´æ–°ã™ã‚‹ï¼ˆãƒã‚¯ãƒ­è¨­å®šç”»é¢ã§ã®ãƒã‚¯ãƒ­åå¤‰æ›´ã‚’åæ˜ ï¼‰	// 2007.11.02 ryoji
 			nIndex = List_GetCurSel( hwndKeyList );
 			nIndex2 = Combo_GetCurSel( hwndCombo );
 			nIndex3 = List_GetCurSel( hwndFuncList );
@@ -185,23 +185,23 @@ INT_PTR CPropKeybind::DispatchEvent(
 		break;
 
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID = LOWORD(wParam);	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
-		hwndCtl = (HWND) lParam;	/* ƒRƒ“ƒgƒ[ƒ‹‚Ìƒnƒ“ƒhƒ‹ */
+		wNotifyCode = HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID = LOWORD(wParam);	/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
+		hwndCtl = (HWND) lParam;	/* ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®ãƒãƒ³ãƒ‰ãƒ« */
 
 		switch( wNotifyCode ){
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 			switch( wID ){
-			case IDC_BUTTON_IMPORT:	/* ƒCƒ“ƒ|[ƒg */
-				/* Keybind:ƒL[Š„‚è“–‚Äİ’è‚ğƒCƒ“ƒ|[ƒg‚·‚é */
+			case IDC_BUTTON_IMPORT:	/* ã‚¤ãƒ³ãƒãƒ¼ãƒˆ */
+				/* Keybind:ã‚­ãƒ¼å‰²ã‚Šå½“ã¦è¨­å®šã‚’ã‚¤ãƒ³ãƒãƒ¼ãƒˆã™ã‚‹ */
 				Import( hwndDlg );
 				return TRUE;
-			case IDC_BUTTON_EXPORT:	/* ƒGƒNƒXƒ|[ƒg */
-				/* Keybind:ƒL[Š„‚è“–‚Äİ’è‚ğƒGƒNƒXƒ|[ƒg‚·‚é */
+			case IDC_BUTTON_EXPORT:	/* ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ */
+				/* Keybind:ã‚­ãƒ¼å‰²ã‚Šå½“ã¦è¨­å®šã‚’ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã™ã‚‹ */
 				Export( hwndDlg );
 				return TRUE;
-			case IDC_BUTTON_ASSIGN:	/* Š„•t */
+			case IDC_BUTTON_ASSIGN:	/* å‰²ä»˜ */
 				nIndex = List_GetCurSel( hwndKeyList );
 				nIndex2 = Combo_GetCurSel( hwndCombo );
 				nIndex3 = List_GetCurSel( hwndFuncList );
@@ -223,7 +223,7 @@ INT_PTR CPropKeybind::DispatchEvent(
 				::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_KEY, LBN_SELCHANGE ), (LPARAM)hwndKeyList );
 				::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_FUNC, LBN_SELCHANGE ), (LPARAM)hwndFuncList );
 				return TRUE;
-			case IDC_BUTTON_RELEASE:	/* ‰ğœ */
+			case IDC_BUTTON_RELEASE:	/* è§£é™¤ */
 				nIndex = List_GetCurSel( hwndKeyList );
 				if( nIndex == LB_ERR ){
 					return TRUE;
@@ -273,7 +273,7 @@ INT_PTR CPropKeybind::DispatchEvent(
 				}
 				nFuncCode = m_Common.m_sKeyBind.m_pKeyNameArr[nIndex].m_nFuncCodeArr[i];
 				// Oct. 2, 2001 genta
-				// 2007.11.02 ryoji F_DISABLE‚È‚ç–¢Š„•t
+				// 2007.11.02 ryoji F_DISABLEãªã‚‰æœªå‰²ä»˜
 				if( nFuncCode == F_DISABLE ){
 					auto_strncpy( pszLabel, LSW(STR_PROPCOMKEYBIND_UNASSIGN), _countof(pszLabel) - 1 );
 					pszLabel[_countof(pszLabel) - 1] = L'\0';
@@ -291,18 +291,18 @@ INT_PTR CPropKeybind::DispatchEvent(
 				nIndex2 = Combo_GetCurSel( hwndCombo );
 				nIndex3 = List_GetCurSel( hwndFuncList );
 				nFuncCode = m_cLookup.Pos2FuncCode( nIndex2, nIndex3 );	// Oct. 2, 2001 genta
-				/* ‹@”\‚É‘Î‰‚·‚éƒL[–¼‚Ìæ“¾(•¡”) */
+				/* æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼åã®å–å¾—(è¤‡æ•°) */
 				CNativeT**	ppcAssignedKeyList;
-				nAssignedKeyNum = CKeyBind::GetKeyStrList(	/* ‹@”\‚É‘Î‰‚·‚éƒL[–¼‚Ìæ“¾(•¡”) */
+				nAssignedKeyNum = CKeyBind::GetKeyStrList(	/* æ©Ÿèƒ½ã«å¯¾å¿œã™ã‚‹ã‚­ãƒ¼åã®å–å¾—(è¤‡æ•°) */
 					G_AppInstance(), m_Common.m_sKeyBind.m_nKeyNameArrNum, (KEYDATA*)m_Common.m_sKeyBind.m_pKeyNameArr,
 					&ppcAssignedKeyList, nFuncCode,
-					FALSE	// 2007.02.22 ryoji ƒfƒtƒHƒ‹ƒg‹@”\‚Íæ“¾‚µ‚È‚¢
+					FALSE	// 2007.02.22 ryoji ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ©Ÿèƒ½ã¯å–å¾—ã—ãªã„
 				);	
-				/* Š„‚è“–‚ÄƒL[ƒŠƒXƒg‚ğƒNƒŠƒA‚µ‚Ä’l‚Ìİ’è */
+				/* å‰²ã‚Šå½“ã¦ã‚­ãƒ¼ãƒªã‚¹ãƒˆã‚’ã‚¯ãƒªã‚¢ã—ã¦å€¤ã®è¨­å®š */
 				List_ResetContent( hwndAssignedkeyList );
 				if( 0 < nAssignedKeyNum){
 					for( j = 0; j < nAssignedKeyNum; ++j ){
-						/* ƒfƒoƒbƒOƒ‚ƒjƒ^‚Éo—Í */
+						/* ãƒ‡ãƒãƒƒã‚°ãƒ¢ãƒ‹ã‚¿ã«å‡ºåŠ› */
 						const TCHAR* cpszString = ppcAssignedKeyList[j]->GetStringPtr();
 						::List_AddString( hwndAssignedkeyList, cpszString );
 						delete ppcAssignedKeyList[j];
@@ -316,7 +316,7 @@ INT_PTR CPropKeybind::DispatchEvent(
 			switch( wNotifyCode ){
 			case CBN_SELCHANGE:
 				nIndex2 = Combo_GetCurSel( hwndCombo );
-				/* ‹@”\ˆê——‚É•¶š—ñ‚ğƒZƒbƒgiƒŠƒXƒgƒ{ƒbƒNƒXj*/
+				/* æ©Ÿèƒ½ä¸€è¦§ã«æ–‡å­—åˆ—ã‚’ã‚»ãƒƒãƒˆï¼ˆãƒªã‚¹ãƒˆãƒœãƒƒã‚¯ã‚¹ï¼‰*/
 				m_cLookup.SetListItem( hwndFuncList, nIndex2 );	//	Oct. 2, 2001 genta
 				return TRUE;
 			}
@@ -358,15 +358,15 @@ INT_PTR CPropKeybind::DispatchEvent(
 							if( _tcscmp(m_Common.m_sKeyBind.m_pKeyNameArr[j].m_szKeyName, p) == 0 )
 							{
 								List_SetCurSel( hwndKeyList, j);
-								if( i & _SHIFT ) ::CheckDlgButton( hwndDlg, IDC_CHECK_SHIFT, BST_CHECKED );  //ƒ`ƒFƒbƒN
-								else             ::CheckDlgButton( hwndDlg, IDC_CHECK_SHIFT, BST_UNCHECKED );  //ƒ`ƒFƒbƒN‚ğ‚Í‚¸‚·
-								if( i & _CTRL )  ::CheckDlgButton( hwndDlg, IDC_CHECK_CTRL,  BST_CHECKED );  //ƒ`ƒFƒbƒN
-								else             ::CheckDlgButton( hwndDlg, IDC_CHECK_CTRL,  BST_UNCHECKED );  //ƒ`ƒFƒbƒN‚ğ‚Í‚¸‚·
-								if( i & _ALT )   ::CheckDlgButton( hwndDlg, IDC_CHECK_ALT,   BST_CHECKED );  //ƒ`ƒFƒbƒN
-								else             ::CheckDlgButton( hwndDlg, IDC_CHECK_ALT,   BST_UNCHECKED );  //ƒ`ƒFƒbƒN‚ğ‚Í‚¸‚·
+								if( i & _SHIFT ) ::CheckDlgButton( hwndDlg, IDC_CHECK_SHIFT, BST_CHECKED );  //ãƒã‚§ãƒƒã‚¯
+								else             ::CheckDlgButton( hwndDlg, IDC_CHECK_SHIFT, BST_UNCHECKED );  //ãƒã‚§ãƒƒã‚¯ã‚’ã¯ãšã™
+								if( i & _CTRL )  ::CheckDlgButton( hwndDlg, IDC_CHECK_CTRL,  BST_CHECKED );  //ãƒã‚§ãƒƒã‚¯
+								else             ::CheckDlgButton( hwndDlg, IDC_CHECK_CTRL,  BST_UNCHECKED );  //ãƒã‚§ãƒƒã‚¯ã‚’ã¯ãšã™
+								if( i & _ALT )   ::CheckDlgButton( hwndDlg, IDC_CHECK_ALT,   BST_CHECKED );  //ãƒã‚§ãƒƒã‚¯
+								else             ::CheckDlgButton( hwndDlg, IDC_CHECK_ALT,   BST_UNCHECKED );  //ãƒã‚§ãƒƒã‚¯ã‚’ã¯ãšã™
 								::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_KEY, LBN_SELCHANGE ), (LPARAM)hwndKeyList );
 
-								// ƒL[ˆê——‚Ì•¶š—ñ‚à•ÏX
+								// ã‚­ãƒ¼ä¸€è¦§ã®æ–‡å­—åˆ—ã‚‚å¤‰æ›´
 								ChangeKeyList( hwndDlg );
 								break;
 							}
@@ -381,7 +381,7 @@ INT_PTR CPropKeybind::DispatchEvent(
 		break;
 
 	case WM_TIMER:
-		// ƒ{ƒ^ƒ“‚Ì—LŒø^–³Œø‚ğØ‚è‘Ö‚¦‚é	// 2007.11.02 ryoji
+		// ãƒœã‚¿ãƒ³ã®æœ‰åŠ¹ï¼ç„¡åŠ¹ã‚’åˆ‡ã‚Šæ›¿ãˆã‚‹	// 2007.11.02 ryoji
 		nIndex = List_GetCurSel( hwndKeyList );
 		nIndex2 = Combo_GetCurSel( hwndCombo );
 		nIndex3 = List_GetCurSel( hwndFuncList );
@@ -397,7 +397,7 @@ INT_PTR CPropKeybind::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -407,7 +407,7 @@ INT_PTR CPropKeybind::DispatchEvent(
 //@@@ 2001.11.07 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.11.07 End
 
@@ -421,21 +421,21 @@ INT_PTR CPropKeybind::DispatchEvent(
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Keybind */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Keybind */
 void CPropKeybind::SetData( HWND hwndDlg )
 {
 	HWND		hwndCombo;
 	HWND		hwndKeyList;
 	int			i;
 
-	/* ‹@”\í•Êˆê——‚É•¶š—ñ‚ğƒZƒbƒgiƒRƒ“ƒ{ƒ{ƒbƒNƒXj*/
+	/* æ©Ÿèƒ½ç¨®åˆ¥ä¸€è¦§ã«æ–‡å­—åˆ—ã‚’ã‚»ãƒƒãƒˆï¼ˆã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ï¼‰*/
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_FUNCKIND );
 	m_cLookup.SetCategory2Combo( hwndCombo );	//	Oct. 2, 2001 genta
 
-	/* í•Ê‚Ìæ“ª‚Ì€–Ú‚ğ‘I‘ğiƒRƒ“ƒ{ƒ{ƒbƒNƒXj*/
-	Combo_SetCurSel( hwndCombo, 0 );	//Oct. 14, 2000 JEPRO JEPRO u--–¢’è‹`--v‚ğ•\¦‚³‚¹‚È‚¢‚æ‚¤‚É‘åŒ³ Funcode.cpp ‚Å•ÏX‚µ‚Ä‚ ‚é
+	/* ç¨®åˆ¥ã®å…ˆé ­ã®é …ç›®ã‚’é¸æŠï¼ˆã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ï¼‰*/
+	Combo_SetCurSel( hwndCombo, 0 );	//Oct. 14, 2000 JEPRO JEPRO ã€Œ--æœªå®šç¾©--ã€ã‚’è¡¨ç¤ºã•ã›ãªã„ã‚ˆã†ã«å¤§å…ƒ Funcode.cpp ã§å¤‰æ›´ã—ã¦ã‚ã‚‹
 
-	/* ƒL[ˆê——‚É•¶š—ñ‚ğƒZƒbƒgiƒŠƒXƒgƒ{ƒbƒNƒXj*/
+	/* ã‚­ãƒ¼ä¸€è¦§ã«æ–‡å­—åˆ—ã‚’ã‚»ãƒƒãƒˆï¼ˆãƒªã‚¹ãƒˆãƒœãƒƒã‚¯ã‚¹ï¼‰*/
 	hwndKeyList = ::GetDlgItem( hwndDlg, IDC_LIST_KEY );
 	for( i = 0; i < m_Common.m_sKeyBind.m_nKeyNameArrNum; ++i ){
 		::List_AddString( hwndKeyList, m_Common.m_sKeyBind.m_pKeyNameArr[i].m_szKeyName );
@@ -446,13 +446,13 @@ void CPropKeybind::SetData( HWND hwndDlg )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Keybind */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Keybind */
 int CPropKeybind::GetData( HWND hwndDlg )
 {
 	return TRUE;
 }
 	
-/*! Keybind: ƒL[ƒŠƒXƒg‚ğƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚Ìó‘Ô‚É‡‚í‚¹‚ÄXV‚·‚é */
+/*! Keybind: ã‚­ãƒ¼ãƒªã‚¹ãƒˆã‚’ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã®çŠ¶æ…‹ã«åˆã‚ã›ã¦æ›´æ–°ã™ã‚‹ */
 void CPropKeybind::ChangeKeyList( HWND hwndDlg){
 	HWND	hwndKeyList;
 	int 	nIndex;
@@ -477,7 +477,7 @@ void CPropKeybind::ChangeKeyList( HWND hwndDlg){
 		i |= _ALT;
 		wcscat( szKeyState, L"Alt+" );
 	}
-	/* ƒL[ˆê——‚É•¶š—ñ‚ğƒZƒbƒgiƒŠƒXƒgƒ{ƒbƒNƒXj*/
+	/* ã‚­ãƒ¼ä¸€è¦§ã«æ–‡å­—åˆ—ã‚’ã‚»ãƒƒãƒˆï¼ˆãƒªã‚¹ãƒˆãƒœãƒƒã‚¯ã‚¹ï¼‰*/
 	List_ResetContent( hwndKeyList );
 	for( i = 0; i < m_Common.m_sKeyBind.m_nKeyNameArrNum; ++i ){
 		TCHAR	pszLabel[256];
@@ -489,21 +489,21 @@ void CPropKeybind::ChangeKeyList( HWND hwndDlg){
 	::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_KEY, LBN_SELCHANGE ), (LPARAM)hwndKeyList );
 }
 
-/* Keybind:ƒL[Š„‚è“–‚Äİ’è‚ğƒCƒ“ƒ|[ƒg‚·‚é */
+/* Keybind:ã‚­ãƒ¼å‰²ã‚Šå½“ã¦è¨­å®šã‚’ã‚¤ãƒ³ãƒãƒ¼ãƒˆã™ã‚‹ */
 void CPropKeybind::Import( HWND hwndDlg )
 {
 	CImpExpKeybind	cImpExpKeybind( m_Common );
 
-	// ƒCƒ“ƒ|[ƒg
+	// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 	if (!cImpExpKeybind.ImportUI( G_AppInstance(), hwndDlg )) {
-		// ƒCƒ“ƒ|[ƒg‚ğ‚µ‚Ä‚¢‚È‚¢
+		// ã‚¤ãƒ³ãƒãƒ¼ãƒˆã‚’ã—ã¦ã„ãªã„
 		return;
 	}
 
-	// ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Keybind
-	// 2012.11.18 aroka ƒL[ˆê——‚ÌXV‚Í‘SƒAƒCƒeƒ€‚ğXV‚·‚éB
+	// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Keybind
+	// 2012.11.18 aroka ã‚­ãƒ¼ä¸€è¦§ã®æ›´æ–°ã¯å…¨ã‚¢ã‚¤ãƒ†ãƒ ã‚’æ›´æ–°ã™ã‚‹ã€‚
 	ChangeKeyList( hwndDlg );
-	//@@@ 2001.11.07 modify start MIK: ‹@”\‚ÉŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚éƒL[‚ğXV‚·‚éB// 2012.11.18 aroka ƒRƒƒ“ƒgC³
+	//@@@ 2001.11.07 modify start MIK: æ©Ÿèƒ½ã«å‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ã‚‹ã‚­ãƒ¼ã‚’æ›´æ–°ã™ã‚‹ã€‚// 2012.11.18 aroka ã‚³ãƒ¡ãƒ³ãƒˆä¿®æ­£
 	HWND			hwndCtrl;
 	hwndCtrl = ::GetDlgItem( hwndDlg, IDC_LIST_FUNC );
 	::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_FUNC, LBN_SELCHANGE ), (LPARAM)hwndCtrl );
@@ -511,14 +511,14 @@ void CPropKeybind::Import( HWND hwndDlg )
 }
 
 
-/* Keybind:ƒL[Š„‚è“–‚Äİ’è‚ğƒGƒNƒXƒ|[ƒg‚·‚é */
+/* Keybind:ã‚­ãƒ¼å‰²ã‚Šå½“ã¦è¨­å®šã‚’ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã™ã‚‹ */
 void CPropKeybind::Export( HWND hwndDlg )
 {
 	CImpExpKeybind	cImpExpKeybind( m_Common );
 
-	// ƒGƒNƒXƒ|[ƒg
+	// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 	if (!cImpExpKeybind.ExportUI( G_AppInstance(), hwndDlg )) {
-		// ƒGƒNƒXƒ|[ƒg‚ğ‚µ‚Ä‚¢‚È‚¢
+		// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã‚’ã—ã¦ã„ãªã„
 		return;
 	}
 }

--- a/sakura_core/prop/CPropComKeyword.cpp
+++ b/sakura_core/prop/CPropComKeyword.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ���ʐݒ�_�C�A���O�{�b�N�X�A�u�����L�[���[�h�v�y�[�W
+﻿/*!	@file
+	@brief 共通設定ダイアログボックス、「強調キーワード」ページ
 
 	@author Norio Nakatani
 */
@@ -32,18 +32,18 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//10800
-	IDC_BUTTON_ADDSET,				HIDC_BUTTON_ADDSET,			//�L�[���[�h�Z�b�g�ǉ�
-	IDC_BUTTON_DELSET,				HIDC_BUTTON_DELSET,			//�L�[���[�h�Z�b�g�폜
-	IDC_BUTTON_ADDKEYWORD,			HIDC_BUTTON_ADDKEYWORD,		//�L�[���[�h�ǉ�
-	IDC_BUTTON_EDITKEYWORD,			HIDC_BUTTON_EDITKEYWORD,	//�L�[���[�h�ҏW
-	IDC_BUTTON_DELKEYWORD,			HIDC_BUTTON_DELKEYWORD,		//�L�[���[�h�폜
-	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT_KEYWORD,	//�C���|�[�g
-	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT_KEYWORD,	//�G�N�X�|�[�g
-	IDC_CHECK_KEYWORDCASE,			HIDC_CHECK_KEYWORDCASE,		//�L�[���[�h�̉p�啶�����������
-	IDC_COMBO_SET,					HIDC_COMBO_SET,				//�����L�[���[�h�Z�b�g��
-	IDC_LIST_KEYWORD,				HIDC_LIST_KEYWORD,			//�L�[���[�h�ꗗ
-	IDC_BUTTON_KEYCLEAN		,		HIDC_BUTTON_KEYCLEAN,		//�L�[���[�h����	// 2006.08.06 ryoji
-	IDC_BUTTON_KEYSETRENAME,		HIDC_BUTTON_KEYSETRENAME,	//�Z�b�g�̖��̕ύX	// 2006.08.06 ryoji
+	IDC_BUTTON_ADDSET,				HIDC_BUTTON_ADDSET,			//キーワードセット追加
+	IDC_BUTTON_DELSET,				HIDC_BUTTON_DELSET,			//キーワードセット削除
+	IDC_BUTTON_ADDKEYWORD,			HIDC_BUTTON_ADDKEYWORD,		//キーワード追加
+	IDC_BUTTON_EDITKEYWORD,			HIDC_BUTTON_EDITKEYWORD,	//キーワード編集
+	IDC_BUTTON_DELKEYWORD,			HIDC_BUTTON_DELKEYWORD,		//キーワード削除
+	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT_KEYWORD,	//インポート
+	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT_KEYWORD,	//エクスポート
+	IDC_CHECK_KEYWORDCASE,			HIDC_CHECK_KEYWORDCASE,		//キーワードの英大文字小文字区別
+	IDC_COMBO_SET,					HIDC_COMBO_SET,				//強調キーワードセット名
+	IDC_LIST_KEYWORD,				HIDC_LIST_KEYWORD,			//キーワード一覧
+	IDC_BUTTON_KEYCLEAN		,		HIDC_BUTTON_KEYCLEAN,		//キーワード整理	// 2006.08.06 ryoji
+	IDC_BUTTON_KEYSETRENAME,		HIDC_BUTTON_KEYSETRENAME,	//セットの名称変更	// 2006.08.06 ryoji
 //	IDC_STATIC,						-1,
 	0, 0
 };
@@ -51,10 +51,10 @@ static const DWORD p_helpids[] = {	//10800
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg �_�C�A���O�{�b�N�X��Window Handle
-	@param uMsg ���b�Z�[�W
-	@param wParam �p�����[�^1
-	@param lParam �p�����[�^2
+	@param hwndDlg ダイアログボックスのWindow Handle
+	@param uMsg メッセージ
+	@param wParam パラメータ1
+	@param lParam パラメータ2
 */
 INT_PTR CALLBACK CPropKeyword::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -68,7 +68,7 @@ INT_PTR CALLBACK CPropKeyword::DlgProc_dialog(
 	return DlgProc2( reinterpret_cast<pDispatchPage>(&CPropKeyword::DispatchEvent), hwndDlg, uMsg, wParam, lParam );
 }
 
-/* Keyword ���b�Z�[�W���� */
+/* Keyword メッセージ処理 */
 INT_PTR CPropKeyword::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
 	UINT	uMsg,		// message
@@ -94,22 +94,22 @@ INT_PTR CPropKeyword::DispatchEvent(
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* �_�C�A���O�f�[�^�̐ݒ� Keyword */
-		if( wParam == IDOK ){ // �Ɨ��E�B���h�E
+		/* ダイアログデータの設定 Keyword */
+		if( wParam == IDOK ){ // 独立ウィンドウ
 			if( 0 <= m_nKeywordSet1 ){
-				// �^�C�v�ʐݒ�̂��̂�\��
+				// タイプ別設定のものを表示
 				m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx = m_nKeywordSet1;
 			}else{
-				// -1�������狤�ʐݒ�ōŌ�ɕ\���������̂��ێ�����
+				// -1だったら共通設定で最後に表示したものを維持する
 			}
 		}
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
-		if( wParam == IDOK ){ // �Ɨ��E�B���h�E
+		if( wParam == IDOK ){ // 独立ウィンドウ
 			hwndCtl = ::GetDlgItem( hwndDlg, IDOK );
 			GetWindowRect( hwndCtl, &rc );
-			int i = rc.bottom; // OK,CANCEL�{�^���̉��[
+			int i = rc.bottom; // OK,CANCELボタンの下端
 
 			GetWindowRect( hwndDlg, &rc );
 			SetWindowPos( hwndDlg, NULL, 0, 0, rc.right-rc.left, i-rc.top+10, SWP_NOZORDER|SWP_NOMOVE );
@@ -125,7 +125,7 @@ INT_PTR CPropKeyword::DispatchEvent(
 			ShowWindow( hwndCtl, SW_HIDE );
 		}
 
-		/* �R���g���[���̃n���h�����擾 */
+		/* コントロールのハンドルを取得 */
 		hwndCOMBO_SET = ::GetDlgItem( hwndDlg, IDC_COMBO_SET );
 		hwndLIST_KEYWORD = ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD );
 		::GetWindowRect( hwndLIST_KEYWORD, &rc );
@@ -140,7 +140,7 @@ INT_PTR CPropKeyword::DispatchEvent(
 		::SetWindowLongPtr( hwndLIST_KEYWORD, GWL_STYLE, lStyle | LVS_SHOWSELALWAYS );
 
 
-		/* �R���g���[���X�V�̃^�C�~���O�p�̃^�C�}�[���N�� */
+		/* コントロール更新のタイミング用のタイマーを起動 */
 		::SetTimer( hwndDlg, 1, 300, NULL );
 
 		return TRUE;
@@ -155,7 +155,7 @@ INT_PTR CPropKeyword::DispatchEvent(
 			switch( pNMHDR->code ){
 			case NM_DBLCLK:
 //				MYTRACE( _T("NM_DBLCLK     \n") );
-				/* ���X�g���őI������Ă���L�[���[�h��ҏW���� */
+				/* リスト中で選択されているキーワードを編集する */
 				Edit_List_KeyWord( hwndDlg, hwndLIST_KEYWORD );
 				return TRUE;
 			case LVN_BEGINLABELEDIT:
@@ -193,17 +193,17 @@ INT_PTR CPropKeyword::DispatchEvent(
 						InfoMessage( hwndDlg, LS(STR_PROPCOMKEYWORD_ERR_LEN), MAX_KEYWORDLEN );
 						return TRUE;
 					}
-					/* ���Ԗڂ̃Z�b�g�ɃL�[���[�h��ҏW */
+					/* ｎ番目のセットにキーワードを編集 */
 					m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.UpdateKeyWord(
 						m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx,
 						plvi->lParam,
 						to_wchar(plvi->pszText)
 					);
 				}else{
-					/* ���Ԗڂ̃Z�b�g�̂��Ԗڂ̃L�[���[�h���폜 */
+					/* ｎ番目のセットのｍ番目のキーワードを削除 */
 					m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.DelKeyWord( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, plvi->lParam );
 				}
-				/* �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ� */
+				/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 				SetKeyWordSet( hwndDlg, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 
 				ListView_SetItemState( hwndLIST_KEYWORD, plvi->iItem, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
@@ -213,11 +213,11 @@ INT_PTR CPropKeyword::DispatchEvent(
 //				MYTRACE( _T("LVN_KEYDOWN\n") );
 				switch( pnkd->wVKey ){
 				case VK_DELETE:
-					/* ���X�g���őI������Ă���L�[���[�h���폜���� */
+					/* リスト中で選択されているキーワードを削除する */
 					Delete_List_KeyWord( hwndDlg, hwndLIST_KEYWORD );
 					break;
 				case VK_SPACE:
-					/* ���X�g���őI������Ă���L�[���[�h��ҏW���� */
+					/* リスト中で選択されているキーワードを編集する */
 					Edit_List_KeyWord( hwndDlg, hwndLIST_KEYWORD );
 					break;
 				}
@@ -230,10 +230,10 @@ INT_PTR CPropKeyword::DispatchEvent(
 				return TRUE;
 			case PSN_KILLACTIVE:
 				DEBUG_TRACE( _T("Keyword PSN_KILLACTIVE\n") );
-				/* �_�C�A���O�f�[�^�̎擾 Keyword */
+				/* ダイアログデータの取得 Keyword */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+//@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_KEYWORD;
 				return TRUE;
@@ -241,30 +241,30 @@ INT_PTR CPropKeyword::DispatchEvent(
 		}
 		break;
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* �ʒm�R�[�h */
-		wID = LOWORD(wParam);			/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
-		hwndCtl = (HWND) lParam;		/* �R���g���[���̃n���h�� */
+		wNotifyCode = HIWORD(wParam);	/* 通知コード */
+		wID = LOWORD(wParam);			/* 項目ID､ コントロールID､ またはアクセラレータID */
+		hwndCtl = (HWND) lParam;		/* コントロールのハンドル */
 		if( hwndCOMBO_SET == hwndCtl){
 			switch( wNotifyCode ){
 			case CBN_SELCHANGE:
 				nIndex1 = Combo_GetCurSel( hwndCOMBO_SET );
-				/* �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ� */
+				/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 				SetKeyWordSet( hwndDlg, nIndex1 );
 				return TRUE;
 			}
 		}else{
 			switch( wNotifyCode ){
-			/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+			/* ボタン／チェックボックスがクリックされた */
 			case BN_CLICKED:
 				switch( wID ){
-				case IDC_BUTTON_ADDSET:	/* �Z�b�g�ǉ� */
+				case IDC_BUTTON_ADDSET:	/* セット追加 */
 					if( MAX_SETNUM <= m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nKeyWordSetNum ){
 						InfoMessage( hwndDlg, LS(STR_PROPCOMKEYWORD_SETMAX), MAX_SETNUM );
 						return TRUE;
 					}
-					/* ���[�h���X�_�C�A���O�̕\�� */
+					/* モードレスダイアログの表示 */
 					szKeyWord[0] = L'\0';
-					//	Oct. 5, 2002 genta ���������̐ݒ���C���D�o�b�t�@�I�[�o�[�������Ă����D
+					//	Oct. 5, 2002 genta 長さ制限の設定を修正．バッファオーバーランしていた．
 					if( !cDlgInput1.DoModal(
 						G_AppInstance(),
 						hwndDlg,
@@ -277,32 +277,32 @@ INT_PTR CPropKeyword::DispatchEvent(
 						return TRUE;
 					}
 					if( szKeyWord[0] != L'\0' ){
-						/* �Z�b�g�̒ǉ� */
+						/* セットの追加 */
 						m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.AddKeyWordSet( szKeyWord, false );
 
 						m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx = m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nKeyWordSetNum - 1;
 
-						/* �_�C�A���O�f�[�^�̐ݒ� Keyword */
+						/* ダイアログデータの設定 Keyword */
 						SetData( hwndDlg );
 					}
 					return TRUE;
-				case IDC_BUTTON_DELSET:	/* �Z�b�g�폜 */
+				case IDC_BUTTON_DELSET:	/* セット削除 */
 					{
 						nIndex1 = Combo_GetCurSel( hwndCOMBO_SET );
 						if( CB_ERR == nIndex1 ){
 							return TRUE;
 						}
-						/* �폜�Ώۂ̃Z�b�g���g�p���Ă���t�@�C���^�C�v��� */
+						/* 削除対象のセットを使用しているファイルタイプを列挙 */
 						std::tstring strLabel;
 						for( size_t i = 0; i < m_Types_nKeyWordSetIdx.size() ; ++i ){
-							// 2002/04/25 YAZAKI STypeConfig�S�̂�ێ�����K�v�͂Ȃ����Am_pShareData�𒼐ڌ��Ă����Ȃ��B
+							// 2002/04/25 YAZAKI STypeConfig全体を保持する必要はないし、m_pShareDataを直接見ても問題ない。
 							for( int k = 0; k < MAX_KEYWORDSET_PER_TYPE; k++ ){
 								if( nIndex1 == m_Types_nKeyWordSetIdx[i].index[k] ){
 									std::tstring name;
 									std::tstring exts;
 									bool bAdd = false;
 									if( m_Types_nKeyWordSetIdx[i].typeId == -1 ){
-										// �^�C�v�ʈꎞ�\��
+										// タイプ別一時表示
 										name = _T("(Temp)");
 										name += m_tempTypeName;
 										exts = m_tempTypeExts;
@@ -317,7 +317,7 @@ INT_PTR CPropKeyword::DispatchEvent(
 										}
 									}
 									if( bAdd ){
-										strLabel += _T("�E");
+										strLabel += _T("・");
 										strLabel += name;
 										strLabel +=  _T("(");
 										strLabel += exts;
@@ -334,9 +334,9 @@ INT_PTR CPropKeyword::DispatchEvent(
 						) ){
 							return TRUE;
 						}
-						/* �폜�Ώۂ̃Z�b�g���g�p���Ă���t�@�C���^�C�v�̃Z�b�g���N���A */
+						/* 削除対象のセットを使用しているファイルタイプのセットをクリア */
 						for( size_t i = 0; i < m_Types_nKeyWordSetIdx.size(); ++i ){
-							// 2002/04/25 YAZAKI STypeConfig�S�̂�ێ�����K�v�͂Ȃ��B
+							// 2002/04/25 YAZAKI STypeConfig全体を保持する必要はない。
 							for( int j = 0; j < MAX_KEYWORDSET_PER_TYPE; j++ ){
 								if( nIndex1 == m_Types_nKeyWordSetIdx[i].index[j] ){
 									m_Types_nKeyWordSetIdx[i].index[j] = -1;
@@ -346,14 +346,14 @@ INT_PTR CPropKeyword::DispatchEvent(
 								}
 							}
 						}
-						/* ���Ԗڂ̃Z�b�g���폜 */
+						/* ｎ番目のセットを削除 */
 						m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.DelKeyWordSet( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
-						/* �_�C�A���O�f�[�^�̐ݒ� Keyword */
+						/* ダイアログデータの設定 Keyword */
 						SetData( hwndDlg );
 					}
 					return TRUE;
-				case IDC_BUTTON_KEYSETRENAME: // �L�[���[�h�Z�b�g�̖��̕ύX
-					// ���[�h���X�_�C�A���O�̕\��
+				case IDC_BUTTON_KEYSETRENAME: // キーワードセットの名称変更
+					// モードレスダイアログの表示
 					wcscpy( szKeyWord, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetTypeName( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx ) );
 					{
 						BOOL bDlgInputResult = cDlgInput1.DoModal(
@@ -371,39 +371,39 @@ INT_PTR CPropKeyword::DispatchEvent(
 					if( szKeyWord[0] != L'\0' ){
 						m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SetTypeName( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, szKeyWord );
 
-						// �_�C�A���O�f�[�^�̐ݒ� Keyword
+						// ダイアログデータの設定 Keyword
 						SetData( hwndDlg );
 					}
 					return TRUE;
-				case IDC_CHECK_KEYWORDCASE:	/* �L�[���[�h�̉p�啶����������� */
+				case IDC_CHECK_KEYWORDCASE:	/* キーワードの英大文字小文字区別 */
 //					m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_bKEYWORDCASEArr[ m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx ] = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_KEYWORDCASE );	//MIK 2000.12.01 case sense
 					m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SetKeyWordCase(m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_KEYWORDCASE ));			//MIK 2000.12.01 case sense
 					return TRUE;
-				case IDC_BUTTON_ADDKEYWORD:	/* �L�[���[�h�ǉ� */
-					/* ���Ԗڂ̃Z�b�g�̃L�[���[�h�̐���Ԃ� */
+				case IDC_BUTTON_ADDKEYWORD:	/* キーワード追加 */
+					/* ｎ番目のセットのキーワードの数を返す */
 					if( !m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.CanAddKeyWord( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx ) ){
 						InfoMessage( hwndDlg, LS(STR_PROPCOMKEYWORD_KEYMAX) );
 						return TRUE;
 					}
-					/* ���[�h���X�_�C�A���O�̕\�� */
+					/* モードレスダイアログの表示 */
 					szKeyWord[0] = L'\0';
 					if( !cDlgInput1.DoModal( G_AppInstance(), hwndDlg, LS(STR_PROPCOMKEYWORD_KEYADD1), LS(STR_PROPCOMKEYWORD_KEYADD2), MAX_KEYWORDLEN, szKeyWord ) ){
 						return TRUE;
 					}
 					if( szKeyWord[0] != L'\0' ){
-						/* ���Ԗڂ̃Z�b�g�ɃL�[���[�h��ǉ� */
+						/* ｎ番目のセットにキーワードを追加 */
 						if( 0 == m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.AddKeyWord( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, szKeyWord ) ){
-							// �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ�
+							// ダイアログデータの設定 Keyword 指定キーワードセットの設定
 							SetKeyWordSet( hwndDlg, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 						}
 					}
 					return TRUE;
-				case IDC_BUTTON_EDITKEYWORD:	/* �L�[���[�h�ҏW */
-					/* ���X�g���őI������Ă���L�[���[�h��ҏW���� */
+				case IDC_BUTTON_EDITKEYWORD:	/* キーワード編集 */
+					/* リスト中で選択されているキーワードを編集する */
 					Edit_List_KeyWord( hwndDlg, hwndLIST_KEYWORD );
 					return TRUE;
-				case IDC_BUTTON_DELKEYWORD:	/* �L�[���[�h�폜 */
-					/* ���X�g���őI������Ă���L�[���[�h���폜���� */
+				case IDC_BUTTON_DELKEYWORD:	/* キーワード削除 */
+					/* リスト中で選択されているキーワードを削除する */
 					Delete_List_KeyWord( hwndDlg, hwndLIST_KEYWORD );
 					return TRUE;
 				// From Here 2005.01.26 Moca
@@ -411,15 +411,15 @@ INT_PTR CPropKeyword::DispatchEvent(
 					Clean_List_KeyWord( hwndDlg, hwndLIST_KEYWORD );
 					return TRUE;
 				// To Here 2005.01.26 Moca
-				case IDC_BUTTON_IMPORT:	/* �C���|�[�g */
-					/* ���X�g���̃L�[���[�h���C���|�[�g���� */
+				case IDC_BUTTON_IMPORT:	/* インポート */
+					/* リスト中のキーワードをインポートする */
 					Import_List_KeyWord( hwndDlg, hwndLIST_KEYWORD );
 					return TRUE;
-				case IDC_BUTTON_EXPORT:	/* �G�N�X�|�[�g */
-					/* ���X�g���̃L�[���[�h���G�N�X�|�[�g���� */
+				case IDC_BUTTON_EXPORT:	/* エクスポート */
+					/* リスト中のキーワードをエクスポートする */
 					Export_List_KeyWord( hwndDlg, hwndLIST_KEYWORD );
 					return TRUE;
-				// �Ɨ��E�B���h�E�Ŏg�p����
+				// 独立ウィンドウで使用する
 				case IDOK:
 					EndDialog( hwndDlg, IDOK );
 					break;
@@ -451,7 +451,7 @@ INT_PTR CPropKeyword::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -461,7 +461,7 @@ INT_PTR CPropKeyword::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -469,7 +469,7 @@ INT_PTR CPropKeyword::DispatchEvent(
 	return FALSE;
 }
 
-/* ���X�g���őI������Ă���L�[���[�h��ҏW���� */
+/* リスト中で選択されているキーワードを編集する */
 void CPropKeyword::Edit_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 {
 	int			nIndex1;
@@ -486,25 +486,25 @@ void CPropKeyword::Edit_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 	lvi.iSubItem = 0;
 	ListView_GetItem( hwndLIST_KEYWORD, &lvi );
 
-	/* ���Ԗڂ̃Z�b�g�̂��Ԗڂ̃L�[���[�h��Ԃ� */
+	/* ｎ番目のセットのｍ番目のキーワードを返す */
 	wcscpy( szKeyWord, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWord( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, lvi.lParam ) );
 
-	/* ���[�h���X�_�C�A���O�̕\�� */
+	/* モードレスダイアログの表示 */
 	if( !cDlgInput1.DoModal( G_AppInstance(), hwndDlg, LS(STR_PROPCOMKEYWORD_KEYEDIT1), LS(STR_PROPCOMKEYWORD_KEYEDIT2), MAX_KEYWORDLEN, szKeyWord ) ){
 		return;
 	}
 	if( szKeyWord[0] != L'\0' ){
-		/* ���Ԗڂ̃Z�b�g�ɃL�[���[�h��ҏW */
+		/* ｎ番目のセットにキーワードを編集 */
 		m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.UpdateKeyWord(
 			m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx,
 			lvi.lParam,
 			szKeyWord
 		);
 	}else{
-		/* ���Ԗڂ̃Z�b�g�̂��Ԗڂ̃L�[���[�h���폜 */
+		/* ｎ番目のセットのｍ番目のキーワードを削除 */
 		m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.DelKeyWord( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, lvi.lParam );
 	}
-	/* �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ� */
+	/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 	SetKeyWordSet( hwndDlg, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 
 	ListView_SetItemState( hwndLIST_KEYWORD, nIndex1, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
@@ -513,7 +513,7 @@ void CPropKeyword::Edit_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 
 
 
-/* ���X�g���őI������Ă���L�[���[�h���폜���� */
+/* リスト中で選択されているキーワードを削除する */
 void CPropKeyword::Delete_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 {
 	int			nIndex1;
@@ -527,20 +527,20 @@ void CPropKeyword::Delete_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 	lvi.iItem = nIndex1;
 	lvi.iSubItem = 0;
 	ListView_GetItem( hwndLIST_KEYWORD, &lvi );
-	/* ���Ԗڂ̃Z�b�g�̂��Ԗڂ̃L�[���[�h���폜 */
+	/* ｎ番目のセットのｍ番目のキーワードを削除 */
 	m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.DelKeyWord( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, lvi.lParam );
-	/* �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ� */
+	/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 	SetKeyWordSet( hwndDlg, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 	ListView_SetItemState( hwndLIST_KEYWORD, nIndex1, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 
-	//�L�[���[�h����\������B
+	//キーワード数を表示する。
 	DispKeywordCount( hwndDlg );
 
 	return;
 }
 
 
-/* ���X�g���̃L�[���[�h���C���|�[�g���� */
+/* リスト中のキーワードをインポートする */
 void CPropKeyword::Import_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 {
 	bool	bCase = false;
@@ -548,36 +548,36 @@ void CPropKeyword::Import_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 	m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SetKeyWordCase( nIdx, bCase );
 	CImpExpKeyWord	cImpExpKeyWord( m_Common, nIdx, bCase );
 
-	// �C���|�[�g
+	// インポート
 	if (!cImpExpKeyWord.ImportUI( G_AppInstance(), hwndDlg )) {
-		// �C���|�[�g�����Ă��Ȃ�
+		// インポートをしていない
 		return;
 	}
 
-	/* �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ� */
+	/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 	SetKeyWordSet( hwndDlg, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 	return;
 }
 
 
-/* ���X�g���̃L�[���[�h���G�N�X�|�[�g���� */
+/* リスト中のキーワードをエクスポートする */
 void CPropKeyword::Export_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 {
-	/* �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ� */
+	/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 	SetKeyWordSet( hwndDlg, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 
 	bool	bCase;
 	CImpExpKeyWord	cImpExpKeyWord( m_Common, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, bCase );
 
-	// �G�N�X�|�[�g
+	// エクスポート
 	if (!cImpExpKeyWord.ExportUI( G_AppInstance(), hwndDlg )) {
-		// �G�N�X�|�[�g�����Ă��Ȃ�
+		// エクスポートをしていない
 		return;
 	}
 }
 
 
-//! �L�[���[�h�𐮓ڂ���
+//! キーワードを整頓する
 void CPropKeyword::Clean_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 {
 	if( IDYES == ::MessageBox( hwndDlg, LS(STR_PROPCOMKEYWORD_DEL),
@@ -588,27 +588,27 @@ void CPropKeyword::Clean_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 	}
 }
 
-/* �_�C�A���O�f�[�^�̐ݒ� Keyword */
+/* ダイアログデータの設定 Keyword */
 void CPropKeyword::SetData( HWND hwndDlg )
 {
 	int		i;
 	HWND	hwndWork;
 
 
-	/* �Z�b�g���R���{�{�b�N�X�̒l�Z�b�g */
+	/* セット名コンボボックスの値セット */
 	hwndWork = ::GetDlgItem( hwndDlg, IDC_COMBO_SET );
-	Combo_ResetContent( hwndWork );  /* �R���{�{�b�N�X����ɂ��� */
+	Combo_ResetContent( hwndWork );  /* コンボボックスを空にする */
 	if( 0 < m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nKeyWordSetNum ){
 		for( i = 0; i < m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nKeyWordSetNum; ++i ){
 			Combo_AddString( hwndWork, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetTypeName( i ) );
 		}
-		/* �Z�b�g���R���{�{�b�N�X�̃f�t�H���g�I�� */
+		/* セット名コンボボックスのデフォルト選択 */
 		Combo_SetCurSel( hwndWork, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 
-		/* �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ� */
+		/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 		SetKeyWordSet( hwndDlg, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 	}else{
-		/* �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ� */
+		/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 		SetKeyWordSet( hwndDlg, -1 );
 	}
 
@@ -616,7 +616,7 @@ void CPropKeyword::SetData( HWND hwndDlg )
 }
 
 
-/* �_�C�A���O�f�[�^�̐ݒ� Keyword �w��L�[���[�h�Z�b�g�̐ݒ� */
+/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 {
 	int		i;
@@ -630,9 +630,9 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KEYWORDCASE ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADDKEYWORD ), TRUE );
-		//	Jan. 29, 2005 genta �L�[���[�h�Z�b�g�؂�ւ�����̓L�[���[�h�͖��I��
-		//	���̂��ߗL���ɂ��Ă����Ƀ^�C�}�[�Ŗ����ɂȂ�D
-		//	�Ȃ̂ł����Ŗ����ɂ��Ă����D
+		//	Jan. 29, 2005 genta キーワードセット切り替え直後はキーワードは未選択
+		//	そのため有効にしてすぐにタイマーで無効になる．
+		//	なのでここで無効にしておく．
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EDITKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_IMPORT ), TRUE );
@@ -651,22 +651,22 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 		return;
 	}
 
-	/* �L�[���[�h�̉p�啶����������� */
+	/* キーワードの英大文字小文字区別 */
 	if( true == m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWordCase(nIdx) ){		//MIK 2000.12.01 case sense
 		::CheckDlgButton( hwndDlg, IDC_CHECK_KEYWORDCASE, TRUE );
 	}else{
 		::CheckDlgButton( hwndDlg, IDC_CHECK_KEYWORDCASE, FALSE );
 	}
 
-	/* ���Ԗڂ̃Z�b�g�̃L�[���[�h�̐���Ԃ� */
+	/* ｎ番目のセットのキーワードの数を返す */
 	nNum = m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWordNum( nIdx );
 	hwndList = ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD );
 
-	// 2005.01.25 Moca/genta ���X�g�ǉ����͍ĕ`���}�����Ă��΂₭�\��
+	// 2005.01.25 Moca/genta リスト追加中は再描画を抑制してすばやく表示
 	::SendMessageAny( hwndList, WM_SETREDRAW, FALSE, 0 );
 
 	for( i = 0; i < nNum; ++i ){
-		/* ���Ԗڂ̃Z�b�g�̂��Ԗڂ̃L�[���[�h��Ԃ� */
+		/* ｎ番目のセットのｍ番目のキーワードを返す */
 		const TCHAR* pszKeyWord = to_tchar(m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWord( nIdx, i ));
 
 		lvi.mask = LVIF_TEXT | LVIF_PARAM;
@@ -679,10 +679,10 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 	}
 	m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx = nIdx;
 
-	// 2005.01.25 Moca/genta ���X�g�ǉ������̂��ߍĕ`�拖��
+	// 2005.01.25 Moca/genta リスト追加完了のため再描画許可
 	::SendMessageAny( hwndList, WM_SETREDRAW, TRUE, 0 );
 
-	//�L�[���[�h����\������B
+	//キーワード数を表示する。
 	DispKeywordCount( hwndDlg );
 
 	return;
@@ -690,18 +690,18 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 
 
 
-/* �_�C�A���O�f�[�^�̎擾 Keyword */
+/* ダイアログデータの取得 Keyword */
 int CPropKeyword::GetData( HWND hwndDlg )
 {
 	return TRUE;
 }
 
-/* �_�C�A���O�f�[�^�̎擾 Keyword �w��L�[���[�h�Z�b�g�̎擾 */
+/* ダイアログデータの取得 Keyword 指定キーワードセットの取得 */
 void CPropKeyword::GetKeyWordSet( HWND hwndDlg, int nIdx )
 {
 }
 
-//�L�[���[�h����\������B
+//キーワード数を表示する。
 void CPropKeyword::DispKeywordCount( HWND hwndDlg )
 {
 	HWND	hwndList;

--- a/sakura_core/prop/CPropComMacro.cpp
+++ b/sakura_core/prop/CPropComMacro.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	���ʐݒ�_�C�A���O�{�b�N�X�A�u�}�N���v�y�[�W
+﻿/*!	@file
+	共通設定ダイアログボックス、「マクロ」ページ
 
 	@author genta
 	@date Jun. 2, 2001 genta
@@ -43,31 +43,31 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 
-//! Popup Help�pID
+//! Popup Help用ID
 //@@@ 2001.12.22 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//11700
-	IDC_MACRODIRREF,	HIDC_MACRODIRREF,	//�}�N���f�B���N�g���Q��
-	IDC_MACRO_REG,		HIDC_MACRO_REG,		//�}�N���ݒ�
+	IDC_MACRODIRREF,	HIDC_MACRODIRREF,	//マクロディレクトリ参照
+	IDC_MACRO_REG,		HIDC_MACRO_REG,		//マクロ設定
 	IDC_COMBO_MACROID,	HIDC_COMBO_MACROID,	//ID
 	IDC_MACROPATH,		HIDC_MACROPATH,		//File
-	IDC_MACRONAME,		HIDC_MACRONAME,		//�}�N����
-	IDC_MACROLIST,		HIDC_MACROLIST,		//�}�N�����X�g
-	IDC_MACRODIR,		HIDC_MACRODIR,		//�}�N���ꗗ
-	IDC_CHECK_RELOADWHENEXECUTE,	HIDC_CHECK_RELOADWHENEXECUTE,	//�}�N�������s���邽�тɃt�@�C����ǂݍ��݂Ȃ���	// 2006.08.06 ryoji
-	IDC_CHECK_MacroOnOpened,		HIDC_CHECK_MacroOnOpened,		//�I�[�v���㎩�����s�}�N��	// 2006.09.01 ryoji
-	IDC_CHECK_MacroOnTypeChanged,	HIDC_CHECK_MacroOnTypeChanged,	//�^�C�v�ύX�㎩�����s�}�N��	// 2006.09.01 ryoji
-	IDC_CHECK_MacroOnSave,			HIDC_CHECK_MacroOnSave,			//�ۑ��O�������s�}�N��	// 2006.09.01 ryoji
-	IDC_MACROCANCELTIMER,			HIDC_MACROCANCELTIMER,			//�}�N����~�_�C�A���O�\���҂�����	// 2011.08.04 syat
+	IDC_MACRONAME,		HIDC_MACRONAME,		//マクロ名
+	IDC_MACROLIST,		HIDC_MACROLIST,		//マクロリスト
+	IDC_MACRODIR,		HIDC_MACRODIR,		//マクロ一覧
+	IDC_CHECK_RELOADWHENEXECUTE,	HIDC_CHECK_RELOADWHENEXECUTE,	//マクロを実行するたびにファイルを読み込みなおす	// 2006.08.06 ryoji
+	IDC_CHECK_MacroOnOpened,		HIDC_CHECK_MacroOnOpened,		//オープン後自動実行マクロ	// 2006.09.01 ryoji
+	IDC_CHECK_MacroOnTypeChanged,	HIDC_CHECK_MacroOnTypeChanged,	//タイプ変更後自動実行マクロ	// 2006.09.01 ryoji
+	IDC_CHECK_MacroOnSave,			HIDC_CHECK_MacroOnSave,			//保存前自動実行マクロ	// 2006.09.01 ryoji
+	IDC_MACROCANCELTIMER,			HIDC_MACROCANCELTIMER,			//マクロ停止ダイアログ表示待ち時間	// 2011.08.04 syat
 //	IDC_STATIC,			-1,
 	0, 0
 };
 //@@@ 2001.12.22 End
 
 /*!
-	@param hwndDlg �_�C�A���O�{�b�N�X��Window Handle
-	@param uMsg ���b�Z�[�W
-	@param wParam �p�����[�^1
-	@param lParam �p�����[�^2
+	@param hwndDlg ダイアログボックスのWindow Handle
+	@param uMsg メッセージ
+	@param wParam パラメータ1
+	@param lParam パラメータ2
 */
 INT_PTR CALLBACK CPropMacro::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -75,11 +75,11 @@ INT_PTR CALLBACK CPropMacro::DlgProc_page(
 	return DlgProc( reinterpret_cast<pDispatchPage>(&CPropMacro::DispatchEvent), hwndDlg, uMsg, wParam, lParam );
 }
 
-/*! Macro�y�[�W�̃��b�Z�[�W����
-	@param hwndDlg �_�C�A���O�{�b�N�X��Window Handlw
-	@param uMsg ���b�Z�[�W
-	@param wParam �p�����[�^1
-	@param lParam �p�����[�^2
+/*! Macroページのメッセージ処理
+	@param hwndDlg ダイアログボックスのWindow Handlw
+	@param uMsg メッセージ
+	@param wParam パラメータ1
+	@param lParam パラメータ2
 */
 INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
@@ -92,13 +92,13 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 	switch( uMsg ){
 
 	case WM_INITDIALOG:
-		/* �_�C�A���O�f�[�^�̐ݒ� Macro */
+		/* ダイアログデータの設定 Macro */
 		InitDialog( hwndDlg );
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		//	Oct. 5, 2002 genta �G�f�B�b�g �R���g���[���ɓ��͂ł���e�L�X�g�̒����𐧌�����
+		//	Oct. 5, 2002 genta エディット コントロールに入力できるテキストの長さを制限する
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_MACRONAME ), _countof( m_Common.m_sMacro.m_MacroTable[0].m_szName ) - 1 );
 		Combo_LimitText( ::GetDlgItem( hwndDlg, IDC_MACROPATH ), _countof( m_Common.m_sMacro.m_MacroTable[0].m_szFile ) - 1 );
 		// 2003.06.23 Moca
@@ -123,10 +123,10 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 				OnHelp( hwndDlg, IDD_PROP_MACRO );
 				return TRUE;
 			case PSN_KILLACTIVE:
-				/* �_�C�A���O�f�[�^�̎擾 Macro */
+				/* ダイアログデータの取得 Macro */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+//@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_MACRO;
 				return TRUE;
@@ -136,17 +136,17 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 		break;
 
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* �ʒm�R�[�h */
-		wID = LOWORD(wParam);			/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
+		wNotifyCode = HIWORD(wParam);	/* 通知コード */
+		wID = LOWORD(wParam);			/* 項目ID､ コントロールID､ またはアクセラレータID */
 
 		switch( wNotifyCode ){
-		/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+		/* ボタン／チェックボックスがクリックされた */
 		case BN_CLICKED:
 			switch( wID ){
-			case IDC_MACRODIRREF:	// �}�N���f�B���N�g���Q��
+			case IDC_MACRODIRREF:	// マクロディレクトリ参照
 				SelectBaseDir_Macro( hwndDlg );
 				break;
-			case IDC_MACRO_REG:		// �}�N���ݒ�
+			case IDC_MACRO_REG:		// マクロ設定
 				SetMacro2List_Macro( hwndDlg );
 				break;
 			}
@@ -158,7 +158,7 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 				break;
 			}
 			break;	/* CBN_DROPDOWN */
-		// From Here 2003.06.23 Moca �}�N���t�H���_�̍Ō��\���Ȃ���Εt����
+		// From Here 2003.06.23 Moca マクロフォルダの最後の\がなければ付ける
 		case EN_KILLFOCUS:
 			switch( wID ){
 			case IDC_MACRODIR:
@@ -180,7 +180,7 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -190,7 +190,7 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -200,16 +200,16 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 
 
 /*!
-	�_�C�A���O��̃R���g���[���Ƀf�[�^��ݒ肷��
+	ダイアログ上のコントロールにデータを設定する
 
-	@param hwndDlg �_�C�A���O�{�b�N�X�̃E�B���h�E�n���h��
+	@param hwndDlg ダイアログボックスのウィンドウハンドル
 */
 void CPropMacro::SetData( HWND hwndDlg )
 {
 	int index;
 	LVITEM sItem;
 
-	//	�}�N���f�[�^
+	//	マクロデータ
 	HWND hListView = ::GetDlgItem( hwndDlg, IDC_MACROLIST );
 	
 	for( index = 0; index < MAX_CUSTMACRO; ++index ){
@@ -234,7 +234,7 @@ void CPropMacro::SetData( HWND hwndDlg )
 		sItem.pszText = const_cast<TCHAR*>(m_pShareData->m_Common.m_sMacro.m_MacroTable[index].m_bReloadWhenExecute ? _T("on") : _T("off"));
 		ListView_SetItem( hListView, &sItem );
 
-		// �������s�}�N��	// 2006.09.01 ryoji
+		// 自動実行マクロ	// 2006.09.01 ryoji
 		TCHAR szText[8];
 		szText[0] = _T('\0');
 		if( index == m_pShareData->m_Common.m_sMacro.m_nMacroOnOpened )
@@ -251,20 +251,20 @@ void CPropMacro::SetData( HWND hwndDlg )
 		ListView_SetItem( hListView, &sItem );
 	}
 	
-	//	�}�N���f�B���N�g��
+	//	マクロディレクトリ
 	::DlgItem_SetText( hwndDlg, IDC_MACRODIR, /*m_pShareData->*/m_Common.m_sMacro.m_szMACROFOLDER );
 
 	nLastPos_Macro = -1;
 	
-	//	���X�g�r���[�̍s�I�����\�ɂ���D
-	//	IE 3.x�ȍ~�������Ă���ꍇ�̂ݓ��삷��D
-	//	���ꂪ�����Ă��C�ԍ����������I���ł��Ȃ������ő��쎩�͉̂\�D
+	//	リストビューの行選択を可能にする．
+	//	IE 3.x以降が入っている場合のみ動作する．
+	//	これが無くても，番号部分しか選択できないだけで操作自体は可能．
 	DWORD dwStyle;
 	dwStyle = ListView_GetExtendedListViewStyle( hListView );
 	dwStyle |= LVS_EX_FULLROWSELECT;
 	ListView_SetExtendedListViewStyle( hListView, dwStyle );
 	
-	//	�}�N����~�_�C�A���O�\���҂�����
+	//	マクロ停止ダイアログ表示待ち時間
 	TCHAR szCancelTimer[16] = {0};
 	::DlgItem_SetText( hwndDlg, IDC_MACROCANCELTIMER, _itot(m_Common.m_sMacro.m_nMacroCancelTimer, szCancelTimer, 10) );
 
@@ -272,9 +272,9 @@ void CPropMacro::SetData( HWND hwndDlg )
 }
 
 /*!
-	�_�C�A���O��̃R���g���[������f�[�^���擾���ă������Ɋi�[����
+	ダイアログ上のコントロールからデータを取得してメモリに格納する
 
-	@param hwndDlg �_�C�A���O�{�b�N�X�̃E�B���h�E�n���h��
+	@param hwndDlg ダイアログボックスのウィンドウハンドル
 */
 
 int CPropMacro::GetData( HWND hwndDlg )
@@ -282,12 +282,12 @@ int CPropMacro::GetData( HWND hwndDlg )
 	int index;
 	LVITEM sItem;
 
-	// �������s�}�N���ϐ�������	// 2006.09.01 ryoji
+	// 自動実行マクロ変数初期化	// 2006.09.01 ryoji
 	m_Common.m_sMacro.m_nMacroOnOpened = -1;
 	m_Common.m_sMacro.m_nMacroOnTypeChanged = -1;
 	m_Common.m_sMacro.m_nMacroOnSave = -1;
 
-	//	�}�N���f�[�^
+	//	マクロデータ
 	HWND hListView = ::GetDlgItem( hwndDlg, IDC_MACROLIST );
 
 	for( index = 0; index < MAX_CUSTMACRO; ++index ){
@@ -296,7 +296,7 @@ int CPropMacro::GetData( HWND hwndDlg )
 		sItem.mask = LVIF_TEXT;
 		sItem.iSubItem = 1;
 		sItem.cchTextMax = MACRONAME_MAX - 1;
-//@@@ 2002.01.03 YAZAKI ���ʐݒ�w�}�N���x���^�u��؂�ւ��邾���Őݒ肪�ۑ�����Ȃ��悤�ɁB
+//@@@ 2002.01.03 YAZAKI 共通設定『マクロ』がタブを切り替えるだけで設定が保存されないように。
 		sItem.pszText = /*m_pShareData->*/m_Common.m_sMacro.m_MacroTable[index].m_szName;
 		ListView_GetItem( hListView, &sItem );
 
@@ -305,7 +305,7 @@ int CPropMacro::GetData( HWND hwndDlg )
 		sItem.mask = LVIF_TEXT;
 		sItem.iSubItem = 2;
 		sItem.cchTextMax = _MAX_PATH;
-//@@@ 2002.01.03 YAZAKI ���ʐݒ�w�}�N���x���^�u��؂�ւ��邾���Őݒ肪�ۑ�����Ȃ��悤�ɁB
+//@@@ 2002.01.03 YAZAKI 共通設定『マクロ』がタブを切り替えるだけで設定が保存されないように。
 		sItem.pszText = /*m_pShareData->*/m_Common.m_sMacro.m_MacroTable[index].m_szFile;
 		ListView_GetItem( hListView, &sItem );
 
@@ -324,7 +324,7 @@ int CPropMacro::GetData( HWND hwndDlg )
 			m_Common.m_sMacro.m_MacroTable[index].m_bReloadWhenExecute = false;
 		}
 
-		// �������s�}�N��	// 2006.09.01 ryoji
+		// 自動実行マクロ	// 2006.09.01 ryoji
 		memset_raw( &sItem, 0, sizeof( sItem ));
 		sItem.iItem = index;
 		sItem.mask = LVIF_TEXT;
@@ -347,13 +347,13 @@ int CPropMacro::GetData( HWND hwndDlg )
 		}
 	}
 
-	//	�}�N���f�B���N�g��
-//@@@ 2002.01.03 YAZAKI ���ʐݒ�w�}�N���x���^�u��؂�ւ��邾���Őݒ肪�ۑ�����Ȃ��悤�ɁB
+	//	マクロディレクトリ
+//@@@ 2002.01.03 YAZAKI 共通設定『マクロ』がタブを切り替えるだけで設定が保存されないように。
 	::DlgItem_GetText( hwndDlg, IDC_MACRODIR, m_Common.m_sMacro.m_szMACROFOLDER, _MAX_PATH );
-	// 2003.06.23 Moca �}�N���t�H���_�̍Ō��\���Ȃ���Εt����
+	// 2003.06.23 Moca マクロフォルダの最後の\がなければ付ける
 	AddLastChar( m_Common.m_sMacro.m_szMACROFOLDER, _MAX_PATH, _T('\\') );
 	
-	//	�}�N����~�_�C�A���O�\���҂�����
+	//	マクロ停止ダイアログ表示待ち時間
 	TCHAR szCancelTimer[16] = {0};
 	::DlgItem_GetText( hwndDlg, IDC_MACROCANCELTIMER, szCancelTimer, _countof(szCancelTimer) );
 	m_Common.m_sMacro.m_nMacroCancelTimer = _ttoi(szCancelTimer);
@@ -376,11 +376,11 @@ void CPropMacro::InitDialog( HWND hwndDlg )
 		{ STR_PROPCOMMACR_LIST5, 40 },
 	};
 
-	//	ListView�̏�����
+	//	ListViewの初期化
 	HWND hListView = ::GetDlgItem( hwndDlg, IDC_MACROLIST );
 	if( hListView == NULL ){
 		PleaseReportToAuthor( hwndDlg, _T("PropComMacro::InitDlg::NoListView") );
-		return;	//	�悭�킩��񂯂ǎ��s����	
+		return;	//	よくわからんけど失敗した	
 	}
 
 	LVCOLUMN sColumn;
@@ -400,15 +400,15 @@ void CPropMacro::InitDialog( HWND hwndDlg )
 		
 		if( ListView_InsertColumn( hListView, pos, &sColumn ) < 0 ){
 			PleaseReportToAuthor( hwndDlg, _T("PropComMacro::InitDlg::ColumnRegistrationFail") );
-			return;	//	�悭�킩��񂯂ǎ��s����
+			return;	//	よくわからんけど失敗した
 		}
 	}
 
-	//	�������̊m��
-	//	�K�v�Ȑ�������Ɋm�ۂ���D
+	//	メモリの確保
+	//	必要な数だけ先に確保する．
 	ListView_SetItemCount( hListView, MAX_CUSTMACRO );
 
-	//	Index�����̓o�^
+	//	Index部分の登録
 	for( pos = 0; pos < MAX_CUSTMACRO ; ++pos ){
 		LVITEM sItem;
 		TCHAR buf[4];
@@ -422,7 +422,7 @@ void CPropMacro::InitDialog( HWND hwndDlg )
 		ListView_InsertItem( hListView, &sItem );
 	}
 	
-	// �o�^��w�� ComboBox�̏�����
+	// 登録先指定 ComboBoxの初期化
 	HWND hNumCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_MACROID );
 	for( pos = 0; pos < MAX_CUSTMACRO ; ++pos ){
 		wchar_t buf[10];
@@ -430,11 +430,11 @@ void CPropMacro::InitDialog( HWND hwndDlg )
 		int result = Combo_AddString( hNumCombo, buf );
 		if( result == CB_ERR ){
 			PleaseReportToAuthor( hwndDlg, _T("PropComMacro::InitDlg::AddMacroId") );
-			return;	//	�悭�킩��񂯂ǎ��s����
+			return;	//	よくわからんけど失敗した
 		}
 		else if( result == CB_ERRSPACE ){
 			PleaseReportToAuthor( hwndDlg, _T("PropComMacro::InitDlg::AddMacroId/InsufficientSpace") );
-			return;	//	�悭�킩��񂯂ǎ��s����
+			return;	//	よくわからんけど失敗した
 		}
 	}
 	Combo_SetCurSel( hNumCombo, 0 );
@@ -448,14 +448,14 @@ void CPropMacro::SetMacro2List_Macro( HWND hwndDlg )
 	HWND hListView = ::GetDlgItem( hwndDlg, IDC_MACROLIST );
 	HWND hNum = ::GetDlgItem( hwndDlg, IDC_COMBO_MACROID );
 
-	//	�ݒ��擾
+	//	設定先取得
 	index = Combo_GetCurSel( hNum );
 	if( index == CB_ERR ){
 		PleaseReportToAuthor( hwndDlg, _T("PropComMacro::SetMacro2List::GetCurSel") );
-		return;	//	�悭�킩��񂯂ǎ��s����
+		return;	//	よくわからんけど失敗した
 	}
 
-	// �}�N����
+	// マクロ名
 	memset_raw( &sItem, 0, sizeof( sItem ));
 	sItem.iItem = index;
 	sItem.mask = LVIF_TEXT;
@@ -466,7 +466,7 @@ void CPropMacro::SetMacro2List_Macro( HWND hwndDlg )
 	sItem.pszText = buf;
 	ListView_SetItem( hListView, &sItem );
 
-	// �t�@�C����
+	// ファイル名
 	memset_raw( &sItem, 0, sizeof( sItem ));
 	sItem.iItem = index;
 	sItem.mask = LVIF_TEXT;
@@ -476,7 +476,7 @@ void CPropMacro::SetMacro2List_Macro( HWND hwndDlg )
 	sItem.pszText = buf;
 	ListView_SetItem( hListView, &sItem );
 
-	// �`�F�b�N
+	// チェック
 	memset_raw( &sItem, 0, sizeof( sItem ));
 	sItem.iItem = index;
 	sItem.mask = LVIF_TEXT;
@@ -484,7 +484,7 @@ void CPropMacro::SetMacro2List_Macro( HWND hwndDlg )
 	sItem.pszText = const_cast<TCHAR*>(::IsDlgButtonChecked( hwndDlg, IDC_CHECK_RELOADWHENEXECUTE ) ? _T("on") : _T("off"));
 	ListView_SetItem( hListView, &sItem );
 
-	// �������s�}�N��	// 2006.09.01 ryoji
+	// 自動実行マクロ	// 2006.09.01 ryoji
 	int nMacroOnOpened = -1;
 	int nMacroOnTypeChanged = -1;
 	int nMacroOnSave = -1;
@@ -541,19 +541,19 @@ void CPropMacro::SetMacro2List_Macro( HWND hwndDlg )
 }
 
 /*!
-	Macro�i�[�p�f�B���N�g����I������
+	Macro格納用ディレクトリを選択する
 
-	@param hwndDlg [in] �_�C�A���O�{�b�N�X�̃E�B���h�E�n���h��
+	@param hwndDlg [in] ダイアログボックスのウィンドウハンドル
 */
 void CPropMacro::SelectBaseDir_Macro( HWND hwndDlg )
 {
 	TCHAR szDir[_MAX_PATH];
 
-	/* �����t�H���_ */
+	/* 検索フォルダ */
 	::DlgItem_GetText( hwndDlg, IDC_MACRODIR, szDir, _countof(szDir) );
 
-	// 2003.06.23 Moca ���΃p�X�͎��s�t�@�C������̃p�X
-	// 2007.05.19 ryoji ���΃p�X�͐ݒ�t�@�C������̃p�X��D��
+	// 2003.06.23 Moca 相対パスは実行ファイルからのパス
+	// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
 	if( _IS_REL_PATH( szDir ) ){
 		TCHAR folder[_MAX_PATH];
 		_tcscpy( folder, szDir );
@@ -561,18 +561,18 @@ void CPropMacro::SelectBaseDir_Macro( HWND hwndDlg )
 	}
 
 	if( SelectDir( hwndDlg, LS(STR_PROPCOMMACR_SEL_DIR), szDir, szDir ) ){
-		//	������\\�}�[�N��ǉ�����D
+		//	末尾に\\マークを追加する．
 		AddLastChar( szDir, _countof(szDir), _T('\\') );
-		::DlgItem_SetText( hwndDlg, IDC_MACRODIR, GetRelPath(szDir) ); // 2015.03.03 �\�Ȃ瑊�΃p�X�ɂ���
+		::DlgItem_SetText( hwndDlg, IDC_MACRODIR, GetRelPath(szDir) ); // 2015.03.03 可能なら相対パスにする
 	}
 }
 
 
 /*!
-	�}�N���t�@�C���w��p�R���{�{�b�N�X�̃h���b�v�_�E�����X�g���J�����Ƃ��ɁC
-	�w��f�B���N�g���̃t�@�C���ꗗ������𐶐�����D
+	マクロファイル指定用コンボボックスのドロップダウンリストが開かれるときに，
+	指定ディレクトリのファイル一覧から候補を生成する．
 
-	@param hwndDlg [in] �_�C�A���O�{�b�N�X�̃E�B���h�E�n���h��
+	@param hwndDlg [in] ダイアログボックスのウィンドウハンドル
 */
 void CPropMacro::OnFileDropdown_Macro( HWND hwndDlg )
 {
@@ -582,19 +582,19 @@ void CPropMacro::OnFileDropdown_Macro( HWND hwndDlg )
 	TCHAR path[_MAX_PATH * 2];
 	::DlgItem_GetText( hwndDlg, IDC_MACRODIR, path, _countof(path) );
 
-	// 2003.06.23 Moca ���΃p�X�͎��s�t�@�C������̃p�X
-	// 2007.05.19 ryoji ���΃p�X�͐ݒ�t�@�C������̃p�X��D��
+	// 2003.06.23 Moca 相対パスは実行ファイルからのパス
+	// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
 	if( _IS_REL_PATH( path ) ){
 		TCHAR folder[_MAX_PATH * 2];
 		_tcscpy( folder, path );
 		GetInidirOrExedir( path, folder );
 	}
-	_tcscat( path, _T("*.*") );	//	2002/05/01 YAZAKI �ǂ�ȃt�@�C�����ǂ�Ɨ����B
+	_tcscat( path, _T("*.*") );	//	2002/05/01 YAZAKI どんなファイルもどんと来い。
 
-	//	���̏�����
+	//	候補の初期化
 	Combo_ResetContent( hCombo );
 
-	//	�t�@�C���̌���
+	//	ファイルの検索
 	WIN32_FIND_DATA wf;
 	hFind = FindFirstFile(path, &wf);
 
@@ -603,10 +603,10 @@ void CPropMacro::OnFileDropdown_Macro( HWND hwndDlg )
 	}
 
 	do {
-		//	�R���{�{�b�N�X�ɐݒ�
-		//	�ł�.��..�͊��فB
+		//	コンボボックスに設定
+		//	でも.と..は勘弁。
 		//if (_tcscmp( wf.cFileName, _T(".") ) != 0 && _tcscmp( wf.cFileName, _T("..") ) != 0){
-		if( (wf.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0 ){	// 2009.02.12 ryoji �t�H���_�����O
+		if( (wf.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0 ){	// 2009.02.12 ryoji フォルダを除外
 			int result = Combo_AddString( hCombo, wf.cFileName );
 			if( result == CB_ERR || result == CB_ERRSPACE )
 				break;
@@ -621,7 +621,7 @@ void CPropMacro::CheckListPosition_Macro( HWND hwndDlg )
 	HWND hListView = ::GetDlgItem( hwndDlg, IDC_MACROLIST );
 	HWND hNum = ::GetDlgItem( hwndDlg, IDC_COMBO_MACROID );
 	
-	//	���݂�Focus�擾
+	//	現在のFocus取得
 	int current = ListView_GetNextItem( hListView, -1, LVNI_SELECTED);
 
 	if( current == -1 || current == nLastPos_Macro )
@@ -629,10 +629,10 @@ void CPropMacro::CheckListPosition_Macro( HWND hwndDlg )
 
 	nLastPos_Macro = current;
 	
-	//	�����l�̐ݒ�
+	//	初期値の設定
 	Combo_SetCurSel( hNum, nLastPos_Macro );
 	
-	TCHAR buf[MAX_PATH + MACRONAME_MAX];	// MAX_PATH��MACRONAME_MAX�̗������傫���l
+	TCHAR buf[MAX_PATH + MACRONAME_MAX];	// MAX_PATHとMACRONAME_MAXの両方より大きい値
 	LVITEM sItem;
 
 	memset_raw( &sItem, 0, sizeof( sItem ));
@@ -669,7 +669,7 @@ void CPropMacro::CheckListPosition_Macro( HWND hwndDlg )
 		::CheckDlgButton( hwndDlg, IDC_CHECK_RELOADWHENEXECUTE, false );
 	}
 
-	// �������s�}�N��	// 2006.09.01 ryoji
+	// 自動実行マクロ	// 2006.09.01 ryoji
 	memset_raw( &sItem, 0, sizeof( sItem ));
 	sItem.iItem = current;
 	sItem.mask = LVIF_TEXT;

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAuƒƒCƒ“ƒƒjƒ…[vƒy[ƒW
+ï»¿/*!	@file
+	å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã€ãƒšãƒ¼ã‚¸
 
 	@author Uchi
 */
@@ -39,64 +39,64 @@
 
 using std::wstring;
 
-// TreeView •\¦ŒÅ’è‰Šú’l
+// TreeView è¡¨ç¤ºå›ºå®šåˆæœŸå€¤
 
 static const DWORD p_helpids[] = {
-	IDC_COMBO_FUNCKIND,				HIDC_COMBO_FUNCKIND,				//‹@”\‚Ìí•Ê
-	IDC_LIST_FUNC,					HIDC_LIST_FUNC,						//‹@”\ˆê——
-	IDC_TREE_RES,					HIDC_TREE_RES,						//ƒƒjƒ…[ˆê——
-	IDC_BUTTON_DELETE,				HIDC_BUTTON_TREE_DELETE,			//ƒƒjƒ…[‚©‚ç‹@”\íœ
-	IDC_BUTTON_INSERT_NODE,			HIDC_BUTTON_TREE_INSERT_NODE,		//ƒƒjƒ…[‚Öƒm[ƒh’Ç‰Á
-	IDC_BUTTON_INSERTSEPARATOR,		HIDC_BUTTON_TREE_INSERT_SEPARATOR,	//ƒƒjƒ…[‚Ö‹æØü‘}“ü
-	IDC_BUTTON_INSERT,				HIDC_BUTTON_TREE_INSERT,			//ƒƒjƒ…[‚Ö‹@”\‘}“ü(ã)
-	IDC_BUTTON_INSERT_A,			HIDC_BUTTON_TREE_INSERT_A,			//ƒƒjƒ…[‚Ö‹@”\‘}“ü(‰º)
-	IDC_BUTTON_ADD,					HIDC_BUTTON_TREE_ADD,				//ƒƒjƒ…[‚Ö‹@”\’Ç‰Á
-	IDC_BUTTON_UP,					HIDC_BUTTON_TREE_UP,				//ƒƒjƒ…[‚Ì‹@”\‚ğã‚ÖˆÚ“®
-	IDC_BUTTON_DOWN,				HIDC_BUTTON_TREE_DOWN,				//ƒƒjƒ…[‚Ì‹@”\‚ğ‰º‚ÖˆÚ“®
-	IDC_BUTTON_RIGHT,				HIDC_BUTTON_TREE_RIGHT,				//ƒƒjƒ…[‚Ì‹@”\‚ğ‰E‚ÖˆÚ“®
-	IDC_BUTTON_LEFT,				HIDC_BUTTON_TREE_LEFT,				//ƒƒjƒ…[‚Ì‹@”\‚ğ¶‚ÖˆÚ“®
-	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT,					//ƒƒjƒ…[‚ÌƒCƒ“ƒ|[ƒg
-	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT,					//ƒƒjƒ…[‚ÌƒGƒNƒXƒ|[ƒg
-	IDC_BUTTON_CHECK,				HIDC_BUTTON_NENU_CHECK,				//ƒƒjƒ…[‚ÌŒŸ¸
-	IDC_BUTTON_CLEAR,				HIDC_BUTTON_TREE_CLEAR,				//ƒƒjƒ…[‚ğƒNƒŠƒA
-	IDC_BUTTON_INITIALIZE,			HIDC_BUTTON_TREE_INITIALIZE,		//ƒƒjƒ…[‚ğ‰Šúó‘Ô‚É–ß‚·
-	IDC_CHECK_KEY_PARENTHESES,		HIDC_CHECK_KEY_PARENTHESES,			//ƒAƒNƒZƒXƒL[‚ğ•K‚¸( )•t‚Å•\¦(&P)
+	IDC_COMBO_FUNCKIND,				HIDC_COMBO_FUNCKIND,				//æ©Ÿèƒ½ã®ç¨®åˆ¥
+	IDC_LIST_FUNC,					HIDC_LIST_FUNC,						//æ©Ÿèƒ½ä¸€è¦§
+	IDC_TREE_RES,					HIDC_TREE_RES,						//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ä¸€è¦§
+	IDC_BUTTON_DELETE,				HIDC_BUTTON_TREE_DELETE,			//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã‹ã‚‰æ©Ÿèƒ½å‰Šé™¤
+	IDC_BUTTON_INSERT_NODE,			HIDC_BUTTON_TREE_INSERT_NODE,		//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã¸ãƒãƒ¼ãƒ‰è¿½åŠ 
+	IDC_BUTTON_INSERTSEPARATOR,		HIDC_BUTTON_TREE_INSERT_SEPARATOR,	//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã¸åŒºåˆ‡ç·šæŒ¿å…¥
+	IDC_BUTTON_INSERT,				HIDC_BUTTON_TREE_INSERT,			//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã¸æ©Ÿèƒ½æŒ¿å…¥(ä¸Š)
+	IDC_BUTTON_INSERT_A,			HIDC_BUTTON_TREE_INSERT_A,			//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã¸æ©Ÿèƒ½æŒ¿å…¥(ä¸‹)
+	IDC_BUTTON_ADD,					HIDC_BUTTON_TREE_ADD,				//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã¸æ©Ÿèƒ½è¿½åŠ 
+	IDC_BUTTON_UP,					HIDC_BUTTON_TREE_UP,				//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ©Ÿèƒ½ã‚’ä¸Šã¸ç§»å‹•
+	IDC_BUTTON_DOWN,				HIDC_BUTTON_TREE_DOWN,				//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ©Ÿèƒ½ã‚’ä¸‹ã¸ç§»å‹•
+	IDC_BUTTON_RIGHT,				HIDC_BUTTON_TREE_RIGHT,				//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ©Ÿèƒ½ã‚’å³ã¸ç§»å‹•
+	IDC_BUTTON_LEFT,				HIDC_BUTTON_TREE_LEFT,				//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ©Ÿèƒ½ã‚’å·¦ã¸ç§»å‹•
+	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT,					//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT,					//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
+	IDC_BUTTON_CHECK,				HIDC_BUTTON_NENU_CHECK,				//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ¤œæŸ»
+	IDC_BUTTON_CLEAR,				HIDC_BUTTON_TREE_CLEAR,				//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã‚’ã‚¯ãƒªã‚¢
+	IDC_BUTTON_INITIALIZE,			HIDC_BUTTON_TREE_INITIALIZE,		//ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã‚’åˆæœŸçŠ¶æ…‹ã«æˆ»ã™
+	IDC_CHECK_KEY_PARENTHESES,		HIDC_CHECK_KEY_PARENTHESES,			//ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã‚’å¿…ãš( )ä»˜ã§è¡¨ç¤º(&P)
 	0, 0
 };
 
-// “à•”g—p•Ï”
-// ‹@”\Ši”[(Work)
+// å†…éƒ¨ä½¿ç”¨å¤‰æ•°
+// æ©Ÿèƒ½æ ¼ç´(Work)
 struct SMainMenuWork {
-	wstring			m_sName;		// –¼‘O
+	wstring			m_sName;		// åå‰
 	EFunctionCode	m_nFunc;		// Function
-	WCHAR			m_sKey[2];		// ƒAƒNƒZƒXƒL[
-	bool			m_bDupErr;		// ƒAƒNƒZƒXƒL[d•¡ƒGƒ‰[
-	bool			m_bIsNode;		// ƒm[ƒh‚©”Û‚©iƒm[ƒh‚Å‚àm_nFunc‚ªF_NODE(0)‚Å‚È‚¢‚à‚Ì‚ª‚ ‚é‚½‚ßj
+	WCHAR			m_sKey[2];		// ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼
+	bool			m_bDupErr;		// ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼é‡è¤‡ã‚¨ãƒ©ãƒ¼
+	bool			m_bIsNode;		// ãƒãƒ¼ãƒ‰ã‹å¦ã‹ï¼ˆãƒãƒ¼ãƒ‰ã§ã‚‚m_nFuncãŒF_NODE(0)ã§ãªã„ã‚‚ã®ãŒã‚ã‚‹ãŸã‚ï¼‰
 };
 
-static	std::map<int, SMainMenuWork>	msMenu;	// ˆêƒf[ƒ^
-static	int		nMenuCnt = 0;					// ˆêƒf[ƒ^”Ô†
+static	std::map<int, SMainMenuWork>	msMenu;	// ä¸€æ™‚ãƒ‡ãƒ¼ã‚¿
+static	int		nMenuCnt = 0;					// ä¸€æ™‚ãƒ‡ãƒ¼ã‚¿ç•ªå·
 
 
-// ƒ[ƒJƒ‹ŠÖ”’è‹`
+// ãƒ­ãƒ¼ã‚«ãƒ«é–¢æ•°å®šç¾©
 static HTREEITEM TreeCopy( HWND, HTREEITEM, HTREEITEM, bool, bool );
 static const TCHAR * MakeDispLabel( SMainMenuWork* );
 
-static	int 	nSpecialFuncsNum;		// “Á•Ê‹@”\‚ÌƒRƒ“ƒ{ƒ{ƒbƒNƒX“à‚Å‚Ì”Ô†
+static	int 	nSpecialFuncsNum;		// ç‰¹åˆ¥æ©Ÿèƒ½ã®ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹å†…ã§ã®ç•ªå·
 
-//  TreeViewƒL[“ü—Í‚ÌƒƒbƒZ[ƒWˆ——p
+//  TreeViewã‚­ãƒ¼å…¥åŠ›æ™‚ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†ç”¨
 static WNDPROC	m_wpTreeView = NULL;
 static HWND		m_hwndDlg;
 
-// TreeViewƒ‰ƒxƒ‹•ÒW‚ÌƒƒbƒZ[ƒWˆ——p
+// TreeViewãƒ©ãƒ™ãƒ«ç·¨é›†æ™‚ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†ç”¨
 static WNDPROC	m_wpEdit = NULL;
 
 
 /*!
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropMainMenu::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -106,7 +106,7 @@ INT_PTR CALLBACK CPropMainMenu::DlgProc_page(
 
 
 
-// TreeViewƒL[“ü—Í‚ÌƒƒbƒZ[ƒWˆ—
+// TreeViewã‚­ãƒ¼å…¥åŠ›æ™‚ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 static LRESULT CALLBACK TreeViewProc(
 	HWND	hwndTree,		// handle to dialog box
 	UINT	uMsg,			// message
@@ -115,9 +115,9 @@ static LRESULT CALLBACK TreeViewProc(
 )
 {
 	HTREEITEM		htiItem;
-	TV_ITEM			tvi;		// æ“¾—p
+	TV_ITEM			tvi;		// å–å¾—ç”¨
 	WCHAR			cKey;
-	SMainMenuWork*	pFuncWk;	// ‹@”\
+	SMainMenuWork*	pFuncWk;	// æ©Ÿèƒ½
 
 	switch (uMsg) {
 	case WM_GETDLGCODE:
@@ -134,7 +134,7 @@ static LRESULT CALLBACK TreeViewProc(
 		htiItem = TreeView_GetSelection( hwndTree );
 		cKey = (WCHAR)MapVirtualKey( wParam, 2 );
 		if (cKey > ' ') {
-			// ƒAƒNƒZƒXƒL[İ’è
+			// ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼è¨­å®š
 			tvi.mask = TVIF_HANDLE | TVIF_PARAM;
 			tvi.hItem = htiItem;
 			if (!TreeView_GetItem( hwndTree, &tvi )) {
@@ -149,17 +149,17 @@ static LRESULT CALLBACK TreeViewProc(
 			pFuncWk->m_bDupErr = false;
 			tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_PARAM;
 			tvi.pszText = const_cast<TCHAR*>( MakeDispLabel( pFuncWk ) );
-			TreeView_SetItem( hwndTree , &tvi );		//	ƒL[İ’èŒ‹‰Ê‚ğ”½‰f
+			TreeView_SetItem( hwndTree , &tvi );		//	ã‚­ãƒ¼è¨­å®šçµæœã‚’åæ˜ 
 			return 0;
 		}
 
 
 		switch (wParam) {
 		case VK_BACK:
-		case VK_DELETE:	//	DELƒL[‚ª‰Ÿ‚³‚ê‚½‚çƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÉƒƒbƒZ[ƒW‚ğ‘—M
+		case VK_DELETE:	//	DELã‚­ãƒ¼ãŒæŠ¼ã•ã‚ŒãŸã‚‰ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’é€ä¿¡
 			::SendMessage( m_hwndDlg, WM_COMMAND, IDC_BUTTON_DELETE, (LPARAM)::GetDlgItem( m_hwndDlg, IDC_BUTTON_DELETE ) );
 			return 0;
-		case VK_F2:						// F2‚Å•ÒW
+		case VK_F2:						// F2ã§ç·¨é›†
 			if (htiItem != NULL) {
 				TreeView_EditLabel( hwndTree, htiItem );
 			}
@@ -172,7 +172,7 @@ static LRESULT CALLBACK TreeViewProc(
 	return  CallWindowProc( m_wpTreeView, hwndTree, uMsg, wParam, lParam);
 }
 
-// TreeViewƒ‰ƒxƒ‹•ÒW‚ÌƒƒbƒZ[ƒWˆ—
+// TreeViewãƒ©ãƒ™ãƒ«ç·¨é›†æ™‚ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 static LRESULT CALLBACK WindowProcEdit(
 	HWND	hwndEdit,	// handle to dialog box
 	UINT	uMsg,		// message
@@ -228,7 +228,7 @@ static void SetDlgItemsEnableState(
 
 }
 
-/* Menu ƒƒbƒZ[ƒWˆ— */
+/* Menu ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropMainMenu::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
 	UINT	uMsg,		// message
@@ -251,11 +251,11 @@ INT_PTR CPropMainMenu::DispatchEvent(
 	WCHAR		szLabel[256+10];
 
 	EFunctionCode	eFuncCode;
-	SMainMenuWork*	pFuncWk;	// ‹@”\
+	SMainMenuWork*	pFuncWk;	// æ©Ÿèƒ½
 	TCHAR			szKey[2];
 
-	TV_INSERTSTRUCT	tvis;		// ‘}“ü—p
-	TV_ITEM			tvi;		// æ“¾—p
+	TV_INSERTSTRUCT	tvis;		// æŒ¿å…¥ç”¨
+	TV_ITEM			tvi;		// å–å¾—ç”¨
 	HTREEITEM		htiItem;
 	HTREEITEM		htiParent;
 	HTREEITEM		htiTemp;
@@ -269,19 +269,19 @@ INT_PTR CPropMainMenu::DispatchEvent(
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Menu */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Menu */
 		SetData( hwndDlg );
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒRƒ“ƒgƒ[ƒ‹‚Ìƒnƒ“ƒhƒ‹‚ğæ“¾ */
+		/* ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®ãƒãƒ³ãƒ‰ãƒ«ã‚’å–å¾— */
 		hwndComboFunkKind = ::GetDlgItem( hwndDlg, IDC_COMBO_FUNCKIND );
 		hwndListFunk = ::GetDlgItem( hwndDlg, IDC_LIST_FUNC );
 		hwndTreeRes = ::GetDlgItem( hwndDlg, IDC_TREE_RES );
 
-		/* ƒL[‘I‘ğ‚Ìˆ— */
+		/* ã‚­ãƒ¼é¸æŠæ™‚ã®å‡¦ç† */
 		::SendMessage( hwndDlg, WM_COMMAND, MAKELONG( IDC_COMBO_FUNCKIND, CBN_SELCHANGE ), (LPARAM)hwndComboFunkKind );
 
-		// TreeView‚ÌƒƒbƒZ[ƒWˆ—iƒAƒNƒZƒXƒL[“ü—Í—pj
+		// TreeViewã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†ï¼ˆã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼å…¥åŠ›ç”¨ï¼‰
 		m_hwndDlg = hwndDlg;
 		m_wpTreeView = (WNDPROC)SetWindowLongPtr( hwndTreeRes, GWLP_WNDPROC, (LONG_PTR)TreeViewProc );
 
@@ -302,13 +302,13 @@ INT_PTR CPropMainMenu::DispatchEvent(
 			OnHelp( hwndDlg, IDD_PROP_MAINMENU );
 			return TRUE;
 		case PSN_KILLACTIVE:
-			/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Menu */
+			/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Menu */
 			GetData( hwndDlg );
 			return TRUE;
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPCOM_PAGENUM_MAINMENU;
 
-			// •\¦‚ğXV‚·‚éiƒ}ƒNƒİ’è‰æ–Ê‚Å‚Ìƒ}ƒNƒ–¼•ÏX‚ğ”½‰fj
+			// è¡¨ç¤ºã‚’æ›´æ–°ã™ã‚‹ï¼ˆãƒã‚¯ãƒ­è¨­å®šç”»é¢ã§ã®ãƒã‚¯ãƒ­åå¤‰æ›´ã‚’åæ˜ ï¼‰
 			nIdxFIdx = Combo_GetCurSel( hwndComboFunkKind );
 			nIdxFunc = List_GetCurSel( hwndListFunk );
 			if( nIdxFIdx != CB_ERR ){
@@ -318,47 +318,47 @@ INT_PTR CPropMainMenu::DispatchEvent(
 				}
 			}
 			return TRUE;
-		case TVN_BEGINLABELEDIT:	//	ƒAƒCƒeƒ€‚Ì•ÒWŠJn
+		case TVN_BEGINLABELEDIT:	//	ã‚¢ã‚¤ãƒ†ãƒ ã®ç·¨é›†é–‹å§‹
 			if (pNMHDR->hwndFrom == hwndTreeRes) { 
 				HWND hEdit = TreeView_GetEditControl( hwndTreeRes );
 				if (msMenu[ptdi->item.lParam].m_bIsNode) {
-					// ƒm[ƒh‚Ì‚İ—LŒø
+					// ãƒãƒ¼ãƒ‰ã®ã¿æœ‰åŠ¹
 					SetWindowText( hEdit, to_tchar( msMenu[ptdi->item.lParam].m_sName.c_str() ) ) ;
 					EditCtl_LimitText( hEdit, MAX_MAIN_MENU_NAME_LEN );
-					// •ÒW‚ÌƒƒbƒZ[ƒWˆ—
+					// ç·¨é›†æ™‚ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 					m_wpEdit = (WNDPROC)SetWindowLongPtr( hEdit, GWLP_WNDPROC, (LONG_PTR)WindowProcEdit );
 				}
 				else {
-					// ƒm[ƒhˆÈŠO•ÒW•s‰Â
+					// ãƒãƒ¼ãƒ‰ä»¥å¤–ç·¨é›†ä¸å¯
 					SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, TRUE);
 				}
 			}
 			return TRUE;
-		case TVN_ENDLABELEDIT:		//	ƒAƒCƒeƒ€‚Ì•ÒW‚ªI—¹
+		case TVN_ENDLABELEDIT:		//	ã‚¢ã‚¤ãƒ†ãƒ ã®ç·¨é›†ãŒçµ‚äº†
  			if (pNMHDR->hwndFrom == hwndTreeRes 
 			  && msMenu[ ptdi->item.lParam ].m_bIsNode) {
-				// ƒm[ƒh—LŒø
+				// ãƒãƒ¼ãƒ‰æœ‰åŠ¹
 				pFuncWk = &msMenu[ptdi->item.lParam];
 				std::wstring strNameOld = pFuncWk->m_sName;
 				if (ptdi->item.pszText == NULL) {
 					// Esc
-					//	‰½‚àİ’è‚µ‚È‚¢iŒ³‚Ì‚Ü‚Üj
+					//	ä½•ã‚‚è¨­å®šã—ãªã„ï¼ˆå…ƒã®ã¾ã¾ï¼‰
 				}
 				else if (auto_strcmp(ptdi->item.pszText, _T("")) == 0) {
-					// ‹ó
+					// ç©º
 					pFuncWk->m_sName = LSW(STR_PROPCOMMAINMENU_EDIT);
 				}
 				else {
 					pFuncWk->m_sName = to_wchar(ptdi->item.pszText);
 				}
 				if( strNameOld != pFuncWk->m_sName ){
-					// ƒ‰ƒxƒ‹‚ğ•ÒW‚µ‚½‚çƒŠƒ\[ƒX‚©‚ç‚Ì•¶š—ñæ“¾‚ğ‚â‚ß‚é 2012.10.14 syat Še‘Œê‘Î‰
+					// ãƒ©ãƒ™ãƒ«ã‚’ç·¨é›†ã—ãŸã‚‰ãƒªã‚½ãƒ¼ã‚¹ã‹ã‚‰ã®æ–‡å­—åˆ—å–å¾—ã‚’ã‚„ã‚ã‚‹ 2012.10.14 syat å„å›½èªå¯¾å¿œ
 					pFuncWk->m_nFunc = F_NODE;
 				}
 				ptdi->item.pszText = const_cast<TCHAR*>( MakeDispLabel( pFuncWk ) );
-				TreeView_SetItem( hwndTreeRes , &ptdi->item );	//	•ÒWŒ‹‰Ê‚ğ”½‰f
+				TreeView_SetItem( hwndTreeRes , &ptdi->item );	//	ç·¨é›†çµæœã‚’åæ˜ 
 
-				// •ÒW‚ÌƒƒbƒZ[ƒWˆ—‚ğ–ß‚·
+				// ç·¨é›†æ™‚ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†ã‚’æˆ»ã™
 				SetWindowLongPtr( TreeView_GetEditControl( hwndTreeRes ), GWLP_WNDPROC, (LONG_PTR)m_wpEdit );
 				m_wpEdit = NULL;
 			}
@@ -367,7 +367,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 			if (!bInMove && !msMenu.empty()
 			  && pNMHDR->hwndFrom == hwndTreeRes
 			  && (htiItem = TreeView_GetSelection( hwndTreeRes )) != NULL) {
-				//•t‘®î•ñ‚ğíœ
+				//ä»˜å±æƒ…å ±ã‚’å‰Šé™¤
 				tvi.mask = TVIF_HANDLE | TVIF_PARAM;
 				tvi.hItem = htiItem;
 				if (TreeView_GetItem( hwndTreeRes, &tvi )) {
@@ -377,7 +377,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 			}
 			break;
 		case NM_DBLCLK:
-			// ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Ìˆ—
+			// ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯æ™‚ã®å‡¦ç†
 			if (pNMHDR->hwndFrom == hwndTreeRes) {
 				htiItem = TreeView_GetSelection( hwndTreeRes );
 				if (htiItem == NULL) {
@@ -414,9 +414,9 @@ INT_PTR CPropMainMenu::DispatchEvent(
 		break;
 
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID = LOWORD(wParam);			/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
-		hwndCtl = (HWND) lParam;		/* ƒRƒ“ƒgƒ[ƒ‹‚Ìƒnƒ“ƒhƒ‹ */
+		wNotifyCode = HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID = LOWORD(wParam);			/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
+		hwndCtl = (HWND) lParam;		/* ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã®ãƒãƒ³ãƒ‰ãƒ« */
 
 		if (hwndComboFunkKind == hwndCtl) {
 			switch( wNotifyCode ){
@@ -424,14 +424,14 @@ INT_PTR CPropMainMenu::DispatchEvent(
 				nIdxFIdx = Combo_GetCurSel( hwndComboFunkKind );
 
 				if (nIdxFIdx == nSpecialFuncsNum) {
-					// ‹@”\ˆê——‚É“Áê‹@”\‚ğƒZƒbƒg
+					// æ©Ÿèƒ½ä¸€è¦§ã«ç‰¹æ®Šæ©Ÿèƒ½ã‚’ã‚»ãƒƒãƒˆ
 					List_ResetContent( hwndListFunk );
 					for (i = 0; i < nsFuncCode::nFuncList_Special_Num; i++) {
 						List_AddString( hwndListFunk, LS(nsFuncCode::pnFuncList_Special[i]) );
 					}
 				}
 				else {
-					/* ‹@”\ˆê——‚É•¶š—ñ‚ğƒZƒbƒgiƒŠƒXƒgƒ{ƒbƒNƒXj*/
+					/* æ©Ÿèƒ½ä¸€è¦§ã«æ–‡å­—åˆ—ã‚’ã‚»ãƒƒãƒˆï¼ˆãƒªã‚¹ãƒˆãƒœãƒƒã‚¯ã‚¹ï¼‰*/
 					m_cLookup.SetListItem( hwndListFunk, nIdxFIdx );
 				}
 
@@ -440,15 +440,15 @@ INT_PTR CPropMainMenu::DispatchEvent(
 		}
 		else{
 			switch( wNotifyCode ){
-			/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+			/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 			case BN_CLICKED:
 				switch( wID ){
-				case IDC_BUTTON_IMPORT:	/* ƒCƒ“ƒ|[ƒg */
-					/* ƒJƒXƒ^ƒ€ƒƒjƒ…[İ’è‚ğƒCƒ“ƒ|[ƒg‚·‚é */
+				case IDC_BUTTON_IMPORT:	/* ã‚¤ãƒ³ãƒãƒ¼ãƒˆ */
+					/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šã‚’ã‚¤ãƒ³ãƒãƒ¼ãƒˆã™ã‚‹ */
 					Import( hwndDlg );
 					return TRUE;
-				case IDC_BUTTON_EXPORT:	/* ƒGƒNƒXƒ|[ƒg */
-					/* ƒJƒXƒ^ƒ€ƒƒjƒ…[İ’è‚ğƒGƒNƒXƒ|[ƒg‚·‚é */
+				case IDC_BUTTON_EXPORT:	/* ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ */
+					/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šã‚’ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã™ã‚‹ */
 					Export( hwndDlg );
 					return TRUE;
 
@@ -457,10 +457,10 @@ INT_PTR CPropMainMenu::DispatchEvent(
 						LS(STR_PROPCOMMAINMENU_CLEAR)) ) {
 						return TRUE;
 					}
-					// “à•”ƒf[ƒ^‰Šú‰»
+					// å†…éƒ¨ãƒ‡ãƒ¼ã‚¿åˆæœŸåŒ–
 					msMenu.clear();
 					nMenuCnt = 0;
-					// TreeView‰Šú‰»
+					// TreeViewåˆæœŸåŒ–
 					TreeView_DeleteAllItems( hwndTreeRes );
 					return TRUE;
 
@@ -469,7 +469,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 						LS(STR_PROPCOMMAINMENU_INIT))) {
 						return TRUE;
 					}
-					// ‰Šúó‘Ô‚É–ß‚·
+					// åˆæœŸçŠ¶æ…‹ã«æˆ»ã™
 					{
 						CDataProfile	cProfile;
 						std::vector<std::wstring> data;
@@ -492,7 +492,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 						}
 						htiTemp = TreeView_GetNextSibling( hwndTreeRes, htiItem );
 						if (htiTemp == NULL) {
-							// ––”ö‚È‚ç‚ÎA‘O‚ğæ‚é
+							// æœ«å°¾ãªã‚‰ã°ã€å‰ã‚’å–ã‚‹
 							htiTemp = TreeView_GetPrevSibling( hwndTreeRes, htiItem );
 						}
 						TreeView_DeleteItem( hwndTreeRes, htiItem );
@@ -503,29 +503,29 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					break;
 
 
-				case IDC_BUTTON_INSERT_NODE:			// ƒm[ƒh‘}“ü
-				case IDC_BUTTON_INSERTSEPARATOR:		// ‹æØü‘}“ü
-				case IDC_BUTTON_INSERT:					// ‘}“ü(ã)
-				case IDC_BUTTON_INSERT_A:				// ‘}“ü(‰º)
-				case IDC_BUTTON_ADD:					// ’Ç‰Á
+				case IDC_BUTTON_INSERT_NODE:			// ãƒãƒ¼ãƒ‰æŒ¿å…¥
+				case IDC_BUTTON_INSERTSEPARATOR:		// åŒºåˆ‡ç·šæŒ¿å…¥
+				case IDC_BUTTON_INSERT:					// æŒ¿å…¥(ä¸Š)
+				case IDC_BUTTON_INSERT_A:				// æŒ¿å…¥(ä¸‹)
+				case IDC_BUTTON_ADD:					// è¿½åŠ 
 					eFuncCode = F_INVALID;
 					bIsNode = false;
 					switch (wID) {
-					case IDC_BUTTON_INSERT_NODE:		// ƒm[ƒh‘}“ü
+					case IDC_BUTTON_INSERT_NODE:		// ãƒãƒ¼ãƒ‰æŒ¿å…¥
 						eFuncCode = F_NODE;
 						bIsNode = true;
 						auto_strncpy( szLabel , LSW(STR_PROPCOMMAINMENU_EDIT), _countof(szLabel) - 1 );
 						szLabel[_countof(szLabel) - 1] = L'\0';
 						break;
-					case IDC_BUTTON_INSERTSEPARATOR:	// ‹æØü‘}“ü
+					case IDC_BUTTON_INSERTSEPARATOR:	// åŒºåˆ‡ç·šæŒ¿å…¥
 						eFuncCode = F_SEPARATOR;
 						auto_strncpy( szLabel , LSW(STR_PROPCOMMAINMENU_SEP), _countof(szLabel) - 1 );
 						szLabel[_countof(szLabel) - 1] = L'\0';
 						break;
-					case IDC_BUTTON_INSERT:				// ‘}“ü
-					case IDC_BUTTON_INSERT_A:			// ‘}“ü
-					case IDC_BUTTON_ADD:				// ’Ç‰Á
-						// Function æ“¾
+					case IDC_BUTTON_INSERT:				// æŒ¿å…¥
+					case IDC_BUTTON_INSERT_A:			// æŒ¿å…¥
+					case IDC_BUTTON_ADD:				// è¿½åŠ 
+						// Function å–å¾—
 						if (CB_ERR == (nIdxFIdx = Combo_GetCurSel( hwndComboFunkKind ))) {
 							return FALSE;
 						}
@@ -533,7 +533,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 							return FALSE;
 						}
 						if (nIdxFIdx == nSpecialFuncsNum) {
-							// “Áê‹@”\
+							// ç‰¹æ®Šæ©Ÿèƒ½
 							auto_strcpy( szLabel, LSW(nsFuncCode::pnFuncList_Special[nIdxFunc]) );
 							eFuncCode = nsFuncCode::pnFuncList_Special[nIdxFunc];
 						}
@@ -548,43 +548,43 @@ INT_PTR CPropMainMenu::DispatchEvent(
 						break;
 					}
 
-					// ‘}“üˆÊ’uŒŸõ
+					// æŒ¿å…¥ä½ç½®æ¤œç´¢
 					htiTemp = TreeView_GetSelection( hwndTreeRes );
 					if (htiTemp == NULL) {
-						// æ‚ê‚È‚©‚Á‚½‚çRoot‚Ì––”ö
+						// å–ã‚Œãªã‹ã£ãŸã‚‰Rootã®æœ«å°¾
 						htiParent = TVI_ROOT;
 						htiTemp = TVI_LAST;
 					}
 					else {
 						if (wID == IDC_BUTTON_ADD) {
-							// ’Ç‰Á
+							// è¿½åŠ 
 							tvi.mask = TVIF_HANDLE | TVIF_PARAM;
 							tvi.hItem = htiTemp;
 							if (!TreeView_GetItem( hwndTreeRes, &tvi )) {
-								// æ‚ê‚È‚©‚Á‚½‚çRoot‚Ì––”ö
+								// å–ã‚Œãªã‹ã£ãŸã‚‰Rootã®æœ«å°¾
 								htiParent = TVI_ROOT;
 								htiTemp = TVI_LAST;
 							}
 							else {
 								if (msMenu[tvi.lParam].m_bIsNode) {
-									// ƒm[ƒh
+									// ãƒãƒ¼ãƒ‰
 									htiParent = htiTemp;
 									htiTemp = TVI_LAST;
 								}
 								else {
-									// q‚ğ•t‚¯‚ç‚ê‚È‚¢‚Ì‚Åe‚É•t‚¯‚éi‘I‘ğƒAƒCƒeƒ€‚Ì‰º‚É•t‚­j
+									// å­ã‚’ä»˜ã‘ã‚‰ã‚Œãªã„ã®ã§è¦ªã«ä»˜ã‘ã‚‹ï¼ˆé¸æŠã‚¢ã‚¤ãƒ†ãƒ ã®ä¸‹ã«ä»˜ãï¼‰
 									htiParent = TreeView_GetParent( hwndTreeRes, htiTemp );
 									htiTemp = TVI_LAST;
 									if (htiParent == NULL) {
-										// æ‚ê‚È‚©‚Á‚½‚çRoot‚Ì––”ö
+										// å–ã‚Œãªã‹ã£ãŸã‚‰Rootã®æœ«å°¾
 										htiParent = TVI_ROOT;
 									}
 								}
 							}
 						}
 						else if (wID == IDC_BUTTON_INSERT_NODE || wID == IDC_BUTTON_INSERT_A) {
-							// ƒm[ƒh‘}“üA‘}“ü(‰º)
-							// ’Ç‰Áæ‚ğ’T‚é
+							// ãƒãƒ¼ãƒ‰æŒ¿å…¥ã€æŒ¿å…¥(ä¸‹)
+							// è¿½åŠ å…ˆã‚’æ¢ã‚‹
 							htiTemp = TreeView_GetSelection( hwndTreeRes );
 							if (htiTemp == NULL) {
 								htiParent = TVI_ROOT;
@@ -595,47 +595,47 @@ INT_PTR CPropMainMenu::DispatchEvent(
 								tvi.hItem = htiTemp;
 								if (TreeView_GetItem( hwndTreeRes, &tvi )) {
 									if (msMenu[tvi.lParam].m_bIsNode) {
-										// ƒm[ƒh
+										// ãƒãƒ¼ãƒ‰
 										htiParent = htiTemp;
 										htiTemp = TVI_FIRST;
 									}
 									else {
-										// q‚ğ•t‚¯‚ç‚ê‚È‚¢‚Ì‚Åe‚É•t‚¯‚éi‘I‘ğƒAƒCƒeƒ€‚Ì‰º‚É•t‚­j
+										// å­ã‚’ä»˜ã‘ã‚‰ã‚Œãªã„ã®ã§è¦ªã«ä»˜ã‘ã‚‹ï¼ˆé¸æŠã‚¢ã‚¤ãƒ†ãƒ ã®ä¸‹ã«ä»˜ãï¼‰
 										htiParent = TreeView_GetParent( hwndTreeRes, htiTemp );
 										if (htiParent == NULL) {
-											// æ‚ê‚È‚©‚Á‚½‚çRoot
+											// å–ã‚Œãªã‹ã£ãŸã‚‰Root
 											htiParent = TVI_ROOT;
 										}
 									}
 								}
 								else {
-									// æ‚ê‚È‚©‚Á‚½‚çRoot
+									// å–ã‚Œãªã‹ã£ãŸã‚‰Root
 									htiParent = TVI_ROOT;
 									htiTemp = TVI_LAST;
 								}
 							}
 						}
 						else {
-							// ‘}“ü(ã)A‹æØü
-							// ‘}“üæ‚ğ’T‚é
+							// æŒ¿å…¥(ä¸Š)ã€åŒºåˆ‡ç·š
+							// æŒ¿å…¥å…ˆã‚’æ¢ã‚‹
 							htiParent = TreeView_GetParent( hwndTreeRes, htiTemp );
 							if (htiParent == NULL) {
-								// æ‚ê‚È‚©‚Á‚½‚çRoot‚Ìƒgƒbƒv
+								// å–ã‚Œãªã‹ã£ãŸã‚‰Rootã®ãƒˆãƒƒãƒ—
 								htiParent = TVI_ROOT;
 								htiTemp = TVI_FIRST;
 							}
 							else {
-								// ˆê‚Âè‘O
+								// ä¸€ã¤æ‰‹å‰
 								htiTemp = TreeView_GetPrevSibling( hwndTreeRes, htiTemp );
 								if (htiTemp == NULL) {
-									// æ‚ê‚È‚©‚Á‚½‚çe‚ÌÅ‰
+									// å–ã‚Œãªã‹ã£ãŸã‚‰è¦ªã®æœ€åˆ
 									htiTemp = TVI_FIRST;
 								}
 							}
 						}
 					}
 
-					// TreeView‚É‘}“ü
+					// TreeViewã«æŒ¿å…¥
 					pFuncWk = &msMenu[nMenuCnt];
 					pFuncWk->m_nFunc = (EFunctionCode)eFuncCode;
 					pFuncWk->m_sName = szLabel;
@@ -649,17 +649,17 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					tvis.item.lParam = nMenuCnt++;
 					tvis.item.cChildren = ( wID == IDC_BUTTON_INSERT_NODE );
 					htiItem = TreeView_InsertItem( hwndTreeRes, &tvis );
-					// “WŠJ
+					// å±•é–‹
 					if (htiParent != TVI_ROOT) {
 						TreeView_Expand( hwndTreeRes, htiParent, TVE_EXPAND );
 					}
 					TreeView_SelectItem( hwndTreeRes, htiItem );
 
-					// ƒŠƒXƒg‚ğ1‚Âi‚ß‚é
+					// ãƒªã‚¹ãƒˆã‚’1ã¤é€²ã‚ã‚‹
 					switch (wID) {
-					case IDC_BUTTON_INSERT:				// ‘}“ü
-					case IDC_BUTTON_INSERT_A:			// ‘}“ü
-					case IDC_BUTTON_ADD:				// ’Ç‰Á
+					case IDC_BUTTON_INSERT:				// æŒ¿å…¥
+					case IDC_BUTTON_INSERT_A:			// æŒ¿å…¥
+					case IDC_BUTTON_ADD:				// è¿½åŠ 
 						List_SetCurSel( hwndListFunk, nIdxFunc+1 );
 						break;
 					}
@@ -673,15 +673,15 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					}
 					htiTemp = TreeView_GetPrevSibling( hwndTreeRes, htiItem );
 					if (htiTemp == NULL) {
-						// ‚»‚ÌƒGƒŠƒA‚ÅÅ‰
+						// ãã®ã‚¨ãƒªã‚¢ã§æœ€åˆ
 						break;
 					}
 
-					// ƒRƒs[
+					// ã‚³ãƒ”ãƒ¼
 					bInMove = true;
 					TreeCopy(hwndTreeRes, htiItem, htiTemp, false, true);
 
-					// íœ
+					// å‰Šé™¤
 					TreeView_DeleteItem( hwndTreeRes, htiTemp );
 					bInMove = false;
 					break;
@@ -693,19 +693,19 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					}
 					htiTemp = TreeView_GetNextSibling( hwndTreeRes, htiItem );
 					if (htiTemp == NULL) {
-						// ‚»‚ÌƒGƒŠƒA‚ÅÅŒã
+						// ãã®ã‚¨ãƒªã‚¢ã§æœ€å¾Œ
 						break;
 					}
 
-					// ƒRƒs[
+					// ã‚³ãƒ”ãƒ¼
 					bInMove = true;
 					TreeCopy(hwndTreeRes, htiTemp, htiItem, false, true);
 
-					// íœ
+					// å‰Šé™¤
 					TreeView_DeleteItem( hwndTreeRes, htiItem );
 					bInMove = false;
 
-					// ‘I‘ğ
+					// é¸æŠ
 					htiItem = TreeView_GetNextSibling( hwndTreeRes, htiTemp );
 					if (htiItem != NULL) {
 						TreeView_SelectItem( hwndTreeRes, htiItem );
@@ -719,33 +719,33 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					}
 					htiTemp = TreeView_GetPrevSibling( hwndTreeRes, htiItem );
 					if (htiTemp == NULL) {
-						// ‚»‚ÌƒGƒŠƒA‚ÅÅ‰
+						// ãã®ã‚¨ãƒªã‚¢ã§æœ€åˆ
 						break;
 					}
-					// ƒm[ƒhŠm”F
+					// ãƒãƒ¼ãƒ‰ç¢ºèª
 					tvi.mask = TVIF_HANDLE | TVIF_PARAM | TVIF_CHILDREN;
 					tvi.hItem = htiTemp;
 					i = TreeView_GetItem( hwndTreeRes, &tvi );
 					if (!TreeView_GetItem( hwndTreeRes, &tvi )) {
-						// ƒGƒ‰[
+						// ã‚¨ãƒ©ãƒ¼
 						break;
 					}
 					if (tvi.cChildren) {
-						// ’¼‘O‚ªƒm[ƒh
+						// ç›´å‰ãŒãƒãƒ¼ãƒ‰
 						HTREEITEM		htiTemp2;
-						// ƒRƒs[
+						// ã‚³ãƒ”ãƒ¼
 						bInMove = true;
 						htiTemp2 = TreeCopy(hwndTreeRes, htiTemp, htiItem, true, true);
 
-						// íœ
+						// å‰Šé™¤
 						TreeView_DeleteItem( hwndTreeRes, htiItem );
 						bInMove = false;
 
-						// ‘I‘ğ
+						// é¸æŠ
 						TreeView_SelectItem( hwndTreeRes, htiTemp2 );
 					}
 					else {
-						// ƒm[ƒh‚ª–³‚¢
+						// ãƒãƒ¼ãƒ‰ãŒç„¡ã„
 						break;
 					}
 					break;
@@ -760,20 +760,20 @@ INT_PTR CPropMainMenu::DispatchEvent(
 						// Root
 						break;
 					}
-					// ƒRƒs[
+					// ã‚³ãƒ”ãƒ¼
 					bInMove = true;
 					htiTemp2 = TreeCopy(hwndTreeRes, htiParent, htiItem, false, true);
 
-					// íœ
+					// å‰Šé™¤
 					TreeView_DeleteItem( hwndTreeRes, htiItem );
 					bInMove = false;
 
-					// ‘I‘ğ
+					// é¸æŠ
 					TreeView_SelectItem( hwndTreeRes, htiTemp2 );
 					break;
 
 
-				case IDC_BUTTON_CHECK:		// ƒƒjƒ…[‚ÌŒŸ¸
+				case IDC_BUTTON_CHECK:		// ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ¤œæŸ»
 					{
 						wstring sErrMsg;
 						if (Check_MainMenu( hwndTreeRes, sErrMsg )) {
@@ -786,11 +786,11 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					break;
 
 
-				case IDC_BUTTON_EXPAND:		// ƒcƒŠ[‘SŠJ
+				case IDC_BUTTON_EXPAND:		// ãƒ„ãƒªãƒ¼å…¨é–‹
 					TreeView_ExpandAll( hwndTreeRes, true );
 					break;
 
-				case IDC_BUTTON_COLLAPSE:	// ƒcƒŠ[‘S•Â
+				case IDC_BUTTON_COLLAPSE:	// ãƒ„ãƒªãƒ¼å…¨é–‰
 					TreeView_ExpandAll( hwndTreeRes, false );
 					break;
 				}
@@ -806,11 +806,11 @@ INT_PTR CPropMainMenu::DispatchEvent(
 	case WM_DESTROY:
 		::KillTimer( hwndDlg, 1 );
 
-		// •ÒW‚ÌƒƒbƒZ[ƒWˆ—‚ğ–ß‚·
+		// ç·¨é›†æ™‚ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†ã‚’æˆ»ã™
 		SetWindowLongPtr( hwndTreeRes, GWLP_WNDPROC, (LONG_PTR)m_wpTreeView );
 		m_wpTreeView = NULL;
 
-		// ƒ[ƒN‚ÌƒNƒŠƒA
+		// ãƒ¯ãƒ¼ã‚¯ã®ã‚¯ãƒªã‚¢
 		msMenu.clear();
 		nMenuCnt = 0;
 		break;
@@ -834,13 +834,13 @@ INT_PTR CPropMainMenu::DispatchEvent(
 
 
 
-// & ‚Ì•âŠ®
+// & ã®è£œå®Œ
 static wstring	SupplementAmpersand( wstring sLavel)
 {
 	size_t	nPos =0;
 	while ((nPos = sLavel.find( L"&", nPos)) != wstring::npos) {
 		if (sLavel[nPos+1] != L'&') {
-			// &&‚Å‚È‚¢
+			// &&ã§ãªã„
 			sLavel.replace( nPos, 1, L"&&");
 		}
 		nPos +=2;
@@ -848,7 +848,7 @@ static wstring	SupplementAmpersand( wstring sLavel)
 	return sLavel;
 }
 
-// & ‚Ìíœ
+// & ã®å‰Šé™¤
 static wstring	RemoveAmpersand( wstring sLavel)
 {
 	size_t	nPos =0;
@@ -862,7 +862,7 @@ static wstring	RemoveAmpersand( wstring sLavel)
 	return sLavel;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è MainMenu */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š MainMenu */
 void CPropMainMenu::SetData( HWND hwndDlg )
 {
 	CMainMenu*		pcMenuTBL = m_Common.m_sMainMenu.m_cMainMenuTbl;
@@ -875,32 +875,32 @@ void CPropMainMenu::SetData( HWND hwndDlg )
 	int				nCurLevel;
 	HTREEITEM		htiItem;
 	HTREEITEM		htiParent;
-	TV_INSERTSTRUCT	tvis;			// ‘}“ü—p
-	SMainMenuWork*	pFuncWk;		// ‹@”\(work)
+	TV_INSERTSTRUCT	tvis;			// æŒ¿å…¥ç”¨
+	SMainMenuWork*	pFuncWk;		// æ©Ÿèƒ½(work)
 	int 			i;
 
-	/* ‹@”\í•Êˆê——‚É•¶š—ñ‚ğƒZƒbƒgiƒRƒ“ƒ{ƒ{ƒbƒNƒXj */
+	/* æ©Ÿèƒ½ç¨®åˆ¥ä¸€è¦§ã«æ–‡å­—åˆ—ã‚’ã‚»ãƒƒãƒˆï¼ˆã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ï¼‰ */
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_FUNCKIND );
 	m_cLookup.SetCategory2Combo( hwndCombo );
 
-	// “Á•Ê‹@”\’Ç‰Á
+	// ç‰¹åˆ¥æ©Ÿèƒ½è¿½åŠ 
 	nSpecialFuncsNum = Combo_AddString( hwndCombo, LS( STR_SPECIAL_FUNC ) );
 
-	/* í•Ê‚Ìæ“ª‚Ì€–Ú‚ğ‘I‘ğiƒRƒ“ƒ{ƒ{ƒbƒNƒXj*/
+	/* ç¨®åˆ¥ã®å…ˆé ­ã®é …ç›®ã‚’é¸æŠï¼ˆã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ï¼‰*/
 	Combo_SetCurSel( hwndCombo, 0 );
 
-	// ƒ[ƒNATreeView‚Ì‰Šú‰»
+	// ãƒ¯ãƒ¼ã‚¯ã€TreeViewã®åˆæœŸåŒ–
 	msMenu.clear();
 	nMenuCnt = 0;
 
 	hwndTreeRes = ::GetDlgItem( hwndDlg, IDC_TREE_RES );
 	TreeView_DeleteAllItems( hwndTreeRes );
 
-	// ƒAƒNƒZƒXƒL[‚ğ( )•t‚Å•\¦
+	// ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã‚’( )ä»˜ã§è¡¨ç¤º
 	hwndCheck = ::GetDlgItem( hwndDlg, IDC_CHECK_KEY_PARENTHESES );
 	BtnCtl_SetCheck( hwndCheck, m_Common.m_sMainMenu.m_bMainMenuKeyParentheses );
 
-	/* ƒƒjƒ…[€–Úˆê——‚Æ“à•”ƒf[ƒ^‚ğƒZƒbƒgiTreeViewj*/
+	/* ãƒ¡ãƒ‹ãƒ¥ãƒ¼é …ç›®ä¸€è¦§ã¨å†…éƒ¨ãƒ‡ãƒ¼ã‚¿ã‚’ã‚»ãƒƒãƒˆï¼ˆTreeViewï¼‰*/
 	nCurLevel = 0;
 	htiParent = TVI_ROOT;
 	htiItem = TreeView_GetRoot( hwndTreeRes );
@@ -916,13 +916,13 @@ void CPropMainMenu::SetData( HWND hwndDlg )
 		else if (pcFunc->m_nLevel > nCurLevel) {
 			// Level Down
 			for ( htiParent = htiItem, nCurLevel++; pcFunc->m_nLevel < nCurLevel; nCurLevel++) {
-				// Às‚³‚ê‚é‚±‚Æ‚Í–³‚¢‚Í‚¸iƒf[ƒ^‚ª³í‚È‚ç‚Îj
+				// å®Ÿè¡Œã•ã‚Œã‚‹ã“ã¨ã¯ç„¡ã„ã¯ãšï¼ˆãƒ‡ãƒ¼ã‚¿ãŒæ­£å¸¸ãªã‚‰ã°ï¼‰
 				htiParent = TreeView_GetChild( hwndTreeRes, htiItem );
 				if (htiParent == NULL)		htiParent = htiItem;
 			}
 		}
 
-		// “à•”ƒf[ƒ^‚ğì¬
+		// å†…éƒ¨ãƒ‡ãƒ¼ã‚¿ã‚’ä½œæˆ
 		pFuncWk = &msMenu[nMenuCnt];
 		pFuncWk->m_nFunc = pcFunc->m_nFunc;
 		pFuncWk->m_bIsNode = false;
@@ -935,12 +935,12 @@ void CPropMainMenu::SetData( HWND hwndDlg )
 				pFuncWk->m_sName = LSW(STR_PROPCOMMAINMENU_SEP);
 				break;
 			case T_SPECIAL:
-				// 2014.05.04 Še‘Œê‘Î‰
+				// 2014.05.04 å„å›½èªå¯¾å¿œ
 				pFuncWk->m_sName = LSW(pcFunc->m_nFunc);
 				break;
 			case T_NODE:
 				pFuncWk->m_bIsNode = true;
-				// ƒ‰ƒxƒ‹•ÒWŒã‚Ìƒm[ƒh‚Íini‚©‚çA‚»‚êˆÈŠO‚ÍƒŠƒ\[ƒX‚©‚çƒ‰ƒxƒ‹‚ğæ“¾ 2012.10.14 syat Še‘Œê‘Î‰
+				// ãƒ©ãƒ™ãƒ«ç·¨é›†å¾Œã®ãƒãƒ¼ãƒ‰ã¯iniã‹ã‚‰ã€ãã‚Œä»¥å¤–ã¯ãƒªã‚½ãƒ¼ã‚¹ã‹ã‚‰ãƒ©ãƒ™ãƒ«ã‚’å–å¾— 2012.10.14 syat å„å›½èªå¯¾å¿œ
 				if (pFuncWk->m_nFunc == F_NODE) {
 					pFuncWk->m_sName = RemoveAmpersand( pcFunc->m_sName );
 				} else {
@@ -950,29 +950,29 @@ void CPropMainMenu::SetData( HWND hwndDlg )
 		}
 		auto_strcpy(pFuncWk->m_sKey, pcFunc->m_sKey);
 		pFuncWk->m_bDupErr = false;
-		// TreeView‚É‘}“ü
+		// TreeViewã«æŒ¿å…¥
 		tvis.item.mask = TVIF_TEXT | TVIF_PARAM | TVIF_CHILDREN;
 		tvis.hParent = htiParent;
 		tvis.hInsertAfter = TVI_LAST;
 		tvis.item.pszText = const_cast<TCHAR*>( MakeDispLabel( pFuncWk ) );
-		tvis.item.lParam = nMenuCnt++;								// “à•”ƒf[ƒ^ƒCƒ“ƒfƒbƒNƒX‚ÌƒCƒ“ƒNƒŠƒƒ“ƒg
+		tvis.item.lParam = nMenuCnt++;								// å†…éƒ¨ãƒ‡ãƒ¼ã‚¿ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ã®ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ãƒˆ
 		tvis.item.cChildren = ( pcFunc->m_nType == T_NODE );
 		htiItem = TreeView_InsertItem( hwndTreeRes, &tvis );
 	}
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ MainMenu */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— MainMenu */
 int CPropMainMenu::GetData( HWND hwndDlg )
 {
 	HWND			hwndTreeRes;
 	HWND			hwndCheck;
 	HTREEITEM		htiItem;
 
-	// ƒAƒNƒZƒXƒL[‚ğ( )•t‚Å•\¦
+	// ã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ã‚’( )ä»˜ã§è¡¨ç¤º
 	hwndCheck = ::GetDlgItem( hwndDlg, IDC_CHECK_KEY_PARENTHESES );
 	m_Common.m_sMainMenu.m_bMainMenuKeyParentheses = (BtnCtl_GetCheck( hwndCheck ) != 0);
 
-	// ƒƒjƒ…[ƒgƒbƒv€–Ú‚ğƒZƒbƒg
+	// ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒˆãƒƒãƒ—é …ç›®ã‚’ã‚»ãƒƒãƒˆ
 	m_Common.m_sMainMenu.m_nMainMenuNum = 0;
 	memset( m_Common.m_sMainMenu.m_nMenuTopIdx, -1, sizeof(m_Common.m_sMainMenu.m_nMenuTopIdx) );
 
@@ -984,7 +984,7 @@ int CPropMainMenu::GetData( HWND hwndDlg )
 	return TRUE;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ TreeView‚Ì 1 level */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— TreeViewã® 1 level */
 bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 {
 	static	bool	bOptionOk;
@@ -992,18 +992,18 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 	CMainMenu*		pcFunc;
 	HTREEITEM		s;
 	HTREEITEM		ts;
-	TV_ITEM			tvi;			// æ“¾—p
-	SMainMenuWork*	pFuncWk;		// ‹@”\(work)
+	TV_ITEM			tvi;			// å–å¾—ç”¨
+	SMainMenuWork*	pFuncWk;		// æ©Ÿèƒ½(work)
 	int 			nTopCount = 0;
 
 	if (nLevel == 0) {
-		// ‹¤’Êİ’èƒtƒ‰ƒO
+		// å…±é€šè¨­å®šãƒ•ãƒ©ã‚°
 		bOptionOk = false;
 	}
 
 	for (s = htiTrg; s != NULL; s = TreeView_GetNextSibling( hwndTree, s )) {
 		if (m_Common.m_sMainMenu.m_nMainMenuNum >= MAX_MAINMENU) {
-			// “o˜^” over
+			// ç™»éŒ²æ•° over
 			return false;
 		}
 		tvi.mask = TVIF_HANDLE | TVIF_PARAM | TVIF_CHILDREN;
@@ -1018,7 +1018,7 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 			if (nTopCount >= MAX_MAINMENU_TOP) {
 				continue;
 			}
-			// Top Level‚Ì‹L˜^
+			// Top Levelã®è¨˜éŒ²
 			m_Common.m_sMainMenu.m_nMenuTopIdx[nTopCount++] = m_Common.m_sMainMenu.m_nMainMenuNum;
 		}
 		pcFunc = &pcMenuTBL[m_Common.m_sMainMenu.m_nMainMenuNum++];
@@ -1034,14 +1034,14 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 			break;
 		default:
 			if ( pFuncWk->m_bIsNode ) {
-				// ƒRƒ}ƒ“ƒh’è‹`ŠO‚ÌID‚Ìê‡Aƒm[ƒh‚Æ‚µ‚Äˆµ‚¤ 2012.10.14 syat Še‘Œê‘Î‰
+				// ã‚³ãƒãƒ³ãƒ‰å®šç¾©å¤–ã®IDã®å ´åˆã€ãƒãƒ¼ãƒ‰ã¨ã—ã¦æ‰±ã† 2012.10.14 syat å„å›½èªå¯¾å¿œ
 				pcFunc->m_nType = T_NODE;
-				pcFunc->m_sName[0] = L'\0';	// –¼‘O‚ÍAƒŠƒ\[ƒX‚©‚çæ“¾‚·‚é‚½‚ß‹ó”’‚Éİ’è
+				pcFunc->m_sName[0] = L'\0';	// åå‰ã¯ã€ãƒªã‚½ãƒ¼ã‚¹ã‹ã‚‰å–å¾—ã™ã‚‹ãŸã‚ç©ºç™½ã«è¨­å®š
 				break;
 			}
 			if (pFuncWk->m_nFunc >= F_SPECIAL_FIRST && pFuncWk->m_nFunc <= F_SPECIAL_LAST) {
 				pcFunc->m_nType = T_SPECIAL;
-				// 2014.05.04 nLevel == 0 ‚Ì‚Æ‚«‚à"–¼‘O‚È‚µ"‚É‚·‚é
+				// 2014.05.04 nLevel == 0 ã®ã¨ãã‚‚"åå‰ãªã—"ã«ã™ã‚‹
 				pcFunc->m_sName[0] = L'\0';
 			}
 			else {
@@ -1058,7 +1058,7 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 		pcFunc->m_nLevel = nLevel;
 
 		if (tvi.cChildren) {
-			ts = TreeView_GetChild( hwndTree, s );	//	q‚Ìæ“¾
+			ts = TreeView_GetChild( hwndTree, s );	//	å­ã®å–å¾—
 			if (ts != NULL) {
 				if (!GetDataTree( hwndTree, ts, nLevel+1 )) {
 					return false;
@@ -1068,11 +1068,11 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 	}
 
 	if (nLevel == 0 && !bOptionOk) {
-		// ‹¤’Êİ’è‚ª–³‚¢
+		// å…±é€šè¨­å®šãŒç„¡ã„
 		if (nTopCount < MAX_MAINMENU_TOP && m_Common.m_sMainMenu.m_nMainMenuNum+1 < MAX_MAINMENU) {
-			// Top Level‚Ì‹L˜^
+			// Top Levelã®è¨˜éŒ²
 			m_Common.m_sMainMenu.m_nMenuTopIdx[nTopCount++] = m_Common.m_sMainMenu.m_nMainMenuNum;
-			// Top Level‚Ì’Ç‰Áiƒ_ƒ~[j
+			// Top Levelã®è¿½åŠ ï¼ˆãƒ€ãƒŸãƒ¼ï¼‰
 			pcFunc = &pcMenuTBL[m_Common.m_sMainMenu.m_nMainMenuNum++];
 			pcFunc->m_nType = T_NODE;
 			pcFunc->m_nFunc = F_NODE;
@@ -1081,11 +1081,11 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 			pcFunc->m_nLevel = nLevel++;
 		}
 		else {
-			// ––”ö‚É’Ç‰Á‚ğw’è
+			// æœ«å°¾ã«è¿½åŠ ã‚’æŒ‡å®š
 			nLevel = 1;
 		}
 		if (m_Common.m_sMainMenu.m_nMainMenuNum < MAX_MAINMENU) {
-			// ‹¤’Êİ’è
+			// å…±é€šè¨­å®š
 			pcFunc = &pcMenuTBL[m_Common.m_sMainMenu.m_nMainMenuNum++];
 			pcFunc->m_nType = T_LEAF;
 			pcFunc->m_nFunc = F_OPTION;
@@ -1094,7 +1094,7 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 			pcFunc->m_nLevel = nLevel;
 		}
 		else {
-			// “o˜^” over
+			// ç™»éŒ²æ•° over
 			return false;
 		}
 	}
@@ -1104,45 +1104,45 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 
 
 
-/* ƒƒCƒ“ƒƒjƒ…[İ’è‚ğƒCƒ“ƒ|[ƒg‚·‚é */
+/* ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šã‚’ã‚¤ãƒ³ãƒãƒ¼ãƒˆã™ã‚‹ */
 void CPropMainMenu::Import( HWND hwndDlg )
 {
 	CImpExpMainMenu	cImpExp( m_Common );
 
-	// ƒCƒ“ƒ|[ƒg
+	// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 	if (!cImpExp.ImportUI( G_AppInstance(), hwndDlg )) {
-		// ƒCƒ“ƒ|[ƒg‚ğ‚µ‚Ä‚¢‚È‚¢
+		// ã‚¤ãƒ³ãƒãƒ¼ãƒˆã‚’ã—ã¦ã„ãªã„
 		return;
 	}
 	SetData( hwndDlg );
 }
 
-/* ƒƒCƒ“ƒƒjƒ…[İ’è‚ğƒGƒNƒXƒ|[ƒg‚·‚é */
+/* ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šã‚’ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã™ã‚‹ */
 void CPropMainMenu::Export( HWND hwndDlg )
 {
 	CImpExpMainMenu	cImpExp( m_Common );
 
 	GetData( hwndDlg );
 
-	// ƒGƒNƒXƒ|[ƒg
+	// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 	if (!cImpExp.ExportUI( G_AppInstance(), hwndDlg )) {
-		// ƒGƒNƒXƒ|[ƒg‚ğ‚µ‚Ä‚¢‚È‚¢
+		// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã‚’ã—ã¦ã„ãªã„
 		return;
 	}
 }
 
 
 
-// ƒcƒŠ[‚ÌƒRƒs[
-//		fChild‚ªtrue‚Ì‚Ídst‚Ìq‚Æ‚µ‚ÄƒRƒs[, ‚»‚¤‚Å‚È‚¯‚ê‚Îdst‚ÌŒZ’í‚Æ‚µ‚Ädst‚ÌŒã‚ë‚ÉƒRƒs[
-//		fOnryOne‚ªtrue‚Ì‚Í1‚Â‚¾‚¯ƒRƒs[iq‚ª‚ ‚Á‚½‚çƒRƒs[j
+// ãƒ„ãƒªãƒ¼ã®ã‚³ãƒ”ãƒ¼
+//		fChildãŒtrueã®æ™‚ã¯dstã®å­ã¨ã—ã¦ã‚³ãƒ”ãƒ¼, ãã†ã§ãªã‘ã‚Œã°dstã®å…„å¼Ÿã¨ã—ã¦dstã®å¾Œã‚ã«ã‚³ãƒ”ãƒ¼
+//		fOnryOneãŒtrueã®æ™‚ã¯1ã¤ã ã‘ã‚³ãƒ”ãƒ¼ï¼ˆå­ãŒã‚ã£ãŸã‚‰ã‚³ãƒ”ãƒ¼ï¼‰
 static HTREEITEM TreeCopy( HWND hwndTree, HTREEITEM dst, HTREEITEM src, bool fChild, bool fOnryOne )
 {
 	HTREEITEM		s;
 	HTREEITEM		ts;
 	HTREEITEM		td = NULL;
-	TV_INSERTSTRUCT	tvis;		// ‘}“ü—p
-	TV_ITEM			tvi;		// æ“¾—p
+	TV_INSERTSTRUCT	tvis;		// æŒ¿å…¥ç”¨
+	TV_ITEM			tvi;		// å–å¾—ç”¨
 	int				n = 0;
 #ifdef _UNICODE
 	const int		MAX_LABEL_CCH = 256+10;
@@ -1162,26 +1162,26 @@ static HTREEITEM TreeCopy( HWND hwndTree, HTREEITEM dst, HTREEITEM src, bool fCh
 		}
 		tvis.item.mask = TVIF_TEXT | TVIF_PARAM | TVIF_CHILDREN;
 		if (fChild || n != 0) {
-			// dst‚Ìq‹Ÿ‚Æ‚µ‚Äì¬
+			// dstã®å­ä¾›ã¨ã—ã¦ä½œæˆ
 			tvis.hParent = dst;
 			tvis.hInsertAfter = TVI_LAST;
 		}
 		else {
-			//	dst‚ÌŒZ’í‚Æ‚µ‚Äì¬
+			//	dstã®å…„å¼Ÿã¨ã—ã¦ä½œæˆ
 			tvis.hParent = TreeView_GetParent( hwndTree, dst );
 			tvis.hInsertAfter = dst;
 		}
 		tvis.item.pszText = szLabel;
 		tvis.item.lParam = tvi.lParam;
 		tvis.item.cChildren = tvi.cChildren;
-		td = TreeView_InsertItem( hwndTree, &tvis );	//	Item‚Ìì¬
+		td = TreeView_InsertItem( hwndTree, &tvis );	//	Itemã®ä½œæˆ
 
 		if (tvi.cChildren) {
-			ts = TreeView_GetChild( hwndTree, s );	//	q‚Ìæ“¾
+			ts = TreeView_GetChild( hwndTree, s );	//	å­ã®å–å¾—
 			if (ts != NULL) {
 				TreeCopy( hwndTree, td, ts, true, false );
 			}
-			// “WŠJ
+			// å±•é–‹
 			if (tvi.state & TVIS_EXPANDEDONCE) {
 				TreeView_Expand( hwndTree, td, TVE_EXPAND );
 			}
@@ -1192,7 +1192,7 @@ static HTREEITEM TreeCopy( HWND hwndTree, HTREEITEM dst, HTREEITEM src, bool fCh
 	return td;
 }
 
-// •\¦—pƒf[ƒ^‚Ìì¬iƒAƒNƒZƒXƒL[•t‰Áj
+// è¡¨ç¤ºç”¨ãƒ‡ãƒ¼ã‚¿ã®ä½œæˆï¼ˆã‚¢ã‚¯ã‚»ã‚¹ã‚­ãƒ¼ä»˜åŠ ï¼‰
 static const TCHAR* MakeDispLabel( SMainMenuWork* pFunc )
 {
 	static	WCHAR	szLabel[MAX_MAIN_MENU_NAME_LEN + 10];
@@ -1213,10 +1213,10 @@ static const TCHAR* MakeDispLabel( SMainMenuWork* pFunc )
 
 
 
-// ƒƒjƒ…[‚ÌŒŸ¸
+// ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ¤œæŸ»
 bool CPropMainMenu::Check_MainMenu( 
 	HWND	hwndTree,		// handle to TreeView
-	wstring&	sErrMsg			// ƒGƒ‰[ƒƒbƒZ[ƒW
+	wstring&	sErrMsg			// ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
 )
 {
 	HTREEITEM		htiItem;
@@ -1229,28 +1229,28 @@ bool CPropMainMenu::Check_MainMenu(
 	return bRet;
 }
 
-// ƒƒjƒ…[‚ÌŒŸ¸ TreeView‚Ì 1 level
+// ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ¤œæŸ» TreeViewã® 1 level
 bool CPropMainMenu::Check_MainMenu_Sub(
 	HWND		hwndTree,		// handle to dialog box
-	HTREEITEM 	htiTrg,			// ƒ^[ƒQƒbƒg
+	HTREEITEM 	htiTrg,			// ã‚¿ãƒ¼ã‚²ãƒƒãƒˆ
 	int 		nLevel,
 	wstring&	sErrMsg )
 {
-	// ŒŸ¸—p
-	static	bool		bOptionOk;		// u‹¤’Êİ’èv
-	static	int 		nMenuNum;		// ƒƒjƒ…[€–Ú”		Å‘å MAX_MAINMENU
-	static	int 		nTopNum;		// ƒgƒbƒvƒŒƒxƒ‹€–Ú”	Å‘å MAX_MAINMENU_TOP
-	static	int 		nDupErrNum;		// d•¡ƒGƒ‰[ŒÂ”
-	static	int 		nNoSetErrNum;	// –¢İ’èƒGƒ‰[ŒÂ”
+	// æ¤œæŸ»ç”¨
+	static	bool		bOptionOk;		// ã€Œå…±é€šè¨­å®šã€
+	static	int 		nMenuNum;		// ãƒ¡ãƒ‹ãƒ¥ãƒ¼é …ç›®æ•°		æœ€å¤§ MAX_MAINMENU
+	static	int 		nTopNum;		// ãƒˆãƒƒãƒ—ãƒ¬ãƒ™ãƒ«é …ç›®æ•°	æœ€å¤§ MAX_MAINMENU_TOP
+	static	int 		nDupErrNum;		// é‡è¤‡ã‚¨ãƒ©ãƒ¼å€‹æ•°
+	static	int 		nNoSetErrNum;	// æœªè¨­å®šã‚¨ãƒ©ãƒ¼å€‹æ•°
 	static	HTREEITEM	htiErr;
 	//
 	bool			bRet = true;
 	EMainMenuType	nType;
 	HTREEITEM		s;
 	HTREEITEM		ts;
-	TV_ITEM			tvi;							// æ“¾—p
-	SMainMenuWork*	pFuncWk;						// ‹@”\(work)
-	std::map< WCHAR, HTREEITEM >	mKey;			// d•¡ƒGƒ‰[ŒŸo—p
+	TV_ITEM			tvi;							// å–å¾—ç”¨
+	SMainMenuWork*	pFuncWk;						// æ©Ÿèƒ½(work)
+	std::map< WCHAR, HTREEITEM >	mKey;			// é‡è¤‡ã‚¨ãƒ©ãƒ¼æ¤œå‡ºç”¨
 
 	if (nLevel == 0) {
 		bOptionOk = false;
@@ -1260,7 +1260,7 @@ bool CPropMainMenu::Check_MainMenu_Sub(
 	mKey.clear();
 
 	for (s = htiTrg; s != NULL; s = TreeView_GetNextSibling( hwndTree, s )) {
-		// ƒƒjƒ…[”‚ÌƒJƒEƒ“ƒg
+		// ãƒ¡ãƒ‹ãƒ¥ãƒ¼æ•°ã®ã‚«ã‚¦ãƒ³ãƒˆ
 		nMenuNum++;
 		if (nLevel == 0) {
 			nTopNum++;
@@ -1297,7 +1297,7 @@ bool CPropMainMenu::Check_MainMenu_Sub(
 		}
 		if (pFuncWk->m_sKey[0] == '\0') {
 			if (nType == T_NODE || nType == T_LEAF) {
-				// –¢İ’è
+				// æœªè¨­å®š
 				if (nNoSetErrNum == 0) {
 					if (htiErr == NULL) {
 						htiErr = s;
@@ -1313,15 +1313,15 @@ bool CPropMainMenu::Check_MainMenu_Sub(
 				mKey[pFuncWk->m_sKey[0]] = s;
 
 				if (pFuncWk->m_bDupErr) {
-					// –ÚˆóƒNƒŠƒA
+					// ç›®å°ã‚¯ãƒªã‚¢
 					pFuncWk->m_bDupErr = false;
 					tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_PARAM;
 					tvi.pszText =  const_cast<TCHAR*>( MakeDispLabel( pFuncWk ) );
-					TreeView_SetItem( hwndTree , &tvi );		//	ƒL[İ’èŒ‹‰Ê‚ğ”½‰f
+					TreeView_SetItem( hwndTree , &tvi );		//	ã‚­ãƒ¼è¨­å®šçµæœã‚’åæ˜ 
 				}
 			}
 			else {
-				// d•¡ƒGƒ‰[
+				// é‡è¤‡ã‚¨ãƒ©ãƒ¼
 				if (nDupErrNum == 0) {
 					if (htiErr == NULL) {
 						htiErr = mKey[pFuncWk->m_sKey[0]];
@@ -1331,13 +1331,13 @@ bool CPropMainMenu::Check_MainMenu_Sub(
 
 				nDupErrNum++;
 
-				// –Úˆóİ’è
+				// ç›®å°è¨­å®š
 				pFuncWk->m_bDupErr = true;
 				tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_PARAM;
 				tvi.pszText = const_cast<TCHAR*>( MakeDispLabel( pFuncWk ) );
-				TreeView_SetItem( hwndTree , &tvi );		//	ƒL[İ’èŒ‹‰Ê‚ğ”½‰f
+				TreeView_SetItem( hwndTree , &tvi );		//	ã‚­ãƒ¼è¨­å®šçµæœã‚’åæ˜ 
 
-				// –Úˆóİ’èiŒ³•ªj
+				// ç›®å°è¨­å®šï¼ˆå…ƒåˆ†ï¼‰
 				tvi.mask = TVIF_HANDLE | TVIF_PARAM | TVIF_CHILDREN;
 				tvi.hItem = mKey[pFuncWk->m_sKey[0]];
 				if (!TreeView_GetItem( hwndTree, &tvi )) {
@@ -1349,15 +1349,15 @@ bool CPropMainMenu::Check_MainMenu_Sub(
 					msMenu[tvi.lParam].m_bDupErr = true;
 					tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_PARAM;
 					tvi.pszText = const_cast<TCHAR*>( MakeDispLabel( &msMenu[tvi.lParam] ) );
-					TreeView_SetItem( hwndTree , &tvi );		//	ƒL[İ’èŒ‹‰Ê‚ğ”½‰f
+					TreeView_SetItem( hwndTree , &tvi );		//	ã‚­ãƒ¼è¨­å®šçµæœã‚’åæ˜ 
 				}
 			}
 		}
 		if (tvi.cChildren) {
-			ts = TreeView_GetChild( hwndTree, s );	//	q‚Ìæ“¾
+			ts = TreeView_GetChild( hwndTree, s );	//	å­ã®å–å¾—
 			if (ts != NULL) {
 				if (!Check_MainMenu_Sub( hwndTree, ts, nLevel+1, sErrMsg )) {
-					// “à•”ƒGƒ‰[
+					// å†…éƒ¨ã‚¨ãƒ©ãƒ¼
 					return false;
 				}
 			}

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAuƒvƒ‰ƒOƒCƒ“vƒy[ƒW
+ï»¿/*!	@file
+	å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã€ãƒšãƒ¼ã‚¸
 
 	@author syat
 */
@@ -44,26 +44,26 @@
 
 static void LoadPluginTemp(CommonSetting& common, CMenuDrawer& cMenuDrawer);
 
-//! Popup Help—pID
+//! Popup Helpç”¨ID
 static const DWORD p_helpids[] = {	//11700
-	IDC_CHECK_PluginEnable,	HIDC_CHECK_PluginEnable,	//ƒvƒ‰ƒOƒCƒ“‚ğ—LŒø‚É‚·‚é
-	IDC_PLUGINLIST,			HIDC_PLUGINLIST,			//ƒvƒ‰ƒOƒCƒ“ƒŠƒXƒg
-	IDC_PLUGIN_INST_ZIP,	HIDC_PLUGIN_INST_ZIP,		//Zipƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á	// 2011/11/2 Uchi
-	IDC_PLUGIN_SearchNew,	HIDC_PLUGIN_SearchNew,		//V‹Kƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á
-	IDC_PLUGIN_OpenFolder,	HIDC_PLUGIN_OpenFolder,		//ƒtƒHƒ‹ƒ_‚ğŠJ‚­
-	IDC_PLUGIN_Remove,		HIDC_PLUGIN_Remove,			//ƒvƒ‰ƒOƒCƒ“‚ğíœ
-	IDC_PLUGIN_OPTION,		HIDC_PLUGIN_OPTION,			//ƒvƒ‰ƒOƒCƒ“İ’è	// 2010/3/22 Uchi
-	IDC_PLUGIN_README,		HIDC_PLUGIN_README,			//ReadMe•\¦		// 2011/11/2 Uchi
-	IDC_PLUGIN_URL,			HIDC_PLUGIN_URL,			//”z•zæ			// 2015/01/02 syat
+	IDC_CHECK_PluginEnable,	HIDC_CHECK_PluginEnable,	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’æœ‰åŠ¹ã«ã™ã‚‹
+	IDC_PLUGINLIST,			HIDC_PLUGINLIST,			//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒªã‚¹ãƒˆ
+	IDC_PLUGIN_INST_ZIP,	HIDC_PLUGIN_INST_ZIP,		//Zipãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ 	// 2011/11/2 Uchi
+	IDC_PLUGIN_SearchNew,	HIDC_PLUGIN_SearchNew,		//æ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ 
+	IDC_PLUGIN_OpenFolder,	HIDC_PLUGIN_OpenFolder,		//ãƒ•ã‚©ãƒ«ãƒ€ã‚’é–‹ã
+	IDC_PLUGIN_Remove,		HIDC_PLUGIN_Remove,			//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å‰Šé™¤
+	IDC_PLUGIN_OPTION,		HIDC_PLUGIN_OPTION,			//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³è¨­å®š	// 2010/3/22 Uchi
+	IDC_PLUGIN_README,		HIDC_PLUGIN_README,			//ReadMeè¡¨ç¤º		// 2011/11/2 Uchi
+	IDC_PLUGIN_URL,			HIDC_PLUGIN_URL,			//é…å¸ƒå…ˆ			// 2015/01/02 syat
 	//	IDC_STATIC,			-1,
 	0, 0
 };
 
 /*!
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropPlugin::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -71,11 +71,11 @@ INT_PTR CALLBACK CPropPlugin::DlgProc_page(
 	return DlgProc( reinterpret_cast<pDispatchPage>(&CPropPlugin::DispatchEvent), hwndDlg, uMsg, wParam, lParam );
 }
 
-/*! Pluginƒy[ƒW‚ÌƒƒbƒZ[ƒWˆ—
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handlw
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+/*! Pluginãƒšãƒ¼ã‚¸ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handlw
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
@@ -88,7 +88,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 	switch( uMsg ){
 
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Plugin */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Plugin */
 		InitDialog( hwndDlg );
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
@@ -116,7 +116,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 							::SetWindowText( ::GetDlgItem( hwndDlg, IDC_LABEL_PLUGIN_Author ), _T("") );
 							::SetWindowText( ::GetDlgItem( hwndDlg, IDC_LABEL_PLUGIN_Version ), _T("") );
 						}
-						// 2010.08.21 –¾‚ç‚©‚Ég‚¦‚È‚¢‚Æ‚«‚ÍDisable‚É‚·‚é
+						// 2010.08.21 æ˜ã‚‰ã‹ã«ä½¿ãˆãªã„ã¨ãã¯Disableã«ã™ã‚‹
 						EPluginState state = m_Common.m_sPlugin.m_PluginTable[sel].m_state;
 						BOOL bEdit = (state != PLS_DELETED && state != PLS_NONE);
 						::EnableWindow( ::GetDlgItem( hwndDlg, IDC_PLUGIN_Remove ), bEdit );
@@ -129,7 +129,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 				}
 				break;
 			case NM_DBLCLK:
-				// ƒŠƒXƒgƒrƒ…[‚Ö‚Ìƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Åuƒvƒ‰ƒOƒCƒ“İ’èv‚ğŒÄ‚Ño‚·
+				// ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã¸ã®ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ã€Œãƒ—ãƒ©ã‚°ã‚¤ãƒ³è¨­å®šã€ã‚’å‘¼ã³å‡ºã™
 				if (::IsWindowEnabled(::GetDlgItem( hwndDlg, IDC_PLUGIN_OPTION )))
 				{
 					DispatchEvent( hwndDlg, WM_COMMAND, MAKEWPARAM(IDC_PLUGIN_OPTION, BN_CLICKED), (LPARAM)::GetDlgItem( hwndDlg, IDC_PLUGIN_OPTION ) );
@@ -143,7 +143,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 				OnHelp( hwndDlg, IDD_PROP_PLUGIN );
 				return TRUE;
 			case PSN_KILLACTIVE:
-				/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Plugin */
+				/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Plugin */
 				GetData( hwndDlg );
 				return TRUE;
 			case PSN_SETACTIVE:
@@ -155,28 +155,28 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 		break;
 
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID = LOWORD(wParam);			/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+		wNotifyCode = HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID = LOWORD(wParam);			/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 
 		switch( wNotifyCode ){
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 			switch( wID ){
-			case IDC_PLUGIN_SearchNew:		// V‹Kƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á
+			case IDC_PLUGIN_SearchNew:		// æ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ 
 				GetData( hwndDlg );
 				CPluginManager::getInstance()->SearchNewPlugin( m_Common, hwndDlg );
 				if( m_bTrayProc ){
 					LoadPluginTemp(m_Common, *m_pcMenuDrawer);
 				}
-				SetData_LIST( hwndDlg );	//ƒŠƒXƒg‚ÌÄ\’z
+				SetData_LIST( hwndDlg );	//ãƒªã‚¹ãƒˆã®å†æ§‹ç¯‰
 				break;
-			case IDC_PLUGIN_INST_ZIP:		// ZIPƒvƒ‰ƒOƒCƒ“‚ğ’Ç‰Á
+			case IDC_PLUGIN_INST_ZIP:		// ZIPãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’è¿½åŠ 
 				{
 					static std::tstring	sTrgDir;
 					CDlgOpenFile	cDlgOpenFile;
 					TCHAR			szPath[_MAX_PATH + 1];
 					_tcscpy( szPath, (sTrgDir.empty() ? CPluginManager::getInstance()->GetBaseDir().c_str() : sTrgDir.c_str()));
-					// ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“ƒ_ƒCƒAƒƒO‚Ì‰Šú‰»
+					// ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸåŒ–
 					cDlgOpenFile.Create(
 						G_AppInstance(),
 						hwndDlg,
@@ -189,19 +189,19 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 						if( m_bTrayProc ){
 							LoadPluginTemp(m_Common, *m_pcMenuDrawer);
 						}
-						SetData_LIST( hwndDlg );	//ƒŠƒXƒg‚ÌÄ\’z
+						SetData_LIST( hwndDlg );	//ãƒªã‚¹ãƒˆã®å†æ§‹ç¯‰
 					}
-					// ƒtƒHƒ‹ƒ_‚ğ‹L‰¯
+					// ãƒ•ã‚©ãƒ«ãƒ€ã‚’è¨˜æ†¶
 					TCHAR	szFolder[_MAX_PATH + 1];
 					TCHAR	szFname[_MAX_PATH + 1];
 					SplitPath_FolderAndFile(szPath, szFolder, szFname);
 					sTrgDir = szFolder;
 				}
 				break;
-			case IDC_CHECK_PluginEnable:	// ƒvƒ‰ƒOƒCƒ“‚ğ—LŒø‚É‚·‚é
+			case IDC_CHECK_PluginEnable:	// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’æœ‰åŠ¹ã«ã™ã‚‹
 				EnablePluginPropInput( hwndDlg );
 				break;
-			case IDC_PLUGIN_Remove:			// ƒvƒ‰ƒOƒCƒ“‚ğíœ
+			case IDC_PLUGIN_Remove:			// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’å‰Šé™¤
 				{
 					HWND hListView = ::GetDlgItem( hwndDlg, IDC_PLUGINLIST );
 					int sel = ListView_GetNextItem( hListView, -1, LVNI_SELECTED );
@@ -214,12 +214,12 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 					}
 				}
 				break;
-			case IDC_PLUGIN_OPTION:		// ƒvƒ‰ƒOƒCƒ“İ’è	// 2010/3/22 Uchi
+			case IDC_PLUGIN_OPTION:		// ãƒ—ãƒ©ã‚°ã‚¤ãƒ³è¨­å®š	// 2010/3/22 Uchi
 				{
 					HWND hListView = ::GetDlgItem( hwndDlg, IDC_PLUGINLIST );
 					int sel = ListView_GetNextItem( hListView, -1, LVNI_SELECTED );
 					if( sel >= 0 && m_Common.m_sPlugin.m_PluginTable[sel].m_state == PLS_LOADED ){
-						// 2010.08.21 ƒvƒ‰ƒOƒCƒ“–¼(ƒtƒHƒ‹ƒ_–¼)‚Ì“¯ˆê«‚ÌŠm”F
+						// 2010.08.21 ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å(ãƒ•ã‚©ãƒ«ãƒ€å)ã®åŒä¸€æ€§ã®ç¢ºèª
 						CPlugin* plugin = CPluginManager::getInstance()->GetPlugin(sel);
 						wstring sDirName = to_wchar(plugin->GetFolderName().c_str());
 						if( plugin && 0 == auto_stricmp(sDirName.c_str(), m_Common.m_sPlugin.m_PluginTable[sel].m_szName ) ){
@@ -231,7 +231,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 					}
 				}
 				break;
-			case IDC_PLUGIN_OpenFolder:			// ƒtƒHƒ‹ƒ_‚ğŠJ‚­
+			case IDC_PLUGIN_OpenFolder:			// ãƒ•ã‚©ãƒ«ãƒ€ã‚’é–‹ã
 				{
 					std::tstring sBaseDir = CPluginManager::getInstance()->GetBaseDir() + _T(".");
 					if( ! IsDirectory(sBaseDir.c_str()) ){
@@ -242,11 +242,11 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 					::ShellExecute( NULL, _T("open"), sBaseDir.c_str(), NULL, NULL, SW_SHOW );
 				}
 				break;
-			case IDC_PLUGIN_README:		// ReadMe•\¦	// 2011/11/2 Uchi
+			case IDC_PLUGIN_README:		// ReadMeè¡¨ç¤º	// 2011/11/2 Uchi
 				{
 					HWND hListView = ::GetDlgItem( hwndDlg, IDC_PLUGINLIST );
 					int sel = ListView_GetNextItem( hListView, -1, LVNI_SELECTED );
-					std::tstring sName = to_tchar(m_Common.m_sPlugin.m_PluginTable[sel].m_szName);	// ŒÂ•ÊƒtƒHƒ‹ƒ_–¼
+					std::tstring sName = to_tchar(m_Common.m_sPlugin.m_PluginTable[sel].m_szName);	// å€‹åˆ¥ãƒ•ã‚©ãƒ«ãƒ€å
 					std::tstring sReadMeName = GetReadMeFile(sName);
 					if (!sReadMeName.empty()) {
 						if (!BrowseReadMe(sReadMeName)) {
@@ -290,7 +290,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -300,7 +300,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -310,16 +310,16 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 
 
 /*!
-	ƒ_ƒCƒAƒƒOã‚ÌƒRƒ“ƒgƒ[ƒ‹‚Éƒf[ƒ^‚ğİ’è‚·‚é
+	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ä¸Šã®ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«ãƒ‡ãƒ¼ã‚¿ã‚’è¨­å®šã™ã‚‹
 
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«
 */
 void CPropPlugin::SetData( HWND hwndDlg )
 {
-	//ƒvƒ‰ƒOƒCƒ“‚ğ—LŒø‚É‚·‚é
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’æœ‰åŠ¹ã«ã™ã‚‹
 	::CheckDlgButton( hwndDlg, IDC_CHECK_PluginEnable, m_Common.m_sPlugin.m_bEnablePlugin );
 
-	//ƒvƒ‰ƒOƒCƒ“ƒŠƒXƒg
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒªã‚¹ãƒˆ
 	SetData_LIST( hwndDlg );
 	
 	EnablePluginPropInput( hwndDlg );
@@ -327,9 +327,9 @@ void CPropPlugin::SetData( HWND hwndDlg )
 }
 
 /*!
-	ƒ_ƒCƒAƒƒOã‚ÌƒRƒ“ƒgƒ[ƒ‹‚Éƒf[ƒ^‚ğİ’è‚·‚é
+	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ä¸Šã®ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«ãƒ‡ãƒ¼ã‚¿ã‚’è¨­å®šã™ã‚‹
 
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«
 */
 void CPropPlugin::SetData_LIST( HWND hwndDlg )
 {
@@ -342,16 +342,16 @@ void CPropPlugin::SetData_LIST( HWND hwndDlg )
 	::EnableWindow( ::GetDlgItem( hwndDlg, IDC_PLUGIN_README ), FALSE );
 	::EnableWindow( ::GetDlgItem( hwndDlg, IDC_PLUGIN_URL ), FALSE );
 
-	//ƒvƒ‰ƒOƒCƒ“ƒŠƒXƒg
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒªã‚¹ãƒˆ
 	HWND hListView = ::GetDlgItem( hwndDlg, IDC_PLUGINLIST );
 
 	ListView_DeleteAllItems( hListView );
 
 	for( index = 0; index < MAX_PLUGIN; ++index ){
-		std::basic_string<TCHAR> sDirName;	//CPlugin.GetDirName()‚ÌŒ‹‰Ê•Û•Ï”
+		std::basic_string<TCHAR> sDirName;	//CPlugin.GetDirName()ã®çµæœä¿æŒå¤‰æ•°
 		CPlugin* plugin = CPluginManager::getInstance()->GetPlugin( index );
 
-		//”Ô†
+		//ç•ªå·
 		TCHAR buf[4];
 		memset_raw( &sItem, 0, sizeof( sItem ));
 		sItem.mask = LVIF_TEXT | LVIF_PARAM;
@@ -362,7 +362,7 @@ void CPropPlugin::SetData_LIST( HWND hwndDlg )
 		sItem.lParam = index;
 		ListView_InsertItem( hListView, &sItem );
 
-		//–¼‘O
+		//åå‰
 		memset_raw( &sItem, 0, sizeof( sItem ));
 		sItem.iItem = index;
 		sItem.mask = LVIF_TEXT;
@@ -374,7 +374,7 @@ void CPropPlugin::SetData_LIST( HWND hwndDlg )
 		}
 		ListView_SetItem( hListView, &sItem );
 
-		//ó‘Ô
+		//çŠ¶æ…‹
 		memset_raw( &sItem, 0, sizeof( sItem ));
 		sItem.iItem = index;
 		sItem.mask = LVIF_TEXT;
@@ -390,7 +390,7 @@ void CPropPlugin::SetData_LIST( HWND hwndDlg )
 		}
 		ListView_SetItem( hListView, &sItem );
 		
-		//“Ç
+		//èª­è¾¼
 		sItem.iItem = index;
 		sItem.mask = LVIF_TEXT;
 		sItem.iSubItem = 3;
@@ -401,7 +401,7 @@ void CPropPlugin::SetData_LIST( HWND hwndDlg )
 		}
 		ListView_SetItem( hListView, &sItem );
 
-		//ƒtƒHƒ‹ƒ_
+		//ãƒ•ã‚©ãƒ«ãƒ€
 		memset_raw( &sItem, 0, sizeof( sItem ));
 		sItem.iItem = index;
 		sItem.mask = LVIF_TEXT;
@@ -424,9 +424,9 @@ void CPropPlugin::SetData_LIST( HWND hwndDlg )
 		ListView_SetItem( hListView, &sItem );
 	}
 	
-	//	ƒŠƒXƒgƒrƒ…[‚Ìs‘I‘ğ‚ğ‰Â”\‚É‚·‚éD
-	//	IE 3.xˆÈ~‚ª“ü‚Á‚Ä‚¢‚éê‡‚Ì‚İ“®ì‚·‚éD
-	//	‚±‚ê‚ª–³‚­‚Ä‚àC”Ô†•”•ª‚µ‚©‘I‘ğ‚Å‚«‚È‚¢‚¾‚¯‚Å‘€ì©‘Ì‚Í‰Â”\D
+	//	ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®è¡Œé¸æŠã‚’å¯èƒ½ã«ã™ã‚‹ï¼
+	//	IE 3.xä»¥é™ãŒå…¥ã£ã¦ã„ã‚‹å ´åˆã®ã¿å‹•ä½œã™ã‚‹ï¼
+	//	ã“ã‚ŒãŒç„¡ãã¦ã‚‚ï¼Œç•ªå·éƒ¨åˆ†ã—ã‹é¸æŠã§ããªã„ã ã‘ã§æ“ä½œè‡ªä½“ã¯å¯èƒ½ï¼
 	DWORD dwStyle;
 	dwStyle = ListView_GetExtendedListViewStyle( hListView );
 	dwStyle |= LVS_EX_FULLROWSELECT;
@@ -436,17 +436,17 @@ void CPropPlugin::SetData_LIST( HWND hwndDlg )
 }
 
 /*!
-	ƒ_ƒCƒAƒƒOã‚ÌƒRƒ“ƒgƒ[ƒ‹‚©‚çƒf[ƒ^‚ğæ“¾‚µ‚Äƒƒ‚ƒŠ‚ÉŠi”[‚·‚é
+	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ä¸Šã®ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‹ã‚‰ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾—ã—ã¦ãƒ¡ãƒ¢ãƒªã«æ ¼ç´ã™ã‚‹
 
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«
 */
 int CPropPlugin::GetData( HWND hwndDlg )
 {
-	//ƒvƒ‰ƒOƒCƒ“‚ğ—LŒø‚É‚·‚é
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’æœ‰åŠ¹ã«ã™ã‚‹
 	m_Common.m_sPlugin.m_bEnablePlugin = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_PluginEnable );
 
-	//ƒvƒ‰ƒOƒCƒ“ƒŠƒXƒg‚Í¡‚Ì‚Æ‚±‚ë•ÏX‚Å‚«‚é•”•ª‚ª‚È‚¢
-	//uV‹Kƒvƒ‰ƒOƒCƒ“’Ç‰Áv‚Ím_Common‚É’¼Ú‘‚«‚Ş‚Ì‚ÅA‚±‚ÌŠÖ”‚Å‚·‚é‚±‚Æ‚Í‚È‚¢
+	//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒªã‚¹ãƒˆã¯ä»Šã®ã¨ã“ã‚å¤‰æ›´ã§ãã‚‹éƒ¨åˆ†ãŒãªã„
+	//ã€Œæ–°è¦ãƒ—ãƒ©ã‚°ã‚¤ãƒ³è¿½åŠ ã€ã¯m_Commonã«ç›´æ¥æ›¸ãè¾¼ã‚€ã®ã§ã€ã“ã®é–¢æ•°ã§ã™ã‚‹ã“ã¨ã¯ãªã„
 
 	return TRUE;
 }
@@ -457,9 +457,9 @@ struct ColumnData_CPropPlugin_Init {
 };
 
 /*!
-	ƒ_ƒCƒAƒƒOã‚ÌƒRƒ“ƒgƒ[ƒ‹‚ğ‰Šú‰»‚·‚é
+	ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ä¸Šã®ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚’åˆæœŸåŒ–ã™ã‚‹
 
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ«
 */
 void CPropPlugin::InitDialog( HWND hwndDlg )
 {
@@ -471,7 +471,7 @@ void CPropPlugin::InitDialog( HWND hwndDlg )
 		{ STR_PROPCOMPLG_LIST5, 150 },
 	};
 
-	//	ListView‚Ì‰Šú‰»
+	//	ListViewã®åˆæœŸåŒ–
 	HWND hListView = ::GetDlgItem( hwndDlg, IDC_PLUGINLIST );
 
 	LVCOLUMN sColumn;
@@ -491,16 +491,16 @@ void CPropPlugin::InitDialog( HWND hwndDlg )
 		
 		if( ListView_InsertColumn( hListView, pos, &sColumn ) < 0 ){
 			PleaseReportToAuthor( hwndDlg, _T("PropComMacro::InitDlg::ColumnRegistrationFail") );
-			return;	//	‚æ‚­‚í‚©‚ç‚ñ‚¯‚Ç¸”s‚µ‚½
+			return;	//	ã‚ˆãã‚ã‹ã‚‰ã‚“ã‘ã©å¤±æ•—ã—ãŸ
 		}
 	}
 
 }
 
-/*! uƒvƒ‰ƒOƒCƒ“vƒV[ƒgã‚ÌƒAƒCƒeƒ€‚Ì—LŒøE–³Œø‚ğ“KØ‚Éİ’è‚·‚é
+/*! ã€Œãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã€ã‚·ãƒ¼ãƒˆä¸Šã®ã‚¢ã‚¤ãƒ†ãƒ ã®æœ‰åŠ¹ãƒ»ç„¡åŠ¹ã‚’é©åˆ‡ã«è¨­å®šã™ã‚‹
 
-	@date 2009.12.06 syat V‹Kì¬
-	@date 2010.08.21 Moca ƒvƒ‰ƒOƒCƒ“–³Œøó‘Ô‚Å‚àíœ‘€ì‚È‚Ç‚ğ‰Â”\‚É‚·‚é
+	@date 2009.12.06 syat æ–°è¦ä½œæˆ
+	@date 2010.08.21 Moca ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç„¡åŠ¹çŠ¶æ…‹ã§ã‚‚å‰Šé™¤æ“ä½œãªã©ã‚’å¯èƒ½ã«ã™ã‚‹
 */
 void CPropPlugin::EnablePluginPropInput(HWND hwndDlg)
 {
@@ -517,7 +517,7 @@ void CPropPlugin::EnablePluginPropInput(HWND hwndDlg)
 	}
 }
 
-//	Readme ƒtƒ@ƒCƒ‹‚Ìæ“¾	2011/11/2 Uchi
+//	Readme ãƒ•ã‚¡ã‚¤ãƒ«ã®å–å¾—	2011/11/2 Uchi
 std::tstring CPropPlugin::GetReadMeFile(const std::tstring& sName)
 {
 	std::tstring sReadMeName = CPluginManager::getInstance()->GetBaseDir()
@@ -530,7 +530,7 @@ std::tstring CPropPlugin::GetReadMeFile(const std::tstring& sName)
 		fl = new CFile(sReadMeName.c_str());
 	}
 	if (!fl->IsFileExist()) {
-		// exeƒtƒHƒ‹ƒ_”z‰º
+		// exeãƒ•ã‚©ãƒ«ãƒ€é…ä¸‹
 		sReadMeName = CPluginManager::getInstance()->GetExePluginDir()
 			+ sName + _T("\\ReadMe.txt");
 		delete fl;
@@ -551,35 +551,35 @@ std::tstring CPropPlugin::GetReadMeFile(const std::tstring& sName)
 }
 
 /*!
-	Readme ƒtƒ@ƒCƒ‹‚Ì•\¦
+	Readme ãƒ•ã‚¡ã‚¤ãƒ«ã®è¡¨ç¤º
 
 	@date 2011/11/2 Uchi
 
-	@return true: ¬Œ÷, false: ¸”s
+	@return true: æˆåŠŸ, false: å¤±æ•—
 */
 bool CPropPlugin::BrowseReadMe(const std::tstring& sReadMeName)
 {
-	// -- -- -- -- ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“•¶š—ñ‚ğ¶¬ -- -- -- -- //
+	// -- -- -- -- ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³æ–‡å­—åˆ—ã‚’ç”Ÿæˆ -- -- -- -- //
 	CCommandLineString cCmdLineBuf;
 
-	//ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒpƒX
+	//ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ãƒ‘ã‚¹
 	TCHAR szExePath[MAX_PATH + 1];
 	::GetModuleFileName( NULL, szExePath, _countof( szExePath ) );
 	cCmdLineBuf.AppendF( _T("\"%ts\""), szExePath );
 
-	// ƒtƒ@ƒCƒ‹–¼
+	// ãƒ•ã‚¡ã‚¤ãƒ«å
 	cCmdLineBuf.AppendF( _T(" \"%ts\""), sReadMeName.c_str() );
 
-	// ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“ƒIƒvƒVƒ‡ƒ“
+	// ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 	cCmdLineBuf.AppendF(_T(" -R -CODE=99"));
 
-	// ƒOƒ‹[ƒvID
+	// ã‚°ãƒ«ãƒ¼ãƒ—ID
 	int nGroup = GetDllShareData().m_sNodes.m_nGroupSequences;
 	if( nGroup > 0 ){
 		cCmdLineBuf.AppendF( _T(" -GROUP=%d"), nGroup+1 );
 	}
 
-	//CreateProcess‚É“n‚·STARTUPINFO‚ğì¬
+	//CreateProcessã«æ¸¡ã™STARTUPINFOã‚’ä½œæˆ
 	STARTUPINFO	sui;
 	::GetStartupInfo(&sui);
 
@@ -588,16 +588,16 @@ bool CPropPlugin::BrowseReadMe(const std::tstring& sReadMeName)
 
 	TCHAR	szCmdLine[1024];
 	auto_strcpy_s(szCmdLine, _countof(szCmdLine), cCmdLineBuf.c_str());
-	//ƒŠƒ\[ƒXƒŠ[ƒN‘Îô
+	//ãƒªã‚½ãƒ¼ã‚¹ãƒªãƒ¼ã‚¯å¯¾ç­–
 	BOOL bRet = ::CreateProcess( NULL, szCmdLine, NULL, NULL, TRUE,
 		CREATE_NEW_CONSOLE, NULL, NULL, &sui, &pi );
 
-	//ƒvƒƒZƒXì¬‚É¬Œ÷‚µ‚½ê‡
+	//ãƒ—ãƒ­ã‚»ã‚¹ä½œæˆã«æˆåŠŸã—ãŸå ´åˆ
 	if ( bRet )
 	{
-		//ƒXƒŒƒbƒhƒnƒ“ƒhƒ‹‚Íg‚í‚È‚¢‚Ì‚Å•Â‚¶‚Ä‚¨‚­
+		//ã‚¹ãƒ¬ãƒƒãƒ‰ãƒãƒ³ãƒ‰ãƒ«ã¯ä½¿ã‚ãªã„ã®ã§é–‰ã˜ã¦ãŠã
 		::CloseHandle( pi.hThread );
-		//ƒvƒƒZƒXƒnƒ“ƒhƒ‹‚Íg‚í‚È‚¢‚Ì‚Å•Â‚¶‚Ä‚¨‚­
+		//ãƒ—ãƒ­ã‚»ã‚¹ãƒãƒ³ãƒ‰ãƒ«ã¯ä½¿ã‚ãªã„ã®ã§é–‰ã˜ã¦ãŠã
 		::CloseHandle( pi.hProcess );
 	}
 
@@ -607,9 +607,9 @@ bool CPropPlugin::BrowseReadMe(const std::tstring& sReadMeName)
 static void LoadPluginTemp(CommonSetting& common, CMenuDrawer& cMenuDrawer)
 {
 	{
-		// 2013.05.31 ƒRƒ“ƒgƒ[ƒ‹ƒvƒƒZƒX‚È‚ç‘¦“Ç‚İ‚İ
+		// 2013.05.31 ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ãƒ—ãƒ­ã‚»ã‚¹ãªã‚‰å³æ™‚èª­ã¿è¾¼ã¿
 		CPluginManager::getInstance()->LoadAllPlugin( &common );
-		// ƒc[ƒ‹ƒo[ƒAƒCƒRƒ“‚ÌXV
+		// ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã‚¢ã‚¤ã‚³ãƒ³ã®æ›´æ–°
 		const CPlug::Array& plugs = CJackManager::getInstance()->GetPlugs( PP_COMMAND );
 		cMenuDrawer.m_pcIcons->ResetExtend();
 		for( CPlug::ArrayIter it = plugs.begin(); it != plugs.end(); it++ ) {

--- a/sakura_core/prop/CPropComStatusbar.cpp
+++ b/sakura_core/prop/CPropComStatusbar.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ���ʐݒ�_�C�A���O�{�b�N�X�A�u�X�e�[�^�X�o�[�v�y�[�W
+﻿/*!	@file
+	@brief 共通設定ダイアログボックス、「ステータスバー」ページ
 
 	@author Uchi
 */
@@ -25,21 +25,21 @@
 
 
 static const DWORD p_helpids[] = {
-	IDC_CHECK_DISP_UNICODE_IN_SJIS,		HIDC_CHECK_DISP_UNICODE_IN_SJIS,		// SJIS�ŕ����R�[�h�l��Unicode�ŕ\������
-	IDC_CHECK_DISP_UNICODE_IN_JIS,		HIDC_CHECK_DISP_UNICODE_IN_JIS,			// JIS�ŕ����R�[�h�l��Unicode�ŕ\������
-	IDC_CHECK_DISP_UNICODE_IN_EUC,		HIDC_CHECK_DISP_UNICODE_IN_EUC,			// EUC�ŕ����R�[�h�l��Unicode�ŕ\������
-	IDC_CHECK_DISP_UTF8_CODEPOINT,		HIDC_CHECK_DISP_UTF8_CODEPOINT,			// UTF-8���R�[�h�|�C���g�ŕ\������
-	IDC_CHECK_DISP_SP_CODEPOINT,		HIDC_CHECK_DISP_SP_CODEPOINT,			// �T���Q�[�g�y�A���R�[�h�|�C���g�ŕ\������
-	IDC_CHECK_DISP_SELCOUNT_BY_BYTE,	HIDC_CHECK_DISP_SELCOUNT_BY_BYTE,		// �I�𕶎����𕶎��P�ʂł͂Ȃ��o�C�g�P�ʂŕ\������
-	IDC_CHECK_DISP_COL_BY_CHAR,			HIDC_CHECK_DISP_COL_BY_CHAR,			// ���݌������[���[�P�ʂł͂Ȃ������P�ʂŕ\������
+	IDC_CHECK_DISP_UNICODE_IN_SJIS,		HIDC_CHECK_DISP_UNICODE_IN_SJIS,		// SJISで文字コード値をUnicodeで表示する
+	IDC_CHECK_DISP_UNICODE_IN_JIS,		HIDC_CHECK_DISP_UNICODE_IN_JIS,			// JISで文字コード値をUnicodeで表示する
+	IDC_CHECK_DISP_UNICODE_IN_EUC,		HIDC_CHECK_DISP_UNICODE_IN_EUC,			// EUCで文字コード値をUnicodeで表示する
+	IDC_CHECK_DISP_UTF8_CODEPOINT,		HIDC_CHECK_DISP_UTF8_CODEPOINT,			// UTF-8をコードポイントで表示する
+	IDC_CHECK_DISP_SP_CODEPOINT,		HIDC_CHECK_DISP_SP_CODEPOINT,			// サロゲートペアをコードポイントで表示する
+	IDC_CHECK_DISP_SELCOUNT_BY_BYTE,	HIDC_CHECK_DISP_SELCOUNT_BY_BYTE,		// 選択文字数を文字単位ではなくバイト単位で表示する
+	IDC_CHECK_DISP_COL_BY_CHAR,			HIDC_CHECK_DISP_COL_BY_CHAR,			// 現在桁をルーラー単位ではなく文字単位で表示する
 	0, 0
 };
 
 /*!
-	@param hwndDlg �_�C�A���O�{�b�N�X��Window Handle
-	@param uMsg ���b�Z�[�W
-	@param wParam �p�����[�^1
-	@param lParam �p�����[�^2
+	@param hwndDlg ダイアログボックスのWindow Handle
+	@param uMsg メッセージ
+	@param wParam パラメータ1
+	@param lParam パラメータ2
 */
 INT_PTR CALLBACK CPropStatusbar::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -47,7 +47,7 @@ INT_PTR CALLBACK CPropStatusbar::DlgProc_page(
 	return DlgProc( reinterpret_cast<pDispatchPage>(&CPropStatusbar::DispatchEvent), hwndDlg, uMsg, wParam, lParam );
 }
 
-/* ���b�Z�[�W���� */
+/* メッセージ処理 */
 INT_PTR CPropStatusbar::DispatchEvent(
     HWND		hwndDlg,	// handle to dialog box
     UINT		uMsg,		// message
@@ -60,7 +60,7 @@ INT_PTR CPropStatusbar::DispatchEvent(
 	switch( uMsg ){
 
 	case WM_INITDIALOG:
-		/* �_�C�A���O�f�[�^�̐ݒ� */
+		/* ダイアログデータの設定 */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
@@ -78,11 +78,11 @@ INT_PTR CPropStatusbar::DispatchEvent(
 		case PSN_KILLACTIVE:
 			DEBUG_TRACE( _T("statusbar PSN_KILLACTIVE\n") );
 
-			/* �_�C�A���O�f�[�^�̎擾 */
+			/* ダイアログデータの取得 */
 			GetData( hwndDlg );
 			return TRUE;
 
-		case PSN_SETACTIVE: //@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+		case PSN_SETACTIVE: //@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 			m_nPageNum = ID_PROPCOM_PAGENUM_STATUSBAR;
 			return TRUE;
 		}
@@ -92,7 +92,7 @@ INT_PTR CPropStatusbar::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -102,7 +102,7 @@ INT_PTR CPropStatusbar::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -111,45 +111,45 @@ INT_PTR CPropStatusbar::DispatchEvent(
 }
 
 
-/* �_�C�A���O�f�[�^�̐ݒ� */
+/* ダイアログデータの設定 */
 void CPropStatusbar::SetData( HWND hwndDlg )
 {
-	// �������R�[�h�̎w��
-	// SJIS�ŕ����R�[�h�l��Unicode�ŏo�͂���
+	// 示文字コードの指定
+	// SJISで文字コード値をUnicodeで出力する
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DISP_UNICODE_IN_SJIS, m_Common.m_sStatusbar.m_bDispUniInSjis );
-	// JIS�ŕ����R�[�h�l��Unicode�ŏo�͂���
+	// JISで文字コード値をUnicodeで出力する
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DISP_UNICODE_IN_JIS,  m_Common.m_sStatusbar.m_bDispUniInJis );
-	// EUC�ŕ����R�[�h�l��Unicode�ŏo�͂���
+	// EUCで文字コード値をUnicodeで出力する
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DISP_UNICODE_IN_EUC,  m_Common.m_sStatusbar.m_bDispUniInEuc );
-	// UTF-8�ŕ\�����o�C�g�R�[�h�ōs��
+	// UTF-8で表示をバイトコードで行う
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DISP_UTF8_CODEPOINT,  m_Common.m_sStatusbar.m_bDispUtf8Codepoint );
-	// �T���Q�[�g�y�A���R�[�h�|�C���g�ŕ\��
+	// サロゲートペアをコードポイントで表示
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DISP_SP_CODEPOINT,    m_Common.m_sStatusbar.m_bDispSPCodepoint );
-	// �I�𕶎����𕶎��P�ʂł͂Ȃ��o�C�g�P�ʂŕ\������
+	// 選択文字数を文字単位ではなくバイト単位で表示する
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DISP_SELCOUNT_BY_BYTE,m_Common.m_sStatusbar.m_bDispSelCountByByte );
-	// ���݌������[���[�P�ʂł͂Ȃ������P�ʂŕ\������
+	// 現在桁をルーラー単位ではなく文字単位で表示する
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DISP_COL_BY_CHAR,     m_Common.m_sStatusbar.m_bDispColByChar );
 	return;
 }
 
 
-/* �_�C�A���O�f�[�^�̎擾 */
+/* ダイアログデータの取得 */
 int CPropStatusbar::GetData( HWND hwndDlg )
 {
-	// �������R�[�h�̎w��
-	// SJIS�ŕ����R�[�h�l��Unicode�ŏo�͂���
+	// 示文字コードの指定
+	// SJISで文字コード値をUnicodeで出力する
 	m_Common.m_sStatusbar.m_bDispUniInSjis		= ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DISP_UNICODE_IN_SJIS );
-	// JIS�ŕ����R�[�h�l��Unicode�ŏo�͂���
+	// JISで文字コード値をUnicodeで出力する
 	m_Common.m_sStatusbar.m_bDispUniInJis		= ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DISP_UNICODE_IN_JIS );
-	// EUC�ŕ����R�[�h�l��Unicode�ŏo�͂���
+	// EUCで文字コード値をUnicodeで出力する
 	m_Common.m_sStatusbar.m_bDispUniInEuc		= ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DISP_UNICODE_IN_EUC );
-	// UTF-8�ŕ\�����o�C�g�R�[�h�ōs��
+	// UTF-8で表示をバイトコードで行う
 	m_Common.m_sStatusbar.m_bDispUtf8Codepoint	= ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DISP_UTF8_CODEPOINT );
-	// �T���Q�[�g�y�A���R�[�h�|�C���g�ŕ\��
+	// サロゲートペアをコードポイントで表示
 	m_Common.m_sStatusbar.m_bDispSPCodepoint	= ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DISP_SP_CODEPOINT );
-	// �I�𕶎����𕶎��P�ʂł͂Ȃ��o�C�g�P�ʂŕ\������
+	// 選択文字数を文字単位ではなくバイト単位で表示する
 	m_Common.m_sStatusbar.m_bDispSelCountByByte	= ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DISP_SELCOUNT_BY_BYTE );
-	// ���݌������[���[�P�ʂł͂Ȃ������P�ʂŕ\������
+	// 現在桁をルーラー単位ではなく文字単位で表示する
 	m_Common.m_sStatusbar.m_bDispColByChar		= ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DISP_COL_BY_CHAR );
 
 	return TRUE;

--- a/sakura_core/prop/CPropComTab.cpp
+++ b/sakura_core/prop/CPropComTab.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAuƒ^ƒuƒo[vƒy[ƒW
+ï»¿/*!	@file
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œã‚¿ãƒ–ãƒãƒ¼ã€ãƒšãƒ¼ã‚¸
 
 	@author Norio Nakatani
-	@date 2007.02.11 genta ‹¤’Êİ’è‚ÉV‹Kƒ^ƒu‚ğ’Ç‰Á
+	@date 2007.02.11 genta å…±é€šè¨­å®šã«æ–°è¦ã‚¿ãƒ–ã‚’è¿½åŠ 
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -46,20 +46,20 @@
 
 
 static const DWORD p_helpids[] = {
-	IDC_CHECK_DispTabWnd,			HIDC_CHECK_DispTabWnd,			//ƒ^ƒuƒEƒCƒ“ƒhƒE•\¦	//@@@ 2003.05.31 MIK
-	IDC_CHECK_DispTabWndMultiWin,	HIDC_CHECK_DispTabWndMultiWin,	//ƒEƒBƒ“ƒhƒE‚ğ‚Ü‚Æ‚ß‚ÄƒOƒ‹[ƒv‰»‚·‚é
-	IDC_CHECK_RetainEmptyWindow,	HIDC_CHECK_RetainEmptyWindow,	//ÅŒã‚Ìƒtƒ@ƒCƒ‹‚ğ•Â‚¶‚½‚Æ‚«(–³‘è)•¶‘‚ğc‚·	// 2007.02.13 ryoji
-	IDC_CHECK_CloseOneWin,			HIDC_CHECK_CloseOneWin,			//ƒEƒBƒ“ƒhƒE‚Ì•Â‚¶‚éƒ{ƒ^ƒ“‚ÍŒ»İ‚Ìƒtƒ@ƒCƒ‹‚Ì‚İ•Â‚¶‚é	// 2007.02.13 ryoji
-	IDC_CHECK_OpenNewWin,			HIDC_CHECK_OpenNewWin,			//ŠO•”‚©‚ç‹N“®‚·‚é‚Æ‚«‚ÍV‚µ‚¢ƒEƒCƒ“ƒhƒE‚ÅŠJ‚­ 2009.06.19
-	IDC_CHECK_DispTabIcon,			HIDC_CHECK_DispTabIcon,			//ƒAƒCƒRƒ“•\¦	// 2006.08.06 ryoji
-	IDC_CHECK_SameTabWidth,			HIDC_CHECK_SameTabWidth,		//“™•	// 2006.08.06 ryoji
-	IDC_CHECK_DispTabClose,			HIDC_CHECK_DispTabClose,		//ƒ^ƒu‚ğ•Â‚¶‚éƒ{ƒ^ƒ“•\¦	// 2012.04.14 syat
-	IDC_BUTTON_TABFONT,				HIDC_BUTTON_TABFONT,			//ƒ^ƒuƒtƒHƒ“ƒg
-	IDC_CHECK_SortTabList,			HIDC_CHECK_SortTabList,			//ƒ^ƒuˆê——ƒ\[ƒg	// 2006.08.06 ryoji
-	IDC_CHECK_TAB_MULTILINE,		HIDC_CHECK_TAB_MULTILINE,		//ƒ^ƒu‘½’i
-	IDC_COMBO_TAB_POSITION,			HIDC_COMBO_TAB_POSITION,		//ƒ^ƒu•\¦ˆÊ’u
-	IDC_TABWND_CAPTION,				HIDC_TABWND_CAPTION,			//ƒ^ƒuƒEƒCƒ“ƒhƒEƒLƒƒƒvƒVƒ‡ƒ“	//@@@ 2003.06.15 MIK
-	IDC_CHECK_ChgWndByWheel,		HIDC_CHECK_ChgWndByWheel,		//ƒ}ƒEƒXƒzƒC[ƒ‹‚ÅƒEƒBƒ“ƒhƒEØ‚è‘Ö‚¦ 2007.04.03 ryoji
+	IDC_CHECK_DispTabWnd,			HIDC_CHECK_DispTabWnd,			//ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦è¡¨ç¤º	//@@@ 2003.05.31 MIK
+	IDC_CHECK_DispTabWndMultiWin,	HIDC_CHECK_DispTabWndMultiWin,	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã¾ã¨ã‚ã¦ã‚°ãƒ«ãƒ¼ãƒ—åŒ–ã™ã‚‹
+	IDC_CHECK_RetainEmptyWindow,	HIDC_CHECK_RetainEmptyWindow,	//æœ€å¾Œã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‰ã˜ãŸã¨ã(ç„¡é¡Œ)æ–‡æ›¸ã‚’æ®‹ã™	// 2007.02.13 ryoji
+	IDC_CHECK_CloseOneWin,			HIDC_CHECK_CloseOneWin,			//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³ã¯ç¾åœ¨ã®ãƒ•ã‚¡ã‚¤ãƒ«ã®ã¿é–‰ã˜ã‚‹	// 2007.02.13 ryoji
+	IDC_CHECK_OpenNewWin,			HIDC_CHECK_OpenNewWin,			//å¤–éƒ¨ã‹ã‚‰èµ·å‹•ã™ã‚‹ã¨ãã¯æ–°ã—ã„ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã§é–‹ã 2009.06.19
+	IDC_CHECK_DispTabIcon,			HIDC_CHECK_DispTabIcon,			//ã‚¢ã‚¤ã‚³ãƒ³è¡¨ç¤º	// 2006.08.06 ryoji
+	IDC_CHECK_SameTabWidth,			HIDC_CHECK_SameTabWidth,		//ç­‰å¹…	// 2006.08.06 ryoji
+	IDC_CHECK_DispTabClose,			HIDC_CHECK_DispTabClose,		//ã‚¿ãƒ–ã‚’é–‰ã˜ã‚‹ãƒœã‚¿ãƒ³è¡¨ç¤º	// 2012.04.14 syat
+	IDC_BUTTON_TABFONT,				HIDC_BUTTON_TABFONT,			//ã‚¿ãƒ–ãƒ•ã‚©ãƒ³ãƒˆ
+	IDC_CHECK_SortTabList,			HIDC_CHECK_SortTabList,			//ã‚¿ãƒ–ä¸€è¦§ã‚½ãƒ¼ãƒˆ	// 2006.08.06 ryoji
+	IDC_CHECK_TAB_MULTILINE,		HIDC_CHECK_TAB_MULTILINE,		//ã‚¿ãƒ–å¤šæ®µ
+	IDC_COMBO_TAB_POSITION,			HIDC_COMBO_TAB_POSITION,		//ã‚¿ãƒ–è¡¨ç¤ºä½ç½®
+	IDC_TABWND_CAPTION,				HIDC_TABWND_CAPTION,			//ã‚¿ãƒ–ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³	//@@@ 2003.06.15 MIK
+	IDC_CHECK_ChgWndByWheel,		HIDC_CHECK_ChgWndByWheel,		//ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã§ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ‡ã‚Šæ›¿ãˆ 2007.04.03 ryoji
 	0, 0
 };
 
@@ -80,10 +80,10 @@ TYPE_NAME_ID<ETabPosition> TabPosArr[] = {
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg[in] ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg[in] ƒƒbƒZ[ƒW
-	@param wParam[in] ƒpƒ‰ƒ[ƒ^1
-	@param lParam[in] ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg[in] ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg[in] ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam[in] ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam[in] ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropTab::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -92,7 +92,7 @@ INT_PTR CALLBACK CPropTab::DlgProc_page(
 }
 //	To Here Jun. 2, 2001 genta
 
-/* ƒƒbƒZ[ƒWˆ— */
+/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	NMHDR*		pNMHDR;
@@ -101,12 +101,12 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 	switch( uMsg ){
 
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Tab */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Tab */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒ†[ƒU[‚ªƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+		/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 
 		return TRUE;
 	case WM_NOTIFY:
@@ -119,10 +119,10 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 				OnHelp( hwndDlg, IDD_PROP_TAB );
 				return TRUE;
 			case PSN_KILLACTIVE:
-				/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Tab */
+				/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Tab */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_TAB;
 				return TRUE;
@@ -133,8 +133,8 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 
 	case WM_COMMAND:
 		{
-			WORD wNotifyCode = HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-			WORD wID = LOWORD(wParam);	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+			WORD wNotifyCode = HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+			WORD wID = LOWORD(wParam);	/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 			if( wNotifyCode == BN_CLICKED ){
 				switch( wID ){
 				case IDC_CHECK_DispTabWnd:
@@ -148,7 +148,7 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 					if( MySelectFont( &lf, &nPointSize, hwndDlg, false) ){
 						m_Common.m_sTabBar.m_lf = lf;
 						m_Common.m_sTabBar.m_nPointSize = nPointSize;
-						// ƒ^ƒu ƒtƒHƒ“ƒg•\¦	// 2013/4/24 Uchi
+						// ã‚¿ãƒ– ãƒ•ã‚©ãƒ³ãƒˆè¡¨ç¤º	// 2013/4/24 Uchi
 						HFONT hFont = SetFontLabel( hwndDlg, IDC_STATIC_TABFONT, m_Common.m_sTabBar.m_lf, m_Common.m_sTabBar.m_nPointSize);
 						if (m_hTabFont != NULL){
 							::DeleteObject( m_hTabFont );
@@ -164,7 +164,7 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -174,12 +174,12 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.12.22 End
 
 	case WM_DESTROY:
-		// ƒ^ƒu ƒtƒHƒ“ƒg”jŠü	// 2013/4/24 Uchi
+		// ã‚¿ãƒ– ãƒ•ã‚©ãƒ³ãƒˆç ´æ£„	// 2013/4/24 Uchi
 		if (m_hTabFont != NULL) {
 			::DeleteObject( m_hTabFont );
 			m_hTabFont = NULL;
@@ -190,10 +190,10 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 }
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CPropTab::SetData( HWND hwndDlg )
 {
-	//	Feb. 11, 2007 gentauƒEƒBƒ“ƒhƒEvƒV[ƒg‚æ‚èˆÚ“®
+	//	Feb. 11, 2007 gentaã€Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã€ã‚·ãƒ¼ãƒˆã‚ˆã‚Šç§»å‹•
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DispTabWnd, m_Common.m_sTabBar.m_bDispTabWnd );	//@@@ 2003.05.31 MIK
 	::CheckDlgButton( hwndDlg, IDC_CHECK_SameTabWidth, m_Common.m_sTabBar.m_bSameTabWidth );	//@@@ 2006.01.28 ryoji
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DispTabIcon, m_Common.m_sTabBar.m_bDispTabIcon );	//@@@ 2006.01.28 ryoji
@@ -225,22 +225,22 @@ void CPropTab::SetData( HWND hwndDlg )
 	}
 	Combo_SetCurSel( hwndCombo, nSelPos );
 
-	//	Feb. 11, 2007 genta V‹Kì¬
+	//	Feb. 11, 2007 genta æ–°è¦ä½œæˆ
 	::CheckDlgButton( hwndDlg, IDC_CHECK_RetainEmptyWindow, m_Common.m_sTabBar.m_bTab_RetainEmptyWin );
 	::CheckDlgButton( hwndDlg, IDC_CHECK_CloseOneWin, m_Common.m_sTabBar.m_bTab_CloseOneWin );
 	::CheckDlgButton( hwndDlg, IDC_CHECK_ChgWndByWheel, m_Common.m_sTabBar.m_bChgWndByWheel );	// 2007.04.03 ryoji
 	::CheckDlgButton( hwndDlg, IDC_CHECK_OpenNewWin, m_Common.m_sTabBar.m_bNewWindow ); // 2009.06.17
 
-	// ƒ^ƒu ƒtƒHƒ“ƒg	// 2013/4/24 Uchi
+	// ã‚¿ãƒ– ãƒ•ã‚©ãƒ³ãƒˆ	// 2013/4/24 Uchi
 	m_hTabFont = SetFontLabel( hwndDlg, IDC_STATIC_TABFONT, m_Common.m_sTabBar.m_lf, m_Common.m_sTabBar.m_nPointSize);
 
 	EnableTabPropInput(hwndDlg);
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 int CPropTab::GetData( HWND hwndDlg )
 {
-	//	Feb. 11, 2007 gentauƒEƒBƒ“ƒhƒEvƒV[ƒg‚æ‚èˆÚ“®
+	//	Feb. 11, 2007 gentaã€Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã€ã‚·ãƒ¼ãƒˆã‚ˆã‚Šç§»å‹•
 	m_Common.m_sTabBar.m_bDispTabWnd = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DispTabWnd );
 
 	m_Common.m_sTabBar.m_bSameTabWidth = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_SameTabWidth );		// 2006.01.28 ryoji
@@ -259,7 +259,7 @@ int CPropTab::GetData( HWND hwndDlg )
 	nSelPos = Combo_GetCurSel( hwndCombo );
 	m_Common.m_sTabBar.m_eTabPosition = TabPosArr[nSelPos].nMethod;
 
-	//	Feb. 11, 2007 genta V‹Kì¬
+	//	Feb. 11, 2007 genta æ–°è¦ä½œæˆ
 	m_Common.m_sTabBar.m_bTab_RetainEmptyWin = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_RetainEmptyWindow );
 	m_Common.m_sTabBar.m_bTab_CloseOneWin = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_CloseOneWin );
 	m_Common.m_sTabBar.m_bChgWndByWheel = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_ChgWndByWheel );	// 2007.04.03 ryoji
@@ -268,9 +268,9 @@ int CPropTab::GetData( HWND hwndDlg )
 	return TRUE;
 }
 
-/*! uƒ^ƒuƒo[vƒV[ƒgã‚ÌƒAƒCƒeƒ€‚Ì—LŒøE–³Œø‚ğ“KØ‚Éİ’è‚·‚é
+/*! ã€Œã‚¿ãƒ–ãƒãƒ¼ã€ã‚·ãƒ¼ãƒˆä¸Šã®ã‚¢ã‚¤ãƒ†ãƒ ã®æœ‰åŠ¹ãƒ»ç„¡åŠ¹ã‚’é©åˆ‡ã«è¨­å®šã™ã‚‹
 
-	@date 2007.02.12 genta V‹Kì¬
+	@date 2007.02.12 genta æ–°è¦ä½œæˆ
 */
 void CPropTab::EnableTabPropInput(HWND hwndDlg)
 {

--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ���ʐݒ�_�C�A���O�{�b�N�X�A�u�c�[���o�[�v�y�[�W
+﻿/*!	@file
+	@brief 共通設定ダイアログボックス、「ツールバー」ページ
 
 	@author Norio Nakatani
 */
@@ -28,17 +28,17 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//11000
-	IDC_BUTTON_DELETE,				HIDC_BUTTON_DELETE_TOOLBAR,				//�c�[���o�[����@�\�폜
-	IDC_BUTTON_INSERTSEPARATOR,		HIDC_BUTTON_INSERTSEPARATOR_TOOLBAR,	//�Z�p���[�^�}��
-	IDC_BUTTON_INSERT,				HIDC_BUTTON_INSERT_TOOLBAR,				//�c�[���o�[�֋@�\�}��
-	IDC_BUTTON_ADD,					HIDC_BUTTON_ADD_TOOLBAR,				//�c�[���o�[�֋@�\�ǉ�
-	IDC_BUTTON_UP,					HIDC_BUTTON_UP_TOOLBAR,					//�c�[���o�[�̋@�\����ֈړ�
-	IDC_BUTTON_DOWN,				HIDC_BUTTON_DOWN_TOOLBAR,				//�c�[���o�[�̋@�\�����ֈړ�
-	IDC_CHECK_TOOLBARISFLAT,		HIDC_CHECK_TOOLBARISFLAT,				//�t���b�g�ȃ{�^��
-	IDC_COMBO_FUNCKIND,				HIDC_COMBO_FUNCKIND_TOOLBAR,			//�@�\�̎��
-	IDC_LIST_FUNC,					HIDC_LIST_FUNC_TOOLBAR,					//�@�\�ꗗ
-	IDC_LIST_RES,					HIDC_LIST_RES_TOOLBAR,					//�c�[���o�[�ꗗ
-	IDC_BUTTON_INSERTWRAP,			HIDC_BUTTON_INSERTWRAP,					//�c�[���o�[�ܕ�	// 2006.08.06 ryoji
+	IDC_BUTTON_DELETE,				HIDC_BUTTON_DELETE_TOOLBAR,				//ツールバーから機能削除
+	IDC_BUTTON_INSERTSEPARATOR,		HIDC_BUTTON_INSERTSEPARATOR_TOOLBAR,	//セパレータ挿入
+	IDC_BUTTON_INSERT,				HIDC_BUTTON_INSERT_TOOLBAR,				//ツールバーへ機能挿入
+	IDC_BUTTON_ADD,					HIDC_BUTTON_ADD_TOOLBAR,				//ツールバーへ機能追加
+	IDC_BUTTON_UP,					HIDC_BUTTON_UP_TOOLBAR,					//ツールバーの機能を上へ移動
+	IDC_BUTTON_DOWN,				HIDC_BUTTON_DOWN_TOOLBAR,				//ツールバーの機能を下へ移動
+	IDC_CHECK_TOOLBARISFLAT,		HIDC_CHECK_TOOLBARISFLAT,				//フラットなボタン
+	IDC_COMBO_FUNCKIND,				HIDC_COMBO_FUNCKIND_TOOLBAR,			//機能の種別
+	IDC_LIST_FUNC,					HIDC_LIST_FUNC_TOOLBAR,					//機能一覧
+	IDC_LIST_RES,					HIDC_LIST_RES_TOOLBAR,					//ツールバー一覧
+	IDC_BUTTON_INSERTWRAP,			HIDC_BUTTON_INSERTWRAP,					//ツールバー折返	// 2006.08.06 ryoji
 	IDC_LABEL_MENUFUNCKIND,			(DWORD)-1,
 	IDC_LABEL_MENUFUNC,				(DWORD)-1,
 	IDC_LABEL_TOOLBAR,				(DWORD)-1,
@@ -49,10 +49,10 @@ static const DWORD p_helpids[] = {	//11000
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg �_�C�A���O�{�b�N�X��Window Handle
-	@param uMsg ���b�Z�[�W
-	@param wParam �p�����[�^1
-	@param lParam �p�����[�^2
+	@param hwndDlg ダイアログボックスのWindow Handle
+	@param uMsg メッセージ
+	@param wParam パラメータ1
+	@param lParam パラメータ2
 */
 INT_PTR CALLBACK CPropToolbar::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -63,16 +63,16 @@ INT_PTR CALLBACK CPropToolbar::DlgProc_page(
 
 //	From Here Apr. 13, 2002 genta
 /*!
-	Owner Draw List Box�Ɏw��̒l��}������ (Windows XP�̖����p)
+	Owner Draw List Boxに指定の値を挿入する (Windows XPの問題回避用)
 	
-	Windows XP + manifest�̎���LB_INSERTSTRING���l0���󂯕t���Ȃ��̂�
-	�Ƃ肠����0�ȊO�̒l�����Ă���0�ɐݒ肵�����ĉ������B
-	1��ڂ̑}����0�łȂ���Ή��ł������͂��B
+	Windows XP + manifestの時にLB_INSERTSTRINGが値0を受け付けないので
+	とりあえず0以外の値を入れてから0に設定し直して回避する。
+	1回目の挿入は0でなければ何でもいいはず。
 	
-	@param hWnd [in] ���X�g�{�b�N�X�̃E�B���h�E�n���h��
-	@param index [in] �}���ʒu
-	@param value [in] �}������l
-	@return �}���ʒu�B�G���[�̎���LB_ERR�܂���LB_ERRSPACE
+	@param hWnd [in] リストボックスのウィンドウハンドル
+	@param index [in] 挿入位置
+	@param value [in] 挿入する値
+	@return 挿入位置。エラーの時はLB_ERRまたはLB_ERRSPACE
 	
 	@date 2002.04.13 genta 
 */
@@ -96,16 +96,16 @@ int Listbox_INSERTDATA(
 
 //	From Here Apr. 13, 2002 genta
 /*!
-	Owner Draw List Box�Ɏw��̒l��ǉ����� (Windows XP�̖����p)
+	Owner Draw List Boxに指定の値を追加する (Windows XPの問題回避用)
 	
-	Windows XP + manifest�̎���LB_ADDSTRING���l0���󂯕t���Ȃ��̂�
-	�Ƃ肠����0�ȊO�̒l�����Ă���0�ɐݒ肵�����ĉ������B
-	1��ڂ̑}����0�łȂ���Ή��ł������͂��B
+	Windows XP + manifestの時にLB_ADDSTRINGが値0を受け付けないので
+	とりあえず0以外の値を入れてから0に設定し直して回避する。
+	1回目の挿入は0でなければ何でもいいはず。
 	
-	@param hWnd [in] ���X�g�{�b�N�X�̃E�B���h�E�n���h��
-	@param index [in] �}���ʒu
-	@param value [in] �}������l
-	@return �}���ʒu�B�G���[�̎���LB_ERR�܂���LB_ERRSPACE
+	@param hWnd [in] リストボックスのウィンドウハンドル
+	@param index [in] 挿入位置
+	@param value [in] 挿入する値
+	@return 挿入位置。エラーの時はLB_ERRまたはLB_ERRSPACE
 	
 	@date 2002.04.13 genta 
 */
@@ -168,7 +168,7 @@ static void SetDlgItemsEnableState(
 
 }
 
-/* Toolbar ���b�Z�[�W���� */
+/* Toolbar メッセージ処理 */
 INT_PTR CPropToolbar::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
 	UINT	uMsg,		// message
@@ -196,16 +196,16 @@ INT_PTR CPropToolbar::DispatchEvent(
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* �R���g���[���̃n���h�����擾 */
+		/* コントロールのハンドルを取得 */
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_FUNCKIND );
 		hwndFuncList = ::GetDlgItem( hwndDlg, IDC_LIST_FUNC );
 		hwndResList = ::GetDlgItem( hwndDlg, IDC_LIST_RES );
 
 		{
-			// 2014.11.25 �t�H���g�̍������������Ȃ������o�O���C��
+			// 2014.11.25 フォントの高さが正しくなかったバグを修正
 			CTextWidthCalc calc(hwndResList);
 			int nFontHeight = calc.GetTextHeight();
-			nListItemHeight = 18; //Oct. 18, 2000 JEPRO �u�c�[���o�[�v�^�u�ł̋@�\�A�C�e���̍s�Ԃ������������ĕ\���s���𑝂₵��(20��18 ����ȏ㏬�������Ă����ʂ͂Ȃ��悤��)
+			nListItemHeight = 18; //Oct. 18, 2000 JEPRO 「ツールバー」タブでの機能アイテムの行間を少し狭くして表示行数を増やした(20→18 これ以上小さくしても効果はないようだ)
 			if( nListItemHeight < nFontHeight ){
 				nListItemHeight = nFontHeight;
 				nToolBarListBoxTopMargin = 0;
@@ -213,13 +213,13 @@ INT_PTR CPropToolbar::DispatchEvent(
 				nToolBarListBoxTopMargin = (nListItemHeight - (nFontHeight + 1)) / 2;
 			}
 		}
-		/* �_�C�A���O�f�[�^�̐ݒ� Toolbar */
+		/* ダイアログデータの設定 Toolbar */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-//	From Here Oct.14, 2000 JEPRO added	(Ref. CPropComCustmenu.cpp ����WM_INITDIALOG���Q�l�ɂ���)
-		/* �L�[�I�����̏��� */
+//	From Here Oct.14, 2000 JEPRO added	(Ref. CPropComCustmenu.cpp 内のWM_INITDIALOGを参考にした)
+		/* キー選択時の処理 */
 		::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_COMBO_FUNCKIND, CBN_SELCHANGE ), (LPARAM)hwndCombo );
 //	To Here Oct. 14, 2000
 
@@ -229,12 +229,12 @@ INT_PTR CPropToolbar::DispatchEvent(
 		return TRUE;
 
 	case WM_DRAWITEM:
-		idCtrl = (UINT) wParam;	/* �R���g���[����ID */
-		pDis = (LPDRAWITEMSTRUCT) lParam;	/* ���ڕ`���� */
+		idCtrl = (UINT) wParam;	/* コントロールのID */
+		pDis = (LPDRAWITEMSTRUCT) lParam;	/* 項目描画情報 */
 		switch( idCtrl ){
-		case IDC_LIST_RES:	/* �c�[���o�[�{�^�����ʃ��X�g */
-		case IDC_LIST_FUNC:	/* �{�^���ꗗ���X�g */
-			DrawToolBarItemList( pDis );	/* �c�[���o�[�{�^�����X�g�̃A�C�e���`�� */
+		case IDC_LIST_RES:	/* ツールバーボタン結果リスト */
+		case IDC_LIST_FUNC:	/* ボタン一覧リスト */
+			DrawToolBarItemList( pDis );	/* ツールバーボタンリストのアイテム描画 */
 			return TRUE;
 		}
 		return TRUE;
@@ -248,10 +248,10 @@ INT_PTR CPropToolbar::DispatchEvent(
 			return TRUE;
 		case PSN_KILLACTIVE:
 //			MYTRACE( _T("PROP_TOOLBAR PSN_KILLACTIVE\n") );
-			/* �_�C�A���O�f�[�^�̎擾 Toolbar */
+			/* ダイアログデータの取得 Toolbar */
 			GetData( hwndDlg );
 			return TRUE;
-//@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+//@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPCOM_PAGENUM_TOOLBAR;
 			return TRUE;
@@ -259,9 +259,9 @@ INT_PTR CPropToolbar::DispatchEvent(
 		break;
 
 	case WM_COMMAND:
-		wNotifyCode = HIWORD( wParam );	/* �ʒm�R�[�h */
-		wID = LOWORD( wParam );			/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
-		hwndCtl = (HWND) lParam;		/* �R���g���[���̃n���h�� */
+		wNotifyCode = HIWORD( wParam );	/* 通知コード */
+		wID = LOWORD( wParam );			/* 項目ID､ コントロールID､ またはアクセラレータID */
+		hwndCtl = (HWND) lParam;		/* コントロールのハンドル */
 
 		if( hwndResList == hwndCtl ){
 			switch( wNotifyCode ){
@@ -276,15 +276,15 @@ INT_PTR CPropToolbar::DispatchEvent(
 
 				List_ResetContent( hwndFuncList );
 
-				/* �@�\�ꗗ�ɕ�������Z�b�g (���X�g�{�b�N�X) */
-				//	From Here Oct. 15, 2001 genta Lookup���g���悤�ɕύX
+				/* 機能一覧に文字列をセット (リストボックス) */
+				//	From Here Oct. 15, 2001 genta Lookupを使うように変更
 				nNum = m_cLookup.GetItemCount( nIndex2 );
 				for( i = 0; i < nNum; ++i ){
 					nIndex1 = m_cLookup.Pos2FuncCode( nIndex2, i );
 					int nbarNo = m_pcMenuDrawer->FindToolbarNoFromCommandId( nIndex1 );
 
 					if( nbarNo >= 0 ){
-						/* �c�[���o�[�{�^���̏����Z�b�g (���X�g�{�b�N�X) */
+						/* ツールバーボタンの情報をセット (リストボックス) */
 						lResult = ::Listbox_ADDDATA( hwndFuncList, (LPARAM)nbarNo );
 						if( lResult == LB_ERR || lResult == LB_ERRSPACE ){
 							break;
@@ -297,7 +297,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 			}
 		}else{
 			switch( wNotifyCode ){
-			/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+			/* ボタン／チェックボックスがクリックされた */
 			case BN_CLICKED:
 				switch( wID ){
 				case IDC_BUTTON_INSERTSEPARATOR:
@@ -315,7 +315,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 					List_SetCurSel( hwndResList, nIndex1 );
 					break;
 
-// 2005/8/9 aroka �ܕԃ{�^���������ꂽ��A�E�̃��X�g�Ɂu�c�[���o�[�ܕԁv��ǉ�����B
+// 2005/8/9 aroka 折返ボタンが押されたら、右のリストに「ツールバー折返」を追加する。
 				case IDC_BUTTON_INSERTWRAP:
 					nIndex1 = List_GetCurSel( hwndResList );
 					if( LB_ERR == nIndex1 ){
@@ -323,7 +323,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 						nIndex1 = 0;
 					}
 					//	From Here Apr. 13, 2002 genta
-					//	2010.06.25 Moca �܂�Ԃ��̃c�[���o�[�̃{�^���ԍ��萔����ύX�B�Ō�ł͂Ȃ��Œ�l�ɂ���
+					//	2010.06.25 Moca 折り返しのツールバーのボタン番号定数名を変更。最後ではなく固定値にする
 					nIndex1 = ::Listbox_INSERTDATA( hwndResList, nIndex1, CMenuDrawer::TOOLBAR_BUTTON_F_TOOLBARWRAP );
 					if( nIndex1 == LB_ERR || nIndex1 == LB_ERRSPACE ){
 						break;
@@ -381,7 +381,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 					}
 					i = List_GetItemData( hwndFuncList, nIndex2 );
 					//	From Here Apr. 13, 2002 genta
-					//	�����ł� i != 0 ���Ƃ͎v�����ǁA�ꉞ�ی��ł��B
+					//	ここでは i != 0 だとは思うけど、一応保険です。
 					nIndex1 = ::Listbox_INSERTDATA( hwndResList, nIndex1, i );
 					if( nIndex1 == LB_ERR || nIndex1 == LB_ERRSPACE ){
 						TopErrorMessage( NULL, LS(STR_PROPCOMTOOL_ERR05), nIndex1 );
@@ -452,7 +452,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -462,7 +462,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -473,7 +473,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 
 
 
-/* �_�C�A���O�f�[�^�̐ݒ� Toolbar */
+/* ダイアログデータの設定 Toolbar */
 void CPropToolbar::SetData( HWND hwndDlg )
 {
 	HWND		hwndCombo;
@@ -482,27 +482,27 @@ void CPropToolbar::SetData( HWND hwndDlg )
 	int			nListItemHeight;
 	LRESULT		lResult;
 
-	/* �@�\��ʈꗗ�ɕ�������Z�b�g(�R���{�{�b�N�X) */
+	/* 機能種別一覧に文字列をセット(コンボボックス) */
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_FUNCKIND );
 	m_cLookup.SetCategory2Combo( hwndCombo );	//	Oct. 15, 2001 genta
 	
-	/* ��ʂ̐擪�̍��ڂ�I��(�R���{�{�b�N�X) */
-	Combo_SetCurSel( hwndCombo, 0 );	//Oct. 14, 2000 JEPRO JEPRO �u--����`--�v��\�������Ȃ��悤�ɑ匳 Funcode.cpp �ŕύX���Ă���
+	/* 種別の先頭の項目を選択(コンボボックス) */
+	Combo_SetCurSel( hwndCombo, 0 );	//Oct. 14, 2000 JEPRO JEPRO 「--未定義--」を表示させないように大元 Funcode.cpp で変更してある
 	::PostMessageCmd( hwndCombo, WM_COMMAND, MAKELONG( IDC_COMBO_FUNCKIND, CBN_SELCHANGE ), (LPARAM)hwndCombo );
 
-	/* �R���g���[���̃n���h�����擾 */
+	/* コントロールのハンドルを取得 */
 	hwndResList = ::GetDlgItem( hwndDlg, IDC_LIST_RES );
 
-	// 2014.11.25 �t�H���g�̍������������Ȃ������o�O���C��
+	// 2014.11.25 フォントの高さが正しくなかったバグを修正
 	int nFontHeight = CTextWidthCalc(hwndResList).GetTextHeight();
 
-	nListItemHeight = 18; //Oct. 18, 2000 JEPRO �u�c�[���o�[�v�^�u�ł̃c�[���o�[�A�C�e���̍s�Ԃ������������ĕ\���s���𑝂₵��(20��18 ����ȏ㏬�������Ă����ʂ͂Ȃ��悤��)
+	nListItemHeight = 18; //Oct. 18, 2000 JEPRO 「ツールバー」タブでのツールバーアイテムの行間を少し狭くして表示行数を増やした(20→18 これ以上小さくしても効果はないようだ)
 	if( nListItemHeight < nFontHeight ){
 		nListItemHeight = nFontHeight;
 	}
 //	nListItemHeight+=2;
 
-	/* �c�[���o�[�{�^���̏����Z�b�g(���X�g�{�b�N�X)*/
+	/* ツールバーボタンの情報をセット(リストボックス)*/
 	for( i = 0; i < m_Common.m_sToolBar.m_nToolBarButtonNum; ++i ){
 		//	From Here Apr. 13, 2002 genta
 		lResult = ::Listbox_ADDDATA( hwndResList, (LPARAM)m_Common.m_sToolBar.m_nToolBarButtonIdxArr[i] );
@@ -512,17 +512,17 @@ void CPropToolbar::SetData( HWND hwndDlg )
 		//	To Here Apr. 13, 2002 genta
 		lResult = List_SetItemHeight( hwndResList, lResult, nListItemHeight );
 	}
-	/* �c�[���o�[�̐擪�̍��ڂ�I��(���X�g�{�b�N�X)*/
-	List_SetCurSel( hwndResList, 0 );	//Oct. 14, 2000 JEPRO �������R�����g�A�E�g����Ɛ擪���ڂ��I������Ȃ��Ȃ�
+	/* ツールバーの先頭の項目を選択(リストボックス)*/
+	List_SetCurSel( hwndResList, 0 );	//Oct. 14, 2000 JEPRO ここをコメントアウトすると先頭項目が選択されなくなる
 
-	/* �t���b�g�c�[���o�[�ɂ���^���Ȃ�  */
+	/* フラットツールバーにする／しない  */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_TOOLBARISFLAT, m_Common.m_sToolBar.m_bToolBarIsFlat );
 	return;
 }
 
 
 
-/* �_�C�A���O�f�[�^�̎擾 Toolbar */
+/* ダイアログデータの取得 Toolbar */
 int CPropToolbar::GetData( HWND hwndDlg )
 {
 	HWND	hwndResList;
@@ -532,10 +532,10 @@ int CPropToolbar::GetData( HWND hwndDlg )
 
 	hwndResList = ::GetDlgItem( hwndDlg, IDC_LIST_RES );
 
-	/* �c�[���o�[�{�^���̐� */
+	/* ツールバーボタンの数 */
 	m_Common.m_sToolBar.m_nToolBarButtonNum = List_GetCount( hwndResList );
 
-	/* �c�[���o�[�{�^���̏����擾 */
+	/* ツールバーボタンの情報を取得 */
 	k = 0;
 	for( i = 0; i < m_Common.m_sToolBar.m_nToolBarButtonNum; ++i ){
 		j = List_GetItemData( hwndResList, i );
@@ -546,16 +546,16 @@ int CPropToolbar::GetData( HWND hwndDlg )
 	}
 	m_Common.m_sToolBar.m_nToolBarButtonNum = k;
 
-	/* �t���b�g�c�[���o�[�ɂ���^���Ȃ�  */
+	/* フラットツールバーにする／しない  */
 	m_Common.m_sToolBar.m_bToolBarIsFlat = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_TOOLBARISFLAT );
 
 	return TRUE;
 }
 
-/* �c�[���o�[�{�^�����X�g�̃A�C�e���`��
-	@date 2003.08.27 Moca �V�X�e���J���[�̃u���V��CreateSolidBrush�����GetSysColorBrush��
-	@date 2005.08.09 aroka CPropCommon.cpp ����ړ�
-	@date 2007.11.02 ryoji �{�^���ƃZ�p���[�^�Ƃŏ����𕪂���
+/* ツールバーボタンリストのアイテム描画
+	@date 2003.08.27 Moca システムカラーのブラシはCreateSolidBrushをやめGetSysColorBrushに
+	@date 2005.08.09 aroka CPropCommon.cpp から移動
+	@date 2007.11.02 ryoji ボタンとセパレータとで処理を分ける
 */
 void CPropToolbar::DrawToolBarItemList( DRAWITEMSTRUCT* pDis )
 {
@@ -574,27 +574,27 @@ void CPropToolbar::DrawToolBarItemList( DRAWITEMSTRUCT* pDis )
 
 	rc  = pDis->rcItem;
 	rc0 = pDis->rcItem;
-	rc0.left += 18;//20 //Oct. 18, 2000 JEPRO �s�擪�̃A�C�R���Ƃ���ɑ����L���v�V�����Ƃ̊Ԃ������l�߂�(20��18)
+	rc0.left += 18;//20 //Oct. 18, 2000 JEPRO 行先頭のアイコンとそれに続くキャプションとの間を少し詰めた(20→18)
 	rc1 = rc0;
 	rc2 = rc0;
 
 	if( (int)pDis->itemID < 0 ){
 	}else{
 
-//@@@ 2002.01.03 YAZAKI m_tbMyButton�Ȃǂ�CShareData����CMenuDrawer�ֈړ��������Ƃɂ��C���B
+//@@@ 2002.01.03 YAZAKI m_tbMyButtonなどをCShareDataからCMenuDrawerへ移動したことによる修正。
 //		tbb = m_cShareData.m_tbMyButton[pDis->itemData];
 //		tbb = m_pcMenuDrawer->m_tbMyButton[pDis->itemData];
 		tbb = m_pcMenuDrawer->getButton(pDis->itemData);
 
-		// �{�^���ƃZ�p���[�^�Ƃŏ����𕪂���	2007.11.02 ryoji
+		// ボタンとセパレータとで処理を分ける	2007.11.02 ryoji
 		WCHAR	szLabel[256];
 		if( tbb.fsStyle & TBSTYLE_SEP ){
-			// �e�L�X�g�����\������
+			// テキストだけ表示する
 			if( tbb.idCommand == F_SEPARATOR ){
-				auto_strncpy( szLabel, LSW(STR_PROPCOMTOOL_ITEM1), _countof(szLabel) - 1 );	// nLength ���g�p 2003/01/09 Moca
+				auto_strncpy( szLabel, LSW(STR_PROPCOMTOOL_ITEM1), _countof(szLabel) - 1 );	// nLength 未使用 2003/01/09 Moca
 				szLabel[_countof(szLabel) - 1] = L'\0';
 			}else if( tbb.idCommand == F_MENU_NOT_USED_FIRST ){
-				// �c�[���o�[�ܕ�
+				// ツールバー折返
 				auto_strncpy( szLabel, LSW(STR_PROPCOMTOOL_ITEM2), _countof(szLabel) - 1 );
 				szLabel[_countof(szLabel) - 1] = L'\0';
 			}else{
@@ -603,13 +603,13 @@ void CPropToolbar::DrawToolBarItemList( DRAWITEMSTRUCT* pDis )
 			}
 		//	From Here Oct. 15, 2001 genta
 		}else{
-			// �A�C�R���ƃe�L�X�g��\������
+			// アイコンとテキストを表示する
 			m_pcIcons->Draw( tbb.iBitmap, pDis->hDC, rc.left + 2, rc.top + 2, ILD_NORMAL );
 			m_cLookup.Funccode2Name( tbb.idCommand, szLabel, _countof( szLabel ) );
 		}
 		//	To Here Oct. 15, 2001 genta
 
-		/* �A�C�e�����I������Ă��� */
+		/* アイテムが選択されている */
 		if( pDis->itemState & ODS_SELECTED ){
 //			hBrush = ::CreateSolidBrush( ::GetSysColor( COLOR_HIGHLIGHT ) );
 			hBrush = ::GetSysColorBrush( COLOR_HIGHLIGHT );
@@ -627,12 +627,12 @@ void CPropToolbar::DrawToolBarItemList( DRAWITEMSTRUCT* pDis )
 //		::DeleteObject( hBrush );
 
 		::SetBkMode( pDis->hDC, TRANSPARENT );
-		// 2014.11.25 top�}�[�W����2�Œ肾�ƃt�H���g���傫�����Ɍ��؂��̂ŕϐ��ɕύX
+		// 2014.11.25 topマージンが2固定だとフォントが大きい時に見切れるので変数に変更
 		TextOutW_AnyBuild( pDis->hDC, rc1.left + 4, rc1.top + nToolBarListBoxTopMargin, szLabel, wcslen( szLabel ) );
 
 	}
 
-	/* �A�C�e���Ƀt�H�[�J�X������ */
+	/* アイテムにフォーカスがある */
 	if( pDis->itemState & ODS_FOCUS ){
 		::DrawFocusRect( pDis->hDC, &rc2 );
 	}

--- a/sakura_core/prop/CPropComWin.cpp
+++ b/sakura_core/prop/CPropComWin.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAuƒEƒBƒ“ƒhƒEvƒy[ƒW
+ï»¿/*!	@file
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã€ãƒšãƒ¼ã‚¸
 
 	@author Norio Nakatani
 */
@@ -27,28 +27,28 @@
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 static const DWORD p_helpids[] = {	//11200
-	IDC_CHECK_DispFUNCKEYWND,		HIDC_CHECK_DispFUNCKEYWND,		//ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\¦
-	IDC_CHECK_DispSTATUSBAR,		HIDC_CHECK_DispSTATUSBAR,		//ƒXƒe[ƒ^ƒXƒo[•\¦
-	IDC_CHECK_DispTOOLBAR,			HIDC_CHECK_DispTOOLBAR,			//ƒc[ƒ‹ƒo[•\¦
-	IDC_CHECK_bScrollBarHorz,		HIDC_CHECK_bScrollBarHorz,		//…•½ƒXƒNƒ[ƒ‹ƒo[
-	IDC_CHECK_bMenuIcon,			HIDC_CHECK_bMenuIcon,			//ƒAƒCƒRƒ“•t‚«ƒƒjƒ…[
-	IDC_CHECK_SplitterWndVScroll,	HIDC_CHECK_SplitterWndVScroll,	//‚’¼ƒXƒNƒ[ƒ‹‚Ì“¯Šú	//Jul. 05, 2001 JEPRO ’Ç‰Á
-	IDC_CHECK_SplitterWndHScroll,	HIDC_CHECK_SplitterWndHScroll,	//…•½ƒXƒNƒ[ƒ‹‚Ì“¯Šú	//Jul. 05, 2001 JEPRO ’Ç‰Á
-	IDC_EDIT_nRulerBottomSpace,		HIDC_EDIT_nRulerBottomSpace,	//ƒ‹[ƒ‰[‚Ì‚‚³
-	IDC_EDIT_nRulerHeight,			HIDC_EDIT_nRulerHeight,			//ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŠÔŠu
-	IDC_EDIT_nLineNumberRightSpace,	HIDC_EDIT_nLineNumberRightSpace,	//s”Ô†‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ
-	IDC_RADIO_FUNCKEYWND_PLACE1,	HIDC_RADIO_FUNCKEYWND_PLACE1,	//ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\¦ˆÊ’u
-	IDC_RADIO_FUNCKEYWND_PLACE2,	HIDC_RADIO_FUNCKEYWND_PLACE2,	//ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\¦ˆÊ’u
-	IDC_EDIT_FUNCKEYWND_GROUPNUM,	HIDC_EDIT_FUNCKEYWND_GROUPNUM,	//ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ÌƒOƒ‹[ƒvƒ{ƒ^ƒ“”
+	IDC_CHECK_DispFUNCKEYWND,		HIDC_CHECK_DispFUNCKEYWND,		//ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤º
+	IDC_CHECK_DispSTATUSBAR,		HIDC_CHECK_DispSTATUSBAR,		//ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼è¡¨ç¤º
+	IDC_CHECK_DispTOOLBAR,			HIDC_CHECK_DispTOOLBAR,			//ãƒ„ãƒ¼ãƒ«ãƒãƒ¼è¡¨ç¤º
+	IDC_CHECK_bScrollBarHorz,		HIDC_CHECK_bScrollBarHorz,		//æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼
+	IDC_CHECK_bMenuIcon,			HIDC_CHECK_bMenuIcon,			//ã‚¢ã‚¤ã‚³ãƒ³ä»˜ããƒ¡ãƒ‹ãƒ¥ãƒ¼
+	IDC_CHECK_SplitterWndVScroll,	HIDC_CHECK_SplitterWndVScroll,	//å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸ	//Jul. 05, 2001 JEPRO è¿½åŠ 
+	IDC_CHECK_SplitterWndHScroll,	HIDC_CHECK_SplitterWndHScroll,	//æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸ	//Jul. 05, 2001 JEPRO è¿½åŠ 
+	IDC_EDIT_nRulerBottomSpace,		HIDC_EDIT_nRulerBottomSpace,	//ãƒ«ãƒ¼ãƒ©ãƒ¼ã®é«˜ã•
+	IDC_EDIT_nRulerHeight,			HIDC_EDIT_nRulerHeight,			//ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®é–“éš”
+	IDC_EDIT_nLineNumberRightSpace,	HIDC_EDIT_nLineNumberRightSpace,	//è¡Œç•ªå·ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“
+	IDC_RADIO_FUNCKEYWND_PLACE1,	HIDC_RADIO_FUNCKEYWND_PLACE1,	//ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤ºä½ç½®
+	IDC_RADIO_FUNCKEYWND_PLACE2,	HIDC_RADIO_FUNCKEYWND_PLACE2,	//ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤ºä½ç½®
+	IDC_EDIT_FUNCKEYWND_GROUPNUM,	HIDC_EDIT_FUNCKEYWND_GROUPNUM,	//ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®ã‚°ãƒ«ãƒ¼ãƒ—ãƒœã‚¿ãƒ³æ•°
 	IDC_SPIN_nRulerBottomSpace,		HIDC_EDIT_nRulerBottomSpace,
 	IDC_SPIN_nRulerHeight,			HIDC_EDIT_nRulerHeight,
 	IDC_SPIN_nLineNumberRightSpace,	HIDC_EDIT_nLineNumberRightSpace,
 	IDC_SPIN_FUNCKEYWND_GROUPNUM,	HIDC_EDIT_FUNCKEYWND_GROUPNUM,
-	IDC_WINCAPTION_ACTIVE,			HIDC_WINCAPTION_ACTIVE,			//ƒAƒNƒeƒBƒu	//@@@ 2003.06.15 MIK
-	IDC_WINCAPTION_INACTIVE,		HIDC_WINCAPTION_INACTIVE,		//”ñƒAƒNƒeƒBƒu	//@@@ 2003.06.15 MIK
-	IDC_BUTTON_WINSIZE,				HIDC_BUTTON_WINSIZE,			//ˆÊ’u‚Æ‘å‚«‚³‚Ìİ’è	// 2006.08.06 ryoji
-	IDC_COMBO_LANGUAGE,				HIDC_COMBO_LANGUAGE,			//Œ¾Œê‘I‘ğ
-	//	Feb. 11, 2007 genta TABŠÖ˜A‚Íuƒ^ƒuƒo[vƒV[ƒg‚ÖˆÚ“®
+	IDC_WINCAPTION_ACTIVE,			HIDC_WINCAPTION_ACTIVE,			//ã‚¢ã‚¯ãƒ†ã‚£ãƒ–æ™‚	//@@@ 2003.06.15 MIK
+	IDC_WINCAPTION_INACTIVE,		HIDC_WINCAPTION_INACTIVE,		//éã‚¢ã‚¯ãƒ†ã‚£ãƒ–æ™‚	//@@@ 2003.06.15 MIK
+	IDC_BUTTON_WINSIZE,				HIDC_BUTTON_WINSIZE,			//ä½ç½®ã¨å¤§ãã•ã®è¨­å®š	// 2006.08.06 ryoji
+	IDC_COMBO_LANGUAGE,				HIDC_COMBO_LANGUAGE,			//è¨€èªé¸æŠ
+	//	Feb. 11, 2007 genta TABé–¢é€£ã¯ã€Œã‚¿ãƒ–ãƒãƒ¼ã€ã‚·ãƒ¼ãƒˆã¸ç§»å‹•
 //	IDC_STATIC,						-1,
 	0, 0
 };
@@ -56,10 +56,10 @@ static const DWORD p_helpids[] = {	//11200
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handle
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handle
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CALLBACK CPropWin::DlgProc_page(
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -69,7 +69,7 @@ INT_PTR CALLBACK CPropWin::DlgProc_page(
 //	To Here Jun. 2, 2001 genta
 
 
-/* ƒƒbƒZ[ƒWˆ— */
+/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropWin::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
 	UINT	uMsg,	// message
@@ -85,20 +85,20 @@ INT_PTR CPropWin::DispatchEvent(
 	NMHDR*		pNMHDR;
 	NM_UPDOWN*	pMNUD;
 	int			idCtrl;
-	int			nVal;	//Sept.21, 2000 JEPRO ƒXƒsƒ“—v‘f‚ğ‰Á‚¦‚½‚Ì‚Å•œŠˆ‚³‚¹‚½
+	int			nVal;	//Sept.21, 2000 JEPRO ã‚¹ãƒ”ãƒ³è¦ç´ ã‚’åŠ ãˆãŸã®ã§å¾©æ´»ã•ã›ãŸ
 
 	switch( uMsg ){
 
 	case WM_INITDIALOG:
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è Window */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š Window */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒ†[ƒU[‚ªƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
-		/* ƒ‹[ƒ‰[‚‚³ */
+		/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
+		/* ãƒ«ãƒ¼ãƒ©ãƒ¼é«˜ã• */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_nRulerHeight ), 2 );
-		/* ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ */
+		/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“ */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_nRulerBottomSpace ), 2 );
 
 		return TRUE;
@@ -115,17 +115,17 @@ INT_PTR CPropWin::DispatchEvent(
 				return TRUE;
 			case PSN_KILLACTIVE:
 //				MYTRACE( _T("Window PSN_KILLACTIVE\n") );
-				/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ Window */
+				/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— Window */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_WIN;
 				return TRUE;
 			}
 			break;
 		case IDC_SPIN_nRulerHeight:
-			/* ƒ‹[ƒ‰|‚Ì‚‚³ */
+			/* ãƒ«ãƒ¼ãƒ©ï¼ã®é«˜ã• */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_nRulerHeight, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -142,7 +142,7 @@ INT_PTR CPropWin::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_nRulerHeight, nVal, FALSE );
 			return TRUE;
 		case IDC_SPIN_nRulerBottomSpace:
-			/* ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ */
+			/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“ */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_nRulerBottomSpace, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -159,7 +159,7 @@ INT_PTR CPropWin::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_nRulerBottomSpace, nVal, FALSE );
 			return TRUE;
 		case IDC_SPIN_nLineNumberRightSpace:
-			/* ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ */
+			/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“ */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_nLineNumberRightSpace, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -196,19 +196,19 @@ INT_PTR CPropWin::DispatchEvent(
 //****	To Here Sept. 21, 2000
 //	From Here Sept. 9, 2000 JEPRO
 	case WM_COMMAND:
-		wNotifyCode	= HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID			= LOWORD(wParam);	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+		wNotifyCode	= HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID			= LOWORD(wParam);	/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 		switch( wNotifyCode ){
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 			switch( wID ){
-			//	ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ğ•\¦‚·‚é‚¾‚¯‚»‚ÌˆÊ’uw’è‚ğEnable‚Éİ’è
+			//	ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹æ™‚ã ã‘ãã®ä½ç½®æŒ‡å®šã‚’Enableã«è¨­å®š
 			case IDC_CHECK_DispFUNCKEYWND:
 				EnableWinPropInput( hwndDlg );
 				break;
 
-			// From Here 2004.05.13 Moca uˆÊ’u‚Æ‘å‚«‚³‚Ìİ’èvƒ{ƒ^ƒ“
-			//	ƒEƒBƒ“ƒhƒEİ’èƒ_ƒCƒAƒƒO‚É‚Ä‹N“®‚ÌƒEƒBƒ“ƒhƒEó‘Ôw’è
+			// From Here 2004.05.13 Moca ã€Œä½ç½®ã¨å¤§ãã•ã®è¨­å®šã€ãƒœã‚¿ãƒ³
+			//	ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã«ã¦èµ·å‹•æ™‚ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦çŠ¶æ…‹æŒ‡å®š
 			case IDC_BUTTON_WINSIZE:
 				{
 					CDlgWinSize cDlgWinSize;
@@ -242,7 +242,7 @@ INT_PTR CPropWin::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -252,7 +252,7 @@ INT_PTR CPropWin::DispatchEvent(
 //@@@ 2001.12.22 Start by MIK: Context Menu Help
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.12.22 End
 
@@ -260,18 +260,18 @@ INT_PTR CPropWin::DispatchEvent(
 	return FALSE;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CPropWin::SetData( HWND hwndDlg )
 {
 //	BOOL	bRet;
 
-	/* Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒc[ƒ‹ƒo[‚ğ•\¦‚·‚é */
+	/* æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ããƒ„ãƒ¼ãƒ«ãƒãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DispTOOLBAR, m_Common.m_sWindow.m_bDispTOOLBAR );
 
-	/* Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ğ•\¦‚·‚é */
+	/* æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ããƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DispFUNCKEYWND, m_Common.m_sWindow.m_bDispFUNCKEYWND );
 
-	/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\¦ˆÊ’u^0:ã 1:‰º */
+	/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤ºä½ç½®ï¼0:ä¸Š 1:ä¸‹ */
 	if( 0 == m_Common.m_sWindow.m_nFUNCKEYWND_Place ){
 		::CheckDlgButton( hwndDlg, IDC_RADIO_FUNCKEYWND_PLACE1, TRUE );
 		::CheckDlgButton( hwndDlg, IDC_RADIO_FUNCKEYWND_PLACE2, FALSE );
@@ -279,26 +279,26 @@ void CPropWin::SetData( HWND hwndDlg )
 		::CheckDlgButton( hwndDlg, IDC_RADIO_FUNCKEYWND_PLACE1, FALSE );
 		::CheckDlgButton( hwndDlg, IDC_RADIO_FUNCKEYWND_PLACE2, TRUE );
 	}
-	// 2002/11/04 Moca ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ÌƒOƒ‹[ƒvƒ{ƒ^ƒ“”
+	// 2002/11/04 Moca ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®ã‚°ãƒ«ãƒ¼ãƒ—ãƒœã‚¿ãƒ³æ•°
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_FUNCKEYWND_GROUPNUM, m_Common.m_sWindow.m_nFUNCKEYWND_GroupNum, FALSE );
 
 	//From Here@@@ 2003.06.13 MIK
-	//	Feb. 12, 2007 genta TABŠÖ˜A‚Íuƒ^ƒuƒo[vƒV[ƒg‚ÖˆÚ“®
+	//	Feb. 12, 2007 genta TABé–¢é€£ã¯ã€Œã‚¿ãƒ–ãƒãƒ¼ã€ã‚·ãƒ¼ãƒˆã¸ç§»å‹•
 
 	//To Here@@@ 2003.06.13 MIK
-	//	Feb. 11, 2007 genta TABŠÖ˜A‚Íuƒ^ƒuƒo[vƒV[ƒg‚ÖˆÚ“®
+	//	Feb. 11, 2007 genta TABé–¢é€£ã¯ã€Œã‚¿ãƒ–ãƒãƒ¼ã€ã‚·ãƒ¼ãƒˆã¸ç§»å‹•
 
-	/* Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒXƒe[ƒ^ƒXƒo[‚ğ•\¦‚·‚é */
+	/* æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ãã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DispSTATUSBAR, m_Common.m_sWindow.m_bDispSTATUSBAR );
 
-	/* ƒ‹[ƒ‰[‚‚³ */
+	/* ãƒ«ãƒ¼ãƒ©ãƒ¼é«˜ã• */
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_nRulerHeight, m_Common.m_sWindow.m_nRulerHeight, FALSE );
-	/* ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ */
+	/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“ */
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_nRulerBottomSpace, m_Common.m_sWindow.m_nRulerBottomSpace, FALSE );
-	//	Sep. 18. 2002 genta s”Ô†‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ
+	//	Sep. 18. 2002 genta è¡Œç•ªå·ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“
 	::SetDlgItemInt( hwndDlg, IDC_EDIT_nLineNumberRightSpace, m_Common.m_sWindow.m_nLineNumRightSpace, FALSE );
 
-	/* ƒ‹[ƒ‰[‚Ìƒ^ƒCƒv *///	del 2008/7/4 Uchi
+	/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚¿ã‚¤ãƒ— *///	del 2008/7/4 Uchi
 //	if( 0 == m_Common.m_sWindow.m_nRulerType ){
 //		::CheckDlgButton( hwndDlg, IDC_RADIO_nRulerType_0, TRUE );
 //		::CheckDlgButton( hwndDlg, IDC_RADIO_nRulerType_1, FALSE );
@@ -307,29 +307,29 @@ void CPropWin::SetData( HWND hwndDlg )
 //		::CheckDlgButton( hwndDlg, IDC_RADIO_nRulerType_1, TRUE );
 //	}
 
-	/* …•½ƒXƒNƒ[ƒ‹ƒo[ */
+	/* æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_bScrollBarHorz, m_Common.m_sWindow.m_bScrollBarHorz );
 
-	/* ƒAƒCƒRƒ“•t‚«ƒƒjƒ…[ */
+	/* ã‚¢ã‚¤ã‚³ãƒ³ä»˜ããƒ¡ãƒ‹ãƒ¥ãƒ¼ */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_bMenuIcon, m_Common.m_sWindow.m_bMenuIcon );
 
-	//	2001/06/20 Start by asa-o:	ƒXƒNƒ[ƒ‹‚Ì“¯Šú
+	//	2001/06/20 Start by asa-o:	ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸ
 	::CheckDlgButton( hwndDlg, IDC_CHECK_SplitterWndVScroll, m_Common.m_sWindow.m_bSplitterWndVScroll );
 	::CheckDlgButton( hwndDlg, IDC_CHECK_SplitterWndHScroll, m_Common.m_sWindow.m_bSplitterWndHScroll );
 	//	2001/06/20 End
 
-	//	Apr. 05, 2003 genta ƒEƒBƒ“ƒhƒEƒLƒƒƒvƒVƒ‡ƒ“‚ÌƒJƒXƒ^ƒ}ƒCƒY
+	//	Apr. 05, 2003 genta ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³ã®ã‚«ã‚¹ã‚¿ãƒã‚¤ã‚º
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_WINCAPTION_ACTIVE   ), _countof( m_Common.m_sWindow.m_szWindowCaptionActive   ) - 1 );	//@@@ 2003.06.13 MIK
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_WINCAPTION_INACTIVE ), _countof( m_Common.m_sWindow.m_szWindowCaptionInactive ) - 1 );	//@@@ 2003.06.13 MIK
 	::DlgItem_SetText( hwndDlg, IDC_WINCAPTION_ACTIVE, m_Common.m_sWindow.m_szWindowCaptionActive );
 	::DlgItem_SetText( hwndDlg, IDC_WINCAPTION_INACTIVE, m_Common.m_sWindow.m_szWindowCaptionInactive );
 
 	//	Fronm Here Sept. 9, 2000 JEPRO
-	//	ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ğ•\¦‚·‚é‚¾‚¯‚»‚ÌˆÊ’uw’è‚ğEnable‚Éİ’è
+	//	ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹æ™‚ã ã‘ãã®ä½ç½®æŒ‡å®šã‚’Enableã«è¨­å®š
 	EnableWinPropInput( hwndDlg );
 	//	To Here Sept. 9, 2000
 
-	// Œ¾Œê‘I‘ğ
+	// è¨€èªé¸æŠ
 	HWND hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_LANGUAGE );
 	Combo_ResetContent( hwndCombo );
 	int nSelPos = 0;
@@ -350,16 +350,16 @@ void CPropWin::SetData( HWND hwndDlg )
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— */
 int CPropWin::GetData( HWND hwndDlg )
 {
-	/* Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒc[ƒ‹ƒo[‚ğ•\¦‚·‚é */
+	/* æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ããƒ„ãƒ¼ãƒ«ãƒãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ */
 	m_Common.m_sWindow.m_bDispTOOLBAR = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DispTOOLBAR );
 
-	/* Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ğ•\¦‚·‚é */
+	/* æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ããƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ */
 	m_Common.m_sWindow.m_bDispFUNCKEYWND = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DispFUNCKEYWND );
 
-	/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\¦ˆÊ’u^0:ã 1:‰º */
+	/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤ºä½ç½®ï¼0:ä¸Š 1:ä¸‹ */
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_FUNCKEYWND_PLACE1 ) ){
 		m_Common.m_sWindow.m_nFUNCKEYWND_Place = 0;
 	}
@@ -367,7 +367,7 @@ int CPropWin::GetData( HWND hwndDlg )
 		m_Common.m_sWindow.m_nFUNCKEYWND_Place = 1;
 	}
 
-	// 2002/11/04 Moca ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[‚ÌƒOƒ‹[ƒvƒ{ƒ^ƒ“”
+	// 2002/11/04 Moca ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã®ã‚°ãƒ«ãƒ¼ãƒ—ãƒœã‚¿ãƒ³æ•°
 	m_Common.m_sWindow.m_nFUNCKEYWND_GroupNum = ::GetDlgItemInt( hwndDlg, IDC_EDIT_FUNCKEYWND_GROUPNUM, NULL, FALSE );
 	if( m_Common.m_sWindow.m_nFUNCKEYWND_GroupNum < 1 ){
 		m_Common.m_sWindow.m_nFUNCKEYWND_GroupNum = 1;
@@ -377,13 +377,13 @@ int CPropWin::GetData( HWND hwndDlg )
 	}
 
 	//From Here@@@ 2003.06.13 MIK
-	//	Feb. 12, 2007 genta TABŠÖ˜A‚Íuƒ^ƒuƒo[vƒV[ƒg‚ÖˆÚ“®
+	//	Feb. 12, 2007 genta TABé–¢é€£ã¯ã€Œã‚¿ãƒ–ãƒãƒ¼ã€ã‚·ãƒ¼ãƒˆã¸ç§»å‹•
 	//To Here@@@ 2003.06.13 MIK
 
-	/* Ÿ‰ñƒEƒBƒ“ƒhƒE‚ğŠJ‚¢‚½‚Æ‚«ƒXƒe[ƒ^ƒXƒo[‚ğ•\¦‚·‚é */
+	/* æ¬¡å›ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‹ã„ãŸã¨ãã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ */
 	m_Common.m_sWindow.m_bDispSTATUSBAR = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DispSTATUSBAR );
 
-	/* ƒ‹[ƒ‰[‚Ìƒ^ƒCƒv *///	del 2008/7/4 Uchi
+	/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚¿ã‚¤ãƒ— *///	del 2008/7/4 Uchi
 //	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_nRulerType_0 ) ){
 //		m_Common.m_sWindow.m_nRulerType = 0;
 //	}
@@ -391,7 +391,7 @@ int CPropWin::GetData( HWND hwndDlg )
 //		m_Common.m_sWindow.m_nRulerType = 1;
 //	}
 
-	/* ƒ‹[ƒ‰[‚‚³ */
+	/* ãƒ«ãƒ¼ãƒ©ãƒ¼é«˜ã• */
 	m_Common.m_sWindow.m_nRulerHeight = ::GetDlgItemInt( hwndDlg, IDC_EDIT_nRulerHeight, NULL, FALSE );
 	if( m_Common.m_sWindow.m_nRulerHeight < IDC_SPIN_nRulerHeight_MIN ){
 		m_Common.m_sWindow.m_nRulerHeight = IDC_SPIN_nRulerHeight_MIN;
@@ -399,7 +399,7 @@ int CPropWin::GetData( HWND hwndDlg )
 	if( m_Common.m_sWindow.m_nRulerHeight > IDC_SPIN_nRulerHeight_MAX ){
 		m_Common.m_sWindow.m_nRulerHeight = IDC_SPIN_nRulerHeight_MAX;
 	}
-	/* ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ */
+	/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“ */
 	m_Common.m_sWindow.m_nRulerBottomSpace = ::GetDlgItemInt( hwndDlg, IDC_EDIT_nRulerBottomSpace, NULL, FALSE );
 	if( m_Common.m_sWindow.m_nRulerBottomSpace < 0 ){
 		m_Common.m_sWindow.m_nRulerBottomSpace = 0;
@@ -408,7 +408,7 @@ int CPropWin::GetData( HWND hwndDlg )
 		m_Common.m_sWindow.m_nRulerBottomSpace = 32;
 	}
 
-	//	Sep. 18. 2002 genta s”Ô†‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ
+	//	Sep. 18. 2002 genta è¡Œç•ªå·ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“
 	m_Common.m_sWindow.m_nLineNumRightSpace = ::GetDlgItemInt( hwndDlg, IDC_EDIT_nLineNumberRightSpace, NULL, FALSE );
 	if( m_Common.m_sWindow.m_nLineNumRightSpace < 0 ){
 		m_Common.m_sWindow.m_nLineNumRightSpace = 0;
@@ -417,24 +417,24 @@ int CPropWin::GetData( HWND hwndDlg )
 		m_Common.m_sWindow.m_nLineNumRightSpace = 32;
 	}
 
-	/* …•½ƒXƒNƒ[ƒ‹ƒo[ */
+	/* æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ */
 	m_Common.m_sWindow.m_bScrollBarHorz = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_bScrollBarHorz );
 
-	/* ƒAƒCƒRƒ“•t‚«ƒƒjƒ…[ */
+	/* ã‚¢ã‚¤ã‚³ãƒ³ä»˜ããƒ¡ãƒ‹ãƒ¥ãƒ¼ */
 	m_Common.m_sWindow.m_bMenuIcon = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_bMenuIcon );
 
-	//	2001/06/20 Start by asa-o:	ƒXƒNƒ[ƒ‹‚Ì“¯Šú
+	//	2001/06/20 Start by asa-o:	ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®åŒæœŸ
 	m_Common.m_sWindow.m_bSplitterWndVScroll = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_SplitterWndVScroll );
 	m_Common.m_sWindow.m_bSplitterWndHScroll = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_SplitterWndHScroll );
 	//	2001/06/20 End
 
-	//	Apr. 05, 2003 genta ƒEƒBƒ“ƒhƒEƒLƒƒƒvƒVƒ‡ƒ“‚ÌƒJƒXƒ^ƒ}ƒCƒY
+	//	Apr. 05, 2003 genta ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚­ãƒ£ãƒ—ã‚·ãƒ§ãƒ³ã®ã‚«ã‚¹ã‚¿ãƒã‚¤ã‚º
 	::DlgItem_GetText( hwndDlg, IDC_WINCAPTION_ACTIVE, m_Common.m_sWindow.m_szWindowCaptionActive,
 		_countof( m_Common.m_sWindow.m_szWindowCaptionActive ) );
 	::DlgItem_GetText( hwndDlg, IDC_WINCAPTION_INACTIVE, m_Common.m_sWindow.m_szWindowCaptionInactive,
 		_countof( m_Common.m_sWindow.m_szWindowCaptionInactive ) );
 
-	// Œ¾Œê‘I‘ğ
+	// è¨€èªé¸æŠ
 	HWND hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_LANGUAGE );
 	int nSelPos = Combo_GetCurSel( hwndCombo );
 	CSelectLang::SSelLangInfo *psLangInfo = CSelectLang::m_psLangInfoList.at( nSelPos );
@@ -450,11 +450,11 @@ int CPropWin::GetData( HWND hwndDlg )
 
 
 //	From Here Sept. 9, 2000 JEPRO
-//	ƒ`ƒFƒbƒNó‘Ô‚É‰‚¶‚Äƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX—v‘f‚ÌEnable/Disable‚ğ
-//	“KØ‚Éİ’è‚·‚é
+//	ãƒã‚§ãƒƒã‚¯çŠ¶æ…‹ã«å¿œã˜ã¦ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹è¦ç´ ã®Enable/Disableã‚’
+//	é©åˆ‡ã«è¨­å®šã™ã‚‹
 void CPropWin::EnableWinPropInput( HWND hwndDlg )
 {
-	//	ƒtƒ@ƒNƒVƒ‡ƒ“ƒL[‚ğ•\¦‚·‚é‚©‚Ç‚¤‚©
+	//	ãƒ•ã‚¡ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ã‹ã©ã†ã‹
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DispFUNCKEYWND ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_FUNCKEYWND_GROUPNUM ), TRUE );	// IDC_GROUP_FUNCKEYWND_POSITION->IDC_EDIT_FUNCKEYWND_GROUPNUM 2008/7/4 Uchi
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_RADIO_FUNCKEYWND_PLACE1 ), TRUE );

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -1,14 +1,14 @@
-/*!	@file
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXAu‘S”Êvƒy[ƒW
+ï»¿/*!	@file
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã€ã€Œå…¨èˆ¬ã€ãƒšãƒ¼ã‚¸
 
 	@author Norio Nakatani
-	@date 1998/12/24 V‹Kì¬
+	@date 1998/12/24 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2002, Norio Nakatani
 	Copyright (C) 2000-2001, jepro
 	Copyright (C) 2001, genta, MIK, hor, Stonee, YAZAKI
-	Copyright (C) 2002, YAZAKI, aroka, MIK, Moca, ‚±‚¨‚è
+	Copyright (C) 2002, YAZAKI, aroka, MIK, Moca, ã“ãŠã‚Š
 	Copyright (C) 2003, MIK, KEITA
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, genta, ryoji
@@ -59,14 +59,14 @@ int	CPropCommon::SearchIntArr( int nKey, int* pnArr, int nArrNum )
 
 
 /*!
-	ƒvƒƒpƒeƒBƒy[ƒW‚²‚Æ‚ÌWindow Procedure‚ğˆø”‚Éæ‚é‚±‚Æ‚Å
-	ˆ—‚Ì‹¤’Ê‰»‚ğ‘_‚Á‚½D
+	ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ãƒšãƒ¼ã‚¸ã”ã¨ã®Window Procedureã‚’å¼•æ•°ã«å–ã‚‹ã“ã¨ã§
+	å‡¦ç†ã®å…±é€šåŒ–ã‚’ç‹™ã£ãŸï¼
 
-	@param DispatchPage ^‚ÌWindow Procedure‚Ìƒƒ“ƒoŠÖ”ƒ|ƒCƒ“ƒ^
-	@param hwndDlg ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚ÌWindow Handlw
-	@param uMsg ƒƒbƒZ[ƒW
-	@param wParam ƒpƒ‰ƒ[ƒ^1
-	@param lParam ƒpƒ‰ƒ[ƒ^2
+	@param DispatchPage çœŸã®Window Procedureã®ãƒ¡ãƒ³ãƒé–¢æ•°ãƒã‚¤ãƒ³ã‚¿
+	@param hwndDlg ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®Window Handlw
+	@param uMsg ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+	@param wParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿1
+	@param lParam ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿2
 */
 INT_PTR CPropCommon::DlgProc(
 	INT_PTR (CPropCommon::*DispatchPage)( HWND, UINT, WPARAM, LPARAM ),
@@ -96,7 +96,7 @@ INT_PTR CPropCommon::DlgProc(
 }
 //	To Here Jun. 2, 2001 genta
 
-// “Æ—§ƒEƒBƒ“ƒhƒE—p 2013.3.14 aroka
+// ç‹¬ç«‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç”¨ 2013.3.14 aroka
 INT_PTR CPropCommon::DlgProc2(
 	INT_PTR (CPropCommon::*DispatchPage)( HWND, UINT, WPARAM, LPARAM ),
 	HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
@@ -122,7 +122,7 @@ INT_PTR CPropCommon::DlgProc2(
 	}
 }
 
-//	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+//	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 CPropCommon::CPropCommon()
 {
 	{
@@ -146,11 +146,11 @@ CPropCommon::CPropCommon()
 		assert( sizeof(CPropPlugin)    - sizeof(CPropCommon) == 0 );
 	}
 
-	/* ‹¤—Lƒf[ƒ^\‘¢‘Ì‚ÌƒAƒhƒŒƒX‚ğ•Ô‚· */
+	/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿æ§‹é€ ä½“ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‚’è¿”ã™ */
 	m_pShareData = &GetDllShareData();
 
-	m_hwndParent = NULL;	/* ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹ */
-	m_hwndThis  = NULL;		/* ‚±‚Ìƒ_ƒCƒAƒƒO‚Ìƒnƒ“ƒhƒ‹ */
+	m_hwndParent = NULL;	/* ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ« */
+	m_hwndThis  = NULL;		/* ã“ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒãƒ³ãƒ‰ãƒ« */
 	m_nPageNum = ID_PROPCOM_PAGENUM_GENERAL;
 	m_nKeywordSet1 = -1;
 
@@ -169,19 +169,19 @@ CPropCommon::~CPropCommon()
 
 
 
-/* ‰Šú‰» */
-//@@@ 2002.01.03 YAZAKI m_tbMyButton‚È‚Ç‚ğCShareData‚©‚çCMenuDrawer‚ÖˆÚ“®‚µ‚½‚±‚Æ‚É‚æ‚éC³B
+/* åˆæœŸåŒ– */
+//@@@ 2002.01.03 YAZAKI m_tbMyButtonãªã©ã‚’CShareDataã‹ã‚‰CMenuDrawerã¸ç§»å‹•ã—ãŸã“ã¨ã«ã‚ˆã‚‹ä¿®æ­£ã€‚
 void CPropCommon::Create( HWND hwndParent, CImageListMgr* pcIcons, CMenuDrawer* pMenuDrawer )
 {
-	m_hwndParent = hwndParent;	/* ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹ */
+	m_hwndParent = hwndParent;	/* ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ« */
 	m_pcIcons = pcIcons;
 
-	// 2007.11.02 ryoji ƒ}ƒNƒİ’è‚ğ•ÏX‚µ‚½‚ ‚ÆA‰æ–Ê‚ğ•Â‚¶‚È‚¢‚ÅƒJƒXƒ^ƒ€ƒƒjƒ…[Aƒc[ƒ‹ƒo[A
-	//                  ƒL[Š„‚è“–‚Ä‚Ì‰æ–Ê‚ÉØ‚è‘Ö‚¦‚½‚ÉŠe‰æ–Ê‚Åƒ}ƒNƒİ’è‚Ì•ÏX‚ª”½‰f‚³‚ê‚é‚æ‚¤A
-	//                  m_Common.m_sMacro.m_MacroTableiƒ[ƒJƒ‹ƒƒ“ƒoj‚Åm_cLookup‚ğ‰Šú‰»‚·‚é
-	m_cLookup.Init( m_Common.m_sMacro.m_MacroTable, &m_Common );	//	‹@”\–¼E”Ô†resolveƒNƒ‰ƒXD
+	// 2007.11.02 ryoji ãƒã‚¯ãƒ­è¨­å®šã‚’å¤‰æ›´ã—ãŸã‚ã¨ã€ç”»é¢ã‚’é–‰ã˜ãªã„ã§ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã€ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã€
+	//                  ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ã®ç”»é¢ã«åˆ‡ã‚Šæ›¿ãˆãŸæ™‚ã«å„ç”»é¢ã§ãƒã‚¯ãƒ­è¨­å®šã®å¤‰æ›´ãŒåæ˜ ã•ã‚Œã‚‹ã‚ˆã†ã€
+	//                  m_Common.m_sMacro.m_MacroTableï¼ˆãƒ­ãƒ¼ã‚«ãƒ«ãƒ¡ãƒ³ãƒï¼‰ã§m_cLookupã‚’åˆæœŸåŒ–ã™ã‚‹
+	m_cLookup.Init( m_Common.m_sMacro.m_MacroTable, &m_Common );	//	æ©Ÿèƒ½åãƒ»ç•ªå·resolveã‚¯ãƒ©ã‚¹ï¼
 
-//@@@ 2002.01.03 YAZAKI m_tbMyButton‚È‚Ç‚ğCShareData‚©‚çCMenuDrawer‚ÖˆÚ“®‚µ‚½‚±‚Æ‚É‚æ‚éC³B
+//@@@ 2002.01.03 YAZAKI m_tbMyButtonãªã©ã‚’CShareDataã‹ã‚‰CMenuDrawerã¸ç§»å‹•ã—ãŸã“ã¨ã«ã‚ˆã‚‹ä¿®æ­£ã€‚
 	m_pcMenuDrawer = pMenuDrawer;
 
 	return;
@@ -194,19 +194,19 @@ void CPropCommon::Create( HWND hwndParent, CImageListMgr* pcIcons, CMenuDrawer* 
 
 //	From Here Jun. 2, 2001 genta
 /*!
-	u‹¤’Êİ’èvƒvƒƒpƒeƒBƒV[ƒg‚Ìì¬‚É•K—v‚Èî•ñ‚ğ
-	•Û‚·‚é\‘¢‘Ì
+	ã€Œå…±é€šè¨­å®šã€ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆã®ä½œæˆæ™‚ã«å¿…è¦ãªæƒ…å ±ã‚’
+	ä¿æŒã™ã‚‹æ§‹é€ ä½“
 */
 struct ComPropSheetInfo {
-	int m_nTabNameId;										//!< TAB‚Ì•\¦–¼
-	unsigned int resId;										//!< Property sheet‚É‘Î‰‚·‚éDialog resource
+	int m_nTabNameId;										//!< TABã®è¡¨ç¤ºå
+	unsigned int resId;										//!< Property sheetã«å¯¾å¿œã™ã‚‹Dialog resource
 	INT_PTR (CALLBACK *DProc)(HWND, UINT, WPARAM, LPARAM);	//!< Dialog Procedure
 };
 //	To Here Jun. 2, 2001 genta
 
-//	ƒL[ƒ[ƒhF‹¤’Êİ’èƒ^ƒu‡˜(ƒvƒƒpƒeƒBƒV[ƒg)
-/*! ƒvƒƒpƒeƒBƒV[ƒg‚Ìì¬
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+//	ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ï¼šå…±é€šè¨­å®šã‚¿ãƒ–é †åº(ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆ)
+/*! ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆã®ä½œæˆ
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 */
 INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 {
@@ -216,23 +216,23 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 	m_bTrayProc = bTrayProc;
 
 	//	From Here Jun. 2, 2001 genta
-	//	Feb. 11, 2007 genta URL‚ğTAB‚Æ“ü‚êŠ·‚¦	// 2007.02.13 ‡˜•ÏXiTAB‚ğWIN‚ÌŸ‚Éj
-	//!	u‹¤’Êİ’èvƒvƒƒpƒeƒBƒV[ƒg‚Ìì¬‚É•K—v‚Èî•ñ‚Ì”z—ñD
-	//	‡˜•ÏX Win,Toolbar,Tab,Statusbar‚Ì‡‚ÉAFile,FileName ‡‚É	2008/6/22 Uchi 
-	//	DProc‚Ì•ÏX	2010/5/9 Uchi
+	//	Feb. 11, 2007 genta URLã‚’TABã¨å…¥ã‚Œæ›ãˆ	// 2007.02.13 é †åºå¤‰æ›´ï¼ˆTABã‚’WINã®æ¬¡ã«ï¼‰
+	//!	ã€Œå…±é€šè¨­å®šã€ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆã®ä½œæˆæ™‚ã«å¿…è¦ãªæƒ…å ±ã®é…åˆ—ï¼
+	//	é †åºå¤‰æ›´ Win,Toolbar,Tab,Statusbarã®é †ã«ã€File,FileName é †ã«	2008/6/22 Uchi 
+	//	DProcã®å¤‰æ›´	2010/5/9 Uchi
 	static const ComPropSheetInfo ComPropSheetInfoList[] = {
 		{ STR_PROPCOMMON_GENERAL,	IDD_PROP_GENERAL,	CPropGeneral::DlgProc_page },
 		{ STR_PROPCOMMON_WINDOW,	IDD_PROP_WIN,		CPropWin::DlgProc_page },
 		{ STR_PROPCOMMON_MAINMENU,	IDD_PROP_MAINMENU,	CPropMainMenu::DlgProc_page },	// 2010/5/8 Uchi
 		{ STR_PROPCOMMON_TOOLBAR,	IDD_PROP_TOOLBAR,	CPropToolbar::DlgProc_page },
 		{ STR_PROPCOMMON_TABS,		IDD_PROP_TAB,		CPropTab::DlgProc_page },
-		{ STR_PROPCOMMON_STATBAR,	IDD_PROP_STATUSBAR,	CPropStatusbar::DlgProc_page },	// •¶šƒR[ƒh•\¦w’è	2008/6/21	Uchi
+		{ STR_PROPCOMMON_STATBAR,	IDD_PROP_STATUSBAR,	CPropStatusbar::DlgProc_page },	// æ–‡å­—ã‚³ãƒ¼ãƒ‰è¡¨ç¤ºæŒ‡å®š	2008/6/21	Uchi
 		{ STR_PROPCOMMON_EDITING,	IDD_PROP_EDIT,		CPropEdit::DlgProc_page },
 		{ STR_PROPCOMMON_FILE,		IDD_PROP_FILE,		CPropFile::DlgProc_page },
 		{ STR_PROPCOMMON_FILENAME,	IDD_PROP_FNAME,		CPropFileName::DlgProc_page },
 		{ STR_PROPCOMMON_BACKUP,	IDD_PROP_BACKUP,	CPropBackup::DlgProc_page },
 		{ STR_PROPCOMMON_FORMAT,	IDD_PROP_FORMAT,	CPropFormat::DlgProc_page },
-		{ STR_PROPCOMMON_SEARCH,	IDD_PROP_GREP,		CPropGrep::DlgProc_page },	// 2006.08.23 ryoji ƒ^ƒCƒgƒ‹•ÏXiGrep -> ŒŸõj
+		{ STR_PROPCOMMON_SEARCH,	IDD_PROP_GREP,		CPropGrep::DlgProc_page },	// 2006.08.23 ryoji ã‚¿ã‚¤ãƒˆãƒ«å¤‰æ›´ï¼ˆGrep -> æ¤œç´¢ï¼‰
 		{ STR_PROPCOMMON_KEYS,		IDD_PROP_KEYBIND,	CPropKeybind::DlgProc_page },
 		{ STR_PROPCOMMON_CUSTMENU,	IDD_PROP_CUSTMENU,	CPropCustmenu::DlgProc_page },
 		{ STR_PROPCOMMON_KEYWORD,	IDD_PROP_KEYWORD,	CPropKeyword::DlgProc_page },
@@ -263,19 +263,19 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 	PROPSHEETHEADER		psh;
 	memset_raw( &psh, 0, sizeof_raw( psh ) );
 	
-	//	Jun. 29, 2002 ‚±‚¨‚è
-	//	Windows 95‘ÎôDProperty Sheet‚ÌƒTƒCƒY‚ğWindows95‚ª”F¯‚Å‚«‚é•¨‚ÉŒÅ’è‚·‚éD
+	//	Jun. 29, 2002 ã“ãŠã‚Š
+	//	Windows 95å¯¾ç­–ï¼Property Sheetã®ã‚µã‚¤ã‚ºã‚’Windows95ãŒèªè­˜ã§ãã‚‹ç‰©ã«å›ºå®šã™ã‚‹ï¼
 	psh.dwSize = sizeof_old_PROPSHEETHEADER;
 
-	//	JEPROtest Sept. 30, 2000 ‹¤’Êİ’è‚Ì‰B‚ê[“K—p]ƒ{ƒ^ƒ“‚Ì³‘Ì‚Í‚±‚±Bs“ª‚ÌƒRƒƒ“ƒgƒAƒEƒg‚ğ“ü‚ê‘Ö‚¦‚Ä‚İ‚ê‚Î‚í‚©‚é
+	//	JEPROtest Sept. 30, 2000 å…±é€šè¨­å®šã®éš ã‚Œ[é©ç”¨]ãƒœã‚¿ãƒ³ã®æ­£ä½“ã¯ã“ã“ã€‚è¡Œé ­ã®ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã‚’å…¥ã‚Œæ›¿ãˆã¦ã¿ã‚Œã°ã‚ã‹ã‚‹
 	psh.dwFlags    = PSH_NOAPPLYNOW | PSH_PROPSHEETPAGE | PSH_USEPAGELANG;
 	psh.hwndParent = m_hwndParent;
 	psh.hInstance  = CSelectLang::getLangRsrcInstance();
 	psh.pszIcon    = NULL;
-	psh.pszCaption = LS( STR_PROPCOMMON );	//_T("‹¤’Êİ’è");
+	psh.pszCaption = LS( STR_PROPCOMMON );	//_T("å…±é€šè¨­å®š");
 	psh.nPages     = nIdx;
 
-	//- 20020106 aroka # psh.nStartPage ‚Í unsigned ‚È‚Ì‚Å•‰‚É‚È‚ç‚È‚¢
+	//- 20020106 aroka # psh.nStartPage ã¯ unsigned ãªã®ã§è² ã«ãªã‚‰ãªã„
 	if( -1 == nPageNum ){
 		psh.nStartPage = m_nPageNum;
 	}else
@@ -291,7 +291,7 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 	psh.ppsp = psp;
 	psh.pfnCallback = NULL;
 
-	nRet = MyPropertySheet( &psh );	// 2007.05.24 ryoji “Æ©Šg’£ƒvƒƒpƒeƒBƒV[ƒg
+	nRet = MyPropertySheet( &psh );	// 2007.05.24 ryoji ç‹¬è‡ªæ‹¡å¼µãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆ
 	if( -1 == nRet ){
 		TCHAR*	pszMsgBuf;
 		::FormatMessage(
@@ -300,7 +300,7 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 			FORMAT_MESSAGE_IGNORE_INSERTS,
 			NULL,
 			::GetLastError(),
-			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// ƒfƒtƒHƒ‹ƒgŒ¾Œê
+			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè¨€èª
 			(LPTSTR)&pszMsgBuf,
 			0,
 			NULL
@@ -317,12 +317,12 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 	return nRet;
 }
 
-/*!	ShareData‚©‚çˆê—Ìˆæ‚Öİ’è‚ğƒRƒs[‚·‚é
-	@param[in] tempTypeKeywordSet ƒL[ƒ[ƒhƒZƒbƒg
-	@param[in] name	ƒ^ƒCƒv‘®«F–¼Ì
-	@param[in] exts	ƒ^ƒCƒv‘®«FŠg’£qƒŠƒXƒg
+/*!	ShareDataã‹ã‚‰ä¸€æ™‚é ˜åŸŸã¸è¨­å®šã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹
+	@param[in] tempTypeKeywordSet ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
+	@param[in] name	ã‚¿ã‚¤ãƒ—å±æ€§ï¼šåç§°
+	@param[in] exts	ã‚¿ã‚¤ãƒ—å±æ€§ï¼šæ‹¡å¼µå­ãƒªã‚¹ãƒˆ
 
-	@date 2002.12.11 Moca CEditDoc::OpenPropertySheet‚©‚çˆÚ“®
+	@date 2002.12.11 Moca CEditDoc::OpenPropertySheetã‹ã‚‰ç§»å‹•
 */
 void CPropCommon::InitData( const int* tempTypeKeywordSet, const TCHAR* name, const TCHAR* exts )
 {
@@ -330,7 +330,7 @@ void CPropCommon::InitData( const int* tempTypeKeywordSet, const TCHAR* name, co
 	m_tempTypeName[0] = _T('\0');
 	m_tempTypeExts[0] = _T('\0');
 
-	//2002/04/25 YAZAKI STypeConfig‘S‘Ì‚ğ•Û‚·‚é•K—v‚Í‚È‚¢B
+	//2002/04/25 YAZAKI STypeConfigå…¨ä½“ã‚’ä¿æŒã™ã‚‹å¿…è¦ã¯ãªã„ã€‚
 	if( tempTypeKeywordSet ){
 		m_nKeywordSet1 = tempTypeKeywordSet[0];
 		auto_strcpy(m_tempTypeName, name);
@@ -355,10 +355,10 @@ void CPropCommon::InitData( const int* tempTypeKeywordSet, const TCHAR* name, co
 	}
 }
 
-/*!	ShareData ‚É İ’è‚ğ“K—pEƒRƒs[‚·‚é
-	@param[out] tempTypeKeywordSet ƒL[ƒ[ƒhƒZƒbƒg
-	@note ShareData‚ÉƒRƒs[‚·‚é‚¾‚¯‚È‚Ì‚ÅCXV—v‹‚È‚Ç‚ÍC—˜—p‚·‚é‘¤‚Åˆ—‚µ‚Ä‚à‚ç‚¤
-	@date 2002.12.11 Moca CEditDoc::OpenPropertySheet‚©‚çˆÚ“®
+/*!	ShareData ã« è¨­å®šã‚’é©ç”¨ãƒ»ã‚³ãƒ”ãƒ¼ã™ã‚‹
+	@param[out] tempTypeKeywordSet ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
+	@note ShareDataã«ã‚³ãƒ”ãƒ¼ã™ã‚‹ã ã‘ãªã®ã§ï¼Œæ›´æ–°è¦æ±‚ãªã©ã¯ï¼Œåˆ©ç”¨ã™ã‚‹å´ã§å‡¦ç†ã—ã¦ã‚‚ã‚‰ã†
+	@date 2002.12.11 Moca CEditDoc::OpenPropertySheetã‹ã‚‰ç§»å‹•
 */
 void CPropCommon::ApplyData( int* tempTypeKeywordSet )
 {
@@ -378,8 +378,8 @@ void CPropCommon::ApplyData( int* tempTypeKeywordSet )
 		if( configIdx.IsValidType() ){
 			STypeConfig type;
 			CDocTypeManager().GetTypeConfig(configIdx, type);
-			//2002/04/25 YAZAKI STypeConfig‘S‘Ì‚ğ•Û‚·‚é•K—v‚Í‚È‚¢B
-			/* •ÏX‚³‚ê‚½İ’è’l‚ÌƒRƒs[ */
+			//2002/04/25 YAZAKI STypeConfigå…¨ä½“ã‚’ä¿æŒã™ã‚‹å¿…è¦ã¯ãªã„ã€‚
+			/* å¤‰æ›´ã•ã‚ŒãŸè¨­å®šå€¤ã®ã‚³ãƒ”ãƒ¼ */
 			for( int j = 0; j < MAX_KEYWORDSET_PER_TYPE; j++ ){
 				type.m_nKeyWordSetIdx[j] = m_Types_nKeyWordSetIdx[i].index[j];
 			}
@@ -390,8 +390,8 @@ void CPropCommon::ApplyData( int* tempTypeKeywordSet )
 
 
 
-/* ƒwƒ‹ƒv */
-//Stonee, 2001/05/18 ‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
+/* ãƒ˜ãƒ«ãƒ— */
+//Stonee, 2001/05/18 æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
 void CPropCommon::OnHelp( HWND hwndParent, int nPageID )
 {
 	int		nContextID;
@@ -405,8 +405,8 @@ void CPropCommon::OnHelp( HWND hwndParent, int nPageID )
 	case IDD_PROP_FILE:
 		nContextID = ::FuncID_To_HelpContextID(F_OPTION_FILE);
 		break;
-//	Sept. 10, 2000 JEPRO ID–¼‚ğÀÛ‚Ì–¼‘O‚É•ÏX‚·‚é‚½‚ßˆÈ‰º‚Ìs‚ÍƒRƒƒ“ƒgƒAƒEƒg
-//	•ÏX‚Í­‚µŒã‚Ìs(Sept. 9, 2000)‚Ås‚Á‚Ä‚¢‚é
+//	Sept. 10, 2000 JEPRO IDåã‚’å®Ÿéš›ã®åå‰ã«å¤‰æ›´ã™ã‚‹ãŸã‚ä»¥ä¸‹ã®è¡Œã¯ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆ
+//	å¤‰æ›´ã¯å°‘ã—å¾Œã®è¡Œ(Sept. 9, 2000)ã§è¡Œã£ã¦ã„ã‚‹
 //	case IDD_PROP1P5:
 //		nContextID = 84;
 //		break;
@@ -423,7 +423,7 @@ void CPropCommon::OnHelp( HWND hwndParent, int nPageID )
 		nContextID = ::FuncID_To_HelpContextID(F_OPTION_HELPER);
 		break;
 
-	// From Here Sept. 9, 2000 JEPRO ‹¤’Êİ’è‚Ìƒwƒ‹ƒvƒ{ƒ^ƒ“‚ªŒø‚©‚È‚­‚È‚Á‚Ä‚¢‚½•”•ª‚ğˆÈ‰º‚Ì’Ç‰Á‚É‚æ‚Á‚ÄC³
+	// From Here Sept. 9, 2000 JEPRO å…±é€šè¨­å®šã®ãƒ˜ãƒ«ãƒ—ãƒœã‚¿ãƒ³ãŒåŠ¹ã‹ãªããªã£ã¦ã„ãŸéƒ¨åˆ†ã‚’ä»¥ä¸‹ã®è¿½åŠ ã«ã‚ˆã£ã¦ä¿®æ­£
 	case IDD_PROP_EDIT:
 		nContextID = ::FuncID_To_HelpContextID(F_OPTION_EDIT);
 		break;
@@ -449,7 +449,7 @@ void CPropCommon::OnHelp( HWND hwndParent, int nPageID )
 	case IDD_PROP_MACRO:	//@@@ 2002.01.02
 		nContextID = ::FuncID_To_HelpContextID(F_OPTION_MACRO);
 		break;
-	case IDD_PROP_FNAME:	// 2002.12.09 Moca FNAME’Ç‰Á
+	case IDD_PROP_FNAME:	// 2002.12.09 Moca FNAMEè¿½åŠ 
 		nContextID = ::FuncID_To_HelpContextID(F_OPTION_FNAME);
 		break;
 	case IDD_PROP_PLUGIN:	//@@@ 2002.01.02
@@ -464,14 +464,14 @@ void CPropCommon::OnHelp( HWND hwndParent, int nPageID )
 		break;
 	}
 	if( -1 != nContextID ){
-		MyWinHelp( hwndParent, HELP_CONTEXT, nContextID );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndParent, HELP_CONTEXT, nContextID );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 	}
 	return;
 }
 
 
 
-/*!	ƒRƒ“ƒgƒ[ƒ‹‚ÉƒtƒHƒ“ƒgİ’è‚·‚é
+/*!	ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«ãƒ•ã‚©ãƒ³ãƒˆè¨­å®šã™ã‚‹
 	@date 2013.04.24 Uchi
 */
 HFONT CPropCommon::SetCtrlFont( HWND hwndDlg, int idc_ctrl, const LOGFONT& lf )
@@ -479,11 +479,11 @@ HFONT CPropCommon::SetCtrlFont( HWND hwndDlg, int idc_ctrl, const LOGFONT& lf )
 	HFONT	hFont;
 	HWND	hCtrl;
 
-	// ˜_—ƒtƒHƒ“ƒg‚ğì¬
+	// è«–ç†ãƒ•ã‚©ãƒ³ãƒˆã‚’ä½œæˆ
 	hCtrl = ::GetDlgItem( hwndDlg, idc_ctrl );
 	hFont = ::CreateFontIndirect( &lf );
 	if (hFont) {
-		// ƒtƒHƒ“ƒg‚Ìİ’è
+		// ãƒ•ã‚©ãƒ³ãƒˆã®è¨­å®š
 		::SendMessage( hCtrl, WM_SETFONT, (WPARAM)hFont, MAKELPARAM(FALSE, 0) );
 	}
 
@@ -492,7 +492,7 @@ HFONT CPropCommon::SetCtrlFont( HWND hwndDlg, int idc_ctrl, const LOGFONT& lf )
 
 
 
-/*!	ƒtƒHƒ“ƒgƒ‰ƒxƒ‹‚ÉƒtƒHƒ“ƒg‚ÆƒtƒHƒ“ƒg–¼İ’è‚·‚é
+/*!	ãƒ•ã‚©ãƒ³ãƒˆãƒ©ãƒ™ãƒ«ã«ãƒ•ã‚©ãƒ³ãƒˆã¨ãƒ•ã‚©ãƒ³ãƒˆåè¨­å®šã™ã‚‹
 	@date 2013.04.24 Uchi
 */
 HFONT CPropCommon::SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf, int nps )
@@ -501,14 +501,14 @@ HFONT CPropCommon::SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf
 	TCHAR	szFontName[80];
 	LOGFONT lfTemp;
 	lfTemp = lf;
-	// ‘å‚«‚·‚¬‚éƒtƒHƒ“ƒg‚Í¬‚³‚­•\¦
+	// å¤§ãã™ãã‚‹ãƒ•ã‚©ãƒ³ãƒˆã¯å°ã•ãè¡¨ç¤º
 	if( lfTemp.lfHeight < -16 ){
 		lfTemp.lfHeight = -16;
 	}
 
 	hFont = SetCtrlFont( hwndDlg, idc_static, lfTemp );
 
-	// ƒtƒHƒ“ƒg–¼‚Ìİ’è
+	// ãƒ•ã‚©ãƒ³ãƒˆåã®è¨­å®š
 	auto_sprintf( szFontName, nps % 10 ? _T("%s(%.1fpt)") : _T("%s(%.0fpt)"),
 		lf.lfFaceName, double(nps)/10 );
 	::DlgItem_SetText( hwndDlg, idc_static, szFontName );

--- a/sakura_core/prop/CPropCommon.h
+++ b/sakura_core/prop/CPropCommon.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚Ìˆ—
+ï»¿/*!	@file
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®å‡¦ç†
 
 	@author	Norio Nakatani
-	@date 1998/12/24 V‹Kì¬
+	@date 1998/12/24 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -47,41 +47,41 @@ class CImageListMgr;
 class CSMacroMgr;
 class CMenuDrawer;// 2002/2/10 aroka to here
 
-/*! ƒvƒƒpƒeƒBƒV[ƒg”Ô†
-	@date 2008.6.22 Uchi #define -> enum ‚É•ÏX	
-	@date 2008.6.22 Uchi‡˜•ÏX Win,Toolbar,Tab,Statusbar‚Ì‡‚ÉAFile,FileName ‡‚É
+/*! ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆç•ªå·
+	@date 2008.6.22 Uchi #define -> enum ã«å¤‰æ›´	
+	@date 2008.6.22 Uchié †åºå¤‰æ›´ Win,Toolbar,Tab,Statusbarã®é †ã«ã€File,FileName é †ã«
 */
 enum PropComSheetOrder {
-	ID_PROPCOM_PAGENUM_GENERAL = 0,		//!< ‘S”Ê
-	ID_PROPCOM_PAGENUM_WIN,				//!< ƒEƒBƒ“ƒhƒE
-	ID_PROPCOM_PAGENUM_MAINMENU,		//!< ƒƒCƒ“ƒƒjƒ…[
-	ID_PROPCOM_PAGENUM_TOOLBAR,			//!< ƒc[ƒ‹ƒo[
-	ID_PROPCOM_PAGENUM_TAB,				//!< ƒ^ƒuƒo[
-	ID_PROPCOM_PAGENUM_STATUSBAR,		//!< ƒXƒe[ƒ^ƒXƒo[
-	ID_PROPCOM_PAGENUM_EDIT,			//!< •ÒW
-	ID_PROPCOM_PAGENUM_FILE,			//!< ƒtƒ@ƒCƒ‹
-	ID_PROPCOM_PAGENUM_FILENAME,		//!< ƒtƒ@ƒCƒ‹–¼•\¦
-	ID_PROPCOM_PAGENUM_BACKUP,			//!< ƒoƒbƒNƒAƒbƒv
-	ID_PROPCOM_PAGENUM_FORMAT,			//!< ‘®
-	ID_PROPCOM_PAGENUM_GREP,			//!< ŒŸõ
-	ID_PROPCOM_PAGENUM_KEYBOARD,		//!< ƒL[Š„‚è“–‚Ä
-	ID_PROPCOM_PAGENUM_CUSTMENU,		//!< ƒJƒXƒ^ƒ€ƒƒjƒ…[
-	ID_PROPCOM_PAGENUM_KEYWORD,			//!< ‹­’²ƒL[ƒ[ƒh
-	ID_PROPCOM_PAGENUM_HELPER,			//!< x‰‡
-	ID_PROPCOM_PAGENUM_MACRO,			//!< ƒ}ƒNƒ
-	ID_PROPCOM_PAGENUM_PLUGIN,			//!< ƒvƒ‰ƒOƒCƒ“
+	ID_PROPCOM_PAGENUM_GENERAL = 0,		//!< å…¨èˆ¬
+	ID_PROPCOM_PAGENUM_WIN,				//!< ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	ID_PROPCOM_PAGENUM_MAINMENU,		//!< ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼
+	ID_PROPCOM_PAGENUM_TOOLBAR,			//!< ãƒ„ãƒ¼ãƒ«ãƒãƒ¼
+	ID_PROPCOM_PAGENUM_TAB,				//!< ã‚¿ãƒ–ãƒãƒ¼
+	ID_PROPCOM_PAGENUM_STATUSBAR,		//!< ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼
+	ID_PROPCOM_PAGENUM_EDIT,			//!< ç·¨é›†
+	ID_PROPCOM_PAGENUM_FILE,			//!< ãƒ•ã‚¡ã‚¤ãƒ«
+	ID_PROPCOM_PAGENUM_FILENAME,		//!< ãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤º
+	ID_PROPCOM_PAGENUM_BACKUP,			//!< ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—
+	ID_PROPCOM_PAGENUM_FORMAT,			//!< æ›¸å¼
+	ID_PROPCOM_PAGENUM_GREP,			//!< æ¤œç´¢
+	ID_PROPCOM_PAGENUM_KEYBOARD,		//!< ã‚­ãƒ¼å‰²ã‚Šå½“ã¦
+	ID_PROPCOM_PAGENUM_CUSTMENU,		//!< ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼
+	ID_PROPCOM_PAGENUM_KEYWORD,			//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+	ID_PROPCOM_PAGENUM_HELPER,			//!< æ”¯æ´
+	ID_PROPCOM_PAGENUM_MACRO,			//!< ãƒã‚¯ãƒ­
+	ID_PROPCOM_PAGENUM_PLUGIN,			//!< ãƒ—ãƒ©ã‚°ã‚¤ãƒ³
 	ID_PROPCOM_PAGENUM_MAX,
 };
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 /*!
-	@brief ‹¤’Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒXƒNƒ‰ƒX
+	@brief å…±é€šè¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã‚¯ãƒ©ã‚¹
 
-	1‚Â‚Ìƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚É•¡”‚ÌƒvƒƒpƒeƒBƒy[ƒW‚ª“ü‚Á‚½\‘¢‚É
-	‚È‚Á‚Ä‚¨‚èADialog procedure‚ÆEvent Dispatcher‚ªƒy[ƒW‚²‚Æ‚É‚ ‚éD
+	1ã¤ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã«è¤‡æ•°ã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ãƒšãƒ¼ã‚¸ãŒå…¥ã£ãŸæ§‹é€ ã«
+	ãªã£ã¦ãŠã‚Šã€Dialog procedureã¨Event DispatcherãŒãƒšãƒ¼ã‚¸ã”ã¨ã«ã‚ã‚‹ï¼
 
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 */
 class CPropCommon
 {
@@ -91,18 +91,18 @@ public:
 	*/
 	CPropCommon();
 	~CPropCommon();
-	//	Sep. 29, 2001 genta ƒ}ƒNƒƒNƒ‰ƒX‚ğ“n‚·‚æ‚¤‚É;
-//@@@ 2002.01.03 YAZAKI m_tbMyButton‚È‚Ç‚ğCShareData‚©‚çCMenuDrawer‚ÖˆÚ“®‚µ‚½‚±‚Æ‚É‚æ‚éC³B
-	void Create( HWND, CImageListMgr*, CMenuDrawer* );	/* ‰Šú‰» */
+	//	Sep. 29, 2001 genta ãƒã‚¯ãƒ­ã‚¯ãƒ©ã‚¹ã‚’æ¸¡ã™ã‚ˆã†ã«;
+//@@@ 2002.01.03 YAZAKI m_tbMyButtonãªã©ã‚’CShareDataã‹ã‚‰CMenuDrawerã¸ç§»å‹•ã—ãŸã“ã¨ã«ã‚ˆã‚‹ä¿®æ­£ã€‚
+	void Create( HWND, CImageListMgr*, CMenuDrawer* );	/* åˆæœŸåŒ– */
 
 	/*
 	||  Attributes & Operations
 	*/
-	INT_PTR DoPropertySheet( int, bool );	/* ƒvƒƒpƒeƒBƒV[ƒg‚Ìì¬ */
+	INT_PTR DoPropertySheet( int, bool );	/* ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆã®ä½œæˆ */
 
-	// 2002.12.11 Moca ’Ç‰Á
-	void InitData( const int* = NULL, const TCHAR* = NULL, const TCHAR* = NULL );	//!< DLLSHAREDATA‚©‚çˆêƒf[ƒ^—Ìˆæ‚Éİ’è‚ğ•¡»‚·‚é
-	void ApplyData( int* = NULL );	//!< ˆêƒf[ƒ^—Ìˆæ‚©‚ç‚ÉDLLSHAREDATAİ’è‚ğƒRƒs[‚·‚é
+	// 2002.12.11 Moca è¿½åŠ 
+	void InitData( const int* = NULL, const TCHAR* = NULL, const TCHAR* = NULL );	//!< DLLSHAREDATAã‹ã‚‰ä¸€æ™‚ãƒ‡ãƒ¼ã‚¿é ˜åŸŸã«è¨­å®šã‚’è¤‡è£½ã™ã‚‹
+	void ApplyData( int* = NULL );	//!< ä¸€æ™‚ãƒ‡ãƒ¼ã‚¿é ˜åŸŸã‹ã‚‰ã«DLLSHAREDATAè¨­å®šã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹
 	int GetPageNum(){ return m_nPageNum; }
 
 	//
@@ -110,88 +110,88 @@ public:
 		HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam );
 
 	//	Jun. 2, 2001 genta
-	//	‚±‚±‚É‚ ‚Á‚½Event Handler‚ÍprotectedƒGƒŠƒA‚ÉˆÚ“®‚µ‚½D
+	//	ã“ã“ã«ã‚ã£ãŸEvent Handlerã¯protectedã‚¨ãƒªã‚¢ã«ç§»å‹•ã—ãŸï¼
 
-	HWND				m_hwndParent;	/* ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹ */
-	HWND				m_hwndThis;		/* ‚±‚Ìƒ_ƒCƒAƒƒO‚Ìƒnƒ“ƒhƒ‹ */
+	HWND				m_hwndParent;	/* ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ« */
+	HWND				m_hwndThis;		/* ã“ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒãƒ³ãƒ‰ãƒ« */
 	PropComSheetOrder	m_nPageNum;
 	DLLSHAREDATA*		m_pShareData;
 	int					m_nKeywordSet1;
 	//	Oct. 16, 2000 genta
 	CImageListMgr*	m_pcIcons;	//	Image List
 	
-	//	Oct. 2, 2001 genta ŠO•”ƒ}ƒNƒ’Ç‰Á‚É”º‚¤C‘Î‰•”•ª‚Ì•ÊƒNƒ‰ƒX‰»
-	//	Oct. 15, 2001 genta Lookup‚Íƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX“à‚Å•ÊƒCƒ“ƒXƒ^ƒ“ƒX‚ğì‚é‚æ‚¤‚É
-	//	(ŒŸõ‘ÎÛ‚Æ‚µ‚ÄCİ’è—pcommon—Ìˆæ‚ğw‚·‚æ‚¤‚É‚·‚é‚½‚ßD)
+	//	Oct. 2, 2001 genta å¤–éƒ¨ãƒã‚¯ãƒ­è¿½åŠ ã«ä¼´ã†ï¼Œå¯¾å¿œéƒ¨åˆ†ã®åˆ¥ã‚¯ãƒ©ã‚¹åŒ–
+	//	Oct. 15, 2001 genta Lookupã¯ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹å†…ã§åˆ¥ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã‚’ä½œã‚‹ã‚ˆã†ã«
+	//	(æ¤œç´¢å¯¾è±¡ã¨ã—ã¦ï¼Œè¨­å®šç”¨commoné ˜åŸŸã‚’æŒ‡ã™ã‚ˆã†ã«ã™ã‚‹ãŸã‚ï¼)
 	CFuncLookup			m_cLookup;
 
 	CMenuDrawer*		m_pcMenuDrawer;
 	/*
-	|| ƒ_ƒCƒAƒƒOƒf[ƒ^
+	|| ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿
 	*/
 	CommonSetting	m_Common;
 
-	// 2005.01.13 MIK ƒZƒbƒg”‘‰Á
+	// 2005.01.13 MIK ã‚»ãƒƒãƒˆæ•°å¢—åŠ 
 	struct SKeywordSetIndex{
 		int typeId;
 		int index[MAX_KEYWORDSET_PER_TYPE];
 	};
 	std::vector<SKeywordSetIndex>	m_Types_nKeyWordSetIdx;
-	TCHAR			m_tempTypeName[MAX_TYPES_NAME];	//!< ƒ^ƒCƒv‘®«F–¼Ì
-	TCHAR			m_tempTypeExts[MAX_TYPES_EXTS];	//!< ƒ^ƒCƒv‘®«FŠg’£qƒŠƒXƒg
+	TCHAR			m_tempTypeName[MAX_TYPES_NAME];	//!< ã‚¿ã‚¤ãƒ—å±æ€§ï¼šåç§°
+	TCHAR			m_tempTypeExts[MAX_TYPES_EXTS];	//!< ã‚¿ã‚¤ãƒ—å±æ€§ï¼šæ‹¡å¼µå­ãƒªã‚¹ãƒˆ
 	bool			m_bTrayProc;
-	HFONT			m_hKeywordHelpFont;		//!< ƒL[ƒ[ƒhƒwƒ‹ƒv ƒtƒHƒ“ƒg ƒnƒ“ƒhƒ‹
-	HFONT			m_hTabFont;				//!< ƒ^ƒu ƒtƒHƒ“ƒg ƒnƒ“ƒhƒ‹
+	HFONT			m_hKeywordHelpFont;		//!< ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ— ãƒ•ã‚©ãƒ³ãƒˆ ãƒãƒ³ãƒ‰ãƒ«
+	HFONT			m_hTabFont;				//!< ã‚¿ãƒ– ãƒ•ã‚©ãƒ³ãƒˆ ãƒãƒ³ãƒ‰ãƒ«
 
 protected:
 	/*
-	||  À‘•ƒwƒ‹ƒpŠÖ”
+	||  å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	*/
-	void OnHelp( HWND, int );	/* ƒwƒ‹ƒv */
+	void OnHelp( HWND, int );	/* ãƒ˜ãƒ«ãƒ— */
 	int	SearchIntArr( int , int* , int );
-//	void DrawToolBarItemList( DRAWITEMSTRUCT* );	/* ƒc[ƒ‹ƒo[ƒ{ƒ^ƒ“ƒŠƒXƒg‚ÌƒAƒCƒeƒ€•`‰æ */
-//	void DrawColorButton( DRAWITEMSTRUCT* , COLORREF );	/* Fƒ{ƒ^ƒ“‚Ì•`‰æ */ // 2002.11.09 Moca –¢g—p
-//	BOOL SelectColor( HWND , COLORREF* );	/* F‘I‘ğƒ_ƒCƒAƒƒO */
+//	void DrawToolBarItemList( DRAWITEMSTRUCT* );	/* ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ãƒœã‚¿ãƒ³ãƒªã‚¹ãƒˆã®ã‚¢ã‚¤ãƒ†ãƒ æç”» */
+//	void DrawColorButton( DRAWITEMSTRUCT* , COLORREF );	/* è‰²ãƒœã‚¿ãƒ³ã®æç”» */ // 2002.11.09 Moca æœªä½¿ç”¨
+//	BOOL SelectColor( HWND , COLORREF* );	/* è‰²é¸æŠãƒ€ã‚¤ã‚¢ãƒ­ã‚° */
 
 	//	Jun. 2, 2001 genta
-	//	Event Handler, Dialog Procedure‚ÌŒ©’¼‚µ
-	//	GlobalŠÖ”‚¾‚Á‚½Dialog procedure‚ğclass‚Ìstatic method‚Æ‚µ‚Ä
-	//	‘g‚İ‚ñ‚¾D
-	//	‚±‚±‚©‚çˆÈ‰º Macro‚Ü‚Å”z’u‚ÌŒ©’¼‚µ‚Æstatic method‚Ì’Ç‰Á
+	//	Event Handler, Dialog Procedureã®è¦‹ç›´ã—
+	//	Globalé–¢æ•°ã ã£ãŸDialog procedureã‚’classã®static methodã¨ã—ã¦
+	//	çµ„ã¿è¾¼ã‚“ã ï¼
+	//	ã“ã“ã‹ã‚‰ä»¥ä¸‹ Macroã¾ã§é…ç½®ã®è¦‹ç›´ã—ã¨static methodã®è¿½åŠ 
 
-	//! ”Ä—pƒ_ƒCƒAƒƒOƒvƒƒV[ƒWƒƒ
+	//! æ±ç”¨ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£
 	static INT_PTR DlgProc(
 		INT_PTR (CPropCommon::*DispatchPage)( HWND, UINT, WPARAM, LPARAM ),
 		HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam );
-	static INT_PTR DlgProc2( //“Æ—§ƒEƒBƒ“ƒhƒE—p
+	static INT_PTR DlgProc2( //ç‹¬ç«‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç”¨
 		INT_PTR (CPropCommon::*DispatchPage)( HWND, UINT, WPARAM, LPARAM ),
 		HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam );
 	typedef	INT_PTR (CPropCommon::*pDispatchPage)( HWND, UINT, WPARAM, LPARAM );
 
-	int nLastPos_Macro; //!< ‘O‰ñƒtƒH[ƒJƒX‚Ì‚ ‚Á‚½êŠ
-	int m_nLastPos_FILENAME; //!< ‘O‰ñƒtƒH[ƒJƒX‚Ì‚ ‚Á‚½êŠ ƒtƒ@ƒCƒ‹–¼ƒ^ƒu—p
+	int nLastPos_Macro; //!< å‰å›ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã®ã‚ã£ãŸå ´æ‰€
+	int m_nLastPos_FILENAME; //!< å‰å›ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã®ã‚ã£ãŸå ´æ‰€ ãƒ•ã‚¡ã‚¤ãƒ«åã‚¿ãƒ–ç”¨
 
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
-	void Import( HWND );	//!< ƒCƒ“ƒ|[ƒg‚·‚é
-	void Export( HWND );	//!< ƒGƒNƒXƒ|[ƒg‚·‚é
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
+	void Import( HWND );	//!< ã‚¤ãƒ³ãƒãƒ¼ãƒˆã™ã‚‹
+	void Export( HWND );	//!< ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã™ã‚‹
 
-	HFONT SetCtrlFont( HWND hwndDlg, int idc_static, const LOGFONT& lf );			//!< ƒRƒ“ƒgƒ[ƒ‹‚ÉƒtƒHƒ“ƒgİ’è‚·‚é		// 2013/4/24 Uchi
-	HFONT SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf, int nps );	//!< ƒtƒHƒ“ƒgƒ‰ƒxƒ‹‚ÉƒtƒHƒ“ƒg‚ÆƒtƒHƒ“ƒg–¼İ’è‚·‚é	// 2013/4/24 Uchi
+	HFONT SetCtrlFont( HWND hwndDlg, int idc_static, const LOGFONT& lf );			//!< ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«ãƒ•ã‚©ãƒ³ãƒˆè¨­å®šã™ã‚‹		// 2013/4/24 Uchi
+	HFONT SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf, int nps );	//!< ãƒ•ã‚©ãƒ³ãƒˆãƒ©ãƒ™ãƒ«ã«ãƒ•ã‚©ãƒ³ãƒˆã¨ãƒ•ã‚©ãƒ³ãƒˆåè¨­å®šã™ã‚‹	// 2013/4/24 Uchi
 };
 
 
 /*!
-	@brief ‹¤’Êİ’èƒvƒƒpƒeƒBƒy[ƒWƒNƒ‰ƒX
+	@brief å…±é€šè¨­å®šãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ãƒšãƒ¼ã‚¸ã‚¯ãƒ©ã‚¹
 
-	1‚Â‚ÌƒvƒƒpƒeƒBƒy[ƒW–ˆ‚É’è‹`
-	Dialog procedure‚ÆEvent Dispatcher‚ªƒy[ƒW‚²‚Æ‚É‚ ‚éD
-	•Ï”‚Ì’è‹`‚ÍCPropCommon‚Ås‚¤
+	1ã¤ã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ãƒšãƒ¼ã‚¸æ¯ã«å®šç¾©
+	Dialog procedureã¨Event DispatcherãŒãƒšãƒ¼ã‚¸ã”ã¨ã«ã‚ã‚‹ï¼
+	å¤‰æ•°ã®å®šç¾©ã¯CPropCommonã§è¡Œã†
 */
 //==============================================================
-//!	‘S”Êƒy[ƒW
+//!	å…¨èˆ¬ãƒšãƒ¼ã‚¸
 class CPropGeneral : CPropCommon
 {
 public:
@@ -201,12 +201,12 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 };
 
 //==============================================================
-//!	ƒtƒ@ƒCƒ‹ƒy[ƒW
+//!	ãƒ•ã‚¡ã‚¤ãƒ«ãƒšãƒ¼ã‚¸
 class CPropFile : CPropCommon
 {
 public:
@@ -216,16 +216,16 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
 	//	Aug. 21, 2000 genta
-	void EnableFilePropInput(HWND hwndDlg);	//	ƒtƒ@ƒCƒ‹İ’è‚ÌON/OFF
+	void EnableFilePropInput(HWND hwndDlg);	//	ãƒ•ã‚¡ã‚¤ãƒ«è¨­å®šã®ON/OFF
 };
 
 //==============================================================
-//!	ƒL[Š„‚è“–‚Äƒy[ƒW
+//!	ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ãƒšãƒ¼ã‚¸
 class CPropKeybind : CPropCommon
 {
 public:
@@ -235,18 +235,18 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
-	void Import( HWND );	//!< ƒCƒ“ƒ|[ƒg‚·‚é
-	void Export( HWND );	//!< ƒGƒNƒXƒ|[ƒg‚·‚é
+	void Import( HWND );	//!< ã‚¤ãƒ³ãƒãƒ¼ãƒˆã™ã‚‹
+	void Export( HWND );	//!< ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã™ã‚‹
 
 private:
-	void ChangeKeyList( HWND ); /* ƒL[ƒŠƒXƒg‚ğƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚Ìó‘Ô‚É‡‚í‚¹‚ÄXV‚·‚é*/
+	void ChangeKeyList( HWND ); /* ã‚­ãƒ¼ãƒªã‚¹ãƒˆã‚’ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã®çŠ¶æ…‹ã«åˆã‚ã›ã¦æ›´æ–°ã™ã‚‹*/
 };
 
 //==============================================================
-//!	ƒc[ƒ‹ƒo[ƒy[ƒW
+//!	ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ãƒšãƒ¼ã‚¸
 class CPropToolbar : CPropCommon
 {
 public:
@@ -256,15 +256,15 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
-	void DrawToolBarItemList( DRAWITEMSTRUCT* );	/* ƒc[ƒ‹ƒo[ƒ{ƒ^ƒ“ƒŠƒXƒg‚ÌƒAƒCƒeƒ€•`‰æ */
+	void DrawToolBarItemList( DRAWITEMSTRUCT* );	/* ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ãƒœã‚¿ãƒ³ãƒªã‚¹ãƒˆã®ã‚¢ã‚¤ãƒ†ãƒ æç”» */
 };
 
 //==============================================================
-//!	ƒL[ƒ[ƒhƒy[ƒW
+//!	ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒšãƒ¼ã‚¸
 class CPropKeyword : CPropCommon
 {
 public:
@@ -276,23 +276,23 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
-	void SetKeyWordSet( HWND , int );	/* w’èƒL[ƒ[ƒhƒZƒbƒg‚Ìİ’è */
-	void GetKeyWordSet( HWND , int );	/* w’èƒL[ƒ[ƒhƒZƒbƒg‚Ìæ“¾ */
+	void SetKeyWordSet( HWND , int );	/* æŒ‡å®šã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã®è¨­å®š */
+	void GetKeyWordSet( HWND , int );	/* æŒ‡å®šã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆã®å–å¾— */
 	void DispKeywordCount( HWND hwndDlg );
 
-	void Edit_List_KeyWord( HWND, HWND );		//!< ƒŠƒXƒg’†‚Å‘I‘ğ‚³‚ê‚Ä‚¢‚éƒL[ƒ[ƒh‚ğ•ÒW‚·‚é
-	void Delete_List_KeyWord( HWND , HWND );	//!< ƒŠƒXƒg’†‚Å‘I‘ğ‚³‚ê‚Ä‚¢‚éƒL[ƒ[ƒh‚ğíœ‚·‚é
-	void Import_List_KeyWord( HWND , HWND );	//!< ƒŠƒXƒg’†‚ÌƒL[ƒ[ƒh‚ğƒCƒ“ƒ|[ƒg‚·‚é
-	void Export_List_KeyWord( HWND , HWND );	//!< ƒŠƒXƒg’†‚ÌƒL[ƒ[ƒh‚ğƒGƒNƒXƒ|[ƒg‚·‚é
-	void Clean_List_KeyWord( HWND , HWND );		//!< ƒŠƒXƒg’†‚ÌƒL[ƒ[ƒh‚ğ®—‚·‚é 2005.01.26 Moca
+	void Edit_List_KeyWord( HWND, HWND );		//!< ãƒªã‚¹ãƒˆä¸­ã§é¸æŠã•ã‚Œã¦ã„ã‚‹ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ç·¨é›†ã™ã‚‹
+	void Delete_List_KeyWord( HWND , HWND );	//!< ãƒªã‚¹ãƒˆä¸­ã§é¸æŠã•ã‚Œã¦ã„ã‚‹ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’å‰Šé™¤ã™ã‚‹
+	void Import_List_KeyWord( HWND , HWND );	//!< ãƒªã‚¹ãƒˆä¸­ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ã‚¤ãƒ³ãƒãƒ¼ãƒˆã™ã‚‹
+	void Export_List_KeyWord( HWND , HWND );	//!< ãƒªã‚¹ãƒˆä¸­ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã™ã‚‹
+	void Clean_List_KeyWord( HWND , HWND );		//!< ãƒªã‚¹ãƒˆä¸­ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’æ•´ç†ã™ã‚‹ 2005.01.26 Moca
 };
 
 //==============================================================
-//!	ƒJƒXƒ^ƒ€ƒƒjƒ…[ƒy[ƒW
+//!	ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒšãƒ¼ã‚¸
 class CPropCustmenu : CPropCommon
 {
 public:
@@ -302,15 +302,15 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
 	void SetDataMenuList( HWND, int );
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
-	void Import( HWND );	//!< ƒJƒXƒ^ƒ€ƒƒjƒ…[İ’è‚ğƒCƒ“ƒ|[ƒg‚·‚é
-	void Export( HWND );	//!< ƒJƒXƒ^ƒ€ƒƒjƒ…[İ’è‚ğƒGƒNƒXƒ|[ƒg‚·‚é
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
+	void Import( HWND );	//!< ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šã‚’ã‚¤ãƒ³ãƒãƒ¼ãƒˆã™ã‚‹
+	void Export( HWND );	//!< ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šã‚’ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã™ã‚‹
 };
 
 //==============================================================
-//!	‘®ƒy[ƒW
+//!	æ›¸å¼ãƒšãƒ¼ã‚¸
 class CPropFormat : CPropCommon
 {
 public:
@@ -320,19 +320,19 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
 	void ChangeDateExample( HWND hwndDlg );
 	void ChangeTimeExample( HWND hwndDlg );
 
-	//	Sept. 10, 2000 JEPRO	Ÿs‚ğ’Ç‰Á
-	void EnableFormatPropInput( HWND hwndDlg );	//	‘®İ’è‚ÌON/OFF
+	//	Sept. 10, 2000 JEPRO	æ¬¡è¡Œã‚’è¿½åŠ 
+	void EnableFormatPropInput( HWND hwndDlg );	//	æ›¸å¼è¨­å®šã®ON/OFF
 };
 
 //==============================================================
-//!	x‰‡ƒy[ƒW
+//!	æ”¯æ´ãƒšãƒ¼ã‚¸
 class CPropHelper : CPropCommon
 {
 public:
@@ -342,12 +342,12 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 };
 
 //==============================================================
-//!	ƒoƒbƒNƒAƒbƒvƒy[ƒW
+//!	ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒšãƒ¼ã‚¸
 class CPropBackup : CPropCommon
 {
 public:
@@ -357,18 +357,18 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
 	//	Aug. 16, 2000 genta
-	void EnableBackupInput(HWND hwndDlg);	//	ƒoƒbƒNƒAƒbƒvİ’è‚ÌON/OFF
+	void EnableBackupInput(HWND hwndDlg);	//	ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—è¨­å®šã®ON/OFF
 	//	20051107 aroka
-	void UpdateBackupFile(HWND hwndDlg);	//	ƒoƒbƒNƒAƒbƒvƒtƒ@ƒCƒ‹‚ÌÚ×İ’è
+	void UpdateBackupFile(HWND hwndDlg);	//	ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ã®è©³ç´°è¨­å®š
 };
 
 //==============================================================
-//!	ƒEƒBƒ“ƒhƒEƒy[ƒW
+//!	ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒšãƒ¼ã‚¸
 class CPropWin : CPropCommon
 {
 public:
@@ -378,16 +378,16 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
-	//	Sept. 9, 2000 JEPRO		Ÿs‚ğ’Ç‰Á
-	void EnableWinPropInput( HWND hwndDlg) ;	//	ƒEƒBƒ“ƒhƒEİ’è‚ÌON/OFF
+	//	Sept. 9, 2000 JEPRO		æ¬¡è¡Œã‚’è¿½åŠ 
+	void EnableWinPropInput( HWND hwndDlg) ;	//	ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦è¨­å®šã®ON/OFF
 };
 
 //==============================================================
-//!	ƒ^ƒu“®ìƒy[ƒW
+//!	ã‚¿ãƒ–å‹•ä½œãƒšãƒ¼ã‚¸
 class CPropTab : CPropCommon
 {
 public:
@@ -397,15 +397,15 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
 	void EnableTabPropInput(HWND hwndDlg);
 };
 
 //==============================================================
-//!	•ÒWƒy[ƒW
+//!	ç·¨é›†ãƒšãƒ¼ã‚¸
 class CPropEdit : CPropCommon
 {
 public:
@@ -415,15 +415,15 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
 	void EnableEditPropInput( HWND hwndDlg );
 };
 
 //==============================================================
-//!	ŒŸõƒy[ƒW
+//!	æ¤œç´¢ãƒšãƒ¼ã‚¸
 class CPropGrep : CPropCommon
 {
 public:
@@ -433,15 +433,15 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
-	void SetRegexpVersion( HWND ); // 2007.08.12 genta ƒo[ƒWƒ‡ƒ“•\¦
+	void SetRegexpVersion( HWND ); // 2007.08.12 genta ãƒãƒ¼ã‚¸ãƒ§ãƒ³è¡¨ç¤º
 };
 
 //==============================================================
-//!	ƒ}ƒNƒƒy[ƒW
+//!	ãƒã‚¯ãƒ­ãƒšãƒ¼ã‚¸
 class CPropMacro : CPropCommon
 {
 public:
@@ -451,21 +451,21 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
-	void InitDialog( HWND hwndDlg );//!< Macroƒy[ƒW‚Ì‰Šú‰»
+	void InitDialog( HWND hwndDlg );//!< Macroãƒšãƒ¼ã‚¸ã®åˆæœŸåŒ–
 	//	To Here Jun. 2, 2001 genta
-	void SetMacro2List_Macro( HWND hwndDlg );//!< Macroƒf[ƒ^‚Ìİ’è
-	void SelectBaseDir_Macro( HWND hwndDlg );//!< MacroƒfƒBƒŒƒNƒgƒŠ‚Ì‘I‘ğ
-	void OnFileDropdown_Macro( HWND hwndDlg );//!< ƒtƒ@ƒCƒ‹ƒhƒƒbƒvƒ_ƒEƒ“‚ªŠJ‚©‚ê‚é‚Æ‚«
-	void CheckListPosition_Macro( HWND hwndDlg );//!< ƒŠƒXƒgƒrƒ…[‚ÌFocusˆÊ’uŠm”F
+	void SetMacro2List_Macro( HWND hwndDlg );//!< Macroãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	void SelectBaseDir_Macro( HWND hwndDlg );//!< Macroãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®é¸æŠ
+	void OnFileDropdown_Macro( HWND hwndDlg );//!< ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‰ãƒ­ãƒƒãƒ—ãƒ€ã‚¦ãƒ³ãŒé–‹ã‹ã‚Œã‚‹ã¨ã
+	void CheckListPosition_Macro( HWND hwndDlg );//!< ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®Focusä½ç½®ç¢ºèª
 	static int CALLBACK DirCallback_Macro( HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData );
 };
 
 //==============================================================
-//!	ƒtƒ@ƒCƒ‹–¼•\¦ƒy[ƒW
+//!	ãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤ºãƒšãƒ¼ã‚¸
 class CPropFileName : CPropCommon
 {
 public:
@@ -475,17 +475,17 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
-	static int SetListViewItem_FILENAME( HWND hListView, int, LPTSTR, LPTSTR, bool );//!<ListView‚ÌƒAƒCƒeƒ€‚ğİ’è
-	static void GetListViewItem_FILENAME( HWND hListView, int, LPTSTR, LPTSTR );//!<ListView‚ÌƒAƒCƒeƒ€‚ğæ“¾
-	static int MoveListViewItem_FILENAME( HWND hListView, int, int );//!<ListView‚ÌƒAƒCƒeƒ€‚ğˆÚ“®‚·‚é
+	static int SetListViewItem_FILENAME( HWND hListView, int, LPTSTR, LPTSTR, bool );//!<ListViewã®ã‚¢ã‚¤ãƒ†ãƒ ã‚’è¨­å®š
+	static void GetListViewItem_FILENAME( HWND hListView, int, LPTSTR, LPTSTR );//!<ListViewã®ã‚¢ã‚¤ãƒ†ãƒ ã‚’å–å¾—
+	static int MoveListViewItem_FILENAME( HWND hListView, int, int );//!<ListViewã®ã‚¢ã‚¤ãƒ†ãƒ ã‚’ç§»å‹•ã™ã‚‹
 };
 
 //==============================================================
-//!	ƒXƒe[ƒ^ƒXƒo[ƒy[ƒW
+//!	ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ãƒšãƒ¼ã‚¸
 class CPropStatusbar : CPropCommon
 {
 public:
@@ -495,34 +495,34 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 };
 
 //==============================================================
-//!	ƒvƒ‰ƒOƒCƒ“ƒy[ƒW
+//!	ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãƒšãƒ¼ã‚¸
 class CPropPlugin : CPropCommon
 {
 public:
 	//!	Dialog Procedure
 	static INT_PTR CALLBACK DlgProc_page(
 		HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam );
-	std::tstring GetReadMeFile(const std::tstring& sName);	//	Readme ƒtƒ@ƒCƒ‹‚Ìæ“¾
-	bool BrowseReadMe(const std::tstring& sReadMeName);		//	Readme ƒtƒ@ƒCƒ‹‚Ì•\¦
+	std::tstring GetReadMeFile(const std::tstring& sName);	//	Readme ãƒ•ã‚¡ã‚¤ãƒ«ã®å–å¾—
+	bool BrowseReadMe(const std::tstring& sReadMeName);		//	Readme ãƒ•ã‚¡ã‚¤ãƒ«ã®è¡¨ç¤º
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 private:
 	void SetData_LIST( HWND );
-	void InitDialog( HWND hwndDlg );	//!< Pluginƒy[ƒW‚Ì‰Šú‰»
+	void InitDialog( HWND hwndDlg );	//!< Pluginãƒšãƒ¼ã‚¸ã®åˆæœŸåŒ–
 	void EnablePluginPropInput(HWND hwndDlg);
 };
 
 //==============================================================
-//!	ƒƒCƒ“ƒƒjƒ…[ƒy[ƒW
+//!	ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒšãƒ¼ã‚¸
 class CPropMainMenu : CPropCommon
 {
 public:
@@ -532,16 +532,16 @@ public:
 protected:
 	//! Message Handler
 	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );
-	void SetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );	//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
-	void Import( HWND );	//!< ƒƒjƒ…[İ’è‚ğƒCƒ“ƒ|[ƒg‚·‚é
-	void Export( HWND );	//!< ƒƒjƒ…[İ’è‚ğƒGƒNƒXƒ|[ƒg‚·‚é
+	void SetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );	//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
+	void Import( HWND );	//!< ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šã‚’ã‚¤ãƒ³ãƒãƒ¼ãƒˆã™ã‚‹
+	void Export( HWND );	//!< ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¨­å®šã‚’ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã™ã‚‹
 
 private:
 	bool GetDataTree( HWND, HTREEITEM, int );
 
-	bool Check_MainMenu( HWND, std::wstring& );						// ƒƒjƒ…[‚ÌŒŸ¸
-	bool Check_MainMenu_Sub( HWND, HTREEITEM, int, std::wstring& );	// ƒƒjƒ…[‚ÌŒŸ¸
+	bool Check_MainMenu( HWND, std::wstring& );						// ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ¤œæŸ»
+	bool Check_MainMenu_Sub( HWND, HTREEITEM, int, std::wstring& );	// ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®æ¤œæŸ»
 };
 
 


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/prop
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。

主に動作影響について対応前後で挙動に変化がないことのご確認をいただけると助かります。
