### PR TITLE
types 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -37,7 +37,7 @@ void _DefaultConfig(STypeConfig* pType);
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 void CType::InitTypeConfig(int nIdx, STypeConfig& type)
 {
-	//‹K’è’l‚ğƒRƒs[
+	//è¦å®šå€¤ã‚’ã‚³ãƒ”ãƒ¼
 	static STypeConfig sDefault;
 	static bool bLoadedDefault = false;
 	if(!bLoadedDefault){
@@ -46,11 +46,11 @@ void CType::InitTypeConfig(int nIdx, STypeConfig& type)
 	}
 	type = sDefault;
 
-	//ƒCƒ“ƒfƒbƒNƒX‚ğİ’è
+	//ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ã‚’è¨­å®š
 	type.m_nIdx = nIdx;
 	type.m_id = nIdx;
 
-	//ŒÂ•Êİ’è
+	//å€‹åˆ¥è¨­å®š
 	InitTypeConfigImp(&type);
 }
 
@@ -59,31 +59,31 @@ void CType::InitTypeConfig(int nIdx, STypeConfig& type)
 //                        CShareData                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*!	@brief ‹¤—Lƒƒ‚ƒŠ‰Šú‰»/ƒ^ƒCƒv•Êİ’è
+/*!	@brief å…±æœ‰ãƒ¡ãƒ¢ãƒªåˆæœŸåŒ–/ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®š
 
-	ƒ^ƒCƒv•Êİ’è‚Ì‰Šú‰»ˆ—
+	ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®åˆæœŸåŒ–å‡¦ç†
 
-	@date 2005.01.30 genta CShareData::Init()‚©‚ç•ª—£D
+	@date 2005.01.30 genta CShareData::Init()ã‹ã‚‰åˆ†é›¢ï¼
 */
 void CShareData::InitTypeConfigs(DLLSHAREDATA* pShareData, std::vector<STypeConfig*>& types )
 {
 	CType* table[] = {
-		new CType_Basis(),	//Šî–{
-		new CType_Text(),	//ƒeƒLƒXƒg
+		new CType_Basis(),	//åŸºæœ¬
+		new CType_Text(),	//ãƒ†ã‚­ã‚¹ãƒˆ
 		new CType_Cpp(),	//C/C++
 		new CType_Html(),	//HTML
 		new CType_Sql(),	//PL/SQL
 		new CType_Cobol(),	//COBOL
 		new CType_Java(),	//Java
-		new CType_Asm(),	//ƒAƒZƒ“ƒuƒ‰
+		new CType_Asm(),	//ã‚¢ã‚»ãƒ³ãƒ–ãƒ©
 		new CType_Awk(),	//awk
-		new CType_Dos(),	//MS-DOSƒoƒbƒ`ƒtƒ@ƒCƒ‹
+		new CType_Dos(),	//MS-DOSãƒãƒƒãƒãƒ•ã‚¡ã‚¤ãƒ«
 		new CType_Pascal(),	//Pascal
 		new CType_Tex(),	//TeX
 		new CType_Perl(),	//Perl
 		new CType_Vb(),		//Visual Basic
-		new CType_Rich(),	//ƒŠƒbƒ`ƒeƒLƒXƒg
-		new CType_Ini(),	//İ’èƒtƒ@ƒCƒ‹
+		new CType_Rich(),	//ãƒªãƒƒãƒãƒ†ã‚­ã‚¹ãƒˆ
+		new CType_Ini(),	//è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«
 	};
 	types.clear();
 	assert( _countof(table) <= MAX_TYPES );
@@ -101,16 +101,16 @@ void CShareData::InitTypeConfigs(DLLSHAREDATA* pShareData, std::vector<STypeConf
 	pShareData->m_nTypesCount = (int)types.size();
 }
 
-/*!	@brief ‹¤—Lƒƒ‚ƒŠ‰Šú‰»/‹­’²ƒL[ƒ[ƒh
+/*!	@brief å…±æœ‰ãƒ¡ãƒ¢ãƒªåˆæœŸåŒ–/å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
 
-	‹­’²ƒL[ƒ[ƒhŠÖ˜A‚Ì‰Šú‰»ˆ—
+	å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰é–¢é€£ã®åˆæœŸåŒ–å‡¦ç†
 
-	@date 2005.01.30 genta CShareData::Init()‚©‚ç•ª—£D
-		ƒL[ƒ[ƒh’è‹`‚ğŠÖ”‚ÌŠO‚Éo‚µC“o˜^‚ğƒ}ƒNƒ‰»‚µ‚ÄŠÈŒ‰‚ÉD
+	@date 2005.01.30 genta CShareData::Init()ã‹ã‚‰åˆ†é›¢ï¼
+		ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å®šç¾©ã‚’é–¢æ•°ã®å¤–ã«å‡ºã—ï¼Œç™»éŒ²ã‚’ãƒã‚¯ãƒ­åŒ–ã—ã¦ç°¡æ½”ã«ï¼
 */
 void CShareData::InitKeyword(DLLSHAREDATA* pShareData)
 {
-	/* ‹­’²ƒL[ƒ[ƒh‚ÌƒeƒXƒgƒf[ƒ^ */
+	/* å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®ãƒ†ã‚¹ãƒˆãƒ‡ãƒ¼ã‚¿ */
 	pShareData->m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx = 0;
 
 	int nSetCount = -1;
@@ -121,80 +121,80 @@ void CShareData::InitKeyword(DLLSHAREDATA* pShareData)
 	pShareData->m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.AddKeyWordSet( (name), (case_sensitive) );	\
 	pShareData->m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SetKeyWordArr( ++nSetCount, g_nKeywords##aryname, g_ppszKeywords##aryname );
 	
-	PopulateKeyword( L"C/C++",			true,	CPP );			/* ƒZƒbƒg 0‚Ì’Ç‰Á */
-	PopulateKeyword( L"HTML",			false,	HTML );			/* ƒZƒbƒg 1‚Ì’Ç‰Á */
-	PopulateKeyword( L"PL/SQL",			false,	PLSQL );		/* ƒZƒbƒg 2‚Ì’Ç‰Á */
-	PopulateKeyword( L"COBOL",			true,	COBOL );		/* ƒZƒbƒg 3‚Ì’Ç‰Á */
-	PopulateKeyword( L"Java",			true,	JAVA );			/* ƒZƒbƒg 4‚Ì’Ç‰Á */
-	PopulateKeyword( L"CORBA IDL",		true,	CORBA_IDL );	/* ƒZƒbƒg 5‚Ì’Ç‰Á */
-	PopulateKeyword( L"AWK",			true,	AWK );			/* ƒZƒbƒg 6‚Ì’Ç‰Á */
-	PopulateKeyword( L"MS-DOS batch",	false,	BAT );			/* ƒZƒbƒg 7‚Ì’Ç‰Á */	//Oct. 31, 2000 JEPRO 'ƒoƒbƒ`ƒtƒ@ƒCƒ‹'¨'batch' ‚É’Zk
-	PopulateKeyword( L"Pascal",			false,	PASCAL );		/* ƒZƒbƒg 8‚Ì’Ç‰Á */	//Nov. 5, 2000 JEPRO ‘åE¬•¶š‚Ì‹æ•Ê‚ğ'‚µ‚È‚¢'‚É•ÏX
-	PopulateKeyword( L"TeX",			true,	TEX );			/* ƒZƒbƒg 9‚Ì’Ç‰Á */	//Sept. 2, 2000 jepro Tex ¨TeX ‚ÉC³ Bool’l‚Í‘åE¬•¶š‚Ì‹æ•Ê
-	PopulateKeyword( L"TeX2",			true,	TEX2 );			/* ƒZƒbƒg10‚Ì’Ç‰Á */	//Jan. 19, 2001 JEPRO ’Ç‰Á
-	PopulateKeyword( L"Perl",			true,	PERL );			/* ƒZƒbƒg11‚Ì’Ç‰Á */
-	PopulateKeyword( L"Perl2",			true,	PERL2 );		/* ƒZƒbƒg12‚Ì’Ç‰Á */	//Jul. 10, 2001 JEPRO Perl‚©‚ç•Ï”‚ğ•ª—£E“Æ—§
-	PopulateKeyword( L"Visual Basic",	false,	VB );			/* ƒZƒbƒg13‚Ì’Ç‰Á */	//Jul. 10, 2001 JEPRO
-	PopulateKeyword( L"Visual Basic2",	false,	VB2 );			/* ƒZƒbƒg14‚Ì’Ç‰Á */	//Jul. 10, 2001 JEPRO
-	PopulateKeyword( L"Rich Text",		true,	RTF );			/* ƒZƒbƒg15‚Ì’Ç‰Á */	//Jul. 10, 2001 JEPRO
+	PopulateKeyword( L"C/C++",			true,	CPP );			/* ã‚»ãƒƒãƒˆ 0ã®è¿½åŠ  */
+	PopulateKeyword( L"HTML",			false,	HTML );			/* ã‚»ãƒƒãƒˆ 1ã®è¿½åŠ  */
+	PopulateKeyword( L"PL/SQL",			false,	PLSQL );		/* ã‚»ãƒƒãƒˆ 2ã®è¿½åŠ  */
+	PopulateKeyword( L"COBOL",			true,	COBOL );		/* ã‚»ãƒƒãƒˆ 3ã®è¿½åŠ  */
+	PopulateKeyword( L"Java",			true,	JAVA );			/* ã‚»ãƒƒãƒˆ 4ã®è¿½åŠ  */
+	PopulateKeyword( L"CORBA IDL",		true,	CORBA_IDL );	/* ã‚»ãƒƒãƒˆ 5ã®è¿½åŠ  */
+	PopulateKeyword( L"AWK",			true,	AWK );			/* ã‚»ãƒƒãƒˆ 6ã®è¿½åŠ  */
+	PopulateKeyword( L"MS-DOS batch",	false,	BAT );			/* ã‚»ãƒƒãƒˆ 7ã®è¿½åŠ  */	//Oct. 31, 2000 JEPRO 'ãƒãƒƒãƒãƒ•ã‚¡ã‚¤ãƒ«'â†’'batch' ã«çŸ­ç¸®
+	PopulateKeyword( L"Pascal",			false,	PASCAL );		/* ã‚»ãƒƒãƒˆ 8ã®è¿½åŠ  */	//Nov. 5, 2000 JEPRO å¤§ãƒ»å°æ–‡å­—ã®åŒºåˆ¥ã‚’'ã—ãªã„'ã«å¤‰æ›´
+	PopulateKeyword( L"TeX",			true,	TEX );			/* ã‚»ãƒƒãƒˆ 9ã®è¿½åŠ  */	//Sept. 2, 2000 jepro Tex â†’TeX ã«ä¿®æ­£ Boolå€¤ã¯å¤§ãƒ»å°æ–‡å­—ã®åŒºåˆ¥
+	PopulateKeyword( L"TeX2",			true,	TEX2 );			/* ã‚»ãƒƒãƒˆ10ã®è¿½åŠ  */	//Jan. 19, 2001 JEPRO è¿½åŠ 
+	PopulateKeyword( L"Perl",			true,	PERL );			/* ã‚»ãƒƒãƒˆ11ã®è¿½åŠ  */
+	PopulateKeyword( L"Perl2",			true,	PERL2 );		/* ã‚»ãƒƒãƒˆ12ã®è¿½åŠ  */	//Jul. 10, 2001 JEPRO Perlã‹ã‚‰å¤‰æ•°ã‚’åˆ†é›¢ãƒ»ç‹¬ç«‹
+	PopulateKeyword( L"Visual Basic",	false,	VB );			/* ã‚»ãƒƒãƒˆ13ã®è¿½åŠ  */	//Jul. 10, 2001 JEPRO
+	PopulateKeyword( L"Visual Basic2",	false,	VB2 );			/* ã‚»ãƒƒãƒˆ14ã®è¿½åŠ  */	//Jul. 10, 2001 JEPRO
+	PopulateKeyword( L"Rich Text",		true,	RTF );			/* ã‚»ãƒƒãƒˆ15ã®è¿½åŠ  */	//Jul. 10, 2001 JEPRO
 
 #undef PopulateKeyword
 }
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        ƒfƒtƒHƒ‹ƒg                           //
+//                        ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆ                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void _DefaultConfig(STypeConfig* pType)
 {
-//ƒL[ƒ[ƒhFƒfƒtƒHƒ‹ƒgƒJƒ‰[İ’è
+//ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ï¼šãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã‚«ãƒ©ãƒ¼è¨­å®š
 /************************/
-/* ƒ^ƒCƒv•Êİ’è‚Ì‹K’è’l */
+/* ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã®è¦å®šå€¤ */
 /************************/
 
-	pType->m_nTextWrapMethod = WRAP_NO_TEXT_WRAP;	// ƒeƒLƒXƒg‚ÌÜ‚è•Ô‚µ•û–@		// 2008.05.30 nasukoji
-	pType->m_nMaxLineKetas = CKetaXInt(MAXLINEKETAS);	/* Ü‚è•Ô‚µŒ…” */
-	pType->m_nColumnSpace = 0;					/* •¶š‚Æ•¶š‚ÌŒ„ŠÔ */
-	pType->m_nLineSpace = 1;					/* sŠÔ‚Ì‚·‚«‚Ü */
-	pType->m_nTabSpace = CKetaXInt(4);					/* TAB‚Ì•¶š” */
-	pType->m_nTsvMode = 0;						/* TSVƒ‚[ƒh */
+	pType->m_nTextWrapMethod = WRAP_NO_TEXT_WRAP;	// ãƒ†ã‚­ã‚¹ãƒˆã®æŠ˜ã‚Šè¿”ã—æ–¹æ³•		// 2008.05.30 nasukoji
+	pType->m_nMaxLineKetas = CKetaXInt(MAXLINEKETAS);	/* æŠ˜ã‚Šè¿”ã—æ¡æ•° */
+	pType->m_nColumnSpace = 0;					/* æ–‡å­—ã¨æ–‡å­—ã®éš™é–“ */
+	pType->m_nLineSpace = 1;					/* è¡Œé–“ã®ã™ãã¾ */
+	pType->m_nTabSpace = CKetaXInt(4);					/* TABã®æ–‡å­—æ•° */
+	pType->m_nTsvMode = 0;						/* TSVãƒ¢ãƒ¼ãƒ‰ */
 	for( int i = 0; i < MAX_KEYWORDSET_PER_TYPE; i++ ){
 		pType->m_nKeyWordSetIdx[i] = -1;
 	}
-	wcscpy( pType->m_szTabViewString, _EDITL("^       ") );	/* TAB•\¦•¶š—ñ */
-	pType->m_bTabArrow = TABARROW_STRING;	/* ƒ^ƒu–îˆó•\¦ */	// 2001.12.03 hor	// default on 2013/4/11 Uchi
-	pType->m_bInsSpace = false;				/* ƒXƒy[ƒX‚Ì‘}“ü */	// 2001.12.03 hor
+	wcscpy( pType->m_szTabViewString, _EDITL("^       ") );	/* TABè¡¨ç¤ºæ–‡å­—åˆ— */
+	pType->m_bTabArrow = TABARROW_STRING;	/* ã‚¿ãƒ–çŸ¢å°è¡¨ç¤º */	// 2001.12.03 hor	// default on 2013/4/11 Uchi
+	pType->m_bInsSpace = false;				/* ã‚¹ãƒšãƒ¼ã‚¹ã®æŒ¿å…¥ */	// 2001.12.03 hor
 	
-	//@@@ 2002.09.22 YAZAKI ˆÈ‰ºAm_cLineComment‚Æm_cBlockComments‚ğg‚¤‚æ‚¤‚ÉC³
-	pType->m_cLineComment.CopyTo(0, L"", -1);	/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_cLineComment.CopyTo(1, L"", -1);	/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^2 */
-	pType->m_cLineComment.CopyTo(2, L"", -1);	/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^3 */	//Jun. 01, 2001 JEPRO ’Ç‰Á
-	pType->m_cBlockComments[0].SetBlockCommentRule(L"", L"");	/* ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_cBlockComments[1].SetBlockCommentRule(L"", L"");	/* ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^2 */
+	//@@@ 2002.09.22 YAZAKI ä»¥ä¸‹ã€m_cLineCommentã¨m_cBlockCommentsã‚’ä½¿ã†ã‚ˆã†ã«ä¿®æ­£
+	pType->m_cLineComment.CopyTo(0, L"", -1);	/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_cLineComment.CopyTo(1, L"", -1);	/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿2 */
+	pType->m_cLineComment.CopyTo(2, L"", -1);	/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿3 */	//Jun. 01, 2001 JEPRO è¿½åŠ 
+	pType->m_cBlockComments[0].SetBlockCommentRule(L"", L"");	/* ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_cBlockComments[1].SetBlockCommentRule(L"", L"");	/* ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿2 */
 
-	pType->m_nStringType = STRING_LITERAL_CPP;					/* •¶š—ñ‹æØ‚è‹L†ƒGƒXƒP[ƒv•û–@ 0=[\"][\'] 1=[""][''] */
+	pType->m_nStringType = STRING_LITERAL_CPP;					/* æ–‡å­—åˆ—åŒºåˆ‡ã‚Šè¨˜å·ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—æ–¹æ³• 0=[\"][\'] 1=[""][''] */
 	pType->m_bStringLineOnly = false;
 	pType->m_bStringEndLine  = false;
 	pType->m_nHeredocType = HEREDOC_PHP;
-	pType->m_szIndentChars[0] = L'\0';		/* ‚»‚Ì‘¼‚ÌƒCƒ“ƒfƒ“ƒg‘ÎÛ•¶š */
+	pType->m_szIndentChars[0] = L'\0';		/* ãã®ä»–ã®ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¯¾è±¡æ–‡å­— */
 
 	pType->m_nColorInfoArrNum = COLORIDX_LAST;
 
 	// 2001/06/14 Start by asa-o
-	_tcscpy( pType->m_szHokanFile, _T("") );		/* “ü—Í•âŠ® ’PŒêƒtƒ@ƒCƒ‹ */
+	_tcscpy( pType->m_szHokanFile, _T("") );		/* å…¥åŠ›è£œå®Œ å˜èªãƒ•ã‚¡ã‚¤ãƒ« */
 	// 2001/06/14 End
 
 	pType->m_nHokanType = 0;
 
 	// 2001/06/19 asa-o
-	pType->m_bHokanLoHiCase = false;			// “ü—Í•âŠ®‹@”\F‰p‘å•¶š¬•¶š‚ğ“¯ˆê‹‚·‚é
+	pType->m_bHokanLoHiCase = false;			// å…¥åŠ›è£œå®Œæ©Ÿèƒ½ï¼šè‹±å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–ã™ã‚‹
 
-	//	2003.06.23 Moca ƒtƒ@ƒCƒ‹“à‚©‚ç‚Ì“ü—Í•âŠ®‹@”\
-	pType->m_bUseHokanByFile = true;			//! “ü—Í•âŠ® ŠJ‚¢‚Ä‚¢‚éƒtƒ@ƒCƒ‹“à‚©‚çŒó•â‚ğ’T‚·
-	pType->m_bUseHokanByKeyword = false;			// ‹­’²ƒL[ƒ[ƒh‚©‚ç“ü—Í•âŠ®
+	//	2003.06.23 Moca ãƒ•ã‚¡ã‚¤ãƒ«å†…ã‹ã‚‰ã®å…¥åŠ›è£œå®Œæ©Ÿèƒ½
+	pType->m_bUseHokanByFile = true;			//! å…¥åŠ›è£œå®Œ é–‹ã„ã¦ã„ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«å†…ã‹ã‚‰å€™è£œã‚’æ¢ã™
+	pType->m_bUseHokanByKeyword = false;			// å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‹ã‚‰å…¥åŠ›è£œå®Œ
 
-	// •¶šƒR[ƒhİ’è
+	// æ–‡å­—ã‚³ãƒ¼ãƒ‰è¨­å®š
 	pType->m_encoding.m_bPriorCesu8 = false;
 	pType->m_encoding.m_eDefaultCodetype = CODE_SJIS;
 	pType->m_encoding.m_eDefaultEoltype = EOL_CRLF;
@@ -205,11 +205,11 @@ void _DefaultConfig(STypeConfig* pType)
 	pType->m_szExtHtmlHelp[0] = L'\0';
 	pType->m_bHtmlHelpIsSingle = true;
 
-	pType->m_bAutoIndent = true;			/* ƒI[ƒgƒCƒ“ƒfƒ“ƒg */
-	pType->m_bAutoIndent_ZENSPACE = true;	/* “ú–{Œê‹ó”’‚àƒCƒ“ƒfƒ“ƒg */
-	pType->m_bRTrimPrevLine = false;		// 2005.10.11 ryoji ‰üs‚É––”ö‚Ì‹ó”’‚ğíœ
+	pType->m_bAutoIndent = true;			/* ã‚ªãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ */
+	pType->m_bAutoIndent_ZENSPACE = true;	/* æ—¥æœ¬èªç©ºç™½ã‚‚ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ */
+	pType->m_bRTrimPrevLine = false;		// 2005.10.11 ryoji æ”¹è¡Œæ™‚ã«æœ«å°¾ã®ç©ºç™½ã‚’å‰Šé™¤
 
-	pType->m_nIndentLayout = 0;	/* Ü‚è•Ô‚µ‚Í2s–ÚˆÈ~‚ğš‰º‚°•\¦ */
+	pType->m_nIndentLayout = 0;	/* æŠ˜ã‚Šè¿”ã—ã¯2è¡Œç›®ä»¥é™ã‚’å­—ä¸‹ã’è¡¨ç¤º */
 
 
 	assert( COLORIDX_LAST <= _countof(pType->m_ColorInfoArr) );
@@ -226,38 +226,38 @@ void _DefaultConfig(STypeConfig* pType)
 		POINT pt ={0,0};
 		pType->m_backImgPosOffset = pt;
 	}
-	pType->m_bLineNumIsCRLF = true;					// s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ
-	pType->m_nLineTermType = 1;						// s”Ô†‹æØ‚è 0=‚È‚µ 1=cü 2=”CˆÓ
-	pType->m_cLineTermChar = L':';					// s”Ô†‹æØ‚è•¶š
-	pType->m_bWordWrap = false;						// ‰p•¶ƒ[ƒhƒ‰ƒbƒv‚ğ‚·‚é
-	pType->m_nCurrentPrintSetting = 0;				// Œ»İ‘I‘ğ‚µ‚Ä‚¢‚éˆóüİ’è
-	pType->m_bOutlineDockDisp = false;				// ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•\¦‚Ì—L–³
-	pType->m_eOutlineDockSide = DOCKSIDE_FLOAT;		// ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒhƒbƒLƒ“ƒO”z’u
-	pType->m_cxOutlineDockLeft = 0;					// ƒAƒEƒgƒ‰ƒCƒ“‚Ì¶ƒhƒbƒLƒ“ƒO•
-	pType->m_cyOutlineDockTop = 0;					// ƒAƒEƒgƒ‰ƒCƒ“‚ÌãƒhƒbƒLƒ“ƒO‚
-	pType->m_cxOutlineDockRight = 0;				// ƒAƒEƒgƒ‰ƒCƒ“‚Ì‰EƒhƒbƒLƒ“ƒO•
-	pType->m_cyOutlineDockBottom = 0;				// ƒAƒEƒgƒ‰ƒCƒ“‚Ì‰ºƒhƒbƒLƒ“ƒO‚
-	pType->m_eDefaultOutline = OUTLINE_TEXT;		/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
-	pType->m_nOutlineSortCol = 0;					/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ\[ƒg—ñ”Ô† */
-	pType->m_bOutlineSortDesc = false;				// ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ\[ƒg~‡
-	pType->m_nOutlineSortType = 0;					/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍƒ\[ƒgŠî€ */
+	pType->m_bLineNumIsCRLF = true;					// è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½
+	pType->m_nLineTermType = 1;						// è¡Œç•ªå·åŒºåˆ‡ã‚Š 0=ãªã— 1=ç¸¦ç·š 2=ä»»æ„
+	pType->m_cLineTermChar = L':';					// è¡Œç•ªå·åŒºåˆ‡ã‚Šæ–‡å­—
+	pType->m_bWordWrap = false;						// è‹±æ–‡ãƒ¯ãƒ¼ãƒ‰ãƒ©ãƒƒãƒ—ã‚’ã™ã‚‹
+	pType->m_nCurrentPrintSetting = 0;				// ç¾åœ¨é¸æŠã—ã¦ã„ã‚‹å°åˆ·è¨­å®š
+	pType->m_bOutlineDockDisp = false;				// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æè¡¨ç¤ºã®æœ‰ç„¡
+	pType->m_eOutlineDockSide = DOCKSIDE_FLOAT;		// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æãƒ‰ãƒƒã‚­ãƒ³ã‚°é…ç½®
+	pType->m_cxOutlineDockLeft = 0;					// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®å·¦ãƒ‰ãƒƒã‚­ãƒ³ã‚°å¹…
+	pType->m_cyOutlineDockTop = 0;					// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®ä¸Šãƒ‰ãƒƒã‚­ãƒ³ã‚°é«˜
+	pType->m_cxOutlineDockRight = 0;				// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®å³ãƒ‰ãƒƒã‚­ãƒ³ã‚°å¹…
+	pType->m_cyOutlineDockBottom = 0;				// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³ã®ä¸‹ãƒ‰ãƒƒã‚­ãƒ³ã‚°é«˜
+	pType->m_eDefaultOutline = OUTLINE_TEXT;		/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
+	pType->m_nOutlineSortCol = 0;					/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã‚½ãƒ¼ãƒˆåˆ—ç•ªå· */
+	pType->m_bOutlineSortDesc = false;				// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã‚½ãƒ¼ãƒˆé™é †
+	pType->m_nOutlineSortType = 0;					/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã‚½ãƒ¼ãƒˆåŸºæº– */
 	CShareData::InitFileTree( &pType->m_sFileTree );
-	pType->m_eSmartIndent = SMARTINDENT_NONE;		/* ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒgí•Ê */
+	pType->m_eSmartIndent = SMARTINDENT_NONE;		/* ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆç¨®åˆ¥ */
 	pType->m_bIndentCppStringIgnore = true;
 	pType->m_bIndentCppCommentIgnore = true;
 	pType->m_bIndentCppUndoSep = false;
-	pType->m_nImeState = IME_CMODE_NOCONVERSION;	/* IME“ü—Í */
+	pType->m_nImeState = IME_CMODE_NOCONVERSION;	/* IMEå…¥åŠ› */
 
 	pType->m_szOutlineRuleFilename[0] = L'\0';		//Dec. 4, 2000 MIK
-	pType->m_bKinsokuHead = false;					// s“ª‹Ö‘¥				//@@@ 2002.04.08 MIK
-	pType->m_bKinsokuTail = false;					// s––‹Ö‘¥				//@@@ 2002.04.08 MIK
-	pType->m_bKinsokuRet  = false;					// ‰üs•¶š‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.13 MIK
-	pType->m_bKinsokuKuto = false;					// ‹å“Ç“_‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.17 MIK
-	pType->m_szKinsokuHead[0] = L'\0';				// s“ª‹Ö‘¥				//@@@ 2002.04.08 MIK
-	pType->m_szKinsokuTail[0] = L'\0';				// s––‹Ö‘¥				//@@@ 2002.04.08 MIK
-	wcscpy( pType->m_szKinsokuKuto, L"ABCD¤¡,." );	// ‹å“Ç“_‚Ô‚ç‰º‚°•¶š	// 2009.08.07 ryoji
+	pType->m_bKinsokuHead = false;					// è¡Œé ­ç¦å‰‡				//@@@ 2002.04.08 MIK
+	pType->m_bKinsokuTail = false;					// è¡Œæœ«ç¦å‰‡				//@@@ 2002.04.08 MIK
+	pType->m_bKinsokuRet  = false;					// æ”¹è¡Œæ–‡å­—ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.13 MIK
+	pType->m_bKinsokuKuto = false;					// å¥èª­ç‚¹ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.17 MIK
+	pType->m_szKinsokuHead[0] = L'\0';				// è¡Œé ­ç¦å‰‡				//@@@ 2002.04.08 MIK
+	pType->m_szKinsokuTail[0] = L'\0';				// è¡Œæœ«ç¦å‰‡				//@@@ 2002.04.08 MIK
+	wcscpy( pType->m_szKinsokuKuto, L"ã€ã€‚ï¼Œï¼ï½¤ï½¡,." );	// å¥èª­ç‚¹ã¶ã‚‰ä¸‹ã’æ–‡å­—	// 2009.08.07 ryoji
 
-	pType->m_bUseDocumentIcon = false;				// •¶‘‚ÉŠÖ˜A‚Ã‚¯‚ç‚ê‚½ƒAƒCƒRƒ“‚ğg‚¤
+	pType->m_bUseDocumentIcon = false;				// æ–‡æ›¸ã«é–¢é€£ã¥ã‘ã‚‰ã‚ŒãŸã‚¢ã‚¤ã‚³ãƒ³ã‚’ä½¿ã†
 
 //@@@ 2001.11.17 add start MIK
 	for(int i = 0; i < _countof(pType->m_RegexKeywordArr); i++)
@@ -275,24 +275,24 @@ void _DefaultConfig(STypeConfig* pType)
 		pType->m_KeyHelpArr[i].m_szAbout[0] = _T('\0');
 		pType->m_KeyHelpArr[i].m_szPath[0] = _T('\0');
 	}
-	pType->m_bUseKeyWordHelp = false;		// «‘‘I‘ğ‹@”\‚Ìg—p‰Â”Û
-	pType->m_nKeyHelpNum = 0;				// “o˜^«‘”
-	pType->m_bUseKeyHelpAllSearch = false;	// ƒqƒbƒg‚µ‚½Ÿ‚Ì«‘‚àŒŸõ(&A)
-	pType->m_bUseKeyHelpKeyDisp = false;	// 1s–Ú‚ÉƒL[ƒ[ƒh‚à•\¦‚·‚é(&W)
-	pType->m_bUseKeyHelpPrefix = false;		// ‘I‘ğ”ÍˆÍ‚Å‘O•ûˆê’vŒŸõ(&P)
+	pType->m_bUseKeyWordHelp = false;		// è¾æ›¸é¸æŠæ©Ÿèƒ½ã®ä½¿ç”¨å¯å¦
+	pType->m_nKeyHelpNum = 0;				// ç™»éŒ²è¾æ›¸æ•°
+	pType->m_bUseKeyHelpAllSearch = false;	// ãƒ’ãƒƒãƒˆã—ãŸæ¬¡ã®è¾æ›¸ã‚‚æ¤œç´¢(&A)
+	pType->m_bUseKeyHelpKeyDisp = false;	// 1è¡Œç›®ã«ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚‚è¡¨ç¤ºã™ã‚‹(&W)
+	pType->m_bUseKeyHelpPrefix = false;		// é¸æŠç¯„å›²ã§å‰æ–¹ä¸€è‡´æ¤œç´¢(&P)
 	pType->m_eKeyHelpRMenuShowType = KEYHELP_RMENU_TOP;
 //@@@ 2006.04.10 fon ADD-end
 
-	// 2005.11.08 Moca w’èˆÊ’ucü‚Ìİ’è
+	// 2005.11.08 Moca æŒ‡å®šä½ç½®ç¸¦ç·šã®è¨­å®š
 	for(int i = 0; i < MAX_VERTLINES; i++ ){
 		pType->m_nVertLineIdx[i] = CKetaXInt(0);
 	}
 	pType->m_nNoteLineOffset = 0;
 
-	//  •Û‘¶‚É‰üsƒR[ƒh‚Ì¬İ‚ğŒx‚·‚é	2013/4/14 Uchi
+	//  ä¿å­˜æ™‚ã«æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®æ··åœ¨ã‚’è­¦å‘Šã™ã‚‹	2013/4/14 Uchi
 	pType->m_bChkEnterAtEnd = true;
 
-	pType->m_bUseTypeFont = false;			//!< ƒ^ƒCƒv•ÊƒtƒHƒ“ƒg‚Ìg—p
+	pType->m_bUseTypeFont = false;			//!< ã‚¿ã‚¤ãƒ—åˆ¥ãƒ•ã‚©ãƒ³ãƒˆã®ä½¿ç”¨
 
-	pType->m_nLineNumWidth = LINENUMWIDTH_MIN;	//!< s”Ô†Å¬Œ…” 2014.08.02 katze
+	pType->m_nLineNumWidth = LINENUMWIDTH_MIN;	//!< è¡Œç•ªå·æœ€å°æ¡æ•° 2014.08.02 katze
 }

--- a/sakura_core/types/CType.h
+++ b/sakura_core/types/CType.h
@@ -1,4 +1,4 @@
-/*
+Ôªø/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -33,17 +33,17 @@
 #include "CRegexKeyword.h"	// RegexKeywordInfo
 
 
-//! É^Éuï\é¶ï˚ñ@
+//! „Çø„ÉñË°®Á§∫ÊñπÊ≥ï
 enum ETabArrow {
-	TABARROW_STRING = 0,	//!< ï∂éöéwíË
-	TABARROW_SHORT,			//!< íZÇ¢ñÓàÛ
-	TABARROW_LONG,			//!< í∑Ç¢ñÓàÛ
+	TABARROW_STRING = 0,	//!< ÊñáÂ≠óÊåáÂÆö
+	TABARROW_SHORT,			//!< Áü≠„ÅÑÁü¢Âç∞
+	TABARROW_LONG,			//!< Èï∑„ÅÑÁü¢Âç∞
 };
 
-//! ÉAÉEÉgÉâÉCÉìâêÕÇÃéÌóﬁ
+//! „Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê„ÅÆÁ®ÆÈ°û
 enum EOutlineType{
 	OUTLINE_C,
-	OUTLINE_C_CPP,		// C/C++é©ìÆîFéØ
+	OUTLINE_C_CPP,		// C/C++Ëá™ÂãïË™çË≠ò
 	OUTLINE_PLSQL,
 	OUTLINE_TEXT,
 	OUTLINE_JAVA,
@@ -51,239 +51,239 @@ enum EOutlineType{
 	OUTLINE_ASM,
 	OUTLINE_PERL,		//	Sep. 8, 2000 genta
 	OUTLINE_VB,			//	June 23, 2001 N.Nakatani
-	OUTLINE_WZTXT,		// 2003.05.20 zenryaku äKëwïtÉeÉLÉXÉgÉAÉEÉgÉâÉCÉìâêÕ
-	OUTLINE_HTML,		// 2003.05.20 zenryaku HTMLÉAÉEÉgÉâÉCÉìâêÕ
-	OUTLINE_TEX,		// 2003.07.20 naoh TeXÉAÉEÉgÉâÉCÉìâêÕ
-	OUTLINE_FILE,		//	2002.04.01 YAZAKI ÉãÅ[ÉãÉtÉ@ÉCÉãóp
-	OUTLINE_PYTHON,		//	2007.02.08 genta PythonÉAÉEÉgÉâÉCÉìâêÕ
-	OUTLINE_ERLANG,		//	2009.08.10 genta ErlangÉAÉEÉgÉâÉCÉìâêÕ
+	OUTLINE_WZTXT,		// 2003.05.20 zenryaku ÈöéÂ±§‰ªò„ÉÜ„Ç≠„Çπ„Éà„Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê
+	OUTLINE_HTML,		// 2003.05.20 zenryaku HTML„Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê
+	OUTLINE_TEX,		// 2003.07.20 naoh TeX„Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê
+	OUTLINE_FILE,		//	2002.04.01 YAZAKI „É´„Éº„É´„Éï„Ç°„Ç§„É´Áî®
+	OUTLINE_PYTHON,		//	2007.02.08 genta Python„Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê
+	OUTLINE_ERLANG,		//	2009.08.10 genta Erlang„Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê
 	OUTLINE_XML,		//  2014.12.25 Moca
 	OUTLINE_CPP,		//  2015.11.13 Moca
-	//	êVÇµÇ¢ÉAÉEÉgÉâÉCÉìâêÕÇÕïKÇ∏Ç±ÇÃíºëOÇ÷ë}ì¸
+	//	Êñ∞„Åó„ÅÑ„Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê„ÅØÂøÖ„Åö„Åì„ÅÆÁõ¥Ââç„Å∏ÊåøÂÖ•
 	OUTLINE_CODEMAX,
 	OUTLINE_BOOKMARK,	//	2001.12.03 hor
-	OUTLINE_PLUGIN,		//	2009.10.29 syat ÉvÉâÉOÉCÉìÇ…ÇÊÇÈÉAÉEÉgÉâÉCÉìâêÕ
-	OUTLINE_FILETREE,	//	2012.06.20 Moca ÉtÉ@ÉCÉãÉcÉäÅ[
+	OUTLINE_PLUGIN,		//	2009.10.29 syat „Éó„É©„Ç∞„Ç§„É≥„Å´„Çà„Çã„Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê
+	OUTLINE_FILETREE,	//	2012.06.20 Moca „Éï„Ç°„Ç§„É´„ÉÑ„É™„Éº
 	OUTLINE_DEFAULT =-1,//	2001.12.03 hor
 	OUTLINE_UNKNOWN	= 99,
-	OUTLINE_TREE = 100,		// îƒópÉcÉäÅ[ 2010.03.28 syat
-	OUTLINE_TREE_TAGJUMP = 101,	// îƒópÉcÉäÅ[(É^ÉOÉWÉÉÉìÉvïtÇ´) 2013.05.01 Moca
-	OUTLINE_CLSTREE = 200,	// îƒópÉcÉäÅ[(ÉNÉâÉX) 2010.03.28 syat
-	OUTLINE_LIST = 300,		// îƒópÉäÉXÉg 2010.03.28 syat
+	OUTLINE_TREE = 100,		// Ê±éÁî®„ÉÑ„É™„Éº 2010.03.28 syat
+	OUTLINE_TREE_TAGJUMP = 101,	// Ê±éÁî®„ÉÑ„É™„Éº(„Çø„Ç∞„Ç∏„É£„É≥„Éó‰ªò„Åç) 2013.05.01 Moca
+	OUTLINE_CLSTREE = 200,	// Ê±éÁî®„ÉÑ„É™„Éº(„ÇØ„É©„Çπ) 2010.03.28 syat
+	OUTLINE_LIST = 300,		// Ê±éÁî®„É™„Çπ„Éà 2010.03.28 syat
 };
 
-//! ÉXÉ}Å[ÉgÉCÉìÉfÉìÉgéÌï 
+//! „Çπ„Éû„Éº„Éà„Ç§„É≥„Éá„É≥„ÉàÁ®ÆÂà•
 enum ESmartIndentType {
-	SMARTINDENT_NONE,		//!< Ç»Çµ
+	SMARTINDENT_NONE,		//!< „Å™„Åó
 	SMARTINDENT_CPP			//!< C/C++
 };
 
-//! ÉqÉAÉhÉLÉÖÉÅÉìÉgéÌï 
+//! „Éí„Ç¢„Éâ„Ç≠„É•„É°„É≥„ÉàÁ®ÆÂà•
 enum EHereDocType{
 	HEREDOC_PHP,			//!< PHP
 	HEREDOC_RUBY,			//!< Ruby
 	HEREDOC_PERL			//!< Perl
 };
 
-//! îwåiâÊëúï\é¶à íu
+//! ËÉåÊôØÁîªÂÉèË°®Á§∫‰ΩçÁΩÆ
 enum EBackgroundImagePos {
-	BGIMAGE_TOP_LEFT,		//!< ç∂è„
-	BGIMAGE_TOP_RIGHT,		//!< âEè„
-	BGIMAGE_BOTTOM_LEFT,	//!< ç∂â∫
-	BGIMAGE_BOTTOM_RIGHT,	//!< âEâ∫
-	BGIMAGE_CENTER,			//!< íÜâõ
-	BGIMAGE_TOP_CENTER,		//!< íÜâõè„
-	BGIMAGE_BOTTOM_CENTER,	//!< íÜâõâ∫
-	BGIMAGE_CENTER_LEFT,	//!< íÜâõç∂
-	BGIMAGE_CENTER_RIGHT	//!< íÜâõâE
+	BGIMAGE_TOP_LEFT,		//!< Â∑¶‰∏ä
+	BGIMAGE_TOP_RIGHT,		//!< Âè≥‰∏ä
+	BGIMAGE_BOTTOM_LEFT,	//!< Â∑¶‰∏ã
+	BGIMAGE_BOTTOM_RIGHT,	//!< Âè≥‰∏ã
+	BGIMAGE_CENTER,			//!< ‰∏≠Â§Æ
+	BGIMAGE_TOP_CENTER,		//!< ‰∏≠Â§Æ‰∏ä
+	BGIMAGE_BOTTOM_CENTER,	//!< ‰∏≠Â§Æ‰∏ã
+	BGIMAGE_CENTER_LEFT,	//!< ‰∏≠Â§ÆÂ∑¶
+	BGIMAGE_CENTER_RIGHT	//!< ‰∏≠Â§ÆÂè≥
 };
 
-//! ÉGÉìÉRÅ[ÉhÉIÉvÉVÉáÉì
+//! „Ç®„É≥„Ç≥„Éº„Éâ„Ç™„Éó„Ç∑„Éß„É≥
 struct SEncodingConfig{
-	bool				m_bPriorCesu8;					//!< é©ìÆîªï éûÇ… CESU-8 ÇóDêÊÇ∑ÇÈÇ©Ç«Ç§Ç©
-	ECodeType			m_eDefaultCodetype;				//!< ÉfÉtÉHÉãÉgï∂éöÉRÅ[Éh
-	EEolType			m_eDefaultEoltype;				//!< ÉfÉtÉHÉãÉgâ¸çsÉRÅ[Éh	// 2011.01.24 ryoji
-	bool				m_bDefaultBom;					//!< ÉfÉtÉHÉãÉgBOM			// 2011.01.24 ryoji
+	bool				m_bPriorCesu8;					//!< Ëá™ÂãïÂà§Âà•ÊôÇ„Å´ CESU-8 „ÇíÂÑ™ÂÖà„Åô„Çã„Åã„Å©„ÅÜ„Åã
+	ECodeType			m_eDefaultCodetype;				//!< „Éá„Éï„Ç©„É´„ÉàÊñáÂ≠ó„Ç≥„Éº„Éâ
+	EEolType			m_eDefaultEoltype;				//!< „Éá„Éï„Ç©„É´„ÉàÊîπË°å„Ç≥„Éº„Éâ	// 2011.01.24 ryoji
+	bool				m_bDefaultBom;					//!< „Éá„Éï„Ç©„É´„ÉàBOM			// 2011.01.24 ryoji
 };
 
-//! ï∂éöóÒãÊêÿÇËãLçÜÉGÉXÉPÅ[Évï˚ñ@
+//! ÊñáÂ≠óÂàóÂå∫Âàá„ÇäË®òÂè∑„Ç®„Çπ„Ç±„Éº„ÉóÊñπÊ≥ï
 enum EStringLiteralType{
-	STRING_LITERAL_CPP,		//!< C/C++åæåÍïó
-	STRING_LITERAL_PLSQL,	//!< PL/SQLïó
-	STRING_LITERAL_HTML,	//!< HTML/XMLïó
-	STRING_LITERAL_CSHARP,	//!< C#ïó
-	STRING_LITERAL_PYTHON,	//!< Pythonïó
+	STRING_LITERAL_CPP,		//!< C/C++Ë®ÄË™ûÈ¢®
+	STRING_LITERAL_PLSQL,	//!< PL/SQLÈ¢®
+	STRING_LITERAL_HTML,	//!< HTML/XMLÈ¢®
+	STRING_LITERAL_CSHARP,	//!< C#È¢®
+	STRING_LITERAL_PYTHON,	//!< PythonÈ¢®
 };
 
-//! âEÉNÉäÉbÉNÉÅÉjÉÖÅ[ï\é¶
+//! Âè≥„ÇØ„É™„ÉÉ„ÇØ„É°„Éã„É•„ÉºË°®Á§∫
 enum EKeyHelpRMenuType{
-	KEYHELP_RMENU_NONE,		//!< îÒï\é¶
-	KEYHELP_RMENU_TOP,		//!< ÉÅÉjÉÖÅ[êÊì™
-	KEYHELP_RMENU_BOTTOM,	//!< ÉÅÉjÉÖÅ[ññîˆ
+	KEYHELP_RMENU_NONE,		//!< ÈùûË°®Á§∫
+	KEYHELP_RMENU_TOP,		//!< „É°„Éã„É•„ÉºÂÖàÈ†≠
+	KEYHELP_RMENU_BOTTOM,	//!< „É°„Éã„É•„ÉºÊú´Â∞æ
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       É^ÉCÉvï ê›íË                          //
+//                       „Çø„Ç§„ÉóÂà•Ë®≠ÂÆö                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! É^ÉCÉvï ê›íË
+//! „Çø„Ç§„ÉóÂà•Ë®≠ÂÆö
 struct STypeConfig{
-	//2007.09.07 ïœêîñºïœçX: m_nMaxLineSizeÅ®m_nMaxLineKetas
+	//2007.09.07 Â§âÊï∞ÂêçÂ§âÊõ¥: m_nMaxLineSize‚Üím_nMaxLineKetas
 	int					m_nIdx;
 	int					m_id;
-	TCHAR				m_szTypeName[MAX_TYPES_NAME];	//!< É^ÉCÉvëÆê´ÅFñºèÃ
-	TCHAR				m_szTypeExts[MAX_TYPES_EXTS];	//!< É^ÉCÉvëÆê´ÅFägí£éqÉäÉXÉg
-	int					m_nTextWrapMethod;				//!< ÉeÉLÉXÉgÇÃê‹ÇËï‘Çµï˚ñ@		// 2008.05.30 nasukoji
-	CKetaXInt			m_nMaxLineKetas;				//!< ê‹ÇËï‘ÇµåÖêî
-	int					m_nColumnSpace;					//!< ï∂éöÇ∆ï∂éöÇÃåÑä‘
-	int					m_nLineSpace;					//!< çsä‘ÇÃÇ∑Ç´Ç‹
-	CKetaXInt			m_nTabSpace;					//!< TABÇÃï∂éöêî
-	ETabArrow			m_bTabArrow;					//!< É^ÉuñÓàÛï\é¶		//@@@ 2003.03.26 MIK
-	EDIT_CHAR			m_szTabViewString[8+1];			//!< TABï\é¶ï∂éöóÒ	// 2003.1.26 aroka ÉTÉCÉYägí£	// 2009.02.11 ryoji ÉTÉCÉYñﬂÇµ(17->8+1)
-	bool				m_bInsSpace;					//!< ÉXÉyÅ[ÉXÇÃë}ì¸	// 2001.12.03 hor
-	int					m_nTsvMode;						//!< TSVÉÇÅ[Éh	// 2015.05.02 syat
-	// 2005.01.13 MIK îzóÒâª
-	int					m_nKeyWordSetIdx[MAX_KEYWORDSET_PER_TYPE];	//!< ÉLÅ[ÉèÅ[ÉhÉZÉbÉg
+	TCHAR				m_szTypeName[MAX_TYPES_NAME];	//!< „Çø„Ç§„ÉóÂ±ûÊÄßÔºöÂêçÁß∞
+	TCHAR				m_szTypeExts[MAX_TYPES_EXTS];	//!< „Çø„Ç§„ÉóÂ±ûÊÄßÔºöÊã°ÂºµÂ≠ê„É™„Çπ„Éà
+	int					m_nTextWrapMethod;				//!< „ÉÜ„Ç≠„Çπ„Éà„ÅÆÊäò„ÇäËøî„ÅóÊñπÊ≥ï		// 2008.05.30 nasukoji
+	CKetaXInt			m_nMaxLineKetas;				//!< Êäò„ÇäËøî„ÅóÊ°ÅÊï∞
+	int					m_nColumnSpace;					//!< ÊñáÂ≠ó„Å®ÊñáÂ≠ó„ÅÆÈöôÈñì
+	int					m_nLineSpace;					//!< Ë°åÈñì„ÅÆ„Åô„Åç„Åæ
+	CKetaXInt			m_nTabSpace;					//!< TAB„ÅÆÊñáÂ≠óÊï∞
+	ETabArrow			m_bTabArrow;					//!< „Çø„ÉñÁü¢Âç∞Ë°®Á§∫		//@@@ 2003.03.26 MIK
+	EDIT_CHAR			m_szTabViewString[8+1];			//!< TABË°®Á§∫ÊñáÂ≠óÂàó	// 2003.1.26 aroka „Çµ„Ç§„Ç∫Êã°Âºµ	// 2009.02.11 ryoji „Çµ„Ç§„Ç∫Êàª„Åó(17->8+1)
+	bool				m_bInsSpace;					//!< „Çπ„Éö„Éº„Çπ„ÅÆÊåøÂÖ•	// 2001.12.03 hor
+	int					m_nTsvMode;						//!< TSV„É¢„Éº„Éâ	// 2015.05.02 syat
+	// 2005.01.13 MIK ÈÖçÂàóÂåñ
+	int					m_nKeyWordSetIdx[MAX_KEYWORDSET_PER_TYPE];	//!< „Ç≠„Éº„ÉØ„Éº„Éâ„Çª„ÉÉ„Éà
 
-	CLineComment		m_cLineComment;					//!< çsÉRÉÅÉìÉgÉfÉäÉ~É^			//@@@ 2002.09.22 YAZAKI
-	CBlockComment		m_cBlockComments[2];			//!< ÉuÉçÉbÉNÉRÉÅÉìÉgÉfÉäÉ~É^	//@@@ 2002.09.22 YAZAKI
+	CLineComment		m_cLineComment;					//!< Ë°å„Ç≥„É°„É≥„Éà„Éá„É™„Éü„Çø			//@@@ 2002.09.22 YAZAKI
+	CBlockComment		m_cBlockComments[2];			//!< „Éñ„É≠„ÉÉ„ÇØ„Ç≥„É°„É≥„Éà„Éá„É™„Éü„Çø	//@@@ 2002.09.22 YAZAKI
 
-	int					m_nStringType;					//!< ï∂éöóÒãÊêÿÇËãLçÜÉGÉXÉPÅ[Évï˚ñ@  0=[\"][\'] 1=[""]['']
-	bool				m_bStringLineOnly;				//!< ï∂éöóÒÇÕçsì‡ÇÃÇ›
-	bool				m_bStringEndLine;				//!< (èIóπï∂éöóÒÇ™Ç»Ç¢èÍçá)çsññÇ‹Ç≈êFï™ÇØ
+	int					m_nStringType;					//!< ÊñáÂ≠óÂàóÂå∫Âàá„ÇäË®òÂè∑„Ç®„Çπ„Ç±„Éº„ÉóÊñπÊ≥ï  0=[\"][\'] 1=[""]['']
+	bool				m_bStringLineOnly;				//!< ÊñáÂ≠óÂàó„ÅØË°åÂÜÖ„ÅÆ„Åø
+	bool				m_bStringEndLine;				//!< (ÁµÇ‰∫ÜÊñáÂ≠óÂàó„Åå„Å™„ÅÑÂ†¥Âêà)Ë°åÊú´„Åæ„ÅßËâ≤ÂàÜ„Åë
 	int					m_nHeredocType;
-	wchar_t				m_szIndentChars[64];			//!< ÇªÇÃëºÇÃÉCÉìÉfÉìÉgëŒè€ï∂éö
+	wchar_t				m_szIndentChars[64];			//!< „Åù„ÅÆ‰ªñ„ÅÆ„Ç§„É≥„Éá„É≥„ÉàÂØæË±°ÊñáÂ≠ó
 
-	int					m_nColorInfoArrNum;				//!< êFê›íËîzóÒÇÃóLå¯êî
-	ColorInfo			m_ColorInfoArr[64];				//!< êFê›íËîzóÒ
+	int					m_nColorInfoArrNum;				//!< Ëâ≤Ë®≠ÂÆöÈÖçÂàó„ÅÆÊúâÂäπÊï∞
+	ColorInfo			m_ColorInfoArr[64];				//!< Ëâ≤Ë®≠ÂÆöÈÖçÂàó
 
-	SFilePath			m_szBackImgPath;				//!< îwåiâÊëú
-	EBackgroundImagePos m_backImgPos;					//!< îwåiâÊëúï\é¶à íu
-	bool				m_backImgRepeatX;				//!< îwåiâÊëúï\é¶â°ï˚å¸åJÇËï‘Çµ
-	bool				m_backImgRepeatY;				//!< îwåiâÊëúï\é¶ècï˚å¸åJÇËï‘Çµ
-	bool				m_backImgScrollX;				//!< îwåiâÊëúï\é¶â°ï˚å¸ÉXÉNÉçÅ[Éã
-	bool				m_backImgScrollY;				//!< îwåiâÊëúï\é¶ècï˚å¸ÉXÉNÉçÅ[Éã
-	POINT				m_backImgPosOffset;				//!< îwåiâÊëúï\é¶ÉIÉtÉZÉbÉg
+	SFilePath			m_szBackImgPath;				//!< ËÉåÊôØÁîªÂÉè
+	EBackgroundImagePos m_backImgPos;					//!< ËÉåÊôØÁîªÂÉèË°®Á§∫‰ΩçÁΩÆ
+	bool				m_backImgRepeatX;				//!< ËÉåÊôØÁîªÂÉèË°®Á§∫Ê®™ÊñπÂêëÁπ∞„ÇäËøî„Åó
+	bool				m_backImgRepeatY;				//!< ËÉåÊôØÁîªÂÉèË°®Á§∫Á∏¶ÊñπÂêëÁπ∞„ÇäËøî„Åó
+	bool				m_backImgScrollX;				//!< ËÉåÊôØÁîªÂÉèË°®Á§∫Ê®™ÊñπÂêë„Çπ„ÇØ„É≠„Éº„É´
+	bool				m_backImgScrollY;				//!< ËÉåÊôØÁîªÂÉèË°®Á§∫Á∏¶ÊñπÂêë„Çπ„ÇØ„É≠„Éº„É´
+	POINT				m_backImgPosOffset;				//!< ËÉåÊôØÁîªÂÉèË°®Á§∫„Ç™„Éï„Çª„ÉÉ„Éà
 
-	bool				m_bLineNumIsCRLF;				//!< çsî‘çÜÇÃï\é¶ false=ê‹ÇËï‘ÇµíPà Å^true=â¸çsíPà 
-	int					m_nLineTermType;				//!< çsî‘çÜãÊêÿÇË  0=Ç»Çµ 1=ècê¸ 2=îCà”
-	wchar_t				m_cLineTermChar;				//!< çsî‘çÜãÊêÿÇËï∂éö
-	CKetaXInt			m_nVertLineIdx[MAX_VERTLINES];	//!< éwíËåÖècê¸
-	int 				m_nNoteLineOffset;				//!< ÉmÅ[Égê¸ÇÃÉIÉtÉZÉbÉg
+	bool				m_bLineNumIsCRLF;				//!< Ë°åÁï™Âè∑„ÅÆË°®Á§∫ false=Êäò„ÇäËøî„ÅóÂçò‰ΩçÔºètrue=ÊîπË°åÂçò‰Ωç
+	int					m_nLineTermType;				//!< Ë°åÁï™Âè∑Âå∫Âàá„Çä  0=„Å™„Åó 1=Á∏¶Á∑ö 2=‰ªªÊÑè
+	wchar_t				m_cLineTermChar;				//!< Ë°åÁï™Âè∑Âå∫Âàá„ÇäÊñáÂ≠ó
+	CKetaXInt			m_nVertLineIdx[MAX_VERTLINES];	//!< ÊåáÂÆöÊ°ÅÁ∏¶Á∑ö
+	int 				m_nNoteLineOffset;				//!< „Éé„Éº„ÉàÁ∑ö„ÅÆ„Ç™„Éï„Çª„ÉÉ„Éà
 
-	bool				m_bWordWrap;					//!< âpï∂ÉèÅ[ÉhÉâÉbÉvÇÇ∑ÇÈ
-	bool				m_bKinsokuHead;					//!< çsì™ã÷ë•ÇÇ∑ÇÈ		//@@@ 2002.04.08 MIK
-	bool				m_bKinsokuTail;					//!< çsññã÷ë•ÇÇ∑ÇÈ		//@@@ 2002.04.08 MIK
-	bool				m_bKinsokuRet;					//!< â¸çsï∂éöÇÃÇ‘ÇÁâ∫Ç∞	//@@@ 2002.04.13 MIK
-	bool				m_bKinsokuKuto;					//!< ãÂì«ì_ÇÃÇ‘ÇÁÇ≥Ç∞	//@@@ 2002.04.17 MIK
-	bool				m_bKinsokuHide;					//!< Ç‘ÇÁâ∫Ç∞ÇâBÇ∑		// 2011/11/30 Uchi
-	wchar_t				m_szKinsokuHead[200];			//!< çsì™ã÷ë•ï∂éö	//@@@ 2002.04.08 MIK
-	wchar_t				m_szKinsokuTail[200];			//!< çsì™ã÷ë•ï∂éö	//@@@ 2002.04.08 MIK
-	wchar_t				m_szKinsokuKuto[200];			//!< ãÂì«ì_Ç‘ÇÁÇ≥Ç∞ï∂éö	// 2009.08.07 ryoji
+	bool				m_bWordWrap;					//!< Ëã±Êñá„ÉØ„Éº„Éâ„É©„ÉÉ„Éó„Çí„Åô„Çã
+	bool				m_bKinsokuHead;					//!< Ë°åÈ†≠Á¶ÅÂâá„Çí„Åô„Çã		//@@@ 2002.04.08 MIK
+	bool				m_bKinsokuTail;					//!< Ë°åÊú´Á¶ÅÂâá„Çí„Åô„Çã		//@@@ 2002.04.08 MIK
+	bool				m_bKinsokuRet;					//!< ÊîπË°åÊñáÂ≠ó„ÅÆ„Å∂„Çâ‰∏ã„Åí	//@@@ 2002.04.13 MIK
+	bool				m_bKinsokuKuto;					//!< Âè•Ë™≠ÁÇπ„ÅÆ„Å∂„Çâ„Åï„Åí	//@@@ 2002.04.17 MIK
+	bool				m_bKinsokuHide;					//!< „Å∂„Çâ‰∏ã„Åí„ÇíÈö†„Åô		// 2011/11/30 Uchi
+	wchar_t				m_szKinsokuHead[200];			//!< Ë°åÈ†≠Á¶ÅÂâáÊñáÂ≠ó	//@@@ 2002.04.08 MIK
+	wchar_t				m_szKinsokuTail[200];			//!< Ë°åÈ†≠Á¶ÅÂâáÊñáÂ≠ó	//@@@ 2002.04.08 MIK
+	wchar_t				m_szKinsokuKuto[200];			//!< Âè•Ë™≠ÁÇπ„Å∂„Çâ„Åï„ÅíÊñáÂ≠ó	// 2009.08.07 ryoji
 
-	int					m_nCurrentPrintSetting;			//!< åªç›ëIëÇµÇƒÇ¢ÇÈàÛç¸ê›íË
+	int					m_nCurrentPrintSetting;			//!< ÁèæÂú®ÈÅ∏Êäû„Åó„Å¶„ÅÑ„ÇãÂç∞Âà∑Ë®≠ÂÆö
 
-	BOOL				m_bOutlineDockDisp;				//!< ÉAÉEÉgÉâÉCÉìâêÕï\é¶ÇÃóLñ≥
-	EDockSide			m_eOutlineDockSide;				//!< ÉAÉEÉgÉâÉCÉìâêÕÉhÉbÉLÉìÉOîzíu
-	int					m_cxOutlineDockLeft;			//!< ÉAÉEÉgÉâÉCÉìÇÃç∂ÉhÉbÉLÉìÉOïù
-	int					m_cyOutlineDockTop;				//!< ÉAÉEÉgÉâÉCÉìÇÃè„ÉhÉbÉLÉìÉOçÇ
-	int					m_cxOutlineDockRight;			//!< ÉAÉEÉgÉâÉCÉìÇÃâEÉhÉbÉLÉìÉOïù
-	int					m_cyOutlineDockBottom;			//!< ÉAÉEÉgÉâÉCÉìÇÃâ∫ÉhÉbÉLÉìÉOçÇ
-	int					m_nDockOutline;					//!< ÉhÉbÉLÉìÉOéûÇÃÉAÉEÉgÉâÉCÉì/ÉuÉbÉNÉ}Å[ÉN
-	EOutlineType		m_eDefaultOutline;				//!< ÉAÉEÉgÉâÉCÉìâêÕï˚ñ@
-	SFilePath			m_szOutlineRuleFilename;		//!< ÉAÉEÉgÉâÉCÉìâêÕÉãÅ[ÉãÉtÉ@ÉCÉã
-	int					m_nOutlineSortCol;				//!< ÉAÉEÉgÉâÉCÉìâêÕÉ\Å[ÉgóÒî‘çÜ
-	bool				m_bOutlineSortDesc;				//!< ÉAÉEÉgÉâÉCÉìâêÕÉ\Å[Égç~èá
-	int					m_nOutlineSortType;				//!< ÉAÉEÉgÉâÉCÉìâêÕÉ\Å[ÉgäÓèÄ
-	SFileTree			m_sFileTree;					/*!< ÉtÉ@ÉCÉãÉcÉäÅ[ê›íË */
+	BOOL				m_bOutlineDockDisp;				//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£ÊûêË°®Á§∫„ÅÆÊúâÁÑ°
+	EDockSide			m_eOutlineDockSide;				//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê„Éâ„ÉÉ„Ç≠„É≥„Ç∞ÈÖçÁΩÆ
+	int					m_cxOutlineDockLeft;			//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥„ÅÆÂ∑¶„Éâ„ÉÉ„Ç≠„É≥„Ç∞ÂπÖ
+	int					m_cyOutlineDockTop;				//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥„ÅÆ‰∏ä„Éâ„ÉÉ„Ç≠„É≥„Ç∞È´ò
+	int					m_cxOutlineDockRight;			//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥„ÅÆÂè≥„Éâ„ÉÉ„Ç≠„É≥„Ç∞ÂπÖ
+	int					m_cyOutlineDockBottom;			//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥„ÅÆ‰∏ã„Éâ„ÉÉ„Ç≠„É≥„Ç∞È´ò
+	int					m_nDockOutline;					//!< „Éâ„ÉÉ„Ç≠„É≥„Ç∞ÊôÇ„ÅÆ„Ç¢„Ç¶„Éà„É©„Ç§„É≥/„Éñ„ÉÉ„ÇØ„Éû„Éº„ÇØ
+	EOutlineType		m_eDefaultOutline;				//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£ÊûêÊñπÊ≥ï
+	SFilePath			m_szOutlineRuleFilename;		//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê„É´„Éº„É´„Éï„Ç°„Ç§„É´
+	int					m_nOutlineSortCol;				//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê„ÇΩ„Éº„ÉàÂàóÁï™Âè∑
+	bool				m_bOutlineSortDesc;				//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê„ÇΩ„Éº„ÉàÈôçÈ†Ü
+	int					m_nOutlineSortType;				//!< „Ç¢„Ç¶„Éà„É©„Ç§„É≥Ëß£Êûê„ÇΩ„Éº„ÉàÂü∫Ê∫ñ
+	SFileTree			m_sFileTree;					/*!< „Éï„Ç°„Ç§„É´„ÉÑ„É™„ÉºË®≠ÂÆö */
 
-	ESmartIndentType	m_eSmartIndent;					//!< ÉXÉ}Å[ÉgÉCÉìÉfÉìÉgéÌï 
-	bool				m_bIndentCppStringIgnore;		//!< C/C++ÉCÉìÉfÉìÉgÅFï∂éöóÒÇñ≥éãÇ∑ÇÈ
-	bool				m_bIndentCppCommentIgnore;		//!< C/C++ÉCÉìÉfÉìÉgÅFÉRÉÅÉìÉgÇñ≥éãÇ∑ÇÈ
-	bool				m_bIndentCppUndoSep;			//!< C/C++ÉCÉìÉfÉìÉgÅFUndoÉoÉbÉtÉ@Çï™ÇØÇÈ
-	int					m_nImeState;					//!< èâä˙IMEèÛë‘	Nov. 20, 2000 genta
+	ESmartIndentType	m_eSmartIndent;					//!< „Çπ„Éû„Éº„Éà„Ç§„É≥„Éá„É≥„ÉàÁ®ÆÂà•
+	bool				m_bIndentCppStringIgnore;		//!< C/C++„Ç§„É≥„Éá„É≥„ÉàÔºöÊñáÂ≠óÂàó„ÇíÁÑ°Ë¶ñ„Åô„Çã
+	bool				m_bIndentCppCommentIgnore;		//!< C/C++„Ç§„É≥„Éá„É≥„ÉàÔºö„Ç≥„É°„É≥„Éà„ÇíÁÑ°Ë¶ñ„Åô„Çã
+	bool				m_bIndentCppUndoSep;			//!< C/C++„Ç§„É≥„Éá„É≥„ÉàÔºöUndo„Éê„ÉÉ„Éï„Ç°„ÇíÂàÜ„Åë„Çã
+	int					m_nImeState;					//!< ÂàùÊúüIMEÁä∂ÊÖã	Nov. 20, 2000 genta
 
-	//	2001/06/14 asa-o ï‚äÆÇÃÉ^ÉCÉvï ê›íË
-	SFilePath			m_szHokanFile;					//!< ì¸óÕï‚äÆ íPåÍÉtÉ@ÉCÉã
-	int					m_nHokanType;					//!< ì¸óÕï‚äÆ éÌï (ÉvÉâÉOÉCÉì)
-	//	2003.06.23 Moca ÉtÉ@ÉCÉãì‡Ç©ÇÁÇÃì¸óÕï‚äÆã@î\
-	bool				m_bUseHokanByFile;				//!< ì¸óÕï‚äÆ äJÇ¢ÇƒÇ¢ÇÈÉtÉ@ÉCÉãì‡Ç©ÇÁåÛï‚ÇíTÇ∑
-	bool				m_bUseHokanByKeyword;			//!< ã≠í≤ÉLÅ[ÉèÅ[ÉhÇ©ÇÁì¸óÕï‚äÆ
+	//	2001/06/14 asa-o Ë£úÂÆå„ÅÆ„Çø„Ç§„ÉóÂà•Ë®≠ÂÆö
+	SFilePath			m_szHokanFile;					//!< ÂÖ•ÂäõË£úÂÆå ÂçòË™û„Éï„Ç°„Ç§„É´
+	int					m_nHokanType;					//!< ÂÖ•ÂäõË£úÂÆå Á®ÆÂà•(„Éó„É©„Ç∞„Ç§„É≥)
+	//	2003.06.23 Moca „Éï„Ç°„Ç§„É´ÂÜÖ„Åã„Çâ„ÅÆÂÖ•ÂäõË£úÂÆåÊ©üËÉΩ
+	bool				m_bUseHokanByFile;				//!< ÂÖ•ÂäõË£úÂÆå Èñã„ÅÑ„Å¶„ÅÑ„Çã„Éï„Ç°„Ç§„É´ÂÜÖ„Åã„ÇâÂÄôË£ú„ÇíÊé¢„Åô
+	bool				m_bUseHokanByKeyword;			//!< Âº∑Ë™ø„Ç≠„Éº„ÉØ„Éº„Éâ„Åã„ÇâÂÖ•ÂäõË£úÂÆå
 	
 	//	2001/06/19 asa-o
-	bool				m_bHokanLoHiCase;				//!< ì¸óÕï‚äÆã@î\ÅFâpëÂï∂éöè¨ï∂éöÇìØàÍéãÇ∑ÇÈ
+	bool				m_bHokanLoHiCase;				//!< ÂÖ•ÂäõË£úÂÆåÊ©üËÉΩÔºöËã±Â§ßÊñáÂ≠óÂ∞èÊñáÂ≠ó„ÇíÂêå‰∏ÄË¶ñ„Åô„Çã
 
-	SFilePath			m_szExtHelp;					//!< äOïîÉwÉãÉvÇP
-	SFilePath			m_szExtHtmlHelp;				//!< äOïîHTMLÉwÉãÉv
-	bool				m_bHtmlHelpIsSingle;			//!< HtmlHelpÉrÉÖÅ[ÉAÇÕÇ–Ç∆Ç¬
+	SFilePath			m_szExtHelp;					//!< Â§ñÈÉ®„Éò„É´„ÉóÔºë
+	SFilePath			m_szExtHtmlHelp;				//!< Â§ñÈÉ®HTML„Éò„É´„Éó
+	bool				m_bHtmlHelpIsSingle;			//!< HtmlHelp„Éì„É•„Éº„Ç¢„ÅØ„Å≤„Å®„Å§
 
-	bool				m_bChkEnterAtEnd;				//!< ï€ë∂éûÇ…â¸çsÉRÅ[ÉhÇÃç¨ç›ÇåxçêÇ∑ÇÈ	2013/4/14 Uchi
+	bool				m_bChkEnterAtEnd;				//!< ‰øùÂ≠òÊôÇ„Å´ÊîπË°å„Ç≥„Éº„Éâ„ÅÆÊ∑∑Âú®„ÇíË≠¶Âëä„Åô„Çã	2013/4/14 Uchi
 
-	SEncodingConfig		m_encoding;						//!< ÉGÉìÉRÅ[ÉhÉIÉvÉVÉáÉì
+	SEncodingConfig		m_encoding;						//!< „Ç®„É≥„Ç≥„Éº„Éâ„Ç™„Éó„Ç∑„Éß„É≥
 
 
 //@@@ 2001.11.17 add start MIK
-	bool				m_bUseRegexKeyword;								//!< ê≥ãKï\åªÉLÅ[ÉèÅ[ÉhÇégÇ§Ç©
-	DWORD				m_nRegexKeyMagicNumber;							//!< ê≥ãKï\åªÉLÅ[ÉèÅ[ÉhçXêVÉ}ÉWÉbÉNÉiÉìÉoÅ[
-	RegexKeywordInfo	m_RegexKeywordArr[MAX_REGEX_KEYWORD];			//!< ê≥ãKï\åªÉLÅ[ÉèÅ[Éh
-	wchar_t				m_RegexKeywordList[MAX_REGEX_KEYWORDLISTLEN];	//!< ê≥ãKï\åªÉLÅ[ÉèÅ[Éh
+	bool				m_bUseRegexKeyword;								//!< Ê≠£Ë¶èË°®Áèæ„Ç≠„Éº„ÉØ„Éº„Éâ„Çí‰Ωø„ÅÜ„Åã
+	DWORD				m_nRegexKeyMagicNumber;							//!< Ê≠£Ë¶èË°®Áèæ„Ç≠„Éº„ÉØ„Éº„ÉâÊõ¥Êñ∞„Éû„Ç∏„ÉÉ„ÇØ„Éä„É≥„Éê„Éº
+	RegexKeywordInfo	m_RegexKeywordArr[MAX_REGEX_KEYWORD];			//!< Ê≠£Ë¶èË°®Áèæ„Ç≠„Éº„ÉØ„Éº„Éâ
+	wchar_t				m_RegexKeywordList[MAX_REGEX_KEYWORDLISTLEN];	//!< Ê≠£Ë¶èË°®Áèæ„Ç≠„Éº„ÉØ„Éº„Éâ
 //@@@ 2001.11.17 add end MIK
 
 //@@@ 2006.04.10 fon ADD-start
-	bool				m_bUseKeyWordHelp;				//!< ÉLÅ[ÉèÅ[Éhé´èëÉZÉåÉNÉgã@î\ÇégÇ§Ç©
-	int					m_nKeyHelpNum;					//!< ÉLÅ[ÉèÅ[Éhé´èëÇÃç˚êî
-	KeyHelpInfo			m_KeyHelpArr[MAX_KEYHELP_FILE];	//!< ÉLÅ[ÉèÅ[Éhé´èëÉtÉ@ÉCÉã
-	bool				m_bUseKeyHelpAllSearch;			//!< ÉqÉbÉgÇµÇΩéüÇÃé´èëÇ‡åüçı(&A)
-	bool				m_bUseKeyHelpKeyDisp;			//!< 1çsñ⁄Ç…ÉLÅ[ÉèÅ[ÉhÇ‡ï\é¶Ç∑ÇÈ(&W)
-	bool				m_bUseKeyHelpPrefix;			//!< ëIëîÕàÕÇ≈ëOï˚àÍívåüçı(&P)
-	EKeyHelpRMenuType	m_eKeyHelpRMenuShowType;		//!< âEÉNÉäÉbÉNÉÅÉjÉÖÅ[ï\é¶
+	bool				m_bUseKeyWordHelp;				//!< „Ç≠„Éº„ÉØ„Éº„ÉâËæûÊõ∏„Çª„É¨„ÇØ„ÉàÊ©üËÉΩ„Çí‰Ωø„ÅÜ„Åã
+	int					m_nKeyHelpNum;					//!< „Ç≠„Éº„ÉØ„Éº„ÉâËæûÊõ∏„ÅÆÂÜäÊï∞
+	KeyHelpInfo			m_KeyHelpArr[MAX_KEYHELP_FILE];	//!< „Ç≠„Éº„ÉØ„Éº„ÉâËæûÊõ∏„Éï„Ç°„Ç§„É´
+	bool				m_bUseKeyHelpAllSearch;			//!< „Éí„ÉÉ„Éà„Åó„ÅüÊ¨°„ÅÆËæûÊõ∏„ÇÇÊ§úÁ¥¢(&A)
+	bool				m_bUseKeyHelpKeyDisp;			//!< 1Ë°åÁõÆ„Å´„Ç≠„Éº„ÉØ„Éº„Éâ„ÇÇË°®Á§∫„Åô„Çã(&W)
+	bool				m_bUseKeyHelpPrefix;			//!< ÈÅ∏ÊäûÁØÑÂõ≤„ÅßÂâçÊñπ‰∏ÄËá¥Ê§úÁ¥¢(&P)
+	EKeyHelpRMenuType	m_eKeyHelpRMenuShowType;		//!< Âè≥„ÇØ„É™„ÉÉ„ÇØ„É°„Éã„É•„ÉºË°®Á§∫
 //@@@ 2006.04.10 fon ADD-end
 
-	//	2002/04/30 YAZAKI CommonÇ©ÇÁà⁄ìÆÅB
-	bool				m_bAutoIndent;					//!< ÉIÅ[ÉgÉCÉìÉfÉìÉg
-	bool				m_bAutoIndent_ZENSPACE;			//!< ì˙ñ{åÍãÛîíÇ‡ÉCÉìÉfÉìÉg
-	bool				m_bRTrimPrevLine;				//!< 2005.10.11 ryoji â¸çséûÇ…ññîˆÇÃãÛîíÇçÌèú
-	int					m_nIndentLayout;				//!< ê‹ÇËï‘ÇµÇÕ2çsñ⁄à»ç~Çéöâ∫Ç∞ï\é¶
+	//	2002/04/30 YAZAKI Common„Åã„ÇâÁßªÂãï„ÄÇ
+	bool				m_bAutoIndent;					//!< „Ç™„Éº„Éà„Ç§„É≥„Éá„É≥„Éà
+	bool				m_bAutoIndent_ZENSPACE;			//!< Êó•Êú¨Ë™ûÁ©∫ÁôΩ„ÇÇ„Ç§„É≥„Éá„É≥„Éà
+	bool				m_bRTrimPrevLine;				//!< 2005.10.11 ryoji ÊîπË°åÊôÇ„Å´Êú´Â∞æ„ÅÆÁ©∫ÁôΩ„ÇíÂâäÈô§
+	int					m_nIndentLayout;				//!< Êäò„ÇäËøî„Åó„ÅØ2Ë°åÁõÆ‰ª•Èôç„ÇíÂ≠ó‰∏ã„ÅíË°®Á§∫
 
 	//	Sep. 10, 2002 genta
-	bool				m_bUseDocumentIcon;				//!< ÉtÉ@ÉCÉãÇ…ä÷òAÇ√ÇØÇÁÇÍÇΩÉAÉCÉRÉìÇégÇ§
+	bool				m_bUseDocumentIcon;				//!< „Éï„Ç°„Ç§„É´„Å´Èñ¢ÈÄ£„Å•„Åë„Çâ„Çå„Åü„Ç¢„Ç§„Ç≥„É≥„Çí‰Ωø„ÅÜ
 
-	bool				m_bUseTypeFont;					//!< É^ÉCÉvï ÉtÉHÉìÉgÇÃégóp
-	LOGFONT				m_lf;							//!< ÉtÉHÉìÉg // 2013.03.18 aroka
-	INT					m_nPointSize;					//!< ÉtÉHÉìÉgÉTÉCÉYÅi1/10É|ÉCÉìÉgíPà Åj
+	bool				m_bUseTypeFont;					//!< „Çø„Ç§„ÉóÂà•„Éï„Ç©„É≥„Éà„ÅÆ‰ΩøÁî®
+	LOGFONT				m_lf;							//!< „Éï„Ç©„É≥„Éà // 2013.03.18 aroka
+	INT					m_nPointSize;					//!< „Éï„Ç©„É≥„Éà„Çµ„Ç§„Ç∫Ôºà1/10„Éù„Ç§„É≥„ÉàÂçò‰ΩçÔºâ
 
 	STypeConfig()
-	: m_nMaxLineKetas(10) //	âÊñ ê‹ÇËï‘ÇµïùÇ™TABïùà»â∫Ç…Ç»ÇÁÇ»Ç¢Ç±Ç∆Çèâä˙ílÇ≈Ç‡ï€èÿÇ∑ÇÈ	//	2004.04.03 Moca
+	: m_nMaxLineKetas(10) //	ÁîªÈù¢Êäò„ÇäËøî„ÅóÂπÖ„ÅåTABÂπÖ‰ª•‰∏ã„Å´„Å™„Çâ„Å™„ÅÑ„Åì„Å®„ÇíÂàùÊúüÂÄ§„Åß„ÇÇ‰øùË®º„Åô„Çã	//	2004.04.03 Moca
 	{
 	}
 
-	int					m_nLineNumWidth;				//!< çsî‘çÜÇÃç≈è¨åÖêî 2014.08.02 katze
+	int					m_nLineNumWidth;				//!< Ë°åÁï™Âè∑„ÅÆÊúÄÂ∞èÊ°ÅÊï∞ 2014.08.02 katze
 }; /* STypeConfig */
 
-//! É^ÉCÉvï ê›íË(mini)
+//! „Çø„Ç§„ÉóÂà•Ë®≠ÂÆö(mini)
 struct STypeConfigMini
 {
 	int					m_id;
-	TCHAR				m_szTypeName[MAX_TYPES_NAME];	//!< É^ÉCÉvëÆê´ÅFñºèÃ
-	TCHAR				m_szTypeExts[MAX_TYPES_EXTS];	//!< É^ÉCÉvëÆê´ÅFägí£éqÉäÉXÉg
-	SEncodingConfig		m_encoding;						//!< ÉGÉìÉRÅ[ÉhÉIÉvÉVÉáÉì
+	TCHAR				m_szTypeName[MAX_TYPES_NAME];	//!< „Çø„Ç§„ÉóÂ±ûÊÄßÔºöÂêçÁß∞
+	TCHAR				m_szTypeExts[MAX_TYPES_EXTS];	//!< „Çø„Ç§„ÉóÂ±ûÊÄßÔºöÊã°ÂºµÂ≠ê„É™„Çπ„Éà
+	SEncodingConfig		m_encoding;						//!< „Ç®„É≥„Ç≥„Éº„Éâ„Ç™„Éó„Ç∑„Éß„É≥
 };
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                   É^ÉCÉvï ê›íËÉAÉNÉZÉT                      //
+//                   „Çø„Ç§„ÉóÂà•Ë®≠ÂÆö„Ç¢„ÇØ„Çª„Çµ                      //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//!ÉhÉLÉÖÉÅÉìÉgéÌóﬁÅBã§óLÉfÅ[É^ì‡ STypeConfig Ç÷ÇÃÉAÉNÉZÉTÇ‡åìÇÀÇÈÅB
-//2007.12.13 kobake çÏê¨
+//!„Éâ„Ç≠„É•„É°„É≥„ÉàÁ®ÆÈ°û„ÄÇÂÖ±Êúâ„Éá„Éº„ÇøÂÜÖ STypeConfig „Å∏„ÅÆ„Ç¢„ÇØ„Çª„Çµ„ÇÇÂÖº„Å≠„Çã„ÄÇ
+//2007.12.13 kobake ‰ΩúÊàê
 class CTypeConfig{
 public:
 	CTypeConfig()
 	{
 #ifdef _DEBUG
-		//å≥Ç™intÇæÇ¡ÇΩÇÃÇ≈ÅAñ¢èâä˙âªÇ≈égÇ§Ç∆ñ‚ëËÇ™î≠ê∂Ç∑ÇÈÇÊÇ§Ç…ÅAÇ†Ç¶ÇƒÅAïœÇ»ílÇì¸ÇÍÇƒÇ®Ç≠ÅB
+		//ÂÖÉ„Ååint„Å†„Å£„Åü„ÅÆ„Åß„ÄÅÊú™ÂàùÊúüÂåñ„Åß‰Ωø„ÅÜ„Å®ÂïèÈ°å„ÅåÁô∫Áîü„Åô„Çã„Çà„ÅÜ„Å´„ÄÅ„ÅÇ„Åà„Å¶„ÄÅÂ§â„Å™ÂÄ§„ÇíÂÖ•„Çå„Å¶„Åä„Åè„ÄÇ
 		m_nType = 1234;
 #else
-		//ÉäÉäÅ[ÉXéûÇÕÅAñ¢èâä˙âªÇ≈Ç‡ñ‚ëËÇ™ãNÇ±ÇËÇ…Ç≠Ç¢ÇÊÇ§Ç…ÅAÉ[ÉçÉNÉäÉAÇµÇƒÇ®Ç≠
+		//„É™„É™„Éº„ÇπÊôÇ„ÅØ„ÄÅÊú™ÂàùÊúüÂåñ„Åß„ÇÇÂïèÈ°å„ÅåËµ∑„Åì„Çä„Å´„Åè„ÅÑ„Çà„ÅÜ„Å´„ÄÅ„Çº„É≠„ÇØ„É™„Ç¢„Åó„Å¶„Åä„Åè
 		m_nType = 0;
 #endif
 	}
@@ -294,7 +294,7 @@ public:
 	bool IsValidType() const{ return m_nType>=0 && m_nType<MAX_TYPES; }
 	int GetIndex() const{ /*assert(IsValid());*/ return m_nType; }
 
-	//ã§óLÉfÅ[É^Ç÷ÇÃä»à’ÉAÉNÉZÉT
+	//ÂÖ±Êúâ„Éá„Éº„Çø„Å∏„ÅÆÁ∞°Êòì„Ç¢„ÇØ„Çª„Çµ
 //	STypeConfig* operator->(){ return GetTypeConfig(); }
 //	STypeConfig* GetTypeConfig();
 private:
@@ -304,7 +304,7 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        É^ÉCÉvê›íË                           //
+//                        „Çø„Ç§„ÉóË®≠ÂÆö                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 class CType{
@@ -342,11 +342,11 @@ GEN_CTYPE(CType_Other)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         é¿ëïï‚èï                            //
+//                         ÂÆüË£ÖË£úÂä©                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /*!
-	ÉXÉyÅ[ÉXÇÃîªíË
+	„Çπ„Éö„Éº„Çπ„ÅÆÂà§ÂÆö
 */
 inline bool C_IsSpace( wchar_t c, bool bExtEol )
 {

--- a/sakura_core/types/CTypeSupport.cpp
+++ b/sakura_core/types/CTypeSupport.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/types/CTypeSupport.h
+++ b/sakura_core/types/CTypeSupport.h
@@ -1,4 +1,4 @@
-/*
+Ôªø/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -30,13 +30,13 @@
 #include "view/CViewFont.h"
 #include "view/colors/CColorStrategy.h"
 
-//2007.08.28 kobake í«â¡
-/*!É^ÉCÉvÉTÉ|Å[ÉgÉNÉâÉX
-	ç°ÇÃÇ∆Ç±ÇÎÉ^ÉCÉvï ê›íËÇÃêFèÓïÒéÊìæÇÃï‚èï
+//2007.08.28 kobake ËøΩÂä†
+/*!„Çø„Ç§„Éó„Çµ„Éù„Éº„Éà„ÇØ„É©„Çπ
+	‰ªä„ÅÆ„Å®„Åì„Çç„Çø„Ç§„ÉóÂà•Ë®≠ÂÆö„ÅÆËâ≤ÊÉÖÂ†±ÂèñÂæó„ÅÆË£úÂä©
 */
 class CTypeSupport{
 private:
-	static const COLORREF INVALID_COLOR=0xFFFFFFFF; //ñ≥å¯Ç»êFíËêî
+	static const COLORREF INVALID_COLOR=0xFFFFFFFF; //ÁÑ°Âäπ„Å™Ëâ≤ÂÆöÊï∞
 
 public:
 	CTypeSupport(const CEditView* pEditView, EColorIndexType eColorIdx)
@@ -58,33 +58,33 @@ public:
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           éÊìæ                              //
+	//                           ÂèñÂæó                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//!ëOåiêF(ï∂éöêF)
+	//!ÂâçÊôØËâ≤(ÊñáÂ≠óËâ≤)
 	COLORREF GetTextColor() const
 	{
 		return m_pColorInfoArr->m_sColorAttr.m_cTEXT;
 	}
 
-	//!îwåiêF
+	//!ËÉåÊôØËâ≤
 	COLORREF GetBackColor() const
 	{
 		return m_pColorInfoArr->m_sColorAttr.m_cBACK;
 	}
 
-	//!ï\é¶Ç∑ÇÈÇ©Ç«Ç§Ç©
+	//!Ë°®Á§∫„Åô„Çã„Åã„Å©„ÅÜ„Åã
 	bool IsDisp() const
 	{
 		return m_pColorInfoArr->m_bDisp;
 	}
 
-	//!ëæéöÇ©Ç«Ç§Ç©
+	//!Â§™Â≠ó„Åã„Å©„ÅÜ„Åã
 	bool IsBoldFont() const
 	{
 		return m_pColorInfoArr->m_sFontAttr.m_bBoldFont;
 	}
 
-	//!â∫ê¸ÇéùÇ¬Ç©Ç«Ç§Ç©
+	//!‰∏ãÁ∑ö„ÇíÊåÅ„Å§„Åã„Å©„ÅÜ„Åã
 	bool HasUnderLine() const
 	{
 		return m_pColorInfoArr->m_sFontAttr.m_bUnderLine;
@@ -97,7 +97,7 @@ public:
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ï`âÊ                              //
+	//                           ÊèèÁîª                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	void FillBack(CGraphics& gr,const RECT& rc)
 	{
@@ -105,7 +105,7 @@ public:
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ê›íË                              //
+	//                           Ë®≠ÂÆö                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	SFONT GetTypeFont()
 	{
@@ -122,11 +122,11 @@ public:
 
 		m_gr = &gr;
 
-		//ÉeÉLÉXÉgêF
+		//„ÉÜ„Ç≠„Çπ„ÉàËâ≤
 		gr.PushTextBackColor(GetBackColor());
 		gr.PushTextForeColor(GetTextColor());
 
-		//ÉtÉHÉìÉg
+		//„Éï„Ç©„É≥„Éà
 		gr.PushMyFont(GetTypeFont());
 	}
 	void RewindGraphicsState(CGraphics& gr)
@@ -145,7 +145,7 @@ private:
 	int						m_nColorIdx;
 	const ColorInfo*		m_pColorInfoArr;
 
-	CGraphics* m_gr;        //ê›íËÇïœçXÇµÇΩHDC
+	CGraphics* m_gr;        //Ë®≠ÂÆö„ÇíÂ§âÊõ¥„Åó„ÅüHDC
 };
 
 #endif /* SAKURA_CTYPESUPPORT_21FC7075_96B4_4572_BA60_A6550E11AC0B9_H_ */

--- a/sakura_core/types/CType_Asm.cpp
+++ b/sakura_core/types/CType_Asm.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -30,27 +30,27 @@
 #include "outline/CFuncInfoArr.h"
 #include "view/Colors/EColorIndexType.h"
 
-/* ƒAƒZƒ“ƒuƒ‰ */
+/* ã‚¢ã‚»ãƒ³ãƒ–ãƒ© */
 //	2004.05.01 MIK/genta
-//Mar. 10, 2001 JEPRO	”¼Šp”’l‚ğF•ª‚¯•\¦
+//Mar. 10, 2001 JEPRO	åŠè§’æ•°å€¤ã‚’è‰²åˆ†ã‘è¡¨ç¤º
 void CType_Asm::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£q
-	_tcscpy( pType->m_szTypeName, _T("ƒAƒZƒ“ƒuƒ‰") );
+	//åå‰ã¨æ‹¡å¼µå­
+	_tcscpy( pType->m_szTypeName, _T("ã‚¢ã‚»ãƒ³ãƒ–ãƒ©") );
 	_tcscpy( pType->m_szTypeExts, _T("asm") );
 
-	//İ’è
-	pType->m_cLineComment.CopyTo( 0, L";", -1 );			/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_eDefaultOutline = OUTLINE_ASM;					/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L";", -1 );			/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_eDefaultOutline = OUTLINE_ASM;					/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
 	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;
 }
 
 
 
-/*! ƒAƒZƒ“ƒuƒ‰ ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ
+/*! ã‚¢ã‚»ãƒ³ãƒ–ãƒ© ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ
 
 	@author MIK
-	@date 2004.04.12 ì‚è’¼‚µ
+	@date 2004.04.12 ä½œã‚Šç›´ã—
 */
 void CDocOutline::MakeTopicList_asm( CFuncInfoArr* pcFuncInfoArr )
 {
@@ -69,30 +69,30 @@ void CDocOutline::MakeTopicList_asm( CFuncInfoArr* pcFuncInfoArr )
 		int j;
 		WCHAR* p;
 
-		//1sæ“¾‚·‚éB
+		//1è¡Œå–å¾—ã™ã‚‹ã€‚
 		pLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLineCount)->GetDocLineStrWithEOL(&nLineLen);
 		if( pLine == NULL ) break;
 
-		//ì‹Æ—p‚ÉƒRƒs[‚ğì¬‚·‚éBƒoƒCƒiƒŠ‚ª‚ ‚Á‚½‚ç‚»‚ÌŒã‚ë‚Í’m‚ç‚È‚¢B
+		//ä½œæ¥­ç”¨ã«ã‚³ãƒ”ãƒ¼ã‚’ä½œæˆã™ã‚‹ã€‚ãƒã‚¤ãƒŠãƒªãŒã‚ã£ãŸã‚‰ãã®å¾Œã‚ã¯çŸ¥ã‚‰ãªã„ã€‚
 		pTmpLine = wcsdup( pLine );
 		if( pTmpLine == NULL ) break;
-		if( wcslen( pTmpLine ) >= (unsigned int)nLineLen ){	//ƒoƒCƒiƒŠ‚ğŠÜ‚ñ‚Å‚¢‚½‚ç’Z‚­‚È‚é‚Ì‚Å...
-			pTmpLine[ nLineLen ] = L'\0';	//w’è’·‚ÅØ‚è‹l‚ß
+		if( wcslen( pTmpLine ) >= (unsigned int)nLineLen ){	//ãƒã‚¤ãƒŠãƒªã‚’å«ã‚“ã§ã„ãŸã‚‰çŸ­ããªã‚‹ã®ã§...
+			pTmpLine[ nLineLen ] = L'\0';	//æŒ‡å®šé•·ã§åˆ‡ã‚Šè©°ã‚
 		}
 
-		//sƒRƒƒ“ƒgíœ
+		//è¡Œã‚³ãƒ¡ãƒ³ãƒˆå‰Šé™¤
 		p = wcsstr( pTmpLine, L";" );
 		if( p ) *p = L'\0';
 
 		length = wcslen( pTmpLine );
 		offset = 0;
 
-		//ƒg[ƒNƒ“‚É•ªŠ„
+		//ãƒˆãƒ¼ã‚¯ãƒ³ã«åˆ†å‰²
 		for( j = 0; j < MAX_ASM_TOKEN; j++ ) token[ j ] = NULL;
 		for( j = 0; j < MAX_ASM_TOKEN; j++ ){
 			token[ j ] = my_strtok<WCHAR>( pTmpLine, length, &offset, L" \t\r\n" );
 			if( token[ j ] == NULL ) break;
-			//ƒg[ƒNƒ“‚ÉŠÜ‚Ü‚ê‚é‚×‚«•¶š‚Å‚È‚¢‚©H
+			//ãƒˆãƒ¼ã‚¯ãƒ³ã«å«ã¾ã‚Œã‚‹ã¹ãæ–‡å­—ã§ãªã„ã‹ï¼Ÿ
 			if( wcsstr( token[ j ], L"\"") != NULL
 			 || wcsstr( token[ j ], L"\\") != NULL
 			 || wcsstr( token[ j ], L"'" ) != NULL ){
@@ -101,31 +101,31 @@ void CDocOutline::MakeTopicList_asm( CFuncInfoArr* pcFuncInfoArr )
 			}
 		}
 
-		if( token[ 0 ] != NULL ){	//ƒg[ƒNƒ“‚ª1ŒÂˆÈã‚ ‚é
+		if( token[ 0 ] != NULL ){	//ãƒˆãƒ¼ã‚¯ãƒ³ãŒ1å€‹ä»¥ä¸Šã‚ã‚‹
 			int nFuncId = -1;
 			WCHAR* entry_token = NULL;
 
 			length = wcslen( token[ 0 ] );
 			if( length >= 2
-			 && token[ 0 ][ length - 1 ] == L':' ){	//ƒ‰ƒxƒ‹
+			 && token[ 0 ][ length - 1 ] == L':' ){	//ãƒ©ãƒ™ãƒ«
 				token[ 0 ][ length - 1 ] = L'\0';
 				nFuncId = 51;
 				entry_token = token[ 0 ];
 			}
-			else if( token[ 1 ] != NULL ){	//ƒg[ƒNƒ“‚ª2ŒÂˆÈã‚ ‚é
-				if( wcsicmp( token[ 1 ], L"proc" ) == 0 ){	//ŠÖ”
+			else if( token[ 1 ] != NULL ){	//ãƒˆãƒ¼ã‚¯ãƒ³ãŒ2å€‹ä»¥ä¸Šã‚ã‚‹
+				if( wcsicmp( token[ 1 ], L"proc" ) == 0 ){	//é–¢æ•°
 					nFuncId = 50;
 					entry_token = token[ 0 ];
 				}else
-				if( wcsicmp( token[ 1 ], L"endp" ) == 0 ){	//ŠÖ”I—¹
+				if( wcsicmp( token[ 1 ], L"endp" ) == 0 ){	//é–¢æ•°çµ‚äº†
 					nFuncId = 52;
 					entry_token = token[ 0 ];
 				//}else
-				//if( my_stricmp( token[ 1 ], _T("macro") ) == 0 ){	//ƒ}ƒNƒ
+				//if( my_stricmp( token[ 1 ], _T("macro") ) == 0 ){	//ãƒã‚¯ãƒ­
 				//	nFuncId = -1;
 				//	entry_token = token[ 0 ];
 				//}else
-				//if( my_stricmp( token[ 1 ], _T("struc") ) == 0 ){	//\‘¢‘Ì
+				//if( my_stricmp( token[ 1 ], _T("struc") ) == 0 ){	//æ§‹é€ ä½“
 				//	nFuncId = -1;
 				//	entry_token = token[ 0 ];
 				}
@@ -133,10 +133,10 @@ void CDocOutline::MakeTopicList_asm( CFuncInfoArr* pcFuncInfoArr )
 
 			if( nFuncId >= 0 ){
 				/*
-				  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-				  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-				  ¨
-				  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+				  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+				  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+				  â†’
+				  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 				*/
 				CLayoutPoint ptPos;
 				m_pcDocRef->m_cLayoutMgr.LogicToLayout(

--- a/sakura_core/types/CType_Awk.cpp
+++ b/sakura_core/types/CType_Awk.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -28,14 +28,14 @@
 /* awk */
 void CType_Awk::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£Žq
+	//åå‰ã¨æ‹¡å¼µå­
 	_tcscpy( pType->m_szTypeName, _T("AWK") );
 	_tcscpy( pType->m_szTypeExts, _T("awk") );
 
-	//Ý’è
-	pType->m_cLineComment.CopyTo( 0, L"#", -1 );		/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_eDefaultOutline = OUTLINE_TEXT;			/* ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ•û–@ */
-	pType->m_nKeyWordSetIdx[0] = 6;						/* ƒL[ƒ[ƒhƒZƒbƒg */
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"#", -1 );		/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_eDefaultOutline = OUTLINE_TEXT;			/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžæ–¹æ³• */
+	pType->m_nKeyWordSetIdx[0] = 6;						/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
 }
 
 

--- a/sakura_core/types/CType_Basis.cpp
+++ b/sakura_core/types/CType_Basis.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -29,13 +29,13 @@
 
 void CType_Basis::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£Žq
-	_tcscpy( pType->m_szTypeName, _T("Šî–{") );
+	//åå‰ã¨æ‹¡å¼µå­
+	_tcscpy( pType->m_szTypeName, _T("åŸºæœ¬") );
 	_tcscpy( pType->m_szTypeExts, _T("") );
 
-	//Ý’è
-	pType->m_nMaxLineKetas = CKetaXInt(MAXLINEKETAS);			// Ü‚è•Ô‚µŒ…”
-	pType->m_eDefaultOutline = OUTLINE_TEXT;					// ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ•û–@
-	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	// ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ‚ðF•ª‚¯•\Ž¦‚µ‚È‚¢	//Oct. 17, 2000 JEPRO
-	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	// ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ‚ðF•ª‚¯•\Ž¦‚µ‚È‚¢	//Sept. 4, 2000 JEPRO
+	//è¨­å®š
+	pType->m_nMaxLineKetas = CKetaXInt(MAXLINEKETAS);			// æŠ˜ã‚Šè¿”ã—æ¡æ•°
+	pType->m_eDefaultOutline = OUTLINE_TEXT;					// ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžæ–¹æ³•
+	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	// ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„	//Oct. 17, 2000 JEPRO
+	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	// ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„	//Sept. 4, 2000 JEPRO
 }

--- a/sakura_core/types/CType_Cobol.cpp
+++ b/sakura_core/types/CType_Cobol.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -33,18 +33,18 @@
 /* COBOL */
 void CType_Cobol::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£q
+	//åå‰ã¨æ‹¡å¼µå­
 	_tcscpy( pType->m_szTypeName, _T("COBOL") );
-	_tcscpy( pType->m_szTypeExts, _T("cbl,cpy,pco,cob") );	//Jun. 04, 2001 JEPRO KENCH‚Ì•Œ¾‚É]‚¢’Ç‰Á
+	_tcscpy( pType->m_szTypeExts, _T("cbl,cpy,pco,cob") );	//Jun. 04, 2001 JEPRO KENCHæ°ã®åŠ©è¨€ã«å¾“ã„è¿½åŠ 
 
-	//İ’è
-	pType->m_cLineComment.CopyTo( 0, L"*", 6 );			//Jun. 02, 2001 JEPRO C³
-	pType->m_cLineComment.CopyTo( 1, L"D", 6 );			//Jun. 04, 2001 JEPRO ’Ç‰Á
-	pType->m_nStringType = STRING_LITERAL_PLSQL;							/* •¶š—ñ‹æØ‚è‹L†ƒGƒXƒP[ƒv•û–@  0=[\"][\'] 1=[""][''] */
-	wcscpy( pType->m_szIndentChars, L"*" );				/* ‚»‚Ì‘¼‚ÌƒCƒ“ƒfƒ“ƒg‘ÎÛ•¶š */
-	pType->m_nKeyWordSetIdx[0] = 3;						/* ƒL[ƒ[ƒhƒZƒbƒg */		//Jul. 10, 2001 JEPRO
-	pType->m_eDefaultOutline = OUTLINE_COBOL;			/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
-	// w’èŒ…cü	//2005.11.08 Moca
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"*", 6 );			//Jun. 02, 2001 JEPRO ä¿®æ­£
+	pType->m_cLineComment.CopyTo( 1, L"D", 6 );			//Jun. 04, 2001 JEPRO è¿½åŠ 
+	pType->m_nStringType = STRING_LITERAL_PLSQL;							/* æ–‡å­—åˆ—åŒºåˆ‡ã‚Šè¨˜å·ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—æ–¹æ³•  0=[\"][\'] 1=[""][''] */
+	wcscpy( pType->m_szIndentChars, L"*" );				/* ãã®ä»–ã®ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¯¾è±¡æ–‡å­— */
+	pType->m_nKeyWordSetIdx[0] = 3;						/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */		//Jul. 10, 2001 JEPRO
+	pType->m_eDefaultOutline = OUTLINE_COBOL;			/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
+	// æŒ‡å®šæ¡ç¸¦ç·š	//2005.11.08 Moca
 	pType->m_ColorInfoArr[COLORIDX_VERTLINE].m_bDisp = true;
 	pType->m_nVertLineIdx[0] = CKetaXInt(7);
 	pType->m_nVertLineIdx[1] = CKetaXInt(8);
@@ -55,7 +55,7 @@ void CType_Cobol::InitTypeConfigImp(STypeConfig* pType)
 
 
 
-/*! COBOL ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ */
+/*! COBOL ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ */
 void CDocOutline::MakeTopicList_cobol( CFuncInfoArr* pcFuncInfoArr )
 {
 	const wchar_t*	pLine;
@@ -79,11 +79,11 @@ void CDocOutline::MakeTopicList_cobol( CFuncInfoArr* pcFuncInfoArr )
 		if( NULL == pLine ){
 			break;
 		}
-		/* ƒRƒƒ“ƒgs‚© */
+		/* ã‚³ãƒ¡ãƒ³ãƒˆè¡Œã‹ */
 		if( 7 <= nLineLen && pLine[6] == L'*' ){
 			continue;
 		}
-		/* ƒ‰ƒxƒ‹s‚© */
+		/* ãƒ©ãƒ™ãƒ«è¡Œã‹ */
 		if( 8 <= nLineLen && pLine[7] != L' ' ){
 			k = 0;
 			for( i = 7; i < nLineLen; ){
@@ -124,10 +124,10 @@ void CDocOutline::MakeTopicList_cobol( CFuncInfoArr* pcFuncInfoArr )
 				continue;
 			}
 			/*
-			  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-			  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-			  ¨
-			  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+			  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+			  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+			  â†’
+			  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 			*/
 
 			CLayoutPoint ptPos;
@@ -146,7 +146,7 @@ void CDocOutline::MakeTopicList_cobol( CFuncInfoArr* pcFuncInfoArr )
 
 
 
-//Jul. 10, 2001 JEPRO ’Ç‰Á
+//Jul. 10, 2001 JEPRO è¿½åŠ 
 const wchar_t* g_ppszKeywordsCOBOL[] = {
 	L"ACCEPT",
 	L"ADD",

--- a/sakura_core/types/CType_CorbaIdl.cpp
+++ b/sakura_core/types/CType_CorbaIdl.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -32,7 +32,7 @@
 #include "view/CEditView.h"
 #include "view/colors/EColorIndexType.h"
 
-//!CPPƒL[ƒ[ƒh‚Ån‚Ü‚Á‚Ä‚¢‚ê‚Î true
+//!CPPã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã§å§‹ã¾ã£ã¦ã„ã‚Œã° true
 inline bool IsHeadCppKeyword(const wchar_t* pData)
 {
 	#define HEAD_EQ(DATA,LITERAL) (wcsncmp(DATA,LITERAL,_countof(LITERAL)-1)==0)
@@ -46,26 +46,26 @@ inline bool IsHeadCppKeyword(const wchar_t* pData)
 
 
 /* C/C++ */
-// Oct. 31, 2000 JEPRO VC++‚Ì¶¬‚·‚éƒeƒLƒXƒgƒtƒ@ƒCƒ‹‚à“Ç‚ß‚é‚æ‚¤‚É‚·‚é
-// Jan. 24, 2004 genta ŠÖ˜A‚Ã‚¯ãD‚Ü‚µ‚­‚È‚¢‚Ì‚Ådsw,dsp,dep,mak‚Í‚Í‚¸‚·
-//	2003.06.23 Moca ƒtƒ@ƒCƒ‹“à‚©‚ç‚Ì“ü—Í•âŠ®‹@”\
+// Oct. 31, 2000 JEPRO VC++ã®ç”Ÿæˆã™ã‚‹ãƒ†ã‚­ã‚¹ãƒˆãƒ•ã‚¡ã‚¤ãƒ«ã‚‚èª­ã‚ã‚‹ã‚ˆã†ã«ã™ã‚‹
+// Jan. 24, 2004 genta é–¢é€£ã¥ã‘ä¸Šå¥½ã¾ã—ããªã„ã®ã§dsw,dsp,dep,makã¯ã¯ãšã™
+//	2003.06.23 Moca ãƒ•ã‚¡ã‚¤ãƒ«å†…ã‹ã‚‰ã®å…¥åŠ›è£œå®Œæ©Ÿèƒ½
 void CType_Cpp::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£q
+	//åå‰ã¨æ‹¡å¼µå­
 	_tcscpy( pType->m_szTypeName, _T("C/C++") );
 	_tcscpy( pType->m_szTypeExts, _T("c,cpp,cxx,cc,cp,c++,h,hpp,hxx,hh,hp,h++,rc,hm") );
 
-	//İ’è
-	pType->m_cLineComment.CopyTo( 0, L"//", -1 );							/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_cBlockComments[0].SetBlockCommentRule( L"/*", L"*/" );			/* ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_cBlockComments[1].SetBlockCommentRule( L"#if 0", L"#endif" );	/* ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^2 */	//Jul. 11, 2001 JEPRO
-	pType->m_nKeyWordSetIdx[0] = 0;											/* ƒL[ƒ[ƒhƒZƒbƒg */
-	pType->m_eDefaultOutline = OUTLINE_C_CPP;									/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
-	pType->m_eSmartIndent = SMARTINDENT_CPP;								/* ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒgí•Ê */
-	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;					//”¼Šp”’l‚ğF•ª‚¯•\¦	//Mar. 10, 2001 JEPRO
-	pType->m_ColorInfoArr[COLORIDX_BRACKET_PAIR].m_bDisp = true;			//	Sep. 21, 2002 genta ‘ÎŠ‡ŒÊ‚Ì‹­’²‚ğƒfƒtƒHƒ‹ƒgON‚É
-	pType->m_bUseHokanByFile = true;										/*! “ü—Í•âŠ® ŠJ‚¢‚Ä‚¢‚éƒtƒ@ƒCƒ‹“à‚©‚çŒó•â‚ğ’T‚· */
-	pType->m_bStringLineOnly = true; // •¶š—ñ‚Ís“à‚Ì‚İ
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"//", -1 );							/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_cBlockComments[0].SetBlockCommentRule( L"/*", L"*/" );			/* ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_cBlockComments[1].SetBlockCommentRule( L"#if 0", L"#endif" );	/* ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿2 */	//Jul. 11, 2001 JEPRO
+	pType->m_nKeyWordSetIdx[0] = 0;											/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
+	pType->m_eDefaultOutline = OUTLINE_C_CPP;									/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
+	pType->m_eSmartIndent = SMARTINDENT_CPP;								/* ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆç¨®åˆ¥ */
+	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;					//åŠè§’æ•°å€¤ã‚’è‰²åˆ†ã‘è¡¨ç¤º	//Mar. 10, 2001 JEPRO
+	pType->m_ColorInfoArr[COLORIDX_BRACKET_PAIR].m_bDisp = true;			//	Sep. 21, 2002 genta å¯¾æ‹¬å¼§ã®å¼·èª¿ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆONã«
+	pType->m_bUseHokanByFile = true;										/*! å…¥åŠ›è£œå®Œ é–‹ã„ã¦ã„ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«å†…ã‹ã‚‰å€™è£œã‚’æ¢ã™ */
+	pType->m_bStringLineOnly = true; // æ–‡å­—åˆ—ã¯è¡Œå†…ã®ã¿
 }
 
 
@@ -74,7 +74,7 @@ void CType_Cpp::InitTypeConfigImp(STypeConfig* pType)
 
 
 /*!
-	ŠÖ”‚É—p‚¢‚é‚±‚Æ‚ª‚Å‚«‚é•¶š‚©‚Ç‚¤‚©‚Ì”»’è
+	é–¢æ•°ã«ç”¨ã„ã‚‹ã“ã¨ãŒã§ãã‚‹æ–‡å­—ã‹ã©ã†ã‹ã®åˆ¤å®š
 */
 inline bool C_IsWordChar( wchar_t c )
 {
@@ -92,23 +92,23 @@ inline bool C_IsWordChar( wchar_t c )
 
 //	From Here Apr. 1, 2001 genta
 /*!
-	“Áê‚ÈŠÖ”–¼ "operator" ‚©‚Ç‚¤‚©‚ğ”»’è‚·‚éB
+	ç‰¹æ®Šãªé–¢æ•°å "operator" ã‹ã©ã†ã‹ã‚’åˆ¤å®šã™ã‚‹ã€‚
 
-	•¶š—ñ‚ª"operator"‚»‚ê©g‚©A‚ ‚é‚¢‚Í::‚ÌŒã‚ë‚Éoperator‚Æ‘±‚¢‚Ä
-	I‚í‚Á‚Ä‚¢‚é‚Æ‚«‚Éoperator‚Æ”»’èB
+	æ–‡å­—åˆ—ãŒ"operator"ãã‚Œè‡ªèº«ã‹ã€ã‚ã‚‹ã„ã¯::ã®å¾Œã‚ã«operatorã¨ç¶šã„ã¦
+	çµ‚ã‚ã£ã¦ã„ã‚‹ã¨ãã«operatorã¨åˆ¤å®šã€‚
 
-	‰‰Zq‚Ì•]‰¿‡˜‚ğ•ÛØ‚·‚é‚½‚ß2‚Â‚Ìif•¶‚É•ª‚¯‚Ä‚ ‚é
+	æ¼”ç®—å­ã®è©•ä¾¡é †åºã‚’ä¿è¨¼ã™ã‚‹ãŸã‚2ã¤ã®ifæ–‡ã«åˆ†ã‘ã¦ã‚ã‚‹
 
-	@param szStr ”»’è‘ÎÛ‚Ì•¶š—ñ
-	@param nLen •¶š—ñ‚Ì’·‚³B
-	–{¿“I‚É‚Í•s—v‚Å‚ ‚é‚ªA‚‘¬‰»‚Ì‚½‚ß‚ÉŠù‚É‚ ‚é’l‚ğ—˜—p‚·‚éB
+	@param szStr åˆ¤å®šå¯¾è±¡ã®æ–‡å­—åˆ—
+	@param nLen æ–‡å­—åˆ—ã®é•·ã•ã€‚
+	æœ¬è³ªçš„ã«ã¯ä¸è¦ã§ã‚ã‚‹ãŒã€é«˜é€ŸåŒ–ã®ãŸã‚ã«æ—¢ã«ã‚ã‚‹å€¤ã‚’åˆ©ç”¨ã™ã‚‹ã€‚
 */
 static bool C_IsOperator( wchar_t* szStr, int nLen	)
 {
 	if( nLen >= 8 && szStr[ nLen - 1 ] == L'r' ){
 		if( nLen > 8 ?
-				wcscmp( szStr + nLen - 9, L":operator" ) == 0 :	// ƒƒ“ƒo[ŠÖ”‚É‚æ‚é’è‹`
-				wcscmp( szStr, L"operator" ) == 0	// friendŠÖ”‚É‚æ‚é’è‹`
+				wcscmp( szStr + nLen - 9, L":operator" ) == 0 :	// ãƒ¡ãƒ³ãƒãƒ¼é–¢æ•°ã«ã‚ˆã‚‹å®šç¾©
+				wcscmp( szStr, L"operator" ) == 0	// friendé–¢æ•°ã«ã‚ˆã‚‹å®šç¾©
 		 ){
 		 	return true;
 		}
@@ -118,9 +118,9 @@ static bool C_IsOperator( wchar_t* szStr, int nLen	)
 //	To Here Apr. 1, 2001 genta
 
 /*!
-	‰üs’¼‘O‚ğ \ ‚ÅƒGƒXƒP[ƒv‚µ‚Ä‚¢‚é‚©‚Ç‚¤‚©”»’è
+	æ”¹è¡Œç›´å‰ã‚’ \ ã§ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã—ã¦ã„ã‚‹ã‹ã©ã†ã‹åˆ¤å®š
 
-	@date 2005.12.06 ‚¶‚ã‚¤‚¶ ÅŒã‚Ì1•¶š‚µ‚©Œ©‚È‚¢‚Æ2ƒoƒCƒgƒR[ƒh‚ÌŒã”¼‚ªƒoƒbƒNƒXƒ‰ƒbƒVƒ…‚Ìê‡‚ÉŒë”F‚·‚é
+	@date 2005.12.06 ã˜ã‚…ã†ã˜ æœ€å¾Œã®1æ–‡å­—ã—ã‹è¦‹ãªã„ã¨2ãƒã‚¤ãƒˆã‚³ãƒ¼ãƒ‰ã®å¾ŒåŠãŒãƒãƒƒã‚¯ã‚¹ãƒ©ãƒƒã‚·ãƒ¥ã®å ´åˆã«èª¤èªã™ã‚‹
 */
 static bool C_IsLineEsc(const wchar_t *s, int len)
 {
@@ -133,7 +133,7 @@ static bool C_IsLineEsc(const wchar_t *s, int len)
 		} else if ( len == 2 ) {
 			if ( CNativeW::GetSizeOfChar( s, 2 , 0 ) == 1 )
 				return(true);
-		} else { //c‚è‚RƒoƒCƒgˆÈã
+		} else { //æ®‹ã‚Šï¼“ãƒã‚¤ãƒˆä»¥ä¸Š
 			if ( CNativeW::GetSizeOfChar( s, len , len-2 ) == 1 )
 				return(true);
 			if ( CNativeW::GetSizeOfChar( s, len , len-3 ) == 2 )
@@ -159,110 +159,110 @@ static bool CPP_IsFunctionAfterKeyword( const wchar_t* s )
 
 
 /*!
-	CƒvƒŠƒvƒƒZƒbƒT‚Ì #if/ifdef/ifndef - #else - #endifó‘ÔŠÇ—ƒNƒ‰ƒX
+	Cãƒ—ãƒªãƒ—ãƒ­ã‚»ãƒƒã‚µã® #if/ifdef/ifndef - #else - #endifçŠ¶æ…‹ç®¡ç†ã‚¯ãƒ©ã‚¹
 
-	ƒlƒXƒgƒŒƒxƒ‹‚Í32ƒŒƒxƒ‹=(sizeof(int) * 8)‚Ü‚Å
+	ãƒã‚¹ãƒˆãƒ¬ãƒ™ãƒ«ã¯32ãƒ¬ãƒ™ãƒ«=(sizeof(int) * 8)ã¾ã§
 	
-	@date 2007.12.15 genta : m_enablebuf‚Ì‰Šú’l‚ªˆ«‚³‚ğ‚·‚é‚±‚Æ‚ª‚ ‚é‚Ì‚Å0‚É
+	@date 2007.12.15 genta : m_enablebufã®åˆæœŸå€¤ãŒæ‚ªã•ã‚’ã™ã‚‹ã“ã¨ãŒã‚ã‚‹ã®ã§0ã«
 */
 
 class CCppPreprocessMng {
 public:
 	CCppPreprocessMng(void) :
-		// 2007.12.15 genta : m_bitpattern‚ğ0‚É‚µ‚È‚¢‚ÆC
-		// ‚¢‚«‚È‚è#else‚ªŒ»‚ê‚½‚Æ‚«‚Éƒpƒ^[ƒ“‚ª‚¨‚©‚µ‚­‚È‚é
+		// 2007.12.15 genta : m_bitpatternã‚’0ã«ã—ãªã„ã¨ï¼Œ
+		// ã„ããªã‚Š#elseãŒç¾ã‚ŒãŸã¨ãã«ãƒ‘ã‚¿ãƒ¼ãƒ³ãŒãŠã‹ã—ããªã‚‹
 		m_ismultiline( false ), m_maxnestlevel( 32 ), m_stackptr( 0 ), m_bitpattern( 0 ), m_enablebuf( 0 )
 	{}
 
 	CLogicInt ScanLine(const wchar_t*, CLogicInt);
 
 private:
-	bool m_ismultiline; //!< •¡”s‚ÌƒfƒBƒŒƒNƒeƒBƒu
-	int m_maxnestlevel;	//!< ƒlƒXƒgƒŒƒxƒ‹‚ÌÅ‘å’l
+	bool m_ismultiline; //!< è¤‡æ•°è¡Œã®ãƒ‡ã‚£ãƒ¬ã‚¯ãƒ†ã‚£ãƒ–
+	int m_maxnestlevel;	//!< ãƒã‚¹ãƒˆãƒ¬ãƒ™ãƒ«ã®æœ€å¤§å€¤
 
-	int m_stackptr;	//!< ƒlƒXƒgƒŒƒxƒ‹
+	int m_stackptr;	//!< ãƒã‚¹ãƒˆãƒ¬ãƒ™ãƒ«
 	/*!
-		ƒlƒXƒgƒŒƒxƒ‹‚É‘Î‰‚·‚éƒrƒbƒgƒpƒ^[ƒ“
+		ãƒã‚¹ãƒˆãƒ¬ãƒ™ãƒ«ã«å¯¾å¿œã™ã‚‹ãƒ“ãƒƒãƒˆãƒ‘ã‚¿ãƒ¼ãƒ³
 		
-		m_stackptr = n ‚ÌC‰º‚©‚ç(n-1)bit–Ú‚É1‚ª“ü‚Á‚Ä‚¢‚é
+		m_stackptr = n ã®æ™‚ï¼Œä¸‹ã‹ã‚‰(n-1)bitç›®ã«1ãŒå…¥ã£ã¦ã„ã‚‹
 	*/
 	unsigned int m_bitpattern;
-	unsigned int m_enablebuf;	//!< ˆ—‚Ì—L–³‚ğ•Û‘¶‚·‚éƒoƒbƒtƒ@
+	unsigned int m_enablebuf;	//!< å‡¦ç†ã®æœ‰ç„¡ã‚’ä¿å­˜ã™ã‚‹ãƒãƒƒãƒ•ã‚¡
 };
 
 /*!
-	CƒvƒŠƒvƒƒZƒbƒT‚Ì #if/ifdef/ifndef - #else - #endif‚ğŒ³‚É
-	ˆ—‚Ì•K—v«‚ğ”»’è‚·‚éD
+	Cãƒ—ãƒªãƒ—ãƒ­ã‚»ãƒƒã‚µã® #if/ifdef/ifndef - #else - #endifã‚’å…ƒã«
+	å‡¦ç†ã®å¿…è¦æ€§ã‚’åˆ¤å®šã™ã‚‹ï¼
 
-	—^‚¦‚ç‚ê‚½1s‚Ì•¶š—ñ‚ğæ“ª‚©‚ç‘–¸‚µCC/C++‚Å‚Ì‘–¸‚ª•K—v‚Èê‡‚Í
-	æ“ª‚Ì‹ó”’‚ğœ‚¢‚½ŠJnˆÊ’u‚ğC•s—v‚Èê‡‚Ílength‚ğ•Ô‚·D
-	ŒÄ‚Ño‚µ‘¤‚Å‚Í–ß‚è’l‚©‚ç‰ğÍ‚ğn‚ß‚é‚Ì‚ÅC
-	length‚ğ•Ô‚·‚±‚Æ‚Í‚·‚×‚Ä‹ó”’‚ÆŒ©‚È‚·‚±‚Æ‚É‚È‚éD
+	ä¸ãˆã‚‰ã‚ŒãŸ1è¡Œã®æ–‡å­—åˆ—ã‚’å…ˆé ­ã‹ã‚‰èµ°æŸ»ã—ï¼ŒC/C++ã§ã®èµ°æŸ»ãŒå¿…è¦ãªå ´åˆã¯
+	å…ˆé ­ã®ç©ºç™½ã‚’é™¤ã„ãŸé–‹å§‹ä½ç½®ã‚’ï¼Œä¸è¦ãªå ´åˆã¯lengthã‚’è¿”ã™ï¼
+	å‘¼ã³å‡ºã—å´ã§ã¯æˆ»ã‚Šå€¤ã‹ã‚‰è§£æã‚’å§‹ã‚ã‚‹ã®ã§ï¼Œ
+	lengthã‚’è¿”ã™ã“ã¨ã¯ã™ã¹ã¦ç©ºç™½ã¨è¦‹ãªã™ã“ã¨ã«ãªã‚‹ï¼
 
-	ƒlƒXƒg‚ÌÅ‘å‚ğ’´‚¦‚½ê‡‚É‚Í‹L‰¯ˆæ‚ª‚È‚¢‚½‚ß‚É”»’è‚Í•s‰Â”\‚Æ‚È‚é‚ªC
-	ƒlƒXƒgƒŒƒxƒ‹‚¾‚¯‚ÍŠÇ—‚·‚éD
+	ãƒã‚¹ãƒˆã®æœ€å¤§ã‚’è¶…ãˆãŸå ´åˆã«ã¯è¨˜æ†¶åŸŸãŒãªã„ãŸã‚ã«åˆ¤å®šã¯ä¸å¯èƒ½ã¨ãªã‚‹ãŒï¼Œ
+	ãƒã‚¹ãƒˆãƒ¬ãƒ™ãƒ«ã ã‘ã¯ç®¡ç†ã™ã‚‹ï¼
 
-	@param str		[in] 1s‚Ì•¶š—ñ
-	@param length	[in] •¶š—ñ’·
+	@param str		[in] 1è¡Œã®æ–‡å­—åˆ—
+	@param length	[in] æ–‡å­—åˆ—é•·
 
-	@return C‰ğÍŠJnˆÊ’uDˆ—•s—v‚Ìê‡‚Ílength(s––‚Ü‚ÅƒXƒLƒbƒv)D
+	@return Cè§£æé–‹å§‹ä½ç½®ï¼å‡¦ç†ä¸è¦ã®å ´åˆã¯length(è¡Œæœ«ã¾ã§ã‚¹ã‚­ãƒƒãƒ—)ï¼
 	
-	@par elif‚Ìˆµ‚¢
-	if (A) elif (B) elif (C) else (D) endif‚Ì‚æ‚¤‚Èê‡‚É‚Í(A)-(D)‚Ì‚Ç‚ê‚©1‚Â
-	‚¾‚¯‚ªÀs‚³‚ê‚éD‚µ‚©‚µC‚»‚¤‚È‚é‚Æ1ƒrƒbƒg‚Å‚ÍŠÇ—‚Å‚«‚È‚¢‚µƒlƒXƒg‚ğ
-	ˆÍ‚Ş‚æ‚¤‚ÈƒP[ƒX‚Åelif‚ğg‚¤‚±‚Æ‚Í‚ ‚Ü‚è–³‚¢‚ÆŸè‚ÉŒˆ‚ß‚ÄŒ©‚È‚©‚Á‚½‚±‚Æ‚É‚·‚éD
+	@par elifã®æ‰±ã„
+	if (A) elif (B) elif (C) else (D) endifã®ã‚ˆã†ãªå ´åˆã«ã¯(A)-(D)ã®ã©ã‚Œã‹1ã¤
+	ã ã‘ãŒå®Ÿè¡Œã•ã‚Œã‚‹ï¼ã—ã‹ã—ï¼Œãã†ãªã‚‹ã¨1ãƒ“ãƒƒãƒˆã§ã¯ç®¡ç†ã§ããªã„ã—ãƒã‚¹ãƒˆã‚’
+	å›²ã‚€ã‚ˆã†ãªã‚±ãƒ¼ã‚¹ã§elifã‚’ä½¿ã†ã“ã¨ã¯ã‚ã¾ã‚Šç„¡ã„ã¨å‹æ‰‹ã«æ±ºã‚ã¦è¦‹ãªã‹ã£ãŸã“ã¨ã«ã™ã‚‹ï¼
 
 	@author genta
-	@date 2004.08.10 V‹Kì¬
-	@date 2004.08.13 zenryaku •¡”s‚ÌƒfƒBƒŒƒNƒeƒBƒu‚É‘Î‰
-	@date 2007.12.13 ‚¶‚ã‚¤‚¶ : if‚Ì’¼Œã‚ÉƒXƒy[ƒX‚ª‚È‚¢ê‡‚Ì‘Î‰
+	@date 2004.08.10 æ–°è¦ä½œæˆ
+	@date 2004.08.13 zenryaku è¤‡æ•°è¡Œã®ãƒ‡ã‚£ãƒ¬ã‚¯ãƒ†ã‚£ãƒ–ã«å¯¾å¿œ
+	@date 2007.12.13 ã˜ã‚…ã†ã˜ : ifã®ç›´å¾Œã«ã‚¹ãƒšãƒ¼ã‚¹ãŒãªã„å ´åˆã®å¯¾å¿œ
 
 */
 CLogicInt CCppPreprocessMng::ScanLine( const wchar_t* str, CLogicInt _length )
 {
 	int length=_length;
 
-	const wchar_t* lastptr = str + length;	//	ˆ—•¶š—ñ––”ö
-	const wchar_t* p;	//	ˆ—’†‚ÌˆÊ’u
+	const wchar_t* lastptr = str + length;	//	å‡¦ç†æ–‡å­—åˆ—æœ«å°¾
+	const wchar_t* p;	//	å‡¦ç†ä¸­ã®ä½ç½®
 	bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 
 	//	skip whitespace
 	for( p = str; C_IsSpace( *p, bExtEol ) && p < lastptr ; ++p )
 		;
 	if( lastptr <= p )
-		return CLogicInt(length);	//	‹ós‚Ì‚½‚ßˆ—•s—v
+		return CLogicInt(length);	//	ç©ºè¡Œã®ãŸã‚å‡¦ç†ä¸è¦
 
-	if(m_ismultiline){ // •¡”s‚ÌƒfƒBƒŒƒNƒeƒBƒu‚Í–³‹
-		m_ismultiline = C_IsLineEsc(str, length); // s––‚ª \ ‚ÅI‚í‚Á‚Ä‚¢‚È‚¢‚©
+	if(m_ismultiline){ // è¤‡æ•°è¡Œã®ãƒ‡ã‚£ãƒ¬ã‚¯ãƒ†ã‚£ãƒ–ã¯ç„¡è¦–
+		m_ismultiline = C_IsLineEsc(str, length); // è¡Œæœ«ãŒ \ ã§çµ‚ã‚ã£ã¦ã„ãªã„ã‹
 		return CLogicInt(length);
 	}
 
-	if( *p != L'#' ){	//	ƒvƒŠƒvƒƒZƒbƒTˆÈŠO‚Ìˆ—‚ÍƒƒCƒ“•”‚É”C‚¹‚é
+	if( *p != L'#' ){	//	ãƒ—ãƒªãƒ—ãƒ­ã‚»ãƒƒã‚µä»¥å¤–ã®å‡¦ç†ã¯ãƒ¡ã‚¤ãƒ³éƒ¨ã«ä»»ã›ã‚‹
 		if( m_enablebuf ){
-			return CLogicInt(length);	//	1ƒrƒbƒg‚Å‚à1‚Æ‚È‚Á‚Ä‚¢‚½‚ç–³‹
+			return CLogicInt(length);	//	1ãƒ“ãƒƒãƒˆã§ã‚‚1ã¨ãªã£ã¦ã„ãŸã‚‰ç„¡è¦–
 		}
 		return CLogicInt(p - str);
 	}
 
-	++p; // #‚ğƒXƒLƒbƒv
+	++p; // #ã‚’ã‚¹ã‚­ãƒƒãƒ—
 	
 	//	skip whitespace
 	for( ; C_IsSpace( *p, bExtEol ) && p < lastptr ; ++p )
 		;
 
-	//	‚±‚±‚©‚çPreprocessor directive‰ğÍ
+	//	ã“ã“ã‹ã‚‰Preprocessor directiveè§£æ
 	if( p + 2 + 2 < lastptr && wcsncmp_literal( p, L"if" ) == 0 ){
 		// if
 		p += 2;
 		
-		int enable = 0;	//	0: ˆ—‚µ‚È‚¢, 1: elseˆÈ~‚ª—LŒø, 2: Å‰‚ª—LŒø, 
+		int enable = 0;	//	0: å‡¦ç†ã—ãªã„, 1: elseä»¥é™ãŒæœ‰åŠ¹, 2: æœ€åˆãŒæœ‰åŠ¹, 
 		
-		//	if 0‚ÍÅ‰‚ª–³Œø•”•ª‚Æ‚İ‚È‚·D
-		//	‚»‚êˆÈŠO‚Ìif/ifdef/ifndef‚ÍÅ‰‚ª—LŒø•”•ª‚ÆŒ©‚È‚·
-		//	Å‰‚ÌğŒ‚É‚æ‚Á‚Ä‚±‚Ì“_‚Å‚Íp < lastptr‚È‚Ì‚Å”»’èÈ—ª
-		// 2007/12/13 ‚¶‚ã‚¤‚¶ : #if(0)‚ÆƒXƒy[ƒX‚ğ‹ó‚¯‚È‚¢ê‡‚Ì‘Î‰
+		//	if 0ã¯æœ€åˆãŒç„¡åŠ¹éƒ¨åˆ†ã¨ã¿ãªã™ï¼
+		//	ãã‚Œä»¥å¤–ã®if/ifdef/ifndefã¯æœ€åˆãŒæœ‰åŠ¹éƒ¨åˆ†ã¨è¦‹ãªã™
+		//	æœ€åˆã®æ¡ä»¶ã«ã‚ˆã£ã¦ã“ã®æ™‚ç‚¹ã§ã¯p < lastptrãªã®ã§åˆ¤å®šçœç•¥
+		// 2007/12/13 ã˜ã‚…ã†ã˜ : #if(0)ã¨ã‚¹ãƒšãƒ¼ã‚¹ã‚’ç©ºã‘ãªã„å ´åˆã®å¯¾å¿œ
 		if( C_IsSpace( *p, bExtEol ) || *p == L'(' ){
-			//	if 0 ƒ`ƒFƒbƒN
+			//	if 0 ãƒã‚§ãƒƒã‚¯
 			//	skip whitespace
 			//	2007.12.15 genta
 			for( ; ( C_IsSpace( *p, bExtEol ) || *p == L'(' ) && p < lastptr ; ++p )
@@ -280,7 +280,7 @@ CLogicInt CCppPreprocessMng::ScanLine( const wchar_t* str, CLogicInt _length )
 			enable = 2;
 		}
 		
-		//	•Û‘¶—Ìˆæ‚ÌŠm•Û‚Æƒrƒbƒgƒpƒ^[ƒ“‚Ìİ’è
+		//	ä¿å­˜é ˜åŸŸã®ç¢ºä¿ã¨ãƒ“ãƒƒãƒˆãƒ‘ã‚¿ãƒ¼ãƒ³ã®è¨­å®š
 		if( enable > 0 ){
 			m_bitpattern = 1 << m_stackptr;
 			++m_stackptr;
@@ -290,7 +290,7 @@ CLogicInt CCppPreprocessMng::ScanLine( const wchar_t* str, CLogicInt _length )
 		}
 	}
 	else if( p + 4 < lastptr && wcsncmp_literal( p, L"else" ) == 0 ){
-		//	2007.12.14 genta : #if‚ª–³‚­#else‚ªo‚½‚Æ‚«‚ÌƒK[ƒh’Ç‰Á
+		//	2007.12.14 genta : #ifãŒç„¡ã#elseãŒå‡ºãŸã¨ãã®ã‚¬ãƒ¼ãƒ‰è¿½åŠ 
 		if( 0 < m_stackptr && m_stackptr < m_maxnestlevel ){
 			m_enablebuf ^= m_bitpattern;
 		}
@@ -303,39 +303,39 @@ CLogicInt CCppPreprocessMng::ScanLine( const wchar_t* str, CLogicInt _length )
 		}
 	}
 	else{
-		m_ismultiline = C_IsLineEsc(str, length); // s––‚ª \ ‚ÅI‚í‚Á‚Ä‚¢‚È‚¢‚©
+		m_ismultiline = C_IsLineEsc(str, length); // è¡Œæœ«ãŒ \ ã§çµ‚ã‚ã£ã¦ã„ãªã„ã‹
 	}
 
-	return CLogicInt(length);	//	Šî–{“I‚ÉƒvƒŠƒvƒƒZƒbƒTw—ß‚Í–³‹
+	return CLogicInt(length);	//	åŸºæœ¬çš„ã«ãƒ—ãƒªãƒ—ãƒ­ã‚»ãƒƒã‚µæŒ‡ä»¤ã¯ç„¡è¦–
 }
 
 /*!
-	@brief C/C++ŠÖ”ƒŠƒXƒgì¬
+	@brief C/C++é–¢æ•°ãƒªã‚¹ãƒˆä½œæˆ
 
-	@param bVisibleMemberFunc ƒNƒ‰ƒXA\‘¢‘Ì’è‹`“à‚Ìƒƒ“ƒoŠÖ”‚ÌéŒ¾‚ğƒAƒEƒgƒ‰ƒCƒ“‰ğÍŒ‹‰Ê‚É“o˜^‚·‚éê‡‚Ítrue
+	@param bVisibleMemberFunc ã‚¯ãƒ©ã‚¹ã€æ§‹é€ ä½“å®šç¾©å†…ã®ãƒ¡ãƒ³ãƒé–¢æ•°ã®å®£è¨€ã‚’ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æçµæœã«ç™»éŒ²ã™ã‚‹å ´åˆã¯true
 
-	@par MODEˆê——
-	- 0	’Êí
-	- 20	Single quotation•¶š—ñ“Ç‚İ‚İ’†
-	- 21	Double quotation•¶š—ñ“Ç‚İ‚İ’†
-	- 8	ƒRƒƒ“ƒg“Ç‚İ‚İ’†
-	- 1	’PŒê“Ç‚İ‚İ’†
-	- 2	‹L†—ñ“Ç‚İ‚İ’†
-	- 999	’·‰ß‚¬‚é’PŒê–³‹’†
+	@par MODEä¸€è¦§
+	- 0	é€šå¸¸
+	- 20	Single quotationæ–‡å­—åˆ—èª­ã¿è¾¼ã¿ä¸­
+	- 21	Double quotationæ–‡å­—åˆ—èª­ã¿è¾¼ã¿ä¸­
+	- 8	ã‚³ãƒ¡ãƒ³ãƒˆèª­ã¿è¾¼ã¿ä¸­
+	- 1	å˜èªèª­ã¿è¾¼ã¿ä¸­
+	- 2	è¨˜å·åˆ—èª­ã¿è¾¼ã¿ä¸­
+	- 999	é•·éãã‚‹å˜èªç„¡è¦–ä¸­
 
 
-	@par FuncId‚Ì’l‚ÌˆÓ–¡
-	10‚ÌˆÊ‚Å–Ú“I•Ê‚Ég‚¢•ª‚¯‚Ä‚¢‚éDC/C++—p‚Í10ˆÊ‚ª0
-	- 1: éŒ¾
-	- 2: ’Êí‚ÌŠÖ” (’Ç‰Á•¶š—ñ–³‚µ)
-	- 3: ƒNƒ‰ƒX("ƒNƒ‰ƒX")
-	- 4: \‘¢‘Ì ("\‘¢‘Ì")
-	- 5: —ñ‹“‘Ì("—ñ‹“‘Ì")
-	- 6: ‹¤—p‘Ì("‹¤—p‘Ì")
-	- 7: –¼‘O‹óŠÔ("–¼‘O‹óŠÔ")
+	@par FuncIdã®å€¤ã®æ„å‘³
+	10ã®ä½ã§ç›®çš„åˆ¥ã«ä½¿ã„åˆ†ã‘ã¦ã„ã‚‹ï¼C/C++ç”¨ã¯10ä½ãŒ0
+	- 1: å®£è¨€
+	- 2: é€šå¸¸ã®é–¢æ•° (è¿½åŠ æ–‡å­—åˆ—ç„¡ã—)
+	- 3: ã‚¯ãƒ©ã‚¹("ã‚¯ãƒ©ã‚¹")
+	- 4: æ§‹é€ ä½“ ("æ§‹é€ ä½“")
+	- 5: åˆ—æŒ™ä½“("åˆ—æŒ™ä½“")
+	- 6: å…±ç”¨ä½“("å…±ç”¨ä½“")
+	- 7: åå‰ç©ºé–“("åå‰ç©ºé–“")
 
-	@param pcFuncInfoArr [out] ŠÖ”ˆê——‚ğ•Ô‚·‚½‚ß‚ÌƒNƒ‰ƒXB
-	‚±‚±‚ÉŠÖ”‚ÌƒŠƒXƒg‚ğ“o˜^‚·‚éB
+	@param pcFuncInfoArr [out] é–¢æ•°ä¸€è¦§ã‚’è¿”ã™ãŸã‚ã®ã‚¯ãƒ©ã‚¹ã€‚
+	ã“ã“ã«é–¢æ•°ã®ãƒªã‚¹ãƒˆã‚’ç™»éŒ²ã™ã‚‹ã€‚
 */
 void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOutlineType,
 	const TCHAR* pszFileName, bool bVisibleMemberFunc
@@ -347,7 +347,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 	const wchar_t*	pLine;
 	CLogicInt	nLineLen;
 	CLogicInt	i;
-	// 2015.11.14 C/C++‚Ìƒtƒ@ƒCƒ‹–¼‚É‚æ‚é”»’è
+	// 2015.11.14 C/C++ã®ãƒ•ã‚¡ã‚¤ãƒ«åã«ã‚ˆã‚‹åˆ¤å®š
 	if( nOutlineType == OUTLINE_C_CPP ){
 		if( CheckEXT( pszFileName, _T("c") ) ){
 			nOutlineType = OUTLINE_C;
@@ -366,95 +366,95 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 		}
 	}
 
-	// 2002/10/27 frozen@‚±‚±‚©‚ç
-	// nNestLevel‚ğ nNestLevel_global ‚ğ nNestLevel_func ‚É•ªŠ„‚µ‚½B
-	int			nNestLevel_global = 0;	// nNestLevel_global ŠÖ”ŠO‚Ì {}‚ÌƒŒƒxƒ‹  
-	int			nNestLevel_func   = 0;	//	nNestLevel_func ŠÖ”‚Ì’è‹`A‚¨‚æ‚ÑŠÖ”“à‚Ì	{}‚ÌƒŒƒxƒ‹
-//	int			nNestLevel2;			//	nNestLevel2	()‚É‘Î‚·‚éˆÊ’u // 2002/10/27 frozen nNastLevel_fparam‚ÆnMode2‚ÌM2_FUNC_NAME_END‚Å‘ã—p
-	int			nNestLevel_fparam = 0;	// ()‚ÌƒŒƒxƒ‹
-	int			nNestPoint_class = 0;	// ŠO‘¤‚©‚ç‰½”Ô–Ú‚Ì{‚ªƒNƒ‰ƒX‚Ì’è‹`‚ğˆÍ‚Ş{‚©H (ˆê”ÔŠO‘¤‚È‚ç1A0‚È‚ç–³‚µBbVisibleMemberFunc‚ªfalse‚Ì‚Ì‚İ—LŒøBtrue‚Å‚Íí‚É0)
-	// 2002/10/27 frozen@‚±‚±‚Ü‚Å
+	// 2002/10/27 frozenã€€ã“ã“ã‹ã‚‰
+	// nNestLevelã‚’ nNestLevel_global ã‚’ nNestLevel_func ã«åˆ†å‰²ã—ãŸã€‚
+	int			nNestLevel_global = 0;	// nNestLevel_global é–¢æ•°å¤–ã® {}ã®ãƒ¬ãƒ™ãƒ«  
+	int			nNestLevel_func   = 0;	//	nNestLevel_func é–¢æ•°ã®å®šç¾©ã€ãŠã‚ˆã³é–¢æ•°å†…ã®	{}ã®ãƒ¬ãƒ™ãƒ«
+//	int			nNestLevel2;			//	nNestLevel2	()ã«å¯¾ã™ã‚‹ä½ç½® // 2002/10/27 frozen nNastLevel_fparamã¨nMode2ã®M2_FUNC_NAME_ENDã§ä»£ç”¨
+	int			nNestLevel_fparam = 0;	// ()ã®ãƒ¬ãƒ™ãƒ«
+	int			nNestPoint_class = 0;	// å¤–å´ã‹ã‚‰ä½•ç•ªç›®ã®{ãŒã‚¯ãƒ©ã‚¹ã®å®šç¾©ã‚’å›²ã‚€{ã‹ï¼Ÿ (ä¸€ç•ªå¤–å´ãªã‚‰1ã€0ãªã‚‰ç„¡ã—ã€‚bVisibleMemberFuncãŒfalseã®æ™‚ã®ã¿æœ‰åŠ¹ã€‚trueã§ã¯å¸¸ã«0)
+	// 2002/10/27 frozenã€€ã“ã“ã¾ã§
 
-	bool bInInitList = false;	// 2010.07.08 ryoji ŠÖ”–¼’²¸‚ÌÛAŒ»İˆÊ’u‚ª‰Šú‰»ƒŠƒXƒgi':'ˆÈŒãj‚É“’B‚µ‚½‚©‚Ç‚¤‚©‚ğ¦‚·
-	int			nNestLevel_template = 0; // template<> func<vector<int>> ‚È‚Ç‚Ì<>‚Ì”
+	bool bInInitList = false;	// 2010.07.08 ryoji é–¢æ•°åèª¿æŸ»ã®éš›ã€ç¾åœ¨ä½ç½®ãŒåˆæœŸåŒ–ãƒªã‚¹ãƒˆï¼ˆ':'ä»¥å¾Œï¼‰ã«åˆ°é”ã—ãŸã‹ã©ã†ã‹ã‚’ç¤ºã™
+	int			nNestLevel_template = 0; // template<> func<vector<int>> ãªã©ã®<>ã®æ•°
 
-	wchar_t		szWordPrev[256];	//	1‚Â‘O‚Ìword
-	wchar_t		szWord[256];		//	Œ»İ‰ğ“Ç’†‚Ìword‚ğ“ü‚ê‚é‚Æ‚±‚ë
+	wchar_t		szWordPrev[256];	//	1ã¤å‰ã®word
+	wchar_t		szWord[256];		//	ç¾åœ¨è§£èª­ä¸­ã®wordã‚’å…¥ã‚Œã‚‹ã¨ã“ã‚
 	int			nWordIdx = 0;
-	int			nMaxWordLeng = 100;	//	‹–—e‚³‚ê‚éword‚ÌÅ‘å’·‚³
-	int			nMode;				//	Œ»İ‚Ìstate
+	int			nMaxWordLeng = 100;	//	è¨±å®¹ã•ã‚Œã‚‹wordã®æœ€å¤§é•·ã•
+	int			nMode;				//	ç¾åœ¨ã®state
 	/*
 		nMode
-		  0 : ‰Šú’l
-		  1 : ’PŒê“Ç‚İ‚İ’†
-		      szWord‚É’PŒê‚ğŠi”[
-		  2 : ‹L†—ñ
-		  8 : ƒuƒƒbƒNƒRƒƒ“ƒg’†
-		 10 : // ƒRƒƒ“ƒg’†
-		 20 : •¶š’è” ''
-		 21 : •¶š—ñ ""
-		999 : ’·‚¢’PŒê–³‹
+		  0 : åˆæœŸå€¤
+		  1 : å˜èªèª­ã¿è¾¼ã¿ä¸­
+		      szWordã«å˜èªã‚’æ ¼ç´
+		  2 : è¨˜å·åˆ—
+		  8 : ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆä¸­
+		 10 : // ã‚³ãƒ¡ãƒ³ãƒˆä¸­
+		 20 : æ–‡å­—å®šæ•° ''
+		 21 : æ–‡å­—åˆ— ""
+		999 : é•·ã„å˜èªç„¡è¦–
 	*/
 
-	// 2002/10/27 frozen@‚±‚±‚©‚ç
-	//! ó‘Ô2
+	// 2002/10/27 frozenã€€ã“ã“ã‹ã‚‰
+	//! çŠ¶æ…‹2
 	enum MODE2
 	{
-		M2_NORMAL			= 0x00,	//!< ’Êí
+		M2_NORMAL			= 0x00,	//!< é€šå¸¸
 		M2_ATTRIBUTE		= 0x02,	//!< C++/CLI attribute : 2007.05.26 genta
-		M2_TEMPLATE			= 0x03, //!< "template<" ‚ÅM2_TEMPLATE‚É‚È‚è '>' ‚ÅM2_NORMAL‚É–ß‚é
-		M2_NAMESPACE_SAVE	= 0x11,	//!< ƒl[ƒ€ƒXƒy[ƒX–¼’²¸’†
-			// u’Êívó‘Ô‚Å’PŒê "class" "struct" "union" "enum" "namespace", "__interface" ‚ğ“Ç‚İ‚Ş‚ÆA‚±‚Ìó‘Ô‚É‚È‚èA';' '{' ',' '>' '='‚ğ“Ç‚İ‚Ş‚Æu’Êív‚É‚È‚éB
-			//	2007.05.26 genta ƒL[ƒ[ƒh‚É__interface’Ç‰Á
+		M2_TEMPLATE			= 0x03, //!< "template<" ã§M2_TEMPLATEã«ãªã‚Š '>' ã§M2_NORMALã«æˆ»ã‚‹
+		M2_NAMESPACE_SAVE	= 0x11,	//!< ãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹åèª¿æŸ»ä¸­
+			// ã€Œé€šå¸¸ã€çŠ¶æ…‹ã§å˜èª "class" "struct" "union" "enum" "namespace", "__interface" ã‚’èª­ã¿è¾¼ã‚€ã¨ã€ã“ã®çŠ¶æ…‹ã«ãªã‚Šã€';' '{' ',' '>' '='ã‚’èª­ã¿è¾¼ã‚€ã¨ã€Œé€šå¸¸ã€ã«ãªã‚‹ã€‚
+			//	2007.05.26 genta ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã«__interfaceè¿½åŠ 
 			//
-			// ':' ‚ğ“Ç‚İ‚Ş‚Æuƒl[ƒ€ƒXƒy[ƒX–¼’²¸Š®—¹v‚ÖˆÚs‚·‚é‚Æ“¯‚É
-			// szWord‚ğszItemName‚É•Û‘¶‚µA‚ ‚Æ‚Å ':' –”‚Í '{' ‚Ì’¼‘O‚Ì’PŒê‚ª’²‚×‚ç‚ê‚é‚æ‚¤‚É‚µ‚Ä‚¢‚éB
-			// ‚±‚ê‚Í "__declspec( dllexport )"‚Ì‚æ‚¤‚É"class"‚ÆƒNƒ‰ƒX–¼‚ÌŠÔ‚ÉƒL[ƒ[ƒh‚ª‘‚¢‚Ä‚ ‚éê‡‚Å‚àƒNƒ‰ƒX–¼‚ğæ“¾‚Å‚«‚é‚æ‚¤‚É‚·‚é‚½‚ßB
+			// ':' ã‚’èª­ã¿è¾¼ã‚€ã¨ã€Œãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹åèª¿æŸ»å®Œäº†ã€ã¸ç§»è¡Œã™ã‚‹ã¨åŒæ™‚ã«
+			// szWordã‚’szItemNameã«ä¿å­˜ã—ã€ã‚ã¨ã§ ':' åˆã¯ '{' ã®ç›´å‰ã®å˜èªãŒèª¿ã¹ã‚‰ã‚Œã‚‹ã‚ˆã†ã«ã—ã¦ã„ã‚‹ã€‚
+			// ã“ã‚Œã¯ "__declspec( dllexport )"ã®ã‚ˆã†ã«"class"ã¨ã‚¯ãƒ©ã‚¹åã®é–“ã«ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãŒæ›¸ã„ã¦ã‚ã‚‹å ´åˆã§ã‚‚ã‚¯ãƒ©ã‚¹åã‚’å–å¾—ã§ãã‚‹ã‚ˆã†ã«ã™ã‚‹ãŸã‚ã€‚
 			//
-			// '<' ‚ğ“Ç‚İ‚Ş‚Æuƒeƒ“ƒvƒŒ[ƒgƒNƒ‰ƒX–¼’²¸’†v‚ÉˆÚs‚·‚éB
-		M2_TEMPLATE_SAVE	= 0x12, //!< ƒeƒ“ƒvƒŒ[ƒgƒNƒ‰ƒX–¼’²¸’†
-			// ';' '{'‚ğ“Ç‚İ‚Ş‚Æu’Êív‚É‚È‚éB
-			// ‚Ü‚½A‚±‚Ìó‘Ô‚ÌŠÔ‚Í’PŒê‚ğ‹æØ‚é•û–@‚ğˆê“I‚É•ÏX‚µA
-			// utemplate_name <paramA,paramB>v‚Ì‚æ‚¤‚È•¶š—ñ‚ğˆê‚Â‚Ì’PŒê‚ğ‚İ‚È‚·‚æ‚¤‚É‚·‚éB
-			// ‚±‚ê‚Í“Áê‰»‚µ‚½ƒNƒ‰ƒXƒeƒ“ƒvƒŒ[ƒg‚ğÀ‘•‚·‚éÛ‚Ì\•¶‚Å—LŒø‚É“­‚­B	
-		M2_NAMESPACE_END	= 0x13,	//!< ƒl[ƒ€ƒXƒy[ƒX–¼’²¸Š®—¹B(';' '{' ‚ğ“Ç‚İ‚ñ‚¾“_‚Åu’Êív‚É‚È‚éB )
-		M2_OPERATOR_WORD	= 0x14, //!< operator–¼’²¸’†Boperator‚Å '('‚ÅŸ‚É‘JˆÚ@template<> names::operator<T>(x)
-		M2_TEMPLATE_WORD	= 0x15, //!< ƒeƒ“ƒvƒŒ[ƒg“Áê‰»‚ğ’²¸’† func<int>()“™ '’PŒê <'‚ÅM2_TEMPLATE_WORD‚É‚È‚èA'>'(ƒlƒXƒg”F¯)‚ÅM2_NORMAL/M2_OPERATOR_WORD‚É–ß‚é
-		M2_FUNC_NAME_END	= 0x16, //!< ŠÖ”–¼’²¸Š®—¹B(';' '{' ‚ğ“Ç‚İ‚ñ‚¾“_‚Åu’Êív‚É‚È‚éB )
-		M2_AFTER_EQUAL		= 0x05,	//!< '='‚ÌŒãB
-			//u’Êív‚©‚Â nNestLevel_fparam==0 ‚Å'='‚ªŒ©‚Â‚©‚é‚Æ‚±‚Ìó‘Ô‚É‚È‚éBi‚½‚¾‚µ "opreator"‚Ì’¼Œã‚Íœ‚­j
-			// ';'‚ªŒ©‚Â‚©‚é‚Æu’Êív‚É–ß‚éB
+			// '<' ã‚’èª­ã¿è¾¼ã‚€ã¨ã€Œãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã‚¯ãƒ©ã‚¹åèª¿æŸ»ä¸­ã€ã«ç§»è¡Œã™ã‚‹ã€‚
+		M2_TEMPLATE_SAVE	= 0x12, //!< ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã‚¯ãƒ©ã‚¹åèª¿æŸ»ä¸­
+			// ';' '{'ã‚’èª­ã¿è¾¼ã‚€ã¨ã€Œé€šå¸¸ã€ã«ãªã‚‹ã€‚
+			// ã¾ãŸã€ã“ã®çŠ¶æ…‹ã®é–“ã¯å˜èªã‚’åŒºåˆ‡ã‚‹æ–¹æ³•ã‚’ä¸€æ™‚çš„ã«å¤‰æ›´ã—ã€
+			// ã€Œtemplate_name <paramA,paramB>ã€ã®ã‚ˆã†ãªæ–‡å­—åˆ—ã‚’ä¸€ã¤ã®å˜èªã‚’ã¿ãªã™ã‚ˆã†ã«ã™ã‚‹ã€‚
+			// ã“ã‚Œã¯ç‰¹æ®ŠåŒ–ã—ãŸã‚¯ãƒ©ã‚¹ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã‚’å®Ÿè£…ã™ã‚‹éš›ã®æ§‹æ–‡ã§æœ‰åŠ¹ã«åƒãã€‚	
+		M2_NAMESPACE_END	= 0x13,	//!< ãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹åèª¿æŸ»å®Œäº†ã€‚(';' '{' ã‚’èª­ã¿è¾¼ã‚“ã æ™‚ç‚¹ã§ã€Œé€šå¸¸ã€ã«ãªã‚‹ã€‚ )
+		M2_OPERATOR_WORD	= 0x14, //!< operatoråèª¿æŸ»ä¸­ã€‚operatorã§ '('ã§æ¬¡ã«é·ç§»ã€€template<> names::operator<T>(x)
+		M2_TEMPLATE_WORD	= 0x15, //!< ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆç‰¹æ®ŠåŒ–ã‚’èª¿æŸ»ä¸­ func<int>()ç­‰ 'å˜èª <'ã§M2_TEMPLATE_WORDã«ãªã‚Šã€'>'(ãƒã‚¹ãƒˆèªè­˜)ã§M2_NORMAL/M2_OPERATOR_WORDã«æˆ»ã‚‹
+		M2_FUNC_NAME_END	= 0x16, //!< é–¢æ•°åèª¿æŸ»å®Œäº†ã€‚(';' '{' ã‚’èª­ã¿è¾¼ã‚“ã æ™‚ç‚¹ã§ã€Œé€šå¸¸ã€ã«ãªã‚‹ã€‚ )
+		M2_AFTER_EQUAL		= 0x05,	//!< '='ã®å¾Œã€‚
+			//ã€Œé€šå¸¸ã€ã‹ã¤ nNestLevel_fparam==0 ã§'='ãŒè¦‹ã¤ã‹ã‚‹ã¨ã“ã®çŠ¶æ…‹ã«ãªã‚‹ã€‚ï¼ˆãŸã ã— "opreator"ã®ç›´å¾Œã¯é™¤ãï¼‰
+			// ';'ãŒè¦‹ã¤ã‹ã‚‹ã¨ã€Œé€šå¸¸ã€ã«æˆ»ã‚‹ã€‚
 			// int val=abs(-1);
-			// ‚Ì‚æ‚¤‚È•¶‚ªŠÖ”‚Æ‚İ‚È‚³‚ê‚È‚¢‚æ‚¤‚É‚·‚é‚½‚ß‚Ég—p‚·‚éB
-		M2_KR_FUNC	= 0x18,	//!< K&RƒXƒ^ƒCƒ‹/C++‚ÌŠÖ”’è‹`‚ğ’²¸‚·‚éBfunc() word ©word‚ª‚ ‚é‚Æ‘JˆÚ‚·‚é
+			// ã®ã‚ˆã†ãªæ–‡ãŒé–¢æ•°ã¨ã¿ãªã•ã‚Œãªã„ã‚ˆã†ã«ã™ã‚‹ãŸã‚ã«ä½¿ç”¨ã™ã‚‹ã€‚
+		M2_KR_FUNC	= 0x18,	//!< K&Rã‚¹ã‚¿ã‚¤ãƒ«/C++ã®é–¢æ•°å®šç¾©ã‚’èª¿æŸ»ã™ã‚‹ã€‚func() word â†wordãŒã‚ã‚‹ã¨é·ç§»ã™ã‚‹
 		M2_AFTER_ITEM		= 0x10,
 	} nMode2 = M2_NORMAL;
-	MODE2 nMode2Old = M2_NORMAL; // M2_TEMPLATE_WORD‚É‚È‚é’¼‘O‚ÌnMode2
+	MODE2 nMode2Old = M2_NORMAL; // M2_TEMPLATE_WORDã«ãªã‚‹ç›´å‰ã®nMode2
 	MODE2 nMode2AttOld = M2_NORMAL;
-	bool  bDefinedTypedef = false;	// typedef ‚ª‘‚©‚ê‚Ä‚¢‚éBtrue‚ÌŠÔ‚ÍŠÖ”–¼‚Æ‚µ‚Ä”F¯‚µ‚È‚¢B;‚Å•œ‹A‚·‚é
-	bool  bNoFunction = true; // fparam‚¾‚¯‚ÇŠÖ”’è‹`‚Å‚È‚¢‰Â”\«‚Ìê‡
+	bool  bDefinedTypedef = false;	// typedef ãŒæ›¸ã‹ã‚Œã¦ã„ã‚‹ã€‚trueã®é–“ã¯é–¢æ•°åã¨ã—ã¦èªè­˜ã—ãªã„ã€‚;ã§å¾©å¸°ã™ã‚‹
+	bool  bNoFunction = true; // fparamã ã‘ã©é–¢æ•°å®šç¾©ã§ãªã„å¯èƒ½æ€§ã®å ´åˆ
 
-	const int	nNamespaceNestMax	= 32;			//!< ƒlƒXƒg‰Â”\‚Èƒl[ƒ€ƒXƒy[ƒXAƒNƒ‰ƒX“™‚ÌÅ‘å”
-	int			nNamespaceLen[nNamespaceNestMax+1];	//!< ƒl[ƒ€ƒXƒy[ƒX‘S‘Ì‚Ì’·‚³
-	const int	nNamespaceLenMax 	= 512;			//!< Å‘å‚Ìƒl[ƒ€ƒXƒy[ƒX‘S‘Ì‚Ì’·‚³
-	wchar_t		szNamespace[nNamespaceLenMax];		//!< Œ»İ‚Ìƒl[ƒ€ƒXƒy[ƒX(I’[‚ª\0‚É‚È‚Á‚Ä‚¢‚é‚Æ‚ÍŒÀ‚ç‚È‚¢‚Ì‚Å’ˆÓ)
+	const int	nNamespaceNestMax	= 32;			//!< ãƒã‚¹ãƒˆå¯èƒ½ãªãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹ã€ã‚¯ãƒ©ã‚¹ç­‰ã®æœ€å¤§æ•°
+	int			nNamespaceLen[nNamespaceNestMax+1];	//!< ãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹å…¨ä½“ã®é•·ã•
+	const int	nNamespaceLenMax 	= 512;			//!< æœ€å¤§ã®ãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹å…¨ä½“ã®é•·ã•
+	wchar_t		szNamespace[nNamespaceLenMax];		//!< ç¾åœ¨ã®ãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹(çµ‚ç«¯ãŒ\0ã«ãªã£ã¦ã„ã‚‹ã¨ã¯é™ã‚‰ãªã„ã®ã§æ³¨æ„)
 	const int 	nItemNameLenMax	 	= 256;
-	wchar_t		szItemName[nItemNameLenMax];		//!< ‚·‚®‘O‚Ì ŠÖ”–¼ or ƒNƒ‰ƒX–¼ or \‘¢‘Ì–¼ or ‹¤—p‘Ì–¼ or —ñ‹“‘Ì–¼ or ƒl[ƒ€ƒXƒy[ƒX–¼
-	wchar_t		szTemplateName[nItemNameLenMax];		//!< ‚·‚®‘O‚Ì ŠÖ”–¼ or ƒNƒ‰ƒX–¼ or \‘¢‘Ì–¼ or ‹¤—p‘Ì–¼ or —ñ‹“‘Ì–¼ or ƒl[ƒ€ƒXƒy[ƒX–¼
-	// —á‚¦‚Î‰º‚ÌƒR[ƒh‚Ì©‚Ì•”•ª‚Å‚Ì
-	// szNamespace‚Í"Namespace\ClassName\"
-	// nMamespaceLen‚Í{10,20}
-	// nNestLevel_global‚Í2‚Æ‚È‚éB
+	wchar_t		szItemName[nItemNameLenMax];		//!< ã™ãå‰ã® é–¢æ•°å or ã‚¯ãƒ©ã‚¹å or æ§‹é€ ä½“å or å…±ç”¨ä½“å or åˆ—æŒ™ä½“å or ãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹å
+	wchar_t		szTemplateName[nItemNameLenMax];		//!< ã™ãå‰ã® é–¢æ•°å or ã‚¯ãƒ©ã‚¹å or æ§‹é€ ä½“å or å…±ç”¨ä½“å or åˆ—æŒ™ä½“å or ãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹å
+	// ä¾‹ãˆã°ä¸‹ã®ã‚³ãƒ¼ãƒ‰ã®â†ã®éƒ¨åˆ†ã§ã®
+	// szNamespaceã¯"Namespace\ClassName\"
+	// nMamespaceLenã¯{10,20}
+	// nNestLevel_globalã¯2ã¨ãªã‚‹ã€‚
 	//
-	//@namespace Namespace{
-	//@class ClassName{
-	//@©
-	//@}}
+	//ã€€namespace Namespace{
+	//ã€€class ClassName{
+	//ã€€â†
+	//ã€€}}
 	wchar_t		szRawStringTag[32];	// C++11 raw string litteral
 	int nRawStringTagLen = 0;
 	int nRawStringTagCompLen = 0;
 
-	CLogicInt	nItemLine(0);		//!< ‚·‚®‘O‚Ì ŠÖ” or ƒNƒ‰ƒX or \‘¢‘Ì or ‹¤—p‘Ì or —ñ‹“‘Ì or ƒl[ƒ€ƒXƒy[ƒX‚Ì‚ ‚és
+	CLogicInt	nItemLine(0);		//!< ã™ãå‰ã® é–¢æ•° or ã‚¯ãƒ©ã‚¹ or æ§‹é€ ä½“ or å…±ç”¨ä½“ or åˆ—æŒ™ä½“ or ãƒãƒ¼ãƒ ã‚¹ãƒšãƒ¼ã‚¹ã®ã‚ã‚‹è¡Œ
 	int			nItemFuncId = 0;
 
 	szWordPrev[0] = L'\0';
@@ -465,7 +465,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 	szTemplateName[0] = L'\0';
 	nMode = 0;
 	
-	//	Aug. 10, 2004 genta ƒvƒŠƒvƒƒZƒXˆ—ƒNƒ‰ƒX
+	//	Aug. 10, 2004 genta ãƒ—ãƒªãƒ—ãƒ­ã‚»ã‚¹å‡¦ç†ã‚¯ãƒ©ã‚¹
 	CCppPreprocessMng cCppPMng;
 	bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 	
@@ -474,16 +474,16 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 		pLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLineCount)->GetDocLineStrWithEOL(&nLineLen);
 
 		//	From Here Aug. 10, 2004 genta
-		//	ƒvƒŠƒvƒƒZƒXˆ—
-		//	ƒRƒƒ“ƒg’†‚Å‚È‚¯‚ê‚ÎƒvƒŠƒvƒƒZƒbƒTw—ß‚ğæ‚É”»’è‚³‚¹‚é
-		if( 8 != nMode && 10 != nMode ){	/* chg 2005/12/6 ‚¶‚ã‚¤‚¶ Ÿ‚Ìs‚ª‹ó”’‚Å‚à‚æ‚¢	*/
+		//	ãƒ—ãƒªãƒ—ãƒ­ã‚»ã‚¹å‡¦ç†
+		//	ã‚³ãƒ¡ãƒ³ãƒˆä¸­ã§ãªã‘ã‚Œã°ãƒ—ãƒªãƒ—ãƒ­ã‚»ãƒƒã‚µæŒ‡ä»¤ã‚’å…ˆã«åˆ¤å®šã•ã›ã‚‹
+		if( 8 != nMode && 10 != nMode ){	/* chg 2005/12/6 ã˜ã‚…ã†ã˜ æ¬¡ã®è¡ŒãŒç©ºç™½ã§ã‚‚ã‚ˆã„	*/
 			i = cCppPMng.ScanLine( pLine, nLineLen );
 		}
 		else {
 			i = CLogicInt(0);
 		}
-		//	C/C++‚Æ‚µ‚Ä‚Ìˆ—‚ª•s—v‚ÈƒP[ƒX‚Å‚Í i == nLineLen‚Æ‚È‚Á‚Ä‚¢‚é‚Ì‚Å
-		//	ˆÈ‰º‚Ì‰ğÍˆ—‚ÍSKIP‚³‚ê‚éD
+		//	C/C++ã¨ã—ã¦ã®å‡¦ç†ãŒä¸è¦ãªã‚±ãƒ¼ã‚¹ã§ã¯ i == nLineLenã¨ãªã£ã¦ã„ã‚‹ã®ã§
+		//	ä»¥ä¸‹ã®è§£æå‡¦ç†ã¯SKIPã•ã‚Œã‚‹ï¼
 		//	To Here Aug. 10, 2004 genta
 #ifdef TRACE_OUTLINE
 		DEBUG_TRACE(_T("line:%ls"), pLine);
@@ -493,13 +493,13 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 			DEBUG_TRACE(_T("%2d [%lc] %d %x %d %d %d wd[%ls] pre[%ls] tmp[%ls] til[%ls] %d\n"), int((Int)i), pLine[i], nMode, nMode2,
 				nNestLevel_global, nNestLevel_func, nNestLevel_fparam, szWord, szWordPrev, szTemplateName, szItemName, nWordIdx );
 #endif
-/* del start 2005/12/6 ‚¶‚ã‚¤‚¶	*/
-			/* ƒGƒXƒP[ƒvƒV[ƒPƒ“ƒX‚Íí‚Éæ‚èœ‚­ */
-			/* ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ“Ç‚İ‚İ’† */
-			/* ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ“Ç‚İ‚İ’† */
-			// ‚¢‚¸‚ê‚àƒRƒƒ“ƒgˆ—‚ÌŒã‚ÖˆÚ“®
-/* del end 2005/12/6 ‚¶‚ã‚¤‚¶	*/
-			/* ƒRƒƒ“ƒg“Ç‚İ‚İ’† */
+/* del start 2005/12/6 ã˜ã‚…ã†ã˜	*/
+			/* ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã‚·ãƒ¼ã‚±ãƒ³ã‚¹ã¯å¸¸ã«å–ã‚Šé™¤ã */
+			/* ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—èª­ã¿è¾¼ã¿ä¸­ */
+			/* ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—èª­ã¿è¾¼ã¿ä¸­ */
+			// ã„ãšã‚Œã‚‚ã‚³ãƒ¡ãƒ³ãƒˆå‡¦ç†ã®å¾Œã¸ç§»å‹•
+/* del end 2005/12/6 ã˜ã‚…ã†ã˜	*/
+			/* ã‚³ãƒ¡ãƒ³ãƒˆèª­ã¿è¾¼ã¿ä¸­ */
 			if( 8 == nMode ){
 				if( i < nLineLen - 1 && '*' == pLine[i] &&  '/' == pLine[i + 1] ){
 					++i;
@@ -508,7 +508,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 				}else{
 				}
 			}
-			/* ƒ‰ƒCƒ“ƒRƒƒ“ƒg“Ç‚İ‚İ’† */
+			/* ãƒ©ã‚¤ãƒ³ã‚³ãƒ¡ãƒ³ãƒˆèª­ã¿è¾¼ã¿ä¸­ */
 			// 2003/06/24 zenryaku
 			else if( 10 == nMode)
 			{
@@ -518,12 +518,12 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 				i = nLineLen;
 				continue;
 			}
-			/* add start 2005/12/6 ‚¶‚ã‚¤‚¶	*/
-			/* ƒGƒXƒP[ƒvƒV[ƒPƒ“ƒX‚Íí‚Éæ‚èœ‚­ */
+			/* add start 2005/12/6 ã˜ã‚…ã†ã˜	*/
+			/* ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã‚·ãƒ¼ã‚±ãƒ³ã‚¹ã¯å¸¸ã«å–ã‚Šé™¤ã */
 			else if( '\\' == pLine[i] && nRawStringTagLen == 0 ){
 				++i;
 			}
-			/* ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ“Ç‚İ‚İ’† */
+			/* ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—èª­ã¿è¾¼ã¿ä¸­ */
 			else if( 20 == nMode ){
 				if( '\'' == pLine[i] ){
 					nMode = 0;
@@ -531,7 +531,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 				}else{
 				}
 			}
-			/* ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ“Ç‚İ‚İ’† */
+			/* ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—èª­ã¿è¾¼ã¿ä¸­ */
 			else if( 21 == nMode ){
 				// operator "" _userliteral
 				if( nMode2 == M2_OPERATOR_WORD ){
@@ -557,8 +557,8 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 				}else{
 				}
 			}
-			/* add end 2005/12/6 ‚¶‚ã‚¤‚¶	*/
-			/* ’PŒê“Ç‚İ‚İ’† */
+			/* add end 2005/12/6 ã˜ã‚…ã†ã˜	*/
+			/* å˜èªèª­ã¿è¾¼ã¿ä¸­ */
 			else if( 1 == nMode ){
 				if( C_IsWordChar( pLine[i] ) ){
 					++nWordIdx;
@@ -570,7 +570,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							if( pLine[i + 1] == L':' ||  0 < i && pLine[i-1] == L':' ){
 								// name ::class or class :: member
 							}else{
-								// class Klass:base ‚Ì‚æ‚¤‚É:‚Ì‘O‚ÉƒXƒy[ƒX‚ª‚È‚¢ê‡
+								// class Klass:base ã®ã‚ˆã†ã«:ã®å‰ã«ã‚¹ãƒšãƒ¼ã‚¹ãŒãªã„å ´åˆ
 								if(nMode2 == M2_NAMESPACE_SAVE)
 								{
 									if(szWord[0]!='\0')
@@ -588,22 +588,22 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 						szWord[nWordIdx + 1] = L'\0';
 					}
 				}else{
-					// 2002/10/27 frozen@‚±‚±‚©‚ç
+					// 2002/10/27 frozenã€€ã“ã“ã‹ã‚‰
 					if( nMode2 == M2_NAMESPACE_SAVE ){
 						if( wcscmp(L"final", szWord) == 0 && wcscmp(LSW(STR_OUTLINE_CPP_NONAME), szItemName) != 0 ){
-							// strcut name final ‚Ìfinal‚ÍƒNƒ‰ƒX–¼‚Ìˆê•”‚Å‚Í‚È‚¢
-							// ‚½‚¾‚µ struct final‚Í–¼‘O
+							// strcut name final ã®finalã¯ã‚¯ãƒ©ã‚¹åã®ä¸€éƒ¨ã§ã¯ãªã„
+							// ãŸã ã— struct finalã¯åå‰
 						}else{
 							wcscpy( szTemplateName, szWord );
 							wcscpy( szItemName, szWord );
 						}
 					}else if( nMode2 == M2_TEMPLATE_SAVE || nMode2 == M2_TEMPLATE_WORD ){
-						// strcut name<X> final ‚Ìfinal‚ÍƒNƒ‰ƒX–¼‚Ìˆê•”‚Å‚Í‚È‚¢
-						// struct name<final> ‚Ìfinal‚Íˆê•”
+						// strcut name<X> final ã®finalã¯ã‚¯ãƒ©ã‚¹åã®ä¸€éƒ¨ã§ã¯ãªã„
+						// struct name<final> ã®finalã¯ä¸€éƒ¨
 						if( wcscmp(L"final", szWord) != 0 || nNestLevel_template != 0 ){
 							int nLen = wcslen(szTemplateName);
 							if( 0 < nLen && C_IsWordChar(szTemplateName[nLen - 1]) && szTemplateName[nLen - 1] != L':' && szWord[nWordIdx] != L':' ){
-								// template func<const x>() ‚Ì‚æ‚¤‚Èê‡‚Éconst‚ÌŒã‚ë‚ÉƒXƒy[ƒX‚ğ‘}“ü
+								// template func<const x>() ã®ã‚ˆã†ãªå ´åˆã«constã®å¾Œã‚ã«ã‚¹ãƒšãƒ¼ã‚¹ã‚’æŒ¿å…¥
 								if( nLen + 1 < nItemNameLenMax ){
 									wcscat( szTemplateName, L" " );
 									nLen++;
@@ -612,7 +612,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							wcsncat( szTemplateName, szWord, nItemNameLenMax - nLen - 1 );
 						}
 					}
-					else if( nNestLevel_func == 0 && (nMode2 == M2_NORMAL || nMode2 == M2_FUNC_NAME_END) )	// 2010.07.08 ryoji ŠÖ”Œ^ƒ}ƒNƒŒÄo‚µ‚ğŠÖ”‚ÆŒë”F‚·‚é‚±‚Æ‚ª‚ ‚é–â‘è‘Îô‚Æ‚µ‚Ä nMode2 == M2_FUNC_NAME_END ğŒ‚ğ’Ç‰Á‚µA•â³‚ª‚©‚©‚é‚æ‚¤‚É‚µ‚½B
+					else if( nNestLevel_func == 0 && (nMode2 == M2_NORMAL || nMode2 == M2_FUNC_NAME_END) )	// 2010.07.08 ryoji é–¢æ•°å‹ãƒã‚¯ãƒ­å‘¼å‡ºã—ã‚’é–¢æ•°ã¨èª¤èªã™ã‚‹ã“ã¨ãŒã‚ã‚‹å•é¡Œå¯¾ç­–ã¨ã—ã¦ nMode2 == M2_FUNC_NAME_END æ¡ä»¶ã‚’è¿½åŠ ã—ã€è£œæ­£ãŒã‹ã‹ã‚‹ã‚ˆã†ã«ã—ãŸã€‚
 					{
 						if( nMode2 == M2_NORMAL )
 							nItemFuncId = 0;
@@ -626,29 +626,29 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							nItemFuncId = FL_OBJ_ENUM;
 						else if( wcscmp(szWord,L"union")==0 )
 							nItemFuncId = FL_OBJ_UNION;
-						else if( wcscmp(szWord,L"__interface")==0 ) // 2007.05.26 genta "__interface" ‚ğƒNƒ‰ƒX‚É—Ş‚·‚éˆµ‚¢‚É‚·‚é
+						else if( wcscmp(szWord,L"__interface")==0 ) // 2007.05.26 genta "__interface" ã‚’ã‚¯ãƒ©ã‚¹ã«é¡ã™ã‚‹æ‰±ã„ã«ã™ã‚‹
 							nItemFuncId = FL_OBJ_INTERFACE;
 						else if( wcscmp(szWord,L"typedef") == 0 )
 							bDefinedTypedef = true;
-						if( nItemFuncId != 0 && nItemFuncId != FL_OBJ_FUNCTION )	//  2010.07.08 ryoji nMode2 == M2_FUNC_NAME_END ‚Ì‚Æ‚«‚Í nItemFuncId == 2 ‚Ì‚Í‚¸
+						if( nItemFuncId != 0 && nItemFuncId != FL_OBJ_FUNCTION )	//  2010.07.08 ryoji nMode2 == M2_FUNC_NAME_END ã®ã¨ãã¯ nItemFuncId == 2 ã®ã¯ãš
 						{
 							nMode2 = M2_NAMESPACE_SAVE;
 							nItemLine = nLineCount + CLogicInt(1);
 							wcscpy(szItemName,LSW(STR_OUTLINE_CPP_NONAME));
 						}
 					}
-					/*else*/ if( nMode2 == M2_FUNC_NAME_END )	// 2010.07.08 ryoji ã‚ÅğŒ•ÏX‚µ‚½‚Ì‚Ås“ª‚Ì else ‚ğœ‹
+					/*else*/ if( nMode2 == M2_FUNC_NAME_END )	// 2010.07.08 ryoji ä¸Šã§æ¡ä»¶å¤‰æ›´ã—ãŸã®ã§è¡Œé ­ã® else ã‚’é™¤å»
 					{
 						nMode2 = M2_KR_FUNC;
 					}
-					// 2002/10/27 frozen@‚±‚±‚Ü‚Å
+					// 2002/10/27 frozenã€€ã“ã“ã¾ã§
 					if( nMode2 == M2_NORMAL ){
-						// template‚ÍI‚í‚Á‚½
+						// templateã¯çµ‚ã‚ã£ãŸ
 						szTemplateName[0] = L'\0';
 					}
 
 					//	To Here Mar. 31, 2001 genta
-					// 2004/03/12 zenryaku ƒL[ƒ[ƒh‚É _ ‚Æ PARAMS ‚ğg‚í‚¹‚È‚¢ (GNU‚ÌƒR[ƒh‚ªŒ©‚É‚­‚­‚È‚é‚©‚ç)
+					// 2004/03/12 zenryaku ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã« _ ã¨ PARAMS ã‚’ä½¿ã‚ã›ãªã„ (GNUã®ã‚³ãƒ¼ãƒ‰ãŒè¦‹ã«ãããªã‚‹ã‹ã‚‰)
 					if( !( wcscmp(L"PARAMS",szWord) == 0 || wcscmp(L"_",szWord) == 0 ) )
 						wcscpy( szWordPrev, szWord );
 					nWordIdx = 0;
@@ -658,7 +658,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					continue;
 				}
 			}else
-			/* ‹L†—ñ“Ç‚İ‚İ’† */
+			/* è¨˜å·åˆ—èª­ã¿è¾¼ã¿ä¸­ */
 			if( 2 == nMode ){
 				if( C_IsWordChar( pLine[i] ) ||
 					C_IsSpace( pLine[i], bExtEol ) ||
@@ -697,7 +697,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 						const wchar_t* p = &szWord[nWordIdx-8];
 						if(  (8 <= nWordIdx && wcsncmp(L"operator<", p, 9) == 0)
 						 || ((9 <= nWordIdx && wcsncmp(L"operator<<", p-1, 10) == 0) && 0 < i && L'<' == pLine[i-1]) ){
-							// ˆá‚¤Foperator<<const() / operator<<()
+							// é•ã†ï¼šoperator<<const() / operator<<()
 						}else{
 							// operator< <T>() / operator<<<T>() / operator+<T>()
 							nMode2Old = nMode2;
@@ -728,17 +728,17 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					}
 				}
 			}else
-			/* ’·‰ß‚¬‚é’PŒê–³‹’† */
+			/* é•·éãã‚‹å˜èªç„¡è¦–ä¸­ */
 			if( 999 == nMode ){
-				/* ‹ó”’‚âƒ^ƒu‹L†“™‚ğ”ò‚Î‚· */
+				/* ç©ºç™½ã‚„ã‚¿ãƒ–è¨˜å·ç­‰ã‚’é£›ã°ã™ */
 				if( C_IsSpace( pLine[i], bExtEol ) ){
 					nMode = 0;
 					continue;
 				}
 			}else
-			/* ƒm[ƒ}ƒ‹ƒ‚[ƒh */
+			/* ãƒãƒ¼ãƒãƒ«ãƒ¢ãƒ¼ãƒ‰ */
 			if( 0 == nMode ){
-				/* ‹ó”’‚âƒ^ƒu‹L†“™‚ğ”ò‚Î‚· */
+				/* ç©ºç™½ã‚„ã‚¿ãƒ–è¨˜å·ç­‰ã‚’é£›ã°ã™ */
 				if( C_IsSpace( pLine[i], bExtEol ) )
 					continue;
 
@@ -759,7 +759,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 				if( '"' == pLine[i] ){
 					int nLen = (int)wcslen(szWordPrev);
 					if( nMode2 == M2_NORMAL && C_IsOperator(szWordPrev, nLen) ){
-						// ‰‰Zq‚ÌƒIƒyƒŒ[ƒ^‚¾‚Á‚½ operator ""i
+						// æ¼”ç®—å­ã®ã‚ªãƒšãƒ¬ãƒ¼ã‚¿ã ã£ãŸ operator ""i
 						if( nLen + 1 < _countof(szWordPrev) ){
 							szWordPrev[nLen] = pLine[i];
 							szWordPrev[nLen + 1] = L'\0';
@@ -792,7 +792,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					continue;
 				}else
 				
-				// 2002/10/27 frozen ‚±‚±‚©‚ç
+				// 2002/10/27 frozen ã“ã“ã‹ã‚‰
 				if( '{' == pLine[i] )
 				{
 					bool bAddFunction = false;
@@ -808,17 +808,17 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							nNestLevel_global < nNamespaceNestMax &&
 							(nNamespaceLen[nNestLevel_global] +  (nItemNameLen = wcslen(szItemName)) + nLenDefPos + 1) < nNamespaceLenMax &&
 							(nItemLine > 0) )
-					// ‚R”Ô–Ú‚Ì(&&‚ÌŒã‚Ì)ğŒ
-					// ƒoƒbƒtƒ@‚ª‘«‚è‚È‚¢ê‡‚Í€–Ú‚Ì’Ç‰Á‚ğs‚í‚È‚¢B
-					// +nLenDefPos‚Í’Ç‰Á‚·‚é•¶š—ñ‚ÌÅ‘å’·(’Ç‰Á‚·‚é•¶š—ñ‚Í"::’è‹`ˆÊ’u"‚ªÅ’·)
-					// +1‚ÍI’[NUL•¶š
+					// ï¼“ç•ªç›®ã®(&&ã®å¾Œã®)æ¡ä»¶
+					// ãƒãƒƒãƒ•ã‚¡ãŒè¶³ã‚Šãªã„å ´åˆã¯é …ç›®ã®è¿½åŠ ã‚’è¡Œã‚ãªã„ã€‚
+					// +nLenDefPosã¯è¿½åŠ ã™ã‚‹æ–‡å­—åˆ—ã®æœ€å¤§é•·(è¿½åŠ ã™ã‚‹æ–‡å­—åˆ—ã¯"::å®šç¾©ä½ç½®"ãŒæœ€é•·)
+					// +1ã¯çµ‚ç«¯NULæ–‡å­—
 					{
 						wcscpy( &szNamespace[nNamespaceLen[nNestLevel_global]] , szItemName);
 						szItemName[0] = L'\0';
-						//	Jan. 30, 2005 genta M2_KR_FUNC ’Ç‰Á
-						//	ŠÖ”‚ÌŒã‚ë‚Éconst, throw ‚Ü‚½‚Í‰Šú‰»q‚ª‚ ‚é‚Æ
-						//	M2_KR_FUNC‚É‘JˆÚ‚µ‚ÄC';'‚ªŒ©‚Â‚©‚ç‚È‚¢‚Æ‚»‚Ìó‘Ô‚Ì‚Ü‚Ü
-						//	’†Š‡ŒÊ‚É‘˜‹ö‚·‚éD
+						//	Jan. 30, 2005 genta M2_KR_FUNC è¿½åŠ 
+						//	é–¢æ•°ã®å¾Œã‚ã«const, throw ã¾ãŸã¯åˆæœŸåŒ–å­ãŒã‚ã‚‹ã¨
+						//	M2_KR_FUNCã«é·ç§»ã—ã¦ï¼Œ';'ãŒè¦‹ã¤ã‹ã‚‰ãªã„ã¨ãã®çŠ¶æ…‹ã®ã¾ã¾
+						//	ä¸­æ‹¬å¼§ã«é­é‡ã™ã‚‹ï¼
 						if( bAddFunction ){
 							++ nNestLevel_func;
 						}
@@ -837,10 +837,10 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							}
 						}
 						/*
-						  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-						  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-						  ¨
-						  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+						  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+						  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+						  â†’
+						  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 						*/
 						CLayoutPoint ptPosXY;
 						m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -853,7 +853,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 						pcFuncInfoArr->AppendData( nItemLine, ptPosXY.GetY2() + CLayoutInt(1) , szNamespace, nItemFuncId);
 						bDefinedTypedef = false;
 						nItemLine = -1;
-						//	Jan. 30, 2005 genta M2_KR_FUNC ’Ç‰Á
+						//	Jan. 30, 2005 genta M2_KR_FUNC è¿½åŠ 
 						if( !bAddFunction )
 						{
 							szNamespace[nNamespaceLen[nNestLevel_global]] = L':';
@@ -862,7 +862,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					}
 					else
 					{
-						//	Jan. 30, 2005 genta M2_KR_FUNC ’Ç‰Á
+						//	Jan. 30, 2005 genta M2_KR_FUNC è¿½åŠ 
 						if( bAddFunction )
 							++ nNestLevel_func;
 						else
@@ -880,10 +880,10 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					// nNestLevel2 = 0;
 					continue;
 				}else
-				// 2002/10/27 frozen ‚±‚±‚Ü‚Å
+				// 2002/10/27 frozen ã“ã“ã¾ã§
 				
 				if( '}' == pLine[i] ){
-					//  2002/10/27 frozen ‚±‚±‚©‚ç
+					//  2002/10/27 frozen ã“ã“ã‹ã‚‰
 //					nNestLevel2 = 0;
 					if(nNestLevel_func == 0)
 					{
@@ -896,14 +896,14 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					}
 					else
 						--nNestLevel_func;
-					//  2002/10/27 frozen ‚±‚±‚Ü‚Å
+					//  2002/10/27 frozen ã“ã“ã¾ã§
 					nMode = 0;
 					nMode2 = M2_NORMAL;
 					nMode2Old = M2_NORMAL;
 					continue;
 				}else
 				if( '(' == pLine[i] ){
-					//  2002/10/27 frozen ‚±‚±‚©‚ç
+					//  2002/10/27 frozen ã“ã“ã‹ã‚‰
 //					if( nNestLevel == 0 && !bCppInitSkip ){
 //						wcscpy( szFuncName, szWordPrev );
 //						nFuncLine = nLineCount + 1;
@@ -918,7 +918,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 						if( k < nLineLen && pLine[k] == L')' ){
 							for( k++; k < nLineLen && C_IsSpace(pLine[k], bExtEol); k++){}
 							if( k < nLineLen && (pLine[k] == L'<' || pLine[k] == L'(' ) ){
-								// ƒIƒyƒŒ[ƒ^‚¾‚Á‚½ operator()( / operator()<;
+								// ã‚ªãƒšãƒ¬ãƒ¼ã‚¿ã ã£ãŸ operator()( / operator()<;
 								if( nLen + 1 < _countof(szWordPrev) ){
 									szWordPrev[nLen] = pLine[i];
 									szWordPrev[nLen + 1] = L'\0';
@@ -926,13 +926,13 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 								nMode2 = M2_OPERATOR_WORD;
 								bOperator = true;
 							}else{
-								// ƒIƒyƒŒ[ƒ^‚©operator‚Æ‚¢‚¤C‚ÌŠÖ”
+								// ã‚ªãƒšãƒ¬ãƒ¼ã‚¿ã‹operatorã¨ã„ã†Cã®é–¢æ•°
 							}
 						}
 					}
-					//	2007.05.26 genta C++/CLI nMode2 == M2_NAMESPACE_END‚Ìê‡‚ğ‘ÎÛŠO‚É
-					//	NAMESPACE_END(class ƒNƒ‰ƒX–¼ :‚ÌŒã‚ë)‚É‚¨‚¢‚Ä‚Í()‚ğŠÖ”‚Æ‚İ‚È‚³‚È‚¢D
-					//	TEMPLATE<sizeof(int)> ‚Ì‚æ‚¤‚ÈƒP[ƒX‚Åsizeof‚ğŠÖ”‚ÆŒë”F‚·‚éD
+					//	2007.05.26 genta C++/CLI nMode2 == M2_NAMESPACE_ENDã®å ´åˆã‚’å¯¾è±¡å¤–ã«
+					//	NAMESPACE_END(class ã‚¯ãƒ©ã‚¹å :ã®å¾Œã‚)ã«ãŠã„ã¦ã¯()ã‚’é–¢æ•°ã¨ã¿ãªã•ãªã„ï¼
+					//	TEMPLATE<sizeof(int)> ã®ã‚ˆã†ãªã‚±ãƒ¼ã‚¹ã§sizeofã‚’é–¢æ•°ã¨èª¤èªã™ã‚‹ï¼
 					if( !bOperator && nNestLevel_func == 0
 					  && (nMode2 == M2_NORMAL || nMode2 == M2_NAMESPACE_SAVE || nMode2 == M2_OPERATOR_WORD || nMode2 == M2_KR_FUNC) ){
 						if(nNestLevel_fparam==0)
@@ -947,7 +947,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 								bAdd = false;
 							}else{
 								if( !(nMode2 == M2_KR_FUNC && bInInitList) && !(nMode2 == M2_KR_FUNC
-									&& CPP_IsFunctionAfterKeyword(szWordPrev)) )	// 2010.07.08 ryoji ‰Šú‰»ƒŠƒXƒg‚É“ü‚éˆÈ‘O‚Ü‚Å‚ÍŒã”­‚Ì–¼‘O‚ğ—Dæ“I‚ÉŠÖ”–¼Œó•â‚Æ‚·‚é
+									&& CPP_IsFunctionAfterKeyword(szWordPrev)) )	// 2010.07.08 ryoji åˆæœŸåŒ–ãƒªã‚¹ãƒˆã«å…¥ã‚‹ä»¥å‰ã¾ã§ã¯å¾Œç™ºã®åå‰ã‚’å„ªå…ˆçš„ã«é–¢æ•°åå€™è£œã¨ã™ã‚‹
 								{
 									bNoFunction = false;
 								}else{
@@ -965,7 +965,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 						}
 						++ nNestLevel_fparam;
 					}
-					//  2002/10/27 frozen ‚±‚±‚Ü‚Å
+					//  2002/10/27 frozen ã“ã“ã¾ã§
 					if( nMode2 == M2_TEMPLATE_SAVE || nMode2 == M2_TEMPLATE_WORD ){
 						int nItemNameLen = wcslen(szTemplateName);
 						if( nItemNameLen + 1 < nItemNameLenMax ){
@@ -976,7 +976,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					continue;
 				}else
 				if( ')' == pLine[i] ){
-					//  2002/10/27 frozen ‚±‚±‚©‚ç
+					//  2002/10/27 frozen ã“ã“ã‹ã‚‰
 //					if( 1 == nNestLevel2 ){
 //						nNestLevel2 = 2;
 //					}
@@ -984,7 +984,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					if( nNestLevel_fparam > 0)
 					{
 						--nNestLevel_fparam;
-						//	2007.05.26 genta C++/CLI Attribute“à•”‚Å‚ÍnMode2‚Ì•ÏX‚Ís‚í‚È‚¢
+						//	2007.05.26 genta C++/CLI Attributeå†…éƒ¨ã§ã¯nMode2ã®å¤‰æ›´ã¯è¡Œã‚ãªã„
 						if( nNestLevel_fparam == 0 && nMode2 != M2_ATTRIBUTE && nMode2 != M2_TEMPLATE_WORD ){
 							if( nMode2 == M2_NORMAL )
 								bInInitList = false;
@@ -994,7 +994,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							}
 						}
 					}
-					//  2002/10/27 frozen ‚±‚±‚Ü‚Å
+					//  2002/10/27 frozen ã“ã“ã¾ã§
 					if( nMode2 == M2_OPERATOR_WORD ){
 						int nLen = wcslen(szWordPrev);
 						if( nLen + 1 < _countof(szWordPrev) ){
@@ -1010,11 +1010,11 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					}
 					continue;
 				}else
-				// From Here 2007.05.26 genta C++/CLI Attribute‚Ìæ‚èˆµ‚¢
+				// From Here 2007.05.26 genta C++/CLI Attributeã®å–ã‚Šæ‰±ã„
 				if( '[' == pLine[i] ){
 					int nLen = (int)wcslen(szWordPrev);
 					if( nMode2 == M2_NORMAL && C_IsOperator(szWordPrev, nLen) ){
-						// ‰‰Zq‚ÌƒIƒyƒŒ[ƒ^‚¾‚Á‚½ operator []
+						// æ¼”ç®—å­ã®ã‚ªãƒšãƒ¬ãƒ¼ã‚¿ã ã£ãŸ operator []
 						if( nLen + 1 < _countof(szWordPrev) ){
 							szWordPrev[nLen] = pLine[i];
 							szWordPrev[nLen + 1] = L'\0';
@@ -1030,8 +1030,8 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					continue;
 				} else
 				if( ']' == pLine[i] ){
-					//	Attribute“à•”‚Å‚à[]‚ğ”z—ñ‚Æ‚µ‚Äg‚¤‚©‚à‚µ‚ê‚È‚¢‚Ì‚ÅC
-					//	Š‡ŒÊ‚ÌƒŒƒxƒ‹‚ÍŒ³‚É–ß‚Á‚Ä‚¢‚é•K—v—L‚è
+					//	Attributeå†…éƒ¨ã§ã‚‚[]ã‚’é…åˆ—ã¨ã—ã¦ä½¿ã†ã‹ã‚‚ã—ã‚Œãªã„ã®ã§ï¼Œ
+					//	æ‹¬å¼§ã®ãƒ¬ãƒ™ãƒ«ã¯å…ƒã«æˆ»ã£ã¦ã„ã‚‹å¿…è¦æœ‰ã‚Š
 					if( nNestLevel_fparam == 0 && nMode2 == M2_ATTRIBUTE ) {
 						nMode2 = nMode2AttOld;
 						continue;
@@ -1044,37 +1044,37 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 						}
 					}
 				} else
-				// To Here 2007.05.26 genta C++/CLI Attribute‚Ìæ‚èˆµ‚¢
+				// To Here 2007.05.26 genta C++/CLI Attributeã®å–ã‚Šæ‰±ã„
 				if( ';' == pLine[i] ){
-					//  2002/10/27 frozen ‚±‚±‚©‚ç
+					//  2002/10/27 frozen ã“ã“ã‹ã‚‰
 					if( nMode2 == M2_KR_FUNC )
 					{
-						// zenryaku K&RƒXƒ^ƒCƒ‹‚ÌŠÖ”éŒ¾‚ÌI—¹Œã M2_FUNC_NAME_END ‚É‚à‚Ç‚·
+						// zenryaku K&Rã‚¹ã‚¿ã‚¤ãƒ«ã®é–¢æ•°å®£è¨€ã®çµ‚äº†å¾Œ M2_FUNC_NAME_END ã«ã‚‚ã©ã™
 						nMode2 = M2_FUNC_NAME_END;
 						if( nOutlineType == OUTLINE_C ){
-							// C‚Ì‚Æ‚«‚ÍK&R’è‹`B
+							// Cã®ã¨ãã¯K&Rå®šç¾©ã€‚
 							continue;
 						}
-						// ‚»‚êˆÈŠO‚ÍC++‚ÌˆÈ‰º‚Ì‚æ‚¤‚Èê‡
+						// ãã‚Œä»¥å¤–ã¯C++ã®ä»¥ä¸‹ã®ã‚ˆã†ãªå ´åˆ
 						// int funcname() const;
 						// void funcname() throw(MyException);
 						// auto funcname() -> int;
-					} //	Jan. 30, 2005 genta K&Rˆ—‚Éˆø‚«‘±‚¢‚ÄéŒ¾ˆ—‚às‚¤D
+					} //	Jan. 30, 2005 genta K&Rå‡¦ç†ã«å¼•ãç¶šã„ã¦å®£è¨€å‡¦ç†ã‚‚è¡Œã†ï¼
 					if( nMode2 == M2_FUNC_NAME_END &&
 						nNestLevel_global < nNamespaceNestMax &&
 						(nNamespaceLen[nNestLevel_global] + wcslen(szItemName)) < nNamespaceLenMax &&
 						nNestPoint_class == 0 && !bDefinedTypedef && 0 < nItemLine)
-					// ‚R”Ô–Ú‚Ì(&&‚ÌŒã‚Ì)ğŒ
-					// ƒoƒbƒtƒ@‚ª‘«‚è‚È‚¢ê‡‚Í€–Ú‚Ì’Ç‰Á‚ğs‚í‚È‚¢B
+					// ï¼“ç•ªç›®ã®(&&ã®å¾Œã®)æ¡ä»¶
+					// ãƒãƒƒãƒ•ã‚¡ãŒè¶³ã‚Šãªã„å ´åˆã¯é …ç›®ã®è¿½åŠ ã‚’è¡Œã‚ãªã„ã€‚
 					{
 						wcscpy( &szNamespace[nNamespaceLen[ nNestLevel_global]] , szItemName);
 
 						nItemFuncId = FL_OBJ_DECLARE;
 						/*
-						  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-						  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-						  ¨
-						  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+						  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+						  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+						  â†’
+						  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 						*/
 						CLayoutPoint ptPosXY;
 						m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -1088,32 +1088,32 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					}
 					nItemLine = -1;
 					szWordPrev[0] = L'\0';
-					szTemplateName[0] = L'\0'; // hoge < ... ; ‚Ítemplate‚Å‚Í‚È‚©‚Á‚½‚Ì‚ÅƒNƒŠƒA
+					szTemplateName[0] = L'\0'; // hoge < ... ; ã¯templateã§ã¯ãªã‹ã£ãŸã®ã§ã‚¯ãƒªã‚¢
 					nNestLevel_template = 0;
 					nMode2 = M2_NORMAL;
-					//  2002/10/27 frozen ‚±‚±‚Ü‚Å
+					//  2002/10/27 frozen ã“ã“ã¾ã§
 					bNoFunction = true;
 					bDefinedTypedef = false;
 					nMode2Old = M2_NORMAL;
 					nMode = 0;
 					continue;
 				}else if( nNestLevel_fparam == 0 && nMode2 != M2_ATTRIBUTE ){
-					// 2007.05.26 genta C++/CLI Attribute“à•”‚Å‚ÍŠÖ”–¼ˆ—‚ÍˆêØs‚í‚È‚¢
+					// 2007.05.26 genta C++/CLI Attributeå†…éƒ¨ã§ã¯é–¢æ•°åå‡¦ç†ã¯ä¸€åˆ‡è¡Œã‚ãªã„
 					if( C_IsWordChar( pLine[i] ) ){
 						//	//	Mar. 15, 2000 genta
 						//	From Here
-						//	’¼‘O‚Ìword‚ÌÅŒã‚ª::‚©C‚ ‚é‚¢‚Í’¼Œã‚Ìword‚Ìæ“ª‚ª::‚È‚ç
-						//	ƒNƒ‰ƒXŒÀ’èq‚Æl‚¦‚Ä—¼Ò‚ğÚ‘±‚·‚éD
+						//	ç›´å‰ã®wordã®æœ€å¾ŒãŒ::ã‹ï¼Œã‚ã‚‹ã„ã¯ç›´å¾Œã®wordã®å…ˆé ­ãŒ::ãªã‚‰
+						//	ã‚¯ãƒ©ã‚¹é™å®šå­ã¨è€ƒãˆã¦ä¸¡è€…ã‚’æ¥ç¶šã™ã‚‹ï¼
 						{
 							int pos = wcslen( szWordPrev ) - 2;
-							if( //	‘O‚Ì•¶š—ñ‚Ì––”öƒ`ƒFƒbƒN
+							if( //	å‰ã®æ–‡å­—åˆ—ã®æœ«å°¾ãƒã‚§ãƒƒã‚¯
 								( pos > 0 &&	szWordPrev[pos] == L':' &&
 								szWordPrev[pos + 1] == L':' ) ||
-								//	Ÿ‚Ì•¶š—ñ‚Ìæ“ªƒ`ƒFƒbƒN
+								//	æ¬¡ã®æ–‡å­—åˆ—ã®å…ˆé ­ãƒã‚§ãƒƒã‚¯
 								( i < nLineLen - 1 && pLine[i] == L':' &&
 									pLine[i+1] == L':' )
 							){
-								//	‘O‚Ì•¶š—ñ‚É‘±‚¯‚é
+								//	å‰ã®æ–‡å­—åˆ—ã«ç¶šã‘ã‚‹
 								if( nMode2 == M2_NORMAL || nMode2 == M2_OPERATOR_WORD ){
 									if( szTemplateName[0] ){
 										wcscpy( szWord, szTemplateName );
@@ -1125,10 +1125,10 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 								nWordIdx = wcslen( szWord );
 							}
 							//	From Here Apr. 1, 2001 genta
-							//	operator new/delete ‰‰Zq‚Ì‘Î‰
+							//	operator new/delete æ¼”ç®—å­ã®å¯¾å¿œ
 							else if( nMode2 == M2_NORMAL && C_IsOperator( szWordPrev, pos + 2 ) ){
 								if( -1 < pos && C_IsWordChar( szWordPrev[pos + 1] ) ){
-									//	ƒXƒy[ƒX‚ğ“ü‚ê‚ÄA‘O‚Ì•¶š—ñ‚É‘±‚¯‚é
+									//	ã‚¹ãƒšãƒ¼ã‚¹ã‚’å…¥ã‚Œã¦ã€å‰ã®æ–‡å­—åˆ—ã«ç¶šã‘ã‚‹
 									szWordPrev[pos + 2] = L' ';
 									szWordPrev[pos + 3] = L'\0';
 								}
@@ -1136,9 +1136,9 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 								nWordIdx = wcslen( szWord );
 								nMode2 = M2_OPERATOR_WORD;
 							}else if( nMode2 == M2_OPERATOR_WORD ){
-								// operator Œp‘±’†
+								// operator ç¶™ç¶šä¸­
 								if( -1 < pos && C_IsWordChar( szWordPrev[pos + 1] ) ){
-									//	ƒXƒy[ƒX‚ğ“ü‚ê‚ÄA‘O‚Ì•¶š—ñ‚É‘±‚¯‚é
+									//	ã‚¹ãƒšãƒ¼ã‚¹ã‚’å…¥ã‚Œã¦ã€å‰ã®æ–‡å­—åˆ—ã«ç¶šã‘ã‚‹
 									szWordPrev[pos + 2] = L' ';
 									szWordPrev[pos + 3] = L'\0';
 								}
@@ -1150,7 +1150,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 								nWordIdx = 0;
 							}
 						}
-						//	wcscpy( szWordPrev, szWord );	•s—vH
+						//	wcscpy( szWordPrev, szWord );	ä¸è¦ï¼Ÿ
 						//	To Here
 						if( pLine[i] == L':' && pLine[i+1] != L':')
 						{
@@ -1173,7 +1173,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 
 						//	//	Mar. 15, 2000 genta
 						//	From Here
-						//	’·‚³ƒ`ƒFƒbƒN‚Í•K{
+						//	é•·ã•ãƒã‚§ãƒƒã‚¯ã¯å¿…é ˆ
 						if( nWordIdx < nMaxWordLeng ){
 							nMode = 1;
 							szWord[nWordIdx] = pLine[i];
@@ -1184,7 +1184,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 						}
 						//	To Here
 					}else{
-						// 2011.12.02 template‘Î‰
+						// 2011.12.02 templateå¯¾å¿œ
 						if( nMode2 == M2_NORMAL || nMode2 == M2_OPERATOR_WORD ){
 							if( pLine[i] == L'<' ){
 								int nLen = (int)wcslen(szWordPrev);
@@ -1205,38 +1205,38 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							}
 						}
 						//	Aug. 13, 2004 genta
-						//	szWordPrev‚ª¸‚í‚ê‚È‚¢‚¤‚¿‚Éoperator‚Ì”»’è‚ğs‚¤
-						//	operator‚Ì”»’è‚Í‘O‚ÉƒNƒ‰ƒX–¼‚ª•t‚¢‚Ä‚¢‚é‰Â”\«‚ª‚ ‚é‚Ì‚Å
-						//	ê—p‚Ì”»’èŠÖ”‚ğg‚¤‚×‚µD
-						//	operator‚Å–³‚¯‚ê‚Î=‚Í‘ã“ü‚È‚Ì‚Å‚±‚±‚ÍéŒ¾•¶‚Å‚Í‚È‚¢D
+						//	szWordPrevãŒå¤±ã‚ã‚Œãªã„ã†ã¡ã«operatorã®åˆ¤å®šã‚’è¡Œã†
+						//	operatorã®åˆ¤å®šã¯å‰ã«ã‚¯ãƒ©ã‚¹åãŒä»˜ã„ã¦ã„ã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹ã®ã§
+						//	å°‚ç”¨ã®åˆ¤å®šé–¢æ•°ã‚’ä½¿ã†ã¹ã—ï¼
+						//	operatorã§ç„¡ã‘ã‚Œã°=ã¯ä»£å…¥ãªã®ã§ã“ã“ã¯å®£è¨€æ–‡ã§ã¯ãªã„ï¼
 						int nLen = (int)wcslen(szWordPrev);
 						if( pLine[i] == L'=' && nNestLevel_func == 0
 							&& nMode2 == M2_NORMAL && ! C_IsOperator(szWordPrev,nLen) ){
 							nMode2 = M2_AFTER_EQUAL;
 						}else if( nMode2 == M2_NORMAL && C_IsOperator(szWordPrev, nLen) ){
-							// ‰‰Zq‚ÌƒIƒyƒŒ[ƒ^‚¾‚Á‚½ operator +
+							// æ¼”ç®—å­ã®ã‚ªãƒšãƒ¬ãƒ¼ã‚¿ã ã£ãŸ operator +
 							wcscpy(szWord, szWordPrev);
 							nWordIdx = (int)nLen -1;
 							nMode2 = M2_OPERATOR_WORD;
 						}else if( nMode2 == M2_OPERATOR_WORD ){
-							// operator Œp‘±’†
+							// operator ç¶™ç¶šä¸­
 							wcscpy(szWord, szWordPrev);
 							nWordIdx = (int)nLen -1;
 						}else{
 							wcscpy(szWordPrev, szWord);
 							nWordIdx = -1;
 						}
-						// 2002/10/27 frozen ‚±‚±‚©‚ç
+						// 2002/10/27 frozen ã“ã“ã‹ã‚‰
 						if( nMode2 == M2_NAMESPACE_SAVE )
 						{
 #if 0
 							if( pLine[i] == L'>' || pLine[i] == L',' || pLine[i] == L'=')
-								// '<' ‚Ì‘O‚É '>' , ',' , '=' ‚ª‚ ‚Á‚½‚Ì‚ÅA‚¨‚»‚ç‚­
-								// ‘O‚É‚ ‚Á‚½"class"‚Íƒeƒ“ƒvƒŒ[ƒgƒpƒ‰ƒ[ƒ^‚ÌŒ^‚ğ•\‚µ‚Ä‚¢‚½‚Æl‚¦‚ç‚ê‚éB
-								// ‚æ‚Á‚ÄAƒNƒ‰ƒX–¼‚Ì’²¸‚ÍI—¹B
-								// '>' ‚Íƒeƒ“ƒvƒŒ[ƒgƒpƒ‰ƒ[ƒ^‚ÌI—¹
-								// ',' ‚Íƒeƒ“ƒvƒŒ[ƒgƒpƒ‰ƒ[ƒ^‚Ì‹æØ‚è
-								// '=' ‚ÍƒfƒtƒHƒ‹ƒgƒeƒ“ƒvƒŒ[ƒgƒpƒ‰ƒ[ƒ^‚Ìw’è
+								// '<' ã®å‰ã« '>' , ',' , '=' ãŒã‚ã£ãŸã®ã§ã€ãŠãã‚‰ã
+								// å‰ã«ã‚ã£ãŸ"class"ã¯ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®å‹ã‚’è¡¨ã—ã¦ã„ãŸã¨è€ƒãˆã‚‰ã‚Œã‚‹ã€‚
+								// ã‚ˆã£ã¦ã€ã‚¯ãƒ©ã‚¹åã®èª¿æŸ»ã¯çµ‚äº†ã€‚
+								// '>' ã¯ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®çµ‚äº†
+								// ',' ã¯ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®åŒºåˆ‡ã‚Š
+								// '=' ã¯ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®æŒ‡å®š
 								nMode2 = M2_NORMAL; 
 							else
 #endif
@@ -1270,7 +1270,7 @@ static bool IsCommentBlock( std::vector<SCommentBlock>& arr, int pos )
 
 
 
-/* C/C++ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒgˆ— */
+/* C/C++ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå‡¦ç† */
 void CEditView::SmartIndent_CPP( wchar_t wcChar )
 {
 	const wchar_t*	pLine;
@@ -1281,7 +1281,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 	int			nLevel;
 	CLogicInt j;
 
-	/* ’²®‚É‚æ‚Á‚Ä’uŠ·‚³‚ê‚é‰ÓŠ */
+	/* èª¿æ•´ã«ã‚ˆã£ã¦ç½®æ›ã•ã‚Œã‚‹ç®‡æ‰€ */
 	CLogicRange sRangeA;
 	sRangeA.Clear(-1);
 
@@ -1299,7 +1299,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 	CLogicPoint	ptCP;
 
 	if(wcChar==WCODE::CR || wcschr(L":{}()",wcChar)!=NULL){
-		//Ÿ‚Öi‚Ş
+		//æ¬¡ã¸é€²ã‚€
 	}else return;
 
 	switch( wcChar ){
@@ -1318,19 +1318,19 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 			if( WCODE::CR != wcChar ){
 				return;
 			}
-			/* ’²®‚É‚æ‚Á‚Ä’uŠ·‚³‚ê‚é‰ÓŠ */
+			/* èª¿æ•´ã«ã‚ˆã£ã¦ç½®æ›ã•ã‚Œã‚‹ç®‡æ‰€ */
 			sRangeA.Set(CLogicPoint(0,GetCaret().GetCaretLogicPos().y));
 		}else{
 
 
-			//	nWork‚Éˆ—‚ÌŠî€Œ…ˆÊ’u‚ğİ’è‚·‚é
+			//	nWorkã«å‡¦ç†ã®åŸºæº–æ¡ä½ç½®ã‚’è¨­å®šã™ã‚‹
 			if( WCODE::CR != wcChar ){
 				nWork = nCaretPosX_PHY - 1;
 			}else{
 				/*
-				|| CR‚ª“ü—Í‚³‚ê‚½AƒJ[ƒ\ƒ‹’¼Œã‚Ì¯•Êq‚ğƒCƒ“ƒfƒ“ƒg‚·‚éB
-				|| ƒJ[ƒ\ƒ‹’¼Œã‚Ì¯•Êq‚ª'}'‚â')'‚È‚ç‚Î
-				|| '}'‚â')'‚ª“ü—Í‚³‚ê‚½‚Æ“¯‚¶ˆ—‚ğ‚·‚é
+				|| CRãŒå…¥åŠ›ã•ã‚ŒãŸæ™‚ã€ã‚«ãƒ¼ã‚½ãƒ«ç›´å¾Œã®è­˜åˆ¥å­ã‚’ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã™ã‚‹ã€‚
+				|| ã‚«ãƒ¼ã‚½ãƒ«ç›´å¾Œã®è­˜åˆ¥å­ãŒ'}'ã‚„')'ãªã‚‰ã°
+				|| '}'ã‚„')'ãŒå…¥åŠ›ã•ã‚ŒãŸæ™‚ã¨åŒã˜å‡¦ç†ã‚’ã™ã‚‹
 				*/
 
 				int i;
@@ -1359,7 +1359,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 			}
 			if( i < nWork ){
 				if( ( L':' == wcChar && IsHeadCppKeyword(&pLine[i]) )
-					//	Sep. 18, 2002 ‚©‚ë‚Æ
+					//	Sep. 18, 2002 ã‹ã‚ã¨
 					|| ( L'{' == wcChar && L'#' != pLine[i] )
 					|| ( L'(' == wcChar && L'#' != pLine[i] )
 				){
@@ -1372,24 +1372,24 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 					return;
 				}
 			}
-			/* ’²®‚É‚æ‚Á‚Ä’uŠ·‚³‚ê‚é‰ÓŠ */
+			/* èª¿æ•´ã«ã‚ˆã£ã¦ç½®æ›ã•ã‚Œã‚‹ç®‡æ‰€ */
 			sRangeA.SetFrom(CLogicPoint(0, GetCaret().GetCaretLogicPos().GetY2()));
 			sRangeA.SetTo(CLogicPoint(i, GetCaret().GetCaretLogicPos().GetY2()));
 		}
 
 
-		/* ‘Î‰‚·‚éŠ‡ŒÊ‚ğ‚³‚ª‚· */
-		nLevel = 0;	/* {}‚Ì“ü‚êqƒŒƒxƒ‹ */
+		/* å¯¾å¿œã™ã‚‹æ‹¬å¼§ã‚’ã•ãŒã™ */
+		nLevel = 0;	/* {}ã®å…¥ã‚Œå­ãƒ¬ãƒ™ãƒ« */
 
 
 		nDataLen = CLogicInt(0);
 		for( j = GetCaret().GetCaretLogicPos().GetY2(); j >= CLogicInt(0); --j ){
 			pLine2 = m_pcEditDoc->m_cDocLineMgr.GetLine(j)->GetDocLineStrWithEOL(&nLineLen2);
 			if( j == GetCaret().GetCaretLogicPos().y ){
-				// 2005.10.11 ryoji EOF ‚Ì‚İ‚Ìs‚àƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒg‚Ì‘ÎÛ‚É‚·‚é
+				// 2005.10.11 ryoji EOF ã®ã¿ã®è¡Œã‚‚ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã®å¯¾è±¡ã«ã™ã‚‹
 				if( NULL == pLine2 ){
 					if( GetCaret().GetCaretLogicPos().y == m_pcEditDoc->m_cDocLineMgr.GetLineCount() )
-						continue;	// EOF ‚Ì‚İ‚Ìs
+						continue;	// EOF ã®ã¿ã®è¡Œ
 					break;
 				}
 				nCharChars = CLogicInt(&pLine2[nWork] - CNativeW::GetCharPrev( pLine2, nLineLen2, &pLine2[nWork] ));
@@ -1401,7 +1401,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 				k = nLineLen2 - nCharChars;
 			}
 
-			// ƒRƒƒ“ƒgE•¶š—ñŒŸõ
+			// ã‚³ãƒ¡ãƒ³ãƒˆãƒ»æ–‡å­—åˆ—æ¤œç´¢
 			bool bCommentStringCheck = m_pTypeData->m_bIndentCppStringIgnore || m_pTypeData->m_bIndentCppCommentIgnore;
 			std::vector<SCommentBlock> arrCommentBlock;
 			if( bCommentStringCheck ){
@@ -1489,7 +1489,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 					}
 				}
 				if( 0 < nBegin ){
-					// I‚í‚è‚Ì‚È‚¢•¶š—ñorƒRƒƒ“ƒg
+					// çµ‚ã‚ã‚Šã®ãªã„æ–‡å­—åˆ—orã‚³ãƒ¡ãƒ³ãƒˆ
 					SCommentBlock block = { nBegin, nLineLen2 };
 					arrCommentBlock.push_back(block);
 				}
@@ -1497,7 +1497,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 					if( wcCharOrg != WCODE::CR ){
 						int pos = GetCaret().GetCaretLogicPos().GetX();
 						if( IsCommentBlock(arrCommentBlock, pos) ){
-							// ‚à‚µÅŒã‚É“ü—Í‚µ‚½•¶š‚ªƒRƒƒ“ƒg“à‚¾‚Á‚½‚ç‰½‚à‚µ‚È‚¢
+							// ã‚‚ã—æœ€å¾Œã«å…¥åŠ›ã—ãŸæ–‡å­—ãŒã‚³ãƒ¡ãƒ³ãƒˆå†…ã ã£ãŸã‚‰ä½•ã‚‚ã—ãªã„
 							return;
 						}
 					}
@@ -1510,22 +1510,22 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 					if( 0 < k && L'\'' == pLine2[k - 1]
 					 && nLineLen2 - 1 > k && L'\'' == pLine2[k + 1]
 					){
-//						MYTRACE( _T("¥[%ls]\n"), pLine2 );
+//						MYTRACE( _T("â–¼[%ls]\n"), pLine2 );
 					}else if( bCommentStringCheck && IsCommentBlock(arrCommentBlock, k) ){
 					}else{
-						//“¯‚¶s‚Ìê‡
+						//åŒã˜è¡Œã®å ´åˆ
 						if( j == GetCaret().GetCaretLogicPos().y ){
 							if( L'{' == wcChar && L'}' == pLine2[k] ){
 								wcChar = L'}';
-								nLevel--;	/* {}‚Ì“ü‚êqƒŒƒxƒ‹ */
+								nLevel--;	/* {}ã®å…¥ã‚Œå­ãƒ¬ãƒ™ãƒ« */
 							}
 							if( L'(' == wcChar && L')' == pLine2[k] ){
 								wcChar = L')';
-								nLevel--;	/* {}‚Ì“ü‚êqƒŒƒxƒ‹ */
+								nLevel--;	/* {}ã®å…¥ã‚Œå­ãƒ¬ãƒ™ãƒ« */
 							}
 						}
 
-						nLevel++;	/* {}‚Ì“ü‚êqƒŒƒxƒ‹ */
+						nLevel++;	/* {}ã®å…¥ã‚Œå­ãƒ¬ãƒ™ãƒ« */
 					}
 				}
 				if( 1 == nCharChars && ( L'{' == pLine2[k] || L'(' == pLine2[k] )
@@ -1533,10 +1533,10 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 					if( 0 < k && L'\'' == pLine2[k - 1]
 					 && nLineLen2 - 1 > k && L'\'' == pLine2[k + 1]
 					){
-//						MYTRACE( _T("¥[%ls]\n"), pLine2 );
+//						MYTRACE( _T("â–¼[%ls]\n"), pLine2 );
 					}else if( bCommentStringCheck && IsCommentBlock(arrCommentBlock, k) ){
 					}else{
-						//“¯‚¶s‚Ìê‡
+						//åŒã˜è¡Œã®å ´åˆ
 						if( j == GetCaret().GetCaretLogicPos().y ){
 							if( L'{' == wcChar && L'{' == pLine2[k] ){
 								return;
@@ -1548,7 +1548,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 						if( 0 == nLevel ){
 							break;
 						}else{
-							nLevel--;	/* {}‚Ì“ü‚êqƒŒƒxƒ‹ */
+							nLevel--;	/* {}ã®å…¥ã‚Œå­ãƒ¬ãƒ™ãƒ« */
 						}
 
 					}
@@ -1560,7 +1560,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 				k -= nCharChars;
 			}
 			if( k < 0 ){
-				/* ‚±‚Ìs‚É‚Í‚È‚¢ */
+				/* ã“ã®è¡Œã«ã¯ãªã„ */
 				continue;
 			}
 
@@ -1578,9 +1578,9 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 			pszData = new wchar_t[nDataLen + nCharChars + 1];
 			wmemcpy( pszData, pLine2, nDataLen );
 			if( WCODE::CR  == wcChar || L'{' == wcChar || L'(' == wcChar ){
-				// 2005.10.11 ryoji TABƒL[‚ªSPACE‘}“ü‚Ìİ’è‚È‚ç’Ç‰ÁƒCƒ“ƒfƒ“ƒg‚àSPACE‚É‚·‚é
-				//	Šù‘¶•¶š—ñ‚Ì‰E’[‚Ì•\¦ˆÊ’u‚ğ‹‚ß‚½ã‚Å‘}“ü‚·‚éƒXƒy[ƒX‚Ì”‚ğŒˆ’è‚·‚é
-				if( m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_bInsSpace ){	// SPACE‘}“üİ’è
+				// 2005.10.11 ryoji TABã‚­ãƒ¼ãŒSPACEæŒ¿å…¥ã®è¨­å®šãªã‚‰è¿½åŠ ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã‚‚SPACEã«ã™ã‚‹
+				//	æ—¢å­˜æ–‡å­—åˆ—ã®å³ç«¯ã®è¡¨ç¤ºä½ç½®ã‚’æ±‚ã‚ãŸä¸Šã§æŒ¿å…¥ã™ã‚‹ã‚¹ãƒšãƒ¼ã‚¹ã®æ•°ã‚’æ±ºå®šã™ã‚‹
+				if( m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_bInsSpace ){	// SPACEæŒ¿å…¥è¨­å®š
 					int i;
 					CKetaXInt m = CKetaXInt(0);
 					i = 0;
@@ -1610,7 +1610,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 			break;
 		}
 		if( j < 0 ){
-			/* ‘Î‰‚·‚éŠ‡ŒÊ‚ªŒ©‚Â‚©‚ç‚È‚©‚Á‚½ */
+			/* å¯¾å¿œã™ã‚‹æ‹¬å¼§ãŒè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸ */
 			if( WCODE::CR == wcChar ){
 				return;
 			}else{
@@ -1620,13 +1620,13 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 			}
 		}
 
-		/* ’²®Œã‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚ğŒvZ‚µ‚Ä‚¨‚­ */
+		/* èª¿æ•´å¾Œã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’è¨ˆç®—ã—ã¦ãŠã */
 		ptCP.x = nCaretPosX_PHY - sRangeA.GetTo().x + nDataLen;
 		ptCP.y = GetCaret().GetCaretLogicPos().y;
 
 		nSrcLen = sRangeA.GetTo().x - sRangeA.GetFrom().x;
 		if( nSrcLen >= _countof( pszSrc ) - 1 ){
-			//	Sep. 18, 2002 genta ƒƒ‚ƒŠƒŠ[ƒN‘Îô
+			//	Sep. 18, 2002 genta ãƒ¡ãƒ¢ãƒªãƒªãƒ¼ã‚¯å¯¾ç­–
 			delete [] pszData;
 			return;
 		}
@@ -1638,7 +1638,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 		}
 
 
-		/* ’²®‚É‚æ‚Á‚Ä’uŠ·‚³‚ê‚é‰ÓŠ */
+		/* èª¿æ•´ã«ã‚ˆã£ã¦ç½®æ›ã•ã‚Œã‚‹ç®‡æ‰€ */
 		CLayoutRange sRangeLayout;
 		m_pcEditDoc->m_cLayoutMgr.LogicToLayout( sRangeA, &sRangeLayout );
 
@@ -1649,7 +1649,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 		}else{
 			bChange = TRUE;
 			if( m_pTypeData->m_bIndentCppUndoSep ){
-				//ƒL[“ü—Í‚ÆƒCƒ“ƒfƒ“ƒg‚ğ•Ê‚ÌƒAƒ“ƒhƒDƒoƒbƒtƒ@‚É‚·‚é
+				//ã‚­ãƒ¼å…¥åŠ›ã¨ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã‚’åˆ¥ã®ã‚¢ãƒ³ãƒ‰ã‚¥ãƒãƒƒãƒ•ã‚¡ã«ã™ã‚‹
 				SetUndoBuffer();
 				if( m_cCommander.GetOpeBlk() == NULL ){
 					m_cCommander.SetOpeBlk(new COpeBlk);
@@ -1657,31 +1657,31 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 				m_cCommander.GetOpeBlk()->AddRef();
 			}
 
-			/* ƒf[ƒ^’uŠ· íœ&‘}“ü‚É‚àg‚¦‚é */
+			/* ãƒ‡ãƒ¼ã‚¿ç½®æ› å‰Šé™¤&æŒ¿å…¥ã«ã‚‚ä½¿ãˆã‚‹ */
 			ReplaceData_CEditView(
 				sRangeLayout,
-				pszData,	/* ‘}“ü‚·‚éƒf[ƒ^ */
-				nDataLen,	/* ‘}“ü‚·‚éƒf[ƒ^‚Ì’·‚³ */
+				pszData,	/* æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ */
+				nDataLen,	/* æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã®é•·ã• */
 				true,
 				m_bDoing_UndoRedo?NULL:m_cCommander.GetOpeBlk()
 			);
 		}
 
 
-		/* ƒJ[ƒ\ƒ‹ˆÊ’u’²® */
+		/* ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®èª¿æ•´ */
 		CLayoutPoint ptCP_Layout;
 		m_pcEditDoc->m_cLayoutMgr.LogicToLayout( ptCP, &ptCP_Layout );
 
-		/* ‘I‘ğƒGƒŠƒA‚Ìæ“ª‚ÖƒJ[ƒ\ƒ‹‚ğˆÚ“® */
+		/* é¸æŠã‚¨ãƒªã‚¢ã®å…ˆé ­ã¸ã‚«ãƒ¼ã‚½ãƒ«ã‚’ç§»å‹• */
 		GetCaret().MoveCursor( ptCP_Layout, true );
 		GetCaret().m_nCaretPosX_Prev = GetCaret().GetCaretLayoutPos().GetX();
 
 
-		if( bChange && !m_bDoing_UndoRedo ){	/* ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚© */
-			/* ‘€ì‚Ì’Ç‰Á */
+		if( bChange && !m_bDoing_UndoRedo ){	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹ */
+			/* æ“ä½œã®è¿½åŠ  */
 			m_cCommander.GetOpeBlk()->AppendOpe(
 				new CMoveCaretOpe(
-					GetCaret().GetCaretLogicPos()	// ‘€ì‘OŒã‚ÌƒLƒƒƒŒƒbƒgˆÊ’u
+					GetCaret().GetCaretLogicPos()	// æ“ä½œå‰å¾Œã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®
 				)
 			);
 		}

--- a/sakura_core/types/CType_Dos.cpp
+++ b/sakura_core/types/CType_Dos.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,17 +25,17 @@
 #include "StdAfx.h"
 #include "types/CType.h"
 
-/* MS-DOS�o�b�`�t�@�C�� */
+/* MS-DOSバッチファイル */
 void CType_Dos::InitTypeConfigImp(STypeConfig* pType)
 {
-	//���O�Ɗg���q
-	_tcscpy( pType->m_szTypeName, _T("MS-DOS�o�b�`�t�@�C��") );
+	//名前と拡張子
+	_tcscpy( pType->m_szTypeName, _T("MS-DOSバッチファイル") );
 	_tcscpy( pType->m_szTypeExts, _T("bat") );
 
-	//�ݒ�
-	pType->m_cLineComment.CopyTo( 0, L"REM ", -1 );	/* �s�R�����g�f���~�^ */
-	pType->m_eDefaultOutline = OUTLINE_TEXT;		/* �A�E�g���C����͕��@ */
-	pType->m_nKeyWordSetIdx[0] = 7;					/* �L�[���[�h�Z�b�g */
+	//設定
+	pType->m_cLineComment.CopyTo( 0, L"REM ", -1 );	/* 行コメントデリミタ */
+	pType->m_eDefaultOutline = OUTLINE_TEXT;		/* アウトライン解析方法 */
+	pType->m_nKeyWordSetIdx[0] = 7;					/* キーワードセット */
 }
 
 
@@ -79,16 +79,16 @@ const wchar_t* g_ppszKeywordsBAT[] = {
 	L"EXIT",
 	L"CTTY",
 	L"ECHO",
-	L"@ECHO",	//Oct. 31, 2000 JEPRO '@' �������\�ɂ����̂Œǉ�
+	L"@ECHO",	//Oct. 31, 2000 JEPRO '@' を強調可能にしたので追加
 	L"LOCK",
 	L"UNLOCK",
 	L"GOTO",
 	L"SHIFT",
 	L"IF",
 	L"FOR",
-	L"DO",	//Nov. 2, 2000 JEPRO �ǉ�
-	L"IN",	//Nov. 2, 2000 JEPRO �ǉ�
-	L"ELSE",	//Nov. 2, 2000 JEPRO �ǉ� Win2000�Ŏg����
+	L"DO",	//Nov. 2, 2000 JEPRO 追加
+	L"IN",	//Nov. 2, 2000 JEPRO 追加
+	L"ELSE",	//Nov. 2, 2000 JEPRO 追加 Win2000で使える
 	L"CLS",
 	L"TRUENAME",
 	L"LOADHIGH",

--- a/sakura_core/types/CType_Erlang.cpp
+++ b/sakura_core/types/CType_Erlang.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief Erlang ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ
+ï»¿/*!	@file
+	@brief Erlang ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ
 	
 	@author genta
 	@date 2009.08.10 created
@@ -36,23 +36,23 @@
 #include "doc/logic/CDocLine.h"
 #include "outline/CFuncInfoArr.h"
 
-/** Erlang ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ ŠÇ—•‰ğÍ
+/** Erlang ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ ç®¡ç†ï¼†è§£æ
 */
 struct COutlineErlang {
 	enum {
-		STATE_NORMAL,	//!< ‰ğÍ’†‚Å‚È‚¢
-		STATE_FUNC_CANDIDATE_FIN,	//!< ŠÖ”‚ç‚µ‚«‚à‚Ì(s“ª‚Ìatom)‚ğ‰ğÍÏ‚İ
-		STATE_FUNC_ARGS1,	//!< Å‰‚Ìˆø”Šm”F’†
-		STATE_FUNC_ARGS,	//!< 2‚Â‚ßˆÈ~‚Ìˆø”Šm”F’†
-		STATE_FUNC_ARGS_FIN,//!< ŠÖ”‚Ì‰ğÍ‚ğŠ®—¹
-		STATE_FUNC_FOUND,	//!< ŠÖ”‚ğ”­Œ©Dƒf[ƒ^‚Ìæ“¾‚ª‰Â”\
+		STATE_NORMAL,	//!< è§£æä¸­ã§ãªã„
+		STATE_FUNC_CANDIDATE_FIN,	//!< é–¢æ•°ã‚‰ã—ãã‚‚ã®(è¡Œé ­ã®atom)ã‚’è§£ææ¸ˆã¿
+		STATE_FUNC_ARGS1,	//!< æœ€åˆã®å¼•æ•°ç¢ºèªä¸­
+		STATE_FUNC_ARGS,	//!< 2ã¤ã‚ä»¥é™ã®å¼•æ•°ç¢ºèªä¸­
+		STATE_FUNC_ARGS_FIN,//!< é–¢æ•°ã®è§£æã‚’å®Œäº†
+		STATE_FUNC_FOUND,	//!< é–¢æ•°ã‚’ç™ºè¦‹ï¼ãƒ‡ãƒ¼ã‚¿ã®å–å¾—ãŒå¯èƒ½
 	} m_state;
 
-	wchar_t m_func[64];	//!< ŠÖ”–¼(ArityŠÜ‚Ş) = •\¦–¼
-	CLogicInt m_lnum;	//!< ŠÖ”‚Ìs”Ô†
-	int m_argcount;		//!< ”­Œ©‚µ‚½ˆø”‚Ì”
-	wchar_t m_parenthesis[32];	//!< Š‡ŒÊ‚ÌƒlƒXƒg‚ğŠÇ—‚·‚é‚à‚Ì
-	int m_parenthesis_ptr;	//!< Š‡ŒÊ‚ÌƒlƒXƒgƒŒƒxƒ‹
+	wchar_t m_func[64];	//!< é–¢æ•°å(Arityå«ã‚€) = è¡¨ç¤ºå
+	CLogicInt m_lnum;	//!< é–¢æ•°ã®è¡Œç•ªå·
+	int m_argcount;		//!< ç™ºè¦‹ã—ãŸå¼•æ•°ã®æ•°
+	wchar_t m_parenthesis[32];	//!< æ‹¬å¼§ã®ãƒã‚¹ãƒˆã‚’ç®¡ç†ã™ã‚‹ã‚‚ã®
+	int m_parenthesis_ptr;	//!< æ‹¬å¼§ã®ãƒã‚¹ãƒˆãƒ¬ãƒ™ãƒ«
 	
 	COutlineErlang();
 	bool parse( const wchar_t* buf, int linelen, CLogicInt linenum );
@@ -96,14 +96,14 @@ COutlineErlang::COutlineErlang() :
 {
 }
 
-/** ŠÖ”–¼‚Ìæ“¾
+/** é–¢æ•°åã®å–å¾—
 
-	@param[in] buf s(æ“ª‚©‚ç)
-	@param[in] end buf––”ö
-	@param[in] p ‰ğÍ‚ÌŒ»İˆÊ’u
+	@param[in] buf è¡Œ(å…ˆé ­ã‹ã‚‰)
+	@param[in] end bufæœ«å°¾
+	@param[in] p è§£æã®ç¾åœ¨ä½ç½®
 	
-	ŠÖ”–¼‚ÍatomDatom‚Í ¬•¶šƒAƒ‹ƒtƒ@ƒxƒbƒgC_, @ ‚Ì‚¢‚¸‚ê‚©‚©‚çn‚Ü‚é
-	‰p”•¶š—ñ‚©C‚ ‚é‚¢‚ÍƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“‚ÅˆÍ‚Ü‚ê‚½•¶š—ñD
+	é–¢æ•°åã¯atomï¼atomã¯ å°æ–‡å­—ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆï¼Œ_, @ ã®ã„ãšã‚Œã‹ã‹ã‚‰å§‹ã¾ã‚‹
+	è‹±æ•°æ–‡å­—åˆ—ã‹ï¼Œã‚ã‚‹ã„ã¯ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³ã§å›²ã¾ã‚ŒãŸæ–‡å­—åˆ—ï¼
 */
 const wchar_t* COutlineErlang::ScanFuncName( const wchar_t* buf, const wchar_t* end, const wchar_t* p )
 {
@@ -143,12 +143,12 @@ const wchar_t* COutlineErlang::ScanFuncName( const wchar_t* buf, const wchar_t* 
 	return p;
 }
 
-/** ƒpƒ‰ƒ[ƒ^‚Ì”­Œ©
+/** ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®ç™ºè¦‹
 
-	@param[in] end buf––”ö
-	@param[in] p ‰ğÍ‚ÌŒ»İˆÊ’u
+	@param[in] end bufæœ«å°¾
+	@param[in] p è§£æã®ç¾åœ¨ä½ç½®
 	
-	ŠÖ”–¼‚Ìæ“¾‚ªŠ®—¹‚µCƒpƒ‰ƒ[ƒ^æ“ª‚ÌŠ‡ŒÊ‚ğ’T‚·D
+	é–¢æ•°åã®å–å¾—ãŒå®Œäº†ã—ï¼Œãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿å…ˆé ­ã®æ‹¬å¼§ã‚’æ¢ã™ï¼
 */
 const wchar_t* COutlineErlang::EnterArgs( const wchar_t* end, const wchar_t* p )
 {
@@ -178,12 +178,12 @@ const wchar_t* COutlineErlang::EnterArgs( const wchar_t* end, const wchar_t* p )
 	return end;
 }
 
-/** æ“ªƒpƒ‰ƒ[ƒ^‚Ì”­Œ©
+/** å…ˆé ­ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®ç™ºè¦‹
 
-	@param[in] end buf––”ö
-	@param[in] p ‰ğÍ‚ÌŒ»İˆÊ’u
+	@param[in] end bufæœ«å°¾
+	@param[in] p è§£æã®ç¾åœ¨ä½ç½®
 	
-	ƒpƒ‰ƒ[ƒ^‚ª0ŒÂ‚Æ1ŒÂˆÈã‚Ì”»•Ê‚Ì‚½‚ß‚Éó‘Ô‚ğİ‚¯‚Ä‚¢‚éD
+	ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ãŒ0å€‹ã¨1å€‹ä»¥ä¸Šã®åˆ¤åˆ¥ã®ãŸã‚ã«çŠ¶æ…‹ã‚’è¨­ã‘ã¦ã„ã‚‹ï¼
 */
 const wchar_t* COutlineErlang::ScanArgs1( const wchar_t* end, const wchar_t* p )
 {
@@ -211,21 +211,21 @@ const wchar_t* COutlineErlang::ScanArgs1( const wchar_t* end, const wchar_t* p )
 	return p;
 }
 
-/** ƒpƒ‰ƒ[ƒ^‚Ì‰ğÍ‚ÆƒJƒEƒ“ƒg
+/** ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®è§£æã¨ã‚«ã‚¦ãƒ³ãƒˆ
 
-	@param[in] end buf––”ö
-	@param[in] p ‰ğÍ‚ÌŒ»İˆÊ’u
+	@param[in] end bufæœ«å°¾
+	@param[in] p è§£æã®ç¾åœ¨ä½ç½®
 	
-	ƒpƒ‰ƒ[ƒ^‚ğ‰ğÍ‚·‚éDƒpƒ‰ƒ[ƒ^‚Ì”‚Æ––”ö‚Ì•Â‚¶Š‡ŒÊ‚ğ³‚µ‚­”»•Ê‚·‚é‚½‚ß‚ÉC
-	ˆø—p•„CŠ‡ŒÊCƒpƒ‰ƒ[ƒ^‚Ì‹æØ‚è‚ÌƒJƒ“ƒ}‚É’…–Ú‚·‚éD
-	ˆø—p•„‚Í‰üs‚ğŠÜ‚Ş‚±‚Æ‚ª‚Å‚«‚È‚¢D
+	ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã‚’è§£æã™ã‚‹ï¼ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®æ•°ã¨æœ«å°¾ã®é–‰ã˜æ‹¬å¼§ã‚’æ­£ã—ãåˆ¤åˆ¥ã™ã‚‹ãŸã‚ã«ï¼Œ
+	å¼•ç”¨ç¬¦ï¼Œæ‹¬å¼§ï¼Œãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®åŒºåˆ‡ã‚Šã®ã‚«ãƒ³ãƒã«ç€ç›®ã™ã‚‹ï¼
+	å¼•ç”¨ç¬¦ã¯æ”¹è¡Œã‚’å«ã‚€ã“ã¨ãŒã§ããªã„ï¼
 */
 const wchar_t* COutlineErlang::ScanArgs( const wchar_t* end, const wchar_t* p )
 {
 	assert( m_state == STATE_FUNC_ARGS );
 
 	const int parptr_max = sizeof( m_parenthesis ) / sizeof( m_parenthesis[0] );
-	wchar_t quote = L'\0'; // æ“ªˆÊ’u‚ğ•Û‘¶
+	wchar_t quote = L'\0'; // å…ˆé ­ä½ç½®ã‚’ä¿å­˜
 	for(const wchar_t* head = p ; p < end ; p++ ){
 		if( quote ){
 			if( *p == quote )
@@ -273,20 +273,20 @@ const wchar_t* COutlineErlang::ScanArgs( const wchar_t* end, const wchar_t* p )
 				++m_argcount;
 			}
 			else if( *p == L';' ){
-				//	ƒZƒ~ƒRƒƒ“‚Í•¡”‚Ì•¶‚Ì‹æØ‚èD
-				//	ƒpƒ‰ƒ[ƒ^’†‚É‚ÍŒ»‚ê‚È‚¢‚Ì‚ÅC‰ğÍ‚ª¸”s‚µ‚Ä‚¢‚é
-				//	Š‡ŒÊ‚Ì•Â‚¶–Y‚ê‚ªl‚¦‚ç‚ê‚é‚Ì‚ÅCdØ‚è’¼‚µ
+				//	ã‚»ãƒŸã‚³ãƒ­ãƒ³ã¯è¤‡æ•°ã®æ–‡ã®åŒºåˆ‡ã‚Šï¼
+				//	ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ä¸­ã«ã¯ç¾ã‚Œãªã„ã®ã§ï¼Œè§£æãŒå¤±æ•—ã—ã¦ã„ã‚‹
+				//	æ‹¬å¼§ã®é–‰ã˜å¿˜ã‚ŒãŒè€ƒãˆã‚‰ã‚Œã‚‹ã®ã§ï¼Œä»•åˆ‡ã‚Šç›´ã—
 				m_state = STATE_NORMAL;
 				return end;
 			}
 			else if( *p == L'.' ){
-				//	ƒsƒŠƒIƒh‚Í®‚Ì––”ö‚©C¬”“_‚Æ‚µ‚Äg‚í‚ê‚éD
+				//	ãƒ”ãƒªã‚ªãƒ‰ã¯å¼ã®æœ«å°¾ã‹ï¼Œå°æ•°ç‚¹ã¨ã—ã¦ä½¿ã‚ã‚Œã‚‹ï¼
 				if( p > head && ( L'0' <= p[-1] && p[-1] <= L'9' )){
-					//	¬”“_‚©‚à‚µ‚ê‚È‚¢‚Ì‚ÅC‚»‚Ì‚Ü‚Ü‚É‚·‚é
+					//	å°æ•°ç‚¹ã‹ã‚‚ã—ã‚Œãªã„ã®ã§ï¼Œãã®ã¾ã¾ã«ã™ã‚‹
 				}
 				else {
-					//	ˆø”‚Ì“r’†‚Å•¶––‚ªŒ»‚ê‚½‚Ì‚Í‰ğÍ‚ª¸”s‚µ‚Ä‚¢‚é
-					//	Š‡ŒÊ‚Ì•Â‚¶–Y‚ê‚ªl‚¦‚ç‚ê‚é‚Ì‚ÅCdØ‚è’¼‚µ
+					//	å¼•æ•°ã®é€”ä¸­ã§æ–‡æœ«ãŒç¾ã‚ŒãŸã®ã¯è§£æãŒå¤±æ•—ã—ã¦ã„ã‚‹
+					//	æ‹¬å¼§ã®é–‰ã˜å¿˜ã‚ŒãŒè€ƒãˆã‚‰ã‚Œã‚‹ã®ã§ï¼Œä»•åˆ‡ã‚Šç›´ã—
 					m_state = STATE_NORMAL;
 					return end;
 				}
@@ -305,14 +305,14 @@ const wchar_t* COutlineErlang::ScanArgs( const wchar_t* end, const wchar_t* p )
 	return p;
 }
 
-/** ŠÖ”–{‘Ì‚Ì‹æØ‚èC‚Ü‚½‚ÍğŒ•¶‚ÌŒŸo
+/** é–¢æ•°æœ¬ä½“ã®åŒºåˆ‡ã‚Šï¼Œã¾ãŸã¯æ¡ä»¶æ–‡ã®æ¤œå‡º
 
-	@param[in] end buf––”ö
-	@param[in] p ‰ğÍ‚ÌŒ»İˆÊ’u
+	@param[in] end bufæœ«å°¾
+	@param[in] p è§£æã®ç¾åœ¨ä½ç½®
 	
-	ƒpƒ‰ƒ[ƒ^–{‘Ì‚ğ•\‚·‹L†(->)‚©ğŒ•¶‚ÌŠJnƒL[ƒ[ƒh(when)‚ğ
-	Œ©‚Â‚¯‚½‚çCŠÖ””­Œ©‚Æ‚·‚éD
-	‚»‚êˆÈŠO‚Ìê‡‚ÍŠÖ”‚Å‚Í‚È‚©‚Á‚½‚Æl‚¦‚éD
+	ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿æœ¬ä½“ã‚’è¡¨ã™è¨˜å·(->)ã‹æ¡ä»¶æ–‡ã®é–‹å§‹ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰(when)ã‚’
+	è¦‹ã¤ã‘ãŸã‚‰ï¼Œé–¢æ•°ç™ºè¦‹ã¨ã™ã‚‹ï¼
+	ãã‚Œä»¥å¤–ã®å ´åˆã¯é–¢æ•°ã§ã¯ãªã‹ã£ãŸã¨è€ƒãˆã‚‹ï¼
 */
 const wchar_t* COutlineErlang::EnterCond( const wchar_t* end, const wchar_t* p )
 {
@@ -339,11 +339,11 @@ const wchar_t* COutlineErlang::EnterCond( const wchar_t* end, const wchar_t* p )
 	return end;
 }
 
-/** s‚Ì‰ğÍ
+/** è¡Œã®è§£æ
 
-	@param[in] buf s(æ“ª‚©‚ç)
-	@param[in] linelen s‚Ì’·‚³
-	@param[in] linenum s”Ô†
+	@param[in] buf è¡Œ(å…ˆé ­ã‹ã‚‰)
+	@param[in] linelen è¡Œã®é•·ã•
+	@param[in] linenum è¡Œç•ªå·
 */
 bool COutlineErlang::parse( const wchar_t* buf, int linelen, CLogicInt linenum )
 {
@@ -380,13 +380,13 @@ bool COutlineErlang::parse( const wchar_t* buf, int linelen, CLogicInt linenum )
 	return m_state == STATE_FUNC_FOUND;
 }
 
-/** ŠÖ”–¼‚ÌŒã‚ë‚É Arity (ˆø”‚Ì”)‚ğ•t‰Á‚·‚é
+/** é–¢æ•°åã®å¾Œã‚ã« Arity (å¼•æ•°ã®æ•°)ã‚’ä»˜åŠ ã™ã‚‹
 
-	@param[in] arity ˆø”‚Ì”
+	@param[in] arity å¼•æ•°ã®æ•°
 	
-	ŠÖ”–¼‚ÌŒã‚ë‚É /ƒpƒ‰ƒ[ƒ^” ‚ÌŒ`‚Å•¶š—ñ‚ğ’Ç‰Á‚·‚éD
-	ƒoƒbƒtƒ@‚ª•s‘«‚·‚éê‡‚Í‚Å‚«‚é‚Æ‚±‚ë‚Ü‚Å‘‚«‚ŞD
-	‚»‚Ì‚½‚ßC10ŒÂˆÈã‚Ìˆø”‚ª‚ ‚éê‡‚ÉCˆø”‚Ì”‚Ì‰ºˆÊŒ…‚ªŒ‡‚¯‚é‚±‚Æ‚ª‚ ‚éD
+	é–¢æ•°åã®å¾Œã‚ã« /ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿æ•° ã®å½¢ã§æ–‡å­—åˆ—ã‚’è¿½åŠ ã™ã‚‹ï¼
+	ãƒãƒƒãƒ•ã‚¡ãŒä¸è¶³ã™ã‚‹å ´åˆã¯ã§ãã‚‹ã¨ã“ã‚ã¾ã§æ›¸ãè¾¼ã‚€ï¼
+	ãã®ãŸã‚ï¼Œ10å€‹ä»¥ä¸Šã®å¼•æ•°ãŒã‚ã‚‹å ´åˆã«ï¼Œå¼•æ•°ã®æ•°ã®ä¸‹ä½æ¡ãŒæ¬ ã‘ã‚‹ã“ã¨ãŒã‚ã‚‹ï¼
 */ 
 void COutlineErlang::build_arity( int arity )
 {
@@ -404,18 +404,18 @@ void COutlineErlang::build_arity( int arity )
 	m_func[ buf_size - 1 ] = L'\0';
 }
 
-/** Erlang ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ
+/** Erlang ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ
 
-	@par å‚È‰¼’è‚Æ•ûj
-	ŠÖ”éŒ¾‚Í1ƒJƒ‰ƒ€–Ú‚©‚ç‹LÚ‚³‚ê‚Ä‚¢‚éD
+	@par ä¸»ãªä»®å®šã¨æ–¹é‡
+	é–¢æ•°å®£è¨€ã¯1ã‚«ãƒ©ãƒ ç›®ã‹ã‚‰è¨˜è¼‰ã•ã‚Œã¦ã„ã‚‹ï¼
 	
 	
-	@par ‰ğÍƒAƒ‹ƒSƒŠƒYƒ€
-	1ƒJƒ‰ƒ€–Ú‚ªƒAƒ‹ƒtƒ@ƒxƒbƒg‚Ìê‡: ŠÖ”‚ç‚µ‚¢‚Æ‚µ‚Ä‰ğÍŠJn / ŠÖ”–¼‚ğ•Û‘¶
-	ƒXƒy[ƒX‚Í“Ç‚İ”ò‚Î‚·
-	( ‚ğ”­Œ©‚µ‚½‚ç ) ‚Ü‚Åˆø”‚ğ”‚¦‚éD‚»‚Ìê‡“ü‚êq‚ÌŠ‡ŒÊ‚Æ•¶š—ñ‚ğl—¶
-	-> ‚Ü‚½‚Í when ‚ª‚ ‚ê‚ÎŠÖ”’è‹`‚ÆŒ©‚È‚·(Ÿ‚Ìs‚É‚Ü‚½‚ª‚Á‚Ä‚à—Ç‚¢)
-	“r’† % (ƒRƒƒ“ƒg) ‚ªŒ»‚ê‚½‚çs––‚Ü‚Å“Ç‚İ”ò‚Î‚·
+	@par è§£æã‚¢ãƒ«ã‚´ãƒªã‚ºãƒ 
+	1ã‚«ãƒ©ãƒ ç›®ãŒã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆã®å ´åˆ: é–¢æ•°ã‚‰ã—ã„ã¨ã—ã¦è§£æé–‹å§‹ / é–¢æ•°åã‚’ä¿å­˜
+	ã‚¹ãƒšãƒ¼ã‚¹ã¯èª­ã¿é£›ã°ã™
+	( ã‚’ç™ºè¦‹ã—ãŸã‚‰ ) ã¾ã§å¼•æ•°ã‚’æ•°ãˆã‚‹ï¼ãã®å ´åˆå…¥ã‚Œå­ã®æ‹¬å¼§ã¨æ–‡å­—åˆ—ã‚’è€ƒæ…®
+	-> ã¾ãŸã¯ when ãŒã‚ã‚Œã°é–¢æ•°å®šç¾©ã¨è¦‹ãªã™(æ¬¡ã®è¡Œã«ã¾ãŸãŒã£ã¦ã‚‚è‰¯ã„)
+	é€”ä¸­ % (ã‚³ãƒ¡ãƒ³ãƒˆ) ãŒç¾ã‚ŒãŸã‚‰è¡Œæœ«ã¾ã§èª­ã¿é£›ã°ã™
 */
 void CDocOutline::MakeFuncList_Erlang( CFuncInfoArr* pcFuncInfoArr )
 {
@@ -429,10 +429,10 @@ void CDocOutline::MakeFuncList_Erlang( CFuncInfoArr* pcFuncInfoArr )
 		const wchar_t* pLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLineCount)->GetDocLineStrWithEOL(&nLineLen);
 		if( erl_state_machine.parse( pLine, nLineLen, nLineCount )){
 			/*
-			  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-			  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-			  ¨
-			  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+			  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+			  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+			  â†’
+			  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 			*/
 			CLayoutPoint ptPosXY;
 			m_pcDocRef->m_cLayoutMgr.LogicToLayout(

--- a/sakura_core/types/CType_Ini.cpp
+++ b/sakura_core/types/CType_Ini.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,18 +26,18 @@
 #include "types/CType.h"
 #include "view/colors/EColorIndexType.h"
 
-/* Ý’èƒtƒ@ƒCƒ‹ */
-//Nov. 9, 2000 JEPRO Windows•W€‚Ìini, inf, cnfƒtƒ@ƒCƒ‹‚ÆsakuraƒL[ƒ[ƒhÝ’èƒtƒ@ƒCƒ‹.kwd, FÝ’èƒtƒ@ƒCƒ‹.col ‚à“Ç‚ß‚é‚æ‚¤‚É‚·‚é
+/* è¨­å®šãƒ•ã‚¡ã‚¤ãƒ« */
+//Nov. 9, 2000 JEPRO Windowsæ¨™æº–ã®ini, inf, cnfãƒ•ã‚¡ã‚¤ãƒ«ã¨sakuraã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«.kwd, è‰²è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«.col ã‚‚èª­ã‚ã‚‹ã‚ˆã†ã«ã™ã‚‹
 void CType_Ini::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£Žq
-	_tcscpy( pType->m_szTypeName, _T("Ý’èƒtƒ@ƒCƒ‹") );
+	//åå‰ã¨æ‹¡å¼µå­
+	_tcscpy( pType->m_szTypeName, _T("è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«") );
 	_tcscpy( pType->m_szTypeExts, _T("ini,inf,cnf,kwd,col") );
 	
-	//Ý’è
-	pType->m_cLineComment.CopyTo( 0, L"//", -1 );				/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_cLineComment.CopyTo( 1, L";", -1 );				/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^2 */
-	pType->m_eDefaultOutline = OUTLINE_TEXT;					/* ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ•û–@ */
-	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ‚ðF•ª‚¯•\Ž¦‚µ‚È‚¢
-	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	//ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ‚ðF•ª‚¯•\Ž¦‚µ‚È‚¢
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"//", -1 );				/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_cLineComment.CopyTo( 1, L";", -1 );				/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿2 */
+	pType->m_eDefaultOutline = OUTLINE_TEXT;					/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžæ–¹æ³• */
+	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„
+	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	//ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„
 }

--- a/sakura_core/types/CType_Java.cpp
+++ b/sakura_core/types/CType_Java.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -33,23 +33,23 @@
 /* Java */
 void CType_Java::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£q
+	//åå‰ã¨æ‹¡å¼µå­
 	_tcscpy( pType->m_szTypeName, _T("Java") );
 	_tcscpy( pType->m_szTypeExts, _T("java,jav") );
 
-	//İ’è
-	pType->m_cLineComment.CopyTo( 0, L"//", -1 );					/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_cBlockComments[0].SetBlockCommentRule( L"/*", L"*/" );	/* ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_nKeyWordSetIdx[0] = 4;									/* ƒL[ƒ[ƒhƒZƒbƒg */
-	pType->m_eDefaultOutline = OUTLINE_JAVA;						/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
-	pType->m_eSmartIndent = SMARTINDENT_CPP;						/* ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒgí•Ê */
-	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;			//”¼Šp”’l‚ğF•ª‚¯•\¦	//Mar. 10, 2001 JEPRO
-	pType->m_ColorInfoArr[COLORIDX_BRACKET_PAIR].m_bDisp = true;	//‘ÎŠ‡ŒÊ‚Ì‹­’²‚ğƒfƒtƒHƒ‹ƒgON‚É	//Sep. 21, 2002 genta
-	pType->m_bStringLineOnly = true; // •¶š—ñ‚Ís“à‚Ì‚İ
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"//", -1 );					/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_cBlockComments[0].SetBlockCommentRule( L"/*", L"*/" );	/* ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_nKeyWordSetIdx[0] = 4;									/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
+	pType->m_eDefaultOutline = OUTLINE_JAVA;						/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
+	pType->m_eSmartIndent = SMARTINDENT_CPP;						/* ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆç¨®åˆ¥ */
+	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;			//åŠè§’æ•°å€¤ã‚’è‰²åˆ†ã‘è¡¨ç¤º	//Mar. 10, 2001 JEPRO
+	pType->m_ColorInfoArr[COLORIDX_BRACKET_PAIR].m_bDisp = true;	//å¯¾æ‹¬å¼§ã®å¼·èª¿ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆONã«	//Sep. 21, 2002 genta
+	pType->m_bStringLineOnly = true; // æ–‡å­—åˆ—ã¯è¡Œå†…ã®ã¿
 }
 
 
-/* Java‰ğÍƒ‚[ƒh */
+/* Javaè§£æãƒ¢ãƒ¼ãƒ‰ */
 enum EFuncListJavaMode {
 	FL_JAVA_MODE_NORMAL = 0,
 	FL_JAVA_MODE_WORD = 1,
@@ -60,7 +60,7 @@ enum EFuncListJavaMode {
 	FL_JAVA_MODE_TOO_LONG_WORD = 999
 };
 
-/* JavaŠÖ”ƒŠƒXƒgì¬ */
+/* Javaé–¢æ•°ãƒªã‚¹ãƒˆä½œæˆ */
 void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 {
 	const wchar_t*	pLine;
@@ -92,7 +92,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 	szClass[0] = L'\0';
 	nClassNestArrNum = 0;
 	CLogicInt		nLineCount;
-	const wchar_t*	szJavaKigou = L"!\"#%&'()=-^|\\`@[{+;*}]<,>?/";	//¯•Êq‚Ég—p‚Å‚«‚È‚¢”¼Šp‹L†B_:~.$‚Í‹–‰Â
+	const wchar_t*	szJavaKigou = L"!\"#%&'()=-^|\\`@[{+;*}]<,>?/";	//è­˜åˆ¥å­ã«ä½¿ç”¨ã§ããªã„åŠè§’è¨˜å·ã€‚_:~.$ã¯è¨±å¯
 	bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 
 	for( nLineCount = CLogicInt(0); nLineCount <  m_pcDocRef->m_cDocLineMgr.GetLineCount(); ++nLineCount ){
@@ -100,11 +100,11 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 		for( i = 0; i < nLineLen; i += nCharChars ){
 			nCharChars = CNativeW::GetSizeOfChar( pLine, nLineLen, i );
 
-			/* ƒGƒXƒP[ƒvƒV[ƒPƒ“ƒX‚Íí‚Éæ‚èœ‚­ */
+			/* ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã‚·ãƒ¼ã‚±ãƒ³ã‚¹ã¯å¸¸ã«å–ã‚Šé™¤ã */
 			if( L'\\' == pLine[i] ){
 				++i;
 			}else
-			/* ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ“Ç‚İ‚İ’† */
+			/* ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—èª­ã¿è¾¼ã¿ä¸­ */
 			if( FL_JAVA_MODE_SINGLE_QUOTE == nMode ){
 				if( L'\'' == pLine[i] ){
 					nMode = FL_JAVA_MODE_NORMAL;
@@ -112,7 +112,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 				}else{
 				}
 			}else
-			/* ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ“Ç‚İ‚İ’† */
+			/* ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—èª­ã¿è¾¼ã¿ä¸­ */
 			if( FL_JAVA_MODE_DOUBLE_QUOTE == nMode ){
 				if( L'"' == pLine[i] ){
 					nMode = FL_JAVA_MODE_NORMAL;
@@ -120,7 +120,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 				}else{
 				}
 			}else
-			/* ƒRƒƒ“ƒg“Ç‚İ‚İ’† */
+			/* ã‚³ãƒ¡ãƒ³ãƒˆèª­ã¿è¾¼ã¿ä¸­ */
 			if( FL_JAVA_MODE_COMMENT == nMode ){
 				if( i < nLineLen - 1 && L'*' == pLine[i] &&  L'/' == pLine[i + 1] ){
 					++i;
@@ -129,9 +129,9 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 				}else{
 				}
 			}
-			/* ’PŒê“Ç‚İ‚İ’† */
+			/* å˜èªèª­ã¿è¾¼ã¿ä¸­ */
 			else if( FL_JAVA_MODE_WORD == nMode ){
-				// 2011.09.16 syat ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ‚Å“ú–{Œê‚ªŠÜ‚Ü‚ê‚Ä‚¢‚é•”•ª‚ª•\¦‚³‚ê‚È‚¢
+				// 2011.09.16 syat ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æã§æ—¥æœ¬èªãŒå«ã¾ã‚Œã¦ã„ã‚‹éƒ¨åˆ†ãŒè¡¨ç¤ºã•ã‚Œãªã„
 				if( ! WCODE::IsBlank(pLine[i]) &&
 					! WCODE::IsLineDelimiter(pLine[i], bExtEol) &&
 					! WCODE::IsControlCode(pLine[i]) &&
@@ -146,8 +146,8 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 					}
 					nWordIdx += nCharChars;
 				}else{
-					/* ƒNƒ‰ƒXéŒ¾•”•ª‚ğŒ©‚Â‚¯‚½ */
-					//	Oct. 10, 2002 genta interface‚à‘ÎÛ‚É
+					/* ã‚¯ãƒ©ã‚¹å®£è¨€éƒ¨åˆ†ã‚’è¦‹ã¤ã‘ãŸ */
+					//	Oct. 10, 2002 genta interfaceã‚‚å¯¾è±¡ã«
 					if( 0 == wcscmp( L"class", szWordPrev ) ||
 						0 == wcscmp( L"interface", szWordPrev )
 					 ){
@@ -162,10 +162,10 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 						nFuncId = FL_OBJ_DEFINITION;
 						++nFuncNum;
 						/*
-						  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-						  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-						  ¨
-						  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+						  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+						  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+						  â†’
+						  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 						*/
 						CLogicPoint  ptPosXY_Logic = CLogicPoint(CLogicInt(0), nLineCount);
 						CLayoutPoint ptPosXY_Layout;
@@ -175,7 +175,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 						);
 						wchar_t szWork[256];
 						if( 0 < auto_snprintf_s( szWork, _countof(szWork), L"%ls::%ls", szClass, LSW(STR_OUTLINE_JAVA_DEFPOS) ) ){
-							pcFuncInfoArr->AppendData( ptPosXY_Logic.GetY2() + CLogicInt(1), ptPosXY_Layout.GetY2() + CLayoutInt(1), szWork, nFuncId ); //2007.10.09 kobake ƒŒƒCƒAƒEƒgEƒƒWƒbƒN‚Ì¬İƒoƒOC³
+							pcFuncInfoArr->AppendData( ptPosXY_Logic.GetY2() + CLogicInt(1), ptPosXY_Layout.GetY2() + CLayoutInt(1), szWork, nFuncId ); //2007.10.09 kobake ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆãƒ»ãƒ­ã‚¸ãƒƒã‚¯ã®æ··åœ¨ãƒã‚°ä¿®æ­£
 						}
 					}
 
@@ -184,7 +184,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 					continue;
 				}
 			}else
-			/* ‹L†—ñ“Ç‚İ‚İ’† */
+			/* è¨˜å·åˆ—èª­ã¿è¾¼ã¿ä¸­ */
 			if( FL_JAVA_MODE_SYMBOL == nMode ){
 				if( L'_' == pLine[i] ||
 					L':' == pLine[i] ||
@@ -211,9 +211,9 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 				}else{
 				}
 			}else
-			/* ’·‰ß‚¬‚é’PŒê–³‹’† */
+			/* é•·éãã‚‹å˜èªç„¡è¦–ä¸­ */
 			if( FL_JAVA_MODE_TOO_LONG_WORD == nMode ){
-				/* ‹ó”’‚âƒ^ƒu‹L†“™‚ğ”ò‚Î‚· */
+				/* ç©ºç™½ã‚„ã‚¿ãƒ–è¨˜å·ç­‰ã‚’é£›ã°ã™ */
 				if( L'\t' == pLine[i] ||
 					L' ' == pLine[i] ||
 					WCODE::IsLineDelimiter(pLine[i], bExtEol)
@@ -222,9 +222,9 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 					continue;
 				}
 			}else
-			/* ƒm[ƒ}ƒ‹ƒ‚[ƒh */
+			/* ãƒãƒ¼ãƒãƒ«ãƒ¢ãƒ¼ãƒ‰ */
 			if( FL_JAVA_MODE_NORMAL == nMode ){
-				/* ‹ó”’‚âƒ^ƒu‹L†“™‚ğ”ò‚Î‚· */
+				/* ç©ºç™½ã‚„ã‚¿ãƒ–è¨˜å·ç­‰ã‚’é£›ã°ã™ */
 				if( L'\t' == pLine[i] ||
 					L' ' == pLine[i] ||
 					WCODE::IsLineDelimiter(pLine[i], bExtEol)
@@ -250,8 +250,8 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 				if( L'{' == pLine[i] ){
 					if( 0 < nClassNestArrNum && 2 == nNestLevel2Arr[nClassNestArrNum - 1] ){
 						//	Oct. 10, 2002 genta
-						//	ƒƒ\ƒbƒh’†‚Å‚³‚ç‚Éƒƒ\ƒbƒh‚ğ’è‹`‚·‚é‚±‚Æ‚Í‚È‚¢‚Ì‚Å
-						//	ƒlƒXƒgƒŒƒxƒ‹”»’è’Ç‰Á class/interface‚Ì’¼‰º‚Ìê‡‚Ì‚İ”»’è‚·‚é
+						//	ãƒ¡ã‚½ãƒƒãƒ‰ä¸­ã§ã•ã‚‰ã«ãƒ¡ã‚½ãƒƒãƒ‰ã‚’å®šç¾©ã™ã‚‹ã“ã¨ã¯ãªã„ã®ã§
+						//	ãƒã‚¹ãƒˆãƒ¬ãƒ™ãƒ«åˆ¤å®šè¿½åŠ  class/interfaceã®ç›´ä¸‹ã®å ´åˆã®ã¿åˆ¤å®šã™ã‚‹
 						if( nClassNestArr[nClassNestArrNum - 1] == nNestLevel - 1
 						 && 0 != wcscmp( L"sizeof", szFuncName )
 						 && 0 != wcscmp( L"if", szFuncName )
@@ -265,10 +265,10 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 							nFuncId = FL_OBJ_FUNCTION;
 							++nFuncNum;
 							/*
-							  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-							  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-							  ¨
-							  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+							  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+							  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+							  â†’
+							  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 							*/
 							CLayoutPoint ptPosXY;
 							m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -372,7 +372,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 						}
 					}else{
 						//	Oct. 10, 2002 genta
-						//	abstract ‚É‚à‘Î‰
+						//	abstract ã«ã‚‚å¯¾å¿œ
 						if( pLine2[k] == L'{' || pLine2[k] == L';' ||
 							__iscsym( pLine2[k] ) ){
 							if( 0 < nClassNestArrNum ){
@@ -392,7 +392,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 				if( L';' == pLine[i] ){
 					if( 0 < nClassNestArrNum && 2 == nNestLevel2Arr[nClassNestArrNum - 1] ){
 						//	Oct. 10, 2002 genta
-						// ŠÖ”‚Ì’†‚Å•Ê‚ÌŠÖ”‚ÌéŒ¾•”‚ğg‚¤‚±‚Æ‚Á‚ÄCJava‚Å‚ ‚é‚ÌH
+						// é–¢æ•°ã®ä¸­ã§åˆ¥ã®é–¢æ•°ã®å®£è¨€éƒ¨ã‚’ä½¿ã†ã“ã¨ã£ã¦ï¼ŒJavaã§ã‚ã‚‹ã®ï¼Ÿ
 						if( nClassNestArr[nClassNestArrNum - 1] == nNestLevel - 1
 						 && 0 != wcscmp( L"sizeof", szFuncName )
 						 && 0 != wcscmp( L"if", szFuncName )
@@ -406,10 +406,10 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 							nFuncId = FL_OBJ_DECLARE;
 							++nFuncNum;
 							/*
-							  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-							  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-							  ¨
-							  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+							  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+							  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+							  â†’
+							  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 							*/
 							CLayoutPoint ptPosXY;
 							m_pcDocRef->m_cLayoutMgr.LogicToLayout(

--- a/sakura_core/types/CType_Others.cpp
+++ b/sakura_core/types/CType_Others.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -27,8 +27,8 @@
 
 void CType_Other::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£Žq
-	auto_sprintf( pType->m_szTypeName, _T("Ý’è%d"), pType->m_nIdx + 1 );
+	//åå‰ã¨æ‹¡å¼µå­
+	auto_sprintf( pType->m_szTypeName, _T("è¨­å®š%d"), pType->m_nIdx + 1 );
 	_tcscpy( pType->m_szTypeExts, _T("") );
 
 }

--- a/sakura_core/types/CType_Pascal.cpp
+++ b/sakura_core/types/CType_Pascal.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -27,21 +27,21 @@
 #include "view/colors/EColorIndexType.h"
 
 /* Pascal */
-//Mar. 10, 2001 JEPRO	”¼Šp”’l‚ğF•ª‚¯•\¦
+//Mar. 10, 2001 JEPRO	åŠè§’æ•°å€¤ã‚’è‰²åˆ†ã‘è¡¨ç¤º
 void CType_Pascal::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£q
+	//åå‰ã¨æ‹¡å¼µå­
 	_tcscpy( pType->m_szTypeName, _T("Pascal") );
 	_tcscpy( pType->m_szTypeExts, _T("dpr,pas") );
 
-	//İ’è
-	pType->m_cLineComment.CopyTo( 0, L"//", -1 );					/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */		//Nov. 5, 2000 JEPRO ’Ç‰Á
-	pType->m_cBlockComments[0].SetBlockCommentRule( L"{", L"}" );	/* ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */	//Nov. 5, 2000 JEPRO ’Ç‰Á
-	pType->m_cBlockComments[1].SetBlockCommentRule( L"(*", L"*)" );	/* ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^2 */	//@@@ 2001.03.10 by MIK
-	pType->m_nStringType = 1;										/* •¶š—ñ‹æØ‚è‹L†ƒGƒXƒP[ƒv•û–@  0=[\"][\'] 1=[""][''] */	//Nov. 5, 2000 JEPRO ’Ç‰Á
-	pType->m_nKeyWordSetIdx[0] = 8;									/* ƒL[ƒ[ƒhƒZƒbƒg */
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"//", -1 );					/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */		//Nov. 5, 2000 JEPRO è¿½åŠ 
+	pType->m_cBlockComments[0].SetBlockCommentRule( L"{", L"}" );	/* ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */	//Nov. 5, 2000 JEPRO è¿½åŠ 
+	pType->m_cBlockComments[1].SetBlockCommentRule( L"(*", L"*)" );	/* ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿2 */	//@@@ 2001.03.10 by MIK
+	pType->m_nStringType = 1;										/* æ–‡å­—åˆ—åŒºåˆ‡ã‚Šè¨˜å·ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—æ–¹æ³•  0=[\"][\'] 1=[""][''] */	//Nov. 5, 2000 JEPRO è¿½åŠ 
+	pType->m_nKeyWordSetIdx[0] = 8;									/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
 	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;			//@@@ 2001.11.11 upd MIK
-	pType->m_bStringLineOnly = true; // •¶š—ñ‚Ís“à‚Ì‚İ
+	pType->m_bStringLineOnly = true; // æ–‡å­—åˆ—ã¯è¡Œå†…ã®ã¿
 }
 
 

--- a/sakura_core/types/CType_Perl.cpp
+++ b/sakura_core/types/CType_Perl.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -31,40 +31,40 @@
 #include "view/Colors/EColorIndexType.h"
 
 /* Perl */
-//Jul. 08, 2001 JEPRO Perl ƒ†[ƒU‚É‘¡‚é
-//Jul. 08, 2001 JEPRO ’Ç‰Á
+//Jul. 08, 2001 JEPRO Perl ãƒ¦ãƒ¼ã‚¶ã«è´ˆã‚‹
+//Jul. 08, 2001 JEPRO è¿½åŠ 
 void CType_Perl::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£Žq
+	//åå‰ã¨æ‹¡å¼µå­
 	_tcscpy( pType->m_szTypeName, _T("Perl") );
 	_tcscpy( pType->m_szTypeExts, _T("cgi,pl,pm") );
 
-	//Ý’è
-	pType->m_cLineComment.CopyTo( 0, L"#", -1 );					/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_eDefaultOutline = OUTLINE_PERL;						/* ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ•û–@ */
-	pType->m_nKeyWordSetIdx[0]  = 11;								/* ƒL[ƒ[ƒhƒZƒbƒg */
-	pType->m_nKeyWordSetIdx[1] = 12;								/* ƒL[ƒ[ƒhƒZƒbƒg2 */
-	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;			/* ”¼Šp”’l‚ðF•ª‚¯•\Ž¦ */
-	pType->m_ColorInfoArr[COLORIDX_BRACKET_PAIR].m_bDisp = true;	//‘ÎŠ‡ŒÊ‚Ì‹­’²‚ðƒfƒtƒHƒ‹ƒgON	//Sep. 21, 2002 genta
-	pType->m_bStringLineOnly = true; // •¶Žš—ñ‚Ís“à‚Ì‚Ý
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"#", -1 );					/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_eDefaultOutline = OUTLINE_PERL;						/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžæ–¹æ³• */
+	pType->m_nKeyWordSetIdx[0]  = 11;								/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
+	pType->m_nKeyWordSetIdx[1] = 12;								/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ2 */
+	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;			/* åŠè§’æ•°å€¤ã‚’è‰²åˆ†ã‘è¡¨ç¤º */
+	pType->m_ColorInfoArr[COLORIDX_BRACKET_PAIR].m_bDisp = true;	//å¯¾æ‹¬å¼§ã®å¼·èª¿ã‚’ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆON	//Sep. 21, 2002 genta
+	pType->m_bStringLineOnly = true; // æ–‡å­—åˆ—ã¯è¡Œå†…ã®ã¿
 }
 
 
 
 //	From Here Sep 8, 2000 genta
 //
-//!	Perl—pƒAƒEƒgƒ‰ƒCƒ“‰ðÍ‹@”\iŠÈˆÕ”Åj
+//!	Perlç”¨ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžæ©Ÿèƒ½ï¼ˆç°¡æ˜“ç‰ˆï¼‰
 /*!
-	’Pƒ‚É /^\\s*sub\\s+(\\w+)/ ‚Éˆê’v‚µ‚½‚ç $1‚ðŽæ‚èo‚·“®ì‚ðs‚¤B
-	ƒlƒXƒg‚Æ‚©‚Í–Ê“|‚­‚³‚¢‚Ì‚Ål‚¦‚È‚¢B
-	package{ }‚ðŽg‚í‚È‚¯‚ê‚Î‚±‚ê‚Å\•ªD–³‚¢‚æ‚è‚Í‚Ü‚µB
+	å˜ç´”ã« /^\\s*sub\\s+(\\w+)/ ã«ä¸€è‡´ã—ãŸã‚‰ $1ã‚’å–ã‚Šå‡ºã™å‹•ä½œã‚’è¡Œã†ã€‚
+	ãƒã‚¹ãƒˆã¨ã‹ã¯é¢å€’ãã•ã„ã®ã§è€ƒãˆãªã„ã€‚
+	package{ }ã‚’ä½¿ã‚ãªã‘ã‚Œã°ã“ã‚Œã§ååˆ†ï¼Žç„¡ã„ã‚ˆã‚Šã¯ã¾ã—ã€‚
 
-	@par nMode‚ÌˆÓ–¡
-	@li 0: ‚Í‚¶‚ß
-	@li 2: sub‚ðŒ©‚Â‚¯‚½Œã
-	@li 1: ’PŒê“Ç‚Ýo‚µ’†
+	@par nModeã®æ„å‘³
+	@li 0: ã¯ã˜ã‚
+	@li 2: subã‚’è¦‹ã¤ã‘ãŸå¾Œ
+	@li 1: å˜èªžèª­ã¿å‡ºã—ä¸­
 
-	@date 2005.06.18 genta ƒpƒbƒP[ƒW‹æØ‚è‚ð•\‚· ::‚Æ'‚ðl—¶‚·‚é‚æ‚¤‚É
+	@date 2005.06.18 genta ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸åŒºåˆ‡ã‚Šã‚’è¡¨ã™ ::ã¨'ã‚’è€ƒæ…®ã™ã‚‹ã‚ˆã†ã«
 */
 void CDocOutline::MakeFuncList_Perl( CFuncInfoArr* pcFuncInfoArr )
 {
@@ -83,16 +83,16 @@ void CDocOutline::MakeFuncList_Perl( CFuncInfoArr* pcFuncInfoArr )
 		pLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLineCount)->GetDocLineStrWithEOL(&nLineLen);
 		nMode = 0;
 		for( i = 0; i < nLineLen; ++i ){
-			/* 1ƒoƒCƒg•¶Žš‚¾‚¯‚ðˆ—‚·‚é */
+			/* 1ãƒã‚¤ãƒˆæ–‡å­—ã ã‘ã‚’å‡¦ç†ã™ã‚‹ */
 			// 2005-09-02 D.S.Koba GetSizeOfChar
 			nCharChars = CNativeW::GetSizeOfChar( pLine, nLineLen, i );
 			if(	1 < nCharChars ){
 				break;
 			}
 
-			/* ’PŒê“Ç‚Ýž‚Ý’† */
+			/* å˜èªžèª­ã¿è¾¼ã¿ä¸­ */
 			if( 0 == nMode ){
-				/* ‹ó”’‚âƒ^ƒu‹L†“™‚ð”ò‚Î‚· */
+				/* ç©ºç™½ã‚„ã‚¿ãƒ–è¨˜å·ç­‰ã‚’é£›ã°ã™ */
 				if( L'\t' == pLine[i] ||
 					L' ' == pLine[i] ||
 					WCODE::IsLineDelimiter(pLine[i], bExtEol)
@@ -101,14 +101,14 @@ void CDocOutline::MakeFuncList_Perl( CFuncInfoArr* pcFuncInfoArr )
 				}
 				if( 's' != pLine[i] )
 					break;
-				//	sub ‚Ìˆê•¶Žš–Ú‚©‚à‚µ‚ê‚È‚¢
+				//	sub ã®ä¸€æ–‡å­—ç›®ã‹ã‚‚ã—ã‚Œãªã„
 				if( nLineLen - i < 4 )
 					break;
 				if( wcsncmp_literal( pLine + i, L"sub" ) )
 					break;
 				int c = pLine[ i + 3 ];
 				if( c == L' ' || c == L'\t' ){
-					nMode = 2;	//	”­Œ©
+					nMode = 2;	//	ç™ºè¦‹
 					i += 3;
 				}
 				else
@@ -126,7 +126,7 @@ void CDocOutline::MakeFuncList_Perl( CFuncInfoArr* pcFuncInfoArr )
 					(L'A' <= pLine[i] &&	pLine[i] <= L'Z' )||
 					(L'0' <= pLine[i] &&	pLine[i] <= L'9' )
 				){
-					//	ŠÖ”–¼‚ÌŽn‚Ü‚è
+					//	é–¢æ•°åã®å§‹ã¾ã‚Š
 					nWordIdx = 0;
 					szWord[nWordIdx] = pLine[i];
 					szWord[nWordIdx + 1] = L'\0';
@@ -142,8 +142,8 @@ void CDocOutline::MakeFuncList_Perl( CFuncInfoArr* pcFuncInfoArr )
 					(L'a' <= pLine[i] &&	pLine[i] <= L'z' )||
 					(L'A' <= pLine[i] &&	pLine[i] <= L'Z' )||
 					(L'0' <= pLine[i] &&	pLine[i] <= L'9' )||
-					//	Jun. 18, 2005 genta ƒpƒbƒP[ƒWCüŽq‚ðl—¶
-					//	ƒRƒƒ“‚Í2‚Â˜A‘±‚µ‚È‚¢‚Æ‚¢‚¯‚È‚¢‚Ì‚¾‚ªC‚»‚±‚ÍŽè”²‚«
+					//	Jun. 18, 2005 genta ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸ä¿®é£¾å­ã‚’è€ƒæ…®
+					//	ã‚³ãƒ­ãƒ³ã¯2ã¤é€£ç¶šã—ãªã„ã¨ã„ã‘ãªã„ã®ã ãŒï¼Œãã“ã¯æ‰‹æŠœã
 					L':' == pLine[i] || L'\'' == pLine[i]
 				){
 					++nWordIdx;
@@ -154,12 +154,12 @@ void CDocOutline::MakeFuncList_Perl( CFuncInfoArr* pcFuncInfoArr )
 						szWord[nWordIdx + 1] = L'\0';
 					}
 				}else{
-					//	ŠÖ”–¼Žæ“¾
+					//	é–¢æ•°åå–å¾—
 					/*
-					  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-					  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-					  ¨
-					  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\Ž¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+					  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+					  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+					  â†’
+					  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 					*/
 					CLayoutPoint ptPosXY;
 					m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -185,7 +185,7 @@ void CDocOutline::MakeFuncList_Perl( CFuncInfoArr* pcFuncInfoArr )
 
 
 const wchar_t* g_ppszKeywordsPERL[] = {
-	//Jul. 10, 2001 JEPRO	•Ï”‚ð‘æ‚Q‹­’²ƒL[ƒ[ƒh‚Æ‚µ‚Ä•ª—£‚µ‚½
+	//Jul. 10, 2001 JEPRO	å¤‰æ•°ã‚’ç¬¬ï¼’å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã¨ã—ã¦åˆ†é›¢ã—ãŸ
 	L"break",
 	L"continue",
 	L"do",
@@ -420,8 +420,8 @@ int g_nKeywordsPERL = _countof(g_ppszKeywordsPERL);
 
 
 
-//Jul. 10, 2001 JEPRO	•Ï”‚ð‘æ‚Q‹­’²ƒL[ƒ[ƒh‚Æ‚µ‚Ä•ª—£‚µ‚½
-// 2008/05/05 novice d•¡•¶Žš—ñíœ
+//Jul. 10, 2001 JEPRO	å¤‰æ•°ã‚’ç¬¬ï¼’å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã¨ã—ã¦åˆ†é›¢ã—ãŸ
+// 2008/05/05 novice é‡è¤‡æ–‡å­—åˆ—å‰Šé™¤
 const wchar_t* g_ppszKeywordsPERL2[] = {
 	L"$ARGV",
 	L"$_",

--- a/sakura_core/types/CType_Rich.cpp
+++ b/sakura_core/types/CType_Rich.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,27 +26,27 @@
 #include "types/CType.h"
 #include "view/colors/EColorIndexType.h"
 
-/* ƒŠƒbƒ`ƒeƒLƒXƒg */
-//JUl. 10, 2001 JEPRO WinHelpì‚é‚Ì‚É‚¢‚éƒPƒ“‚Ë
-//Jul. 10, 2001 JEPRO ’Ç‰Á
+/* ãƒªãƒƒãƒãƒ†ã‚­ã‚¹ãƒˆ */
+//JUl. 10, 2001 JEPRO WinHelpä½œã‚‹ã®ã«ã„ã‚‹ã‚±ãƒ³ã­
+//Jul. 10, 2001 JEPRO è¿½åŠ 
 void CType_Rich::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£Žq
-	_tcscpy( pType->m_szTypeName, _T("ƒŠƒbƒ`ƒeƒLƒXƒg") );
+	//åå‰ã¨æ‹¡å¼µå­
+	_tcscpy( pType->m_szTypeName, _T("ãƒªãƒƒãƒãƒ†ã‚­ã‚¹ãƒˆ") );
 	_tcscpy( pType->m_szTypeExts, _T("rtf") );
 
-	//Ý’è
-	pType->m_eDefaultOutline = OUTLINE_TEXT;					/* ƒAƒEƒgƒ‰ƒCƒ“‰ðÍ•û–@ */
-	pType->m_nKeyWordSetIdx[0]  = 15;							/* ƒL[ƒ[ƒhƒZƒbƒg */
-	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;		/* ”¼Šp”’l‚ðF•ª‚¯•\Ž¦ */
-	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ‚ðF•ª‚¯•\Ž¦‚µ‚È‚¢
-	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	//ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶Žš—ñ‚ðF•ª‚¯•\Ž¦‚µ‚È‚¢
-	pType->m_ColorInfoArr[COLORIDX_URL].m_bDisp = false;		//URL‚ÉƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ðˆø‚©‚È‚¢
+	//è¨­å®š
+	pType->m_eDefaultOutline = OUTLINE_TEXT;					/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æžæ–¹æ³• */
+	pType->m_nKeyWordSetIdx[0]  = 15;							/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
+	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;		/* åŠè§’æ•°å€¤ã‚’è‰²åˆ†ã‘è¡¨ç¤º */
+	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„
+	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	//ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„
+	pType->m_ColorInfoArr[COLORIDX_URL].m_bDisp = false;		//URLã«ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã‚’å¼•ã‹ãªã„
 }
 
 
 
-//Jul. 10, 2001 JEPRO ’Ç‰Á
+//Jul. 10, 2001 JEPRO è¿½åŠ 
 const wchar_t* g_ppszKeywordsRTF[] = {
 	L"\\ansi",
 	L"\\b",

--- a/sakura_core/types/CType_Sql.cpp
+++ b/sakura_core/types/CType_Sql.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -32,23 +32,23 @@
 /* PL/SQL */
 void CType_Sql::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£q
+	//åå‰ã¨æ‹¡å¼µå­
 	_tcscpy( pType->m_szTypeName, _T("PL/SQL") );
 	_tcscpy( pType->m_szTypeExts, _T("sql,plsql") );
 
-	//İ’è
-	pType->m_cLineComment.CopyTo( 0, L"--", -1 );					/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_cBlockComments[0].SetBlockCommentRule( L"/*", L"*/" );	/* ƒuƒƒbƒNƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_nStringType = STRING_LITERAL_PLSQL;					/* •¶š—ñ‹æØ‚è‹L†ƒGƒXƒP[ƒv•û–@  0=[\"][\'] 1=[""][''] */
-	wcscpy( pType->m_szIndentChars, L"|š" );						/* ‚»‚Ì‘¼‚ÌƒCƒ“ƒfƒ“ƒg‘ÎÛ•¶š */
-	pType->m_nKeyWordSetIdx[0] = 2;									/* ƒL[ƒ[ƒhƒZƒbƒg */
-	pType->m_eDefaultOutline = OUTLINE_PLSQL;						/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"--", -1 );					/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_cBlockComments[0].SetBlockCommentRule( L"/*", L"*/" );	/* ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_nStringType = STRING_LITERAL_PLSQL;					/* æ–‡å­—åˆ—åŒºåˆ‡ã‚Šè¨˜å·ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—æ–¹æ³•  0=[\"][\'] 1=[""][''] */
+	wcscpy( pType->m_szIndentChars, L"|â˜…" );						/* ãã®ä»–ã®ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå¯¾è±¡æ–‡å­— */
+	pType->m_nKeyWordSetIdx[0] = 2;									/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
+	pType->m_eDefaultOutline = OUTLINE_PLSQL;						/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
 }
 
 
 
 
-/*! PL/SQLŠÖ”ƒŠƒXƒgì¬ */
+/*! PL/SQLé–¢æ•°ãƒªã‚¹ãƒˆä½œæˆ */
 void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 {
 	const wchar_t*	pLine;
@@ -76,7 +76,7 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 	for( nLineCount = CLogicInt(0); nLineCount <  m_pcDocRef->m_cDocLineMgr.GetLineCount(); ++nLineCount ){
 		pLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLineCount)->GetDocLineStrWithEOL( &nLineLen );
 		for( i = 0; i < nLineLen; ++i ){
-			/* 1ƒoƒCƒg•¶š‚¾‚¯‚ğˆ—‚·‚é */
+			/* 1ãƒã‚¤ãƒˆæ–‡å­—ã ã‘ã‚’å‡¦ç†ã™ã‚‹ */
 			// 2005-09-02 D.S.Koba GetSizeOfChar
 			nCharChars = CNativeW::GetSizeOfChar( pLine, nLineLen, i );
 			if( 0 == nCharChars ){
@@ -86,7 +86,7 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 //				i += (nCharChars - 1);
 //				continue;
 //			}
-			/* ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ“Ç‚İ‚İ’† */
+			/* ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—èª­ã¿è¾¼ã¿ä¸­ */
 			if( 20 == nMode ){
 				if( L'\'' == pLine[i] ){
 					if( i + 1 < nLineLen && L'\'' == pLine[i + 1] ){
@@ -98,7 +98,7 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 				}else{
 				}
 			}else
-			/* ƒRƒƒ“ƒg“Ç‚İ‚İ’† */
+			/* ã‚³ãƒ¡ãƒ³ãƒˆèª­ã¿è¾¼ã¿ä¸­ */
 			if( 8 == nMode ){
 				if( i + 1 < nLineLen && L'*' == pLine[i] &&  L'/' == pLine[i + 1] ){
 					++i;
@@ -107,7 +107,7 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 				}else{
 				}
 			}else
-			/* ’PŒê“Ç‚İ‚İ’† */
+			/* å˜èªèª­ã¿è¾¼ã¿ä¸­ */
 			if( 1 == nMode ){
 				if( (1 == nCharChars && (
 					L'_' == pLine[i] ||
@@ -115,7 +115,7 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 					(L'a' <= pLine[i] &&	pLine[i] <= L'z' )||
 					(L'A' <= pLine[i] &&	pLine[i] <= L'Z' )||
 					(L'0' <= pLine[i] &&	pLine[i] <= L'9' )||
-					(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i])) // 2013.05.08 “ú–{Œê‘Î‰
+					(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i])) // 2013.05.08 æ—¥æœ¬èªå¯¾å¿œ
 					) )
 				 || 2 == nCharChars
 				){
@@ -167,23 +167,23 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 					if( 2 == nParseCnt ){
 						if( 0 == wcsicmp( szWord, L"IS" ) ){
 							if( 1 == nFuncOrProc ){
-								nFuncId = 11;	/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“–{‘Ì */
+								nFuncId = 11;	/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³æœ¬ä½“ */
 							}else
 							if( 2 == nFuncOrProc ){
-								nFuncId = 21;	/* ƒvƒƒV[ƒWƒƒ–{‘Ì */
+								nFuncId = 21;	/* ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£æœ¬ä½“ */
 							}else
 							if( 3 == nFuncOrProc ){
-								nFuncId = 31;	/* ƒpƒbƒP[ƒWd—l•” */
+								nFuncId = 31;	/* ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸ä»•æ§˜éƒ¨ */
 							}else
 							if( 4 == nFuncOrProc ){
-								nFuncId = 41;	/* ƒpƒbƒP[ƒW–{‘Ì */
+								nFuncId = 41;	/* ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸æœ¬ä½“ */
 							}
 							++nFuncNum;
 							/*
-							  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-							  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-							  ¨
-							  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+							  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+							  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+							  â†’
+							  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 							*/
 							CLayoutPoint ptPos;
 							m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -195,13 +195,13 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 						}
 						if( 0 == wcsicmp( szWord, L"AS" ) ){
 							if( 3 == nFuncOrProc ){
-								nFuncId = 31;	/* ƒpƒbƒP[ƒWd—l•” */
+								nFuncId = 31;	/* ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸ä»•æ§˜éƒ¨ */
 								++nFuncNum;
 								/*
-								  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-								  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-								  ¨
-								  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+								  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+								  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+								  â†’
+								  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 								*/
 								CLayoutPoint ptPos;
 								m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -212,13 +212,13 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 								nParseCnt = 0;
 							}
 							else if( 4 == nFuncOrProc ){
-								nFuncId = 41;	/* ƒpƒbƒP[ƒW–{‘Ì */
+								nFuncId = 41;	/* ãƒ‘ãƒƒã‚±ãƒ¼ã‚¸æœ¬ä½“ */
 								++nFuncNum;
 								/*
-								  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-								  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-								  ¨
-								  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+								  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+								  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+								  â†’
+								  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 								*/
 								CLayoutPoint ptPos;
 								m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -238,14 +238,14 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 					continue;
 				}
 			}else
-			/* ‹L†—ñ“Ç‚İ‚İ’† */
+			/* è¨˜å·åˆ—èª­ã¿è¾¼ã¿ä¸­ */
 			if( 2 == nMode ){
 				if( L'_' == pLine[i] ||
 					L'~' == pLine[i] ||
 					(L'a' <= pLine[i] &&	pLine[i] <= L'z' )||
 					(L'A' <= pLine[i] &&	pLine[i] <= L'Z' )||
 					(L'0' <= pLine[i] &&	pLine[i] <= L'9' )||
-					(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i]))|| // 2013.05.08 “ú–{Œê‘Î‰
+					(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i]))|| // 2013.05.08 æ—¥æœ¬èªå¯¾å¿œ
 					L'\t' == pLine[i] ||
 					 L' ' == pLine[i] ||
 					 WCODE::IsLineDelimiter(pLine[i], bExtEol) ||
@@ -279,9 +279,9 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 					}
 				}
 			}else
-			/* ’·‰ß‚¬‚é’PŒê–³‹’† */
+			/* é•·éãã‚‹å˜èªç„¡è¦–ä¸­ */
 			if( 999 == nMode ){
-				/* ‹ó”’‚âƒ^ƒu‹L†“™‚ğ”ò‚Î‚· */
+				/* ç©ºç™½ã‚„ã‚¿ãƒ–è¨˜å·ç­‰ã‚’é£›ã°ã™ */
 				if( L'\t' == pLine[i] ||
 					L' ' == pLine[i] ||
 					WCODE::IsLineDelimiter(pLine[i], bExtEol)
@@ -290,9 +290,9 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 					continue;
 				}
 			}else
-			/* ƒm[ƒ}ƒ‹ƒ‚[ƒh */
+			/* ãƒãƒ¼ãƒãƒ«ãƒ¢ãƒ¼ãƒ‰ */
 			if( 0 == nMode ){
-				/* ‹ó”’‚âƒ^ƒu‹L†“™‚ğ”ò‚Î‚· */
+				/* ç©ºç™½ã‚„ã‚¿ãƒ–è¨˜å·ç­‰ã‚’é£›ã°ã™ */
 				if( L'\t' == pLine[i] ||
 					L' ' == pLine[i] ||
 					WCODE::IsLineDelimiter(pLine[i], bExtEol)
@@ -314,16 +314,16 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 				if( L';' == pLine[i] ){
 					if( 2 == nParseCnt ){
 						if( 1 == nFuncOrProc ){
-							nFuncId = 10;	/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“éŒ¾ */
+							nFuncId = 10;	/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³å®£è¨€ */
 						}else{
-							nFuncId = 20;	/* ƒvƒƒV[ƒWƒƒéŒ¾ */
+							nFuncId = 20;	/* ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£å®£è¨€ */
 						}
 						++nFuncNum;
 						/*
-						  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-						  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-						  ¨
-						  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+						  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+						  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+						  â†’
+						  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 						*/
 						CLayoutPoint ptPos;
 						m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -342,7 +342,7 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 						(L'a' <= pLine[i] &&	pLine[i] <= L'z' )||
 						(L'A' <= pLine[i] &&	pLine[i] <= L'Z' )||
 						(L'0' <= pLine[i] &&	pLine[i] <= L'9' )||
-						(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i])) // 2013.05.08 “ú–{Œê‘Î‰
+						(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i])) // 2013.05.08 æ—¥æœ¬èªå¯¾å¿œ
 						) )
 					 || 2 == nCharChars
 					){

--- a/sakura_core/types/CType_Tex.cpp
+++ b/sakura_core/types/CType_Tex.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -31,31 +31,31 @@
 #include "view/Colors/EColorIndexType.h"
 
 /* TeX */
-//Oct. 31, 2000 JEPRO TeX  ƒ†[ƒU‚É‘¡‚é
-//Oct. 31, 2000 JEPRO TeX ƒ†[ƒU‚É‘¡‚é	//Mar. 10, 2001 JEPRO ’Ç‰Á
+//Oct. 31, 2000 JEPRO TeX  ãƒ¦ãƒ¼ã‚¶ã«è´ˆã‚‹
+//Oct. 31, 2000 JEPRO TeX ãƒ¦ãƒ¼ã‚¶ã«è´ˆã‚‹	//Mar. 10, 2001 JEPRO è¿½åŠ 
 void CType_Tex::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£q
+	//åå‰ã¨æ‹¡å¼µå­
 	_tcscpy( pType->m_szTypeName, _T("TeX") );
 	_tcscpy( pType->m_szTypeExts, _T("tex,ltx,sty,bib,log,blg,aux,bbl,toc,lof,lot,idx,ind,glo") );
 
-	//İ’è
-	pType->m_cLineComment.CopyTo( 0, L"%", -1 );				/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_eDefaultOutline = OUTLINE_TEX;						/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
-	pType->m_nKeyWordSetIdx[0] = 9;								/* ƒL[ƒ[ƒhƒZƒbƒg */
-	pType->m_nKeyWordSetIdx[1] = 10;							/* ƒL[ƒ[ƒhƒZƒbƒg2 */	//Jan. 19, 2001 JEPRO
-	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ‚ğF•ª‚¯•\¦‚µ‚È‚¢
-	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	//ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ‚ğF•ª‚¯•\¦‚µ‚È‚¢
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"%", -1 );				/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_eDefaultOutline = OUTLINE_TEX;						/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
+	pType->m_nKeyWordSetIdx[0] = 9;								/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
+	pType->m_nKeyWordSetIdx[1] = 10;							/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ2 */	//Jan. 19, 2001 JEPRO
+	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„
+	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	//ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„
 }
 
 
 
 
-/*! TeX ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ
+/*! TeX ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ
 
 	@author naoh
-	@date 2003.07.21 naoh V‹Kì¬
-	@date 2005.01.03 naoh uƒ}v‚È‚Ç‚Ì"}"‚ğŠÜ‚Ş•¶š‚É‘Î‚·‚éC³Aprosper‚Ìslide‚É‘Î‰
+	@date 2003.07.21 naoh æ–°è¦ä½œæˆ
+	@date 2005.01.03 naoh ã€Œãƒã€ãªã©ã®"}"ã‚’å«ã‚€æ–‡å­—ã«å¯¾ã™ã‚‹ä¿®æ­£ã€prosperã®slideã«å¯¾å¿œ
 */
 void CDocOutline::MakeTopicList_tex(CFuncInfoArr* pcFuncInfoArr)
 {
@@ -65,28 +65,28 @@ void CDocOutline::MakeTopicList_tex(CFuncInfoArr* pcFuncInfoArr)
 	int				j;
 	int				k;
 
-	const int nMaxStack = 8;	//	ƒlƒXƒg‚ÌÅ[
-	int nDepth = 0;				//	‚¢‚Ü‚ÌƒAƒCƒeƒ€‚Ì[‚³‚ğ•\‚·”’lB
-	wchar_t szTag[32], szTitle[256];			//	ˆê—Ìˆæ
-	int thisSection=0, lastSection = 0;	// Œ»İ‚ÌƒZƒNƒVƒ‡ƒ“í—Ş‚Æˆê‚Â‘O‚ÌƒZƒNƒVƒ‡ƒ“í—Ş
-	int stackSection[nMaxStack];		// Še[‚³‚Å‚ÌƒZƒNƒVƒ‡ƒ“‚Ì”Ô†
-	int nStartTitlePos = 0;				// \section{dddd} ‚Ì dddd ‚Ì•”•ª‚Ìn‚Ü‚é”Ô†
-	int bNoNumber = 0;					// * •t‚Ìê‡‚ÍƒZƒNƒVƒ‡ƒ“”Ô†‚ğ•t‚¯‚È‚¢
+	const int nMaxStack = 8;	//	ãƒã‚¹ãƒˆã®æœ€æ·±
+	int nDepth = 0;				//	ã„ã¾ã®ã‚¢ã‚¤ãƒ†ãƒ ã®æ·±ã•ã‚’è¡¨ã™æ•°å€¤ã€‚
+	wchar_t szTag[32], szTitle[256];			//	ä¸€æ™‚é ˜åŸŸ
+	int thisSection=0, lastSection = 0;	// ç¾åœ¨ã®ã‚»ã‚¯ã‚·ãƒ§ãƒ³ç¨®é¡ã¨ä¸€ã¤å‰ã®ã‚»ã‚¯ã‚·ãƒ§ãƒ³ç¨®é¡
+	int stackSection[nMaxStack];		// å„æ·±ã•ã§ã®ã‚»ã‚¯ã‚·ãƒ§ãƒ³ã®ç•ªå·
+	int nStartTitlePos = 0;				// \section{dddd} ã® dddd ã®éƒ¨åˆ†ã®å§‹ã¾ã‚‹ç•ªå·
+	int bNoNumber = 0;					// * ä»˜ã®å ´åˆã¯ã‚»ã‚¯ã‚·ãƒ§ãƒ³ç•ªå·ã‚’ä»˜ã‘ãªã„
 
-	// ˆês‚¸‚Â
+	// ä¸€è¡Œãšã¤
 	CLogicInt	nLineCount;
 	for(nLineCount=CLogicInt(0);nLineCount<m_pcDocRef->m_cDocLineMgr.GetLineCount();nLineCount++)
 	{
 		pLine	=	m_pcDocRef->m_cDocLineMgr.GetLine(nLineCount)->GetDocLineStrWithEOL(&nLineLen);
 		if(!pLine) break;
-		// ˆê•¶š‚¸‚Â
+		// ä¸€æ–‡å­—ãšã¤
 		for(i=0;i<nLineLen-1;i++)
 		{
-			if(pLine[i] == L'%') break;	// ƒRƒƒ“ƒg‚È‚çˆÈ~‚Í‚¢‚ç‚È‚¢
+			if(pLine[i] == L'%') break;	// ã‚³ãƒ¡ãƒ³ãƒˆãªã‚‰ä»¥é™ã¯ã„ã‚‰ãªã„
 			if(nDepth>=nMaxStack)continue;
-			if(pLine[i] != L'\\')continue;	// u\v‚ª‚È‚¢‚È‚çŸ‚Ì•¶š‚Ö
+			if(pLine[i] != L'\\')continue;	// ã€Œ\ã€ãŒãªã„ãªã‚‰æ¬¡ã®æ–‡å­—ã¸
 			++i;
-			// Œ©‚Â‚©‚Á‚½u\vˆÈ~‚Ì•¶š—ñƒ`ƒFƒbƒN
+			// è¦‹ã¤ã‹ã£ãŸã€Œ\ã€ä»¥é™ã®æ–‡å­—åˆ—ãƒã‚§ãƒƒã‚¯
 			for(j=0;i+j<nLineLen && j<_countof(szTag)-1;j++)
 			{
 				if(pLine[i+j] == L'{') { // }
@@ -108,8 +108,8 @@ void CDocOutline::MakeTopicList_tex(CFuncInfoArr* pcFuncInfoArr)
 			else if(!wcscmp(szTag,L"subsection")) thisSection = 3;
 			else if(!wcscmp(szTag,L"section")) thisSection = 2;
 			else if(!wcscmp(szTag,L"chapter")) thisSection = 1;
-			else if(!wcscmp(szTag,L"begin")) {		// begin‚È‚ç prosper‚Ìslide‚Ì‰Â”\«‚àl—¶
-				// ‚³‚ç‚É{slide}{}‚Ü‚Å“Ç‚İ‚Æ‚Á‚Ä‚¨‚­
+			else if(!wcscmp(szTag,L"begin")) {		// beginãªã‚‰ prosperã®slideã®å¯èƒ½æ€§ã‚‚è€ƒæ…®
+				// ã•ã‚‰ã«{slide}{}ã¾ã§èª­ã¿ã¨ã£ã¦ãŠã
 				if(wcsstr(pLine, L"{slide}")){
 					k=0;
 					for(j=nStartTitlePos+1;i+j<nLineLen && j<_countof(szTag)-1;j++)
@@ -127,7 +127,7 @@ void CDocOutline::MakeTopicList_tex(CFuncInfoArr* pcFuncInfoArr)
 
 			if( thisSection > 0)
 			{
-				// section‚Ì’†gæ“¾
+				// sectionã®ä¸­èº«å–å¾—
 				for(k=0;nStartTitlePos+k<nLineLen && k<_countof(szTitle)-1;k++)
 				{
 					// {
@@ -182,7 +182,7 @@ void CDocOutline::MakeTopicList_tex(CFuncInfoArr* pcFuncInfoArr)
 
 
 const wchar_t* g_ppszKeywordsTEX[] = {
-//Nov. 20, 2000 JEPRO	‘å•’Ç‰Á & áŠ±C³Eíœ --‚Ù‚Æ‚ñ‚ÇƒRƒ}ƒ“ƒh‚Ì‚İ
+//Nov. 20, 2000 JEPRO	å¤§å¹…è¿½åŠ  & è‹¥å¹²ä¿®æ­£ãƒ»å‰Šé™¤ --ã»ã¨ã‚“ã©ã‚³ãƒãƒ³ãƒ‰ã®ã¿
 	L"error",
 	L"Warning",
 //			"center",
@@ -715,10 +715,10 @@ const wchar_t* g_ppszKeywordsTEX[] = {
 };
 int g_nKeywordsTEX = _countof(g_ppszKeywordsTEX);
 
-//Jan. 19, 2001 JEPRO	TeX ‚ÌƒL[ƒ[ƒh2‚Æ‚µ‚ÄV‹K’Ç‰Á & ˆê•”•œŠˆ --ŠÂ‹«ƒRƒ}ƒ“ƒh‚ÆƒIƒvƒVƒ‡ƒ“–¼‚ª’†S
+//Jan. 19, 2001 JEPRO	TeX ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰2ã¨ã—ã¦æ–°è¦è¿½åŠ  & ä¸€éƒ¨å¾©æ´» --ç’°å¢ƒã‚³ãƒãƒ³ãƒ‰ã¨ã‚ªãƒ—ã‚·ãƒ§ãƒ³åãŒä¸­å¿ƒ
 const wchar_t* g_ppszKeywordsTEX2[] = {
-	//	ŠÂ‹«ƒRƒ}ƒ“ƒh
-	//Jan. 19, 2001 JEPRO –{“–‚Í{}•t‚«‚ÅƒL[ƒ[ƒh‚É‚µ‚½‚©‚Á‚½‚ª’PŒê‚Æ‚µ‚Ä”F¯‚µ‚Ä‚­‚ê‚È‚¢‚Ì‚Å~‚ß‚½
+	//	ç’°å¢ƒã‚³ãƒãƒ³ãƒ‰
+	//Jan. 19, 2001 JEPRO æœ¬å½“ã¯{}ä»˜ãã§ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã«ã—ãŸã‹ã£ãŸãŒå˜èªã¨ã—ã¦èªè­˜ã—ã¦ãã‚Œãªã„ã®ã§æ­¢ã‚ãŸ
 	L"abstract",
 	L"array",
 	L"center",
@@ -764,7 +764,7 @@ const wchar_t* g_ppszKeywordsTEX2[] = {
 	L"verbatim*",
 	L"verse",
 	L"wrapfigure",
-	//	ƒXƒ^ƒCƒ‹ƒIƒvƒVƒ‡ƒ“
+	//	ã‚¹ã‚¿ã‚¤ãƒ«ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 	L"a4",
 	L"a4j",
 	L"a5",

--- a/sakura_core/types/CType_Text.cpp
+++ b/sakura_core/types/CType_Text.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -32,48 +32,48 @@
 #include "outline/CFuncInfoArr.h"
 #include "view/colors/EColorIndexType.h"
 
-/* ƒeƒLƒXƒg */
-//Sep. 20, 2000 JEPRO ƒeƒLƒXƒg‚Ì‹K’è’l‚ğ80¨120‚É•ÏX(•s‹ï‡ˆê——.txt‚ª‚ ‚é’ö“x“Ç‚İ‚â‚·‚¢Œ…”)
-//Nov. 15, 2000 JEPRO PostScriptƒtƒ@ƒCƒ‹‚à“Ç‚ß‚é‚æ‚¤‚É‚·‚é
-//Jan. 12, 2001 JEPRO readme.1st ‚à“Ç‚ß‚é‚æ‚¤‚É‚·‚é
-//Feb. 12, 2001 JEPRO .err ƒGƒ‰[ƒƒbƒZ[ƒW
-//Nov.  6, 2002 genta doc‚ÍMS Word‚É÷‚Á‚Ä‚±‚±‚©‚ç‚ÍŠO‚·iŠÖ˜A‚Ã‚¯–h~‚Ì‚½‚ßj
-//Nov.  6, 2002 genta log ‚ğ’Ç‰Á
+/* ãƒ†ã‚­ã‚¹ãƒˆ */
+//Sep. 20, 2000 JEPRO ãƒ†ã‚­ã‚¹ãƒˆã®è¦å®šå€¤ã‚’80â†’120ã«å¤‰æ›´(ä¸å…·åˆä¸€è¦§.txtãŒã‚ã‚‹ç¨‹åº¦èª­ã¿ã‚„ã™ã„æ¡æ•°)
+//Nov. 15, 2000 JEPRO PostScriptãƒ•ã‚¡ã‚¤ãƒ«ã‚‚èª­ã‚ã‚‹ã‚ˆã†ã«ã™ã‚‹
+//Jan. 12, 2001 JEPRO readme.1st ã‚‚èª­ã‚ã‚‹ã‚ˆã†ã«ã™ã‚‹
+//Feb. 12, 2001 JEPRO .err ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
+//Nov.  6, 2002 genta docã¯MS Wordã«è­²ã£ã¦ã“ã“ã‹ã‚‰ã¯å¤–ã™ï¼ˆé–¢é€£ã¥ã‘é˜²æ­¢ã®ãŸã‚ï¼‰
+//Nov.  6, 2002 genta log ã‚’è¿½åŠ 
 void CType_Text::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£q
-	_tcscpy( pType->m_szTypeName, _T("ƒeƒLƒXƒg") );
+	//åå‰ã¨æ‹¡å¼µå­
+	_tcscpy( pType->m_szTypeName, _T("ãƒ†ã‚­ã‚¹ãƒˆ") );
 	_tcscpy( pType->m_szTypeExts, _T("txt,log,1st,err,ps") );
 
-	//İ’è
-	pType->m_nMaxLineKetas = CKetaXInt(120);					/* Ü‚è•Ô‚µŒ…” */
-	pType->m_eDefaultOutline = OUTLINE_TEXT;					/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
-	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//Oct. 17, 2000 JEPRO	ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ‚ğF•ª‚¯•\¦‚µ‚È‚¢
-	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	//Sept. 4, 2000 JEPRO	ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ‚ğF•ª‚¯•\¦‚µ‚È‚¢
-	pType->m_bKinsokuHead = false;								// s“ª‹Ö‘¥				//@@@ 2002.04.08 MIK
-	pType->m_bKinsokuTail = false;								// s––‹Ö‘¥				//@@@ 2002.04.08 MIK
-	pType->m_bKinsokuRet  = false;								// ‰üs•¶š‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.13 MIK
-	pType->m_bKinsokuKuto = false;								// ‹å“Ç“_‚ğ‚Ô‚ç‰º‚°‚é	//@@@ 2002.04.17 MIK
-	wcscpy( pType->m_szKinsokuHead, L"!%),.:;?]}\xa2‹fhñŒABXrtvxzlJKTUERSI“jCDFGHnp¡£¤¥Şß‘" );		/* s“ª‹Ö‘¥ */	//@@@ 2002.04.13 MIK 
-	wcscpy( pType->m_szKinsokuTail, L"$([\\{\xa3\xa5egqsuwykimo¢’" );		/* s––‹Ö‘¥ */	//@@@ 2002.04.08 MIK 
-	// pType->m_szKinsokuKutoi‹å“Ç“_‚Ô‚ç‰º‚°•¶šj‚Í‚±‚±‚Å‚Í‚È‚­‘Sƒ^ƒCƒv‚ÉƒfƒtƒHƒ‹ƒgİ’è	// 2009.08.07 ryoji 
+	//è¨­å®š
+	pType->m_nMaxLineKetas = CKetaXInt(120);					/* æŠ˜ã‚Šè¿”ã—æ¡æ•° */
+	pType->m_eDefaultOutline = OUTLINE_TEXT;					/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
+	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//Oct. 17, 2000 JEPRO	ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„
+	pType->m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp = false;	//Sept. 4, 2000 JEPRO	ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„
+	pType->m_bKinsokuHead = false;								// è¡Œé ­ç¦å‰‡				//@@@ 2002.04.08 MIK
+	pType->m_bKinsokuTail = false;								// è¡Œæœ«ç¦å‰‡				//@@@ 2002.04.08 MIK
+	pType->m_bKinsokuRet  = false;								// æ”¹è¡Œæ–‡å­—ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.13 MIK
+	pType->m_bKinsokuKuto = false;								// å¥èª­ç‚¹ã‚’ã¶ã‚‰ä¸‹ã’ã‚‹	//@@@ 2002.04.17 MIK
+	wcscpy( pType->m_szKinsokuHead, L"!%),.:;?]}\xa2Â°â€™â€â€°â€²â€³â„ƒã€ã€‚ã€…ã€‰ã€‹ã€ã€ã€‘ã€•ã‚›ã‚œã‚ã‚ãƒ»ãƒ½ãƒ¾ï¼ï¼…ï¼‰ï¼Œï¼ï¼šï¼›ï¼Ÿï¼½ï½ï½¡ï½£ï½¤ï½¥ï¾ï¾Ÿï¿ " );		/* è¡Œé ­ç¦å‰‡ */	//@@@ 2002.04.13 MIK 
+	wcscpy( pType->m_szKinsokuTail, L"$([\\{\xa3\xa5â€˜â€œã€ˆã€Šã€Œã€ã€ã€”ï¼„ï¼ˆï¼»ï½›ï½¢ï¿¡ï¿¥" );		/* è¡Œæœ«ç¦å‰‡ */	//@@@ 2002.04.08 MIK 
+	// pType->m_szKinsokuKutoï¼ˆå¥èª­ç‚¹ã¶ã‚‰ä¸‹ã’æ–‡å­—ï¼‰ã¯ã“ã“ã§ã¯ãªãå…¨ã‚¿ã‚¤ãƒ—ã«ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè¨­å®š	// 2009.08.07 ryoji 
 
-	//¦¬‚³‚ÈeØ‚Æ‚µ‚ÄAC:\`` ‚â \\`` ‚È‚Ç‚Ìƒtƒ@ƒCƒ‹ƒpƒX‚ğƒNƒŠƒbƒJƒuƒ‹‚É‚·‚éİ’è‚ğuƒeƒLƒXƒgv‚ÉŠù’è‚Åd‚Ş
-	//¦""‚Å‹²‚Ü‚ê‚éİ’è‚Í‹²‚Ü‚ê‚È‚¢İ’è‚æ‚è‚àã‚É–³‚¯‚ê‚Î‚È‚ç‚È‚¢
-	//¦""‚Å‹²‚Ü‚ê‚éİ’è‚ğ•¡»‚µ‚Ä‚¿‚å‚Á‚ÆC³‚·‚ê‚ÎA<>‚â[]‚É‹²‚Ü‚ê‚½‚à‚Ì‚É‚à‘Î‰‚Å‚«‚éiƒ†[ƒU‚É”C‚¹‚éj
+	//â€»å°ã•ãªè¦ªåˆ‡ã¨ã—ã¦ã€C:\ï½ï½ ã‚„ \\ï½ï½ ãªã©ã®ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã‚’ã‚¯ãƒªãƒƒã‚«ãƒ–ãƒ«ã«ã™ã‚‹è¨­å®šã‚’ã€Œãƒ†ã‚­ã‚¹ãƒˆã€ã«æ—¢å®šã§ä»•è¾¼ã‚€
+	//â€»""ã§æŒŸã¾ã‚Œã‚‹è¨­å®šã¯æŒŸã¾ã‚Œãªã„è¨­å®šã‚ˆã‚Šã‚‚ä¸Šã«ç„¡ã‘ã‚Œã°ãªã‚‰ãªã„
+	//â€»""ã§æŒŸã¾ã‚Œã‚‹è¨­å®šã‚’è¤‡è£½ã—ã¦ã¡ã‚‡ã£ã¨ä¿®æ­£ã™ã‚Œã°ã€<>ã‚„[]ã«æŒŸã¾ã‚ŒãŸã‚‚ã®ã«ã‚‚å¯¾å¿œã§ãã‚‹ï¼ˆãƒ¦ãƒ¼ã‚¶ã«ä»»ã›ã‚‹ï¼‰
 
-	//³‹K•\Œ»ƒL[ƒ[ƒh
+	//æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
 	int keywordPos = 0;
 	wchar_t* pKeyword = pType->m_RegexKeywordList;
-	pType->m_bUseRegexKeyword = true;							// ³‹K•\Œ»ƒL[ƒ[ƒh‚ğg‚¤‚©
-	pType->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_URL;	// Fw’è”Ô†
-	wcscpyn( &pKeyword[keywordPos],			// ³‹K•\Œ»ƒL[ƒ[ƒh
-		L"/(?<=\")(\\b[a-zA-Z]:|\\B\\\\\\\\)[^\"\\r\\n]*/k",			//   ""‚Å‹²‚Ü‚ê‚½ C:\`, \\` ‚Éƒ}ƒbƒ`‚·‚éƒpƒ^[ƒ“
+	pType->m_bUseRegexKeyword = true;							// æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’ä½¿ã†ã‹
+	pType->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_URL;	// è‰²æŒ‡å®šç•ªå·
+	wcscpyn( &pKeyword[keywordPos],			// æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+		L"/(?<=\")(\\b[a-zA-Z]:|\\B\\\\\\\\)[^\"\\r\\n]*/k",			//   ""ã§æŒŸã¾ã‚ŒãŸ C:\ï½, \\ï½ ã«ãƒãƒƒãƒã™ã‚‹ãƒ‘ã‚¿ãƒ¼ãƒ³
 		_countof(pType->m_RegexKeywordList) - 1 );
 	keywordPos += auto_strlen(&pKeyword[keywordPos]) + 1;
-	pType->m_RegexKeywordArr[1].m_nColorIndex = COLORIDX_URL;	// Fw’è”Ô†
-	wcscpyn( &pKeyword[keywordPos],			// ³‹K•\Œ»ƒL[ƒ[ƒh
-		L"/(\\b[a-zA-Z]:\\\\|\\B\\\\\\\\)[\\w\\-_.\\\\\\/$%~]*/k",		//   C:\`, \\` ‚Éƒ}ƒbƒ`‚·‚éƒpƒ^[ƒ“
+	pType->m_RegexKeywordArr[1].m_nColorIndex = COLORIDX_URL;	// è‰²æŒ‡å®šç•ªå·
+	wcscpyn( &pKeyword[keywordPos],			// æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+		L"/(\\b[a-zA-Z]:\\\\|\\B\\\\\\\\)[\\w\\-_.\\\\\\/$%~]*/k",		//   C:\ï½, \\ï½ ã«ãƒãƒƒãƒã™ã‚‹ãƒ‘ã‚¿ãƒ¼ãƒ³
 		_countof(pType->m_RegexKeywordList) - keywordPos - 1 );
 	keywordPos += auto_strlen(&pKeyword[keywordPos]) + 1;
 	pKeyword[keywordPos] = L'\0';
@@ -82,39 +82,39 @@ void CType_Text::InitTypeConfigImp(STypeConfig* pType)
 
 
 
-/*!	ƒeƒLƒXƒgEƒgƒsƒbƒNƒŠƒXƒgì¬
+/*!	ãƒ†ã‚­ã‚¹ãƒˆãƒ»ãƒˆãƒ”ãƒƒã‚¯ãƒªã‚¹ãƒˆä½œæˆ
 	
-	@date 2002.04.01 YAZAKI CDlgFuncList::SetText()‚ğg—p‚·‚é‚æ‚¤‚É‰ü’ùB
-	@date 2002.11.03 Moca	ŠK‘w‚ªÅ‘å’l‚ğ’´‚¦‚é‚Æƒoƒbƒtƒ@ƒI[ƒo[ƒ‰ƒ“‚·‚é‚Ì‚ğC³
-							Å‘å’lˆÈã‚Í’Ç‰Á‚¹‚¸‚É–³‹‚·‚é
-	@date 2007.8    kobake ‹@ŠB“I‚ÉUNICODE‰»
-	@date 2007.11.29 kobake UNICODE‘Î‰‚Å‚«‚Ä‚È‚©‚Á‚½‚Ì‚ÅC³
+	@date 2002.04.01 YAZAKI CDlgFuncList::SetText()ã‚’ä½¿ç”¨ã™ã‚‹ã‚ˆã†ã«æ”¹è¨‚ã€‚
+	@date 2002.11.03 Moca	éšå±¤ãŒæœ€å¤§å€¤ã‚’è¶…ãˆã‚‹ã¨ãƒãƒƒãƒ•ã‚¡ã‚ªãƒ¼ãƒãƒ¼ãƒ©ãƒ³ã™ã‚‹ã®ã‚’ä¿®æ­£
+							æœ€å¤§å€¤ä»¥ä¸Šã¯è¿½åŠ ã›ãšã«ç„¡è¦–ã™ã‚‹
+	@date 2007.8é ƒ   kobake æ©Ÿæ¢°çš„ã«UNICODEåŒ–
+	@date 2007.11.29 kobake UNICODEå¯¾å¿œã§ãã¦ãªã‹ã£ãŸã®ã§ä¿®æ­£
 */
 void CDocOutline::MakeTopicList_txt( CFuncInfoArr* pcFuncInfoArr )
 {
 	using namespace WCODE;
 
-	//Œ©o‚µ‹L†
+	//è¦‹å‡ºã—è¨˜å·
 	const wchar_t*	pszStarts = GetDllShareData().m_Common.m_sFormat.m_szMidashiKigou;
 	int				nStartsLen = wcslen( pszStarts );
 
-	/*	ƒlƒXƒg‚Ì[‚³‚ÍAnMaxStackƒŒƒxƒ‹‚Ü‚ÅA‚Ğ‚Æ‚Â‚Ìƒwƒbƒ_‚ÍAÅ’·32•¶š‚Ü‚Å‹æ•Ê
-		i32•¶š‚Ü‚Å“¯‚¶‚¾‚Á‚½‚ç“¯‚¶‚à‚Ì‚Æ‚µ‚Äˆµ‚¢‚Ü‚·j
+	/*	ãƒã‚¹ãƒˆã®æ·±ã•ã¯ã€nMaxStackãƒ¬ãƒ™ãƒ«ã¾ã§ã€ã²ã¨ã¤ã®ãƒ˜ãƒƒãƒ€ã¯ã€æœ€é•·32æ–‡å­—ã¾ã§åŒºåˆ¥
+		ï¼ˆ32æ–‡å­—ã¾ã§åŒã˜ã ã£ãŸã‚‰åŒã˜ã‚‚ã®ã¨ã—ã¦æ‰±ã„ã¾ã™ï¼‰
 	*/
-	const int nMaxStack = 32;	//	ƒlƒXƒg‚ÌÅ[
-	int nDepth = 0;				//	‚¢‚Ü‚ÌƒAƒCƒeƒ€‚Ì[‚³‚ğ•\‚·”’lB
+	const int nMaxStack = 32;	//	ãƒã‚¹ãƒˆã®æœ€æ·±
+	int nDepth = 0;				//	ã„ã¾ã®ã‚¢ã‚¤ãƒ†ãƒ ã®æ·±ã•ã‚’è¡¨ã™æ•°å€¤ã€‚
 	wchar_t pszStack[nMaxStack][32];
-	wchar_t szTitle[32];			//	ˆê—Ìˆæ
+	wchar_t szTitle[32];			//	ä¸€æ™‚é ˜åŸŸ
 	CLogicInt				nLineCount;
 	bool b278a = false;
 	for( nLineCount = CLogicInt(0); nLineCount <  m_pcDocRef->m_cDocLineMgr.GetLineCount(); ++nLineCount )
 	{
-		//sæ“¾
+		//è¡Œå–å¾—
 		CLogicInt		nLineLen;
 		const wchar_t*	pLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLineCount)->GetDocLineStrWithEOL(&nLineLen);
 		if( NULL == pLine )break;
 
-		//s“ª‚Ì‹ó”’”ò‚Î‚µ
+		//è¡Œé ­ã®ç©ºç™½é£›ã°ã—
 		int i;
 		for( i = 0; i < nLineLen; ++i ){
 			if( WCODE::IsBlank(pLine[i]) ){
@@ -126,7 +126,7 @@ void CDocOutline::MakeTopicList_txt( CFuncInfoArr* pcFuncInfoArr )
 			continue;
 		}
 
-		//æ“ª•¶š‚ªŒ©o‚µ‹L†‚Ì‚¢‚¸‚ê‚©‚Å‚ ‚ê‚ÎAŸ‚Öi‚Ş
+		//å…ˆé ­æ–‡å­—ãŒè¦‹å‡ºã—è¨˜å·ã®ã„ãšã‚Œã‹ã§ã‚ã‚Œã°ã€æ¬¡ã¸é€²ã‚€
 		int j;
 		int nCharChars;
 		int nCharChars2;
@@ -144,45 +144,45 @@ void CDocOutline::MakeTopicList_txt( CFuncInfoArr* pcFuncInfoArr )
 			continue;
 		}
 
-		//Œ©o‚µí—Ş‚Ì”»•Ê -> szTitle
+		//è¦‹å‡ºã—ç¨®é¡ã®åˆ¤åˆ¥ -> szTitle
 		if( pLine[i] == L'(' ){
-			     if ( IsInRange(pLine[i + 1], L'0', L'9') ) wcscpy( szTitle, L"(0)" ); //”š
-			else if ( IsInRange(pLine[i + 1], L'A', L'Z') ) wcscpy( szTitle, L"(A)" ); //‰p‘å•¶š
-			else if ( IsInRange(pLine[i + 1], L'a', L'z') ) wcscpy( szTitle, L"(a)" ); //‰p¬•¶š
-			else continue; //¦u(v‚ÌŸ‚ª‰p”š‚Å–³‚¢ê‡AŒ©o‚µ‚Æ‚İ‚È‚³‚È‚¢
+			     if ( IsInRange(pLine[i + 1], L'0', L'9') ) wcscpy( szTitle, L"(0)" ); //æ•°å­—
+			else if ( IsInRange(pLine[i + 1], L'A', L'Z') ) wcscpy( szTitle, L"(A)" ); //è‹±å¤§æ–‡å­—
+			else if ( IsInRange(pLine[i + 1], L'a', L'z') ) wcscpy( szTitle, L"(a)" ); //è‹±å°æ–‡å­—
+			else continue; //â€»ã€Œ(ã€ã®æ¬¡ãŒè‹±æ•°å­—ã§ç„¡ã„å ´åˆã€è¦‹å‡ºã—ã¨ã¿ãªã•ãªã„
 		}
-		else if( IsInRange(pLine[i], L'‚O', L'‚X') ) wcscpy( szTitle, L"‚O" ); // ‘SŠp”š
-		else if( IsInRange(pLine[i], L'‡@', L'‡S') || pLine[i] == L'\u24ea'
-			|| IsInRange(pLine[i], L'\u3251', L'\u325f') || IsInRange(pLine[i], L'\u32b1', L'\u32bf') ) wcscpy( szTitle, L"‡@" ); // ‡@`‡S ›0@›21›35@›36›50
-		else if( IsInRange(pLine[i], L'‡T', L'\u216f') ) wcscpy( szTitle, L"‡T" ); // ‡T`‡]@XIXIILCDM
-		else if( IsInRange(pLine[i], L'ú@', L'\u217f') ) wcscpy( szTitle, L"‡T" ); // ‡T`‡]@xixiilcdm
+		else if( IsInRange(pLine[i], L'ï¼', L'ï¼™') ) wcscpy( szTitle, L"ï¼" ); // å…¨è§’æ•°å­—
+		else if( IsInRange(pLine[i], L'â‘ ', L'â‘³') || pLine[i] == L'\u24ea'
+			|| IsInRange(pLine[i], L'\u3251', L'\u325f') || IsInRange(pLine[i], L'\u32b1', L'\u32bf') ) wcscpy( szTitle, L"â‘ " ); // â‘ ï½â‘³ â—‹0ã€€â—‹21â—‹35ã€€â—‹36â—‹50
+		else if( IsInRange(pLine[i], L'â… ', L'\u216f') ) wcscpy( szTitle, L"â… " ); // â… ï½â…©ã€€XIXIILCDM
+		else if( IsInRange(pLine[i], L'â…°', L'\u217f') ) wcscpy( szTitle, L"â… " ); // â… ï½â…©ã€€xixiilcdm
 		else if( IsInRange(pLine[i], L'\u2474', L'\u2487') ) wcscpy( szTitle, L"\u2474" ); // (1)-(20)
 		else if( IsInRange(pLine[i], L'\u2488', L'\u249b') ) wcscpy( szTitle, L"\u2488" ); // 1.-20.
 		else if( IsInRange(pLine[i], L'\u249c', L'\u24b5') ) wcscpy( szTitle, L"\u249c" ); // (a)-(z)
-		else if( IsInRange(pLine[i], L'\u24b6', L'\u24cf') ) wcscpy( szTitle, L"\u24b6" ); // ›A-›Z
-		else if( IsInRange(pLine[i], L'\u24d0', L'\u24e9') ) wcscpy( szTitle, L"\u24d0" ); // ›a-›z
-		else if( IsInRange(pLine[i], L'\u24eb', L'\u24f4') ){ // œ11-œ20
+		else if( IsInRange(pLine[i], L'\u24b6', L'\u24cf') ) wcscpy( szTitle, L"\u24b6" ); // â—‹A-â—‹Z
+		else if( IsInRange(pLine[i], L'\u24d0', L'\u24e9') ) wcscpy( szTitle, L"\u24d0" ); // â—‹a-â—‹z
+		else if( IsInRange(pLine[i], L'\u24eb', L'\u24f4') ){ // â—11-â—20
 			if(b278a){ wcscpy( szTitle, L"\u278a" ); }
 			else{ wcscpy( szTitle, L"\u2776" ); } }
-		else if( IsInRange(pLine[i], L'\u24f5', L'\u24fe') ) wcscpy( szTitle, L"\u24f5" ); // 1-10
-		else if( IsInRange(pLine[i], L'\u2776', L'\u277f') ) wcscpy( szTitle, L"\u2776" ); // œ1-œ10
-		else if( IsInRange(pLine[i], L'\u2780', L'\u2789') ) wcscpy( szTitle, L"\u2780" ); // ›1-›10
-		else if( IsInRange(pLine[i], L'\u278a', L'\u2793') ){ wcscpy( szTitle, L"\u278a" ); b278a = true; } // œ1-œ10(SANS-SERIF)
-		else if( IsInRange(pLine[i], L'\u3220', L'\u3229') ) wcscpy( szTitle, L"\ua3220" ); // (ˆê)-(\)
-		else if( IsInRange(pLine[i], L'\u3280', L'\u3289') ) wcscpy( szTitle, L"\u3220" ); // ›ˆê-›\
-		else if( IsInRange(pLine[i], L'\u32d0', L'\u32fe') ) wcscpy( szTitle, L"\u32d0" ); // ›ƒA-›ƒ’
-		else if( wcschr(L"Zˆê“ñOlŒÜ˜Zµ”ª‹ã\•S—ëˆë“óQŒŞ", pLine[i]) ) wcscpy( szTitle, L"ˆê" ); //Š¿”š
+		else if( IsInRange(pLine[i], L'\u24f5', L'\u24fe') ) wcscpy( szTitle, L"\u24f5" ); // â—1-â—10
+		else if( IsInRange(pLine[i], L'\u2776', L'\u277f') ) wcscpy( szTitle, L"\u2776" ); // â—1-â—10
+		else if( IsInRange(pLine[i], L'\u2780', L'\u2789') ) wcscpy( szTitle, L"\u2780" ); // â—‹1-â—‹10
+		else if( IsInRange(pLine[i], L'\u278a', L'\u2793') ){ wcscpy( szTitle, L"\u278a" ); b278a = true; } // â—1-â—10(SANS-SERIF)
+		else if( IsInRange(pLine[i], L'\u3220', L'\u3229') ) wcscpy( szTitle, L"\ua3220" ); // (ä¸€)-(å)
+		else if( IsInRange(pLine[i], L'\u3280', L'\u3289') ) wcscpy( szTitle, L"\u3220" ); // â—‹ä¸€-â—‹å
+		else if( IsInRange(pLine[i], L'\u32d0', L'\u32fe') ) wcscpy( szTitle, L"\u32d0" ); // â—‹ã‚¢-â—‹ãƒ²
+		else if( wcschr(L"ã€‡ä¸€äºŒä¸‰å››äº”å…­ä¸ƒå…«ä¹åç™¾é›¶å£±å¼å‚ä¼", pLine[i]) ) wcscpy( szTitle, L"ä¸€" ); //æ¼¢æ•°å­—
 		else{
-			wcsncpy( szTitle, &pLine[i], nCharChars );	//	æ“ª•¶š‚ğszTitle‚É•ÛB
+			wcsncpy( szTitle, &pLine[i], nCharChars );	//	å…ˆé ­æ–‡å­—ã‚’szTitleã«ä¿æŒã€‚
 			szTitle[nCharChars] = L'\0';
 		}
 
-		/*	uŒ©o‚µ‹L†v‚ÉŠÜ‚Ü‚ê‚é•¶š‚Ån‚Ü‚é‚©A
-			(0A(1A...(9A(AA(BA...(ZA(aA(bA...(z
-			‚Ån‚Ü‚és‚ÍAƒAƒEƒgƒ‰ƒCƒ“Œ‹‰Ê‚É•\¦‚·‚éB
+		/*	ã€Œè¦‹å‡ºã—è¨˜å·ã€ã«å«ã¾ã‚Œã‚‹æ–‡å­—ã§å§‹ã¾ã‚‹ã‹ã€
+			(0ã€(1ã€...(9ã€(Aã€(Bã€...(Zã€(aã€(bã€...(z
+			ã§å§‹ã¾ã‚‹è¡Œã¯ã€ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³çµæœã«è¡¨ç¤ºã™ã‚‹ã€‚
 		*/
 
-		//s•¶š—ñ‚©‚ç‰üs‚ğæ‚èœ‚­ pLine -> pszText
+		//è¡Œæ–‡å­—åˆ—ã‹ã‚‰æ”¹è¡Œã‚’å–ã‚Šé™¤ã pLine -> pszText
 		const wchar_t*	pszText = &pLine[i];
 		nLineLen -= i;
 		const bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
@@ -195,10 +195,10 @@ void CDocOutline::MakeTopicList_txt( CFuncInfoArr* pcFuncInfoArr )
 		pszText = strText.c_str();
 
 		/*
-		  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-		  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-		  ¨
-		  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+		  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+		  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+		  â†’
+		  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 		*/
 		CLayoutPoint ptPos;
 		m_pcDocRef->m_cLayoutMgr.LogicToLayout(
@@ -206,7 +206,7 @@ void CDocOutline::MakeTopicList_txt( CFuncInfoArr* pcFuncInfoArr )
 			&ptPos
 		);
 
-		/* nDepth‚ğŒvZ */
+		/* nDepthã‚’è¨ˆç®— */
 		int k;
 		bool bAppend = true;
 		for ( k = 0; k < nDepth; k++ ){
@@ -216,17 +216,17 @@ void CDocOutline::MakeTopicList_txt( CFuncInfoArr* pcFuncInfoArr )
 			}
 		}
 		if ( k < nDepth ){
-			//	ƒ‹[ƒv“r’†‚Åbreak;‚µ‚Ä‚«‚½B¡‚Ü‚Å‚É“¯‚¶Œ©o‚µ‚ª‘¶İ‚µ‚Ä‚¢‚½B
-			//	‚Ì‚ÅA“¯‚¶ƒŒƒxƒ‹‚É‡‚í‚¹‚ÄAppendData.
+			//	ãƒ«ãƒ¼ãƒ—é€”ä¸­ã§break;ã—ã¦ããŸã€‚ï¼ä»Šã¾ã§ã«åŒã˜è¦‹å‡ºã—ãŒå­˜åœ¨ã—ã¦ã„ãŸã€‚
+			//	ã®ã§ã€åŒã˜ãƒ¬ãƒ™ãƒ«ã«åˆã‚ã›ã¦AppendData.
 			nDepth = k;
 		}
 		else if( nMaxStack > k ){
-			//	‚¢‚Ü‚Ü‚Å‚É“¯‚¶Œ©o‚µ‚ª‘¶İ‚µ‚È‚©‚Á‚½B
-			//	‚Ì‚ÅApszStack‚ÉƒRƒs[‚µ‚ÄAppendData.
+			//	ã„ã¾ã¾ã§ã«åŒã˜è¦‹å‡ºã—ãŒå­˜åœ¨ã—ãªã‹ã£ãŸã€‚
+			//	ã®ã§ã€pszStackã«ã‚³ãƒ”ãƒ¼ã—ã¦AppendData.
 			wcscpy(pszStack[nDepth], szTitle);
 		}
 		else{
-			// 2002.11.03 Moca Å‘å’l‚ğ’´‚¦‚é‚Æƒoƒbƒtƒ@ƒI[ƒo[ƒ‰ƒ“
+			// 2002.11.03 Moca æœ€å¤§å€¤ã‚’è¶…ãˆã‚‹ã¨ãƒãƒƒãƒ•ã‚¡ã‚ªãƒ¼ãƒãƒ¼ãƒ©ãƒ³
 			// nDepth = nMaxStack;
 			bAppend = false;
 		}
@@ -243,12 +243,12 @@ void CDocOutline::MakeTopicList_txt( CFuncInfoArr* pcFuncInfoArr )
 
 
 
-/*! ŠK‘w•t‚«ƒeƒLƒXƒg ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ
+/*! éšå±¤ä»˜ããƒ†ã‚­ã‚¹ãƒˆ ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£æ
 
 	@author zenryaku
-	@date 2003.05.20 zenryaku V‹Kì¬
-	@date 2003.05.25 genta À‘••û–@ˆê•”C³
-	@date 2003.06.21 Moca ŠK‘w‚ª2’iˆÈã[‚­‚È‚éê‡‚ğl—¶
+	@date 2003.05.20 zenryaku æ–°è¦ä½œæˆ
+	@date 2003.05.25 genta å®Ÿè£…æ–¹æ³•ä¸€éƒ¨ä¿®æ­£
+	@date 2003.06.21 Moca éšå±¤ãŒ2æ®µä»¥ä¸Šæ·±ããªã‚‹å ´åˆã‚’è€ƒæ…®
 */
 void CDocOutline::MakeTopicList_wztxt(CFuncInfoArr* pcFuncInfoArr)
 {
@@ -265,14 +265,14 @@ void CDocOutline::MakeTopicList_wztxt(CFuncInfoArr* pcFuncInfoArr)
 		{
 			break;
 		}
-		//	May 25, 2003 genta ”»’è‡˜•ÏX
+		//	May 25, 2003 genta åˆ¤å®šé †åºå¤‰æ›´
 		if( *pLine == L'.' )
 		{
 			const wchar_t* pPos;	//	May 25, 2003 genta
 			int			nLength;
 			wchar_t		szTitle[1024];
 
-			//	ƒsƒŠƒIƒh‚Ì”ŠK‘w‚Ì[‚³‚ğ”‚¦‚é
+			//	ãƒ”ãƒªã‚ªãƒ‰ã®æ•°ï¼éšå±¤ã®æ·±ã•ã‚’æ•°ãˆã‚‹
 			for( pPos = pLine + 1 ; *pPos == L'.' ; ++pPos )
 				;
 
@@ -284,11 +284,11 @@ void CDocOutline::MakeTopicList_wztxt(CFuncInfoArr* pcFuncInfoArr)
 			
 			int level = pPos - pLine;
 
-			// 2003.06.27 Moca ŠK‘w‚ª2’iˆÊã[‚­‚È‚é‚Æ‚«‚ÍA–³‘è‚Ì—v‘f‚ğ’Ç‰Á
+			// 2003.06.27 Moca éšå±¤ãŒ2æ®µä½ä¸Šæ·±ããªã‚‹ã¨ãã¯ã€ç„¡é¡Œã®è¦ç´ ã‚’è¿½åŠ 
 			if( levelPrev < level && level != levelPrev + 1  ){
 				int dummyLevel;
-				// (–³‘è)‚ğ‘}“ü
-				//	‚½‚¾‚µCTAGˆê——‚É‚Ío—Í‚³‚ê‚È‚¢‚æ‚¤‚É
+				// (ç„¡é¡Œ)ã‚’æŒ¿å…¥
+				//	ãŸã ã—ï¼ŒTAGä¸€è¦§ã«ã¯å‡ºåŠ›ã•ã‚Œãªã„ã‚ˆã†ã«
 				for( dummyLevel = levelPrev + 1; dummyLevel < level; dummyLevel++ ){
 					pcFuncInfoArr->AppendData(
 						nLineCount+CLogicInt(1),
@@ -303,7 +303,7 @@ void CDocOutline::MakeTopicList_wztxt(CFuncInfoArr* pcFuncInfoArr)
 
 			nLength = auto_sprintf(szTitle,L"%d - ", level );
 			
-			wchar_t *pDest = szTitle + nLength; // ‘‚«‚İæ
+			wchar_t *pDest = szTitle + nLength; // æ›¸ãè¾¼ã¿å…ˆ
 			wchar_t *pDestEnd = szTitle + _countof(szTitle) - 2;
 			
 			while( pDest < pDestEnd )

--- a/sakura_core/types/CType_Vb.cpp
+++ b/sakura_core/types/CType_Vb.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -31,63 +31,63 @@
 #include "view/Colors/EColorIndexType.h"
 
 /* Visual Basic */
-//JUl. 10, 2001 JEPRO VB   ƒ†[ƒU‚É‘¡‚é
-//Jul. 09, 2001 JEPRO ’Ç‰Á //Dec. 16, 2002 MIK’Ç‰Á // Feb. 19, 2006 genta .vb’Ç‰Á
+//JUl. 10, 2001 JEPRO VB   ãƒ¦ãƒ¼ã‚¶ã«è´ˆã‚‹
+//Jul. 09, 2001 JEPRO è¿½åŠ  //Dec. 16, 2002 MIKè¿½åŠ  // Feb. 19, 2006 genta .vbè¿½åŠ 
 void CType_Vb::InitTypeConfigImp(STypeConfig* pType)
 {
-	//–¼‘O‚ÆŠg’£q
+	//åå‰ã¨æ‹¡å¼µå­
 	_tcscpy( pType->m_szTypeName, _T("Visual Basic") );
 	_tcscpy( pType->m_szTypeExts, _T("bas,frm,cls,ctl,pag,dob,dsr,vb") );
 
-	//İ’è
-	pType->m_cLineComment.CopyTo( 0, L"'", -1 );				/* sƒRƒƒ“ƒgƒfƒŠƒ~ƒ^ */
-	pType->m_eDefaultOutline = OUTLINE_VB;						/* ƒAƒEƒgƒ‰ƒCƒ“‰ğÍ•û–@ */
-	pType->m_nKeyWordSetIdx[0]  = 13;							/* ƒL[ƒ[ƒhƒZƒbƒg */
-	pType->m_nKeyWordSetIdx[1] = 14;							/* ƒL[ƒ[ƒhƒZƒbƒg2 */
-	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;		/* ”¼Šp”’l‚ğF•ª‚¯•\¦ */
-	pType->m_nStringType = STRING_LITERAL_PLSQL;				/* •¶š—ñ‹æØ‚è‹L†ƒGƒXƒP[ƒv•û–@  0=[\"][\'] 1=[""][''] */
-	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ‚ğF•ª‚¯•\¦‚µ‚È‚¢
-	pType->m_bStringLineOnly = true; // •¶š—ñ‚Ís“à‚Ì‚İ
+	//è¨­å®š
+	pType->m_cLineComment.CopyTo( 0, L"'", -1 );				/* è¡Œã‚³ãƒ¡ãƒ³ãƒˆãƒ‡ãƒªãƒŸã‚¿ */
+	pType->m_eDefaultOutline = OUTLINE_VB;						/* ã‚¢ã‚¦ãƒˆãƒ©ã‚¤ãƒ³è§£ææ–¹æ³• */
+	pType->m_nKeyWordSetIdx[0]  = 13;							/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ */
+	pType->m_nKeyWordSetIdx[1] = 14;							/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ2 */
+	pType->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp = true;		/* åŠè§’æ•°å€¤ã‚’è‰²åˆ†ã‘è¡¨ç¤º */
+	pType->m_nStringType = STRING_LITERAL_PLSQL;				/* æ–‡å­—åˆ—åŒºåˆ‡ã‚Šè¨˜å·ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—æ–¹æ³•  0=[\"][\'] 1=[""][''] */
+	pType->m_ColorInfoArr[COLORIDX_SSTRING].m_bDisp = false;	//ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã‚’è‰²åˆ†ã‘è¡¨ç¤ºã—ãªã„
+	pType->m_bStringLineOnly = true; // æ–‡å­—åˆ—ã¯è¡Œå†…ã®ã¿
 }
 
 
 
 
 //	From Here June 23, 2001 N.Nakatani
-//!	Visual BasicŠÖ”ƒŠƒXƒgì¬iŠÈˆÕ”Åj
+//!	Visual Basicé–¢æ•°ãƒªã‚¹ãƒˆä½œæˆï¼ˆç°¡æ˜“ç‰ˆï¼‰
 /*!
-	Visual Basic‚ÌƒR[ƒh‚©‚ç’Pƒ‚Éƒ†[ƒU[’è‹`‚ÌŠÖ”‚âƒXƒe[ƒgƒƒ“ƒg‚ğæ‚èo‚·“®ì‚ğs‚¤B
+	Visual Basicã®ã‚³ãƒ¼ãƒ‰ã‹ã‚‰å˜ç´”ã«ãƒ¦ãƒ¼ã‚¶ãƒ¼å®šç¾©ã®é–¢æ•°ã‚„ã‚¹ãƒ†ãƒ¼ãƒˆãƒ¡ãƒ³ãƒˆã‚’å–ã‚Šå‡ºã™å‹•ä½œã‚’è¡Œã†ã€‚
 
-    Jul 10, 2003 little YOSHI  ×‚©‚­‰ğÍ‚·‚é‚æ‚¤‚É•ÏX
-                               ‚·‚×‚Ä‚ÌƒL[ƒ[ƒh‚Í©“®“I‚É¬Œ`‚³‚ê‚é‚Ì‚ÅA‘å•¶š¬•¶š‚ÍŠ®‘S‚Éˆê’v‚·‚éB
-                               ƒtƒH[ƒ€‚âƒ‚ƒWƒ…[ƒ‹‚¾‚¯‚Å‚Í‚È‚­AƒNƒ‰ƒX‚É‚à‘Î‰B
-							   ‚½‚¾‚µAConst‚Ìu,v‚Å˜A‘±éŒ¾‚É‚Í–¢‘Î‰
-	Jul. 21, 2003 genta ƒL[ƒ[ƒh‚Ì‘å•¶šE¬•¶š‚ğ“¯ˆê‹‚·‚é‚æ‚¤‚É‚µ‚½
-	Aug  7, 2003 little YOSHI  ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“‚ÅˆÍ‚Ü‚ê‚½ƒeƒLƒXƒg‚ğ–³‹‚·‚é‚æ‚¤‚É‚µ‚½
-	                           ŠÖ”–¼‚È‚Ç‚ğVB‚Ì–¼‘O•t‚¯‹K‘¥‚æ‚è255•¶š‚ÉŠg’£
+    Jul 10, 2003 little YOSHI  ç´°ã‹ãè§£æã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
+                               ã™ã¹ã¦ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã¯è‡ªå‹•çš„ã«æˆå½¢ã•ã‚Œã‚‹ã®ã§ã€å¤§æ–‡å­—å°æ–‡å­—ã¯å®Œå…¨ã«ä¸€è‡´ã™ã‚‹ã€‚
+                               ãƒ•ã‚©ãƒ¼ãƒ ã‚„ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ã ã‘ã§ã¯ãªãã€ã‚¯ãƒ©ã‚¹ã«ã‚‚å¯¾å¿œã€‚
+							   ãŸã ã—ã€Constã®ã€Œ,ã€ã§é€£ç¶šå®£è¨€ã«ã¯æœªå¯¾å¿œ
+	Jul. 21, 2003 genta ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®å¤§æ–‡å­—ãƒ»å°æ–‡å­—ã‚’åŒä¸€è¦–ã™ã‚‹ã‚ˆã†ã«ã—ãŸ
+	Aug  7, 2003 little YOSHI  ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³ã§å›²ã¾ã‚ŒãŸãƒ†ã‚­ã‚¹ãƒˆã‚’ç„¡è¦–ã™ã‚‹ã‚ˆã†ã«ã—ãŸ
+	                           é–¢æ•°åãªã©ã‚’VBã®åå‰ä»˜ã‘è¦å‰‡ã‚ˆã‚Š255æ–‡å­—ã«æ‹¡å¼µ
 */
 void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 {
-	const int	nMaxWordLeng = 255;	// Aug 7, 2003 little YOSHI  VB‚Ì–¼‘O•t‚¯‹K‘¥‚æ‚è255•¶š‚ÉŠg’£
+	const int	nMaxWordLeng = 255;	// Aug 7, 2003 little YOSHI  VBã®åå‰ä»˜ã‘è¦å‰‡ã‚ˆã‚Š255æ–‡å­—ã«æ‹¡å¼µ
 	const wchar_t*	pLine;
-	CLogicInt		nLineLen = CLogicInt(0);//: 2002/2/3 aroka Œx‘ÎôF‰Šú‰»
+	CLogicInt		nLineLen = CLogicInt(0);//: 2002/2/3 aroka è­¦å‘Šå¯¾ç­–ï¼šåˆæœŸåŒ–
 	int			i;
 	int			nCharChars;
-	wchar_t		szWordPrev[256];	// Aug 7, 2003 little YOSHI  VB‚Ì–¼‘O•t‚¯‹K‘¥‚æ‚è255•¶š‚ÉŠg’£
-	wchar_t		szWord[256];		// Aug 7, 2003 little YOSHI  VB‚Ì–¼‘O•t‚¯‹K‘¥‚æ‚è255•¶š‚ÉŠg’£
+	wchar_t		szWordPrev[256];	// Aug 7, 2003 little YOSHI  VBã®åå‰ä»˜ã‘è¦å‰‡ã‚ˆã‚Š255æ–‡å­—ã«æ‹¡å¼µ
+	wchar_t		szWord[256];		// Aug 7, 2003 little YOSHI  VBã®åå‰ä»˜ã‘è¦å‰‡ã‚ˆã‚Š255æ–‡å­—ã«æ‹¡å¼µ
 	int			nWordIdx = 0;
 	int			nMode;
-	wchar_t		szFuncName[256];	// Aug 7, 2003 little YOSHI  VB‚Ì–¼‘O•t‚¯‹K‘¥‚æ‚è255•¶š‚ÉŠg’£
+	wchar_t		szFuncName[256];	// Aug 7, 2003 little YOSHI  VBã®åå‰ä»˜ã‘è¦å‰‡ã‚ˆã‚Š255æ–‡å­—ã«æ‹¡å¼µ
 	CLogicInt	nFuncLine(0);
 	int			nFuncId;
 	int			nParseCnt = 0;
-	bool		bClass;			// ƒNƒ‰ƒXƒ‚ƒWƒ…[ƒ‹ƒtƒ‰ƒO
-	bool		bProcedure;		// ƒvƒƒV[ƒWƒƒƒtƒ‰ƒOiƒvƒƒV[ƒWƒƒ“à‚Å‚ÍTruej
-	bool		bDQuote;		// ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“ƒtƒ‰ƒOiƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“‚ª‚«‚½‚çTruej
+	bool		bClass;			// ã‚¯ãƒ©ã‚¹ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ãƒ•ãƒ©ã‚°
+	bool		bProcedure;		// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãƒ•ãƒ©ã‚°ï¼ˆãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£å†…ã§ã¯Trueï¼‰
+	bool		bDQuote;		// ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³ãƒ•ãƒ©ã‚°ï¼ˆãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³ãŒããŸã‚‰Trueï¼‰
 	bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 
 
-	// ’²‚×‚éƒtƒ@ƒCƒ‹‚ªƒNƒ‰ƒXƒ‚ƒWƒ…[ƒ‹‚Ì‚Æ‚«‚ÍTypeAConst‚Ì‹““®‚ªˆÙ‚È‚é‚Ì‚Åƒtƒ‰ƒO‚ğ—§‚Ä‚é
+	// èª¿ã¹ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ãŒã‚¯ãƒ©ã‚¹ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ã®ã¨ãã¯Typeã€Constã®æŒ™å‹•ãŒç•°ãªã‚‹ã®ã§ãƒ•ãƒ©ã‚°ã‚’ç«‹ã¦ã‚‹
 	bClass	= false;
 	int filelen = _tcslen(m_pcDocRef->m_cDocFile.GetFilePath());
 	if ( 4 < filelen ) {
@@ -117,7 +117,7 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 			if(	0 == nCharChars ){
 				nCharChars = 1;
 			}
-			/* ’PŒê“Ç‚İ‚İ’† */
+			/* å˜èªèª­ã¿è¾¼ã¿ä¸­ */
 			if( 1 == nMode ){
 				if( (1 == nCharChars && (
 					L'_' == pLine[i] ||
@@ -125,7 +125,7 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					(L'a' <= pLine[i] &&	pLine[i] <= L'z' )||
 					(L'A' <= pLine[i] &&	pLine[i] <= L'Z' )||
 					(L'0' <= pLine[i] &&	pLine[i] <= L'9' )||
-					(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i])) // 2013.05.08 “ú–{Œê‘Î‰
+					(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i])) // 2013.05.08 æ—¥æœ¬èªå¯¾å¿œ
 					) )
 				 || 2 == nCharChars
 				){
@@ -139,54 +139,54 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 						nWordIdx += (nCharChars);
 					}
 				} else if (1 == nCharChars && '"' == pLine[i]) {
-					// Aug 7, 2003 little YOSHI  ’Ç‰Á
-					// ƒeƒLƒXƒg‚Ì’†‚Í–³‹‚µ‚Ü‚·B
+					// Aug 7, 2003 little YOSHI  è¿½åŠ 
+					// ãƒ†ã‚­ã‚¹ãƒˆã®ä¸­ã¯ç„¡è¦–ã—ã¾ã™ã€‚
 					nMode	= 3;
 				}else{
 					if ( 0 == nParseCnt && 0 == wcsicmp(szWord, L"Public") ) {
-						// ƒpƒuƒŠƒbƒNéŒ¾‚ğŒ©‚Â‚¯‚½I
+						// ãƒ‘ãƒ–ãƒªãƒƒã‚¯å®£è¨€ã‚’è¦‹ã¤ã‘ãŸï¼
 						nFuncId |= 0x10;
 					}else
 					if ( 0 == nParseCnt && 0 == wcsicmp(szWord, L"Private") ) {
-						// ƒvƒ‰ƒCƒx[ƒgéŒ¾‚ğŒ©‚Â‚¯‚½I
+						// ãƒ—ãƒ©ã‚¤ãƒ™ãƒ¼ãƒˆå®£è¨€ã‚’è¦‹ã¤ã‘ãŸï¼
 						nFuncId |= 0x20;
 					}else
 					if ( 0 == nParseCnt && 0 == wcsicmp(szWord, L"Friend") ) {
-						// ƒtƒŒƒ“ƒhéŒ¾‚ğŒ©‚Â‚¯‚½I
+						// ãƒ•ãƒ¬ãƒ³ãƒ‰å®£è¨€ã‚’è¦‹ã¤ã‘ãŸï¼
 						nFuncId |= 0x30;
 					}else
 					if ( 0 == nParseCnt && 0 == wcsicmp(szWord, L"Static") ) {
-						// ƒXƒ^ƒeƒBƒbƒNéŒ¾‚ğŒ©‚Â‚¯‚½I
+						// ã‚¹ã‚¿ãƒ†ã‚£ãƒƒã‚¯å®£è¨€ã‚’è¦‹ã¤ã‘ãŸï¼
 						nFuncId |= 0x100;
 					}else
 					if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Function" ) ){
 						if ( 0 == wcsicmp( szWordPrev, L"End" ) ){
-							// ƒvƒƒV[ƒWƒƒƒtƒ‰ƒO‚ğƒNƒŠƒA
+							// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãƒ•ãƒ©ã‚°ã‚’ã‚¯ãƒªã‚¢
 							bProcedure	= false;
 						}else
 						if( 0 != wcsicmp( szWordPrev, L"Exit" ) ){
 							if( 0 == wcsicmp( szWordPrev, L"Declare" ) ){
-								nFuncId |= 0x200;	// DLLQÆéŒ¾
+								nFuncId |= 0x200;	// DLLå‚ç…§å®£è¨€
 							}else{
-								bProcedure	= true;	// ƒvƒƒV[ƒWƒƒƒtƒ‰ƒO‚ğƒZƒbƒg
+								bProcedure	= true;	// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãƒ•ãƒ©ã‚°ã‚’ã‚»ãƒƒãƒˆ
 							}
-							nFuncId |= 0x01;		// ŠÖ”
+							nFuncId |= 0x01;		// é–¢æ•°
 							nParseCnt = 1;
 							nFuncLine = nLineCount + CLogicInt(1);
 						}
 					}
 					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Sub" ) ){
 						if ( 0 == wcsicmp( szWordPrev, L"End" ) ){
-							// ƒvƒƒV[ƒWƒƒƒtƒ‰ƒO‚ğƒNƒŠƒA
+							// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãƒ•ãƒ©ã‚°ã‚’ã‚¯ãƒªã‚¢
 							bProcedure	= false;
 						}else
 						if( 0 != wcsicmp( szWordPrev, L"Exit" ) ){
 							if( 0 == wcsicmp( szWordPrev, L"Declare" ) ){
-								nFuncId |= 0x200;	// DLLQÆéŒ¾
+								nFuncId |= 0x200;	// DLLå‚ç…§å®£è¨€
 							}else{
-								bProcedure	= true;	// ƒvƒƒV[ƒWƒƒƒtƒ‰ƒO‚ğƒZƒbƒg
+								bProcedure	= true;	// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãƒ•ãƒ©ã‚°ã‚’ã‚»ãƒƒãƒˆ
 							}
-							nFuncId |= 0x02;		// ŠÖ”
+							nFuncId |= 0x02;		// é–¢æ•°
 							nParseCnt = 1;
 							nFuncLine = nLineCount + CLogicInt(1);
 						}
@@ -194,24 +194,24 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Get" )
 					 && 0 == wcsicmp( szWordPrev, L"Property" )
 					){
-						bProcedure	= true;	// ƒvƒƒV[ƒWƒƒƒtƒ‰ƒO‚ğƒZƒbƒg
-						nFuncId	|= 0x03;		// ƒvƒƒpƒeƒBæ“¾
+						bProcedure	= true;	// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãƒ•ãƒ©ã‚°ã‚’ã‚»ãƒƒãƒˆ
+						nFuncId	|= 0x03;		// ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£å–å¾—
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
 					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Let" )
 					 && 0 == wcsicmp( szWordPrev, L"Property" )
 					){
-						bProcedure	= true;	// ƒvƒƒV[ƒWƒƒƒtƒ‰ƒO‚ğƒZƒbƒg
-						nFuncId |= 0x04;		// ƒvƒƒpƒeƒBİ’è
+						bProcedure	= true;	// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãƒ•ãƒ©ã‚°ã‚’ã‚»ãƒƒãƒˆ
+						nFuncId |= 0x04;		// ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£è¨­å®š
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
 					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Set" )
 					 && 0 == wcsicmp( szWordPrev, L"Property" )
 					){
-						bProcedure	= true;	// ƒvƒƒV[ƒWƒƒƒtƒ‰ƒO‚ğƒZƒbƒg
-						nFuncId |= 0x05;		// ƒvƒƒpƒeƒBQÆ
+						bProcedure	= true;	// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãƒ•ãƒ©ã‚°ã‚’ã‚»ãƒƒãƒˆ
+						nFuncId |= 0x05;		// ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£å‚ç…§
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
@@ -219,56 +219,56 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					 && 0 != wcsicmp( szWordPrev, L"#" )
 					){
 						if ( bClass || bProcedure || 0 == ((nFuncId >> 4) & 0x0f) ) {
-							// ƒNƒ‰ƒXƒ‚ƒWƒ…[ƒ‹‚Å‚Í‹­§“I‚ÉPrivate
-							// ƒvƒƒV[ƒWƒƒ“à‚Å‚Í‹­§“I‚ÉPrivate
-							// Public‚Ìw’è‚ª‚È‚¢‚Æ‚«AƒfƒtƒHƒ‹ƒg‚ÅPrivate‚É‚È‚é
+							// ã‚¯ãƒ©ã‚¹ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ã§ã¯å¼·åˆ¶çš„ã«Private
+							// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£å†…ã§ã¯å¼·åˆ¶çš„ã«Private
+							// Publicã®æŒ‡å®šãŒãªã„ã¨ãã€ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã§Privateã«ãªã‚‹
 							nFuncId &= 0x0f2f;
 							nFuncId	|= 0x20;
 						}
-						nFuncId	|= 0x06;		// ’è”
+						nFuncId	|= 0x06;		// å®šæ•°
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
 					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Enum" )
 					){
-						nFuncId	|= 0x207;		// —ñ‹“Œ^éŒ¾
+						nFuncId	|= 0x207;		// åˆ—æŒ™å‹å®£è¨€
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
 					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Type" )
 					){
 						if ( bClass ) {
-							// ƒNƒ‰ƒXƒ‚ƒWƒ…[ƒ‹‚Å‚Í‹­§“I‚ÉPrivate
+							// ã‚¯ãƒ©ã‚¹ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ã§ã¯å¼·åˆ¶çš„ã«Private
 							nFuncId &= 0x0f2f;
 							nFuncId	|= 0x20;
 						}
-						nFuncId	|= 0x208;		// ƒ†[ƒU’è‹`Œ^éŒ¾
+						nFuncId	|= 0x208;		// ãƒ¦ãƒ¼ã‚¶å®šç¾©å‹å®£è¨€
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
 					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Event" )
 					){
-						nFuncId	|= 0x209;		// ƒCƒxƒ“ƒgéŒ¾
+						nFuncId	|= 0x209;		// ã‚¤ãƒ™ãƒ³ãƒˆå®£è¨€
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
 					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Property" )
 					 && 0 == wcsicmp( szWordPrev, L"End")
 					){
-						bProcedure	= false;	// ƒvƒƒV[ƒWƒƒƒtƒ‰ƒO‚ğƒNƒŠƒA
+						bProcedure	= false;	// ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ãƒ•ãƒ©ã‚°ã‚’ã‚¯ãƒªã‚¢
 					}
 					else if( 1 == nParseCnt ){
 						wcscpy( szFuncName, szWord );
 						/*
-						  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-						  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-						  ¨ ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
+						  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+						  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+						  â†’ ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
 						*/
 						CLayoutPoint ptPosXY;
 						m_pcDocRef->m_cLayoutMgr.LogicToLayout(	CLogicPoint(CLogicInt(0), nFuncLine - CLogicInt(1)), &ptPosXY );
 						pcFuncInfoArr->AppendData( nFuncLine, ptPosXY.GetY2() + CLayoutInt(1) , szFuncName, nFuncId );
 						nParseCnt = 0;
-						nFuncId	= 0;	// Jul 10, 2003  little YOSHI  ˜_—˜a‚ğg—p‚·‚é‚½‚ßA•K‚¸‰Šú‰»
+						nFuncId	= 0;	// Jul 10, 2003  little YOSHI  è«–ç†å’Œã‚’ä½¿ç”¨ã™ã‚‹ãŸã‚ã€å¿…ãšåˆæœŸåŒ–
 					}
 
 					wcscpy( szWordPrev, szWord );
@@ -279,16 +279,16 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					continue;
 				}
 			}
-			/* ‹L†—ñ“Ç‚İ‚İ’† */
+			/* è¨˜å·åˆ—èª­ã¿è¾¼ã¿ä¸­ */
 			else if( 2 == nMode ){
 				// Jul 10, 2003  little YOSHI
-				// u#Constv‚ÆuConstv‚ğ‹æ•Ê‚·‚é‚½‚ß‚ÉAu#v‚à¯•Ê‚·‚é‚æ‚¤‚É•ÏX
+				// ã€Œ#Constã€ã¨ã€ŒConstã€ã‚’åŒºåˆ¥ã™ã‚‹ãŸã‚ã«ã€ã€Œ#ã€ã‚‚è­˜åˆ¥ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
 				if( L'_' == pLine[i] ||
 					L'~' == pLine[i] ||
 					(L'a' <= pLine[i] &&	pLine[i] <= L'z' )||
 					(L'A' <= pLine[i] &&	pLine[i] <= L'Z' )||
 					(L'0' <= pLine[i] &&	pLine[i] <= L'9' )||
-					(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i]))|| // 2013.05.08 “ú–{Œê‘Î‰
+					(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i]))|| // 2013.05.08 æ—¥æœ¬èªå¯¾å¿œ
 					L'\t' == pLine[i] ||
 					L' ' == pLine[i] ||
 					WCODE::IsLineDelimiter(pLine[i], bExtEol) ||
@@ -310,8 +310,8 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					i--;
 					continue;
 				} else if (1 == nCharChars && L'"' == pLine[i]) {
-					// Aug 7, 2003 little YOSHI  ’Ç‰Á
-					// ƒeƒLƒXƒg‚Ì’†‚Í–³‹‚µ‚Ü‚·B
+					// Aug 7, 2003 little YOSHI  è¿½åŠ 
+					// ãƒ†ã‚­ã‚¹ãƒˆã®ä¸­ã¯ç„¡è¦–ã—ã¾ã™ã€‚
 					nMode	= 3;
 				}else{
 					if( nWordIdx >= nMaxWordLeng ){
@@ -324,9 +324,9 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					}
 				}
 			}else
-			/* ’·‰ß‚¬‚é’PŒê–³‹’† */
+			/* é•·éãã‚‹å˜èªç„¡è¦–ä¸­ */
 			if( 999 == nMode ){
-				/* ‹ó”’‚âƒ^ƒu‹L†“™‚ğ”ò‚Î‚· */
+				/* ç©ºç™½ã‚„ã‚¿ãƒ–è¨˜å·ç­‰ã‚’é£›ã°ã™ */
 				if( L'\t' == pLine[i] ||
 					L' ' == pLine[i] ||
 					WCODE::IsLineDelimiter(pLine[i], bExtEol)
@@ -335,9 +335,9 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					continue;
 				}
 			}else
-			/* ƒm[ƒ}ƒ‹ƒ‚[ƒh */
+			/* ãƒãƒ¼ãƒãƒ«ãƒ¢ãƒ¼ãƒ‰ */
 			if( 0 == nMode ){
-				/* ‹ó”’‚âƒ^ƒu‹L†“™‚ğ”ò‚Î‚· */
+				/* ç©ºç™½ã‚„ã‚¿ãƒ–è¨˜å·ç­‰ã‚’é£›ã°ã™ */
 				if( L'\t' == pLine[i] ||
 					L' ' == pLine[i] ||
 					WCODE::IsLineDelimiter(pLine[i], bExtEol)
@@ -347,8 +347,8 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 				if( i < nLineLen && L'\'' == pLine[i] ){
 					break;
 				} else if (1 == nCharChars && L'"' == pLine[i]) {
-					// Aug 7, 2003 little YOSHI  ’Ç‰Á
-					// ƒeƒLƒXƒg‚Ì’†‚Í–³‹‚µ‚Ü‚·B
+					// Aug 7, 2003 little YOSHI  è¿½åŠ 
+					// ãƒ†ã‚­ã‚¹ãƒˆã®ä¸­ã¯ç„¡è¦–ã—ã¾ã™ã€‚
 					nMode	= 3;
 				}else{
 					if( (1 == nCharChars && (
@@ -357,7 +357,7 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 						(L'a' <= pLine[i] &&	pLine[i] <= L'z' )||
 						(L'A' <= pLine[i] &&	pLine[i] <= L'Z' )||
 						(L'0' <= pLine[i] &&	pLine[i] <= L'9' )||
-						(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i])) // 2013.05.08 “ú–{Œê‘Î‰
+						(L'\u00a1' <= pLine[i] && !iswcntrl(pLine[i]) && !iswspace(pLine[i])) // 2013.05.08 æ—¥æœ¬èªå¯¾å¿œ
 						) )
 					 || 2 == nCharChars
 					){
@@ -378,15 +378,15 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					}
 				}
 			} else
-			/* ƒeƒLƒXƒg‚ª•Â‚¶‚é‚Ü‚Å“Ç‚İ”ò‚Î‚· */	// Aug 7, 2003 little YOSHI  ’Ç‰Á
+			/* ãƒ†ã‚­ã‚¹ãƒˆãŒé–‰ã˜ã‚‹ã¾ã§èª­ã¿é£›ã°ã™ */	// Aug 7, 2003 little YOSHI  è¿½åŠ 
 			if (nMode == 3) {
-				// ˜A‘±‚·‚éƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“‚Í–³‹‚·‚é
+				// é€£ç¶šã™ã‚‹ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³ã¯ç„¡è¦–ã™ã‚‹
 				if (1 == nCharChars && L'"' == pLine[i]) {
-					// ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“‚ªŒ»‚ê‚½‚çƒtƒ‰ƒO‚ğ”½“]‚·‚é
+					// ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³ãŒç¾ã‚ŒãŸã‚‰ãƒ•ãƒ©ã‚°ã‚’åè»¢ã™ã‚‹
 					bDQuote	= !bDQuote;
 				} else if (bDQuote) {
-					// ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“‚ÌŸ‚É
-					// ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“ˆÈŠO‚Ì•¶š‚ªŒ»‚ê‚½‚çƒm[ƒ}ƒ‹ƒ‚[ƒh‚ÉˆÚs
+					// ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³ã®æ¬¡ã«
+					// ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³ä»¥å¤–ã®æ–‡å­—ãŒç¾ã‚ŒãŸã‚‰ãƒãƒ¼ãƒãƒ«ãƒ¢ãƒ¼ãƒ‰ã«ç§»è¡Œ
 					--i;
 					nMode	= 0;
 					bDQuote	= false;
@@ -402,7 +402,7 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 
 
 
-//Jul. 10, 2001 JEPRO ’Ç‰Á
+//Jul. 10, 2001 JEPRO è¿½åŠ 
 const wchar_t* g_ppszKeywordsVB[] = {
 	L"And",
 	L"As",
@@ -496,7 +496,7 @@ const wchar_t* g_ppszKeywordsVB[] = {
 	L"Terminate",
 	L"Until",
 	//=========================================================
-	// ˆÈ‰º‚ÍVB.NET(VB7)‚Å‚Ì”p~‚ªŒˆ’è‚µ‚Ä‚¢‚éƒL[ƒ[ƒh‚Å‚·
+	// ä»¥ä¸‹ã¯VB.NET(VB7)ã§ã®å»ƒæ­¢ãŒæ±ºå®šã—ã¦ã„ã‚‹ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã§ã™
 	//=========================================================
 	L"DefBool",
 	L"DefByte",
@@ -516,7 +516,7 @@ const wchar_t* g_ppszKeywordsVB[] = {
 	//			"Option Base
 	//			"As Any
 	//=========================================================
-	// ˆÈ‰º‚ÍVB.NET—pƒL[ƒ[ƒh‚Å‚·
+	// ä»¥ä¸‹ã¯VB.NETç”¨ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã§ã™
 	//=========================================================
 	//BitAnd
 	//BitOr
@@ -528,7 +528,7 @@ const wchar_t* g_ppszKeywordsVB[] = {
 };
 int g_nKeywordsVB = _countof(g_ppszKeywordsVB);
 
-//Jul. 10, 2001 JEPRO ’Ç‰Á
+//Jul. 10, 2001 JEPRO è¿½åŠ 
 const wchar_t* g_ppszKeywordsVB2[] = {
 	L"AppActivate",
 	L"Beep",
@@ -703,9 +703,9 @@ const wchar_t* g_ppszKeywordsVB2[] = {
 	L"Refresh",
 	L"Show",
 	//=========================================================
-	// ˆÈ‰º‚ÍVB.NET(VB7)‚Å‚Ì”p~‚ªŒˆ’è‚µ‚Ä‚¢‚éƒL[ƒ[ƒh‚Å‚·
+	// ä»¥ä¸‹ã¯VB.NET(VB7)ã§ã®å»ƒæ­¢ãŒæ±ºå®šã—ã¦ã„ã‚‹ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã§ã™
 	//=========================================================
-	//$•t‚«ŠÖ”Šeí
+	//$ä»˜ãé–¢æ•°å„ç¨®
 	L"Dir$",
 	L"LCase$",
 	L"Left$",
@@ -719,7 +719,7 @@ const wchar_t* g_ppszKeywordsVB2[] = {
 	L"String$",
 	L"Trim$",
 	L"UCase$",
-	//VB5,6‚Ì‰B‚µŠÖ”
+	//VB5,6ã®éš ã—é–¢æ•°
 	L"VarPtr",
 	L"StrPtr",
 	L"ObjPtr",


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/types
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。

主に動作影響について対応前後で挙動に変化がないことのご確認をいただけると助かります。
