### PR TITLE
typeprop 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/typeprop/CDlgKeywordSelect.cpp
+++ b/sakura_core/typeprop/CDlgKeywordSelect.cpp
@@ -1,8 +1,8 @@
-/*! @file
-	@brief ‹­’²ƒL[ƒ[ƒh‘I‘ğƒ_ƒCƒAƒƒO
+ï»¿/*! @file
+	@brief å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰é¸æŠãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author MIK
-	@date 2005/01/13 ì¬
+	@date 2005/01/13 ä½œæˆ
 */
 /*
 	Copyright (C) 2005, MIK
@@ -79,7 +79,7 @@ CDlgKeywordSelect::~CDlgKeywordSelect()
 }
 
 
-/* !ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦
+/* !ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º
 */
 int CDlgKeywordSelect::DoModal( HINSTANCE hInstance, HWND hwndParent, int* pnSet )
 {
@@ -98,7 +98,7 @@ int CDlgKeywordSelect::DoModal( HINSTANCE hInstance, HWND hwndParent, int* pnSet
 	return TRUE;
 }
 
-/*! ‰Šú‰»ˆ—
+/*! åˆæœŸåŒ–å‡¦ç†
 */
 BOOL CDlgKeywordSelect::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 {
@@ -120,7 +120,7 @@ BOOL CDlgKeywordSelect::OnBnClicked( int wID )
 	return CDialog::OnBnClicked( wID );
 }
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
 */
 void CDlgKeywordSelect::SetData( void )
 {
@@ -132,10 +132,10 @@ void CDlgKeywordSelect::SetData( void )
 	{
 		hwndCombo = ::GetDlgItem( GetHwnd(), keyword_select_target_combo[ index ] );
 
-		/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ğ‹ó‚É‚·‚é */
+		/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã‚’ç©ºã«ã™ã‚‹ */
 		Combo_ResetContent( hwndCombo );
 		
-		/* ˆês–Ú‚Í‹ó”’ */
+		/* ä¸€è¡Œç›®ã¯ç©ºç™½ */
 		Combo_AddString( hwndCombo, L" " );
 
 		if( m_pCKeyWordSetMgr->m_nKeyWordSetNum > 0 )
@@ -147,12 +147,12 @@ void CDlgKeywordSelect::SetData( void )
 
 			if( -1 == m_nSet[ index ] )
 			{
-				/* ƒZƒbƒg–¼ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ÌƒfƒtƒHƒ‹ƒg‘I‘ğ */
+				/* ã‚»ãƒƒãƒˆåã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆé¸æŠ */
 				Combo_SetCurSel( hwndCombo, 0 );
 			}
 			else
 			{
-				/* ƒZƒbƒg–¼ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ÌƒfƒtƒHƒ‹ƒg‘I‘ğ */
+				/* ã‚»ãƒƒãƒˆåã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆé¸æŠ */
 				Combo_SetCurSel( hwndCombo, m_nSet[ index ] + 1 );
 			}
 		}
@@ -160,7 +160,7 @@ void CDlgKeywordSelect::SetData( void )
 }
 
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
 */
 int CDlgKeywordSelect::GetData( void )
 {

--- a/sakura_core/typeprop/CDlgKeywordSelect.h
+++ b/sakura_core/typeprop/CDlgKeywordSelect.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief �����L�[���[�h�I���_�C�A���O
+﻿/*!	@file
+	@brief 強調キーワード選択ダイアログ
 
 	@author MIK
-	@date 2005/01/13 �쐬
+	@date 2005/01/13 作成
 */
 /*
 	Copyright (C) 2005, MIK, genta
@@ -37,12 +37,12 @@
 class CKeyWordSetMgr;
 
 /*
-	�����L�[���[�h�I���\��
-	1�`10�͈̔͂Ŏw��ł���B
-	�������A�\�[�X�̏C���͕K�v�ł��B
+	強調キーワード選択可能数
+	1～10個の範囲で指定できる。
+	ただし、ソースの修正は必要です。
 */
 
-//	2005.01.13 genta ShareData�̒�`�ƘA��������
+//	2005.01.13 genta ShareDataの定義と連動させる
 const int KEYWORD_SELECT_NUM = MAX_KEYWORDSET_PER_TYPE;
 
 class CDlgKeywordSelect : public CDialog

--- a/sakura_core/typeprop/CDlgSameColor.cpp
+++ b/sakura_core/typeprop/CDlgSameColor.cpp
@@ -1,8 +1,8 @@
-/*! @file
-	@brief �����F�^�w�i�F����_�C�A���O
+﻿/*! @file
+	@brief 文字色／背景色統一ダイアログ
 
 	@author ryoji
-	@date 2006/04/26 �쐬
+	@date 2006/04/26 作成
 */
 /*
 	Copyright (C) 2006, ryoji
@@ -39,13 +39,13 @@
 
 static const DWORD p_helpids[] = {	// 2006.10.10 ryoji
 	IDOK,						HIDOK_SAMECOLOR,						// OK
-	IDCANCEL,					HIDCANCEL_SAMECOLOR,					// �L�����Z��
-	IDC_BUTTON_HELP,			HIDC_BUTTON_SAMECOLOR_HELP,				// �w���v
-	IDC_LIST_COLORS,			HIDC_LIST_SAMECOLOR_COLORS,				// �ύX�Ώۂ̐F
-	IDC_BUTTON_SELALL,			HIDC_BUTTON_SAMECOLOR_SELALL,			// �S�`�F�b�N
-	IDC_BUTTON_SELNOTING,		HIDC_BUTTON_SAMECOLOR_SELNOTING,		// �S����
-	IDC_LIST_ITEMINFO,			HIDC_LIST_SAMECOLOR_ITEMINFO,			// �I�𒆂̐F�ɑΉ����鍀�ڂ̃��X�g
-	IDC_STATIC_COLOR,			HIDC_STATIC_COLOR,						// ����F
+	IDCANCEL,					HIDCANCEL_SAMECOLOR,					// キャンセル
+	IDC_BUTTON_HELP,			HIDC_BUTTON_SAMECOLOR_HELP,				// ヘルプ
+	IDC_LIST_COLORS,			HIDC_LIST_SAMECOLOR_COLORS,				// 変更対象の色
+	IDC_BUTTON_SELALL,			HIDC_BUTTON_SAMECOLOR_SELALL,			// 全チェック
+	IDC_BUTTON_SELNOTING,		HIDC_BUTTON_SAMECOLOR_SELNOTING,		// 全解除
+	IDC_LIST_ITEMINFO,			HIDC_LIST_SAMECOLOR_ITEMINFO,			// 選択中の色に対応する項目のリスト
+	IDC_STATIC_COLOR,			HIDC_STATIC_COLOR,						// 統一色
 	0, 0
 };
 
@@ -70,7 +70,7 @@ CDlgSameColor::~CDlgSameColor()
 }
 
 /*!
-	�W���ȊO�̃��b�Z�[�W��ߑ�����
+	標準以外のメッセージを捕捉する
 */
 INT_PTR CDlgSameColor::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam )
 {
@@ -78,7 +78,7 @@ INT_PTR CDlgSameColor::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARA
 	result = CDialog::DispatchEvent( hWnd, wMsg, wParam, lParam );
 	switch( wMsg ){
 	case WM_COMMAND:
-		// �F�I�����X�g�{�b�N�X�̑I�����ύX���ꂽ�ꍇ�̏���
+		// 色選択リストボックスの選択が変更された場合の処理
 		if( IDC_LIST_COLORS == LOWORD(wParam) && LBN_SELCHANGE == HIWORD(wParam) ){
 			OnSelChangeListColors( (HWND)lParam );
 		}
@@ -86,7 +86,7 @@ INT_PTR CDlgSameColor::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARA
 
 	case WM_CTLCOLORLISTBOX:
 		{
-			// ���ڃ��X�g�̔w�i�F��ݒ肷�鏈��
+			// 項目リストの背景色を設定する処理
 			HWND hwndLB = (HWND)lParam;
 			if( IDC_LIST_ITEMINFO == ::GetDlgCtrlID( hwndLB ) ){
 				HDC hdcLB = (HDC)wParam;
@@ -103,12 +103,12 @@ INT_PTR CDlgSameColor::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARA
 	return result;
 }
 
-/*! ���[�_���_�C�A���O�̕\��
-	@param wID [in] �^�C�v�ʐݒ�_�C�A���O�ŉ����ꂽ�{�^��ID
-	@param pTypes  [in,out] �^�C�v�ʐݒ�f�[�^
-	@param cr [in] �w��F
+/*! モーダルダイアログの表示
+	@param wID [in] タイプ別設定ダイアログで押されたボタンID
+	@param pTypes  [in,out] タイプ別設定データ
+	@param cr [in] 指定色
 
-	@date 2006.04.26 ryoji �V�K�쐬
+	@date 2006.04.26 ryoji 新規作成
 */
 int CDlgSameColor::DoModal( HINSTANCE hInstance, HWND hwndParent, WORD wID, STypeConfig* pTypes, COLORREF cr )
 {
@@ -121,8 +121,8 @@ int CDlgSameColor::DoModal( HINSTANCE hInstance, HWND hwndParent, WORD wID, STyp
 	return TRUE;
 }
 
-/*! WM_INITDIALOG ����
-	@date 2006.04.26 ryoji �V�K�쐬
+/*! WM_INITDIALOG 処理
+	@date 2006.04.26 ryoji 新規作成
 */
 BOOL CDlgSameColor::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 {
@@ -131,7 +131,7 @@ BOOL CDlgSameColor::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	HWND hwndStatic = ::GetDlgItem( GetHwnd(), IDC_STATIC_COLOR );
 	HWND hwndList = ::GetDlgItem( GetHwnd(), IDC_LIST_COLORS );
 
-	// �w��F�X�^�e�B�b�N�A�F�I�����X�g���T�u�N���X��
+	// 指定色スタティック、色選択リストをサブクラス化
 	::SetWindowLongPtr( hwndStatic, GWLP_USERDATA, (LONG_PTR)this );
 	m_wpColorStaticProc = (WNDPROC)::SetWindowLongPtr( hwndStatic, GWLP_WNDPROC, (LONG_PTR)ColorStatic_SubclassProc );
 	::SetWindowLongPtr( hwndList, GWLP_USERDATA, (LONG_PTR)this );
@@ -142,10 +142,10 @@ BOOL CDlgSameColor::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	int nItem;
 	int i;
 
-	switch( m_wID )	// �^�C�v�ʐݒ�_�C�A���O�ŉ����ꂽ�{�^��ID
+	switch( m_wID )	// タイプ別設定ダイアログで押されたボタンID
 	{
 	case IDC_BUTTON_SAMETEXTCOLOR:
-		// �^�C�v�ʐݒ肩�當���F���d�����Ȃ��悤�Ɏ��o��
+		// タイプ別設定から文字色を重複しないように取り出す
 		::SetWindowText( GetHwnd(), LS(STR_DLGSMCLR_BTN1) );
 		for( i = 0; i < COLORIDX_LAST; ++i ){
 			if( 0 != (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_TEXT) )
@@ -161,10 +161,10 @@ BOOL CDlgSameColor::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		break;
 
 	case IDC_BUTTON_SAMEBKCOLOR:
-		// �^�C�v�ʐݒ肩��w�i�F���d�����Ȃ��悤�Ɏ��o��
+		// タイプ別設定から背景色を重複しないように取り出す
 		::SetWindowText( GetHwnd(), LS(STR_DLGSMCLR_BTN2) );
 		for( i = 0; i < COLORIDX_LAST; ++i ){
-			if( 0 != (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji �t���O���p�Ŋȑf��
+			if( 0 != (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji フラグ利用で簡素化
 				continue;
 			if( m_cr != m_pTypes->m_ColorInfoArr[i].m_sColorAttr.m_cBACK ){
 				_ultow( m_pTypes->m_ColorInfoArr[i].m_sColorAttr.m_cBACK, szText, 10 );
@@ -189,8 +189,8 @@ BOOL CDlgSameColor::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return bRet;
 }
 
-/*! BN_CLICKED ����
-	@date 2006.04.26 ryoji �V�K�쐬
+/*! BN_CLICKED 処理
+	@date 2006.04.26 ryoji 新規作成
 */
 BOOL CDlgSameColor::OnBnClicked( int wID )
 {
@@ -202,13 +202,13 @@ BOOL CDlgSameColor::OnBnClicked( int wID )
 
 	switch( wID ){
 	case IDC_BUTTON_HELP:
-		// �w���v	// 2006.10.07 ryoji
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, HLP000316 );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		// ヘルプ	// 2006.10.07 ryoji
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, HLP000316 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 
 	case IDC_BUTTON_SELALL:
 	case IDC_BUTTON_SELNOTING:
-		// �S�I���^�S�����̏���
+		// 全選択／全解除の処理
 		bCheck = (wID == IDC_BUTTON_SELALL);
 		for( i = 0; i < nItemNum; ++i ){
 			List_SetItemData( hwndList, i, bCheck );
@@ -217,7 +217,7 @@ BOOL CDlgSameColor::OnBnClicked( int wID )
 		break;
 
 	case IDOK:
-		// �^�C�v�ʐݒ肩��I��F�Ɠ��F�̂��̂����o���Ďw��F�Ɉꊇ�ύX����
+		// タイプ別設定から選択色と同色のものを取り出して指定色に一括変更する
 		WCHAR szText[30];
 		LPWSTR pszStop;
 		COLORREF cr;
@@ -259,20 +259,20 @@ BOOL CDlgSameColor::OnBnClicked( int wID )
 	return CDialog::OnBnClicked( wID );
 }
 
-/*! WM_DRAWITEM ����
-	@date 2006.04.26 ryoji �V�K�쐬
+/*! WM_DRAWITEM 処理
+	@date 2006.04.26 ryoji 新規作成
 */
 BOOL CDlgSameColor::OnDrawItem( WPARAM wParam, LPARAM lParam )
 {
-	LPDRAWITEMSTRUCT pDis = (LPDRAWITEMSTRUCT)lParam;	// ���ڕ`����
-	if( IDC_LIST_COLORS != pDis->CtlID )	// �I�[�i�[�`��ɂ��Ă���̂͐F�I�����X�g����
+	LPDRAWITEMSTRUCT pDis = (LPDRAWITEMSTRUCT)lParam;	// 項目描画情報
+	if( IDC_LIST_COLORS != pDis->CtlID )	// オーナー描画にしているのは色選択リストだけ
 		return TRUE;
 
-	//�`��Ώ�
+	//描画対象
 	CGraphics gr(pDis->hDC);
 
 	//
-	// �F�I�����X�g�̕`�揈��
+	// 色選択リストの描画処理
 	//
 	RECT		rc;
 	WCHAR		szText[30];
@@ -284,22 +284,22 @@ BOOL CDlgSameColor::OnDrawItem( WPARAM wParam, LPARAM lParam )
 
 	rc = pDis->rcItem;
 
-	// �A�C�e����`�h��Ԃ�
+	// アイテム矩形塗りつぶし
 	::FillRect( gr, &pDis->rcItem, ::GetSysColorBrush( COLOR_WINDOW ) );
 
-	// �A�C�e�����I�����
+	// アイテムが選択状態
 	if( pDis->itemState & ODS_SELECTED ){
 		rc = pDis->rcItem;
 		rc.left += (rc.bottom - rc.top);
 		::FillRect( gr, &rc, ::GetSysColorBrush( COLOR_HIGHLIGHT ) );
 	}
 
-	// �A�C�e���Ƀt�H�[�J�X������
+	// アイテムにフォーカスがある
 	if( pDis->itemState & ODS_FOCUS ){
 		::DrawFocusRect( gr, &pDis->rcItem );
 	}
 
-	// �`�F�b�N�{�b�N�X�\��
+	// チェックボックス表示
 	rc = pDis->rcItem;
 	rc.top += 2;
 	rc.bottom -= 2;
@@ -307,10 +307,10 @@ BOOL CDlgSameColor::OnDrawItem( WPARAM wParam, LPARAM lParam )
 	rc.right = rc.left + (rc.bottom - rc.top);
 	UINT uState =  DFCS_BUTTONCHECK | DFCS_FLAT;
 	if( FALSE != (BOOL)pDis->itemData )
-		uState |= DFCS_CHECKED;		// �`�F�b�N���
+		uState |= DFCS_CHECKED;		// チェック状態
 	::DrawFrameControl( gr, &rc, DFC_BUTTON, uState );
 
-	// �F���{��`
+	// 色見本矩形
 	rc = pDis->rcItem;
 	rc.left += rc.bottom - rc.top + 2;
 	rc.top += 2;
@@ -323,13 +323,13 @@ BOOL CDlgSameColor::OnDrawItem( WPARAM wParam, LPARAM lParam )
 	return TRUE;
 }
 
-/*! �F�I�����X�g�� LBN_SELCHANGE ����
-	@date 2006.05.01 ryoji �V�K�쐬
+/*! 色選択リストの LBN_SELCHANGE 処理
+	@date 2006.05.01 ryoji 新規作成
 */
 BOOL CDlgSameColor::OnSelChangeListColors( HWND hwndCtl )
 {
-	// �F�I�����X�g�Ō��݃t�H�[�J�X�̂���F�ɂ���
-	// �^�C�v�ʐݒ肩�瓯�F�̍��ڂ����o���č��ڃ��X�g�ɕ\������
+	// 色選択リストで現在フォーカスのある色について
+	// タイプ別設定から同色の項目を取り出して項目リストに表示する
 	HWND hwndListInfo;
 	COLORREF cr;
 	WCHAR szText[30];
@@ -359,7 +359,7 @@ BOOL CDlgSameColor::OnSelChangeListColors( HWND hwndCtl )
 
 		case IDC_BUTTON_SAMEBKCOLOR:
 			for( j = 0; j < COLORIDX_LAST; ++j ){
-			if( 0 != (g_ColorAttributeArr[j].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji �t���O���p�Ŋȑf��
+			if( 0 != (g_ColorAttributeArr[j].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji フラグ利用で簡素化
 					continue;
 				if( cr == m_pTypes->m_ColorInfoArr[j].m_sColorAttr.m_cBACK ){
 					::List_AddString( hwndListInfo, m_pTypes->m_ColorInfoArr[j].m_szName);
@@ -375,8 +375,8 @@ BOOL CDlgSameColor::OnSelChangeListColors( HWND hwndCtl )
 	return TRUE;
 }
 
-/*! �T�u�N���X�����ꂽ�w��F�X�^�e�B�b�N�̃E�B���h�E�v���V�[�W��
-	@date 2006.04.26 ryoji �V�K�쐬
+/*! サブクラス化された指定色スタティックのウィンドウプロシージャ
+	@date 2006.04.26 ryoji 新規作成
 */
 LRESULT CALLBACK CDlgSameColor::ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
@@ -388,12 +388,12 @@ LRESULT CALLBACK CDlgSameColor::ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, 
 
 	switch( uMsg ){
 	case WM_PAINT:
-		// �E�B���h�E�`��
+		// ウィンドウ描画
 		PAINTSTRUCT ps;
 
 		hDC = ::BeginPaint( hwnd, &ps );
 
-		// �F���{��`
+		// 色見本矩形
 		::GetClientRect( hwnd, &rc );
 		rc.left += 2;
 		rc.top += 2;
@@ -409,11 +409,11 @@ LRESULT CALLBACK CDlgSameColor::ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, 
 		return (LRESULT)0;
 
 	case WM_ERASEBKGND:
-		// �w�i�`��
+		// 背景描画
 		hDC = (HDC)wParam;
 		::GetClientRect( hwnd, &rc );
 
-		// �e��WM_CTLCOLORSTATIC�𑗂��Ĕw�i�u���V���擾���A�w�i�`�悷��
+		// 親にWM_CTLCOLORSTATICを送って背景ブラシを取得し、背景描画する
 		{
 			HBRUSH	hBrush = (HBRUSH)::SendMessageAny( GetParent( hwnd ), WM_CTLCOLORSTATIC, wParam, (LPARAM)hwnd );
 			HBRUSH	hBrushOld = (HBRUSH)::SelectObject( hDC, hBrush );
@@ -423,7 +423,7 @@ LRESULT CALLBACK CDlgSameColor::ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, 
 		return (LRESULT)1;
 
 	case WM_DESTROY:
-		// �T�u�N���X������
+		// サブクラス化解除
 		::SetWindowLongPtr( hwnd, GWLP_WNDPROC, (LONG_PTR)pCDlgSameColor->m_wpColorStaticProc );
 		pCDlgSameColor->m_wpColorStaticProc = NULL;
 		return (LRESULT)0;
@@ -435,8 +435,8 @@ LRESULT CALLBACK CDlgSameColor::ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, 
 	return CallWindowProc( pCDlgSameColor->m_wpColorStaticProc, hwnd, uMsg, wParam, lParam );
 }
 
-/*! �T�u�N���X�����ꂽ�F�I�����X�g�̃E�B���h�E�v���V�[�W��
-	@date 2006.04.26 ryoji �V�K�쐬
+/*! サブクラス化された色選択リストのウィンドウプロシージャ
+	@date 2006.04.26 ryoji 新規作成
 */
 LRESULT CALLBACK CDlgSameColor::ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
@@ -451,7 +451,7 @@ LRESULT CALLBACK CDlgSameColor::ColorList_SubclassProc( HWND hwnd, UINT uMsg, WP
 
 	switch( uMsg ){
 	case WM_LBUTTONUP:
-		// �}�E�X�{�^�����ɂ��鍀�ڂ̑I���^�I���������g�O������
+		// マウスボタン下にある項目の選択／選択解除をトグルする
 		po.x = LOWORD(lParam);	// horizontal position of cursor
 		po.y = HIWORD(lParam);	// vertical position of cursor
 		nItemNum = List_GetCount( hwnd );
@@ -473,7 +473,7 @@ LRESULT CALLBACK CDlgSameColor::ColorList_SubclassProc( HWND hwnd, UINT uMsg, WP
 		break;
 
 	case WM_KEYUP:
-		// �t�H�[�J�X���ڂ̑I���^�I���������g�O������
+		// フォーカス項目の選択／選択解除をトグルする
 		if( VK_SPACE == wParam ){
 			BOOL bCheck;
 			i = List_GetCaretIndex( hwnd );
@@ -486,7 +486,7 @@ LRESULT CALLBACK CDlgSameColor::ColorList_SubclassProc( HWND hwnd, UINT uMsg, WP
 		break;
 
 	case WM_DESTROY:
-		// �T�u�N���X������
+		// サブクラス化解除
 		::SetWindowLongPtr( hwnd, GWLP_WNDPROC, (LONG_PTR)pCDlgSameColor->m_wpColorListProc );
 		pCDlgSameColor->m_wpColorListProc = NULL;
 		return (LRESULT)0;

--- a/sakura_core/typeprop/CDlgSameColor.h
+++ b/sakura_core/typeprop/CDlgSameColor.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief •¶ŽšF^”wŒiF“ˆêƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief æ–‡å­—è‰²ï¼èƒŒæ™¯è‰²çµ±ä¸€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author ryoji
-	@date 2006/04/26 ì¬
+	@date 2006/04/26 ä½œæˆ
 */
 /*
 	Copyright (C) 2006, ryoji
@@ -35,36 +35,36 @@
 
 struct STypeConfig;
 
-/*!	@brief •¶ŽšF^”wŒiF“ˆêƒ_ƒCƒAƒƒO
+/*!	@brief æ–‡å­—è‰²ï¼èƒŒæ™¯è‰²çµ±ä¸€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
-	ƒ^ƒCƒv•ÊÝ’è‚ÌƒJƒ‰[Ý’è‚ÅC•¶ŽšF^”wŒiF“ˆê‚Ì‘ÎÛF‚ðŽw’è‚·‚é‚½‚ß‚É•â•“I‚É
-	Žg—p‚³‚ê‚éƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®ã‚«ãƒ©ãƒ¼è¨­å®šã§ï¼Œæ–‡å­—è‰²ï¼èƒŒæ™¯è‰²çµ±ä¸€ã®å¯¾è±¡è‰²ã‚’æŒ‡å®šã™ã‚‹ãŸã‚ã«è£œåŠ©çš„ã«
+	ä½¿ç”¨ã•ã‚Œã‚‹ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 */
 class CDlgSameColor : public CDialog
 {
 public:
 	CDlgSameColor();
 	~CDlgSameColor();
-	int DoModal( HINSTANCE, HWND, WORD, STypeConfig*, COLORREF );		//!< ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\Ž¦
+	int DoModal( HINSTANCE, HWND, WORD, STypeConfig*, COLORREF );		//!< ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º
 
 protected:
 
 	virtual LPVOID GetHelpIdTable( void );
-	virtual INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );	//! ƒ_ƒCƒAƒƒO‚ÌƒƒbƒZ[ƒWˆ—
-	virtual BOOL OnInitDialog( HWND, WPARAM, LPARAM );			//!< WM_INITDIALOG ˆ—
-	virtual BOOL OnBnClicked( int );							//!< BN_CLICKED ˆ—
-	virtual BOOL OnDrawItem( WPARAM wParam, LPARAM lParam );	//!< WM_DRAWITEM ˆ—
-	BOOL OnSelChangeListColors( HWND hwndCtl );					//!< F‘I‘ðƒŠƒXƒg‚Ì LBN_SELCHANGE ˆ—
+	virtual INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );	//! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
+	virtual BOOL OnInitDialog( HWND, WPARAM, LPARAM );			//!< WM_INITDIALOG å‡¦ç†
+	virtual BOOL OnBnClicked( int );							//!< BN_CLICKED å‡¦ç†
+	virtual BOOL OnDrawItem( WPARAM wParam, LPARAM lParam );	//!< WM_DRAWITEM å‡¦ç†
+	BOOL OnSelChangeListColors( HWND hwndCtl );					//!< è‰²é¸æŠžãƒªã‚¹ãƒˆã® LBN_SELCHANGE å‡¦ç†
 
-	static LRESULT CALLBACK ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	//!< ƒTƒuƒNƒ‰ƒX‰»‚³‚ê‚½Žw’èFƒXƒ^ƒeƒBƒbƒN‚ÌƒEƒBƒ“ƒhƒEƒvƒƒV[ƒWƒƒ
-	static LRESULT CALLBACK ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	//!< ƒTƒuƒNƒ‰ƒX‰»‚³‚ê‚½F‘I‘ðƒŠƒXƒg‚ÌƒEƒBƒ“ƒhƒEƒvƒƒV[ƒWƒƒ
+	static LRESULT CALLBACK ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	//!< ã‚µãƒ–ã‚¯ãƒ©ã‚¹åŒ–ã•ã‚ŒãŸæŒ‡å®šè‰²ã‚¹ã‚¿ãƒ†ã‚£ãƒƒã‚¯ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£
+	static LRESULT CALLBACK ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	//!< ã‚µãƒ–ã‚¯ãƒ©ã‚¹åŒ–ã•ã‚ŒãŸè‰²é¸æŠžãƒªã‚¹ãƒˆã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£
 
-	WNDPROC m_wpColorStaticProc;	//!< ƒTƒuƒNƒ‰ƒX‰»ˆÈ‘O‚ÌŽw’èFƒXƒ^ƒeƒBƒbƒN‚ÌƒEƒBƒ“ƒhƒEƒvƒƒV[ƒWƒƒ
-	WNDPROC m_wpColorListProc;		//!< ƒTƒuƒNƒ‰ƒX‰»ˆÈ‘O‚ÌF‘I‘ðƒŠƒXƒg‚ÌƒEƒBƒ“ƒhƒEƒvƒƒV[ƒWƒƒ
+	WNDPROC m_wpColorStaticProc;	//!< ã‚µãƒ–ã‚¯ãƒ©ã‚¹åŒ–ä»¥å‰ã®æŒ‡å®šè‰²ã‚¹ã‚¿ãƒ†ã‚£ãƒƒã‚¯ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£
+	WNDPROC m_wpColorListProc;		//!< ã‚µãƒ–ã‚¯ãƒ©ã‚¹åŒ–ä»¥å‰ã®è‰²é¸æŠžãƒªã‚¹ãƒˆã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£
 
-	WORD m_wID;			//!< ƒ^ƒCƒv•ÊÝ’èƒ_ƒCƒAƒƒOieƒ_ƒCƒAƒƒOj‚Å‰Ÿ‚³‚ê‚½ƒ{ƒ^ƒ“ID
-	STypeConfig* m_pTypes;	//!< ƒ^ƒCƒv•ÊÝ’èƒf[ƒ^
-	COLORREF m_cr;		//!< Žw’èF
+	WORD m_wID;			//!< ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ï¼ˆè¦ªãƒ€ã‚¤ã‚¢ãƒ­ã‚°ï¼‰ã§æŠ¼ã•ã‚ŒãŸãƒœã‚¿ãƒ³ID
+	STypeConfig* m_pTypes;	//!< ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãƒ‡ãƒ¼ã‚¿
+	COLORREF m_cr;		//!< æŒ‡å®šè‰²
 };
 
 #endif

--- a/sakura_core/typeprop/CDlgTypeAscertain.cpp
+++ b/sakura_core/typeprop/CDlgTypeAscertain.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒ^ƒCƒv•Êİ’èƒCƒ“ƒ|[ƒgŠm”Fƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚¤ãƒ³ãƒãƒ¼ãƒˆç¢ºèªãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Uchi
-	@date 2010/4/17 V‹Kì¬
+	@date 2010/4/17 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2010, Uchi
@@ -35,14 +35,14 @@
 #include "sakura.hh"
 #include "sakura_rc.h"
 
-// ƒ^ƒCƒv•Êİ’èƒCƒ“ƒ|[ƒgŠm”F CDlgTypeAscertain.cpp
+// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚¤ãƒ³ãƒãƒ¼ãƒˆç¢ºèª CDlgTypeAscertain.cpp
 const DWORD p_helpids[] = {
-	IDC_RADIO_TYPE_TO,		HIDC_RADIO_TYPE_TO,		//ƒ^ƒCƒv•Ê–¼
-	IDC_RADIO_TYPE_ADD,		HIDC_RADIO_TYPE_ADD,	//ƒ^ƒCƒv•Ê’Ç‰Á
-	IDC_COMBO_COLORS,		HIDC_COMBO_COLORS,		//Fw’è
+	IDC_RADIO_TYPE_TO,		HIDC_RADIO_TYPE_TO,		//ã‚¿ã‚¤ãƒ—åˆ¥å
+	IDC_RADIO_TYPE_ADD,		HIDC_RADIO_TYPE_ADD,	//ã‚¿ã‚¤ãƒ—åˆ¥è¿½åŠ 
+	IDC_COMBO_COLORS,		HIDC_COMBO_COLORS,		//è‰²æŒ‡å®š
 	IDOK,					HIDOK_DTA,				//OK
-	IDCANCEL,				HIDCANCEL_DTA,			//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,		HIDC_DTA_BUTTON_HELP,	//ƒwƒ‹ƒv
+	IDCANCEL,				HIDCANCEL_DTA,			//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,		HIDC_DTA_BUTTON_HELP,	//ãƒ˜ãƒ«ãƒ—
 //	IDC_STATIC,				-1,
 	0, 0
 };
@@ -53,7 +53,7 @@ CDlgTypeAscertain::CDlgTypeAscertain()
 {
 }
 
-// ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦
+// ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º
 int CDlgTypeAscertain::DoModal( HINSTANCE hInstance, HWND hwndParent, SAscertainInfo* psAscertainInfo )
 {
 	m_psi = psAscertainInfo;
@@ -63,12 +63,12 @@ int CDlgTypeAscertain::DoModal( HINSTANCE hInstance, HWND hwndParent, SAscertain
 	return (int)CDialog::DoModal( hInstance, hwndParent, IDD_TYPE_ASCERTAIN, (LPARAM)NULL );
 }
 
-// ƒ{ƒ^ƒ“ƒNƒŠƒbƒN
+// ãƒœã‚¿ãƒ³ã‚¯ãƒªãƒƒã‚¯
 BOOL CDlgTypeAscertain::OnBnClicked( int wID )
 {
 	switch( wID ){
 	case IDC_BUTTON_HELP:
-		/* uƒ^ƒCƒv•Êİ’èƒCƒ“ƒ|[ƒgv‚Ìƒwƒ‹ƒv */
+		/* ã€Œã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚¤ãƒ³ãƒãƒ¼ãƒˆã€ã®ãƒ˜ãƒ«ãƒ— */
 		MyWinHelp( GetHwnd(), HELP_CONTEXT, HLP000338 );
 		return TRUE;
 	case IDOK:
@@ -90,15 +90,15 @@ BOOL CDlgTypeAscertain::OnBnClicked( int wID )
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 }
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgTypeAscertain::SetData( void )
 {
-	// ƒ^ƒCƒv–¼İ’è
+	// ã‚¿ã‚¤ãƒ—åè¨­å®š
 	std::wstring typeNameTo = m_psi->sTypeNameTo + L"(&B)";
 	::SetWindowText( ::GetDlgItem( GetHwnd(), IDC_RADIO_TYPE_TO    ), to_tchar(typeNameTo.c_str()) );
 	::SetWindowText( ::GetDlgItem( GetHwnd(), IDC_STATIC_TYPE_FILE ), to_tchar(m_psi->sTypeNameFile.c_str()) );
@@ -109,29 +109,29 @@ void CDlgTypeAscertain::SetData( void )
 	HWND	hwndCombo;
 	TCHAR	szText[_MAX_PATH + 10];
 	hwndCombo = ::GetDlgItem( GetHwnd(), IDC_COMBO_COLORS );
-	/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ğ‹ó‚É‚·‚é */
+	/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã‚’ç©ºã«ã™ã‚‹ */
 	Combo_ResetContent( hwndCombo );
-	/* ˆês–Ú‚Í‚»‚Ì‚Ü‚Ü */
+	/* ä¸€è¡Œç›®ã¯ãã®ã¾ã¾ */
 	Combo_AddString( hwndCombo, LSW(STR_DLGTYPEASC_IMPORT) );
 
-	// ƒGƒfƒBƒ^“à‚Ìİ’è
+	// ã‚¨ãƒ‡ã‚£ã‚¿å†…ã®è¨­å®š
 	for (nIdx = 0; nIdx < GetDllShareData().m_nTypesCount; ++nIdx) {
 		const STypeConfigMini* type;
 		CDocTypeManager().GetTypeConfigMini(CTypeConfig(nIdx), &type);
-		if (type->m_szTypeExts[0] != _T('\0') ) {		/* ƒ^ƒCƒv‘®«FŠg’£qƒŠƒXƒg */
+		if (type->m_szTypeExts[0] != _T('\0') ) {		/* ã‚¿ã‚¤ãƒ—å±æ€§ï¼šæ‹¡å¼µå­ãƒªã‚¹ãƒˆ */
 			auto_sprintf( szText, _T("%ts (%ts)"),
-				type->m_szTypeName,	/* ƒ^ƒCƒv‘®«F–¼Ì */
-				type->m_szTypeExts	/* ƒ^ƒCƒv‘®«FŠg’£qƒŠƒXƒg */
+				type->m_szTypeName,	/* ã‚¿ã‚¤ãƒ—å±æ€§ï¼šåç§° */
+				type->m_szTypeExts	/* ã‚¿ã‚¤ãƒ—å±æ€§ï¼šæ‹¡å¼µå­ãƒªã‚¹ãƒˆ */
 			);
 		}
 		else{
 			auto_sprintf( szText, _T("%ts"),
-				type->m_szTypeName	/* ƒ^ƒCƒv‘®«FŠgÌ */
+				type->m_szTypeName	/* ã‚¿ã‚¤ãƒ—å±æ€§ï¼šæ‹¡ç§° */
 			);
 		}
 		::Combo_AddString( hwndCombo, szText );
 	}
-	// “ÇFİ’èƒtƒ@ƒCƒ‹İ’è
+	// èª­è¾¼è‰²è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«è¨­å®š
 	HANDLE	hFind;
 	WIN32_FIND_DATA	wf;
 	BOOL	bFind;
@@ -143,14 +143,14 @@ void CDlgTypeAscertain::SetData( void )
 		bFind;
 		bFind = FindNextFile( hFind, &wf )) {
 		if ( (wf.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-			// “ÇFİ’èƒtƒ@ƒCƒ‹”­Œ©
+			// èª­è¾¼è‰²è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ç™ºè¦‹
 			auto_sprintf( szText, _T("File -- %ts"), wf.cFileName );
 			::Combo_AddString( hwndCombo, szText );
 		}
 	}
 	FindClose( hFind );
 
-	// ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ÌƒfƒtƒHƒ‹ƒg‘I‘ğ
+	// ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆé¸æŠ
 	Combo_SetCurSel( hwndCombo, 0 );
 	return;
 }

--- a/sakura_core/typeprop/CDlgTypeAscertain.h
+++ b/sakura_core/typeprop/CDlgTypeAscertain.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒ^ƒCƒv•Êİ’èƒCƒ“ƒ|[ƒgŠm”Fƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚¤ãƒ³ãƒãƒ¼ãƒˆç¢ºèªãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Uchi
-	@date 2010/4/17 V‹Kì¬
+	@date 2010/4/17 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2010, Uchi
@@ -37,38 +37,38 @@ using std::tstring;
 
 #include "dlg/CDialog.h"
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 /*!
-	@brief ƒtƒ@ƒCƒ‹ƒ^ƒCƒvˆê——ƒ_ƒCƒAƒƒO
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«ã‚¿ã‚¤ãƒ—ä¸€è¦§ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 */
 class CDlgTypeAscertain : public CDialog
 {
 public:
-	// Œ^
+	// å‹
 	struct SAscertainInfo {
-		tstring	sImportFile;	//!< in ƒCƒ“ƒ|[ƒgƒtƒ@ƒCƒ‹–¼
-		wstring	sTypeNameTo;	//!< in ƒ^ƒCƒv–¼iƒCƒ“ƒ|[ƒgæj
-		wstring	sTypeNameFile;	//!< in ƒ^ƒCƒv–¼iƒtƒ@ƒCƒ‹‚©‚çj
-		int 	nColorType;		//!< out •¶‘í—Ş(ƒJƒ‰[ƒRƒs[—p)
-		wstring	sColorFile;		//!< out Fİ’èƒtƒ@ƒCƒ‹–¼
-		bool	bAddType;		//!< out ƒ^ƒCƒv‚ğ’Ç‰Á‚·‚é
+		tstring	sImportFile;	//!< in ã‚¤ãƒ³ãƒãƒ¼ãƒˆãƒ•ã‚¡ã‚¤ãƒ«å
+		wstring	sTypeNameTo;	//!< in ã‚¿ã‚¤ãƒ—åï¼ˆã‚¤ãƒ³ãƒãƒ¼ãƒˆå…ˆï¼‰
+		wstring	sTypeNameFile;	//!< in ã‚¿ã‚¤ãƒ—åï¼ˆãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ï¼‰
+		int 	nColorType;		//!< out æ–‡æ›¸ç¨®é¡(ã‚«ãƒ©ãƒ¼ã‚³ãƒ”ãƒ¼ç”¨)
+		wstring	sColorFile;		//!< out è‰²è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«å
+		bool	bAddType;		//!< out ã‚¿ã‚¤ãƒ—ã‚’è¿½åŠ ã™ã‚‹
 	};
 
 public:
 	//  Constructors
 	CDlgTypeAscertain();
-	// ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦
-	int DoModal( HINSTANCE, HWND, SAscertainInfo* );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	// ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º
+	int DoModal( HINSTANCE, HWND, SAscertainInfo* );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 protected:
-	// À‘•ƒwƒ‹ƒpŠÖ”
+	// å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	BOOL OnBnClicked( int );
-	void SetData();	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+	void SetData();	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 	LPVOID GetHelpIdTable(void);
 
 private:
-	SAscertainInfo* m_psi;			// ƒCƒ“ƒ^[ƒtƒFƒCƒX
+	SAscertainInfo* m_psi;			// ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ã‚¤ã‚¹
 };
 
 

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒtƒ@ƒCƒ‹ƒ^ƒCƒvˆê——ƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«ã‚¿ã‚¤ãƒ—ä¸€è¦§ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
 */
@@ -15,7 +15,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 #include "StdAfx.h"
-#include "types/CType.h" // use CDlgTypeList’è‹`
+#include "types/CType.h" // use CDlgTypeListå®šç¾©
 #include "window/CEditWnd.h"
 #include "typeprop/CDlgTypeList.h"
 #include "typeprop/CImpExpManager.h"	// 2010/4/24 Uchi
@@ -36,38 +36,38 @@ typedef std::basic_string<TCHAR> tstring;
 #define PROGID_BACKUP_NAME	(_T("SakuraEditorBackup"))
 #define ACTION_BACKUP_PATH	(_T("\\ShellBackup"))
 
-//ŠÖ”ƒvƒƒgƒ^ƒCƒv
+//é–¢æ•°ãƒ—ãƒ­ãƒˆã‚¿ã‚¤ãƒ—
 int CopyRegistry(HKEY srcRoot, const tstring& srcPath, HKEY destRoot, const tstring& destPath);
 int DeleteRegistry(HKEY root, const tstring& path);
 int RegistExt(LPCTSTR sExt, bool bDefProg);
 int UnregistExt(LPCTSTR sExt);
 int CheckExt(LPCTSTR sExt, bool *pbRMenu, bool *pbDblClick);
 
-//“à•”g—p’è”
+//å†…éƒ¨ä½¿ç”¨å®šæ•°
 static const int PROP_TEMPCHANGE_FLAG = 0x10000;
 
-// ƒ^ƒCƒv•Êİ’èˆê—— CDlgTypeList.cpp	//@@@ 2002.01.07 add start MIK
+// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šä¸€è¦§ CDlgTypeList.cpp	//@@@ 2002.01.07 add start MIK
 const DWORD p_helpids[] = {	//12700
-	IDC_BUTTON_TEMPCHANGE,	HIDC_TL_BUTTON_TEMPCHANGE,	//ˆê“K—p
-	IDOK,					HIDOK_TL,					//İ’è
-	IDCANCEL,				HIDCANCEL_TL,				//ƒLƒƒƒ“ƒZƒ‹
-	IDC_BUTTON_HELP,		HIDC_TL_BUTTON_HELP,		//ƒwƒ‹ƒv
-	IDC_LIST_TYPES,			HIDC_TL_LIST_TYPES,			//ƒŠƒXƒg
-	IDC_BUTTON_IMPORT,		HIDC_TL_BUTTON_IMPORT,		//ƒCƒ“ƒ|[ƒg
-	IDC_BUTTON_EXPORT,		HIDC_TL_BUTTON_EXPORT,		//ƒGƒNƒXƒ|[ƒg
-	IDC_BUTTON_INITIALIZE,	HIDC_TL_BUTTON_INIT,		//‰Šú‰»
-	IDC_BUTTON_COPY_TYPE,	HIDC_BUTTON_COPY_TYPE,		//•¡»
-	IDC_BUTTON_UP_TYPE,		HIDC_BUTTON_UP_TYPE,		//ª
-	IDC_BUTTON_DOWN_TYPE,	HIDC_BUTTON_DOWN_TYPE,		//«
-	IDC_BUTTON_ADD_TYPE,	HIDC_BUTTON_ADD_TYPE,		//’Ç‰Á
-	IDC_BUTTON_DEL_TYPE,	HIDC_BUTTON_DEL_TYPE,		//íœ
-	IDC_CHECK_EXT_RMENU,	HIDC_TL_CHECK_RMENU,		//‰EƒNƒŠƒbƒNƒƒjƒ…[‚É’Ç‰Á
-	IDC_CHECK_EXT_DBLCLICK,	HIDC_TL_CHECK_DBLCLICK,		//ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚ÅŠJ‚­
+	IDC_BUTTON_TEMPCHANGE,	HIDC_TL_BUTTON_TEMPCHANGE,	//ä¸€æ™‚é©ç”¨
+	IDOK,					HIDOK_TL,					//è¨­å®š
+	IDCANCEL,				HIDCANCEL_TL,				//ã‚­ãƒ£ãƒ³ã‚»ãƒ«
+	IDC_BUTTON_HELP,		HIDC_TL_BUTTON_HELP,		//ãƒ˜ãƒ«ãƒ—
+	IDC_LIST_TYPES,			HIDC_TL_LIST_TYPES,			//ãƒªã‚¹ãƒˆ
+	IDC_BUTTON_IMPORT,		HIDC_TL_BUTTON_IMPORT,		//ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	IDC_BUTTON_EXPORT,		HIDC_TL_BUTTON_EXPORT,		//ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
+	IDC_BUTTON_INITIALIZE,	HIDC_TL_BUTTON_INIT,		//åˆæœŸåŒ–
+	IDC_BUTTON_COPY_TYPE,	HIDC_BUTTON_COPY_TYPE,		//è¤‡è£½
+	IDC_BUTTON_UP_TYPE,		HIDC_BUTTON_UP_TYPE,		//â†‘
+	IDC_BUTTON_DOWN_TYPE,	HIDC_BUTTON_DOWN_TYPE,		//â†“
+	IDC_BUTTON_ADD_TYPE,	HIDC_BUTTON_ADD_TYPE,		//è¿½åŠ 
+	IDC_BUTTON_DEL_TYPE,	HIDC_BUTTON_DEL_TYPE,		//å‰Šé™¤
+	IDC_CHECK_EXT_RMENU,	HIDC_TL_CHECK_RMENU,		//å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«è¿½åŠ 
+	IDC_CHECK_EXT_DBLCLICK,	HIDC_TL_CHECK_DBLCLICK,		//ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§é–‹ã
 //	IDC_STATIC,				-1,
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
 
-/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 int CDlgTypeList::DoModal( HINSTANCE hInstance, HWND hwndParent, SResult* psResult )
 {
 	int	nRet;
@@ -79,7 +79,7 @@ int CDlgTypeList::DoModal( HINSTANCE hInstance, HWND hwndParent, SResult* psResu
 		return FALSE;
 	}
 	else{
-		//Œ‹‰Ê
+		//çµæœ
 		psResult->cDocumentType = CTypeConfig(nRet & ~PROP_TEMPCHANGE_FLAG);
 		psResult->bTempChange   = ((nRet & PROP_TEMPCHANGE_FLAG) != 0);
 		return TRUE;
@@ -92,7 +92,7 @@ BOOL CDlgTypeList::OnLbnDblclk( int wID )
 	switch( wID ){
 	case IDC_LIST_TYPES:
 		//	Nov. 29, 2000	genta
-		//	“®ì•ÏX: w’èƒ^ƒCƒv‚Ìİ’èƒ_ƒCƒAƒƒO¨ˆê“I‚É•Ê‚Ìİ’è‚ğ“K—p
+		//	å‹•ä½œå¤‰æ›´: æŒ‡å®šã‚¿ã‚¤ãƒ—ã®è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°â†’ä¸€æ™‚çš„ã«åˆ¥ã®è¨­å®šã‚’é©ç”¨
 		::EndDialog(
 			GetHwnd(),
 			List_GetCurSel( GetDlgItem( GetHwnd(), IDC_LIST_TYPES ) )
@@ -107,12 +107,12 @@ BOOL CDlgTypeList::OnBnClicked( int wID )
 {
 	switch( wID ){
 	case IDC_BUTTON_HELP:
-		/* uƒ^ƒCƒv•Êİ’èˆê——v‚Ìƒwƒ‹ƒv */
-		//Stonee, 2001/03/12 ‘ælˆø”‚ğA‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
-		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_TYPE_LIST) );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		/* ã€Œã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šä¸€è¦§ã€ã®ãƒ˜ãƒ«ãƒ— */
+		//Stonee, 2001/03/12 ç¬¬å››å¼•æ•°ã‚’ã€æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_TYPE_LIST) );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 	//	Nov. 29, 2000	From Here	genta
-	//	“K—p‚·‚éŒ^‚Ìˆê“I•ÏX
+	//	é©ç”¨ã™ã‚‹å‹ã®ä¸€æ™‚çš„å¤‰æ›´
 	case IDC_BUTTON_TEMPCHANGE:
 		::EndDialog(
 			GetHwnd(),
@@ -152,7 +152,7 @@ BOOL CDlgTypeList::OnBnClicked( int wID )
 		DelType();
 		return TRUE;
 	}
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnBnClicked( wID );
 
 }
@@ -173,7 +173,7 @@ BOOL CDlgTypeList::OnActivate( WPARAM wParam, LPARAM lParam )
 		break;
 	}
 
-	/* Šî’êƒNƒ‰ƒXƒƒ“ƒo */
+	/* åŸºåº•ã‚¯ãƒ©ã‚¹ãƒ¡ãƒ³ãƒ */
 	return CDialog::OnActivate( wParam, lParam );
 }
 
@@ -236,7 +236,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 		else if( LOWORD(wParam) == IDC_CHECK_EXT_RMENU && HIWORD(wParam) == BN_CLICKED )
 		{
 			bool checked = ( BtnCtl_GetCheck( hwndRMenu ) != FALSE ? true : false );
-			if( ! AlertFileAssociation() ){		//ƒŒƒWƒXƒgƒŠ•ÏXŠm”F
+			if( ! AlertFileAssociation() ){		//ãƒ¬ã‚¸ã‚¹ãƒˆãƒªå¤‰æ›´ç¢ºèª
 				BtnCtl_SetCheck( hwndRMenu, !checked );
 				break;
 			}
@@ -246,7 +246,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 			int nRet;
 			while( NULL != ext ){
 				if (_tcspbrk(ext, CDocTypeManager::m_typeExtWildcards) == NULL) {
-					if( checked ){	//u‰EƒNƒŠƒbƒNvƒ`ƒFƒbƒNON
+					if( checked ){	//ã€Œå³ã‚¯ãƒªãƒƒã‚¯ã€ãƒã‚§ãƒƒã‚¯ON
 						if( (nRet = RegistExt( ext, true )) != 0 )
 						{
 							TCHAR buf[BUFFER_SIZE] = {0};
@@ -254,7 +254,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 							::MessageBox( GetHwnd(), (tstring(LS(STR_DLGTYPELIST_ERR1)) + buf).c_str(), GSTR_APPNAME, MB_OK );
 							break;
 						}
-					}else{			//u‰EƒNƒŠƒbƒNvƒ`ƒFƒbƒNOFF
+					}else{			//ã€Œå³ã‚¯ãƒªãƒƒã‚¯ã€ãƒã‚§ãƒƒã‚¯OFF
 						if( (nRet = UnregistExt( ext )) != 0 )
 						{
 							TCHAR buf[BUFFER_SIZE] = {0};
@@ -275,7 +275,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 		else if( LOWORD(wParam) == IDC_CHECK_EXT_DBLCLICK && HIWORD(wParam) == BN_CLICKED )
 		{
 			bool checked = ( BtnCtl_GetCheck( hwndDblClick ) != FALSE ? true : false );
-			if( ! AlertFileAssociation() ){		//ƒŒƒWƒXƒgƒŠ•ÏXŠm”F
+			if( ! AlertFileAssociation() ){		//ãƒ¬ã‚¸ã‚¹ãƒˆãƒªå¤‰æ›´ç¢ºèª
 				BtnCtl_SetCheck( hwndDblClick, !checked );
 				break;
 			}
@@ -304,7 +304,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 }
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 void CDlgTypeList::SetData( void )
 {
 	SetData(m_nSettingType.GetIndex());
@@ -329,18 +329,18 @@ void CDlgTypeList::SetData( int selIdx )
 	if( GetDllShareData().m_nTypesCount <= selIdx ){
 		selIdx = GetDllShareData().m_nTypesCount - 1;
 	}
-	List_ResetContent( hwndList );	/* ƒŠƒXƒg‚ğ‹ó‚É‚·‚é */
+	List_ResetContent( hwndList );	/* ãƒªã‚¹ãƒˆã‚’ç©ºã«ã™ã‚‹ */
 	for( nIdx = 0; nIdx < GetDllShareData().m_nTypesCount; ++nIdx ){
 		const STypeConfigMini* type;
 		CDocTypeManager().GetTypeConfigMini(CTypeConfig(nIdx), &type);
-		if( type->m_szTypeExts[0] != _T('\0') ){		/* ƒ^ƒCƒv‘®«FŠg’£qƒŠƒXƒg */
+		if( type->m_szTypeExts[0] != _T('\0') ){		/* ã‚¿ã‚¤ãƒ—å±æ€§ï¼šæ‹¡å¼µå­ãƒªã‚¹ãƒˆ */
 			auto_sprintf( szText, _T("%ts ( %ts )"),
-				type->m_szTypeName,	/* ƒ^ƒCƒv‘®«F–¼Ì */
-				type->m_szTypeExts	/* ƒ^ƒCƒv‘®«FŠg’£qƒŠƒXƒg */
+				type->m_szTypeName,	/* ã‚¿ã‚¤ãƒ—å±æ€§ï¼šåç§° */
+				type->m_szTypeExts	/* ã‚¿ã‚¤ãƒ—å±æ€§ï¼šæ‹¡å¼µå­ãƒªã‚¹ãƒˆ */
 			);
 		}else{
 			auto_sprintf( szText, _T("%ts"),
-				type->m_szTypeName	/* ƒ^ƒCƒv‘®«FŠgÌ */
+				type->m_szTypeName	/* ã‚¿ã‚¤ãƒ—å±æ€§ï¼šæ‹¡ç§° */
 			);
 		}
 		::List_AddString( hwndList, szText );
@@ -410,14 +410,14 @@ static void SendChangeSettingType2(int nType)
 	);
 }
 
-// ƒ^ƒCƒv•Êİ’èƒCƒ“ƒ|[ƒg
+// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 //		2010/4/12 Uchi
 bool CDlgTypeList::Import()
 {
 	HWND hwndList = GetDlgItem( GetHwnd(), IDC_LIST_TYPES );
 	int nIdx = List_GetCurSel( hwndList );
 	STypeConfig type;
-	// ƒx[ƒX‚Ìƒf[ƒ^‚ÍŠî–{
+	// ãƒ™ãƒ¼ã‚¹ã®ãƒ‡ãƒ¼ã‚¿ã¯åŸºæœ¬
 	CDocTypeManager().GetTypeConfig(CTypeConfig(0), type);
 
 	CImpExpType	cImpExpType( nIdx, type, hwndList );
@@ -425,10 +425,10 @@ bool CDlgTypeList::Import()
 	CDocTypeManager().GetTypeConfigMini(CTypeConfig(nIdx), &typeMini);
 	int id = typeMini->m_id;
 
-	// ƒCƒ“ƒ|[ƒg
+	// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 	cImpExpType.SetBaseName( to_wchar( type.m_szTypeName ) );
 	if (!cImpExpType.ImportUI( G_AppInstance(), GetHwnd() )) {
-		// ƒCƒ“ƒ|[ƒg‚ğ‚µ‚Ä‚¢‚È‚¢
+		// ã‚¤ãƒ³ãƒãƒ¼ãƒˆã‚’ã—ã¦ã„ãªã„
 		return false;
 	}
 	bool bAdd = cImpExpType.IsAddType();
@@ -437,7 +437,7 @@ bool CDlgTypeList::Import()
 		nIdx = GetDllShareData().m_nTypesCount - 1;
 		type.m_nIdx = nIdx;
 	}else{
-		// UI‚ğ•\¦‚µ‚Ä‚¢‚éŠÔ‚É‚¸‚ê‚Ä‚¢‚é‚©‚à‚µ‚ê‚È‚¢‚Ì‚ÅindexÄæ“¾
+		// UIã‚’è¡¨ç¤ºã—ã¦ã„ã‚‹é–“ã«ãšã‚Œã¦ã„ã‚‹ã‹ã‚‚ã—ã‚Œãªã„ã®ã§indexå†å–å¾—
 		nIdx = CDocTypeManager().GetDocumentTypeOfId(id).GetIndex();
 		if( -1 == nIdx ){
 			return false;
@@ -445,19 +445,19 @@ bool CDlgTypeList::Import()
 		type.m_nIdx = nIdx;
 	}
 	type.m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();
-	// “K—p
+	// é©ç”¨
 	CDocTypeManager().SetTypeConfig(CTypeConfig(nIdx), type);
 	if( !bAdd ){
 		SendChangeSettingType(nIdx);
 	}
 
-	// ƒŠƒXƒgÄ‰Šú‰»
+	// ãƒªã‚¹ãƒˆå†åˆæœŸåŒ–
 	SetData(nIdx);
 
 	return true;
 }
 
-// ƒ^ƒCƒv•Êİ’èƒGƒNƒXƒ|[ƒg
+// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 //		2010/4/12 Uchi
 bool CDlgTypeList::Export()
 {
@@ -468,22 +468,22 @@ bool CDlgTypeList::Export()
 
 	CImpExpType	cImpExpType( nIdx, types, hwndList );
 
-	// ƒGƒNƒXƒ|[ƒg
+	// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 	cImpExpType.SetBaseName( to_wchar( types.m_szTypeName) );
 	if (!cImpExpType.ExportUI( G_AppInstance(), GetHwnd() )) {
-		// ƒGƒNƒXƒ|[ƒg‚ğ‚µ‚Ä‚¢‚È‚¢
+		// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã‚’ã—ã¦ã„ãªã„
 		return false;
 	}
 
 	return true;
 }
 
-/*! ƒ^ƒCƒv•Êİ’è‰Šú‰»
+/*! ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šåˆæœŸåŒ–
 	@date 2010/4/12 Uchi
-	@date 2016.03.09 Moca Šî–{‚Ì‰Šú‰»‚ğƒTƒ|[ƒgBŠî–{‚Ì‚Í“à‘ İ’è‚É–ß‚·“®ì‚É‚·‚é
+	@date 2016.03.09 Moca åŸºæœ¬ã®åˆæœŸåŒ–ã‚’ã‚µãƒãƒ¼ãƒˆã€‚åŸºæœ¬ã®æ™‚ã¯å†…è”µè¨­å®šã«æˆ»ã™å‹•ä½œã«ã™ã‚‹
 
-	@retval true  ³í
-	@retval false ˆÙí
+	@retval true  æ­£å¸¸
+	@retval false ç•°å¸¸
 */
 bool CDlgTypeList::InitializeType( void )
 {
@@ -492,7 +492,7 @@ bool CDlgTypeList::InitializeType( void )
 	int iDocType = List_GetCurSel( hwndList );
 	const STypeConfigMini* typeMini;
 	if( !CDocTypeManager().GetTypeConfigMini(CTypeConfig(iDocType), &typeMini) ){
-		// ‚È‚ñ‚©ƒGƒ‰[‚¾‚Á‚½
+		// ãªã‚“ã‹ã‚¨ãƒ©ãƒ¼ã ã£ãŸ
 		return false;
 	}
 	int			nRet;
@@ -512,12 +512,12 @@ bool CDlgTypeList::InitializeType( void )
 	if( -1 == iDocType ){
 		return false;
 	}
-//	_DefaultConfig(&types);		//‹K’è’l‚ğƒRƒs[
+//	_DefaultConfig(&types);		//è¦å®šå€¤ã‚’ã‚³ãƒ”ãƒ¼
 	std::auto_ptr<STypeConfig> type(new STypeConfig());
 	if( 0 != iDocType ){
-		CDocTypeManager().GetTypeConfig(CTypeConfig(0), *type); 	// Šî–{‚ğƒRƒs[
+		CDocTypeManager().GetTypeConfig(CTypeConfig(0), *type); 	// åŸºæœ¬ã‚’ã‚³ãƒ”ãƒ¼
 
-		// “¯‚¶–¼‘O‚É‚È‚ç‚È‚¢‚æ‚¤‚É”š‚ğ‚Â‚¯‚é
+		// åŒã˜åå‰ã«ãªã‚‰ãªã„ã‚ˆã†ã«æ•°å­—ã‚’ã¤ã‘ã‚‹
 		int nNameNum = iDocType + 1;
 		bool bUpdate = true;
 		for(int i = 1; i < GetDllShareData().m_nTypesCount; i++){
@@ -541,7 +541,7 @@ bool CDlgTypeList::InitializeType( void )
 		type->m_id = (::GetTickCount() & 0x3fffffff) + iDocType * 0x10000;
 		type->m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();
 	}else{
-		// 2016.03.09 Šî–{‚Ì‰Šú‰»
+		// 2016.03.09 åŸºæœ¬ã®åˆæœŸåŒ–
 		CType_Basis basis;
 		basis.InitTypeConfig(0, *type);
 	}
@@ -550,7 +550,7 @@ bool CDlgTypeList::InitializeType( void )
 
 	SendChangeSettingType(iDocType);
 
-	// ƒŠƒXƒgÄ‰Šú‰»
+	// ãƒªã‚¹ãƒˆå†åˆæœŸåŒ–
 	SetData(iDocType);
 
 	InfoMessage( hwndDlg, LS(STR_DLGTYPELIST_INIT2), type->m_szTypeName );
@@ -566,7 +566,7 @@ bool CDlgTypeList::CopyType()
 	int iDocType = List_GetCurSel( hwndList );
 	STypeConfig type;
 	CDocTypeManager().GetTypeConfig(CTypeConfig(iDocType), type);
-	// –¼‘O‚É2“™‚ğ•t‚¯‚é
+	// åå‰ã«2ç­‰ã‚’ä»˜ã‘ã‚‹
 	int n = 1;
 	bool bUpdate = true;
 	for(int i = 0; i < nNewTypeIndex; i++){
@@ -592,7 +592,7 @@ bool CDlgTypeList::CopyType()
 			auto_strcpy( szTemp, type.m_szTypeName );
 			int nTempLen = auto_strlen( szTemp );
 			CNativeT cmem;
-			// ƒoƒbƒtƒ@‚ğ‚Í‚İo‚³‚È‚¢‚æ‚¤‚É
+			// ãƒãƒƒãƒ•ã‚¡ã‚’ã¯ã¿å‡ºã•ãªã„ã‚ˆã†ã«
 			LimitStringLengthT( szTemp, nTempLen, _countof(type.m_szTypeName) - nLen - 1, cmem );
 			auto_strcpy( type.m_szTypeName, cmem.GetStringPtr() );
 			auto_strcat( type.m_szTypeName, szNum );
@@ -621,7 +621,7 @@ bool CDlgTypeList::UpType()
 	HWND hwndList = GetDlgItem( GetHwnd(), IDC_LIST_TYPES );
 	int iDocType = List_GetCurSel( hwndList );
 	if (iDocType == 0 ) {
-		// Šî–{‚Ìê‡‚É‚Í‰½‚à‚µ‚È‚¢
+		// åŸºæœ¬ã®å ´åˆã«ã¯ä½•ã‚‚ã—ãªã„
 		return true;
 	}
 	std::auto_ptr<STypeConfig> type1(new STypeConfig());
@@ -643,7 +643,7 @@ bool CDlgTypeList::DownType()
 	HWND hwndList = GetDlgItem( GetHwnd(), IDC_LIST_TYPES );
 	int iDocType = List_GetCurSel( hwndList );
 	if (iDocType == 0 || GetDllShareData().m_nTypesCount <= iDocType + 1 ) {
-		// Šî–{AÅŒã‚Ìê‡‚É‚Í‰½‚à‚µ‚È‚¢
+		// åŸºæœ¬ã€æœ€å¾Œã®å ´åˆã«ã¯ä½•ã‚‚ã—ãªã„
 		return true;
 	}
 	std::auto_ptr<STypeConfig> type1(new STypeConfig());
@@ -676,21 +676,21 @@ bool CDlgTypeList::DelType()
 	HWND hwndList = GetDlgItem( GetHwnd(), IDC_LIST_TYPES );
 	int iDocType = List_GetCurSel( hwndList );
 	if (iDocType == 0) {
-		// Šî–{‚Ìê‡‚É‚Í‰½‚à‚µ‚È‚¢
+		// åŸºæœ¬ã®å ´åˆã«ã¯ä½•ã‚‚ã—ãªã„
 		return true;
 	}
 	const STypeConfigMini* typeMini;
 	if( !CDocTypeManager().GetTypeConfigMini(CTypeConfig(iDocType), &typeMini) ){
-		// “ä‚ÌƒGƒ‰[
+		// è¬ã®ã‚¨ãƒ©ãƒ¼
 		return false;
 	}
-	const STypeConfigMini type = *typeMini; // ƒ_ƒCƒAƒƒO‚ğo‚µ‚Ä‚¢‚éŠÔ‚É•ÏX‚³‚ê‚é‚©‚à‚µ‚ê‚È‚¢‚Ì‚ÅƒRƒs[‚·‚é
+	const STypeConfigMini type = *typeMini; // ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’å‡ºã—ã¦ã„ã‚‹é–“ã«å¤‰æ›´ã•ã‚Œã‚‹ã‹ã‚‚ã—ã‚Œãªã„ã®ã§ã‚³ãƒ”ãƒ¼ã™ã‚‹
 	int nRet = ConfirmMessage( hwndDlg,
 		LS(STR_DLGTYPELIST_DEL), type.m_szTypeName );
 	if (nRet != IDYES) {
 		return false;
 	}
-	// ƒ_ƒCƒAƒƒO‚ğo‚µ‚Ä‚¢‚éŠÔ‚Éƒ^ƒCƒv•ÊƒŠƒXƒg‚ªXV‚³‚ê‚½‚©‚à‚µ‚ê‚È‚¢‚Ì‚Åid‚©‚çÄŒŸõ
+	// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚’å‡ºã—ã¦ã„ã‚‹é–“ã«ã‚¿ã‚¤ãƒ—åˆ¥ãƒªã‚¹ãƒˆãŒæ›´æ–°ã•ã‚ŒãŸã‹ã‚‚ã—ã‚Œãªã„ã®ã§idã‹ã‚‰å†æ¤œç´¢
 	CTypeConfig config = CDocTypeManager().GetDocumentTypeOfId(type.m_id);
 	if( !config.IsValidType() ){
 		return false;
@@ -706,7 +706,7 @@ bool CDlgTypeList::DelType()
 }
 
 
-/*! Ä‹A“IƒŒƒWƒXƒgƒŠƒRƒs[ */
+/*! å†å¸°çš„ãƒ¬ã‚¸ã‚¹ãƒˆãƒªã‚³ãƒ”ãƒ¼ */
 int CopyRegistry(HKEY srcRoot, const tstring& srcPath, HKEY destRoot, const tstring& destPath)
 {
 	int errorCode;
@@ -734,7 +734,7 @@ int CopyRegistry(HKEY srcRoot, const tstring& srcPath, HKEY destRoot, const tstr
 		}else if( errorCode ){
 			return errorCode;
 		}else{
-			// è”²‚«Fƒf[ƒ^‚ÌƒTƒCƒY‚ªBUFFER_SIZE(=1024)‚ğ’´‚¦‚éê‡‚ğl—¶‚µ‚Ä‚¢‚È‚¢
+			// æ‰‹æŠœãï¼šãƒ‡ãƒ¼ã‚¿ã®ã‚µã‚¤ã‚ºãŒBUFFER_SIZE(=1024)ã‚’è¶…ãˆã‚‹å ´åˆã‚’è€ƒæ…®ã—ã¦ã„ãªã„
 			if( (errorCode = keyDest.SetValue(szValue, data, dwDataLen, dwType)) != 0 ){ return errorCode; }
 			index++;
 		}
@@ -759,7 +759,7 @@ int CopyRegistry(HKEY srcRoot, const tstring& srcPath, HKEY destRoot, const tstr
 	return errorCode;
 }
 
-/*! Ä‹A“IƒŒƒWƒXƒgƒŠíœ */
+/*! å†å¸°çš„ãƒ¬ã‚¸ã‚¹ãƒˆãƒªå‰Šé™¤ */
 int DeleteRegistry(HKEY root, const tstring& path)
 {
 	int errorCode;
@@ -788,41 +788,41 @@ int DeleteRegistry(HKEY root, const tstring& path)
 }
 
 /*!
-	@brief Šg’£q‚²‚Æ‚ÌŠÖ˜A•t‚¯ƒŒƒWƒXƒgƒŠİ’è‚ğs‚¤
-	@param sExt	Šg’£q
-	@param bDefProg [in]Šù’èƒtƒ‰ƒOiƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Å‹N“®‚³‚¹‚é‚©j
-	ƒŒƒWƒXƒgƒŠƒAƒNƒZƒX•ûj
-	EŠÇ—ÒŒ ŒÀ‚È‚µ‚ÅÀ{‚µ‚½‚¢‚½‚ßAHKLM‚Í“Ç‚İ‚İ‚Ì‚İ‚Æ‚µA‘‚«‚İ‚ÍHKCU‚És‚¤B
-	ˆ—‚Ì—¬‚ê
-	E[HKCU\Software\Classes\.(Šg’£q)]‚Ì‘¶İƒ`ƒFƒbƒN
-		‘¶İ‚µ‚È‚¯‚ê‚Î
-		E[HKCU\Software\Classes\.(Šg’£q)]‚ğì¬B’l‚ÍuSakuraEditor_(Šg’£q)v
-	E[HKCU\Software\Classes\.(Šg’£q)]‚Ì’l‚ªuSakuraEditor_(Šg’£q)vˆÈŠO‚Ìê‡A
-		[HKCU\Software\Classes\.(Šg’£q)\SakuraEditorBackup]‚É’l‚ğƒRƒs[‚·‚é
-		’l‚ÉuSakuraEditor_(Šg’£q)v‚ğİ’è‚·‚é
-	EProgID <- [HKCR\Software\Classes\.(Šg’£q)]‚Ì’l
-	E[HKCU\Software\Classes\(ProgID)]‚Ì‘¶İƒ`ƒFƒbƒN
-		‘¶İ‚µ‚È‚¯‚ê‚Î
-		E[HKLM\Software\Classes\(HKLM‚ÌProgID)]‚Ì‘¶İƒ`ƒFƒbƒN
-		‘¶İ‚·‚ê‚Î
-			E[HKLM\Software\Classes\(ProgID)]‚Ì\‘¢‚ğ[HKCU\Software\Classes\(ProgID)]‚ÉƒRƒs[‚·‚é
-	E[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor\command]‚ğì¬B’l‚Íu"(ƒTƒNƒ‰EXEƒpƒX)" "%1"v
-	E[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor]‚Ì’l‚ğuSakura &Editorv‚Æ‚·‚é
-	EŠù’èƒtƒ‰ƒO”»’è
-		true‚È‚ç
-			E[HKCU\Software\Classes\(ProgID)\shell]‚Ì’l‚ª‹ó‚Å‚È‚¯‚ê‚Î[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor\ShellBackup]‚É‘Ş”ğ‚·‚é
-			E[HKCU\Software\Classes\(ProgID)\shell]‚Ì’l‚ğuSakuraEditorv‚Æ‚·‚é
-		false‚È‚ç
-			E[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor\ShellBackup]‚Ì‘¶İƒ`ƒFƒbƒN
-				‘¶İ‚·‚ê‚ÎA‘Ş”ğ‚µ‚½’l‚ğ[HKCU\Software\Classes\(ProgID)\shell]‚Éİ’è
-				‘¶İ‚µ‚È‚¯‚ê‚ÎA[HKCU\Software\Classes\(ProgID)\shell]‚Ì’l‚ğíœ
+	@brief æ‹¡å¼µå­ã”ã¨ã®é–¢é€£ä»˜ã‘ãƒ¬ã‚¸ã‚¹ãƒˆãƒªè¨­å®šã‚’è¡Œã†
+	@param sExt	æ‹¡å¼µå­
+	@param bDefProg [in]æ—¢å®šãƒ•ãƒ©ã‚°ï¼ˆãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§èµ·å‹•ã•ã›ã‚‹ã‹ï¼‰
+	ãƒ¬ã‚¸ã‚¹ãƒˆãƒªã‚¢ã‚¯ã‚»ã‚¹æ–¹é‡
+	ãƒ»ç®¡ç†è€…æ¨©é™ãªã—ã§å®Ÿæ–½ã—ãŸã„ãŸã‚ã€HKLMã¯èª­ã¿è¾¼ã¿ã®ã¿ã¨ã—ã€æ›¸ãè¾¼ã¿ã¯HKCUã«è¡Œã†ã€‚
+	å‡¦ç†ã®æµã‚Œ
+	ãƒ»[HKCU\Software\Classes\.(æ‹¡å¼µå­)]ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
+		å­˜åœ¨ã—ãªã‘ã‚Œã°
+		ãƒ»[HKCU\Software\Classes\.(æ‹¡å¼µå­)]ã‚’ä½œæˆã€‚å€¤ã¯ã€ŒSakuraEditor_(æ‹¡å¼µå­)ã€
+	ãƒ»[HKCU\Software\Classes\.(æ‹¡å¼µå­)]ã®å€¤ãŒã€ŒSakuraEditor_(æ‹¡å¼µå­)ã€ä»¥å¤–ã®å ´åˆã€
+		[HKCU\Software\Classes\.(æ‹¡å¼µå­)\SakuraEditorBackup]ã«å€¤ã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹
+		å€¤ã«ã€ŒSakuraEditor_(æ‹¡å¼µå­)ã€ã‚’è¨­å®šã™ã‚‹
+	ãƒ»ProgID <- [HKCR\Software\Classes\.(æ‹¡å¼µå­)]ã®å€¤
+	ãƒ»[HKCU\Software\Classes\(ProgID)]ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
+		å­˜åœ¨ã—ãªã‘ã‚Œã°
+		ãƒ»[HKLM\Software\Classes\(HKLMã®ProgID)]ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
+		å­˜åœ¨ã™ã‚Œã°
+			ãƒ»[HKLM\Software\Classes\(ProgID)]ã®æ§‹é€ ã‚’[HKCU\Software\Classes\(ProgID)]ã«ã‚³ãƒ”ãƒ¼ã™ã‚‹
+	ãƒ»[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor\command]ã‚’ä½œæˆã€‚å€¤ã¯ã€Œ"(ã‚µã‚¯ãƒ©EXEãƒ‘ã‚¹)" "%1"ã€
+	ãƒ»[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor]ã®å€¤ã‚’ã€ŒSakura &Editorã€ã¨ã™ã‚‹
+	ãƒ»æ—¢å®šãƒ•ãƒ©ã‚°åˆ¤å®š
+		trueãªã‚‰
+			ãƒ»[HKCU\Software\Classes\(ProgID)\shell]ã®å€¤ãŒç©ºã§ãªã‘ã‚Œã°[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor\ShellBackup]ã«é€€é¿ã™ã‚‹
+			ãƒ»[HKCU\Software\Classes\(ProgID)\shell]ã®å€¤ã‚’ã€ŒSakuraEditorã€ã¨ã™ã‚‹
+		falseãªã‚‰
+			ãƒ»[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor\ShellBackup]ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
+				å­˜åœ¨ã™ã‚Œã°ã€é€€é¿ã—ãŸå€¤ã‚’[HKCU\Software\Classes\(ProgID)\shell]ã«è¨­å®š
+				å­˜åœ¨ã—ãªã‘ã‚Œã°ã€[HKCU\Software\Classes\(ProgID)\shell]ã®å€¤ã‚’å‰Šé™¤
 */
 int RegistExt(LPCTSTR sExt, bool bDefProg)
 {
 	int errorCode = ERROR_SUCCESS;
 	tstring sBasePath = tstring( _T("Software\\Classes\\") );
 
-	//¬•¶š‰»
+	//å°æ–‡å­—åŒ–
 	TCHAR szLowerExt[MAX_PATH] = {0};
 	_tcsncpy_s(szLowerExt, sizeof(szLowerExt) / sizeof(szLowerExt[0]), sExt, _tcslen(sExt));
 	CharLower(szLowerExt);
@@ -922,27 +922,27 @@ int RegistExt(LPCTSTR sExt, bool bDefProg)
 }
 
 /*!
-	@brief Šg’£q‚²‚Æ‚ÌŠÖ˜A•t‚¯ƒŒƒWƒXƒgƒŠİ’è‚ğíœ‚·‚é
-	@param sExt	[in]Šg’£q
-	ˆ—‚Ì—¬‚ê
-	E[HKCU\Software\Classes\.(Šg’£q)]‚Ì‘¶İƒ`ƒFƒbƒN
-		‘¶İ‚µ‚È‚¯‚ê‚ÎI—¹
-	EProgID <- [HKCU\Software\Classes\.(Šg’£q)]‚Ì’l
-	E[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor]‚Ì‘¶İƒ`ƒFƒbƒN
-		‘¶İ‚µ‚È‚¯‚ê‚ÎI—¹
-	E[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor\ShellBackup]‚Ì‘¶İƒ`ƒFƒbƒN
-		‘¶İ‚·‚ê‚ÎA‘Ş”ğ‚µ‚½’l‚ğ[HKCU\Software\Classes\(ProgID)\shell]‚Éİ’è
-		‘¶İ‚µ‚È‚¯‚ê‚ÎA[HKCU\Software\Classes\(ProgID)\shell]‚Ì’l‚ğíœ
-	EProgID‚Ìæ“ª‚ª"SakuraEditor_"‚©H
-		‚»‚¤‚È‚ç[HKCU\Software\Classes\(ProgID)]‚Æ[HKCU\Software\Classes\.(Šg’£q)]‚ğíœ
-	@@‚»‚¤‚Å‚È‚¯‚ê‚Î[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor]‚ğíœ
+	@brief æ‹¡å¼µå­ã”ã¨ã®é–¢é€£ä»˜ã‘ãƒ¬ã‚¸ã‚¹ãƒˆãƒªè¨­å®šã‚’å‰Šé™¤ã™ã‚‹
+	@param sExt	[in]æ‹¡å¼µå­
+	å‡¦ç†ã®æµã‚Œ
+	ãƒ»[HKCU\Software\Classes\.(æ‹¡å¼µå­)]ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
+		å­˜åœ¨ã—ãªã‘ã‚Œã°çµ‚äº†
+	ãƒ»ProgID <- [HKCU\Software\Classes\.(æ‹¡å¼µå­)]ã®å€¤
+	ãƒ»[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor]ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
+		å­˜åœ¨ã—ãªã‘ã‚Œã°çµ‚äº†
+	ãƒ»[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor\ShellBackup]ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
+		å­˜åœ¨ã™ã‚Œã°ã€é€€é¿ã—ãŸå€¤ã‚’[HKCU\Software\Classes\(ProgID)\shell]ã«è¨­å®š
+		å­˜åœ¨ã—ãªã‘ã‚Œã°ã€[HKCU\Software\Classes\(ProgID)\shell]ã®å€¤ã‚’å‰Šé™¤
+	ãƒ»ProgIDã®å…ˆé ­ãŒ"SakuraEditor_"ã‹ï¼Ÿ
+		ãã†ãªã‚‰[HKCU\Software\Classes\(ProgID)]ã¨[HKCU\Software\Classes\.(æ‹¡å¼µå­)]ã‚’å‰Šé™¤
+	ã€€ã€€ãã†ã§ãªã‘ã‚Œã°[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor]ã‚’å‰Šé™¤
 */
 int UnregistExt(LPCTSTR sExt)
 {
 	int errorCode = ERROR_SUCCESS;
 	tstring sBasePath = tstring( _T("Software\\Classes\\") );
 
-	//¬•¶š‰»
+	//å°æ–‡å­—åŒ–
 	TCHAR szLowerExt[MAX_PATH] = {0};
 	_tcsncpy_s(szLowerExt, sizeof(szLowerExt) / sizeof(szLowerExt[0]), sExt, _tcslen(sExt));
 	CharLower(szLowerExt);
@@ -1011,20 +1011,20 @@ int UnregistExt(LPCTSTR sExt)
 }
 
 /*!
-	@brief Šg’£q‚²‚Æ‚ÌŠÖ˜A•t‚¯ƒŒƒWƒXƒgƒŠİ’è‚ğŠm”F‚·‚é
-	@param sExt			[in]Šg’£q
-	@param pbRMenu		[out]ŠÖ˜A•t‚¯İ’è
-	@param pbDblClick	[out]Šù’èİ’è
-	ˆ—‚Ì—¬‚ê
-	EpbRMenu <- false, pbDblClick <- false
-	E[HKCU\Software\Classes\.(Šg’£q)]‚Ì‘¶İƒ`ƒFƒbƒN
-		‘¶İ‚µ‚È‚¯‚ê‚ÎI—¹
-	EProgID <- [HKCU\Software\Classes\.(Šg’£q)]‚Ì’l
-	E[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor]‚Ì‘¶İƒ`ƒFƒbƒN
-		‘¶İ‚µ‚È‚¯‚ê‚ÎI—¹
-	EpbRMenu <- true
-	E[HKCU\Software\Classes\(ProgID)\shell]‚Ì’l‚ğƒ`ƒFƒbƒN
-		uSakuraEditorv‚È‚çApbDblClick <- true
+	@brief æ‹¡å¼µå­ã”ã¨ã®é–¢é€£ä»˜ã‘ãƒ¬ã‚¸ã‚¹ãƒˆãƒªè¨­å®šã‚’ç¢ºèªã™ã‚‹
+	@param sExt			[in]æ‹¡å¼µå­
+	@param pbRMenu		[out]é–¢é€£ä»˜ã‘è¨­å®š
+	@param pbDblClick	[out]æ—¢å®šè¨­å®š
+	å‡¦ç†ã®æµã‚Œ
+	ãƒ»pbRMenu <- false, pbDblClick <- false
+	ãƒ»[HKCU\Software\Classes\.(æ‹¡å¼µå­)]ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
+		å­˜åœ¨ã—ãªã‘ã‚Œã°çµ‚äº†
+	ãƒ»ProgID <- [HKCU\Software\Classes\.(æ‹¡å¼µå­)]ã®å€¤
+	ãƒ»[HKCU\Software\Classes\(ProgID)\shell\SakuraEditor]ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
+		å­˜åœ¨ã—ãªã‘ã‚Œã°çµ‚äº†
+	ãƒ»pbRMenu <- true
+	ãƒ»[HKCU\Software\Classes\(ProgID)\shell]ã®å€¤ã‚’ãƒã‚§ãƒƒã‚¯
+		ã€ŒSakuraEditorã€ãªã‚‰ã€pbDblClick <- true
 */
 int CheckExt(LPCTSTR sExt, bool *pbRMenu, bool *pbDblClick)
 {
@@ -1034,7 +1034,7 @@ int CheckExt(LPCTSTR sExt, bool *pbRMenu, bool *pbDblClick)
 	*pbRMenu = false;
 	*pbDblClick = false;
 
-	//¬•¶š‰»
+	//å°æ–‡å­—åŒ–
 	TCHAR szLowerExt[MAX_PATH] = {0};
 	_tcsncpy_s(szLowerExt, sizeof(szLowerExt) / sizeof(szLowerExt[0]), sExt, _tcslen(sExt));
 	CharLower(szLowerExt);
@@ -1077,7 +1077,7 @@ int CheckExt(LPCTSTR sExt, bool *pbRMenu, bool *pbDblClick)
 }
 
 /*!
-	@brief ƒŒƒWƒXƒgƒŠ•ÏX‚ÌŒxƒƒbƒZ[ƒW‚ğ•\¦‚·‚é
+	@brief ãƒ¬ã‚¸ã‚¹ãƒˆãƒªå¤‰æ›´ã®è­¦å‘Šãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤ºã™ã‚‹
 */
 bool CDlgTypeList::AlertFileAssociation()
 {
@@ -1088,7 +1088,7 @@ bool CDlgTypeList::AlertFileAssociation()
 						LS(STR_DLGTYPELIST_ACC))
 					)
 		{
-			m_bAlertFileAssociation = false;	//u‚Í‚¢v‚È‚çÅ‰‚Ìˆê“x‚¾‚¯Šm”F‚·‚é
+			m_bAlertFileAssociation = false;	//ã€Œã¯ã„ã€ãªã‚‰æœ€åˆã®ä¸€åº¦ã ã‘ç¢ºèªã™ã‚‹
 			return true;
 		}else{
 			return false;

--- a/sakura_core/typeprop/CDlgTypeList.h
+++ b/sakura_core/typeprop/CDlgTypeList.h
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ƒtƒ@ƒCƒ‹ƒ^ƒCƒvˆê——ƒ_ƒCƒAƒƒO
+ï»¿/*!	@file
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«ã‚¿ã‚¤ãƒ—ä¸€è¦§ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 
 	@author Norio Nakatani
-	@date 1998/12/23 V‹Kì¬
-	@date 1999/12/05 Äì¬
+	@date 1998/12/23 æ–°è¦ä½œæˆ
+	@date 1999/12/05 å†ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -21,32 +21,32 @@ class CDlgTypeList;
 using std::wstring;
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 /*!
-	@brief ƒtƒ@ƒCƒ‹ƒ^ƒCƒvˆê——ƒ_ƒCƒAƒƒO
+	@brief ãƒ•ã‚¡ã‚¤ãƒ«ã‚¿ã‚¤ãƒ—ä¸€è¦§ãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 */
 class CDlgTypeList : public CDialog
 {
 public:
-	// Œ^
+	// å‹
 	struct SResult{
-		CTypeConfig	cDocumentType;	//!< •¶‘í—Ş
-		bool			bTempChange;	//!< ‹ŒPROP_TEMPCHANGE_FLAG
+		CTypeConfig	cDocumentType;	//!< æ–‡æ›¸ç¨®é¡
+		bool			bTempChange;	//!< æ—§PROP_TEMPCHANGE_FLAG
 	};
 
 public:
-	// ƒCƒ“ƒ^[ƒtƒF[ƒX
-	int DoModal( HINSTANCE, HWND, SResult* );	/* ƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚Ì•\¦ */
+	// ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
+	int DoModal( HINSTANCE, HWND, SResult* );	/* ãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®è¡¨ç¤º */
 
 protected:
-	// À‘•ƒwƒ‹ƒpŠÖ”
+	// å®Ÿè£…ãƒ˜ãƒ«ãƒ‘é–¢æ•°
 	BOOL OnLbnDblclk( int );
 	BOOL OnBnClicked( int );
 	BOOL OnActivate( WPARAM wParam, LPARAM lParam );
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );
-	void SetData();	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
-	void SetData(int);	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è */
+	void SetData();	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
+	void SetData(int);	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š */
 	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
 	bool Import( void );			// 2010/4/12 Uchi
 	bool Export( void );			// 2010/4/12 Uchi
@@ -60,12 +60,12 @@ protected:
 
 private:
 	CTypeConfig				m_nSettingType;
-	// ŠÖ˜A•t‚¯ó‘Ô
-	bool m_bRegistryChecked[ MAX_TYPES ];	//ƒŒƒWƒXƒgƒŠŠm”F –¢^Ï
-	bool m_bExtRMenu[ MAX_TYPES ];			//‰EƒNƒŠƒbƒN“o˜^ –¢^Ï
-	bool m_bExtDblClick[ MAX_TYPES ];		//ƒ_ƒuƒ‹ƒNƒŠƒbƒN –¢^Ï
-	bool m_bAlertFileAssociation;			//ŠÖ˜A•t‚¯Œx‚Ì•\¦ƒtƒ‰ƒO
-	bool m_bEnableTempChange;				//ˆê“K—p‚Ì—LŒø‰»
+	// é–¢é€£ä»˜ã‘çŠ¶æ…‹
+	bool m_bRegistryChecked[ MAX_TYPES ];	//ãƒ¬ã‚¸ã‚¹ãƒˆãƒªç¢ºèª æœªï¼æ¸ˆ
+	bool m_bExtRMenu[ MAX_TYPES ];			//å³ã‚¯ãƒªãƒƒã‚¯ç™»éŒ² æœªï¼æ¸ˆ
+	bool m_bExtDblClick[ MAX_TYPES ];		//ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ æœªï¼æ¸ˆ
+	bool m_bAlertFileAssociation;			//é–¢é€£ä»˜ã‘è­¦å‘Šã®è¡¨ç¤ºãƒ•ãƒ©ã‚°
+	bool m_bEnableTempChange;				//ä¸€æ™‚é©ç”¨ã®æœ‰åŠ¹åŒ–
 };
 
 

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒCƒ“ƒ|[ƒgAƒGƒNƒXƒ|[ƒgƒ}ƒl[ƒWƒƒ
+ï»¿/*!	@file
+	@brief ã‚¤ãƒ³ãƒãƒ¼ãƒˆã€ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆãƒãƒãƒ¼ã‚¸ãƒ£
 
 	@author Uchi
-	@date 2010/4/22 V‹Kì¬
+	@date 2010/4/22 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2010, Uchi, Moca
@@ -41,12 +41,12 @@
 #include "util/other_util.h"
 
 /*-----------------------------------------------------------------------
-’è”
+å®šæ•°
 -----------------------------------------------------------------------*/
 static const wchar_t	szSecInfo[]				= L"Info";
 
-// ƒ^ƒCƒv•Êİ’è
-static const wchar_t	WSTR_TYPE_HEAD[]		= L" ƒ^ƒCƒv•Êİ’è Ver1";
+// ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š
+static const wchar_t	WSTR_TYPE_HEAD[]		= L" ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š Ver1";
 
 static const wchar_t	szSecTypeEx[]			= L"TypeEx";
 static const wchar_t	szSecTypes[]			= L"Types";
@@ -61,41 +61,41 @@ static const wchar_t	szKeyPluginSmartIndentId[]		= L"szPluginSmartIndentId";
 static const wchar_t	szKeyVersion[]					= L"szVersion";
 static const wchar_t	szKeyStructureVersion[]			= L"vStructureVersion";
 
-// ƒJƒ‰[i CPropTypes.h‚©‚çƒRƒs[‰ü•Ï j
-//static const wchar_t	WSTR_COLORDATA_HEAD2[]	=  L" ƒeƒLƒXƒgƒGƒfƒBƒ^Fİ’è Ver2";
-//static const wchar_t	WSTR_COLORDATA_HEAD21[]	=  L" ƒeƒLƒXƒgƒGƒfƒBƒ^Fİ’è Ver2.1";	//Nov. 2, 2000 JEPRO •ÏX [’]. 0.3.9.0:ur3ƒÀ10ˆÈ~Aİ’è€–Ú‚Ì”Ô†‚ğ“ü‚ê‘Ö‚¦‚½‚½‚ß
-static const wchar_t	WSTR_COLORDATA_HEAD3[]	=  L" ƒeƒLƒXƒgƒGƒfƒBƒ^Fİ’è Ver3";		//Jan. 15, 2001 Stonee  Fİ’èVer3ƒhƒ‰ƒtƒg(İ’èƒtƒ@ƒCƒ‹‚ÌƒL[‚ğ˜A”Ô¨•¶š—ñ‚É)	//Feb. 11, 2001 JEPRO —LŒø‚É‚µ‚½
-//static const wchar_t	WSTR_COLORDATA_HEAD4[]	=  L" ƒeƒLƒXƒgƒGƒfƒBƒ^Fİ’è Ver4";		//2007.10.02 kobake UNICODE‰»‚ÉÛ‚µ‚ÄƒJƒ‰[ƒtƒ@ƒCƒ‹d—l‚à•ÏX
+// ã‚«ãƒ©ãƒ¼ï¼ˆ CPropTypes.hã‹ã‚‰ã‚³ãƒ”ãƒ¼æ”¹å¤‰ ï¼‰
+//static const wchar_t	WSTR_COLORDATA_HEAD2[]	=  L" ãƒ†ã‚­ã‚¹ãƒˆã‚¨ãƒ‡ã‚£ã‚¿è‰²è¨­å®š Ver2";
+//static const wchar_t	WSTR_COLORDATA_HEAD21[]	=  L" ãƒ†ã‚­ã‚¹ãƒˆã‚¨ãƒ‡ã‚£ã‚¿è‰²è¨­å®š Ver2.1";	//Nov. 2, 2000 JEPRO å¤‰æ›´ [æ³¨]. 0.3.9.0:ur3Î²10ä»¥é™ã€è¨­å®šé …ç›®ã®ç•ªå·ã‚’å…¥ã‚Œæ›¿ãˆãŸãŸã‚
+static const wchar_t	WSTR_COLORDATA_HEAD3[]	=  L" ãƒ†ã‚­ã‚¹ãƒˆã‚¨ãƒ‡ã‚£ã‚¿è‰²è¨­å®š Ver3";		//Jan. 15, 2001 Stonee  è‰²è¨­å®šVer3ãƒ‰ãƒ©ãƒ•ãƒˆ(è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚­ãƒ¼ã‚’é€£ç•ªâ†’æ–‡å­—åˆ—ã«)	//Feb. 11, 2001 JEPRO æœ‰åŠ¹ã«ã—ãŸ
+//static const wchar_t	WSTR_COLORDATA_HEAD4[]	=  L" ãƒ†ã‚­ã‚¹ãƒˆã‚¨ãƒ‡ã‚£ã‚¿è‰²è¨­å®š Ver4";		//2007.10.02 kobake UNICODEåŒ–ã«éš›ã—ã¦ã‚«ãƒ©ãƒ¼ãƒ•ã‚¡ã‚¤ãƒ«ä»•æ§˜ã‚‚å¤‰æ›´
 static const wchar_t	szSecColor[]			=  L"SakuraColor";
 
-// ³‹K•\Œ»ƒL[ƒ[ƒh
-static const wchar_t	WSTR_REGEXKW_HEAD[]		= L"// ³‹K•\Œ»ƒL[ƒ[ƒh Ver1\n";
+// æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+static const wchar_t	WSTR_REGEXKW_HEAD[]		= L"// æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ Ver1\n";
 
-// ƒL[ƒ[ƒhƒwƒ‹ƒv
-static const wchar_t	WSTR_KEYHELP_HEAD[]		= L"// ƒL[ƒ[ƒh«‘İ’è Ver1\n";
+// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—
+static const wchar_t	WSTR_KEYHELP_HEAD[]		= L"// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾æ›¸è¨­å®š Ver1\n";
 
-// ƒL[Š„‚è“–‚Ä
-static const wchar_t	WSTR_KEYBIND_HEAD4[]		= L"SakuraKeyBind_Ver4";	//2013.12.05 syat ‘½Œ¾Œê‘Î‰
-static const wchar_t	WSTR_KEYBIND_HEAD3[]	= L"SakuraKeyBind_Ver3";	//2007.10.05 kobake ƒtƒ@ƒCƒ‹Œ`®‚ğiniŒ`®‚É•ÏX
-static const wchar_t	WSTR_KEYBIND_HEAD2[]	= L"// ƒeƒLƒXƒgƒGƒfƒBƒ^ƒL[İ’è Ver2";	// (‹Œƒo[ƒWƒ‡ƒ“(ANSI”Å)j “Ç‚İ‚İ‚Ì‚İ‘Î‰ 2008/5/3 by Uchi
+// ã‚­ãƒ¼å‰²ã‚Šå½“ã¦
+static const wchar_t	WSTR_KEYBIND_HEAD4[]		= L"SakuraKeyBind_Ver4";	//2013.12.05 syat å¤šè¨€èªå¯¾å¿œ
+static const wchar_t	WSTR_KEYBIND_HEAD3[]	= L"SakuraKeyBind_Ver3";	//2007.10.05 kobake ãƒ•ã‚¡ã‚¤ãƒ«å½¢å¼ã‚’iniå½¢å¼ã«å¤‰æ›´
+static const wchar_t	WSTR_KEYBIND_HEAD2[]	= L"// ãƒ†ã‚­ã‚¹ãƒˆã‚¨ãƒ‡ã‚£ã‚¿ã‚­ãƒ¼è¨­å®š Ver2";	// (æ—§ãƒãƒ¼ã‚¸ãƒ§ãƒ³(ANSIç‰ˆ)ï¼‰ èª­ã¿è¾¼ã¿ã®ã¿å¯¾å¿œ 2008/5/3 by Uchi
 
-// ƒJƒXƒ^ƒ€ƒƒjƒ…[ƒtƒ@ƒCƒ‹
-// 2007.10.02 kobake UNICODE‰»‚ÉÛ‚µ‚ÄAƒJƒXƒ^ƒ€ƒƒjƒ…[ƒtƒ@ƒCƒ‹‚Ìd—l‚ğ•ÏX
+// ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒ•ã‚¡ã‚¤ãƒ«
+// 2007.10.02 kobake UNICODEåŒ–ã«éš›ã—ã¦ã€ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒ•ã‚¡ã‚¤ãƒ«ã®ä»•æ§˜ã‚’å¤‰æ›´
 static       wchar_t	WSTR_CUSTMENU_HEAD_V2[]	= L"SakuraEditorMenu_Ver2";
 
-// ƒL[ƒ[ƒh’è‹`ƒtƒ@ƒCƒ‹
-static const wchar_t	WSTR_KEYWORD_HEAD[]		= L" ƒL[ƒ[ƒh’è‹`ƒtƒ@ƒCƒ‹\n";
+// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«
+static const wchar_t	WSTR_KEYWORD_HEAD[]		= L" ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«\n";
 static const wchar_t	WSTR_KEYWORD_CASE[]		= L"// CASE=";
 static const wchar_t	WSTR_CASE_TRUE[]		= L"// CASE=True";
 static const wchar_t	WSTR_CASE_FALSE[]		= L"// CASE=False";
 
-// ƒƒCƒ“ƒƒjƒ…[ƒtƒ@ƒCƒ‹
+// ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒ•ã‚¡ã‚¤ãƒ«
 static       wchar_t	WSTR_MAINMENU_HEAD_V1[]	= L"SakuraEditorMainMenu Ver1";
 
 static       wchar_t	WSTR_FILETREE_HEAD_V1[]	= L"SakuraEditorFileTree_Ver1";
 
-// Exportƒtƒ@ƒCƒ‹–¼‚Ìì¬
-//	  ƒ^ƒCƒv–¼‚È‚Çƒtƒ@ƒCƒ‹‚Æ‚µ‚Äˆµ‚¤‚±‚Æ‚ğl‚¦‚Ä‚¢‚È‚¢•¶š—ñ‚ğˆµ‚¤
+// Exportãƒ•ã‚¡ã‚¤ãƒ«åã®ä½œæˆ
+//	  ã‚¿ã‚¤ãƒ—åãªã©ãƒ•ã‚¡ã‚¤ãƒ«ã¨ã—ã¦æ‰±ã†ã“ã¨ã‚’è€ƒãˆã¦ã„ãªã„æ–‡å­—åˆ—ã‚’æ‰±ã†
 //		2010/4/12 Uchi
 static wchar_t* MakeExportFileName(wchar_t* res, const wchar_t* trg, const wchar_t* ext)
 {
@@ -106,29 +106,29 @@ static wchar_t* MakeExportFileName(wchar_t* res, const wchar_t* trg, const wchar
 
 	p = conv;
 	while ( (p = wcspbrk( p, L"\t\\:*?\"<>|" )) != NULL ) {
-		// ƒtƒ@ƒCƒ‹–¼‚Ég‚¦‚È‚¢•¶š‚ğ _ ‚É’u‚«Š·‚¦‚é
+		// ãƒ•ã‚¡ã‚¤ãƒ«åã«ä½¿ãˆãªã„æ–‡å­—ã‚’ _ ã«ç½®ãæ›ãˆã‚‹
 		*p++ = L'_';
 	}
 	p = conv;
 	while ( (p = wcspbrk( p, L"/" )) != NULL ) {
-		// ƒtƒ@ƒCƒ‹–¼‚Ég‚¦‚È‚¢•¶š‚ğ ^ ‚É’u‚«Š·‚¦‚é
-		*p++ = L'^';
+		// ãƒ•ã‚¡ã‚¤ãƒ«åã«ä½¿ãˆãªã„æ–‡å­—ã‚’ ï¼ ã«ç½®ãæ›ãˆã‚‹
+		*p++ = L'ï¼';
 	}
 	auto_sprintf_s(res, _MAX_PATH, L"%ls.%ls", conv, ext);
 
 	return res;
 }
 
-// ƒCƒ“ƒ|[ƒg ƒtƒ@ƒCƒ‹w’è•t‚«
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ ãƒ•ã‚¡ã‚¤ãƒ«æŒ‡å®šä»˜ã
 bool CImpExpManager::ImportUI( HINSTANCE hInstance, HWND hwndParent )
 {
-	/* ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“ƒ_ƒCƒAƒƒO‚Ì‰Šú‰» */
+	/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸåŒ– */
 	CDlgOpenFile	cDlgOpenFile;
 	cDlgOpenFile.Create(
 		hInstance,
 		hwndParent,
 		GetDefaultExtension(),
-		GetDllShareData().m_sHistory.m_szIMPORTFOLDER // ƒCƒ“ƒ|[ƒg—pƒtƒHƒ‹ƒ_
+		GetDllShareData().m_sHistory.m_szIMPORTFOLDER // ã‚¤ãƒ³ãƒãƒ¼ãƒˆç”¨ãƒ•ã‚©ãƒ«ãƒ€
 	);
 	TCHAR	szPath[_MAX_PATH + 1];
 	szPath[0] = _T('\0');
@@ -142,7 +142,7 @@ bool CImpExpManager::ImportUI( HINSTANCE hInstance, HWND hwndParent )
 	const wstring	sPath = to_wchar(szPath);
 	wstring	sErrMsg;
 
-	// Šm”F
+	// ç¢ºèª
 	if (!ImportAscertain( hInstance, hwndParent, sPath, sErrMsg )) {
 		if (sErrMsg.length() > 0) {
 			ErrorMessage( hwndParent, _T("%ls"), sErrMsg.c_str() );
@@ -150,7 +150,7 @@ bool CImpExpManager::ImportUI( HINSTANCE hInstance, HWND hwndParent )
 		return false;
 	}
 
-	// Import Folder‚Ìİ’è
+	// Import Folderã®è¨­å®š
 	SetImportFolder( szPath );
 
 	// Import
@@ -166,16 +166,16 @@ bool CImpExpManager::ImportUI( HINSTANCE hInstance, HWND hwndParent )
 	return true;
 }
 
-// ƒGƒNƒXƒ|[ƒg ƒtƒ@ƒCƒ‹w’è•t‚«
+// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ ãƒ•ã‚¡ã‚¤ãƒ«æŒ‡å®šä»˜ã
 bool CImpExpManager::ExportUI( HINSTANCE hInstance, HWND hwndParent )
 {
-	/* ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“ƒ_ƒCƒAƒƒO‚Ì‰Šú‰» */
+	/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸåŒ– */
 	CDlgOpenFile	cDlgOpenFile;
 	cDlgOpenFile.Create(
 		hInstance,
 		hwndParent,
 		GetDefaultExtension(),
-		GetDllShareData().m_sHistory.m_szIMPORTFOLDER // ƒCƒ“ƒ|[ƒg—pƒtƒHƒ‹ƒ_
+		GetDllShareData().m_sHistory.m_szIMPORTFOLDER // ã‚¤ãƒ³ãƒãƒ¼ãƒˆç”¨ãƒ•ã‚©ãƒ«ãƒ€
 	);
 	TCHAR			szPath[_MAX_PATH + 1];
 	szPath[0] = _T('\0');
@@ -186,7 +186,7 @@ bool CImpExpManager::ExportUI( HINSTANCE hInstance, HWND hwndParent )
 		return false;
 	}
 
-	// Import Folder‚Ìİ’è
+	// Import Folderã®è¨­å®š
 	SetImportFolder( szPath );
 
 	// Export
@@ -206,13 +206,13 @@ bool CImpExpManager::ExportUI( HINSTANCE hInstance, HWND hwndParent )
 	return true;
 }
 
-// ƒCƒ“ƒ|[ƒgŠm”F
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆç¢ºèª
 bool CImpExpManager::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const wstring& sFileName, wstring& sErrMsg )
 {
 	return true;
 }
 
-// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 const TCHAR* CImpExpManager::GetDefaultExtension()
 {
 	return _T("");
@@ -222,7 +222,7 @@ const wchar_t* CImpExpManager::GetOriginExtension()
 	return L"";
 }
 
-// ƒtƒ@ƒCƒ‹–¼‚Ì‰Šú’l‚ğİ’è
+// ãƒ•ã‚¡ã‚¤ãƒ«åã®åˆæœŸå€¤ã‚’è¨­å®š
 void CImpExpManager::SetBaseName(const wstring& sBase)
 {
 	wchar_t		wbuff[_MAX_PATH + 1];
@@ -232,9 +232,9 @@ void CImpExpManager::SetBaseName(const wstring& sBase)
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒ^ƒCƒv•Êİ’è                       //
+//                          ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-// ƒCƒ“ƒ|[ƒgŠm”F
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆç¢ºèª
 bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring	sPath = to_tchar( sFileName.c_str() );
@@ -242,7 +242,7 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 	m_cProfile.SetReadingMode();
 
 	if (!m_cProfile.ReadProfile( sPath.c_str() )) {
-		/* İ’èƒtƒ@ƒCƒ‹‚ª‘¶İ‚µ‚È‚¢ */
+		/* è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã—ãªã„ */
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
 		return false;
 	}
@@ -265,13 +265,13 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 		}
 	}
 
-	// Šm”F•Fw’è
+	// ç¢ºèªï¼†è‰²æŒ‡å®š
 	CDlgTypeAscertain::SAscertainInfo	sAscertainInfo;
 	CDlgTypeAscertain	cDlgTypeAscertain;
 	wchar_t wszLabel[1024];
 	STypeConfig TmpType;
 
-	// ƒpƒ‰ƒ[ƒ^‚Ìİ’è
+	// ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®è¨­å®š
 	sAscertainInfo.sImportFile = sPath;
 	List_GetText( m_hwndList, m_nIdx, wszLabel );
 	sAscertainInfo.sTypeNameTo = wszLabel;
@@ -279,7 +279,7 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 	m_cProfile.IOProfileData( szSecTypes, L"szTypeName", MakeStringBufferW( wszLabel ));
 	sAscertainInfo.sTypeNameFile = wszLabel;
 
-	// Šm”F
+	// ç¢ºèª
 	if (!cDlgTypeAscertain.DoModal( hInstance, hwndParent, &sAscertainInfo )) {
 		return false;
 	}
@@ -291,59 +291,59 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 	return true;
 }
 
-// ƒCƒ“ƒ|[ƒg
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	wstring	files = L"";
 	wstring TmpMsg;
-	ColorInfo	colorInfoArr[_countof(m_Types.m_ColorInfoArr)];				// Fİ’è”z—ñ(ƒoƒbƒNƒAƒbƒv)
+	ColorInfo	colorInfoArr[_countof(m_Types.m_ColorInfoArr)];				// è‰²è¨­å®šé…åˆ—(ãƒãƒƒã‚¯ã‚¢ãƒƒãƒ—)
 	int		i;
 
-	// F‚Ì•ÏX
+	// è‰²ã®å¤‰æ›´
 	if (m_nColorType >= MAX_TYPES) {
-		// Fİ’èƒCƒ“ƒ|[ƒg
+		// è‰²è¨­å®šã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 		CImpExpColors	cImpExpColors( colorInfoArr );
 		if (cImpExpColors.Import( cImpExpColors.MakeFullPath( m_sColorFile ), TmpMsg)) {
 			files += wstring(L"\n") + m_sColorFile;
 		}
 		else {
-			// ¸”s‚µ‚½‚çŠî–{‚ğƒRƒs[(ƒƒbƒZ[ƒW‚Ío‚³‚È‚¢)
+			// å¤±æ•—ã—ãŸã‚‰åŸºæœ¬ã‚’ã‚³ãƒ”ãƒ¼(ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯å‡ºã•ãªã„)
 			memcpy( &colorInfoArr, GetDllShareData().m_TypeBasis.m_ColorInfoArr, sizeof(colorInfoArr) );
-			files += wstring(L"\n~ ") + m_sColorFile;	// ¸”s
+			files += wstring(L"\nÃ— ") + m_sColorFile;	// å¤±æ•—
 		}
 	}
 	else if (m_nColorType >= 0 ) {
-		// Fw’è(“à•”)
+		// è‰²æŒ‡å®š(å†…éƒ¨)
 		STypeConfig type;
 		CDocTypeManager().GetTypeConfig(CTypeConfig(m_nColorType), type);
 		memcpy( &colorInfoArr, type.m_ColorInfoArr, sizeof(colorInfoArr) );
 	}
 
-	// “Ç‚İ‚İ
+	// èª­ã¿è¾¼ã¿
 	CShareData_IO::ShareData_IO_Type_One( m_cProfile, m_Types, szSecTypes );
 
 	m_nIdx = m_Types.m_nIdx;
 	if (m_nIdx == 0) {
-		// Šî–{‚Ìê‡‚Ì–¼‘O‚ÆŠg’£q‚ğ‰Šú‰»
+		// åŸºæœ¬ã®å ´åˆã®åå‰ã¨æ‹¡å¼µå­ã‚’åˆæœŸåŒ–
 		_tcscpy( m_Types.m_szTypeName, LS(STR_TYPE_NAME_BASIS) );
 		_tcscpy( m_Types.m_szTypeExts, _T("") );
 		m_Types.m_id = 0;
 	}else{
-		// Šî–{‚¶‚á‚È‚©‚Á‚½ê‡Aid”Ô†‚ğƒ‰ƒ“ƒ_ƒ€‚É‰¼Ì”Ô(‚ ‚Æ‚ÅU‚è‚È‚¨‚·)
+		// åŸºæœ¬ã˜ã‚ƒãªã‹ã£ãŸå ´åˆã€idç•ªå·ã‚’ãƒ©ãƒ³ãƒ€ãƒ ã«ä»®æ¡ç•ª(ã‚ã¨ã§æŒ¯ã‚ŠãªãŠã™)
 		m_Types.m_id = (::GetTickCount() & 0x3fffffff) + m_nIdx * 0x10000;
 	}
 
-	// F‚Ìİ’è
+	// è‰²ã®è¨­å®š
 	if (m_nColorType >= 0 ) {
-		// Fw’è‚ ‚è
+		// è‰²æŒ‡å®šã‚ã‚Š
 		for (i = 0; i < _countof(colorInfoArr); i++) {
 			bool bDisp = m_Types.m_ColorInfoArr[i].m_bDisp;
 			m_Types.m_ColorInfoArr[i] = colorInfoArr[i];
-			m_Types.m_ColorInfoArr[i].m_bDisp = bDisp;		// •\¦ƒtƒ‰ƒO‚Íƒtƒ@ƒCƒ‹‚Ì‚à‚Ì‚ğg—p‚·‚é
+			m_Types.m_ColorInfoArr[i].m_bDisp = bDisp;		// è¡¨ç¤ºãƒ•ãƒ©ã‚°ã¯ãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚‚ã®ã‚’ä½¿ç”¨ã™ã‚‹
 		}
 	}
 
-	// ‹¤’Êİ’è‚Æ‚Ì˜AŒ‹•”
+	// å…±é€šè¨­å®šã¨ã®é€£çµéƒ¨
 	wchar_t	szKeyName[64];
 	wchar_t	szKeyData[1024];
 	int		nIdx;
@@ -355,7 +355,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 	wstring	sErrMag;
 	CommonSetting& common = m_pShareData->m_Common;
 
-	// ‹­’²ƒL[ƒ[ƒh
+	// å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
 	CKeyWordSetMgr&	cKeyWordSetMgr = common.m_sSpecialKeyword.m_CKeyWordSetMgr;
 	for (i=0; i < MAX_KEYWORDSET_PER_TYPE; i++) {
 		//types.m_nKeyWordSetIdx[i] = -1;
@@ -363,16 +363,16 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 		if (m_cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( szKeyData ))) {
 			nIdx = cKeyWordSetMgr.SearchKeyWordSet( szKeyData );
 			if (nIdx < 0) {
-				// ƒGƒ“ƒgƒŠì¬
+				// ã‚¨ãƒ³ãƒˆãƒªä½œæˆ
 				cKeyWordSetMgr.AddKeyWordSet( szKeyData, false );
 				nIdx = cKeyWordSetMgr.SearchKeyWordSet( szKeyData );
 			}
 			if (nIdx >= 0) {
 				auto_sprintf( szKeyName, szKeyKeywordCaseTemp, i+1 );
-				bCase = false;		// ‘å•¶š¬•¶š‹æ•Ê‚µ‚È‚¢ (Defaule)
+				bCase = false;		// å¤§æ–‡å­—å°æ–‡å­—åŒºåˆ¥ã—ãªã„ (Defaule)
 				m_cProfile.IOProfileData( szSecTypeEx, szKeyName, bCase );
 
-				// ƒL[ƒ[ƒh’è‹`ƒtƒ@ƒCƒ‹“ü—Í
+				// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«å…¥åŠ›
 				CImpExpKeyWord	cImpExpKeyWord( common, nIdx, bCase );
 
 				auto_sprintf( szKeyName, szKeyKeywordFileTemp, i+1 );
@@ -381,7 +381,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 					if( cImpExpKeyWord.Import( cImpExpKeyWord.MakeFullPath( szFileName ), TmpMsg )) {
 						files += wstring(L"\n") + szFileName;
 					} else {
-						files += wstring(L"\n~ ") + szFileName;	// ¸”s
+						files += wstring(L"\nÃ— ") + szFileName;	// å¤±æ•—
 					}
 				}
 			}
@@ -390,7 +390,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 	}
 
 	// Plugin
-	//  ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@
+	//  ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³•
 	CommonSetting_Plugin& plugin = common.m_sPlugin;
 	if (m_cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineId, MakeStringBufferW( szKeyData ))) {
 		nDataLen = wcslen( szKeyData );
@@ -399,7 +399,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 		for (i = 0; i < MAX_PLUGIN; i++) {
 			if (auto_strncmp(szKeyData, plugin.m_PluginTable[i].m_szId, pSlashPos ? pSlashPos-szKeyData : nDataLen) == 0) {
 				nIdx = i;
-				if (pSlashPos) {	// ƒXƒ‰ƒbƒVƒ…‚ÌŒã‚ë‚Ìƒvƒ‰ƒOID‚ğæ“¾
+				if (pSlashPos) {	// ã‚¹ãƒ©ãƒƒã‚·ãƒ¥ã®å¾Œã‚ã®ãƒ—ãƒ©ã‚°IDã‚’å–å¾—
 					nPlug = _wtoi( pSlashPos + 1 );
 				} else {
 					nPlug = 0;
@@ -407,12 +407,12 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 				break;
 			}
 		}
-		// 2010.08.21 0‚ª”ÍˆÍ‚©‚ç˜R‚ê‚Ä‚¢‚½
+		// 2010.08.21 0ãŒç¯„å›²ã‹ã‚‰æ¼ã‚Œã¦ã„ãŸ
 		if (nIdx >= 0) {
 			m_Types.m_eDefaultOutline = CPlug::GetOutlineType( CPlug::GetPluginFunctionCode(nIdx, nPlug) );
 		}
 	}
-	//  ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒg
+	//  ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
 	if (m_cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentId, MakeStringBufferW( szKeyData ))) {
 		nDataLen = wcslen( szKeyData );
 		pSlashPos = wcschr( szKeyData, L'/' );
@@ -420,7 +420,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 		for (i = 0; i < MAX_PLUGIN; i++) {
 			if (auto_strncmp(szKeyData, plugin.m_PluginTable[i].m_szId, pSlashPos ? pSlashPos-szKeyData : nDataLen) == 0) {
 				nIdx = i;
-				if (pSlashPos) {	// ƒXƒ‰ƒbƒVƒ…‚ÌŒã‚ë‚Ìƒvƒ‰ƒOID‚ğæ“¾
+				if (pSlashPos) {	// ã‚¹ãƒ©ãƒƒã‚·ãƒ¥ã®å¾Œã‚ã®ãƒ—ãƒ©ã‚°IDã‚’å–å¾—
 					nPlug = _wtoi( pSlashPos + 1 );
 				} else {
 					nPlug = 0;
@@ -428,7 +428,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 				break;
 			}
 		}
-		// 2010.08.21 0‚ª”ÍˆÍ‚©‚ç˜R‚ê‚Ä‚¢‚½
+		// 2010.08.21 0ãŒç¯„å›²ã‹ã‚‰æ¼ã‚Œã¦ã„ãŸ
 		if (nIdx >= 0) {
 			m_Types.m_eSmartIndent = CPlug::GetSmartIndentType( CPlug::GetPluginFunctionCode(nIdx, nPlug) );
 		}
@@ -440,7 +440,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 }
 
 
-// ƒGƒNƒXƒ|[ƒg
+// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 {
 	CDataProfile	cProfile;
@@ -449,7 +449,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	CShareData_IO::ShareData_IO_Type_One( cProfile , m_Types, szSecTypes );
 
-	// ‹¤’Êİ’è‚Æ‚Ì˜AŒ‹•”
+	// å…±é€šè¨­å®šã¨ã®é€£çµéƒ¨
 	int		i;
 	wchar_t	szKeyName[64];
 	wchar_t buff[MAX_SETNAMELEN+1];
@@ -460,7 +460,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 	int		nIdx;
 	CommonSetting& common  = m_pShareData->m_Common;
 
-	// ‹­’²ƒL[ƒ[ƒh
+	// å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
 	CKeyWordSetMgr&	cKeyWordSetMgr = common.m_sSpecialKeyword.m_CKeyWordSetMgr;
 	for (i=0; i < MAX_KEYWORDSET_PER_TYPE; i++) {
 		if (m_Types.m_nKeyWordSetIdx[i] >= 0) {
@@ -469,10 +469,10 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 			auto_strcpy( buff, cKeyWordSetMgr.GetTypeName( nIdx ));
 			cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( buff ));
 
-			// ‘å•¶š¬•¶š‹æ•Ê
+			// å¤§æ–‡å­—å°æ–‡å­—åŒºåˆ¥
 			bCase = common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWordCase( nIdx );
 
-			// ƒL[ƒ[ƒh’è‹`ƒtƒ@ƒCƒ‹o—Í
+			// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å®šç¾©ãƒ•ã‚¡ã‚¤ãƒ«å‡ºåŠ›
 			CImpExpKeyWord	cImpExpKeyWord( common, m_Types.m_nKeyWordSetIdx[i], bCase );
 			cImpExpKeyWord.SetBaseName( common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetTypeName( nIdx ));
 
@@ -490,7 +490,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 	}
 
 	// Plugin
-	//  ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@
+	//  ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³•
 	CommonSetting_Plugin& plugin = common.m_sPlugin;
 	int		nPIdx;
 	int		nPlug;
@@ -505,7 +505,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 		}
 		cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineId,   MakeStringBufferW(szId) );
 	}
-	//  ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒg
+	//  ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ
 	if ((nPIdx = CPlug::GetPluginId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) >= 0) {
 		cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentName, MakeStringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
 		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, _countof(szId) );
@@ -530,7 +530,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 	nStructureVersion = int(pShare->m_vStructureVersion);
 	cProfile.IOProfileData( szSecInfo, szKeyStructureVersion, nStructureVersion );
 
-	// ‘‚«‚İ
+	// æ›¸ãè¾¼ã¿
 	if (!cProfile.WriteProfile( to_tchar(sFileName.c_str()), WSTR_TYPE_HEAD )) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_EXPORT)) + sFileName;
 		return false;
@@ -543,31 +543,31 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒJƒ‰[                             //
+//                          ã‚«ãƒ©ãƒ¼                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-// ƒCƒ“ƒ|[ƒg
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 bool CImpExpColors::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring strPath = to_tchar( sFileName.c_str() );
 
-	// ŠJ‚¯‚é‚©
+	// é–‹ã‘ã‚‹ã‹
 	CTextInputStream in( strPath.c_str() );
 	if (!in) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
 		return false;
 	}
 
-	/* ƒtƒ@ƒCƒ‹æ“ª */
-	//ƒwƒbƒ_“Çæ
+	/* ãƒ•ã‚¡ã‚¤ãƒ«å…ˆé ­ */
+	//ãƒ˜ãƒƒãƒ€èª­å–
 	wstring szHeader = in.ReadLineW();
 	if(szHeader.length()>=2) {
-		//ƒRƒƒ“ƒg‚ğ”²‚­
+		//ã‚³ãƒ¡ãƒ³ãƒˆã‚’æŠœã
 		szHeader = &szHeader.c_str()[ szHeader.c_str()[0] == _T(';') ? 1 : 2];
 	}
-	//”äŠr
+	//æ¯”è¼ƒ
 	if (szHeader != WSTR_COLORDATA_HEAD3) {
 		in.Close();
-		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_COLOR_OLD))	// ‹Œƒo[ƒWƒ‡ƒ“‚Ìà–¾‚Ìíœ 2010/4/22 Uchi
+		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_COLOR_OLD))	// æ—§ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã®èª¬æ˜ã®å‰Šé™¤ 2010/4/22 Uchi
 			+ sFileName;
 		return false;
 	}
@@ -576,21 +576,21 @@ bool CImpExpColors::Import( const wstring& sFileName, wstring& sErrMsg )
 	CDataProfile	cProfile;
 	cProfile.SetReadingMode();
 
-	/* Fİ’èVer3 */
+	/* è‰²è¨­å®šVer3 */
 	if( !cProfile.ReadProfile( strPath.c_str() ) ){
 		return false;
 	}
 
-	/* Fİ’è I/O */
+	/* è‰²è¨­å®š I/O */
 	CShareData_IO::IO_ColorSet( &cProfile, szSecColor, m_ColorInfoArr );
 
 	return true;
 }
 
-// ƒGƒNƒXƒ|[ƒg
+// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 bool CImpExpColors::Export( const wstring& sFileName, wstring& sErrMsg )
 {
-	/* Fİ’è I/O */
+	/* è‰²è¨­å®š I/O */
 	CDataProfile	cProfile;
 	cProfile.SetWritingMode();
 	CShareData_IO::IO_ColorSet( &cProfile, szSecColor, m_ColorInfoArr );
@@ -604,9 +604,9 @@ bool CImpExpColors::Export( const wstring& sFileName, wstring& sErrMsg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                    ³‹K•\Œ»ƒL[ƒ[ƒh                       //
+//                    æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-// ƒCƒ“ƒ|[ƒg
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	CTextInputStream	in( to_tchar( sFileName.c_str() ) );
@@ -623,7 +623,7 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 	int count = 0;
 	while(in)
 	{
-		//1s“Ç‚İ‚İ
+		//1è¡Œèª­ã¿è¾¼ã¿
 		wstring line=in.ReadLineW();
 		_wcstotcs(buff,line.c_str(),_countof(buff));
 
@@ -642,12 +642,12 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 		{
 			*p = _T('\0');
 			p++;
-			if( p[0] && CRegexKeyword::RegexKeyCheckSyntax(to_wchar(p)) )	//ˆÍ‚İ‚ª‚ ‚é
+			if( p[0] && CRegexKeyword::RegexKeyCheckSyntax(to_wchar(p)) )	//å›²ã¿ãŒã‚ã‚‹
 			{
-				//Fw’è–¼‚É‘Î‰‚·‚é”Ô†‚ğ’T‚·
+				//è‰²æŒ‡å®šåã«å¯¾å¿œã™ã‚‹ç•ªå·ã‚’æ¢ã™
 				int k = GetColorIndexByName( &buff[11] );	//@@@ 2002.04.30
 				if( k == -1 ){
-					/* “ú–{Œê–¼‚©‚çƒCƒ“ƒfƒbƒNƒX”Ô†‚É•ÏŠ·‚·‚é */
+					/* æ—¥æœ¬èªåã‹ã‚‰ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ç•ªå·ã«å¤‰æ›ã™ã‚‹ */
 					for(int m = 0; m < COLORIDX_LAST; m++){
 						if( auto_strcmp(m_Types.m_ColorInfoArr[m].m_szName, &buff[11]) == 0 ){
 							k = m;
@@ -655,7 +655,7 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 						}
 					}
 				}
-				if( k != -1 )	/* 3•¶šƒJƒ‰[–¼‚©‚çƒCƒ“ƒfƒbƒNƒX”Ô†‚É•ÏŠ· */
+				if( k != -1 )	/* 3æ–‡å­—ã‚«ãƒ©ãƒ¼åã‹ã‚‰ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ç•ªå·ã«å¤‰æ› */
 				{
 					if( 0 < MAX_REGEX_KEYWORDLISTLEN - keywordPos - 1 ){
 						regexKeyArr[count].m_nColorIndex = k;
@@ -686,7 +686,7 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 	return true;
 }
 
-// ƒGƒNƒXƒ|[ƒg
+// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 bool CImpExpRegex::Export( const wstring& sFileName, wstring& sErrMsg )
 {
 	CTextOutputStream out( to_tchar( sFileName.c_str() ) );
@@ -716,10 +716,10 @@ bool CImpExpRegex::Export( const wstring& sFileName, wstring& sErrMsg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒL[ƒ[ƒhƒwƒ‹ƒv                        //
+//                     ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-/*! ƒCƒ“ƒ|[ƒg
-	@date 2010.07.14 Moca ListView‚Ö‚Ìİ’è‚©‚çm_Types‚Ö‚Ìİ’è‚É•ÏX
+/*! ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	@date 2010.07.14 Moca ListViewã¸ã®è¨­å®šã‹ã‚‰m_Typesã¸ã®è¨­å®šã«å¤‰æ›´
 */
 bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 {
@@ -731,20 +731,20 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 		return false;
 	}
 
-	/* ƒf[ƒ^æ“¾ */
-	int invalid_record = 0; // •s³‚Ès
+	/* ãƒ‡ãƒ¼ã‚¿å–å¾— */
+	int invalid_record = 0; // ä¸æ­£ãªè¡Œ
 	int i=0;
 	while (in && i<MAX_KEYHELP_FILE) {
 		wstring buff=in.ReadLineW();
 
-		// 2007.02.03 genta ƒRƒƒ“ƒg‚İ‚½‚¢‚Ès‚Í–Ù‚Á‚ÄƒXƒLƒbƒv
-		// 2007.10.08 kobake ‹ós‚àƒXƒLƒbƒv
+		// 2007.02.03 genta ã‚³ãƒ¡ãƒ³ãƒˆã¿ãŸã„ãªè¡Œã¯é»™ã£ã¦ã‚¹ã‚­ãƒƒãƒ—
+		// 2007.10.08 kobake ç©ºè¡Œã‚‚ã‚¹ã‚­ãƒƒãƒ—
 		if( buff[0] == LTEXT('\0') ||
 			buff[0] == LTEXT('\n') ||
 			buff[0] == LTEXT('#') ||
 			buff[0] == LTEXT(';') ||
 			( buff[0] == LTEXT('/') && buff[1] == LTEXT('/') )){
-				//	2007.02.03 genta ˆ—‚ğŒp‘±
+				//	2007.02.03 genta å‡¦ç†ã‚’ç¶™ç¶š
 				continue;
 		}
 
@@ -753,34 +753,34 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 			auto_memcmp(buff.c_str(), LTEXT("KDct["), 5) != 0 ||
 			auto_memcmp(&buff[7], LTEXT("]="), 2) != 0
 			){
-			//	2007.02.03 genta ˆ—‚ğŒp‘±
+			//	2007.02.03 genta å‡¦ç†ã‚’ç¶™ç¶š
 			++invalid_record;
 			continue;
 		}
 
 		WCHAR *p1, *p2, *p3;
 		p1 = &buff[9];
-		p3 = p1;					//Œ‹‰ÊŠm”F—p‚É‰Šú‰»
+		p3 = p1;					//çµæœç¢ºèªç”¨ã«åˆæœŸåŒ–
 		if( NULL != (p2=wcsstr(p1,LTEXT(","))) ){
 			*p2 = LTEXT('\0');
-			p2 += 1;				//ƒJƒ“ƒ}‚ÌŸ‚ªAŸ‚Ì—v‘f
+			p2 += 1;				//ã‚«ãƒ³ãƒã®æ¬¡ãŒã€æ¬¡ã®è¦ç´ 
 			if( NULL != (p3=wcsstr(p2,LTEXT(","))) ){
 				*p3 = LTEXT('\0');
-				p3 += 1;			//ƒJƒ“ƒ}‚ÌŸ‚ªAŸ‚Ì—v‘f
+				p3 += 1;			//ã‚«ãƒ³ãƒã®æ¬¡ãŒã€æ¬¡ã®è¦ç´ 
 			}
-		}/* Œ‹‰Ê‚ÌŠm”F */
-		if( (p3==NULL) ||			//ƒJƒ“ƒ}‚ª1ŒÂ‘«‚è‚È‚¢
-			(p3==p1) //||			//ƒJƒ“ƒ}‚ª2ŒÂ‘«‚è‚È‚¢
-			//	2007.02.03 genta ƒtƒ@ƒCƒ‹–¼‚ÉƒJƒ“ƒ}‚ª‚ ‚é‚©‚à‚µ‚ê‚È‚¢
-			//(NULL!=wcsstr(p3,","))	//ƒJƒ“ƒ}‚ª‘½‚·‚¬‚é
+		}/* çµæœã®ç¢ºèª */
+		if( (p3==NULL) ||			//ã‚«ãƒ³ãƒãŒ1å€‹è¶³ã‚Šãªã„
+			(p3==p1) //||			//ã‚«ãƒ³ãƒãŒ2å€‹è¶³ã‚Šãªã„
+			//	2007.02.03 genta ãƒ•ã‚¡ã‚¤ãƒ«åã«ã‚«ãƒ³ãƒãŒã‚ã‚‹ã‹ã‚‚ã—ã‚Œãªã„
+			//(NULL!=wcsstr(p3,","))	//ã‚«ãƒ³ãƒãŒå¤šã™ãã‚‹
 		){
-			//	2007.02.03 genta ˆ—‚ğŒp‘±
+			//	2007.02.03 genta å‡¦ç†ã‚’ç¶™ç¶š
 			++invalid_record;
 			continue;
 		}
-		/* value‚Ìƒ`ƒFƒbƒN */
+		/* valueã®ãƒã‚§ãƒƒã‚¯ */
 		//ON/OFF
-		//	2007.02.03 genta 1‚Å‚È‚¯‚ê‚Î1‚É‚·‚é
+		//	2007.02.03 genta 1ã§ãªã‘ã‚Œã°1ã«ã™ã‚‹
 		unsigned int b_enable_flag = (unsigned int)_wtoi(p1);
 		if( b_enable_flag > 1){
 			b_enable_flag = 1;
@@ -788,8 +788,8 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 		//Path
 		FILE* fp2;
 		const WCHAR* p4 = p2;
-		if( (fp2=_tfopen_absini(to_tchar(p3),_T("r"))) == NULL ){	// 2007.02.03 genta ‘Š‘ÎƒpƒX‚Ísakura.exeŠî€‚ÅŠJ‚­	// 2007.05.19 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
-			// 2007.02.03 genta «‘‚ªŒ©‚Â‚©‚ç‚È‚¢ê‡‚Ì‘[’uDŒx‚ğo‚·‚ªæ‚è‚Ş
+		if( (fp2=_tfopen_absini(to_tchar(p3),_T("r"))) == NULL ){	// 2007.02.03 genta ç›¸å¯¾ãƒ‘ã‚¹ã¯sakura.exeåŸºæº–ã§é–‹ã	// 2007.05.19 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
+			// 2007.02.03 genta è¾æ›¸ãŒè¦‹ã¤ã‹ã‚‰ãªã„å ´åˆã®æªç½®ï¼è­¦å‘Šã‚’å‡ºã™ãŒå–ã‚Šè¾¼ã‚€
 			p4 = LSW(STR_IMPEXP_DIC_NOTFOUND);
 			b_enable_flag = 0;
 		}
@@ -804,7 +804,7 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 			continue;
 		}
 
-		//—Ç‚³‚»‚¤‚È‚ç
+		//è‰¯ã•ãã†ãªã‚‰
 		m_Types.m_KeyHelpArr[i].m_bUse = (b_enable_flag!=0);	// 2007.02.03 genta
 		_tcscpy(m_Types.m_KeyHelpArr[i].m_szAbout, to_tchar(p4));
 		_tcscpy(m_Types.m_KeyHelpArr[i].m_szPath,  to_tchar(p3));
@@ -812,7 +812,7 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 	}
 	in.Close();
 
-	// ‹ó‚«‚ª‚ ‚é‚È‚ç”Ô•º‚ğİ’è
+	// ç©ºããŒã‚ã‚‹ãªã‚‰ç•ªå…µã‚’è¨­å®š
 	if( i < _countof(m_Types.m_KeyHelpArr) ){
 		m_Types.m_KeyHelpArr[i].m_bUse = false;
 		m_Types.m_KeyHelpArr[i].m_szAbout[0] = _T('\0');
@@ -820,7 +820,7 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 	}
 	m_Types.m_nKeyHelpNum = i;
 
-	// 2007.02.03 genta ¸”s‚µ‚½‚çŒx‚·‚é
+	// 2007.02.03 genta å¤±æ•—ã—ãŸã‚‰è­¦å‘Šã™ã‚‹
 	if( invalid_record > 0 ){
 		auto_sprintf( msgBuff, LSW(STR_IMPEXP_DIC_RECORD), invalid_record );
 		sErrMsg = msgBuff;
@@ -829,8 +829,8 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 	return true;
 }
 
-/*! ƒGƒNƒXƒ|[ƒg
-	@date 2010.07.14 Moca ListView‚©‚çm_Types‚©‚ç‚ÌƒGƒNƒXƒ|[ƒg‚É•ÏX
+/*! ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
+	@date 2010.07.14 Moca ListViewã‹ã‚‰m_Typesã‹ã‚‰ã®ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆã«å¤‰æ›´
 */
 bool CImpExpKeyHelp::Export( const wstring& sFileName, wstring& sErrMsg )
 {
@@ -858,16 +858,16 @@ bool CImpExpKeyHelp::Export( const wstring& sFileName, wstring& sErrMsg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒL[Š„‚è“–‚Ä                            //
+//                     ã‚­ãƒ¼å‰²ã‚Šå½“ã¦                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-// ƒCƒ“ƒ|[ƒg
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring	strPath = to_tchar( sFileName.c_str() );
-	const int KEYNAME_SIZE = _countof(m_Common.m_sKeyBind.m_pKeyNameArr)-1;// ÅŒã‚Ì‚P—v‘f‚Íƒ_ƒ~[—p‚É—\–ñ 2012.11.25 aroka
+	const int KEYNAME_SIZE = _countof(m_Common.m_sKeyBind.m_pKeyNameArr)-1;// æœ€å¾Œã®ï¼‘è¦ç´ ã¯ãƒ€ãƒŸãƒ¼ç”¨ã«äºˆç´„ 2012.11.25 aroka
 	CommonSetting_KeyBind sKeyBind = m_Common.m_sKeyBind;
 
-	//ƒI[ƒvƒ“
+	//ã‚ªãƒ¼ãƒ—ãƒ³
 	CDataProfile in;
 	in.SetReadingMode();
 	if (!in.ReadProfile( to_tchar( sFileName.c_str() ))) {
@@ -875,9 +875,9 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 		return false;
 	}
 
-	//ƒo[ƒWƒ‡ƒ“Šm”F
-	bool	bVer4;			// Vƒo[ƒWƒ‡ƒ“i‘½Œ¾Œê‘Î‰j‚Ìƒtƒ@ƒCƒ‹
-	bool	bVer3;			// Vƒo[ƒWƒ‡ƒ“‚Ìƒtƒ@ƒCƒ‹
+	//ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç¢ºèª
+	bool	bVer4;			// æ–°ãƒãƒ¼ã‚¸ãƒ§ãƒ³ï¼ˆå¤šè¨€èªå¯¾å¿œï¼‰ã®ãƒ•ã‚¡ã‚¤ãƒ«
+	bool	bVer3;			// æ–°ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã®ãƒ•ã‚¡ã‚¤ãƒ«
 	bool	bVer2;
 	WCHAR szHeader[256];
 	bVer4 = false;
@@ -887,27 +887,27 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 	if(wcscmp(szHeader,WSTR_KEYBIND_HEAD4)==0)	bVer4=true;
 	else if(wcscmp(szHeader,WSTR_KEYBIND_HEAD3)==0)	bVer3=true;
 
-	//int	nKeyNameArrNum;			// ƒL[Š„‚è“–‚Ä•\‚Ì—LŒøƒf[ƒ^”
+	//int	nKeyNameArrNum;			// ã‚­ãƒ¼å‰²ã‚Šå½“ã¦è¡¨ã®æœ‰åŠ¹ãƒ‡ãƒ¼ã‚¿æ•°
 	if ( bVer3 || bVer4 ) {
-		//Countæ“¾ -> nKeyNameArrNum
+		//Countå–å¾— -> nKeyNameArrNum
 		in.IOProfileData(szSecInfo, L"KEYBIND_COUNT", sKeyBind.m_nKeyNameArrNum);
-		if (sKeyBind.m_nKeyNameArrNum < 0 || sKeyBind.m_nKeyNameArrNum > KEYNAME_SIZE){	bVer3=false; bVer4=false; } //”ÍˆÍƒ`ƒFƒbƒN
+		if (sKeyBind.m_nKeyNameArrNum < 0 || sKeyBind.m_nKeyNameArrNum > KEYNAME_SIZE){	bVer3=false; bVer4=false; } //ç¯„å›²ãƒã‚§ãƒƒã‚¯
 
 		CShareData_IO::IO_KeyBind(in, sKeyBind, true);	// 2008/5/25 Uchi
 	}
 
 	if (!bVer3 && !bVer4) {
-		// Vƒo[ƒWƒ‡ƒ“‚Å‚È‚¢
+		// æ–°ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã§ãªã„
 		CTextInputStream in(strPath.c_str());
 		if (!in) {
 			sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
 			return false;
 		}
-		// ƒwƒbƒ_ƒ`ƒFƒbƒN
+		// ãƒ˜ãƒƒãƒ€ãƒã‚§ãƒƒã‚¯
 		wstring	szLine = in.ReadLineW();
 		bVer2 = true;
 		if ( wcscmp(szLine.c_str(), WSTR_KEYBIND_HEAD2) != 0)	bVer2 = false;
-		// ƒJƒEƒ“ƒgƒ`ƒFƒbƒN
+		// ã‚«ã‚¦ãƒ³ãƒˆãƒã‚§ãƒƒã‚¯
 		int	i, cnt;
 		if ( bVer2 ) {
 			int	an;
@@ -921,15 +921,15 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 			}
 		}
 		if ( bVer2 ) {
-			//Še—v‘fæ“¾
+			//å„è¦ç´ å–å¾—
 			for(i = 0; i < KEYNAME_SIZE; i++) {
 				int n, kc, nc;
-				//’l -> szData
+				//å€¤ -> szData
 				wchar_t szData[1024];
 				auto_strncpy(szData, in.ReadLineW().c_str(), _countof(szData) - 1);
 				szData[_countof(szData) - 1] = L'\0';
 
-				//‰ğÍŠJn
+				//è§£æé–‹å§‹
 				cnt = swscanf(szData, L"KeyBind[%03d]=%04x,%n",
 												&n,   &kc, &nc);
 				if( cnt !=2 && cnt !=3 )	{ bVer2= false; break;}
@@ -937,15 +937,15 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 				sKeyBind.m_pKeyNameArr[i].m_nKeyCode = (short)kc;
 				wchar_t* p = szData + nc;
 
-				//Œã‚É‘±‚­ƒg[ƒNƒ“
+				//å¾Œã«ç¶šããƒˆãƒ¼ã‚¯ãƒ³
 				for(int j=0;j<8;j++)
 				{
 					wchar_t* q=auto_strchr(p,L',');
 					if(!q)	{ bVer2= false; break;}
 					*q=L'\0';
 
-					//‹@”\–¼‚ğ”’l‚É’u‚«Š·‚¦‚éB(”’l‚Ì‹@”\–¼‚à‚ ‚é‚©‚à)
-					//@@@ 2002.2.2 YAZAKI ƒ}ƒNƒ‚ğCSMacroMgr‚É“ˆê
+					//æ©Ÿèƒ½åã‚’æ•°å€¤ã«ç½®ãæ›ãˆã‚‹ã€‚(æ•°å€¤ã®æ©Ÿèƒ½åã‚‚ã‚ã‚‹ã‹ã‚‚)
+					//@@@ 2002.2.2 YAZAKI ãƒã‚¯ãƒ­ã‚’CSMacroMgrã«çµ±ä¸€
 					EFunctionCode n = CSMacroMgr::GetFuncInfoByName(G_AppInstance(), p, NULL);
 					if( n == F_INVALID )
 					{
@@ -972,12 +972,12 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 		return false;
 	}
 
-	// ƒf[ƒ^‚ÌƒRƒs[ 	// ƒ}ƒEƒXƒR[ƒh‚ÌŒÅ’è‚Æd•¡”rœ 2012.11.19 aroka
+	// ãƒ‡ãƒ¼ã‚¿ã®ã‚³ãƒ”ãƒ¼ 	// ãƒã‚¦ã‚¹ã‚³ãƒ¼ãƒ‰ã®å›ºå®šã¨é‡è¤‡æ’é™¤ 2012.11.19 aroka
 	//m_Common.m_sKeyBind.m_nKeyNameArrNum = nKeyNameArrNum;
 	//memcpy_raw( m_Common.m_sKeyBind.m_pKeyNameArr, pKeyNameArr, sizeof_raw( pKeyNameArr ) );
-	int nKeyNameArrUsed = m_Common.m_sKeyBind.m_nKeyNameArrNum; // g—pÏ‚İ—Ìˆæ
+	int nKeyNameArrUsed = m_Common.m_sKeyBind.m_nKeyNameArrNum; // ä½¿ç”¨æ¸ˆã¿é ˜åŸŸ
 	for( int j=sKeyBind.m_nKeyNameArrNum-1; j>=0; j-- ){
-		if( (bVer2 || bVer3) && sKeyBind.m_pKeyNameArr[j].m_nKeyCode <= 0 ){ // ƒ}ƒEƒXƒR[ƒh‚Íæ“ª‚ÉŒÅ’è‚³‚ê‚Ä‚¢‚é KeyCode‚ª“¯‚¶‚È‚Ì‚ÅKeyName‚Å”»•Ê
+		if( (bVer2 || bVer3) && sKeyBind.m_pKeyNameArr[j].m_nKeyCode <= 0 ){ // ãƒã‚¦ã‚¹ã‚³ãƒ¼ãƒ‰ã¯å…ˆé ­ã«å›ºå®šã•ã‚Œã¦ã„ã‚‹ KeyCodeãŒåŒã˜ãªã®ã§KeyNameã§åˆ¤åˆ¥
 			for( int im=0; im< MOUSEFUNCTION_KEYBEGIN; im++ ){
 				if( _tcscmp( sKeyBind.m_pKeyNameArr[j].m_szKeyName, m_Common.m_sKeyBind.m_pKeyNameArr[im].m_szKeyName ) == 0 ){
 					m_Common.m_sKeyBind.m_pKeyNameArr[im] = sKeyBind.m_pKeyNameArr[j];
@@ -985,14 +985,14 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 			}
 		}
 		else{
-			// Š„‚è“–‚ÄÏ‚İƒL[ƒR[ƒh‚Íã‘‚«
+			// å‰²ã‚Šå½“ã¦æ¸ˆã¿ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ã¯ä¸Šæ›¸ã
 			int idx = sKeyBind.m_VKeyToKeyNameArr[sKeyBind.m_pKeyNameArr[j].m_nKeyCode];
 			if( idx != KEYNAME_SIZE ){
 				m_Common.m_sKeyBind.m_pKeyNameArr[idx] = sKeyBind.m_pKeyNameArr[j];
 			}
 		}
 	}
-	// –¢Š„‚è“–‚Ä‚ÌƒL[ƒR[ƒh‚Í‹ó‚«—Ìˆæ‚ªˆê”t‚É‚È‚é‚Ü‚Å’Ç‰Á
+	// æœªå‰²ã‚Šå½“ã¦ã®ã‚­ãƒ¼ã‚³ãƒ¼ãƒ‰ã¯ç©ºãé ˜åŸŸãŒä¸€æ¯ã«ãªã‚‹ã¾ã§è¿½åŠ 
 	for( int j2=0; j2<sKeyBind.m_nKeyNameArrNum; j2++ ){
 		int idx = sKeyBind.m_VKeyToKeyNameArr[sKeyBind.m_pKeyNameArr[j2].m_nKeyCode];
 		if( idx == KEYNAME_SIZE ){// not assigned
@@ -1007,7 +1007,7 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 	return true;
 }
 
-// ƒGƒNƒXƒ|[ƒg
+// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 bool CImpExpKeybind::Export( const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring	strPath = to_tchar( sFileName.c_str() );
@@ -1020,21 +1020,21 @@ bool CImpExpKeybind::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	out.Close();
 
-	/* ƒL[Š„‚è“–‚Äî•ñ */
+	/* ã‚­ãƒ¼å‰²ã‚Šå½“ã¦æƒ…å ± */
 	CDataProfile cProfile;
 
-	// ‘‚«‚İƒ‚[ƒhİ’è
+	// æ›¸ãè¾¼ã¿ãƒ¢ãƒ¼ãƒ‰è¨­å®š
 	cProfile.SetWritingMode();
 
-	// ƒwƒbƒ_
+	// ãƒ˜ãƒƒãƒ€
 	StaticString<wchar_t,256> szKeydataHead = WSTR_KEYBIND_HEAD4;
 	cProfile.IOProfileData( szSecInfo, L"KEYBIND_VERSION", szKeydataHead );
 	cProfile.IOProfileData_WrapInt( szSecInfo, L"KEYBIND_COUNT", m_Common.m_sKeyBind.m_nKeyNameArrNum );
 
-	//“à—e
+	//å†…å®¹
 	CShareData_IO::IO_KeyBind(cProfile, m_Common.m_sKeyBind, true);
 
-	// ‘‚«‚İ
+	// æ›¸ãè¾¼ã¿
 	if (!cProfile.WriteProfile( strPath.c_str(), WSTR_KEYBIND_HEAD4)) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_EXPORT)) + sFileName;
 		return false;
@@ -1045,14 +1045,14 @@ bool CImpExpKeybind::Export( const wstring& sFileName, wstring& sErrMsg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒJƒXƒ^ƒ€ƒƒjƒ…[                        //
+//                     ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-// ƒCƒ“ƒ|[ƒg
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 bool CImpExpCustMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring	strPath = to_tchar( sFileName.c_str() );
 
-	//ƒwƒbƒ_Šm”F
+	//ãƒ˜ãƒƒãƒ€ç¢ºèª
 	CTextInputStream in(strPath.c_str());
 	if (!in) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
@@ -1063,7 +1063,7 @@ bool CImpExpCustMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 	cProfile.SetReadingMode();
 	cProfile.ReadProfile(strPath.c_str());
 
-	//ƒo[ƒWƒ‡ƒ“Šm”F
+	//ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç¢ºèª
 	WCHAR szHeader[256];
 	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", MakeStringBufferW(szHeader));
 	if(wcscmp(szHeader, WSTR_CUSTMENU_HEAD_V2)!=0) {
@@ -1076,12 +1076,12 @@ bool CImpExpCustMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 	return true;
 }
 
-// ƒGƒNƒXƒ|[ƒg
+// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 bool CImpExpCustMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring	strPath = to_tchar( sFileName.c_str() );
 
-	// ƒI[ƒvƒ“
+	// ã‚ªãƒ¼ãƒ—ãƒ³
 	CTextOutputStream out(strPath.c_str());
 	if (!out) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
@@ -1090,23 +1090,23 @@ bool CImpExpCustMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	out.Close();
 
-	/* ƒJƒXƒ^ƒ€ƒƒjƒ…[î•ñ */
-	//ƒwƒbƒ_
+	/* ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼æƒ…å ± */
+	//ãƒ˜ãƒƒãƒ€
 	CDataProfile	cProfile;
 	CommonSetting_CustomMenu* menu=&m_Common.m_sCustomMenu;
 
-	// ‘‚«‚İƒ‚[ƒhİ’è
+	// æ›¸ãè¾¼ã¿ãƒ¢ãƒ¼ãƒ‰è¨­å®š
 	cProfile.SetWritingMode();
 
-	//ƒwƒbƒ_
+	//ãƒ˜ãƒƒãƒ€
 	cProfile.IOProfileData( szSecInfo, L"MENU_VERSION", MakeStringBufferW(WSTR_CUSTMENU_HEAD_V2) );
 	int iWork = MAX_CUSTOM_MENU;
 	cProfile.IOProfileData_WrapInt( szSecInfo, L"MAX_CUSTOM_MENU", iWork );
 	
-	//“à—e
+	//å†…å®¹
 	CShareData_IO::IO_CustMenu(cProfile, *menu, true);
 
-	// ‘‚«‚İ
+	// æ›¸ãè¾¼ã¿
 	if (!cProfile.WriteProfile( strPath.c_str(), WSTR_CUSTMENU_HEAD_V2)) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_EXPORT)) + sFileName;
 		return false;
@@ -1117,9 +1117,9 @@ bool CImpExpCustMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ‹­’²ƒL[ƒ[ƒh                          //
+//                     å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-// ƒCƒ“ƒ|[ƒg
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 bool CImpExpKeyWord::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	bool			bAddError = false;
@@ -1132,7 +1132,7 @@ bool CImpExpKeyWord::Import( const wstring& sFileName, wstring& sErrMsg )
 	while( in ){
 		wstring szLine = in.ReadLineW();
 
-		// ƒRƒƒ“ƒg–³‹
+		// ã‚³ãƒ¡ãƒ³ãƒˆç„¡è¦–
 		if (szLine.length() == 0) {
 			continue;
 		}
@@ -1146,9 +1146,9 @@ bool CImpExpKeyWord::Import( const wstring& sFileName, wstring& sErrMsg )
 			continue;
 		}
 		
-		//‰ğÍ
+		//è§£æ
 		if( 0 < szLine.length() ){
-			/* ‚”Ô–Ú‚ÌƒZƒbƒg‚ÉƒL[ƒ[ƒh‚ğ’Ç‰Á */
+			/* ï½ç•ªç›®ã®ã‚»ãƒƒãƒˆã«ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’è¿½åŠ  */
 			int nRetValue = m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.AddKeyWord( m_nIdx, szLine.c_str() );
 			if( 2 == nRetValue ){
 				bAddError = true;
@@ -1158,7 +1158,7 @@ bool CImpExpKeyWord::Import( const wstring& sFileName, wstring& sErrMsg )
 	}
 	in.Close();
 
-	// ‘å•¶š¬•¶š‹æ•Ê
+	// å¤§æ–‡å­—å°æ–‡å­—åŒºåˆ¥
 	m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SetKeyWordCase( m_nIdx, m_bCase );
 
 	if (bAddError) {
@@ -1168,7 +1168,7 @@ bool CImpExpKeyWord::Import( const wstring& sFileName, wstring& sErrMsg )
 	return true;
 }
 
-// ƒGƒNƒXƒ|[ƒg
+// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 bool CImpExpKeyWord::Export( const wstring& sFileName, wstring& sErrMsg )
 {
 	int 		nKeyWordNum;
@@ -1180,7 +1180,7 @@ bool CImpExpKeyWord::Export( const wstring& sFileName, wstring& sErrMsg )
 		return false;
 	}
 	out.WriteF( L"// " );
-	// 2012.03.10 syat ƒL[ƒ[ƒh‚Éu%v‚ğŠÜ‚Şê‡‚ÉƒGƒNƒXƒ|[ƒgŒ‹‰Ê‚ª•s³
+	// 2012.03.10 syat ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã«ã€Œ%ã€ã‚’å«ã‚€å ´åˆã«ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆçµæœãŒä¸æ­£
 	out.WriteString( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetTypeName( m_nIdx ) );
 	out.WriteF( WSTR_KEYWORD_HEAD );
 
@@ -1190,11 +1190,11 @@ bool CImpExpKeyWord::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SortKeyWord(m_nIdx);	//MIK 2000.12.01 sort keyword
 
-	/* ‚”Ô–Ú‚ÌƒZƒbƒg‚ÌƒL[ƒ[ƒh‚Ì”‚ğ•Ô‚· */
+	/* ï½ç•ªç›®ã®ã‚»ãƒƒãƒˆã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®æ•°ã‚’è¿”ã™ */
 	nKeyWordNum = m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWordNum( m_nIdx );
 	for( i = 0; i < nKeyWordNum; ++i ){
-		/* ‚”Ô–Ú‚ÌƒZƒbƒg‚Ì‚”Ô–Ú‚ÌƒL[ƒ[ƒh‚ğ•Ô‚· */
-		// 2012.03.10 syat ƒL[ƒ[ƒh‚Éu%v‚ğŠÜ‚Şê‡‚ÉƒGƒNƒXƒ|[ƒgŒ‹‰Ê‚ª•s³
+		/* ï½ç•ªç›®ã®ã‚»ãƒƒãƒˆã®ï½ç•ªç›®ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’è¿”ã™ */
+		// 2012.03.10 syat ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã«ã€Œ%ã€ã‚’å«ã‚€å ´åˆã«ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆçµæœãŒä¸æ­£
 		out.WriteString( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWord( m_nIdx, i ) );
 		out.WriteF( L"\n" );
 	}
@@ -1205,15 +1205,15 @@ bool CImpExpKeyWord::Export( const wstring& sFileName, wstring& sErrMsg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒƒCƒ“ƒƒjƒ…[                          //
+//                     ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //	2010/5/23 Uchi
-// ƒCƒ“ƒ|[ƒg
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 bool CImpExpMainMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring strPath = to_tchar( sFileName.c_str() );
 
-	//ƒwƒbƒ_Šm”F
+	//ãƒ˜ãƒƒãƒ€ç¢ºèª
 	CTextInputStream in(strPath.c_str());
 	if (!in) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
@@ -1224,7 +1224,7 @@ bool CImpExpMainMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 	cProfile.SetReadingMode();
 	cProfile.ReadProfile( strPath.c_str() );
 
-	//ƒo[ƒWƒ‡ƒ“Šm”F
+	//ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç¢ºèª
 	WCHAR szHeader[256];
 	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", MakeStringBufferW(szHeader));
 	if(wcscmp(szHeader, WSTR_MAINMENU_HEAD_V1)!=0) {
@@ -1237,12 +1237,12 @@ bool CImpExpMainMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 	return true;
 }
 
-// ƒGƒNƒXƒ|[ƒg
+// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 bool CImpExpMainMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring strPath = to_tchar( sFileName.c_str() );
 
-	// ƒI[ƒvƒ“
+	// ã‚ªãƒ¼ãƒ—ãƒ³
 	CTextOutputStream out( strPath.c_str() );
 	if (!out) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
@@ -1251,20 +1251,20 @@ bool CImpExpMainMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	out.Close();
 
-	//ƒwƒbƒ_
+	//ãƒ˜ãƒƒãƒ€
 	CDataProfile	cProfile;
 	CommonSetting_MainMenu* menu=&m_Common.m_sMainMenu;
 
-	// ‘‚«‚İƒ‚[ƒhİ’è
+	// æ›¸ãè¾¼ã¿ãƒ¢ãƒ¼ãƒ‰è¨­å®š
 	cProfile.SetWritingMode();
 
-	//ƒwƒbƒ_
+	//ãƒ˜ãƒƒãƒ€
 	cProfile.IOProfileData( szSecInfo, L"MENU_VERSION", MakeStringBufferW(WSTR_MAINMENU_HEAD_V1) );
 	
-	//“à—e
+	//å†…å®¹
 	CShareData_IO::IO_MainMenu(cProfile, *menu, true);
 
-	// ‘‚«‚İ
+	// æ›¸ãè¾¼ã¿
 	if (!cProfile.WriteProfile( strPath.c_str(), WSTR_MAINMENU_HEAD_V1)) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_EXPORT)) + sFileName;
 		return false;
@@ -1275,10 +1275,10 @@ bool CImpExpMainMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒtƒ@ƒCƒ‹ƒcƒŠ[                          //
+//                     ãƒ•ã‚¡ã‚¤ãƒ«ãƒ„ãƒªãƒ¼                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //	2014.06.07 Moca
-// ƒCƒ“ƒ|[ƒg
+// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 bool CImpExpFileTree::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring strPath = to_tchar( sFileName.c_str() );
@@ -1292,19 +1292,19 @@ bool CImpExpFileTree::Import( const wstring& sFileName, wstring& sErrMsg )
 	return true;
 }
 
-// ƒGƒNƒXƒ|[ƒg
+// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 bool CImpExpFileTree::Export( const wstring& sFileName, wstring& sErrMsg )
 {
 	const tstring strPath = to_tchar( sFileName.c_str() );
 
 	CDataProfile	cProfile;
 
-	// ‘‚«‚İƒ‚[ƒhİ’è
+	// æ›¸ãè¾¼ã¿ãƒ¢ãƒ¼ãƒ‰è¨­å®š
 	cProfile.SetWritingMode();
 
 	IO_FileTreeIni( cProfile, m_aFileTreeItems );
 
-	// ‘‚«‚İ
+	// æ›¸ãè¾¼ã¿
 	if (!cProfile.WriteProfile( strPath.c_str(), WSTR_FILETREE_HEAD_V1)) {
 		sErrMsg = std::wstring(LSW(STR_IMPEXP_ERR_EXPORT)) + sFileName;
 		return false;

--- a/sakura_core/typeprop/CImpExpManager.h
+++ b/sakura_core/typeprop/CImpExpManager.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒCƒ“ƒ|[ƒgAƒGƒNƒXƒ|[ƒgƒ}ƒl[ƒWƒƒ
+ï»¿/*!	@file
+	@brief ã‚¤ãƒ³ãƒãƒ¼ãƒˆã€ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆãƒãƒãƒ¼ã‚¸ãƒ£
 
 	@author Uchi
-	@date 2010/4/22 V‹Kì¬
+	@date 2010/4/22 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2010, Uchi, Moca
@@ -44,34 +44,34 @@ public:
 	virtual bool ImportAscertain( HINSTANCE, HWND, const wstring&, wstring& );
 	virtual bool Import( const wstring&, wstring& ) = 0;
 	virtual bool Export( const wstring&, wstring& ) = 0;
-	// ƒtƒ@ƒCƒ‹–¼‚Ì‰Šú’l‚ğİ’è
+	// ãƒ•ã‚¡ã‚¤ãƒ«åã®åˆæœŸå€¤ã‚’è¨­å®š
 	void SetBaseName( const wstring& );
-	// ƒtƒ‹ƒpƒX–¼‚ğæ“¾
+	// ãƒ•ãƒ«ãƒ‘ã‚¹åã‚’å–å¾—
 	inline wstring GetFullPath()
 	{
 		return to_wchar( GetDllShareData().m_sHistory.m_szIMPORTFOLDER ) + m_sOriginName;
 	}
-	// ƒtƒ‹ƒpƒX–¼‚ğæ“¾
+	// ãƒ•ãƒ«ãƒ‘ã‚¹åã‚’å–å¾—
 	inline wstring MakeFullPath( wstring sFileName )
 	{
 		return to_wchar( GetDllShareData().m_sHistory.m_szIMPORTFOLDER ) + sFileName;
 	}
-	// ƒtƒ@ƒCƒ‹–¼‚ğæ“¾
+	// ãƒ•ã‚¡ã‚¤ãƒ«åã‚’å–å¾—
 	inline wstring GetFileName()	{ return m_sOriginName; }
 
 protected:
-	// Import Folder‚Ìİ’è
+	// Import Folderã®è¨­å®š
 	inline void SetImportFolder( const TCHAR* szPath ) 
 	{
-		/* ƒtƒ@ƒCƒ‹‚Ìƒtƒ‹ƒpƒX‚ğƒtƒHƒ‹ƒ_‚Æƒtƒ@ƒCƒ‹–¼‚É•ªŠ„ */
-		/* [c:\work\test\aaa.txt] ¨ [c:\work\test] + [aaa.txt] */
+		/* ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’ãƒ•ã‚©ãƒ«ãƒ€ã¨ãƒ•ã‚¡ã‚¤ãƒ«åã«åˆ†å‰² */
+		/* [c:\work\test\aaa.txt] â†’ [c:\work\test] + [aaa.txt] */
 		::SplitPath_FolderAndFile( szPath, GetDllShareData().m_sHistory.m_szIMPORTFOLDER, NULL );
 		_tcscat( GetDllShareData().m_sHistory.m_szIMPORTFOLDER, _T("\\") );
 	}
 
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾(u*.txtvŒ`®)
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—(ã€Œ*.txtã€å½¢å¼)
 	virtual const TCHAR* GetDefaultExtension();
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾(utxtvŒ`®)
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—(ã€Œtxtã€å½¢å¼)
 	virtual const wchar_t* GetOriginExtension();
 
 protected:
@@ -81,7 +81,7 @@ protected:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒ^ƒCƒv•Êİ’è                       //
+//                          ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CImpExpType : public CImpExpManager
 {
@@ -92,7 +92,7 @@ public:
 		, m_Types( types )
 		, m_hwndList( hwndList )
 	{
-		/* ‹¤—Lƒf[ƒ^\‘¢‘Ì‚ÌƒAƒhƒŒƒX‚ğ•Ô‚· */
+		/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿æ§‹é€ ä½“ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‚’è¿”ã™ */
 		m_pShareData = &GetDllShareData();
 	}
 
@@ -102,18 +102,18 @@ public:
 	bool Export( const wstring&, wstring& );
 
 public:
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 	const TCHAR* GetDefaultExtension()	{ return _T("*.ini"); }
 	const wchar_t* GetOriginExtension()	{ return L"ini"; }
 	bool IsAddType(){ return m_bAddType; }
 
 private:
-	// ƒCƒ“ƒ^[ƒtƒF[ƒX—p
+	// ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ç”¨
 	int 			m_nIdx;
 	STypeConfig&	m_Types;
 	HWND			m_hwndList;
 
-	// “à•”g—p
+	// å†…éƒ¨ä½¿ç”¨
 	DLLSHAREDATA*	m_pShareData;
 	int				m_nColorType;
 	wstring 		m_sColorFile;
@@ -123,7 +123,7 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒJƒ‰[                             //
+//                          ã‚«ãƒ©ãƒ¼                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CImpExpColors : public CImpExpManager
 {
@@ -139,7 +139,7 @@ public:
 	bool Export( const wstring&, wstring& );
 
 public:
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 	const TCHAR* GetDefaultExtension()	{ return _T("*.col"); }
 	const wchar_t* GetOriginExtension()	{ return L"col"; }
 
@@ -149,7 +149,7 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                    ³‹K•\Œ»ƒL[ƒ[ƒh                       //
+//                    æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CImpExpRegex : public CImpExpManager
 {
@@ -165,7 +165,7 @@ public:
 	bool Export( const wstring&, wstring& );
 
 public:
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 	const TCHAR* GetDefaultExtension()	{ return _T("*.rkw"); }
 	const wchar_t* GetOriginExtension()	{ return L"rkw"; }
 
@@ -175,7 +175,7 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒL[ƒ[ƒhƒwƒ‹ƒv                        //
+//                     ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CImpExpKeyHelp : public CImpExpManager
 {
@@ -191,7 +191,7 @@ public:
 	bool Export( const wstring&, wstring& );
 
 public:
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 	const TCHAR* GetDefaultExtension()	{ return _T("*.txt"); }
 	const wchar_t* GetOriginExtension()	{ return L"txt"; }
 
@@ -201,7 +201,7 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒL[Š„‚è“–‚Ä                            //
+//                     ã‚­ãƒ¼å‰²ã‚Šå½“ã¦                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CImpExpKeybind : public CImpExpManager
 {
@@ -217,7 +217,7 @@ public:
 	bool Export( const wstring&, wstring& );
 
 public:
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 	const TCHAR* GetDefaultExtension()	{ return _T("*.key"); }
 	const wchar_t* GetOriginExtension()	{ return L"key"; }
 
@@ -227,7 +227,7 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒJƒXƒ^ƒ€ƒƒjƒ…[                        //
+//                     ã‚«ã‚¹ã‚¿ãƒ ãƒ¡ãƒ‹ãƒ¥ãƒ¼                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CImpExpCustMenu : public CImpExpManager
 {
@@ -243,7 +243,7 @@ public:
 	bool Export( const wstring&, wstring& );
 
 public:
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 	const TCHAR* GetDefaultExtension()	{ return _T("*.mnu"); }
 	const wchar_t* GetOriginExtension()	{ return L"mnu"; }
 
@@ -253,7 +253,7 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ‹­’²ƒL[ƒ[ƒh                          //
+//                     å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CImpExpKeyWord : public CImpExpManager
 {
@@ -271,7 +271,7 @@ public:
 	bool Export( const wstring&, wstring& );
 
 public:
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 	const TCHAR* GetDefaultExtension()	{ return _T("*.kwd"); }
 	const wchar_t* GetOriginExtension()	{ return L"kwd"; }
 
@@ -283,7 +283,7 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒƒCƒ“ƒƒjƒ…[                          //
+//                     ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CImpExpMainMenu : public CImpExpManager
 {
@@ -299,7 +299,7 @@ public:
 	bool Export( const wstring&, wstring& );
 
 public:
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 	const TCHAR* GetDefaultExtension()	{ return _T("*.ini"); }
 	const wchar_t* GetOriginExtension()	{ return L"ini"; }
 
@@ -309,7 +309,7 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒƒCƒ“ƒƒjƒ…[                          //
+//                     ãƒ¡ã‚¤ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CImpExpFileTree : public CImpExpManager
 {
@@ -326,7 +326,7 @@ public:
 	static void IO_FileTreeIni( CDataProfile&, std::vector<SFileTreeItem>& );
 
 public:
-	// ƒfƒtƒHƒ‹ƒgŠg’£q‚Ìæ“¾
+	// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ‹¡å¼µå­ã®å–å¾—
 	const TCHAR* GetDefaultExtension()	{ return _T("*.ini"); }
 	const wchar_t* GetOriginExtension()	{ return L"ini"; }
 

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -1,14 +1,14 @@
-/*!	@file
-	@brief ƒ^ƒCƒv•Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date 1998/12/24  V‹Kì¬
+	@date 1998/12/24  æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2002, Norio Nakatani
 	Copyright (C) 2000, jepro, genta
 	Copyright (C) 2001, jepro, genta, MIK, hor, Stonee, asa-o
-	Copyright (C) 2002, YAZAKI, aroka, MIK, genta, ‚±‚¨‚è, Moca
+	Copyright (C) 2002, YAZAKI, aroka, MIK, genta, ã“ãŠã‚Š, Moca
 	Copyright (C) 2003, MIK, zenryaku, Moca, naoh, KEITA, genta
 	Copyright (C) 2005, MIK, genta, Moca, ryoji
 	Copyright (C) 2006, ryoji, fon, novice
@@ -30,12 +30,12 @@
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      ƒƒbƒZ[ƒWˆ—                         //
+//                      ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 typedef INT_PTR (CPropTypes::*DISPATCH_EVENT_TYPE)(HWND,UINT,WPARAM,LPARAM);
 
-// ‹¤’Êƒ_ƒCƒAƒƒOƒvƒƒV[ƒWƒƒ
+// å…±é€šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£
 INT_PTR CALLBACK PropTypesCommonProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam, DISPATCH_EVENT_TYPE pDispatch)
 {
 	PROPSHEETPAGE*	pPsp;
@@ -60,7 +60,7 @@ INT_PTR CALLBACK PropTypesCommonProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
 	}
 }
 
-// Šeíƒ_ƒCƒAƒƒOƒvƒƒV[ƒWƒƒ
+// å„ç¨®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£
 typedef	INT_PTR (CPropTypes::*pDispatchPage)( HWND, UINT, WPARAM, LPARAM );
 #define GEN_PROPTYPES_CALLBACK(FUNC,CLASS) \
 INT_PTR CALLBACK FUNC(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) \
@@ -77,7 +77,7 @@ GEN_PROPTYPES_CALLBACK(PropTypesKeyHelp,	CPropTypesKeyHelp)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ¶¬‚Æ”jŠü                           //
+//                        ç”Ÿæˆã¨ç ´æ£„                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CPropTypes::CPropTypes()
@@ -91,15 +91,15 @@ CPropTypes::CPropTypes()
 		assert( sizeof(CPropTypesKeyHelp) - sizeof(CPropTypes) == 0 );
 	}
 
-	/* ‹¤—Lƒf[ƒ^\‘¢‘Ì‚ÌƒAƒhƒŒƒX‚ğ•Ô‚· */
+	/* å…±æœ‰ãƒ‡ãƒ¼ã‚¿æ§‹é€ ä½“ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‚’è¿”ã™ */
 	m_pShareData = &GetDllShareData();
 
-	// Mar. 31, 2003 genta ƒƒ‚ƒŠíŒ¸‚Ì‚½‚ßƒ|ƒCƒ“ƒ^‚É•ÏX
+	// Mar. 31, 2003 genta ãƒ¡ãƒ¢ãƒªå‰Šæ¸›ã®ãŸã‚ãƒã‚¤ãƒ³ã‚¿ã«å¤‰æ›´
 	m_pCKeyWordSetMgr = &m_pShareData->m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr;
 
-	m_hInstance = NULL;		/* ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒCƒ“ƒXƒ^ƒ“ƒX‚Ìƒnƒ“ƒhƒ‹ */
-	m_hwndParent = NULL;	/* ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹ */
-	m_hwndThis  = NULL;		/* ‚±‚Ìƒ_ƒCƒAƒƒO‚Ìƒnƒ“ƒhƒ‹ */
+	m_hInstance = NULL;		/* ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ« */
+	m_hwndParent = NULL;	/* ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ« */
+	m_hwndThis  = NULL;		/* ã“ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒãƒ³ãƒ‰ãƒ« */
 	m_nPageNum = ID_PROPTYPE_PAGENUM_SCREEN;
 
 	(static_cast<CPropTypesScreen*>(this))->CPropTypes_Screen();
@@ -109,30 +109,30 @@ CPropTypes::~CPropTypes()
 {
 }
 
-/* ‰Šú‰» */
+/* åˆæœŸåŒ– */
 void CPropTypes::Create( HINSTANCE hInstApp, HWND hwndParent )
 {
-	m_hInstance = hInstApp;		/* ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒCƒ“ƒXƒ^ƒ“ƒX‚Ìƒnƒ“ƒhƒ‹ */
-	m_hwndParent = hwndParent;	/* ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹ */
+	m_hInstance = hInstApp;		/* ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ« */
+	m_hwndParent = hwndParent;	/* ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ« */
 }
 
 struct TypePropSheetInfo {
-	int m_nTabNameId;										//!< TAB‚Ì•\¦–¼
-	unsigned int resId;										//!< Property sheet‚É‘Î‰‚·‚éDialog resource
+	int m_nTabNameId;										//!< TABã®è¡¨ç¤ºå
+	unsigned int resId;										//!< Property sheetã«å¯¾å¿œã™ã‚‹Dialog resource
 	INT_PTR (CALLBACK *DProc)(HWND, UINT, WPARAM, LPARAM);	//!< Dialog Procedure
 };
 
-// ƒL[ƒ[ƒhFƒ^ƒCƒv•Êİ’èƒ^ƒu‡˜(ƒvƒƒpƒeƒBƒV[ƒg)
-/* ƒvƒƒpƒeƒBƒV[ƒg‚Ìì¬ */
+// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ï¼šã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚¿ãƒ–é †åº(ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆ)
+/* ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆã®ä½œæˆ */
 INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 {
 	INT_PTR				nRet;
 	int					nIdx;
 
-	// 2001/06/14 Start by asa-o: ƒ^ƒCƒv•Êİ’è‚Éx‰‡ƒ^ƒu’Ç‰Á
-	// 2001.11.17 add start MIK ƒ^ƒCƒv•Êİ’è‚É³‹K•\Œ»ƒL[ƒ[ƒhƒ^ƒu’Ç‰Á
-	// 2006.04.10 fon ADD-start ƒ^ƒCƒv•Êİ’è‚ÉuƒL[ƒ[ƒhƒwƒ‹ƒvvƒ^ƒu‚ğ’Ç‰Á
-	// 2013.03.10 aroka ADD-start ƒ^ƒCƒv•Êİ’è‚ÉuƒEƒBƒ“ƒhƒEvƒ^ƒu‚ğ’Ç‰Á
+	// 2001/06/14 Start by asa-o: ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã«æ”¯æ´ã‚¿ãƒ–è¿½åŠ 
+	// 2001.11.17 add start MIK ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã«æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚¿ãƒ–è¿½åŠ 
+	// 2006.04.10 fon ADD-start ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã«ã€Œã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã€ã‚¿ãƒ–ã‚’è¿½åŠ 
+	// 2013.03.10 aroka ADD-start ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã«ã€Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã€ã‚¿ãƒ–ã‚’è¿½åŠ 
 	static const TypePropSheetInfo TypePropSheetInfoList[] = {
 		{ STR_PROPTYPE_SCREEN,			IDD_PROP_SCREEN,	PropTypesScreen },
 		{ STR_PROPTYPE_COLOR,			IDD_PROP_COLOR,		PropTypesColor },
@@ -142,9 +142,9 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 		{ STR_PROPTYPE_KEYWORD_HELP,	IDD_PROP_KEYHELP,	PropTypesKeyHelp }
 	};
 
-	// ƒJƒXƒ^ƒ€F‚ğ‹¤—Lƒƒ‚ƒŠ‚©‚çæ“¾
+	// ã‚«ã‚¹ã‚¿ãƒ è‰²ã‚’å…±æœ‰ãƒ¡ãƒ¢ãƒªã‹ã‚‰å–å¾—
 	memcpy_raw( m_dwCustColors, m_pShareData->m_dwCustColors, sizeof(m_dwCustColors) );
-	// 2005.11.30 Moca ƒJƒXƒ^ƒ€F‚Ìæ“ª‚ÉƒeƒLƒXƒgF‚ğİ’è‚µ‚Ä‚¨‚­
+	// 2005.11.30 Moca ã‚«ã‚¹ã‚¿ãƒ è‰²ã®å…ˆé ­ã«ãƒ†ã‚­ã‚¹ãƒˆè‰²ã‚’è¨­å®šã—ã¦ãŠã
 	m_dwCustColors[0] = m_Types.m_ColorInfoArr[COLORIDX_TEXT].m_sColorAttr.m_cTEXT;
 	m_dwCustColors[1] = m_Types.m_ColorInfoArr[COLORIDX_TEXT].m_sColorAttr.m_cBACK;
 
@@ -170,19 +170,19 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 	PROPSHEETHEADER		psh;
 	memset_raw( &psh, 0, sizeof_raw( psh ) );
 
-	//	Jun. 29, 2002 ‚±‚¨‚è
-	//	Windows 95‘ÎôDProperty Sheet‚ÌƒTƒCƒY‚ğWindows95‚ª”F¯‚Å‚«‚é•¨‚ÉŒÅ’è‚·‚éD
+	//	Jun. 29, 2002 ã“ãŠã‚Š
+	//	Windows 95å¯¾ç­–ï¼Property Sheetã®ã‚µã‚¤ã‚ºã‚’Windows95ãŒèªè­˜ã§ãã‚‹ç‰©ã«å›ºå®šã™ã‚‹ï¼
 	psh.dwSize = sizeof_old_PROPSHEETHEADER;
 
-	// JEPROtest Sept. 30, 2000 ƒ^ƒCƒv•Êİ’è‚Ì‰B‚ê[“K—p]ƒ{ƒ^ƒ“‚Ì³‘Ì‚Í‚±‚±Bs“ª‚ÌƒRƒƒ“ƒgƒAƒEƒg‚ğ“ü‚ê‘Ö‚¦‚Ä‚İ‚ê‚Î‚í‚©‚é
+	// JEPROtest Sept. 30, 2000 ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®éš ã‚Œ[é©ç”¨]ãƒœã‚¿ãƒ³ã®æ­£ä½“ã¯ã“ã“ã€‚è¡Œé ­ã®ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã‚’å…¥ã‚Œæ›¿ãˆã¦ã¿ã‚Œã°ã‚ã‹ã‚‹
 	psh.dwFlags    = /*PSH_USEICONID |*/ PSH_NOAPPLYNOW | PSH_PROPSHEETPAGE/* | PSH_HASHELP*/ | PSH_USEPAGELANG;
 	psh.hwndParent = m_hwndParent;
 	psh.hInstance  = CSelectLang::getLangRsrcInstance();
 	psh.pszIcon    = NULL;
-	psh.pszCaption = LS( STR_PROPTYPE );	//_T("ƒ^ƒCƒv•Êİ’è");	// Sept. 8, 2000 jepro ’P‚È‚éuİ’èv‚©‚ç•ÏX
+	psh.pszCaption = LS( STR_PROPTYPE );	//_T("ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š");	// Sept. 8, 2000 jepro å˜ãªã‚‹ã€Œè¨­å®šã€ã‹ã‚‰å¤‰æ›´
 	psh.nPages     = nIdx;
 
-	//- 20020106 aroka # psh.nStartPage ‚Í unsigned ‚È‚Ì‚Å•‰‚É‚È‚ç‚È‚¢
+	//- 20020106 aroka # psh.nStartPage ã¯ unsigned ãªã®ã§è² ã«ãªã‚‰ãªã„
 	if( -1 == nPageNum ){
 		psh.nStartPage = m_nPageNum;
 	}
@@ -199,7 +199,7 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 	psh.ppsp = psp;
 	psh.pfnCallback = NULL;
 
-	nRet = MyPropertySheet( &psh );	// 2007.05.24 ryoji “Æ©Šg’£ƒvƒƒpƒeƒBƒV[ƒg
+	nRet = MyPropertySheet( &psh );	// 2007.05.24 ryoji ç‹¬è‡ªæ‹¡å¼µãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆ
 
 	if( -1 == nRet ){
 		TCHAR*	pszMsgBuf;
@@ -209,7 +209,7 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 			FORMAT_MESSAGE_IGNORE_INSERTS,
 			NULL,
 			::GetLastError(),
-			MAKELANGID( LANG_NEUTRAL, SUBLANG_DEFAULT ), // ƒfƒtƒHƒ‹ƒgŒ¾Œê
+			MAKELANGID( LANG_NEUTRAL, SUBLANG_DEFAULT ), // ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè¨€èª
 			(LPTSTR)&pszMsgBuf,
 			0,
 			NULL
@@ -223,7 +223,7 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 		::LocalFree( pszMsgBuf );
 	}
 
-	// ƒJƒXƒ^ƒ€F‚ğ‹¤—Lƒƒ‚ƒŠ‚Éİ’è
+	// ã‚«ã‚¹ã‚¿ãƒ è‰²ã‚’å…±æœ‰ãƒ¡ãƒ¢ãƒªã«è¨­å®š
 	memcpy_raw( m_pShareData->m_dwCustColors, m_dwCustColors, sizeof(m_dwCustColors) );
 
 	return nRet;
@@ -232,12 +232,12 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ƒCƒxƒ“ƒg                            //
+//                         ã‚¤ãƒ™ãƒ³ãƒˆ                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/* ƒwƒ‹ƒv */
-//2001.05.18 Stonee ‹@”\”Ô†‚©‚çƒwƒ‹ƒvƒgƒsƒbƒN”Ô†‚ğ’²‚×‚é‚æ‚¤‚É‚µ‚½
-//2001.07.03 JEPRO  x‰‡ƒ^ƒu‚Ìƒwƒ‹ƒv‚ğ—LŒø‰»
+/* ãƒ˜ãƒ«ãƒ— */
+//2001.05.18 Stonee æ©Ÿèƒ½ç•ªå·ã‹ã‚‰ãƒ˜ãƒ«ãƒ—ãƒˆãƒ”ãƒƒã‚¯ç•ªå·ã‚’èª¿ã¹ã‚‹ã‚ˆã†ã«ã—ãŸ
+//2001.07.03 JEPRO  æ”¯æ´ã‚¿ãƒ–ã®ãƒ˜ãƒ«ãƒ—ã‚’æœ‰åŠ¹åŒ–
 //2001.11.17 MIK    IDD_PROP_REGEX
 void CPropTypes::OnHelp( HWND hwndParent, int nPageID )
 {
@@ -252,13 +252,13 @@ void CPropTypes::OnHelp( HWND hwndParent, int nPageID )
 	default:				nContextID = -1;												break;
 	}
 	if( -1 != nContextID ){
-		MyWinHelp( hwndParent, HELP_CONTEXT, nContextID );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndParent, HELP_CONTEXT, nContextID );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 	}
 }
 
 
 
-/*!	ƒRƒ“ƒgƒ[ƒ‹‚ÉƒtƒHƒ“ƒgİ’è‚·‚é
+/*!	ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«ãƒ•ã‚©ãƒ³ãƒˆè¨­å®šã™ã‚‹
 	@date 2013.04.24 Uchi
 */
 HFONT CPropTypes::SetCtrlFont( HWND hwndDlg, int idc_ctrl, const LOGFONT& lf )
@@ -266,11 +266,11 @@ HFONT CPropTypes::SetCtrlFont( HWND hwndDlg, int idc_ctrl, const LOGFONT& lf )
 	HFONT	hFont;
 	HWND	hCtrl;
 
-	// ˜_—ƒtƒHƒ“ƒg‚ğì¬
+	// è«–ç†ãƒ•ã‚©ãƒ³ãƒˆã‚’ä½œæˆ
 	hCtrl = ::GetDlgItem( hwndDlg, idc_ctrl );
 	hFont = ::CreateFontIndirect( &lf );
 	if (hFont) {
-		// ƒtƒHƒ“ƒg‚Ìİ’è
+		// ãƒ•ã‚©ãƒ³ãƒˆã®è¨­å®š
 		::SendMessage( hCtrl, WM_SETFONT, (WPARAM)hFont, MAKELPARAM(FALSE, 0) );
 	}
 
@@ -279,7 +279,7 @@ HFONT CPropTypes::SetCtrlFont( HWND hwndDlg, int idc_ctrl, const LOGFONT& lf )
 
 
 
-/*!	ƒtƒHƒ“ƒgƒ‰ƒxƒ‹‚ÉƒtƒHƒ“ƒg‚ÆƒtƒHƒ“ƒg–¼İ’è‚·‚é
+/*!	ãƒ•ã‚©ãƒ³ãƒˆãƒ©ãƒ™ãƒ«ã«ãƒ•ã‚©ãƒ³ãƒˆã¨ãƒ•ã‚©ãƒ³ãƒˆåè¨­å®šã™ã‚‹
 	@date 2013.04.24 Uchi
 */
 HFONT CPropTypes::SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf, int nps, bool bUse)
@@ -288,7 +288,7 @@ HFONT CPropTypes::SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf,
 	TCHAR	szFontName[80];
 	LOGFONT lfTemp;
 	lfTemp = lf;
-	// ‘å‚«‚·‚¬‚éƒtƒHƒ“ƒg‚Í¬‚³‚­•\¦
+	// å¤§ãã™ãã‚‹ãƒ•ã‚©ãƒ³ãƒˆã¯å°ã•ãè¡¨ç¤º
 	if( lfTemp.lfHeight < -16 ){
 		lfTemp.lfHeight = -16;
 	}
@@ -296,7 +296,7 @@ HFONT CPropTypes::SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf,
 	if (bUse) {
 		hFont = SetCtrlFont( hwndDlg, idc_static, lfTemp );
 
-		// ƒtƒHƒ“ƒg–¼‚Ìİ’è
+		// ãƒ•ã‚©ãƒ³ãƒˆåã®è¨­å®š
 		auto_sprintf( szFontName, nps % 10 ? _T("%s(%.1fpt)") : _T("%s(%.0fpt)"),
 			lf.lfFaceName, double(nps)/10 );
 		::DlgItem_SetText( hwndDlg, idc_static, szFontName );

--- a/sakura_core/typeprop/CPropTypes.h
+++ b/sakura_core/typeprop/CPropTypes.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief ƒ^ƒCƒv•Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	@brief ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author Norio Nakatani
-	@date 1998/05/08  V‹Kì¬
+	@date 1998/05/08  æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -27,10 +27,10 @@ class CPropTypes;
 class CKeyWordSetMgr;
 
 /*-----------------------------------------------------------------------
-’è”
+å®šæ•°
 -----------------------------------------------------------------------*/
 
-//2007.11.29 kobake •Ï”‚ÌˆÓ–¡‚ğ–¾Šm‚É‚·‚é‚½‚ßAnMethos ‚ğ ƒeƒ“ƒvƒŒ[ƒg‰»B
+//2007.11.29 kobake å¤‰æ•°ã®æ„å‘³ã‚’æ˜ç¢ºã«ã™ã‚‹ãŸã‚ã€nMethos ã‚’ ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆåŒ–ã€‚
 template <class TYPE>
 struct TYPE_NAME {
 	TYPE			nMethod;
@@ -50,181 +50,181 @@ struct TYPE_NAME_ID2 {
 	const TCHAR*	pszName;
 };
 
-//!< ƒvƒƒpƒeƒBƒV[ƒg”Ô†
+//!< ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆç•ªå·
 enum PropTypeSheetOrder {
-	ID_PROPTYPE_PAGENUM_SCREEN = 0,		//!< ƒXƒNƒŠ[ƒ“
-	ID_PROPTYPE_PAGENUM_COLOR,			//!< ƒJƒ‰[
-	ID_PROPTYPE_PAGENUM_WINDOW,			//!< ƒEƒBƒ“ƒhƒE
-	ID_PROPTYPE_PAGENUM_SUPPORT,		//!< x‰‡
-	ID_PROPTYPE_PAGENUM_REGEX,			//!< ³‹K•\Œ»ƒL[ƒ[ƒh
-	ID_PROPTYPE_PAGENUM_KEYHELP,		//!< ƒXƒe[ƒ^ƒXƒo[
+	ID_PROPTYPE_PAGENUM_SCREEN = 0,		//!< ã‚¹ã‚¯ãƒªãƒ¼ãƒ³
+	ID_PROPTYPE_PAGENUM_COLOR,			//!< ã‚«ãƒ©ãƒ¼
+	ID_PROPTYPE_PAGENUM_WINDOW,			//!< ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	ID_PROPTYPE_PAGENUM_SUPPORT,		//!< æ”¯æ´
+	ID_PROPTYPE_PAGENUM_REGEX,			//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+	ID_PROPTYPE_PAGENUM_KEYHELP,		//!< ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼
 	ID_PROPTYPE_PAGENUM_MAX,
 };
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 /*!
-	@brief ƒ^ƒCƒv•Êİ’èƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+	@brief ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 */
 class CPropTypes{
 
 public:
-	//¶¬‚Æ”jŠü
+	//ç”Ÿæˆã¨ç ´æ£„
 	CPropTypes();
 	~CPropTypes();
-	void Create( HINSTANCE, HWND );	//!< ‰Šú‰»
-	INT_PTR DoPropertySheet( int );		//!< ƒvƒƒpƒeƒBƒV[ƒg‚Ìì¬
+	void Create( HINSTANCE, HWND );	//!< åˆæœŸåŒ–
+	INT_PTR DoPropertySheet( int );		//!< ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆã®ä½œæˆ
 
-	//ƒCƒ“ƒ^[ƒtƒF[ƒX	
-	void SetTypeData( const STypeConfig& t ){ m_Types = t; }	//!< ƒ^ƒCƒv•Êİ’èƒf[ƒ^‚Ìİ’è  Jan. 23, 2005 genta
-	void GetTypeData( STypeConfig& t ) const { t = m_Types; }	//!< ƒ^ƒCƒv•Êİ’èƒf[ƒ^‚Ìæ“¾  Jan. 23, 2005 genta
+	//ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹	
+	void SetTypeData( const STypeConfig& t ){ m_Types = t; }	//!< ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãƒ‡ãƒ¼ã‚¿ã®è¨­å®š  Jan. 23, 2005 genta
+	void GetTypeData( STypeConfig& t ) const { t = m_Types; }	//!< ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãƒ‡ãƒ¼ã‚¿ã®å–å¾—  Jan. 23, 2005 genta
 	HWND GetHwndParent()const { return m_hwndParent; }
 	int GetPageNum(){ return m_nPageNum; }
 	bool GetChangeKeyWordSet() const { return m_bChangeKeyWordSet; }
 
 protected:
-	//ƒCƒxƒ“ƒg
-	void OnHelp( HWND , int );	//!< ƒwƒ‹ƒv
+	//ã‚¤ãƒ™ãƒ³ãƒˆ
+	void OnHelp( HWND , int );	//!< ãƒ˜ãƒ«ãƒ—
 
 protected:
-	//ŠeíQÆ
-	HINSTANCE	m_hInstance;	//!< ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒCƒ“ƒXƒ^ƒ“ƒX‚Ìƒnƒ“ƒhƒ‹
-	HWND		m_hwndParent;	//!< ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹
-	HWND		m_hwndThis;		//!< ‚±‚Ìƒ_ƒCƒAƒƒO‚Ìƒnƒ“ƒhƒ‹
+	//å„ç¨®å‚ç…§
+	HINSTANCE	m_hInstance;	//!< ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ«
+	HWND		m_hwndParent;	//!< ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ«
+	HWND		m_hwndThis;		//!< ã“ã®ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®ãƒãƒ³ãƒ‰ãƒ«
 
-	//ƒ_ƒCƒAƒƒOƒf[ƒ^
+	//ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿
 	PropTypeSheetOrder	m_nPageNum;
 	DLLSHAREDATA*		m_pShareData;
 	STypeConfig			m_Types;
 
-	// ƒXƒNƒŠ[ƒ“—pƒf[ƒ^	2010/5/10 CPropTypes_P1_Screen.cpp‚©‚çˆÚ“®
-	static std::vector<TYPE_NAME_ID2<EOutlineType> > m_OlmArr;			//!<ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ‹[ƒ‹”z—ñ
-	static std::vector<TYPE_NAME_ID2<ESmartIndentType> > m_SIndentArr;	//!<ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒgƒ‹[ƒ‹”z—ñ
+	// ã‚¹ã‚¯ãƒªãƒ¼ãƒ³ç”¨ãƒ‡ãƒ¼ã‚¿	2010/5/10 CPropTypes_P1_Screen.cppã‹ã‚‰ç§»å‹•
+	static std::vector<TYPE_NAME_ID2<EOutlineType> > m_OlmArr;			//!<ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æãƒ«ãƒ¼ãƒ«é…åˆ—
+	static std::vector<TYPE_NAME_ID2<ESmartIndentType> > m_SIndentArr;	//!<ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆãƒ«ãƒ¼ãƒ«é…åˆ—
 
-	// ƒJƒ‰[—pƒf[ƒ^
-	DWORD			m_dwCustColors[16];						//!< ƒtƒHƒ“ƒgDialogƒJƒXƒ^ƒ€ƒpƒŒƒbƒg
+	// ã‚«ãƒ©ãƒ¼ç”¨ãƒ‡ãƒ¼ã‚¿
+	DWORD			m_dwCustColors[16];						//!< ãƒ•ã‚©ãƒ³ãƒˆDialogã‚«ã‚¹ã‚¿ãƒ ãƒ‘ãƒ¬ãƒƒãƒˆ
 	int				m_nSet[ MAX_KEYWORDSET_PER_TYPE ];		//!< keyword set index  2005.01.13 MIK
-	int				m_nCurrentColorType;					//!< Œ»İ‘I‘ğ‚³‚ê‚Ä‚¢‚éFƒ^ƒCƒv
-	CKeyWordSetMgr*	m_pCKeyWordSetMgr;						//!< ƒƒ‚ƒŠíŒ¸‚Ì‚½‚ßƒ|ƒCƒ“ƒ^‚É  Mar. 31, 2003 genta
+	int				m_nCurrentColorType;					//!< ç¾åœ¨é¸æŠã•ã‚Œã¦ã„ã‚‹è‰²ã‚¿ã‚¤ãƒ—
+	CKeyWordSetMgr*	m_pCKeyWordSetMgr;						//!< ãƒ¡ãƒ¢ãƒªå‰Šæ¸›ã®ãŸã‚ãƒã‚¤ãƒ³ã‚¿ã«  Mar. 31, 2003 genta
 	bool			m_bChangeKeyWordSet;
 
-	// ƒtƒHƒ“ƒg•\¦—pƒf[ƒ^
-	HFONT			m_hTypeFont;							//!< ƒ^ƒCƒv•ÊƒtƒHƒ“ƒg•\¦ƒnƒ“ƒhƒ‹
+	// ãƒ•ã‚©ãƒ³ãƒˆè¡¨ç¤ºç”¨ãƒ‡ãƒ¼ã‚¿
+	HFONT			m_hTypeFont;							//!< ã‚¿ã‚¤ãƒ—åˆ¥ãƒ•ã‚©ãƒ³ãƒˆè¡¨ç¤ºãƒãƒ³ãƒ‰ãƒ«
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ŠeƒvƒƒpƒeƒBƒy[ƒW                     //
+	//                      å„ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ãƒšãƒ¼ã‚¸                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ƒƒbƒZ[ƒWˆ—
+	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 protected:
-	void SetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
-	bool Import( HWND );											//!< ƒCƒ“ƒ|[ƒg
-	bool Export( HWND );											//!< ƒGƒNƒXƒ|[ƒg
+	void SetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
+	bool Import( HWND );											//!< ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	bool Export( HWND );											//!< ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 
-	HFONT SetCtrlFont( HWND hwndDlg, int idc_static, const LOGFONT& lf );								//!< ƒRƒ“ƒgƒ[ƒ‹‚ÉƒtƒHƒ“ƒgİ’è‚·‚é		// 2013/4/24 Uchi
-	HFONT SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf, int nps, bool bUse = true );	//!< ƒtƒHƒ“ƒgƒ‰ƒxƒ‹‚ÉƒtƒHƒ“ƒg‚ÆƒtƒHƒ“ƒg–¼İ’è‚·‚é	// 2013/4/24 Uchi
+	HFONT SetCtrlFont( HWND hwndDlg, int idc_static, const LOGFONT& lf );								//!< ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«ãƒ•ã‚©ãƒ³ãƒˆè¨­å®šã™ã‚‹		// 2013/4/24 Uchi
+	HFONT SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf, int nps, bool bUse = true );	//!< ãƒ•ã‚©ãƒ³ãƒˆãƒ©ãƒ™ãƒ«ã«ãƒ•ã‚©ãƒ³ãƒˆã¨ãƒ•ã‚©ãƒ³ãƒˆåè¨­å®šã™ã‚‹	// 2013/4/24 Uchi
 };
 
 
 /*!
-	@brief ƒ^ƒCƒv•Êİ’èƒvƒƒpƒeƒBƒy[ƒWƒNƒ‰ƒX
+	@brief ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ãƒšãƒ¼ã‚¸ã‚¯ãƒ©ã‚¹
 
-	ƒvƒƒpƒeƒBƒy[ƒW–ˆ‚É’è‹`
-	•Ï”‚Ì’è‹`‚ÍCPropTypes‚Ås‚¤
+	ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ãƒšãƒ¼ã‚¸æ¯ã«å®šç¾©
+	å¤‰æ•°ã®å®šç¾©ã¯CPropTypesã§è¡Œã†
 */
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ƒXƒNƒŠ[ƒ“                           //
+//                        ã‚¹ã‚¯ãƒªãƒ¼ãƒ³                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CPropTypesScreen : public CPropTypes
 {
 public:
-	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ƒƒbƒZ[ƒWˆ—
+	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 protected:
-	void SetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 public:
-	static void AddOutlineMethod(int nMethod, const WCHAR* szName);	//!<ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ‹[ƒ‹‚Ì’Ç‰Á
-	static void AddSIndentMethod(int nMethod, const WCHAR* szName);	//!<ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒgƒ‹[ƒ‹‚Ì’Ç‰Á
-	static void RemoveOutlineMethod(int nMethod, const WCHAR* szName);	//!<ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ‹[ƒ‹‚Ì’Ç‰Á
-	static void RemoveSIndentMethod(int nMethod, const WCHAR* szName);	//!<ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒgƒ‹[ƒ‹‚Ì’Ç‰Á
-	void CPropTypes_Screen();										//!<ƒXƒNƒŠ[ƒ“ƒ^ƒu‚ÌƒRƒ“ƒXƒgƒ‰ƒNƒ^
+	static void AddOutlineMethod(int nMethod, const WCHAR* szName);	//!<ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æãƒ«ãƒ¼ãƒ«ã®è¿½åŠ 
+	static void AddSIndentMethod(int nMethod, const WCHAR* szName);	//!<ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆãƒ«ãƒ¼ãƒ«ã®è¿½åŠ 
+	static void RemoveOutlineMethod(int nMethod, const WCHAR* szName);	//!<ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æãƒ«ãƒ¼ãƒ«ã®è¿½åŠ 
+	static void RemoveSIndentMethod(int nMethod, const WCHAR* szName);	//!<ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆãƒ«ãƒ¼ãƒ«ã®è¿½åŠ 
+	void CPropTypes_Screen();										//!<ã‚¹ã‚¯ãƒªãƒ¼ãƒ³ã‚¿ãƒ–ã®ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒEƒBƒ“ƒhƒE                         //
+//                          ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CPropTypesWindow : public CPropTypes
 {
 public:
-	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ƒƒbƒZ[ƒWˆ—
+	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 protected:
-	void SetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 
 protected:
 	void SetCombobox(HWND hwndWork, const int* nIds, int nCount, int select);
-	void EnableTypesPropInput( HWND hwndDlg );						//!< ƒ^ƒCƒv•Êİ’è‚ÌON/OFF
+	void EnableTypesPropInput( HWND hwndDlg );						//!< ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®ON/OFF
 public:
 private:
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒJƒ‰[                             //
+//                          ã‚«ãƒ©ãƒ¼                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CPropTypesColor : public CPropTypes
 {
 public:
-	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ƒƒbƒZ[ƒWˆ—
+	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 protected:
-	void SetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	void SetDataKeyword( HWND );									//!< ƒZƒbƒg–¼ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚Ì’lƒZƒbƒg
-	int  GetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
-	bool Import( HWND );											//!< ƒCƒ“ƒ|[ƒg
-	bool Export( HWND );											//!< ƒGƒNƒXƒ|[ƒg
+	void SetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	void SetDataKeyword( HWND );									//!< ã‚»ãƒƒãƒˆåã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®å€¤ã‚»ãƒƒãƒˆ
+	int  GetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
+	bool Import( HWND );											//!< ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	bool Export( HWND );											//!< ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 
 protected:
-	void DrawColorListItem( DRAWITEMSTRUCT* );				//!< Fí•ÊƒŠƒXƒg ƒI[ƒi[•`‰æ
-	void EnableTypesPropInput( HWND hwndDlg );				//!< ƒ^ƒCƒv•Êİ’è‚ÌƒJƒ‰[İ’è‚ÌON/OFF
-	void RearrangeKeywordSet( HWND );						//!< ƒL[ƒ[ƒhƒZƒbƒgÄ”z’u  Jan. 23, 2005 genta
-	void DrawColorButton( DRAWITEMSTRUCT* , COLORREF );		//!< Fƒ{ƒ^ƒ“‚Ì•`‰æ
+	void DrawColorListItem( DRAWITEMSTRUCT* );				//!< è‰²ç¨®åˆ¥ãƒªã‚¹ãƒˆ ã‚ªãƒ¼ãƒŠãƒ¼æç”»
+	void EnableTypesPropInput( HWND hwndDlg );				//!< ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®ã‚«ãƒ©ãƒ¼è¨­å®šã®ON/OFF
+	void RearrangeKeywordSet( HWND );						//!< ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆå†é…ç½®  Jan. 23, 2005 genta
+	void DrawColorButton( DRAWITEMSTRUCT* , COLORREF );		//!< è‰²ãƒœã‚¿ãƒ³ã®æç”»
 public:
-	static BOOL SelectColor( HWND , COLORREF*, DWORD* );	//!< F‘I‘ğƒ_ƒCƒAƒƒO
+	static BOOL SelectColor( HWND , COLORREF*, DWORD* );	//!< è‰²é¸æŠãƒ€ã‚¤ã‚¢ãƒ­ã‚°
 private:
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           x‰‡                              //
+//                           æ”¯æ´                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CPropTypesSupport : public CPropTypes
 {
 public:
-	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ƒƒbƒZ[ƒWˆ—
+	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 protected:
-	void SetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
+	void SetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 public:
-	static void AddHokanMethod(int nMethod, const WCHAR* szName);	//!<•âŠ®í•Ê‚Ì’Ç‰Á
-	static void RemoveHokanMethod(int nMethod, const WCHAR* szName);	//!<•âŠ®í•Ê‚Ì’Ç‰Á
+	static void AddHokanMethod(int nMethod, const WCHAR* szName);	//!<è£œå®Œç¨®åˆ¥ã®è¿½åŠ 
+	static void RemoveHokanMethod(int nMethod, const WCHAR* szName);	//!<è£œå®Œç¨®åˆ¥ã®è¿½åŠ 
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                    ³‹K•\Œ»ƒL[ƒ[ƒh                       //
+//                    æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CPropTypesRegex : public CPropTypes
 {
 public:
-	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ƒƒbƒZ[ƒWˆ—
+	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 protected:
-	void SetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	void SetDataKeywordList( HWND );								//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’èƒŠƒXƒg•”•ª
-	int  GetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
-	bool Import( HWND );											//!< ƒCƒ“ƒ|[ƒg
-	bool Export( HWND );											//!< ƒGƒNƒXƒ|[ƒg
+	void SetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	void SetDataKeywordList( HWND );								//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®šãƒªã‚¹ãƒˆéƒ¨åˆ†
+	int  GetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
+	bool Import( HWND );											//!< ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	bool Export( HWND );											//!< ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 private:
 	BOOL RegexKakomiCheck(const wchar_t *s);	//@@@ 2001.11.17 add MIK
 
@@ -233,17 +233,17 @@ private:
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒL[ƒ[ƒhƒwƒ‹ƒv                        //
+//                     ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CPropTypesKeyHelp : public CPropTypes
 {
 public:
-	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ƒƒbƒZ[ƒWˆ—
+	INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );			//!< ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 protected:
-	void SetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è
-	int  GetData( HWND );											//!< ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾
-	bool Import( HWND );											//!< ƒCƒ“ƒ|[ƒg
-	bool Export( HWND );											//!< ƒGƒNƒXƒ|[ƒg
+	void SetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š
+	int  GetData( HWND );											//!< ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
+	bool Import( HWND );											//!< ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	bool Export( HWND );											//!< ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 };
 
 template<typename T>

--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -1,14 +1,14 @@
-/*! @file
-	@brief �^�C�v�ʐݒ� - �J���[
+﻿/*! @file
+	@brief タイプ別設定 - カラー
 
-	@date 2008.04.12 kobake CPropTypes.cpp���番��
+	@date 2008.04.12 kobake CPropTypes.cppから分離
 	@date 2009.02.22 ryoji
 */
 /*
 	Copyright (C) 1998-2002, Norio Nakatani
 	Copyright (C) 2000, jepro, genta
 	Copyright (C) 2001, jepro, genta, MIK, hor, Stonee, asa-o
-	Copyright (C) 2002, YAZAKI, aroka, MIK, genta, ������, Moca
+	Copyright (C) 2002, YAZAKI, aroka, MIK, genta, こおり, Moca
 	Copyright (C) 2003, MIK, zenryaku, Moca, naoh, KEITA, genta
 	Copyright (C) 2005, MIK, genta, Moca, ryoji
 	Copyright (C) 2006, ryoji, fon, novice
@@ -36,41 +36,41 @@
 
 using namespace std;
 
-//! �J�X�^���J���[�p�̎��ʕ�����
+//! カスタムカラー用の識別文字列
 static const TCHAR* TSTR_PTRCUSTOMCOLORS = _T("ptrCustomColors");
 
 WNDPROC	m_wpColorListProc;
 
 static const DWORD p_helpids2[] = {	//11400
-	IDC_LIST_COLORS,				HIDC_LIST_COLORS,				//�F�w��
-	IDC_CHECK_DISP,					HIDC_CHECK_DISP,				//�F�����\��
-	IDC_CHECK_BOLD,					HIDC_CHECK_BOLD,				//����
-	IDC_CHECK_UNDERLINE,			HIDC_CHECK_UNDERLINE,			//����
-	IDC_BUTTON_TEXTCOLOR,			HIDC_BUTTON_TEXTCOLOR,			//�����F
-	IDC_BUTTON_BACKCOLOR,			HIDC_BUTTON_BACKCOLOR,			//�w�i�F
-	IDC_BUTTON_SAMETEXTCOLOR,		HIDC_BUTTON_SAMETEXTCOLOR,		//�����F����
-	IDC_BUTTON_SAMEBKCOLOR,			HIDC_BUTTON_SAMEBKCOLOR,		//�w�i�F����
-	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT_COLOR,		//�C���|�[�g
-	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT_COLOR,		//�G�N�X�|�[�g
-	IDC_COMBO_SET,					HIDC_COMBO_SET_COLOR,			//�����L�[���[�h�P�Z�b�g��
-	IDC_BUTTON_KEYWORD_SELECT,		HIDC_BUTTON_KEYWORD_SELECT,		//�����L�[���[�h2�`10	// 2006.08.06 ryoji
-	IDC_EDIT_BLOCKCOMMENT_FROM,		HIDC_EDIT_BLOCKCOMMENT_FROM,	//�u���b�N�R�����g�P�J�n
-	IDC_EDIT_BLOCKCOMMENT_TO,		HIDC_EDIT_BLOCKCOMMENT_TO,		//�u���b�N�R�����g�P�I��
-	IDC_EDIT_BLOCKCOMMENT_FROM2,	HIDC_EDIT_BLOCKCOMMENT_FROM2,	//�u���b�N�R�����g�Q�J�n
-	IDC_EDIT_BLOCKCOMMENT_TO2,		HIDC_EDIT_BLOCKCOMMENT_TO2,		//�u���b�N�R�����g�Q�I��
-	IDC_EDIT_LINECOMMENT,			HIDC_EDIT_LINECOMMENT,			//�s�R�����g�P
-	IDC_EDIT_LINECOMMENT2,			HIDC_EDIT_LINECOMMENT2,			//�s�R�����g�Q
-	IDC_EDIT_LINECOMMENT3,			HIDC_EDIT_LINECOMMENT3,			//�s�R�����g�R
-	IDC_EDIT_LINECOMMENTPOS,		HIDC_EDIT_LINECOMMENTPOS,		//�����P
-	IDC_EDIT_LINECOMMENTPOS2,		HIDC_EDIT_LINECOMMENTPOS2,		//�����Q
-	IDC_EDIT_LINECOMMENTPOS3,		HIDC_EDIT_LINECOMMENTPOS3,		//�����R
-	IDC_CHECK_LCPOS,				HIDC_CHECK_LCPOS,				//���w��P
-	IDC_CHECK_LCPOS2,				HIDC_CHECK_LCPOS2,				//���w��Q
-	IDC_CHECK_LCPOS3,				HIDC_CHECK_LCPOS3,				//���w��R
-	IDC_COMBO_STRINGLITERAL,		HIDC_COMBO_STRINGLITERAL,		//������G�X�P�[�v
-	IDC_CHECK_STRINGLINEONLY,		HIDC_CHECK_STRINGLINEONLY,		//������͍s���̂�
-	IDC_CHECK_STRINGENDLINE,		HIDC_CHECK_STRINGENDLINE,		//�I���������Ȃ��ꍇ�s���܂ŐF����
-	IDC_EDIT_VERTLINE,				HIDC_EDIT_VERTLINE,				//�c���̌��w��	// 2006.08.06 ryoji
+	IDC_LIST_COLORS,				HIDC_LIST_COLORS,				//色指定
+	IDC_CHECK_DISP,					HIDC_CHECK_DISP,				//色分け表示
+	IDC_CHECK_BOLD,					HIDC_CHECK_BOLD,				//太字
+	IDC_CHECK_UNDERLINE,			HIDC_CHECK_UNDERLINE,			//下線
+	IDC_BUTTON_TEXTCOLOR,			HIDC_BUTTON_TEXTCOLOR,			//文字色
+	IDC_BUTTON_BACKCOLOR,			HIDC_BUTTON_BACKCOLOR,			//背景色
+	IDC_BUTTON_SAMETEXTCOLOR,		HIDC_BUTTON_SAMETEXTCOLOR,		//文字色統一
+	IDC_BUTTON_SAMEBKCOLOR,			HIDC_BUTTON_SAMEBKCOLOR,		//背景色統一
+	IDC_BUTTON_IMPORT,				HIDC_BUTTON_IMPORT_COLOR,		//インポート
+	IDC_BUTTON_EXPORT,				HIDC_BUTTON_EXPORT_COLOR,		//エクスポート
+	IDC_COMBO_SET,					HIDC_COMBO_SET_COLOR,			//強調キーワード１セット名
+	IDC_BUTTON_KEYWORD_SELECT,		HIDC_BUTTON_KEYWORD_SELECT,		//強調キーワード2～10	// 2006.08.06 ryoji
+	IDC_EDIT_BLOCKCOMMENT_FROM,		HIDC_EDIT_BLOCKCOMMENT_FROM,	//ブロックコメント１開始
+	IDC_EDIT_BLOCKCOMMENT_TO,		HIDC_EDIT_BLOCKCOMMENT_TO,		//ブロックコメント１終了
+	IDC_EDIT_BLOCKCOMMENT_FROM2,	HIDC_EDIT_BLOCKCOMMENT_FROM2,	//ブロックコメント２開始
+	IDC_EDIT_BLOCKCOMMENT_TO2,		HIDC_EDIT_BLOCKCOMMENT_TO2,		//ブロックコメント２終了
+	IDC_EDIT_LINECOMMENT,			HIDC_EDIT_LINECOMMENT,			//行コメント１
+	IDC_EDIT_LINECOMMENT2,			HIDC_EDIT_LINECOMMENT2,			//行コメント２
+	IDC_EDIT_LINECOMMENT3,			HIDC_EDIT_LINECOMMENT3,			//行コメント３
+	IDC_EDIT_LINECOMMENTPOS,		HIDC_EDIT_LINECOMMENTPOS,		//桁数１
+	IDC_EDIT_LINECOMMENTPOS2,		HIDC_EDIT_LINECOMMENTPOS2,		//桁数２
+	IDC_EDIT_LINECOMMENTPOS3,		HIDC_EDIT_LINECOMMENTPOS3,		//桁数３
+	IDC_CHECK_LCPOS,				HIDC_CHECK_LCPOS,				//桁指定１
+	IDC_CHECK_LCPOS2,				HIDC_CHECK_LCPOS2,				//桁指定２
+	IDC_CHECK_LCPOS3,				HIDC_CHECK_LCPOS3,				//桁指定３
+	IDC_COMBO_STRINGLITERAL,		HIDC_COMBO_STRINGLITERAL,		//文字列エスケープ
+	IDC_CHECK_STRINGLINEONLY,		HIDC_CHECK_STRINGLINEONLY,		//文字列は行内のみ
+	IDC_CHECK_STRINGENDLINE,		HIDC_CHECK_STRINGENDLINE,		//終了文字がない場合行末まで色分け
+	IDC_EDIT_VERTLINE,				HIDC_EDIT_VERTLINE,				//縦線の桁指定	// 2006.08.06 ryoji
 //	IDC_STATIC,						-1,
 	0, 0
 };
@@ -84,7 +84,7 @@ TYPE_NAME_ID<EStringLiteralType> StringLitteralArr[] = {
 };
 
 
-//	�s�R�����g�Ɋւ�����
+//	行コメントに関する情報
 struct {
 	int nEditID;
 	int nCheckBoxID;
@@ -95,45 +95,45 @@ struct {
 	{ IDC_EDIT_LINECOMMENT3	, IDC_CHECK_LCPOS3, IDC_EDIT_LINECOMMENTPOS3}
 };
 
-/* �F�̐ݒ���C���|�[�g */
-// 2010/4/23 Uchi Import�̊O�o��
+/* 色の設定をインポート */
+// 2010/4/23 Uchi Importの外出し
 bool CPropTypesColor::Import( HWND hwndDlg )
 {
 	ColorInfo		ColorInfoArr[64];
 	CImpExpColors	cImpExpColors( ColorInfoArr );
 
-	/* �F�ݒ� I/O */
+	/* 色設定 I/O */
 	for( int i = 0; i < m_Types.m_nColorInfoArrNum; ++i ){
 		ColorInfoArr[i] = m_Types.m_ColorInfoArr[i];
 		_tcscpy( ColorInfoArr[i].m_szName, m_Types.m_ColorInfoArr[i].m_szName );
 	}
 
-	// �C���|�[�g
+	// インポート
 	if (!cImpExpColors.ImportUI(m_hInstance, hwndDlg)) {
-		// �C���|�[�g�����Ă��Ȃ�
+		// インポートをしていない
 		return false;
 	}
 
-	/* �f�[�^�̃R�s�[ */
+	/* データのコピー */
 	m_Types.m_nColorInfoArrNum = COLORIDX_LAST;
 	for( int i = 0; i < m_Types.m_nColorInfoArrNum; ++i ){
 		m_Types.m_ColorInfoArr[i] =  ColorInfoArr[i];
 		_tcscpy( m_Types.m_ColorInfoArr[i].m_szName, ColorInfoArr[i].m_szName );
 	}
-	/* �_�C�A���O�f�[�^�̐ݒ� color */
+	/* ダイアログデータの設定 color */
 	SetData( hwndDlg );
 
 	return true;
 }
 
 
-/* �F�̐ݒ���G�N�X�|�[�g */
-// 2010/4/23 Uchi Export�̊O�o��
+/* 色の設定をエクスポート */
+// 2010/4/23 Uchi Exportの外出し
 bool CPropTypesColor::Export( HWND hwndDlg )
 {
 	CImpExpColors	cImpExpColors( m_Types.m_ColorInfoArr);
 
-	// �G�N�X�|�[�g
+	// エクスポート
 	return cImpExpColors.ExportUI(m_hInstance, hwndDlg);
 }
 
@@ -177,12 +177,12 @@ LRESULT APIENTRY ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 		if( -1 == nIndex ){
 			break;
 		}
-		if( 18 <= xPos && xPos <= rcItem.right - 29 ){	// 2009.02.22 ryoji �L���͈͂̐����ǉ�
+		if( 18 <= xPos && xPos <= rcItem.right - 29 ){	// 2009.02.22 ryoji 有効範囲の制限追加
 			List_SetCurSel( hwnd, nIndex );
 			::SendMessageCmd( ::GetParent( hwnd ), WM_COMMAND, MAKELONG( IDC_LIST_COLORS, LBN_SELCHANGE ), (LPARAM)hwnd );
 			pColorInfo = (ColorInfo*)List_GetItemData( hwnd, nIndex );
-			/* ���� */
-			if( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_NO_UNDERLINE) )	// 2006.12.18 ryoji �t���O���p�Ŋȑf��
+			/* 下線 */
+			if( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_NO_UNDERLINE) )	// 2006.12.18 ryoji フラグ利用で簡素化
 			{
 				pColorInfo->m_sFontAttr.m_bUnderLine = !pColorInfo->m_sFontAttr.m_bUnderLine; // toggle true/false
 				::CheckDlgButtonBool( ::GetParent( hwnd ), IDC_CHECK_UNDERLINE, pColorInfo->m_sFontAttr.m_bUnderLine );
@@ -195,10 +195,10 @@ LRESULT APIENTRY ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 		if( -1 == nIndex ){
 			break;
 		}
-		if( 18 <= xPos && xPos <= rcItem.right - 29 ){	// 2009.02.22 ryoji �L���͈͂̐����ǉ�
+		if( 18 <= xPos && xPos <= rcItem.right - 29 ){	// 2009.02.22 ryoji 有効範囲の制限追加
 			pColorInfo = (ColorInfo*)List_GetItemData( hwnd, nIndex );
-			/* �����ŕ\�� */
-			if( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_NO_BOLD) )	// 2006.12.18 ryoji �t���O���p�Ŋȑf��
+			/* 太字で表示 */
+			if( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_NO_BOLD) )	// 2006.12.18 ryoji フラグ利用で簡素化
 			{
 				pColorInfo->m_sFontAttr.m_bBoldFont = !pColorInfo->m_sFontAttr.m_bBoldFont; // toggle true/false
 				::CheckDlgButtonBool( ::GetParent( hwnd ), IDC_CHECK_BOLD, pColorInfo->m_sFontAttr.m_bBoldFont );
@@ -211,12 +211,12 @@ LRESULT APIENTRY ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 			break;
 		}
 		pColorInfo = (ColorInfo*)List_GetItemData( hwnd, nIndex );
-		/* �F����/�\�� ���� */
+		/* 色分け/表示 する */
 		if( 2 <= xPos && xPos <= 16
-			&& ( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_FORCE_DISP) )	// 2006.12.18 ryoji �t���O���p�Ŋȑf��
+			&& ( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_FORCE_DISP) )	// 2006.12.18 ryoji フラグ利用で簡素化
 			)
 		{
-			if( pColorInfo->m_bDisp ){	/* �F����/�\������ */
+			if( pColorInfo->m_bDisp ){	/* 色分け/表示する */
 				pColorInfo->m_bDisp = false;
 			}else{
 				pColorInfo->m_bDisp = true;
@@ -228,25 +228,25 @@ LRESULT APIENTRY ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 
 			::InvalidateRect( hwnd, &rcItem, TRUE );
 		}else
-		/* �O�i�F���{ ��` */
+		/* 前景色見本 矩形 */
 		if( rcItem.right - 27 <= xPos && xPos <= rcItem.right - 27 + 12
 			&& ( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_NO_TEXT) ) )
 		{
-			/* �F�I���_�C�A���O */
-			// 2005.11.30 Moca �J�X�^���F�ێ�
+			/* 色選択ダイアログ */
+			// 2005.11.30 Moca カスタム色保持
 			DWORD* pColors = (DWORD*)::GetProp( hwnd, TSTR_PTRCUSTOMCOLORS );
 			if( CPropTypesColor::SelectColor( hwnd, &pColorInfo->m_sColorAttr.m_cTEXT, pColors ) ){
 				::InvalidateRect( hwnd, &rcItem, TRUE );
 				::InvalidateRect( ::GetDlgItem( ::GetParent( hwnd ), IDC_BUTTON_TEXTCOLOR ), NULL, TRUE );
 			}
 		}else
-		/* �O�i�F���{ ��` */
+		/* 前景色見本 矩形 */
 		if( rcItem.right - 13 <= xPos && xPos <= rcItem.right - 13 + 12
-			&& ( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji �t���O���p�Ŋȑf��
+			&& ( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji フラグ利用で簡素化
 			)
 		{
-			/* �F�I���_�C�A���O */
-			// 2005.11.30 Moca �J�X�^���F�ێ�
+			/* 色選択ダイアログ */
+			// 2005.11.30 Moca カスタム色保持
 			DWORD* pColors = (DWORD*)::GetProp( hwnd, TSTR_PTRCUSTOMCOLORS );
 			if( CPropTypesColor::SelectColor( hwnd, &pColorInfo->m_sColorAttr.m_cBACK, pColors ) ){
 				::InvalidateRect( hwnd, &rcItem, TRUE );
@@ -254,7 +254,7 @@ LRESULT APIENTRY ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 			}
 		}
 		break;
-	// 2005.11.30 Moca �J�X�^���F�ێ�
+	// 2005.11.30 Moca カスタム色保持
 	case WM_DESTROY:
 		if( ::GetProp( hwnd, TSTR_PTRCUSTOMCOLORS ) ){
 			::RemoveProp( hwnd, TSTR_PTRCUSTOMCOLORS );
@@ -268,7 +268,7 @@ LRESULT APIENTRY ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 
 
 
-/* color ���b�Z�[�W���� */
+/* color メッセージ処理 */
 INT_PTR CPropTypesColor::DispatchEvent(
 	HWND				hwndDlg,	// handle to dialog box
 	UINT				uMsg,		// message
@@ -294,29 +294,29 @@ INT_PTR CPropTypesColor::DispatchEvent(
 
 		hwndListColor = ::GetDlgItem( hwndDlg, IDC_LIST_COLORS );
 
-		/* �_�C�A���O�f�[�^�̐ݒ� color */
+		/* ダイアログデータの設定 color */
 		SetData( hwndDlg );
 
-		/* �F���X�g���t�b�N */
+		/* 色リストをフック */
 		// Modified by KEITA for WIN64 2003.9.6
 		m_wpColorListProc = (WNDPROC) ::SetWindowLongPtr( hwndListColor, GWLP_WNDPROC, (LONG_PTR)ColorList_SubclassProc );
-		// 2005.11.30 Moca �J�X�^���F��ێ�
+		// 2005.11.30 Moca カスタム色を保持
 		::SetProp( hwndListColor, TSTR_PTRCUSTOMCOLORS, m_dwCustColors );
 		
 		return TRUE;
 
 	case WM_COMMAND:
-		wNotifyCode	= HIWORD( wParam );	/* �ʒm�R�[�h */
-		wID			= LOWORD( wParam );	/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
-		hwndCtl		= (HWND) lParam;	/* �R���g���[���̃n���h�� */
+		wNotifyCode	= HIWORD( wParam );	/* 通知コード */
+		wID			= LOWORD( wParam );	/* 項目ID､ コントロールID､ またはアクセラレータID */
+		hwndCtl		= (HWND) lParam;	/* コントロールのハンドル */
 		if( hwndListColor == hwndCtl ){
 			switch( wNotifyCode ){
 			case LBN_SELCHANGE:
 				nIndex = List_GetCurSel( hwndListColor );
-				m_nCurrentColorType = nIndex;		/* ���ݑI������Ă���F�^�C�v */
+				m_nCurrentColorType = nIndex;		/* 現在選択されている色タイプ */
 
 				{
-					// �e��R���g���[���̗L���^������؂�ւ���	// 2006.12.18 ryoji �t���O���p�Ŋȑf��
+					// 各種コントロールの有効／無効を切り替える	// 2006.12.18 ryoji フラグ利用で簡素化
 					unsigned int fAttribute = g_ColorAttributeArr[nIndex].fAttribute;
 					::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_DISP ),			(0 == (fAttribute & COLOR_ATTRIB_FORCE_DISP))? TRUE: FALSE );
 					::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_BOLD ),			(0 == (fAttribute & COLOR_ATTRIB_NO_BOLD))? TRUE: FALSE );
@@ -329,11 +329,11 @@ INT_PTR CPropTypesColor::DispatchEvent(
 					::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_SAMEBKCOLOR ),	(0 == (fAttribute & COLOR_ATTRIB_NO_BACK))? TRUE: FALSE );
 				}
 
-				/* �F����/�\�� ������ */
+				/* 色分け/表示 をする */
 				::CheckDlgButtonBool( hwndDlg, IDC_CHECK_DISP, m_Types.m_ColorInfoArr[m_nCurrentColorType].m_bDisp );
-				/* �����ŕ\�� */
+				/* 太字で表示 */
 				::CheckDlgButtonBool( hwndDlg, IDC_CHECK_BOLD, m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sFontAttr.m_bBoldFont );
-				/* ������\�� */
+				/* 下線を表示 */
 				::CheckDlgButtonBool( hwndDlg, IDC_CHECK_UNDERLINE, m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sFontAttr.m_bUnderLine );
 
 				::InvalidateRect( ::GetDlgItem( hwndDlg, IDC_BUTTON_TEXTCOLOR ), NULL, TRUE );
@@ -342,12 +342,12 @@ INT_PTR CPropTypesColor::DispatchEvent(
 			}
 		}
 		switch( wNotifyCode ){
-		/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+		/* ボタン／チェックボックスがクリックされた */
 		case BN_CLICKED:
 			switch( wID ){
-			case IDC_BUTTON_SAMETEXTCOLOR: /* �����F���� */
+			case IDC_BUTTON_SAMETEXTCOLOR: /* 文字色統一 */
 				{
-					// 2006.04.26 ryoji �����F�^�w�i�F����_�C�A���O���g��
+					// 2006.04.26 ryoji 文字色／背景色統一ダイアログを使う
 					CDlgSameColor cDlgSameColor;
 					COLORREF cr = m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cTEXT;
 					cDlgSameColor.DoModal( ::GetModuleHandle(NULL), hwndDlg, wID, &m_Types, cr );
@@ -355,9 +355,9 @@ INT_PTR CPropTypesColor::DispatchEvent(
 				::InvalidateRect( hwndListColor, NULL, TRUE );
 				return TRUE;
 
-			case IDC_BUTTON_SAMEBKCOLOR:	/* �w�i�F���� */
+			case IDC_BUTTON_SAMEBKCOLOR:	/* 背景色統一 */
 				{
-					// 2006.04.26 ryoji �����F�^�w�i�F����_�C�A���O���g��
+					// 2006.04.26 ryoji 文字色／背景色統一ダイアログを使う
 					CDlgSameColor cDlgSameColor;
 					COLORREF cr = m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cBACK;
 					cDlgSameColor.DoModal( ::GetModuleHandle(NULL), hwndDlg, wID, &m_Types, cr );
@@ -365,50 +365,50 @@ INT_PTR CPropTypesColor::DispatchEvent(
 				::InvalidateRect( hwndListColor, NULL, TRUE );
 				return TRUE;
 
-			case IDC_BUTTON_TEXTCOLOR:	/* �e�L�X�g�F */
-				/* �F�I���_�C�A���O */
+			case IDC_BUTTON_TEXTCOLOR:	/* テキスト色 */
+				/* 色選択ダイアログ */
 				if( SelectColor( hwndDlg, &m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cTEXT, m_dwCustColors ) ){
 					::InvalidateRect( ::GetDlgItem( hwndDlg, IDC_BUTTON_TEXTCOLOR ), NULL, TRUE );
 				}
-				/* ���ݑI������Ă���F�^�C�v */
+				/* 現在選択されている色タイプ */
 				List_SetCurSel( hwndListColor, m_nCurrentColorType );
 				return TRUE;
-			case IDC_BUTTON_BACKCOLOR:	/* �w�i�F */
-				/* �F�I���_�C�A���O */
+			case IDC_BUTTON_BACKCOLOR:	/* 背景色 */
+				/* 色選択ダイアログ */
 				if( SelectColor( hwndDlg, &m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cBACK, m_dwCustColors ) ){
 					::InvalidateRect( ::GetDlgItem( hwndDlg, IDC_BUTTON_BACKCOLOR ), NULL, TRUE );
 				}
-				/* ���ݑI������Ă���F�^�C�v */
+				/* 現在選択されている色タイプ */
 				List_SetCurSel( hwndListColor, m_nCurrentColorType );
 				return TRUE;
-			case IDC_CHECK_DISP:	/* �F����/�\�� ������ */
+			case IDC_CHECK_DISP:	/* 色分け/表示 をする */
 				m_Types.m_ColorInfoArr[m_nCurrentColorType].m_bDisp = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_DISP );
-				/* ���ݑI������Ă���F�^�C�v */
+				/* 現在選択されている色タイプ */
 				List_SetCurSel( hwndListColor, m_nCurrentColorType );
-				m_Types.m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();	//Need Compile	//@@@ 2001.11.17 add MIK ���K�\���L�[���[�h�̂���
+				m_Types.m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();	//Need Compile	//@@@ 2001.11.17 add MIK 正規表現キーワードのため
 				return TRUE;
-			case IDC_CHECK_BOLD:	/* ������ */
+			case IDC_CHECK_BOLD:	/* 太字か */
 				m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sFontAttr.m_bBoldFont = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_BOLD );
-				/* ���ݑI������Ă���F�^�C�v */
+				/* 現在選択されている色タイプ */
 				List_SetCurSel( hwndListColor, m_nCurrentColorType );
 				return TRUE;
-			case IDC_CHECK_UNDERLINE:	/* ������\�� */
+			case IDC_CHECK_UNDERLINE:	/* 下線を表示 */
 				m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sFontAttr.m_bUnderLine = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_UNDERLINE );
-				/* ���ݑI������Ă���F�^�C�v */
+				/* 現在選択されている色タイプ */
 				List_SetCurSel( hwndListColor, m_nCurrentColorType );
 				return TRUE;
 
-			case IDC_BUTTON_IMPORT:	/* �F�̐ݒ���C���|�[�g */
+			case IDC_BUTTON_IMPORT:	/* 色の設定をインポート */
 				Import( hwndDlg );
-				m_Types.m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();	//Need Compile	//@@@ 2001.11.17 add MIK ���K�\���L�[���[�h�̂���
+				m_Types.m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();	//Need Compile	//@@@ 2001.11.17 add MIK 正規表現キーワードのため
 				return TRUE;
 
-			case IDC_BUTTON_EXPORT:	/* �F�̐ݒ���G�N�X�|�[�g */
+			case IDC_BUTTON_EXPORT:	/* 色の設定をエクスポート */
 				Export( hwndDlg );
 				return TRUE;
 
 			//	From Here Jun. 6, 2001 genta
-			//	�s�R�����g�J�n���w���ON/OFF
+			//	行コメント開始桁指定のON/OFF
 			case IDC_CHECK_LCPOS:
 			case IDC_CHECK_LCPOS2:
 			case IDC_CHECK_LCPOS3:
@@ -417,11 +417,11 @@ INT_PTR CPropTypesColor::DispatchEvent(
 				return TRUE;
 			//	To Here Sept. 10, 2000
 
-			//�����L�[���[�h�̑I��
+			//強調キーワードの選択
 			case IDC_BUTTON_KEYWORD_SELECT:
 				{
 					CDlgKeywordSelect cDlgKeywordSelect;
-					//�����L�[���[�h1���擾����B
+					//強調キーワード1を取得する。
 					HWND hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_SET );
 					int nIdx = Combo_GetCurSel( hwndCombo );
 					if( CB_ERR == nIdx || 0 == nIdx ){
@@ -430,8 +430,8 @@ INT_PTR CPropTypesColor::DispatchEvent(
 						m_nSet[ 0 ] = nIdx - 1;
 					}
 					cDlgKeywordSelect.DoModal( ::GetModuleHandle(NULL), hwndDlg, m_nSet );
-					RearrangeKeywordSet( hwndDlg );	//	Jan. 23, 2005 genta �L�[���[�h�Z�b�g�Ĕz�u
-					//�����L�[���[�h1�𔽉f����B
+					RearrangeKeywordSet( hwndDlg );	//	Jan. 23, 2005 genta キーワードセット再配置
+					//強調キーワード1を反映する。
 					if( -1 == m_nSet[ 0 ] ){
 						Combo_SetCurSel( hwndCombo, 0 );
 					}else{
@@ -439,10 +439,10 @@ INT_PTR CPropTypesColor::DispatchEvent(
 					}
 				}
 				break;
-			//�����L�[���[�h�̑I��
+			//強調キーワードの選択
 			case IDC_BUTTON_EDITKEYWORD:
 				{
-					GetData( hwndDlg ); // Keywrod1�擾
+					GetData( hwndDlg ); // Keywrod1取得
 					CPropKeyword* pPropKeyword = new CPropKeyword;
 					CPropCommon* pCommon = (CPropCommon*)pPropKeyword;
 					pCommon->m_hwndParent = ::GetParent(hwndDlg);
@@ -458,7 +458,7 @@ INT_PTR CPropTypesColor::DispatchEvent(
 						CShareDataLockCounter::WaitLock( pCommon->m_hwndParent );
 						pCommon->ApplyData( m_nSet );
 						SetDataKeyword(hwndDlg);
-						// �ݒ�ς݃L�[���[�h���폜���ꂽ��������Ȃ��̂ōĐݒ�
+						// 設定済みキーワードが削除されたかもしれないので再設定
 						RearrangeKeywordSet( hwndDlg );
 						m_bChangeKeyWordSet = true;
 					}
@@ -482,7 +482,7 @@ INT_PTR CPropTypesColor::DispatchEvent(
 		switch( idCtrl ){
 		//	From Here May 21, 2001 genta activate spin control
 		case IDC_SPIN_LCColNum:
-			/* �s�R�����g���ʒu */
+			/* 行コメント桁位置 */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_LINECOMMENTPOS, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -499,7 +499,7 @@ INT_PTR CPropTypesColor::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_LINECOMMENTPOS, nVal, FALSE );
 			return TRUE;
 		case IDC_SPIN_LCColNum2:
-			/* �s�R�����g���ʒu */
+			/* 行コメント桁位置 */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_LINECOMMENTPOS2, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -517,9 +517,9 @@ INT_PTR CPropTypesColor::DispatchEvent(
 			return TRUE;
 		//	To Here May 21, 2001 genta activate spin control
 
-		//	From Here Jun. 01, 2001 JEPRO 3�ڂ�ǉ�
+		//	From Here Jun. 01, 2001 JEPRO 3つ目を追加
 		case IDC_SPIN_LCColNum3:
-			/* �s�R�����g���ʒu */
+			/* 行コメント桁位置 */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_LINECOMMENTPOS3, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -539,16 +539,16 @@ INT_PTR CPropTypesColor::DispatchEvent(
 		default:
 			switch( pNMHDR->code ){
 			case PSN_HELP:
-//	Sept. 10, 2000 JEPRO ID�������ۂ̖��O�ɕύX���邽�߈ȉ��̍s�̓R�����g�A�E�g
+//	Sept. 10, 2000 JEPRO ID名を実際の名前に変更するため以下の行はコメントアウト
 //				OnHelp( hwndDlg, IDD_PROP1P3 );
 				OnHelp( hwndDlg, IDD_PROP_COLOR );
 				return TRUE;
 			case PSN_KILLACTIVE:
 //				MYTRACE( _T("color PSN_KILLACTIVE\n") );
-				/* �_�C�A���O�f�[�^�̎擾 color */
+				/* ダイアログデータの取得 color */
 				GetData( hwndDlg );
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+//@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPTYPE_PAGENUM_COLOR;
 				return TRUE;
@@ -557,17 +557,17 @@ INT_PTR CPropTypesColor::DispatchEvent(
 		}
 		break;	/* WM_NOTIFY */
 	case WM_DRAWITEM:
-		idCtrl = (UINT) wParam;				/* �R���g���[����ID */
-		pDis = (LPDRAWITEMSTRUCT) lParam;	/* ���ڕ`���� */
+		idCtrl = (UINT) wParam;				/* コントロールのID */
+		pDis = (LPDRAWITEMSTRUCT) lParam;	/* 項目描画情報 */
 		switch( idCtrl ){
 
-		case IDC_BUTTON_TEXTCOLOR:	/* �e�L�X�g�F */
+		case IDC_BUTTON_TEXTCOLOR:	/* テキスト色 */
 			DrawColorButton( pDis, m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cTEXT );
 			return TRUE;
-		case IDC_BUTTON_BACKCOLOR:	/* �w�i�F */
+		case IDC_BUTTON_BACKCOLOR:	/* 背景色 */
 			DrawColorButton( pDis, m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cBACK );
 			return TRUE;
-		case IDC_LIST_COLORS:		/* �F��ʃ��X�g */
+		case IDC_LIST_COLORS:		/* 色種別リスト */
 			DrawColorListItem( pDis );
 			return TRUE;
 		}
@@ -577,7 +577,7 @@ INT_PTR CPropTypesColor::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids2 );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids2 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -587,7 +587,7 @@ INT_PTR CPropTypesColor::DispatchEvent(
 //@@@ 2001.11.17 add start MIK
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids2 );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids2 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.11.17 add end MIK
 
@@ -596,7 +596,7 @@ INT_PTR CPropTypesColor::DispatchEvent(
 }
 
 
-/* �_�C�A���O�f�[�^�̐ݒ� color */
+/* ダイアログデータの設定 color */
 void CPropTypesColor::SetData( HWND hwndDlg )
 {
 
@@ -604,31 +604,31 @@ void CPropTypesColor::SetData( HWND hwndDlg )
 	int		i;
 	int		nItem;
 
-	m_nCurrentColorType = 0;	/* ���ݑI������Ă���F�^�C�v */
+	m_nCurrentColorType = 0;	/* 現在選択されている色タイプ */
 
-	/* ���[�U�[���G�f�B�b�g �R���g���[���ɓ��͂ł���e�L�X�g�̒����𐧌����� */	//@@@ 2002.09.22 YAZAKI
+	/* ユーザーがエディット コントロールに入力できるテキストの長さを制限する */	//@@@ 2002.09.22 YAZAKI
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_LINECOMMENT )		, COMMENT_DELIMITER_BUFFERSIZE - 1 );
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_LINECOMMENT2 )		, COMMENT_DELIMITER_BUFFERSIZE - 1 );
-	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_LINECOMMENT3 )		, COMMENT_DELIMITER_BUFFERSIZE - 1 );	//Jun. 01, 2001 JEPRO �ǉ�
+	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_LINECOMMENT3 )		, COMMENT_DELIMITER_BUFFERSIZE - 1 );	//Jun. 01, 2001 JEPRO 追加
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM )	, BLOCKCOMMENT_BUFFERSIZE - 1 );
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO )	, BLOCKCOMMENT_BUFFERSIZE - 1 );
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM2 ), BLOCKCOMMENT_BUFFERSIZE - 1 );
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO2 )	, BLOCKCOMMENT_BUFFERSIZE - 1 );
 
-	::DlgItem_SetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM	, m_Types.m_cBlockComments[0].getBlockCommentFrom() );	/* �u���b�N�R�����g�f���~�^(From) */
-	::DlgItem_SetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO	, m_Types.m_cBlockComments[0].getBlockCommentTo() );	/* �u���b�N�R�����g�f���~�^(To) */
-	::DlgItem_SetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM2	, m_Types.m_cBlockComments[1].getBlockCommentFrom() );	/* �u���b�N�R�����g�f���~�^2(From) */
-	::DlgItem_SetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO2	, m_Types.m_cBlockComments[1].getBlockCommentTo() );	/* �u���b�N�R�����g�f���~�^2(To) */
+	::DlgItem_SetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM	, m_Types.m_cBlockComments[0].getBlockCommentFrom() );	/* ブロックコメントデリミタ(From) */
+	::DlgItem_SetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO	, m_Types.m_cBlockComments[0].getBlockCommentTo() );	/* ブロックコメントデリミタ(To) */
+	::DlgItem_SetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM2	, m_Types.m_cBlockComments[1].getBlockCommentFrom() );	/* ブロックコメントデリミタ2(From) */
+	::DlgItem_SetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO2	, m_Types.m_cBlockComments[1].getBlockCommentTo() );	/* ブロックコメントデリミタ2(To) */
 
-	/* �s�R�����g�f���~�^ @@@ 2002.09.22 YAZAKI*/
+	/* 行コメントデリミタ @@@ 2002.09.22 YAZAKI*/
 	//	From Here May 12, 2001 genta
-	//	�s�R�����g�̊J�n���ʒu�ݒ�
-	//	May 21, 2001 genta ���ʒu��1���琔����悤��
+	//	行コメントの開始桁位置設定
+	//	May 21, 2001 genta 桁位置を1から数えるように
 	for ( i=0; i<COMMENT_DELIMITER_NUM; i++ ){
-		//	�e�L�X�g
+		//	テキスト
 		::DlgItem_SetText( hwndDlg, cLineComment[i].nEditID, m_Types.m_cLineComment.getLineComment(i) );	
 
-		//	�����`�F�b�N�ƁA���l
+		//	桁数チェックと、数値
 		int nPos = m_Types.m_cLineComment.getLineCommentPos(i);
 		if( nPos >= 0 ){
 			::CheckDlgButton( hwndDlg, cLineComment[i].nCheckBoxID, TRUE );
@@ -645,7 +645,7 @@ void CPropTypesColor::SetData( HWND hwndDlg )
 	int		nSelPos = 0;
 	for( i = 0; i < _countof( StringLitteralArr ); ++i ){
 		Combo_InsertString( hwndCombo, i, LS(StringLitteralArr[i].nNameId) );
-		if( StringLitteralArr[i].nMethod == m_Types.m_nStringType ){		// �e�L�X�g�̐܂�Ԃ����@
+		if( StringLitteralArr[i].nMethod == m_Types.m_nStringType ){		// テキストの折り返し方法
 			nSelPos = i;
 		}
 	}
@@ -655,16 +655,16 @@ void CPropTypesColor::SetData( HWND hwndDlg )
 	::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_STRINGENDLINE),
 		::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_STRINGLINEONLY ) );
 
-	//�����L�[���[�h1�`10�̐ݒ�
+	//強調キーワード1～10の設定
 	for( i = 0; i < MAX_KEYWORDSET_PER_TYPE; i++ ){
 		m_nSet[ i ] = m_Types.m_nKeyWordSetIdx[i];
 	}
 	SetDataKeyword( hwndDlg ); // m_nSet
 
-	/* �F�����镶����ނ̃��X�g */
+	/* 色をつける文字種類のリスト */
 	hwndWork = ::GetDlgItem( hwndDlg, IDC_LIST_COLORS );
-	List_ResetContent( hwndWork );  /* ���X�g����ɂ��� */
-	// 2014.11.25 �傫���t�H���g�Ή�
+	List_ResetContent( hwndWork );  /* リストを空にする */
+	// 2014.11.25 大きいフォント対応
 	int nItemHeight = CTextWidthCalc(hwndWork).GetTextHeight();
 	List_SetItemHeight(hwndWork, 0, nItemHeight + 4);
 	for( i = 0; i < COLORIDX_LAST; ++i ){
@@ -672,11 +672,11 @@ void CPropTypesColor::SetData( HWND hwndDlg )
 		nItem = ::List_AddString( hwndWork, m_Types.m_ColorInfoArr[i].m_szName );
 		List_SetItemData( hwndWork, nItem, &m_Types.m_ColorInfoArr[i] );
 	}
-	/* ���ݑI������Ă���F�^�C�v */
+	/* 現在選択されている色タイプ */
 	List_SetCurSel( hwndWork, m_nCurrentColorType );
 	::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_COLORS, LBN_SELCHANGE ), (LPARAM)hwndWork );
 
-	// from here 2005.11.30 Moca �w��ʒu�c���̐ݒ�
+	// from here 2005.11.30 Moca 指定位置縦線の設定
 	WCHAR szVertLine[MAX_VERTLINES * 15] = L"";
 	int offset = 0;
 	for( i = 0; i < MAX_VERTLINES && m_Types.m_nVertLineIdx[i] != 0; i++ ){
@@ -710,32 +710,32 @@ void CPropTypesColor::SetData( HWND hwndDlg )
 	}
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_VERTLINE ), MAX_VERTLINES * 15 );
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_VERTLINE, szVertLine );
-	// to here 2005.11.30 Moca �w��ʒu�c���̐ݒ�
+	// to here 2005.11.30 Moca 指定位置縦線の設定
 	return;
 }
 
 
-/*! �Z�b�g���R���{�{�b�N�X�̒l�Z�b�g
+/*! セット名コンボボックスの値セット
 */
 void CPropTypesColor::SetDataKeyword( HWND hwndDlg )
 {
 	int i;
 
 	HWND hwndWork = ::GetDlgItem( hwndDlg, IDC_COMBO_SET );
-	Combo_ResetContent( hwndWork );  /* �R���{�{�b�N�X����ɂ��� */
-	/* ��s�ڂ͋� */
+	Combo_ResetContent( hwndWork );  /* コンボボックスを空にする */
+	/* 一行目は空白 */
 	Combo_AddString( hwndWork, L" " );
-	//	Mar. 31, 2003 genta KeyWordSetMgr���|�C���^��
+	//	Mar. 31, 2003 genta KeyWordSetMgrをポインタに
 	if( 0 < m_pCKeyWordSetMgr->m_nKeyWordSetNum ){
 		const int* const set = m_nSet;
 		for( i = 0; i < m_pCKeyWordSetMgr->m_nKeyWordSetNum; ++i ){
 			Combo_AddString( hwndWork, m_pCKeyWordSetMgr->GetTypeName( i ) );
 		}
 		if( -1 == set[0] ){
-			/* �Z�b�g���R���{�{�b�N�X�̃f�t�H���g�I�� */
+			/* セット名コンボボックスのデフォルト選択 */
 			Combo_SetCurSel( hwndWork, 0 );
 		}else{
-			/* �Z�b�g���R���{�{�b�N�X�̃f�t�H���g�I�� */
+			/* セット名コンボボックスのデフォルト選択 */
 			Combo_SetCurSel( hwndWork, set[0] + 1 );
 		}
 	}
@@ -745,21 +745,21 @@ void CPropTypesColor::SetDataKeyword( HWND hwndDlg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         �����⏕                            //
+//                         実装補助                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
 
-/* �_�C�A���O�f�[�^�̎擾 color */
+/* ダイアログデータの取得 color */
 int CPropTypesColor::GetData( HWND hwndDlg )
 {
 	int		nIdx;
 	HWND	hwndWork;
 
 	//	From Here May 12, 2001 genta
-	//	�R�����g�̊J�n���ʒu�̎擾
-	//	May 21, 2001 genta ���ʒu��1���琔����悤��
-	wchar_t buffer[COMMENT_DELIMITER_BUFFERSIZE];	//@@@ 2002.09.22 YAZAKI LineComment���擾���邽�߂̃o�b�t�@
+	//	コメントの開始桁位置の取得
+	//	May 21, 2001 genta 桁位置を1から数えるように
+	wchar_t buffer[COMMENT_DELIMITER_BUFFERSIZE];	//@@@ 2002.09.22 YAZAKI LineCommentを取得するためのバッファ
 	int pos;
 	UINT en;
 	BOOL bTranslated;
@@ -772,27 +772,27 @@ int CPropTypesColor::GetData( HWND hwndDlg )
 			en = 0;
 			pos = 0;
 		}
-		//	pos == 0�̂Ƃ��͖�������
+		//	pos == 0のときは無効扱い
 		if( pos == 0 )	en = 0;
 		else			--pos;
-		//	�����̂Ƃ���1�̕␔�Ŋi�[
+		//	無効のときは1の補数で格納
 
-		::DlgItem_GetText( hwndDlg, cLineComment[i].nEditID		, buffer	, COMMENT_DELIMITER_BUFFERSIZE );		/* �s�R�����g�f���~�^ */
+		::DlgItem_GetText( hwndDlg, cLineComment[i].nEditID		, buffer	, COMMENT_DELIMITER_BUFFERSIZE );		/* 行コメントデリミタ */
 		m_Types.m_cLineComment.CopyTo( i, buffer, en ? pos : ~pos );
 	}
 
 	wchar_t szFromBuffer[BLOCKCOMMENT_BUFFERSIZE];	//@@@ 2002.09.22 YAZAKI
 	wchar_t szToBuffer[BLOCKCOMMENT_BUFFERSIZE];	//@@@ 2002.09.22 YAZAKI
 
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM	, szFromBuffer	, BLOCKCOMMENT_BUFFERSIZE );	/* �u���b�N�R�����g�f���~�^(From) */
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO		, szToBuffer	, BLOCKCOMMENT_BUFFERSIZE );	/* �u���b�N�R�����g�f���~�^(To) */
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM	, szFromBuffer	, BLOCKCOMMENT_BUFFERSIZE );	/* ブロックコメントデリミタ(From) */
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO		, szToBuffer	, BLOCKCOMMENT_BUFFERSIZE );	/* ブロックコメントデリミタ(To) */
 	m_Types.m_cBlockComments[0].SetBlockCommentRule( szFromBuffer, szToBuffer );
 
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM2	, szFromBuffer	, BLOCKCOMMENT_BUFFERSIZE );	/* �u���b�N�R�����g�f���~�^(From) */
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO2	, szToBuffer	, BLOCKCOMMENT_BUFFERSIZE );	/* �u���b�N�R�����g�f���~�^(To) */
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_FROM2	, szFromBuffer	, BLOCKCOMMENT_BUFFERSIZE );	/* ブロックコメントデリミタ(From) */
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_BLOCKCOMMENT_TO2	, szToBuffer	, BLOCKCOMMENT_BUFFERSIZE );	/* ブロックコメントデリミタ(To) */
 	m_Types.m_cBlockComments[1].SetBlockCommentRule( szFromBuffer, szToBuffer );
 
-	/* �������؂�L���G�X�P�[�v���@ */
+	/* 文字列区切り記号エスケープ方法 */
 	int		nSelPos = Combo_GetCurSel( GetDlgItem(hwndDlg, IDC_COMBO_STRINGLITERAL) );
 	if( nSelPos >= 0 ){
 		m_Types.m_nStringType = StringLitteralArr[nSelPos].nMethod;
@@ -801,7 +801,7 @@ int CPropTypesColor::GetData( HWND hwndDlg )
 	m_Types.m_bStringEndLine = IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_STRINGENDLINE );
 	
 
-	/* �Z�b�g���R���{�{�b�N�X�̒l�Z�b�g */
+	/* セット名コンボボックスの値セット */
 	hwndWork = ::GetDlgItem( hwndDlg, IDC_COMBO_SET );
 	nIdx = Combo_GetCurSel( hwndWork );
 	if( CB_ERR == nIdx ||
@@ -813,12 +813,12 @@ int CPropTypesColor::GetData( HWND hwndDlg )
 	}
 	m_nSet[0] = m_Types.m_nKeyWordSetIdx[0];
 
-	//�����L�[���[�h2�`10�̎擾(1�͕�)
+	//強調キーワード2～10の取得(1は別)
 	for( nIdx = 1; nIdx < MAX_KEYWORDSET_PER_TYPE; nIdx++ ){
 		m_Types.m_nKeyWordSetIdx[nIdx] = m_nSet[nIdx];
 	}
 
-	// from here 2005.11.30 Moca �w��ʒu�c���̐ݒ�
+	// from here 2005.11.30 Moca 指定位置縦線の設定
 	WCHAR szVertLine[MAX_VERTLINES * 15];
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_VERTLINE, szVertLine, MAX_VERTLINES * 15 );
 
@@ -877,13 +877,13 @@ int CPropTypesColor::GetData( HWND hwndDlg )
 	if( i < MAX_VERTLINES ){
 		m_Types.m_nVertLineIdx[i] = CKetaXInt(0);
 	}
-	// to here 2005.11.30 Moca �w��ʒu�c���̐ݒ�
+	// to here 2005.11.30 Moca 指定位置縦線の設定
 	return TRUE;
 }
 
 
 
-/* �F�{�^���̕`�� */
+/* 色ボタンの描画 */
 void CPropTypesColor::DrawColorButton( DRAWITEMSTRUCT* pDis, COLORREF cColor )
 {
 //	MYTRACE( _T("pDis->itemAction = ") );
@@ -895,14 +895,14 @@ void CPropTypesColor::DrawColorButton( DRAWITEMSTRUCT* pDis, COLORREF cColor )
 	RECT		rc;
 	RECT		rcFocus;
 
-	//�`��Ώ�
+	//描画対象
 	CGraphics gr(pDis->hDC);
 
-	/* �{�^���̕\�ʂ̐F�œh��Ԃ� */
+	/* ボタンの表面の色で塗りつぶす */
 	gr.SetBrushColor( cBtnFace );
 	gr.FillMyRect( pDis->rcItem );
 
-	/* �g�̕`�� */
+	/* 枠の描画 */
 	rc = pDis->rcItem;
 	rc.top += 4;
 	rc.left += 4;
@@ -957,13 +957,13 @@ void CPropTypesColor::DrawColorButton( DRAWITEMSTRUCT* pDis, COLORREF cColor )
 	}
 	
 	if((pDis->itemState & ODS_DISABLED)==0){
-		/* �w��F�œh��Ԃ� */
+		/* 指定色で塗りつぶす */
 		gr.SetBrushColor(cColor);
 		gr.SetPen(cBtnShadow);
 		::RoundRect( gr, rc.left, rc.top, rc.right, rc.bottom , 5, 5 );
 	}
 
-	/* �t�H�[�J�X�̒����` */
+	/* フォーカスの長方形 */
 	if( pDis->itemState & ODS_FOCUS ){
 		rcFocus.top -= 3;
 		rcFocus.left -= 3;
@@ -976,13 +976,13 @@ void CPropTypesColor::DrawColorButton( DRAWITEMSTRUCT* pDis, COLORREF cColor )
 
 
 //	From Here Sept. 10, 2000 JEPRO
-//	�`�F�b�N��Ԃɉ����ă_�C�A���O�{�b�N�X�v�f��Enable/Disable��
-//	�K�؂ɐݒ肷��
+//	チェック状態に応じてダイアログボックス要素のEnable/Disableを
+//	適切に設定する
 void CPropTypesColor::EnableTypesPropInput( HWND hwndDlg )
 {
 	//	From Here Jun. 6, 2001 genta
-	//	�s�R�����g�J�n���ʒu���̓{�b�N�X��Enable/Disable�ݒ�
-	//	1��
+	//	行コメント開始桁位置入力ボックスのEnable/Disable設定
+	//	1つ目
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_LCPOS ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_LINECOMMENTPOS ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_LCPOS ), TRUE );
@@ -992,7 +992,7 @@ void CPropTypesColor::EnableTypesPropInput( HWND hwndDlg )
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_LCPOS ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_LCColNum ), FALSE );
 	}
-	//	2��
+	//	2つ目
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_LCPOS2 ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_LINECOMMENTPOS2 ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_LCPOS2 ), TRUE );
@@ -1002,7 +1002,7 @@ void CPropTypesColor::EnableTypesPropInput( HWND hwndDlg )
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_LCPOS2 ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_SPIN_LCColNum2 ), FALSE );
 	}
-	//	3��
+	//	3つ目
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_LCPOS3 ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_LINECOMMENTPOS3 ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_LCPOS3 ), TRUE );
@@ -1018,16 +1018,16 @@ void CPropTypesColor::EnableTypesPropInput( HWND hwndDlg )
 
 
 
-/*!	@brief �L�[���[�h�Z�b�g�̍Ĕz��
+/*!	@brief キーワードセットの再配列
 
-	�L�[���[�h�Z�b�g�̐F�����ł͖��w��̃L�[���[�h�Z�b�g�ȍ~�̓`�F�b�N���ȗ�����D
-	���̂��߃Z�b�g�̓r���ɖ��w��̂��̂�����ꍇ�͂���ȍ~��O�ɋl�߂邱�Ƃ�
-	�w�肳�ꂽ�S�ẴL�[���[�h�Z�b�g���L���ɂȂ�悤�ɂ���D
-	���̍ہC�F�����̐ݒ�������Ɉړ�����D
+	キーワードセットの色分けでは未指定のキーワードセット以降はチェックを省略する．
+	そのためセットの途中に未指定のものがある場合はそれ以降を前に詰めることで
+	指定された全てのキーワードセットが有効になるようにする．
+	その際，色分けの設定も同時に移動する．
 
-	m_nSet, m_Types.m_ColorInfoArr[]���ύX�����D
+	m_nSet, m_Types.m_ColorInfoArr[]が変更される．
 
-	@param hwndDlg [in] �_�C�A���O�{�b�N�X�̃E�B���h�E�n���h��
+	@param hwndDlg [in] ダイアログボックスのウィンドウハンドル
 
 	@author	genta 
 	@date	2005.01.23 genta new
@@ -1040,15 +1040,15 @@ void CPropTypesColor::RearrangeKeywordSet( HWND hwndDlg )
 		if( m_nSet[ i ] != -1 )
 			continue;
 
-		//	���ݒ�̏ꍇ
+		//	未設定の場合
 		for( j = i; j < MAX_KEYWORDSET_PER_TYPE; j++ ){
 			if( m_nSet[ j ] != -1 ){
-				//	���ɐݒ�ςݍ��ڂ��������ꍇ
+				//	後ろに設定済み項目があった場合
 				m_nSet[ i ] = m_nSet[ j ];
 				m_nSet[ j ] = -1;
 
-				//	�F�ݒ�����ւ���
-				//	�\���̂��Ɠ���ւ���Ɩ��O���ς���Ă��܂��̂Œ���
+				//	色設定を入れ替える
+				//	構造体ごと入れ替えると名前が変わってしまうので注意
 				ColorInfo &col1 = m_Types.m_ColorInfoArr[ COLORIDX_KEYWORD1 + i ];
 				ColorInfo &col2   = m_Types.m_ColorInfoArr[ COLORIDX_KEYWORD1 + j ];
 
@@ -1060,12 +1060,12 @@ void CPropTypesColor::RearrangeKeywordSet( HWND hwndDlg )
 			}
 		}
 		if( j == MAX_KEYWORDSET_PER_TYPE ){
-			//	���ɂ͐ݒ�ςݍ��ڂ��Ȃ�����
+			//	後ろには設定済み項目がなかった
 			break;
 		}
 	}
 	
-	//	���X�g�{�b�N�X�y�ѐF�ݒ�{�^�����ĕ`��
+	//	リストボックス及び色設定ボタンを再描画
 	::InvalidateRect( ::GetDlgItem( hwndDlg, IDC_BUTTON_TEXTCOLOR ), NULL, TRUE );
 	::InvalidateRect( ::GetDlgItem( hwndDlg, IDC_BUTTON_BACKCOLOR ), NULL, TRUE );
 	::InvalidateRect( ::GetDlgItem( hwndDlg, IDC_LIST_COLORS ), NULL, TRUE );
@@ -1073,7 +1073,7 @@ void CPropTypesColor::RearrangeKeywordSet( HWND hwndDlg )
 
 
 
-/* �F��ʃ��X�g �I�[�i�[�`�� */
+/* 色種別リスト オーナー描画 */
 void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 {
 	ColorInfo*	pColorInfo;
@@ -1083,21 +1083,21 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 
 	if( pDis == NULL || pDis->itemData == 0 ) return;
 
-	//�`��Ώ�
+	//描画対象
 	CGraphics gr(pDis->hDC);
 
 //	rc0 = pDis->rcItem;
 	rc1 = pDis->rcItem;
 //	rc2 = pDis->rcItem;
 
-	/* �A�C�e���f�[�^�̎擾 */
+	/* アイテムデータの取得 */
 	pColorInfo = (ColorInfo*)pDis->itemData;
 
-	/* �A�C�e����`�h��Ԃ� */
+	/* アイテム矩形塗りつぶし */
 	gr.SetBrushColor( ::GetSysColor( COLOR_WINDOW ) );
 	gr.FillMyRect( pDis->rcItem );
 	
-	/* �A�C�e�����I������Ă��� */
+	/* アイテムが選択されている */
 	if( pDis->itemState & ODS_SELECTED ){
 		gr.SetBrushColor( ::GetSysColor( COLOR_HIGHLIGHT ) );
 		gr.SetTextForeColor( ::GetSysColor( COLOR_HIGHLIGHTTEXT ) );
@@ -1110,15 +1110,15 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 	rc1.top += 2;
 	rc1.right -= ( 2 + 27 );
 	rc1.bottom -= 2;
-	/* �I���n�C���C�g��` */
+	/* 選択ハイライト矩形 */
 	gr.FillMyRect(rc1);
-	/* �e�L�X�g */
+	/* テキスト */
 	::SetBkMode( gr, TRANSPARENT );
 	::TextOut( gr, rc1.left, rc1.top, pColorInfo->m_szName, _tcslen( pColorInfo->m_szName ) );
-	if( pColorInfo->m_sFontAttr.m_bBoldFont ){	/* ������ */
+	if( pColorInfo->m_sFontAttr.m_bBoldFont ){	/* 太字か */
 		::TextOut( gr, rc1.left + 1, rc1.top, pColorInfo->m_szName, _tcslen( pColorInfo->m_szName ) );
 	}
-	if( pColorInfo->m_sFontAttr.m_bUnderLine ){	/* ������ */
+	if( pColorInfo->m_sFontAttr.m_bUnderLine ){	/* 下線か */
 		SIZE	sz;
 		::GetTextExtentPoint32( gr, pColorInfo->m_szName, _tcslen( pColorInfo->m_szName ), &sz );
 		::MoveToEx( gr, rc1.left,		rc1.bottom - 2, NULL );
@@ -1127,19 +1127,19 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 		::LineTo( gr, rc1.left + sz.cx,	rc1.bottom - 1 );
 	}
 
-	/* �A�C�e���Ƀt�H�[�J�X������ */	// 2006.05.01 ryoji �`������̕s�����C��
+	/* アイテムにフォーカスがある */	// 2006.05.01 ryoji 描画条件の不正を修正
 	if( pDis->itemState & ODS_FOCUS ){
 		::DrawFocusRect( gr, &pDis->rcItem );
 	}
 
-	/* �u�F����/�\������v�̃`�F�b�N */
+	/* 「色分け/表示する」のチェック */
 	rc1 = pDis->rcItem;
 	rc1.left += 2;
 	rc1.top += 3;
 	rc1.right = rc1.left + 12;
 	rc1.bottom = rc1.top + 12;
-	if( pColorInfo->m_bDisp ){	/* �F����/�\������ */
-		// 2006.04.26 ryoji �e�L�X�g�F���g���i�u�n�C�R���g���X�g���v�̂悤�Ȑݒ�ł�������悤�Ɂj
+	if( pColorInfo->m_bDisp ){	/* 色分け/表示する */
+		// 2006.04.26 ryoji テキスト色を使う（「ハイコントラスト黒」のような設定でも見えるように）
 		gr.SetPen( ::GetSysColor( COLOR_WINDOWTEXT ) );
 
 		::MoveToEx( gr,	rc1.left + 2, rc1.top + 6, NULL );
@@ -1159,11 +1159,11 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 //	return;
 
 
-	// 2002/11/02 Moca ��r���@�ύX
-//	if( 0 != strcmp( "�J�[�\���s�A���_�[���C��", pColorInfo->m_szName ) )
-	if ( 0 == (g_ColorAttributeArr[pColorInfo->m_nColorIdx].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji �t���O���p�Ŋȑf��
+	// 2002/11/02 Moca 比較方法変更
+//	if( 0 != strcmp( "カーソル行アンダーライン", pColorInfo->m_szName ) )
+	if ( 0 == (g_ColorAttributeArr[pColorInfo->m_nColorIdx].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji フラグ利用で簡素化
 	{
-		/* �w�i�F ���{��` */
+		/* 背景色 見本矩形 */
 		rc1 = pDis->rcItem;
 		rc1.left = rc1.right - 13;
 		rc1.top += 2;
@@ -1178,7 +1178,7 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 
 	if( 0 == (g_ColorAttributeArr[pColorInfo->m_nColorIdx].fAttribute & COLOR_ATTRIB_NO_TEXT) )
 	{
-		/* �O�i�F ���{��` */
+		/* 前景色 見本矩形 */
 		rc1 = pDis->rcItem;
 		rc1.left = rc1.right - 27;
 		rc1.top += 2;
@@ -1192,7 +1192,7 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 
 
 
-/* �F�I���_�C�A���O */
+/* 色選択ダイアログ */
 BOOL CPropTypesColor::SelectColor( HWND hwndParent, COLORREF* pColor, DWORD* pCustColors )
 {
 	CHOOSECOLOR		cc;

--- a/sakura_core/typeprop/CPropTypesKeyHelp.cpp
+++ b/sakura_core/typeprop/CPropTypesKeyHelp.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	ƒ^ƒCƒv•Êİ’è - ƒL[ƒ[ƒhƒwƒ‹ƒv ƒy[ƒW
+ï»¿/*!	@file
+	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š - ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ— ãƒšãƒ¼ã‚¸
 
 	@author fon
-	@date 2006/04/10 V‹Kì¬
+	@date 2006/04/10 æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2006, fon, ryoji
@@ -44,23 +44,23 @@
 using namespace std;
 
 static const DWORD p_helpids[] = {	// 2006.10.10 ryoji
-	IDC_CHECK_KEYHELP,				HIDC_CHECK_KEYHELP,				//ƒL[ƒ[ƒhƒwƒ‹ƒv‹@”\‚ğg‚¤
+	IDC_CHECK_KEYHELP,				HIDC_CHECK_KEYHELP,				//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—æ©Ÿèƒ½ã‚’ä½¿ã†
 	IDC_LIST_KEYHELP,				HIDC_LIST_KEYHELP,				//SysListView32
-	IDC_BUTTON_KEYHELP_UPD,			HIDC_BUTTON_KEYHELP_UPD,		//XV(&E)
+	IDC_BUTTON_KEYHELP_UPD,			HIDC_BUTTON_KEYHELP_UPD,		//æ›´æ–°(&E)
 	IDC_EDIT_KEYHELP,				HIDC_EDIT_KEYHELP,				//EDITTEXT
-	IDC_BUTTON_KEYHELP_REF,			HIDC_BUTTON_KEYHELP_REF,		//QÆ(&O)...
-	IDC_BUTTON_KEYHELP_TOP,			HIDC_BUTTON_KEYHELP_TOP,		//æ“ª(&T)
-	IDC_BUTTON_KEYHELP_UP,			HIDC_BUTTON_KEYHELP_UP,			//ã‚Ö(&U)
-	IDC_BUTTON_KEYHELP_DOWN,		HIDC_BUTTON_KEYHELP_DOWN,		//‰º‚Ö(&G)
-	IDC_BUTTON_KEYHELP_LAST,		HIDC_BUTTON_KEYHELP_LAST,		//ÅI(&B)
-	IDC_BUTTON_KEYHELP_INS,			HIDC_BUTTON_KEYHELP_INS,		//‘}“ü(&S)
-	IDC_BUTTON_KEYHELP_DEL,			HIDC_BUTTON_KEYHELP_DEL,		//íœ(&D)
-	IDC_CHECK_KEYHELP_ALLSEARCH,	HIDC_CHECK_KEYHELP_ALLSEARCH,	//‘S«‘ŒŸõ‚·‚é(&A)
-	IDC_CHECK_KEYHELP_KEYDISP,		HIDC_CHECK_KEYHELP_KEYDISP,		//ƒL[ƒ[ƒh‚à•\¦‚·‚é(&W)
-	IDC_CHECK_KEYHELP_PREFIX,		HIDC_CHECK_KEYHELP_PREFIX,		//‘O•ûˆê’vŒŸõ(&P)
-	IDC_COMBO_MENU,					HIDC_COMBO_KEYHELP_RMENU,		//‰EƒNƒŠƒbƒNƒƒjƒ…[
-	IDC_BUTTON_KEYHELP_IMPORT,		HIDC_BUTTON_KEYHELP_IMPORT,		//ƒCƒ“ƒ|[ƒg
-	IDC_BUTTON_KEYHELP_EXPORT,		HIDC_BUTTON_KEYHELP_EXPORT,		//ƒGƒNƒXƒ|[ƒg
+	IDC_BUTTON_KEYHELP_REF,			HIDC_BUTTON_KEYHELP_REF,		//å‚ç…§(&O)...
+	IDC_BUTTON_KEYHELP_TOP,			HIDC_BUTTON_KEYHELP_TOP,		//å…ˆé ­(&T)
+	IDC_BUTTON_KEYHELP_UP,			HIDC_BUTTON_KEYHELP_UP,			//ä¸Šã¸(&U)
+	IDC_BUTTON_KEYHELP_DOWN,		HIDC_BUTTON_KEYHELP_DOWN,		//ä¸‹ã¸(&G)
+	IDC_BUTTON_KEYHELP_LAST,		HIDC_BUTTON_KEYHELP_LAST,		//æœ€çµ‚(&B)
+	IDC_BUTTON_KEYHELP_INS,			HIDC_BUTTON_KEYHELP_INS,		//æŒ¿å…¥(&S)
+	IDC_BUTTON_KEYHELP_DEL,			HIDC_BUTTON_KEYHELP_DEL,		//å‰Šé™¤(&D)
+	IDC_CHECK_KEYHELP_ALLSEARCH,	HIDC_CHECK_KEYHELP_ALLSEARCH,	//å…¨è¾æ›¸æ¤œç´¢ã™ã‚‹(&A)
+	IDC_CHECK_KEYHELP_KEYDISP,		HIDC_CHECK_KEYHELP_KEYDISP,		//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚‚è¡¨ç¤ºã™ã‚‹(&W)
+	IDC_CHECK_KEYHELP_PREFIX,		HIDC_CHECK_KEYHELP_PREFIX,		//å‰æ–¹ä¸€è‡´æ¤œç´¢(&P)
+	IDC_COMBO_MENU,					HIDC_COMBO_KEYHELP_RMENU,		//å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼
+	IDC_BUTTON_KEYHELP_IMPORT,		HIDC_BUTTON_KEYHELP_IMPORT,		//ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	IDC_BUTTON_KEYHELP_EXPORT,		HIDC_BUTTON_KEYHELP_EXPORT,		//ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 	0, 0
 };
 
@@ -73,9 +73,9 @@ static int nKeyHelpRMenuType[] = {
 	STR_KEYHELP_RMENU_BOTTOM,
 };
 
-/*! ƒL[ƒ[ƒh«‘ƒtƒ@ƒCƒ‹İ’è ƒƒbƒZ[ƒWˆ—
+/*! ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«è¨­å®š ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 
-	@date 2006.04.10 fon V‹Kì¬
+	@date 2006.04.10 fon æ–°è¦ä½œæˆ
 */
 INT_PTR CPropTypesKeyHelp::DispatchEvent(
 	HWND		hwndDlg,	// handle to dialog box
@@ -93,9 +93,9 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 	LV_COLUMN	col;
 	RECT		rc;
 
-	BOOL	bUse;						/* «‘‚ğ g—p‚·‚é/‚µ‚È‚¢ */
-	TCHAR	szAbout[DICT_ABOUT_LEN];	/* «‘‚Ìà–¾(«‘ƒtƒ@ƒCƒ‹‚Ì1s–Ú‚©‚ç¶¬) */
-	TCHAR	szPath[_MAX_PATH];			/* ƒtƒ@ƒCƒ‹ƒpƒX */
+	BOOL	bUse;						/* è¾æ›¸ã‚’ ä½¿ç”¨ã™ã‚‹/ã—ãªã„ */
+	TCHAR	szAbout[DICT_ABOUT_LEN];	/* è¾æ›¸ã®èª¬æ˜(è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ã®1è¡Œç›®ã‹ã‚‰ç”Ÿæˆ) */
+	TCHAR	szPath[_MAX_PATH];			/* ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 	DWORD	dwStyle;
 
 	hwndList = GetDlgItem( hwndDlg, IDC_LIST_KEYHELP );
@@ -103,9 +103,9 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 	switch( uMsg ){
 	case WM_INITDIALOG:
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
-		/* ƒJƒ‰ƒ€’Ç‰Á */
+		/* ã‚«ãƒ©ãƒ è¿½åŠ  */
 		::GetWindowRect( hwndList, &rc );
-		/* ƒŠƒXƒg‚Éƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ğ’Ç‰Á */
+		/* ãƒªã‚¹ãƒˆã«ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã‚’è¿½åŠ  */
 		dwStyle = ListView_GetExtendedListViewStyle(hwndList);
 		dwStyle |= LVS_EX_CHECKBOXES /*| LVS_EX_FULLROWSELECT*/ | LVS_EX_GRIDLINES;
 		ListView_SetExtendedListViewStyle(hwndList, dwStyle);
@@ -113,104 +113,104 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 		col.mask     = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;
 		col.fmt      = LVCFMT_LEFT;
 		col.cx       = (rc.right - rc.left) * 25 / 100;
-		col.pszText  = const_cast<TCHAR*>(LS(STR_PROPTYPKEYHELP_DIC));	/* w’è«‘ƒtƒ@ƒCƒ‹‚Ìg—p‰Â”Û */
+		col.pszText  = const_cast<TCHAR*>(LS(STR_PROPTYPKEYHELP_DIC));	/* æŒ‡å®šè¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½¿ç”¨å¯å¦ */
 		col.iSubItem = 0;
 		ListView_InsertColumn( hwndList, 0, &col );
 		col.mask     = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;
 		col.fmt      = LVCFMT_LEFT;
 		col.cx       = (rc.right - rc.left) * 55 / 100;
-		col.pszText  = const_cast<TCHAR*>(LS(STR_PROPTYPKEYHELP_INFO));		/* w’è«‘‚Ì‚Ps–Ú‚ğæ“¾ */
+		col.pszText  = const_cast<TCHAR*>(LS(STR_PROPTYPKEYHELP_INFO));		/* æŒ‡å®šè¾æ›¸ã®ï¼‘è¡Œç›®ã‚’å–å¾— */
 		col.iSubItem = 1;
 		ListView_InsertColumn( hwndList, 1, &col );
 		col.mask     = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;
 		col.fmt      = LVCFMT_LEFT;
 		col.cx       = (rc.right - rc.left) * 18 / 100;
-		col.pszText  = const_cast<TCHAR*>(LS(STR_PROPTYPKEYHELP_PATH));				/* w’è«‘ƒtƒ@ƒCƒ‹ƒpƒX */
+		col.pszText  = const_cast<TCHAR*>(LS(STR_PROPTYPKEYHELP_PATH));				/* æŒ‡å®šè¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 		col.iSubItem = 2;
 		ListView_InsertColumn( hwndList, 2, &col );
-		SetData( hwndDlg );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è «‘ƒtƒ@ƒCƒ‹ˆê—— */
+		SetData( hwndDlg );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§ */
 
-		/* ƒŠƒXƒg‚ª‚ ‚ê‚Îæ“ª‚ğƒtƒH[ƒJƒX‚·‚é */
+		/* ãƒªã‚¹ãƒˆãŒã‚ã‚Œã°å…ˆé ­ã‚’ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã™ã‚‹ */
 		if(ListView_GetItemCount(hwndList) > 0){
 			ListView_SetItemState( hwndList, 0, LVIS_SELECTED /*| LVIS_FOCUSED*/, LVIS_SELECTED /*| LVIS_FOCUSED*/ );
 		}
-		/* ƒŠƒXƒg‚ª‚È‚¯‚ê‚Î‰Šú’l‚Æ‚µ‚Ä—p“r‚ğ•\¦ */
+		/* ãƒªã‚¹ãƒˆãŒãªã‘ã‚Œã°åˆæœŸå€¤ã¨ã—ã¦ç”¨é€”ã‚’è¡¨ç¤º */
 		else{
 			::DlgItem_SetText( hwndDlg, IDC_LABEL_KEYHELP_ABOUT, LS(STR_PROPTYPKEYHELP_LINE1) );
 			::DlgItem_SetText( hwndDlg, IDC_EDIT_KEYHELP, LS(STR_PROPTYPKEYHELP_DICPATH) );
 		}
 
-		/* ‰Šúó‘Ô‚ğİ’è */
+		/* åˆæœŸçŠ¶æ…‹ã‚’è¨­å®š */
 		SendMessageCmd(hwndDlg, WM_COMMAND, (WPARAM)MAKELONG(IDC_CHECK_KEYHELP,BN_CLICKED), 0 );
 
 		return TRUE;
 
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID	= LOWORD(wParam);			/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+		wNotifyCode = HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID	= LOWORD(wParam);			/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 
 		switch( wNotifyCode ){
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 
 			switch( wID ){
-			case IDC_CHECK_KEYHELP:	/* ƒL[ƒ[ƒhƒwƒ‹ƒv‹@”\‚ğg‚¤ */
+			case IDC_CHECK_KEYHELP:	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—æ©Ÿèƒ½ã‚’ä½¿ã† */
 				{
 					BOOL bEnable = TRUE;
 					if( !IsDlgButtonChecked( hwndDlg, IDC_CHECK_KEYHELP ) ){
 						bEnable = FALSE;
 					}
-					//EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_KEYHELP ), FALSE );			//ƒL[ƒ[ƒhƒwƒ‹ƒv‹@”\‚ğg‚¤(&K)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_FRAME_KEYHELP ), bEnable );		  	//«‘ƒtƒ@ƒCƒ‹ˆê——(&L)
+					//EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_KEYHELP ), FALSE );			//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—æ©Ÿèƒ½ã‚’ä½¿ã†(&K)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_FRAME_KEYHELP ), bEnable );		  	//è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ä¸€è¦§(&L)
 					EnableWindow( GetDlgItem( hwndDlg, IDC_LIST_KEYHELP ), bEnable );         	//SysListView32
-					EnableWindow( GetDlgItem( hwndDlg, IDC_LABEL_KEYHELP_TITLE ), bEnable );  	//<«‘‚Ìà–¾>
-					EnableWindow( GetDlgItem( hwndDlg, IDC_LABEL_KEYHELP_ABOUT ), bEnable );  	//«‘ƒtƒ@ƒCƒ‹‚ÌŠT—v
-					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_UPD ), bEnable );   	//XV(&E)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_LABEL_KEYHELP_KEYWORD ), bEnable );	//«‘ƒtƒ@ƒCƒ‹
+					EnableWindow( GetDlgItem( hwndDlg, IDC_LABEL_KEYHELP_TITLE ), bEnable );  	//<è¾æ›¸ã®èª¬æ˜>
+					EnableWindow( GetDlgItem( hwndDlg, IDC_LABEL_KEYHELP_ABOUT ), bEnable );  	//è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ã®æ¦‚è¦
+					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_UPD ), bEnable );   	//æ›´æ–°(&E)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_LABEL_KEYHELP_KEYWORD ), bEnable );	//è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«
 					EnableWindow( GetDlgItem( hwndDlg, IDC_EDIT_KEYHELP ), bEnable );         	//EDITTEXT
-					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_REF ), bEnable );   	//QÆ(&O)...
-					EnableWindow( GetDlgItem( hwndDlg, IDC_LABEL_KEYHELP_PRIOR ), bEnable );  	//ª—Dæ“x(‚)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_TOP ), bEnable );   	//æ“ª(&T)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_UP ), bEnable );    	//ã‚Ö(&U)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_DOWN ), bEnable );  	//‰º‚Ö(&G)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_LAST ), bEnable );  	//ÅI(&B)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_INS ), bEnable );   	//‘}“ü(&S)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_DEL ), bEnable );   	//íœ(&D)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_KEYHELP_ALLSEARCH ), bEnable );	//‘S«‘ŒŸõ‚·‚é(&A)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_KEYHELP_KEYDISP ), bEnable );	//ƒL[ƒ[ƒh‚à•\¦‚·‚é(&W)
-					EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_KEYHELP_PREFIX ), bEnable );		//‘O•ûˆê’vŒŸõ(&P)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_REF ), bEnable );   	//å‚ç…§(&O)...
+					EnableWindow( GetDlgItem( hwndDlg, IDC_LABEL_KEYHELP_PRIOR ), bEnable );  	//â†‘å„ªå…ˆåº¦(é«˜)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_TOP ), bEnable );   	//å…ˆé ­(&T)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_UP ), bEnable );    	//ä¸Šã¸(&U)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_DOWN ), bEnable );  	//ä¸‹ã¸(&G)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_LAST ), bEnable );  	//æœ€çµ‚(&B)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_INS ), bEnable );   	//æŒ¿å…¥(&S)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_BUTTON_KEYHELP_DEL ), bEnable );   	//å‰Šé™¤(&D)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_KEYHELP_ALLSEARCH ), bEnable );	//å…¨è¾æ›¸æ¤œç´¢ã™ã‚‹(&A)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_KEYHELP_KEYDISP ), bEnable );	//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚‚è¡¨ç¤ºã™ã‚‹(&W)
+					EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_KEYHELP_PREFIX ), bEnable );		//å‰æ–¹ä¸€è‡´æ¤œç´¢(&P)
 					EnableWindow( GetDlgItem( hwndDlg, IDC_STATIC_MENU ), bEnable );
 					EnableWindow( GetDlgItem( hwndDlg, IDC_COMBO_MENU ), bEnable );
 				}
 				m_Types.m_nKeyHelpNum = ListView_GetItemCount( hwndList );
 				return TRUE;
 
-			/* ‘}“üEXVƒCƒxƒ“ƒg‚ğ“Z‚ß‚Äˆ— */
-			case IDC_BUTTON_KEYHELP_INS:	/* ‘}“ü */
-			case IDC_BUTTON_KEYHELP_UPD:	/* XV */
+			/* æŒ¿å…¥ãƒ»æ›´æ–°ã‚¤ãƒ™ãƒ³ãƒˆã‚’çºã‚ã¦å‡¦ç† */
+			case IDC_BUTTON_KEYHELP_INS:	/* æŒ¿å…¥ */
+			case IDC_BUTTON_KEYHELP_UPD:	/* æ›´æ–° */
 				nIndex2 = ListView_GetItemCount(hwndList);
-				/* ‘I‘ğ’†‚ÌƒL[‚ğ’T‚·B */
+				/* é¸æŠä¸­ã®ã‚­ãƒ¼ã‚’æ¢ã™ã€‚ */
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 
-				if(wID == IDC_BUTTON_KEYHELP_INS){	/* ‘}“ü */
+				if(wID == IDC_BUTTON_KEYHELP_INS){	/* æŒ¿å…¥ */
 					if( nIndex2 >= MAX_KEYHELP_FILE ){
 						ErrorMessage( hwndDlg, LS(STR_PROPTYPKEYHELP_ERR_REG1));
 						return FALSE;
 					}if( -1 == nIndex ){
-						/* ‘I‘ğ’†‚Å‚È‚¯‚ê‚ÎÅŒã‚É‚·‚éB */
+						/* é¸æŠä¸­ã§ãªã‘ã‚Œã°æœ€å¾Œã«ã™ã‚‹ã€‚ */
 						nIndex = nIndex2;
 					}
-				}else{								/* XV */
+				}else{								/* æ›´æ–° */
 					if( -1 == nIndex ){
 						ErrorMessage( hwndDlg, LS(STR_PROPTYPKEYHELP_SELECT));
 						return FALSE;
 					}
 				}
-				/* XV‚·‚éƒL[î•ñ‚ğæ“¾‚·‚éB */
+				/* æ›´æ–°ã™ã‚‹ã‚­ãƒ¼æƒ…å ±ã‚’å–å¾—ã™ã‚‹ã€‚ */
 				auto_memset(szPath, 0, _countof(szPath));
 				::DlgItem_GetText( hwndDlg, IDC_EDIT_KEYHELP, szPath, _countof(szPath) );
 				if( szPath[0] == _T('\0') ) return FALSE;
-				/* d•¡ŒŸ¸ */
+				/* é‡è¤‡æ¤œæŸ» */
 				nIndex2 = ListView_GetItemCount(hwndList);
 				TCHAR szPath2[_MAX_PATH];
 				int i;
@@ -218,7 +218,7 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 					auto_memset(szPath2, 0, _countof(szPath2));
 					ListView_GetItemText(hwndList, i, 2, szPath2, _countof(szPath2));
 					if( _tcscmp(szPath, szPath2) == 0 ){
-						if( (wID ==IDC_BUTTON_KEYHELP_UPD) && (i == nIndex) ){	/* XVA•Ï‚í‚Á‚Ä‚¢‚È‚©‚Á‚½‚ç‰½‚à‚µ‚È‚¢ */
+						if( (wID ==IDC_BUTTON_KEYHELP_UPD) && (i == nIndex) ){	/* æ›´æ–°æ™‚ã€å¤‰ã‚ã£ã¦ã„ãªã‹ã£ãŸã‚‰ä½•ã‚‚ã—ãªã„ */
 						}else{
 							ErrorMessage( hwndDlg, LS(STR_PROPTYPKEYHELP_ERR_REG2));
 							return FALSE;
@@ -226,229 +226,229 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 					}
 				}
 
-				/* w’è‚µ‚½ƒpƒX‚É«‘‚ª‚ ‚é‚©ƒ`ƒFƒbƒN‚·‚é */
+				/* æŒ‡å®šã—ãŸãƒ‘ã‚¹ã«è¾æ›¸ãŒã‚ã‚‹ã‹ãƒã‚§ãƒƒã‚¯ã™ã‚‹ */
 				{
 					CTextInputStream_AbsIni in(szPath);
 					if(!in){
 						ErrorMessage( hwndDlg, LS(STR_PROPTYPKEYHELP_ERR_OPEN), szPath );
 						return FALSE;
 					}
-					// ŠJ‚¯‚½‚È‚ç1s–Ú‚ğæ“¾‚µ‚Ä‚©‚ç•Â‚¶‚é -> szAbout
+					// é–‹ã‘ãŸãªã‚‰1è¡Œç›®ã‚’å–å¾—ã—ã¦ã‹ã‚‰é–‰ã˜ã‚‹ -> szAbout
 					std::wstring line=in.ReadLineW();
 					_wcstotcs(szAbout,line.c_str(),_countof(szAbout));
 					in.Close();
 				}
 				strcnv(szAbout);
 
-				/* ‚Â‚¢‚Å‚É«‘‚Ìà–¾‚ğXV */
-				::DlgItem_SetText( hwndDlg, IDC_LABEL_KEYHELP_ABOUT, szAbout );	/* «‘ƒtƒ@ƒCƒ‹‚ÌŠT—v */
+				/* ã¤ã„ã§ã«è¾æ›¸ã®èª¬æ˜ã‚’æ›´æ–° */
+				::DlgItem_SetText( hwndDlg, IDC_LABEL_KEYHELP_ABOUT, szAbout );	/* è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ã®æ¦‚è¦ */
 				
-				/* XV‚Ì‚Æ‚«‚Ísíœ‚·‚éB */
-				if(wID == IDC_BUTTON_KEYHELP_UPD){	/* XV */
+				/* æ›´æ–°ã®ã¨ãã¯è¡Œå‰Šé™¤ã™ã‚‹ã€‚ */
+				if(wID == IDC_BUTTON_KEYHELP_UPD){	/* æ›´æ–° */
 					ListView_DeleteItem( hwndList, nIndex );
 				}
 				
-				/* ON/OFF ƒtƒ@ƒCƒ‹–¼ */
+				/* ON/OFF ãƒ•ã‚¡ã‚¤ãƒ«å */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex;
 				lvi.iSubItem = 0;
-				lvi.pszText = GetFileName(szPath);	/* ƒtƒ@ƒCƒ‹–¼‚ğ•\¦ */
+				lvi.pszText = GetFileName(szPath);	/* ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¡¨ç¤º */
 				ListView_InsertItem( hwndList, &lvi );
-				/* «‘‚Ìà–¾ */
+				/* è¾æ›¸ã®èª¬æ˜ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex;
 				lvi.iSubItem = 1;
 				lvi.pszText  = szAbout;
 				ListView_SetItem( hwndList, &lvi );
-				/* «‘ƒtƒ@ƒCƒ‹ƒpƒX */
+				/* è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex;
 				lvi.iSubItem = 2;
 				lvi.pszText  = szPath;
 				ListView_SetItem( hwndList, &lvi );
 				
-				/* ƒfƒtƒHƒ‹ƒg‚Åƒ`ƒFƒbƒNON */
+				/* ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã§ãƒã‚§ãƒƒã‚¯ON */
 				ListView_SetCheckState(hwndList, nIndex, TRUE);
 
-				/* XV‚µ‚½ƒL[‚ğ‘I‘ğ‚·‚éB */
+				/* æ›´æ–°ã—ãŸã‚­ãƒ¼ã‚’é¸æŠã™ã‚‹ã€‚ */
 				ListView_SetItemState( hwndList, nIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				GetData( hwndDlg );
 				return TRUE;
 
-			case IDC_BUTTON_KEYHELP_DEL:	/* íœ */
-				/* ‘I‘ğ’†‚ÌƒL[”Ô†‚ğ’T‚·B */
+			case IDC_BUTTON_KEYHELP_DEL:	/* å‰Šé™¤ */
+				/* é¸æŠä¸­ã®ã‚­ãƒ¼ç•ªå·ã‚’æ¢ã™ã€‚ */
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
-				/* íœ‚·‚éB */
+				/* å‰Šé™¤ã™ã‚‹ã€‚ */
 				ListView_DeleteItem( hwndList, nIndex );
-				/* ƒŠƒXƒg‚ª‚È‚­‚È‚Á‚½‚ç‰Šú’l‚Æ‚µ‚Ä—p“r‚ğ•\¦ */
+				/* ãƒªã‚¹ãƒˆãŒãªããªã£ãŸã‚‰åˆæœŸå€¤ã¨ã—ã¦ç”¨é€”ã‚’è¡¨ç¤º */
 				if(ListView_GetItemCount(hwndList) == 0){
 					::DlgItem_SetText( hwndDlg, IDC_LABEL_KEYHELP_ABOUT, LS(STR_PROPTYPKEYHELP_LINE1) );
 					::DlgItem_SetText( hwndDlg, IDC_EDIT_KEYHELP, LS(STR_PROPTYPKEYHELP_DICPATH) );
-				}/* ƒŠƒXƒg‚ÌÅŒã‚ğíœ‚µ‚½ê‡‚ÍAíœŒã‚ÌƒŠƒXƒg‚ÌÅŒã‚ğ‘I‘ğ‚·‚éB */
+				}/* ãƒªã‚¹ãƒˆã®æœ€å¾Œã‚’å‰Šé™¤ã—ãŸå ´åˆã¯ã€å‰Šé™¤å¾Œã®ãƒªã‚¹ãƒˆã®æœ€å¾Œã‚’é¸æŠã™ã‚‹ã€‚ */
 				else if(nIndex > ListView_GetItemCount(hwndList)-1){
 					ListView_SetItemState( hwndList, ListView_GetItemCount(hwndList)-1, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
-				}/* “¯‚¶ˆÊ’u‚ÌƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB */
+				}/* åŒã˜ä½ç½®ã®ã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚ */
 				else{
 					ListView_SetItemState( hwndList, nIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				}
 				GetData( hwndDlg );
 				return TRUE;
 
-			case IDC_BUTTON_KEYHELP_TOP:	/* æ“ª */
-				/* ‘I‘ğ’†‚ÌƒL[‚ğ’T‚·B */
+			case IDC_BUTTON_KEYHELP_TOP:	/* å…ˆé ­ */
+				/* é¸æŠä¸­ã®ã‚­ãƒ¼ã‚’æ¢ã™ã€‚ */
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
-				if( 0 == nIndex ) return TRUE;	/* ‚·‚Å‚Éæ“ª‚É‚ ‚éB */
+				if( 0 == nIndex ) return TRUE;	/* ã™ã§ã«å…ˆé ­ã«ã‚ã‚‹ã€‚ */
 				nIndex2 = 0;
 				bUse = ListView_GetCheckState(hwndList, nIndex);
 				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
 				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
-				ListView_DeleteItem(hwndList, nIndex);	/* ŒÃ‚¢ƒL[‚ğíœ */
+				ListView_DeleteItem(hwndList, nIndex);	/* å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤ */
 				/* ON-OFF */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 0;
-				lvi.pszText = GetFileName(szPath);	/* ƒtƒ@ƒCƒ‹–¼‚ğ•\¦ */
+				lvi.pszText = GetFileName(szPath);	/* ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¡¨ç¤º */
 				ListView_InsertItem( hwndList, &lvi );
-				/* «‘‚Ìà–¾ */
+				/* è¾æ›¸ã®èª¬æ˜ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 1;
 				lvi.pszText  = szAbout;
 				ListView_SetItem( hwndList, &lvi );
-				/* «‘ƒtƒ@ƒCƒ‹ƒpƒX */
+				/* è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 2;
 				lvi.pszText  = szPath;
 				ListView_SetItem( hwndList, &lvi );
 				ListView_SetCheckState(hwndList, nIndex2, bUse);
-				/* ˆÚ“®‚µ‚½ƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB */
+				/* ç§»å‹•ã—ãŸã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚ */
 				ListView_SetItemState( hwndList, nIndex2, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				GetData( hwndDlg );
 				return TRUE;
 
-			case IDC_BUTTON_KEYHELP_LAST:	/* ÅI */
+			case IDC_BUTTON_KEYHELP_LAST:	/* æœ€çµ‚ */
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
 				nIndex2 = ListView_GetItemCount(hwndList);
-				if( nIndex2 - 1 == nIndex ) return TRUE;	/* ‚·‚Å‚ÉÅI‚É‚ ‚éB */
+				if( nIndex2 - 1 == nIndex ) return TRUE;	/* ã™ã§ã«æœ€çµ‚ã«ã‚ã‚‹ã€‚ */
 				bUse = ListView_GetCheckState(hwndList, nIndex);
 				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
 				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
-				/* ƒL[‚ğ’Ç‰Á‚·‚éB */
+				/* ã‚­ãƒ¼ã‚’è¿½åŠ ã™ã‚‹ã€‚ */
 				/* ON-OFF */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 0;
-				lvi.pszText = GetFileName(szPath);	/* ƒtƒ@ƒCƒ‹–¼‚ğ•\¦ */
+				lvi.pszText = GetFileName(szPath);	/* ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¡¨ç¤º */
 				ListView_InsertItem( hwndList, &lvi );
-				/* «‘‚Ìà–¾ */
+				/* è¾æ›¸ã®èª¬æ˜ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 1;
 				lvi.pszText  = szAbout;
 				ListView_SetItem( hwndList, &lvi );
-				/* «‘ƒtƒ@ƒCƒ‹ƒpƒX */
+				/* è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 2;
 				lvi.pszText  = szPath;
 				ListView_SetItem( hwndList, &lvi );
 				ListView_SetCheckState(hwndList, nIndex2, bUse);
-				/* ˆÚ“®‚µ‚½ƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB */
+				/* ç§»å‹•ã—ãŸã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚ */
 				ListView_SetItemState( hwndList, nIndex2, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
-				ListView_DeleteItem(hwndList, nIndex);	/* ŒÃ‚¢ƒL[‚ğíœ */
+				ListView_DeleteItem(hwndList, nIndex);	/* å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤ */
 				GetData( hwndDlg );
 				return TRUE;
 
-			case IDC_BUTTON_KEYHELP_UP:	/* ã‚Ö */
+			case IDC_BUTTON_KEYHELP_UP:	/* ä¸Šã¸ */
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
-				if( 0 == nIndex ) return TRUE;	/* ‚·‚Å‚Éæ“ª‚É‚ ‚éB */
+				if( 0 == nIndex ) return TRUE;	/* ã™ã§ã«å…ˆé ­ã«ã‚ã‚‹ã€‚ */
 				nIndex2 = ListView_GetItemCount(hwndList);
 				if( nIndex2 <= 1 ) return TRUE;
 				nIndex2 = nIndex - 1;
 				bUse = ListView_GetCheckState(hwndList, nIndex);
 				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
 				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
-				ListView_DeleteItem(hwndList, nIndex);	/* ŒÃ‚¢ƒL[‚ğíœ */
-				/* ƒL[‚ğ’Ç‰Á‚·‚éB */
+				ListView_DeleteItem(hwndList, nIndex);	/* å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤ */
+				/* ã‚­ãƒ¼ã‚’è¿½åŠ ã™ã‚‹ã€‚ */
 				/* ON-OFF */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 0;
-				lvi.pszText = GetFileName(szPath);	/* ƒtƒ@ƒCƒ‹–¼‚ğ•\¦ */
+				lvi.pszText = GetFileName(szPath);	/* ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¡¨ç¤º */
 				ListView_InsertItem( hwndList, &lvi );
-				/* «‘‚Ìà–¾ */
+				/* è¾æ›¸ã®èª¬æ˜ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 1;
 				lvi.pszText  = szAbout;
 				ListView_SetItem( hwndList, &lvi );
-				/* «‘ƒtƒ@ƒCƒ‹ƒpƒX */
+				/* è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 2;
 				lvi.pszText  = szPath;
 				ListView_SetItem( hwndList, &lvi );
 				ListView_SetCheckState(hwndList, nIndex2, bUse);
-				/* ˆÚ“®‚µ‚½ƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB */
+				/* ç§»å‹•ã—ãŸã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚ */
 				ListView_SetItemState( hwndList, nIndex2, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				GetData( hwndDlg );
 				return TRUE;
 
-			case IDC_BUTTON_KEYHELP_DOWN:	/* ‰º‚Ö */
+			case IDC_BUTTON_KEYHELP_DOWN:	/* ä¸‹ã¸ */
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
 				nIndex2 = ListView_GetItemCount(hwndList);
-				if( nIndex2 - 1 == nIndex ) return TRUE;	/* ‚·‚Å‚ÉÅI‚É‚ ‚éB */
+				if( nIndex2 - 1 == nIndex ) return TRUE;	/* ã™ã§ã«æœ€çµ‚ã«ã‚ã‚‹ã€‚ */
 				if( nIndex2 <= 1 ) return TRUE;
 				nIndex2 = nIndex + 2;
 				bUse = ListView_GetCheckState(hwndList, nIndex);
 				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
 				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
-				/* ƒL[‚ğ’Ç‰Á‚·‚éB */
+				/* ã‚­ãƒ¼ã‚’è¿½åŠ ã™ã‚‹ã€‚ */
 				/* ON-OFF */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 0;
-				lvi.pszText = GetFileName(szPath);	/* ƒtƒ@ƒCƒ‹–¼‚ğ•\¦ */
+				lvi.pszText = GetFileName(szPath);	/* ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¡¨ç¤º */
 				ListView_InsertItem( hwndList, &lvi );
-				/* «‘‚Ìà–¾ */
+				/* è¾æ›¸ã®èª¬æ˜ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 1;
 				lvi.pszText  = szAbout;
 				ListView_SetItem( hwndList, &lvi );
-				/* «‘ƒtƒ@ƒCƒ‹ƒpƒX */
+				/* è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 				lvi.mask     = LVIF_TEXT;
 				lvi.iItem    = nIndex2;
 				lvi.iSubItem = 2;
 				lvi.pszText  = szPath;
 				ListView_SetItem( hwndList, &lvi );
 				ListView_SetCheckState(hwndList, nIndex2, bUse);
-				/* ˆÚ“®‚µ‚½ƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB */
+				/* ç§»å‹•ã—ãŸã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚ */
 				ListView_SetItemState( hwndList, nIndex2, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
-				ListView_DeleteItem(hwndList, nIndex);	/* ŒÃ‚¢ƒL[‚ğíœ */
+				ListView_DeleteItem(hwndList, nIndex);	/* å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤ */
 				GetData( hwndDlg );
 				return TRUE;
 
-			case IDC_BUTTON_KEYHELP_REF:	/* ƒL[ƒ[ƒhƒwƒ‹ƒv «‘ƒtƒ@ƒCƒ‹‚ÌuQÆ...vƒ{ƒ^ƒ“ */
+			case IDC_BUTTON_KEYHELP_REF:	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ— è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ã®ã€Œå‚ç…§...ã€ãƒœã‚¿ãƒ³ */
 				{
-					/* ƒtƒ@ƒCƒ‹ƒI[ƒvƒ“ƒ_ƒCƒAƒƒO‚Ì‰Šú‰» */
-					// 2007.05.19 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+					/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã®åˆæœŸåŒ– */
+					// 2007.05.19 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 					CDlgOpenFile::SelectFile(hwndDlg, GetDlgItem(hwndDlg, IDC_EDIT_KEYHELP), _T("*.khp"), true, EFITER_TEXT);
 				}
 				return TRUE;
 
-			case IDC_BUTTON_KEYHELP_IMPORT:	/* ƒCƒ“ƒ|[ƒg */
+			case IDC_BUTTON_KEYHELP_IMPORT:	/* ã‚¤ãƒ³ãƒãƒ¼ãƒˆ */
 				Import(hwndDlg);
 				m_Types.m_nKeyHelpNum = ListView_GetItemCount( hwndList );
 				return TRUE;
 
-			case IDC_BUTTON_KEYHELP_EXPORT:	/* ƒGƒNƒXƒ|[ƒg */
+			case IDC_BUTTON_KEYHELP_EXPORT:	/* ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ */
 				Export(hwndDlg);
 				return TRUE;
 			}
@@ -465,26 +465,26 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 			return TRUE;
 
 		case PSN_KILLACTIVE:
-			/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ «‘ƒtƒ@ƒCƒ‹ƒŠƒXƒg */
+			/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ãƒªã‚¹ãƒˆ */
 			GetData( hwndDlg );
 			return TRUE;
 
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPTYPE_PAGENUM_KEYHELP;
 			return TRUE;
 
-		case LVN_ITEMCHANGED:	/*ƒŠƒXƒg‚Ì€–Ú‚ª•ÏX‚³‚ê‚½Û‚Ìˆ—*/
+		case LVN_ITEMCHANGED:	/*ãƒªã‚¹ãƒˆã®é …ç›®ãŒå¤‰æ›´ã•ã‚ŒãŸéš›ã®å‡¦ç†*/
 			if( pNMHDR->hwndFrom == hwndList ){
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
-				if( -1 == nIndex ){	//íœA”ÍˆÍŠO‚ÅƒNƒŠƒbƒN”½‰f‚³‚ê‚È‚¢ƒoƒOC³	//@@@ 2003.06.17 MIK
+				if( -1 == nIndex ){	//å‰Šé™¤ã€ç¯„å›²å¤–ã§ã‚¯ãƒªãƒƒã‚¯æ™‚åæ˜ ã•ã‚Œãªã„ãƒã‚°ä¿®æ­£	//@@@ 2003.06.17 MIK
 					nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_FOCUSED );
 					return FALSE;
 				}
 				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
 				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
-				::DlgItem_SetText( hwndDlg, IDC_LABEL_KEYHELP_ABOUT, szAbout );	/* «‘‚Ìà–¾ */
-				::DlgItem_SetText( hwndDlg, IDC_EDIT_KEYHELP, szPath );			/* ƒtƒ@ƒCƒ‹ƒpƒX */
+				::DlgItem_SetText( hwndDlg, IDC_LABEL_KEYHELP_ABOUT, szAbout );	/* è¾æ›¸ã®èª¬æ˜ */
+				::DlgItem_SetText( hwndDlg, IDC_EDIT_KEYHELP, szPath );			/* ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 			}
 			break;
 		}
@@ -492,11 +492,11 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 
 	case WM_HELP:
 		{	HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}return TRUE;
 
 	case WM_CONTEXTMENU:	/* Context Menu */
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 	}
 	return FALSE;
@@ -506,9 +506,9 @@ void CheckDlgButtonBOOL(HWND hwnd, int id, BOOL bState ){
 	CheckDlgButton( hwnd, id, (bState ? BST_CHECKED : BST_UNCHECKED) );
 }
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è ƒL[ƒ[ƒh«‘ƒtƒ@ƒCƒ‹İ’è
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«è¨­å®š
 
-	@date 2006.04.10 fon V‹Kì¬
+	@date 2006.04.10 fon æ–°è¦ä½œæˆ
 */
 void CPropTypesKeyHelp::SetData( HWND hwndDlg )
 {
@@ -517,10 +517,10 @@ void CPropTypesKeyHelp::SetData( HWND hwndDlg )
 	LV_ITEM	lvi;
 	DWORD	dwStyle;
 
-	/* ƒ†[ƒU[‚ªƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+	/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KEYHELP ), _countof2( m_Types.m_KeyHelpArr[0].m_szPath ) - 1 );
 
-	// g—p‚·‚éEg—p‚µ‚È‚¢
+	// ä½¿ç”¨ã™ã‚‹ãƒ»ä½¿ç”¨ã—ãªã„
 	CheckDlgButtonBOOL( hwndDlg, IDC_CHECK_KEYHELP, m_Types.m_bUseKeyWordHelp );
 	CheckDlgButtonBOOL( hwndDlg, IDC_CHECK_KEYHELP_ALLSEARCH, m_Types.m_bUseKeyHelpAllSearch );
 	CheckDlgButtonBOOL( hwndDlg, IDC_CHECK_KEYHELP_KEYDISP, m_Types.m_bUseKeyHelpKeyDisp );
@@ -533,14 +533,14 @@ void CPropTypesKeyHelp::SetData( HWND hwndDlg )
 	}
 	Combo_SetCurSel(hwndCombo, m_Types.m_eKeyHelpRMenuShowType);
 
-	/* ƒŠƒXƒg */
+	/* ãƒªã‚¹ãƒˆ */
 	hwndWork = ::GetDlgItem( hwndDlg, IDC_LIST_KEYHELP );
-	ListView_DeleteAllItems(hwndWork);  /* ƒŠƒXƒg‚ğ‹ó‚É‚·‚é */
-	/* s‘I‘ğ */
+	ListView_DeleteAllItems(hwndWork);  /* ãƒªã‚¹ãƒˆã‚’ç©ºã«ã™ã‚‹ */
+	/* è¡Œé¸æŠ */
 	dwStyle = ListView_GetExtendedListViewStyle( hwndWork );
 	dwStyle |= LVS_EX_FULLROWSELECT;
 	ListView_SetExtendedListViewStyle( hwndWork, dwStyle );
-	/* ƒf[ƒ^•\¦ */
+	/* ãƒ‡ãƒ¼ã‚¿è¡¨ç¤º */
 	for(i = 0; i < MAX_KEYHELP_FILE; i++){
 		if( m_Types.m_KeyHelpArr[i].m_szPath[0] == _T('\0') ) break;
 		/* ON-OFF */
@@ -549,19 +549,19 @@ void CPropTypesKeyHelp::SetData( HWND hwndDlg )
 		lvi.iSubItem = 0;
 		lvi.pszText = GetFileName(m_Types.m_KeyHelpArr[i].m_szPath);
 		ListView_InsertItem( hwndWork, &lvi );
-		/* «‘‚Ìà–¾ */
+		/* è¾æ›¸ã®èª¬æ˜ */
 		lvi.mask     = LVIF_TEXT;
 		lvi.iItem    = i;
 		lvi.iSubItem = 1;
 		lvi.pszText  = m_Types.m_KeyHelpArr[i].m_szAbout;
 		ListView_SetItem( hwndWork, &lvi );
-		/* «‘ƒtƒ@ƒCƒ‹ƒpƒX */
+		/* è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 		lvi.mask     = LVIF_TEXT;
 		lvi.iItem    = i;
 		lvi.iSubItem = 2;
 		lvi.pszText  = m_Types.m_KeyHelpArr[i].m_szPath;
 		ListView_SetItem( hwndWork, &lvi );
-		/* ON/OFF‚ğæ“¾‚µ‚Äƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ÉƒZƒbƒgi‚Æ‚è‚ ‚¦‚¸‰‹}ˆ’uj */
+		/* ON/OFFã‚’å–å¾—ã—ã¦ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã«ã‚»ãƒƒãƒˆï¼ˆã¨ã‚Šã‚ãˆãšå¿œæ€¥å‡¦ç½®ï¼‰ */
 		if(m_Types.m_KeyHelpArr[i].m_bUse){	// ON
 			ListView_SetCheckState(hwndWork, i, TRUE);
 		}
@@ -573,33 +573,33 @@ void CPropTypesKeyHelp::SetData( HWND hwndDlg )
 	return;
 }
 
-/*! ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ ƒL[ƒ[ƒh«‘ƒtƒ@ƒCƒ‹İ’è
+/*! ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«è¨­å®š
 
-	@date 2006.04.10 fon V‹Kì¬
+	@date 2006.04.10 fon æ–°è¦ä½œæˆ
 */
 int CPropTypesKeyHelp::GetData( HWND hwndDlg )
 {
 	HWND	hwndList;
 	int	nIndex, i;
-	TCHAR	szAbout[DICT_ABOUT_LEN];	/* «‘‚Ìà–¾(«‘ƒtƒ@ƒCƒ‹‚Ì1s–Ú‚©‚ç¶¬) */
-	TCHAR	szPath[_MAX_PATH];			/* ƒtƒ@ƒCƒ‹ƒpƒX */
+	TCHAR	szAbout[DICT_ABOUT_LEN];	/* è¾æ›¸ã®èª¬æ˜(è¾æ›¸ãƒ•ã‚¡ã‚¤ãƒ«ã®1è¡Œç›®ã‹ã‚‰ç”Ÿæˆ) */
+	TCHAR	szPath[_MAX_PATH];			/* ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ */
 
-	/* g—p‚·‚éEg—p‚µ‚È‚¢ */
+	/* ä½¿ç”¨ã™ã‚‹ãƒ»ä½¿ç”¨ã—ãªã„ */
 	m_Types.m_bUseKeyWordHelp      = ( BST_CHECKED == IsDlgButtonChecked( hwndDlg, IDC_CHECK_KEYHELP ) );
 	m_Types.m_bUseKeyHelpAllSearch = ( BST_CHECKED == IsDlgButtonChecked( hwndDlg, IDC_CHECK_KEYHELP_ALLSEARCH ) );
 	m_Types.m_bUseKeyHelpKeyDisp   = ( BST_CHECKED == IsDlgButtonChecked( hwndDlg, IDC_CHECK_KEYHELP_KEYDISP ) );
 	m_Types.m_bUseKeyHelpPrefix    = ( BST_CHECKED == IsDlgButtonChecked( hwndDlg, IDC_CHECK_KEYHELP_PREFIX ) );
 	m_Types.m_eKeyHelpRMenuShowType = (EKeyHelpRMenuType)Combo_GetCurSel(GetDlgItem(hwndDlg, IDC_COMBO_MENU));
 
-	/* ƒŠƒXƒg‚É“o˜^‚³‚ê‚Ä‚¢‚éî•ñ‚ğ”z—ñ‚Éæ‚è‚Ş */
+	/* ãƒªã‚¹ãƒˆã«ç™»éŒ²ã•ã‚Œã¦ã„ã‚‹æƒ…å ±ã‚’é…åˆ—ã«å–ã‚Šè¾¼ã‚€ */
 	hwndList = GetDlgItem( hwndDlg, IDC_LIST_KEYHELP );
 	nIndex = ListView_GetItemCount( hwndList );
 	for(i = 0; i < MAX_KEYHELP_FILE; i++){
 		if( i < nIndex ){
-			bool		bUse = false;						/* «‘ON(1)/OFF(0) */
+			bool		bUse = false;						/* è¾æ›¸ON(1)/OFF(0) */
 			szAbout[0]	= _T('\0');
 			szPath[0]	= _T('\0');
-			/* ƒ`ƒFƒbƒNƒ{ƒbƒNƒXó‘Ô‚ğæ“¾‚µ‚ÄbUse‚ÉƒZƒbƒg */
+			/* ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹çŠ¶æ…‹ã‚’å–å¾—ã—ã¦bUseã«ã‚»ãƒƒãƒˆ */
 			if(ListView_GetCheckState(hwndList, i))
 				bUse = true;
 			ListView_GetItemText( hwndList, i, 1, szAbout, _countof(szAbout) );
@@ -607,27 +607,27 @@ int CPropTypesKeyHelp::GetData( HWND hwndDlg )
 			m_Types.m_KeyHelpArr[i].m_bUse = bUse;
 			_tcscpy(m_Types.m_KeyHelpArr[i].m_szAbout, szAbout);
 			_tcscpy(m_Types.m_KeyHelpArr[i].m_szPath, szPath);
-		}else{	/* –¢“o˜^•”•ª‚ÍƒNƒŠƒA‚·‚é */
+		}else{	/* æœªç™»éŒ²éƒ¨åˆ†ã¯ã‚¯ãƒªã‚¢ã™ã‚‹ */
 			m_Types.m_KeyHelpArr[i].m_szPath[0] = _T('\0');
 		}
 	}
-	/* «‘‚Ìû”‚ğæ“¾ */
+	/* è¾æ›¸ã®å†Šæ•°ã‚’å–å¾— */
 	m_Types.m_nKeyHelpNum = nIndex;
 	return TRUE;
 }
 
-/*! ƒL[ƒ[ƒhƒwƒ‹ƒvƒtƒ@ƒCƒ‹ƒŠƒXƒg‚ÌƒCƒ“ƒ|[ƒg
+/*! ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ãƒªã‚¹ãƒˆã®ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 
-	@date 2006.04.10 fon V‹Kì¬
+	@date 2006.04.10 fon æ–°è¦ä½œæˆ
 */
 bool CPropTypesKeyHelp::Import(HWND hwndDlg)
 {
-	// ƒCƒ“ƒ|[ƒg
+	// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 	GetData( hwndDlg );
 
 	CImpExpKeyHelp  cImpExpKeyHelp( m_Types );
 	if (!cImpExpKeyHelp.ImportUI(m_hInstance, hwndDlg)) {
-		// ƒCƒ“ƒ|[ƒg‚ğ‚µ‚Ä‚¢‚È‚¢
+		// ã‚¤ãƒ³ãƒãƒ¼ãƒˆã‚’ã—ã¦ã„ãªã„
 		return false;
 	}
 	SetData( hwndDlg );
@@ -636,34 +636,34 @@ bool CPropTypesKeyHelp::Import(HWND hwndDlg)
 }
 
 
-/*! ƒL[ƒ[ƒhƒwƒ‹ƒvƒtƒ@ƒCƒ‹ƒŠƒXƒg‚ÌƒCƒ“ƒ|[ƒgƒGƒNƒXƒ|[ƒg
+/*! ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ãƒªã‚¹ãƒˆã®ã‚¤ãƒ³ãƒãƒ¼ãƒˆã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 
-	@date 2006.04.10 fon V‹Kì¬
+	@date 2006.04.10 fon æ–°è¦ä½œæˆ
 */
 bool CPropTypesKeyHelp::Export(HWND hwndDlg)
 {
 	GetData(hwndDlg);
 	CImpExpKeyHelp	cImpExpKeyHelp( m_Types );
 
-	// ƒGƒNƒXƒ|[ƒg
+	// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 	return cImpExpKeyHelp.ExportUI(m_hInstance, hwndDlg);
 }
 
 
-/*! «‘‚Ìà–¾‚ÌƒtƒH[ƒ}ƒbƒg‘µ‚¦
+/*! è¾æ›¸ã®èª¬æ˜ã®ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆæƒãˆ
 
-	@date 2006.04.10 fon V‹Kì¬
+	@date 2006.04.10 fon æ–°è¦ä½œæˆ
 */
 static TCHAR* strcnv(TCHAR *str)
 {
 	TCHAR* p=str;
-	/* ‰üsƒR[ƒh‚Ìíœ */
+	/* æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®å‰Šé™¤ */
 	if( NULL != (p=_tcschr(p,_T('\n'))) )
 		*p=_T('\0');
 	p=str;
 	if( NULL != (p=_tcschr(p,_T('\r'))) )
 		*p=_T('\0');
-	/* ƒJƒ“ƒ}‚Ì’uŠ· */
+	/* ã‚«ãƒ³ãƒã®ç½®æ› */
 	p=str;
 	for(; (p=_tcschr(p,_T(','))) != NULL; ){
 		*p=_T('.');
@@ -671,10 +671,10 @@ static TCHAR* strcnv(TCHAR *str)
 	return str;
 }
 
-/*! ƒtƒ‹ƒpƒX‚©‚çƒtƒ@ƒCƒ‹–¼‚ğ•Ô‚·
+/*! ãƒ•ãƒ«ãƒ‘ã‚¹ã‹ã‚‰ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¿”ã™
 
-	@date 2006.04.10 fon V‹Kì¬
-	@date 2006.09.14 genta ƒfƒBƒŒƒNƒgƒŠ‚ª‚È‚¢ê‡‚ÉÅ‰‚Ì1•¶š‚ªØ‚ê‚È‚¢‚æ‚¤‚É
+	@date 2006.04.10 fon æ–°è¦ä½œæˆ
+	@date 2006.09.14 genta ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãŒãªã„å ´åˆã«æœ€åˆã®1æ–‡å­—ãŒåˆ‡ã‚Œãªã„ã‚ˆã†ã«
 */
 static TCHAR* GetFileName(const TCHAR* fullpath)
 {

--- a/sakura_core/typeprop/CPropTypesRegex.cpp
+++ b/sakura_core/typeprop/CPropTypesRegex.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	ƒ^ƒCƒv•Êİ’è - ³‹K•\Œ»ƒL[ƒ[ƒh ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX
+ï»¿/*!	@file
+	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š - æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹
 
 	@author MIK
-	@date 2001/11/17  V‹Kì¬
+	@date 2001/11/17  æ–°è¦ä½œæˆ
 */
 /*
 	Copyright (C) 2001, MIK, Stonee
@@ -31,24 +31,24 @@ using namespace std;
 
 
 static const DWORD p_helpids[] = {	//11600
-	IDC_BUTTON_REGEX_IMPORT,	HIDC_BUTTON_REGEX_IMPORT,	//ƒCƒ“ƒ|[ƒg
-	IDC_BUTTON_REGEX_EXPORT,	HIDC_BUTTON_REGEX_EXPORT,	//ƒGƒNƒXƒ|[ƒg
-	IDC_BUTTON_REGEX_INS,		HIDC_BUTTON_REGEX_INS,		//‘}“ü
-	IDC_BUTTON_REGEX_ADD,		HIDC_BUTTON_REGEX_ADD,		//’Ç‰Á
-	IDC_BUTTON_REGEX_UPD,		HIDC_BUTTON_REGEX_UPD,		//XV
-	IDC_BUTTON_REGEX_DEL,		HIDC_BUTTON_REGEX_DEL,		//íœ
-	IDC_BUTTON_REGEX_TOP,		HIDC_BUTTON_REGEX_TOP,		//æ“ª
-	IDC_BUTTON_REGEX_LAST,		HIDC_BUTTON_REGEX_LAST,		//ÅI
-	IDC_BUTTON_REGEX_UP,		HIDC_BUTTON_REGEX_UP,		//ã‚Ö
-	IDC_BUTTON_REGEX_DOWN,		HIDC_BUTTON_REGEX_DOWN,		//‰º‚Ö
-	IDC_CHECK_REGEX,			HIDC_CHECK_REGEX,			//³‹K•\Œ»ƒL[ƒ[ƒh‚ğg—p‚·‚é
-	IDC_COMBO_REGEX_COLOR,		HIDC_COMBO_REGEX_COLOR,		//F
-	IDC_EDIT_REGEX,				HIDC_EDIT_REGEX,			//³‹K•\Œ»ƒL[ƒ[ƒh
-	IDC_LIST_REGEX,				HIDC_LIST_REGEX,			//ƒŠƒXƒg
+	IDC_BUTTON_REGEX_IMPORT,	HIDC_BUTTON_REGEX_IMPORT,	//ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
+	IDC_BUTTON_REGEX_EXPORT,	HIDC_BUTTON_REGEX_EXPORT,	//ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
+	IDC_BUTTON_REGEX_INS,		HIDC_BUTTON_REGEX_INS,		//æŒ¿å…¥
+	IDC_BUTTON_REGEX_ADD,		HIDC_BUTTON_REGEX_ADD,		//è¿½åŠ 
+	IDC_BUTTON_REGEX_UPD,		HIDC_BUTTON_REGEX_UPD,		//æ›´æ–°
+	IDC_BUTTON_REGEX_DEL,		HIDC_BUTTON_REGEX_DEL,		//å‰Šé™¤
+	IDC_BUTTON_REGEX_TOP,		HIDC_BUTTON_REGEX_TOP,		//å…ˆé ­
+	IDC_BUTTON_REGEX_LAST,		HIDC_BUTTON_REGEX_LAST,		//æœ€çµ‚
+	IDC_BUTTON_REGEX_UP,		HIDC_BUTTON_REGEX_UP,		//ä¸Šã¸
+	IDC_BUTTON_REGEX_DOWN,		HIDC_BUTTON_REGEX_DOWN,		//ä¸‹ã¸
+	IDC_CHECK_REGEX,			HIDC_CHECK_REGEX,			//æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ä½¿ç”¨ã™ã‚‹
+	IDC_COMBO_REGEX_COLOR,		HIDC_COMBO_REGEX_COLOR,		//è‰²
+	IDC_EDIT_REGEX,				HIDC_EDIT_REGEX,			//æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+	IDC_LIST_REGEX,				HIDC_LIST_REGEX,			//ãƒªã‚¹ãƒˆ
 	IDC_LABEL_REGEX_KEYWORD,	HIDC_EDIT_REGEX,			
 	IDC_LABEL_REGEX_COLOR,		HIDC_COMBO_REGEX_COLOR,		
 	IDC_FRAME_REGEX,			HIDC_LIST_REGEX,			
-	IDC_LABEL_REGEX_VERSION,	HIDC_LABEL_REGEX_VERSION,	//ƒo[ƒWƒ‡ƒ“
+	IDC_LABEL_REGEX_VERSION,	HIDC_LABEL_REGEX_VERSION,	//ãƒãƒ¼ã‚¸ãƒ§ãƒ³
 //	IDC_STATIC,						-1,
 	0, 0
 };
@@ -56,12 +56,12 @@ static const DWORD p_helpids[] = {	//11600
 
 
 // Import
-// 2010/4/23 Uchi Import‚ÌŠOo‚µ
+// 2010/4/23 Uchi Importã®å¤–å‡ºã—
 bool CPropTypesRegex::Import(HWND hwndDlg)
 {
 	CImpExpRegex	cImpExpRegex(m_Types);
 
-	// ƒCƒ“ƒ|[ƒg
+	// ã‚¤ãƒ³ãƒãƒ¼ãƒˆ
 	bool bImport = cImpExpRegex.ImportUI(m_hInstance, hwndDlg);
 	if( bImport ){
 		SetDataKeywordList(hwndDlg);
@@ -70,17 +70,17 @@ bool CPropTypesRegex::Import(HWND hwndDlg)
 }
 
 // Export
-// 2010/4/23 Uchi Export‚ÌŠOo‚µ
+// 2010/4/23 Uchi Exportã®å¤–å‡ºã—
 bool CPropTypesRegex::Export(HWND hwndDlg)
 {
 	GetData(hwndDlg);
 	CImpExpRegex	cImpExpRegex(m_Types);
 
-	// ƒGƒNƒXƒ|[ƒg
+	// ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ
 	return cImpExpRegex.ExportUI(m_hInstance, hwndDlg);
 }
 
-/* ³‹K•\Œ»ƒL[ƒ[ƒh ƒƒbƒZ[ƒWˆ— */
+/* æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropTypesRegex::DispatchEvent(
 	HWND		hwndDlg,	// handle to dialog box
 	UINT		uMsg,		// message
@@ -96,12 +96,12 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 	LV_ITEM	lvi;
 	LV_COLUMN	col;
 	RECT		rc;
-	static int nPrevIndex = -1;	//XV‚É‚¨‚©‚µ‚­‚È‚éƒoƒOC³ @@@ 2003.03.26 MIK
+	static int nPrevIndex = -1;	//æ›´æ–°æ™‚ã«ãŠã‹ã—ããªã‚‹ãƒã‚°ä¿®æ­£ @@@ 2003.03.26 MIK
 
 
 	hwndList = GetDlgItem( hwndDlg, IDC_LIST_REGEX );
 
-	// ANSIƒrƒ‹ƒh‚Å‚ÍCP932‚¾‚Æ2”{’ö“x•K—v
+	// ANSIãƒ“ãƒ«ãƒ‰ã§ã¯CP932ã ã¨2å€ç¨‹åº¦å¿…è¦
 	const int nKeyWordSize = MAX_REGEX_KEYWORDLEN;
 	TCHAR	szColorIndex[256];
 
@@ -110,7 +110,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒJƒ‰ƒ€’Ç‰Á */
+		/* ã‚«ãƒ©ãƒ è¿½åŠ  */
 		//ListView_DeleteColumn( hwndList, 1 );
 		//ListView_DeleteColumn( hwndList, 0 );
 		::GetWindowRect( hwndList, &rc );
@@ -128,32 +128,32 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 		ListView_InsertColumn( hwndList, 1, &col );
 
 		nPrevIndex = -1;	//@@@ 2003.05.12 MIK
-		SetData( hwndDlg );	/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è ³‹K•\Œ»ƒL[ƒ[ƒh */
+		SetData( hwndDlg );	/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ */
 		if( CheckRegexpVersion( hwndDlg, IDC_LABEL_REGEX_VERSION, false ) == false )	//@@@ 2001.11.17 add MIK
 		{
 			::DlgItem_SetText( hwndDlg, IDC_LABEL_REGEX_VERSION, LS(STR_PROPTYPEREGEX_NOUSE) );
-			//ƒ‰ƒCƒuƒ‰ƒŠ‚ª‚È‚­‚ÄAg—p‚µ‚È‚¢‚É‚È‚Á‚Ä‚¢‚éê‡‚ÍA–³Œø‚É‚·‚éB
+			//ãƒ©ã‚¤ãƒ–ãƒ©ãƒªãŒãªãã¦ã€ä½¿ç”¨ã—ãªã„ã«ãªã£ã¦ã„ã‚‹å ´åˆã¯ã€ç„¡åŠ¹ã«ã™ã‚‹ã€‚
 			if( ! IsDlgButtonChecked( hwndDlg, IDC_CHECK_REGEX ) )
 			{
-				//Disable‚É‚·‚éB
+				//Disableã«ã™ã‚‹ã€‚
 				EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_REGEX ), FALSE );
 			}
 			else
 			{
-				//g—p‚·‚é‚É‚È‚Á‚Ä‚é‚ñ‚¾‚¯‚ÇDisable‚É‚·‚éB‚à‚¤ƒ†[ƒU‚Í•ÏX‚Å‚«‚È‚¢B
+				//ä½¿ç”¨ã™ã‚‹ã«ãªã£ã¦ã‚‹ã‚“ã ã‘ã©Disableã«ã™ã‚‹ã€‚ã‚‚ã†ãƒ¦ãƒ¼ã‚¶ã¯å¤‰æ›´ã§ããªã„ã€‚
 				EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_REGEX ), FALSE );
 			}
 		}
 		return TRUE;
 
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* ’Ê’mƒR[ƒh */
-		wID	= LOWORD(wParam);	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+		wNotifyCode = HIWORD(wParam);	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID	= LOWORD(wParam);	/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 		switch( wNotifyCode ){
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 			switch( wID ){
-			case IDC_CHECK_REGEX:	/* ³‹K•\Œ»ƒL[ƒ[ƒh‚ğg‚¤ */
+			case IDC_CHECK_REGEX:	/* æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ä½¿ã† */
 				if( IsDlgButtonChecked( hwndDlg, IDC_CHECK_REGEX ) )
 				{
 					if( CheckRegexpVersion( NULL, 0, false ) == false )
@@ -166,7 +166,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 						if( nRet != IDYES )
 						{
 							CheckDlgButton( hwndDlg, IDC_CHECK_REGEX, BST_UNCHECKED );
-							//Disable‚É‚·‚éB
+							//Disableã«ã™ã‚‹ã€‚
 							EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_REGEX ), FALSE );
 							return TRUE;
 						}
@@ -176,42 +176,42 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				{
 					if( CheckRegexpVersion( NULL, 0, false ) == false )
 					{
-						//Disable‚É‚·‚éB
+						//Disableã«ã™ã‚‹ã€‚
 						EnableWindow( GetDlgItem( hwndDlg, IDC_CHECK_REGEX ), FALSE );
 					}
 				}
 				m_Types.m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();	//Need Compile
 				return TRUE;
 
-			case IDC_BUTTON_REGEX_INS:	/* ‘}“ü */
+			case IDC_BUTTON_REGEX_INS:	/* æŒ¿å…¥ */
 			{
-				//‘}“ü‚·‚éƒL[î•ñ‚ğæ“¾‚·‚éB
+				//æŒ¿å…¥ã™ã‚‹ã‚­ãƒ¼æƒ…å ±ã‚’å–å¾—ã™ã‚‹ã€‚
 				auto_array_ptr<TCHAR> szKeyWord(new TCHAR [ nKeyWordSize ]);
 				szKeyWord[0] = _T('\0');
 				::DlgItem_GetText( hwndDlg, IDC_EDIT_REGEX, &szKeyWord[0], nKeyWordSize );
 				if( szKeyWord[0] == _T('\0') ) return FALSE;
-				//“¯‚¶ƒL[‚ª‚È‚¢‚©’²‚×‚éB
+				//åŒã˜ã‚­ãƒ¼ãŒãªã„ã‹èª¿ã¹ã‚‹ã€‚
 				nIndex2 = ListView_GetItemCount(hwndList);
 				if( nIndex2 >= MAX_REGEX_KEYWORD )
 				{
 					ErrorMessage( hwndDlg, LS(STR_PROPTYPEREGEX_NOREG));
 					return FALSE;
 				}
-				//‘I‘ğ’†‚ÌƒL[‚ğ’T‚·B
+				//é¸æŠä¸­ã®ã‚­ãƒ¼ã‚’æ¢ã™ã€‚
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex )
 				{
-					//‘I‘ğ’†‚Å‚È‚¯‚ê‚ÎÅŒã‚É‚·‚éB
+					//é¸æŠä¸­ã§ãªã‘ã‚Œã°æœ€å¾Œã«ã™ã‚‹ã€‚
 					nIndex = nIndex2;
 				}
 				if( !CheckKeywordList(hwndDlg, &szKeyWord[0], -1) ){
 					return FALSE;
 				}
 				
-				//‘}“ü‚·‚éƒL[î•ñ‚ğæ“¾‚·‚éB
+				//æŒ¿å…¥ã™ã‚‹ã‚­ãƒ¼æƒ…å ±ã‚’å–å¾—ã™ã‚‹ã€‚
 				auto_memset(szColorIndex, 0, _countof(szColorIndex));
 				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, _countof(szColorIndex) );
-				//ƒL[î•ñ‚ğ‘}“ü‚·‚éB
+				//ã‚­ãƒ¼æƒ…å ±ã‚’æŒ¿å…¥ã™ã‚‹ã€‚
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
 				lvi.iItem    = nIndex;
@@ -223,18 +223,18 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				lvi.iSubItem = 1;
 				lvi.pszText  = szColorIndex;
 				ListView_SetItem( hwndList, &lvi );
-				//‘}“ü‚µ‚½ƒL[‚ğ‘I‘ğ‚·‚éB
+				//æŒ¿å…¥ã—ãŸã‚­ãƒ¼ã‚’é¸æŠã™ã‚‹ã€‚
 				ListView_SetItemState( hwndList, nIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				GetData( hwndDlg );
 				return TRUE;
 			}
 
-			case IDC_BUTTON_REGEX_ADD:	/* ’Ç‰Á */
+			case IDC_BUTTON_REGEX_ADD:	/* è¿½åŠ  */
 			{
 				auto_array_ptr<TCHAR> szKeyWord(new TCHAR [ nKeyWordSize ]);
-				//ÅŒã‚ÌƒL[”Ô†‚ğæ“¾‚·‚éB
+				//æœ€å¾Œã®ã‚­ãƒ¼ç•ªå·ã‚’å–å¾—ã™ã‚‹ã€‚
 				nIndex = ListView_GetItemCount( hwndList );
-				//’Ç‰Á‚·‚éƒL[î•ñ‚ğæ“¾‚·‚éB
+				//è¿½åŠ ã™ã‚‹ã‚­ãƒ¼æƒ…å ±ã‚’å–å¾—ã™ã‚‹ã€‚
 				szKeyWord[0] = _T('\0');
 				::DlgItem_GetText( hwndDlg, IDC_EDIT_REGEX, &szKeyWord[0], nKeyWordSize );
 				if( szKeyWord[0] == L'\0' ) return FALSE;
@@ -247,10 +247,10 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				if( !CheckKeywordList(hwndDlg, &szKeyWord[0], -1) ){
 					return FALSE;
 				}
-				//’Ç‰Á‚·‚éƒL[î•ñ‚ğæ“¾‚·‚éB
+				//è¿½åŠ ã™ã‚‹ã‚­ãƒ¼æƒ…å ±ã‚’å–å¾—ã™ã‚‹ã€‚
 				auto_memset(szColorIndex, 0, _countof(szColorIndex));
 				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, _countof(szColorIndex) );
-				//ƒL[‚ğ’Ç‰Á‚·‚éB
+				//ã‚­ãƒ¼ã‚’è¿½åŠ ã™ã‚‹ã€‚
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
 				lvi.iItem    = nIndex;
@@ -262,33 +262,33 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				lvi.iSubItem = 1;
 				lvi.pszText  = szColorIndex;
 				ListView_SetItem( hwndList, &lvi );
-				//’Ç‰Á‚µ‚½ƒL[‚ğ‘I‘ğ‚·‚éB
+				//è¿½åŠ ã—ãŸã‚­ãƒ¼ã‚’é¸æŠã™ã‚‹ã€‚
 				ListView_SetItemState( hwndList, nIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				GetData( hwndDlg );
 				return TRUE;
 			}
 
-			case IDC_BUTTON_REGEX_UPD:	/* XV */
+			case IDC_BUTTON_REGEX_UPD:	/* æ›´æ–° */
 			{
 				auto_array_ptr<TCHAR> szKeyWord(new TCHAR [ nKeyWordSize ]);
-				//‘I‘ğ’†‚ÌƒL[‚ğ’T‚·B
+				//é¸æŠä¸­ã®ã‚­ãƒ¼ã‚’æ¢ã™ã€‚
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex )
 				{
 					ErrorMessage( hwndDlg, LS(STR_PROPTYPEREGEX_NOSEL));
 					return FALSE;
 				}
-				//XV‚·‚éƒL[î•ñ‚ğæ“¾‚·‚éB
+				//æ›´æ–°ã™ã‚‹ã‚­ãƒ¼æƒ…å ±ã‚’å–å¾—ã™ã‚‹ã€‚
 				szKeyWord[0] = _T('\0');
 				::DlgItem_GetText( hwndDlg, IDC_EDIT_REGEX, &szKeyWord[0], nKeyWordSize );
 				if( szKeyWord[0] == L'\0' ) return FALSE;
 				if( !CheckKeywordList(hwndDlg, &szKeyWord[0], nIndex) ){
 					return FALSE;
 				}
-				//’Ç‰Á‚·‚éƒL[î•ñ‚ğæ“¾‚·‚éB
+				//è¿½åŠ ã™ã‚‹ã‚­ãƒ¼æƒ…å ±ã‚’å–å¾—ã™ã‚‹ã€‚
 				auto_memset(szColorIndex, 0, _countof(szColorIndex));
 				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, _countof(szColorIndex) );
-				//ƒL[‚ğXV‚·‚éB
+				//ã‚­ãƒ¼ã‚’æ›´æ–°ã™ã‚‹ã€‚
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
 				lvi.iItem    = nIndex;
@@ -302,36 +302,36 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				lvi.pszText  = szColorIndex;
 				ListView_SetItem( hwndList, &lvi );
 
-				//XV‚µ‚½ƒL[‚ğ‘I‘ğ‚·‚éB
+				//æ›´æ–°ã—ãŸã‚­ãƒ¼ã‚’é¸æŠã™ã‚‹ã€‚
 				ListView_SetItemState( hwndList, nIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				GetData( hwndDlg );
 				return TRUE;
 			}
 
-			case IDC_BUTTON_REGEX_DEL:	/* íœ */
-				//‘I‘ğ’†‚ÌƒL[”Ô†‚ğ’T‚·B
+			case IDC_BUTTON_REGEX_DEL:	/* å‰Šé™¤ */
+				//é¸æŠä¸­ã®ã‚­ãƒ¼ç•ªå·ã‚’æ¢ã™ã€‚
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
-				//íœ‚·‚éB
+				//å‰Šé™¤ã™ã‚‹ã€‚
 				ListView_DeleteItem( hwndList, nIndex );
-				//“¯‚¶ˆÊ’u‚ÌƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB
+				//åŒã˜ä½ç½®ã®ã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚
 				ListView_SetItemState( hwndList, nIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				GetData( hwndDlg );
 				return TRUE;
 
-			case IDC_BUTTON_REGEX_TOP:	/* æ“ª */
+			case IDC_BUTTON_REGEX_TOP:	/* å…ˆé ­ */
 			{
 				auto_array_ptr<TCHAR> szKeyWord(new TCHAR [ nKeyWordSize ]);
 				szKeyWord[0] = _T('\0');
-				//‘I‘ğ’†‚ÌƒL[‚ğ’T‚·B
+				//é¸æŠä¸­ã®ã‚­ãƒ¼ã‚’æ¢ã™ã€‚
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
-				if( 0 == nIndex ) return TRUE;	//‚·‚Å‚Éæ“ª‚É‚ ‚éB
+				if( 0 == nIndex ) return TRUE;	//ã™ã§ã«å…ˆé ­ã«ã‚ã‚‹ã€‚
 				nIndex2 = 0;
 				ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
 				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
-				ListView_DeleteItem(hwndList, nIndex);	//ŒÃ‚¢ƒL[‚ğíœ
-				//ƒL[‚ğ’Ç‰Á‚·‚éB
+				ListView_DeleteItem(hwndList, nIndex);	//å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤
+				//ã‚­ãƒ¼ã‚’è¿½åŠ ã™ã‚‹ã€‚
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
 				lvi.iItem    = nIndex2;
@@ -343,23 +343,23 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				lvi.iSubItem = 1;
 				lvi.pszText  = szColorIndex;
 				ListView_SetItem( hwndList, &lvi );
-				//ˆÚ“®‚µ‚½ƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB
+				//ç§»å‹•ã—ãŸã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚
 				ListView_SetItemState( hwndList, nIndex2, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				GetData( hwndDlg );
 				return TRUE;
 			}
 
-			case IDC_BUTTON_REGEX_LAST:	/* ÅI */
+			case IDC_BUTTON_REGEX_LAST:	/* æœ€çµ‚ */
 			{
 				auto_array_ptr<TCHAR> szKeyWord(new TCHAR [ nKeyWordSize ]);
 				szKeyWord[0] = _T('\0');
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
 				nIndex2 = ListView_GetItemCount(hwndList);
-				if( nIndex2 - 1 == nIndex ) return TRUE;	//‚·‚Å‚ÉÅI‚É‚ ‚éB
+				if( nIndex2 - 1 == nIndex ) return TRUE;	//ã™ã§ã«æœ€çµ‚ã«ã‚ã‚‹ã€‚
 				ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
 				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
-				//ƒL[‚ğ’Ç‰Á‚·‚éB
+				//ã‚­ãƒ¼ã‚’è¿½åŠ ã™ã‚‹ã€‚
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
 				lvi.iItem    = nIndex2;
@@ -371,27 +371,27 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				lvi.iSubItem = 1;
 				lvi.pszText  = szColorIndex;
 				ListView_SetItem( hwndList, &lvi );
-				//ˆÚ“®‚µ‚½ƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB
+				//ç§»å‹•ã—ãŸã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚
 				ListView_SetItemState( hwndList, nIndex2, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
-				ListView_DeleteItem(hwndList, nIndex);	//ŒÃ‚¢ƒL[‚ğíœ
+				ListView_DeleteItem(hwndList, nIndex);	//å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤
 				GetData( hwndDlg );
 				return TRUE;
 			}
 
-			case IDC_BUTTON_REGEX_UP:	/* ã‚Ö */
+			case IDC_BUTTON_REGEX_UP:	/* ä¸Šã¸ */
 			{
 				auto_array_ptr<TCHAR> szKeyWord(new TCHAR [ nKeyWordSize ]);
 				szKeyWord[0] = _T('\0');
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
-				if( 0 == nIndex ) return TRUE;	//‚·‚Å‚Éæ“ª‚É‚ ‚éB
+				if( 0 == nIndex ) return TRUE;	//ã™ã§ã«å…ˆé ­ã«ã‚ã‚‹ã€‚
 				nIndex2 = ListView_GetItemCount(hwndList);
 				if( nIndex2 <= 1 ) return TRUE;
 				nIndex2 = nIndex - 1;
 				ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
 				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
-				ListView_DeleteItem(hwndList, nIndex);	//ŒÃ‚¢ƒL[‚ğíœ
-				//ƒL[‚ğ’Ç‰Á‚·‚éB
+				ListView_DeleteItem(hwndList, nIndex);	//å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤
+				//ã‚­ãƒ¼ã‚’è¿½åŠ ã™ã‚‹ã€‚
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
 				lvi.iItem    = nIndex2;
@@ -403,25 +403,25 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				lvi.iSubItem = 1;
 				lvi.pszText  = szColorIndex;
 				ListView_SetItem( hwndList, &lvi );
-				//ˆÚ“®‚µ‚½ƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB
+				//ç§»å‹•ã—ãŸã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚
 				ListView_SetItemState( hwndList, nIndex2, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
 				GetData( hwndDlg );
 				return TRUE;
 			}
 
-			case IDC_BUTTON_REGEX_DOWN:	/* ‰º‚Ö */
+			case IDC_BUTTON_REGEX_DOWN:	/* ä¸‹ã¸ */
 			{
 				auto_array_ptr<TCHAR> szKeyWord(new TCHAR [ nKeyWordSize ]);
 				szKeyWord[0] = _T('\0');
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
 				if( -1 == nIndex ) return FALSE;
 				nIndex2 = ListView_GetItemCount(hwndList);
-				if( nIndex2 - 1 == nIndex ) return TRUE;	//‚·‚Å‚ÉÅI‚É‚ ‚éB
+				if( nIndex2 - 1 == nIndex ) return TRUE;	//ã™ã§ã«æœ€çµ‚ã«ã‚ã‚‹ã€‚
 				if( nIndex2 <= 1 ) return TRUE;
 				nIndex2 = nIndex + 2;
 				ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
 				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
-				//ƒL[‚ğ’Ç‰Á‚·‚éB
+				//ã‚­ãƒ¼ã‚’è¿½åŠ ã™ã‚‹ã€‚
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
 				lvi.iItem    = nIndex2;
@@ -433,19 +433,19 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				lvi.iSubItem = 1;
 				lvi.pszText  = szColorIndex;
 				ListView_SetItem( hwndList, &lvi );
-				//ˆÚ“®‚µ‚½ƒL[‚ğ‘I‘ğó‘Ô‚É‚·‚éB
+				//ç§»å‹•ã—ãŸã‚­ãƒ¼ã‚’é¸æŠçŠ¶æ…‹ã«ã™ã‚‹ã€‚
 				ListView_SetItemState( hwndList, nIndex2, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
-				ListView_DeleteItem(hwndList, nIndex);	//ŒÃ‚¢ƒL[‚ğíœ
+				ListView_DeleteItem(hwndList, nIndex);	//å¤ã„ã‚­ãƒ¼ã‚’å‰Šé™¤
 				GetData( hwndDlg );
 				return TRUE;
 			}
 
-			case IDC_BUTTON_REGEX_IMPORT:	/* ƒCƒ“ƒ|[ƒg */
+			case IDC_BUTTON_REGEX_IMPORT:	/* ã‚¤ãƒ³ãƒãƒ¼ãƒˆ */
 				Import(hwndDlg);
-				m_Types.m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();	//Need Compile	//@@@ 2001.11.17 add MIK ³‹K•\Œ»ƒL[ƒ[ƒh‚Ì‚½‚ß
+				m_Types.m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();	//Need Compile	//@@@ 2001.11.17 add MIK æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®ãŸã‚
 				return TRUE;
 
-			case IDC_BUTTON_REGEX_EXPORT:	/* ƒGƒNƒXƒ|[ƒg */
+			case IDC_BUTTON_REGEX_EXPORT:	/* ã‚¨ã‚¯ã‚¹ãƒãƒ¼ãƒˆ */
 				Export(hwndDlg);
 				return TRUE;
 			}
@@ -460,10 +460,10 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 			OnHelp( hwndDlg, IDD_PROP_REGEX );
 			return TRUE;
 		case PSN_KILLACTIVE:
-			/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ ³‹K•\Œ»ƒL[ƒ[ƒh */
+			/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ */
 			GetData( hwndDlg );
 			return TRUE;
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPTYPE_PAGENUM_REGEX;
 			return TRUE;
@@ -472,23 +472,23 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 			{
 				HWND	hwndCombo;
 				nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_SELECTED );
-				if( -1 == nIndex )	//íœA”ÍˆÍŠO‚ÅƒNƒŠƒbƒN”½‰f‚³‚ê‚È‚¢ƒoƒOC³	//@@@ 2003.06.17 MIK
+				if( -1 == nIndex )	//å‰Šé™¤ã€ç¯„å›²å¤–ã§ã‚¯ãƒªãƒƒã‚¯æ™‚åæ˜ ã•ã‚Œãªã„ãƒã‚°ä¿®æ­£	//@@@ 2003.06.17 MIK
 				{
 					nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_FOCUSED );
 				}
 				if( -1 == nIndex )
 				{
-					/* ‰Šú’l‚ğİ’è‚·‚é */
-					::DlgItem_SetText( hwndDlg, IDC_EDIT_REGEX, _T("//k") );	/* ³‹K•\Œ» */
+					/* åˆæœŸå€¤ã‚’è¨­å®šã™ã‚‹ */
+					::DlgItem_SetText( hwndDlg, IDC_EDIT_REGEX, _T("//k") );	/* æ­£è¦è¡¨ç¾ */
 					hwndCombo = GetDlgItem( hwndDlg, IDC_COMBO_REGEX_COLOR );
 					for( i = 0, j = 0; i < COLORIDX_LAST; i++ )
 					{
 						if ( 0 == (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_TEXT) &&
-							0 == (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji ƒtƒ‰ƒO—˜—p‚ÅŠÈ‘f‰»
+							0 == (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji ãƒ•ãƒ©ã‚°åˆ©ç”¨ã§ç°¡ç´ åŒ–
 						{
 							if( m_Types.m_ColorInfoArr[i].m_nColorIdx == COLORIDX_REGEX1 )
 							{
-								Combo_SetCurSel( hwndCombo, j );	/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ÌƒfƒtƒHƒ‹ƒg‘I‘ğ */
+								Combo_SetCurSel( hwndCombo, j );	/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆé¸æŠ */
 								break;
 							}
 							j++;
@@ -497,17 +497,17 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 					return FALSE;
 				}
 				if( nPrevIndex != nIndex )	//@@@ 2003.03.26 MIK
-				{	//XV‚ÉListView‚ÌSubItem‚ğ³‚µ‚­æ“¾‚Å‚«‚È‚¢‚Ì‚ÅA‚»‚Ì‘Îô
+				{	//æ›´æ–°æ™‚ã«ListViewã®SubItemã‚’æ­£ã—ãå–å¾—ã§ããªã„ã®ã§ã€ãã®å¯¾ç­–
 					auto_array_ptr<TCHAR> szKeyWord(new TCHAR [ nKeyWordSize ]);
 					szKeyWord[0] = _T('\0');
 					ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
 					ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
-					::DlgItem_SetText( hwndDlg, IDC_EDIT_REGEX, &szKeyWord[0] );	/* ³‹K•\Œ» */
+					::DlgItem_SetText( hwndDlg, IDC_EDIT_REGEX, &szKeyWord[0] );	/* æ­£è¦è¡¨ç¾ */
 					hwndCombo = GetDlgItem( hwndDlg, IDC_COMBO_REGEX_COLOR );
 					for(i = 0, j = 0; i < COLORIDX_LAST; i++)
 					{
 						if ( 0 == (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_TEXT) &&
-							0 == (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji ƒtƒ‰ƒO—˜—p‚ÅŠÈ‘f‰»
+							0 == (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji ãƒ•ãƒ©ã‚°åˆ©ç”¨ã§ç°¡ç´ åŒ–
 						{
 							if(_tcscmp(m_Types.m_ColorInfoArr[i].m_szName, szColorIndex) == 0)
 							{
@@ -527,7 +527,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -535,35 +535,35 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 
 	}
 	return FALSE;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è ³‹K•\Œ»ƒL[ƒ[ƒh */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ */
 void CPropTypesRegex::SetData( HWND hwndDlg )
 {
 	HWND		hwndWork;
 	int			i, j;
 
-	/* ƒ†[ƒU[‚ªƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+	/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_REGEX ), MAX_REGEX_KEYWORDLEN - 1 );
-	::DlgItem_SetText( hwndDlg, IDC_EDIT_REGEX, _T("//k") );	/* ³‹K•\Œ» */
+	::DlgItem_SetText( hwndDlg, IDC_EDIT_REGEX, _T("//k") );	/* æ­£è¦è¡¨ç¾ */
 
-	/* Fí—Ş‚ÌƒŠƒXƒg */
+	/* è‰²ç¨®é¡ã®ãƒªã‚¹ãƒˆ */
 	hwndWork = ::GetDlgItem( hwndDlg, IDC_COMBO_REGEX_COLOR );
-	Combo_ResetContent( hwndWork );  /* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ğ‹ó‚É‚·‚é */
+	Combo_ResetContent( hwndWork );  /* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã‚’ç©ºã«ã™ã‚‹ */
 	for( i = 0; i < COLORIDX_LAST; i++ )
 	{
 		GetDefaultColorInfoName( &m_Types.m_ColorInfoArr[i], i );
 		if ( 0 == (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_TEXT) &&
-			0 == (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji ƒtƒ‰ƒO—˜—p‚ÅŠÈ‘f‰»
+			0 == (g_ColorAttributeArr[i].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji ãƒ•ãƒ©ã‚°åˆ©ç”¨ã§ç°¡ç´ åŒ–
 		{
 			j = Combo_AddString( hwndWork, m_Types.m_ColorInfoArr[i].m_szName );
 			if( m_Types.m_ColorInfoArr[i].m_nColorIdx == COLORIDX_REGEX1 )
-				Combo_SetCurSel( hwndWork, j );	/* ƒRƒ“ƒ{ƒ{ƒbƒNƒX‚ÌƒfƒtƒHƒ‹ƒg‘I‘ğ */
+				Combo_SetCurSel( hwndWork, j );	/* ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆé¸æŠ */
 		}
 	}
 
@@ -572,7 +572,7 @@ void CPropTypesRegex::SetData( HWND hwndDlg )
 	else
 		CheckDlgButton( hwndDlg, IDC_CHECK_REGEX, BST_UNCHECKED );
 
-	/* s‘I‘ğ */
+	/* è¡Œé¸æŠ */
 	hwndWork = ::GetDlgItem( hwndDlg, IDC_LIST_REGEX );
 	DWORD		dwStyle;
 	dwStyle = ListView_GetExtendedListViewStyle( hwndWork );
@@ -582,16 +582,16 @@ void CPropTypesRegex::SetData( HWND hwndDlg )
 	SetDataKeywordList( hwndDlg );
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è ³‹K•\Œ»ƒL[ƒ[ƒh‚Ìˆê——•”•ª */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®ä¸€è¦§éƒ¨åˆ† */
 void CPropTypesRegex::SetDataKeywordList( HWND hwndDlg )
 {
 	LV_ITEM		lvi;
 
-	/* ƒŠƒXƒg */
+	/* ãƒªã‚¹ãƒˆ */
 	HWND hwndWork = ::GetDlgItem( hwndDlg, IDC_LIST_REGEX );
-	ListView_DeleteAllItems(hwndWork);  /* ƒŠƒXƒg‚ğ‹ó‚É‚·‚é */
+	ListView_DeleteAllItems(hwndWork);  /* ãƒªã‚¹ãƒˆã‚’ç©ºã«ã™ã‚‹ */
 
-	/* ƒf[ƒ^•\¦ */
+	/* ãƒ‡ãƒ¼ã‚¿è¡¨ç¤º */
 	wchar_t *pKeyword = &m_Types.m_RegexKeywordList[0];
 	for(int i = 0; i < MAX_REGEX_KEYWORD; i++)
 	{
@@ -616,7 +616,7 @@ void CPropTypesRegex::SetDataKeywordList( HWND hwndDlg )
 	return;
 }
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ ³‹K•\Œ»ƒL[ƒ[ƒh */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ */
 int CPropTypesRegex::GetData( HWND hwndDlg )
 {
 	HWND	hwndList;
@@ -625,18 +625,18 @@ int CPropTypesRegex::GetData( HWND hwndDlg )
 	auto_array_ptr<TCHAR> szKeyWord(new TCHAR [ szKeyWordSize ]);
 	TCHAR	szColorIndex[256];
 
-	//g—p‚·‚éEg—p‚µ‚È‚¢
+	//ä½¿ç”¨ã™ã‚‹ãƒ»ä½¿ç”¨ã—ãªã„
 	if( IsDlgButtonChecked( hwndDlg, IDC_CHECK_REGEX ) )
 		m_Types.m_bUseRegexKeyword = true;
 	else
 		m_Types.m_bUseRegexKeyword = false;
 
-	//ƒŠƒXƒg‚É“o˜^‚³‚ê‚Ä‚¢‚éî•ñ‚ğ”z—ñ‚Éæ‚è‚Ş
+	//ãƒªã‚¹ãƒˆã«ç™»éŒ²ã•ã‚Œã¦ã„ã‚‹æƒ…å ±ã‚’é…åˆ—ã«å–ã‚Šè¾¼ã‚€
 	hwndList = GetDlgItem( hwndDlg, IDC_LIST_REGEX );
 	nIndex = ListView_GetItemCount(hwndList);
 	wchar_t* pKeyword = &m_Types.m_RegexKeywordList[0];
 	wchar_t* pKeywordLast = pKeyword + _countof(m_Types.m_RegexKeywordList) - 1;
-	// key1\0key2\0\0 ‚ÌŒ`®
+	// key1\0key2\0\0 ã®å½¢å¼
 	for(i = 0; i < MAX_REGEX_KEYWORD; i++)
 	{
 		if( i < nIndex )
@@ -648,7 +648,7 @@ int CPropTypesRegex::GetData( HWND hwndDlg )
 			if( pKeyword < pKeywordLast - 1 ){
 				_tcstowcs(pKeyword, &szKeyWord[0], pKeywordLast - pKeyword);
 			}
-			//Fw’è•¶š—ñ‚ğ”Ô†‚É•ÏŠ·‚·‚é
+			//è‰²æŒ‡å®šæ–‡å­—åˆ—ã‚’ç•ªå·ã«å¤‰æ›ã™ã‚‹
 			m_Types.m_RegexKeywordArr[i].m_nColorIndex = COLORIDX_REGEX1;
 			for(j = 0; j < COLORIDX_LAST; j++)
 			{
@@ -663,14 +663,14 @@ int CPropTypesRegex::GetData( HWND hwndDlg )
 				pKeyword++;
 			}
 		}
-		else	//–¢“o˜^•”•ª‚ÍƒNƒŠƒA‚·‚é
+		else	//æœªç™»éŒ²éƒ¨åˆ†ã¯ã‚¯ãƒªã‚¢ã™ã‚‹
 		{
 			m_Types.m_RegexKeywordArr[i].m_nColorIndex = COLORIDX_REGEX1;
 		}
 	}
-	*pKeyword = L'\0'; // ”Ô•º
+	*pKeyword = L'\0'; // ç•ªå…µ
 
-	//ƒ^ƒCƒvİ’è‚Ì•ÏX‚ª‚ ‚Á‚½
+	//ã‚¿ã‚¤ãƒ—è¨­å®šã®å¤‰æ›´ãŒã‚ã£ãŸ
 	m_Types.m_nRegexKeyMagicNumber = CRegexKeyword::GetNewMagicNumber();
 //	m_Types.m_nRegexKeyMagicNumber = 0;	//Not Compiled.
 
@@ -678,7 +678,7 @@ int CPropTypesRegex::GetData( HWND hwndDlg )
 }
 
 /*!
-	@date 2010.07.11 Moca ¡‚Ì‚Æ‚±‚ëCRegexKeyword::RegexKeyCheckSyntax‚Æ“¯ˆê‚È‚Ì‚ÅA’†g‚ğíœ‚µ‚Ä“]‘—ŠÖ”‚É•ÏX
+	@date 2010.07.11 Moca ä»Šã®ã¨ã“ã‚CRegexKeyword::RegexKeyCheckSyntaxã¨åŒä¸€ãªã®ã§ã€ä¸­èº«ã‚’å‰Šé™¤ã—ã¦è»¢é€é–¢æ•°ã«å¤‰æ›´
 */
 BOOL CPropTypesRegex::RegexKakomiCheck(const wchar_t *s)
 {
@@ -689,8 +689,8 @@ BOOL CPropTypesRegex::RegexKakomiCheck(const wchar_t *s)
 bool CPropTypesRegex::CheckKeywordList(HWND hwndDlg, const TCHAR* szNewKeyWord, int nUpdateItem)
 {
 	int nRet;
-	//‘®‚ğƒ`ƒFƒbƒN‚·‚éB
-	if( !RegexKakomiCheck(to_wchar(szNewKeyWord)) )	//ˆÍ‚İ‚ğƒ`ƒFƒbƒN‚·‚éB
+	//æ›¸å¼ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹ã€‚
+	if( !RegexKakomiCheck(to_wchar(szNewKeyWord)) )	//å›²ã¿ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹ã€‚
 	{
 		nRet = ::MYMESSAGEBOX(
 				hwndDlg,
@@ -708,7 +708,7 @@ bool CPropTypesRegex::CheckKeywordList(HWND hwndDlg, const TCHAR* szNewKeyWord, 
 				LS(STR_PROPTYPEREGEX_INVALID) );
 		if( nRet != IDYES ) return false;
 	}
-	// d•¡Šm”FE•¶š—ñ’·§ŒÀƒ`ƒFƒbƒN
+	// é‡è¤‡ç¢ºèªãƒ»æ–‡å­—åˆ—é•·åˆ¶é™ãƒã‚§ãƒƒã‚¯
 	const int nKeyWordSize = MAX_REGEX_KEYWORDLEN;
 	HWND hwndList = GetDlgItem( hwndDlg, IDC_LIST_REGEX );
 	int  nIndex  = ListView_GetItemCount(hwndList);
@@ -723,7 +723,7 @@ bool CPropTypesRegex::CheckKeywordList(HWND hwndDlg, const TCHAR* szNewKeyWord, 
 				ErrorMessage( hwndDlg, LS(STR_PROPTYPEREGEX_ALREADY));
 				return false;
 			}
-			// ’·‚³‚É‚Í\0‚àŠÜ‚Ş
+			// é•·ã•ã«ã¯\0ã‚‚å«ã‚€
 			nKeywordLen += auto_strlen(to_wchar(&szKeyWord[0])) + 1;
 			if( _countof(m_Types.m_RegexKeywordList) - 1 < nKeywordLen ){
 				ErrorMessage( hwndDlg, LS(STR_PROPTYPEREGEX_FULL) );

--- a/sakura_core/typeprop/CPropTypesScreen.cpp
+++ b/sakura_core/typeprop/CPropTypesScreen.cpp
@@ -1,13 +1,13 @@
-/*! @file
-	@brief �^�C�v�ʐݒ� - �X�N���[��
+﻿/*! @file
+	@brief タイプ別設定 - スクリーン
 
-	@date 2008.04.12 kobake CPropTypes.cpp���番��
+	@date 2008.04.12 kobake CPropTypes.cppから分離
 */
 /*
 	Copyright (C) 1998-2002, Norio Nakatani
 	Copyright (C) 2000, jepro, genta
 	Copyright (C) 2001, jepro, genta, MIK, hor, Stonee, asa-o
-	Copyright (C) 2002, YAZAKI, aroka, MIK, genta, ������, Moca
+	Copyright (C) 2002, YAZAKI, aroka, MIK, genta, こおり, Moca
 	Copyright (C) 2003, MIK, zenryaku, Moca, naoh, KEITA, genta
 	Copyright (C) 2005, MIK, genta, Moca, ryoji
 	Copyright (C) 2006, ryoji, fon, novice
@@ -31,48 +31,48 @@
 #include "doc/layout/CTsvModeInfo.h"
 
 static const DWORD p_helpids1[] = {	//11300
-	IDC_EDIT_TYPENAME,				HIDC_EDIT_TYPENAME,			//�ݒ�̖��O
-	IDC_EDIT_TYPEEXTS,				HIDC_EDIT_TYPEEXTS,			//�t�@�C���g���q
+	IDC_EDIT_TYPENAME,				HIDC_EDIT_TYPENAME,			//設定の名前
+	IDC_EDIT_TYPEEXTS,				HIDC_EDIT_TYPEEXTS,			//ファイル拡張子
 
-	IDC_COMBO_WRAPMETHOD,			HIDC_COMBO_WRAPMETHOD,		//�e�L�X�g�̐܂�Ԃ����@		// 2008.05.30 nasukoji
-	IDC_EDIT_MAXLINELEN,			HIDC_EDIT_MAXLINELEN,		//�܂�Ԃ�����
+	IDC_COMBO_WRAPMETHOD,			HIDC_COMBO_WRAPMETHOD,		//テキストの折り返し方法		// 2008.05.30 nasukoji
+	IDC_EDIT_MAXLINELEN,			HIDC_EDIT_MAXLINELEN,		//折り返し桁数
 	IDC_SPIN_MAXLINELEN,			HIDC_EDIT_MAXLINELEN,
-	IDC_EDIT_CHARSPACE,				HIDC_EDIT_CHARSPACE,		//�����̊Ԋu
+	IDC_EDIT_CHARSPACE,				HIDC_EDIT_CHARSPACE,		//文字の間隔
 	IDC_SPIN_CHARSPACE,				HIDC_EDIT_CHARSPACE,
-	IDC_EDIT_LINESPACE,				HIDC_EDIT_LINESPACE,		//�s�̊Ԋu
+	IDC_EDIT_LINESPACE,				HIDC_EDIT_LINESPACE,		//行の間隔
 	IDC_SPIN_LINESPACE,				HIDC_EDIT_LINESPACE,
-	IDC_EDIT_TABSPACE,				HIDC_EDIT_TABSPACE,			//TAB�� // Sep. 19, 2002 genta
+	IDC_EDIT_TABSPACE,				HIDC_EDIT_TABSPACE,			//TAB幅 // Sep. 19, 2002 genta
 	IDC_SPIN_TABSPACE,				HIDC_EDIT_TABSPACE,
-	IDC_EDIT_TABVIEWSTRING,			HIDC_EDIT_TABVIEWSTRING,	//TAB�\��������
-	IDC_CHECK_TAB_ARROW,			HIDC_CHECK_TAB_ARROW,		//���\��	// 2006.08.06 ryoji
-	IDC_CHECK_INS_SPACE,			HIDC_CHECK_INS_SPACE,		//�X�y�[�X�̑}��
-	IDC_COMBO_TSV_MODE,				HIDC_COMBO_TSV_MODE,		//TSV���[�h
+	IDC_EDIT_TABVIEWSTRING,			HIDC_EDIT_TABVIEWSTRING,	//TAB表示文字列
+	IDC_CHECK_TAB_ARROW,			HIDC_CHECK_TAB_ARROW,		//矢印表示	// 2006.08.06 ryoji
+	IDC_CHECK_INS_SPACE,			HIDC_CHECK_INS_SPACE,		//スペースの挿入
+	IDC_COMBO_TSV_MODE,				HIDC_COMBO_TSV_MODE,		//TSVモード
 
-	IDC_CHECK_INDENT,				HIDC_CHECK_INDENT,			//�����C���f���g	// 2006.08.19 ryoji
-	IDC_CHECK_INDENT_WSPACE,		HIDC_CHECK_INDENT_WSPACE,	//�S�p�󔒂��C���f���g	// 2006.08.19 ryoji
-	IDC_COMBO_SMARTINDENT,			HIDC_COMBO_SMARTINDENT,		//�X�}�[�g�C���f���g
-	IDC_EDIT_INDENTCHARS,			HIDC_EDIT_INDENTCHARS,		//���̑��̃C���f���g�Ώە���
-	IDC_COMBO_INDENTLAYOUT,			HIDC_COMBO_INDENTLAYOUT,	//�܂�Ԃ��s�C���f���g	// 2006.08.06 ryoji
-	IDC_CHECK_RTRIM_PREVLINE,		HIDC_CHECK_RTRIM_PREVLINE,	//���s���ɖ����̋󔒂��폜	// 2006.08.06 ryoji
+	IDC_CHECK_INDENT,				HIDC_CHECK_INDENT,			//自動インデント	// 2006.08.19 ryoji
+	IDC_CHECK_INDENT_WSPACE,		HIDC_CHECK_INDENT_WSPACE,	//全角空白もインデント	// 2006.08.19 ryoji
+	IDC_COMBO_SMARTINDENT,			HIDC_COMBO_SMARTINDENT,		//スマートインデント
+	IDC_EDIT_INDENTCHARS,			HIDC_EDIT_INDENTCHARS,		//その他のインデント対象文字
+	IDC_COMBO_INDENTLAYOUT,			HIDC_COMBO_INDENTLAYOUT,	//折り返し行インデント	// 2006.08.06 ryoji
+	IDC_CHECK_RTRIM_PREVLINE,		HIDC_CHECK_RTRIM_PREVLINE,	//改行時に末尾の空白を削除	// 2006.08.06 ryoji
 
-	IDC_RADIO_OUTLINEDEFAULT,		HIDC_RADIO_OUTLINEDEFAULT,	//�W�����[��	// 2006.08.06 ryoji
-	IDC_COMBO_OUTLINES,				HIDC_COMBO_OUTLINES,		//�A�E�g���C����͕��@
-	IDC_RADIO_OUTLINERULEFILE,		HIDC_RADIO_OUTLINERULEFILE,	//���[���t�@�C��	// 2006.08.06 ryoji
-	IDC_EDIT_OUTLINERULEFILE,		HIDC_EDIT_OUTLINERULEFILE,	//���[���t�@�C����	// 2006.08.06 ryoji
-	IDC_BUTTON_RULEFILE_REF,		HIDC_BUTTON_RULEFILE_REF,	//���[���t�@�C���Q��	// 2006/09/09 novice
+	IDC_RADIO_OUTLINEDEFAULT,		HIDC_RADIO_OUTLINEDEFAULT,	//標準ルール	// 2006.08.06 ryoji
+	IDC_COMBO_OUTLINES,				HIDC_COMBO_OUTLINES,		//アウトライン解析方法
+	IDC_RADIO_OUTLINERULEFILE,		HIDC_RADIO_OUTLINERULEFILE,	//ルールファイル	// 2006.08.06 ryoji
+	IDC_EDIT_OUTLINERULEFILE,		HIDC_EDIT_OUTLINERULEFILE,	//ルールファイル名	// 2006.08.06 ryoji
+	IDC_BUTTON_RULEFILE_REF,		HIDC_BUTTON_RULEFILE_REF,	//ルールファイル参照	// 2006/09/09 novice
 
-	IDC_CHECK_USETYPEFONT,			HIDC_CHECK_USETYPEFONT,		//�^�C�v�ʃt�H���g�g�p����
-	IDC_BUTTON_TYPEFONT,			HIDC_BUTTON_TYPEFONT,		//�^�C�v�ʃt�H���g
+	IDC_CHECK_USETYPEFONT,			HIDC_CHECK_USETYPEFONT,		//タイプ別フォント使用する
+	IDC_BUTTON_TYPEFONT,			HIDC_BUTTON_TYPEFONT,		//タイプ別フォント
 
-	IDC_CHECK_WORDWRAP,				HIDC_CHECK_WORDWRAP,		//�p�����[�h���b�v
-	IDC_CHECK_KINSOKURET,			HIDC_CHECK_KINSOKURET,		//���s�������Ԃ牺����	//@@@ 2002.04.14 MIK
-	IDC_CHECK_KINSOKUHIDE,			HIDC_CHECK_KINSOKUHIDE,		//�Ԃ牺�����B��		// 2012.11.30 Uchi
-	IDC_CHECK_KINSOKUKUTO,			HIDC_CHECK_KINSOKUKUTO,		//��Ǔ_���Ԃ牺����	//@@@ 2002.04.17 MIK
-	IDC_EDIT_KINSOKUKUTO,			HIDC_EDIT_KINSOKUKUTO,		//��Ǔ_�Ԃ牺������	// 2009.08.07 ryoji
-	IDC_CHECK_KINSOKUHEAD,			HIDC_CHECK_KINSOKUHEAD,		//�s���֑�	//@@@ 2002.04.08 MIK
-	IDC_EDIT_KINSOKUHEAD,			HIDC_EDIT_KINSOKUHEAD,		//�s���֑�	//@@@ 2002.04.08 MIK
-	IDC_CHECK_KINSOKUTAIL,			HIDC_CHECK_KINSOKUTAIL,		//�s���֑�	//@@@ 2002.04.08 MIK
-	IDC_EDIT_KINSOKUTAIL,			HIDC_EDIT_KINSOKUTAIL,		//�s���֑�	//@@@ 2002.04.08 MIK
+	IDC_CHECK_WORDWRAP,				HIDC_CHECK_WORDWRAP,		//英文ワードラップ
+	IDC_CHECK_KINSOKURET,			HIDC_CHECK_KINSOKURET,		//改行文字をぶら下げる	//@@@ 2002.04.14 MIK
+	IDC_CHECK_KINSOKUHIDE,			HIDC_CHECK_KINSOKUHIDE,		//ぶら下げを隠す		// 2012.11.30 Uchi
+	IDC_CHECK_KINSOKUKUTO,			HIDC_CHECK_KINSOKUKUTO,		//句読点をぶら下げる	//@@@ 2002.04.17 MIK
+	IDC_EDIT_KINSOKUKUTO,			HIDC_EDIT_KINSOKUKUTO,		//句読点ぶら下げ文字	// 2009.08.07 ryoji
+	IDC_CHECK_KINSOKUHEAD,			HIDC_CHECK_KINSOKUHEAD,		//行頭禁則	//@@@ 2002.04.08 MIK
+	IDC_EDIT_KINSOKUHEAD,			HIDC_EDIT_KINSOKUHEAD,		//行頭禁則	//@@@ 2002.04.08 MIK
+	IDC_CHECK_KINSOKUTAIL,			HIDC_CHECK_KINSOKUTAIL,		//行末禁則	//@@@ 2002.04.08 MIK
+	IDC_EDIT_KINSOKUTAIL,			HIDC_EDIT_KINSOKUTAIL,		//行末禁則	//@@@ 2002.04.08 MIK
 //	IDC_STATIC,						-1,
 	0, 0
 };
@@ -92,7 +92,7 @@ const TCHAR* pszOutlineNames[] = {
 };
 
 
-//�A�E�g���C����͕��@�E�W�����[��
+//アウトライン解析方法・標準ルール
 TYPE_NAME_ID<EOutlineType> OlmArr[] = {
 	{ OUTLINE_C_CPP,	STR_OUTLINE_CPP },
 	{ OUTLINE_C,		STR2_OUTLINE_C },
@@ -105,17 +105,17 @@ TYPE_NAME_ID<EOutlineType> OlmArr[] = {
 	{ OUTLINE_VB,		STR_OUTLINE_VB },			// 2001/06/23 N.Nakatani
 	{ OUTLINE_PYTHON,	STR_OUTLINE_PYTHON },		//	2007.02.08 genta
 	{ OUTLINE_ERLANG,	STR_OUTLINE_ERLANG },			//	2009.08.10 genta
-	{ OUTLINE_WZTXT,	STR_OUTLINE_WZ },			// 2003.05.20 zenryaku, 2003.06.23 Moca ���̕ύX
+	{ OUTLINE_WZTXT,	STR_OUTLINE_WZ },			// 2003.05.20 zenryaku, 2003.06.23 Moca 名称変更
 	{ OUTLINE_HTML,		STR_OUTLINE_HTML },			// 2003.05.20 zenryaku
 	{ OUTLINE_XML,		STR2_OUTLINE_XML },			// 2014.12.25 Moca
 	{ OUTLINE_TEX,		STR_OUTLINE_TEX },		// 2003.07.20 naoh
-	{ OUTLINE_TEXT,		STR_OUTLINE_TEXT }		//Jul. 08, 2001 JEPRO ��ɍŌ���ɂ���
+	{ OUTLINE_TEXT,		STR_OUTLINE_TEXT }		//Jul. 08, 2001 JEPRO 常に最後尾におく
 };
 
 TYPE_NAME_ID<ETabArrow> TabArrowArr[] = {
-	{ TABARROW_STRING,	STR_TAB_SYMBOL_CHARA },			//_T("�����w��")
-	{ TABARROW_SHORT,	STR_TAB_SYMBOL_SHORT_ARROW },	//_T("�Z�����")
-	{ TABARROW_LONG,	STR_TAB_SYMBOL_LONG_ARROW },	//_T("�������")
+	{ TABARROW_STRING,	STR_TAB_SYMBOL_CHARA },			//_T("文字指定")
+	{ TABARROW_SHORT,	STR_TAB_SYMBOL_SHORT_ARROW },	//_T("短い矢印")
+	{ TABARROW_LONG,	STR_TAB_SYMBOL_LONG_ARROW },	//_T("長い矢印")
 };
 
 TYPE_NAME_ID<ESmartIndentType> SmartIndentArr[] = {
@@ -123,48 +123,48 @@ TYPE_NAME_ID<ESmartIndentType> SmartIndentArr[] = {
 	{ SMARTINDENT_CPP,	STR_SMART_INDENT_C_CPP },
 };
 
-/*!	2�s�ڈȍ~�̃C���f���g���@
+/*!	2行目以降のインデント方法
 
 	@sa CLayoutMgr::SetLayoutInfo()
 	@date Oct. 1, 2002 genta 
 */
 TYPE_NAME_ID<int> IndentTypeArr[] = {
-	{ 0, STR_WRAP_INDENT_NONE },	//_T("�Ȃ�")
+	{ 0, STR_WRAP_INDENT_NONE },	//_T("なし")
 	{ 1, STR_WRAP_INDENT_TX2X },	//_T("tx2x")
-	{ 2, STR_WRAP_INDENT_BOL },		//_T("�_���s�擪")
+	{ 2, STR_WRAP_INDENT_BOL },		//_T("論理行先頭")
 };
 
-// 2008.05.30 nasukoji	�e�L�X�g�̐܂�Ԃ����@
+// 2008.05.30 nasukoji	テキストの折り返し方法
 TYPE_NAME_ID<int> WrapMethodArr[] = {
-	{ WRAP_NO_TEXT_WRAP,	STR_WRAP_METHOD_NO_WRAP },	//_T("�܂�Ԃ��Ȃ�")
-	{ WRAP_SETTING_WIDTH,	STR_WRAP_METHOD_SPEC_WIDTH },	//_T("�w�茅�Ő܂�Ԃ�")
-	{ WRAP_WINDOW_WIDTH,	STR_WRAP_METHOD_WIN_WIDTH },	//_T("�E�[�Ő܂�Ԃ�")
+	{ WRAP_NO_TEXT_WRAP,	STR_WRAP_METHOD_NO_WRAP },	//_T("折り返さない")
+	{ WRAP_SETTING_WIDTH,	STR_WRAP_METHOD_SPEC_WIDTH },	//_T("指定桁で折り返す")
+	{ WRAP_WINDOW_WIDTH,	STR_WRAP_METHOD_WIN_WIDTH },	//_T("右端で折り返す")
 };
 
-// TSV���[�h
+// TSVモード
 TYPE_NAME_ID<int> TsvModeArr[] = {
-	{ TSV_MODE_NONE,		STR_TSV_MODE_NONE },	//_T("�ʏ�")
+	{ TSV_MODE_NONE,		STR_TSV_MODE_NONE },	//_T("通常")
 	{ TSV_MODE_TSV,			STR_TSV_MODE_TSV },		//_T("TSV")
 	{ TSV_MODE_CSV,			STR_TSV_MODE_CSV },		//_T("CSV")
 };
 
-//�ÓI�����o
-std::vector<TYPE_NAME_ID2<EOutlineType> > CPropTypes::m_OlmArr;	//!<�A�E�g���C����̓��[���z��
-std::vector<TYPE_NAME_ID2<ESmartIndentType> > CPropTypes::m_SIndentArr;	//!<�X�}�[�g�C���f���g���[���z��
+//静的メンバ
+std::vector<TYPE_NAME_ID2<EOutlineType> > CPropTypes::m_OlmArr;	//!<アウトライン解析ルール配列
+std::vector<TYPE_NAME_ID2<ESmartIndentType> > CPropTypes::m_SIndentArr;	//!<スマートインデントルール配列
 
-//�X�N���[���^�u�̏�����
+//スクリーンタブの初期化
 void CPropTypesScreen::CPropTypes_Screen()
 {
-	//�v���O�C�������̏ꍇ�A�����ŐÓI�����o������������B�v���O�C���L���̏ꍇ��AddXXXMethod���ŏ���������B
+	//プラグイン無効の場合、ここで静的メンバを初期化する。プラグイン有効の場合はAddXXXMethod内で初期化する。
 	if( m_OlmArr.empty() ){
-		InitTypeNameId2(m_OlmArr, OlmArr, _countof(OlmArr));	//�A�E�g���C����̓��[��
+		InitTypeNameId2(m_OlmArr, OlmArr, _countof(OlmArr));	//アウトライン解析ルール
 	}
 	if( m_SIndentArr.empty() ){
-		InitTypeNameId2(m_SIndentArr, SmartIndentArr, _countof(SmartIndentArr));	//�X�}�[�g�C���f���g���[��
+		InitTypeNameId2(m_SIndentArr, SmartIndentArr, _countof(SmartIndentArr));	//スマートインデントルール
 	}
 }
 
-/* Screen ���b�Z�[�W���� */
+/* Screen メッセージ処理 */
 INT_PTR CPropTypesScreen::DispatchEvent(
 	HWND		hwndDlg,	// handle to dialog box
 	UINT		uMsg,		// message
@@ -183,35 +183,35 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 
 	case WM_INITDIALOG:
 		m_hwndThis = hwndDlg;
-		/* �_�C�A���O�f�[�^�̐ݒ� Screen */
+		/* ダイアログデータの設定 Screen */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		// �G�f�B�b�g�R���g���[���̓��͕���������
+		// エディットコントロールの入力文字数制限
 		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_TYPENAME        ), _countof( m_Types.m_szTypeName      ) - 1 );
 		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_TYPEEXTS        ), _countof( m_Types.m_szTypeExts      ) - 1 );
 		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_INDENTCHARS     ), _countof( m_Types.m_szIndentChars   ) - 1 );
 		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_TABVIEWSTRING   ), _countof( m_Types.m_szTabViewString ) - 1 );
-		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_OUTLINERULEFILE ), _countof2( m_Types.m_szOutlineRuleFilename ) - 1 );	//	Oct. 5, 2002 genta ��ʏ�ł����͐���
+		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_OUTLINERULEFILE ), _countof2( m_Types.m_szOutlineRuleFilename ) - 1 );	//	Oct. 5, 2002 genta 画面上でも入力制限
 
 		if( 0 == m_Types.m_nIdx ){
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_TYPENAME ), FALSE );	//�ݒ�̖��O
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_TYPEEXTS ), FALSE );	//�t�@�C���g���q
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_TYPENAME ), FALSE );	//設定の名前
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_TYPEEXTS ), FALSE );	//ファイル拡張子
 		}
 		UpDown_SetRange(::GetDlgItem(hwndDlg, IDC_SPIN_LINESPACE), -LINESPACE_MAX, LINESPACE_MAX);
 
 		return TRUE;
 	case WM_COMMAND:
-		wNotifyCode	= HIWORD(wParam);	/* �ʒm�R�[�h */
-		wID			= LOWORD(wParam);	/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
-//		hwndCtl		= (HWND) lParam;	/* �R���g���[���̃n���h�� */
+		wNotifyCode	= HIWORD(wParam);	/* 通知コード */
+		wID			= LOWORD(wParam);	/* 項目ID､ コントロールID､ またはアクセラレータID */
+//		hwndCtl		= (HWND) lParam;	/* コントロールのハンドル */
 		switch( wNotifyCode ){
 		case CBN_SELCHANGE:
 			switch( wID ){
 			case IDC_CHECK_TAB_ARROW:
 				{
-					// Mar. 31, 2003 genta ���\����ON/OFF��TAB������ݒ�ɘA��������
+					// Mar. 31, 2003 genta 矢印表示のON/OFFをTAB文字列設定に連動させる
 					HWND hwndCombo = ::GetDlgItem( hwndDlg, IDC_CHECK_TAB_ARROW );
 					int nSelPos = Combo_GetCurSel( hwndCombo );
 					if( TABARROW_STRING == TabArrowArr[nSelPos].nMethod ){
@@ -225,13 +225,13 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 			}
 			break;
 
-		/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+		/* ボタン／チェックボックスがクリックされた */
 		case BN_CLICKED:
 			switch( wID ){
-			/*	2002.04.01 YAZAKI �I�[�g�C���f���g���폜�i���Ƃ��ƕs�v�j
-				�A�E�g���C����͂Ƀ��[���t�@�C���֘A��ǉ�
+			/*	2002.04.01 YAZAKI オートインデントを削除（もともと不要）
+				アウトライン解析にルールファイル関連を追加
 			*/
-			case IDC_RADIO_OUTLINEDEFAULT:	/* �A�E�g���C����́��W�����[�� */
+			case IDC_RADIO_OUTLINEDEFAULT:	/* アウトライン解析→標準ルール */
 				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_COMBO_OUTLINES ), TRUE );
 				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_OUTLINERULEFILE ), FALSE );
 				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_RULEFILE_REF ), FALSE );
@@ -239,16 +239,16 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 				Combo_SetCurSel( ::GetDlgItem( hwndDlg, IDC_COMBO_OUTLINES ), 0 );
 
 				return TRUE;
-			case IDC_RADIO_OUTLINERULEFILE:	/* �A�E�g���C����́����[���t�@�C�� */
+			case IDC_RADIO_OUTLINERULEFILE:	/* アウトライン解析→ルールファイル */
 				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_COMBO_OUTLINES ), FALSE );
 				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_OUTLINERULEFILE ), TRUE );
 				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_RULEFILE_REF ), TRUE );
 				return TRUE;
 
-			case IDC_BUTTON_RULEFILE_REF:	/* �A�E�g���C����́����[���t�@�C���́u�Q��...�v�{�^�� */
+			case IDC_BUTTON_RULEFILE_REF:	/* アウトライン解析→ルールファイルの「参照...」ボタン */
 				{
-					// 2003.06.23 Moca ���΃p�X�͎��s�t�@�C������̃p�X�Ƃ��ĊJ��
-					// 2007.05.19 ryoji ���΃p�X�͐ݒ�t�@�C������̃p�X��D��
+					// 2003.06.23 Moca 相対パスは実行ファイルからのパスとして開く
+					// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
 					CDlgOpenFile::SelectFile(hwndDlg, GetDlgItem(hwndDlg, IDC_EDIT_OUTLINERULEFILE), _T("*.rul;*.rule;*.txt"), true, EFITER_NONE);
 				}
 				return TRUE;
@@ -270,10 +270,10 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 					if( MySelectFont( &lf, &nPointSize, hwndDlg, bFixedFont) ){
 						m_Types.m_lf = lf;
 						m_Types.m_nPointSize = nPointSize;
-						m_Types.m_bUseTypeFont = true;		// �^�C�v�ʃt�H���g�̎g�p
+						m_Types.m_bUseTypeFont = true;		// タイプ別フォントの使用
 						::CheckDlgButton( hwndDlg, IDC_CHECK_USETYPEFONT, m_Types.m_bUseTypeFont );
 						::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_USETYPEFONT ), m_Types.m_bUseTypeFont );
-						// �t�H���g�\��	// 2013/6/23 Uchi
+						// フォント表示	// 2013/6/23 Uchi
 						HFONT hFont = SetFontLabel( hwndDlg, IDC_STATIC_TYPEFONT, m_Types.m_lf, m_Types.m_nPointSize, m_Types.m_bUseTypeFont);
 						if(m_hTypeFont != NULL){
 							::DeleteObject( m_hTypeFont );
@@ -285,7 +285,7 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 			case IDC_CHECK_USETYPEFONT:	// 2013/6/24 Uchi
 				if (!::IsDlgButtonChecked( hwndDlg, IDC_CHECK_USETYPEFONT )) {
 					::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_USETYPEFONT ), FALSE );
-					// �t�H���g�\��
+					// フォント表示
 					HFONT hFont = SetFontLabel( hwndDlg, IDC_STATIC_TYPEFONT, m_Types.m_lf, m_Types.m_nPointSize, FALSE);
 					if(m_hTypeFont != NULL){
 						::DeleteObject( m_hTypeFont );
@@ -293,9 +293,9 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 					m_hTypeFont = hFont;
 				}
 				return TRUE;
-			case IDC_CHECK_KINSOKURET:		//���s�������Ԃ牺����
-			case IDC_CHECK_KINSOKUKUTO:		//��Ǔ_���Ԃ牺����
-				// �Ԃ牺�����B���̗L����	2012/11/30 Uchi
+			case IDC_CHECK_KINSOKURET:		//改行文字をぶら下げる
+			case IDC_CHECK_KINSOKUKUTO:		//句読点をぶら下げる
+				// ぶら下げを隠すの有効化	2012/11/30 Uchi
 				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KINSOKUHIDE ), 
 					::IsDlgButtonChecked( hwndDlg, IDC_CHECK_KINSOKURET ) 
 				 || ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_KINSOKUKUTO ) );
@@ -309,7 +309,7 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 		pMNUD  = (NM_UPDOWN*)lParam;
 		switch( idCtrl ){
 		case IDC_SPIN_MAXLINELEN:
-			/* �܂�Ԃ����� */
+			/* 折り返し桁数 */
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_MAXLINELEN, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				++nVal;
@@ -326,7 +326,7 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_MAXLINELEN, nVal, FALSE );
 			return TRUE;
 		case IDC_SPIN_CHARSPACE:
-			/* �����̌��� */
+			/* 文字の隙間 */
 //			MYTRACE( _T("IDC_SPIN_CHARSPACE\n") );
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_CHARSPACE, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
@@ -338,13 +338,13 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 			if( nVal < 0 ){
 				nVal = 0;
 			}
-			if( nVal > COLUMNSPACE_MAX ){ // Feb. 18, 2003 genta �ő�l�̒萔��
+			if( nVal > COLUMNSPACE_MAX ){ // Feb. 18, 2003 genta 最大値の定数化
 				nVal = COLUMNSPACE_MAX;
 			}
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_CHARSPACE, nVal, FALSE );
 			return TRUE;
 		case IDC_SPIN_LINESPACE:
-			/* �s�̌��� */
+			/* 行の隙間 */
 //			MYTRACE( _T("IDC_SPIN_LINESPACE\n") );
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_LINESPACE, NULL, TRUE );
 			if( pMNUD->iDelta < 0 ){
@@ -353,7 +353,7 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 			if( pMNUD->iDelta > 0 ){
 				--nVal;
 			}
-//	From Here Oct. 8, 2000 JEPRO �s�Ԃ��ŏ�0�܂Őݒ�ł���悤�ɕύX(�̂ɖ߂�������?)
+//	From Here Oct. 8, 2000 JEPRO 行間も最小0まで設定できるように変更(昔に戻っただけ?)
 //			if( nVal < 1 ){
 //				nVal = 1;
 //			}
@@ -361,14 +361,14 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 				nVal = -LINESPACE_MAX;
 			}
 //	To Here  Oct. 8, 2000
-			if( nVal > LINESPACE_MAX ){ // Feb. 18, 2003 genta �ő�l�̒萔��
+			if( nVal > LINESPACE_MAX ){ // Feb. 18, 2003 genta 最大値の定数化
 				nVal = LINESPACE_MAX;
 			}
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_LINESPACE, nVal, TRUE );
 			return TRUE;
 		case IDC_SPIN_TABSPACE:
 			//	Sep. 22, 2002 genta
-			/* TAB�� */
+			/* TAB幅 */
 //			MYTRACE( _T("IDC_SPIN_CHARSPACE\n") );
 			nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_TABSPACE, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
@@ -392,11 +392,11 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 				OnHelp( hwndDlg, IDD_PROP_SCREEN );
 				return TRUE;
 			case PSN_KILLACTIVE:
-				/* �_�C�A���O�f�[�^�̎擾 Screen */
+				/* ダイアログデータの取得 Screen */
 				GetData( hwndDlg );
 
 				return TRUE;
-//@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+//@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPTYPE_PAGENUM_SCREEN;
 				return TRUE;
@@ -415,7 +415,7 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids1 );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids1 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -425,12 +425,12 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 //@@@ 2001.11.17 add start MIK
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids1 );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids1 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.11.17 add end MIK
 
 	case WM_DESTROY:
-		// �^�C�v�t�H���g�j��	// 2013/6/23 Uchi
+		// タイプフォント破棄	// 2013/6/23 Uchi
 		if (m_hTypeFont != NULL) {
 			::DeleteObject( m_hTypeFont );
 			m_hTypeFont = NULL;
@@ -442,34 +442,34 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 
 
 
-/* �_�C�A���O�f�[�^�̐ݒ� Screen */
+/* ダイアログデータの設定 Screen */
 void CPropTypesScreen::SetData( HWND hwndDlg )
 {
-	::DlgItem_SetText( hwndDlg, IDC_EDIT_TYPENAME, m_Types.m_szTypeName );	//�ݒ�̖��O
-	::DlgItem_SetText( hwndDlg, IDC_EDIT_TYPEEXTS, m_Types.m_szTypeExts );	//�t�@�C���g���q
+	::DlgItem_SetText( hwndDlg, IDC_EDIT_TYPENAME, m_Types.m_szTypeName );	//設定の名前
+	::DlgItem_SetText( hwndDlg, IDC_EDIT_TYPEEXTS, m_Types.m_szTypeExts );	//ファイル拡張子
 
-	//���C�A�E�g
+	//レイアウト
 	{
-		// 2008.05.30 nasukoji	�e�L�X�g�̐܂�Ԃ����@
+		// 2008.05.30 nasukoji	テキストの折り返し方法
 		HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WRAPMETHOD );
 		Combo_ResetContent( hwndCombo );
 		int		nSelPos = 0;
 		for( int i = 0; i < _countof( WrapMethodArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS( WrapMethodArr[i].nNameId ) );
-			if( WrapMethodArr[i].nMethod == m_Types.m_nTextWrapMethod ){		// �e�L�X�g�̐܂�Ԃ����@
+			if( WrapMethodArr[i].nMethod == m_Types.m_nTextWrapMethod ){		// テキストの折り返し方法
 				nSelPos = i;
 			}
 		}
 		Combo_SetCurSel( hwndCombo, nSelPos );
 
-		::SetDlgItemInt( hwndDlg, IDC_EDIT_MAXLINELEN, (Int)m_Types.m_nMaxLineKetas, FALSE );	// �܂�Ԃ�������
-		::SetDlgItemInt( hwndDlg, IDC_EDIT_CHARSPACE, m_Types.m_nColumnSpace, FALSE );			// �����̊Ԋu
-		::SetDlgItemInt( hwndDlg, IDC_EDIT_LINESPACE, m_Types.m_nLineSpace, TRUE );			// �s�̊Ԋu
-		::SetDlgItemInt( hwndDlg, IDC_EDIT_TABSPACE, (Int)m_Types.m_nTabSpace, FALSE );			// TAB��	//	Sep. 22, 2002 genta
-		::DlgItem_SetText( hwndDlg, IDC_EDIT_TABVIEWSTRING, m_Types.m_szTabViewString );		// TAB�\��(8����)
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_TABVIEWSTRING ), m_Types.m_bTabArrow == TABARROW_STRING );	// Mar. 31, 2003 genta ���\����ON/OFF��TAB������ݒ�ɘA��������
+		::SetDlgItemInt( hwndDlg, IDC_EDIT_MAXLINELEN, (Int)m_Types.m_nMaxLineKetas, FALSE );	// 折り返し文字数
+		::SetDlgItemInt( hwndDlg, IDC_EDIT_CHARSPACE, m_Types.m_nColumnSpace, FALSE );			// 文字の間隔
+		::SetDlgItemInt( hwndDlg, IDC_EDIT_LINESPACE, m_Types.m_nLineSpace, TRUE );			// 行の間隔
+		::SetDlgItemInt( hwndDlg, IDC_EDIT_TABSPACE, (Int)m_Types.m_nTabSpace, FALSE );			// TAB幅	//	Sep. 22, 2002 genta
+		::DlgItem_SetText( hwndDlg, IDC_EDIT_TABVIEWSTRING, m_Types.m_szTabViewString );		// TAB表示(8文字)
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_TABVIEWSTRING ), m_Types.m_bTabArrow == TABARROW_STRING );	// Mar. 31, 2003 genta 矢印表示のON/OFFをTAB文字列設定に連動させる
 
-		// ���\��	//@@@ 2003.03.26 MIK
+		// 矢印表示	//@@@ 2003.03.26 MIK
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_CHECK_TAB_ARROW );
 		Combo_ResetContent( hwndCombo );
 		nSelPos = 0;
@@ -481,9 +481,9 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 		}
 		Combo_SetCurSel( hwndCombo, nSelPos );
 
-		::CheckDlgButtonBool( hwndDlg, IDC_CHECK_INS_SPACE, m_Types.m_bInsSpace );				// SPACE�̑}�� [�`�F�b�N�{�b�N�X]	// From Here 2001.12.03 hor
+		::CheckDlgButtonBool( hwndDlg, IDC_CHECK_INS_SPACE, m_Types.m_bInsSpace );				// SPACEの挿入 [チェックボックス]	// From Here 2001.12.03 hor
 
-		// TSV���[�h
+		// TSVモード
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_TSV_MODE );
 		Combo_ResetContent( hwndCombo );
 		nSelPos = 0;
@@ -496,15 +496,15 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 		Combo_SetCurSel( hwndCombo, nSelPos );
 	}
 
-	//�C���f���g
+	//インデント
 	{
-		/* �����C���f���g */
+		/* 自動インデント */
 		::CheckDlgButtonBool( hwndDlg, IDC_CHECK_INDENT, m_Types.m_bAutoIndent );
 
-		/* ���{��󔒂��C���f���g */
+		/* 日本語空白もインデント */
 		::CheckDlgButtonBool( hwndDlg, IDC_CHECK_INDENT_WSPACE, m_Types.m_bAutoIndent_ZENSPACE );
 
-		/* �X�}�[�g�C���f���g��� */
+		/* スマートインデント種別 */
 		HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_SMARTINDENT );
 		Combo_ResetContent( hwndCombo );
 		int		nSelPos = 0;
@@ -515,35 +515,35 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 			}else{
 				Combo_InsertString( hwndCombo, i, m_SIndentArr[i].pszName );
 			}
-			if( m_SIndentArr[i].nMethod == m_Types.m_eSmartIndent ){	/* �X�}�[�g�C���f���g��� */
+			if( m_SIndentArr[i].nMethod == m_Types.m_eSmartIndent ){	/* スマートインデント種別 */
 				nSelPos = i;
 			}
 		}
 		Combo_SetCurSel( hwndCombo, nSelPos );
 
-		// ���̑��̃C���f���g�Ώە���
+		// その他のインデント対象文字
 		::DlgItem_SetText( hwndDlg, IDC_EDIT_INDENTCHARS, m_Types.m_szIndentChars );
 
-		//�܂�Ԃ��s�C���f���g	//	Oct. 1, 2002 genta �R���{�{�b�N�X�ɕύX
+		//折り返し行インデント	//	Oct. 1, 2002 genta コンボボックスに変更
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_INDENTLAYOUT );
 		Combo_ResetContent( hwndCombo );
 		nSelPos = 0;
 		for( int i = 0; i < _countof( IndentTypeArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS( IndentTypeArr[i].nNameId ) );
-			if( IndentTypeArr[i].nMethod == m_Types.m_nIndentLayout ){	/* �܂�Ԃ��C���f���g��� */
+			if( IndentTypeArr[i].nMethod == m_Types.m_nIndentLayout ){	/* 折り返しインデント種別 */
 				nSelPos = i;
 			}
 		}
 		Combo_SetCurSel( hwndCombo, nSelPos );
 
-		// ���s���ɖ����̋󔒂��폜	//2005.10.11 ryoji
+		// 改行時に末尾の空白を削除	//2005.10.11 ryoji
 		::CheckDlgButton( hwndDlg, IDC_CHECK_RTRIM_PREVLINE, m_Types.m_bRTrimPrevLine );
 	}
 
-	//�A�E�g���C����͕��@
-	//2002.04.01 YAZAKI ���[���t�@�C���֘A�ǉ�
+	//アウトライン解析方法
+	//2002.04.01 YAZAKI ルールファイル関連追加
 	{
-		//�W�����[���̃R���{�{�b�N�X������
+		//標準ルールのコンボボックス初期化
 		HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_OUTLINES );
 		Combo_ResetContent( hwndCombo );
 		int		nSelPos = 0;
@@ -558,16 +558,16 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 			}else{
 				Combo_InsertString( hwndCombo, i, m_OlmArr[i].pszName );
 			}
-			if( m_OlmArr[i].nMethod == m_Types.m_eDefaultOutline ){	/* �A�E�g���C����͕��@ */
+			if( m_OlmArr[i].nMethod == m_Types.m_eDefaultOutline ){	/* アウトライン解析方法 */
 				nSelPos = i;
 			}
 		}
 
-		//���[���t�@�C��	// 2003.06.23 Moca ���[���t�@�C�����͎g��Ȃ��Ă��Z�b�g���Ă���
+		//ルールファイル	// 2003.06.23 Moca ルールファイル名は使わなくてもセットしておく
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_OUTLINERULEFILE ), TRUE );
 		::DlgItem_SetText( hwndDlg, IDC_EDIT_OUTLINERULEFILE, m_Types.m_szOutlineRuleFilename );
 
-		//�W�����[��
+		//標準ルール
 		if( m_Types.m_eDefaultOutline != OUTLINE_FILE ){
 			::CheckDlgButton( hwndDlg, IDC_RADIO_OUTLINEDEFAULT, TRUE );
 			::CheckDlgButton( hwndDlg, IDC_RADIO_OUTLINERULEFILE, FALSE );
@@ -578,7 +578,7 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 
 			Combo_SetCurSel( hwndCombo, nSelPos );
 		}
-		//���[���t�@�C��
+		//ルールファイル
 		else{
 			::CheckDlgButton( hwndDlg, IDC_RADIO_OUTLINEDEFAULT, FALSE );
 			::CheckDlgButton( hwndDlg, IDC_RADIO_OUTLINERULEFILE, TRUE );
@@ -588,78 +588,78 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 		}
 	}
 
-	//�t�H���g
+	//フォント
 	{
-		::CheckDlgButton( hwndDlg, IDC_CHECK_USETYPEFONT, m_Types.m_bUseTypeFont );			// �^�C�v�ʃt�H���g�̎g�p
+		::CheckDlgButton( hwndDlg, IDC_CHECK_USETYPEFONT, m_Types.m_bUseTypeFont );			// タイプ別フォントの使用
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_USETYPEFONT ), m_Types.m_bUseTypeFont );
 		m_hTypeFont = SetFontLabel( hwndDlg, IDC_STATIC_TYPEFONT, m_Types.m_lf, m_Types.m_nPointSize, m_Types.m_bUseTypeFont);
 	}
 
-	//���̑�
+	//その他
 	{
-		/* �p�����[�h���b�v������ */
+		/* 英文ワードラップをする */
 		::CheckDlgButtonBool( hwndDlg, IDC_CHECK_WORDWRAP, m_Types.m_bWordWrap );
 
-		/* �֑����� */
+		/* 禁則処理 */
 		{	//@@@ 2002.04.08 MIK start
 			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKUHEAD, m_Types.m_bKinsokuHead );
 			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKUTAIL, m_Types.m_bKinsokuTail );
-			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKURET,  m_Types.m_bKinsokuRet  );	/* ���s�������Ԃ牺���� */	//@@@ 2002.04.13 MIK
-			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKUKUTO, m_Types.m_bKinsokuKuto );	/* ��Ǔ_���Ԃ牺���� */	//@@@ 2002.04.17 MIK
-			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKUHIDE, m_Types.m_bKinsokuHide );	// �Ԃ牺�����B��			// 2011/11/30 Uchi
+			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKURET,  m_Types.m_bKinsokuRet  );	/* 改行文字をぶら下げる */	//@@@ 2002.04.13 MIK
+			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKUKUTO, m_Types.m_bKinsokuKuto );	/* 句読点をぶら下げる */	//@@@ 2002.04.17 MIK
+			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKUHIDE, m_Types.m_bKinsokuHide );	// ぶら下げを隠す			// 2011/11/30 Uchi
 			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KINSOKUHEAD ), _countof(m_Types.m_szKinsokuHead) - 1 );
 			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KINSOKUTAIL ), _countof(m_Types.m_szKinsokuTail) - 1 );
 			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KINSOKUKUTO ), _countof(m_Types.m_szKinsokuKuto) - 1 );	// 2009.08.07 ryoji
 			::DlgItem_SetText( hwndDlg, IDC_EDIT_KINSOKUHEAD, m_Types.m_szKinsokuHead );
 			::DlgItem_SetText( hwndDlg, IDC_EDIT_KINSOKUTAIL, m_Types.m_szKinsokuTail );
 			::DlgItem_SetText( hwndDlg, IDC_EDIT_KINSOKUKUTO, m_Types.m_szKinsokuKuto );	// 2009.08.07 ryoji
-			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KINSOKUHIDE ), ( m_Types.m_bKinsokuRet || m_Types.m_bKinsokuKuto ) ? TRUE : FALSE );	// �Ԃ牺�����B���̗L����	2012/11/30 Uchi
+			::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KINSOKUHIDE ), ( m_Types.m_bKinsokuRet || m_Types.m_bKinsokuKuto ) ? TRUE : FALSE );	// ぶら下げを隠すの有効化	2012/11/30 Uchi
 		}	//@@@ 2002.04.08 MIK end
 	}
 }
 
 
 
-/* �_�C�A���O�f�[�^�̎擾 Screen */
+/* ダイアログデータの取得 Screen */
 int CPropTypesScreen::GetData( HWND hwndDlg )
 {
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_TYPENAME, m_Types.m_szTypeName, _countof( m_Types.m_szTypeName ) );	// �ݒ�̖��O
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_TYPEEXTS, m_Types.m_szTypeExts, _countof( m_Types.m_szTypeExts ) );	// �t�@�C���g���q
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_TYPENAME, m_Types.m_szTypeName, _countof( m_Types.m_szTypeName ) );	// 設定の名前
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_TYPEEXTS, m_Types.m_szTypeExts, _countof( m_Types.m_szTypeExts ) );	// ファイル拡張子
 
-	//���C�A�E�g
+	//レイアウト
 	{
-		// 2008.05.30 nasukoji	�e�L�X�g�̐܂�Ԃ����@
+		// 2008.05.30 nasukoji	テキストの折り返し方法
 		HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WRAPMETHOD );
 		int		nSelPos = Combo_GetCurSel( hwndCombo );
-		m_Types.m_nTextWrapMethod = WrapMethodArr[nSelPos].nMethod;		// �e�L�X�g�̐܂�Ԃ����@
+		m_Types.m_nTextWrapMethod = WrapMethodArr[nSelPos].nMethod;		// テキストの折り返し方法
 
-		/* �܂�Ԃ����� */
+		/* 折り返し桁数 */
 		m_Types.m_nMaxLineKetas = CKetaXInt(t_max(MINLINEKETAS,
 			t_min<int>(MAXLINEKETAS, ::GetDlgItemInt( hwndDlg, IDC_EDIT_MAXLINELEN, NULL, FALSE ))));
 
-		/* �����̊Ԋu */
+		/* 文字の間隔 */
 		m_Types.m_nColumnSpace = ::GetDlgItemInt( hwndDlg, IDC_EDIT_CHARSPACE, NULL, FALSE );
 		if( m_Types.m_nColumnSpace < 0 ){
 			m_Types.m_nColumnSpace = 0;
 		}
-		if( m_Types.m_nColumnSpace > COLUMNSPACE_MAX ){ // Feb. 18, 2003 genta �ő�l�̒萔��
+		if( m_Types.m_nColumnSpace > COLUMNSPACE_MAX ){ // Feb. 18, 2003 genta 最大値の定数化
 			m_Types.m_nColumnSpace = COLUMNSPACE_MAX;
 		}
 
-		/* �s�̊Ԋu */
+		/* 行の間隔 */
 		m_Types.m_nLineSpace = ::GetDlgItemInt( hwndDlg, IDC_EDIT_LINESPACE, NULL, TRUE );
 		if( m_Types.m_nLineSpace < -LINESPACE_MAX ){
 			m_Types.m_nLineSpace = -LINESPACE_MAX;
  		}
-		if( m_Types.m_nLineSpace > LINESPACE_MAX ){	// Feb. 18, 2003 genta �ő�l�̒萔��
+		if( m_Types.m_nLineSpace > LINESPACE_MAX ){	// Feb. 18, 2003 genta 最大値の定数化
 			m_Types.m_nLineSpace = LINESPACE_MAX;
 		}
 
-		/* TAB�� */
+		/* TAB幅 */
 		m_Types.m_nTabSpace = CKetaXInt(t_max(1,
 			t_min<int>(64, ::GetDlgItemInt( hwndDlg, IDC_EDIT_TABSPACE, NULL, FALSE ))));
 
-		/* TAB�\�������� */
+		/* TAB表示文字列 */
 		WIN_CHAR szTab[8+1]; /* +1. happy */
 		::DlgItem_GetText( hwndDlg, IDC_EDIT_TABVIEWSTRING, szTab, _countof( szTab ) );
 		wcscpy( m_Types.m_szTabViewString, L"^       " );
@@ -668,71 +668,71 @@ int CPropTypesScreen::GetData( HWND hwndDlg )
 			m_Types.m_szTabViewString[i] = szTab[i];
 		}
 
-		// �^�u���\��	//@@@ 2003.03.26 MIK
+		// タブ矢印表示	//@@@ 2003.03.26 MIK
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_CHECK_TAB_ARROW );
 		nSelPos = Combo_GetCurSel( hwndCombo );
-		m_Types.m_bTabArrow = TabArrowArr[nSelPos].nMethod;		// �e�L�X�g�̐܂�Ԃ����@
+		m_Types.m_bTabArrow = TabArrowArr[nSelPos].nMethod;		// テキストの折り返し方法
 
-		// SPACE�̑}��
+		// SPACEの挿入
 		m_Types.m_bInsSpace = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_INS_SPACE );
 
-		// TSV���[�h
+		// TSVモード
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_TSV_MODE );
 		nSelPos = Combo_GetCurSel( hwndCombo );
 		m_Types.m_nTsvMode = TsvModeArr[nSelPos].nMethod;
 	}
 
-	//�C���f���g
+	//インデント
 	{
-		/* �����C���f���g */
+		/* 自動インデント */
 		m_Types.m_bAutoIndent = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_INDENT );
 
-		/* ���{��󔒂��C���f���g */
+		/* 日本語空白もインデント */
 		m_Types.m_bAutoIndent_ZENSPACE = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_INDENT_WSPACE );
 
-		/* �X�}�[�g�C���f���g��� */
+		/* スマートインデント種別 */
 		HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_SMARTINDENT );
 		int		nSelPos = Combo_GetCurSel( hwndCombo );
 		if( nSelPos >= 0 ){
-			m_Types.m_eSmartIndent = m_SIndentArr[nSelPos].nMethod;	/* �X�}�[�g�C���f���g��� */
+			m_Types.m_eSmartIndent = m_SIndentArr[nSelPos].nMethod;	/* スマートインデント種別 */
 		}
 
-		/* ���̑��̃C���f���g�Ώە��� */
+		/* その他のインデント対象文字 */
 		::DlgItem_GetText( hwndDlg, IDC_EDIT_INDENTCHARS, m_Types.m_szIndentChars, _countof( m_Types.m_szIndentChars ) );
 
-		// �܂�Ԃ��s�C���f���g	//	Oct. 1, 2002 genta �R���{�{�b�N�X�ɕύX
+		// 折り返し行インデント	//	Oct. 1, 2002 genta コンボボックスに変更
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_INDENTLAYOUT );
 		nSelPos = Combo_GetCurSel( hwndCombo );
-		m_Types.m_nIndentLayout = IndentTypeArr[nSelPos].nMethod;	/* �܂�Ԃ����C���f���g��� */
+		m_Types.m_nIndentLayout = IndentTypeArr[nSelPos].nMethod;	/* 折り返し部インデント種別 */
 
-		// ���s���ɖ����̋󔒂��폜	//2005.10.11 ryoji
+		// 改行時に末尾の空白を削除	//2005.10.11 ryoji
 		m_Types.m_bRTrimPrevLine = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_RTRIM_PREVLINE );
 	}
 
-	//�A�E�g���C����͕��@
-	//2002.04.01 YAZAKI ���[���t�@�C���֘A�ǉ�
+	//アウトライン解析方法
+	//2002.04.01 YAZAKI ルールファイル関連追加
 	{
-		//�W�����[��
+		//標準ルール
 		if ( !::IsDlgButtonChecked( hwndDlg, IDC_RADIO_OUTLINERULEFILE) ){
 			HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_OUTLINES );
 			int		nSelPos = Combo_GetCurSel( hwndCombo );
 			if( nSelPos >= 0 ){
-				m_Types.m_eDefaultOutline = m_OlmArr[nSelPos].nMethod;	/* �A�E�g���C����͕��@ */
+				m_Types.m_eDefaultOutline = m_OlmArr[nSelPos].nMethod;	/* アウトライン解析方法 */
 			}
 		}
-		//���[���t�@�C��
+		//ルールファイル
 		else {
 			m_Types.m_eDefaultOutline = OUTLINE_FILE;
 		}
 
-		//���[���t�@�C��	//2003.06.23 Moca ���[�����g���Ă��Ȃ��Ă��t�@�C������ێ�
+		//ルールファイル	//2003.06.23 Moca ルールを使っていなくてもファイル名を保持
 		::DlgItem_GetText( hwndDlg, IDC_EDIT_OUTLINERULEFILE, m_Types.m_szOutlineRuleFilename, _countof2( m_Types.m_szOutlineRuleFilename ));
 	}
 
-	//�t�H���g
+	//フォント
 	{
 		LOGFONT lf;
-		m_Types.m_bUseTypeFont = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_USETYPEFONT );		// �^�C�v�ʃt�H���g�̎g�p
+		m_Types.m_bUseTypeFont = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_USETYPEFONT );		// タイプ別フォントの使用
 		if( m_Types.m_bUseTypeFont ){
 			lf = m_Types.m_lf;
 		}
@@ -741,18 +741,18 @@ int CPropTypesScreen::GetData( HWND hwndDlg )
 		}
 	}
 
-	//���̑�
+	//その他
 	{
-		/* �p�����[�h���b�v������ */
+		/* 英文ワードラップをする */
 		m_Types.m_bWordWrap = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_WORDWRAP );
 
-		/* �֑����� */
+		/* 禁則処理 */
 		{	//@@@ 2002.04.08 MIK start
 			m_Types.m_bKinsokuHead = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKUHEAD );
 			m_Types.m_bKinsokuTail = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKUTAIL );
-			m_Types.m_bKinsokuRet  = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKURET  );	// ���s�������Ԃ牺����	//@@@ 2002.04.13 MIK
-			m_Types.m_bKinsokuKuto = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKUKUTO );	// ��Ǔ_���Ԃ牺����	//@@@ 2002.04.17 MIK
-			m_Types.m_bKinsokuHide = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKUHIDE );	// �Ԃ牺�����B��		// 2011/11/30 Uchi
+			m_Types.m_bKinsokuRet  = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKURET  );	// 改行文字をぶら下げる	//@@@ 2002.04.13 MIK
+			m_Types.m_bKinsokuKuto = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKUKUTO );	// 句読点をぶら下げる	//@@@ 2002.04.17 MIK
+			m_Types.m_bKinsokuHide = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKUHIDE );	// ぶら下げを隠す		// 2011/11/30 Uchi
 			::DlgItem_GetText( hwndDlg, IDC_EDIT_KINSOKUHEAD, m_Types.m_szKinsokuHead, _countof( m_Types.m_szKinsokuHead ) );
 			::DlgItem_GetText( hwndDlg, IDC_EDIT_KINSOKUTAIL, m_Types.m_szKinsokuTail, _countof( m_Types.m_szKinsokuTail ) );
 			::DlgItem_GetText( hwndDlg, IDC_EDIT_KINSOKUKUTO, m_Types.m_szKinsokuKuto, _countof( m_Types.m_szKinsokuKuto ) );	// 2009.08.07 ryoji
@@ -763,11 +763,11 @@ int CPropTypesScreen::GetData( HWND hwndDlg )
 	return TRUE;
 }
 
-//�A�E�g���C����̓��[���̒ǉ�
+//アウトライン解析ルールの追加
 void CPropTypesScreen::AddOutlineMethod(int nMethod, const WCHAR* szName)
 {
 	if( m_OlmArr.empty() ){
-		InitTypeNameId2(m_OlmArr, OlmArr, _countof(OlmArr));	//�A�E�g���C����̓��[��
+		InitTypeNameId2(m_OlmArr, OlmArr, _countof(OlmArr));	//アウトライン解析ルール
 	}
 	TYPE_NAME_ID2<EOutlineType> method;
 	method.nMethod = (EOutlineType)nMethod;
@@ -791,11 +791,11 @@ void CPropTypesScreen::RemoveOutlineMethod(int nMethod, const WCHAR* szName)
 	}
 }
 
-//�X�}�[�g�C���f���g���[���̒ǉ�
+//スマートインデントルールの追加
 void CPropTypesScreen::AddSIndentMethod(int nMethod, const WCHAR* szName)
 {
 	if( m_SIndentArr.empty() ){
-		InitTypeNameId2(m_SIndentArr, SmartIndentArr, _countof(SmartIndentArr));	//�X�}�[�g�C���f���g���[��
+		InitTypeNameId2(m_SIndentArr, SmartIndentArr, _countof(SmartIndentArr));	//スマートインデントルール
 	}
 	TYPE_NAME_ID2<ESmartIndentType> method;
 	method.nMethod = (ESmartIndentType)nMethod;

--- a/sakura_core/typeprop/CPropTypesSupport.cpp
+++ b/sakura_core/typeprop/CPropTypesSupport.cpp
@@ -1,13 +1,13 @@
-/*! @file
-	@brief �^�C�v�ʐݒ� - �x��
+﻿/*! @file
+	@brief タイプ別設定 - 支援
 
-	@date 2008.04.12 kobake CPropTypes.cpp���番��
+	@date 2008.04.12 kobake CPropTypes.cppから分離
 */
 /*
 	Copyright (C) 1998-2002, Norio Nakatani
 	Copyright (C) 2000, jepro, genta
 	Copyright (C) 2001, jepro, genta, MIK, hor, Stonee, asa-o
-	Copyright (C) 2002, YAZAKI, aroka, MIK, genta, ������, Moca
+	Copyright (C) 2002, YAZAKI, aroka, MIK, genta, こおり, Moca
 	Copyright (C) 2003, MIK, zenryaku, Moca, naoh, KEITA, genta
 	Copyright (C) 2005, MIK, genta, Moca, ryoji
 	Copyright (C) 2006, ryoji, fon, novice
@@ -30,20 +30,20 @@
 #include "sakura.hh"
 
 static const DWORD p_helpids3[] = {	//11500
-	IDC_EDIT_HOKANFILE,				HIDC_EDIT_HOKANFILE,				//�P��t�@�C����
-	IDC_BUTTON_HOKANFILE_REF,		HIDC_BUTTON_HOKANFILE_REF,			//���͕⊮ �P��t�@�C���Q��
-	IDC_COMBO_HOKAN_TYPE,			HIDC_COMBO_HOKAN_TYPE,				//���͕⊮�^�C�v
-	IDC_CHECK_HOKANLOHICASE,		HIDC_CHECK_HOKANLOHICASE,			//���͕⊮�̉p�啶��������
-	IDC_CHECK_HOKANBYFILE,			HIDC_CHECK_HOKANBYFILE,				//���݂̃t�@�C��������͕⊮
-	IDC_CHECK_HOKANBYKEYWORD,		HIDC_CHECK_HOKANBYKEYWORD,			//�����L�[���[�h������͕⊮
+	IDC_EDIT_HOKANFILE,				HIDC_EDIT_HOKANFILE,				//単語ファイル名
+	IDC_BUTTON_HOKANFILE_REF,		HIDC_BUTTON_HOKANFILE_REF,			//入力補完 単語ファイル参照
+	IDC_COMBO_HOKAN_TYPE,			HIDC_COMBO_HOKAN_TYPE,				//入力補完タイプ
+	IDC_CHECK_HOKANLOHICASE,		HIDC_CHECK_HOKANLOHICASE,			//入力補完の英大文字小文字
+	IDC_CHECK_HOKANBYFILE,			HIDC_CHECK_HOKANBYFILE,				//現在のファイルから入力補完
+	IDC_CHECK_HOKANBYKEYWORD,		HIDC_CHECK_HOKANBYKEYWORD,			//強調キーワードから入力補完
 
-	IDC_EDIT_TYPEEXTHELP,			HIDC_EDIT_TYPEEXTHELP,				//�O���w���v�t�@�C����	// 2006.08.06 ryoji
-	IDC_BUTTON_TYPEOPENHELP,		HIDC_BUTTON_TYPEOPENHELP,			//�O���w���v�t�@�C���Q��	// 2006.08.06 ryoji
-	IDC_EDIT_TYPEEXTHTMLHELP,		HIDC_EDIT_TYPEEXTHTMLHELP,			//�O��HTML�w���v�t�@�C����	// 2006.08.06 ryoji
-	IDC_BUTTON_TYPEOPENEXTHTMLHELP,	HIDC_BUTTON_TYPEOPENEXTHTMLHELP,	//�O��HTML�w���v�t�@�C���Q��	// 2006.08.06 ryoji
-	IDC_CHECK_TYPEHTMLHELPISSINGLE,	HIDC_CHECK_TYPEHTMLHELPISSINGLE,	//�r���[�A�𕡐��N�����Ȃ�	// 2006.08.06 ryoji
+	IDC_EDIT_TYPEEXTHELP,			HIDC_EDIT_TYPEEXTHELP,				//外部ヘルプファイル名	// 2006.08.06 ryoji
+	IDC_BUTTON_TYPEOPENHELP,		HIDC_BUTTON_TYPEOPENHELP,			//外部ヘルプファイル参照	// 2006.08.06 ryoji
+	IDC_EDIT_TYPEEXTHTMLHELP,		HIDC_EDIT_TYPEEXTHTMLHELP,			//外部HTMLヘルプファイル名	// 2006.08.06 ryoji
+	IDC_BUTTON_TYPEOPENEXTHTMLHELP,	HIDC_BUTTON_TYPEOPENEXTHTMLHELP,	//外部HTMLヘルプファイル参照	// 2006.08.06 ryoji
+	IDC_CHECK_TYPEHTMLHELPISSINGLE,	HIDC_CHECK_TYPEHTMLHELPISSINGLE,	//ビューアを複数起動しない	// 2006.08.06 ryoji
 
-	IDC_CHECK_CHKENTERATEND,		HIDC_CHECK_CHKENTERATEND,			//�ۑ����ɉ��s�R�[�h�̍��݂��x������	// 2013/4/14 Uchi
+	IDC_CHECK_CHKENTERATEND,		HIDC_CHECK_CHKENTERATEND,			//保存時に改行コードの混在を警告する	// 2013/4/14 Uchi
 	IDC_CHECK_INDENTCPPSTR,			HIDC_CHECK_INDENTCPPSTR,
 	IDC_CHECK_INDENTCPPCMT,			HIDC_CHECK_INDENTCPPCMT,
 	IDC_CHECK_INDENTCPPUNDO,		HIDC_CHECK_INDENTCPPUNDO,
@@ -64,9 +64,9 @@ static std::vector<SHokanMethod>* GetHokanMethodList()
 }
 
 
-// 2001/06/13 Start By asa-o: �^�C�v�ʐݒ�̎x���^�u�Ɋւ��鏈��
+// 2001/06/13 Start By asa-o: タイプ別設定の支援タブに関する処理
 
-/* ���b�Z�[�W���� */
+/* メッセージ処理 */
 INT_PTR CPropTypesSupport::DispatchEvent(
 	HWND		hwndDlg,	// handle to dialog box
 	UINT		uMsg,		// message
@@ -80,44 +80,44 @@ INT_PTR CPropTypesSupport::DispatchEvent(
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
-		/* �_�C�A���O�f�[�^�̐ݒ� p2 */
+		/* ダイアログデータの設定 p2 */
 		SetData( hwndDlg );
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ���[�U�[���G�f�B�b�g �R���g���[���ɓ��͂ł���e�L�X�g�̒����𐧌����� */
-		/* ���͕⊮ �P��t�@�C�� */
+		/* ユーザーがエディット コントロールに入力できるテキストの長さを制限する */
+		/* 入力補完 単語ファイル */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_HOKANFILE ), _MAX_PATH - 1 );
 
 		return TRUE;
 	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* �ʒm�R�[�h */
-		wID			= LOWORD(wParam);	/* ����ID� �R���g���[��ID� �܂��̓A�N�Z�����[�^ID */
-//		hwndCtl		= (HWND) lParam;	/* �R���g���[���̃n���h�� */
+		wNotifyCode = HIWORD(wParam);	/* 通知コード */
+		wID			= LOWORD(wParam);	/* 項目ID､ コントロールID､ またはアクセラレータID */
+//		hwndCtl		= (HWND) lParam;	/* コントロールのハンドル */
 		switch( wNotifyCode ){
-		/* �{�^���^�`�F�b�N�{�b�N�X���N���b�N���ꂽ */
+		/* ボタン／チェックボックスがクリックされた */
 		case BN_CLICKED:
-			/* �_�C�A���O�f�[�^�̎擾 p2 */
+			/* ダイアログデータの取得 p2 */
 			GetData( hwndDlg );
 			switch( wID ){
-			case IDC_BUTTON_HOKANFILE_REF:	/* ���͕⊮ �P��t�@�C���́u�Q��...�v�{�^�� */
+			case IDC_BUTTON_HOKANFILE_REF:	/* 入力補完 単語ファイルの「参照...」ボタン */
 				{
-					// 2003.06.23 Moca ���΃p�X�͎��s�t�@�C������̃p�X�Ƃ��ĊJ��
-					// 2007.05.19 ryoji ���΃p�X�͐ݒ�t�@�C������̃p�X��D��
+					// 2003.06.23 Moca 相対パスは実行ファイルからのパスとして開く
+					// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
 					CDlgOpenFile::SelectFile(hwndDlg, GetDlgItem(hwndDlg, IDC_EDIT_HOKANFILE), _T("*.kwd"), true, EFITER_TEXT);
 				}
 				return TRUE;
-			case IDC_BUTTON_TYPEOPENHELP:	/* �O���w���v�P�́u�Q��...�v�{�^�� */
+			case IDC_BUTTON_TYPEOPENHELP:	/* 外部ヘルプ１の「参照...」ボタン */
 				{
-					// 2003.06.23 Moca ���΃p�X�͎��s�t�@�C������̃p�X�Ƃ��ĊJ��
-					// 2007.05.21 ryoji ���΃p�X�͐ݒ�t�@�C������̃p�X��D��
+					// 2003.06.23 Moca 相対パスは実行ファイルからのパスとして開く
+					// 2007.05.21 ryoji 相対パスは設定ファイルからのパスを優先
 					CDlgOpenFile::SelectFile(hwndDlg, GetDlgItem(hwndDlg, IDC_EDIT_TYPEEXTHELP), _T("*.hlp;*.chm;*.col"), true, EFITER_NONE);
 				}
 				return TRUE;
-			case IDC_BUTTON_TYPEOPENEXTHTMLHELP:	/* �O��HTML�w���v�́u�Q��...�v�{�^�� */
+			case IDC_BUTTON_TYPEOPENEXTHTMLHELP:	/* 外部HTMLヘルプの「参照...」ボタン */
 				{
-					// 2003.06.23 Moca ���΃p�X�͎��s�t�@�C������̃p�X�Ƃ��ĊJ��
-					// 2007.05.21 ryoji ���΃p�X�͐ݒ�t�@�C������̃p�X��D��
+					// 2003.06.23 Moca 相対パスは実行ファイルからのパスとして開く
+					// 2007.05.21 ryoji 相対パスは設定ファイルからのパスを優先
 					CDlgOpenFile::SelectFile(hwndDlg, GetDlgItem(hwndDlg, IDC_EDIT_TYPEEXTHTMLHELP), _T("*.chm;*.col"), true, EFITER_NONE);
 				}
 				return TRUE;
@@ -130,14 +130,14 @@ INT_PTR CPropTypesSupport::DispatchEvent(
 		pNMHDR = (NMHDR*)lParam;
 //		pMNUD  = (NM_UPDOWN*)lParam;
 		switch( pNMHDR->code ){
-		case PSN_HELP:	//Jul. 03, 2001 JEPRO �x���^�u�̃w���v��L����
+		case PSN_HELP:	//Jul. 03, 2001 JEPRO 支援タブのヘルプを有効化
 			OnHelp( hwndDlg, IDD_PROP_SUPPORT );
 			return TRUE;
 		case PSN_KILLACTIVE:
-			/* �_�C�A���O�f�[�^�̎擾 p2 */
+			/* ダイアログデータの取得 p2 */
 			GetData( hwndDlg );
 			return TRUE;
-//@@@ 2002.01.03 YAZAKI �Ō�ɕ\�����Ă����V�[�g�𐳂����o���Ă��Ȃ��o�O�C��
+//@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPTYPE_PAGENUM_SUPPORT;
 			return TRUE;
@@ -148,7 +148,7 @@ INT_PTR CPropTypesSupport::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids3 );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids3 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -158,7 +158,7 @@ INT_PTR CPropTypesSupport::DispatchEvent(
 //@@@ 2001.11.17 add start MIK
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids3 );	// 2006.10.10 ryoji MyWinHelp�ɕύX�ɕύX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids3 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.11.17 add end MIK
 
@@ -166,10 +166,10 @@ INT_PTR CPropTypesSupport::DispatchEvent(
 	return FALSE;
 }
 
-/* �_�C�A���O�f�[�^�̐ݒ� */
+/* ダイアログデータの設定 */
 void CPropTypesSupport::SetData( HWND hwndDlg )
 {
-	/* ���͕⊮ �P��t�@�C�� */
+	/* 入力補完 単語ファイル */
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_HOKANFILE, m_Types.m_szHokanFile );
 
 	{
@@ -187,10 +187,10 @@ void CPropTypesSupport::SetData( HWND hwndDlg )
 	}
 
 //	2001/06/19 asa-o
-	/* ���͕⊮�@�\�F�p�啶���������𓯈ꎋ���� */
+	/* 入力補完機能：英大文字小文字を同一視する */
 	::CheckDlgButton( hwndDlg, IDC_CHECK_HOKANLOHICASE, m_Types.m_bHokanLoHiCase ? BST_CHECKED : BST_UNCHECKED);
 
-	// 2003.06.25 Moca �t�@�C������̕⊮�@�\
+	// 2003.06.25 Moca ファイルからの補完機能
 	::CheckDlgButton( hwndDlg, IDC_CHECK_HOKANBYFILE, m_Types.m_bUseHokanByFile ? BST_CHECKED : BST_UNCHECKED);
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_HOKANBYKEYWORD, m_Types.m_bUseHokanByKeyword );
 
@@ -199,7 +199,7 @@ void CPropTypesSupport::SetData( HWND hwndDlg )
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_TYPEEXTHTMLHELP, m_Types.m_szExtHtmlHelp );
 	::CheckDlgButton( hwndDlg, IDC_CHECK_TYPEHTMLHELPISSINGLE, m_Types.m_bHtmlHelpIsSingle ? BST_CHECKED : BST_UNCHECKED);
 
-	// �ۑ����ɉ��s�R�[�h�̍��݂��x������	2013/4/14 Uchi
+	// 保存時に改行コードの混在を警告する	2013/4/14 Uchi
 	::CheckDlgButton( hwndDlg, IDC_CHECK_CHKENTERATEND, m_Types.m_bChkEnterAtEnd ? BST_CHECKED : BST_UNCHECKED);
 
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_INDENTCPPSTR,  m_Types.m_bIndentCppStringIgnore );
@@ -207,20 +207,20 @@ void CPropTypesSupport::SetData( HWND hwndDlg )
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_INDENTCPPUNDO, m_Types.m_bIndentCppUndoSep );
 }
 
-/* �_�C�A���O�f�[�^�̎擾 */
+/* ダイアログデータの取得 */
 int CPropTypesSupport::GetData( HWND hwndDlg )
 {
 //	2001/06/19	asa-o
-	/* ���͕⊮�@�\�F�p�啶���������𓯈ꎋ���� */
+	/* 入力補完機能：英大文字小文字を同一視する */
 	m_Types.m_bHokanLoHiCase = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_HOKANLOHICASE ) != 0;
 
 	m_Types.m_bUseHokanByFile = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_HOKANBYFILE ) != 0;
 	m_Types.m_bUseHokanByKeyword = IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_HOKANBYKEYWORD );
 
-	/* ���͕⊮ �P��t�@�C�� */
+	/* 入力補完 単語ファイル */
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_HOKANFILE, m_Types.m_szHokanFile, _countof2( m_Types.m_szHokanFile ));
 
-	// ���͕⊮���
+	// 入力補完種別
 	{
 		HWND hCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_HOKAN_TYPE );
 		int i = Combo_GetCurSel( hCombo );
@@ -236,7 +236,7 @@ int CPropTypesSupport::GetData( HWND hwndDlg )
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_TYPEEXTHTMLHELP, m_Types.m_szExtHtmlHelp, _countof2( m_Types.m_szExtHtmlHelp ));
 	m_Types.m_bHtmlHelpIsSingle = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_TYPEHTMLHELPISSINGLE ) != 0;
 
-	// �ۑ����ɉ��s�R�[�h�̍��݂��x������	2013/4/14 Uchi
+	// 保存時に改行コードの混在を警告する	2013/4/14 Uchi
 	m_Types.m_bChkEnterAtEnd = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_CHKENTERATEND ) != 0;
 
 
@@ -248,7 +248,7 @@ int CPropTypesSupport::GetData( HWND hwndDlg )
 
 // 2001/06/13 End
 
-/*! �⊮��ʂ̒ǉ�
+/*! 補完種別の追加
 /*/
 void CPropTypesSupport::AddHokanMethod(int nMethod, const WCHAR* szName)
 {

--- a/sakura_core/typeprop/CPropTypesWindow.cpp
+++ b/sakura_core/typeprop/CPropTypesWindow.cpp
@@ -1,7 +1,7 @@
-/*
-	ƒ^ƒCƒv•Êİ’è - ƒEƒBƒ“ƒhƒE
+ï»¿/*
+	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š - ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
 
-	2008.04.12 kobake CPropTypes.cpp‚©‚ç•ª—£
+	2008.04.12 kobake CPropTypes.cppã‹ã‚‰åˆ†é›¢
 	2009.02.22 ryoji
 */
 #include "StdAfx.h"
@@ -21,33 +21,33 @@
 using namespace std;
 
 static const DWORD p_helpids2[] = {	//11400
-	IDC_CHECK_DOCICON,				HIDC_CHECK_DOCICON,				//•¶‘ƒAƒCƒRƒ“‚ğg‚¤	// 2006.08.06 ryoji
+	IDC_CHECK_DOCICON,				HIDC_CHECK_DOCICON,				//æ–‡æ›¸ã‚¢ã‚¤ã‚³ãƒ³ã‚’ä½¿ã†	// 2006.08.06 ryoji
 
-	IDC_COMBO_IMESWITCH,			HIDC_COMBO_IMESWITCH,		//IME‚ÌON/OFFó‘Ô
-	IDC_COMBO_IMESTATE,				HIDC_COMBO_IMESTATE,		//IME‚Ì“ü—Íƒ‚[ƒh
+	IDC_COMBO_IMESWITCH,			HIDC_COMBO_IMESWITCH,		//IMEã®ON/OFFçŠ¶æ…‹
+	IDC_COMBO_IMESTATE,				HIDC_COMBO_IMESTATE,		//IMEã®å…¥åŠ›ãƒ¢ãƒ¼ãƒ‰
 
-	IDC_COMBO_DEFAULT_CODETYPE,		HIDC_COMBO_DEFAULT_CODETYPE,		//ƒfƒtƒHƒ‹ƒg•¶šƒR[ƒh
-	IDC_CHECK_CP,					HIDC_CHECK_TYPE_SUPPORT_CP,			//ƒR[ƒhƒy[ƒW
-	IDC_COMBO_DEFAULT_EOLTYPE,		HIDC_COMBO_DEFAULT_EOLTYPE,			//ƒfƒtƒHƒ‹ƒg‰üsƒR[ƒh	// 2011.01.24 ryoji
-	IDC_CHECK_DEFAULT_BOM,			HIDC_CHECK_DEFAULT_BOM,				//ƒfƒtƒHƒ‹ƒgBOM	// 2011.01.24 ryoji
-	IDC_CHECK_PRIOR_CESU8,			HIDC_CHECK_PRIOR_CESU8,				//©“®”»•Ê‚ÉCESU-8‚ğ—Dæ‚·‚é
+	IDC_COMBO_DEFAULT_CODETYPE,		HIDC_COMBO_DEFAULT_CODETYPE,		//ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ–‡å­—ã‚³ãƒ¼ãƒ‰
+	IDC_CHECK_CP,					HIDC_CHECK_TYPE_SUPPORT_CP,			//ã‚³ãƒ¼ãƒ‰ãƒšãƒ¼ã‚¸
+	IDC_COMBO_DEFAULT_EOLTYPE,		HIDC_COMBO_DEFAULT_EOLTYPE,			//ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ”¹è¡Œã‚³ãƒ¼ãƒ‰	// 2011.01.24 ryoji
+	IDC_CHECK_DEFAULT_BOM,			HIDC_CHECK_DEFAULT_BOM,				//ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆBOM	// 2011.01.24 ryoji
+	IDC_CHECK_PRIOR_CESU8,			HIDC_CHECK_PRIOR_CESU8,				//è‡ªå‹•åˆ¤åˆ¥æ™‚ã«CESU-8ã‚’å„ªå…ˆã™ã‚‹
 
-	IDC_EDIT_BACKIMG_PATH,			HIDC_EDIT_BACKIMG_PATH,			//”wŒi‰æ‘œ
-	IDC_BUTTON_BACKIMG_PATH_SEL,	HIDC_BUTTON_BACKIMG_PATH_SEL,	//”wŒi‰æ‘œƒ{ƒ^ƒ“
-	IDC_COMBO_BACKIMG_POS,			HIDC_COMBO_BACKIMG_POS,			//”wŒi‰æ‘œˆÊ’u
-	IDC_CHECK_BACKIMG_SCR_X,		HIDC_CHECK_BACKIMG_SCR_X,		//”wŒi‰æ‘œScrollX
-	IDC_CHECK_BACKIMG_SCR_Y,		HIDC_CHECK_BACKIMG_SCR_Y,		//”wŒi‰æ‘œScrollY
-	IDC_CHECK_BACKIMG_REP_X,		HIDC_CHECK_BACKIMG_REP_X,		//”wŒi‰æ‘œRepeatX
-	IDC_CHECK_BACKIMG_REP_Y,		HIDC_CHECK_BACKIMG_REP_Y,		//”wŒi‰æ‘œRepeatY
-	IDC_EDIT_BACKIMG_OFFSET_X,		HIDC_EDIT_BACKIMG_OFFSET_X,		//”wŒi‰æ‘œOffsetX
-	IDC_EDIT_BACKIMG_OFFSET_Y,		HIDC_EDIT_BACKIMG_OFFSET_Y,		//”wŒi‰æ‘œOffsetY
-	IDC_RADIO_LINENUM_LAYOUT,		HIDC_RADIO_LINENUM_LAYOUT,		//s”Ô†‚Ì•\¦iÜ‚è•Ô‚µ’PˆÊj
-	IDC_RADIO_LINENUM_CRLF,			HIDC_RADIO_LINENUM_CRLF,		//s”Ô†‚Ì•\¦i‰üs’PˆÊj
-	IDC_RADIO_LINETERMTYPE0,		HIDC_RADIO_LINETERMTYPE0,		//s”Ô†‹æØ‚èi‚È‚µj
-	IDC_RADIO_LINETERMTYPE1,		HIDC_RADIO_LINETERMTYPE1,		//s”Ô†‹æØ‚èicüj
-	IDC_RADIO_LINETERMTYPE2,		HIDC_RADIO_LINETERMTYPE2,		//s”Ô†‹æØ‚èi”CˆÓj
-	IDC_EDIT_LINETERMCHAR,			HIDC_EDIT_LINETERMCHAR,			//s”Ô†‹æØ‚è
-	IDC_EDIT_LINENUMWIDTH,			HIDC_EDIT_LINENUMWIDTH,			//s”Ô†‚ÌÅ¬Œ…” 2014.08.02 katze
+	IDC_EDIT_BACKIMG_PATH,			HIDC_EDIT_BACKIMG_PATH,			//èƒŒæ™¯ç”»åƒ
+	IDC_BUTTON_BACKIMG_PATH_SEL,	HIDC_BUTTON_BACKIMG_PATH_SEL,	//èƒŒæ™¯ç”»åƒãƒœã‚¿ãƒ³
+	IDC_COMBO_BACKIMG_POS,			HIDC_COMBO_BACKIMG_POS,			//èƒŒæ™¯ç”»åƒä½ç½®
+	IDC_CHECK_BACKIMG_SCR_X,		HIDC_CHECK_BACKIMG_SCR_X,		//èƒŒæ™¯ç”»åƒScrollX
+	IDC_CHECK_BACKIMG_SCR_Y,		HIDC_CHECK_BACKIMG_SCR_Y,		//èƒŒæ™¯ç”»åƒScrollY
+	IDC_CHECK_BACKIMG_REP_X,		HIDC_CHECK_BACKIMG_REP_X,		//èƒŒæ™¯ç”»åƒRepeatX
+	IDC_CHECK_BACKIMG_REP_Y,		HIDC_CHECK_BACKIMG_REP_Y,		//èƒŒæ™¯ç”»åƒRepeatY
+	IDC_EDIT_BACKIMG_OFFSET_X,		HIDC_EDIT_BACKIMG_OFFSET_X,		//èƒŒæ™¯ç”»åƒOffsetX
+	IDC_EDIT_BACKIMG_OFFSET_Y,		HIDC_EDIT_BACKIMG_OFFSET_Y,		//èƒŒæ™¯ç”»åƒOffsetY
+	IDC_RADIO_LINENUM_LAYOUT,		HIDC_RADIO_LINENUM_LAYOUT,		//è¡Œç•ªå·ã®è¡¨ç¤ºï¼ˆæŠ˜ã‚Šè¿”ã—å˜ä½ï¼‰
+	IDC_RADIO_LINENUM_CRLF,			HIDC_RADIO_LINENUM_CRLF,		//è¡Œç•ªå·ã®è¡¨ç¤ºï¼ˆæ”¹è¡Œå˜ä½ï¼‰
+	IDC_RADIO_LINETERMTYPE0,		HIDC_RADIO_LINETERMTYPE0,		//è¡Œç•ªå·åŒºåˆ‡ã‚Šï¼ˆãªã—ï¼‰
+	IDC_RADIO_LINETERMTYPE1,		HIDC_RADIO_LINETERMTYPE1,		//è¡Œç•ªå·åŒºåˆ‡ã‚Šï¼ˆç¸¦ç·šï¼‰
+	IDC_RADIO_LINETERMTYPE2,		HIDC_RADIO_LINETERMTYPE2,		//è¡Œç•ªå·åŒºåˆ‡ã‚Šï¼ˆä»»æ„ï¼‰
+	IDC_EDIT_LINETERMCHAR,			HIDC_EDIT_LINETERMCHAR,			//è¡Œç•ªå·åŒºåˆ‡ã‚Š
+	IDC_EDIT_LINENUMWIDTH,			HIDC_EDIT_LINENUMWIDTH,			//è¡Œç•ªå·ã®æœ€å°æ¡æ•° 2014.08.02 katze
 //	IDC_STATIC,						-1,
 	0, 0
 };
@@ -86,7 +86,7 @@ static const EEolType aeEolType[] = {
 	EOL_PS,
 };
 
-/*! window ƒƒbƒZ[ƒWˆ— */
+/*! window ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 INT_PTR CPropTypesWindow::DispatchEvent(
 	HWND				hwndDlg,	// handle to dialog box
 	UINT				uMsg,		// message
@@ -97,24 +97,24 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 	WORD				wNotifyCode;
 	WORD				wID;
 	NMHDR*				pNMHDR;
-	NM_UPDOWN*			pMNUD;		// ’Ç‰Á 2014.08.02 katze
+	NM_UPDOWN*			pMNUD;		// è¿½åŠ  2014.08.02 katze
 
 	switch( uMsg ){
 	case WM_INITDIALOG:
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
-		/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è color */
+		/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š color */
 		SetData( hwndDlg );
 
-		/* ƒ†[ƒU[‚ªƒGƒfƒBƒbƒg ƒRƒ“ƒgƒ[ƒ‹‚É“ü—Í‚Å‚«‚éƒeƒLƒXƒg‚Ì’·‚³‚ğ§ŒÀ‚·‚é */
+		/* ãƒ¦ãƒ¼ã‚¶ãƒ¼ãŒã‚¨ãƒ‡ã‚£ãƒƒãƒˆ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã«å…¥åŠ›ã§ãã‚‹ãƒ†ã‚­ã‚¹ãƒˆã®é•·ã•ã‚’åˆ¶é™ã™ã‚‹ */
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_LINETERMCHAR ), 1 );
 
 		return TRUE;
 
 	case WM_COMMAND:
-		wNotifyCode	= HIWORD( wParam );	/* ’Ê’mƒR[ƒh */
-		wID			= LOWORD( wParam );	/* €–ÚID¤ ƒRƒ“ƒgƒ[ƒ‹ID¤ ‚Ü‚½‚ÍƒAƒNƒZƒ‰ƒŒ[ƒ^ID */
+		wNotifyCode	= HIWORD( wParam );	/* é€šçŸ¥ã‚³ãƒ¼ãƒ‰ */
+		wID			= LOWORD( wParam );	/* é …ç›®IDï½¤ ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«IDï½¤ ã¾ãŸã¯ã‚¢ã‚¯ã‚»ãƒ©ãƒ¬ãƒ¼ã‚¿ID */
 
 		switch( wNotifyCode ){
 		case CBN_SELCHANGE:
@@ -122,7 +122,7 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 				int i;
 				switch( wID ){
 				case IDC_COMBO_DEFAULT_CODETYPE:
-					// •¶šƒR[ƒh‚Ì•ÏX‚ğBOMƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚É”½‰f
+					// æ–‡å­—ã‚³ãƒ¼ãƒ‰ã®å¤‰æ›´ã‚’BOMãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã«åæ˜ 
 					i = Combo_GetCurSel( (HWND) lParam );
 					if( CB_ERR != i ){
 						CCodeTypeName	cCodeTypeName( Combo_GetItemData( (HWND)lParam, i ) );
@@ -134,7 +134,7 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 			}
 			break;
 
-		/* ƒ{ƒ^ƒ“^ƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚ªƒNƒŠƒbƒN‚³‚ê‚½ */
+		/* ãƒœã‚¿ãƒ³ï¼ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸ */
 		case BN_CLICKED:
 			switch( wID ){
 			case IDC_BUTTON_BACKIMG_PATH_SEL:
@@ -144,8 +144,8 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 				}
 				return TRUE;
 			//	From Here Sept. 10, 2000 JEPRO
-			//	s”Ô†‹æØ‚è‚ğ”CˆÓ‚Ì”¼Šp•¶š‚É‚·‚é‚Æ‚«‚¾‚¯w’è•¶š“ü—Í‚ğEnable‚Éİ’è
-			case IDC_RADIO_LINETERMTYPE0: /* s”Ô†‹æØ‚è 0=‚È‚µ 1=cü 2=”CˆÓ */
+			//	è¡Œç•ªå·åŒºåˆ‡ã‚Šã‚’ä»»æ„ã®åŠè§’æ–‡å­—ã«ã™ã‚‹ã¨ãã ã‘æŒ‡å®šæ–‡å­—å…¥åŠ›ã‚’Enableã«è¨­å®š
+			case IDC_RADIO_LINETERMTYPE0: /* è¡Œç•ªå·åŒºåˆ‡ã‚Š 0=ãªã— 1=ç¸¦ç·š 2=ä»»æ„ */
 			case IDC_RADIO_LINETERMTYPE1:
 			case IDC_RADIO_LINETERMTYPE2:
 				EnableTypesPropInput( hwndDlg );
@@ -167,26 +167,26 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 		pNMHDR = (NMHDR*)lParam;
 		switch( pNMHDR->code ){
 		case PSN_HELP:
-//	Sept. 10, 2000 JEPRO ID–¼‚ğÀÛ‚Ì–¼‘O‚É•ÏX‚·‚é‚½‚ßˆÈ‰º‚Ìs‚ÍƒRƒƒ“ƒgƒAƒEƒg
+//	Sept. 10, 2000 JEPRO IDåã‚’å®Ÿéš›ã®åå‰ã«å¤‰æ›´ã™ã‚‹ãŸã‚ä»¥ä¸‹ã®è¡Œã¯ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆ
 //				OnHelp( hwndDlg, IDD_PROP1P3 );
 			OnHelp( hwndDlg, IDD_PROP_WINDOW );
 			return TRUE;
 		case PSN_KILLACTIVE:
 //			MYTRACE( _T("color PSN_KILLACTIVE\n") );
-			/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ window */
+			/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— window */
 			GetData( hwndDlg );
 			return TRUE;
-//@@@ 2002.01.03 YAZAKI ÅŒã‚É•\¦‚µ‚Ä‚¢‚½ƒV[ƒg‚ğ³‚µ‚­Šo‚¦‚Ä‚¢‚È‚¢ƒoƒOC³
+//@@@ 2002.01.03 YAZAKI æœ€å¾Œã«è¡¨ç¤ºã—ã¦ã„ãŸã‚·ãƒ¼ãƒˆã‚’æ­£ã—ãè¦šãˆã¦ã„ãªã„ãƒã‚°ä¿®æ­£
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPTYPE_PAGENUM_WINDOW;
 			return TRUE;
 		}
 
-		// switch•¶’Ç‰Á 2014.08.02 katze
+		// switchæ–‡è¿½åŠ  2014.08.02 katze
 		pMNUD  = (NM_UPDOWN*)lParam;
 		switch( (int)wParam ) {
 		case IDC_SPIN_LINENUMWIDTH:
-			/* s”Ô†‚ÌÅ¬Œ…” */
+			/* è¡Œç•ªå·ã®æœ€å°æ¡æ•° */
 //			MYTRACE( _T("IDC_SPIN_LINENUMWIDTH\n") );
 			int nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_LINENUMWIDTH, NULL, FALSE );
 			if( pMNUD->iDelta < 0 ){
@@ -211,7 +211,7 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 	case WM_HELP:
 		{
 			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids2 );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids2 );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		}
 		return TRUE;
 		/*NOTREACHED*/
@@ -221,7 +221,7 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 //@@@ 2001.11.17 add start MIK
 	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids2 );	// 2006.10.10 ryoji MyWinHelp‚É•ÏX‚É•ÏX
+		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids2 );	// 2006.10.10 ryoji MyWinHelpã«å¤‰æ›´ã«å¤‰æ›´
 		return TRUE;
 //@@@ 2001.11.17 add end MIK
 
@@ -241,53 +241,53 @@ void CPropTypesWindow::SetCombobox(HWND hwndWork, const int* nIds, int nCount, i
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìİ’è window */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®è¨­å®š window */
 void CPropTypesWindow::SetData( HWND hwndDlg )
 {
 	{
-		// •¶‘ƒAƒCƒRƒ“‚ğg‚¤	//Sep. 10, 2002 genta
+		// æ–‡æ›¸ã‚¢ã‚¤ã‚³ãƒ³ã‚’ä½¿ã†	//Sep. 10, 2002 genta
 		::CheckDlgButtonBool( hwndDlg, IDC_CHECK_DOCICON, m_Types.m_bUseDocumentIcon );
 	}
 
-	//‹N“®‚ÌIME(“ú–{Œê“ü—Í•ÏŠ·)	//Nov. 20, 2000 genta
+	//èµ·å‹•æ™‚ã®IME(æ—¥æœ¬èªå…¥åŠ›å¤‰æ›)	//Nov. 20, 2000 genta
 	{
 		int ime;
-		// ON/OFFó‘Ô
+		// ON/OFFçŠ¶æ…‹
 		HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_IMESWITCH );
 		Combo_ResetContent( hwndCombo );
 		ime = m_Types.m_nImeState & 3;
 		int		nSelPos = 0;
 		for( int i = 0; i < _countof( ImeSwitchArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS(ImeSwitchArr[i].nNameId) );
-			if( ImeSwitchArr[i].nMethod == ime ){	/* IMEó‘Ô */
+			if( ImeSwitchArr[i].nMethod == ime ){	/* IMEçŠ¶æ…‹ */
 				nSelPos = i;
 			}
 		}
 		Combo_SetCurSel( hwndCombo, nSelPos );
 
-		// “ü—Íƒ‚[ƒh
+		// å…¥åŠ›ãƒ¢ãƒ¼ãƒ‰
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_IMESTATE );
 		Combo_ResetContent( hwndCombo );
 		ime = m_Types.m_nImeState >> 2;
 		nSelPos = 0;
 		for( int i = 0; i < _countof( ImeStateArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS(ImeStateArr[i].nNameId) );
-			if( ImeStateArr[i].nMethod == ime ){	/* IMEó‘Ô */
+			if( ImeStateArr[i].nMethod == ime ){	/* IMEçŠ¶æ…‹ */
 				nSelPos = i;
 			}
 		}
 		Combo_SetCurSel( hwndCombo, nSelPos );
 	}
 
-	/* u•¶šƒR[ƒhvƒOƒ‹[ƒv‚Ìİ’è */
+	/* ã€Œæ–‡å­—ã‚³ãƒ¼ãƒ‰ã€ã‚°ãƒ«ãƒ¼ãƒ—ã®è¨­å®š */
 	{
 		int i;
 		HWND hCombo;
 
-		// u©“®”F¯‚ÉCESU-8‚ğ—Dævm_Types.m_encoding.m_bPriorCesu8 ‚ğƒ`ƒFƒbƒN
+		// ã€Œè‡ªå‹•èªè­˜æ™‚ã«CESU-8ã‚’å„ªå…ˆã€m_Types.m_encoding.m_bPriorCesu8 ã‚’ãƒã‚§ãƒƒã‚¯
 		::CheckDlgButton( hwndDlg, IDC_CHECK_PRIOR_CESU8, m_Types.m_encoding.m_bPriorCesu8 );
 
-		// ƒfƒtƒHƒ‹ƒgƒR[ƒhƒ^ƒCƒv‚ÌƒRƒ“ƒ{ƒ{ƒbƒNƒXİ’è
+		// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã‚³ãƒ¼ãƒ‰ã‚¿ã‚¤ãƒ—ã®ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹è¨­å®š
 		int		nSel= -1;
 		int		j = 0;
 		hCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_DEFAULT_CODETYPE );
@@ -314,14 +314,14 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 		}
 		Combo_SetCurSel( hCombo, nSel );
 
-		// BOM ƒ`ƒFƒbƒNƒ{ƒbƒNƒXİ’è
+		// BOM ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹è¨­å®š
 		CCodeTypeName	cCodeTypeName(m_Types.m_encoding.m_eDefaultCodetype);
 		if( !cCodeTypeName.UseBom() )
 			m_Types.m_encoding.m_bDefaultBom = false;
 		::CheckDlgButton( hwndDlg, IDC_CHECK_DEFAULT_BOM, (m_Types.m_encoding.m_bDefaultBom ? BST_CHECKED : BST_UNCHECKED) );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_DEFAULT_BOM ), (int)cCodeTypeName.UseBom() );
 
-		// ƒfƒtƒHƒ‹ƒg‰üsƒ^ƒCƒv‚ÌƒRƒ“ƒ{ƒ{ƒbƒNƒXİ’è
+		// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆæ”¹è¡Œã‚¿ã‚¤ãƒ—ã®ã‚³ãƒ³ãƒœãƒœãƒƒã‚¯ã‚¹è¨­å®š
 		hCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_DEFAULT_EOLTYPE );
 		for( i = 0; i < _countof(aszEolStr); ++i ){
 			ApiWrap::Combo_AddString( hCombo, aszEolStr[i] );
@@ -337,7 +337,7 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 		Combo_SetCurSel( hCombo, i );
 	}
 
-	/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+	/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 	if( !m_Types.m_bLineNumIsCRLF ){
 		::CheckDlgButton( hwndDlg, IDC_RADIO_LINENUM_LAYOUT, TRUE );
 		::CheckDlgButton( hwndDlg, IDC_RADIO_LINENUM_CRLF, FALSE );
@@ -347,11 +347,11 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 	}
 
 	{
-		// s”Ô†‚ÌÅ¬Œ…”	// ’Ç‰Á 2014.08.02 katze
+		// è¡Œç•ªå·ã®æœ€å°æ¡æ•°	// è¿½åŠ  2014.08.02 katze
 		::SetDlgItemInt( hwndDlg, IDC_EDIT_LINENUMWIDTH, (Int)m_Types.m_nLineNumWidth, FALSE );
 	}
 
-	// ”wŒi‰æ‘œ
+	// èƒŒæ™¯ç”»åƒ
 	EditCtl_LimitText(GetDlgItem(hwndDlg, IDC_EDIT_BACKIMG_PATH), _countof2(m_Types.m_szBackImgPath));
 	EditCtl_LimitText(GetDlgItem(hwndDlg, IDC_EDIT_BACKIMG_OFFSET_X), 5);
 	EditCtl_LimitText(GetDlgItem(hwndDlg, IDC_EDIT_BACKIMG_OFFSET_Y), 5);
@@ -380,7 +380,7 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 	SetDlgItemInt(hwndDlg, IDC_EDIT_BACKIMG_OFFSET_X, m_Types.m_backImgPosOffset.x, TRUE);
 	SetDlgItemInt(hwndDlg, IDC_EDIT_BACKIMG_OFFSET_Y, m_Types.m_backImgPosOffset.y, TRUE);
 
-	/* s”Ô†‹æØ‚è  0=‚È‚µ 1=cü 2=”CˆÓ */
+	/* è¡Œç•ªå·åŒºåˆ‡ã‚Š  0=ãªã— 1=ç¸¦ç·š 2=ä»»æ„ */
 	if( 0 == m_Types.m_nLineTermType ){
 		::CheckDlgButton( hwndDlg, IDC_RADIO_LINETERMTYPE0, TRUE );
 		::CheckDlgButton( hwndDlg, IDC_RADIO_LINETERMTYPE1, FALSE );
@@ -397,13 +397,13 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 		::CheckDlgButton( hwndDlg, IDC_RADIO_LINETERMTYPE2, TRUE );
 	}
 
-	/* s”Ô†‹æØ‚è•¶š */
+	/* è¡Œç•ªå·åŒºåˆ‡ã‚Šæ–‡å­— */
 	wchar_t	szLineTermChar[2];
 	auto_sprintf( szLineTermChar, L"%lc", m_Types.m_cLineTermChar );
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_LINETERMCHAR, szLineTermChar );
 
 	//	From Here Sept. 10, 2000 JEPRO
-	//	s”Ô†‹æØ‚è‚ğ”CˆÓ‚Ì”¼Šp•¶š‚É‚·‚é‚Æ‚«‚¾‚¯w’è•¶š“ü—Í‚ğEnable‚Éİ’è
+	//	è¡Œç•ªå·åŒºåˆ‡ã‚Šã‚’ä»»æ„ã®åŠè§’æ–‡å­—ã«ã™ã‚‹ã¨ãã ã‘æŒ‡å®šæ–‡å­—å…¥åŠ›ã‚’Enableã«è¨­å®š
 	EnableTypesPropInput( hwndDlg );
 	//	To Here Sept. 10, 2000
 
@@ -415,51 +415,51 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         À‘••â•                            //
+//                         å®Ÿè£…è£œåŠ©                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
 
-/* ƒ_ƒCƒAƒƒOƒf[ƒ^‚Ìæ“¾ color */
+/* ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ‡ãƒ¼ã‚¿ã®å–å¾— color */
 int CPropTypesWindow::GetData( HWND hwndDlg )
 {
 	{
-		// •¶‘ƒAƒCƒRƒ“‚ğg‚¤	//Sep. 10, 2002 genta
+		// æ–‡æ›¸ã‚¢ã‚¤ã‚³ãƒ³ã‚’ä½¿ã†	//Sep. 10, 2002 genta
 		m_Types.m_bUseDocumentIcon = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_DOCICON );
 	}
 
-	//‹N“®‚ÌIME(“ú–{Œê“ü—Í•ÏŠ·)	Nov. 20, 2000 genta
+	//èµ·å‹•æ™‚ã®IME(æ—¥æœ¬èªå…¥åŠ›å¤‰æ›)	Nov. 20, 2000 genta
 	{
-		//“ü—Íƒ‚[ƒh
+		//å…¥åŠ›ãƒ¢ãƒ¼ãƒ‰
 		HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_IMESTATE );
 		int		nSelPos = Combo_GetCurSel( hwndCombo );
-		m_Types.m_nImeState = ImeStateArr[nSelPos].nMethod << 2;	//	IME“ü—Íƒ‚[ƒh
+		m_Types.m_nImeState = ImeStateArr[nSelPos].nMethod << 2;	//	IMEå…¥åŠ›ãƒ¢ãƒ¼ãƒ‰
 
-		//ON/OFFó‘Ô
+		//ON/OFFçŠ¶æ…‹
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_IMESWITCH );
 		nSelPos = Combo_GetCurSel( hwndCombo );
 		m_Types.m_nImeState |= ImeSwitchArr[nSelPos].nMethod;	//	IME ON/OFF
 	}
 
-	/* u•¶šƒR[ƒhvƒOƒ‹[ƒv‚Ìİ’è */
+	/* ã€Œæ–‡å­—ã‚³ãƒ¼ãƒ‰ã€ã‚°ãƒ«ãƒ¼ãƒ—ã®è¨­å®š */
 	{
 		int i;
 		HWND hCombo;
 
-		// m_Types.m_bPriorCesu8 ‚ğİ’è
+		// m_Types.m_bPriorCesu8 ã‚’è¨­å®š
 		m_Types.m_encoding.m_bPriorCesu8 = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_PRIOR_CESU8 ) != 0;
 
-		// m_Types.eDefaultCodetype ‚ğİ’è
+		// m_Types.eDefaultCodetype ã‚’è¨­å®š
 		hCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_DEFAULT_CODETYPE );
 		i = Combo_GetCurSel( hCombo );
 		if( CB_ERR != i ){
 			m_Types.m_encoding.m_eDefaultCodetype = ECodeType( Combo_GetItemData( hCombo, i ) );
 		}
 
-		// m_Types.m_bDefaultBom ‚ğİ’è
+		// m_Types.m_bDefaultBom ã‚’è¨­å®š
 		m_Types.m_encoding.m_bDefaultBom = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DEFAULT_BOM ) != 0;
 
-		// m_Types.eDefaultEoltype ‚ğİ’è
+		// m_Types.eDefaultEoltype ã‚’è¨­å®š
 		hCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_DEFAULT_EOLTYPE );
 		i = Combo_GetCurSel( hCombo );
 		if( CB_ERR != i ){
@@ -467,7 +467,7 @@ int CPropTypesWindow::GetData( HWND hwndDlg )
 		}
 	}
 
-	/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+	/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_LINENUM_LAYOUT ) ){
 		m_Types.m_bLineNumIsCRLF = false;
 	}else{
@@ -483,7 +483,7 @@ int CPropTypesWindow::GetData( HWND hwndDlg )
 	m_Types.m_backImgPosOffset.x = GetDlgItemInt(hwndDlg, IDC_EDIT_BACKIMG_OFFSET_X, NULL, TRUE);
 	m_Types.m_backImgPosOffset.y = GetDlgItemInt(hwndDlg, IDC_EDIT_BACKIMG_OFFSET_Y, NULL, TRUE);
 
-	/* s”Ô†‹æØ‚è  0=‚È‚µ 1=cü 2=”CˆÓ */
+	/* è¡Œç•ªå·åŒºåˆ‡ã‚Š  0=ãªã— 1=ç¸¦ç·š 2=ä»»æ„ */
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_LINETERMTYPE0 ) ){
 		m_Types.m_nLineTermType = 0;
 	}else
@@ -494,12 +494,12 @@ int CPropTypesWindow::GetData( HWND hwndDlg )
 		m_Types.m_nLineTermType = 2;
 	}
 	
-	/* s”Ô†‹æØ‚è•¶š */
+	/* è¡Œç•ªå·åŒºåˆ‡ã‚Šæ–‡å­— */
 	wchar_t	szLineTermChar[2];
 	::DlgItem_GetText( hwndDlg, IDC_EDIT_LINETERMCHAR, szLineTermChar, 2 );
 	m_Types.m_cLineTermChar = szLineTermChar[0];
 
-	/* s”Ô†‚ÌÅ¬Œ…” */	// ’Ç‰Á 2014.08.02 katze
+	/* è¡Œç•ªå·ã®æœ€å°æ¡æ•° */	// è¿½åŠ  2014.08.02 katze
 	m_Types.m_nLineNumWidth = ::GetDlgItemInt( hwndDlg, IDC_EDIT_LINENUMWIDTH, NULL, FALSE );
 	if( m_Types.m_nLineNumWidth < LINENUMWIDTH_MIN ){
 		m_Types.m_nLineNumWidth = LINENUMWIDTH_MIN;
@@ -515,11 +515,11 @@ int CPropTypesWindow::GetData( HWND hwndDlg )
 
 
 //	From Here Sept. 10, 2000 JEPRO
-//	ƒ`ƒFƒbƒNó‘Ô‚É‰‚¶‚Äƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX—v‘f‚ÌEnable/Disable‚ğ
-//	“KØ‚Éİ’è‚·‚é
+//	ãƒã‚§ãƒƒã‚¯çŠ¶æ…‹ã«å¿œã˜ã¦ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹è¦ç´ ã®Enable/Disableã‚’
+//	é©åˆ‡ã«è¨­å®šã™ã‚‹
 void CPropTypesWindow::EnableTypesPropInput( HWND hwndDlg )
 {
-	//	s”Ô†‹æØ‚è‚ğ”CˆÓ‚Ì”¼Šp•¶š‚É‚·‚é‚©‚Ç‚¤‚©
+	//	è¡Œç•ªå·åŒºåˆ‡ã‚Šã‚’ä»»æ„ã®åŠè§’æ–‡å­—ã«ã™ã‚‹ã‹ã©ã†ã‹
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_LINETERMTYPE2 ) ){
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LABEL_LINETERMCHAR ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_EDIT_LINETERMCHAR ), TRUE );


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/typeprop
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。

主に動作影響について対応前後で挙動に変化がないことのご確認をいただけると助かります。
