### PR TITLE
util 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/util/MessageBoxF.cpp
+++ b/sakura_core/util/MessageBoxF.cpp
@@ -1,10 +1,10 @@
-/*!	@file
-	@brief MessageBox—pŠÖ”
+ï»¿/*!	@file
+	@brief MessageBoxç”¨é–¢æ•°
 
 	@author Norio Nakatani
 
-	@date 2002/01/17 aroka Œ^‚ÌC³
-	@date 2013/03/03 Uchi Debug1.cpp‚©‚ç•ª—£
+	@date 2002/01/17 aroka å‹ã®ä¿®æ­£
+	@date 2013/03/03 Uchi Debug1.cppã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -38,13 +38,13 @@
 #include "window/CEditWnd.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                 ƒƒbƒZ[ƒWƒ{ƒbƒNƒXFÀ‘•                    //
+//                 ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ï¼šå®Ÿè£…                    //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 int Wrap_MessageBox(HWND hWnd, LPCTSTR lpText, LPCTSTR lpCaption, UINT uType)
 {
 	static int (WINAPI *RealMessageBox)(HWND, LPCTSTR, LPCTSTR, UINT, WORD);
 	static HMODULE hMod = NULL;
-	if( hMod == NULL ){	// ‰Šú‰»‚³‚ê‚Ä‚¢‚È‚¢ê‡‚Í‰Šú‰»‚·‚é
+	if( hMod == NULL ){	// åˆæœŸåŒ–ã•ã‚Œã¦ã„ãªã„å ´åˆã¯åˆæœŸåŒ–ã™ã‚‹
 	hMod = GetModuleHandle(_T("USER32"));
 #ifdef _UNICODE
 		*(FARPROC *)&RealMessageBox = GetProcAddress(hMod, "MessageBoxExW");
@@ -53,9 +53,9 @@ int Wrap_MessageBox(HWND hWnd, LPCTSTR lpText, LPCTSTR lpCaption, UINT uType)
 #endif
 	}
 
-	// lpText, lpCaption ‚ğƒ[ƒJƒ‹ƒoƒbƒtƒ@‚ÉƒRƒs[‚µ‚Ä MessageBox API ‚ğŒÄ‚Ño‚·
-	// ¦ g‚¢‰ñ‚µ‚Ìƒoƒbƒtƒ@‚ªg—p‚³‚ê‚Ä‚¢‚Ä‚»‚ê‚ª— ‚Å‘‚«Š·‚¦‚ç‚ê‚½ê‡‚Å‚à
-	//    ƒƒbƒZ[ƒWƒ{ƒbƒNƒXã‚Ì Ctrl+C ‚ª•¶š‰»‚¯‚µ‚È‚¢‚æ‚¤‚É
+	// lpText, lpCaption ã‚’ãƒ­ãƒ¼ã‚«ãƒ«ãƒãƒƒãƒ•ã‚¡ã«ã‚³ãƒ”ãƒ¼ã—ã¦ MessageBox API ã‚’å‘¼ã³å‡ºã™
+	// â€» ä½¿ã„å›ã—ã®ãƒãƒƒãƒ•ã‚¡ãŒä½¿ç”¨ã•ã‚Œã¦ã„ã¦ãã‚ŒãŒè£ã§æ›¸ãæ›ãˆã‚‰ã‚ŒãŸå ´åˆã§ã‚‚
+	//    ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ä¸Šã® Ctrl+C ãŒæ–‡å­—åŒ–ã‘ã—ãªã„ã‚ˆã†ã«
 	return RealMessageBox(hWnd, lpText? std::tstring(lpText).c_str(): NULL,
 		lpCaption? std::tstring(lpCaption).c_str(): NULL, uType, CSelectLang::getDefaultLangId());
 }
@@ -71,24 +71,24 @@ HWND GetMessageBoxOwner(HWND hwndOwner)
 }
 
 /*!
-	‘®•t‚«ƒƒbƒZ[ƒWƒ{ƒbƒNƒX
+	æ›¸å¼ä»˜ããƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹
 
-	ˆø”‚Å—^‚¦‚ç‚ê‚½î•ñ‚ğƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚Å•\¦‚·‚éD
-	ƒfƒoƒbƒO–Ú“IˆÈŠO‚Å‚àg—p‚Å‚«‚éD
+	å¼•æ•°ã§ä¸ãˆã‚‰ã‚ŒãŸæƒ…å ±ã‚’ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã§è¡¨ç¤ºã™ã‚‹ï¼
+	ãƒ‡ãƒãƒƒã‚°ç›®çš„ä»¥å¤–ã§ã‚‚ä½¿ç”¨ã§ãã‚‹ï¼
 */
 int VMessageBoxF(
-	HWND		hwndOwner,	//!< [in] ƒI[ƒi[ƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹
-	UINT		uType,		//!< [in] ƒƒbƒZ[ƒWƒ{ƒbƒNƒX‚ÌƒXƒ^ƒCƒ‹ (MessageBox‚Æ“¯‚¶Œ`®)
-	LPCTSTR		lpCaption,	//!< [in] ƒƒbƒZ[ƒWƒ{ƒbƒNƒX‚Ìƒ^ƒCƒgƒ‹
-	LPCTSTR		lpText,		//!< [in] •\¦‚·‚éƒeƒLƒXƒgBprintfd—l‚Ì‘®w’è‚ª‰Â”\B
-	va_list&	v			//!< [in,out] ˆø”ƒŠƒXƒg
+	HWND		hwndOwner,	//!< [in] ã‚ªãƒ¼ãƒŠãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ«
+	UINT		uType,		//!< [in] ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã®ã‚¹ã‚¿ã‚¤ãƒ« (MessageBoxã¨åŒã˜å½¢å¼)
+	LPCTSTR		lpCaption,	//!< [in] ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã®ã‚¿ã‚¤ãƒˆãƒ«
+	LPCTSTR		lpText,		//!< [in] è¡¨ç¤ºã™ã‚‹ãƒ†ã‚­ã‚¹ãƒˆã€‚printfä»•æ§˜ã®æ›¸å¼æŒ‡å®šãŒå¯èƒ½ã€‚
+	va_list&	v			//!< [in,out] å¼•æ•°ãƒªã‚¹ãƒˆ
 )
 {
 	hwndOwner=GetMessageBoxOwner(hwndOwner);
-	//®Œ`
+	//æ•´å½¢
 	static TCHAR szBuf[16000];
 	tchar_vsnprintf_s(szBuf,_countof(szBuf),lpText,v);
-	//APIŒÄ‚Ño‚µ
+	//APIå‘¼ã³å‡ºã—
 	return ::MessageBox( hwndOwner, szBuf, lpCaption, uType);
 }
 
@@ -102,35 +102,35 @@ int MessageBoxF( HWND hwndOwner, UINT uType, LPCTSTR lpCaption, LPCTSTR lpText, 
 }
 
 
-//ƒGƒ‰[FÔŠÛ‚Éu~v[OK]
+//ã‚¨ãƒ©ãƒ¼ï¼šèµ¤ä¸¸ã«ã€ŒÃ—ã€[OK]
 int ErrorMessage   (HWND hwnd, LPCTSTR format, ...){      va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_OK | MB_ICONSTOP                     , GSTR_APPNAME,   format, p);va_end(p);return n;}
 int TopErrorMessage(HWND hwnd, LPCTSTR format, ...){      va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_OK | MB_ICONSTOP | MB_TOPMOST        , GSTR_APPNAME,   format, p);va_end(p);return n;}	//(TOPMOST)
 
-//ŒxFOŠp‚Éuiv
+//è­¦å‘Šï¼šä¸‰è§’ã«ã€Œiã€
 int WarningMessage   (HWND hwnd, LPCTSTR format, ...){    va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_OK | MB_ICONEXCLAMATION              , GSTR_APPNAME,   format, p);va_end(p);return n;}
 int TopWarningMessage(HWND hwnd, LPCTSTR format, ...){    va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_OK | MB_ICONEXCLAMATION | MB_TOPMOST , GSTR_APPNAME,   format, p);va_end(p);return n;}
 
-//î•ñFÂŠÛ‚Éuiv
+//æƒ…å ±ï¼šé’ä¸¸ã«ã€Œiã€
 int InfoMessage   (HWND hwnd, LPCTSTR format, ...){       va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_OK | MB_ICONINFORMATION              , GSTR_APPNAME,   format, p);va_end(p);return n;}
 int TopInfoMessage(HWND hwnd, LPCTSTR format, ...){       va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_OK | MB_ICONINFORMATION | MB_TOPMOST , GSTR_APPNAME,   format, p);va_end(p);return n;}
 
-//Šm”FF‚«o‚µ‚ÌuHv –ß‚è’l:ID_YES,ID_NO
+//ç¢ºèªï¼šå¹ãå‡ºã—ã®ã€Œï¼Ÿã€ æˆ»ã‚Šå€¤:ID_YES,ID_NO
 int ConfirmMessage   (HWND hwnd, LPCTSTR format, ...){    va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_YESNO | MB_ICONQUESTION              , GSTR_APPNAME,   format, p);va_end(p);return n;}
 int TopConfirmMessage(HWND hwnd, LPCTSTR format, ...){    va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_YESNO | MB_ICONQUESTION | MB_TOPMOST , GSTR_APPNAME,   format, p);va_end(p);return n;}
 
-//O‘ğF‚«o‚µ‚ÌuHv –ß‚è’l:ID_YES,ID_NO,ID_CANCEL
+//ä¸‰æŠï¼šå¹ãå‡ºã—ã®ã€Œï¼Ÿã€ æˆ»ã‚Šå€¤:ID_YES,ID_NO,ID_CANCEL
 int Select3Message   (HWND hwnd, LPCTSTR format, ...){    va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_YESNOCANCEL | MB_ICONQUESTION              , GSTR_APPNAME, format, p);va_end(p);return n;}
 int TopSelect3Message(HWND hwnd, LPCTSTR format, ...){    va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_YESNOCANCEL | MB_ICONQUESTION | MB_TOPMOST , GSTR_APPNAME, format, p);va_end(p);return n;}
 
-//‚»‚Ì‘¼ƒƒbƒZ[ƒW•\¦—pƒ{ƒbƒNƒX
+//ãã®ä»–ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸è¡¨ç¤ºç”¨ãƒœãƒƒã‚¯ã‚¹
 int OkMessage   (HWND hwnd, LPCTSTR format, ...){         va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_OK                                   , GSTR_APPNAME,   format, p);va_end(p);return n;}
 int TopOkMessage(HWND hwnd, LPCTSTR format, ...){         va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_OK | MB_TOPMOST                      , GSTR_APPNAME,   format, p);va_end(p);return n;}	//(TOPMOST)
 
-//ƒ^ƒCƒvw’èƒƒbƒZ[ƒW•\¦—pƒ{ƒbƒNƒX
+//ã‚¿ã‚¤ãƒ—æŒ‡å®šãƒ¡ãƒƒã‚»ãƒ¼ã‚¸è¡¨ç¤ºç”¨ãƒœãƒƒã‚¯ã‚¹
 int CustomMessage   (HWND hwnd, UINT uType, LPCTSTR format, ...){   va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, uType                         , GSTR_APPNAME,   format, p);va_end(p);return n;}
 int TopCustomMessage(HWND hwnd, UINT uType, LPCTSTR format, ...){   va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, uType | MB_TOPMOST            , GSTR_APPNAME,   format, p);va_end(p);return n;}	//(TOPMOST)
 
-//ìÒ‚É‹³‚¦‚Ä—~‚µ‚¢ƒGƒ‰[
+//ä½œè€…ã«æ•™ãˆã¦æ¬²ã—ã„ã‚¨ãƒ©ãƒ¼
 int PleaseReportToAuthor(HWND hwnd, LPCTSTR format, ...){ va_list p;va_start(p, format);int n=VMessageBoxF  (hwnd, MB_OK | MB_ICONSTOP | MB_TOPMOST, LS(STR_ERR_DLGDOCLMN1), format, p);va_end(p);return n;}
 
 

--- a/sakura_core/util/MessageBoxF.h
+++ b/sakura_core/util/MessageBoxF.h
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief MessageBox—pŠÖ”
+ï»¿/*!	@file
+	@brief MessageBoxç”¨é–¢æ•°
 
 	@author Norio Nakatani
 
-	@date 2013/03/03 Uchi Debug1.h‚©‚ç•ª—£
+	@date 2013/03/03 Uchi Debug1.hã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -33,61 +33,61 @@
 #define SAKURA_MESSAGEBOX_2D6EF6BC_3D8C_427B_8AFB_E8903838A1ED_H_
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                 ƒƒbƒZ[ƒWƒ{ƒbƒNƒXFÀ‘•                    //
+//                 ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ï¼šå®Ÿè£…                    //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//2007.10.02 kobake ƒƒbƒZ[ƒWƒ{ƒbƒNƒX‚Ìg—p‚ÍƒfƒoƒbƒO‚ÉŒÀ‚ç‚È‚¢‚Ì‚ÅAuDebug`v‚Æ‚¢‚¤–¼‘O‚ğ”p~
+//2007.10.02 kobake ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã®ä½¿ç”¨ã¯ãƒ‡ãƒãƒƒã‚°æ™‚ã«é™ã‚‰ãªã„ã®ã§ã€ã€ŒDebugï½ã€ã¨ã„ã†åå‰ã‚’å»ƒæ­¢
 #undef MessageBox
 #define MessageBox Wrap_MessageBox
 int Wrap_MessageBox(HWND hWnd, LPCTSTR lpText, LPCTSTR lpCaption, UINT uType);
 
-//ƒeƒLƒXƒg®Œ`‹@”\•t‚«MessageBox
+//ãƒ†ã‚­ã‚¹ãƒˆæ•´å½¢æ©Ÿèƒ½ä»˜ãMessageBox
 int VMessageBoxF( HWND hwndOwner, UINT uType, LPCTSTR lpCaption, LPCTSTR lpText, va_list& v );
 int MessageBoxF ( HWND hwndOwner, UINT uType, LPCTSTR lpCaption, LPCTSTR lpText, ... );
 
 
-//                ƒ†[ƒU—pƒƒbƒZ[ƒWƒ{ƒbƒNƒX                   //
+//                ãƒ¦ãƒ¼ã‚¶ç”¨ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹                   //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//ƒfƒoƒbƒO—pƒƒbƒZ[ƒWƒ{ƒbƒNƒX
+//ãƒ‡ãƒãƒƒã‚°ç”¨ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹
 #define MYMESSAGEBOX MessageBoxF
 
-//ˆê”Ê‚ÌŒx‰¹
+//ä¸€èˆ¬ã®è­¦å‘ŠéŸ³
 #define DefaultBeep()   ::MessageBeep(MB_OK)
 
-//ƒGƒ‰[FÔŠÛ‚Éu~v[OK]
+//ã‚¨ãƒ©ãƒ¼ï¼šèµ¤ä¸¸ã«ã€ŒÃ—ã€[OK]
 int ErrorMessage   (HWND hwnd, LPCTSTR format, ...);
 int TopErrorMessage(HWND hwnd, LPCTSTR format, ...);	//(TOPMOST)
 #define ErrorBeep()     ::MessageBeep(MB_ICONSTOP)
 
-//ŒxFOŠp‚ÉuIv[OK]
+//è­¦å‘Šï¼šä¸‰è§’ã«ã€Œï¼ã€[OK]
 int WarningMessage   (HWND hwnd, LPCTSTR format, ...);
 int TopWarningMessage(HWND hwnd, LPCTSTR format, ...);
 #define WarningBeep()   ::MessageBeep(MB_ICONEXCLAMATION)
 
-//î•ñFÂŠÛ‚Éuiv[OK]
+//æƒ…å ±ï¼šé’ä¸¸ã«ã€Œiã€[OK]
 int InfoMessage   (HWND hwnd, LPCTSTR format, ...);
 int TopInfoMessage(HWND hwnd, LPCTSTR format, ...);
 #define InfoBeep()      ::MessageBeep(MB_ICONINFORMATION)
 
-//Šm”FF‚«o‚µ‚ÌuHv [‚Í‚¢][‚¢‚¢‚¦] –ß‚è’l:IDYES,IDNO
+//ç¢ºèªï¼šå¹ãå‡ºã—ã®ã€Œï¼Ÿã€ [ã¯ã„][ã„ã„ãˆ] æˆ»ã‚Šå€¤:IDYES,IDNO
 int ConfirmMessage   (HWND hwnd, LPCTSTR format, ...);
 int TopConfirmMessage(HWND hwnd, LPCTSTR format, ...);
 #define ConfirmBeep()   ::MessageBeep(MB_ICONQUESTION)
 
-//O‘ğF‚«o‚µ‚ÌuHv [‚Í‚¢][‚¢‚¢‚¦][ƒLƒƒƒ“ƒZƒ‹]  –ß‚è’l:ID_YES,ID_NO,ID_CANCEL
+//ä¸‰æŠï¼šå¹ãå‡ºã—ã®ã€Œï¼Ÿã€ [ã¯ã„][ã„ã„ãˆ][ã‚­ãƒ£ãƒ³ã‚»ãƒ«]  æˆ»ã‚Šå€¤:ID_YES,ID_NO,ID_CANCEL
 int Select3Message   (HWND hwnd, LPCTSTR format, ...);
 int TopSelect3Message(HWND hwnd, LPCTSTR format, ...);
 
-//‚»‚Ì‘¼ƒƒbƒZ[ƒW•\¦—pƒ{ƒbƒNƒX[OK]
+//ãã®ä»–ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸è¡¨ç¤ºç”¨ãƒœãƒƒã‚¯ã‚¹[OK]
 int OkMessage   (HWND hwnd, LPCTSTR format, ...);
 int TopOkMessage(HWND hwnd, LPCTSTR format, ...);
 
-//ƒ^ƒCƒvw’èƒƒbƒZ[ƒW•\¦—pƒ{ƒbƒNƒX
+//ã‚¿ã‚¤ãƒ—æŒ‡å®šãƒ¡ãƒƒã‚»ãƒ¼ã‚¸è¡¨ç¤ºç”¨ãƒœãƒƒã‚¯ã‚¹
 int CustomMessage   (HWND hwnd, UINT uType, LPCTSTR format, ...);
 int TopCustomMessage(HWND hwnd, UINT uType, LPCTSTR format, ...);	//(TOPMOST)
 
-//ìÒ‚É‹³‚¦‚Ä—~‚µ‚¢ƒGƒ‰[
+//ä½œè€…ã«æ•™ãˆã¦æ¬²ã—ã„ã‚¨ãƒ©ãƒ¼
 int PleaseReportToAuthor(HWND hwnd, LPCTSTR format, ...);
 
 

--- a/sakura_core/util/RegKey.h
+++ b/sakura_core/util/RegKey.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,24 +26,24 @@
 
 #include "util/string_ex.h"
 
-//! ƒq[ƒv‚ğ—p‚¢‚È‚¢vector
-//2007.09.23 kobake ì¬B
+//! ãƒ’ãƒ¼ãƒ—ã‚’ç”¨ã„ãªã„vector
+//2007.09.23 kobake ä½œæˆã€‚
 template <class ELEMENT_TYPE, int MAX_SIZE, class SET_TYPE = const ELEMENT_TYPE&>
 class StaticVector{
 public:
-	//Œ^
+	//å‹
 	typedef ELEMENT_TYPE ElementType;
 
 public:
-	//‘®«
+	//å±æ€§
 	int size() const{ return m_nCount; }
 	int max_size() const{ return MAX_SIZE; }
 
-	//—v‘fƒAƒNƒZƒX
+	//è¦ç´ ã‚¢ã‚¯ã‚»ã‚¹
 	ElementType&       operator[](int nIndex)      { assert(nIndex<MAX_SIZE); assert_warning(nIndex<m_nCount); return m_aElements[nIndex]; }
 	const ElementType& operator[](int nIndex) const{ assert(nIndex<MAX_SIZE); assert_warning(nIndex<m_nCount); return m_aElements[nIndex]; }
 
-	//‘€ì
+	//æ“ä½œ
 	void clear(){ m_nCount=0; }
 	void push_back(SET_TYPE e)
 	{
@@ -58,10 +58,10 @@ public:
 		m_nCount = nNewSize;
 	}
 	
-	//! —v‘f”‚ª0‚Å‚à—v‘f‚Ö‚Ìƒ|ƒCƒ“ƒ^‚ğæ“¾
+	//! è¦ç´ æ•°ãŒ0ã§ã‚‚è¦ç´ ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã‚’å–å¾—
 	ElementType*  dataPtr(){ return m_aElements;}
 
-	//“Áê
+	//ç‰¹æ®Š
 	int& _GetSizeRef(){ return m_nCount; }
 	void SetSizeLimit(){
 		if( MAX_SIZE < m_nCount ){
@@ -76,8 +76,8 @@ private:
 	ElementType m_aElements[MAX_SIZE];
 };
 
-//! ƒq[ƒv‚ğ—p‚¢‚È‚¢•¶š—ñƒNƒ‰ƒX
-//2007.09.23 kobake ì¬B
+//! ãƒ’ãƒ¼ãƒ—ã‚’ç”¨ã„ãªã„æ–‡å­—åˆ—ã‚¯ãƒ©ã‚¹
+//2007.09.23 kobake ä½œæˆã€‚
 template <class CHAR_TYPE, int N_BUFFER_COUNT>
 class StaticString{
 private:
@@ -85,28 +85,28 @@ private:
 public:
 	static const int BUFFER_COUNT = N_BUFFER_COUNT;
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	StaticString(){ m_szData[0]=0; }
 	StaticString(const CHAR_TYPE* rhs){ if(!rhs) m_szData[0]=0; else auto_strcpy(m_szData,rhs); }
 
-	//ƒNƒ‰ƒX‘®«
+	//ã‚¯ãƒ©ã‚¹å±æ€§
 	size_t GetBufferCount() const{ return N_BUFFER_COUNT; }
 
-	//ƒf[ƒ^ƒAƒNƒZƒX
+	//ãƒ‡ãƒ¼ã‚¿ã‚¢ã‚¯ã‚»ã‚¹
 	CHAR_TYPE*       GetBufferPointer()      { return m_szData; }
 	const CHAR_TYPE* GetBufferPointer() const{ return m_szData; }
-	const CHAR_TYPE* c_str()            const{ return m_szData; } //std::string•—
+	const CHAR_TYPE* c_str()            const{ return m_szData; } //std::stringé¢¨
 
-	//ŠÈˆÕƒf[ƒ^ƒAƒNƒZƒX
+	//ç°¡æ˜“ãƒ‡ãƒ¼ã‚¿ã‚¢ã‚¯ã‚»ã‚¹
 	operator       CHAR_TYPE*()      { return m_szData; }
 	operator const CHAR_TYPE*() const{ return m_szData; }
 	CHAR_TYPE At(int nIndex) const{ return m_szData[nIndex]; }
 
-	//ŠÈˆÕƒRƒs[
+	//ç°¡æ˜“ã‚³ãƒ”ãƒ¼
 	void Assign(const CHAR_TYPE* src){ if(!src) m_szData[0]=0; else auto_strcpy_s(m_szData,_countof(m_szData),src); }
 	Me& operator = (const CHAR_TYPE* src){ Assign(src); return *this; }
 
-	//Šeíƒƒ\ƒbƒh
+	//å„ç¨®ãƒ¡ã‚½ãƒƒãƒ‰
 	int Length() const{ return auto_strlen(m_szData); }
 
 private:

--- a/sakura_core/util/container.h
+++ b/sakura_core/util/container.h
@@ -1,7 +1,7 @@
-/*
-	ƒRƒ“ƒeƒi—Ş
+ï»¿/*
+	ã‚³ãƒ³ãƒ†ãƒŠé¡
 
-	2007.11.27 kobake ì¬
+	2007.11.27 kobake ä½œæˆ
 */
 /*
 	Copyright (C) 2008, kobake
@@ -32,7 +32,7 @@
 #include <vector>
 #include <algorithm> //find
 
-//! vector‚É‚¿‚å‚Á‚Æ‹@”\‚ğ’Ç‰Á‚µ‚½”Å
+//! vectorã«ã¡ã‚‡ã£ã¨æ©Ÿèƒ½ã‚’è¿½åŠ ã—ãŸç‰ˆ
 template <class T>
 class vector_ex : public std::vector<T>{
 public:
@@ -41,14 +41,14 @@ public:
 	using std::vector<T>::push_back;
 
 public:
-	// -- -- ƒCƒ“ƒ^[ƒtƒF[ƒX -- -- //
-	//!—v‘f‚ğ’T‚·BŒ©‚Â‚©‚ê‚ÎtrueB
+	// -- -- ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ -- -- //
+	//!è¦ç´ ã‚’æ¢ã™ã€‚è¦‹ã¤ã‹ã‚Œã°trueã€‚
 	bool exist(const T& t) const
 	{
 		return std::find(begin(), end(), t) != end();
 	}
 
-	//!—v‘f‚ğ’Ç‰ÁB‚½‚¾‚µd•¡‚µ‚½—v‘f‚Í’e‚­B
+	//!è¦ç´ ã‚’è¿½åŠ ã€‚ãŸã ã—é‡è¤‡ã—ãŸè¦ç´ ã¯å¼¾ãã€‚
 	bool push_back_unique(const T& t)
 	{
 		if(!exist(t)){

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -1,8 +1,8 @@
-/*
+ï»¿/*
 2007.10.23 kobake
 
-ƒfƒUƒCƒ“ƒpƒ^[ƒ““I‚Èƒ‚ƒm‚ğ’u‚¯‚é‚Æ—Ç‚¢‚È‚ŸB
-‚¿‚È‚İ‚É TSingleInstance ‚ÍƒVƒ“ƒOƒ‹ƒgƒ“ƒpƒ^[ƒ“‚Æ‚Í—‚Ä”ñ‚È‚éƒ‚ƒm‚Å‚·‚ªB
+ãƒ‡ã‚¶ã‚¤ãƒ³ãƒ‘ã‚¿ãƒ¼ãƒ³çš„ãªãƒ¢ãƒã‚’ç½®ã‘ã‚‹ã¨è‰¯ã„ãªãã€‚
+ã¡ãªã¿ã« TSingleInstance ã¯ã‚·ãƒ³ã‚°ãƒ«ãƒˆãƒ³ãƒ‘ã‚¿ãƒ¼ãƒ³ã¨ã¯ä¼¼ã¦éãªã‚‹ãƒ¢ãƒã§ã™ãŒã€‚
 */
 /*
 	Copyright (C) 2008, kobake
@@ -38,14 +38,14 @@
   void operator=(const TypeName&)
 
 /*!
-	Singletonƒpƒ^[ƒ“
+	Singletonãƒ‘ã‚¿ãƒ¼ãƒ³
 
-	2008.03.03 kobake ì¬
+	2008.03.03 kobake ä½œæˆ
 */
 template <class T>
 class TSingleton{
 public:
-	//ŒöŠJƒCƒ“ƒ^[ƒtƒF[ƒX
+	//å…¬é–‹ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 	static T* getInstance()
 	{
 		static T instance;
@@ -59,19 +59,19 @@ private:
 };
 
 /*!
-	1ŒÂ‚µ‚©ƒCƒ“ƒXƒ^ƒ“ƒX‚ª‘¶İ‚µ‚È‚¢ƒNƒ‰ƒX‚©‚ç‚ÌƒCƒ“ƒXƒ^ƒ“ƒXæ“¾ƒCƒ“ƒ^[ƒtƒF[ƒX‚ğstatic‚Å’ñ‹ŸB
-	Singletonƒpƒ^[ƒ“‚Æ‚ÍˆÙ‚È‚èAInstance()ŒÄ‚Ño‚µ‚É‚æ‚èAƒCƒ“ƒXƒ^ƒ“ƒX‚ª©“®¶¬‚³‚ê‚È‚¢“_‚É’ˆÓB
+	1å€‹ã—ã‹ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ãŒå­˜åœ¨ã—ãªã„ã‚¯ãƒ©ã‚¹ã‹ã‚‰ã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹å–å¾—ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã‚’staticã§æä¾›ã€‚
+	Singletonãƒ‘ã‚¿ãƒ¼ãƒ³ã¨ã¯ç•°ãªã‚Šã€Instance()å‘¼ã³å‡ºã—ã«ã‚ˆã‚Šã€ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ãŒè‡ªå‹•ç”Ÿæˆã•ã‚Œãªã„ç‚¹ã«æ³¨æ„ã€‚
 
-	2007.10.23 kobake ì¬
+	2007.10.23 kobake ä½œæˆ
 */
 template <class T>
 class TSingleInstance{
 public:
-	//ŒöŠJƒCƒ“ƒ^[ƒtƒF[ƒX
-	static T* getInstance(){ return gm_instance; } //!< ì¬Ï‚İ‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ğ•Ô‚·BƒCƒ“ƒXƒ^ƒ“ƒX‚ª‘¶İ‚µ‚È‚¯‚ê‚Î NULLB
+	//å…¬é–‹ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
+	static T* getInstance(){ return gm_instance; } //!< ä½œæˆæ¸ˆã¿ã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã‚’è¿”ã™ã€‚ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ãŒå­˜åœ¨ã—ãªã‘ã‚Œã° NULLã€‚
 
 protected:
-	//¦2ŒÂˆÈã‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚Í‘z’è‚µ‚Ä‚¢‚Ü‚¹‚ñBassert‚ª”j’]‚ğŒŸo‚µ‚Ü‚·B
+	//â€»2å€‹ä»¥ä¸Šã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯æƒ³å®šã—ã¦ã„ã¾ã›ã‚“ã€‚assertãŒç ´ç¶»ã‚’æ¤œå‡ºã—ã¾ã™ã€‚
 	TSingleInstance(){ assert(gm_instance==NULL); gm_instance=static_cast<T*>(this); }
 	~TSingleInstance(){ assert(gm_instance); gm_instance=NULL; }
 private:
@@ -82,7 +82,7 @@ T* TSingleInstance<T>::gm_instance = NULL;
 
 
 
-//‹L˜^‚à‚·‚é
+//è¨˜éŒ²ã‚‚ã™ã‚‹
 #include <vector>
 template <class T> class TInstanceHolder{
 public:

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2002, SUI
 	Copyright (C) 2003, MIK
 	Copyright (C) 2008, kobake
@@ -40,28 +40,28 @@ bool fexist(LPCTSTR pszPath)
 	return _taccess(pszPath,0)!=-1;
 }
 
-/*!	ƒtƒ@ƒCƒ‹–¼‚ÌØ‚èo‚µ
+/*!	ãƒ•ã‚¡ã‚¤ãƒ«åã®åˆ‡ã‚Šå‡ºã—
 
-	w’è•¶š—ñ‚©‚çƒtƒ@ƒCƒ‹–¼‚Æ”F¯‚³‚ê‚é•¶š—ñ‚ğæ‚èo‚µA
-	æ“ªOffset‹y‚Ñ’·‚³‚ğ•Ô‚·B
+	æŒ‡å®šæ–‡å­—åˆ—ã‹ã‚‰ãƒ•ã‚¡ã‚¤ãƒ«åã¨èªè­˜ã•ã‚Œã‚‹æ–‡å­—åˆ—ã‚’å–ã‚Šå‡ºã—ã€
+	å…ˆé ­OffsetåŠã³é•·ã•ã‚’è¿”ã™ã€‚
 	
-	@retval true ƒtƒ@ƒCƒ‹–¼”­Œ©
-	@retval false ƒtƒ@ƒCƒ‹–¼‚ÍŒ©‚Â‚©‚ç‚È‚©‚Á‚½
+	@retval true ãƒ•ã‚¡ã‚¤ãƒ«åç™ºè¦‹
+	@retval false ãƒ•ã‚¡ã‚¤ãƒ«åã¯è¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸ
 	
-	@date 2002.01.04 genta ƒtƒ@ƒCƒ‹‘¶İŠm”F•û–@•ÏX
-	@date 2002.01.04 genta ƒfƒBƒŒƒNƒgƒŠ‚ğŒŸ¸‘ÎÛŠO‚É‚·‚é‹@”\‚ğ’Ç‰Á
-	@date 2003.01.15 matsumo gcc‚ÌƒGƒ‰[ƒƒbƒZ[ƒW(:‹æØ‚è)‚Å‚àƒtƒ@ƒCƒ‹‚ğŒŸo‰Â”\‚É
-	@date 2004.05.29 genta C:\‚©‚çƒtƒ@ƒCƒ‹C‚ªØ‚èo‚³‚ê‚é‚Ì‚ğ–h~
-	@date 2004.11.13 genta/Moca ƒtƒ@ƒCƒ‹–¼æ“ª‚Ì*?‚ğl—¶
-	@date 2005.01.10 genta •Ï”–¼•ÏX j -> cur_pos
-	@date 2005.01.23 genta Œx—}§‚Ì‚½‚ßCgoto‚ğreturn‚É•ÏX
-	@date 2013.05.27 Moca Å’·ˆê’v‚É•ÏX
+	@date 2002.01.04 genta ãƒ•ã‚¡ã‚¤ãƒ«å­˜åœ¨ç¢ºèªæ–¹æ³•å¤‰æ›´
+	@date 2002.01.04 genta ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’æ¤œæŸ»å¯¾è±¡å¤–ã«ã™ã‚‹æ©Ÿèƒ½ã‚’è¿½åŠ 
+	@date 2003.01.15 matsumo gccã®ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸(:åŒºåˆ‡ã‚Š)ã§ã‚‚ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æ¤œå‡ºå¯èƒ½ã«
+	@date 2004.05.29 genta C:\ã‹ã‚‰ãƒ•ã‚¡ã‚¤ãƒ«CãŒåˆ‡ã‚Šå‡ºã•ã‚Œã‚‹ã®ã‚’é˜²æ­¢
+	@date 2004.11.13 genta/Moca ãƒ•ã‚¡ã‚¤ãƒ«åå…ˆé ­ã®*?ã‚’è€ƒæ…®
+	@date 2005.01.10 genta å¤‰æ•°åå¤‰æ›´ j -> cur_pos
+	@date 2005.01.23 genta è­¦å‘ŠæŠ‘åˆ¶ã®ãŸã‚ï¼Œgotoã‚’returnã«å¤‰æ›´
+	@date 2013.05.27 Moca æœ€é•·ä¸€è‡´ã«å¤‰æ›´
 */
 bool IsFilePath(
-	const wchar_t*	pLine,		//!< [in]  ’T¸‘ÎÛ•¶š—ñ
-	size_t*			pnBgn,		//!< [out] æ“ªoffsetBpLine + *pnBgn‚ªƒtƒ@ƒCƒ‹–¼æ“ª‚Ö‚Ìƒ|ƒCƒ“ƒ^B
-	size_t*			pnPathLen,	//!< [out] ƒtƒ@ƒCƒ‹–¼‚Ì’·‚³
-	bool			bFileOnly	//!< [in]  true: ƒtƒ@ƒCƒ‹‚Ì‚İ‘ÎÛ / false: ƒfƒBƒŒƒNƒgƒŠ‚à‘ÎÛ
+	const wchar_t*	pLine,		//!< [in]  æ¢æŸ»å¯¾è±¡æ–‡å­—åˆ—
+	size_t*			pnBgn,		//!< [out] å…ˆé ­offsetã€‚pLine + *pnBgnãŒãƒ•ã‚¡ã‚¤ãƒ«åå…ˆé ­ã¸ã®ãƒã‚¤ãƒ³ã‚¿ã€‚
+	size_t*			pnPathLen,	//!< [out] ãƒ•ã‚¡ã‚¤ãƒ«åã®é•·ã•
+	bool			bFileOnly	//!< [in]  true: ãƒ•ã‚¡ã‚¤ãƒ«ã®ã¿å¯¾è±¡ / false: ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚‚å¯¾è±¡
 )
 {
 	wchar_t	szJumpToFile[_MAX_PATH];
@@ -69,7 +69,7 @@ bool IsFilePath(
 
 	size_t	nLineLen = wcslen( pLine );
 
-	//æ“ª‚Ì‹ó”’‚ğ“Ç‚İ”ò‚Î‚·
+	//å…ˆé ­ã®ç©ºç™½ã‚’èª­ã¿é£›ã°ã™
 	size_t	i;
 	for( i = 0; i < nLineLen; ++i ){
 		wchar_t c = pLine[i];
@@ -78,8 +78,8 @@ bool IsFilePath(
 		}
 	}
 
-	//	#include <ƒtƒ@ƒCƒ‹–¼>‚Ìl—¶
-	//	#‚Ån‚Ü‚é‚Æ‚«‚Í"‚Ü‚½‚Í<‚Ü‚Å“Ç‚İ”ò‚Î‚·
+	//	#include <ãƒ•ã‚¡ã‚¤ãƒ«å>ã®è€ƒæ…®
+	//	#ã§å§‹ã¾ã‚‹ã¨ãã¯"ã¾ãŸã¯<ã¾ã§èª­ã¿é£›ã°ã™
 	if( i < nLineLen && L'#' == pLine[i] ){
 		for( ; i < nLineLen; ++i ){
 			if( L'<'  == pLine[i] || L'\"' == pLine[i]){
@@ -89,7 +89,7 @@ bool IsFilePath(
 		}
 	}
 
-	//	‚±‚Ì“_‚ÅŠù‚És––‚É’B‚µ‚Ä‚¢‚½‚çƒtƒ@ƒCƒ‹–¼‚ÍŒ©‚Â‚©‚ç‚È‚¢
+	//	ã“ã®æ™‚ç‚¹ã§æ—¢ã«è¡Œæœ«ã«é”ã—ã¦ã„ãŸã‚‰ãƒ•ã‚¡ã‚¤ãƒ«åã¯è¦‹ã¤ã‹ã‚‰ãªã„
 	if( i >= nLineLen ){
 		return false;
 	}
@@ -98,30 +98,30 @@ bool IsFilePath(
 	size_t cur_pos = 0;
 	size_t tmp_end = 0;
 	for( ; i <= nLineLen && cur_pos + 1 < _countof(szJumpToFile); ++i ){
-		//ƒtƒ@ƒCƒ‹–¼I’[‚ğŒŸ’m‚·‚é
+		//ãƒ•ã‚¡ã‚¤ãƒ«åçµ‚ç«¯ã‚’æ¤œçŸ¥ã™ã‚‹
 		if( WCODE::IsLineDelimiterExt(pLine[i]) || pLine[i] == L'\0' ){
 			break;
 		}
 
-		//ƒtƒ@ƒCƒ‹–¼I’[‚ğŒŸ’m‚·‚é
+		//ãƒ•ã‚¡ã‚¤ãƒ«åçµ‚ç«¯ã‚’æ¤œçŸ¥ã™ã‚‹
 		if( ( i == nLineLen    ||
-			  // 2002.01.08 YAZAKI ƒ^ƒu•¶š‚àB
-			  // 2013.05.27 Moca •¶ší’Ç‰Á
+			  // 2002.01.08 YAZAKI ã‚¿ãƒ–æ–‡å­—ã‚‚ã€‚
+			  // 2013.05.27 Moca æ–‡å­—ç¨®è¿½åŠ 
 			  wcschr(L" \t(\")'`[]{};#!@&%$", pLine[i]) != NULL
 			) &&
 			szJumpToFile[0] != L'\0'
 		){
-			//	ƒtƒ@ƒCƒ‹‘¶İŠm”F
+			//	ãƒ•ã‚¡ã‚¤ãƒ«å­˜åœ¨ç¢ºèª
 			if( IsFileExists(to_tchar(szJumpToFile), bFileOnly)){
 				tmp_end = cur_pos;
 			}
 		}
 
-		// May 29, 2004 genta C:\‚Ì:‚Íƒtƒ@ƒCƒ‹‹æØ‚è‚ÆŒ©‚È‚µ‚Ä—~‚µ‚­‚È‚¢
+		// May 29, 2004 genta C:\ã®:ã¯ãƒ•ã‚¡ã‚¤ãƒ«åŒºåˆ‡ã‚Šã¨è¦‹ãªã—ã¦æ¬²ã—ããªã„
 		if( cur_pos > 1 && pLine[i] == L':' ){   //@@@ 2003/1/15/ matsumo (for gcc)
 			break;
 		}
-		//ƒtƒ@ƒCƒ‹–¼‚Ég‚¦‚È‚¢•¶š‚ªŠÜ‚Ü‚ê‚Ä‚¢‚½‚çA‘¦ƒ‹[ƒvI—¹
+		//ãƒ•ã‚¡ã‚¤ãƒ«åã«ä½¿ãˆãªã„æ–‡å­—ãŒå«ã¾ã‚Œã¦ã„ãŸã‚‰ã€å³ãƒ«ãƒ¼ãƒ—çµ‚äº†
 		if( !WCODE::IsValidFilenameChar(pLine[i]) ){
 			break;
 		}
@@ -131,7 +131,7 @@ bool IsFilePath(
 	}
 
 	//	Jan. 04, 2002 genta
-	//	ƒtƒ@ƒCƒ‹‘¶İŠm”F•û–@•ÏX
+	//	ãƒ•ã‚¡ã‚¤ãƒ«å­˜åœ¨ç¢ºèªæ–¹æ³•å¤‰æ›´
 	if( szJumpToFile[0] != L'\0' && IsFileExists(to_tchar(szJumpToFile), bFileOnly)){
 		tmp_end = cur_pos;
 	}
@@ -145,24 +145,24 @@ bool IsFilePath(
 }
 
 /*!
-	ƒ[ƒJƒ‹ƒhƒ‰ƒCƒu‚Ì”»’è
+	ãƒ­ãƒ¼ã‚«ãƒ«ãƒ‰ãƒ©ã‚¤ãƒ–ã®åˆ¤å®š
 
-	@param[in] pszDrive ƒhƒ‰ƒCƒu–¼‚ğŠÜ‚ŞƒpƒX–¼
+	@param[in] pszDrive ãƒ‰ãƒ©ã‚¤ãƒ–åã‚’å«ã‚€ãƒ‘ã‚¹å
 	
-	@retval true ƒ[ƒJƒ‹ƒhƒ‰ƒCƒu
-	@retval false ƒŠƒ€[ƒoƒuƒ‹ƒhƒ‰ƒCƒuDƒlƒbƒgƒ[ƒNƒhƒ‰ƒCƒuD
+	@retval true ãƒ­ãƒ¼ã‚«ãƒ«ãƒ‰ãƒ©ã‚¤ãƒ–
+	@retval false ãƒªãƒ ãƒ¼ãƒãƒ–ãƒ«ãƒ‰ãƒ©ã‚¤ãƒ–ï¼ãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯ãƒ‰ãƒ©ã‚¤ãƒ–ï¼
 	
 	@author MIK
-	@date 2001.03.29 MIK V‹Kì¬
-	@date 2001.12.23 YAZAKI MRU‚Ì•ÊƒNƒ‰ƒX‰»‚É”º‚¤ŠÖ”‰»
-	@date 2002.01.28 genta –ß‚è’l‚ÌŒ^‚ğBOOL‚©‚çbool‚É•ÏXD
-	@date 2005.11.12 aroka •¶š”»’è•”•ÏX
-	@date 2006.01.08 genta CMRU::IsRemovableDrive‚ÆCEditDoc::IsLocalDrive‚ª
-		À¿“I‚É“¯‚¶‚à‚Ì‚¾‚Á‚½
+	@date 2001.03.29 MIK æ–°è¦ä½œæˆ
+	@date 2001.12.23 YAZAKI MRUã®åˆ¥ã‚¯ãƒ©ã‚¹åŒ–ã«ä¼´ã†é–¢æ•°åŒ–
+	@date 2002.01.28 genta æˆ»ã‚Šå€¤ã®å‹ã‚’BOOLã‹ã‚‰boolã«å¤‰æ›´ï¼
+	@date 2005.11.12 aroka æ–‡å­—åˆ¤å®šéƒ¨å¤‰æ›´
+	@date 2006.01.08 genta CMRU::IsRemovableDriveã¨CEditDoc::IsLocalDriveãŒ
+		å®Ÿè³ªçš„ã«åŒã˜ã‚‚ã®ã ã£ãŸ
 */
 bool IsLocalDrive( const TCHAR* pszDrive )
 {
-	TCHAR	szDriveType[_MAX_DRIVE+1];	// "A:\ "“o˜^—p
+	TCHAR	szDriveType[_MAX_DRIVE+1];	// "A:\ "ç™»éŒ²ç”¨
 	long	lngRet;
 
 	if( iswalpha(pszDrive[0]) ){
@@ -174,7 +174,7 @@ bool IsLocalDrive( const TCHAR* pszDrive )
 		}
 	}
 	else if (pszDrive[0] == _T('\\') && pszDrive[1] == _T('\\')) {
-		// ƒlƒbƒgƒ[ƒNƒpƒX	2010/5/27 Uchi
+		// ãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯ãƒ‘ã‚¹	2010/5/27 Uchi
 		return false;
 	}
 	return true;
@@ -201,10 +201,10 @@ const TCHAR* GetFileTitlePointer(const TCHAR* tszPath)
 }
 
 
-/*! fname‚ª‘Š‘ÎƒpƒX‚Ìê‡‚ÍAÀsƒtƒ@ƒCƒ‹‚ÌƒpƒX‚©‚ç‚Ì‘Š‘ÎƒpƒX‚Æ‚µ‚ÄŠJ‚­
+/*! fnameãŒç›¸å¯¾ãƒ‘ã‚¹ã®å ´åˆã¯ã€å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹ã‹ã‚‰ã®ç›¸å¯¾ãƒ‘ã‚¹ã¨ã—ã¦é–‹ã
 	@author Moca
 	@date 2003.06.23
-	@date 2007.05.20 ryoji ŠÖ”–¼•ÏXi‹ŒFfopen_absexejA”Ä—pƒeƒLƒXƒgƒ}ƒbƒsƒ“ƒO‰»
+	@date 2007.05.20 ryoji é–¢æ•°åå¤‰æ›´ï¼ˆæ—§ï¼šfopen_absexeï¼‰ã€æ±ç”¨ãƒ†ã‚­ã‚¹ãƒˆãƒãƒƒãƒ”ãƒ³ã‚°åŒ–
 */
 FILE* _tfopen_absexe(LPCTSTR fname, LPCTSTR mode)
 {
@@ -216,9 +216,9 @@ FILE* _tfopen_absexe(LPCTSTR fname, LPCTSTR mode)
 	return _tfopen( fname, mode );
 }
 
-/*! fname‚ª‘Š‘ÎƒpƒX‚Ìê‡‚ÍAINIƒtƒ@ƒCƒ‹‚ÌƒpƒX‚©‚ç‚Ì‘Š‘ÎƒpƒX‚Æ‚µ‚ÄŠJ‚­
+/*! fnameãŒç›¸å¯¾ãƒ‘ã‚¹ã®å ´åˆã¯ã€INIãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹ã‹ã‚‰ã®ç›¸å¯¾ãƒ‘ã‚¹ã¨ã—ã¦é–‹ã
 	@author ryoji
-	@date 2007.05.19 V‹Kì¬i_tfopen_absexeƒx[ƒXj
+	@date 2007.05.19 æ–°è¦ä½œæˆï¼ˆ_tfopen_absexeãƒ™ãƒ¼ã‚¹ï¼‰
 */
 FILE* _tfopen_absini(LPCTSTR fname, LPCTSTR mode, BOOL bOrExedir/*=TRUE*/ )
 {
@@ -235,16 +235,16 @@ FILE* _tfopen_absini(LPCTSTR fname, LPCTSTR mode, BOOL bOrExedir/*=TRUE*/ )
 
 
 
-/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ª”¼Šp‚©‚Â'\\'‚Ìê‡‚ÍAæ‚èœ‚­ "c:\\"“™‚Ìƒ‹[ƒg‚Íæ‚èœ‚©‚È‚¢ */
+/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒåŠè§’ã‹ã¤'\\'ã®å ´åˆã¯ã€å–ã‚Šé™¤ã "c:\\"ç­‰ã®ãƒ«ãƒ¼ãƒˆã¯å–ã‚Šé™¤ã‹ãªã„ */
 void CutLastYenFromDirectoryPath( TCHAR* pszFolder )
 {
 	if( 3 == _tcslen( pszFolder )
 	 && pszFolder[1] == _T(':')
 	 && pszFolder[2] == _T('\\')
 	){
-		/* ƒhƒ‰ƒCƒu–¼:\ */
+		/* ãƒ‰ãƒ©ã‚¤ãƒ–å:\ */
 	}else{
-		/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ª”¼Šp‚©‚Â'\\'‚Ìê‡‚ÍAæ‚èœ‚­ */
+		/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒåŠè§’ã‹ã¤'\\'ã®å ´åˆã¯ã€å–ã‚Šé™¤ã */
 		int	nFolderLen;
 		int	nCharChars;
 		nFolderLen = _tcslen( pszFolder );
@@ -261,16 +261,16 @@ void CutLastYenFromDirectoryPath( TCHAR* pszFolder )
 
 
 
-/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ª”¼Šp‚©‚Â'\\'‚Å‚È‚¢ê‡‚ÍA•t‰Á‚·‚é */
+/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒåŠè§’ã‹ã¤'\\'ã§ãªã„å ´åˆã¯ã€ä»˜åŠ ã™ã‚‹ */
 void AddLastYenFromDirectoryPath( CHAR* pszFolder )
 {
 	if( 3 == auto_strlen( pszFolder )
 	 && pszFolder[1] == ':'
 	 && pszFolder[2] == '\\'
 	){
-		/* ƒhƒ‰ƒCƒu–¼:\ */
+		/* ãƒ‰ãƒ©ã‚¤ãƒ–å:\ */
 	}else{
-		/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ª”¼Šp‚©‚Â'\\'‚Å‚È‚¢ê‡‚ÍA•t‰Á‚·‚é */
+		/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒåŠè§’ã‹ã¤'\\'ã§ãªã„å ´åˆã¯ã€ä»˜åŠ ã™ã‚‹ */
 		int	nFolderLen;
 		int	nCharChars;
 		nFolderLen = auto_strlen( pszFolder );
@@ -292,9 +292,9 @@ void AddLastYenFromDirectoryPath( WCHAR* pszFolder )
 	 && pszFolder[1] == L':'
 	 && pszFolder[2] == L'\\'
 	){
-		/* ƒhƒ‰ƒCƒu–¼:\ */
+		/* ãƒ‰ãƒ©ã‚¤ãƒ–å:\ */
 	}else{
-		/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ª”¼Šp‚©‚Â'\\'‚Å‚È‚¢ê‡‚ÍA•t‰Á‚·‚é */
+		/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒåŠè§’ã‹ã¤'\\'ã§ãªã„å ´åˆã¯ã€ä»˜åŠ ã™ã‚‹ */
 		int	nFolderLen;
 		nFolderLen = auto_strlen( pszFolder );
 		if( 0 < nFolderLen ){
@@ -309,8 +309,8 @@ void AddLastYenFromDirectoryPath( WCHAR* pszFolder )
 }
 
 
-/* ƒtƒ@ƒCƒ‹‚Ìƒtƒ‹ƒpƒX‚ğAƒtƒHƒ‹ƒ_‚Æƒtƒ@ƒCƒ‹–¼‚É•ªŠ„ */
-/* [c:\work\test\aaa.txt] ¨ [c:\work\test] + [aaa.txt] */
+/* ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’ã€ãƒ•ã‚©ãƒ«ãƒ€ã¨ãƒ•ã‚¡ã‚¤ãƒ«åã«åˆ†å‰² */
+/* [c:\work\test\aaa.txt] â†’ [c:\work\test] + [aaa.txt] */
 void SplitPath_FolderAndFile( const TCHAR* pszFilePath, TCHAR* pszFolder, TCHAR* pszFile )
 {
 	TCHAR	szDrive[_MAX_DRIVE];
@@ -323,7 +323,7 @@ void SplitPath_FolderAndFile( const TCHAR* pszFilePath, TCHAR* pszFolder, TCHAR*
 	if( NULL != pszFolder ){
 		_tcscpy( pszFolder, szDrive );
 		_tcscat( pszFolder, szDir );
-		/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ª”¼Šp‚©‚Â'\\'‚Ìê‡‚ÍAæ‚èœ‚­ */
+		/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒåŠè§’ã‹ã¤'\\'ã®å ´åˆã¯ã€å–ã‚Šé™¤ã */
 		nFolderLen = _tcslen( pszFolder );
 		if( 0 < nFolderLen ){
 			nCharChars = &pszFolder[nFolderLen] - CNativeT::GetCharPrev( pszFolder, nFolderLen, &pszFolder[nFolderLen] );
@@ -339,20 +339,20 @@ void SplitPath_FolderAndFile( const TCHAR* pszFilePath, TCHAR* pszFolder, TCHAR*
 	return;
 }
 
-/* ƒtƒHƒ‹ƒ_Aƒtƒ@ƒCƒ‹–¼‚©‚çAŒ‹‡‚µ‚½ƒpƒX‚ğì¬
- * [c:\work\test] + [aaa.txt] ¨ [c:\work\test\aaa.txt]
- * ƒtƒHƒ‹ƒ_––”ö‚É‰~‹L†‚ª‚ ‚Á‚Ä‚à‚È‚­‚Ä‚à—Ç‚¢B
+/* ãƒ•ã‚©ãƒ«ãƒ€ã€ãƒ•ã‚¡ã‚¤ãƒ«åã‹ã‚‰ã€çµåˆã—ãŸãƒ‘ã‚¹ã‚’ä½œæˆ
+ * [c:\work\test] + [aaa.txt] â†’ [c:\work\test\aaa.txt]
+ * ãƒ•ã‚©ãƒ«ãƒ€æœ«å°¾ã«å††è¨˜å·ãŒã‚ã£ã¦ã‚‚ãªãã¦ã‚‚è‰¯ã„ã€‚
  */
 void Concat_FolderAndFile( const TCHAR* pszDir, const TCHAR* pszTitle, TCHAR* pszPath )
 {
 	TCHAR* out=pszPath;
 	const TCHAR* in;
 
-	//ƒtƒHƒ‹ƒ_‚ğƒRƒs[
+	//ãƒ•ã‚©ãƒ«ãƒ€ã‚’ã‚³ãƒ”ãƒ¼
 	for( in=pszDir ; *in != '\0'; ){
 		*out++ = *in++;
 	}
-	//‰~‹L†‚ğ•t‰Á
+	//å††è¨˜å·ã‚’ä»˜åŠ 
 #if UNICODE
 	if( *(out-1) != '\\' ){ *out++ = '\\'; }
 #else
@@ -361,7 +361,7 @@ void Concat_FolderAndFile( const TCHAR* pszDir, const TCHAR* pszTitle, TCHAR* ps
 			*out++ = '\\';
 	}
 #endif
-	//ƒtƒ@ƒCƒ‹–¼‚ğƒRƒs[
+	//ãƒ•ã‚¡ã‚¤ãƒ«åã‚’ã‚³ãƒ”ãƒ¼
 	for( in=pszTitle; *in != '\0'; ){
 		*out++ = *in++;
 	}
@@ -370,14 +370,14 @@ void Concat_FolderAndFile( const TCHAR* pszDir, const TCHAR* pszTitle, TCHAR* ps
 }
 
 
-/*! ƒƒ“ƒOƒtƒ@ƒCƒ‹–¼‚ğæ“¾‚·‚é 
+/*! ãƒ­ãƒ³ã‚°ãƒ•ã‚¡ã‚¤ãƒ«åã‚’å–å¾—ã™ã‚‹ 
 
-	@param[in] pszFilePathSrc •ÏŠ·Œ³ƒpƒX–¼
-	@param[out] pszFilePathDes Œ‹‰Ê‘‚«‚İæ (’·‚³MAX_PATH‚Ì—Ìˆæ‚ª•K—v)
+	@param[in] pszFilePathSrc å¤‰æ›å…ƒãƒ‘ã‚¹å
+	@param[out] pszFilePathDes çµæœæ›¸ãè¾¼ã¿å…ˆ (é•·ã•MAX_PATHã®é ˜åŸŸãŒå¿…è¦)
 
-	@date Oct. 2, 2005 genta GetFilePath API‚ğg‚Á‚Ä‘‚«Š·‚¦
-	@date Oct. 4, 2005 genta ‘Š‘ÎƒpƒX‚ªâ‘ÎƒpƒX‚É’¼‚³‚ê‚È‚©‚Á‚½
-	@date Oct. 5, 2005 Moca  ‘Š‘ÎƒpƒX‚ğâ‘ÎƒpƒX‚É•ÏŠ·‚·‚é‚æ‚¤‚É
+	@date Oct. 2, 2005 genta GetFilePath APIã‚’ä½¿ã£ã¦æ›¸ãæ›ãˆ
+	@date Oct. 4, 2005 genta ç›¸å¯¾ãƒ‘ã‚¹ãŒçµ¶å¯¾ãƒ‘ã‚¹ã«ç›´ã•ã‚Œãªã‹ã£ãŸ
+	@date Oct. 5, 2005 Moca  ç›¸å¯¾ãƒ‘ã‚¹ã‚’çµ¶å¯¾ãƒ‘ã‚¹ã«å¤‰æ›ã™ã‚‹ã‚ˆã†ã«
 */
 BOOL GetLongFileName( const TCHAR* pszFilePathSrc, TCHAR* pszFilePathDes )
 {
@@ -399,7 +399,7 @@ BOOL GetLongFileName( const TCHAR* pszFilePathSrc, TCHAR* pszFilePathDes )
 }
 
 
-/* Šg’£q‚ğ’²‚×‚é */
+/* æ‹¡å¼µå­ã‚’èª¿ã¹ã‚‹ */
 BOOL CheckEXT( const TCHAR* pszPath, const TCHAR* pszExt )
 {
 	TCHAR	szExt[_MAX_EXT];
@@ -416,7 +416,7 @@ BOOL CheckEXT( const TCHAR* pszPath, const TCHAR* pszExt )
 	}
 }
 
-/*! ‘Š‘ÎƒpƒX‚©”»’è‚·‚é
+/*! ç›¸å¯¾ãƒ‘ã‚¹ã‹åˆ¤å®šã™ã‚‹
 	@author Moca
 	@date 2003.06.23
 */
@@ -437,49 +437,49 @@ bool _IS_REL_PATH(const TCHAR* path)
 
 
 
-/*! @brief ƒfƒBƒŒƒNƒgƒŠ‚Ì[‚³‚ğŒvZ‚·‚é
+/*! @brief ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®æ·±ã•ã‚’è¨ˆç®—ã™ã‚‹
 
-	—^‚¦‚ç‚ê‚½ƒpƒX–¼‚©‚çƒfƒBƒŒƒNƒgƒŠ‚Ì[‚³‚ğŒvZ‚·‚éD
-	ƒpƒX‚Ì‹æØ‚è‚Í\Dƒ‹[ƒgƒfƒBƒŒƒNƒgƒŠ‚ª[‚³0‚ÅCƒTƒuƒfƒBƒŒƒNƒgƒŠ–ˆ‚É
-	[‚³‚ª1‚¸‚Âã‚ª‚Á‚Ä‚¢‚­D
+	ä¸ãˆã‚‰ã‚ŒãŸãƒ‘ã‚¹åã‹ã‚‰ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®æ·±ã•ã‚’è¨ˆç®—ã™ã‚‹ï¼
+	ãƒ‘ã‚¹ã®åŒºåˆ‡ã‚Šã¯\ï¼ãƒ«ãƒ¼ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãŒæ·±ã•0ã§ï¼Œã‚µãƒ–ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªæ¯ã«
+	æ·±ã•ãŒ1ãšã¤ä¸ŠãŒã£ã¦ã„ãï¼
  
-	@date 2003.04.30 genta V‹Kì¬
+	@date 2003.04.30 genta æ–°è¦ä½œæˆ
 */
 int CalcDirectoryDepth(
-	const TCHAR* path	//!< [in] [‚³‚ğ’²‚×‚½‚¢ƒtƒ@ƒCƒ‹/ƒfƒBƒŒƒNƒgƒŠ‚Ìƒtƒ‹ƒpƒX
+	const TCHAR* path	//!< [in] æ·±ã•ã‚’èª¿ã¹ãŸã„ãƒ•ã‚¡ã‚¤ãƒ«/ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®ãƒ•ãƒ«ãƒ‘ã‚¹
 )
 {
 	int depth = 0;
  
-	//	‚Æ‚è‚ ‚¦‚¸\‚Ì”‚ğ”‚¦‚é
+	//	ã¨ã‚Šã‚ãˆãš\ã®æ•°ã‚’æ•°ãˆã‚‹
 	for( CharPointerT p = path; *p != _T('\0'); ++p ){
 		if( *p == _T('\\') ){
 			++depth;
-			//	ƒtƒ‹ƒpƒX‚É‚Í“ü‚Á‚Ä‚¢‚È‚¢‚Í‚¸‚¾‚ª”O‚Ì‚½‚ß
-			//	.\‚ÍƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚È‚Ì‚ÅC[‚³‚ÉŠÖŒW‚È‚¢D
+			//	ãƒ•ãƒ«ãƒ‘ã‚¹ã«ã¯å…¥ã£ã¦ã„ãªã„ã¯ãšã ãŒå¿µã®ãŸã‚
+			//	.\ã¯ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãªã®ã§ï¼Œæ·±ã•ã«é–¢ä¿‚ãªã„ï¼
 			while( p[1] == _T('.') && p[2] == _T('\\') ){
 				p += 2;
 			}
 		}
 	}
  
-	//	•â³
-	//	ƒhƒ‰ƒCƒu–¼‚ÍƒpƒX‚Ì[‚³‚É”‚¦‚È‚¢
+	//	è£œæ­£
+	//	ãƒ‰ãƒ©ã‚¤ãƒ–åã¯ãƒ‘ã‚¹ã®æ·±ã•ã«æ•°ãˆãªã„
 	if( ((_T('A') <= path[0] && path[0] <= _T('Z')) || (_T('a') <= path[0] && path[0] <= _T('z')))
 		&& path[1] == _T(':') && path[2] == _T('\\') ){
-		//ƒtƒ‹ƒpƒX
-		--depth; // C:\ ‚Ì \ ‚Íƒ‹[ƒg‚Ì‹L†‚È‚Ì‚ÅŠK‘w[‚³‚Å‚Í‚È‚¢
+		//ãƒ•ãƒ«ãƒ‘ã‚¹
+		--depth; // C:\ ã® \ ã¯ãƒ«ãƒ¼ãƒˆã®è¨˜å·ãªã®ã§éšå±¤æ·±ã•ã§ã¯ãªã„
 	}
 	else if( path[0] == _T('\\') ){
 		if( path[1] == _T('\\') ){
-			//	ƒlƒbƒgƒ[ƒNƒpƒX
-			//	æ“ª‚Ì2‚Â‚Íƒlƒbƒgƒ[ƒN‚ğ•\‚µC‚»‚ÌŸ‚ÍƒzƒXƒg–¼‚È‚Ì‚Å
-			//	ƒfƒBƒŒƒNƒgƒŠŠK‘w‚Æ‚Í–³ŠÖŒW
+			//	ãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯ãƒ‘ã‚¹
+			//	å…ˆé ­ã®2ã¤ã¯ãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯ã‚’è¡¨ã—ï¼Œãã®æ¬¡ã¯ãƒ›ã‚¹ãƒˆåãªã®ã§
+			//	ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªéšå±¤ã¨ã¯ç„¡é–¢ä¿‚
 			depth -= 3;
 		}
 		else {
-			//	ƒhƒ‰ƒCƒu–¼–³‚µ‚Ìƒtƒ‹ƒpƒX
-			//	æ“ª‚Ì\‚Í‘ÎÛŠO
+			//	ãƒ‰ãƒ©ã‚¤ãƒ–åç„¡ã—ã®ãƒ•ãƒ«ãƒ‘ã‚¹
+			//	å…ˆé ­ã®\ã¯å¯¾è±¡å¤–
 			--depth;
 		}
 	}
@@ -488,23 +488,23 @@ int CalcDirectoryDepth(
 
 
 /*!
-	@brief exeƒtƒ@ƒCƒ‹‚Ì‚ ‚éƒfƒBƒŒƒNƒgƒŠC‚Ü‚½‚Íw’è‚³‚ê‚½ƒtƒ@ƒCƒ‹–¼‚Ìƒtƒ‹ƒpƒX‚ğ•Ô‚·D
+	@brief exeãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚ã‚‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªï¼Œã¾ãŸã¯æŒ‡å®šã•ã‚ŒãŸãƒ•ã‚¡ã‚¤ãƒ«åã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’è¿”ã™ï¼
 	
 	@author genta
 	@date 2002.12.02 genta
-	@date 2007.05.20 ryoji ŠÖ”–¼•ÏXi‹ŒFGetExecutableDirjA”Ä—pƒeƒLƒXƒgƒ}ƒbƒsƒ“ƒO‰»
-	@date 2008.05.05 novice GetModuleHandle(NULL)¨NULL‚É•ÏX
+	@date 2007.05.20 ryoji é–¢æ•°åå¤‰æ›´ï¼ˆæ—§ï¼šGetExecutableDirï¼‰ã€æ±ç”¨ãƒ†ã‚­ã‚¹ãƒˆãƒãƒƒãƒ”ãƒ³ã‚°åŒ–
+	@date 2008.05.05 novice GetModuleHandle(NULL)â†’NULLã«å¤‰æ›´
 */
 void GetExedir(
-	LPTSTR	pDir,	//!< [out] EXEƒtƒ@ƒCƒ‹‚Ì‚ ‚éƒfƒBƒŒƒNƒgƒŠ‚ğ•Ô‚·êŠD—\‚ß_MAX_PATH‚Ìƒoƒbƒtƒ@‚ğ—pˆÓ‚µ‚Ä‚¨‚­‚±‚ÆD
-	LPCTSTR	szFile	//!< [in]  ƒfƒBƒŒƒNƒgƒŠ–¼‚ÉŒ‹‡‚·‚éƒtƒ@ƒCƒ‹–¼D
+	LPTSTR	pDir,	//!< [out] EXEãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚ã‚‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’è¿”ã™å ´æ‰€ï¼äºˆã‚_MAX_PATHã®ãƒãƒƒãƒ•ã‚¡ã‚’ç”¨æ„ã—ã¦ãŠãã“ã¨ï¼
+	LPCTSTR	szFile	//!< [in]  ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã«çµåˆã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«åï¼
 )
 {
 	if( pDir == NULL )
 		return;
 	
 	TCHAR	szPath[_MAX_PATH];
-	// sakura.exe ‚ÌƒpƒX‚ğæ“¾
+	// sakura.exe ã®ãƒ‘ã‚¹ã‚’å–å¾—
 	::GetModuleFileName( NULL, szPath, _countof(szPath) );
 	if( szFile == NULL ){
 		SplitPath_FolderAndFile( szPath, pDir, NULL );
@@ -517,14 +517,14 @@ void GetExedir(
 }
 
 /*!
-	@brief INIƒtƒ@ƒCƒ‹‚Ì‚ ‚éƒfƒBƒŒƒNƒgƒŠC‚Ü‚½‚Íw’è‚³‚ê‚½ƒtƒ@ƒCƒ‹–¼‚Ìƒtƒ‹ƒpƒX‚ğ•Ô‚·D
+	@brief INIãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚ã‚‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªï¼Œã¾ãŸã¯æŒ‡å®šã•ã‚ŒãŸãƒ•ã‚¡ã‚¤ãƒ«åã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’è¿”ã™ï¼
 	
 	@author ryoji
-	@date 2007.05.19 V‹Kì¬iGetExedirƒx[ƒXj
+	@date 2007.05.19 æ–°è¦ä½œæˆï¼ˆGetExedirãƒ™ãƒ¼ã‚¹ï¼‰
 */
 void GetInidir(
-	LPTSTR	pDir,				//!< [out] INIƒtƒ@ƒCƒ‹‚Ì‚ ‚éƒfƒBƒŒƒNƒgƒŠ‚ğ•Ô‚·êŠD—\‚ß_MAX_PATH‚Ìƒoƒbƒtƒ@‚ğ—pˆÓ‚µ‚Ä‚¨‚­‚±‚ÆD
-	LPCTSTR szFile	/*=NULL*/	//!< [in] ƒfƒBƒŒƒNƒgƒŠ–¼‚ÉŒ‹‡‚·‚éƒtƒ@ƒCƒ‹–¼D
+	LPTSTR	pDir,				//!< [out] INIãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚ã‚‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’è¿”ã™å ´æ‰€ï¼äºˆã‚_MAX_PATHã®ãƒãƒƒãƒ•ã‚¡ã‚’ç”¨æ„ã—ã¦ãŠãã“ã¨ï¼
+	LPCTSTR szFile	/*=NULL*/	//!< [in] ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã«çµåˆã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«åï¼
 )
 {
 	if( pDir == NULL )
@@ -533,7 +533,7 @@ void GetInidir(
 	std::tstring strProfileName = to_tchar(CCommandLine::getInstance()->GetProfileName());
 	TCHAR	szPath[_MAX_PATH];
 
-	// sakura.ini ‚ÌƒpƒX‚ğæ“¾
+	// sakura.ini ã®ãƒ‘ã‚¹ã‚’å–å¾—
 	CFileNameManager::getInstance()->GetIniFileName( szPath, strProfileName.c_str() );
 	if( szFile == NULL ){
 		SplitPath_FolderAndFile( szPath, pDir, NULL );
@@ -547,37 +547,37 @@ void GetInidir(
 
 
 /*!
-	@brief INIƒtƒ@ƒCƒ‹‚Ü‚½‚ÍEXEƒtƒ@ƒCƒ‹‚Ì‚ ‚éƒfƒBƒŒƒNƒgƒŠC‚Ü‚½‚Íw’è‚³‚ê‚½ƒtƒ@ƒCƒ‹–¼‚Ìƒtƒ‹ƒpƒX‚ğ•Ô‚·iINI‚ğ—DæjD
+	@brief INIãƒ•ã‚¡ã‚¤ãƒ«ã¾ãŸã¯EXEãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚ã‚‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªï¼Œã¾ãŸã¯æŒ‡å®šã•ã‚ŒãŸãƒ•ã‚¡ã‚¤ãƒ«åã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’è¿”ã™ï¼ˆINIã‚’å„ªå…ˆï¼‰ï¼
 	
 	@author ryoji
-	@date 2007.05.22 V‹Kì¬
+	@date 2007.05.22 æ–°è¦ä½œæˆ
 */
 void GetInidirOrExedir(
-	LPTSTR	pDir,								//!< [out] INIƒtƒ@ƒCƒ‹‚Ü‚½‚ÍEXEƒtƒ@ƒCƒ‹‚Ì‚ ‚éƒfƒBƒŒƒNƒgƒŠ‚ğ•Ô‚·êŠD
-												//         —\‚ß_MAX_PATH‚Ìƒoƒbƒtƒ@‚ğ—pˆÓ‚µ‚Ä‚¨‚­‚±‚ÆD
-	LPCTSTR	szFile					/*=NULL*/,	//!< [in] ƒfƒBƒŒƒNƒgƒŠ–¼‚ÉŒ‹‡‚·‚éƒtƒ@ƒCƒ‹–¼D
-	BOOL	bRetExedirIfFileEmpty	/*=FALSE*/	//!< [in] ƒtƒ@ƒCƒ‹–¼‚Ìw’è‚ª‹ó‚Ìê‡‚ÍEXEƒtƒ@ƒCƒ‹‚Ìƒtƒ‹ƒpƒX‚ğ•Ô‚·D
+	LPTSTR	pDir,								//!< [out] INIãƒ•ã‚¡ã‚¤ãƒ«ã¾ãŸã¯EXEãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚ã‚‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’è¿”ã™å ´æ‰€ï¼
+												//         äºˆã‚_MAX_PATHã®ãƒãƒƒãƒ•ã‚¡ã‚’ç”¨æ„ã—ã¦ãŠãã“ã¨ï¼
+	LPCTSTR	szFile					/*=NULL*/,	//!< [in] ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã«çµåˆã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«åï¼
+	BOOL	bRetExedirIfFileEmpty	/*=FALSE*/	//!< [in] ãƒ•ã‚¡ã‚¤ãƒ«åã®æŒ‡å®šãŒç©ºã®å ´åˆã¯EXEãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’è¿”ã™ï¼
 )
 {
 	TCHAR	szInidir[_MAX_PATH];
 	TCHAR	szExedir[_MAX_PATH];
 
-	// ƒtƒ@ƒCƒ‹–¼‚Ìw’è‚ª‹ó‚Ìê‡‚ÍEXEƒtƒ@ƒCƒ‹‚Ìƒtƒ‹ƒpƒX‚ğ•Ô‚·iƒIƒvƒVƒ‡ƒ“j
+	// ãƒ•ã‚¡ã‚¤ãƒ«åã®æŒ‡å®šãŒç©ºã®å ´åˆã¯EXEãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’è¿”ã™ï¼ˆã‚ªãƒ—ã‚·ãƒ§ãƒ³ï¼‰
 	if( bRetExedirIfFileEmpty && (szFile == NULL || szFile[0] == _T('\0')) ){
 		GetExedir( szExedir, szFile );
 		::lstrcpy( pDir, szExedir );
 		return;
 	}
 
-	// INIŠî€‚Ìƒtƒ‹ƒpƒX‚ªÀİ‚·‚ê‚Î‚»‚ÌƒpƒX‚ğ•Ô‚·
+	// INIåŸºæº–ã®ãƒ•ãƒ«ãƒ‘ã‚¹ãŒå®Ÿåœ¨ã™ã‚Œã°ãã®ãƒ‘ã‚¹ã‚’è¿”ã™
 	GetInidir( szInidir, szFile );
 	if( fexist(szInidir) ){
 		::lstrcpy( pDir, szInidir );
 		return;
 	}
 
-	// EXEŠî€‚Ìƒtƒ‹ƒpƒX‚ªÀİ‚·‚ê‚Î‚»‚ÌƒpƒX‚ğ•Ô‚·
-	if( CShareData::getInstance()->IsPrivateSettings() ){	// INI‚ÆEXE‚ÅƒpƒX‚ªˆÙ‚È‚éê‡
+	// EXEåŸºæº–ã®ãƒ•ãƒ«ãƒ‘ã‚¹ãŒå®Ÿåœ¨ã™ã‚Œã°ãã®ãƒ‘ã‚¹ã‚’è¿”ã™
+	if( CShareData::getInstance()->IsPrivateSettings() ){	// INIã¨EXEã§ãƒ‘ã‚¹ãŒç•°ãªã‚‹å ´åˆ
 		GetExedir( szExedir, szFile );
 		if( fexist(szExedir) ){
 			::lstrcpy( pDir, szExedir );
@@ -585,14 +585,14 @@ void GetInidirOrExedir(
 		}
 	}
 
-	// ‚Ç‚¿‚ç‚É‚àÀİ‚µ‚È‚¯‚ê‚ÎINIŠî€‚Ìƒtƒ‹ƒpƒX‚ğ•Ô‚·
+	// ã©ã¡ã‚‰ã«ã‚‚å®Ÿåœ¨ã—ãªã‘ã‚Œã°INIåŸºæº–ã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’è¿”ã™
 	::lstrcpy( pDir, szInidir );
 }
 
 /*!
-	@brief INIƒtƒ@ƒCƒ‹‚Ü‚½‚ÍEXEƒtƒ@ƒCƒ‹‚Ì‚ ‚éƒfƒBƒŒƒNƒgƒŠ‚Ì‘Š‘ÎƒpƒX‚ğ•Ô‚·iINI‚ğ—DæjD
-	@param pszPath [in] ‘ÎÛƒpƒX
-	@date 2013.06.26 novice V‹Kì¬
+	@brief INIãƒ•ã‚¡ã‚¤ãƒ«ã¾ãŸã¯EXEãƒ•ã‚¡ã‚¤ãƒ«ã®ã‚ã‚‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®ç›¸å¯¾ãƒ‘ã‚¹ã‚’è¿”ã™ï¼ˆINIã‚’å„ªå…ˆï¼‰ï¼
+	@param pszPath [in] å¯¾è±¡ãƒ‘ã‚¹
+	@date 2013.06.26 novice æ–°è¦ä½œæˆ
 */
 LPCTSTR GetRelPath( LPCTSTR pszPath )
 {
@@ -616,18 +616,18 @@ LPCTSTR GetRelPath( LPCTSTR pszPath )
 
 
 
-/**	ƒtƒ@ƒCƒ‹‚Ì‘¶İƒ`ƒFƒbƒN
+/**	ãƒ•ã‚¡ã‚¤ãƒ«ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
 
-	w’è‚³‚ê‚½ƒpƒX‚Ìƒtƒ@ƒCƒ‹‚ª‘¶İ‚·‚é‚©‚Ç‚¤‚©‚ğŠm”F‚·‚éB
+	æŒ‡å®šã•ã‚ŒãŸãƒ‘ã‚¹ã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã™ã‚‹ã‹ã©ã†ã‹ã‚’ç¢ºèªã™ã‚‹ã€‚
 	
-	@param path [in] ’²‚×‚éƒpƒX–¼
-	@param bFileOnly [in] true: ƒtƒ@ƒCƒ‹‚Ì‚İ‘ÎÛ / false: ƒfƒBƒŒƒNƒgƒŠ‚à‘ÎÛ
+	@param path [in] èª¿ã¹ã‚‹ãƒ‘ã‚¹å
+	@param bFileOnly [in] true: ãƒ•ã‚¡ã‚¤ãƒ«ã®ã¿å¯¾è±¡ / false: ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚‚å¯¾è±¡
 	
-	@retval true  ƒtƒ@ƒCƒ‹‚Í‘¶İ‚·‚é
-	@retval false ƒtƒ@ƒCƒ‹‚Í‘¶İ‚µ‚È‚¢
+	@retval true  ãƒ•ã‚¡ã‚¤ãƒ«ã¯å­˜åœ¨ã™ã‚‹
+	@retval false ãƒ•ã‚¡ã‚¤ãƒ«ã¯å­˜åœ¨ã—ãªã„
 	
 	@author genta
-	@date 2002.01.04 V‹Kì¬
+	@date 2002.01.04 æ–°è¦ä½œæˆ
 */
 bool IsFileExists(const TCHAR* path, bool bFileOnly)
 {
@@ -641,17 +641,17 @@ bool IsFileExists(const TCHAR* path, bool bFileOnly)
 	return false;
 }
 
-/**	ƒfƒBƒŒƒNƒgƒŠƒ`ƒFƒbƒN
+/**	ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãƒã‚§ãƒƒã‚¯
 
-	w’è‚³‚ê‚½ƒpƒX‚ªƒfƒBƒŒƒNƒgƒŠ‚©‚Ç‚¤‚©‚ğŠm”F‚·‚éB
+	æŒ‡å®šã•ã‚ŒãŸãƒ‘ã‚¹ãŒãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‹ã©ã†ã‹ã‚’ç¢ºèªã™ã‚‹ã€‚
 
-	@param pszPath [in] ’²‚×‚éƒpƒX–¼
+	@param pszPath [in] èª¿ã¹ã‚‹ãƒ‘ã‚¹å
 
-	@retval true  ƒfƒBƒŒƒNƒgƒŠ
-	@retval false ƒfƒBƒŒƒNƒgƒŠ‚Å‚Í‚È‚¢
+	@retval true  ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª
+	@retval false ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã§ã¯ãªã„
 	
 	@author ryoji
-	@date 2009.08.20 V‹Kì¬
+	@date 2009.08.20 æ–°è¦ä½œæˆ
 */
 bool IsDirectory(LPCTSTR pszPath)
 {
@@ -666,21 +666,21 @@ bool IsDirectory(LPCTSTR pszPath)
 
 
 
-/*!	ƒtƒ@ƒCƒ‹‚ÌXV“ú‚ğæ“¾
+/*!	ãƒ•ã‚¡ã‚¤ãƒ«ã®æ›´æ–°æ—¥æ™‚ã‚’å–å¾—
 
-	@return true: ¬Œ÷, false: FindFirstFile¸”s
+	@return true: æˆåŠŸ, false: FindFirstFileå¤±æ•—
 
 	@author genta by assitance with ryoji
 	@date 2005.10.22 new
 
-	@note ‘‚«‚İŒã‚Éƒtƒ@ƒCƒ‹‚ğÄƒI[ƒvƒ“‚µ‚Äƒ^ƒCƒ€ƒXƒ^ƒ“ƒv‚ğ“¾‚æ‚¤‚Æ‚·‚é‚Æ
-	ƒtƒ@ƒCƒ‹‚ª‚Ü‚¾ƒƒbƒN‚³‚ê‚Ä‚¢‚é‚±‚Æ‚ª‚ ‚èCã‘‚«‹Ö~‚ÆŒë”F‚³‚ê‚é‚±‚Æ‚ª‚ ‚éD
-	FindFirstFile‚ğg‚¤‚±‚Æ‚Åƒtƒ@ƒCƒ‹‚ÌƒƒbƒNó‘Ô‚É‰e‹¿‚³‚ê‚¸‚Éƒ^ƒCƒ€ƒXƒ^ƒ“ƒv‚ğ
-	æ“¾‚Å‚«‚éD(ryoji)
+	@note æ›¸ãè¾¼ã¿å¾Œã«ãƒ•ã‚¡ã‚¤ãƒ«ã‚’å†ã‚ªãƒ¼ãƒ—ãƒ³ã—ã¦ã‚¿ã‚¤ãƒ ã‚¹ã‚¿ãƒ³ãƒ—ã‚’å¾—ã‚ˆã†ã¨ã™ã‚‹ã¨
+	ãƒ•ã‚¡ã‚¤ãƒ«ãŒã¾ã ãƒ­ãƒƒã‚¯ã•ã‚Œã¦ã„ã‚‹ã“ã¨ãŒã‚ã‚Šï¼Œä¸Šæ›¸ãç¦æ­¢ã¨èª¤èªã•ã‚Œã‚‹ã“ã¨ãŒã‚ã‚‹ï¼
+	FindFirstFileã‚’ä½¿ã†ã“ã¨ã§ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ­ãƒƒã‚¯çŠ¶æ…‹ã«å½±éŸ¿ã•ã‚Œãšã«ã‚¿ã‚¤ãƒ ã‚¹ã‚¿ãƒ³ãƒ—ã‚’
+	å–å¾—ã§ãã‚‹ï¼(ryoji)
 */
 bool GetLastWriteTimestamp(
-	const TCHAR*	pszFileName,	//!< [in]  ƒtƒ@ƒCƒ‹‚ÌƒpƒX
-	CFileTime*		pcFileTime		//!< [out] XV“ú‚ğ•Ô‚·êŠ
+	const TCHAR*	pszFileName,	//!< [in]  ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹
+	CFileTime*		pcFileTime		//!< [out] æ›´æ–°æ—¥æ™‚ã‚’è¿”ã™å ´æ‰€
 )
 {
 	HANDLE hFindFile;
@@ -694,7 +694,7 @@ bool GetLastWriteTimestamp(
 		return true;
 	}
 	else{
-		//	ƒtƒ@ƒCƒ‹‚ªŒ©‚Â‚©‚ç‚È‚©‚Á‚½
+		//	ãƒ•ã‚¡ã‚¤ãƒ«ãŒè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸ
 		pcFileTime->ClearFILETIME();
 		return false;
 	}
@@ -719,151 +719,151 @@ bool GetLastWriteTimestamp(
 /* ============================================================================
 my_splitpath( const char *CommandLine, char *drive, char *dir, char *fname, char *ext );
 
-š ŠT—v
-CommandLine ‚É—^‚¦‚ç‚ê‚½ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“•¶š—ñ‚Ìæ“ª‚©‚çAÀİ‚·‚éƒtƒ@ƒCƒ‹EƒfƒB
-ƒŒƒNƒgƒŠ‚Ì•”•ª‚Ì‚İ‚ğ’Šo‚µA‚»‚Ì’Šo•”•ª‚É‘Î‚µ‚Ä _splitpath() ‚Æ“¯“™‚Ìˆ—‚ğ‚¨
-‚±‚È‚¢‚Ü‚·B
-æ“ª•”•ª‚ÉÀİ‚·‚éƒtƒ@ƒCƒ‹EƒfƒBƒŒƒNƒgƒŠ–¼‚ª–³‚¢ê‡‚Í‹ó•¶š—ñ‚ª•Ô‚è‚Ü‚·B
-•¶š—ñ’†‚Ì“ú–{Œê(Shift_JISƒR[ƒh‚Ì‚İ)‚É‘Î‰‚µ‚Ä‚¢‚Ü‚·B
+â˜… æ¦‚è¦
+CommandLine ã«ä¸ãˆã‚‰ã‚ŒãŸã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³æ–‡å­—åˆ—ã®å…ˆé ­ã‹ã‚‰ã€å®Ÿåœ¨ã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ãƒ‡ã‚£
+ãƒ¬ã‚¯ãƒˆãƒªã®éƒ¨åˆ†ã®ã¿ã‚’æŠ½å‡ºã—ã€ãã®æŠ½å‡ºéƒ¨åˆ†ã«å¯¾ã—ã¦ _splitpath() ã¨åŒç­‰ã®å‡¦ç†ã‚’ãŠ
+ã“ãªã„ã¾ã™ã€‚
+å…ˆé ­éƒ¨åˆ†ã«å®Ÿåœ¨ã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåãŒç„¡ã„å ´åˆã¯ç©ºæ–‡å­—åˆ—ãŒè¿”ã‚Šã¾ã™ã€‚
+æ–‡å­—åˆ—ä¸­ã®æ—¥æœ¬èª(Shift_JISã‚³ãƒ¼ãƒ‰ã®ã¿)ã«å¯¾å¿œã—ã¦ã„ã¾ã™ã€‚
 
-š ƒvƒƒOƒ‰ƒ€‹Lq“à—e‚É‚Â‚¢‚Ä(Œ¾‚¢–ó‚ ‚ê‚±‚ê)
-•¶š—ñ‚Ì split ˆ—•”‚¾‚¯‚É‚Å‚à _splitpath() ‚ğg‚¦‚Î‚à‚Á‚Æ’Z‚­‚È‚Á‚½‚Ì‚Å‚·‚ªA
-‚»‚¤‚â‚ç‚¸‚É‘S‚Ä©‘O‚Åˆ—‚µ‚Ä‚¢‚é——R‚ÍA
-EƒRƒ“ƒpƒCƒ‰‚É‚æ‚Á‚Ä‚Í _splitpath() ‚ª“ú–{Œê‚É‘Î‰‚µ‚Ä‚¢‚È‚¢‰Â”\«‚à‚ ‚éB
-E_splitpath() ‚Á‚ÄAƒRƒ“ƒpƒCƒ‰‚É‚æ‚Á‚ÄAÚ×“®ì‚ª”÷–­‚ÉˆÙ‚È‚é‚©‚à‚µ‚ê‚È‚¢‚©‚ç
-@d—l‚ğƒnƒbƒLƒŠ‚³‚¹‚é‚½‚ß‚É‚àƒRƒ“ƒpƒCƒ‰‚É“Y•t‚³‚ê‚Ä‚¢‚é _splitpath() ‚É‚ ‚Ü‚è
-@—Š‚è‚½‚­‚È‚©‚Á‚½B
-E‚Æ‚¢‚¤‚©Aå‚É“®ìŠm”F‚Ég—p‚µ‚Ä‚¢‚½ LSI-CH”Å‚É‚Í‚»‚à‚»‚à _splitpath() ‚ª
-@‘¶İ‚µ‚È‚¢‚©‚çA‚â‚ç‚´‚é‚ğ‚¦‚È‚©‚Á‚½B :-(
-‚Æ‚¢‚¤–‚É‚æ‚è‚Ü‚·B
+â˜… ãƒ—ãƒ­ã‚°ãƒ©ãƒ è¨˜è¿°å†…å®¹ã«ã¤ã„ã¦(è¨€ã„è¨³ã‚ã‚Œã“ã‚Œ)
+æ–‡å­—åˆ—ã® split å‡¦ç†éƒ¨ã ã‘ã«ã§ã‚‚ _splitpath() ã‚’ä½¿ãˆã°ã‚‚ã£ã¨çŸ­ããªã£ãŸã®ã§ã™ãŒã€
+ãã†ã‚„ã‚‰ãšã«å…¨ã¦è‡ªå‰ã§å‡¦ç†ã—ã¦ã„ã‚‹ç†ç”±ã¯ã€
+ãƒ»ã‚³ãƒ³ãƒ‘ã‚¤ãƒ©ã«ã‚ˆã£ã¦ã¯ _splitpath() ãŒæ—¥æœ¬èªã«å¯¾å¿œã—ã¦ã„ãªã„å¯èƒ½æ€§ã‚‚ã‚ã‚‹ã€‚
+ãƒ»_splitpath() ã£ã¦ã€ã‚³ãƒ³ãƒ‘ã‚¤ãƒ©ã«ã‚ˆã£ã¦ã€è©³ç´°å‹•ä½œãŒå¾®å¦™ã«ç•°ãªã‚‹ã‹ã‚‚ã—ã‚Œãªã„ã‹ã‚‰
+ã€€ä»•æ§˜ã‚’ãƒãƒƒã‚­ãƒªã•ã›ã‚‹ãŸã‚ã«ã‚‚ã‚³ãƒ³ãƒ‘ã‚¤ãƒ©ã«æ·»ä»˜ã•ã‚Œã¦ã„ã‚‹ _splitpath() ã«ã‚ã¾ã‚Š
+ã€€é ¼ã‚ŠãŸããªã‹ã£ãŸã€‚
+ãƒ»ã¨ã„ã†ã‹ã€ä¸»ã«å‹•ä½œç¢ºèªã«ä½¿ç”¨ã—ã¦ã„ãŸ LSI-Cè©¦é£Ÿç‰ˆã«ã¯ãã‚‚ãã‚‚ _splitpath() ãŒ
+ã€€å­˜åœ¨ã—ãªã„ã‹ã‚‰ã€ã‚„ã‚‰ã–ã‚‹ã‚’ãˆãªã‹ã£ãŸã€‚ :-(
+ã¨ã„ã†äº‹ã«ã‚ˆã‚Šã¾ã™ã€‚
 
-¦ "LFN library" -> http://webs.to/ken/
+â€» "LFN library" -> http://webs.to/ken/
 
-š Ú×“®ì
+â˜… è©³ç´°å‹•ä½œ
 my_splitpath( CommandLine, drive, dir, fname, ext );
-CommandLine ‚É•¶š—ñ‚Æ‚µ‚Ä D:\Test.ext ‚ª—^‚¦‚ç‚ê‚½ê‡A
-„¥ED:\Test.ext ‚Æ‚¢‚¤ƒtƒ@ƒCƒ‹‚ª‘¶İ‚·‚éê‡
-„ @drive = "D:"
-„ @dir   = "\"
-„ @fname = "Test"
-„ @ext   = ".ext"
-„¥ED:\Test.ext ‚Æ‚¢‚¤ƒfƒBƒŒƒNƒgƒŠ‚ª‘¶İ‚·‚éê‡
-„ @drive = "D:"
-„ @dir   = "\Test.ext\"
-„ @fname = ""
-„ @ext   = ""
-„¤ED:\Test.ext ‚Æ‚¢‚¤ƒtƒ@ƒCƒ‹EƒfƒBƒŒƒNƒgƒŠ‚ª‘¶İ‚µ‚È‚¢ê‡A
-@@„¥ED:ƒhƒ‰ƒCƒu‚Í—LŒø
-@@„ @drive = "D:"
-@@„ @dir   = "\"
-@@„ @fname = ""
-@@„ @ext   = ""
-@@„¤ED:ƒhƒ‰ƒCƒu‚Í–³Œø
-@@@@drive = ""
-@@@@dir   = ""
-@@@@fname = ""
-@@@@ext   = ""
+CommandLine ã«æ–‡å­—åˆ—ã¨ã—ã¦ D:\Test.ext ãŒä¸ãˆã‚‰ã‚ŒãŸå ´åˆã€
+â”œãƒ»D:\Test.ext ã¨ã„ã†ãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã™ã‚‹å ´åˆ
+â”‚ã€€drive = "D:"
+â”‚ã€€dir   = "\"
+â”‚ã€€fname = "Test"
+â”‚ã€€ext   = ".ext"
+â”œãƒ»D:\Test.ext ã¨ã„ã†ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãŒå­˜åœ¨ã™ã‚‹å ´åˆ
+â”‚ã€€drive = "D:"
+â”‚ã€€dir   = "\Test.ext\"
+â”‚ã€€fname = ""
+â”‚ã€€ext   = ""
+â””ãƒ»D:\Test.ext ã¨ã„ã†ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãŒå­˜åœ¨ã—ãªã„å ´åˆã€
+ã€€ã€€â”œãƒ»D:ãƒ‰ãƒ©ã‚¤ãƒ–ã¯æœ‰åŠ¹
+ã€€ã€€â”‚ã€€drive = "D:"
+ã€€ã€€â”‚ã€€dir   = "\"
+ã€€ã€€â”‚ã€€fname = ""
+ã€€ã€€â”‚ã€€ext   = ""
+ã€€ã€€â””ãƒ»D:ãƒ‰ãƒ©ã‚¤ãƒ–ã¯ç„¡åŠ¹
+ã€€ã€€ã€€ã€€drive = ""
+ã€€ã€€ã€€ã€€dir   = ""
+ã€€ã€€ã€€ã€€fname = ""
+ã€€ã€€ã€€ã€€ext   = ""
 )=========================================================================== */
 
-/* Shift_JIS ‘Î‰‚ÅŒŸõ‘ÎÛ•¶š‚ğ‚QŒÂw’è‚Å‚«‚é strrchr() ‚İ‚½‚¢‚È‚à‚ÌB
-/ w’è‚³‚ê‚½‚Q‚Â‚Ì•¶š‚Ì‚¤‚¿AŒ©‚Â‚©‚Á‚½•û(‚æ‚èŒã•û‚Ì•û)‚ÌˆÊ’u‚ğ•Ô‚·B
-/ # strrchr( char *s , char c ) ‚Æ‚ÍA•¶š—ñ s ’†‚ÌÅŒã”ö‚Ì c ‚ğ’T‚µo‚·ŠÖ”B
-/ # •¶š c ‚ªŒ©‚Â‚©‚Á‚½‚çA‚»‚ÌˆÊ’u‚ğ•Ô‚·B
-/ # •¶š c ‚ªŒ©‚Â‚©‚ç‚È‚¢ê‡‚Í NULL ‚ğ•Ô‚·B */
+/* Shift_JIS å¯¾å¿œã§æ¤œç´¢å¯¾è±¡æ–‡å­—ã‚’ï¼’å€‹æŒ‡å®šã§ãã‚‹ strrchr() ã¿ãŸã„ãªã‚‚ã®ã€‚
+/ æŒ‡å®šã•ã‚ŒãŸï¼’ã¤ã®æ–‡å­—ã®ã†ã¡ã€è¦‹ã¤ã‹ã£ãŸæ–¹(ã‚ˆã‚Šå¾Œæ–¹ã®æ–¹)ã®ä½ç½®ã‚’è¿”ã™ã€‚
+/ # strrchr( char *s , char c ) ã¨ã¯ã€æ–‡å­—åˆ— s ä¸­ã®æœ€å¾Œå°¾ã® c ã‚’æ¢ã—å‡ºã™é–¢æ•°ã€‚
+/ # æ–‡å­— c ãŒè¦‹ã¤ã‹ã£ãŸã‚‰ã€ãã®ä½ç½®ã‚’è¿”ã™ã€‚
+/ # æ–‡å­— c ãŒè¦‹ã¤ã‹ã‚‰ãªã„å ´åˆã¯ NULL ã‚’è¿”ã™ã€‚ */
 char *sjis_strrchr2( const char *pt , const char ch1 , const char ch2 ){
 	const char *pf = NULL;
-	while( *pt != '\0' ){	/* •¶š—ñ‚ÌI’[‚Ü‚Å’²‚×‚éB */
-		if( ( *pt == ch1 ) || ( *pt == ch2 ) )	pf = pt;	/* pf = ŒŸõ•¶š‚ÌˆÊ’u */
-		if( _IS_SJIS_1(*pt) )	pt++;	/* Shift_JIS ‚Ì1•¶š–Ú‚È‚çAŸ‚Ì1•¶š‚ğƒXƒLƒbƒv */
-		if( *pt != '\0' )		pt++;	/* Ÿ‚Ì•¶š‚Ö */
+	while( *pt != '\0' ){	/* æ–‡å­—åˆ—ã®çµ‚ç«¯ã¾ã§èª¿ã¹ã‚‹ã€‚ */
+		if( ( *pt == ch1 ) || ( *pt == ch2 ) )	pf = pt;	/* pf = æ¤œç´¢æ–‡å­—ã®ä½ç½® */
+		if( _IS_SJIS_1(*pt) )	pt++;	/* Shift_JIS ã®1æ–‡å­—ç›®ãªã‚‰ã€æ¬¡ã®1æ–‡å­—ã‚’ã‚¹ã‚­ãƒƒãƒ— */
+		if( *pt != '\0' )		pt++;	/* æ¬¡ã®æ–‡å­—ã¸ */
 	}
 	return	(char *)pf;
 }
 wchar_t* wcsrchr2( const wchar_t *pt , const wchar_t ch1 , const wchar_t ch2 ){
 	const wchar_t *pf = NULL;
-	while( *pt != L'\0' ){	/* •¶š—ñ‚ÌI’[‚Ü‚Å’²‚×‚éB */
-		if( ( *pt == ch1 ) || ( *pt == ch2 ) )	pf = pt;	/* pf = ŒŸõ•¶š‚ÌˆÊ’u */
-		if( *pt != '\0' )		pt++;	/* Ÿ‚Ì•¶š‚Ö */
+	while( *pt != L'\0' ){	/* æ–‡å­—åˆ—ã®çµ‚ç«¯ã¾ã§èª¿ã¹ã‚‹ã€‚ */
+		if( ( *pt == ch1 ) || ( *pt == ch2 ) )	pf = pt;	/* pf = æ¤œç´¢æ–‡å­—ã®ä½ç½® */
+		if( *pt != '\0' )		pt++;	/* æ¬¡ã®æ–‡å­—ã¸ */
 	}
 	return	(wchar_t *)pf;
 }
 
-#define		GetExistPath_NO_DriveLetter	0	/* ƒhƒ‰ƒCƒuƒŒƒ^[‚ª–³‚¢ */
-#define		GetExistPath_IV_Drive		1	/* ƒhƒ‰ƒCƒu‚ª–³Œø */
-#define		GetExistPath_AV_Drive		2	/* ƒhƒ‰ƒCƒu‚ª—LŒø */
+#define		GetExistPath_NO_DriveLetter	0	/* ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ãŒç„¡ã„ */
+#define		GetExistPath_IV_Drive		1	/* ãƒ‰ãƒ©ã‚¤ãƒ–ãŒç„¡åŠ¹ */
+#define		GetExistPath_AV_Drive		2	/* ãƒ‰ãƒ©ã‚¤ãƒ–ãŒæœ‰åŠ¹ */
 
 void	GetExistPath( char *po , const char *pi )
 {
 	char	*pw,*ps;
 	int		cnt;
 	char	drv[4] = "_:\\";
-	int		dl;		/* ƒhƒ‰ƒCƒu‚Ìó‘Ô */
+	int		dl;		/* ãƒ‰ãƒ©ã‚¤ãƒ–ã®çŠ¶æ…‹ */
 
-	/* pi ‚Ì“à—e‚ğ
-	/ E " ‚ğíœ‚µ‚Â‚Â
-	/ E / ‚ğ \ ‚É•ÏŠ·‚µ‚Â‚Â(Win32API ‚Å‚Í / ‚à \ ‚Æ“¯“™‚Éˆµ‚í‚ê‚é‚©‚ç)
-	/ EÅ‘å ( _MAX_PATH -1 ) •¶š‚Ü‚Å
-	/ po ‚ÉƒRƒs[‚·‚éB */
+	/* pi ã®å†…å®¹ã‚’
+	/ ãƒ» " ã‚’å‰Šé™¤ã—ã¤ã¤
+	/ ãƒ» / ã‚’ \ ã«å¤‰æ›ã—ã¤ã¤(Win32API ã§ã¯ / ã‚‚ \ ã¨åŒç­‰ã«æ‰±ã‚ã‚Œã‚‹ã‹ã‚‰)
+	/ ãƒ»æœ€å¤§ ( _MAX_PATH -1 ) æ–‡å­—ã¾ã§
+	/ po ã«ã‚³ãƒ”ãƒ¼ã™ã‚‹ã€‚ */
 	for( pw=po,cnt=0 ; ( *pi != '\0' ) && ( cnt < _MAX_PATH -1 ) ; pi++ ){
-		/* /," ‹¤‚É Shift_JIS ‚ÌŠ¿šƒR[ƒh’†‚É‚ÍŠÜ‚Ü‚ê‚È‚¢‚Ì‚Å Shift_JIS ”»’è‚Í•s—vB */
-		if( *pi == '\"' )	continue;		/*  " ‚È‚ç‰½‚à‚µ‚È‚¢BŸ‚Ì•¶š‚Ö */
-		if( *pi == '/' )	*pw++ = '\\';	/*  / ‚È‚ç \ ‚É•ÏŠ·‚µ‚ÄƒRƒs[    */
-		else				*pw++ = *pi;	/* ‚»‚Ì‘¼‚Ì•¶š‚Í‚»‚Ì‚Ü‚ÜƒRƒs[  */
-		cnt++;	/* ƒRƒs[‚µ‚½•¶š” ++ */
+		/* /," å…±ã« Shift_JIS ã®æ¼¢å­—ã‚³ãƒ¼ãƒ‰ä¸­ã«ã¯å«ã¾ã‚Œãªã„ã®ã§ Shift_JIS åˆ¤å®šã¯ä¸è¦ã€‚ */
+		if( *pi == '\"' )	continue;		/*  " ãªã‚‰ä½•ã‚‚ã—ãªã„ã€‚æ¬¡ã®æ–‡å­—ã¸ */
+		if( *pi == '/' )	*pw++ = '\\';	/*  / ãªã‚‰ \ ã«å¤‰æ›ã—ã¦ã‚³ãƒ”ãƒ¼    */
+		else				*pw++ = *pi;	/* ãã®ä»–ã®æ–‡å­—ã¯ãã®ã¾ã¾ã‚³ãƒ”ãƒ¼  */
+		cnt++;	/* ã‚³ãƒ”ãƒ¼ã—ãŸæ–‡å­—æ•° ++ */
 	}
-	*pw = '\0';		/* •¶š—ñI’[ */
+	*pw = '\0';		/* æ–‡å­—åˆ—çµ‚ç«¯ */
 
-	dl = GetExistPath_NO_DriveLetter;	/*uƒhƒ‰ƒCƒuƒŒƒ^[‚ª–³‚¢v‚É‚µ‚Ä‚¨‚­*/
+	dl = GetExistPath_NO_DriveLetter;	/*ã€Œãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ãŒç„¡ã„ã€ã«ã—ã¦ãŠã*/
 	if(
 		( *(po+1) == ':' )&&
 		( ACODE::IsAZ(*po) )
-	){	/* æ“ª‚Éƒhƒ‰ƒCƒuƒŒƒ^[‚ª‚ ‚éB‚»‚Ìƒhƒ‰ƒCƒu‚ª—LŒø‚©‚Ç‚¤‚©”»’è‚·‚é */
+	){	/* å…ˆé ­ã«ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ãŒã‚ã‚‹ã€‚ãã®ãƒ‰ãƒ©ã‚¤ãƒ–ãŒæœ‰åŠ¹ã‹ã©ã†ã‹åˆ¤å®šã™ã‚‹ */
 		drv[0] = *po;
-		if( access(drv,0) == 0 )	dl = GetExistPath_AV_Drive;		/* —LŒø */
-		else						dl = GetExistPath_IV_Drive;		/* –³Œø */
+		if( access(drv,0) == 0 )	dl = GetExistPath_AV_Drive;		/* æœ‰åŠ¹ */
+		else						dl = GetExistPath_IV_Drive;		/* ç„¡åŠ¹ */
 	}
 
-	if( dl == GetExistPath_IV_Drive ){	/* ƒhƒ‰ƒCƒu©‘Ì‚ª–³Œø */
-		/* ƒtƒƒbƒs[ƒfƒBƒXƒN’†‚Ìƒtƒ@ƒCƒ‹‚ªw’è‚³‚ê‚Ä‚¢‚ÄA
-		@ ‚»‚Ìƒhƒ‰ƒCƒu‚Éƒtƒƒbƒs[ƒfƒBƒXƒN‚ª“ü‚Á‚Ä‚¢‚È‚¢A‚Æ‚© */
-		*po = '\0';	/* •Ô’l•¶š—ñ = "";(‹ó•¶š—ñ) */
-		return;		/* ‚±‚êˆÈã‰½‚à‚µ‚È‚¢ */
+	if( dl == GetExistPath_IV_Drive ){	/* ãƒ‰ãƒ©ã‚¤ãƒ–è‡ªä½“ãŒç„¡åŠ¹ */
+		/* ãƒ•ãƒ­ãƒƒãƒ”ãƒ¼ãƒ‡ã‚£ã‚¹ã‚¯ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¦ã€
+		ã€€ ãã®ãƒ‰ãƒ©ã‚¤ãƒ–ã«ãƒ•ãƒ­ãƒƒãƒ”ãƒ¼ãƒ‡ã‚£ã‚¹ã‚¯ãŒå…¥ã£ã¦ã„ãªã„ã€ã¨ã‹ */
+		*po = '\0';	/* è¿”å€¤æ–‡å­—åˆ— = "";(ç©ºæ–‡å­—åˆ—) */
+		return;		/* ã“ã‚Œä»¥ä¸Šä½•ã‚‚ã—ãªã„ */
 	}
 
-	/* ps = ŒŸõŠJnˆÊ’u */
-	ps = po;	/* «•¶š—ñ‚Ìæ“ª‚ª \\ ‚È‚çA\ ŒŸõˆ—‚Ì‘ÎÛ‚©‚çŠO‚· */
+	/* ps = æ¤œç´¢é–‹å§‹ä½ç½® */
+	ps = po;	/* â†“æ–‡å­—åˆ—ã®å…ˆé ­ãŒ \\ ãªã‚‰ã€\ æ¤œç´¢å‡¦ç†ã®å¯¾è±¡ã‹ã‚‰å¤–ã™ */
 	if( ( *po == '\\' )&&( *(po+1) == '\\' ) )	ps +=2;
 
-	if( *ps == '\0' ){	/* ŒŸõ‘ÎÛ‚ª‹ó•¶š—ñ‚È‚ç */
-		*po = '\0';		/* •Ô’l•¶š—ñ = "";(‹ó•¶š—ñ) */
-		return;			/*‚±‚êˆÈã‰½‚à‚µ‚È‚¢ */
+	if( *ps == '\0' ){	/* æ¤œç´¢å¯¾è±¡ãŒç©ºæ–‡å­—åˆ—ãªã‚‰ */
+		*po = '\0';		/* è¿”å€¤æ–‡å­—åˆ— = "";(ç©ºæ–‡å­—åˆ—) */
+		return;			/*ã“ã‚Œä»¥ä¸Šä½•ã‚‚ã—ãªã„ */
 	}
 
 	for(;;){
-		if( access(po,0) == 0 )	break;	/* —LŒø‚ÈƒpƒX•¶š—ñ‚ªŒ©‚Â‚©‚Á‚½ */
-		/* «•¶š—ñÅŒã”ö‚Ì \ ‚Ü‚½‚Í ' ' ‚ğ’T‚µo‚µA‚»‚±‚ğ•¶š—ñI’[‚É‚·‚éB*/
+		if( access(po,0) == 0 )	break;	/* æœ‰åŠ¹ãªãƒ‘ã‚¹æ–‡å­—åˆ—ãŒè¦‹ã¤ã‹ã£ãŸ */
+		/* â†“æ–‡å­—åˆ—æœ€å¾Œå°¾ã® \ ã¾ãŸã¯ ' ' ã‚’æ¢ã—å‡ºã—ã€ãã“ã‚’æ–‡å­—åˆ—çµ‚ç«¯ã«ã™ã‚‹ã€‚*/
 
-		pw = sjis_strrchr2(ps,'\\',' ');	/* Å––”ö‚Ì \ ‚© ' ' ‚ğ’T‚·B */
-		if ( pw == NULL ){	/* •¶š—ñ’†‚É '\\' ‚à ' ' ‚à–³‚©‚Á‚½ */
-			/* —á‚¦‚Î "C:testdir" ‚Æ‚¢‚¤•¶š—ñ‚ª—ˆ‚½‚ÉA"C:testdir" ‚ªÀİ
-			@ ‚µ‚È‚­‚Æ‚à C:ƒhƒ‰ƒCƒu‚ª—LŒø‚È‚ç "C:" ‚Æ‚¢‚¤•¶š—ñ‚¾‚¯‚Å‚à•Ô‚µ
-			@ ‚½‚¢BˆÈ‰º«‚ÍA‚»‚Ì‚½‚ß‚Ìˆ—B */
+		pw = sjis_strrchr2(ps,'\\',' ');	/* æœ€æœ«å°¾ã® \ ã‹ ' ' ã‚’æ¢ã™ã€‚ */
+		if ( pw == NULL ){	/* æ–‡å­—åˆ—ä¸­ã« '\\' ã‚‚ ' ' ã‚‚ç„¡ã‹ã£ãŸ */
+			/* ä¾‹ãˆã° "C:testdir" ã¨ã„ã†æ–‡å­—åˆ—ãŒæ¥ãŸæ™‚ã«ã€"C:testdir" ãŒå®Ÿåœ¨
+			ã€€ ã—ãªãã¨ã‚‚ C:ãƒ‰ãƒ©ã‚¤ãƒ–ãŒæœ‰åŠ¹ãªã‚‰ "C:" ã¨ã„ã†æ–‡å­—åˆ—ã ã‘ã§ã‚‚è¿”ã—
+			ã€€ ãŸã„ã€‚ä»¥ä¸‹â†“ã¯ã€ãã®ãŸã‚ã®å‡¦ç†ã€‚ */
 			if( dl == GetExistPath_AV_Drive ){
-				/* æ“ª‚É—LŒø‚Èƒhƒ‰ƒCƒu‚Ìƒhƒ‰ƒCƒuƒŒƒ^[‚ª‚ ‚éB */
-				*(po+2) = '\0';		/* ƒhƒ‰ƒCƒuƒŒƒ^[•”‚Ì•¶š—ñ‚Ì‚İ•Ô‚· */
+				/* å…ˆé ­ã«æœ‰åŠ¹ãªãƒ‰ãƒ©ã‚¤ãƒ–ã®ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ãŒã‚ã‚‹ã€‚ */
+				*(po+2) = '\0';		/* ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼éƒ¨ã®æ–‡å­—åˆ—ã®ã¿è¿”ã™ */
 			}
-			else{	/* —LŒø‚ÈƒpƒX•”•ª‚ª‘S‚­Œ©‚Â‚©‚ç‚È‚©‚Á‚½ */
-				*po = '\0';	/* •Ô’l•¶š—ñ = "";(‹ó•¶š—ñ) */
+			else{	/* æœ‰åŠ¹ãªãƒ‘ã‚¹éƒ¨åˆ†ãŒå…¨ãè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸ */
+				*po = '\0';	/* è¿”å€¤æ–‡å­—åˆ— = "";(ç©ºæ–‡å­—åˆ—) */
 			}
-			break;		/* ƒ‹[ƒv‚ğ”²‚¯‚é */
+			break;		/* ãƒ«ãƒ¼ãƒ—ã‚’æŠœã‘ã‚‹ */
 		}
-		/* «ƒ‹[ƒgƒfƒBƒŒƒNƒgƒŠ‚ğˆø‚Á‚©‚¯‚é‚½‚ß‚Ìˆ— */
-		if( ( *pw == '\\' )&&( *(pw-1) == ':' ) ){	/* C:\ ‚Æ‚©‚Ì \ ‚Á‚Û‚¢ */
-			* (pw+1) = '\0';		/* \ ‚ÌŒã‚ë‚ÌˆÊ’u‚ğ•¶š—ñ‚ÌI’[‚É‚·‚éB */
-			if( access(po,0) == 0 )	break;	/* —LŒø‚ÈƒpƒX•¶š—ñ‚ªŒ©‚Â‚©‚Á‚½ */
+		/* â†“ãƒ«ãƒ¼ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’å¼•ã£ã‹ã‘ã‚‹ãŸã‚ã®å‡¦ç† */
+		if( ( *pw == '\\' )&&( *(pw-1) == ':' ) ){	/* C:\ ã¨ã‹ã® \ ã£ã½ã„ */
+			* (pw+1) = '\0';		/* \ ã®å¾Œã‚ã®ä½ç½®ã‚’æ–‡å­—åˆ—ã®çµ‚ç«¯ã«ã™ã‚‹ã€‚ */
+			if( access(po,0) == 0 )	break;	/* æœ‰åŠ¹ãªãƒ‘ã‚¹æ–‡å­—åˆ—ãŒè¦‹ã¤ã‹ã£ãŸ */
 		}
-		*pw = '\0';		/* \ ‚© ' ' ‚ÌˆÊ’u‚ğ•¶š—ñ‚ÌI’[‚É‚·‚éB */
-		/* «––”ö‚ªƒXƒy[ƒX‚È‚çAƒXƒy[ƒX‚ğ‘S‚Äíœ‚·‚é */
+		*pw = '\0';		/* \ ã‹ ' ' ã®ä½ç½®ã‚’æ–‡å­—åˆ—ã®çµ‚ç«¯ã«ã™ã‚‹ã€‚ */
+		/* â†“æœ«å°¾ãŒã‚¹ãƒšãƒ¼ã‚¹ãªã‚‰ã€ã‚¹ãƒšãƒ¼ã‚¹ã‚’å…¨ã¦å‰Šé™¤ã™ã‚‹ */
 		while( ( pw != ps ) && ( *(pw-1) == ' ' ) )	* --pw = '\0';
 	}
 
@@ -875,70 +875,70 @@ void GetExistPathW( wchar_t *po , const wchar_t *pi )
 	wchar_t	*pw,*ps;
 	int		cnt;
 	wchar_t	drv[4] = L"_:\\";
-	int		dl;		/* ƒhƒ‰ƒCƒu‚Ìó‘Ô */
+	int		dl;		/* ãƒ‰ãƒ©ã‚¤ãƒ–ã®çŠ¶æ…‹ */
 
-	/* pi ‚Ì“à—e‚ğ
-	/ E " ‚ğíœ‚µ‚Â‚Â
-	/ E / ‚ğ \ ‚É•ÏŠ·‚µ‚Â‚Â(Win32API ‚Å‚Í / ‚à \ ‚Æ“¯“™‚Éˆµ‚í‚ê‚é‚©‚ç)
-	/ EÅ‘å ( _MAX_PATH-1 ) •¶š‚Ü‚Å
-	/ po ‚ÉƒRƒs[‚·‚éB */
+	/* pi ã®å†…å®¹ã‚’
+	/ ãƒ» " ã‚’å‰Šé™¤ã—ã¤ã¤
+	/ ãƒ» / ã‚’ \ ã«å¤‰æ›ã—ã¤ã¤(Win32API ã§ã¯ / ã‚‚ \ ã¨åŒç­‰ã«æ‰±ã‚ã‚Œã‚‹ã‹ã‚‰)
+	/ ãƒ»æœ€å¤§ ( _MAX_PATH-1 ) æ–‡å­—ã¾ã§
+	/ po ã«ã‚³ãƒ”ãƒ¼ã™ã‚‹ã€‚ */
 	for( pw=po,cnt=0 ; ( *pi != L'\0' ) && ( cnt < _MAX_PATH-1 ) ; pi++ ){
-		/* /," ‹¤‚É Shift_JIS ‚ÌŠ¿šƒR[ƒh’†‚É‚ÍŠÜ‚Ü‚ê‚È‚¢‚Ì‚Å Shift_JIS ”»’è‚Í•s—vB */
-		if( *pi == L'\"' )	continue;		/*  " ‚È‚ç‰½‚à‚µ‚È‚¢BŸ‚Ì•¶š‚Ö */
-		if( *pi == L'/' )	*pw++ = L'\\';	/*  / ‚È‚ç \ ‚É•ÏŠ·‚µ‚ÄƒRƒs[    */
-		else				*pw++ = *pi;	/* ‚»‚Ì‘¼‚Ì•¶š‚Í‚»‚Ì‚Ü‚ÜƒRƒs[  */
-		cnt++;	/* ƒRƒs[‚µ‚½•¶š” ++ */
+		/* /," å…±ã« Shift_JIS ã®æ¼¢å­—ã‚³ãƒ¼ãƒ‰ä¸­ã«ã¯å«ã¾ã‚Œãªã„ã®ã§ Shift_JIS åˆ¤å®šã¯ä¸è¦ã€‚ */
+		if( *pi == L'\"' )	continue;		/*  " ãªã‚‰ä½•ã‚‚ã—ãªã„ã€‚æ¬¡ã®æ–‡å­—ã¸ */
+		if( *pi == L'/' )	*pw++ = L'\\';	/*  / ãªã‚‰ \ ã«å¤‰æ›ã—ã¦ã‚³ãƒ”ãƒ¼    */
+		else				*pw++ = *pi;	/* ãã®ä»–ã®æ–‡å­—ã¯ãã®ã¾ã¾ã‚³ãƒ”ãƒ¼  */
+		cnt++;	/* ã‚³ãƒ”ãƒ¼ã—ãŸæ–‡å­—æ•° ++ */
 	}
-	*pw = L'\0';		/* •¶š—ñI’[ */
+	*pw = L'\0';		/* æ–‡å­—åˆ—çµ‚ç«¯ */
 
-	dl = GetExistPath_NO_DriveLetter;	/*uƒhƒ‰ƒCƒuƒŒƒ^[‚ª–³‚¢v‚É‚µ‚Ä‚¨‚­*/
-	if( *(po+1)==L':' && WCODE::IsAZ(*po) ){	/* æ“ª‚Éƒhƒ‰ƒCƒuƒŒƒ^[‚ª‚ ‚éB‚»‚Ìƒhƒ‰ƒCƒu‚ª—LŒø‚©‚Ç‚¤‚©”»’è‚·‚é */
+	dl = GetExistPath_NO_DriveLetter;	/*ã€Œãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ãŒç„¡ã„ã€ã«ã—ã¦ãŠã*/
+	if( *(po+1)==L':' && WCODE::IsAZ(*po) ){	/* å…ˆé ­ã«ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ãŒã‚ã‚‹ã€‚ãã®ãƒ‰ãƒ©ã‚¤ãƒ–ãŒæœ‰åŠ¹ã‹ã©ã†ã‹åˆ¤å®šã™ã‚‹ */
 		drv[0] = *po;
-		if( _waccess(drv,0) == 0 )	dl = GetExistPath_AV_Drive;		/* —LŒø */
-		else						dl = GetExistPath_IV_Drive;		/* –³Œø */
+		if( _waccess(drv,0) == 0 )	dl = GetExistPath_AV_Drive;		/* æœ‰åŠ¹ */
+		else						dl = GetExistPath_IV_Drive;		/* ç„¡åŠ¹ */
 	}
 
-	if( dl == GetExistPath_IV_Drive ){	/* ƒhƒ‰ƒCƒu©‘Ì‚ª–³Œø */
-		/* ƒtƒƒbƒs[ƒfƒBƒXƒN’†‚Ìƒtƒ@ƒCƒ‹‚ªw’è‚³‚ê‚Ä‚¢‚ÄA
-		@ ‚»‚Ìƒhƒ‰ƒCƒu‚Éƒtƒƒbƒs[ƒfƒBƒXƒN‚ª“ü‚Á‚Ä‚¢‚È‚¢A‚Æ‚© */
-		*po = L'\0';	/* •Ô’l•¶š—ñ = "";(‹ó•¶š—ñ) */
-		return;		/* ‚±‚êˆÈã‰½‚à‚µ‚È‚¢ */
+	if( dl == GetExistPath_IV_Drive ){	/* ãƒ‰ãƒ©ã‚¤ãƒ–è‡ªä½“ãŒç„¡åŠ¹ */
+		/* ãƒ•ãƒ­ãƒƒãƒ”ãƒ¼ãƒ‡ã‚£ã‚¹ã‚¯ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒæŒ‡å®šã•ã‚Œã¦ã„ã¦ã€
+		ã€€ ãã®ãƒ‰ãƒ©ã‚¤ãƒ–ã«ãƒ•ãƒ­ãƒƒãƒ”ãƒ¼ãƒ‡ã‚£ã‚¹ã‚¯ãŒå…¥ã£ã¦ã„ãªã„ã€ã¨ã‹ */
+		*po = L'\0';	/* è¿”å€¤æ–‡å­—åˆ— = "";(ç©ºæ–‡å­—åˆ—) */
+		return;		/* ã“ã‚Œä»¥ä¸Šä½•ã‚‚ã—ãªã„ */
 	}
 
-	/* ps = ŒŸõŠJnˆÊ’u */
-	ps = po;	/* «•¶š—ñ‚Ìæ“ª‚ª \\ ‚È‚çA\ ŒŸõˆ—‚Ì‘ÎÛ‚©‚çŠO‚· */
+	/* ps = æ¤œç´¢é–‹å§‹ä½ç½® */
+	ps = po;	/* â†“æ–‡å­—åˆ—ã®å…ˆé ­ãŒ \\ ãªã‚‰ã€\ æ¤œç´¢å‡¦ç†ã®å¯¾è±¡ã‹ã‚‰å¤–ã™ */
 	if( ( *po == L'\\' )&&( *(po+1) == L'\\' ) )	ps +=2;
 
-	if( *ps == L'\0' ){	/* ŒŸõ‘ÎÛ‚ª‹ó•¶š—ñ‚È‚ç */
-		*po = L'\0';		/* •Ô’l•¶š—ñ = "";(‹ó•¶š—ñ) */
-		return;			/*‚±‚êˆÈã‰½‚à‚µ‚È‚¢ */
+	if( *ps == L'\0' ){	/* æ¤œç´¢å¯¾è±¡ãŒç©ºæ–‡å­—åˆ—ãªã‚‰ */
+		*po = L'\0';		/* è¿”å€¤æ–‡å­—åˆ— = "";(ç©ºæ–‡å­—åˆ—) */
+		return;			/*ã“ã‚Œä»¥ä¸Šä½•ã‚‚ã—ãªã„ */
 	}
 
 	for(;;){
-		if( _waccess(po,0) == 0 )	break;	/* —LŒø‚ÈƒpƒX•¶š—ñ‚ªŒ©‚Â‚©‚Á‚½ */
-		/* «•¶š—ñÅŒã”ö‚Ì \ ‚Ü‚½‚Í ' ' ‚ğ’T‚µo‚µA‚»‚±‚ğ•¶š—ñI’[‚É‚·‚éB*/
+		if( _waccess(po,0) == 0 )	break;	/* æœ‰åŠ¹ãªãƒ‘ã‚¹æ–‡å­—åˆ—ãŒè¦‹ã¤ã‹ã£ãŸ */
+		/* â†“æ–‡å­—åˆ—æœ€å¾Œå°¾ã® \ ã¾ãŸã¯ ' ' ã‚’æ¢ã—å‡ºã—ã€ãã“ã‚’æ–‡å­—åˆ—çµ‚ç«¯ã«ã™ã‚‹ã€‚*/
 
-		pw = wcsrchr2(ps,'\\',' ');	/* Å––”ö‚Ì \ ‚© ' ' ‚ğ’T‚·B */
-		if ( pw == NULL ){	/* •¶š—ñ’†‚É '\\' ‚à ' ' ‚à–³‚©‚Á‚½ */
-			/* —á‚¦‚Î "C:testdir" ‚Æ‚¢‚¤•¶š—ñ‚ª—ˆ‚½‚ÉA"C:testdir" ‚ªÀİ
-			@ ‚µ‚È‚­‚Æ‚à C:ƒhƒ‰ƒCƒu‚ª—LŒø‚È‚ç "C:" ‚Æ‚¢‚¤•¶š—ñ‚¾‚¯‚Å‚à•Ô‚µ
-			@ ‚½‚¢BˆÈ‰º«‚ÍA‚»‚Ì‚½‚ß‚Ìˆ—B */
+		pw = wcsrchr2(ps,'\\',' ');	/* æœ€æœ«å°¾ã® \ ã‹ ' ' ã‚’æ¢ã™ã€‚ */
+		if ( pw == NULL ){	/* æ–‡å­—åˆ—ä¸­ã« '\\' ã‚‚ ' ' ã‚‚ç„¡ã‹ã£ãŸ */
+			/* ä¾‹ãˆã° "C:testdir" ã¨ã„ã†æ–‡å­—åˆ—ãŒæ¥ãŸæ™‚ã«ã€"C:testdir" ãŒå®Ÿåœ¨
+			ã€€ ã—ãªãã¨ã‚‚ C:ãƒ‰ãƒ©ã‚¤ãƒ–ãŒæœ‰åŠ¹ãªã‚‰ "C:" ã¨ã„ã†æ–‡å­—åˆ—ã ã‘ã§ã‚‚è¿”ã—
+			ã€€ ãŸã„ã€‚ä»¥ä¸‹â†“ã¯ã€ãã®ãŸã‚ã®å‡¦ç†ã€‚ */
 			if( dl == GetExistPath_AV_Drive ){
-				/* æ“ª‚É—LŒø‚Èƒhƒ‰ƒCƒu‚Ìƒhƒ‰ƒCƒuƒŒƒ^[‚ª‚ ‚éB */
-				*(po+2) = L'\0';		/* ƒhƒ‰ƒCƒuƒŒƒ^[•”‚Ì•¶š—ñ‚Ì‚İ•Ô‚· */
+				/* å…ˆé ­ã«æœ‰åŠ¹ãªãƒ‰ãƒ©ã‚¤ãƒ–ã®ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ãŒã‚ã‚‹ã€‚ */
+				*(po+2) = L'\0';		/* ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼éƒ¨ã®æ–‡å­—åˆ—ã®ã¿è¿”ã™ */
 			}
-			else{	/* —LŒø‚ÈƒpƒX•”•ª‚ª‘S‚­Œ©‚Â‚©‚ç‚È‚©‚Á‚½ */
-				*po = L'\0';	/* •Ô’l•¶š—ñ = "";(‹ó•¶š—ñ) */
+			else{	/* æœ‰åŠ¹ãªãƒ‘ã‚¹éƒ¨åˆ†ãŒå…¨ãè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸ */
+				*po = L'\0';	/* è¿”å€¤æ–‡å­—åˆ— = "";(ç©ºæ–‡å­—åˆ—) */
 			}
-			break;		/* ƒ‹[ƒv‚ğ”²‚¯‚é */
+			break;		/* ãƒ«ãƒ¼ãƒ—ã‚’æŠœã‘ã‚‹ */
 		}
-		/* «ƒ‹[ƒgƒfƒBƒŒƒNƒgƒŠ‚ğˆø‚Á‚©‚¯‚é‚½‚ß‚Ìˆ— */
-		if( ( *pw == L'\\' )&&( *(pw-1) == L':' ) ){	/* C:\ ‚Æ‚©‚Ì \ ‚Á‚Û‚¢ */
-			* (pw+1) = L'\0';		/* \ ‚ÌŒã‚ë‚ÌˆÊ’u‚ğ•¶š—ñ‚ÌI’[‚É‚·‚éB */
-			if( _waccess(po,0) == 0 )	break;	/* —LŒø‚ÈƒpƒX•¶š—ñ‚ªŒ©‚Â‚©‚Á‚½ */
+		/* â†“ãƒ«ãƒ¼ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’å¼•ã£ã‹ã‘ã‚‹ãŸã‚ã®å‡¦ç† */
+		if( ( *pw == L'\\' )&&( *(pw-1) == L':' ) ){	/* C:\ ã¨ã‹ã® \ ã£ã½ã„ */
+			* (pw+1) = L'\0';		/* \ ã®å¾Œã‚ã®ä½ç½®ã‚’æ–‡å­—åˆ—ã®çµ‚ç«¯ã«ã™ã‚‹ã€‚ */
+			if( _waccess(po,0) == 0 )	break;	/* æœ‰åŠ¹ãªãƒ‘ã‚¹æ–‡å­—åˆ—ãŒè¦‹ã¤ã‹ã£ãŸ */
 		}
-		*pw = L'\0';		/* \ ‚© ' ' ‚ÌˆÊ’u‚ğ•¶š—ñ‚ÌI’[‚É‚·‚éB */
-		/* «––”ö‚ªƒXƒy[ƒX‚È‚çAƒXƒy[ƒX‚ğ‘S‚Äíœ‚·‚é */
+		*pw = L'\0';		/* \ ã‹ ' ' ã®ä½ç½®ã‚’æ–‡å­—åˆ—ã®çµ‚ç«¯ã«ã™ã‚‹ã€‚ */
+		/* â†“æœ«å°¾ãŒã‚¹ãƒšãƒ¼ã‚¹ãªã‚‰ã€ã‚¹ãƒšãƒ¼ã‚¹ã‚’å…¨ã¦å‰Šé™¤ã™ã‚‹ */
 		while( ( pw != ps ) && ( *(pw-1) == L' ' ) )	* --pw = L'\0';
 	}
 
@@ -946,12 +946,12 @@ void GetExistPathW( wchar_t *po , const wchar_t *pi )
 }
 
 #ifndef _UNICODE
-/* —^‚¦‚ç‚ê‚½ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“•¶š—ñ‚Ìæ“ª•”•ª‚©‚çÀİ‚·‚éƒtƒ@ƒCƒ‹EƒfƒBƒŒƒNƒgƒŠ
-@ ‚ÌƒpƒX•¶š—ñ‚ğ’Šo‚µA‚»‚ÌƒpƒX‚ğ•ª‰ğ‚µ‚Ä drv dir fnm ext ‚É‘‚«‚ŞB
-@ æ“ª•”•ª‚É—LŒø‚ÈƒpƒX–¼‚ª‘¶İ‚µ‚È‚¢ê‡A‘S‚Ä‚É‹ó•¶š—ñ‚ª•Ô‚éB */
+/* ä¸ãˆã‚‰ã‚ŒãŸã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³æ–‡å­—åˆ—ã®å…ˆé ­éƒ¨åˆ†ã‹ã‚‰å®Ÿåœ¨ã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª
+ã€€ ã®ãƒ‘ã‚¹æ–‡å­—åˆ—ã‚’æŠ½å‡ºã—ã€ãã®ãƒ‘ã‚¹ã‚’åˆ†è§£ã—ã¦ drv dir fnm ext ã«æ›¸ãè¾¼ã‚€ã€‚
+ã€€ å…ˆé ­éƒ¨åˆ†ã«æœ‰åŠ¹ãªãƒ‘ã‚¹åãŒå­˜åœ¨ã—ãªã„å ´åˆã€å…¨ã¦ã«ç©ºæ–‡å­—åˆ—ãŒè¿”ã‚‹ã€‚ */
 void	my_splitpath ( const char *comln , char *drv,char *dir,char *fnm,char *ext )
 {
-	char	ppp[_MAX_PATH];		/* ƒpƒXŠi”[iì‹Æ—pj */
+	char	ppp[_MAX_PATH];		/* ãƒ‘ã‚¹æ ¼ç´ï¼ˆä½œæ¥­ç”¨ï¼‰ */
 	char	*pd;
 	char	*pf;
 	char	*pe;
@@ -965,62 +965,62 @@ void	my_splitpath ( const char *comln , char *drv,char *dir,char *fnm,char *ext 
 	if( ext != NULL )	*ext = '\0';
 	if( *comln == '\0' )	return;
 
-	/* ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“æ“ª•”•ª‚ÌÀİ‚·‚éƒpƒX–¼‚ğ ppp ‚É‘‚«o‚·B */
+	/* ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³å…ˆé ­éƒ¨åˆ†ã®å®Ÿåœ¨ã™ã‚‹ãƒ‘ã‚¹åã‚’ ppp ã«æ›¸ãå‡ºã™ã€‚ */
 	GetExistPath( ppp , comln );
 
-	if( *ppp != '\0' ) {	/* ƒtƒ@ƒCƒ‹EƒfƒBƒŒƒNƒgƒŠ‚ª‘¶İ‚·‚éê‡ */
-		/* æ“ª•¶š‚ªƒhƒ‰ƒCƒuƒŒƒ^[‚©‚Ç‚¤‚©”»’è‚µA
-		@ pd = ƒfƒBƒŒƒNƒgƒŠ–¼‚Ìæ“ªˆÊ’u‚Éİ’è‚·‚éB */
+	if( *ppp != '\0' ) {	/* ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãŒå­˜åœ¨ã™ã‚‹å ´åˆ */
+		/* å…ˆé ­æ–‡å­—ãŒãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ã‹ã©ã†ã‹åˆ¤å®šã—ã€
+		ã€€ pd = ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®å…ˆé ­ä½ç½®ã«è¨­å®šã™ã‚‹ã€‚ */
 		pd = ppp;
 		if(
 			( *(pd+1)==':' )&&
 			( ACODE::IsAZ(*pd) )
-		){	/* æ“ª‚Éƒhƒ‰ƒCƒuƒŒƒ^[‚ª‚ ‚éB */
-			pd += 2;	/* pd = ƒhƒ‰ƒCƒuƒŒƒ^[•”‚ÌŒã‚ë         */
-		}				/*      ( = ƒfƒBƒŒƒNƒgƒŠ–¼‚Ìæ“ªˆÊ’u ) */
-		/* ‚±‚±‚Ü‚Å‚ÅApd = ƒfƒBƒŒƒNƒgƒŠ–¼‚Ìæ“ªˆÊ’u */
+		){	/* å…ˆé ­ã«ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ãŒã‚ã‚‹ã€‚ */
+			pd += 2;	/* pd = ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼éƒ¨ã®å¾Œã‚         */
+		}				/*      ( = ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®å…ˆé ­ä½ç½® ) */
+		/* ã“ã“ã¾ã§ã§ã€pd = ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®å…ˆé ­ä½ç½® */
 
 		attr =  GetFileAttributesA(ppp);
 		a_dir = ( attr & FILE_ATTRIBUTE_DIRECTORY ) ?  1 : 0;
-		if( ! a_dir ){	/* Œ©‚Â‚¯‚½•¨‚ªƒtƒ@ƒCƒ‹‚¾‚Á‚½ê‡B */
-			pf = sjis_strrchr2(ppp,'\\','\\');	/* Å––”ö‚Ì \ ‚ğ’T‚·B */
-			if(pf != NULL)	pf++;		/* Œ©‚Â‚©‚Á‚½¨  pf=\‚ÌŸ‚Ì•¶š‚ÌˆÊ’u*/
-			else			pf = pd;	/* Œ©‚Â‚©‚ç‚È‚¢¨pf=ƒpƒX–¼‚Ìæ“ªˆÊ’u */
-			/* ‚±‚±‚Ü‚Å‚Å pf = ƒtƒ@ƒCƒ‹–¼‚Ìæ“ªˆÊ’u */
-			pe = sjis_strrchr2(pf,'.','.');		/* Å––”ö‚Ì '.' ‚ğ’T‚·B */
-			if( pe != NULL ){					/* Œ©‚Â‚©‚Á‚½(pe = '.'‚ÌˆÊ’u)*/
-				if( ext != NULL ){	/* Šg’£q‚ğ•Ô’l‚Æ‚µ‚Ä‘‚«‚ŞB */
+		if( ! a_dir ){	/* è¦‹ã¤ã‘ãŸç‰©ãŒãƒ•ã‚¡ã‚¤ãƒ«ã ã£ãŸå ´åˆã€‚ */
+			pf = sjis_strrchr2(ppp,'\\','\\');	/* æœ€æœ«å°¾ã® \ ã‚’æ¢ã™ã€‚ */
+			if(pf != NULL)	pf++;		/* è¦‹ã¤ã‹ã£ãŸâ†’  pf=\ã®æ¬¡ã®æ–‡å­—ã®ä½ç½®*/
+			else			pf = pd;	/* è¦‹ã¤ã‹ã‚‰ãªã„â†’pf=ãƒ‘ã‚¹åã®å…ˆé ­ä½ç½® */
+			/* ã“ã“ã¾ã§ã§ pf = ãƒ•ã‚¡ã‚¤ãƒ«åã®å…ˆé ­ä½ç½® */
+			pe = sjis_strrchr2(pf,'.','.');		/* æœ€æœ«å°¾ã® '.' ã‚’æ¢ã™ã€‚ */
+			if( pe != NULL ){					/* è¦‹ã¤ã‹ã£ãŸ(pe = '.'ã®ä½ç½®)*/
+				if( ext != NULL ){	/* æ‹¡å¼µå­ã‚’è¿”å€¤ã¨ã—ã¦æ›¸ãè¾¼ã‚€ã€‚ */
 					strncpy(ext,pe,_MAX_EXT -1);
 					ext[_MAX_EXT -1] = '\0';
 				}
-				*pe = '\0';	/* ‹æØ‚èˆÊ’u‚ğ•¶š—ñI’[‚É‚·‚éBpe = Šg’£q–¼‚Ìæ“ªˆÊ’uB */
+				*pe = '\0';	/* åŒºåˆ‡ã‚Šä½ç½®ã‚’æ–‡å­—åˆ—çµ‚ç«¯ã«ã™ã‚‹ã€‚pe = æ‹¡å¼µå­åã®å…ˆé ­ä½ç½®ã€‚ */
 			}
-			if( fnm != NULL ){	/* ƒtƒ@ƒCƒ‹–¼‚ğ•Ô’l‚Æ‚µ‚Ä‘‚«‚ŞB */
+			if( fnm != NULL ){	/* ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¿”å€¤ã¨ã—ã¦æ›¸ãè¾¼ã‚€ã€‚ */
 				strncpy(fnm,pf,_MAX_FNAME -1);
 				fnm[_MAX_FNAME -1] = '\0';
 			}
-			*pf = '\0';	/* ƒtƒ@ƒCƒ‹–¼‚Ìæ“ªˆÊ’u‚ğ•¶š—ñI’[‚É‚·‚éB */
+			*pf = '\0';	/* ãƒ•ã‚¡ã‚¤ãƒ«åã®å…ˆé ­ä½ç½®ã‚’æ–‡å­—åˆ—çµ‚ç«¯ã«ã™ã‚‹ã€‚ */
 		}
-		/* ‚±‚±‚Ü‚Å‚Å•¶š—ñ ppp ‚Íƒhƒ‰ƒCƒuƒŒƒ^[{ƒfƒBƒŒƒNƒgƒŠ–¼‚Ì‚İ‚É‚È‚Á‚Ä‚¢‚é */
+		/* ã“ã“ã¾ã§ã§æ–‡å­—åˆ— ppp ã¯ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ï¼‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®ã¿ã«ãªã£ã¦ã„ã‚‹ */
 		if( dir != NULL ){
-			/* ƒfƒBƒŒƒNƒgƒŠ–¼‚ÌÅŒã‚Ì•¶š‚ª \ ‚Å‚Í‚È‚¢ê‡A\ ‚É‚·‚éB */
+			/* ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®æœ€å¾Œã®æ–‡å­—ãŒ \ ã§ã¯ãªã„å ´åˆã€\ ã«ã™ã‚‹ã€‚ */
 
-			/* «ÅŒã‚Ì•¶š‚ğ ch ‚É“¾‚éB(ƒfƒBƒŒƒNƒgƒŠ•¶š—ñ‚ª‹ó‚Ìê‡ ch='\\' ‚Æ‚È‚é) */
+			/* â†“æœ€å¾Œã®æ–‡å­—ã‚’ ch ã«å¾—ã‚‹ã€‚(ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªæ–‡å­—åˆ—ãŒç©ºã®å ´åˆ ch='\\' ã¨ãªã‚‹) */
 			for( ch = '\\' , pf = pd ; *pf != '\0' ; pf++ ){
 				ch = *pf;
-				if( _IS_SJIS_1(*pf) )	pf++;	/* Shift_JIS ‚Ì1•¶š–Ú‚È‚çŸ‚Ì1•¶š‚ğƒXƒLƒbƒv */
+				if( _IS_SJIS_1(*pf) )	pf++;	/* Shift_JIS ã®1æ–‡å­—ç›®ãªã‚‰æ¬¡ã®1æ–‡å­—ã‚’ã‚¹ã‚­ãƒƒãƒ— */
 			}
-			/* •¶š—ñ‚ª‹ó‚Å‚È‚­A‚©‚ÂAÅŒã‚Ì•¶š‚ª \ ‚Å‚È‚©‚Á‚½‚È‚ç‚Î \ ‚ğ’Ç‰ÁB */
+			/* æ–‡å­—åˆ—ãŒç©ºã§ãªãã€ã‹ã¤ã€æœ€å¾Œã®æ–‡å­—ãŒ \ ã§ãªã‹ã£ãŸãªã‚‰ã° \ ã‚’è¿½åŠ ã€‚ */
 			if( ( ch != '\\' ) && ( strlen(ppp) < _MAX_PATH -1 ) ){
 				*pf++ = '\\';	*pf = '\0';
 			}
 
-			/* ƒfƒBƒŒƒNƒgƒŠ–¼‚ğ•Ô’l‚Æ‚µ‚Ä‘‚«‚ŞB */
+			/* ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã‚’è¿”å€¤ã¨ã—ã¦æ›¸ãè¾¼ã‚€ã€‚ */
 			strncpy(dir,pd,_MAX_DIR -1);
 			dir[_MAX_DIR -1] = '\0';
 		}
-		*pd = '\0';		/* ƒfƒBƒŒƒNƒgƒŠ–¼‚Ìæ“ªˆÊ’u‚ğ•¶š—ñI’[‚É‚·‚éB */
-		if( drv != NULL ){	/* ƒhƒ‰ƒCƒuƒŒƒ^[‚ğ•Ô’l‚Æ‚µ‚Ä‘‚«‚ŞB */
+		*pd = '\0';		/* ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®å…ˆé ­ä½ç½®ã‚’æ–‡å­—åˆ—çµ‚ç«¯ã«ã™ã‚‹ã€‚ */
+		if( drv != NULL ){	/* ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ã‚’è¿”å€¤ã¨ã—ã¦æ›¸ãè¾¼ã‚€ã€‚ */
 			strncpy(drv,ppp,_MAX_DRIVE -1);
 			drv[_MAX_DRIVE -1] = '\0';
 		}
@@ -1030,9 +1030,9 @@ void	my_splitpath ( const char *comln , char *drv,char *dir,char *fnm,char *ext 
 
 #else
 
-/* —^‚¦‚ç‚ê‚½ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“•¶š—ñ‚Ìæ“ª•”•ª‚©‚çÀİ‚·‚éƒtƒ@ƒCƒ‹EƒfƒBƒŒƒNƒgƒŠ
-@ ‚ÌƒpƒX•¶š—ñ‚ğ’Šo‚µA‚»‚ÌƒpƒX‚ğ•ª‰ğ‚µ‚Ä drv dir fnm ext ‚É‘‚«‚ŞB
-@ æ“ª•”•ª‚É—LŒø‚ÈƒpƒX–¼‚ª‘¶İ‚µ‚È‚¢ê‡A‘S‚Ä‚É‹ó•¶š—ñ‚ª•Ô‚éB */
+/* ä¸ãˆã‚‰ã‚ŒãŸã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³æ–‡å­—åˆ—ã®å…ˆé ­éƒ¨åˆ†ã‹ã‚‰å®Ÿåœ¨ã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª
+ã€€ ã®ãƒ‘ã‚¹æ–‡å­—åˆ—ã‚’æŠ½å‡ºã—ã€ãã®ãƒ‘ã‚¹ã‚’åˆ†è§£ã—ã¦ drv dir fnm ext ã«æ›¸ãè¾¼ã‚€ã€‚
+ã€€ å…ˆé ­éƒ¨åˆ†ã«æœ‰åŠ¹ãªãƒ‘ã‚¹åãŒå­˜åœ¨ã—ãªã„å ´åˆã€å…¨ã¦ã«ç©ºæ–‡å­—åˆ—ãŒè¿”ã‚‹ã€‚ */
 void my_splitpath_w (
 	const wchar_t *comln,
 	wchar_t *drv,
@@ -1041,7 +1041,7 @@ void my_splitpath_w (
 	wchar_t *ext
 )
 {
-	wchar_t	ppp[_MAX_PATH];		/* ƒpƒXŠi”[iì‹Æ—pj */
+	wchar_t	ppp[_MAX_PATH];		/* ãƒ‘ã‚¹æ ¼ç´ï¼ˆä½œæ¥­ç”¨ï¼‰ */
 	wchar_t	*pd;
 	wchar_t	*pf;
 	wchar_t	*pe;
@@ -1055,59 +1055,59 @@ void my_splitpath_w (
 	if( ext != NULL )	*ext = L'\0';
 	if( *comln == L'\0' )	return;
 
-	/* ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“æ“ª•”•ª‚ÌÀİ‚·‚éƒpƒX–¼‚ğ ppp ‚É‘‚«o‚·B */
+	/* ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³å…ˆé ­éƒ¨åˆ†ã®å®Ÿåœ¨ã™ã‚‹ãƒ‘ã‚¹åã‚’ ppp ã«æ›¸ãå‡ºã™ã€‚ */
 	GetExistPathW( ppp , comln );
 
-	if( *ppp != L'\0' ) {	/* ƒtƒ@ƒCƒ‹EƒfƒBƒŒƒNƒgƒŠ‚ª‘¶İ‚·‚éê‡ */
-		/* æ“ª•¶š‚ªƒhƒ‰ƒCƒuƒŒƒ^[‚©‚Ç‚¤‚©”»’è‚µA
-		@ pd = ƒfƒBƒŒƒNƒgƒŠ–¼‚Ìæ“ªˆÊ’u‚Éİ’è‚·‚éB */
+	if( *ppp != L'\0' ) {	/* ãƒ•ã‚¡ã‚¤ãƒ«ãƒ»ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãŒå­˜åœ¨ã™ã‚‹å ´åˆ */
+		/* å…ˆé ­æ–‡å­—ãŒãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ã‹ã©ã†ã‹åˆ¤å®šã—ã€
+		ã€€ pd = ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®å…ˆé ­ä½ç½®ã«è¨­å®šã™ã‚‹ã€‚ */
 		pd = ppp;
-		if(*(pd+1)==L':' && WCODE::IsAZ(*pd)){	/* æ“ª‚Éƒhƒ‰ƒCƒuƒŒƒ^[‚ª‚ ‚éB */
-			pd += 2;	/* pd = ƒhƒ‰ƒCƒuƒŒƒ^[•”‚ÌŒã‚ë         */
-		}				/*      ( = ƒfƒBƒŒƒNƒgƒŠ–¼‚Ìæ“ªˆÊ’u ) */
-		/* ‚±‚±‚Ü‚Å‚ÅApd = ƒfƒBƒŒƒNƒgƒŠ–¼‚Ìæ“ªˆÊ’u */
+		if(*(pd+1)==L':' && WCODE::IsAZ(*pd)){	/* å…ˆé ­ã«ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ãŒã‚ã‚‹ã€‚ */
+			pd += 2;	/* pd = ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼éƒ¨ã®å¾Œã‚         */
+		}				/*      ( = ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®å…ˆé ­ä½ç½® ) */
+		/* ã“ã“ã¾ã§ã§ã€pd = ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®å…ˆé ­ä½ç½® */
 
 		attr =  GetFileAttributesW(ppp);
 		a_dir = ( attr & FILE_ATTRIBUTE_DIRECTORY ) ?  1 : 0;
 
-		if( ! a_dir ){	/* Œ©‚Â‚¯‚½•¨‚ªƒtƒ@ƒCƒ‹‚¾‚Á‚½ê‡B */
-			pf = wcsrchr(ppp,L'\\');	/* Å––”ö‚Ì \ ‚ğ’T‚·B */
-			if(pf != NULL)	pf++;		/* Œ©‚Â‚©‚Á‚½¨  pf=\‚ÌŸ‚Ì•¶š‚ÌˆÊ’u*/
-			else			pf = pd;	/* Œ©‚Â‚©‚ç‚È‚¢¨pf=ƒpƒX–¼‚Ìæ“ªˆÊ’u */
-			/* ‚±‚±‚Ü‚Å‚Å pf = ƒtƒ@ƒCƒ‹–¼‚Ìæ“ªˆÊ’u */
-			pe = wcsrchr(pf,L'.');		/* Å––”ö‚Ì '.' ‚ğ’T‚·B */
-			if( pe != NULL ){					/* Œ©‚Â‚©‚Á‚½(pe = L'.'‚ÌˆÊ’u)*/
-				if( ext != NULL ){	/* Šg’£q‚ğ•Ô’l‚Æ‚µ‚Ä‘‚«‚ŞB */
+		if( ! a_dir ){	/* è¦‹ã¤ã‘ãŸç‰©ãŒãƒ•ã‚¡ã‚¤ãƒ«ã ã£ãŸå ´åˆã€‚ */
+			pf = wcsrchr(ppp,L'\\');	/* æœ€æœ«å°¾ã® \ ã‚’æ¢ã™ã€‚ */
+			if(pf != NULL)	pf++;		/* è¦‹ã¤ã‹ã£ãŸâ†’  pf=\ã®æ¬¡ã®æ–‡å­—ã®ä½ç½®*/
+			else			pf = pd;	/* è¦‹ã¤ã‹ã‚‰ãªã„â†’pf=ãƒ‘ã‚¹åã®å…ˆé ­ä½ç½® */
+			/* ã“ã“ã¾ã§ã§ pf = ãƒ•ã‚¡ã‚¤ãƒ«åã®å…ˆé ­ä½ç½® */
+			pe = wcsrchr(pf,L'.');		/* æœ€æœ«å°¾ã® '.' ã‚’æ¢ã™ã€‚ */
+			if( pe != NULL ){					/* è¦‹ã¤ã‹ã£ãŸ(pe = L'.'ã®ä½ç½®)*/
+				if( ext != NULL ){	/* æ‹¡å¼µå­ã‚’è¿”å€¤ã¨ã—ã¦æ›¸ãè¾¼ã‚€ã€‚ */
 					wcsncpy(ext,pe,_MAX_EXT-1);
 					ext[_MAX_EXT -1] = L'\0';
 				}
-				*pe = L'\0';	/* ‹æØ‚èˆÊ’u‚ğ•¶š—ñI’[‚É‚·‚éBpe = Šg’£q–¼‚Ìæ“ªˆÊ’uB */
+				*pe = L'\0';	/* åŒºåˆ‡ã‚Šä½ç½®ã‚’æ–‡å­—åˆ—çµ‚ç«¯ã«ã™ã‚‹ã€‚pe = æ‹¡å¼µå­åã®å…ˆé ­ä½ç½®ã€‚ */
 			}
-			if( fnm != NULL ){	/* ƒtƒ@ƒCƒ‹–¼‚ğ•Ô’l‚Æ‚µ‚Ä‘‚«‚ŞB */
+			if( fnm != NULL ){	/* ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¿”å€¤ã¨ã—ã¦æ›¸ãè¾¼ã‚€ã€‚ */
 				wcsncpy(fnm,pf,_MAX_FNAME-1);
 				fnm[_MAX_FNAME -1] = L'\0';
 			}
-			*pf = L'\0';	/* ƒtƒ@ƒCƒ‹–¼‚Ìæ“ªˆÊ’u‚ğ•¶š—ñI’[‚É‚·‚éB */
+			*pf = L'\0';	/* ãƒ•ã‚¡ã‚¤ãƒ«åã®å…ˆé ­ä½ç½®ã‚’æ–‡å­—åˆ—çµ‚ç«¯ã«ã™ã‚‹ã€‚ */
 		}
-		/* ‚±‚±‚Ü‚Å‚Å•¶š—ñ ppp ‚Íƒhƒ‰ƒCƒuƒŒƒ^[{ƒfƒBƒŒƒNƒgƒŠ–¼‚Ì‚İ‚É‚È‚Á‚Ä‚¢‚é */
+		/* ã“ã“ã¾ã§ã§æ–‡å­—åˆ— ppp ã¯ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ï¼‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®ã¿ã«ãªã£ã¦ã„ã‚‹ */
 		if( dir != NULL ){
-			/* ƒfƒBƒŒƒNƒgƒŠ–¼‚ÌÅŒã‚Ì•¶š‚ª \ ‚Å‚Í‚È‚¢ê‡A\ ‚É‚·‚éB */
+			/* ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®æœ€å¾Œã®æ–‡å­—ãŒ \ ã§ã¯ãªã„å ´åˆã€\ ã«ã™ã‚‹ã€‚ */
 
-			/* «ÅŒã‚Ì•¶š‚ğ ch ‚É“¾‚éB(ƒfƒBƒŒƒNƒgƒŠ•¶š—ñ‚ª‹ó‚Ìê‡ ch=L'\\' ‚Æ‚È‚é) */
+			/* â†“æœ€å¾Œã®æ–‡å­—ã‚’ ch ã«å¾—ã‚‹ã€‚(ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªæ–‡å­—åˆ—ãŒç©ºã®å ´åˆ ch=L'\\' ã¨ãªã‚‹) */
 			for( ch = L'\\' , pf = pd ; *pf != L'\0' ; pf++ ){
 				ch = *pf;
 			}
-			/* •¶š—ñ‚ª‹ó‚Å‚È‚­A‚©‚ÂAÅŒã‚Ì•¶š‚ª \ ‚Å‚È‚©‚Á‚½‚È‚ç‚Î \ ‚ğ’Ç‰ÁB */
+			/* æ–‡å­—åˆ—ãŒç©ºã§ãªãã€ã‹ã¤ã€æœ€å¾Œã®æ–‡å­—ãŒ \ ã§ãªã‹ã£ãŸãªã‚‰ã° \ ã‚’è¿½åŠ ã€‚ */
 			if( ( ch != L'\\' ) && ( wcslen(ppp) < _MAX_PATH -1 ) ){
 				*pf++ = L'\\';	*pf = L'\0';
 			}
 
-			/* ƒfƒBƒŒƒNƒgƒŠ–¼‚ğ•Ô’l‚Æ‚µ‚Ä‘‚«‚ŞB */
+			/* ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã‚’è¿”å€¤ã¨ã—ã¦æ›¸ãè¾¼ã‚€ã€‚ */
 			wcsncpy(dir,pd,_MAX_DIR -1);
 			dir[_MAX_DIR -1] = L'\0';
 		}
-		*pd = L'\0';		/* ƒfƒBƒŒƒNƒgƒŠ–¼‚Ìæ“ªˆÊ’u‚ğ•¶š—ñI’[‚É‚·‚éB */
-		if( drv != NULL ){	/* ƒhƒ‰ƒCƒuƒŒƒ^[‚ğ•Ô’l‚Æ‚µ‚Ä‘‚«‚ŞB */
+		*pd = L'\0';		/* ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã®å…ˆé ­ä½ç½®ã‚’æ–‡å­—åˆ—çµ‚ç«¯ã«ã™ã‚‹ã€‚ */
+		if( drv != NULL ){	/* ãƒ‰ãƒ©ã‚¤ãƒ–ãƒ¬ã‚¿ãƒ¼ã‚’è¿”å€¤ã¨ã—ã¦æ›¸ãè¾¼ã‚€ã€‚ */
 			wcsncpy(drv,ppp,_MAX_DRIVE -1);
 			drv[_MAX_DRIVE -1] = L'\0';
 		}
@@ -1124,8 +1124,8 @@ void my_splitpath_w (
 // -----------------------------------------------------------------------------
 int FileMatchScore( const TCHAR *file1, const TCHAR *file2 );
 
-// ƒtƒ‹ƒpƒX‚©‚çƒtƒ@ƒCƒ‹–¼‚Ì.ˆÈ~‚ğ•ª—£‚·‚é
-// 2014.06.15 ƒtƒHƒ‹ƒ_–¼‚É.‚ªŠÜ‚Ü‚ê‚½ê‡AƒtƒHƒ‹ƒ_‚ª•ª—£‚³‚ê‚½‚Ì‚ğC³
+// ãƒ•ãƒ«ãƒ‘ã‚¹ã‹ã‚‰ãƒ•ã‚¡ã‚¤ãƒ«åã®.ä»¥é™ã‚’åˆ†é›¢ã™ã‚‹
+// 2014.06.15 ãƒ•ã‚©ãƒ«ãƒ€åã«.ãŒå«ã¾ã‚ŒãŸå ´åˆã€ãƒ•ã‚©ãƒ«ãƒ€ãŒåˆ†é›¢ã•ã‚ŒãŸã®ã‚’ä¿®æ­£
 static void FileNameSepExt( const TCHAR *file, TCHAR* pszFile, TCHAR* pszExt )
 {
 	const TCHAR* folderPos = file;
@@ -1161,7 +1161,7 @@ int FileMatchScoreSepExt( const TCHAR *file1, const TCHAR *file2 )
 	return score;
 }
 
-/*!	2‚Â‚Ìƒtƒ@ƒCƒ‹–¼‚ÌÅ’·ˆê’v•”•ª‚Ì’·‚³‚ğ•Ô‚·
+/*!	2ã¤ã®ãƒ•ã‚¡ã‚¤ãƒ«åã®æœ€é•·ä¸€è‡´éƒ¨åˆ†ã®é•·ã•ã‚’è¿”ã™
 */
 int FileMatchScore( const TCHAR *file1, const TCHAR *file2 )
 {
@@ -1212,12 +1212,12 @@ int FileMatchScore( const TCHAR *file1, const TCHAR *file2 )
 	return score;
 }
 
-/*! w’è•‚Ü‚Å‚É•¶š—ñ‚ğÈ—ª
-	@date 2014.06.12 V‹Kì¬ Moca
+/*! æŒ‡å®šå¹…ã¾ã§ã«æ–‡å­—åˆ—ã‚’çœç•¥
+	@date 2014.06.12 æ–°è¦ä½œæˆ Moca
 */
 void GetStrTrancateWidth( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, int nPxWidth )
 {
-	// ‚Å‚«‚é‚¾‚¯¶‘¤‚©‚ç•\¦
+	// ã§ãã‚‹ã ã‘å·¦å´ã‹ã‚‰è¡¨ç¤º
 	// \\server\dir...
 	const int nPathLen = auto_strlen(path);
 	CTextWidthCalc calc(hDC);
@@ -1233,7 +1233,7 @@ void GetStrTrancateWidth( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, in
 		std::tstring strTemp2 = strTemp;
 		strTemp2 += _T("...");
 		if( nPxWidth < calc.GetTextWidth(strTemp2.c_str()) ){
-			// “ü‚è‚«‚ç‚È‚©‚Á‚½‚Ì‚Å1•¶š‘O‚Ü‚Å‚ğƒRƒs[
+			// å…¥ã‚Šãã‚‰ãªã‹ã£ãŸã®ã§1æ–‡å­—å‰ã¾ã§ã‚’ã‚³ãƒ”ãƒ¼
 			_tcsncpy_s(dest, t_max(0, nSize - 3), strTempOld.c_str(), _TRUNCATE);
 			_tcscat_s(dest, nSize, _T("..."));
 			return;
@@ -1241,23 +1241,23 @@ void GetStrTrancateWidth( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, in
 		strTempOld = strTemp;
 		nPos += t_max(1, (int)(Int)CNativeT::GetSizeOfChar(path, nPathLen, nPos));
 	}
-	// ‘S•”•\¦(‚±‚±‚É‚Í—ˆ‚È‚¢‚Í‚¸)
+	// å…¨éƒ¨è¡¨ç¤º(ã“ã“ã«ã¯æ¥ãªã„ã¯ãš)
 	_tcsncpy_s(dest, nSize, path, _TRUNCATE);
 }
 
-/*! ƒpƒX‚ÌÈ—ª•\¦
+/*! ãƒ‘ã‚¹ã®çœç•¥è¡¨ç¤º
 	in  C:\sub1\sub2\sub3\file.ext
 	out C:\...\sub3\file.ext
-	@date 2014.06.12 V‹Kì¬ Moca
+	@date 2014.06.12 æ–°è¦ä½œæˆ Moca
 */
 void GetShortViewPath( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, int nPxWidth, bool bFitMode )
 {
-	int nLeft = 0; // ¶‘¤ŒÅ’è•\¦•”•ª
+	int nLeft = 0; // å·¦å´å›ºå®šè¡¨ç¤ºéƒ¨åˆ†
 	int nSkipLevel = 1;
 	const int nPathLen = auto_strlen(path);
 	CTextWidthCalc calc(hDC);
 	if( calc.GetTextWidth(path) <= nPxWidth ){
-		// ‘S•”•\¦‰Â”\
+		// å…¨éƒ¨è¡¨ç¤ºå¯èƒ½
 		_tcsncpy_s(dest, nSize, path, _TRUNCATE);
 		return;
 	}
@@ -1266,17 +1266,17 @@ void GetShortViewPath( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, int n
 			// [\\?\A:\]
 			nLeft = 4;
 		}else{
-			nSkipLevel = 2; // [\\server\dir\] ‚Ì2ŠK‘w”ò‚Î‚·
+			nSkipLevel = 2; // [\\server\dir\] ã®2éšå±¤é£›ã°ã™
 			nLeft = 2;
 		}
 	}else{
-		// http://server/ ‚Æ‚© ftp://server/ ‚Æ‚©‚ğ•Û
+		// http://server/ ã¨ã‹ ftp://server/ ã¨ã‹ã‚’ä¿æŒ
 		int nTop = 0;
 		while( path[nTop] != _T('\0') && path[nTop] != _T('/') ){
 			nTop += t_max(1, (int)(Int)CNativeT::GetSizeOfChar(path, nPathLen, nTop));
 		}
 		if( 0 < nTop && path[nTop - 1] == ':' ){
-			// u‚Ù‚É‚á‚ç‚ç:/v‚¾‚Á‚½ /‚ª‘±‚¢‚Ä‚éŠÔ”ò‚Î‚·
+			// ã€Œã»ã«ã‚ƒã‚‰ã‚‰:/ã€ã ã£ãŸ /ãŒç¶šã„ã¦ã‚‹é–“é£›ã°ã™
 			while( path[nTop] == _T('/') ){
 				nTop += t_max(1, (int)(Int)CNativeT::GetSizeOfChar(path, nPathLen, nTop));
 			}
@@ -1296,12 +1296,12 @@ void GetShortViewPath( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, int n
 				GetStrTrancateWidth(dest, nSize, path, hDC, nPxWidth);
 				return;
 			}
-			// ‚±‚±‚ÅI’[‚È‚ç‘S•”•\¦
+			// ã“ã“ã§çµ‚ç«¯ãªã‚‰å…¨éƒ¨è¡¨ç¤º
 			_tcsncpy_s(dest, nSize, path, _TRUNCATE);
 			return;
 		}
 	}
-	int nRight = nLeft; // ‰E‘¤‚Ì•\¦ŠJnˆÊ’u(nRight‚Í\‚ğw‚µ‚Ä‚¢‚é)
+	int nRight = nLeft; // å³å´ã®è¡¨ç¤ºé–‹å§‹ä½ç½®(nRightã¯\ã‚’æŒ‡ã—ã¦ã„ã‚‹)
 	while( path[nRight] != _T('\0') ){
 		int nNext = nRight;
 		nNext++;
@@ -1309,7 +1309,7 @@ void GetShortViewPath( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, int n
 			nNext += t_max(1, (int)(Int)CNativeT::GetSizeOfChar(path, nPathLen, nNext));
 		}
 		if( path[nNext] != _T('\0') ){
-			// ƒTƒuƒtƒHƒ‹ƒ_È—ª
+			// ã‚µãƒ–ãƒ•ã‚©ãƒ«ãƒ€çœç•¥
 			// C:\...\dir\file.ext
 			std::tstring strTemp(path, nLeft + 1);
 			if( nLeft + 1 < nRight ){
@@ -1320,7 +1320,7 @@ void GetShortViewPath( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, int n
 				_tcsncpy_s(dest, nSize, strTemp.c_str(), _TRUNCATE);
 				return;
 			}
-			// C:\...\dir\   ƒtƒHƒ‹ƒ_ƒpƒX‚¾‚Á‚½BÅŒã‚ÌƒtƒHƒ‹ƒ_‚ğ•\¦
+			// C:\...\dir\   ãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹ã ã£ãŸã€‚æœ€å¾Œã®ãƒ•ã‚©ãƒ«ãƒ€ã‚’è¡¨ç¤º
 			if( path[nNext+1] == _T('\0') ){
 				if( bFitMode ){
 					GetStrTrancateWidth(dest, nSize, strTemp.c_str(), hDC, nPxWidth);
@@ -1334,7 +1334,7 @@ void GetShortViewPath( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, int n
 			break;
 		}
 	}
-	// nRight‚æ‚è‰E‚É\‚ªŒ©‚Â‚©‚ç‚È‚©‚Á‚½=ƒtƒ@ƒCƒ‹–¼‚¾‚Á‚½‚Ì‚Åƒtƒ@ƒCƒ‹–¼•\¦
+	// nRightã‚ˆã‚Šå³ã«\ãŒè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸ=ãƒ•ã‚¡ã‚¤ãƒ«åã ã£ãŸã®ã§ãƒ•ã‚¡ã‚¤ãƒ«åè¡¨ç¤º
 	// C:\...\file.ext
 	int nLeftLen = nLeft;
 	if( nLeftLen && nLeftLen != nRight ){
@@ -1350,10 +1350,10 @@ void GetShortViewPath( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, int n
 			_tcsncpy_s(dest, nSize, strTemp.c_str(), _TRUNCATE);
 			return;
 		}
-		// ƒtƒ@ƒCƒ‹–¼(‚©¶‘¤ŒÅ’è•”)‚ª’·‚·‚¬‚Ä‚Í‚¢‚ç‚È‚¢
+		// ãƒ•ã‚¡ã‚¤ãƒ«å(ã‹å·¦å´å›ºå®šéƒ¨)ãŒé•·ã™ãã¦ã¯ã„ã‚‰ãªã„
 		int nExtPos = -1;
 		{
-			// Šg’£q‚Ì.‚ğ’T‚·
+			// æ‹¡å¼µå­ã®.ã‚’æ¢ã™
 			int nExt = nRight;
 			while( path[nExt] != _T('\0') ){
 				if( path[nExt] == _T('.') ){
@@ -1371,18 +1371,18 @@ void GetShortViewPath( TCHAR* dest, int nSize, const TCHAR* path, HDC hDC, int n
 			int nLeftWidth = calc.GetTextWidth(strLeftFile.c_str());
 			int nFileNameWidth = nPxWidth - nLeftWidth - nExtWidth;
 			if( 0 < nFileNameWidth ){
-				// Šg’£q‚ÍÈ—ª‚µ‚È‚¢(ƒtƒ@ƒCƒ‹ƒ^ƒCƒgƒ‹‚ğÈ—ª)
+				// æ‹¡å¼µå­ã¯çœç•¥ã—ãªã„(ãƒ•ã‚¡ã‚¤ãƒ«ã‚¿ã‚¤ãƒˆãƒ«ã‚’çœç•¥)
 				std::tstring strFile(&path[nRight], nExtPos - nRight); // \longfilename
 				strLeftFile += strFile; // C:\...\longfilename
 				int nExtLen = nPathLen - nExtPos;
 				GetStrTrancateWidth(dest, t_max(0, nSize - nExtLen), strLeftFile.c_str(), hDC, nPxWidth - nExtWidth);
-				_tcscat_s(dest, nSize, &path[nExtPos+1]); // Šg’£q˜AŒ‹ C:\...\longf...ext
+				_tcscat_s(dest, nSize, &path[nExtPos+1]); // æ‹¡å¼µå­é€£çµ C:\...\longf...ext
 			}else{
-				// ƒtƒ@ƒCƒ‹–¼‚ª’u‚¯‚È‚¢‚­‚ç‚¢Šg’£q‚©¶‘¤‚ª’·‚¢BƒpƒX‚Ì¶‘¤‚ğ—Dæ‚µ‚Äc‚·
+				// ãƒ•ã‚¡ã‚¤ãƒ«åãŒç½®ã‘ãªã„ãã‚‰ã„æ‹¡å¼µå­ã‹å·¦å´ãŒé•·ã„ã€‚ãƒ‘ã‚¹ã®å·¦å´ã‚’å„ªå…ˆã—ã¦æ®‹ã™
 				GetStrTrancateWidth(dest, nSize, strTemp.c_str(), hDC, nPxWidth);
 			}
 		}else{
-			// Šg’£q‚Í‚È‚©‚Á‚½B¶‘¤‚©‚çc‚·
+			// æ‹¡å¼µå­ã¯ãªã‹ã£ãŸã€‚å·¦å´ã‹ã‚‰æ®‹ã™
 			GetStrTrancateWidth(dest, nSize, strTemp.c_str(), hDC, nPxWidth);
 		}
 		return;

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2002, SUI
 	Copyright (C) 2008, kobake
 
@@ -25,65 +25,65 @@
 #ifndef SAKURA_FILE_2813BD8E_F6B9_400F_AA27_A6DDC372D6B89_H_
 #define SAKURA_FILE_2813BD8E_F6B9_400F_AA27_A6DDC372D6B89_H_
 
-bool fexist(LPCTSTR pszPath); //!< ƒtƒ@ƒCƒ‹‚Ü‚½‚ÍƒfƒBƒŒƒNƒgƒŠ‚ª‘¶Ý‚·‚ê‚Îtrue
+bool fexist(LPCTSTR pszPath); //!< ãƒ•ã‚¡ã‚¤ãƒ«ã¾ãŸã¯ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãŒå­˜åœ¨ã™ã‚Œã°true
 
 bool IsFilePath( const wchar_t*, size_t*, size_t*, bool = true );
 bool IsFileExists(const TCHAR* path, bool bFileOnly = false);
 bool IsDirectory(LPCTSTR pszPath);	// 2009.08.20 ryoji
 
 //	Apr. 30, 2003 genta
-//	ƒfƒBƒŒƒNƒgƒŠ‚Ì[‚³‚ð’²‚×‚é
+//	ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã®æ·±ã•ã‚’èª¿ã¹ã‚‹
 int CalcDirectoryDepth(const TCHAR* path);
 
 // 2005.11.26 aroka
 bool IsLocalDrive( const TCHAR* pszDrive );
 
-//¦ƒTƒNƒ‰ˆË‘¶
+//â€»ã‚µã‚¯ãƒ©ä¾å­˜
 FILE *_tfopen_absexe(LPCTSTR fname, LPCTSTR mode); // 2003.06.23 Moca
 FILE *_tfopen_absini(LPCTSTR fname, LPCTSTR mode, BOOL bOrExedir = TRUE); // 2007.05.19 ryoji
 
-//ƒpƒX•¶Žš—ñˆ—
-void CutLastYenFromDirectoryPath( TCHAR* );						/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ª”¼Šp‚©‚Â'\\'‚Ìê‡‚ÍAŽæ‚èœ‚­ "c:\\"“™‚Ìƒ‹[ƒg‚ÍŽæ‚èœ‚©‚È‚¢*/
-void AddLastYenFromDirectoryPath(  CHAR* );						/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ª”¼Šp‚©‚Â'\\'‚Å‚È‚¢ê‡‚ÍA•t‰Á‚·‚é */
-void AddLastYenFromDirectoryPath( WCHAR* );						/* ƒtƒHƒ‹ƒ_‚ÌÅŒã‚ª”¼Šp‚©‚Â'\\'‚Å‚È‚¢ê‡‚ÍA•t‰Á‚·‚é */
-void SplitPath_FolderAndFile( const TCHAR*, TCHAR*, TCHAR* );	/* ƒtƒ@ƒCƒ‹‚Ìƒtƒ‹ƒpƒX‚ðAƒtƒHƒ‹ƒ_‚Æƒtƒ@ƒCƒ‹–¼‚É•ªŠ„ */
-void Concat_FolderAndFile( const TCHAR*, const TCHAR*, TCHAR* );/* ƒtƒHƒ‹ƒ_Aƒtƒ@ƒCƒ‹–¼‚©‚çAŒ‹‡‚µ‚½ƒpƒX‚ðì¬ */
-BOOL GetLongFileName( const TCHAR*, TCHAR* );					/* ƒƒ“ƒOƒtƒ@ƒCƒ‹–¼‚ðŽæ“¾‚·‚é */
-BOOL CheckEXT( const TCHAR*, const TCHAR* );					/* Šg’£Žq‚ð’²‚×‚é */
-const TCHAR* GetFileTitlePointer(const TCHAR* tszPath);							//!< ƒtƒ@ƒCƒ‹ƒtƒ‹ƒpƒX“à‚Ìƒtƒ@ƒCƒ‹–¼‚ðŽw‚·ƒ|ƒCƒ“ƒ^‚ðŽæ“¾B2007.09.20 kobake ì¬
-bool _IS_REL_PATH(const TCHAR* path);											//!< ‘Š‘ÎƒpƒX‚©”»’è‚·‚éB2003.06.23 Moca
+//ãƒ‘ã‚¹æ–‡å­—åˆ—å‡¦ç†
+void CutLastYenFromDirectoryPath( TCHAR* );						/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒåŠè§’ã‹ã¤'\\'ã®å ´åˆã¯ã€å–ã‚Šé™¤ã "c:\\"ç­‰ã®ãƒ«ãƒ¼ãƒˆã¯å–ã‚Šé™¤ã‹ãªã„*/
+void AddLastYenFromDirectoryPath(  CHAR* );						/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒåŠè§’ã‹ã¤'\\'ã§ãªã„å ´åˆã¯ã€ä»˜åŠ ã™ã‚‹ */
+void AddLastYenFromDirectoryPath( WCHAR* );						/* ãƒ•ã‚©ãƒ«ãƒ€ã®æœ€å¾ŒãŒåŠè§’ã‹ã¤'\\'ã§ãªã„å ´åˆã¯ã€ä»˜åŠ ã™ã‚‹ */
+void SplitPath_FolderAndFile( const TCHAR*, TCHAR*, TCHAR* );	/* ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ•ãƒ«ãƒ‘ã‚¹ã‚’ã€ãƒ•ã‚©ãƒ«ãƒ€ã¨ãƒ•ã‚¡ã‚¤ãƒ«åã«åˆ†å‰² */
+void Concat_FolderAndFile( const TCHAR*, const TCHAR*, TCHAR* );/* ãƒ•ã‚©ãƒ«ãƒ€ã€ãƒ•ã‚¡ã‚¤ãƒ«åã‹ã‚‰ã€çµåˆã—ãŸãƒ‘ã‚¹ã‚’ä½œæˆ */
+BOOL GetLongFileName( const TCHAR*, TCHAR* );					/* ãƒ­ãƒ³ã‚°ãƒ•ã‚¡ã‚¤ãƒ«åã‚’å–å¾—ã™ã‚‹ */
+BOOL CheckEXT( const TCHAR*, const TCHAR* );					/* æ‹¡å¼µå­ã‚’èª¿ã¹ã‚‹ */
+const TCHAR* GetFileTitlePointer(const TCHAR* tszPath);							//!< ãƒ•ã‚¡ã‚¤ãƒ«ãƒ•ãƒ«ãƒ‘ã‚¹å†…ã®ãƒ•ã‚¡ã‚¤ãƒ«åã‚’æŒ‡ã™ãƒã‚¤ãƒ³ã‚¿ã‚’å–å¾—ã€‚2007.09.20 kobake ä½œæˆ
+bool _IS_REL_PATH(const TCHAR* path);											//!< ç›¸å¯¾ãƒ‘ã‚¹ã‹åˆ¤å®šã™ã‚‹ã€‚2003.06.23 Moca
 
-//¦ƒTƒNƒ‰ˆË‘¶
+//â€»ã‚µã‚¯ãƒ©ä¾å­˜
 void GetExedir( LPTSTR pDir, LPCTSTR szFile = NULL );
 void GetInidir( LPTSTR pDir, LPCTSTR szFile = NULL ); // 2007.05.19 ryoji
 void GetInidirOrExedir( LPTSTR pDir, LPCTSTR szFile = NULL, BOOL bRetExedirIfFileEmpty = FALSE ); // 2007.05.22 ryoji
 
 LPCTSTR GetRelPath( LPCTSTR pszPath );
 
-//ƒtƒ@ƒCƒ‹Žž
+//ãƒ•ã‚¡ã‚¤ãƒ«æ™‚åˆ»
 class CFileTime{
 public:
 	CFileTime(){ ClearFILETIME(); }
 	CFileTime(const FILETIME& ftime){ SetFILETIME(ftime); }
-	//Ý’è
+	//è¨­å®š
 	void ClearFILETIME(){ m_ftime.dwLowDateTime = m_ftime.dwHighDateTime = 0; m_bModified = true; }
 	void SetFILETIME(const FILETIME& ftime){ m_ftime = ftime; m_bModified = true; }
-	//Žæ“¾
+	//å–å¾—
 	const FILETIME& GetFILETIME() const{ return m_ftime; }
 	const SYSTEMTIME& GetSYSTEMTIME() const
 	{
-		//ƒLƒƒƒbƒVƒ…XV -> m_systime, m_bModified
+		//ã‚­ãƒ£ãƒƒã‚·ãƒ¥æ›´æ–° -> m_systime, m_bModified
 		if(m_bModified){
 			m_bModified = false;
 			FILETIME ftimeLocal;
 			if(!::FileTimeToLocalFileTime( &m_ftime, &ftimeLocal ) || !::FileTimeToSystemTime( &ftimeLocal, &m_systime )){
-				memset(&m_systime,0,sizeof(m_systime)); //Ž¸”sŽžƒ[ƒƒNƒŠƒA
+				memset(&m_systime,0,sizeof(m_systime)); //å¤±æ•—æ™‚ã‚¼ãƒ­ã‚¯ãƒªã‚¢
 			}
 		}
 		return m_systime;
 	}
 	const SYSTEMTIME* operator->() const{ return &GetSYSTEMTIME(); }
-	//”»’è
+	//åˆ¤å®š
 	bool IsZero() const
 	{
 		return m_ftime.dwLowDateTime == 0 && m_ftime.dwHighDateTime == 0;
@@ -91,13 +91,13 @@ public:
 protected:
 private:
 	FILETIME m_ftime;
-	//ƒLƒƒƒbƒVƒ…
+	//ã‚­ãƒ£ãƒƒã‚·ãƒ¥
 	mutable SYSTEMTIME	m_systime;
 	mutable bool		m_bModified;
 };
 bool GetLastWriteTimestamp( const TCHAR* filename, CFileTime* pcFileTime ); //	Oct. 22, 2005 genta
 
-//•¶Žš—ñ•ªŠ„
+//æ–‡å­—åˆ—åˆ†å‰²
 void my_splitpath ( const char *comln , char *drv,char *dir,char *fnm,char *ext );
 void my_splitpath_w ( const wchar_t *comln , wchar_t *drv,wchar_t *dir,wchar_t *fnm,wchar_t *ext );
 void my_splitpath_t ( const TCHAR *comln , TCHAR *drv,TCHAR *dir,TCHAR *fnm,TCHAR *ext );

--- a/sakura_core/util/format.cpp
+++ b/sakura_core/util/format.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2007, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,20 +26,20 @@
 #include "format.h"
 
 
-/*!	“ú‚ğƒtƒH[ƒ}ƒbƒg
+/*!	æ—¥æ™‚ã‚’ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ
 
-	@param[out] ‘®•ÏŠ·Œã‚Ì•¶š—ñ
-	@param[in] ƒoƒbƒtƒ@ƒTƒCƒY
-	@param[in] format ‘®
-	@param[in] systime ‘®‰»‚µ‚½‚¢“ú
+	@param[out] æ›¸å¼å¤‰æ›å¾Œã®æ–‡å­—åˆ—
+	@param[in] ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚º
+	@param[in] format æ›¸å¼
+	@param[in] systime æ›¸å¼åŒ–ã—ãŸã„æ—¥æ™‚
 	@return bool true
 
-	@note  %Y %y %m %d %H %M %S ‚Ì•ÏŠ·‚É‘Î‰
+	@note  %Y %y %m %d %H %M %S ã®å¤‰æ›ã«å¯¾å¿œ
 
 	@author aroka
-	@date 2005.11.21 V‹K
+	@date 2005.11.21 æ–°è¦
 	
-	@todo o—Íƒoƒbƒtƒ@‚ÌƒTƒCƒYƒ`ƒFƒbƒN‚ğs‚¤
+	@todo å‡ºåŠ›ãƒãƒƒãƒ•ã‚¡ã®ã‚µã‚¤ã‚ºãƒã‚§ãƒƒã‚¯ã‚’è¡Œã†
 */
 bool GetDateTimeFormat( TCHAR* szResult, int size, const TCHAR* format, const SYSTEMTIME& systime )
 {
@@ -101,27 +101,27 @@ bool GetDateTimeFormat( TCHAR* szResult, int size, const TCHAR* format, const SY
 	return true;
 }
 
-/*!	ƒo[ƒWƒ‡ƒ“”Ô†‚Ì‰ğÍ
+/*!	ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã®è§£æ
 
-	@param[in] ƒo[ƒWƒ‡ƒ“”Ô†•¶š—ñ
-	@return UINT32 8biti•„†1bit+”’l7bitj‚¸‚ÂƒƒWƒƒ[Aƒ}ƒCƒi[Aƒrƒ‹ƒhAƒŠƒrƒWƒ‡ƒ“‚ğŠi”[
+	@param[in] ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·æ–‡å­—åˆ—
+	@return UINT32 8bitï¼ˆç¬¦å·1bit+æ•°å€¤7bitï¼‰ãšã¤ãƒ¡ã‚¸ãƒ£ãƒ¼ã€ãƒã‚¤ãƒŠãƒ¼ã€ãƒ“ãƒ«ãƒ‰ã€ãƒªãƒ“ã‚¸ãƒ§ãƒ³ã‚’æ ¼ç´
 
 	@author syat
-	@date 2011.03.18 V‹K
-	@note Ql PHP version_compare http://php.s3.to/man/function.version-compare.html
+	@date 2011.03.18 æ–°è¦
+	@note å‚è€ƒ PHP version_compare http://php.s3.to/man/function.version-compare.html
 */
 UINT32 ParseVersion( const TCHAR* sVer )
 {
 	int nVer;
-	int nShift = 0;	//“Á•Ê‚È•¶š—ñ‚É‚æ‚é‰º‘Ê
-	int nDigit = 0;	//˜A‘±‚·‚é”š‚Ì”
+	int nShift = 0;	//ç‰¹åˆ¥ãªæ–‡å­—åˆ—ã«ã‚ˆã‚‹ä¸‹é§„
+	int nDigit = 0;	//é€£ç¶šã™ã‚‹æ•°å­—ã®æ•°
 	UINT32 ret = 0;
 
 	const TCHAR *p = sVer;
 	int i;
 
 	for( i=0; *p && i<4; i++){
-		//“Á•Ê‚È•¶š—ñ‚Ìˆ—
+		//ç‰¹åˆ¥ãªæ–‡å­—åˆ—ã®å‡¦ç†
 		if( *p == _T('a') ){
 			if( _tcsncmp( _T("alpha"), p, 5 ) == 0 )p += 5;
 			else p++;
@@ -149,18 +149,18 @@ UINT32 ParseVersion( const TCHAR* sVer )
 			nShift = 0;
 		}
 		while( *p && !_istdigit(*p) ){ p++; }
-		//”’l‚Ì’Šo
+		//æ•°å€¤ã®æŠ½å‡º
 		for( nVer = 0, nDigit = 0; _istdigit(*p); p++ ){
-			if( ++nDigit > 2 )break;	//”š‚Í2Œ…‚Ü‚Å‚Å~‚ß‚é
+			if( ++nDigit > 2 )break;	//æ•°å­—ã¯2æ¡ã¾ã§ã§æ­¢ã‚ã‚‹
 			nVer = nVer * 10 + *p - _T('0');
 		}
-		//‹æØ‚è•¶š‚Ìˆ—
+		//åŒºåˆ‡ã‚Šæ–‡å­—ã®å‡¦ç†
 		while( *p && _tcschr( _T(".-_+"), *p ) ){ p++; }
 
 		DEBUG_TRACE(_T("  VersionPart%d: ver=%d,shift=%d\n"), i, nVer, nShift);
 		ret |= ( (nShift + nVer + 128) << (24-8*i) );
 	}
-	for( ; i<4; i++ ){	//c‚è‚Ì•”•ª‚Ísigned 0 (=0x80)‚ğ–„‚ß‚é
+	for( ; i<4; i++ ){	//æ®‹ã‚Šã®éƒ¨åˆ†ã¯signed 0 (=0x80)ã‚’åŸ‹ã‚ã‚‹
 		ret |= ( 128 << (24-8*i) );
 	}
 
@@ -170,14 +170,14 @@ UINT32 ParseVersion( const TCHAR* sVer )
 	return ret;
 }
 
-/*!	ƒo[ƒWƒ‡ƒ“”Ô†‚Ì”äŠr
+/*!	ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã®æ¯”è¼ƒ
 
-	@param[in] ƒo[ƒWƒ‡ƒ“A
-	@param[in] ƒo[ƒWƒ‡ƒ“B
-	@return int 0: ƒo[ƒWƒ‡ƒ“‚Í“™‚µ‚¢A1ˆÈã: A‚ªV‚µ‚¢A-1ˆÈ‰º: B‚ªV‚µ‚¢
+	@param[in] ãƒãƒ¼ã‚¸ãƒ§ãƒ³A
+	@param[in] ãƒãƒ¼ã‚¸ãƒ§ãƒ³B
+	@return int 0: ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã¯ç­‰ã—ã„ã€1ä»¥ä¸Š: AãŒæ–°ã—ã„ã€-1ä»¥ä¸‹: BãŒæ–°ã—ã„
 
 	@author syat
-	@date 2011.03.18 V‹K
+	@date 2011.03.18 æ–°è¦
 */
 int CompareVersion( const TCHAR* verA, const TCHAR* verB )
 {

--- a/sakura_core/util/format.h
+++ b/sakura_core/util/format.h
@@ -1,4 +1,4 @@
-// 2007.10.20 kobake ‘®ŠÖ˜A
+ï»¿// 2007.10.20 kobake æ›¸å¼é–¢é€£
 /*
 	Copyright (C) 2007, kobake
 
@@ -27,8 +27,8 @@
 
 // 20051121 aroka
 bool GetDateTimeFormat( TCHAR* szResult, int size, const TCHAR* format, const SYSTEMTIME& systime );
-UINT32 ParseVersion( const TCHAR* ver );	//ƒo[ƒWƒ‡ƒ“”Ô†‚Ì‰ğÍ
-int CompareVersion( const TCHAR* verA, const TCHAR* verB );	//ƒo[ƒWƒ‡ƒ“”Ô†‚Ì”äŠr
+UINT32 ParseVersion( const TCHAR* ver );	//ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã®è§£æ
+int CompareVersion( const TCHAR* verA, const TCHAR* verB );	//ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã®æ¯”è¼ƒ
 
 #endif /* SAKURA_FORMAT_2E480672_88BC_482E_B204_52BB5D84F20C9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/input.cpp
+++ b/sakura_core/util/input.cpp
@@ -1,26 +1,26 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "input.h"
 
-// novice 2004/10/10 ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“‘Î‰
+// novice 2004/10/10 ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³å¯¾å¿œ
 /*!
-	Shift,Ctrl,AltƒL[ó‘Ô‚Ìæ“¾
+	Shift,Ctrl,Altã‚­ãƒ¼çŠ¶æ…‹ã®å–å¾—
 
-	@retval nIdx Shift,Ctrl,AltƒL[ó‘Ô
-	@date 2004.10.10 ŠÖ”‰»
+	@retval nIdx Shift,Ctrl,Altã‚­ãƒ¼çŠ¶æ…‹
+	@date 2004.10.10 é–¢æ•°åŒ–
 */
 int getCtrlKeyState()
 {
 	int nIdx = 0;
 
-	/* ShiftƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚é‚È‚ç */
+	/* Shiftã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ã‚‹ãªã‚‰ */
 	if(GetKeyState_Shift()){
 		nIdx |= _SHIFT;
 	}
-	/* CtrlƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚é‚È‚ç */
+	/* Ctrlã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ã‚‹ãªã‚‰ */
 	if( GetKeyState_Control() ){
 		nIdx |= _CTRL;
 	}
-	/* AltƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚é‚È‚ç */
+	/* Altã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ã‚‹ãªã‚‰ */
 	if( GetKeyState_Alt() ){
 		nIdx |= _ALT;
 	}

--- a/sakura_core/util/input.h
+++ b/sakura_core/util/input.h
@@ -1,4 +1,4 @@
-/*
+Ôªø/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -24,7 +24,7 @@
 #ifndef SAKURA_INPUT_7F979711_2295_4A97_BF62_75F89729717D9_H_
 #define SAKURA_INPUT_7F979711_2295_4A97_BF62_75F89729717D9_H_
 
-//ÉLÅ[ì¸óÕ
+//„Ç≠„ÉºÂÖ•Âäõ
 // novice 2004/10/10
 int getCtrlKeyState();
 

--- a/sakura_core/util/module.cpp
+++ b/sakura_core/util/module.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -29,8 +29,8 @@
 #include <Shlwapi.h>	// 2006.06.17 ryoji
 
 /*! 
-	ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚ğÀsƒtƒ@ƒCƒ‹‚ÌêŠ‚ÉˆÚ“®
-	@date 2010.08.28 Moca V‹Kì¬
+	ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ã®å ´æ‰€ã«ç§»å‹•
+	@date 2010.08.28 Moca æ–°è¦ä½œæˆ
 */
 void ChangeCurrentDirectoryToExeDir()
 {
@@ -40,7 +40,7 @@ void ChangeCurrentDirectoryToExeDir()
 	if( szExeDir[0] ){
 		::SetCurrentDirectory( szExeDir );
 	}else{
-		// ˆÚ“®‚Å‚«‚È‚¢‚Æ‚«‚ÍSYSTEM32(9x‚Å‚ÍSYSTEM)‚ÉˆÚ“®
+		// ç§»å‹•ã§ããªã„ã¨ãã¯SYSTEM32(9xã§ã¯SYSTEM)ã«ç§»å‹•
 		szExeDir[0] = _T('\0');
 		int n = ::GetSystemDirectory( szExeDir, _MAX_PATH );
 		if( n && n < _MAX_PATH ){
@@ -50,23 +50,23 @@ void ChangeCurrentDirectoryToExeDir()
 }
 
 /*! 
-	@date 2010.08.28 Moca V‹Kì¬
+	@date 2010.08.28 Moca æ–°è¦ä½œæˆ
 */
 HMODULE LoadLibraryExedir(LPCTSTR pszDll)
 {
 	CCurrentDirectoryBackupPoint dirBack;
-	// DLL ƒCƒ“ƒWƒFƒNƒVƒ‡ƒ“‘Îô‚Æ‚µ‚ÄEXE‚ÌƒtƒHƒ‹ƒ_‚ÉˆÚ“®‚·‚é
+	// DLL ã‚¤ãƒ³ã‚¸ã‚§ã‚¯ã‚·ãƒ§ãƒ³å¯¾ç­–ã¨ã—ã¦EXEã®ãƒ•ã‚©ãƒ«ãƒ€ã«ç§»å‹•ã™ã‚‹
 	ChangeCurrentDirectoryToExeDir();
 	return ::LoadLibrary( pszDll );
 }
 
-/*!	ƒVƒFƒ‹‚âƒRƒ‚ƒ“ƒRƒ“ƒgƒ[ƒ‹ DLL ‚Ìƒo[ƒWƒ‡ƒ“”Ô†‚ğæ“¾
+/*!	ã‚·ã‚§ãƒ«ã‚„ã‚³ãƒ¢ãƒ³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ« DLL ã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã‚’å–å¾—
 
-	@param[in] lpszDllName DLL ƒtƒ@ƒCƒ‹‚ÌƒpƒX
-	@return DLL ‚Ìƒo[ƒWƒ‡ƒ“”Ô†i¸”s‚Í 0j
+	@param[in] lpszDllName DLL ãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹
+	@return DLL ã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ï¼ˆå¤±æ•—æ™‚ã¯ 0ï¼‰
 
 	@author ? (from MSDN Library document)
-	@date 2006.06.17 ryoji MSDNƒ‰ƒCƒuƒ‰ƒŠ‚©‚çˆø—p
+	@date 2006.06.17 ryoji MSDNãƒ©ã‚¤ãƒ–ãƒ©ãƒªã‹ã‚‰å¼•ç”¨
 */
 DWORD GetDllVersion(LPCTSTR lpszDllName)
 {
@@ -113,31 +113,31 @@ DWORD GetDllVersion(LPCTSTR lpszDllName)
 
 
 /*!
-	@brief ƒAƒvƒŠƒP[ƒVƒ‡ƒ“ƒAƒCƒRƒ“‚Ìæ“¾
+	@brief ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚¢ã‚¤ã‚³ãƒ³ã®å–å¾—
 	
-	ƒAƒCƒRƒ“ƒtƒ@ƒCƒ‹‚ª‘¶İ‚·‚éê‡‚Í‚»‚±‚©‚çC–³‚¢ê‡‚Í
-	ƒŠƒ\[ƒXƒtƒ@ƒCƒ‹‚©‚çæ“¾‚·‚é
+	ã‚¢ã‚¤ã‚³ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«ãŒå­˜åœ¨ã™ã‚‹å ´åˆã¯ãã“ã‹ã‚‰ï¼Œç„¡ã„å ´åˆã¯
+	ãƒªã‚½ãƒ¼ã‚¹ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰å–å¾—ã™ã‚‹
 	
 	@param hInst [in] Instance Handle
-	@param nResource [in] ƒfƒtƒHƒ‹ƒgƒAƒCƒRƒ“—pResource ID
-	@param szFile [in] ƒAƒCƒRƒ“ƒtƒ@ƒCƒ‹–¼
+	@param nResource [in] ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã‚¢ã‚¤ã‚³ãƒ³ç”¨Resource ID
+	@param szFile [in] ã‚¢ã‚¤ã‚³ãƒ³ãƒ•ã‚¡ã‚¤ãƒ«å
 	@param bSmall [in] true: small icon (16x16) / false: large icon (32x32)
 	
-	@return ƒAƒCƒRƒ“ƒnƒ“ƒhƒ‹D¸”s‚µ‚½ê‡‚ÍNULLD
+	@return ã‚¢ã‚¤ã‚³ãƒ³ãƒãƒ³ãƒ‰ãƒ«ï¼å¤±æ•—ã—ãŸå ´åˆã¯NULLï¼
 	
-	@date 2002.12.02 genta V‹Kì¬
-	@date 2007.05.20 ryoji iniƒtƒ@ƒCƒ‹ƒpƒX‚ğ—Dæ
+	@date 2002.12.02 genta æ–°è¦ä½œæˆ
+	@date 2007.05.20 ryoji iniãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 	@author genta
 */
 HICON GetAppIcon( HINSTANCE hInst, int nResource, const TCHAR* szFile, bool bSmall )
 {
-	// ƒTƒCƒY‚Ìİ’è
+	// ã‚µã‚¤ã‚ºã®è¨­å®š
 	int size = ( bSmall ? 16 : 32 );
 
 	TCHAR szPath[_MAX_PATH];
 	HICON hIcon;
 
-	// ƒtƒ@ƒCƒ‹‚©‚ç‚Ì“Ç‚İ‚İ‚ğ‚Ü‚¸‚İ‚é
+	// ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®èª­ã¿è¾¼ã¿ã‚’ã¾ãšè©¦ã¿ã‚‹
 	GetInidirOrExedir( szPath, szFile );
 
 	hIcon = (HICON)::LoadImage(
@@ -152,7 +152,7 @@ HICON GetAppIcon( HINSTANCE hInst, int nResource, const TCHAR* szFile, bool bSma
 		return hIcon;
 	}
 
-	//	ƒtƒ@ƒCƒ‹‚©‚ç‚Ì“Ç‚İ‚İ‚É¸”s‚µ‚½‚çƒŠƒ\[ƒX‚©‚çæ“¾
+	//	ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®èª­ã¿è¾¼ã¿ã«å¤±æ•—ã—ãŸã‚‰ãƒªã‚½ãƒ¼ã‚¹ã‹ã‚‰å–å¾—
 	hIcon = (HICON)::LoadImage(
 		hInst,
 		MAKEINTRESOURCE(nResource),
@@ -178,8 +178,8 @@ struct VS_VERSION_INFO_HEAD {
 	VS_FIXEDFILEINFO Value;
 };
 
-/*! ƒŠƒ\[ƒX‚©‚ç»•iƒo[ƒWƒ‡ƒ“‚Ìæ“¾
-	@date 2004.05.13 Moca ˆê“xæ“¾‚µ‚½‚çƒLƒƒƒbƒVƒ…‚·‚é
+/*! ãƒªã‚½ãƒ¼ã‚¹ã‹ã‚‰è£½å“ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã®å–å¾—
+	@date 2004.05.13 Moca ä¸€åº¦å–å¾—ã—ãŸã‚‰ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã™ã‚‹
 */
 void GetAppVersionInfo(
 	HINSTANCE	hInstance,
@@ -191,7 +191,7 @@ void GetAppVersionInfo(
 	HRSRC					hRSRC;
 	HGLOBAL					hgRSRC;
 	VS_VERSION_INFO_HEAD*	pVVIH;
-	/* ƒŠƒ\[ƒX‚©‚ç»•iƒo[ƒWƒ‡ƒ“‚Ìæ“¾ */
+	/* ãƒªã‚½ãƒ¼ã‚¹ã‹ã‚‰è£½å“ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã®å–å¾— */
 	*pdwProductVersionMS = 0;
 	*pdwProductVersionLS = 0;
 	static bool bLoad = false;

--- a/sakura_core/util/module.h
+++ b/sakura_core/util/module.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -24,15 +24,15 @@
 #ifndef SAKURA_MODULE_4F382EF5_EF52_47E1_A774_5CDFB545AB25_H_
 #define SAKURA_MODULE_4F382EF5_EF52_47E1_A774_5CDFB545AB25_H_
 
-void GetAppVersionInfo( HINSTANCE, int, DWORD*, DWORD* );	/* ƒŠƒ\[ƒX‚©‚ç»•iƒo[ƒWƒ‡ƒ“‚Ìæ“¾ */
+void GetAppVersionInfo( HINSTANCE, int, DWORD*, DWORD* );	/* ãƒªã‚½ãƒ¼ã‚¹ã‹ã‚‰è£½å“ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã®å–å¾— */
 
 HICON GetAppIcon( HINSTANCE hInst, int nResource, const TCHAR* szFile, bool bSmall = false);
 
-DWORD GetDllVersion( LPCTSTR lpszDllName );	// ƒVƒFƒ‹‚âƒRƒ‚ƒ“ƒRƒ“ƒgƒ[ƒ‹ DLL ‚Ìƒo[ƒWƒ‡ƒ“”Ô†‚ğæ“¾	// 2006.06.17 ryoji
+DWORD GetDllVersion( LPCTSTR lpszDllName );	// ã‚·ã‚§ãƒ«ã‚„ã‚³ãƒ¢ãƒ³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ« DLL ã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã‚’å–å¾—	// 2006.06.17 ryoji
 
 void ChangeCurrentDirectoryToExeDir();
 
-//! ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠˆÚ“®‹@”\•tLoadLibrary
+//! ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªç§»å‹•æ©Ÿèƒ½ä»˜LoadLibrary
 HMODULE LoadLibraryExedir( LPCTSTR pszDll);
 
 #endif /* SAKURA_MODULE_4F382EF5_EF52_47E1_A774_5CDFB545AB25_H_ */

--- a/sakura_core/util/ole_convert.cpp
+++ b/sakura_core/util/ole_convert.cpp
@@ -1,16 +1,16 @@
-/*!	@file
-	@brief OLEŒ^iVARIANT, BSTR‚È‚Çj‚Ì•ÏŠ·ŠÖ”
+ï»¿/*!	@file
+	@brief OLEå‹ï¼ˆVARIANT, BSTRãªã©ï¼‰ã®å¤‰æ›é–¢æ•°
 
 */
 #include "StdAfx.h"
 #include "ole_convert.h"
 
-// VARIANT•Ï”‚ğBSTR‚Æ‚İ‚È‚µAwstring‚É•ÏŠ·‚·‚é
-// CMacro::HandleFunction‚ğQl‚Æ‚µ‚½B
+// VARIANTå¤‰æ•°ã‚’BSTRã¨ã¿ãªã—ã€wstringã«å¤‰æ›ã™ã‚‹
+// CMacro::HandleFunctionã‚’å‚è€ƒã¨ã—ãŸã€‚
 bool variant_to_wstr( VARIANT v, std::wstring& wstr )
 {
-	Variant varCopy;	// VT_BYREF‚¾‚Æ¢‚é‚Ì‚ÅƒRƒs[—p
-	if(VariantChangeType(&varCopy.Data, &v, 0, VT_BSTR) != S_OK) return false;	// VT_BSTR‚Æ‚µ‚Ä‰ğß
+	Variant varCopy;	// VT_BYREFã ã¨å›°ã‚‹ã®ã§ã‚³ãƒ”ãƒ¼ç”¨
+	if(VariantChangeType(&varCopy.Data, &v, 0, VT_BSTR) != S_OK) return false;	// VT_BSTRã¨ã—ã¦è§£é‡ˆ
 
 	wchar_t *Source;
 	int SourceLength;
@@ -22,12 +22,12 @@ bool variant_to_wstr( VARIANT v, std::wstring& wstr )
 	return true;
 }
 
-// VARIANT•Ï”‚ğ®”‚Æ‚İ‚È‚µAint‚É•ÏŠ·‚·‚é
-// CMacro::HandleFunction‚ğQl‚Æ‚µ‚½B
+// VARIANTå¤‰æ•°ã‚’æ•´æ•°ã¨ã¿ãªã—ã€intã«å¤‰æ›ã™ã‚‹
+// CMacro::HandleFunctionã‚’å‚è€ƒã¨ã—ãŸã€‚
 bool variant_to_int( VARIANT v, int& n )
 {
-	Variant varCopy;	// VT_BYREF‚¾‚Æ¢‚é‚Ì‚ÅƒRƒs[—p
-	if(VariantChangeType(&varCopy.Data, &v, 0, VT_I4) != S_OK) return false;	// VT_I4‚Æ‚µ‚Ä‰ğß
+	Variant varCopy;	// VT_BYREFã ã¨å›°ã‚‹ã®ã§ã‚³ãƒ”ãƒ¼ç”¨
+	if(VariantChangeType(&varCopy.Data, &v, 0, VT_I4) != S_OK) return false;	// VT_I4ã¨ã—ã¦è§£é‡ˆ
 
 	n = varCopy.Data.lVal;
 	return true;

--- a/sakura_core/util/ole_convert.h
+++ b/sakura_core/util/ole_convert.h
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief OLEŒ^iVARIANT, BSTR‚È‚Çj‚Ì•ÏŠ·ŠÖ”
+ï»¿/*!	@file
+	@brief OLEå‹ï¼ˆVARIANT, BSTRãªã©ï¼‰ã®å¤‰æ›é–¢æ•°
 
 */
 #ifndef SAKURA_OLE_CONVERT_208FE8C1_C742_4ED8_9C9C_25841915706BD_H_
@@ -8,8 +8,8 @@
 #include <string>
 #include "_os/OleTypes.h"
 
-bool variant_to_wstr( VARIANT v, std::wstring& wstr );	// VARIANT•Ï”‚ğBSTR‚Æ‚İ‚È‚µAwstring‚É•ÏŠ·‚·‚é
-bool variant_to_int( VARIANT v, int& n );	// VARIANT•Ï”‚ğ®”‚Æ‚İ‚È‚µAint‚É•ÏŠ·‚·‚é
+bool variant_to_wstr( VARIANT v, std::wstring& wstr );	// VARIANTå¤‰æ•°ã‚’BSTRã¨ã¿ãªã—ã€wstringã«å¤‰æ›ã™ã‚‹
+bool variant_to_int( VARIANT v, int& n );	// VARIANTå¤‰æ•°ã‚’æ•´æ•°ã¨ã¿ãªã—ã€intã«å¤‰æ›ã™ã‚‹
 
 #endif /* SAKURA_OLE_CONVERT_208FE8C1_C742_4ED8_9C9C_25841915706BD_H_ */
 /*[EOF]*/

--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -1,14 +1,14 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "os.h"
 #include "util/module.h"
 #include "extmodule/CUxTheme.h"
 
-/*!	Comctl32.dll �̃o�[�W�����ԍ����擾
+/*!	Comctl32.dll のバージョン番号を取得
 
-	@return Comctl32.dll �̃o�[�W�����ԍ��i���s���� 0�j
+	@return Comctl32.dll のバージョン番号（失敗時は 0）
 
 	@author ryoji
-	@date 2006.06.17 ryoji �V�K
+	@date 2006.06.17 ryoji 新規
 */
 static DWORD s_dwComctl32Version = PACKVERSION(0, 0);
 DWORD GetComctl32Version()
@@ -19,29 +19,29 @@ DWORD GetComctl32Version()
 }
 
 
-/*!	���������݃r�W���A���X�^�C���\����Ԃ��ǂ���������
-	Win32 API �� IsAppThemed() �͂���Ƃ͈�v���Ȃ��iIsAppThemed() �� IsThemeActive() �Ƃ̍��ق͕s���j
+/*!	自分が現在ビジュアルスタイル表示状態かどうかを示す
+	Win32 API の IsAppThemed() はこれとは一致しない（IsAppThemed() と IsThemeActive() との差異は不明）
 
-	@return �r�W���A���X�^�C���\�����(TRUE)�^�N���b�V�b�N�\�����(FALSE)
+	@return ビジュアルスタイル表示状態(TRUE)／クラッシック表示状態(FALSE)
 
 	@author ryoji
-	@date 2006.06.17 ryoji �V�K
+	@date 2006.06.17 ryoji 新規
 */
 BOOL IsVisualStyle()
 {
-	// ���[�h���� Comctl32.dll �� Ver 6 �ȏ�ŉ�ʐݒ肪�r�W���A���X�^�C���w��ɂȂ��Ă���ꍇ����
-	// �r�W���A���X�^�C���\���ɂȂ�i�}�j�t�F�X�g�Ŏw�肵�Ȃ��� Comctl32.dll �� 6 �����ɂȂ�j
+	// ロードした Comctl32.dll が Ver 6 以上で画面設定がビジュアルスタイル指定になっている場合だけ
+	// ビジュアルスタイル表示になる（マニフェストで指定しないと Comctl32.dll は 6 未満になる）
 	return ( (GetComctl32Version() >= PACKVERSION(6, 0)) && CUxTheme::getInstance()->IsThemeActive() );
 }
 
 
 
-/*!	�w��E�B���h�E�Ńr�W���A���X�^�C�����g��Ȃ��悤�ɂ���
+/*!	指定ウィンドウでビジュアルスタイルを使わないようにする
 
-	@param[in] hWnd �E�B���h�E
+	@param[in] hWnd ウィンドウ
 
 	@author ryoji
-	@date 2006.06.23 ryoji �V�K
+	@date 2006.06.23 ryoji 新規
 */
 void PreventVisualStyle( HWND hWnd )
 {
@@ -52,10 +52,10 @@ void PreventVisualStyle( HWND hWnd )
 
 
 
-/*!	�R�����R���g���[��������������
+/*!	コモンコントロールを初期化する
 
 	@author ryoji
-	@date 2006.06.21 ryoji �V�K
+	@date 2006.06.21 ryoji 新規
 */
 void MyInitCommonControls()
 {
@@ -83,24 +83,24 @@ void MyInitCommonControls()
 
 
 /*!
-	�w�肵���E�B���h�E�^�����`�̈�^�_�^���j�^�ɑΉ����郂�j�^��Ɨ̈���擾����
+	指定したウィンドウ／長方形領域／点／モニタに対応するモニタ作業領域を取得する
 
-	���j�^��Ɨ̈�F��ʑS�̂���V�X�e���̃^�X�N�o�[��A�v���P�[�V�����̃c�[���o�[����L����̈���������̈�
+	モニタ作業領域：画面全体からシステムのタスクバーやアプリケーションのツールバーが占有する領域を除いた領域
 
-	@param hWnd/prc/pt/hMon [in] �ړI�̃E�B���h�E�^�����`�̈�^�_�^���j�^
-	@param prcWork [out] ���j�^��Ɨ̈�
-	@param prcMonitor [out] ���j�^��ʑS��
+	@param hWnd/prc/pt/hMon [in] 目的のウィンドウ／長方形領域／点／モニタ
+	@param prcWork [out] モニタ作業領域
+	@param prcMonitor [out] モニタ画面全体
 
-	@retval true �Ή����郂�j�^�̓v���C�}�����j�^
-	@retval false �Ή����郂�j�^�͔�v���C�}�����j�^
+	@retval true 対応するモニタはプライマリモニタ
+	@retval false 対応するモニタは非プライマリモニタ
 
-	@note �o�̓p�����[�^�� prcWork �� prcMonior �� NULL ���w�肵���ꍇ�A
-	�Y������̈���͏o�͂��Ȃ��B�Ăяo�����͗~�������̂������w�肷��΂悢�B
+	@note 出力パラメータの prcWork や prcMonior に NULL を指定した場合、
+	該当する領域情報は出力しない。呼び出し元は欲しいものだけを指定すればよい。
 */
 //	From Here May 01, 2004 genta MutiMonitor
 bool GetMonitorWorkRect(HWND hWnd, LPRECT prcWork, LPRECT prcMonitor/* = NULL*/)
 {
-	// 2006.04.21 ryoji Windows API �`���̊֐��Ăяo���ɕύX�i�X�^�u�� PSDK �� MultiMon.h �𗘗p�j
+	// 2006.04.21 ryoji Windows API 形式の関数呼び出しに変更（スタブに PSDK の MultiMon.h を利用）
 	HMONITOR hMon = ::MonitorFromWindow( hWnd, MONITOR_DEFAULTTONEAREST );
 	return GetMonitorWorkRect( hMon, prcWork, prcMonitor );
 }
@@ -137,19 +137,19 @@ bool GetMonitorWorkRect(HMONITOR hMon, LPRECT prcWork, LPRECT prcMonitor/* = NUL
 
 
 /*!
-	@brief ���W�X�g�����當�����ǂݏo���D
+	@brief レジストリから文字列を読み出す．
 	
 	@param Hive        [in]  HIVE
-	@param Path        [in]  ���W�X�g���L�[�ւ̃p�X
-	@param Item        [in]  ���W�X�g���A�C�e�����DNULL�ŕW���̃A�C�e���D
-	@param Buffer      [out] �擾��������i�[����ꏊ
-	@param BufferCount [in]  Buffer�̎w���̈�̃T�C�Y�B�����P�ʁB
+	@param Path        [in]  レジストリキーへのパス
+	@param Item        [in]  レジストリアイテム名．NULLで標準のアイテム．
+	@param Buffer      [out] 取得文字列を格納する場所
+	@param BufferCount [in]  Bufferの指す領域のサイズ。文字単位。
 	
-	@retval true �l�̎擾�ɐ���
-	@retval false �l�̎擾�Ɏ��s
+	@retval true 値の取得に成功
+	@retval false 値の取得に失敗
 	
-	@author �S
-	@date 2002.09.10 genta CWSH.cpp����ړ�
+	@author 鬼
+	@date 2002.09.10 genta CWSH.cppから移動
 */
 bool ReadRegistry(HKEY Hive, const TCHAR* Path, const TCHAR* Item, TCHAR* Buffer, unsigned BufferCount)
 {
@@ -161,7 +161,7 @@ bool ReadRegistry(HKEY Hive, const TCHAR* Path, const TCHAR* Item, TCHAR* Buffer
 		auto_memset(Buffer, 0, BufferCount);
 
 		DWORD dwType = REG_SZ;
-		DWORD dwDataLen = (BufferCount - 1) * sizeof(TCHAR); //���o�C�g�P�ʁI
+		DWORD dwDataLen = (BufferCount - 1) * sizeof(TCHAR); //※バイト単位！
 		
 		Result = (RegQueryValueEx(Key, Item, NULL, &dwType, reinterpret_cast<LPBYTE>(Buffer), &dwDataLen) == ERROR_SUCCESS);
 		
@@ -172,20 +172,20 @@ bool ReadRegistry(HKEY Hive, const TCHAR* Path, const TCHAR* Item, TCHAR* Buffer
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      �N���b�v�{�[�h                         //
+//                      クリップボード                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//SetClipboardTextA,SetClipboardTextT �����p�e���v���[�g
-//2007.08.14 kobake UNICODE�p�ɉ���
+//SetClipboardTextA,SetClipboardTextT 実装用テンプレート
+//2007.08.14 kobake UNICODE用に改造
 //
-/*! �N���[�v�{�[�h��Text�`���ŃR�s�[����
-	@param hwnd    [in] �N���b�v�{�[�h�̃I�[�i�[
-	@param pszText [in] �ݒ肷��e�L�X�g
-	@param nLength [in] �L���ȃe�L�X�g�̒����B�����P�ʁB
+/*! クリープボードにText形式でコピーする
+	@param hwnd    [in] クリップボードのオーナー
+	@param pszText [in] 設定するテキスト
+	@param nLength [in] 有効なテキストの長さ。文字単位。
 	
-	@retval true �R�s�[����
-	@retval false �R�s�[���s�B�ꍇ�ɂ���Ă̓N���b�v�{�[�h�Ɍ��̓��e���c��
-	@date 2004.02.17 Moca �e���̃\�[�X�𓝍�
+	@retval true コピー成功
+	@retval false コピー失敗。場合によってはクリップボードに元の内容が残る
+	@date 2004.02.17 Moca 各所のソースを統合
 */
 template <class T>
 bool SetClipboardTextImp( HWND hwnd, const T* pszText, int nLength )
@@ -217,7 +217,7 @@ bool SetClipboardTextImp( HWND hwnd, const T* pszText, int nLength )
 		::SetClipboardData( CF_UNICODETEXT, hgClip );
 	}
 	else{
-		assert(0); //�������ɂ͗��Ȃ�
+		assert(0); //※ここには来ない
 	}
 	::CloseClipboard();
 
@@ -235,21 +235,21 @@ bool SetClipboardText( HWND hwnd, const WCHAR* pszText, int nLength )
 }
 
 /*
-	@date 2006.01.16 Moca ����TYMED�����p�\�ł��A�擾�ł���悤�ɕύX�B
-	@note IDataObject::GetData() �� tymed = TYMED_HGLOBAL ���w�肷�邱�ƁB
+	@date 2006.01.16 Moca 他のTYMEDが利用可能でも、取得できるように変更。
+	@note IDataObject::GetData() で tymed = TYMED_HGLOBAL を指定すること。
 */
 BOOL IsDataAvailable( LPDATAOBJECT pDataObject, CLIPFORMAT cfFormat )
 {
 	FORMATETC	fe;
 
-	// 2006.01.16 Moca ����TYMED�����p�\�ł��AIDataObject::GetData()��
-	//  tymed = TYMED_HGLOBAL���w�肷��Ζ��Ȃ�
+	// 2006.01.16 Moca 他のTYMEDが利用可能でも、IDataObject::GetData()で
+	//  tymed = TYMED_HGLOBALを指定すれば問題ない
 	fe.cfFormat = cfFormat;
 	fe.ptd = NULL;
 	fe.dwAspect = DVASPECT_CONTENT;
 	fe.lindex = -1;
 	fe.tymed = TYMED_HGLOBAL;
-	// 2006.03.16 Moca S_FALSE�ł��󂯓���Ă��܂��o�O���C��(�t�@�C���̃h���b�v��)
+	// 2006.03.16 Moca S_FALSEでも受け入れてしまうバグを修正(ファイルのドロップ等)
 	return S_OK == pDataObject->QueryGetData( &fe );
 }
 
@@ -260,12 +260,12 @@ HGLOBAL GetGlobalData( LPDATAOBJECT pDataObject, CLIPFORMAT cfFormat )
 	fe.ptd = NULL;
 	fe.dwAspect = DVASPECT_CONTENT;
 	fe.lindex = -1;
-	// 2006.01.16 Moca fe.tymed = -1����TYMED_HGLOBAL�ɕύX�B
+	// 2006.01.16 Moca fe.tymed = -1からTYMED_HGLOBALに変更。
 	fe.tymed = TYMED_HGLOBAL;
 
 	HGLOBAL hDest = NULL;
 	STGMEDIUM stgMedium;
-	// 2006.03.16 Moca SUCCEEDED�}�N���ł�S_FALSE�̂Ƃ�����̂ŁAS_OK�ɕύX
+	// 2006.03.16 Moca SUCCEEDEDマクロではS_FALSEのとき困るので、S_OKに変更
 	if( S_OK == pDataObject->GetData( &fe, &stgMedium ) ){
 		if( stgMedium.pUnkForRelease == NULL ){
 			if( stgMedium.tymed == TYMED_HGLOBAL )
@@ -291,15 +291,15 @@ HGLOBAL GetGlobalData( LPDATAOBJECT pDataObject, CLIPFORMAT cfFormat )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       �V�X�e������                          //
+//                       システム資源                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/* �V�X�e�����\�[�X�𒲂ׂ�
-	Win16 �̎��́AGetFreeSystemResources �Ƃ����֐�������܂����B�������AWin32 �ł͂���܂���B
-	�T���N����邾�� DLL ����邾�͓̂�����܂��B�ȒP�ȕ��@��������܂��B
-	���g���� Windows95 �� [�A�N�Z�T��]-[�V�X�e���c�[��] �Ƀ��\�[�X���[�^������̂Ȃ�A
-	c:\windows\system\rsrc32.dll ������͂��ł��B����́A���\�[�X���[�^�Ƃ��� Win32 �A�v�����A
-	Win16 �� GetFreeSystemResources �֐����ĂԈׂ� DLL �ł��B������g���܂��傤�B
+/* システムリソースを調べる
+	Win16 の時は、GetFreeSystemResources という関数がありました。しかし、Win32 ではありません。
+	サンクを作るだの DLL を作るだのは難しすぎます。簡単な方法を説明します。
+	お使いの Windows95 の [アクセサリ]-[システムツール] にリソースメータがあるのなら、
+	c:\windows\system\rsrc32.dll があるはずです。これは、リソースメータという Win32 アプリが、
+	Win16 の GetFreeSystemResources 関数を呼ぶ為の DLL です。これを使いましょう。
 */
 BOOL GetSystemResources(
 	int*	pnSystemResources,
@@ -336,25 +336,25 @@ BOOL GetSystemResources(
 
 
 #if (WINVER < _WIN32_WINNT_WIN2K)
-// NT�ł̓��\�[�X�`�F�b�N���s��Ȃ�
-/* �V�X�e�����\�[�X�̃`�F�b�N */
+// NTではリソースチェックを行わない
+/* システムリソースのチェック */
 BOOL CheckSystemResources( const TCHAR* pszAppName )
 {
 	int		nSystemResources;
 	int		nUserResources;
 	int		nGDIResources;
 	const TCHAR*	pszResourceName;
-	/* �V�X�e�����\�[�X�̎擾 */
+	/* システムリソースの取得 */
 	if( GetSystemResources( &nSystemResources, &nUserResources,	&nGDIResources ) ){
 //		MYTRACE( _T("nSystemResources=%d\n"), nSystemResources );
 //		MYTRACE( _T("nUserResources=%d\n"), nUserResources );
 //		MYTRACE( _T("nGDIResources=%d\n"), nGDIResources );
 		pszResourceName = NULL;
 		if( nSystemResources <= 5 ){
-			pszResourceName = _T("�V�X�e�� ");
+			pszResourceName = _T("システム ");
 		}else
 		if( nUserResources <= 5 ){
-			pszResourceName = _T("���[�U�[ ");
+			pszResourceName = _T("ユーザー ");
 		}else
 		if( nGDIResources <= 5 ){
 			pszResourceName = _T("GDI ");
@@ -363,13 +363,13 @@ BOOL CheckSystemResources( const TCHAR* pszAppName )
 			ErrorBeep();
 			ErrorBeep();
 			::MYMESSAGEBOX( NULL, MB_OK | /*MB_YESNO | */ MB_ICONSTOP | MB_APPLMODAL | MB_TOPMOST, pszAppName,
-				_T("%ts���\�[�X���ɒ[�ɕs�����Ă��܂��B\n")
-				_T("���̂܂�%ts���N������ƁA����ɓ��삵�Ȃ��\��������܂��B\n")
-				_T("�V����%ts�̋N���𒆒f���܂��B\n")
+				_T("%tsリソースが極端に不足しています。\n")
+				_T("このまま%tsを起動すると、正常に動作しない可能性があります。\n")
+				_T("新しい%tsの起動を中断します。\n")
 				_T("\n")
-				_T("�V�X�e�� ���\�[�X\t�c��  %d%%\n")
-				_T("User ���\�[�X\t�c��  %d%%\n")
-				_T("GDI ���\�[�X\t�c��  %d%%\n\n"),
+				_T("システム リソース\t残り  %d%%\n")
+				_T("User リソース\t残り  %d%%\n")
+				_T("GDI リソース\t残り  %d%%\n\n"),
 				pszResourceName,
 				pszAppName,
 				pszAppName,
@@ -388,10 +388,10 @@ BOOL CheckSystemResources( const TCHAR* pszAppName )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        �֗��N���X                           //
+//                        便利クラス                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//�R���X�g���N�^�ŃJ�����g�f�B���N�g����ۑ����A�f�X�g���N�^�ŃJ�����g�f�B���N�g���𕜌����郂�m�B
+//コンストラクタでカレントディレクトリを保存し、デストラクタでカレントディレクトリを復元するモノ。
 
 CCurrentDirectoryBackupPoint::CCurrentDirectoryBackupPoint()
 {

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -27,21 +27,21 @@
 #include <ObjIdl.h> // LPDATAOBJECT
 
 
-//ƒVƒXƒeƒ€‘Œ¹
-BOOL GetSystemResources( int*, int*, int* );	/* ƒVƒXƒeƒ€ƒŠƒ\[ƒX‚ğ’²‚×‚é */
-BOOL CheckSystemResources( const TCHAR* );	/* ƒVƒXƒeƒ€ƒŠƒ\[ƒX‚Ìƒ`ƒFƒbƒN */
+//ã‚·ã‚¹ãƒ†ãƒ è³‡æº
+BOOL GetSystemResources( int*, int*, int* );	/* ã‚·ã‚¹ãƒ†ãƒ ãƒªã‚½ãƒ¼ã‚¹ã‚’èª¿ã¹ã‚‹ */
+BOOL CheckSystemResources( const TCHAR* );	/* ã‚·ã‚¹ãƒ†ãƒ ãƒªã‚½ãƒ¼ã‚¹ã®ãƒã‚§ãƒƒã‚¯ */
 
-//ƒNƒŠƒbƒvƒ{[ƒh
-bool SetClipboardText( HWND hwnd, const ACHAR* pszText, int nLength );    //!< ƒNƒŠ[ƒvƒ{[ƒh‚ÉTextŒ`®‚ÅƒRƒs[‚·‚éBANSI”ÅBnLength‚Í•¶š’PˆÊB
-bool SetClipboardText( HWND hwnd, const WCHAR* pszText, int nLength ); //!< ƒNƒŠ[ƒvƒ{[ƒh‚ÉTextŒ`®‚ÅƒRƒs[‚·‚éBUNICODE”ÅBnLength‚Í•¶š’PˆÊB
+//ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰
+bool SetClipboardText( HWND hwnd, const ACHAR* pszText, int nLength );    //!< ã‚¯ãƒªãƒ¼ãƒ—ãƒœãƒ¼ãƒ‰ã«Textå½¢å¼ã§ã‚³ãƒ”ãƒ¼ã™ã‚‹ã€‚ANSIç‰ˆã€‚nLengthã¯æ–‡å­—å˜ä½ã€‚
+bool SetClipboardText( HWND hwnd, const WCHAR* pszText, int nLength ); //!< ã‚¯ãƒªãƒ¼ãƒ—ãƒœãƒ¼ãƒ‰ã«Textå½¢å¼ã§ã‚³ãƒ”ãƒ¼ã™ã‚‹ã€‚UNICODEç‰ˆã€‚nLengthã¯æ–‡å­—å˜ä½ã€‚
 BOOL IsDataAvailable( LPDATAOBJECT pDataObject, CLIPFORMAT cfFormat );
 HGLOBAL GetGlobalData( LPDATAOBJECT pDataObject, CLIPFORMAT cfFormat );
 
-//	Sep. 10, 2002 genta CWSH.cpp‚©‚ç‚ÌˆÚ“®‚É”º‚¤’Ç‰Á
+//	Sep. 10, 2002 genta CWSH.cppã‹ã‚‰ã®ç§»å‹•ã«ä¼´ã†è¿½åŠ 
 bool ReadRegistry(HKEY Hive, const TCHAR* Path, const TCHAR* Item, TCHAR* Buffer, unsigned BufferCount);
 
-//	May 01, 2004 genta ƒ}ƒ‹ƒ`ƒ‚ƒjƒ^‘Î‰‚ÌƒfƒXƒNƒgƒbƒv—Ìˆææ“¾
-bool GetMonitorWorkRect(HWND     hWnd, LPRECT prcWork, LPRECT prcMonitor = NULL);	// 2006.04.21 ryoji ƒpƒ‰ƒ[ƒ^ prcMonitor ‚ğ’Ç‰Á
+//	May 01, 2004 genta ãƒãƒ«ãƒãƒ¢ãƒ‹ã‚¿å¯¾å¿œã®ãƒ‡ã‚¹ã‚¯ãƒˆãƒƒãƒ—é ˜åŸŸå–å¾—
+bool GetMonitorWorkRect(HWND     hWnd, LPRECT prcWork, LPRECT prcMonitor = NULL);	// 2006.04.21 ryoji ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ prcMonitor ã‚’è¿½åŠ 
 bool GetMonitorWorkRect(LPCRECT  prc,  LPRECT prcWork, LPRECT prcMonitor = NULL);	// 2006.04.21 ryoji
 bool GetMonitorWorkRect(POINT    pt,   LPRECT prcWork, LPRECT prcMonitor = NULL);	// 2006.04.21 ryoji
 bool GetMonitorWorkRect(HMONITOR hMon, LPRECT prcWork, LPRECT prcMonitor = NULL);	// 2006.04.21 ryoji
@@ -49,15 +49,15 @@ bool GetMonitorWorkRect(HMONITOR hMon, LPRECT prcWork, LPRECT prcMonitor = NULL)
 
 // 2006.06.17 ryoji
 #define PACKVERSION( major, minor ) MAKELONG( minor, major )
-DWORD GetComctl32Version();					// Comctl32.dll ‚Ìƒo[ƒWƒ‡ƒ“”Ô†‚ğæ“¾						// 2006.06.17 ryoji
-BOOL IsVisualStyle();						// ©•ª‚ªŒ»İƒrƒWƒ…ƒAƒ‹ƒXƒ^ƒCƒ‹•\¦ó‘Ô‚©‚Ç‚¤‚©‚ğ¦‚·		// 2006.06.17 ryoji
-void PreventVisualStyle( HWND hWnd );		// w’èƒEƒBƒ“ƒhƒE‚ÅƒrƒWƒ…ƒAƒ‹ƒXƒ^ƒCƒ‹‚ğg‚í‚È‚¢‚æ‚¤‚É‚·‚é	// 2006.06.23 ryoji
-void MyInitCommonControls();				// ƒRƒ‚ƒ“ƒRƒ“ƒgƒ[ƒ‹‚ğ‰Šú‰»‚·‚é							// 2006.06.21 ryoji
+DWORD GetComctl32Version();					// Comctl32.dll ã®ãƒãƒ¼ã‚¸ãƒ§ãƒ³ç•ªå·ã‚’å–å¾—						// 2006.06.17 ryoji
+BOOL IsVisualStyle();						// è‡ªåˆ†ãŒç¾åœ¨ãƒ“ã‚¸ãƒ¥ã‚¢ãƒ«ã‚¹ã‚¿ã‚¤ãƒ«è¡¨ç¤ºçŠ¶æ…‹ã‹ã©ã†ã‹ã‚’ç¤ºã™		// 2006.06.17 ryoji
+void PreventVisualStyle( HWND hWnd );		// æŒ‡å®šã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã§ãƒ“ã‚¸ãƒ¥ã‚¢ãƒ«ã‚¹ã‚¿ã‚¤ãƒ«ã‚’ä½¿ã‚ãªã„ã‚ˆã†ã«ã™ã‚‹	// 2006.06.23 ryoji
+void MyInitCommonControls();				// ã‚³ãƒ¢ãƒ³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚’åˆæœŸåŒ–ã™ã‚‹							// 2006.06.21 ryoji
 
 
-//ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠƒ†[ƒeƒBƒŠƒeƒBB
-//ƒRƒ“ƒXƒgƒ‰ƒNƒ^‚ÅƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚ğ•Û‘¶‚µAƒfƒXƒgƒ‰ƒNƒ^‚ÅƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚ğ•œŒ³‚·‚éƒ‚ƒmB
-//2008.03.01 kobake ì¬
+//ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªãƒ¦ãƒ¼ãƒ†ã‚£ãƒªãƒ†ã‚£ã€‚
+//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã§ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’ä¿å­˜ã—ã€ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã§ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’å¾©å…ƒã™ã‚‹ãƒ¢ãƒã€‚
+//2008.03.01 kobake ä½œæˆ
 class CCurrentDirectoryBackupPoint{
 public:
 	CCurrentDirectoryBackupPoint();
@@ -69,15 +69,15 @@ private:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      ƒƒbƒZ[ƒW’è”                         //
+//                      ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å®šæ•°                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-// -- -- ƒ}ƒEƒX -- -- //
+// -- -- ãƒã‚¦ã‚¹ -- -- //
 
 #ifndef WM_MOUSEWHEEL
 	#define WM_MOUSEWHEEL	0x020A
 #endif
-// novice 2004/10/10 ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“‘Î‰
+// novice 2004/10/10 ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³å¯¾å¿œ
 #ifndef WM_XBUTTONDOWN
 	#define WM_XBUTTONDOWN   0x020B
 	#define WM_XBUTTONUP     0x020C
@@ -89,7 +89,7 @@ private:
 #endif
 
 
-// -- -- ƒe[ƒ} -- -- //
+// -- -- ãƒ†ãƒ¼ãƒ -- -- //
 
 // 2006.06.17 ryoji WM_THEMECHANGED
 #ifndef	WM_THEMECHANGED
@@ -103,7 +103,7 @@ private:
 #define IMR_RECONVERTSTRING             0x0004
 #endif // IMR_RECONVERTSTRING
 
-/* 2002.04.09 minfu Ä•ÏŠ·’²® */
+/* 2002.04.09 minfu å†å¤‰æ›èª¿æ•´ */
 #ifndef IMR_CONFIRMRECONVERTSTRING
 #define IMR_CONFIRMRECONVERTSTRING             0x0005
 #endif // IMR_CONFIRMRECONVERTSTRING

--- a/sakura_core/util/other_util.cpp
+++ b/sakura_core/util/other_util.cpp
@@ -1,2 +1,2 @@
-#include "StdAfx.h"
+﻿#include "StdAfx.h"
 #include "other_util.h"

--- a/sakura_core/util/other_util.h
+++ b/sakura_core/util/other_util.h
@@ -1,7 +1,7 @@
-/*
+ï»¿/*
 	2007.11.29 kobake
 
-	–¢•ª—Ş¬•¨—Ş
+	æœªåˆ†é¡å°ç‰©é¡
 */
 /*
 	Copyright (C) 2008, kobake
@@ -30,24 +30,24 @@
 #define SAKURA_OTHER_UTIL_F0E0EBE0_94B6_4E28_8241_6D842C0E8B73_H_
 
 /*!
-	auto_ptr ‚Ì ”z—ñ”Å
+	auto_ptr ã® é…åˆ—ç‰ˆ
 
-	2007.11.29 kobake ì¬
+	2007.11.29 kobake ä½œæˆ
 */
 template <class T> class auto_array_ptr{
 private:
 	typedef auto_array_ptr<T> Me;
 public:
-	//‘ã“ü
+	//ä»£å…¥
 	auto_array_ptr (T*  rhs){ m_array = rhs;          }
 	auto_array_ptr (Me& rhs){ m_array = rhs.detach(); }
 	Me& operator = (T*  rhs){ reset(rhs         ); return *this; }
 	Me& operator = (Me& rhs){ reset(rhs.detach()); return *this; }
 
-	//”jŠü
+	//ç ´æ£„
 	~auto_array_ptr(){ delete[] m_array; }
 
-	//è•ú‚· (‰ğ•ú‚Í‚µ‚È‚¢)
+	//æ‰‹æ”¾ã™ (è§£æ”¾ã¯ã—ãªã„)
 	T* detach()
 	{
 		T* p = m_array;
@@ -55,7 +55,7 @@ public:
 		return p;
 	}
 
-	//•Û’l‚ğ•ÏX‚·‚é
+	//ä¿æŒå€¤ã‚’å¤‰æ›´ã™ã‚‹
 	void reset(T* p)
 	{
 		if(m_array==p)return;
@@ -63,10 +63,10 @@ public:
 		m_array = p;
 	}
 
-	//•Û’l‚ÉƒAƒNƒZƒX
+	//ä¿æŒå€¤ã«ã‚¢ã‚¯ã‚»ã‚¹
 	T* get(){ return m_array; }
 
-	//”z—ñ—v‘f‚ÉƒAƒNƒZƒX
+	//é…åˆ—è¦ç´ ã«ã‚¢ã‚¯ã‚»ã‚¹
 	T& operator[](int i){ return m_array[i]; }
 
 private:

--- a/sakura_core/util/relation_tool.cpp
+++ b/sakura_core/util/relation_tool.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "relation_tool.h"
 
 
@@ -12,7 +12,7 @@ CSubject::CSubject()
 
 CSubject::~CSubject()
 {
-	//ƒŠƒXƒi‚ğ‰ğœ
+	//ãƒªã‚¹ãƒŠã‚’è§£é™¤
 	for(int i=0;i<(int)m_vListenersRef.size();i++){
 		m_vListenersRef[i]->Listen(NULL);
 	}
@@ -21,19 +21,19 @@ CSubject::~CSubject()
 
 void CSubject::_AddListener(CListener* pcListener)
 {
-	//Šù‚É’Ç‰ÁÏ‚İ‚È‚ç‰½‚à‚µ‚È‚¢
+	//æ—¢ã«è¿½åŠ æ¸ˆã¿ãªã‚‰ä½•ã‚‚ã—ãªã„
 	for(int i=0;i<(int)m_vListenersRef.size();i++){
 		if(m_vListenersRef[i]==pcListener){
 			return;
 		}
 	}
-	//’Ç‰Á
+	//è¿½åŠ 
 	m_vListenersRef.push_back(pcListener);
 }
 
 void CSubject::_RemoveListener(CListener* pcListener)
 {
-	//”z—ñ‚©‚çíœ
+	//é…åˆ—ã‹ã‚‰å‰Šé™¤
 	for(int i=0;i<(int)m_vListenersRef.size();i++){
 		if(m_vListenersRef[i]==pcListener){
 			m_vListenersRef.erase(m_vListenersRef.begin()+i);
@@ -60,13 +60,13 @@ CSubject* CListener::Listen(CSubject* pcSubject)
 {
 	CSubject* pOld = GetListeningSubject();
 
-	//ŒÃ‚¢ƒTƒuƒWƒFƒNƒg‚ğ‰ğœ
+	//å¤ã„ã‚µãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’è§£é™¤
 	if(m_pcSubjectRef){
 		m_pcSubjectRef->_RemoveListener(this);
 		m_pcSubjectRef = NULL;
 	}
 
-	//V‚µ‚­İ’è
+	//æ–°ã—ãè¨­å®š
 	m_pcSubjectRef = pcSubject;
 	if(m_pcSubjectRef){
 		m_pcSubjectRef->_AddListener(this);

--- a/sakura_core/util/relation_tool.h
+++ b/sakura_core/util/relation_tool.h
@@ -1,5 +1,5 @@
-/*
-	ŠÖ˜A‚ÌŠÇ—
+ï»¿/*
+	é–¢é€£ã®ç®¡ç†
 */
 /*
 	Copyright (C) 2008, kobake
@@ -31,19 +31,19 @@
 class CSubject;
 class CListener;
 
-//! •¡”‚ÌCListener‚©‚çƒEƒHƒbƒ`‚³‚ê‚é
+//! è¤‡æ•°ã®CListenerã‹ã‚‰ã‚¦ã‚©ãƒƒãƒã•ã‚Œã‚‹
 class CSubject{
 public:
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^
+	//ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
 	CSubject();
 	virtual ~CSubject();
 
-	//ŒöŠJƒCƒ“ƒ^[ƒtƒF[ƒX
+	//å…¬é–‹ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 	int GetListenerCount() const{ return (int)m_vListenersRef.size(); }
 	CListener* GetListener(int nIndex) const{ return m_vListenersRef[nIndex]; }
 
 public:
-	//ŠÇ——p
+	//ç®¡ç†ç”¨
 	void _AddListener(CListener* pcListener);
 	void _RemoveListener(CListener* pcListener);
 
@@ -51,14 +51,14 @@ private:
 	std::vector<CListener*> m_vListenersRef;
 };
 
-//! 1‚Â‚ÌCSubject‚ğƒEƒHƒbƒ`‚·‚é
+//! 1ã¤ã®CSubjectã‚’ã‚¦ã‚©ãƒƒãƒã™ã‚‹
 class CListener{
 public:
 	CListener();
 	virtual ~CListener();
 
-	//ŒöŠJƒCƒ“ƒ^[ƒtƒF[ƒX
-	CSubject* Listen(CSubject* pcSubject); //!< ’¼‘O‚ÉƒEƒHƒbƒ`‚µ‚Ä‚¢‚½ƒTƒuƒWƒFƒNƒg‚ğ•Ô‚·
+	//å…¬é–‹ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
+	CSubject* Listen(CSubject* pcSubject); //!< ç›´å‰ã«ã‚¦ã‚©ãƒƒãƒã—ã¦ã„ãŸã‚µãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’è¿”ã™
 	CSubject* GetListeningSubject() const{ return m_pcSubjectRef; }
 
 private:

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@
 #include <HtmlHelp.h>
 #include <ShlObj.h>
 #include <ShellAPI.h>
-#include <CdErr.h> // Nov. 3, 2005 genta	//CDERR_FINDRESFAILURE��
+#include <CdErr.h> // Nov. 3, 2005 genta	//CDERR_FINDRESFAILURE等
 #include "util/shell.h"
 #include "util/string_ex2.h"
 #include "util/file.h"
@@ -56,21 +56,21 @@ int CALLBACK MYBrowseCallbackProc(
 }
 
 
-/* �t�H���_�I���_�C�A���O */
+/* フォルダ選択ダイアログ */
 BOOL SelectDir( HWND hWnd, const TCHAR* pszTitle, const TCHAR* pszInitFolder, TCHAR* strFolderName )
 {
 	BOOL	bRes;
 	TCHAR	szInitFolder[MAX_PATH];
 
 	_tcscpy( szInitFolder, pszInitFolder );
-	/* �t�H���_�̍Ōオ���p����'\\'�̏ꍇ�́A��菜�� "c:\\"���̃��[�g�͎�菜���Ȃ�*/
+	/* フォルダの最後が半角かつ'\\'の場合は、取り除く "c:\\"等のルートは取り除かない*/
 	CutLastYenFromDirectoryPath( szInitFolder );
 
-	// 2010.08.28 �t�H���_���J���ƃt�b�N���܂߂ĐF�XDLL���ǂݍ��܂��̂ňړ�
+	// 2010.08.28 フォルダを開くとフックも含めて色々DLLが読み込まれるので移動
 	CCurrentDirectoryBackupPoint dirBack;
 	ChangeCurrentDirectoryToExeDir();
 
-	// SHBrowseForFolder()�֐��ɓn���\����
+	// SHBrowseForFolder()関数に渡す構造体
 	BROWSEINFO bi;
 	bi.hwndOwner = hWnd;
 	bi.pidlRoot = NULL;
@@ -80,13 +80,13 @@ BOOL SelectDir( HWND hWnd, const TCHAR* pszTitle, const TCHAR* pszInitFolder, TC
 	bi.lpfn = MYBrowseCallbackProc;
 	bi.lParam = (LPARAM)szInitFolder;
 	bi.iImage = 0;
-	// �A�C�e���h�c���X�g��Ԃ�
-	// ITEMIDLIST�̓A�C�e���̈�ӂ�\���\����
+	// アイテムＩＤリストを返す
+	// ITEMIDLISTはアイテムの一意を表す構造体
 	LPITEMIDLIST pList = ::SHBrowseForFolder(&bi);
 	if( NULL != pList ){
-		// SHGetPathFromIDList()�֐��̓A�C�e���h�c���X�g�̕����p�X��T���Ă����
+		// SHGetPathFromIDList()関数はアイテムＩＤリストの物理パスを探してくれる
 		bRes = ::SHGetPathFromIDList( pList, strFolderName );
-		// :SHBrowseForFolder()�Ŏ擾�����A�C�e���h�c���X�g���폜
+		// :SHBrowseForFolder()で取得したアイテムＩＤリストを削除
 		::CoTaskMemFree( pList );
 		if( bRes ){
 			return TRUE;
@@ -99,17 +99,17 @@ BOOL SelectDir( HWND hWnd, const TCHAR* pszTitle, const TCHAR* pszInitFolder, TC
 
 
 
-/*!	����t�H���_�̃p�X���擾����
-	SHGetSpecialFolderPath API�ishell32.dll version 4.71�ȏオ�K�v�j�Ɠ����̏���������
+/*!	特殊フォルダのパスを取得する
+	SHGetSpecialFolderPath API（shell32.dll version 4.71以上が必要）と同等の処理をする
 
 	@param [in] nFolder CSIDL (constant special item ID list)
-	@param [out] pszPath ����t�H���_�̃p�X
+	@param [out] pszPath 特殊フォルダのパス
 
 	@author ryoji
-	@date 2007.05.19 �V�K
-	@date 2017.06.24 novice SHGetFolderLocation()�ɕύX
+	@date 2007.05.19 新規
+	@date 2017.06.24 novice SHGetFolderLocation()に変更
 
-	@note SHGetFolderLocation()�́Ashell32.dll version 5.00�ȏオ�K�v
+	@note SHGetFolderLocation()は、shell32.dll version 5.00以上が必要
 */
 BOOL GetSpecialFolderPath( int nFolder, LPTSTR pszPath )
 {
@@ -145,19 +145,19 @@ BOOL GetSpecialFolderPath( int nFolder, LPTSTR pszPath )
 
 
 ///////////////////////////////////////////////////////////////////////
-// From Here 2007.05.25 ryoji �Ǝ��g���̃v���p�e�B�V�[�g�֐��Q
+// From Here 2007.05.25 ryoji 独自拡張のプロパティシート関数群
 
-static WNDPROC s_pOldPropSheetWndProc;	// �v���p�e�B�V�[�g�̌��̃E�B���h�E�v���V�[�W��
+static WNDPROC s_pOldPropSheetWndProc;	// プロパティシートの元のウィンドウプロシージャ
 
-/*!	�Ǝ��g���v���p�e�B�V�[�g�̃E�B���h�E�v���V�[�W��
+/*!	独自拡張プロパティシートのウィンドウプロシージャ
 	@author ryoji
-	@date 2007.05.25 �V�K
+	@date 2007.05.25 新規
 */
 static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	switch( uMsg ){
 	case WM_SHOWWINDOW:
-		// �ǉ��{�^���̈ʒu�𒲐�����
+		// 追加ボタンの位置を調整する
 		if( wParam ){
 			HWND hwndBtn;
 			RECT rcOk;
@@ -175,17 +175,17 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 		break;
 
 	case WM_COMMAND:
-		// �ǉ��{�^���������ꂽ���͂��̏������s��
+		// 追加ボタンが押された時はその処理を行う
 		if( HIWORD( wParam ) == BN_CLICKED && LOWORD( wParam ) == 0x02000 ){
 			HWND hwndBtn = ::GetDlgItem( hwnd, 0x2000 );
 			RECT rc;
 			POINT pt;
 
-			// ���j���[��\������
+			// メニューを表示する
 			::GetWindowRect( hwndBtn, &rc );
 			pt.x = rc.left;
 			pt.y = rc.bottom;
-			GetMonitorWorkRect( pt, &rc );	// ���j�^�̃��[�N�G���A
+			GetMonitorWorkRect( pt, &rc );	// モニタのワークエリア
 
 			HMENU hMenu = ::CreatePopupMenu();
 			::InsertMenu( hMenu, 0, MF_BYPOSITION | MF_STRING, 100, LS(STR_SHELL_MENU_OPEN) );
@@ -197,17 +197,17 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 										0, hwnd, NULL );
 			::DestroyMenu( hMenu );
 
-			// �I�����ꂽ���j���[�̏���
+			// 選択されたメニューの処理
 			switch( nId ){
-			case 100:	// �ݒ�t�H���_���J��
+			case 100:	// 設定フォルダを開く
 				TCHAR szPath[_MAX_PATH];
 				GetInidir( szPath );
 
-				// �t�H���_�� ITEMIDLIST ���擾���� ShellExecuteEx() �ŊJ��
-				// Note. MSDN �� ShellExecute() �̉���ɂ�����@�Ńt�H���_���J�����Ƃ����ꍇ�A
-				//       �t�H���_�Ɠ����ꏊ�� <�t�H���_��>.exe ������Ƃ��܂������Ȃ��B
-				//       verb��"open"��NULL�ł�exe�̂ق������s����"explore"�ł͎��s����
-				//       �i�t�H���_���̖�����'\\'��t�����Ă�Windows 2000�ł͕t�����Ȃ��̂Ɠ�������ɂȂ��Ă��܂��j
+				// フォルダの ITEMIDLIST を取得して ShellExecuteEx() で開く
+				// Note. MSDN の ShellExecute() の解説にある方法でフォルダを開こうとした場合、
+				//       フォルダと同じ場所に <フォルダ名>.exe があるとうまく動かない。
+				//       verbが"open"やNULLではexeのほうが実行され"explore"では失敗する
+				//       （フォルダ名の末尾に'\\'を付加してもWindows 2000では付加しないのと同じ動作になってしまう）
 				LPSHELLFOLDER pDesktopFolder;
 				if( SUCCEEDED(::SHGetDesktopFolder(&pDesktopFolder)) ){
 					LPMALLOC pMalloc;
@@ -230,7 +230,7 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 							si.lpVerb   = _T("open");
 							si.lpIDList = pIDL;
 							si.nShow    = SW_SHOWNORMAL;
-							::ShellExecuteEx( &si );	// �t�H���_���J��
+							::ShellExecuteEx( &si );	// フォルダを開く
 							pMalloc->Free( (void*)pIDL );
 						}
 						pMalloc->Release();
@@ -238,7 +238,7 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 					pDesktopFolder->Release();
 				}
 				break;
-			case 101:	// �C���|�[�g�^�G�N�X�|�[�g�̋N�_���Z�b�g�i�N�_��ݒ�t�H���_�ɂ���j
+			case 101:	// インポート／エクスポートの起点リセット（起点を設定フォルダにする）
 				int nMsgResult = MYMESSAGEBOX(
 					hwnd,
 					MB_OKCANCEL | MB_ICONINFORMATION,
@@ -264,13 +264,13 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 	return ::CallWindowProc( s_pOldPropSheetWndProc, hwnd, uMsg, wParam, lParam );
 }
 
-/*!	�Ǝ��g���v���p�e�B�V�[�g�̃R�[���o�b�N�֐�
+/*!	独自拡張プロパティシートのコールバック関数
 	@author ryoji
-	@date 2007.05.25 �V�K
+	@date 2007.05.25 新規
 */
 static int CALLBACK PropSheetProc( HWND hwndDlg, UINT uMsg, LPARAM lParam )
 {
-	// �v���p�e�B�V�[�g�̏��������Ƀ{�^���ǉ��A�v���p�e�B�V�[�g�̃T�u�N���X�����s��
+	// プロパティシートの初期化時にボタン追加、プロパティシートのサブクラス化を行う
 	if( uMsg == PSCB_INITIALIZED ){
 		s_pOldPropSheetWndProc = (WNDPROC)::SetWindowLongPtr( hwndDlg, GWLP_WNDPROC, (LONG_PTR)PropSheetWndProc );
 		HINSTANCE hInstance = (HINSTANCE)::GetModuleHandle( NULL );
@@ -282,13 +282,13 @@ static int CALLBACK PropSheetProc( HWND hwndDlg, UINT uMsg, LPARAM lParam )
 }
 
 
-/*!	�Ǝ��g���v���p�e�B�V�[�g�i���ʐݒ�^�^�C�v�ʐݒ��ʗp�j
+/*!	独自拡張プロパティシート（共通設定／タイプ別設定画面用）
 	@author ryoji
-	@date 2007.05.25 �V�K
+	@date 2007.05.25 新規
 */
 INT_PTR MyPropertySheet( LPPROPSHEETHEADER lppsph )
 {
-	// �l�ݒ�t�H���_���g�p����Ƃ��́u�ݒ�t�H���_�v�{�^����ǉ�����
+	// 個人設定フォルダを使用するときは「設定フォルダ」ボタンを追加する
 	if( CShareData::getInstance()->IsPrivateSettings() ){
 		lppsph->dwFlags |= PSH_USECALLBACK;
 		lppsph->pfnCallback = PropSheetProc;
@@ -297,24 +297,24 @@ INT_PTR MyPropertySheet( LPPROPSHEETHEADER lppsph )
 }
 
 
-// To Here 2007.05.25 ryoji �Ǝ��g���̃v���p�e�B�V�[�g�֐��Q
+// To Here 2007.05.25 ryoji 独自拡張のプロパティシート関数群
 ///////////////////////////////////////////////////////////////////////
 
 
 
 
-/*	�w���v�̖ڎ���\��
-	�ڎ��^�u��\���B��肪����o�[�W�����ł́A�ڎ��y�[�W��\���B
+/*	ヘルプの目次を表示
+	目次タブを表示。問題があるバージョンでは、目次ページを表示。
 */
 void ShowWinHelpContents( HWND hwnd )
 {
 	if ( HasWinHelpContentsProblem() ){
-		/* �ڎ��y�[�W��\������ */
-		MyWinHelp( hwnd, HELP_CONTENTS , 0 );	// 2006.10.10 ryoji MyWinHelp�ɕύX
+		/* 目次ページを表示する */
+		MyWinHelp( hwnd, HELP_CONTENTS , 0 );	// 2006.10.10 ryoji MyWinHelpに変更
 		return;
 	}
-	/* �ڎ��^�u��\������ */
-	MyWinHelp( hwnd, HELP_COMMAND, (ULONG_PTR)"CONTENTS()" );	// 2006.10.10 ryoji MyWinHelp�ɕύX
+	/* 目次タブを表示する */
+	MyWinHelp( hwnd, HELP_COMMAND, (ULONG_PTR)"CONTENTS()" );	// 2006.10.10 ryoji MyWinHelpに変更
 	return;
 }
 
@@ -323,31 +323,31 @@ void ShowWinHelpContents( HWND hwnd )
 
 
 // Stonee, 2001/12/21
-// NetWork��̃��\�[�X�ɐڑ����邽�߂̃_�C�A���O���o��������
-// NO_ERROR:���� ERROR_CANCELLED:�L�����Z�� ����ȊO:���s
-// �v���W�F�N�g�̐ݒ�Ń����N���W���[����Mpr.lib��ǉ��̂���
+// NetWork上のリソースに接続するためのダイアログを出現させる
+// NO_ERROR:成功 ERROR_CANCELLED:キャンセル それ以外:失敗
+// プロジェクトの設定でリンクモジュールにMpr.libを追加のこと
 DWORD NetConnect ( const TCHAR strNetWorkPass[] )
 {
-	//char sPassWord[] = "\0";	//�p�X���[�h
-	//char sUser[] = "\0";		//���[�U�[��
-	DWORD dwRet;				//�߂�l�@�G���[�R�[�h��WINERROR.H���Q��
+	//char sPassWord[] = "\0";	//パスワード
+	//char sUser[] = "\0";		//ユーザー名
+	DWORD dwRet;				//戻り値　エラーコードはWINERROR.Hを参照
 	TCHAR sTemp[256];
 	TCHAR sDrive[] = _T("");
     int i;
 
-	if (_tcslen(strNetWorkPass) < 3)	return ERROR_BAD_NET_NAME;  //UNC�ł͂Ȃ��B
-	if (strNetWorkPass[0] != _T('\\') && strNetWorkPass[1] != _T('\\'))	return ERROR_BAD_NET_NAME;  //UNC�ł͂Ȃ��B
+	if (_tcslen(strNetWorkPass) < 3)	return ERROR_BAD_NET_NAME;  //UNCではない。
+	if (strNetWorkPass[0] != _T('\\') && strNetWorkPass[1] != _T('\\'))	return ERROR_BAD_NET_NAME;  //UNCではない。
 
-	//3�����ڂ��琔���čŏ���\�̒��O�܂ł�؂�o��
+	//3文字目から数えて最初の\の直前までを切り出す
 	sTemp[0] = _T('\\');
 	sTemp[1] = _T('\\');
 	for (i = 2; strNetWorkPass[i] != _T('\0'); i++) {
 		if (strNetWorkPass[i] == _T('\\')) break;
 		sTemp[i] = strNetWorkPass[i];
 	}
-	sTemp[i] = _T('\0');	//�I�[
+	sTemp[i] = _T('\0');	//終端
 
-	//NETRESOURCE�쐬
+	//NETRESOURCE作成
 	NETRESOURCE nr;
 	ZeroMemory( &nr, sizeof( nr ) );
 	nr.dwScope       = RESOURCE_GLOBALNET;
@@ -357,7 +357,7 @@ DWORD NetConnect ( const TCHAR strNetWorkPass[] )
 	nr.lpLocalName   = sDrive;
 	nr.lpRemoteName  = sTemp;
 
-	//���[�U�[�F�؃_�C�A���O��\��
+	//ユーザー認証ダイアログを表示
 	dwRet = WNetAddConnection3(0, &nr, NULL, NULL, CONNECT_UPDATE_PROFILE | CONNECT_INTERACTIVE);
 
 	return dwRet;
@@ -368,26 +368,26 @@ DWORD NetConnect ( const TCHAR strNetWorkPass[] )
 
 //	From Here Jun. 26, 2001 genta
 /*!
-	HTML Help�R���|�[�l���g�̃A�N�Z�X��񋟂���B
-	�����ŕێ����ׂ��f�[�^�͓��ɂȂ��A���鏊����g����̂�Global�ϐ��ɂ��邪�A
-	���ڂ̃A�N�Z�X��OpenHtmlHelp()�֐��݂̂���s���B
-	���̃t�@�C�������CHtmlHelp�N���X�͉B����Ă���B
+	HTML Helpコンポーネントのアクセスを提供する。
+	内部で保持すべきデータは特になく、至る所から使われるのでGlobal変数にするが、
+	直接のアクセスはOpenHtmlHelp()関数のみから行う。
+	他のファイルからはCHtmlHelpクラスは隠されている。
 */
 CHtmlHelp g_cHtmlHelp;
 
 /*!
-	HTML Help���J��
-	HTML Help�����p�\�ł���Έ��������̂܂ܓn���A�����łȂ���΃��b�Z�[�W��\������B
+	HTML Helpを開く
+	HTML Helpが利用可能であれば引数をそのまま渡し、そうでなければメッセージを表示する。
 
-	@return �J�����w���v�E�B���h�E�̃E�B���h�E�n���h���B�J���Ȃ������Ƃ���NULL�B
+	@return 開いたヘルプウィンドウのウィンドウハンドル。開けなかったときはNULL。
 */
 
 HWND OpenHtmlHelp(
-	HWND		hWnd,	//!< [in] �Ăяo�����E�B���h�E�̃E�B���h�E�n���h��
-	LPCTSTR		szFile,	//!< [in] HTML Help�̃t�@�C�����B�s�����ɑ����ăE�B���h�E�^�C�v�����w��\�B
-	UINT		uCmd,	//!< [in] HTML Help �ɓn���R�}���h
-	DWORD_PTR	data,	//!< [in] �R�}���h�ɉ������f�[�^
-	bool		msgflag	//!< [in] �G���[���b�Z�[�W��\�����邩�B�ȗ�����true�B
+	HWND		hWnd,	//!< [in] 呼び出し元ウィンドウのウィンドウハンドル
+	LPCTSTR		szFile,	//!< [in] HTML Helpのファイル名。不等号に続けてウィンドウタイプ名を指定可能。
+	UINT		uCmd,	//!< [in] HTML Help に渡すコマンド
+	DWORD_PTR	data,	//!< [in] コマンドに応じたデータ
+	bool		msgflag	//!< [in] エラーメッセージを表示するか。省略時はtrue。
 )
 {
 	if( DLL_SUCCESS == g_cHtmlHelp.InitDll() ){
@@ -409,8 +409,8 @@ HWND OpenHtmlHelp(
 
 
 
-/*! �V���[�g�J�b�g(.lnk)�̉���
-	@date 2009.01.08 ryoji CoInitialize/CoUninitialize���폜�iWinMain��OleInitialize/OleUninitialize��ǉ��j
+/*! ショートカット(.lnk)の解決
+	@date 2009.01.08 ryoji CoInitialize/CoUninitializeを削除（WinMainにOleInitialize/OleUninitializeを追加）
 */
 BOOL ResolveShortcutLink( HWND hwnd, LPCTSTR lpszLinkFile, LPTSTR lpszPath )
 {
@@ -419,13 +419,13 @@ BOOL ResolveShortcutLink( HWND hwnd, LPCTSTR lpszLinkFile, LPTSTR lpszPath )
 	IShellLink*		pIShellLink;
 	IPersistFile*	pIPersistFile;
 	WIN32_FIND_DATA	wfd;
-	/* ������ */
+	/* 初期化 */
 	pIShellLink = NULL;
 	pIPersistFile = NULL;
 	*lpszPath = 0; // assume failure
 	bRes = FALSE;
 
-// 2009.01.08 ryoji CoInitialize���폜�iWinMain��OleInitialize�ǉ��j
+// 2009.01.08 ryoji CoInitializeを削除（WinMainにOleInitialize追加）
 
 	// Get a pointer to the IShellLink interface.
 //	hRes = 0;
@@ -434,7 +434,7 @@ BOOL ResolveShortcutLink( HWND hwnd, LPCTSTR lpszLinkFile, LPTSTR lpszPath )
 		return FALSE;
 	}
 
-	// 2010.08.28 DLL �C���W�F�N�V�����΍�Ƃ���EXE�̃t�H���_�Ɉړ�����
+	// 2010.08.28 DLL インジェクション対策としてEXEのフォルダに移動する
 	CCurrentDirectoryBackupPoint dirBack;
 	ChangeCurrentDirectoryToExeDir();
 
@@ -457,7 +457,7 @@ BOOL ResolveShortcutLink( HWND hwnd, LPCTSTR lpszLinkFile, LPTSTR lpszPath )
 						TCHAR szDescription[MAX_PATH];
 						if( SUCCEEDED(hRes = pIShellLink->GetDescription(szDescription, MAX_PATH ) ) ){
 							if( _T('\0') != szGotPath[0] ){
-								/* ����I�� */
+								/* 正常終了 */
 								_tcscpy_s( lpszPath, _MAX_PATH, szGotPath );
 								bRes = TRUE;
 							}
@@ -477,7 +477,7 @@ BOOL ResolveShortcutLink( HWND hwnd, LPCTSTR lpszLinkFile, LPTSTR lpszPath )
 		pIShellLink->Release();
 		pIShellLink = NULL;
 	}
-// 2009.01.08 ryoji CoUninitialize���폜�iWinMain��OleUninitialize�ǉ��j
+// 2009.01.08 ryoji CoUninitializeを削除（WinMainにOleUninitialize追加）
 	return bRes;
 }
 
@@ -485,17 +485,17 @@ BOOL ResolveShortcutLink( HWND hwnd, LPCTSTR lpszLinkFile, LPTSTR lpszPath )
 
 
 
-/*! �w���v�t�@�C���̃t���p�X��Ԃ�
+/*! ヘルプファイルのフルパスを返す
  
-    @return �p�X���i�[�����o�b�t�@�̃|�C���^
+    @return パスを格納したバッファのポインタ
  
-    @note ���s�t�@�C���Ɠ����ʒu�� sakura.chm �t�@�C����Ԃ��B
-        �p�X�� UNC �̂Ƃ��� _MAX_PATH �Ɏ��܂�Ȃ��\��������B
+    @note 実行ファイルと同じ位置の sakura.chm ファイルを返す。
+        パスが UNC のときは _MAX_PATH に収まらない可能性がある。
  
-    @date 2002/01/19 aroka �GnMaxLen �����ǉ�
-	@date 2007/10/23 kobake ���������̌����C��(in��out)
-	@date 2007/10/23 kobake CEditApp�̃����o�֐��ɕύX
-	@date 2007/10/23 kobake �V�O�j�`���ύX�Bconst�|�C���^��Ԃ������̃C���^�[�t�F�[�X�ɂ��܂����B
+    @date 2002/01/19 aroka ；nMaxLen 引数追加
+	@date 2007/10/23 kobake 引数説明の誤りを修正(in→out)
+	@date 2007/10/23 kobake CEditAppのメンバ関数に変更
+	@date 2007/10/23 kobake シグニチャ変更。constポインタを返すだけのインターフェースにしました。
 */
 static LPCTSTR GetHelpFilePath()
 {
@@ -506,63 +506,63 @@ static LPCTSTR GetHelpFilePath()
 	return szHelpFile;
 }
 
-/*!	WinHelp �̂����� HtmlHelp ���Ăяo��
+/*!	WinHelp のかわりに HtmlHelp を呼び出す
 
 	@author ryoji
-	@date 2006.07.22 ryoji �V�K
+	@date 2006.07.22 ryoji 新規
 */
 BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData)
 {
-	UINT uCommandOrg = uCommand;	// WinHelp �̃R�}���h
-	bool bDesktop = false;	// �f�X�N�g�b�v��e�ɂ��ăw���v��ʂ��o�����ǂ���
-	HH_POPUP hp;	// �|�b�v�A�b�v�w���v�p�̍\����
+	UINT uCommandOrg = uCommand;	// WinHelp のコマンド
+	bool bDesktop = false;	// デスクトップを親にしてヘルプ画面を出すかどうか
+	HH_POPUP hp;	// ポップアップヘルプ用の構造体
 
-	// Note: HH_TP_HELP_CONTEXTMENU �� HELP_WM_HELP �ł̓w���v�R���p�C������
-	// �g�s�b�N�t�@�C���� Cshelp.txt �ȊO�ɂ��Ă���ꍇ�A
-	// ���̃t�@�C������ .chm �p�X���ɒǉ��w�肷��K�v������B
-	//     ��jsakura.chm::/xxx.txt
+	// Note: HH_TP_HELP_CONTEXTMENU や HELP_WM_HELP ではヘルプコンパイル時の
+	// トピックファイルを Cshelp.txt 以外にしている場合、
+	// そのファイル名を .chm パス名に追加指定する必要がある。
+	//     例）sakura.chm::/xxx.txt
 
 	switch( uCommandOrg )
 	{
-	case HELP_COMMAND:	// [�w���v]-[�ڎ�]
+	case HELP_COMMAND:	// [ヘルプ]-[目次]
 	case HELP_CONTENTS:
 		uCommand = HH_DISPLAY_TOC;
 		hwndCaller = ::GetDesktopWindow();
 		bDesktop = true;
 		break;
-	case HELP_KEY:	// [�w���v]-[�L�[���[�h����]
+	case HELP_KEY:	// [ヘルプ]-[キーワード検索]
 		uCommand = HH_DISPLAY_INDEX;
 		hwndCaller = ::GetDesktopWindow();
 		bDesktop = true;
 		break;
-	case HELP_CONTEXT:	// ���j���[��ł�[F1]�L�[�^�_�C�A���O��[�w���v]�{�^��
+	case HELP_CONTEXT:	// メニュー上での[F1]キー／ダイアログの[ヘルプ]ボタン
 		uCommand = HH_HELP_CONTEXT;
 		hwndCaller = ::GetDesktopWindow();
 		bDesktop = true;
 		break;
-	case HELP_CONTEXTMENU:	// �R���g���[����ł̉E�N���b�N
-	case HELP_WM_HELP:		// [�H]�{�^���������ăR���g���[�����N���b�N�^�R���g���[���Ƀt�H�[�J�X��u����[F1]�L�[
+	case HELP_CONTEXTMENU:	// コントロール上での右クリック
+	case HELP_WM_HELP:		// [？]ボタンを押してコントロールをクリック／コントロールにフォーカスを置いて[F1]キー
 		uCommand = HH_DISPLAY_TEXT_POPUP;
 		{
-			// �|�b�v�A�b�v�w���v�p�̍\���̂ɒl���Z�b�g����
-			HWND hwndCtrl;	// �w���v�\���Ώۂ̃R���g���[��
-			int nCtrlID;	// �ΏۃR���g���[���� ID
-			DWORD* pHelpIDs;	// �R���g���[�� ID �ƃw���v ID �̑Ή��\�ւ̃|�C���^
+			// ポップアップヘルプ用の構造体に値をセットする
+			HWND hwndCtrl;	// ヘルプ表示対象のコントロール
+			int nCtrlID;	// 対象コントロールの ID
+			DWORD* pHelpIDs;	// コントロール ID とヘルプ ID の対応表へのポインタ
 
-			memset(&hp, 0, sizeof(hp));	// �\���̂��[���N���A
+			memset(&hp, 0, sizeof(hp));	// 構造体をゼロクリア
 			hp.cbStruct = sizeof(hp);
-			hp.pszFont = _T("�l�r �o�S�V�b�N, 9");
+			hp.pszFont = _T("ＭＳ Ｐゴシック, 9");
 			hp.clrForeground = hp.clrBackground = -1;
 			hp.rcMargins.left = hp.rcMargins.top = hp.rcMargins.right = hp.rcMargins.bottom = -1;
 			if( uCommandOrg == HELP_CONTEXTMENU ){
-				// �}�E�X�J�[�\���ʒu����ΏۃR���g���[���ƕ\���ʒu�����߂�
+				// マウスカーソル位置から対象コントロールと表示位置を求める
 				if( !::GetCursorPos(&hp.pt) )
 					return FALSE;
 				hwndCtrl = ::WindowFromPoint(hp.pt);
 			}
 			else{
-				// �ΏۃR���g���[���� hwndCaller
-				// [F1]�L�[�̏ꍇ������̂őΏۃR���g���[���̈ʒu����\���ʒu�����߂�
+				// 対象コントロールは hwndCaller
+				// [F1]キーの場合もあるので対象コントロールの位置から表示位置を決める
 				RECT rc;
 				hwndCtrl = hwndCaller;
 				if( !::GetWindowRect( hwndCtrl, &rc ) )
@@ -570,20 +570,20 @@ BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData)
 				hp.pt.x = (rc.left + rc.right) / 2;
 				hp.pt.y = rc.top;
 			}
-			// �ΏۃR���g���[���ɑΉ�����w���v ID ��T��
+			// 対象コントロールに対応するヘルプ ID を探す
 			nCtrlID = ::GetDlgCtrlID( hwndCtrl );
 			if( nCtrlID <= 0 )
 				return FALSE;
 			pHelpIDs = (DWORD*)dwData;
 			for (;;) {
 				if( *pHelpIDs == 0 )
-					return FALSE;	// ������Ȃ�����
+					return FALSE;	// 見つからなかった
 				if( *pHelpIDs == (DWORD)nCtrlID )
-					break;			// ��������
+					break;			// 見つかった
 				pHelpIDs += 2;
 			}
-			hp.idString = *(pHelpIDs + 1);	// �������w���v ID ��ݒ肷��
-			dwData = (DWORD_PTR)&hp;	// �������|�b�v�A�b�v�w���v�p�̍\���̂ɍ����ւ���
+			hp.idString = *(pHelpIDs + 1);	// 見つけたヘルプ ID を設定する
+			dwData = (DWORD_PTR)&hp;	// 引数をポップアップヘルプ用の構造体に差し替える
 		}
 		break;
 	default:
@@ -592,19 +592,19 @@ BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData)
 
 	LPCTSTR lpszHelp = GetHelpFilePath();
 	if( IsFileExists( lpszHelp, true ) ){
-		// HTML �w���v���Ăяo��
+		// HTML ヘルプを呼び出す
 		HWND hWnd = OpenHtmlHelp( hwndCaller, lpszHelp, uCommand, dwData );
 		if (bDesktop && hWnd != NULL){
-			::SetForegroundWindow( hWnd );	// �w���v��ʂ���O�ɏo��
+			::SetForegroundWindow( hWnd );	// ヘルプ画面を手前に出す
 		}
 	}
 	else {
 		if( uCommandOrg == HELP_CONTEXTMENU)
-			return FALSE;	// �E�N���b�N�ł͉������Ȃ��ł���
+			return FALSE;	// 右クリックでは何もしないでおく
 
-		// �I�����C���w���v���Ăяo��
+		// オンラインヘルプを呼び出す
 		if( uCommandOrg != HELP_CONTEXT )
-			dwData = 1;	// �ڎ��y�[�W
+			dwData = 1;	// 目次ページ
 
 		TCHAR buf[256];
 		_stprintf( buf, _T("http://sakura-editor.sourceforge.net/cgi-bin/hid2.cgi?%Id"), dwData );
@@ -614,25 +614,25 @@ BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData)
 	return TRUE;
 }
 
-/*�t�H���g�I���_�C�A���O
+/*フォント選択ダイアログ
 	@param plf [in,out]
-	@param piPointSize [in,out] 1/10�|�C���g�P��
+	@param piPointSize [in,out] 1/10ポイント単位
 	
-	2008.04.27 kobake CEditDoc::SelectFont ���番��
-	2009.10.01 ryoji �|�C���g�T�C�Y�i1/10�|�C���g�P�ʁj�����ǉ�
+	2008.04.27 kobake CEditDoc::SelectFont から分離
+	2009.10.01 ryoji ポイントサイズ（1/10ポイント単位）引数追加
 */
 BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool FixedFontOnly )
 {
-	// 2004.02.16 Moca CHOOSEFONT�������o����O��
+	// 2004.02.16 Moca CHOOSEFONTをメンバから外す
 	CHOOSEFONT cf;
-	/* CHOOSEFONT�̏����� */
+	/* CHOOSEFONTの初期化 */
 	::ZeroMemory( &cf, sizeof( cf ) );
 	cf.lStructSize = sizeof( cf );
 	cf.hwndOwner = hwndDlgOwner;
 	cf.hDC = NULL;
 	cf.Flags = CF_SCREENFONTS | CF_INITTOLOGFONTSTRUCT;
 	if( FixedFontOnly ){
-		//FIXED�t�H���g
+		//FIXEDフォント
 		cf.Flags |= CF_FIXEDPITCHONLY;
 	}
 	cf.lpLogFont = plf;

--- a/sakura_core/util/shell.h
+++ b/sakura_core/util/shell.h
@@ -1,5 +1,5 @@
-// 2007.10.19 kobake
-// ‚È‚ñ‚©ƒVƒFƒ‹‚Á‚Û‚¢‹@”\‚ÌŠÖ”ŒQ
+ï»¿// 2007.10.19 kobake
+// ãªã‚“ã‹ã‚·ã‚§ãƒ«ã£ã½ã„æ©Ÿèƒ½ã®é–¢æ•°ç¾¤
 /*
 	Copyright (C) 2008, kobake
 
@@ -26,27 +26,27 @@
 #ifndef SAKURA_SHELL_A129670C_6564_4E0D_AF52_E323B0C7CA099_H_
 #define SAKURA_SHELL_A129670C_6564_4E0D_AF52_E323B0C7CA099_H_
 
-BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData);	/* WinHelp ‚Ì‚©‚í‚è‚É HtmlHelp ‚ğŒÄ‚Ño‚· */	// 2006.07.22 ryoji
+BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData);	/* WinHelp ã®ã‹ã‚ã‚Šã« HtmlHelp ã‚’å‘¼ã³å‡ºã™ */	// 2006.07.22 ryoji
 
-/* Shell InterfaceŒn(?) */
-BOOL SelectDir(HWND, const TCHAR*, const TCHAR*, TCHAR* );	/* ƒtƒHƒ‹ƒ_‘I‘ğƒ_ƒCƒAƒƒO */
-BOOL ResolveShortcutLink(HWND hwnd, LPCTSTR lpszLinkFile, LPTSTR lpszPath);/* ƒVƒ‡[ƒgƒJƒbƒg(.lnk)‚Ì‰ğŒˆ */
+/* Shell Interfaceç³»(?) */
+BOOL SelectDir(HWND, const TCHAR*, const TCHAR*, TCHAR* );	/* ãƒ•ã‚©ãƒ«ãƒ€é¸æŠãƒ€ã‚¤ã‚¢ãƒ­ã‚° */
+BOOL ResolveShortcutLink(HWND hwnd, LPCTSTR lpszLinkFile, LPTSTR lpszPath);/* ã‚·ãƒ§ãƒ¼ãƒˆã‚«ãƒƒãƒˆ(.lnk)ã®è§£æ±º */
 
 HWND OpenHtmlHelp( HWND hWnd, LPCTSTR szFile, UINT uCmd, DWORD_PTR data,bool msgflag = true);
 DWORD NetConnect ( const TCHAR strNetWorkPass[] );
 
-/* ƒwƒ‹ƒv‚Ì–ÚŸ‚ğ•\¦ */
+/* ãƒ˜ãƒ«ãƒ—ã®ç›®æ¬¡ã‚’è¡¨ç¤º */
 void ShowWinHelpContents( HWND hwnd );
 
-BOOL GetSpecialFolderPath( int nFolder, LPTSTR pszPath );	// “ÁêƒtƒHƒ‹ƒ_‚ÌƒpƒX‚ğæ“¾‚·‚é	// 2007.05.19 ryoji
+BOOL GetSpecialFolderPath( int nFolder, LPTSTR pszPath );	// ç‰¹æ®Šãƒ•ã‚©ãƒ«ãƒ€ã®ãƒ‘ã‚¹ã‚’å–å¾—ã™ã‚‹	// 2007.05.19 ryoji
 
 
 
-INT_PTR MyPropertySheet( LPPROPSHEETHEADER lppsph );	// “Æ©Šg’£ƒvƒƒpƒeƒBƒV[ƒg	// 2007.05.24 ryoji
+INT_PTR MyPropertySheet( LPPROPSHEETHEADER lppsph );	// ç‹¬è‡ªæ‹¡å¼µãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã‚·ãƒ¼ãƒˆ	// 2007.05.24 ryoji
 
 
-//!ƒtƒHƒ“ƒg‘I‘ğƒ_ƒCƒAƒƒO
-BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool );	// 2009.10.01 ryoji ƒ|ƒCƒ“ƒgƒTƒCƒYi1/10ƒ|ƒCƒ“ƒg’PˆÊjˆø”’Ç‰Á
+//!ãƒ•ã‚©ãƒ³ãƒˆé¸æŠãƒ€ã‚¤ã‚¢ãƒ­ã‚°
+BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool );	// 2009.10.01 ryoji ãƒã‚¤ãƒ³ãƒˆã‚µã‚¤ã‚ºï¼ˆ1/10ãƒã‚¤ãƒ³ãƒˆå˜ä½ï¼‰å¼•æ•°è¿½åŠ 
 
 #endif /* SAKURA_SHELL_A129670C_6564_4E0D_AF52_E323B0C7CA099_H_ */
 /*[EOF]*/

--- a/sakura_core/util/std_macro.h
+++ b/sakura_core/util/std_macro.h
@@ -1,4 +1,4 @@
-//2007.10.18 kobake �쐬
+﻿//2007.10.18 kobake 作成
 /*
 	Copyright (C) 2007, kobake
 
@@ -30,12 +30,12 @@
 
 /*
 	2007.10.18 kobake
-	�e���v���[�g�� min �Ƃ� max �Ƃ��B
+	テンプレート式 min とか max とか。
 
-	�ǂ����̕W���w�b�_�ɁA�����悤�Ȃ��̂��������C�����邯�ǁA
-	NOMINMAX ���`����ɂ��Ă��A�Ȃ񂾂� min �Ƃ� max �Ƃ��������O���ƁA
-	�e���v���[�g���Ă�ł�񂾂��}�N�����Ă�ł�񂾂��󕪂���Ȃ��̂ŁA
-	�����I�Ɂut_�`�v�Ƃ������O�����֐���p�ӁB
+	どっかの標準ヘッダに、同じようなものがあった気がするけど、
+	NOMINMAX を定義するにしても、なんだか min とか max とかいう名前だと、
+	テンプレートを呼んでるんだかマクロを呼んでるんだか訳分かんないので、
+	明示的に「t_～」という名前を持つ関数を用意。
 */
 
 template <class T>
@@ -68,10 +68,10 @@ T t_unit(T t)
 
 /*
 	2007.10.19 kobake
-	_countof�}�N���B_countof���g���Ȃ��Â��R���p�C���p�B
+	_countofマクロ。_countofが使えない古いコンパイラ用。
 
-	�������A���̏ꏊ�Ńe���v���[�g���育��g���Ă���̂ŁA
-	�ǂ����ɂ���Â����Ńr���h�͒ʂ�Ȃ��\���B
+	ただし、他の場所でテンプレートごりごり使っているので、
+	どっちにしろ古い環境でビルドは通らない予感。
 */
 
 #ifndef _countof
@@ -86,15 +86,15 @@ T t_unit(T t)
 /*
 	2007.10.19 kobake
 
-	���e�����������A�����w��}�N��
+	リテラル文字列種、明示指定マクロ
 */
 
-//�r���h��Ɋ֌W�Ȃ��AUNICODE�B
+//ビルド種に関係なく、UNICODE。
 #define __LTEXT(A) L##A
 #define LTEXT(A) __LTEXT(A)
 #define LCHAR(A) __LTEXT(A)
 
-//�r���h��Ɋ֌W�Ȃ��AANSI�B
+//ビルド種に関係なく、ANSI。
 #define ATEXT(A) A
 
 #endif /* SAKURA_STD_MACRO_A4AD5AD7_E307_4F40_A051_F4301FC8DA58_H_ */

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "string_ex.h"
 #include "charset/charcode.h"
 #include "util/std_macro.h"
@@ -9,33 +9,33 @@ int __cdecl my_internal_icmp( const char *s1, const char *s2, unsigned int n, un
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           •¶š                              //
+//                           æ–‡å­—                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       Šg’£E“Æ©À‘•                        //
+//                       æ‹¡å¼µãƒ»ç‹¬è‡ªå®Ÿè£…                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*!	‘å•¶š¬•¶š‚ğ“¯ˆê‹‚·‚é•¶š—ñ”äŠr‚ğ‚·‚éB
-	@param s1 [in] •¶š—ñ‚P
-	@param s2 [in] •¶š—ñ‚Q
+/*!	å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–ã™ã‚‹æ–‡å­—åˆ—æ¯”è¼ƒã‚’ã™ã‚‹ã€‚
+	@param s1 [in] æ–‡å­—åˆ—ï¼‘
+	@param s2 [in] æ–‡å­—åˆ—ï¼’
 
-	@retval 0	ˆê’v
+	@retval 0	ä¸€è‡´
  */
 int __cdecl my_stricmp( const char *s1, const char *s2 )
 {
-	/* ƒ`ƒFƒbƒN‚·‚é•¶š”‚ğuintÅ‘å‚Éİ’è‚·‚é */
+	/* ãƒã‚§ãƒƒã‚¯ã™ã‚‹æ–‡å­—æ•°ã‚’uintæœ€å¤§ã«è¨­å®šã™ã‚‹ */
 	//return my_internal_icmp( s1, s2, (unsigned int)(~0), 0, true );
 	return my_internal_icmp( s1, s2, UINT_MAX, 0, true );
 }
 
-/*!	‘å•¶š¬•¶š‚ğ“¯ˆê‹‚·‚é•¶š—ñ’·‚³§ŒÀ”äŠr‚ğ‚·‚éB
-	@param s1 [in] •¶š—ñ‚P
-	@param s2 [in] •¶š—ñ‚Q
-	@param n [in] •¶š’·
+/*!	å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–ã™ã‚‹æ–‡å­—åˆ—é•·ã•åˆ¶é™æ¯”è¼ƒã‚’ã™ã‚‹ã€‚
+	@param s1 [in] æ–‡å­—åˆ—ï¼‘
+	@param s2 [in] æ–‡å­—åˆ—ï¼’
+	@param n [in] æ–‡å­—é•·
 
-	@retval 0	ˆê’v
+	@retval 0	ä¸€è‡´
  */
 int __cdecl my_strnicmp( const char *s1, const char *s2, size_t n )
 {
@@ -54,7 +54,7 @@ LPWSTR wcscpyn(LPWSTR lpString1,LPCWSTR lpString2,int iMaxLength)
 
 
 /*
-	TCHAR ‚Æ WCHAR ‚Ü‚½‚Í ACHAR ‚Ì•ÏŠ·ŠÖ”
+	TCHAR ã¨ WCHAR ã¾ãŸã¯ ACHAR ã®å¤‰æ›é–¢æ•°
 */
 
 ACHAR* tcstostr( ACHAR* dest, const TCHAR* src, size_t count){
@@ -98,18 +98,18 @@ TCHAR* strtotcs( TCHAR* dest, const WCHAR* src, size_t count )
 }
 
 
-/*! •¶š”§ŒÀ‹@”\•t‚«strncpy
+/*! æ–‡å­—æ•°åˆ¶é™æ©Ÿèƒ½ä»˜ãstrncpy
 
-	ƒRƒs[æ‚Ìƒoƒbƒtƒ@ƒTƒCƒY‚©‚çˆì‚ê‚È‚¢‚æ‚¤‚Éstrncpy‚·‚éB
-	ƒoƒbƒtƒ@‚ª•s‘«‚·‚éê‡‚É‚Í2ƒoƒCƒg•¶š‚ÌØ’f‚à‚ ‚è“¾‚éB
-	––”ö‚Ì\0‚Í•t—^‚³‚ê‚È‚¢‚ªAƒRƒs[‚ÍƒRƒs[æƒoƒbƒtƒ@ƒTƒCƒY-1‚Ü‚Å‚É‚µ‚Ä‚¨‚­B
+	ã‚³ãƒ”ãƒ¼å…ˆã®ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã‹ã‚‰æº¢ã‚Œãªã„ã‚ˆã†ã«strncpyã™ã‚‹ã€‚
+	ãƒãƒƒãƒ•ã‚¡ãŒä¸è¶³ã™ã‚‹å ´åˆã«ã¯2ãƒã‚¤ãƒˆæ–‡å­—ã®åˆ‡æ–­ã‚‚ã‚ã‚Šå¾—ã‚‹ã€‚
+	æœ«å°¾ã®\0ã¯ä»˜ä¸ã•ã‚Œãªã„ãŒã€ã‚³ãƒ”ãƒ¼ã¯ã‚³ãƒ”ãƒ¼å…ˆãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚º-1ã¾ã§ã«ã—ã¦ãŠãã€‚
 
-	@param dst [in] ƒRƒs[æ—Ìˆæ‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	@param dst_count [in] ƒRƒs[æ—Ìˆæ‚ÌƒTƒCƒY
-	@param src [in] ƒRƒs[Œ³
-	@param src_count [in] ƒRƒs[‚·‚é•¶š—ñ‚Ì––”ö
+	@param dst [in] ã‚³ãƒ”ãƒ¼å…ˆé ˜åŸŸã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	@param dst_count [in] ã‚³ãƒ”ãƒ¼å…ˆé ˜åŸŸã®ã‚µã‚¤ã‚º
+	@param src [in] ã‚³ãƒ”ãƒ¼å…ƒ
+	@param src_count [in] ã‚³ãƒ”ãƒ¼ã™ã‚‹æ–‡å­—åˆ—ã®æœ«å°¾
 
-	@retval ÀÛ‚ÉƒRƒs[‚³‚ê‚½ƒRƒs[æ—Ìˆæ‚Ì1‚ÂŒã‚ğw‚·ƒ|ƒCƒ“ƒ^
+	@retval å®Ÿéš›ã«ã‚³ãƒ”ãƒ¼ã•ã‚ŒãŸã‚³ãƒ”ãƒ¼å…ˆé ˜åŸŸã®1ã¤å¾Œã‚’æŒ‡ã™ãƒã‚¤ãƒ³ã‚¿
 
 	@author genta
 	@date 2003.04.03 genta
@@ -138,7 +138,7 @@ const wchar_t* wcsistr( const wchar_t* s1, const wchar_t* s2 )
 
 const char* stristr(const char* s1, const char* s2)
 {
-	//$ “ú–{Œêl—¶‚µ‚Ä‚È‚¢‚Ì‚ÅA‚ ‚ñ‚Ü‚è–ğ‚É—§‚½‚È‚¢”ÅBstristr_j‚ğg‚¤‚Ì‚ª–]‚Ü‚µ‚¢B
+	//$ æ—¥æœ¬èªè€ƒæ…®ã—ã¦ãªã„ã®ã§ã€ã‚ã‚“ã¾ã‚Šå½¹ã«ç«‹ãŸãªã„ç‰ˆã€‚stristr_jã‚’ä½¿ã†ã®ãŒæœ›ã¾ã—ã„ã€‚
 	size_t len2=strlen(s2);
 	const char* p=s1;
 	const char* q=strchr(s1,L'\0')-len2;
@@ -150,12 +150,12 @@ const char* stristr(const char* s1, const char* s2)
 }
 
 /*!
-	@date 2005.04.07 MIK    V‹Kì¬
-	@date 2007.10.21 kobake ŠÖ”–¼•ÏX: my_strchri¨strichr_j
+	@date 2005.04.07 MIK    æ–°è¦ä½œæˆ
+	@date 2007.10.21 kobake é–¢æ•°åå¤‰æ›´: my_strchriâ†’strichr_j
 */
 const char* strichr_j( const char* s1, char c2 )
 {
-	if(c2==0)return ::strchr(s1,0); //•¶š—ñI’[‚ğ’T‚·‚½‚ß‚Éc2‚É0‚ğ“n‚µ‚½ê‡‚àA³‚µ‚­ˆ—‚³‚ê‚é‚æ‚¤‚ÉB 2007.10.16 kobake
+	if(c2==0)return ::strchr(s1,0); //æ–‡å­—åˆ—çµ‚ç«¯ã‚’æ¢ã™ãŸã‚ã«c2ã«0ã‚’æ¸¡ã—ãŸå ´åˆã‚‚ã€æ­£ã—ãå‡¦ç†ã•ã‚Œã‚‹ã‚ˆã†ã«ã€‚ 2007.10.16 kobake
 
 	int C2 = my_toupper( c2 );
 	for( const char* p1 = s1; *p1; p1++ ){
@@ -166,12 +166,12 @@ const char* strichr_j( const char* s1, char c2 )
 }
 
 /*!
-	@date 2005.04.07 MIK    V‹Kì¬
-	@date 2007.10.21 kobake ŠÖ”–¼•ÏX: my_strchr¨strchr_j
+	@date 2005.04.07 MIK    æ–°è¦ä½œæˆ
+	@date 2007.10.21 kobake é–¢æ•°åå¤‰æ›´: my_strchrâ†’strchr_j
 */
 const char* strchr_j(const char* str, char c)
 {
-	if(c==0)return ::strchr(str,0); //•¶š—ñI’[‚ğ’T‚·‚½‚ß‚Éc‚É0‚ğ“n‚µ‚½ê‡‚àA³‚µ‚­ˆ—‚³‚ê‚é‚æ‚¤‚ÉB 2007.10.16 kobake
+	if(c==0)return ::strchr(str,0); //æ–‡å­—åˆ—çµ‚ç«¯ã‚’æ¢ã™ãŸã‚ã«cã«0ã‚’æ¸¡ã—ãŸå ´åˆã‚‚ã€æ­£ã—ãå‡¦ç†ã•ã‚Œã‚‹ã‚ˆã†ã«ã€‚ 2007.10.16 kobake
 
 	for( const char* p1 = str; *p1; p1++ ){
 		if( *p1 == c ) return p1;
@@ -181,10 +181,10 @@ const char* strchr_j(const char* str, char c)
 }
 
 /*!
-	strstr()‚Ì2byte code‘Î‰”Å
+	strstr()ã®2byte codeå¯¾å¿œç‰ˆ
 
-	@date 2005.04.07 MIK V‹Kì¬
-	@date 2007.10.21 kobake ŠÖ”–¼•ÏX: my_strstr¨strstr_j
+	@date 2005.04.07 MIK æ–°è¦ä½œæˆ
+	@date 2007.10.21 kobake é–¢æ•°åå¤‰æ›´: my_strstrâ†’strstr_j
 */
 const char* strstr_j(const char* s1, const char* s2)
 {
@@ -197,14 +197,14 @@ const char* strstr_j(const char* s1, const char* s2)
 }
 
 /*!
-	strstr()‚Ì‘å•¶š¬•¶š“¯ˆê‹”Å
+	strstr()ã®å¤§æ–‡å­—å°æ–‡å­—åŒä¸€è¦–ç‰ˆ
 
 	@note
-	Windows API‚É‚ ‚éStrStrI‚ÍIE4‚ª“ü‚Á‚Ä‚¢‚È‚¢PC‚Å‚Íg—p•s‰Â‚Ì‚½‚ß
-	“Æ©‚Éì¬
+	Windows APIã«ã‚ã‚‹StrStrIã¯IE4ãŒå…¥ã£ã¦ã„ãªã„PCã§ã¯ä½¿ç”¨ä¸å¯ã®ãŸã‚
+	ç‹¬è‡ªã«ä½œæˆ
 
-	@date 2005.04.07 MIK    V‹Kì¬
-	@date 2007.10.21 kobake ŠÖ”–¼•ÏX: my_strstri¨stristr_j
+	@date 2005.04.07 MIK    æ–°è¦ä½œæˆ
+	@date 2007.10.21 kobake é–¢æ•°åå¤‰æ›´: my_strstriâ†’stristr_j
 */
 const char* stristr_j( const char* s1, const char* s2 )
 {
@@ -219,13 +219,13 @@ const char* stristr_j( const char* s1, const char* s2 )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           ŒİŠ·                              //
+//                           äº’æ›                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-#if (defined(_MSC_VER) && _MSC_VER<1400) || defined(__MINGW32__) //VS2005‚æ‚è‘O‚È‚ç
+#if (defined(_MSC_VER) && _MSC_VER<1400) || defined(__MINGW32__) //VS2005ã‚ˆã‚Šå‰ãªã‚‰
 errno_t wcscat_s(wchar_t* szDst, size_t nDstCount, const wchar_t* szSrc)
 {
-	// –{•¨‚Í _set_invalid_parameter_handler ‚Åİ’è‚³‚ê‚½ƒnƒ“ƒhƒ‰‚ª‹N“®‚µ‚Ü‚·
+	// æœ¬ç‰©ã¯ _set_invalid_parameter_handler ã§è¨­å®šã•ã‚ŒãŸãƒãƒ³ãƒ‰ãƒ©ãŒèµ·å‹•ã—ã¾ã™
 	if(!szDst)return EINVAL;
 	if(!szSrc)return EINVAL;
 
@@ -233,14 +233,14 @@ errno_t wcscat_s(wchar_t* szDst, size_t nDstCount, const wchar_t* szSrc)
 	if(nDstLen>=nDstCount)return EINVAL;
 
 	size_t nSrcCount=wcslen(szSrc)+1;
-	wchar_t* p=&szDst[nDstLen];           //’Ç‰ÁêŠ
-	int nRestCount = nDstCount-(p-szDst); //szDst‚É’Ç‰Á‚Å‚«‚é—v‘f”
+	wchar_t* p=&szDst[nDstLen];           //è¿½åŠ å ´æ‰€
+	int nRestCount = nDstCount-(p-szDst); //szDstã«è¿½åŠ ã§ãã‚‹è¦ç´ æ•°
 
-	//‚Í‚İo‚³‚È‚¢
+	//ã¯ã¿å‡ºã•ãªã„
 	if((int)nSrcCount<=nRestCount){
 		wmemmove(p,szSrc,nSrcCount);
 	}
-	//‚Í‚İo‚·
+	//ã¯ã¿å‡ºã™
 	else{
 		return ERANGE;
 		//wmemmove(p,szSrc,nRestCount-1); p[nRestCount-1]=L'\0';
@@ -253,7 +253,7 @@ errno_t strcat_s(char *dest, size_t num, const char *src)
 {
 	if(!dest || !src) return EINVAL;
 	size_t size1 = strnlen(dest, num);
-	if(size1 == num) return EINVAL; // dest‚ª–¢I—¹
+	if(size1 == num) return EINVAL; // destãŒæœªçµ‚äº†
 	if(num <= size1+strlen(src)) return ERANGE;
 	strcat(dest, src);
 	return 0;
@@ -316,28 +316,28 @@ size_t wcsnlen(const wchar_t *str, size_t num)
 }
 int vsprintf_s(char *buf, size_t num, const char *fmt, va_list vaarg)
 {
-	// è”²‚«
+	// æ‰‹æŠœã
 	if(!buf || num == 0 || !fmt) { errno = EINVAL; return -1; }
 	buf[num-1] = '\0';
 	return _vsnprintf(buf, num-1, fmt, vaarg);
 }
 int vswprintf_s(wchar_t *buf, size_t num, const wchar_t *fmt, va_list vaarg)
 {
-	// è”²‚«
+	// æ‰‹æŠœã
 	if(!buf || num == 0 || !fmt) { errno = EINVAL; return -1; }
 	buf[num-1] = L'\0';
 	return _vsnwprintf(buf, num-1, fmt, vaarg);
 }
 int vsnprintf_s(char *buf, size_t num, size_t count, const char *fmt, va_list vaarg)
 {
-	// è”²‚«
+	// æ‰‹æŠœã
 	if(!buf || num == 0 || !fmt) { errno = EINVAL; return -1; }
 	buf[num-1] = L'\0';
 	return _vsnprintf(buf, num-1, fmt, vaarg);
 }
 int _vsnwprintf_s(wchar_t *buf, size_t num, size_t count, const wchar_t *fmt, va_list vaarg)
 {
-	// è”²‚«
+	// æ‰‹æŠœã
 	if(!buf || num == 0 || !fmt) { errno = EINVAL; return -1; }
 	buf[num-1] = L'\0';
 	return _vsnwprintf(buf, num-1, fmt, vaarg);
@@ -346,11 +346,11 @@ int _vsnwprintf_s(wchar_t *buf, size_t num, size_t count, const wchar_t *fmt, va
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      •¶šƒR[ƒh•ÏŠ·                         //
+//                      æ–‡å­—ã‚³ãƒ¼ãƒ‰å¤‰æ›                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
-//SJIS¨UNICODEBI’[‚ÉL'\0'‚ğ•t‚¯‚Ä‚­‚ê‚é”ÅB
+//SJISâ†’UNICODEã€‚çµ‚ç«¯ã«L'\0'ã‚’ä»˜ã‘ã¦ãã‚Œã‚‹ç‰ˆã€‚
 size_t mbstowcs2(wchar_t* dst,const char* src,size_t dst_count)
 {
 	size_t ret=::mbstowcs(dst,src,dst_count-1);
@@ -371,7 +371,7 @@ size_t mbstowcs2(wchar_t* pDst, int nDstCount, const char* pSrc, int nSrcCount)
 	return (size_t)ret;
 }
 
-//UNICODE¨SJISBI’[‚É'\0'‚ğ•t‚¯‚Ä‚­‚ê‚é”ÅB
+//UNICODEâ†’SJISã€‚çµ‚ç«¯ã«'\0'ã‚’ä»˜ã‘ã¦ãã‚Œã‚‹ç‰ˆã€‚
 size_t wcstombs2(char* dst,const wchar_t* src,size_t dst_count)
 {
 	size_t ret=::wcstombs(dst,src,dst_count-1);
@@ -379,7 +379,7 @@ size_t wcstombs2(char* dst,const wchar_t* src,size_t dst_count)
 	return ret;
 }
 
-//SJIS¨UNICODEB–ß‚è’l‚Ínew[]‚ÅŠm•Û‚µ‚Ä•Ô‚·B
+//SJISâ†’UNICODEã€‚æˆ»ã‚Šå€¤ã¯new[]ã§ç¢ºä¿ã—ã¦è¿”ã™ã€‚
 wchar_t* mbstowcs_new(const char* src)
 {
 	size_t new_length=mbstowcs(NULL,src,0);
@@ -390,7 +390,7 @@ wchar_t* mbstowcs_new(const char* src)
 }
 wchar_t* mbstowcs_new(const char* pSrc, int nSrcLen, int* pnDstLen)
 {
-	//•K—v‚È—ÌˆæƒTƒCƒY
+	//å¿…è¦ãªé ˜åŸŸã‚µã‚¤ã‚º
 	int nNewLength = MultiByteToWideChar(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -400,10 +400,10 @@ wchar_t* mbstowcs_new(const char* pSrc, int nSrcLen, int* pnDstLen)
 		0
 	);
 	
-	//Šm•Û
+	//ç¢ºä¿
 	wchar_t* pNew = new wchar_t[nNewLength+1];
 
-	//•ÏŠ·
+	//å¤‰æ›
 	nNewLength = MultiByteToWideChar(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -419,15 +419,15 @@ wchar_t* mbstowcs_new(const char* pSrc, int nSrcLen, int* pnDstLen)
 	return pNew;
 }
 
-//UNICODE¨SJISB–ß‚è’l‚Ínew[]‚ÅŠm•Û‚µ‚Ä•Ô‚·B
+//UNICODEâ†’SJISã€‚æˆ»ã‚Šå€¤ã¯new[]ã§ç¢ºä¿ã—ã¦è¿”ã™ã€‚
 char* wcstombs_new(const wchar_t* src)
 {
 	return wcstombs_new(src,wcslen(src));
 }
-//–ß‚è’l‚Ínew[]‚ÅŠm•Û‚µ‚Ä•Ô‚·B
+//æˆ»ã‚Šå€¤ã¯new[]ã§ç¢ºä¿ã—ã¦è¿”ã™ã€‚
 char* wcstombs_new(const wchar_t* pSrc,int nSrcLen)
 {
-	//•K—v‚È—ÌˆæƒTƒCƒY
+	//å¿…è¦ãªé ˜åŸŸã‚µã‚¤ã‚º
 	int nNewLength = WideCharToMultiByte(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -439,10 +439,10 @@ char* wcstombs_new(const wchar_t* pSrc,int nSrcLen)
 		NULL
 	);
 
-	//Šm•Û
+	//ç¢ºä¿
 	char* pNew = new char[nNewLength+1];
 
-	//•ÏŠ·
+	//å¤‰æ›
 	nNewLength = WideCharToMultiByte(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -458,16 +458,16 @@ char* wcstombs_new(const wchar_t* pSrc,int nSrcLen)
 	return pNew;
 }
 
-//SJIS¨UNICODEB–ß‚è’l‚Ívector‚Æ‚µ‚Ä•Ô‚·B
+//SJISâ†’UNICODEã€‚æˆ»ã‚Šå€¤ã¯vectorã¨ã—ã¦è¿”ã™ã€‚
 void mbstowcs_vector(const char* src, std::vector<wchar_t>* ret)
 {
 	mbstowcs_vector(src,strlen(src),ret);
 }
 
-//¦–ß‚è’lret‚É‚¨‚¢‚ÄAret->size()‚ª•¶š—ñ’·‚Å‚Í‚È‚¢‚±‚Æ‚É’ˆÓB³‚µ‚­‚ÍA(ret->size()-1)‚ª•¶š—ñ’·‚Æ‚È‚éB
+//â€»æˆ»ã‚Šå€¤retã«ãŠã„ã¦ã€ret->size()ãŒæ–‡å­—åˆ—é•·ã§ã¯ãªã„ã“ã¨ã«æ³¨æ„ã€‚æ­£ã—ãã¯ã€(ret->size()-1)ãŒæ–‡å­—åˆ—é•·ã¨ãªã‚‹ã€‚
 void mbstowcs_vector(const char* pSrc, int nSrcLen, std::vector<wchar_t>* ret)
 {
-	//•K—v‚È—e—Ê
+	//å¿…è¦ãªå®¹é‡
 	int nNewLen = MultiByteToWideChar(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -477,10 +477,10 @@ void mbstowcs_vector(const char* pSrc, int nSrcLen, std::vector<wchar_t>* ret)
 		0
 	);
 
-	//Šm•Û
+	//ç¢ºä¿
 	ret->resize(nNewLen+1);
 
-	//•ÏŠ·
+	//å¤‰æ›
 	nNewLen = MultiByteToWideChar(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -493,14 +493,14 @@ void mbstowcs_vector(const char* pSrc, int nSrcLen, std::vector<wchar_t>* ret)
 }
 
 
-//UNICODE¨SJISB–ß‚è’l‚Ívector‚Æ‚µ‚Ä•Ô‚·B
+//UNICODEâ†’SJISã€‚æˆ»ã‚Šå€¤ã¯vectorã¨ã—ã¦è¿”ã™ã€‚
 void wcstombs_vector(const wchar_t* src, std::vector<char>* ret)
 {
 	wcstombs_vector(src,wcslen(src),ret);
 }
 void wcstombs_vector(const wchar_t* pSrc, int nSrcLen, std::vector<char>* ret)
 {
-	//•K—v‚È—e—Ê
+	//å¿…è¦ãªå®¹é‡
 	int nNewLen = WideCharToMultiByte(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -512,10 +512,10 @@ void wcstombs_vector(const wchar_t* pSrc, int nSrcLen, std::vector<char>* ret)
 		NULL
 	);
 
-	//Šm•Û
+	//ç¢ºä¿
 	ret->resize(nNewLen + 1);
 
-	//•ÏŠ·
+	//å¤‰æ›
 	nNewLen = WideCharToMultiByte(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -591,13 +591,13 @@ void wcstombs_vector(const wchar_t* pSrc, int nSrcLen, std::vector<char>* ret)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒƒ‚ƒŠ                             //
+//                          ãƒ¡ãƒ¢ãƒª                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 int wmemicmp(const WCHAR* p1,const WCHAR* p2,size_t count)
 {
 	for(size_t i=0;i<count;i++){
-		int n=skr_towlower(*p1++)-skr_towlower(*p2++);	//”ñASCII‚à•ÏŠ·
+		int n=skr_towlower(*p1++)-skr_towlower(*p2++);	//éASCIIã‚‚å¤‰æ›
 		if(n!=0)return n;
 	}
 	return 0;
@@ -611,7 +611,7 @@ int wmemicmp(const WCHAR* p1,const WCHAR* p2)
 int wmemicmp_ascii(const WCHAR* p1,const WCHAR* p2,size_t count)
 {
 	for(size_t i=0;i<count;i++){
-		int n=my_towlower(*p1++)-my_towlower(*p2++);	//ASCII‚Ì‚İ•ÏŠ·i‚‘¬j
+		int n=my_towlower(*p1++)-my_towlower(*p2++);	//ASCIIã®ã¿å¤‰æ›ï¼ˆé«˜é€Ÿï¼‰
 		if(n!=0)return n;
 	}
 	return 0;
@@ -623,16 +623,16 @@ int wmemicmp_ascii(const WCHAR* p1,const WCHAR* p2,size_t count)
 
 
 /*!
-	‹ó”’‚ğŠÜ‚Şƒtƒ@ƒCƒ‹–¼‚ğl—¶‚µ‚½ƒg[ƒNƒ“‚Ì•ªŠ„
+	ç©ºç™½ã‚’å«ã‚€ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è€ƒæ…®ã—ãŸãƒˆãƒ¼ã‚¯ãƒ³ã®åˆ†å‰²
 	
-	æ“ª‚É‚ ‚é˜A‘±‚µ‚½‹æØ‚è•¶š‚Í–³‹‚·‚éD
+	å…ˆé ­ã«ã‚ã‚‹é€£ç¶šã—ãŸåŒºåˆ‡ã‚Šæ–‡å­—ã¯ç„¡è¦–ã™ã‚‹ï¼
 	
-	@return ƒg[ƒNƒ“
+	@return ãƒˆãƒ¼ã‚¯ãƒ³
 
-	@date 2004.02.15 ‚İ‚­   Å“K‰»
-	@date 2007.10.21 kobake ƒeƒ“ƒvƒŒ[ƒg‰»
+	@date 2004.02.15 ã¿ã   æœ€é©åŒ–
+	@date 2007.10.21 kobake ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆåŒ–
 */
-//$ ‚¢‚¿‚¢‚¿èŠÔ‚©‚©‚éBB
+//$ ã„ã¡ã„ã¡æ‰‹é–“ã‹ã‹ã‚‹ã€‚ã€‚
 namespace{
 	template <class T> struct Charset{};
 	template <> struct Charset<ACHAR>{ static const ACHAR QUOT= '"'; };
@@ -640,17 +640,17 @@ namespace{
 }
 template <class CHAR_TYPE>
 CHAR_TYPE* my_strtok(
-	CHAR_TYPE*			pBuffer,	//[in] •¶š—ñƒoƒbƒtƒ@(I’[‚ª‚ ‚é‚±‚Æ)
-	int					nLen,		//[in] •¶š—ñ‚Ì’·‚³
-	int*				pnOffset,	//[in,out] ƒIƒtƒZƒbƒg
-	const CHAR_TYPE*	pDelimiter	//[in] ‹æØ‚è•¶š
+	CHAR_TYPE*			pBuffer,	//[in] æ–‡å­—åˆ—ãƒãƒƒãƒ•ã‚¡(çµ‚ç«¯ãŒã‚ã‚‹ã“ã¨)
+	int					nLen,		//[in] æ–‡å­—åˆ—ã®é•·ã•
+	int*				pnOffset,	//[in,out] ã‚ªãƒ•ã‚»ãƒƒãƒˆ
+	const CHAR_TYPE*	pDelimiter	//[in] åŒºåˆ‡ã‚Šæ–‡å­—
 )
 {
 	int i = *pnOffset;
 	CHAR_TYPE* p;
 
 	do {
-		bool bFlag = false;	//ƒ_ƒuƒ‹ƒR[ƒe[ƒVƒ‡ƒ“‚Ì’†‚©H
+		bool bFlag = false;	//ãƒ€ãƒ–ãƒ«ã‚³ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³ã®ä¸­ã‹ï¼Ÿ
 		if( i >= nLen ) return NULL;
 		p = &pBuffer[i];
 		for( ; i < nLen; i++ )
@@ -666,10 +666,10 @@ CHAR_TYPE* my_strtok(
 			}
 		}
 		*pnOffset = i;
-	} while( ! *p );	//‹ó‚Ìƒg[ƒNƒ“‚È‚çŸ‚ğ’T‚·
+	} while( ! *p );	//ç©ºã®ãƒˆãƒ¼ã‚¯ãƒ³ãªã‚‰æ¬¡ã‚’æ¢ã™
 	return p;
 }
-//ƒCƒ“ƒXƒ^ƒ“ƒX‰»
+//ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹åŒ–
 template ACHAR* my_strtok(ACHAR*,int,int*,const ACHAR*);
 template WCHAR* my_strtok(WCHAR*,int,int*,const WCHAR*);
 
@@ -677,7 +677,7 @@ template WCHAR* my_strtok(WCHAR*,int,int*,const WCHAR*);
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         À‘••â•                            //
+//                         å®Ÿè£…è£œåŠ©                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 #ifdef MY_ICMP_MBS
@@ -687,14 +687,14 @@ int my_mbisalpha2( int c );
 #endif  /* MY_ICMP_MBS */
 
 #ifdef MY_ICMP_MBS
-/*!	‘SŠpƒAƒ‹ƒtƒ@ƒxƒbƒg‚Ì‚Q•¶š–Ú‚ğ‘å•¶š‚É•ÏŠ·‚·‚éB
-	@param c [in] •ÏŠ·‚·‚é•¶šƒR[ƒh
+/*!	å…¨è§’ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆã®ï¼’æ–‡å­—ç›®ã‚’å¤§æ–‡å­—ã«å¤‰æ›ã™ã‚‹ã€‚
+	@param c [in] å¤‰æ›ã™ã‚‹æ–‡å­—ã‚³ãƒ¼ãƒ‰
 
 	@note
-		0x8260 - 0x8279 : ‚`...‚y
-		0x8281 - 0x829a : ‚...‚š
+		0x8260 - 0x8279 : ï¼¡...ï¼º
+		0x8281 - 0x829a : ï½...ï½š
 
-	@return •ÏŠ·‚³‚ê‚½•¶šƒR[ƒh
+	@return å¤‰æ›ã•ã‚ŒãŸæ–‡å­—ã‚³ãƒ¼ãƒ‰
 */
 int my_mbtoupper2( int c )
 {
@@ -706,10 +706,10 @@ int my_mbtoupper2( int c )
 
 
 #ifdef MY_ICMP_MBS
-/*!	‘SŠpƒAƒ‹ƒtƒ@ƒxƒbƒg‚Ì‚Q•¶š–Ú‚ğ¬•¶š‚É•ÏŠ·‚·‚éB
-	@param c [in] •ÏŠ·‚·‚é•¶šƒR[ƒh
+/*!	å…¨è§’ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆã®ï¼’æ–‡å­—ç›®ã‚’å°æ–‡å­—ã«å¤‰æ›ã™ã‚‹ã€‚
+	@param c [in] å¤‰æ›ã™ã‚‹æ–‡å­—ã‚³ãƒ¼ãƒ‰
 
-	@return •ÏŠ·‚³‚ê‚½•¶šƒR[ƒh
+	@return å¤‰æ›ã•ã‚ŒãŸæ–‡å­—ã‚³ãƒ¼ãƒ‰
 */
 int my_mbtolower2( int c )
 {
@@ -721,11 +721,11 @@ int my_mbtolower2( int c )
 
 
 #ifdef MY_ICMP_MBS
-/*!	‘SŠpƒAƒ‹ƒtƒ@ƒxƒbƒg‚Ì‚Q•¶š–Ú‚©’²‚×‚éB
-	@param c [in] ŒŸ¸‚·‚é•¶šƒR[ƒh
+/*!	å…¨è§’ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆã®ï¼’æ–‡å­—ç›®ã‹èª¿ã¹ã‚‹ã€‚
+	@param c [in] æ¤œæŸ»ã™ã‚‹æ–‡å­—ã‚³ãƒ¼ãƒ‰
 
-	@retval 1	‘SŠpƒAƒ‹ƒtƒ@ƒxƒbƒg‚QƒoƒCƒg–Ú‚Å‚ ‚é
-	@retval 0	‚¿‚ª‚¤
+	@retval 1	å…¨è§’ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆï¼’ãƒã‚¤ãƒˆç›®ã§ã‚ã‚‹
+	@retval 0	ã¡ãŒã†
 */
 int my_mbisalpha2( int c )
 {
@@ -737,25 +737,25 @@ int my_mbisalpha2( int c )
 
 
 
-/*!	‘å•¶š¬•¶š‚ğ“¯ˆê‹‚·‚é•¶š—ñ’·‚³§ŒÀ”äŠr‚ğ‚·‚éB
-	@param s1   [in] •¶š—ñ‚P
-	@param s2   [in] •¶š—ñ‚Q
-	@param n    [in] •¶š’·
-	@param dcount  [in] ƒXƒeƒbƒv’l (1=strnicmp,memicmp, 0=stricmp)
-	@param flag [in] •¶š—ñI’[ƒ`ƒFƒbƒN (true=stricmp,strnicmp, false=memicmp)
+/*!	å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–ã™ã‚‹æ–‡å­—åˆ—é•·ã•åˆ¶é™æ¯”è¼ƒã‚’ã™ã‚‹ã€‚
+	@param s1   [in] æ–‡å­—åˆ—ï¼‘
+	@param s2   [in] æ–‡å­—åˆ—ï¼’
+	@param n    [in] æ–‡å­—é•·
+	@param dcount  [in] ã‚¹ãƒ†ãƒƒãƒ—å€¤ (1=strnicmp,memicmp, 0=stricmp)
+	@param flag [in] æ–‡å­—åˆ—çµ‚ç«¯ãƒã‚§ãƒƒã‚¯ (true=stricmp,strnicmp, false=memicmp)
 
-	@retval 0	ˆê’v
-	@date 2002.11.29 Moca 0ˆÈŠO‚Ì‚Ì–ß‚è’l‚ğCuŒ³‚Ì’l‚Ì·v‚©‚çu‘å•¶š‚Æ‚µ‚½‚Æ‚«‚Ì·v‚É•ÏX
+	@retval 0	ä¸€è‡´
+	@date 2002.11.29 Moca 0ä»¥å¤–ã®æ™‚ã®æˆ»ã‚Šå€¤ã‚’ï¼Œã€Œå…ƒã®å€¤ã®å·®ã€ã‹ã‚‰ã€Œå¤§æ–‡å­—ã¨ã—ãŸã¨ãã®å·®ã€ã«å¤‰æ›´
  */
 int __cdecl my_internal_icmp( const char *s1, const char *s2, unsigned int n, unsigned int dcount, bool flag )
 {
 	unsigned int	i;
 	unsigned char	*p1, *p2;
-//	2002.11.29 Moca Œ³‚Ì’l‚ğ•Û‚·‚é•K—v‚ª‚È‚­‚È‚Á‚½‚½‚ß *_lo, *_up‚ğíœ
+//	2002.11.29 Moca å…ƒã®å€¤ã‚’ä¿æŒã™ã‚‹å¿…è¦ãŒãªããªã£ãŸãŸã‚ *_lo, *_upã‚’å‰Šé™¤
 //	int	c1, c1_lo, c1_up;
 //	int	c2, c2_lo, c2_up;
 	int 	c1, c2;
-	bool	prev1, prev2; /* ‘O‚Ì•¶š‚ª SJIS‚Ì‚PƒoƒCƒg–Ú‚© */
+	bool	prev1, prev2; /* å‰ã®æ–‡å­—ãŒ SJISã®ï¼‘ãƒã‚¤ãƒˆç›®ã‹ */
 #ifdef MY_ICMP_MBS
 	bool	mba1, mba2;
 #endif  /* MY_ICMP_MBS */
@@ -767,23 +767,23 @@ int __cdecl my_internal_icmp( const char *s1, const char *s2, unsigned int n, un
 	mba1 = mba2 = false;
 #endif  /* MY_ICMP_MBS */
 
-	/* w’è’·‚¾‚¯ŒJ‚è•Ô‚· */
+	/* æŒ‡å®šé•·ã ã‘ç¹°ã‚Šè¿”ã™ */
 	for(i = n; i > 0; i -= dcount)
 	{
-		/* ”äŠr‘ÎÛ‚Æ‚È‚é•¶š‚ğæ“¾‚·‚é */
+		/* æ¯”è¼ƒå¯¾è±¡ã¨ãªã‚‹æ–‡å­—ã‚’å–å¾—ã™ã‚‹ */
 //		c1 = c1_lo = c1_up = (int)((unsigned int)*p1);
 //		c2 = c2_lo = c2_up = (int)((unsigned int)*p2);
 		c1 = (int)((unsigned int)*p1);
 		c2 = (int)((unsigned int)*p2);
 
-		/* 2002.11.29 Moca •¶š—ñ‚ÌI’[‚É’B‚µ‚½‚©’²‚×‚é•”•ª ‚ÍŒã•û‚ÖˆÚ“® */
+		/* 2002.11.29 Moca æ–‡å­—åˆ—ã®çµ‚ç«¯ã«é”ã—ãŸã‹èª¿ã¹ã‚‹éƒ¨åˆ† ã¯å¾Œæ–¹ã¸ç§»å‹• */
 
-		/* •¶š‚P‚Ì“ú–{Œêƒ`ƒFƒbƒN‚ğs‚¢”äŠr—p‚Ì‘å•¶š¬•¶š‚ğƒZƒbƒg‚·‚é */
-		if( prev1 ){	/* ‘O‚Ì•¶š‚ª“ú–{Œê‚PƒoƒCƒg–Ú */
-			/* ¡‰ñ‚Í“ú–{Œê‚QƒoƒCƒg–Ú‚È‚Ì‚Å•ÏŠ·‚µ‚È‚¢ */
+		/* æ–‡å­—ï¼‘ã®æ—¥æœ¬èªãƒã‚§ãƒƒã‚¯ã‚’è¡Œã„æ¯”è¼ƒç”¨ã®å¤§æ–‡å­—å°æ–‡å­—ã‚’ã‚»ãƒƒãƒˆã™ã‚‹ */
+		if( prev1 ){	/* å‰ã®æ–‡å­—ãŒæ—¥æœ¬èªï¼‘ãƒã‚¤ãƒˆç›® */
+			/* ä»Šå›ã¯æ—¥æœ¬èªï¼’ãƒã‚¤ãƒˆç›®ãªã®ã§å¤‰æ›ã—ãªã„ */
 			prev1 = false;
 #ifdef MY_ICMP_MBS
-			/* ‘SŠp•¶š‚ÌƒAƒ‹ƒtƒ@ƒxƒbƒg */
+			/* å…¨è§’æ–‡å­—ã®ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆ */
 			if( mba1 ){
 				mba1 = false;
 				if( my_mbisalpha2( c1 ) ){
@@ -793,7 +793,7 @@ int __cdecl my_internal_icmp( const char *s1, const char *s2, unsigned int n, un
 #endif  /* MY_ICMP_MBS */
 		}
 		else if( my_iskanji1(c1) ){
-			/* ¡‰ñ‚Í“ú–{Œê‚PƒoƒCƒg–Ú‚È‚Ì‚Å•ÏŠ·‚µ‚È‚¢ */
+			/* ä»Šå›ã¯æ—¥æœ¬èªï¼‘ãƒã‚¤ãƒˆç›®ãªã®ã§å¤‰æ›ã—ãªã„ */
 			prev1 = true;
 #ifdef MY_ICMP_MBS
 			if( c1 == 0x82 ) mba1 = true;
@@ -803,12 +803,12 @@ int __cdecl my_internal_icmp( const char *s1, const char *s2, unsigned int n, un
 			c1 = my_toupper(c1);
 		}
 
-		/* •¶š‚Q‚Ì“ú–{Œêƒ`ƒFƒbƒN‚ğs‚¢”äŠr—p‚Ì‘å•¶š¬•¶š‚ğƒZƒbƒg‚·‚é */
-		if( prev2 ){	/* ‘O‚Ì•¶š‚ª“ú–{Œê‚PƒoƒCƒg–Ú */
-			/* ¡‰ñ‚Í“ú–{Œê‚QƒoƒCƒg–Ú‚È‚Ì‚Å•ÏŠ·‚µ‚È‚¢ */
+		/* æ–‡å­—ï¼’ã®æ—¥æœ¬èªãƒã‚§ãƒƒã‚¯ã‚’è¡Œã„æ¯”è¼ƒç”¨ã®å¤§æ–‡å­—å°æ–‡å­—ã‚’ã‚»ãƒƒãƒˆã™ã‚‹ */
+		if( prev2 ){	/* å‰ã®æ–‡å­—ãŒæ—¥æœ¬èªï¼‘ãƒã‚¤ãƒˆç›® */
+			/* ä»Šå›ã¯æ—¥æœ¬èªï¼’ãƒã‚¤ãƒˆç›®ãªã®ã§å¤‰æ›ã—ãªã„ */
 			prev2 = false;
 #ifdef MY_ICMP_MBS
-			/* ‘SŠp•¶š‚ÌƒAƒ‹ƒtƒ@ƒxƒbƒg */
+			/* å…¨è§’æ–‡å­—ã®ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆ */
 			if( mba2 ){
 				mba2 = false;
 				if( my_mbisalpha2( c2 ) ){
@@ -818,7 +818,7 @@ int __cdecl my_internal_icmp( const char *s1, const char *s2, unsigned int n, un
 #endif  /* MY_ICMP_MBS */
 		}
 		else if( my_iskanji1(c2) ){
-			/* ¡‰ñ‚Í“ú–{Œê‚PƒoƒCƒg–Ú‚È‚Ì‚Å•ÏŠ·‚µ‚È‚¢ */
+			/* ä»Šå›ã¯æ—¥æœ¬èªï¼‘ãƒã‚¤ãƒˆç›®ãªã®ã§å¤‰æ›ã—ãªã„ */
 			prev2 = true;
 #ifdef MY_ICMP_MBS
 			if( c2 == 0x82 ) mba2 = true;
@@ -828,17 +828,17 @@ int __cdecl my_internal_icmp( const char *s1, const char *s2, unsigned int n, un
 			c2 = my_toupper(c2);
 		}
 
-		/* ”äŠr‚·‚é */
-//		if( (c1_lo - c2_lo) && (c1_up - c2_up) ) return c1 - c2;	/* –ß‚è’l‚ÍŒ³‚Ì•¶š‚Ì· */
-		if( c1 - c2 ) return c1 - c2;	/* –ß‚è’l‚Í‘å•¶š‚É•ÏŠ·‚µ‚½•¶š‚Ì· */
+		/* æ¯”è¼ƒã™ã‚‹ */
+//		if( (c1_lo - c2_lo) && (c1_up - c2_up) ) return c1 - c2;	/* æˆ»ã‚Šå€¤ã¯å…ƒã®æ–‡å­—ã®å·® */
+		if( c1 - c2 ) return c1 - c2;	/* æˆ»ã‚Šå€¤ã¯å¤§æ–‡å­—ã«å¤‰æ›ã—ãŸæ–‡å­—ã®å·® */
 
-		/* 2002.11.29 Moca –ß‚è’l‚ğ•ÏX‚µ‚½‚±‚Æ‚É‚æ‚èC¬•¶š¨‘å•¶š•ÏŠ·‚ÌŒã‚ÉˆÚ“®
-		   •Ğ•û‚¾‚¯ NULL•¶š ‚Ìê‡‚Íã‚Ì”äŠr‚µ‚½“_‚Å return ‚·‚é‚½‚ß‚»‚Ìˆ—‚Í•s—v */
+		/* 2002.11.29 Moca æˆ»ã‚Šå€¤ã‚’å¤‰æ›´ã—ãŸã“ã¨ã«ã‚ˆã‚Šï¼Œå°æ–‡å­—â†’å¤§æ–‡å­—å¤‰æ›ã®å¾Œã«ç§»å‹•
+		   ç‰‡æ–¹ã ã‘ NULLæ–‡å­— ã®å ´åˆã¯ä¸Šã®æ¯”è¼ƒã—ãŸæ™‚ç‚¹ã§ return ã™ã‚‹ãŸã‚ãã®å‡¦ç†ã¯ä¸è¦ */
 		if( flag ){
-			/* •¶š—ñ‚ÌI’[‚É’B‚µ‚½‚©’²‚×‚é */
+			/* æ–‡å­—åˆ—ã®çµ‚ç«¯ã«é”ã—ãŸã‹èª¿ã¹ã‚‹ */
 			if( ! c1 ) return 0;
 		}
-		/* ƒ|ƒCƒ“ƒ^‚ği‚ß‚é */
+		/* ãƒã‚¤ãƒ³ã‚¿ã‚’é€²ã‚ã‚‹ */
 		p1++;
 		p2++;
 	}
@@ -850,25 +850,25 @@ int __cdecl my_internal_icmp( const char *s1, const char *s2, unsigned int n, un
 // skr_towupper() / skr_tolower()
 //
 // 2010.09.28 ryoji
-// BugReport/64: towupper(c) ‚É‚æ‚Á‚Ä U+00e0-U+00fc ‚Æ U+0020 ‚ª“¯ˆê‹‚³‚ê‚é–â‘è‚Ì‘Îô
-// VC ‚Ìƒ‰ƒ“ƒ^ƒCƒ€‚Í c < 256 ‚ÌğŒ‚Å‚Í‚È‚º‚© locale ‚É‘Î‰‚µ‚½ "ANSI Œn‚Ì" •ÏŠ·ƒe[ƒuƒ‹ˆø‚«‚ğs‚Á‚Ä‚¢‚é–Í—l
-// iUnicode Œn•ÏŠ·ŠÖ”‚È‚Ì‚É locale ‚ª "Japanese" ‚¾‚Æ c < 256 ‚Ì”ÍˆÍ‚Å‚Í SJIS —p‚ç‚µ‚«•ÏŠ·ƒe[ƒuƒ‹‚ªg‚í‚ê‚éj
-// ‚»‚ê‚Å‚Í“s‡‚ªˆ«‚¢‚Ì‚Å c < 256 ”ÍˆÍ‚Ì•ÏŠ·‚É "English"(Windows-1252) locale ‚ğ—˜—p‚·‚éB
-//   EUnicode ‚ÌÅ‰‚Ì 256 ŒÂ‚Ì•„†ˆÊ’u‚Í Windows-1252 ‚ÌeÊ‚Ì ISO-8859-1 —R—ˆB
-//   E‘Šˆá‚Í 0x80-0x9F ‚Ì‹æŠÔ‚ÅAWindows-1252 ‚Å‚Í}Œ`•¶šAISO-8859-1(Unicode) ‚Å‚Í§Œä•¶šB
-// ¦ ƒ‰ƒ“ƒ^ƒCƒ€‚Ì towupper(c)/tolower(c) ‚ª«—ˆŠú‘Ò‚·‚é“®ì‚É‚È‚Á‚½‚Æ‚µ‚Ä‚à‚±‚Ì•û–@‚ğg‚¢‘±‚¯‚Ä–â‘è–³‚¢‚Í‚¸
+// BugReport/64: towupper(c) ã«ã‚ˆã£ã¦ U+00e0-U+00fc ã¨ U+0020 ãŒåŒä¸€è¦–ã•ã‚Œã‚‹å•é¡Œã®å¯¾ç­–
+// VC ã®ãƒ©ãƒ³ã‚¿ã‚¤ãƒ ã¯ c < 256 ã®æ¡ä»¶ã§ã¯ãªãœã‹ locale ã«å¯¾å¿œã—ãŸ "ANSI ç³»ã®" å¤‰æ›ãƒ†ãƒ¼ãƒ–ãƒ«å¼•ãã‚’è¡Œã£ã¦ã„ã‚‹æ¨¡æ§˜
+// ï¼ˆUnicode ç³»å¤‰æ›é–¢æ•°ãªã®ã« locale ãŒ "Japanese" ã ã¨ c < 256 ã®ç¯„å›²ã§ã¯ SJIS ç”¨ã‚‰ã—ãå¤‰æ›ãƒ†ãƒ¼ãƒ–ãƒ«ãŒä½¿ã‚ã‚Œã‚‹ï¼‰
+// ãã‚Œã§ã¯éƒ½åˆãŒæ‚ªã„ã®ã§ c < 256 ç¯„å›²ã®å¤‰æ›ã« "English"(Windows-1252) locale ã‚’åˆ©ç”¨ã™ã‚‹ã€‚
+//   ãƒ»Unicode ã®æœ€åˆã® 256 å€‹ã®ç¬¦å·ä½ç½®ã¯ Windows-1252 ã®è¦ªæˆšã® ISO-8859-1 ç”±æ¥ã€‚
+//   ãƒ»ç›¸é•ã¯ 0x80-0x9F ã®åŒºé–“ã§ã€Windows-1252 ã§ã¯å›³å½¢æ–‡å­—ã€ISO-8859-1(Unicode) ã§ã¯åˆ¶å¾¡æ–‡å­—ã€‚
+// â€» ãƒ©ãƒ³ã‚¿ã‚¤ãƒ ã® towupper(c)/tolower(c) ãŒå°†æ¥æœŸå¾…ã™ã‚‹å‹•ä½œã«ãªã£ãŸã¨ã—ã¦ã‚‚ã“ã®æ–¹æ³•ã‚’ä½¿ã„ç¶šã‘ã¦å•é¡Œç„¡ã„ã¯ãš
 int skr_towupper( int c )
 {
-#if defined(_MSC_VER) && _MSC_VER>=1400 //VS2005ˆÈ~‚È‚ç
-	static wchar_t szMap[256];	// c < 256 —p‚Ì•ÏŠ·ƒe[ƒuƒ‹
+#if defined(_MSC_VER) && _MSC_VER>=1400 //VS2005ä»¥é™ãªã‚‰
+	static wchar_t szMap[256];	// c < 256 ç”¨ã®å¤‰æ›ãƒ†ãƒ¼ãƒ–ãƒ«
 	static bool bInit = false;
 	if( !bInit ){
 		int i;
 		_locale_t locale = _create_locale( LC_CTYPE, "English" );
-		for( i = 0; i < 0x80; i++ ) szMap[i] = (wchar_t)my_towupper( i );	// ©‘O‚Å•ÏŠ·
-		for( ; i < 0xA0; i++ ) szMap[i] = (wchar_t)i;						// –³•ÏŠ·i§ŒäƒR[ƒh•”j
-		for( ; i < 255; i++ ) szMap[i] = _towupper_l( (wchar_t)i, locale );	// "English"locale‚Å•ÏŠ·
-		szMap[255] = 0x0178;	// Windows-1252 ‚¾‚Æ 0x9f(§Œä•¶šˆæ) ‚Éƒ}ƒbƒv‚µ‚Ä‚µ‚Ü‚¤‚Ì‚Å
+		for( i = 0; i < 0x80; i++ ) szMap[i] = (wchar_t)my_towupper( i );	// è‡ªå‰ã§å¤‰æ›
+		for( ; i < 0xA0; i++ ) szMap[i] = (wchar_t)i;						// ç„¡å¤‰æ›ï¼ˆåˆ¶å¾¡ã‚³ãƒ¼ãƒ‰éƒ¨ï¼‰
+		for( ; i < 255; i++ ) szMap[i] = _towupper_l( (wchar_t)i, locale );	// "English"localeã§å¤‰æ›
+		szMap[255] = 0x0178;	// Windows-1252 ã ã¨ 0x9f(åˆ¶å¾¡æ–‡å­—åŸŸ) ã«ãƒãƒƒãƒ—ã—ã¦ã—ã¾ã†ã®ã§
 		_free_locale( locale );
 		bInit = true;
 	}
@@ -880,15 +880,15 @@ int skr_towupper( int c )
 
 int skr_towlower( int c )
 {
-#if defined(_MSC_VER) && _MSC_VER>=1400 //VS2005ˆÈ~‚È‚ç
-	static wchar_t szMap[256];	// c < 256 —p‚Ì•ÏŠ·ƒe[ƒuƒ‹
+#if defined(_MSC_VER) && _MSC_VER>=1400 //VS2005ä»¥é™ãªã‚‰
+	static wchar_t szMap[256];	// c < 256 ç”¨ã®å¤‰æ›ãƒ†ãƒ¼ãƒ–ãƒ«
 	static bool bInit = false;
 	if( !bInit ){
 		int i;
 		_locale_t locale = _create_locale( LC_CTYPE, "English" );
-		for( i = 0; i < 0x80; i++ ) szMap[i] = (wchar_t)my_towlower( i );	// ©‘O‚Å•ÏŠ·
-		for( ; i < 0xA0; i++ ) szMap[i] = (wchar_t)i;						// –³•ÏŠ·i§ŒäƒR[ƒh•”j
-		for( ; i < 256; i++ ) szMap[i] = _towlower_l( (wchar_t)i, locale );	// "English"locale‚Å•ÏŠ·
+		for( i = 0; i < 0x80; i++ ) szMap[i] = (wchar_t)my_towlower( i );	// è‡ªå‰ã§å¤‰æ›
+		for( ; i < 0xA0; i++ ) szMap[i] = (wchar_t)i;						// ç„¡å¤‰æ›ï¼ˆåˆ¶å¾¡ã‚³ãƒ¼ãƒ‰éƒ¨ï¼‰
+		for( ; i < 256; i++ ) szMap[i] = _towlower_l( (wchar_t)i, locale );	// "English"localeã§å¤‰æ›
 		_free_locale( locale );
 		bInit = true;
 	}

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,52 +25,52 @@
 #define SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_
 
 // 2007.10.19 kobake
-// string.h ‚Å’è‹`‚³‚ê‚Ä‚¢‚éŠÖ”‚ğŠg’£‚µ‚½‚æ‚¤‚Èƒ‚ƒm’B
+// string.h ã§å®šç¾©ã•ã‚Œã¦ã„ã‚‹é–¢æ•°ã‚’æ‹¡å¼µã—ãŸã‚ˆã†ãªãƒ¢ãƒé”
 
 
 /*
-	++ ++ –½–¼Ql(‹K‘¥‚Å‚Í–³‚¢) ++ ++
+	++ ++ å‘½åå‚è€ƒ(è¦å‰‡ã§ã¯ç„¡ã„) ++ ++
 
-	•W€ŠÖ”‚©‚çˆø—p
-	`_s:  ƒoƒbƒtƒ@ƒI[ƒo[ƒtƒ[l—¶”Å (—á: strcpy_s)
-	`i`: ‘å•¶š¬•¶š‹æ•Ê–³‚µ”Å       (—á: stricmp)
+	æ¨™æº–é–¢æ•°ã‹ã‚‰å¼•ç”¨
+	ï½_s:  ãƒãƒƒãƒ•ã‚¡ã‚ªãƒ¼ãƒãƒ¼ãƒ•ãƒ­ãƒ¼è€ƒæ…®ç‰ˆ (ä¾‹: strcpy_s)
+	ï½iï½: å¤§æ–‡å­—å°æ–‡å­—åŒºåˆ¥ç„¡ã—ç‰ˆ       (ä¾‹: stricmp)
 
-	“Æ©
-	auto_`:  ˆø”‚ÌŒ^‚É‚æ‚èA©“®‚Åˆ—‚ªŒˆ’è‚³‚ê‚é”Å (—á: auto_strcpy)
+	ç‹¬è‡ª
+	auto_ï½:  å¼•æ•°ã®å‹ã«ã‚ˆã‚Šã€è‡ªå‹•ã§å‡¦ç†ãŒæ±ºå®šã•ã‚Œã‚‹ç‰ˆ (ä¾‹: auto_strcpy)
 */
 
 #include "util/tchar_printf.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒƒ‚ƒŠ                             //
+//                          ãƒ¡ãƒ¢ãƒª                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-// •¶š—ñƒRƒs[‚â•¶š—ñ”äŠr‚ÌÛ‚ÉAmemŒnŠÖ”‚ªg‚í‚ê‚Ä‚¢‚é‰ÓŠ‚ª‘½X‚ ‚è‚Ü‚·‚ªA
-// memŒnŠÖ”‚Ívoidƒ|ƒCƒ“ƒ^‚ğó‚¯æ‚èAŒ^ƒ`ƒFƒbƒN‚ªs‚í‚ê‚È‚¢‚Ì‚ÅŠëŒ¯‚Å‚·B
-// ‚±‚±‚ÉAŒ^ƒ`ƒFƒbƒN•t‚«‚ÌmemŒnŒİŠ·‚ÌŠÖ”‚ğì¬‚µ‚Ü‚µ‚½Bc‚Æ‘‚¢‚½‚¯‚ÇAÀÛ‚Ìƒvƒƒgƒ^ƒCƒv‚Í‚à‚Á‚Æ‰º‚Ì‚Ù‚¤‚ÉBB(auto_mem`)
-// (¦‘ÎÛ‚ªƒƒ‚ƒŠ‚È‚Ì‚ÅA‚»‚à‚»‚à•¶š‚Æ‚¢‚¤ŠT”O‚Í–³‚¢‚ªA
-//    •Ö‹XãAACHARŒn‚Å‚Í1ƒoƒCƒg’PˆÊ‚ğAWCHARŒn‚Å‚Í2ƒoƒCƒg’PˆÊ‚ğA
-//    •¶š‚Æ‚İ‚È‚µ‚Äˆ—‚ğs‚¤A‚Æ‚¢‚¤‚±‚Æ‚Å)
+// æ–‡å­—åˆ—ã‚³ãƒ”ãƒ¼ã‚„æ–‡å­—åˆ—æ¯”è¼ƒã®éš›ã«ã€memç³»é–¢æ•°ãŒä½¿ã‚ã‚Œã¦ã„ã‚‹ç®‡æ‰€ãŒå¤šã€…ã‚ã‚Šã¾ã™ãŒã€
+// memç³»é–¢æ•°ã¯voidãƒã‚¤ãƒ³ã‚¿ã‚’å—ã‘å–ã‚Šã€å‹ãƒã‚§ãƒƒã‚¯ãŒè¡Œã‚ã‚Œãªã„ã®ã§å±é™ºã§ã™ã€‚
+// ã“ã“ã«ã€å‹ãƒã‚§ãƒƒã‚¯ä»˜ãã®memç³»äº’æ›ã®é–¢æ•°ã‚’ä½œæˆã—ã¾ã—ãŸã€‚â€¦ã¨æ›¸ã„ãŸã‘ã©ã€å®Ÿéš›ã®ãƒ—ãƒ­ãƒˆã‚¿ã‚¤ãƒ—ã¯ã‚‚ã£ã¨ä¸‹ã®ã»ã†ã«ã€‚ã€‚(auto_memï½)
+// (â€»å¯¾è±¡ãŒãƒ¡ãƒ¢ãƒªãªã®ã§ã€ãã‚‚ãã‚‚æ–‡å­—ã¨ã„ã†æ¦‚å¿µã¯ç„¡ã„ãŒã€
+//    ä¾¿å®œä¸Šã€ACHARç³»ã§ã¯1ãƒã‚¤ãƒˆå˜ä½ã‚’ã€WCHARç³»ã§ã¯2ãƒã‚¤ãƒˆå˜ä½ã‚’ã€
+//    æ–‡å­—ã¨ã¿ãªã—ã¦å‡¦ç†ã‚’è¡Œã†ã€ã¨ã„ã†ã“ã¨ã§)
 
-//ƒƒ‚ƒŠ”äŠr
+//ãƒ¡ãƒ¢ãƒªæ¯”è¼ƒ
 inline int amemcmp(const ACHAR* p1, const ACHAR* p2, size_t count){ return ::memcmp(p1,p2,count); }
 
-//‘å•¶š¬•¶š‚ğ‹æ•Ê‚¹‚¸‚Éƒƒ‚ƒŠ”äŠr
+//å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã›ãšã«ãƒ¡ãƒ¢ãƒªæ¯”è¼ƒ
 inline int amemicmp(const ACHAR* p1, const ACHAR* p2, size_t count){ return ::memicmp(p1,p2,count); }
        int wmemicmp(const WCHAR* p1, const WCHAR* p2, size_t count);
        int wmemicmp(const WCHAR* p1, const WCHAR* p2 );
        int wmemicmp_ascii(const WCHAR* p1, const WCHAR* p2, size_t count);
 
-//Œ³‚ÌŠÖ”‚Æ“¯‚¶ƒVƒOƒjƒ`ƒƒ”ÅB
-//•¶š—ñˆÈŠO‚Ìƒƒ‚ƒŠˆ—‚Åmem`ŒnŠÖ”‚ğg‚¤ê–Ê‚Å‚ÍA‚±‚ÌŠÖ”‚ğg‚Á‚Ä‚¨‚­‚ÆAˆÓ–¡‡‚¢‚ª‚Í‚Á‚«‚è‚µ‚Ä—Ç‚¢B
+//å…ƒã®é–¢æ•°ã¨åŒã˜ã‚·ã‚°ãƒ‹ãƒãƒ£ç‰ˆã€‚
+//æ–‡å­—åˆ—ä»¥å¤–ã®ãƒ¡ãƒ¢ãƒªå‡¦ç†ã§memï½ç³»é–¢æ•°ã‚’ä½¿ã†å ´é¢ã§ã¯ã€ã“ã®é–¢æ•°ã‚’ä½¿ã£ã¦ãŠãã¨ã€æ„å‘³åˆã„ãŒã¯ã£ãã‚Šã—ã¦è‰¯ã„ã€‚
 inline void* memset_raw(void* dest, int c, size_t size){ return ::memset(dest,c,size); }
 inline void* memcpy_raw(void* dest, const void* src, size_t size){ return ::memcpy(dest,src,size); }
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           •¶š                              //
+//                           æ–‡å­—                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//•¶š•ÏŠ·
+//æ–‡å­—å¤‰æ›
 inline int my_toupper( int c ){ return (((c) >= 'a') && ((c) <= 'z')) ? ((c) - 'a' + 'A') : (c); }
 inline int my_tolower( int c ){ return (((c) >= 'A') && ((c) <= 'Z')) ? ((c) - 'A' + 'a') : (c); }
 inline int my_towupper( int c ){ return (((c) >= L'a') && ((c) <= L'z')) ? ((c) - L'a' + L'A') : (c); }
@@ -88,16 +88,16 @@ int skr_towlower( int c );
 #endif
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           Šg’£E“Æ©À‘•                    //
+//                           æ‹¡å¼µãƒ»ç‹¬è‡ªå®Ÿè£…                    //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//•¶š”‚ÌãŒÀ•t‚«ƒRƒs[
-LPWSTR wcscpyn(LPWSTR lpString1,LPCWSTR lpString2,int iMaxLength); //iMaxLength‚Í•¶š’PˆÊB
+//æ–‡å­—æ•°ã®ä¸Šé™ä»˜ãã‚³ãƒ”ãƒ¼
+LPWSTR wcscpyn(LPWSTR lpString1,LPCWSTR lpString2,int iMaxLength); //iMaxLengthã¯æ–‡å­—å˜ä½ã€‚
 
 //	Apr. 03, 2003 genta
 char *strncpy_ex(char *dst, size_t dst_count, const char* src, size_t src_count);
 
-//‘å•¶š¬•¶š‚ğ‹æ•Ê‚¹‚¸‚É•¶š—ñ‚ğŒŸõ
+//å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã›ãšã«æ–‡å­—åˆ—ã‚’æ¤œç´¢
 const WCHAR* wcsistr( const WCHAR* s1, const WCHAR* s2 );
 const ACHAR* stristr( const ACHAR* s1, const ACHAR* s2 );
 inline WCHAR* wcsistr( WCHAR* s1, const WCHAR* s2 ){ return const_cast<WCHAR*>(wcsistr(static_cast<const WCHAR*>(s1),s2)); }
@@ -108,11 +108,11 @@ inline ACHAR* stristr( ACHAR* s1, const ACHAR* s2 ){ return const_cast<ACHAR*>(s
 #define _tcsistr stristr
 #endif
 
-//‘å•¶š¬•¶š‚ğ‹æ•Ê‚¹‚¸‚É•¶š—ñ‚ğŒŸõi“ú–{Œê‘Î‰”Åj
-const char* strchr_j(const char* s1, char c);				//!< strchr ‚Ì“ú–{Œê‘Î‰”ÅB
-const char* strichr_j( const char* s1, char c );			//!< strchr ‚Ì‘å•¶š¬•¶š“¯ˆê‹•“ú–{Œê‘Î‰”ÅB
-const char* strstr_j(const char* s1, const char* s2);		//!< strstr ‚Ì“ú–{Œê‘Î‰”ÅB
-const char* stristr_j( const char* s1, const char* s2 );	//!< strstr ‚Ì‘å•¶š¬•¶š“¯ˆê‹•“ú–{Œê‘Î‰”ÅB
+//å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒºåˆ¥ã›ãšã«æ–‡å­—åˆ—ã‚’æ¤œç´¢ï¼ˆæ—¥æœ¬èªå¯¾å¿œç‰ˆï¼‰
+const char* strchr_j(const char* s1, char c);				//!< strchr ã®æ—¥æœ¬èªå¯¾å¿œç‰ˆã€‚
+const char* strichr_j( const char* s1, char c );			//!< strchr ã®å¤§æ–‡å­—å°æ–‡å­—åŒä¸€è¦–ï¼†æ—¥æœ¬èªå¯¾å¿œç‰ˆã€‚
+const char* strstr_j(const char* s1, const char* s2);		//!< strstr ã®æ—¥æœ¬èªå¯¾å¿œç‰ˆã€‚
+const char* stristr_j( const char* s1, const char* s2 );	//!< strstr ã®å¤§æ–‡å­—å°æ–‡å­—åŒä¸€è¦–ï¼†æ—¥æœ¬èªå¯¾å¿œç‰ˆã€‚
 inline char* strchr_j ( char* s1, char c         ){ return const_cast<char*>(strchr_j ((const char*)s1, c )); }
 inline char* strichr_j( char* s1, char c         ){ return const_cast<char*>(strichr_j((const char*)s1, c )); }
 inline char* strstr_j ( char* s1, const char* s2 ){ return const_cast<char*>(strstr_j ((const char*)s1, s2)); }
@@ -125,26 +125,26 @@ inline char* stristr_j( char* s1, const char* s2 ){ return const_cast<char*>(str
 
 template <class CHAR_TYPE>
 CHAR_TYPE* my_strtok(
-	CHAR_TYPE*			pBuffer,	//[in] •¶š—ñƒoƒbƒtƒ@(I’[‚ª‚ ‚é‚±‚Æ)
-	int					nLen,		//[in] •¶š—ñ‚Ì’·‚³
-	int*				pnOffset,	//[in,out] ƒIƒtƒZƒbƒg
-	const CHAR_TYPE*	pDelimiter	//[in] ‹æØ‚è•¶š
+	CHAR_TYPE*			pBuffer,	//[in] æ–‡å­—åˆ—ãƒãƒƒãƒ•ã‚¡(çµ‚ç«¯ãŒã‚ã‚‹ã“ã¨)
+	int					nLen,		//[in] æ–‡å­—åˆ—ã®é•·ã•
+	int*				pnOffset,	//[in,out] ã‚ªãƒ•ã‚»ãƒƒãƒˆ
+	const CHAR_TYPE*	pDelimiter	//[in] åŒºåˆ‡ã‚Šæ–‡å­—
 );
 
 
-// ¤ ƒVƒOƒjƒ`ƒƒ‚¨‚æ‚Ñ“®ìd—l‚Í•Ï‚í‚ç‚È‚¢‚¯‚ÇA
-// ƒRƒ“ƒpƒCƒ‰‚ÆŒ¾Œêw’è‚É‚æ‚Á‚Ä•s³“®ì‚ğ‚µ‚Ä‚µ‚Ü‚¤‚±‚Æ‚ğ‰ñ”ğ‚·‚é‚½‚ß‚É
-// “Æ©‚ÉÀ‘•‚µ’¼‚µ‚½‚à‚ÌB
+// â–½ ã‚·ã‚°ãƒ‹ãƒãƒ£ãŠã‚ˆã³å‹•ä½œä»•æ§˜ã¯å¤‰ã‚ã‚‰ãªã„ã‘ã©ã€
+// ã‚³ãƒ³ãƒ‘ã‚¤ãƒ©ã¨è¨€èªæŒ‡å®šã«ã‚ˆã£ã¦ä¸æ­£å‹•ä½œã‚’ã—ã¦ã—ã¾ã†ã“ã¨ã‚’å›é¿ã™ã‚‹ãŸã‚ã«
+// ç‹¬è‡ªã«å®Ÿè£…ã—ç›´ã—ãŸã‚‚ã®ã€‚
 int my_stricmp( const char *s1, const char *s2 );
 int my_strnicmp( const char *s1, const char *s2, size_t n );
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           ŒİŠ·                              //
+//                           äº’æ›                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-// VS2005ˆÈ~‚ÌˆÀ‘S”Å•¶š—ñŠÖ”
-#if (defined(_MSC_VER) && _MSC_VER<1400) || defined(__MINGW32__) //VS2005‚æ‚è‘O‚È‚ç
+// VS2005ä»¥é™ã®å®‰å…¨ç‰ˆæ–‡å­—åˆ—é–¢æ•°
+#if (defined(_MSC_VER) && _MSC_VER<1400) || defined(__MINGW32__) //VS2005ã‚ˆã‚Šå‰ãªã‚‰
 	typedef int errno_t;
 #define _TRUNCATE ((size_t)-1)
 	errno_t strcpy_s(char *dest, size_t num, const char *src);
@@ -181,19 +181,19 @@ int my_strnicmp( const char *s1, const char *s2, size_t n );
 #endif
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//        autoŒni_UNICODE ’è‹`‚ÉˆË‘¶‚µ‚È‚¢ŠÖ”j              //
+//        autoç³»ï¼ˆ_UNICODE å®šç¾©ã«ä¾å­˜ã—ãªã„é–¢æ•°ï¼‰              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//charŒ^‚É‚·‚é‚©wchar_tŒ^‚É‚·‚é‚©Šm’è‚µ‚È‚¢•Ï”‚ª‚ ‚è‚Ü‚·B
-//‰º‹LŠÖ”ŒQ‚ğg‚Á‚Ä•¶š—ñ‘€ì‚ğs‚Á‚½ê‡A
-//«—ˆA‚»‚Ì•Ï”‚ÌŒ^‚ª•Ï‚í‚Á‚Ä‚àA‚»‚Ì‘€ì‰ÓŠ‚ğ‘‚«’¼‚³‚È‚­‚Ä‚à
-//Ï‚Ş‚±‚Æ‚É‚È‚è‚Ü‚·B
+//charå‹ã«ã™ã‚‹ã‹wchar_tå‹ã«ã™ã‚‹ã‹ç¢ºå®šã—ãªã„å¤‰æ•°ãŒã‚ã‚Šã¾ã™ã€‚
+//ä¸‹è¨˜é–¢æ•°ç¾¤ã‚’ä½¿ã£ã¦æ–‡å­—åˆ—æ“ä½œã‚’è¡Œã£ãŸå ´åˆã€
+//å°†æ¥ã€ãã®å¤‰æ•°ã®å‹ãŒå¤‰ã‚ã£ã¦ã‚‚ã€ãã®æ“ä½œç®‡æ‰€ã‚’æ›¸ãç›´ã•ãªãã¦ã‚‚
+//æ¸ˆã‚€ã“ã¨ã«ãªã‚Šã¾ã™ã€‚
 //
-//‹­§ƒLƒƒƒXƒg‚É‚æ‚ég—p‚Í„§‚µ‚Ü‚¹‚ñB
-//‚»‚à‚»‚àA‚±‚ÌŠÖ”ŒÄ‚Ño‚µ‚ÉŒÀ‚ç‚¸A‹­§ƒLƒƒƒXƒg‚ÍÅ’áŒÀ‚É—¯‚ß‚Ä‚­‚¾‚³‚¢B
-//‚¹‚Á‚©‚­‚ÌAC++‚ÌŒµŠi‚ÈŒ^ƒ`ƒFƒbƒN‚Ì‰¶Œb‚ğó‚¯‚é‚±‚Æ‚ª‚Å‚«‚È‚­‚È‚è‚Ü‚·B
+//å¼·åˆ¶ã‚­ãƒ£ã‚¹ãƒˆã«ã‚ˆã‚‹ä½¿ç”¨ã¯æ¨å¥¨ã—ã¾ã›ã‚“ã€‚
+//ãã‚‚ãã‚‚ã€ã“ã®é–¢æ•°å‘¼ã³å‡ºã—ã«é™ã‚‰ãšã€å¼·åˆ¶ã‚­ãƒ£ã‚¹ãƒˆã¯æœ€ä½é™ã«ç•™ã‚ã¦ãã ã•ã„ã€‚
+//ã›ã£ã‹ãã®ã€C++ã®å³æ ¼ãªå‹ãƒã‚§ãƒƒã‚¯ã®æ©æµã‚’å—ã‘ã‚‹ã“ã¨ãŒã§ããªããªã‚Šã¾ã™ã€‚
 
 
-//“]‘—Œn
+//è»¢é€ç³»
 inline ACHAR* auto_memcpy(ACHAR* dest, const ACHAR* src, size_t count){        ::memcpy (dest,src,count); return dest; }
 inline WCHAR* auto_memcpy(WCHAR* dest, const WCHAR* src, size_t count){ return ::wmemcpy(dest,src,count);              }
 inline ACHAR* auto_strcpy(ACHAR* dst, const ACHAR* src){ return strcpy(dst,src); }
@@ -209,7 +209,7 @@ inline WCHAR* auto_strcat(WCHAR* dst, const WCHAR* src){ return wcscat(dst,src);
 inline errno_t auto_strcat_s(ACHAR* dst, size_t nDstCount, const ACHAR* src){ return strcat_s(dst,nDstCount,src); }
 inline errno_t auto_strcat_s(WCHAR* dst, size_t nDstCount, const WCHAR* src){ return wcscat_s(dst,nDstCount,src); }
 
-//”äŠrŒn
+//æ¯”è¼ƒç³»
 inline int auto_memcmp (const ACHAR* p1, const ACHAR* p2, size_t count){ return amemcmp(p1,p2,count); }
 inline int auto_memcmp (const WCHAR* p1, const WCHAR* p2, size_t count){ return wmemcmp(p1,p2,count); }
 inline int auto_strcmp (const ACHAR* p1, const ACHAR* p2){ return strcmp(p1,p2); }
@@ -217,23 +217,23 @@ inline int auto_strcmp (const WCHAR* p1, const WCHAR* p2){ return wcscmp(p1,p2);
 inline int auto_strncmp(const ACHAR* str1, const ACHAR* str2, size_t count){ return strncmp(str1,str2,count); }
 inline int auto_strncmp(const WCHAR* str1, const WCHAR* str2, size_t count){ return wcsncmp(str1,str2,count); }
 
-//”äŠrŒniASCII, UCS2 ê—pj
+//æ¯”è¼ƒç³»ï¼ˆASCII, UCS2 å°‚ç”¨ï¼‰
 inline int auto_memicmp(const ACHAR* p1, const ACHAR* p2, size_t count){ return amemicmp(p1,p2,count); }
 inline int auto_memicmp(const WCHAR* p1, const WCHAR* p2, size_t count){ return wmemicmp(p1,p2,count); }
 
-//”äŠrŒniSJIS, UTF-16 ê—p)
+//æ¯”è¼ƒç³»ï¼ˆSJIS, UTF-16 å°‚ç”¨)
 inline int auto_strnicmp(const ACHAR* p1, const ACHAR* p2, size_t count){ return my_strnicmp(p1,p2,count); }
 inline int auto_strnicmp(const WCHAR* p1, const WCHAR* p2, size_t count){ return wmemicmp(p1,p2,count); } // Stub.
 inline int auto_stricmp(const ACHAR* p1, const ACHAR* p2){ return my_stricmp(p1,p2); }
 inline int auto_stricmp(const WCHAR* p1, const WCHAR* p2){ return wmemicmp(p1,p2); } // Stub.
 
-//’·‚³ŒvZŒn
+//é•·ã•è¨ˆç®—ç³»
 inline size_t auto_strlen(const ACHAR* str){ return strlen(str); }
 inline size_t auto_strlen(const WCHAR* str){ return wcslen(str); }
 inline size_t auto_strnlen(const ACHAR* str, size_t count){ return strnlen(str, count); }
 inline size_t auto_strnlen(const WCHAR* str, size_t count){ return wcsnlen(str, count); }
 
-//ŒŸõŒniSJIS, UCS2 ê—pj
+//æ¤œç´¢ç³»ï¼ˆSJIS, UCS2 å°‚ç”¨ï¼‰
 inline const ACHAR* auto_strstr(const ACHAR* str, const ACHAR* strSearch){ return ::strstr_j(str,strSearch); }
 inline const WCHAR* auto_strstr(const WCHAR* str, const WCHAR* strSearch){ return ::wcsstr  (str,strSearch); }
 inline       ACHAR* auto_strstr(      ACHAR* str, const ACHAR* strSearch){ return ::strstr_j(str,strSearch); }
@@ -243,7 +243,7 @@ inline const WCHAR* auto_strchr(const WCHAR* str, WCHAR c){ return ::wcschr  (st
 inline       ACHAR* auto_strchr(      ACHAR* str, ACHAR c){ return ::strchr_j(str,c); }
 inline       WCHAR* auto_strchr(      WCHAR* str, WCHAR c){ return ::wcschr  (str,c); }
 
-//•ÏŠ·Œn
+//å¤‰æ›ç³»
 inline long auto_atol(const ACHAR* str){ return atol(str);  }
 inline long auto_atol(const WCHAR* str){ return _wtol(str); }
 ACHAR* tcstostr( ACHAR* dest, const TCHAR* src, size_t count );
@@ -251,7 +251,7 @@ WCHAR* tcstostr( WCHAR* dest, const TCHAR* src, size_t count );
 TCHAR* strtotcs( TCHAR* dest, const ACHAR* src, size_t count );
 TCHAR* strtotcs( TCHAR* dest, const WCHAR* src, size_t count );
 
-//ˆóšŒn
+//å°å­—ç³»
 #if defined(_MSC_VER) && _MSC_VER>=1400
 #define auto_snprintf_s(buf, count, format, ...) tchar_sprintf_s((buf), count, (format), __VA_ARGS__)
 #define auto_sprintf(buf, format, ...)           tchar_sprintf((buf), (format), __VA_ARGS__)
@@ -272,29 +272,29 @@ inline int auto_vsprintf_s(WCHAR* buf, size_t nBufCount, const WCHAR* format, va
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      •¶šƒR[ƒh•ÏŠ·                         //
+//                      æ–‡å­—ã‚³ãƒ¼ãƒ‰å¤‰æ›                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 #include <vector>
 
-//SJIS¨UNICODEBI’[‚ÉL'\0'‚ğ•t‚¯‚Ä‚­‚ê‚é”ÅB
+//SJISâ†’UNICODEã€‚çµ‚ç«¯ã«L'\0'ã‚’ä»˜ã‘ã¦ãã‚Œã‚‹ç‰ˆã€‚
 size_t mbstowcs2(wchar_t* dst,const char* src,size_t dst_count);
 size_t mbstowcs2(wchar_t* pDst, int nDstCount, const char* pSrc, int nSrcCount);
 
-//UNICODE¨SJISBI’[‚É'\0'‚ğ•t‚¯‚Ä‚­‚ê‚é”ÅB
+//UNICODEâ†’SJISã€‚çµ‚ç«¯ã«'\0'ã‚’ä»˜ã‘ã¦ãã‚Œã‚‹ç‰ˆã€‚
 size_t wcstombs2(char* dst,const wchar_t* src,size_t dst_count);
 
-//SJIS¨UNICODEB
-wchar_t*	mbstowcs_new(const char* pszSrc);								//–ß‚è’l‚Ínew[]‚ÅŠm•Û‚µ‚Ä•Ô‚·Bg‚¢I‚í‚Á‚½‚çdelete[]‚·‚é‚±‚ÆB
-wchar_t*	mbstowcs_new(const char* pSrc, int nSrcLen, int* pnDstLen);		//–ß‚è’l‚Ínew[]‚ÅŠm•Û‚µ‚Ä•Ô‚·Bg‚¢I‚í‚Á‚½‚çdelete[]‚·‚é‚±‚ÆB
-void		mbstowcs_vector(const char* src, std::vector<wchar_t>* ret);	//–ß‚è’l‚Ívector‚Æ‚µ‚Ä•Ô‚·B
-void		mbstowcs_vector(const char* pSrc, int nSrcLen, std::vector<wchar_t>* ret);	//–ß‚è’l‚Ívector‚Æ‚µ‚Ä•Ô‚·B
+//SJISâ†’UNICODEã€‚
+wchar_t*	mbstowcs_new(const char* pszSrc);								//æˆ»ã‚Šå€¤ã¯new[]ã§ç¢ºä¿ã—ã¦è¿”ã™ã€‚ä½¿ã„çµ‚ã‚ã£ãŸã‚‰delete[]ã™ã‚‹ã“ã¨ã€‚
+wchar_t*	mbstowcs_new(const char* pSrc, int nSrcLen, int* pnDstLen);		//æˆ»ã‚Šå€¤ã¯new[]ã§ç¢ºä¿ã—ã¦è¿”ã™ã€‚ä½¿ã„çµ‚ã‚ã£ãŸã‚‰delete[]ã™ã‚‹ã“ã¨ã€‚
+void		mbstowcs_vector(const char* src, std::vector<wchar_t>* ret);	//æˆ»ã‚Šå€¤ã¯vectorã¨ã—ã¦è¿”ã™ã€‚
+void		mbstowcs_vector(const char* pSrc, int nSrcLen, std::vector<wchar_t>* ret);	//æˆ»ã‚Šå€¤ã¯vectorã¨ã—ã¦è¿”ã™ã€‚
 
-//UNICODE¨SJIS
-char*	wcstombs_new(const wchar_t* src); //–ß‚è’l‚Ínew[]‚ÅŠm•Û‚µ‚Ä•Ô‚·B
-char*	wcstombs_new(const wchar_t* pSrc,int nSrcLen); //–ß‚è’l‚Ínew[]‚ÅŠm•Û‚µ‚Ä•Ô‚·B
-void	wcstombs_vector(const wchar_t* pSrc, std::vector<char>* ret); //–ß‚è’l‚Ívector‚Æ‚µ‚Ä•Ô‚·B
-void	wcstombs_vector(const wchar_t* pSrc, int nSrcLen, std::vector<char>* ret); //–ß‚è’l‚Ívector‚Æ‚µ‚Ä•Ô‚·B
+//UNICODEâ†’SJIS
+char*	wcstombs_new(const wchar_t* src); //æˆ»ã‚Šå€¤ã¯new[]ã§ç¢ºä¿ã—ã¦è¿”ã™ã€‚
+char*	wcstombs_new(const wchar_t* pSrc,int nSrcLen); //æˆ»ã‚Šå€¤ã¯new[]ã§ç¢ºä¿ã—ã¦è¿”ã™ã€‚
+void	wcstombs_vector(const wchar_t* pSrc, std::vector<char>* ret); //æˆ»ã‚Šå€¤ã¯vectorã¨ã—ã¦è¿”ã™ã€‚
+void	wcstombs_vector(const wchar_t* pSrc, int nSrcLen, std::vector<char>* ret); //æˆ»ã‚Šå€¤ã¯vectorã¨ã—ã¦è¿”ã™ã€‚
 
 //TCHAR
 size_t _tcstowcs(WCHAR* wszDst, const TCHAR* tszSrc, size_t nDstCount);
@@ -309,25 +309,25 @@ int _tctowc(const TCHAR* p,WCHAR* wc);
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       ƒŠƒeƒ‰ƒ‹”äŠr                          //
+//                       ãƒªãƒ†ãƒ©ãƒ«æ¯”è¼ƒ                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-// ƒŠƒeƒ‰ƒ‹‚Æ‚Ì•¶š—ñ”äŠr‚ÌÛ‚ÉAè‘Å‚¿‚Å•¶š”‚ğ“ü—Í‚·‚é‚Ì‚Í
-// èŠÔ‚ªŠ|‚©‚éã‚ÉA•Ûç«‚ª‘¹‚È‚í‚ê‚é‚Ì‚ÅA
-// ƒJƒvƒZƒ‹‰»‚³‚ê‚½ŠÖ”‚âƒ}ƒNƒ‚Éˆ—‚ğ”C‚¹‚é‚Ì‚ª–]‚Ü‚µ‚¢B
+// ãƒªãƒ†ãƒ©ãƒ«ã¨ã®æ–‡å­—åˆ—æ¯”è¼ƒã®éš›ã«ã€æ‰‹æ‰“ã¡ã§æ–‡å­—æ•°ã‚’å…¥åŠ›ã™ã‚‹ã®ã¯
+// æ‰‹é–“ãŒæ›ã‹ã‚‹ä¸Šã«ã€ä¿å®ˆæ€§ãŒæãªã‚ã‚Œã‚‹ã®ã§ã€
+// ã‚«ãƒ—ã‚»ãƒ«åŒ–ã•ã‚ŒãŸé–¢æ•°ã‚„ãƒã‚¯ãƒ­ã«å‡¦ç†ã‚’ä»»ã›ã‚‹ã®ãŒæœ›ã¾ã—ã„ã€‚
 
-//wcsncmp‚Ì•¶š”w’è‚ğszData2‚©‚çwcslen‚Åæ“¾‚µ‚Ä‚­‚ê‚é”Å
+//wcsncmpã®æ–‡å­—æ•°æŒ‡å®šã‚’szData2ã‹ã‚‰wcslenã§å–å¾—ã—ã¦ãã‚Œã‚‹ç‰ˆ
 inline int wcsncmp_auto(const wchar_t* strData1, const wchar_t* szData2)
 {
 	return wcsncmp(strData1,szData2,wcslen(szData2));
 }
 
-//wcsncmp‚Ì•¶š”w’è‚ğliteralData2‚Ì‘å‚«‚³‚Åæ“¾‚µ‚Ä‚­‚ê‚é”Å
+//wcsncmpã®æ–‡å­—æ•°æŒ‡å®šã‚’literalData2ã®å¤§ãã•ã§å–å¾—ã—ã¦ãã‚Œã‚‹ç‰ˆ
 #define wcsncmp_literal(strData1, literalData2) \
-	::wcsncmp(strData1, literalData2, _countof(literalData2) - 1 ) //¦I’[ƒkƒ‹‚ğŠÜ‚ß‚È‚¢‚Ì‚ÅA_countof‚©‚çƒ}ƒCƒiƒX1‚·‚é
+	::wcsncmp(strData1, literalData2, _countof(literalData2) - 1 ) //â€»çµ‚ç«¯ãƒŒãƒ«ã‚’å«ã‚ãªã„ã®ã§ã€_countofã‹ã‚‰ãƒã‚¤ãƒŠã‚¹1ã™ã‚‹
 
-//strncmp‚Ì•¶š”w’è‚ğliteralData2‚Ì‘å‚«‚³‚Åæ“¾‚µ‚Ä‚­‚ê‚é”Å
+//strncmpã®æ–‡å­—æ•°æŒ‡å®šã‚’literalData2ã®å¤§ãã•ã§å–å¾—ã—ã¦ãã‚Œã‚‹ç‰ˆ
 #define strncmp_literal(strData1, literalData2) \
-	::strncmp(strData1, literalData2, _countof(literalData2) - 1 ) //¦I’[ƒkƒ‹‚ğŠÜ‚ß‚È‚¢‚Ì‚ÅA_countof‚©‚çƒ}ƒCƒiƒX1‚·‚é
+	::strncmp(strData1, literalData2, _countof(literalData2) - 1 ) //â€»çµ‚ç«¯ãƒŒãƒ«ã‚’å«ã‚ãªã„ã®ã§ã€_countofã‹ã‚‰ãƒã‚¤ãƒŠã‚¹1ã™ã‚‹
 
 //TCHAR
 #ifdef _UNICODE

--- a/sakura_core/util/string_ex2.cpp
+++ b/sakura_core/util/string_ex2.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "string_ex2.h"
 #include "charset/charcode.h"
 #include "CEol.h"
@@ -27,27 +27,27 @@ wchar_t *wcs_pushA(wchar_t *dst, size_t dst_count, const char* src)
 
 
 
-/*! •¶š‚ÌƒGƒXƒP[ƒv
+/*! æ–‡å­—ã®ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—
 
-	@param org [in] •ÏŠ·‚µ‚½‚¢•¶š—ñ
-	@param buf [out] •ÔŠÒŒã‚Ì•¶š—ñ‚ğ“ü‚ê‚éƒoƒbƒtƒ@
-	@param cesc  [in] ƒGƒXƒP[ƒv‚µ‚È‚¢‚Æ‚¢‚¯‚È‚¢•¶š
-	@param cwith [in] ƒGƒXƒP[ƒv‚Ég‚¤•¶š
+	@param org [in] å¤‰æ›ã—ãŸã„æ–‡å­—åˆ—
+	@param buf [out] è¿”é‚„å¾Œã®æ–‡å­—åˆ—ã‚’å…¥ã‚Œã‚‹ãƒãƒƒãƒ•ã‚¡
+	@param cesc  [in] ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã—ãªã„ã¨ã„ã‘ãªã„æ–‡å­—
+	@param cwith [in] ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã«ä½¿ã†æ–‡å­—
 	
-	@retval o—Í‚µ‚½ƒoƒCƒg” (Unicode‚Ìê‡‚Í•¶š”)
+	@retval å‡ºåŠ›ã—ãŸãƒã‚¤ãƒˆæ•° (Unicodeã®å ´åˆã¯æ–‡å­—æ•°)
 
-	•¶š—ñ’†‚É‚»‚Ì‚Ü‚Üg‚¤‚Æ‚Ü‚¸‚¢•¶š‚ª‚ ‚éê‡‚É‚»‚Ì•¶š‚Ì‘O‚É
-	ƒGƒXƒP[ƒvƒLƒƒƒ‰ƒNƒ^‚ğ‘}“ü‚·‚é‚½‚ß‚Ég‚¤D
+	æ–‡å­—åˆ—ä¸­ã«ãã®ã¾ã¾ä½¿ã†ã¨ã¾ãšã„æ–‡å­—ãŒã‚ã‚‹å ´åˆã«ãã®æ–‡å­—ã®å‰ã«
+	ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã‚­ãƒ£ãƒ©ã‚¯ã‚¿ã‚’æŒ¿å…¥ã™ã‚‹ãŸã‚ã«ä½¿ã†ï¼
 
-	@note •ÏŠ·Œã‚Ìƒf[ƒ^‚ÍÅ‘å‚ÅŒ³‚Ì•¶š—ñ‚Ì2”{‚É‚È‚é
-	@note ‚±‚ÌŠÖ”‚Í2ƒoƒCƒg•¶š‚Ìl—¶‚ğs‚Á‚Ä‚¢‚È‚¢
+	@note å¤‰æ›å¾Œã®ãƒ‡ãƒ¼ã‚¿ã¯æœ€å¤§ã§å…ƒã®æ–‡å­—åˆ—ã®2å€ã«ãªã‚‹
+	@note ã“ã®é–¢æ•°ã¯2ãƒã‚¤ãƒˆæ–‡å­—ã®è€ƒæ…®ã‚’è¡Œã£ã¦ã„ãªã„
 
 	@author genta
-	@date 2002/01/04 V‹Kì¬
-	@date 2002/01/30 genta &ê—p(dupamp)‚©‚çˆê”Ê‚Ì•¶š‚ğˆµ‚¦‚é‚æ‚¤‚ÉŠg’£D
-		dupamp‚ÍinlineŠÖ”‚É‚µ‚½D
-	@date 2002/02/01 genta bugfix ƒGƒXƒP[ƒv‚·‚é•¶š‚Æ‚³‚ê‚é•¶š‚Ìo—Í‡˜‚ª‹t‚¾‚Á‚½
-	@date 2004/06/19 genta Generic mapping‘Î‰
+	@date 2002/01/04 æ–°è¦ä½œæˆ
+	@date 2002/01/30 genta &å°‚ç”¨(dupamp)ã‹ã‚‰ä¸€èˆ¬ã®æ–‡å­—ã‚’æ‰±ãˆã‚‹ã‚ˆã†ã«æ‹¡å¼µï¼
+		dupampã¯inlineé–¢æ•°ã«ã—ãŸï¼
+	@date 2002/02/01 genta bugfix ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ã™ã‚‹æ–‡å­—ã¨ã•ã‚Œã‚‹æ–‡å­—ã®å‡ºåŠ›é †åºãŒé€†ã ã£ãŸ
+	@date 2004/06/19 genta Generic mappingå¯¾å¿œ
 */
 int cescape(const TCHAR* org, TCHAR* buf, TCHAR cesc, TCHAR cwith)
 {
@@ -66,20 +66,20 @@ int cescape(const TCHAR* org, TCHAR* buf, TCHAR cesc, TCHAR cwith)
 
 
 
-/*!	•¶š—ñ‚ªw’è‚³‚ê‚½•¶š‚ÅI‚í‚Á‚Ä‚¢‚È‚©‚Á‚½ê‡‚É‚Í
-	––”ö‚É‚»‚Ì•¶š‚ğ•t‰Á‚·‚éD
+/*!	æ–‡å­—åˆ—ãŒæŒ‡å®šã•ã‚ŒãŸæ–‡å­—ã§çµ‚ã‚ã£ã¦ã„ãªã‹ã£ãŸå ´åˆã«ã¯
+	æœ«å°¾ã«ãã®æ–‡å­—ã‚’ä»˜åŠ ã™ã‚‹ï¼
 
-	@param pszPath [i/o]‘€ì‚·‚é•¶š—ñ
-	@param nMaxLen [in]ƒoƒbƒtƒ@’·
-	@param c [in]’Ç‰Á‚µ‚½‚¢•¶š
-	@retval  0 \‚ªŒ³‚©‚ç•t‚¢‚Ä‚¢‚½
-	@retval  1 \‚ğ•t‰Á‚µ‚½
-	@retval -1 ƒoƒbƒtƒ@‚ª‘«‚è‚¸A\‚ğ•t‰Á‚Å‚«‚È‚©‚Á‚½
-	@date 2003.06.24 Moca V‹Kì¬
+	@param pszPath [i/o]æ“ä½œã™ã‚‹æ–‡å­—åˆ—
+	@param nMaxLen [in]ãƒãƒƒãƒ•ã‚¡é•·
+	@param c [in]è¿½åŠ ã—ãŸã„æ–‡å­—
+	@retval  0 \ãŒå…ƒã‹ã‚‰ä»˜ã„ã¦ã„ãŸ
+	@retval  1 \ã‚’ä»˜åŠ ã—ãŸ
+	@retval -1 ãƒãƒƒãƒ•ã‚¡ãŒè¶³ã‚Šãšã€\ã‚’ä»˜åŠ ã§ããªã‹ã£ãŸ
+	@date 2003.06.24 Moca æ–°è¦ä½œæˆ
 */
 int AddLastChar( TCHAR* pszPath, int nMaxLen, TCHAR c ){
 	int pos = _tcslen( pszPath );
-	// ‰½‚à‚È‚¢‚Æ‚«‚Í\‚ğ•t‰Á
+	// ä½•ã‚‚ãªã„ã¨ãã¯\ã‚’ä»˜åŠ 
 	if( 0 == pos ){
 		if( nMaxLen <= pos + 1 ){
 			return -1;
@@ -88,7 +88,7 @@ int AddLastChar( TCHAR* pszPath, int nMaxLen, TCHAR c ){
 		pszPath[1] = _T('\0');
 		return 1;
 	}
-	// ÅŒã‚ª\‚Å‚È‚¢‚Æ‚«‚à\‚ğ•t‰Á(“ú–{Œê‚ğl—¶)
+	// æœ€å¾ŒãŒ\ã§ãªã„ã¨ãã‚‚\ã‚’ä»˜åŠ (æ—¥æœ¬èªã‚’è€ƒæ…®)
 	else if( *::CharPrev( pszPath, &pszPath[pos] ) != c ){
 		if( nMaxLen <= pos + 1 ){
 			return -1;
@@ -102,7 +102,7 @@ int AddLastChar( TCHAR* pszPath, int nMaxLen, TCHAR c ){
 
 
 
-/* CR0LF0,CRLF,LF,CR‚Å‹æØ‚ç‚ê‚éusv‚ğ•Ô‚·B‰üsƒR[ƒh‚Ís’·‚É‰Á‚¦‚È‚¢ */
+/* CR0LF0,CRLF,LF,CRã§åŒºåˆ‡ã‚‰ã‚Œã‚‹ã€Œè¡Œã€ã‚’è¿”ã™ã€‚æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã¯è¡Œé•·ã«åŠ ãˆãªã„ */
 const char* GetNextLine(
 	const char*		pData,
 	int				nDataLen,
@@ -121,9 +121,9 @@ const char* GetNextLine(
 		return NULL;
 	}
 	for( i = *pnBgn; i < nDataLen; ++i ){
-		/* ‰üsƒR[ƒh‚ª‚ ‚Á‚½ */
+		/* æ”¹è¡Œã‚³ãƒ¼ãƒ‰ãŒã‚ã£ãŸ */
 		if( pData[i] == '\n' || pData[i] == '\r' ){
-			/* sI’[q‚Ìí—Ş‚ğ’²‚×‚é */
+			/* è¡Œçµ‚ç«¯å­ã®ç¨®é¡ã‚’èª¿ã¹ã‚‹ */
 			pcEol->SetTypeByString( &pData[i], nDataLen - i );
 			break;
 		}
@@ -134,15 +134,15 @@ const char* GetNextLine(
 }
 
 /*!
-	GetNextLine‚Ìwchar_t”Å
-	GetNextLine‚æ‚èì¬
-	static ƒƒ“ƒoŠÖ”
+	GetNextLineã®wchar_tç‰ˆ
+	GetNextLineã‚ˆã‚Šä½œæˆ
+	static ãƒ¡ãƒ³ãƒé–¢æ•°
 */
 const wchar_t* GetNextLineW(
-	const wchar_t*	pData,		//!< [in]	ŒŸõ•¶š—ñ
-	int				nDataLen,	//!< [in]	ŒŸõ•¶š—ñ‚Ì•¶š”
-	int*			pnLineLen,	//!< [out]	1s‚Ì•¶š”‚ğ•Ô‚·‚½‚¾‚µEOL‚ÍŠÜ‚Ü‚È‚¢
-	int*			pnBgn,		//!< [i/o]	ŒŸõ•¶š—ñ‚ÌƒIƒtƒZƒbƒgˆÊ’u
+	const wchar_t*	pData,		//!< [in]	æ¤œç´¢æ–‡å­—åˆ—
+	int				nDataLen,	//!< [in]	æ¤œç´¢æ–‡å­—åˆ—ã®æ–‡å­—æ•°
+	int*			pnLineLen,	//!< [out]	1è¡Œã®æ–‡å­—æ•°ã‚’è¿”ã™ãŸã ã—EOLã¯å«ã¾ãªã„
+	int*			pnBgn,		//!< [i/o]	æ¤œç´¢æ–‡å­—åˆ—ã®ã‚ªãƒ•ã‚»ãƒƒãƒˆä½ç½®
 	CEol*			pcEol,		//!< [out]	EOL
 	bool			bExtEol
 )
@@ -156,9 +156,9 @@ const wchar_t* GetNextLineW(
 		return NULL;
 	}
 	for( i = *pnBgn; i < nDataLen; ++i ){
-		// ‰üsƒR[ƒh‚ª‚ ‚Á‚½
+		// æ”¹è¡Œã‚³ãƒ¼ãƒ‰ãŒã‚ã£ãŸ
 		if( WCODE::IsLineDelimiter(pData[i], bExtEol) ){
-			// sI’[q‚Ìí—Ş‚ğ’²‚×‚é
+			// è¡Œçµ‚ç«¯å­ã®ç¨®é¡ã‚’èª¿ã¹ã‚‹
 			pcEol->SetTypeByString(&pData[i], nDataLen - i);
 			break;
 		}
@@ -167,16 +167,16 @@ const wchar_t* GetNextLineW(
 	*pnLineLen = i - nBgn;
 	return &pData[nBgn];
 }
-#if 0 // –¢g—p
+#if 0 // æœªä½¿ç”¨
 /*
-	s’[q‚Ìí—Ş‚ğ’²‚×‚éUnicodeBE”Å
-	@param pszData ’²¸‘ÎÛ•¶š—ñ‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	@param nDataLen ’²¸‘ÎÛ•¶š—ñ‚Ì’·‚³(wchar_t‚Ì’·‚³)
-	@return ‰üsƒR[ƒh‚Ìí—ŞBI’[q‚ªŒ©‚Â‚©‚ç‚È‚©‚Á‚½‚Æ‚«‚ÍEOL_NONE‚ğ•Ô‚·B
+	è¡Œç«¯å­ã®ç¨®é¡ã‚’èª¿ã¹ã‚‹UnicodeBEç‰ˆ
+	@param pszData èª¿æŸ»å¯¾è±¡æ–‡å­—åˆ—ã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	@param nDataLen èª¿æŸ»å¯¾è±¡æ–‡å­—åˆ—ã®é•·ã•(wchar_tã®é•·ã•)
+	@return æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®ç¨®é¡ã€‚çµ‚ç«¯å­ãŒè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸã¨ãã¯EOL_NONEã‚’è¿”ã™ã€‚
 */
 static EEolType GetEOLTypeUniBE( const wchar_t* pszData, int nDataLen )
 {
-	/*! sI’[q‚Ìƒf[ƒ^‚Ì”z—ñ(UnicodeBE”Å) 2000.05.30 Moca */
+	/*! è¡Œçµ‚ç«¯å­ã®ãƒ‡ãƒ¼ã‚¿ã®é…åˆ—(UnicodeBEç‰ˆ) 2000.05.30 Moca */
 	static const wchar_t* aEolTable[EOL_TYPE_NUM] = {
 		L"",									// EOL_NONE
 		(const wchar_t*)"\x00\x0d\x00\x0a\x00",	// EOL_CRLF
@@ -184,7 +184,7 @@ static EEolType GetEOLTypeUniBE( const wchar_t* pszData, int nDataLen )
 		(const wchar_t*)"\x00\x0d\x00"			// EOL_CR
 	};
 
-	/* ‰üsƒR[ƒh‚Ì’·‚³‚ğ’²‚×‚é */
+	/* æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®é•·ã•ã‚’èª¿ã¹ã‚‹ */
 
 	for( int i = 1; i < EOL_TYPE_NUM; ++i ){
 		CEol cEol((EEolType)i);
@@ -196,15 +196,15 @@ static EEolType GetEOLTypeUniBE( const wchar_t* pszData, int nDataLen )
 }
 
 /*!
-	GetNextLine‚Ìwchar_t”Å(ƒrƒbƒNƒGƒ“ƒfƒBƒAƒ“—p)
-	GetNextLine‚æ‚èì¬
-	static ƒƒ“ƒoŠÖ”
+	GetNextLineã®wchar_tç‰ˆ(ãƒ“ãƒƒã‚¯ã‚¨ãƒ³ãƒ‡ã‚£ã‚¢ãƒ³ç”¨)
+	GetNextLineã‚ˆã‚Šä½œæˆ
+	static ãƒ¡ãƒ³ãƒé–¢æ•°
 */
 const wchar_t* GetNextLineWB(
-	const wchar_t*	pData,	//!< [in]	ŒŸõ•¶š—ñ
-	int			nDataLen,	//!< [in]	ŒŸõ•¶š—ñ‚Ì•¶š”
-	int*		pnLineLen,	//!< [out]	1s‚Ì•¶š”‚ğ•Ô‚·‚½‚¾‚µEOL‚ÍŠÜ‚Ü‚È‚¢
-	int*		pnBgn,		//!< [i/o]	ŒŸõ•¶š—ñ‚ÌƒIƒtƒZƒbƒgˆÊ’u
+	const wchar_t*	pData,	//!< [in]	æ¤œç´¢æ–‡å­—åˆ—
+	int			nDataLen,	//!< [in]	æ¤œç´¢æ–‡å­—åˆ—ã®æ–‡å­—æ•°
+	int*		pnLineLen,	//!< [out]	1è¡Œã®æ–‡å­—æ•°ã‚’è¿”ã™ãŸã ã—EOLã¯å«ã¾ãªã„
+	int*		pnBgn,		//!< [i/o]	æ¤œç´¢æ–‡å­—åˆ—ã®ã‚ªãƒ•ã‚»ãƒƒãƒˆä½ç½®
 	CEol*		pcEol		//!< [i/o]	EOL
 )
 {
@@ -217,9 +217,9 @@ const wchar_t* GetNextLineWB(
 		return NULL;
 	}
 	for( i = *pnBgn; i < nDataLen; ++i ){
-		// ‰üsƒR[ƒh‚ª‚ ‚Á‚½
+		// æ”¹è¡Œã‚³ãƒ¼ãƒ‰ãŒã‚ã£ãŸ
 		if( pData[i] == (wchar_t)0x0a00 || pData[i] == (wchar_t)0x0d00 ){
-			// sI’[q‚Ìí—Ş‚ğ’²‚×‚é
+			// è¡Œçµ‚ç«¯å­ã®ç¨®é¡ã‚’èª¿ã¹ã‚‹
 			pcEol->SetType( GetEOLTypeUniBE( &pData[i], nDataLen - i ) );
 			break;
 		}
@@ -230,15 +230,15 @@ const wchar_t* GetNextLineWB(
 }
 #endif
 
-/*! w’è’·ˆÈ‰º‚ÌƒeƒLƒXƒg‚ÉØ‚è•ª‚¯‚é
+/*! æŒ‡å®šé•·ä»¥ä¸‹ã®ãƒ†ã‚­ã‚¹ãƒˆã«åˆ‡ã‚Šåˆ†ã‘ã‚‹
 
-	@param pText     [in] Ø‚è•ª‚¯‘ÎÛ‚Æ‚È‚é•¶š—ñ‚Ö‚Ìƒ|ƒCƒ“ƒ^
-	@param nTextLen  [in] Ø‚è•ª‚¯‘ÎÛ‚Æ‚È‚é•¶š—ñ‘S‘Ì‚Ì’·‚³
-	@param nLimitLen [in] Ø‚è•ª‚¯‚é’·‚³
-	@param pnLineLen [out] ÀÛ‚Éæ‚èo‚³‚ê‚½•¶š—ñ‚Ì’·‚³
-	@param pnBgn     [i/o] “ü—Í: Ø‚è•ª‚¯ŠJnˆÊ’u, o—Í: æ‚èo‚³‚ê‚½•¶š—ñ‚ÌŸ‚ÌˆÊ’u
+	@param pText     [in] åˆ‡ã‚Šåˆ†ã‘å¯¾è±¡ã¨ãªã‚‹æ–‡å­—åˆ—ã¸ã®ãƒã‚¤ãƒ³ã‚¿
+	@param nTextLen  [in] åˆ‡ã‚Šåˆ†ã‘å¯¾è±¡ã¨ãªã‚‹æ–‡å­—åˆ—å…¨ä½“ã®é•·ã•
+	@param nLimitLen [in] åˆ‡ã‚Šåˆ†ã‘ã‚‹é•·ã•
+	@param pnLineLen [out] å®Ÿéš›ã«å–ã‚Šå‡ºã•ã‚ŒãŸæ–‡å­—åˆ—ã®é•·ã•
+	@param pnBgn     [i/o] å…¥åŠ›: åˆ‡ã‚Šåˆ†ã‘é–‹å§‹ä½ç½®, å‡ºåŠ›: å–ã‚Šå‡ºã•ã‚ŒãŸæ–‡å­—åˆ—ã®æ¬¡ã®ä½ç½®
 
-	@note 2003.05.25 –¢g—p‚Ì‚æ‚¤‚¾
+	@note 2003.05.25 æœªä½¿ç”¨ã®ã‚ˆã†ã 
 */
 const char* GetNextLimitedLengthText( const char* pText, int nTextLen, int nLimitLen, int* pnLineLen, int* pnBgn )
 {
@@ -269,7 +269,7 @@ const char* GetNextLimitedLengthText( const char* pText, int nTextLen, int nLimi
 
 
 
-//! ƒf[ƒ^‚ğw’èu•¶š”vˆÈ“à‚ÉØ‚è‹l‚ß‚éB–ß‚è’l‚ÍŒ‹‰Ê‚Ì•¶š”B
+//! ãƒ‡ãƒ¼ã‚¿ã‚’æŒ‡å®šã€Œæ–‡å­—æ•°ã€ä»¥å†…ã«åˆ‡ã‚Šè©°ã‚ã‚‹ã€‚æˆ»ã‚Šå€¤ã¯çµæœã®æ–‡å­—æ•°ã€‚
 int LimitStringLengthW(
 	const wchar_t*	pszData,		//!< [in]
 	int				nDataLength,	//!< [in]
@@ -291,7 +291,7 @@ int LimitStringLengthW(
 	return n;
 }
 
-//! ƒf[ƒ^‚ğw’èu•¶š”vˆÈ“à‚ÉØ‚è‹l‚ß‚éB–ß‚è’l‚ÍŒ‹‰Ê‚Ì•¶š”B
+//! ãƒ‡ãƒ¼ã‚¿ã‚’æŒ‡å®šã€Œæ–‡å­—æ•°ã€ä»¥å†…ã«åˆ‡ã‚Šè©°ã‚ã‚‹ã€‚æˆ»ã‚Šå€¤ã¯çµæœã®æ–‡å­—æ•°ã€‚
 int LimitStringLengthA(
 	const char*		pszData,		//!< [in]
 	int				nDataLength,	//!< [in]
@@ -332,7 +332,7 @@ void GetLineColumn( const wchar_t* pLine, int* pnJumpToLine, int* pnJumpToColumn
 	wmemset( szNumber, 0, _countof( szNumber ) );
 	if( i >= nLineLen ){
 	}else{
-		/* sˆÊ’u ‰üs’PˆÊs”Ô†(1‹N“_)‚Ì’Šo */
+		/* è¡Œä½ç½® æ”¹è¡Œå˜ä½è¡Œç•ªå·(1èµ·ç‚¹)ã®æŠ½å‡º */
 		j = 0;
 		for( ; i < nLineLen && j + 1 < _countof( szNumber ); ){
 			szNumber[j] = pLine[i];
@@ -346,7 +346,7 @@ void GetLineColumn( const wchar_t* pLine, int* pnJumpToLine, int* pnJumpToColumn
 		}
 		*pnJumpToLine = _wtoi( szNumber );
 
-		/* Œ…ˆÊ’u ‰üs’PˆÊsæ“ª‚©‚ç‚ÌƒoƒCƒg”(1‹N“_)‚Ì’Šo */
+		/* æ¡ä½ç½® æ”¹è¡Œå˜ä½è¡Œå…ˆé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°(1èµ·ç‚¹)ã®æŠ½å‡º */
 		if( i < nLineLen && pLine[i] == ',' ){
 			wmemset( szNumber, 0, _countof( szNumber ) );
 			j = 0;
@@ -376,12 +376,12 @@ void GetLineColumn( const wchar_t* pLine, int* pnJumpToLine, int* pnJumpToColumn
 
 
 /*
-	scanf“IˆÀ‘SƒXƒLƒƒƒ“
+	scanfçš„å®‰å…¨ã‚¹ã‚­ãƒ£ãƒ³
 
-	g—p—á:
+	ä½¿ç”¨ä¾‹:
 		int a[3];
 		scan_ints("1,23,4,5", "%d,%d,%d", a);
-		//Œ‹‰Ê: a[0]=1, a[1]=23, a[2]=4 ‚Æ‚È‚éB
+		//çµæœ: a[0]=1, a[1]=23, a[2]=4 ã¨ãªã‚‹ã€‚
 */
 int scan_ints(
 	const wchar_t*	pszData,	//!< [in]
@@ -389,7 +389,7 @@ int scan_ints(
 	int*			anBuf		//!< [out]
 )
 {
-	//—v‘f”
+	//è¦ç´ æ•°
 	int num = 0;
 	const wchar_t* p = pszFormat;
 	while(*p){
@@ -397,7 +397,7 @@ int scan_ints(
 		p++;
 	}
 
-	//ƒXƒLƒƒƒ“
+	//ã‚¹ã‚­ãƒ£ãƒ³
 	int dummy[32];
 	memset(dummy,0,sizeof(dummy));
 	int nRet = swscanf(
@@ -407,7 +407,7 @@ int scan_ints(
 		&dummy[20],&dummy[21],&dummy[22],&dummy[23],&dummy[24],&dummy[25],&dummy[26],&dummy[27],&dummy[28],&dummy[29]
 	);
 
-	//Œ‹‰ÊƒRƒs[
+	//çµæœã‚³ãƒ”ãƒ¼
 	for(int i=0;i<num;i++){
 		anBuf[i]=dummy[i];
 	}

--- a/sakura_core/util/string_ex2.h
+++ b/sakura_core/util/string_ex2.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -38,29 +38,29 @@ wchar_t *wcs_pushA(wchar_t *dst, size_t dst_count, const char* src);
 #define wcs_pushT wcs_pushA
 #endif
 
-int AddLastChar( TCHAR*, int, TCHAR );/* 2003.06.24 Moca ÅŒã‚Ì•¶š‚ªw’è‚³‚ê‚½•¶š‚Å‚È‚¢‚Æ‚«‚Í•t‰Á‚·‚é */
-int LimitStringLengthA( const ACHAR*, int, int, CNativeA& );/* ƒf[ƒ^‚ğw’èu•¶š”vˆÈ“à‚ÉØ‚è‹l‚ß‚é */
-int LimitStringLengthW( const WCHAR*, int, int, CNativeW& );/* ƒf[ƒ^‚ğw’èu•¶š”vˆÈ“à‚ÉØ‚è‹l‚ß‚é */
+int AddLastChar( TCHAR*, int, TCHAR );/* 2003.06.24 Moca æœ€å¾Œã®æ–‡å­—ãŒæŒ‡å®šã•ã‚ŒãŸæ–‡å­—ã§ãªã„ã¨ãã¯ä»˜åŠ ã™ã‚‹ */
+int LimitStringLengthA( const ACHAR*, int, int, CNativeA& );/* ãƒ‡ãƒ¼ã‚¿ã‚’æŒ‡å®šã€Œæ–‡å­—æ•°ã€ä»¥å†…ã«åˆ‡ã‚Šè©°ã‚ã‚‹ */
+int LimitStringLengthW( const WCHAR*, int, int, CNativeW& );/* ãƒ‡ãƒ¼ã‚¿ã‚’æŒ‡å®šã€Œæ–‡å­—æ•°ã€ä»¥å†…ã«åˆ‡ã‚Šè©°ã‚ã‚‹ */
 #ifdef _UNICODE
 #define LimitStringLengthT LimitStringLengthW
 #else
 #define LimitStringLengthT LimitStringLengthA
 #endif
 
-const char* GetNextLimitedLengthText( const char*, int, int, int*, int* );/* w’è’·ˆÈ‰º‚ÌƒeƒLƒXƒg‚ÉØ‚è•ª‚¯‚é */
-const char*    GetNextLine  ( const char*   , int, int*, int*, CEol* ); /* CR0LF0,CRLF,LF,CR‚Å‹æØ‚ç‚ê‚éusv‚ğ•Ô‚·B‰üsƒR[ƒh‚Ís’·‚É‰Á‚¦‚È‚¢ */
-const wchar_t* GetNextLineW ( const wchar_t*, int, int*, int*, CEol*, bool ); // GetNextLine‚Ìwchar_t”Å
-//wchar_t* GetNextLineWB( const wchar_t*, int, int*, int*, CEol* ); // GetNextLine‚Ìwchar_t”Å(ƒrƒbƒNƒGƒ“ƒfƒBƒAƒ“—p)  // –¢g—p
+const char* GetNextLimitedLengthText( const char*, int, int, int*, int* );/* æŒ‡å®šé•·ä»¥ä¸‹ã®ãƒ†ã‚­ã‚¹ãƒˆã«åˆ‡ã‚Šåˆ†ã‘ã‚‹ */
+const char*    GetNextLine  ( const char*   , int, int*, int*, CEol* ); /* CR0LF0,CRLF,LF,CRã§åŒºåˆ‡ã‚‰ã‚Œã‚‹ã€Œè¡Œã€ã‚’è¿”ã™ã€‚æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã¯è¡Œé•·ã«åŠ ãˆãªã„ */
+const wchar_t* GetNextLineW ( const wchar_t*, int, int*, int*, CEol*, bool ); // GetNextLineã®wchar_tç‰ˆ
+//wchar_t* GetNextLineWB( const wchar_t*, int, int*, int*, CEol* ); // GetNextLineã®wchar_tç‰ˆ(ãƒ“ãƒƒã‚¯ã‚¨ãƒ³ãƒ‡ã‚£ã‚¢ãƒ³ç”¨)  // æœªä½¿ç”¨
 void GetLineColumn( const wchar_t*, int*, int* );
 
 
 int cescape(const TCHAR* org, TCHAR* buf, TCHAR cesc, TCHAR cwith);
 
 
-/*!	&‚Ì“ñd‰»
-	ƒƒjƒ…[‚ÉŠÜ‚Ü‚ê‚é&‚ğ&&‚É’u‚«Š·‚¦‚é
+/*!	&ã®äºŒé‡åŒ–
+	ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«å«ã¾ã‚Œã‚‹&ã‚’&&ã«ç½®ãæ›ãˆã‚‹
 	@author genta
-	@date 2002/01/30 cescape‚ÉŠg’£‚µC
+	@date 2002/01/30 cescapeã«æ‹¡å¼µã—ï¼Œ
 	@date 2004/06/19 genta Generic mapping
 */
 inline void dupamp(const TCHAR* org, TCHAR* out)
@@ -68,17 +68,17 @@ inline void dupamp(const TCHAR* org, TCHAR* out)
 
 
 /*
-	scanf“IˆÀ‘SƒXƒLƒƒƒ“
+	scanfçš„å®‰å…¨ã‚¹ã‚­ãƒ£ãƒ³
 
-	g—p—á:
+	ä½¿ç”¨ä¾‹:
 		int a[3];
 		scan_ints("1,23,4,5", "%d,%d,%d", a);
-		//Œ‹‰Ê: a[0]=1, a[1]=23, a[2]=4 ‚Æ‚È‚éB
+		//çµæœ: a[0]=1, a[1]=23, a[2]=4 ã¨ãªã‚‹ã€‚
 */
 int scan_ints(
-	const wchar_t*	pszData,	//!< [in]  ƒf[ƒ^•¶š—ñ
-	const wchar_t*	pszFormat,	//!< [in]  ƒf[ƒ^ƒtƒH[ƒ}ƒbƒg
-	int*			anBuf		//!< [out] æ“¾‚µ‚½”’l (—v‘f”‚ÍÅ‘å32‚Ü‚Å)
+	const wchar_t*	pszData,	//!< [in]  ãƒ‡ãƒ¼ã‚¿æ–‡å­—åˆ—
+	const wchar_t*	pszFormat,	//!< [in]  ãƒ‡ãƒ¼ã‚¿ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆ
+	int*			anBuf		//!< [out] å–å¾—ã—ãŸæ•°å€¤ (è¦ç´ æ•°ã¯æœ€å¤§32ã¾ã§)
 );
 
 #endif /* SAKURA_STRING_EX2_AA243462_59E7_4F55_B206_FD9ED8836A09_H_ */

--- a/sakura_core/util/tchar_convert.cpp
+++ b/sakura_core/util/tchar_convert.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "util/tchar_convert.h"
 #include "mem/CRecycledBuffer.h"
 
@@ -18,7 +18,7 @@ const WCHAR* to_wchar(const ACHAR* pSrc, int nSrcLength)
 {
 	if(pSrc==NULL)return NULL;
 
-	//•K—v‚ÈƒTƒCƒY‚ğŒvZ
+	//å¿…è¦ãªã‚µã‚¤ã‚ºã‚’è¨ˆç®—
 	int nDstLen = MultiByteToWideChar(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -29,7 +29,7 @@ const WCHAR* to_wchar(const ACHAR* pSrc, int nSrcLength)
 	);
 	size_t nDstCnt = (size_t)nDstLen + 1;
 
-	//ƒoƒbƒtƒ@æ“¾
+	//ãƒãƒƒãƒ•ã‚¡å–å¾—
 	WCHAR* pDst;
 	if(nDstCnt < g_bufSmall.GetMaxCount<WCHAR>()){
 		pDst=g_bufSmall.GetBuffer<WCHAR>(&nDstCnt);
@@ -38,7 +38,7 @@ const WCHAR* to_wchar(const ACHAR* pSrc, int nSrcLength)
 		pDst=g_bufBig.GetBuffer<WCHAR>(nDstCnt);
 	}
 
-	//•ÏŠ·
+	//å¤‰æ›
 	nDstLen = MultiByteToWideChar(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -64,7 +64,7 @@ const ACHAR* to_achar(const WCHAR* pSrc, int nSrcLength)
 {
 	if(pSrc==NULL)return NULL;
 
-	//•K—v‚ÈƒTƒCƒY‚ğŒvZ
+	//å¿…è¦ãªã‚µã‚¤ã‚ºã‚’è¨ˆç®—
 	int nDstLen = WideCharToMultiByte(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,
@@ -77,7 +77,7 @@ const ACHAR* to_achar(const WCHAR* pSrc, int nSrcLength)
 	);
 	size_t nDstCnt = (size_t)nDstLen + 1;
 
-	//ƒoƒbƒtƒ@æ“¾
+	//ãƒãƒƒãƒ•ã‚¡å–å¾—
 	ACHAR* pDst;
 	if(nDstCnt < g_bufSmall.GetMaxCount<ACHAR>()){
 		pDst=g_bufSmall.GetBuffer<ACHAR>(&nDstCnt);
@@ -86,7 +86,7 @@ const ACHAR* to_achar(const WCHAR* pSrc, int nSrcLength)
 		pDst=g_bufBig.GetBuffer<ACHAR>(nDstCnt);
 	}
 
-	//•ÏŠ·
+	//å¤‰æ›
 	nDstLen = WideCharToMultiByte(
 		CP_SJIS,				// 2008/5/12 Uchi
 		0,

--- a/sakura_core/util/tchar_convert.h
+++ b/sakura_core/util/tchar_convert.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -24,19 +24,19 @@
 #ifndef SAKURA_TCHAR_CONVERT_12EEF467_2644_4401_92A6_A0EA26FC78F39_H_
 #define SAKURA_TCHAR_CONVERT_12EEF467_2644_4401_92A6_A0EA26FC78F39_H_
 
-//WCHAR�ɕϊ�
+//WCHARに変換
 const WCHAR* to_wchar(const ACHAR* src);
 const WCHAR* to_wchar(const ACHAR* pSrcData, int nSrcLength);
 inline
 const WCHAR* to_wchar(const WCHAR* src){ return src; }
 
-//ACHAR�ɕϊ�
+//ACHARに変換
 inline
 const ACHAR* to_achar(const ACHAR* src){ return src; }
 const ACHAR* to_achar(const WCHAR* src);
 const ACHAR* to_achar(const WCHAR* pSrc, int nSrcLength);
 
-//TCHAR�ɕϊ�
+//TCHARに変換
 #ifdef _UNICODE
 	#define to_tchar     to_wchar
 	#define to_not_tchar to_achar
@@ -45,7 +45,7 @@ const ACHAR* to_achar(const WCHAR* pSrc, int nSrcLength);
 	#define to_not_tchar to_wchar
 #endif
 
-//���̑�
+//その他
 const WCHAR* easy_format(const WCHAR* format, ...);
 
 #endif /* SAKURA_TCHAR_CONVERT_12EEF467_2644_4401_92A6_A0EA26FC78F39_H_ */

--- a/sakura_core/util/tchar_printf.cpp
+++ b/sakura_core/util/tchar_printf.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -28,14 +28,14 @@
 
 #define MAX_BUF 0x7FFFFFFF
 
-//ƒeƒ“ƒvƒŒ[ƒg‚Å TEXT<T> g‚¦‚ê‚ÎA‚±‚ñ‚È‰˜‚¢ƒRƒsƒy‚µ‚È‚­‚ÄÏ‚Ş‚Ì‚Éc
+//ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã§ TEXT<T> ä½¿ãˆã‚Œã°ã€ã“ã‚“ãªæ±šã„ã‚³ãƒ”ãƒšã—ãªãã¦æ¸ˆã‚€ã®ã«â€¦
 template <class T>
 inline bool is_field_begin(T c)
 {
 	return c==_T2(T,'%');
 }
 
-//‘®w’è: flag
+//æ›¸å¼æŒ‡å®š: flag
 template <class T>
 inline const T* skip_field_flag(const T* p)
 {
@@ -47,29 +47,29 @@ inline const T* skip_field_flag(const T* p)
 	return p;
 }
 
-//‘®w’è: width
+//æ›¸å¼æŒ‡å®š: width
 template <class T>
 inline const T* skip_field_width(const T* p)
 {
-	if(*p>=_T2(T,'1') && *p<=_T2(T,'9'))p++; else return p; //ˆêŒ…–Ú‚Í0‚ğó‚¯•t‚¯‚È‚¢
+	if(*p>=_T2(T,'1') && *p<=_T2(T,'9'))p++; else return p; //ä¸€æ¡ç›®ã¯0ã‚’å—ã‘ä»˜ã‘ãªã„
 	while(*p>=_T2(T,'0') && *p<=_T2(T,'9'))p++;
 	return p;
 }
 
-//‘®w’è: precision
+//æ›¸å¼æŒ‡å®š: precision
 template <class T>
 inline const T* skip_field_precision(const T* p)
 {
-	if(*p==_T2(T,'.'))p++; else return p; //ƒhƒbƒg‚Ån‚Ü‚é•¶š—ñ‚Ì‚İó‚¯•t‚¯‚é
-	while(*p>=_T2(T,'0') && *p<=_T2(T,'9'))p++; //‚æ‚­‚í‚©‚ç‚ñ‚Ì‚Å‚Æ‚è‚ ‚¦‚¸‘S”š‚ğó‚¯•t‚¯‚é
+	if(*p==_T2(T,'.'))p++; else return p; //ãƒ‰ãƒƒãƒˆã§å§‹ã¾ã‚‹æ–‡å­—åˆ—ã®ã¿å—ã‘ä»˜ã‘ã‚‹
+	while(*p>=_T2(T,'0') && *p<=_T2(T,'9'))p++; //ã‚ˆãã‚ã‹ã‚‰ã‚“ã®ã§ã¨ã‚Šã‚ãˆãšå…¨æ•°å­—ã‚’å—ã‘ä»˜ã‘ã‚‹
 	return p;
 }
 
-//‘®w’è: prefix
+//æ›¸å¼æŒ‡å®š: prefix
 template <class T>
 inline const T* skip_field_prefix(const T* p)
 {
-	if(*p==_T2(T,'t'))return p+1; //“Æ©Šg’£
+	if(*p==_T2(T,'t'))return p+1; //ç‹¬è‡ªæ‹¡å¼µ
 	if(*p==_T2(T,'h'))return p+1;
 	if(p[0]==_T2(T,'l') && p[1]==_T2(T,'l'))return p+2;
 	if(*p==_T2(T,'l'))return p+1;
@@ -79,7 +79,7 @@ inline const T* skip_field_prefix(const T* p)
 	return p;
 }
 
-//‘®w’è: type
+//æ›¸å¼æŒ‡å®š: type
 inline bool is_field_type(char c)
 {
 	return strchr("cCdiouxXeEfgGaAnpsS",c)!=NULL;
@@ -140,7 +140,7 @@ static void my_va_forward(va_list& v, const char* field, const char* prefix)
 	case 'x':
 	case 'X':
 		{
-			// 2014.06.12 64bit’l‘Î‰
+			// 2014.06.12 64bitå€¤å¯¾å¿œ
 			const char *p = prefix;
 			if( p[0]=='I' && p[1]=='6' && p[2]=='4' ){
 				va_arg(v,LONGLONG);
@@ -185,7 +185,7 @@ static void my_va_forward(va_list& v, const wchar_t* field, const wchar_t* prefi
 	case L'u':
 	case L'x':
 	case L'X':
-		// 2014.06.12 64bit’l‘Î‰
+		// 2014.06.12 64bitå€¤å¯¾å¿œ
 		{
 			const wchar_t *p = prefix;
 			if( p[0]==L'I' && p[1]==L'6' && p[2]==L'4' ){
@@ -239,18 +239,18 @@ static void field_convert(wchar_t* src)
 }
 
 
-//"%ts","%tc"‚ğƒTƒ|[ƒg
-//¦“ú–{Œêl—¶‚µ‚È‚¢B(UNICODE”Å‚Å‚Í‚±‚ê‚Å–â‘è‚ª”­¶‚µ‚È‚¢)
+//"%ts","%tc"ã‚’ã‚µãƒãƒ¼ãƒˆ
+//â€»æ—¥æœ¬èªè€ƒæ…®ã—ãªã„ã€‚(UNICODEç‰ˆã§ã¯ã“ã‚Œã§å•é¡ŒãŒç™ºç”Ÿã—ãªã„)
 template <class T>
 int tchar_vsprintf_s_imp(T* buf, size_t nBufCount, const T* format, va_list& v, bool truncate)
 {
-	T* buf_end=buf+nBufCount; //•ÏŠ·ƒŠƒ~ƒbƒg
+	T* buf_end=buf+nBufCount; //å¤‰æ›ãƒªãƒŸãƒƒãƒˆ
 
-	T* dst=buf;          //•ÏŠ·æƒ[ƒN•Ï”
-	const T* src=format; //•ÏŠ·Œ³ƒ[ƒN•Ï”
+	T* dst=buf;          //å¤‰æ›å…ˆãƒ¯ãƒ¼ã‚¯å¤‰æ•°
+	const T* src=format; //å¤‰æ›å…ƒãƒ¯ãƒ¼ã‚¯å¤‰æ•°
 	while(*src){
 		if(nBufCount!=MAX_BUF && dst>=buf_end-1)break;
-		//‘®w’èƒtƒB[ƒ‹ƒh‚ğæ“¾
+		//æ›¸å¼æŒ‡å®šãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ã‚’å–å¾—
 		if(is_field_begin(*src)){
 			const T* field_begin=src;
 			src++;
@@ -264,22 +264,22 @@ int tchar_vsprintf_s_imp(T* buf, size_t nBufCount, const T* format, va_list& v, 
 				src++;
 				const T* field_end=src;
 
-				//ƒtƒB[ƒ‹ƒh‚ğˆê•Ï”‚ÉƒRƒs[
+				//ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ã‚’ä¸€æ™‚å¤‰æ•°ã«ã‚³ãƒ”ãƒ¼
 				T field[64];
-				if(field_end-field_begin>=_countof(field))field_end=field_begin+_countof(field)-1; //ƒtƒB[ƒ‹ƒh’·§ŒÀ
+				if(field_end-field_begin>=_countof(field))field_end=field_begin+_countof(field)-1; //ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰é•·åˆ¶é™
 				auto_strncpy(field,field_begin,field_end-field_begin);
 				field[field_end-field_begin] = 0;
 				
-				//ƒtƒB[ƒ‹ƒh“à‚É%ts‚Ü‚½‚Í%tc‚ª‚ ‚Á‚½‚çA“KØ‚É•ÏŠ·
+				//ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰å†…ã«%tsã¾ãŸã¯%tcãŒã‚ã£ãŸã‚‰ã€é©åˆ‡ã«å¤‰æ›
 				field_convert(field);
 
-				//•ÏŠ·ˆ—‚Í•W€ƒ‰ƒCƒuƒ‰ƒŠ‚ÉˆÏ÷
+				//å¤‰æ›å‡¦ç†ã¯æ¨™æº–ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã«å§”è­²
 				int ret;
-				va_list tmp_v=v; //¦v‚ğƒRƒs[‚µ‚Ä—p‚¢‚é
+				va_list tmp_v=v; //â€»vã‚’ã‚³ãƒ”ãƒ¼ã—ã¦ç”¨ã„ã‚‹
 				if(truncate){
 					ret=local_vsnprintf_s(dst,buf_end-dst,field,tmp_v);
 					if( ret<0 ){
-						//ƒoƒbƒtƒ@‚É“ü‚è‚«‚ç‚È‚¢•¶š—ñ‚ªØ‚èÌ‚Ä‚ç‚ê‚½
+						//ãƒãƒƒãƒ•ã‚¡ã«å…¥ã‚Šãã‚‰ãªã„æ–‡å­—åˆ—ãŒåˆ‡ã‚Šæ¨ã¦ã‚‰ã‚ŒãŸ
 						return -1;
 					}
 				}
@@ -290,30 +290,30 @@ int tchar_vsprintf_s_imp(T* buf, size_t nBufCount, const T* format, va_list& v, 
 					ret=local_vsprintf(dst,field,tmp_v);
 				}
 
-				//v‚ği‚ß‚éB©M‚È‚Á‚µ‚ñ‚®
+				//vã‚’é€²ã‚ã‚‹ã€‚è‡ªä¿¡ãªã£ã—ã‚“ã
 				my_va_forward(v,field, prefix);
 
-				//•ÏŠ·æƒ[ƒNƒ|ƒCƒ“ƒ^‚ği‚ß‚é
+				//å¤‰æ›å…ˆãƒ¯ãƒ¼ã‚¯ãƒã‚¤ãƒ³ã‚¿ã‚’é€²ã‚ã‚‹
 				if(ret!=-1){
 					dst+=ret;
 				}
 				src=field_end;
 			}
 			else{
-				//—LŒø‚ÈŒ^ƒtƒB[ƒ‹ƒh‚Å‚Í‚È‚©‚Á‚½‚Ì‚ÅA‚»‚Ì‚Ü‚ñ‚Üo—Í‚µ‚¿‚á‚¤
+				//æœ‰åŠ¹ãªå‹ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ã§ã¯ãªã‹ã£ãŸã®ã§ã€ãã®ã¾ã‚“ã¾å‡ºåŠ›ã—ã¡ã‚ƒã†
 				*dst++ = *src++;
 			}
 		}
 		else{
-			//–³•ÏŠ·
+			//ç„¡å¤‰æ›
 			*dst++ = *src++;
 		}
 	}
-	//I’[
+	//çµ‚ç«¯
 	*dst = 0;
 
-	if( truncate && *src != '\0' ){		//Ø‚è‹l‚ß‚ ‚è‚ÅAsrc‚Ìˆ—‚ªŠ®—¹‚µ‚Ä‚¢‚È‚¢ê‡
-		return -1;						//Ø‚è‹l‚ß‚ç‚ê‚½
+	if( truncate && *src != '\0' ){		//åˆ‡ã‚Šè©°ã‚ã‚ã‚Šã§ã€srcã®å‡¦ç†ãŒå®Œäº†ã—ã¦ã„ãªã„å ´åˆ
+		return -1;						//åˆ‡ã‚Šè©°ã‚ã‚‰ã‚ŒãŸ
 	}
 	return dst-buf;
 }
@@ -332,8 +332,8 @@ int tchar_vsprintf_s(WCHAR* buf, size_t nBufCount, const WCHAR* format, va_list&
 
 
 
-// vsprintfƒ‰ƒbƒv
-// ¦buf‚É\•ª‚È—e—Ê‚ª‚ ‚é‚±‚Æ‚É©M‚ª‚ ‚é‚Æ‚«‚¾‚¯Ag‚Á‚Ä‚­‚¾‚³‚¢B
+// vsprintfãƒ©ãƒƒãƒ—
+// â€»bufã«ååˆ†ãªå®¹é‡ãŒã‚ã‚‹ã“ã¨ã«è‡ªä¿¡ãŒã‚ã‚‹ã¨ãã ã‘ã€ä½¿ã£ã¦ãã ã•ã„ã€‚
 //
 int tchar_vsprintf(ACHAR* buf, const ACHAR* format, va_list& v)
 {
@@ -345,8 +345,8 @@ int tchar_vsprintf(WCHAR* buf, const WCHAR* format, va_list& v)
 }
 
 
-// vsnprintf_sƒ‰ƒbƒv
-// ƒoƒbƒtƒ@‚ªo—Í•¶š—ñ‚æ‚è¬‚³‚¢ê‡‚Í‰Â”\‚ÈŒÀ‚èo—Í‚µ‚Ä––”ö‚É\0‚ğ•t‚¯A–ß‚è’l-1‚Å•Ô‚è‚Ü‚·B
+// vsnprintf_sãƒ©ãƒƒãƒ—
+// ãƒãƒƒãƒ•ã‚¡ãŒå‡ºåŠ›æ–‡å­—åˆ—ã‚ˆã‚Šå°ã•ã„å ´åˆã¯å¯èƒ½ãªé™ã‚Šå‡ºåŠ›ã—ã¦æœ«å°¾ã«\0ã‚’ä»˜ã‘ã€æˆ»ã‚Šå€¤-1ã§è¿”ã‚Šã¾ã™ã€‚
 //
 int tchar_vsnprintf_s(ACHAR* buf, size_t nBufCount, const ACHAR* format, va_list& v)
 {
@@ -358,13 +358,13 @@ int tchar_vsnprintf_s(WCHAR* buf, size_t nBufCount, const WCHAR* format, va_list
 }
 
 
-// sprintf_sƒ‰ƒbƒv
+// sprintf_sãƒ©ãƒƒãƒ—
 //
-// (À‘•‚É‚Â‚¢‚Ä)
-//     “à—e‚ª“¯‚¶‚È‚Ì‚ÅAtemplate‚Å‚à—Ç‚©‚Á‚½‚Ì‚Å‚·‚ªA
-//     ‚»‚¤‚·‚é‚ÆAACHAR, WCHAR ˆÈŠO‚ÌŒ^‚©‚ç‚ÌˆÃ–Ù‚ÅˆÀ‘S‚ÈƒLƒƒƒXƒg‚ª
-//     Œø‚©‚È‚­‚È‚èAƒR[ƒfƒBƒ“ƒO‚ª•s•Ö‚É‚È‚é‚½‚ßA
-//     ‚ ‚¦‚ÄAACHAR, WCHAR ‚ÅŠÖ”‚ğ‚Ğ‚Æ‚Â‚¸‚Â’è‹`‚µ‚Ä‚¢‚Ü‚·B
+// (å®Ÿè£…ã«ã¤ã„ã¦)
+//     å†…å®¹ãŒåŒã˜ãªã®ã§ã€templateã§ã‚‚è‰¯ã‹ã£ãŸã®ã§ã™ãŒã€
+//     ãã†ã™ã‚‹ã¨ã€ACHAR, WCHAR ä»¥å¤–ã®å‹ã‹ã‚‰ã®æš—é»™ã§å®‰å…¨ãªã‚­ãƒ£ã‚¹ãƒˆãŒ
+//     åŠ¹ã‹ãªããªã‚Šã€ã‚³ãƒ¼ãƒ‡ã‚£ãƒ³ã‚°ãŒä¸ä¾¿ã«ãªã‚‹ãŸã‚ã€
+//     ã‚ãˆã¦ã€ACHAR, WCHAR ã§é–¢æ•°ã‚’ã²ã¨ã¤ãšã¤å®šç¾©ã—ã¦ã„ã¾ã™ã€‚
 //
 int tchar_sprintf_s(ACHAR* buf, size_t nBufCount, const ACHAR* format, ...)
 {
@@ -384,14 +384,14 @@ int tchar_sprintf_s(WCHAR* buf, size_t nBufCount, const WCHAR* format, ...)
 }
 
 
-// sprintfƒ‰ƒbƒv
-// ¦buf‚É\•ª‚È—e—Ê‚ª‚ ‚é‚±‚Æ‚É©M‚ª‚ ‚é‚Æ‚«‚¾‚¯Ag‚Á‚Ä‚­‚¾‚³‚¢B
+// sprintfãƒ©ãƒƒãƒ—
+// â€»bufã«ååˆ†ãªå®¹é‡ãŒã‚ã‚‹ã“ã¨ã«è‡ªä¿¡ãŒã‚ã‚‹ã¨ãã ã‘ã€ä½¿ã£ã¦ãã ã•ã„ã€‚
 //
-// (À‘•‚É‚Â‚¢‚Ä)
-//     “à—e‚ª“¯‚¶‚È‚Ì‚ÅAtemplate‚Å‚à—Ç‚©‚Á‚½‚Ì‚Å‚·‚ªA
-//     ‚»‚¤‚·‚é‚ÆAACHAR, WCHAR ˆÈŠO‚ÌŒ^‚©‚ç‚ÌˆÃ–Ù‚ÅˆÀ‘S‚ÈƒLƒƒƒXƒg‚ª
-//     Œø‚©‚È‚­‚È‚èAƒR[ƒfƒBƒ“ƒO‚ª•s•Ö‚É‚È‚é‚½‚ßA
-//     ‚ ‚¦‚ÄAACHAR, WCHAR ‚ÅŠÖ”‚ğ‚Ğ‚Æ‚Â‚¸‚Â’è‹`‚µ‚Ä‚¢‚Ü‚·B
+// (å®Ÿè£…ã«ã¤ã„ã¦)
+//     å†…å®¹ãŒåŒã˜ãªã®ã§ã€templateã§ã‚‚è‰¯ã‹ã£ãŸã®ã§ã™ãŒã€
+//     ãã†ã™ã‚‹ã¨ã€ACHAR, WCHAR ä»¥å¤–ã®å‹ã‹ã‚‰ã®æš—é»™ã§å®‰å…¨ãªã‚­ãƒ£ã‚¹ãƒˆãŒ
+//     åŠ¹ã‹ãªããªã‚Šã€ã‚³ãƒ¼ãƒ‡ã‚£ãƒ³ã‚°ãŒä¸ä¾¿ã«ãªã‚‹ãŸã‚ã€
+//     ã‚ãˆã¦ã€ACHAR, WCHAR ã§é–¢æ•°ã‚’ã²ã¨ã¤ãšã¤å®šç¾©ã—ã¦ã„ã¾ã™ã€‚
 //
 int tchar_sprintf(ACHAR* buf, const ACHAR* format, ...)
 {
@@ -411,8 +411,8 @@ int tchar_sprintf(WCHAR* buf, const WCHAR* format, ...)
 	return ret;
 }
 
-// snprintf_sƒ‰ƒbƒv
-// ƒoƒbƒtƒ@‚ªo—Í•¶š—ñ‚æ‚è¬‚³‚¢ê‡‚Í‰Â”\‚ÈŒÀ‚èo—Í‚µ‚Ä––”ö‚É\0‚ğ•t‚¯A–ß‚è’l-1‚Å•Ô‚è‚Ü‚·B
+// snprintf_sãƒ©ãƒƒãƒ—
+// ãƒãƒƒãƒ•ã‚¡ãŒå‡ºåŠ›æ–‡å­—åˆ—ã‚ˆã‚Šå°ã•ã„å ´åˆã¯å¯èƒ½ãªé™ã‚Šå‡ºåŠ›ã—ã¦æœ«å°¾ã«\0ã‚’ä»˜ã‘ã€æˆ»ã‚Šå€¤-1ã§è¿”ã‚Šã¾ã™ã€‚
 //
 int tchar_snprintf_s(ACHAR* buf, size_t count, const ACHAR* format, ...) 
 {

--- a/sakura_core/util/tchar_printf.h
+++ b/sakura_core/util/tchar_printf.h
@@ -1,25 +1,25 @@
-// printf�n���b�v�֐��Q
-// 2007.09.20 kobake �쐬�B
+﻿// printf系ラップ関数群
+// 2007.09.20 kobake 作成。
 //
-// �d�v�ȓ����Ƃ��āA�Ǝ��̃t�B�[���h "%ts" ����� "%tc" ��F�����ď�������A�Ƃ����_������܂��B
-// UNICODE�r���h�ł� "%ts", "%tc" �͂��ꂼ�� "%ls", %lc" �Ƃ��ĔF������A
-// ANSI�r���h�ł�    "%ts", "%tc" �͂��ꂼ�� "%hs", %hc" �Ƃ��ĔF������܂��B
+// 重要な特徴として、独自のフィールド "%ts" および "%tc" を認識して処理する、という点があります。
+// UNICODEビルドでは "%ts", "%tc" はそれぞれ "%ls", %lc" として認識され、
+// ANSIビルドでは    "%ts", "%tc" はそれぞれ "%hs", %hc" として認識されます。
 //
-// "%s", "%c" �͎g�p�֐��ɂ��^���ς��Achar, wchar_t �����݂���R�[�f�B���O���ł̓o�O�̌��ƂȂ�₷���̂ŁA
-// �ł��邾���A��ɋL�����悤�Ȗ����I�Ȍ^�w��������t�B�[���h��p���Ă��������B
+// "%s", "%c" は使用関数により型が変わり、char, wchar_t が混在するコーディング環境ではバグの元となりやすいので、
+// できるだけ、上に記したような明示的な型指定をしたフィールドを用いてください。
 //
-// ���ӁF%10ts %.12ts �̂悤�Ȃ��͖̂��T�|�[�g
+// 注意：%10ts %.12ts のようなものは未サポート
 //
-// ++ ++ ���P�� ++ ++
+// ++ ++ 改善案 ++ ++
 //
-// �����܂ł��W�����C�u����������u���b�v�v���Ă��邾���Ȃ̂ŁA
-// ���̃��b�v�������A�p�t�H�[�}���X�͈����ł��B
-// �W�����C�u�����ɗ��炸�ɑS�Ď��O�Ŏ�������΁A�W�����C�u�������݂̃p�t�H�[�}���X��������͂��ł��B
+// あくまでも標準ライブラリ動作を「ラップ」しているだけなので、
+// そのラップ処理分、パフォーマンスは悪いです。
+// 標準ライブラリに頼らずに全て自前で実装すれば、標準ライブラリ並みのパフォーマンスが得られるはずです。
 //
-// ������Ɗ֐�����������ɂ����̂ŁA�����Ɨǂ����O��W�B
-// ���̂܂܂��ƁA��L������ǂ܂Ȃ���΁A_tsprintf �Ƃ��Ɖ����Ⴄ�́H�Ǝv��ꂿ�Ⴂ�����B�B�B
+// ちょっと関数名が分かりにくいので、もっと良い名前募集。
+// 今のままだと、上記説明を読まなければ、_tsprintf とかと何が違うの？と思われちゃいそう。。。
 //
-// �v���W�F�N�g�S�̂�TCHAR�ɗ���Ȃ��̂ł���΁A�����̊֐��Q�͕s�v�B
+// プロジェクト全体がTCHARに頼らないのであれば、これらの関数群は不要。
 //
 /*
 	Copyright (C) 2008, kobake
@@ -47,27 +47,27 @@
 #ifndef SAKURA_TCHAR_PRINTF_DAD4722C_BE9A_420C_BB75_311B6B1EC14E9_H_
 #define SAKURA_TCHAR_PRINTF_DAD4722C_BE9A_420C_BB75_311B6B1EC14E9_H_
 
-// vsprintf_s���b�v
+// vsprintf_sラップ
 int tchar_vsprintf_s(ACHAR* buf, size_t nBufCount, const ACHAR* format, va_list& v);
 int tchar_vsprintf_s(WCHAR* buf, size_t nBufCount, const WCHAR* format, va_list& v);
 
-// vsprintf���b�v
+// vsprintfラップ
 int tchar_vsprintf(ACHAR* buf, const ACHAR* format, va_list& v);
 int tchar_vsprintf(WCHAR* buf, const WCHAR* format, va_list& v);
 
-// vsnprintf_s���b�v
+// vsnprintf_sラップ
 int tchar_vsnprintf_s(ACHAR* buf, size_t nBufCount, const ACHAR* format, va_list& v);
 int tchar_vsnprintf_s(WCHAR* buf, size_t nBufCount, const WCHAR* format, va_list& v);
 
-// sprintf_s���b�v
+// sprintf_sラップ
 int tchar_sprintf_s(ACHAR* buf, size_t nBufCount, const ACHAR* format, ...);
 int tchar_sprintf_s(WCHAR* buf, size_t nBufCount, const WCHAR* format, ...);
 
-// sprintf���b�v
+// sprintfラップ
 int tchar_sprintf(ACHAR* buf, const ACHAR* format, ...);
 int tchar_sprintf(WCHAR* buf, const WCHAR* format, ...);
 
-// _snprintf_s���b�v
+// _snprintf_sラップ
 int tchar_snprintf_s(ACHAR* buf, size_t count, const ACHAR* format, ...);
 int tchar_snprintf_s(WCHAR* buf, size_t count, const WCHAR* format, ...);
 

--- a/sakura_core/util/tchar_receive.cpp
+++ b/sakura_core/util/tchar_receive.cpp
@@ -1,29 +1,29 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "tchar_receive.h"
 using namespace std;
 
-//TcharReceiverÀ‘•
+//TcharReceiverå®Ÿè£…
 #ifdef _UNICODE
-	//UNICODEƒrƒ‹ƒh‚ÅAWCHAR‚ğó‚¯æ‚é
+	//UNICODEãƒ“ãƒ«ãƒ‰ã§ã€WCHARã‚’å—ã‘å–ã‚‹
 	template <> TCHAR* TcharReceiver<WCHAR>::GetBufferPointer(){ return m_pReceiver; }
-	template <> void   TcharReceiver<WCHAR>::Apply(){} //‰½‚à‚µ‚È‚¢
+	template <> void   TcharReceiver<WCHAR>::Apply(){} //ä½•ã‚‚ã—ãªã„
 
-	//UNICODEƒrƒ‹ƒh‚ÅAACHAR‚ğó‚¯æ‚é
+	//UNICODEãƒ“ãƒ«ãƒ‰ã§ã€ACHARã‚’å—ã‘å–ã‚‹
 	template <> TCHAR* TcharReceiver<ACHAR>::GetBufferPointer(){ return (m_pBuff = new TCHAR[m_nReceiverCount]); }
 	template <> void   TcharReceiver<ACHAR>::Apply(){ _tcstombs(m_pReceiver, m_pBuff, m_nReceiverCount); delete []m_pBuff; }
 
 #else
-	//ANSIƒrƒ‹ƒh‚ÅAWCHAR‚ğó‚¯æ‚é
+	//ANSIãƒ“ãƒ«ãƒ‰ã§ã€WCHARã‚’å—ã‘å–ã‚‹
 	template <> TCHAR* TcharReceiver<WCHAR>::GetBufferPointer(){ return (m_pBuff = new TCHAR[m_nReceiverCount]); }
 	template <> void   TcharReceiver<WCHAR>::Apply(){ _tcstowcs(m_pReceiver, m_pBuff, m_nReceiverCount); delete []m_pBuff; }
 
-	//ANSIƒrƒ‹ƒh‚ÅAACHAR‚ğó‚¯æ‚é
+	//ANSIãƒ“ãƒ«ãƒ‰ã§ã€ACHARã‚’å—ã‘å–ã‚‹
 	template <> TCHAR* TcharReceiver<ACHAR>::GetBufferPointer(){ return m_pReceiver; }
-	template <> void   TcharReceiver<ACHAR>::Apply(){} //‰½‚à‚µ‚È‚¢
+	template <> void   TcharReceiver<ACHAR>::Apply(){} //ä½•ã‚‚ã—ãªã„
 
 #endif
 
-//ƒCƒ“ƒXƒ^ƒ“ƒX‰»
+//ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹åŒ–
 template class TcharReceiver<WCHAR>;
 template class TcharReceiver<ACHAR>;
 

--- a/sakura_core/util/tchar_receive.h
+++ b/sakura_core/util/tchar_receive.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2007, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,39 +25,39 @@
 #define SAKURA_TCHAR_RECEIVE_173C52CE_CAC9_4ED5_8399_EFEF8CC7DBD2_H_
 
 /*!
-	���ۂ̃f�[�^��Ɋւ�炸�ATCHAR[]�^�̎󂯎��o�b�t�@��񋟂���N���X�B
-	�g����������Ȃ̂Œ��ӁB
+	実際のデータ種に関わらず、TCHAR[]型の受け取りバッファを提供するクラス。
+	使い方が特殊なので注意。
 
-	��:
+	例:
 	{
 		wchar_t buf[256];
 		GetWindowText(hwnd,TcharReceiver(buf));
 	}
 
-	���̃R�[�h�́AANSI�r���h�AUNICODE�r���h�A�Ƃ��ɒʂ�܂��B
-	ANSI�r���h���́Achar��wchar_t�ϊ����������邽�߁A�������ׂ�������܂� (���̗�̏ꍇ)�B
-	UNICODE�r���h���́A���ׂ� TcharReceiver ���g��Ȃ��ꍇ�ƂقƂ�Ǖς��܂��� (���̗�̏ꍇ)�B
+	このコードは、ANSIビルド、UNICODEビルド、ともに通ります。
+	ANSIビルド時は、char→wchar_t変換が発生するため、少し負荷がかかります (この例の場合)。
+	UNICODEビルド時は、負荷は TcharReceiver を使わない場合とほとんど変わりません (この例の場合)。
 
-	���쌴���̓\�[�X���Q�Ƃ̂��ƁB
-	operator TCHAR* �� GetWindowText �ɓn���|�C���^��񋟂��A
-	~TcharReceiver �ɂ����āA�K�v�ł���� (�r���h��Ǝ󂯎��^���قȂ��)�A
-	TCHAR��wchar_t�ϊ����������܂��B
+	動作原理はソースを参照のこと。
+	operator TCHAR* が GetWindowText に渡すポインタを提供し、
+	~TcharReceiver において、必要であれば (ビルド種と受け取り型が異なれば)、
+	TCHAR→wchar_t変換が発生します。
 
-	2007.10.27 kobake �쐬
-	2009.02.21 ryoji		�W��������ȊO�������ꍇ�iUNICODE�r���h��ACHAR�AANSI�r���h��WCHAR�j��
-							512�����̃T�C�Y�����t���ÓI�o�b�t�@���g�p���Ă����̂��A
-							�T�C�Y�����̖������I�o�b�t�@���g���悤�ɕύX�B�i���ׂ͂ǂ݂̂��ϊ��̂ق��ɂ�������j
+	2007.10.27 kobake 作成
+	2009.02.21 ryoji		標準文字列以外を扱う場合（UNICODEビルドでACHAR、ANSIビルドでWCHAR）に
+							512文字のサイズ制限付き静的バッファを使用していたのを、
+							サイズ制限の無い動的バッファを使うように変更。（負荷はどのみち変換のほうにがかかる）
 */
 template <class RECEIVE_CHAR_TYPE>
 class TcharReceiver{
 public:
-	TcharReceiver(RECEIVE_CHAR_TYPE* pReceiver, size_t nReceiverCount)	//!< �󂯎��o�b�t�@���w��B
+	TcharReceiver(RECEIVE_CHAR_TYPE* pReceiver, size_t nReceiverCount)	//!< 受け取りバッファを指定。
 	: m_pReceiver(pReceiver), m_nReceiverCount(nReceiverCount), m_pBuff(NULL) { }
 	operator TCHAR* (){ return GetBufferPointer(); }
 	~TcharReceiver(){ Apply(); }
 protected:
-	TCHAR* GetBufferPointer();	//!< �ꎞ�o�b�t�@��񋟁B�o�b�t�@�����͒Z���̂Œ��ӁB
-	void Apply();				//!< �ꎞ�o�b�t�@����A���ۂ̎󂯎��o�b�t�@�փf�[�^���R�s�[�B
+	TCHAR* GetBufferPointer();	//!< 一時バッファを提供。バッファ寿命は短いので注意。
+	void Apply();				//!< 一時バッファから、実際の受け取りバッファへデータをコピー。
 private:
 	RECEIVE_CHAR_TYPE*	m_pReceiver;
 	size_t				m_nReceiverCount;

--- a/sakura_core/util/tchar_template.cpp
+++ b/sakura_core/util/tchar_template.cpp
@@ -1,8 +1,8 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "tchar_template.h"
 
-// -- -- •K—v‚È•¶ŽšŒQ‚ðŽè“®‚Å’è‹` -- -- //
-//ƒAƒ‹ƒtƒ@ƒxƒbƒg
+// -- -- å¿…è¦ãªæ–‡å­—ç¾¤ã‚’æ‰‹å‹•ã§å®šç¾© -- -- //
+//ã‚¢ãƒ«ãƒ•ã‚¡ãƒ™ãƒƒãƒˆ
 DEFINE_T2('A')
 DEFINE_T2('B')
 DEFINE_T2('C')
@@ -56,7 +56,7 @@ DEFINE_T2('x')
 DEFINE_T2('y')
 DEFINE_T2('z')
 
-//”Žš
+//æ•°å­—
 DEFINE_T2('0')
 DEFINE_T2('1')
 DEFINE_T2('2')
@@ -68,7 +68,7 @@ DEFINE_T2('7')
 DEFINE_T2('8')
 DEFINE_T2('9')
 
-//‹L†
+//è¨˜å·
 DEFINE_T2('-')
 DEFINE_T2('^')
 DEFINE_T2('\\')
@@ -103,7 +103,7 @@ DEFINE_T2('?')
 DEFINE_T2('_')
 DEFINE_T2(' ')
 
-//“ÁŽê•¶Žš
+//ç‰¹æ®Šæ–‡å­—
 DEFINE_T2('\r')
 DEFINE_T2('\n')
 DEFINE_T2('\t')

--- a/sakura_core/util/tchar_template.h
+++ b/sakura_core/util/tchar_template.h
@@ -1,16 +1,16 @@
-/*
-	_T�}�N���݊��̃e���v���[�g�B
-	�r���h��Ɋւ�炸�A�w�肵���^�̕����萔��񋟂���B
+﻿/*
+	_Tマクロ互換のテンプレート。
+	ビルド種に関わらず、指定した型の文字定数を提供する。
 
 	_T2(char,'A')
 	_T2(wchar_t,'x')
 	_T2(TCHAR,'/')
-	�̂悤�Ɏg���܂��B
+	のように使います。
 
-	�e���v���[�g�Ă񂱂���Ȃ̂ŁA�R���p�C�����d���Ȃ�Ǝv���܂��B
-	�C���N���[�h�͍ŏ����ɁI
+	テンプレートてんこもりなので、コンパイルが重くなると思われます。
+	インクルードは最小限に！
 
-	2007.10.23 kobake �쐬
+	2007.10.23 kobake 作成
 */
 
 typedef char ACHAR;
@@ -19,11 +19,11 @@ typedef wchar_t WCHAR;
 template <class CHAR_TYPE, int CHAR_VALUE>
 CHAR_TYPE _TextTemplate();
 
-//������`�}�N��
+//文字定義マクロ
 #define DEFINE_T2(CHAR_VALUE) \
 template<> ACHAR _TextTemplate<ACHAR,CHAR_VALUE>(){ return ATEXT(CHAR_VALUE); } \
 template<> WCHAR _TextTemplate<WCHAR,CHAR_VALUE>(){ return LTEXT(CHAR_VALUE); }
 
-//�g�p�}�N��
+//使用マクロ
 #define _T2(CHAR_TYPE,CHAR_VALUE) _TextTemplate<CHAR_TYPE,CHAR_VALUE>()
 

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "env/CShareData.h"
 #include "env/DLLSHAREDATA.h"
 #include "env/CSakuraEnvironment.h"
@@ -9,18 +9,18 @@ int CDPI::nDpiX = 96;
 int CDPI::nDpiY = 96;
 bool CDPI::bInitialized = false;
 
-/**	w’è‚µ‚½ƒEƒBƒ“ƒhƒE‚Ì‘cæ‚Ìƒnƒ“ƒhƒ‹‚ğæ“¾‚·‚é
+/**	æŒ‡å®šã—ãŸã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ç¥–å…ˆã®ãƒãƒ³ãƒ‰ãƒ«ã‚’å–å¾—ã™ã‚‹
 
-	GetAncestor() API‚ªWin95‚Åg‚¦‚È‚¢‚Ì‚Å‚»‚Ì‚©‚í‚è
+	GetAncestor() APIãŒWin95ã§ä½¿ãˆãªã„ã®ã§ãã®ã‹ã‚ã‚Š
 
-	WS_POPUPƒXƒ^ƒCƒ‹‚ğ‚½‚È‚¢ƒEƒBƒ“ƒhƒEiex.CDlgFuncListƒ_ƒCƒAƒƒOj‚¾‚ÆA
-	GA_ROOTOWNER‚Å‚Í•ÒWƒEƒBƒ“ƒhƒE‚Ü‚Å‘k‚ê‚È‚¢‚İ‚½‚¢BGetAncestor() API‚Å‚à“¯—lB
-	–{ŠÖ”ŒÅ—L‚É—pˆÓ‚µ‚½GA_ROOTOWNER2‚Å‚Í‘k‚é‚±‚Æ‚ª‚Å‚«‚éB
+	WS_POPUPã‚¹ã‚¿ã‚¤ãƒ«ã‚’æŒãŸãªã„ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ï¼ˆex.CDlgFuncListãƒ€ã‚¤ã‚¢ãƒ­ã‚°ï¼‰ã ã¨ã€
+	GA_ROOTOWNERã§ã¯ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¾ã§é¡ã‚Œãªã„ã¿ãŸã„ã€‚GetAncestor() APIã§ã‚‚åŒæ§˜ã€‚
+	æœ¬é–¢æ•°å›ºæœ‰ã«ç”¨æ„ã—ãŸGA_ROOTOWNER2ã§ã¯é¡ã‚‹ã“ã¨ãŒã§ãã‚‹ã€‚
 
 	@author ryoji
-	@date 2007.07.01 ryoji V‹K
-	@date 2007.10.22 ryoji ƒtƒ‰ƒO’l‚Æ‚µ‚ÄGA_ROOTOWNER2i–{ŠÖ”ŒÅ—Lj‚ğ’Ç‰Á
-	@date 2008.04.09 ryoji GA_ROOTOWNER2 ‚Í‰Â”\‚ÈŒÀ‚è‘cæ‚ğ‘k‚é‚æ‚¤‚É“®ìC³
+	@date 2007.07.01 ryoji æ–°è¦
+	@date 2007.10.22 ryoji ãƒ•ãƒ©ã‚°å€¤ã¨ã—ã¦GA_ROOTOWNER2ï¼ˆæœ¬é–¢æ•°å›ºæœ‰ï¼‰ã‚’è¿½åŠ 
+	@date 2008.04.09 ryoji GA_ROOTOWNER2 ã¯å¯èƒ½ãªé™ã‚Šç¥–å…ˆã‚’é¡ã‚‹ã‚ˆã†ã«å‹•ä½œä¿®æ­£
 */
 HWND MyGetAncestor( HWND hWnd, UINT gaFlags )
 {
@@ -33,17 +33,17 @@ HWND MyGetAncestor( HWND hWnd, UINT gaFlags )
 
 	switch( gaFlags )
 	{
-	case GA_PARENT:	// eƒEƒBƒ“ƒhƒE‚ğ•Ô‚·iƒI[ƒi[‚Í•Ô‚³‚È‚¢j
+	case GA_PARENT:	// è¦ªã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¿”ã™ï¼ˆã‚ªãƒ¼ãƒŠãƒ¼ã¯è¿”ã•ãªã„ï¼‰
 		hwndAncestor = ( (DWORD)::GetWindowLongPtr( hWnd, GWL_STYLE ) & WS_CHILD )? ::GetParent( hWnd ): hwndDesktop;
 		break;
 
-	case GA_ROOT:	// eqŠÖŒW‚ğ‘k‚Á‚Ä’¼‹ßãˆÊ‚ÌƒgƒbƒvƒŒƒxƒ‹ƒEƒBƒ“ƒhƒE‚ğ•Ô‚·
+	case GA_ROOT:	// è¦ªå­é–¢ä¿‚ã‚’é¡ã£ã¦ç›´è¿‘ä¸Šä½ã®ãƒˆãƒƒãƒ—ãƒ¬ãƒ™ãƒ«ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¿”ã™
 		hwndAncestor = hWnd;
 		while( (DWORD)::GetWindowLongPtr( hwndAncestor, GWL_STYLE ) & WS_CHILD )
 			hwndAncestor = ::GetParent( hwndAncestor );
 		break;
 
-	case GA_ROOTOWNER:	// eqŠÖŒW‚ÆŠ—LŠÖŒW‚ğGetParent()‚Å‘k‚Á‚ÄŠ—L‚³‚ê‚Ä‚¢‚È‚¢ƒgƒbƒvƒŒƒxƒ‹ƒEƒBƒ“ƒhƒE‚ğ•Ô‚·
+	case GA_ROOTOWNER:	// è¦ªå­é–¢ä¿‚ã¨æ‰€æœ‰é–¢ä¿‚ã‚’GetParent()ã§é¡ã£ã¦æ‰€æœ‰ã•ã‚Œã¦ã„ãªã„ãƒˆãƒƒãƒ—ãƒ¬ãƒ™ãƒ«ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¿”ã™
 		hwndWk = hWnd;
 		do{
 			hwndAncestor = hwndWk;
@@ -51,7 +51,7 @@ HWND MyGetAncestor( HWND hWnd, UINT gaFlags )
 		}while( hwndWk != NULL );
 		break;
 
-	case GA_ROOTOWNER2:	// Š—LŠÖŒW‚ğGetWindow()‚Å‘k‚Á‚ÄŠ—L‚³‚ê‚Ä‚¢‚È‚¢ƒgƒbƒvƒŒƒxƒ‹ƒEƒBƒ“ƒhƒE‚ğ•Ô‚·
+	case GA_ROOTOWNER2:	// æ‰€æœ‰é–¢ä¿‚ã‚’GetWindow()ã§é¡ã£ã¦æ‰€æœ‰ã•ã‚Œã¦ã„ãªã„ãƒˆãƒƒãƒ—ãƒ¬ãƒ™ãƒ«ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¿”ã™
 		hwndWk = hWnd;
 		do{
 			hwndAncestor = hwndWk;
@@ -71,16 +71,16 @@ HWND MyGetAncestor( HWND hWnd, UINT gaFlags )
 
 
 /*!
-	ˆ—’†‚Ìƒ†[ƒU[‘€ì‚ğ‰Â”\‚É‚·‚é
-	ƒuƒƒbƒLƒ“ƒOƒtƒbƒN(?)iƒƒbƒZ[ƒW”z‘—
+	å‡¦ç†ä¸­ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼æ“ä½œã‚’å¯èƒ½ã«ã™ã‚‹
+	ãƒ–ãƒ­ãƒƒã‚­ãƒ³ã‚°ãƒ•ãƒƒã‚¯(?)ï¼ˆãƒ¡ãƒƒã‚»ãƒ¼ã‚¸é…é€
 
-	@date 2003.07.04 genta ˆê‰ñ‚ÌŒÄ‚Ño‚µ‚Å•¡”ƒƒbƒZ[ƒW‚ğˆ—‚·‚é‚æ‚¤‚É
+	@date 2003.07.04 genta ä¸€å›ã®å‘¼ã³å‡ºã—ã§è¤‡æ•°ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å‡¦ç†ã™ã‚‹ã‚ˆã†ã«
 */
 BOOL BlockingHook( HWND hwndDlgCancel )
 {
 	MSG		msg;
 	BOOL	ret;
-	//	Jun. 04, 2003 genta ƒƒbƒZ[ƒW‚ğ‚ ‚é‚¾‚¯ˆ—‚·‚é‚æ‚¤‚É
+	//	Jun. 04, 2003 genta ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ã‚ã‚‹ã ã‘å‡¦ç†ã™ã‚‹ã‚ˆã†ã«
 	while(( ret = (BOOL)::PeekMessage( &msg, NULL, 0, 0, PM_REMOVE )) != 0 ){
 		if ( msg.message == WM_QUIT ){
 			return FALSE;
@@ -97,21 +97,21 @@ BOOL BlockingHook( HWND hwndDlgCancel )
 
 
 
-/** ƒtƒŒ[ƒ€ƒEƒBƒ“ƒhƒE‚ğƒAƒNƒeƒBƒu‚É‚·‚é
-	@date 2007.11.07 ryoji ‘ÎÛ‚ªdisable‚Ì‚Æ‚«‚ÍÅ‹ß‚Ìƒ|ƒbƒvƒAƒbƒv‚ğƒtƒHƒAƒOƒ‰ƒEƒ“ƒh‰»‚·‚éD
-		iƒ‚[ƒ_ƒ‹ƒ_ƒCƒAƒƒO‚âƒƒbƒZ[ƒWƒ{ƒbƒNƒX‚ğ•\¦‚µ‚Ä‚¢‚é‚æ‚¤‚È‚Æ‚«j
+/** ãƒ•ãƒ¬ãƒ¼ãƒ ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹
+	@date 2007.11.07 ryoji å¯¾è±¡ãŒdisableã®ã¨ãã¯æœ€è¿‘ã®ãƒãƒƒãƒ—ã‚¢ãƒƒãƒ—ã‚’ãƒ•ã‚©ã‚¢ã‚°ãƒ©ã‚¦ãƒ³ãƒ‰åŒ–ã™ã‚‹ï¼
+		ï¼ˆãƒ¢ãƒ¼ãƒ€ãƒ«ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚„ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã‚’è¡¨ç¤ºã—ã¦ã„ã‚‹ã‚ˆã†ãªã¨ãï¼‰
 */
 void ActivateFrameWindow( HWND hwnd )
 {
-	// •ÒWƒEƒBƒ“ƒhƒE‚Åƒ^ƒu‚Ü‚Æ‚ß•\¦‚Ìê‡‚Í•\¦ˆÊ’u‚ğ•œŒ³‚·‚é
+	// ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã§ã‚¿ãƒ–ã¾ã¨ã‚è¡¨ç¤ºã®å ´åˆã¯è¡¨ç¤ºä½ç½®ã‚’å¾©å…ƒã™ã‚‹
 	DLLSHAREDATA* pShareData = &GetDllShareData();
 	if( pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin ) {
 		if( IsSakuraMainWindow( hwnd ) ){
 			if( pShareData->m_sFlags.m_bEditWndChanging )
-				return;	// Ø‘Ö‚ÌÅ’†(busy)‚Í—v‹‚ğ–³‹‚·‚é
-			pShareData->m_sFlags.m_bEditWndChanging = TRUE;	// •ÒWƒEƒBƒ“ƒhƒEØ‘Ö’†ON	2007.04.03 ryoji
+				return;	// åˆ‡æ›¿ã®æœ€ä¸­(busy)ã¯è¦æ±‚ã‚’ç„¡è¦–ã™ã‚‹
+			pShareData->m_sFlags.m_bEditWndChanging = TRUE;	// ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ‡æ›¿ä¸­ON	2007.04.03 ryoji
 
-			// ‘ÎÛƒEƒBƒ“ƒhƒE‚ÌƒXƒŒƒbƒh‚ÉˆÊ’u‡‚í‚¹‚ğˆË—Š‚·‚é	// 2007.04.03 ryoji
+			// å¯¾è±¡ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã‚¹ãƒ¬ãƒƒãƒ‰ã«ä½ç½®åˆã‚ã›ã‚’ä¾é ¼ã™ã‚‹	// 2007.04.03 ryoji
 			DWORD_PTR dwResult;
 			::SendMessageTimeout(
 				hwnd,
@@ -125,7 +125,7 @@ void ActivateFrameWindow( HWND hwnd )
 		}
 	}
 
-	// ‘ÎÛ‚ªdisable‚Ì‚Æ‚«‚ÍÅ‹ß‚Ìƒ|ƒbƒvƒAƒbƒv‚ğƒtƒHƒAƒOƒ‰ƒEƒ“ƒh‰»‚·‚é
+	// å¯¾è±¡ãŒdisableã®ã¨ãã¯æœ€è¿‘ã®ãƒãƒƒãƒ—ã‚¢ãƒƒãƒ—ã‚’ãƒ•ã‚©ã‚¢ã‚°ãƒ©ã‚¦ãƒ³ãƒ‰åŒ–ã™ã‚‹
 	HWND hwndActivate;
 	hwndActivate = ::IsWindowEnabled( hwnd )? hwnd: ::GetLastActivePopup( hwnd );
 	if( ::IsIconic( hwnd ) ){
@@ -141,7 +141,7 @@ void ActivateFrameWindow( HWND hwnd )
 	::BringWindowToTop( hwndActivate );
 
 	if( pShareData )
-		pShareData->m_sFlags.m_bEditWndChanging = FALSE;	// •ÒWƒEƒBƒ“ƒhƒEØ‘Ö’†OFF	2007.04.03 ryoji
+		pShareData->m_sFlags.m_bEditWndChanging = FALSE;	// ç·¨é›†ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ‡æ›¿ä¸­OFF	2007.04.03 ryoji
 
 	return;
 }
@@ -291,7 +291,7 @@ void CFontAutoDeleter::SetFont( HFONT hfontOld, HFONT hfont, HWND hwnd )
 	m_hwnd = hwnd;
 }
 
-/*! ƒEƒBƒ“ƒhƒE‚ÌƒŠƒŠ[ƒX(WM_DESTROY—p)
+/*! ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒªãƒªãƒ¼ã‚¹(WM_DESTROYç”¨)
 */
 void CFontAutoDeleter::ReleaseOnDestroy()
 {
@@ -302,7 +302,7 @@ void CFontAutoDeleter::ReleaseOnDestroy()
 	m_hFontOld = NULL;
 }
 
-/*! ƒEƒBƒ“ƒhƒE¶‘¶’†‚ÌƒŠƒŠ[ƒX
+/*! ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç”Ÿå­˜ä¸­ã®ãƒªãƒªãƒ¼ã‚¹
 */
 #if 0
 void CFontAutoDeleter::Release()

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,10 +25,10 @@
 #define SAKURA_WINDOW_E7B899CD_2106_4A3B_BBA1_EB29FD9640F39_H_
 
 /*!
-	@brief ‰æ–Ê DPI ƒXƒP[ƒŠƒ“ƒO
-	@note 96 DPI ƒsƒNƒZƒ‹‚ğ‘z’è‚µ‚Ä‚¢‚éƒfƒUƒCƒ“‚ğ‚Ç‚ê‚¾‚¯ƒXƒP[ƒŠƒ“ƒO‚·‚é‚©
+	@brief ç”»é¢ DPI ã‚¹ã‚±ãƒ¼ãƒªãƒ³ã‚°
+	@note 96 DPI ãƒ”ã‚¯ã‚»ãƒ«ã‚’æƒ³å®šã—ã¦ã„ã‚‹ãƒ‡ã‚¶ã‚¤ãƒ³ã‚’ã©ã‚Œã ã‘ã‚¹ã‚±ãƒ¼ãƒªãƒ³ã‚°ã™ã‚‹ã‹
 
-	@date 2009.10.01 ryoji ‚DPI‘Î‰—p‚Éì¬
+	@date 2009.10.01 ryoji é«˜DPIå¯¾å¿œç”¨ã«ä½œæˆ
 */
 class CDPI{
 	static void Init()
@@ -64,8 +64,8 @@ public:
 		lprc->top = UnscaleY(lprc->top);
 		lprc->bottom = UnscaleY(lprc->bottom);
 	}
-	static int PointsToPixels(int pt, int ptMag = 1){Init(); return ::MulDiv(pt, nDpiY, 72 * ptMag);}	// ptMag: ˆø”‚Ìƒ|ƒCƒ“ƒg”‚É‚©‚©‚Á‚Ä‚¢‚é”{—¦
-	static int PixelsToPoints(int px, int ptMag = 1){Init(); return ::MulDiv(px * ptMag, 72, nDpiY);}	// ptMag: –ß‚è’l‚Ìƒ|ƒCƒ“ƒg”‚É‚©‚¯‚é”{—¦
+	static int PointsToPixels(int pt, int ptMag = 1){Init(); return ::MulDiv(pt, nDpiY, 72 * ptMag);}	// ptMag: å¼•æ•°ã®ãƒã‚¤ãƒ³ãƒˆæ•°ã«ã‹ã‹ã£ã¦ã„ã‚‹å€ç‡
+	static int PixelsToPoints(int px, int ptMag = 1){Init(); return ::MulDiv(px * ptMag, 72, nDpiY);}	// ptMag: æˆ»ã‚Šå€¤ã®ãƒã‚¤ãƒ³ãƒˆæ•°ã«ã‹ã‘ã‚‹å€ç‡
 };
 
 inline int DpiScaleX(int x){return CDPI::ScaleX(x);}
@@ -77,11 +77,11 @@ inline void DpiUnscaleRect(LPRECT lprc){CDPI::UnscaleRect(lprc);}
 inline int DpiPointsToPixels(int pt, int ptMag = 1){return CDPI::PointsToPixels(pt, ptMag);}
 inline int DpiPixelsToPoints(int px, int ptMag = 1){return CDPI::PixelsToPoints(px, ptMag);}
 
-void ActivateFrameWindow( HWND );	/* ƒAƒNƒeƒBƒu‚É‚·‚é */
+void ActivateFrameWindow( HWND );	/* ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹ */
 
 /*
-||	ˆ—’†‚Ìƒ†[ƒU[‘€ì‚ğ‰Â”\‚É‚·‚é
-||	ƒuƒƒbƒLƒ“ƒOƒtƒbƒN(?)(ƒƒbƒZ[ƒW”z‘—)
+||	å‡¦ç†ä¸­ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼æ“ä½œã‚’å¯èƒ½ã«ã™ã‚‹
+||	ãƒ–ãƒ­ãƒƒã‚­ãƒ³ã‚°ãƒ•ãƒƒã‚¯(?)(ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸é…é€)
 */
 BOOL BlockingHook( HWND hwndDlgCancel );
 
@@ -94,10 +94,10 @@ BOOL BlockingHook( HWND hwndDlgCancel );
 #define GA_ROOTOWNER2	100
 
 
-HWND MyGetAncestor( HWND hWnd, UINT gaFlags );	// w’è‚µ‚½ƒEƒBƒ“ƒhƒE‚Ì‘cæ‚Ìƒnƒ“ƒhƒ‹‚ğæ“¾‚·‚é	// 2007.07.01 ryoji
+HWND MyGetAncestor( HWND hWnd, UINT gaFlags );	// æŒ‡å®šã—ãŸã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ç¥–å…ˆã®ãƒãƒ³ãƒ‰ãƒ«ã‚’å–å¾—ã™ã‚‹	// 2007.07.01 ryoji
 
 
-//ƒ`ƒFƒbƒNƒ{ƒbƒNƒX
+//ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹
 inline void CheckDlgButtonBool(HWND hDlg, int nIDButton, bool bCheck)
 {
 	CheckDlgButton(hDlg,nIDButton,bCheck?BST_CHECKED:BST_UNCHECKED);
@@ -107,14 +107,14 @@ inline bool IsDlgButtonCheckedBool(HWND hDlg, int nIDButton)
 	return (IsDlgButtonChecked(hDlg,nIDButton) & BST_CHECKED) != 0;
 }
 
-//ƒ_ƒCƒAƒƒOƒAƒCƒeƒ€‚Ì—LŒø‰»
+//ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚¢ã‚¤ãƒ†ãƒ ã®æœ‰åŠ¹åŒ–
 inline bool DlgItem_Enable(HWND hwndDlg, int nIDDlgItem, bool nEnable)
 {
 	return FALSE != ::EnableWindow( ::GetDlgItem(hwndDlg, nIDDlgItem), nEnable?TRUE:FALSE);
 }
 
-// •ŒvZ•â•ƒNƒ‰ƒX
-// Å‘å‚Ì•‚ğ•ñ‚µ‚Ü‚·
+// å¹…è¨ˆç®—è£œåŠ©ã‚¯ãƒ©ã‚¹
+// æœ€å¤§ã®å¹…ã‚’å ±å‘Šã—ã¾ã™
 class CTextWidthCalc
 {
 public:
@@ -134,16 +134,16 @@ public:
 	int GetTextHeight() const;
 	HDC GetDC() const{ return hDC; }
 	int GetCx(){ return nCx; }
-	// Zo•û–@‚ª‚æ‚­•ª‚©‚ç‚È‚¢‚Ì‚Å’è”‚É‚µ‚Ä‚¨‚­
-	// §Œä•s—v‚È‚ç ListView‚ÍLVSCW_AUTOSIZE“™„§
+	// ç®—å‡ºæ–¹æ³•ãŒã‚ˆãåˆ†ã‹ã‚‰ãªã„ã®ã§å®šæ•°ã«ã—ã¦ãŠã
+	// åˆ¶å¾¡ä¸è¦ãªã‚‰ ListViewã¯LVSCW_AUTOSIZEç­‰æ¨å¥¨
 	enum StaticMagicNambers{
-		//! ƒXƒNƒ[ƒ‹ƒo[‚ÆƒAƒCƒeƒ€‚ÌŠÔ‚ÌŒ„ŠÔ
+		//! ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã¨ã‚¢ã‚¤ãƒ†ãƒ ã®é–“ã®éš™é–“
 		WIDTH_MARGIN_SCROLLBER = 8,
-		//! ƒŠƒXƒgƒrƒ…[ƒwƒbƒ_ ƒ}[ƒWƒ“
+		//! ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ãƒ˜ãƒƒãƒ€ ãƒãƒ¼ã‚¸ãƒ³
 		WIDTH_LV_HEADER = 17,
-		//! ƒŠƒXƒgƒrƒ…[‚Ìƒ}[ƒWƒ“
+		//! ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®ãƒãƒ¼ã‚¸ãƒ³
 		WIDTH_LV_ITEM_NORMAL  = 14,
-		//! ƒŠƒXƒgƒrƒ…[‚Ìƒ`ƒFƒbƒNƒ{ƒbƒNƒX‚Æƒ}[ƒWƒ“‚Ì•
+		//! ãƒªã‚¹ãƒˆãƒ“ãƒ¥ãƒ¼ã®ãƒã‚§ãƒƒã‚¯ãƒœãƒƒã‚¯ã‚¹ã¨ãƒãƒ¼ã‚¸ãƒ³ã®å¹…
 		WIDTH_LV_ITEM_CHECKBOX = 30,
 	};
 private:


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/util
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。

主に動作影響について対応前後で挙動に変化がないことのご確認をいただけると助かります。
