### PR TITLE
view 配下のファイルを UTF-8 (BOM付) に変換

### DIFF
--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief ƒLƒƒƒŒƒbƒg‚ÌŠÇ—
+ï»¿/*!	@file
+	@brief ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ç®¡ç†
 
 	@author	kobake
 */
@@ -56,7 +56,7 @@ using namespace std;
 #define SCROLLMARGIN_NOMOVE 4
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ŠO•”ˆË‘¶                            //
+//                         å¤–éƒ¨ä¾å­˜                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
@@ -80,17 +80,17 @@ inline int CCaret::GetHankakuDy() const
 //                      CCaretUnderLine                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/* ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌON */
+/* ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®ON */
 void CCaretUnderLine::CaretUnderLineON( bool bDraw, bool bPaintDraw )
 {
-	if( m_nLockCounter ) return;	//	ƒƒbƒN‚³‚ê‚Ä‚¢‚½‚ç‰½‚à‚Å‚«‚È‚¢B
+	if( m_nLockCounter ) return;	//	ãƒ­ãƒƒã‚¯ã•ã‚Œã¦ã„ãŸã‚‰ä½•ã‚‚ã§ããªã„ã€‚
 	m_pcEditView->CaretUnderLineON( bDraw, bPaintDraw, m_nUnderLineLockCounter != 0 );
 }
 
-/* ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌOFF */
+/* ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®OFF */
 void CCaretUnderLine::CaretUnderLineOFF( bool bDraw, bool bDrawPaint, bool bResetFlag )
 {
-	if( m_nLockCounter ) return;	//	ƒƒbƒN‚³‚ê‚Ä‚¢‚½‚ç‰½‚à‚Å‚«‚È‚¢B
+	if( m_nLockCounter ) return;	//	ãƒ­ãƒƒã‚¯ã•ã‚Œã¦ã„ãŸã‚‰ä½•ã‚‚ã§ããªã„ã€‚
 	m_pcEditView->CaretUnderLineOFF( bDraw, bDrawPaint, bResetFlag, m_nUnderLineLockCounter != 0 );
 }
 
@@ -98,73 +98,73 @@ void CCaretUnderLine::CaretUnderLineOFF( bool bDraw, bool bDrawPaint, bool bRese
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//               ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^                  //
+//               ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿                  //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CCaret::CCaret(CEditView* pEditView, const CEditDoc* pEditDoc)
 : m_pEditView(pEditView)
 , m_pEditDoc(pEditDoc)
 , m_ptCaretPos_Layout(0,0)
-, m_ptCaretPos_Logic(0,0)			// ƒJ[ƒ\ƒ‹ˆÊ’u (‰üs’PˆÊsæ“ª‚©‚ç‚ÌƒoƒCƒg”(0ŠJn), ‰üs’PˆÊs‚Ìs”Ô†(0ŠJn))
-, m_sizeCaret(0,0)				// ƒLƒƒƒŒƒbƒg‚ÌƒTƒCƒY
+, m_ptCaretPos_Logic(0,0)			// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½® (æ”¹è¡Œå˜ä½è¡Œå…ˆé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°(0é–‹å§‹), æ”¹è¡Œå˜ä½è¡Œã®è¡Œç•ªå·(0é–‹å§‹))
+, m_sizeCaret(0,0)				// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ã‚µã‚¤ã‚º
 , m_cUnderLine(pEditView)
 {
-	m_nCaretPosX_Prev = CLayoutInt(0);		/* ƒrƒ…[¶’[‚©‚ç‚ÌƒJ[ƒ\ƒ‹Œ…’¼‘O‚ÌˆÊ’u(‚OƒIƒŠƒWƒ“) */
+	m_nCaretPosX_Prev = CLayoutInt(0);		/* ãƒ“ãƒ¥ãƒ¼å·¦ç«¯ã‹ã‚‰ã®ã‚«ãƒ¼ã‚½ãƒ«æ¡ç›´å‰ã®ä½ç½®(ï¼ã‚ªãƒªã‚¸ãƒ³) */
 
-	m_crCaret = -1;				/* ƒLƒƒƒŒƒbƒg‚ÌF */			// 2006.12.16 ryoji
-	m_hbmpCaret = NULL;			/* ƒLƒƒƒŒƒbƒg—pƒrƒbƒgƒ}ƒbƒv */	// 2006.11.28 ryoji
+	m_crCaret = -1;				/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è‰² */			// 2006.12.16 ryoji
+	m_hbmpCaret = NULL;			/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆç”¨ãƒ“ãƒƒãƒˆãƒãƒƒãƒ— */	// 2006.11.28 ryoji
 	m_bClearStatus = true;
 	ClearCaretPosInfoCache();
 }
 
 CCaret::~CCaret()
 {
-	// ƒLƒƒƒŒƒbƒg—pƒrƒbƒgƒ}ƒbƒv	// 2006.11.28 ryoji
+	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆç”¨ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—	// 2006.11.28 ryoji
 	if( m_hbmpCaret != NULL )
 		DeleteObject( m_hbmpCaret );
 }
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒCƒ“ƒ^[ƒtƒF[ƒX                        //
+//                     ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*!	@brief sŒ…w’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“®
+/*!	@brief è¡Œæ¡æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•
 
-	•K—v‚É‰‚¶‚Äc/‰¡ƒXƒNƒ[ƒ‹‚à‚·‚éD
-	‚’¼ƒXƒNƒ[ƒ‹‚ğ‚µ‚½ê‡‚Í‚»‚Ìs”‚ğ•Ô‚·i³^•‰jD
+	å¿…è¦ã«å¿œã˜ã¦ç¸¦/æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚‚ã™ã‚‹ï¼
+	å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚’ã—ãŸå ´åˆã¯ãã®è¡Œæ•°ã‚’è¿”ã™ï¼ˆæ­£ï¼è² ï¼‰ï¼
 	
-	@return cƒXƒNƒ[ƒ‹s”(•‰:ãƒXƒNƒ[ƒ‹/³:‰ºƒXƒNƒ[ƒ‹)
+	@return ç¸¦ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•°(è² :ä¸Šã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«/æ­£:ä¸‹ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«)
 
-	@note •s³‚ÈˆÊ’u‚ªw’è‚³‚ê‚½ê‡‚É‚Í“KØ‚ÈÀ•W’l‚É
-		ˆÚ“®‚·‚é‚½‚ßCˆø”‚Å—^‚¦‚½À•W‚ÆˆÚ“®Œã‚ÌÀ•W‚Í
-		•K‚¸‚µ‚àˆê’v‚µ‚È‚¢D
+	@note ä¸æ­£ãªä½ç½®ãŒæŒ‡å®šã•ã‚ŒãŸå ´åˆã«ã¯é©åˆ‡ãªåº§æ¨™å€¤ã«
+		ç§»å‹•ã™ã‚‹ãŸã‚ï¼Œå¼•æ•°ã§ä¸ãˆãŸåº§æ¨™ã¨ç§»å‹•å¾Œã®åº§æ¨™ã¯
+		å¿…ãšã—ã‚‚ä¸€è‡´ã—ãªã„ï¼
 	
-	@note bScroll‚ªfalse‚Ìê‡‚É‚ÍƒJ[ƒ\ƒ‹ˆÊ’u‚Ì‚İˆÚ“®‚·‚éD
-		true‚Ìê‡‚É‚ÍƒXƒNƒ[ƒ‹ˆÊ’u‚ª‚ ‚í‚¹‚Ä•ÏX‚³‚ê‚é
+	@note bScrollãŒfalseã®å ´åˆã«ã¯ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®ã¿ç§»å‹•ã™ã‚‹ï¼
+		trueã®å ´åˆã«ã¯ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ä½ç½®ãŒã‚ã‚ã›ã¦å¤‰æ›´ã•ã‚Œã‚‹
 
-	@note “¯‚¶s‚Ì¶‰EˆÚ“®‚ÍƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ğˆê“xÁ‚·•K—v‚ª–³‚¢‚Ì‚Å
-		bUnderlineDoNotOFF‚ğw’è‚·‚é‚Æ‚‘¬‰»‚Å‚«‚é.
-		“¯—l‚É“¯‚¶Œ…‚Ìã‰ºˆÚ“®‚ÍbVertLineDoNotOFF‚ğw’è‚·‚é‚Æ
-		ƒJ[ƒ\ƒ‹ˆÊ’ucü‚ÌÁ‹‚ğÈ‚¢‚Ä‚‘¬‰»‚Å‚«‚é.
+	@note åŒã˜è¡Œã®å·¦å³ç§»å‹•ã¯ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã‚’ä¸€åº¦æ¶ˆã™å¿…è¦ãŒç„¡ã„ã®ã§
+		bUnderlineDoNotOFFã‚’æŒ‡å®šã™ã‚‹ã¨é«˜é€ŸåŒ–ã§ãã‚‹.
+		åŒæ§˜ã«åŒã˜æ¡ã®ä¸Šä¸‹ç§»å‹•ã¯bVertLineDoNotOFFã‚’æŒ‡å®šã™ã‚‹ã¨
+		ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·šã®æ¶ˆå»ã‚’çœã„ã¦é«˜é€ŸåŒ–ã§ãã‚‹.
 
-	@date 2001.10.20 deleted by novice AdjustScrollBar()‚ğŒÄ‚ÔˆÊ’u‚ğ•ÏX
-	@date 2004.04.02 Moca s‚¾‚¯—LŒø‚ÈÀ•W‚ÉC³‚·‚é‚Ì‚ğŒµ–§‚Éˆ—‚·‚é
-	@date 2004.09.11 genta bDrawƒXƒCƒbƒ`‚Í“®ì‚Æ–¼Ì‚ªˆê’v‚µ‚Ä‚¢‚È‚¢‚Ì‚Å
-		Ä•`‰æƒXƒCƒbƒ`¨‰æ–ÊˆÊ’u’²®ƒXƒCƒbƒ`‚Æ–¼Ì•ÏX
-	@date 2009.08.28 nasukoji	ƒeƒLƒXƒgÜ‚è•Ô‚µ‚ÌuÜ‚è•Ô‚³‚È‚¢v‘Î‰
-	@date 2010.11.27 syat ƒAƒ“ƒ_[ƒ‰ƒCƒ“Acü‚ğÁ‹‚µ‚È‚¢ƒtƒ‰ƒO‚ğ’Ç‰Á
+	@date 2001.10.20 deleted by novice AdjustScrollBar()ã‚’å‘¼ã¶ä½ç½®ã‚’å¤‰æ›´
+	@date 2004.04.02 Moca è¡Œã ã‘æœ‰åŠ¹ãªåº§æ¨™ã«ä¿®æ­£ã™ã‚‹ã®ã‚’å³å¯†ã«å‡¦ç†ã™ã‚‹
+	@date 2004.09.11 genta bDrawã‚¹ã‚¤ãƒƒãƒã¯å‹•ä½œã¨åç§°ãŒä¸€è‡´ã—ã¦ã„ãªã„ã®ã§
+		å†æç”»ã‚¹ã‚¤ãƒƒãƒâ†’ç”»é¢ä½ç½®èª¿æ•´ã‚¹ã‚¤ãƒƒãƒã¨åç§°å¤‰æ›´
+	@date 2009.08.28 nasukoji	ãƒ†ã‚­ã‚¹ãƒˆæŠ˜ã‚Šè¿”ã—ã®ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€å¯¾å¿œ
+	@date 2010.11.27 syat ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã€ç¸¦ç·šã‚’æ¶ˆå»ã—ãªã„ãƒ•ãƒ©ã‚°ã‚’è¿½åŠ 
 */
 CLayoutInt CCaret::MoveCursor(
-	CLayoutPoint	ptWk_CaretPos,		//!< [in] ˆÚ“®æƒŒƒCƒAƒEƒgˆÊ’u
-	bool			bScroll,			//!< [in] true: ‰æ–ÊˆÊ’u’²®—L‚è  false: ‰æ–ÊˆÊ’u’²®–³‚µ
-	int				nCaretMarginRate,	//!< [in] cƒXƒNƒ[ƒ‹ŠJnˆÊ’u‚ğŒˆ‚ß‚é’l
-	bool			bUnderLineDoNotOFF,	//!< [in] ƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ğÁ‹‚µ‚È‚¢
-	bool			bVertLineDoNotOFF	//!< [in] ƒJ[ƒ\ƒ‹ˆÊ’ucü‚ğÁ‹‚µ‚È‚¢
+	CLayoutPoint	ptWk_CaretPos,		//!< [in] ç§»å‹•å…ˆãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®
+	bool			bScroll,			//!< [in] true: ç”»é¢ä½ç½®èª¿æ•´æœ‰ã‚Š  false: ç”»é¢ä½ç½®èª¿æ•´ç„¡ã—
+	int				nCaretMarginRate,	//!< [in] ç¸¦ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é–‹å§‹ä½ç½®ã‚’æ±ºã‚ã‚‹å€¤
+	bool			bUnderLineDoNotOFF,	//!< [in] ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã‚’æ¶ˆå»ã—ãªã„
+	bool			bVertLineDoNotOFF	//!< [in] ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·šã‚’æ¶ˆå»ã—ãªã„
 )
 {
 	CTextArea& area = m_pEditView->GetTextArea();
-	// ƒXƒNƒ[ƒ‹ˆ—
+	// ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å‡¦ç†
 	CLayoutInt	nScrollRowNum = CLayoutInt(0);
 	CLayoutInt	nScrollColNum = CLayoutInt(0);
 	int		nCaretMarginY;
@@ -175,7 +175,7 @@ CLayoutInt CCaret::MoveCursor(
 		return CLayoutInt(0);
 	}
 
-	if( m_pEditView->GetSelectionInfo().IsMouseSelecting() ){	// ”ÍˆÍ‘I‘ğ’†
+	if( m_pEditView->GetSelectionInfo().IsMouseSelecting() ){	// ç¯„å›²é¸æŠä¸­
 		nCaretMarginY = 0;
 	}
 	else{
@@ -185,17 +185,17 @@ CLayoutInt CCaret::MoveCursor(
 			nCaretMarginY = 1;
 		}
 	}
-	// 2004.04.02 Moca s‚¾‚¯—LŒø‚ÈÀ•W‚ÉC³‚·‚é‚Ì‚ğŒµ–§‚Éˆ—‚·‚é
+	// 2004.04.02 Moca è¡Œã ã‘æœ‰åŠ¹ãªåº§æ¨™ã«ä¿®æ­£ã™ã‚‹ã®ã‚’å³å¯†ã«å‡¦ç†ã™ã‚‹
 	GetAdjustCursorPos( &ptWk_CaretPos );
 	m_pEditDoc->m_cLayoutMgr.LayoutToLogic(
 		ptWk_CaretPos,
-		&m_ptCaretPos_Logic	//ƒJ[ƒ\ƒ‹ˆÊ’uBƒƒWƒbƒN’PˆÊB
+		&m_ptCaretPos_Logic	//ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã€‚ãƒ­ã‚¸ãƒƒã‚¯å˜ä½ã€‚
 	);
-	/* ƒLƒƒƒŒƒbƒgˆÚ“® */
+	/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆç§»å‹• */
 	SetCaretLayoutPos(ptWk_CaretPos);
 
 
-	// ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌOFF
+	// ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®OFF
 	bool bDrawPaint = ptWk_CaretPos.GetY2() != m_pEditView->m_nOldUnderLineYBg;
 	m_cUnderLine.SetUnderLineDoNotOFF( bUnderLineDoNotOFF );
 	m_cUnderLine.SetVertLineDoNotOFF( bVertLineDoNotOFF );
@@ -203,23 +203,23 @@ CLayoutInt CCaret::MoveCursor(
 	m_cUnderLine.SetUnderLineDoNotOFF( false );
 	m_cUnderLine.SetVertLineDoNotOFF( false );
 	
-	// …•½ƒXƒNƒ[ƒ‹—Êi•¶š”j‚ÌZo
+	// æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é‡ï¼ˆæ–‡å­—æ•°ï¼‰ã®ç®—å‡º
 	nScrollColNum = CLayoutInt(0);
 	nScrollMarginRight = m_pEditView->GetTextMetrics().GetLayoutXDefault(CKetaXInt(SCROLLMARGIN_RIGHT));
 	nScrollMarginLeft = m_pEditView->GetTextMetrics().GetLayoutXDefault(CKetaXInt(SCROLLMARGIN_LEFT));
 
-	// 2010.08.24 Moca •‚ª‹·‚¢ê‡‚Ìƒ}[ƒWƒ“‚Ì’²®
+	// 2010.08.24 Moca å¹…ãŒç‹­ã„å ´åˆã®ãƒãƒ¼ã‚¸ãƒ³ã®èª¿æ•´
 	{
-		// ƒJ[ƒ\ƒ‹‚ª^‚ñ’†‚É‚ ‚é‚Æ‚«‚É¶‰E‚É‚Ô‚ê‚È‚¢‚æ‚¤‚É
+		// ã‚«ãƒ¼ã‚½ãƒ«ãŒçœŸã‚“ä¸­ã«ã‚ã‚‹ã¨ãã«å·¦å³ã«ã¶ã‚Œãªã„ã‚ˆã†ã«
 		CLayoutInt nNoMove = m_pEditView->GetTextMetrics().GetLayoutXDefault(CKetaXInt(SCROLLMARGIN_NOMOVE));
 		CLayoutInt Keta2Width = m_pEditView->GetTextMetrics().GetLayoutXDefault(CKetaXInt(2));
 		CLayoutInt a = ((m_pEditView->GetTextArea().m_nViewColNum) - nNoMove) / 2;
-		CLayoutInt nMin = (Keta2Width <= a ? a : CLayoutInt(0)); // 1‚¾‚Æ‘SŠpˆÚ“®‚Éxá‚ª‚ ‚é‚Ì‚Å2ˆÈã
+		CLayoutInt nMin = (Keta2Width <= a ? a : CLayoutInt(0)); // 1ã ã¨å…¨è§’ç§»å‹•ã«æ”¯éšœãŒã‚ã‚‹ã®ã§2ä»¥ä¸Š
 		nScrollMarginRight = t_min(nScrollMarginRight, nMin);
 		nScrollMarginLeft  = t_min(nScrollMarginLeft,  nMin);
 	}
 	
-	//	Aug. 14, 2005 genta Ü‚è•Ô‚µ•‚ğLayoutMgr‚©‚çæ“¾‚·‚é‚æ‚¤‚É
+	//	Aug. 14, 2005 genta æŠ˜ã‚Šè¿”ã—å¹…ã‚’LayoutMgrã‹ã‚‰å–å¾—ã™ã‚‹ã‚ˆã†ã«
 	if( m_pEditDoc->m_cLayoutMgr.GetMaxLineLayout() > area.m_nViewColNum &&
 		ptWk_CaretPos.GetX() >area.GetViewLeftCol() + area.m_nViewColNum - nScrollMarginRight ){
 		nScrollColNum =
@@ -235,57 +235,57 @@ CLayoutInt CCaret::MoveCursor(
 
 	}
 
-	// 2013.12.30 bScroll‚ªOFF‚Ì‚Æ‚«‚Í‰¡ƒXƒNƒ[ƒ‹‚µ‚È‚¢
+	// 2013.12.30 bScrollãŒOFFã®ã¨ãã¯æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ãªã„
 	if( bScroll ){
 		m_pEditView->GetTextArea().SetViewLeftCol(m_pEditView->GetTextArea().GetViewLeftCol() - nScrollColNum);
 	}else{
 		nScrollColNum = 0;
 	}
 
-	//	From Here 2007.07.28 ‚¶‚ã‚¤‚¶ : •\¦s”‚ª3sˆÈ‰º‚Ìê‡‚Ì“®ì‰ü‘P
-	/* ‚’¼ƒXƒNƒ[ƒ‹—Êis”j‚ÌZo */
-										// ‰æ–Ê‚ª‚RsˆÈ‰º
+	//	From Here 2007.07.28 ã˜ã‚…ã†ã˜ : è¡¨ç¤ºè¡Œæ•°ãŒ3è¡Œä»¥ä¸‹ã®å ´åˆã®å‹•ä½œæ”¹å–„
+	/* å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é‡ï¼ˆè¡Œæ•°ï¼‰ã®ç®—å‡º */
+										// ç”»é¢ãŒï¼“è¡Œä»¥ä¸‹
 	if( m_pEditView->GetTextArea().m_nViewRowNum <= 3 ){
-							// ˆÚ“®æ‚ÍA‰æ–Ê‚ÌƒXƒNƒ[ƒ‹ƒ‰ƒCƒ“‚æ‚èã‚©Hiup ƒL[j
+							// ç§»å‹•å…ˆã¯ã€ç”»é¢ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ©ã‚¤ãƒ³ã‚ˆã‚Šä¸Šã‹ï¼Ÿï¼ˆup ã‚­ãƒ¼ï¼‰
 		if( ptWk_CaretPos.y - m_pEditView->GetTextArea().GetViewTopLine() < nCaretMarginY ){
-			if( ptWk_CaretPos.y < nCaretMarginY ){	//‚Ps–Ú‚ÉˆÚ“®
+			if( ptWk_CaretPos.y < nCaretMarginY ){	//ï¼‘è¡Œç›®ã«ç§»å‹•
 				nScrollRowNum = m_pEditView->GetTextArea().GetViewTopLine();
 			}
-			else if( m_pEditView->GetTextArea().m_nViewRowNum <= 1 ){	// ‰æ–Ê‚ª‚Ps
+			else if( m_pEditView->GetTextArea().m_nViewRowNum <= 1 ){	// ç”»é¢ãŒï¼‘è¡Œ
 				nScrollRowNum = m_pEditView->GetTextArea().GetViewTopLine() - ptWk_CaretPos.y;
 			}
-#if !(0)	// COMMENT‚É‚·‚é‚ÆAã‰º‚Ì‹ó‚«‚ğ€ç‚µ‚È‚¢ˆ×AcˆÚ“®‚Ígood‚¾‚ªA‰¡ˆÚ“®‚Ìê‡ã‰º‚É‚Ô‚ê‚é
-			else if( m_pEditView->GetTextArea().m_nViewRowNum <= 2 ){	// ‰æ–Ê‚ª‚Qs
+#if !(0)	// COMMENTã«ã™ã‚‹ã¨ã€ä¸Šä¸‹ã®ç©ºãã‚’æ­»å®ˆã—ãªã„ç‚ºã€ç¸¦ç§»å‹•ã¯goodã ãŒã€æ¨ªç§»å‹•ã®å ´åˆä¸Šä¸‹ã«ã¶ã‚Œã‚‹
+			else if( m_pEditView->GetTextArea().m_nViewRowNum <= 2 ){	// ç”»é¢ãŒï¼’è¡Œ
 				nScrollRowNum = m_pEditView->GetTextArea().GetViewTopLine() - ptWk_CaretPos.y;
 			}
 #endif
 			else
-			{						// ‰æ–Ê‚ª‚Rs
+			{						// ç”»é¢ãŒï¼“è¡Œ
 				nScrollRowNum = m_pEditView->GetTextArea().GetViewTopLine() - ptWk_CaretPos.y + 1;
 			}
 		}else
-							// ˆÚ“®æ‚ÍA‰æ–Ê‚ÌÅ‘ås”|‚Q‚æ‚è‰º‚©Hidown ƒL[j
+							// ç§»å‹•å…ˆã¯ã€ç”»é¢ã®æœ€å¤§è¡Œæ•°ï¼ï¼’ã‚ˆã‚Šä¸‹ã‹ï¼Ÿï¼ˆdown ã‚­ãƒ¼ï¼‰
 		if( ptWk_CaretPos.y - m_pEditView->GetTextArea().GetViewTopLine() >= (m_pEditView->GetTextArea().m_nViewRowNum - nCaretMarginY - 2) ){
 			CLayoutInt ii = m_pEditDoc->m_cLayoutMgr.GetLineCount();
 			if( ii - ptWk_CaretPos.y < nCaretMarginY + 1 &&
 				ii - m_pEditView->GetTextArea().GetViewTopLine() < m_pEditView->GetTextArea().m_nViewRowNum ) {
 			}
-			else if( m_pEditView->GetTextArea().m_nViewRowNum <= 2 ){	// ‰æ–Ê‚ª‚QsA‚Ps
+			else if( m_pEditView->GetTextArea().m_nViewRowNum <= 2 ){	// ç”»é¢ãŒï¼’è¡Œã€ï¼‘è¡Œ
 				nScrollRowNum = m_pEditView->GetTextArea().GetViewTopLine() - ptWk_CaretPos.y;
-			}else{						// ‰æ–Ê‚ª‚Rs
+			}else{						// ç”»é¢ãŒï¼“è¡Œ
 				nScrollRowNum = m_pEditView->GetTextArea().GetViewTopLine() - ptWk_CaretPos.y + 1;
 			}
 		}
 	}
-	// ˆÚ“®æ‚ÍA‰æ–Ê‚ÌƒXƒNƒ[ƒ‹ƒ‰ƒCƒ“‚æ‚èã‚©Hiup ƒL[j
+	// ç§»å‹•å…ˆã¯ã€ç”»é¢ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ©ã‚¤ãƒ³ã‚ˆã‚Šä¸Šã‹ï¼Ÿï¼ˆup ã‚­ãƒ¼ï¼‰
 	else if( ptWk_CaretPos.y - m_pEditView->GetTextArea().GetViewTopLine() < nCaretMarginY ){
-		if( ptWk_CaretPos.y < nCaretMarginY ){	//‚Ps–Ú‚ÉˆÚ“®
+		if( ptWk_CaretPos.y < nCaretMarginY ){	//ï¼‘è¡Œç›®ã«ç§»å‹•
 			nScrollRowNum = m_pEditView->GetTextArea().GetViewTopLine();
 		}else{
 			nScrollRowNum = -(ptWk_CaretPos.y - m_pEditView->GetTextArea().GetViewTopLine()) + nCaretMarginY;
 		}
 	}
-	// ˆÚ“®æ‚ÍA‰æ–Ê‚ÌÅ‘ås”|‚Q‚æ‚è‰º‚©Hidown ƒL[j
+	// ç§»å‹•å…ˆã¯ã€ç”»é¢ã®æœ€å¤§è¡Œæ•°ï¼ï¼’ã‚ˆã‚Šä¸‹ã‹ï¼Ÿï¼ˆdown ã‚­ãƒ¼ï¼‰
 	else if( ptWk_CaretPos.y - m_pEditView->GetTextArea().GetViewTopLine() >= m_pEditView->GetTextArea().m_nViewRowNum - nCaretMarginY - 2 ){
 		CLayoutInt ii = m_pEditDoc->m_cLayoutMgr.GetLineCount();
 		if( ii - ptWk_CaretPos.y < nCaretMarginY + 1 &&
@@ -296,9 +296,9 @@ CLayoutInt CCaret::MoveCursor(
 				-(ptWk_CaretPos.y - m_pEditView->GetTextArea().GetViewTopLine()) + (m_pEditView->GetTextArea().m_nViewRowNum - nCaretMarginY - 2);
 		}
 	}
-	//	To Here 2007.07.28 ‚¶‚ã‚¤‚¶
+	//	To Here 2007.07.28 ã˜ã‚…ã†ã˜
 	if( bScroll ){
-		/* ƒXƒNƒ[ƒ‹ */
+		/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ« */
 		if( t_abs( nScrollColNum ) >= m_pEditView->GetTextArea().m_nViewColNum ||
 			t_abs( nScrollRowNum ) >= m_pEditView->GetTextArea().m_nViewRowNum ){
 			m_pEditView->GetTextArea().OffsetViewTopLine(-nScrollRowNum);
@@ -345,45 +345,45 @@ CLayoutInt CCaret::MoveCursor(
 			}
 		}
 
-		/* ƒXƒNƒ[ƒ‹ƒo[‚Ìó‘Ô‚ğXV‚·‚é */
+		/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®çŠ¶æ…‹ã‚’æ›´æ–°ã™ã‚‹ */
 		m_pEditView->AdjustScrollBars(); // 2001/10/20 novice
 	}
 
-	// ‰¡ƒXƒNƒ[ƒ‹‚ª”­¶‚µ‚½‚çAƒ‹[ƒ‰[‘S‘Ì‚ğÄ•`‰æ 2002.02.25 Add By KK
+	// æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãŒç™ºç”Ÿã—ãŸã‚‰ã€ãƒ«ãƒ¼ãƒ©ãƒ¼å…¨ä½“ã‚’å†æç”» 2002.02.25 Add By KK
 	if (nScrollColNum != 0 ){
-		//Ÿ‰ñDispRulerŒÄ‚Ño‚µ‚ÉÄ•`‰æBibDraw=false‚ÌƒP[ƒX‚ğl—¶‚µ‚½Bj
+		//æ¬¡å›DispRulerå‘¼ã³å‡ºã—æ™‚ã«å†æç”»ã€‚ï¼ˆbDraw=falseã®ã‚±ãƒ¼ã‚¹ã‚’è€ƒæ…®ã—ãŸã€‚ï¼‰
 		m_pEditView->GetRuler().SetRedrawFlag();
 	}
 
-	/* ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌON */
-	//CaretUnderLineON( bDraw ); //2002.02.27 Del By KK ƒAƒ“ƒ_[ƒ‰ƒCƒ“‚Ì‚¿‚ç‚Â‚«‚ğ’áŒ¸
+	/* ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®ON */
+	//CaretUnderLineON( bDraw ); //2002.02.27 Del By KK ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®ã¡ã‚‰ã¤ãã‚’ä½æ¸›
 	if( bScroll ){
-		/* ƒLƒƒƒŒƒbƒg‚Ì•\¦EXV */
+		/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤ºãƒ»æ›´æ–° */
 		ShowEditCaret();
 
-		/* ƒ‹[ƒ‰‚ÌÄ•`‰æ */
+		/* ãƒ«ãƒ¼ãƒ©ã®å†æç”» */
 		HDC		hdc = m_pEditView->GetDC();
 		m_pEditView->GetRuler().DispRuler( hdc );
 		m_pEditView->ReleaseDC( hdc );
 
-		/* ƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌÄ•`‰æ */
+		/* ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®å†æç”» */
 		m_cUnderLine.CaretUnderLineON(true, bDrawPaint);
 
-		/* ƒLƒƒƒŒƒbƒg‚ÌsŒ…ˆÊ’u‚ğ•\¦‚·‚é */
+		/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡Œæ¡ä½ç½®ã‚’è¡¨ç¤ºã™ã‚‹ */
 		ShowCaretPosInfo();
 
-		//	Sep. 11, 2004 genta “¯ŠúƒXƒNƒ[ƒ‹‚ÌŠÖ”‰»
-		//	bScroll == FALSE‚Ì‚É‚ÍƒXƒNƒ[ƒ‹‚µ‚È‚¢‚Ì‚ÅCÀs‚µ‚È‚¢
-		m_pEditView->SyncScrollV( -nScrollRowNum );	//	•ûŒü‚ª‹t‚È‚Ì‚Å•„†”½“]‚ª•K—v
-		m_pEditView->SyncScrollH( -nScrollColNum );	//	•ûŒü‚ª‹t‚È‚Ì‚Å•„†”½“]‚ª•K—v
+		//	Sep. 11, 2004 genta åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®é–¢æ•°åŒ–
+		//	bScroll == FALSEã®æ™‚ã«ã¯ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ãªã„ã®ã§ï¼Œå®Ÿè¡Œã—ãªã„
+		m_pEditView->SyncScrollV( -nScrollRowNum );	//	æ–¹å‘ãŒé€†ãªã®ã§ç¬¦å·åè»¢ãŒå¿…è¦
+		m_pEditView->SyncScrollH( -nScrollColNum );	//	æ–¹å‘ãŒé€†ãªã®ã§ç¬¦å·åè»¢ãŒå¿…è¦
 
 	}
 
-// 02/09/18 ‘ÎŠ‡ŒÊ‚Ì‹­’²•\¦ ai Start	03/02/18 ai mod S
+// 02/09/18 å¯¾æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤º ai Start	03/02/18 ai mod S
 	m_pEditView->DrawBracketPair( false );
 	m_pEditView->SetBracketPairPos( true );
 	m_pEditView->DrawBracketPair( true );
-// 02/09/18 ‘ÎŠ‡ŒÊ‚Ì‹­’²•\¦ ai End		03/02/18 ai mod E
+// 02/09/18 å¯¾æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤º ai End		03/02/18 ai mod E
 
 	return nScrollRowNum;
 
@@ -391,7 +391,7 @@ CLayoutInt CCaret::MoveCursor(
 
 
 CLayoutInt CCaret::MoveCursorFastMode(
-	const CLogicPoint&		ptWk_CaretPosLogic	//!< [in] ˆÚ“®æƒƒWƒbƒNˆÊ’u
+	const CLogicPoint&		ptWk_CaretPosLogic	//!< [in] ç§»å‹•å…ˆãƒ­ã‚¸ãƒƒã‚¯ä½ç½®
 )
 {
 	// fastMode
@@ -399,18 +399,18 @@ CLayoutInt CCaret::MoveCursorFastMode(
 	return CLayoutInt(0);
 }
 
-/* ƒ}ƒEƒX“™‚É‚æ‚éÀ•Ww’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“®
-|| •K—v‚É‰‚¶‚Äc/‰¡ƒXƒNƒ[ƒ‹‚à‚·‚é
-|| ‚’¼ƒXƒNƒ[ƒ‹‚ğ‚µ‚½ê‡‚Í‚»‚Ìs”‚ğ•Ô‚·(³^•‰)
+/* ãƒã‚¦ã‚¹ç­‰ã«ã‚ˆã‚‹åº§æ¨™æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•
+|| å¿…è¦ã«å¿œã˜ã¦ç¸¦/æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚‚ã™ã‚‹
+|| å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚’ã—ãŸå ´åˆã¯ãã®è¡Œæ•°ã‚’è¿”ã™(æ­£ï¼è² )
 */
-//2007.09.11 kobake ŠÖ”–¼•ÏX: MoveCursorToPoint¨MoveCursorToClientPoint
+//2007.09.11 kobake é–¢æ•°åå¤‰æ›´: MoveCursorToPointâ†’MoveCursorToClientPoint
 CLayoutInt CCaret::MoveCursorToClientPoint( const POINT& ptClientPos, bool test, CLayoutPoint* pCaretPosNew )
 {
 	CLayoutInt		nScrollRowNum;
 	CLayoutPoint	ptLayoutPos;
 	m_pEditView->GetTextArea().ClientToLayout(ptClientPos, &ptLayoutPos);
 
-	int dx = 0; // ©‚±‚ê‚Å‚¢‚¢‚ç‚µ‚¢
+	int dx = 0; // â†ã“ã‚Œã§ã„ã„ã‚‰ã—ã„
 
 	nScrollRowNum = MoveCursorProperly( ptLayoutPos, true, test, pCaretPosNew, 1000, dx );
 	if( !test ){
@@ -422,19 +422,19 @@ CLayoutInt CCaret::MoveCursorToClientPoint( const POINT& ptClientPos, bool test,
 
 
 
-/*! ³‚µ‚¢ƒJ[ƒ\ƒ‹ˆÊ’u‚ğZo‚·‚é(EOFˆÈ~‚Ì‚İ)
-	@param pptPosXY [in,out] ƒJ[ƒ\ƒ‹‚ÌƒŒƒCƒAƒEƒgÀ•W
-	@retval	TRUE À•W‚ğC³‚µ‚½
-	@retval	FALSE À•W‚ÍC³‚³‚ê‚È‚©‚Á‚½
-	@note	EOF‚Ì’¼‘O‚ª‰üs‚Å‚È‚¢ê‡‚ÍA‚»‚Ìs‚ÉŒÀ‚èEOFˆÈ~‚É‚àˆÚ“®‰Â”\
-			EOF‚¾‚¯‚Ìs‚ÍAæ“ªˆÊ’u‚Ì‚İ³‚µ‚¢B
-	@date 2004.04.02 Moca ŠÖ”‰»
+/*! æ­£ã—ã„ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’ç®—å‡ºã™ã‚‹(EOFä»¥é™ã®ã¿)
+	@param pptPosXY [in,out] ã‚«ãƒ¼ã‚½ãƒ«ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆåº§æ¨™
+	@retval	TRUE åº§æ¨™ã‚’ä¿®æ­£ã—ãŸ
+	@retval	FALSE åº§æ¨™ã¯ä¿®æ­£ã•ã‚Œãªã‹ã£ãŸ
+	@note	EOFã®ç›´å‰ãŒæ”¹è¡Œã§ãªã„å ´åˆã¯ã€ãã®è¡Œã«é™ã‚ŠEOFä»¥é™ã«ã‚‚ç§»å‹•å¯èƒ½
+			EOFã ã‘ã®è¡Œã¯ã€å…ˆé ­ä½ç½®ã®ã¿æ­£ã—ã„ã€‚
+	@date 2004.04.02 Moca é–¢æ•°åŒ–
 */
 BOOL CCaret::GetAdjustCursorPos(
 	CLayoutPoint* pptPosXY
 )
 {
-	// 2004.03.28 Moca EOF‚Ì‚İ‚ÌƒŒƒCƒAƒEƒgs‚ÍA0Œ…–Ú‚Ì‚İ—LŒø.EOF‚æ‚è‰º‚Ìs‚Ì‚ ‚éê‡‚ÍAEOFˆÊ’u‚É‚·‚é
+	// 2004.03.28 Moca EOFã®ã¿ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã¯ã€0æ¡ç›®ã®ã¿æœ‰åŠ¹.EOFã‚ˆã‚Šä¸‹ã®è¡Œã®ã‚ã‚‹å ´åˆã¯ã€EOFä½ç½®ã«ã™ã‚‹
 	CLayoutInt nLayoutLineCount = m_pEditDoc->m_cLayoutMgr.GetLineCount();
 
 	CLayoutPoint ptPosXY2 = *pptPosXY;
@@ -445,23 +445,23 @@ BOOL CCaret::GetAdjustCursorPos(
 			const CLayout* pcLayout = m_pEditDoc->m_cLayoutMgr.SearchLineByLayoutY( ptPosXY2.GetY2() );
 			if( pcLayout->GetLayoutEol() == EOL_NONE ){
 				ptPosXY2.x = m_pEditView->LineIndexToColumn( pcLayout, (CLogicInt)pcLayout->GetLengthWithEOL() );
-				// [EOF]‚Ì‚İÜ‚è•Ô‚·‚Ì‚Í‚â‚ß‚é	// 2009.02.17 ryoji
-				// •œŠˆ‚·‚é‚È‚ç ptPosXY2.x ‚ÉÜ‚è•Ô‚µsƒCƒ“ƒfƒ“ƒg‚ğ“K—p‚·‚é‚Ì‚ª‚æ‚¢
+				// [EOF]ã®ã¿æŠ˜ã‚Šè¿”ã™ã®ã¯ã‚„ã‚ã‚‹	// 2009.02.17 ryoji
+				// å¾©æ´»ã™ã‚‹ãªã‚‰ ptPosXY2.x ã«æŠ˜ã‚Šè¿”ã—è¡Œã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã‚’é©ç”¨ã™ã‚‹ã®ãŒã‚ˆã„
 
-				// EOF‚¾‚¯Ü‚è•Ô‚³‚ê‚Ä‚¢‚é‚©
-				//	Aug. 14, 2005 genta Ü‚è•Ô‚µ•‚ğLayoutMgr‚©‚çæ“¾‚·‚é‚æ‚¤‚É
+				// EOFã ã‘æŠ˜ã‚Šè¿”ã•ã‚Œã¦ã„ã‚‹ã‹
+				//	Aug. 14, 2005 genta æŠ˜ã‚Šè¿”ã—å¹…ã‚’LayoutMgrã‹ã‚‰å–å¾—ã™ã‚‹ã‚ˆã†ã«
 				//if( ptPosXY2.x >= m_pEditDoc->m_cLayoutMgr.GetMaxLineLayout() ){
 				//	ptPosXY2.y++;
 				//	ptPosXY2.x = CLayoutInt(0);
 				//}
 			}
 			else{
-				// EOF‚¾‚¯‚Ìs
+				// EOFã ã‘ã®è¡Œ
 				ptPosXY2.y++;
 				ptPosXY2.x = CLayoutInt(0);
 			}
 		}else{
-			// ‹ó‚Ìƒtƒ@ƒCƒ‹
+			// ç©ºã®ãƒ•ã‚¡ã‚¤ãƒ«
 			ptPosXY2.Set(CLayoutInt(0), CLayoutInt(0));
 		}
 		if( *pptPosXY != ptPosXY2 ){
@@ -472,13 +472,13 @@ BOOL CCaret::GetAdjustCursorPos(
 	return ret;
 }
 
-/* ƒLƒƒƒŒƒbƒg‚Ì•\¦EXV */
+/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤ºãƒ»æ›´æ–° */
 void CCaret::ShowEditCaret()
 {
 	if( m_pEditView->m_bMiniMap ){
 		return;
 	}
-	//•K—v‚ÈƒCƒ“ƒ^[ƒtƒF[ƒX
+	//å¿…è¦ãªã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 	const CLayoutMgr* pLayoutMgr=&m_pEditDoc->m_cLayoutMgr;
 	CommonSetting* pCommon=&GetDllShareData().m_Common;
 	const STypeConfig* pTypes=&m_pEditDoc->m_cDocType.GetDocumentAttribute();
@@ -489,27 +489,27 @@ void CCaret::ShowEditCaret()
 	int				nIdxFrom;
 
 /*
-	ƒtƒH[ƒJƒX‚ª–³‚¢‚Æ‚«‚É“à•”“I‚ÉƒLƒƒƒŒƒbƒgì¬‚·‚é‚ÆˆÃ–Ù“I‚ÉƒLƒƒƒŒƒbƒg”jŠüi¦j‚³‚ê‚Ä‚à
-	ƒLƒƒƒŒƒbƒg‚ª‚ ‚éim_nCaretWidth != 0j‚Æ‚¢‚¤‚±‚Æ‚É‚È‚Á‚Ä‚µ‚Ü‚¢AƒtƒH[ƒJƒX‚ğæ“¾‚µ‚Ä‚à
-	ƒLƒƒƒŒƒbƒg‚ªo‚Ä‚±‚È‚­‚È‚éê‡‚ª‚ ‚é
-	ƒtƒH[ƒJƒX‚ª–³‚¢‚Æ‚«‚ÍƒLƒƒƒŒƒbƒg‚ğì¬^•\¦‚µ‚È‚¢‚æ‚¤‚É‚·‚é
+	ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ãŒç„¡ã„ã¨ãã«å†…éƒ¨çš„ã«ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½œæˆã™ã‚‹ã¨æš—é»™çš„ã«ã‚­ãƒ£ãƒ¬ãƒƒãƒˆç ´æ£„ï¼ˆâ€»ï¼‰ã•ã‚Œã¦ã‚‚
+	ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒã‚ã‚‹ï¼ˆm_nCaretWidth != 0ï¼‰ã¨ã„ã†ã“ã¨ã«ãªã£ã¦ã—ã¾ã„ã€ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã‚’å–å¾—ã—ã¦ã‚‚
+	ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒå‡ºã¦ã“ãªããªã‚‹å ´åˆãŒã‚ã‚‹
+	ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ãŒç„¡ã„ã¨ãã¯ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’ä½œæˆï¼è¡¨ç¤ºã—ãªã„ã‚ˆã†ã«ã™ã‚‹
 
-	¦ƒLƒƒƒŒƒbƒg‚ÍƒXƒŒƒbƒh‚É‚Ğ‚Æ‚Â‚¾‚¯‚È‚Ì‚Å—á‚¦‚ÎƒGƒfƒBƒbƒgƒ{ƒbƒNƒX‚ªƒtƒH[ƒJƒXæ“¾‚·‚ê‚Î
-	@•ÊŒ`ó‚ÌƒLƒƒƒŒƒbƒg‚ÉˆÃ–Ù“I‚É·‚µ‘Ö‚¦‚ç‚ê‚é‚µƒtƒH[ƒJƒX‚ğ¸‚¦‚ÎˆÃ–Ù“I‚É”jŠü‚³‚ê‚é
+	â€»ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã¯ã‚¹ãƒ¬ãƒƒãƒ‰ã«ã²ã¨ã¤ã ã‘ãªã®ã§ä¾‹ãˆã°ã‚¨ãƒ‡ã‚£ãƒƒãƒˆãƒœãƒƒã‚¯ã‚¹ãŒãƒ•ã‚©ãƒ¼ã‚«ã‚¹å–å¾—ã™ã‚Œã°
+	ã€€åˆ¥å½¢çŠ¶ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã«æš—é»™çš„ã«å·®ã—æ›¿ãˆã‚‰ã‚Œã‚‹ã—ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã‚’å¤±ãˆã°æš—é»™çš„ã«ç ´æ£„ã•ã‚Œã‚‹
 
 	2007.12.11 ryoji
-	ƒhƒ‰ƒbƒOƒAƒ“ƒhƒhƒƒbƒv•ÒW’†‚ÍƒLƒƒƒŒƒbƒg‚ª•K—v‚ÅˆÃ–Ù”jŠü‚Ì—vˆö‚à–³‚¢‚Ì‚Å—áŠO“I‚É•\¦‚·‚é
+	ãƒ‰ãƒ©ãƒƒã‚°ã‚¢ãƒ³ãƒ‰ãƒ‰ãƒ­ãƒƒãƒ—ç·¨é›†ä¸­ã¯ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒå¿…è¦ã§æš—é»™ç ´æ£„ã®è¦å› ã‚‚ç„¡ã„ã®ã§ä¾‹å¤–çš„ã«è¡¨ç¤ºã™ã‚‹
 */
 	if( ::GetFocus() != m_pEditView->GetHwnd() && !m_pEditView->m_bDragMode ){
 		m_sizeCaret.cx = 0;
 		return;
 	}
-	// 2014.07.02 GetDrawSwitch‚ğŒ©‚é
+	// 2014.07.02 GetDrawSwitchã‚’è¦‹ã‚‹
 	if( !m_pEditView->GetDrawSwitch() ){
 		return;
 	}
 
-	// CalcCaretDrawPos‚Ì‚½‚ß‚ÉCaretƒTƒCƒY‚ğ‰¼İ’è
+	// CalcCaretDrawPosã®ãŸã‚ã«Caretã‚µã‚¤ã‚ºã‚’ä»®è¨­å®š
 	int				nCaretWidth = 0;
 	int				nCaretHeight = 0;
 	if( 0 == pCommon->m_sGeneral.GetCaretType() ){
@@ -531,20 +531,20 @@ void CCaret::ShowEditCaret()
 	CMySize caretSizeOld = GetCaretSize();
 	SetCaretSize(nCaretWidth,nCaretHeight);
 	POINT ptDrawPos=CalcCaretDrawPos(GetCaretLayoutPos());
-	SetCaretSize(caretSizeOld.cx, caretSizeOld.cy); // Œã‚Å”äŠr‚·‚é‚Ì‚Å–ß‚·
+	SetCaretSize(caretSizeOld.cx, caretSizeOld.cy); // å¾Œã§æ¯”è¼ƒã™ã‚‹ã®ã§æˆ»ã™
 	bool bShowCaret = false;
 	if ( m_pEditView->GetTextArea().GetAreaLeft() <= ptDrawPos.x && m_pEditView->GetTextArea().GetAreaTop() <= ptDrawPos.y
 		&& ptDrawPos.x < m_pEditView->GetTextArea().GetAreaRight() && ptDrawPos.y < m_pEditView->GetTextArea().GetAreaBottom() ){
-		// ƒLƒƒƒŒƒbƒg‚Ì•\¦
+		// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤º
 		bShowCaret = true;
 	}
-	/* ƒLƒƒƒŒƒbƒg‚Ì•A‚‚³‚ğŒˆ’è */
-	// ƒJ[ƒ\ƒ‹‚Ìƒ^ƒCƒv = win
+	/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®å¹…ã€é«˜ã•ã‚’æ±ºå®š */
+	// ã‚«ãƒ¼ã‚½ãƒ«ã®ã‚¿ã‚¤ãƒ— = win
 	if( 0 == pCommon->m_sGeneral.GetCaretType() ){
-		nCaretHeight = GetHankakuHeight();					/* ƒLƒƒƒŒƒbƒg‚Ì‚‚³ */
+		nCaretHeight = GetHankakuHeight();					/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®é«˜ã• */
 		if( m_pEditView->IsInsMode() /* Oct. 2, 2005 genta */ ){
 			nCaretWidth = 2; //2px
-			// 2011.12.22 ƒVƒXƒeƒ€‚Ìİ’è‚É]‚¤(‚¯‚Ç2pxˆÈã)
+			// 2011.12.22 ã‚·ã‚¹ãƒ†ãƒ ã®è¨­å®šã«å¾“ã†(ã‘ã©2pxä»¥ä¸Š)
 			DWORD dwWidth;
 			if( ::SystemParametersInfo(SPI_GETCARETWIDTH, 0, &dwWidth, 0) && 2 < dwWidth){
 				nCaretWidth = t_min((int)dwWidth, GetHankakuDx());
@@ -557,12 +557,12 @@ void CCaret::ShowEditCaret()
 			CLogicInt		nLineLen = CLogicInt(0);
 			const CLayout*	pcLayout = NULL;
 			if( bShowCaret ){
-				// ‰æ–ÊŠO‚Ì‚Æ‚«‚ÍGetLineStr‚ğŒÄ‚Î‚È‚¢
+				// ç”»é¢å¤–ã®ã¨ãã¯GetLineStrã‚’å‘¼ã°ãªã„
 				pLine = pLayoutMgr->GetLineStr( GetCaretLayoutPos().GetY2(), &nLineLen, &pcLayout );
 			}
 
 			if( NULL != pLine ){
-				/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é */
+				/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 				nIdxFrom = GetCaretLogicPos().GetX() - pcLayout->GetLogicOffset();
 				if( nIdxFrom >= nLineLen ||
 					WCODE::IsLineDelimiter(pLine[nIdxFrom], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ||
@@ -578,13 +578,13 @@ void CCaret::ShowEditCaret()
 			}
 		}
 	}
-	// ƒJ[ƒ\ƒ‹‚Ìƒ^ƒCƒv = dos
+	// ã‚«ãƒ¼ã‚½ãƒ«ã®ã‚¿ã‚¤ãƒ— = dos
 	else if( 1 == pCommon->m_sGeneral.GetCaretType() ){
 		if( m_pEditView->IsInsMode() /* Oct. 2, 2005 genta */ ){
-			nCaretHeight = GetHankakuHeight() / 2;			/* ƒLƒƒƒŒƒbƒg‚Ì‚‚³ */
+			nCaretHeight = GetHankakuHeight() / 2;			/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®é«˜ã• */
 		}
 		else{
-			nCaretHeight = GetHankakuHeight();				/* ƒLƒƒƒŒƒbƒg‚Ì‚‚³ */
+			nCaretHeight = GetHankakuHeight();				/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®é«˜ã• */
 		}
 		nCaretWidth = GetHankakuDx();
 
@@ -596,7 +596,7 @@ void CCaret::ShowEditCaret()
 		}
 
 		if( NULL != pLine ){
-			/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é */
+			/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 			nIdxFrom = GetCaretLogicPos().GetX() - pcLayout->GetLogicOffset();
 			if( nIdxFrom >= nLineLen ||
 				WCODE::IsLineDelimiter(pLine[nIdxFrom], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ||
@@ -611,43 +611,43 @@ void CCaret::ShowEditCaret()
 		}
 	}
 
-	//	ƒLƒƒƒŒƒbƒgF‚Ìæ“¾
+	//	ã‚­ãƒ£ãƒ¬ãƒƒãƒˆè‰²ã®å–å¾—
 	const ColorInfo* ColorInfoArr = pTypes->m_ColorInfoArr;
 	int nCaretColor = ( ColorInfoArr[COLORIDX_CARET_IME].m_bDisp && m_pEditView->IsImeON() )? COLORIDX_CARET_IME: COLORIDX_CARET;
 	COLORREF crCaret = ColorInfoArr[nCaretColor].m_sColorAttr.m_cTEXT;
 	COLORREF crBack = ColorInfoArr[COLORIDX_TEXT].m_sColorAttr.m_cBACK;
 
 	if( !ExistCaretFocus() ){
-		/* ƒLƒƒƒŒƒbƒg‚ª‚È‚©‚Á‚½ê‡ */
-		/* ƒLƒƒƒŒƒbƒg‚Ìì¬ */
+		/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒãªã‹ã£ãŸå ´åˆ */
+		/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ä½œæˆ */
 		CreateEditCaret( crCaret, crBack, nCaretWidth, nCaretHeight );	// 2006.12.07 ryoji
 		m_bCaretShowFlag = false; // 2002/07/22 novice
 	}
 	else{
 		if( GetCaretSize() != CMySize(nCaretWidth,nCaretHeight) || m_crCaret != crCaret || m_pEditView->m_crBack2 != crBack ){
-			/* ƒLƒƒƒŒƒbƒg‚Í‚ ‚é‚ªA‘å‚«‚³‚âF‚ª•Ï‚í‚Á‚½ê‡ */
-			/* Œ»İ‚ÌƒLƒƒƒŒƒbƒg‚ğíœ */
+			/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã¯ã‚ã‚‹ãŒã€å¤§ãã•ã‚„è‰²ãŒå¤‰ã‚ã£ãŸå ´åˆ */
+			/* ç¾åœ¨ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’å‰Šé™¤ */
 			::DestroyCaret();
 
-			/* ƒLƒƒƒŒƒbƒg‚Ìì¬ */
+			/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ä½œæˆ */
 			CreateEditCaret( crCaret, crBack, nCaretWidth, nCaretHeight );	// 2006.12.07 ryoji
 			m_bCaretShowFlag = false; // 2002/07/22 novice
 		}
 		else{
-			/* ƒLƒƒƒŒƒbƒg‚Í‚ ‚é‚µA‘å‚«‚³‚à•Ï‚í‚Á‚Ä‚¢‚È‚¢ê‡ */
-			/* ƒLƒƒƒŒƒbƒg‚ğ‰B‚· */
+			/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã¯ã‚ã‚‹ã—ã€å¤§ãã•ã‚‚å¤‰ã‚ã£ã¦ã„ãªã„å ´åˆ */
+			/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’éš ã™ */
 			HideCaret_( m_pEditView->GetHwnd() ); // 2002/07/22 novice
 		}
 	}
 
-	// ƒLƒƒƒŒƒbƒgƒTƒCƒY
+	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚µã‚¤ã‚º
 	SetCaretSize(nCaretWidth,nCaretHeight);
 
-	/* ƒLƒƒƒŒƒbƒg‚ÌˆÊ’u‚ğ’²® */
-	//2007.08.26 kobake ƒLƒƒƒŒƒbƒgXÀ•W‚ÌŒvZ‚ğUNICODEd—l‚É‚µ‚½B
+	/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ä½ç½®ã‚’èª¿æ•´ */
+	//2007.08.26 kobake ã‚­ãƒ£ãƒ¬ãƒƒãƒˆXåº§æ¨™ã®è¨ˆç®—ã‚’UNICODEä»•æ§˜ã«ã—ãŸã€‚
 	::SetCaretPos( ptDrawPos.x, ptDrawPos.y );
 	if ( bShowCaret ){
-		/* ƒLƒƒƒŒƒbƒg‚Ì•\¦ */
+		/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤º */
 		ShowCaret_( m_pEditView->GetHwnd() ); // 2002/07/22 novice
 	}
 
@@ -659,18 +659,18 @@ void CCaret::ShowEditCaret()
 
 
 
-/*! ƒLƒƒƒŒƒbƒg‚ÌsŒ…ˆÊ’u‚¨‚æ‚ÑƒXƒe[ƒ^ƒXƒo[‚Ìó‘Ô•\¦‚ÌXV
+/*! ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡Œæ¡ä½ç½®ãŠã‚ˆã³ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã®çŠ¶æ…‹è¡¨ç¤ºã®æ›´æ–°
 
-	@note ƒXƒe[ƒ^ƒXƒo[‚Ìó‘Ô‚Ì•À‚Ñ•û‚Ì•ÏX‚ÍƒƒbƒZ[ƒW‚ğóM‚·‚é
-		CEditWnd::DispatchEvent()‚ÌWM_NOTIFY‚É‚à‰e‹¿‚ª‚ ‚é‚±‚Æ‚É’ˆÓ
+	@note ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã®çŠ¶æ…‹ã®ä¸¦ã³æ–¹ã®å¤‰æ›´ã¯ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å—ä¿¡ã™ã‚‹
+		CEditWnd::DispatchEvent()ã®WM_NOTIFYã«ã‚‚å½±éŸ¿ãŒã‚ã‚‹ã“ã¨ã«æ³¨æ„
 	
-	@note ƒXƒe[ƒ^ƒXƒo[‚Ìo—Í“à—e‚Ì•ÏX‚ÍCEditWnd::OnSize()‚Ì
-		ƒJƒ‰ƒ€•ŒvZ‚É‰e‹¿‚ª‚ ‚é‚±‚Æ‚É’ˆÓ
+	@note ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã®å‡ºåŠ›å†…å®¹ã®å¤‰æ›´ã¯CEditWnd::OnSize()ã®
+		ã‚«ãƒ©ãƒ å¹…è¨ˆç®—ã«å½±éŸ¿ãŒã‚ã‚‹ã“ã¨ã«æ³¨æ„
 */
-//2007.10.17 kobake d•¡‚·‚éƒR[ƒh‚ğ®—
+//2007.10.17 kobake é‡è¤‡ã™ã‚‹ã‚³ãƒ¼ãƒ‰ã‚’æ•´ç†
 void CCaret::ShowCaretPosInfo()
 {
-	//•K—v‚ÈƒCƒ“ƒ^[ƒtƒF[ƒX
+	//å¿…è¦ãªã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 	const CLayoutMgr* pLayoutMgr=&m_pEditDoc->m_cLayoutMgr;
 	const STypeConfig* pTypes=&m_pEditDoc->m_cDocType.GetDocumentAttribute();
 
@@ -679,17 +679,17 @@ void CCaret::ShowCaretPosInfo()
 		return;
 	}
 
-	// ƒXƒe[ƒ^ƒXƒo[ƒnƒ“ƒhƒ‹‚ğæ“¾
+	// ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ãƒãƒ³ãƒ‰ãƒ«ã‚’å–å¾—
 	HWND hwndStatusBar = m_pEditDoc->m_pcEditWnd->m_cStatusBar.GetStatusHwnd();
 
 
-	// ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì•¶š—ñ‚ğæ“¾
+	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ–‡å­—åˆ—ã‚’å–å¾—
 	const CLayout*	pcLayout;
 	CLogicInt		nLineLen;
 	const wchar_t*	pLine = pLayoutMgr->GetLineStr( GetCaretLayoutPos().GetY2(), &nLineLen, &pcLayout );
 
 
-	// -- -- -- -- •¶šƒR[ƒhî•ñ -> pszCodeName -- -- -- -- //
+	// -- -- -- -- æ–‡å­—ã‚³ãƒ¼ãƒ‰æƒ…å ± -> pszCodeName -- -- -- -- //
 	const TCHAR* pszCodeName;
 	CNativeT cmemCodeName;
 	if (hwndStatusBar) {
@@ -705,34 +705,34 @@ void CCaret::ShowCaretPosInfo()
 		CCodePage::GetNameShort(szCodeName, m_pEditDoc->GetDocumentEncoding());
 		cmemCodeName.AppendString(szCodeName);
 		if (m_pEditDoc->GetDocumentBomExist()) {
-			cmemCodeName.AppendString( _T("#") );		// BOM•t(ƒƒjƒ…[ƒo[‚È‚Ì‚Å¬‚³‚­)	// 2013/4/17 Uchi
+			cmemCodeName.AppendString( _T("#") );		// BOMä»˜(ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒãƒ¼ãªã®ã§å°ã•ã)	// 2013/4/17 Uchi
 		}
 	}
 	pszCodeName = cmemCodeName.GetStringPtr();
 
 
-	// -- -- -- -- ‰üsƒ‚[ƒh -> szEolMode -- -- -- -- //
+	// -- -- -- -- æ”¹è¡Œãƒ¢ãƒ¼ãƒ‰ -> szEolMode -- -- -- -- //
 	//	May 12, 2000 genta
-	//	‰üsƒR[ƒh‚Ì•\¦‚ğ’Ç‰Á
+	//	æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®è¡¨ç¤ºã‚’è¿½åŠ 
 	CEol cNlType = m_pEditDoc->m_cDocEditor.GetNewLineCode();
 	const TCHAR* szEolMode = cNlType.GetName();
 
 
-	// -- -- -- -- ƒLƒƒƒŒƒbƒgˆÊ’u -> ptCaret -- -- -- -- //
+	// -- -- -- -- ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½® -> ptCaret -- -- -- -- //
 	//
 	bool bCaretHabaMode = GetDllShareData().m_Common.m_sStatusbar.m_bDispColByChar == 0;
 	CMyPoint ptCaret;
-	//s”Ô†‚ğƒƒWƒbƒN’PˆÊ‚Å•\¦
+	//è¡Œç•ªå·ã‚’ãƒ­ã‚¸ãƒƒã‚¯å˜ä½ã§è¡¨ç¤º
 	if(pTypes->m_bLineNumIsCRLF){
 		if( bCaretHabaMode ){
 			ptCaret.y = GetCaretLogicPos().GetPOINT().y;
 			if( pcLayout ){
-				// VƒŒƒCƒAƒEƒgŒ…”‚ğŒvZ(1s‚Ìƒf[ƒ^‚ª’·‚¢‚Æd‚¢)
+				// æ–°ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæ¡æ•°ã‚’è¨ˆç®—(1è¡Œã®ãƒ‡ãƒ¼ã‚¿ãŒé•·ã„ã¨é‡ã„)
 				int nPosX = 0;
 				const CLayout* pcLayoutCalc = pcLayout;
 				while( pcLayoutCalc->GetPrevLayout() ){
 					if( pcLayoutCalc->GetLogicOffset() == 0 ){
-						break; // æ“ªs
+						break; // å…ˆé ­è¡Œ
 					}
 					pcLayoutCalc = pcLayoutCalc->GetPrevLayout();
 					nPosX += Int((m_pEditView->LineIndexToColumn(pcLayoutCalc, pcLayoutCalc->GetLengthWithoutEOL()) - pcLayoutCalc->GetIndent()) / (Int)m_pEditView->GetTextMetrics().GetLayoutXDefault());
@@ -745,13 +745,13 @@ void CCaret::ShowCaretPosInfo()
 			ptCaret = GetCaretLogicPos().GetPOINT();
 		}
 	}
-	//s”Ô†‚ğƒŒƒCƒAƒEƒg’PˆÊ‚Å•\¦
+	//è¡Œç•ªå·ã‚’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã§è¡¨ç¤º
 	else {
 		if( bCaretHabaMode ){
-			// ƒ‹[ƒ‰[Šî€
+			// ãƒ«ãƒ¼ãƒ©ãƒ¼åŸºæº–
 			ptCaret.x = (Int)GetCaretLayoutPos().GetX() / (Int)m_pEditView->GetTextMetrics().GetLayoutXDefault();
 		}else{
-			// •¶š’PˆÊ
+			// æ–‡å­—å˜ä½
 			if( pcLayout ){
 				ptCaret.x = (Int)GetCaretLogicPos().GetX() - pcLayout->GetLogicOffset();
 			}else{
@@ -760,27 +760,27 @@ void CCaret::ShowCaretPosInfo()
 		}
 		ptCaret.y = (Int)GetCaretLayoutPos().GetY();
 	}
-	//•\¦’l‚ª1‚©‚çn‚Ü‚é‚æ‚¤‚É•â³
+	//è¡¨ç¤ºå€¤ãŒ1ã‹ã‚‰å§‹ã¾ã‚‹ã‚ˆã†ã«è£œæ­£
 	ptCaret.x++;
 	ptCaret.y++;
 
 
-	// -- -- -- -- ƒLƒƒƒŒƒbƒgˆÊ’u‚Ì•¶šî•ñ -> szCaretChar -- -- -- -- //
+	// -- -- -- -- ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã®æ–‡å­—æƒ…å ± -> szCaretChar -- -- -- -- //
 	//
 	TCHAR szCaretChar[32]=_T("");
 	if( pLine ){
-		// w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é
+		// æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹
 		CLogicInt nIdx = GetCaretLogicPos().GetX2() - pcLayout->GetLogicOffset();
 		if( nIdx < nLineLen ){
 			if( nIdx < nLineLen - (pcLayout->GetLayoutEol().GetLen()?1:0) ){
 				//auto_sprintf( szCaretChar, _T("%04x"), );
-				//”CˆÓ‚Ì•¶šƒR[ƒh‚©‚çUnicode‚Ö•ÏŠ·‚·‚é		2008/6/9 Uchi
+				//ä»»æ„ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‹ã‚‰Unicodeã¸å¤‰æ›ã™ã‚‹		2008/6/9 Uchi
 				CCodeBase* pCode = CCodeFactory::CreateCodeBase(m_pEditDoc->GetDocumentEncoding(), false);
 				CommonSetting_Statusbar* psStatusbar = &GetDllShareData().m_Common.m_sStatusbar;
 				EConvertResult ret = pCode->UnicodeToHex(&pLine[nIdx], nLineLen - nIdx, szCaretChar, psStatusbar);
 				delete pCode;
 				if (ret != RESULT_COMPLETE) {
-					// ‚¤‚Ü‚­ƒR[ƒh‚ªæ‚ê‚È‚©‚Á‚½(Unicode‚Å•\¦)
+					// ã†ã¾ãã‚³ãƒ¼ãƒ‰ãŒå–ã‚Œãªã‹ã£ãŸ(Unicodeã§è¡¨ç¤º)
 					pCode = CCodeFactory::CreateCodeBase(CODE_UNICODE, false);
 					/* EConvertResult ret = */ pCode->UnicodeToHex(&pLine[nIdx], nLineLen - nIdx, szCaretChar, psStatusbar);
 					delete pCode;
@@ -793,21 +793,21 @@ void CCaret::ShowCaretPosInfo()
 	}
 
 
-	// -- -- -- --  ƒXƒe[ƒ^ƒXî•ñ‚ğ‘‚«o‚· -- -- -- -- //
+	// -- -- -- --  ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹æƒ…å ±ã‚’æ›¸ãå‡ºã™ -- -- -- -- //
 	//
-	// ƒEƒBƒ“ƒhƒE‰Eã‚É‘‚«o‚·
+	// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å³ä¸Šã«æ›¸ãå‡ºã™
 	if( !hwndStatusBar ){
 		TCHAR	szText[64];
 		TCHAR	szFormat[64];
 		TCHAR	szLeft[64];
 		TCHAR	szRight[64];
 		int		nLen;
-		{	// ƒƒbƒZ[ƒW‚Ì¶‘¤•¶š—ñius:—ñv‚ğœ‚¢‚½•\¦j
+		{	// ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®å·¦å´æ–‡å­—åˆ—ï¼ˆã€Œè¡Œ:åˆ—ã€ã‚’é™¤ã„ãŸè¡¨ç¤ºï¼‰
 			nLen = _tcslen(pszCodeName) + _tcslen(szEolMode) + _tcslen(szCaretChar);
-			// ‚±‚ê‚Í %s(%s)%6s%s%s “™‚É‚È‚éB%6ts•\‹L‚Íg‚¦‚È‚¢‚Ì‚Å’ˆÓ
+			// ã“ã‚Œã¯ %s(%s)%6s%s%s ç­‰ã«ãªã‚‹ã€‚%6tsè¡¨è¨˜ã¯ä½¿ãˆãªã„ã®ã§æ³¨æ„
 			auto_sprintf(
 				szFormat,
-				_T("%%s(%%s)%%%ds%%s%%s"),	// uƒLƒƒƒŒƒbƒgˆÊ’u‚Ì•¶šî•ñv‚ğ‰E‹l‚Å”z’ui‘«‚è‚È‚¢‚Æ‚«‚Í¶‹l‚É‚È‚Á‚Ä‰E‚ÉL‚Ñ‚éj
+				_T("%%s(%%s)%%%ds%%s%%s"),	// ã€Œã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã®æ–‡å­—æƒ…å ±ã€ã‚’å³è©°ã§é…ç½®ï¼ˆè¶³ã‚Šãªã„ã¨ãã¯å·¦è©°ã«ãªã£ã¦å³ã«ä¼¸ã³ã‚‹ï¼‰
 				(nLen < 15)? 15 - nLen: 1
 			);
 			auto_sprintf(
@@ -815,24 +815,24 @@ void CCaret::ShowCaretPosInfo()
 				szFormat,
 				pszCodeName,
 				szEolMode,
-				szCaretChar[0]? _T("["): _T(" "),	// •¶šî•ñ–³‚µ‚È‚çŠ‡ŒÊ‚àÈ—ªiEOF‚âƒtƒŠ[ƒJ[ƒ\ƒ‹ˆÊ’uj
+				szCaretChar[0]? _T("["): _T(" "),	// æ–‡å­—æƒ…å ±ç„¡ã—ãªã‚‰æ‹¬å¼§ã‚‚çœç•¥ï¼ˆEOFã‚„ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ï¼‰
 				szCaretChar,
-				szCaretChar[0]? _T("]"): _T(" ")	// •¶šî•ñ–³‚µ‚È‚çŠ‡ŒÊ‚àÈ—ªiEOF‚âƒtƒŠ[ƒJ[ƒ\ƒ‹ˆÊ’uj
+				szCaretChar[0]? _T("]"): _T(" ")	// æ–‡å­—æƒ…å ±ç„¡ã—ãªã‚‰æ‹¬å¼§ã‚‚çœç•¥ï¼ˆEOFã‚„ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ï¼‰
 			);
 		}
 		szRight[0] = _T('\0');
-		nLen = MENUBAR_MESSAGE_MAX_LEN - _tcslen(szLeft);	// ‰E‘¤‚Éc‚Á‚Ä‚¢‚é•¶š’·
-		if( nLen > 0 ){	// ƒƒbƒZ[ƒW‚Ì‰E‘¤•¶š—ñius:—ñv•\¦j
+		nLen = MENUBAR_MESSAGE_MAX_LEN - _tcslen(szLeft);	// å³å´ã«æ®‹ã£ã¦ã„ã‚‹æ–‡å­—é•·
+		if( nLen > 0 ){	// ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®å³å´æ–‡å­—åˆ—ï¼ˆã€Œè¡Œ:åˆ—ã€è¡¨ç¤ºï¼‰
 			TCHAR szRowCol[32];
 			auto_sprintf(
 				szRowCol,
-				_T("%d:%-4d"),	// u—ñv‚ÍÅ¬•‚ğw’è‚µ‚Ä¶Šñ‚¹i‘«‚è‚È‚¢‚Æ‚«‚Í‰E‚ÉL‚Ñ‚éj
+				_T("%d:%-4d"),	// ã€Œåˆ—ã€ã¯æœ€å°å¹…ã‚’æŒ‡å®šã—ã¦å·¦å¯„ã›ï¼ˆè¶³ã‚Šãªã„ã¨ãã¯å³ã«ä¼¸ã³ã‚‹ï¼‰
 				ptCaret.y,
 				ptCaret.x
 			);
 			auto_sprintf(
 				szFormat,
-				_T("%%%ds"),	// us:—ñv‚ğ‰E‹l‚Å”z’ui‘«‚è‚È‚¢‚Æ‚«‚Í¶‹l‚É‚È‚Á‚Ä‰E‚ÉL‚Ñ‚éj
+				_T("%%%ds"),	// ã€Œè¡Œ:åˆ—ã€ã‚’å³è©°ã§é…ç½®ï¼ˆè¶³ã‚Šãªã„ã¨ãã¯å·¦è©°ã«ãªã£ã¦å³ã«ä¼¸ã³ã‚‹ï¼‰
 				nLen
 			);
 			auto_sprintf(
@@ -849,23 +849,23 @@ void CCaret::ShowCaretPosInfo()
 		);
 		m_pEditDoc->m_pcEditWnd->PrintMenubarMessage( szText );
 	}
-	// ƒXƒe[ƒ^ƒXƒo[‚Éó‘Ô‚ğ‘‚«o‚·
+	// ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã«çŠ¶æ…‹ã‚’æ›¸ãå‡ºã™
 	else{
 		TCHAR	szText_1[64];
-		auto_sprintf( szText_1, LS( STR_STATUS_ROW_COL ), ptCaret.y, ptCaret.x );	//Oct. 30, 2000 JEPRO ç–œs‚à—v‚ç‚ñ
+		auto_sprintf( szText_1, LS( STR_STATUS_ROW_COL ), ptCaret.y, ptCaret.x );	//Oct. 30, 2000 JEPRO åƒä¸‡è¡Œã‚‚è¦ã‚‰ã‚“
 
 		TCHAR	szText_6[16];
 		if( m_pEditView->IsInsMode() /* Oct. 2, 2005 genta */ ){
-			_tcscpy( szText_6, LS( STR_INS_MODE_INS ) );	// "‘}“ü"
+			_tcscpy( szText_6, LS( STR_INS_MODE_INS ) );	// "æŒ¿å…¥"
 		}else{
-			_tcscpy( szText_6, LS( STR_INS_MODE_OVR ) );	// "ã‘"
+			_tcscpy( szText_6, LS( STR_INS_MODE_OVR ) );	// "ä¸Šæ›¸"
 		}
 		if( m_bClearStatus ){
 			::StatusBar_SetText( hwndStatusBar, 0 | SBT_NOBORDERS, _T("") );
 		}
 		::StatusBar_SetText( hwndStatusBar, 1 | 0,             szText_1 );
 		//	May 12, 2000 genta
-		//	‰üsƒR[ƒh‚Ì•\¦‚ğ’Ç‰ÁDŒã‚ë‚Ì”Ô†‚ğ1‚Â‚¸‚Â‚¸‚ç‚·
+		//	æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã®è¡¨ç¤ºã‚’è¿½åŠ ï¼å¾Œã‚ã®ç•ªå·ã‚’1ã¤ãšã¤ãšã‚‰ã™
 		//	From Here
 		::StatusBar_SetText( hwndStatusBar, 2 | 0,             szEolMode );
 		//	To Here
@@ -881,58 +881,58 @@ void CCaret::ClearCaretPosInfoCache()
 {
 }
 
-/* ƒJ[ƒ\ƒ‹ã‰ºˆÚ“®ˆ— */
+/* ã‚«ãƒ¼ã‚½ãƒ«ä¸Šä¸‹ç§»å‹•å‡¦ç† */
 CLayoutInt CCaret::Cursor_UPDOWN( CLayoutInt nMoveLines, bool bSelect )
 {
-	//•K—v‚ÈƒCƒ“ƒ^[ƒtƒF[ƒX
+	//å¿…è¦ãªã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 	const CLayoutMgr* const pLayoutMgr = &m_pEditDoc->m_cLayoutMgr;
 	const CommonSetting* const pCommon = &GetDllShareData().m_Common;
 
 	const CLayoutPoint ptCaret = GetCaretLayoutPos();
 
-	bool	bVertLineDoNotOFF = true;	// ƒJ[ƒ\ƒ‹ˆÊ’ucü‚ğÁ‹‚µ‚È‚¢
+	bool	bVertLineDoNotOFF = true;	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·šã‚’æ¶ˆå»ã—ãªã„
 	if( bSelect ){
-		bVertLineDoNotOFF = false;		//‘I‘ğó‘Ô‚È‚çƒJ[ƒ\ƒ‹ˆÊ’ucüÁ‹‚ğs‚¤
+		bVertLineDoNotOFF = false;		//é¸æŠçŠ¶æ…‹ãªã‚‰ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·šæ¶ˆå»ã‚’è¡Œã†
 	}
 
-	// Œ»İ‚ÌƒLƒƒƒŒƒbƒgYÀ•W + nMoveLines‚ª³‚µ‚¢ƒŒƒCƒAƒEƒgs‚Ì”ÍˆÍ“à‚Éû‚Ü‚é‚æ‚¤‚É nMoveLines‚ğ’²®‚·‚éB
-	if( nMoveLines > 0 ) { // ‰ºˆÚ“®B
+	// ç¾åœ¨ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆYåº§æ¨™ + nMoveLinesãŒæ­£ã—ã„ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®ç¯„å›²å†…ã«åã¾ã‚‹ã‚ˆã†ã« nMoveLinesã‚’èª¿æ•´ã™ã‚‹ã€‚
+	if( nMoveLines > 0 ) { // ä¸‹ç§»å‹•ã€‚
 		const bool existsEOFOnlyLine = pLayoutMgr->GetBottomLayout() && pLayoutMgr->GetBottomLayout()->GetLayoutEol() != EOL_NONE
 			|| pLayoutMgr->GetLineCount() == 0;
 		const CLayoutInt maxLayoutLine = pLayoutMgr->GetLineCount() + (existsEOFOnlyLine ? 1 : 0 ) - 1;
-		// ˆÚ“®æ‚ª EOF‚Ì‚İ‚Ìs‚ğŠÜ‚ß‚½ƒŒƒCƒAƒEƒgs”–¢–‚É‚È‚é‚æ‚¤‚ÉˆÚ“®—Ê‚ğ‹K³‚·‚éB
+		// ç§»å‹•å…ˆãŒ EOFã®ã¿ã®è¡Œã‚’å«ã‚ãŸãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œæ•°æœªæº€ã«ãªã‚‹ã‚ˆã†ã«ç§»å‹•é‡ã‚’è¦æ­£ã™ã‚‹ã€‚
 		nMoveLines = t_min( nMoveLines,  maxLayoutLine - ptCaret.y );
-		if( ptCaret.y + nMoveLines == maxLayoutLine && existsEOFOnlyLine // ˆÚ“®æ‚ª EOF‚Ì‚İ‚Ìs
-			&& m_pEditView->GetSelectionInfo().IsBoxSelecting() && 0 != ptCaret.x // ‚©‚Â‹éŒ`‘I‘ğ’†‚È‚çA
+		if( ptCaret.y + nMoveLines == maxLayoutLine && existsEOFOnlyLine // ç§»å‹•å…ˆãŒ EOFã®ã¿ã®è¡Œ
+			&& m_pEditView->GetSelectionInfo().IsBoxSelecting() && 0 != ptCaret.x // ã‹ã¤çŸ©å½¢é¸æŠä¸­ãªã‚‰ã€
 		) {
-			// EOF‚Ì‚İ‚Ìs‚É‚ÍˆÚ“®‚µ‚È‚¢B‰ºˆÚ“®‚ÅƒLƒƒƒŒƒbƒg‚Ì XÀ•W‚ğ“®‚©‚µ‚½‚­‚È‚¢‚Ì‚ÅB
-			nMoveLines = t_max( CLayoutInt(0), nMoveLines - 1 ); // ‚¤‚Á‚©‚èãˆÚ“®‚µ‚È‚¢‚æ‚¤‚É 0ˆÈã‚ğç‚éB
+			// EOFã®ã¿ã®è¡Œã«ã¯ç§»å‹•ã—ãªã„ã€‚ä¸‹ç§»å‹•ã§ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã® Xåº§æ¨™ã‚’å‹•ã‹ã—ãŸããªã„ã®ã§ã€‚
+			nMoveLines = t_max( CLayoutInt(0), nMoveLines - 1 ); // ã†ã£ã‹ã‚Šä¸Šç§»å‹•ã—ãªã„ã‚ˆã†ã« 0ä»¥ä¸Šã‚’å®ˆã‚‹ã€‚
 		}
-	} else { // ãˆÚ“®B
-		// ˆÚ“®æ‚ª 0s–Ú‚æ‚è¬‚³‚­‚È‚ç‚È‚¢‚æ‚¤‚ÉˆÚ“®—Ê‚ğ‹K§B
+	} else { // ä¸Šç§»å‹•ã€‚
+		// ç§»å‹•å…ˆãŒ 0è¡Œç›®ã‚ˆã‚Šå°ã•ããªã‚‰ãªã„ã‚ˆã†ã«ç§»å‹•é‡ã‚’è¦åˆ¶ã€‚
 		nMoveLines = t_max( nMoveLines, - GetCaretLayoutPos().GetY() );
 	}
 
 	if( bSelect && ! m_pEditView->GetSelectionInfo().IsTextSelected() ) {
-		/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é */
+		/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹ */
 		m_pEditView->GetSelectionInfo().BeginSelectArea();
 	}
 	if( ! bSelect ){
 		if( m_pEditView->GetSelectionInfo().IsTextSelected() ) {
-			/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+			/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 			m_pEditView->GetSelectionInfo().DisableSelectArea(true);
 		}else if( m_pEditView->GetSelectionInfo().IsBoxSelecting() ){
 			m_pEditView->GetSelectionInfo().SetBoxSelect(false);
 		}
 	}
 
-	// (‚±‚ê‚©‚ç‹‚ß‚é)ƒLƒƒƒŒƒbƒg‚ÌˆÚ“®æB
+	// (ã“ã‚Œã‹ã‚‰æ±‚ã‚ã‚‹)ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ç§»å‹•å…ˆã€‚
 	CLayoutPoint ptTo( CLayoutInt(0), ptCaret.y + nMoveLines );
 
-	/* ˆÚ“®æ‚Ìs‚Ìƒf[ƒ^‚ğæ“¾ */
+	/* ç§»å‹•å…ˆã®è¡Œã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
 	const CLayout* const pLayout = pLayoutMgr->SearchLineByLayoutY( ptTo.y );
 	const CLogicInt nLineLen = pLayout ? pLayout->GetLengthWithEOL() : CLogicInt(0);
-	int i = 0; ///< ‰½H
+	int i = 0; ///< ä½•ï¼Ÿ
 	if( pLayout ) {
 		CMemoryIterator it = pLayoutMgr->CreateCMemoryIterator(pLayout);
 		while( ! it.end() ){
@@ -953,7 +953,7 @@ CLayoutInt CCaret::Cursor_UPDOWN( CLayoutInt nMoveLines, bool bSelect )
 		}
 	}
 	if( i >= nLineLen ) {
-		/* ƒtƒŠ[ƒJ[ƒ\ƒ‹ƒ‚[ƒh‚Æ‹éŒ`‘I‘ğ’†‚ÍAƒLƒƒƒŒƒbƒg‚ÌˆÊ’u‚ğ‰üs‚â EOF‚Ì‘O‚É§ŒÀ‚µ‚È‚¢ */
+		/* ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ãƒ¢ãƒ¼ãƒ‰ã¨çŸ©å½¢é¸æŠä¸­ã¯ã€ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ä½ç½®ã‚’æ”¹è¡Œã‚„ EOFã®å‰ã«åˆ¶é™ã—ãªã„ */
 		if( pCommon->m_sGeneral.m_bIsFreeCursorMode
 			|| m_pEditView->GetSelectionInfo().IsBoxSelecting()
 		) {
@@ -965,7 +965,7 @@ CLayoutInt CCaret::Cursor_UPDOWN( CLayoutInt nMoveLines, bool bSelect )
 	}
 	GetAdjustCursorPos( &ptTo );
 	if( bSelect ) {
-		/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+		/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 		m_pEditView->GetSelectionInfo().ChangeSelectAreaByCurrentCursor( ptTo );
 	}
 	const CLayoutInt nScrollLines = MoveCursor(	ptTo,
@@ -977,28 +977,28 @@ CLayoutInt CCaret::Cursor_UPDOWN( CLayoutInt nMoveLines, bool bSelect )
 }
 
 
-/*!	ƒLƒƒƒŒƒbƒg‚Ìì¬
+/*!	ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ä½œæˆ
 
-	@param nCaretColor [in]	ƒLƒƒƒŒƒbƒg‚ÌFí•Ê (0:’Êí, 1:IME ON)
-	@param nWidth [in]		ƒLƒƒƒŒƒbƒg•
-	@param nHeight [in]		ƒLƒƒƒŒƒbƒg‚
+	@param nCaretColor [in]	ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è‰²ç¨®åˆ¥ (0:é€šå¸¸, 1:IME ON)
+	@param nWidth [in]		ã‚­ãƒ£ãƒ¬ãƒƒãƒˆå¹…
+	@param nHeight [in]		ã‚­ãƒ£ãƒ¬ãƒƒãƒˆé«˜
 
-	@date 2006.12.07 ryoji V‹Kì¬
+	@date 2006.12.07 ryoji æ–°è¦ä½œæˆ
 */
 void CCaret::CreateEditCaret( COLORREF crCaret, COLORREF crBack, int nWidth, int nHeight )
 {
 	//
-	// ƒLƒƒƒŒƒbƒg—p‚Ìƒrƒbƒgƒ}ƒbƒv‚ğì¬‚·‚é
+	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆç”¨ã®ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—ã‚’ä½œæˆã™ã‚‹
 	//
-	// Note: ƒEƒBƒ“ƒhƒEŒİŠ·‚Ìƒƒ‚ƒŠ DC ã‚Å PatBlt ‚ğ—p‚¢‚ÄƒLƒƒƒŒƒbƒgF‚Æ”wŒiF‚ğ XOR Œ‹‡
-	//       ‚·‚é‚±‚Æ‚ÅC–Ú“I‚Ìƒrƒbƒgƒ}ƒbƒv‚ğ“¾‚éD
-	//       ¦ 256 FŠÂ‹«‚Å‚Í RGB ’l‚ğ’Pƒ‚É’¼Ú‰‰Z‚µ‚Ä‚àƒLƒƒƒŒƒbƒgF‚ğo‚·‚½‚ß‚Ì³‚µ‚¢
-	//          ƒrƒbƒgƒ}ƒbƒvF‚Í“¾‚ç‚ê‚È‚¢D
-	//       Ql: [HOWTO] ƒLƒƒƒŒƒbƒg‚ÌF‚ğ§Œä‚·‚é•û–@
+	// Note: ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦äº’æ›ã®ãƒ¡ãƒ¢ãƒª DC ä¸Šã§ PatBlt ã‚’ç”¨ã„ã¦ã‚­ãƒ£ãƒ¬ãƒƒãƒˆè‰²ã¨èƒŒæ™¯è‰²ã‚’ XOR çµåˆ
+	//       ã™ã‚‹ã“ã¨ã§ï¼Œç›®çš„ã®ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—ã‚’å¾—ã‚‹ï¼
+	//       â€» 256 è‰²ç’°å¢ƒã§ã¯ RGB å€¤ã‚’å˜ç´”ã«ç›´æ¥æ¼”ç®—ã—ã¦ã‚‚ã‚­ãƒ£ãƒ¬ãƒƒãƒˆè‰²ã‚’å‡ºã™ãŸã‚ã®æ­£ã—ã„
+	//          ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—è‰²ã¯å¾—ã‚‰ã‚Œãªã„ï¼
+	//       å‚è€ƒ: [HOWTO] ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è‰²ã‚’åˆ¶å¾¡ã™ã‚‹æ–¹æ³•
 	//             http://support.microsoft.com/kb/84054/ja
 	//
 
-	HBITMAP hbmpCaret;	// ƒLƒƒƒŒƒbƒg—p‚Ìƒrƒbƒgƒ}ƒbƒv
+	HBITMAP hbmpCaret;	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆç”¨ã®ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—
 
 	HDC hdc = m_pEditView->GetDC();
 
@@ -1019,12 +1019,12 @@ void CCaret::CreateEditCaret( COLORREF crCaret, COLORREF crBack, int nWidth, int
 
 	m_pEditView->ReleaseDC( hdc );
 
-	// ˆÈ‘O‚Ìƒrƒbƒgƒ}ƒbƒv‚ğ”jŠü‚·‚é
+	// ä»¥å‰ã®ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—ã‚’ç ´æ£„ã™ã‚‹
 	if( m_hbmpCaret != NULL )
 		::DeleteObject( m_hbmpCaret );
 	m_hbmpCaret = hbmpCaret;
 
-	// ƒLƒƒƒŒƒbƒg‚ğì¬‚·‚é
+	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’ä½œæˆã™ã‚‹
 	m_pEditView->CreateCaret( hbmpCaret, nWidth, nHeight );
 	return;
 }
@@ -1032,7 +1032,7 @@ void CCaret::CreateEditCaret( COLORREF crCaret, COLORREF crBack, int nWidth, int
 
 // 2002/07/22 novice
 /*!
-	ƒLƒƒƒŒƒbƒg‚Ì•\¦
+	ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤º
 */
 void CCaret::ShowCaret_( HWND hwnd )
 {
@@ -1044,7 +1044,7 @@ void CCaret::ShowCaret_( HWND hwnd )
 
 
 /*!
-	ƒLƒƒƒŒƒbƒg‚Ì”ñ•\¦
+	ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®éè¡¨ç¤º
 */
 void CCaret::HideCaret_( HWND hwnd )
 {
@@ -1054,14 +1054,14 @@ void CCaret::HideCaret_( HWND hwnd )
 	}
 }
 
-//! ©•ª‚Ìó‘Ô‚ğ‘¼‚ÌCCaret‚ÉƒRƒs[
+//! è‡ªåˆ†ã®çŠ¶æ…‹ã‚’ä»–ã®CCaretã«ã‚³ãƒ”ãƒ¼
 void CCaret::CopyCaretStatus(CCaret* pCaret) const
 {
 	pCaret->SetCaretLayoutPos(GetCaretLayoutPos());
 	pCaret->SetCaretLogicPos(GetCaretLogicPos());
-	pCaret->m_nCaretPosX_Prev = m_nCaretPosX_Prev;	/* ƒrƒ…[¶’[‚©‚ç‚ÌƒJ[ƒ\ƒ‹Œ…ˆÊ’ui‚OƒIƒŠƒWƒ“j*/
+	pCaret->m_nCaretPosX_Prev = m_nCaretPosX_Prev;	/* ãƒ“ãƒ¥ãƒ¼å·¦ç«¯ã‹ã‚‰ã®ã‚«ãƒ¼ã‚½ãƒ«æ¡ä½ç½®ï¼ˆï¼ã‚ªãƒªã‚¸ãƒ³ï¼‰*/
 
-	//¦ ƒLƒƒƒŒƒbƒg‚ÌƒTƒCƒY‚ÍƒRƒs[‚µ‚È‚¢B2002/05/12 YAZAKI
+	//â€» ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ã‚µã‚¤ã‚ºã¯ã‚³ãƒ”ãƒ¼ã—ãªã„ã€‚2002/05/12 YAZAKI
 }
 
 
@@ -1079,7 +1079,7 @@ POINT CCaret::CalcCaretDrawPos(const CLayoutPoint& ptCaretPos) const
 	}else{
 		nPosY = m_pEditView->GetTextArea().GetAreaTop()
 			+ (Int)(nY) * m_pEditView->GetTextMetrics().GetHankakuDy()
-			+ m_pEditView->GetTextMetrics().GetHankakuHeight() - GetCaretSize().cy; //‰ºŠñ‚¹
+			+ m_pEditView->GetTextMetrics().GetHankakuHeight() - GetCaretSize().cy; //ä¸‹å¯„ã›
 	}
 
 	return CMyPoint(nPosX,nPosY);
@@ -1089,24 +1089,24 @@ POINT CCaret::CalcCaretDrawPos(const CLayoutPoint& ptCaretPos) const
 
 
 /*!
-	sŒ…w’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“®iÀ•W’²®•t‚«j
+	è¡Œæ¡æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ï¼ˆåº§æ¨™èª¿æ•´ä»˜ãï¼‰
 
-	@return cƒXƒNƒ[ƒ‹s”(•‰:ãƒXƒNƒ[ƒ‹/³:‰ºƒXƒNƒ[ƒ‹)
+	@return ç¸¦ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•°(è² :ä¸Šã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«/æ­£:ä¸‹ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«)
 
-	@note ƒ}ƒEƒX“™‚É‚æ‚éˆÚ“®‚Å•s“KØ‚ÈˆÊ’u‚És‚©‚È‚¢‚æ‚¤À•W’²®‚µ‚ÄƒJ[ƒ\ƒ‹ˆÚ“®‚·‚é
+	@note ãƒã‚¦ã‚¹ç­‰ã«ã‚ˆã‚‹ç§»å‹•ã§ä¸é©åˆ‡ãªä½ç½®ã«è¡Œã‹ãªã„ã‚ˆã†åº§æ¨™èª¿æ•´ã—ã¦ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ã™ã‚‹
 
-	@date 2007.08.23 ryoji ŠÖ”‰»iMoveCursorToPoint()‚©‚çˆ—‚ğ”²‚«o‚µj
-	@date 2007.09.26 ryoji ”¼Šp•¶š‚Å‚à’†‰›‚Å¶‰E‚ÉƒJ[ƒ\ƒ‹‚ğU‚è•ª‚¯‚é
-	@date 2007.10.23 kobake ˆø”à–¾‚ÌŒë‚è‚ğC³ ([in,out]¨[in])
-	@date 2009.02.17 ryoji ƒŒƒCƒAƒEƒgs––ˆÈŒã‚ÌƒJƒ‰ƒ€ˆÊ’uw’è‚È‚ç––”ö•¶š‚Ì‘O‚Å‚Í‚È‚­––”ö•¶š‚ÌŒã‚ÉˆÚ“®‚·‚é
+	@date 2007.08.23 ryoji é–¢æ•°åŒ–ï¼ˆMoveCursorToPoint()ã‹ã‚‰å‡¦ç†ã‚’æŠœãå‡ºã—ï¼‰
+	@date 2007.09.26 ryoji åŠè§’æ–‡å­—ã§ã‚‚ä¸­å¤®ã§å·¦å³ã«ã‚«ãƒ¼ã‚½ãƒ«ã‚’æŒ¯ã‚Šåˆ†ã‘ã‚‹
+	@date 2007.10.23 kobake å¼•æ•°èª¬æ˜ã®èª¤ã‚Šã‚’ä¿®æ­£ ([in,out]â†’[in])
+	@date 2009.02.17 ryoji ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œæœ«ä»¥å¾Œã®ã‚«ãƒ©ãƒ ä½ç½®æŒ‡å®šãªã‚‰æœ«å°¾æ–‡å­—ã®å‰ã§ã¯ãªãæœ«å°¾æ–‡å­—ã®å¾Œã«ç§»å‹•ã™ã‚‹
 */
 CLayoutInt CCaret::MoveCursorProperly(
-	CLayoutPoint	ptNewXY,			//!< [in] ƒJ[ƒ\ƒ‹‚ÌƒŒƒCƒAƒEƒgÀ•WX
-	bool			bScroll,			//!< [in] true: ‰æ–ÊˆÊ’u’²®—L‚è/ false: ‰æ–ÊˆÊ’u’²®—L‚è–³‚µ
-	bool			test,				//!< [in] true: ƒJ[ƒ\ƒ‹ˆÚ“®‚Í‚µ‚È‚¢
-	CLayoutPoint*	ptNewXYNew,			//!< [out] V‚µ‚¢ƒŒƒCƒAƒEƒgÀ•W
-	int				nCaretMarginRate,	//!< [in] cƒXƒNƒ[ƒ‹ŠJnˆÊ’u‚ğŒˆ‚ß‚é’l
-	int				dx					//!< [in] ptNewXY.x‚Æƒ}ƒEƒXƒJ[ƒ\ƒ‹ˆÊ’u‚Æ‚ÌŒë·(ƒJƒ‰ƒ€•–¢–‚Ìƒhƒbƒg”)
+	CLayoutPoint	ptNewXY,			//!< [in] ã‚«ãƒ¼ã‚½ãƒ«ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆåº§æ¨™X
+	bool			bScroll,			//!< [in] true: ç”»é¢ä½ç½®èª¿æ•´æœ‰ã‚Š/ false: ç”»é¢ä½ç½®èª¿æ•´æœ‰ã‚Šç„¡ã—
+	bool			test,				//!< [in] true: ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ã¯ã—ãªã„
+	CLayoutPoint*	ptNewXYNew,			//!< [out] æ–°ã—ã„ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆåº§æ¨™
+	int				nCaretMarginRate,	//!< [in] ç¸¦ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é–‹å§‹ä½ç½®ã‚’æ±ºã‚ã‚‹å€¤
+	int				dx					//!< [in] ptNewXY.xã¨ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã¨ã®èª¤å·®(ã‚«ãƒ©ãƒ å¹…æœªæº€ã®ãƒ‰ãƒƒãƒˆæ•°)
 )
 {
 	CLogicInt		nLineLen;
@@ -1116,27 +1116,27 @@ CLayoutInt CCaret::MoveCursorProperly(
 		ptNewXY.y = CLayoutInt(0);
 	}
 	
-	// 2011.12.26 EOFˆÈ‰º‚Ìs‚¾‚Á‚½ê‡‚Å‹éŒ`‚Ì‚Æ‚«‚ÍAÅIƒŒƒCƒAƒEƒgs‚ÖˆÚ“®‚·‚é
+	// 2011.12.26 EOFä»¥ä¸‹ã®è¡Œã ã£ãŸå ´åˆã§çŸ©å½¢ã®ã¨ãã¯ã€æœ€çµ‚ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã¸ç§»å‹•ã™ã‚‹
 	if( ptNewXY.y >= m_pEditDoc->m_cLayoutMgr.GetLineCount()
 	 && (m_pEditView->GetSelectionInfo().IsMouseSelecting() && m_pEditView->GetSelectionInfo().IsBoxSelecting()) ){
 		const CLayout* layoutEnd = m_pEditDoc->m_cLayoutMgr.GetBottomLayout();
 		bool bEofOnly = (layoutEnd && layoutEnd->GetLayoutEol() != EOL_NONE) || NULL == layoutEnd;
-	 	// 2012.01.09 ‚Ò‚Á‚½‚è[EOF]ˆÊ’u‚É‚ ‚éê‡‚ÍˆÊ’u‚ğˆÛ(1‚Âã‚Ìs‚É‚µ‚È‚¢)
+	 	// 2012.01.09 ã´ã£ãŸã‚Š[EOF]ä½ç½®ã«ã‚ã‚‹å ´åˆã¯ä½ç½®ã‚’ç¶­æŒ(1ã¤ä¸Šã®è¡Œã«ã—ãªã„)
 	 	if( bEofOnly && ptNewXY.y == m_pEditDoc->m_cLayoutMgr.GetLineCount() && ptNewXY.x == 0 ){
 	 	}else{
 			ptNewXY.y = t_max(CLayoutInt(0), m_pEditDoc->m_cLayoutMgr.GetLineCount() - 1);
 		}
 	}
-	/* ƒJ[ƒ\ƒ‹‚ªƒeƒLƒXƒgÅ‰º’[s‚É‚ ‚é‚© */
+	/* ã‚«ãƒ¼ã‚½ãƒ«ãŒãƒ†ã‚­ã‚¹ãƒˆæœ€ä¸‹ç«¯è¡Œã«ã‚ã‚‹ã‹ */
 	if( ptNewXY.y >= m_pEditDoc->m_cLayoutMgr.GetLineCount() ){
-		// 2004.04.03 Moca EOF‚æ‚èŒã‚ë‚ÌÀ•W’²®‚ÍAMoveCursor“à‚Å‚â‚Á‚Ä‚à‚ç‚¤‚Ì‚ÅAíœ
+		// 2004.04.03 Moca EOFã‚ˆã‚Šå¾Œã‚ã®åº§æ¨™èª¿æ•´ã¯ã€MoveCursorå†…ã§ã‚„ã£ã¦ã‚‚ã‚‰ã†ã®ã§ã€å‰Šé™¤
 	}
-	/* ƒJ[ƒ\ƒ‹‚ªƒeƒLƒXƒgÅã’[s‚É‚ ‚é‚© */
+	/* ã‚«ãƒ¼ã‚½ãƒ«ãŒãƒ†ã‚­ã‚¹ãƒˆæœ€ä¸Šç«¯è¡Œã«ã‚ã‚‹ã‹ */
 	else if( ptNewXY.y < 0 ){
 		ptNewXY.Set(CLayoutInt(0), CLayoutInt(0));
 	}
 	else{
-		/* ˆÚ“®æ‚Ìs‚Ìƒf[ƒ^‚ğæ“¾ */
+		/* ç§»å‹•å…ˆã®è¡Œã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
 		m_pEditDoc->m_cLayoutMgr.GetLineStr( ptNewXY.GetY2(), &nLineLen, &pcLayout );
 
 		int nColWidth = m_pEditView->GetTextMetrics().GetCharPxWidth();
@@ -1163,18 +1163,18 @@ CLayoutInt CCaret::MoveCursorProperly(
 		nPosX += it.getColumn();
 		if ( it.end() ){
 			i = it.getIndex();
-			//nPosX -= it.getColumnDelta();	// 2009.02.17 ryoji ƒRƒƒ“ƒgƒAƒEƒgi––”ö•¶š‚ÌŒã‚ÉˆÚ“®‚·‚éj
+			//nPosX -= it.getColumnDelta();	// 2009.02.17 ryoji ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆï¼ˆæœ«å°¾æ–‡å­—ã®å¾Œã«ç§»å‹•ã™ã‚‹ï¼‰
 		}
 
 		if( i >= nLineLen ){
-			// 2011.12.26 ƒtƒŠ[ƒJ[ƒ\ƒ‹/‹éŒ`‚Åƒf[ƒ^•t‚«EOF‚Ì‰E‘¤‚ÖˆÚ“®‚Å‚«‚é‚æ‚¤‚É
-			/* ƒtƒŠ[ƒJ[ƒ\ƒ‹ƒ‚[ƒh‚© */
+			// 2011.12.26 ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«/çŸ©å½¢ã§ãƒ‡ãƒ¼ã‚¿ä»˜ãEOFã®å³å´ã¸ç§»å‹•ã§ãã‚‹ã‚ˆã†ã«
+			/* ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ãƒ¢ãƒ¼ãƒ‰ã‹ */
 			if( GetDllShareData().m_Common.m_sGeneral.m_bIsFreeCursorMode
-			  || ( m_pEditView->GetSelectionInfo().IsMouseSelecting() && m_pEditView->GetSelectionInfo().IsBoxSelecting() )	/* ƒ}ƒEƒX”ÍˆÍ‘I‘ğ’† && ‹éŒ`”ÍˆÍ‘I‘ğ’† */
-			  || ( m_pEditView->m_bDragMode && m_pEditView->m_bDragBoxData ) /* OLE DropTarget && ‹éŒ`ƒf[ƒ^ */
+			  || ( m_pEditView->GetSelectionInfo().IsMouseSelecting() && m_pEditView->GetSelectionInfo().IsBoxSelecting() )	/* ãƒã‚¦ã‚¹ç¯„å›²é¸æŠä¸­ && çŸ©å½¢ç¯„å›²é¸æŠä¸­ */
+			  || ( m_pEditView->m_bDragMode && m_pEditView->m_bDragBoxData ) /* OLE DropTarget && çŸ©å½¢ãƒ‡ãƒ¼ã‚¿ */
 			){
-				// Ü‚è•Ô‚µ•‚ÆƒŒƒCƒAƒEƒgsŒ…”i‚Ô‚ç‰º‚°‚ğŠÜ‚Şj‚Ì‚Ç‚¿‚ç‚©‘å‚«‚¢‚Ù‚¤‚Ü‚ÅƒJ[ƒ\ƒ‹ˆÚ“®‰Â”\
-				//	Aug. 14, 2005 genta Ü‚è•Ô‚µ•‚ğLayoutMgr‚©‚çæ“¾‚·‚é‚æ‚¤‚É
+				// æŠ˜ã‚Šè¿”ã—å¹…ã¨ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œæ¡æ•°ï¼ˆã¶ã‚‰ä¸‹ã’ã‚’å«ã‚€ï¼‰ã®ã©ã¡ã‚‰ã‹å¤§ãã„ã»ã†ã¾ã§ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•å¯èƒ½
+				//	Aug. 14, 2005 genta æŠ˜ã‚Šè¿”ã—å¹…ã‚’LayoutMgrã‹ã‚‰å–å¾—ã™ã‚‹ã‚ˆã†ã«
 				CLayoutInt nMaxX = t_max(nPosX, m_pEditDoc->m_cLayoutMgr.GetMaxLineLayout());
 				nPosX = ptNewXY.GetX2();
 				if( nPosX < CLayoutInt(0) ){

--- a/sakura_core/view/CCaret.h
+++ b/sakura_core/view/CCaret.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -41,12 +41,12 @@ public:
 		m_nLockCounter = 0;
 		m_nUnderLineLockCounter = 0;
 	}
-	// •\¦”ñ•\¦‚ğØ‚è‘Ö‚¦‚ç‚ê‚È‚¢‚æ‚¤‚É‚·‚é
+	// è¡¨ç¤ºéè¡¨ç¤ºã‚’åˆ‡ã‚Šæ›¿ãˆã‚‰ã‚Œãªã„ã‚ˆã†ã«ã™ã‚‹
 	void Lock()
 	{
 		m_nLockCounter++;
 	}
-	// •\¦”ñ•\¦‚ğØ‚è‘Ö‚¦‚ç‚ê‚é‚æ‚¤‚É‚·‚é
+	// è¡¨ç¤ºéè¡¨ç¤ºã‚’åˆ‡ã‚Šæ›¿ãˆã‚‰ã‚Œã‚‹ã‚ˆã†ã«ã™ã‚‹
 	void UnLock()
 	{
 		m_nLockCounter--;
@@ -58,7 +58,7 @@ public:
 	{
 		m_nUnderLineLockCounter++;
 	}
-	// •\¦”ñ•\¦‚ğØ‚è‘Ö‚¦‚ç‚ê‚é‚æ‚¤‚É‚·‚é
+	// è¡¨ç¤ºéè¡¨ç¤ºã‚’åˆ‡ã‚Šæ›¿ãˆã‚‰ã‚Œã‚‹ã‚ˆã†ã«ã™ã‚‹
 	void UnderLineUnLock()
 	{
 		m_nUnderLineLockCounter--;
@@ -66,14 +66,14 @@ public:
 			m_nUnderLineLockCounter = 0;
 		}
 	}
-	void CaretUnderLineON( bool, bool );	// ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌON
-	void CaretUnderLineOFF( bool, bool = true, bool = false );	// ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌOFF
+	void CaretUnderLineON( bool, bool );	// ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®ON
+	void CaretUnderLineOFF( bool, bool = true, bool = false );	// ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®OFF
 	void SetUnderLineDoNotOFF( bool flag ){ if( !m_nLockCounter )m_bUnderLineDoNotOFF = flag; }
 	void SetVertLineDoNotOFF( bool flag ){ if( !m_nLockCounter )m_bVertLineDoNotOFF = flag; }
 	inline bool GetUnderLineDoNotOFF( )const { return m_bUnderLineDoNotOFF; }
 	inline bool GetVertLineDoNotOFF( )const { return m_bVertLineDoNotOFF; }
 private:
-	/* ƒƒbƒNƒJƒEƒ“ƒ^B0‚Ì‚Æ‚«‚ÍAƒƒbƒN‚³‚ê‚Ä‚¢‚È‚¢BUnLock‚ªŒÄ‚Î‚ê‚·‚¬‚Ä‚à•‰‚É‚Í‚È‚ç‚È‚¢ */
+	/* ãƒ­ãƒƒã‚¯ã‚«ã‚¦ãƒ³ã‚¿ã€‚0ã®ã¨ãã¯ã€ãƒ­ãƒƒã‚¯ã•ã‚Œã¦ã„ãªã„ã€‚UnLockãŒå‘¼ã°ã‚Œã™ãã¦ã‚‚è² ã«ã¯ãªã‚‰ãªã„ */
 	int m_nLockCounter;
 	int m_nUnderLineLockCounter;
 	CEditView* m_pcEditView;
@@ -89,27 +89,27 @@ public:
 	virtual ~CCaret();
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ŠO•”ˆË‘¶                            //
+	//                         å¤–éƒ¨ä¾å­˜                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 	int GetHankakuDx() const;
 	int GetHankakuDy() const;
 	int GetHankakuHeight() const;
 
-	//ƒhƒLƒ…ƒƒ“ƒg‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ğ‹‚ß‚é
+	//ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã‚’æ±‚ã‚ã‚‹
 	const CEditDoc* GetDocument() const{ return m_pEditDoc; }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         À‘••â•                            //
+	//                         å®Ÿè£…è£œåŠ©                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	POINT CalcCaretDrawPos(const CLayoutPoint& ptCaretPos) const;
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                   ‰Šú‰»EI—¹ˆ—‚È‚Ç                      //
+	//                   åˆæœŸåŒ–ãƒ»çµ‚äº†å‡¦ç†ãªã©                      //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//! ƒLƒƒƒŒƒbƒg‚Ìì¬B2006.12.07 ryoji
+	//! ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ä½œæˆã€‚2006.12.07 ryoji
 	void CreateEditCaret(
 		COLORREF crCaret,
 		COLORREF crBack,
@@ -117,107 +117,107 @@ public:
 		int nHeight
 	);
 	
-	//! ƒLƒƒƒŒƒbƒg‚ğ”jŠü‚·‚éi“à•”“I‚É‚à”jŠüj
+	//! ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’ç ´æ£„ã™ã‚‹ï¼ˆå†…éƒ¨çš„ã«ã‚‚ç ´æ£„ï¼‰
 	void DestroyCaret()
 	{
 		::DestroyCaret();
 		m_sizeCaret.cx = 0;
 	}
 
-	//! ƒRƒs[
+	//! ã‚³ãƒ”ãƒ¼
 	void CopyCaretStatus(CCaret* pDestCaret) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ˆÚ“®                              //
+	//                           ç§»å‹•                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//İ’è
-	CLayoutInt MoveCursorToClientPoint( const POINT& ptClientPos, bool = false, CLayoutPoint* = NULL );		//!< ƒ}ƒEƒX“™‚É‚æ‚éÀ•Ww’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“®
-	CLayoutInt Cursor_UPDOWN( CLayoutInt nMoveLines, bool bSelect );	//!< ƒJ[ƒ\ƒ‹ã‰ºˆÚ“®ˆ—
-	CLayoutInt MoveCursor(												//!< sŒ…w’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“®
-		CLayoutPoint	ptWk_CaretPos,									//!< [in] ˆÚ“®æƒŒƒCƒAƒEƒgˆÊ’u
-		bool			bScroll,										//!< [in] true: ‰æ–ÊˆÊ’u’²®—L‚è  false: ‰æ–ÊˆÊ’u’²®–³‚µ
-		int				nCaretMarginRate	= _CARETMARGINRATE,			//!< [in] cƒXƒNƒ[ƒ‹ŠJnˆÊ’u‚ğŒˆ‚ß‚é’l
-		bool			bUnderlineDoNotOFF	= false,					//!< [in] ƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ğÁ‹‚µ‚È‚¢
-		bool			bVertLineDoNotOFF	= false						//!< [in] ƒJ[ƒ\ƒ‹ˆÊ’ucü‚ğÁ‹‚µ‚È‚¢
+	//è¨­å®š
+	CLayoutInt MoveCursorToClientPoint( const POINT& ptClientPos, bool = false, CLayoutPoint* = NULL );		//!< ãƒã‚¦ã‚¹ç­‰ã«ã‚ˆã‚‹åº§æ¨™æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•
+	CLayoutInt Cursor_UPDOWN( CLayoutInt nMoveLines, bool bSelect );	//!< ã‚«ãƒ¼ã‚½ãƒ«ä¸Šä¸‹ç§»å‹•å‡¦ç†
+	CLayoutInt MoveCursor(												//!< è¡Œæ¡æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•
+		CLayoutPoint	ptWk_CaretPos,									//!< [in] ç§»å‹•å…ˆãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®
+		bool			bScroll,										//!< [in] true: ç”»é¢ä½ç½®èª¿æ•´æœ‰ã‚Š  false: ç”»é¢ä½ç½®èª¿æ•´ç„¡ã—
+		int				nCaretMarginRate	= _CARETMARGINRATE,			//!< [in] ç¸¦ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é–‹å§‹ä½ç½®ã‚’æ±ºã‚ã‚‹å€¤
+		bool			bUnderlineDoNotOFF	= false,					//!< [in] ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã‚’æ¶ˆå»ã—ãªã„
+		bool			bVertLineDoNotOFF	= false						//!< [in] ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·šã‚’æ¶ˆå»ã—ãªã„
 	);
 	CLayoutInt MoveCursorFastMode(
-		const CLogicPoint&	pptWk_CaretPosLogic							//!< [in] ˆÚ“®æƒƒWƒbƒNˆÊ’u
+		const CLogicPoint&	pptWk_CaretPosLogic							//!< [in] ç§»å‹•å…ˆãƒ­ã‚¸ãƒƒã‚¯ä½ç½®
 	);
-	CLayoutInt MoveCursorProperly( CLayoutPoint ptNewXY, bool, bool = false, CLayoutPoint* = NULL, int = _CARETMARGINRATE, int = 0 );	/* sŒ…w’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“®iÀ•W’²®•t‚«j */
+	CLayoutInt MoveCursorProperly( CLayoutPoint ptNewXY, bool, bool = false, CLayoutPoint* = NULL, int = _CARETMARGINRATE, int = 0 );	/* è¡Œæ¡æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ï¼ˆåº§æ¨™èª¿æ•´ä»˜ãï¼‰ */
 
-	//$ İŒvv‘z“I‚É”÷–­
-	void SetCaretLayoutPos(const CLayoutPoint& pt){ m_ptCaretPos_Layout = pt; }	//!< ƒLƒƒƒŒƒbƒgˆÊ’u(ƒŒƒCƒAƒEƒg)‚ğİ’è
-	void SetCaretLogicPos(const CLogicPoint& pt){ m_ptCaretPos_Logic=pt; }		//!< ƒLƒƒƒŒƒbƒgˆÊ’u(ƒƒWƒbƒN)‚ğİ’è
-
-	
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ƒTƒCƒY•ÏX                           //
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	void SetCaretSize(int nW, int nH){ m_sizeCaret.Set(nW,nH); }						//!< ƒLƒƒƒŒƒbƒgƒTƒCƒY‚ğİ’è
+	//$ è¨­è¨ˆæ€æƒ³çš„ã«å¾®å¦™
+	void SetCaretLayoutPos(const CLayoutPoint& pt){ m_ptCaretPos_Layout = pt; }	//!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆ)ã‚’è¨­å®š
+	void SetCaretLogicPos(const CLogicPoint& pt){ m_ptCaretPos_Logic=pt; }		//!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®(ãƒ­ã‚¸ãƒƒã‚¯)ã‚’è¨­å®š
 
 	
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ŒvZ                              //
+	//                        ã‚µã‚¤ã‚ºå¤‰æ›´                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//ŒvZ
-	BOOL GetAdjustCursorPos( CLayoutPoint* pptPosXY ); //!< ³‚µ‚¢ƒJ[ƒ\ƒ‹ˆÊ’u‚ğZo‚·‚é
+	void SetCaretSize(int nW, int nH){ m_sizeCaret.Set(nW,nH); }						//!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚µã‚¤ã‚ºã‚’è¨­å®š
+
+	
+	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
+	//                           è¨ˆç®—                              //
+	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
+	//è¨ˆç®—
+	BOOL GetAdjustCursorPos( CLayoutPoint* pptPosXY ); //!< æ­£ã—ã„ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’ç®—å‡ºã™ã‚‹
 
 	void ClearCaretPosInfoCache();
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           •\¦                              //
+	//                           è¡¨ç¤º                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//•`‰æH
-	void ShowEditCaret();    //!< ƒLƒƒƒŒƒbƒg‚Ì•\¦EXV
-	void ShowCaretPosInfo(); //!< ƒLƒƒƒŒƒbƒg‚ÌsŒ…ˆÊ’u‚ğ•\¦‚·‚é
+	//æç”»ï¼Ÿ
+	void ShowEditCaret();    //!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤ºãƒ»æ›´æ–°
+	void ShowCaretPosInfo(); //!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡Œæ¡ä½ç½®ã‚’è¡¨ç¤ºã™ã‚‹
 
-	//APIŒÄ‚Ño‚µ
+	//APIå‘¼ã³å‡ºã—
 	void ShowCaret_( HWND hwnd );
 	void HideCaret_( HWND hwnd );
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           æ“¾                              //
+	//                           å–å¾—                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	CLayoutPoint GetCaretLayoutPos() const	{ return m_ptCaretPos_Layout; }	//!< ƒLƒƒƒŒƒbƒgˆÊ’u(ƒŒƒCƒAƒEƒg)‚ğæ“¾
-	CMySize GetCaretSize() const			{ return m_sizeCaret; }			//!< ƒLƒƒƒŒƒbƒgƒTƒCƒY‚ğæ“¾B¦³Šm‚É‚Í‚‚³‚Íˆá‚¤‚ç‚µ‚¢ (‚±‚Ì”¼•ª‚Ì‚±‚Æ‚à‚ ‚éH)
-	bool ExistCaretFocus() const			{ return m_sizeCaret.cx>0; }	//!< ƒLƒƒƒŒƒbƒg‚ÌƒtƒH[ƒJƒX‚ª‚ ‚é‚©B¦‰¡•’l‚Å”»’è‚µ‚Ä‚é‚ç‚µ‚¢B
-	CLogicPoint GetCaretLogicPos() const	{ return m_ptCaretPos_Logic; }	//!< ƒLƒƒƒŒƒbƒgˆÊ’u(ƒƒWƒbƒN)‚ğæ“¾
+	CLayoutPoint GetCaretLayoutPos() const	{ return m_ptCaretPos_Layout; }	//!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆ)ã‚’å–å¾—
+	CMySize GetCaretSize() const			{ return m_sizeCaret; }			//!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚µã‚¤ã‚ºã‚’å–å¾—ã€‚â€»æ­£ç¢ºã«ã¯é«˜ã•ã¯é•ã†ã‚‰ã—ã„ (ã“ã®åŠåˆ†ã®ã“ã¨ã‚‚ã‚ã‚‹ï¼Ÿ)
+	bool ExistCaretFocus() const			{ return m_sizeCaret.cx>0; }	//!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ãŒã‚ã‚‹ã‹ã€‚â€»æ¨ªå¹…å€¤ã§åˆ¤å®šã—ã¦ã‚‹ã‚‰ã—ã„ã€‚
+	CLogicPoint GetCaretLogicPos() const	{ return m_ptCaretPos_Logic; }	//!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®(ãƒ­ã‚¸ãƒƒã‚¯)ã‚’å–å¾—
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                  ’á•p“xƒCƒ“ƒ^[ƒtƒF[ƒX                     //
+	//                  ä½é »åº¦ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	bool GetCaretShowFlag() const{ return m_bCaretShowFlag; }
 
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ƒƒ“ƒo•Ï”                           //
+	//                        ãƒ¡ãƒ³ãƒå¤‰æ•°                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 private:
-	//QÆ
+	//å‚ç…§
 	CEditView*				m_pEditView;
 	const CEditDoc*			m_pEditDoc;
 
-	//ƒLƒƒƒŒƒbƒgˆÊ’u
-	CLayoutPoint	m_ptCaretPos_Layout;	// ƒrƒ…[¶ã’[‚©‚ç‚ÌƒJ[ƒ\ƒ‹ˆÊ’uBƒŒƒCƒAƒEƒg’PˆÊB
-	CLogicPoint		m_ptCaretPos_Logic;		// ƒJ[ƒ\ƒ‹ˆÊ’uBƒƒWƒbƒN’PˆÊBƒf[ƒ^“à•¶š’PˆÊB
+	//ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®
+	CLayoutPoint	m_ptCaretPos_Layout;	// ãƒ“ãƒ¥ãƒ¼å·¦ä¸Šç«¯ã‹ã‚‰ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã€‚ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã€‚
+	CLogicPoint		m_ptCaretPos_Logic;		// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã€‚ãƒ­ã‚¸ãƒƒã‚¯å˜ä½ã€‚ãƒ‡ãƒ¼ã‚¿å†…æ–‡å­—å˜ä½ã€‚
 
 public:
-	CLayoutInt		m_nCaretPosX_Prev;	// ’¼‘O‚ÌXÀ•W‹L‰¯—pBƒŒƒCƒAƒEƒg’PˆÊB‚±‚Ìƒ\[ƒX‚Ì‰º•”‚ÉÚ×à–¾‚ª‚ ‚è‚Ü‚·B
+	CLayoutInt		m_nCaretPosX_Prev;	// ç›´å‰ã®Xåº§æ¨™è¨˜æ†¶ç”¨ã€‚ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã€‚ã“ã®ã‚½ãƒ¼ã‚¹ã®ä¸‹éƒ¨ã«è©³ç´°èª¬æ˜ãŒã‚ã‚Šã¾ã™ã€‚
 
-	//ƒLƒƒƒŒƒbƒgŒ©‚½–Ú
+	//ã‚­ãƒ£ãƒ¬ãƒƒãƒˆè¦‹ãŸç›®
 private:
-	CMySize			m_sizeCaret;		// ƒLƒƒƒŒƒbƒg‚ÌƒTƒCƒYBƒsƒNƒZƒ‹’PˆÊB
-	COLORREF		m_crCaret;			// ƒLƒƒƒŒƒbƒg‚ÌF				// 2006.12.07 ryoji
-	HBITMAP			m_hbmpCaret;		// ƒLƒƒƒŒƒbƒg‚Ìƒrƒbƒgƒ}ƒbƒv		// 2006.11.28 ryoji
+	CMySize			m_sizeCaret;		// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ã‚µã‚¤ã‚ºã€‚ãƒ”ã‚¯ã‚»ãƒ«å˜ä½ã€‚
+	COLORREF		m_crCaret;			// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è‰²				// 2006.12.07 ryoji
+	HBITMAP			m_hbmpCaret;		// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—		// 2006.11.28 ryoji
 	bool			m_bCaretShowFlag;
 
-	//ƒAƒ“ƒ_[ƒ‰ƒCƒ“
+	//ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³
 public:
 	mutable CCaretUnderLine m_cUnderLine;
 	
@@ -226,22 +226,22 @@ public:
 
 
 /*!	@brief CCaret::m_nCaretPosX_Prev
-	’¼‘O‚ÌXÀ•W‹L‰¯—p
+	ç›´å‰ã®Xåº§æ¨™è¨˜æ†¶ç”¨
 
-	ƒtƒŠ[ƒJ[ƒ\ƒ‹ƒ‚[ƒh‚Å‚È‚¢ê‡‚ÉƒJ[ƒ\ƒ‹‚ğã‰º‚ÉˆÚ“®‚³‚¹‚½ê‡
-	ƒJ[ƒ\ƒ‹ˆÊ’u‚æ‚è’Z‚¢s‚Å‚Ís––‚ÉƒJ[ƒ\ƒ‹‚ğˆÚ“®‚·‚é‚ªC
-	‚³‚ç‚ÉˆÚ“®‚ğ‘±‚¯‚½ê‡‚É’·‚¢s‚ÅˆÚ“®‹N“_‚ÌXˆÊ’u‚ğ•œŒ³‚Å‚«‚é‚æ‚¤‚É
-	‚·‚é‚½‚ß‚Ì•Ï”D
+	ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ãƒ¢ãƒ¼ãƒ‰ã§ãªã„å ´åˆã«ã‚«ãƒ¼ã‚½ãƒ«ã‚’ä¸Šä¸‹ã«ç§»å‹•ã•ã›ãŸå ´åˆ
+	ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚ˆã‚ŠçŸ­ã„è¡Œã§ã¯è¡Œæœ«ã«ã‚«ãƒ¼ã‚½ãƒ«ã‚’ç§»å‹•ã™ã‚‹ãŒï¼Œ
+	ã•ã‚‰ã«ç§»å‹•ã‚’ç¶šã‘ãŸå ´åˆã«é•·ã„è¡Œã§ç§»å‹•èµ·ç‚¹ã®Xä½ç½®ã‚’å¾©å…ƒã§ãã‚‹ã‚ˆã†ã«
+	ã™ã‚‹ãŸã‚ã®å¤‰æ•°ï¼
 	
-	@par g‚¢•û
-	“Ç‚İo‚µ‚ÍCEditView::Cursor_UPDOWN()‚Ì‚İ‚Ås‚¤D
-	ƒJ[ƒ\ƒ‹ã‰ºˆÚ“®ˆÈŠO‚ÅƒJ[ƒ\ƒ‹ˆÚ“®‚ğs‚Á‚½ê‡‚É‚Í
-	’¼‚¿‚Ém_nCaretPosX‚Ì’l‚ğİ’è‚·‚éD‚»‚¤‚µ‚È‚¢‚Æ
-	‚»‚Ì’¼Œã‚ÌƒJ[ƒ\ƒ‹ã‰ºˆÚ“®‚ÅˆÚ“®‘O‚ÌXÀ•W‚É–ß‚Á‚Ä‚µ‚Ü‚¤D
+	@par ä½¿ã„æ–¹
+	èª­ã¿å‡ºã—ã¯CEditView::Cursor_UPDOWN()ã®ã¿ã§è¡Œã†ï¼
+	ã‚«ãƒ¼ã‚½ãƒ«ä¸Šä¸‹ç§»å‹•ä»¥å¤–ã§ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ã‚’è¡Œã£ãŸå ´åˆã«ã¯
+	ç›´ã¡ã«m_nCaretPosXã®å€¤ã‚’è¨­å®šã™ã‚‹ï¼ãã†ã—ãªã„ã¨
+	ãã®ç›´å¾Œã®ã‚«ãƒ¼ã‚½ãƒ«ä¸Šä¸‹ç§»å‹•ã§ç§»å‹•å‰ã®Xåº§æ¨™ã«æˆ»ã£ã¦ã—ã¾ã†ï¼
 
-	ƒrƒ…[¶’[‚©‚ç‚ÌƒJ[ƒ\ƒ‹Œ…ˆÊ’u(‚OŠJn)
+	ãƒ“ãƒ¥ãƒ¼å·¦ç«¯ã‹ã‚‰ã®ã‚«ãƒ¼ã‚½ãƒ«æ¡ä½ç½®(ï¼é–‹å§‹)
 	
-	@date 2004.04.09 genta à–¾•¶’Ç‰Á
+	@date 2004.04.09 genta èª¬æ˜æ–‡è¿½åŠ 
 */
 
 #endif /* SAKURA_CCARET_EF835ACD_9DB2_4F5A_8513_35034F1894219_H_ */

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief •¶‘ƒEƒBƒ“ƒhƒE‚ÌŠÇ—
+ï»¿/*!	@file
+	@brief æ–‡æ›¸ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ç®¡ç†
 
 	@author Norio Nakatani
-	@date	1998/03/13 ì¬
+	@date	1998/03/13 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -57,7 +57,7 @@
 #include "window/CTipWnd.h"
 #include "window/CAutoScrollWnd.h"
 #include "CDicMgr.h"
-//	Jun. 26, 2001 genta	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦
+//	Jun. 26, 2001 genta	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆ
 #include "extmodule/CBregexp.h"
 #include "CEol.h"				// EEolType
 #include "cmd/CViewCommander.h"
@@ -69,20 +69,20 @@
 
 class CViewFont;
 class CRuler;
-class CDropTarget; /// 2002/2/3 aroka ƒwƒbƒ_Œy—Ê‰»
+class CDropTarget; /// 2002/2/3 aroka ãƒ˜ãƒƒãƒ€è»½é‡åŒ–
 class COpeBlk;///
 class CSplitBoxWnd;///
 class CRegexKeyword;///
-class CAutoMarkMgr; /// 2002/2/3 aroka ƒwƒbƒ_Œy—Ê‰» to here
-class CEditDoc;	//	2002/5/13 YAZAKI ƒwƒbƒ_Œy—Ê‰»
-class CLayout;	//	2002/5/13 YAZAKI ƒwƒbƒ_Œy—Ê‰»
+class CAutoMarkMgr; /// 2002/2/3 aroka ãƒ˜ãƒƒãƒ€è»½é‡åŒ– to here
+class CEditDoc;	//	2002/5/13 YAZAKI ãƒ˜ãƒƒãƒ€è»½é‡åŒ–
+class CLayout;	//	2002/5/13 YAZAKI ãƒ˜ãƒƒãƒ€è»½é‡åŒ–
 class CMigemo;	// 2004.09.14 isearch
 struct SColorStrategyInfo;
 struct CColor3Setting;
 class COutputAdapter;
 
-// struct DispPos; //	’N‚©‚ªinclude‚µ‚Ä‚Ü‚·
-// class CColorStrategy;	// ’N‚©‚ªinclude‚µ‚Ä‚Ü‚·
+// struct DispPos; //	èª°ã‹ãŒincludeã—ã¦ã¾ã™
+// class CColorStrategy;	// èª°ã‹ãŒincludeã—ã¦ã¾ã™
 class CColor_Found;
 
 #ifndef IDM_COPYDICINFO
@@ -105,29 +105,29 @@ typedef struct tagRECONVERTSTRING {
 } RECONVERTSTRING, *PRECONVERTSTRING;
 #endif // RECONVERTSTRING
 
-///	ƒ}ƒEƒX‚©‚çƒRƒ}ƒ“ƒh‚ªÀs‚³‚ê‚½ê‡‚ÌãˆÊƒrƒbƒg
+///	ãƒã‚¦ã‚¹ã‹ã‚‰ã‚³ãƒãƒ³ãƒ‰ãŒå®Ÿè¡Œã•ã‚ŒãŸå ´åˆã®ä¸Šä½ãƒ“ãƒƒãƒˆ
 ///	@date 2006.05.19 genta
 const int CMD_FROM_MOUSE = 2;
 
 
 /*-----------------------------------------------------------------------
-ƒNƒ‰ƒX‚ÌéŒ¾
+ã‚¯ãƒ©ã‚¹ã®å®£è¨€
 -----------------------------------------------------------------------*/
 /*!
-	@brief •¶‘ƒEƒBƒ“ƒhƒE‚ÌŠÇ—
+	@brief æ–‡æ›¸ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ç®¡ç†
 	
-	1‚Â‚Ì•¶‘ƒEƒBƒ“ƒhƒE‚É‚Â‚«1‚Â‚ÌCEditDocƒIƒuƒWƒFƒNƒg‚ªŠ„‚è“–‚Ä‚ç‚êA
-	1‚Â‚ÌCEditDocƒIƒuƒWƒFƒNƒg‚É‚Â‚«A4‚Â‚ÌCEditViweƒIƒuƒWƒFƒNƒg‚ªŠ„‚è“–‚Ä‚ç‚ê‚éB
-	ƒEƒBƒ“ƒhƒEƒƒbƒZ[ƒW‚Ìˆ—AƒRƒ}ƒ“ƒhƒƒbƒZ[ƒW‚Ìˆ—A
-	‰æ–Ê•\¦‚È‚Ç‚ğs‚¤B
+	1ã¤ã®æ–‡æ›¸ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«ã¤ã1ã¤ã®CEditDocã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆãŒå‰²ã‚Šå½“ã¦ã‚‰ã‚Œã€
+	1ã¤ã®CEditDocã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã«ã¤ãã€4ã¤ã®CEditViweã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆãŒå‰²ã‚Šå½“ã¦ã‚‰ã‚Œã‚‹ã€‚
+	ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®å‡¦ç†ã€ã‚³ãƒãƒ³ãƒ‰ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®å‡¦ç†ã€
+	ç”»é¢è¡¨ç¤ºãªã©ã‚’è¡Œã†ã€‚
 	
-	@date 2002.2.17 YAZAKI CShareData‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ÍACProcess‚É‚Ğ‚Æ‚Â‚ ‚é‚Ì‚İB
+	@date 2002.2.17 YAZAKI CShareDataã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ã€CProcessã«ã²ã¨ã¤ã‚ã‚‹ã®ã¿ã€‚
 */
-//2007.08.25 kobake •¶šŠÔŠu”z—ñ‚Ì‹@”\‚ğCTextMetrics‚ÉˆÚ“®
-//2007.10.02 kobake Command_TRIM2‚ğCConvert‚ÉˆÚ“®
+//2007.08.25 kobake æ–‡å­—é–“éš”é…åˆ—ã®æ©Ÿèƒ½ã‚’CTextMetricsã«ç§»å‹•
+//2007.10.02 kobake Command_TRIM2ã‚’CConvertã«ç§»å‹•
 
 class CEditView
-: public CViewCalc //$$ ‚±‚ê‚ªeƒNƒ‰ƒX‚Å‚ ‚é•K—v‚Í–³‚¢‚ªA‚±‚ÌƒNƒ‰ƒX‚Ìƒƒ\ƒbƒhŒÄ‚Ño‚µ‚ª‘½‚¢‚Ì‚ÅAb’è“I‚ÉeƒNƒ‰ƒX‚Æ‚·‚éB
+: public CViewCalc //$$ ã“ã‚ŒãŒè¦ªã‚¯ãƒ©ã‚¹ã§ã‚ã‚‹å¿…è¦ã¯ç„¡ã„ãŒã€ã“ã®ã‚¯ãƒ©ã‚¹ã®ãƒ¡ã‚½ãƒƒãƒ‰å‘¼ã³å‡ºã—ãŒå¤šã„ã®ã§ã€æš«å®šçš„ã«è¦ªã‚¯ãƒ©ã‚¹ã¨ã™ã‚‹ã€‚
 , public CEditView_Paint
 , public CMyWnd
 , public CDocListenerEx
@@ -142,8 +142,8 @@ public:
 		return m_pcEditDoc;
 	}
 public:
-	//! ”wŒi‚Éƒrƒbƒgƒ}ƒbƒv‚ğg—p‚·‚é‚©‚Ç‚¤‚©
-	//! 2010.10.03 ”wŒiÀ‘•
+	//! èƒŒæ™¯ã«ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—ã‚’ä½¿ç”¨ã™ã‚‹ã‹ã©ã†ã‹
+	//! 2010.10.03 èƒŒæ™¯å®Ÿè£…
 	bool IsBkBitmap() const{ return NULL != m_pcEditDoc->m_hBackImg; }
 
 public:
@@ -158,117 +158,117 @@ public:
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ¶¬‚Æ”jŠü                           //
+	//                        ç”Ÿæˆã¨ç ´æ£„                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	/* Constructors */
 	CEditView(CEditWnd* pcEditWnd);
 	~CEditView();
 	void Close();
-	/* ‰Šú‰»Œnƒƒ“ƒoŠÖ” */
+	/* åˆæœŸåŒ–ç³»ãƒ¡ãƒ³ãƒé–¢æ•° */
 	BOOL Create(
-		HWND		hwndParent,	//!< e
-		CEditDoc*	pcEditDoc,	//!< QÆ‚·‚éƒhƒLƒ…ƒƒ“ƒg
-		int			nMyIndex,	//!< ƒrƒ…[‚ÌƒCƒ“ƒfƒbƒNƒX
-		BOOL		bShow,		//!< ì¬‚É•\¦‚·‚é‚©‚Ç‚¤‚©
+		HWND		hwndParent,	//!< è¦ª
+		CEditDoc*	pcEditDoc,	//!< å‚ç…§ã™ã‚‹ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ
+		int			nMyIndex,	//!< ãƒ“ãƒ¥ãƒ¼ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹
+		BOOL		bShow,		//!< ä½œæˆæ™‚ã«è¡¨ç¤ºã™ã‚‹ã‹ã©ã†ã‹
 		bool		bMiniMap
 	);
-	void CopyViewStatus( CEditView* ) const;					/* ©•ª‚Ì•\¦ó‘Ô‚ğ‘¼‚Ìƒrƒ…[‚ÉƒRƒs[ */
+	void CopyViewStatus( CEditView* ) const;					/* è‡ªåˆ†ã®è¡¨ç¤ºçŠ¶æ…‹ã‚’ä»–ã®ãƒ“ãƒ¥ãƒ¼ã«ã‚³ãƒ”ãƒ¼ */
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ƒNƒŠƒbƒvƒ{[ƒh                         //
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-public:
-	//æ“¾
-	bool MyGetClipboardData( CNativeW&, bool*, bool* = NULL );			/* ƒNƒŠƒbƒvƒ{[ƒh‚©‚çƒf[ƒ^‚ğæ“¾ */
-
-	//İ’è
-	bool MySetClipboardData( const ACHAR*, int, bool bColumnSelect, bool = false );	/* ƒNƒŠƒbƒvƒ{[ƒh‚Éƒf[ƒ^‚ğİ’è */
-	bool MySetClipboardData( const WCHAR*, int, bool bColumnSelect, bool = false );	/* ƒNƒŠƒbƒvƒ{[ƒh‚Éƒf[ƒ^‚ğİ’è */
-
-	//—˜—p
-	void CopyCurLine( bool bAddCRLFWhenCopy, EEolType neweol, bool bEnableLineModePaste );	/* ƒJ[ƒ\ƒ‹s‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[‚·‚é */	// 2007.10.08 ryoji
-	void CopySelectedAllLines( const wchar_t*, BOOL );			/* ‘I‘ğ”ÍˆÍ“à‚Ì‘Ss‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[‚·‚é */
-
-
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ƒCƒxƒ“ƒg                            //
+	//                      ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//ƒhƒLƒ…ƒƒ“ƒgƒCƒxƒ“ƒg
+	//å–å¾—
+	bool MyGetClipboardData( CNativeW&, bool*, bool* = NULL );			/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
+
+	//è¨­å®š
+	bool MySetClipboardData( const ACHAR*, int, bool bColumnSelect, bool = false );	/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ãƒ‡ãƒ¼ã‚¿ã‚’è¨­å®š */
+	bool MySetClipboardData( const WCHAR*, int, bool bColumnSelect, bool = false );	/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ãƒ‡ãƒ¼ã‚¿ã‚’è¨­å®š */
+
+	//åˆ©ç”¨
+	void CopyCurLine( bool bAddCRLFWhenCopy, EEolType neweol, bool bEnableLineModePaste );	/* ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼ã™ã‚‹ */	// 2007.10.08 ryoji
+	void CopySelectedAllLines( const wchar_t*, BOOL );			/* é¸æŠç¯„å›²å†…ã®å…¨è¡Œã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼ã™ã‚‹ */
+
+
+	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
+	//                         ã‚¤ãƒ™ãƒ³ãƒˆ                            //
+	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
+public:
+	//ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚¤ãƒ™ãƒ³ãƒˆ
 	void OnAfterLoad(const SLoadInfo& sLoadInfo);
-	/* ƒƒbƒZ[ƒWƒfƒBƒXƒpƒbƒ`ƒƒ */
+	/* ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒ‡ã‚£ã‚¹ãƒ‘ãƒƒãƒãƒ£ */
 	LRESULT DispatchEvent( HWND, UINT, WPARAM, LPARAM );
 	//
-	void OnChangeSetting();										/* İ’è•ÏX‚ğ”½‰f‚³‚¹‚é */
-	void OnPaint( HDC, PAINTSTRUCT *, BOOL );			/* ’Êí‚Ì•`‰æˆ— */
-	void OnPaint2( HDC, PAINTSTRUCT *, BOOL );			/* ’Êí‚Ì•`‰æˆ— */
+	void OnChangeSetting();										/* è¨­å®šå¤‰æ›´ã‚’åæ˜ ã•ã›ã‚‹ */
+	void OnPaint( HDC, PAINTSTRUCT *, BOOL );			/* é€šå¸¸ã®æç”»å‡¦ç† */
+	void OnPaint2( HDC, PAINTSTRUCT *, BOOL );			/* é€šå¸¸ã®æç”»å‡¦ç† */
 	void DrawBackImage(HDC hdc, RECT& rcPaint, HDC hdcBgImg);
 	void OnTimer( HWND, UINT, UINT_PTR, DWORD );
-	//ƒEƒBƒ“ƒhƒE
-	void OnSize( int, int );							/* ƒEƒBƒ“ƒhƒEƒTƒCƒY‚Ì•ÏXˆ— */
+	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	void OnSize( int, int );							/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚µã‚¤ã‚ºã®å¤‰æ›´å‡¦ç† */
 	void OnMove( int, int, int, int );
-	//ƒtƒH[ƒJƒX
+	//ãƒ•ã‚©ãƒ¼ã‚«ã‚¹
 	void OnSetFocus( void );
 	void OnKillFocus( void );
-	//ƒXƒNƒ[ƒ‹
-	CLayoutInt  OnVScroll( int, int );							/* ‚’¼ƒXƒNƒ[ƒ‹ƒo[ƒƒbƒZ[ƒWˆ— */
-	CLayoutInt  OnHScroll( int, int );							/* …•½ƒXƒNƒ[ƒ‹ƒo[ƒƒbƒZ[ƒWˆ— */
-	//ƒ}ƒEƒX
-	void OnLBUTTONDOWN( WPARAM, int, int );				/* ƒ}ƒEƒX¶ƒ{ƒ^ƒ“‰Ÿ‰º */
-	void OnMOUSEMOVE( WPARAM, int, int );				/* ƒ}ƒEƒXˆÚ“®‚ÌƒƒbƒZ[ƒWˆ— */
-	void OnLBUTTONUP( WPARAM, int, int );				/* ƒ}ƒEƒX¶ƒ{ƒ^ƒ“ŠJ•ú‚ÌƒƒbƒZ[ƒWˆ— */
-	void OnLBUTTONDBLCLK( WPARAM, int , int );			/* ƒ}ƒEƒX¶ƒ{ƒ^ƒ“ƒ_ƒuƒ‹ƒNƒŠƒbƒN */
-	void OnRBUTTONDOWN( WPARAM, int, int );				/* ƒ}ƒEƒX‰Eƒ{ƒ^ƒ“‰Ÿ‰º */
-	void OnRBUTTONUP( WPARAM, int, int );				/* ƒ}ƒEƒX‰Eƒ{ƒ^ƒ“ŠJ•ú */
-	void OnMBUTTONDOWN( WPARAM, int, int );				/* ƒ}ƒEƒX’†ƒ{ƒ^ƒ“‰Ÿ‰º */
-	void OnMBUTTONUP( WPARAM, int, int );				/* ƒ}ƒEƒX’†ƒ{ƒ^ƒ“ŠJ•ú */
-	void OnXLBUTTONDOWN( WPARAM, int, int );			/* ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“1‰Ÿ‰º */
-	void OnXLBUTTONUP( WPARAM, int, int );				/* ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“1ŠJ•ú */		// 2009.01.17 nasukoji
-	void OnXRBUTTONDOWN( WPARAM, int, int );			/* ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“2‰Ÿ‰º */
-	void OnXRBUTTONUP( WPARAM, int, int );				/* ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“2ŠJ•ú */		// 2009.01.17 nasukoji
-	LRESULT OnMOUSEWHEEL( WPARAM, LPARAM );				//!< ‚’¼ƒ}ƒEƒXƒzƒC[ƒ‹‚ÌƒƒbƒZ[ƒWˆ—
-	LRESULT OnMOUSEHWHEEL( WPARAM, LPARAM );			//!< …•½ƒ}ƒEƒXƒzƒC[ƒ‹‚ÌƒƒbƒZ[ƒWˆ—
-	LRESULT OnMOUSEWHEEL2( WPARAM, LPARAM, bool, EFunctionCode );		//!< ƒ}ƒEƒXƒzƒC[ƒ‹‚ÌƒƒbƒZ[ƒWˆ—
-	bool IsSpecialScrollMode( int );					/* ƒL[Eƒ}ƒEƒXƒ{ƒ^ƒ“ó‘Ô‚æ‚èƒXƒNƒ[ƒ‹ƒ‚[ƒh‚ğ”»’è‚·‚é */		// 2009.01.17 nasukoji
+	//ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
+	CLayoutInt  OnVScroll( int, int );							/* å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
+	CLayoutInt  OnHScroll( int, int );							/* æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
+	//ãƒã‚¦ã‚¹
+	void OnLBUTTONDOWN( WPARAM, int, int );				/* ãƒã‚¦ã‚¹å·¦ãƒœã‚¿ãƒ³æŠ¼ä¸‹ */
+	void OnMOUSEMOVE( WPARAM, int, int );				/* ãƒã‚¦ã‚¹ç§»å‹•ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
+	void OnLBUTTONUP( WPARAM, int, int );				/* ãƒã‚¦ã‚¹å·¦ãƒœã‚¿ãƒ³é–‹æ”¾ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
+	void OnLBUTTONDBLCLK( WPARAM, int , int );			/* ãƒã‚¦ã‚¹å·¦ãƒœã‚¿ãƒ³ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ */
+	void OnRBUTTONDOWN( WPARAM, int, int );				/* ãƒã‚¦ã‚¹å³ãƒœã‚¿ãƒ³æŠ¼ä¸‹ */
+	void OnRBUTTONUP( WPARAM, int, int );				/* ãƒã‚¦ã‚¹å³ãƒœã‚¿ãƒ³é–‹æ”¾ */
+	void OnMBUTTONDOWN( WPARAM, int, int );				/* ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³æŠ¼ä¸‹ */
+	void OnMBUTTONUP( WPARAM, int, int );				/* ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³é–‹æ”¾ */
+	void OnXLBUTTONDOWN( WPARAM, int, int );			/* ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³1æŠ¼ä¸‹ */
+	void OnXLBUTTONUP( WPARAM, int, int );				/* ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³1é–‹æ”¾ */		// 2009.01.17 nasukoji
+	void OnXRBUTTONDOWN( WPARAM, int, int );			/* ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³2æŠ¼ä¸‹ */
+	void OnXRBUTTONUP( WPARAM, int, int );				/* ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³2é–‹æ”¾ */		// 2009.01.17 nasukoji
+	LRESULT OnMOUSEWHEEL( WPARAM, LPARAM );				//!< å‚ç›´ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
+	LRESULT OnMOUSEHWHEEL( WPARAM, LPARAM );			//!< æ°´å¹³ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
+	LRESULT OnMOUSEWHEEL2( WPARAM, LPARAM, bool, EFunctionCode );		//!< ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
+	bool IsSpecialScrollMode( int );					/* ã‚­ãƒ¼ãƒ»ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³çŠ¶æ…‹ã‚ˆã‚Šã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ¢ãƒ¼ãƒ‰ã‚’åˆ¤å®šã™ã‚‹ */		// 2009.01.17 nasukoji
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           •`‰æ                              //
+	//                           æç”»                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	// 2006.05.14 Moca  ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
-	// 2007.09.30 genta CompatibleDC‘€ìŠÖ”
+	// 2006.05.14 Moca  äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
+	// 2007.09.30 genta CompatibleDCæ“ä½œé–¢æ•°
 protected:
-	//! ƒƒWƒbƒNs‚ğ1s•`‰æ
+	//! ãƒ­ã‚¸ãƒƒã‚¯è¡Œã‚’1è¡Œæç”»
 	bool DrawLogicLine(
-		HDC				hdc,			//!< [in]     ì‰æ‘ÎÛ
-		DispPos*		pDispPos,		//!< [in,out] •`‰æ‚·‚é‰ÓŠA•`‰æŒ³ƒ\[ƒX
-		CLayoutInt		nLineTo			//!< [in]     ì‰æI—¹‚·‚éƒŒƒCƒAƒEƒgs”Ô†
+		HDC				hdc,			//!< [in]     ä½œç”»å¯¾è±¡
+		DispPos*		pDispPos,		//!< [in,out] æç”»ã™ã‚‹ç®‡æ‰€ã€æç”»å…ƒã‚½ãƒ¼ã‚¹
+		CLayoutInt		nLineTo			//!< [in]     ä½œç”»çµ‚äº†ã™ã‚‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œç•ªå·
 	);
 
-	//! ƒŒƒCƒAƒEƒgs‚ğ1s•`‰æ
+	//! ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã‚’1è¡Œæç”»
 	bool DrawLayoutLine(SColorStrategyInfo* pInfo);
 
-	//F•ª‚¯
+	//è‰²åˆ†ã‘
 public:
-	CColor3Setting GetColorIndex( const CLayout* pcLayout, CLayoutYInt nLineNum, int nIndex, SColorStrategyInfo* pInfo, bool bPrev = false );	/* w’èˆÊ’u‚ÌColorIndex‚Ìæ“¾ 02/12/13 ai */
+	CColor3Setting GetColorIndex( const CLayout* pcLayout, CLayoutYInt nLineNum, int nIndex, SColorStrategyInfo* pInfo, bool bPrev = false );	/* æŒ‡å®šä½ç½®ã®ColorIndexã®å–å¾— 02/12/13 ai */
 	void SetCurrentColor( CGraphics& gr, EColorIndexType, EColorIndexType, EColorIndexType);
 	COLORREF GetTextColorByColorInfo2(const ColorInfo& info, const ColorInfo& info2);
 	COLORREF GetBackColorByColorInfo2(const ColorInfo& info, const ColorInfo& info2);
 
-	//‰æ–Êƒoƒbƒtƒ@
+	//ç”»é¢ãƒãƒƒãƒ•ã‚¡
 protected:
-	bool CreateOrUpdateCompatibleBitmap( int cx, int cy );	//!< ƒƒ‚ƒŠBMP‚ğì¬‚Ü‚½‚ÍXV
+	bool CreateOrUpdateCompatibleBitmap( int cx, int cy );	//!< ãƒ¡ãƒ¢ãƒªBMPã‚’ä½œæˆã¾ãŸã¯æ›´æ–°
 	void UseCompatibleDC(BOOL fCache);
 public:
-	void DeleteCompatibleBitmap();							//!< ƒƒ‚ƒŠBMP‚ğíœ
+	void DeleteCompatibleBitmap();							//!< ãƒ¡ãƒ¢ãƒªBMPã‚’å‰Šé™¤
 
 public:
-	void DispTextSelected( HDC hdc, CLayoutInt nLineNum, const CMyPoint& ptXY, CLayoutInt nX_Layout );	/* ƒeƒLƒXƒg”½“] */
-	void RedrawAll();											/* ƒtƒH[ƒJƒXˆÚ“®‚ÌÄ•`‰æ */
-	void Redraw();										// 2001/06/21 asa-o Ä•`‰æ
+	void DispTextSelected( HDC hdc, CLayoutInt nLineNum, const CMyPoint& ptXY, CLayoutInt nX_Layout );	/* ãƒ†ã‚­ã‚¹ãƒˆåè»¢ */
+	void RedrawAll();											/* ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ç§»å‹•æ™‚ã®å†æç”» */
+	void Redraw();										// 2001/06/21 asa-o å†æç”»
 	void RedrawLines( CLayoutYInt top, CLayoutYInt bottom );
-	void CaretUnderLineON( bool, bool, bool );						/* ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌON */
-	void CaretUnderLineOFF( bool, bool, bool, bool );				/* ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌOFF */
+	void CaretUnderLineON( bool, bool, bool );						/* ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®ON */
+	void CaretUnderLineOFF( bool, bool, bool, bool );				/* ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®OFF */
 	bool GetDrawSwitch() const
 	{
 		return m_bDrawSWITCH;
@@ -285,39 +285,39 @@ public:
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ƒXƒNƒ[ƒ‹                           //
+	//                        ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	void AdjustScrollBars();											/* ƒXƒNƒ[ƒ‹ƒo[‚Ìó‘Ô‚ğXV‚·‚é */
-	BOOL CreateScrollBar();												/* ƒXƒNƒ[ƒ‹ƒo[ì¬ */	// 2006.12.19 ryoji
-	void DestroyScrollBar();											/* ƒXƒNƒ[ƒ‹ƒo[”jŠü */	// 2006.12.19 ryoji
-	CLayoutInt GetWrapOverhang( void ) const;							/* Ü‚è•Ô‚µŒ…ˆÈŒã‚Ì‚Ô‚ç‰º‚°—]”’ŒvZ */	// 2008.06.08 ryoji
-	CKetaXInt ViewColNumToWrapColNum( CLayoutXInt nViewColNum ) const;	/* u‰E’[‚ÅÜ‚è•Ô‚·v—p‚Éƒrƒ…[‚ÌŒ…”‚©‚çÜ‚è•Ô‚µŒ…”‚ğŒvZ‚·‚é */	// 2008.06.08 ryoji
-	CLayoutInt GetRightEdgeForScrollBar( void );								/* ƒXƒNƒ[ƒ‹ƒo[§Œä—p‚É‰E’[À•W‚ğæ“¾‚·‚é */		// 2009.08.28 nasukoji
+	void AdjustScrollBars();											/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®çŠ¶æ…‹ã‚’æ›´æ–°ã™ã‚‹ */
+	BOOL CreateScrollBar();												/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ä½œæˆ */	// 2006.12.19 ryoji
+	void DestroyScrollBar();											/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ç ´æ£„ */	// 2006.12.19 ryoji
+	CLayoutInt GetWrapOverhang( void ) const;							/* æŠ˜ã‚Šè¿”ã—æ¡ä»¥å¾Œã®ã¶ã‚‰ä¸‹ã’ä½™ç™½è¨ˆç®— */	// 2008.06.08 ryoji
+	CKetaXInt ViewColNumToWrapColNum( CLayoutXInt nViewColNum ) const;	/* ã€Œå³ç«¯ã§æŠ˜ã‚Šè¿”ã™ã€ç”¨ã«ãƒ“ãƒ¥ãƒ¼ã®æ¡æ•°ã‹ã‚‰æŠ˜ã‚Šè¿”ã—æ¡æ•°ã‚’è¨ˆç®—ã™ã‚‹ */	// 2008.06.08 ryoji
+	CLayoutInt GetRightEdgeForScrollBar( void );								/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼åˆ¶å¾¡ç”¨ã«å³ç«¯åº§æ¨™ã‚’å–å¾—ã™ã‚‹ */		// 2009.08.28 nasukoji
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           IME                               //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//	Aug. 25, 2002 genta protected->public‚ÉˆÚ“®
-	bool IsImeON( void );	// IME ON‚©	// 2006.12.04 ryoji
+	//	Aug. 25, 2002 genta protected->publicã«ç§»å‹•
+	bool IsImeON( void );	// IME ONã‹	// 2006.12.04 ryoji
 	
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ƒXƒNƒ[ƒ‹                           //
+	//                        ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	CLayoutInt  ScrollAtV( CLayoutInt );										/* w’èã’[sˆÊ’u‚ÖƒXƒNƒ[ƒ‹ */
-	CLayoutInt  ScrollAtH( CLayoutInt );										/* w’è¶’[Œ…ˆÊ’u‚ÖƒXƒNƒ[ƒ‹ */
-	//	From Here Sep. 11, 2004 genta ‚¸‚êˆÛ‚Ì“¯ŠúƒXƒNƒ[ƒ‹
-	CLayoutInt  ScrollByV( CLayoutInt vl ){	return ScrollAtV( GetTextArea().GetViewTopLine() + vl );}	/* w’èsƒXƒNƒ[ƒ‹*/
-	CLayoutInt  ScrollByH( CLayoutInt hl ){	return ScrollAtH( GetTextArea().GetViewLeftCol() + hl );}	/* w’èŒ…ƒXƒNƒ[ƒ‹ */
+	CLayoutInt  ScrollAtV( CLayoutInt );										/* æŒ‡å®šä¸Šç«¯è¡Œä½ç½®ã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ« */
+	CLayoutInt  ScrollAtH( CLayoutInt );										/* æŒ‡å®šå·¦ç«¯æ¡ä½ç½®ã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ« */
+	//	From Here Sep. 11, 2004 genta ãšã‚Œç¶­æŒã®åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
+	CLayoutInt  ScrollByV( CLayoutInt vl ){	return ScrollAtV( GetTextArea().GetViewTopLine() + vl );}	/* æŒ‡å®šè¡Œã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«*/
+	CLayoutInt  ScrollByH( CLayoutInt hl ){	return ScrollAtH( GetTextArea().GetViewLeftCol() + hl );}	/* æŒ‡å®šæ¡ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ« */
 	void ScrollDraw(CLayoutInt, CLayoutInt, const RECT&, const RECT&, const RECT&);
 	void MiniMapRedraw(bool);
 public:
-	void SyncScrollV( CLayoutInt );									/* ‚’¼“¯ŠúƒXƒNƒ[ƒ‹ */
-	void SyncScrollH( CLayoutInt );									/* …•½“¯ŠúƒXƒNƒ[ƒ‹ */
+	void SyncScrollV( CLayoutInt );									/* å‚ç›´åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ« */
+	void SyncScrollH( CLayoutInt );									/* æ°´å¹³åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ« */
 
-	void SetBracketPairPos( bool );								/* ‘ÎŠ‡ŒÊ‚Ì‹­’²•\¦ˆÊ’uİ’è 03/02/18 ai */
+	void SetBracketPairPos( bool );								/* å¯¾æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤ºä½ç½®è¨­å®š 03/02/18 ai */
 
 	void AutoScrollEnter();
 	void AutoScrollExit();
@@ -325,56 +325,56 @@ public:
 	void AutoScrollOnTimer();
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ‰ß‹‚ÌˆâY                           //
+	//                        éå»ã®éºç”£                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	void SetIMECompFormPos( void );								/* IME•ÒWƒGƒŠƒA‚ÌˆÊ’u‚ğ•ÏX */
-	void SetIMECompFormFont( void );							/* IME•ÒWƒGƒŠƒA‚Ì•\¦ƒtƒHƒ“ƒg‚ğ•ÏX */
+	void SetIMECompFormPos( void );								/* IMEç·¨é›†ã‚¨ãƒªã‚¢ã®ä½ç½®ã‚’å¤‰æ›´ */
+	void SetIMECompFormFont( void );							/* IMEç·¨é›†ã‚¨ãƒªã‚¢ã®è¡¨ç¤ºãƒ•ã‚©ãƒ³ãƒˆã‚’å¤‰æ›´ */
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                       ƒeƒLƒXƒg‘I‘ğ                          //
+	//                       ãƒ†ã‚­ã‚¹ãƒˆé¸æŠ                          //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	// 2002/01/19 novice public‘®«‚É•ÏX
-	bool GetSelectedDataSimple( CNativeW& );// ‘I‘ğ”ÍˆÍ‚Ìƒf[ƒ^‚ğæ“¾
+	// 2002/01/19 novice publicå±æ€§ã«å¤‰æ›´
+	bool GetSelectedDataSimple( CNativeW& );// é¸æŠç¯„å›²ã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾—
 	bool GetSelectedDataOne( CNativeW& cmemBuf, int nMaxLen );
-	bool GetSelectedData( CNativeW*, BOOL, const wchar_t*, BOOL, bool bAddCRLFWhenCopy, EEolType neweol = EOL_UNKNOWN);/* ‘I‘ğ”ÍˆÍ‚Ìƒf[ƒ^‚ğæ“¾ */
-	int IsCurrentPositionSelected( CLayoutPoint ptCaretPos );					/* w’èƒJ[ƒ\ƒ‹ˆÊ’u‚ª‘I‘ğƒGƒŠƒA“à‚É‚ ‚é‚© */
-	int IsCurrentPositionSelectedTEST( const CLayoutPoint& ptCaretPos, const CLayoutRange& sSelect ) const;/* w’èƒJ[ƒ\ƒ‹ˆÊ’u‚ª‘I‘ğƒGƒŠƒA“à‚É‚ ‚é‚© */
-	// 2006.07.09 genta sŒ…w’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“®(‘I‘ğ—Ìˆæ‚ğl—¶)
+	bool GetSelectedData( CNativeW*, BOOL, const wchar_t*, BOOL, bool bAddCRLFWhenCopy, EEolType neweol = EOL_UNKNOWN);/* é¸æŠç¯„å›²ã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
+	int IsCurrentPositionSelected( CLayoutPoint ptCaretPos );					/* æŒ‡å®šã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ãŒé¸æŠã‚¨ãƒªã‚¢å†…ã«ã‚ã‚‹ã‹ */
+	int IsCurrentPositionSelectedTEST( const CLayoutPoint& ptCaretPos, const CLayoutRange& sSelect ) const;/* æŒ‡å®šã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ãŒé¸æŠã‚¨ãƒªã‚¢å†…ã«ã‚ã‚‹ã‹ */
+	// 2006.07.09 genta è¡Œæ¡æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•(é¸æŠé ˜åŸŸã‚’è€ƒæ…®)
 	void MoveCursorSelecting( CLayoutPoint ptWk_CaretPos, bool bSelect, int = _CARETMARGINRATE );
-	void ConvSelectedArea( EFunctionCode );								/* ‘I‘ğƒGƒŠƒA‚ÌƒeƒLƒXƒg‚ğw’è•û–@‚Å•ÏŠ· */
-	//!w’èˆÊ’u‚Ü‚½‚Íw’è”ÍˆÍ‚ªƒeƒLƒXƒg‚Ì‘¶İ‚µ‚È‚¢ƒGƒŠƒA‚©ƒ`ƒFƒbƒN‚·‚é		// 2008.08.03 nasukoji
+	void ConvSelectedArea( EFunctionCode );								/* é¸æŠã‚¨ãƒªã‚¢ã®ãƒ†ã‚­ã‚¹ãƒˆã‚’æŒ‡å®šæ–¹æ³•ã§å¤‰æ› */
+	//!æŒ‡å®šä½ç½®ã¾ãŸã¯æŒ‡å®šç¯„å›²ãŒãƒ†ã‚­ã‚¹ãƒˆã®å­˜åœ¨ã—ãªã„ã‚¨ãƒªã‚¢ã‹ãƒã‚§ãƒƒã‚¯ã™ã‚‹		// 2008.08.03 nasukoji
 	bool IsEmptyArea( CLayoutPoint ptFrom, CLayoutPoint ptTo = CLayoutPoint( CLayoutInt(-1), CLayoutInt(-1) ), bool bSelect = false, bool bBoxSelect = false ) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         Šeí”»’è                            //
+	//                         å„ç¨®åˆ¤å®š                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	bool IsCurrentPositionURL( const CLayoutPoint& ptCaretPos, CLogicRange* pUrlRange, std::wstring* pwstrURL );/* ƒJ[ƒ\ƒ‹ˆÊ’u‚ÉURL‚ª—L‚éê‡‚Ì‚»‚Ì”ÍˆÍ‚ğ’²‚×‚é */
-	BOOL CheckTripleClick( CMyPoint ptMouse );							/* ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚ğƒ`ƒFƒbƒN‚·‚é */	// 2007.10.02 nasukoji
+	bool IsCurrentPositionURL( const CLayoutPoint& ptCaretPos, CLogicRange* pUrlRange, std::wstring* pwstrURL );/* ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«URLãŒæœ‰ã‚‹å ´åˆã®ãã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
+	BOOL CheckTripleClick( CMyPoint ptMouse );							/* ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹ */	// 2007.10.02 nasukoji
 
 
 
-	bool ExecCmd(const TCHAR*, int, const TCHAR*, COutputAdapter* = NULL ) ;							// qƒvƒƒZƒX‚Ì•W€o—Í‚ğƒŠƒ_ƒCƒŒƒNƒg‚·‚é
+	bool ExecCmd(const TCHAR*, int, const TCHAR*, COutputAdapter* = NULL ) ;							// å­ãƒ—ãƒ­ã‚»ã‚¹ã®æ¨™æº–å‡ºåŠ›ã‚’ãƒªãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆã™ã‚‹
 	void AddToCmdArr( const TCHAR* );
-	BOOL ChangeCurRegexp(bool bRedrawIfChanged= true);									// 2002.01.16 hor ³‹K•\Œ»‚ÌŒŸõƒpƒ^[ƒ“‚ğ•K—v‚É‰‚¶‚ÄXV‚·‚é(ƒ‰ƒCƒuƒ‰ƒŠ‚ªg—p‚Å‚«‚È‚¢‚Æ‚«‚ÍFALSE‚ğ•Ô‚·)
-	void SendStatusMessage( const TCHAR* msg );					// 2002.01.26 hor ŒŸõ^’uŠ·^ƒuƒbƒNƒ}[ƒNŒŸõ‚Ìó‘Ô‚ğƒXƒe[ƒ^ƒXƒo[‚É•\¦‚·‚é
-	LRESULT SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, bool bDocumentFeed = false);	/* Ä•ÏŠ·—p\‘¢‘Ì‚ğİ’è‚·‚é 2002.04.09 minfu */
-	LRESULT SetSelectionFromReonvert(const PRECONVERTSTRING pReconv, bool bUnicode);				/* Ä•ÏŠ·—p\‘¢‘Ì‚Ìî•ñ‚ğŒ³‚É‘I‘ğ”ÍˆÍ‚ğ•ÏX‚·‚é 2002.04.09 minfu */
+	BOOL ChangeCurRegexp(bool bRedrawIfChanged= true);									// 2002.01.16 hor æ­£è¦è¡¨ç¾ã®æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã‚’å¿…è¦ã«å¿œã˜ã¦æ›´æ–°ã™ã‚‹(ãƒ©ã‚¤ãƒ–ãƒ©ãƒªãŒä½¿ç”¨ã§ããªã„ã¨ãã¯FALSEã‚’è¿”ã™)
+	void SendStatusMessage( const TCHAR* msg );					// 2002.01.26 hor æ¤œç´¢ï¼ç½®æ›ï¼ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯æ¤œç´¢æ™‚ã®çŠ¶æ…‹ã‚’ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã«è¡¨ç¤ºã™ã‚‹
+	LRESULT SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, bool bDocumentFeed = false);	/* å†å¤‰æ›ç”¨æ§‹é€ ä½“ã‚’è¨­å®šã™ã‚‹ 2002.04.09 minfu */
+	LRESULT SetSelectionFromReonvert(const PRECONVERTSTRING pReconv, bool bUnicode);				/* å†å¤‰æ›ç”¨æ§‹é€ ä½“ã®æƒ…å ±ã‚’å…ƒã«é¸æŠç¯„å›²ã‚’å¤‰æ›´ã™ã‚‹ 2002.04.09 minfu */
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           D&D                               //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-public: /* ƒeƒXƒg—p‚ÉƒAƒNƒZƒX‘®«‚ğ•ÏX */
-	/* IDropTargetÀ‘• */
+public: /* ãƒ†ã‚¹ãƒˆç”¨ã«ã‚¢ã‚¯ã‚»ã‚¹å±æ€§ã‚’å¤‰æ›´ */
+	/* IDropTargetå®Ÿè£… */
 	STDMETHODIMP DragEnter( LPDATAOBJECT, DWORD, POINTL, LPDWORD );
 	STDMETHODIMP DragOver(DWORD, POINTL, LPDWORD );
 	STDMETHODIMP DragLeave( void );
 	STDMETHODIMP Drop( LPDATAOBJECT, DWORD, POINTL, LPDWORD );
-	STDMETHODIMP PostMyDropFiles( LPDATAOBJECT pDataObject );		/* “Æ©ƒhƒƒbƒvƒtƒ@ƒCƒ‹ƒƒbƒZ[ƒW‚ğƒ|ƒXƒg‚·‚é */	// 2008.06.20 ryoji
-	void OnMyDropFiles( HDROP hDrop );								/* “Æ©ƒhƒƒbƒvƒtƒ@ƒCƒ‹ƒƒbƒZ[ƒWˆ— */	// 2008.06.20 ryoji
+	STDMETHODIMP PostMyDropFiles( LPDATAOBJECT pDataObject );		/* ç‹¬è‡ªãƒ‰ãƒ­ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ãƒã‚¹ãƒˆã™ã‚‹ */	// 2008.06.20 ryoji
+	void OnMyDropFiles( HDROP hDrop );								/* ç‹¬è‡ªãƒ‰ãƒ­ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */	// 2008.06.20 ryoji
 	CLIPFORMAT GetAvailableClipFormat( LPDATAOBJECT pDataObject );
 	DWORD TranslateDropEffect( CLIPFORMAT cf, DWORD dwKeyState, POINTL pt, DWORD dwEffect );
 	bool IsDragSource( void );
@@ -386,49 +386,49 @@ public: /* ƒeƒXƒg—p‚ÉƒAƒNƒZƒX‘®«‚ğ•ÏX */
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           •ÒW                              //
+	//                           ç·¨é›†                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	/* w’èˆÊ’u‚Ìw’è’·ƒf[ƒ^íœ */
+	/* æŒ‡å®šä½ç½®ã®æŒ‡å®šé•·ãƒ‡ãƒ¼ã‚¿å‰Šé™¤ */
 	void DeleteData2(
 		const CLayoutPoint&	ptCaretPos,
 		CLogicInt			nDelLen,
 		CNativeW*			pcMem
 	);
 
-	/* Œ»İˆÊ’u‚Ìƒf[ƒ^íœ */
+	/* ç¾åœ¨ä½ç½®ã®ãƒ‡ãƒ¼ã‚¿å‰Šé™¤ */
 	void DeleteData( bool bRedraw );
 
-	/* Œ»İˆÊ’u‚Éƒf[ƒ^‚ğ‘}“ü */
+	/* ç¾åœ¨ä½ç½®ã«ãƒ‡ãƒ¼ã‚¿ã‚’æŒ¿å…¥ */
 	void InsertData_CEditView(
 		CLayoutPoint	ptInsertPos,
 		const wchar_t*	pData,
 		int				nDataLen,
-		CLayoutPoint*	pptNewPos,	//‘}“ü‚³‚ê‚½•”•ª‚ÌŸ‚ÌˆÊ’u‚Ìƒf[ƒ^ˆÊ’u
+		CLayoutPoint*	pptNewPos,	//æŒ¿å…¥ã•ã‚ŒãŸéƒ¨åˆ†ã®æ¬¡ã®ä½ç½®ã®ãƒ‡ãƒ¼ã‚¿ä½ç½®
 		bool			bRedraw
 	);
 
-	/* ƒf[ƒ^’uŠ· íœ&‘}“ü‚É‚àg‚¦‚é */
+	/* ãƒ‡ãƒ¼ã‚¿ç½®æ› å‰Šé™¤&æŒ¿å…¥ã«ã‚‚ä½¿ãˆã‚‹ */
 	void ReplaceData_CEditView(
-		const CLayoutRange&	sDelRange,			// íœ”ÍˆÍBƒŒƒCƒAƒEƒg’PˆÊB
-		const wchar_t*		pInsData,			// ‘}“ü‚·‚éƒf[ƒ^
-		CLogicInt			nInsDataLen,		// ‘}“ü‚·‚éƒf[ƒ^‚Ì’·‚³
+		const CLayoutRange&	sDelRange,			// å‰Šé™¤ç¯„å›²ã€‚ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã€‚
+		const wchar_t*		pInsData,			// æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿
+		CLogicInt			nInsDataLen,		// æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã®é•·ã•
 		bool				bRedraw,
 		COpeBlk*			pcOpeBlk,
 		bool				bFastMode = false,
 		const CLogicRange*	psDelRangeLogicFast = NULL
 	);
 	void ReplaceData_CEditView2(
-		const CLogicRange&	sDelRange,			// íœ”ÍˆÍBƒƒWƒbƒN’PˆÊB
-		const wchar_t*		pInsData,			// ‘}“ü‚·‚éƒf[ƒ^
-		CLogicInt			nInsDataLen,		// ‘}“ü‚·‚éƒf[ƒ^‚Ì’·‚³
+		const CLogicRange&	sDelRange,			// å‰Šé™¤ç¯„å›²ã€‚ãƒ­ã‚¸ãƒƒã‚¯å˜ä½ã€‚
+		const wchar_t*		pInsData,			// æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿
+		CLogicInt			nInsDataLen,		// æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã®é•·ã•
 		bool				bRedraw,
 		COpeBlk*			pcOpeBlk,
 		bool				bFastMode = false
 	);
 	bool ReplaceData_CEditView3(
-		CLayoutRange	sDelRange,			// íœ”ÍˆÍBƒŒƒCƒAƒEƒg’PˆÊB
-		COpeLineData*	pcmemCopyOfDeleted,	// íœ‚³‚ê‚½ƒf[ƒ^‚ÌƒRƒs[(NULL‰Â”\)
+		CLayoutRange	sDelRange,			// å‰Šé™¤ç¯„å›²ã€‚ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã€‚
+		COpeLineData*	pcmemCopyOfDeleted,	// å‰Šé™¤ã•ã‚ŒãŸãƒ‡ãƒ¼ã‚¿ã®ã‚³ãƒ”ãƒ¼(NULLå¯èƒ½)
 		COpeLineData*	pInsData,
 		bool			bRedraw,
 		COpeBlk*		pcOpeBlk,
@@ -437,31 +437,31 @@ public:
 		bool			bFastMode = false,
 		const CLogicRange*	psDelRangeLogicFast = NULL
 	);
-	void RTrimPrevLine( void );		/* 2005.10.11 ryoji ‘O‚Ìs‚É‚ ‚é––”ö‚Ì‹ó”’‚ğíœ */
+	void RTrimPrevLine( void );		/* 2005.10.11 ryoji å‰ã®è¡Œã«ã‚ã‚‹æœ«å°¾ã®ç©ºç™½ã‚’å‰Šé™¤ */
 
-	//	Oct. 2, 2005 genta ‘}“üƒ‚[ƒh‚Ìİ’èEæ“¾
+	//	Oct. 2, 2005 genta æŒ¿å…¥ãƒ¢ãƒ¼ãƒ‰ã®è¨­å®šãƒ»å–å¾—
 	bool IsInsMode() const;
 	void SetInsMode(bool);
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ŒŸõ                              //
+	//                           æ¤œç´¢                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//2004.10.13 ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`ŠÖŒW
+	//2004.10.13 ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒé–¢ä¿‚
 	void TranslateCommand_isearch( EFunctionCode&, bool&, LPARAM&, LPARAM&, LPARAM&, LPARAM& );
 	bool ProcessCommand_isearch( int, bool, LPARAM, LPARAM, LPARAM, LPARAM );
 
-	//	Jan. 10, 2005 genta HandleCommand‚©‚çgrepŠÖ˜Aˆ—‚ğ•ª—£
+	//	Jan. 10, 2005 genta HandleCommandã‹ã‚‰grepé–¢é€£å‡¦ç†ã‚’åˆ†é›¢
 	void TranslateCommand_grep( EFunctionCode&, bool&, LPARAM&, LPARAM&, LPARAM&, LPARAM& );
 
-	//	Jan. 10, 2005 ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`
+	//	Jan. 10, 2005 ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ
 	bool IsISearchEnabled(int nCommand) const;
 
 	BOOL KeySearchCore( const CNativeW* pcmemCurText );	// 2006.04.10 fon
 	bool MiniMapCursorLineTip( POINT* po, RECT* rc, bool* pbHide );
 
-	/*!	CEditView::KeyWordHelpSearchDict‚ÌƒR[ƒ‹Œ³w’è—pƒ[ƒJƒ‹ID
-		@date 2006.04.10 fon V‹Kì¬
+	/*!	CEditView::KeyWordHelpSearchDictã®ã‚³ãƒ¼ãƒ«å…ƒæŒ‡å®šç”¨ãƒ­ãƒ¼ã‚«ãƒ«ID
+		@date 2006.04.10 fon æ–°è¦ä½œæˆ
 	*/
 	enum LID_SKH {
 		LID_SKH_ONTIMER		= 1,	/*!< CEditView::OnTimer */
@@ -469,13 +469,13 @@ public:
 	};
 	BOOL KeyWordHelpSearchDict( LID_SKH nID, POINT* po, RECT* rc );	// 2006.04.10 fon
 
-	int IsSearchString( const CStringRef& cStr, CLogicInt, CLogicInt*, CLogicInt* ) const;	/* Œ»İˆÊ’u‚ªŒŸõ•¶š—ñ‚ÉŠY“–‚·‚é‚© */	//2002.02.08 hor ˆø”’Ç‰Á
+	int IsSearchString( const CStringRef& cStr, CLogicInt, CLogicInt*, CLogicInt* ) const;	/* ç¾åœ¨ä½ç½®ãŒæ¤œç´¢æ–‡å­—åˆ—ã«è©²å½“ã™ã‚‹ã‹ */	//2002.02.08 hor å¼•æ•°è¿½åŠ 
 
-	void GetCurrentTextForSearch( CNativeW&, bool bStripMaxPath = true, bool bTrimSpaceTab = false );			/* Œ»İƒJ[ƒ\ƒ‹ˆÊ’u’PŒê‚Ü‚½‚Í‘I‘ğ”ÍˆÍ‚æ‚èŒŸõ“™‚ÌƒL[‚ğæ“¾ */
-	bool GetCurrentTextForSearchDlg( CNativeW&, bool bGetHistory = false );		/* Œ»İƒJ[ƒ\ƒ‹ˆÊ’u’PŒê‚Ü‚½‚Í‘I‘ğ”ÍˆÍ‚æ‚èŒŸõ“™‚ÌƒL[‚ğæ“¾iƒ_ƒCƒAƒƒO—pj 2006.08.23 ryoji */
+	void GetCurrentTextForSearch( CNativeW&, bool bStripMaxPath = true, bool bTrimSpaceTab = false );			/* ç¾åœ¨ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å˜èªã¾ãŸã¯é¸æŠç¯„å›²ã‚ˆã‚Šæ¤œç´¢ç­‰ã®ã‚­ãƒ¼ã‚’å–å¾— */
+	bool GetCurrentTextForSearchDlg( CNativeW&, bool bGetHistory = false );		/* ç¾åœ¨ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å˜èªã¾ãŸã¯é¸æŠç¯„å›²ã‚ˆã‚Šæ¤œç´¢ç­‰ã®ã‚­ãƒ¼ã‚’å–å¾—ï¼ˆãƒ€ã‚¤ã‚¢ãƒ­ã‚°ç”¨ï¼‰ 2006.08.23 ryoji */
 
 private:
-	/* ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ` */ 
+	/* ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ */ 
 	//2004.10.24 isearch migemo
 	void ISearchEnter( ESearchMode mode, ESearchDirection direction);
 	void ISearchExit();
@@ -487,49 +487,49 @@ private:
 	void ISearchSetStatusMsg(CNativeT* msg) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           Š‡ŒÊ                              //
+	//                           æ‹¬å¼§                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	//	Jun. 16, 2000 genta
-	bool  SearchBracket( const CLayoutPoint& ptPos, CLayoutPoint* pptLayoutNew, int* mode );	// ‘ÎŠ‡ŒÊ‚ÌŒŸõ		// mode‚Ì’Ç‰Á 02/09/18 ai
+	bool  SearchBracket( const CLayoutPoint& ptPos, CLayoutPoint* pptLayoutNew, int* mode );	// å¯¾æ‹¬å¼§ã®æ¤œç´¢		// modeã®è¿½åŠ  02/09/18 ai
 	bool  SearchBracketForward( CLogicPoint ptPos, CLayoutPoint* pptLayoutNew,
-						const wchar_t* upChar, const wchar_t* dnChar, int* mode );	//	‘ÎŠ‡ŒÊ‚Ì‘O•ûŒŸõ	// mode‚Ì’Ç‰Á 02/09/19 ai
+						const wchar_t* upChar, const wchar_t* dnChar, int* mode );	//	å¯¾æ‹¬å¼§ã®å‰æ–¹æ¤œç´¢	// modeã®è¿½åŠ  02/09/19 ai
 	bool  SearchBracketBackward( CLogicPoint ptPos, CLayoutPoint* pptLayoutNew,
-						const wchar_t* dnChar, const wchar_t* upChar, int* mode );	//	‘ÎŠ‡ŒÊ‚ÌŒã•ûŒŸõ	// mode‚Ì’Ç‰Á 02/09/19 ai
-	void DrawBracketPair( bool );								/* ‘ÎŠ‡ŒÊ‚Ì‹­’²•\¦ 02/09/18 ai */
-	bool IsBracket( const wchar_t*, CLogicInt, CLogicInt );					/* Š‡ŒÊ”»’è 03/01/09 ai */
+						const wchar_t* dnChar, const wchar_t* upChar, int* mode );	//	å¯¾æ‹¬å¼§ã®å¾Œæ–¹æ¤œç´¢	// modeã®è¿½åŠ  02/09/19 ai
+	void DrawBracketPair( bool );								/* å¯¾æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤º 02/09/18 ai */
+	bool IsBracket( const wchar_t*, CLogicInt, CLogicInt );					/* æ‹¬å¼§åˆ¤å®š 03/01/09 ai */
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           •âŠ®                              //
+	//                           è£œå®Œ                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	/* x‰‡ */
-	//	Jan. 10, 2005 genta HandleCommand‚©‚ç•âŠ®ŠÖ˜Aˆ—‚ğ•ª—£
+	/* æ”¯æ´ */
+	//	Jan. 10, 2005 genta HandleCommandã‹ã‚‰è£œå®Œé–¢é€£å‡¦ç†ã‚’åˆ†é›¢
 	void PreprocessCommand_hokan( int nCommand );
 	void PostprocessCommand_hokan(void);
 
-	// •âŠ®ƒEƒBƒ“ƒhƒE‚ğ•\¦‚·‚éBCtrl+Space‚âA•¶š‚Ì“ü—Í/íœ‚ÉŒÄ‚Ño‚³‚ê‚Ü‚·B YAZAKI 2002/03/11
+	// è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¡¨ç¤ºã™ã‚‹ã€‚Ctrl+Spaceã‚„ã€æ–‡å­—ã®å…¥åŠ›/å‰Šé™¤æ™‚ã«å‘¼ã³å‡ºã•ã‚Œã¾ã™ã€‚ YAZAKI 2002/03/11
 	void ShowHokanMgr( CNativeW& cmemData, BOOL bAutoDecided );
 
 	int HokanSearchByFile( const wchar_t*, bool, vector_ex<std::wstring>&, int ); // 2003.06.25 Moca
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ƒWƒƒƒ“ƒv                            //
+	//                         ã‚¸ãƒ£ãƒ³ãƒ—                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//@@@ 2003.04.13 MIK, Apr. 21, 2003 genta bClose’Ç‰Á
-	//	Feb. 17, 2007 genta ‘Š‘ÎƒpƒX‚ÌŠî€ƒfƒBƒŒƒNƒgƒŠw¦‚ğ’Ç‰Á
+	//@@@ 2003.04.13 MIK, Apr. 21, 2003 genta bCloseè¿½åŠ 
+	//	Feb. 17, 2007 genta ç›¸å¯¾ãƒ‘ã‚¹ã®åŸºæº–ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªæŒ‡ç¤ºã‚’è¿½åŠ 
 	bool TagJumpSub( const TCHAR* pszJumpToFile, CMyPoint ptJumpTo,bool bClose = false,
 		bool bRelFromIni = false, bool* pbJumpToSelf = NULL );
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ƒƒjƒ…[                            //
+	//                         ãƒ¡ãƒ‹ãƒ¥ãƒ¼                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	int	CreatePopUpMenu_R( void );		/* ƒ|ƒbƒvƒAƒbƒvƒƒjƒ…[(‰EƒNƒŠƒbƒN) */
-	int	CreatePopUpMenuSub( HMENU hMenu, int nMenuIdx, int* pParentMenus, EKeyHelpRMenuType eRmenuType );		/* ƒ|ƒbƒvƒAƒbƒvƒƒjƒ…[ */
+	int	CreatePopUpMenu_R( void );		/* ãƒãƒƒãƒ—ã‚¢ãƒƒãƒ—ãƒ¡ãƒ‹ãƒ¥ãƒ¼(å³ã‚¯ãƒªãƒƒã‚¯) */
+	int	CreatePopUpMenuSub( HMENU hMenu, int nMenuIdx, int* pParentMenus, EKeyHelpRMenuType eRmenuType );		/* ãƒãƒƒãƒ—ã‚¢ãƒƒãƒ—ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */
 	void AddKeyHelpMenu( HMENU, EKeyHelpRMenuType );
 
 
@@ -538,25 +538,25 @@ public:
 	//                           DIFF                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	void AnalyzeDiffInfo( const char*, int );	/* DIFFî•ñ‚Ì‰ğÍ */	//@@@ 2002.05.25 MIK
-	BOOL MakeDiffTmpFile( TCHAR*, HWND, ECodeType, bool );	/* DIFFˆêƒtƒ@ƒCƒ‹ì¬ */	//@@@ 2002.05.28 MIK	//2005.10.29 maru
+	void AnalyzeDiffInfo( const char*, int );	/* DIFFæƒ…å ±ã®è§£æ */	//@@@ 2002.05.25 MIK
+	BOOL MakeDiffTmpFile( TCHAR*, HWND, ECodeType, bool );	/* DIFFä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ä½œæˆ */	//@@@ 2002.05.28 MIK	//2005.10.29 maru
 	BOOL MakeDiffTmpFile2( TCHAR*, const TCHAR*, ECodeType, ECodeType );
-	void ViewDiffInfo( const TCHAR*, const TCHAR*, int, bool );		/* DIFF·•ª•\¦ */		//2005.10.29 maru
+	void ViewDiffInfo( const TCHAR*, const TCHAR*, int, bool );		/* DIFFå·®åˆ†è¡¨ç¤º */		//2005.10.29 maru
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           —š—ğ                              //
+	//                           å±¥æ­´                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	//	Aug. 31, 2000 genta
-	void AddCurrentLineToHistory(void);	//Œ»İs‚ğ—š—ğ‚É’Ç‰Á‚·‚é
+	void AddCurrentLineToHistory(void);	//ç¾åœ¨è¡Œã‚’å±¥æ­´ã«è¿½åŠ ã™ã‚‹
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                          ‚»‚Ì‘¼                             //
+	//                          ãã®ä»–                             //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	BOOL OPEN_ExtFromtoExt( BOOL, BOOL, const TCHAR* [], const TCHAR* [], int, int, const TCHAR* ); // w’èŠg’£q‚Ìƒtƒ@ƒCƒ‹‚É‘Î‰‚·‚éƒtƒ@ƒCƒ‹‚ğŠJ‚­•â•ŠÖ” // 2003.08.12 Moca
-	//	Jan.  8, 2006 genta Ü‚è•Ô‚µƒgƒOƒ‹“®ì”»’è
+	BOOL OPEN_ExtFromtoExt( BOOL, BOOL, const TCHAR* [], const TCHAR* [], int, int, const TCHAR* ); // æŒ‡å®šæ‹¡å¼µå­ã®ãƒ•ã‚¡ã‚¤ãƒ«ã«å¯¾å¿œã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ãè£œåŠ©é–¢æ•° // 2003.08.12 Moca
+	//	Jan.  8, 2006 genta æŠ˜ã‚Šè¿”ã—ãƒˆã‚°ãƒ«å‹•ä½œåˆ¤å®š
 	enum TOGGLE_WRAP_ACTION {
 		TGWRAP_NONE = 0,
 		TGWRAP_FULL,
@@ -564,22 +564,22 @@ public:
 		TGWRAP_PROP,
 	};
 	TOGGLE_WRAP_ACTION GetWrapMode( CKetaXInt* newKetas );
-	void SmartIndent_CPP( wchar_t );	/* C/C++ƒXƒ}[ƒgƒCƒ“ƒfƒ“ƒgˆ— */
-	/* ƒRƒ}ƒ“ƒh‘€ì */
-	void SetFont( void );										/* ƒtƒHƒ“ƒg‚Ì•ÏX */
-	void SplitBoxOnOff( BOOL, BOOL, BOOL );						/* cE‰¡‚Ì•ªŠ„ƒ{ƒbƒNƒXEƒTƒCƒYƒ{ƒbƒNƒX‚Ì‚n‚m^‚n‚e‚e */
+	void SmartIndent_CPP( wchar_t );	/* C/C++ã‚¹ãƒãƒ¼ãƒˆã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆå‡¦ç† */
+	/* ã‚³ãƒãƒ³ãƒ‰æ“ä½œ */
+	void SetFont( void );										/* ãƒ•ã‚©ãƒ³ãƒˆã®å¤‰æ›´ */
+	void SplitBoxOnOff( BOOL, BOOL, BOOL );						/* ç¸¦ãƒ»æ¨ªã®åˆ†å‰²ãƒœãƒƒã‚¯ã‚¹ãƒ»ã‚µã‚¤ã‚ºãƒœãƒƒã‚¯ã‚¹ã®ï¼¯ï¼®ï¼ï¼¯ï¼¦ï¼¦ */
 
 //	2001/06/18 asa-o
-	bool  ShowKeywordHelp( POINT po, LPCWSTR pszHelp, LPRECT prcHokanWin);	// •âŠ®ƒEƒBƒ“ƒhƒE—p‚ÌƒL[ƒ[ƒhƒwƒ‹ƒv•\¦
-	void SetUndoBuffer( bool bPaintLineNumber = false );			// ƒAƒ“ƒhƒDƒoƒbƒtƒ@‚Ìˆ—
+	bool  ShowKeywordHelp( POINT po, LPCWSTR pszHelp, LPRECT prcHokanWin);	// è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ç”¨ã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—è¡¨ç¤º
+	void SetUndoBuffer( bool bPaintLineNumber = false );			// ã‚¢ãƒ³ãƒ‰ã‚¥ãƒãƒƒãƒ•ã‚¡ã®å‡¦ç†
 	HWND StartProgress();
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ƒAƒNƒZƒT                            //
+	//                         ã‚¢ã‚¯ã‚»ã‚µ                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//å—v\¬•”•iƒAƒNƒZƒX
+	//ä¸»è¦æ§‹æˆéƒ¨å“ã‚¢ã‚¯ã‚»ã‚¹
 	CTextArea& GetTextArea(){ assert(m_pcTextArea); return *m_pcTextArea; }
 	const CTextArea& GetTextArea() const{ assert(m_pcTextArea); return *m_pcTextArea; }
 	CCaret& GetCaret(){ assert(m_pcCaret); return *m_pcCaret; }
@@ -587,146 +587,146 @@ public:
 	CRuler& GetRuler(){ assert(m_pcRuler); return *m_pcRuler; }
 	const CRuler& GetRuler() const{ assert(m_pcRuler); return *m_pcRuler; }
 
-	//å—v‘®«ƒAƒNƒZƒX
+	//ä¸»è¦å±æ€§ã‚¢ã‚¯ã‚»ã‚¹
 	CTextMetrics& GetTextMetrics(){ return m_cTextMetrics; }
 	const CTextMetrics& GetTextMetrics() const{ return m_cTextMetrics; }
 	CViewSelect& GetSelectionInfo(){ return m_cViewSelect; }
 	const CViewSelect& GetSelectionInfo() const{ return m_cViewSelect; }
 
-	//å—vƒIƒuƒWƒFƒNƒgƒAƒNƒZƒX
+	//ä¸»è¦ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚¢ã‚¯ã‚»ã‚¹
 	CViewFont& GetFontset(){ assert(m_pcViewFont); return *m_pcViewFont; }
 	const CViewFont& GetFontset() const{ assert(m_pcViewFont); return *m_pcViewFont; }
 
-	//å—vƒwƒ‹ƒpƒAƒNƒZƒX
+	//ä¸»è¦ãƒ˜ãƒ«ãƒ‘ã‚¢ã‚¯ã‚»ã‚¹
 	const CViewParser& GetParser() const{ return m_cParser; }
 	const CTextDrawer& GetTextDrawer() const{ return m_cTextDrawer; }
 	CViewCommander& GetCommander(){ return m_cCommander; }
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                       ƒƒ“ƒo•Ï”ŒQ                          //
+	//                       ãƒ¡ãƒ³ãƒå¤‰æ•°ç¾¤                          //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	//QÆ
-	CEditWnd*		m_pcEditWnd;	//!< ƒEƒBƒ“ƒhƒE
-	CEditDoc*		m_pcEditDoc;	//!< ƒhƒLƒ…ƒƒ“ƒg
+	//å‚ç…§
+	CEditWnd*		m_pcEditWnd;	//!< ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	CEditDoc*		m_pcEditDoc;	//!< ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ
 	const STypeConfig*	m_pTypeData;
 
-	//å—v\¬•”•i
+	//ä¸»è¦æ§‹æˆéƒ¨å“
 	CTextArea*		m_pcTextArea;
 	CCaret*			m_pcCaret;
 	CRuler*			m_pcRuler;
 
-	//å—v‘®«
+	//ä¸»è¦å±æ€§
 	CTextMetrics	m_cTextMetrics;
 	CViewSelect		m_cViewSelect;
 
-	//å—vƒIƒuƒWƒFƒNƒg
+	//ä¸»è¦ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 	CViewFont*		m_pcViewFont;
 
-	//å—vƒwƒ‹ƒp
+	//ä¸»è¦ãƒ˜ãƒ«ãƒ‘
 	CViewParser		m_cParser;
 	CTextDrawer		m_cTextDrawer;
 	CViewCommander	m_cCommander;
 
 public:
-	//ƒEƒBƒ“ƒhƒE
-	HWND			m_hwndParent;		/* eƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹ */
-	HWND			m_hwndVScrollBar;	/* ‚’¼ƒXƒNƒ[ƒ‹ƒo[ƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹ */
-	int				m_nVScrollRate;		/* ‚’¼ƒXƒNƒ[ƒ‹ƒo[‚ÌkÚ */
-	HWND			m_hwndHScrollBar;	/* …•½ƒXƒNƒ[ƒ‹ƒo[ƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹ */
-	HWND			m_hwndSizeBox;		/* ƒTƒCƒYƒ{ƒbƒNƒXƒEƒBƒ“ƒhƒEƒnƒ“ƒhƒ‹ */
-	CSplitBoxWnd*	m_pcsbwVSplitBox;	/* ‚’¼•ªŠ„ƒ{ƒbƒNƒX */
-	CSplitBoxWnd*	m_pcsbwHSplitBox;	/* …•½•ªŠ„ƒ{ƒbƒNƒX */
-	CAutoScrollWnd	m_cAutoScrollWnd;	//!< ƒI[ƒgƒXƒNƒ[ƒ‹
+	//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	HWND			m_hwndParent;		/* è¦ªã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ« */
+	HWND			m_hwndVScrollBar;	/* å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ« */
+	int				m_nVScrollRate;		/* å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®ç¸®å°º */
+	HWND			m_hwndHScrollBar;	/* æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ« */
+	HWND			m_hwndSizeBox;		/* ã‚µã‚¤ã‚ºãƒœãƒƒã‚¯ã‚¹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒãƒ³ãƒ‰ãƒ« */
+	CSplitBoxWnd*	m_pcsbwVSplitBox;	/* å‚ç›´åˆ†å‰²ãƒœãƒƒã‚¯ã‚¹ */
+	CSplitBoxWnd*	m_pcsbwHSplitBox;	/* æ°´å¹³åˆ†å‰²ãƒœãƒƒã‚¯ã‚¹ */
+	CAutoScrollWnd	m_cAutoScrollWnd;	//!< ã‚ªãƒ¼ãƒˆã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
 
 public:
-	//•`‰æ
+	//æç”»
 	bool			m_bDrawSWITCH;
-	COLORREF		m_crBack;				/* ƒeƒLƒXƒg‚Ì”wŒiF */			// 2006.12.07 ryoji
-	COLORREF		m_crBack2;				// ƒeƒLƒXƒg‚Ì”wŒi(ƒLƒƒƒŒƒbƒg—p)
-	CLayoutInt		m_nOldUnderLineY;		// ‘O‰ñì‰æ‚µ‚½ƒJ[ƒ\ƒ‹ƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ÌˆÊ’u 0–¢–=”ñ•\¦
+	COLORREF		m_crBack;				/* ãƒ†ã‚­ã‚¹ãƒˆã®èƒŒæ™¯è‰² */			// 2006.12.07 ryoji
+	COLORREF		m_crBack2;				// ãƒ†ã‚­ã‚¹ãƒˆã®èƒŒæ™¯(ã‚­ãƒ£ãƒ¬ãƒƒãƒˆç”¨)
+	CLayoutInt		m_nOldUnderLineY;		// å‰å›ä½œç”»ã—ãŸã‚«ãƒ¼ã‚½ãƒ«ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã®ä½ç½® 0æœªæº€=éè¡¨ç¤º
 	CLayoutInt		m_nOldUnderLineYBg;
 	int				m_nOldUnderLineYMargin;
 	int				m_nOldUnderLineYHeight;
 	int				m_nOldUnderLineYHeightReal;
-	int				m_nOldCursorLineX;		/* ‘O‰ñì‰æ‚µ‚½ƒJ[ƒ\ƒ‹ˆÊ’ucü‚ÌˆÊ’u */ // 2007.09.09 Moca
-	int				m_nOldCursorVLineWidth;	// ƒJ[ƒ\ƒ‹ˆÊ’ucü‚Ì‘¾‚³(px)
+	int				m_nOldCursorLineX;		/* å‰å›ä½œç”»ã—ãŸã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·šã®ä½ç½® */ // 2007.09.09 Moca
+	int				m_nOldCursorVLineWidth;	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·šã®å¤ªã•(px)
 
 public:
-	//‰æ–Êƒoƒbƒtƒ@
-	HDC				m_hdcCompatDC;		/* Ä•`‰æ—pƒRƒ“ƒpƒ`ƒuƒ‹‚c‚b */
-	HBITMAP			m_hbmpCompatBMP;	/* Ä•`‰æ—pƒƒ‚ƒŠ‚a‚l‚o */
-	HBITMAP			m_hbmpCompatBMPOld;	/* Ä•`‰æ—pƒƒ‚ƒŠ‚a‚l‚o(OLD) */
-	int				m_nCompatBMPWidth;  /* Äì‰æ—pƒƒ‚ƒŠ‚a‚l‚o‚Ì• */	// 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
-	int				m_nCompatBMPHeight; /* Äì‰æ—pƒƒ‚ƒŠ‚a‚l‚o‚Ì‚‚³ */	// 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
+	//ç”»é¢ãƒãƒƒãƒ•ã‚¡
+	HDC				m_hdcCompatDC;		/* å†æç”»ç”¨ã‚³ãƒ³ãƒ‘ãƒãƒ–ãƒ«ï¼¤ï¼£ */
+	HBITMAP			m_hbmpCompatBMP;	/* å†æç”»ç”¨ãƒ¡ãƒ¢ãƒªï¼¢ï¼­ï¼° */
+	HBITMAP			m_hbmpCompatBMPOld;	/* å†æç”»ç”¨ãƒ¡ãƒ¢ãƒªï¼¢ï¼­ï¼°(OLD) */
+	int				m_nCompatBMPWidth;  /* å†ä½œç”»ç”¨ãƒ¡ãƒ¢ãƒªï¼¢ï¼­ï¼°ã®å¹… */	// 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
+	int				m_nCompatBMPHeight; /* å†ä½œç”»ç”¨ãƒ¡ãƒ¢ãƒªï¼¢ï¼­ï¼°ã®é«˜ã• */	// 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
 
 public:
 	//D&D
 	CDropTarget*	m_pcDropTarget;
-	BOOL			m_bDragMode;	/* ‘I‘ğƒeƒLƒXƒg‚Ìƒhƒ‰ƒbƒO’†‚© */
-	CLIPFORMAT		m_cfDragData;	/* ƒhƒ‰ƒbƒOƒf[ƒ^‚ÌƒNƒŠƒbƒvŒ`® */	// 2008.06.20 ryoji
-	BOOL			m_bDragBoxData;	/* ƒhƒ‰ƒbƒOƒf[ƒ^‚Í‹éŒ`‚© */
-	CLayoutPoint	m_ptCaretPos_DragEnter;			/* ƒhƒ‰ƒbƒOŠJn‚ÌƒJ[ƒ\ƒ‹ˆÊ’u */	// 2007.12.09 ryoji
-	CLayoutInt		m_nCaretPosX_Prev_DragEnter;	/* ƒhƒ‰ƒbƒOŠJn‚ÌXÀ•W‹L‰¯ */	// 2007.12.09 ryoji
+	BOOL			m_bDragMode;	/* é¸æŠãƒ†ã‚­ã‚¹ãƒˆã®ãƒ‰ãƒ©ãƒƒã‚°ä¸­ã‹ */
+	CLIPFORMAT		m_cfDragData;	/* ãƒ‰ãƒ©ãƒƒã‚°ãƒ‡ãƒ¼ã‚¿ã®ã‚¯ãƒªãƒƒãƒ—å½¢å¼ */	// 2008.06.20 ryoji
+	BOOL			m_bDragBoxData;	/* ãƒ‰ãƒ©ãƒƒã‚°ãƒ‡ãƒ¼ã‚¿ã¯çŸ©å½¢ã‹ */
+	CLayoutPoint	m_ptCaretPos_DragEnter;			/* ãƒ‰ãƒ©ãƒƒã‚°é–‹å§‹æ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½® */	// 2007.12.09 ryoji
+	CLayoutInt		m_nCaretPosX_Prev_DragEnter;	/* ãƒ‰ãƒ©ãƒƒã‚°é–‹å§‹æ™‚ã®Xåº§æ¨™è¨˜æ†¶ */	// 2007.12.09 ryoji
 
-	//Š‡ŒÊ
-	CLogicPoint		m_ptBracketCaretPos_PHY;	// ‘OƒJ[ƒ\ƒ‹ˆÊ’u‚ÌŠ‡ŒÊ‚ÌˆÊ’u (‰üs’PˆÊsæ“ª‚©‚ç‚ÌƒoƒCƒg”(0ŠJn), ‰üs’PˆÊs‚Ìs”Ô†(0ŠJn))
-	CLogicPoint		m_ptBracketPairPos_PHY;		// ‘ÎŠ‡ŒÊ‚ÌˆÊ’u (‰üs’PˆÊsæ“ª‚©‚ç‚ÌƒoƒCƒg”(0ŠJn), ‰üs’PˆÊs‚Ìs”Ô†(0ŠJn))
-	BOOL			m_bDrawBracketPairFlag;		/* ‘ÎŠ‡ŒÊ‚Ì‹­’²•\¦‚ğs‚È‚¤‚© */						// 03/02/18 ai
+	//æ‹¬å¼§
+	CLogicPoint		m_ptBracketCaretPos_PHY;	// å‰ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ‹¬å¼§ã®ä½ç½® (æ”¹è¡Œå˜ä½è¡Œå…ˆé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°(0é–‹å§‹), æ”¹è¡Œå˜ä½è¡Œã®è¡Œç•ªå·(0é–‹å§‹))
+	CLogicPoint		m_ptBracketPairPos_PHY;		// å¯¾æ‹¬å¼§ã®ä½ç½® (æ”¹è¡Œå˜ä½è¡Œå…ˆé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°(0é–‹å§‹), æ”¹è¡Œå˜ä½è¡Œã®è¡Œç•ªå·(0é–‹å§‹))
+	BOOL			m_bDrawBracketPairFlag;		/* å¯¾æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤ºã‚’è¡Œãªã†ã‹ */						// 03/02/18 ai
 
-	//ƒ}ƒEƒX
-	bool			m_bActivateByMouse;		//!< ƒ}ƒEƒX‚É‚æ‚éƒAƒNƒeƒBƒx[ƒg	//2007.10.02 nasukoji
-	DWORD			m_dwTripleClickCheck;	//!< ƒgƒŠƒvƒ‹ƒNƒŠƒbƒNƒ`ƒFƒbƒN—p	//2007.10.02 nasukoji
-	CMyPoint		m_cMouseDownPos;	//!< ƒNƒŠƒbƒN‚Ìƒ}ƒEƒXÀ•W
-	int				m_nWheelDelta;	//!< ƒzƒC[ƒ‹•Ï‰»—Ê
-	EFunctionCode	m_eWheelScroll; //!< ƒXƒNƒ[ƒ‹‚Ìí—Ş
-	int				m_nMousePouse;	// ƒ}ƒEƒX’â~ŠÔ
-	CMyPoint		m_cMousePousePos;	// ƒ}ƒEƒX‚Ì’â~ˆÊ’u
+	//ãƒã‚¦ã‚¹
+	bool			m_bActivateByMouse;		//!< ãƒã‚¦ã‚¹ã«ã‚ˆã‚‹ã‚¢ã‚¯ãƒ†ã‚£ãƒ™ãƒ¼ãƒˆ	//2007.10.02 nasukoji
+	DWORD			m_dwTripleClickCheck;	//!< ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãƒã‚§ãƒƒã‚¯ç”¨æ™‚åˆ»	//2007.10.02 nasukoji
+	CMyPoint		m_cMouseDownPos;	//!< ã‚¯ãƒªãƒƒã‚¯æ™‚ã®ãƒã‚¦ã‚¹åº§æ¨™
+	int				m_nWheelDelta;	//!< ãƒ›ã‚¤ãƒ¼ãƒ«å¤‰åŒ–é‡
+	EFunctionCode	m_eWheelScroll; //!< ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®ç¨®é¡
+	int				m_nMousePouse;	// ãƒã‚¦ã‚¹åœæ­¢æ™‚é–“
+	CMyPoint		m_cMousePousePos;	// ãƒã‚¦ã‚¹ã®åœæ­¢ä½ç½®
 	bool			m_bHideMouse;
 
-	int				m_nAutoScrollMode;			//!< ƒI[ƒgƒXƒNƒ[ƒ‹ƒ‚[ƒh
-	bool			m_bAutoScrollDragMode;		//!< ƒhƒ‰ƒbƒOƒ‚[ƒh
-	CMyPoint		m_cAutoScrollMousePos;		//!< ƒI[ƒgƒXƒNƒ[ƒ‹‚Ìƒ}ƒEƒXŠî€ˆÊ’u
-	bool			m_bAutoScrollVertical;		//!< ‚’¼ƒXƒNƒ[ƒ‹‰Â
-	bool			m_bAutoScrollHorizontal;	//!< …•½ƒXƒNƒ[ƒ‹‰Â
+	int				m_nAutoScrollMode;			//!< ã‚ªãƒ¼ãƒˆã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ¢ãƒ¼ãƒ‰
+	bool			m_bAutoScrollDragMode;		//!< ãƒ‰ãƒ©ãƒƒã‚°ãƒ¢ãƒ¼ãƒ‰
+	CMyPoint		m_cAutoScrollMousePos;		//!< ã‚ªãƒ¼ãƒˆã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®ãƒã‚¦ã‚¹åŸºæº–ä½ç½®
+	bool			m_bAutoScrollVertical;		//!< å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å¯
+	bool			m_bAutoScrollHorizontal;	//!< æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å¯
 
-	//ŒŸõ
+	//æ¤œç´¢
 	CSearchStringPattern m_sSearchPattern;
-	mutable CBregexp	m_CurRegexp;				/*!< ƒRƒ“ƒpƒCƒ‹ƒf[ƒ^ */
-	bool				m_bCurSrchKeyMark;			/* ŒŸõ•¶š—ñ‚Ìƒ}[ƒN */
-	bool				m_bCurSearchUpdate;			//!< ƒRƒ“ƒpƒCƒ‹ƒf[ƒ^XV—v‹
-	int					m_nCurSearchKeySequence;	//!< ŒŸõƒL[ƒV[ƒPƒ“ƒX
-	std::wstring		m_strCurSearchKey;			//!< ŒŸõ•¶š—ñ
-	SSearchOption		m_sCurSearchOption;			// ŒŸõ^’uŠ·  ƒIƒvƒVƒ‡ƒ“
-	CLogicPoint			m_ptSrchStartPos_PHY;		// ŒŸõ/’uŠ·ŠJn‚ÌƒJ[ƒ\ƒ‹ˆÊ’u (‰üs’PˆÊsæ“ª‚©‚ç‚ÌƒoƒCƒg”(0ŠJn), ‰üs’PˆÊs‚Ìs”Ô†(0ŠJn))
-	BOOL				m_bSearch;					/* ŒŸõ/’uŠ·ŠJnˆÊ’u‚ğ“o˜^‚·‚é‚© */											// 02/06/26 ai
-	ESearchDirection	m_nISearchDirection;		//!< ŒŸõ•ûŒü
-	ESearchMode			m_nISearchMode;				//!< ŒŸõƒ‚[ƒh
+	mutable CBregexp	m_CurRegexp;				/*!< ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ãƒ‡ãƒ¼ã‚¿ */
+	bool				m_bCurSrchKeyMark;			/* æ¤œç´¢æ–‡å­—åˆ—ã®ãƒãƒ¼ã‚¯ */
+	bool				m_bCurSearchUpdate;			//!< ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ãƒ‡ãƒ¼ã‚¿æ›´æ–°è¦æ±‚
+	int					m_nCurSearchKeySequence;	//!< æ¤œç´¢ã‚­ãƒ¼ã‚·ãƒ¼ã‚±ãƒ³ã‚¹
+	std::wstring		m_strCurSearchKey;			//!< æ¤œç´¢æ–‡å­—åˆ—
+	SSearchOption		m_sCurSearchOption;			// æ¤œç´¢ï¼ç½®æ›  ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+	CLogicPoint			m_ptSrchStartPos_PHY;		// æ¤œç´¢/ç½®æ›é–‹å§‹æ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½® (æ”¹è¡Œå˜ä½è¡Œå…ˆé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°(0é–‹å§‹), æ”¹è¡Œå˜ä½è¡Œã®è¡Œç•ªå·(0é–‹å§‹))
+	BOOL				m_bSearch;					/* æ¤œç´¢/ç½®æ›é–‹å§‹ä½ç½®ã‚’ç™»éŒ²ã™ã‚‹ã‹ */											// 02/06/26 ai
+	ESearchDirection	m_nISearchDirection;		//!< æ¤œç´¢æ–¹å‘
+	ESearchMode			m_nISearchMode;				//!< æ¤œç´¢ãƒ¢ãƒ¼ãƒ‰
 	bool				m_bISearchWrap;
 	bool				m_bISearchFlagHistory[256];
 	int					m_nISearchHistoryCount;
 	bool				m_bISearchFirst;
 	CLayoutRange		m_sISearchHistory[256];
 
-	//ƒ}ƒNƒ
-	bool			m_bExecutingKeyMacro;		/* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ÌÀs’† */
-	BOOL			m_bCommandRunning;	/* ƒRƒ}ƒ“ƒh‚ÌÀs’† */
+	//ãƒã‚¯ãƒ­
+	bool			m_bExecutingKeyMacro;		/* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®å®Ÿè¡Œä¸­ */
+	BOOL			m_bCommandRunning;	/* ã‚³ãƒãƒ³ãƒ‰ã®å®Ÿè¡Œä¸­ */
 
-	// “ü—Í•âŠ®
-	BOOL			m_bHokan;			//	•âŠ®’†‚©H•âŠ®ƒEƒBƒ“ƒhƒE‚ª•\¦‚³‚ê‚Ä‚¢‚é‚©H‚©‚ÈH
+	// å…¥åŠ›è£œå®Œ
+	BOOL			m_bHokan;			//	è£œå®Œä¸­ã‹ï¼Ÿï¼è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒè¡¨ç¤ºã•ã‚Œã¦ã„ã‚‹ã‹ï¼Ÿã‹ãªï¼Ÿ
 
-	//•ÒW
-	bool			m_bDoing_UndoRedo;	/* ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚© */
+	//ç·¨é›†
+	bool			m_bDoing_UndoRedo;	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹ */
 
-	// «‘TipŠÖ˜A
-	DWORD			m_dwTipTimer;			/* Tip‹N“®ƒ^ƒCƒ}[ */
-	CTipWnd			m_cTipWnd;				/* Tip•\¦ƒEƒBƒ“ƒhƒE */
-	POINT			m_poTipCurPos;			/* Tip‹N“®‚Ìƒ}ƒEƒXƒJ[ƒ\ƒ‹ˆÊ’u */
-	BOOL			m_bInMenuLoop;			/* ƒƒjƒ…[ ƒ‚[ƒ_ƒ‹ ƒ‹[ƒv‚É“ü‚Á‚Ä‚¢‚Ü‚· */
-	CDicMgr			m_cDicMgr;				/* «‘ƒ}ƒl[ƒWƒƒ */
+	// è¾æ›¸Tipé–¢é€£
+	DWORD			m_dwTipTimer;			/* Tipèµ·å‹•ã‚¿ã‚¤ãƒãƒ¼ */
+	CTipWnd			m_cTipWnd;				/* Tipè¡¨ç¤ºã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ */
+	POINT			m_poTipCurPos;			/* Tipèµ·å‹•æ™‚ã®ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ä½ç½® */
+	BOOL			m_bInMenuLoop;			/* ãƒ¡ãƒ‹ãƒ¥ãƒ¼ ãƒ¢ãƒ¼ãƒ€ãƒ« ãƒ«ãƒ¼ãƒ—ã«å…¥ã£ã¦ã„ã¾ã™ */
+	CDicMgr			m_cDicMgr;				/* è¾æ›¸ãƒãƒãƒ¼ã‚¸ãƒ£ */
 
-	TCHAR			m_szComposition[512]; // IMR_DOCUMENTFEED—p“ü—Í’†•¶š—ñƒf[ƒ^
+	TCHAR			m_szComposition[512]; // IMR_DOCUMENTFEEDç”¨å…¥åŠ›ä¸­æ–‡å­—åˆ—ãƒ‡ãƒ¼ã‚¿
 
 	// IME
 private:
@@ -735,19 +735,19 @@ private:
 public:
 	UINT			m_uWM_MSIME_RECONVERTREQUEST;
 private:
-	int				m_nLastReconvLine;             //2002.04.09 minfu Ä•ÏŠ·î•ñ•Û‘¶—p;
-	int				m_nLastReconvIndex;            //2002.04.09 minfu Ä•ÏŠ·î•ñ•Û‘¶—p;
+	int				m_nLastReconvLine;             //2002.04.09 minfu å†å¤‰æ›æƒ…å ±ä¿å­˜ç”¨;
+	int				m_nLastReconvIndex;            //2002.04.09 minfu å†å¤‰æ›æƒ…å ±ä¿å­˜ç”¨;
 
 public:
-	//ATOKê—pÄ•ÏŠ·‚ÌAPI
+	//ATOKå°‚ç”¨å†å¤‰æ›ã®API
 	typedef BOOL (WINAPI *FP_ATOK_RECONV)( HIMC , int ,PRECONVERTSTRING , DWORD  );
 	HMODULE			m_hAtokModule;
 	FP_ATOK_RECONV	m_AT_ImmSetReconvertString;
 
-	// ‚»‚Ì‘¼
-	CAutoMarkMgr*	m_cHistory;	//	Jump—š—ğ
+	// ãã®ä»–
+	CAutoMarkMgr*	m_cHistory;	//	Jumpå±¥æ­´
 	CRegexKeyword*	m_cRegexKeyword;	//@@@ 2001.11.17 add MIK
-	int				m_nMyIndex;	/* •ªŠ„ó‘Ô */
+	int				m_nMyIndex;	/* åˆ†å‰²çŠ¶æ…‹ */
 	CMigemo*		m_pcmigemo;
 	bool			m_bMiniMap;
 	bool			m_bMiniMapMouseDown;

--- a/sakura_core/view/CEditView_CmdHokan.cpp
+++ b/sakura_core/view/CEditView_CmdHokan.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief CEditViewƒNƒ‰ƒX‚Ì•âŠ®ŠÖ˜AƒRƒ}ƒ“ƒhˆ—ŒnŠÖ”ŒQ
+ï»¿/*!	@file
+	@brief CEditViewã‚¯ãƒ©ã‚¹ã®è£œå®Œé–¢é€£ã‚³ãƒãƒ³ãƒ‰å‡¦ç†ç³»é–¢æ•°ç¾¤
 
 	@author genta
-	@date	2005/01/10 ì¬
+	@date	2005/01/10 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -25,20 +25,20 @@
 #include "sakura_rc.h"
 
 /*!
-	@brief ƒRƒ}ƒ“ƒhóM‘O•âŠ®ˆ—
+	@brief ã‚³ãƒãƒ³ãƒ‰å—ä¿¡å‰è£œå®Œå‡¦ç†
 	
-	•âŠ®ƒEƒBƒ“ƒhƒE‚Ì”ñ•\¦
+	è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®éè¡¨ç¤º
 
-	@date 2005.01.10 genta ŠÖ”‰»
+	@date 2005.01.10 genta é–¢æ•°åŒ–
 */
 void CEditView::PreprocessCommand_hokan( int nCommand )
 {
-	/* •âŠ®ƒEƒBƒ“ƒhƒE‚ª•\¦‚³‚ê‚Ä‚¢‚é‚Æ‚«A“Á•Ê‚Èê‡‚ğœ‚¢‚ÄƒEƒBƒ“ƒhƒE‚ğ”ñ•\¦‚É‚·‚é */
+	/* è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒè¡¨ç¤ºã•ã‚Œã¦ã„ã‚‹ã¨ãã€ç‰¹åˆ¥ãªå ´åˆã‚’é™¤ã„ã¦ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’éè¡¨ç¤ºã«ã™ã‚‹ */
 	if( m_bHokan ){
-		if( nCommand != F_HOKAN		//	•âŠ®ŠJnEI—¹ƒRƒ}ƒ“ƒh
-		 && nCommand != F_WCHAR		//	•¶š“ü—Í
-		 && nCommand != F_IME_CHAR	//	Š¿š“ü—Í
-		 && nCommand != F_DELETE_BACK	//	ƒJ[ƒ\ƒ‹‘O‚ğíœ
+		if( nCommand != F_HOKAN		//	è£œå®Œé–‹å§‹ãƒ»çµ‚äº†ã‚³ãƒãƒ³ãƒ‰
+		 && nCommand != F_WCHAR		//	æ–‡å­—å…¥åŠ›
+		 && nCommand != F_IME_CHAR	//	æ¼¢å­—å…¥åŠ›
+		 && nCommand != F_DELETE_BACK	//	ã‚«ãƒ¼ã‚½ãƒ«å‰ã‚’å‰Šé™¤
 		 ){
 			m_pcEditWnd->m_cHokanMgr.Hide();
 			m_bHokan = FALSE;
@@ -47,17 +47,17 @@ void CEditView::PreprocessCommand_hokan( int nCommand )
 }
 
 /*!
-	ƒRƒ}ƒ“ƒhÀsŒã•âŠ®ˆ—
+	ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œå¾Œè£œå®Œå‡¦ç†
 
 	@author Moca
-	@date 2005.01.10 genta ŠÖ”‰»
+	@date 2005.01.10 genta é–¢æ•°åŒ–
 */
 void CEditView::PostprocessCommand_hokan(void)
 {
-	if( m_bHokan && !m_bExecutingKeyMacro ){ /* ƒL[ƒ{[ƒhƒ}ƒNƒ‚ÌÀs’† */
+	if( m_bHokan && !m_bExecutingKeyMacro ){ /* ã‚­ãƒ¼ãƒœãƒ¼ãƒ‰ãƒã‚¯ãƒ­ã®å®Ÿè¡Œä¸­ */
 		CNativeW	cmemData;
 
-		/* ƒJ[ƒ\ƒ‹’¼‘O‚Ì’PŒê‚ğæ“¾ */
+		/* ã‚«ãƒ¼ã‚½ãƒ«ç›´å‰ã®å˜èªã‚’å–å¾— */
 		if( 0 < GetParser().GetLeftWord( &cmemData, 100 ) ){
 			ShowHokanMgr( cmemData, FALSE );
 		}else{
@@ -69,21 +69,21 @@ void CEditView::PostprocessCommand_hokan(void)
 	}
 }
 
-/*!	•âŠ®ƒEƒBƒ“ƒhƒE‚ğ•\¦‚·‚é
-	ƒEƒBƒ“ƒhƒE‚ğ•\¦‚µ‚½Œã‚ÍAHokanMgr‚É”C‚¹‚é‚Ì‚ÅAShowHokanMgr‚Ì’m‚é‚Æ‚±‚ë‚Å‚Í‚È‚¢B
+/*!	è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¡¨ç¤ºã™ã‚‹
+	ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¡¨ç¤ºã—ãŸå¾Œã¯ã€HokanMgrã«ä»»ã›ã‚‹ã®ã§ã€ShowHokanMgrã®çŸ¥ã‚‹ã¨ã“ã‚ã§ã¯ãªã„ã€‚
 	
-	@param cmemData [in] •âŠ®‚·‚éŒ³‚ÌƒeƒLƒXƒg uAbv‚È‚Ç‚ª‚­‚éB
-	@param bAutoDecided [in] Œó•â‚ª1‚Â‚¾‚Á‚½‚çŠm’è‚·‚é
+	@param cmemData [in] è£œå®Œã™ã‚‹å…ƒã®ãƒ†ã‚­ã‚¹ãƒˆ ã€ŒAbã€ãªã©ãŒãã‚‹ã€‚
+	@param bAutoDecided [in] å€™è£œãŒ1ã¤ã ã£ãŸã‚‰ç¢ºå®šã™ã‚‹
 
-	@date 2005.01.10 genta CEditView_Command‚©‚çˆÚ“®
+	@date 2005.01.10 genta CEditView_Commandã‹ã‚‰ç§»å‹•
 */
 void CEditView::ShowHokanMgr( CNativeW& cmemData, BOOL bAutoDecided )
 {
-	/* •âŠ®‘ÎÛƒ[ƒhƒŠƒXƒg‚ğ’²‚×‚é */
+	/* è£œå®Œå¯¾è±¡ãƒ¯ãƒ¼ãƒ‰ãƒªã‚¹ãƒˆã‚’èª¿ã¹ã‚‹ */
 	CNativeW	cmemHokanWord;
 	int			nKouhoNum;
 	POINT		poWin;
-	/* •âŠ®ƒEƒBƒ“ƒhƒE‚Ì•\¦ˆÊ’u‚ğZo */
+	/* è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®è¡¨ç¤ºä½ç½®ã‚’ç®—å‡º */
 	CLayoutXInt nX = GetCaret().GetCaretLayoutPos().GetX2() - GetTextArea().GetViewLeftCol();
 	if( nX < 0 ){
 		poWin.x = 0;
@@ -101,12 +101,12 @@ void CEditView::ShowHokanMgr( CNativeW& cmemData, BOOL bAutoDecided )
 		poWin.y = GetTextArea().GetAreaTop() + (Int)(nY) * GetTextMetrics().GetHankakuDy();
 	}
 	this->ClientToScreen( &poWin );
-	// 2010.09.05 Moca ‘SŠp•‚Ìl—¶‚Ê‚¯‚ğC³
+	// 2010.09.05 Moca å…¨è§’å¹…ã®è€ƒæ…®ã¬ã‘ã‚’ä¿®æ­£
 	poWin.x -= GetTextMetrics().CalcTextWidth3(cmemData.GetStringPtr(), cmemData.GetStringLength());
 
-	/*	•âŠ®ƒEƒBƒ“ƒhƒE‚ğ•\¦
-		‚½‚¾‚µAbAutoDecided == TRUE‚Ìê‡‚ÍA•âŠ®Œó•â‚ª1‚Â‚Ì‚Æ‚«‚ÍAƒEƒBƒ“ƒhƒE‚ğ•\¦‚µ‚È‚¢B
-		Ú‚µ‚­‚ÍASearch()‚Ìà–¾‚ğQÆ‚Ì‚±‚ÆB
+	/*	è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¡¨ç¤º
+		ãŸã ã—ã€bAutoDecided == TRUEã®å ´åˆã¯ã€è£œå®Œå€™è£œãŒ1ã¤ã®ã¨ãã¯ã€ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’è¡¨ç¤ºã—ãªã„ã€‚
+		è©³ã—ãã¯ã€Search()ã®èª¬æ˜ã‚’å‚ç…§ã®ã“ã¨ã€‚
 	*/
 	CNativeW* pcmemHokanWord;
 	if ( bAutoDecided ){
@@ -116,11 +116,11 @@ void CEditView::ShowHokanMgr( CNativeW& cmemData, BOOL bAutoDecided )
 		pcmemHokanWord = NULL;
 	}
 
-	/* “ü—Í•âŠ®ƒEƒBƒ“ƒhƒEì¬ */
-	// ˆÈ‘O‚ÍƒGƒfƒBƒ^‹N“®‚Éì¬‚µ‚Ä‚¢‚½‚ª•K—v‚É‚È‚Á‚Ä‚©‚ç‚±‚±‚Åì¬‚·‚é‚æ‚¤‚É‚µ‚½B
-	// ƒGƒfƒBƒ^‹N“®‚¾‚ÆƒGƒfƒBƒ^‰Â‹‰»‚Ì“r’†‚É‚È‚º‚©•s‰Â‹‚Ì“ü—Í•âŠ®ƒEƒBƒ“ƒhƒE‚ªˆê“I‚ÉƒtƒHƒAƒOƒ‰ƒEƒ“ƒh‚É‚È‚Á‚ÄA
-	// ƒ^ƒuƒo[‚ÉV‹Kƒ^ƒu‚ª’Ç‰Á‚³‚ê‚é‚Æ‚«‚Ìƒ^ƒuØ‘Ö‚Åƒ^ƒCƒgƒ‹ƒo[‚ª‚¿‚ç‚Â‚­iˆêu”ñƒAƒNƒeƒBƒu•\¦‚É‚È‚é‚Ì‚ª‚Í‚Á‚«‚èŒ©‚¦‚éj‚±‚Æ‚ª‚ ‚Á‚½B
-	// ¦ Vista/7 ‚Ì“Á’è‚Ì PC ‚Å‚¾‚¯‚Ì‚¿‚ç‚Â‚«‚©H ŠY“– PC ˆÈŠO‚Ì Vista/7 PC ‚Å‚à‚½‚Ü‚É”÷–­‚É•\¦‚ª—‚ê‚½Š´‚¶‚É‚È‚é’ö“x‚ÌÇó‚ªŒ©‚ç‚ê‚½‚ªA‚»‚ê‚ç‚ª“¯ˆêŒ´ˆö‚©‚Ç‚¤‚©‚Í•s–¾B
+	/* å…¥åŠ›è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä½œæˆ */
+	// ä»¥å‰ã¯ã‚¨ãƒ‡ã‚£ã‚¿èµ·å‹•æ™‚ã«ä½œæˆã—ã¦ã„ãŸãŒå¿…è¦ã«ãªã£ã¦ã‹ã‚‰ã“ã“ã§ä½œæˆã™ã‚‹ã‚ˆã†ã«ã—ãŸã€‚
+	// ã‚¨ãƒ‡ã‚£ã‚¿èµ·å‹•æ™‚ã ã¨ã‚¨ãƒ‡ã‚£ã‚¿å¯è¦–åŒ–ã®é€”ä¸­ã«ãªãœã‹ä¸å¯è¦–ã®å…¥åŠ›è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒä¸€æ™‚çš„ã«ãƒ•ã‚©ã‚¢ã‚°ãƒ©ã‚¦ãƒ³ãƒ‰ã«ãªã£ã¦ã€
+	// ã‚¿ãƒ–ãƒãƒ¼ã«æ–°è¦ã‚¿ãƒ–ãŒè¿½åŠ ã•ã‚Œã‚‹ã¨ãã®ã‚¿ãƒ–åˆ‡æ›¿ã§ã‚¿ã‚¤ãƒˆãƒ«ãƒãƒ¼ãŒã¡ã‚‰ã¤ãï¼ˆä¸€ç¬éã‚¢ã‚¯ãƒ†ã‚£ãƒ–è¡¨ç¤ºã«ãªã‚‹ã®ãŒã¯ã£ãã‚Šè¦‹ãˆã‚‹ï¼‰ã“ã¨ãŒã‚ã£ãŸã€‚
+	// â€» Vista/7 ã®ç‰¹å®šã® PC ã§ã ã‘ã®ã¡ã‚‰ã¤ãã‹ï¼Ÿ è©²å½“ PC ä»¥å¤–ã® Vista/7 PC ã§ã‚‚ãŸã¾ã«å¾®å¦™ã«è¡¨ç¤ºãŒä¹±ã‚ŒãŸæ„Ÿã˜ã«ãªã‚‹ç¨‹åº¦ã®ç—‡çŠ¶ãŒè¦‹ã‚‰ã‚ŒãŸãŒã€ãã‚Œã‚‰ãŒåŒä¸€åŸå› ã‹ã©ã†ã‹ã¯ä¸æ˜ã€‚
 	if( !m_pcEditWnd->m_cHokanMgr.GetHwnd() ){
 		m_pcEditWnd->m_cHokanMgr.DoModeless(
 			G_AppInstance(),
@@ -140,21 +140,21 @@ void CEditView::ShowHokanMgr( CNativeW& cmemData, BOOL bAutoDecided )
 		m_pTypeData->m_bUseHokanByKeyword,
 		pcmemHokanWord
 	);
-	/* •âŠ®Œó•â‚Ì”‚É‚æ‚Á‚Ä“®ì‚ğ•Ï‚¦‚é */
-	if (nKouhoNum <= 0) {				//	Œó•â–³‚µ
+	/* è£œå®Œå€™è£œã®æ•°ã«ã‚ˆã£ã¦å‹•ä½œã‚’å¤‰ãˆã‚‹ */
+	if (nKouhoNum <= 0) {				//	å€™è£œç„¡ã—
 		if( m_bHokan ){
 			m_pcEditWnd->m_cHokanMgr.Hide();
 			m_bHokan = FALSE;
-			// 2003.06.25 Moca ¸”s‚µ‚Ä‚½‚çAƒr[ƒv‰¹‚ğo‚µ‚Ä•âŠ®I—¹B
+			// 2003.06.25 Moca å¤±æ•—ã—ã¦ãŸã‚‰ã€ãƒ“ãƒ¼ãƒ—éŸ³ã‚’å‡ºã—ã¦è£œå®Œçµ‚äº†ã€‚
 			ErrorBeep();
 		}
 	}
-	else if( bAutoDecided && nKouhoNum == 1){ //	Œó•â1‚Â‚Ì‚İ¨Šm’èB
+	else if( bAutoDecided && nKouhoNum == 1){ //	å€™è£œ1ã¤ã®ã¿â†’ç¢ºå®šã€‚
 		if( m_bHokan ){
 			m_pcEditWnd->m_cHokanMgr.Hide();
 			m_bHokan = FALSE;
 		}
-		// 2004.05.14 Moca CHokanMgr::Search‘¤‚Å‰üs‚ğíœ‚·‚é‚æ‚¤‚É‚µA’¼Ú‘‚«Š·‚¦‚é‚Ì‚ğ‚â‚ß‚½
+		// 2004.05.14 Moca CHokanMgr::Searchå´ã§æ”¹è¡Œã‚’å‰Šé™¤ã™ã‚‹ã‚ˆã†ã«ã—ã€ç›´æ¥æ›¸ãæ›ãˆã‚‹ã®ã‚’ã‚„ã‚ãŸ
 
 		GetCommander().Command_WordDeleteToStart();
 		GetCommander().Command_INSTEXT( true, cmemHokanWord.GetStringPtr(), cmemHokanWord.GetStringLength(), TRUE );
@@ -167,25 +167,25 @@ void CEditView::ShowHokanMgr( CNativeW& cmemData, BOOL bAutoDecided )
 
 
 /*!
-	•ÒW’†ƒf[ƒ^‚©‚ç“ü—Í•âŠ®ƒL[ƒ[ƒh‚ÌŒŸõ
-	CHokanMgr‚©‚çŒÄ‚Î‚ê‚é
+	ç·¨é›†ä¸­ãƒ‡ãƒ¼ã‚¿ã‹ã‚‰å…¥åŠ›è£œå®Œã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®æ¤œç´¢
+	CHokanMgrã‹ã‚‰å‘¼ã°ã‚Œã‚‹
 
-	@return Œó•â”
+	@return å€™è£œæ•°
 
 	@author Moca
 	@date 2003.06.25
 
-	@date 2005/01/10 genta  CEditView_Command‚©‚çˆÚ“®
-	@date 2007/10/17 kobake “Ç‚İ‚â‚·‚¢‚æ‚¤‚ÉƒlƒXƒg‚ğó‚­‚µ‚Ü‚µ‚½B
-	@date 2008.07.25 nasukoji ‘å•¶š¬•¶š‚ğ“¯ˆê‹‚Ìê‡‚Å‚àŒó•â‚ÌU‚é‚¢—‚Æ‚µ‚ÍŠ®‘Sˆê’v‚ÅŒ©‚é
-	@date 2008.10.11 syat “ú–{Œê‚Ì•âŠ®
-	@date 2010.06.16 Moca ‚Ğ‚ç‚ª‚È‚Å‘±s‚·‚éê‡A’¼‘O‚ğŠ¿š‚É§ŒÀ
+	@date 2005/01/10 genta  CEditView_Commandã‹ã‚‰ç§»å‹•
+	@date 2007/10/17 kobake èª­ã¿ã‚„ã™ã„ã‚ˆã†ã«ãƒã‚¹ãƒˆã‚’æµ…ãã—ã¾ã—ãŸã€‚
+	@date 2008.07.25 nasukoji å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–ã®å ´åˆã§ã‚‚å€™è£œã®æŒ¯ã‚‹ã„è½ã¨ã—ã¯å®Œå…¨ä¸€è‡´ã§è¦‹ã‚‹
+	@date 2008.10.11 syat æ—¥æœ¬èªã®è£œå®Œ
+	@date 2010.06.16 Moca ã²ã‚‰ãŒãªã§ç¶šè¡Œã™ã‚‹å ´åˆã€ç›´å‰ã‚’æ¼¢å­—ã«åˆ¶é™
 */
 int CEditView::HokanSearchByFile(
 	const wchar_t*	pszKey,			//!< [in]
-	bool			bHokanLoHiCase,	//!< [in] ‰p‘å•¶š¬•¶š‚ğ“¯ˆê‹‚·‚é
-	vector_ex<std::wstring>& 	vKouho,	//!< [in,out] Œó•â
-	int				nMaxKouho		//!< [in] MaxŒó•â”(0==–³§ŒÀ)
+	bool			bHokanLoHiCase,	//!< [in] è‹±å¤§æ–‡å­—å°æ–‡å­—ã‚’åŒä¸€è¦–ã™ã‚‹
+	vector_ex<std::wstring>& 	vKouho,	//!< [in,out] å€™è£œ
+	int				nMaxKouho		//!< [in] Maxå€™è£œæ•°(0==ç„¡åˆ¶é™)
 ){
 	const int nKeyLen = wcslen( pszKey );
 	int nLines = m_pcEditDoc->m_cDocLineMgr.GetLineCount();
@@ -194,11 +194,11 @@ int CEditView::HokanSearchByFile(
 	const wchar_t* pszLine;
 	const wchar_t* word;
 
-	CLogicPoint ptCur = GetCaret().GetCaretLogicPos(); //•¨—ƒJ[ƒ\ƒ‹ˆÊ’u
-	bool bKeyStartWithMark;			//ƒL[‚ª‹L†‚Ån‚Ü‚é‚©
-	bool bWordStartWithMark;		//Œó•â‚ª‹L†‚Ån‚Ü‚é‚©
+	CLogicPoint ptCur = GetCaret().GetCaretLogicPos(); //ç‰©ç†ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
+	bool bKeyStartWithMark;			//ã‚­ãƒ¼ãŒè¨˜å·ã§å§‹ã¾ã‚‹ã‹
+	bool bWordStartWithMark;		//å€™è£œãŒè¨˜å·ã§å§‹ã¾ã‚‹ã‹
 
-	// ƒL[‚Ìæ“ª‚ª‹L†(#$@\)‚©‚Ç‚¤‚©”»’è
+	// ã‚­ãƒ¼ã®å…ˆé ­ãŒè¨˜å·(#$@\)ã‹ã©ã†ã‹åˆ¤å®š
 	bKeyStartWithMark = ( wcschr( L"$@#\\", pszKey[0] ) != NULL ? true : false );
 
 	for( CLogicInt i = CLogicInt(0); i < nLines; i++  ){
@@ -207,57 +207,57 @@ int CEditView::HokanSearchByFile(
 		for( j = 0; j < nLineLen; j += nCharSize ){
 			nCharSize = CNativeW::GetSizeOfChar( pszLine, nLineLen, j );
 
-			// ”¼Šp‹L†‚ÍŒó•â‚ÉŠÜ‚ß‚È‚¢
+			// åŠè§’è¨˜å·ã¯å€™è£œã«å«ã‚ãªã„
 			if ( pszLine[j] < 0x00C0 && !IS_KEYWORD_CHAR( pszLine[j] ) )continue;
 
-			// ƒL[‚Ìæ“ª‚ª‹L†ˆÈŠO‚Ìê‡A‹L†‚Ån‚Ü‚é’PŒê‚ÍŒó•â‚©‚ç‚Í‚¸‚·
+			// ã‚­ãƒ¼ã®å…ˆé ­ãŒè¨˜å·ä»¥å¤–ã®å ´åˆã€è¨˜å·ã§å§‹ã¾ã‚‹å˜èªã¯å€™è£œã‹ã‚‰ã¯ãšã™
 			if( !bKeyStartWithMark && wcschr( L"$@#\\", pszLine[j] ) != NULL )continue;
 
-			// •¶ší—Şæ“¾
-			ECharKind kindPre = CWordParse::WhatKindOfChar( pszLine, nLineLen, j );	// •¶ší—Şæ“¾
+			// æ–‡å­—ç¨®é¡å–å¾—
+			ECharKind kindPre = CWordParse::WhatKindOfChar( pszLine, nLineLen, j );	// æ–‡å­—ç¨®é¡å–å¾—
 
-			// ‘SŠp‹L†‚ÍŒó•â‚ÉŠÜ‚ß‚È‚¢
+			// å…¨è§’è¨˜å·ã¯å€™è£œã«å«ã‚ãªã„
 			if ( kindPre == CK_ZEN_SPACE || kindPre == CK_ZEN_NOBASU || kindPre == CK_ZEN_DAKU ||
 				 kindPre == CK_ZEN_KIGO  || kindPre == CK_ZEN_SKIGO )continue;
 
 			bWordStartWithMark = ( wcschr( L"$@#\\", pszLine[j] ) != NULL ? true : false );
 
 			nWordBegin = j;
-			// Œó•â’PŒê‚ÌI—¹ˆÊ’u‚ğ‹‚ß‚é
+			// å€™è£œå˜èªã®çµ‚äº†ä½ç½®ã‚’æ±‚ã‚ã‚‹
 			nWordLen = nCharSize;
-			nWordLenStop = -1; // ‘—‚è‰¼–¼–³‹—p’PŒê‚ÌI‚í‚èB-1‚Í–³Œø
+			nWordLenStop = -1; // é€ã‚Šä»®åç„¡è¦–ç”¨å˜èªã®çµ‚ã‚ã‚Šã€‚-1ã¯ç„¡åŠ¹
 			for( j += nCharSize; j < nLineLen; j += nCharSize ){
 				nCharSize = CNativeW::GetSizeOfChar( pszLine, nLineLen, j );
 
-				// ”¼Šp‹L†‚ÍŠÜ‚ß‚È‚¢
+				// åŠè§’è¨˜å·ã¯å«ã‚ãªã„
 				if ( pszLine[j] < 0x00C0 && !IS_KEYWORD_CHAR( pszLine[j] ) )break;
 
-				// •¶ší—Şæ“¾
+				// æ–‡å­—ç¨®é¡å–å¾—
 				ECharKind kindCur = CWordParse::WhatKindOfChar( pszLine, nLineLen, j );
-				// ‘SŠp‹L†‚ÍŒó•â‚ÉŠÜ‚ß‚È‚¢
+				// å…¨è§’è¨˜å·ã¯å€™è£œã«å«ã‚ãªã„
 				if ( kindCur == CK_ZEN_SPACE || kindCur == CK_ZEN_KIGO || kindCur == CK_ZEN_SKIGO ){
 					break;
 				}
 
-				// •¶ší—Ş‚ª•Ï‚í‚Á‚½‚ç’PŒê‚ÌØ‚ê–Ú‚Æ‚·‚é
+				// æ–‡å­—ç¨®é¡ãŒå¤‰ã‚ã£ãŸã‚‰å˜èªã®åˆ‡ã‚Œç›®ã¨ã™ã‚‹
 				ECharKind kindMerge = CWordParse::WhatKindOfTwoChars( kindPre, kindCur );
-				if ( kindMerge == CK_NULL ) {	// kindPre‚ÆkindCur‚ª•Êí
+				if ( kindMerge == CK_NULL ) {	// kindPreã¨kindCurãŒåˆ¥ç¨®
 					if( kindCur == CK_HIRA ) {
-						kindMerge = kindCur;		// ‚Ğ‚ç‚ª‚È‚È‚ç‘±s
-						// 2010.06.16 Moca Š¿š‚Ì‚İ‘—‚è‰¼–¼‚ğŒó•â‚ÉŠÜ‚ß‚é
+						kindMerge = kindCur;		// ã²ã‚‰ãŒãªãªã‚‰ç¶šè¡Œ
+						// 2010.06.16 Moca æ¼¢å­—ã®ã¿é€ã‚Šä»®åã‚’å€™è£œã«å«ã‚ã‚‹
 						if( kindPre != CK_ZEN_ETC ) {
 							nWordLenStop = nWordLen;
 						}
 					}else if( bKeyStartWithMark && bWordStartWithMark && kindPre == CK_UDEF ){
-						kindMerge = kindCur;		// ‹L†‚Ån‚Ü‚é’PŒê‚Í§ŒÀ‚ğŠÉ‚ß‚é
+						kindMerge = kindCur;		// è¨˜å·ã§å§‹ã¾ã‚‹å˜èªã¯åˆ¶é™ã‚’ç·©ã‚ã‚‹
 					}else{
 						j -= nCharSize;
-						break;						// ‚»‚êˆÈŠO‚Í’PŒê‚ÌØ‚ê–Ú
+						break;						// ãã‚Œä»¥å¤–ã¯å˜èªã®åˆ‡ã‚Œç›®
 					}
 				}
 
 				kindPre = kindMerge;
-				nWordLen += nCharSize;				// Ÿ‚Ì•¶š‚Ö
+				nWordLen += nCharSize;				// æ¬¡ã®æ–‡å­—ã¸
 			}
 
 			if( 0 < nWordLenStop ){
@@ -265,16 +265,16 @@ int CEditView::HokanSearchByFile(
 			}
 
 
-			// CDicMgr“™‚Ì§ŒÀ‚É‚æ‚è’·‚·‚¬‚é’PŒê‚Í–³‹‚·‚é
+			// CDicMgrç­‰ã®åˆ¶é™ã«ã‚ˆã‚Šé•·ã™ãã‚‹å˜èªã¯ç„¡è¦–ã™ã‚‹
 			if( nWordLen > 1020 ){
 				continue;
 			}
 			if( nKeyLen > nWordLen ) continue;
 
-			// Œó•â’PŒê‚ÌŠJnˆÊ’u‚ğ‹‚ß‚é
+			// å€™è£œå˜èªã®é–‹å§‹ä½ç½®ã‚’æ±‚ã‚ã‚‹
 			word = pszLine + nWordBegin;
 
-			// ƒL[‚Æ”äŠr‚·‚é
+			// ã‚­ãƒ¼ã¨æ¯”è¼ƒã™ã‚‹
 			if( bHokanLoHiCase ){
 				nRet = auto_memicmp( pszKey, word, nKeyLen );
 			}else{
@@ -282,12 +282,12 @@ int CEditView::HokanSearchByFile(
 			}
 			if( nRet!=0 )continue;
 
-			// ƒJ[ƒ\ƒ‹ˆÊ’u‚Ì’PŒê‚ÍŒó•â‚©‚ç‚Í‚¸‚·
-			if( ptCur.y == i && nWordBegin <= ptCur.x && ptCur.x <= nWordBegin + nWordLen ){	// 2010.02.20 syat C³// 2008.11.09 syat C³
+			// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®å˜èªã¯å€™è£œã‹ã‚‰ã¯ãšã™
+			if( ptCur.y == i && nWordBegin <= ptCur.x && ptCur.x <= nWordBegin + nWordLen ){	// 2010.02.20 syat ä¿®æ­£// 2008.11.09 syat ä¿®æ­£
 				continue;
 			}
 
-			// Œó•â‚ğ’Ç‰Á(d•¡‚Íœ‚­)
+			// å€™è£œã‚’è¿½åŠ (é‡è¤‡ã¯é™¤ã)
 			{
 				std::wstring strWord = std::wstring(word, nWordLen);
 				CHokanMgr::AddKouhoUnique(vKouho, strWord);

--- a/sakura_core/view/CEditView_Cmdgrep.cpp
+++ b/sakura_core/view/CEditView_Cmdgrep.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief CEditViewƒNƒ‰ƒX‚ÌgrepŠÖ˜AƒRƒ}ƒ“ƒhˆ—ŒnŠÖ”ŒQ
+ï»¿/*!	@file
+	@brief CEditViewã‚¯ãƒ©ã‚¹ã®grepé–¢é€£ã‚³ãƒãƒ³ãƒ‰å‡¦ç†ç³»é–¢æ•°ç¾¤
 
 	@author genta
-	@date	2005/01/10 ì¬
+	@date	2005/01/10 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -24,7 +24,7 @@
 #include "sakura_rc.h"
 
 /*!
-	ƒRƒ}ƒ“ƒhƒR[ƒh‚Ì•ÏŠ·(grep mode)
+	ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã®å¤‰æ›(grep modeæ™‚)
 */
 void CEditView::TranslateCommand_grep(
 	EFunctionCode&	nCommand,
@@ -39,7 +39,7 @@ void CEditView::TranslateCommand_grep(
 		return;
 
 	if( nCommand == F_WCHAR ){
-		//	Jan. 23, 2005 genta •¶š”»’è–Y‚ê
+		//	Jan. 23, 2005 genta æ–‡å­—åˆ¤å®šå¿˜ã‚Œ
 		if( WCODE::IsLineDelimiter((wchar_t)lparam1, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol)
 				&& GetDllShareData().m_Common.m_sSearch.m_bGTJW_RETURN ){
 			nCommand = F_TAGJUMP;

--- a/sakura_core/view/CEditView_Cmdisrch.cpp
+++ b/sakura_core/view/CEditView_Cmdisrch.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief CEditViewƒNƒ‰ƒX‚ÌƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`ŠÖ˜AƒRƒ}ƒ“ƒhˆ—ŒnŠÖ”ŒQ
+ï»¿/*!	@file
+	@brief CEditViewã‚¯ãƒ©ã‚¹ã®ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒé–¢é€£ã‚³ãƒãƒ³ãƒ‰å‡¦ç†ç³»é–¢æ•°ç¾¤
 
 	@author genta
-	@date	2005/01/10 ì¬
+	@date	2005/01/10 ä½œæˆ
 */
 /*
 	Copyright (C) 2004, isearch
@@ -20,17 +20,17 @@
 #include "sakura_rc.h"
 
 /*!
-	ƒRƒ}ƒ“ƒhƒR[ƒh‚Ì•ÏŠ·(ISearch)‹y‚Ñ
-	ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`ƒ‚[ƒh‚ğ”²‚¯‚é”»’è
+	ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã®å¤‰æ›(ISearchæ™‚)åŠã³
+	ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒãƒ¢ãƒ¼ãƒ‰ã‚’æŠœã‘ã‚‹åˆ¤å®š
 
-	@return true: ƒRƒ}ƒ“ƒhˆ—Ï‚İ / false: ƒRƒ}ƒ“ƒhˆ—Œp‘±
+	@return true: ã‚³ãƒãƒ³ãƒ‰å‡¦ç†æ¸ˆã¿ / false: ã‚³ãƒãƒ³ãƒ‰å‡¦ç†ç¶™ç¶š
 
-	@date 2004.09.14 isearch V‹Kì¬
-	@date 2005.01.10 genta ŠÖ”‰», UNINDENT’Ç‰Á
+	@date 2004.09.14 isearch æ–°è¦ä½œæˆ
+	@date 2005.01.10 genta é–¢æ•°åŒ–, UNINDENTè¿½åŠ 
 
-	@note UNINDENT‚ğ’Êí•¶š‚Æ‚µ‚Äˆµ‚¤‚Ì‚ÍC
-		SHIFT+•¶š‚ÌŒã‚ÅSPACE‚ğ“ü—Í‚·‚é‚æ‚¤‚ÈƒP[ƒX‚Å
-		SHIFT‚Ì‰ğ•ú‚ª’x‚ê‚Ä‚à•¶š‚ª“ü‚ç‚È‚­‚È‚é‚±‚Æ‚ğ–h‚®‚½‚ßD
+	@note UNINDENTã‚’é€šå¸¸æ–‡å­—ã¨ã—ã¦æ‰±ã†ã®ã¯ï¼Œ
+		SHIFT+æ–‡å­—ã®å¾Œã§SPACEã‚’å…¥åŠ›ã™ã‚‹ã‚ˆã†ãªã‚±ãƒ¼ã‚¹ã§
+		SHIFTã®è§£æ”¾ãŒé…ã‚Œã¦ã‚‚æ–‡å­—ãŒå…¥ã‚‰ãªããªã‚‹ã“ã¨ã‚’é˜²ããŸã‚ï¼
 */
 void CEditView::TranslateCommand_isearch(
 	EFunctionCode&	nCommand,
@@ -45,7 +45,7 @@ void CEditView::TranslateCommand_isearch(
 		return;
 
 	switch (nCommand){
-		//‚±‚ê‚ç‚Ì‹@”\‚Ì‚Æ‚«AƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`‚É“ü‚é
+		//ã“ã‚Œã‚‰ã®æ©Ÿèƒ½ã®ã¨ãã€ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒã«å…¥ã‚‹
 		case F_ISEARCH_NEXT:
 		case F_ISEARCH_PREV:
 		case F_ISEARCH_REGEXP_NEXT:
@@ -54,7 +54,7 @@ void CEditView::TranslateCommand_isearch(
 		case F_ISEARCH_MIGEMO_PREV:
 			break;
 
-		//ˆÈ‰º‚Ì‹@”\‚Ì‚Æ‚«AƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`’†‚ÍŒŸõ•¶š“ü—Í‚Æ‚µ‚Äˆ—
+		//ä»¥ä¸‹ã®æ©Ÿèƒ½ã®ã¨ãã€ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒä¸­ã¯æ¤œç´¢æ–‡å­—å…¥åŠ›ã¨ã—ã¦å‡¦ç†
 		case F_WCHAR:
 		case F_IME_CHAR:
 			nCommand = F_ISEARCH_ADD_CHAR;
@@ -63,13 +63,13 @@ void CEditView::TranslateCommand_isearch(
 			nCommand = F_ISEARCH_ADD_STR;
 			break;
 
-		case F_INDENT_TAB:	// TAB‚ÍƒCƒ“ƒfƒ“ƒg‚Å‚Í‚È‚­’P‚È‚éTAB•¶š‚ÆŒ©‚È‚·
-		case F_UNINDENT_TAB:	// genta’Ç‰Á
+		case F_INDENT_TAB:	// TABã¯ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã§ã¯ãªãå˜ãªã‚‹TABæ–‡å­—ã¨è¦‹ãªã™
+		case F_UNINDENT_TAB:	// gentaè¿½åŠ 
 			nCommand = F_ISEARCH_ADD_CHAR;
 			lparam1 = '\t';
 			break;
-		case F_INDENT_SPACE:	// ƒXƒy[ƒX‚ÍƒCƒ“ƒfƒ“ƒg‚Å‚Í‚È‚­’P‚È‚éTAB•¶š‚ÆŒ©‚È‚·
-		case F_UNINDENT_SPACE:	// genta’Ç‰Á
+		case F_INDENT_SPACE:	// ã‚¹ãƒšãƒ¼ã‚¹ã¯ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆã§ã¯ãªãå˜ãªã‚‹TABæ–‡å­—ã¨è¦‹ãªã™
+		case F_UNINDENT_SPACE:	// gentaè¿½åŠ 
 			nCommand = F_ISEARCH_ADD_CHAR;
 			lparam1 = ' ';
 			break;
@@ -78,15 +78,15 @@ void CEditView::TranslateCommand_isearch(
 			break;
 
 		default:
-			//ã‹LˆÈŠO‚ÌƒRƒ}ƒ“ƒh‚Ìê‡‚ÍƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`‚ğ”²‚¯‚é
+			//ä¸Šè¨˜ä»¥å¤–ã®ã‚³ãƒãƒ³ãƒ‰ã®å ´åˆã¯ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒã‚’æŠœã‘ã‚‹
 			ISearchExit();
 	}
 }
 
 /*!
-	ISearch ƒRƒ}ƒ“ƒhˆ—
+	ISearch ã‚³ãƒãƒ³ãƒ‰å‡¦ç†
 
-	@date 2005.01.10 genta ŠeƒRƒ}ƒ“ƒh‚É“ü‚Á‚Ä‚¢‚½ˆ—‚ğ1ƒJŠ‚ÉˆÚ“®
+	@date 2005.01.10 genta å„ã‚³ãƒãƒ³ãƒ‰ã«å…¥ã£ã¦ã„ãŸå‡¦ç†ã‚’1ã‚«æ‰€ã«ç§»å‹•
 */
 bool CEditView::ProcessCommand_isearch(
 	int	nCommand,
@@ -98,7 +98,7 @@ bool CEditView::ProcessCommand_isearch(
 )
 {
 	switch( nCommand ){
-		//	ŒŸõ•¶š—ñ‚Ì•ÏX‘€ì
+		//	æ¤œç´¢æ–‡å­—åˆ—ã®å¤‰æ›´æ“ä½œ
 		case F_ISEARCH_ADD_CHAR:
 			ISearchExec((DWORD)lparam1);
 			return true;
@@ -111,68 +111,68 @@ bool CEditView::ProcessCommand_isearch(
 			ISearchExec((LPCWSTR)lparam1);
 			return true;
 
-		//	ŒŸõƒ‚[ƒh‚Ö‚ÌˆÚs
+		//	æ¤œç´¢ãƒ¢ãƒ¼ãƒ‰ã¸ã®ç§»è¡Œ
 		case F_ISEARCH_NEXT:
-			ISearchEnter(SEARCH_NORMAL, SEARCH_FORWARD);	//‘O•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ` //2004.10.13 isearch
+			ISearchEnter(SEARCH_NORMAL, SEARCH_FORWARD);	//å‰æ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ //2004.10.13 isearch
 			return true;
 		case F_ISEARCH_PREV:
-			ISearchEnter(SEARCH_NORMAL, SEARCH_BACKWARD);	//Œã•ûƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ` //2004.10.13 isearch
+			ISearchEnter(SEARCH_NORMAL, SEARCH_BACKWARD);	//å¾Œæ–¹ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ //2004.10.13 isearch
 			return true;
 		case F_ISEARCH_REGEXP_NEXT:
-			ISearchEnter(SEARCH_REGEXP, SEARCH_FORWARD);	//‘O•û³‹K•\Œ»ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`  //2004.10.13 isearch
+			ISearchEnter(SEARCH_REGEXP, SEARCH_FORWARD);	//å‰æ–¹æ­£è¦è¡¨ç¾ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ  //2004.10.13 isearch
 			return true;
 		case F_ISEARCH_REGEXP_PREV:
-			ISearchEnter(SEARCH_REGEXP, SEARCH_BACKWARD);	//Œã•û³‹K•\Œ»ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`  //2004.10.13 isearch
+			ISearchEnter(SEARCH_REGEXP, SEARCH_BACKWARD);	//å¾Œæ–¹æ­£è¦è¡¨ç¾ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ  //2004.10.13 isearch
 			return true;
 		case F_ISEARCH_MIGEMO_NEXT:
-			ISearchEnter(SEARCH_MIGEMO, SEARCH_FORWARD);	//‘O•ûMIGEMOƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`    //2004.10.13 isearch
+			ISearchEnter(SEARCH_MIGEMO, SEARCH_FORWARD);	//å‰æ–¹MIGEMOã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ    //2004.10.13 isearch
 			return true;
 		case F_ISEARCH_MIGEMO_PREV:
-			ISearchEnter(SEARCH_MIGEMO, SEARCH_BACKWARD);	//Œã•ûMIGEMOƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`    //2004.10.13 isearch
+			ISearchEnter(SEARCH_MIGEMO, SEARCH_BACKWARD);	//å¾Œæ–¹MIGEMOã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ    //2004.10.13 isearch
 			return true;
 	}
 	return false;
 }
 
 /*!
-	ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`ƒ‚[ƒh‚É“ü‚é
+	ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒãƒ¢ãƒ¼ãƒ‰ã«å…¥ã‚‹
 
-	@param mode [in] ŒŸõ•û–@ 1:’Êí, 2:³‹K•\Œ», 3:MIGEMO
-	@param direction [in] ŒŸõ•ûŒü 0:Œã•û(ã•û), 1:‘O•û(‰º•û)
+	@param mode [in] æ¤œç´¢æ–¹æ³• 1:é€šå¸¸, 2:æ­£è¦è¡¨ç¾, 3:MIGEMO
+	@param direction [in] æ¤œç´¢æ–¹å‘ 0:å¾Œæ–¹(ä¸Šæ–¹), 1:å‰æ–¹(ä¸‹æ–¹)
 
 	@author isearch
-	@date 2011.12.15 Moca m_sCurSearchOption/m_sSearchOption‚Æ“¯Šú‚ğ‚Æ‚é
-	@date 2012.10.11 novice m_sCurSearchOption/m_sSearchOption‚Ì“¯Šú‚ğswitch‚Ì‘O‚É•ÏX
-	@date 2012.10.11 novice MIGEMO‚Ìˆ—‚ğcase“à‚ÉˆÚ“®
+	@date 2011.12.15 Moca m_sCurSearchOption/m_sSearchOptionã¨åŒæœŸã‚’ã¨ã‚‹
+	@date 2012.10.11 novice m_sCurSearchOption/m_sSearchOptionã®åŒæœŸã‚’switchã®å‰ã«å¤‰æ›´
+	@date 2012.10.11 novice MIGEMOã®å‡¦ç†ã‚’caseå†…ã«ç§»å‹•
 */
 void CEditView::ISearchEnter( ESearchMode mode, ESearchDirection direction)
 {
 
 	if (m_nISearchMode == mode ) {
-		//ÄÀs
+		//å†å®Ÿè¡Œ
 		m_nISearchDirection =  direction;
 		
 		if ( m_bISearchFirst ){
 			m_bISearchFirst = false;
 		}
-		//‚¿‚å‚Á‚ÆC³
+		//ã¡ã‚‡ã£ã¨ä¿®æ­£
 		ISearchExec(true);
 
 	}else{
-		//ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`ƒ‚[ƒh‚É“ü‚é‚¾‚¯.		
-		//‘I‘ğ”ÍˆÍ‚Ì‰ğœ
+		//ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒãƒ¢ãƒ¼ãƒ‰ã«å…¥ã‚‹ã ã‘.		
+		//é¸æŠç¯„å›²ã®è§£é™¤
 		if(GetSelectionInfo().IsTextSelected())	
 			GetSelectionInfo().DisableSelectArea( true );
 
 		m_sCurSearchOption = GetDllShareData().m_Common.m_sSearch.m_sSearchOption;
 		switch( mode ) {
-			case SEARCH_NORMAL: // ’ÊíƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`
+			case SEARCH_NORMAL: // é€šå¸¸ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ
 				m_sCurSearchOption.bRegularExp = false;
 				m_sCurSearchOption.bLoHiCase = false;
 				m_sCurSearchOption.bWordOnly = false;
 				//SendStatusMessage(_T("I-Search: "));
 				break;
-			case SEARCH_REGEXP: // ³‹K•\Œ»ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`
+			case SEARCH_REGEXP: // æ­£è¦è¡¨ç¾ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ
 				if (!m_CurRegexp.IsAvailable()){
 					WarningBeep();
 					SendStatusMessage(LS(STR_EDITVWISRCH_REGEX));
@@ -182,7 +182,7 @@ void CEditView::ISearchEnter( ESearchMode mode, ESearchDirection direction)
 				m_sCurSearchOption.bLoHiCase = false;
 				//SendStatusMessage(_T("[RegExp] I-Search: "));
 				break;
-			case SEARCH_MIGEMO: // MIGEMOƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`
+			case SEARCH_MIGEMO: // MIGEMOã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ
 				if (!m_CurRegexp.IsAvailable()){
 					WarningBeep();
 					SendStatusMessage(LS(STR_EDITVWISRCH_REGEX));
@@ -192,9 +192,9 @@ void CEditView::ISearchEnter( ESearchMode mode, ESearchDirection direction)
 					m_pcmigemo = CMigemo::getInstance();
 					m_pcmigemo->InitDll();
 				}
-				//migemo dll ƒ`ƒFƒbƒN
-				//	Jan. 10, 2005 genta İ’è•ÏX‚Åg‚¦‚é‚æ‚¤‚É‚È‚Á‚Ä‚¢‚é
-				//	‰Â”\«‚ª‚ ‚é‚Ì‚ÅCg—p‰Â”\‚Å‚È‚¯‚ê‚Îˆê‰‰Šú‰»‚ğ‚İ‚é
+				//migemo dll ãƒã‚§ãƒƒã‚¯
+				//	Jan. 10, 2005 genta è¨­å®šå¤‰æ›´ã§ä½¿ãˆã‚‹ã‚ˆã†ã«ãªã£ã¦ã„ã‚‹
+				//	å¯èƒ½æ€§ãŒã‚ã‚‹ã®ã§ï¼Œä½¿ç”¨å¯èƒ½ã§ãªã‘ã‚Œã°ä¸€å¿œåˆæœŸåŒ–ã‚’è©¦ã¿ã‚‹
 				if ( !m_pcmigemo->IsAvailable() && DLL_SUCCESS != m_pcmigemo->InitDll() ){
 					WarningBeep();
 					SendStatusMessage(LS(STR_EDITVWISRCH_MIGEGO1));
@@ -213,8 +213,8 @@ void CEditView::ISearchEnter( ESearchMode mode, ESearchDirection direction)
 				break;
 		}
 		
-		//	Feb. 04, 2005 genta	ŒŸõŠJnˆÊ’u‚ğ‹L˜^
-		//	ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`ŠÔ‚Åƒ‚[ƒh‚ğØ‚è‘Ö‚¦‚éê‡‚É‚ÍŠJn‚ÆŒ©‚È‚³‚È‚¢
+		//	Feb. 04, 2005 genta	æ¤œç´¢é–‹å§‹ä½ç½®ã‚’è¨˜éŒ²
+		//	ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒé–“ã§ãƒ¢ãƒ¼ãƒ‰ã‚’åˆ‡ã‚Šæ›¿ãˆã‚‹å ´åˆã«ã¯é–‹å§‹ã¨è¦‹ãªã•ãªã„
 		if( m_nISearchMode == SEARCH_NONE ){
 			m_ptSrchStartPos_PHY = GetCaret().GetCaretLogicPos();
 		}
@@ -236,7 +236,7 @@ void CEditView::ISearchEnter( ESearchMode mode, ESearchDirection direction)
 		m_bISearchFirst = true;
 	}
 
-	//ƒ}ƒEƒXƒJ[ƒ\ƒ‹•ÏX
+	//ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«å¤‰æ›´
 	if (direction == 1){
 		::SetCursor( ::LoadCursor( G_AppInstance(),MAKEINTRESOURCE(IDC_CURSOR_ISEARCH_F)));
 	}else{
@@ -244,10 +244,10 @@ void CEditView::ISearchEnter( ESearchMode mode, ESearchDirection direction)
 	}
 }
 
-//!	ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`ƒ‚[ƒh‚©‚ç”²‚¯‚é
+//!	ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒãƒ¢ãƒ¼ãƒ‰ã‹ã‚‰æŠœã‘ã‚‹
 void CEditView::ISearchExit()
 {
-	// ƒV[ƒPƒ“ƒX‚ğã‘‚«‚µ‚ÄŒ»İ‚ÌŒŸõƒL[‚ğˆÛ‚·‚é
+	// ã‚·ãƒ¼ã‚±ãƒ³ã‚¹ã‚’ä¸Šæ›¸ãã—ã¦ç¾åœ¨ã®æ¤œç´¢ã‚­ãƒ¼ã‚’ç¶­æŒã™ã‚‹
 	if( m_strCurSearchKey.size() < _MAX_PATH ){
 		CSearchKeywordManager().AddToSearchKeyArr( m_strCurSearchKey.c_str() );
 	}
@@ -261,24 +261,24 @@ void CEditView::ISearchExit()
 		m_strCurSearchKey.clear();
 	}
 
-	//ƒ}ƒEƒXƒJ[ƒ\ƒ‹‚ğŒ³‚É–ß‚·
+	//ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ã‚’å…ƒã«æˆ»ã™
 	POINT point1;
 	GetCursorPos(&point1);
 	OnMOUSEMOVE(0,point1.x,point1.y);
 
-	//ƒXƒe[ƒ^ƒX•\¦ƒGƒŠƒA‚ğƒNƒŠƒA
+	//ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹è¡¨ç¤ºã‚¨ãƒªã‚¢ã‚’ã‚¯ãƒªã‚¢
 	SendStatusMessage(_T(""));
 
 }
 
 /*!
-	@brief ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`‚ÌÀs(1•¶š’Ç‰Á)
+	@brief ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒã®å®Ÿè¡Œ(1æ–‡å­—è¿½åŠ )
 	
-	@param wChar [in] ’Ç‰Á‚·‚é•¶š (1byte or 2byte)
+	@param wChar [in] è¿½åŠ ã™ã‚‹æ–‡å­— (1byte or 2byte)
 */
 void CEditView::ISearchExec(DWORD wChar)
 {
-	//“Áê•¶š‚Íˆ—‚µ‚È‚¢
+	//ç‰¹æ®Šæ–‡å­—ã¯å‡¦ç†ã—ãªã„
 	switch ( wChar){
 		case L'\r':
 		case L'\n':
@@ -305,13 +305,13 @@ void CEditView::ISearchExec(DWORD wChar)
 }
 
 /*!
-	@brief ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`‚ÌÀs(•¶š—ñ’Ç‰Á)
+	@brief ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒã®å®Ÿè¡Œ(æ–‡å­—åˆ—è¿½åŠ )
 	
-	@param pszText [in] ’Ç‰Á‚·‚é•¶š—ñ
+	@param pszText [in] è¿½åŠ ã™ã‚‹æ–‡å­—åˆ—
 */
 void CEditView::ISearchExec(LPCWSTR pszText)
 {
-	//ˆê•¶š‚¸‚Â•ª‰ğ‚µ‚ÄÀs
+	//ä¸€æ–‡å­—ãšã¤åˆ†è§£ã—ã¦å®Ÿè¡Œ
 
 	const WCHAR* p;
 	DWORD c;
@@ -331,16 +331,16 @@ void CEditView::ISearchExec(LPCWSTR pszText)
 }
 
 /*!
-	@brief ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`‚ÌÀs
+	@brief ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒã®å®Ÿè¡Œ
 
-	@param bNext [in] true:Ÿ‚ÌŒó•â‚ğŒŸõ, false:Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚Ì‚Ü‚ÜŒŸõ
+	@param bNext [in] true:æ¬¡ã®å€™è£œã‚’æ¤œç´¢, false:ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®ã¾ã¾æ¤œç´¢
 */
 void CEditView::ISearchExec(bool bNext) 
 {
-	//ŒŸõ‚ğÀs‚·‚é.
+	//æ¤œç´¢ã‚’å®Ÿè¡Œã™ã‚‹.
 
 	if ( (m_strCurSearchKey.size() == 0) || (m_nISearchMode == SEARCH_NONE)){
-		//ƒXƒe[ƒ^ƒX‚Ì•\¦
+		//ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ã®è¡¨ç¤º
 		CNativeT msg;
 		ISearchSetStatusMsg(&msg);
 		SendStatusMessage(msg.GetStringPtr());
@@ -360,7 +360,7 @@ void CEditView::ISearchExec(bool bNext)
 			nIdx1 = CLayoutInt(0);
 			break;
 		case SEARCH_BACKWARD:
-			//ÅŒã‚©‚çŒŸõ
+			//æœ€å¾Œã‹ã‚‰æ¤œç´¢
 			CLogicInt nLineP;
 			int nIdxP;
 			nLineP =  m_pcEditDoc->m_cDocLineMgr.GetLineCount() - CLogicInt(1);
@@ -373,15 +373,15 @@ void CEditView::ISearchExec(bool bNext)
 		}
 	}else if (GetSelectionInfo().IsTextSelected()){
 		switch( m_nISearchDirection * 2 + (bNext ? 1: 0)){
-			case (SEARCH_FORWARD * 2): //‘O•ûŒŸõ‚ÅŒ»İˆÊ’u‚©‚çŒŸõ‚Ì‚Æ‚«
-			case (SEARCH_BACKWARD * 2 + 1): //Œã•ûŒŸõ‚ÅŸ‚ğŒŸõ‚Ì‚Æ‚«
-				//‘I‘ğ”ÍˆÍ‚Ìæ“ª‚ğŒŸõŠJnˆÊ’u‚É
+			case (SEARCH_FORWARD * 2): //å‰æ–¹æ¤œç´¢ã§ç¾åœ¨ä½ç½®ã‹ã‚‰æ¤œç´¢ã®ã¨ã
+			case (SEARCH_BACKWARD * 2 + 1): //å¾Œæ–¹æ¤œç´¢ã§æ¬¡ã‚’æ¤œç´¢ã®ã¨ã
+				//é¸æŠç¯„å›²ã®å…ˆé ­ã‚’æ¤œç´¢é–‹å§‹ä½ç½®ã«
 				nLine = GetSelectionInfo().m_sSelect.GetFrom().GetY2();
 				nIdx1 = GetSelectionInfo().m_sSelect.GetFrom().GetX2();
 				break;
-			case (SEARCH_BACKWARD * 2): //Œã•ûŒŸõ‚ÅŒ»İˆÊ’u‚©‚çŒŸõ
-			case (SEARCH_FORWARD * 2 + 1): //‘O•ûŒŸõ‚ÅŸ‚ğŒŸõ
-				//‘I‘ğ”ÍˆÍ‚ÌŒã‚ë‚©‚ç
+			case (SEARCH_BACKWARD * 2): //å¾Œæ–¹æ¤œç´¢ã§ç¾åœ¨ä½ç½®ã‹ã‚‰æ¤œç´¢
+			case (SEARCH_FORWARD * 2 + 1): //å‰æ–¹æ¤œç´¢ã§æ¬¡ã‚’æ¤œç´¢
+				//é¸æŠç¯„å›²ã®å¾Œã‚ã‹ã‚‰
 				nLine = GetSelectionInfo().m_sSelect.GetTo().GetY2();
 				nIdx1 = GetSelectionInfo().m_sSelect.GetTo().GetX2();
 				break;
@@ -391,7 +391,7 @@ void CEditView::ISearchExec(bool bNext)
 		nIdx1  = GetCaret().GetCaretLayoutPos().GetX2();
 	}
 
-	//Œ…ˆÊ’u‚©‚çindex‚É•ÏŠ·
+	//æ¡ä½ç½®ã‹ã‚‰indexã«å¤‰æ›
 	const CLayout* pCLayout = m_pcEditDoc->m_cLayoutMgr.SearchLineByLayoutY( nLine );
 	CLogicInt nIdx = LineColumnToIndex( pCLayout, nIdx1 );
 
@@ -412,14 +412,14 @@ void CEditView::ISearchExec(bool bNext)
 	CLayoutRange sMatchRange;
 
 	int nSearchResult = m_pcEditDoc->m_cLayoutMgr.SearchWord(
-		nLine,						// ŒŸõŠJnƒŒƒCƒAƒEƒgs
-		nIdx,						// ŒŸõŠJnƒf[ƒ^ˆÊ’u
-		m_nISearchDirection,		// ŒŸõ•ûŒü
-		&sMatchRange,				// ƒ}ƒbƒ`ƒŒƒCƒAƒEƒg”ÍˆÍ
+		nLine,						// æ¤œç´¢é–‹å§‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
+		nIdx,						// æ¤œç´¢é–‹å§‹ãƒ‡ãƒ¼ã‚¿ä½ç½®
+		m_nISearchDirection,		// æ¤œç´¢æ–¹å‘
+		&sMatchRange,				// ãƒãƒƒãƒãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆç¯„å›²
 		m_sSearchPattern
 	);
 	if( nSearchResult == 0 ){
-		/*ŒŸõŒ‹‰Ê‚ª‚È‚¢*/
+		/*æ¤œç´¢çµæœãŒãªã„*/
 		msg.AppendString(LS(STR_EDITVWISRCH_NOMATCH));
 		SendStatusMessage(msg.GetStringPtr());
 		
@@ -430,8 +430,8 @@ void CEditView::ISearchExec(bool bNext)
 			m_sISearchHistory[m_nISearchHistoryCount].Set(GetCaret().GetCaretLayoutPos());
 		}
 	}else{
-		//ŒŸõŒ‹‰Ê‚ ‚è
-		//ƒLƒƒƒŒƒbƒgˆÚ“®
+		//æ¤œç´¢çµæœã‚ã‚Š
+		//ã‚­ãƒ£ãƒ¬ãƒƒãƒˆç§»å‹•
 		GetCaret().MoveCursor( sMatchRange.GetFrom(), true, _CARETMARGINRATE / 3 );
 		
 		//	2005.06.24 Moca
@@ -448,7 +448,7 @@ void CEditView::ISearchExec(bool bNext)
 	return ;
 }
 
-//!	ƒoƒbƒNƒXƒy[ƒX‚ğ‰Ÿ‚³‚ê‚½‚Æ‚«‚Ìˆ—
+//!	ãƒãƒƒã‚¯ã‚¹ãƒšãƒ¼ã‚¹ã‚’æŠ¼ã•ã‚ŒãŸã¨ãã®å‡¦ç†
 void CEditView::ISearchBack(void) {
 	if(m_nISearchHistoryCount==0) return;
 	
@@ -456,10 +456,10 @@ void CEditView::ISearchBack(void) {
 		m_bCurSrchKeyMark = false;
 		m_bISearchFirst = true;
 	}else if( m_bISearchFlagHistory[m_nISearchHistoryCount] == false){
-		//ŒŸõ•¶š‚ğ‚Ö‚ç‚·
+		//æ¤œç´¢æ–‡å­—ã‚’ã¸ã‚‰ã™
 		size_t l = m_strCurSearchKey.size();
 		if (l > 0 ){
-			//ÅŒã‚Ì•¶š‚Ìˆê‚Â‘O
+			//æœ€å¾Œã®æ–‡å­—ã®ä¸€ã¤å‰
 			wchar_t* p = (wchar_t*)CNativeW::GetCharPrev( m_strCurSearchKey.c_str(), l, &m_strCurSearchKey.c_str()[l] );
 			size_t new_len = p - m_strCurSearchKey.c_str();
 			m_strCurSearchKey.resize( new_len );
@@ -491,27 +491,27 @@ void CEditView::ISearchBack(void) {
 
 	Redraw();
 
-	//ƒXƒe[ƒ^ƒX•\¦
+	//ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹è¡¨ç¤º
 	CNativeT msg;
 	ISearchSetStatusMsg(&msg);
 	SendStatusMessage(msg.GetStringPtr());
 	
 }
 
-//!	“ü—Í•¶š‚©‚çAŒŸõ•¶š‚ğ¶¬‚·‚éB
+//!	å…¥åŠ›æ–‡å­—ã‹ã‚‰ã€æ¤œç´¢æ–‡å­—ã‚’ç”Ÿæˆã™ã‚‹ã€‚
 void CEditView::ISearchWordMake(void)
 {
 	switch ( m_nISearchMode ) {
-	case SEARCH_NORMAL: // ’ÊíƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`
-	case SEARCH_REGEXP: // ³‹K•\Œ»ƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`
+	case SEARCH_NORMAL: // é€šå¸¸ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ
+	case SEARCH_REGEXP: // æ­£è¦è¡¨ç¾ã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ
 		m_sSearchPattern.SetPattern(this->GetHwnd(), m_strCurSearchKey.c_str(), m_strCurSearchKey.size(), m_sCurSearchOption, &m_CurRegexp);
 		break;
-	case SEARCH_MIGEMO: // MIGEMOƒCƒ“ƒNƒŠƒƒ“ƒ^ƒ‹ƒT[ƒ`
+	case SEARCH_MIGEMO: // MIGEMOã‚¤ãƒ³ã‚¯ãƒªãƒ¡ãƒ³ã‚¿ãƒ«ã‚µãƒ¼ãƒ
 		{
-			//migemo‚Å‘{‚·
+			//migemoã§æœã™
 			std::wstring strMigemoWord = m_pcmigemo->migemo_query_w(m_strCurSearchKey.c_str());
 			
-			/* ŒŸõƒpƒ^[ƒ“‚ÌƒRƒ“ƒpƒCƒ‹ */
+			/* æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã®ã‚³ãƒ³ãƒ‘ã‚¤ãƒ« */
 			const wchar_t* p = strMigemoWord.c_str();
 			m_sSearchPattern.SetPattern(this->GetHwnd(), p, (int)strMigemoWord.size(), m_sCurSearchOption, &m_CurRegexp);
 
@@ -520,16 +520,16 @@ void CEditView::ISearchWordMake(void)
 	}
 }
 
-/*!	@brief ISearchƒƒbƒZ[ƒW\’z
+/*!	@brief ISearchãƒ¡ãƒƒã‚»ãƒ¼ã‚¸æ§‹ç¯‰
 
-	Œ»İ‚ÌƒT[ƒ`ƒ‚[ƒh‹y‚ÑŒŸõ’†•¶š—ñ‚©‚ç
-	ƒƒbƒZ[ƒWƒGƒŠƒA‚É•\¦‚·‚é•¶š—ñ‚ğ\’z‚·‚é
+	ç¾åœ¨ã®ã‚µãƒ¼ãƒãƒ¢ãƒ¼ãƒ‰åŠã³æ¤œç´¢ä¸­æ–‡å­—åˆ—ã‹ã‚‰
+	ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚¨ãƒªã‚¢ã«è¡¨ç¤ºã™ã‚‹æ–‡å­—åˆ—ã‚’æ§‹ç¯‰ã™ã‚‹
 	
-	@param msg [out] ƒƒbƒZ[ƒWƒoƒbƒtƒ@
+	@param msg [out] ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒãƒƒãƒ•ã‚¡
 	
 	@author isearch
 	@date 2004/10/13
-	@date 2005.01.13 genta •¶š—ñC³
+	@date 2005.01.13 genta æ–‡å­—åˆ—ä¿®æ­£
 */
 void CEditView::ISearchSetStatusMsg(CNativeT* msg) const
 {
@@ -560,14 +560,14 @@ void CEditView::ISearchSetStatusMsg(CNativeT* msg) const
 }
 
 /*!
-	ISearchó‘Ô‚ğƒc[ƒ‹ƒo[‚É”½‰f‚³‚¹‚éD
+	ISearchçŠ¶æ…‹ã‚’ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã«åæ˜ ã•ã›ã‚‹ï¼
 	
 	@sa CEditWnd::IsFuncChecked()
 
-	@param nCommand [in] ’²‚×‚½‚¢ƒRƒ}ƒ“ƒh‚ÌID
-	@return true:ƒ`ƒFƒbƒN—L‚è / false: ƒ`ƒFƒbƒN–³‚µ
+	@param nCommand [in] èª¿ã¹ãŸã„ã‚³ãƒãƒ³ãƒ‰ã®ID
+	@return true:ãƒã‚§ãƒƒã‚¯æœ‰ã‚Š / false: ãƒã‚§ãƒƒã‚¯ç„¡ã—
 	
-	@date 2005.01.10 genta V‹Kì¬
+	@date 2005.01.10 genta æ–°è¦ä½œæˆ
 */
 bool CEditView::IsISearchEnabled(int nCommand) const
 {

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -38,37 +38,37 @@
 #include "recent/CRecent.h"
 
 /*
-	w’èƒtƒ@ƒCƒ‹‚Ìw’èˆÊ’u‚Éƒ^ƒOƒWƒƒƒ“ƒv‚·‚éB
+	æŒ‡å®šãƒ•ã‚¡ã‚¤ãƒ«ã®æŒ‡å®šä½ç½®ã«ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ã™ã‚‹ã€‚
 
 	@author	MIK
-	@date	2003.04.13	V‹Kì¬
-	@date	2003.04.21 genta bClose’Ç‰Á
-	@date	2004.05.29 Moca 0ˆÈ‰º‚ªw’è‚³‚ê‚½‚Æ‚«‚ÍA‘Pˆ‚·‚é
-	@date	2007.02.17 genta ‘Š‘ÎƒpƒX‚ÌŠî€ƒfƒBƒŒƒNƒgƒŠw¦‚ğ’Ç‰Á
+	@date	2003.04.13	æ–°è¦ä½œæˆ
+	@date	2003.04.21 genta bCloseè¿½åŠ 
+	@date	2004.05.29 Moca 0ä»¥ä¸‹ãŒæŒ‡å®šã•ã‚ŒãŸã¨ãã¯ã€å–„å‡¦ã™ã‚‹
+	@date	2007.02.17 genta ç›¸å¯¾ãƒ‘ã‚¹ã®åŸºæº–ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªæŒ‡ç¤ºã‚’è¿½åŠ 
 */
 bool CEditView::TagJumpSub(
 	const TCHAR*	pszFileName,
-	CMyPoint		ptJumpTo,		//!< ƒWƒƒƒ“ƒvˆÊ’u(1ŠJn)
-	bool			bClose,			//!< [in] true: Œ³ƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚é / false: Œ³ƒEƒBƒ“ƒhƒE‚ğ•Â‚¶‚È‚¢
+	CMyPoint		ptJumpTo,		//!< ã‚¸ãƒ£ãƒ³ãƒ—ä½ç½®(1é–‹å§‹)
+	bool			bClose,			//!< [in] true: å…ƒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ã‚‹ / false: å…ƒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’é–‰ã˜ãªã„
 	bool			bRelFromIni,
-	bool*			pbJumpToSelf	//!< [out] ƒIƒvƒVƒ‡ƒ“NULL‰ÂB©•ª‚ÉƒWƒƒƒ“ƒv‚µ‚½‚©
+	bool*			pbJumpToSelf	//!< [out] ã‚ªãƒ—ã‚·ãƒ§ãƒ³NULLå¯ã€‚è‡ªåˆ†ã«ã‚¸ãƒ£ãƒ³ãƒ—ã—ãŸã‹
 )
 {
 	HWND	hwndOwner;
 	POINT	poCaret;
-	// 2004/06/21 novice ƒ^ƒOƒWƒƒƒ“ƒv‹@”\’Ç‰Á
+	// 2004/06/21 novice ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½è¿½åŠ 
 	TagJump	tagJump;
 
 	if( pbJumpToSelf ){
 		*pbJumpToSelf = false;
 	}
 
-	// QÆŒ³ƒEƒBƒ“ƒhƒE•Û‘¶
+	// å‚ç…§å…ƒã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ä¿å­˜
 	tagJump.hwndReferer = CEditWnd::getInstance()->GetHwnd();
 
-	//	Feb. 17, 2007 genta Àsƒtƒ@ƒCƒ‹‚©‚ç‚Ì‘Š‘Îw’è‚Ìê‡‚Í
-	//	—\‚ßâ‘ÎƒpƒX‚É•ÏŠ·‚·‚éD(ƒL[ƒ[ƒhƒwƒ‹ƒvƒWƒƒƒ“ƒv‚Å—p‚¢‚é)
-	// 2007.05.19 ryoji ‘Š‘ÎƒpƒX‚Íİ’èƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒpƒX‚ğ—Dæ
+	//	Feb. 17, 2007 genta å®Ÿè¡Œãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ç›¸å¯¾æŒ‡å®šã®å ´åˆã¯
+	//	äºˆã‚çµ¶å¯¾ãƒ‘ã‚¹ã«å¤‰æ›ã™ã‚‹ï¼(ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã‚¸ãƒ£ãƒ³ãƒ—ã§ç”¨ã„ã‚‹)
+	// 2007.05.19 ryoji ç›¸å¯¾ãƒ‘ã‚¹ã¯è¨­å®šãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‘ã‚¹ã‚’å„ªå…ˆ
 	TCHAR	szJumpToFile[1024];
 	if( bRelFromIni && _IS_REL_PATH( pszFileName ) ){
 		GetInidirOrExedir( szJumpToFile, pszFileName );
@@ -77,37 +77,37 @@ bool CEditView::TagJumpSub(
 		_tcscpy( szJumpToFile, pszFileName );
 	}
 
-	/* ƒƒ“ƒOƒtƒ@ƒCƒ‹–¼‚ğæ“¾‚·‚é */
+	/* ãƒ­ãƒ³ã‚°ãƒ•ã‚¡ã‚¤ãƒ«åã‚’å–å¾—ã™ã‚‹ */
 	TCHAR	szWork[1024];
 	if( FALSE != ::GetLongFileName( szJumpToFile, szWork ) )
 	{
 		_tcscpy( szJumpToFile, szWork );
 	}
 
-// 2004/06/21 novice ƒ^ƒOƒWƒƒƒ“ƒv‹@”\’Ç‰Á
-// 2004/07/05 ‚İ‚¿‚Î‚È
-// “¯ˆêƒtƒ@ƒCƒ‹‚¾‚ÆSendMesssage‚Å GetCaret().GetCaretLayoutPos().GetX2(),GetCaret().GetCaretLayoutPos().GetY2()‚ªXV‚³‚ê‚Ä‚µ‚Ü‚¢A
-// ƒWƒƒƒ“ƒvæ‚ÌêŠ‚ªƒWƒƒƒ“ƒvŒ³‚Æ‚µ‚Ä•Û‘¶‚³‚ê‚Ä‚µ‚Ü‚Á‚Ä‚¢‚é‚Ì‚ÅA
-// ‚»‚Ì‘O‚Å•Û‘¶‚·‚é‚æ‚¤‚É•ÏXB
+// 2004/06/21 novice ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½è¿½åŠ 
+// 2004/07/05 ã¿ã¡ã°ãª
+// åŒä¸€ãƒ•ã‚¡ã‚¤ãƒ«ã ã¨SendMesssageã§ GetCaret().GetCaretLayoutPos().GetX2(),GetCaret().GetCaretLayoutPos().GetY2()ãŒæ›´æ–°ã•ã‚Œã¦ã—ã¾ã„ã€
+// ã‚¸ãƒ£ãƒ³ãƒ—å…ˆã®å ´æ‰€ãŒã‚¸ãƒ£ãƒ³ãƒ—å…ƒã¨ã—ã¦ä¿å­˜ã•ã‚Œã¦ã—ã¾ã£ã¦ã„ã‚‹ã®ã§ã€
+// ãã®å‰ã§ä¿å­˜ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´ã€‚
 
-	/* ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ· */
+	/* ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ› */
 	GetDocument()->m_cLayoutMgr.LayoutToLogic(
 		GetCaret().GetCaretLayoutPos(),
 		&tagJump.point
 	);
 
-	// ƒ^ƒOƒWƒƒƒ“ƒvî•ñ‚Ì•Û‘¶
+	// ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±ã®ä¿å­˜
 	CTagJumpManager().PushTagJump(&tagJump);
 
 
-	/* w’èƒtƒ@ƒCƒ‹‚ªŠJ‚©‚ê‚Ä‚¢‚é‚©’²‚×‚é */
-	/* ŠJ‚©‚ê‚Ä‚¢‚éê‡‚ÍŠJ‚¢‚Ä‚¢‚éƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹‚à•Ô‚· */
-	/* ƒtƒ@ƒCƒ‹‚ğŠJ‚¢‚Ä‚¢‚é‚© */
+	/* æŒ‡å®šãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‹ã‹ã‚Œã¦ã„ã‚‹ã‹èª¿ã¹ã‚‹ */
+	/* é–‹ã‹ã‚Œã¦ã„ã‚‹å ´åˆã¯é–‹ã„ã¦ã„ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ«ã‚‚è¿”ã™ */
+	/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã„ã¦ã„ã‚‹ã‹ */
 	if( CShareData::getInstance()->IsPathOpened( szJumpToFile, &hwndOwner ) )
 	{
-		// 2004.05.13 Moca ƒ}ƒCƒiƒX’l‚Í–³Œø
+		// 2004.05.13 Moca ãƒã‚¤ãƒŠã‚¹å€¤ã¯ç„¡åŠ¹
 		if( 0 < ptJumpTo.y ){
-			/* ƒJ[ƒ\ƒ‹‚ğˆÚ“®‚³‚¹‚é */
+			/* ã‚«ãƒ¼ã‚½ãƒ«ã‚’ç§»å‹•ã•ã›ã‚‹ */
 			poCaret.y = ptJumpTo.y - 1;
 			if( 0 < ptJumpTo.x ){
 				poCaret.x = ptJumpTo.x - 1;
@@ -117,7 +117,7 @@ bool CEditView::TagJumpSub(
 			GetDllShareData().m_sWorkBuffer.m_LogicPoint.Set(CLogicInt(poCaret.x), CLogicInt(poCaret.y));
 			::SendMessageAny( hwndOwner, MYWM_SETCARETPOS, 0, 0 );
 		}
-		/* ƒAƒNƒeƒBƒu‚É‚·‚é */
+		/* ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹ */
 		ActivateFrameWindow( hwndOwner );
 		if( tagJump.hwndReferer == hwndOwner ){
 			if( pbJumpToSelf ){
@@ -126,7 +126,7 @@ bool CEditView::TagJumpSub(
 		}
 	}
 	else{
-		/* V‚µ‚­ŠJ‚­ */
+		/* æ–°ã—ãé–‹ã */
 		EditInfo	inf;
 		bool		bSuccess;
 
@@ -140,26 +140,26 @@ bool CEditView::TagJumpSub(
 			G_AppInstance(),
 			this->GetHwnd(),
 			&inf,
-			false,	/* ƒrƒ…[ƒ‚[ƒh‚© */
-			true	//	“¯Šúƒ‚[ƒh‚ÅŠJ‚­
+			false,	/* ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ã‹ */
+			true	//	åŒæœŸãƒ¢ãƒ¼ãƒ‰ã§é–‹ã
 		);
 
-		if( ! bSuccess )	//	ƒtƒ@ƒCƒ‹‚ªŠJ‚¯‚È‚©‚Á‚½
+		if( ! bSuccess )	//	ãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‹ã‘ãªã‹ã£ãŸ
 			return false;
 
 		//	Apr. 23, 2001 genta
-		//	hwndOwner‚É’l‚ª“ü‚ç‚È‚­‚È‚Á‚Ä‚µ‚Ü‚Á‚½‚½‚ß‚É
-		//	Tag Jump Back‚ª“®ì‚µ‚È‚­‚È‚Á‚Ä‚¢‚½‚Ì‚ğC³
+		//	hwndOwnerã«å€¤ãŒå…¥ã‚‰ãªããªã£ã¦ã—ã¾ã£ãŸãŸã‚ã«
+		//	Tag Jump BackãŒå‹•ä½œã—ãªããªã£ã¦ã„ãŸã®ã‚’ä¿®æ­£
 		if( !CShareData::getInstance()->IsPathOpened( szJumpToFile, &hwndOwner ) )
 			return false;
 	}
 
-	// 2006.12.30 ryoji •Â‚¶‚éˆ—‚ÍÅŒã‚Éiˆ—ˆÊ’uˆÚ“®j
-	//	Apr. 2003 genta •Â‚¶‚é‚©‚Ç‚¤‚©‚Íˆø”‚É‚æ‚é
-	//	grepŒ‹‰Ê‚©‚çEnter‚ÅƒWƒƒƒ“ƒv‚·‚é‚Æ‚±‚ë‚ÉCtrl”»’èˆÚ“®
+	// 2006.12.30 ryoji é–‰ã˜ã‚‹å‡¦ç†ã¯æœ€å¾Œã«ï¼ˆå‡¦ç†ä½ç½®ç§»å‹•ï¼‰
+	//	Apr. 2003 genta é–‰ã˜ã‚‹ã‹ã©ã†ã‹ã¯å¼•æ•°ã«ã‚ˆã‚‹
+	//	grepçµæœã‹ã‚‰Enterã§ã‚¸ãƒ£ãƒ³ãƒ—ã™ã‚‹ã¨ã“ã‚ã«Ctrlåˆ¤å®šç§»å‹•
 	if( bClose )
 	{
-		GetCommander().Command_WINCLOSE();	//	’§í‚·‚é‚¾‚¯B
+		GetCommander().Command_WINCLOSE();	//	æŒ‘æˆ¦ã™ã‚‹ã ã‘ã€‚
 	}
 
 	return true;
@@ -167,26 +167,26 @@ bool CEditView::TagJumpSub(
 
 
 
-/*! w’èŠg’£q‚Ìƒtƒ@ƒCƒ‹‚É‘Î‰‚·‚éƒtƒ@ƒCƒ‹‚ğŠJ‚­•â•ŠÖ”
+/*! æŒ‡å®šæ‹¡å¼µå­ã®ãƒ•ã‚¡ã‚¤ãƒ«ã«å¯¾å¿œã™ã‚‹ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ãè£œåŠ©é–¢æ•°
 
-	@date 2003.06.28 Moca ƒwƒbƒ_Eƒ\[ƒXƒtƒ@ƒCƒ‹ƒI[ƒvƒ“‹@”\‚ÌƒR[ƒh‚ğ“‡
-	@date 2008.04.09 ryoji ˆ—‘ÎÛ(file_ext)‚ÆŠJ‚­‘ÎÛ(open_ext)‚Ìˆµ‚¢‚ª‹t‚É‚È‚Á‚Ä‚¢‚½‚Ì‚ğC³
+	@date 2003.06.28 Moca ãƒ˜ãƒƒãƒ€ãƒ»ã‚½ãƒ¼ã‚¹ãƒ•ã‚¡ã‚¤ãƒ«ã‚ªãƒ¼ãƒ—ãƒ³æ©Ÿèƒ½ã®ã‚³ãƒ¼ãƒ‰ã‚’çµ±åˆ
+	@date 2008.04.09 ryoji å‡¦ç†å¯¾è±¡(file_ext)ã¨é–‹ãå¯¾è±¡(open_ext)ã®æ‰±ã„ãŒé€†ã«ãªã£ã¦ã„ãŸã®ã‚’ä¿®æ­£
 */
 BOOL CEditView::OPEN_ExtFromtoExt(
-	BOOL			bCheckOnly,		//!< [in] true: ƒ`ƒFƒbƒN‚Ì‚İs‚Á‚Äƒtƒ@ƒCƒ‹‚ÍŠJ‚©‚È‚¢
-	BOOL			bBeepWhenMiss,	//!< [in] true: ƒtƒ@ƒCƒ‹‚ğŠJ‚¯‚È‚©‚Á‚½ê‡‚ÉŒx‰¹‚ğo‚·
-	const TCHAR*	file_ext[],		//!< [in] ˆ—‘ÎÛ‚Æ‚·‚éŠg’£q
-	const TCHAR*	open_ext[],		//!< [in] ŠJ‚­‘ÎÛ‚Æ‚·‚éŠg’£q
-	int				file_extno,		//!< [in] ˆ—‘ÎÛŠg’£qƒŠƒXƒg‚Ì—v‘f”
-	int				open_extno,		//!< [in] ŠJ‚­‘ÎÛŠg’£qƒŠƒXƒg‚Ì—v‘f”
-	const TCHAR*	errmes			//!< [in] ƒtƒ@ƒCƒ‹‚ğŠJ‚¯‚È‚©‚Á‚½ê‡‚É•\¦‚·‚éƒGƒ‰[ƒƒbƒZ[ƒW
+	BOOL			bCheckOnly,		//!< [in] true: ãƒã‚§ãƒƒã‚¯ã®ã¿è¡Œã£ã¦ãƒ•ã‚¡ã‚¤ãƒ«ã¯é–‹ã‹ãªã„
+	BOOL			bBeepWhenMiss,	//!< [in] true: ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ãªã‹ã£ãŸå ´åˆã«è­¦å‘ŠéŸ³ã‚’å‡ºã™
+	const TCHAR*	file_ext[],		//!< [in] å‡¦ç†å¯¾è±¡ã¨ã™ã‚‹æ‹¡å¼µå­
+	const TCHAR*	open_ext[],		//!< [in] é–‹ãå¯¾è±¡ã¨ã™ã‚‹æ‹¡å¼µå­
+	int				file_extno,		//!< [in] å‡¦ç†å¯¾è±¡æ‹¡å¼µå­ãƒªã‚¹ãƒˆã®è¦ç´ æ•°
+	int				open_extno,		//!< [in] é–‹ãå¯¾è±¡æ‹¡å¼µå­ãƒªã‚¹ãƒˆã®è¦ç´ æ•°
+	const TCHAR*	errmes			//!< [in] ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã‘ãªã‹ã£ãŸå ´åˆã«è¡¨ç¤ºã™ã‚‹ã‚¨ãƒ©ãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸
 )
 {
-//From Here Feb. 7, 2001 JEPRO ’Ç‰Á
+//From Here Feb. 7, 2001 JEPRO è¿½åŠ 
 	int		i;
 //To Here Feb. 7, 2001
 
-	/* •ÒW’†ƒtƒ@ƒCƒ‹‚ÌŠg’£q‚ğ’²‚×‚é */
+	/* ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ã®æ‹¡å¼µå­ã‚’èª¿ã¹ã‚‹ */
 	for( i = 0; i < file_extno; i++ ){
 		if( CheckEXT( GetDocument()->m_cDocFile.GetFilePath(), file_ext[i] ) ){
 			goto open_c;
@@ -224,12 +224,12 @@ open_c:;
 		return TRUE;
 	}
 
-	/* w’èƒtƒ@ƒCƒ‹‚ªŠJ‚©‚ê‚Ä‚¢‚é‚©’²‚×‚é */
-	/* ŠJ‚©‚ê‚Ä‚¢‚éê‡‚ÍŠJ‚¢‚Ä‚¢‚éƒEƒBƒ“ƒhƒE‚Ìƒnƒ“ƒhƒ‹‚à•Ô‚· */
-	/* ƒtƒ@ƒCƒ‹‚ğŠJ‚¢‚Ä‚¢‚é‚© */
+	/* æŒ‡å®šãƒ•ã‚¡ã‚¤ãƒ«ãŒé–‹ã‹ã‚Œã¦ã„ã‚‹ã‹èª¿ã¹ã‚‹ */
+	/* é–‹ã‹ã‚Œã¦ã„ã‚‹å ´åˆã¯é–‹ã„ã¦ã„ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ãƒãƒ³ãƒ‰ãƒ«ã‚‚è¿”ã™ */
+	/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã„ã¦ã„ã‚‹ã‹ */
 	if( CShareData::getInstance()->IsPathOpened( szPath, &hwndOwner ) ){
 	}else{
-		/* •¶šƒR[ƒh‚Í‚±‚Ìƒtƒ@ƒCƒ‹‚É‡‚í‚¹‚é */
+		/* æ–‡å­—ã‚³ãƒ¼ãƒ‰ã¯ã“ã®ãƒ•ã‚¡ã‚¤ãƒ«ã«åˆã‚ã›ã‚‹ */
 		SLoadInfo sLoadInfo;
 		sLoadInfo.cFilePath = szPath;
 		sLoadInfo.eCharCode = GetDocument()->GetDocumentEncoding();
@@ -241,85 +241,85 @@ open_c:;
 			NULL,
 			true
 		);
-		/* ƒtƒ@ƒCƒ‹‚ğŠJ‚¢‚Ä‚¢‚é‚© */
+		/* ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã„ã¦ã„ã‚‹ã‹ */
 		if( CShareData::getInstance()->IsPathOpened( szPath, &hwndOwner ) ){
 		}else{
-			// 2011.01.12 ryoji ƒGƒ‰[‚Í•\¦‚µ‚È‚¢‚Å‚¨‚­
-			// ƒtƒ@ƒCƒ‹ƒTƒCƒY‚ª‘å‚«‚·‚¬‚Ä“Ç‚Ş‚©‚Ç‚¤‚©–â‚¢‡‚í‚¹‚Ä‚¢‚é‚æ‚¤‚Èê‡‚Å‚àƒGƒ‰[•\¦‚É‚È‚é‚Ì‚Í•Ï
-			// OpenNewEditor()‚Ü‚½‚Í‹N“®‚³‚ê‚½‘¤‚ÌƒƒbƒZ[ƒW•\¦‚Å\•ª‚Æv‚í‚ê‚é
+			// 2011.01.12 ryoji ã‚¨ãƒ©ãƒ¼ã¯è¡¨ç¤ºã—ãªã„ã§ãŠã
+			// ãƒ•ã‚¡ã‚¤ãƒ«ã‚µã‚¤ã‚ºãŒå¤§ãã™ãã¦èª­ã‚€ã‹ã©ã†ã‹å•ã„åˆã‚ã›ã¦ã„ã‚‹ã‚ˆã†ãªå ´åˆã§ã‚‚ã‚¨ãƒ©ãƒ¼è¡¨ç¤ºã«ãªã‚‹ã®ã¯å¤‰
+			// OpenNewEditor()ã¾ãŸã¯èµ·å‹•ã•ã‚ŒãŸå´ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸è¡¨ç¤ºã§ååˆ†ã¨æ€ã‚ã‚Œã‚‹
 
 			//ErrorMessage( this->GetHwnd(), _T("%ts\n\n%ts\n\n"), errmes, szPath );
 			return FALSE;
 		}
 	}
-	/* ƒAƒNƒeƒBƒu‚É‚·‚é */
+	/* ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹ */
 	ActivateFrameWindow( hwndOwner );
 
-// 2004/06/21 novice ƒ^ƒOƒWƒƒƒ“ƒv‹@”\’Ç‰Á
-// 2004/07/09 genta/Moca ƒ^ƒOƒWƒƒƒ“ƒvƒoƒbƒN‚Ì“o˜^‚ªæ‚èœ‚©‚ê‚Ä‚¢‚½‚ªA
-//            ‚±‚¿‚ç‚Å‚à]—ˆ‚Ç‚¨‚è“o˜^‚·‚é
+// 2004/06/21 novice ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½è¿½åŠ 
+// 2004/07/09 genta/Moca ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ãƒãƒƒã‚¯ã®ç™»éŒ²ãŒå–ã‚Šé™¤ã‹ã‚Œã¦ã„ãŸãŒã€
+//            ã“ã¡ã‚‰ã§ã‚‚å¾“æ¥ã©ãŠã‚Šç™»éŒ²ã™ã‚‹
 	TagJump	tagJump;
 	/*
-	  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-	  ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
-	  ¨
-	  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
+	  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+	  ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
+	  â†’
+	  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
 	*/
 	GetDocument()->m_cLayoutMgr.LayoutToLogic(
 		GetCaret().GetCaretLayoutPos(),
 		&tagJump.point
 	);
 	tagJump.hwndReferer = CEditWnd::getInstance()->GetHwnd();
-	// ƒ^ƒOƒWƒƒƒ“ƒvî•ñ‚Ì•Û‘¶
+	// ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æƒ…å ±ã®ä¿å­˜
 	CTagJumpManager().PushTagJump(&tagJump);
 	return TRUE;
 }
 
 
-/*!	@brief Ü‚è•Ô‚µ‚Ì“®ì‚ğŒˆ’è
+/*!	@brief æŠ˜ã‚Šè¿”ã—ã®å‹•ä½œã‚’æ±ºå®š
 
-	ƒgƒOƒ‹ƒRƒ}ƒ“ƒhuŒ»İ‚ÌƒEƒBƒ“ƒhƒE•‚ÅÜ‚è•Ô‚µv‚ğs‚Á‚½ê‡‚Ì“®ì‚ğŒˆ’è‚·‚é
+	ãƒˆã‚°ãƒ«ã‚³ãƒãƒ³ãƒ‰ã€Œç¾åœ¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ã§æŠ˜ã‚Šè¿”ã—ã€ã‚’è¡Œã£ãŸå ´åˆã®å‹•ä½œã‚’æ±ºå®šã™ã‚‹
 	
 	@retval TGWRAP_NONE No action
-	@retval TGWRAP_FULL Å‘å’l
-	@retval TGWRAP_WINDOW ƒEƒBƒ“ƒhƒE•
-	@retval TGWRAP_PROP İ’è’l
+	@retval TGWRAP_FULL æœ€å¤§å€¤
+	@retval TGWRAP_WINDOW ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…
+	@retval TGWRAP_PROP è¨­å®šå€¤
 
-	@date 2006.01.08 genta ƒƒjƒ…[•\¦‚Å“¯ˆê‚Ì”»’è‚ğg‚¤‚½‚ßCCommand_WRAPWINDOWWIDTH()‚æ‚è•ª—£D
-	@date 2006.01.08 genta ”»’èğŒ‚ğŒ©’¼‚µ
-	@date 2008.06.08 ryoji ƒEƒBƒ“ƒhƒE•İ’è‚É‚Ô‚ç‰º‚°—]”’‚ğ’Ç‰Á
+	@date 2006.01.08 genta ãƒ¡ãƒ‹ãƒ¥ãƒ¼è¡¨ç¤ºã§åŒä¸€ã®åˆ¤å®šã‚’ä½¿ã†ãŸã‚ï¼ŒCommand_WRAPWINDOWWIDTH()ã‚ˆã‚Šåˆ†é›¢ï¼
+	@date 2006.01.08 genta åˆ¤å®šæ¡ä»¶ã‚’è¦‹ç›´ã—
+	@date 2008.06.08 ryoji ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…è¨­å®šã«ã¶ã‚‰ä¸‹ã’ä½™ç™½ã‚’è¿½åŠ 
 */
 CEditView::TOGGLE_WRAP_ACTION CEditView::GetWrapMode( CKetaXInt* _newKetas )
 {
 	CKetaXInt& newKetas=*_newKetas;
-	//@@@ 2002.01.14 YAZAKI Œ»İ‚ÌƒEƒBƒ“ƒhƒE•‚ÅÜ‚è•Ô‚³‚ê‚Ä‚¢‚é‚Æ‚«‚ÍAÅ‘å’l‚É‚·‚éƒRƒ}ƒ“ƒhB
-	//2002/04/08 YAZAKI ‚Æ‚«‚Ç‚«ƒEƒBƒ“ƒhƒE•‚ÅÜ‚è•Ô‚³‚ê‚È‚¢‚±‚Æ‚ª‚ ‚éƒoƒOC³B
-	// 20051022 aroka Œ»İ‚ÌƒEƒBƒ“ƒhƒE•¨Å‘å’l¨•¶‘ƒ^ƒCƒv‚Ì‰Šú’l ‚ğƒgƒOƒ‹‚É‚·‚éƒRƒ}ƒ“ƒh
-	// ƒEƒBƒ“ƒhƒE•==•¶‘ƒ^ƒCƒv||Å‘å’l==•¶‘ƒ^ƒCƒv ‚Ìê‡‚ª‚ ‚é‚½‚ß”»’è‡˜‚É’ˆÓ‚·‚éB
+	//@@@ 2002.01.14 YAZAKI ç¾åœ¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ã§æŠ˜ã‚Šè¿”ã•ã‚Œã¦ã„ã‚‹ã¨ãã¯ã€æœ€å¤§å€¤ã«ã™ã‚‹ã‚³ãƒãƒ³ãƒ‰ã€‚
+	//2002/04/08 YAZAKI ã¨ãã©ãã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ã§æŠ˜ã‚Šè¿”ã•ã‚Œãªã„ã“ã¨ãŒã‚ã‚‹ãƒã‚°ä¿®æ­£ã€‚
+	// 20051022 aroka ç¾åœ¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…â†’æœ€å¤§å€¤â†’æ–‡æ›¸ã‚¿ã‚¤ãƒ—ã®åˆæœŸå€¤ ã‚’ãƒˆã‚°ãƒ«ã«ã™ã‚‹ã‚³ãƒãƒ³ãƒ‰
+	// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…==æ–‡æ›¸ã‚¿ã‚¤ãƒ—||æœ€å¤§å€¤==æ–‡æ›¸ã‚¿ã‚¤ãƒ— ã®å ´åˆãŒã‚ã‚‹ãŸã‚åˆ¤å®šé †åºã«æ³¨æ„ã™ã‚‹ã€‚
 	/*	Jan.  8, 2006 genta
-		‚¶‚ã‚¤‚¶‚³‚ñ‚Ì—v–]‚É‚æ‚è”»’è•û–@‚ğÄlDŒ»İ‚Ì•‚É‡‚í‚¹‚é‚Ì‚ğÅ—Dæ‚ÉD
+		ã˜ã‚…ã†ã˜ã•ã‚“ã®è¦æœ›ã«ã‚ˆã‚Šåˆ¤å®šæ–¹æ³•ã‚’å†è€ƒï¼ç¾åœ¨ã®å¹…ã«åˆã‚ã›ã‚‹ã®ã‚’æœ€å„ªå…ˆã«ï¼
 	
-		Šî–{“®ìF İ’è’l¨ƒEƒBƒ“ƒhƒE•
-			¨(ƒEƒBƒ“ƒhƒE•‚Æ‡‚Á‚Ä‚¢‚È‚¯‚ê‚Î)¨ƒEƒBƒ“ƒhƒE•¨ã‚Ö–ß‚é
-			¨(ƒEƒBƒ“ƒhƒE•‚Æ‡‚Á‚Ä‚¢‚½‚ç)¨Å‘å’l¨İ’è’l
-			‚½‚¾‚µCÅ‘å’l==İ’è’l‚Ìê‡‚É‚ÍÅ‘å’l¨İ’è’l‚Ì‘JˆÚ‚ªÈ—ª‚³‚ê‚Äã‚É–ß‚é
+		åŸºæœ¬å‹•ä½œï¼š è¨­å®šå€¤â†’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…
+			â†’(ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ã¨åˆã£ã¦ã„ãªã‘ã‚Œã°)â†’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…â†’ä¸Šã¸æˆ»ã‚‹
+			â†’(ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ã¨åˆã£ã¦ã„ãŸã‚‰)â†’æœ€å¤§å€¤â†’è¨­å®šå€¤
+			ãŸã ã—ï¼Œæœ€å¤§å€¤==è¨­å®šå€¤ã®å ´åˆã«ã¯æœ€å¤§å€¤â†’è¨­å®šå€¤ã®é·ç§»ãŒçœç•¥ã•ã‚Œã¦ä¸Šã«æˆ»ã‚‹
 			
-			ƒEƒBƒ“ƒhƒE•‚ª‹É’[‚É‹·‚¢ê‡‚É‚ÍƒEƒBƒ“ƒhƒE•‚É‡‚í‚¹‚é‚±‚Æ‚Ío—ˆ‚È‚¢‚ªC
-			İ’è’l‚ÆÅ‘å’l‚ÌƒgƒOƒ‹‚Í‰Â”\D
+			ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ãŒæ¥µç«¯ã«ç‹­ã„å ´åˆã«ã¯ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ã«åˆã‚ã›ã‚‹ã“ã¨ã¯å‡ºæ¥ãªã„ãŒï¼Œ
+			è¨­å®šå€¤ã¨æœ€å¤§å€¤ã®ãƒˆã‚°ãƒ«ã¯å¯èƒ½ï¼
 
-		0)Œ»İ‚ÌƒeƒLƒXƒg‚ÌÜ‚è•Ô‚µ•û–@!=w’èŒ…‚ÅÜ‚è•Ô‚·F•ÏX•s”\
-		1)Œ»İ‚ÌÜ‚è•Ô‚µ•==ƒEƒBƒ“ƒhƒE• : Å‘å’l
-		2)Œ»İ‚ÌÜ‚è•Ô‚µ•!=ƒEƒBƒ“ƒhƒE•
-		3)¨ƒEƒBƒ“ƒhƒE•‚ª‹É’[‚É‹·‚¢ê‡
-		4)@„¤¨Ü‚è•Ô‚µ•!=Å‘å’l : Å‘å’l
-		5)@„¤¨Ü‚è•Ô‚µ•==Å‘å’l
-		6)@@@„¤¨Å‘å’l==İ’è’l : •ÏX•s”\
-		7)@@@„¤¨Å‘å’l!=İ’è’l : İ’è’l
-		8)¨ƒEƒBƒ“ƒhƒE•‚ª\•ª‚É‚ ‚é
-		9)@„¤¨Ü‚è•Ô‚µ•==Å‘å’l
-		a)@@@„¤¨Å‘å’l!=İ’è’l : İ’è’l
-	 	b)@@@„¤¨Å‘å’l==İ’è’l : ƒEƒBƒ“ƒhƒE•
-		c)@„¤¨ƒEƒBƒ“ƒhƒE•
+		0)ç¾åœ¨ã®ãƒ†ã‚­ã‚¹ãƒˆã®æŠ˜ã‚Šè¿”ã—æ–¹æ³•!=æŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™ï¼šå¤‰æ›´ä¸èƒ½
+		1)ç¾åœ¨ã®æŠ˜ã‚Šè¿”ã—å¹…==ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹… : æœ€å¤§å€¤
+		2)ç¾åœ¨ã®æŠ˜ã‚Šè¿”ã—å¹…!=ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…
+		3)â†’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ãŒæ¥µç«¯ã«ç‹­ã„å ´åˆ
+		4)ã€€â””â†’æŠ˜ã‚Šè¿”ã—å¹…!=æœ€å¤§å€¤ : æœ€å¤§å€¤
+		5)ã€€â””â†’æŠ˜ã‚Šè¿”ã—å¹…==æœ€å¤§å€¤
+		6)ã€€ã€€ã€€â””â†’æœ€å¤§å€¤==è¨­å®šå€¤ : å¤‰æ›´ä¸èƒ½
+		7)ã€€ã€€ã€€â””â†’æœ€å¤§å€¤!=è¨­å®šå€¤ : è¨­å®šå€¤
+		8)â†’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ãŒååˆ†ã«ã‚ã‚‹
+		9)ã€€â””â†’æŠ˜ã‚Šè¿”ã—å¹…==æœ€å¤§å€¤
+		a)ã€€ã€€ã€€â””â†’æœ€å¤§å€¤!=è¨­å®šå€¤ : è¨­å®šå€¤
+	 	b)ã€€ã€€ã€€â””â†’æœ€å¤§å€¤==è¨­å®šå€¤ : ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…
+		c)ã€€â””â†’ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…
 	*/
 	
 	if (GetDocument()->m_cLayoutMgr.GetMaxLineKetas() == ViewColNumToWrapColNum( GetTextArea().m_nViewColNum ) ){
@@ -352,7 +352,7 @@ CEditView::TOGGLE_WRAP_ACTION CEditView::GetWrapMode( CKetaXInt* _newKetas )
 			
 		}
 		else {	// b) c)
-			//	Œ»İ‚ÌƒEƒBƒ“ƒhƒE•
+			//	ç¾åœ¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…
 			newKetas = ViewColNumToWrapColNum( GetTextArea().m_nViewColNum );
 			return TGWRAP_WINDOW;
 		}
@@ -368,9 +368,9 @@ void CEditView::AddToCmdArr( const TCHAR* szCmd )
 }
 
 
-/*! ³‹K•\Œ»‚ÌŒŸõƒpƒ^[ƒ“‚ğ•K—v‚É‰‚¶‚ÄXV‚·‚é(ƒ‰ƒCƒuƒ‰ƒŠ‚ªg—p‚Å‚«‚È‚¢‚Æ‚«‚ÍFALSE‚ğ•Ô‚·)
-	@date 2002.01.16 hor ‹¤’ÊƒƒWƒbƒN‚ğŠÖ”‚É‚µ‚½‚¾‚¯EEE
-	@date 2011.12.18 Moca ƒV[ƒPƒ“ƒX“±“üBview‚ÌŒŸõ•¶š—ñ’·‚Ì“P”pB‘¼‚Ìƒrƒ…[‚ÌŒŸõğŒ‚ğˆø‚«Œp‚®ƒtƒ‰ƒO‚ğ’Ç‰Á
+/*! æ­£è¦è¡¨ç¾ã®æ¤œç´¢ãƒ‘ã‚¿ãƒ¼ãƒ³ã‚’å¿…è¦ã«å¿œã˜ã¦æ›´æ–°ã™ã‚‹(ãƒ©ã‚¤ãƒ–ãƒ©ãƒªãŒä½¿ç”¨ã§ããªã„ã¨ãã¯FALSEã‚’è¿”ã™)
+	@date 2002.01.16 hor å…±é€šãƒ­ã‚¸ãƒƒã‚¯ã‚’é–¢æ•°ã«ã—ãŸã ã‘ãƒ»ãƒ»ãƒ»
+	@date 2011.12.18 Moca ã‚·ãƒ¼ã‚±ãƒ³ã‚¹å°å…¥ã€‚viewã®æ¤œç´¢æ–‡å­—åˆ—é•·ã®æ’¤å»ƒã€‚ä»–ã®ãƒ“ãƒ¥ãƒ¼ã®æ¤œç´¢æ¡ä»¶ã‚’å¼•ãç¶™ããƒ•ãƒ©ã‚°ã‚’è¿½åŠ 
 */
 BOOL CEditView::ChangeCurRegexp( bool bRedrawIfChanged )
 {
@@ -379,9 +379,9 @@ BOOL CEditView::ChangeCurRegexp( bool bRedrawIfChanged )
 	if( GetDllShareData().m_Common.m_sSearch.m_bInheritKeyOtherView
 			&& m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence
 		|| 0 == m_strCurSearchKey.size() ){
-		// —š—ğ‚ÌŒŸõƒL[‚ÉXV
-		m_strCurSearchKey = GetDllShareData().m_sSearchKeywords.m_aSearchKeys[0];		// ŒŸõ•¶š—ñ
-		m_sCurSearchOption = GetDllShareData().m_Common.m_sSearch.m_sSearchOption;// ŒŸõ^’uŠ·  ƒIƒvƒVƒ‡ƒ“
+		// å±¥æ­´ã®æ¤œç´¢ã‚­ãƒ¼ã«æ›´æ–°
+		m_strCurSearchKey = GetDllShareData().m_sSearchKeywords.m_aSearchKeys[0];		// æ¤œç´¢æ–‡å­—åˆ—
+		m_sCurSearchOption = GetDllShareData().m_Common.m_sSearch.m_sSearchOption;// æ¤œç´¢ï¼ç½®æ›  ã‚ªãƒ—ã‚·ãƒ§ãƒ³
 		m_nCurSearchKeySequence = GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence;
 		bChangeState = true;
 	}else if( m_bCurSearchUpdate ){
@@ -403,9 +403,9 @@ BOOL CEditView::ChangeCurRegexp( bool bRedrawIfChanged )
 	}
 	if( ! m_bCurSrchKeyMark ){
 		m_bCurSrchKeyMark = true;
-		// ŒŸõ•¶š—ñ‚Ìƒ}[ƒN‚¾‚¯İ’è
+		// æ¤œç´¢æ–‡å­—åˆ—ã®ãƒãƒ¼ã‚¯ã ã‘è¨­å®š
 		if( bRedrawIfChanged ){
-			Redraw(); // ©ViewÄ•`‰æ
+			Redraw(); // è‡ªViewå†æç”»
 		}
 	}
 
@@ -416,14 +416,14 @@ BOOL CEditView::ChangeCurRegexp( bool bRedrawIfChanged )
 
 
 /*!
-	ƒJ[ƒ\ƒ‹s‚ğƒNƒŠƒbƒvƒ{[ƒh‚ÉƒRƒs[‚·‚é
+	ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚’ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ã‚³ãƒ”ãƒ¼ã™ã‚‹
 
-	@date 2007.10.08 ryoji V‹KiCommand_COPY()‚©‚çˆ—”²‚«o‚µj
+	@date 2007.10.08 ryoji æ–°è¦ï¼ˆCommand_COPY()ã‹ã‚‰å‡¦ç†æŠœãå‡ºã—ï¼‰
 */
 void CEditView::CopyCurLine(
-	bool			bAddCRLFWhenCopy,		//!< [in] Ü‚è•Ô‚µˆÊ’u‚É‰üsƒR[ƒh‚ğ‘}“ü‚·‚é‚©H
-	EEolType		neweol,					//!< [in] ƒRƒs[‚·‚é‚Æ‚«‚ÌEOLB
-	bool			bEnableLineModePaste	//!< [in] ƒ‰ƒCƒ“ƒ‚[ƒh“\‚è•t‚¯‚ğ‰Â”\‚É‚·‚é
+	bool			bAddCRLFWhenCopy,		//!< [in] æŠ˜ã‚Šè¿”ã—ä½ç½®ã«æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’æŒ¿å…¥ã™ã‚‹ã‹ï¼Ÿ
+	EEolType		neweol,					//!< [in] ã‚³ãƒ”ãƒ¼ã™ã‚‹ã¨ãã®EOLã€‚
+	bool			bEnableLineModePaste	//!< [in] ãƒ©ã‚¤ãƒ³ãƒ¢ãƒ¼ãƒ‰è²¼ã‚Šä»˜ã‘ã‚’å¯èƒ½ã«ã™ã‚‹
 )
 {
 	if( GetSelectionInfo().IsTextSelected() ){
@@ -435,7 +435,7 @@ void CEditView::CopyCurLine(
 		return;
 	}
 
-	/* ƒNƒŠƒbƒvƒ{[ƒh‚É“ü‚ê‚é‚×‚«ƒeƒLƒXƒgƒf[ƒ^‚ğAcmemBuf‚ÉŠi”[‚·‚é */
+	/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«å…¥ã‚Œã‚‹ã¹ããƒ†ã‚­ã‚¹ãƒˆãƒ‡ãƒ¼ã‚¿ã‚’ã€cmemBufã«æ ¼ç´ã™ã‚‹ */
 	CNativeW cmemBuf;
 	cmemBuf.SetString( pcLayout->GetPtr(), pcLayout->GetLengthWithoutEOL() );
 	if( pcLayout->GetLayoutEol().GetLen() != 0 ){
@@ -443,14 +443,14 @@ void CEditView::CopyCurLine(
 			( neweol == EOL_UNKNOWN ) ?
 				pcLayout->GetLayoutEol().GetValue2() : CEol(neweol).GetValue2()
 		);
-	}else if( bAddCRLFWhenCopy ){	// 2007.10.08 ryoji bAddCRLFWhenCopy‘Î‰ˆ—’Ç‰Á
+	}else if( bAddCRLFWhenCopy ){	// 2007.10.08 ryoji bAddCRLFWhenCopyå¯¾å¿œå‡¦ç†è¿½åŠ 
 		cmemBuf.AppendString(
 			( neweol == EOL_UNKNOWN ) ?
 				WCODE::CRLF : CEol(neweol).GetValue2()
 		);
 	}
 
-	/* ƒNƒŠƒbƒvƒ{[ƒh‚Éƒf[ƒ^cmemBuf‚Ì“à—e‚ğİ’è */
+	/* ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã«ãƒ‡ãƒ¼ã‚¿cmemBufã®å†…å®¹ã‚’è¨­å®š */
 	BOOL bSetResult = MySetClipboardData(
 		cmemBuf.GetStringPtr(),
 		cmemBuf.GetStringLength(),

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -1,5 +1,5 @@
-/*!	@file
-	@brief CEditViewƒNƒ‰ƒX‚ÌƒRƒ}ƒ“ƒhˆ—ŒnŠÖ”ŒQ
+ï»¿/*!	@file
+	@brief CEditViewã‚¯ãƒ©ã‚¹ã®ã‚³ãƒãƒ³ãƒ‰å‡¦ç†ç³»é–¢æ•°ç¾¤
 
 	@author Norio Nakatani
 */
@@ -7,7 +7,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2000, genta
 	Copyright (C) 2001, genta, asa-o, hor
-	Copyright (C) 2002, YAZAKI, hor, genta. aroka, MIK, minfu, KK, ‚©‚ë‚Æ
+	Copyright (C) 2002, YAZAKI, hor, genta. aroka, MIK, minfu, KK, ã‹ã‚ã¨
 	Copyright (C) 2003, MIK, Moca
 	Copyright (C) 2004, genta, Moca
 	Copyright (C) 2005, ryoji, genta, D.S.Koba
@@ -25,14 +25,14 @@
 #include "charset/charcode.h"
 #include "COpe.h" ///	2002/2/3 aroka from here
 #include "COpeBlk.h" ///
-#include "doc/CEditDoc.h"	//	2002/5/13 YAZAKI ƒwƒbƒ_®—
+#include "doc/CEditDoc.h"	//	2002/5/13 YAZAKI ãƒ˜ãƒƒãƒ€æ•´ç†
 #include "doc/CDocReader.h"
 #include "doc/layout/CLayout.h"
 #include "doc/logic/CDocLine.h"
 #include "cmd/CViewCommander_inline.h"
 #include "window/CEditWnd.h"
-#include "dlg/CDlgCtrlCode.h"	//ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh‚Ì“ü—Í(ƒ_ƒCƒAƒƒO)
-#include "dlg/CDlgFavorite.h"	//—š—ğ‚ÌŠÇ—	//@@@ 2003.04.08 MIK
+#include "dlg/CDlgCtrlCode.h"	//ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰ã®å…¥åŠ›(ãƒ€ã‚¤ã‚¢ãƒ­ã‚°)
+#include "dlg/CDlgFavorite.h"	//å±¥æ­´ã®ç®¡ç†	//@@@ 2003.04.08 MIK
 #include "debug/CRunningTimer.h"
 
 using namespace std; // 2002/2/3 aroka
@@ -67,15 +67,15 @@ static void StringToOpeLineData(const wchar_t* pLineData, int nLineDataLen, COpe
 }
 
 
-/*!	Œ»İˆÊ’u‚Éƒf[ƒ^‚ğ‘}“ü Ver0
+/*!	ç¾åœ¨ä½ç½®ã«ãƒ‡ãƒ¼ã‚¿ã‚’æŒ¿å…¥ Ver0
 
-	@date 2002/03/24 YAZAKI bUndoíœ
+	@date 2002/03/24 YAZAKI bUndoå‰Šé™¤
 */
 void CEditView::InsertData_CEditView(
-	CLayoutPoint	ptInsertPos,	// [in] ‘}“üˆÊ’u
-	const wchar_t*	pData,			// [in] ‘}“üƒeƒLƒXƒg
-	int				nDataLen,		// [in] ‘}“üƒeƒLƒXƒg’·B•¶š’PˆÊB
-	CLayoutPoint*	pptNewPos,		// [out] ‘}“ü‚³‚ê‚½•”•ª‚ÌŸ‚ÌˆÊ’u‚ÌƒŒƒCƒAƒEƒgˆÊ’u
+	CLayoutPoint	ptInsertPos,	// [in] æŒ¿å…¥ä½ç½®
+	const wchar_t*	pData,			// [in] æŒ¿å…¥ãƒ†ã‚­ã‚¹ãƒˆ
+	int				nDataLen,		// [in] æŒ¿å…¥ãƒ†ã‚­ã‚¹ãƒˆé•·ã€‚æ–‡å­—å˜ä½ã€‚
+	CLayoutPoint*	pptNewPos,		// [out] æŒ¿å…¥ã•ã‚ŒãŸéƒ¨åˆ†ã®æ¬¡ã®ä½ç½®ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®
 	bool			bRedraw
 )
 {
@@ -83,10 +83,10 @@ void CEditView::InsertData_CEditView(
 	MY_RUNNINGTIMER( cRunningTimer, "CEditView::InsertData_CEditView" );
 #endif
 
-	//2007.10.18 kobake COpeˆ—‚ğ‚±‚±‚É‚Ü‚Æ‚ß‚é
+	//2007.10.18 kobake COpeå‡¦ç†ã‚’ã“ã“ã«ã¾ã¨ã‚ã‚‹
 	CInsertOpe* pcOpe = NULL;
 	int opeSeq;
-	if( !m_bDoing_UndoRedo ){	/* ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚© */
+	if( !m_bDoing_UndoRedo ){	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹ */
 		pcOpe = new CInsertOpe();
 		m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(
 			ptInsertPos,
@@ -98,24 +98,24 @@ void CEditView::InsertData_CEditView(
 	}
 
 
-	pptNewPos->y = 0;			// ‘}“ü‚³‚ê‚½•”•ª‚ÌŸ‚ÌˆÊ’u‚ÌƒŒƒCƒAƒEƒgs
-	pptNewPos->x = 0;			// ‘}“ü‚³‚ê‚½•”•ª‚ÌŸ‚ÌˆÊ’u‚ÌƒŒƒCƒAƒEƒgˆÊ’u
+	pptNewPos->y = 0;			// æŒ¿å…¥ã•ã‚ŒãŸéƒ¨åˆ†ã®æ¬¡ã®ä½ç½®ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
+	pptNewPos->x = 0;			// æŒ¿å…¥ã•ã‚ŒãŸéƒ¨åˆ†ã®æ¬¡ã®ä½ç½®ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®
 
-	// ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚©
+	// ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹
 	if( GetSelectionInfo().IsTextSelected() ){
 		DeleteData( bRedraw );
 		ptInsertPos = GetCaret().GetCaretLayoutPos();
 	}
 
-	//ƒeƒLƒXƒgæ“¾ -> pLine, nLineLen, pcLayout
+	//ãƒ†ã‚­ã‚¹ãƒˆå–å¾— -> pLine, nLineLen, pcLayout
 	CLogicInt		nLineLen;
 	const CLayout*	pcLayout;
-	bool			bHintPrev = false;	// XV‚ª‘Os‚©‚ç‚É‚È‚é‰Â”\«‚ª‚ ‚é‚±‚Æ‚ğ¦´‚·‚é
-	bool			bHintNext = false;	// XV‚ªŸs‚©‚ç‚É‚È‚é‰Â”\«‚ª‚ ‚é‚±‚Æ‚ğ¦´‚·‚é
-	bool			bKinsoku;			// ‹Ö‘¥‚Ì—L–³
+	bool			bHintPrev = false;	// æ›´æ–°ãŒå‰è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹ã“ã¨ã‚’ç¤ºå”†ã™ã‚‹
+	bool			bHintNext = false;	// æ›´æ–°ãŒæ¬¡è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹ã“ã¨ã‚’ç¤ºå”†ã™ã‚‹
+	bool			bKinsoku;			// ç¦å‰‡ã®æœ‰ç„¡
 	const wchar_t*	pLine = m_pcEditDoc->m_cLayoutMgr.GetLineStr( ptInsertPos.GetY2(), &nLineLen, &pcLayout );
 
-	//‹Ö‘¥‚ª‚ ‚éê‡‚Í1s‘O‚©‚çÄ•`‰æ‚ğs‚¤	@@@ 2002.04.19 MIK
+	//ç¦å‰‡ãŒã‚ã‚‹å ´åˆã¯1è¡Œå‰ã‹ã‚‰å†æç”»ã‚’è¡Œã†	@@@ 2002.04.19 MIK
 	bKinsoku = ( m_pTypeData->m_bWordWrap
 			 || m_pTypeData->m_bKinsokuHead	//@@@ 2002.04.19 MIK
 			 || m_pTypeData->m_bKinsokuTail	//@@@ 2002.04.19 MIK
@@ -128,23 +128,23 @@ void CEditView::InsertData_CEditView(
 	CNativeW	cMem(L"");
 	COpeLineData insData;
 	if( pLine ){
-		// XV‚ª‘Os‚©‚ç‚É‚È‚é‰Â”\«‚ğ’²‚×‚é	// 2009.02.17 ryoji
-		// ¦Ü‚è•Ô‚µs“ª‚Ö‚Ì‹å“Ç“_“ü—Í‚Å‘O‚Ìs‚¾‚¯‚ªXV‚³‚ê‚éê‡‚à‚ ‚é
-		// ¦‘}“üˆÊ’u‚Ís“r’†‚Å‚à‹å“Ç“_“ü—Í{ƒ[ƒhƒ‰ƒbƒv‚Å‘O‚Ì•¶š—ñ‚©‚ç‘±‚¯‚Ä‘Os‚É‰ñ‚è‚Şê‡‚à‚ ‚é
-		if( pcLayout->GetLogicOffset() && bKinsoku ){	// Ü‚è•Ô‚µƒŒƒCƒAƒEƒgs‚©H
-			bHintPrev = true;	// XV‚ª‘Os‚©‚ç‚É‚È‚é‰Â”\«‚ª‚ ‚é
+		// æ›´æ–°ãŒå‰è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ã‚’èª¿ã¹ã‚‹	// 2009.02.17 ryoji
+		// â€»æŠ˜ã‚Šè¿”ã—è¡Œé ­ã¸ã®å¥èª­ç‚¹å…¥åŠ›ã§å‰ã®è¡Œã ã‘ãŒæ›´æ–°ã•ã‚Œã‚‹å ´åˆã‚‚ã‚ã‚‹
+		// â€»æŒ¿å…¥ä½ç½®ã¯è¡Œé€”ä¸­ã§ã‚‚å¥èª­ç‚¹å…¥åŠ›ï¼‹ãƒ¯ãƒ¼ãƒ‰ãƒ©ãƒƒãƒ—ã§å‰ã®æ–‡å­—åˆ—ã‹ã‚‰ç¶šã‘ã¦å‰è¡Œã«å›ã‚Šè¾¼ã‚€å ´åˆã‚‚ã‚ã‚‹
+		if( pcLayout->GetLogicOffset() && bKinsoku ){	// æŠ˜ã‚Šè¿”ã—ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã‹ï¼Ÿ
+			bHintPrev = true;	// æ›´æ–°ãŒå‰è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 		}
 
-		// XV‚ªŸs‚©‚ç‚É‚È‚é‰Â”\«‚ğ’²‚×‚é	// 2009.02.17 ryoji
-		// ¦Ü‚è•Ô‚µs––‚Ö‚Ì•¶š“ü—Í‚â•¶š—ñ“\‚è•t‚¯‚ÅŒ»İs‚ÍXV‚³‚ê‚¸ŸsˆÈŒã‚ªXV‚³‚ê‚éê‡‚à‚ ‚é
-		// w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é
+		// æ›´æ–°ãŒæ¬¡è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ã‚’èª¿ã¹ã‚‹	// 2009.02.17 ryoji
+		// â€»æŠ˜ã‚Šè¿”ã—è¡Œæœ«ã¸ã®æ–‡å­—å…¥åŠ›ã‚„æ–‡å­—åˆ—è²¼ã‚Šä»˜ã‘ã§ç¾åœ¨è¡Œã¯æ›´æ–°ã•ã‚Œãšæ¬¡è¡Œä»¥å¾ŒãŒæ›´æ–°ã•ã‚Œã‚‹å ´åˆã‚‚ã‚ã‚‹
+		// æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹
 		nIdxFrom = LineColumnToIndex2( pcLayout, ptInsertPos.GetX2(), &nLineAllColLen );
 
-		// sI’[‚æ‚è‰E‚É‘}“ü‚µ‚æ‚¤‚Æ‚µ‚½
+		// è¡Œçµ‚ç«¯ã‚ˆã‚Šå³ã«æŒ¿å…¥ã—ã‚ˆã†ã¨ã—ãŸ
 		if( nLineAllColLen > 0 ){
 			int nSpWidth = GetTextMetrics().CalcTextWidth3(L" ", 1);
-			// I’[’¼‘O‚©‚ç‘}“üˆÊ’u‚Ü‚Å‹ó”’‚ğ–„‚ß‚éˆ×‚Ìˆ—
-			// sI’[‚ª‰½‚ç‚©‚Ì‰üsƒR[ƒh‚©?
+			// çµ‚ç«¯ç›´å‰ã‹ã‚‰æŒ¿å…¥ä½ç½®ã¾ã§ç©ºç™½ã‚’åŸ‹ã‚ã‚‹ç‚ºã®å‡¦ç†
+			// è¡Œçµ‚ç«¯ãŒä½•ã‚‰ã‹ã®æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‹?
 			if( EOL_NONE != pcLayout->GetLayoutEol() ){
 				nIdxFrom = nLineLen - CLogicInt(1);
 				cMem.AllocStringBuffer( (Int)(ptInsertPos.GetX2() - nLineAllColLen + 1)/ nSpWidth + nDataLen );
@@ -160,7 +160,7 @@ void CEditView::InsertData_CEditView(
 					cMem += L' ';
 				}
 				cMem.AppendString( pData, nDataLen );
-				// 1s‘½‚­XV‚·‚é•K—v‚ª‚ ‚é‰Â”\«‚ª‚ ‚é
+				// 1è¡Œå¤šãæ›´æ–°ã™ã‚‹å¿…è¦ãŒã‚ã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 				bHintNext = true;
 			}
 			StringToOpeLineData( cMem.GetStringPtr(), cMem.GetStringLength(), insData, opeSeq );
@@ -172,10 +172,10 @@ void CEditView::InsertData_CEditView(
 		}
 	}
 	else{
-		// XV‚ª‘Os‚©‚ç‚É‚È‚é‰Â”\«‚ğ’²‚×‚é	// 2009.02.17 ryoji
+		// æ›´æ–°ãŒå‰è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ã‚’èª¿ã¹ã‚‹	// 2009.02.17 ryoji
 		const CLayout* pcLayoutWk = m_pcEditDoc->m_cLayoutMgr.GetBottomLayout();
-		if( pcLayoutWk && pcLayoutWk->GetLayoutEol() == EOL_NONE && bKinsoku ){	// Ü‚è•Ô‚µƒŒƒCƒAƒEƒgs‚©Hi‘Os‚ÌI’[‚Å’²¸j
-			bHintPrev = true;	// XV‚ª‘Os‚©‚ç‚É‚È‚é‰Â”\«‚ª‚ ‚é
+		if( pcLayoutWk && pcLayoutWk->GetLayoutEol() == EOL_NONE && bKinsoku ){	// æŠ˜ã‚Šè¿”ã—ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã‹ï¼Ÿï¼ˆå‰è¡Œã®çµ‚ç«¯ã§èª¿æŸ»ï¼‰
+			bHintPrev = true;	// æ›´æ–°ãŒå‰è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 		}
 		if( 0 < ptInsertPos.GetX2() ){
 			int nSpWidth = GetTextMetrics().CalcTextWidth3(L" ", 1);
@@ -193,7 +193,7 @@ void CEditView::InsertData_CEditView(
 	}
 
 
-	if( !m_bDoing_UndoRedo && pcOpe ){	// ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚©
+	if( !m_bDoing_UndoRedo && pcOpe ){	// ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹
 		m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(
 			CLayoutPoint(nColumnFrom, ptInsertPos.y),
 			&pcOpe->m_ptCaretPos_PHY_Before
@@ -201,9 +201,9 @@ void CEditView::InsertData_CEditView(
 	}
 
 
-	// •¶š—ñ‘}“ü
+	// æ–‡å­—åˆ—æŒ¿å…¥
 	CLayoutInt	nModifyLayoutLinesOld=CLayoutInt(0);
-	CLayoutInt	nInsLineNum;		/* ‘}“ü‚É‚æ‚Á‚Ä‘‚¦‚½ƒŒƒCƒAƒEƒgs‚Ì” */
+	CLayoutInt	nInsLineNum;		/* æŒ¿å…¥ã«ã‚ˆã£ã¦å¢—ãˆãŸãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®æ•° */
 	int	nInsSeq;
 	{
 		LayoutReplaceArg arg;
@@ -218,16 +218,16 @@ void CEditView::InsertData_CEditView(
 		nInsSeq = arg.nInsSeq;
 	}
 
-	// w’è‚³‚ê‚½s‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚É‘Î‰‚·‚éŒ…‚ÌˆÊ’u‚ğ’²‚×‚é
+	// æŒ‡å®šã•ã‚ŒãŸè¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ¡ã®ä½ç½®ã‚’èª¿ã¹ã‚‹
 	const wchar_t*	pLine2;
 	CLogicInt		nLineLen2;
 	pLine2 = m_pcEditDoc->m_cLayoutMgr.GetLineStr( pptNewPos->GetY2(), &nLineLen2, &pcLayout );
 	if( pLine2 ){
-		// 2007.10.15 kobake Šù‚ÉƒŒƒCƒAƒEƒg’PˆÊ‚È‚Ì‚Å•ÏŠ·‚Í•s—v
+		// 2007.10.15 kobake æ—¢ã«ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ãªã®ã§å¤‰æ›ã¯ä¸è¦
 		pptNewPos->x = pptNewPos->GetX2(); //LineIndexToColumn( pcLayout, pptNewPos->GetX2() );
 	}
 
-	//	Aug. 14, 2005 genta Ü‚è•Ô‚µ•‚ğLayoutMgr‚©‚çæ“¾‚·‚é‚æ‚¤‚É
+	//	Aug. 14, 2005 genta æŠ˜ã‚Šè¿”ã—å¹…ã‚’LayoutMgrã‹ã‚‰å–å¾—ã™ã‚‹ã‚ˆã†ã«
 	if( pptNewPos->x >= m_pcEditDoc->m_cLayoutMgr.GetMaxLineLayout() ){
 		if( m_pTypeData->m_bKinsokuRet
 		 || m_pTypeData->m_bKinsokuKuto )	//@@@ 2002.04.16 MIK
@@ -246,15 +246,15 @@ void CEditView::InsertData_CEditView(
 		}
 	}
 
-	// ó‘Ô‘JˆÚ
-	if( !m_bDoing_UndoRedo ){	/* ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚© */
+	// çŠ¶æ…‹é·ç§»
+	if( !m_bDoing_UndoRedo ){	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹ */
 		m_pcEditDoc->m_cDocEditor.SetModified(true,bRedraw);	//	Jan. 22, 2002 genta
 	}
 
-	// Ä•`‰æ
-	// s”Ô†•\¦‚É•K—v‚È•‚ğİ’è
+	// å†æç”»
+	// è¡Œç•ªå·è¡¨ç¤ºã«å¿…è¦ãªå¹…ã‚’è¨­å®š
 	if( m_pcEditWnd->DetectWidthOfLineNumberAreaAllPane( bRedraw ) ){
-		// ƒLƒƒƒŒƒbƒg‚Ì•\¦EXV
+		// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤ºãƒ»æ›´æ–°
 		GetCaret().ShowEditCaret();
 	}
 	else{
@@ -262,11 +262,11 @@ void CEditView::InsertData_CEditView(
 
 		if( bRedraw ){
 			CLayoutInt nStartLine(ptInsertPos.y);
-			// 2013.05.08 Ü‚è•Ô‚µs‚ÅEOF’¼‘O‚Å‰üs‚µ‚½‚Æ‚«EOF‚ªÄ•`‰æ‚³‚ê‚È‚¢ƒoƒO‚ÌC³
+			// 2013.05.08 æŠ˜ã‚Šè¿”ã—è¡Œã§EOFç›´å‰ã§æ”¹è¡Œã—ãŸã¨ãEOFãŒå†æç”»ã•ã‚Œãªã„ãƒã‚°ã®ä¿®æ­£
 			if( nModifyLayoutLinesOld < 1 ){
 				nModifyLayoutLinesOld = CLayoutInt(1);
 			}
-			// 2011.12.26 ³‹K•\Œ»ƒL[ƒ[ƒhEŒŸõ•¶š—ñ‚È‚Ç‚ÍAƒƒWƒbƒNs“ª‚Ü‚Å‚³‚©‚Ì‚Ú‚Á‚ÄXV‚·‚é•K—v‚ª‚ ‚é
+			// 2011.12.26 æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ»æ¤œç´¢æ–‡å­—åˆ—ãªã©ã¯ã€ãƒ­ã‚¸ãƒƒã‚¯è¡Œé ­ã¾ã§ã•ã‹ã®ã¼ã£ã¦æ›´æ–°ã™ã‚‹å¿…è¦ãŒã‚ã‚‹
 			{
 				const CLayout* pcLayoutLineFirst = m_pcEditDoc->m_cLayoutMgr.SearchLineByLayoutY( ptInsertPos.GetY2() );
 				while( pcLayoutLineFirst && 0 != pcLayoutLineFirst->GetLogicOffset() ){
@@ -281,11 +281,11 @@ void CEditView::InsertData_CEditView(
 			CLayoutYInt nLayoutTop;
 			CLayoutYInt nLayoutBottom;
 			if( 0 != nInsLineNum ){
-				// ƒXƒNƒ[ƒ‹ƒo[‚Ìó‘Ô‚ğXV‚·‚é
+				// ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®çŠ¶æ…‹ã‚’æ›´æ–°ã™ã‚‹
 				AdjustScrollBars();
 
-				// •`‰æŠJnsˆÊ’u‚ğ’²®‚·‚é	// 2009.02.17 ryoji
-				if( bHintPrev ){	// XV‚ª‘Os‚©‚ç‚É‚È‚é‰Â”\«‚ª‚ ‚é
+				// æç”»é–‹å§‹è¡Œä½ç½®ã‚’èª¿æ•´ã™ã‚‹	// 2009.02.17 ryoji
+				if( bHintPrev ){	// æ›´æ–°ãŒå‰è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 					nStartLine--;
 				}
 
@@ -297,12 +297,12 @@ void CEditView::InsertData_CEditView(
 				nLayoutBottom = CLayoutYInt(-1);
 			}
 			else{
-				// •`‰æŠJnsˆÊ’u‚Æ•`‰æs”‚ğ’²®‚·‚é	// 2009.02.17 ryoji
-				if( bHintPrev ){	// XV‚ª‘Os‚©‚ç‚É‚È‚é‰Â”\«‚ª‚ ‚é
+				// æç”»é–‹å§‹è¡Œä½ç½®ã¨æç”»è¡Œæ•°ã‚’èª¿æ•´ã™ã‚‹	// 2009.02.17 ryoji
+				if( bHintPrev ){	// æ›´æ–°ãŒå‰è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 					nStartLine--;
 					nModifyLayoutLinesOld++;
 				}
-				if( bHintNext ){	// XV‚ªŸs‚©‚ç‚É‚È‚é‰Â”\«‚ª‚ ‚é
+				if( bHintNext ){	// æ›´æ–°ãŒæ¬¡è¡Œã‹ã‚‰ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 					nModifyLayoutLinesOld++;
 				}
 
@@ -310,7 +310,7 @@ void CEditView::InsertData_CEditView(
 				ps.rcPaint.left = 0;
 				ps.rcPaint.right = GetTextArea().GetAreaRight();
 
-				// 2002.02.25 Mod By KK Ÿs (ptInsertPos.y - GetTextArea().GetViewTopLine() - 1); => (ptInsertPos.y - GetTextArea().GetViewTopLine());
+				// 2002.02.25 Mod By KK æ¬¡è¡Œ (ptInsertPos.y - GetTextArea().GetViewTopLine() - 1); => (ptInsertPos.y - GetTextArea().GetViewTopLine());
 				//ps.rcPaint.top = GetTextArea().GetAreaTop() + GetTextMetrics().GetHankakuDy() * (ptInsertPos.y - GetTextArea().GetViewTopLine() - 1);
 				ps.rcPaint.top = GetTextArea().GenerateYPx(nStartLine);
 				ps.rcPaint.bottom = GetTextArea().GenerateYPx(nStartLine + nModifyLayoutLinesOld);
@@ -320,7 +320,7 @@ void CEditView::InsertData_CEditView(
 			HDC hdc = this->GetDC();
 			OnPaint( hdc, &ps, FALSE );
 			this->ReleaseDC( hdc );
-			// 2014.07.16 ‘¼‚Ìƒrƒ…[(ƒ~ƒjƒ}ƒbƒv)‚ÌÄ•`‰æ‚ğ—}§‚·‚é
+			// 2014.07.16 ä»–ã®ãƒ“ãƒ¥ãƒ¼(ãƒŸãƒ‹ãƒãƒƒãƒ—)ã®å†æç”»ã‚’æŠ‘åˆ¶ã™ã‚‹
 			if( 0 == nInsLineNum ){
 				for(int i = 0; i < m_pcEditWnd->GetAllViewCount(); i++ ){
 					CEditView* pcView = &m_pcEditWnd->GetView(i);
@@ -337,7 +337,7 @@ void CEditView::InsertData_CEditView(
 		}
 	}
 
-	//2007.10.18 kobake ‚±‚±‚ÅCOpeˆ—‚ğ‚Ü‚Æ‚ß‚é
+	//2007.10.18 kobake ã“ã“ã§COpeå‡¦ç†ã‚’ã¾ã¨ã‚ã‚‹
 	if( !m_bDoing_UndoRedo ){
 		m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(
 			*pptNewPos,
@@ -345,22 +345,22 @@ void CEditView::InsertData_CEditView(
 		);
 		pcOpe->m_nOrgSeq = nInsSeq;
 
-		// ‘€ì‚Ì’Ç‰Á
+		// æ“ä½œã®è¿½åŠ 
 		m_cCommander.GetOpeBlk()->AppendOpe( pcOpe );
 	}
 }
 
 
-/*!	w’èˆÊ’u‚Ìw’è’·ƒf[ƒ^íœ
+/*!	æŒ‡å®šä½ç½®ã®æŒ‡å®šé•·ãƒ‡ãƒ¼ã‚¿å‰Šé™¤
 
-	@param _ptCaretPos [in]  íœƒf[ƒ^‚ÌˆÊ’u
-	@param nDelLen [out] íœƒf[ƒ^‚ÌƒTƒCƒY
-	@param pcMem [out]  íœ‚µ‚½ƒf[ƒ^(NULL‰Â”\)
+	@param _ptCaretPos [in]  å‰Šé™¤ãƒ‡ãƒ¼ã‚¿ã®ä½ç½®
+	@param nDelLen [out] å‰Šé™¤ãƒ‡ãƒ¼ã‚¿ã®ã‚µã‚¤ã‚º
+	@param pcMem [out]  å‰Šé™¤ã—ãŸãƒ‡ãƒ¼ã‚¿(NULLå¯èƒ½)
 
-	@date 2002/03/24 YAZAKI bUndoíœ
-	@date 2002/05/12 YAZAKI bRedraw, bRedraw2íœií‚ÉFALSE‚¾‚©‚çj
-	@date 2007/10/17 kobake (d—v)pcMem‚ÌŠ—LÒ‚ªğŒ‚É‚æ‚èCOpe‚ÉˆÚ‚Á‚½‚èˆÚ‚ç‚È‚©‚Á‚½‚è‚·‚éU‚é•‘‚¢‚Í
-	                        ”ñí‚É‚â‚â‚±‚µ‚­¬—‚ÌŒ³‚É‚È‚é‚½‚ßAí‚ÉApcMem‚ÌŠ—LÒ‚ÍˆÚ‚³‚È‚¢‚æ‚¤‚Éd—l•ÏXB
+	@date 2002/03/24 YAZAKI bUndoå‰Šé™¤
+	@date 2002/05/12 YAZAKI bRedraw, bRedraw2å‰Šé™¤ï¼ˆå¸¸ã«FALSEã ã‹ã‚‰ï¼‰
+	@date 2007/10/17 kobake (é‡è¦)pcMemã®æ‰€æœ‰è€…ãŒæ¡ä»¶ã«ã‚ˆã‚ŠCOpeã«ç§»ã£ãŸã‚Šç§»ã‚‰ãªã‹ã£ãŸã‚Šã™ã‚‹æŒ¯ã‚‹èˆã„ã¯
+	                        éå¸¸ã«ã‚„ã‚„ã“ã—ãæ··ä¹±ã®å…ƒã«ãªã‚‹ãŸã‚ã€å¸¸ã«ã€pcMemã®æ‰€æœ‰è€…ã¯ç§»ã•ãªã„ã‚ˆã†ã«ä»•æ§˜å¤‰æ›´ã€‚
 */
 void CEditView::DeleteData2(
 	const CLayoutPoint& _ptCaretPos,
@@ -382,7 +382,7 @@ void CEditView::DeleteData2(
 	}
 	nIdxFrom = LineColumnToIndex( pcLayout, _ptCaretPos.GetX2() );
 
-	//2007.10.18 kobake COpe‚Ì¶¬‚ğ‚±‚±‚É‚Ü‚Æ‚ß‚é
+	//2007.10.18 kobake COpeã®ç”Ÿæˆã‚’ã“ã“ã«ã¾ã¨ã‚ã‚‹
 	CDeleteOpe*	pcOpe = NULL;
 	CLayoutInt columnFrom = LineIndexToColumn( pcLayout, nIdxFrom );
 	CLayoutInt columnTo = LineIndexToColumn( pcLayout, nIdxFrom + nDelLen );
@@ -403,7 +403,7 @@ void CEditView::DeleteData2(
 		pmemDeleted = &memDeleted;
 	}
 
-	/* ƒf[ƒ^íœ */
+	/* ãƒ‡ãƒ¼ã‚¿å‰Šé™¤ */
 	{
 		LayoutReplaceArg arg;
 		arg.sDelRange.SetFrom(_ptCaretPos);
@@ -414,7 +414,7 @@ void CEditView::DeleteData2(
 		m_pcEditDoc->m_cLayoutMgr.ReplaceData_CLayoutMgr( &arg );
 	}
 
-	/* ‘I‘ğƒGƒŠƒA‚Ìæ“ª‚ÖƒJ[ƒ\ƒ‹‚ğˆÚ“® */
+	/* é¸æŠã‚¨ãƒªã‚¢ã®å…ˆé ­ã¸ã‚«ãƒ¼ã‚½ãƒ«ã‚’ç§»å‹• */
 	GetCaret().MoveCursor( _ptCaretPos, false );
 	GetCaret().m_nCaretPosX_Prev = GetCaret().GetCaretLayoutPos().GetX();
 
@@ -430,14 +430,14 @@ void CEditView::DeleteData2(
 			pcMem->AppendNativeData(memDeleted[i].cmemLine);
 		}
 	}
-	//2007.10.18 kobake COpe‚Ì’Ç‰Á‚ğ‚±‚±‚É‚Ü‚Æ‚ß‚é
+	//2007.10.18 kobake COpeã®è¿½åŠ ã‚’ã“ã“ã«ã¾ã¨ã‚ã‚‹
 	if( pcOpe ){
 		pcOpe->m_cOpeLineData.swap(memDeleted);
 		m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(
 			_ptCaretPos,
 			&pcOpe->m_ptCaretPos_PHY_After
 		);
-		// ‘€ì‚Ì’Ç‰Á
+		// æ“ä½œã®è¿½åŠ 
 		m_cCommander.GetOpeBlk()->AppendOpe( pcOpe );
 	}
 }
@@ -446,13 +446,13 @@ void CEditView::DeleteData2(
 
 
 
-/*!	ƒJ[ƒ\ƒ‹ˆÊ’u‚Ü‚½‚Í‘I‘ğƒGƒŠƒA‚ğíœ
+/*!	ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã¾ãŸã¯é¸æŠã‚¨ãƒªã‚¢ã‚’å‰Šé™¤
 
-	@date 2002/03/24 YAZAKI bUndoíœ
+	@date 2002/03/24 YAZAKI bUndoå‰Šé™¤
 */
 void CEditView::DeleteData(
 	bool	bRedraw
-//	BOOL	bUndo	/* Undo‘€ì‚©‚Ç‚¤‚© */
+//	BOOL	bUndo	/* Undoæ“ä½œã‹ã©ã†ã‹ */
 )
 {
 #ifdef _DEBUG
@@ -469,10 +469,10 @@ void CEditView::DeleteData(
 	CLayoutRect		rcSel;
 	const CLayout*	pcLayout;
 
-	// ƒeƒLƒXƒg‚Ì‘¶İ‚µ‚È‚¢ƒGƒŠƒA‚Ìíœ‚ÍA‘I‘ğ”ÍˆÍ‚ÌƒLƒƒƒ“ƒZƒ‹‚ÆƒJ[ƒ\ƒ‹ˆÚ“®‚Ì‚İ‚Æ‚·‚é	// 2008.08.05 ryoji
-	if( GetSelectionInfo().IsTextSelected() ){		// ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚©
+	// ãƒ†ã‚­ã‚¹ãƒˆã®å­˜åœ¨ã—ãªã„ã‚¨ãƒªã‚¢ã®å‰Šé™¤ã¯ã€é¸æŠç¯„å›²ã®ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã¨ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ã®ã¿ã¨ã™ã‚‹	// 2008.08.05 ryoji
+	if( GetSelectionInfo().IsTextSelected() ){		// ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹
 		if( IsEmptyArea( GetSelectionInfo().m_sSelect.GetFrom(), GetSelectionInfo().m_sSelect.GetTo(), true, GetSelectionInfo().IsBoxSelecting() ) ){
-			// ƒJ[ƒ\ƒ‹‚ğ‘I‘ğ”ÍˆÍ‚Ì¶ã‚ÉˆÚ“®
+			// ã‚«ãƒ¼ã‚½ãƒ«ã‚’é¸æŠç¯„å›²ã®å·¦ä¸Šã«ç§»å‹•
 			GetCaret().MoveCursor(
 				CLayoutPoint(
 					GetSelectionInfo().m_sSelect.GetFrom().GetX2() < GetSelectionInfo().m_sSelect.GetTo().GetX2() ? GetSelectionInfo().m_sSelect.GetFrom().GetX2() : GetSelectionInfo().m_sSelect.GetTo().GetX2(),
@@ -491,32 +491,32 @@ void CEditView::DeleteData(
 
 	CLayoutPoint ptCaretPosOld = GetCaret().GetCaretLayoutPos();
 
-	/* ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚© */
+	/* ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹ */
 	if( GetSelectionInfo().IsTextSelected() ){
 		CWaitCursor cWaitCursor( this->GetHwnd() );  // 2002.02.05 hor
-		if( !m_bDoing_UndoRedo ){	/* ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚© */
-			/* ‘€ì‚Ì’Ç‰Á */
+		if( !m_bDoing_UndoRedo ){	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹ */
+			/* æ“ä½œã®è¿½åŠ  */
 			m_cCommander.GetOpeBlk()->AppendOpe(
 				new CMoveCaretOpe(
-					GetCaret().GetCaretLogicPos()	// ‘€ì‘OŒã‚ÌƒLƒƒƒŒƒbƒgˆÊ’u
+					GetCaret().GetCaretLogicPos()	// æ“ä½œå‰å¾Œã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®
 				)
 			);
 		}
 
-		/* ‹éŒ`”ÍˆÍ‘I‘ğ’†‚© */
+		/* çŸ©å½¢ç¯„å›²é¸æŠä¸­ã‹ */
 		if( GetSelectionInfo().IsBoxSelecting() ){
-			m_pcEditDoc->m_cDocEditor.SetModified(true,bRedraw);	//	2002/06/04 YAZAKI ‹éŒ`‘I‘ğ‚ğíœ‚µ‚½‚Æ‚«‚É•ÏXƒ}[ƒN‚ª‚Â‚©‚È‚¢B
+			m_pcEditDoc->m_cDocEditor.SetModified(true,bRedraw);	//	2002/06/04 YAZAKI çŸ©å½¢é¸æŠã‚’å‰Šé™¤ã—ãŸã¨ãã«å¤‰æ›´ãƒãƒ¼ã‚¯ãŒã¤ã‹ãªã„ã€‚
 
 			SetDrawSwitch(false);	// 2002.01.25 hor
-			/* ‘I‘ğ”ÍˆÍ‚Ìƒf[ƒ^‚ğæ“¾ */
-			/* ³í‚ÍTRUE,”ÍˆÍ–¢‘I‘ğ‚Ìê‡‚ÍFALSE‚ğ•Ô‚· */
-			/* ‚Q“_‚ğ‘ÎŠp‚Æ‚·‚é‹éŒ`‚ğ‹‚ß‚é */
+			/* é¸æŠç¯„å›²ã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
+			/* æ­£å¸¸æ™‚ã¯TRUE,ç¯„å›²æœªé¸æŠã®å ´åˆã¯FALSEã‚’è¿”ã™ */
+			/* ï¼’ç‚¹ã‚’å¯¾è§’ã¨ã™ã‚‹çŸ©å½¢ã‚’æ±‚ã‚ã‚‹ */
 			TwoPointToRect(
 				&rcSel,
-				GetSelectionInfo().m_sSelect.GetFrom(),	// ”ÍˆÍ‘I‘ğŠJn
-				GetSelectionInfo().m_sSelect.GetTo()		// ”ÍˆÍ‘I‘ğI—¹
+				GetSelectionInfo().m_sSelect.GetFrom(),	// ç¯„å›²é¸æŠé–‹å§‹
+				GetSelectionInfo().m_sSelect.GetTo()		// ç¯„å›²é¸æŠçµ‚äº†
 			);
-			/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+			/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 			GetSelectionInfo().DisableSelectArea( bRedraw );
 
 			nIdxFrom = CLogicInt(0);
@@ -527,7 +527,7 @@ void CEditView::DeleteData(
 				if( pLine ){
 					using namespace WCODE;
 
-					/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é */
+					/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 					nIdxFrom = LineColumnToIndex( pcLayout, rcSel.left  );
 					nIdxTo	 = LineColumnToIndex( pcLayout, rcSel.right );
 
@@ -544,7 +544,7 @@ void CEditView::DeleteData(
 				}
 				nDelLen	= nDelLenNext;
 				if( nLineNum < rcSel.bottom && 0 < nDelLen ){
-					// w’èˆÊ’u‚Ìw’è’·ƒf[ƒ^íœ
+					// æŒ‡å®šä½ç½®ã®æŒ‡å®šé•·ãƒ‡ãƒ¼ã‚¿å‰Šé™¤
 					DeleteData2(
 						CLayoutPoint(rcSel.left, nLineNum + 1),
 						nDelLen,
@@ -554,86 +554,86 @@ void CEditView::DeleteData(
 			}
 			SetDrawSwitch(true);	// 2002.01.25 hor
 
-			/* s”Ô†•\¦‚É•K—v‚È•‚ğİ’è */
+			/* è¡Œç•ªå·è¡¨ç¤ºã«å¿…è¦ãªå¹…ã‚’è¨­å®š */
 			if ( m_pcEditWnd->DetectWidthOfLineNumberAreaAllPane( true ) ){
-				/* ƒLƒƒƒŒƒbƒg‚Ì•\¦EXV */
+				/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤ºãƒ»æ›´æ–° */
 				GetCaret().ShowEditCaret();
 			}
 			if( bRedraw ){
-				/* ƒXƒNƒ[ƒ‹ƒo[‚Ìó‘Ô‚ğXV‚·‚é */
+				/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®çŠ¶æ…‹ã‚’æ›´æ–°ã™ã‚‹ */
 				AdjustScrollBars();
 
-				/* Ä•`‰æ */
+				/* å†æç”» */
 				Call_OnPaint(PAINT_LINENUMBER | PAINT_BODY, false);
 			}
-			/* ‘I‘ğƒGƒŠƒA‚Ìæ“ª‚ÖƒJ[ƒ\ƒ‹‚ğˆÚ“® */
+			/* é¸æŠã‚¨ãƒªã‚¢ã®å…ˆé ­ã¸ã‚«ãƒ¼ã‚½ãƒ«ã‚’ç§»å‹• */
 			this->UpdateWindow();
 			
 			CLayoutPoint caretOld = CLayoutPoint(rcSel.left, rcSel.top);
 			m_pcEditDoc->m_cLayoutMgr.GetLineStr( rcSel.top, &nLineLen, &pcLayout );
 			if( rcSel.left <= pcLayout->CalcLayoutWidth( m_pcEditDoc->m_cLayoutMgr ) ){
-				// EOL‚æ‚è¶‚È‚ç•¶š‚Ì’PˆÊ‚É‚»‚ë‚¦‚é
+				// EOLã‚ˆã‚Šå·¦ãªã‚‰æ–‡å­—ã®å˜ä½ã«ãã‚ãˆã‚‹
 				CLogicInt nIdxCaret = LineColumnToIndex( pcLayout, rcSel.left );
 				caretOld.SetX( LineIndexToColumn( pcLayout, nIdxCaret ) );
 			}
 			GetCaret().MoveCursor( caretOld, bRedraw );
 			GetCaret().m_nCaretPosX_Prev = GetCaret().GetCaretLayoutPos().GetX();
-			if( !m_bDoing_UndoRedo ){	/* ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚© */
+			if( !m_bDoing_UndoRedo ){	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹ */
 				CMoveCaretOpe*		pcOpe = new CMoveCaretOpe();
 				m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(
 					ptCaretPosOld,
 					&pcOpe->m_ptCaretPos_PHY_Before
 				);
 
-				pcOpe->m_ptCaretPos_PHY_After = GetCaret().GetCaretLogicPos();	// ‘€ìŒã‚ÌƒLƒƒƒŒƒbƒgˆÊ’u
-				/* ‘€ì‚Ì’Ç‰Á */
+				pcOpe->m_ptCaretPos_PHY_After = GetCaret().GetCaretLogicPos();	// æ“ä½œå¾Œã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®
+				/* æ“ä½œã®è¿½åŠ  */
 				m_cCommander.GetOpeBlk()->AppendOpe( pcOpe );
 			}
 		}else{
-			/* ƒf[ƒ^’uŠ· íœ&‘}“ü‚É‚àg‚¦‚é */
+			/* ãƒ‡ãƒ¼ã‚¿ç½®æ› å‰Šé™¤&æŒ¿å…¥ã«ã‚‚ä½¿ãˆã‚‹ */
 			ReplaceData_CEditView(
 				GetSelectionInfo().m_sSelect,
-				L"",					/* ‘}“ü‚·‚éƒf[ƒ^ */
-				CLogicInt(0),			/* ‘}“ü‚·‚éƒf[ƒ^‚Ì’·‚³ */
+				L"",					/* æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ */
+				CLogicInt(0),			/* æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã®é•·ã• */
 				bRedraw,
 				m_bDoing_UndoRedo?NULL:m_cCommander.GetOpeBlk()
 			);
 		}
 	}else{
-		/* Œ»İs‚Ìƒf[ƒ^‚ğæ“¾ */
+		/* ç¾åœ¨è¡Œã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
 		pLine = m_pcEditDoc->m_cLayoutMgr.GetLineStr( GetCaret().GetCaretLayoutPos().GetY2(), &nLineLen, &pcLayout );
 		if( NULL == pLine ){
 			goto end_of_func;
 //			return;
 		}
-		/* ÅŒã‚Ìs‚ÉƒJ[ƒ\ƒ‹‚ª‚ ‚é‚©‚Ç‚¤‚© */
+		/* æœ€å¾Œã®è¡Œã«ã‚«ãƒ¼ã‚½ãƒ«ãŒã‚ã‚‹ã‹ã©ã†ã‹ */
 		bool bLastLine = ( GetCaret().GetCaretLayoutPos().GetY() == m_pcEditDoc->m_cLayoutMgr.GetLineCount() - 1 );
 
-		/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é */
+		/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 		nCurIdx = LineColumnToIndex( pcLayout, GetCaret().GetCaretLayoutPos().GetX2() );
 //		MYTRACE( _T("nLineLen=%d nCurIdx=%d \n"), nLineLen, nCurIdx);
-		if( nCurIdx == nLineLen && bLastLine ){	/* ‘SƒeƒLƒXƒg‚ÌÅŒã */
+		if( nCurIdx == nLineLen && bLastLine ){	/* å…¨ãƒ†ã‚­ã‚¹ãƒˆã®æœ€å¾Œ */
 			goto end_of_func;
 //			return;
 		}
 
-		/* w’è‚³‚ê‚½Œ…‚Ì•¶š‚ÌƒoƒCƒg”‚ğ’²‚×‚é */
+		/* æŒ‡å®šã•ã‚ŒãŸæ¡ã®æ–‡å­—ã®ãƒã‚¤ãƒˆæ•°ã‚’èª¿ã¹ã‚‹ */
 		CLogicInt	nNxtIdx;
 		CLayoutInt	nNxtPos;
 		bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 		if( WCODE::IsLineDelimiter(pLine[nCurIdx], bExtEol) ){
-			/* ‰üs */
+			/* æ”¹è¡Œ */
 			nNxtIdx = pcLayout->GetLengthWithoutEOL() + pcLayout->GetLayoutEol().GetLen();
 			nNxtPos = GetCaret().GetCaretLayoutPos().GetX() + CLayoutInt(pcLayout->GetLayoutEol().GetLen()>0?1+m_pcEditDoc->m_cLayoutMgr.GetCharSpacing():0);
 		}
 		else{
 			nNxtIdx = CLogicInt(CNativeW::GetCharNext( pLine, nLineLen, &pLine[nCurIdx] ) - pLine);
-			// w’è‚³‚ê‚½s‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚É‘Î‰‚·‚éŒ…‚ÌˆÊ’u‚ğ’²‚×‚é
+			// æŒ‡å®šã•ã‚ŒãŸè¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ¡ã®ä½ç½®ã‚’èª¿ã¹ã‚‹
 			nNxtPos = LineIndexToColumn( pcLayout, nNxtIdx );
 		}
 
 
-		/* ƒf[ƒ^’uŠ· íœ&‘}“ü‚É‚àg‚¦‚é */
+		/* ãƒ‡ãƒ¼ã‚¿ç½®æ› å‰Šé™¤&æŒ¿å…¥ã«ã‚‚ä½¿ãˆã‚‹ */
 		CLayoutRange sDelRange;
 		sDelRange.SetFrom(GetCaret().GetCaretLayoutPos());
 		sDelRange.SetTo(CLayoutPoint(nNxtPos,GetCaret().GetCaretLayoutPos().GetY()));
@@ -642,8 +642,8 @@ void CEditView::DeleteData(
 		sDelRangeLogic.SetTo(CLogicPoint(nNxtIdx + pcLayout->GetLogicOffset(), GetCaret().GetCaretLogicPos().GetY()));
 		ReplaceData_CEditView(
 			sDelRange,
-			L"",				/* ‘}“ü‚·‚éƒf[ƒ^ */
-			CLogicInt(0),		/* ‘}“ü‚·‚éƒf[ƒ^‚Ì’·‚³ */
+			L"",				/* æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ */
+			CLogicInt(0),		/* æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã®é•·ã• */
 			bRedraw,
 			m_bDoing_UndoRedo?NULL:m_cCommander.GetOpeBlk(),
 			false,
@@ -655,17 +655,17 @@ void CEditView::DeleteData(
 
 	if( m_pcEditDoc->m_cLayoutMgr.GetLineCount() > 0 ){
 		if( GetCaret().GetCaretLayoutPos().GetY() > m_pcEditDoc->m_cLayoutMgr.GetLineCount()	- 1	){
-			/* Œ»İs‚Ìƒf[ƒ^‚ğæ“¾ */
+			/* ç¾åœ¨è¡Œã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
 			const CLayout*	pcLayout;
 			pLine = m_pcEditDoc->m_cLayoutMgr.GetLineStr( m_pcEditDoc->m_cLayoutMgr.GetLineCount() - CLayoutInt(1), &nLineLen, &pcLayout );
 			if( NULL == pLine ){
 				goto end_of_func;
 			}
-			/* ‰üs‚ÅI‚í‚Á‚Ä‚¢‚é‚© */
+			/* æ”¹è¡Œã§çµ‚ã‚ã£ã¦ã„ã‚‹ã‹ */
 			if( ( EOL_NONE != pcLayout->GetLayoutEol() ) ){
 				goto end_of_func;
 			}
-			/*ƒtƒ@ƒCƒ‹‚ÌÅŒã‚ÉˆÚ“® */
+			/*ãƒ•ã‚¡ã‚¤ãƒ«ã®æœ€å¾Œã«ç§»å‹• */
 			GetCommander().Command_GOFILEEND( false );
 		}
 	}
@@ -676,9 +676,9 @@ end_of_func:;
 
 
 void CEditView::ReplaceData_CEditView(
-	const CLayoutRange&	sDelRange,			//!< [in]  íœ”ÍˆÍƒŒƒCƒAƒEƒg’PˆÊ
-	const wchar_t*		pInsData,			//!< [in]  ‘}“ü‚·‚éƒf[ƒ^
-	CLogicInt			nInsDataLen,		//!< [in]  ‘}“ü‚·‚éƒf[ƒ^‚Ì’·‚³
+	const CLayoutRange&	sDelRange,			//!< [in]  å‰Šé™¤ç¯„å›²ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½
+	const wchar_t*		pInsData,			//!< [in]  æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿
+	CLogicInt			nInsDataLen,		//!< [in]  æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã®é•·ã•
 	bool				bRedraw,
 	COpeBlk*			pcOpeBlk,
 	bool				bFastMode,
@@ -701,9 +701,9 @@ void CEditView::ReplaceData_CEditView(
 }
 
 void CEditView::ReplaceData_CEditView2(
-	const CLogicRange&	sDelRange,			// íœ”ÍˆÍBƒƒWƒbƒN’PˆÊB
-	const wchar_t*		pInsData,			// ‘}“ü‚·‚éƒf[ƒ^
-	CLogicInt			nInsDataLen,		// ‘}“ü‚·‚éƒf[ƒ^‚Ì’·‚³
+	const CLogicRange&	sDelRange,			// å‰Šé™¤ç¯„å›²ã€‚ãƒ­ã‚¸ãƒƒã‚¯å˜ä½ã€‚
+	const wchar_t*		pInsData,			// æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿
+	CLogicInt			nInsDataLen,		// æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã®é•·ã•
 	bool				bRedraw,
 	COpeBlk*			pcOpeBlk,
 	bool				bFastMode
@@ -719,33 +719,33 @@ void CEditView::ReplaceData_CEditView2(
 
 
 
-/* ƒf[ƒ^’uŠ· íœ&‘}“ü‚É‚àg‚¦‚é */
-// Jun 23, 2000 genta •Ï”–¼‚ğ‘‚«Š·‚¦–Y‚ê‚Ä‚¢‚½‚Ì‚ğC³
-// Jun. 1, 2000 genta DeleteData‚©‚çˆÚ“®‚µ‚½
+/* ãƒ‡ãƒ¼ã‚¿ç½®æ› å‰Šé™¤&æŒ¿å…¥ã«ã‚‚ä½¿ãˆã‚‹ */
+// Jun 23, 2000 genta å¤‰æ•°åã‚’æ›¸ãæ›ãˆå¿˜ã‚Œã¦ã„ãŸã®ã‚’ä¿®æ­£
+// Jun. 1, 2000 genta DeleteDataã‹ã‚‰ç§»å‹•ã—ãŸ
 bool CEditView::ReplaceData_CEditView3(
-	CLayoutRange	sDelRange,			//!< [in]  íœ”ÍˆÍƒŒƒCƒAƒEƒg’PˆÊ
-	COpeLineData*	pcmemCopyOfDeleted,	//!< [out] íœ‚³‚ê‚½ƒf[ƒ^‚ÌƒRƒs[(NULL‰Â”\)
-	COpeLineData*	pInsData,			//!< [in]  ‘}“ü‚·‚éƒf[ƒ^
+	CLayoutRange	sDelRange,			//!< [in]  å‰Šé™¤ç¯„å›²ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½
+	COpeLineData*	pcmemCopyOfDeleted,	//!< [out] å‰Šé™¤ã•ã‚ŒãŸãƒ‡ãƒ¼ã‚¿ã®ã‚³ãƒ”ãƒ¼(NULLå¯èƒ½)
+	COpeLineData*	pInsData,			//!< [in]  æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿
 	bool			bRedraw,
 	COpeBlk*		pcOpeBlk,
 	int				nDelSeq,
 	int*			pnInsSeq,
-	bool			bFastMode,			//!< [in] CDocLineMgr‚ğXV‚µ‚È‚¢,s––ƒ`ƒFƒbƒN‚ğÈ—ª‚·‚éBbRedraw==false‚Ì•K—v‚ ‚è
+	bool			bFastMode,			//!< [in] CDocLineMgrã‚’æ›´æ–°ã—ãªã„,è¡Œæœ«ãƒã‚§ãƒƒã‚¯ã‚’çœç•¥ã™ã‚‹ã€‚bRedraw==falseã®å¿…è¦ã‚ã‚Š
 	const CLogicRange*	psDelRangeLogicFast
 )
 {
-	assert( (bFastMode && bRedraw == false) || (!bFastMode) ); // bFastMode‚Ì‚Æ‚«‚Í bReadraw == false
+	assert( (bFastMode && bRedraw == false) || (!bFastMode) ); // bFastModeã®ã¨ãã¯ bReadraw == false
 	bool bUpdateAll = true;
 
 	bool bDelRangeUpdate = false;
 	{
 		//	May. 29, 2000 genta
 		//	From Here
-		//	s‚ÌŒã‚ë‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚½‚Æ‚«‚Ì•s‹ï‡‚ğ‰ñ”ğ‚·‚é‚½‚ßC
-		//	‘I‘ğ—Ìˆæ‚©‚çs––ˆÈ~‚Ì•”•ª‚ğæ‚èœ‚­D
+		//	è¡Œã®å¾Œã‚ãŒé¸æŠã•ã‚Œã¦ã„ãŸã¨ãã®ä¸å…·åˆã‚’å›é¿ã™ã‚‹ãŸã‚ï¼Œ
+		//	é¸æŠé ˜åŸŸã‹ã‚‰è¡Œæœ«ä»¥é™ã®éƒ¨åˆ†ã‚’å–ã‚Šé™¤ãï¼
 
 		if( !bFastMode ){
-			//	æ“ª
+			//	å…ˆé ­
 			const CLayout*	pcLayout;
 			CLogicInt		len;
 			const wchar_t*	line = NULL;
@@ -753,14 +753,14 @@ bool CEditView::ReplaceData_CEditView3(
 			if( line ){
 				CLogicInt pos = LineColumnToIndex( pcLayout, sDelRange.GetFrom().GetX2() );
 				//	Jun. 1, 2000 genta
-				//	“¯ˆês‚Ìs––ˆÈ~‚Ì‚İ‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚éê‡‚ğl—¶‚·‚é
+				//	åŒä¸€è¡Œã®è¡Œæœ«ä»¥é™ã®ã¿ãŒé¸æŠã•ã‚Œã¦ã„ã‚‹å ´åˆã‚’è€ƒæ…®ã™ã‚‹
 
 				//	Aug. 22, 2000 genta
-				//	ŠJnˆÊ’u‚ªEOF‚ÌŒã‚ë‚Ì‚Æ‚«‚ÍŸs‚É‘—‚éˆ—‚ğs‚í‚È‚¢
-				//	‚±‚ê‚ğ‚â‚Á‚Ä‚µ‚Ü‚¤‚Æ‘¶İ‚µ‚È‚¢s‚ğPoint‚µ‚Ä—‚¿‚éD
+				//	é–‹å§‹ä½ç½®ãŒEOFã®å¾Œã‚ã®ã¨ãã¯æ¬¡è¡Œã«é€ã‚‹å‡¦ç†ã‚’è¡Œã‚ãªã„
+				//	ã“ã‚Œã‚’ã‚„ã£ã¦ã—ã¾ã†ã¨å­˜åœ¨ã—ãªã„è¡Œã‚’Pointã—ã¦è½ã¡ã‚‹ï¼
 				if( sDelRange.GetFrom().y < m_pcEditDoc->m_cLayoutMgr.GetLineCount() - 1 && pos >= len){
 					if( sDelRange.GetFrom().y == sDelRange.GetTo().y  ){
-						//	GetSelectionInfo().m_sSelect.GetFrom().y <= GetSelectionInfo().m_sSelect.GetTo().y ‚Íƒ`ƒFƒbƒN‚µ‚È‚¢
+						//	GetSelectionInfo().m_sSelect.GetFrom().y <= GetSelectionInfo().m_sSelect.GetTo().y ã¯ãƒã‚§ãƒƒã‚¯ã—ãªã„
 						CLayoutPoint tmp = sDelRange.GetFrom();
 						tmp.y++;
 						tmp.x = CLayoutInt(0);
@@ -774,7 +774,7 @@ bool CEditView::ReplaceData_CEditView3(
 				}
 			}
 
-			//	––”ö
+			//	æœ«å°¾
 			line = m_pcEditDoc->m_cLayoutMgr.GetLineStr( sDelRange.GetTo().GetY2(), &len, &pcLayout );
 			if( line ){
 				CLayoutInt p = LineIndexToColumn( pcLayout, len );
@@ -788,7 +788,7 @@ bool CEditView::ReplaceData_CEditView3(
 		//	To Here
 	}
 
-	//íœ”ÍˆÍƒƒWƒbƒN’PˆÊ sDelRange -> sDelRangeLogic
+	//å‰Šé™¤ç¯„å›²ãƒ­ã‚¸ãƒƒã‚¯å˜ä½ sDelRange -> sDelRangeLogic
 	CLogicRange sDelRangeLogic;
 	if( !bDelRangeUpdate && psDelRangeLogicFast ){
 		sDelRangeLogic = *psDelRangeLogicFast;
@@ -803,23 +803,23 @@ bool CEditView::ReplaceData_CEditView3(
 	CLogicPoint		ptCaretPos_PHY_Old;
 
 	ptCaretPos_PHY_Old = GetCaret().GetCaretLogicPos();
-	if( pcOpeBlk ){	/* ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚© */
-		/* ‘€ì‚Ì’Ç‰Á */
+	if( pcOpeBlk ){	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹ */
+		/* æ“ä½œã®è¿½åŠ  */
 		if( sDelRangeLogic.GetFrom() != GetCaret().GetCaretLogicPos() ){
 			pcOpeBlk->AppendOpe(
 				new CMoveCaretOpe(
-					GetCaret().GetCaretLogicPos()	// ‘€ì‘OŒã‚ÌƒLƒƒƒŒƒbƒgˆÊ’u
+					GetCaret().GetCaretLogicPos()	// æ“ä½œå‰å¾Œã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®
 				)
 			);
 		}
 	}
 
-	CReplaceOpe* pcReplaceOpe = NULL;	// •ÒW‘€ì—v‘f COpe
+	CReplaceOpe* pcReplaceOpe = NULL;	// ç·¨é›†æ“ä½œè¦ç´  COpe
 	if( pcOpeBlk ){
 		pcReplaceOpe = new CReplaceOpe();
 		pcReplaceOpe->m_ptCaretPos_PHY_Before = sDelRangeLogic.GetFrom();
 		pcReplaceOpe->m_ptCaretPos_PHY_To = sDelRangeLogic.GetTo();
-		pcReplaceOpe->m_ptCaretPos_PHY_After = pcReplaceOpe->m_ptCaretPos_PHY_Before;	// ‘€ìŒã‚ÌƒLƒƒƒŒƒbƒgˆÊ’u
+		pcReplaceOpe->m_ptCaretPos_PHY_After = pcReplaceOpe->m_ptCaretPos_PHY_Before;	// æ“ä½œå¾Œã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®
 	}
 
 	COpeLineData* pcMemDeleted = NULL;
@@ -829,11 +829,11 @@ bool CEditView::ReplaceData_CEditView3(
 	}
 
 
-	/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
-	// 2009.07.18 ryoji ’uŠ·Œã¨’uŠ·‘O‚ÉˆÊ’u‚ğ•ÏXi’uŠ·Œã‚¾‚Æ”½“]‚ª•s³‚É‚È‚Á‚Ä‰˜‚¢ Wiki BugReport/43j
+	/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
+	// 2009.07.18 ryoji ç½®æ›å¾Œâ†’ç½®æ›å‰ã«ä½ç½®ã‚’å¤‰æ›´ï¼ˆç½®æ›å¾Œã ã¨åè»¢ãŒä¸æ­£ã«ãªã£ã¦æ±šã„ Wiki BugReport/43ï¼‰
 	GetSelectionInfo().DisableSelectArea( bRedraw );
 
-	/* •¶š—ñ’uŠ· */
+	/* æ–‡å­—åˆ—ç½®æ› */
 	LayoutReplaceArg LRArg;
 	DocLineReplaceArg DLRArg;
 	if( bFastMode ){
@@ -844,38 +844,38 @@ bool CEditView::ReplaceData_CEditView3(
 		// DLRArg.ptNewPos;
 		CSearchAgent(&GetDocument()->m_cDocLineMgr).ReplaceData( &DLRArg );
 	}else{
-		LRArg.sDelRange    = sDelRange;		//!< íœ”ÍˆÍƒŒƒCƒAƒEƒg
-		LRArg.pcmemDeleted = pcMemDeleted;	//!< [out] íœ‚³‚ê‚½ƒf[ƒ^
-		LRArg.pInsData     = pInsData;		//!< ‘}“ü‚·‚éƒf[ƒ^
-		LRArg.nDelSeq      = nDelSeq;	//!< ‘}“ü‚·‚éƒf[ƒ^‚Ì’·‚³
+		LRArg.sDelRange    = sDelRange;		//!< å‰Šé™¤ç¯„å›²ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆ
+		LRArg.pcmemDeleted = pcMemDeleted;	//!< [out] å‰Šé™¤ã•ã‚ŒãŸãƒ‡ãƒ¼ã‚¿
+		LRArg.pInsData     = pInsData;		//!< æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿
+		LRArg.nDelSeq      = nDelSeq;	//!< æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã®é•·ã•
 		m_pcEditDoc->m_cLayoutMgr.ReplaceData_CLayoutMgr( &LRArg );
 	}
 
 	//	Jan. 30, 2001 genta
-	//	Ä•`‰æ‚Ì“_‚Åƒtƒ@ƒCƒ‹XVƒtƒ‰ƒO‚ª“KØ‚É‚È‚Á‚Ä‚¢‚È‚¢‚Æ‚¢‚¯‚È‚¢‚Ì‚Å
-	//	ŠÖ”‚Ì––”ö‚©‚ç‚±‚±‚ÖˆÚ“®
-	/* ó‘Ô‘JˆÚ */
-	if( pcOpeBlk ){	/* ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚© */
+	//	å†æç”»ã®æ™‚ç‚¹ã§ãƒ•ã‚¡ã‚¤ãƒ«æ›´æ–°ãƒ•ãƒ©ã‚°ãŒé©åˆ‡ã«ãªã£ã¦ã„ãªã„ã¨ã„ã‘ãªã„ã®ã§
+	//	é–¢æ•°ã®æœ«å°¾ã‹ã‚‰ã“ã“ã¸ç§»å‹•
+	/* çŠ¶æ…‹é·ç§» */
+	if( pcOpeBlk ){	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹ */
 		m_pcEditDoc->m_cDocEditor.SetModified(true,bRedraw);	//	Jan. 22, 2002 genta
 	}
 
-	/* s”Ô†•\¦‚É•K—v‚È•‚ğİ’è */
+	/* è¡Œç•ªå·è¡¨ç¤ºã«å¿…è¦ãªå¹…ã‚’è¨­å®š */
 	if( m_pcEditWnd->DetectWidthOfLineNumberAreaAllPane( bRedraw ) ){
-		/* ƒLƒƒƒŒƒbƒg‚Ì•\¦EXV */
+		/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤ºãƒ»æ›´æ–° */
 		GetCaret().ShowEditCaret();
 	}
 	else{
-		/* Ä•`‰æ */
+		/* å†æç”» */
 		if( bRedraw ){
-			/* Ä•`‰æƒqƒ“ƒg ƒŒƒCƒAƒEƒgs‚Ì‘Œ¸ */
-			//	Jan. 30, 2001 genta	“\‚è•t‚¯‚Ås”‚ªŒ¸‚éê‡‚Ìl—¶‚ª”²‚¯‚Ä‚¢‚½
+			/* å†æç”»ãƒ’ãƒ³ãƒˆ ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®å¢—æ¸› */
+			//	Jan. 30, 2001 genta	è²¼ã‚Šä»˜ã‘ã§è¡Œæ•°ãŒæ¸›ã‚‹å ´åˆã®è€ƒæ…®ãŒæŠœã‘ã¦ã„ãŸ
 			if( 0 != LRArg.nAddLineNum ){
 				Call_OnPaint( PAINT_LINENUMBER | PAINT_BODY, false);
 			}
 			else{
-				// •¶‘––‚ª‰üs‚È‚µ¨‚ ‚è‚É•Ï‰»‚µ‚½‚ç				// 2009.11.11 ryoji
-				// EOF‚Ì‚İs‚ª’Ç‰Á‚É‚È‚é‚Ì‚ÅA1s—]•ª‚É•`‰æ‚·‚éB
-				// i•¶‘––‚ª‰üs‚ ‚è¨‚È‚µ‚É•Ï‰»‚·‚éê‡‚Ì––”öEOFÁ‹‚Í•`‰æŠÖ”‘¤‚Ås‚í‚ê‚éj
+				// æ–‡æ›¸æœ«ãŒæ”¹è¡Œãªã—â†’ã‚ã‚Šã«å¤‰åŒ–ã—ãŸã‚‰				// 2009.11.11 ryoji
+				// EOFã®ã¿è¡ŒãŒè¿½åŠ ã«ãªã‚‹ã®ã§ã€1è¡Œä½™åˆ†ã«æç”»ã™ã‚‹ã€‚
+				// ï¼ˆæ–‡æ›¸æœ«ãŒæ”¹è¡Œã‚ã‚Šâ†’ãªã—ã«å¤‰åŒ–ã™ã‚‹å ´åˆã®æœ«å°¾EOFæ¶ˆå»ã¯æç”»é–¢æ•°å´ã§è¡Œã‚ã‚Œã‚‹ï¼‰
 				int nAddLine = ( LRArg.ptLayoutNew.GetY2() > LRArg.sDelRange.GetTo().GetY2() )? 1: 0;
 
 				PAINTSTRUCT ps;
@@ -883,9 +883,9 @@ bool CEditView::ReplaceData_CEditView3(
 				ps.rcPaint.left = 0;
 				ps.rcPaint.right = GetTextArea().GetAreaRight();
 
-				/* Ä•`‰æƒqƒ“ƒg •ÏX‚³‚ê‚½ƒŒƒCƒAƒEƒgsFrom(ƒŒƒCƒAƒEƒgs‚Ì‘Œ¸‚ª0‚Ì‚Æ‚«g‚¤) */
+				/* å†æç”»ãƒ’ãƒ³ãƒˆ å¤‰æ›´ã•ã‚ŒãŸãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡ŒFrom(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã®å¢—æ¸›ãŒ0ã®ã¨ãä½¿ã†) */
 				ps.rcPaint.top = GetTextArea().GenerateYPx(LRArg.nModLineFrom);
-				// 2011.12.26 ³‹K•\Œ»ƒL[ƒ[ƒhEŒŸõ•¶š—ñ‚È‚Ç‚ÍAƒƒWƒbƒNs“ª‚Ü‚Å‚³‚©‚Ì‚Ú‚Á‚ÄXV‚·‚é•K—v‚ª‚ ‚é
+				// 2011.12.26 æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ»æ¤œç´¢æ–‡å­—åˆ—ãªã©ã¯ã€ãƒ­ã‚¸ãƒƒã‚¯è¡Œé ­ã¾ã§ã•ã‹ã®ã¼ã£ã¦æ›´æ–°ã™ã‚‹å¿…è¦ãŒã‚ã‚‹
 				{
 					const CLayout* pcLayoutLineFirst = m_pcEditDoc->m_cLayoutMgr.SearchLineByLayoutY( LRArg.nModLineFrom );
 					while( pcLayoutLineFirst && 0 != pcLayoutLineFirst->GetLogicOffset() ){
@@ -926,7 +926,7 @@ bool CEditView::ReplaceData_CEditView3(
 		}
 	}
 
-	// íœ‚³‚ê‚½ƒf[ƒ^‚ÌƒRƒs[(NULL‰Â”\)
+	// å‰Šé™¤ã•ã‚ŒãŸãƒ‡ãƒ¼ã‚¿ã®ã‚³ãƒ”ãƒ¼(NULLå¯èƒ½)
 	if( pcMemDeleted && 0 < pcMemDeleted->size() ){
 		if( pcmemCopyOfDeleted ){
 			if( pcOpeBlk ){
@@ -946,22 +946,22 @@ bool CEditView::ReplaceData_CEditView3(
 			m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(LRArg.ptLayoutNew,   &pcReplaceOpe->m_ptCaretPos_PHY_After);
 			pcReplaceOpe->m_nOrgInsSeq = LRArg.nInsSeq;
 		}
-		/* ‘€ì‚Ì’Ç‰Á */
+		/* æ“ä½œã®è¿½åŠ  */
 		pcOpeBlk->AppendOpe( pcReplaceOpe );
 	}
 
-	// ‘}“ü’¼ŒãˆÊ’u‚ÖƒJ[ƒ\ƒ‹‚ğˆÚ“®
+	// æŒ¿å…¥ç›´å¾Œä½ç½®ã¸ã‚«ãƒ¼ã‚½ãƒ«ã‚’ç§»å‹•
 	if( bFastMode ){
 		GetCaret().MoveCursorFastMode(DLRArg.ptNewPos);
 	}else{
 		GetCaret().MoveCursor(
-			LRArg.ptLayoutNew,	// ‘}“ü‚³‚ê‚½•”•ª‚ÌŸ‚ÌˆÊ’u
+			LRArg.ptLayoutNew,	// æŒ¿å…¥ã•ã‚ŒãŸéƒ¨åˆ†ã®æ¬¡ã®ä½ç½®
 			bRedraw
 		);
 		GetCaret().m_nCaretPosX_Prev = GetCaret().GetCaretLayoutPos().GetX();
 	}
 
-// 2013.06.29 CMoveCaretOpe‚Í•s—vBReplaceOpe‚Ì‚İ‚É‚·‚é
+// 2013.06.29 CMoveCaretOpeã¯ä¸è¦ã€‚ReplaceOpeã®ã¿ã«ã™ã‚‹
 	if( pnInsSeq ){
 		if( bFastMode ){
 			*pnInsSeq = DLRArg.nInsSeq;
@@ -971,15 +971,15 @@ bool CEditView::ReplaceData_CEditView3(
 	}
 
 	//	Jan. 30, 2001 genta
-	//	ƒtƒ@ƒCƒ‹‘S‘Ì‚ÌXVƒtƒ‰ƒO‚ª—§‚Á‚Ä‚¢‚È‚¢‚ÆŠes‚ÌXVó‘Ô‚ª•\¦‚³‚ê‚È‚¢‚Ì‚Å
-	//	ƒtƒ‰ƒOXVˆ—‚ğÄ•`‰æ‚æ‚è‘O‚ÉˆÚ“®‚·‚é
+	//	ãƒ•ã‚¡ã‚¤ãƒ«å…¨ä½“ã®æ›´æ–°ãƒ•ãƒ©ã‚°ãŒç«‹ã£ã¦ã„ãªã„ã¨å„è¡Œã®æ›´æ–°çŠ¶æ…‹ãŒè¡¨ç¤ºã•ã‚Œãªã„ã®ã§
+	//	ãƒ•ãƒ©ã‚°æ›´æ–°å‡¦ç†ã‚’å†æç”»ã‚ˆã‚Šå‰ã«ç§»å‹•ã™ã‚‹
 	return  bUpdateAll;
 }
 
 
 
 
-// 2005.10.11 ryoji ‘O‚Ìs‚É‚ ‚é––”ö‚Ì‹ó”’‚ğíœ
+// 2005.10.11 ryoji å‰ã®è¡Œã«ã‚ã‚‹æœ«å°¾ã®ç©ºç™½ã‚’å‰Šé™¤
 void CEditView::RTrimPrevLine( void )
 {
 	int			nCharChars;
@@ -1006,8 +1006,8 @@ void CEditView::RTrimPrevLine( void )
 				if( !( sRangeA.GetFrom().x >= sRangeA.GetTo().x && sRangeA.GetFrom().y == sRangeA.GetTo().y) ){
 					ReplaceData_CEditView(
 						sRangeA,
-						NULL,		/* ‘}“ü‚·‚éƒf[ƒ^ */
-						CLogicInt(0),			/* ‘}“ü‚·‚éƒf[ƒ^‚Ì’·‚³ */
+						NULL,		/* æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ */
+						CLogicInt(0),			/* æŒ¿å…¥ã™ã‚‹ãƒ‡ãƒ¼ã‚¿ã®é•·ã• */
 						true,
 						m_bDoing_UndoRedo?NULL:m_cCommander.GetOpeBlk()
 					);
@@ -1015,11 +1015,11 @@ void CEditView::RTrimPrevLine( void )
 					m_pcEditDoc->m_cLayoutMgr.LogicToLayout( ptCaretPos_PHY, &ptCP );
 					GetCaret().MoveCursor( ptCP, true );
 
-					if( !m_bDoing_UndoRedo ){	/* ƒAƒ“ƒhƒDEƒŠƒhƒD‚ÌÀs’†‚© */
-						/* ‘€ì‚Ì’Ç‰Á */
+					if( !m_bDoing_UndoRedo ){	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒ»ãƒªãƒ‰ã‚¥ã®å®Ÿè¡Œä¸­ã‹ */
+						/* æ“ä½œã®è¿½åŠ  */
 						m_cCommander.GetOpeBlk()->AppendOpe(
 							new CMoveCaretOpe(
-								GetCaret().GetCaretLogicPos()	// ‘€ì‘OŒã‚ÌƒLƒƒƒŒƒbƒgˆÊ’u
+								GetCaret().GetCaretLogicPos()	// æ“ä½œå‰å¾Œã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®
 							)
 						);
 					}

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief DIFF·•ª•\¦
+ï»¿/*!	@file
+	@brief DIFFå·®åˆ†è¡¨ç¤º
 
 	@author MIK
-	@date	2002/05/25 ExecCmd ‚ğQl‚ÉDIFFÀsŒ‹‰Ê‚ğæ‚è‚Şˆ—ì¬
- 	@date	2005/10/29	maru Diff·•ª•\¦ˆ—‚ğ•ª—£‚µAƒ_ƒCƒAƒƒO‚ ‚è”ÅEƒ_ƒCƒAƒƒO‚È‚µ”Å‚Ì—¼•û‚©‚çƒR[ƒ‹
+	@date	2002/05/25 ExecCmd ã‚’å‚è€ƒã«DIFFå®Ÿè¡Œçµæœã‚’å–ã‚Šè¾¼ã‚€å‡¦ç†ä½œæˆ
+ 	@date	2005/10/29	maru Diffå·®åˆ†è¡¨ç¤ºå‡¦ç†ã‚’åˆ†é›¢ã—ã€ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã‚ã‚Šç‰ˆãƒ»ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãªã—ç‰ˆã®ä¸¡æ–¹ã‹ã‚‰ã‚³ãƒ¼ãƒ«
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -80,35 +80,35 @@ public:
 	bool IsActiveDebugWindow(){ return false; }
 
 public:
-	bool	bDiffInfo;	//DIFFî•ñ‚©
-	int		nDiffLen;		//DIFFî•ñ’·
-	char	szDiffData[100];	//DIFFî•ñ
+	bool	bDiffInfo;	//DIFFæƒ…å ±ã‹
+	int		nDiffLen;		//DIFFæƒ…å ±é•·
+	char	szDiffData[100];	//DIFFæƒ…å ±
 protected:
 	CEditView* m_view;
-	bool	bLineHead;	//s“ª‚©
-	bool	bFirst;	//æ“ª‚©H	//@@@ 2003.05.31 MIK
+	bool	bLineHead;	//è¡Œé ­ã‹
+	bool	bFirst;	//å…ˆé ­ã‹ï¼Ÿ	//@@@ 2003.05.31 MIK
 	int		nFlgFile12;
 };
 
 
-/*!	·•ª•\¦
-	@param	pszFile1	[in]	©ƒtƒ@ƒCƒ‹–¼
-	@param	pszFile2	[in]	‘Šèƒtƒ@ƒCƒ‹–¼
+/*!	å·®åˆ†è¡¨ç¤º
+	@param	pszFile1	[in]	è‡ªãƒ•ã‚¡ã‚¤ãƒ«å
+	@param	pszFile2	[in]	ç›¸æ‰‹ãƒ•ã‚¡ã‚¤ãƒ«å
     @param  nFlgOpt     [in]    0b000000000
-                                    ||||||+--- -i ignore-case         ‘å•¶š¬•¶š“¯ˆê‹
-                                    |||||+---- -w ignore-all-space    ‹ó”’–³‹
-                                    ||||+----- -b ignore-space-change ‹ó”’•ÏX–³‹
-                                    |||+------ -B ignore-blank-lines  ‹ós–³‹
-                                    ||+------- -t expand-tabs         TAB-SPACE•ÏŠ·
-                                    |+--------    (•ÒW’†‚Ìƒtƒ@ƒCƒ‹‚ª‹Œƒtƒ@ƒCƒ‹)
-                                    +---------    (DIFF·•ª‚ª‚È‚¢‚Æ‚«‚ÉƒƒbƒZ[ƒW•\¦)
-	@note	HandleCommand‚©‚ç‚ÌŒÄ‚Ño‚µ‘Î‰(ƒ_ƒCƒAƒƒO‚È‚µ”Å)
+                                    ||||||+--- -i ignore-case         å¤§æ–‡å­—å°æ–‡å­—åŒä¸€è¦–
+                                    |||||+---- -w ignore-all-space    ç©ºç™½ç„¡è¦–
+                                    ||||+----- -b ignore-space-change ç©ºç™½å¤‰æ›´ç„¡è¦–
+                                    |||+------ -B ignore-blank-lines  ç©ºè¡Œç„¡è¦–
+                                    ||+------- -t expand-tabs         TAB-SPACEå¤‰æ›
+                                    |+--------    (ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒæ—§ãƒ•ã‚¡ã‚¤ãƒ«)
+                                    +---------    (DIFFå·®åˆ†ãŒãªã„ã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸è¡¨ç¤º)
+	@note	HandleCommandã‹ã‚‰ã®å‘¼ã³å‡ºã—å¯¾å¿œ(ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãªã—ç‰ˆ)
 	@author	MIK
 	@date	2002/05/25
-	@date	2005/10/28	‹ŒCommand_Diff‚©‚çŠÖ”–¼‚Ì•ÏXB
-						GetCommander().Command_Diff_Dialog‚¾‚¯‚Å‚È‚­VCommand_Diff
-						‚©‚ç‚àŒÄ‚Î‚ê‚éŠÖ”Bmaru
-	@date	2013/06/21	ExecCmd‚ğ—˜—p‚·‚é‚æ‚¤‚É
+	@date	2005/10/28	æ—§Command_Diffã‹ã‚‰é–¢æ•°åã®å¤‰æ›´ã€‚
+						GetCommander().Command_Diff_Dialogã ã‘ã§ãªãæ–°Command_Diff
+						ã‹ã‚‰ã‚‚å‘¼ã°ã‚Œã‚‹é–¢æ•°ã€‚maru
+	@date	2013/06/21	ExecCmdã‚’åˆ©ç”¨ã™ã‚‹ã‚ˆã†ã«
 */
 void CEditView::ViewDiffInfo( 
 	const TCHAR*	pszFile1,
@@ -117,18 +117,18 @@ void CEditView::ViewDiffInfo(
 	bool 			bUTF8
 )
 /*
-	bool	bFlgCase,		//‘å•¶š¬•¶š“¯ˆê‹
-	bool	bFlgBlank,		//‹ó”’–³‹
-	bool	bFlgWhite,		//‹ó”’•ÏX–³‹
-	bool	bFlgBLine,		//‹ós–³‹
-	bool	bFlgTabSpc,		//TAB-SPACE•ÏŠ·
-	bool	bFlgFile12,		//•ÒW’†‚Ìƒtƒ@ƒCƒ‹‚ª‹Œƒtƒ@ƒCƒ‹
+	bool	bFlgCase,		//å¤§æ–‡å­—å°æ–‡å­—åŒä¸€è¦–
+	bool	bFlgBlank,		//ç©ºç™½ç„¡è¦–
+	bool	bFlgWhite,		//ç©ºç™½å¤‰æ›´ç„¡è¦–
+	bool	bFlgBLine,		//ç©ºè¡Œç„¡è¦–
+	bool	bFlgTabSpc,		//TAB-SPACEå¤‰æ›
+	bool	bFlgFile12,		//ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ãŒæ—§ãƒ•ã‚¡ã‚¤ãƒ«
 */
 {
 	CWaitCursor	cWaitCursor( this->GetHwnd() );
 	int		nFlgFile12 = 1;
 
-	/* exe‚Ì‚ ‚éƒtƒHƒ‹ƒ_ */
+	/* exeã®ã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€ */
 	TCHAR	szExeFolder[_MAX_PATH + 1];
 
 	TCHAR	cmdline[1024];
@@ -136,7 +136,7 @@ void CEditView::ViewDiffInfo(
 	SplitPath_FolderAndFile( cmdline, szExeFolder, NULL );
 
 	//	From Here Dec. 28, 2002 MIK
-	//	diff.exe‚Ì‘¶İƒ`ƒFƒbƒN
+	//	diff.exeã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
 	if( !IsFileExists( cmdline, true ) )
 	{
 		WarningMessage( GetHwnd(), LS(STR_ERR_DLGEDITVWDIFF2) );
@@ -144,33 +144,33 @@ void CEditView::ViewDiffInfo(
 	}
 	cmdline[0] = _T('\0');
 
-	//¡‚ ‚éDIFF·•ª‚ğÁ‹‚·‚éB
+	//ä»Šã‚ã‚‹DIFFå·®åˆ†ã‚’æ¶ˆå»ã™ã‚‹ã€‚
 	if( CDiffManager::getInstance()->IsDiffUse() )
 		GetCommander().Command_Diff_Reset();
 		//m_pcEditDoc->m_cDocLineMgr.ResetAllDiffMark();
 
-	//ƒIƒvƒVƒ‡ƒ“‚ğì¬‚·‚é
+	//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã‚’ä½œæˆã™ã‚‹
 	TCHAR	szOption[16];	// "-cwbBt"
 	_tcscpy( szOption, _T("-") );
-	if( nFlgOpt & 0x0001 ) _tcscat( szOption, _T("i") );	//-i ignore-case         ‘å•¶š¬•¶š“¯ˆê‹
-	if( nFlgOpt & 0x0002 ) _tcscat( szOption, _T("w") );	//-w ignore-all-space    ‹ó”’–³‹
-	if( nFlgOpt & 0x0004 ) _tcscat( szOption, _T("b") );	//-b ignore-space-change ‹ó”’•ÏX–³‹
-	if( nFlgOpt & 0x0008 ) _tcscat( szOption, _T("B") );	//-B ignore-blank-lines  ‹ós–³‹
-	if( nFlgOpt & 0x0010 ) _tcscat( szOption, _T("t") );	//-t expand-tabs         TAB-SPACE•ÏŠ·
-	if( _tcscmp( szOption, _T("-") ) == 0 ) _tcscpy( szOption, _T("") );	//ƒIƒvƒVƒ‡ƒ“‚È‚µ
+	if( nFlgOpt & 0x0001 ) _tcscat( szOption, _T("i") );	//-i ignore-case         å¤§æ–‡å­—å°æ–‡å­—åŒä¸€è¦–
+	if( nFlgOpt & 0x0002 ) _tcscat( szOption, _T("w") );	//-w ignore-all-space    ç©ºç™½ç„¡è¦–
+	if( nFlgOpt & 0x0004 ) _tcscat( szOption, _T("b") );	//-b ignore-space-change ç©ºç™½å¤‰æ›´ç„¡è¦–
+	if( nFlgOpt & 0x0008 ) _tcscat( szOption, _T("B") );	//-B ignore-blank-lines  ç©ºè¡Œç„¡è¦–
+	if( nFlgOpt & 0x0010 ) _tcscat( szOption, _T("t") );	//-t expand-tabs         TAB-SPACEå¤‰æ›
+	if( _tcscmp( szOption, _T("-") ) == 0 ) _tcscpy( szOption, _T("") );	//ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãªã—
 	if( nFlgOpt & 0x0020 ) nFlgFile12 = 0;
 	else                   nFlgFile12 = 1;
 
 	//	To Here Dec. 28, 2002 MIK
 
 	{
-		//ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“•¶š—ñì¬(MAX:1024)
+		//ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³æ–‡å­—åˆ—ä½œæˆ(MAX:1024)
 		auto_sprintf(
 			cmdline,
 			_T("\"%ts\\%ts\" %ts \"%ts\" \"%ts\""),
-			szExeFolder,	//sakura.exeƒpƒX
+			szExeFolder,	//sakura.exeãƒ‘ã‚¹
 			_T("diff.exe"),		//diff.exe
-			szOption,		//diffƒIƒvƒVƒ‡ƒ“
+			szOption,		//diffã‚ªãƒ—ã‚·ãƒ§ãƒ³
 			( nFlgFile12 ? pszFile2 : pszFile1 ),
 			( nFlgFile12 ? pszFile1 : pszFile2 )
 		);
@@ -180,10 +180,10 @@ void CEditView::ViewDiffInfo(
 		int nFlgOpt = 0;
 		nFlgOpt |= 0x01;  // GetStdOut
 		if( bUTF8 ){
-			nFlgOpt |= 0x80;  // UTF-8 out (SJIS‚Æˆá‚Á‚ÄASCIIƒZ[ƒt‚È‚Ì‚Å)
+			nFlgOpt |= 0x80;  // UTF-8 out (SJISã¨é•ã£ã¦ASCIIã‚»ãƒ¼ãƒ•ãªã®ã§)
 			nFlgOpt |= 0x100; // UTF-8 in
 		}
-		nFlgOpt |= 0x40;  // Šg’£î•ño—Í–³Œø
+		nFlgOpt |= 0x40;  // æ‹¡å¼µæƒ…å ±å‡ºåŠ›ç„¡åŠ¹
 		COutputAdapterDiff oa(this, nFlgFile12);
 		bool ret = ExecCmd( cmdline, nFlgOpt, NULL, &oa );
 
@@ -196,7 +196,7 @@ void CEditView::ViewDiffInfo(
 		}
 	}
 
-	//DIFF·•ª‚ªŒ©‚Â‚©‚ç‚È‚©‚Á‚½‚Æ‚«‚ÉƒƒbƒZ[ƒW•\¦
+	//DIFFå·®åˆ†ãŒè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸã¨ãã«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸è¡¨ç¤º
 	if( nFlgOpt & 0x0040 )
 	{
 		if( !CDiffManager::getInstance()->IsDiffUse() )
@@ -206,7 +206,7 @@ void CEditView::ViewDiffInfo(
 	}
 
 
-	//•ªŠ„‚µ‚½ƒrƒ…[‚àXV
+	//åˆ†å‰²ã—ãŸãƒ“ãƒ¥ãƒ¼ã‚‚æ›´æ–°
 	m_pcEditWnd->Views_Redraw();
 
 	return;
@@ -218,7 +218,7 @@ bool COutputAdapterDiff::OutputA(const ACHAR* pBuf, int size)
 		size = auto_strlen(pBuf);
 	}
 	//@@@ 2003.05.31 MIK
-	//	æ“ª‚ªBinary files‚È‚çƒoƒCƒiƒŠƒtƒ@ƒCƒ‹‚Ì‚½‚ßˆÓ–¡‚Ì‚ ‚é·•ª‚ªæ‚ç‚ê‚È‚©‚Á‚½
+	//	å…ˆé ­ãŒBinary filesãªã‚‰ãƒã‚¤ãƒŠãƒªãƒ•ã‚¡ã‚¤ãƒ«ã®ãŸã‚æ„å‘³ã®ã‚ã‚‹å·®åˆ†ãŒå–ã‚‰ã‚Œãªã‹ã£ãŸ
 	if( bFirst )
 	{
 		bFirst = false;
@@ -229,7 +229,7 @@ bool COutputAdapterDiff::OutputA(const ACHAR* pBuf, int size)
 		}
 	}
 
-	//“Ç‚İo‚µ‚½•¶š—ñ‚ğƒ`ƒFƒbƒN‚·‚é
+	//èª­ã¿å‡ºã—ãŸæ–‡å­—åˆ—ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹
 	int j;
 	for( j = 0; j < (int)size/*-1*/; j++ )
 	{
@@ -239,7 +239,7 @@ bool COutputAdapterDiff::OutputA(const ACHAR* pBuf, int size)
 			{
 				bLineHead = false;
 			
-				//DIFFî•ñ‚Ìn‚Ü‚è‚©H
+				//DIFFæƒ…å ±ã®å§‹ã¾ã‚Šã‹ï¼Ÿ
 				if( pBuf[j] >= '0' && pBuf[j] <= '9' )
 				{
 					bDiffInfo = true;
@@ -257,10 +257,10 @@ bool COutputAdapterDiff::OutputA(const ACHAR* pBuf, int size)
 		}
 		else
 		{
-			//s––‚É’B‚µ‚½‚©H
+			//è¡Œæœ«ã«é”ã—ãŸã‹ï¼Ÿ
 			if( pBuf[j] == '\n' || pBuf[j] == '\r' )
 			{
-				//DIFFî•ñ‚ª‚ ‚ê‚Î‰ğÍ‚·‚é
+				//DIFFæƒ…å ±ãŒã‚ã‚Œã°è§£æã™ã‚‹
 				if( bDiffInfo == true && nDiffLen > 0 )
 				{
 					szDiffData[nDiffLen] = '\0';
@@ -273,7 +273,7 @@ bool COutputAdapterDiff::OutputA(const ACHAR* pBuf, int size)
 			}
 			else if( bDiffInfo == true )
 			{
-				//DIFFî•ñ‚É’Ç‰Á‚·‚é
+				//DIFFæƒ…å ±ã«è¿½åŠ ã™ã‚‹
 				szDiffData[nDiffLen++] = pBuf[j];
 				if( nDiffLen >= 99 )
 				{
@@ -286,11 +286,11 @@ bool COutputAdapterDiff::OutputA(const ACHAR* pBuf, int size)
 	return true;
 }
 
-/*!	DIFF·•ªî•ñ‚ğ‰ğÍ‚µƒ}[ƒN“o˜^
-	@param	pszDiffInfo	[in]	Vƒtƒ@ƒCƒ‹–¼
-	@param	nFlgFile12	[in]	•ÒW’†ƒtƒ@ƒCƒ‹‚Í...
-									0	ƒtƒ@ƒCƒ‹1(‹Œƒtƒ@ƒCƒ‹)
-									1	ƒtƒ@ƒCƒ‹2(Vƒtƒ@ƒCƒ‹)
+/*!	DIFFå·®åˆ†æƒ…å ±ã‚’è§£æã—ãƒãƒ¼ã‚¯ç™»éŒ²
+	@param	pszDiffInfo	[in]	æ–°ãƒ•ã‚¡ã‚¤ãƒ«å
+	@param	nFlgFile12	[in]	ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ã¯...
+									0	ãƒ•ã‚¡ã‚¤ãƒ«1(æ—§ãƒ•ã‚¡ã‚¤ãƒ«)
+									1	ãƒ•ã‚¡ã‚¤ãƒ«2(æ–°ãƒ•ã‚¡ã‚¤ãƒ«)
 	@author	MIK
 	@date	2002/05/25
 */
@@ -300,35 +300,35 @@ void CEditView::AnalyzeDiffInfo(
 )
 {
 	/*
-	 * 99a99		‹Œƒtƒ@ƒCƒ‹99s‚ÌŸs‚ÉVƒtƒ@ƒCƒ‹99s‚ª’Ç‰Á‚³‚ê‚½B
-	 * 99a99,99		‹Œƒtƒ@ƒCƒ‹99s‚ÌŸs‚ÉVƒtƒ@ƒCƒ‹99`99s‚ª’Ç‰Á‚³‚ê‚½B
-	 * 99c99		‹Œƒtƒ@ƒCƒ‹99s‚ªVƒtƒ@ƒCƒ‹99s‚É•ÏX‚³‚ê‚½B
-	 * 99,99c99,99	‹Œƒtƒ@ƒCƒ‹99`99s‚ªVƒtƒ@ƒCƒ‹99`99s‚É•ÏX‚³‚ê‚½B
-	 * 99d99		‹Œƒtƒ@ƒCƒ‹99s‚ªVƒtƒ@ƒCƒ‹99s‚ÌŸs‚©‚çíœ‚³‚ê‚½B
-	 * 99,99d99		‹Œƒtƒ@ƒCƒ‹99`99s‚ªVƒtƒ@ƒCƒ‹99s‚ÌŸs‚©‚çíœ‚³‚ê‚½B
+	 * 99a99		æ—§ãƒ•ã‚¡ã‚¤ãƒ«99è¡Œã®æ¬¡è¡Œã«æ–°ãƒ•ã‚¡ã‚¤ãƒ«99è¡ŒãŒè¿½åŠ ã•ã‚ŒãŸã€‚
+	 * 99a99,99		æ—§ãƒ•ã‚¡ã‚¤ãƒ«99è¡Œã®æ¬¡è¡Œã«æ–°ãƒ•ã‚¡ã‚¤ãƒ«99ï½99è¡ŒãŒè¿½åŠ ã•ã‚ŒãŸã€‚
+	 * 99c99		æ—§ãƒ•ã‚¡ã‚¤ãƒ«99è¡ŒãŒæ–°ãƒ•ã‚¡ã‚¤ãƒ«99è¡Œã«å¤‰æ›´ã•ã‚ŒãŸã€‚
+	 * 99,99c99,99	æ—§ãƒ•ã‚¡ã‚¤ãƒ«99ï½99è¡ŒãŒæ–°ãƒ•ã‚¡ã‚¤ãƒ«99ï½99è¡Œã«å¤‰æ›´ã•ã‚ŒãŸã€‚
+	 * 99d99		æ—§ãƒ•ã‚¡ã‚¤ãƒ«99è¡ŒãŒæ–°ãƒ•ã‚¡ã‚¤ãƒ«99è¡Œã®æ¬¡è¡Œã‹ã‚‰å‰Šé™¤ã•ã‚ŒãŸã€‚
+	 * 99,99d99		æ—§ãƒ•ã‚¡ã‚¤ãƒ«99ï½99è¡ŒãŒæ–°ãƒ•ã‚¡ã‚¤ãƒ«99è¡Œã®æ¬¡è¡Œã‹ã‚‰å‰Šé™¤ã•ã‚ŒãŸã€‚
 	 * s1,e1 mode s2,e2
-	 * æ“ª‚Ìê‡0‚ÌŸs‚Æ‚È‚é‚±‚Æ‚à‚ ‚é
+	 * å…ˆé ­ã®å ´åˆ0ã®æ¬¡è¡Œã¨ãªã‚‹ã“ã¨ã‚‚ã‚ã‚‹
 	 */
 	const char	*q;
 	int		s1, e1, s2, e2;
 	char	mode;
 
-	//‘O”¼ƒtƒ@ƒCƒ‹‚ÌŠJns
+	//å‰åŠãƒ•ã‚¡ã‚¤ãƒ«ã®é–‹å§‹è¡Œ
 	s1 = 0;
 	for( q = pszDiffInfo; *q; q++ )
 	{
 		if( *q == ',' ) break;
 		if( *q == 'a' || *q == 'c' || *q == 'd' ) break;
-		//s”Ô†‚ğ’Šo
+		//è¡Œç•ªå·ã‚’æŠ½å‡º
 		if( *q >= '0' && *q <= '9' ) s1 = s1 * 10 + (*q - '0');
 		else return;
 	}
 	if( ! *q ) return;
 
-	//‘O”¼ƒtƒ@ƒCƒ‹‚ÌI—¹s
+	//å‰åŠãƒ•ã‚¡ã‚¤ãƒ«ã®çµ‚äº†è¡Œ
 	if( *q != ',' )
 	{
-		//ŠJnEI—¹s”Ô†‚Í“¯‚¶
+		//é–‹å§‹ãƒ»çµ‚äº†è¡Œç•ªå·ã¯åŒã˜
 		e1 = s1;
 	}
 	else
@@ -337,30 +337,30 @@ void CEditView::AnalyzeDiffInfo(
 		for( q++; *q; q++ )
 		{
 			if( *q == 'a' || *q == 'c' || *q == 'd' ) break;
-			//s”Ô†‚ğ’Šo
+			//è¡Œç•ªå·ã‚’æŠ½å‡º
 			if( *q >= '0' && *q <= '9' ) e1 = e1 * 10 + (*q - '0');
 			else return;
 		}
 	}
 	if( ! *q ) return;
 
-	//DIFFƒ‚[ƒh‚ğæ“¾
+	//DIFFãƒ¢ãƒ¼ãƒ‰ã‚’å–å¾—
 	mode = *q;
 
-	//Œã”¼ƒtƒ@ƒCƒ‹‚ÌŠJns
+	//å¾ŒåŠãƒ•ã‚¡ã‚¤ãƒ«ã®é–‹å§‹è¡Œ
 	s2 = 0;
 	for( q++; *q; q++ )
 	{
 		if( *q == ',' ) break;
-		//s”Ô†‚ğ’Šo
+		//è¡Œç•ªå·ã‚’æŠ½å‡º
 		if( *q >= '0' && *q <= '9' ) s2 = s2 * 10 + (*q - '0');
 		else return;
 	}
 
-	//Œã”¼ƒtƒ@ƒCƒ‹‚ÌI—¹s
+	//å¾ŒåŠãƒ•ã‚¡ã‚¤ãƒ«ã®çµ‚äº†è¡Œ
 	if( *q != ',' )
 	{
-		//ŠJnEI—¹s”Ô†‚Í“¯‚¶
+		//é–‹å§‹ãƒ»çµ‚äº†è¡Œç•ªå·ã¯åŒã˜
 		e2 = s2;
 	}
 	else
@@ -368,23 +368,23 @@ void CEditView::AnalyzeDiffInfo(
 		e2 = 0;
 		for( q++; *q; q++ )
 		{
-			//s”Ô†‚ğ’Šo
+			//è¡Œç•ªå·ã‚’æŠ½å‡º
 			if( *q >= '0' && *q <= '9' ) e2 = e2 * 10 + (*q - '0');
 			else return;
 		}
 	}
 
-	//s––‚É’B‚µ‚Ä‚È‚¯‚ê‚ÎƒGƒ‰[
+	//è¡Œæœ«ã«é”ã—ã¦ãªã‘ã‚Œã°ã‚¨ãƒ©ãƒ¼
 	if( *q ) return;
 
-	//’Šo‚µ‚½DIFFî•ñ‚©‚çs”Ô†‚É·•ªƒ}[ƒN‚ğ•t‚¯‚é
-	if( 0 == nFlgFile12 )	//•ÒW’†ƒtƒ@ƒCƒ‹‚Í‹Œƒtƒ@ƒCƒ‹
+	//æŠ½å‡ºã—ãŸDIFFæƒ…å ±ã‹ã‚‰è¡Œç•ªå·ã«å·®åˆ†ãƒãƒ¼ã‚¯ã‚’ä»˜ã‘ã‚‹
+	if( 0 == nFlgFile12 )	//ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ã¯æ—§ãƒ•ã‚¡ã‚¤ãƒ«
 	{
 		if     ( mode == 'a' ) CDiffLineMgr(&m_pcEditDoc->m_cDocLineMgr).SetDiffMarkRange( MARK_DIFF_DELETE, CLogicInt(s1    ), CLogicInt(e1    ) );
 		else if( mode == 'c' ) CDiffLineMgr(&m_pcEditDoc->m_cDocLineMgr).SetDiffMarkRange( MARK_DIFF_CHANGE, CLogicInt(s1 - 1), CLogicInt(e1 - 1) );
 		else if( mode == 'd' ) CDiffLineMgr(&m_pcEditDoc->m_cDocLineMgr).SetDiffMarkRange( MARK_DIFF_APPEND, CLogicInt(s1 - 1), CLogicInt(e1 - 1) );
 	}
-	else	//•ÒW’†ƒtƒ@ƒCƒ‹‚ÍVƒtƒ@ƒCƒ‹
+	else	//ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ã¯æ–°ãƒ•ã‚¡ã‚¤ãƒ«
 	{
 		if     ( mode == 'a' ) CDiffLineMgr(&m_pcEditDoc->m_cDocLineMgr).SetDiffMarkRange( MARK_DIFF_APPEND, CLogicInt(s2 - 1), CLogicInt(e2 - 1) );
 		else if( mode == 'c' ) CDiffLineMgr(&m_pcEditDoc->m_cDocLineMgr).SetDiffMarkRange( MARK_DIFF_CHANGE, CLogicInt(s2 - 1), CLogicInt(e2 - 1) );
@@ -403,7 +403,7 @@ static bool MakeDiffTmpFile_core(CTextOutputStream& out, HWND hwnd, CEditView& v
 		for(;;){
 			CLogicInt		nLineLen;
 			pLineData = docMgr.GetLine(y)->GetDocLineStrWithEOL(&nLineLen);
-			// ³íI—¹
+			// æ­£å¸¸çµ‚äº†
 			if( 0 == nLineLen || NULL == pLineData ) break;
 			if( bBom ){
 				CNativeW cLine2(L"\ufeff");
@@ -420,14 +420,14 @@ static bool MakeDiffTmpFile_core(CTextOutputStream& out, HWND hwnd, CEditView& v
 		pLineData = GetDllShareData().m_sWorkBuffer.GetWorkBuffer<const EDIT_CHAR>();
 		for(;;){
 			int nLineOffset = 0;
-			int nLineLen = 0; //‰‰ñ—p‰¼’l
+			int nLineLen = 0; //åˆå›ç”¨ä»®å€¤
 			do{
-				// m_sWorkBuffer#m_Work‚Ì”r‘¼§ŒäBŠO•”ƒRƒ}ƒ“ƒho—Í/TraceOut/Diff‚ª‘ÎÛ
+				// m_sWorkBuffer#m_Workã®æ’ä»–åˆ¶å¾¡ã€‚å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰å‡ºåŠ›/TraceOut/DiffãŒå¯¾è±¡
 				LockGuard<CMutex> guard( CShareData::GetMutexShareWork() );
 				{
 					nLineLen = ::SendMessageAny( hwnd, MYWM_GETLINEDATA, y, nLineOffset );
-					if( nLineLen == 0 ){ return true; } // EOF => ³íI—¹
-					if( nLineLen < 0 ){ return false; } // ‰½‚©ƒGƒ‰[
+					if( nLineLen == 0 ){ return true; } // EOF => æ­£å¸¸çµ‚äº†
+					if( nLineLen < 0 ){ return false; } // ä½•ã‹ã‚¨ãƒ©ãƒ¼
 					if( bBom ){
 						CNativeW cLine2(L"\ufeff");
 						cLine2.AppendString(pLineData, t_min(nLineLen, max_size));
@@ -450,18 +450,18 @@ static bool MakeDiffTmpFile_core(CTextOutputStream& out, HWND hwnd, CEditView& v
 	return true;
 }
 
-/*!	ˆêƒtƒ@ƒCƒ‹‚ğì¬‚·‚é
+/*!	ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½œæˆã™ã‚‹
 	@author	MIK
 	@date	2002/05/26
-	@date	2005/10/29	ˆø”•ÏXconst char* ¨ char*
-						ˆêƒtƒ@ƒCƒ‹–¼‚Ìæ“¾ˆ—‚à‚±‚±‚Å‚¨‚±‚È‚¤Bmaru
-	@date	2007/08/??	kobake ‹@ŠB“I‚ÉUNICODE‰»
-	@date	2008/01/26	kobake o—ÍŒ`®C³
-	@date	2013/06/21 ƒGƒ“ƒR[ƒh‚ğASCIIŒn‚É‚·‚é(SJISŒÅ’è‚ğ‚â‚ß‚é)
+	@date	2005/10/29	å¼•æ•°å¤‰æ›´const char* â†’ char*
+						ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«åã®å–å¾—å‡¦ç†ã‚‚ã“ã“ã§ãŠã“ãªã†ã€‚maru
+	@date	2007/08/??	kobake æ©Ÿæ¢°çš„ã«UNICODEåŒ–
+	@date	2008/01/26	kobake å‡ºåŠ›å½¢å¼ä¿®æ­£
+	@date	2013/06/21 ã‚¨ãƒ³ã‚³ãƒ¼ãƒ‰ã‚’ASCIIç³»ã«ã™ã‚‹(SJISå›ºå®šã‚’ã‚„ã‚ã‚‹)
 */
 BOOL CEditView::MakeDiffTmpFile( TCHAR* filename, HWND hWnd, ECodeType code, bool bBom )
 {
-	//ˆê
+	//ä¸€æ™‚
 	TCHAR* pszTmpName = _ttempnam( NULL, SAKURA_DIFF_TEMP_PREFIX );
 	if( NULL == pszTmpName ){
 		WarningMessage( NULL, LS(STR_DIFF_FAILED) );
@@ -471,7 +471,7 @@ BOOL CEditView::MakeDiffTmpFile( TCHAR* filename, HWND hWnd, ECodeType code, boo
 	_tcscpy( filename, pszTmpName );
 	free( pszTmpName );
 
-	//©•ª‚©H
+	//è‡ªåˆ†ã‹ï¼Ÿ
 	if( NULL == hWnd )
 	{
 		EConvertResult eWriteResult = CWriteManager().WriteFile_From_CDocLineMgr(
@@ -503,7 +503,7 @@ BOOL CEditView::MakeDiffTmpFile( TCHAR* filename, HWND hWnd, ECodeType code, boo
 	}
 	if( bError ){
 		out.Close();
-		_tunlink( filename );	//ŠÖ”‚ÌÀs‚É¸”s‚µ‚½‚Æ‚«Aˆêƒtƒ@ƒCƒ‹‚Ìíœ‚ÍŠÖ”“à‚Ås‚¤B2005.10.29
+		_tunlink( filename );	//é–¢æ•°ã®å®Ÿè¡Œã«å¤±æ•—ã—ãŸã¨ãã€ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ã®å‰Šé™¤ã¯é–¢æ•°å†…ã§è¡Œã†ã€‚2005.10.29
 		WarningMessage( NULL, LS(STR_DIFF_FAILED_TEMP) );
 	}
 
@@ -512,11 +512,11 @@ BOOL CEditView::MakeDiffTmpFile( TCHAR* filename, HWND hWnd, ECodeType code, boo
 
 
 
-/*!	ŠO•”ƒtƒ@ƒCƒ‹‚ğw’è‚Å‚Ìƒtƒ@ƒCƒ‹‚ğ•\¦
+/*!	å¤–éƒ¨ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æŒ‡å®šã§ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’è¡¨ç¤º
 */
 BOOL CEditView::MakeDiffTmpFile2( TCHAR* tmpName, const TCHAR* orgName, ECodeType code, ECodeType saveCode )
 {
-	//ˆê
+	//ä¸€æ™‚
 	TCHAR* pszTmpName = _ttempnam( NULL, SAKURA_DIFF_TEMP_PREFIX );
 	if( NULL == pszTmpName ){
 		WarningMessage( NULL, LS(STR_DIFF_FAILED) );
@@ -565,7 +565,7 @@ BOOL CEditView::MakeDiffTmpFile2( TCHAR* tmpName, const TCHAR* orgName, ECodeTyp
 	}
 	catch(...){
 		out.Close();
-		_tunlink( tmpName );	//ŠÖ”‚ÌÀs‚É¸”s‚µ‚½‚Æ‚«Aˆêƒtƒ@ƒCƒ‹‚Ìíœ‚ÍŠÖ”“à‚Ås‚¤B
+		_tunlink( tmpName );	//é–¢æ•°ã®å®Ÿè¡Œã«å¤±æ•—ã—ãŸã¨ãã€ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ã®å‰Šé™¤ã¯é–¢æ•°å†…ã§è¡Œã†ã€‚
 		WarningMessage( NULL, LS(STR_DIFF_FAILED_TEMP) );
 		return FALSE;
 	}

--- a/sakura_core/view/CEditView_ExecCmd.cpp
+++ b/sakura_core/view/CEditView_ExecCmd.cpp
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ŠO•”ƒRƒ}ƒ“ƒh‚ÌÀs
+ï»¿/*!	@file
+	@brief å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰ã®å®Ÿè¡Œ
 
 	@author Norio Nakatani
-	@date	1998/03/13 ì¬
-	@date   2008/04/13 CEditView.cpp‚©‚ç•ª—£
+	@date	1998/03/13 ä½œæˆ
+	@date   2008/04/13 CEditView.cppã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 1998-2002, Norio Nakatani
@@ -12,9 +12,9 @@
 	Copyright (C) 2002, YAZAKI, hor, aroka, MIK, Moca, minfu, KK, novice, ai, Azumaiya, genta
 	Copyright (C) 2003, MIK, ai, ryoji, Moca, wmlhq, genta
 	Copyright (C) 2004, genta, Moca, novice, naoh, isearch, fotomo
-	Copyright (C) 2005, genta, MIK, novice, aroka, D.S.Koba, ‚©‚ë‚Æ, Moca
+	Copyright (C) 2005, genta, MIK, novice, aroka, D.S.Koba, ã‹ã‚ã¨, Moca
 	Copyright (C) 2006, Moca, aroka, ryoji, fon, genta
-	Copyright (C) 2007, ryoji, ‚¶‚ã‚¤‚¶, maru
+	Copyright (C) 2007, ryoji, ã˜ã‚…ã†ã˜, maru
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.
@@ -35,7 +35,7 @@
 #include "sakura_rc.h" // IDD_EXECRUNNING
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       ŠO•”ƒRƒ}ƒ“ƒh                          //
+//                       å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class COutputAdapterDefault: public COutputAdapter
 {
@@ -74,38 +74,38 @@ protected:
 	std::auto_ptr<CCodeBase> pcCodeBase;
 };
 
-/*!	@brief	ŠO•”ƒRƒ}ƒ“ƒh‚ÌÀs
+/*!	@brief	å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰ã®å®Ÿè¡Œ
 
-	@param[in] pszCmd ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“
-	@param[in] nFlgOpt ƒIƒvƒVƒ‡ƒ“
-		@li	0x01	•W€o—Í‚ğ“¾‚é
-		@li	0x02	•W€o—Í‚ÌƒŠƒ_ƒCƒŒƒNƒgæi–³Œø=ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE / —LŒø=•ÒW’†‚ÌƒEƒBƒ“ƒhƒEj
-		@li	0x04	•ÒW’†ƒtƒ@ƒCƒ‹‚ğ•W€“ü—Í‚Ö
-		@li	0x08	•W€o—Í‚ğUnicode‚Ås‚¤
-		@li	0x10	•W€“ü—Í‚ğUnicode‚Ås‚¤
-		@li	0x20	î•ño—Í‚·‚é
-		@li	0x40	î•ño—Í‚µ‚È‚¢
-		@li	0x80	•W€o—Í‚ğUTF-8‚Ås‚¤
-		@li	0x100	•W€“ü—Í‚ğUTF-8‚Ås‚¤
-		@li	0x200	ƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠ‚ğw’è
+	@param[in] pszCmd ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³
+	@param[in] nFlgOpt ã‚ªãƒ—ã‚·ãƒ§ãƒ³
+		@li	0x01	æ¨™æº–å‡ºåŠ›ã‚’å¾—ã‚‹
+		@li	0x02	æ¨™æº–å‡ºåŠ›ã®ãƒªãƒ€ã‚¤ãƒ¬ã‚¯ãƒˆå…ˆï¼ˆç„¡åŠ¹=ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ / æœ‰åŠ¹=ç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ï¼‰
+		@li	0x04	ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ã‚’æ¨™æº–å…¥åŠ›ã¸
+		@li	0x08	æ¨™æº–å‡ºåŠ›ã‚’Unicodeã§è¡Œã†
+		@li	0x10	æ¨™æº–å…¥åŠ›ã‚’Unicodeã§è¡Œã†
+		@li	0x20	æƒ…å ±å‡ºåŠ›ã™ã‚‹
+		@li	0x40	æƒ…å ±å‡ºåŠ›ã—ãªã„
+		@li	0x80	æ¨™æº–å‡ºåŠ›ã‚’UTF-8ã§è¡Œã†
+		@li	0x100	æ¨™æº–å…¥åŠ›ã‚’UTF-8ã§è¡Œã†
+		@li	0x200	ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’æŒ‡å®š
 
-	@note	qƒvƒƒZƒX‚Ì•W€o—Íæ“¾‚ÍƒpƒCƒv‚ğg—p‚·‚é
-	@note	qƒvƒƒZƒX‚Ì•W€“ü—Í‚Ö‚Ì‘—M‚Íˆêƒtƒ@ƒCƒ‹‚ğg—p
+	@note	å­ãƒ—ãƒ­ã‚»ã‚¹ã®æ¨™æº–å‡ºåŠ›å–å¾—ã¯ãƒ‘ã‚¤ãƒ—ã‚’ä½¿ç”¨ã™ã‚‹
+	@note	å­ãƒ—ãƒ­ã‚»ã‚¹ã®æ¨™æº–å…¥åŠ›ã¸ã®é€ä¿¡ã¯ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä½¿ç”¨
 
 	@author	N.Nakatani
 	@date	2001/06/23
 	@date	2001/06/30	GAE
-	@date	2002/01/24	YAZAKI	1ƒoƒCƒgæ‚è‚±‚Ú‚·‰Â”\«‚ª‚ ‚Á‚½
+	@date	2002/01/24	YAZAKI	1ãƒã‚¤ãƒˆå–ã‚Šã“ã¼ã™å¯èƒ½æ€§ãŒã‚ã£ãŸ
 	@date	2003/06/04	genta
-	@date	2004/09/20	naoh	‘½­‚ÍŒ©‚â‚·‚­EEE
+	@date	2004/09/20	naoh	å¤šå°‘ã¯è¦‹ã‚„ã™ããƒ»ãƒ»ãƒ»
 	@date	2004/01/23	genta
-	@date	2004/01/28	Moca	‰üsƒR[ƒh‚ª•ªŠ„‚³‚ê‚é‚Ì‚ğ–h‚®
-	@date	2007/03/18	maru	ƒIƒvƒVƒ‡ƒ“‚ÌŠg’£
-	@date	2008/06/07	Uchi	Unidoe‚Ìg—p
-	@date	2009/02/21	ryoji	ƒrƒ…[ƒ‚[ƒh‚âã‘‚«‹Ö~‚Ì‚Æ‚«‚Í•ÒW’†ƒEƒBƒ“ƒhƒE‚Ö‚Ío—Í‚µ‚È‚¢iw’è‚ÍƒAƒEƒgƒvƒbƒg‚Öj
-	@date	2010/04/12	Moca	nFlgOpt‚Ì0x20,0x40’Ç‰ÁB–³ŒÀo—Í‘ÎôBWM_QUIT‘ÎôBUnicode‚ÌCarryü‚è‚ÌC³
+	@date	2004/01/28	Moca	æ”¹è¡Œã‚³ãƒ¼ãƒ‰ãŒåˆ†å‰²ã•ã‚Œã‚‹ã®ã‚’é˜²ã
+	@date	2007/03/18	maru	ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã®æ‹¡å¼µ
+	@date	2008/06/07	Uchi	Unidoeã®ä½¿ç”¨
+	@date	2009/02/21	ryoji	ãƒ“ãƒ¥ãƒ¼ãƒ¢ãƒ¼ãƒ‰ã‚„ä¸Šæ›¸ãç¦æ­¢ã®ã¨ãã¯ç·¨é›†ä¸­ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸ã¯å‡ºåŠ›ã—ãªã„ï¼ˆæŒ‡å®šæ™‚ã¯ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã¸ï¼‰
+	@date	2010/04/12	Moca	nFlgOptã®0x20,0x40è¿½åŠ ã€‚ç„¡é™å‡ºåŠ›å¯¾ç­–ã€‚WM_QUITå¯¾ç­–ã€‚Unicodeã®Carryå‘¨ã‚Šã®ä¿®æ­£
 
-	TODO:	•W€“ü—ÍE•W€ƒGƒ‰[‚Ìæ‘I‘ğBƒJƒŒƒ“ƒgƒfƒBƒŒƒNƒgƒŠBUTF-8“™‚Ö‚Ì‘Î‰
+	TODO:	æ¨™æº–å…¥åŠ›ãƒ»æ¨™æº–ã‚¨ãƒ©ãƒ¼ã®å–è¾¼é¸æŠã€‚ã‚«ãƒ¬ãƒ³ãƒˆãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã€‚UTF-8ç­‰ã¸ã®å¯¾å¿œ
 */
 bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDir, COutputAdapter* customOa )
 {
@@ -117,12 +117,12 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 
 	bool bEditable = m_pcEditDoc->IsEditable();
 
-	//	From Here 2006.12.03 maru ˆø”‚ğŠg’£‚Ì‚½‚ß
-	BOOL	bGetStdout		= nFlgOpt & 0x01 ? TRUE : FALSE;	//	qƒvƒƒZƒX‚Ì•W€o—Í‚ğ“¾‚é
-	BOOL	bToEditWindow	= ((nFlgOpt & 0x02) && bEditable) ? TRUE : FALSE;	//	TRUE=•ÒW’†‚ÌƒEƒBƒ“ƒhƒE / FALSAE=ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE
-	BOOL	bSendStdin		= nFlgOpt & 0x04 ? TRUE : FALSE;	//	•ÒW’†ƒtƒ@ƒCƒ‹‚ğqƒvƒƒZƒXSTDIN‚É“n‚·
-	// BOOL	bIOUnicodeGet	= nFlgOpt & 0x08 ? TRUE : FALSE;	//	•W€o—Í‚ğUnicode‚Ås‚¤	2008/6/17 Uchi
-	// BOOL	bIOUnicodeSend	= nFlgOpt & 0x10 ? TRUE : FALSE;	//	•W€“ü—Í‚ğUnicode‚Ås‚¤	2008/6/20 Uchi
+	//	From Here 2006.12.03 maru å¼•æ•°ã‚’æ‹¡å¼µã®ãŸã‚
+	BOOL	bGetStdout		= nFlgOpt & 0x01 ? TRUE : FALSE;	//	å­ãƒ—ãƒ­ã‚»ã‚¹ã®æ¨™æº–å‡ºåŠ›ã‚’å¾—ã‚‹
+	BOOL	bToEditWindow	= ((nFlgOpt & 0x02) && bEditable) ? TRUE : FALSE;	//	TRUE=ç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ / FALSAE=ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦
+	BOOL	bSendStdin		= nFlgOpt & 0x04 ? TRUE : FALSE;	//	ç·¨é›†ä¸­ãƒ•ã‚¡ã‚¤ãƒ«ã‚’å­ãƒ—ãƒ­ã‚»ã‚¹STDINã«æ¸¡ã™
+	// BOOL	bIOUnicodeGet	= nFlgOpt & 0x08 ? TRUE : FALSE;	//	æ¨™æº–å‡ºåŠ›ã‚’Unicodeã§è¡Œã†	2008/6/17 Uchi
+	// BOOL	bIOUnicodeSend	= nFlgOpt & 0x10 ? TRUE : FALSE;	//	æ¨™æº–å…¥åŠ›ã‚’Unicodeã§è¡Œã†	2008/6/20 Uchi
 	ECodeType outputEncoding;
 	if( nFlgOpt & 0x08 ){
 		outputEncoding = CODE_UNICODE;
@@ -139,42 +139,42 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 	}else{
 		sendEncoding = CODE_SJIS;
 	}
-	//	To Here 2006.12.03 maru ˆø”‚ğŠg’£‚Ì‚½‚ß
-	// 2010.04.12 Moca î•ño—Í
+	//	To Here 2006.12.03 maru å¼•æ•°ã‚’æ‹¡å¼µã®ãŸã‚
+	// 2010.04.12 Moca æƒ…å ±å‡ºåŠ›
 	BOOL	bOutputExtInfo	= !bToEditWindow;
 	if( nFlgOpt & 0x20 ) bOutputExtInfo = TRUE;
 	if( nFlgOpt & 0x40 ) bOutputExtInfo = FALSE;
 	bool	bCurDir = (nFlgOpt & 0x200) == 0x200;
 
-	// •ÒW’†‚ÌƒEƒBƒ“ƒhƒE‚Éo—Í‚·‚éê‡‚Ì‘I‘ğ”ÍˆÍˆ——p	/* 2007.04.29 maru */
+	// ç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«å‡ºåŠ›ã™ã‚‹å ´åˆã®é¸æŠç¯„å›²å‡¦ç†ç”¨	/* 2007.04.29 maru */
 	CLayoutPoint ptFrom( 0, 0 );
 	bool bBeforeTextSelected = GetSelectionInfo().IsTextSelected();
 	if (bBeforeTextSelected){
 		ptFrom = this->GetSelectionInfo().m_sSelect.GetFrom();
 	}
 
-	//qƒvƒƒZƒX‚Ì•W€o—Í‚ÆÚ‘±‚·‚éƒpƒCƒv‚ğì¬
+	//å­ãƒ—ãƒ­ã‚»ã‚¹ã®æ¨™æº–å‡ºåŠ›ã¨æ¥ç¶šã™ã‚‹ãƒ‘ã‚¤ãƒ—ã‚’ä½œæˆ
 	SECURITY_ATTRIBUTES	sa;
 	sa.nLength = sizeof(sa);
 	sa.bInheritHandle = TRUE;
 	sa.lpSecurityDescriptor = NULL;
 	if( CreatePipe( &hStdOutRead, &hStdOutWrite, &sa, 1000 ) == FALSE ) {
-		//ƒGƒ‰[B‘Îô–³‚µ
+		//ã‚¨ãƒ©ãƒ¼ã€‚å¯¾ç­–ç„¡ã—
 		return false;
 	}
-	//hStdOutRead‚Ì‚Ù‚¤‚ÍqƒvƒƒZƒX‚Å‚Íg—p‚³‚ê‚È‚¢‚Ì‚ÅŒp³•s”\‚É‚·‚éiqƒvƒƒZƒX‚ÌƒŠƒ\[ƒX‚ğ–³‘Ê‚É‘‚â‚³‚È‚¢j
+	//hStdOutReadã®ã»ã†ã¯å­ãƒ—ãƒ­ã‚»ã‚¹ã§ã¯ä½¿ç”¨ã•ã‚Œãªã„ã®ã§ç¶™æ‰¿ä¸èƒ½ã«ã™ã‚‹ï¼ˆå­ãƒ—ãƒ­ã‚»ã‚¹ã®ãƒªã‚½ãƒ¼ã‚¹ã‚’ç„¡é§„ã«å¢—ã‚„ã•ãªã„ï¼‰
 	DuplicateHandle( GetCurrentProcess(), hStdOutRead,
-				GetCurrentProcess(), &hStdOutRead,					// V‚µ‚¢Œp³•s”\ƒnƒ“ƒhƒ‹‚ğó‚¯æ‚é	// 2007.01.31 ryoji
+				GetCurrentProcess(), &hStdOutRead,					// æ–°ã—ã„ç¶™æ‰¿ä¸èƒ½ãƒãƒ³ãƒ‰ãƒ«ã‚’å—ã‘å–ã‚‹	// 2007.01.31 ryoji
 				0, FALSE,
-				DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS );	// Œ³‚ÌŒp³‰Â”\ƒnƒ“ƒhƒ‹‚Í DUPLICATE_CLOSE_SOURCE ‚Å•Â‚¶‚é	// 2007.01.31 ryoji
+				DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS );	// å…ƒã®ç¶™æ‰¿å¯èƒ½ãƒãƒ³ãƒ‰ãƒ«ã¯ DUPLICATE_CLOSE_SOURCE ã§é–‰ã˜ã‚‹	// 2007.01.31 ryoji
 
 
-	// From Here 2007.03.18 maru qƒvƒƒZƒX‚Ì•W€“ü—Íƒnƒ“ƒhƒ‹
-	// CDocLineMgr::WriteFile‚È‚ÇŠù‘¶‚Ìƒtƒ@ƒCƒ‹o—ÍŒn‚ÌŠÖ”‚Ì‚È‚©‚É‚Í
-	// ƒtƒ@ƒCƒ‹ƒnƒ“ƒhƒ‹‚ğ•Ô‚·ƒ^ƒCƒv‚Ì‚à‚Ì‚ª‚È‚¢‚Ì‚ÅAˆê’U‘‚«o‚µ‚Ä‚©‚ç
-	// ˆêƒtƒ@ƒCƒ‹‘®«‚ÅƒI[ƒvƒ“‚·‚é‚±‚Æ‚ÉB
+	// From Here 2007.03.18 maru å­ãƒ—ãƒ­ã‚»ã‚¹ã®æ¨™æº–å…¥åŠ›ãƒãƒ³ãƒ‰ãƒ«
+	// CDocLineMgr::WriteFileãªã©æ—¢å­˜ã®ãƒ•ã‚¡ã‚¤ãƒ«å‡ºåŠ›ç³»ã®é–¢æ•°ã®ãªã‹ã«ã¯
+	// ãƒ•ã‚¡ã‚¤ãƒ«ãƒãƒ³ãƒ‰ãƒ«ã‚’è¿”ã™ã‚¿ã‚¤ãƒ—ã®ã‚‚ã®ãŒãªã„ã®ã§ã€ä¸€æ—¦æ›¸ãå‡ºã—ã¦ã‹ã‚‰
+	// ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«å±æ€§ã§ã‚ªãƒ¼ãƒ—ãƒ³ã™ã‚‹ã“ã¨ã«ã€‚
 	hStdIn = NULL;
-	if(bSendStdin){	/* Œ»İ•ÒW’†‚Ìƒtƒ@ƒCƒ‹‚ğqƒvƒƒZƒX‚Ì•W€“ü—Í‚Ö */
+	if(bSendStdin){	/* ç¾åœ¨ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‚’å­ãƒ—ãƒ­ã‚»ã‚¹ã®æ¨™æº–å…¥åŠ›ã¸ */
 		TCHAR		szPathName[MAX_PATH];
 		TCHAR		szTempFileName[MAX_PATH];
 		int			nFlgOpt;
@@ -183,12 +183,12 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 		GetTempFileName( szPathName, TEXT("skr_"), 0, szTempFileName );
 		DEBUG_TRACE( _T("CEditView::ExecCmd() TempFilename=[%ts]\n"), szTempFileName );
 
-		nFlgOpt = bBeforeTextSelected ? 0x01 : 0x00;		/* ‘I‘ğ”ÍˆÍ‚ğo—Í */
+		nFlgOpt = bBeforeTextSelected ? 0x01 : 0x00;		/* é¸æŠç¯„å›²ã‚’å‡ºåŠ› */
 
-		if( !GetCommander().Command_PUTFILE( to_wchar(szTempFileName), sendEncoding, nFlgOpt) ){	// ˆêƒtƒ@ƒCƒ‹o—Í
+		if( !GetCommander().Command_PUTFILE( to_wchar(szTempFileName), sendEncoding, nFlgOpt) ){	// ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«å‡ºåŠ›
 			hStdIn = NULL;
 		} else {
-			// qƒvƒƒZƒX‚Ö‚ÌŒp³—p‚Éƒtƒ@ƒCƒ‹‚ğŠJ‚­
+			// å­ãƒ—ãƒ­ã‚»ã‚¹ã¸ã®ç¶™æ‰¿ç”¨ã«ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã
 			hStdIn = CreateFile(
 				szTempFileName,
 				GENERIC_READ,
@@ -202,14 +202,14 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 		}
 	}
 	
-	if (hStdIn == NULL) {	/* •W€“ü—Í‚ğ§Œä‚µ‚È‚¢ê‡A‚Ü‚½‚Íˆêƒtƒ@ƒCƒ‹‚Ì¶¬‚É¸”s‚µ‚½ê‡ */
+	if (hStdIn == NULL) {	/* æ¨™æº–å…¥åŠ›ã‚’åˆ¶å¾¡ã—ãªã„å ´åˆã€ã¾ãŸã¯ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ã®ç”Ÿæˆã«å¤±æ•—ã—ãŸå ´åˆ */
 		bSendStdin = FALSE;
 		hStdIn = GetStdHandle( STD_INPUT_HANDLE );
 		if(hStdIn == NULL){
-			// 2013.06.12 Moca •W€“ü—Íƒnƒ“ƒhƒ‹‚ğ—pˆÓ‚·‚é
+			// 2013.06.12 Moca æ¨™æº–å…¥åŠ›ãƒãƒ³ãƒ‰ãƒ«ã‚’ç”¨æ„ã™ã‚‹
 			HANDLE hStdInWrite = NULL;
 			if( CreatePipe( &hStdIn, &hStdInWrite, &sa, 1000 ) == FALSE ) {
-				//ƒGƒ‰[
+				//ã‚¨ãƒ©ãƒ¼
 				hStdIn = hStdInWrite = NULL;
 			}
 			if( hStdInWrite != NULL ){
@@ -217,10 +217,10 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 			}
 		}
 	}
-	// To Here 2007.03.18 maru qƒvƒƒZƒX‚Ì•W€“ü—Íƒnƒ“ƒhƒ‹
+	// To Here 2007.03.18 maru å­ãƒ—ãƒ­ã‚»ã‚¹ã®æ¨™æº–å…¥åŠ›ãƒãƒ³ãƒ‰ãƒ«
 	
 
-	//CreateProcess‚É“n‚·STARTUPINFO‚ğì¬
+	//CreateProcessã«æ¸¡ã™STARTUPINFOã‚’ä½œæˆ
 	STARTUPINFO	sui;
 	ZeroMemory( &sui, sizeof(sui) );
 	sui.cb = sizeof(sui);
@@ -233,15 +233,15 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 	}
 	bool bRet = false;
 
-	//ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“Às
+	//ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³å®Ÿè¡Œ
 	TCHAR	cmdline[1024];
 	_tcscpy( cmdline, pszCmd );
 	if( CreateProcess( NULL, cmdline, NULL, NULL, TRUE,
 				CREATE_NEW_CONSOLE, NULL, bCurDir ? pszCurDir : NULL, &sui, &pi ) == FALSE ) {
-		//Às‚É¸”s‚µ‚½ê‡AƒRƒ}ƒ“ƒhƒ‰ƒCƒ“ƒx[ƒX‚ÌƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚Æ”»’f‚µ‚Ä
-		// command(9x) ‚© cmd(NT) ‚ğŒÄ‚Ño‚·
+		//å®Ÿè¡Œã«å¤±æ•—ã—ãŸå ´åˆã€ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³ãƒ™ãƒ¼ã‚¹ã®ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã¨åˆ¤æ–­ã—ã¦
+		// command(9x) ã‹ cmd(NT) ã‚’å‘¼ã³å‡ºã™
 
-		// 2010.08.27 Moca ƒVƒXƒeƒ€ƒfƒBƒŒƒNƒgƒŠ•t‰Á
+		// 2010.08.27 Moca ã‚·ã‚¹ãƒ†ãƒ ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªä»˜åŠ 
 		TCHAR szCmdDir[_MAX_PATH];
 		if( IsWin32NT() ){
 			::GetSystemDirectory(szCmdDir, _countof(szCmdDir));
@@ -249,13 +249,13 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 			::GetWindowsDirectory(szCmdDir, _countof(szCmdDir));
 		}
 
-		//ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“•¶š—ñì¬
+		//ã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³æ–‡å­—åˆ—ä½œæˆ
 		auto_sprintf(
 			cmdline,
 			_T("\"%ts\\%ts\" %ts%ts%ts"),
 			szCmdDir,
 			( IsWin32NT() ? _T("cmd.exe") : _T("command.com") ),
-			( outputEncoding == CODE_UNICODE ? _T("/U") : _T("") ),		// Unicdeƒ‚[ƒh‚ÅƒRƒ}ƒ“ƒhÀs	2008/6/17 Uchi
+			( outputEncoding == CODE_UNICODE ? _T("/U") : _T("") ),		// Unicdeãƒ¢ãƒ¼ãƒ‰ã§ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œ	2008/6/17 Uchi
 			( bGetStdout ? _T("/C ") : _T("/K ") ),
 			pszCmd
 		);
@@ -266,11 +266,11 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 		}
 	}
 
-	// ƒtƒ@ƒCƒ‹‘S‘Ì‚É‘Î‚·‚éƒtƒBƒ‹ƒ^“®ì
-	//	Œ»İ•ÒW’†‚Ìƒtƒ@ƒCƒ‹‚©‚ç‚Ìƒf[ƒ^‘‚«‚¾‚µ‚¨‚æ‚Ñƒf[ƒ^æ‚è‚İ‚ª
-	//	w’è‚³‚ê‚Ä‚¢‚ÄC‚©‚Â”ÍˆÍ‘I‘ğ‚ªs‚í‚ê‚Ä‚¢‚È‚¢ê‡‚Í
-	//	u‚·‚×‚Ä‘I‘ğv‚³‚ê‚Ä‚¢‚é‚à‚Ì‚Æ‚µ‚ÄC•ÒWƒf[ƒ^‘S‘Ì‚ğ
-	//	ƒRƒ}ƒ“ƒh‚Ìo—ÍŒ‹‰Ê‚Æ’u‚«Š·‚¦‚éD
+	// ãƒ•ã‚¡ã‚¤ãƒ«å…¨ä½“ã«å¯¾ã™ã‚‹ãƒ•ã‚£ãƒ«ã‚¿å‹•ä½œ
+	//	ç¾åœ¨ç·¨é›†ä¸­ã®ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ãƒ‡ãƒ¼ã‚¿æ›¸ãã ã—ãŠã‚ˆã³ãƒ‡ãƒ¼ã‚¿å–ã‚Šè¾¼ã¿ãŒ
+	//	æŒ‡å®šã•ã‚Œã¦ã„ã¦ï¼Œã‹ã¤ç¯„å›²é¸æŠãŒè¡Œã‚ã‚Œã¦ã„ãªã„å ´åˆã¯
+	//	ã€Œã™ã¹ã¦é¸æŠã€ã•ã‚Œã¦ã„ã‚‹ã‚‚ã®ã¨ã—ã¦ï¼Œç·¨é›†ãƒ‡ãƒ¼ã‚¿å…¨ä½“ã‚’
+	//	ã‚³ãƒãƒ³ãƒ‰ã®å‡ºåŠ›çµæœã¨ç½®ãæ›ãˆã‚‹ï¼
 	//	2007.05.20 maru
 	if(!bBeforeTextSelected && bSendStdin && bGetStdout && bToEditWindow){
 		GetSelectionInfo().SetSelectArea(
@@ -282,17 +282,17 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 		DeleteData( true );
 	}
 
-	// hStdOutWrite ‚Í CreateProcess() ‚ÅŒp³‚µ‚½‚Ì‚ÅeƒvƒƒZƒX‚Å‚Í—pÏ‚İ
-	// hStdIn‚àeƒvƒƒZƒX‚Å‚Íg—p‚µ‚È‚¢‚ªAWin9xŒn‚Å‚ÍqƒvƒƒZƒX‚ªI—¹‚µ‚Ä‚©‚ç
-	// ƒNƒ[ƒY‚·‚é‚æ‚¤‚É‚µ‚È‚¢‚Æˆêƒtƒ@ƒCƒ‹‚ª©“®íœ‚³‚ê‚È‚¢
+	// hStdOutWrite ã¯ CreateProcess() ã§ç¶™æ‰¿ã—ãŸã®ã§è¦ªãƒ—ãƒ­ã‚»ã‚¹ã§ã¯ç”¨æ¸ˆã¿
+	// hStdInã‚‚è¦ªãƒ—ãƒ­ã‚»ã‚¹ã§ã¯ä½¿ç”¨ã—ãªã„ãŒã€Win9xç³»ã§ã¯å­ãƒ—ãƒ­ã‚»ã‚¹ãŒçµ‚äº†ã—ã¦ã‹ã‚‰
+	// ã‚¯ãƒ­ãƒ¼ã‚ºã™ã‚‹ã‚ˆã†ã«ã—ãªã„ã¨ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ãŒè‡ªå‹•å‰Šé™¤ã•ã‚Œãªã„
 	CloseHandle(hStdOutWrite);
-	hStdOutWrite = NULL;	// 2007.09.08 genta “ñdclose‚ğ–h‚®
+	hStdOutWrite = NULL;	// 2007.09.08 genta äºŒé‡closeã‚’é˜²ã
 
 	if( bGetStdout ) {
 		DWORD	new_cnt;
 		int		bufidx = 0;
 		bool	bLoopFlag = true;
-		bool	bCancelEnd = false; // ƒLƒƒƒ“ƒZƒ‹‚ÅƒvƒƒZƒX’â~
+		bool	bCancelEnd = false; // ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã§ãƒ—ãƒ­ã‚»ã‚¹åœæ­¢
 		oaInst =  (customOa
 					? NULL
 					: (outputEncoding == CODE_UTF8
@@ -300,15 +300,15 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 						: new COutputAdapterDefault(this, bToEditWindow)) );
 		COutputAdapter& oa = customOa ? *customOa: *oaInst;
 
-		//’†’fƒ_ƒCƒAƒƒO•\¦
+		//ä¸­æ–­ãƒ€ã‚¤ã‚¢ãƒ­ã‚°è¡¨ç¤º
 		if( oa.IsEnableRunningDlg() ){
 			cDlgCancel.DoModeless( G_AppInstance(), m_hwndParent, IDD_EXECRUNNING );
-			// ƒ_ƒCƒAƒƒO‚ÉƒRƒ}ƒ“ƒh‚ğ•\¦
+			// ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ã«ã‚³ãƒãƒ³ãƒ‰ã‚’è¡¨ç¤º
 			::DlgItem_SetText( cDlgCancel.GetHwnd(), IDC_STATIC_CMD, pszCmd );
 		}
-		//Às‚µ‚½ƒRƒ}ƒ“ƒhƒ‰ƒCƒ“‚ğ•\¦
-		// 2004.09.20 naoh ‘½­‚ÍŒ©‚â‚·‚­EEE
-		// 2006.12.03 maru ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚É‚Ì‚İo—Í
+		//å®Ÿè¡Œã—ãŸã‚³ãƒãƒ³ãƒ‰ãƒ©ã‚¤ãƒ³ã‚’è¡¨ç¤º
+		// 2004.09.20 naoh å¤šå°‘ã¯è¦‹ã‚„ã™ããƒ»ãƒ»ãƒ»
+		// 2006.12.03 maru ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«ã®ã¿å‡ºåŠ›
 		if (bOutputExtInfo)
 		{
 			TCHAR szTextDate[1024], szTextTime[1024];
@@ -328,36 +328,36 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 			oa.OutputW( L"#============================================================\r\n" );
 		}
 		
-		//char‚Å“Ç‚Ş
+		//charã§èª­ã‚€
 		typedef char PIPE_CHAR;
-		const int WORK_NULL_TERMS = sizeof(wchar_t); // o—Í—p\0‚Ì•ª
-		const int MAX_BUFIDX = 10; // bufidx‚Ì•ª
-		const DWORD MAX_WORK_READ = 1024*5; // 5KiB ReadFile‚Å“Ç‚İ‚ŞŒÀŠE’l
-		// 2010.04.13 Moca ƒoƒbƒtƒ@ƒTƒCƒY‚Ì’²® 1022 Byte “Ç‚İæ‚è‚ğ 5KiB‚É•ÏX
-		// ƒ{ƒgƒ‹ƒlƒbƒN‚ÍƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚Ö‚Ì“]‘—
-		// ‘Šè‚ÌƒvƒƒOƒ‰ƒ€‚ªVC9‚Ìstdout‚Å‚ÍƒfƒtƒHƒ‹ƒg‚Å4096BVC6,VC8‚âWinXP‚ÌtypeƒRƒ}ƒ“ƒh‚Å‚Í1024
-		// ƒeƒLƒXƒgƒ‚[ƒh‚¾‚Æ new_cnt‚ª‰üs‚É\r‚ª‚Â‚­•ª‚¾‚¯Œü‚±‚¤‘¤‚Ìİ’è’l‚æ‚è‘½‚­ˆê“x‚É‘—‚ç‚ê‚Ä‚­‚é
-		// 4KB‚¾‚Æ 4096 -> 100 -> 4096 -> 100 ‚Ì‚æ‚¤‚É“Ç‚İæ‚é‚±‚Æ‚É‚È‚é‚Ì‚Å5KB‚É‚µ‚½
+		const int WORK_NULL_TERMS = sizeof(wchar_t); // å‡ºåŠ›ç”¨\0ã®åˆ†
+		const int MAX_BUFIDX = 10; // bufidxã®åˆ†
+		const DWORD MAX_WORK_READ = 1024*5; // 5KiB ReadFileã§èª­ã¿è¾¼ã‚€é™ç•Œå€¤
+		// 2010.04.13 Moca ãƒãƒƒãƒ•ã‚¡ã‚µã‚¤ã‚ºã®èª¿æ•´ 1022 Byte èª­ã¿å–ã‚Šã‚’ 5KiBã«å¤‰æ›´
+		// ãƒœãƒˆãƒ«ãƒãƒƒã‚¯ã¯ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¸ã®è»¢é€
+		// ç›¸æ‰‹ã®ãƒ—ãƒ­ã‚°ãƒ©ãƒ ãŒVC9ã®stdoutã§ã¯ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã§4096ã€‚VC6,VC8ã‚„WinXPã®typeã‚³ãƒãƒ³ãƒ‰ã§ã¯1024
+		// ãƒ†ã‚­ã‚¹ãƒˆãƒ¢ãƒ¼ãƒ‰ã ã¨ new_cntãŒæ”¹è¡Œã«\rãŒã¤ãåˆ†ã ã‘å‘ã“ã†å´ã®è¨­å®šå€¤ã‚ˆã‚Šå¤šãä¸€åº¦ã«é€ã‚‰ã‚Œã¦ãã‚‹
+		// 4KBã ã¨ 4096 -> 100 -> 4096 -> 100 ã®ã‚ˆã†ã«èª­ã¿å–ã‚‹ã“ã¨ã«ãªã‚‹ã®ã§5KBã«ã—ãŸ
 		PIPE_CHAR work[MAX_WORK_READ + MAX_BUFIDX + WORK_NULL_TERMS];
-		//ÀsŒ‹‰Ê‚Ìæ‚è‚İ
+		//å®Ÿè¡Œçµæœã®å–ã‚Šè¾¼ã¿
 		do {
-			//ƒvƒƒZƒX‚ªI—¹‚µ‚Ä‚¢‚È‚¢‚©Šm”F
-			// Jun. 04, 2003 genta CPUÁ”ï‚ğŒ¸‚ç‚·‚½‚ß‚É200msec‘Ò‚Â
-			// ‚»‚ÌŠÔƒƒbƒZ[ƒWˆ—‚ª‘Ø‚ç‚È‚¢‚æ‚¤‚É‘Ò‚¿•û‚ğWaitForSingleObject‚©‚ç
-			// MsgWaitForMultipleObject‚É•ÏX
+			//ãƒ—ãƒ­ã‚»ã‚¹ãŒçµ‚äº†ã—ã¦ã„ãªã„ã‹ç¢ºèª
+			// Jun. 04, 2003 genta CPUæ¶ˆè²»ã‚’æ¸›ã‚‰ã™ãŸã‚ã«200msecå¾…ã¤
+			// ãã®é–“ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†ãŒæ»ã‚‰ãªã„ã‚ˆã†ã«å¾…ã¡æ–¹ã‚’WaitForSingleObjectã‹ã‚‰
+			// MsgWaitForMultipleObjectã«å¤‰æ›´
 			// Jan. 23, 2004 genta
-			// qƒvƒƒZƒX‚Ìo—Í‚ğ‚Ç‚ñ‚Ç‚ñó‚¯æ‚ç‚È‚¢‚ÆqƒvƒƒZƒX‚ª
-			// ’â~‚µ‚Ä‚µ‚Ü‚¤‚½‚ßC‘Ò‚¿ŠÔ‚ğ200ms‚©‚ç20ms‚ÉŒ¸‚ç‚·
+			// å­ãƒ—ãƒ­ã‚»ã‚¹ã®å‡ºåŠ›ã‚’ã©ã‚“ã©ã‚“å—ã‘å–ã‚‰ãªã„ã¨å­ãƒ—ãƒ­ã‚»ã‚¹ãŒ
+			// åœæ­¢ã—ã¦ã—ã¾ã†ãŸã‚ï¼Œå¾…ã¡æ™‚é–“ã‚’200msã‹ã‚‰20msã«æ¸›ã‚‰ã™
 			switch( MsgWaitForMultipleObjects( 1, &pi.hProcess, FALSE, 20, QS_ALLEVENTS )){
 				case WAIT_OBJECT_0:
-					//I—¹‚µ‚Ä‚¢‚ê‚Îƒ‹[ƒvƒtƒ‰ƒO‚ğfalse‚Æ‚·‚é
-					//‚½‚¾‚µƒ‹[ƒv‚ÌI—¹ğŒ‚Í ƒvƒƒZƒXI—¹ && ƒpƒCƒv‚ª‹ó
+					//çµ‚äº†ã—ã¦ã„ã‚Œã°ãƒ«ãƒ¼ãƒ—ãƒ•ãƒ©ã‚°ã‚’falseã¨ã™ã‚‹
+					//ãŸã ã—ãƒ«ãƒ¼ãƒ—ã®çµ‚äº†æ¡ä»¶ã¯ ãƒ—ãƒ­ã‚»ã‚¹çµ‚äº† && ãƒ‘ã‚¤ãƒ—ãŒç©º
 					bLoopFlag = false;
 					break;
 				case WAIT_OBJECT_0 + 1:
-					//ˆ—’†‚Ìƒ†[ƒU[‘€ì‚ğ‰Â”\‚É‚·‚é
+					//å‡¦ç†ä¸­ã®ãƒ¦ãƒ¼ã‚¶ãƒ¼æ“ä½œã‚’å¯èƒ½ã«ã™ã‚‹
 					if( !::BlockingHook( cDlgCancel.GetHwnd() ) ){
-						// WM_QUITóMB‚½‚¾‚¿‚ÉI—¹ˆ—
+						// WM_QUITå—ä¿¡ã€‚ãŸã ã¡ã«çµ‚äº†å‡¦ç†
 						::TerminateProcess( pi.hProcess, 0 );
 						goto finish;
 					}
@@ -365,30 +365,30 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 				default:
 					break;
 			}
-			//’†’fƒ{ƒ^ƒ“‰Ÿ‰ºƒ`ƒFƒbƒN
+			//ä¸­æ–­ãƒœã‚¿ãƒ³æŠ¼ä¸‹ãƒã‚§ãƒƒã‚¯
 			if( cDlgCancel.IsCanceled() ){
-				//w’è‚³‚ê‚½ƒvƒƒZƒX‚ÆA‚»‚ÌƒvƒƒZƒX‚ª‚Â‚·‚×‚Ä‚ÌƒXƒŒƒbƒh‚ğI—¹‚³‚¹‚Ü‚·B
+				//æŒ‡å®šã•ã‚ŒãŸãƒ—ãƒ­ã‚»ã‚¹ã¨ã€ãã®ãƒ—ãƒ­ã‚»ã‚¹ãŒæŒã¤ã™ã¹ã¦ã®ã‚¹ãƒ¬ãƒƒãƒ‰ã‚’çµ‚äº†ã•ã›ã¾ã™ã€‚
 				::TerminateProcess( pi.hProcess, 0 );
 				bCancelEnd  = true;
 				break;
 			}
 			new_cnt = 0;
 
-			if( PeekNamedPipe( hStdOutRead, NULL, 0, NULL, &new_cnt, NULL ) ) {	//ƒpƒCƒv‚Ì’†‚Ì“Ç‚İo‚µ‘Ò‹@’†‚Ì•¶š”‚ğæ“¾
-				while( new_cnt > 0 ) {												//‘Ò‹@’†‚Ì‚à‚Ì‚ª‚ ‚é
+			if( PeekNamedPipe( hStdOutRead, NULL, 0, NULL, &new_cnt, NULL ) ) {	//ãƒ‘ã‚¤ãƒ—ã®ä¸­ã®èª­ã¿å‡ºã—å¾…æ©Ÿä¸­ã®æ–‡å­—æ•°ã‚’å–å¾—
+				while( new_cnt > 0 ) {												//å¾…æ©Ÿä¸­ã®ã‚‚ã®ãŒã‚ã‚‹
 
-					if( new_cnt > MAX_WORK_READ) {							//ƒpƒCƒv‚©‚ç“Ç‚İo‚·—Ê‚ğ’²®
+					if( new_cnt > MAX_WORK_READ) {							//ãƒ‘ã‚¤ãƒ—ã‹ã‚‰èª­ã¿å‡ºã™é‡ã‚’èª¿æ•´
 						new_cnt = MAX_WORK_READ;
 					}
 					DWORD	read_cnt = 0;
-					::ReadFile( hStdOutRead, &work[bufidx], new_cnt, &read_cnt, NULL );	//ƒpƒCƒv‚©‚ç“Ç‚İo‚µ
-					read_cnt += bufidx;													//work“à‚ÌÀÛ‚ÌƒTƒCƒY‚É‚·‚é
+					::ReadFile( hStdOutRead, &work[bufidx], new_cnt, &read_cnt, NULL );	//ãƒ‘ã‚¤ãƒ—ã‹ã‚‰èª­ã¿å‡ºã—
+					read_cnt += bufidx;													//workå†…ã®å®Ÿéš›ã®ã‚µã‚¤ã‚ºã«ã™ã‚‹
 
 					if( read_cnt == 0 ) {
-						// Jan. 23, 2004 genta while’Ç‰Á‚Ì‚½‚ß§Œä‚ğ•ÏX
+						// Jan. 23, 2004 genta whileè¿½åŠ ã®ãŸã‚åˆ¶å¾¡ã‚’å¤‰æ›´
 						break;
 					}
-					// Unicode ‚Å ƒf[ƒ^‚ğó‚¯æ‚é start 2008/6/8 Uchi
+					// Unicode ã§ ãƒ‡ãƒ¼ã‚¿ã‚’å—ã‘å–ã‚‹ start 2008/6/8 Uchi
 					if( outputEncoding == CODE_UNICODE ){
 						wchar_t*	workw;
 						int			read_cntw;
@@ -402,10 +402,10 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 						if(read_cntw){
 							workw[read_cntw] = L'\0';
 							bCarry = false;
-							//“Ç‚İo‚µ‚½•¶š—ñ‚ğƒ`ƒFƒbƒN‚·‚é
+							//èª­ã¿å‡ºã—ãŸæ–‡å­—åˆ—ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹
 							if (workw[read_cntw-1] == L'\r') {
 								bCarry = true;
-								read_cntw -= 1; // 2010.04.12 1•¶š—]•ª‚ÉÁ‚³‚ê‚Ä‚½
+								read_cntw -= 1; // 2010.04.12 1æ–‡å­—ä½™åˆ†ã«æ¶ˆã•ã‚Œã¦ãŸ
 								workw[read_cntw] = L'\0';
 							}
 							if( !oa.OutputW( workw, read_cntw ) ){
@@ -419,7 +419,7 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 							}
 						}
 						if( read_cnt % (int)sizeof(wchar_t) ){
-							// ‚Šm—¦‚Å0‚¾‚Æv‚¤‚ª1‚¾‚Æ¢‚é
+							// é«˜ç¢ºç‡ã§0ã ã¨æ€ã†ãŒ1ã ã¨å›°ã‚‹
 							DEBUG_TRACE( _T("ExecCmd: Carry Unicode 1byte [%x]\n"), byteCarry );
 							work[bufidx] = byteCarry;
 							bufidx += 1;
@@ -427,10 +427,10 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 					}
 					// end 2008/6/8 Uchi
 					else if (outputEncoding == CODE_SJIS) {
-						//“Ç‚İo‚µ‚½•¶š—ñ‚ğƒ`ƒFƒbƒN‚·‚é
-						// \r\n ‚ğ \r ‚¾‚¯‚Æ‚©Š¿š‚Ì‘æˆêƒoƒCƒg‚¾‚¯‚ğo—Í‚·‚é‚Ì‚ğ–h‚®•K—v‚ª‚ ‚é
-						//@@@ 2002.1.24 YAZAKI 1ƒoƒCƒgæ‚è‚±‚Ú‚·‰Â”\«‚ª‚ ‚Á‚½B
-						//	Jan. 28, 2004 Moca ÅŒã‚Ì•¶š‚Í‚ ‚Æ‚Åƒ`ƒFƒbƒN‚·‚é
+						//èª­ã¿å‡ºã—ãŸæ–‡å­—åˆ—ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹
+						// \r\n ã‚’ \r ã ã‘ã¨ã‹æ¼¢å­—ã®ç¬¬ä¸€ãƒã‚¤ãƒˆã ã‘ã‚’å‡ºåŠ›ã™ã‚‹ã®ã‚’é˜²ãå¿…è¦ãŒã‚ã‚‹
+						//@@@ 2002.1.24 YAZAKI 1ãƒã‚¤ãƒˆå–ã‚Šã“ã¼ã™å¯èƒ½æ€§ãŒã‚ã£ãŸã€‚
+						//	Jan. 28, 2004 Moca æœ€å¾Œã®æ–‡å­—ã¯ã‚ã¨ã§ãƒã‚§ãƒƒã‚¯ã™ã‚‹
 						int		j;
 						for( j=0; j<(int)read_cnt - 1; j++ ) {
 							//	2007.09.10 ryoji
@@ -443,22 +443,22 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 							}
 						}
 						//	From Here Jan. 28, 2004 Moca
-						//	‰üsƒR[ƒh‚ª•ªŠ„‚³‚ê‚é‚Ì‚ğ–h‚®
+						//	æ”¹è¡Œã‚³ãƒ¼ãƒ‰ãŒåˆ†å‰²ã•ã‚Œã‚‹ã®ã‚’é˜²ã
 						if( (DWORD)j == read_cnt - 1 ){
 							if( _IS_SJIS_1(work[j]) ) {
-								j = read_cnt + 1; // ‚Ò‚Á‚½‚èo—Í‚Å‚«‚È‚¢‚±‚Æ‚ğå’£
+								j = read_cnt + 1; // ã´ã£ãŸã‚Šå‡ºåŠ›ã§ããªã„ã“ã¨ã‚’ä¸»å¼µ
 							}else if( work[j] == _T2(PIPE_CHAR,'\r') ) {
-								// CRLF‚Ìˆê•”‚Å‚Í‚È‚¢‰üs‚ª––”ö‚É‚ ‚é
-								// Ÿ‚Ì“Ç‚İ‚İ‚ÅACRLF‚Ìˆê•”‚É‚È‚é‰Â”\«‚ª‚ ‚é
+								// CRLFã®ä¸€éƒ¨ã§ã¯ãªã„æ”¹è¡ŒãŒæœ«å°¾ã«ã‚ã‚‹
+								// æ¬¡ã®èª­ã¿è¾¼ã¿ã§ã€CRLFã®ä¸€éƒ¨ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 								j = read_cnt + 1;
 							}else{
 								j = read_cnt;
 							}
 						}
 						//	To Here Jan. 28, 2004 Moca
-						if( j == (int)read_cnt ) {	//‚Ò‚Á‚½‚èo—Í‚Å‚«‚éê‡
+						if( j == (int)read_cnt ) {	//ã´ã£ãŸã‚Šå‡ºåŠ›ã§ãã‚‹å ´åˆ
 							work[read_cnt] = '\0';
-							//	2006.12.03 maru ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒEor•ÒW’†‚ÌƒEƒBƒ“ƒhƒE•ªŠò’Ç‰Á
+							//	2006.12.03 maru ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦orç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ†å²è¿½åŠ 
 							if( !oa.OutputA( work, read_cnt ) ){
 								goto finish;
 							}
@@ -467,7 +467,7 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 						else {
 							char tmp = work[read_cnt-1];
 							work[read_cnt-1] = '\0';
-							//	2006.12.03 maru ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒEor•ÒW’†‚ÌƒEƒBƒ“ƒhƒE•ªŠò’Ç‰Á
+							//	2006.12.03 maru ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦orç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ†å²è¿½åŠ 
 							if( !oa.OutputA( work, read_cnt-1 ) ){
 								goto finish;
 							}
@@ -485,16 +485,16 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 							if( echarset == CHARSET_BINARY2 ){
 								break;
 							}else if( read_cnt - 1 == j && work[j] == _T2(PIPE_CHAR,'\r') ){
-								// CRLF‚Ìˆê•”‚Å‚Í‚È‚¢‰üs‚ª––”ö‚É‚ ‚é
-								// Ÿ‚Ì“Ç‚İ‚İ‚ÅACRLF‚Ìˆê•”‚É‚È‚é‰Â”\«‚ª‚ ‚é
+								// CRLFã®ä¸€éƒ¨ã§ã¯ãªã„æ”¹è¡ŒãŒæœ«å°¾ã«ã‚ã‚‹
+								// æ¬¡ã®èª­ã¿è¾¼ã¿ã§ã€CRLFã®ä¸€éƒ¨ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 								break;
 							}else{
 								j += checklen;
 							}
 						}
-						if( j == (int)read_cnt ) {	//‚Ò‚Á‚½‚èo—Í‚Å‚«‚éê‡
+						if( j == (int)read_cnt ) {	//ã´ã£ãŸã‚Šå‡ºåŠ›ã§ãã‚‹å ´åˆ
 							work[read_cnt] = '\0';
-							//	2006.12.03 maru ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒEor•ÒW’†‚ÌƒEƒBƒ“ƒhƒE•ªŠò’Ç‰Á
+							//	2006.12.03 maru ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦orç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ†å²è¿½åŠ 
 							if( !oa.OutputA(work, read_cnt) ){
 								goto finish;
 							}
@@ -506,7 +506,7 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 							int len = read_cnt - j;
 							memcpy(tmp, &work[j], len);
 							work[j] = '\0';
-							//	2006.12.03 maru ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒEor•ÒW’†‚ÌƒEƒBƒ“ƒhƒE•ªŠò’Ç‰Á
+							//	2006.12.03 maru ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦orç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦åˆ†å²è¿½åŠ 
 							if( !oa.OutputA(work, j) ){
 								goto finish;
 							}
@@ -516,17 +516,17 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 						}
 					}
 					// Jan. 23, 2004 genta
-					// qƒvƒƒZƒX‚Ìo—Í‚ğ‚Ç‚ñ‚Ç‚ñó‚¯æ‚ç‚È‚¢‚ÆqƒvƒƒZƒX‚ª
-					// ’â~‚µ‚Ä‚µ‚Ü‚¤‚½‚ßCƒoƒbƒtƒ@‚ª‹ó‚É‚È‚é‚Ü‚Å‚Ç‚ñ‚Ç‚ñ“Ç‚İo‚·D
+					// å­ãƒ—ãƒ­ã‚»ã‚¹ã®å‡ºåŠ›ã‚’ã©ã‚“ã©ã‚“å—ã‘å–ã‚‰ãªã„ã¨å­ãƒ—ãƒ­ã‚»ã‚¹ãŒ
+					// åœæ­¢ã—ã¦ã—ã¾ã†ãŸã‚ï¼Œãƒãƒƒãƒ•ã‚¡ãŒç©ºã«ãªã‚‹ã¾ã§ã©ã‚“ã©ã‚“èª­ã¿å‡ºã™ï¼
 					new_cnt = 0;
 					if( ! PeekNamedPipe( hStdOutRead, NULL, 0, NULL, &new_cnt, NULL ) ){
 						break;
 					}
 					Sleep(0);
 					
-					// 2010.04.12 Moca ‘Šè‚ªo—Í‚µ‚Â‚Ã‚¯‚Ä‚¢‚é‚Æ~‚ß‚ç‚ê‚È‚¢‚©‚ç
-					// BlockingHook‚ÆƒLƒƒƒ“ƒZƒ‹Šm”F‚ğ“Çæƒ‹[ƒv’†‚Å‚às‚¤
-					// bLoopFlag ‚ª—§‚Á‚Ä‚¢‚È‚¢‚Æ‚«‚ÍA‚·‚Å‚ÉƒvƒƒZƒX‚ÍI—¹‚µ‚Ä‚¢‚é‚©‚çTerminate‚µ‚È‚¢
+					// 2010.04.12 Moca ç›¸æ‰‹ãŒå‡ºåŠ›ã—ã¤ã¥ã‘ã¦ã„ã‚‹ã¨æ­¢ã‚ã‚‰ã‚Œãªã„ã‹ã‚‰
+					// BlockingHookã¨ã‚­ãƒ£ãƒ³ã‚»ãƒ«ç¢ºèªã‚’èª­å–ãƒ«ãƒ¼ãƒ—ä¸­ã§ã‚‚è¡Œã†
+					// bLoopFlag ãŒç«‹ã£ã¦ã„ãªã„ã¨ãã¯ã€ã™ã§ã«ãƒ—ãƒ­ã‚»ã‚¹ã¯çµ‚äº†ã—ã¦ã„ã‚‹ã‹ã‚‰Terminateã—ãªã„
 					if( !::BlockingHook( cDlgCancel.GetHwnd() ) ){
 						if( bLoopFlag ){
 							::TerminateProcess( pi.hProcess, 0 );
@@ -534,7 +534,7 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 						goto finish;
 					}
 					if( cDlgCancel.IsCanceled() ){
-						//w’è‚³‚ê‚½ƒvƒƒZƒX‚ÆA‚»‚ÌƒvƒƒZƒX‚ª‚Â‚·‚×‚Ä‚ÌƒXƒŒƒbƒh‚ğI—¹‚³‚¹‚Ü‚·B
+						//æŒ‡å®šã•ã‚ŒãŸãƒ—ãƒ­ã‚»ã‚¹ã¨ã€ãã®ãƒ—ãƒ­ã‚»ã‚¹ãŒæŒã¤ã™ã¹ã¦ã®ã‚¹ãƒ¬ãƒƒãƒ‰ã‚’çµ‚äº†ã•ã›ã¾ã™ã€‚
 						if( bLoopFlag ){
 							::TerminateProcess( pi.hProcess, 0 );
 						}
@@ -547,13 +547,13 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 
 user_cancel:
 
-		// ÅŒã‚Ì•¶š‚Ìo—Í(‚½‚¢‚Ä‚¢CR)
+		// æœ€å¾Œã®æ–‡å­—ã®å‡ºåŠ›(ãŸã„ã¦ã„CR)
 		if( 0 < bufidx ){
 			if( outputEncoding == CODE_UNICODE ){
 				if( bufidx % (int)sizeof(wchar_t) ){
 					DEBUG_TRACE( _T("ExecCmd: Carry last Unicode byte [%x]\n"), work[bufidx-1] );
-					// UTF-16‚È‚Ì‚ÉŠï”ƒoƒCƒg‚¾‚Á‚½
-					work[bufidx] = 0x00; // ãˆÊƒoƒCƒg‚ğ0‚É‚µ‚Ä‚²‚Ü‚©‚·
+					// UTF-16ãªã®ã«å¥‡æ•°ãƒã‚¤ãƒˆã ã£ãŸ
+					work[bufidx] = 0x00; // ä¸Šä½ãƒã‚¤ãƒˆã‚’0ã«ã—ã¦ã”ã¾ã‹ã™
 					bufidx += 1;
 				}
 				wchar_t* workw = (wchar_t*)work;
@@ -570,14 +570,14 @@ user_cancel:
 		}
 
 		if( bCancelEnd && bOutputExtInfo ){
-			//	2006.12.03 maru ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚É‚Ì‚İo—Í
-			//ÅŒã‚ÉƒeƒLƒXƒg‚ğ’Ç‰Á
+			//	2006.12.03 maru ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«ã®ã¿å‡ºåŠ›
+			//æœ€å¾Œã«ãƒ†ã‚­ã‚¹ãƒˆã‚’è¿½åŠ 
 			oa.OutputW( LSW(STR_EDITVIEW_EXECCMD_STOP) );
 		}
 		
 		{
-			//	2006.12.03 maru ƒAƒEƒgƒvƒbƒgƒEƒBƒ“ƒhƒE‚É‚Ì‚İo—Í
-			//	Jun. 04, 2003 genta	I—¹ƒR[ƒh‚Ìæ“¾‚Æo—Í
+			//	2006.12.03 maru ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«ã®ã¿å‡ºåŠ›
+			//	Jun. 04, 2003 genta	çµ‚äº†ã‚³ãƒ¼ãƒ‰ã®å–å¾—ã¨å‡ºåŠ›
 			DWORD result;
 			::GetExitCodeProcess( pi.hProcess, &result );
 			if( bOutputExtInfo ){
@@ -585,13 +585,13 @@ user_cancel:
 				auto_sprintf( endCode, LSW(STR_EDITVIEW_EXECCMD_RET), result );
 				oa.OutputW( endCode );
 			}
-			// 2004.09.20 naoh I—¹ƒR[ƒh‚ª1ˆÈã‚Ì‚ÍƒAƒEƒgƒvƒbƒg‚ğƒAƒNƒeƒBƒu‚É‚·‚é
+			// 2004.09.20 naoh çµ‚äº†ã‚³ãƒ¼ãƒ‰ãŒ1ä»¥ä¸Šã®æ™‚ã¯ã‚¢ã‚¦ãƒˆãƒ—ãƒƒãƒˆã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«ã™ã‚‹
 			if(!bToEditWindow && result > 0 && oa.IsActiveDebugWindow() ){
 				ActivateFrameWindow( GetDllShareData().m_sHandles.m_hwndDebug );
 			}
 		}
 		if (bToEditWindow) {
-			if (bBeforeTextSelected){	// ‘}“ü‚³‚ê‚½•”•ª‚ğ‘I‘ğó‘Ô‚É
+			if (bBeforeTextSelected){	// æŒ¿å…¥ã•ã‚ŒãŸéƒ¨åˆ†ã‚’é¸æŠçŠ¶æ…‹ã«
 				GetSelectionInfo().SetSelectArea(
 					CLayoutRange(
 						ptFrom,
@@ -600,7 +600,7 @@ user_cancel:
 				);
 				GetSelectionInfo().DrawSelectArea();
 			}
-			//	2006.12.03 maru •ÒW’†‚ÌƒEƒBƒ“ƒhƒE‚Éo—Í‚ÍÅŒã‚ÉÄ•`‰æ
+			//	2006.12.03 maru ç·¨é›†ä¸­ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«å‡ºåŠ›æ™‚ã¯æœ€å¾Œã«å†æç”»
 			RedrawAll();
 		}
 		if( !bCancelEnd ){
@@ -612,8 +612,8 @@ user_cancel:
 
 
 finish:
-	//I—¹ˆ—
-	if(hStdIn != NULL) CloseHandle( hStdIn );	/* 2007.03.18 maru •W€“ü—Í‚Ì§Œä‚Ì‚½‚ß */
+	//çµ‚äº†å‡¦ç†
+	if(hStdIn != NULL) CloseHandle( hStdIn );	/* 2007.03.18 maru æ¨™æº–å…¥åŠ›ã®åˆ¶å¾¡ã®ãŸã‚ */
 	if(hStdOutWrite) CloseHandle( hStdOutWrite );
 	CloseHandle( hStdOutRead );
 	if( pi.hProcess ) CloseHandle( pi.hProcess );
@@ -623,8 +623,8 @@ finish:
 }
 
 /*!
-	@param pBuf size–¢w’è‚È‚ç—vNULI’[
-	@param size WCHAR’PˆÊ 
+	@param pBuf sizeæœªæŒ‡å®šãªã‚‰è¦NULçµ‚ç«¯
+	@param size WCHARå˜ä½ 
 */
 void COutputAdapterDefault::OutputBuf(const WCHAR* pBuf, int size)
 {
@@ -642,8 +642,8 @@ bool COutputAdapterDefault::OutputW(const WCHAR* pBuf, int size)
 }
 
 /*
-	@param pBuf size–¢w’è‚È‚ç—vNULI’[
-	@param size ACHAR’PˆÊ 
+	@param pBuf sizeæœªæŒ‡å®šãªã‚‰è¦NULçµ‚ç«¯
+	@param size ACHARå˜ä½ 
 */
 bool COutputAdapterDefault::OutputA(const ACHAR* pBuf, int size)
 {
@@ -658,8 +658,8 @@ bool COutputAdapterDefault::OutputA(const ACHAR* pBuf, int size)
 }
 
 /*
-	@param pBuf size–¢w’è‚È‚ç—vNULI’[
-	@param size ACHAR’PˆÊ 
+	@param pBuf sizeæœªæŒ‡å®šãªã‚‰è¦NULçµ‚ç«¯
+	@param size ACHARå˜ä½ 
 */
 bool COutputAdapterUTF8::OutputA(const ACHAR* pBuf, int size)
 {

--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief IME�̏���
+﻿/*!	@file
+	@brief IMEの処理
 
 	@author Norio Nakatani
-	@date	1998/03/13 �쐬
-	@date   2008/04/13 CEditView.cpp���番��
+	@date	1998/03/13 作成
+	@date   2008/04/13 CEditView.cppから分離
 */
 /*
 	Copyright (C) 1998-2002, Norio Nakatani
@@ -12,9 +12,9 @@
 	Copyright (C) 2002, YAZAKI, hor, aroka, MIK, Moca, minfu, KK, novice, ai, Azumaiya, genta
 	Copyright (C) 2003, MIK, ai, ryoji, Moca, wmlhq, genta
 	Copyright (C) 2004, genta, Moca, novice, naoh, isearch, fotomo
-	Copyright (C) 2005, genta, MIK, novice, aroka, D.S.Koba, �����, Moca
+	Copyright (C) 2005, genta, MIK, novice, aroka, D.S.Koba, かろと, Moca
 	Copyright (C) 2006, Moca, aroka, ryoji, fon, genta
-	Copyright (C) 2007, ryoji, ���イ��, maru
+	Copyright (C) 2007, ryoji, じゅうじ, maru
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.
@@ -34,9 +34,9 @@
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
-/*!	IME ON��
+/*!	IME ONか
 
-	@date  2006.12.04 ryoji �V�K�쐬�i�֐����j
+	@date  2006.12.04 ryoji 新規作成（関数化）
 */
 bool CEditView::IsImeON( void )
 {
@@ -64,7 +64,7 @@ bool CEditView::IsImeON( void )
 	return bRet;
 }
 
-/* IME�ҏW�G���A�̈ʒu��ύX */
+/* IME編集エリアの位置を変更 */
 void CEditView::SetIMECompFormPos( void )
 {
 	//
@@ -90,7 +90,7 @@ void CEditView::SetIMECompFormPos( void )
 }
 
 
-/* IME�ҏW�G���A�̕\���t�H���g��ύX */
+/* IME編集エリアの表示フォントを変更 */
 void CEditView::SetIMECompFormFont( void )
 {
 	//
@@ -109,16 +109,16 @@ void CEditView::SetIMECompFormFont( void )
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          �ĕϊ��E�ϊ��⏕
+//                          再変換・変換補助
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 /*!
-	@brief IME�̍ĕϊ�/�O��Q�ƂŁA�J�[�\���ʒu����O��200chars�ʂ����o����RECONVERTSTRING�𖄂߂�
-	@param  pReconv  [out]  RECONVERTSTRING�\���̂ւ̃|�C���^�BNULL����
-	@param  bUnicode        true�Ȃ��UNICODE�ō\���̂𖄂߂�
-	@param  bDocumentFeed   true�Ȃ��IMR_DOCUMENTFEED�Ƃ��ď�������
-	@return   RECONVERTSTRING�̃T�C�Y�B0�Ȃ�IME�͉������Ȃ�(�͂�)
+	@brief IMEの再変換/前後参照で、カーソル位置から前後200chars位を取り出してRECONVERTSTRINGを埋める
+	@param  pReconv  [out]  RECONVERTSTRING構造体へのポインタ。NULLあり
+	@param  bUnicode        trueならばUNICODEで構造体を埋める
+	@param  bDocumentFeed   trueならばIMR_DOCUMENTFEEDとして処理する
+	@return   RECONVERTSTRINGのサイズ。0ならIMEは何もしない(はず)
 	@date 2002.04.09 minfu
-	@date 2010.03.16 Moca IMR_DOCUMENTFEED�Ή�
+	@date 2010.03.16 Moca IMR_DOCUMENTFEED対応
 */
 LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, bool bDocumentFeed)
 {
@@ -127,92 +127,92 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 		m_nLastReconvLine  = -1;
 	}
 	
-	//��`�I�𒆂͉������Ȃ�
+	//矩形選択中は何もしない
 	if( GetSelectionInfo().IsBoxSelecting() )
 		return 0;
 
-	// 2010.04.06 �r���[���[�h�ł͉������Ȃ�
+	// 2010.04.06 ビューモードでは何もしない
 	if( CAppMode::getInstance()->IsViewMode() ){
 		return 0;
 	}
 	
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      �I��͈͂��擾                         //
+	//                      選択範囲を取得                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//�I��͈͂��擾 -> ptSelect, ptSelectTo, nSelectedLen
+	//選択範囲を取得 -> ptSelect, ptSelectTo, nSelectedLen
 	CLogicPoint	ptSelect;
 	CLogicPoint	ptSelectTo;
 	int			nSelectedLen;
 	if( GetSelectionInfo().IsTextSelected() ){
-		//�e�L�X�g���I������Ă���Ƃ�
+		//テキストが選択されているとき
 		m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(GetSelectionInfo().m_sSelect.GetFrom(), &ptSelect);
 		m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(GetSelectionInfo().m_sSelect.GetTo(), &ptSelectTo);
 		
-		// �I��͈͂������s�̎��A�P���W�b�N�s�ȓ��ɐ���
+		// 選択範囲が複数行の時、１ロジック行以内に制限
 		if (ptSelectTo.y != ptSelect.y){
 			if( bDocumentFeed ){
-				// �b��F���I���Ƃ��ĐU����
-				// ���P�āF�I��͈͂͒u�������̂ŁA�I��͈͂̑O���IME�ɓn��
+				// 暫定：未選択として振舞う
+				// 改善案：選択範囲は置換されるので、選択範囲の前後をIMEに渡す
 				// ptSelectTo.y = ptSelectTo.y;
 				ptSelectTo.x = ptSelect.x;
 			}else{
-				// 2010.04.06 �Ώۂ�ptSelect.y�̍s����J�[�\���s�ɕύX
+				// 2010.04.06 対象をptSelect.yの行からカーソル行に変更
 				const CDocLine* pDocLine = m_pcEditDoc->m_cDocLineMgr.GetLine(GetCaret().GetCaretLogicPos().y);
 				CLogicInt targetY = GetCaret().GetCaretLogicPos().y;
-				// �J�[�\���s���������I���Ȃ�A���O�E����̍s��I��
+				// カーソル行が実質無選択なら、直前・直後の行を選択
 				if( ptSelect.y == GetCaret().GetCaretLogicPos().y
 						&& pDocLine && pDocLine->GetLengthWithoutEOL() == GetCaret().GetCaretLogicPos().x ){
-					// �J�[�\�����㑤�s�� => ���̍s�B�s���J�[�\���ł�Shift+Up�Ȃ�
+					// カーソルが上側行末 => 次の行。行末カーソルでのShift+Upなど
 					targetY = t_min(m_pcEditDoc->m_cDocLineMgr.GetLineCount(),
 						GetCaret().GetCaretLogicPos().y + 1);
 					pDocLine = m_pcEditDoc->m_cDocLineMgr.GetLine(targetY);
 				}else
 				if( ptSelectTo.y == GetCaret().GetCaretLogicPos().y
 						&& 0 == GetCaret().GetCaretLogicPos().x ){
-					// �J�[�\���������s�� => �O�̍s�B �s����Shift+Down/Shift+End��Right�Ȃ�
+					// カーソルが下側行頭 => 前の行。 行頭でShift+Down/Shift+End→Rightなど
 					targetY = GetCaret().GetCaretLogicPos().y - 1;
 					pDocLine = m_pcEditDoc->m_cDocLineMgr.GetLine(targetY);
 				}
-				// �I��͈͂�x�Ŏw��F������̓J�[�\���ł͂Ȃ��I��͈͊
+				// 選択範囲をxで指定：こちらはカーソルではなく選択範囲基準
 				if(targetY == ptSelect.y){
-					// ptSelect.x; ���ύX
+					// ptSelect.x; 未変更
 					ptSelectTo.x = pDocLine ? pDocLine->GetLengthWithoutEOL() : 0;
 				}else
 				if(targetY == ptSelectTo.y){
 					ptSelect.x = 0;
-					// ptSelectTo.x; ���ύX
+					// ptSelectTo.x; 未変更
 				}else{
 					ptSelect.x = 0;
 					ptSelectTo.x = pDocLine ? pDocLine->GetLengthWithoutEOL() : 0;
 				}
 				ptSelect.y = targetY;
-				// ptSelectTo.y = targetY; �ȉ����g�p
+				// ptSelectTo.y = targetY; 以下未使用
 			}
 		}
 	}
 	else{
-		//�e�L�X�g���I������Ă��Ȃ��Ƃ�
+		//テキストが選択されていないとき
 		m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(GetCaret().GetCaretLayoutPos(), &ptSelect);
 		ptSelectTo = ptSelect;
 	}
 	nSelectedLen = ptSelectTo.x - ptSelect.x;
-	// �ȉ� ptSelect.y ptSelect.x, nSelectedLen ���g�p
+	// 以下 ptSelect.y ptSelect.x, nSelectedLen を使用
 
-	//�h�L�������g�s�擾 -> pcCurDocLine
+	//ドキュメント行取得 -> pcCurDocLine
 	const CDocLine* pcCurDocLine = m_pcEditDoc->m_cDocLineMgr.GetLine(ptSelect.GetY2());
 	if (NULL == pcCurDocLine )
 		return 0;
 
-	//�e�L�X�g�擾 -> pLine, nLineLen
+	//テキスト取得 -> pLine, nLineLen
 	const int nLineLen = pcCurDocLine->GetLengthWithoutEOL();
 	if ( 0 == nLineLen )
 		return 0;
 	const wchar_t* pLine = pcCurDocLine->GetPtr();
 
-	// 2010.04.17 �s�����灩�I�����ƁuSelectTo�����s�̌��̈ʒu�v�ɂ��邽�ߔ͈͂𒲐�����
-	// �t���[�J�[�\���I���ł��s�������ɃJ�[�\��������
+	// 2010.04.17 行頭から←選択だと「SelectToが改行の後ろの位置」にあるため範囲を調整する
+	// フリーカーソル選択でも行末より後ろにカーソルがある
 	if( nLineLen < ptSelect.x ){
-		// ���s���O��IME�ɓn���J�[�\���ʒu�Ƃ������Ƃɂ���
+		// 改行直前をIMEに渡すカーソル位置ということにする
 		ptSelect.x = CLogicInt(nLineLen);
 		nSelectedLen = 0;
 	}
@@ -222,24 +222,24 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//              �ĕϊ��͈́E�l���������C��                     //
+	//              再変換範囲・考慮文字を修正                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//�ĕϊ��l��������J�n  //�s�̒��ōĕϊ���API�ɂ킽���Ƃ��镶����̊J�n�ʒu
+	//再変換考慮文字列開始  //行の中で再変換のAPIにわたすとする文字列の開始位置
 	int nReconvIndex = 0;
-	int nInsertCompLen = 0; // DOCUMENTFEED�p�B�ϊ����̕������dwStr�ɍ�����
-	// I�̓J�[�\���@[]���I��͈�=dwTargetStrLen���Ƃ���
-	// �s�F���{���I���܂��B
-	// IME�F�ɂイ��
-	// API�ɓn��������F���{���[�ɂイ��]I���܂��B
+	int nInsertCompLen = 0; // DOCUMENTFEED用。変換中の文字列をdwStrに混ぜる
+	// Iはカーソル　[]が選択範囲=dwTargetStrLenだとして
+	// 行：日本語をIします。
+	// IME：にゅうｒ
+	// APIに渡す文字列：日本語を[にゅうｒ]Iします。
 
-	// �I���J�n�ʒu���O��200(or 50)���������l��������ɂ���
-	const int nReconvMaxLen = (bDocumentFeed ? 50 : 200); //$$�}�W�b�N�i���o�[����
+	// 選択開始位置より前後200(or 50)文字ずつを考慮文字列にする
+	const int nReconvMaxLen = (bDocumentFeed ? 50 : 200); //$$マジックナンバー注意
 	while (ptSelect.x - nReconvIndex > nReconvMaxLen) {
 		nReconvIndex = t_max<int>(nReconvIndex+1, ::CharNextW_AnyBuild(pLine+nReconvIndex)-pLine);
 	}
 	
-	//�ĕϊ��l��������I��  //�s�̒��ōĕϊ���API�ɂ킽���Ƃ��镶����̒���
+	//再変換考慮文字列終了  //行の中で再変換のAPIにわたすとする文字列の長さ
 	int nReconvLen = nLineLen - nReconvIndex;
 	if ( (nReconvLen + nReconvIndex - ptSelect.x) > nReconvMaxLen ){
 		const wchar_t*       p = pLine + ptSelect.x;
@@ -250,17 +250,17 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 		nReconvLen = p - pLine - nReconvIndex;
 	}
 	
-	//�Ώە�����̒���
+	//対象文字列の調整
 	if ( ptSelect.x + nSelectedLen > nReconvIndex + nReconvLen ){
-		// �l��������API�ɓn���Ȃ��̂ŁA�I��͈͂��k��
+		// 考慮分しかAPIに渡さないので、選択範囲を縮小
 		nSelectedLen = nReconvLen + nReconvIndex - ptSelect.x;
 	}
 	
 	if( bDocumentFeed ){
-		// IMR_DOCUMENTFEED�ł́A�ĕϊ��Ώۂ�IME����擾�������͒�������
+		// IMR_DOCUMENTFEEDでは、再変換対象はIMEから取得した入力中文字列
 		nInsertCompLen = auto_strlen(m_szComposition);
 		if( 0 == nInsertCompLen ){
-			// 2��Ă΂��̂ŁAm_szComposition�Ɋo���Ă���
+			// 2回呼ばれるので、m_szCompositionに覚えておく
 			HWND hwnd = GetHwnd();
 			HIMC hIMC = ::ImmGetContext( hwnd );
 			if( !hIMC ){
@@ -277,10 +277,10 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      �\���̐ݒ�v�f                         //
+	//                      構造体設定要素                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//�s�̒��ōĕϊ���API�ɂ킽���Ƃ��镶����̒���
+	//行の中で再変換のAPIにわたすとする文字列の長さ
 	int         cbReconvLenWithNull; // byte
 	DWORD       dwReconvTextLen;    // CHARs
 	DWORD       dwReconvTextInsLen; // CHARs
@@ -292,7 +292,7 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 	const void* pszReconv; 
 	const void* pszInsBuffer;
 
-	//UNICODE��UNICODE
+	//UNICODE→UNICODE
 	if(bUnicode){
 		const WCHAR* pszCompInsStr = L"";
 		int nCompInsStr   = 0;
@@ -302,34 +302,34 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 		}
 		dwInsByteCount      = nCompInsStr * sizeof(wchar_t);
 		dwReconvTextLen     = nReconvLen;
-		dwReconvTextInsLen  = dwReconvTextLen + nCompInsStr;                 //reconv�����񒷁B�����P�ʁB
-		cbReconvLenWithNull = (dwReconvTextInsLen + 1) * sizeof(wchar_t);    //reconv�f�[�^���B�o�C�g�P�ʁB
-		dwCompStrOffset     = (Int)(ptSelect.x - nReconvIndex) * sizeof(wchar_t);    //comp�I�t�Z�b�g�B�o�C�g�P�ʁB
-		dwCompStrLen        = nSelectedLen + nCompInsStr;                            //comp�����񒷁B�����P�ʁB
-		pszReconv           = reinterpret_cast<const void*>(pLine + nReconvIndex);   //reconv������ւ̃|�C���^�B
+		dwReconvTextInsLen  = dwReconvTextLen + nCompInsStr;                 //reconv文字列長。文字単位。
+		cbReconvLenWithNull = (dwReconvTextInsLen + 1) * sizeof(wchar_t);    //reconvデータ長。バイト単位。
+		dwCompStrOffset     = (Int)(ptSelect.x - nReconvIndex) * sizeof(wchar_t);    //compオフセット。バイト単位。
+		dwCompStrLen        = nSelectedLen + nCompInsStr;                            //comp文字列長。文字単位。
+		pszReconv           = reinterpret_cast<const void*>(pLine + nReconvIndex);   //reconv文字列へのポインタ。
 		pszInsBuffer        = pszCompInsStr;
 	}
-	//UNICODE��ANSI
+	//UNICODE→ANSI
 	else{
 		const wchar_t* pszReconvSrc =  pLine + nReconvIndex;
 
-		//�l��������̊J�n����Ώە�����̊J�n�܂� -> dwCompStrOffset
+		//考慮文字列の開始から対象文字列の開始まで -> dwCompStrOffset
 		if( ptSelect.x - nReconvIndex > 0 ){
 			cmemBuf1.SetString(pszReconvSrc, ptSelect.x - nReconvIndex);
 			CShiftJis::UnicodeToSJIS(cmemBuf1, cmemBuf2._GetMemory());
-			dwCompStrOffset = cmemBuf2._GetMemory()->GetRawLength();				//comp�I�t�Z�b�g�B�o�C�g�P�ʁB
+			dwCompStrOffset = cmemBuf2._GetMemory()->GetRawLength();				//compオフセット。バイト単位。
 		}else{
 			dwCompStrOffset = 0;
 		}
 		
 		pszInsBuffer = "";
-		//�Ώە�����̊J�n����Ώە�����̏I���܂� -> dwCompStrLen
+		//対象文字列の開始から対象文字列の終了まで -> dwCompStrLen
 		if (nSelectedLen > 0 ){
 			cmemBuf1.SetString(pszReconvSrc + ptSelect.x, nSelectedLen);
 			CShiftJis::UnicodeToSJIS(cmemBuf1, cmemBuf2._GetMemory());
-			dwCompStrLen = cmemBuf2._GetMemory()->GetRawLength();					//comp�����񒷁B�����P�ʁB
+			dwCompStrLen = cmemBuf2._GetMemory()->GetRawLength();					//comp文字列長。文字単位。
 		}else if(nInsertCompLen > 0){
-			// nSelectedLen �� nInsertCompLen �������w�肳��邱�Ƃ͂Ȃ��͂�
+			// nSelectedLen と nInsertCompLen が両方指定されることはないはず
 			const ACHAR* pComp = to_achar(m_szComposition);
 			pszInsBuffer = pComp;
 			dwInsByteCount = strlen( pComp );
@@ -338,27 +338,27 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 			dwCompStrLen = 0;
 		}
 		
-		//�l�������񂷂ׂ�
+		//考慮文字列すべて
 		cmemBuf1.SetString(pszReconvSrc , nReconvLen );
 		CShiftJis::UnicodeToSJIS(cmemBuf1, cmemBuf2._GetMemory());
 		
-		dwReconvTextLen    = cmemBuf2._GetMemory()->GetRawLength();				//reconv�����񒷁B�����P�ʁB
-		dwReconvTextInsLen = dwReconvTextLen + dwInsByteCount;						//reconv�����񒷁B�����P�ʁB
-		cbReconvLenWithNull = cmemBuf2._GetMemory()->GetRawLength() + dwInsByteCount + sizeof(char);		//reconv�f�[�^���B�o�C�g�P�ʁB
+		dwReconvTextLen    = cmemBuf2._GetMemory()->GetRawLength();				//reconv文字列長。文字単位。
+		dwReconvTextInsLen = dwReconvTextLen + dwInsByteCount;						//reconv文字列長。文字単位。
+		cbReconvLenWithNull = cmemBuf2._GetMemory()->GetRawLength() + dwInsByteCount + sizeof(char);		//reconvデータ長。バイト単位。
 		
-		pszReconv = reinterpret_cast<const void*>(cmemBuf2._GetMemory()->GetRawPtr());	//reconv������ւ̃|�C���^
+		pszReconv = reinterpret_cast<const void*>(cmemBuf2._GetMemory()->GetRawPtr());	//reconv文字列へのポインタ
 	}
 	
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        �\���̐ݒ�                           //
+	//                        構造体設定                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	if ( NULL != pReconv) {
-		//�ĕϊ��\���̂̐ݒ�
+		//再変換構造体の設定
 		DWORD dwOrgSize = pReconv->dwSize;
-		// 2010.03.17 Moca dwSize��pReconv��p�ӂ��鑤(IME��)���ݒ�
-		//     �̂͂��Ȃ̂� Win XP+IME2002+TSF �ł� dwSize��0�ő����Ă���
+		// 2010.03.17 Moca dwSizeはpReconvを用意する側(IME等)が設定
+		//     のはずなのに Win XP+IME2002+TSF では dwSizeが0で送られてくる
 		if( dwOrgSize != 0 && dwOrgSize < sizeof(*pReconv) + cbReconvLenWithNull ){
-			// �o�b�t�@�s��
+			// バッファ不足
 			m_szComposition[0] = _T('\0');
 			return 0;
 		}
@@ -366,18 +366,18 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 			pReconv->dwSize = sizeof(*pReconv) + cbReconvLenWithNull;
 		}
 		pReconv->dwVersion         = 0;
-		pReconv->dwStrLen          = dwReconvTextInsLen;	//�����P��
+		pReconv->dwStrLen          = dwReconvTextInsLen;	//文字単位
 		pReconv->dwStrOffset       = sizeof(*pReconv) ;
-		pReconv->dwCompStrLen      = dwCompStrLen;		//�����P��
-		pReconv->dwCompStrOffset   = dwCompStrOffset;	//�o�C�g�P��
-		pReconv->dwTargetStrLen    = dwCompStrLen;		//�����P��
-		pReconv->dwTargetStrOffset = dwCompStrOffset;	//�o�C�g�P��
+		pReconv->dwCompStrLen      = dwCompStrLen;		//文字単位
+		pReconv->dwCompStrOffset   = dwCompStrOffset;	//バイト単位
+		pReconv->dwTargetStrLen    = dwCompStrLen;		//文字単位
+		pReconv->dwTargetStrOffset = dwCompStrOffset;	//バイト単位
 		
-		// 2004.01.28 Moca �k���I�[�̏C��
+		// 2004.01.28 Moca ヌル終端の修正
 		if( bUnicode ){
 			WCHAR* p = (WCHAR*)(pReconv + 1);
 			if( dwInsByteCount ){
-				// �J�[�\���ʒu�ɁA���͒�IME�f�[�^��}��
+				// カーソル位置に、入力中IMEデータを挿入
 				CHAR* pb = (CHAR*)p;
 				CopyMemory(pb, pszReconv, dwCompStrOffset);
 				pb += dwCompStrOffset;
@@ -388,7 +388,7 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 			}else{
 				CopyMemory(p, pszReconv, cbReconvLenWithNull - sizeof(wchar_t));
 			}
-			// \0������Ɖ����Ȃ��ɂȂ邱�Ƃ�����
+			// \0があると応答なしになることがある
 			for( DWORD i = 0; i < dwReconvTextInsLen; i++ ){
 				if( p[i] == 0 ){
 					p[i] = L' ';
@@ -408,7 +408,7 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 			}else{
 				CopyMemory(p, pszReconv, cbReconvLenWithNull - sizeof(char));
 			}
-			// \0������Ɖ����Ȃ��ɂȂ邱�Ƃ�����
+			// \0があると応答なしになることがある
 			for( DWORD i = 0; i < dwReconvTextInsLen; i++ ){
 				if( p[i] == 0 ){
 					p[i] = ' ';
@@ -419,7 +419,7 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 	}
 	
 	if( false == bDocumentFeed ){
-		// �ĕϊ����̕ۑ�
+		// 再変換情報の保存
 		m_nLastReconvIndex = nReconvIndex;
 		m_nLastReconvLine  = ptSelect.y;
 	}
@@ -429,10 +429,10 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 	return sizeof(RECONVERTSTRING) + cbReconvLenWithNull;
 }
 
-/*�ĕϊ��p �G�f�B�^��̑I��͈͂�ύX���� 2002.04.09 minfu */
+/*再変換用 エディタ上の選択範囲を変更する 2002.04.09 minfu */
 LRESULT CEditView::SetSelectionFromReonvert(const PRECONVERTSTRING pReconv, bool bUnicode){
 	
-	// �ĕϊ���񂪕ۑ�����Ă��邩
+	// 再変換情報が保存されているか
 	if ( (m_nLastReconvIndex < 0) || (m_nLastReconvLine < 0))
 		return 0;
 
@@ -445,21 +445,21 @@ LRESULT CEditView::SetSelectionFromReonvert(const PRECONVERTSTRING pReconv, bool
 	
 	DWORD dwOffset, dwLen;
 
-	//UNICODE��UNICODE
+	//UNICODE→UNICODE
 	if(bUnicode){
-		dwOffset = pReconv->dwCompStrOffset/sizeof(WCHAR);	//0�܂��̓f�[�^���B�o�C�g�P�ʁB�������P��
-		dwLen    = pReconv->dwCompStrLen;					//0�܂��͕����񒷁B�����P�ʁB
+		dwOffset = pReconv->dwCompStrOffset/sizeof(WCHAR);	//0またはデータ長。バイト単位。→文字単位
+		dwLen    = pReconv->dwCompStrLen;					//0または文字列長。文字単位。
 	}
-	//ANSI��UNICODE
+	//ANSI→UNICODE
 	else{
 		CNativeW	cmemBuf;
 
-		//�l��������̊J�n����Ώە�����̊J�n�܂�
+		//考慮文字列の開始から対象文字列の開始まで
 		if( pReconv->dwCompStrOffset > 0){
 			if( pReconv->dwSize < (pReconv->dwStrOffset + pReconv->dwCompStrOffset) ){
 				return 0;
 			}
-			// 2010.03.17 sizeof(pReconv)+1�ł͂Ȃ�dwStrOffset�𗘗p����悤��
+			// 2010.03.17 sizeof(pReconv)+1ではなくdwStrOffsetを利用するように
 			const char* p=((const char*)(pReconv)) + pReconv->dwStrOffset;
 			cmemBuf._GetMemory()->SetRawData(p, pReconv->dwCompStrOffset );
 			CShiftJis::SJISToUnicode(*(cmemBuf._GetMemory()), &cmemBuf);
@@ -468,13 +468,13 @@ LRESULT CEditView::SetSelectionFromReonvert(const PRECONVERTSTRING pReconv, bool
 			dwOffset = 0;
 		}
 
-		//�Ώە�����̊J�n����Ώە�����̏I���܂�
+		//対象文字列の開始から対象文字列の終了まで
 		if( pReconv->dwCompStrLen > 0 ){
 			if( pReconv->dwSize <
 					pReconv->dwStrOffset + pReconv->dwCompStrOffset + pReconv->dwCompStrLen*sizeof(char) ){
 				return 0;
 			}
-			// 2010.03.17 sizeof(pReconv)+1�ł͂Ȃ�dwStrOffset�𗘗p����悤��
+			// 2010.03.17 sizeof(pReconv)+1ではなくdwStrOffsetを利用するように
 			const char* p= ((const char*)pReconv) + pReconv->dwStrOffset;
 			cmemBuf._GetMemory()->SetRawData(p + pReconv->dwCompStrOffset, pReconv->dwCompStrLen);
 			CShiftJis::SJISToUnicode(*(cmemBuf._GetMemory()), &cmemBuf);
@@ -484,25 +484,25 @@ LRESULT CEditView::SetSelectionFromReonvert(const PRECONVERTSTRING pReconv, bool
 		}
 	}
 	
-	//�I���J�n�̈ʒu���擾
+	//選択開始の位置を取得
 	m_pcEditDoc->m_cLayoutMgr.LogicToLayout(
 		CLogicPoint(m_nLastReconvIndex + dwOffset, m_nLastReconvLine),
 		GetSelectionInfo().m_sSelect.GetFromPointer()
 	);
 
-	//�I���I���̈ʒu���擾
+	//選択終了の位置を取得
 	m_pcEditDoc->m_cLayoutMgr.LogicToLayout(
 		CLogicPoint(m_nLastReconvIndex + dwOffset + dwLen, m_nLastReconvLine),
 		GetSelectionInfo().m_sSelect.GetToPointer()
 	);
 
-	// �P��̐擪�ɃJ�[�\�����ړ�
+	// 単語の先頭にカーソルを移動
 	GetCaret().MoveCursor( GetSelectionInfo().m_sSelect.GetFrom(), true );
 
-	//�I��͈͍ĕ`�� 
+	//選択範囲再描画 
 	GetSelectionInfo().DrawSelectArea();
 
-	// �ĕϊ����̔j��
+	// 再変換情報の破棄
 	m_nLastReconvIndex = -1;
 	m_nLastReconvLine  = -1;
 

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -1,9 +1,9 @@
-/*!	@file
-	@brief ƒ}ƒEƒXƒCƒxƒ“ƒg‚Ìˆ—
+ï»¿/*!	@file
+	@brief ãƒã‚¦ã‚¹ã‚¤ãƒ™ãƒ³ãƒˆã®å‡¦ç†
 
 	@author Norio Nakatani
-	@date	1998/03/13 ì¬
-	@date   2008/04/13 CEditView.cpp‚©‚ç•ª—£
+	@date	1998/03/13 ä½œæˆ
+	@date   2008/04/13 CEditView.cppã‹ã‚‰åˆ†é›¢
 */
 /*
 	Copyright (C) 1998-2002, Norio Nakatani
@@ -12,9 +12,9 @@
 	Copyright (C) 2002, YAZAKI, hor, aroka, MIK, Moca, minfu, KK, novice, ai, Azumaiya, genta
 	Copyright (C) 2003, MIK, ai, ryoji, Moca, wmlhq, genta
 	Copyright (C) 2004, genta, Moca, novice, naoh, isearch, fotomo
-	Copyright (C) 2005, genta, MIK, novice, aroka, D.S.Koba, ‚©‚ë‚Æ, Moca
+	Copyright (C) 2005, genta, MIK, novice, aroka, D.S.Koba, ã‹ã‚ã¨, Moca
 	Copyright (C) 2006, Moca, aroka, ryoji, fon, genta
-	Copyright (C) 2007, ryoji, ‚¶‚ã‚¤‚¶, maru
+	Copyright (C) 2007, ryoji, ã˜ã‚…ã†ã˜, maru
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.
@@ -40,10 +40,10 @@
 #include "sakura_rc.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      ƒ}ƒEƒXƒCƒxƒ“ƒg                         //
+//                      ãƒã‚¦ã‚¹ã‚¤ãƒ™ãƒ³ãƒˆ                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/* ƒ}ƒEƒX¶ƒ{ƒ^ƒ“‰Ÿ‰º */
+/* ãƒã‚¦ã‚¹å·¦ãƒœã‚¿ãƒ³æŠ¼ä¸‹ */
 void CEditView::OnLBUTTONDOWN( WPARAM fwKeys, int _xPos , int _yPos )
 {
 	CMyPoint ptMouse(_xPos,_yPos);
@@ -53,7 +53,7 @@ void CEditView::OnLBUTTONDOWN( WPARAM fwKeys, int _xPos , int _yPos )
 		m_bHokan = FALSE;
 	}
 
-	//isearch 2004.10.22 isearch‚ğƒLƒƒƒ“ƒZƒ‹‚·‚é
+	//isearch 2004.10.22 isearchã‚’ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã™ã‚‹
 	if (m_nISearchMode > SEARCH_NONE ){
 		ISearchExit();
 	}
@@ -76,66 +76,66 @@ void CEditView::OnLBUTTONDOWN( WPARAM fwKeys, int _xPos , int _yPos )
 
 	CLogicInt	nIdx;
 	int			nWork;
-	BOOL		tripleClickMode = FALSE;	// 2007.10.02 nasukoji	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Å‚ ‚é‚±‚Æ‚ğ¦‚·
-	int			nFuncID = 0;				// 2007.12.02 nasukoji	ƒ}ƒEƒX¶ƒNƒŠƒbƒN‚É‘Î‰‚·‚é‹@”\ƒR[ƒh
+	BOOL		tripleClickMode = FALSE;	// 2007.10.02 nasukoji	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ã‚ã‚‹ã“ã¨ã‚’ç¤ºã™
+	int			nFuncID = 0;				// 2007.12.02 nasukoji	ãƒã‚¦ã‚¹å·¦ã‚¯ãƒªãƒƒã‚¯ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰
 
 	if( m_pcEditDoc->m_cLayoutMgr.GetLineCount() == 0 ){
 		return;
 	}
-	if( !GetCaret().ExistCaretFocus() ){ //ƒtƒH[ƒJƒX‚ª‚È‚¢‚Æ‚«
+	if( !GetCaret().ExistCaretFocus() ){ //ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ãŒãªã„ã¨ã
 		return;
 	}
 
-	/* «‘Tip‚ª‹N“®‚³‚ê‚Ä‚¢‚é */
+	/* è¾æ›¸TipãŒèµ·å‹•ã•ã‚Œã¦ã„ã‚‹ */
 	if( 0 == m_dwTipTimer ){
-		/* «‘Tip‚ğÁ‚· */
+		/* è¾æ›¸Tipã‚’æ¶ˆã™ */
 		m_cTipWnd.Hide();
-		m_dwTipTimer = ::GetTickCount();	/* «‘Tip‹N“®ƒ^ƒCƒ}[ */
+		m_dwTipTimer = ::GetTickCount();	/* è¾æ›¸Tipèµ·å‹•ã‚¿ã‚¤ãƒãƒ¼ */
 	}
 	else{
-		m_dwTipTimer = ::GetTickCount();		/* «‘Tip‹N“®ƒ^ƒCƒ}[ */
+		m_dwTipTimer = ::GetTickCount();		/* è¾æ›¸Tipèµ·å‹•ã‚¿ã‚¤ãƒãƒ¼ */
 	}
 
-	// 2007.12.02 nasukoji	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚ğƒ`ƒFƒbƒN
+	// 2007.12.02 nasukoji	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã‚’ãƒã‚§ãƒƒã‚¯
 	tripleClickMode = CheckTripleClick(ptMouse);
 
 	if(tripleClickMode){
-		// ƒ}ƒEƒX¶ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚É‘Î‰‚·‚é‹@”\ƒR[ƒh‚Ím_Common.m_pKeyNameArr[5]‚É“ü‚Á‚Ä‚¢‚é
+		// ãƒã‚¦ã‚¹å·¦ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã¯m_Common.m_pKeyNameArr[5]ã«å…¥ã£ã¦ã„ã‚‹
 		nFuncID = GetDllShareData().m_Common.m_sKeyBind.m_pKeyNameArr[MOUSEFUNCTION_TRIPLECLICK].m_nFuncCodeArr[getCtrlKeyState()];
 		if( 0 == nFuncID ){
-			tripleClickMode = 0;	// Š„‚è“–‚Ä‹@”\–³‚µ‚Ì‚ÍƒgƒŠƒvƒ‹ƒNƒŠƒbƒN OFF
+			tripleClickMode = 0;	// å‰²ã‚Šå½“ã¦æ©Ÿèƒ½ç„¡ã—ã®æ™‚ã¯ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ OFF
 		}
 	}else{
-		m_dwTripleClickCheck = 0;	// ƒgƒŠƒvƒ‹ƒNƒŠƒbƒNƒ`ƒFƒbƒN OFF
+		m_dwTripleClickCheck = 0;	// ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãƒã‚§ãƒƒã‚¯ OFF
 	}
 
-	/* Œ»İ‚Ìƒ}ƒEƒXƒJ[ƒ\ƒ‹ˆÊ’u¨ƒŒƒCƒAƒEƒgˆÊ’u */
+	/* ç¾åœ¨ã®ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½® */
 	CLayoutPoint ptNew;
 	GetTextArea().ClientToLayout(ptMouse, &ptNew);
 
-	// 2010.07.15 Moca ƒ}ƒEƒXƒ_ƒEƒ“‚ÌÀ•W‚ğŠo‚¦‚Ä—˜—p‚·‚é
+	// 2010.07.15 Moca ãƒã‚¦ã‚¹ãƒ€ã‚¦ãƒ³æ™‚ã®åº§æ¨™ã‚’è¦šãˆã¦åˆ©ç”¨ã™ã‚‹
 	m_cMouseDownPos = ptMouse;
 
-	// OLE‚É‚æ‚éƒhƒ‰ƒbƒO & ƒhƒƒbƒv‚ğg‚¤
-	// 2007.12.02 nasukoji	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Íƒhƒ‰ƒbƒO‚ğŠJn‚µ‚È‚¢
+	// OLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚° & ãƒ‰ãƒ­ãƒƒãƒ—ã‚’ä½¿ã†
+	// 2007.12.02 nasukoji	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯æ™‚ã¯ãƒ‰ãƒ©ãƒƒã‚°ã‚’é–‹å§‹ã—ãªã„
 	if( !tripleClickMode && GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DragDrop ){
-		if( GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DropSource ){		/* OLE‚É‚æ‚éƒhƒ‰ƒbƒOŒ³‚É‚·‚é‚© */
-			/* s‘I‘ğƒGƒŠƒA‚ğƒhƒ‰ƒbƒO‚µ‚½ */
+		if( GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DropSource ){		/* OLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚°å…ƒã«ã™ã‚‹ã‹ */
+			/* è¡Œé¸æŠã‚¨ãƒªã‚¢ã‚’ãƒ‰ãƒ©ãƒƒã‚°ã—ãŸ */
 			if( ptMouse.x < GetTextArea().GetAreaLeft() - GetTextMetrics().GetHankakuDx() ){
 				goto normal_action;
 			}
-			/* w’èƒJ[ƒ\ƒ‹ˆÊ’u‚ª‘I‘ğƒGƒŠƒA“à‚É‚ ‚é‚© */
+			/* æŒ‡å®šã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ãŒé¸æŠã‚¨ãƒªã‚¢å†…ã«ã‚ã‚‹ã‹ */
 			if( 0 == IsCurrentPositionSelected(ptNew) ){
 				POINT ptWk = {ptMouse.x, ptMouse.y};
 				::ClientToScreen(GetHwnd(), &ptWk);
 				if( !::DragDetect(GetHwnd(), ptWk) ){
-					// ƒhƒ‰ƒbƒOŠJnğŒ‚ğ–‚½‚³‚È‚©‚Á‚½‚Ì‚ÅƒNƒŠƒbƒNˆÊ’u‚ÉƒJ[ƒ\ƒ‹ˆÚ“®‚·‚é
-					if( GetSelectionInfo().IsTextSelected() ){	/* ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚© */
-						/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+					// ãƒ‰ãƒ©ãƒƒã‚°é–‹å§‹æ¡ä»¶ã‚’æº€ãŸã•ãªã‹ã£ãŸã®ã§ã‚¯ãƒªãƒƒã‚¯ä½ç½®ã«ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ã™ã‚‹
+					if( GetSelectionInfo().IsTextSelected() ){	/* ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹ */
+						/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 						GetSelectionInfo().DisableSelectArea( true );
 					}
-//@@@ 2002.01.08 YAZAKI ƒtƒŠ[ƒJ[ƒ\ƒ‹OFF‚Å•¡”s‘I‘ğ‚µAs‚ÌŒã‚ë‚ğƒNƒŠƒbƒN‚·‚é‚Æ‚»‚±‚ÉƒLƒƒƒŒƒbƒg‚ª’u‚©‚ê‚Ä‚µ‚Ü‚¤ƒoƒOC³
-					/* ƒJ[ƒ\ƒ‹ˆÚ“®B */
+//@@@ 2002.01.08 YAZAKI ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«OFFã§è¤‡æ•°è¡Œé¸æŠã—ã€è¡Œã®å¾Œã‚ã‚’ã‚¯ãƒªãƒƒã‚¯ã™ã‚‹ã¨ãã“ã«ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒç½®ã‹ã‚Œã¦ã—ã¾ã†ãƒã‚°ä¿®æ­£
+					/* ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ã€‚ */
 					if( ptMouse.y >= GetTextArea().GetAreaTop() && ptMouse.y < GetTextArea().GetAreaBottom() ){
 						if( ptMouse.x >= GetTextArea().GetAreaLeft() && ptMouse.x < GetTextArea().GetAreaRight() ){
 							GetCaret().MoveCursorToClientPoint( ptMouse );
@@ -146,7 +146,7 @@ void CEditView::OnLBUTTONDOWN( WPARAM fwKeys, int _xPos , int _yPos )
 					}
 					return;
 				}
-				/* ‘I‘ğ”ÍˆÍ‚Ìƒf[ƒ^‚ğæ“¾ */
+				/* é¸æŠç¯„å›²ã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
 				if( GetSelectedData( &cmemCurText, FALSE, NULL, FALSE, GetDllShareData().m_Common.m_sEdit.m_bAddCRLFWhenCopy ) ){
 					DWORD dwEffects;
 					DWORD dwEffectsSrc = ( !m_pcEditDoc->IsEditable() )?
@@ -156,21 +156,21 @@ void CEditView::OnLBUTTONDOWN( WPARAM fwKeys, int _xPos , int _yPos )
 					CDataObject data( cmemCurText.GetStringPtr(), cmemCurText.GetStringLength(), GetSelectionInfo().IsBoxSelecting() );
 					dwEffects = data.DragDrop( TRUE, dwEffectsSrc );
 					m_pcEditWnd->SetDragSourceView( NULL );
-					if( m_pcEditDoc->m_cDocEditor.m_cOpeBuf.GetCurrentPointer() == nOpe ){	// ƒhƒLƒ…ƒƒ“ƒg•ÏX‚È‚µ‚©H	// 2007.12.09 ryoji
+					if( m_pcEditDoc->m_cDocEditor.m_cOpeBuf.GetCurrentPointer() == nOpe ){	// ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆå¤‰æ›´ãªã—ã‹ï¼Ÿ	// 2007.12.09 ryoji
 						m_pcEditWnd->SetActivePane( m_nMyIndex );
 						if( DROPEFFECT_MOVE == (dwEffectsSrc & dwEffects) ){
-							// ˆÚ“®”ÍˆÍ‚ğíœ‚·‚é
-							// ƒhƒƒbƒvæ‚ªˆÚ“®‚ğˆ—‚µ‚½‚ª©ƒhƒLƒ…ƒƒ“ƒg‚É‚±‚±‚Ü‚Å•ÏX‚ª–³‚¢
-							// ¨ƒhƒƒbƒvæ‚ÍŠO•”‚ÌƒEƒBƒ“ƒhƒE‚Å‚ ‚é
+							// ç§»å‹•ç¯„å›²ã‚’å‰Šé™¤ã™ã‚‹
+							// ãƒ‰ãƒ­ãƒƒãƒ—å…ˆãŒç§»å‹•ã‚’å‡¦ç†ã—ãŸãŒè‡ªãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã«ã“ã“ã¾ã§å¤‰æ›´ãŒç„¡ã„
+							// â†’ãƒ‰ãƒ­ãƒƒãƒ—å…ˆã¯å¤–éƒ¨ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã§ã‚ã‚‹
 							if( NULL == m_cCommander.GetOpeBlk() ){
 								m_cCommander.SetOpeBlk(new COpeBlk);
 							}
 							m_cCommander.GetOpeBlk()->AddRef();
 
-							// ‘I‘ğ”ÍˆÍ‚ğíœ
+							// é¸æŠç¯„å›²ã‚’å‰Šé™¤
 							DeleteData( true );
 
-							// ƒAƒ“ƒhƒDƒoƒbƒtƒ@‚Ìˆ—
+							// ã‚¢ãƒ³ãƒ‰ã‚¥ãƒãƒƒãƒ•ã‚¡ã®å‡¦ç†
 							SetUndoBuffer();
 						}
 					}
@@ -182,10 +182,10 @@ void CEditView::OnLBUTTONDOWN( WPARAM fwKeys, int _xPos , int _yPos )
 
 normal_action:;
 
-	// ALTƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚éA‚©‚ÂƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Å‚È‚¢		// 2007.11.15 nasukoji	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‘Î‰
+	// ALTã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ã‚‹ã€ã‹ã¤ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ãªã„		// 2007.11.15 nasukoji	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯å¯¾å¿œ
 	if( GetKeyState_Alt() &&( ! tripleClickMode)){
-		if( GetSelectionInfo().IsTextSelected() ){	/* ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚© */
-			/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+		if( GetSelectionInfo().IsTextSelected() ){	/* ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹ */
+			/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 			GetSelectionInfo().DisableSelectArea( true );
 		}
 		if( ptMouse.y >= GetTextArea().GetAreaTop()  && ptMouse.y < GetTextArea().GetAreaBottom() ){
@@ -198,24 +198,24 @@ normal_action:;
 				return;
 			}
 		}
-		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse;	// ƒ}ƒEƒX”ÍˆÍ‘I‘ğ‘O‰ñˆÊ’u(XYÀ•W)
+		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse;	// ãƒã‚¦ã‚¹ç¯„å›²é¸æŠå‰å›ä½ç½®(XYåº§æ¨™)
 
-		/* ”ÍˆÍ‘I‘ğŠJn & ƒ}ƒEƒXƒLƒƒƒvƒ`ƒƒ[ */
+		/* ç¯„å›²é¸æŠé–‹å§‹ & ãƒã‚¦ã‚¹ã‚­ãƒ£ãƒ—ãƒãƒ£ãƒ¼ */
 		GetSelectionInfo().SelectBeginBox();
 
 		::SetCapture( GetHwnd() );
 		GetCaret().HideCaret_( GetHwnd() ); // 2002/07/22 novice
-		/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é */
+		/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹ */
 		GetSelectionInfo().BeginSelectArea( );
 		GetCaret().m_cUnderLine.CaretUnderLineOFF( true );
 		GetCaret().m_cUnderLine.UnderLineLock();
 		if( ptMouse.x < GetTextArea().GetAreaLeft() ){
-			/* ƒJ[ƒ\ƒ‹‰ºˆÚ“® */
+			/* ã‚«ãƒ¼ã‚½ãƒ«ä¸‹ç§»å‹• */
 			GetCommander().Command_DOWN( true, false );
 		}
 	}
 	else{
-		/* ƒJ[ƒ\ƒ‹ˆÚ“® */
+		/* ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹• */
 		if( ptMouse.y >= GetTextArea().GetAreaTop() && ptMouse.y < GetTextArea().GetAreaBottom() ){
 			if( ptMouse.x >= GetTextArea().GetAreaLeft() && ptMouse.x < GetTextArea().GetAreaRight() ){
 			}
@@ -226,17 +226,17 @@ normal_action:;
 			}
 		}
 		else if( ptMouse.y < GetTextArea().GetAreaTop() ){
-			//	ƒ‹[ƒ‰ƒNƒŠƒbƒN
+			//	ãƒ«ãƒ¼ãƒ©ã‚¯ãƒªãƒƒã‚¯
 			return;
 		}
 		else {
 			return;
 		}
 
-		/* ƒ}ƒEƒX‚ÌƒLƒƒƒvƒ`ƒƒ‚È‚Ç */
-		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse;	// ƒ}ƒEƒX”ÍˆÍ‘I‘ğ‘O‰ñˆÊ’u(XYÀ•W)
+		/* ãƒã‚¦ã‚¹ã®ã‚­ãƒ£ãƒ—ãƒãƒ£ãªã© */
+		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse;	// ãƒã‚¦ã‚¹ç¯„å›²é¸æŠå‰å›ä½ç½®(XYåº§æ¨™)
 		
-		/* ”ÍˆÍ‘I‘ğŠJn & ƒ}ƒEƒXƒLƒƒƒvƒ`ƒƒ[ */
+		/* ç¯„å›²é¸æŠé–‹å§‹ & ãƒã‚¦ã‚¹ã‚­ãƒ£ãƒ—ãƒãƒ£ãƒ¼ */
 		GetSelectionInfo().SelectBeginNazo();
 		::SetCapture( GetHwnd() );
 		GetCaret().HideCaret_( GetHwnd() ); // 2002/07/22 novice
@@ -244,61 +244,61 @@ normal_action:;
 
 		CLayoutPoint ptNewCaret = GetCaret().GetCaretLayoutPos();
 		bool bSetPtNewCaret = false;
-		if(tripleClickMode){		// 2007.11.15 nasukoji	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚ğˆ—‚·‚é
-			// 1s‘I‘ğ‚Å‚È‚¢ê‡‚Í‘I‘ğ•¶š—ñ‚ğ‰ğœ
-			// ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚ª1s‘I‘ğ‚Å‚È‚­‚Ä‚àƒNƒAƒhƒ‰ƒvƒ‹ƒNƒŠƒbƒN‚ğ—LŒø‚Æ‚·‚é
+		if(tripleClickMode){		// 2007.11.15 nasukoji	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã‚’å‡¦ç†ã™ã‚‹
+			// 1è¡Œé¸æŠã§ãªã„å ´åˆã¯é¸æŠæ–‡å­—åˆ—ã‚’è§£é™¤
+			// ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãŒ1è¡Œé¸æŠã§ãªãã¦ã‚‚ã‚¯ã‚¢ãƒ‰ãƒ©ãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã‚’æœ‰åŠ¹ã¨ã™ã‚‹
 			if(F_SELECTLINE != nFuncID){
-				OnLBUTTONUP( fwKeys, ptMouse.x, ptMouse.y );	// ‚±‚±‚Å¶ƒ{ƒ^ƒ“ƒAƒbƒv‚µ‚½‚±‚Æ‚É‚·‚é
+				OnLBUTTONUP( fwKeys, ptMouse.x, ptMouse.y );	// ã“ã“ã§å·¦ãƒœã‚¿ãƒ³ã‚¢ãƒƒãƒ—ã—ãŸã“ã¨ã«ã™ã‚‹
 
-				if( GetSelectionInfo().IsTextSelected() )		// ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚©
-					GetSelectionInfo().DisableSelectArea( true );	// Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚·
+				if( GetSelectionInfo().IsTextSelected() )		// ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹
+					GetSelectionInfo().DisableSelectArea( true );	// ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™
 			}
 
-			// ’PŒê‚Ì“r’†‚ÅÜ‚è•Ô‚³‚ê‚Ä‚¢‚é‚Æ‰º‚Ìs‚ª‘I‘ğ‚³‚ê‚Ä‚µ‚Ü‚¤‚±‚Æ‚Ö‚Ì‘Îˆ
+			// å˜èªã®é€”ä¸­ã§æŠ˜ã‚Šè¿”ã•ã‚Œã¦ã„ã‚‹ã¨ä¸‹ã®è¡ŒãŒé¸æŠã•ã‚Œã¦ã—ã¾ã†ã“ã¨ã¸ã®å¯¾å‡¦
 			if(F_SELECTLINE != nFuncID){
-				GetCaret().MoveCursorToClientPoint( ptMouse );	// ƒJ[ƒ\ƒ‹ˆÚ“®
+				GetCaret().MoveCursorToClientPoint( ptMouse );	// ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•
 			}else{
-				GetCaret().MoveCursorToClientPoint( ptMouse, true, &ptNewCaret );	// ƒJ[ƒ\ƒ‹ˆÚ“®
+				GetCaret().MoveCursorToClientPoint( ptMouse, true, &ptNewCaret );	// ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•
 				bSetPtNewCaret = true;
 			}
 
-			// ƒRƒ}ƒ“ƒhƒR[ƒh‚É‚æ‚éˆ—U‚è•ª‚¯
-			// ƒ}ƒEƒX‚©‚ç‚ÌƒƒbƒZ[ƒW‚ÍCMD_FROM_MOUSE‚ğãˆÊƒrƒbƒg‚É“ü‚ê‚Ä‘—‚é
+			// ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã«ã‚ˆã‚‹å‡¦ç†æŒ¯ã‚Šåˆ†ã‘
+			// ãƒã‚¦ã‚¹ã‹ã‚‰ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯CMD_FROM_MOUSEã‚’ä¸Šä½ãƒ“ãƒƒãƒˆã«å…¥ã‚Œã¦é€ã‚‹
 			::SendMessage( ::GetParent( m_hwndParent ), WM_COMMAND, MAKELONG( nFuncID, CMD_FROM_MOUSE ), (LPARAM)NULL );
 
-			// 1s‘I‘ğ‚Å‚È‚¢ê‡‚Í‚±‚±‚Å”²‚¯‚éi‘¼‚Ì‘I‘ğƒRƒ}ƒ“ƒh‚Ì–â‘è‚Æ‚È‚é‚©‚àj
+			// 1è¡Œé¸æŠã§ãªã„å ´åˆã¯ã“ã“ã§æŠœã‘ã‚‹ï¼ˆä»–ã®é¸æŠã‚³ãƒãƒ³ãƒ‰ã®æ™‚å•é¡Œã¨ãªã‚‹ã‹ã‚‚ï¼‰
 			if(F_SELECTLINE != nFuncID)
 				return;
 			ptNewCaret = GetCaret().GetCaretLayoutPos();
 
-			// ‘I‘ğ‚·‚é‚à‚Ì‚ª–³‚¢i[EOF]‚Ì‚İ‚Ìsj‚Í’ÊíƒNƒŠƒbƒN‚Æ“¯‚¶ˆ—
+			// é¸æŠã™ã‚‹ã‚‚ã®ãŒç„¡ã„ï¼ˆ[EOF]ã®ã¿ã®è¡Œï¼‰æ™‚ã¯é€šå¸¸ã‚¯ãƒªãƒƒã‚¯ã¨åŒã˜å‡¦ç†
 			if(( ! GetSelectionInfo().IsTextSelected() )&&
 			   ( GetCaret().GetCaretLogicPos().y >= m_pcEditDoc->m_cDocLineMgr.GetLineCount() ))
 			{
-				GetSelectionInfo().BeginSelectArea();				// Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é
-				GetSelectionInfo().m_bBeginLineSelect = false;		// s’PˆÊ‘I‘ğ’† OFF
+				GetSelectionInfo().BeginSelectArea();				// ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹
+				GetSelectionInfo().m_bBeginLineSelect = false;		// è¡Œå˜ä½é¸æŠä¸­ OFF
 			}
 		}else
-		/* ‘I‘ğŠJnˆ— */
-		/* SHIFTƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚½‚© */
+		/* é¸æŠé–‹å§‹å‡¦ç† */
+		/* SHIFTã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãŸã‹ */
 		if(GetKeyState_Shift()){
-			if( GetSelectionInfo().IsTextSelected() ){		/* ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚© */
-				if( GetSelectionInfo().IsBoxSelecting() ){	/* ‹éŒ`”ÍˆÍ‘I‘ğ’† */
-					/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+			if( GetSelectionInfo().IsTextSelected() ){		/* ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹ */
+				if( GetSelectionInfo().IsBoxSelecting() ){	/* çŸ©å½¢ç¯„å›²é¸æŠä¸­ */
+					/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 					GetSelectionInfo().DisableSelectArea( true );
 
-					/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é */
+					/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹ */
 					GetSelectionInfo().BeginSelectArea( );
 				}
 				else{
 				}
 			}
 			else{
-				/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é */
+				/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹ */
 				GetSelectionInfo().BeginSelectArea( );
 			}
 
-			/* ƒJ[ƒ\ƒ‹ˆÚ“® */
+			/* ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹• */
 			if( ptMouse.y >= GetTextArea().GetAreaTop() && ptMouse.y < GetTextArea().GetAreaBottom() ){
 				if( ptMouse.x >= GetTextArea().GetAreaLeft() && ptMouse.x < GetTextArea().GetAreaRight() ){
 					GetCaret().MoveCursorToClientPoint( ptMouse, true, &ptNewCaret );
@@ -310,11 +310,11 @@ normal_action:;
 			}
 		}
 		else{
-			if( GetSelectionInfo().IsTextSelected() ){	/* ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚© */
-				/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+			if( GetSelectionInfo().IsTextSelected() ){	/* ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹ */
+				/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 				GetSelectionInfo().DisableSelectArea( true );
 			}
-			/* ƒJ[ƒ\ƒ‹ˆÚ“® */
+			/* ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹• */
 			if( ptMouse.y >= GetTextArea().GetAreaTop() && ptMouse.y < GetTextArea().GetAreaBottom() ){
 				if( ptMouse.x >= GetTextArea().GetAreaLeft() && ptMouse.x < GetTextArea().GetAreaRight() ){
 					GetCaret().MoveCursorToClientPoint( ptMouse, true, &ptNewCaret );
@@ -324,12 +324,12 @@ normal_action:;
 				}
 				bSetPtNewCaret = true;
 			}
-			/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é */
+			/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹ */
 			GetSelectionInfo().BeginSelectArea( &ptNewCaret );
 		}
 
 
-		/******* ‚±‚Ì“_‚Å•K‚¸ true == GetSelectionInfo().IsTextSelected() ‚Ìó‘Ô‚É‚È‚é ****:*/
+		/******* ã“ã®æ™‚ç‚¹ã§å¿…ãš true == GetSelectionInfo().IsTextSelected() ã®çŠ¶æ…‹ã«ãªã‚‹ ****:*/
 		if( !GetSelectionInfo().IsTextSelected() ){
 			WarningMessage( GetHwnd(), LS(STR_VIEW_MOUSE_BUG) );
 			return;
@@ -337,30 +337,30 @@ normal_action:;
 
 		int	nWorkRel;
 		nWorkRel = IsCurrentPositionSelected(
-			ptNewCaret	// ƒJ[ƒ\ƒ‹ˆÊ’u
+			ptNewCaret	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
 		);
 
 
-		/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+		/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 		GetSelectionInfo().ChangeSelectAreaByCurrentCursor( ptNewCaret );
 
 		bool bSelectWord = false;
-		// CTRLƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚éA‚©‚ÂƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Å‚È‚¢		// 2007.11.15 nasukoji	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‘Î‰
+		// CTRLã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ã‚‹ã€ã‹ã¤ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ãªã„		// 2007.11.15 nasukoji	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯å¯¾å¿œ
 		if( GetKeyState_Control() &&( ! tripleClickMode)){
-			GetSelectionInfo().m_bBeginWordSelect = true;		/* ’PŒê’PˆÊ‘I‘ğ’† */
+			GetSelectionInfo().m_bBeginWordSelect = true;		/* å˜èªå˜ä½é¸æŠä¸­ */
 			if( !GetSelectionInfo().IsTextSelected() ){
-				/* Œ»İˆÊ’u‚Ì’PŒê‘I‘ğ */
+				/* ç¾åœ¨ä½ç½®ã®å˜èªé¸æŠ */
 				if ( GetCommander().Command_SELECTWORD( &ptNewCaret ) ){
 					bSelectWord = true;
 					GetSelectionInfo().m_sSelectBgn = GetSelectionInfo().m_sSelect;
 				}
 			}else{
 
-				/* ‘I‘ğ—Ìˆæ•`‰æ */
+				/* é¸æŠé ˜åŸŸæç”» */
 				GetSelectionInfo().DrawSelectArea();
 
 
-				/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é */
+				/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 				const CLayout* pcLayout;
 				pLine = m_pcEditDoc->m_cLayoutMgr.GetLineStr(
 					GetSelectionInfo().m_sSelect.GetFrom().GetY2(),
@@ -369,7 +369,7 @@ normal_action:;
 				);
 				if( NULL != pLine ){
 					nIdx = LineColumnToIndex( pcLayout, GetSelectionInfo().m_sSelect.GetFrom().GetX2() );
-					/* Œ»İˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ğ’²‚×‚é */
+					/* ç¾åœ¨ä½ç½®ã®å˜èªã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 					bool bWhareResult = m_pcEditDoc->m_cLayoutMgr.WhereCurrentWord(
 						GetSelectionInfo().m_sSelect.GetFrom().GetY2(),
 						nIdx,
@@ -378,8 +378,8 @@ normal_action:;
 						NULL
 					);
 					if( bWhareResult ){
-						// w’è‚³‚ê‚½s‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚É‘Î‰‚·‚éŒ…‚ÌˆÊ’u‚ğ’²‚×‚éB
-						// 2007.10.15 kobake Šù‚ÉƒŒƒCƒAƒEƒg’PˆÊ‚È‚Ì‚Å•ÏŠ·‚Í•s—v
+						// æŒ‡å®šã•ã‚ŒãŸè¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ¡ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ã€‚
+						// 2007.10.15 kobake æ—¢ã«ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ãªã®ã§å¤‰æ›ã¯ä¸è¦
 						/*
 						pLine            = m_pcEditDoc->m_cLayoutMgr.GetLineStr( sRange.GetFrom().GetY2(), &nLineLen, &pcLayout );
 						sRange.SetFromX( LineIndexToColumn( pcLayout, sRange.GetFrom().x ) );
@@ -388,7 +388,7 @@ normal_action:;
 						*/
 
 						nWork = IsCurrentPositionSelected(
-							sRange.GetFrom()	// ƒJ[ƒ\ƒ‹ˆÊ’u
+							sRange.GetFrom()	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
 						);
 						if( -1 == nWork || 0 == nWork ){
 							GetSelectionInfo().m_sSelect.SetFrom(sRange.GetFrom());
@@ -401,12 +401,12 @@ normal_action:;
 				pLine = m_pcEditDoc->m_cLayoutMgr.GetLineStr( GetSelectionInfo().m_sSelect.GetTo().GetY2(), &nLineLen, &pcLayout );
 				if( NULL != pLine ){
 					nIdx = LineColumnToIndex( pcLayout, GetSelectionInfo().m_sSelect.GetTo().GetX2() );
-					/* Œ»İˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ğ’²‚×‚é */
+					/* ç¾åœ¨ä½ç½®ã®å˜èªã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 					if( m_pcEditDoc->m_cLayoutMgr.WhereCurrentWord(
 						GetSelectionInfo().m_sSelect.GetTo().GetY2(), nIdx, &sRange, NULL, NULL )
 					){
-						// w’è‚³‚ê‚½s‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚É‘Î‰‚·‚éŒ…‚ÌˆÊ’u‚ğ’²‚×‚é
-						// 2007.10.15 kobake Šù‚ÉƒŒƒCƒAƒEƒg’PˆÊ‚È‚Ì‚Å•ÏŠ·‚Í•s—v
+						// æŒ‡å®šã•ã‚ŒãŸè¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ¡ã®ä½ç½®ã‚’èª¿ã¹ã‚‹
+						// 2007.10.15 kobake æ—¢ã«ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ãªã®ã§å¤‰æ›ã¯ä¸è¦
 						/*
 						pLine = m_pcEditDoc->m_cLayoutMgr.GetLineStr( sRange.GetFrom().GetY2(), &nLineLen, &pcLayout );
 						sRange.SetFromX( LineIndexToColumn( pcLayout, sRange.GetFrom().x ) );
@@ -430,19 +430,19 @@ normal_action:;
 				if( 0 < nWorkRel ){
 
 				}
-				/* ‘I‘ğ—Ìˆæ•`‰æ */
+				/* é¸æŠé ˜åŸŸæç”» */
 				GetSelectionInfo().DrawSelectArea();
 			}
 		}
-		// s”Ô†ƒGƒŠƒA‚ğƒNƒŠƒbƒN‚µ‚½
-		// 2008.05.22 nasukoji	ƒVƒtƒgƒL[‚ğ‰Ÿ‚µ‚Ä‚¢‚éê‡‚Ís“ªƒNƒŠƒbƒN‚Æ‚µ‚Äˆµ‚¤
+		// è¡Œç•ªå·ã‚¨ãƒªã‚¢ã‚’ã‚¯ãƒªãƒƒã‚¯ã—ãŸ
+		// 2008.05.22 nasukoji	ã‚·ãƒ•ãƒˆã‚­ãƒ¼ã‚’æŠ¼ã—ã¦ã„ã‚‹å ´åˆã¯è¡Œé ­ã‚¯ãƒªãƒƒã‚¯ã¨ã—ã¦æ‰±ã†
 		if( ptMouse.x < GetTextArea().GetAreaLeft() && !GetKeyState_Shift() ){
-			/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é */
+			/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹ */
 			GetSelectionInfo().m_bBeginLineSelect = true;
 
 			// 2009.02.22 ryoji 
-			// Command_GOLINEEND()/Command_RIGHT()‚Å‚Í‚È‚­Ÿ‚ÌƒŒƒCƒAƒEƒg‚ğ’²‚×‚ÄˆÚ“®‘I‘ğ‚·‚é•û–@‚É•ÏX
-			// ¦Command_GOLINEEND()/Command_RIGHT()‚Í[Ü‚è•Ô‚µ––”ö•¶š‚Ì‰E‚ÖˆÚ“®]{[Ÿs‚Ìæ“ª•¶š‚Ì‰E‚ÉˆÚ“®]‚Ìd—l‚¾‚Æ‚m‚f
+			// Command_GOLINEEND()/Command_RIGHT()ã§ã¯ãªãæ¬¡ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã‚’èª¿ã¹ã¦ç§»å‹•é¸æŠã™ã‚‹æ–¹æ³•ã«å¤‰æ›´
+			// â€»Command_GOLINEEND()/Command_RIGHT()ã¯[æŠ˜ã‚Šè¿”ã—æœ«å°¾æ–‡å­—ã®å³ã¸ç§»å‹•]ï¼‹[æ¬¡è¡Œã®å…ˆé ­æ–‡å­—ã®å³ã«ç§»å‹•]ã®ä»•æ§˜ã ã¨ï¼®ï¼§
 			const CLayout* pcLayout = m_pcEditDoc->m_cLayoutMgr.SearchLineByLayoutY( ptNewCaret.GetY2() );
 			if( pcLayout ){
 				CLayoutPoint ptCaret;
@@ -452,13 +452,13 @@ normal_action:;
 				}else{
 					ptCaret.x = CLayoutInt(0);
 				}
-				ptCaret.y = ptNewCaret.GetY2() + 1;	// ‰üs–³‚µEOFs‚Å‚à MoveCursor() ‚ª—LŒø‚ÈÀ•W‚É’²®‚µ‚Ä‚­‚ê‚é
+				ptCaret.y = ptNewCaret.GetY2() + 1;	// æ”¹è¡Œç„¡ã—EOFè¡Œã§ã‚‚ MoveCursor() ãŒæœ‰åŠ¹ãªåº§æ¨™ã«èª¿æ•´ã—ã¦ãã‚Œã‚‹
 				GetCaret().GetAdjustCursorPos( &ptCaret );
 				GetSelectionInfo().ChangeSelectAreaByCurrentCursor( ptCaret );
 				GetCaret().MoveCursor( ptCaret, true );
 				GetCaret().m_nCaretPosX_Prev = GetCaret().GetCaretLayoutPos().GetX2();
 			}else{
-				/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+				/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 				if( bSetPtNewCaret ){
 					GetSelectionInfo().ChangeSelectAreaByCurrentCursor( ptNewCaret );
 					GetCaret().MoveCursor( ptNewCaret, true, 1000 );
@@ -467,38 +467,38 @@ normal_action:;
 			}
 
 			//	Apr. 14, 2003 genta
-			//	s”Ô†‚Ì‰º‚ğƒNƒŠƒbƒN‚µ‚Äƒhƒ‰ƒbƒO‚ğŠJn‚·‚é‚Æ‚¨‚©‚µ‚­‚È‚é‚Ì‚ğC³
-			//	s”Ô†‚ğƒNƒŠƒbƒN‚µ‚½ê‡‚É‚ÍGetSelectionInfo().ChangeSelectAreaByCurrentCursor()‚É‚Ä
-			//	GetSelectionInfo().m_sSelect.GetTo().x/GetSelectionInfo().m_sSelect.GetTo().y‚É-1‚ªİ’è‚³‚ê‚é‚ªAã‚Ì
-			//	GetCommander().Command_GOLINEEND(), Command_RIGHT()‚É‚æ‚Á‚Äs‘I‘ğ‚ªs‚í‚ê‚éB
-			//	‚µ‚©‚µƒLƒƒƒŒƒbƒg‚ª––”ö‚É‚ ‚éê‡‚É‚ÍƒLƒƒƒŒƒbƒg‚ªˆÚ“®‚µ‚È‚¢‚Ì‚Å
-			//	GetSelectionInfo().m_sSelect.GetTo().x/GetSelectionInfo().m_sSelect.GetTo().y‚ª-1‚Ì‚Ü‚Üc‚Á‚Ä‚µ‚Ü‚¢A‚»‚ê‚ª
-			//	Œ´“_‚Éİ’è‚³‚ê‚é‚½‚ß‚É‚¨‚©‚µ‚­‚È‚Á‚Ä‚¢‚½B
-			//	‚È‚Ì‚ÅA”ÍˆÍ‘I‘ğ‚ªs‚í‚ê‚Ä‚¢‚È‚¢ê‡‚Í‹N“_––”ö‚Ìİ’è‚ğs‚í‚È‚¢‚æ‚¤‚É‚·‚é
+			//	è¡Œç•ªå·ã®ä¸‹ã‚’ã‚¯ãƒªãƒƒã‚¯ã—ã¦ãƒ‰ãƒ©ãƒƒã‚°ã‚’é–‹å§‹ã™ã‚‹ã¨ãŠã‹ã—ããªã‚‹ã®ã‚’ä¿®æ­£
+			//	è¡Œç•ªå·ã‚’ã‚¯ãƒªãƒƒã‚¯ã—ãŸå ´åˆã«ã¯GetSelectionInfo().ChangeSelectAreaByCurrentCursor()ã«ã¦
+			//	GetSelectionInfo().m_sSelect.GetTo().x/GetSelectionInfo().m_sSelect.GetTo().yã«-1ãŒè¨­å®šã•ã‚Œã‚‹ãŒã€ä¸Šã®
+			//	GetCommander().Command_GOLINEEND(), Command_RIGHT()ã«ã‚ˆã£ã¦è¡Œé¸æŠãŒè¡Œã‚ã‚Œã‚‹ã€‚
+			//	ã—ã‹ã—ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒæœ«å°¾ã«ã‚ã‚‹å ´åˆã«ã¯ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒç§»å‹•ã—ãªã„ã®ã§
+			//	GetSelectionInfo().m_sSelect.GetTo().x/GetSelectionInfo().m_sSelect.GetTo().yãŒ-1ã®ã¾ã¾æ®‹ã£ã¦ã—ã¾ã„ã€ãã‚ŒãŒ
+			//	åŸç‚¹ã«è¨­å®šã•ã‚Œã‚‹ãŸã‚ã«ãŠã‹ã—ããªã£ã¦ã„ãŸã€‚
+			//	ãªã®ã§ã€ç¯„å›²é¸æŠãŒè¡Œã‚ã‚Œã¦ã„ãªã„å ´åˆã¯èµ·ç‚¹æœ«å°¾ã®è¨­å®šã‚’è¡Œã‚ãªã„ã‚ˆã†ã«ã™ã‚‹
 			if( GetSelectionInfo().IsTextSelected() ){
 				GetSelectionInfo().m_sSelectBgn.SetTo( GetSelectionInfo().m_sSelect.GetTo() );
 			}
 		}
 		else{
-			/* URL‚ªƒNƒŠƒbƒN‚³‚ê‚½‚ç‘I‘ğ‚·‚é‚© */
+			/* URLãŒã‚¯ãƒªãƒƒã‚¯ã•ã‚ŒãŸã‚‰é¸æŠã™ã‚‹ã‹ */
 			if( FALSE != GetDllShareData().m_Common.m_sEdit.m_bSelectClickedURL ){
 
-				CLogicRange cUrlRange;	//URL”ÍˆÍ
-				// ƒJ[ƒ\ƒ‹ˆÊ’u‚ÉURL‚ª—L‚éê‡‚Ì‚»‚Ì”ÍˆÍ‚ğ’²‚×‚é
+				CLogicRange cUrlRange;	//URLç¯„å›²
+				// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«URLãŒæœ‰ã‚‹å ´åˆã®ãã®ç¯„å›²ã‚’èª¿ã¹ã‚‹
 				bool bIsUrl = IsCurrentPositionURL(
-					ptNewCaret,	// ƒJ[ƒ\ƒ‹ˆÊ’u
-					&cUrlRange,						// URL”ÍˆÍ
-					NULL							// URLó‚¯æ‚èæ
+					ptNewCaret,	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
+					&cUrlRange,						// URLç¯„å›²
+					NULL							// URLå—ã‘å–ã‚Šå…ˆ
 				);
 				if( bIsUrl ){
-					/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+					/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 					GetSelectionInfo().DisableSelectArea( true );
 
 					/*
-					  ƒJ[ƒ\ƒ‹ˆÊ’u•ÏŠ·
-					  •¨—ˆÊ’u(s“ª‚©‚ç‚ÌƒoƒCƒg”AÜ‚è•Ô‚µ–³‚µsˆÊ’u)
-					  ¨ƒŒƒCƒAƒEƒgˆÊ’u(s“ª‚©‚ç‚Ì•\¦Œ…ˆÊ’uAÜ‚è•Ô‚µ‚ ‚èsˆÊ’u)
-						2002/04/08 YAZAKI ­‚µ‚Å‚à‚í‚©‚è‚â‚·‚­B
+					  ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å¤‰æ›
+					  ç‰©ç†ä½ç½®(è¡Œé ­ã‹ã‚‰ã®ãƒã‚¤ãƒˆæ•°ã€æŠ˜ã‚Šè¿”ã—ç„¡ã—è¡Œä½ç½®)
+					  â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®(è¡Œé ­ã‹ã‚‰ã®è¡¨ç¤ºæ¡ä½ç½®ã€æŠ˜ã‚Šè¿”ã—ã‚ã‚Šè¡Œä½ç½®)
+						2002/04/08 YAZAKI å°‘ã—ã§ã‚‚ã‚ã‹ã‚Šã‚„ã™ãã€‚
 					*/
 					CLayoutRange sRangeB;
 					m_pcEditDoc->m_cLayoutMgr.LogicToLayout( cUrlRange, &sRangeB );
@@ -510,12 +510,12 @@ normal_action:;
 					GetSelectionInfo().m_sSelectBgn = sRangeB;
 					GetSelectionInfo().m_sSelect = sRangeB;
 
-					/* ‘I‘ğ—Ìˆæ•`‰æ */
+					/* é¸æŠé ˜åŸŸæç”» */
 					GetSelectionInfo().DrawSelectArea();
 				}
 			}
 			if( bSetPtNewCaret && !bSelectWord ){
-				/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+				/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 				GetCaret().MoveCursor( ptNewCaret, true, 1000 );
 				GetCaret().m_nCaretPosX_Prev = GetCaret().GetCaretLayoutPos().GetX2();
 			}
@@ -524,47 +524,47 @@ normal_action:;
 }
 
 
-/*!	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Ìƒ`ƒFƒbƒN
-	@brief ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚ğ”»’è‚·‚é
+/*!	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã®ãƒã‚§ãƒƒã‚¯
+	@brief ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã‚’åˆ¤å®šã™ã‚‹
 	
-	2‰ñ–Ú‚ÌƒNƒŠƒbƒN‚©‚ç3‰ñ–Ú‚ÌƒNƒŠƒbƒN‚Ü‚Å‚ÌŠÔ‚ªƒ_ƒuƒ‹ƒNƒŠƒbƒNŠÔˆÈ“à‚ÅA
-	‚©‚Â‚»‚Ì‚ÌƒNƒŠƒbƒNˆÊ’u‚Ì‚¸‚ê‚ªƒVƒXƒeƒ€ƒƒgƒŠƒbƒNiX:SM_CXDOUBLECLK,
-	Y:SM_CYDOUBLECLKj‚Ì’liƒsƒNƒZƒ‹jˆÈ‰º‚ÌƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Æ‚·‚éB
+	2å›ç›®ã®ã‚¯ãƒªãƒƒã‚¯ã‹ã‚‰3å›ç›®ã®ã‚¯ãƒªãƒƒã‚¯ã¾ã§ã®æ™‚é–“ãŒãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯æ™‚é–“ä»¥å†…ã§ã€
+	ã‹ã¤ãã®æ™‚ã®ã‚¯ãƒªãƒƒã‚¯ä½ç½®ã®ãšã‚ŒãŒã‚·ã‚¹ãƒ†ãƒ ãƒ¡ãƒˆãƒªãƒƒã‚¯ï¼ˆX:SM_CXDOUBLECLK,
+	Y:SM_CYDOUBLECLKï¼‰ã®å€¤ï¼ˆãƒ”ã‚¯ã‚»ãƒ«ï¼‰ä»¥ä¸‹ã®æ™‚ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã¨ã™ã‚‹ã€‚
 	
-	@param[in] xPos		ƒ}ƒEƒXƒNƒŠƒbƒNXÀ•W
-	@param[in] yPos		ƒ}ƒEƒXƒNƒŠƒbƒNYÀ•W
-	@return		ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Ì‚ÍTRUE‚ğ•Ô‚·
-	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Å‚È‚¢‚ÍFALSE‚ğ•Ô‚·
+	@param[in] xPos		ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯Xåº§æ¨™
+	@param[in] yPos		ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯Yåº§æ¨™
+	@return		ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã®æ™‚ã¯TRUEã‚’è¿”ã™
+	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ãªã„æ™‚ã¯FALSEã‚’è¿”ã™
 
-	@note	m_dwTripleClickCheck‚ª0‚Å‚È‚¢‚Éƒ`ƒFƒbƒNƒ‚[ƒh‚Æ”»’è‚·‚é‚ªAPC‚ğ
-			˜A‘±‰Ò“®‚µ‚Ä‚¢‚éê‡49.7“ú–ˆ‚ÉƒJƒEƒ“ƒ^‚ª0‚É‚È‚éˆ×A‚í‚¸‚©‚È‰Â”\«
-			‚Å‚ ‚é‚ªƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚ª”»’è‚Å‚«‚È‚¢‚ª‚ ‚éB
-			s”Ô†•\¦ƒGƒŠƒA‚ÌƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Í’ÊíƒNƒŠƒbƒN‚Æ‚µ‚Äˆµ‚¤B
+	@note	m_dwTripleClickCheckãŒ0ã§ãªã„æ™‚ã«ãƒã‚§ãƒƒã‚¯ãƒ¢ãƒ¼ãƒ‰ã¨åˆ¤å®šã™ã‚‹ãŒã€PCã‚’
+			é€£ç¶šç¨¼å‹•ã—ã¦ã„ã‚‹å ´åˆ49.7æ—¥æ¯ã«ã‚«ã‚¦ãƒ³ã‚¿ãŒ0ã«ãªã‚‹ç‚ºã€ã‚ãšã‹ãªå¯èƒ½æ€§
+			ã§ã‚ã‚‹ãŒãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãŒåˆ¤å®šã§ããªã„æ™‚ãŒã‚ã‚‹ã€‚
+			è¡Œç•ªå·è¡¨ç¤ºã‚¨ãƒªã‚¢ã®ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã¯é€šå¸¸ã‚¯ãƒªãƒƒã‚¯ã¨ã—ã¦æ‰±ã†ã€‚
 	
-	@date 2007.11.15 nasukoji	V‹Kì¬
+	@date 2007.11.15 nasukoji	æ–°è¦ä½œæˆ
 */
 BOOL CEditView::CheckTripleClick( CMyPoint ptMouse )
 {
 
-	// ƒgƒŠƒvƒ‹ƒNƒŠƒbƒNƒ`ƒFƒbƒN—LŒø‚Å‚È‚¢i‚ªƒZƒbƒg‚³‚ê‚Ä‚¢‚È‚¢j
+	// ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãƒã‚§ãƒƒã‚¯æœ‰åŠ¹ã§ãªã„ï¼ˆæ™‚åˆ»ãŒã‚»ãƒƒãƒˆã•ã‚Œã¦ã„ãªã„ï¼‰
 	if(! m_dwTripleClickCheck)
 		return FALSE;
 
 	BOOL result = FALSE;
 
-	// ‘O‰ñƒNƒŠƒbƒN‚Æ‚ÌƒNƒŠƒbƒNˆÊ’u‚Ì‚¸‚ê‚ğZo
+	// å‰å›ã‚¯ãƒªãƒƒã‚¯ã¨ã®ã‚¯ãƒªãƒƒã‚¯ä½ç½®ã®ãšã‚Œã‚’ç®—å‡º
 	CMyPoint dpos( GetSelectionInfo().m_ptMouseRollPosOld.x - ptMouse.x,
 				   GetSelectionInfo().m_ptMouseRollPosOld.y - ptMouse.y );
 
 	if(dpos.x < 0)
-		dpos.x = -dpos.x;	// â‘Î’l‰»
+		dpos.x = -dpos.x;	// çµ¶å¯¾å€¤åŒ–
 
 	if(dpos.y < 0)
-		dpos.y = -dpos.y;	// â‘Î’l‰»
+		dpos.y = -dpos.y;	// çµ¶å¯¾å€¤åŒ–
 
-	// s”Ô†•\¦ƒGƒŠƒA‚Å‚È‚¢A‚©‚ÂƒNƒŠƒbƒNƒvƒŒƒX‚©‚çƒ_ƒuƒ‹ƒNƒŠƒbƒNŠÔˆÈ“àA
-	// ‚©‚Âƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Ì‹–—e‚¸‚êƒsƒNƒZƒ‹ˆÈ‰º‚Ì‚¸‚ê‚ÌƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚Æ‚·‚é
-	//	2007.10.12 genta/dskoba ƒVƒXƒeƒ€‚Ìƒ_ƒuƒ‹ƒNƒŠƒbƒN‘¬“xC‚¸‚ê‹–—e—Ê‚ğæ“¾
+	// è¡Œç•ªå·è¡¨ç¤ºã‚¨ãƒªã‚¢ã§ãªã„ã€ã‹ã¤ã‚¯ãƒªãƒƒã‚¯ãƒ—ãƒ¬ã‚¹ã‹ã‚‰ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯æ™‚é–“ä»¥å†…ã€
+	// ã‹ã¤ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã®è¨±å®¹ãšã‚Œãƒ”ã‚¯ã‚»ãƒ«ä»¥ä¸‹ã®ãšã‚Œã®æ™‚ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã¨ã™ã‚‹
+	//	2007.10.12 genta/dskoba ã‚·ã‚¹ãƒ†ãƒ ã®ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯é€Ÿåº¦ï¼Œãšã‚Œè¨±å®¹é‡ã‚’å–å¾—
 	if( (ptMouse.x >= GetTextArea().GetAreaLeft())&&
 		(::GetTickCount() - m_dwTripleClickCheck <= GetDoubleClickTime() )&&
 		(dpos.x <= GetSystemMetrics(SM_CXDOUBLECLK) ) &&
@@ -572,13 +572,13 @@ BOOL CEditView::CheckTripleClick( CMyPoint ptMouse )
 	{
 		result = TRUE;
 	}else{
-		m_dwTripleClickCheck = 0;	// ƒgƒŠƒvƒ‹ƒNƒŠƒbƒNƒ`ƒFƒbƒN OFF
+		m_dwTripleClickCheck = 0;	// ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãƒã‚§ãƒƒã‚¯ OFF
 	}
 	
 	return result;
 }
 
-/* ƒ}ƒEƒX‰Eƒ{ƒ^ƒ“‰Ÿ‰º */
+/* ãƒã‚¦ã‚¹å³ãƒœã‚¿ãƒ³æŠ¼ä¸‹ */
 void CEditView::OnRBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 {
 	if( m_nAutoScrollMode ){
@@ -587,7 +587,7 @@ void CEditView::OnRBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 	if( m_bMiniMap ){
 		return;
 	}
-	/* Œ»İ‚Ìƒ}ƒEƒXƒJ[ƒ\ƒ‹ˆÊ’u¨ƒŒƒCƒAƒEƒgˆÊ’u */
+	/* ç¾åœ¨ã®ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½® */
 
 	CLayoutPoint ptNew;
 	GetTextArea().ClientToLayout(CMyPoint(xPos,yPos), &ptNew);
@@ -595,9 +595,9 @@ void CEditView::OnRBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 	ptNew.x = GetTextArea().GetViewLeftCol() + (xPos - GetTextArea().GetAreaLeft()) / GetTextMetrics().GetHankakuDx();
 	ptNew.y = GetTextArea().GetViewTopLine() + (yPos - GetTextArea().GetAreaTop()) / GetTextMetrics().GetHankakuDy();
 	*/
-	/* w’èƒJ[ƒ\ƒ‹ˆÊ’u‚ª‘I‘ğƒGƒŠƒA“à‚É‚ ‚é‚© */
+	/* æŒ‡å®šã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ãŒé¸æŠã‚¨ãƒªã‚¢å†…ã«ã‚ã‚‹ã‹ */
 	if( 0 == IsCurrentPositionSelected(
-		ptNew		// ƒJ[ƒ\ƒ‹ˆÊ’u
+		ptNew		// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
 		)
 	){
 		return;
@@ -606,11 +606,11 @@ void CEditView::OnRBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 	return;
 }
 
-/* ƒ}ƒEƒX‰Eƒ{ƒ^ƒ“ŠJ•ú */
+/* ãƒã‚¦ã‚¹å³ãƒœã‚¿ãƒ³é–‹æ”¾ */
 void CEditView::OnRBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 {
-	if( GetSelectionInfo().IsMouseSelecting() ){	/* ”ÍˆÍ‘I‘ğ’† */
-		/* ƒ}ƒEƒX¶ƒ{ƒ^ƒ“ŠJ•ú‚ÌƒƒbƒZ[ƒWˆ— */
+	if( GetSelectionInfo().IsMouseSelecting() ){	/* ç¯„å›²é¸æŠä¸­ */
+		/* ãƒã‚¦ã‚¹å·¦ãƒœã‚¿ãƒ³é–‹æ”¾ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 		OnLBUTTONUP( fwKeys, xPos, yPos );
 	}
 
@@ -618,31 +618,31 @@ void CEditView::OnRBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 	int		nIdx;
 	int		nFuncID;
 // novice 2004/10/10
-	/* Shift,Ctrl,AltƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚½‚© */
+	/* Shift,Ctrl,Altã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãŸã‹ */
 	nIdx = getCtrlKeyState();
-	/* ƒ}ƒEƒX‰EƒNƒŠƒbƒN‚É‘Î‰‚·‚é‹@”\ƒR[ƒh‚Ím_Common.m_pKeyNameArr[1]‚É“ü‚Á‚Ä‚¢‚é */
+	/* ãƒã‚¦ã‚¹å³ã‚¯ãƒªãƒƒã‚¯ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã¯m_Common.m_pKeyNameArr[1]ã«å…¥ã£ã¦ã„ã‚‹ */
 	nFuncID = GetDllShareData().m_Common.m_sKeyBind.m_pKeyNameArr[MOUSEFUNCTION_RIGHT].m_nFuncCodeArr[nIdx];
 	if( nFuncID != 0 ){
-		/* ƒRƒ}ƒ“ƒhƒR[ƒh‚É‚æ‚éˆ—U‚è•ª‚¯ */
-		//	May 19, 2006 genta ƒ}ƒEƒX‚©‚ç‚ÌƒƒbƒZ[ƒW‚ÍCMD_FROM_MOUSE‚ğãˆÊƒrƒbƒg‚É“ü‚ê‚Ä‘—‚é
+		/* ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã«ã‚ˆã‚‹å‡¦ç†æŒ¯ã‚Šåˆ†ã‘ */
+		//	May 19, 2006 genta ãƒã‚¦ã‚¹ã‹ã‚‰ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯CMD_FROM_MOUSEã‚’ä¸Šä½ãƒ“ãƒƒãƒˆã«å…¥ã‚Œã¦é€ã‚‹
 		::PostMessageCmd( ::GetParent( m_hwndParent ), WM_COMMAND, MAKELONG( nFuncID, CMD_FROM_MOUSE ),  (LPARAM)NULL );
 	}
-//	/* ‰EƒNƒŠƒbƒNƒƒjƒ…[ */
+//	/* å³ã‚¯ãƒªãƒƒã‚¯ãƒ¡ãƒ‹ãƒ¥ãƒ¼ */
 //	GetCommander().Command_MENU_RBUTTON();
 	return;
 }
 
 
-// novice 2004/10/11 ƒ}ƒEƒX’†ƒ{ƒ^ƒ“‘Î‰
+// novice 2004/10/11 ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³å¯¾å¿œ
 /*!
-	@brief ƒ}ƒEƒX’†ƒ{ƒ^ƒ“‚ğ‰Ÿ‚µ‚½‚Æ‚«‚Ìˆ—
+	@brief ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³ã‚’æŠ¼ã—ãŸã¨ãã®å‡¦ç†
 
 	@param fwKeys [in] first message parameter
-	@param xPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹XÀ•W
-	@param yPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹YÀ•W
-	@date 2004.10.11 novice V‹Kì¬
-	@date 2008.10.06 nasukoji	ƒ}ƒEƒX’†ƒ{ƒ^ƒ“‰Ÿ‰º’†‚ÌƒzƒC[ƒ‹‘€ì‘Î‰
-	@date 2009.01.17 nasukoji	ƒ{ƒ^ƒ“UP‚ÅƒRƒ}ƒ“ƒh‚ğ‹N“®‚·‚é‚æ‚¤‚É•ÏX
+	@param xPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Xåº§æ¨™
+	@param yPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Yåº§æ¨™
+	@date 2004.10.11 novice æ–°è¦ä½œæˆ
+	@date 2008.10.06 nasukoji	ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³æŠ¼ä¸‹ä¸­ã®ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œå¯¾å¿œ
+	@date 2009.01.17 nasukoji	ãƒœã‚¿ãƒ³UPã§ã‚³ãƒãƒ³ãƒ‰ã‚’èµ·å‹•ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
 */
 void CEditView::OnMBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 {
@@ -661,20 +661,20 @@ void CEditView::OnMBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 
 
 /*!
-	@brief ƒ}ƒEƒX’†ƒ{ƒ^ƒ“‚ğŠJ•ú‚µ‚½‚Æ‚«‚Ìˆ—
+	@brief ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³ã‚’é–‹æ”¾ã—ãŸã¨ãã®å‡¦ç†
 
 	@param fwKeys [in] first message parameter
-	@param xPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹XÀ•W
-	@param yPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹YÀ•W
+	@param xPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Xåº§æ¨™
+	@param yPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Yåº§æ¨™
 	
-	@date 2009.01.17 nasukoji	V‹Kì¬iƒ{ƒ^ƒ“UP‚ÅƒRƒ}ƒ“ƒh‚ğ‹N“®‚·‚é‚æ‚¤‚É•ÏXj
+	@date 2009.01.17 nasukoji	æ–°è¦ä½œæˆï¼ˆãƒœã‚¿ãƒ³UPã§ã‚³ãƒãƒ³ãƒ‰ã‚’èµ·å‹•ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´ï¼‰
 */
 void CEditView::OnMBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 {
 	int		nIdx;
 	int		nFuncID;
 
-	// ƒzƒC[ƒ‹‘€ì‚É‚æ‚éƒy[ƒWƒXƒNƒ[ƒ‹‚ ‚è
+	// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Š
 	if( GetDllShareData().m_Common.m_sGeneral.m_nPageScrollByWheel == MOUSEFUNCTION_CENTER &&
 	    m_pcEditWnd->IsPageScrollByWheel() )
 	{
@@ -682,7 +682,7 @@ void CEditView::OnMBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 		return;
 	}
 
-	// ƒzƒC[ƒ‹‘€ì‚É‚æ‚éƒy[ƒWƒXƒNƒ[ƒ‹‚ ‚è
+	// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Š
 	if( GetDllShareData().m_Common.m_sGeneral.m_nHorizontalScrollByWheel == MOUSEFUNCTION_CENTER &&
 	    m_pcEditWnd->IsHScrollByWheel() )
 	{
@@ -690,9 +690,9 @@ void CEditView::OnMBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 		return;
 	}
 
-	/* Shift,Ctrl,AltƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚½‚© */
+	/* Shift,Ctrl,Altã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãŸã‹ */
 	nIdx = getCtrlKeyState();
-	/* ƒ}ƒEƒX¶ƒTƒCƒhƒ{ƒ^ƒ“‚É‘Î‰‚·‚é‹@”\ƒR[ƒh‚Ím_Common.m_pKeyNameArr[2]‚É“ü‚Á‚Ä‚¢‚é */
+	/* ãƒã‚¦ã‚¹å·¦ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã¯m_Common.m_pKeyNameArr[2]ã«å…¥ã£ã¦ã„ã‚‹ */
 	nFuncID = GetDllShareData().m_Common.m_sKeyBind.m_pKeyNameArr[MOUSEFUNCTION_CENTER].m_nFuncCodeArr[nIdx];
 	if( nFuncID == F_AUTOSCROLL ){
 		if( 1 == m_nAutoScrollMode ){
@@ -705,8 +705,8 @@ void CEditView::OnMBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 		}
 	}else
 	if( nFuncID != 0 ){
-		/* ƒRƒ}ƒ“ƒhƒR[ƒh‚É‚æ‚éˆ—U‚è•ª‚¯ */
-		//	May 19, 2006 genta ƒ}ƒEƒX‚©‚ç‚ÌƒƒbƒZ[ƒW‚ÍCMD_FROM_MOUSE‚ğãˆÊƒrƒbƒg‚É“ü‚ê‚Ä‘—‚é
+		/* ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã«ã‚ˆã‚‹å‡¦ç†æŒ¯ã‚Šåˆ†ã‘ */
+		//	May 19, 2006 genta ãƒã‚¦ã‚¹ã‹ã‚‰ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯CMD_FROM_MOUSEã‚’ä¸Šä½ãƒ“ãƒƒãƒˆã«å…¥ã‚Œã¦é€ã‚‹
 		::PostMessageCmd( ::GetParent( m_hwndParent ), WM_COMMAND, MAKELONG( nFuncID, CMD_FROM_MOUSE ),  (LPARAM)NULL );
 	}
 	if( m_nAutoScrollMode ){
@@ -815,16 +815,16 @@ void CEditView::AutoScrollOnTimer()
 	}
 }
 
-// novice 2004/10/10 ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“‘Î‰
+// novice 2004/10/10 ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³å¯¾å¿œ
 /*!
-	@brief ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“1‚ğ‰Ÿ‚µ‚½‚Æ‚«‚Ìˆ—
+	@brief ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³1ã‚’æŠ¼ã—ãŸã¨ãã®å‡¦ç†
 
 	@param fwKeys [in] first message parameter
-	@param xPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹XÀ•W
-	@param yPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹YÀ•W
-	@date 2004.10.10 novice V‹Kì¬
-	@date 2004.10.11 novice ƒ}ƒEƒX’†ƒ{ƒ^ƒ“‘Î‰‚Ì‚½‚ß•ÏX
-	@date 2009.01.17 nasukoji	ƒ{ƒ^ƒ“UP‚ÅƒRƒ}ƒ“ƒh‚ğ‹N“®‚·‚é‚æ‚¤‚É•ÏX
+	@param xPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Xåº§æ¨™
+	@param yPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Yåº§æ¨™
+	@date 2004.10.10 novice æ–°è¦ä½œæˆ
+	@date 2004.10.11 novice ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³å¯¾å¿œã®ãŸã‚å¤‰æ›´
+	@date 2009.01.17 nasukoji	ãƒœã‚¿ãƒ³UPã§ã‚³ãƒãƒ³ãƒ‰ã‚’èµ·å‹•ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
 */
 void CEditView::OnXLBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 {
@@ -835,20 +835,20 @@ void CEditView::OnXLBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 
 
 /*!
-	@brief ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“1‚ğŠJ•ú‚µ‚½‚Æ‚«‚Ìˆ—
+	@brief ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³1ã‚’é–‹æ”¾ã—ãŸã¨ãã®å‡¦ç†
 
 	@param fwKeys [in] first message parameter
-	@param xPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹XÀ•W
-	@param yPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹YÀ•W
+	@param xPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Xåº§æ¨™
+	@param yPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Yåº§æ¨™
 
-	@date 2009.01.17 nasukoji	V‹Kì¬iƒ{ƒ^ƒ“UP‚ÅƒRƒ}ƒ“ƒh‚ğ‹N“®‚·‚é‚æ‚¤‚É•ÏXj
+	@date 2009.01.17 nasukoji	æ–°è¦ä½œæˆï¼ˆãƒœã‚¿ãƒ³UPã§ã‚³ãƒãƒ³ãƒ‰ã‚’èµ·å‹•ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´ï¼‰
 */
 void CEditView::OnXLBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 {
 	int		nIdx;
 	int		nFuncID;
 
-	// ƒzƒC[ƒ‹‘€ì‚É‚æ‚éƒy[ƒWƒXƒNƒ[ƒ‹‚ ‚è
+	// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Š
 	if( GetDllShareData().m_Common.m_sGeneral.m_nPageScrollByWheel == MOUSEFUNCTION_LEFTSIDE &&
 	    m_pcEditWnd->IsPageScrollByWheel() )
 	{
@@ -856,7 +856,7 @@ void CEditView::OnXLBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 		return;
 	}
 
-	// ƒzƒC[ƒ‹‘€ì‚É‚æ‚éƒy[ƒWƒXƒNƒ[ƒ‹‚ ‚è
+	// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Š
 	if( GetDllShareData().m_Common.m_sGeneral.m_nHorizontalScrollByWheel == MOUSEFUNCTION_LEFTSIDE &&
 	    m_pcEditWnd->IsHScrollByWheel() )
 	{
@@ -864,13 +864,13 @@ void CEditView::OnXLBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 		return;
 	}
 
-	/* Shift,Ctrl,AltƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚½‚© */
+	/* Shift,Ctrl,Altã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãŸã‹ */
 	nIdx = getCtrlKeyState();
-	/* ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“1‚É‘Î‰‚·‚é‹@”\ƒR[ƒh‚Ím_Common.m_pKeyNameArr[3]‚É“ü‚Á‚Ä‚¢‚é */
+	/* ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³1ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã¯m_Common.m_pKeyNameArr[3]ã«å…¥ã£ã¦ã„ã‚‹ */
 	nFuncID = GetDllShareData().m_Common.m_sKeyBind.m_pKeyNameArr[MOUSEFUNCTION_LEFTSIDE].m_nFuncCodeArr[nIdx];
 	if( nFuncID != 0 ){
-		/* ƒRƒ}ƒ“ƒhƒR[ƒh‚É‚æ‚éˆ—U‚è•ª‚¯ */
-		//	May 19, 2006 genta ƒ}ƒEƒX‚©‚ç‚ÌƒƒbƒZ[ƒW‚ÍCMD_FROM_MOUSE‚ğãˆÊƒrƒbƒg‚É“ü‚ê‚Ä‘—‚é
+		/* ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã«ã‚ˆã‚‹å‡¦ç†æŒ¯ã‚Šåˆ†ã‘ */
+		//	May 19, 2006 genta ãƒã‚¦ã‚¹ã‹ã‚‰ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯CMD_FROM_MOUSEã‚’ä¸Šä½ãƒ“ãƒƒãƒˆã«å…¥ã‚Œã¦é€ã‚‹
 		::PostMessageCmd( ::GetParent( m_hwndParent ), WM_COMMAND, MAKELONG( nFuncID, CMD_FROM_MOUSE ),  (LPARAM)NULL );
 	}
 
@@ -879,14 +879,14 @@ void CEditView::OnXLBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 
 
 /*!
-	@brief ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“2‚ğ‰Ÿ‚µ‚½‚Æ‚«‚Ìˆ—
+	@brief ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³2ã‚’æŠ¼ã—ãŸã¨ãã®å‡¦ç†
 
 	@param fwKeys [in] first message parameter
-	@param xPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹XÀ•W
-	@param yPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹YÀ•W
-	@date 2004.10.10 novice V‹Kì¬
-	@date 2004.10.11 novice ƒ}ƒEƒX’†ƒ{ƒ^ƒ“‘Î‰‚Ì‚½‚ß•ÏX
-	@date 2009.01.17 nasukoji	ƒ{ƒ^ƒ“UP‚ÅƒRƒ}ƒ“ƒh‚ğ‹N“®‚·‚é‚æ‚¤‚É•ÏX
+	@param xPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Xåº§æ¨™
+	@param yPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Yåº§æ¨™
+	@date 2004.10.10 novice æ–°è¦ä½œæˆ
+	@date 2004.10.11 novice ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³å¯¾å¿œã®ãŸã‚å¤‰æ›´
+	@date 2009.01.17 nasukoji	ãƒœã‚¿ãƒ³UPã§ã‚³ãƒãƒ³ãƒ‰ã‚’èµ·å‹•ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
 */
 void CEditView::OnXRBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 {
@@ -897,51 +897,51 @@ void CEditView::OnXRBUTTONDOWN( WPARAM fwKeys, int xPos , int yPos )
 
 
 /*!
-	@brief ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“2‚ğŠJ•ú‚µ‚½‚Æ‚«‚Ìˆ—
+	@brief ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³2ã‚’é–‹æ”¾ã—ãŸã¨ãã®å‡¦ç†
 
 	@param fwKeys [in] first message parameter
-	@param xPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹XÀ•W
-	@param yPos [in] ƒ}ƒEƒXƒJ[ƒ\ƒ‹YÀ•W
+	@param xPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Xåº§æ¨™
+	@param yPos [in] ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«Yåº§æ¨™
 
-	@date 2009.01.17 nasukoji	V‹Kì¬iƒ{ƒ^ƒ“UP‚ÅƒRƒ}ƒ“ƒh‚ğ‹N“®‚·‚é‚æ‚¤‚É•ÏXj
+	@date 2009.01.17 nasukoji	æ–°è¦ä½œæˆï¼ˆãƒœã‚¿ãƒ³UPã§ã‚³ãƒãƒ³ãƒ‰ã‚’èµ·å‹•ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´ï¼‰
 */
 void CEditView::OnXRBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 {
 	int		nIdx;
 	int		nFuncID;
 
-	// ƒzƒC[ƒ‹‘€ì‚É‚æ‚éƒy[ƒWƒXƒNƒ[ƒ‹‚ ‚è
+	// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Š
 	if( GetDllShareData().m_Common.m_sGeneral.m_nPageScrollByWheel == MOUSEFUNCTION_RIGHTSIDE &&
 	    m_pcEditWnd->IsPageScrollByWheel() )
 	{
-		// ƒzƒC[ƒ‹‘€ì‚É‚æ‚éƒy[ƒWƒXƒNƒ[ƒ‹‚ ‚è‚ğOFF
+		// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Šã‚’OFF
 		m_pcEditWnd->SetPageScrollByWheel( FALSE );
 		return;
 	}
 
-	// ƒzƒC[ƒ‹‘€ì‚É‚æ‚éƒy[ƒWƒXƒNƒ[ƒ‹‚ ‚è
+	// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Š
 	if( GetDllShareData().m_Common.m_sGeneral.m_nHorizontalScrollByWheel == MOUSEFUNCTION_RIGHTSIDE &&
 	    m_pcEditWnd->IsHScrollByWheel() )
 	{
-		// ƒzƒC[ƒ‹‘€ì‚É‚æ‚é‰¡ƒXƒNƒ[ƒ‹‚ ‚è‚ğOFF
+		// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Šã‚’OFF
 		m_pcEditWnd->SetHScrollByWheel( FALSE );
 		return;
 	}
 
-	/* Shift,Ctrl,AltƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚½‚© */
+	/* Shift,Ctrl,Altã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãŸã‹ */
 	nIdx = getCtrlKeyState();
-	/* ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“2‚É‘Î‰‚·‚é‹@”\ƒR[ƒh‚Ím_Common.m_pKeyNameArr[4]‚É“ü‚Á‚Ä‚¢‚é */
+	/* ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³2ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã¯m_Common.m_pKeyNameArr[4]ã«å…¥ã£ã¦ã„ã‚‹ */
 	nFuncID = GetDllShareData().m_Common.m_sKeyBind.m_pKeyNameArr[MOUSEFUNCTION_RIGHTSIDE].m_nFuncCodeArr[nIdx];
 	if( nFuncID != 0 ){
-		/* ƒRƒ}ƒ“ƒhƒR[ƒh‚É‚æ‚éˆ—U‚è•ª‚¯ */
-		//	May 19, 2006 genta ƒ}ƒEƒX‚©‚ç‚ÌƒƒbƒZ[ƒW‚ÍCMD_FROM_MOUSE‚ğãˆÊƒrƒbƒg‚É“ü‚ê‚Ä‘—‚é
+		/* ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã«ã‚ˆã‚‹å‡¦ç†æŒ¯ã‚Šåˆ†ã‘ */
+		//	May 19, 2006 genta ãƒã‚¦ã‚¹ã‹ã‚‰ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯CMD_FROM_MOUSEã‚’ä¸Šä½ãƒ“ãƒƒãƒˆã«å…¥ã‚Œã¦é€ã‚‹
 		::PostMessageCmd( ::GetParent( m_hwndParent ), WM_COMMAND, MAKELONG( nFuncID, CMD_FROM_MOUSE ),  (LPARAM)NULL );
 	}
 
 	return;
 }
 
-/* ƒ}ƒEƒXˆÚ“®‚ÌƒƒbƒZ[ƒWˆ— */
+/* ãƒã‚¦ã‚¹ç§»å‹•ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 {
 	CMyPoint ptMouse(xPos_, yPos_);
@@ -955,7 +955,7 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 
 	CLayoutRange sSelect_Old    = GetSelectionInfo().m_sSelect;
 
-	// ƒI[ƒgƒXƒNƒ[ƒ‹
+	// ã‚ªãƒ¼ãƒˆã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
 	if( 1 == m_nAutoScrollMode ){
 		if( ::GetSystemMetrics(SM_CXDOUBLECLK) < abs(ptMouse.x - m_cAutoScrollMousePos.x) ||
 		    ::GetSystemMetrics(SM_CYDOUBLECLK) < abs(ptMouse.y - m_cAutoScrollMousePos.y) ){
@@ -971,7 +971,7 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 	if( m_bMiniMap ){
 		POINT		po;
 		::GetCursorPos( &po );
-		// «‘Tip‚ª‹N“®‚³‚ê‚Ä‚¢‚é
+		// è¾æ›¸TipãŒèµ·å‹•ã•ã‚Œã¦ã„ã‚‹
 		if( 0 == m_dwTipTimer ){
 			if( (m_poTipCurPos.x != po.x || m_poTipCurPos.y != po.y ) ){
 				m_cTipWnd.Hide();
@@ -984,7 +984,7 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 			CLayoutPoint ptNew;
 			CTextArea& area = GetTextArea();
 			area.ClientToLayout( ptMouse, &ptNew );
-			// ƒ~ƒjƒ}ƒbƒv‚Ìã‰ºƒXƒNƒ[ƒ‹
+			// ãƒŸãƒ‹ãƒãƒƒãƒ—ã®ä¸Šä¸‹ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
 			if( ptNew.y < 0 ){
 				ptNew.y = CLayoutYInt(0);
 			}
@@ -1033,68 +1033,68 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 			view.GetCaret().m_nCaretPosX_Prev = GetCaret().GetCaretLayoutPos().GetX2();
 		}
 		::SetCursor( ::LoadCursor( NULL, IDC_ARROW ) );
-		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse; // ƒ}ƒEƒX”ÍˆÍ‘I‘ğ‘O‰ñˆÊ’u(XYÀ•W)
+		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse; // ãƒã‚¦ã‚¹ç¯„å›²é¸æŠå‰å›ä½ç½®(XYåº§æ¨™)
 		return;
 	}
 
 	if( !GetSelectionInfo().IsMouseSelecting() ){
-		// ƒ}ƒEƒX‚É‚æ‚é”ÍˆÍ‘I‘ğ’†‚Å‚È‚¢ê‡
+		// ãƒã‚¦ã‚¹ã«ã‚ˆã‚‹ç¯„å›²é¸æŠä¸­ã§ãªã„å ´åˆ
 		POINT		po;
 		::GetCursorPos( &po );
-		//	2001/06/18 asa-o: •âŠ®ƒEƒBƒ“ƒhƒE‚ª•\¦‚³‚ê‚Ä‚¢‚È‚¢
+		//	2001/06/18 asa-o: è£œå®Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒè¡¨ç¤ºã•ã‚Œã¦ã„ãªã„
 		if(!m_bHokan){
-			/* «‘Tip‚ª‹N“®‚³‚ê‚Ä‚¢‚é */
+			/* è¾æ›¸TipãŒèµ·å‹•ã•ã‚Œã¦ã„ã‚‹ */
 			if( 0 == m_dwTipTimer ){
 				if( (m_poTipCurPos.x != po.x || m_poTipCurPos.y != po.y ) ){
-					/* «‘Tip‚ğÁ‚· */
+					/* è¾æ›¸Tipã‚’æ¶ˆã™ */
 					m_cTipWnd.Hide();
-					m_dwTipTimer = ::GetTickCount();	/* «‘Tip‹N“®ƒ^ƒCƒ}[ */
+					m_dwTipTimer = ::GetTickCount();	/* è¾æ›¸Tipèµ·å‹•ã‚¿ã‚¤ãƒãƒ¼ */
 				}
 			}else{
-				m_dwTipTimer = ::GetTickCount();		/* «‘Tip‹N“®ƒ^ƒCƒ}[ */
+				m_dwTipTimer = ::GetTickCount();		/* è¾æ›¸Tipèµ·å‹•ã‚¿ã‚¤ãƒãƒ¼ */
 			}
 		}
-		/* Œ»İ‚Ìƒ}ƒEƒXƒJ[ƒ\ƒ‹ˆÊ’u¨ƒŒƒCƒAƒEƒgˆÊ’u */
+		/* ç¾åœ¨ã®ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½® */
 		CLayoutPoint ptNew;
 		GetTextArea().ClientToLayout(ptMouse, &ptNew);
 
-		CLogicRange	cUrlRange;	//URL”ÍˆÍ
+		CLogicRange	cUrlRange;	//URLç¯„å›²
 
-		/* ‘I‘ğƒeƒLƒXƒg‚Ìƒhƒ‰ƒbƒO’†‚© */
+		/* é¸æŠãƒ†ã‚­ã‚¹ãƒˆã®ãƒ‰ãƒ©ãƒƒã‚°ä¸­ã‹ */
 		if( m_bDragMode ){
-			if( GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DragDrop ){	/* OLE‚É‚æ‚éƒhƒ‰ƒbƒO & ƒhƒƒbƒv‚ğg‚¤ */
-				/* À•Ww’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“® */
+			if( GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DragDrop ){	/* OLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚° & ãƒ‰ãƒ­ãƒƒãƒ—ã‚’ä½¿ã† */
+				/* åº§æ¨™æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹• */
 				GetCaret().MoveCursorToClientPoint( ptMouse );
 			}
 		}
 		else{
-			/* s‘I‘ğƒGƒŠƒA? */
+			/* è¡Œé¸æŠã‚¨ãƒªã‚¢? */
 			if( ptMouse.x < GetTextArea().GetAreaLeft() || ptMouse.y < GetTextArea().GetAreaTop() ){	//	2002/2/10 aroka
-				/* –îˆóƒJ[ƒ\ƒ‹ */
+				/* çŸ¢å°ã‚«ãƒ¼ã‚½ãƒ« */
 				if( ptMouse.y >= GetTextArea().GetAreaTop() )
 					::SetCursor( ::LoadCursor( G_AppInstance(), MAKEINTRESOURCE( IDC_CURSOR_RVARROW ) ) );
 				else
 					::SetCursor( ::LoadCursor( NULL, IDC_ARROW ) );
 			}
-			else if( GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DragDrop	/* OLE‚É‚æ‚éƒhƒ‰ƒbƒO & ƒhƒƒbƒv‚ğg‚¤ */
-			 && GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DropSource /* OLE‚É‚æ‚éƒhƒ‰ƒbƒOŒ³‚É‚·‚é‚© */
-			 && 0 == IsCurrentPositionSelected(						/* w’èƒJ[ƒ\ƒ‹ˆÊ’u‚ª‘I‘ğƒGƒŠƒA“à‚É‚ ‚é‚© */
-				ptNew	// ƒJ[ƒ\ƒ‹ˆÊ’u
+			else if( GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DragDrop	/* OLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚° & ãƒ‰ãƒ­ãƒƒãƒ—ã‚’ä½¿ã† */
+			 && GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DropSource /* OLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚°å…ƒã«ã™ã‚‹ã‹ */
+			 && 0 == IsCurrentPositionSelected(						/* æŒ‡å®šã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ãŒé¸æŠã‚¨ãƒªã‚¢å†…ã«ã‚ã‚‹ã‹ */
+				ptNew	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
 				)
 			){
-				/* –îˆóƒJ[ƒ\ƒ‹ */
+				/* çŸ¢å°ã‚«ãƒ¼ã‚½ãƒ« */
 				::SetCursor( ::LoadCursor( NULL, IDC_ARROW ) );
 			}
-			/* ƒJ[ƒ\ƒ‹ˆÊ’u‚ÉURL‚ª—L‚éê‡ */
+			/* ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«URLãŒæœ‰ã‚‹å ´åˆ */
 			else if(
 				IsCurrentPositionURL(
-					ptNew,			// ƒJ[ƒ\ƒ‹ˆÊ’u
-					&cUrlRange,		// URL”ÍˆÍ
-					NULL			// URLó‚¯æ‚èæ
+					ptNew,			// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
+					&cUrlRange,		// URLç¯„å›²
+					NULL			// URLå—ã‘å–ã‚Šå…ˆ
 				)
 			){
-				/* èƒJ[ƒ\ƒ‹ */
-				SetHandCursor();		// Hand Cursor‚ğİ’è 2013/1/29 Uchi
+				/* æ‰‹ã‚«ãƒ¼ã‚½ãƒ« */
+				SetHandCursor();		// Hand Cursorã‚’è¨­å®š 2013/1/29 Uchi
 			}else{
 				//migemo isearch 2004.10.22
 				if( m_nISearchMode > SEARCH_NONE ){
@@ -1104,7 +1104,7 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 						::SetCursor( ::LoadCursor( G_AppInstance(),MAKEINTRESOURCE(IDC_CURSOR_ISEARCH_B)));
 					}
 				}else
-				/* ƒAƒCƒr[ƒ€ */
+				/* ã‚¢ã‚¤ãƒ“ãƒ¼ãƒ  */
 				if( 0 <= m_nMousePouse ){
 					::SetCursor( ::LoadCursor( NULL, IDC_IBEAM ) );
 				}
@@ -1112,52 +1112,52 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 		}
 		return;
 	}
-	// ˆÈ‰ºAƒ}ƒEƒX‚Å‚Ì‘I‘ğ’†(ƒhƒ‰ƒbƒO’†)
+	// ä»¥ä¸‹ã€ãƒã‚¦ã‚¹ã§ã®é¸æŠä¸­(ãƒ‰ãƒ©ãƒƒã‚°ä¸­)
 
 	if( 0 <= m_nMousePouse ){
 		::SetCursor( ::LoadCursor( NULL, IDC_IBEAM ) );
 	}
 
-	// 2010.07.15 Moca ƒhƒ‰ƒbƒOŠJnˆÊ’u‚©‚çˆÚ“®‚µ‚Ä‚¢‚È‚¢ê‡‚ÍMOVE‚Æ‚İ‚È‚³‚È‚¢
-	// —V‚Ñ‚Í 2pxŒÅ’è‚Æ‚·‚é
+	// 2010.07.15 Moca ãƒ‰ãƒ©ãƒƒã‚°é–‹å§‹ä½ç½®ã‹ã‚‰ç§»å‹•ã—ã¦ã„ãªã„å ´åˆã¯MOVEã¨ã¿ãªã•ãªã„
+	// éŠã³ã¯ 2pxå›ºå®šã¨ã™ã‚‹
 	CMyPoint ptMouseMove = ptMouse - m_cMouseDownPos;
 	if(m_cMouseDownPos.x != -INT_MAX && abs(ptMouseMove.x) <= 2 && abs(ptMouseMove.y) <= 2 ){
 		return;
 	}
-	// ˆê“xˆÚ“®‚µ‚½‚ç–ß‚Á‚Ä‚«‚½‚Æ‚«‚àAˆÚ“®‚Æ‚İ‚È‚·‚æ‚¤‚Éİ’è
+	// ä¸€åº¦ç§»å‹•ã—ãŸã‚‰æˆ»ã£ã¦ããŸã¨ãã‚‚ã€ç§»å‹•ã¨ã¿ãªã™ã‚ˆã†ã«è¨­å®š
 	m_cMouseDownPos.Set(-INT_MAX, -INT_MAX);
 	
 	CLayoutPoint ptNewCursor(CLayoutInt(-1), CLayoutInt(-1));
-	if( GetSelectionInfo().IsBoxSelecting() ){	/* ‹éŒ`”ÍˆÍ‘I‘ğ’† */
-		/* À•Ww’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“® */
+	if( GetSelectionInfo().IsBoxSelecting() ){	/* çŸ©å½¢ç¯„å›²é¸æŠä¸­ */
+		/* åº§æ¨™æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹• */
 		GetCaret().MoveCursorToClientPoint( ptMouse, true, &ptNewCursor );
 		GetSelectionInfo().ChangeSelectAreaByCurrentCursor( ptNewCursor );
 		GetCaret().MoveCursorToClientPoint( ptMouse );
-		/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
-		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse; // ƒ}ƒEƒX”ÍˆÍ‘I‘ğ‘O‰ñˆÊ’u(XYÀ•W)
+		/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
+		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse; // ãƒã‚¦ã‚¹ç¯„å›²é¸æŠå‰å›ä½ç½®(XYåº§æ¨™)
 	}
 	else{
-		/* À•Ww’è‚É‚æ‚éƒJ[ƒ\ƒ‹ˆÚ“® */
-		if(( ptMouse.x < GetTextArea().GetAreaLeft() || m_dwTripleClickCheck )&& GetSelectionInfo().m_bBeginLineSelect ){	// s’PˆÊ‘I‘ğ’†
-			// 2007.11.15 nasukoji	ã•ûŒü‚Ìs‘I‘ğ‚àƒ}ƒEƒXƒJ[ƒ\ƒ‹‚ÌˆÊ’u‚Ìs‚ª‘I‘ğ‚³‚ê‚é‚æ‚¤‚É‚·‚é
+		/* åº§æ¨™æŒ‡å®šã«ã‚ˆã‚‹ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹• */
+		if(( ptMouse.x < GetTextArea().GetAreaLeft() || m_dwTripleClickCheck )&& GetSelectionInfo().m_bBeginLineSelect ){	// è¡Œå˜ä½é¸æŠä¸­
+			// 2007.11.15 nasukoji	ä¸Šæ–¹å‘ã®è¡Œé¸æŠæ™‚ã‚‚ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ã®ä½ç½®ã®è¡ŒãŒé¸æŠã•ã‚Œã‚‹ã‚ˆã†ã«ã™ã‚‹
 			CMyPoint nNewPos(0, ptMouse.y);
 
-			// 1s‚Ì‚‚³
+			// 1è¡Œã®é«˜ã•
 			int nLineHeight = GetTextMetrics().GetHankakuDy();
 
-			// ‘I‘ğŠJnsˆÈ‰º‚Ö‚Ìƒhƒ‰ƒbƒO‚Í1s‰º‚ÉƒJ[ƒ\ƒ‹‚ğˆÚ“®‚·‚é
+			// é¸æŠé–‹å§‹è¡Œä»¥ä¸‹ã¸ã®ãƒ‰ãƒ©ãƒƒã‚°æ™‚ã¯1è¡Œä¸‹ã«ã‚«ãƒ¼ã‚½ãƒ«ã‚’ç§»å‹•ã™ã‚‹
 			if( GetTextArea().GetViewTopLine() + (ptMouse.y - GetTextArea().GetAreaTop()) / nLineHeight >= GetSelectionInfo().m_sSelectBgn.GetTo().y)
 				nNewPos.y += nLineHeight;
 
-			// ƒJ[ƒ\ƒ‹‚ğˆÚ“®
+			// ã‚«ãƒ¼ã‚½ãƒ«ã‚’ç§»å‹•
 			nNewPos.x = GetTextArea().GetAreaLeft() - GetTextMetrics().GetCharPxWidth(GetTextArea().GetViewLeftCol());
 			GetCaret().MoveCursorToClientPoint( nNewPos, false, &ptNewCursor );
 
-			// 2.5ƒNƒŠƒbƒN‚É‚æ‚és’PˆÊ‚Ìƒhƒ‰ƒbƒO
+			// 2.5ã‚¯ãƒªãƒƒã‚¯ã«ã‚ˆã‚‹è¡Œå˜ä½ã®ãƒ‰ãƒ©ãƒƒã‚°
 			if( m_dwTripleClickCheck ){
-				// ‘I‘ğŠJnsˆÈã‚Éƒhƒ‰ƒbƒO‚µ‚½
+				// é¸æŠé–‹å§‹è¡Œä»¥ä¸Šã«ãƒ‰ãƒ©ãƒƒã‚°ã—ãŸ
 				if( ptNewCursor.GetY() <= GetSelectionInfo().m_sSelectBgn.GetTo().y ){
-					// GetCommander().Command_GOLINETOP( true, 0x09 );		// ‰üs’PˆÊ‚Ìs“ª‚ÖˆÚ“®
+					// GetCommander().Command_GOLINETOP( true, 0x09 );		// æ”¹è¡Œå˜ä½ã®è¡Œé ­ã¸ç§»å‹•
 					CLogicInt nLineLen;
 					const CLayout*	pcLayout;
 					const wchar_t*	pLine = m_pcEditDoc->m_cLayoutMgr.GetLineStr( ptNewCursor.GetY2(), &nLineLen, &pcLayout );
@@ -1173,21 +1173,21 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 
 					CLogicPoint ptCaretPrevLog(0, GetCaret().GetCaretLogicPos().y);
 
-					// ‘I‘ğŠJns‚æ‚è‰º‚ÉƒJ[ƒ\ƒ‹‚ª‚ ‚é‚Í1s‘O‚Æ•¨—s”Ô†‚Ìˆá‚¢‚ğƒ`ƒFƒbƒN‚·‚é
-					// ‘I‘ğŠJns‚ÉƒJ[ƒ\ƒ‹‚ª‚ ‚é‚Íƒ`ƒFƒbƒN•s—v
+					// é¸æŠé–‹å§‹è¡Œã‚ˆã‚Šä¸‹ã«ã‚«ãƒ¼ã‚½ãƒ«ãŒã‚ã‚‹æ™‚ã¯1è¡Œå‰ã¨ç‰©ç†è¡Œç•ªå·ã®é•ã„ã‚’ãƒã‚§ãƒƒã‚¯ã™ã‚‹
+					// é¸æŠé–‹å§‹è¡Œã«ã‚«ãƒ¼ã‚½ãƒ«ãŒã‚ã‚‹æ™‚ã¯ãƒã‚§ãƒƒã‚¯ä¸è¦
 					if( ptNewCursor.GetY() > GetSelectionInfo().m_sSelectBgn.GetTo().y ){
-						// 1s‘O‚Ì•¨—s‚ğæ“¾‚·‚é
+						// 1è¡Œå‰ã®ç‰©ç†è¡Œã‚’å–å¾—ã™ã‚‹
 						m_pcEditDoc->m_cLayoutMgr.LayoutToLogic( CLayoutPoint(CLayoutInt(0), ptNewCursor.GetY() - 1), &ptCaretPrevLog );
 					}
 
 					CLogicPoint ptNewCursorLogic;
 					m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(ptNewCursor, &ptNewCursorLogic);
-					// ‘O‚Ìs‚Æ“¯‚¶•¨—s
+					// å‰ã®è¡Œã¨åŒã˜ç‰©ç†è¡Œ
 					if( ptCaretPrevLog.y == ptNewCursorLogic.y ){
-						// 1sæ‚Ì•¨—s‚©‚çƒŒƒCƒAƒEƒgs‚ğ‹‚ß‚é
+						// 1è¡Œå…ˆã®ç‰©ç†è¡Œã‹ã‚‰ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã‚’æ±‚ã‚ã‚‹
 						m_pcEditDoc->m_cLayoutMgr.LogicToLayout( CLogicPoint(0, GetCaret().GetCaretLogicPos().y + 1), &ptCaret );
 
-						// ƒJ[ƒ\ƒ‹‚ğŸ‚Ì•¨—s“ª‚ÖˆÚ“®‚·‚é
+						// ã‚«ãƒ¼ã‚½ãƒ«ã‚’æ¬¡ã®ç‰©ç†è¡Œé ­ã¸ç§»å‹•ã™ã‚‹
 						ptNewCursor = ptCaret;
 					}
 				}
@@ -1195,23 +1195,23 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 		}else{
 			GetCaret().MoveCursorToClientPoint( ptMouse, true, &ptNewCursor );
 		}
-		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse; // ƒ}ƒEƒX”ÍˆÍ‘I‘ğ‘O‰ñˆÊ’u(XYÀ•W)
+		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse; // ãƒã‚¦ã‚¹ç¯„å›²é¸æŠå‰å›ä½ç½®(XYåº§æ¨™)
 
-		/* CTRLƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚½‚© */
+		/* CTRLã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãŸã‹ */
 //		if( GetKeyState_Control() ){
 		if( !GetSelectionInfo().m_bBeginWordSelect ){
-			/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+			/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 			GetSelectionInfo().ChangeSelectAreaByCurrentCursor( ptNewCursor );
 			GetCaret().MoveCursor( ptNewCursor, true, 1000 );
 		}else{
 			CLayoutRange sSelect;
 			
-			/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX(ƒeƒXƒg‚Ì‚İ) */
+			/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´(ãƒ†ã‚¹ãƒˆã®ã¿) */
 			GetSelectionInfo().ChangeSelectAreaByCurrentCursorTEST(
 				GetCaret().GetCaretLayoutPos(),
 				&sSelect
 			);
-			/* ‘I‘ğ”ÍˆÍ‚É•ÏX‚È‚µ */
+			/* é¸æŠç¯„å›²ã«å¤‰æ›´ãªã— */
 			if( sSelect_Old == sSelect ){
 				GetSelectionInfo().ChangeSelectAreaByCurrentCursor(
 					GetCaret().GetCaretLayoutPos()
@@ -1225,7 +1225,7 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 				CLogicInt	nIdx = LineColumnToIndex( pcLayout, GetCaret().GetCaretLayoutPos().GetX2() );
 				CLayoutRange sRange;
 
-				/* Œ»İˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ğ’²‚×‚é */
+				/* ç¾åœ¨ä½ç½®ã®å˜èªã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 				bool bResult = m_pcEditDoc->m_cLayoutMgr.WhereCurrentWord(
 					GetCaret().GetCaretLayoutPos().GetY2(),
 					nIdx,
@@ -1234,8 +1234,8 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 					NULL
 				);
 				if( bResult ){
-					// w’è‚³‚ê‚½s‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚É‘Î‰‚·‚éŒ…‚ÌˆÊ’u‚ğ’²‚×‚é
-					// 2007.10.15 kobake Šù‚ÉƒŒƒCƒAƒEƒg’PˆÊ‚È‚Ì‚Å•ÏŠ·‚Í•s—v
+					// æŒ‡å®šã•ã‚ŒãŸè¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ¡ã®ä½ç½®ã‚’èª¿ã¹ã‚‹
+					// 2007.10.15 kobake æ—¢ã«ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ãªã®ã§å¤‰æ›ã¯ä¸è¦
 					/*
 					pLine     = m_pcEditDoc->m_cLayoutMgr.GetLineStr( sRange.GetFrom().GetY2(), &nLineLen, &pcLayout );
 					sRange.SetFromX( LineIndexToColumn( pcLayout, sRange.GetFrom().x ) );
@@ -1243,37 +1243,37 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 					sRange.SetToX( LineIndexToColumn( pcLayout, sRange.GetTo().x ) );
 					*/
 					int nWorkF = IsCurrentPositionSelectedTEST(
-						sRange.GetFrom(), //ƒJ[ƒ\ƒ‹ˆÊ’u
+						sRange.GetFrom(), //ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
 						sSelect
 					);
 					int nWorkT = IsCurrentPositionSelectedTEST(
-						sRange.GetTo(),	// ƒJ[ƒ\ƒ‹ˆÊ’u
+						sRange.GetTo(),	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
 						sSelect
 					);
 					if( -1 == nWorkF ){
-						/* n“_‚ª‘O•û‚ÉˆÚ“®BŒ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+						/* å§‹ç‚¹ãŒå‰æ–¹ã«ç§»å‹•ã€‚ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 						GetSelectionInfo().ChangeSelectAreaByCurrentCursor( sRange.GetFrom() );
 					}
 					else if( 1 == nWorkT ){
-						/* I“_‚ªŒã•û‚ÉˆÚ“®BŒ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+						/* çµ‚ç‚¹ãŒå¾Œæ–¹ã«ç§»å‹•ã€‚ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 						GetSelectionInfo().ChangeSelectAreaByCurrentCursor( sRange.GetTo() );
 					}
 					else if( sSelect_Old.GetFrom() == sSelect.GetFrom() ){
-						/* n“_‚ª–³•ÏX‘O•û‚Ék¬‚³‚ê‚½ */
-						/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+						/* å§‹ç‚¹ãŒç„¡å¤‰æ›´ï¼å‰æ–¹ã«ç¸®å°ã•ã‚ŒãŸ */
+						/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 						GetSelectionInfo().ChangeSelectAreaByCurrentCursor( sRange.GetTo() );
 					}
 					else if( sSelect_Old.GetTo()==sSelect.GetTo() ){
-						/* I“_‚ª–³•ÏXŒã•û‚Ék¬‚³‚ê‚½ */
-						/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+						/* çµ‚ç‚¹ãŒç„¡å¤‰æ›´ï¼å¾Œæ–¹ã«ç¸®å°ã•ã‚ŒãŸ */
+						/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 						GetSelectionInfo().ChangeSelectAreaByCurrentCursor( sRange.GetFrom() );
 					}
 				}else{
-					/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+					/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 					GetSelectionInfo().ChangeSelectAreaByCurrentCursor( GetCaret().GetCaretLayoutPos() );
 				}
 			}else{
-				/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX */
+				/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´ */
 				GetSelectionInfo().ChangeSelectAreaByCurrentCursor( GetCaret().GetCaretLayoutPos() );
 			}
 			GetCaret().MoveCursor( ptNewCursor, true, 1000 );
@@ -1289,10 +1289,10 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 #endif
 
 
-/* ƒ}ƒEƒXƒzƒC[ƒ‹‚ÌƒƒbƒZ[ƒWˆ—
-	2009.01.17 nasukoji	ƒzƒC[ƒ‹ƒXƒNƒ[ƒ‹‚ğ—˜—p‚µ‚½ƒy[ƒWƒXƒNƒ[ƒ‹E‰¡ƒXƒNƒ[ƒ‹‘Î‰
-	2011.11.16 Moca ƒXƒNƒ[ƒ‹•Ï‰»—Ê‚Ö‚Ì‘Î‰
-	2013.09.10 Moca ƒXƒyƒVƒƒƒ‹ƒXƒNƒ[ƒ‹‚Ì•s‹ï‡‚ÌC³
+/* ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
+	2009.01.17 nasukoji	ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚’åˆ©ç”¨ã—ãŸãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ»æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å¯¾å¿œ
+	2011.11.16 Moca ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å¤‰åŒ–é‡ã¸ã®å¯¾å¿œ
+	2013.09.10 Moca ã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®ä¸å…·åˆã®ä¿®æ­£
 */
 LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontalMsg, EFunctionCode nCmdFuncID )
 {
@@ -1312,11 +1312,11 @@ LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontal
 
 	if( bHorizontalMsg ){
 		if( 0 < zDelta ){
-			nScrollCode = SB_LINEDOWN; // ‰E
+			nScrollCode = SB_LINEDOWN; // å³
 		}else{
-			nScrollCode = SB_LINEUP; // ¶
+			nScrollCode = SB_LINEUP; // å·¦
 		}
-		zDelta *= -1; // ”½‘Î‚É‚·‚é
+		zDelta *= -1; // åå¯¾ã«ã™ã‚‹
 	}else{
 		if( 0 < zDelta ){
 			nScrollCode = SB_LINEUP;
@@ -1326,16 +1326,16 @@ LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontal
 	}
 
 	{
-		// 2009.01.17 nasukoji	ƒL[/ƒ}ƒEƒXƒ{ƒ^ƒ“ + ƒzƒC[ƒ‹ƒXƒNƒ[ƒ‹‚Å‰¡ƒXƒNƒ[ƒ‹‚·‚é
+		// 2009.01.17 nasukoji	ã‚­ãƒ¼/ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³ + ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã§æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹
 		bool bHorizontal = false;
 		bool bKeyPageScroll = false;
 		if( nCmdFuncID == F_0 ){
-			// ’ÊíƒXƒNƒ[ƒ‹‚Ì‚¾‚¯“K—p
+			// é€šå¸¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã®æ™‚ã ã‘é©ç”¨
 			bHorizontal = IsSpecialScrollMode( GetDllShareData().m_Common.m_sGeneral.m_nHorizontalScrollByWheel );
 			bKeyPageScroll = IsSpecialScrollMode( GetDllShareData().m_Common.m_sGeneral.m_nPageScrollByWheel );
 		}
 
-		// 2013.05.30 Moca ƒzƒC[ƒ‹ƒXƒNƒ[ƒ‹‚ÉƒL[Š„‚è“–‚Ä
+		// 2013.05.30 Moca ãƒ›ã‚¤ãƒ¼ãƒ«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã«ã‚­ãƒ¼å‰²ã‚Šå½“ã¦
 		int nIdx = getCtrlKeyState();
 		EFunctionCode nFuncID = nCmdFuncID;
 		if( nFuncID != F_0 ){
@@ -1380,11 +1380,11 @@ LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontal
 			}
 		}
 
-		/* ƒ}ƒEƒXƒzƒC[ƒ‹‚É‚æ‚éƒXƒNƒ[ƒ‹s”‚ğƒŒƒWƒXƒgƒŠ‚©‚çæ“¾ */
+		/* ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«ã«ã‚ˆã‚‹ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•°ã‚’ãƒ¬ã‚¸ã‚¹ãƒˆãƒªã‹ã‚‰å–å¾— */
 		nRollLineNum = 3;
 
-		/* ƒŒƒWƒXƒgƒŠ‚Ì‘¶İƒ`ƒFƒbƒN */
-		// 2006.06.03 Moca ReadRegistry ‚É‘‚«Š·‚¦
+		/* ãƒ¬ã‚¸ã‚¹ãƒˆãƒªã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯ */
+		// 2006.06.03 Moca ReadRegistry ã«æ›¸ãæ›ãˆ
 		unsigned int uDataLen;	// size of value data
 		TCHAR szValStr[256];
 		uDataLen = _countof(szValStr) - 1;
@@ -1411,15 +1411,15 @@ LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontal
 		}
 
 		if( -1 == nRollLineNum || bKeyPageScroll ){
-			/* u1‰æ–Ê•ªƒXƒNƒ[ƒ‹‚·‚év */
+			/* ã€Œ1ç”»é¢åˆ†ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹ã€ */
 			if( bHorizontal ){
-				nRollLineNum = (Int)GetTextArea().m_nViewColNum - 1;	// •\¦ˆæ‚ÌŒ…”
+				nRollLineNum = (Int)GetTextArea().m_nViewColNum - 1;	// è¡¨ç¤ºåŸŸã®æ¡æ•°
 			}else{
-				nRollLineNum = (Int)GetTextArea().m_nViewRowNum - 1;	// •\¦ˆæ‚Ìs”
+				nRollLineNum = (Int)GetTextArea().m_nViewRowNum - 1;	// è¡¨ç¤ºåŸŸã®è¡Œæ•°
 			}
 		}
 		else{
-			if( nRollLineNum > 30 ){	//@@@ YAZAKI 2001.12.31 10¨30‚ÖB
+			if( nRollLineNum > 30 ){	//@@@ YAZAKI 2001.12.31 10â†’30ã¸ã€‚
 				nRollLineNum = 30;
 			}
 		}
@@ -1427,17 +1427,17 @@ LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontal
 			nRollLineNum = 1;
 		}
 
-		// ƒXƒNƒ[ƒ‹‘€ì‚Ìí—Ş(’Êí•û–@‚Ìƒy[ƒWƒXƒNƒ[ƒ‹‚ÍNORMALˆµ‚¢)
+		// ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ“ä½œã®ç¨®é¡(é€šå¸¸æ–¹æ³•ã®ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã¯NORMALæ‰±ã„)
 		if( bKeyPageScroll ){
 			if( bHorizontal ){
-				// ƒzƒC[ƒ‹‘€ì‚É‚æ‚é‰¡ƒXƒNƒ[ƒ‹‚ ‚è
+				// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Š
 				m_pcEditWnd->SetHScrollByWheel( TRUE );
 			}
-			// ƒzƒC[ƒ‹‘€ì‚É‚æ‚éƒy[ƒWƒXƒNƒ[ƒ‹‚ ‚è
+			// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Š
 			m_pcEditWnd->SetPageScrollByWheel( TRUE );
 		}else{
 			if( bHorizontal ){
-				// ƒzƒC[ƒ‹‘€ì‚É‚æ‚é‰¡ƒXƒNƒ[ƒ‹‚ ‚è
+				// ãƒ›ã‚¤ãƒ¼ãƒ«æ“ä½œã«ã‚ˆã‚‹æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã‚ã‚Š
 				m_pcEditWnd->SetHScrollByWheel( TRUE );
 			}
 		}
@@ -1450,14 +1450,14 @@ LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontal
 		}
 		m_nWheelDelta += zDelta;
 
-		// 2011.05.18 API‚ÌƒXƒNƒ[ƒ‹—Ê‚É]‚¤
+		// 2011.05.18 APIã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é‡ã«å¾“ã†
 		int nRollNum = abs(m_nWheelDelta) * nRollLineNum / 120;
-		// Ÿ‰ñ‰z‚µ‚Ì•Ï‰»—Ê(ã‹L®Delta‚Ì‚ ‚Ü‚èBƒXƒNƒ[ƒ‹•ûŒü‚ÆzDelta‚Í•„†‚ª”½‘Î)
+		// æ¬¡å›æŒè¶Šã—ã®å¤‰åŒ–é‡(ä¸Šè¨˜å¼Deltaã®ã‚ã¾ã‚Šã€‚ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ–¹å‘ã¨zDeltaã¯ç¬¦å·ãŒåå¯¾)
 		m_nWheelDelta = (abs(m_nWheelDelta) - nRollNum * 120 / nRollLineNum) * ((nScrollCode == SB_LINEUP) ? 1 : -1);
 
 		if( bExecCmd ){
 			if( nFuncID != F_0 ){
-				// ƒXƒNƒ[ƒ‹•Ï‰»—Ê•ªƒRƒ}ƒ“ƒhÀs(zDelta‚ª120‚ ‚½‚è‚Å1‰ñ)
+				// ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å¤‰åŒ–é‡åˆ†ã‚³ãƒãƒ³ãƒ‰å®Ÿè¡Œ(zDeltaãŒ120ã‚ãŸã‚Šã§1å›)
 				for( int i = 0; i < nRollNum; i++ ){
 					::PostMessageCmd( ::GetParent( m_hwndParent ), WM_COMMAND, MAKELONG( nFuncID, CMD_FROM_MOUSE ),  (LPARAM)NULL );
 				}
@@ -1467,10 +1467,10 @@ LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontal
 
 		const bool bSmooth = !! GetDllShareData().m_Common.m_sGeneral.m_nRepeatedScroll_Smooth;
 		const int nRollActions = bSmooth ? nRollNum : 1;
-		int nCount = ((nScrollCode == SB_LINEUP) ? -1 : 1) * (bSmooth ? 1 : nRollNum);		// 1‰ñ‚ ‚½‚è‚ÌƒXƒNƒ[ƒ‹”(c‰¡¬İ)
+		int nCount = ((nScrollCode == SB_LINEUP) ? -1 : 1) * (bSmooth ? 1 : nRollNum);		// 1å›ã‚ãŸã‚Šã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ•°(ç¸¦æ¨ªæ··åœ¨)
 
 		for( i = 0; i < nRollActions; ++i ){
-			//	Sep. 11, 2004 genta “¯ŠúƒXƒNƒ[ƒ‹s”
+			//	Sep. 11, 2004 genta åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•°
 			if( bHorizontal ){
 				const CLayoutXInt layoutCount = nCount * GetTextMetrics().GetLayoutXDefault();
 				SyncScrollH( ScrollAtH( GetTextArea().GetViewLeftCol() + layoutCount ) );
@@ -1483,18 +1483,18 @@ LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontal
 }
 
 
-/*! ‚’¼ƒ}ƒEƒXƒXƒNƒ[ƒ‹
+/*! å‚ç›´ãƒã‚¦ã‚¹ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
 */
 LRESULT CEditView::OnMOUSEWHEEL( WPARAM wParam, LPARAM lParam )
 {
 	return OnMOUSEWHEEL2( wParam, lParam, false, F_0 );
 }
 
-/*! …•½ƒ}ƒEƒXƒXƒNƒ[ƒ‹
+/*! æ°´å¹³ãƒã‚¦ã‚¹ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
 	@note http://msdn.microsoft.com/en-us/library/ms997498.aspx
 	Best Practices for Supporting Microsoft Mouse and Keyboard Devices
-	‚É‚æ‚é‚ÆAWM_MOUSEHWHEEL‚ğˆ—‚µ‚½ê‡‚ÍTRUE‚ğ•Ô‚·•K—v‚ª‚ ‚é‚»‚¤‚Å‚·B
-	MSDN‚ÌWM_MOUSEHWHEEL Message‚Ìƒy[ƒW‚ÍŠÔˆá‚Á‚Ä‚¢‚é‚Ì‚Å’ˆÓB
+	ã«ã‚ˆã‚‹ã¨ã€WM_MOUSEHWHEELã‚’å‡¦ç†ã—ãŸå ´åˆã¯TRUEã‚’è¿”ã™å¿…è¦ãŒã‚ã‚‹ãã†ã§ã™ã€‚
+	MSDNã®WM_MOUSEHWHEEL Messageã®ãƒšãƒ¼ã‚¸ã¯é–“é•ã£ã¦ã„ã‚‹ã®ã§æ³¨æ„ã€‚
 */
 LRESULT CEditView::OnMOUSEHWHEEL( WPARAM wParam, LPARAM lParam )
 {
@@ -1502,50 +1502,50 @@ LRESULT CEditView::OnMOUSEHWHEEL( WPARAM wParam, LPARAM lParam )
 }
 
 /*!
-	@brief ƒL[Eƒ}ƒEƒXƒ{ƒ^ƒ“ó‘Ô‚æ‚èƒXƒNƒ[ƒ‹ƒ‚[ƒh‚ğ”»’è‚·‚é
+	@brief ã‚­ãƒ¼ãƒ»ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³çŠ¶æ…‹ã‚ˆã‚Šã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ¢ãƒ¼ãƒ‰ã‚’åˆ¤å®šã™ã‚‹
 
-	ƒ}ƒEƒXƒzƒC[ƒ‹AsƒXƒNƒ[ƒ‹‚·‚×‚«‚©ƒy[ƒWƒXƒNƒ[ƒ‹E‰¡ƒXƒNƒ[ƒ‹
-	‚·‚×‚«‚©‚ğ”»’è‚·‚éB
-	Œ»İ‚ÌƒL[‚Ü‚½‚Íƒ}ƒEƒXó‘Ô‚ªˆø”‚Åw’è‚³‚ê‚½‘g‚İ‡‚í‚¹‚É‡’v‚·‚éê‡
-	true‚ğ•Ô‚·B
+	ãƒã‚¦ã‚¹ãƒ›ã‚¤ãƒ¼ãƒ«æ™‚ã€è¡Œã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã¹ãã‹ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒ»æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
+	ã™ã¹ãã‹ã‚’åˆ¤å®šã™ã‚‹ã€‚
+	ç¾åœ¨ã®ã‚­ãƒ¼ã¾ãŸã¯ãƒã‚¦ã‚¹çŠ¶æ…‹ãŒå¼•æ•°ã§æŒ‡å®šã•ã‚ŒãŸçµ„ã¿åˆã‚ã›ã«åˆè‡´ã™ã‚‹å ´åˆ
+	trueã‚’è¿”ã™ã€‚
 
-	@param nSelect	[in] ƒL[Eƒ}ƒEƒXƒ{ƒ^ƒ“‚Ì‘g‚İ‡‚í‚¹w’è”Ô†
+	@param nSelect	[in] ã‚­ãƒ¼ãƒ»ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³ã®çµ„ã¿åˆã‚ã›æŒ‡å®šç•ªå·
 
-	@return ƒy[ƒWƒXƒNƒ[ƒ‹‚Ü‚½‚Í‰¡ƒXƒNƒ[ƒ‹‚·‚×‚«ó‘Ô‚Ìtrue‚ğ•Ô‚·
-	        ’Êí‚ÌsƒXƒNƒ[ƒ‹‚·‚×‚«ó‘Ô‚Ìfalse‚ğ•Ô‚·
+	@return ãƒšãƒ¼ã‚¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã¾ãŸã¯æ¨ªã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã¹ãçŠ¶æ…‹ã®æ™‚trueã‚’è¿”ã™
+	        é€šå¸¸ã®è¡Œã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã¹ãçŠ¶æ…‹ã®æ™‚falseã‚’è¿”ã™
 
-	@date 2009.01.17 nasukoji	V‹Kì¬
+	@date 2009.01.17 nasukoji	æ–°è¦ä½œæˆ
 */
 bool CEditView::IsSpecialScrollMode( int nSelect )
 {
 	bool bSpecialScrollMode;
 
 	switch( nSelect ){
-	case 0:		// w’è‚Ì‘g‚İ‡‚í‚¹‚È‚µ
+	case 0:		// æŒ‡å®šã®çµ„ã¿åˆã‚ã›ãªã—
 		bSpecialScrollMode = false;
 		break;
 
-	case MOUSEFUNCTION_CENTER:		// ƒ}ƒEƒX’†ƒ{ƒ^ƒ“
+	case MOUSEFUNCTION_CENTER:		// ãƒã‚¦ã‚¹ä¸­ãƒœã‚¿ãƒ³
 		bSpecialScrollMode = ( 0 != ( 0x8000 & ::GetAsyncKeyState( VK_MBUTTON ) ) );
 		break;
 
-	case MOUSEFUNCTION_LEFTSIDE:	// ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“1
+	case MOUSEFUNCTION_LEFTSIDE:	// ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³1
 		bSpecialScrollMode = ( 0 != ( 0x8000 & ::GetAsyncKeyState( VK_XBUTTON1 ) ) );
 		break;
 
-	case MOUSEFUNCTION_RIGHTSIDE:	// ƒ}ƒEƒXƒTƒCƒhƒ{ƒ^ƒ“2
+	case MOUSEFUNCTION_RIGHTSIDE:	// ãƒã‚¦ã‚¹ã‚µã‚¤ãƒ‰ãƒœã‚¿ãƒ³2
 		bSpecialScrollMode = ( 0 != ( 0x8000 & ::GetAsyncKeyState( VK_XBUTTON2 ) ) );
 		break;
 
-	case VK_CONTROL:	// ControlƒL[
+	case VK_CONTROL:	// Controlã‚­ãƒ¼
 		bSpecialScrollMode = GetKeyState_Control();
 		break;
 
-	case VK_SHIFT:		// ShiftƒL[
+	case VK_SHIFT:		// Shiftã‚­ãƒ¼
 		bSpecialScrollMode = GetKeyState_Shift();
 		break;
 
-	default:	// ã‹LˆÈŠOi‚±‚±‚É‚Í—ˆ‚È‚¢j
+	default:	// ä¸Šè¨˜ä»¥å¤–ï¼ˆã“ã“ã«ã¯æ¥ãªã„ï¼‰
 		bSpecialScrollMode = false;
 		break;
 	}
@@ -1559,25 +1559,25 @@ bool CEditView::IsSpecialScrollMode( int nSelect )
 
 
 
-/* ƒ}ƒEƒX¶ƒ{ƒ^ƒ“ŠJ•ú‚ÌƒƒbƒZ[ƒWˆ— */
+/* ãƒã‚¦ã‚¹å·¦ãƒœã‚¿ãƒ³é–‹æ”¾ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 void CEditView::OnLBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 {
 //	MYTRACE( _T("OnLBUTTONUP()\n") );
 
-	/* ”ÍˆÍ‘I‘ğI—¹ & ƒ}ƒEƒXƒLƒƒƒvƒ`ƒƒ[‚¨‚í‚è */
-	if( GetSelectionInfo().IsMouseSelecting() ){	/* ”ÍˆÍ‘I‘ğ’† */
-		/* ƒ}ƒEƒX ƒLƒƒƒvƒ`ƒƒ‚ğ‰ğ•ú */
+	/* ç¯„å›²é¸æŠçµ‚äº† & ãƒã‚¦ã‚¹ã‚­ãƒ£ãƒ—ãƒãƒ£ãƒ¼ãŠã‚ã‚Š */
+	if( GetSelectionInfo().IsMouseSelecting() ){	/* ç¯„å›²é¸æŠä¸­ */
+		/* ãƒã‚¦ã‚¹ ã‚­ãƒ£ãƒ—ãƒãƒ£ã‚’è§£æ”¾ */
 		::ReleaseCapture();
 		GetCaret().ShowCaret_( GetHwnd() ); // 2002/07/22 novice
 
 		GetSelectionInfo().SelectEnd();
 
-		// 20100715 Moca ƒ}ƒEƒXƒNƒŠƒbƒNÀ•W‚ğƒŠƒZƒbƒg
+		// 20100715 Moca ãƒã‚¦ã‚¹ã‚¯ãƒªãƒƒã‚¯åº§æ¨™ã‚’ãƒªã‚»ãƒƒãƒˆ
 		m_cMouseDownPos.Set(-INT_MAX, -INT_MAX);
 
 		GetCaret().m_cUnderLine.UnderLineUnLock();
 		if( GetSelectionInfo().m_sSelect.IsOne() ){
-			/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+			/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 			GetSelectionInfo().DisableSelectArea( true );
 		}
 	}
@@ -1590,8 +1590,8 @@ void CEditView::OnLBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 
 
 
-/* ShellExecute‚ğŒÄ‚Ño‚·ƒvƒƒV[ƒWƒƒ */
-/*   ŒÄ‚Ño‚µ‘O‚É lpParameter ‚ğ new ‚µ‚Ä‚¨‚­‚±‚Æ */
+/* ShellExecuteã‚’å‘¼ã³å‡ºã™ãƒ—ãƒ­ã‚·ãƒ¼ã‚¸ãƒ£ */
+/*   å‘¼ã³å‡ºã—å‰ã« lpParameter ã‚’ new ã—ã¦ãŠãã“ã¨ */
 static unsigned __stdcall ShellExecuteProc( LPVOID lpParameter )
 {
 	LPTSTR pszFile = (LPTSTR)lpParameter;
@@ -1601,38 +1601,38 @@ static unsigned __stdcall ShellExecuteProc( LPVOID lpParameter )
 }
 
 
-// ƒ}ƒEƒX¶ƒ{ƒ^ƒ“ƒ_ƒuƒ‹ƒNƒŠƒbƒN
-// 2007.01.18 kobake IsCurrentPositionURLd—l•ÏX‚É”º‚¢Aˆ—‚Ì‘‚«Š·‚¦
+// ãƒã‚¦ã‚¹å·¦ãƒœã‚¿ãƒ³ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯
+// 2007.01.18 kobake IsCurrentPositionURLä»•æ§˜å¤‰æ›´ã«ä¼´ã„ã€å‡¦ç†ã®æ›¸ãæ›ãˆ
 void CEditView::OnLBUTTONDBLCLK( WPARAM fwKeys, int _xPos , int _yPos )
 {
 	CMyPoint ptMouse(_xPos,_yPos);
 
-	CLogicRange		cUrlRange;	// URL”ÍˆÍ
+	CLogicRange		cUrlRange;	// URLç¯„å›²
 	std::wstring	wstrURL;
 	const wchar_t*	pszMailTo = L"mailto:";
 
-	// 2007.10.06 nasukoji	ƒNƒAƒhƒ‰ƒvƒ‹ƒNƒŠƒbƒN‚Íƒ`ƒFƒbƒN‚µ‚È‚¢
+	// 2007.10.06 nasukoji	ã‚¯ã‚¢ãƒ‰ãƒ©ãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯æ™‚ã¯ãƒã‚§ãƒƒã‚¯ã—ãªã„
 	if(! m_dwTripleClickCheck){
-		/* ƒJ[ƒ\ƒ‹ˆÊ’u‚ÉURL‚ª—L‚éê‡‚Ì‚»‚Ì”ÍˆÍ‚ğ’²‚×‚é */
+		/* ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«URLãŒæœ‰ã‚‹å ´åˆã®ãã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 		if(
 			IsCurrentPositionURL(
-				GetCaret().GetCaretLayoutPos(),	// ƒJ[ƒ\ƒ‹ˆÊ’u
-				&cUrlRange,				// URL”ÍˆÍ
-				&wstrURL				// URLó‚¯æ‚èæ
+				GetCaret().GetCaretLayoutPos(),	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®
+				&cUrlRange,				// URLç¯„å›²
+				&wstrURL				// URLå—ã‘å–ã‚Šå…ˆ
 			)
 		){
 			std::wstring wstrOPEN;
 
-			// URL‚ğŠJ‚­
-		 	// Œ»İˆÊ’u‚ªƒ[ƒ‹ƒAƒhƒŒƒX‚È‚ç‚ÎANULLˆÈŠO‚ÆA‚»‚Ì’·‚³‚ğ•Ô‚·
+			// URLã‚’é–‹ã
+		 	// ç¾åœ¨ä½ç½®ãŒãƒ¡ãƒ¼ãƒ«ã‚¢ãƒ‰ãƒ¬ã‚¹ãªã‚‰ã°ã€NULLä»¥å¤–ã¨ã€ãã®é•·ã•ã‚’è¿”ã™
 			if( IsMailAddress( wstrURL.c_str(), wstrURL.length(), NULL ) ){
 				wstrOPEN = pszMailTo + wstrURL;
 			}
 			else{
-				if( wcsnicmp( wstrURL.c_str(), L"ttp://", 6 ) == 0 ){	//—}~URL
+				if( wcsnicmp( wstrURL.c_str(), L"ttp://", 6 ) == 0 ){	//æŠ‘æ­¢URL
 					wstrOPEN = L"h" + wstrURL;
 				}
-				else if( wcsnicmp( wstrURL.c_str(), L"tp://", 5 ) == 0 ){	//—}~URL
+				else if( wcsnicmp( wstrURL.c_str(), L"tp://", 5 ) == 0 ){	//æŠ‘æ­¢URL
 					wstrOPEN = L"ht" + wstrURL;
 				}
 				else{
@@ -1640,9 +1640,9 @@ void CEditView::OnLBUTTONDBLCLK( WPARAM fwKeys, int _xPos , int _yPos )
 				}
 			}
 			{
-				// URL‚ğŠJ‚­
-				// 2009.05.21 syat UNCƒpƒX‚¾‚Æ1•ªˆÈã–³‰“š‚É‚È‚é‚±‚Æ‚ª‚ ‚é‚Ì‚ÅƒXƒŒƒbƒh‰»
-				CWaitCursor cWaitCursor( GetHwnd() );	// ƒJ[ƒ\ƒ‹‚ğ»Œv‚É‚·‚é
+				// URLã‚’é–‹ã
+				// 2009.05.21 syat UNCãƒ‘ã‚¹ã ã¨1åˆ†ä»¥ä¸Šç„¡å¿œç­”ã«ãªã‚‹ã“ã¨ãŒã‚ã‚‹ã®ã§ã‚¹ãƒ¬ãƒƒãƒ‰åŒ–
+				CWaitCursor cWaitCursor( GetHwnd() );	// ã‚«ãƒ¼ã‚½ãƒ«ã‚’ç ‚æ™‚è¨ˆã«ã™ã‚‹
 
 				unsigned int nThreadId;
 				LPCTSTR szUrl = to_tchar(wstrOPEN.c_str());
@@ -1650,98 +1650,98 @@ void CEditView::OnLBUTTONDBLCLK( WPARAM fwKeys, int _xPos , int _yPos )
 				_tcscpy( szUrlDup, szUrl );
 				HANDLE hThread = (HANDLE)_beginthreadex( NULL, 0, ShellExecuteProc, (LPVOID)szUrlDup, 0, &nThreadId );
 				if( hThread != INVALID_HANDLE_VALUE ){
-					// ƒ†[ƒU[‚ÌURL‹N“®w¦‚É”½‰‚µ‚½–Úˆó‚Æ‚µ‚Ä‚¿‚å‚Á‚Æ‚ÌŠÔ‚¾‚¯»ŒvƒJ[ƒ\ƒ‹‚ğ•\¦‚µ‚Ä‚¨‚­
-					// ShellExecute ‚Í‘¦À‚ÉƒGƒ‰[I—¹‚·‚é‚±‚Æ‚ª‚¿‚å‚­‚¿‚å‚­‚ ‚é‚Ì‚Å WaitForSingleObject ‚Å‚Í‚È‚­ Sleep ‚ğg—piex.‘¶İ‚µ‚È‚¢ƒpƒX‚Ì‹N“®j
-					// y•â‘«z‚¢‚¸‚ê‚Ì API ‚Å‚à‘Ò‚¿‚ğ’·‚ßi2`3•bj‚É‚·‚é‚Æ‚È‚º‚© Web ƒuƒ‰ƒEƒU–¢‹N“®‚©‚ç‚Ì‹N“®‚ªd‚­‚È‚é–Í—liPCƒ^ƒCƒv, XP/Vista, IE/FireFox ‚ÉŠÖŒW‚È‚­j
+					// ãƒ¦ãƒ¼ã‚¶ãƒ¼ã®URLèµ·å‹•æŒ‡ç¤ºã«åå¿œã—ãŸç›®å°ã¨ã—ã¦ã¡ã‚‡ã£ã¨ã®æ™‚é–“ã ã‘ç ‚æ™‚è¨ˆã‚«ãƒ¼ã‚½ãƒ«ã‚’è¡¨ç¤ºã—ã¦ãŠã
+					// ShellExecute ã¯å³åº§ã«ã‚¨ãƒ©ãƒ¼çµ‚äº†ã™ã‚‹ã“ã¨ãŒã¡ã‚‡ãã¡ã‚‡ãã‚ã‚‹ã®ã§ WaitForSingleObject ã§ã¯ãªã Sleep ã‚’ä½¿ç”¨ï¼ˆex.å­˜åœ¨ã—ãªã„ãƒ‘ã‚¹ã®èµ·å‹•ï¼‰
+					// ã€è£œè¶³ã€‘ã„ãšã‚Œã® API ã§ã‚‚å¾…ã¡ã‚’é•·ã‚ï¼ˆ2ï½3ç§’ï¼‰ã«ã™ã‚‹ã¨ãªãœã‹ Web ãƒ–ãƒ©ã‚¦ã‚¶æœªèµ·å‹•ã‹ã‚‰ã®èµ·å‹•ãŒé‡ããªã‚‹æ¨¡æ§˜ï¼ˆPCã‚¿ã‚¤ãƒ—, XP/Vista, IE/FireFox ã«é–¢ä¿‚ãªãï¼‰
 					::Sleep(200);
 					::CloseHandle(hThread);
 				}else{
-					//ƒXƒŒƒbƒhì¬¸”s
+					//ã‚¹ãƒ¬ãƒƒãƒ‰ä½œæˆå¤±æ•—
 					delete[] szUrlDup;
 				}
 			}
 			return;
 		}
 
-		/* GREPo—Íƒ‚[ƒh‚Ü‚½‚ÍƒfƒoƒbƒOƒ‚[ƒh ‚©‚Â ƒ}ƒEƒX¶ƒ{ƒ^ƒ“ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚Åƒ^ƒOƒWƒƒƒ“ƒv ‚Ìê‡ */
-		//	2004.09.20 naoh ŠO•”ƒRƒ}ƒ“ƒh‚Ìo—Í‚©‚çTagjump‚Å‚«‚é‚æ‚¤‚É
+		/* GREPå‡ºåŠ›ãƒ¢ãƒ¼ãƒ‰ã¾ãŸã¯ãƒ‡ãƒãƒƒã‚°ãƒ¢ãƒ¼ãƒ‰ ã‹ã¤ ãƒã‚¦ã‚¹å·¦ãƒœã‚¿ãƒ³ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã§ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ— ã®å ´åˆ */
+		//	2004.09.20 naoh å¤–éƒ¨ã‚³ãƒãƒ³ãƒ‰ã®å‡ºåŠ›ã‹ã‚‰Tagjumpã§ãã‚‹ã‚ˆã†ã«
 		if( (CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode || CAppMode::getInstance()->IsDebugMode()) && GetDllShareData().m_Common.m_sSearch.m_bGTJW_LDBLCLK ){
-			/* ƒ^ƒOƒWƒƒƒ“ƒv‹@”\ */
+			/* ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—æ©Ÿèƒ½ */
 			if( GetCommander().Command_TAGJUMP() ){
-				// 2013.05.27 ƒ^ƒOƒWƒƒƒ“ƒv¸”s‚Í’Êí‚Ìˆ—‚ğÀs‚·‚é
+				// 2013.05.27 ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—å¤±æ•—æ™‚ã¯é€šå¸¸ã®å‡¦ç†ã‚’å®Ÿè¡Œã™ã‚‹
 				return;
 			}
 		}
 	}
 
 // novice 2004/10/10
-	/* Shift,Ctrl,AltƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚½‚© */
+	/* Shift,Ctrl,Altã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãŸã‹ */
 	int	nIdx = getCtrlKeyState();
 
-	/* ƒ}ƒEƒX¶ƒNƒŠƒbƒN‚É‘Î‰‚·‚é‹@”\ƒR[ƒh‚Ím_Common.m_pKeyNameArr[?]‚É“ü‚Á‚Ä‚¢‚é 2007.11.15 nasukoji */
+	/* ãƒã‚¦ã‚¹å·¦ã‚¯ãƒªãƒƒã‚¯ã«å¯¾å¿œã™ã‚‹æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã¯m_Common.m_pKeyNameArr[?]ã«å…¥ã£ã¦ã„ã‚‹ 2007.11.15 nasukoji */
 	EFunctionCode	nFuncID = GetDllShareData().m_Common.m_sKeyBind.m_pKeyNameArr[
 		m_dwTripleClickCheck ? MOUSEFUNCTION_QUADCLICK : MOUSEFUNCTION_DOUBLECLICK
 	].m_nFuncCodeArr[nIdx];
 	if(m_dwTripleClickCheck){
-		// ”ñ‘I‘ğó‘Ô‚É‚µ‚½Œã¶ƒNƒŠƒbƒN‚µ‚½‚±‚Æ‚É‚·‚é
-		// ‚·‚×‚Ä‘I‘ğ‚Ìê‡‚ÍA3.5ƒNƒŠƒbƒN‚Ì‘I‘ğó‘Ô•Û‚Æƒhƒ‰ƒbƒOŠJn‚Ì
-		// ”ÍˆÍ•ÏX‚Ì‚½‚ßB
-		// ƒNƒAƒhƒ‰ƒvƒ‹ƒNƒŠƒbƒN‹@”\‚ªŠ„‚è“–‚Ä‚ç‚ê‚Ä‚¢‚È‚¢ê‡‚ÍAƒ_ƒuƒ‹ƒNƒŠƒbƒN
-		// ‚Æ‚µ‚Äˆ—‚·‚é‚½‚ßB
-		if( GetSelectionInfo().IsTextSelected() )		// ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚©
-			GetSelectionInfo().DisableSelectArea( true );		// Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚·
+		// éé¸æŠçŠ¶æ…‹ã«ã—ãŸå¾Œå·¦ã‚¯ãƒªãƒƒã‚¯ã—ãŸã“ã¨ã«ã™ã‚‹
+		// ã™ã¹ã¦é¸æŠã®å ´åˆã¯ã€3.5ã‚¯ãƒªãƒƒã‚¯æ™‚ã®é¸æŠçŠ¶æ…‹ä¿æŒã¨ãƒ‰ãƒ©ãƒƒã‚°é–‹å§‹æ™‚ã®
+		// ç¯„å›²å¤‰æ›´ã®ãŸã‚ã€‚
+		// ã‚¯ã‚¢ãƒ‰ãƒ©ãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯æ©Ÿèƒ½ãŒå‰²ã‚Šå½“ã¦ã‚‰ã‚Œã¦ã„ãªã„å ´åˆã¯ã€ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯
+		// ã¨ã—ã¦å‡¦ç†ã™ã‚‹ãŸã‚ã€‚
+		if( GetSelectionInfo().IsTextSelected() )		// ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹
+			GetSelectionInfo().DisableSelectArea( true );		// ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™
 
 		if(! nFuncID){
-			m_dwTripleClickCheck = 0;	// ƒgƒŠƒvƒ‹ƒNƒŠƒbƒNƒ`ƒFƒbƒN OFF
+			m_dwTripleClickCheck = 0;	// ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãƒã‚§ãƒƒã‚¯ OFF
 			nFuncID = GetDllShareData().m_Common.m_sKeyBind.m_pKeyNameArr[MOUSEFUNCTION_DOUBLECLICK].m_nFuncCodeArr[nIdx];
-			OnLBUTTONDOWN( fwKeys, ptMouse.x , ptMouse.y );	// ƒJ[ƒ\ƒ‹‚ğƒNƒŠƒbƒNˆÊ’u‚ÖˆÚ“®‚·‚é
+			OnLBUTTONDOWN( fwKeys, ptMouse.x , ptMouse.y );	// ã‚«ãƒ¼ã‚½ãƒ«ã‚’ã‚¯ãƒªãƒƒã‚¯ä½ç½®ã¸ç§»å‹•ã™ã‚‹
 		}
 	}
 
 	if( nFuncID != 0 ){
-		/* ƒRƒ}ƒ“ƒhƒR[ƒh‚É‚æ‚éˆ—U‚è•ª‚¯ */
-		//	May 19, 2006 genta ƒ}ƒEƒX‚©‚ç‚ÌƒƒbƒZ[ƒW‚ÍCMD_FROM_MOUSE‚ğãˆÊƒrƒbƒg‚É“ü‚ê‚Ä‘—‚é
+		/* ã‚³ãƒãƒ³ãƒ‰ã‚³ãƒ¼ãƒ‰ã«ã‚ˆã‚‹å‡¦ç†æŒ¯ã‚Šåˆ†ã‘ */
+		//	May 19, 2006 genta ãƒã‚¦ã‚¹ã‹ã‚‰ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã¯CMD_FROM_MOUSEã‚’ä¸Šä½ãƒ“ãƒƒãƒˆã«å…¥ã‚Œã¦é€ã‚‹
 		::SendMessageCmd( ::GetParent( m_hwndParent ), WM_COMMAND, MAKELONG( nFuncID, CMD_FROM_MOUSE ),  (LPARAM)NULL );
 	}
 
-	// 2007.10.06 nasukoji	ƒNƒAƒhƒ‰ƒvƒ‹ƒNƒŠƒbƒN‚à‚±‚±‚Å”²‚¯‚é
+	// 2007.10.06 nasukoji	ã‚¯ã‚¢ãƒ‰ãƒ©ãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯æ™‚ã‚‚ã“ã“ã§æŠœã‘ã‚‹
 	if(m_dwTripleClickCheck){
-		m_dwTripleClickCheck = 0;	// ƒgƒŠƒvƒ‹ƒNƒŠƒbƒNƒ`ƒFƒbƒN OFFiŸ‰ñ‚Í’ÊíƒNƒŠƒbƒNj
+		m_dwTripleClickCheck = 0;	// ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãƒã‚§ãƒƒã‚¯ OFFï¼ˆæ¬¡å›ã¯é€šå¸¸ã‚¯ãƒªãƒƒã‚¯ï¼‰
 		return;
 	}
 
-	// 2007.11.06 nasukoji	ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚ª’PŒê‘I‘ğ‚Å‚È‚­‚Ä‚àƒgƒŠƒvƒ‹ƒNƒŠƒbƒN‚ğ—LŒø‚Æ‚·‚é
-	// 2007.10.02 nasukoji	ƒgƒŠƒvƒ‹ƒNƒŠƒbƒNƒ`ƒFƒbƒN—p‚É‚ğæ“¾
+	// 2007.11.06 nasukoji	ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ãŒå˜èªé¸æŠã§ãªãã¦ã‚‚ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ã‚’æœ‰åŠ¹ã¨ã™ã‚‹
+	// 2007.10.02 nasukoji	ãƒˆãƒªãƒ—ãƒ«ã‚¯ãƒªãƒƒã‚¯ãƒã‚§ãƒƒã‚¯ç”¨ã«æ™‚åˆ»ã‚’å–å¾—
 	m_dwTripleClickCheck = ::GetTickCount();
 
-	// ƒ_ƒuƒ‹ƒNƒŠƒbƒNˆÊ’u‚Æ‚µ‚Ä‹L‰¯
-	GetSelectionInfo().m_ptMouseRollPosOld = ptMouse;	// ƒ}ƒEƒX”ÍˆÍ‘I‘ğ‘O‰ñˆÊ’u(XYÀ•W)
+	// ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ä½ç½®ã¨ã—ã¦è¨˜æ†¶
+	GetSelectionInfo().m_ptMouseRollPosOld = ptMouse;	// ãƒã‚¦ã‚¹ç¯„å›²é¸æŠå‰å›ä½ç½®(XYåº§æ¨™)
 
-	/*	2007.07.09 maru ‹@”\ƒR[ƒh‚Ì”»’è‚ğ’Ç‰Á
-		ƒ_ƒuƒ‹ƒNƒŠƒbƒN‚©‚ç‚Ìƒhƒ‰ƒbƒO‚Å‚Í’PŒê’PˆÊ‚Ì”ÍˆÍ‘I‘ğ(ƒGƒfƒBƒ^‚Ìˆê”Ê“I“®ì)‚É‚È‚é‚ª
-		‚±‚Ì“®ì‚ÍAƒ_ƒuƒ‹ƒNƒŠƒbƒN’PŒê‘I‘ğ‚ğ‘O’ñ‚Æ‚µ‚½‚à‚ÌB
-		ƒL[Š„‚è“–‚Ä‚Ì•ÏX‚É‚æ‚èAƒ_ƒuƒ‹ƒNƒŠƒbƒN‚’PŒê‘I‘ğ‚Ì‚Æ‚«‚É‚Í GetSelectionInfo().m_bBeginWordSelect = true
-		‚É‚·‚é‚ÆAˆ—‚Ì“à—e‚É‚æ‚Á‚Ä‚Í•\¦‚ª‚¨‚©‚µ‚­‚È‚é‚Ì‚ÅA‚±‚±‚Å”²‚¯‚é‚æ‚¤‚É‚·‚éB
+	/*	2007.07.09 maru æ©Ÿèƒ½ã‚³ãƒ¼ãƒ‰ã®åˆ¤å®šã‚’è¿½åŠ 
+		ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ã‹ã‚‰ã®ãƒ‰ãƒ©ãƒƒã‚°ã§ã¯å˜èªå˜ä½ã®ç¯„å›²é¸æŠ(ã‚¨ãƒ‡ã‚£ã‚¿ã®ä¸€èˆ¬çš„å‹•ä½œ)ã«ãªã‚‹ãŒ
+		ã“ã®å‹•ä½œã¯ã€ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯ï¼å˜èªé¸æŠã‚’å‰æã¨ã—ãŸã‚‚ã®ã€‚
+		ã‚­ãƒ¼å‰²ã‚Šå½“ã¦ã®å¤‰æ›´ã«ã‚ˆã‚Šã€ãƒ€ãƒ–ãƒ«ã‚¯ãƒªãƒƒã‚¯â‰ å˜èªé¸æŠã®ã¨ãã«ã¯ GetSelectionInfo().m_bBeginWordSelect = true
+		ã«ã™ã‚‹ã¨ã€å‡¦ç†ã®å†…å®¹ã«ã‚ˆã£ã¦ã¯è¡¨ç¤ºãŒãŠã‹ã—ããªã‚‹ã®ã§ã€ã“ã“ã§æŠœã‘ã‚‹ã‚ˆã†ã«ã™ã‚‹ã€‚
 	*/
 	if(F_SELECTWORD != nFuncID) return;
 
-	/* ”ÍˆÍ‘I‘ğŠJn & ƒ}ƒEƒXƒLƒƒƒvƒ`ƒƒ[ */
+	/* ç¯„å›²é¸æŠé–‹å§‹ & ãƒã‚¦ã‚¹ã‚­ãƒ£ãƒ—ãƒãƒ£ãƒ¼ */
 	GetSelectionInfo().SelectBeginWord();
 
-	if( GetDllShareData().m_Common.m_sView.m_bFontIs_FIXED_PITCH ){	/* Œ»İ‚ÌƒtƒHƒ“ƒg‚ÍŒÅ’è•ƒtƒHƒ“ƒg‚Å‚ ‚é */
-		/* ALTƒL[‚ª‰Ÿ‚³‚ê‚Ä‚¢‚½‚© */
+	if( GetDllShareData().m_Common.m_sView.m_bFontIs_FIXED_PITCH ){	/* ç¾åœ¨ã®ãƒ•ã‚©ãƒ³ãƒˆã¯å›ºå®šå¹…ãƒ•ã‚©ãƒ³ãƒˆã§ã‚ã‚‹ */
+		/* ALTã‚­ãƒ¼ãŒæŠ¼ã•ã‚Œã¦ã„ãŸã‹ */
 		if( GetKeyState_Alt() ){
-			GetSelectionInfo().SetBoxSelect(true);	/* ‹éŒ`”ÍˆÍ‘I‘ğ’† */
+			GetSelectionInfo().SetBoxSelect(true);	/* çŸ©å½¢ç¯„å›²é¸æŠä¸­ */
 		}
 	}
 	::SetCapture( GetHwnd() );
 	GetCaret().HideCaret_( GetHwnd() ); // 2002/07/22 novice
 	if( GetSelectionInfo().IsTextSelected() ){
-		/* í‘I‘ğ”ÍˆÍ‚Ì”ÍˆÍ */
+		/* å¸¸æ™‚é¸æŠç¯„å›²ã®ç¯„å›² */
 		GetSelectionInfo().m_sSelectBgn.SetTo( GetSelectionInfo().m_sSelect.GetTo() );
 	}
 	else{
-		/* Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é */
+		/* ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹ */
 		GetSelectionInfo().BeginSelectArea( );
 	}
 
@@ -1758,10 +1758,10 @@ void CEditView::OnLBUTTONDBLCLK( WPARAM fwKeys, int _xPos , int _yPos )
 STDMETHODIMP CEditView::DragEnter( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect )
 {
 	DEBUG_TRACE( _T("CEditView::DragEnter()\n") );
-	//uOLE‚É‚æ‚éƒhƒ‰ƒbƒO & ƒhƒƒbƒv‚ğg‚¤vƒIƒvƒVƒ‡ƒ“‚ª–³Œø‚Ìê‡‚É‚Íƒhƒƒbƒv‚ğó‚¯•t‚¯‚È‚¢
+	//ã€ŒOLEã«ã‚ˆã‚‹ãƒ‰ãƒ©ãƒƒã‚° & ãƒ‰ãƒ­ãƒƒãƒ—ã‚’ä½¿ã†ã€ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãŒç„¡åŠ¹ã®å ´åˆã«ã¯ãƒ‰ãƒ­ãƒƒãƒ—ã‚’å—ã‘ä»˜ã‘ãªã„
 	if(!GetDllShareData().m_Common.m_sEdit.m_bUseOLE_DragDrop)return E_UNEXPECTED;
 
-	//•ÒW‹Ö~‚Ìê‡‚Íƒhƒƒbƒv‚ğó‚¯•t‚¯‚È‚¢
+	//ç·¨é›†ç¦æ­¢ã®å ´åˆã¯ãƒ‰ãƒ­ãƒƒãƒ—ã‚’å—ã‘ä»˜ã‘ãªã„
 	if(!m_pcEditDoc->IsEditable())return E_UNEXPECTED;
 
 
@@ -1772,22 +1772,22 @@ STDMETHODIMP CEditView::DragEnter( LPDATAOBJECT pDataObject, DWORD dwKeyState, P
 	if( m_cfDragData == 0 )
 		return E_INVALIDARG;
 	else if( m_cfDragData == CF_HDROP ){
-		// ‰Eƒ{ƒ^ƒ“‚Å“ü‚Á‚Ä‚«‚½‚Æ‚«‚¾‚¯ƒtƒ@ƒCƒ‹‚ğƒrƒ…[‚Åæ‚èˆµ‚¤
+		// å³ãƒœã‚¿ãƒ³ã§å…¥ã£ã¦ããŸã¨ãã ã‘ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ãƒ“ãƒ¥ãƒ¼ã§å–ã‚Šæ‰±ã†
 		if( !(MK_RBUTTON & dwKeyState) )
 			return E_INVALIDARG;
 	}
 
-	/* ©•ª‚ğƒAƒNƒeƒBƒuƒyƒCƒ“‚É‚·‚é */
+	/* è‡ªåˆ†ã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ãƒšã‚¤ãƒ³ã«ã™ã‚‹ */
 	m_pcEditWnd->SetActivePane( m_nMyIndex );
 
-	// Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚ğ‹L‰¯‚·‚é	// 2007.12.09 ryoji
+	// ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’è¨˜æ†¶ã™ã‚‹	// 2007.12.09 ryoji
 	m_ptCaretPos_DragEnter = GetCaret().GetCaretLayoutPos();
 	m_nCaretPosX_Prev_DragEnter = GetCaret().m_nCaretPosX_Prev;
 
-	// ƒhƒ‰ƒbƒOƒf[ƒ^‚Í‹éŒ`‚©
+	// ãƒ‰ãƒ©ãƒƒã‚°ãƒ‡ãƒ¼ã‚¿ã¯çŸ©å½¢ã‹
 	m_bDragBoxData = IsDataAvailable( pDataObject, (CLIPFORMAT)::RegisterClipboardFormat( _T("MSDEVColumnSelect") ) );
 
-	/* ‘I‘ğƒeƒLƒXƒg‚Ìƒhƒ‰ƒbƒO’†‚© */
+	/* é¸æŠãƒ†ã‚­ã‚¹ãƒˆã®ãƒ‰ãƒ©ãƒƒã‚°ä¸­ã‹ */
 	_SetDragMode( TRUE );
 
 	DragOver( dwKeyState, pt, pdwEffect );
@@ -1798,7 +1798,7 @@ STDMETHODIMP CEditView::DragOver( DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect
 {
 	DEBUG_TRACE( _T("CEditView::DragOver()\n") );
 
-	/* ƒ}ƒEƒXˆÚ“®‚ÌƒƒbƒZ[ƒWˆ— */
+	/* ãƒã‚¦ã‚¹ç§»å‹•ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç† */
 	::ScreenToClient( GetHwnd(), (LPPOINT)&pt );
 	OnMOUSEMOVE( dwKeyState, pt.x , pt.y );
 
@@ -1809,8 +1809,8 @@ STDMETHODIMP CEditView::DragOver( DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect
 
 	CEditView* pcDragSourceView = m_pcEditWnd->GetDragSourceView();
 
-	// ƒhƒ‰ƒbƒOŒ³‚ª‘¼ƒrƒ…[‚ÅA‚±‚Ìƒrƒ…[‚ÌƒJ[ƒ\ƒ‹‚ªƒhƒ‰ƒbƒOŒ³‚Ì‘I‘ğ”ÍˆÍ“à‚Ìê‡‚Í‹Ö~ƒ}[ƒN‚É‚·‚é
-	// ¦©ƒrƒ…[‚Ì‚Æ‚«‚Í‹Ö~ƒ}[ƒN‚É‚µ‚È‚¢i‘¼ƒAƒvƒŠ‚Å‚à‘½‚­‚Í‚»‚¤‚È‚Á‚Ä‚¢‚é–Í—lj	// 2009.06.09 ryoji
+	// ãƒ‰ãƒ©ãƒƒã‚°å…ƒãŒä»–ãƒ“ãƒ¥ãƒ¼ã§ã€ã“ã®ãƒ“ãƒ¥ãƒ¼ã®ã‚«ãƒ¼ã‚½ãƒ«ãŒãƒ‰ãƒ©ãƒƒã‚°å…ƒã®é¸æŠç¯„å›²å†…ã®å ´åˆã¯ç¦æ­¢ãƒãƒ¼ã‚¯ã«ã™ã‚‹
+	// â€»è‡ªãƒ“ãƒ¥ãƒ¼ã®ã¨ãã¯ç¦æ­¢ãƒãƒ¼ã‚¯ã«ã—ãªã„ï¼ˆä»–ã‚¢ãƒ—ãƒªã§ã‚‚å¤šãã¯ãã†ãªã£ã¦ã„ã‚‹æ¨¡æ§˜ï¼‰	// 2009.06.09 ryoji
 	if( pcDragSourceView && !IsDragSource() &&
 		!pcDragSourceView->IsCurrentPositionSelected( GetCaret().GetCaretLayoutPos() )
 	){
@@ -1823,16 +1823,16 @@ STDMETHODIMP CEditView::DragOver( DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect
 STDMETHODIMP CEditView::DragLeave( void )
 {
 	DEBUG_TRACE( _T("CEditView::DragLeave()\n") );
-	/* ‘I‘ğƒeƒLƒXƒg‚Ìƒhƒ‰ƒbƒO’†‚© */
+	/* é¸æŠãƒ†ã‚­ã‚¹ãƒˆã®ãƒ‰ãƒ©ãƒƒã‚°ä¸­ã‹ */
 	_SetDragMode( FALSE );
 
-	// DragEnter‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚ğ•œŒ³	// 2007.12.09 ryoji
-	// ¦”ÍˆÍ‘I‘ğ’†‚Ì‚Æ‚«‚É‘I‘ğ”ÍˆÍ‚ÆƒJ[ƒ\ƒ‹‚ª•ª—£‚·‚é‚Æ•Ï‚¾‚©‚ç
+	// DragEnteræ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’å¾©å…ƒ	// 2007.12.09 ryoji
+	// â€»ç¯„å›²é¸æŠä¸­ã®ã¨ãã«é¸æŠç¯„å›²ã¨ã‚«ãƒ¼ã‚½ãƒ«ãŒåˆ†é›¢ã™ã‚‹ã¨å¤‰ã ã‹ã‚‰
 	GetCaret().MoveCursor( m_ptCaretPos_DragEnter, false );
 	GetCaret().m_nCaretPosX_Prev = m_nCaretPosX_Prev_DragEnter;
-	RedrawAll();	// ƒ‹[ƒ‰[AƒAƒ“ƒ_[ƒ‰ƒCƒ“AƒJ[ƒ\ƒ‹ˆÊ’u•\¦XV
+	RedrawAll();	// ãƒ«ãƒ¼ãƒ©ãƒ¼ã€ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ã€ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®è¡¨ç¤ºæ›´æ–°
 
-	// ”ñƒAƒNƒeƒBƒu‚Í•\¦ó‘Ô‚ğ”ñƒAƒNƒeƒBƒu‚É–ß‚·	// 2007.12.09 ryoji
+	// éã‚¢ã‚¯ãƒ†ã‚£ãƒ–æ™‚ã¯è¡¨ç¤ºçŠ¶æ…‹ã‚’éã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«æˆ»ã™	// 2007.12.09 ryoji
 	if( ::GetActiveWindow() == NULL )
 		OnKillFocus();
 
@@ -1854,10 +1854,10 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 
 
 
-	/* ‘I‘ğƒeƒLƒXƒg‚Ìƒhƒ‰ƒbƒO’†‚© */
+	/* é¸æŠãƒ†ã‚­ã‚¹ãƒˆã®ãƒ‰ãƒ©ãƒƒã‚°ä¸­ã‹ */
 	_SetDragMode( FALSE );
 
-	// ”ñƒAƒNƒeƒBƒu‚Í•\¦ó‘Ô‚ğ”ñƒAƒNƒeƒBƒu‚É–ß‚·	// 2007.12.09 ryoji
+	// éã‚¢ã‚¯ãƒ†ã‚£ãƒ–æ™‚ã¯è¡¨ç¤ºçŠ¶æ…‹ã‚’éã‚¢ã‚¯ãƒ†ã‚£ãƒ–ã«æˆ»ã™	// 2007.12.09 ryoji
 	if( ::GetActiveWindow() == NULL )
 		OnKillFocus();
 
@@ -1873,30 +1873,30 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 	if( *pdwEffect == DROPEFFECT_NONE )
 		return E_INVALIDARG;
 
-	// ƒtƒ@ƒCƒ‹ƒhƒƒbƒv‚Í PostMyDropFiles() ‚Åˆ—‚·‚é
+	// ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‰ãƒ­ãƒƒãƒ—ã¯ PostMyDropFiles() ã§å‡¦ç†ã™ã‚‹
 	if( cf == CF_HDROP )
 		return PostMyDropFiles( pDataObject );
 
-	// ŠO•”‚©‚ç‚Ìƒhƒƒbƒv‚ÍˆÈŒã‚Ìˆ—‚Å‚ÍƒRƒs[‚Æ“¯—l‚Éˆµ‚¤
+	// å¤–éƒ¨ã‹ã‚‰ã®ãƒ‰ãƒ­ãƒƒãƒ—ã¯ä»¥å¾Œã®å‡¦ç†ã§ã¯ã‚³ãƒ”ãƒ¼ã¨åŒæ§˜ã«æ‰±ã†
 	CEditView* pcDragSourceView = m_pcEditWnd->GetDragSourceView();
 	bMove = (*pdwEffect == DROPEFFECT_MOVE) && pcDragSourceView;
 	bBoxData = m_bDragBoxData;
 
-	// ƒJ[ƒ\ƒ‹‚ª‘I‘ğ”ÍˆÍ“à‚É‚ ‚é‚Æ‚«‚ÍƒRƒs[^ˆÚ“®‚µ‚È‚¢	// 2009.06.09 ryoji
+	// ã‚«ãƒ¼ã‚½ãƒ«ãŒé¸æŠç¯„å›²å†…ã«ã‚ã‚‹ã¨ãã¯ã‚³ãƒ”ãƒ¼ï¼ç§»å‹•ã—ãªã„	// 2009.06.09 ryoji
 	if( pcDragSourceView &&
 		!pcDragSourceView->IsCurrentPositionSelected( GetCaret().GetCaretLayoutPos() )
 	){
-		// DragEnter‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚ğ•œŒ³
-		// Note. ƒhƒ‰ƒbƒOŒ³‚ª‘¼ƒrƒ…[‚Å‚àƒ}ƒEƒXˆÚ“®‚ª‘¬‚¢‚Æ‹H‚É‚±‚±‚É‚­‚é‰Â”\«‚ª‚ ‚è‚»‚¤
+		// DragEnteræ™‚ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’å¾©å…ƒ
+		// Note. ãƒ‰ãƒ©ãƒƒã‚°å…ƒãŒä»–ãƒ“ãƒ¥ãƒ¼ã§ã‚‚ãƒã‚¦ã‚¹ç§»å‹•ãŒé€Ÿã„ã¨ç¨€ã«ã“ã“ã«ãã‚‹å¯èƒ½æ€§ãŒã‚ã‚Šãã†
 		*pdwEffect = DROPEFFECT_NONE;
 		GetCaret().MoveCursor( m_ptCaretPos_DragEnter, false );
 		GetCaret().m_nCaretPosX_Prev = m_nCaretPosX_Prev_DragEnter;
-		if( !IsDragSource() )	// ƒhƒ‰ƒbƒOŒ³‚Ìê‡‚Í‚±‚±‚Å‚ÍÄ•`‰æ•s—viDragDropŒãˆ—‚ÌSetActivePane‚ÅÄ•`‰æ‚³‚ê‚éj
-			RedrawAll();	// ©å‚ÉˆÈŒã‚Ì”ñƒAƒNƒeƒBƒu‰»‚É”º‚¤ƒAƒ“ƒ_[ƒ‰ƒCƒ“Á‚µ‚Ì‚½‚ß‚Éˆê“xXV‚µ‚Ä®‡‚ğ‚Æ‚é
+		if( !IsDragSource() )	// ãƒ‰ãƒ©ãƒƒã‚°å…ƒã®å ´åˆã¯ã“ã“ã§ã¯å†æç”»ä¸è¦ï¼ˆDragDropå¾Œå‡¦ç†ã®SetActivePaneã§å†æç”»ã•ã‚Œã‚‹ï¼‰
+			RedrawAll();	// â†ä¸»ã«ä»¥å¾Œã®éã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–ã«ä¼´ã†ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³æ¶ˆã—ã®ãŸã‚ã«ä¸€åº¦æ›´æ–°ã—ã¦æ•´åˆã‚’ã¨ã‚‹
 		return S_OK;
 	}
 
-	// ƒhƒƒbƒvƒf[ƒ^‚Ìæ“¾
+	// ãƒ‰ãƒ­ãƒƒãƒ—ãƒ‡ãƒ¼ã‚¿ã®å–å¾—
 	HGLOBAL hData = GetGlobalData( pDataObject, cf );
 	if (hData == NULL)
 		return E_INVALIDARG;
@@ -1905,7 +1905,7 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 	if( cf == CClipboard::GetSakuraFormat() ){
 		if( nSize > sizeof(int) ){
 			wchar_t* pszData = (wchar_t*)((BYTE*)pData + sizeof(int));
-			cmemBuf.SetString( pszData, t_min( (SIZE_T)*(int*)pData, nSize / sizeof(wchar_t) ) );	// “r’†‚ÌNUL•¶š‚àŠÜ‚ß‚é
+			cmemBuf.SetString( pszData, t_min( (SIZE_T)*(int*)pData, nSize / sizeof(wchar_t) ) );	// é€”ä¸­ã®NULæ–‡å­—ã‚‚å«ã‚ã‚‹
 		}
 	}else if( cf == CF_UNICODETEXT ){
 		cmemBuf.SetString( (wchar_t*)pData, wcsnlen( (wchar_t*)pData, nSize / sizeof(wchar_t) ) );
@@ -1913,20 +1913,20 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 		cmemBuf.SetStringOld( (char*)pData, strnlen( (char*)pData, nSize / sizeof(char) ) );
 	}
 
-	// ƒAƒ“ƒhƒDƒoƒbƒtƒ@‚Ì€”õ
+	// ã‚¢ãƒ³ãƒ‰ã‚¥ãƒãƒƒãƒ•ã‚¡ã®æº–å‚™
 	if( NULL == m_cCommander.GetOpeBlk() ){
 		m_cCommander.SetOpeBlk(new COpeBlk);
 	}
 	m_cCommander.GetOpeBlk()->AddRef();
 
-	/* ˆÚ“®‚Ìê‡AˆÊ’uŠÖŒW‚ğZo */
+	/* ç§»å‹•ã®å ´åˆã€ä½ç½®é–¢ä¿‚ã‚’ç®—å‡º */
 	if( bMove ){
 		if( bBoxData ){
-			/* 2“_‚ğ‘ÎŠp‚Æ‚·‚é‹éŒ`‚ğ‹‚ß‚é */
+			/* 2ç‚¹ã‚’å¯¾è§’ã¨ã™ã‚‹çŸ©å½¢ã‚’æ±‚ã‚ã‚‹ */
 			TwoPointToRect(
 				&rcSel,
-				pcDragSourceView->GetSelectionInfo().m_sSelect.GetFrom(),	// ”ÍˆÍ‘I‘ğŠJn
-				pcDragSourceView->GetSelectionInfo().m_sSelect.GetTo()		// ”ÍˆÍ‘I‘ğI—¹
+				pcDragSourceView->GetSelectionInfo().m_sSelect.GetFrom(),	// ç¯„å›²é¸æŠé–‹å§‹
+				pcDragSourceView->GetSelectionInfo().m_sSelect.GetTo()		// ç¯„å›²é¸æŠçµ‚äº†
 			);
 			++rcSel.bottom;
 			if( GetCaret().GetCaretLayoutPos().GetY() >= rcSel.bottom ){
@@ -1958,16 +1958,16 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 
 	CLayoutPoint ptCaretPos_Old = GetCaret().GetCaretLayoutPos();
 	if( !bMove ){
-		/* ƒRƒs[ƒ‚[ƒh */
-		/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+		/* ã‚³ãƒ”ãƒ¼ãƒ¢ãƒ¼ãƒ‰ */
+		/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 		GetSelectionInfo().DisableSelectArea( true );
 	}else{
 		bBeginBoxSelect_Old = pcDragSourceView->GetSelectionInfo().IsBoxSelecting();
 		sSelectBgn_Old = pcDragSourceView->GetSelectionInfo().m_sSelectBgn;
 		sSelect_Old = pcDragSourceView->GetSelectionInfo().m_sSelect;
 		if( bMoveToPrev ){
-			/* ˆÚ“®ƒ‚[ƒh & ‘O‚ÉˆÚ“® */
-			/* ‘I‘ğƒGƒŠƒA‚ğíœ */
+			/* ç§»å‹•ãƒ¢ãƒ¼ãƒ‰ & å‰ã«ç§»å‹• */
+			/* é¸æŠã‚¨ãƒªã‚¢ã‚’å‰Šé™¤ */
 			if( this != pcDragSourceView ){
 				pcDragSourceView->GetSelectionInfo().DisableSelectArea( true );
 				GetSelectionInfo().DisableSelectArea( true );
@@ -1978,17 +1978,17 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 			DeleteData( true );
 			GetCaret().MoveCursor( ptCaretPos_Old, true );
 		}else{
-			/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+			/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 			pcDragSourceView->GetSelectionInfo().DisableSelectArea( true );
 			if( this != pcDragSourceView )
 				GetSelectionInfo().DisableSelectArea( true );
 		}
 	}
-	if( !bBoxData ){	/* ‹éŒ`ƒf[ƒ^ */
-		//	2004,05.14 Moca ˆø”‚É•¶š—ñ’·‚ğ’Ç‰Á
+	if( !bBoxData ){	/* çŸ©å½¢ãƒ‡ãƒ¼ã‚¿ */
+		//	2004,05.14 Moca å¼•æ•°ã«æ–‡å­—åˆ—é•·ã‚’è¿½åŠ 
 
-		// ‘}“ü‘O‚ÌƒLƒƒƒŒƒbƒgˆÊ’u‚ğ‹L‰¯‚·‚é
-		// iƒLƒƒƒŒƒbƒg‚ªsI’[‚æ‚è‰E‚Ìê‡‚Í–„‚ß‚Ü‚ê‚é‹ó”’•ª‚¾‚¯Œ…ˆÊ’u‚ğƒVƒtƒgj
+		// æŒ¿å…¥å‰ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã‚’è¨˜æ†¶ã™ã‚‹
+		// ï¼ˆã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒè¡Œçµ‚ç«¯ã‚ˆã‚Šå³ã®å ´åˆã¯åŸ‹ã‚è¾¼ã¾ã‚Œã‚‹ç©ºç™½åˆ†ã ã‘æ¡ä½ç½®ã‚’ã‚·ãƒ•ãƒˆï¼‰
 		CLogicPoint ptCaretLogicPos_Old = GetCaret().GetCaretLogicPos();
 		const CLayout* pcLayout;
 		CLogicInt nLineLen;
@@ -1996,7 +1996,7 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 		if( m_pcEditDoc->m_cLayoutMgr.GetLineStr( ptCaretLayoutPos_Old.GetY2(), &nLineLen, &pcLayout ) ){
 			CLayoutInt nLineAllColLen;
 			LineColumnToIndex2( pcLayout, ptCaretLayoutPos_Old.GetX2(), &nLineAllColLen );
-			if( nLineAllColLen > CLayoutInt(0) ){	// sI’[‚æ‚è‰E‚Ìê‡‚É‚Í nLineAllColLen ‚És‘S‘Ì‚Ì•\¦Œ…”‚ª“ü‚Á‚Ä‚¢‚é
+			if( nLineAllColLen > CLayoutInt(0) ){	// è¡Œçµ‚ç«¯ã‚ˆã‚Šå³ã®å ´åˆã«ã¯ nLineAllColLen ã«è¡Œå…¨ä½“ã®è¡¨ç¤ºæ¡æ•°ãŒå…¥ã£ã¦ã„ã‚‹
 				ptCaretLogicPos_Old.SetX(
 					ptCaretLogicPos_Old.GetX2()
 					+ (Int)(ptCaretLayoutPos_Old.GetX2() - nLineAllColLen)
@@ -2006,7 +2006,7 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 
 		GetCommander().Command_INSTEXT( true, cmemBuf.GetStringPtr(), cmemBuf.GetStringLength(), FALSE );
 
-		// ‘}“ü‘O‚ÌƒLƒƒƒŒƒbƒgˆÊ’u‚©‚ç‘}“üŒã‚ÌƒLƒƒƒŒƒbƒgˆÊ’u‚Ü‚Å‚ğ‘I‘ğ”ÍˆÍ‚É‚·‚é
+		// æŒ¿å…¥å‰ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã‹ã‚‰æŒ¿å…¥å¾Œã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã¾ã§ã‚’é¸æŠç¯„å›²ã«ã™ã‚‹
 		CLayoutPoint ptSelectFrom;
 		m_pcEditDoc->m_cLayoutMgr.LogicToLayout(
 			ptCaretLogicPos_Old,
@@ -2014,10 +2014,10 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 		);
 		GetSelectionInfo().SetSelectArea( CLayoutRange(ptSelectFrom, GetCaret().GetCaretLayoutPos()) );	// 2009.07.25 ryoji
 	}else{
-		// 2004.07.12 Moca ƒNƒŠƒbƒvƒ{[ƒh‚ğ‘‚«Š·‚¦‚È‚¢‚æ‚¤‚É
+		// 2004.07.12 Moca ã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‚’æ›¸ãæ›ãˆãªã„ã‚ˆã†ã«
 		// TRUE == bBoxSelected
 		// FALSE == GetSelectionInfo().IsBoxSelecting()
-		/* “\‚è•t‚¯iƒNƒŠƒbƒvƒ{[ƒh‚©‚ç“\‚è•t‚¯j*/
+		/* è²¼ã‚Šä»˜ã‘ï¼ˆã‚¯ãƒªãƒƒãƒ—ãƒœãƒ¼ãƒ‰ã‹ã‚‰è²¼ã‚Šä»˜ã‘ï¼‰*/
 		GetCommander().Command_PASTEBOX( cmemBuf.GetStringPtr(), cmemBuf.GetStringLength() );
 		AdjustScrollBars(); // 2007.07.22 ryoji
 		Redraw();
@@ -2025,57 +2025,57 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 	if( bMove ){
 		if( bMoveToPrev ){
 		}else{
-			/* ˆÚ“®ƒ‚[ƒh & Œã‚ë‚ÉˆÚ“®*/
+			/* ç§»å‹•ãƒ¢ãƒ¼ãƒ‰ & å¾Œã‚ã«ç§»å‹•*/
 
-			// Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ‹L‰¯‚·‚é	// 2008.03.26 ryoji
+			// ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’è¨˜æ†¶ã™ã‚‹	// 2008.03.26 ryoji
 			CLogicRange sSelLogic;
 			m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(
 				GetSelectionInfo().m_sSelect,
 				&sSelLogic
 			);
 
-			// ˆÈ‘O‚Ì‘I‘ğ”ÍˆÍ‚ğ‹L‰¯‚·‚é	// 2008.03.26 ryoji
+			// ä»¥å‰ã®é¸æŠç¯„å›²ã‚’è¨˜æ†¶ã™ã‚‹	// 2008.03.26 ryoji
 			CLogicRange sDelLogic;
 			m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(
 				sSelect_Old,
 				&sDelLogic
 			);
 
-			// Œ»İ‚Ìs”‚ğ‹L‰¯‚·‚é	// 2008.03.26 ryoji
+			// ç¾åœ¨ã®è¡Œæ•°ã‚’è¨˜æ†¶ã™ã‚‹	// 2008.03.26 ryoji
 			int nLines_Old = m_pcEditDoc->m_cDocLineMgr.GetLineCount();
 
-			// ˆÈ‘O‚Ì‘I‘ğ”ÍˆÍ‚ğ‘I‘ğ‚·‚é
+			// ä»¥å‰ã®é¸æŠç¯„å›²ã‚’é¸æŠã™ã‚‹
 			GetSelectionInfo().SetBoxSelect( bBeginBoxSelect_Old );
 			GetSelectionInfo().m_sSelectBgn = sSelectBgn_Old;
 			GetSelectionInfo().m_sSelect = sSelect_Old;
 
-			/* ‘I‘ğƒGƒŠƒA‚ğíœ */
+			/* é¸æŠã‚¨ãƒªã‚¢ã‚’å‰Šé™¤ */
 			DeleteData( true );
 
-			// íœ‘O‚Ì‘I‘ğ”ÍˆÍ‚ğ•œŒ³‚·‚é	// 2008.03.26 ryoji
+			// å‰Šé™¤å‰ã®é¸æŠç¯„å›²ã‚’å¾©å…ƒã™ã‚‹	// 2008.03.26 ryoji
 			if( !bBoxData ){
-				// íœ‚³‚ê‚½”ÍˆÍ‚ğl—¶‚µ‚Ä‘I‘ğ”ÍˆÍ‚ğ’²®‚·‚é
-				if( sSelLogic.GetFrom().GetY2() == sDelLogic.GetTo().GetY2() ){	// ‘I‘ğŠJn‚ªíœ––”ö‚Æ“¯ˆês
+				// å‰Šé™¤ã•ã‚ŒãŸç¯„å›²ã‚’è€ƒæ…®ã—ã¦é¸æŠç¯„å›²ã‚’èª¿æ•´ã™ã‚‹
+				if( sSelLogic.GetFrom().GetY2() == sDelLogic.GetTo().GetY2() ){	// é¸æŠé–‹å§‹ãŒå‰Šé™¤æœ«å°¾ã¨åŒä¸€è¡Œ
 					sSelLogic.SetFromX(
 						sSelLogic.GetFrom().GetX2()
 						- (sDelLogic.GetTo().GetX2() - sDelLogic.GetFrom().GetX2())
 					);
 				}
-				if( sSelLogic.GetTo().GetY2() == sDelLogic.GetTo().GetY2() ){	// ‘I‘ğI—¹‚ªíœ––”ö‚Æ“¯ˆês
+				if( sSelLogic.GetTo().GetY2() == sDelLogic.GetTo().GetY2() ){	// é¸æŠçµ‚äº†ãŒå‰Šé™¤æœ«å°¾ã¨åŒä¸€è¡Œ
 					sSelLogic.SetToX(
 						sSelLogic.GetTo().GetX2()
 						- (sDelLogic.GetTo().GetX2() - sDelLogic.GetFrom().GetX2())
 					);
 				}
 				// Note.
-				// (sDelLogic.GetTo().GetY2() - sDelLogic.GetFrom().GetY2()) ‚¾‚ÆÀÛ‚Ìíœs”‚Æ“¯‚¶‚É‚È‚é
-				// ‚±‚Æ‚à‚ ‚é‚ªAiíœs”|‚Pj‚É‚È‚é‚±‚Æ‚à‚ ‚éD
-				// —ájƒtƒŠ[ƒJ[ƒ\ƒ‹‚Å‚Ìs”Ô†ƒNƒŠƒbƒN‚Ì‚Ps‘I‘ğ
+				// (sDelLogic.GetTo().GetY2() - sDelLogic.GetFrom().GetY2()) ã ã¨å®Ÿéš›ã®å‰Šé™¤è¡Œæ•°ã¨åŒã˜ã«ãªã‚‹
+				// ã“ã¨ã‚‚ã‚ã‚‹ãŒã€ï¼ˆå‰Šé™¤è¡Œæ•°ï¼ï¼‘ï¼‰ã«ãªã‚‹ã“ã¨ã‚‚ã‚ã‚‹ï¼
+				// ä¾‹ï¼‰ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ã§ã®è¡Œç•ªå·ã‚¯ãƒªãƒƒã‚¯æ™‚ã®ï¼‘è¡Œé¸æŠ
 				int nLines = m_pcEditDoc->m_cDocLineMgr.GetLineCount();
 				sSelLogic.SetFromY( sSelLogic.GetFrom().GetY2() - (nLines_Old - nLines) );
 				sSelLogic.SetToY( sSelLogic.GetTo().GetY2() - (nLines_Old - nLines) );
 
-				// ’²®Œã‚Ì‘I‘ğ”ÍˆÍ‚ğİ’è‚·‚é
+				// èª¿æ•´å¾Œã®é¸æŠç¯„å›²ã‚’è¨­å®šã™ã‚‹
 				CLayoutRange sSelect;
 				m_pcEditDoc->m_cLayoutMgr.LogicToLayout(
 					sSelLogic,
@@ -2085,11 +2085,11 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 				ptCaretPos_Old = GetSelectionInfo().m_sSelect.GetTo();
 			}
 
-			// ƒLƒƒƒŒƒbƒg‚ğˆÚ“®‚·‚é
+			// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’ç§»å‹•ã™ã‚‹
 			GetCaret().MoveCursor( ptCaretPos_Old, true );
 			GetCaret().m_nCaretPosX_Prev = GetCaret().GetCaretLayoutPos().GetX2();
 
-			// íœˆÊ’u‚©‚çˆÚ“®æ‚Ö‚ÌƒJ[ƒ\ƒ‹ˆÚ“®‚ğƒAƒ“ƒhƒD‘€ì‚É’Ç‰Á‚·‚é	// 2008.03.26 ryoji
+			// å‰Šé™¤ä½ç½®ã‹ã‚‰ç§»å‹•å…ˆã¸ã®ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ã‚’ã‚¢ãƒ³ãƒ‰ã‚¥æ“ä½œã«è¿½åŠ ã™ã‚‹	// 2008.03.26 ryoji
 			CLogicPoint ptBefore;
 			m_pcEditDoc->m_cLayoutMgr.LayoutToLogic(
 				GetSelectionInfo().m_sSelect.GetFrom(),
@@ -2105,11 +2105,11 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 	}
 	GetSelectionInfo().DrawSelectArea();
 
-	/* ƒAƒ“ƒhƒDƒoƒbƒtƒ@‚Ìˆ— */
+	/* ã‚¢ãƒ³ãƒ‰ã‚¥ãƒãƒƒãƒ•ã‚¡ã®å‡¦ç† */
 	SetUndoBuffer();
 
 	::GlobalUnlock( hData );
-	// 2004.07.12 fotomo/‚à‚© ƒƒ‚ƒŠ[ƒŠ[ƒN‚ÌC³
+	// 2004.07.12 fotomo/ã‚‚ã‹ ãƒ¡ãƒ¢ãƒªãƒ¼ãƒªãƒ¼ã‚¯ã®ä¿®æ­£
 	if( 0 == (GMEM_LOCKCOUNT & ::GlobalFlags(hData)) ){
 		::GlobalFree( hData );
 	}
@@ -2118,8 +2118,8 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 }
 
 
-/** “Æ©ƒhƒƒbƒvƒtƒ@ƒCƒ‹ƒƒbƒZ[ƒW‚ğƒ|ƒXƒg‚·‚é
-	@date 2008.06.20 ryoji V‹Kì¬
+/** ç‹¬è‡ªãƒ‰ãƒ­ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’ãƒã‚¹ãƒˆã™ã‚‹
+	@date 2008.06.20 ryoji æ–°è¦ä½œæˆ
 */
 STDMETHODIMP CEditView::PostMyDropFiles( LPDATAOBJECT pDataObject )
 {
@@ -2129,7 +2129,7 @@ STDMETHODIMP CEditView::PostMyDropFiles( LPDATAOBJECT pDataObject )
 	LPVOID pData = ::GlobalLock( hData );
 	SIZE_T nSize = ::GlobalSize( hData );
 
-	// ƒhƒƒbƒvƒf[ƒ^‚ğƒRƒs[‚µ‚Ä‚ ‚Æ‚Å“Æ©‚Ìƒhƒƒbƒvƒtƒ@ƒCƒ‹ˆ—‚ğs‚¤
+	// ãƒ‰ãƒ­ãƒƒãƒ—ãƒ‡ãƒ¼ã‚¿ã‚’ã‚³ãƒ”ãƒ¼ã—ã¦ã‚ã¨ã§ç‹¬è‡ªã®ãƒ‰ãƒ­ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«å‡¦ç†ã‚’è¡Œã†
 	HGLOBAL hDrop = ::GlobalAlloc( GHND | GMEM_DDESHARE, nSize );
 	memcpy_raw( ::GlobalLock( hDrop ), pData, nSize );
 	::GlobalUnlock( hDrop );
@@ -2148,31 +2148,31 @@ STDMETHODIMP CEditView::PostMyDropFiles( LPDATAOBJECT pDataObject )
 	return S_OK;
 }
 
-/** “Æ©ƒhƒƒbƒvƒtƒ@ƒCƒ‹ƒƒbƒZ[ƒWˆ—
-	@date 2008.06.20 ryoji V‹Kì¬
+/** ç‹¬è‡ªãƒ‰ãƒ­ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
+	@date 2008.06.20 ryoji æ–°è¦ä½œæˆ
 */
 void CEditView::OnMyDropFiles( HDROP hDrop )
 {
-	// •’Ê‚Éƒƒjƒ…[‘€ì‚ª‚Å‚«‚é‚æ‚¤‚É“ü—Íó‘Ô‚ğƒtƒHƒAƒOƒ‰ƒ“ƒhƒEƒBƒ“ƒhƒE‚ÉƒAƒ^ƒbƒ`‚·‚é
+	// æ™®é€šã«ãƒ¡ãƒ‹ãƒ¥ãƒ¼æ“ä½œãŒã§ãã‚‹ã‚ˆã†ã«å…¥åŠ›çŠ¶æ…‹ã‚’ãƒ•ã‚©ã‚¢ã‚°ãƒ©ãƒ³ãƒ‰ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã«ã‚¢ã‚¿ãƒƒãƒã™ã‚‹
 	int nTid2 = ::GetWindowThreadProcessId( ::GetForegroundWindow(), NULL );
 	int nTid1 = ::GetCurrentThreadId();
 	if( nTid1 != nTid2 ) ::AttachThreadInput( nTid1, nTid2, TRUE );
 
-	// ƒ_ƒ~[‚Ì STATIC ‚ğì‚Á‚ÄƒtƒH[ƒJƒX‚ğ“–‚Ä‚éiƒGƒfƒBƒ^‚ª‘O–Ê‚Éo‚È‚¢‚æ‚¤‚Éj
+	// ãƒ€ãƒŸãƒ¼ã® STATIC ã‚’ä½œã£ã¦ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã‚’å½“ã¦ã‚‹ï¼ˆã‚¨ãƒ‡ã‚£ã‚¿ãŒå‰é¢ã«å‡ºãªã„ã‚ˆã†ã«ï¼‰
 	HWND hwnd = ::CreateWindow(_T("STATIC"), _T(""), 0, 0, 0, 0, 0, NULL, NULL, G_AppInstance(), NULL );
 	::SetFocus(hwnd);
 
-	// ƒƒjƒ…[‚ğì¬‚·‚é
+	// ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã‚’ä½œæˆã™ã‚‹
 	POINT pt;
 	::GetCursorPos( &pt );
 	RECT rcWork;
-	GetMonitorWorkRect( pt, &rcWork );	// ƒ‚ƒjƒ^‚Ìƒ[ƒNƒGƒŠƒA
+	GetMonitorWorkRect( pt, &rcWork );	// ãƒ¢ãƒ‹ã‚¿ã®ãƒ¯ãƒ¼ã‚¯ã‚¨ãƒªã‚¢
 	HMENU hMenu = ::CreatePopupMenu();
 	::InsertMenu( hMenu, 0, MF_BYPOSITION | MF_STRING, 100, LS(STR_VIEW_MOUSE_MENU_PATH) );
 	::InsertMenu( hMenu, 1, MF_BYPOSITION | MF_STRING, 101, LS(STR_VIEW_MOUSE_MENU_FILE) );
-	::InsertMenu( hMenu, 2, MF_BYPOSITION | MF_SEPARATOR, 0, NULL);	// ƒZƒpƒŒ[ƒ^
+	::InsertMenu( hMenu, 2, MF_BYPOSITION | MF_SEPARATOR, 0, NULL);	// ã‚»ãƒ‘ãƒ¬ãƒ¼ã‚¿
 	::InsertMenu( hMenu, 3, MF_BYPOSITION | MF_STRING, 110, LS(STR_VIEW_MOUSE_MENU_OPEN) );
-	::InsertMenu( hMenu, 4, MF_BYPOSITION | MF_SEPARATOR, 0, NULL);	// ƒZƒpƒŒ[ƒ^
+	::InsertMenu( hMenu, 4, MF_BYPOSITION | MF_SEPARATOR, 0, NULL);	// ã‚»ãƒ‘ãƒ¬ãƒ¼ã‚¿
 	::InsertMenu( hMenu, 5, MF_BYPOSITION | MF_STRING, IDCANCEL, LS(STR_VIEW_MOUSE_MENU_CANCEL) );
 	int nId = ::TrackPopupMenu( hMenu, TPM_LEFTALIGN | TPM_TOPALIGN | TPM_LEFTBUTTON | TPM_RETURNCMD,
 									( pt.x > rcWork.left )? pt.x: rcWork.left,
@@ -2182,18 +2182,18 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 
 	::DestroyWindow( hwnd );
 
-	// “ü—Íó‘Ô‚ğƒfƒ^ƒbƒ`‚·‚é
+	// å…¥åŠ›çŠ¶æ…‹ã‚’ãƒ‡ã‚¿ãƒƒãƒã™ã‚‹
 	if( nTid1 != nTid2 ) ::AttachThreadInput( nTid1, nTid2, FALSE );
 
-	// ‘I‘ğ‚³‚ê‚½ƒƒjƒ…[‚É‘Î‰‚·‚éˆ—‚ğÀs‚·‚é
+	// é¸æŠã•ã‚ŒãŸãƒ¡ãƒ‹ãƒ¥ãƒ¼ã«å¯¾å¿œã™ã‚‹å‡¦ç†ã‚’å®Ÿè¡Œã™ã‚‹
 	switch( nId ){
-	case 110:	// ƒtƒ@ƒCƒ‹‚ğŠJ‚­
-		// ’Êí‚Ìƒhƒƒbƒvƒtƒ@ƒCƒ‹ˆ—‚ğs‚¤
+	case 110:	// ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã
+		// é€šå¸¸ã®ãƒ‰ãƒ­ãƒƒãƒ—ãƒ•ã‚¡ã‚¤ãƒ«å‡¦ç†ã‚’è¡Œã†
 		::SendMessageAny( m_pcEditWnd->GetHwnd(), WM_DROPFILES, (WPARAM)hDrop, 0 );
 		break;
 
-	case 100:	// ƒpƒX–¼‚ğ“\‚è•t‚¯‚é
-	case 101:	// ƒtƒ@ƒCƒ‹–¼‚ğ“\‚è•t‚¯‚é
+	case 100:	// ãƒ‘ã‚¹åã‚’è²¼ã‚Šä»˜ã‘ã‚‹
+	case 101:	// ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è²¼ã‚Šä»˜ã‘ã‚‹
 		CNativeW cmemBuf;
 		UINT nFiles;
 		TCHAR szPath[_MAX_PATH];
@@ -2205,9 +2205,9 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 			::DragQueryFile( hDrop, i, szPath, sizeof(szPath)/sizeof(TCHAR) );
 			if( !::GetLongFileName( szPath, szWork ) )
 				continue;
-			if( nId == 100 ){	// ƒpƒX–¼
+			if( nId == 100 ){	// ãƒ‘ã‚¹å
 				::lstrcpy( szPath, szWork );
-			}else if( nId == 101 ){	// ƒtƒ@ƒCƒ‹–¼
+			}else if( nId == 101 ){	// ãƒ•ã‚¡ã‚¤ãƒ«å
 				_tsplitpath( szWork, NULL, NULL, szPath, szExt );
 				::lstrcat( szPath, szExt );
 			}
@@ -2222,13 +2222,13 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 		}
 		::DragFinish( hDrop );
 
-		// ‘I‘ğ”ÍˆÍ‚Ì‘I‘ğ‰ğœ
+		// é¸æŠç¯„å›²ã®é¸æŠè§£é™¤
 		if( GetSelectionInfo().IsTextSelected() ){
 			GetSelectionInfo().DisableSelectArea( true );
 		}
 
-		// ‘}“ü‘O‚ÌƒLƒƒƒŒƒbƒgˆÊ’u‚ğ‹L‰¯‚·‚é
-		// iƒLƒƒƒŒƒbƒg‚ªsI’[‚æ‚è‰E‚Ìê‡‚Í–„‚ß‚Ü‚ê‚é‹ó”’•ª‚¾‚¯Œ…ˆÊ’u‚ğƒVƒtƒgj
+		// æŒ¿å…¥å‰ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã‚’è¨˜æ†¶ã™ã‚‹
+		// ï¼ˆã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒè¡Œçµ‚ç«¯ã‚ˆã‚Šå³ã®å ´åˆã¯åŸ‹ã‚è¾¼ã¾ã‚Œã‚‹ç©ºç™½åˆ†ã ã‘æ¡ä½ç½®ã‚’ã‚·ãƒ•ãƒˆï¼‰
 		CLogicPoint ptCaretLogicPos_Old = GetCaret().GetCaretLogicPos();
 		const CLayout* pcLayout;
 		CLogicInt nLineLen;
@@ -2236,7 +2236,7 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 		if( m_pcEditDoc->m_cLayoutMgr.GetLineStr( ptCaretLayoutPos_Old.GetY2(), &nLineLen, &pcLayout ) ){
 			CLayoutInt nLineAllColLen;
 			LineColumnToIndex2( pcLayout, ptCaretLayoutPos_Old.GetX2(), &nLineAllColLen );
-			if( nLineAllColLen > CLayoutInt(0) ){	// sI’[‚æ‚è‰E‚Ìê‡‚É‚Í nLineAllColLen ‚És‘S‘Ì‚Ì•\¦Œ…”‚ª“ü‚Á‚Ä‚¢‚é
+			if( nLineAllColLen > CLayoutInt(0) ){	// è¡Œçµ‚ç«¯ã‚ˆã‚Šå³ã®å ´åˆã«ã¯ nLineAllColLen ã«è¡Œå…¨ä½“ã®è¡¨ç¤ºæ¡æ•°ãŒå…¥ã£ã¦ã„ã‚‹
 				ptCaretLogicPos_Old.SetX(
 					ptCaretLogicPos_Old.GetX2()
 					+ (Int)(ptCaretLayoutPos_Old.GetX2() - nLineAllColLen)
@@ -2244,10 +2244,10 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 			}
 		}
 
-		// ƒeƒLƒXƒg‘}“ü
+		// ãƒ†ã‚­ã‚¹ãƒˆæŒ¿å…¥
 		GetCommander().HandleCommand( F_INSTEXT_W, true, (LPARAM)cmemBuf.GetStringPtr(), cmemBuf.GetStringLength(), TRUE, 0 );
 
-		// ‘}“ü‘O‚ÌƒLƒƒƒŒƒbƒgˆÊ’u‚©‚ç‘}“üŒã‚ÌƒLƒƒƒŒƒbƒgˆÊ’u‚Ü‚Å‚ğ‘I‘ğ”ÍˆÍ‚É‚·‚é
+		// æŒ¿å…¥å‰ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã‹ã‚‰æŒ¿å…¥å¾Œã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã¾ã§ã‚’é¸æŠç¯„å›²ã«ã™ã‚‹
 		CLayoutPoint ptSelectFrom;
 		m_pcEditDoc->m_cLayoutMgr.LogicToLayout(
 			ptCaretLogicPos_Old,
@@ -2258,7 +2258,7 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 		break;
 	}
 
-	// ƒƒ‚ƒŠ‰ğ•ú
+	// ãƒ¡ãƒ¢ãƒªè§£æ”¾
 	::GlobalFree( hDrop );
 }
 
@@ -2287,15 +2287,15 @@ DWORD CEditView::TranslateDropEffect( CLIPFORMAT cf, DWORD dwKeyState, POINTL pt
 	CEditView* pcDragSourceView = m_pcEditWnd->GetDragSourceView();
 
 	// 2008.06.21 ryoji
-	// Win 98/Me ŠÂ‹«‚Å‚ÍŠO•”‚©‚ç‚Ìƒhƒ‰ƒbƒO‚É GetKeyState() ‚Å‚ÍƒL[ó‘Ô‚ğ³‚µ‚­æ“¾‚Å‚«‚È‚¢‚½‚ßA
-	// Drag & Drop ƒCƒ“ƒ^[ƒtƒF[ƒX‚Å“n‚³‚ê‚é dwKeyState ‚ğ—p‚¢‚Ä”»’è‚·‚éB
+	// Win 98/Me ç’°å¢ƒã§ã¯å¤–éƒ¨ã‹ã‚‰ã®ãƒ‰ãƒ©ãƒƒã‚°æ™‚ã« GetKeyState() ã§ã¯ã‚­ãƒ¼çŠ¶æ…‹ã‚’æ­£ã—ãå–å¾—ã§ããªã„ãŸã‚ã€
+	// Drag & Drop ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã§æ¸¡ã•ã‚Œã‚‹ dwKeyState ã‚’ç”¨ã„ã¦åˆ¤å®šã™ã‚‹ã€‚
 #if 1
-	// ƒhƒ‰ƒbƒOŒ³‚ªŠO•”ƒEƒBƒ“ƒhƒE‚©‚Ç‚¤‚©‚É‚æ‚Á‚Äó‚¯•û‚ğ•Ï‚¦‚é
-	// ¦”Ä—pƒeƒLƒXƒgƒGƒfƒBƒ^‚Å‚Í‚±‚¿‚ç‚ªå—¬‚Á‚Û‚¢
+	// ãƒ‰ãƒ©ãƒƒã‚°å…ƒãŒå¤–éƒ¨ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‹ã©ã†ã‹ã«ã‚ˆã£ã¦å—ã‘æ–¹ã‚’å¤‰ãˆã‚‹
+	// â€»æ±ç”¨ãƒ†ã‚­ã‚¹ãƒˆã‚¨ãƒ‡ã‚£ã‚¿ã§ã¯ã“ã¡ã‚‰ãŒä¸»æµã£ã½ã„
 	if( pcDragSourceView ){
 #else
-	// ƒhƒ‰ƒbƒOŒ³‚ªˆÚ“®‚ğ‹–‚·‚©‚Ç‚¤‚©‚É‚æ‚Á‚Äó‚¯•û‚ğ•Ï‚¦‚é
-	// ¦MS »•iiMS Office, Visual Studio‚È‚Çj‚Å‚Í‚±‚¿‚ç‚ªå—¬‚Á‚Û‚¢
+	// ãƒ‰ãƒ©ãƒƒã‚°å…ƒãŒç§»å‹•ã‚’è¨±ã™ã‹ã©ã†ã‹ã«ã‚ˆã£ã¦å—ã‘æ–¹ã‚’å¤‰ãˆã‚‹
+	// â€»MS è£½å“ï¼ˆMS Office, Visual Studioãªã©ï¼‰ã§ã¯ã“ã¡ã‚‰ãŒä¸»æµã£ã½ã„
 	if( dwEffect & DROPEFFECT_MOVE ){
 #endif
 		dwEffect &= (MK_CONTROL & dwKeyState)? DROPEFFECT_COPY: DROPEFFECT_MOVE;

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -49,24 +49,24 @@
 void _DispWrap(CGraphics& gr, DispPos* pDispPos, const CEditView* pcView, CLayoutYInt nLineNum);
 
 /*
-	PAINT_LINENUMBER = (1<<0), //!< s”Ô†
-	PAINT_RULER      = (1<<1), //!< ƒ‹[ƒ‰[
-	PAINT_BODY       = (1<<2), //!< –{•¶
+	PAINT_LINENUMBER = (1<<0), //!< è¡Œç•ªå·
+	PAINT_RULER      = (1<<1), //!< ãƒ«ãƒ¼ãƒ©ãƒ¼
+	PAINT_BODY       = (1<<2), //!< æœ¬æ–‡
 */
 
 void CEditView_Paint::Call_OnPaint(
-	int nPaintFlag,   //!< •`‰æ‚·‚é—Ìˆæ‚ğ‘I‘ğ‚·‚é
-	bool bUseMemoryDC //!< ƒƒ‚ƒŠDC‚ğg—p‚·‚é
+	int nPaintFlag,   //!< æç”»ã™ã‚‹é ˜åŸŸã‚’é¸æŠã™ã‚‹
+	bool bUseMemoryDC //!< ãƒ¡ãƒ¢ãƒªDCã‚’ä½¿ç”¨ã™ã‚‹
 )
 {
 	CEditView* pView = GetEditView();
 
-	//Še—v‘f
+	//å„è¦ç´ 
 	CMyRect rcLineNumber(0,pView->GetTextArea().GetAreaTop(),pView->GetTextArea().GetAreaLeft(),pView->GetTextArea().GetAreaBottom());
 	CMyRect rcRuler(pView->GetTextArea().GetAreaLeft(),0,pView->GetTextArea().GetAreaRight(),pView->GetTextArea().GetAreaTop());
 	CMyRect rcBody(pView->GetTextArea().GetAreaLeft(),pView->GetTextArea().GetAreaTop(),pView->GetTextArea().GetAreaRight(),pView->GetTextArea().GetAreaBottom());
 
-	//—Ìˆæ‚ğì¬ -> rc
+	//é ˜åŸŸã‚’ä½œæˆ -> rc
 	std::vector<CMyRect> rcs;
 	if(nPaintFlag & PAINT_LINENUMBER)rcs.push_back(rcLineNumber);
 	if(nPaintFlag & PAINT_RULER)rcs.push_back(rcRuler);
@@ -77,7 +77,7 @@ void CEditView_Paint::Call_OnPaint(
 	for(int i=1;i<nSize;i++)
 		rc=MergeRect(rc,rcs[i]);
 
-	//•`‰æ
+	//æç”»
 	PAINTSTRUCT	ps;
 	ps.rcPaint = rc;
 	HDC hdc = pView->GetDC();
@@ -87,9 +87,9 @@ void CEditView_Paint::Call_OnPaint(
 
 
 
-/* ƒtƒH[ƒJƒXˆÚ“®‚ÌÄ•`‰æ
+/* ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ç§»å‹•æ™‚ã®å†æç”»
 
-	@date 2001/06/21 asa-o uƒXƒNƒ[ƒ‹ƒo[‚Ìó‘Ô‚ğXV‚·‚évuƒJ[ƒ\ƒ‹ˆÚ“®víœ
+	@date 2001/06/21 asa-o ã€Œã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®çŠ¶æ…‹ã‚’æ›´æ–°ã™ã‚‹ã€ã€Œã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•ã€å‰Šé™¤
 */
 void CEditView::RedrawAll()
 {
@@ -98,7 +98,7 @@ void CEditView::RedrawAll()
 	}
 	
 	if( GetDrawSwitch() ){
-		// ƒEƒBƒ“ƒhƒE‘S‘Ì‚ğÄ•`‰æ
+		// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å…¨ä½“ã‚’å†æç”»
 		PAINTSTRUCT	ps;
 		HDC hdc = ::GetDC( GetHwnd() );
 		::GetClientRect( GetHwnd(), &ps.rcPaint );
@@ -106,23 +106,23 @@ void CEditView::RedrawAll()
 		::ReleaseDC( GetHwnd(), hdc );
 	}
 
-	// ƒLƒƒƒŒƒbƒg‚Ì•\¦
+	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤º
 	GetCaret().ShowEditCaret();
 
-	// ƒLƒƒƒŒƒbƒg‚ÌsŒ…ˆÊ’u‚ğ•\¦‚·‚é
+	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡Œæ¡ä½ç½®ã‚’è¡¨ç¤ºã™ã‚‹
 	GetCaret().ShowCaretPosInfo();
 
-	// eƒEƒBƒ“ƒhƒE‚Ìƒ^ƒCƒgƒ‹‚ğXV
+	// è¦ªã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã‚¿ã‚¤ãƒˆãƒ«ã‚’æ›´æ–°
 	m_pcEditWnd->UpdateCaption();
 
-	//	Jul. 9, 2005 genta	‘I‘ğ”ÍˆÍ‚Ìî•ñ‚ğƒXƒe[ƒ^ƒXƒo[‚Ö•\¦
+	//	Jul. 9, 2005 genta	é¸æŠç¯„å›²ã®æƒ…å ±ã‚’ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã¸è¡¨ç¤º
 	GetSelectionInfo().PrintSelectionInfoMsg();
 
-	// ƒXƒNƒ[ƒ‹ƒo[‚Ìó‘Ô‚ğXV‚·‚é
+	// ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®çŠ¶æ…‹ã‚’æ›´æ–°ã™ã‚‹
 	AdjustScrollBars();
 }
 
-// 2001/06/21 Start by asa-o Ä•`‰æ
+// 2001/06/21 Start by asa-o å†æç”»
 void CEditView::Redraw()
 {
 	if( NULL == GetHwnd() ){
@@ -183,7 +183,7 @@ void MyFillRect(HDC hdc, RECT& re)
 void CEditView::DrawBackImage(HDC hdc, RECT& rcPaint, HDC hdcBgImg)
 {
 #if 0
-//	ƒeƒXƒg”wŒiƒpƒ^[ƒ“
+//	ãƒ†ã‚¹ãƒˆèƒŒæ™¯ãƒ‘ã‚¿ãƒ¼ãƒ³
 	static int testColorIndex = 0;
 	testColorIndex = testColorIndex % 7;
 	COLORREF cols[7] = {RGB(255,255,255),
@@ -244,7 +244,7 @@ void CEditView::DrawBackImage(HDC hdc, RECT& rcPaint, HDC hdcBgImg)
 	}
 	rcImagePos.left += typeConfig.m_backImgPosOffset.x;
 	rcImagePos.top  += typeConfig.m_backImgPosOffset.y;
-	// ƒXƒNƒ[ƒ‹‚Ì‰æ–Ê‚Ì’[‚ğì‰æ‚·‚é‚Æ‚«‚ÌˆÊ’u‚ ‚½‚è‚ÖˆÚ“®
+	// ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ™‚ã®ç”»é¢ã®ç«¯ã‚’ä½œç”»ã™ã‚‹ã¨ãã®ä½ç½®ã‚ãŸã‚Šã¸ç§»å‹•
 	if( typeConfig.m_backImgScrollX ){
 		int tile = typeConfig.m_backImgRepeatX ? doc.m_nBackImgWidth : INT_MAX;
 		Int posX = (area.GetViewLeftCol() % tile) * GetTextMetrics().GetCharPxWidth();
@@ -272,7 +272,7 @@ void CEditView::DrawBackImage(HDC hdc, RECT& rcPaint, HDC hdcBgImg)
 	
 	RECT rc = rcPaint;
 	// rc.left = t_max((int)rc.left, area.GetAreaLeft());
-	rc.top  = t_max((int)rc.top,  area.GetRulerHeight()); // ƒ‹[ƒ‰[‚ğœŠO
+	rc.top  = t_max((int)rc.top,  area.GetRulerHeight()); // ãƒ«ãƒ¼ãƒ©ãƒ¼ã‚’é™¤å¤–
 	const int nXEnd = area.GetAreaRight();
 	const int nYEnd = area.GetAreaBottom();
 	CMyRect rcBltAll;
@@ -313,7 +313,7 @@ void CEditView::DrawBackImage(HDC hdc, RECT& rcPaint, HDC hdcBgImg)
 		}
 	}
 	if( rcBltAll.left != INT_MAX ){
-		// ã‰º¶‰E‚È‚È‚ß‚ÌŒ„ŠÔ‚ğ–„‚ß‚é
+		// ä¸Šä¸‹å·¦å³ãªãªã‚ã®éš™é–“ã‚’åŸ‹ã‚ã‚‹
 		CMyRect rcFill;
 		LONG& x1 = rc.left;
 		LONG& x2 = rcBltAll.left;
@@ -344,19 +344,19 @@ void CEditView::DrawBackImage(HDC hdc, RECT& rcPaint, HDC hdcBgImg)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          Fİ’è                             //
+//                          è‰²è¨­å®š                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*! w’èˆÊ’u‚ÌColorIndex‚Ìæ“¾
-	CEditView::DrawLogicLine‚ğŒ³‚É‚µ‚½‚½‚ßCEditView::DrawLogicLine‚É
-	C³‚ª‚ ‚Á‚½ê‡‚ÍA‚±‚±‚àC³‚ª•K—vB
+/*! æŒ‡å®šä½ç½®ã®ColorIndexã®å–å¾—
+	CEditView::DrawLogicLineã‚’å…ƒã«ã—ãŸãŸã‚CEditView::DrawLogicLineã«
+	ä¿®æ­£ãŒã‚ã£ãŸå ´åˆã¯ã€ã“ã“ã‚‚ä¿®æ­£ãŒå¿…è¦ã€‚
 */
 CColor3Setting CEditView::GetColorIndex(
 	const CLayout*			pcLayout,
 	CLayoutYInt				nLineNum,
 	int						nIndex,
-	SColorStrategyInfo* 	pInfo,			// 2010.03.31 ryoji ’Ç‰Á
-	bool					bPrev			// w’èˆÊ’u‚ÌF•ÏX’¼‘O‚Ü‚Å	2010.06.19 ryoji ’Ç‰Á
+	SColorStrategyInfo* 	pInfo,			// 2010.03.31 ryoji è¿½åŠ 
+	bool					bPrev			// æŒ‡å®šä½ç½®ã®è‰²å¤‰æ›´ç›´å‰ã¾ã§	2010.06.19 ryoji è¿½åŠ 
 )
 {
 	EColorIndexType eRet = COLORIDX_TEXT;
@@ -365,7 +365,7 @@ CColor3Setting CEditView::GetColorIndex(
 		CColor3Setting cColor = { COLORIDX_TEXT, COLORIDX_TEXT, COLORIDX_TEXT };
 		return cColor;
 	}
-	// 2014.12.30 Skipƒ‚[ƒh‚Ì‚àCOLORIDX_TEXT
+	// 2014.12.30 Skipãƒ¢ãƒ¼ãƒ‰ã®æ™‚ã‚‚COLORIDX_TEXT
 	if (CColorStrategyPool::getInstance()->IsSkipBeforeLayout()) {
 		CColor3Setting cColor = { COLORIDX_TEXT, COLORIDX_TEXT, COLORIDX_TEXT };
 		return cColor;
@@ -375,34 +375,34 @@ CColor3Setting CEditView::GetColorIndex(
 	const CLayout* pcLayoutLineFirst = pcLayout;
 	CLayoutYInt nLineNumFirst = nLineNum;
 	{
-		// 2002/2/10 aroka CMemory•ÏX
+		// 2002/2/10 aroka CMemoryå¤‰æ›´
 		pInfo->m_pLineOfLogic = pcLayout->GetDocLineRef()->GetPtr();
 
-		// ˜_—s‚ÌÅ‰‚ÌƒŒƒCƒAƒEƒgî•ñ‚ğæ“¾ -> pcLayoutLineFirst
+		// è«–ç†è¡Œã®æœ€åˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±ã‚’å–å¾— -> pcLayoutLineFirst
 		while( 0 != pcLayoutLineFirst->GetLogicOffset() ){
 			pcLayoutLineFirst = pcLayoutLineFirst->GetPrevLayout();
 			nLineNumFirst--;
 
-			// ˜_—s‚Ìæ“ª‚Ü‚Å–ß‚ç‚È‚¢‚ÆŠmÀ‚É‚Í³Šm‚ÈF‚Í“¾‚ç‚ê‚È‚¢
-			// i³‹K•\Œ»ƒL[ƒ[ƒh‚Éƒ}ƒbƒ`‚µ‚½’·‚¢‹­’²•\¦‚ª‚»‚ÌˆÊ’u‚ÌƒŒƒCƒAƒEƒgs“ª‚ğ‚Ü‚½‚¢‚Å‚¢‚éê‡‚È‚Çj
+			// è«–ç†è¡Œã®å…ˆé ­ã¾ã§æˆ»ã‚‰ãªã„ã¨ç¢ºå®Ÿã«ã¯æ­£ç¢ºãªè‰²ã¯å¾—ã‚‰ã‚Œãªã„
+			// ï¼ˆæ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã«ãƒãƒƒãƒã—ãŸé•·ã„å¼·èª¿è¡¨ç¤ºãŒãã®ä½ç½®ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œé ­ã‚’ã¾ãŸã„ã§ã„ã‚‹å ´åˆãªã©ï¼‰
 			//if( pcLayout->GetLogicOffset() - pcLayoutLineFirst->GetLogicOffset() > 260 )
 			//	break;
 		}
 
-		// 2005.11.20 Moca F‚ª³‚µ‚­‚È‚¢‚±‚Æ‚ª‚ ‚é–â‘è‚É‘Îˆ
-		eRet = pcLayoutLineFirst->GetColorTypePrev();	/* Œ»İ‚ÌF‚ğw’è */	// 02/12/18 ai
+		// 2005.11.20 Moca è‰²ãŒæ­£ã—ããªã„ã“ã¨ãŒã‚ã‚‹å•é¡Œã«å¯¾å‡¦
+		eRet = pcLayoutLineFirst->GetColorTypePrev();	/* ç¾åœ¨ã®è‰²ã‚’æŒ‡å®š */	// 02/12/18 ai
 		colorInfo = pcLayoutLineFirst->GetColorInfo();
 		pInfo->m_nPosInLogic = pcLayoutLineFirst->GetLogicOffset();
 
-		//CColorStrategyPool‰Šú‰»
+		//CColorStrategyPoolåˆæœŸåŒ–
 		CColorStrategyPool* pool = CColorStrategyPool::getInstance();
 		pool->SetCurrentView(this);
 		pool->NotifyOnStartScanLogic();
 
 
-		// 2009.02.07 ryoji ‚±‚ÌŠÖ”‚Å‚Í pInfo->CheckChangeColor() ‚ÅF‚ğ’²‚×‚é‚¾‚¯‚È‚Ì‚ÅˆÈ‰º‚Ìˆ—‚Í•s—v
+		// 2009.02.07 ryoji ã“ã®é–¢æ•°ã§ã¯ pInfo->CheckChangeColor() ã§è‰²ã‚’èª¿ã¹ã‚‹ã ã‘ãªã®ã§ä»¥ä¸‹ã®å‡¦ç†ã¯ä¸è¦
 		//
-		////############’´‰¼B–{“–‚ÍVisitor‚ğg‚¤‚×‚«
+		////############è¶…ä»®ã€‚æœ¬å½“ã¯Visitorã‚’ä½¿ã†ã¹ã
 		//class TmpVisitor{
 		//public:
 		//	static int CalcLayoutIndex(const CLayout* pcLayout)
@@ -416,11 +416,11 @@ CColor3Setting CEditView::GetColorIndex(
 		//	}
 		//};
 		//pInfo->pDispPos->SetLayoutLineRef(CLayoutInt(TmpVisitor::CalcLayoutIndex(pcLayout)));
-		// 2013.12.11 Moca ƒJƒŒƒ“ƒgs‚ÌF‘Ö‚¦‚Å•K—v‚É‚È‚è‚Ü‚µ‚½
+		// 2013.12.11 Moca ã‚«ãƒ¬ãƒ³ãƒˆè¡Œã®è‰²æ›¿ãˆã§å¿…è¦ã«ãªã‚Šã¾ã—ãŸ
 		pInfo->m_pDispPos->SetLayoutLineRef(nLineNumFirst);
 	}
 
-	//•¶š—ñQÆ
+	//æ–‡å­—åˆ—å‚ç…§
 	const CDocLine* pcDocLine = pcLayout->GetDocLineRef();
 	CStringRef cLineStr(pcDocLine->GetPtr(),pcDocLine->GetLengthWithEOL());
 
@@ -439,10 +439,10 @@ CColor3Setting CEditView::GetColorIndex(
 		if( bPrev && pInfo->m_nPosInLogic == nPosTo )
 			break;
 
-		//FØ‘Ö
+		//è‰²åˆ‡æ›¿
 		pInfo->CheckChangeColor(cLineStr);
 
-		//1•¶ši‚Ş
+		//1æ–‡å­—é€²ã‚€
 		pInfo->m_nPosInLogic += CNativeW::GetSizeOfChar(
 									cLineStr.GetPtr(),
 									cLineStr.GetLength(),
@@ -461,27 +461,27 @@ CColor3Setting CEditView::GetColorIndex(
 	return cColor;
 }
 
-/*! Œ»İ‚ÌF‚ğw’è
-	@param eColorIndex   ‘I‘ğ‚ğŠÜ‚ŞŒ»İ‚ÌF
-	@param eColorIndex2  ‘I‘ğˆÈŠO‚ÌŒ»İ‚ÌF
-	@param eColorIndexBg ”wŒiF
+/*! ç¾åœ¨ã®è‰²ã‚’æŒ‡å®š
+	@param eColorIndex   é¸æŠã‚’å«ã‚€ç¾åœ¨ã®è‰²
+	@param eColorIndex2  é¸æŠä»¥å¤–ã®ç¾åœ¨ã®è‰²
+	@param eColorIndexBg èƒŒæ™¯è‰²
 
-	@date 2013.05.08 novice ”ÍˆÍŠOƒ`ƒFƒbƒNíœ
+	@date 2013.05.08 novice ç¯„å›²å¤–ãƒã‚§ãƒƒã‚¯å‰Šé™¤
 */
 void CEditView::SetCurrentColor( CGraphics& gr, EColorIndexType eColorIndex,  EColorIndexType eColorIndex2, EColorIndexType eColorIndexBg)
 {
-	//ƒCƒ“ƒfƒbƒNƒXŒˆ’è
+	//ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹æ±ºå®š
 	int		nColorIdx = ToColorInfoArrIndex(eColorIndex);
 	int		nColorIdx2 = ToColorInfoArrIndex(eColorIndex2);
 	int		nColorIdxBg = ToColorInfoArrIndex(eColorIndexBg);
 
-	//ÀÛ‚ÉF‚ğİ’è
+	//å®Ÿéš›ã«è‰²ã‚’è¨­å®š
 	const ColorInfo& info  = m_pTypeData->m_ColorInfoArr[nColorIdx];
 	const ColorInfo& info2 = m_pTypeData->m_ColorInfoArr[nColorIdx2];
 	const ColorInfo& infoBg = m_pTypeData->m_ColorInfoArr[nColorIdxBg];
 	COLORREF fgcolor = GetTextColorByColorInfo2(info, info2);
 	gr.SetTextForeColor(fgcolor);
-	// 2012.11.21 ”wŒiF‚ªƒeƒLƒXƒg‚Æ‚¨‚È‚¶‚È‚ç”wŒiF‚ÍƒJ[ƒ\ƒ‹s”wŒi
+	// 2012.11.21 èƒŒæ™¯è‰²ãŒãƒ†ã‚­ã‚¹ãƒˆã¨ãŠãªã˜ãªã‚‰èƒŒæ™¯è‰²ã¯ã‚«ãƒ¼ã‚½ãƒ«è¡ŒèƒŒæ™¯
 	const ColorInfo& info3 = (info2.m_sColorAttr.m_cBACK == m_crBack ? infoBg : info2);
 	COLORREF bkcolor = (nColorIdx == nColorIdx2) ? info3.m_sColorAttr.m_cBACK : GetBackColorByColorInfo2(info, info3);
 	gr.SetTextBackColor(bkcolor);
@@ -530,7 +530,7 @@ COLORREF CEditView::GetTextColorByColorInfo2(const ColorInfo& info, const ColorI
 	if( info.m_sColorAttr.m_cTEXT != info.m_sColorAttr.m_cBACK ){
 		return info.m_sColorAttr.m_cTEXT;
 	}
-	// ”½“]•\¦
+	// åè»¢è¡¨ç¤º
 	if( info.m_sColorAttr.m_cBACK == m_crBack ){
 		return  info2.m_sColorAttr.m_cTEXT ^ 0x00FFFFFF;
 	}
@@ -543,7 +543,7 @@ COLORREF CEditView::GetBackColorByColorInfo2(const ColorInfo& info, const ColorI
 	if( info.m_sColorAttr.m_cTEXT != info.m_sColorAttr.m_cBACK ){
 		return info.m_sColorAttr.m_cBACK;
 	}
-	// ”½“]•\¦
+	// åè»¢è¡¨ç¤º
 	if( info.m_sColorAttr.m_cBACK == m_crBack ){
 		return  info2.m_sColorAttr.m_cBACK ^ 0x00FFFFFF;
 	}
@@ -553,7 +553,7 @@ COLORREF CEditView::GetBackColorByColorInfo2(const ColorInfo& info, const ColorI
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           •`‰æ                              //
+//                           æç”»                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void CEditView::OnPaint( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp )
@@ -571,21 +571,21 @@ void CEditView::OnPaint( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp 
 	}
 }
 
-/*! ’Êí‚Ì•`‰æˆ— new 
-	@param pPs  pPs.rcPaint ‚Í³‚µ‚¢•K—v‚ª‚ ‚é
-	@param bDrawFromComptibleBmp  TRUE ‰æ–Êƒoƒbƒtƒ@‚©‚çhdc‚Éì‰æ‚·‚é(ƒRƒs[‚·‚é‚¾‚¯)B
-			TRUE‚Ìê‡ApPs.rcPaint—ÌˆæŠO‚Íì‰æ‚³‚ê‚È‚¢‚ªAFALSE‚Ìê‡‚Íì‰æ‚³‚ê‚é–‚ª‚ ‚éB
-			ŒİŠ·DC/BMP‚ª–³‚¢ê‡‚ÍA•’Ê‚Ìì‰æˆ—‚ğ‚·‚éB
+/*! é€šå¸¸ã®æç”»å‡¦ç† new 
+	@param pPs  pPs.rcPaint ã¯æ­£ã—ã„å¿…è¦ãŒã‚ã‚‹
+	@param bDrawFromComptibleBmp  TRUE ç”»é¢ãƒãƒƒãƒ•ã‚¡ã‹ã‚‰hdcã«ä½œç”»ã™ã‚‹(ã‚³ãƒ”ãƒ¼ã™ã‚‹ã ã‘)ã€‚
+			TRUEã®å ´åˆã€pPs.rcPainté ˜åŸŸå¤–ã¯ä½œç”»ã•ã‚Œãªã„ãŒã€FALSEã®å ´åˆã¯ä½œç”»ã•ã‚Œã‚‹äº‹ãŒã‚ã‚‹ã€‚
+			äº’æ›DC/BMPãŒç„¡ã„å ´åˆã¯ã€æ™®é€šã®ä½œç”»å‡¦ç†ã‚’ã™ã‚‹ã€‚
 
-	@date 2007.09.09 Moca Œ³X–³Œø‰»‚³‚ê‚Ä‚¢‚½‘æOƒpƒ‰ƒ[ƒ^‚ÌbUseMemoryDC‚ğbDrawFromComptibleBmp‚É•ÏXB
-	@date 2009.03.26 ryoji s”Ô†‚Ì‚İ•`‰æ‚ğ’Êí‚Ìs•`‰æ‚Æ•ª—£iŒø—¦‰»j
+	@date 2007.09.09 Moca å…ƒã€…ç„¡åŠ¹åŒ–ã•ã‚Œã¦ã„ãŸç¬¬ä¸‰ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®bUseMemoryDCã‚’bDrawFromComptibleBmpã«å¤‰æ›´ã€‚
+	@date 2009.03.26 ryoji è¡Œç•ªå·ã®ã¿æç”»ã‚’é€šå¸¸ã®è¡Œæç”»ã¨åˆ†é›¢ï¼ˆåŠ¹ç‡åŒ–ï¼‰
 */
 void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp )
 {
 //	MY_RUNNINGTIMER( cRunningTimer, "CEditView::OnPaint" );
 	CGraphics gr(_hdc);
 
-	// 2004.01.28 Moca ƒfƒXƒNƒgƒbƒv‚Éì‰æ‚µ‚È‚¢‚æ‚¤‚É
+	// 2004.01.28 Moca ãƒ‡ã‚¹ã‚¯ãƒˆãƒƒãƒ—ã«ä½œç”»ã—ãªã„ã‚ˆã†ã«
 	if( NULL == GetHwnd() || NULL == _hdc )return;
 
 	if( !GetDrawSwitch() )return;
@@ -600,8 +600,8 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 		);
 #endif
 	
-	// From Here 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
-	// ŒİŠ·BMP‚©‚ç‚Ì“]‘—‚Ì‚İ‚É‚æ‚éì‰æ
+	// From Here 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
+	// äº’æ›BMPã‹ã‚‰ã®è»¢é€ã®ã¿ã«ã‚ˆã‚‹ä½œç”»
 	if( bDrawFromComptibleBmp
 		&& m_hdcCompatDC && m_hbmpCompatBMP ){
 		::BitBlt(
@@ -616,7 +616,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 			SRCCOPY
 		);
 		if ( m_pcEditWnd->GetActivePane() == m_nMyIndex ){
-			/* ƒAƒNƒeƒBƒuƒyƒCƒ“‚ÍAƒAƒ“ƒ_[ƒ‰ƒCƒ“•`‰æ */
+			/* ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ãƒšã‚¤ãƒ³ã¯ã€ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³æç”» */
 			GetCaret().m_cUnderLine.CaretUnderLineON( true, false );
 		}
 		return;
@@ -630,7 +630,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 	}
 	// To Here 2007.09.09 Moca
 
-	// ƒLƒƒƒŒƒbƒg‚ğ‰B‚·
+	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’éš ã™
 	bool bCaretShowFlag_Old = GetCaret().GetCaretShowFlag();	// 2008.06.09 ryoji
 	GetCaret().HideCaret_( this->GetHwnd() ); // 2002/07/22 novice
 
@@ -639,22 +639,22 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 	int				nLineHeight = GetTextMetrics().GetHankakuDy();
 	int				nCharDx = GetTextMetrics().GetCharPxWidth();
 
-	//ƒTƒ|[ƒg
+	//ã‚µãƒãƒ¼ãƒˆ
 	CTypeSupport cTextType(this,COLORIDX_TEXT);
 
 //@@@ 2001.11.17 add start MIK
-	//•ÏX‚ª‚ ‚ê‚Îƒ^ƒCƒvİ’è‚ğs‚¤B
-	if( m_pTypeData->m_bUseRegexKeyword || m_cRegexKeyword->m_bUseRegexKeyword ) //OFF‚È‚Ì‚É‘O‰ñ‚Ìƒf[ƒ^‚ªc‚Á‚Ä‚é
+	//å¤‰æ›´ãŒã‚ã‚Œã°ã‚¿ã‚¤ãƒ—è¨­å®šã‚’è¡Œã†ã€‚
+	if( m_pTypeData->m_bUseRegexKeyword || m_cRegexKeyword->m_bUseRegexKeyword ) //OFFãªã®ã«å‰å›ã®ãƒ‡ãƒ¼ã‚¿ãŒæ®‹ã£ã¦ã‚‹
 	{
-		//ƒ^ƒCƒv•Êİ’è‚ğ‚·‚éBİ’èÏ‚İ‚©‚Ç‚¤‚©‚ÍŒÄ‚Ñæ‚Åƒ`ƒFƒbƒN‚·‚éB
+		//ã‚¿ã‚¤ãƒ—åˆ¥è¨­å®šã‚’ã™ã‚‹ã€‚è¨­å®šæ¸ˆã¿ã‹ã©ã†ã‹ã¯å‘¼ã³å…ˆã§ãƒã‚§ãƒƒã‚¯ã™ã‚‹ã€‚
 		m_cRegexKeyword->RegexKeySetTypes(m_pTypeData);
 	}
 //@@@ 2001.11.17 add end MIK
 
 	bool bTransText = IsBkBitmap();
-	// ƒƒ‚ƒŠ‚c‚b‚ğ—˜—p‚µ‚½Ä•`‰æ‚Ìê‡‚Í•`‰ææ‚Ì‚c‚b‚ğØ‚è‘Ö‚¦‚é
+	// ãƒ¡ãƒ¢ãƒªï¼¤ï¼£ã‚’åˆ©ç”¨ã—ãŸå†æç”»ã®å ´åˆã¯æç”»å…ˆã®ï¼¤ï¼£ã‚’åˆ‡ã‚Šæ›¿ãˆã‚‹
 	HDC hdcOld = 0;
-	// 2007.09.09 Moca bUseMemoryDC‚ğ—LŒø‰»B
+	// 2007.09.09 Moca bUseMemoryDCã‚’æœ‰åŠ¹åŒ–ã€‚
 	// bUseMemoryDC = FALSE;
 	BOOL bUseMemoryDC = (m_hdcCompatDC != NULL);
 	assert_warning(gr != m_hdcCompatDC);
@@ -664,17 +664,17 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 		gr = m_hdcCompatDC;
 	}else{
 		if( bTransText || pPs->rcPaint.bottom - pPs->rcPaint.top <= 2 || pPs->rcPaint.right - pPs->rcPaint.left <= 2 ){
-			// “§‰ßˆ—‚Ìê‡ƒtƒHƒ“ƒg‚Ì—ÖŠs‚ªd‚Ë“h‚è‚É‚È‚é‚½‚ß©•ª‚ÅƒNƒŠƒbƒsƒ“ƒO—Ìˆæ‚ğİ’è
-			// 2ˆÈ‰º‚Í‚½‚Ô‚ñƒAƒ“ƒ_[ƒ‰ƒCƒ“EƒJ[ƒ\ƒ‹scü‚Ìì‰æ
-			// MemoryDC‚Ìê‡‚Í“]‘—‚ª‹éŒ`ƒNƒŠƒbƒsƒ“ƒO‚Ì‘ã‚í‚è‚É‚È‚Á‚Ä‚¢‚é
+			// é€éå‡¦ç†ã®å ´åˆãƒ•ã‚©ãƒ³ãƒˆã®è¼ªéƒ­ãŒé‡ã­å¡—ã‚Šã«ãªã‚‹ãŸã‚è‡ªåˆ†ã§ã‚¯ãƒªãƒƒãƒ”ãƒ³ã‚°é ˜åŸŸã‚’è¨­å®š
+			// 2ä»¥ä¸‹ã¯ãŸã¶ã‚“ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ãƒ»ã‚«ãƒ¼ã‚½ãƒ«è¡Œç¸¦ç·šã®ä½œç”»
+			// MemoryDCã®å ´åˆã¯è»¢é€ãŒçŸ©å½¢ã‚¯ãƒªãƒƒãƒ”ãƒ³ã‚°ã®ä»£ã‚ã‚Šã«ãªã£ã¦ã„ã‚‹
 			gr.SetClipping(pPs->rcPaint);
 			bClipping = true;
 		}
 	}
 
-	/* 03/02/18 ‘ÎŠ‡ŒÊ‚Ì‹­’²•\¦(Á‹) ai */
+	/* 03/02/18 å¯¾æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤º(æ¶ˆå») ai */
 	if( !bUseMemoryDC ){
-		// MemoryDC‚¾‚ÆƒXƒNƒ[ƒ‹‚Éæ‚ÉŠ‡ŒÊ‚¾‚¯•\¦‚³‚ê‚Ä•s©‘R‚È‚Ì‚ÅŒã‚Å‚â‚éB
+		// MemoryDCã ã¨ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ™‚ã«å…ˆã«æ‹¬å¼§ã ã‘è¡¨ç¤ºã•ã‚Œã¦ä¸è‡ªç„¶ãªã®ã§å¾Œã§ã‚„ã‚‹ã€‚
 		DrawBracketPair( false );
 	}
 
@@ -682,7 +682,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 	m_nPageViewTop = cActiveView.GetTextArea().GetViewTopLine();
 	m_nPageViewBottom = cActiveView.GetTextArea().GetBottomLine();
 
-	// ”wŒi‚Ì•\¦
+	// èƒŒæ™¯ã®è¡¨ç¤º
 	if( bTransText ){
 		HDC hdcBgImg = CreateCompatibleDC(gr);
 		HBITMAP hOldBmp = (HBITMAP)::SelectObject(hdcBgImg, m_pcEditDoc->m_hBackImg);
@@ -691,8 +691,8 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 		DeleteObject(hdcBgImg);
 	}
 
-	/* ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŠÔ‚Ì—]”’ */
-	//@@@ 2002.01.03 YAZAKI —]”’‚ª0‚Ì‚Æ‚«‚Í–³‘Ê‚Å‚µ‚½B
+	/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®é–“ã®ä½™ç™½ */
+	//@@@ 2002.01.03 YAZAKI ä½™ç™½ãŒ0ã®ã¨ãã¯ç„¡é§„ã§ã—ãŸã€‚
 	if ( GetTextArea().GetTopYohaku() ){
 		if( !bTransText ){
 			rc.left   = 0;
@@ -703,15 +703,15 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 		}
 	}
 
-	/* s”Ô†‚Ì•\¦ */
+	/* è¡Œç•ªå·ã®è¡¨ç¤º */
 	//	From Here Sep. 7, 2001 genta
-	//	Sep. 23, 2002 genta s”Ô†”ñ•\¦‚Å‚às”Ô†F‚Ì‘Ñ‚ª‚ ‚é‚Ì‚ÅŒ„ŠÔ‚ğ–„‚ß‚é
+	//	Sep. 23, 2002 genta è¡Œç•ªå·éè¡¨ç¤ºã§ã‚‚è¡Œç•ªå·è‰²ã®å¸¯ãŒã‚ã‚‹ã®ã§éš™é–“ã‚’åŸ‹ã‚ã‚‹
 	if( GetTextArea().GetTopYohaku() ){
 		if( bTransText && m_pTypeData->m_ColorInfoArr[COLORIDX_GYOU].m_sColorAttr.m_cBACK == cTextType.GetBackColor() ){
 		}else{
 			rc.left   = 0;
 			rc.top    = GetTextArea().GetRulerHeight();
-			rc.right  = GetTextArea().GetLineNumberWidth(); //	Sep. 23 ,2002 genta —]”’‚ÍƒeƒLƒXƒgF‚Ì‚Ü‚Üc‚·
+			rc.right  = GetTextArea().GetLineNumberWidth(); //	Sep. 23 ,2002 genta ä½™ç™½ã¯ãƒ†ã‚­ã‚¹ãƒˆè‰²ã®ã¾ã¾æ®‹ã™
 			rc.bottom = GetTextArea().GetAreaTop();
 			gr.SetTextBackColor(m_pTypeData->m_ColorInfoArr[COLORIDX_GYOU].m_sColorAttr.m_cBACK);
 			gr.FillMyRectTextBackColor(rc);
@@ -727,26 +727,26 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 	int nTop = pPs->rcPaint.top;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//           •`‰æŠJnƒŒƒCƒAƒEƒgâ‘Îs -> nLayoutLine             //
+	//           æç”»é–‹å§‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆçµ¶å¯¾è¡Œ -> nLayoutLine             //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	CLayoutInt nLayoutLine;
 	if( 0 > nTop - GetTextArea().GetAreaTop() ){
-		nLayoutLine = GetTextArea().GetViewTopLine(); //ƒrƒ…[ã•”‚©‚ç•`‰æ
+		nLayoutLine = GetTextArea().GetViewTopLine(); //ãƒ“ãƒ¥ãƒ¼ä¸Šéƒ¨ã‹ã‚‰æç”»
 	}else{
-		nLayoutLine = GetTextArea().GetViewTopLine() + CLayoutInt( ( nTop - GetTextArea().GetAreaTop() ) / nLineHeight ); //ƒrƒ…[“r’†‚©‚ç•`‰æ
+		nLayoutLine = GetTextArea().GetViewTopLine() + CLayoutInt( ( nTop - GetTextArea().GetAreaTop() ) / nLineHeight ); //ãƒ“ãƒ¥ãƒ¼é€”ä¸­ã‹ã‚‰æç”»
 	}
 
-	// ¦ ‚±‚±‚É‚ ‚Á‚½•`‰æ”ÍˆÍ‚Ì 260 •¶šƒ[ƒ‹ƒoƒbƒNˆ—‚Í GetColorIndex() ‚É‹zû	// 2009.02.11 ryoji
+	// â€» ã“ã“ã«ã‚ã£ãŸæç”»ç¯„å›²ã® 260 æ–‡å­—ãƒ­ãƒ¼ãƒ«ãƒãƒƒã‚¯å‡¦ç†ã¯ GetColorIndex() ã«å¸å	// 2009.02.11 ryoji
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//          •`‰æI—¹ƒŒƒCƒAƒEƒgâ‘Îs -> nLayoutLineTo            //
+	//          æç”»çµ‚äº†ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆçµ¶å¯¾è¡Œ -> nLayoutLineTo            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	CLayoutInt nLayoutLineTo = GetTextArea().GetViewTopLine()
-		+ CLayoutInt( ( pPs->rcPaint.bottom - GetTextArea().GetAreaTop() + (nLineHeight - 1) ) / nLineHeight ) - 1;	// 2007.02.17 ryoji ŒvZ‚ğ¸–§‰»
+		+ CLayoutInt( ( pPs->rcPaint.bottom - GetTextArea().GetAreaTop() + (nLineHeight - 1) ) / nLineHeight ) - 1;	// 2007.02.17 ryoji è¨ˆç®—ã‚’ç²¾å¯†åŒ–
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         •`‰æÀ•W                            //
+	//                         æç”»åº§æ¨™                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	DispPos sPos(nCharDx, GetTextMetrics().GetHankakuDy());
 	sPos.InitDrawPos(CMyPoint(
@@ -757,33 +757,33 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ‘S•”‚Ìs‚ğ•`‰æ                         //
+	//                      å…¨éƒ¨ã®è¡Œã‚’æç”»                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//•K—v‚Ès‚ğ•`‰æ‚·‚é	// 2009.03.26 ryoji s”Ô†‚Ì‚İ•`‰æ‚ğ’Êí‚Ìs•`‰æ‚Æ•ª—£iŒø—¦‰»j
+	//å¿…è¦ãªè¡Œã‚’æç”»ã™ã‚‹	// 2009.03.26 ryoji è¡Œç•ªå·ã®ã¿æç”»ã‚’é€šå¸¸ã®è¡Œæç”»ã¨åˆ†é›¢ï¼ˆåŠ¹ç‡åŒ–ï¼‰
 	if(pPs->rcPaint.right <= GetTextArea().GetAreaLeft()){
 		while(sPos.GetLayoutLineRef() <= nLayoutLineTo)
 		{
 			if(!sPos.GetLayoutRef())
 				break;
 
-			//1s•`‰æis”Ô†‚Ì‚İj
+			//1è¡Œæç”»ï¼ˆè¡Œç•ªå·ã®ã¿ï¼‰
 			GetTextDrawer().DispLineNumber(
 				gr,
 				sPos.GetLayoutLineRef(),
 				sPos.GetDrawPos().y
 			);
-			//s‚ği‚ß‚é
-			sPos.ForwardDrawLine(1);		//•`‰æYÀ•W{{
-			sPos.ForwardLayoutLineRef(1);	//ƒŒƒCƒAƒEƒgs{{
+			//è¡Œã‚’é€²ã‚ã‚‹
+			sPos.ForwardDrawLine(1);		//æç”»Yåº§æ¨™ï¼‹ï¼‹
+			sPos.ForwardLayoutLineRef(1);	//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œï¼‹ï¼‹
 		}
 	}else{
 		while(sPos.GetLayoutLineRef() <= nLayoutLineTo)
 		{
-			//•`‰æXˆÊ’uƒŠƒZƒbƒg
+			//æç”»Xä½ç½®ãƒªã‚»ãƒƒãƒˆ
 			sPos.ResetDrawCol();
 
-			//1s•`‰æ
+			//1è¡Œæç”»
 			bool bDispResult = DrawLogicLine(
 				gr,
 				&sPos,
@@ -791,7 +791,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 			);
 
 			if(bDispResult){
-				// EOFÄ•`‰æ‘Î‰
+				// EOFå†æç”»å¯¾å¿œ
 				nLayoutLineTo++;
 				int nBackImageTop = pPs->rcPaint.bottom;
 				pPs->rcPaint.bottom += nLineHeight;
@@ -815,19 +815,19 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                       ƒ‹[ƒ‰[•`‰æ                          //
+	//                       ãƒ«ãƒ¼ãƒ©ãƒ¼æç”»                          //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	if ( pPs->rcPaint.top < GetTextArea().GetRulerHeight() ) { // ƒ‹[ƒ‰[‚ªÄ•`‰æ”ÍˆÍ‚É‚ ‚é‚Æ‚«‚Ì‚İÄ•`‰æ‚·‚é 2002.02.25 Add By KK
-		GetRuler().SetRedrawFlag(); //2002.02.25 Add By KK ƒ‹[ƒ‰[‘S‘Ì‚ğ•`‰æB
+	if ( pPs->rcPaint.top < GetTextArea().GetRulerHeight() ) { // ãƒ«ãƒ¼ãƒ©ãƒ¼ãŒå†æç”»ç¯„å›²ã«ã‚ã‚‹ã¨ãã®ã¿å†æç”»ã™ã‚‹ 2002.02.25 Add By KK
+		GetRuler().SetRedrawFlag(); //2002.02.25 Add By KK ãƒ«ãƒ¼ãƒ©ãƒ¼å…¨ä½“ã‚’æç”»ã€‚
 		GetRuler().DispRuler( gr );
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                     ‚»‚Ì‘¼Œãn––‚È‚Ç                        //
+	//                     ãã®ä»–å¾Œå§‹æœ«ãªã©                        //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	/* ƒƒ‚ƒŠ‚c‚b‚ğ—˜—p‚µ‚½Ä•`‰æ‚Ìê‡‚Íƒƒ‚ƒŠ‚c‚b‚É•`‰æ‚µ‚½“à—e‚ğ‰æ–Ê‚ÖƒRƒs[‚·‚é */
+	/* ãƒ¡ãƒ¢ãƒªï¼¤ï¼£ã‚’åˆ©ç”¨ã—ãŸå†æç”»ã®å ´åˆã¯ãƒ¡ãƒ¢ãƒªï¼¤ï¼£ã«æç”»ã—ãŸå†…å®¹ã‚’ç”»é¢ã¸ã‚³ãƒ”ãƒ¼ã™ã‚‹ */
 	if( bUseMemoryDC ){
-		// 2010.10.11 æ‚É•`‚­‚Æ”wŒiŒÅ’è‚ÌƒXƒNƒ[ƒ‹‚È‚Ç‚Å‚Ì•\¦‚ª•s©‘R‚É‚È‚é
+		// 2010.10.11 å…ˆã«æãã¨èƒŒæ™¯å›ºå®šã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãªã©ã§ã®è¡¨ç¤ºãŒä¸è‡ªç„¶ã«ãªã‚‹
 		DrawBracketPair( false );
 
 		::BitBlt(
@@ -843,37 +843,37 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 		);
 	}
 
-	// From Here 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
-	//     ƒAƒ“ƒ_[ƒ‰ƒCƒ“•`‰æ‚ğƒƒ‚ƒŠDC‚©‚ç‚ÌƒRƒs[‘Oˆ—‚©‚çŒã‚ÉˆÚ“®
+	// From Here 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
+	//     ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³æç”»ã‚’ãƒ¡ãƒ¢ãƒªDCã‹ã‚‰ã®ã‚³ãƒ”ãƒ¼å‰å‡¦ç†ã‹ã‚‰å¾Œã«ç§»å‹•
 	if ( m_pcEditWnd->GetActivePane() == m_nMyIndex ){
-		/* ƒAƒNƒeƒBƒuƒyƒCƒ“‚ÍAƒAƒ“ƒ_[ƒ‰ƒCƒ“•`‰æ */
+		/* ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ãƒšã‚¤ãƒ³ã¯ã€ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³æç”» */
 		GetCaret().m_cUnderLine.CaretUnderLineON( true, false );
 	}
 	// To Here 2007.09.09 Moca
 
-	/* 03/02/18 ‘ÎŠ‡ŒÊ‚Ì‹­’²•\¦(•`‰æ) ai */
+	/* 03/02/18 å¯¾æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤º(æç”») ai */
 	DrawBracketPair( true );
 
-	/* ƒLƒƒƒŒƒbƒg‚ğŒ»İˆÊ’u‚É•\¦‚µ‚Ü‚· */
+	/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’ç¾åœ¨ä½ç½®ã«è¡¨ç¤ºã—ã¾ã™ */
 	if( bCaretShowFlag_Old )	// 2008.06.09 ryoji
 		GetCaret().ShowCaret_( this->GetHwnd() ); // 2002/07/22 novice
 	return;
 }
 
 /*!
-	s‚ÌƒeƒLƒXƒg^‘I‘ğó‘Ô‚Ì•`‰æ
-	1‰ñ‚Å1ƒƒWƒbƒNs•ª‚ğì‰æ‚·‚éB
+	è¡Œã®ãƒ†ã‚­ã‚¹ãƒˆï¼é¸æŠçŠ¶æ…‹ã®æç”»
+	1å›ã§1ãƒ­ã‚¸ãƒƒã‚¯è¡Œåˆ†ã‚’ä½œç”»ã™ã‚‹ã€‚
 
-	@return EOF‚ğì‰æ‚µ‚½‚çtrue
+	@return EOFã‚’ä½œç”»ã—ãŸã‚‰true
 
 	@date 2001.02.17 MIK
-	@date 2001.12.21 YAZAKI ‰üs‹L†‚Ì•`‚«‚©‚½‚ğ•ÏX
-	@date 2007.08.31 kobake ˆø” bDispBkBitmap ‚ğíœ
+	@date 2001.12.21 YAZAKI æ”¹è¡Œè¨˜å·ã®æãã‹ãŸã‚’å¤‰æ›´
+	@date 2007.08.31 kobake å¼•æ•° bDispBkBitmap ã‚’å‰Šé™¤
 */
 bool CEditView::DrawLogicLine(
-	HDC				_hdc,			//!< [in]     ì‰æ‘ÎÛ
-	DispPos*		_pDispPos,		//!< [in,out] •`‰æ‚·‚é‰ÓŠA•`‰æŒ³ƒ\[ƒX
-	CLayoutInt		nLineTo			//!< [in]     ì‰æI—¹‚·‚éƒŒƒCƒAƒEƒgs”Ô†
+	HDC				_hdc,			//!< [in]     ä½œç”»å¯¾è±¡
+	DispPos*		_pDispPos,		//!< [in,out] æç”»ã™ã‚‹ç®‡æ‰€ã€æç”»å…ƒã‚½ãƒ¼ã‚¹
+	CLayoutInt		nLineTo			//!< [in]     ä½œç”»çµ‚äº†ã™ã‚‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œç•ªå·
 )
 {
 //	MY_RUNNINGTIMER( cRunningTimer, "CEditView::DrawLogicLine" );
@@ -884,29 +884,29 @@ bool CEditView::DrawLogicLine(
 	pInfo->m_pDispPos = _pDispPos;
 	pInfo->m_pcView = this;
 
-	//CColorStrategyPool‰Šú‰»
+	//CColorStrategyPoolåˆæœŸåŒ–
 	CColorStrategyPool* pool = CColorStrategyPool::getInstance();
 	pool->SetCurrentView(this);
 	pool->NotifyOnStartScanLogic();
 	bool bSkipBeforeLayout = pool->IsSkipBeforeLayout();
 
-	//DispPos‚ğ•Û‘¶‚µ‚Ä‚¨‚­
+	//DispPosã‚’ä¿å­˜ã—ã¦ãŠã
 	pInfo->m_sDispPosBegin = *pInfo->m_pDispPos;
 
-	//ˆ—‚·‚é•¶šˆÊ’u
-	pInfo->m_nPosInLogic = CLogicInt(0); //™ŠJn
+	//å‡¦ç†ã™ã‚‹æ–‡å­—ä½ç½®
+	pInfo->m_nPosInLogic = CLogicInt(0); //â˜†é–‹å§‹
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//          ˜_—sƒf[ƒ^‚Ìæ“¾ -> pLine, pLineLen              //
+	//          è«–ç†è¡Œãƒ‡ãƒ¼ã‚¿ã®å–å¾— -> pLine, pLineLen              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	// ‘Os‚ÌÅIİ’èF
+	// å‰è¡Œã®æœ€çµ‚è¨­å®šè‰²
 	{
 		const CLayout* pcLayout = pInfo->m_pDispPos->GetLayoutRef();
 		if( bSkipBeforeLayout ){
 			EColorIndexType eRet = COLORIDX_TEXT;
 			const CLayoutColorInfo* colorInfo = NULL;
 			if( pcLayout ){
-				eRet = pcLayout->GetColorTypePrev(); // COLORIDX_TEXT‚Ì‚Í‚¸
+				eRet = pcLayout->GetColorTypePrev(); // COLORIDX_TEXTã®ã¯ãš
 				colorInfo = pcLayout->GetColorInfo();
 			}
 			pInfo->m_pStrategy = pool->GetStrategyByColor(eRet);
@@ -920,14 +920,14 @@ bool CEditView::DrawLogicLine(
 		}
 	}
 
-	//ŠJnƒƒWƒbƒNˆÊ’u‚ğZo
+	//é–‹å§‹ãƒ­ã‚¸ãƒƒã‚¯ä½ç½®ã‚’ç®—å‡º
 	{
 		const CLayout* pcLayout = pInfo->m_pDispPos->GetLayoutRef();
 		pInfo->m_nPosInLogic = pcLayout?pcLayout->GetLogicOffset():CLogicInt(0);
 	}
 
 	for (;;) {
-		//‘ÎÛs‚ª•`‰æ”ÍˆÍŠO‚¾‚Á‚½‚çI—¹
+		//å¯¾è±¡è¡ŒãŒæç”»ç¯„å›²å¤–ã ã£ãŸã‚‰çµ‚äº†
 		if( GetTextArea().GetBottomLine() < pInfo->m_pDispPos->GetLayoutLineRef() ){
 			pInfo->m_pDispPos->SetLayoutLineRef(nLineTo + CLayoutInt(1));
 			break;
@@ -936,20 +936,20 @@ bool CEditView::DrawLogicLine(
 			break;
 		}
 
-		//ƒŒƒCƒAƒEƒgs‚ğ1s•`‰æ
+		//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã‚’1è¡Œæç”»
 		bDispEOF = DrawLayoutLine(pInfo);
 
-		//s‚ği‚ß‚é
+		//è¡Œã‚’é€²ã‚ã‚‹
 		CLogicInt nOldLogicLineNo = pInfo->m_pDispPos->GetLayoutRef()->GetLogicLineNo();
-		pInfo->m_pDispPos->ForwardDrawLine(1);		//•`‰æYÀ•W{{
-		pInfo->m_pDispPos->ForwardLayoutLineRef(1);	//ƒŒƒCƒAƒEƒgs{{
+		pInfo->m_pDispPos->ForwardDrawLine(1);		//æç”»Yåº§æ¨™ï¼‹ï¼‹
+		pInfo->m_pDispPos->ForwardLayoutLineRef(1);	//ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œï¼‹ï¼‹
 
-		// ƒƒWƒbƒNs‚ğ•`‰æ‚µI‚í‚Á‚½‚ç”²‚¯‚é
+		// ãƒ­ã‚¸ãƒƒã‚¯è¡Œã‚’æç”»ã—çµ‚ã‚ã£ãŸã‚‰æŠœã‘ã‚‹
 		if(pInfo->m_pDispPos->GetLayoutRef()->GetLogicLineNo()!=nOldLogicLineNo){
 			break;
 		}
 
-		// nLineTo‚ğ’´‚¦‚½‚ç”²‚¯‚é
+		// nLineToã‚’è¶…ãˆãŸã‚‰æŠœã‘ã‚‹
 		if(pInfo->m_pDispPos->GetLayoutLineRef() >= nLineTo + CLayoutInt(1)){
 			break;
 		}
@@ -959,9 +959,9 @@ bool CEditView::DrawLogicLine(
 }
 
 /*!
-	ƒŒƒCƒAƒEƒgs‚ğ1s•`‰æ
+	ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã‚’1è¡Œæç”»
 */
-//‰üs‹L†‚ğ•`‰æ‚µ‚½ê‡‚Ítrue‚ğ•Ô‚·H
+//æ”¹è¡Œè¨˜å·ã‚’æç”»ã—ãŸå ´åˆã¯trueã‚’è¿”ã™ï¼Ÿ
 bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 {
 	bool bDispEOF = false;
@@ -969,7 +969,7 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 
 	const CLayout* pcLayout = pInfo->m_pDispPos->GetLayoutRef(); //m_pcEditDoc->m_cLayoutMgr.SearchLineByLayoutY( pInfo->pDispPos->GetLayoutLineRef() );
 
-	// ƒŒƒCƒAƒEƒgî•ñ
+	// ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæƒ…å ±
 	if( pcLayout ){
 		pInfo->m_pLineOfLogic = pcLayout->GetDocLineRef()->GetPtr();
 	}
@@ -977,21 +977,21 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		pInfo->m_pLineOfLogic = NULL;
 	}
 
-	//•¶š—ñQÆ
+	//æ–‡å­—åˆ—å‚ç…§
 	const CDocLine* pcDocLine = pInfo->GetDocLine();
 	CStringRef cLineStr = pcDocLine->GetStringRefWithEOL();
 
-	// •`‰æ”ÍˆÍŠO‚Ìê‡‚ÍFØ‘Ö‚¾‚¯‚Å”²‚¯‚é
+	// æç”»ç¯„å›²å¤–ã®å ´åˆã¯è‰²åˆ‡æ›¿ã ã‘ã§æŠœã‘ã‚‹
 	if(pInfo->m_pDispPos->GetDrawPos().y < GetTextArea().GetAreaTop()){
 		if(pcLayout){
 			bool bChange = false;
 			int nPosTo = pcLayout->GetLogicOffset() + pcLayout->GetLengthWithEOL();
 			CColor3Setting cColor;
 			while(pInfo->m_nPosInLogic < nPosTo){
-				//FØ‘Ö
+				//è‰²åˆ‡æ›¿
 				bChange |= pInfo->CheckChangeColor(cLineStr);
 
-				//1•¶ši‚Ş
+				//1æ–‡å­—é€²ã‚€
 				pInfo->m_nPosInLogic += CNativeW::GetSizeOfChar(
 											cLineStr.GetPtr(),
 											cLineStr.GetLength(),
@@ -1006,8 +1006,8 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		return false;
 	}
 
-	// ƒRƒ“ƒtƒBƒO
-	int nLineHeight = GetTextMetrics().GetHankakuDy();  //s‚Ìc•H
+	// ã‚³ãƒ³ãƒ•ã‚£ã‚°
+	int nLineHeight = GetTextMetrics().GetHankakuDy();  //è¡Œã®ç¸¦å¹…ï¼Ÿ
 	CTypeSupport	cCaretLineBg(this, COLORIDX_CARETLINEBG);
 	CTypeSupport	cEvenLineBg(this, COLORIDX_EVENLINEBG);
 	CTypeSupport	cPageViewBg(this, COLORIDX_PAGEVIEW);
@@ -1028,7 +1028,7 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        s”Ô†•`‰æ                           //
+	//                        è¡Œç•ªå·æç”»                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	GetTextDrawer().DispLineNumber(
 		pInfo->m_gr,
@@ -1038,13 +1038,13 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                       –{•¶•`‰æŠJn                          //
+	//                       æœ¬æ–‡æç”»é–‹å§‹                          //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	pInfo->m_pDispPos->ResetDrawCol();
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                 s“ª(ƒCƒ“ƒfƒ“ƒg)”wŒi•`‰æ                    //
+	//                 è¡Œé ­(ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ)èƒŒæ™¯æç”»                    //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	if(pcLayout && pcLayout->GetIndent()!=0)
 	{
@@ -1052,43 +1052,43 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		if(!bTransText && GetTextArea().GenerateClipRect(&rcClip, *pInfo->m_pDispPos, pcLayout->GetIndent())){
 			cBackType.FillBack(pInfo->m_gr,rcClip);
 		}
-		//•`‰æˆÊ’ui‚ß‚é
+		//æç”»ä½ç½®é€²ã‚ã‚‹
 		pInfo->m_pDispPos->ForwardDrawCol(pcLayout->GetIndent());
 	}
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         –{•¶•`‰æ                            //
+	//                         æœ¬æ–‡æç”»                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	bool bSkipRight = false; // ‘±‚«‚ğ•`‰æ‚µ‚È‚­‚Ä‚¢‚¢ê‡‚ÍƒXƒLƒbƒv‚·‚é
+	bool bSkipRight = false; // ç¶šãã‚’æç”»ã—ãªãã¦ã„ã„å ´åˆã¯ã‚¹ã‚­ãƒƒãƒ—ã™ã‚‹
 	if(pcLayout){
 		const CLayout* pcLayoutNext = pcLayout->GetNextLayout();
 		if( NULL == pcLayoutNext ){
 			bSkipRight = true;
 		}else if( pcLayoutNext->GetLogicOffset() == 0 ){
-			bSkipRight = true; // Ÿ‚Ìs‚Í•Ê‚ÌƒƒWƒbƒNs‚È‚Ì‚ÅƒXƒLƒbƒv‰Â”\
+			bSkipRight = true; // æ¬¡ã®è¡Œã¯åˆ¥ã®ãƒ­ã‚¸ãƒƒã‚¯è¡Œãªã®ã§ã‚¹ã‚­ãƒƒãƒ—å¯èƒ½
 		}
 		if( !bSkipRight ){
 			bSkipRight = CColorStrategyPool::getInstance()->IsSkipBeforeLayout();
 		}
 	}
-	//sI’[‚Ü‚½‚ÍÜ‚è•Ô‚µ‚É’B‚·‚é‚Ü‚Åƒ‹[ƒv
+	//è¡Œçµ‚ç«¯ã¾ãŸã¯æŠ˜ã‚Šè¿”ã—ã«é”ã™ã‚‹ã¾ã§ãƒ«ãƒ¼ãƒ—
 	if(pcLayout){
 		int nPosTo = pcLayout->GetLogicOffset() + pcLayout->GetLengthWithEOL();
 		CFigureManager* pcFigureManager = CFigureManager::getInstance();
 		while(pInfo->m_nPosInLogic < nPosTo){
-			//FØ‘Ö
+			//è‰²åˆ‡æ›¿
 			if( pInfo->CheckChangeColor(cLineStr) ){
 				CColor3Setting cColor;
 				pInfo->DoChangeColor(&cColor);
 				SetCurrentColor(pInfo->m_gr, cColor.eColorIndex, cColor.eColorIndex2, cColor.eColorIndexBg);
 			}
 
-			//1•¶šî•ñæ“¾ $$‚‘¬‰»‰Â”\
+			//1æ–‡å­—æƒ…å ±å–å¾— $$é«˜é€ŸåŒ–å¯èƒ½
 			CFigure& cFigure = pcFigureManager->GetFigure(&cLineStr.GetPtr()[pInfo->GetPosInLogic()],
 				cLineStr.GetLength() - pInfo->GetPosInLogic());
 
-			//1•¶š•`‰æ
+			//1æ–‡å­—æç”»
 			cFigure.DrawImp(pInfo);
 			if( bSkipRight && GetTextArea().GetAreaRight() < pInfo->m_pDispPos->GetDrawPos().x ){
 				pInfo->m_nPosInLogic = nPosTo;
@@ -1097,15 +1097,15 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		}
 	}
 
-	// •K—v‚È‚çEOF•`‰æ
+	// å¿…è¦ãªã‚‰EOFæç”»
 	void _DispEOF( CGraphics& gr, DispPos* pDispPos, const CEditView* pcView);
 	if(pcLayout && pcLayout->GetNextLayout()==NULL && pcLayout->GetLayoutEol().GetLen()==0){
-		// —L•¶šs‚ÌEOF
+		// æœ‰æ–‡å­—è¡Œã®EOF
 		_DispEOF(pInfo->m_gr,pInfo->m_pDispPos,this);
 		bDispEOF = true;
 	}
 	else if(!pcLayout && pInfo->m_pDispPos->GetLayoutLineRef()==m_pcEditDoc->m_cLayoutMgr.GetLineCount()){
-		// ‹ós‚ÌEOF
+		// ç©ºè¡Œã®EOF
 		const CLayout* pBottom = m_pcEditDoc->m_cLayoutMgr.GetBottomLayout();
 		if(pBottom==NULL || (pBottom && pBottom->GetLayoutEol().GetLen())){
 			_DispEOF(pInfo->m_gr,pInfo->m_pDispPos,this);
@@ -1113,12 +1113,12 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		}
 	}
 
-	// •K—v‚È‚çÜ‚è•Ô‚µ‹L†•`‰æ
+	// å¿…è¦ãªã‚‰æŠ˜ã‚Šè¿”ã—è¨˜å·æç”»
 	if(pcLayout && pcLayout->GetLayoutEol().GetLen()==0 && pcLayout->GetNextLayout()!=NULL){
 		_DispWrap(pInfo->m_gr,pInfo->m_pDispPos,this,pInfo->m_pDispPos->GetLayoutLineRef());
 	}
 
-	// s––”wŒi•`‰æ
+	// è¡Œæœ«èƒŒæ™¯æç”»
 	RECT rcClip;
 	bool rcClipRet = GetTextArea().GenerateClipRectRight(&rcClip,*pInfo->m_pDispPos);
 	if(rcClipRet){
@@ -1127,9 +1127,9 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		}
 		CTypeSupport cSelectType(this, COLORIDX_SELECT);
 		if( GetSelectionInfo().IsTextSelected() && cSelectType.IsDisp() ){
-			// ‘I‘ğ”ÍˆÍ‚Ìw’èFF•K—v‚È‚çƒeƒLƒXƒg‚Ì‚È‚¢•”•ª‚Ì‹éŒ`‘I‘ğ‚ğì‰æ
+			// é¸æŠç¯„å›²ã®æŒ‡å®šè‰²ï¼šå¿…è¦ãªã‚‰ãƒ†ã‚­ã‚¹ãƒˆã®ãªã„éƒ¨åˆ†ã®çŸ©å½¢é¸æŠã‚’ä½œç”»
 			CLayoutRange selectArea = GetSelectionInfo().GetSelectAreaLine(pInfo->m_pDispPos->GetLayoutLineRef(), pcLayout);
-			// 2010.10.04 ƒXƒNƒ[ƒ‹•ª‚Ì‘«‚µ–Y‚ê
+			// 2010.10.04 ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«åˆ†ã®è¶³ã—å¿˜ã‚Œ
 			CPixelXInt nSelectFromPx =  GetTextMetrics().GetCharPxWidth(selectArea.GetFrom().x - GetTextArea().GetViewLeftCol());
 			CPixelXInt nSelectToPx   = GetTextMetrics().GetCharPxWidth(selectArea.GetTo().x - GetTextArea().GetViewLeftCol());
 			if( nSelectFromPx < nSelectToPx && selectArea.GetTo().x != INT_MAX ){
@@ -1149,7 +1149,7 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		}
 	}
 
-	// ƒm[ƒgü•`‰æ
+	// ãƒãƒ¼ãƒˆç·šæç”»
 	if( !m_bMiniMap ){
 		GetTextDrawer().DispNoteLine(
 			pInfo->m_gr,
@@ -1160,7 +1160,7 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		);
 	}
 
-	// w’èŒ…cü•`‰æ
+	// æŒ‡å®šæ¡ç¸¦ç·šæç”»
 	GetTextDrawer().DispVerticalLines(
 		pInfo->m_gr,
 		pInfo->m_pDispPos->GetDrawPos().y,
@@ -1169,7 +1169,7 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		CLayoutInt(-1)
 	);
 
-	// Ü‚è•Ô‚µŒ…cü•`‰æ
+	// æŠ˜ã‚Šè¿”ã—æ¡ç¸¦ç·šæç”»
 	if( !m_bMiniMap ){
 		GetTextDrawer().DispWrapLine(
 			pInfo->m_gr,
@@ -1178,7 +1178,7 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 		);
 	}
 
-	// ”½“]•`‰æ
+	// åè»¢æç”»
 	if( pcLayout && GetSelectionInfo().IsTextSelected() ){
 		DispTextSelected(
 			pInfo->m_gr,
@@ -1187,8 +1187,8 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 			pcLayout->CalcLayoutWidth(m_pcEditDoc->m_cLayoutMgr)
 				+ CLayoutInt(pcLayout->GetLayoutEol().GetLen()
 					? (CTypeSupport(this, COLORIDX_EOL).IsDisp()
-						? (GetTextMetrics().GetLayoutXDefault()+CLayoutXInt(4)) // HACK:EOL‚Ì•`‰æ••ª‚¾‚¯Šm•Û‚·‚éB4px‚ÍCRLF‚Ì‚Í‚İo‚µ‚Ä‚¢‚é•ª
-						: CLayoutXInt(2)) // ”ñ•\¦ = 2px
+						? (GetTextMetrics().GetLayoutXDefault()+CLayoutXInt(4)) // HACK:EOLã®æç”»å¹…åˆ†ã ã‘ç¢ºä¿ã™ã‚‹ã€‚4pxã¯CRLFã®ã¯ã¿å‡ºã—ã¦ã„ã‚‹åˆ†
+						: CLayoutXInt(2)) // éè¡¨ç¤º = 2px
 					: CLayoutInt(0))
 		);
 	}
@@ -1203,7 +1203,7 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 
 
 
-/* ƒeƒLƒXƒg”½“]
+/* ãƒ†ã‚­ã‚¹ãƒˆåè»¢
 
 	@param hdc      
 	@param nLineNum 
@@ -1212,15 +1212,15 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 	@param nX       
 
 	@note
-	CCEditView::DrawLogicLine() ‚Å‚Ìì‰æ(WM_PAINT)‚ÉA1ƒŒƒCƒAƒEƒgs‚ğ‚Ü‚Æ‚ß‚Ä”½“]ˆ—‚·‚é‚½‚ß‚ÌŠÖ”B
-	”ÍˆÍ‘I‘ğ‚ÌXV‚ÍACEditView::DrawSelectArea() ‚ª‘I‘ğE”½“]‰ğœ‚ğs‚¤B
+	CCEditView::DrawLogicLine() ã§ã®ä½œç”»(WM_PAINT)æ™‚ã«ã€1ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œã‚’ã¾ã¨ã‚ã¦åè»¢å‡¦ç†ã™ã‚‹ãŸã‚ã®é–¢æ•°ã€‚
+	ç¯„å›²é¸æŠã®éšæ™‚æ›´æ–°ã¯ã€CEditView::DrawSelectArea() ãŒé¸æŠãƒ»åè»¢è§£é™¤ã‚’è¡Œã†ã€‚
 	
 */
 void CEditView::DispTextSelected(
-	HDC				hdc,		//!< ì‰æ‘ÎÛƒrƒbƒgƒ}ƒbƒv‚ğŠÜ‚ŞƒfƒoƒCƒX
-	CLayoutInt		nLineNum,	//!< ”½“]ˆ—‘ÎÛƒŒƒCƒAƒEƒgs”Ô†(0ŠJn)
-	const CMyPoint&	ptXY,		//!< (‘Š‘ÎƒŒƒCƒAƒEƒg0Œ…–Ú‚Ì¶’[À•W, ‘ÎÛs‚Ìã’[À•W)
-	CLayoutInt		nX_Layout	//!< ‘ÎÛs‚ÌI—¹Œ…ˆÊ’uB@[ABC\n]‚È‚ç‰üs‚ÌŒã‚ë‚Å4
+	HDC				hdc,		//!< ä½œç”»å¯¾è±¡ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—ã‚’å«ã‚€ãƒ‡ãƒã‚¤ã‚¹
+	CLayoutInt		nLineNum,	//!< åè»¢å‡¦ç†å¯¾è±¡ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œç•ªå·(0é–‹å§‹)
+	const CMyPoint&	ptXY,		//!< (ç›¸å¯¾ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆ0æ¡ç›®ã®å·¦ç«¯åº§æ¨™, å¯¾è±¡è¡Œã®ä¸Šç«¯åº§æ¨™)
+	CLayoutInt		nX_Layout	//!< å¯¾è±¡è¡Œã®çµ‚äº†æ¡ä½ç½®ã€‚ã€€[ABC\n]ãªã‚‰æ”¹è¡Œã®å¾Œã‚ã§4
 )
 {
 	CLayoutInt	nSelectFrom;
@@ -1232,7 +1232,7 @@ void CEditView::DispTextSelected(
 	const CLayout* pcLayout = m_pcEditDoc->m_cLayoutMgr.SearchLineByLayoutY( nLineNum );
 	CLayoutRange& sSelect = GetSelectionInfo().m_sSelect;
 
-	/* ‘I‘ğ”ÍˆÍ“à‚Ìs‚©‚È */
+	/* é¸æŠç¯„å›²å†…ã®è¡Œã‹ãª */
 //	if( IsTextSelected() ){
 		if( nLineNum >= sSelect.GetFrom().y && nLineNum <= sSelect.GetTo().y ){
 			CLayoutRange selectArea = GetSelectionInfo().GetSelectAreaLine(nLineNum, pcLayout);
@@ -1245,11 +1245,11 @@ void CEditView::DispTextSelected(
 				nSelectTo = nX_Layout;
 			}
 
-			// 2006.03.28 Moca •\¦ˆæŠO‚È‚ç‰½‚à‚µ‚È‚¢
+			// 2006.03.28 Moca è¡¨ç¤ºåŸŸå¤–ãªã‚‰ä½•ã‚‚ã—ãªã„
 			if( GetTextArea().GetRightCol() < nSelectFrom ){
 				return;
 			}
-			if( nSelectTo < GetTextArea().GetViewLeftCol() ){	// nSelectTo == GetTextArea().GetViewLeftCol()‚ÌƒP[ƒX‚ÍŒã‚Å‚O•¶šƒ}ƒbƒ`‚Å‚È‚¢‚±‚Æ‚ğŠm”F‚µ‚Ä‚©‚ç”²‚¯‚é
+			if( nSelectTo < GetTextArea().GetViewLeftCol() ){	// nSelectTo == GetTextArea().GetViewLeftCol()ã®ã‚±ãƒ¼ã‚¹ã¯å¾Œã§ï¼æ–‡å­—ãƒãƒƒãƒã§ãªã„ã“ã¨ã‚’ç¢ºèªã—ã¦ã‹ã‚‰æŠœã‘ã‚‹
 				return;
 			}
 
@@ -1263,9 +1263,9 @@ void CEditView::DispTextSelected(
 
 			bool bOMatch = false;
 
-			// 2005/04/02 ‚©‚ë‚Æ ‚O•¶šƒ}ƒbƒ`‚¾‚Æ”½“]•‚ª‚O‚Æ‚È‚è”½“]‚³‚ê‚È‚¢‚Ì‚ÅA1/3•¶š•‚¾‚¯”½“]‚³‚¹‚é
-			// 2005/06/26 zenryaku ‘I‘ğ‰ğœ‚ÅƒLƒƒƒŒƒbƒg‚ÌcŠ[‚ªc‚é–â‘è‚ğC³
-			// 2005/09/29 ryoji ƒXƒNƒ[ƒ‹‚ÉƒLƒƒƒŒƒbƒg‚Ì‚æ‚¤‚ÈƒSƒ~‚ª•\¦‚³‚ê‚é–â‘è‚ğC³
+			// 2005/04/02 ã‹ã‚ã¨ ï¼æ–‡å­—ãƒãƒƒãƒã ã¨åè»¢å¹…ãŒï¼ã¨ãªã‚Šåè»¢ã•ã‚Œãªã„ã®ã§ã€1/3æ–‡å­—å¹…ã ã‘åè»¢ã•ã›ã‚‹
+			// 2005/06/26 zenryaku é¸æŠè§£é™¤ã§ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®æ®‹éª¸ãŒæ®‹ã‚‹å•é¡Œã‚’ä¿®æ­£
+			// 2005/09/29 ryoji ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ™‚ã«ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ã‚ˆã†ãªã‚´ãƒŸãŒè¡¨ç¤ºã•ã‚Œã‚‹å•é¡Œã‚’ä¿®æ­£
 			if (GetSelectionInfo().IsTextSelected() && rcClip.right == rcClip.left &&
 				sSelect.IsLineOne() &&
 				sSelect.GetFrom().x >= GetTextArea().GetViewLeftCol())
@@ -1277,15 +1277,15 @@ void CEditView::DispTextSelected(
 				}
 			}
 			if( rcClip.right == rcClip.left ){
-				return;	//‚O•¶šƒ}ƒbƒ`‚É‚æ‚é”½“]•Šg’£‚È‚µ
+				return;	//ï¼æ–‡å­—ãƒãƒƒãƒã«ã‚ˆã‚‹åè»¢å¹…æ‹¡å¼µãªã—
 			}
 
-			// 2006.03.28 Moca ƒEƒBƒ“ƒhƒE•‚ª‘å‚«‚¢‚Æ³‚µ‚­”½“]‚µ‚È‚¢–â‘è‚ğC³
+			// 2006.03.28 Moca ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ãŒå¤§ãã„ã¨æ­£ã—ãåè»¢ã—ãªã„å•é¡Œã‚’ä¿®æ­£
 			if( rcClip.right > GetTextArea().GetAreaRight() ){
 				rcClip.right = GetTextArea().GetAreaRight();
 			}
 			
-			// ‘I‘ğF•\¦‚È‚ç”½“]‚µ‚È‚¢
+			// é¸æŠè‰²è¡¨ç¤ºãªã‚‰åè»¢ã—ãªã„
 			if( !bOMatch && CTypeSupport(this, COLORIDX_SELECT).IsDisp() ){
 				return;
 			}
@@ -1313,25 +1313,25 @@ void CEditView::DispTextSelected(
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       ‰æ–Êƒoƒbƒtƒ@                          //
+//                       ç”»é¢ãƒãƒƒãƒ•ã‚¡                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
 /*!
-	‰æ–Ê‚ÌŒİŠ·ƒrƒbƒgƒ}ƒbƒv‚ğì¬‚Ü‚½‚ÍXV‚·‚éB
-		•K—v‚Ì–³‚¢‚Æ‚«‚Í‰½‚à‚µ‚È‚¢B
+	ç”»é¢ã®äº’æ›ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—ã‚’ä½œæˆã¾ãŸã¯æ›´æ–°ã™ã‚‹ã€‚
+		å¿…è¦ã®ç„¡ã„ã¨ãã¯ä½•ã‚‚ã—ãªã„ã€‚
 	
-	@param cx ƒEƒBƒ“ƒhƒE‚Ì‚‚³
-	@param cy ƒEƒBƒ“ƒhƒE‚Ì•
-	@return true: ƒrƒbƒgƒ}ƒbƒv‚ğ—˜—p‰Â”\ / false: ƒrƒbƒgƒ}ƒbƒv‚Ìì¬EXV‚É¸”s
+	@param cx ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é«˜ã•
+	@param cy ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®å¹…
+	@return true: ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—ã‚’åˆ©ç”¨å¯èƒ½ / false: ãƒ“ãƒƒãƒˆãƒãƒƒãƒ—ã®ä½œæˆãƒ»æ›´æ–°ã«å¤±æ•—
 
-	@date 2007.09.09 Moca CEditView::OnSize‚©‚ç•ª—£B
-		’Pƒ‚É¶¬‚·‚é‚¾‚¯‚¾‚Á‚½‚à‚Ì‚ğAd—l•ÏX‚É]‚¢“à—eƒRƒs[‚ğ’Ç‰ÁB
-		ƒTƒCƒY‚ª“¯‚¶‚Æ‚«‚Í‰½‚à‚µ‚È‚¢‚æ‚¤‚É•ÏX
+	@date 2007.09.09 Moca CEditView::OnSizeã‹ã‚‰åˆ†é›¢ã€‚
+		å˜ç´”ã«ç”Ÿæˆã™ã‚‹ã ã‘ã ã£ãŸã‚‚ã®ã‚’ã€ä»•æ§˜å¤‰æ›´ã«å¾“ã„å†…å®¹ã‚³ãƒ”ãƒ¼ã‚’è¿½åŠ ã€‚
+		ã‚µã‚¤ã‚ºãŒåŒã˜ã¨ãã¯ä½•ã‚‚ã—ãªã„ã‚ˆã†ã«å¤‰æ›´
 
-	@par ŒİŠ·BMP‚É‚ÍƒLƒƒƒŒƒbƒgEƒJ[ƒ\ƒ‹ˆÊ’u‰¡cüE‘ÎŠ‡ŒÊˆÈŠO‚Ìî•ñ‚ğ‘S‚Ä‘‚«‚ŞB
-		‘I‘ğ”ÍˆÍ•ÏX‚Ì”½“]ˆ—‚ÍA‰æ–Ê‚ÆŒİŠ·BMP‚Ì—¼•û‚ğ•ÊX‚É•ÏX‚·‚éB
-		ƒJ[ƒ\ƒ‹ˆÊ’u‰¡cü•ÏX‚É‚ÍAŒİŠ·BMP‚©‚ç‰æ–Ê‚ÉŒ³‚Ìî•ñ‚ğ•œ‹A‚³‚¹‚Ä‚¢‚éB
+	@par äº’æ›BMPã«ã¯ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãƒ»ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®æ¨ªç¸¦ç·šãƒ»å¯¾æ‹¬å¼§ä»¥å¤–ã®æƒ…å ±ã‚’å…¨ã¦æ›¸ãè¾¼ã‚€ã€‚
+		é¸æŠç¯„å›²å¤‰æ›´æ™‚ã®åè»¢å‡¦ç†ã¯ã€ç”»é¢ã¨äº’æ›BMPã®ä¸¡æ–¹ã‚’åˆ¥ã€…ã«å¤‰æ›´ã™ã‚‹ã€‚
+		ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®æ¨ªç¸¦ç·šå¤‰æ›´æ™‚ã«ã¯ã€äº’æ›BMPã‹ã‚‰ç”»é¢ã«å…ƒã®æƒ…å ±ã‚’å¾©å¸°ã•ã›ã¦ã„ã‚‹ã€‚
 
 */
 bool CEditView::CreateOrUpdateCompatibleBitmap( int cx, int cy )
@@ -1339,7 +1339,7 @@ bool CEditView::CreateOrUpdateCompatibleBitmap( int cx, int cy )
 	if( NULL == m_hdcCompatDC ){
 		return false;
 	}
-	// ƒTƒCƒY‚ğ64‚Ì”{”‚Å®—ñ
+	// ã‚µã‚¤ã‚ºã‚’64ã®å€æ•°ã§æ•´åˆ—
 	int nBmpWidthNew  = ((cx + 63) & (0x7fffffff - 63));
 	int nBmpHeightNew = ((cy + 63) & (0x7fffffff - 63));
 	if( nBmpWidthNew != m_nCompatBMPWidth || nBmpHeightNew != m_nCompatBMPHeight ){
@@ -1349,12 +1349,12 @@ bool CEditView::CreateOrUpdateCompatibleBitmap( int cx, int cy )
 		HDC	hdc = ::GetDC( GetHwnd() );
 		HBITMAP hBitmapNew = NULL;
 		if( m_hbmpCompatBMP ){
-			// BMP‚ÌXV
+			// BMPã®æ›´æ–°
 			HDC hdcTemp = ::CreateCompatibleDC( hdc );
 			hBitmapNew = ::CreateCompatibleBitmap( hdc, nBmpWidthNew, nBmpHeightNew );
 			if( hBitmapNew ){
 				HBITMAP hBitmapOld = (HBITMAP)::SelectObject( hdcTemp, hBitmapNew );
-				// ‘O‚Ì‰æ–Ê“à—e‚ğƒRƒs[‚·‚é
+				// å‰ã®ç”»é¢å†…å®¹ã‚’ã‚³ãƒ”ãƒ¼ã™ã‚‹
 				::BitBlt( hdcTemp, 0, 0,
 					t_min( nBmpWidthNew,m_nCompatBMPWidth ),
 					t_min( nBmpHeightNew, m_nCompatBMPHeight ),
@@ -1365,7 +1365,7 @@ bool CEditView::CreateOrUpdateCompatibleBitmap( int cx, int cy )
 			}
 			::DeleteDC( hdcTemp );
 		}else{
-			// BMP‚ÌV‹Kì¬
+			// BMPã®æ–°è¦ä½œæˆ
 			hBitmapNew = ::CreateCompatibleBitmap( hdc, nBmpWidthNew, nBmpHeightNew );
 		}
 		if( hBitmapNew ){
@@ -1374,10 +1374,10 @@ bool CEditView::CreateOrUpdateCompatibleBitmap( int cx, int cy )
 			m_nCompatBMPHeight = nBmpHeightNew;
 			m_hbmpCompatBMPOld = (HBITMAP)::SelectObject( m_hdcCompatDC, m_hbmpCompatBMP );
 		}else{
-			// ŒİŠ·BMP‚Ìì¬‚É¸”s
-			// ¡Œã‚à¸”s‚ğŒJ‚è•Ô‚·‰Â”\«‚ª‚‚¢‚Ì‚Å
-			// m_hdcCompatDC‚ğNULL‚É‚·‚é‚±‚Æ‚Å‰æ–Êƒoƒbƒtƒ@‹@”\‚ğ‚±‚ÌƒEƒBƒ“ƒhƒE‚Ì‚İ–³Œø‚É‚·‚éB
-			//	2007.09.29 genta ŠÖ”‰»DŠù‘¶‚ÌBMP‚à‰ğ•ú
+			// äº’æ›BMPã®ä½œæˆã«å¤±æ•—
+			// ä»Šå¾Œã‚‚å¤±æ•—ã‚’ç¹°ã‚Šè¿”ã™å¯èƒ½æ€§ãŒé«˜ã„ã®ã§
+			// m_hdcCompatDCã‚’NULLã«ã™ã‚‹ã“ã¨ã§ç”»é¢ãƒãƒƒãƒ•ã‚¡æ©Ÿèƒ½ã‚’ã“ã®ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã¿ç„¡åŠ¹ã«ã™ã‚‹ã€‚
+			//	2007.09.29 genta é–¢æ•°åŒ–ï¼æ—¢å­˜ã®BMPã‚‚è§£æ”¾
 			UseCompatibleDC(FALSE);
 		}
 		::ReleaseDC( GetHwnd(), hdc );
@@ -1387,11 +1387,11 @@ bool CEditView::CreateOrUpdateCompatibleBitmap( int cx, int cy )
 
 
 /*!
-	ŒİŠ·ƒƒ‚ƒŠBMP‚ğíœ
+	äº’æ›ãƒ¡ãƒ¢ãƒªBMPã‚’å‰Šé™¤
 
-	@note •ªŠ„ƒrƒ…[‚ª”ñ•\¦‚É‚È‚Á‚½ê‡‚Æ
-		eƒEƒBƒ“ƒhƒE‚ª”ñ•\¦EÅ¬‰»‚³‚ê‚½ê‡‚Éíœ‚³‚ê‚éB
-	@date 2007.09.09 Moca V‹Kì¬ 
+	@note åˆ†å‰²ãƒ“ãƒ¥ãƒ¼ãŒéè¡¨ç¤ºã«ãªã£ãŸå ´åˆã¨
+		è¦ªã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒéè¡¨ç¤ºãƒ»æœ€å°åŒ–ã•ã‚ŒãŸå ´åˆã«å‰Šé™¤ã•ã‚Œã‚‹ã€‚
+	@date 2007.09.09 Moca æ–°è¦ä½œæˆ 
 */
 void CEditView::DeleteCompatibleBitmap()
 {
@@ -1407,15 +1407,15 @@ void CEditView::DeleteCompatibleBitmap()
 
 
 
-/** ‰æ–ÊƒLƒƒƒbƒVƒ…—pCompatibleDC‚ğ—pˆÓ‚·‚é
+/** ç”»é¢ã‚­ãƒ£ãƒƒã‚·ãƒ¥ç”¨CompatibleDCã‚’ç”¨æ„ã™ã‚‹
 
-	@param[in] TRUE: ‰æ–ÊƒLƒƒƒbƒVƒ…ON
+	@param[in] TRUE: ç”»é¢ã‚­ãƒ£ãƒƒã‚·ãƒ¥ON
 
-	@date 2007.09.30 genta ŠÖ”‰»
+	@date 2007.09.30 genta é–¢æ•°åŒ–
 */
 void CEditView::UseCompatibleDC(BOOL fCache)
 {
-	// From Here 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
+	// From Here 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
 	if( fCache ){
 		if( m_hdcCompatDC == NULL ){
 			HDC			hdc;
@@ -1429,7 +1429,7 @@ void CEditView::UseCompatibleDC(BOOL fCache)
 		}
 	}
 	else {
-		//	CompatibleBitmap‚ªc‚Á‚Ä‚¢‚é‚©‚à‚µ‚ê‚È‚¢‚Ì‚ÅÅ‰‚Éíœ
+		//	CompatibleBitmapãŒæ®‹ã£ã¦ã„ã‚‹ã‹ã‚‚ã—ã‚Œãªã„ã®ã§æœ€åˆã«å‰Šé™¤
 		DeleteCompatibleBitmap();
 		if( m_hdcCompatDC != NULL ){
 			::DeleteDC( m_hdcCompatDC );

--- a/sakura_core/view/CEditView_Paint.h
+++ b/sakura_core/view/CEditView_Paint.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -27,14 +27,14 @@
 class CEditView;
 
 
-//! ƒNƒŠƒbƒsƒ“ƒO—Ìˆæ‚ğŒvZ‚·‚éÛ‚Ìƒtƒ‰ƒO
+//! ã‚¯ãƒªãƒƒãƒ”ãƒ³ã‚°é ˜åŸŸã‚’è¨ˆç®—ã™ã‚‹éš›ã®ãƒ•ãƒ©ã‚°
 enum EPaintArea{
-	PAINT_LINENUMBER = (1<<0), //!< s”Ô†
-	PAINT_RULER      = (1<<1), //!< ƒ‹[ƒ‰[
-	PAINT_BODY       = (1<<2), //!< –{•¶
+	PAINT_LINENUMBER = (1<<0), //!< è¡Œç•ªå·
+	PAINT_RULER      = (1<<1), //!< ãƒ«ãƒ¼ãƒ©ãƒ¼
+	PAINT_BODY       = (1<<2), //!< æœ¬æ–‡
 
-	//“Áê
-	PAINT_ALL        = PAINT_LINENUMBER | PAINT_RULER | PAINT_BODY, //!< ‚º‚ñ‚Ô
+	//ç‰¹æ®Š
+	PAINT_ALL        = PAINT_LINENUMBER | PAINT_RULER | PAINT_BODY, //!< ãœã‚“ã¶
 };
 
 class CEditView_Paint{
@@ -44,8 +44,8 @@ public:
 public:
 	virtual ~CEditView_Paint(){}
 	void Call_OnPaint(
-		int nPaintFlag,   //!< •`‰æ‚·‚é—Ìˆæ‚ğ‘I‘ğ‚·‚é
-		bool bUseMemoryDC //!< ƒƒ‚ƒŠDC‚ğg—p‚·‚é
+		int nPaintFlag,   //!< æç”»ã™ã‚‹é ˜åŸŸã‚’é¸æŠã™ã‚‹
+		bool bUseMemoryDC //!< ãƒ¡ãƒ¢ãƒªDCã‚’ä½¿ç”¨ã™ã‚‹
 	);
 };
 

--- a/sakura_core/view/CEditView_Paint_Bracket.cpp
+++ b/sakura_core/view/CEditView_Paint_Bracket.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -29,18 +29,18 @@
 #include "types/CTypeSupport.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           Š‡ŒÊ                              //
+//                           æ‹¬å¼§                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /*!
 	@date 2003/02/18 ai
-	@param flag [in] ƒ‚[ƒh(true:“o˜^, false:‰ğœ)
+	@param flag [in] ãƒ¢ãƒ¼ãƒ‰(true:ç™»éŒ², false:è§£é™¤)
 */
 void CEditView::SetBracketPairPos( bool flag )
 {
 	int	mode;
 
-	// 03/03/06 ai ‚·‚×‚Ä’uŠ·A‚·‚×‚Ä’uŠ·Œã‚ÌUndo&Redo‚ª‚©‚È‚è’x‚¢–â‘è‚É‘Î‰
+	// 03/03/06 ai ã™ã¹ã¦ç½®æ›ã€ã™ã¹ã¦ç½®æ›å¾Œã®Undo&RedoãŒã‹ãªã‚Šé…ã„å•é¡Œã«å¯¾å¿œ
 	if( m_bDoing_UndoRedo || !GetDrawSwitch() ){
 		return;
 	}
@@ -49,11 +49,11 @@ void CEditView::SetBracketPairPos( bool flag )
 		return;
 	}
 
-	// ‘ÎŠ‡ŒÊ‚ÌŒŸõ&“o˜^
+	// å¯¾æ‹¬å¼§ã®æ¤œç´¢&ç™»éŒ²
 	/*
-	bit0(in)  : •\¦—ÌˆæŠO‚ğ’²‚×‚é‚©H 0:’²‚×‚È‚¢  1:’²‚×‚é
-	bit1(in)  : ‘O•û•¶š‚ğ’²‚×‚é‚©H   0:’²‚×‚È‚¢  1:’²‚×‚é
-	bit2(out) : Œ©‚Â‚©‚Á‚½ˆÊ’u         0:Œã‚ë      1:‘O
+	bit0(in)  : è¡¨ç¤ºé ˜åŸŸå¤–ã‚’èª¿ã¹ã‚‹ã‹ï¼Ÿ 0:èª¿ã¹ãªã„  1:èª¿ã¹ã‚‹
+	bit1(in)  : å‰æ–¹æ–‡å­—ã‚’èª¿ã¹ã‚‹ã‹ï¼Ÿ   0:èª¿ã¹ãªã„  1:èª¿ã¹ã‚‹
+	bit2(out) : è¦‹ã¤ã‹ã£ãŸä½ç½®         0:å¾Œã‚      1:å‰
 	*/
 	mode = 2;
 
@@ -62,30 +62,30 @@ void CEditView::SetBracketPairPos( bool flag )
 	if( flag && !GetSelectionInfo().IsTextSelected() && !GetSelectionInfo().m_bDrawSelectArea
 		&& SearchBracket( GetCaret().GetCaretLayoutPos(), &ptColLine, &mode ) )
 	{
-		// “o˜^w’è(flag=true)			&&
-		// ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚È‚¢	&&
-		// ‘I‘ğ”ÍˆÍ‚ğ•`‰æ‚µ‚Ä‚¢‚È‚¢		&&
-		// ‘Î‰‚·‚éŠ‡ŒÊ‚ªŒ©‚Â‚©‚Á‚½		ê‡
+		// ç™»éŒ²æŒ‡å®š(flag=true)			&&
+		// ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ãªã„	&&
+		// é¸æŠç¯„å›²ã‚’æç”»ã—ã¦ã„ãªã„		&&
+		// å¯¾å¿œã™ã‚‹æ‹¬å¼§ãŒè¦‹ã¤ã‹ã£ãŸ		å ´åˆ
 		if ( ( ptColLine.x >= GetTextArea().GetViewLeftCol() ) && ( ptColLine.x <= GetTextArea().GetRightCol() )
 			&& ( ptColLine.y >= GetTextArea().GetViewTopLine() ) && ( ptColLine.y <= GetTextArea().GetBottomLine() ) )
 		{
-			// •\¦—Ìˆæ“à‚Ìê‡
+			// è¡¨ç¤ºé ˜åŸŸå†…ã®å ´åˆ
 
-			// ƒŒƒCƒAƒEƒgˆÊ’u‚©‚ç•¨—ˆÊ’u‚Ö•ÏŠ·(‹­’²•\¦ˆÊ’u‚ğ“o˜^)
+			// ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã‹ã‚‰ç‰©ç†ä½ç½®ã¸å¤‰æ›(å¼·èª¿è¡¨ç¤ºä½ç½®ã‚’ç™»éŒ²)
 			m_pcEditDoc->m_cLayoutMgr.LayoutToLogic( ptColLine, &m_ptBracketPairPos_PHY );
 			m_ptBracketCaretPos_PHY.y = GetCaret().GetCaretLogicPos().y;
 			if( 0 == ( mode & 4 ) ){
-				// ƒJ[ƒ\ƒ‹‚ÌŒã•û•¶šˆÊ’u
+				// ã‚«ãƒ¼ã‚½ãƒ«ã®å¾Œæ–¹æ–‡å­—ä½ç½®
 				m_ptBracketCaretPos_PHY.x = GetCaret().GetCaretLogicPos().x;
 			}else{
-				// ƒJ[ƒ\ƒ‹‚Ì‘O•û•¶šˆÊ’u
+				// ã‚«ãƒ¼ã‚½ãƒ«ã®å‰æ–¹æ–‡å­—ä½ç½®
 				m_ptBracketCaretPos_PHY.x = GetCaret().GetCaretLogicPos().x - 1;
 			}
 			return;
 		}
 	}
 
-	// Š‡ŒÊ‚Ì‹­’²•\¦ˆÊ’uî•ñ‰Šú‰»
+	// æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤ºä½ç½®æƒ…å ±åˆæœŸåŒ–
 	m_ptBracketPairPos_PHY.Set(CLogicInt(-1), CLogicInt(-1));
 	m_ptBracketCaretPos_PHY.Set(CLogicInt(-1), CLogicInt(-1));
 
@@ -93,13 +93,13 @@ void CEditView::SetBracketPairPos( bool flag )
 }
 
 /*!
-	‘ÎŠ‡ŒÊ‚Ì‹­’²•\¦
+	å¯¾æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤º
 	@date 2002/09/18 ai
-	@date 2003/02/18 ai Ä•`‰æ‘Î‰‚Ìˆ×‘å‰ü‘¢
+	@date 2003/02/18 ai å†æç”»å¯¾å¿œã®ç‚ºå¤§æ”¹é€ 
 */
 void CEditView::DrawBracketPair( bool bDraw )
 {
-	// 03/03/06 ai ‚·‚×‚Ä’uŠ·A‚·‚×‚Ä’uŠ·Œã‚ÌUndo&Redo‚ª‚©‚È‚è’x‚¢–â‘è‚É‘Î‰
+	// 03/03/06 ai ã™ã¹ã¦ç½®æ›ã€ã™ã¹ã¦ç½®æ›å¾Œã®Undo&RedoãŒã‹ãªã‚Šé…ã„å•é¡Œã«å¯¾å¿œ
 	if( m_bDoing_UndoRedo || !GetDrawSwitch() ){
 		return;
 	}
@@ -108,16 +108,16 @@ void CEditView::DrawBracketPair( bool bDraw )
 		return;
 	}
 
-	// Š‡ŒÊ‚Ì‹­’²•\¦ˆÊ’u‚ª–¢“o˜^‚Ìê‡‚ÍI—¹
+	// æ‹¬å¼§ã®å¼·èª¿è¡¨ç¤ºä½ç½®ãŒæœªç™»éŒ²ã®å ´åˆã¯çµ‚äº†
 	if( m_ptBracketPairPos_PHY.HasNegative() || m_ptBracketCaretPos_PHY.HasNegative() ){
 		return;
 	}
 
-	// •`‰æw’è(bDraw=true)				‚©‚Â
-	// ( ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é		–”‚Í
-	//   ‘I‘ğ”ÍˆÍ‚ğ•`‰æ‚µ‚Ä‚¢‚é			–”‚Í
-	//   ƒtƒH[ƒJƒX‚ğ‚Á‚Ä‚¢‚È‚¢		–”‚Í
-	//   ƒAƒNƒeƒBƒu‚ÈƒyƒCƒ“‚Å‚Í‚È‚¢ )	ê‡‚ÍI—¹
+	// æç”»æŒ‡å®š(bDraw=true)				ã‹ã¤
+	// ( ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹		åˆã¯
+	//   é¸æŠç¯„å›²ã‚’æç”»ã—ã¦ã„ã‚‹			åˆã¯
+	//   ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ã‚’æŒã£ã¦ã„ãªã„		åˆã¯
+	//   ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ãªãƒšã‚¤ãƒ³ã§ã¯ãªã„ )	å ´åˆã¯çµ‚äº†
 	if( bDraw
 	 &&( GetSelectionInfo().IsTextSelected() || GetSelectionInfo().m_bDrawSelectArea || !m_bDrawBracketPairFlag
 	 || ( m_pcEditWnd->GetActivePane() != m_nMyIndex ) ) ){
@@ -131,10 +131,10 @@ void CEditView::DrawBracketPair( bool bDraw )
 
 	for( int i = 0; i < 2; i++ )
 	{
-		// i=0:‘ÎŠ‡ŒÊ,i=1:ƒJ[ƒ\ƒ‹ˆÊ’u‚ÌŠ‡ŒÊ
-		// 2011.11.23 ryoji ‘ÎŠ‡ŒÊ -> ƒJ[ƒ\ƒ‹ˆÊ’u‚ÌŠ‡ŒÊ ‚Ì‡‚Éˆ—‡˜‚ğ•ÏX
-		//   ” { ‚Æ } ‚ªˆÙ‚È‚és‚É‚ ‚éê‡‚É { ‚ğ BS ‚ÅÁ‚·‚Æ } ‚Ì‹­’²•\¦‚ª‰ğœ‚³‚ê‚È‚¢–â‘èiWiki BugReport/89j‚Ì‘Îô
-		//   ” ‚±‚Ì‡˜•ÏX‚É‚æ‚èƒJ[ƒ\ƒ‹ˆÊ’u‚ªŠ‡ŒÊ‚Å‚È‚­‚È‚Á‚Ä‚¢‚Ä‚à‘ÎŠ‡ŒÊ‚ª‚ ‚ê‚Î‘ÎŠ‡ŒÊ‘¤‚Ì‹­’²•\¦‚Í‰ğœ‚³‚ê‚é
+		// i=0:å¯¾æ‹¬å¼§,i=1:ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ‹¬å¼§
+		// 2011.11.23 ryoji å¯¾æ‹¬å¼§ -> ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ‹¬å¼§ ã®é †ã«å‡¦ç†é †åºã‚’å¤‰æ›´
+		//   ï¼ƒ { ã¨ } ãŒç•°ãªã‚‹è¡Œã«ã‚ã‚‹å ´åˆã« { ã‚’ BS ã§æ¶ˆã™ã¨ } ã®å¼·èª¿è¡¨ç¤ºãŒè§£é™¤ã•ã‚Œãªã„å•é¡Œï¼ˆWiki BugReport/89ï¼‰ã®å¯¾ç­–
+		//   ï¼ƒ ã“ã®é †åºå¤‰æ›´ã«ã‚ˆã‚Šã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ãŒæ‹¬å¼§ã§ãªããªã£ã¦ã„ã¦ã‚‚å¯¾æ‹¬å¼§ãŒã‚ã‚Œã°å¯¾æ‹¬å¼§å´ã®å¼·èª¿è¡¨ç¤ºã¯è§£é™¤ã•ã‚Œã‚‹
 
 		CLayoutPoint	ptColLine;
 
@@ -146,9 +146,9 @@ void CEditView::DrawBracketPair( bool bDraw )
 
 		if ( ( ptColLine.x >= GetTextArea().GetViewLeftCol() ) && ( ptColLine.x <= GetTextArea().GetRightCol() )
 			&& ( ptColLine.y >= GetTextArea().GetViewTopLine() ) && ( ptColLine.y <= GetTextArea().GetBottomLine() ) )
-		{	// •\¦—Ìˆæ“à‚Ìê‡
+		{	// è¡¨ç¤ºé ˜åŸŸå†…ã®å ´åˆ
 			if( !bDraw && GetSelectionInfo().m_bDrawSelectArea && ( 0 == IsCurrentPositionSelected( ptColLine ) ) )
-			{	// ‘I‘ğ”ÍˆÍ•`‰æÏ‚İ‚ÅÁ‹‘ÎÛ‚ÌŠ‡ŒÊ‚ª‘I‘ğ”ÍˆÍ“à‚Ìê‡
+			{	// é¸æŠç¯„å›²æç”»æ¸ˆã¿ã§æ¶ˆå»å¯¾è±¡ã®æ‹¬å¼§ãŒé¸æŠç¯„å›²å†…ã®å ´åˆ
 				continue;
 			}
 			const CLayout* pcLayout;
@@ -163,14 +163,14 @@ void CEditView::DrawBracketPair( bool bDraw )
 				}
 				else{
 					if( IsBracket( pLine, OutputX, CLogicInt(1) ) ){
-						DispPos _sPos(0,0); // ’ˆÓF‚±‚Ì’l‚Íƒ_ƒ~[BCheckChangeColor‚Å‚ÌQÆˆÊ’u‚Í•s³Šm
+						DispPos _sPos(0,0); // æ³¨æ„ï¼šã“ã®å€¤ã¯ãƒ€ãƒŸãƒ¼ã€‚CheckChangeColorã§ã®å‚ç…§ä½ç½®ã¯ä¸æ­£ç¢º
 						SColorStrategyInfo _sInfo;
 						SColorStrategyInfo* pInfo = &_sInfo;
 						pInfo->m_pDispPos = &_sPos;
 						pInfo->m_pcView = this;
 
-						// 03/10/24 ai Ü‚è•Ô‚µs‚ÌColorIndex‚ª³‚µ‚­æ“¾‚Å‚«‚È‚¢–â‘è‚É‘Î‰
-						// 2009.02.07 ryoji GetColorIndex ‚É“n‚·ƒCƒ“ƒfƒbƒNƒX‚Ìd—l•ÏXiŒ³‚Í‚±‚Á‚¿‚Ìd—l‚¾‚Á‚½–Í—lj
+						// 03/10/24 ai æŠ˜ã‚Šè¿”ã—è¡Œã®ColorIndexãŒæ­£ã—ãå–å¾—ã§ããªã„å•é¡Œã«å¯¾å¿œ
+						// 2009.02.07 ryoji GetColorIndex ã«æ¸¡ã™ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ã®ä»•æ§˜å¤‰æ›´ï¼ˆå…ƒã¯ã“ã£ã¡ã®ä»•æ§˜ã ã£ãŸæ¨¡æ§˜ï¼‰
 						CColor3Setting cColor = GetColorIndex( pcLayout, ptColLine.GetY2(), OutputX, pInfo );
 						nColorIndex = cColor.eColorIndex2;
 					}
@@ -185,13 +185,13 @@ void CEditView::DrawBracketPair( bool bDraw )
 					: CTypeSupport(this,COLORIDX_EVENLINEBG).IsDisp() && ptColLine.GetY2() % 2 == 1
 						? COLORIDX_EVENLINEBG
 						: COLORIDX_TEXT);
-				// 03/03/03 ai ƒJ[ƒ\ƒ‹‚Ì¶‚ÉŠ‡ŒÊ‚ª‚ ‚èŠ‡ŒÊ‚ª‹­’²•\¦‚³‚ê‚Ä‚¢‚éó‘Ô‚ÅShift+©‚Å‘I‘ğŠJn‚·‚é‚Æ
-				//             ‘I‘ğ”ÍˆÍ“à‚É”½“]•\¦‚³‚ê‚È‚¢•”•ª‚ª‚ ‚é–â‘è‚ÌC³
+				// 03/03/03 ai ã‚«ãƒ¼ã‚½ãƒ«ã®å·¦ã«æ‹¬å¼§ãŒã‚ã‚Šæ‹¬å¼§ãŒå¼·èª¿è¡¨ç¤ºã•ã‚Œã¦ã„ã‚‹çŠ¶æ…‹ã§Shift+â†ã§é¸æŠé–‹å§‹ã™ã‚‹ã¨
+				//             é¸æŠç¯„å›²å†…ã«åè»¢è¡¨ç¤ºã•ã‚Œãªã„éƒ¨åˆ†ãŒã‚ã‚‹å•é¡Œã®ä¿®æ­£
 				CLayoutInt caretX = GetCaret().GetCaretLayoutPos().GetX2();
 				bool bCaretHide = (!bCaretChange && (ptColLine.x == caretX || ptColLine.x + 1 == caretX) && GetCaret().GetCaretShowFlag());
 				if( bCaretHide ){
 					bCaretChange = true;
-					GetCaret().HideCaret_( GetHwnd() );	// ƒLƒƒƒŒƒbƒg‚ªˆêuÁ‚¦‚é‚Ì‚ğ–h~
+					GetCaret().HideCaret_( GetHwnd() );	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒä¸€ç¬æ¶ˆãˆã‚‹ã®ã‚’é˜²æ­¢
 				}
 				{
 					int nWidth  = GetTextMetrics().GetHankakuDx();
@@ -200,10 +200,10 @@ void CEditView::DrawBracketPair( bool bDraw )
 					int nTop  = (Int)( ptColLine.GetY2() - GetTextArea().GetViewTopLine() ) * nHeight + GetTextArea().GetAreaTop();
 					CLayoutXInt charsWidth = m_pcEditDoc->m_cLayoutMgr.GetLayoutXOfChar(pLine, nLineLen, OutputX);
 
-					//Fİ’è
+					//è‰²è¨­å®š
 					CTypeSupport cTextType(this,COLORIDX_TEXT);
 					cTextType.SetGraphicsState_WhileThisObj(gr);
-					// 2013.05.24 ”wŒiF‚ªƒeƒLƒXƒg‚Ì”wŒiF‚Æ“¯‚¶‚È‚çƒJ[ƒ\ƒ‹s‚Ì”wŒiF‚ğ“K—p
+					// 2013.05.24 èƒŒæ™¯è‰²ãŒãƒ†ã‚­ã‚¹ãƒˆã®èƒŒæ™¯è‰²ã¨åŒã˜ãªã‚‰ã‚«ãƒ¼ã‚½ãƒ«è¡Œã®èƒŒæ™¯è‰²ã‚’é©ç”¨
 					CTypeSupport cColorIndexType(this,nColorIndex);
 					CTypeSupport cColorIndexBgType(this,nColorIndexBg);
 					CTypeSupport* pcColorBack = &cColorIndexType;
@@ -232,20 +232,20 @@ void CEditView::DrawBracketPair( bool bDraw )
 					sPos.InitDrawPos(CMyPoint(nLeft, nTop));
 					GetTextDrawer().DispText(gr, &sPos, 0, &pLine[OutputX], 1, bTrans);
 					GetTextDrawer().DispNoteLine(gr, nTop, nTop + nHeight, nLeft, nLeft + (Int)charsWidth * nWidth);
-					// 2006.04.30 Moca ‘ÎŠ‡ŒÊ‚Ìcü‘Î‰
-					GetTextDrawer().DispVerticalLines(gr, nTop, nTop + nHeight, ptColLine.x, ptColLine.x + charsWidth); //¦Š‡ŒÊ‚ª‘SŠp•‚Å‚ ‚éê‡‚ğl—¶
+					// 2006.04.30 Moca å¯¾æ‹¬å¼§ã®ç¸¦ç·šå¯¾å¿œ
+					GetTextDrawer().DispVerticalLines(gr, nTop, nTop + nHeight, ptColLine.x, ptColLine.x + charsWidth); //â€»æ‹¬å¼§ãŒå…¨è§’å¹…ã§ã‚ã‚‹å ´åˆã‚’è€ƒæ…®
 					cTextType.RewindGraphicsState(gr);
 				}
 
 				if( ( m_pcEditWnd->GetActivePane() == m_nMyIndex )
-					&& ( ( ptColLine.y == GetCaret().GetCaretLayoutPos().GetY() ) || ( ptColLine.y - 1 == GetCaret().GetCaretLayoutPos().GetY() ) ) ){	// 03/02/27 ai s‚ÌŠÔŠu‚ª"0"‚Ì‚ÉƒAƒ“ƒ_[ƒ‰ƒCƒ“‚ªŒ‡‚¯‚é–‚ª‚ ‚éˆ×C³
+					&& ( ( ptColLine.y == GetCaret().GetCaretLayoutPos().GetY() ) || ( ptColLine.y - 1 == GetCaret().GetCaretLayoutPos().GetY() ) ) ){	// 03/02/27 ai è¡Œã®é–“éš”ãŒ"0"ã®æ™‚ã«ã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³ãŒæ¬ ã‘ã‚‹äº‹ãŒã‚ã‚‹ç‚ºä¿®æ­£
 					GetCaret().m_cUnderLine.CaretUnderLineON( true, false );
 				}
 			}
 		}
 	}
 	if( bCaretChange ){
-		GetCaret().ShowCaret_( GetHwnd() );	// ƒLƒƒƒŒƒbƒg‚ªˆêuÁ‚¦‚é‚Ì‚ğ–h~
+		GetCaret().ShowCaret_( GetHwnd() );	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒä¸€ç¬æ¶ˆãˆã‚‹ã®ã‚’é˜²æ­¢
 	}
 
 	::ReleaseDC( GetHwnd(), gr );
@@ -253,34 +253,34 @@ void CEditView::DrawBracketPair( bool bDraw )
 
 
 //======================================================================
-//!‘ÎŠ‡ŒÊ‚Ì‘Î‰•\
+//!å¯¾æ‹¬å¼§ã®å¯¾å¿œè¡¨
 //2007.10.16 kobake
 struct KAKKO_T{
 	const wchar_t *sStr;
 	const wchar_t *eStr;
 };
 static const KAKKO_T g_aKakkos[] = {
-	//”¼Šp
+	//åŠè§’
 	{ L"(", L")", },
 	{ L"[", L"]", },
 	{ L"{", L"}", },
 	{ L"<", L">", },
-	{ L"¢", L"£", },
-	//‘SŠp
-	{ L"y", L"z", },
-	{ L"w", L"x", },
-	{ L"u", L"v", },
-	{ L"ƒ", L"„", },
-	{ L"á", L"â", },
-	{ L"s", L"t", },
-	{ L"i", L"j", },
-	{ L"q", L"r", },
-	{ L"o", L"p", },
-	{ L"k", L"l", },
-	{ L"m", L"n", },
-	{ L"g", L"h", },
-	{ L"‡€", L"‡", },
-	//I’[
+	{ L"ï½¢", L"ï½£", },
+	//å…¨è§’
+	{ L"ã€", L"ã€‘", },
+	{ L"ã€", L"ã€", },
+	{ L"ã€Œ", L"ã€", },
+	{ L"ï¼œ", L"ï¼", },
+	{ L"â‰ª", L"â‰«", },
+	{ L"ã€Š", L"ã€‹", },
+	{ L"ï¼ˆ", L"ï¼‰", },
+	{ L"ã€ˆ", L"ã€‰", },
+	{ L"ï½›", L"ï½", },
+	{ L"ã€”", L"ã€•", },
+	{ L"ï¼»", L"ï¼½", },
+	{ L"â€œ", L"â€", },
+	{ L"ã€", L"ã€Ÿ", },
+	//çµ‚ç«¯
 	{ NULL, NULL, },
 };
 
@@ -288,29 +288,29 @@ static const KAKKO_T g_aKakkos[] = {
 
 //	Jun. 16, 2000 genta
 /*!
-	@brief ‘ÎŠ‡ŒÊ‚ÌŒŸõ
+	@brief å¯¾æ‹¬å¼§ã®æ¤œç´¢
 
-	ƒJ[ƒ\ƒ‹ˆÊ’u‚ÌŠ‡ŒÊ‚É‘Î‰‚·‚éŠ‡ŒÊ‚ğ’T‚·BƒJ[ƒ\ƒ‹ˆÊ’u‚ªŠ‡ŒÊ‚Å‚È‚¢ê‡‚Í
-	ƒJ[ƒ\ƒ‹‚ÌŒã‚ë‚Ì•¶š‚ªŠ‡ŒÊ‚©‚Ç‚¤‚©‚ğ’²‚×‚éB
+	ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã®æ‹¬å¼§ã«å¯¾å¿œã™ã‚‹æ‹¬å¼§ã‚’æ¢ã™ã€‚ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ãŒæ‹¬å¼§ã§ãªã„å ´åˆã¯
+	ã‚«ãƒ¼ã‚½ãƒ«ã®å¾Œã‚ã®æ–‡å­—ãŒæ‹¬å¼§ã‹ã©ã†ã‹ã‚’èª¿ã¹ã‚‹ã€‚
 
-	ƒJ[ƒ\ƒ‹‚Ì‘OŒã‚¢‚¸‚ê‚à‚ªŠ‡ŒÊ‚Å‚È‚¢ê‡‚Í‰½‚à‚µ‚È‚¢B
+	ã‚«ãƒ¼ã‚½ãƒ«ã®å‰å¾Œã„ãšã‚Œã‚‚ãŒæ‹¬å¼§ã§ãªã„å ´åˆã¯ä½•ã‚‚ã—ãªã„ã€‚
 
-	Š‡ŒÊ‚ª”¼Šp‚©‘SŠp‚©A‹y‚Ñn‚Ü‚è‚©I‚í‚è‚©‚É‚æ‚Á‚Ä‚±‚ê‚É‘±‚­4‚Â‚ÌŠÖ”‚É
-	§Œä‚ğˆÚ‚·B
+	æ‹¬å¼§ãŒåŠè§’ã‹å…¨è§’ã‹ã€åŠã³å§‹ã¾ã‚Šã‹çµ‚ã‚ã‚Šã‹ã«ã‚ˆã£ã¦ã“ã‚Œã«ç¶šã4ã¤ã®é–¢æ•°ã«
+	åˆ¶å¾¡ã‚’ç§»ã™ã€‚
 
-	@param ptLayout [in] ŒŸõŠJn“_‚Ì•¨—À•W
-	@param pptLayoutNew [out] ˆÚ“®æ‚ÌƒŒƒCƒAƒEƒgÀ•W
-	@param mode [in,out] bit0(in)  : •\¦—ÌˆæŠO‚ğ’²‚×‚é‚©H 0:’²‚×‚È‚¢  1:’²‚×‚é
-						 bit1(in)  : ‘O•û•¶š‚ğ’²‚×‚é‚©H   0:’²‚×‚È‚¢  1:’²‚×‚é (‚±‚Ìbit‚ğQÆ)
-						 bit2(out) : Œ©‚Â‚©‚Á‚½ˆÊ’u         0:Œã‚ë      1:‘O     (‚±‚Ìbit‚ğXV)
+	@param ptLayout [in] æ¤œç´¢é–‹å§‹ç‚¹ã®ç‰©ç†åº§æ¨™
+	@param pptLayoutNew [out] ç§»å‹•å…ˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆåº§æ¨™
+	@param mode [in,out] bit0(in)  : è¡¨ç¤ºé ˜åŸŸå¤–ã‚’èª¿ã¹ã‚‹ã‹ï¼Ÿ 0:èª¿ã¹ãªã„  1:èª¿ã¹ã‚‹
+						 bit1(in)  : å‰æ–¹æ–‡å­—ã‚’èª¿ã¹ã‚‹ã‹ï¼Ÿ   0:èª¿ã¹ãªã„  1:èª¿ã¹ã‚‹ (ã“ã®bitã‚’å‚ç…§)
+						 bit2(out) : è¦‹ã¤ã‹ã£ãŸä½ç½®         0:å¾Œã‚      1:å‰     (ã“ã®bitã‚’æ›´æ–°)
 
-	@retval true ¬Œ÷
-	@retval false ¸”s
+	@retval true æˆåŠŸ
+	@retval false å¤±æ•—
 
 	@author genta
 	@date Jun. 16, 2000 genta
-	@date Feb. 03, 2001 MIK ‘SŠpŠ‡ŒÊ‚É‘Î‰
-	@date Sep. 18, 2002 ai mode‚Ì’Ç‰Á
+	@date Feb. 03, 2001 MIK å…¨è§’æ‹¬å¼§ã«å¯¾å¿œ
+	@date Sep. 18, 2002 ai modeã®è¿½åŠ 
 */
 bool CEditView::SearchBracket(
 	const CLayoutPoint&	ptLayout,
@@ -318,7 +318,7 @@ bool CEditView::SearchBracket(
 	int*				mode
 )
 {
-	CLogicInt len;	//	s‚Ì’·‚³
+	CLogicInt len;	//	è¡Œã®é•·ã•
 
 	CLogicPoint ptPos;
 
@@ -326,10 +326,10 @@ bool CEditView::SearchBracket(
 	const wchar_t *cline = m_pcEditDoc->m_cDocLineMgr.GetLine(ptPos.GetY2())->GetDocLineStrWithEOL(&len);
 
 	//	Jun. 19, 2000 genta
-	if( cline == NULL )	//	ÅŒã‚Ìs‚É–{•¶‚ª‚È‚¢ê‡
+	if( cline == NULL )	//	æœ€å¾Œã®è¡Œã«æœ¬æ–‡ãŒãªã„å ´åˆ
 		return false;
 
-	// Š‡ŒÊˆ— 2007.10.16 kobake
+	// æ‹¬å¼§å‡¦ç† 2007.10.16 kobake
 	{
 		const KAKKO_T* p;
 		for( p = g_aKakkos; p->sStr != NULL;  p++ )
@@ -347,21 +347,21 @@ bool CEditView::SearchBracket(
 
 	// 02/09/18 ai Start
 	if( 0 == ( *mode & 2 ) ){
-		/* ƒJ[ƒ\ƒ‹‚Ì‘O•û‚ğ’²‚×‚È‚¢ê‡ */
+		/* ã‚«ãƒ¼ã‚½ãƒ«ã®å‰æ–¹ã‚’èª¿ã¹ãªã„å ´åˆ */
 		return false;
 	}
 	*mode |= 4;
 	// 02/09/18 ai End
 
-	//	Š‡ŒÊ‚ªŒ©‚Â‚©‚ç‚È‚©‚Á‚½‚çCƒJ[ƒ\ƒ‹‚Ì’¼‘O‚Ì•¶š‚ğ’²‚×‚é
+	//	æ‹¬å¼§ãŒè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸã‚‰ï¼Œã‚«ãƒ¼ã‚½ãƒ«ã®ç›´å‰ã®æ–‡å­—ã‚’èª¿ã¹ã‚‹
 
 	if( ptPos.x <= 0 ){
-		return false;	//	‘O‚Ì•¶š‚Í‚È‚¢
+		return false;	//	å‰ã®æ–‡å­—ã¯ãªã„
 	}
 
 	const wchar_t *bPos = CNativeW::GetCharPrev( cline, ptPos.x, cline + ptPos.x );
 	int nCharSize = cline + ptPos.x - bPos;
-	// Š‡ŒÊˆ— 2007.10.16 kobake
+	// æ‹¬å¼§å‡¦ç† 2007.10.16 kobake
 	if(nCharSize==1){
 		const KAKKO_T* p;
 		ptPos.x = bPos - cline;
@@ -381,20 +381,20 @@ bool CEditView::SearchBracket(
 }
 
 /*!
-	@brief ”¼Šp‘ÎŠ‡ŒÊ‚ÌŒŸõ:‡•ûŒü
+	@brief åŠè§’å¯¾æ‹¬å¼§ã®æ¤œç´¢:é †æ–¹å‘
 
 	@author genta
 
-	@param ptLayout [in] ŒŸõŠJn“_‚Ì•¨—À•W
-	@param pptLayoutNew [out] ˆÚ“®æ‚ÌƒŒƒCƒAƒEƒgÀ•W
-	@param upChar [in] Š‡ŒÊ‚Ìn‚Ü‚è‚Ì•¶š
-	@param dnChar [in] Š‡ŒÊ‚ğ•Â‚¶‚é•¶š—ñ
-	@param mode   [in] bit0(in)  : •\¦—ÌˆæŠO‚ğ’²‚×‚é‚©H 0:’²‚×‚È‚¢  1:’²‚×‚é (‚±‚Ìbit‚ğQÆ)
-					 bit1(in)  : ‘O•û•¶š‚ğ’²‚×‚é‚©H   0:’²‚×‚È‚¢  1:’²‚×‚é
-					 bit2(out) : Œ©‚Â‚©‚Á‚½ˆÊ’u         0:Œã‚ë      1:‘O
+	@param ptLayout [in] æ¤œç´¢é–‹å§‹ç‚¹ã®ç‰©ç†åº§æ¨™
+	@param pptLayoutNew [out] ç§»å‹•å…ˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆåº§æ¨™
+	@param upChar [in] æ‹¬å¼§ã®å§‹ã¾ã‚Šã®æ–‡å­—
+	@param dnChar [in] æ‹¬å¼§ã‚’é–‰ã˜ã‚‹æ–‡å­—åˆ—
+	@param mode   [in] bit0(in)  : è¡¨ç¤ºé ˜åŸŸå¤–ã‚’èª¿ã¹ã‚‹ã‹ï¼Ÿ 0:èª¿ã¹ãªã„  1:èª¿ã¹ã‚‹ (ã“ã®bitã‚’å‚ç…§)
+					 bit1(in)  : å‰æ–¹æ–‡å­—ã‚’èª¿ã¹ã‚‹ã‹ï¼Ÿ   0:èª¿ã¹ãªã„  1:èª¿ã¹ã‚‹
+					 bit2(out) : è¦‹ã¤ã‹ã£ãŸä½ç½®         0:å¾Œã‚      1:å‰
 
-	@retval true ¬Œ÷
-	@retval false ¸”s
+	@retval true æˆåŠŸ
+	@retval false å¤±æ•—
 */
 // 03/01/08 ai
 bool CEditView::SearchBracketForward(
@@ -418,7 +418,7 @@ bool CEditView::SearchBracketForward(
 
 	CLayoutInt	nSearchNum;	// 02/09/19 ai
 
-	//	‰ŠúˆÊ’u‚Ìİ’è
+	//	åˆæœŸä½ç½®ã®è¨­å®š
 	m_pcEditDoc->m_cLayoutMgr.LogicToLayout( ptPos, &ptColLine );	// 02/09/19 ai
 	nSearchNum = ( GetTextArea().GetBottomLine() ) - ptColLine.y;					// 02/09/19 ai
 	ci = m_pcEditDoc->m_cDocLineMgr.GetLine( ptPos.GetY2() );
@@ -442,29 +442,29 @@ bool CEditView::SearchBracketForward(
 				--level;
 			}// 03/01/08 ai End
 
-			if( level == 0 ){	//	Œ©‚Â‚©‚Á‚½I
+			if( level == 0 ){	//	è¦‹ã¤ã‹ã£ãŸï¼
 				ptPos.x = cPos - cline;
 				m_pcEditDoc->m_cLayoutMgr.LogicToLayout( ptPos, pptLayoutNew );
 				return true;
 				//	Happy Ending
 			}
-			cPos = nPos;	//	Ÿ‚Ì•¶š‚Ö
+			cPos = nPos;	//	æ¬¡ã®æ–‡å­—ã¸
 		}
 
 		// 02/09/19 ai Start
 		nSearchNum--;
 		if( ( 0 > nSearchNum ) && ( 0 == (*mode & 1 ) ) )
-		{	// •\¦—ÌˆæŠO‚ğ’²‚×‚È‚¢ƒ‚[ƒh‚Å•\¦—Ìˆæ‚ÌI’[‚Ìê‡
-			//SendStatusMessage( "‘ÎŠ‡ŒÊ‚ÌŒŸõ‚ğ’†’f‚µ‚Ü‚µ‚½" );
+		{	// è¡¨ç¤ºé ˜åŸŸå¤–ã‚’èª¿ã¹ãªã„ãƒ¢ãƒ¼ãƒ‰ã§è¡¨ç¤ºé ˜åŸŸã®çµ‚ç«¯ã®å ´åˆ
+			//SendStatusMessage( "å¯¾æ‹¬å¼§ã®æ¤œç´¢ã‚’ä¸­æ–­ã—ã¾ã—ãŸ" );
 			break;
 		}
 		// 02/09/19 ai End
 
-		//	Ÿ‚Ìs‚Ö
+		//	æ¬¡ã®è¡Œã¸
 		ptPos.y++;
-		ci = ci->GetNextLine();	//	Ÿ‚ÌƒAƒCƒeƒ€
+		ci = ci->GetNextLine();	//	æ¬¡ã®ã‚¢ã‚¤ãƒ†ãƒ 
 		if( ci == NULL )
-			break;	//	I‚í‚è‚É’B‚µ‚½
+			break;	//	çµ‚ã‚ã‚Šã«é”ã—ãŸ
 
 		cline = ci->GetDocLineStrWithEOL( &len );
 		cPos = cline;
@@ -475,20 +475,20 @@ bool CEditView::SearchBracketForward(
 }
 
 /*!
-	@brief ”¼Šp‘ÎŠ‡ŒÊ‚ÌŒŸõ:‹t•ûŒü
+	@brief åŠè§’å¯¾æ‹¬å¼§ã®æ¤œç´¢:é€†æ–¹å‘
 
 	@author genta
 
-	@param ptLayout [in] ŒŸõŠJn“_‚Ì•¨—À•W
-	@param pptLayoutNew [out] ˆÚ“®æ‚ÌƒŒƒCƒAƒEƒgÀ•W
-	@param upChar [in] Š‡ŒÊ‚Ìn‚Ü‚è‚Ì•¶š
-	@param dnChar [in] Š‡ŒÊ‚ğ•Â‚¶‚é•¶š—ñ
-	@param mode [in] bit0(in)  : •\¦—ÌˆæŠO‚ğ’²‚×‚é‚©H 0:’²‚×‚È‚¢  1:’²‚×‚é (‚±‚Ìbit‚ğQÆ)
-					 bit1(in)  : ‘O•û•¶š‚ğ’²‚×‚é‚©H   0:’²‚×‚È‚¢  1:’²‚×‚é
-					 bit2(out) : Œ©‚Â‚©‚Á‚½ˆÊ’u         0:Œã‚ë      1:‘O
+	@param ptLayout [in] æ¤œç´¢é–‹å§‹ç‚¹ã®ç‰©ç†åº§æ¨™
+	@param pptLayoutNew [out] ç§»å‹•å…ˆã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆåº§æ¨™
+	@param upChar [in] æ‹¬å¼§ã®å§‹ã¾ã‚Šã®æ–‡å­—
+	@param dnChar [in] æ‹¬å¼§ã‚’é–‰ã˜ã‚‹æ–‡å­—åˆ—
+	@param mode [in] bit0(in)  : è¡¨ç¤ºé ˜åŸŸå¤–ã‚’èª¿ã¹ã‚‹ã‹ï¼Ÿ 0:èª¿ã¹ãªã„  1:èª¿ã¹ã‚‹ (ã“ã®bitã‚’å‚ç…§)
+					 bit1(in)  : å‰æ–¹æ–‡å­—ã‚’èª¿ã¹ã‚‹ã‹ï¼Ÿ   0:èª¿ã¹ãªã„  1:èª¿ã¹ã‚‹
+					 bit2(out) : è¦‹ã¤ã‹ã£ãŸä½ç½®         0:å¾Œã‚      1:å‰
 
-	@retval true ¬Œ÷
-	@retval false ¸”s
+	@retval true æˆåŠŸ
+	@retval false å¤±æ•—
 */
 bool CEditView::SearchBracketBackward(
 	CLogicPoint		ptPos,
@@ -510,7 +510,7 @@ bool CEditView::SearchBracketBackward(
 
 	CLayoutInt		nSearchNum;	// 02/09/19 ai
 
-	//	‰ŠúˆÊ’u‚Ìİ’è
+	//	åˆæœŸä½ç½®ã®è¨­å®š
 	m_pcEditDoc->m_cLayoutMgr.LogicToLayout( ptPos, &ptColLine );	// 02/09/19 ai
 	nSearchNum = ptColLine.y - GetTextArea().GetViewTopLine();										// 02/09/19 ai
 	ci = m_pcEditDoc->m_cDocLineMgr.GetLine( ptPos.GetY2() );
@@ -533,29 +533,29 @@ bool CEditView::SearchBracketBackward(
 				--level;
 			}// 03/01/08 ai End
 
-			if( level == 0 ){	//	Œ©‚Â‚©‚Á‚½I
+			if( level == 0 ){	//	è¦‹ã¤ã‹ã£ãŸï¼
 				ptPos.x = pPos - cline;
 				m_pcEditDoc->m_cLayoutMgr.LogicToLayout( ptPos, pptLayoutNew );
 				return true;
 				//	Happy Ending
 			}
-			cPos = pPos;	//	Ÿ‚Ì•¶š‚Ö
+			cPos = pPos;	//	æ¬¡ã®æ–‡å­—ã¸
 		}
 
 		// 02/09/19 ai Start
 		nSearchNum--;
 		if( ( 0 > nSearchNum ) && ( 0 == (*mode & 1 ) ) )
-		{	// •\¦—ÌˆæŠO‚ğ’²‚×‚È‚¢ƒ‚[ƒh‚Å•\¦—Ìˆæ‚Ìæ“ª‚Ìê‡
-			//SendStatusMessage( "‘ÎŠ‡ŒÊ‚ÌŒŸõ‚ğ’†’f‚µ‚Ü‚µ‚½" );
+		{	// è¡¨ç¤ºé ˜åŸŸå¤–ã‚’èª¿ã¹ãªã„ãƒ¢ãƒ¼ãƒ‰ã§è¡¨ç¤ºé ˜åŸŸã®å…ˆé ­ã®å ´åˆ
+			//SendStatusMessage( "å¯¾æ‹¬å¼§ã®æ¤œç´¢ã‚’ä¸­æ–­ã—ã¾ã—ãŸ" );
 			break;
 		}
 		// 02/09/19 ai End
 
-		//	Ÿ‚Ìs‚Ö
+		//	æ¬¡ã®è¡Œã¸
 		ptPos.y--;
-		ci = ci->GetPrevLine();	//	Ÿ‚ÌƒAƒCƒeƒ€
+		ci = ci->GetPrevLine();	//	æ¬¡ã®ã‚¢ã‚¤ãƒ†ãƒ 
 		if( ci == NULL )
-			break;	//	I‚í‚è‚É’B‚µ‚½
+			break;	//	çµ‚ã‚ã‚Šã«é”ã—ãŸ
 
 		cline = ci->GetDocLineStrWithEOL( &len );
 		cPos = cline + len;
@@ -566,7 +566,7 @@ bool CEditView::SearchBracketBackward(
 
 //@@@ 2003.01.09 Start by ai:
 /*!
-	@brief Š‡ŒÊ”»’è
+	@brief æ‹¬å¼§åˆ¤å®š
 
 	@author ai
 
@@ -574,12 +574,12 @@ bool CEditView::SearchBracketBackward(
 	@param x
 	@param size
 
-	@retval true Š‡ŒÊ
-	@retval false ”ñŠ‡ŒÊ
+	@retval true æ‹¬å¼§
+	@retval false éæ‹¬å¼§
 */
 bool CEditView::IsBracket( const wchar_t *pLine, CLogicInt x, CLogicInt size )
 {
-	// Š‡ŒÊˆ— 2007.10.16 kobake
+	// æ‹¬å¼§å‡¦ç† 2007.10.16 kobake
 	if( size == 1 ){
 		const KAKKO_T *p;
 		for( p = g_aKakkos; p->sStr != NULL; p++ )

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -1,8 +1,8 @@
-/*!	@file
-	@brief •¶‘ƒEƒBƒ“ƒhƒE‚ÌŠÇ—
+ï»¿/*!	@file
+	@brief æ–‡æ›¸ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ç®¡ç†
 
 	@author kobake
-	@date	2008/04/14 ì¬
+	@date	2008/04/14 ä½œæˆ
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
@@ -30,14 +30,14 @@
 #include "types/CTypeSupport.h"
 #include <limits.h>
 
-/*! ƒXƒNƒ[ƒ‹ƒo[ì¬
-	@date 2006.12.19 ryoji V‹Kì¬iCEditView::Create‚©‚ç•ª—£j
+/*! ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ä½œæˆ
+	@date 2006.12.19 ryoji æ–°è¦ä½œæˆï¼ˆCEditView::Createã‹ã‚‰åˆ†é›¢ï¼‰
 */
 BOOL CEditView::CreateScrollBar()
 {
 	SCROLLINFO	si;
 
-	/* ƒXƒNƒ[ƒ‹ƒo[‚Ìì¬ */
+	/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®ä½œæˆ */
 	m_hwndVScrollBar = ::CreateWindowEx(
 		0L,									/* no extended styles */
 		_T("SCROLLBAR"),					/* scroll bar control class */
@@ -62,9 +62,9 @@ BOOL CEditView::CreateScrollBar()
 	::SetScrollInfo( m_hwndVScrollBar, SB_CTL, &si, TRUE );
 	::ShowScrollBar( m_hwndVScrollBar, SB_CTL, TRUE );
 
-	/* ƒXƒNƒ[ƒ‹ƒo[‚Ìì¬ */
+	/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®ä½œæˆ */
 	m_hwndHScrollBar = NULL;
-	if( GetDllShareData().m_Common.m_sWindow.m_bScrollBarHorz && !m_bMiniMap ){	/* …•½ƒXƒNƒ[ƒ‹ƒo[‚ğg‚¤ */
+	if( GetDllShareData().m_Common.m_sWindow.m_bScrollBarHorz && !m_bMiniMap ){	/* æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã‚’ä½¿ã† */
 		m_hwndHScrollBar = ::CreateWindowEx(
 			0L,									/* no extended styles */
 			_T("SCROLLBAR"),					/* scroll bar control class */
@@ -91,8 +91,8 @@ BOOL CEditView::CreateScrollBar()
 	}
 
 
-	/* ƒTƒCƒYƒ{ƒbƒNƒX */
-	if( GetDllShareData().m_Common.m_sWindow.m_nFUNCKEYWND_Place == 0 ){	/* ƒtƒ@ƒ“ƒNƒVƒ‡ƒ“ƒL[•\¦ˆÊ’u^0:ã 1:‰º */
+	/* ã‚µã‚¤ã‚ºãƒœãƒƒã‚¯ã‚¹ */
+	if( GetDllShareData().m_Common.m_sWindow.m_nFUNCKEYWND_Place == 0 ){	/* ãƒ•ã‚¡ãƒ³ã‚¯ã‚·ãƒ§ãƒ³ã‚­ãƒ¼è¡¨ç¤ºä½ç½®ï¼0:ä¸Š 1:ä¸‹ */
 		m_hwndSizeBox = ::CreateWindowEx(
 			WS_EX_CONTROLPARENT/*0L*/, 			/* no extended styles */
 			_T("SCROLLBAR"),					/* scroll bar control class */
@@ -128,8 +128,8 @@ BOOL CEditView::CreateScrollBar()
 
 
 
-/*! ƒXƒNƒ[ƒ‹ƒo[”jŠü
-	@date 2006.12.19 ryoji V‹Kì¬
+/*! ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ç ´æ£„
+	@date 2006.12.19 ryoji æ–°è¦ä½œæˆ
 */
 void CEditView::DestroyScrollBar()
 {
@@ -152,20 +152,20 @@ void CEditView::DestroyScrollBar()
 	}
 }
 
-/*! ‚’¼ƒXƒNƒ[ƒ‹ƒo[ƒƒbƒZ[ƒWˆ—
+/*! å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 
-	@param nScrollCode [in]	ƒXƒNƒ[ƒ‹í•Ê (Windows‚©‚ç“n‚³‚ê‚é‚à‚Ì)
-	@param nPos [in]		ƒXƒNƒ[ƒ‹ˆÊ’u(THUMBTRACK—p)
-	@retval	ÀÛ‚ÉƒXƒNƒ[ƒ‹‚µ‚½s”
+	@param nScrollCode [in]	ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ç¨®åˆ¥ (Windowsã‹ã‚‰æ¸¡ã•ã‚Œã‚‹ã‚‚ã®)
+	@param nPos [in]		ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ä½ç½®(THUMBTRACKç”¨)
+	@retval	å®Ÿéš›ã«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ãŸè¡Œæ•°
 
-	@date 2004.09.11 genta ƒXƒNƒ[ƒ‹s”‚ğ•Ô‚·‚æ‚¤‚ÉD
-		–¢g—p‚ÌhwndScrollBarˆø”íœD
+	@date 2004.09.11 genta ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•°ã‚’è¿”ã™ã‚ˆã†ã«ï¼
+		æœªä½¿ç”¨ã®hwndScrollBarå¼•æ•°å‰Šé™¤ï¼
 */
 CLayoutInt CEditView::OnVScroll( int nScrollCode, int nPos )
 {
 	CLayoutInt nScrollVal = CLayoutInt(0);
 
-	// nPos 32bit‘Î‰
+	// nPos 32bitå¯¾å¿œ
 	if( nScrollCode == SB_THUMBTRACK || nScrollCode == SB_THUMBPOSITION ){
 		if( m_hwndVScrollBar ){
 			HWND hWndScroll = m_hwndVScrollBar;
@@ -214,21 +214,21 @@ CLayoutInt CEditView::OnVScroll( int nScrollCode, int nPos )
 	return nScrollVal;
 }
 
-/*! …•½ƒXƒNƒ[ƒ‹ƒo[ƒƒbƒZ[ƒWˆ—
+/*! æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†
 
-	@param nScrollCode [in]	ƒXƒNƒ[ƒ‹í•Ê (Windows‚©‚ç“n‚³‚ê‚é‚à‚Ì)
-	@param nPos [in]		ƒXƒNƒ[ƒ‹ˆÊ’u(THUMBTRACK—p)
-	@retval	ÀÛ‚ÉƒXƒNƒ[ƒ‹‚µ‚½Œ…”
+	@param nScrollCode [in]	ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ç¨®åˆ¥ (Windowsã‹ã‚‰æ¸¡ã•ã‚Œã‚‹ã‚‚ã®)
+	@param nPos [in]		ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ä½ç½®(THUMBTRACKç”¨)
+	@retval	å®Ÿéš›ã«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ãŸæ¡æ•°
 
-	@date 2004.09.11 genta ƒXƒNƒ[ƒ‹Œ…”‚ğ•Ô‚·‚æ‚¤‚ÉD
-		–¢g—p‚ÌhwndScrollBarˆø”íœD
+	@date 2004.09.11 genta ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ¡æ•°ã‚’è¿”ã™ã‚ˆã†ã«ï¼
+		æœªä½¿ç”¨ã®hwndScrollBarå¼•æ•°å‰Šé™¤ï¼
 */
 CLayoutInt CEditView::OnHScroll( int nScrollCode, int nPos )
 {
 	const CLayoutInt nHScrollNum = GetTextMetrics().GetLayoutXDefault(CKetaXInt(4));
 	CLayoutInt nScrollVal = CLayoutInt(0);
 
-	// nPos 32bit‘Î‰
+	// nPos 32bitå¯¾å¿œ
 	if( nScrollCode == SB_THUMBTRACK || nScrollCode == SB_THUMBPOSITION ){
 		if( m_hwndHScrollBar ){
 			HWND hWndScroll = m_hwndHScrollBar;
@@ -266,22 +266,22 @@ CLayoutInt CEditView::OnHScroll( int nScrollCode, int nPos )
 		nScrollVal = ScrollAtH( CLayoutInt(0) );
 		break;
 	case SB_RIGHT:
-		//	Aug. 14, 2005 genta Ü‚è•Ô‚µ•‚ğLayoutMgr‚©‚çæ“¾‚·‚é‚æ‚¤‚É
+		//	Aug. 14, 2005 genta æŠ˜ã‚Šè¿”ã—å¹…ã‚’LayoutMgrã‹ã‚‰å–å¾—ã™ã‚‹ã‚ˆã†ã«
 		nScrollVal = ScrollAtH( m_pcEditDoc->m_cLayoutMgr.GetMaxLineKetas() - GetTextArea().m_nViewColNum );
 		break;
 	}
 	return nScrollVal;
 }
 
-/** ƒXƒNƒ[ƒ‹ƒo[‚Ìó‘Ô‚ğXV‚·‚é
+/** ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®çŠ¶æ…‹ã‚’æ›´æ–°ã™ã‚‹
 
-	ƒ^ƒuƒo[‚Ìƒ^ƒuØ‘Ö‚Í SIF_DISABLENOSCROLL ƒtƒ‰ƒO‚Å‚Ì—LŒø‰»^–³Œø‰»‚ª³í‚É“®ì‚µ‚È‚¢
-	i•s‰Â‹‚ÅƒTƒCƒY•ÏX‚µ‚Ä‚¢‚é‚±‚Æ‚É‚æ‚é‰e‹¿‚©Hj‚Ì‚Å SIF_DISABLENOSCROLL ‚Å—LŒø^–³Œø
-	‚ÌØ‘Ö‚É¸”s‚µ‚½ê‡‚É‚Í‹­§Ø‘Ö‚·‚é
+	ã‚¿ãƒ–ãƒãƒ¼ã®ã‚¿ãƒ–åˆ‡æ›¿æ™‚ã¯ SIF_DISABLENOSCROLL ãƒ•ãƒ©ã‚°ã§ã®æœ‰åŠ¹åŒ–ï¼ç„¡åŠ¹åŒ–ãŒæ­£å¸¸ã«å‹•ä½œã—ãªã„
+	ï¼ˆä¸å¯è¦–ã§ã‚µã‚¤ã‚ºå¤‰æ›´ã—ã¦ã„ã‚‹ã“ã¨ã«ã‚ˆã‚‹å½±éŸ¿ã‹ï¼Ÿï¼‰ã®ã§ SIF_DISABLENOSCROLL ã§æœ‰åŠ¹ï¼ç„¡åŠ¹
+	ã®åˆ‡æ›¿ã«å¤±æ•—ã—ãŸå ´åˆã«ã¯å¼·åˆ¶åˆ‡æ›¿ã™ã‚‹
 
-	@date 2008.05.24 ryoji —LŒø^–³Œø‚Ì‹­§Ø‘Ö‚ğ’Ç‰Á
-	@date 2008.06.08 ryoji …•½ƒXƒNƒ[ƒ‹”ÍˆÍ‚É‚Ô‚ç‰º‚°—]”’‚ğ’Ç‰Á
-	@date 2009.08.28 nasukoji	uÜ‚è•Ô‚³‚È‚¢v‘I‘ğ‚ÌƒXƒNƒ[ƒ‹ƒo[’²®
+	@date 2008.05.24 ryoji æœ‰åŠ¹ï¼ç„¡åŠ¹ã®å¼·åˆ¶åˆ‡æ›¿ã‚’è¿½åŠ 
+	@date 2008.06.08 ryoji æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ç¯„å›²ã«ã¶ã‚‰ä¸‹ã’ä½™ç™½ã‚’è¿½åŠ 
+	@date 2009.08.28 nasukoji	ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€é¸æŠæ™‚ã®ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼èª¿æ•´
 */
 void CEditView::AdjustScrollBars()
 {
@@ -294,13 +294,13 @@ void CEditView::AdjustScrollBars()
 	bool		bEnable;
 
 	if( NULL != m_hwndVScrollBar ){
-		/* ‚’¼ƒXƒNƒ[ƒ‹ƒo[ */
-		const CLayoutInt	nEofMargin = CLayoutInt(2); // EOF‚Æ‚»‚Ì‰º‚Ìƒ}[ƒWƒ“
+		/* å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ */
+		const CLayoutInt	nEofMargin = CLayoutInt(2); // EOFã¨ãã®ä¸‹ã®ãƒãƒ¼ã‚¸ãƒ³
 		const CLayoutInt	nAllLines = m_pcEditDoc->m_cLayoutMgr.GetLineCount() + nEofMargin;
 		int	nVScrollRate = 1;
 #ifdef _WIN64
-		/* nAllLines / nVScrollRate < INT_MAX ‚Æ‚È‚é®”nVScrollRate‚ğ‹‚ß‚é */
-		// 64bit”Å—pƒXƒNƒ[ƒ‹—¦
+		/* nAllLines / nVScrollRate < INT_MAX ã¨ãªã‚‹æ•´æ•°nVScrollRateã‚’æ±‚ã‚ã‚‹ */
+		// 64bitç‰ˆç”¨ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ç‡
 		while( nAllLines / nVScrollRate > INT_MAX ){
 			++nVScrollRate;
 		}
@@ -308,40 +308,40 @@ void CEditView::AdjustScrollBars()
 		si.cbSize = sizeof( si );
 		si.fMask = SIF_ALL | SIF_DISABLENOSCROLL;
 		si.nMin  = 0;
-		si.nMax  = (Int)nAllLines / nVScrollRate - 1;	/* ‘Ss” */
-		si.nPage = (Int)GetTextArea().m_nViewRowNum / nVScrollRate;	/* •\¦ˆæ‚Ìs” */
-		si.nPos  = (Int)GetTextArea().GetViewTopLine() / nVScrollRate;	/* •\¦ˆæ‚Ìˆê”Ôã‚Ìs(0ŠJn) */
+		si.nMax  = (Int)nAllLines / nVScrollRate - 1;	/* å…¨è¡Œæ•° */
+		si.nPage = (Int)GetTextArea().m_nViewRowNum / nVScrollRate;	/* è¡¨ç¤ºåŸŸã®è¡Œæ•° */
+		si.nPos  = (Int)GetTextArea().GetViewTopLine() / nVScrollRate;	/* è¡¨ç¤ºåŸŸã®ä¸€ç•ªä¸Šã®è¡Œ(0é–‹å§‹) */
 		si.nTrackPos = 0;
 		::SetScrollInfo( m_hwndVScrollBar, SB_CTL, &si, TRUE );
-		m_nVScrollRate = nVScrollRate;				/* ‚’¼ƒXƒNƒ[ƒ‹ƒo[‚ÌkÚ */
+		m_nVScrollRate = nVScrollRate;				/* å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®ç¸®å°º */
 		
 		//	Nov. 16, 2002 genta
-		//	cƒXƒNƒ[ƒ‹ƒo[‚ªDisable‚É‚È‚Á‚½‚Æ‚«‚Í•K‚¸‘S‘Ì‚ª‰æ–Ê“à‚Éû‚Ü‚é‚æ‚¤‚É
-		//	ƒXƒNƒ[ƒ‹‚³‚¹‚é
-		//	2005.11.01 aroka ”»’èğŒŒë‚èC³ (ƒo[‚ªÁ‚¦‚Ä‚àƒXƒNƒ[ƒ‹‚µ‚È‚¢)
+		//	ç¸¦ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ãŒDisableã«ãªã£ãŸã¨ãã¯å¿…ãšå…¨ä½“ãŒç”»é¢å†…ã«åã¾ã‚‹ã‚ˆã†ã«
+		//	ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã•ã›ã‚‹
+		//	2005.11.01 aroka åˆ¤å®šæ¡ä»¶èª¤ã‚Šä¿®æ­£ (ãƒãƒ¼ãŒæ¶ˆãˆã¦ã‚‚ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ãªã„)
 		bEnable = ( GetTextArea().m_nViewRowNum < nAllLines );
 		if( bEnable != (::IsWindowEnabled( m_hwndVScrollBar ) != 0) ){
-			::EnableWindow( m_hwndVScrollBar, bEnable? TRUE: FALSE );	// SIF_DISABLENOSCROLL Œë“®ì‚Ì‹­§Ø‘Ö
+			::EnableWindow( m_hwndVScrollBar, bEnable? TRUE: FALSE );	// SIF_DISABLENOSCROLL èª¤å‹•ä½œæ™‚ã®å¼·åˆ¶åˆ‡æ›¿
 		}
 		if( !bEnable ){
 			ScrollAtV( CLayoutInt(0) );
 		}
 	}
 	if( NULL != m_hwndHScrollBar ){
-		/* …•½ƒXƒNƒ[ƒ‹ƒo[ */
+		/* æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ */
 		si.cbSize = sizeof( si );
 		si.fMask = SIF_ALL | SIF_DISABLENOSCROLL;
 		si.nMin  = 0;
-		si.nMax  = (Int)GetRightEdgeForScrollBar() - 1;		// 2009.08.28 nasukoji	ƒXƒNƒ[ƒ‹ƒo[§Œä—p‚Ì‰E’[À•W‚ğæ“¾
-		si.nPage = (Int)GetTextArea().m_nViewColNum;			/* •\¦ˆæ‚ÌŒ…” */
-		si.nPos  = (Int)GetTextArea().GetViewLeftCol();		/* •\¦ˆæ‚Ìˆê”Ô¶‚ÌŒ…(0ŠJn) */
+		si.nMax  = (Int)GetRightEdgeForScrollBar() - 1;		// 2009.08.28 nasukoji	ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼åˆ¶å¾¡ç”¨ã®å³ç«¯åº§æ¨™ã‚’å–å¾—
+		si.nPage = (Int)GetTextArea().m_nViewColNum;			/* è¡¨ç¤ºåŸŸã®æ¡æ•° */
+		si.nPos  = (Int)GetTextArea().GetViewLeftCol();		/* è¡¨ç¤ºåŸŸã®ä¸€ç•ªå·¦ã®æ¡(0é–‹å§‹) */
 		si.nTrackPos = 1;
 		::SetScrollInfo( m_hwndHScrollBar, SB_CTL, &si, TRUE );
 
-		//	2006.1.28 aroka ”»’èğŒŒë‚èC³ (ƒo[‚ªÁ‚¦‚Ä‚àƒXƒNƒ[ƒ‹‚µ‚È‚¢)
+		//	2006.1.28 aroka åˆ¤å®šæ¡ä»¶èª¤ã‚Šä¿®æ­£ (ãƒãƒ¼ãŒæ¶ˆãˆã¦ã‚‚ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ãªã„)
 		bEnable = ( GetTextArea().m_nViewColNum < GetRightEdgeForScrollBar() );
 		if( bEnable != (::IsWindowEnabled( m_hwndHScrollBar ) != 0) ){
-			::EnableWindow( m_hwndHScrollBar, bEnable? TRUE: FALSE );	// SIF_DISABLENOSCROLL Œë“®ì‚Ì‹­§Ø‘Ö
+			::EnableWindow( m_hwndHScrollBar, bEnable? TRUE: FALSE );	// SIF_DISABLENOSCROLL èª¤å‹•ä½œæ™‚ã®å¼·åˆ¶åˆ‡æ›¿
 		}
 		if( !bEnable ){
 			ScrollAtH( CLayoutInt(0) );
@@ -349,12 +349,12 @@ void CEditView::AdjustScrollBars()
 	}
 }
 
-/*! w’èã’[sˆÊ’u‚ÖƒXƒNƒ[ƒ‹
+/*! æŒ‡å®šä¸Šç«¯è¡Œä½ç½®ã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
 
-	@param nPos [in] ƒXƒNƒ[ƒ‹ˆÊ’u
-	@retval ÀÛ‚ÉƒXƒNƒ[ƒ‹‚µ‚½s” (³:‰º•ûŒü/•‰:ã•ûŒü)
+	@param nPos [in] ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ä½ç½®
+	@retval å®Ÿéš›ã«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ãŸè¡Œæ•° (æ­£:ä¸‹æ–¹å‘/è² :ä¸Šæ–¹å‘)
 
-	@date 2004.09.11 genta s”‚ğ–ß‚è’l‚Æ‚µ‚Ä•Ô‚·‚æ‚¤‚ÉD(“¯ŠúƒXƒNƒ[ƒ‹—p)
+	@date 2004.09.11 genta è¡Œæ•°ã‚’æˆ»ã‚Šå€¤ã¨ã—ã¦è¿”ã™ã‚ˆã†ã«ï¼(åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ç”¨)
 */
 CLayoutInt CEditView::ScrollAtV( CLayoutInt nPos )
 {
@@ -371,12 +371,12 @@ CLayoutInt CEditView::ScrollAtV( CLayoutInt nPos )
 		}
 	}
 	if( GetTextArea().GetViewTopLine() == nPos ){
-		return CLayoutInt(0);	//	ƒXƒNƒ[ƒ‹–³‚µB
+		return CLayoutInt(0);	//	ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ç„¡ã—ã€‚
 	}
-	/* ‚’¼ƒXƒNƒ[ƒ‹—Êis”j‚ÌZo */
+	/* å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é‡ï¼ˆè¡Œæ•°ï¼‰ã®ç®—å‡º */
 	nScrollRowNum = GetTextArea().GetViewTopLine() - nPos;
 
-	/* ƒXƒNƒ[ƒ‹ */
+	/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ« */
 	if( t_abs( nScrollRowNum ) >= GetTextArea().m_nViewRowNum ){
 		GetTextArea().SetViewTopLine( CLayoutInt(nPos) );
 		::InvalidateRect( GetHwnd(), NULL, TRUE );
@@ -414,28 +414,28 @@ CLayoutInt CEditView::ScrollAtV( CLayoutInt nPos )
 		}
 	}
 
-	/* ƒXƒNƒ[ƒ‹ƒo[‚Ìó‘Ô‚ğXV‚·‚é */
+	/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®çŠ¶æ…‹ã‚’æ›´æ–°ã™ã‚‹ */
 	AdjustScrollBars();
 
-	/* ƒLƒƒƒŒƒbƒg‚Ì•\¦EXV */
+	/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤ºãƒ»æ›´æ–° */
 	GetCaret().ShowEditCaret();
 
 	MiniMapRedraw(false);
 
-	return -nScrollRowNum;	//•ûŒü‚ª‹t‚È‚Ì‚Å•„†”½“]‚ª•K—v
+	return -nScrollRowNum;	//æ–¹å‘ãŒé€†ãªã®ã§ç¬¦å·åè»¢ãŒå¿…è¦
 }
 
 
 
 
-/*! w’è¶’[Œ…ˆÊ’u‚ÖƒXƒNƒ[ƒ‹
+/*! æŒ‡å®šå·¦ç«¯æ¡ä½ç½®ã¸ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
 
-	@param nPos [in] ƒXƒNƒ[ƒ‹ˆÊ’u
-	@retval ÀÛ‚ÉƒXƒNƒ[ƒ‹‚µ‚½Œ…” (³:‰E•ûŒü/•‰:¶•ûŒü)
+	@param nPos [in] ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ä½ç½®
+	@retval å®Ÿéš›ã«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ãŸæ¡æ•° (æ­£:å³æ–¹å‘/è² :å·¦æ–¹å‘)
 
-	@date 2004.09.11 genta Œ…”‚ğ–ß‚è’l‚Æ‚µ‚Ä•Ô‚·‚æ‚¤‚ÉD(“¯ŠúƒXƒNƒ[ƒ‹—p)
-	@date 2008.06.08 ryoji …•½ƒXƒNƒ[ƒ‹”ÍˆÍ‚É‚Ô‚ç‰º‚°—]”’‚ğ’Ç‰Á
-	@date 2009.08.28 nasukoji	uÜ‚è•Ô‚³‚È‚¢v‘I‘ğ‰E‚És‚«‰ß‚¬‚È‚¢‚æ‚¤‚É‚·‚é
+	@date 2004.09.11 genta æ¡æ•°ã‚’æˆ»ã‚Šå€¤ã¨ã—ã¦è¿”ã™ã‚ˆã†ã«ï¼(åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ç”¨)
+	@date 2008.06.08 ryoji æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ç¯„å›²ã«ã¶ã‚‰ä¸‹ã’ä½™ç™½ã‚’è¿½åŠ 
+	@date 2009.08.28 nasukoji	ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€é¸æŠæ™‚å³ã«è¡Œãéããªã„ã‚ˆã†ã«ã™ã‚‹
 */
 CLayoutInt CEditView::ScrollAtH( CLayoutInt nPos )
 {
@@ -444,24 +444,24 @@ CLayoutInt CEditView::ScrollAtH( CLayoutInt nPos )
 	if( nPos < 0 ){
 		nPos = CLayoutInt(0);
 	}
-	//	Aug. 18, 2003 ryoji •Ï”‚Ìƒ~ƒX‚ğC³
-	//	ƒEƒBƒ“ƒhƒE‚Ì•‚ğ‚«‚í‚ß‚Ä‹·‚­‚µ‚½‚Æ‚«‚É•ÒW—Ìˆæ‚ªs”Ô†‚©‚ç—£‚ê‚Ä‚µ‚Ü‚¤‚±‚Æ‚ª‚ ‚Á‚½D
-	//	Aug. 14, 2005 genta Ü‚è•Ô‚µ•‚ğLayoutMgr‚©‚çæ“¾‚·‚é‚æ‚¤‚É
+	//	Aug. 18, 2003 ryoji å¤‰æ•°ã®ãƒŸã‚¹ã‚’ä¿®æ­£
+	//	ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®å¹…ã‚’ãã‚ã‚ã¦ç‹­ãã—ãŸã¨ãã«ç·¨é›†é ˜åŸŸãŒè¡Œç•ªå·ã‹ã‚‰é›¢ã‚Œã¦ã—ã¾ã†ã“ã¨ãŒã‚ã£ãŸï¼
+	//	Aug. 14, 2005 genta æŠ˜ã‚Šè¿”ã—å¹…ã‚’LayoutMgrã‹ã‚‰å–å¾—ã™ã‚‹ã‚ˆã†ã«
 	else if( GetRightEdgeForScrollBar() + GetWrapOverhang() - GetTextArea().m_nViewColNum  < nPos ){
 		nPos = GetRightEdgeForScrollBar() + GetWrapOverhang() - GetTextArea().m_nViewColNum ;
-		//	May 29, 2004 genta Ü‚è•Ô‚µ•‚æ‚èƒEƒBƒ“ƒhƒE•‚ª‘å‚«‚¢‚Æ‚«‚ÉWM_HSCROLL‚ª—ˆ‚é‚Æ
-		//	nPos‚ª•‰‚Ì’l‚É‚È‚é‚±‚Æ‚ª‚ ‚èC‚»‚Ìê‡‚ÉƒXƒNƒ[ƒ‹ƒo[‚©‚ç•ÒW—Ìˆæ‚ª
-		//	—£‚ê‚Ä‚µ‚Ü‚¤D
+		//	May 29, 2004 genta æŠ˜ã‚Šè¿”ã—å¹…ã‚ˆã‚Šã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ãŒå¤§ãã„ã¨ãã«WM_HSCROLLãŒæ¥ã‚‹ã¨
+		//	nPosãŒè² ã®å€¤ã«ãªã‚‹ã“ã¨ãŒã‚ã‚Šï¼Œãã®å ´åˆã«ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã‹ã‚‰ç·¨é›†é ˜åŸŸãŒ
+		//	é›¢ã‚Œã¦ã—ã¾ã†ï¼
 		if( nPos < 0 )
 			nPos = CLayoutInt(0);
 	}
 	if( GetTextArea().GetViewLeftCol() == nPos ){
 		return CLayoutInt(0);
 	}
-	/* …•½ƒXƒNƒ[ƒ‹—Êi•¶š”j‚ÌZo */
+	/* æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é‡ï¼ˆæ–‡å­—æ•°ï¼‰ã®ç®—å‡º */
 	const CLayoutInt	nScrollColNum = GetTextArea().GetViewLeftCol() - nPos;
 
-	/* ƒXƒNƒ[ƒ‹ */
+	/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ« */
 	if( t_abs( nScrollColNum ) >= GetTextArea().m_nViewColNum /*|| abs( nScrollRowNum ) >= GetTextArea().m_nViewRowNum*/ ){
 		GetTextArea().SetViewLeftCol( nPos );
 		::InvalidateRect( GetHwnd(), NULL, TRUE );
@@ -495,21 +495,21 @@ CLayoutInt CEditView::ScrollAtH( CLayoutInt nPos )
 			::UpdateWindow( GetHwnd() );
 		}
 	}
-	//	2006.1.28 aroka ”»’èğŒŒë‚èC³ (ƒo[‚ªÁ‚¦‚Ä‚àƒXƒNƒ[ƒ‹‚µ‚È‚¢)
-	// æ‚ÉAdjustScrollBars‚ğŒÄ‚ñ‚Å‚µ‚Ü‚¤‚ÆA“ñ“x–Ú‚Í‚±‚±‚Ü‚Å‚±‚È‚¢‚Ì‚ÅA
-	// GetRuler().DispRuler‚ªŒÄ‚Î‚ê‚È‚¢B‚»‚Ì‚½‚ßA‡˜‚ğ“ü‚ê‘Ö‚¦‚½B
-	GetRuler().SetRedrawFlag(); // ƒ‹[ƒ‰[‚ğÄ•`‰æ‚·‚éB
+	//	2006.1.28 aroka åˆ¤å®šæ¡ä»¶èª¤ã‚Šä¿®æ­£ (ãƒãƒ¼ãŒæ¶ˆãˆã¦ã‚‚ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ãªã„)
+	// å…ˆã«AdjustScrollBarsã‚’å‘¼ã‚“ã§ã—ã¾ã†ã¨ã€äºŒåº¦ç›®ã¯ã“ã“ã¾ã§ã“ãªã„ã®ã§ã€
+	// GetRuler().DispRulerãŒå‘¼ã°ã‚Œãªã„ã€‚ãã®ãŸã‚ã€é †åºã‚’å…¥ã‚Œæ›¿ãˆãŸã€‚
+	GetRuler().SetRedrawFlag(); // ãƒ«ãƒ¼ãƒ©ãƒ¼ã‚’å†æç”»ã™ã‚‹ã€‚
 	HDC hdc = ::GetDC( GetHwnd() );
 	GetRuler().DispRuler( hdc );
 	::ReleaseDC( GetHwnd(), hdc );
 
-	/* ƒXƒNƒ[ƒ‹ƒo[‚Ìó‘Ô‚ğXV‚·‚é */
+	/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®çŠ¶æ…‹ã‚’æ›´æ–°ã™ã‚‹ */
 	AdjustScrollBars();
 
-	/* ƒLƒƒƒŒƒbƒg‚Ì•\¦EXV */
+	/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®è¡¨ç¤ºãƒ»æ›´æ–° */
 	GetCaret().ShowEditCaret();
 
-	return -nScrollColNum;	//•ûŒü‚ª‹t‚È‚Ì‚Å•„†”½“]‚ª•K—v
+	return -nScrollColNum;	//æ–¹å‘ãŒé€†ãªã®ã§ç¬¦å·åè»¢ãŒå¿…è¦
 }
 
 
@@ -517,26 +517,26 @@ void CEditView::ScrollDraw(CLayoutInt nScrollRowNum, CLayoutInt nScrollColNum, c
 {
 	const CTextArea& area = GetTextArea();
 
-	// ”wŒi‚Í‰æ–Ê‚É‘Î‚µ‚ÄŒÅ’è‚©
+	// èƒŒæ™¯ã¯ç”»é¢ã«å¯¾ã—ã¦å›ºå®šã‹
 	bool bBackImgFixed = IsBkBitmap() &&
 		(0 != nScrollRowNum && !m_pTypeData->m_backImgScrollY ||
 		 0 != nScrollColNum && !m_pTypeData->m_backImgScrollX);
 	if( bBackImgFixed ){
 		CMyRect rcBody = area.GetAreaRect();
-		rcBody.left = 0; // s”Ô†‚àˆÚ“®
+		rcBody.left = 0; // è¡Œç•ªå·ã‚‚ç§»å‹•
 		rcBody.top = area.GetRulerHeight();
 		InvalidateRect(&rcBody, FALSE);
 	}else{
 		int nScrollColPxWidth = GetTextMetrics().GetCharPxWidth(nScrollColNum);
 		ScrollWindowEx(
-			nScrollColPxWidth,	// …•½ƒXƒNƒ[ƒ‹—Ê
-			(Int)nScrollRowNum * GetTextMetrics().GetHankakuDy(),	// ‚’¼ƒXƒNƒ[ƒ‹—Ê
-			&rcScroll,	/* ƒXƒNƒ[ƒ‹’·•ûŒ`‚Ì\‘¢‘Ì‚ÌƒAƒhƒŒƒX */
+			nScrollColPxWidth,	// æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é‡
+			(Int)nScrollRowNum * GetTextMetrics().GetHankakuDy(),	// å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é‡
+			&rcScroll,	/* ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«é•·æ–¹å½¢ã®æ§‹é€ ä½“ã®ã‚¢ãƒ‰ãƒ¬ã‚¹ */
 			NULL, NULL , NULL, SW_ERASE | SW_INVALIDATE
 		);
-		// From Here 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
+		// From Here 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
 		if( m_hbmpCompatBMP ){
-			// ŒİŠ·BMP‚àƒXƒNƒ[ƒ‹ˆ—‚Ì‚½‚ß‚ÉBitBlt‚ÅˆÚ“®‚³‚¹‚é
+			// äº’æ›BMPã‚‚ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å‡¦ç†ã®ãŸã‚ã«BitBltã§ç§»å‹•ã•ã›ã‚‹
 			::BitBlt(
 				m_hdcCompatDC,
 				rcScroll.left + nScrollColPxWidth,
@@ -549,7 +549,7 @@ void CEditView::ScrollDraw(CLayoutInt nScrollRowNum, CLayoutInt nScrollColNum, c
 		if( 0 < area.GetTopYohaku() &&
 		  IsBkBitmap() &&
 		  (0 != nScrollRowNum && m_pTypeData->m_backImgScrollY || 0 != nScrollColNum && m_pTypeData->m_backImgScrollX) ){
-			// Scroll‚Ì‚Æ‚«‚Éƒ‹[ƒ‰[—]”’XV
+			// Scrollã®ã¨ãã«ãƒ«ãƒ¼ãƒ©ãƒ¼ä½™ç™½æ›´æ–°
 			CMyRect rcTopYohaku;
 			if( CTypeSupport(this, COLORIDX_TEXT).GetBackColor() == CTypeSupport(this, COLORIDX_GYOU).GetBackColor() ){
 				rcTopYohaku.left = 0;
@@ -570,13 +570,13 @@ void CEditView::ScrollDraw(CLayoutInt nScrollRowNum, CLayoutInt nScrollColNum, c
 			}
 		}
 		if( IsBkBitmap() && 0 != nScrollColNum && m_pTypeData->m_backImgScrollX ){
-			// s”Ô†”wŒi‚Ì‚½‚ß‚ÉXV
+			// è¡Œç•ªå·èƒŒæ™¯ã®ãŸã‚ã«æ›´æ–°
 			CMyRect rcLineNum;
 			area.GenerateLineNumberRect(&rcLineNum);
 			InvalidateRect( &rcLineNum, FALSE );
 		}
 	}
-	// ƒJ[ƒ\ƒ‹‚Ìcü‚ªƒeƒLƒXƒg‚Æs”Ô†‚ÌŒ„ŠÔ‚É‚ ‚é‚Æ‚«AƒXƒNƒ[ƒ‹‚Écü—Ìˆæ‚ğXV
+	// ã‚«ãƒ¼ã‚½ãƒ«ã®ç¸¦ç·šãŒãƒ†ã‚­ã‚¹ãƒˆã¨è¡Œç•ªå·ã®éš™é–“ã«ã‚ã‚‹ã¨ãã€ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ™‚ã«ç¸¦ç·šé ˜åŸŸã‚’æ›´æ–°
 	if( nScrollColNum != 0 && m_nOldCursorLineX == GetTextArea().GetAreaLeft() - 1 ){
 		RECT rcClip3;
 		rcClip3.left   = m_nOldCursorLineX - (m_nOldCursorVLineWidth - 1);
@@ -614,7 +614,7 @@ void CEditView::MiniMapRedraw(bool bUpdateAll)
 		bool bUpdateOne = false;
 		if( bUpdate ){
 			if( nViewTop == GetTextArea().GetViewTopLine() ){
-				// OnSize:‰º‚¾‚¯Lk‚·‚é
+				// OnSize:ä¸‹ã ã‘ä¼¸ç¸®ã™ã‚‹
 				bUpdateOne = true;
 				nDrawTopTop = t_min(nViewBottom, GetTextArea().GetBottomLine());
 				nDrawTopBottom = t_max(nViewBottom, GetTextArea().GetBottomLine());
@@ -624,11 +624,11 @@ void CEditView::MiniMapRedraw(bool bUpdateAll)
 			}
 		}else{
 			if( nDiff < 0 ){
-				// ã‚ÉˆÚ“®
+				// ä¸Šã«ç§»å‹•
 				nDrawTopTop = GetTextArea().GetViewTopLine();
 				nDrawTopBottom = nViewTop;
 			}else{
-				// ‰º‚ÉˆÚ“®
+				// ä¸‹ã«ç§»å‹•
 				nDrawTopTop = nViewTop;
 				nDrawTopBottom = GetTextArea().GetViewTopLine();
 			}
@@ -651,11 +651,11 @@ void CEditView::MiniMapRedraw(bool bUpdateAll)
 			nDrawBottomBottom = GetTextArea().GetBottomLine();
 		}else{
 			if( nDiff < 0 ){
-				// ã‚ÉˆÚ“®
+				// ä¸Šã«ç§»å‹•
 				nDrawBottomTop = GetTextArea().GetBottomLine();
 				nDrawBottomBottom = nViewBottom;
 			}else{
-				// ‰º‚ÉˆÚ“®
+				// ä¸‹ã«ç§»å‹•
 				nDrawBottomTop = nViewBottom;
 				nDrawBottomBottom = GetTextArea().GetBottomLine();
 			}
@@ -670,17 +670,17 @@ void CEditView::MiniMapRedraw(bool bUpdateAll)
 }
 
 
-/*!	‚’¼“¯ŠúƒXƒNƒ[ƒ‹
+/*!	å‚ç›´åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
 
-	‚’¼“¯ŠúƒXƒNƒ[ƒ‹‚ªON‚È‚ç‚ÎC‘Î‰‚·‚éƒEƒBƒ“ƒhƒE‚ğw’ès”“¯ŠúƒXƒNƒ[ƒ‹‚·‚é
+	å‚ç›´åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãŒONãªã‚‰ã°ï¼Œå¯¾å¿œã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’æŒ‡å®šè¡Œæ•°åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹
 	
-	@param line [in] ƒXƒNƒ[ƒ‹s” (³:‰º•ûŒü/•‰:ã•ûŒü/0:‰½‚à‚µ‚È‚¢)
+	@param line [in] ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«è¡Œæ•° (æ­£:ä¸‹æ–¹å‘/è² :ä¸Šæ–¹å‘/0:ä½•ã‚‚ã—ãªã„)
 	
 	@author asa-o
-	@date 2001.06.20 asa-o V‹Kì¬
-	@date 2004.09.11 genta ŠÖ”‰»
+	@date 2001.06.20 asa-o æ–°è¦ä½œæˆ
+	@date 2004.09.11 genta é–¢æ•°åŒ–
 
-	@note “®ì‚ÌÚ×‚Íİ’è‚â‹@”\Šg’£‚É‚æ‚è•ÏX‚É‚È‚é‰Â”\«‚ª‚ ‚é
+	@note å‹•ä½œã®è©³ç´°ã¯è¨­å®šã‚„æ©Ÿèƒ½æ‹¡å¼µã«ã‚ˆã‚Šå¤‰æ›´ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 
 */
 void CEditView::SyncScrollV( CLayoutInt line )
@@ -691,7 +691,7 @@ void CEditView::SyncScrollV( CLayoutInt line )
 	){
 		CEditView&	editView = m_pcEditWnd->GetView(m_nMyIndex^0x01);
 #if 0
-		//	·•ª‚ğ•Û‚Á‚½‚Ü‚ÜƒXƒNƒ[ƒ‹‚·‚éê‡
+		//	å·®åˆ†ã‚’ä¿ã£ãŸã¾ã¾ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹å ´åˆ
 		editView.ScrollByV( line );
 #else
 		editView.ScrollAtV( GetTextArea().GetViewTopLine() );
@@ -699,17 +699,17 @@ void CEditView::SyncScrollV( CLayoutInt line )
 	}
 }
 
-/*!	…•½“¯ŠúƒXƒNƒ[ƒ‹
+/*!	æ°´å¹³åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«
 
-	…•½“¯ŠúƒXƒNƒ[ƒ‹‚ªON‚È‚ç‚ÎC‘Î‰‚·‚éƒEƒBƒ“ƒhƒE‚ğw’ès”“¯ŠúƒXƒNƒ[ƒ‹‚·‚éD
+	æ°´å¹³åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãŒONãªã‚‰ã°ï¼Œå¯¾å¿œã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚’æŒ‡å®šè¡Œæ•°åŒæœŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹ï¼
 	
-	@param col [in] ƒXƒNƒ[ƒ‹Œ…” (³:‰E•ûŒü/•‰:¶•ûŒü/0:‰½‚à‚µ‚È‚¢)
+	@param col [in] ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ¡æ•° (æ­£:å³æ–¹å‘/è² :å·¦æ–¹å‘/0:ä½•ã‚‚ã—ãªã„)
 	
 	@author asa-o
-	@date 2001.06.20 asa-o V‹Kì¬
-	@date 2004.09.11 genta ŠÖ”‰»
+	@date 2001.06.20 asa-o æ–°è¦ä½œæˆ
+	@date 2004.09.11 genta é–¢æ•°åŒ–
 
-	@note “®ì‚ÌÚ×‚Íİ’è‚â‹@”\Šg’£‚É‚æ‚è•ÏX‚É‚È‚é‰Â”\«‚ª‚ ‚é
+	@note å‹•ä½œã®è©³ç´°ã¯è¨­å®šã‚„æ©Ÿèƒ½æ‹¡å¼µã«ã‚ˆã‚Šå¤‰æ›´ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹
 */
 void CEditView::SyncScrollH( CLayoutInt col )
 {
@@ -721,83 +721,83 @@ void CEditView::SyncScrollH( CLayoutInt col )
 		HDC			hdc = ::GetDC( cEditView.GetHwnd() );
 		
 #if 0
-		//	·•ª‚ğ•Û‚Á‚½‚Ü‚ÜƒXƒNƒ[ƒ‹‚·‚éê‡
+		//	å·®åˆ†ã‚’ä¿ã£ãŸã¾ã¾ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã™ã‚‹å ´åˆ
 		cEditView.ScrollByH( col );
 #else
 		cEditView.ScrollAtH( GetTextArea().GetViewLeftCol() );
 #endif
-		GetRuler().SetRedrawFlag(); //2002.02.25 Add By KK ƒXƒNƒ[ƒ‹ƒ‹[ƒ‰[‘S‘Ì‚ğ•`‚«‚È‚¨‚·B
+		GetRuler().SetRedrawFlag(); //2002.02.25 Add By KK ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«æ™‚ãƒ«ãƒ¼ãƒ©ãƒ¼å…¨ä½“ã‚’æããªãŠã™ã€‚
 		GetRuler().DispRuler( hdc );
 		::ReleaseDC( GetHwnd(), hdc );
 	}
 }
 
-/** Ü‚è•Ô‚µŒ…ˆÈŒã‚Ì‚Ô‚ç‰º‚°—]”’ŒvZ
-	@date 2008.06.08 ryoji V‹Kì¬
+/** æŠ˜ã‚Šè¿”ã—æ¡ä»¥å¾Œã®ã¶ã‚‰ä¸‹ã’ä½™ç™½è¨ˆç®—
+	@date 2008.06.08 ryoji æ–°è¦ä½œæˆ
 */
 CLayoutInt CEditView::GetWrapOverhang( void ) const
 {
-	CLayoutInt nMargin = GetTextMetrics().GetLayoutXDefault(CKetaXInt(1));	// Ü‚è•Ô‚µ‹L†
-	if (!m_pTypeData->m_bKinsokuHide) {	// ‚Ô‚ç‰º‚°‚ğ‰B‚·‚ÍƒXƒLƒbƒv	2012/11/30 Uchi
+	CLayoutInt nMargin = GetTextMetrics().GetLayoutXDefault(CKetaXInt(1));	// æŠ˜ã‚Šè¿”ã—è¨˜å·
+	if (!m_pTypeData->m_bKinsokuHide) {	// ã¶ã‚‰ä¸‹ã’ã‚’éš ã™æ™‚ã¯ã‚¹ã‚­ãƒƒãƒ—	2012/11/30 Uchi
 		if( m_pTypeData->m_bKinsokuRet )
-			nMargin += GetTextMetrics().GetLayoutXDefault(CKetaXInt(1));	// ‰üs‚Ô‚ç‰º‚°
+			nMargin += GetTextMetrics().GetLayoutXDefault(CKetaXInt(1));	// æ”¹è¡Œã¶ã‚‰ä¸‹ã’
 		if( m_pTypeData->m_bKinsokuKuto )
-			nMargin += GetTextMetrics().GetLayoutXDefault(CKetaXInt(2));	// ‹å“Ç“_‚Ô‚ç‰º‚°
+			nMargin += GetTextMetrics().GetLayoutXDefault(CKetaXInt(2));	// å¥èª­ç‚¹ã¶ã‚‰ä¸‹ã’
 	}
 	return CLayoutInt( nMargin );
 }
 
-/** u‰E’[‚ÅÜ‚è•Ô‚·v—p‚Éƒrƒ…[‚ÌŒ…”‚©‚çÜ‚è•Ô‚µŒ…”‚ğŒvZ‚·‚é
-	@param nViewColNum	[in] ƒrƒ…[‚ÌŒ…”
-	@retval Ü‚è•Ô‚µŒ…”
-	@date 2008.06.08 ryoji V‹Kì¬
+/** ã€Œå³ç«¯ã§æŠ˜ã‚Šè¿”ã™ã€ç”¨ã«ãƒ“ãƒ¥ãƒ¼ã®æ¡æ•°ã‹ã‚‰æŠ˜ã‚Šè¿”ã—æ¡æ•°ã‚’è¨ˆç®—ã™ã‚‹
+	@param nViewColNum	[in] ãƒ“ãƒ¥ãƒ¼ã®æ¡æ•°
+	@retval æŠ˜ã‚Šè¿”ã—æ¡æ•°
+	@date 2008.06.08 ryoji æ–°è¦ä½œæˆ
 */
 CKetaXInt CEditView::ViewColNumToWrapColNum( CLayoutXInt nViewColNum ) const
 {
-	// ‚Ô‚ç‰º‚°—]”’‚ğ·‚µˆø‚­
+	// ã¶ã‚‰ä¸‹ã’ä½™ç™½ã‚’å·®ã—å¼•ã
 	CKetaXInt nKeta = CKetaXInt((Int)(nViewColNum - GetWrapOverhang())) / (Int)GetTextMetrics().GetLayoutXDefault();
 
-	// MINLINEKETAS–¢–‚Ì‚ÍMINLINEKETAS‚ÅÜ‚è•Ô‚µ‚Æ‚·‚é
+	// MINLINEKETASæœªæº€ã®æ™‚ã¯MINLINEKETASã§æŠ˜ã‚Šè¿”ã—ã¨ã™ã‚‹
 	if( nKeta < CKetaXInt(MINLINEKETAS) ){
-		nKeta = CKetaXInt(MINLINEKETAS);		// Ü‚è•Ô‚µ•‚ÌÅ¬Œ…”‚Éİ’è
+		nKeta = CKetaXInt(MINLINEKETAS);		// æŠ˜ã‚Šè¿”ã—å¹…ã®æœ€å°æ¡æ•°ã«è¨­å®š
 	}
 
 	return nKeta;
 }
 
 /*!
-	@brief  ƒXƒNƒ[ƒ‹ƒo[§Œä—p‚É‰E’[À•W‚ğæ“¾‚·‚é
+	@brief  ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼åˆ¶å¾¡ç”¨ã«å³ç«¯åº§æ¨™ã‚’å–å¾—ã™ã‚‹
 
-	uÜ‚è•Ô‚³‚È‚¢v
-		ƒtƒŠ[ƒJ[ƒ\ƒ‹ó‘Ô‚Ì‚ÍƒeƒLƒXƒg‚Ì•‚æ‚è‚à‰E‘¤‚ÖƒJ[ƒ\ƒ‹‚ªˆÚ“®‚Å‚«‚é
-		‚Ì‚ÅA‚»‚ê‚ğl—¶‚µ‚½ƒXƒNƒ[ƒ‹ƒo[‚Ì§Œä‚ª•K—vB
-		–{ŠÖ”‚ÍA‰º‹L‚Ì“à‚ÅÅ‚à‘å‚«‚È’li‰E’[‚ÌÀ•Wj‚ğ•Ô‚·B
-		@EƒeƒLƒXƒg‚Ì‰E’[
-		@EƒLƒƒƒŒƒbƒgˆÊ’u
-		@E‘I‘ğ”ÍˆÍ‚Ì‰E’[
+	ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€
+		ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«çŠ¶æ…‹ã®æ™‚ã¯ãƒ†ã‚­ã‚¹ãƒˆã®å¹…ã‚ˆã‚Šã‚‚å³å´ã¸ã‚«ãƒ¼ã‚½ãƒ«ãŒç§»å‹•ã§ãã‚‹
+		ã®ã§ã€ãã‚Œã‚’è€ƒæ…®ã—ãŸã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®åˆ¶å¾¡ãŒå¿…è¦ã€‚
+		æœ¬é–¢æ•°ã¯ã€ä¸‹è¨˜ã®å†…ã§æœ€ã‚‚å¤§ããªå€¤ï¼ˆå³ç«¯ã®åº§æ¨™ï¼‰ã‚’è¿”ã™ã€‚
+		ã€€ãƒ»ãƒ†ã‚­ã‚¹ãƒˆã®å³ç«¯
+		ã€€ãƒ»ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®
+		ã€€ãƒ»é¸æŠç¯„å›²ã®å³ç«¯
 	
-	uw’èŒ…‚ÅÜ‚è•Ô‚·v
-	u‰E’[‚ÅÜ‚è•Ô‚·v
-		ã‹L‚Ìê‡Ü‚è•Ô‚µŒ…ˆÈŒã‚Ì‚Ô‚ç‰º‚°—]”’ŒvZ
+	ã€ŒæŒ‡å®šæ¡ã§æŠ˜ã‚Šè¿”ã™ã€
+	ã€Œå³ç«¯ã§æŠ˜ã‚Šè¿”ã™ã€
+		ä¸Šè¨˜ã®å ´åˆæŠ˜ã‚Šè¿”ã—æ¡ä»¥å¾Œã®ã¶ã‚‰ä¸‹ã’ä½™ç™½è¨ˆç®—
 
-	@return     ‰E’[‚ÌƒŒƒCƒAƒEƒgÀ•W‚ğ•Ô‚·
+	@return     å³ç«¯ã®ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆåº§æ¨™ã‚’è¿”ã™
 
-	@note   uÜ‚è•Ô‚³‚È‚¢v‘I‘ğ‚ÍAƒXƒNƒ[ƒ‹Œã‚ÉƒLƒƒƒŒƒbƒg‚ªŒ©‚¦‚È‚­
-	        ‚È‚ç‚È‚¢—l‚É‚·‚é‚½‚ß‚É‰Eƒ}[ƒWƒ“‚Æ‚µ‚Ä”¼Šp3ŒÂ•ªŒÅ’è‚Å‰ÁZ‚·‚éB
+	@note   ã€ŒæŠ˜ã‚Šè¿”ã•ãªã„ã€é¸æŠæ™‚ã¯ã€ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«å¾Œã«ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒè¦‹ãˆãªã
+	        ãªã‚‰ãªã„æ§˜ã«ã™ã‚‹ãŸã‚ã«å³ãƒãƒ¼ã‚¸ãƒ³ã¨ã—ã¦åŠè§’3å€‹åˆ†å›ºå®šã§åŠ ç®—ã™ã‚‹ã€‚
 
-	@date 2009.08.28 nasukoji	V‹Kì¬
+	@date 2009.08.28 nasukoji	æ–°è¦ä½œæˆ
 */
 CLayoutInt CEditView::GetRightEdgeForScrollBar( void )
 {
-	// Ü‚è•Ô‚µŒ…ˆÈŒã‚Ì‚Ô‚ç‰º‚°—]”’ŒvZ
+	// æŠ˜ã‚Šè¿”ã—æ¡ä»¥å¾Œã®ã¶ã‚‰ä¸‹ã’ä½™ç™½è¨ˆç®—
 	CLayoutXInt nWidth = m_pcEditDoc->m_cLayoutMgr.GetMaxLineLayout() + GetWrapOverhang();
 	
 	if( m_pcEditDoc->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP ){
-		CLayoutInt nRightEdge = m_pcEditDoc->m_cLayoutMgr.GetMaxTextWidth();	// ƒeƒLƒXƒg‚ÌÅ‘å•
+		CLayoutInt nRightEdge = m_pcEditDoc->m_cLayoutMgr.GetMaxTextWidth();	// ãƒ†ã‚­ã‚¹ãƒˆã®æœ€å¤§å¹…
 
-		// ‘I‘ğ”ÍˆÍ‚ ‚è ‚©‚Â ”ÍˆÍ‚Ì‰E’[‚ªƒeƒLƒXƒg‚Ì•‚æ‚è‰E‘¤
+		// é¸æŠç¯„å›²ã‚ã‚Š ã‹ã¤ ç¯„å›²ã®å³ç«¯ãŒãƒ†ã‚­ã‚¹ãƒˆã®å¹…ã‚ˆã‚Šå³å´
 		if( GetSelectionInfo().IsTextSelected() ){
-			// ŠJnˆÊ’uEI—¹ˆÊ’u‚Ì‚æ‚è‰E‘¤‚É‚ ‚é•û‚Å”äŠr
+			// é–‹å§‹ä½ç½®ãƒ»çµ‚äº†ä½ç½®ã®ã‚ˆã‚Šå³å´ã«ã‚ã‚‹æ–¹ã§æ¯”è¼ƒ
 			if( GetSelectionInfo().m_sSelect.GetFrom().GetX2() < GetSelectionInfo().m_sSelect.GetTo().GetX2() ){
 				if( nRightEdge < GetSelectionInfo().m_sSelect.GetTo().GetX2() )
 					nRightEdge = GetSelectionInfo().m_sSelect.GetTo().GetX2();
@@ -807,11 +807,11 @@ CLayoutInt CEditView::GetRightEdgeForScrollBar( void )
 			}
 		}
 
-		// ƒtƒŠ[ƒJ[ƒ\ƒ‹ƒ‚[ƒh ‚©‚Â ƒLƒƒƒŒƒbƒgˆÊ’u‚ªƒeƒLƒXƒg‚Ì•‚æ‚è‰E‘¤
+		// ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«ãƒ¢ãƒ¼ãƒ‰ ã‹ã¤ ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ãŒãƒ†ã‚­ã‚¹ãƒˆã®å¹…ã‚ˆã‚Šå³å´
 		if( GetDllShareData().m_Common.m_sGeneral.m_bIsFreeCursorMode && nRightEdge < GetCaret().GetCaretLayoutPos().GetX2() )
 			nRightEdge = GetCaret().GetCaretLayoutPos().GetX2();
 
-		// ‰Eƒ}[ƒWƒ“•ªi3Œ…j‚ğl—¶‚µ‚Â‚ÂnWidth‚ğ’´‚¦‚È‚¢‚æ‚¤‚É‚·‚é
+		// å³ãƒãƒ¼ã‚¸ãƒ³åˆ†ï¼ˆ3æ¡ï¼‰ã‚’è€ƒæ…®ã—ã¤ã¤nWidthã‚’è¶…ãˆãªã„ã‚ˆã†ã«ã™ã‚‹
 		CLayoutXInt layout3Keta = GetTextMetrics().GetLayoutXDefault(CKetaXInt(3));
 		nWidth = t_min( nRightEdge + layout3Keta, nWidth );
 	}

--- a/sakura_core/view/CEditView_Search.cpp
+++ b/sakura_core/view/CEditView_Search.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -29,52 +29,52 @@
 #include "parse/CWordParse.h"
 #include "util/string_ex2.h"
 
-const int STRNCMP_MAX = 100;	/* MAXƒL[ƒ[ƒh’·Fstrnicmp•¶š—ñ”äŠrÅ‘å’l(CEditView::KeySearchCore) */	// 2006.04.10 fon
+const int STRNCMP_MAX = 100;	/* MAXã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰é•·ï¼šstrnicmpæ–‡å­—åˆ—æ¯”è¼ƒæœ€å¤§å€¤(CEditView::KeySearchCore) */	// 2006.04.10 fon
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           ŒŸõ                              //
+//                           æ¤œç´¢                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*! ƒL[ƒ[ƒh«‘ŒŸõ‚Ì‘O’ñğŒƒ`ƒFƒbƒN‚ÆAŒŸõ
+/*! ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾æ›¸æ¤œç´¢ã®å‰ææ¡ä»¶ãƒã‚§ãƒƒã‚¯ã¨ã€æ¤œç´¢
 
-	@date 2006.04.10 fon OnTimer, CreatePopUpMenu_R‚©‚ç•ª—£
+	@date 2006.04.10 fon OnTimer, CreatePopUpMenu_Rã‹ã‚‰åˆ†é›¢
 */
 BOOL CEditView::KeyWordHelpSearchDict( LID_SKH nID, POINT* po, RECT* rc )
 {
 	CNativeW	cmemCurText;
 
-	/* ƒL[ƒ[ƒhƒwƒ‹ƒv‚ğg—p‚·‚é‚©H */
-	if( !m_pTypeData->m_bUseKeyWordHelp )	/* ƒL[ƒ[ƒhƒwƒ‹ƒv‹@”\‚ğg—p‚·‚é */	// 2006.04.10 fon
+	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—ã‚’ä½¿ç”¨ã™ã‚‹ã‹ï¼Ÿ */
+	if( !m_pTypeData->m_bUseKeyWordHelp )	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—æ©Ÿèƒ½ã‚’ä½¿ç”¨ã™ã‚‹ */	// 2006.04.10 fon
 		goto end_of_search;
-	/* ƒtƒH[ƒJƒX‚ª‚ ‚é‚©H */
+	/* ãƒ•ã‚©ãƒ¼ã‚«ã‚¹ãŒã‚ã‚‹ã‹ï¼Ÿ */
 	if( !GetCaret().ExistCaretFocus() ) 
 		goto end_of_search;
-	/* ƒEƒBƒ“ƒhƒE“à‚Éƒ}ƒEƒXƒJ[ƒ\ƒ‹‚ª‚ ‚é‚©H */
+	/* ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å†…ã«ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ãŒã‚ã‚‹ã‹ï¼Ÿ */
 	GetCursorPos( po );
 	GetWindowRect( GetHwnd(), rc );
 	if( !PtInRect( rc, *po ) )
 		goto end_of_search;
 	switch(nID){
 	case LID_SKH_ONTIMER:
-		/* ‰EƒRƒƒ“ƒg‚Ì‚P`‚R‚Å‚È‚¢ê‡ */
-		if(!( m_bInMenuLoop == FALSE	&&			/* ‚PDƒƒjƒ…[ ƒ‚[ƒ_ƒ‹ ƒ‹[ƒv‚É“ü‚Á‚Ä‚¢‚È‚¢ */
-			0 != m_dwTipTimer			&&			/* ‚QD«‘Tip‚ğ•\¦‚µ‚Ä‚¢‚È‚¢ */
-			300 < ::GetTickCount() - m_dwTipTimer	/* ‚RDˆê’èŠÔˆÈãAƒ}ƒEƒX‚ªŒÅ’è‚³‚ê‚Ä‚¢‚é */
+		/* å³ã‚³ãƒ¡ãƒ³ãƒˆã®ï¼‘ï½ï¼“ã§ãªã„å ´åˆ */
+		if(!( m_bInMenuLoop == FALSE	&&			/* ï¼‘ï¼ãƒ¡ãƒ‹ãƒ¥ãƒ¼ ãƒ¢ãƒ¼ãƒ€ãƒ« ãƒ«ãƒ¼ãƒ—ã«å…¥ã£ã¦ã„ãªã„ */
+			0 != m_dwTipTimer			&&			/* ï¼’ï¼è¾æ›¸Tipã‚’è¡¨ç¤ºã—ã¦ã„ãªã„ */
+			300 < ::GetTickCount() - m_dwTipTimer	/* ï¼“ï¼ä¸€å®šæ™‚é–“ä»¥ä¸Šã€ãƒã‚¦ã‚¹ãŒå›ºå®šã•ã‚Œã¦ã„ã‚‹ */
 		) )	goto end_of_search;
 		break;
 	case LID_SKH_POPUPMENU_R:
-		if(!( m_bInMenuLoop == FALSE	//&&			/* ‚PDƒƒjƒ…[ ƒ‚[ƒ_ƒ‹ ƒ‹[ƒv‚É“ü‚Á‚Ä‚¢‚È‚¢ */
-		//	0 != m_dwTipTimer			&&			/* ‚QD«‘Tip‚ğ•\¦‚µ‚Ä‚¢‚È‚¢ */
-		//	1000 < ::GetTickCount() - m_dwTipTimer	/* ‚RDˆê’èŠÔˆÈãAƒ}ƒEƒX‚ªŒÅ’è‚³‚ê‚Ä‚¢‚é */
+		if(!( m_bInMenuLoop == FALSE	//&&			/* ï¼‘ï¼ãƒ¡ãƒ‹ãƒ¥ãƒ¼ ãƒ¢ãƒ¼ãƒ€ãƒ« ãƒ«ãƒ¼ãƒ—ã«å…¥ã£ã¦ã„ãªã„ */
+		//	0 != m_dwTipTimer			&&			/* ï¼’ï¼è¾æ›¸Tipã‚’è¡¨ç¤ºã—ã¦ã„ãªã„ */
+		//	1000 < ::GetTickCount() - m_dwTipTimer	/* ï¼“ï¼ä¸€å®šæ™‚é–“ä»¥ä¸Šã€ãƒã‚¦ã‚¹ãŒå›ºå®šã•ã‚Œã¦ã„ã‚‹ */
 		) )	goto end_of_search;
 		break;
 	default:
 		PleaseReportToAuthor( NULL, _T("CEditView::KeyWordHelpSearchDict\nnID=%d"), (int)nID );
 	}
-	/* ‘I‘ğ”ÍˆÍ‚Ìƒf[ƒ^‚ğæ“¾(•¡”s‘I‘ğ‚Ìê‡‚Íæ“ª‚Ìs‚Ì‚İ) */
+	/* é¸æŠç¯„å›²ã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾—(è¤‡æ•°è¡Œé¸æŠã®å ´åˆã¯å…ˆé ­ã®è¡Œã®ã¿) */
 	if( GetSelectedDataOne( cmemCurText, STRNCMP_MAX + 1 ) ){
 	}
-	/* ƒLƒƒƒŒƒbƒgˆÊ’u‚Ì’PŒê‚ğæ“¾‚·‚éˆ— */	// 2006.03.24 fon
+	/* ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã®å˜èªã‚’å–å¾—ã™ã‚‹å‡¦ç† */	// 2006.03.24 fon
 	else if(GetDllShareData().m_Common.m_sSearch.m_bUseCaretKeyWord){
 		if(!GetParser().GetCurrentWord(&cmemCurText))
 			goto end_of_search;
@@ -82,26 +82,26 @@ BOOL CEditView::KeyWordHelpSearchDict( LID_SKH nID, POINT* po, RECT* rc )
 	else
 		goto end_of_search;
 
-	if( CNativeW::IsEqual( cmemCurText, m_cTipWnd.m_cKey ) &&	/* Šù‚ÉŒŸõÏ‚İ‚© */
-		(!m_cTipWnd.m_KeyWasHit) )								/* ŠY“–‚·‚éƒL[‚ª‚È‚©‚Á‚½ */
+	if( CNativeW::IsEqual( cmemCurText, m_cTipWnd.m_cKey ) &&	/* æ—¢ã«æ¤œç´¢æ¸ˆã¿ã‹ */
+		(!m_cTipWnd.m_KeyWasHit) )								/* è©²å½“ã™ã‚‹ã‚­ãƒ¼ãŒãªã‹ã£ãŸ */
 		goto end_of_search;
 	m_cTipWnd.m_cKey = cmemCurText;
 
-	/* ŒŸõÀs */
+	/* æ¤œç´¢å®Ÿè¡Œ */
 	if( !KeySearchCore(&m_cTipWnd.m_cKey) )
 		goto end_of_search;
-	m_dwTipTimer = 0;		/* «‘Tip‚ğ•\¦‚µ‚Ä‚¢‚é */
-	m_poTipCurPos = *po;	/* Œ»İ‚Ìƒ}ƒEƒXƒJ[ƒ\ƒ‹ˆÊ’u */
-	return TRUE;			/* ‚±‚±‚Ü‚Å—ˆ‚Ä‚¢‚ê‚ÎƒqƒbƒgEƒ[ƒh */
+	m_dwTipTimer = 0;		/* è¾æ›¸Tipã‚’è¡¨ç¤ºã—ã¦ã„ã‚‹ */
+	m_poTipCurPos = *po;	/* ç¾åœ¨ã®ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ä½ç½® */
+	return TRUE;			/* ã“ã“ã¾ã§æ¥ã¦ã„ã‚Œã°ãƒ’ãƒƒãƒˆãƒ»ãƒ¯ãƒ¼ãƒ‰ */
 
-	/* ƒL[ƒ[ƒhƒwƒ‹ƒv•\¦ˆ—I—¹ */
+	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãƒ˜ãƒ«ãƒ—è¡¨ç¤ºå‡¦ç†çµ‚äº† */
 	end_of_search:
 	return FALSE;
 }
 
-/*! ƒL[ƒ[ƒh«‘ŒŸõˆ—ƒƒCƒ“
+/*! ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¾æ›¸æ¤œç´¢å‡¦ç†ãƒ¡ã‚¤ãƒ³
 
-	@date 2006.04.10 fon KeyWordHelpSearchDict‚©‚ç•ª—£
+	@date 2006.04.10 fon KeyWordHelpSearchDictã‹ã‚‰åˆ†é›¢
 */
 BOOL CEditView::KeySearchCore( const CNativeW* pcmemCurText )
 {
@@ -110,20 +110,20 @@ BOOL CEditView::KeySearchCore( const CNativeW* pcmemCurText )
 	int			nLine; // 2006.04.10 fon
 
 
-	m_cTipWnd.m_cInfo.SetString( _T("") );	/* tooltipƒoƒbƒtƒ@‰Šú‰» */
-	/* 1s–Ú‚ÉƒL[ƒ[ƒh•\¦‚Ìê‡ */
-	if(m_pTypeData->m_bUseKeyHelpKeyDisp){	/* ƒL[ƒ[ƒh‚à•\¦‚·‚é */	// 2006.04.10 fon
+	m_cTipWnd.m_cInfo.SetString( _T("") );	/* tooltipãƒãƒƒãƒ•ã‚¡åˆæœŸåŒ– */
+	/* 1è¡Œç›®ã«ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è¡¨ç¤ºã®å ´åˆ */
+	if(m_pTypeData->m_bUseKeyHelpKeyDisp){	/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚‚è¡¨ç¤ºã™ã‚‹ */	// 2006.04.10 fon
 		m_cTipWnd.m_cInfo.AppendString( _T("[ ") );
 		m_cTipWnd.m_cInfo.AppendString( pcmemCurText->GetStringT() );
 		m_cTipWnd.m_cInfo.AppendString( _T(" ]") );
 	}
-	/* “r’†‚Ü‚Åˆê’v‚ğg‚¤ê‡ */
+	/* é€”ä¸­ã¾ã§ä¸€è‡´ã‚’ä½¿ã†å ´åˆ */
 	if(m_pTypeData->m_bUseKeyHelpPrefix)
 		nCmpLen = wcslen( pcmemCurText->GetStringPtr() );	// 2006.04.10 fon
 	m_cTipWnd.m_KeyWasHit = FALSE;
-	for(int i =0 ; i < m_pTypeData->m_nKeyHelpNum; i++){	//Å‘å”FMAX_KEYHELP_FILE
+	for(int i =0 ; i < m_pTypeData->m_nKeyHelpNum; i++){	//æœ€å¤§æ•°ï¼šMAX_KEYHELP_FILE
 		if( m_pTypeData->m_KeyHelpArr[i].m_bUse ){
-			// 2006.04.10 fon (nCmpLen,pcmemRefKey,nSearchLine)ˆø”‚ğ’Ç‰Á
+			// 2006.04.10 fon (nCmpLen,pcmemRefKey,nSearchLine)å¼•æ•°ã‚’è¿½åŠ 
 			CNativeW*	pcmemRefText;
 			int nSearchResult=m_cDicMgr.CDicMgr::Search(
 				pcmemCurText->GetStringPtr(),
@@ -134,55 +134,55 @@ BOOL CEditView::KeySearchCore( const CNativeW* pcmemCurText )
 				&nLine
 			);
 			if(nSearchResult){
-				/* ŠY“–‚·‚éƒL[‚ª‚ ‚é */
+				/* è©²å½“ã™ã‚‹ã‚­ãƒ¼ãŒã‚ã‚‹ */
 				LPWSTR		pszWork;
 				pszWork = pcmemRefText->GetStringPtr();
-				/* —LŒø‚É‚È‚Á‚Ä‚¢‚é«‘‚ğ‘S•”‚È‚ß‚ÄAƒqƒbƒg‚Ì“s“xà–¾‚ÌŒp‚¬‘‚µ */
-				if(m_pTypeData->m_bUseKeyHelpAllSearch){	/* ƒqƒbƒg‚µ‚½Ÿ‚Ì«‘‚àŒŸõ */	// 2006.04.10 fon
-					/* ƒoƒbƒtƒ@‚É‘O‚Ìƒf[ƒ^‚ª‹l‚Ü‚Á‚Ä‚¢‚½‚çseparator‘}“ü */
+				/* æœ‰åŠ¹ã«ãªã£ã¦ã„ã‚‹è¾æ›¸ã‚’å…¨éƒ¨ãªã‚ã¦ã€ãƒ’ãƒƒãƒˆã®éƒ½åº¦èª¬æ˜ã®ç¶™ãå¢—ã— */
+				if(m_pTypeData->m_bUseKeyHelpAllSearch){	/* ãƒ’ãƒƒãƒˆã—ãŸæ¬¡ã®è¾æ›¸ã‚‚æ¤œç´¢ */	// 2006.04.10 fon
+					/* ãƒãƒƒãƒ•ã‚¡ã«å‰ã®ãƒ‡ãƒ¼ã‚¿ãŒè©°ã¾ã£ã¦ã„ãŸã‚‰separatoræŒ¿å…¥ */
 					if(m_cTipWnd.m_cInfo.GetStringLength() != 0)
 						m_cTipWnd.m_cInfo.AppendString( LS(STR_ERR_DLGEDITVW5) );
 					else
-						m_cTipWnd.m_cInfo.AppendString( LS(STR_ERR_DLGEDITVW6) );	/* æ“ª‚Ìê‡ */
-					/* «‘‚ÌƒpƒX‘}“ü */
+						m_cTipWnd.m_cInfo.AppendString( LS(STR_ERR_DLGEDITVW6) );	/* å…ˆé ­ã®å ´åˆ */
+					/* è¾æ›¸ã®ãƒ‘ã‚¹æŒ¿å…¥ */
 					{
 						TCHAR szFile[MAX_PATH];
-						// 2013.05.08 •\¦‚·‚é‚Ì‚Íƒtƒ@ƒCƒ‹–¼(Šg’£q‚È‚µ)‚Ì‚İ‚É‚·‚é
+						// 2013.05.08 è¡¨ç¤ºã™ã‚‹ã®ã¯ãƒ•ã‚¡ã‚¤ãƒ«å(æ‹¡å¼µå­ãªã—)ã®ã¿ã«ã™ã‚‹
 						_tsplitpath( m_pTypeData->m_KeyHelpArr[i].m_szPath, NULL, NULL, szFile, NULL );
 						m_cTipWnd.m_cInfo.AppendString( szFile );
 					}
 					m_cTipWnd.m_cInfo.AppendString( _T("\n") );
-					/* ‘O•ûˆê’v‚Åƒqƒbƒg‚µ‚½’PŒê‚ğ‘}“ü */
-					if(m_pTypeData->m_bUseKeyHelpPrefix){	/* ‘I‘ğ”ÍˆÍ‚Å‘O•ûˆê’vŒŸõ */
+					/* å‰æ–¹ä¸€è‡´ã§ãƒ’ãƒƒãƒˆã—ãŸå˜èªã‚’æŒ¿å…¥ */
+					if(m_pTypeData->m_bUseKeyHelpPrefix){	/* é¸æŠç¯„å›²ã§å‰æ–¹ä¸€è‡´æ¤œç´¢ */
 						m_cTipWnd.m_cInfo.AppendString( pcmemRefKey->GetStringT() );
 						m_cTipWnd.m_cInfo.AppendString( _T(" >>\n") );
-					}/* ’²¸‚µ‚½uˆÓ–¡v‚ğ‘}“ü */
+					}/* èª¿æŸ»ã—ãŸã€Œæ„å‘³ã€ã‚’æŒ¿å…¥ */
 					m_cTipWnd.m_cInfo.AppendStringW( pszWork );
 					delete pcmemRefText;
 					delete pcmemRefKey;	// 2006.07.02 genta
-					/* ƒ^ƒOƒWƒƒƒ“ƒv—p‚Ìî•ñ‚ğc‚· */
+					/* ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ç”¨ã®æƒ…å ±ã‚’æ®‹ã™ */
 					if(!m_cTipWnd.m_KeyWasHit){
-						m_cTipWnd.m_nSearchDict=i;	/* «‘‚ğŠJ‚­‚Æ‚«Å‰‚Éƒqƒbƒg‚µ‚½«‘‚ğŠJ‚­ */
+						m_cTipWnd.m_nSearchDict=i;	/* è¾æ›¸ã‚’é–‹ãã¨ãæœ€åˆã«ãƒ’ãƒƒãƒˆã—ãŸè¾æ›¸ã‚’é–‹ã */
 						m_cTipWnd.m_nSearchLine=nLine;
 						m_cTipWnd.m_KeyWasHit = TRUE;
 					}
 				}
-				else{	/* Å‰‚Ìƒqƒbƒg€–Ú‚Ì‚İ•Ô‚·ê‡ */
-					/* ƒL[ƒ[ƒh‚ª“ü‚Á‚Ä‚¢‚½‚çseparator‘}“ü */
+				else{	/* æœ€åˆã®ãƒ’ãƒƒãƒˆé …ç›®ã®ã¿è¿”ã™å ´åˆ */
+					/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãŒå…¥ã£ã¦ã„ãŸã‚‰separatoræŒ¿å…¥ */
 					if(m_cTipWnd.m_cInfo.GetStringLength() != 0)
 						m_cTipWnd.m_cInfo.AppendString( _T("\n--------------------\n") );
 					
-					/* ‘O•ûˆê’v‚Åƒqƒbƒg‚µ‚½’PŒê‚ğ‘}“ü */
-					if(m_pTypeData->m_bUseKeyHelpPrefix){	/* ‘I‘ğ”ÍˆÍ‚Å‘O•ûˆê’vŒŸõ */
+					/* å‰æ–¹ä¸€è‡´ã§ãƒ’ãƒƒãƒˆã—ãŸå˜èªã‚’æŒ¿å…¥ */
+					if(m_pTypeData->m_bUseKeyHelpPrefix){	/* é¸æŠç¯„å›²ã§å‰æ–¹ä¸€è‡´æ¤œç´¢ */
 						m_cTipWnd.m_cInfo.AppendString( pcmemRefKey->GetStringT() );
 						m_cTipWnd.m_cInfo.AppendString( _T(" >>\n") );
 					}
 					
-					/* ’²¸‚µ‚½uˆÓ–¡v‚ğ‘}“ü */
+					/* èª¿æŸ»ã—ãŸã€Œæ„å‘³ã€ã‚’æŒ¿å…¥ */
 					m_cTipWnd.m_cInfo.AppendStringW( pszWork );
 					delete pcmemRefText;
 					delete pcmemRefKey;	// 2006.07.02 genta
-					/* ƒ^ƒOƒWƒƒƒ“ƒv—p‚Ìî•ñ‚ğc‚· */
+					/* ã‚¿ã‚°ã‚¸ãƒ£ãƒ³ãƒ—ç”¨ã®æƒ…å ±ã‚’æ®‹ã™ */
 					m_cTipWnd.m_nSearchDict=i;
 					m_cTipWnd.m_nSearchLine=nLine;
 					m_cTipWnd.m_KeyWasHit = TRUE;
@@ -194,7 +194,7 @@ BOOL CEditView::KeySearchCore( const CNativeW* pcmemCurText )
 	if( m_cTipWnd.m_KeyWasHit != FALSE ){
 			return TRUE;
 	}
-	/* ŠY“–‚·‚éƒL[‚ª‚È‚©‚Á‚½ê‡ */
+	/* è©²å½“ã™ã‚‹ã‚­ãƒ¼ãŒãªã‹ã£ãŸå ´åˆ */
 	return FALSE;
 }
 
@@ -204,15 +204,15 @@ bool CEditView::MiniMapCursorLineTip( POINT* po, RECT* rc, bool* pbHide )
 	if( !m_bMiniMap ){
 		return false;
 	}
-	// ƒEƒBƒ“ƒhƒE“à‚Éƒ}ƒEƒXƒJ[ƒ\ƒ‹‚ª‚ ‚é‚©H
+	// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å†…ã«ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ãŒã‚ã‚‹ã‹ï¼Ÿ
 	GetCursorPos( po );
 	GetWindowRect( GetHwnd(), rc );
 	rc->right -= ::GetSystemMetrics(SM_CXVSCROLL);
 	if( !PtInRect( rc, *po ) ){
 		return false;
 	}
-	if(!( m_bInMenuLoop == FALSE	&&			/* ‚PDƒƒjƒ…[ ƒ‚[ƒ_ƒ‹ ƒ‹[ƒv‚É“ü‚Á‚Ä‚¢‚È‚¢ */
-		300 < ::GetTickCount() - m_dwTipTimer	/* ‚QDˆê’èŠÔˆÈãAƒ}ƒEƒX‚ªŒÅ’è‚³‚ê‚Ä‚¢‚é */
+	if(!( m_bInMenuLoop == FALSE	&&			/* ï¼‘ï¼ãƒ¡ãƒ‹ãƒ¥ãƒ¼ ãƒ¢ãƒ¼ãƒ€ãƒ« ãƒ«ãƒ¼ãƒ—ã«å…¥ã£ã¦ã„ãªã„ */
+		300 < ::GetTickCount() - m_dwTipTimer	/* ï¼’ï¼ä¸€å®šæ™‚é–“ä»¥ä¸Šã€ãƒã‚¦ã‚¹ãŒå›ºå®šã•ã‚Œã¦ã„ã‚‹ */
 	) ){
 		return false;
 	}
@@ -224,9 +224,9 @@ bool CEditView::MiniMapCursorLineTip( POINT* po, RECT* rc, bool* pbHide )
 	ScreenToClient( GetHwnd(), &ptClient );
 	CLayoutPoint ptNew;
 	GetTextArea().ClientToLayout( ptClient, &ptNew );
-	// “¯‚¶s‚È‚ç‚È‚É‚à‚µ‚È‚¢
+	// åŒã˜è¡Œãªã‚‰ãªã«ã‚‚ã—ãªã„
 	if( 0 == m_dwTipTimer && m_cTipWnd.m_nSearchLine == (Int)ptNew.y ){
-		*pbHide = false; // •\¦Œp‘±
+		*pbHide = false; // è¡¨ç¤ºç¶™ç¶š
 		return false;
 	}
 	CNativeW cmemCurText;
@@ -249,8 +249,8 @@ bool CEditView::MiniMapCursorLineTip( POINT* po, RECT* rc, bool* pbHide )
 				int charSize = CNativeW::GetSizeOfChar( pszData, nLineLen, i );
 				int charWidth = t_max(1, (int)(Int)CNativeW::GetKetaOfChar( pszData, nLineLen, i ));
 				int charType = 0;
-				// ˜A‘±‚·‚é"\t" " " ‚ğ " "1‚Â‚É‚·‚é
-				// ¶‚©‚çnLimitLength‚Ü‚Å‚Ì•‚ğØ‚èæ‚è
+				// é€£ç¶šã™ã‚‹"\t" " " ã‚’ " "1ã¤ã«ã™ã‚‹
+				// å·¦ã‹ã‚‰nLimitLengthã¾ã§ã®å¹…ã‚’åˆ‡ã‚Šå–ã‚Š
 				while( i + charSize <= (Int)nLineLen && k + charWidth <= nLimitLength ){
 					if( pszData[i] == L'\t' || pszData[i] == L' ' ){
 						if( charType == 0 ){
@@ -283,12 +283,12 @@ bool CEditView::MiniMapCursorLineTip( POINT* po, RECT* rc, bool* pbHide )
 	m_cTipWnd.m_cKey = cmemCurText;
 	m_cTipWnd.m_cInfo = cmemCurText.GetStringT();
 	m_cTipWnd.m_nSearchLine = (Int)ptNew.y;
-	m_dwTipTimer = 0;		// «‘Tip‚ğ•\¦‚µ‚Ä‚¢‚é */
-	m_poTipCurPos = *po;	// Œ»İ‚Ìƒ}ƒEƒXƒJ[ƒ\ƒ‹ˆÊ’u */
-	return true;			// ‚±‚±‚Ü‚Å—ˆ‚Ä‚¢‚ê‚ÎƒqƒbƒgEƒ[ƒh
+	m_dwTipTimer = 0;		// è¾æ›¸Tipã‚’è¡¨ç¤ºã—ã¦ã„ã‚‹ */
+	m_poTipCurPos = *po;	// ç¾åœ¨ã®ãƒã‚¦ã‚¹ã‚«ãƒ¼ã‚½ãƒ«ä½ç½® */
+	return true;			// ã“ã“ã¾ã§æ¥ã¦ã„ã‚Œã°ãƒ’ãƒƒãƒˆãƒ»ãƒ¯ãƒ¼ãƒ‰
 }
 
-/* Œ»İƒJ[ƒ\ƒ‹ˆÊ’u’PŒê‚Ü‚½‚Í‘I‘ğ”ÍˆÍ‚æ‚èŒŸõ“™‚ÌƒL[‚ğæ“¾ */
+/* ç¾åœ¨ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å˜èªã¾ãŸã¯é¸æŠç¯„å›²ã‚ˆã‚Šæ¤œç´¢ç­‰ã®ã‚­ãƒ¼ã‚’å–å¾— */
 void CEditView::GetCurrentTextForSearch( CNativeW& cmemCurText, bool bStripMaxPath /* = true */, bool bTrimSpaceTab /* = false */ )
 {
 
@@ -300,10 +300,10 @@ void CEditView::GetCurrentTextForSearch( CNativeW& cmemCurText, bool bStripMaxPa
 	CLayoutRange	sRange;
 
 	cmemCurText.SetString(L"");
-	if( GetSelectionInfo().IsTextSelected() ){	/* ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚© */
-		/* ‘I‘ğ”ÍˆÍ‚Ìƒf[ƒ^‚ğæ“¾ */
+	if( GetSelectionInfo().IsTextSelected() ){	/* ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹ */
+		/* é¸æŠç¯„å›²ã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
 		if( GetSelectedDataOne( cmemCurText, INT_MAX ) ){
-			/* ŒŸõ•¶š—ñ‚ğŒ»İˆÊ’u‚Ì’PŒê‚Å‰Šú‰» */
+			/* æ¤œç´¢æ–‡å­—åˆ—ã‚’ç¾åœ¨ä½ç½®ã®å˜èªã§åˆæœŸåŒ– */
 			if( bStripMaxPath ){
 				LimitStringLengthW(cmemCurText.GetStringPtr(), cmemCurText.GetStringLength(), _MAX_PATH - 1, cmemTopic);
 			}else{
@@ -314,10 +314,10 @@ void CEditView::GetCurrentTextForSearch( CNativeW& cmemCurText, bool bStripMaxPa
 		const CLayout*	pcLayout;
 		pLine = m_pcEditDoc->m_cLayoutMgr.GetLineStr( GetCaret().GetCaretLayoutPos().GetY2(), &nLineLen, &pcLayout );
 		if( NULL != pLine ){
-			/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é */
+			/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 			nIdx = LineColumnToIndex( pcLayout, GetCaret().GetCaretLayoutPos().GetX2() );
 
-			/* Œ»İˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ğ’²‚×‚é */
+			/* ç¾åœ¨ä½ç½®ã®å˜èªã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 			bool bWhere = m_pcEditDoc->m_cLayoutMgr.WhereCurrentWord(
 				GetCaret().GetCaretLayoutPos().GetY2(),
 				nIdx,
@@ -326,20 +326,20 @@ void CEditView::GetCurrentTextForSearch( CNativeW& cmemCurText, bool bStripMaxPa
 				NULL
 			);
 			if( bWhere ){
-				/* ‘I‘ğ”ÍˆÍ‚Ì•ÏX */
+				/* é¸æŠç¯„å›²ã®å¤‰æ›´ */
 				GetSelectionInfo().m_sSelectBgn = sRange;
 				GetSelectionInfo().m_sSelect    = sRange;
 
-				/* ‘I‘ğ”ÍˆÍ‚Ìƒf[ƒ^‚ğæ“¾ */
+				/* é¸æŠç¯„å›²ã®ãƒ‡ãƒ¼ã‚¿ã‚’å–å¾— */
 				if( GetSelectedDataOne( cmemCurText, INT_MAX ) ){
-					/* ŒŸõ•¶š—ñ‚ğŒ»İˆÊ’u‚Ì’PŒê‚Å‰Šú‰» */
+					/* æ¤œç´¢æ–‡å­—åˆ—ã‚’ç¾åœ¨ä½ç½®ã®å˜èªã§åˆæœŸåŒ– */
 					if( bStripMaxPath ){
 						LimitStringLengthW(cmemCurText.GetStringPtr(), cmemCurText.GetStringLength(), _MAX_PATH - 1, cmemTopic);
 					}else{
 						cmemTopic = cmemCurText;
 					}
 				}
-				/* Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚· */
+				/* ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™ */
 				GetSelectionInfo().DisableSelectArea( false );
 			}
 		}
@@ -347,13 +347,13 @@ void CEditView::GetCurrentTextForSearch( CNativeW& cmemCurText, bool bStripMaxPa
 
 	wchar_t *pTopic2 = cmemTopic.GetStringPtr();
 	if( bTrimSpaceTab ){
-		// ‘O‚ÌƒXƒy[ƒXEƒ^ƒu‚ğæ‚èœ‚­
+		// å‰ã®ã‚¹ãƒšãƒ¼ã‚¹ãƒ»ã‚¿ãƒ–ã‚’å–ã‚Šé™¤ã
 		while( L'\0' != *pTopic2 && ( ' ' == *pTopic2 || '\t' == *pTopic2 ) ){
 			pTopic2++;
 		}
 	}
 	int nTopic2Len = (int)wcslen( pTopic2 );
-	/* ŒŸõ•¶š—ñ‚Í‰üs‚Ü‚Å */
+	/* æ¤œç´¢æ–‡å­—åˆ—ã¯æ”¹è¡Œã¾ã§ */
 	bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 	for( i = 0; i < nTopic2Len; ++i ){
 		if( WCODE::IsLineDelimiter(pTopic2[i], bExtEol) ){
@@ -362,7 +362,7 @@ void CEditView::GetCurrentTextForSearch( CNativeW& cmemCurText, bool bStripMaxPa
 	}
 	
 	if( bTrimSpaceTab ){
-		// Œã‚ë‚ÌƒXƒy[ƒXEƒ^ƒu‚ğæ‚èœ‚­
+		// å¾Œã‚ã®ã‚¹ãƒšãƒ¼ã‚¹ãƒ»ã‚¿ãƒ–ã‚’å–ã‚Šé™¤ã
 		int m = i - 1;
 		while( 0 <= m &&
 		    ( L' ' == pTopic2[m] || L'\t' == pTopic2[m] ) ){
@@ -376,23 +376,23 @@ void CEditView::GetCurrentTextForSearch( CNativeW& cmemCurText, bool bStripMaxPa
 }
 
 
-/*!	Œ»İƒJ[ƒ\ƒ‹ˆÊ’u’PŒê‚Ü‚½‚Í‘I‘ğ”ÍˆÍ‚æ‚èŒŸõ“™‚ÌƒL[‚ğæ“¾iƒ_ƒCƒAƒƒO—pj
-	@return ’l‚ğİ’è‚µ‚½‚©
-	@date 2006.08.23 ryoji V‹Kì¬
-	@date 2014.07.01 Moca bGetHistory’Ç‰ÁA–ß‚è’l‚ğbool‚É•ÏX
+/*!	ç¾åœ¨ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å˜èªã¾ãŸã¯é¸æŠç¯„å›²ã‚ˆã‚Šæ¤œç´¢ç­‰ã®ã‚­ãƒ¼ã‚’å–å¾—ï¼ˆãƒ€ã‚¤ã‚¢ãƒ­ã‚°ç”¨ï¼‰
+	@return å€¤ã‚’è¨­å®šã—ãŸã‹
+	@date 2006.08.23 ryoji æ–°è¦ä½œæˆ
+	@date 2014.07.01 Moca bGetHistoryè¿½åŠ ã€æˆ»ã‚Šå€¤ã‚’boolã«å¤‰æ›´
 */
 bool CEditView::GetCurrentTextForSearchDlg( CNativeW& cmemCurText, bool bGetHistory )
 {
 	bool bStripMaxPath = false;
 	cmemCurText.SetString(L"");
 
-	if( GetSelectionInfo().IsTextSelected() ){	// ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é
+	if( GetSelectionInfo().IsTextSelected() ){	// ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹
 		GetCurrentTextForSearch( cmemCurText, bStripMaxPath );
 	}
-	else{	// ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚È‚¢
+	else{	// ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ãªã„
 		bool bGet = false;
 		if( GetDllShareData().m_Common.m_sSearch.m_bCaretTextForSearch ){
-			GetCurrentTextForSearch( cmemCurText, bStripMaxPath );	// ƒJ[ƒ\ƒ‹ˆÊ’u’PŒê‚ğæ“¾
+			GetCurrentTextForSearch( cmemCurText, bStripMaxPath );	// ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®å˜èªã‚’å–å¾—
 			if( cmemCurText.GetStringLength() == 0 && bGetHistory ){
 				bGet = true;
 			}
@@ -402,11 +402,11 @@ bool CEditView::GetCurrentTextForSearchDlg( CNativeW& cmemCurText, bool bGetHist
 		if( bGet ){
 			if( 0 < GetDllShareData().m_sSearchKeywords.m_aSearchKeys.size()
 					&& m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence ){
-				cmemCurText.SetString( GetDllShareData().m_sSearchKeywords.m_aSearchKeys[0] );	// —š—ğ‚©‚ç‚Æ‚Á‚Ä‚­‚é
-				return true; // ""‚Å‚àtrue
+				cmemCurText.SetString( GetDllShareData().m_sSearchKeywords.m_aSearchKeys[0] );	// å±¥æ­´ã‹ã‚‰ã¨ã£ã¦ãã‚‹
+				return true; // ""ã§ã‚‚true
 			}else{
 				cmemCurText.SetString( m_strCurSearchKey.c_str() );
-				return 0 <= m_nCurSearchKeySequence; // ""‚Å‚àtrue.–¢İ’è‚Ì‚Æ‚«‚Ífalse
+				return 0 <= m_nCurSearchKeySequence; // ""ã§ã‚‚true.æœªè¨­å®šã®ã¨ãã¯false
 			}
 		}
 	}
@@ -416,21 +416,21 @@ bool CEditView::GetCurrentTextForSearchDlg( CNativeW& cmemCurText, bool bGetHist
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        •`‰æ—p”»’è                           //
+//                        æç”»ç”¨åˆ¤å®š                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/* Œ»İˆÊ’u‚ªŒŸõ•¶š—ñ‚ÉŠY“–‚·‚é‚© */
+/* ç¾åœ¨ä½ç½®ãŒæ¤œç´¢æ–‡å­—åˆ—ã«è©²å½“ã™ã‚‹ã‹ */
 //2002.02.08 hor
-//³‹K•\Œ»‚ÅŒŸõ‚µ‚½‚Æ‚«‚Ì‘¬“x‰ü‘P‚Ì‚½‚ßAƒ}ƒbƒ`æ“ªˆÊ’u‚ğˆø”‚É’Ç‰Á
-//Jun. 26, 2001 genta	³‹K•\Œ»ƒ‰ƒCƒuƒ‰ƒŠ‚Ì·‚µ‘Ö‚¦
+//æ­£è¦è¡¨ç¾ã§æ¤œç´¢ã—ãŸã¨ãã®é€Ÿåº¦æ”¹å–„ã®ãŸã‚ã€ãƒãƒƒãƒå…ˆé ­ä½ç½®ã‚’å¼•æ•°ã«è¿½åŠ 
+//Jun. 26, 2001 genta	æ­£è¦è¡¨ç¾ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®å·®ã—æ›¿ãˆ
 /*
 	@retval 0
-		(ƒpƒ^[ƒ“ŒŸõ) w’èˆÊ’uˆÈ~‚Éƒ}ƒbƒ`‚Í‚È‚¢B
-		(‚»‚êˆÈŠO) w’èˆÊ’u‚ÍŒŸõ•¶š—ñ‚Ìn‚Ü‚è‚Å‚Í‚È‚¢B
+		(ãƒ‘ã‚¿ãƒ¼ãƒ³æ¤œç´¢æ™‚) æŒ‡å®šä½ç½®ä»¥é™ã«ãƒãƒƒãƒã¯ãªã„ã€‚
+		(ãã‚Œä»¥å¤–) æŒ‡å®šä½ç½®ã¯æ¤œç´¢æ–‡å­—åˆ—ã®å§‹ã¾ã‚Šã§ã¯ãªã„ã€‚
 	@retval 1,2,3,...
-		(ƒpƒ^[ƒ“ŒŸõ) w’èˆÊ’uˆÈ~‚Éƒ}ƒbƒ`‚ªŒ©‚Â‚©‚Á‚½B
-		(’PŒêŒŸõ) w’èˆÊ’u‚ªŒŸõ•¶š—ñ‚ÉŠÜ‚Ü‚ê‚é‰½”Ô–Ú‚Ì’PŒê‚Ìn‚Ü‚è‚Å‚ ‚é‚©B
-		(‚»‚êˆÈŠO) w’èˆÊ’u‚ªŒŸõ•¶š—ñ‚Ìn‚Ü‚è‚¾‚Á‚½B
+		(ãƒ‘ã‚¿ãƒ¼ãƒ³æ¤œç´¢æ™‚) æŒ‡å®šä½ç½®ä»¥é™ã«ãƒãƒƒãƒãŒè¦‹ã¤ã‹ã£ãŸã€‚
+		(å˜èªæ¤œç´¢æ™‚) æŒ‡å®šä½ç½®ãŒæ¤œç´¢æ–‡å­—åˆ—ã«å«ã¾ã‚Œã‚‹ä½•ç•ªç›®ã®å˜èªã®å§‹ã¾ã‚Šã§ã‚ã‚‹ã‹ã€‚
+		(ãã‚Œä»¥å¤–) æŒ‡å®šä½ç½®ãŒæ¤œç´¢æ–‡å­—åˆ—ã®å§‹ã¾ã‚Šã ã£ãŸã€‚
 */
 int CEditView::IsSearchString(
 	const CStringRef&	cStr,
@@ -446,13 +446,13 @@ int CEditView::IsSearchString(
 	*pnSearchStart = nPos;	// 2002.02.08 hor
 
 	if( m_sCurSearchOption.bRegularExp ){
-		/* s“ª‚Å‚Í‚È‚¢? */
-		/* s“ªŒŸõƒ`ƒFƒbƒN‚ÍACBregexpƒNƒ‰ƒX“à•”‚ÅÀ{‚·‚é‚Ì‚Å•s—v 2003.11.01 ‚©‚ë‚Æ */
+		/* è¡Œé ­ã§ã¯ãªã„? */
+		/* è¡Œé ­æ¤œç´¢ãƒã‚§ãƒƒã‚¯ã¯ã€CBregexpã‚¯ãƒ©ã‚¹å†…éƒ¨ã§å®Ÿæ–½ã™ã‚‹ã®ã§ä¸è¦ 2003.11.01 ã‹ã‚ã¨ */
 
-		/* ˆÊ’u‚ğ0‚ÅMatchInfoŒÄ‚Ño‚·‚ÆAs“ª•¶šŒŸõ‚ÉA‘S‚Ä true@‚Æ‚È‚èA
-		** ‰æ–Ê‘S‘Ì‚ªŒŸõ•¶š—ñˆµ‚¢‚É‚È‚é•s‹ï‡C³
-		** ‘Îô‚Æ‚µ‚ÄAs“ª‚ğ MacthInfo‚É‹³‚¦‚È‚¢‚Æ‚¢‚¯‚È‚¢‚Ì‚ÅA•¶š—ñ‚Ì’·‚³EˆÊ’uî•ñ‚ğ—^‚¦‚éŒ`‚É•ÏX
-		** 2003.05.04 ‚©‚ë‚Æ
+		/* ä½ç½®ã‚’0ã§MatchInfoå‘¼ã³å‡ºã™ã¨ã€è¡Œé ­æ–‡å­—æ¤œç´¢æ™‚ã«ã€å…¨ã¦ trueã€€ã¨ãªã‚Šã€
+		** ç”»é¢å…¨ä½“ãŒæ¤œç´¢æ–‡å­—åˆ—æ‰±ã„ã«ãªã‚‹ä¸å…·åˆä¿®æ­£
+		** å¯¾ç­–ã¨ã—ã¦ã€è¡Œé ­ã‚’ MacthInfoã«æ•™ãˆãªã„ã¨ã„ã‘ãªã„ã®ã§ã€æ–‡å­—åˆ—ã®é•·ã•ãƒ»ä½ç½®æƒ…å ±ã‚’ä¸ãˆã‚‹å½¢ã«å¤‰æ›´
+		** 2003.05.04 ã‹ã‚ã¨
 		*/
 		if( m_CurRegexp.Match( cStr.GetPtr(), cStr.GetLength(), nPos ) ){
 			*pnSearchStart = m_CurRegexp.GetIndex();	// 2002.02.08 hor
@@ -463,32 +463,32 @@ int CEditView::IsSearchString(
 			return 0;
 		}
 	}
-	else if( m_sCurSearchOption.bWordOnly ) { // ’PŒêŒŸõ
-		/* w’èˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ğ’²‚×‚é */
+	else if( m_sCurSearchOption.bWordOnly ) { // å˜èªæ¤œç´¢
+		/* æŒ‡å®šä½ç½®ã®å˜èªã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 		CLogicInt posWordHead, posWordEnd;
 		if( ! CWordParse::WhereCurrentWord_2( cStr.GetPtr(), CLogicInt(cStr.GetLength()), nPos, &posWordHead, &posWordEnd, NULL, NULL ) ) {
-			return 0; // w’èˆÊ’u‚É’PŒê‚ªŒ©‚Â‚©‚ç‚È‚©‚Á‚½B
+			return 0; // æŒ‡å®šä½ç½®ã«å˜èªãŒè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸã€‚
  		}
 		if( nPos != posWordHead ) {
-			return 0; // w’èˆÊ’u‚Í’PŒê‚Ìn‚Ü‚è‚Å‚Í‚È‚©‚Á‚½B
+			return 0; // æŒ‡å®šä½ç½®ã¯å˜èªã®å§‹ã¾ã‚Šã§ã¯ãªã‹ã£ãŸã€‚
 		}
 		const CLogicInt wordLength = posWordEnd - posWordHead;
 		const wchar_t *const pWordHead = cStr.GetPtr() + posWordHead;
 
-		// ”äŠrŠÖ”
+		// æ¯”è¼ƒé–¢æ•°
 		int (*const fcmp)( const wchar_t*, const wchar_t*, size_t ) = m_sCurSearchOption.bLoHiCase ? wcsncmp : wcsnicmp;
 
-		// ŒŸõŒê‚ğ’PŒê‚É•ªŠ„‚µ‚È‚ª‚çw’èˆÊ’u‚Ì’PŒê‚ÆÆ‡‚·‚éB
+		// æ¤œç´¢èªã‚’å˜èªã«åˆ†å‰²ã—ãªãŒã‚‰æŒ‡å®šä½ç½®ã®å˜èªã¨ç…§åˆã™ã‚‹ã€‚
 		int wordIndex = 0;
 		const wchar_t* const searchKeyEnd = m_strCurSearchKey.data() + m_strCurSearchKey.size();
 		for( const wchar_t* p = m_strCurSearchKey.data(); p < searchKeyEnd; ) {
-			CLogicInt begin, end; // ŒŸõŒê‚ÉŠÜ‚Ü‚ê‚é’PŒê?‚ÌˆÊ’uBWhereCurrentWord_2()‚Ìd—l‚Å‚Í‹ó”’•¶š—ñ‚à’PŒê‚ÉŠÜ‚Ü‚ê‚éB
+			CLogicInt begin, end; // æ¤œç´¢èªã«å«ã¾ã‚Œã‚‹å˜èª?ã®ä½ç½®ã€‚WhereCurrentWord_2()ã®ä»•æ§˜ã§ã¯ç©ºç™½æ–‡å­—åˆ—ã‚‚å˜èªã«å«ã¾ã‚Œã‚‹ã€‚
 			if( CWordParse::WhereCurrentWord_2( p, CLogicInt(searchKeyEnd - p), CLogicInt(0), &begin, &end, NULL, NULL )
 				&& begin == 0 && begin < end
 			) {
 				if( ! WCODE::IsWordDelimiter( *p ) ) {
 					++wordIndex;
-					// p...(p + end) ‚ªŒŸõŒê‚ÉŠÜ‚Ü‚ê‚é wordIndex”Ô–Ú‚Ì’PŒêB(wordIndex‚ÌÅ‰‚Í 1)
+					// p...(p + end) ãŒæ¤œç´¢èªã«å«ã¾ã‚Œã‚‹ wordIndexç•ªç›®ã®å˜èªã€‚(wordIndexã®æœ€åˆã¯ 1)
 					if( wordLength == end && 0 == fcmp( p, pWordHead, wordLength ) ) {
 						*pnSearchStart = posWordHead;
 						*pnSearchEnd = posWordEnd;
@@ -500,7 +500,7 @@ int CEditView::IsSearchString(
 				p += CNativeW::GetSizeOfChar( p, searchKeyEnd - p, 0 );
 			}
 		}
-		return 0; // w’èˆÊ’u‚Ì’PŒê‚ÆŒŸõ•¶š—ñ‚ÉŠÜ‚Ü‚ê‚é’PŒê‚Íˆê’v‚µ‚È‚©‚Á‚½B
+		return 0; // æŒ‡å®šä½ç½®ã®å˜èªã¨æ¤œç´¢æ–‡å­—åˆ—ã«å«ã¾ã‚Œã‚‹å˜èªã¯ä¸€è‡´ã—ãªã‹ã£ãŸã€‚
 	}
 	else {
 		const wchar_t* pHit = CSearchAgent::SearchString(cStr.GetPtr(), cStr.GetLength(), nPos, m_sSearchPattern);
@@ -509,7 +509,7 @@ int CEditView::IsSearchString(
 			*pnSearchEnd = *pnSearchStart + m_sSearchPattern.GetLen();
 			return 1;
 		}
-		return 0; // ‚±‚Ìs‚Íƒqƒbƒg‚µ‚È‚©‚Á‚½
+		return 0; // ã“ã®è¡Œã¯ãƒ’ãƒƒãƒˆã—ãªã‹ã£ãŸ
 	}
 	return 0;
 }

--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "CRuler.h"
 #include "CTextArea.h"
 #include "view/CEditView.h"
@@ -9,26 +9,26 @@ CRuler::CRuler(const CEditView* pEditView, const CEditDoc* pEditDoc)
 : m_pEditView(pEditView)
 , m_pEditDoc(pEditDoc)
 {
-	m_nOldRulerDrawX = 0;	// ‘O‰ñ•`‰æ‚µ‚½ƒ‹[ƒ‰[‚ÌƒLƒƒƒŒƒbƒgˆÊ’u 2002.02.25 Add By KK
-	m_nOldRulerWidth = 0;	// ‘O‰ñ•`‰æ‚µ‚½ƒ‹[ƒ‰[‚ÌƒLƒƒƒŒƒbƒg•   2002.02.25 Add By KK
+	m_nOldRulerDrawX = 0;	// å‰å›æç”»ã—ãŸãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½® 2002.02.25 Add By KK
+	m_nOldRulerWidth = 0;	// å‰å›æç”»ã—ãŸãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆå¹…   2002.02.25 Add By KK
 }
 
 CRuler::~CRuler()
 {
 }
 
-//2007.08.26 kobake UNICODE—p‚ÉXˆÊ’u‚ğ•ÏX
+//2007.08.26 kobake UNICODEç”¨ã«Xä½ç½®ã‚’å¤‰æ›´
 void CRuler::_DrawRulerCaret( CGraphics& gr, int nCaretDrawPosX, int nCaretWidth )
 {
-	//•`‰æ—Ìˆæ -> hRgn
+	//æç”»é ˜åŸŸ -> hRgn
 	RECT rc;
-	rc.left = nCaretDrawPosX + 1;	// 2012.07.27 Moca 1px‰E‚ÉC³
+	rc.left = nCaretDrawPosX + 1;	// 2012.07.27 Moca 1pxå³ã«ä¿®æ­£
 	rc.right = rc.left + m_pEditView->GetTextMetrics().GetHankakuDx() - 1;
 	rc.top = 0;
 	rc.bottom = m_pEditView->GetTextArea().GetAreaTop() - m_pEditView->GetTextArea().GetTopYohaku() - 1;
 	HRGN hRgn = ::CreateRectRgnIndirect( &rc );
 
-	//ƒuƒ‰ƒVì¬ -> hBrush
+	//ãƒ–ãƒ©ã‚·ä½œæˆ -> hBrush
 	HBRUSH hBrush;
 	if( 0 == nCaretWidth ){
 		hBrush = ::CreateSolidBrush( RGB( 128, 128, 128 ) );
@@ -36,7 +36,7 @@ void CRuler::_DrawRulerCaret( CGraphics& gr, int nCaretDrawPosX, int nCaretWidth
 		hBrush = ::CreateSolidBrush( RGB( 0, 0, 0 ) );
 	}
 
-	//—Ìˆæ‚ğ•`‰æ (F‚ğ”½“]‚³‚¹‚é)
+	//é ˜åŸŸã‚’æç”» (è‰²ã‚’åè»¢ã•ã›ã‚‹)
 	int    nROP_Old  = ::SetROP2( gr, R2_NOTXORPEN );
 	HBRUSH hBrushOld = (HBRUSH)::SelectObject( gr, hBrush );
 	::SelectObject( gr, hBrush );
@@ -44,15 +44,15 @@ void CRuler::_DrawRulerCaret( CGraphics& gr, int nCaretDrawPosX, int nCaretWidth
 	::SelectObject( gr, hBrushOld );
 	::SetROP2( gr, nROP_Old );
 
-	//•`‰æƒIƒuƒWƒFƒNƒg”jŠü
+	//æç”»ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆç ´æ£„
 	::DeleteObject( hRgn );
 	::DeleteObject( hBrush );
 }
 
 /*! 
-	ƒ‹[ƒ‰[‚ÌƒLƒƒƒŒƒbƒg‚ğÄ•`‰æ	2002.02.25 Add By KK
-	@param hdc [in] ƒfƒoƒCƒXƒRƒ“ƒeƒLƒXƒg
-	DispRuler‚Ì“à—e‚ğŒ³‚Éì¬
+	ãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã‚’å†æç”»	2002.02.25 Add By KK
+	@param hdc [in] ãƒ‡ãƒã‚¤ã‚¹ã‚³ãƒ³ãƒ†ã‚­ã‚¹ãƒˆ
+	DispRulerã®å†…å®¹ã‚’å…ƒã«ä½œæˆ
 */
 void CRuler::DrawRulerCaret( CGraphics& gr )
 {
@@ -61,14 +61,14 @@ void CRuler::DrawRulerCaret( CGraphics& gr )
 	){
 		if (m_pEditView->GetRuler().m_nOldRulerDrawX == m_pEditView->GetCaret().CalcCaretDrawPos(m_pEditView->GetCaret().GetCaretLayoutPos()).x
 			&& m_pEditView->GetCaret().GetCaretSize().cx == m_pEditView->GetRuler().m_nOldRulerWidth) {
-			//‘O•`‰æ‚µ‚½ˆÊ’u‰æ“¯‚¶ ‚©‚Â ƒ‹[ƒ‰[‚ÌƒLƒƒƒŒƒbƒg•‚ª“¯‚¶ 
+			//å‰æç”»ã—ãŸä½ç½®ç”»åŒã˜ ã‹ã¤ ãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆå¹…ãŒåŒã˜ 
 			return;
 		}
 
-		//Œ³ˆÊ’u‚ğƒNƒŠƒA m_nOldRulerWidth
+		//å…ƒä½ç½®ã‚’ã‚¯ãƒªã‚¢ m_nOldRulerWidth
 		this->_DrawRulerCaret( gr, m_nOldRulerDrawX, m_nOldRulerWidth );
 
-		//V‚µ‚¢ˆÊ’u‚Å•`‰æ   2007.08.26 kobake UNICODE—p‚ÉXˆÊ’u‚ğ•ÏX
+		//æ–°ã—ã„ä½ç½®ã§æç”»   2007.08.26 kobake UNICODEç”¨ã«Xä½ç½®ã‚’å¤‰æ›´
 		this->_DrawRulerCaret(
 			gr,
 			m_pEditView->GetCaret().CalcCaretDrawPos(m_pEditView->GetCaret().GetCaretLayoutPos()).x,
@@ -77,16 +77,16 @@ void CRuler::DrawRulerCaret( CGraphics& gr )
 	}
 }
 
-//! ƒ‹[ƒ‰[‚Ì”wŒi‚Ì‚İ•`‰æ 2007.08.29 kobake ’Ç‰Á
+//! ãƒ«ãƒ¼ãƒ©ãƒ¼ã®èƒŒæ™¯ã®ã¿æç”» 2007.08.29 kobake è¿½åŠ 
 void CRuler::DrawRulerBg(CGraphics& gr)
 {
-	//•K—v‚ÈƒCƒ“ƒ^[ƒtƒF[ƒX
+	//å¿…è¦ãªã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 	CommonSetting* pCommon=&GetDllShareData().m_Common;
 
-	//ƒTƒ|[ƒg
+	//ã‚µãƒãƒ¼ãƒˆ
 	CTypeSupport cRulerType(m_pEditView,COLORIDX_RULER);
 
-	// ƒtƒHƒ“ƒgİ’è (ƒ‹[ƒ‰[ã‚Ì”š—p)
+	// ãƒ•ã‚©ãƒ³ãƒˆè¨­å®š (ãƒ«ãƒ¼ãƒ©ãƒ¼ä¸Šã®æ•°å­—ç”¨)
 	LOGFONT	lf;
 	HFONT		hFont;
 	HFONT		hFontOld;
@@ -109,7 +109,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 	hFontOld = (HFONT)::SelectObject( gr, hFont );
 	::SetBkMode( gr, TRANSPARENT );
 
-	//”wŒi“h‚è‚Â‚Ô‚µ
+	//èƒŒæ™¯å¡—ã‚Šã¤ã¶ã—
 	RECT rc;
 	rc.left = 0;
 	rc.top = 0;
@@ -117,19 +117,19 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 	rc.bottom = m_pEditView->GetTextArea().GetAreaTop() - m_pEditView->GetTextArea().GetTopYohaku();
 	cRulerType.FillBack(gr,rc);
 
-	//ƒ‹[ƒ‰[Fİ’è
+	//ãƒ«ãƒ¼ãƒ©ãƒ¼è‰²è¨­å®š
 	gr.PushPen(cRulerType.GetTextColor(),0);
 	gr.PushTextForeColor(cRulerType.GetTextColor());
 
 
-	//•`‰æŠJnˆÊ’u
+	//æç”»é–‹å§‹ä½ç½®
 	int nX = m_pEditView->GetTextArea().GetAreaLeft();
 	int nY = m_pEditView->GetTextArea().GetRulerHeight() - 2;
 
 
-	// ‰ºü (ƒ‹[ƒ‰[‚Æ–{•¶‚Ì‹«ŠE)
-	//	Aug. 14, 2005 genta Ü‚è•Ô‚µ•‚ğLayoutMgr‚©‚çæ“¾‚·‚é‚æ‚¤‚É
-	//	2005.11.10 Moca 1dot‘«‚è‚È‚¢
+	// ä¸‹ç·š (ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨æœ¬æ–‡ã®å¢ƒç•Œ)
+	//	Aug. 14, 2005 genta æŠ˜ã‚Šè¿”ã—å¹…ã‚’LayoutMgrã‹ã‚‰å–å¾—ã™ã‚‹ã‚ˆã†ã«
+	//	2005.11.10 Moca 1dotè¶³ã‚Šãªã„
 	CLayoutXInt	nMaxLineColum = m_pEditDoc->m_cLayoutMgr.GetMaxLineLayout();
 	CKetaXInt	nMaxLineKetas = m_pEditDoc->m_cLayoutMgr.GetMaxLineKetas();
 	int nToX = m_pEditView->GetTextArea().GetAreaLeft() + m_pEditView->GetTextMetrics().GetCharPxWidth(nMaxLineColum - m_pEditView->GetTextArea().GetViewLeftCol()) + 1;
@@ -140,12 +140,12 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 	::LineTo( gr, nToX, nY + 1 );
 
 
-	//–Ú·‚ğ•`‰æ
+	//ç›®ç››ã‚’æç”»
 	const int oneColumn = (Int)m_pEditView->GetTextMetrics().GetLayoutXDefault();
 	CLayoutXInt i  = m_pEditView->GetTextArea().GetViewLeftCol();
 	CKetaXInt keta = CKetaXInt(((Int)i) / oneColumn);
-	const int dx = m_pEditView->GetTextMetrics().GetHankakuDx(); // PP‚Å‚àDx
-	// æ“ª‚ª‚©‚¯‚Ä‚¢‚éê‡‚ÍŸ‚ÌŒ…‚Éi‚Ş
+	const int dx = m_pEditView->GetTextMetrics().GetHankakuDx(); // PPã§ã‚‚Dx
+	// å…ˆé ­ãŒã‹ã‘ã¦ã„ã‚‹å ´åˆã¯æ¬¡ã®æ¡ã«é€²ã‚€
 	const int pxOffset = (Int)i % oneColumn;
 	if( pxOffset ){
 		nX += oneColumn - pxOffset;
@@ -154,12 +154,12 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 	}
 	while(i <= m_pEditView->GetTextArea().GetRightCol() + 1 && keta <= nMaxLineKetas)
 	{
-		//ƒ‹[ƒ‰[I’[‚Ì‹æØ‚è(‘å)
+		//ãƒ«ãƒ¼ãƒ©ãƒ¼çµ‚ç«¯ã®åŒºåˆ‡ã‚Š(å¤§)
 		if( keta == nMaxLineKetas ){
 			::MoveToEx( gr, nX, nY, NULL );
 			::LineTo( gr, nX, 0 );
 		}
-		//10–Ú·‚¨‚«‚Ì‹æØ‚è(‘å)‚Æ”š
+		//10ç›®ç››ãŠãã®åŒºåˆ‡ã‚Š(å¤§)ã¨æ•°å­—
 		else if( 0 == keta % 10 ){
 			wchar_t szColumn[32];
 			::MoveToEx( gr, nX, nY, NULL );
@@ -167,12 +167,12 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 			_itow( ((Int)keta) / 10, szColumn, 10 );
 			::TextOutW_AnyBuild( gr, nX + 2 + 0, -1 + 0, szColumn, wcslen( szColumn ) );
 		}
-		//5–Ú·‚¨‚«‚Ì‹æØ‚è(’†)
+		//5ç›®ç››ãŠãã®åŒºåˆ‡ã‚Š(ä¸­)
 		else if( 0 == keta % 5 ){
 			::MoveToEx( gr, nX, nY, NULL );
 			::LineTo( gr, nX, nY - 6 );
 		}
-		//–ˆ–Ú·‚Ì‹æØ‚è(¬)
+		//æ¯ç›®ç››ã®åŒºåˆ‡ã‚Š(å°)
 		else{
 			::MoveToEx( gr, nX, nY, NULL );
 			::LineTo( gr, nX, nY - 3 );
@@ -183,22 +183,22 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 		keta++;
 	}
 
-	//F–ß‚·
+	//è‰²æˆ»ã™
 	gr.PopTextForeColor();
 	gr.PopPen();
 
-	//ƒtƒHƒ“ƒg–ß‚·
+	//ãƒ•ã‚©ãƒ³ãƒˆæˆ»ã™
 	::SelectObject( gr, hFontOld );
 	::DeleteObject( hFont );
 }
 
-/*! ƒ‹[ƒ‰[•`‰æ
+/*! ãƒ«ãƒ¼ãƒ©ãƒ¼æç”»
 
-	@date 2005.08.14 genta Ü‚è•Ô‚µ•‚ğLayoutMgr‚©‚çæ“¾‚·‚é‚æ‚¤‚É
+	@date 2005.08.14 genta æŠ˜ã‚Šè¿”ã—å¹…ã‚’LayoutMgrã‹ã‚‰å–å¾—ã™ã‚‹ã‚ˆã†ã«
 */
 void CRuler::DispRuler( HDC hdc )
 {
-	//ƒTƒ|[ƒg
+	//ã‚µãƒãƒ¼ãƒˆ
 	CTypeSupport cRulerType(m_pEditView,COLORIDX_RULER);
 
 	if( !m_pEditView->GetDrawSwitch() ){
@@ -208,28 +208,28 @@ void CRuler::DispRuler( HDC hdc )
 		return;
 	}
 
-	// •`‰æ‘ÎÛ
+	// æç”»å¯¾è±¡
 	CGraphics gr(hdc);
 
-	// 2002.02.25 Add By KK ƒ‹[ƒ‰[‘S‘Ì‚ğ•`‚«’¼‚·•K—v‚ª‚È‚¢ê‡‚ÍAƒ‹[ƒ‰ã‚ÌƒLƒƒƒŒƒbƒg‚Ì‚İ•`‚«‚È‚¨‚· 
+	// 2002.02.25 Add By KK ãƒ«ãƒ¼ãƒ©ãƒ¼å…¨ä½“ã‚’æãç›´ã™å¿…è¦ãŒãªã„å ´åˆã¯ã€ãƒ«ãƒ¼ãƒ©ä¸Šã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ã¿æããªãŠã™ 
 	if ( !m_bRedrawRuler ) {
 		DrawRulerCaret( gr );
 	}
 	else {
-		// ”wŒi•`‰æ
+		// èƒŒæ™¯æç”»
 		DrawRulerBg(gr);
 
-		// ƒLƒƒƒŒƒbƒg•`‰æ
+		// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆæç”»
 		if( m_pEditView->GetTextArea().GetViewLeftCol() <= m_pEditView->GetCaret().GetCaretLayoutPos().GetX()
 		 && m_pEditView->GetTextArea().GetRightCol() + 2 >= m_pEditView->GetCaret().GetCaretLayoutPos().GetX()
 		){
 			_DrawRulerCaret(gr,m_pEditView->GetCaret().CalcCaretDrawPos(m_pEditView->GetCaret().GetCaretLayoutPos()).x,m_pEditView->GetCaret().GetCaretSize().cx);
 		}
 
-		m_bRedrawRuler = false;	//m_bRedrawRuler = true ‚Åw’è‚³‚ê‚é‚Ü‚ÅAƒ‹[ƒ‰‚ÌƒLƒƒƒŒƒbƒg‚Ì‚İ‚ğÄ•`‰æ 2002.02.25 Add By KK
+		m_bRedrawRuler = false;	//m_bRedrawRuler = true ã§æŒ‡å®šã•ã‚Œã‚‹ã¾ã§ã€ãƒ«ãƒ¼ãƒ©ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ã¿ã‚’å†æç”» 2002.02.25 Add By KK
 	}
 
-	//•`‰æ‚µ‚½ƒ‹[ƒ‰[‚ÌƒLƒƒƒŒƒbƒgˆÊ’uE•‚ğ•Û‘¶ 2002.02.25 Add By KK
+	//æç”»ã—ãŸãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ãƒ»å¹…ã‚’ä¿å­˜ 2002.02.25 Add By KK
 	m_nOldRulerDrawX = m_pEditView->GetCaret().CalcCaretDrawPos(m_pEditView->GetCaret().GetCaretLayoutPos()).x;
 	m_nOldRulerWidth = m_pEditView->GetCaret().GetCaretSize().cx ;
 }

--- a/sakura_core/view/CRuler.h
+++ b/sakura_core/view/CRuler.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -36,36 +36,36 @@ public:
 	virtual ~CRuler();
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                     ƒCƒ“ƒ^[ƒtƒF[ƒX                        //
+	//                     ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                        //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//! ƒ‹[ƒ‰[•`‰æ (”wŒi‚ÆƒLƒƒƒŒƒbƒg)
+	//! ãƒ«ãƒ¼ãƒ©ãƒ¼æç”» (èƒŒæ™¯ã¨ã‚­ãƒ£ãƒ¬ãƒƒãƒˆ)
 	void DispRuler( HDC );
 
-	//! ƒ‹[ƒ‰[‚Ì”wŒi‚Ì‚İ•`‰æ 2007.08.29 kobake ’Ç‰Á
+	//! ãƒ«ãƒ¼ãƒ©ãƒ¼ã®èƒŒæ™¯ã®ã¿æç”» 2007.08.29 kobake è¿½åŠ 
 	void DrawRulerBg(CGraphics& gr);
 
 	void SetRedrawFlag(){ m_bRedrawRuler = true; }
 	bool GetRedrawFlag(){ return m_bRedrawRuler; }
 
 private:
-	//! ƒ‹[ƒ‰[‚ÌƒLƒƒƒŒƒbƒg‚Ì‚İ•`‰æ 2002.02.25 Add By KK
+	//! ãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆã®ã¿æç”» 2002.02.25 Add By KK
 	void DrawRulerCaret( CGraphics& gr );
 
 	void _DrawRulerCaret( CGraphics& gr, int nCaretDrawX, int nCaretWidth );
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                       ƒƒ“ƒo•Ï”ŒQ                          //
+	//                       ãƒ¡ãƒ³ãƒå¤‰æ•°ç¾¤                          //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 private:
-	//QÆ
+	//å‚ç…§
 	const CEditView*	m_pEditView;
 	const CEditDoc*		m_pEditDoc;
 
-	//ó‘Ô
-	bool	m_bRedrawRuler;		// ƒ‹[ƒ‰[‘S‘Ì‚ğ•`‚«’¼‚· = true      2002.02.25 Add By KK
-	int		m_nOldRulerDrawX;	// ‘O‰ñ•`‰æ‚µ‚½ƒ‹[ƒ‰[‚ÌƒLƒƒƒŒƒbƒgˆÊ’u 2002.02.25 Add By KK  2007.08.26 kobake –¼‘O•ÏX
-	int		m_nOldRulerWidth;	// ‘O‰ñ•`‰æ‚µ‚½ƒ‹[ƒ‰[‚ÌƒLƒƒƒŒƒbƒg•   2002.02.25 Add By KK  2007.08.26 kobake –¼‘O•ÏX
+	//çŠ¶æ…‹
+	bool	m_bRedrawRuler;		// ãƒ«ãƒ¼ãƒ©ãƒ¼å…¨ä½“ã‚’æãç›´ã™æ™‚ = true      2002.02.25 Add By KK
+	int		m_nOldRulerDrawX;	// å‰å›æç”»ã—ãŸãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½® 2002.02.25 Add By KK  2007.08.26 kobake åå‰å¤‰æ›´
+	int		m_nOldRulerWidth;	// å‰å›æç”»ã—ãŸãƒ«ãƒ¼ãƒ©ãƒ¼ã®ã‚­ãƒ£ãƒ¬ãƒƒãƒˆå¹…   2002.02.25 Add By KK  2007.08.26 kobake åå‰å¤‰æ›´
 };
 
 #endif /* SAKURA_CRULER_CF213704_1CF6_427E_AD78_D628D2D1F9029_H_ */

--- a/sakura_core/view/CTextArea.cpp
+++ b/sakura_core/view/CTextArea.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "CTextArea.h"
 #include "CViewFont.h"
 #include "CRuler.h"
@@ -8,18 +8,18 @@
 #include "doc/CEditDoc.h"
 
 // 2014.07.26 katze
-//#define USE_LOG10			// ‚±‚Ìs‚ÌƒRƒƒ“ƒg‚ğŠO‚·‚Æs”Ô†‚ÌÅ¬Œ…”‚ÌŒvZ‚Élog10()‚ğ—p‚¢‚é
+//#define USE_LOG10			// ã“ã®è¡Œã®ã‚³ãƒ¡ãƒ³ãƒˆã‚’å¤–ã™ã¨è¡Œç•ªå·ã®æœ€å°æ¡æ•°ã®è¨ˆç®—ã«log10()ã‚’ç”¨ã„ã‚‹
 #ifdef USE_LOG10
 #include <math.h>
 #endif
 
-//! ƒeƒ“ƒvƒŒ[ƒg‚Å‚×‚«æ‚ğŒvZ(!=0)
+//! ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã§ã¹ãä¹—ã‚’è¨ˆç®—(!=0)
 template <int N, int M>
 struct power{
     static const int value = N * power<N, M - 1>::value;
 };
 
-//! ƒeƒ“ƒvƒŒ[ƒg‚Å‚×‚«æ‚ğŒvZ(==0)
+//! ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã§ã¹ãä¹—ã‚’è¨ˆç®—(==0)
 template<int N>
 struct power<N, 0>{
     static const int value = 1;
@@ -30,17 +30,17 @@ CTextArea::CTextArea(CEditView* pEditView)
 {
 	DLLSHAREDATA* pShareData = &GetDllShareData();
 
-	m_nViewAlignLeft = 0;		/* •\¦ˆæ‚Ì¶’[À•W */
-	m_nViewAlignLeftCols = 0;	/* s”Ô†ˆæ‚ÌŒ…” */
-	m_nViewCx = 0;				/* •\¦ˆæ‚Ì• */
-	m_nViewCy = 0;				/* •\¦ˆæ‚Ì‚‚³ */
-	m_nViewColNum = CLayoutInt(0);			/* •\¦ˆæ‚ÌŒ…” */
-	m_nViewRowNum = CLayoutInt(0);			/* •\¦ˆæ‚Ìs” */
-	m_nViewTopLine = CLayoutInt(0);			/* •\¦ˆæ‚Ìˆê”Ôã‚Ìs */
-	m_nViewLeftCol = CLayoutInt(0);			/* •\¦ˆæ‚Ìˆê”Ô¶‚ÌŒ… */
-	SetTopYohaku( pShareData->m_Common.m_sWindow.m_nRulerBottomSpace ); 	/* ƒ‹[ƒ‰[‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ */
+	m_nViewAlignLeft = 0;		/* è¡¨ç¤ºåŸŸã®å·¦ç«¯åº§æ¨™ */
+	m_nViewAlignLeftCols = 0;	/* è¡Œç•ªå·åŸŸã®æ¡æ•° */
+	m_nViewCx = 0;				/* è¡¨ç¤ºåŸŸã®å¹… */
+	m_nViewCy = 0;				/* è¡¨ç¤ºåŸŸã®é«˜ã• */
+	m_nViewColNum = CLayoutInt(0);			/* è¡¨ç¤ºåŸŸã®æ¡æ•° */
+	m_nViewRowNum = CLayoutInt(0);			/* è¡¨ç¤ºåŸŸã®è¡Œæ•° */
+	m_nViewTopLine = CLayoutInt(0);			/* è¡¨ç¤ºåŸŸã®ä¸€ç•ªä¸Šã®è¡Œ */
+	m_nViewLeftCol = CLayoutInt(0);			/* è¡¨ç¤ºåŸŸã®ä¸€ç•ªå·¦ã®æ¡ */
+	SetTopYohaku( pShareData->m_Common.m_sWindow.m_nRulerBottomSpace ); 	/* ãƒ«ãƒ¼ãƒ©ãƒ¼ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“ */
 	SetLeftYohaku( pShareData->m_Common.m_sWindow.m_nLineNumRightSpace );
-	m_nViewAlignTop = GetTopYohaku();		/* •\¦ˆæ‚Ìã’[À•W */
+	m_nViewAlignTop = GetTopYohaku();		/* è¡¨ç¤ºåŸŸã®ä¸Šç«¯åº§æ¨™ */
 }
 
 CTextArea::~CTextArea()
@@ -49,32 +49,32 @@ CTextArea::~CTextArea()
 
 void CTextArea::CopyTextAreaStatus(CTextArea* pDst) const
 {
-	pDst->SetAreaLeft				( this->GetAreaLeft() );		// •\¦ˆæ‚Ì¶’[À•W
-	pDst->m_nViewAlignLeftCols		= this->m_nViewAlignLeftCols;	// s”Ô†ˆæ‚ÌŒ…”
-	pDst->SetAreaTop				(this->GetAreaTop());			// •\¦ˆæ‚Ìã’[À•W
-//	pDst->m_nViewCx					= m_nViewCx;					// •\¦ˆæ‚Ì•
-//	pDst->m_nViewCy					= m_nViewCy;					// •\¦ˆæ‚Ì‚‚³
-//	pDst->m_nViewColNum				= this->m_nViewColNum;			// •\¦ˆæ‚ÌŒ…”
-//	pDst->m_nViewRowNum				= this->m_nViewRowNum;			// •\¦ˆæ‚Ìs”
-	pDst->SetViewTopLine			( this->GetViewTopLine() );		// •\¦ˆæ‚Ìˆê”Ôã‚Ìs(0ŠJn)
-	pDst->SetViewLeftCol			( this->GetViewLeftCol() );		// •\¦ˆæ‚Ìˆê”Ô¶‚ÌŒ…(0ŠJn)
+	pDst->SetAreaLeft				( this->GetAreaLeft() );		// è¡¨ç¤ºåŸŸã®å·¦ç«¯åº§æ¨™
+	pDst->m_nViewAlignLeftCols		= this->m_nViewAlignLeftCols;	// è¡Œç•ªå·åŸŸã®æ¡æ•°
+	pDst->SetAreaTop				(this->GetAreaTop());			// è¡¨ç¤ºåŸŸã®ä¸Šç«¯åº§æ¨™
+//	pDst->m_nViewCx					= m_nViewCx;					// è¡¨ç¤ºåŸŸã®å¹…
+//	pDst->m_nViewCy					= m_nViewCy;					// è¡¨ç¤ºåŸŸã®é«˜ã•
+//	pDst->m_nViewColNum				= this->m_nViewColNum;			// è¡¨ç¤ºåŸŸã®æ¡æ•°
+//	pDst->m_nViewRowNum				= this->m_nViewRowNum;			// è¡¨ç¤ºåŸŸã®è¡Œæ•°
+	pDst->SetViewTopLine			( this->GetViewTopLine() );		// è¡¨ç¤ºåŸŸã®ä¸€ç•ªä¸Šã®è¡Œ(0é–‹å§‹)
+	pDst->SetViewLeftCol			( this->GetViewLeftCol() );		// è¡¨ç¤ºåŸŸã®ä¸€ç•ªå·¦ã®æ¡(0é–‹å§‹)
 }
 
-//!•\¦ˆæ‚ÌÄŒvZ
+//!è¡¨ç¤ºåŸŸã®å†è¨ˆç®—
 void CTextArea::UpdateViewColRowNums()
 {
 	CEditView* pView=m_pEditView;
-	// Note: ƒ}ƒCƒiƒX‚ÌŠ„‚èZ‚Íˆ—ŒnˆË‘¶‚Å‚·B
-	// 0‚¾‚ÆƒJ[ƒ\ƒ‹‚ğİ’è‚Å‚«‚È‚¢E‘I‘ğ‚Å‚«‚È‚¢‚È‚Ç“®ì•s—Ç‚É‚È‚é‚Ì‚Å1ˆÈã‚É‚·‚é
-	m_nViewColNum = CLayoutInt(t_max(1, t_max(0, m_nViewCx - 1) / pView->GetTextMetrics().GetCharPxWidth()));	// •\¦ˆæ‚ÌŒ…”
-	m_nViewRowNum = CLayoutInt(t_max(1, t_max(0, m_nViewCy - 1) / pView->GetTextMetrics().GetHankakuDy()));	// •\¦ˆæ‚Ìs”
+	// Note: ãƒã‚¤ãƒŠã‚¹ã®å‰²ã‚Šç®—ã¯å‡¦ç†ç³»ä¾å­˜ã§ã™ã€‚
+	// 0ã ã¨ã‚«ãƒ¼ã‚½ãƒ«ã‚’è¨­å®šã§ããªã„ãƒ»é¸æŠã§ããªã„ãªã©å‹•ä½œä¸è‰¯ã«ãªã‚‹ã®ã§1ä»¥ä¸Šã«ã™ã‚‹
+	m_nViewColNum = CLayoutInt(t_max(1, t_max(0, m_nViewCx - 1) / pView->GetTextMetrics().GetCharPxWidth()));	// è¡¨ç¤ºåŸŸã®æ¡æ•°
+	m_nViewRowNum = CLayoutInt(t_max(1, t_max(0, m_nViewCy - 1) / pView->GetTextMetrics().GetHankakuDy()));	// è¡¨ç¤ºåŸŸã®è¡Œæ•°
 }
 
-//!ƒtƒHƒ“ƒg•ÏX‚ÌÛAŠeíƒpƒ‰ƒ[ƒ^‚ğŒvZ‚µ’¼‚·
+//!ãƒ•ã‚©ãƒ³ãƒˆå¤‰æ›´ã®éš›ã€å„ç¨®ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã‚’è¨ˆç®—ã—ç›´ã™
 void CTextArea::UpdateAreaMetrics()
 {
-	//•\¦ˆæ‚ÌÄŒvZ
-	//2010.08.24 Dx/Dy‚ğg‚¤‚Ì‚ÅŒã‚Åİ’è
+	//è¡¨ç¤ºåŸŸã®å†è¨ˆç®—
+	//2010.08.24 Dx/Dyã‚’ä½¿ã†ã®ã§å¾Œã§è¨­å®š
 	UpdateViewColRowNums();
 }
 
@@ -90,16 +90,16 @@ void CTextArea::GenerateCharRect(RECT* rc,const DispPos& sPos,CLayoutXInt nColum
 
 bool CTextArea::TrimRectByArea(RECT* rc) const
 {
-	//¶‚Í‚İo‚µ’²®
+	//å·¦ã¯ã¿å‡ºã—èª¿æ•´
 	if( rc->left < GetAreaLeft() ){
 		rc->left = GetAreaLeft();
 	}
 
-	if(rc->left >= rc->right)return false; //¶‚Æ‰E‚ª‚ ‚×‚±‚×
-	if(rc->left >= GetAreaRight())return false; //‰æ–ÊŠO(‰E)
-	if(rc->right <= GetAreaLeft())return false; //‰æ–ÊŠO(¶)
+	if(rc->left >= rc->right)return false; //å·¦ã¨å³ãŒã‚ã¹ã“ã¹
+	if(rc->left >= GetAreaRight())return false; //ç”»é¢å¤–(å³)
+	if(rc->right <= GetAreaLeft())return false; //ç”»é¢å¤–(å·¦)
 
-	//$ Œ³“®ì“¥PF‰æ–Êã‰º‚Ì‚Í‚İo‚µ”»’è‚ÍÈ—ª
+	//$ å…ƒå‹•ä½œè¸è¥²ï¼šç”»é¢ä¸Šä¸‹ã®ã¯ã¿å‡ºã—åˆ¤å®šã¯çœç•¥
 
 	return true;
 }
@@ -110,7 +110,7 @@ bool CTextArea::GenerateClipRect(RECT* rc, const DispPos& sPos, CLayoutXInt nCol
 	return TrimRectByArea(rc);
 }
 
-//!‰E‚Ìc‚è‚ğ•\‚·‹éŒ`‚ğ¶¬‚·‚é
+//!å³ã®æ®‹ã‚Šã‚’è¡¨ã™çŸ©å½¢ã‚’ç”Ÿæˆã™ã‚‹
 bool CTextArea::GenerateClipRectRight(RECT* rc,const DispPos& sPos) const
 {
 	const CEditView* pView=m_pEditView;
@@ -120,16 +120,16 @@ bool CTextArea::GenerateClipRectRight(RECT* rc,const DispPos& sPos) const
 	rc->top    = sPos.GetDrawPos().y;
 	rc->bottom = sPos.GetDrawPos().y + pView->GetTextMetrics().GetHankakuDy();
 
-	//¶‚Í‚İo‚µ’²®
+	//å·¦ã¯ã¿å‡ºã—èª¿æ•´
 	if( rc->left < GetAreaLeft() ){
 		rc->left = GetAreaLeft();
 	}
 
-	if(rc->left >= rc->right)return false; //¶‚Æ‰E‚ª‚ ‚×‚±‚×
-	if(rc->left >= GetAreaRight())return false; //‰æ–ÊŠO(‰E)
-	if(rc->right <= GetAreaLeft())return false; //‰æ–ÊŠO(¶)
+	if(rc->left >= rc->right)return false; //å·¦ã¨å³ãŒã‚ã¹ã“ã¹
+	if(rc->left >= GetAreaRight())return false; //ç”»é¢å¤–(å³)
+	if(rc->right <= GetAreaLeft())return false; //ç”»é¢å¤–(å·¦)
 
-	//$ Œ³“®ì“¥PF‰æ–Êã‰º‚Ì‚Í‚İo‚µ”»’è‚ÍÈ—ª
+	//$ å…ƒå‹•ä½œè¸è¥²ï¼šç”»é¢ä¸Šä¸‹ã®ã¯ã¿å‡ºã—åˆ¤å®šã¯çœç•¥
 
 	return true;
 }
@@ -145,7 +145,7 @@ bool CTextArea::GenerateClipRectLine(RECT* rc,const DispPos& sPos) const
 
 
 /*
-s”Ô†•\¦‚É•K—v‚È•‚ğİ’èB•‚ª•ÏX‚³‚ê‚½ê‡‚ÍTRUE‚ğ•Ô‚·
+è¡Œç•ªå·è¡¨ç¤ºã«å¿…è¦ãªå¹…ã‚’è¨­å®šã€‚å¹…ãŒå¤‰æ›´ã•ã‚ŒãŸå ´åˆã¯TRUEã‚’è¿”ã™
 */
 bool CTextArea::DetectWidthOfLineNumberArea( bool bRedraw )
 {
@@ -155,9 +155,9 @@ bool CTextArea::DetectWidthOfLineNumberArea( bool bRedraw )
 	int				nViewAlignLeftNew;
 
 	if( pView->m_pTypeData->m_ColorInfoArr[COLORIDX_GYOU].m_bDisp && !pView->m_bMiniMap ){
-		/* s”Ô†•\¦‚É•K—v‚ÈŒ…”‚ğŒvZ */
+		/* è¡Œç•ªå·è¡¨ç¤ºã«å¿…è¦ãªæ¡æ•°ã‚’è¨ˆç®— */
 		int i = DetectWidthOfLineNumberArea_calculate(&pView->m_pcEditDoc->m_cLayoutMgr);
-		nViewAlignLeftNew = pView->GetTextMetrics().GetHankakuDx() * (i + 1);	/* •\¦ˆæ‚Ì¶’[À•W */
+		nViewAlignLeftNew = pView->GetTextMetrics().GetHankakuDx() * (i + 1);	/* è¡¨ç¤ºåŸŸã®å·¦ç«¯åº§æ¨™ */
 		m_nViewAlignLeftCols = i + 1;
 	}else if( pView->m_bMiniMap ){
 		nViewAlignLeftNew = 4;
@@ -173,17 +173,17 @@ bool CTextArea::DetectWidthOfLineNumberArea( bool bRedraw )
 		CMyRect			rc;
 		SetAreaLeft(nViewAlignLeftNew);
 		pView->GetClientRect( &rc );
-		int nCxVScroll = ::GetSystemMetrics( SM_CXVSCROLL ); // ‚’¼ƒXƒNƒ[ƒ‹ƒo[‚Ì‰¡•
-		m_nViewCx = rc.Width() - nCxVScroll - GetAreaLeft(); // •\¦ˆæ‚Ì•
-		// 2008.05.27 nasukoji	•\¦ˆæ‚ÌŒ…”‚àZo‚·‚éi‰E’[ƒJ[ƒ\ƒ‹ˆÚ“®‚Ì•\¦êŠ‚¸‚ê‚Ö‚Ì‘Îˆj
-		// m_nViewColNum = CLayoutInt(t_max(0, m_nViewCx - 1) / pView->GetTextMetrics().GetHankakuDx());	// •\¦ˆæ‚ÌŒ…”
+		int nCxVScroll = ::GetSystemMetrics( SM_CXVSCROLL ); // å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®æ¨ªå¹…
+		m_nViewCx = rc.Width() - nCxVScroll - GetAreaLeft(); // è¡¨ç¤ºåŸŸã®å¹…
+		// 2008.05.27 nasukoji	è¡¨ç¤ºåŸŸã®æ¡æ•°ã‚‚ç®—å‡ºã™ã‚‹ï¼ˆå³ç«¯ã‚«ãƒ¼ã‚½ãƒ«ç§»å‹•æ™‚ã®è¡¨ç¤ºå ´æ‰€ãšã‚Œã¸ã®å¯¾å‡¦ï¼‰
+		// m_nViewColNum = CLayoutInt(t_max(0, m_nViewCx - 1) / pView->GetTextMetrics().GetHankakuDx());	// è¡¨ç¤ºåŸŸã®æ¡æ•°
 		UpdateViewColRowNums();
 
 		if( bRedraw && pView2->GetDrawSwitch() ){
-			/* Ä•`‰æ */
+			/* å†æç”» */
 			pView2->GetCaret().m_cUnderLine.Lock();
-			// From Here 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
-			pView2->Call_OnPaint(PAINT_LINENUMBER | PAINT_RULER | PAINT_BODY, false); /* ƒƒ‚ƒŠ‚c‚b‚ğg—p‚µ‚Ä‚¿‚ç‚Â‚«‚Ì‚È‚¢Ä•`‰æ */
+			// From Here 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
+			pView2->Call_OnPaint(PAINT_LINENUMBER | PAINT_RULER | PAINT_BODY, false); /* ãƒ¡ãƒ¢ãƒªï¼¤ï¼£ã‚’ä½¿ç”¨ã—ã¦ã¡ã‚‰ã¤ãã®ãªã„å†æç”» */
 			// To Here 2007.09.09 Moca
 			pView2->GetCaret().m_cUnderLine.UnLock();
 			pView2->GetCaret().ShowEditCaret();
@@ -210,20 +210,20 @@ bool CTextArea::DetectWidthOfLineNumberArea( bool bRedraw )
 
 
 /*!
-	s”Ô†•\¦‚É•K—v‚ÈŒ…”‚ğŒvZ
+	è¡Œç•ªå·è¡¨ç¤ºã«å¿…è¦ãªæ¡æ•°ã‚’è¨ˆç®—
 
 	@param [in] pLayoutMgr
-	@param [in] bLayout true:ƒŒƒCƒAƒEƒgs’PˆÊ / false:•¨—s’PˆÊ
+	@param [in] bLayout true:ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œå˜ä½ / false:ç‰©ç†è¡Œå˜ä½
 
-	@return s”Ô†•\¦‚É•K—v‚ÈŒ…”
+	@return è¡Œç•ªå·è¡¨ç¤ºã«å¿…è¦ãªæ¡æ•°
 */
 int CTextArea::DetectWidthOfLineNumberArea_calculate(const CLayoutMgr* pLayoutMgr, bool bLayout) const
 {
 	const CEditView* pView=m_pEditView;
 
-	int nAllLines; //$$ ’PˆÊ¬İ
+	int nAllLines; //$$ å˜ä½æ··åœ¨
 
-	/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+	/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 	if( pView->m_pTypeData->m_bLineNumIsCRLF && !bLayout){
 		nAllLines = pView->m_pcEditDoc->m_cDocLineMgr.GetLineCount();
 	}
@@ -235,46 +235,46 @@ int CTextArea::DetectWidthOfLineNumberArea_calculate(const CLayoutMgr* pLayoutMg
 		int nWork;
 		int i;
 
-		// s”Ô†‚ÌŒ…”‚ğŒˆ‚ß‚é 2014.07.26 katze
-		/* m_nLineNumWidth‚Íƒˆ‚É”š‚ÌŒ…”‚ğ¦‚µAæ“ª‚Ì‹ó”’‚ğŠÜ‚Ü‚È‚¢id—l•ÏXj 2014.08.02 katze */
+		// è¡Œç•ªå·ã®æ¡æ•°ã‚’æ±ºã‚ã‚‹ 2014.07.26 katze
+		/* m_nLineNumWidthã¯ç´”ç²‹ã«æ•°å­—ã®æ¡æ•°ã‚’ç¤ºã—ã€å…ˆé ­ã®ç©ºç™½ã‚’å«ã¾ãªã„ï¼ˆä»•æ§˜å¤‰æ›´ï¼‰ 2014.08.02 katze */
 #ifdef USE_LOG10
-		/* •\¦‚µ‚Ä‚¢‚és”‚ÌŒ…”‚ğ‹‚ß‚é */
-		nWork = (int)(log10( (double)nAllLines) +1);	// 10‚ğ’ê‚Æ‚·‚é‘Î”(¬”“_ˆÈ‰ºØ‚èÌ‚Ä)+1‚ÅŒ…”
-		/* İ’è’l‚Æ”äŠr‚µA‘å‚«‚¢•û‚ğæ‚é */
+		/* è¡¨ç¤ºã—ã¦ã„ã‚‹è¡Œæ•°ã®æ¡æ•°ã‚’æ±‚ã‚ã‚‹ */
+		nWork = (int)(log10( (double)nAllLines) +1);	// 10ã‚’åº•ã¨ã™ã‚‹å¯¾æ•°(å°æ•°ç‚¹ä»¥ä¸‹åˆ‡ã‚Šæ¨ã¦)+1ã§æ¡æ•°
+		/* è¨­å®šå€¤ã¨æ¯”è¼ƒã—ã€å¤§ãã„æ–¹ã‚’å–ã‚‹ */
 		i = std::max( nWork, pView->m_pTypeData->m_nLineNumWidth );
-		// æ“ª‚Ì‹ó”’•ª‚ğ‰ÁZ‚·‚é
+		// å…ˆé ­ã®ç©ºç™½åˆ†ã‚’åŠ ç®—ã™ã‚‹
 		return (i +1);
 #else
-		/* İ’è‚©‚çs”‚ğ‹‚ß‚é */
+		/* è¨­å®šã‹ã‚‰è¡Œæ•°ã‚’æ±‚ã‚ã‚‹ */
 		nWork = power<10, LINENUMWIDTH_MIN>::value;
 		for( i = LINENUMWIDTH_MIN; i < pView->m_pTypeData->m_nLineNumWidth; ++i ){
 			nWork *= 10;
 		}
-		/* •\¦‚µ‚Ä‚¢‚és”‚Æ”äŠr‚µA‘å‚«‚¢•û‚Ì’l‚ğæ‚é */
+		/* è¡¨ç¤ºã—ã¦ã„ã‚‹è¡Œæ•°ã¨æ¯”è¼ƒã—ã€å¤§ãã„æ–¹ã®å€¤ã‚’å–ã‚‹ */
 		for( /*i = pView->m_pTypeData->m_nLineNumWidth*/; i < LINENUMWIDTH_MAX; ++i ){
-			if( nWork > nAllLines ){	// Oct. 18, 2003 genta ®‚ğ®—
+			if( nWork > nAllLines ){	// Oct. 18, 2003 genta å¼ã‚’æ•´ç†
 				break;
 			}
 			nWork *= 10;
 		}
-		// æ“ª‚Ì‹ó”’•ª‚ğ‰ÁZ‚·‚é
+		// å…ˆé ­ã®ç©ºç™½åˆ†ã‚’åŠ ç®—ã™ã‚‹
 		return (i +1);
 #endif
 	}else{
-		//	2003.09.11 wmlhq s”Ô†‚ª1Œ…‚Ì‚Æ‚«‚Æ•‚ğ‡‚í‚¹‚é
-		// Å¬Œ…”‚ğ‰Â•Ï‚É•ÏX 2014.07.26 katze	// æ“ª‚Ì‹ó”’•ª‚ğ‰ÁZ‚·‚é 2014.07.31 katze
+		//	2003.09.11 wmlhq è¡Œç•ªå·ãŒ1æ¡ã®ã¨ãã¨å¹…ã‚’åˆã‚ã›ã‚‹
+		// æœ€å°æ¡æ•°ã‚’å¯å¤‰ã«å¤‰æ›´ 2014.07.26 katze	// å…ˆé ­ã®ç©ºç™½åˆ†ã‚’åŠ ç®—ã™ã‚‹ 2014.07.31 katze
 		return pView->m_pTypeData->m_nLineNumWidth +1;
 	}
 }
 
 void CTextArea::TextArea_OnSize(
-	const CMySize& sizeClient, //!< ƒEƒBƒ“ƒhƒE‚ÌƒNƒ‰ƒCƒAƒ“ƒgƒTƒCƒY
-	int nCxVScroll,            //!< ‚’¼ƒXƒNƒ[ƒ‹ƒo[‚Ì‰¡•
-	int nCyHScroll             //!< …•½ƒXƒNƒ[ƒ‹ƒo[‚Ìc•
+	const CMySize& sizeClient, //!< ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆã‚µã‚¤ã‚º
+	int nCxVScroll,            //!< å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®æ¨ªå¹…
+	int nCyHScroll             //!< æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®ç¸¦å¹…
 )
 {
-	m_nViewCx = sizeClient.cx - nCxVScroll - GetAreaLeft(); // •\¦ˆæ‚Ì•
-	m_nViewCy = sizeClient.cy - nCyHScroll - GetAreaTop();  // •\¦ˆæ‚Ì‚‚³
+	m_nViewCx = sizeClient.cx - nCxVScroll - GetAreaLeft(); // è¡¨ç¤ºåŸŸã®å¹…
+	m_nViewCy = sizeClient.cy - nCyHScroll - GetAreaTop();  // è¡¨ç¤ºåŸŸã®é«˜ã•
 	UpdateViewColRowNums();
 }
 
@@ -285,7 +285,7 @@ int CTextArea::GetDocumentLeftClientPointX() const
 	return GetAreaLeft() - m_pEditView->GetTextMetrics().GetCharPxWidth(GetViewLeftCol());
 }
 
-//! ƒNƒ‰ƒCƒAƒ“ƒgÀ•W‚©‚çƒŒƒCƒAƒEƒgˆÊ’u‚É•ÏŠ·‚·‚é
+//! ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆåº§æ¨™ã‹ã‚‰ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã«å¤‰æ›ã™ã‚‹
 void CTextArea::ClientToLayout(CMyPoint ptClient, CLayoutPoint* pptLayout) const
 {
 	const CEditView* pView=m_pEditView;
@@ -296,7 +296,7 @@ void CTextArea::ClientToLayout(CMyPoint ptClient, CLayoutPoint* pptLayout) const
 }
 
 
-//! s”Ô†ƒGƒŠƒA‚àŠÜ‚Ş”ÍˆÍ
+//! è¡Œç•ªå·ã‚¨ãƒªã‚¢ã‚‚å«ã‚€ç¯„å›²
 void CTextArea::GenerateTopRect   (RECT* rc, CLayoutInt nLineCount) const
 {
 	rc->left   = 0; //m_nViewAlignLeft;
@@ -305,7 +305,7 @@ void CTextArea::GenerateTopRect   (RECT* rc, CLayoutInt nLineCount) const
 	rc->bottom = m_nViewAlignTop + (Int)nLineCount * m_pEditView->GetTextMetrics().GetHankakuDy();
 }
 
-//! s”Ô†ƒGƒŠƒA‚àŠÜ‚Ş”ÍˆÍ
+//! è¡Œç•ªå·ã‚¨ãƒªã‚¢ã‚‚å«ã‚€ç¯„å›²
 void CTextArea::GenerateBottomRect(RECT* rc, CLayoutInt nLineCount) const
 {
 	rc->left   = 0; //m_nViewAlignLeft;
@@ -324,7 +324,7 @@ void CTextArea::GenerateLeftRect  (RECT* rc, CLayoutInt nColCount ) const
 
 void CTextArea::GenerateRightRect (RECT* rc, CLayoutInt nColCount ) const
 {
-	rc->left   = m_nViewAlignLeft + m_nViewCx - m_pEditView->GetTextMetrics().GetCharPxWidth(nColCount); //2008.01.26 kobake •„†‚ª‹t‚É‚È‚Á‚Ä‚½‚Ì‚ğC³
+	rc->left   = m_nViewAlignLeft + m_nViewCx - m_pEditView->GetTextMetrics().GetCharPxWidth(nColCount); //2008.01.26 kobake ç¬¦å·ãŒé€†ã«ãªã£ã¦ãŸã®ã‚’ä¿®æ­£
 	rc->right  = m_nViewAlignLeft + m_nViewCx;
 	rc->top    = m_nViewAlignTop;
 	rc->bottom = m_nViewAlignTop  + m_nViewCy;

--- a/sakura_core/view/CTextArea.h
+++ b/sakura_core/view/CTextArea.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -37,10 +37,10 @@ public:
 	void CopyTextAreaStatus(CTextArea* pDst) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                     ƒrƒ…[î•ñ‚ğæ“¾                        //
+	//                     ãƒ“ãƒ¥ãƒ¼æƒ…å ±ã‚’å–å¾—                        //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//!•\¦‚³‚ê‚éÅ‰‚Ìs
+	//!è¡¨ç¤ºã•ã‚Œã‚‹æœ€åˆã®è¡Œ
 	CLayoutInt GetViewTopLine() const
 	{
 		return m_nViewTopLine;
@@ -50,7 +50,7 @@ public:
 		m_nViewTopLine=nLine;
 	}
 
-	//!•\¦ˆæ‚Ìˆê”Ô¶‚ÌŒ…
+	//!è¡¨ç¤ºåŸŸã®ä¸€ç•ªå·¦ã®æ¡
 	CLayoutInt GetViewLeftCol() const
 	{
 		return m_nViewLeftCol;
@@ -60,20 +60,20 @@ public:
 		m_nViewLeftCol=nLeftCol;
 	}
 
-	//!‰E‚É‚Í‚İo‚µ‚½Å‰‚Ì—ñ‚ğ•Ô‚·
+	//!å³ã«ã¯ã¿å‡ºã—ãŸæœ€åˆã®åˆ—ã‚’è¿”ã™
 	CLayoutInt GetRightCol() const
 	{
 		return m_nViewLeftCol + m_nViewColNum;
 	}
 
-	//!‰º‚É‚Í‚İo‚µ‚½Å‰‚Ìs‚ğ•Ô‚·
+	//!ä¸‹ã«ã¯ã¿å‡ºã—ãŸæœ€åˆã®è¡Œã‚’è¿”ã™
 	CLayoutInt GetBottomLine() const
 	{
 		return m_nViewTopLine + m_nViewRowNum;
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                   —Ìˆæ‚ğæ“¾(ƒsƒNƒZƒ‹)                      //
+	//                   é ˜åŸŸã‚’å–å¾—(ãƒ”ã‚¯ã‚»ãƒ«)                      //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	int GetAreaLeft() const
 	{
@@ -121,58 +121,58 @@ public:
 	{
 		m_nLeftYohaku=nPixel;
 	}
-	// s”Ô†‚Ì•(—]”’‚È‚µ)
+	// è¡Œç•ªå·ã®å¹…(ä½™ç™½ãªã—)
 	int GetLineNumberWidth() const
 	{
 		return m_nViewAlignLeft - m_nLeftYohaku;
 	}
 
-	//! ƒNƒ‰ƒCƒAƒ“ƒgƒTƒCƒYXV
+	//! ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆã‚µã‚¤ã‚ºæ›´æ–°
 	void TextArea_OnSize(
-		const CMySize& sizeClient, //!< ƒEƒBƒ“ƒhƒE‚ÌƒNƒ‰ƒCƒAƒ“ƒgƒTƒCƒY
-		int nCxVScroll,            //!< ‚’¼ƒXƒNƒ[ƒ‹ƒo[‚Ì‰¡•
-		int nCyHScroll             //!< …•½ƒXƒNƒ[ƒ‹ƒo[‚Ìc•
+		const CMySize& sizeClient, //!< ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆã‚µã‚¤ã‚º
+		int nCxVScroll,            //!< å‚ç›´ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®æ¨ªå¹…
+		int nCyHScroll             //!< æ°´å¹³ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®ç¸¦å¹…
 	);
 
-	//! s”Ô†•\¦‚É•K—v‚È•‚ğİ’è
+	//! è¡Œç•ªå·è¡¨ç¤ºã«å¿…è¦ãªå¹…ã‚’è¨­å®š
 	bool DetectWidthOfLineNumberArea( bool bRedraw );
 
-	//! s”Ô†•\¦‚É•K—v‚ÈŒ…”‚ğŒvZ
+	//! è¡Œç•ªå·è¡¨ç¤ºã«å¿…è¦ãªæ¡æ•°ã‚’è¨ˆç®—
 	int  DetectWidthOfLineNumberArea_calculate(const CLayoutMgr*, bool bLayout=false) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           ”»’è                              //
+	//                           åˆ¤å®š                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	bool IsRectIntersected(const RECT& rc) const
 	{
-		//rc‚ª–³Œø‚Ü‚½‚Íƒ[ƒ—Ìˆæ‚Ìê‡‚Ífalse
+		//rcãŒç„¡åŠ¹ã¾ãŸã¯ã‚¼ãƒ­é ˜åŸŸã®å ´åˆã¯false
 		if( rc.left >= rc.right )return false;
 		if( rc.top  >= rc.bottom )return false;
 
-		if( rc.left >= this->GetAreaRight() )return false; //‰EŠO
-		if( rc.right <= this->GetAreaLeft() )return false; //¶ŠO
-		if( rc.top >= this->GetAreaBottom() )return false; //‰ºŠO
-		if( rc.bottom <= this->GetAreaTop() )return false; //ãŠO
+		if( rc.left >= this->GetAreaRight() )return false; //å³å¤–
+		if( rc.right <= this->GetAreaLeft() )return false; //å·¦å¤–
+		if( rc.top >= this->GetAreaBottom() )return false; //ä¸‹å¤–
+		if( rc.bottom <= this->GetAreaTop() )return false; //ä¸Šå¤–
 		
 		return true;
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                        ‚»‚Ì‘¼æ“¾                           //
+	//                        ãã®ä»–å–å¾—                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	int GetRulerHeight() const
 	{
 		return m_nViewAlignTop - GetTopYohaku();
 	}
-	//! ƒhƒLƒ…ƒƒ“ƒg¶’[‚ÌƒNƒ‰ƒCƒAƒ“ƒgÀ•W‚ğæ“¾ (‚Â‚Ü‚èAƒXƒNƒ[ƒ‹‚³‚ê‚½ó‘Ô‚Å‚ ‚ê‚ÎAƒ}ƒCƒiƒX‚ğ•Ô‚·)
+	//! ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆå·¦ç«¯ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆåº§æ¨™ã‚’å–å¾— (ã¤ã¾ã‚Šã€ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã•ã‚ŒãŸçŠ¶æ…‹ã§ã‚ã‚Œã°ã€ãƒã‚¤ãƒŠã‚¹ã‚’è¿”ã™)
 	int GetDocumentLeftClientPointX() const;
 
-	//ŒvZ
-	//! ƒNƒ‰ƒCƒAƒ“ƒgÀ•W‚©‚çƒŒƒCƒAƒEƒgˆÊ’u‚É•ÏŠ·‚·‚é
+	//è¨ˆç®—
+	//! ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆåº§æ¨™ã‹ã‚‰ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆä½ç½®ã«å¤‰æ›ã™ã‚‹
 	void ClientToLayout(CMyPoint ptClient, CLayoutPoint* pptLayout) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           İ’è                              //
+	//                           è¨­å®š                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	void UpdateAreaMetrics();
 	void SetAreaLeft(int nAreaLeft)
@@ -194,15 +194,15 @@ public:
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ƒTƒ|[ƒg                            //
+	//                         ã‚µãƒãƒ¼ãƒˆ                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//$ Generate‚È‚ñ‚Ä‚¢‚¤‘å‚°‚³‚È–¼‘O‚¶‚á‚È‚­‚ÄAGet`‚Å—Ç‚¢‹C‚ª‚µ‚Ä‚«‚½
-	//!ƒNƒŠƒbƒsƒ“ƒO‹éŒ`‚ğì¬B•\¦”ÍˆÍŠO‚¾‚Á‚½ê‡‚Ífalse‚ğ•Ô‚·B
+	//$ Generateãªã‚“ã¦ã„ã†å¤§ã’ã•ãªåå‰ã˜ã‚ƒãªãã¦ã€Getï½ã§è‰¯ã„æ°—ãŒã—ã¦ããŸ
+	//!ã‚¯ãƒªãƒƒãƒ”ãƒ³ã‚°çŸ©å½¢ã‚’ä½œæˆã€‚è¡¨ç¤ºç¯„å›²å¤–ã ã£ãŸå ´åˆã¯falseã‚’è¿”ã™ã€‚
 	void GenerateCharRect(RECT* rc,const DispPos& sPos,CLayoutXInt nColumns) const;
 	bool TrimRectByArea(RECT* rc) const;
 	bool GenerateClipRect(RECT* rc,const DispPos& sPos,CLayoutXInt nColumns) const;
-	bool GenerateClipRectRight(RECT* rc,const DispPos& sPos) const; //!< ‰E’[‚Ü‚Å‘S•”
-	bool GenerateClipRectLine(RECT* rc,const DispPos& sPos) const;  //!< s‘S•”
+	bool GenerateClipRectRight(RECT* rc,const DispPos& sPos) const; //!< å³ç«¯ã¾ã§å…¨éƒ¨
+	bool GenerateClipRectLine(RECT* rc,const DispPos& sPos) const;  //!< è¡Œå…¨éƒ¨
 
 	void GenerateTopRect   (RECT* rc, CLayoutInt nLineCount) const;
 	void GenerateBottomRect(RECT* rc, CLayoutInt nLineCount) const;
@@ -216,35 +216,35 @@ public:
 	int GenerateYPx(CLayoutYInt nLineNum) const;
 
 private:
-	//QÆ
+	//å‚ç…§
 	CEditView*	m_pEditView;
 
 public:
-	/* ‰æ–Êî•ñ */
-	//ƒsƒNƒZƒ‹
+	/* ç”»é¢æƒ…å ± */
+	//ãƒ”ã‚¯ã‚»ãƒ«
 private:
-	int		m_nViewAlignLeft;		/* •\¦ˆæ‚Ì¶’[À•W */
-	int		m_nViewAlignTop;		/* •\¦ˆæ‚Ìã’[À•W */
+	int		m_nViewAlignLeft;		/* è¡¨ç¤ºåŸŸã®å·¦ç«¯åº§æ¨™ */
+	int		m_nViewAlignTop;		/* è¡¨ç¤ºåŸŸã®ä¸Šç«¯åº§æ¨™ */
 private:
 	int		m_nTopYohaku;
 	int		m_nLeftYohaku;
 private:
-	int		m_nViewCx;				/* •\¦ˆæ‚Ì• */
-	int		m_nViewCy;				/* •\¦ˆæ‚Ì‚‚³ */
+	int		m_nViewCx;				/* è¡¨ç¤ºåŸŸã®å¹… */
+	int		m_nViewCy;				/* è¡¨ç¤ºåŸŸã®é«˜ã• */
 
-	//ƒeƒLƒXƒg
+	//ãƒ†ã‚­ã‚¹ãƒˆ
 private:
-	CLayoutInt	m_nViewTopLine;			/* •\¦ˆæ‚Ìˆê”Ôã‚Ìs(0ŠJn) */
+	CLayoutInt	m_nViewTopLine;			/* è¡¨ç¤ºåŸŸã®ä¸€ç•ªä¸Šã®è¡Œ(0é–‹å§‹) */
 public:
-	CLayoutInt	m_nViewRowNum;			/* •\¦ˆæ‚Ìs” */
+	CLayoutInt	m_nViewRowNum;			/* è¡¨ç¤ºåŸŸã®è¡Œæ•° */
 
 private:
-	CLayoutInt	m_nViewLeftCol;			/* •\¦ˆæ‚Ìˆê”Ô¶‚ÌŒ…(0ŠJn) */
+	CLayoutInt	m_nViewLeftCol;			/* è¡¨ç¤ºåŸŸã®ä¸€ç•ªå·¦ã®æ¡(0é–‹å§‹) */
 public:
-	CLayoutInt	m_nViewColNum;			/* •\¦ˆæ‚ÌŒ…” */
+	CLayoutInt	m_nViewColNum;			/* è¡¨ç¤ºåŸŸã®æ¡æ•° */
 
-	//‚»‚Ì‘¼
-	int		m_nViewAlignLeftCols;	/* s”Ô†ˆæ‚ÌŒ…” */
+	//ãã®ä»–
+	int		m_nViewAlignLeftCols;	/* è¡Œç•ªå·åŸŸã®æ¡æ•° */
 };
 
 #endif /* SAKURA_CTEXTAREA_BE5C17FA_E8D8_4659_9AA4_552DF90288CC9_H_ */

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -45,9 +45,9 @@ using namespace std;
 
 
 /*
-ƒeƒLƒXƒg•\¦
-@@@ 2002.09.22 YAZAKI    const unsigned char* pData‚ğAconst char* pData‚É•ÏX
-@@@ 2007.08.25 kobake –ß‚è’l‚ğ void ‚É•ÏXBˆø” x, y ‚ğ DispPos ‚É•ÏX
+ãƒ†ã‚­ã‚¹ãƒˆè¡¨ç¤º
+@@@ 2002.09.22 YAZAKI    const unsigned char* pDataã‚’ã€const char* pDataã«å¤‰æ›´
+@@@ 2007.08.25 kobake æˆ»ã‚Šå€¤ã‚’ void ã«å¤‰æ›´ã€‚å¼•æ•° x, y ã‚’ DispPos ã«å¤‰æ›´
 */
 void CTextDrawer::DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar_t* pData, int nLength, bool bTransparent ) const
 {
@@ -57,18 +57,18 @@ void CTextDrawer::DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar
 	int x=pDispPos->GetDrawPos().x;
 	int y=pDispPos->GetDrawPos().y;
 
-	//•K—v‚ÈƒCƒ“ƒ^[ƒtƒF[ƒX‚ğæ“¾
+	//å¿…è¦ãªã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã‚’å–å¾—
 	const CTextMetrics* pMetrics=&m_pEditView->GetTextMetrics();
 	const CTextArea* pArea=GetTextArea();
 
-	//•¶šŠÔŠu”z—ñ‚ğ¶¬
+	//æ–‡å­—é–“éš”é…åˆ—ã‚’ç”Ÿæˆ
 	static vector<int> vDxArray(1);
 	const int* pDxArray = pMetrics->GenerateDxArray2(&vDxArray, pData, nLength);
 
-	//•¶š—ñ‚ÌƒsƒNƒZƒ‹•
+	//æ–‡å­—åˆ—ã®ãƒ”ã‚¯ã‚»ãƒ«å¹…
 	int nTextWidth=pMetrics->CalcTextWidth(pData,nLength,pDxArray);
 
-	//ƒeƒLƒXƒg‚Ì•`‰æ”ÍˆÍ‚Ì‹éŒ`‚ğ‹‚ß‚é -> rcClip
+	//ãƒ†ã‚­ã‚¹ãƒˆã®æç”»ç¯„å›²ã®çŸ©å½¢ã‚’æ±‚ã‚ã‚‹ -> rcClip
 	CMyRect rcClip;
 	rcClip.left   = x;
 	rcClip.right  = x + nTextWidth;
@@ -78,19 +78,19 @@ void CTextDrawer::DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar
 		rcClip.left = pArea->GetAreaLeft();
 	}
 
-	//•¶šŠÔŠu
+	//æ–‡å­—é–“éš”
 	int nDx = pMetrics->GetCharPxWidth();
 
 	if( pArea->IsRectIntersected(rcClip) && rcClip.top >= pArea->GetAreaTop() ){
 
-		//@@@	From Here 2002.01.30 YAZAKI ExtTextOutW_AnyBuild‚Ì§ŒÀ‰ñ”ğ
+		//@@@	From Here 2002.01.30 YAZAKI ExtTextOutW_AnyBuildã®åˆ¶é™å›é¿
 		if( rcClip.Width() > pArea->GetAreaWidth() ){
 			rcClip.right = rcClip.left + pArea->GetAreaWidth();
 		}
 
-		// ƒEƒBƒ“ƒhƒE‚Ì¶‚É‚ ‚Ó‚ê‚½•¶š” -> nBefore
-		// 2007.09.08 kobake’ uƒEƒBƒ“ƒhƒE‚Ì¶v‚Å‚Í‚È‚­uƒNƒŠƒbƒv‚Ì¶v‚ğŒ³‚ÉŒvZ‚µ‚½‚Ù‚¤‚ª•`‰æ—Ìˆæ‚ğß–ñ‚Å‚«‚é‚ªA
-		//                        ƒoƒO‚ªo‚é‚Ì‚ª•|‚¢‚Ì‚Å‚Æ‚è‚ ‚¦‚¸‚±‚Ì‚Ü‚ÜB
+		// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®å·¦ã«ã‚ãµã‚ŒãŸæ–‡å­—æ•° -> nBefore
+		// 2007.09.08 kobakeæ³¨ ã€Œã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®å·¦ã€ã§ã¯ãªãã€Œã‚¯ãƒªãƒƒãƒ—ã®å·¦ã€ã‚’å…ƒã«è¨ˆç®—ã—ãŸã»ã†ãŒæç”»é ˜åŸŸã‚’ç¯€ç´„ã§ãã‚‹ãŒã€
+		//                        ãƒã‚°ãŒå‡ºã‚‹ã®ãŒæ€–ã„ã®ã§ã¨ã‚Šã‚ãˆãšã“ã®ã¾ã¾ã€‚
 		int nBeforeLogic = 0;
 		CLayoutInt nBeforeLayout = CLayoutInt(0);
 		if ( x < 0 ){
@@ -103,26 +103,26 @@ void CTextDrawer::DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar
 		}
 
 		/*
-		// ƒEƒBƒ“ƒhƒE‚Ì‰E‚É‚ ‚Ó‚ê‚½•¶š” -> nAfter
+		// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®å³ã«ã‚ãµã‚ŒãŸæ–‡å­—æ•° -> nAfter
 		int nAfterLayout = 0;
 		if ( rcClip.right < x + nTextWidth ){
-			//	-1‚µ‚Ä‚²‚Ü‚©‚·i‚¤‚µ‚ë‚Í‚¢‚¢‚æ‚ËHj
+			//	-1ã—ã¦ã”ã¾ã‹ã™ï¼ˆã†ã—ã‚ã¯ã„ã„ã‚ˆã­ï¼Ÿï¼‰
 			nAfterLayout = (x + nTextWidth - rcClip.right) / nDx - 1;
 		}
 		*/
 
-		// •`‰æŠJnˆÊ’u
+		// æç”»é–‹å§‹ä½ç½®
 		int nDrawX = x + (Int)nBeforeLayout * nDx;
 
-		// ÀÛ‚Ì•`‰æ•¶š—ñƒ|ƒCƒ“ƒ^
+		// å®Ÿéš›ã®æç”»æ–‡å­—åˆ—ãƒã‚¤ãƒ³ã‚¿
 		const wchar_t* pDrawData          = &pData[nBeforeLogic];
 		int            nDrawDataMaxLength = nLength - nBeforeLogic;
 
-		// ÀÛ‚Ì•¶šŠÔŠu”z—ñ
+		// å®Ÿéš›ã®æ–‡å­—é–“éš”é…åˆ—
 		const int* pDrawDxArray = &pDxArray[nBeforeLogic];
 
-		// •`‰æ‚·‚é•¶š—ñ’·‚ğ‹‚ß‚é -> nDrawLength
-		int nRequiredWidth = rcClip.right - nDrawX; //–„‚ß‚é‚×‚«ƒsƒNƒZƒ‹•
+		// æç”»ã™ã‚‹æ–‡å­—åˆ—é•·ã‚’æ±‚ã‚ã‚‹ -> nDrawLength
+		int nRequiredWidth = rcClip.right - nDrawX; //åŸ‹ã‚ã‚‹ã¹ããƒ”ã‚¯ã‚»ãƒ«å¹…
 		if(nRequiredWidth <= 0)goto end;
 		int nWorkWidth = 0;
 		int nDrawLength = 0;
@@ -131,45 +131,45 @@ void CTextDrawer::DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar
 			if(nDrawLength >= nDrawDataMaxLength)break;
 			nWorkWidth += pDrawDxArray[nDrawLength++];
 		}
-		// ƒTƒƒQ[ƒgƒyƒA‘Îô	2008/7/5 Uchi	Update 7/8 Uchi
+		// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢å¯¾ç­–	2008/7/5 Uchi	Update 7/8 Uchi
 		if (nDrawLength < nDrawDataMaxLength && pDrawDxArray[nDrawLength] == 0) {
 			nDrawLength++;
 		}
 
-		//•`‰æ
+		//æç”»
 		::ExtTextOutW_AnyBuild(
 			hdc,
 			nDrawX,					//X
 			y + marginy,			//Y
 			ExtTextOutOption() & ~(bTransparent? ETO_OPAQUE: 0),
 			&rcClip,
-			pDrawData,				//•¶š—ñ
-			nDrawLength,			//•¶š—ñ’·
-			pDrawDxArray			//•¶šŠÔŠu‚Ì“ü‚Á‚½”z—ñ
+			pDrawData,				//æ–‡å­—åˆ—
+			nDrawLength,			//æ–‡å­—åˆ—é•·
+			pDrawDxArray			//æ–‡å­—é–“éš”ã®å…¥ã£ãŸé…åˆ—
 		);
 	}
 
 end:
-	//•`‰æˆÊ’u‚ği‚ß‚é
+	//æç”»ä½ç½®ã‚’é€²ã‚ã‚‹
 	pDispPos->ForwardDrawCol(CLayoutXInt(nTextWidth / nDx));
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        w’èŒ…cü                           //
+//                        æŒ‡å®šæ¡ç¸¦ç·š                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*!	w’èŒ…cü‚Ì•`‰æ
-	@date 2005.11.08 Moca V‹Kì¬
-	@date 2006.04.29 Moca ‘¾üE“_ü‚ÌƒTƒ|[ƒgB‘I‘ğ’†‚Ì”½“]‘Îô‚És‚²‚Æ‚Éì‰æ‚·‚é‚æ‚¤‚É•ÏX
-	    cü‚ÌF‚ªƒeƒLƒXƒg‚Ì”wŒiF‚Æ“¯‚¶ê‡‚ÍAcü‚Ì”wŒiF‚ğEXOR‚Åì‰æ‚·‚é
-	@note Common::m_nVertLineOffset‚É‚æ‚èAw’èŒ…‚Ì‘O‚Ì•¶š‚Ìã‚Éì‰æ‚³‚ê‚é‚±‚Æ‚ª‚ ‚éB
+/*!	æŒ‡å®šæ¡ç¸¦ç·šã®æç”»
+	@date 2005.11.08 Moca æ–°è¦ä½œæˆ
+	@date 2006.04.29 Moca å¤ªç·šãƒ»ç‚¹ç·šã®ã‚µãƒãƒ¼ãƒˆã€‚é¸æŠä¸­ã®åè»¢å¯¾ç­–ã«è¡Œã”ã¨ã«ä½œç”»ã™ã‚‹ã‚ˆã†ã«å¤‰æ›´
+	    ç¸¦ç·šã®è‰²ãŒãƒ†ã‚­ã‚¹ãƒˆã®èƒŒæ™¯è‰²ã¨åŒã˜å ´åˆã¯ã€ç¸¦ç·šã®èƒŒæ™¯è‰²ã‚’EXORã§ä½œç”»ã™ã‚‹
+	@note Common::m_nVertLineOffsetã«ã‚ˆã‚Šã€æŒ‡å®šæ¡ã®å‰ã®æ–‡å­—ã®ä¸Šã«ä½œç”»ã•ã‚Œã‚‹ã“ã¨ãŒã‚ã‚‹ã€‚
 */
 void CTextDrawer::DispVerticalLines(
-	CGraphics&	gr,			//!< ì‰æ‚·‚éƒEƒBƒ“ƒhƒE‚ÌDC
-	int			nTop,		//!< ü‚ğˆø‚­ã’[‚ÌƒNƒ‰ƒCƒAƒ“ƒgÀ•Wy
-	int			nBottom,	//!< ü‚ğˆø‚­‰º’[‚ÌƒNƒ‰ƒCƒAƒ“ƒgÀ•Wy
-	CLayoutInt	nLeftCol,	//!< ü‚ğˆø‚­”ÍˆÍ‚Ì¶Œ…‚Ìw’è
-	CLayoutInt	nRightCol	//!< ü‚ğˆø‚­”ÍˆÍ‚Ì‰EŒ…‚Ìw’è(-1‚Å–¢w’è)
+	CGraphics&	gr,			//!< ä½œç”»ã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®DC
+	int			nTop,		//!< ç·šã‚’å¼•ãä¸Šç«¯ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆåº§æ¨™y
+	int			nBottom,	//!< ç·šã‚’å¼•ãä¸‹ç«¯ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆåº§æ¨™y
+	CLayoutInt	nLeftCol,	//!< ç·šã‚’å¼•ãç¯„å›²ã®å·¦æ¡ã®æŒ‡å®š
+	CLayoutInt	nRightCol	//!< ç·šã‚’å¼•ãç¯„å›²ã®å³æ¡ã®æŒ‡å®š(-1ã§æœªæŒ‡å®š)
 ) const
 {
 	const CEditView* pView=m_pEditView;
@@ -195,9 +195,9 @@ void CTextDrawer::DispVerticalLines(
 	const int nLineHeight = pView->GetTextMetrics().GetHankakuDy();
 	bool bOddLine = ((((nLineHeight % 2) ? (Int)pView->GetTextArea().GetViewTopLine() : 0) + pView->GetTextArea().GetAreaTop() + nTop) % 2 == 1);
 
-	// ‘¾ü
+	// å¤ªç·š
 	const bool bBold = cVertType.IsBoldFont();
-	// ƒhƒbƒgü(‰ºü‘®«‚ğ“]—p/ƒeƒXƒg—p)
+	// ãƒ‰ãƒƒãƒˆç·š(ä¸‹ç·šå±æ€§ã‚’è»¢ç”¨/ãƒ†ã‚¹ãƒˆç”¨)
 	const bool bDot = cVertType.HasUnderLine();
 	const bool bExorPen = ( cVertType.GetTextColor() == cTextType.GetBackColor() );
 	int nROP_Old = 0;
@@ -211,11 +211,11 @@ void CTextDrawer::DispVerticalLines(
 
 	int k;
 	for( k = 0; k < MAX_VERTLINES && typeData.m_nVertLineIdx[k] != 0; k++ ){
-		// nXCol‚Í1ŠJnBGetTextArea().GetViewLeftCol()‚Í0ŠJn‚È‚Ì‚Å’ˆÓB
+		// nXColã¯1é–‹å§‹ã€‚GetTextArea().GetViewLeftCol()ã¯0é–‹å§‹ãªã®ã§æ³¨æ„ã€‚
 		CLayoutXInt nXCol = pView->GetTextMetrics().GetLayoutXDefault(typeData.m_nVertLineIdx[k]);
 		CLayoutXInt nXColEnd = nXCol;
 		CLayoutXInt nXColAdd = pView->GetTextMetrics().GetLayoutXDefault();
-		// nXCol‚ªƒ}ƒCƒiƒX‚¾‚ÆŒJ‚è•Ô‚µBk+1‚ğI—¹’lAk+2‚ğƒXƒeƒbƒv•‚Æ‚µ‚Ä—˜—p‚·‚é
+		// nXColãŒãƒã‚¤ãƒŠã‚¹ã ã¨ç¹°ã‚Šè¿”ã—ã€‚k+1ã‚’çµ‚äº†å€¤ã€k+2ã‚’ã‚¹ãƒ†ãƒƒãƒ—å¹…ã¨ã—ã¦åˆ©ç”¨ã™ã‚‹
 		if( nXCol < 0 ){
 			if( k < MAX_VERTLINES - 2 ){
 				nXCol = -nXCol;
@@ -224,7 +224,7 @@ void CTextDrawer::DispVerticalLines(
 				if( nXColEnd < nXCol || nXColAdd <= 0 ){
 					continue;
 				}
-				// ì‰æ”ÍˆÍ‚Ìn‚ß‚Ü‚ÅƒXƒLƒbƒv
+				// ä½œç”»ç¯„å›²ã®å§‹ã‚ã¾ã§ã‚¹ã‚­ãƒƒãƒ—
 				if( nXCol < nViewLeftCol ){
 					nXCol = nViewLeftCol + nXColAdd - (nViewLeftCol - nXCol) % nXColAdd;
 				}
@@ -238,8 +238,8 @@ void CTextDrawer::DispVerticalLines(
 				break;
 			}
 			int nPosX = nPosXOffset + pView->GetTextMetrics().GetCharPxWidth(nXCol - pView->GetTextMetrics().GetLayoutXDefault() - nViewLeftCol);
-			// 2006.04.30 Moca ü‚Ìˆø‚­”ÍˆÍE•û–@‚ğ•ÏX
-			// ‘¾ü‚Ìê‡A”¼•ª‚¾‚¯ì‰æ‚·‚é‰Â”\«‚ª‚ ‚éB
+			// 2006.04.30 Moca ç·šã®å¼•ãç¯„å›²ãƒ»æ–¹æ³•ã‚’å¤‰æ›´
+			// å¤ªç·šã®å ´åˆã€åŠåˆ†ã ã‘ä½œç”»ã™ã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹ã€‚
 			int nPosXBold = nPosX;
 			if( bBold ){
 				nPosXBold -= 1;
@@ -249,9 +249,9 @@ void CTextDrawer::DispVerticalLines(
 			}
 			if( nPosXLeft <= nPosX ){
 				if( bDot ){
-					// “_ü‚Åì‰æB1ƒhƒbƒg‚Ìü‚ğì¬
+					// ç‚¹ç·šã§ä½œç”»ã€‚1ãƒ‰ãƒƒãƒˆã®ç·šã‚’ä½œæˆ
 					int y = nTop;
-					// ƒXƒNƒ[ƒ‹‚µ‚Ä‚àü‚ªØ‚ê‚È‚¢‚æ‚¤‚ÉÀ•W‚ğ’²®
+					// ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ã—ã¦ã‚‚ç·šãŒåˆ‡ã‚Œãªã„ã‚ˆã†ã«åº§æ¨™ã‚’èª¿æ•´
 					if( bOddLine ){
 						y++;
 					}
@@ -284,11 +284,11 @@ void CTextDrawer::DispVerticalLines(
 }
 
 void CTextDrawer::DispNoteLine(
-	CGraphics&	gr,			//!< ì‰æ‚·‚éƒEƒBƒ“ƒhƒE‚ÌDC
-	int			nTop,		//!< ü‚ğˆø‚­ã’[‚ÌƒNƒ‰ƒCƒAƒ“ƒgÀ•Wy
-	int			nBottom,	//!< ü‚ğˆø‚­‰º’[‚ÌƒNƒ‰ƒCƒAƒ“ƒgÀ•Wy
-	int			nLeft,		//!< ü‚ğˆø‚­¶’[
-	int			nRight		//!< ü‚ğˆø‚­‰E’[
+	CGraphics&	gr,			//!< ä½œç”»ã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®DC
+	int			nTop,		//!< ç·šã‚’å¼•ãä¸Šç«¯ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆåº§æ¨™y
+	int			nBottom,	//!< ç·šã‚’å¼•ãä¸‹ç«¯ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆåº§æ¨™y
+	int			nLeft,		//!< ç·šã‚’å¼•ãå·¦ç«¯
+	int			nRight		//!< ç·šã‚’å¼•ãå³ç«¯
 ) const
 {
 	const CEditView* pView=m_pEditView;
@@ -316,16 +316,16 @@ void CTextDrawer::DispNoteLine(
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        Ü‚è•Ô‚µŒ…cü                       //
+//                        æŠ˜ã‚Šè¿”ã—æ¡ç¸¦ç·š                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*!	Ü‚è•Ô‚µŒ…cü‚Ì•`‰æ
-	@date 2009.10.24 ryoji V‹Kì¬
+/*!	æŠ˜ã‚Šè¿”ã—æ¡ç¸¦ç·šã®æç”»
+	@date 2009.10.24 ryoji æ–°è¦ä½œæˆ
 */
 void CTextDrawer::DispWrapLine(
-	CGraphics&	gr,			//!< ì‰æ‚·‚éƒEƒBƒ“ƒhƒE‚ÌDC
-	int			nTop,		//!< ü‚ğˆø‚­ã’[‚ÌƒNƒ‰ƒCƒAƒ“ƒgÀ•Wy
-	int			nBottom		//!< ü‚ğˆø‚­‰º’[‚ÌƒNƒ‰ƒCƒAƒ“ƒgÀ•Wy
+	CGraphics&	gr,			//!< ä½œç”»ã™ã‚‹ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®DC
+	int			nTop,		//!< ç·šã‚’å¼•ãä¸Šç«¯ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆåº§æ¨™y
+	int			nBottom		//!< ç·šã‚’å¼•ãä¸‹ç«¯ã®ã‚¯ãƒ©ã‚¤ã‚¢ãƒ³ãƒˆåº§æ¨™y
 ) const
 {
 	const CEditView* pView = m_pEditView;
@@ -335,9 +335,9 @@ void CTextDrawer::DispWrapLine(
 	const CTextArea& rArea = *GetTextArea();
 	const CLayoutInt nWrapLayout = pView->m_pcEditDoc->m_cLayoutMgr.GetMaxLineLayout();
 	int nXPos = rArea.GetAreaLeft() + pView->GetTextMetrics().GetCharPxWidth(nWrapLayout - rArea.GetViewLeftCol());
-	//	2005.11.08 Moca ì‰æğŒ•ÏX
+	//	2005.11.08 Moca ä½œç”»æ¡ä»¶å¤‰æ›´
 	if( rArea.GetAreaLeft() < nXPos && nXPos < rArea.GetAreaRight() ){
-		/// Ü‚è•Ô‚µ‹L†‚ÌF‚Ìƒyƒ“‚ğİ’è
+		/// æŠ˜ã‚Šè¿”ã—è¨˜å·ã®è‰²ã®ãƒšãƒ³ã‚’è¨­å®š
 		gr.PushPen(cWrapType.GetTextColor(), 0);
 
 		::MoveToEx( gr, nXPos, nTop, NULL );
@@ -350,7 +350,7 @@ void CTextDrawer::DispWrapLine(
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          s”Ô†                             //
+//                          è¡Œç•ªå·                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void CTextDrawer::DispLineNumber(
@@ -359,7 +359,7 @@ void CTextDrawer::DispLineNumber(
 	int				y
 ) const
 {
-	//$$ ‚‘¬‰»FSearchLineByLayoutY‚ÉƒLƒƒƒbƒVƒ…‚ğ‚½‚¹‚é
+	//$$ é«˜é€ŸåŒ–ï¼šSearchLineByLayoutYã«ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’æŒãŸã›ã‚‹
 	const CLayout*	pcLayout = CEditDoc::GetInstance(0)->m_cLayoutMgr.SearchLineByLayoutY( nLineNum );
 
 	const CEditView* pView=m_pEditView;
@@ -367,13 +367,13 @@ void CTextDrawer::DispLineNumber(
 
 	int				nLineHeight = pView->GetTextMetrics().GetHankakuDy();
 	int				nCharWidth = pView->GetTextMetrics().GetHankakuDx();
-	// s”Ô†•\¦•”•ªX•	Sep. 23, 2002 genta ‹¤’Ê®‚Ì‚­‚­‚è‚¾‚µ
+	// è¡Œç•ªå·è¡¨ç¤ºéƒ¨åˆ†Xå¹…	Sep. 23, 2002 genta å…±é€šå¼ã®ããã‚Šã ã—
 	//int				nLineNumAreaWidth = pView->GetTextArea().m_nViewAlignLeftCols * nCharWidth;
 	int				nLineNumAreaWidth = pView->GetTextArea().GetLineNumberWidth();	// 2009.03.26 ryoji
 	CTypeSupport cTextType(pView,COLORIDX_TEXT);
 	CTypeSupport cCaretLineBg(pView, COLORIDX_CARETLINEBG);
 	CTypeSupport cEvenLineBg(pView, COLORIDX_EVENLINEBG);
-	// s‚ª‚È‚¢‚Æ‚«Es‚Ì”wŒi‚ª“§–¾‚Ì‚Æ‚«‚ÌF
+	// è¡ŒãŒãªã„ã¨ããƒ»è¡Œã®èƒŒæ™¯ãŒé€æ˜ã®ã¨ãã®è‰²
 	CTypeSupport &cBackType = (cCaretLineBg.IsDisp() &&
 		pView->GetCaret().GetCaretLayoutPos().GetY() == nLineNum
 			? cCaretLineBg
@@ -383,28 +383,28 @@ void CTextDrawer::DispLineNumber(
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                     nColorIndex‚ğŒˆ’è                       //
+	//                     nColorIndexã‚’æ±ºå®š                       //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	EColorIndexType nColorIndex = COLORIDX_GYOU;	/* s”Ô† */
+	EColorIndexType nColorIndex = COLORIDX_GYOU;	/* è¡Œç•ªå· */
 	const CDocLine*	pCDocLine = NULL;
 	bool bGyouMod = false;
 	if( pcLayout ){
 		pCDocLine = pcLayout->GetDocLineRef();
 
-		if( pView->GetDocument()->m_cDocEditor.IsModified() && CModifyVisitor().IsLineModified(pCDocLine, pView->GetDocument()->m_cDocEditor.m_cOpeBuf.GetNoModifiedSeq()) ){		/* •ÏXƒtƒ‰ƒO */
+		if( pView->GetDocument()->m_cDocEditor.IsModified() && CModifyVisitor().IsLineModified(pCDocLine, pView->GetDocument()->m_cDocEditor.m_cOpeBuf.GetNoModifiedSeq()) ){		/* å¤‰æ›´ãƒ•ãƒ©ã‚° */
 			if( CTypeSupport(pView,COLORIDX_GYOU_MOD).IsDisp() ){	// 2006.12.12 ryoji
-				nColorIndex = COLORIDX_GYOU_MOD;	/* s”Ô†i•ÏXsj */
+				nColorIndex = COLORIDX_GYOU_MOD;	/* è¡Œç•ªå·ï¼ˆå¤‰æ›´è¡Œï¼‰ */
 				bGyouMod = true;
 			}
 		}
 	}
 
 	if(pCDocLine){
-		//DIFFFİ’è
+		//DIFFè‰²è¨­å®š
 		CDiffLineGetter(pCDocLine).GetDiffColor(&nColorIndex);
 
 		// 02/10/16 ai
-		// ƒuƒbƒNƒ}[ƒN‚Ì•\¦
+		// ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã®è¡¨ç¤º
 		if(CBookmarkGetter(pCDocLine).IsBookmarked()){
 			if( CTypeSupport(pView,COLORIDX_MARK).IsDisp() ) {
 				nColorIndex = COLORIDX_MARK;
@@ -413,13 +413,13 @@ void CTextDrawer::DispLineNumber(
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//             Œˆ’è‚³‚ê‚½nColorIndex‚ğg‚Á‚Ä•`‰æ               //
+	//             æ±ºå®šã•ã‚ŒãŸnColorIndexã‚’ä½¿ã£ã¦æç”»               //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 	CTypeSupport cColorType(pView,nColorIndex);
 	CTypeSupport cMarkType(pView,COLORIDX_MARK);
 
-	//ŠY“–s‚Ìs”Ô†ƒGƒŠƒA‹éŒ`
+	//è©²å½“è¡Œã®è¡Œç•ªå·ã‚¨ãƒªã‚¢çŸ©å½¢
 	RECT	rcLineNum;
 	rcLineNum.left = 0;
 	rcLineNum.right = nLineNumAreaWidth;
@@ -443,22 +443,22 @@ void CTextDrawer::DispLineNumber(
 			bTrans = pView->IsBkBitmap() && cTextType.GetBackColor() == cGyouModType.GetBackColor();
 		}
 	}
-	// 2014.01.29 Moca ”wŒiF‚ªƒeƒLƒXƒg‚Æ“¯‚¶‚È‚çA“§‰ßF‚Æ‚µ‚Äs”wŒiF‚ğ“K—p
+	// 2014.01.29 Moca èƒŒæ™¯è‰²ãŒãƒ†ã‚­ã‚¹ãƒˆã¨åŒã˜ãªã‚‰ã€é€éè‰²ã¨ã—ã¦è¡ŒèƒŒæ™¯è‰²ã‚’é©ç”¨
 	if( bgcolor == cTextType.GetBackColor() ){
 		bgcolor = cBackType.GetBackColor();
 		bTrans = pView->IsBkBitmap() && cTextType.GetBackColor() == bgcolor;
 		bDispLineNumTrans = true;
 	}
 	if(!pcLayout){
-		//s‚ª‘¶İ‚µ‚È‚¢ê‡‚ÍAƒeƒLƒXƒg•`‰æF‚Å“h‚è‚Â‚Ô‚µ
+		//è¡ŒãŒå­˜åœ¨ã—ãªã„å ´åˆã¯ã€ãƒ†ã‚­ã‚¹ãƒˆæç”»è‰²ã§å¡—ã‚Šã¤ã¶ã—
 		if( !bTransText ){
 			cBackType.FillBack(gr,rcLineNum);
 		}
 		bDispLineNumTrans = true;
 	}
-	else if( CTypeSupport(pView,COLORIDX_GYOU).IsDisp() ){ /* s”Ô†•\¦^”ñ•\¦ */
+	else if( CTypeSupport(pView,COLORIDX_GYOU).IsDisp() ){ /* è¡Œç•ªå·è¡¨ç¤ºï¼éè¡¨ç¤º */
 		SFONT sFont = cColorType.GetTypeFont();
-	 	// 2013.12.30 •ÏXs‚ÌFEƒtƒHƒ“ƒg‘®«‚ğDIFFƒuƒbƒNƒ}[ƒNs‚ÉŒp³‚·‚é‚æ‚¤‚É
+	 	// 2013.12.30 å¤‰æ›´è¡Œã®è‰²ãƒ»ãƒ•ã‚©ãƒ³ãƒˆå±æ€§ã‚’DIFFãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯è¡Œã«ç¶™æ‰¿ã™ã‚‹ã‚ˆã†ã«
 		if( bGyouMod && nColorIndex != COLORIDX_GYOU_MOD ){
 			bool bChange = true;
 			if( cGyouType.IsBoldFont() == cColorType.IsBoldFont() ){
@@ -473,33 +473,33 @@ void CTextDrawer::DispLineNumber(
 				sFont.m_hFont = pView->GetFontset().ChooseFontHandle( 0, sFont.m_sFontAttr );
 			}
 		}
-		gr.PushTextForeColor(fgcolor);	//ƒeƒLƒXƒgFs”Ô†‚ÌF
-		gr.PushTextBackColor(bgcolor);	//ƒeƒLƒXƒgFs”Ô†”wŒi‚ÌF
-		gr.PushMyFont(sFont);	//ƒtƒHƒ“ƒgFs”Ô†‚ÌƒtƒHƒ“ƒg
+		gr.PushTextForeColor(fgcolor);	//ãƒ†ã‚­ã‚¹ãƒˆï¼šè¡Œç•ªå·ã®è‰²
+		gr.PushTextBackColor(bgcolor);	//ãƒ†ã‚­ã‚¹ãƒˆï¼šè¡Œç•ªå·èƒŒæ™¯ã®è‰²
+		gr.PushMyFont(sFont);	//ãƒ•ã‚©ãƒ³ãƒˆï¼šè¡Œç•ªå·ã®ãƒ•ã‚©ãƒ³ãƒˆ
 
-		//•`‰æ•¶š—ñ
+		//æç”»æ–‡å­—åˆ—
 		wchar_t szLineNum[18];
 		int nLineCols;
 		int nLineNumCols;
 		{
-			/* s”Ô†‚Ì•\¦ false=Ü‚è•Ô‚µ’PˆÊ^true=‰üs’PˆÊ */
+			/* è¡Œç•ªå·ã®è¡¨ç¤º false=æŠ˜ã‚Šè¿”ã—å˜ä½ï¼true=æ”¹è¡Œå˜ä½ */
 			if( pTypes->m_bLineNumIsCRLF ){
-				/* ˜_—s”Ô†•\¦ƒ‚[ƒh */
-				if( NULL == pcLayout || 0 != pcLayout->GetLogicOffset() ){ //Ü‚è•Ô‚µƒŒƒCƒAƒEƒgs
+				/* è«–ç†è¡Œç•ªå·è¡¨ç¤ºãƒ¢ãƒ¼ãƒ‰ */
+				if( NULL == pcLayout || 0 != pcLayout->GetLogicOffset() ){ //æŠ˜ã‚Šè¿”ã—ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ
 					wcscpy( szLineNum, L" " );
 				}else{
-					_itow( pcLayout->GetLogicLineNo() + 1, szLineNum, 10 );	/* ‘Î‰‚·‚é˜_—s”Ô† */
-//###ƒfƒoƒbƒO—p
-//					_itow( CModifyVisitor().GetLineModifiedSeq(pCDocLine), szLineNum, 10 );	// s‚Ì•ÏX”Ô†
+					_itow( pcLayout->GetLogicLineNo() + 1, szLineNum, 10 );	/* å¯¾å¿œã™ã‚‹è«–ç†è¡Œç•ªå· */
+//###ãƒ‡ãƒãƒƒã‚°ç”¨
+//					_itow( CModifyVisitor().GetLineModifiedSeq(pCDocLine), szLineNum, 10 );	// è¡Œã®å¤‰æ›´ç•ªå·
 				}
 			}else{
-				/* •¨—siƒŒƒCƒAƒEƒgsj”Ô†•\¦ƒ‚[ƒh */
+				/* ç‰©ç†è¡Œï¼ˆãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œï¼‰ç•ªå·è¡¨ç¤ºãƒ¢ãƒ¼ãƒ‰ */
 				_itow( (Int)nLineNum + 1, szLineNum, 10 );
 			}
 			nLineCols = wcslen( szLineNum );
-			nLineNumCols = nLineCols; // 2010.08.17 Moca ˆÊ’uŒˆ’è‚És”Ô†‹æØ‚è‚ÍŠÜ‚ß‚È‚¢
+			nLineNumCols = nLineCols; // 2010.08.17 Moca ä½ç½®æ±ºå®šã«è¡Œç•ªå·åŒºåˆ‡ã‚Šã¯å«ã‚ãªã„
 
-			/* s”Ô†‹æØ‚è 0=‚È‚µ 1=cü 2=”CˆÓ */
+			/* è¡Œç•ªå·åŒºåˆ‡ã‚Š 0=ãªã— 1=ç¸¦ç·š 2=ä»»æ„ */
 			if( 2 == pTypes->m_nLineTermType ){
 				//	Sep. 22, 2002 genta
 				szLineNum[ nLineCols ] = pTypes->m_cLineTermChar;
@@ -521,7 +521,7 @@ void CTextDrawer::DispLineNumber(
 			pView->GetTextMetrics().GetDxArray_AllHankaku()
 		);
 
-		/* s”Ô†‹æØ‚è 0=‚È‚µ 1=cü 2=”CˆÓ */
+		/* è¡Œç•ªå·åŒºåˆ‡ã‚Š 0=ãªã— 1=ç¸¦ç·š 2=ä»»æ„ */
 		if( 1 == pTypes->m_nLineTermType ){
 			RECT rc;
 			rc.left = nLineNumAreaWidth - 2;
@@ -536,18 +536,18 @@ void CTextDrawer::DispLineNumber(
 		gr.PopMyFont();
 	}
 	else{
-		// s”Ô†ƒGƒŠƒA‚Ì”wŒi•`‰æ
+		// è¡Œç•ªå·ã‚¨ãƒªã‚¢ã®èƒŒæ™¯æç”»
 		if( !bTrans ){
 			gr.FillSolidMyRect(rcLineNum, bgcolor);
 		}
 		bDispLineNumTrans = true;
 	}
 
-	//s‘®«•`‰æ ($$$•ª—£—\’è)
+	//è¡Œå±æ€§æç”» ($$$åˆ†é›¢äºˆå®š)
 	if(pCDocLine)
 	{
 		// 2001.12.03 hor
-		/* ‚Æ‚è‚ ‚¦‚¸ƒuƒbƒNƒ}[ƒN‚Écü */
+		/* ã¨ã‚Šã‚ãˆãšãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯ã«ç¸¦ç·š */
 		if(CBookmarkGetter(pCDocLine).IsBookmarked() && !cMarkType.IsDisp() )
 		{
 			gr.PushPen(cColorType.GetTextColor(),2);
@@ -556,13 +556,13 @@ void CTextDrawer::DispLineNumber(
 			gr.PopPen();
 		}
 
-		//DIFFƒ}[ƒN•`‰æ
+		//DIFFãƒãƒ¼ã‚¯æç”»
 		if( !pView->m_bMiniMap ){
 			CDiffLineGetter(pCDocLine).DrawDiffMark(gr,y,nLineHeight,fgcolor);
 		}
 	}
 
-	// s”Ô†‚ÆƒeƒLƒXƒg‚ÌŒ„ŠÔ‚Ì•`‰æ
+	// è¡Œç•ªå·ã¨ãƒ†ã‚­ã‚¹ãƒˆã®éš™é–“ã®æç”»
 	if( !bTransText ){
 		RECT rcRest;
 		rcRest.left   = rcLineNum.right;
@@ -572,7 +572,7 @@ void CTextDrawer::DispLineNumber(
 		cBackType.FillBack(gr,rcRest);
 	}
 
-	// s”Ô†•”•ª‚Ìƒm[ƒgü•`‰æ
+	// è¡Œç•ªå·éƒ¨åˆ†ã®ãƒãƒ¼ãƒˆç·šæç”»
 	if( !pView->m_bMiniMap ){
 		int left   = bDispLineNumTrans ? 0 : rcLineNum.right;
 		int right  = pView->GetTextArea().GetAreaLeft();

--- a/sakura_core/view/CTextDrawer.h
+++ b/sakura_core/view/CTextDrawer.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -40,31 +40,31 @@ public:
 	virtual ~CTextDrawer(){}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ŠO•”ˆË‘¶                            //
+	//                         å¤–éƒ¨ä¾å­˜                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//—Ìˆæ‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ğ‹‚ß‚é
+	//é ˜åŸŸã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã‚’æ±‚ã‚ã‚‹
 	const CTextArea* GetTextArea() const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                     ƒCƒ“ƒ^[ƒtƒF[ƒX                        //
+	//                     ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹                        //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//2007.08.25 kobake –ß‚è’l‚ğ void ‚É•ÏXBˆø” x, y ‚ğ DispPos ‚É•ÏX
-	//ÀÛ‚É‚Í pX ‚Æ nX ‚ªXV‚³‚ê‚éB
-	void DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar_t* pData, int nLength, bool bTransparent = false ) const; // ƒeƒLƒXƒg•\¦
+	//2007.08.25 kobake æˆ»ã‚Šå€¤ã‚’ void ã«å¤‰æ›´ã€‚å¼•æ•° x, y ã‚’ DispPos ã«å¤‰æ›´
+	//å®Ÿéš›ã«ã¯ pX ã¨ nX ãŒæ›´æ–°ã•ã‚Œã‚‹ã€‚
+	void DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar_t* pData, int nLength, bool bTransparent = false ) const; // ãƒ†ã‚­ã‚¹ãƒˆè¡¨ç¤º
 
-	//!	ƒm[ƒgü•`‰æ
+	//!	ãƒãƒ¼ãƒˆç·šæç”»
 	void DispNoteLine( CGraphics& gr, int nTop, int nBottom, int nLeft, int nRight ) const;
 
-	// -- -- w’èŒ…cü•`‰æ -- -- //
-	//!	w’èŒ…cü•`‰æŠÖ”	// 2005.11.08 Moca
+	// -- -- æŒ‡å®šæ¡ç¸¦ç·šæç”» -- -- //
+	//!	æŒ‡å®šæ¡ç¸¦ç·šæç”»é–¢æ•°	// 2005.11.08 Moca
 	void DispVerticalLines( CGraphics& gr, int nTop, int nBottom, CLayoutInt nLeftCol, CLayoutInt nRightCol ) const;
 
-	// -- -- Ü‚è•Ô‚µŒ…cü•`‰æ -- -- //
+	// -- -- æŠ˜ã‚Šè¿”ã—æ¡ç¸¦ç·šæç”» -- -- //
 	void DispWrapLine( CGraphics& gr, int nTop, int nBottom ) const;
 
-	// -- -- s”Ô† -- -- //
-	void DispLineNumber( CGraphics& gr, CLayoutInt nLineNum, int y ) const;		// s”Ô†•\¦
+	// -- -- è¡Œç•ªå· -- -- //
+	void DispLineNumber( CGraphics& gr, CLayoutInt nLineNum, int y ) const;		// è¡Œç•ªå·è¡¨ç¤º
 
 private:
 	const CEditView* m_pEditView;

--- a/sakura_core/view/CTextMetrics.cpp
+++ b/sakura_core/view/CTextMetrics.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2007, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -29,12 +29,12 @@
 using namespace std;
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//               ƒRƒ“ƒXƒgƒ‰ƒNƒ^EƒfƒXƒgƒ‰ƒNƒ^                  //
+//               ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ãƒ»ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿                  //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CTextMetrics::CTextMetrics()
 {
-	//$ “K“–‚È‰¼’l‚Å‰Šú‰»BÀÛ‚É‚Íg‚¤‘¤‚ÅSet`‚ğŒÄ‚Ô‚Ì‚ÅA‚±‚ê‚ç‚Ì‰¼’l‚ªQÆ‚³‚ê‚é‚±‚Æ‚Í–³‚¢B
+	//$ é©å½“ãªä»®å€¤ã§åˆæœŸåŒ–ã€‚å®Ÿéš›ã«ã¯ä½¿ã†å´ã§Setï½ã‚’å‘¼ã¶ã®ã§ã€ã“ã‚Œã‚‰ã®ä»®å€¤ãŒå‚ç…§ã•ã‚Œã‚‹ã“ã¨ã¯ç„¡ã„ã€‚
 	SetHankakuWidth(10);
 	SetHankakuHeight(18);
 	SetHankakuDx(12);
@@ -47,20 +47,20 @@ CTextMetrics::~CTextMetrics()
 
 void CTextMetrics::CopyTextMetricsStatus(CTextMetrics* pDst) const
 {
-	pDst->SetHankakuWidth			(GetHankakuWidth());		/* ”¼Šp•¶š‚Ì• */
-	pDst->SetHankakuHeight			(GetHankakuHeight());		/* •¶š‚Ì‚‚³ */
+	pDst->SetHankakuWidth			(GetHankakuWidth());		/* åŠè§’æ–‡å­—ã®å¹… */
+	pDst->SetHankakuHeight			(GetHankakuHeight());		/* æ–‡å­—ã®é«˜ã• */
 	pDst->m_aFontHeightMargin = m_aFontHeightMargin;
 }
 
 /*
-	•¶š‚Ì‘å‚«‚³‚ğ’²‚×‚é
+	æ–‡å­—ã®å¤§ãã•ã‚’èª¿ã¹ã‚‹
 	
-	¦ƒrƒ‹ƒhí‚É‚æ‚èA”÷–­‚ÉƒTƒCƒY‚ª•Ï‚í‚é‚æ‚¤‚Å‚µ‚½B
-	@ƒTƒCƒY‚ğ‡‚í‚¹‚é‚½‚ßA“K“–‚È•¶š‚Å’²®B
+	â€»ãƒ“ãƒ«ãƒ‰ç¨®ã«ã‚ˆã‚Šã€å¾®å¦™ã«ã‚µã‚¤ã‚ºãŒå¤‰ã‚ã‚‹ã‚ˆã†ã§ã—ãŸã€‚
+	ã€€ã‚µã‚¤ã‚ºã‚’åˆã‚ã›ã‚‹ãŸã‚ã€é©å½“ãªæ–‡å­—ã§èª¿æ•´ã€‚
 */
 void CTextMetrics::Update(HDC hdc, HFONT hFont, int nLineSpace, int nColmSpace)
 {
-	int size = 1; //b’è
+	int size = 1; //æš«å®š
 	HFONT hFontArray[1] = { hFont };
 
 	this->SetHankakuHeight(1);
@@ -71,11 +71,11 @@ void CTextMetrics::Update(HDC hdc, HFONT hFont, int nLineSpace, int nColmSpace)
 	for( int i = 0; i < size; i++ ){
 		HFONT hFontOld = (HFONT)::SelectObject( hdc, hFontArray[i] );
  		SIZE  sz;
-		// LocalCache::m_han_size ‚Æˆê’v‚µ‚Ä‚¢‚È‚¯‚ê‚Î‚È‚ç‚È‚¢
+		// LocalCache::m_han_size ã¨ä¸€è‡´ã—ã¦ã„ãªã‘ã‚Œã°ãªã‚‰ãªã„
 		{
 			// KB145994
-			// tmAveCharWidth ‚Í•s³Šm(”¼Šp‚©‘SŠp‚È‚Ì‚©‚à•s–¾‚È’l‚ğ•Ô‚·)
-			// ‚½‚¾‚µ‚±‚ÌƒR[ƒh‚ÍƒJ[ƒjƒ“ƒO‚Ì‰e‹¿‚ğó‚¯‚é
+			// tmAveCharWidth ã¯ä¸æ­£ç¢º(åŠè§’ã‹å…¨è§’ãªã®ã‹ã‚‚ä¸æ˜ãªå€¤ã‚’è¿”ã™)
+			// ãŸã ã—ã“ã®ã‚³ãƒ¼ãƒ‰ã¯ã‚«ãƒ¼ãƒ‹ãƒ³ã‚°ã®å½±éŸ¿ã‚’å—ã‘ã‚‹
 			GetTextExtentPoint32W_AnyBuild(hdc, L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", 52, &sz);
 			sz.cx = (sz.cx / 26 + 1) / 2;
 		}
@@ -103,21 +103,21 @@ void CTextMetrics::Update(HDC hdc, HFONT hFont, int nLineSpace, int nColmSpace)
 	}
 	int nOrgHeight = GetHankakuHeight();
 	if( nLineSpace < 0 ){
-		// ƒ}ƒCƒiƒX‚Ìê‡‚Í•¶š‚Ì‚‚³‚àˆø‚­
+		// ãƒã‚¤ãƒŠã‚¹ã®å ´åˆã¯æ–‡å­—ã®é«˜ã•ã‚‚å¼•ã
 		SetHankakuHeight( std::max(1, GetHankakuHeight() + nLineSpace) );
 	}
 	for( int i = 0; i < size; i++ ){
 		m_aFontHeightMargin[i] = tmAscentMaxHeight - tmAscent[i] + minMargin;
 	}
 	
-	// Dx/Dy‚àİ’è
+	// Dx/Dyã‚‚è¨­å®š
 	SetHankakuDx( GetHankakuWidth() + nColmSpace );
 	SetHankakuDy( std::max(1, nOrgHeight + nLineSpace) );
 }
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           İ’è                              //
+//                           è¨­å®š                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 void CTextMetrics::SetHankakuWidth(int nHankakuWidth)
@@ -125,14 +125,14 @@ void CTextMetrics::SetHankakuWidth(int nHankakuWidth)
 	m_nCharWidth=nHankakuWidth;
 }
 
-//! ”¼Šp•¶š‚Ìc•‚ğİ’èB’PˆÊ‚ÍƒsƒNƒZƒ‹B
+//! åŠè§’æ–‡å­—ã®ç¸¦å¹…ã‚’è¨­å®šã€‚å˜ä½ã¯ãƒ”ã‚¯ã‚»ãƒ«ã€‚
 void CTextMetrics::SetHankakuHeight(int nHankakuHeight)
 {
 	m_nCharHeight=nHankakuHeight;
 }
 
 
-//!•¶šŠÔŠuŠî€İ’èBnDxBasis‚Í”¼Šp•¶š‚ÌŠî€ƒsƒNƒZƒ‹•BSetHankakuDx
+//!æ–‡å­—é–“éš”åŸºæº–è¨­å®šã€‚nDxBasisã¯åŠè§’æ–‡å­—ã®åŸºæº–ãƒ”ã‚¯ã‚»ãƒ«å¹…ã€‚SetHankakuDx
 void CTextMetrics::SetHankakuDx(int nDxBasis)
 {
 	m_nDxBasis=nDxBasis;
@@ -145,18 +145,18 @@ void CTextMetrics::SetHankakuDy(int nDyBasis)
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           æ“¾                              //
+//                           å–å¾—                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! w’è‚µ‚½•¶š—ñ‚É‚æ‚è•¶šŠÔŠu”z—ñ‚ğ¶¬‚·‚éB
+//! æŒ‡å®šã—ãŸæ–‡å­—åˆ—ã«ã‚ˆã‚Šæ–‡å­—é–“éš”é…åˆ—ã‚’ç”Ÿæˆã™ã‚‹ã€‚
 const int* CTextMetrics::GenerateDxArray(
-	std::vector<int>* vResultArray, //!< [out] •¶šŠÔŠu”z—ñ‚Ìó‚¯æ‚èƒRƒ“ƒeƒi
-	const wchar_t* pText,           //!< [in]  •¶š—ñ
-	int nLength,                    //!< [in]  •¶š—ñ’·
-	int	nHankakuDx,					//!< [in]  ”¼Šp•¶š‚Ì•¶šŠÔŠu
-	int	nTabSpace,					//   [in]  TAB•(CLayoutXInt)
-	int	nIndent,					//   [in]  ƒCƒ“ƒfƒ“ƒg(TAB‘Î‰—p)(CLayoutXInt)
-	int nCharSpacing				//!< [in]  •¶šŒ„ŠÔ
+	std::vector<int>* vResultArray, //!< [out] æ–‡å­—é–“éš”é…åˆ—ã®å—ã‘å–ã‚Šã‚³ãƒ³ãƒ†ãƒŠ
+	const wchar_t* pText,           //!< [in]  æ–‡å­—åˆ—
+	int nLength,                    //!< [in]  æ–‡å­—åˆ—é•·
+	int	nHankakuDx,					//!< [in]  åŠè§’æ–‡å­—ã®æ–‡å­—é–“éš”
+	int	nTabSpace,					//   [in]  TABå¹…(CLayoutXInt)
+	int	nIndent,					//   [in]  ã‚¤ãƒ³ãƒ‡ãƒ³ãƒˆ(TABå¯¾å¿œç”¨)(CLayoutXInt)
+	int nCharSpacing				//!< [in]  æ–‡å­—éš™é–“
 )
 {
 
@@ -167,9 +167,9 @@ const int* CTextMetrics::GenerateDxArray(
 	int	 nLayoutCnt = nIndent;
 	const wchar_t* x=pText;
 	for (int i=0; i<nLength; i++, p++, x++) {
-		// ƒTƒƒQ[ƒgƒ`ƒFƒbƒN
+		// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒã‚§ãƒƒã‚¯
 		if (*x == WCODE::TAB) {
-			// TAB‘Î‰	2013/5/7 Uchi
+			// TABå¯¾å¿œ	2013/5/7 Uchi
 			if (i > 0 && *(x-1) == WCODE::TAB) {
 				*p = nTabSpace;
 				nLayoutCnt += *p;
@@ -214,17 +214,17 @@ const int* CTextMetrics::GenerateDxArray(
 		return NULL;
 }
 
-//!•¶š—ñ‚ÌƒsƒNƒZƒ‹•‚ğ•Ô‚·B
+//!æ–‡å­—åˆ—ã®ãƒ”ã‚¯ã‚»ãƒ«å¹…ã‚’è¿”ã™ã€‚
 int CTextMetrics::CalcTextWidth(
-	const wchar_t* pText, //!< •¶š—ñ
-	int nLength,          //!< •¶š—ñ’·
-	const int* pnDx       //!< •¶šŠÔŠu‚Ì“ü‚Á‚½”z—ñ
+	const wchar_t* pText, //!< æ–‡å­—åˆ—
+	int nLength,          //!< æ–‡å­—åˆ—é•·
+	const int* pnDx       //!< æ–‡å­—é–“éš”ã®å…¥ã£ãŸé…åˆ—
 )
 {
-	//ANSI‘ã‚Ì“®ì ¦pnDx‚É‚Í‚·‚×‚Ä“¯‚¶’l‚ª“ü‚Á‚Ä‚¢‚½
+	//ANSIæ™‚ä»£ã®å‹•ä½œ â€»pnDxã«ã¯ã™ã¹ã¦åŒã˜å€¤ãŒå…¥ã£ã¦ã„ãŸ
 	//return pnDx[0] * nLength;
 
-	//UNICODE‘ã‚Ì“®ì
+	//UNICODEæ™‚ä»£ã®å‹•ä½œ
 	int w=0;
 	for(int i=0;i<nLength;i++){
 		w+=pnDx[i];
@@ -232,15 +232,15 @@ int CTextMetrics::CalcTextWidth(
 	return w;
 }
 
-//!•¶š—ñ‚ÌƒsƒNƒZƒ‹•‚ğ•Ô‚·B
+//!æ–‡å­—åˆ—ã®ãƒ”ã‚¯ã‚»ãƒ«å¹…ã‚’è¿”ã™ã€‚
 int CTextMetrics::CalcTextWidth2(
-	const wchar_t* pText, //!< •¶š—ñ
-	int nLength,          //!< •¶š—ñ’·
-	int nHankakuDx,       //!< ”¼Šp•¶š‚Ì•¶šŠÔŠu
-	int nCharSpacing      //!< •¶š‚ÌŒ„ŠÔ
+	const wchar_t* pText, //!< æ–‡å­—åˆ—
+	int nLength,          //!< æ–‡å­—åˆ—é•·
+	int nHankakuDx,       //!< åŠè§’æ–‡å­—ã®æ–‡å­—é–“éš”
+	int nCharSpacing      //!< æ–‡å­—ã®éš™é–“
 )
 {
-	//•¶šŠÔŠu”z—ñ‚ğ¶¬
+	//æ–‡å­—é–“éš”é…åˆ—ã‚’ç”Ÿæˆ
 	vector<int> vDxArray;
 	const int* pDxArray = CTextMetrics::GenerateDxArray(
 		&vDxArray,
@@ -252,13 +252,13 @@ int CTextMetrics::CalcTextWidth2(
 		nCharSpacing
 	);
 
-	//ƒsƒNƒZƒ‹•‚ğŒvZ
+	//ãƒ”ã‚¯ã‚»ãƒ«å¹…ã‚’è¨ˆç®—
 	return CalcTextWidth(pText, nLength, pDxArray);
 }
 
 int CTextMetrics::CalcTextWidth3(
-	const wchar_t* pText, //!< •¶š—ñ
-	int nLength          //!< •¶š—ñ’·
+	const wchar_t* pText, //!< æ–‡å­—åˆ—
+	int nLength          //!< æ–‡å­—åˆ—é•·
 ) const
 {
 	return CalcTextWidth2(pText, nLength, GetCharPxWidth(), GetCharSpacing());

--- a/sakura_core/view/CTextMetrics.h
+++ b/sakura_core/view/CTextMetrics.h
@@ -1,4 +1,4 @@
-/*
+Ôªø/*
 	Copyright (C) 2007, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -24,7 +24,7 @@
 #ifndef SAKURA_CTEXTMETRICS_815A7F9E_8E38_4FA5_9F68_7CA776A18F1F_H_
 #define SAKURA_CTEXTMETRICS_815A7F9E_8E38_4FA5_9F68_7CA776A18F1F_H_
 
-//2007.08.25 kobake í«â¡
+//2007.08.25 kobake ËøΩÂä†
 
 #include <vector>
 
@@ -32,31 +32,31 @@ class CTextMetrics;
 
 class CTextMetrics{
 public:
-	//ÉRÉìÉXÉgÉâÉNÉ^ÅEÉfÉXÉgÉâÉNÉ^
+	//„Ç≥„É≥„Çπ„Éà„É©„ÇØ„Çø„Éª„Éá„Çπ„Éà„É©„ÇØ„Çø
 	CTextMetrics();
 	virtual ~CTextMetrics();
 	void CopyTextMetricsStatus(CTextMetrics* pDst) const;
 	void Update(HDC hdc, HFONT hFont, int nLineSpace, int nColmSpace);
 
-	//ê›íË
+	//Ë®≠ÂÆö
 private:
-	void SetHankakuWidth(int nHankakuWidth);   //!< îºäpï∂éöÇÃïùÇê›íËÅBíPà ÇÕÉsÉNÉZÉãÅB
-	void SetHankakuHeight(int nHankakuHeight); //!< îºäpï∂éöÇÃècïùÇê›íËÅBíPà ÇÕÉsÉNÉZÉãÅB
-	void SetHankakuDx(int nHankakuDx);         //!< îºäpï∂éöÇÃï∂éöä‘äuÇê›íËÅBíPà ÇÕÉsÉNÉZÉãÅB
-	void SetHankakuDy(int nHankakuDy);         //!< îºäpï∂éöÇÃçsä‘äuÇê›íËÅBíPà ÇÕÉsÉNÉZÉãÅB
+	void SetHankakuWidth(int nHankakuWidth);   //!< ÂçäËßíÊñáÂ≠ó„ÅÆÂπÖ„ÇíË®≠ÂÆö„ÄÇÂçò‰Ωç„ÅØ„Éî„ÇØ„Çª„É´„ÄÇ
+	void SetHankakuHeight(int nHankakuHeight); //!< ÂçäËßíÊñáÂ≠ó„ÅÆÁ∏¶ÂπÖ„ÇíË®≠ÂÆö„ÄÇÂçò‰Ωç„ÅØ„Éî„ÇØ„Çª„É´„ÄÇ
+	void SetHankakuDx(int nHankakuDx);         //!< ÂçäËßíÊñáÂ≠ó„ÅÆÊñáÂ≠óÈñìÈöî„ÇíË®≠ÂÆö„ÄÇÂçò‰Ωç„ÅØ„Éî„ÇØ„Çª„É´„ÄÇ
+	void SetHankakuDy(int nHankakuDy);         //!< ÂçäËßíÊñáÂ≠ó„ÅÆË°åÈñìÈöî„ÇíË®≠ÂÆö„ÄÇÂçò‰Ωç„ÅØ„Éî„ÇØ„Çª„É´„ÄÇ
 
-	//éÊìæ
+	//ÂèñÂæó
 public:
-	int GetHankakuWidth() const{ return m_nCharWidth; }		//!< îºäpï∂éöÇÃâ°ïùÇéÊìæÅBíPà ÇÕÉsÉNÉZÉãÅB
-	int GetHankakuHeight() const{ return m_nCharHeight; }	//!< îºäpï∂éöÇÃècïùÇéÊìæÅBíPà ÇÕÉsÉNÉZÉãÅB
-	int GetHankakuDx() const{ return m_nDxBasis; }			//!< îºäpï∂éöÇÃï∂éöä‘äuÇéÊìæÅBíPà ÇÕÉsÉNÉZÉãÅB
-	int GetZenkakuDx() const{ return m_nDxBasis*2; }		//!< ëSäpï∂éöÇÃï∂éöä‘äuÇéÊìæÅBíPà ÇÕÉsÉNÉZÉãÅB
-	int GetHankakuDy() const{ return m_nDyBasis; }			//!< Yï˚å¸ï∂éöä‘äuÅBï∂éöècïùÅ{çsä‘äuÅBíPà ÇÕÉsÉNÉZÉãÅB
+	int GetHankakuWidth() const{ return m_nCharWidth; }		//!< ÂçäËßíÊñáÂ≠ó„ÅÆÊ®™ÂπÖ„ÇíÂèñÂæó„ÄÇÂçò‰Ωç„ÅØ„Éî„ÇØ„Çª„É´„ÄÇ
+	int GetHankakuHeight() const{ return m_nCharHeight; }	//!< ÂçäËßíÊñáÂ≠ó„ÅÆÁ∏¶ÂπÖ„ÇíÂèñÂæó„ÄÇÂçò‰Ωç„ÅØ„Éî„ÇØ„Çª„É´„ÄÇ
+	int GetHankakuDx() const{ return m_nDxBasis; }			//!< ÂçäËßíÊñáÂ≠ó„ÅÆÊñáÂ≠óÈñìÈöî„ÇíÂèñÂæó„ÄÇÂçò‰Ωç„ÅØ„Éî„ÇØ„Çª„É´„ÄÇ
+	int GetZenkakuDx() const{ return m_nDxBasis*2; }		//!< ÂÖ®ËßíÊñáÂ≠ó„ÅÆÊñáÂ≠óÈñìÈöî„ÇíÂèñÂæó„ÄÇÂçò‰Ωç„ÅØ„Éî„ÇØ„Çª„É´„ÄÇ
+	int GetHankakuDy() const{ return m_nDyBasis; }			//!< YÊñπÂêëÊñáÂ≠óÈñìÈöî„ÄÇÊñáÂ≠óÁ∏¶ÂπÖÔºãË°åÈñìÈöî„ÄÇÂçò‰Ωç„ÅØ„Éî„ÇØ„Çª„É´„ÄÇ
 
 	CPixelXInt GetCharSpacing() const {
 		return GetHankakuDx() - GetHankakuWidth();
 	}
-	// ÉåÉCÉAÉEÉgïùï™ÇÃÉsÉNÉZÉãïùÇéÊìæÇ∑ÇÈ
+	// „É¨„Ç§„Ç¢„Ç¶„ÉàÂπÖÂàÜ„ÅÆ„Éî„ÇØ„Çª„É´ÂπÖ„ÇíÂèñÂæó„Åô„Çã
 	int GetCharPxWidth(CLayoutXInt col) const{
 		return (Int)col;
 	}
@@ -68,65 +68,65 @@ public:
 		return m_aFontHeightMargin[n];
 	}
 
-	// å≈íËï∂éöxåÖÇÃÉåÉCÉAÉEÉgïùÇéÊìæÇ∑ÇÈ
+	// Âõ∫ÂÆöÊñáÂ≠óxÊ°Å„ÅÆ„É¨„Ç§„Ç¢„Ç¶„ÉàÂπÖ„ÇíÂèñÂæó„Åô„Çã
 	CLayoutXInt GetLayoutXDefault(CKetaXInt chars) const{
 		return CLayoutXInt(GetHankakuDx() * (Int)chars);
 	}
-	// å≈íËï∂éö1åÖÇ†ÇΩÇËÇÃÉåÉCÉAÉEÉgïùÇéÊìæÇ∑ÇÈ
+	// Âõ∫ÂÆöÊñáÂ≠ó1Ê°Å„ÅÇ„Åü„Çä„ÅÆ„É¨„Ç§„Ç¢„Ç¶„ÉàÂπÖ„ÇíÂèñÂæó„Åô„Çã
 	CLayoutXInt GetLayoutXDefault() const{ return GetLayoutXDefault(CKetaXInt(1));}
 	
 
-	//ï∂éöä‘äuîzóÒÇéÊìæ
-	const int* GetDxArray_AllHankaku() const{ return m_anHankakuDx; } //!<îºäpï∂éöóÒÇÃï∂éöä‘äuîzóÒÇéÊìæÅBóvëfêîÇÕ64ÅB
-	const int* GetDxArray_AllZenkaku() const{ return m_anZenkakuDx; } //!<îºäpï∂éöóÒÇÃï∂éöä‘äuîzóÒÇéÊìæÅBóvëfêîÇÕ64ÅB
+	//ÊñáÂ≠óÈñìÈöîÈÖçÂàó„ÇíÂèñÂæó
+	const int* GetDxArray_AllHankaku() const{ return m_anHankakuDx; } //!<ÂçäËßíÊñáÂ≠óÂàó„ÅÆÊñáÂ≠óÈñìÈöîÈÖçÂàó„ÇíÂèñÂæó„ÄÇË¶ÅÁ¥†Êï∞„ÅØ64„ÄÇ
+	const int* GetDxArray_AllZenkaku() const{ return m_anZenkakuDx; } //!<ÂçäËßíÊñáÂ≠óÂàó„ÅÆÊñáÂ≠óÈñìÈöîÈÖçÂàó„ÇíÂèñÂæó„ÄÇË¶ÅÁ¥†Êï∞„ÅØ64„ÄÇ
 
 	const int* GenerateDxArray2(
-		std::vector<int>* vResultArray, //!< [out] ï∂éöä‘äuîzóÒÇÃéÛÇØéÊÇËÉRÉìÉeÉi
-		const wchar_t* pText,           //!< [in]  ï∂éöóÒ
-		int nLength                     //!< [in]  ï∂éöóÒí∑
+		std::vector<int>* vResultArray, //!< [out] ÊñáÂ≠óÈñìÈöîÈÖçÂàó„ÅÆÂèó„ÅëÂèñ„Çä„Ç≥„É≥„ÉÜ„Éä
+		const wchar_t* pText,           //!< [in]  ÊñáÂ≠óÂàó
+		int nLength                     //!< [in]  ÊñáÂ≠óÂàóÈï∑
 	) const {
 		return GenerateDxArray(vResultArray, pText, nLength, GetHankakuDx(), 8, 0, GetCharSpacing());
 	}
 
-	//! éwíËÇµÇΩï∂éöóÒÇ…ÇÊÇËï∂éöä‘äuîzóÒÇê∂ê¨Ç∑ÇÈÅB
+	//! ÊåáÂÆö„Åó„ÅüÊñáÂ≠óÂàó„Å´„Çà„ÇäÊñáÂ≠óÈñìÈöîÈÖçÂàó„ÇíÁîüÊàê„Åô„Çã„ÄÇ
 	static const int* GenerateDxArray(
-		std::vector<int>* vResultArray, //!< [out] ï∂éöä‘äuîzóÒÇÃéÛÇØéÊÇËÉRÉìÉeÉi
-		const wchar_t* pText,           //!< [in]  ï∂éöóÒ
-		int nLength,                    //!< [in]  ï∂éöóÒí∑
-		int	nHankakuDx,					//!< [in]  îºäpï∂éöÇÃï∂éöä‘äu
-		int	nTabSpace = 8,				//   [in]  TABïù
-		int	nIndent = 0,				//   [in]  ÉCÉìÉfÉìÉg
-		int nCharSpacing = 0			//   [in]  ï∂éöÇÃä‘äu
+		std::vector<int>* vResultArray, //!< [out] ÊñáÂ≠óÈñìÈöîÈÖçÂàó„ÅÆÂèó„ÅëÂèñ„Çä„Ç≥„É≥„ÉÜ„Éä
+		const wchar_t* pText,           //!< [in]  ÊñáÂ≠óÂàó
+		int nLength,                    //!< [in]  ÊñáÂ≠óÂàóÈï∑
+		int	nHankakuDx,					//!< [in]  ÂçäËßíÊñáÂ≠ó„ÅÆÊñáÂ≠óÈñìÈöî
+		int	nTabSpace = 8,				//   [in]  TABÂπÖ
+		int	nIndent = 0,				//   [in]  „Ç§„É≥„Éá„É≥„Éà
+		int nCharSpacing = 0			//   [in]  ÊñáÂ≠ó„ÅÆÈñìÈöî
 	);
 
-	//!ï∂éöóÒÇÃÉsÉNÉZÉãïùÇï‘Ç∑ÅB
+	//!ÊñáÂ≠óÂàó„ÅÆ„Éî„ÇØ„Çª„É´ÂπÖ„ÇíËøî„Åô„ÄÇ
 	static int CalcTextWidth(
-		const wchar_t* pText, //!< ï∂éöóÒ
-		int nLength,          //!< ï∂éöóÒí∑
-		const int* pnDx       //!< ï∂éöä‘äuÇÃì¸Ç¡ÇΩîzóÒ
+		const wchar_t* pText, //!< ÊñáÂ≠óÂàó
+		int nLength,          //!< ÊñáÂ≠óÂàóÈï∑
+		const int* pnDx       //!< ÊñáÂ≠óÈñìÈöî„ÅÆÂÖ•„Å£„ÅüÈÖçÂàó
 	);
 
-	//!ï∂éöóÒÇÃÉsÉNÉZÉãïùÇï‘Ç∑ÅB
+	//!ÊñáÂ≠óÂàó„ÅÆ„Éî„ÇØ„Çª„É´ÂπÖ„ÇíËøî„Åô„ÄÇ
 	static int CalcTextWidth2(
-		const wchar_t* pText, //!< ï∂éöóÒ
-		int nLength,          //!< ï∂éöóÒí∑
-		int nHankakuDx,       //!< îºäpï∂éöÇÃï∂éöä‘äu
+		const wchar_t* pText, //!< ÊñáÂ≠óÂàó
+		int nLength,          //!< ÊñáÂ≠óÂàóÈï∑
+		int nHankakuDx,       //!< ÂçäËßíÊñáÂ≠ó„ÅÆÊñáÂ≠óÈñìÈöî
 		int nCharSpacing
 	);
 
 	int CalcTextWidth3(
-		const wchar_t* pText, //!< ï∂éöóÒ
-		int nLength           //!< ï∂éöóÒí∑
+		const wchar_t* pText, //!< ÊñáÂ≠óÂàó
+		int nLength           //!< ÊñáÂ≠óÂàóÈï∑
 	) const;
 
 private:
-//	HDC m_hdc; //!< åvéZÇ…ópÇ¢ÇÈÉfÉoÉCÉXÉRÉìÉeÉLÉXÉg
-	int	m_nCharWidth;      //!< îºäpï∂éöÇÃâ°ïù
-	int m_nCharHeight;     //!< îºäpï∂éöÇÃècïù
-	int m_nDxBasis;        //!< îºäpï∂éöÇÃï∂éöä‘äu (â°ïù+Éø)
-	int m_nDyBasis;        //!< îºäpï∂éöÇÃçsä‘äu (ècïù+Éø)
-	int m_anHankakuDx[64]; //!< îºäpópï∂éöä‘äuîzóÒ
-	int m_anZenkakuDx[64]; //!< ëSäpópï∂éöä‘äuîzóÒ
+//	HDC m_hdc; //!< Ë®àÁÆó„Å´Áî®„ÅÑ„Çã„Éá„Éê„Ç§„Çπ„Ç≥„É≥„ÉÜ„Ç≠„Çπ„Éà
+	int	m_nCharWidth;      //!< ÂçäËßíÊñáÂ≠ó„ÅÆÊ®™ÂπÖ
+	int m_nCharHeight;     //!< ÂçäËßíÊñáÂ≠ó„ÅÆÁ∏¶ÂπÖ
+	int m_nDxBasis;        //!< ÂçäËßíÊñáÂ≠ó„ÅÆÊñáÂ≠óÈñìÈöî (Ê®™ÂπÖ+Œ±)
+	int m_nDyBasis;        //!< ÂçäËßíÊñáÂ≠ó„ÅÆË°åÈñìÈöî (Á∏¶ÂπÖ+Œ±)
+	int m_anHankakuDx[64]; //!< ÂçäËßíÁî®ÊñáÂ≠óÈñìÈöîÈÖçÂàó
+	int m_anZenkakuDx[64]; //!< ÂÖ®ËßíÁî®ÊñáÂ≠óÈñìÈöîÈÖçÂàó
 	std::vector<int> m_aFontHeightMargin;
 };
 

--- a/sakura_core/view/CViewCalc.cpp
+++ b/sakura_core/view/CViewCalc.cpp
@@ -1,11 +1,11 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "CViewCalc.h"
 #include "mem/CMemoryIterator.h"
 #include "view/CEditView.h"
 #include "doc/CEditDoc.h"
 #include "doc/layout/CLayout.h"
 
-//ŠO•”ˆË‘¶
+//å¤–éƒ¨ä¾å­˜
 CLayoutInt CViewCalc::GetTabSpace() const
 {
 	return m_pOwner->m_pcEditDoc->m_cLayoutMgr.GetTabSpace();
@@ -21,9 +21,9 @@ CPixelXInt CViewCalc::GetCharSpacing() const
 	return m_pOwner->m_pcEditDoc->m_cLayoutMgr.GetCharSpacing();
 }
 
-/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é Ver1
+/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ Ver1
 	
-	@@@ 2002.09.28 YAZAKI CDocLine”Å
+	@@@ 2002.09.28 YAZAKI CDocLineç‰ˆ
 */
 CLogicInt CViewCalc::LineColumnToIndex( const CDocLine* pcDocLine, CLayoutInt nColumn ) const
 {
@@ -41,9 +41,9 @@ CLogicInt CViewCalc::LineColumnToIndex( const CDocLine* pcDocLine, CLayoutInt nC
 }
 
 
-/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é Ver1
+/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ Ver1
 	
-	@@@ 2002.09.28 YAZAKI CLayout‚ª•K—v‚É‚È‚è‚Ü‚µ‚½B
+	@@@ 2002.09.28 YAZAKI CLayoutãŒå¿…è¦ã«ãªã‚Šã¾ã—ãŸã€‚
 */
 CLogicInt CViewCalc::LineColumnToIndex( const CLayout* pcLayout, CLayoutInt nColumn ) const
 {
@@ -62,11 +62,11 @@ CLogicInt CViewCalc::LineColumnToIndex( const CLayout* pcLayout, CLayoutInt nCol
 
 
 
-/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é Ver0 */
-/* w’è‚³‚ê‚½Œ…‚æ‚èAs‚ª’Z‚¢ê‡‚ÍpnLineAllColLen‚És‘S‘Ì‚Ì•\¦Œ…”‚ğ•Ô‚· */
-/* ‚»‚êˆÈŠO‚Ìê‡‚ÍpnLineAllColLen‚É‚O‚ğƒZƒbƒg‚·‚é
+/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ Ver0 */
+/* æŒ‡å®šã•ã‚ŒãŸæ¡ã‚ˆã‚Šã€è¡ŒãŒçŸ­ã„å ´åˆã¯pnLineAllColLenã«è¡Œå…¨ä½“ã®è¡¨ç¤ºæ¡æ•°ã‚’è¿”ã™ */
+/* ãã‚Œä»¥å¤–ã®å ´åˆã¯pnLineAllColLenã«ï¼ã‚’ã‚»ãƒƒãƒˆã™ã‚‹
 	
-	@@@ 2002.09.28 YAZAKI CLayout‚ª•K—v‚É‚È‚è‚Ü‚µ‚½B
+	@@@ 2002.09.28 YAZAKI CLayoutãŒå¿…è¦ã«ãªã‚Šã¾ã—ãŸã€‚
 */
 CLogicInt CViewCalc::LineColumnToIndex2( const CLayout* pcLayout, CLayoutInt nColumn, CLayoutInt* pnLineAllColLen ) const
 {
@@ -95,13 +95,13 @@ CLogicInt CViewCalc::LineColumnToIndex2( const CLayout* pcLayout, CLayoutInt nCo
 
 
 /*
-||	w’è‚³‚ê‚½s‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚É‘Î‰‚·‚éŒ…‚ÌˆÊ’u‚ğ’²‚×‚é
+||	æŒ‡å®šã•ã‚ŒãŸè¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ¡ã®ä½ç½®ã‚’èª¿ã¹ã‚‹
 ||
-||	@@@ 2002.09.28 YAZAKI CLayout‚ª•K—v‚É‚È‚è‚Ü‚µ‚½B
+||	@@@ 2002.09.28 YAZAKI CLayoutãŒå¿…è¦ã«ãªã‚Šã¾ã—ãŸã€‚
 */
 CLayoutInt CViewCalc::LineIndexToColumn( const CLayout* pcLayout, CLogicInt nIndex ) const
 {
-	//	ˆÈ‰ºAiterator”Å
+	//	ä»¥ä¸‹ã€iteratorç‰ˆ
 	CLayoutInt nPosX2 = CLayoutInt(0);
 	CMemoryIterator it = m_pOwner->m_pcEditDoc->m_cLayoutMgr.CreateCMemoryIterator(pcLayout);
 	while( !it.end() ){
@@ -117,9 +117,9 @@ CLayoutInt CViewCalc::LineIndexToColumn( const CLayout* pcLayout, CLogicInt nInd
 
 
 /*
-||	w’è‚³‚ê‚½s‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚É‘Î‰‚·‚éŒ…‚ÌˆÊ’u‚ğ’²‚×‚é
+||	æŒ‡å®šã•ã‚ŒãŸè¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ¡ã®ä½ç½®ã‚’èª¿ã¹ã‚‹
 ||
-||	@@@ 2002.09.28 YAZAKI CDocLine”Å
+||	@@@ 2002.09.28 YAZAKI CDocLineç‰ˆ
 */
 CLayoutInt CViewCalc::LineIndexToColumn( const CDocLine* pcDocLine, CLogicInt nIndex ) const
 {

--- a/sakura_core/view/CViewCalc.h
+++ b/sakura_core/view/CViewCalc.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -27,7 +27,7 @@
 #include "doc/layout/CTsvModeInfo.h"
 
 /*
-	X’l‚Ì’PˆÊ•ÏŠ·ŠÖ”ŒQB
+	Xå€¤ã®å˜ä½å¤‰æ›é–¢æ•°ç¾¤ã€‚
 */
 
 class CLayout;
@@ -36,7 +36,7 @@ class CEditView;
 
 class CViewCalc{
 protected:
-	//ŠO•”ˆË‘¶
+	//å¤–éƒ¨ä¾å­˜
 	CLayoutInt GetTabSpace() const;
 	CPixelXInt GetCharSpacing() const;
 	CTsvModeInfo& GetTsvMode() const;
@@ -45,14 +45,14 @@ public:
 	CViewCalc(const CEditView* pOwner) : m_pOwner(pOwner) { }
 	virtual ~CViewCalc(){}
 
-	//’PˆÊ•ÏŠ·: ƒŒƒCƒAƒEƒg¨ƒƒWƒbƒN
-	CLogicInt  LineColumnToIndex ( const CLayout*  pcLayout,  CLayoutInt nColumn ) const;		/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é Ver1 */		// @@@ 2002.09.28 YAZAKI
-	CLogicInt  LineColumnToIndex ( const CDocLine* pcDocLine, CLayoutInt nColumn ) const;		/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é Ver1 */		// @@@ 2002.09.28 YAZAKI
-	CLogicInt  LineColumnToIndex2( const CLayout*  pcLayout,  CLayoutInt nColumn, CLayoutInt* pnLineAllColLen ) const;	/* w’è‚³‚ê‚½Œ…‚É‘Î‰‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ğ’²‚×‚é Ver0 */		// @@@ 2002.09.28 YAZAKI
+	//å˜ä½å¤‰æ›: ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆâ†’ãƒ­ã‚¸ãƒƒã‚¯
+	CLogicInt  LineColumnToIndex ( const CLayout*  pcLayout,  CLayoutInt nColumn ) const;		/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ Ver1 */		// @@@ 2002.09.28 YAZAKI
+	CLogicInt  LineColumnToIndex ( const CDocLine* pcDocLine, CLayoutInt nColumn ) const;		/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ Ver1 */		// @@@ 2002.09.28 YAZAKI
+	CLogicInt  LineColumnToIndex2( const CLayout*  pcLayout,  CLayoutInt nColumn, CLayoutInt* pnLineAllColLen ) const;	/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ Ver0 */		// @@@ 2002.09.28 YAZAKI
 
-	//’PˆÊ•ÏŠ·: ƒƒWƒbƒN¨ƒŒƒCƒAƒEƒg
-	CLayoutInt LineIndexToColumn ( const CLayout*  pcLayout,  CLogicInt nIndex ) const;		// w’è‚³‚ê‚½s‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚É‘Î‰‚·‚éŒ…‚ÌˆÊ’u‚ğ’²‚×‚é	// @@@ 2002.09.28 YAZAKI
-	CLayoutInt LineIndexToColumn ( const CDocLine* pcLayout,  CLogicInt nIndex ) const;		// w’è‚³‚ê‚½s‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚É‘Î‰‚·‚éŒ…‚ÌˆÊ’u‚ğ’²‚×‚é	// @@@ 2002.09.28 YAZAKI
+	//å˜ä½å¤‰æ›: ãƒ­ã‚¸ãƒƒã‚¯â†’ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆ
+	CLayoutInt LineIndexToColumn ( const CLayout*  pcLayout,  CLogicInt nIndex ) const;		// æŒ‡å®šã•ã‚ŒãŸè¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ¡ã®ä½ç½®ã‚’èª¿ã¹ã‚‹	// @@@ 2002.09.28 YAZAKI
+	CLayoutInt LineIndexToColumn ( const CDocLine* pcLayout,  CLogicInt nIndex ) const;		// æŒ‡å®šã•ã‚ŒãŸè¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã«å¯¾å¿œã™ã‚‹æ¡ã®ä½ç½®ã‚’èª¿ã¹ã‚‹	// @@@ 2002.09.28 YAZAKI
 
 private:
 	const CEditView* m_pOwner;

--- a/sakura_core/view/CViewFont.cpp
+++ b/sakura_core/view/CViewFont.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,16 +25,16 @@
 #include "StdAfx.h"
 #include "CViewFont.h"
 
-/*! ƒtƒHƒ“ƒgì¬
+/*! ãƒ•ã‚©ãƒ³ãƒˆä½œæˆ
 */
 void CViewFont::CreateFont(const LOGFONT *plf)
 {
 	LOGFONT	lf;
 	int miniSize = GetDllShareData().m_Common.m_sWindow.m_nMiniMapFontSize;
 	int quality = GetDllShareData().m_Common.m_sWindow.m_nMiniMapQuality;
-	int outPrec = OUT_TT_ONLY_PRECIS;	// FixedSys“™‚ÅMiniMap‚ÌƒtƒHƒ“ƒg‚ª¬‚³‚­‚È‚ç‚È‚¢C³
+	int outPrec = OUT_TT_ONLY_PRECIS;	// FixedSysç­‰ã§MiniMapã®ãƒ•ã‚©ãƒ³ãƒˆãŒå°ã•ããªã‚‰ãªã„ä¿®æ­£
 
-	/* ƒtƒHƒ“ƒgì¬ */
+	/* ãƒ•ã‚©ãƒ³ãƒˆä½œæˆ */
 	lf = *plf;
 	if( m_bMiniMap ){
 		lf.lfHeight = miniSize;
@@ -44,7 +44,7 @@ void CViewFont::CreateFont(const LOGFONT *plf)
 	m_hFont_HAN = CreateFontIndirect( &lf );
 	m_LogFont = lf;
 
-	/* ‘¾šƒtƒHƒ“ƒgì¬ */
+	/* å¤ªå­—ãƒ•ã‚©ãƒ³ãƒˆä½œæˆ */
 	lf = *plf;
 	if( m_bMiniMap ){
 		lf.lfHeight = miniSize;
@@ -57,7 +57,7 @@ void CViewFont::CreateFont(const LOGFONT *plf)
 	}
 	m_hFont_HAN_BOLD = CreateFontIndirect( &lf );
 
-	/* ‰ºüƒtƒHƒ“ƒgì¬ */
+	/* ä¸‹ç·šãƒ•ã‚©ãƒ³ãƒˆä½œæˆ */
 	lf = *plf;
 	if( m_bMiniMap ){
 		lf.lfHeight = miniSize;
@@ -68,7 +68,7 @@ void CViewFont::CreateFont(const LOGFONT *plf)
 	lf.lfUnderline = TRUE;
 	m_hFont_HAN_UL = CreateFontIndirect( &lf );
 
-	/* ‘¾š‰ºüƒtƒHƒ“ƒgì¬ */
+	/* å¤ªå­—ä¸‹ç·šãƒ•ã‚©ãƒ³ãƒˆä½œæˆ */
 	lf = *plf;
 	if( m_bMiniMap ){
 		lf.lfHeight = miniSize;
@@ -83,7 +83,7 @@ void CViewFont::CreateFont(const LOGFONT *plf)
 	m_hFont_HAN_BOLD_UL = CreateFontIndirect( &lf );
 }
 
-/*! ƒtƒHƒ“ƒgíœ
+/*! ãƒ•ã‚©ãƒ³ãƒˆå‰Šé™¤
 */
 void CViewFont::DeleteFont()
 {
@@ -93,21 +93,21 @@ void CViewFont::DeleteFont()
 	DeleteObject( m_hFont_HAN_BOLD_UL );
 }
 
-/*! ƒtƒHƒ“ƒg‚ğ‘I‚Ô
-	@param m_bBoldFont true‚Å‘¾š
-	@param m_bUnderLine true‚Å‰ºü
+/*! ãƒ•ã‚©ãƒ³ãƒˆã‚’é¸ã¶
+	@param m_bBoldFont trueã§å¤ªå­—
+	@param m_bUnderLine trueã§ä¸‹ç·š
 */
 HFONT CViewFont::ChooseFontHandle( int fontNo, SFontAttr sFontAttr ) const
 {
 	assert( fontNo == 0 );
-	if( sFontAttr.m_bBoldFont ){	/* ‘¾š‚© */
-		if( sFontAttr.m_bUnderLine ){	/* ‰ºü‚© */
+	if( sFontAttr.m_bBoldFont ){	/* å¤ªå­—ã‹ */
+		if( sFontAttr.m_bUnderLine ){	/* ä¸‹ç·šã‹ */
 			return m_hFont_HAN_BOLD_UL;
 		}else{
 			return m_hFont_HAN_BOLD;
 		}
 	}else{
-		if( sFontAttr.m_bUnderLine ){	/* ‰ºü‚© */
+		if( sFontAttr.m_bUnderLine ){	/* ä¸‹ç·šã‹ */
 			return m_hFont_HAN_UL;
 		}else{
 			return m_hFont_HAN;

--- a/sakura_core/view/CViewFont.h
+++ b/sakura_core/view/CViewFont.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -44,7 +44,7 @@ public:
 		CreateFont(plf);
 	}
 
-	HFONT ChooseFontHandle( int fontNo, SFontAttr sFontAttr ) const;		/* ƒtƒHƒ“ƒg‚ğ‘I‚Ô */
+	HFONT ChooseFontHandle( int fontNo, SFontAttr sFontAttr ) const;		/* ãƒ•ã‚©ãƒ³ãƒˆã‚’é¸ã¶ */
 
 	HFONT GetFontHan() const
 	{
@@ -60,10 +60,10 @@ private:
 	void CreateFont(const LOGFONT *plf);
 	void DeleteFont();
 
-	HFONT	m_hFont_HAN;			/* Œ»İ‚ÌƒtƒHƒ“ƒgƒnƒ“ƒhƒ‹ */
-	HFONT	m_hFont_HAN_BOLD;		/* Œ»İ‚ÌƒtƒHƒ“ƒgƒnƒ“ƒhƒ‹(‘¾š) */
-	HFONT	m_hFont_HAN_UL;			/* Œ»İ‚ÌƒtƒHƒ“ƒgƒnƒ“ƒhƒ‹(‰ºü) */
-	HFONT	m_hFont_HAN_BOLD_UL;	/* Œ»İ‚ÌƒtƒHƒ“ƒgƒnƒ“ƒhƒ‹(‘¾šA‰ºü) */
+	HFONT	m_hFont_HAN;			/* ç¾åœ¨ã®ãƒ•ã‚©ãƒ³ãƒˆãƒãƒ³ãƒ‰ãƒ« */
+	HFONT	m_hFont_HAN_BOLD;		/* ç¾åœ¨ã®ãƒ•ã‚©ãƒ³ãƒˆãƒãƒ³ãƒ‰ãƒ«(å¤ªå­—) */
+	HFONT	m_hFont_HAN_UL;			/* ç¾åœ¨ã®ãƒ•ã‚©ãƒ³ãƒˆãƒãƒ³ãƒ‰ãƒ«(ä¸‹ç·š) */
+	HFONT	m_hFont_HAN_BOLD_UL;	/* ç¾åœ¨ã®ãƒ•ã‚©ãƒ³ãƒˆãƒãƒ³ãƒ‰ãƒ«(å¤ªå­—ã€ä¸‹ç·š) */
 
 	LOGFONT	m_LogFont;
 	bool	m_bMiniMap;

--- a/sakura_core/view/CViewParser.cpp
+++ b/sakura_core/view/CViewParser.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "CViewParser.h"
 #include "doc/CEditDoc.h"
 #include "doc/layout/CLayout.h"
@@ -6,8 +6,8 @@
 #include "charset/charcode.h"
 
 /*
-	ƒJ[ƒ\ƒ‹’¼‘O‚Ì’PŒê‚ðŽæ“¾ ’PŒê‚Ì’·‚³‚ð•Ô‚µ‚Ü‚·
-	’PŒê‹æØ‚è
+	ã‚«ãƒ¼ã‚½ãƒ«ç›´å‰ã®å˜èªžã‚’å–å¾— å˜èªžã®é•·ã•ã‚’è¿”ã—ã¾ã™
+	å˜èªžåŒºåˆ‡ã‚Š
 */
 int CViewParser::GetLeftWord( CNativeW* pcmemWord, int nMaxWordLen ) const
 {
@@ -27,7 +27,7 @@ int CViewParser::GetLeftWord( CNativeW* pcmemWord, int nMaxWordLen ) const
 //		return 0;
 		nIdxTo = CLogicInt(0);
 	}else{
-		/* Žw’è‚³‚ê‚½Œ…‚É‘Î‰ž‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ð’²‚×‚é Ver1 */
+		/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ Ver1 */
 		nIdxTo = m_pEditView->LineColumnToIndex( pcLayout, m_pEditView->GetCaret().GetCaretLayoutPos().GetX2() );
 	}
 	if( 0 == nIdxTo || NULL == pLine ){
@@ -65,7 +65,7 @@ int CViewParser::GetLeftWord( CNativeW* pcmemWord, int nMaxWordLen ) const
 		}
 	}
 
-	/* Œ»ÝˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ð’²‚×‚é */
+	/* ç¾åœ¨ä½ç½®ã®å˜èªžã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 	CLayoutRange sRange;
 	bool bResult = m_pEditView->m_pcEditDoc->m_cLayoutMgr.WhereCurrentWord(
 		nCurLine,
@@ -85,13 +85,13 @@ int CViewParser::GetLeftWord( CNativeW* pcmemWord, int nMaxWordLen ) const
 
 
 /*!
-	ƒLƒƒƒŒƒbƒgˆÊ’u‚Ì’PŒê‚ðŽæ“¾
-	’PŒê‹æØ‚è
+	ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã®å˜èªžã‚’å–å¾—
+	å˜èªžåŒºåˆ‡ã‚Š
 
-	@param[out] pcmemWord ƒLƒƒƒŒƒbƒgˆÊ’u‚Ì’PŒê
-	@return true: ¬Œ÷Cfalse: Ž¸”s
+	@param[out] pcmemWord ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã®å˜èªž
+	@return true: æˆåŠŸï¼Œfalse: å¤±æ•—
 	
-	@date 2006.03.24 fon (CEditView::Command_SELECTWORD‚ð—¬—p)
+	@date 2006.03.24 fon (CEditView::Command_SELECTWORDã‚’æµç”¨)
 */
 bool CViewParser::GetCurrentWord(
 	CNativeW* pcmemWord
@@ -99,13 +99,13 @@ bool CViewParser::GetCurrentWord(
 {
 	const CLayout*	pcLayout = m_pEditView->m_pcEditDoc->m_cLayoutMgr.SearchLineByLayoutY( m_pEditView->GetCaret().GetCaretLayoutPos().GetY2() );
 	if( NULL == pcLayout ){
-		return false;	/* ’PŒê‘I‘ð‚ÉŽ¸”s */
+		return false;	/* å˜èªžé¸æŠžã«å¤±æ•— */
 	}
 
-	/* Žw’è‚³‚ê‚½Œ…‚É‘Î‰ž‚·‚és‚Ìƒf[ƒ^“à‚ÌˆÊ’u‚ð’²‚×‚é */
+	/* æŒ‡å®šã•ã‚ŒãŸæ¡ã«å¯¾å¿œã™ã‚‹è¡Œã®ãƒ‡ãƒ¼ã‚¿å†…ã®ä½ç½®ã‚’èª¿ã¹ã‚‹ */
 	CLogicInt		nIdx = m_pEditView->LineColumnToIndex( pcLayout, m_pEditView->GetCaret().GetCaretLayoutPos().GetX2() );
 
-	/* Œ»ÝˆÊ’u‚Ì’PŒê‚Ì”ÍˆÍ‚ð’²‚×‚é */
+	/* ç¾åœ¨ä½ç½®ã®å˜èªžã®ç¯„å›²ã‚’èª¿ã¹ã‚‹ */
 	CLayoutRange sRange;
 	bool bResult = m_pEditView->m_pcEditDoc->m_cLayoutMgr.WhereCurrentWord(
 		m_pEditView->GetCaret().GetCaretLayoutPos().GetY2(),

--- a/sakura_core/view/CViewParser.h
+++ b/sakura_core/view/CViewParser.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,16 +26,16 @@
 
 class CEditView;
 
-//!•iŒ‰ğÍƒNƒ‰ƒX
+//!å“è©è§£æã‚¯ãƒ©ã‚¹
 class CViewParser{
 public:
 	CViewParser(const CEditView* pEditView) : m_pEditView(pEditView) { }
 	virtual ~CViewParser(){}
 
-	//! ƒJ[ƒ\ƒ‹’¼‘O‚Ì’PŒê‚ğæ“¾
+	//! ã‚«ãƒ¼ã‚½ãƒ«ç›´å‰ã®å˜èªã‚’å–å¾—
 	int GetLeftWord( CNativeW* pcmemWord, int nMaxWordLen ) const;
 
-	//! ƒLƒƒƒŒƒbƒgˆÊ’u‚Ì’PŒê‚ğæ“¾
+	//! ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ã®å˜èªã‚’å–å¾—
 	// 2006.03.24 fon
 	bool GetCurrentWord( CNativeW* pcmemWord ) const;
 

--- a/sakura_core/view/CViewSelect.cpp
+++ b/sakura_core/view/CViewSelect.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include <limits.h>
 #include "CViewSelect.h"
 #include "CEditView.h"
@@ -15,33 +15,33 @@
 CViewSelect::CViewSelect(CEditView* pcEditView)
 : m_pcEditView(pcEditView)
 {
-	m_bSelectingLock   = false;	// ‘I‘ğó‘Ô‚ÌƒƒbƒN
-	m_bBeginSelect     = false;		// ”ÍˆÍ‘I‘ğ’†
-	m_bBeginBoxSelect  = false;	// ‹éŒ`”ÍˆÍ‘I‘ğ’†
-	m_bBeginLineSelect = false;	// s’PˆÊ‘I‘ğ’†
-	m_bBeginWordSelect = false;	// ’PŒê’PˆÊ‘I‘ğ’†
+	m_bSelectingLock   = false;	// é¸æŠçŠ¶æ…‹ã®ãƒ­ãƒƒã‚¯
+	m_bBeginSelect     = false;		// ç¯„å›²é¸æŠä¸­
+	m_bBeginBoxSelect  = false;	// çŸ©å½¢ç¯„å›²é¸æŠä¸­
+	m_bBeginLineSelect = false;	// è¡Œå˜ä½é¸æŠä¸­
+	m_bBeginWordSelect = false;	// å˜èªå˜ä½é¸æŠä¸­
 
-	m_sSelectBgn.Clear(-1); // ”ÍˆÍ‘I‘ğ(Œ´“_)
-	m_sSelect   .Clear(-1); // ”ÍˆÍ‘I‘ğ
-	m_sSelectOld.Clear(0);  // ”ÍˆÍ‘I‘ğ(Old)
-	m_bSelectAreaChanging = false;	// ‘I‘ğ”ÍˆÍ•ÏX’†
-	m_nLastSelectedByteLen = 0;	// ‘O‰ñ‘I‘ğ‚Ì‘I‘ğƒoƒCƒg”
+	m_sSelectBgn.Clear(-1); // ç¯„å›²é¸æŠ(åŸç‚¹)
+	m_sSelect   .Clear(-1); // ç¯„å›²é¸æŠ
+	m_sSelectOld.Clear(0);  // ç¯„å›²é¸æŠ(Old)
+	m_bSelectAreaChanging = false;	// é¸æŠç¯„å›²å¤‰æ›´ä¸­
+	m_nLastSelectedByteLen = 0;	// å‰å›é¸æŠæ™‚ã®é¸æŠãƒã‚¤ãƒˆæ•°
 }
 
 void CViewSelect::CopySelectStatus(CViewSelect* pSelect) const
 {
-	pSelect->m_bSelectingLock		= m_bSelectingLock;		/* ‘I‘ğó‘Ô‚ÌƒƒbƒN */
-	pSelect->m_bBeginSelect			= m_bBeginSelect;		/* ”ÍˆÍ‘I‘ğ’† */
-	pSelect->m_bBeginBoxSelect		= m_bBeginBoxSelect;	/* ‹éŒ`”ÍˆÍ‘I‘ğ’† */
+	pSelect->m_bSelectingLock		= m_bSelectingLock;		/* é¸æŠçŠ¶æ…‹ã®ãƒ­ãƒƒã‚¯ */
+	pSelect->m_bBeginSelect			= m_bBeginSelect;		/* ç¯„å›²é¸æŠä¸­ */
+	pSelect->m_bBeginBoxSelect		= m_bBeginBoxSelect;	/* çŸ©å½¢ç¯„å›²é¸æŠä¸­ */
 
-	pSelect->m_sSelectBgn			= m_sSelectBgn;			//”ÍˆÍ‘I‘ğ(Œ´“_)
-	pSelect->m_sSelect				= m_sSelect;			//”ÍˆÍ‘I‘ğ
-	pSelect->m_sSelectOld			= m_sSelectOld;			//”ÍˆÍ‘I‘ğ
+	pSelect->m_sSelectBgn			= m_sSelectBgn;			//ç¯„å›²é¸æŠ(åŸç‚¹)
+	pSelect->m_sSelect				= m_sSelect;			//ç¯„å›²é¸æŠ
+	pSelect->m_sSelectOld			= m_sSelectOld;			//ç¯„å›²é¸æŠ
 
-	pSelect->m_ptMouseRollPosOld	= m_ptMouseRollPosOld;	// ƒ}ƒEƒX”ÍˆÍ‘I‘ğ‘O‰ñˆÊ’u(XYÀ•W)
+	pSelect->m_ptMouseRollPosOld	= m_ptMouseRollPosOld;	// ãƒã‚¦ã‚¹ç¯„å›²é¸æŠå‰å›ä½ç½®(XYåº§æ¨™)
 }
 
-//! Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é
+//! ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹
 void CViewSelect::BeginSelectArea( const CLayoutPoint* po )
 {
 	const CEditView* pView=GetEditView();
@@ -50,58 +50,58 @@ void CViewSelect::BeginSelectArea( const CLayoutPoint* po )
 		temp = pView->GetCaret().GetCaretLayoutPos();
 		po = &temp;
 	}
-	m_sSelectBgn.Set(*po); //”ÍˆÍ‘I‘ğ(Œ´“_)
-	m_sSelect.   Set(*po); //”ÍˆÍ‘I‘ğ
+	m_sSelectBgn.Set(*po); //ç¯„å›²é¸æŠ(åŸç‚¹)
+	m_sSelect.   Set(*po); //ç¯„å›²é¸æŠ
 }
 
 
-// Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚·
+// ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™
 void CViewSelect::DisableSelectArea( bool bDraw, bool bDrawBracketCursorLine )
 {
 	const CEditView* pView=GetEditView();
 	CEditView* pView2=GetEditView();
 
-	m_sSelectOld = m_sSelect;		//”ÍˆÍ‘I‘ğ(Old)
+	m_sSelectOld = m_sSelect;		//ç¯„å›²é¸æŠ(Old)
 	m_sSelect.Clear(-1);
-	m_bSelectingLock	 = false;	// ‘I‘ğó‘Ô‚ÌƒƒbƒN
+	m_bSelectingLock	 = false;	// é¸æŠçŠ¶æ…‹ã®ãƒ­ãƒƒã‚¯
 
 	if( bDraw ){
 		DrawSelectArea( bDrawBracketCursorLine );
 	}
-	m_bDrawSelectArea = false;	// 02/12/13 ai // 2011.12.24 bDrawŠ‡ŒÊ“à‚©‚çˆÚ“®
+	m_bDrawSelectArea = false;	// 02/12/13 ai // 2011.12.24 bDrawæ‹¬å¼§å†…ã‹ã‚‰ç§»å‹•
 
-	m_sSelectOld.Clear(0);			// ”ÍˆÍ‘I‘ğ(Old)
-	m_bBeginBoxSelect = false;		// ‹éŒ`”ÍˆÍ‘I‘ğ’†
-	m_bBeginLineSelect = false;		// s’PˆÊ‘I‘ğ’†
-	m_bBeginWordSelect = false;		// ’PŒê’PˆÊ‘I‘ğ’†
-	m_nLastSelectedByteLen = 0;		// ‘O‰ñ‘I‘ğ‚Ì‘I‘ğƒoƒCƒg”
+	m_sSelectOld.Clear(0);			// ç¯„å›²é¸æŠ(Old)
+	m_bBeginBoxSelect = false;		// çŸ©å½¢ç¯„å›²é¸æŠä¸­
+	m_bBeginLineSelect = false;		// è¡Œå˜ä½é¸æŠä¸­
+	m_bBeginWordSelect = false;		// å˜èªå˜ä½é¸æŠä¸­
+	m_nLastSelectedByteLen = 0;		// å‰å›é¸æŠæ™‚ã®é¸æŠãƒã‚¤ãƒˆæ•°
 
-	// 2002.02.16 hor ’¼‘O‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚ğƒŠƒZƒbƒg
+	// 2002.02.16 hor ç›´å‰ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‚’ãƒªã‚»ãƒƒãƒˆ
 	pView2->GetCaret().m_nCaretPosX_Prev=pView->GetCaret().GetCaretLayoutPos().GetX();
 
 }
 
 
 
-// Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX
+// ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´
 void CViewSelect::ChangeSelectAreaByCurrentCursor( const CLayoutPoint& ptCaretPos )
 {
-	m_sSelectOld=m_sSelect; // ”ÍˆÍ‘I‘ğ(Old)
+	m_sSelectOld=m_sSelect; // ç¯„å›²é¸æŠ(Old)
 
-	//	2002/04/08 YAZAKI ƒR[ƒh‚Ìd•¡‚ğ”rœ
+	//	2002/04/08 YAZAKI ã‚³ãƒ¼ãƒ‰ã®é‡è¤‡ã‚’æ’é™¤
 	ChangeSelectAreaByCurrentCursorTEST(
 		ptCaretPos,
 		&m_sSelect
 	);
 
-	// ‘I‘ğ—Ìˆæ‚Ì•`‰æ
+	// é¸æŠé ˜åŸŸã®æç”»
 	m_bSelectAreaChanging = true;
 	DrawSelectArea(true);
 	m_bSelectAreaChanging = false;
 }
 
 
-// Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX(ƒeƒXƒg‚Ì‚İ)
+// ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´(ãƒ†ã‚¹ãƒˆã®ã¿)
 void CViewSelect::ChangeSelectAreaByCurrentCursorTEST(
 	const CLayoutPoint& ptCaretPos,
 	CLayoutRange* pSelect
@@ -109,11 +109,11 @@ void CViewSelect::ChangeSelectAreaByCurrentCursorTEST(
 {
 	if(m_sSelectBgn.GetFrom()==m_sSelectBgn.GetTo()){
 		if( ptCaretPos==m_sSelectBgn.GetFrom() ){
-			// ‘I‘ğ‰ğœ
+			// é¸æŠè§£é™¤
 			pSelect->Clear(-1);
-			m_nLastSelectedByteLen = 0;		// ‘O‰ñ‘I‘ğ‚Ì‘I‘ğƒoƒCƒg”
+			m_nLastSelectedByteLen = 0;		// å‰å›é¸æŠæ™‚ã®é¸æŠãƒã‚¤ãƒˆæ•°
 		}
-		else if( PointCompare(ptCaretPos,m_sSelectBgn.GetFrom() ) < 0 ){ //ƒLƒƒƒŒƒbƒgˆÊ’u‚ªm_sSelectBgn‚Ìfrom‚æ‚è¬‚³‚©‚Á‚½‚ç
+		else if( PointCompare(ptCaretPos,m_sSelectBgn.GetFrom() ) < 0 ){ //ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ãŒm_sSelectBgnã®fromã‚ˆã‚Šå°ã•ã‹ã£ãŸã‚‰
 			 pSelect->SetFrom(ptCaretPos);
 			 pSelect->SetTo(m_sSelectBgn.GetFrom());
 		}
@@ -123,8 +123,8 @@ void CViewSelect::ChangeSelectAreaByCurrentCursorTEST(
 		}
 	}
 	else{
-		// í‘I‘ğ”ÍˆÍ‚Ì”ÍˆÍ“à
-		// ƒLƒƒƒŒƒbƒgˆÊ’u‚ª m_sSelectBgn ‚Ì fromˆÈã‚ÅAto‚æ‚è¬‚³‚¢ê‡
+		// å¸¸æ™‚é¸æŠç¯„å›²ã®ç¯„å›²å†…
+		// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ãŒ m_sSelectBgn ã® fromä»¥ä¸Šã§ã€toã‚ˆã‚Šå°ã•ã„å ´åˆ
 		if( PointCompare(ptCaretPos,m_sSelectBgn.GetFrom()) >= 0 && PointCompare(ptCaretPos,m_sSelectBgn.GetTo()) < 0 ){
 			pSelect->SetFrom(m_sSelectBgn.GetFrom());
 			if ( ptCaretPos==m_sSelectBgn.GetFrom() ){
@@ -134,14 +134,14 @@ void CViewSelect::ChangeSelectAreaByCurrentCursorTEST(
 				pSelect->SetTo(ptCaretPos);
 			}
 		}
-		//ƒLƒƒƒŒƒbƒgˆÊ’u‚ªm_sSelectBgn‚Ìfrom‚æ‚è¬‚³‚©‚Á‚½‚ç
+		//ã‚­ãƒ£ãƒ¬ãƒƒãƒˆä½ç½®ãŒm_sSelectBgnã®fromã‚ˆã‚Šå°ã•ã‹ã£ãŸã‚‰
 		else if( PointCompare(ptCaretPos,m_sSelectBgn.GetFrom()) < 0 ){
-			// í‘I‘ğ”ÍˆÍ‚Ì‘O•ûŒü
+			// å¸¸æ™‚é¸æŠç¯„å›²ã®å‰æ–¹å‘
 			pSelect->SetFrom(ptCaretPos);
 			pSelect->SetTo(m_sSelectBgn.GetTo());
 		}
 		else{
-			// í‘I‘ğ”ÍˆÍ‚ÌŒã‚ë•ûŒü
+			// å¸¸æ™‚é¸æŠç¯„å›²ã®å¾Œã‚æ–¹å‘
 			pSelect->SetFrom(m_sSelectBgn.GetFrom());
 			pSelect->SetTo(ptCaretPos);
 		}
@@ -150,11 +150,11 @@ void CViewSelect::ChangeSelectAreaByCurrentCursorTEST(
 
 
 
-/*! ‘I‘ğ—Ìˆæ‚Ì•`‰æ
+/*! é¸æŠé ˜åŸŸã®æç”»
 
-	@date 2006.10.01 Moca d•¡ƒR[ƒhíœD‹éŒ`ì‰æ‰ü‘PD
-	@date 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
-		‰æ–Êƒoƒbƒtƒ@‚ª—LŒøA‰æ–Ê‚ÆŒİŠ·BMP‚Ì—¼•û‚Ì”½“]ˆ—‚ğs‚¤B
+	@date 2006.10.01 Moca é‡è¤‡ã‚³ãƒ¼ãƒ‰å‰Šé™¤ï¼çŸ©å½¢ä½œç”»æ”¹å–„ï¼
+	@date 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
+		ç”»é¢ãƒãƒƒãƒ•ã‚¡ãŒæœ‰åŠ¹æ™‚ã€ç”»é¢ã¨äº’æ›BMPã®ä¸¡æ–¹ã®åè»¢å‡¦ç†ã‚’è¡Œã†ã€‚
 */
 void CViewSelect::DrawSelectArea(bool bDrawBracketCursorLine)
 {
@@ -168,14 +168,14 @@ void CViewSelect::DrawSelectArea(bool bDrawBracketCursorLine)
 	bool bDispText = CTypeSupport(pView,COLORIDX_SELECT).IsDisp();
 	if( bDispText ){
 		if( m_sSelect != m_sSelectOld ){
-			// ‘I‘ğF•\¦‚Ì‚ÍAWM_PAINTŒo—R‚Åì‰æ
+			// é¸æŠè‰²è¡¨ç¤ºã®æ™‚ã¯ã€WM_PAINTçµŒç”±ã§ä½œç”»
 			const int nCharWidth = pView->GetTextMetrics().GetCharPxWidth();
 			const CTextArea& area =  pView->GetTextArea();
 			CLayoutRect rcOld; // CLayoutRect
 			TwoPointToRect( &rcOld, m_sSelectOld.GetFrom(), m_sSelectOld.GetTo() );
 			CLayoutRect rcNew; // CLayoutRect
 			TwoPointToRect( &rcNew, m_sSelect.GetFrom(), m_sSelect.GetTo() );
-			CLayoutRect rc; // CLayoutRect ‚½‚¾‚µtop,bottom‚¾‚¯g‚¤
+			CLayoutRect rc; // CLayoutRect ãŸã ã—top,bottomã ã‘ä½¿ã†
 			CLayoutInt drawLeft = CLayoutInt(0);
 			CLayoutInt drawRight = CLayoutInt(-1);
 			if( !m_sSelect.IsValid() ){
@@ -189,17 +189,17 @@ void CViewSelect::DrawSelectArea(bool bDrawBracketCursorLine)
 				rc.UnionStrictRect(rcOld, rcNew);
 			}else if(!IsBoxSelecting() && rcOld.top == rcNew.top && rcOld.bottom == rcNew.bottom){
 				if(m_sSelect.GetFrom() == m_sSelectOld.GetFrom() && m_sSelect.GetTo().x != m_sSelectOld.GetTo().x){
-					// GetTo‚Ìs‚ª‘ÎÛ
+					// GetToã®è¡ŒãŒå¯¾è±¡
 					rc.top = rc.bottom = m_sSelect.GetTo().GetY2();
 					drawLeft  = t_min(m_sSelect.GetTo().x, m_sSelectOld.GetTo().x);
 					drawRight = t_max(m_sSelect.GetTo().x, m_sSelectOld.GetTo().x)
-						+ pView->GetTextMetrics().GetLayoutXDefault() + 4; // ‰üsƒR[ƒh••ª—]•ª‚Éæ‚é
+						+ pView->GetTextMetrics().GetLayoutXDefault() + 4; // æ”¹è¡Œã‚³ãƒ¼ãƒ‰å¹…åˆ†ä½™åˆ†ã«å–ã‚‹
 				}else if(m_sSelect.GetTo() == m_sSelectOld.GetTo() && m_sSelect.GetFrom().x != m_sSelectOld.GetFrom().x){
-					// GetFrom‚Ìs‚ª‘ÎÛ
+					// GetFromã®è¡ŒãŒå¯¾è±¡
 					rc.top = rc.bottom = m_sSelect.GetFrom().GetY2();
 					drawLeft  = t_min(m_sSelectOld.GetFrom().x, m_sSelect.GetFrom().x);
 					drawRight = t_max(m_sSelectOld.GetFrom().x, m_sSelect.GetFrom().x)
-						+ pView->GetTextMetrics().GetLayoutXDefault() + 4; // ‰üsƒR[ƒh••ª—]•ª‚Éæ‚é
+						+ pView->GetTextMetrics().GetLayoutXDefault() + 4; // æ”¹è¡Œã‚³ãƒ¼ãƒ‰å¹…åˆ†ä½™åˆ†ã«å–ã‚‹
 				}else{
 					rc.UnionStrictRect(rcOld, rcNew);
 				}
@@ -214,7 +214,7 @@ void CViewSelect::DrawSelectArea(bool bDrawBracketCursorLine)
 			}
 			CMyRect rcPx;
 			if( pView->IsBkBitmap() ||  drawRight == -1){
-				// ”wŒi•\¦‚ÌƒNƒŠƒbƒsƒ“ƒO‚ªŠÃ‚¢‚Ì‚Å¶‰E‚ğw’è‚µ‚È‚¢
+				// èƒŒæ™¯è¡¨ç¤ºã®ã‚¯ãƒªãƒƒãƒ”ãƒ³ã‚°ãŒç”˜ã„ã®ã§å·¦å³ã‚’æŒ‡å®šã—ãªã„
 				rcPx.left   =  0;
 				rcPx.right  = SHRT_MAX; 
 			}else{
@@ -232,14 +232,14 @@ void CViewSelect::DrawSelectArea(bool bDrawBracketCursorLine)
 				HDC hdc = view.GetDC();
 				PAINTSTRUCT ps;
 				ps.rcPaint = rcUpdate;
-				// DrawSelectAreaLine‚Å‚Ì‰ºüOFF‚Ì‘ã‚í‚è
+				// DrawSelectAreaLineã§ã®ä¸‹ç·šOFFã®ä»£ã‚ã‚Š
 				view.GetCaret().m_cUnderLine.CaretUnderLineOFF(true, false);
 				view.GetCaret().m_cUnderLine.Lock();
 				view.OnPaint(hdc, &ps, false);
 				view.GetCaret().m_cUnderLine.UnLock();
 				view.ReleaseDC( hdc );
 			}
-			// 2010.10.10 0•‘I‘ğ(‰ğœ)ó‘Ô‚Å‚ÌAƒJ[ƒ\ƒ‹ˆÊ’uƒ‰ƒCƒ“•œ‹A(ƒŠ[ƒWƒ‡ƒ“ŠO)
+			// 2010.10.10 0å¹…é¸æŠ(è§£é™¤)çŠ¶æ…‹ã§ã®ã€ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ãƒ©ã‚¤ãƒ³å¾©å¸°(ãƒªãƒ¼ã‚¸ãƒ§ãƒ³å¤–)
 			if( bDrawBracketCursorLine ){
 				view.GetCaret().m_cUnderLine.CaretUnderLineON(true, false);
 			}
@@ -252,16 +252,16 @@ void CViewSelect::DrawSelectArea(bool bDrawBracketCursorLine)
 		}
 		HDC hdc = pView->GetDC();
 		DrawSelectArea2( hdc );
-		// 2011.12.02 ‘I‘ğ‰ğœó‘Ô‚Å‚ÌAƒJ[ƒ\ƒ‹ˆÊ’uƒ‰ƒCƒ“•œ‹A
+		// 2011.12.02 é¸æŠè§£é™¤çŠ¶æ…‹ã§ã®ã€ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ãƒ©ã‚¤ãƒ³å¾©å¸°
 		if( bDrawBracketCursorLine ){
 			pView->GetCaret().m_cUnderLine.CaretUnderLineON(true, false);
 		}
 		pView->ReleaseDC( hdc );
 	}
 
-	// 2011.12.02 ‘I‘ğ‰ğœó‘Ô‚É‚È‚é‚Æ‘ÎŠ‡ŒÊ‹­’²‚ª‚Å‚«‚È‚­‚È‚éƒoƒO‘Îô
+	// 2011.12.02 é¸æŠè§£é™¤çŠ¶æ…‹ã«ãªã‚‹ã¨å¯¾æ‹¬å¼§å¼·èª¿ãŒã§ããªããªã‚‹ãƒã‚°å¯¾ç­–
 	if( !IsTextSelecting() ){
-		// ‚½‚¾‚µ‘I‘ğƒƒbƒN’†‚Í‚±‚±‚Å‚Í‹­’²•\¦‚³‚ê‚È‚¢
+		// ãŸã ã—é¸æŠãƒ­ãƒƒã‚¯ä¸­ã¯ã“ã“ã§ã¯å¼·èª¿è¡¨ç¤ºã•ã‚Œãªã„
 		m_bDrawSelectArea = false;
 		if( bDrawBracketCursorLine ){
 			pView->SetBracketPairPos( true );
@@ -269,22 +269,22 @@ void CViewSelect::DrawSelectArea(bool bDrawBracketCursorLine)
 		}
 	}
 
-	//	Jul. 9, 2005 genta ‘I‘ğ—Ìˆæ‚Ìî•ñ‚ğ•\¦
+	//	Jul. 9, 2005 genta é¸æŠé ˜åŸŸã®æƒ…å ±ã‚’è¡¨ç¤º
 	PrintSelectionInfoMsg();
 }
 
 /*!
-	”½“]—pÄì‰æˆ—–{‘Ì
+	åè»¢ç”¨å†ä½œç”»å‡¦ç†æœ¬ä½“
 */
 void CViewSelect::DrawSelectArea2( HDC hdc ) const
 {
 	CEditView const * const pView = GetEditView();
 
-	// 2006.10.01 Moca d•¡ƒR[ƒh“‡
+	// 2006.10.01 Moca é‡è¤‡ã‚³ãƒ¼ãƒ‰çµ±åˆ
 	HBRUSH      hBrush = ::CreateSolidBrush( SELECTEDAREA_RGB );
 	HBRUSH      hBrushOld = (HBRUSH)::SelectObject( hdc, hBrush );
 	int         nROP_Old = ::SetROP2( hdc, SELECTEDAREA_ROP2 );
-	// From Here 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
+	// From Here 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
 	HBRUSH		hBrushCompatOld = 0;
 	int			nROPCompatOld = 0;
 	bool bCompatBMP = pView->m_hbmpCompatBMP && hdc != pView->m_hdcCompatDC;
@@ -295,10 +295,10 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 	// To Here 2007.09.09 Moca
 
 //	MYTRACE( _T("DrawSelectArea()  m_bBeginBoxSelect=%hs\n", m_bBeginBoxSelect?"true":"false") );
-	if( IsBoxSelecting() ){		// ‹éŒ`”ÍˆÍ‘I‘ğ’†
-		// 2001.12.21 hor ‹éŒ`ƒGƒŠƒA‚ÉEOF‚ª‚ ‚éê‡ARGN_XOR‚ÅŒ‹‡‚·‚é‚Æ
-		// EOFˆÈ~‚ÌƒGƒŠƒA‚à”½“]‚µ‚Ä‚µ‚Ü‚¤‚Ì‚ÅA‚±‚Ìê‡‚ÍRedraw‚ğg‚¤
-		// 2002.02.16 hor ‚¿‚ç‚Â‚«‚ğ—}~‚·‚é‚½‚ßEOFˆÈ~‚ÌƒGƒŠƒA‚ª”½“]‚µ‚½‚ç‚à‚¤ˆê“x”½“]‚µ‚ÄŒ³‚É–ß‚·‚±‚Æ‚É‚·‚é
+	if( IsBoxSelecting() ){		// çŸ©å½¢ç¯„å›²é¸æŠä¸­
+		// 2001.12.21 hor çŸ©å½¢ã‚¨ãƒªã‚¢ã«EOFãŒã‚ã‚‹å ´åˆã€RGN_XORã§çµåˆã™ã‚‹ã¨
+		// EOFä»¥é™ã®ã‚¨ãƒªã‚¢ã‚‚åè»¢ã—ã¦ã—ã¾ã†ã®ã§ã€ã“ã®å ´åˆã¯Redrawã‚’ä½¿ã†
+		// 2002.02.16 hor ã¡ã‚‰ã¤ãã‚’æŠ‘æ­¢ã™ã‚‹ãŸã‚EOFä»¥é™ã®ã‚¨ãƒªã‚¢ãŒåè»¢ã—ãŸã‚‰ã‚‚ã†ä¸€åº¦åè»¢ã—ã¦å…ƒã«æˆ»ã™ã“ã¨ã«ã™ã‚‹
 		//if((GetTextArea().GetViewTopLine()+m_nViewRowNum+1>=m_pcEditDoc->m_cLayoutMgr.GetLineCount()) &&
 		//   (m_sSelect.GetTo().y+1 >= m_pcEditDoc->m_cLayoutMgr.GetLineCount() ||
 		//	m_sSelectOld.GetTo().y+1 >= m_pcEditDoc->m_cLayoutMgr.GetLineCount() ) ) {
@@ -310,18 +310,18 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 		const int nCharHeight = pView->GetTextMetrics().GetHankakuDy();
 
 
-		// 2“_‚ğ‘ÎŠp‚Æ‚·‚é‹éŒ`‚ğ‹‚ß‚é
+		// 2ç‚¹ã‚’å¯¾è§’ã¨ã™ã‚‹çŸ©å½¢ã‚’æ±‚ã‚ã‚‹
 		CLayoutRect  rcOld;
 		TwoPointToRect(
 			&rcOld,
-			m_sSelectOld.GetFrom(),	// ”ÍˆÍ‘I‘ğŠJn
-			m_sSelectOld.GetTo()	// ”ÍˆÍ‘I‘ğI—¹
+			m_sSelectOld.GetFrom(),	// ç¯„å›²é¸æŠé–‹å§‹
+			m_sSelectOld.GetTo()	// ç¯„å›²é¸æŠçµ‚äº†
 		);
 		rcOld.left   = t_max(rcOld.left  , pView->GetTextArea().GetViewLeftCol()  );
 		rcOld.right  = t_max(rcOld.right , pView->GetTextArea().GetViewLeftCol()  );
 		rcOld.right  = t_min(rcOld.right , pView->GetTextArea().GetRightCol() + 1 );
 		rcOld.top    = t_max(rcOld.top   , pView->GetTextArea().GetViewTopLine()  );
-		rcOld.bottom = t_max(rcOld.bottom, pView->GetTextArea().GetViewTopLine() - 1);	// 2010.11.02 ryoji ’Ç‰Ái‰æ–Êã’[‚æ‚è‚àã‚É‚ ‚é‹éŒ`‘I‘ğ‚ğ‰ğœ‚·‚é‚Æƒ‹[ƒ‰[‚ª”½“]•\¦‚É‚È‚é–â‘è‚ÌC³j
+		rcOld.bottom = t_max(rcOld.bottom, pView->GetTextArea().GetViewTopLine() - 1);	// 2010.11.02 ryoji è¿½åŠ ï¼ˆç”»é¢ä¸Šç«¯ã‚ˆã‚Šã‚‚ä¸Šã«ã‚ã‚‹çŸ©å½¢é¸æŠã‚’è§£é™¤ã™ã‚‹ã¨ãƒ«ãƒ¼ãƒ©ãƒ¼ãŒåè»¢è¡¨ç¤ºã«ãªã‚‹å•é¡Œã®ä¿®æ­£ï¼‰
 		rcOld.bottom = t_min(rcOld.bottom, pView->GetTextArea().GetBottomLine()   );
 
 		RECT rcOld2;
@@ -331,18 +331,18 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 		rcOld2.bottom	= pView->GetTextArea().GenerateYPx( rcOld.bottom + 1 );
 		HRGN hrgnOld = ::CreateRectRgnIndirect( &rcOld2 );
 
-		// 2“_‚ğ‘ÎŠp‚Æ‚·‚é‹éŒ`‚ğ‹‚ß‚é
+		// 2ç‚¹ã‚’å¯¾è§’ã¨ã™ã‚‹çŸ©å½¢ã‚’æ±‚ã‚ã‚‹
 		CLayoutRect  rcNew;
 		TwoPointToRect(
 			&rcNew,
-			m_sSelect.GetFrom(),	// ”ÍˆÍ‘I‘ğŠJn
-			m_sSelect.GetTo()		// ”ÍˆÍ‘I‘ğI—¹
+			m_sSelect.GetFrom(),	// ç¯„å›²é¸æŠé–‹å§‹
+			m_sSelect.GetTo()		// ç¯„å›²é¸æŠçµ‚äº†
 		);
 		rcNew.left   = t_max(rcNew.left  , pView->GetTextArea().GetViewLeftCol() );
 		rcNew.right  = t_max(rcNew.right , pView->GetTextArea().GetViewLeftCol() );
 		rcNew.right  = t_min(rcNew.right , pView->GetTextArea().GetRightCol() + 1);
 		rcNew.top    = t_max(rcNew.top   , pView->GetTextArea().GetViewTopLine() );
-		rcNew.bottom = t_max(rcNew.bottom, pView->GetTextArea().GetViewTopLine() - 1);	// 2010.11.02 ryoji ’Ç‰Ái‰æ–Êã’[‚æ‚è‚àã‚É‚ ‚é‹éŒ`‘I‘ğ‚ğ‰ğœ‚·‚é‚Æƒ‹[ƒ‰[‚ª”½“]•\¦‚É‚È‚é–â‘è‚ÌC³j
+		rcNew.bottom = t_max(rcNew.bottom, pView->GetTextArea().GetViewTopLine() - 1);	// 2010.11.02 ryoji è¿½åŠ ï¼ˆç”»é¢ä¸Šç«¯ã‚ˆã‚Šã‚‚ä¸Šã«ã‚ã‚‹çŸ©å½¢é¸æŠã‚’è§£é™¤ã™ã‚‹ã¨ãƒ«ãƒ¼ãƒ©ãƒ¼ãŒåè»¢è¡¨ç¤ºã«ãªã‚‹å•é¡Œã®ä¿®æ­£ï¼‰
 		rcNew.bottom = t_min(rcNew.bottom, pView->GetTextArea().GetBottomLine()  );
 
 		RECT rcNew2;
@@ -353,23 +353,23 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 
 		HRGN hrgnNew = ::CreateRectRgnIndirect( &rcNew2 );
 
-		// ‹éŒ`ì‰æB
-		// ::CombineRgn()‚ÌŒ‹‰Ê‚ğó‚¯æ‚é‚½‚ß‚ÉA“K“–‚ÈƒŠ[ƒWƒ‡ƒ“‚ğì‚é
+		// çŸ©å½¢ä½œç”»ã€‚
+		// ::CombineRgn()ã®çµæœã‚’å—ã‘å–ã‚‹ãŸã‚ã«ã€é©å½“ãªãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã‚’ä½œã‚‹
 		HRGN hrgnDraw = ::CreateRectRgnIndirect( &rcNew2 );
 		{
-			// ‹Œ‘I‘ğ‹éŒ`‚ÆV‘I‘ğ‹éŒ`‚ÌƒŠ[ƒWƒ‡ƒ“‚ğŒ‹‡‚µ¤ d‚È‚è‚ ‚¤•”•ª‚¾‚¯‚ğœ‹‚µ‚Ü‚·
+			// æ—§é¸æŠçŸ©å½¢ã¨æ–°é¸æŠçŸ©å½¢ã®ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã‚’çµåˆã—ï½¤ é‡ãªã‚Šã‚ã†éƒ¨åˆ†ã ã‘ã‚’é™¤å»ã—ã¾ã™
 			if( NULLREGION != ::CombineRgn( hrgnDraw, hrgnOld, hrgnNew, RGN_XOR ) ){
 
 				// 2002.02.16 hor
-				// Œ‹‡Œã‚ÌƒGƒŠƒA‚ÉEOF‚ªŠÜ‚Ü‚ê‚éê‡‚ÍEOFˆÈ~‚Ì•”•ª‚ğœ‹‚µ‚Ü‚·
-				// 2006.10.01 Moca ƒŠ[ƒ\[ƒXƒŠ[ƒN‚ğC³‚µ‚½‚çAƒ`ƒ‰‚Â‚­‚æ‚¤‚É‚È‚Á‚½‚½‚ßA
-				// —}‚¦‚é‚½‚ß‚É EOFˆÈ~‚ğƒŠ[ƒWƒ‡ƒ“‚©‚çíœ‚µ‚Ä1“x‚Ìì‰æ‚É‚·‚é
+				// çµåˆå¾Œã®ã‚¨ãƒªã‚¢ã«EOFãŒå«ã¾ã‚Œã‚‹å ´åˆã¯EOFä»¥é™ã®éƒ¨åˆ†ã‚’é™¤å»ã—ã¾ã™
+				// 2006.10.01 Moca ãƒªãƒ¼ã‚½ãƒ¼ã‚¹ãƒªãƒ¼ã‚¯ã‚’ä¿®æ­£ã—ãŸã‚‰ã€ãƒãƒ©ã¤ãã‚ˆã†ã«ãªã£ãŸãŸã‚ã€
+				// æŠ‘ãˆã‚‹ãŸã‚ã« EOFä»¥é™ã‚’ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã‹ã‚‰å‰Šé™¤ã—ã¦1åº¦ã®ä½œç”»ã«ã™ã‚‹
 
-				// 2006.10.01 Moca Start EOFˆÊ’uŒvZ‚ğGetEndLayoutPos‚É‘‚«Š·‚¦B
+				// 2006.10.01 Moca Start EOFä½ç½®è¨ˆç®—ã‚’GetEndLayoutPosã«æ›¸ãæ›ãˆã€‚
 				CLayoutPoint ptLast;
 				pView->m_pcEditDoc->m_cLayoutMgr.GetEndLayoutPos( &ptLast );
 				// 2006.10.01 Moca End
-				// 2011.12.26 EOF‚Ì‚Ô‚ç‰º‚ª‚ès‚Í”½“]‚µAEOF‚Ì‚İ‚Ìs‚Í”½“]‚µ‚È‚¢
+				// 2011.12.26 EOFã®ã¶ã‚‰ä¸‹ãŒã‚Šè¡Œã¯åè»¢ã—ã€EOFã®ã¿ã®è¡Œã¯åè»¢ã—ãªã„
 				const CLayout* pBottom = pView->m_pcEditDoc->m_cLayoutMgr.GetBottomLayout();
 				if( pBottom && pBottom->GetLayoutEol() == EOL_NONE ){
 					ptLast.x = 0;
@@ -377,22 +377,22 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 				}
 				if(m_sSelect.GetFrom().y>=ptLast.y || m_sSelect.GetTo().y>=ptLast.y ||
 					m_sSelectOld.GetFrom().y>=ptLast.y || m_sSelectOld.GetTo().y>=ptLast.y){
-					//	Jan. 24, 2004 genta nLastLen‚Í•¨—Œ…‚È‚Ì‚Å•ÏŠ·•K—v
-					//	ÅIs‚ÉTAB‚ª“ü‚Á‚Ä‚¢‚é‚Æ”½“]”ÍˆÍ‚ª•s‘«‚·‚éD
-					//	2006.10.01 Moca GetEndLayoutPos‚Åˆ—‚·‚é‚½‚ßColumnToIndex‚Í•s—v‚ÉB
+					//	Jan. 24, 2004 genta nLastLenã¯ç‰©ç†æ¡ãªã®ã§å¤‰æ›å¿…è¦
+					//	æœ€çµ‚è¡Œã«TABãŒå…¥ã£ã¦ã„ã‚‹ã¨åè»¢ç¯„å›²ãŒä¸è¶³ã™ã‚‹ï¼
+					//	2006.10.01 Moca GetEndLayoutPosã§å‡¦ç†ã™ã‚‹ãŸã‚ColumnToIndexã¯ä¸è¦ã«ã€‚
 					RECT rcNew;
 					rcNew.left   = pView->GetTextArea().GetAreaLeft() + (Int)(pView->GetTextArea().GetViewLeftCol() + ptLast.x) * nCharWidth;
 					rcNew.right  = pView->GetTextArea().GetAreaRight();
 					rcNew.top    = pView->GetTextArea().GenerateYPx( ptLast.y );
 					rcNew.bottom = rcNew.top + nCharHeight;
 					
-					// 2006.10.01 Moca GDI(ƒŠ[ƒWƒ‡ƒ“)ƒŠƒ\[ƒXƒŠ[ƒNC³
+					// 2006.10.01 Moca GDI(ãƒªãƒ¼ã‚¸ãƒ§ãƒ³)ãƒªã‚½ãƒ¼ã‚¹ãƒªãƒ¼ã‚¯ä¿®æ­£
 					HRGN hrgnEOFNew = ::CreateRectRgnIndirect( &rcNew );
 					::CombineRgn( hrgnDraw, hrgnDraw, hrgnEOFNew, RGN_DIFF );
 					::DeleteObject( hrgnEOFNew );
 				}
 				::PaintRgn( hdc, hrgnDraw );
-				// From Here 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
+				// From Here 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
 				if( bCompatBMP ){
 					::PaintRgn( pView->m_hdcCompatDC, hrgnDraw );
 				}
@@ -401,7 +401,7 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 		}
 
 		//////////////////////////////////////////
-		// ƒfƒoƒbƒO—p ƒŠ[ƒWƒ‡ƒ“‹éŒ`‚Ìƒ_ƒ“ƒv
+		// ãƒ‡ãƒãƒƒã‚°ç”¨ ãƒªãƒ¼ã‚¸ãƒ§ãƒ³çŸ©å½¢ã®ãƒ€ãƒ³ãƒ—
 //@@		TraceRgn( hrgnDraw );
 
 
@@ -418,9 +418,9 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 		CLayoutRange sRangeA;
 		CLayoutInt nLineNum;
 
-		// Œ»İ•`‰æ‚³‚ê‚Ä‚¢‚é”ÍˆÍ‚Æn“_‚ª“¯‚¶
+		// ç¾åœ¨æç”»ã•ã‚Œã¦ã„ã‚‹ç¯„å›²ã¨å§‹ç‚¹ãŒåŒã˜
 		if( m_sSelect.GetFrom() == m_sSelectOld.GetFrom() ){
-			// ”ÍˆÍ‚ªŒã•û‚ÉŠg‘å‚³‚ê‚½
+			// ç¯„å›²ãŒå¾Œæ–¹ã«æ‹¡å¤§ã•ã‚ŒãŸ
 			if( PointCompare(m_sSelect.GetTo(),m_sSelectOld.GetTo()) > 0 ){
 				sRangeA.SetFrom(m_sSelectOld.GetTo());
 				sRangeA.SetTo  (m_sSelect.GetTo());
@@ -436,7 +436,7 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 			}
 		}
 		else if( m_sSelect.GetTo() == m_sSelectOld.GetTo() ){
-			// ”ÍˆÍ‚ª‘O•û‚ÉŠg‘å‚³‚ê‚½
+			// ç¯„å›²ãŒå‰æ–¹ã«æ‹¡å¤§ã•ã‚ŒãŸ
 			if(PointCompare(m_sSelect.GetFrom(),m_sSelectOld.GetFrom()) < 0){
 				sRangeA.SetFrom(m_sSelect.GetFrom());
 				sRangeA.SetTo  (m_sSelectOld.GetFrom());
@@ -467,14 +467,14 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 		}
 	}
 
-	// From Here 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
+	// From Here 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
 	if( bCompatBMP ){
 		::SetROP2( pView->m_hdcCompatDC, nROPCompatOld );
 		::SelectObject( pView->m_hdcCompatDC, hBrushCompatOld );
 	}
 	// To Here 2007.09.09 Moca
 
-	// 2006.10.01 Moca d•¡ƒR[ƒh“‡
+	// 2006.10.01 Moca é‡è¤‡ã‚³ãƒ¼ãƒ‰çµ±åˆ
 	::SetROP2( hdc, nROP_Old );
 	::SelectObject( hdc, hBrushOld );
 	::DeleteObject( hBrush );
@@ -483,17 +483,17 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 
 
 
-/*! ‘I‘ğ—Ìˆæ‚Ì’†‚Ìw’ès‚Ì•`‰æ
+/*! é¸æŠé ˜åŸŸã®ä¸­ã®æŒ‡å®šè¡Œã®æç”»
 
-	•¡”s‚É“n‚é‘I‘ğ”ÍˆÍ‚Ì‚¤‚¿CnLineNum‚Åw’è‚³‚ê‚½1s•ª‚¾‚¯‚ğ•`‰æ‚·‚éD
-	‘I‘ğ”ÍˆÍ‚ÍŒÅ’è‚³‚ê‚½‚Ü‚ÜnLineNum‚Ì‚İ‚ª•K—vs•ª•Ï‰»‚µ‚È‚ª‚çŒÄ‚Ñ‚¾‚³‚ê‚éD
+	è¤‡æ•°è¡Œã«æ¸¡ã‚‹é¸æŠç¯„å›²ã®ã†ã¡ï¼ŒnLineNumã§æŒ‡å®šã•ã‚ŒãŸ1è¡Œåˆ†ã ã‘ã‚’æç”»ã™ã‚‹ï¼
+	é¸æŠç¯„å›²ã¯å›ºå®šã•ã‚ŒãŸã¾ã¾nLineNumã®ã¿ãŒå¿…è¦è¡Œåˆ†å¤‰åŒ–ã—ãªãŒã‚‰å‘¼ã³ã ã•ã‚Œã‚‹ï¼
 
-	@date 2006.03.29 Moca 3000Œ…§ŒÀ‚ğ“P”pD
+	@date 2006.03.29 Moca 3000æ¡åˆ¶é™ã‚’æ’¤å»ƒï¼
 */
 void CViewSelect::DrawSelectAreaLine(
-	HDC					hdc,		//!< [in] •`‰æ—Ìˆæ‚ÌDevice Context Handle
-	CLayoutInt			nLineNum,	//!< [in] •`‰æ‘ÎÛs(ƒŒƒCƒAƒEƒgs)
-	const CLayoutRange&	sRange		//!< [in] ‘I‘ğ”ÍˆÍ(ƒŒƒCƒAƒEƒg’PˆÊ)
+	HDC					hdc,		//!< [in] æç”»é ˜åŸŸã®Device Context Handle
+	CLayoutInt			nLineNum,	//!< [in] æç”»å¯¾è±¡è¡Œ(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ)
+	const CLayoutRange&	sRange		//!< [in] é¸æŠç¯„å›²(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½)
 ) const
 {
 	CEditView const * const pView = m_pcEditView;
@@ -512,18 +512,18 @@ void CViewSelect::DrawSelectAreaLine(
 		while( !it.end() ){
 			it.scanNext();
 			if ( it.getIndex() + it.getIndexDelta() > pcLayout->GetLengthWithoutEOL() ){
-				// HACK:‰üsƒR[ƒh‚Í‘I‘ğ‚¾‚¯1Œ…•
+				// HACK:æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã¯é¸æŠã ã‘1æ¡å¹…
 				if( CTypeSupport(pView, COLORIDX_EOL).IsDisp() ){
 					nPosX += pView->GetTextMetrics().GetLayoutXDefault();
 					if( pcLayout->GetLayoutEol().GetLen() != 0 ){
-						nPosX += 4; // 4px‚ÍCRLF‚Ì‚Í‚İo‚Ä‚é•ª
+						nPosX += 4; // 4pxã¯CRLFã®ã¯ã¿å‡ºã¦ã‚‹åˆ†
 					}
 				}else{
-					nPosX += 2; // ”ñ•\¦‚È‚ç()2px
+					nPosX += 2; // éè¡¨ç¤ºãªã‚‰()2px
 				}
 				break;
 			}
-			// 2006.03.28 Moca ‰æ–ÊŠO‚Ü‚Å‹‚ß‚½‚ç‘Å‚¿Ø‚é
+			// 2006.03.28 Moca ç”»é¢å¤–ã¾ã§æ±‚ã‚ãŸã‚‰æ‰“ã¡åˆ‡ã‚‹
 			if( it.getColumn() > pView->GetTextArea().GetRightCol() ){
 				break;
 			}
@@ -539,7 +539,7 @@ void CViewSelect::DrawSelectAreaLine(
 		}
 	}
 	
-	// 2006.03.28 Moca ƒEƒBƒ“ƒhƒE•‚ª‘å‚«‚¢‚Æ³‚µ‚­”½“]‚µ‚È‚¢–â‘è‚ğC³
+	// 2006.03.28 Moca ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦å¹…ãŒå¤§ãã„ã¨æ­£ã—ãåè»¢ã—ãªã„å•é¡Œã‚’ä¿®æ­£
 	if( nSelectFrom < pView->GetTextArea().GetViewLeftCol() ){
 		nSelectFrom = pView->GetTextArea().GetViewLeftCol();
 	}
@@ -553,18 +553,18 @@ void CViewSelect::DrawSelectAreaLine(
 	if( rcClip.right > pView->GetTextArea().GetAreaRight() ){
 		rcClip.right = pView->GetTextArea().GetAreaRight();
 	}
-	//	•K—v‚È‚Æ‚«‚¾‚¯B
+	//	å¿…è¦ãªã¨ãã ã‘ã€‚
 	if ( rcClip.right != rcClip.left ){
 		CLayoutRange selectOld = m_sSelect;
 		const_cast<CLayoutRange*>(&m_sSelect)->Clear(-1);
 		pView->GetCaret().m_cUnderLine.CaretUnderLineOFF(true, false, true);
 		*(const_cast<CLayoutRange*>(&m_sSelect)) = selectOld;
 		
-		// 2006.03.28 Moca •\¦ˆæ“à‚Ì‚İˆ—‚·‚é
+		// 2006.03.28 Moca è¡¨ç¤ºåŸŸå†…ã®ã¿å‡¦ç†ã™ã‚‹
 		if( nSelectFrom <=pView->GetTextArea().GetRightCol() && pView->GetTextArea().GetViewLeftCol() < nSelectTo ){
 			HRGN hrgnDraw = ::CreateRectRgn( rcClip.left, rcClip.top, rcClip.right, rcClip.bottom );
 			::PaintRgn( hdc, hrgnDraw );
-			// From Here 2007.09.09 Moca ŒİŠ·BMP‚É‚æ‚é‰æ–Êƒoƒbƒtƒ@
+			// From Here 2007.09.09 Moca äº’æ›BMPã«ã‚ˆã‚‹ç”»é¢ãƒãƒƒãƒ•ã‚¡
 			if( bCompatBMP ){
 				::PaintRgn( pView->m_hdcCompatDC, hrgnDraw );
 			}
@@ -586,11 +586,11 @@ void CViewSelect::GetSelectAreaLineFromRange(
 		nLineNum >= sRange.GetTo().y && nLineNum <= sRange.GetFrom().y ){
 		CLayoutInt	nSelectFrom = sRange.GetFrom().GetX2();
 		CLayoutInt	nSelectTo   = sRange.GetTo().GetX2();
-		if( IsBoxSelecting() ){		/* ‹éŒ`”ÍˆÍ‘I‘ğ’† */
+		if( IsBoxSelecting() ){		/* çŸ©å½¢ç¯„å›²é¸æŠä¸­ */
 			nSelectFrom = sRange.GetFrom().GetX2();
 			nSelectTo   = sRange.GetTo().GetX2();
-			// 2006.09.30 Moca From ‹éŒ`‘I‘ğ[EOF]‚Æ‚»‚Ì‰E‘¤‚Í”½“]‚µ‚È‚¢‚æ‚¤‚ÉC³Bˆ—‚ğ’Ç‰Á
-			// 2011.12.26 [EOF]’P“ÆsˆÈŠO‚È‚ç”½“]‚·‚é
+			// 2006.09.30 Moca From çŸ©å½¢é¸æŠæ™‚[EOF]ã¨ãã®å³å´ã¯åè»¢ã—ãªã„ã‚ˆã†ã«ä¿®æ­£ã€‚å‡¦ç†ã‚’è¿½åŠ 
+			// 2011.12.26 [EOF]å˜ç‹¬è¡Œä»¥å¤–ãªã‚‰åè»¢ã™ã‚‹
 			if( view.m_pcEditDoc->m_cLayoutMgr.GetLineCount() <= nLineNum ){
 				nSelectFrom = -1;
 				nSelectTo = -1;
@@ -618,8 +618,8 @@ void CViewSelect::GetSelectAreaLineFromRange(
 				}
 			}
 		}
-		// 2006.05.24 Moca ‹éŒ`‘I‘ğ/ƒtƒŠ[ƒJ[ƒ\ƒ‹‘I‘ğ(‘I‘ğŠJn/I—¹s)‚Å
-		// To < From ‚É‚È‚é‚±‚Æ‚ª‚ ‚éB•K‚¸ From < To ‚É‚È‚é‚æ‚¤‚É“ü‚ê‘Ö‚¦‚éB
+		// 2006.05.24 Moca çŸ©å½¢é¸æŠ/ãƒ•ãƒªãƒ¼ã‚«ãƒ¼ã‚½ãƒ«é¸æŠ(é¸æŠé–‹å§‹/çµ‚äº†è¡Œ)ã§
+		// To < From ã«ãªã‚‹ã“ã¨ãŒã‚ã‚‹ã€‚å¿…ãš From < To ã«ãªã‚‹ã‚ˆã†ã«å…¥ã‚Œæ›¿ãˆã‚‹ã€‚
 		if( nSelectTo < nSelectFrom ){
 			std::swap(nSelectFrom, nSelectTo);
 		}
@@ -631,23 +631,23 @@ void CViewSelect::GetSelectAreaLineFromRange(
 	}
 }
 
-/*!	‘I‘ğ”ÍˆÍî•ñƒƒbƒZ[ƒW‚Ì•\¦
+/*!	é¸æŠç¯„å›²æƒ…å ±ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®è¡¨ç¤º
 
 	@author genta
-	@date 2005.07.09 genta V‹Kì¬
-	@date 2006.06.06 ryoji ‘I‘ğ”ÍˆÍ‚Ìs‚ªÀİ‚µ‚È‚¢ê‡‚Ì‘Îô‚ğ’Ç‰Á
-	@date 2006.06.28 syat ƒoƒCƒg”ƒJƒEƒ“ƒg‚ğ’Ç‰Á
+	@date 2005.07.09 genta æ–°è¦ä½œæˆ
+	@date 2006.06.06 ryoji é¸æŠç¯„å›²ã®è¡ŒãŒå®Ÿåœ¨ã—ãªã„å ´åˆã®å¯¾ç­–ã‚’è¿½åŠ 
+	@date 2006.06.28 syat ãƒã‚¤ãƒˆæ•°ã‚«ã‚¦ãƒ³ãƒˆã‚’è¿½åŠ 
 */
 void CViewSelect::PrintSelectionInfoMsg() const
 {
 	const CEditView* pView=GetEditView();
 
-	//	o—Í‚³‚ê‚È‚¢‚È‚çŒvZ‚ğÈ—ª
+	//	å‡ºåŠ›ã•ã‚Œãªã„ãªã‚‰è¨ˆç®—ã‚’çœç•¥
 	if( ! pView->m_pcEditWnd->m_cStatusBar.SendStatusMessage2IsEffective() )
 		return;
 
 	CLayoutInt nLineCount = pView->m_pcEditDoc->m_cLayoutMgr.GetLineCount();
-	if( ! IsTextSelected() || m_sSelect.GetFrom().y >= nLineCount ){ // æ“ªs‚ªÀİ‚µ‚È‚¢
+	if( ! IsTextSelected() || m_sSelect.GetFrom().y >= nLineCount ){ // å…ˆé ­è¡ŒãŒå®Ÿåœ¨ã—ãªã„
 		const_cast<CEditView*>(pView)->GetCaret().m_bClearStatus = false;
 		if( IsBoxSelecting() ){
 			pView->m_pcEditWnd->m_cStatusBar.SendStatusMessage2( _T("box selecting") );
@@ -660,19 +660,19 @@ void CViewSelect::PrintSelectionInfoMsg() const
 	}
 
 	TCHAR msg[128];
-	//	From here 2006.06.06 ryoji ‘I‘ğ”ÍˆÍ‚Ìs‚ªÀİ‚µ‚È‚¢ê‡‚Ì‘Îô
+	//	From here 2006.06.06 ryoji é¸æŠç¯„å›²ã®è¡ŒãŒå®Ÿåœ¨ã—ãªã„å ´åˆã®å¯¾ç­–
 
 	CLayoutInt select_line;
-	if( m_sSelect.GetTo().y >= nLineCount ){	// ÅIs‚ªÀİ‚µ‚È‚¢
+	if( m_sSelect.GetTo().y >= nLineCount ){	// æœ€çµ‚è¡ŒãŒå®Ÿåœ¨ã—ãªã„
 		select_line = nLineCount - m_sSelect.GetFrom().y + 1;
 	}
 	else {
 		select_line = m_sSelect.GetTo().y - m_sSelect.GetFrom().y + 1;
 	}
 	
-	//	To here 2006.06.06 ryoji ‘I‘ğ”ÍˆÍ‚Ìs‚ªÀİ‚µ‚È‚¢ê‡‚Ì‘Îô
+	//	To here 2006.06.06 ryoji é¸æŠç¯„å›²ã®è¡ŒãŒå®Ÿåœ¨ã—ãªã„å ´åˆã®å¯¾ç­–
 	if( IsBoxSelecting() ){
-		//	‹éŒ`‚Ìê‡‚Í•‚Æ‚‚³‚¾‚¯‚Å‚²‚Ü‚©‚·
+		//	çŸ©å½¢ã®å ´åˆã¯å¹…ã¨é«˜ã•ã ã‘ã§ã”ã¾ã‹ã™
 		CLayoutInt select_col = m_sSelect.GetFrom().x - m_sSelect.GetTo().x;
 		if( select_col < 0 ){
 			select_col = -select_col;
@@ -682,84 +682,84 @@ void CViewSelect::PrintSelectionInfoMsg() const
 			select_col_keta, select_col, select_line );
 	}
 	else {
-		//	’Êí‚Ì‘I‘ğ‚Å‚Í‘I‘ğ”ÍˆÍ‚Ì’†g‚ğ”‚¦‚é
-		int select_sum = 0;	//	ƒoƒCƒg”‡Œv
-		const wchar_t *pLine;	//	ƒf[ƒ^‚ğó‚¯æ‚é
-		CLogicInt	nLineLen;		//	s‚Ì’·‚³
+		//	é€šå¸¸ã®é¸æŠã§ã¯é¸æŠç¯„å›²ã®ä¸­èº«ã‚’æ•°ãˆã‚‹
+		int select_sum = 0;	//	ãƒã‚¤ãƒˆæ•°åˆè¨ˆ
+		const wchar_t *pLine;	//	ãƒ‡ãƒ¼ã‚¿ã‚’å—ã‘å–ã‚‹
+		CLogicInt	nLineLen;		//	è¡Œã®é•·ã•
 		const CLayout*	pcLayout;
-		CViewSelect* thiz = const_cast<CViewSelect*>( this );	// constŠO‚µthis
+		CViewSelect* thiz = const_cast<CViewSelect*>( this );	// constå¤–ã—this
 
-		// ‹¤’Êİ’èE‘I‘ğ•¶š”‚ğ•¶š’PˆÊ‚Å‚Í‚È‚­ƒoƒCƒg’PˆÊ‚Å•\¦‚·‚é
+		// å…±é€šè¨­å®šãƒ»é¸æŠæ–‡å­—æ•°ã‚’æ–‡å­—å˜ä½ã§ã¯ãªããƒã‚¤ãƒˆå˜ä½ã§è¡¨ç¤ºã™ã‚‹
 		BOOL bCountByByteCommon = GetDllShareData().m_Common.m_sStatusbar.m_bDispSelCountByByte;
 		BOOL bCountByByte = ( pView->m_pcEditWnd->m_nSelectCountMode == SELECT_COUNT_TOGGLE ?
 								bCountByByteCommon :
 								pView->m_pcEditWnd->m_nSelectCountMode == SELECT_COUNT_BY_BYTE );
 
-		//	1s–Ú
+		//	1è¡Œç›®
 		pLine = pView->m_pcEditDoc->m_cLayoutMgr.GetLineStr( m_sSelect.GetFrom().GetY2(), &nLineLen, &pcLayout );
 		if( pLine ){
 			if( bCountByByte ){
-				//  ƒoƒCƒg”‚ÅƒJƒEƒ“ƒg
-				//  “à•”•¶šƒR[ƒh‚©‚çŒ»İ‚Ì•¶šƒR[ƒh‚É•ÏŠ·‚µAƒoƒCƒg”‚ğæ“¾‚·‚éB
-				//  ƒR[ƒh•ÏŠ·‚Í•‰‰×‚ª‚©‚©‚é‚½‚ßA‘I‘ğ”ÍˆÍ‚Ì‘Œ¸•ª‚Ì‚İ‚ğ‘ÎÛ‚Æ‚·‚éB
+				//  ãƒã‚¤ãƒˆæ•°ã§ã‚«ã‚¦ãƒ³ãƒˆ
+				//  å†…éƒ¨æ–‡å­—ã‚³ãƒ¼ãƒ‰ã‹ã‚‰ç¾åœ¨ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã«å¤‰æ›ã—ã€ãƒã‚¤ãƒˆæ•°ã‚’å–å¾—ã™ã‚‹ã€‚
+				//  ã‚³ãƒ¼ãƒ‰å¤‰æ›ã¯è² è·ãŒã‹ã‹ã‚‹ãŸã‚ã€é¸æŠç¯„å›²ã®å¢—æ¸›åˆ†ã®ã¿ã‚’å¯¾è±¡ã¨ã™ã‚‹ã€‚
 
 				CNativeW cmemW;
 				CMemory cmemCode;
 
-				// ‘Œ¸•ª•¶š—ñ‚Ìæ“¾‚ÉCEditView::GetSelectedData‚ğg‚¢‚½‚¢‚ªAm_sSelectŒÀ’è‚Ì‚½‚ßA
-				// ŒÄ‚Ño‚µ‘O‚Ém_sSelect‚ğ‘‚«Š·‚¦‚éBŒÄo‚µŒã‚ÉŒ³‚É–ß‚·‚Ì‚ÅAconst‚ÆŒ¾‚¦‚È‚¢‚±‚Æ‚à‚È‚¢B
-				CLayoutRange rngSelect = m_sSelect;		// ‘I‘ğ—Ìˆæ‚Ì‘Ş”ğ
-				bool bSelExtend;						// ‘I‘ğ—ÌˆæŠg‘åƒtƒ‰ƒO
+				// å¢—æ¸›åˆ†æ–‡å­—åˆ—ã®å–å¾—ã«CEditView::GetSelectedDataã‚’ä½¿ã„ãŸã„ãŒã€m_sSelecté™å®šã®ãŸã‚ã€
+				// å‘¼ã³å‡ºã—å‰ã«m_sSelectã‚’æ›¸ãæ›ãˆã‚‹ã€‚å‘¼å‡ºã—å¾Œã«å…ƒã«æˆ»ã™ã®ã§ã€constã¨è¨€ãˆãªã„ã“ã¨ã‚‚ãªã„ã€‚
+				CLayoutRange rngSelect = m_sSelect;		// é¸æŠé ˜åŸŸã®é€€é¿
+				bool bSelExtend;						// é¸æŠé ˜åŸŸæ‹¡å¤§ãƒ•ãƒ©ã‚°
 
-				// ÅIs‚Ìˆ—
+				// æœ€çµ‚è¡Œã®å‡¦ç†
 				pLine = pView->m_pcEditDoc->m_cLayoutMgr.GetLineStr( m_sSelect.GetTo().y, &nLineLen, &pcLayout );
 				if( pLine ){
 					if( pView->LineColumnToIndex( pcLayout, m_sSelect.GetTo().GetX2() ) == 0 ){
-						//	ÅIs‚Ìæ“ª‚ÉƒLƒƒƒŒƒbƒg‚ª‚ ‚éê‡‚Í
-						//	‚»‚Ìs‚ğs”‚ÉŠÜ‚ß‚È‚¢
+						//	æœ€çµ‚è¡Œã®å…ˆé ­ã«ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒã‚ã‚‹å ´åˆã¯
+						//	ãã®è¡Œã‚’è¡Œæ•°ã«å«ã‚ãªã„
 						--select_line;
 					}
 				}else{
-					//	ÅIs‚ª‹ós‚È‚ç
-					//	‚»‚Ìs‚ğs”‚ÉŠÜ‚ß‚È‚¢
+					//	æœ€çµ‚è¡ŒãŒç©ºè¡Œãªã‚‰
+					//	ãã®è¡Œã‚’è¡Œæ•°ã«å«ã‚ãªã„
 					--select_line;
 				}
 
-				//2009.07.07 syat m_nLastSelectedByteLen‚ª0‚Ìê‡‚ÍA·•ª‚Å‚Í‚È‚­‘S‘Ì‚ğ•ÏŠ·‚·‚éiƒ‚[ƒhØ‘Ö‚ÉƒLƒƒƒbƒVƒ…ƒNƒŠƒA‚·‚é‚½‚ßj
+				//2009.07.07 syat m_nLastSelectedByteLenãŒ0ã®å ´åˆã¯ã€å·®åˆ†ã§ã¯ãªãå…¨ä½“ã‚’å¤‰æ›ã™ã‚‹ï¼ˆãƒ¢ãƒ¼ãƒ‰åˆ‡æ›¿æ™‚ã«ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚¯ãƒªã‚¢ã™ã‚‹ãŸã‚ï¼‰
 
 				if( m_bSelectAreaChanging && m_nLastSelectedByteLen && m_sSelect.GetFrom() == m_sSelectOld.GetFrom() ){
-					// ”ÍˆÍ‚ªŒã•û‚ÉŠg‘å‚³‚ê‚½
+					// ç¯„å›²ãŒå¾Œæ–¹ã«æ‹¡å¤§ã•ã‚ŒãŸ
 					if( PointCompare( m_sSelect.GetTo(), m_sSelectOld.GetTo() ) < 0 ){
-						bSelExtend = false;				// k¬
+						bSelExtend = false;				// ç¸®å°
 						thiz->m_sSelect = CLayoutRange( m_sSelect.GetTo(), m_sSelectOld.GetTo() );
 					}else{
-						bSelExtend = true;				// Šg‘å
+						bSelExtend = true;				// æ‹¡å¤§
 						thiz->m_sSelect = CLayoutRange( m_sSelectOld.GetTo(), m_sSelect.GetTo() );
 					}
 
 					const_cast<CEditView*>( pView )->GetSelectedDataSimple(cmemW);
-					thiz->m_sSelect = rngSelect;		// m_sSelect‚ğŒ³‚É–ß‚·
+					thiz->m_sSelect = rngSelect;		// m_sSelectã‚’å…ƒã«æˆ»ã™
 				}
 				else if( m_bSelectAreaChanging && m_nLastSelectedByteLen && m_sSelect.GetTo() == m_sSelectOld.GetTo() ){
-					// ”ÍˆÍ‚ª‘O•û‚ÉŠg‘å‚³‚ê‚½
+					// ç¯„å›²ãŒå‰æ–¹ã«æ‹¡å¤§ã•ã‚ŒãŸ
 					if( PointCompare( m_sSelect.GetFrom(), m_sSelectOld.GetFrom() ) < 0 ){
-						bSelExtend = true;				// Šg‘å
+						bSelExtend = true;				// æ‹¡å¤§
 						thiz->m_sSelect = CLayoutRange( m_sSelect.GetFrom(), m_sSelectOld.GetFrom() );
 					}else{
-						bSelExtend = false;				// k¬
+						bSelExtend = false;				// ç¸®å°
 						thiz->m_sSelect = CLayoutRange( m_sSelectOld.GetFrom(), m_sSelect.GetFrom() );
 					}
 
 					const_cast<CEditView*>( pView )->GetSelectedDataSimple(cmemW);
-					thiz->m_sSelect = rngSelect;		// m_sSelect‚ğŒ³‚É–ß‚·
+					thiz->m_sSelect = rngSelect;		// m_sSelectã‚’å…ƒã«æˆ»ã™
 				}
 				else{
-					// ‘I‘ğ—Ìˆæ‘S‘Ì‚ğƒR[ƒh•ÏŠ·‘ÎÛ‚É‚·‚é
+					// é¸æŠé ˜åŸŸå…¨ä½“ã‚’ã‚³ãƒ¼ãƒ‰å¤‰æ›å¯¾è±¡ã«ã™ã‚‹
 					const_cast<CEditView*>( pView )->GetSelectedDataSimple(cmemW);
 					bSelExtend = true;
 					thiz->m_nLastSelectedByteLen = 0;
 				}
-				//  Œ»İ‚Ì•¶šƒR[ƒh‚É•ÏŠ·‚µAƒoƒCƒg’·‚ğæ“¾‚·‚é
+				//  ç¾åœ¨ã®æ–‡å­—ã‚³ãƒ¼ãƒ‰ã«å¤‰æ›ã—ã€ãƒã‚¤ãƒˆé•·ã‚’å–å¾—ã™ã‚‹
 				CCodeBase* pCode = CCodeFactory::CreateCodeBase(pView->m_pcEditDoc->GetDocumentEncoding(), false);
 				pCode->UnicodeToCode( cmemW, &cmemCode );
 				delete pCode;
@@ -773,51 +773,51 @@ void CViewSelect::PrintSelectionInfoMsg() const
 
 			}
 			else{
-				//  •¶š”‚ÅƒJƒEƒ“ƒg
+				//  æ–‡å­—æ•°ã§ã‚«ã‚¦ãƒ³ãƒˆ
 
-				//2009.07.07 syat ƒJƒEƒ“ƒg•û–@‚ğØ‚è‘Ö‚¦‚È‚ª‚ç‘I‘ğ”ÍˆÍ‚ğŠg‘åEk¬‚·‚é‚Æ®‡«‚ª
-				//                ‚Æ‚ê‚È‚­‚È‚é‚½‚ßAƒ‚[ƒhØ‘Ö‚ÉƒLƒƒƒbƒVƒ…‚ğƒNƒŠƒA‚·‚éB
+				//2009.07.07 syat ã‚«ã‚¦ãƒ³ãƒˆæ–¹æ³•ã‚’åˆ‡ã‚Šæ›¿ãˆãªãŒã‚‰é¸æŠç¯„å›²ã‚’æ‹¡å¤§ãƒ»ç¸®å°ã™ã‚‹ã¨æ•´åˆæ€§ãŒ
+				//                ã¨ã‚Œãªããªã‚‹ãŸã‚ã€ãƒ¢ãƒ¼ãƒ‰åˆ‡æ›¿æ™‚ã«ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’ã‚¯ãƒªã‚¢ã™ã‚‹ã€‚
 				thiz->m_nLastSelectedByteLen = 0;
 
-				//	1s‚¾‚¯‘I‘ğ‚³‚ê‚Ä‚¢‚éê‡
+				//	1è¡Œã ã‘é¸æŠã•ã‚Œã¦ã„ã‚‹å ´åˆ
 				if( m_sSelect.IsLineOne() ){
 					select_sum =
 						pView->LineColumnToIndex( pcLayout, m_sSelect.GetTo().GetX2() )
 						- pView->LineColumnToIndex( pcLayout, m_sSelect.GetFrom().GetX2() );
-				} else {	//	2sˆÈã‘I‘ğ‚³‚ê‚Ä‚¢‚éê‡
+				} else {	//	2è¡Œä»¥ä¸Šé¸æŠã•ã‚Œã¦ã„ã‚‹å ´åˆ
 					select_sum =
 						pcLayout->GetLengthWithoutEOL()
 						+ pcLayout->GetLayoutEol().GetLen()
 						- pView->LineColumnToIndex( pcLayout, m_sSelect.GetFrom().GetX2() );
 
-					//	GetSelectedData‚Æ—‚Ä‚¢‚é‚ªCæ“ªs‚ÆÅIs‚Í”rœ‚µ‚Ä‚¢‚é
-					//	Aug. 16, 2005 aroka nLineNum‚ÍforˆÈ~‚Å‚àg‚í‚ê‚é‚Ì‚Åfor‚Ì‘O‚ÅéŒ¾‚·‚é
-					//	VC .NETˆÈ~‚Å‚àMicrosoftŠg’£‚ğ—LŒø‚É‚µ‚½•W€“®ì‚ÍVC6‚Æ“¯‚¶‚±‚Æ‚É’ˆÓ
+					//	GetSelectedDataã¨ä¼¼ã¦ã„ã‚‹ãŒï¼Œå…ˆé ­è¡Œã¨æœ€çµ‚è¡Œã¯æ’é™¤ã—ã¦ã„ã‚‹
+					//	Aug. 16, 2005 aroka nLineNumã¯forä»¥é™ã§ã‚‚ä½¿ã‚ã‚Œã‚‹ã®ã§forã®å‰ã§å®£è¨€ã™ã‚‹
+					//	VC .NETä»¥é™ã§ã‚‚Microsoftæ‹¡å¼µã‚’æœ‰åŠ¹ã«ã—ãŸæ¨™æº–å‹•ä½œã¯VC6ã¨åŒã˜ã“ã¨ã«æ³¨æ„
 					CLayoutInt nLineNum;
 					for( nLineNum = m_sSelect.GetFrom().GetY2() + CLayoutInt(1);
 						nLineNum < m_sSelect.GetTo().GetY2(); ++nLineNum ){
 						pLine = pView->m_pcEditDoc->m_cLayoutMgr.GetLineStr( nLineNum, &nLineLen, &pcLayout );
-						//	2006.06.06 ryoji w’ès‚Ìƒf[ƒ^‚ª‘¶İ‚µ‚È‚¢ê‡‚Ì‘Îô
+						//	2006.06.06 ryoji æŒ‡å®šè¡Œã®ãƒ‡ãƒ¼ã‚¿ãŒå­˜åœ¨ã—ãªã„å ´åˆã®å¯¾ç­–
 						if( NULL == pLine )
 							break;
 						select_sum += pcLayout->GetLengthWithoutEOL() + pcLayout->GetLayoutEol().GetLen();
 					}
 
-					//	ÅIs‚Ìˆ—
+					//	æœ€çµ‚è¡Œã®å‡¦ç†
 					pLine = pView->m_pcEditDoc->m_cLayoutMgr.GetLineStr( nLineNum, &nLineLen, &pcLayout );
 					if( pLine ){
 						int last_line_chars = pView->LineColumnToIndex( pcLayout, m_sSelect.GetTo().GetX2() );
 						select_sum += last_line_chars;
 						if( last_line_chars == 0 ){
-							//	ÅIs‚Ìæ“ª‚ÉƒLƒƒƒŒƒbƒg‚ª‚ ‚éê‡‚Í
-							//	‚»‚Ìs‚ğs”‚ÉŠÜ‚ß‚È‚¢
+							//	æœ€çµ‚è¡Œã®å…ˆé ­ã«ã‚­ãƒ£ãƒ¬ãƒƒãƒˆãŒã‚ã‚‹å ´åˆã¯
+							//	ãã®è¡Œã‚’è¡Œæ•°ã«å«ã‚ãªã„
 							--select_line;
 						}
 					}
 					else
 					{
-						//	ÅIs‚ª‹ós‚È‚ç
-						//	‚»‚Ìs‚ğs”‚ÉŠÜ‚ß‚È‚¢
+						//	æœ€çµ‚è¡ŒãŒç©ºè¡Œãªã‚‰
+						//	ãã®è¡Œã‚’è¡Œæ•°ã«å«ã‚ãªã„
 						--select_line;
 					}
 				}

--- a/sakura_core/view/CViewSelect.h
+++ b/sakura_core/view/CViewSelect.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -39,15 +39,15 @@ public:
 	void CopySelectStatus(CViewSelect* pSelect) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                      ‘I‘ğ”ÍˆÍ‚Ì•ÏX                         //
+	//                      é¸æŠç¯„å›²ã®å¤‰æ›´                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	void DisableSelectArea( bool bDraw, bool bDrawBracketCursorLine = true ); //!< Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ”ñ‘I‘ğó‘Ô‚É–ß‚·
+	void DisableSelectArea( bool bDraw, bool bDrawBracketCursorLine = true ); //!< ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’éé¸æŠçŠ¶æ…‹ã«æˆ»ã™
 
-	void BeginSelectArea( const CLayoutPoint* po = NULL );								// Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚©‚ç‘I‘ğ‚ğŠJn‚·‚é
-	void ChangeSelectAreaByCurrentCursor( const CLayoutPoint& ptCaretPos );			// Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX
-	void ChangeSelectAreaByCurrentCursorTEST( const CLayoutPoint& ptCaretPos, CLayoutRange* pSelect );// Œ»İ‚ÌƒJ[ƒ\ƒ‹ˆÊ’u‚É‚æ‚Á‚Ä‘I‘ğ”ÍˆÍ‚ğ•ÏX
+	void BeginSelectArea( const CLayoutPoint* po = NULL );								// ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã‹ã‚‰é¸æŠã‚’é–‹å§‹ã™ã‚‹
+	void ChangeSelectAreaByCurrentCursor( const CLayoutPoint& ptCaretPos );			// ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´
+	void ChangeSelectAreaByCurrentCursorTEST( const CLayoutPoint& ptCaretPos, CLayoutRange* pSelect );// ç¾åœ¨ã®ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ã«ã‚ˆã£ã¦é¸æŠç¯„å›²ã‚’å¤‰æ›´
 
-	//!‘I‘ğ”ÍˆÍ‚ğw’è‚·‚é(Œ´“_–¢‘I‘ğ)
+	//!é¸æŠç¯„å›²ã‚’æŒ‡å®šã™ã‚‹(åŸç‚¹æœªé¸æŠ)
 	// 2005.06.24 Moca
 	void SetSelectArea( const CLayoutRange& sRange )
 	{
@@ -55,55 +55,55 @@ public:
 		m_sSelect = sRange;
 	}
 
-	//!’PŒê‘I‘ğŠJn
+	//!å˜èªé¸æŠé–‹å§‹
 	void SelectBeginWord()
 	{
-		m_bBeginSelect     = true;				/* ”ÍˆÍ‘I‘ğ’† */
-		m_bBeginBoxSelect  = false;			/* ‹éŒ`”ÍˆÍ‘I‘ğ’†‚Å‚È‚¢ */
-		m_bBeginLineSelect = false;			/* s’PˆÊ‘I‘ğ’† */
-		m_bBeginWordSelect = true;			/* ’PŒê’PˆÊ‘I‘ğ’† */
+		m_bBeginSelect     = true;				/* ç¯„å›²é¸æŠä¸­ */
+		m_bBeginBoxSelect  = false;			/* çŸ©å½¢ç¯„å›²é¸æŠä¸­ã§ãªã„ */
+		m_bBeginLineSelect = false;			/* è¡Œå˜ä½é¸æŠä¸­ */
+		m_bBeginWordSelect = true;			/* å˜èªå˜ä½é¸æŠä¸­ */
 	}
 
-	//!‹éŒ`‘I‘ğŠJn
+	//!çŸ©å½¢é¸æŠé–‹å§‹
 	void SelectBeginBox()
 	{
-		m_bBeginSelect     = true;			/* ”ÍˆÍ‘I‘ğ’† */
-		m_bBeginBoxSelect  = true;		/* ‹éŒ`”ÍˆÍ‘I‘ğ’† */
-		m_bBeginLineSelect = false;		/* s’PˆÊ‘I‘ğ’† */
-		m_bBeginWordSelect = false;		/* ’PŒê’PˆÊ‘I‘ğ’† */
+		m_bBeginSelect     = true;			/* ç¯„å›²é¸æŠä¸­ */
+		m_bBeginBoxSelect  = true;		/* çŸ©å½¢ç¯„å›²é¸æŠä¸­ */
+		m_bBeginLineSelect = false;		/* è¡Œå˜ä½é¸æŠä¸­ */
+		m_bBeginWordSelect = false;		/* å˜èªå˜ä½é¸æŠä¸­ */
 	}
 
-	//!“ä‚Ì‘I‘ğŠJn
+	//!è¬ã®é¸æŠé–‹å§‹
 	void SelectBeginNazo()
 	{
-		m_bBeginSelect     = true;			/* ”ÍˆÍ‘I‘ğ’† */
-//		m_bBeginBoxSelect  = false;		/* ‹éŒ`”ÍˆÍ‘I‘ğ’†‚Å‚È‚¢ */
-		m_bBeginLineSelect = false;		/* s’PˆÊ‘I‘ğ’† */
-		m_bBeginWordSelect = false;		/* ’PŒê’PˆÊ‘I‘ğ’† */
+		m_bBeginSelect     = true;			/* ç¯„å›²é¸æŠä¸­ */
+//		m_bBeginBoxSelect  = false;		/* çŸ©å½¢ç¯„å›²é¸æŠä¸­ã§ãªã„ */
+		m_bBeginLineSelect = false;		/* è¡Œå˜ä½é¸æŠä¸­ */
+		m_bBeginWordSelect = false;		/* å˜èªå˜ä½é¸æŠä¸­ */
 	}
 
-	//!”ÍˆÍ‘I‘ğI—¹
+	//!ç¯„å›²é¸æŠçµ‚äº†
 	void SelectEnd()
 	{
 		m_bBeginSelect = false;
 	}
 
-	//!m_bBeginBoxSelect‚ğİ’èB
+	//!m_bBeginBoxSelectã‚’è¨­å®šã€‚
 	void SetBoxSelect(bool b)
 	{
 		m_bBeginBoxSelect = b;
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           •`‰æ                              //
+	//                           æç”»                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	void DrawSelectArea(bool bDrawBracketCursorLine = true);		//!< w’ès‚Ì‘I‘ğ—Ìˆæ‚Ì•`‰æ
+	void DrawSelectArea(bool bDrawBracketCursorLine = true);		//!< æŒ‡å®šè¡Œã®é¸æŠé ˜åŸŸã®æç”»
 private:
-	void DrawSelectArea2(HDC) const;		//!< w’è”ÍˆÍ‚Ì‘I‘ğ—Ìˆæ‚Ì•`‰æ
-	void DrawSelectAreaLine(			//!< w’ès‚Ì‘I‘ğ—Ìˆæ‚Ì•`‰æ
-		HDC					hdc,		//!< [in] •`‰æ—Ìˆæ‚ÌDevice Context Handle
-		CLayoutInt			nLineNum,	//!< [in] •`‰æ‘ÎÛs(ƒŒƒCƒAƒEƒgs)
-		const CLayoutRange&	sRange		//!< [in] ‘I‘ğ”ÍˆÍ(ƒŒƒCƒAƒEƒg’PˆÊ)
+	void DrawSelectArea2(HDC) const;		//!< æŒ‡å®šç¯„å›²ã®é¸æŠé ˜åŸŸã®æç”»
+	void DrawSelectAreaLine(			//!< æŒ‡å®šè¡Œã®é¸æŠé ˜åŸŸã®æç”»
+		HDC					hdc,		//!< [in] æç”»é ˜åŸŸã®Device Context Handle
+		CLayoutInt			nLineNum,	//!< [in] æç”»å¯¾è±¡è¡Œ(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œ)
+		const CLayoutRange&	sRange		//!< [in] é¸æŠç¯„å›²(ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½)
 	) const;
 public:
 	void GetSelectAreaLineFromRange(CLayoutRange& ret, CLayoutInt nLineNum, const CLayout* pcLayout, const CLayoutRange& sRange) const;
@@ -115,14 +115,14 @@ public:
 		GetSelectAreaLineFromRange(ret, nLineNum, pcLayout, m_sSelect);
 		return ret;
 	}
-	//! ‘I‘ğî•ñƒf[ƒ^‚Ìì¬	2005.07.09 genta
+	//! é¸æŠæƒ…å ±ãƒ‡ãƒ¼ã‚¿ã®ä½œæˆ	2005.07.09 genta
 	void PrintSelectionInfoMsg() const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         ó‘Ôæ“¾                            //
+	//                         çŠ¶æ…‹å–å¾—                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//! ƒeƒLƒXƒg‚ª‘I‘ğ‚³‚ê‚Ä‚¢‚é‚©
-	// 2002/03/29 Azumaiya ƒCƒ“ƒ‰ƒCƒ“ŠÖ”‰»
+	//! ãƒ†ã‚­ã‚¹ãƒˆãŒé¸æŠã•ã‚Œã¦ã„ã‚‹ã‹
+	// 2002/03/29 Azumaiya ã‚¤ãƒ³ãƒ©ã‚¤ãƒ³é–¢æ•°åŒ–
 	bool IsTextSelected() const
 	{
 		return m_sSelect.IsValid();
@@ -131,21 +131,21 @@ public:
 //			);
 	}
 
-	//! ƒeƒLƒXƒg‚Ì‘I‘ğ’†‚©
-	// 2002/03/29 Azumaiya ƒCƒ“ƒ‰ƒCƒ“ŠÖ”‰»
+	//! ãƒ†ã‚­ã‚¹ãƒˆã®é¸æŠä¸­ã‹
+	// 2002/03/29 Azumaiya ã‚¤ãƒ³ãƒ©ã‚¤ãƒ³é–¢æ•°åŒ–
 	bool IsTextSelecting() const
 	{
-		// ƒWƒƒƒ“ƒv‰ñ”‚ğŒ¸‚ç‚µ‚ÄAˆê‹C‚É”»’èB
+		// ã‚¸ãƒ£ãƒ³ãƒ—å›æ•°ã‚’æ¸›ã‚‰ã—ã¦ã€ä¸€æ°—ã«åˆ¤å®šã€‚
 		return m_bSelectingLock || IsTextSelected();
 	}
 
-	//!ƒ}ƒEƒX‚Å‘I‘ğ’†‚©
+	//!ãƒã‚¦ã‚¹ã§é¸æŠä¸­ã‹
 	bool IsMouseSelecting() const
 	{
 		return m_bBeginSelect;
 	}
 
-	//!‹éŒ`‘I‘ğ’†‚©
+	//!çŸ©å½¢é¸æŠä¸­ã‹
 	bool IsBoxSelecting() const
 	{
 		return m_bBeginBoxSelect;
@@ -153,40 +153,40 @@ public:
 
 
 private:
-	//QÆ
+	//å‚ç…§
 	CEditView*	m_pcEditView;
 
 public:
 
 
-	bool	m_bDrawSelectArea;		// ‘I‘ğ”ÍˆÍ‚ğ•`‰æ‚µ‚½‚©	// 02/12/13 ai
+	bool	m_bDrawSelectArea;		// é¸æŠç¯„å›²ã‚’æç”»ã—ãŸã‹	// 02/12/13 ai
 
-	// ‘I‘ğó‘Ô
-	bool	m_bSelectingLock;		// ‘I‘ğó‘Ô‚ÌƒƒbƒN
+	// é¸æŠçŠ¶æ…‹
+	bool	m_bSelectingLock;		// é¸æŠçŠ¶æ…‹ã®ãƒ­ãƒƒã‚¯
 private:
-	bool	m_bBeginSelect;			// ”ÍˆÍ‘I‘ğ’†
-	bool	m_bBeginBoxSelect;		// ‹éŒ`”ÍˆÍ‘I‘ğ’†
-	bool	m_bSelectAreaChanging;	// ‘I‘ğ”ÍˆÍ•ÏX’†
-	int		m_nLastSelectedByteLen;	// ‘O‰ñ‘I‘ğ‚Ì‘I‘ğƒoƒCƒg”
+	bool	m_bBeginSelect;			// ç¯„å›²é¸æŠä¸­
+	bool	m_bBeginBoxSelect;		// çŸ©å½¢ç¯„å›²é¸æŠä¸­
+	bool	m_bSelectAreaChanging;	// é¸æŠç¯„å›²å¤‰æ›´ä¸­
+	int		m_nLastSelectedByteLen;	// å‰å›é¸æŠæ™‚ã®é¸æŠãƒã‚¤ãƒˆæ•°
 
 public:
-	bool	m_bBeginLineSelect;		// s’PˆÊ‘I‘ğ’†
-	bool	m_bBeginWordSelect;		// ’PŒê’PˆÊ‘I‘ğ’†
+	bool	m_bBeginLineSelect;		// è¡Œå˜ä½é¸æŠä¸­
+	bool	m_bBeginWordSelect;		// å˜èªå˜ä½é¸æŠä¸­
 
-	// ‘I‘ğ”ÍˆÍ‚ğ•Û‚·‚é‚½‚ß‚Ì•Ï”ŒQ
-	// ‚±‚ê‚ç‚Í‚·‚×‚ÄÜ‚è•Ô‚µs‚ÆAÜ‚è•Ô‚µŒ…‚ğ•Û‚µ‚Ä‚¢‚éB
-	CLayoutRange m_sSelectBgn; //”ÍˆÍ‘I‘ğ(Œ´“_)
-	CLayoutRange m_sSelect;    //”ÍˆÍ‘I‘ğ
-	CLayoutRange m_sSelectOld; //”ÍˆÍ‘I‘ğOld
+	// é¸æŠç¯„å›²ã‚’ä¿æŒã™ã‚‹ãŸã‚ã®å¤‰æ•°ç¾¤
+	// ã“ã‚Œã‚‰ã¯ã™ã¹ã¦æŠ˜ã‚Šè¿”ã—è¡Œã¨ã€æŠ˜ã‚Šè¿”ã—æ¡ã‚’ä¿æŒã—ã¦ã„ã‚‹ã€‚
+	CLayoutRange m_sSelectBgn; //ç¯„å›²é¸æŠ(åŸç‚¹)
+	CLayoutRange m_sSelect;    //ç¯„å›²é¸æŠ
+	CLayoutRange m_sSelectOld; //ç¯„å›²é¸æŠOld
 
-	CMyPoint	m_ptMouseRollPosOld;	// ƒ}ƒEƒX”ÍˆÍ‘I‘ğ‘O‰ñˆÊ’u(XYÀ•W)
+	CMyPoint	m_ptMouseRollPosOld;	// ãƒã‚¦ã‚¹ç¯„å›²é¸æŠå‰å›ä½ç½®(XYåº§æ¨™)
 };
 
 /*
-m_sSelectOld‚É‚Â‚¢‚Ä
-	DrawSelectArea()‚ÉŒ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğ‹³‚¦‚Ä·•ª‚Ì‚İ•`‰æ‚·‚é‚½‚ß‚Ì‚à‚Ì
-	Œ»İ‚Ì‘I‘ğ”ÍˆÍ‚ğOld‚ÖƒRƒs[‚µ‚½ã‚ÅV‚µ‚¢‘I‘ğ”ÍˆÍ‚ğSelect‚Éİ’è‚µ‚Ä
-	DrawSelectArea()‚ğŒÄ‚Ñ‚¾‚·‚±‚Æ‚ÅV‚µ‚¢”ÍˆÍ‚ª•`‚©‚ê‚éD
+m_sSelectOldã«ã¤ã„ã¦
+	DrawSelectArea()ã«ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’æ•™ãˆã¦å·®åˆ†ã®ã¿æç”»ã™ã‚‹ãŸã‚ã®ã‚‚ã®
+	ç¾åœ¨ã®é¸æŠç¯„å›²ã‚’Oldã¸ã‚³ãƒ”ãƒ¼ã—ãŸä¸Šã§æ–°ã—ã„é¸æŠç¯„å›²ã‚’Selectã«è¨­å®šã—ã¦
+	DrawSelectArea()ã‚’å‘¼ã³ã ã™ã“ã¨ã§æ–°ã—ã„ç¯„å›²ãŒæã‹ã‚Œã‚‹ï¼
 */
 
 #endif /* SAKURA_CVIEWSELECT_F4CBAF6E_90C8_44D2_B6EC_7FE066968A8D9_H_ */

--- a/sakura_core/view/DispPos.cpp
+++ b/sakura_core/view/DispPos.cpp
@@ -1,12 +1,12 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "DispPos.h"
 #include "doc/layout/CLayout.h"
 
-//$$$‚‘¬‰»
+//$$$é«˜é€ŸåŒ–
 void DispPos::ForwardLayoutLineRef(int nOffsetLine)
 {
 	m_nLineRef += CLayoutInt(nOffsetLine);
-	//ƒLƒƒƒbƒVƒ…XV
+	//ã‚­ãƒ£ãƒƒã‚·ãƒ¥æ›´æ–°
 	int n = nOffsetLine;
 	if(m_pcLayoutRef){
 		while(n>0 && m_pcLayoutRef){

--- a/sakura_core/view/DispPos.h
+++ b/sakura_core/view/DispPos.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -39,21 +39,21 @@ public:
 		m_ptDrawLayout.x=CLayoutInt(0);
 		m_ptDrawLayout.y=CLayoutInt(0);
 		m_nLineRef=CLayoutInt(0);
-		//ƒLƒƒƒbƒVƒ…
+		//ã‚­ãƒ£ãƒƒã‚·ãƒ¥
 		m_pcLayoutRef = CEditDoc::GetInstance(0)->m_cLayoutMgr.GetTopLayout();
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         •`‰æˆÊ’u                            //
+	//                         æç”»ä½ç½®                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//ŒÅ’è’l
+	//å›ºå®šå€¤
 	void InitDrawPos(const POINT& pt)
 	{
 		m_ptDrawOrigin=pt;
 		m_ptDrawLayout.x=m_ptDrawLayout.y=CLayoutInt(0);
 	}
 
-	//æ“¾
+	//å–å¾—
 	CMyPoint GetDrawPos() const
 	{
 		return CMyPoint(
@@ -70,49 +70,49 @@ public:
 		return m_nDy;
 	}
 
-	//i‚Ş
+	//é€²ã‚€
 	void ForwardDrawCol (CLayoutXInt nColOffset ){ m_ptDrawLayout.x += nColOffset; }
 	void ForwardDrawLine(int nOffsetLine){ m_ptDrawLayout.y += nOffsetLine; }
 
-	//ƒŠƒZƒbƒg
+	//ãƒªã‚»ãƒƒãƒˆ
 	void ResetDrawCol(){ m_ptDrawLayout.x = CLayoutInt(0); }
 
-	//æ“¾
+	//å–å¾—
 	CLayoutInt GetDrawCol() const{ return m_ptDrawLayout.x; }
 	CLayoutInt GetDrawLine() const{ return m_ptDrawLayout.y; }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                     ƒeƒLƒXƒgQÆˆÊ’u                        //
+	//                     ãƒ†ã‚­ã‚¹ãƒˆå‚ç…§ä½ç½®                        //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//•ÏX
+	//å¤‰æ›´
 	void SetLayoutLineRef(CLayoutInt nOffsetLine)
 	{
 		m_nLineRef = nOffsetLine;
-		//ƒLƒƒƒbƒVƒ…XV
+		//ã‚­ãƒ£ãƒƒã‚·ãƒ¥æ›´æ–°
 		m_pcLayoutRef = CEditDoc::GetInstance(0)->m_cLayoutMgr.SearchLineByLayoutY( m_nLineRef );
 	}
 	void ForwardLayoutLineRef(int nOffsetLine);
 
 
-	//æ“¾
+	//å–å¾—
 	CLayoutInt		GetLayoutLineRef() const{ return m_nLineRef; }
 	const CLayout*	GetLayoutRef() const{ return m_pcLayoutRef; }
 
 
 private:
-	//ŒÅ’è—v‘f
-	int				m_nDx;			//”¼Šp•¶š‚Ì•¶šŠÔŠuBŒÅ’èB
-	int				m_nDy;			//”¼Šp•¶š‚ÌsŠÔŠuBŒÅ’èB
-	POINT			m_ptDrawOrigin;	//•`‰æˆÊ’uŠî€B’PˆÊ‚ÍƒsƒNƒZƒ‹BŒÅ’èB
+	//å›ºå®šè¦ç´ 
+	int				m_nDx;			//åŠè§’æ–‡å­—ã®æ–‡å­—é–“éš”ã€‚å›ºå®šã€‚
+	int				m_nDy;			//åŠè§’æ–‡å­—ã®è¡Œé–“éš”ã€‚å›ºå®šã€‚
+	POINT			m_ptDrawOrigin;	//æç”»ä½ç½®åŸºæº–ã€‚å˜ä½ã¯ãƒ”ã‚¯ã‚»ãƒ«ã€‚å›ºå®šã€‚
 
-	//•`‰æˆÊ’u
-	CLayoutPoint	m_ptDrawLayout; //•`‰æˆÊ’uB‘Š‘ÎƒŒƒCƒAƒEƒg’PˆÊB
+	//æç”»ä½ç½®
+	CLayoutPoint	m_ptDrawLayout; //æç”»ä½ç½®ã€‚ç›¸å¯¾ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã€‚
 
-	//ƒeƒLƒXƒgQÆˆÊ’u
-	CLayoutInt		m_nLineRef; //â‘ÎƒŒƒCƒAƒEƒg’PˆÊB
+	//ãƒ†ã‚­ã‚¹ãƒˆå‚ç…§ä½ç½®
+	CLayoutInt		m_nLineRef; //çµ¶å¯¾ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå˜ä½ã€‚
 
-	//ƒLƒƒƒbƒVƒ…############
+	//ã‚­ãƒ£ãƒƒã‚·ãƒ¥############
 	const CLayout*		m_pcLayoutRef;
 };
 

--- a/sakura_core/view/colors/CColorStrategy.cpp
+++ b/sakura_core/view/colors/CColorStrategy.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -46,9 +46,9 @@ bool _IsPosKeywordHead(const CStringRef& cStr, int nPos)
 	return (nPos==0 || !IS_KEYWORD_CHAR(cStr.At(nPos-1)));
 }
 
-/*! F‚ÌØ‚è‘Ö‚¦”»’è
-	@retval true F‚Ì•ÏX‚ ‚è
-	@retval false F‚Ì•ÏX‚È‚µ
+/*! è‰²ã®åˆ‡ã‚Šæ›¿ãˆåˆ¤å®š
+	@retval true è‰²ã®å¤‰æ›´ã‚ã‚Š
+	@retval false è‰²ã®å¤‰æ›´ãªã—
 */
 bool SColorStrategyInfo::CheckChangeColor(const CStringRef& cLineStr)
 {
@@ -58,14 +58,14 @@ bool SColorStrategyInfo::CheckChangeColor(const CStringRef& cLineStr)
 	CColor_Select* pcSelect = pool->GetSelectStrategy();
 	bool bChange = false;
 
-	//‘I‘ğ”ÍˆÍFI—¹
+	//é¸æŠç¯„å›²è‰²çµ‚äº†
 	if(m_pStrategySelect){
 		if(m_pStrategySelect->EndColor(cLineStr,this->GetPosInLogic())){
 			m_pStrategySelect = NULL;
 			bChange = true;
 		}
 	}
-	//‘I‘ğ”ÍˆÍFŠJn
+	//é¸æŠç¯„å›²è‰²é–‹å§‹
 	if(!m_pStrategySelect){
 		if(pcSelect->BeginColorEx(cLineStr,this->GetPosInLogic(), m_pDispPos->GetLayoutLineRef(), this->GetLayout())){
 			m_pStrategySelect = pcSelect;
@@ -73,7 +73,7 @@ bool SColorStrategyInfo::CheckChangeColor(const CStringRef& cLineStr)
 		}
 	}
 
-	//ŒŸõFI—¹
+	//æ¤œç´¢è‰²çµ‚äº†
 	if(m_pStrategyFound){
 		if(m_pStrategyFound->EndColor(cLineStr,this->GetPosInLogic())){
 			m_pStrategyFound = NULL;
@@ -81,7 +81,7 @@ bool SColorStrategyInfo::CheckChangeColor(const CStringRef& cLineStr)
 		}
 	}
 
-	//ŒŸõFŠJn
+	//æ¤œç´¢è‰²é–‹å§‹
 	if(!m_pStrategyFound){
 		if(pcFound->BeginColor(cLineStr,this->GetPosInLogic())){
 			m_pStrategyFound = pcFound;
@@ -89,7 +89,7 @@ bool SColorStrategyInfo::CheckChangeColor(const CStringRef& cLineStr)
 		}
 	}
 
-	//FI—¹
+	//è‰²çµ‚äº†
 	if(m_pStrategy){
 		if(m_pStrategy->EndColor(cLineStr,this->GetPosInLogic())){
 			m_pStrategy = NULL;
@@ -97,7 +97,7 @@ bool SColorStrategyInfo::CheckChangeColor(const CStringRef& cLineStr)
 		}
 	}
 
-	//FŠJn
+	//è‰²é–‹å§‹
 	if(!m_pStrategy){
 		int size = pool->GetStrategyCount();
 		for(int i = 0; i < size; i++ ){
@@ -109,7 +109,7 @@ bool SColorStrategyInfo::CheckChangeColor(const CStringRef& cLineStr)
 		}
 	}
 
-	//ƒJ[ƒ\ƒ‹s”wŒiF
+	//ã‚«ãƒ¼ã‚½ãƒ«è¡ŒèƒŒæ™¯è‰²
 	CTypeSupport cCaretLineBg(m_pcView, COLORIDX_CARETLINEBG);
 	if( cCaretLineBg.IsDisp() && !m_pcView->m_bMiniMap ){
 		if(m_colorIdxBackLine==COLORIDX_CARETLINEBG){
@@ -124,7 +124,7 @@ bool SColorStrategyInfo::CheckChangeColor(const CStringRef& cLineStr)
 			}
 		}
 	}
-	//‹ô”s‚Ì”wŒiF
+	//å¶æ•°è¡Œã®èƒŒæ™¯è‰²
 	CTypeSupport cEvenLineBg(m_pcView, COLORIDX_EVENLINEBG);
 	if( cEvenLineBg.IsDisp() && !m_pcView->m_bMiniMap && m_colorIdxBackLine != COLORIDX_CARETLINEBG ){
 		if( m_colorIdxBackLine == COLORIDX_EVENLINEBG ){
@@ -162,9 +162,9 @@ bool SColorStrategyInfo::CheckChangeColor(const CStringRef& cLineStr)
 	return bChange;
 }
 
-/*! F‚ÌØ‚è‘Ö‚¦
+/*! è‰²ã®åˆ‡ã‚Šæ›¿ãˆ
 
-	@date 2013.05.11 novice ÀÛ‚Ì•ÏX‚ÍŒÄ‚Ño‚µ‘¤‚Ås‚¤
+	@date 2013.05.11 novice å®Ÿéš›ã®å¤‰æ›´ã¯å‘¼ã³å‡ºã—å´ã§è¡Œã†
 */
 void SColorStrategyInfo::DoChangeColor(CColor3Setting *pcColor)
 {
@@ -189,7 +189,7 @@ void SColorStrategyInfo::DoChangeColor(CColor3Setting *pcColor)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          ƒv[ƒ‹                             //
+//                          ãƒ—ãƒ¼ãƒ«                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CColorStrategyPool::CColorStrategyPool()
@@ -197,19 +197,19 @@ CColorStrategyPool::CColorStrategyPool()
 	m_pcView = &(CEditWnd::getInstance()->GetView(0));
 	m_pcSelectStrategy = new CColor_Select();
 	m_pcFoundStrategy = new CColor_Found();
-//	m_vStrategies.push_back(new CColor_Found);				// ƒ}ƒbƒ`•¶š—ñ
-	m_vStrategies.push_back(new CColor_RegexKeyword);		// ³‹K•\Œ»ƒL[ƒ[ƒh
-	m_vStrategies.push_back(new CColor_Heredoc);			// ƒqƒAƒhƒLƒ…ƒƒ“ƒg
-	m_vStrategies.push_back(new CColor_BlockComment(COLORIDX_BLOCK1));	// ƒuƒƒbƒNƒRƒƒ“ƒg
-	m_vStrategies.push_back(new CColor_BlockComment(COLORIDX_BLOCK2));	// ƒuƒƒbƒNƒRƒƒ“ƒg2
-	m_vStrategies.push_back(new CColor_LineComment);		// sƒRƒƒ“ƒg
-	m_vStrategies.push_back(new CColor_SingleQuote);		// ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ
-	m_vStrategies.push_back(new CColor_DoubleQuote);		// ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ
+//	m_vStrategies.push_back(new CColor_Found);				// ãƒãƒƒãƒæ–‡å­—åˆ—
+	m_vStrategies.push_back(new CColor_RegexKeyword);		// æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
+	m_vStrategies.push_back(new CColor_Heredoc);			// ãƒ’ã‚¢ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ
+	m_vStrategies.push_back(new CColor_BlockComment(COLORIDX_BLOCK1));	// ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ
+	m_vStrategies.push_back(new CColor_BlockComment(COLORIDX_BLOCK2));	// ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ2
+	m_vStrategies.push_back(new CColor_LineComment);		// è¡Œã‚³ãƒ¡ãƒ³ãƒˆ
+	m_vStrategies.push_back(new CColor_SingleQuote);		// ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—
+	m_vStrategies.push_back(new CColor_DoubleQuote);		// ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—
 	m_vStrategies.push_back(new CColor_Url);				// URL
-	m_vStrategies.push_back(new CColor_Numeric);			// ”¼Šp”š
-	m_vStrategies.push_back(new CColor_KeywordSet);			// ƒL[ƒ[ƒhƒZƒbƒg
+	m_vStrategies.push_back(new CColor_Numeric);			// åŠè§’æ•°å­—
+	m_vStrategies.push_back(new CColor_KeywordSet);			// ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ
 
-	// İ’èXV
+	// è¨­å®šæ›´æ–°
 	OnChangeSetting();
 }
 
@@ -250,25 +250,25 @@ void CColorStrategyPool::NotifyOnStartScanLogic()
 }
 
 
-// 2005.11.20 MocaƒRƒƒ“ƒg‚ÌF•ª‚¯‚ªON/OFFŠÖŒW‚È‚­s‚í‚ê‚Ä‚¢‚½ƒoƒO‚ğC³
+// 2005.11.20 Mocaã‚³ãƒ¡ãƒ³ãƒˆã®è‰²åˆ†ã‘ãŒON/OFFé–¢ä¿‚ãªãè¡Œã‚ã‚Œã¦ã„ãŸãƒã‚°ã‚’ä¿®æ­£
 void CColorStrategyPool::CheckColorMODE(
 	CColorStrategy**	ppcColorStrategy,	//!< [in,out]
 	int					nPos,
 	const CStringRef&	cLineStr
 )
 {
-	//FI—¹
+	//è‰²çµ‚äº†
 	if(*ppcColorStrategy){
 		if((*ppcColorStrategy)->EndColor(cLineStr,nPos)){
 			*ppcColorStrategy = NULL;
 		}
 	}
 
-	//FŠJn
+	//è‰²é–‹å§‹
 	if(!*ppcColorStrategy){
-		// CheckColorMODE ‚ÍƒŒƒCƒAƒEƒgˆ—‘S‘Ì‚Ìƒ{ƒgƒ‹ƒlƒbƒN‚É‚È‚é‚­‚ç‚¢•p”É‚ÉŒÄ‚Ño‚³‚ê‚é
-		// Šî–{ƒNƒ‰ƒX‚©‚ç‚Ì“®“I‰¼‘zŠÖ”ŒÄ‚Ño‚µ‚ğg—p‚·‚é‚Æ–³‹‚Å‚«‚È‚¢‚Ù‚Ç‚ÌƒI[ƒoƒwƒbƒh‚É‚È‚é–Í—l
-		// ‚±‚±‚ÍƒGƒŒƒKƒ“ƒg‚³‚æ‚è‚à«”\—Dæ‚ÅŒÂX‚Ì”h¶ƒNƒ‰ƒX‚©‚ç BeginColor() ‚ğŒÄ‚Ño‚·
+		// CheckColorMODE ã¯ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆå‡¦ç†å…¨ä½“ã®ãƒœãƒˆãƒ«ãƒãƒƒã‚¯ã«ãªã‚‹ãã‚‰ã„é »ç¹ã«å‘¼ã³å‡ºã•ã‚Œã‚‹
+		// åŸºæœ¬ã‚¯ãƒ©ã‚¹ã‹ã‚‰ã®å‹•çš„ä»®æƒ³é–¢æ•°å‘¼ã³å‡ºã—ã‚’ä½¿ç”¨ã™ã‚‹ã¨ç„¡è¦–ã§ããªã„ã»ã©ã®ã‚ªãƒ¼ãƒãƒ˜ãƒƒãƒ‰ã«ãªã‚‹æ¨¡æ§˜
+		// ã“ã“ã¯ã‚¨ãƒ¬ã‚¬ãƒ³ãƒˆã•ã‚ˆã‚Šã‚‚æ€§èƒ½å„ªå…ˆã§å€‹ã€…ã®æ´¾ç”Ÿã‚¯ãƒ©ã‚¹ã‹ã‚‰ BeginColor() ã‚’å‘¼ã³å‡ºã™
 		if(m_pcHeredoc && m_pcHeredoc->BeginColor(cLineStr,nPos)){ *ppcColorStrategy = m_pcHeredoc; return; }
 		if(m_pcBlockComment1 && m_pcBlockComment1->BeginColor(cLineStr,nPos)){ *ppcColorStrategy = m_pcBlockComment1; return; }
 		if(m_pcBlockComment2 && m_pcBlockComment2->BeginColor(cLineStr,nPos)){ *ppcColorStrategy = m_pcBlockComment2; return; }
@@ -278,7 +278,7 @@ void CColorStrategyPool::CheckColorMODE(
 	}
 }
 
-/*! İ’èXV
+/*! è¨­å®šæ›´æ–°
 */
 void CColorStrategyPool::OnChangeSetting(void)
 {
@@ -290,21 +290,21 @@ void CColorStrategyPool::OnChangeSetting(void)
 	for(int i = 0; i < size; i++){
 		m_vStrategies[i]->Update();
 
-		// F•ª‚¯•\¦‘ÎÛ‚Å‚ ‚ê‚Î“o˜^
+		// è‰²åˆ†ã‘è¡¨ç¤ºå¯¾è±¡ã§ã‚ã‚Œã°ç™»éŒ²
 		if( m_vStrategies[i]->Disp() ){
 			m_vStrategiesDisp.push_back(m_vStrategies[i]);
 		}
 	}
 
-	// CheckColorMODE —p
+	// CheckColorMODE ç”¨
 	m_pcHeredoc = static_cast<CColor_Heredoc*>(GetStrategyByColor(COLORIDX_HEREDOC));
-	m_pcBlockComment1 = static_cast<CColor_BlockComment*>(GetStrategyByColor(COLORIDX_BLOCK1));	// ƒuƒƒbƒNƒRƒƒ“ƒg
-	m_pcBlockComment2 = static_cast<CColor_BlockComment*>(GetStrategyByColor(COLORIDX_BLOCK2));	// ƒuƒƒbƒNƒRƒƒ“ƒg2
-	m_pcLineComment = static_cast<CColor_LineComment*>(GetStrategyByColor(COLORIDX_COMMENT));	// sƒRƒƒ“ƒg
-	m_pcSingleQuote = static_cast<CColor_SingleQuote*>(GetStrategyByColor(COLORIDX_SSTRING));	// ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ
-	m_pcDoubleQuote = static_cast<CColor_DoubleQuote*>(GetStrategyByColor(COLORIDX_WSTRING));	// ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ
+	m_pcBlockComment1 = static_cast<CColor_BlockComment*>(GetStrategyByColor(COLORIDX_BLOCK1));	// ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ
+	m_pcBlockComment2 = static_cast<CColor_BlockComment*>(GetStrategyByColor(COLORIDX_BLOCK2));	// ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ2
+	m_pcLineComment = static_cast<CColor_LineComment*>(GetStrategyByColor(COLORIDX_COMMENT));	// è¡Œã‚³ãƒ¡ãƒ³ãƒˆ
+	m_pcSingleQuote = static_cast<CColor_SingleQuote*>(GetStrategyByColor(COLORIDX_SSTRING));	// ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—
+	m_pcDoubleQuote = static_cast<CColor_DoubleQuote*>(GetStrategyByColor(COLORIDX_WSTRING));	// ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—
 
-	// F•ª‚¯‚ğ‚µ‚È‚¢ê‡‚ÉAˆ—‚ğƒXƒLƒbƒv‚Å‚«‚é‚æ‚¤‚ÉŠm”F‚·‚é
+	// è‰²åˆ†ã‘ã‚’ã—ãªã„å ´åˆã«ã€å‡¦ç†ã‚’ã‚¹ã‚­ãƒƒãƒ—ã§ãã‚‹ã‚ˆã†ã«ç¢ºèªã™ã‚‹
 	const STypeConfig& type = CEditDoc::GetInstance(0)->m_cDocType.GetDocumentAttribute();
 	EColorIndexType bSkipColorTypeTable[] = {
 		COLORIDX_DIGIT,
@@ -333,7 +333,7 @@ void CColorStrategyPool::OnChangeSetting(void)
 		}
 		if( COLORIDX_KEYWORD1 <= bSkipColorTypeTable[n] && bSkipColorTypeTable[n] <= COLORIDX_KEYWORD10 ){
 			if( type.m_nKeyWordSetIdx[n - nKeyword1] == -1 ){
-				bUnuseKeyword = true; // -1ˆÈ~‚Í–³Œø
+				bUnuseKeyword = true; // -1ä»¥é™ã¯ç„¡åŠ¹
 			}
 			if( !bUnuseKeyword && type.m_ColorInfoArr[bSkipColorTypeTable[n]].m_bDisp ){
 				m_bSkipBeforeLayoutGeneral = false;
@@ -373,22 +373,22 @@ bool CColorStrategyPool::IsSkipBeforeLayout()
 
 
 /*!
-  ini‚ÌFİ’è‚ğ”Ô†‚Å‚È‚­•¶š—ñ‚Å‘‚«o‚·B(added by Stonee, 2001/01/12, 2001/01/15)
-  ”z—ñ‚Ì‡”Ô‚Í‹¤—Lƒƒ‚ƒŠ’†‚Ìƒf[ƒ^‚Ì‡”Ô‚Æˆê’v‚µ‚Ä‚¢‚éB
+  iniã®è‰²è¨­å®šã‚’ç•ªå·ã§ãªãæ–‡å­—åˆ—ã§æ›¸ãå‡ºã™ã€‚(added by Stonee, 2001/01/12, 2001/01/15)
+  é…åˆ—ã®é †ç•ªã¯å…±æœ‰ãƒ¡ãƒ¢ãƒªä¸­ã®ãƒ‡ãƒ¼ã‚¿ã®é †ç•ªã¨ä¸€è‡´ã—ã¦ã„ã‚‹ã€‚
 
-  @note ”’l‚É‚æ‚é“à•”“I‘Î‰‚Í EColorIndexType EColorIndexType.h
-  “ú–{Œê–¼‚È‚Ç‚Í  ColorInfo_DEFAULT CDocTypeSetting.cpp
-  CShareData‚©‚çglobal‚ÉˆÚ“®
+  @note æ•°å€¤ã«ã‚ˆã‚‹å†…éƒ¨çš„å¯¾å¿œã¯ EColorIndexType EColorIndexType.h
+  æ—¥æœ¬èªåãªã©ã¯  ColorInfo_DEFAULT CDocTypeSetting.cpp
+  CShareDataã‹ã‚‰globalã«ç§»å‹•
 */
 const SColorAttributeData g_ColorAttributeArr[] =
 {
 	{_T("TXT"), COLOR_ATTRIB_FORCE_DISP | COLOR_ATTRIB_NO_EFFECTS},
 	{_T("RUL"), COLOR_ATTRIB_NO_EFFECTS},
-	{_T("CAR"), COLOR_ATTRIB_FORCE_DISP | COLOR_ATTRIB_NO_BACK | COLOR_ATTRIB_NO_EFFECTS},	// ƒLƒƒƒŒƒbƒg		// 2006.12.07 ryoji
-	{_T("IME"), COLOR_ATTRIB_NO_BACK | COLOR_ATTRIB_NO_EFFECTS},	// IMEƒLƒƒƒŒƒbƒg	// 2006.12.07 ryoji
+	{_T("CAR"), COLOR_ATTRIB_FORCE_DISP | COLOR_ATTRIB_NO_BACK | COLOR_ATTRIB_NO_EFFECTS},	// ã‚­ãƒ£ãƒ¬ãƒƒãƒˆ		// 2006.12.07 ryoji
+	{_T("IME"), COLOR_ATTRIB_NO_BACK | COLOR_ATTRIB_NO_EFFECTS},	// IMEã‚­ãƒ£ãƒ¬ãƒƒãƒˆ	// 2006.12.07 ryoji
 	{_T("CBK"), COLOR_ATTRIB_NO_TEXT | COLOR_ATTRIB_NO_EFFECTS},
 	{_T("UND"), COLOR_ATTRIB_NO_BACK | COLOR_ATTRIB_NO_EFFECTS},
-	{_T("CVL"), COLOR_ATTRIB_NO_BACK | ( COLOR_ATTRIB_NO_EFFECTS & ~COLOR_ATTRIB_NO_BOLD )}, // 2007.09.09 Moca ƒJ[ƒ\ƒ‹ˆÊ’ucü
+	{_T("CVL"), COLOR_ATTRIB_NO_BACK | ( COLOR_ATTRIB_NO_EFFECTS & ~COLOR_ATTRIB_NO_BOLD )}, // 2007.09.09 Moca ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·š
 	{_T("NOT"), COLOR_ATTRIB_NO_BACK | COLOR_ATTRIB_NO_EFFECTS},
 	{_T("LNO"), 0},
 	{_T("MOD"), 0},
@@ -399,10 +399,10 @@ const SColorAttributeData g_ColorAttributeArr[] =
 	{_T("CTL"), 0},
 	{_T("EOL"), 0},
 	{_T("RAP"), 0},
-	{_T("VER"), 0},  // 2005.11.08 Moca w’èŒ…cü
+	{_T("VER"), 0},  // 2005.11.08 Moca æŒ‡å®šæ¡ç¸¦ç·š
 	{_T("EOF"), 0},
-	{_T("NUM"), 0},	//@@@ 2001.02.17 by MIK ”¼Šp”’l‚Ì‹­’²
-	{_T("BRC"), 0},	//‘ÎŠ‡ŒÊ	// 02/09/18 ai Add
+	{_T("NUM"), 0},	//@@@ 2001.02.17 by MIK åŠè§’æ•°å€¤ã®å¼·èª¿
+	{_T("BRC"), 0},	//å¯¾æ‹¬å¼§	// 02/09/18 ai Add
 	{_T("SEL"), 0},
 	{_T("FND"), 0},
 	{_T("FN2"), 0},
@@ -416,7 +416,7 @@ const SColorAttributeData g_ColorAttributeArr[] =
 	{_T("URL"), 0},
 	{_T("KW1"), 0},
 	{_T("KW2"), 0},
-	{_T("KW3"), 0},	//@@@ 2003.01.13 by MIK ‹­’²ƒL[ƒ[ƒh3-10
+	{_T("KW3"), 0},	//@@@ 2003.01.13 by MIK å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰3-10
 	{_T("KW4"), 0},
 	{_T("KW5"), 0},
 	{_T("KW6"), 0},
@@ -434,10 +434,10 @@ const SColorAttributeData g_ColorAttributeArr[] =
 	{_T("RK8"), 0},	//@@@ 2001.11.17 add MIK
 	{_T("RK9"), 0},	//@@@ 2001.11.17 add MIK
 	{_T("RKA"), 0},	//@@@ 2001.11.17 add MIK
-	{_T("DFA"), 0},	//DIFF’Ç‰Á	//@@@ 2002.06.01 MIK
-	{_T("DFC"), 0},	//DIFF•ÏX	//@@@ 2002.06.01 MIK
-	{_T("DFD"), 0},	//DIFFíœ	//@@@ 2002.06.01 MIK
-	{_T("MRK"), 0},	//ƒuƒbƒNƒ}[ƒN	// 02/10/16 ai Add
+	{_T("DFA"), 0},	//DIFFè¿½åŠ 	//@@@ 2002.06.01 MIK
+	{_T("DFC"), 0},	//DIFFå¤‰æ›´	//@@@ 2002.06.01 MIK
+	{_T("DFD"), 0},	//DIFFå‰Šé™¤	//@@@ 2002.06.01 MIK
+	{_T("MRK"), 0},	//ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯	// 02/10/16 ai Add
 	{_T("PGV"), COLOR_ATTRIB_NO_TEXT | COLOR_ATTRIB_NO_EFFECTS},
 	{_T("LAST"), 0}	// Not Used
 };
@@ -445,7 +445,7 @@ const SColorAttributeData g_ColorAttributeArr[] =
 
 
 /*
- * ƒJƒ‰[–¼‚©‚çƒCƒ“ƒfƒbƒNƒX”Ô†‚É•ÏŠ·‚·‚é
+ * ã‚«ãƒ©ãƒ¼åã‹ã‚‰ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ç•ªå·ã«å¤‰æ›ã™ã‚‹
  */
 int GetColorIndexByName( const TCHAR *name )
 {
@@ -458,7 +458,7 @@ int GetColorIndexByName( const TCHAR *name )
 }
 
 /*
- * ƒCƒ“ƒfƒbƒNƒX”Ô†‚©‚çƒJƒ‰[–¼‚É•ÏŠ·‚·‚é
+ * ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ç•ªå·ã‹ã‚‰ã‚«ãƒ©ãƒ¼åã«å¤‰æ›ã™ã‚‹
  */
 const TCHAR* GetColorNameByIndex( int index )
 {

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -24,7 +24,7 @@
 #ifndef SAKURA_CCOLORSTRATEGY_BC7B5956_A0AF_4C9C_9C0E_07FE658028AC9_H_
 #define SAKURA_CCOLORSTRATEGY_BC7B5956_A0AF_4C9C_9C0E_07FE658028AC9_H_
 
-// —væs’è‹`
+// è¦å…ˆè¡Œå®šç¾©
 // #include "view/CEditView.h"
 #include "EColorIndexType.h"
 #include "uiparts/CGraphics.h"
@@ -34,21 +34,21 @@ class	CEditView;
 bool _IsPosKeywordHead(const CStringRef& cStr, int nPos);
 
 
-//! ³‹K•\Œ»ƒL[ƒ[ƒh‚ÌEColorIndexType’l‚ğì‚éŠÖ”
+//! æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®EColorIndexTypeå€¤ã‚’ä½œã‚‹é–¢æ•°
 inline EColorIndexType ToColorIndexType_RegularExpression(const int nRegexColorIndex)
 {
 	return (EColorIndexType)(COLORIDX_REGEX_FIRST + nRegexColorIndex);
 }
 
-//! ³‹K•\Œ»ƒL[ƒ[ƒh‚ÌEColorIndexType’l‚ğF”Ô†‚É–ß‚·ŠÖ”
+//! æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã®EColorIndexTypeå€¤ã‚’è‰²ç•ªå·ã«æˆ»ã™é–¢æ•°
 inline int ToColorInfoArrIndex_RegularExpression(const EColorIndexType eRegexColorIndex)
 {
 	return eRegexColorIndex - COLORIDX_REGEX_FIRST;
 }
 
-/*! F’è”‚ğF”Ô†‚É•ÏŠ·‚·‚éŠÖ”
+/*! è‰²å®šæ•°ã‚’è‰²ç•ªå·ã«å¤‰æ›ã™ã‚‹é–¢æ•°
 
-	@date 2013.05.08 novice ”ÍˆÍŠO‚Ì‚Æ‚«‚ÍƒeƒLƒXƒg‚ğ‘I‘ğ‚·‚é
+	@date 2013.05.08 novice ç¯„å›²å¤–ã®ã¨ãã¯ãƒ†ã‚­ã‚¹ãƒˆã‚’é¸æŠã™ã‚‹
 */
 inline int ToColorInfoArrIndex(const EColorIndexType eColorIndex)
 {
@@ -59,17 +59,17 @@ inline int ToColorInfoArrIndex(const EColorIndexType eColorIndex)
 	else if( eColorIndex & COLORIDX_REGEX_BIT )
 		return ToColorInfoArrIndex_RegularExpression( eColorIndex );
 
-	assert(0); // ‚±‚±‚É‚Í—ˆ‚È‚¢
+	assert(0); // ã“ã“ã«ã¯æ¥ãªã„
 	return COLORIDX_TEXT;
 }
 
-// ƒJƒ‰[–¼ƒ„ƒCƒ“ƒfƒbƒNƒX”Ô†‚Ì•ÏŠ·	//@@@ 2002.04.30
+// ã‚«ãƒ©ãƒ¼åï¼œï¼ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ç•ªå·ã®å¤‰æ›	//@@@ 2002.04.30
 int GetColorIndexByName( const TCHAR *name );
 const TCHAR* GetColorNameByIndex( int index );
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                           Šî’ê                              //
+//                           åŸºåº•                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 struct DispPos;
@@ -79,11 +79,11 @@ class CColorStrategy;
 class CColor_Found;
 class CColor_Select;
 
-//! Fİ’è
+//! è‰²è¨­å®š
 struct CColor3Setting {
-	EColorIndexType eColorIndex;    //!< ‘I‘ğ‚ğŠÜ‚ŞŒ»İ‚ÌF
-	EColorIndexType eColorIndex2;   //!< ‘I‘ğˆÈŠO‚ÌŒ»İ‚ÌF
-	EColorIndexType eColorIndexBg;  //!< ”wŒiF
+	EColorIndexType eColorIndex;    //!< é¸æŠã‚’å«ã‚€ç¾åœ¨ã®è‰²
+	EColorIndexType eColorIndex2;   //!< é¸æŠä»¥å¤–ã®ç¾åœ¨ã®è‰²
+	EColorIndexType eColorIndexBg;  //!< èƒŒæ™¯è‰²
 };
 
 struct SColorStrategyInfo{
@@ -93,33 +93,33 @@ struct SColorStrategyInfo{
 		m_cIndex.eColorIndexBg = COLORIDX_TEXT;
 	}
 
-	//QÆ
+	//å‚ç…§
 	CEditView*	m_pcView;
-	CGraphics	m_gr;	//(SColorInfo‚Å‚Í–¢g—p)
+	CGraphics	m_gr;	//(SColorInfoã§ã¯æœªä½¿ç”¨)
 
-	//ƒXƒLƒƒƒ“ˆÊ’u
+	//ã‚¹ã‚­ãƒ£ãƒ³ä½ç½®
 	LPCWSTR			m_pLineOfLogic;
 	CLogicInt		m_nPosInLogic;
 
-	//•`‰æˆÊ’u
+	//æç”»ä½ç½®
 	DispPos*		m_pDispPos;
 	DispPos			m_sDispPosBegin;
 
-	//F•Ï‚¦
+	//è‰²å¤‰ãˆ
 	CColorStrategy*		m_pStrategy;
 	CColor_Found*		m_pStrategyFound;
 	CColor_Select*		m_pStrategySelect;
 	EColorIndexType		m_colorIdxBackLine;
 	CColor3Setting		m_cIndex;
 
-	//! F‚ÌØ‚è‘Ö‚¦
+	//! è‰²ã®åˆ‡ã‚Šæ›¿ãˆ
 	bool CheckChangeColor(const CStringRef& cLineStr);
 	void DoChangeColor(CColor3Setting *pcColor);
 	EColorIndexType GetCurrentColor() const { return m_cIndex.eColorIndex; }
 	EColorIndexType GetCurrentColor2() const { return m_cIndex.eColorIndex2; }
 	EColorIndexType GetCurrentColorBg() const{ return m_cIndex.eColorIndexBg; }
 
-	//! Œ»İ‚ÌƒXƒLƒƒƒ“ˆÊ’u
+	//! ç¾åœ¨ã®ã‚¹ã‚­ãƒ£ãƒ³ä½ç½®
 	CLogicInt GetPosInLogic() const
 	{
 		return m_nPosInLogic;
@@ -137,28 +137,28 @@ struct SColorStrategyInfo{
 class CColorStrategy{
 public:
 	virtual ~CColorStrategy(){}
-	//! F’è‹`
+	//! è‰²å®šç¾©
 	virtual EColorIndexType GetStrategyColor() const = 0;
 	virtual CLayoutColorInfo* GetStrategyColorInfo() const{
 		return NULL;
 	}
-	//! FØ‚è‘Ö‚¦ŠJn‚ğŒŸo‚µ‚½‚çA‚»‚Ì’¼‘O‚Ü‚Å‚Ì•`‰æ‚ğs‚¢A‚³‚ç‚ÉFİ’è‚ğs‚¤B
+	//! è‰²åˆ‡ã‚Šæ›¿ãˆé–‹å§‹ã‚’æ¤œå‡ºã—ãŸã‚‰ã€ãã®ç›´å‰ã¾ã§ã®æç”»ã‚’è¡Œã„ã€ã•ã‚‰ã«è‰²è¨­å®šã‚’è¡Œã†ã€‚
 	virtual void InitStrategyStatus() = 0;
 	virtual void SetStrategyColorInfo(const CLayoutColorInfo* = NULL){};
 	virtual bool BeginColor(const CStringRef& cStr, int nPos){ return false; }
 	virtual bool EndColor(const CStringRef& cStr, int nPos){ return true; }
 	virtual bool Disp() const = 0;
-	//ƒCƒxƒ“ƒg
+	//ã‚¤ãƒ™ãƒ³ãƒˆ
 	virtual void OnStartScanLogic(){}
 
-	//! İ’èXV
+	//! è¨­å®šæ›´æ–°
 	virtual void Update(void)
 	{
 		const CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
 		m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
 	}
 
-	//#######ƒ‰ƒbƒv
+	//#######ãƒ©ãƒƒãƒ—
 	EColorIndexType GetStrategyColorSafe() const{ if(this)return GetStrategyColor(); else return COLORIDX_TEXT; }
 	CLayoutColorInfo* GetStrategyColorInfoSafe() const{
 		if(this){
@@ -187,36 +187,36 @@ class CColorStrategyPool : public TSingleton<CColorStrategyPool>{
 
 public:
 
-	//æ“¾
+	//å–å¾—
 	CColorStrategy*	GetStrategy(int nIndex) const{ return m_vStrategiesDisp[nIndex]; }
 	int				GetStrategyCount() const{ return (int)m_vStrategiesDisp.size(); }
 	CColorStrategy*	GetStrategyByColor(EColorIndexType eColor) const;
 
-	//“Á’èæ“¾
+	//ç‰¹å®šå–å¾—
 	CColor_Found*   GetFoundStrategy() const{ return m_pcFoundStrategy; }
 	CColor_Select*  GetSelectStrategy() const{ return m_pcSelectStrategy; }
 
-	//ƒCƒxƒ“ƒg
+	//ã‚¤ãƒ™ãƒ³ãƒˆ
 	void NotifyOnStartScanLogic();
 
 	/*
-	|| F•ª‚¯
+	|| è‰²åˆ†ã‘
 	*/
 	//@@@ 2002.09.22 YAZAKI
-	// 2005.11.21 Moca ˆø—p•„‚ÌF•ª‚¯î•ñ‚ğˆø”‚©‚çœ‹
+	// 2005.11.21 Moca å¼•ç”¨ç¬¦ã®è‰²åˆ†ã‘æƒ…å ±ã‚’å¼•æ•°ã‹ã‚‰é™¤å»
 	void CheckColorMODE( CColorStrategy** ppcColorStrategy, int nPos, const CStringRef& cLineStr );
-	bool IsSkipBeforeLayout();	// ƒŒƒCƒAƒEƒg‚ªs“ª‚©‚çƒ`ƒFƒbƒN‚µ‚È‚­‚Ä‚¢‚¢‚©”»’è
+	bool IsSkipBeforeLayout();	// ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆãŒè¡Œé ­ã‹ã‚‰ãƒã‚§ãƒƒã‚¯ã—ãªãã¦ã„ã„ã‹åˆ¤å®š
 
-	//İ’è•ÏX
+	//è¨­å®šå¤‰æ›´
 	void OnChangeSetting(void);
 
-	//ƒrƒ…[‚Ìİ’èEæ“¾
+	//ãƒ“ãƒ¥ãƒ¼ã®è¨­å®šãƒ»å–å¾—
 	CEditView* GetCurrentView(void) const{ return m_pcView; }
 	void SetCurrentView(CEditView* pcView) { m_pcView = pcView; }
 
 private:
 	std::vector<CColorStrategy*>	m_vStrategies;
-	std::vector<CColorStrategy*>	m_vStrategiesDisp;	//!< F•ª‚¯•\¦‘ÎÛ
+	std::vector<CColorStrategy*>	m_vStrategiesDisp;	//!< è‰²åˆ†ã‘è¡¨ç¤ºå¯¾è±¡
 	CColor_Found*					m_pcFoundStrategy;
 	CColor_Select*					m_pcSelectStrategy;
 

--- a/sakura_core/view/colors/CColor_Comment.cpp
+++ b/sakura_core/view/colors/CColor_Comment.cpp
@@ -1,17 +1,17 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CColor_Comment.h"
 #include "doc/layout/CLayout.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        sƒRƒƒ“ƒg                           //
+//                        è¡Œã‚³ãƒ¡ãƒ³ãƒˆ                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 bool CColor_LineComment::BeginColor(const CStringRef& cStr, int nPos)
 {
 	if(!cStr.IsValid())return false;
 
-	// sƒRƒƒ“ƒg
+	// è¡Œã‚³ãƒ¡ãƒ³ãƒˆ
 	if( m_pTypeData->m_cLineComment.Match( nPos, cStr )	//@@@ 2002.09.22 YAZAKI
 	){
 		return true;
@@ -21,12 +21,12 @@ bool CColor_LineComment::BeginColor(const CStringRef& cStr, int nPos)
 
 bool CColor_LineComment::EndColor(const CStringRef& cStr, int nPos)
 {
-	//•¶Žš—ñI’[
+	//æ–‡å­—åˆ—çµ‚ç«¯
 	if( nPos >= cStr.GetLength() ){
 		return true;
 	}
 
-	//‰üs
+	//æ”¹è¡Œ
 	if( WCODE::IsLineDelimiter(cStr.At(nPos), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 		return true;
 	}
@@ -38,17 +38,17 @@ bool CColor_LineComment::EndColor(const CStringRef& cStr, int nPos)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                    ƒuƒƒbƒNƒRƒƒ“ƒg‚P                       //
+//                    ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆï¼‘                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 bool CColor_BlockComment::BeginColor(const CStringRef& cStr, int nPos)
 {
 	if(!cStr.IsValid())return false;
 
-	// ƒuƒƒbƒNƒRƒƒ“ƒg
+	// ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ
 	if( m_pcBlockComment->Match_CommentFrom( nPos, cStr )	//@@@ 2002.09.22 YAZAKI
 	){
-		/* ‚±‚Ì•¨—s‚ÉƒuƒƒbƒNƒRƒƒ“ƒg‚ÌI’[‚ª‚ ‚é‚© */	//@@@ 2002.09.22 YAZAKI
+		/* ã“ã®ç‰©ç†è¡Œã«ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆã®çµ‚ç«¯ãŒã‚ã‚‹ã‹ */	//@@@ 2002.09.22 YAZAKI
 		this->m_nCOMMENTEND = m_pcBlockComment->Match_CommentTo(
 			nPos + m_pcBlockComment->getBlockFromLen(),
 			cStr
@@ -62,7 +62,7 @@ bool CColor_BlockComment::BeginColor(const CStringRef& cStr, int nPos)
 bool CColor_BlockComment::EndColor(const CStringRef& cStr, int nPos)
 {
 	if( 0 == this->m_nCOMMENTEND ){
-		/* ‚±‚Ì•¨—s‚ÉƒuƒƒbƒNƒRƒƒ“ƒg‚ÌI’[‚ª‚ ‚é‚© */
+		/* ã“ã®ç‰©ç†è¡Œã«ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆã®çµ‚ç«¯ãŒã‚ã‚‹ã‹ */
 		this->m_nCOMMENTEND = m_pcBlockComment->Match_CommentTo(
 			nPos,
 			cStr

--- a/sakura_core/view/colors/CColor_Comment.h
+++ b/sakura_core/view/colors/CColor_Comment.h
@@ -1,4 +1,4 @@
-/*
+Ôªø/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -28,7 +28,7 @@
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                        çsÉRÉÅÉìÉg                           //
+//                        Ë°å„Ç≥„É°„É≥„Éà                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 class CColor_LineComment : public CColorStrategy{
@@ -42,7 +42,7 @@ public:
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                    ÉuÉçÉbÉNÉRÉÅÉìÉgÇP                       //
+//                    „Éñ„É≠„ÉÉ„ÇØ„Ç≥„É°„É≥„ÉàÔºë                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 class CColor_BlockComment : public CColorStrategy{

--- a/sakura_core/view/colors/CColor_Found.cpp
+++ b/sakura_core/view/colors/CColor_Found.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CColor_Found.h"
 #include "types/CTypeSupport.h"
@@ -29,7 +29,7 @@ bool CColor_Select::BeginColorEx(const CStringRef& cStr, int nPos, CLayoutInt nL
 		return false;
 	}
 
-	// 2011.12.27 ƒŒƒCƒAƒEƒgs“ª‚Å1‰ñ‚¾‚¯Šm”F‚µ‚Ä‚ ‚Æ‚Íƒƒ“ƒo[•Ï”‚ğ‚İ‚é
+	// 2011.12.27 ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆè¡Œé ­ã§1å›ã ã‘ç¢ºèªã—ã¦ã‚ã¨ã¯ãƒ¡ãƒ³ãƒãƒ¼å¤‰æ•°ã‚’ã¿ã‚‹
 	if( m_nSelectLine == nLineNum ){
 		if( m_nSelectStart <= nPos && nPos < m_nSelectEnd ){
 			return true;
@@ -57,9 +57,9 @@ bool CColor_Select::BeginColorEx(const CStringRef& cStr, int nPos, CLayoutInt nL
 
 bool CColor_Select::EndColor(const CStringRef& cStr, int nPos)
 {
-	//ƒ}ƒbƒ`•¶š—ñI—¹ŒŸo
+	//ãƒãƒƒãƒæ–‡å­—åˆ—çµ‚äº†æ¤œå‡º
 	if( m_nSelectEnd <= nPos ){
-		// -- -- ƒ}ƒbƒ`•¶š—ñ‚ğ•`‰æ -- -- //
+		// -- -- ãƒãƒƒãƒæ–‡å­—åˆ—ã‚’æç”» -- -- //
 
 		return true;
 	}
@@ -95,9 +95,9 @@ bool CColor_Found::BeginColor(const CStringRef& cStr, int nPos)
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//        ŒŸõƒqƒbƒgƒtƒ‰ƒOİ’è -> bSearchStringMode            //
+	//        æ¤œç´¢ãƒ’ãƒƒãƒˆãƒ•ãƒ©ã‚°è¨­å®š -> bSearchStringMode            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	// 2002.02.08 hor ³‹K•\Œ»‚ÌŒŸõ•¶š—ñƒ}[ƒN‚ğ­‚µ‚‘¬‰»
+	// 2002.02.08 hor æ­£è¦è¡¨ç¾ã®æ¤œç´¢æ–‡å­—åˆ—ãƒãƒ¼ã‚¯ã‚’å°‘ã—é«˜é€ŸåŒ–
 	if( pcView->m_sCurSearchOption.bWordOnly || (m_nSearchResult && m_nSearchStart < nPos) ){
 		m_nSearchResult = pcView->IsSearchString(
 			cStr,
@@ -106,7 +106,7 @@ bool CColor_Found::BeginColor(const CStringRef& cStr, int nPos)
 			&m_nSearchEnd
 		);
 	}
-	//ƒ}ƒbƒ`•¶š—ñŒŸo
+	//ãƒãƒƒãƒæ–‡å­—åˆ—æ¤œå‡º
 	if( m_nSearchResult && m_nSearchStart==nPos){
 		return true;
 	}
@@ -115,9 +115,9 @@ bool CColor_Found::BeginColor(const CStringRef& cStr, int nPos)
 
 bool CColor_Found::EndColor(const CStringRef& cStr, int nPos)
 {
-	//ƒ}ƒbƒ`•¶š—ñI—¹ŒŸo
-	if( m_nSearchEnd <= nPos ){ //+ == ‚Å‚Ís“ª•¶š‚Ìê‡Am_nSearchEnd‚à‚O‚Å‚ ‚é‚½‚ß‚É•¶šF‚Ì‰ğœ‚ª‚Å‚«‚È‚¢ƒoƒO‚ğC³ 2003.05.03 ‚©‚ë‚Æ
-		// -- -- ƒ}ƒbƒ`•¶š—ñ‚ğ•`‰æ -- -- //
+	//ãƒãƒƒãƒæ–‡å­—åˆ—çµ‚äº†æ¤œå‡º
+	if( m_nSearchEnd <= nPos ){ //+ == ã§ã¯è¡Œé ­æ–‡å­—ã®å ´åˆã€m_nSearchEndã‚‚ï¼ã§ã‚ã‚‹ãŸã‚ã«æ–‡å­—è‰²ã®è§£é™¤ãŒã§ããªã„ãƒã‚°ã‚’ä¿®æ­£ 2003.05.03 ã‹ã‚ã¨
+		// -- -- ãƒãƒƒãƒæ–‡å­—åˆ—ã‚’æç”» -- -- //
 
 		return true;
 	}

--- a/sakura_core/view/colors/CColor_Found.h
+++ b/sakura_core/view/colors/CColor_Found.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -29,7 +29,7 @@
 class CColor_Select : public CColorStrategy{
 public:
 	virtual EColorIndexType GetStrategyColor() const{ return COLORIDX_SELECT; }
-	//F‘Ö‚¦
+	//è‰²æ›¿ãˆ
 	virtual void InitStrategyStatus(){ }
 	virtual bool BeginColor(const CStringRef& cStr, int nPos);
 	virtual bool Disp() const { return true; }
@@ -37,7 +37,7 @@ public:
 
 	virtual bool BeginColorEx(const CStringRef& cStr, int nPos, CLayoutInt, const CLayout*);
 
-	//ƒCƒxƒ“ƒg
+	//ã‚¤ãƒ™ãƒ³ãƒˆ
 	virtual void OnStartScanLogic();
 
 private:
@@ -51,20 +51,20 @@ public:
 	CColor_Found();
 	virtual EColorIndexType GetStrategyColor() const
 	{ return this->validColorNum != 0 ? this->highlightColors[ (m_nSearchResult - 1) % this->validColorNum ] : COLORIDX_DEFAULT; }
-	//F‘Ö‚¦
-	virtual void InitStrategyStatus(){ } //############—vŒŸØ
+	//è‰²æ›¿ãˆ
+	virtual void InitStrategyStatus(){ } //############è¦æ¤œè¨¼
 	virtual bool BeginColor(const CStringRef& cStr, int nPos);
 	virtual bool Disp() const { return true; }
 	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	//ƒCƒxƒ“ƒg
+	//ã‚¤ãƒ™ãƒ³ãƒˆ
 	virtual void OnStartScanLogic();
 
 private:
 	int				m_nSearchResult;
 	CLogicInt		m_nSearchStart;
 	CLogicInt		m_nSearchEnd;
-	EColorIndexType highlightColors[ COLORIDX_SEARCHTAIL - COLORIDX_SEARCH + 1 ]; ///< ƒ`ƒFƒbƒN‚ª•t‚¢‚Ä‚¢‚éŒŸõ•¶š—ñF‚Ì”z—ñB
-	unsigned validColorNum; ///< highlightColors‚Ì‰½”Ô–Ú‚Ì—v‘f‚Ü‚Å‚ª—LŒø‚©B
+	EColorIndexType highlightColors[ COLORIDX_SEARCHTAIL - COLORIDX_SEARCH + 1 ]; ///< ãƒã‚§ãƒƒã‚¯ãŒä»˜ã„ã¦ã„ã‚‹æ¤œç´¢æ–‡å­—åˆ—è‰²ã®é…åˆ—ã€‚
+	unsigned validColorNum; ///< highlightColorsã®ä½•ç•ªç›®ã®è¦ç´ ã¾ã§ãŒæœ‰åŠ¹ã‹ã€‚
 };
 
 #endif /* SAKURA_CCOLOR_FOUND_60044D4E_3082_4A9D_98C5_2FE626D3DA1E_H_ */

--- a/sakura_core/view/colors/CColor_Heredoc.cpp
+++ b/sakura_core/view/colors/CColor_Heredoc.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2011, Moca
 
 	This software is provided 'as-is', without any express or implied
@@ -64,7 +64,7 @@ bool CColor_Heredoc::BeginColor(const CStringRef& cStr, int nPos)
 {
 	if(!cStr.IsValid())return false;
 
-	// ƒqƒAƒhƒLƒ…ƒƒ“ƒg
+	// ãƒ’ã‚¢ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ
 	// <<<HEREDOC_ID
 	// ...
 	// HEREDOC_ID

--- a/sakura_core/view/colors/CColor_Heredoc.h
+++ b/sakura_core/view/colors/CColor_Heredoc.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2011, Moca
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/view/colors/CColor_KeywordSet.cpp
+++ b/sakura_core/view/colors/CColor_KeywordSet.cpp
@@ -1,17 +1,17 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CColor_KeywordSet.h"
 #include <limits>
 #include "mem/CNativeW.h"
 #include "charset/charcode.h"
 
-/** start‚æ‚èŒã‚ë‚ÌŒê‚Ì‹«ŠE‚ÌˆÊ’u‚ğ•Ô‚·B
-	start‚æ‚è‘O‚Ì•¶š‚Í“Ç‚Ü‚È‚¢Bˆê”Ô‘å‚«‚¢–ß‚è’l‚Í str.GetLength()‚Æ“™‚µ‚­‚È‚éB
+/** startã‚ˆã‚Šå¾Œã‚ã®èªã®å¢ƒç•Œã®ä½ç½®ã‚’è¿”ã™ã€‚
+	startã‚ˆã‚Šå‰ã®æ–‡å­—ã¯èª­ã¾ãªã„ã€‚ä¸€ç•ªå¤§ãã„æˆ»ã‚Šå€¤ã¯ str.GetLength()ã¨ç­‰ã—ããªã‚‹ã€‚
 */
 static int NextWordBreak( const CStringRef& str, const int start );
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒL[ƒ[ƒhƒZƒbƒg                        //
+//                     ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆ                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CColor_KeywordSet::CColor_KeywordSet()
@@ -21,21 +21,21 @@ CColor_KeywordSet::CColor_KeywordSet()
 }
 
 
-// 2005.01.13 MIK ‹­’²ƒL[ƒ[ƒh”’Ç‰Á‚É”º‚¤”z—ñ‰»
+// 2005.01.13 MIK å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æ•°è¿½åŠ ã«ä¼´ã†é…åˆ—åŒ–
 bool CColor_KeywordSet::BeginColor(const CStringRef& cStr, int nPos)
 {
 	if( ! cStr.IsValid() ) {
-		return false; // ‚Ç‚¤‚É‚à‚Å‚«‚È‚¢B
+		return false; // ã©ã†ã«ã‚‚ã§ããªã„ã€‚
 	}
 
 	/*
 		Summary:
-			Œ»İˆÊ’u‚©‚çƒL[ƒ[ƒh‚ğ”²‚«o‚µA‚»‚ÌƒL[ƒ[ƒh‚ª“o˜^’PŒê‚È‚ç‚ÎAF‚ğ•Ï‚¦‚é
+			ç¾åœ¨ä½ç½®ã‹ã‚‰ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚’æŠœãå‡ºã—ã€ãã®ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ãŒç™»éŒ²å˜èªãªã‚‰ã°ã€è‰²ã‚’å¤‰ãˆã‚‹
 	*/
 
 	const ECharKind charKind = CWordParse::WhatKindOfChar( cStr.GetPtr(), cStr.GetLength() , nPos );
 	if( charKind <= CK_SPACE ){
-		return false; // ‚±‚Ì•¶š‚ÍƒL[ƒ[ƒh‘ÎÛ•¶š‚Å‚Í‚È‚¢B
+		return false; // ã“ã®æ–‡å­—ã¯ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å¯¾è±¡æ–‡å­—ã§ã¯ãªã„ã€‚
 	}
 	if( 0 < nPos ){
 		const ECharKind charKindPrev = CWordParse::WhatKindOfChar( cStr.GetPtr(), cStr.GetLength() , nPos-1 );
@@ -48,38 +48,38 @@ bool CColor_KeywordSet::BeginColor(const CStringRef& cStr, int nPos)
 	const int posNextWordHead = NextWordBreak( cStr, nPos );
 	for( int i = 0; i < MAX_KEYWORDSET_PER_TYPE; ++i ) {
 		if( ! m_pTypeData->m_ColorInfoArr[ COLORIDX_KEYWORD1 + i ].m_bDisp ) {
-			continue; // Fİ’è‚ª”ñ•\¦‚È‚Ì‚ÅƒXƒLƒbƒvB
+			continue; // è‰²è¨­å®šãŒéè¡¨ç¤ºãªã®ã§ã‚¹ã‚­ãƒƒãƒ—ã€‚
 		}
 		const int iKwdSet = m_pTypeData->m_nKeyWordSetIdx[i];
 		if( iKwdSet == -1 ) {
-			continue; // ƒL[ƒ[ƒhƒZƒbƒg‚ªİ’è‚³‚ê‚Ä‚¢‚È‚¢‚Ì‚ÅƒXƒLƒbƒvB
+			continue; // ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚»ãƒƒãƒˆãŒè¨­å®šã•ã‚Œã¦ã„ãªã„ã®ã§ã‚¹ã‚­ãƒƒãƒ—ã€‚
 		}
-		int posWordEnd = nPos; ///< nPos...posWordEnd‚ªƒL[ƒ[ƒhB
-		int posWordEndCandidate = posNextWordHead; ///< nPos...posWordEndCandidate‚ÍƒL[ƒ[ƒhŒó•âB
+		int posWordEnd = nPos; ///< nPos...posWordEndãŒã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã€‚
+		int posWordEndCandidate = posNextWordHead; ///< nPos...posWordEndCandidateã¯ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å€™è£œã€‚
 		do {
 			const int ret = GetDllShareData().m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SearchKeyWord2( iKwdSet, cStr.GetPtr() + nPos, posWordEndCandidate - nPos );
 			if( 0 <= ret ) {
-				// “o˜^‚³‚ê‚½ƒL[ƒ[ƒh‚¾‚Á‚½B
+				// ç™»éŒ²ã•ã‚ŒãŸã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã ã£ãŸã€‚
 				posWordEnd = posWordEndCandidate;
 				if( ret == std::numeric_limits<int>::max() ) {
-					// ‚æ‚è’·‚¢ƒL[ƒ[ƒh‚à‘¶İ‚·‚é‚Ì‚Å‰„’·‚µ‚ÄƒŠƒgƒ‰ƒCB
+					// ã‚ˆã‚Šé•·ã„ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã‚‚å­˜åœ¨ã™ã‚‹ã®ã§å»¶é•·ã—ã¦ãƒªãƒˆãƒ©ã‚¤ã€‚
 					continue;
 				}
 				break;
 			} else if( ret == -1 ) {
-				// “o˜^‚³‚ê‚½ƒL[ƒ[ƒh‚Å‚Í‚È‚©‚Á‚½B
+				// ç™»éŒ²ã•ã‚ŒãŸã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã§ã¯ãªã‹ã£ãŸã€‚
 				break;
 			} else if( ret == -2 ) {
-				// ’·‚³‚ª‘«‚è‚È‚©‚Á‚½‚Ì‚Å‰„’·‚µ‚ÄƒŠƒgƒ‰ƒCB
+				// é•·ã•ãŒè¶³ã‚Šãªã‹ã£ãŸã®ã§å»¶é•·ã—ã¦ãƒªãƒˆãƒ©ã‚¤ã€‚
 				continue;
 			} else {
-				// “o˜^‚³‚ê‚½ƒL[ƒ[ƒh‚Å‚Í‚È‚©‚Á‚½H
-				// CKeyWordSetMgr::SearchKeyWord2()‚©‚ç‘z’èŠO‚Ì–ß‚è’lB
+				// ç™»éŒ²ã•ã‚ŒãŸã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã§ã¯ãªã‹ã£ãŸï¼Ÿ
+				// CKeyWordSetMgr::SearchKeyWord2()ã‹ã‚‰æƒ³å®šå¤–ã®æˆ»ã‚Šå€¤ã€‚
 				break;
 			}
 		} while( posWordEndCandidate < cStr.GetLength() && ((posWordEndCandidate = NextWordBreak( cStr, posWordEndCandidate )) != 0) );
 
-		// nPos...posWordEnd ‚ªƒL[ƒ[ƒhB
+		// nPos...posWordEnd ãŒã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰ã€‚
 		if( nPos < posWordEnd ) {
 			this->m_nCOMMENTEND = posWordEnd;
 			this->m_nKeywordIndex = i;

--- a/sakura_core/view/colors/CColor_KeywordSet.h
+++ b/sakura_core/view/colors/CColor_KeywordSet.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/view/colors/CColor_Numeric.cpp
+++ b/sakura_core/view/colors/CColor_Numeric.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CColor_Numeric.h"
 #include "parse/CWordParse.h"
@@ -6,10 +6,10 @@
 #include "doc/layout/CLayout.h"
 #include "types/CTypeSupport.h"
 
-static int IsNumber( const CStringRef& cStr, int offset );/* ”’l‚È‚ç‚»‚Ì’·‚³‚ğ•Ô‚· */	//@@@ 2001.02.17 by MIK
+static int IsNumber( const CStringRef& cStr, int offset );/* æ•°å€¤ãªã‚‰ãã®é•·ã•ã‚’è¿”ã™ */	//@@@ 2001.02.17 by MIK
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ”¼Šp”’l                            //
+//                         åŠè§’æ•°å€¤                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 bool CColor_Numeric::BeginColor(const CStringRef& cStr, int nPos)
@@ -19,11 +19,11 @@ bool CColor_Numeric::BeginColor(const CStringRef& cStr, int nPos)
 	int	nnn;
 
 	if( _IsPosKeywordHead(cStr,nPos)
-		&& (nnn = IsNumber(cStr, nPos)) > 0 )		/* ”¼Šp”š‚ğ•\¦‚·‚é */
+		&& (nnn = IsNumber(cStr, nPos)) > 0 )		/* åŠè§’æ•°å­—ã‚’è¡¨ç¤ºã™ã‚‹ */
 	{
-		/* ƒL[ƒ[ƒh•¶š—ñ‚ÌI’[‚ğƒZƒbƒg‚·‚é */
+		/* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æ–‡å­—åˆ—ã®çµ‚ç«¯ã‚’ã‚»ãƒƒãƒˆã™ã‚‹ */
 		this->m_nCOMMENTEND = nPos + nnn;
-		return true;	/* ”¼Šp”’l‚Å‚ ‚é */ // 2002/03/13 novice
+		return true;	/* åŠè§’æ•°å€¤ã§ã‚ã‚‹ */ // 2002/03/13 novice
 	}
 	return false;
 }
@@ -39,33 +39,33 @@ bool CColor_Numeric::EndColor(const CStringRef& cStr, int nPos)
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         À‘••â•                            //
+//                         å®Ÿè£…è£œåŠ©                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 //@@@ 2001.11.07 Start by MIK
 /*
- * ”’l‚È‚ç’·‚³‚ğ•Ô‚·B
- * 10i”‚Ì®”‚Ü‚½‚Í¬”B16i”(³”)B
- * •¶š—ñ   ”’l(F•ª‚¯)
+ * æ•°å€¤ãªã‚‰é•·ã•ã‚’è¿”ã™ã€‚
+ * 10é€²æ•°ã®æ•´æ•°ã¾ãŸã¯å°æ•°ã€‚16é€²æ•°(æ­£æ•°)ã€‚
+ * æ–‡å­—åˆ—   æ•°å€¤(è‰²åˆ†ã‘)
  * ---------------------
  * 123      123
  * 0123     0123
  * 0xfedc   0xfedc
  * -123     -123
- * &H9a     &H9a     (‚½‚¾‚µƒ\[ƒX’†‚Ì#if‚ğ—LŒø‚É‚µ‚½‚Æ‚«)
+ * &H9a     &H9a     (ãŸã ã—ã‚½ãƒ¼ã‚¹ä¸­ã®#ifã‚’æœ‰åŠ¹ã«ã—ãŸã¨ã)
  * -0x89a   0x89a
  * 0.5      0.5
- * 0.56.1   0.56 , 1 (‚½‚¾‚µƒ\[ƒX’†‚Ì#if‚ğ—LŒø‚É‚µ‚½‚ç"0.56.1"‚É‚È‚é)
- * .5       5        (‚½‚¾‚µƒ\[ƒX’†‚Ì#if‚ğ—LŒø‚É‚µ‚½‚ç".5"‚É‚È‚é)
- * -.5      5        (‚½‚¾‚µƒ\[ƒX’†‚Ì#if‚ğ—LŒø‚É‚µ‚½‚ç"-.5"‚É‚È‚é)
+ * 0.56.1   0.56 , 1 (ãŸã ã—ã‚½ãƒ¼ã‚¹ä¸­ã®#ifã‚’æœ‰åŠ¹ã«ã—ãŸã‚‰"0.56.1"ã«ãªã‚‹)
+ * .5       5        (ãŸã ã—ã‚½ãƒ¼ã‚¹ä¸­ã®#ifã‚’æœ‰åŠ¹ã«ã—ãŸã‚‰".5"ã«ãªã‚‹)
+ * -.5      5        (ãŸã ã—ã‚½ãƒ¼ã‚¹ä¸­ã®#ifã‚’æœ‰åŠ¹ã«ã—ãŸã‚‰"-.5"ã«ãªã‚‹)
  * 123.     123
  * 0x567.8  0x567 , 8
  */
 /*
- * ”¼Šp”’l
+ * åŠè§’æ•°å€¤
  *   1, 1.2, 1.2.3, .1, 0xabc, 1L, 1F, 1.2f, 0x1L, 0x2F, -.1, -1, 1e2, 1.2e+3, 1.2e-3, -1e0
- *   10i”, 16i”, LFÚ”öŒê, •‚“®¬”“_”, •‰•„†
- *   IPƒAƒhƒŒƒX‚Ìƒhƒbƒg˜AŒ‹(–{“–‚Í”’l‚¶‚á‚È‚¢‚ñ‚¾‚æ‚Ë)
+ *   10é€²æ•°, 16é€²æ•°, LFæ¥å°¾èª, æµ®å‹•å°æ•°ç‚¹æ•°, è² ç¬¦å·
+ *   IPã‚¢ãƒ‰ãƒ¬ã‚¹ã®ãƒ‰ãƒƒãƒˆé€£çµ(æœ¬å½“ã¯æ•°å€¤ã˜ã‚ƒãªã„ã‚“ã ã‚ˆã­)
  */
 static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*, int length*/)
 {
@@ -78,10 +78,10 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 	p = cStr.GetPtr() + offset;
 	q = cStr.GetPtr() + cStr.GetLength();
 
-	if( *p == L'0' )  /* 10i”,C‚Ì16i” */
+	if( *p == L'0' )  /* 10é€²æ•°,Cã®16é€²æ•° */
 	{
 		p++; i++;
-		if( ( p < q ) && ( *p == L'x' ) )  /* C‚Ì16i” */
+		if( ( p < q ) && ( *p == L'x' ) )  /* Cã®16é€²æ•° */
 		{
 			p++; i++;
 			while( p < q )
@@ -97,10 +97,10 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 					break;
 				}
 			}
-			/* "0x" ‚È‚ç "0" ‚¾‚¯‚ª”’l */
+			/* "0x" ãªã‚‰ "0" ã ã‘ãŒæ•°å€¤ */
 			if( i == 2 ) return 1;
 			
-			/* Ú”öŒê */
+			/* æ¥å°¾èª */
 			if( p < q )
 			{
 				if( *p == L'L' || *p == L'l' || *p == L'F' || *p == L'f' )
@@ -119,16 +119,16 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 				{
 					if( *p == L'.' )
 					{
-						if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+						if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 						d++;
 						if( d > 1 )
 						{
-							if( *(p - 1) == L'.' ) break;  /* "." ‚ª˜A‘±‚È‚ç’†’f */
+							if( *(p - 1) == L'.' ) break;  /* "." ãŒé€£ç¶šãªã‚‰ä¸­æ–­ */
 						}
 					}
 					else if( *p == L'E' || *p == L'e' )
 					{
-						if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+						if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 						if( p + 2 < q )
 						{
 							if( ( *(p + 1) == L'+' || *(p + 1) == L'-' )
@@ -172,8 +172,8 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 				}
 				p++; i++;
 			}
-			if( *(p - 1)  == L'.' ) return i - 1;  /* ÅŒã‚ª "." ‚È‚çŠÜ‚ß‚È‚¢ */
-			/* Ú”öŒê */
+			if( *(p - 1)  == L'.' ) return i - 1;  /* æœ€å¾ŒãŒ "." ãªã‚‰å«ã‚ãªã„ */
+			/* æ¥å°¾èª */
 			if( p < q )
 			{
 				if( (( d == 0 ) && ( *p == L'L' || *p == L'l' ))
@@ -192,16 +192,16 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 				{
 					if( *p == L'.' )
 					{
-						if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+						if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 						d++;
 						if( d > 1 )
 						{
-							if( *(p - 1) == L'.' ) break;  /* "." ‚ª˜A‘±‚È‚ç’†’f */
+							if( *(p - 1) == L'.' ) break;  /* "." ãŒé€£ç¶šãªã‚‰ä¸­æ–­ */
 						}
 					}
 					else if( *p == L'E' || *p == L'e' )
 					{
-						if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+						if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 						if( p + 2 < q )
 						{
 							if( ( *(p + 1) == L'+' || *(p + 1) == L'-' )
@@ -245,8 +245,8 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 				}
 				p++; i++;
 			}
-			if( *(p - 1)  == L'.' ) return i - 1;  /* ÅŒã‚ª "." ‚È‚çŠÜ‚ß‚È‚¢ */
-			/* Ú”öŒê */
+			if( *(p - 1)  == L'.' ) return i - 1;  /* æœ€å¾ŒãŒ "." ãªã‚‰å«ã‚ãªã„ */
+			/* æ¥å°¾èª */
 			if( p < q )
 			{
 				if( *p == L'F' || *p == L'f' )
@@ -286,8 +286,8 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 				}
 				p++; i++;
 			}
-			if( i == 2 ) return 1;  /* "0E", 0e" ‚È‚ç "0" ‚ª”’l */
-			/* Ú”öŒê */
+			if( i == 2 ) return 1;  /* "0E", 0e" ãªã‚‰ "0" ãŒæ•°å€¤ */
+			/* æ¥å°¾èª */
 			if( p < q )
 			{
 				if( (( d == 0 ) && ( *p == L'L' || *p == L'l' ))
@@ -300,8 +300,8 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 		}
 		else
 		{
-			/* "0" ‚¾‚¯‚ª”’l */
-			/*if( *p == L'.' ) return i - 1;*/  /* ÅŒã‚ª "." ‚È‚çŠÜ‚ß‚È‚¢ */
+			/* "0" ã ã‘ãŒæ•°å€¤ */
+			/*if( *p == L'.' ) return i - 1;*/  /* æœ€å¾ŒãŒ "." ãªã‚‰å«ã‚ãªã„ */
 			if( p < q )
 			{
 				if( (( d == 0 ) && ( *p == L'L' || *p == L'l' ))
@@ -314,7 +314,7 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 		}
 	}
 
-	else if( *p >= L'1' && *p <= L'9' )  /* 10i” */
+	else if( *p >= L'1' && *p <= L'9' )  /* 10é€²æ•° */
 	{
 		p++; i++;
 		while( p < q )
@@ -323,16 +323,16 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 			{
 				if( *p == L'.' )
 				{
-					if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+					if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 					d++;
 					if( d > 1 )
 					{
-						if( *(p - 1) == L'.' ) break;  /* "." ‚ª˜A‘±‚È‚ç’†’f */
+						if( *(p - 1) == L'.' ) break;  /* "." ãŒé€£ç¶šãªã‚‰ä¸­æ–­ */
 					}
 				}
 				else if( *p == L'E' || *p == L'e' )
 				{
-					if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+					if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 					if( p + 2 < q )
 					{
 						if( ( *(p + 1) == L'+' || *(p + 1) == L'-' )
@@ -376,8 +376,8 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 			}
 			p++; i++;
 		}
-		if( *(p - 1) == L'.' ) return i - 1;  /* ÅŒã‚ª "." ‚È‚çŠÜ‚ß‚È‚¢ */
-		/* Ú”öŒê */
+		if( *(p - 1) == L'.' ) return i - 1;  /* æœ€å¾ŒãŒ "." ãªã‚‰å«ã‚ãªã„ */
+		/* æ¥å°¾èª */
 		if( p < q )
 		{
 			if( (( d == 0 ) && ( *p == L'L' || *p == L'l' ))
@@ -389,7 +389,7 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 		return i;
 	}
 
-	else if( *p == L'-' )  /* ƒ}ƒCƒiƒX */
+	else if( *p == L'-' )  /* ãƒã‚¤ãƒŠã‚¹ */
 	{
 		p++; i++;
 		while( p < q )
@@ -398,16 +398,16 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 			{
 				if( *p == L'.' )
 				{
-					if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+					if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 					d++;
 					if( d > 1 )
 					{
-						if( *(p - 1) == L'.' ) break;  /* "." ‚ª˜A‘±‚È‚ç’†’f */
+						if( *(p - 1) == L'.' ) break;  /* "." ãŒé€£ç¶šãªã‚‰ä¸­æ–­ */
 					}
 				}
 				else if( *p == L'E' || *p == L'e' )
 				{
-					if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+					if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 					if( p + 2 < q )
 					{
 						if( ( *(p + 1) == L'+' || *(p + 1) == L'-' )
@@ -451,10 +451,10 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 			}
 			p++; i++;
 		}
-		/* "-", "-." ‚¾‚¯‚È‚ç”’l‚Å‚È‚¢ */
+		/* "-", "-." ã ã‘ãªã‚‰æ•°å€¤ã§ãªã„ */
 		//@@@ 2001.11.09 start MIK
 		//if( i <= 2 ) return 0;
-		//if( *(p - 1)  == L'.' ) return i - 1;  /* ÅŒã‚ª "." ‚È‚çŠÜ‚ß‚È‚¢ */
+		//if( *(p - 1)  == L'.' ) return i - 1;  /* æœ€å¾ŒãŒ "." ãªã‚‰å«ã‚ãªã„ */
 		if( i == 1 ) return 0;
 		if( *(p - 1) == L'.' )
 		{
@@ -462,7 +462,7 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 			if( i == 1 ) return 0;
 			return i;
 		}  //@@@ 2001.11.09 end MIK
-		/* Ú”öŒê */
+		/* æ¥å°¾èª */
 		if( p < q )
 		{
 			if( (( d == 0 ) && ( *p == L'L' || *p == L'l' ))
@@ -474,7 +474,7 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 		return i;
 	}
 
-	else if( *p == L'.' )  /* ¬”“_ */
+	else if( *p == L'.' )  /* å°æ•°ç‚¹ */
 	{
 		d++;
 		p++; i++;
@@ -484,16 +484,16 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 			{
 				if( *p == L'.' )
 				{
-					if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+					if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 					d++;
 					if( d > 1 )
 					{
-						if( *(p - 1) == L'.' ) break;  /* "." ‚ª˜A‘±‚È‚ç’†’f */
+						if( *(p - 1) == L'.' ) break;  /* "." ãŒé€£ç¶šãªã‚‰ä¸­æ–­ */
 					}
 				}
 				else if( *p == L'E' || *p == L'e' )
 				{
-					if( f == 1 ) break;  /* w”•”‚É“ü‚Á‚Ä‚¢‚é */
+					if( f == 1 ) break;  /* æŒ‡æ•°éƒ¨ã«å…¥ã£ã¦ã„ã‚‹ */
 					if( p + 2 < q )
 					{
 						if( ( *(p + 1) == L'+' || *(p + 1) == L'-' )
@@ -537,10 +537,10 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 			}
 			p++; i++;
 		}
-		/* "." ‚¾‚¯‚È‚ç”’l‚Å‚È‚¢ */
+		/* "." ã ã‘ãªã‚‰æ•°å€¤ã§ãªã„ */
 		if( i == 1 ) return 0;
-		if( *(p - 1)  == L'.' ) return i - 1;  /* ÅŒã‚ª "." ‚È‚çŠÜ‚ß‚È‚¢ */
-		/* Ú”öŒê */
+		if( *(p - 1)  == L'.' ) return i - 1;  /* æœ€å¾ŒãŒ "." ãªã‚‰å«ã‚ãªã„ */
+		/* æ¥å°¾èª */
 		if( p < q )
 		{
 			if( *p == L'F' || *p == L'f' )
@@ -552,7 +552,7 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 	}
 
 #if 0
-	else if( *p == L'&' )  /* VB‚Ì16i” */
+	else if( *p == L'&' )  /* VBã®16é€²æ•° */
 	{
 		p++; i++;
 		if( ( p < q ) && ( *p == L'H' ) )
@@ -571,17 +571,17 @@ static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*,
 					break;
 				}
 			}
-			/* "&H" ‚¾‚¯‚È‚ç”’l‚Å‚È‚¢ */
+			/* "&H" ã ã‘ãªã‚‰æ•°å€¤ã§ãªã„ */
 			if( i == 2 ) i = 0;
 			return i;
 		}
 
-		/* "&" ‚¾‚¯‚È‚ç”’l‚Å‚È‚¢ */
+		/* "&" ã ã‘ãªã‚‰æ•°å€¤ã§ãªã„ */
 		return 0;
 	}
 #endif
 
-	/* ”’l‚Å‚Í‚È‚¢ */
+	/* æ•°å€¤ã§ã¯ãªã„ */
 	return 0;
 }
 //@@@ 2001.11.07 End by MIK

--- a/sakura_core/view/colors/CColor_Numeric.h
+++ b/sakura_core/view/colors/CColor_Numeric.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/view/colors/CColor_Quote.cpp
+++ b/sakura_core/view/colors/CColor_Quote.cpp
@@ -1,9 +1,9 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CColor_Quote.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     ƒNƒH[ƒe[ƒVƒ‡ƒ“                        //
+//                     ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 class CLayoutColorQuoteInfo : public CLayoutColorInfo{
 public:
@@ -69,7 +69,7 @@ CLayoutColorInfo* CColor_Quote::GetStrategyColorInfo() const
 	return NULL;
 }
 
-// nPos "‚ÌˆÊ’u
+// nPos "ã®ä½ç½®
 //staic
 bool CColor_Quote::IsCppRawString(const CStringRef& cStr, int nPos)
 {
@@ -113,7 +113,7 @@ bool CColor_Quote::BeginColor(const CStringRef& cStr, int nPos)
 		m_nCOMMENTEND = -1;
 		int nStringType = m_pTypeData->m_nStringType;
 		bool bPreString = true;
-		/* ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ‚ÌI’[‚ª‚ ‚é‚© */
+		/* ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã®çµ‚ç«¯ãŒã‚ã‚‹ã‹ */
 		switch( nStringType ){
 		case STRING_LITERAL_CPP:
 			if( IsCppRawString(cStr, nPos) ){
@@ -168,12 +168,12 @@ bool CColor_Quote::BeginColor(const CStringRef& cStr, int nPos)
 			m_nColorTypeIndex = 0;
 		}
 
-		// u•¶š—ñ‚Ís“à‚Ì‚İv(C++ Raw StringAPython‚Ìlong stringA@""‚Í“Á•Ê)
+		// ã€Œæ–‡å­—åˆ—ã¯è¡Œå†…ã®ã¿ã€(C++ Raw Stringã€Pythonã®long stringã€@""ã¯ç‰¹åˆ¥)
 		if( m_pTypeData->m_bStringLineOnly && !m_bEscapeEnd
 				&& m_nCOMMENTEND == cStr.GetLength() + 1 ){
-			// I—¹•¶š—ñ‚ª‚È‚¢ê‡‚Ís––‚Ü‚Å‚ğF•ª‚¯
+			// çµ‚äº†æ–‡å­—åˆ—ãŒãªã„å ´åˆã¯è¡Œæœ«ã¾ã§ã‚’è‰²åˆ†ã‘
 			if( m_pTypeData->m_bStringEndLine ){
-				// ‰üsƒR[ƒh‚ğœ‚­
+				// æ”¹è¡Œã‚³ãƒ¼ãƒ‰ã‚’é™¤ã
 				if( 0 < cStr.GetLength() && WCODE::IsLineDelimiter(cStr.At(cStr.GetLength()-1), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 					if( 1 < cStr.GetLength() && cStr.At(cStr.GetLength()-2) == WCODE::CR
 							&& cStr.At(cStr.GetLength()-1) == WCODE::LF ){
@@ -184,7 +184,7 @@ bool CColor_Quote::BeginColor(const CStringRef& cStr, int nPos)
 				}
 				return true;
 			}
-			// I—¹•¶š—ñ‚ª‚È‚¢ê‡‚ÍF•ª‚¯‚µ‚È‚¢
+			// çµ‚äº†æ–‡å­—åˆ—ãŒãªã„å ´åˆã¯è‰²åˆ†ã‘ã—ãªã„
 			m_nCOMMENTEND = -1;
 			return false;
 		}
@@ -198,9 +198,9 @@ bool CColor_Quote::BeginColor(const CStringRef& cStr, int nPos)
 bool CColor_Quote::EndColor(const CStringRef& cStr, int nPos)
 {
 	if( -1 == m_nCOMMENTEND ){
-		// ‚±‚±‚É‚­‚é‚Ì‚Ís“ª‚Ì‚Í‚¸
+		// ã“ã“ã«ãã‚‹ã®ã¯è¡Œé ­ã®ã¯ãš
 		assert_warning( 0 == nPos );
-		// ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ‚ÌI’[‚ª‚ ‚é‚©
+		// ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—ã®çµ‚ç«¯ãŒã‚ã‚‹ã‹
 		switch( m_nColorTypeIndex ){
 		case 0:
 			m_nCOMMENTEND = Match_Quote( m_cQuote, nPos, cStr, m_nEscapeType );
@@ -215,7 +215,7 @@ bool CColor_Quote::EndColor(const CStringRef& cStr, int nPos)
 			m_nCOMMENTEND = Match_QuoteStr( m_szQuote, 3, nPos, cStr, true );
 			break;
 		}
-		// -1‚ÅEndColor‚ªŒÄ‚Ño‚³‚ê‚é‚Ì‚Ís‚ğ’´‚¦‚Ä‚«‚½‚©‚ç‚È‚Ì‚Ås“àƒ`ƒFƒbƒN‚Í•s—v
+		// -1ã§EndColorãŒå‘¼ã³å‡ºã•ã‚Œã‚‹ã®ã¯è¡Œã‚’è¶…ãˆã¦ããŸã‹ã‚‰ãªã®ã§è¡Œå†…ãƒã‚§ãƒƒã‚¯ã¯ä¸è¦
 	}
 	else if( nPos == m_nCOMMENTEND ){
 		return true;
@@ -231,7 +231,7 @@ int CColor_Quote::Match_Quote( wchar_t wcQuote, int nPos, const CStringRef& cLin
 		// 2005-09-02 D.S.Koba GetSizeOfChar
 		nCharChars = (Int)t_max(CLogicInt(1), CNativeW::GetSizeOfChar( cLineStr.GetPtr(), cLineStr.GetLength(), i ));
 		if( escapeType == STRING_LITERAL_CPP ){
-			// ƒGƒXƒP[ƒv \"
+			// ã‚¨ã‚¹ã‚±ãƒ¼ãƒ— \"
 			if( 1 == nCharChars && cLineStr.At(i) == L'\\' ){
 				++i;
 				if( i < cLineStr.GetLength() && WCODE::IsLineDelimiter(cLineStr.At(i), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
@@ -244,7 +244,7 @@ int CColor_Quote::Match_Quote( wchar_t wcQuote, int nPos, const CStringRef& cLin
 				return i + 1;
 			}
 		}else if( escapeType == STRING_LITERAL_PLSQL ){
-			// ƒGƒXƒP[ƒv ""
+			// ã‚¨ã‚¹ã‚±ãƒ¼ãƒ— ""
 			if( 1 == nCharChars && cLineStr.At(i) == wcQuote ){
 				if( i + 1 < cLineStr.GetLength() && cLineStr.At(i + 1) == wcQuote ){
 					++i;
@@ -253,7 +253,7 @@ int CColor_Quote::Match_Quote( wchar_t wcQuote, int nPos, const CStringRef& cLin
 				}
 			}
 		}else{
-			// ƒGƒXƒP[ƒv‚È‚µ
+			// ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—ãªã—
 			if( 1 == nCharChars && cLineStr.At(i) == wcQuote ){
 				return i + 1;
 			}
@@ -262,7 +262,7 @@ int CColor_Quote::Match_Quote( wchar_t wcQuote, int nPos, const CStringRef& cLin
 			++i;
 		}
 	}
-	return cLineStr.GetLength() + 1; // I’[‚È‚µ‚ÍLength + 1
+	return cLineStr.GetLength() + 1; // çµ‚ç«¯ãªã—ã¯Length + 1
 }
 
 int CColor_Quote::Match_QuoteStr( const wchar_t* pszQuote, int nQuoteLen, int nPos, const CStringRef& cLineStr, bool bEscape )

--- a/sakura_core/view/colors/CColor_Quote.h
+++ b/sakura_core/view/colors/CColor_Quote.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/view/colors/CColor_RegexKeyword.cpp
+++ b/sakura_core/view/colors/CColor_RegexKeyword.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -36,10 +36,10 @@ bool CColor_RegexKeyword::BeginColor(const CStringRef& cStr, int nPos)
 
 	const CEditView* pcView = CColorStrategyPool::getInstance()->GetCurrentView();
 
-	//³‹K•\Œ»ƒL[ƒ[ƒh
+	//æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰
 	if( pcView->m_cRegexKeyword->RegexIsKeyword( cStr, nPos, &nMatchLen, &nMatchColor )
 	){
-		this->m_nCOMMENTEND = nPos + nMatchLen;  /* ƒL[ƒ[ƒh•¶Žš—ñ‚ÌI’[‚ðƒZƒbƒg‚·‚é */
+		this->m_nCOMMENTEND = nPos + nMatchLen;  /* ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰æ–‡å­—åˆ—ã®çµ‚ç«¯ã‚’ã‚»ãƒƒãƒˆã™ã‚‹ */
 		this->m_nCOMMENTMODE = ToColorIndexType_RegularExpression(nMatchColor);
 		return true;
 	}

--- a/sakura_core/view/colors/CColor_RegexKeyword.h
+++ b/sakura_core/view/colors/CColor_RegexKeyword.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/view/colors/CColor_Url.cpp
+++ b/sakura_core/view/colors/CColor_Url.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CColor_Url.h"
 #include "parse/CWordParse.h"
@@ -17,8 +17,8 @@ bool CColor_Url::BeginColor(const CStringRef& cStr, int nPos)
 
 	int	nUrlLen;
 
-	if( _IsPosKeywordHead(cStr,nPos) /* URL‚ð•\Ž¦‚·‚é */
-	 && IsURL( cStr.GetPtr() + nPos, cStr.GetLength() - nPos, &nUrlLen )	/* Žw’èƒAƒhƒŒƒX‚ªURL‚Ìæ“ª‚È‚ç‚ÎTRUE‚Æ‚»‚Ì’·‚³‚ð•Ô‚· */
+	if( _IsPosKeywordHead(cStr,nPos) /* URLã‚’è¡¨ç¤ºã™ã‚‹ */
+	 && IsURL( cStr.GetPtr() + nPos, cStr.GetLength() - nPos, &nUrlLen )	/* æŒ‡å®šã‚¢ãƒ‰ãƒ¬ã‚¹ãŒURLã®å…ˆé ­ãªã‚‰ã°TRUEã¨ãã®é•·ã•ã‚’è¿”ã™ */
 	){
 		this->m_nCOMMENTEND = nPos + nUrlLen;
 		return true;

--- a/sakura_core/view/colors/CColor_Url.h
+++ b/sakura_core/view/colors/CColor_Url.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied

--- a/sakura_core/view/colors/EColorIndexType.h
+++ b/sakura_core/view/colors/EColorIndexType.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -25,91 +25,91 @@
 #define SAKURA_ECOLORINDEXTYPE_H_
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                          F’è”                             //
+//                          è‰²å®šæ•°                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-// F’è”‚ğF”Ô†‚É•ÏŠ·‚·‚é‚½‚ß‚Ì¯•Êbit
-#define COLORIDX_BLOCK_BIT (2 << 9)		//!< ƒuƒƒbƒNƒRƒƒ“ƒg¯•Êbit
-#define COLORIDX_REGEX_BIT (2 << 10)	//!< ³‹K•\Œ»ƒL[ƒ[ƒh¯•Êbit
+// è‰²å®šæ•°ã‚’è‰²ç•ªå·ã«å¤‰æ›ã™ã‚‹ãŸã‚ã®è­˜åˆ¥bit
+#define COLORIDX_BLOCK_BIT (2 << 9)		//!< ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆè­˜åˆ¥bit
+#define COLORIDX_REGEX_BIT (2 << 10)	//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰è­˜åˆ¥bit
 
-/*! F’è”
-	@date 2000.01.12 Stonee ‚±‚±‚ğ•ÏX‚µ‚½‚Æ‚«‚ÍACColorStrategy.cpp ‚Ìg_ColorAttributeArr‚Ì’è‹`‚à•ÏX‚µ‚Ä‰º‚³‚¢B
-	@date 2000.09.18 JEPRO ‡”Ô‚ğ‘å•‚É“ü‚ê‘Ö‚¦‚½
-	@date 2007.09.09 Moca  ’†ŠÔ‚Ì’è‹`‚Í‚¨”C‚¹‚É•ÏX
-	@date 2013.04.26 novice F’è”‚ğF”Ô†‚ğ•ÏŠ·‚·‚é‚½‚ß‚Ì¯•Êbit“±“ü
+/*! è‰²å®šæ•°
+	@date 2000.01.12 Stonee ã“ã“ã‚’å¤‰æ›´ã—ãŸã¨ãã¯ã€CColorStrategy.cpp ã®g_ColorAttributeArrã®å®šç¾©ã‚‚å¤‰æ›´ã—ã¦ä¸‹ã•ã„ã€‚
+	@date 2000.09.18 JEPRO é †ç•ªã‚’å¤§å¹…ã«å…¥ã‚Œæ›¿ãˆãŸ
+	@date 2007.09.09 Moca  ä¸­é–“ã®å®šç¾©ã¯ãŠä»»ã›ã«å¤‰æ›´
+	@date 2013.04.26 novice è‰²å®šæ•°ã‚’è‰²ç•ªå·ã‚’å¤‰æ›ã™ã‚‹ãŸã‚ã®è­˜åˆ¥bitå°å…¥
 */
 enum EColorIndexType {
-	COLORIDX_TEXT = 0,		//!< ƒeƒLƒXƒg
-	COLORIDX_RULER,			//!< ƒ‹[ƒ‰[
-	COLORIDX_CARET,			//!< ƒLƒƒƒŒƒbƒg	// 2006.12.07 ryoji
-	COLORIDX_CARET_IME,		//!< IMEƒLƒƒƒŒƒbƒg // 2006.12.07 ryoji
-	COLORIDX_CARETLINEBG,	//!< ƒJ[ƒ\ƒ‹s”wŒiF
-	COLORIDX_UNDERLINE,		//!< ƒJ[ƒ\ƒ‹sƒAƒ“ƒ_[ƒ‰ƒCƒ“
-	COLORIDX_CURSORVLINE,	//!< ƒJ[ƒ\ƒ‹ˆÊ’ucü // 2006.05.13 Moca
-	COLORIDX_NOTELINE,		//!< ƒm[ƒgü	// 2013.12.21 Moca
-	COLORIDX_GYOU,			//!< s”Ô†
-	COLORIDX_GYOU_MOD,		//!< s”Ô†(•ÏXs)
-	COLORIDX_EVENLINEBG,	//!< Šï”s‚Ì”wŒiF
-	COLORIDX_TAB,			//!< TAB‹L†
-	COLORIDX_SPACE,			//!< ”¼Šp‹ó”’ //2002.04.28 Add by KK ˆÈ~‘S‚Ä+1
-	COLORIDX_ZENSPACE,		//!< “ú–{Œê‹ó”’
-	COLORIDX_CTRLCODE,		//!< ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh
-	COLORIDX_EOL,			//!< ‰üs‹L†
-	COLORIDX_WRAP,			//!< Ü‚è•Ô‚µ‹L†
-	COLORIDX_VERTLINE,		//!< w’èŒ…cü	// 2005.11.08 Moca
-	COLORIDX_EOF,			//!< EOF‹L†
-	COLORIDX_DIGIT,			//!< ”¼Šp”’l	 //@@@ 2001.02.17 by MIK //Fİ’èVer.3‚©‚çƒ†[ƒUƒtƒ@ƒCƒ‹‚É‘Î‚µ‚Ä‚Í•¶š—ñ‚Åˆ—‚µ‚Ä‚¢‚é‚Ì‚ÅƒŠƒiƒ“ƒoƒŠƒ“ƒO‚µ‚Ä‚à‚æ‚¢. Mar. 7, 2001 JEPRO noted
-	COLORIDX_BRACKET_PAIR,	//!< ‘ÎŠ‡ŒÊ	  // 02/09/18 ai Add
-	COLORIDX_SELECT,		//!< ‘I‘ğ”ÍˆÍ
-	COLORIDX_SEARCH,		//!< ŒŸõ•¶š—ñ
-	COLORIDX_SEARCH2,		//!< ŒŸõ•¶š—ñ2
-	COLORIDX_SEARCH3,		//!< ŒŸõ•¶š—ñ3
-	COLORIDX_SEARCH4,		//!< ŒŸõ•¶š—ñ4
-	COLORIDX_SEARCH5,		//!< ŒŸõ•¶š—ñ5
-	COLORIDX_COMMENT,		//!< sƒRƒƒ“ƒg						//Dec. 4, 2000 shifted by MIK
-	COLORIDX_SSTRING,		//!< ƒVƒ“ƒOƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ	//Dec. 4, 2000 shifted by MIK
-	COLORIDX_WSTRING,		//!< ƒ_ƒuƒ‹ƒNƒH[ƒe[ƒVƒ‡ƒ“•¶š—ñ		//Dec. 4, 2000 shifted by MIK
-	COLORIDX_HEREDOC,		//!< ƒqƒAƒhƒLƒ…ƒƒ“ƒg
+	COLORIDX_TEXT = 0,		//!< ãƒ†ã‚­ã‚¹ãƒˆ
+	COLORIDX_RULER,			//!< ãƒ«ãƒ¼ãƒ©ãƒ¼
+	COLORIDX_CARET,			//!< ã‚­ãƒ£ãƒ¬ãƒƒãƒˆ	// 2006.12.07 ryoji
+	COLORIDX_CARET_IME,		//!< IMEã‚­ãƒ£ãƒ¬ãƒƒãƒˆ // 2006.12.07 ryoji
+	COLORIDX_CARETLINEBG,	//!< ã‚«ãƒ¼ã‚½ãƒ«è¡ŒèƒŒæ™¯è‰²
+	COLORIDX_UNDERLINE,		//!< ã‚«ãƒ¼ã‚½ãƒ«è¡Œã‚¢ãƒ³ãƒ€ãƒ¼ãƒ©ã‚¤ãƒ³
+	COLORIDX_CURSORVLINE,	//!< ã‚«ãƒ¼ã‚½ãƒ«ä½ç½®ç¸¦ç·š // 2006.05.13 Moca
+	COLORIDX_NOTELINE,		//!< ãƒãƒ¼ãƒˆç·š	// 2013.12.21 Moca
+	COLORIDX_GYOU,			//!< è¡Œç•ªå·
+	COLORIDX_GYOU_MOD,		//!< è¡Œç•ªå·(å¤‰æ›´è¡Œ)
+	COLORIDX_EVENLINEBG,	//!< å¥‡æ•°è¡Œã®èƒŒæ™¯è‰²
+	COLORIDX_TAB,			//!< TABè¨˜å·
+	COLORIDX_SPACE,			//!< åŠè§’ç©ºç™½ //2002.04.28 Add by KK ä»¥é™å…¨ã¦+1
+	COLORIDX_ZENSPACE,		//!< æ—¥æœ¬èªç©ºç™½
+	COLORIDX_CTRLCODE,		//!< ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰
+	COLORIDX_EOL,			//!< æ”¹è¡Œè¨˜å·
+	COLORIDX_WRAP,			//!< æŠ˜ã‚Šè¿”ã—è¨˜å·
+	COLORIDX_VERTLINE,		//!< æŒ‡å®šæ¡ç¸¦ç·š	// 2005.11.08 Moca
+	COLORIDX_EOF,			//!< EOFè¨˜å·
+	COLORIDX_DIGIT,			//!< åŠè§’æ•°å€¤	 //@@@ 2001.02.17 by MIK //è‰²è¨­å®šVer.3ã‹ã‚‰ãƒ¦ãƒ¼ã‚¶ãƒ•ã‚¡ã‚¤ãƒ«ã«å¯¾ã—ã¦ã¯æ–‡å­—åˆ—ã§å‡¦ç†ã—ã¦ã„ã‚‹ã®ã§ãƒªãƒŠãƒ³ãƒãƒªãƒ³ã‚°ã—ã¦ã‚‚ã‚ˆã„. Mar. 7, 2001 JEPRO noted
+	COLORIDX_BRACKET_PAIR,	//!< å¯¾æ‹¬å¼§	  // 02/09/18 ai Add
+	COLORIDX_SELECT,		//!< é¸æŠç¯„å›²
+	COLORIDX_SEARCH,		//!< æ¤œç´¢æ–‡å­—åˆ—
+	COLORIDX_SEARCH2,		//!< æ¤œç´¢æ–‡å­—åˆ—2
+	COLORIDX_SEARCH3,		//!< æ¤œç´¢æ–‡å­—åˆ—3
+	COLORIDX_SEARCH4,		//!< æ¤œç´¢æ–‡å­—åˆ—4
+	COLORIDX_SEARCH5,		//!< æ¤œç´¢æ–‡å­—åˆ—5
+	COLORIDX_COMMENT,		//!< è¡Œã‚³ãƒ¡ãƒ³ãƒˆ						//Dec. 4, 2000 shifted by MIK
+	COLORIDX_SSTRING,		//!< ã‚·ãƒ³ã‚°ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—	//Dec. 4, 2000 shifted by MIK
+	COLORIDX_WSTRING,		//!< ãƒ€ãƒ–ãƒ«ã‚¯ã‚©ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³æ–‡å­—åˆ—		//Dec. 4, 2000 shifted by MIK
+	COLORIDX_HEREDOC,		//!< ãƒ’ã‚¢ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ
 	COLORIDX_URL,			//!< URL								//Dec. 4, 2000 shifted by MIK
-	COLORIDX_KEYWORD1,		//!< ‹­’²ƒL[ƒ[ƒh1 // 2002/03/13 novice
-	COLORIDX_KEYWORD2,		//!< ‹­’²ƒL[ƒ[ƒh2 // 2002/03/13 novice  //MIK ADDED
-	COLORIDX_KEYWORD3,		//!< ‹­’²ƒL[ƒ[ƒh3 // 2005.01.13 MIK 3-10 added
-	COLORIDX_KEYWORD4,		//!< ‹­’²ƒL[ƒ[ƒh4
-	COLORIDX_KEYWORD5,		//!< ‹­’²ƒL[ƒ[ƒh5
-	COLORIDX_KEYWORD6,		//!< ‹­’²ƒL[ƒ[ƒh6
-	COLORIDX_KEYWORD7,		//!< ‹­’²ƒL[ƒ[ƒh7
-	COLORIDX_KEYWORD8,		//!< ‹­’²ƒL[ƒ[ƒh8
-	COLORIDX_KEYWORD9,		//!< ‹­’²ƒL[ƒ[ƒh9
-	COLORIDX_KEYWORD10,		//!< ‹­’²ƒL[ƒ[ƒh10
-	COLORIDX_REGEX1,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh1  //@@@ 2001.11.17 add MIK
-	COLORIDX_REGEX2,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh2  //@@@ 2001.11.17 add MIK
-	COLORIDX_REGEX3,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh3  //@@@ 2001.11.17 add MIK
-	COLORIDX_REGEX4,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh4  //@@@ 2001.11.17 add MIK
-	COLORIDX_REGEX5,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh5  //@@@ 2001.11.17 add MIK
-	COLORIDX_REGEX6,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh6  //@@@ 2001.11.17 add MIK
-	COLORIDX_REGEX7,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh7  //@@@ 2001.11.17 add MIK
-	COLORIDX_REGEX8,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh8  //@@@ 2001.11.17 add MIK
-	COLORIDX_REGEX9,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh9  //@@@ 2001.11.17 add MIK
-	COLORIDX_REGEX10,		//!< ³‹K•\Œ»ƒL[ƒ[ƒh10	//@@@ 2001.11.17 add MIK
-	COLORIDX_DIFF_APPEND,	//!< DIFF’Ç‰Á  //@@@ 2002.06.01 MIK
-	COLORIDX_DIFF_CHANGE,	//!< DIFF’Ç‰Á  //@@@ 2002.06.01 MIK
-	COLORIDX_DIFF_DELETE,	//!< DIFF’Ç‰Á  //@@@ 2002.06.01 MIK
-	COLORIDX_MARK,			//!< ƒuƒbƒNƒ}[ƒN  // 02/10/16 ai Add
-	COLORIDX_PAGEVIEW,		//!< •\¦”ÍˆÍ(ƒ~ƒjƒ}ƒbƒv)  // 2014.07.14 Add
+	COLORIDX_KEYWORD1,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰1 // 2002/03/13 novice
+	COLORIDX_KEYWORD2,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰2 // 2002/03/13 novice  //MIK ADDED
+	COLORIDX_KEYWORD3,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰3 // 2005.01.13 MIK 3-10 added
+	COLORIDX_KEYWORD4,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰4
+	COLORIDX_KEYWORD5,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰5
+	COLORIDX_KEYWORD6,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰6
+	COLORIDX_KEYWORD7,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰7
+	COLORIDX_KEYWORD8,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰8
+	COLORIDX_KEYWORD9,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰9
+	COLORIDX_KEYWORD10,		//!< å¼·èª¿ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰10
+	COLORIDX_REGEX1,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰1  //@@@ 2001.11.17 add MIK
+	COLORIDX_REGEX2,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰2  //@@@ 2001.11.17 add MIK
+	COLORIDX_REGEX3,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰3  //@@@ 2001.11.17 add MIK
+	COLORIDX_REGEX4,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰4  //@@@ 2001.11.17 add MIK
+	COLORIDX_REGEX5,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰5  //@@@ 2001.11.17 add MIK
+	COLORIDX_REGEX6,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰6  //@@@ 2001.11.17 add MIK
+	COLORIDX_REGEX7,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰7  //@@@ 2001.11.17 add MIK
+	COLORIDX_REGEX8,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰8  //@@@ 2001.11.17 add MIK
+	COLORIDX_REGEX9,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰9  //@@@ 2001.11.17 add MIK
+	COLORIDX_REGEX10,		//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰10	//@@@ 2001.11.17 add MIK
+	COLORIDX_DIFF_APPEND,	//!< DIFFè¿½åŠ   //@@@ 2002.06.01 MIK
+	COLORIDX_DIFF_CHANGE,	//!< DIFFè¿½åŠ   //@@@ 2002.06.01 MIK
+	COLORIDX_DIFF_DELETE,	//!< DIFFè¿½åŠ   //@@@ 2002.06.01 MIK
+	COLORIDX_MARK,			//!< ãƒ–ãƒƒã‚¯ãƒãƒ¼ã‚¯  // 02/10/16 ai Add
+	COLORIDX_PAGEVIEW,		//!< è¡¨ç¤ºç¯„å›²(ãƒŸãƒ‹ãƒãƒƒãƒ—)  // 2014.07.14 Add
 
-	//ƒJƒ‰[‚ÌÅŒã
-	COLORIDX_LAST,			//!< ƒJƒ‰[‚ÌÅŒã
+	//ã‚«ãƒ©ãƒ¼ã®æœ€å¾Œ
+	COLORIDX_LAST,			//!< ã‚«ãƒ©ãƒ¼ã®æœ€å¾Œ
 
-	//ƒJƒ‰[•\¦§Œä—p(ƒuƒƒbƒNƒRƒƒ“ƒg)
-	COLORIDX_BLOCK1			= COLORIDX_BLOCK_BIT,			//!< ƒuƒƒbƒNƒRƒƒ“ƒg1(•¶šF‚Æ”wŒiF‚ÍsƒRƒƒ“ƒg‚Æ“¯‚¶)
-	COLORIDX_BLOCK2,										//!< ƒuƒƒbƒNƒRƒƒ“ƒg2(•¶šF‚Æ”wŒiF‚ÍsƒRƒƒ“ƒg‚Æ“¯‚¶)
+	//ã‚«ãƒ©ãƒ¼è¡¨ç¤ºåˆ¶å¾¡ç”¨(ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ)
+	COLORIDX_BLOCK1			= COLORIDX_BLOCK_BIT,			//!< ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ1(æ–‡å­—è‰²ã¨èƒŒæ™¯è‰²ã¯è¡Œã‚³ãƒ¡ãƒ³ãƒˆã¨åŒã˜)
+	COLORIDX_BLOCK2,										//!< ãƒ–ãƒ­ãƒƒã‚¯ã‚³ãƒ¡ãƒ³ãƒˆ2(æ–‡å­—è‰²ã¨èƒŒæ™¯è‰²ã¯è¡Œã‚³ãƒ¡ãƒ³ãƒˆã¨åŒã˜)
 
-	//ƒJƒ‰[•\¦§Œä—p(³‹K•\Œ»ƒL[ƒ[ƒh)
-	COLORIDX_REGEX_FIRST	= COLORIDX_REGEX_BIT,						//!< ³‹K•\Œ»ƒL[ƒ[ƒh(Å‰)
-	COLORIDX_REGEX_LAST		= COLORIDX_REGEX_FIRST + COLORIDX_LAST - 1,	//!< ³‹K•\Œ»ƒL[ƒ[ƒh(ÅŒã)
+	//ã‚«ãƒ©ãƒ¼è¡¨ç¤ºåˆ¶å¾¡ç”¨(æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰)
+	COLORIDX_REGEX_FIRST	= COLORIDX_REGEX_BIT,						//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰(æœ€åˆ)
+	COLORIDX_REGEX_LAST		= COLORIDX_REGEX_FIRST + COLORIDX_LAST - 1,	//!< æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰(æœ€å¾Œ)
 
-	// -- -- •Ê–¼ -- -- //
-	COLORIDX_DEFAULT		= COLORIDX_TEXT,							//!< ƒfƒtƒHƒ‹ƒg
+	// -- -- åˆ¥å -- -- //
+	COLORIDX_DEFAULT		= COLORIDX_TEXT,							//!< ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆ
 	COLORIDX_SEARCHTAIL		= COLORIDX_SEARCH5,
 };
 

--- a/sakura_core/view/figures/CFigureManager.cpp
+++ b/sakura_core/view/figures/CFigureManager.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -57,7 +57,7 @@ CFigureManager::~CFigureManager()
 	m_vFigures.clear();
 }
 
-//$$ ‚‘¬‰»‰Â”\
+//$$ é«˜é€ŸåŒ–å¯èƒ½
 CFigure& CFigureManager::GetFigure(const wchar_t* pText, int nTextLen)
 {
 	int size = (int)m_vFiguresDisp.size();
@@ -72,7 +72,7 @@ CFigure& CFigureManager::GetFigure(const wchar_t* pText, int nTextLen)
 	return *m_vFiguresDisp.back();
 }
 
-/*! İ’èXV
+/*! è¨­å®šæ›´æ–°
 */
 void CFigureManager::OnChangeSetting(void)
 {
@@ -82,7 +82,7 @@ void CFigureManager::OnChangeSetting(void)
 	int i;
 	for(i = 0; i < size; i++){
 		m_vFigures[i]->Update();
-		// F•ª‚¯•\¦‘ÎÛ‚Ì‚İ‚ğ“o˜^
+		// è‰²åˆ†ã‘è¡¨ç¤ºå¯¾è±¡ã®ã¿ã‚’ç™»éŒ²
 		if( m_vFigures[i]->Disp() ){
 			m_vFiguresDisp.push_back(m_vFigures[i]);
 		}

--- a/sakura_core/view/figures/CFigureManager.h
+++ b/sakura_core/view/figures/CFigureManager.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -34,17 +34,17 @@ class CFigureManager : public TSingleton<CFigureManager>{
 	virtual ~CFigureManager();
 
 public:
-	//! •`‰æ‚·‚éCFigure‚ğæ“¾
-	//	@param	pText	‘ÎÛ•¶š—ñ‚Ìæ“ª
-	//	@param	nTextLen	pText‚©‚çs––‚Ü‚Å‚Ì’·‚³(‚½‚¾‚µCRLF==2)
+	//! æç”»ã™ã‚‹CFigureã‚’å–å¾—
+	//	@param	pText	å¯¾è±¡æ–‡å­—åˆ—ã®å…ˆé ­
+	//	@param	nTextLen	pTextã‹ã‚‰è¡Œæœ«ã¾ã§ã®é•·ã•(ãŸã ã—CRLF==2)
 	CFigure& GetFigure(const wchar_t* pText, int nTextLen);
 
-	// İ’è•ÏX
+	// è¨­å®šå¤‰æ›´
 	void OnChangeSetting(void);
 
 private:
 	std::vector<CFigure*>	m_vFigures;
-	std::vector<CFigure*>	m_vFiguresDisp;	//!< F•ª‚¯•\¦‘ÎÛ
+	std::vector<CFigure*>	m_vFiguresDisp;	//!< è‰²åˆ†ã‘è¡¨ç¤ºå¯¾è±¡
 };
 
 #endif /* SAKURA_CFIGUREMANAGER_470D38ED_45D5_4E64_8D29_FFEA361C59E4_H_ */

--- a/sakura_core/view/figures/CFigureStrategy.cpp
+++ b/sakura_core/view/figures/CFigureStrategy.cpp
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -33,7 +33,7 @@
 bool CFigure_Text::DrawImp(SColorStrategyInfo* pInfo)
 {
 	int nIdx = pInfo->GetPosInLogic();
-	int nLength =	CNativeW::GetSizeOfChar(	// ƒTƒƒQ[ƒgƒyƒA‘Îô	2008.10.12 ryoji
+	int nLength =	CNativeW::GetSizeOfChar(	// ã‚µãƒ­ã‚²ãƒ¼ãƒˆãƒšã‚¢å¯¾ç­–	2008.10.12 ryoji
 						pInfo->m_pLineOfLogic,
 						pInfo->GetDocLine()->GetLengthWithoutEOL(),
 						nIdx
@@ -42,8 +42,8 @@ bool CFigure_Text::DrawImp(SColorStrategyInfo* pInfo)
 	int fontNo = (nLength == 2 ? WCODE::GetFontNo2(pInfo->m_pLineOfLogic[nIdx], pInfo->m_pLineOfLogic[nIdx+1]):
 			WCODE::GetFontNo(pInfo->m_pLineOfLogic[nIdx]));
 	if( fontNo ){
-		CTypeSupport cCurrentType(pInfo->m_pcView, pInfo->GetCurrentColor());	// ü•Ó‚ÌFiŒ»İ‚Ìw’èF/‘I‘ğFj
-		CTypeSupport cCurrentType2(pInfo->m_pcView, pInfo->GetCurrentColor2());	// ü•Ó‚ÌFiŒ»İ‚Ìw’èFj
+		CTypeSupport cCurrentType(pInfo->m_pcView, pInfo->GetCurrentColor());	// å‘¨è¾ºã®è‰²ï¼ˆç¾åœ¨ã®æŒ‡å®šè‰²/é¸æŠè‰²ï¼‰
+		CTypeSupport cCurrentType2(pInfo->m_pcView, pInfo->GetCurrentColor2());	// å‘¨è¾ºã®è‰²ï¼ˆç¾åœ¨ã®æŒ‡å®šè‰²ï¼‰
 		bool blendColor = pInfo->GetCurrentColor() != pInfo->GetCurrentColor2() && cCurrentType.GetTextColor() == cCurrentType.GetBackColor();
 		SFONT sFont;
 		sFont.m_sFontAttr.m_bBoldFont  = (blendColor ? cCurrentType2.IsBoldFont() : cCurrentType.IsBoldFont());
@@ -68,7 +68,7 @@ bool CFigure_Text::DrawImp(SColorStrategyInfo* pInfo)
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         •`‰æ“‡                            //
+//                         æç”»çµ±åˆ                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 
@@ -78,12 +78,12 @@ bool CFigure_Text::DrawImp(SColorStrategyInfo* pInfo)
 bool CFigureSpace::DrawImp(SColorStrategyInfo* pInfo)
 {
 	bool bTrans = DrawImp_StyleSelect(pInfo);
-	DispPos sPos(*pInfo->m_pDispPos);	// Œ»İˆÊ’u‚ğŠo‚¦‚Ä‚¨‚­
-	DispSpace(pInfo->m_gr, pInfo->m_pDispPos,pInfo->m_pcView, bTrans);	// ‹ó”’•`‰æ
+	DispPos sPos(*pInfo->m_pDispPos);	// ç¾åœ¨ä½ç½®ã‚’è¦šãˆã¦ãŠã
+	DispSpace(pInfo->m_gr, pInfo->m_pDispPos,pInfo->m_pcView, bTrans);	// ç©ºç™½æç”»
 	DrawImp_StylePop(pInfo);
 	DrawImp_DrawUnderline(pInfo, sPos);
-	// 1•¶š‘O’ñ
-	pInfo->m_nPosInLogic += CNativeW::GetSizeOfChar(	// s––ˆÈŠO‚Í‚±‚±‚ÅƒXƒLƒƒƒ“ˆÊ’u‚ğ‚Pši‚ß‚é
+	// 1æ–‡å­—å‰æ
+	pInfo->m_nPosInLogic += CNativeW::GetSizeOfChar(	// è¡Œæœ«ä»¥å¤–ã¯ã“ã“ã§ã‚¹ã‚­ãƒ£ãƒ³ä½ç½®ã‚’ï¼‘å­—é€²ã‚ã‚‹
 		pInfo->m_pLineOfLogic,
 		pInfo->GetDocLine()->GetLengthWithoutEOL(),
 		pInfo->GetPosInLogic()
@@ -93,35 +93,35 @@ bool CFigureSpace::DrawImp(SColorStrategyInfo* pInfo)
 
 bool CFigureSpace::DrawImp_StyleSelect(SColorStrategyInfo* pInfo)
 {
-	// ‚±‚Ì DrawImp ‚Í‚±‚±iŠî–{ƒNƒ‰ƒXj‚ÅƒfƒtƒHƒ‹ƒg“®ì‚ğÀ‘•‚µ‚Ä‚¢‚é‚ª
-	// ‰¼‘zŠÖ”‚È‚Ì‚Å”h¶ƒNƒ‰ƒX‘¤‚ÌƒI[ƒo[ƒ‰ƒCƒh‚ÅŒÂ•Ê‚Éd—l•ÏX‰Â”\
+	// ã“ã® DrawImp ã¯ã“ã“ï¼ˆåŸºæœ¬ã‚¯ãƒ©ã‚¹ï¼‰ã§ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆå‹•ä½œã‚’å®Ÿè£…ã—ã¦ã„ã‚‹ãŒ
+	// ä»®æƒ³é–¢æ•°ãªã®ã§æ´¾ç”Ÿã‚¯ãƒ©ã‚¹å´ã®ã‚ªãƒ¼ãƒãƒ¼ãƒ©ã‚¤ãƒ‰ã§å€‹åˆ¥ã«ä»•æ§˜å¤‰æ›´å¯èƒ½
 	CEditView* pcView = pInfo->m_pcView;
 
-	CTypeSupport cCurrentType(pcView, pInfo->GetCurrentColor());	// ü•Ó‚ÌFiŒ»İ‚Ìw’èF/‘I‘ğFj
-	CTypeSupport cCurrentType2(pcView, pInfo->GetCurrentColor2());	// ü•Ó‚ÌFiŒ»İ‚Ìw’èFj
-	CTypeSupport cTextType(pcView, COLORIDX_TEXT);				// ƒeƒLƒXƒg‚Ìw’èF
-	CTypeSupport cSpaceType(pcView, GetDispColorIdx());	// ‹ó”’‚Ìw’èF
+	CTypeSupport cCurrentType(pcView, pInfo->GetCurrentColor());	// å‘¨è¾ºã®è‰²ï¼ˆç¾åœ¨ã®æŒ‡å®šè‰²/é¸æŠè‰²ï¼‰
+	CTypeSupport cCurrentType2(pcView, pInfo->GetCurrentColor2());	// å‘¨è¾ºã®è‰²ï¼ˆç¾åœ¨ã®æŒ‡å®šè‰²ï¼‰
+	CTypeSupport cTextType(pcView, COLORIDX_TEXT);				// ãƒ†ã‚­ã‚¹ãƒˆã®æŒ‡å®šè‰²
+	CTypeSupport cSpaceType(pcView, GetDispColorIdx());	// ç©ºç™½ã®æŒ‡å®šè‰²
 	CTypeSupport cCurrentTypeBg(pcView, pInfo->GetCurrentColorBg());
 	CTypeSupport& cCurrentType1 = (cCurrentType.GetBackColor() == cTextType.GetBackColor() ? cCurrentTypeBg: cCurrentType);
 	CTypeSupport& cCurrentType3 = (cCurrentType2.GetBackColor() == cTextType.GetBackColor() ? cCurrentTypeBg: cCurrentType2);
 
-	// ‹ó”’‹L†—Ş‚Í“Á‚É–¾¦w’è‚µ‚½•”•ªˆÈŠO‚Í‚È‚é‚×‚­ü•Ó‚Ìw’è‚É‡‚í‚¹‚é‚æ‚¤‚É‚µ‚Ä‚İ‚½	// 2009.05.30 ryoji
-	// —á‚¦‚ÎA‰ºü‚ğw’è‚µ‚Ä‚¢‚È‚¢ê‡A³‹K•\Œ»ƒL[ƒ[ƒh“à‚È‚ç³‹K•\Œ»ƒL[ƒ[ƒh‘¤‚Ì‰ºüw’è‚É]‚¤‚Ù‚¤‚ª©‘R‚È‹C‚ª‚·‚éB
-	// i‚»‚Ì‚Ù‚¤‚ª‹ó”’‹L†‚Ìu•\¦v‚ğƒ`ƒFƒbƒN‚µ‚Ä‚¢‚È‚¢ê‡‚Ì•\¦‚É‹ß‚¢j
+	// ç©ºç™½è¨˜å·é¡ã¯ç‰¹ã«æ˜ç¤ºæŒ‡å®šã—ãŸéƒ¨åˆ†ä»¥å¤–ã¯ãªã‚‹ã¹ãå‘¨è¾ºã®æŒ‡å®šã«åˆã‚ã›ã‚‹ã‚ˆã†ã«ã—ã¦ã¿ãŸ	// 2009.05.30 ryoji
+	// ä¾‹ãˆã°ã€ä¸‹ç·šã‚’æŒ‡å®šã—ã¦ã„ãªã„å ´åˆã€æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å†…ãªã‚‰æ­£è¦è¡¨ç¾ã‚­ãƒ¼ãƒ¯ãƒ¼ãƒ‰å´ã®ä¸‹ç·šæŒ‡å®šã«å¾“ã†ã»ã†ãŒè‡ªç„¶ãªæ°—ãŒã™ã‚‹ã€‚
+	// ï¼ˆãã®ã»ã†ãŒç©ºç™½è¨˜å·ã®ã€Œè¡¨ç¤ºã€ã‚’ãƒã‚§ãƒƒã‚¯ã—ã¦ã„ãªã„å ´åˆã®è¡¨ç¤ºã«è¿‘ã„ï¼‰
 	//
-	// ‘OŒiFE”wŒiF‚Ìˆµ‚¢
-	// E’ÊíƒeƒLƒXƒg‚Æ‚ÍˆÙ‚È‚éF‚ªw’è‚³‚ê‚Ä‚¢‚éê‡‚Í‹ó”’‹L†‚Ì‘¤‚Ìw’èF‚ğg‚¤
-	// E’ÊíƒeƒLƒXƒg‚Æ“¯‚¶F‚ªw’è‚³‚ê‚Ä‚¢‚éê‡‚Íü•Ó‚ÌFw’è‚É‡‚í‚¹‚é
-	// ‘¾š‚Ìˆµ‚¢
-	// E‹ó”’‹L†‚©ü•Ó‚Ì‚Ç‚¿‚ç‚©ˆê•û‚Å‚à‘¾šw’è‚³‚ê‚Ä‚¢‚ê‚Îu‘OŒiFE”wŒiF‚Ìˆµ‚¢v‚ÅŒˆ’è‚µ‚½‘OŒiF‚Å‘¾š‚É‚·‚é
-	// ‰ºü‚Ìˆµ‚¢
-	// E‹ó”’‹L†‚Å‰ºüw’è‚³‚ê‚Ä‚¢‚ê‚Îu‘OŒiFE”wŒiF‚Ìˆµ‚¢v‚ÅŒˆ’è‚µ‚½‘OŒiF‚Å‰ºü‚ğˆø‚­
-	// E‹ó”’‹L†‚Å‰ºüw’è‚³‚ê‚Ä‚¨‚ç‚¸ü•Ó‚Å‰ºüw’è‚³‚ê‚Ä‚¢‚ê‚Îü•Ó‚Ì‘OŒiF‚Å‰ºü‚ğˆø‚­
-	// [‘I‘ğ]ƒŒƒ“ƒ_ƒŠƒ“ƒO’†
-	// E¬‡F‚Ìê‡‚Í]—ˆ’Ê‚èB
+	// å‰æ™¯è‰²ãƒ»èƒŒæ™¯è‰²ã®æ‰±ã„
+	// ãƒ»é€šå¸¸ãƒ†ã‚­ã‚¹ãƒˆã¨ã¯ç•°ãªã‚‹è‰²ãŒæŒ‡å®šã•ã‚Œã¦ã„ã‚‹å ´åˆã¯ç©ºç™½è¨˜å·ã®å´ã®æŒ‡å®šè‰²ã‚’ä½¿ã†
+	// ãƒ»é€šå¸¸ãƒ†ã‚­ã‚¹ãƒˆã¨åŒã˜è‰²ãŒæŒ‡å®šã•ã‚Œã¦ã„ã‚‹å ´åˆã¯å‘¨è¾ºã®è‰²æŒ‡å®šã«åˆã‚ã›ã‚‹
+	// å¤ªå­—ã®æ‰±ã„
+	// ãƒ»ç©ºç™½è¨˜å·ã‹å‘¨è¾ºã®ã©ã¡ã‚‰ã‹ä¸€æ–¹ã§ã‚‚å¤ªå­—æŒ‡å®šã•ã‚Œã¦ã„ã‚Œã°ã€Œå‰æ™¯è‰²ãƒ»èƒŒæ™¯è‰²ã®æ‰±ã„ã€ã§æ±ºå®šã—ãŸå‰æ™¯è‰²ã§å¤ªå­—ã«ã™ã‚‹
+	// ä¸‹ç·šã®æ‰±ã„
+	// ãƒ»ç©ºç™½è¨˜å·ã§ä¸‹ç·šæŒ‡å®šã•ã‚Œã¦ã„ã‚Œã°ã€Œå‰æ™¯è‰²ãƒ»èƒŒæ™¯è‰²ã®æ‰±ã„ã€ã§æ±ºå®šã—ãŸå‰æ™¯è‰²ã§ä¸‹ç·šã‚’å¼•ã
+	// ãƒ»ç©ºç™½è¨˜å·ã§ä¸‹ç·šæŒ‡å®šã•ã‚Œã¦ãŠã‚‰ãšå‘¨è¾ºã§ä¸‹ç·šæŒ‡å®šã•ã‚Œã¦ã„ã‚Œã°å‘¨è¾ºã®å‰æ™¯è‰²ã§ä¸‹ç·šã‚’å¼•ã
+	// [é¸æŠ]ãƒ¬ãƒ³ãƒ€ãƒªãƒ³ã‚°ä¸­
+	// ãƒ»æ··åˆè‰²ã®å ´åˆã¯å¾“æ¥é€šã‚Šã€‚
 	COLORREF crText;
 	COLORREF crBack;
-	bool blendColor = pInfo->GetCurrentColor() != pInfo->GetCurrentColor2() && cCurrentType.GetTextColor() == cCurrentType.GetBackColor(); // ‘I‘ğ¬‡F
+	bool blendColor = pInfo->GetCurrentColor() != pInfo->GetCurrentColor2() && cCurrentType.GetTextColor() == cCurrentType.GetBackColor(); // é¸æŠæ··åˆè‰²
 	bool bBold;
 	if( blendColor ){
 		CTypeSupport& cText = cSpaceType.GetTextColor() == cTextType.GetTextColor() ? cCurrentType2 : cSpaceType;
@@ -140,7 +140,7 @@ bool CFigureSpace::DrawImp_StyleSelect(SColorStrategyInfo* pInfo)
 
 	pInfo->m_gr.PushTextForeColor(crText);
 	pInfo->m_gr.PushTextBackColor(crBack);
-	// Figure‚ª‰ºüw’è‚È‚ç‚±‚¿‚ç‚Å‰ºü‚ğw’èBŒ³‚ÌF‚Ì‚Ù‚¤‚ª‰ºüw’è‚È‚çADrawImp_DrawUnderline‚Å‰ºü‚¾‚¯w’è
+	// FigureãŒä¸‹ç·šæŒ‡å®šãªã‚‰ã“ã¡ã‚‰ã§ä¸‹ç·šã‚’æŒ‡å®šã€‚å…ƒã®è‰²ã®ã»ã†ãŒä¸‹ç·šæŒ‡å®šãªã‚‰ã€DrawImp_DrawUnderlineã§ä¸‹ç·šã ã‘æŒ‡å®š
 	SFONT sFont;
 	sFont.m_sFontAttr.m_bBoldFont = cSpaceType.IsBoldFont() || bBold;
 	sFont.m_sFontAttr.m_bUnderLine = cSpaceType.HasUnderLine();
@@ -161,16 +161,16 @@ void CFigureSpace::DrawImp_DrawUnderline(SColorStrategyInfo* pInfo, DispPos& sPo
 {
 	CEditView* pcView = pInfo->m_pcView;
 
-	CTypeSupport cCurrentType(pcView, pInfo->GetCurrentColor());	// ü•Ó‚ÌF
-	bool blendColor = pInfo->GetCurrentColor() != pInfo->GetCurrentColor2() && cCurrentType.GetTextColor() == cCurrentType.GetBackColor(); // ‘I‘ğ¬‡F
+	CTypeSupport cCurrentType(pcView, pInfo->GetCurrentColor());	// å‘¨è¾ºã®è‰²
+	bool blendColor = pInfo->GetCurrentColor() != pInfo->GetCurrentColor2() && cCurrentType.GetTextColor() == cCurrentType.GetBackColor(); // é¸æŠæ··åˆè‰²
 
-	CTypeSupport colorStyle(pcView, blendColor ? pInfo->GetCurrentColor2() : pInfo->GetCurrentColor());	// ü•Ó‚ÌF
-	CTypeSupport cSpaceType(pcView, GetDispColorIdx());	// ‹ó”’‚Ìw’èF
+	CTypeSupport colorStyle(pcView, blendColor ? pInfo->GetCurrentColor2() : pInfo->GetCurrentColor());	// å‘¨è¾ºã®è‰²
+	CTypeSupport cSpaceType(pcView, GetDispColorIdx());	// ç©ºç™½ã®æŒ‡å®šè‰²
 
 	if( !cSpaceType.HasUnderLine() && colorStyle.HasUnderLine() )
 	{
 		int fontNo = WCODE::GetFontNo(' ');
-		// ‰ºü‚ğü•Ó‚Ì‘OŒiF‚Å•`‰æ‚·‚é
+		// ä¸‹ç·šã‚’å‘¨è¾ºã®å‰æ™¯è‰²ã§æç”»ã™ã‚‹
 		SFONT sFont;
 		sFont.m_sFontAttr.m_bBoldFont = false;
 		sFont.m_sFontAttr.m_bUnderLine = true;
@@ -189,7 +189,7 @@ void CFigureSpace::DrawImp_DrawUnderline(SColorStrategyInfo* pInfo, DispPos& sPo
 		}
 		RECT rcClip2;
 		rcClip2.left = sPos.GetDrawPos().x;
-		rcClip2.right = rcClip2.left + (Int)(nColLength); // ‘O’ñğŒFCLayoutInt == px
+		rcClip2.right = rcClip2.left + (Int)(nColLength); // å‰ææ¡ä»¶ï¼šCLayoutInt == px
 		if( rcClip2.left < pcView->GetTextArea().GetAreaLeft() ){
 			rcClip2.left = pcView->GetTextArea().GetAreaLeft();
 		}

--- a/sakura_core/view/figures/CFigureStrategy.h
+++ b/sakura_core/view/figures/CFigureStrategy.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -28,17 +28,17 @@
 #include "view/colors/CColorStrategy.h" //SColorStrategyInfo
 
 
-//$$ƒŒƒCƒAƒEƒg\’zƒtƒ[(DoLayout)‚à CFigure ‚Ås‚¤‚Æ®—‚µ‚â‚·‚¢
+//$$ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆæ§‹ç¯‰ãƒ•ãƒ­ãƒ¼(DoLayout)ã‚‚ CFigure ã§è¡Œã†ã¨æ•´ç†ã—ã‚„ã™ã„
 class CFigure{
 public:
 	virtual ~CFigure(){}
 	virtual bool DrawImp(SColorStrategyInfo* pInfo) = 0;
 	virtual bool Match(const wchar_t* pText, int nTextLen) const = 0;
 
-	//! F•ª‚¯•\¦‘ÎÛ”»’è
+	//! è‰²åˆ†ã‘è¡¨ç¤ºå¯¾è±¡åˆ¤å®š
 	virtual bool Disp(void) const = 0;
 
-	//! İ’èXV
+	//! è¨­å®šæ›´æ–°
 	virtual void Update(void)
 	{
 		CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
@@ -48,7 +48,7 @@ protected:
 	const STypeConfig* m_pTypeData;
 };
 
-//! ’ÊíƒeƒLƒXƒg•`‰æ
+//! é€šå¸¸ãƒ†ã‚­ã‚¹ãƒˆæç”»
 class CFigure_Text : public CFigure{
 public:
 	bool DrawImp(SColorStrategyInfo* pInfo);
@@ -57,14 +57,14 @@ public:
 		return true;
 	}
 
-	//! F•ª‚¯•\¦‘ÎÛ”»’è
+	//! è‰²åˆ†ã‘è¡¨ç¤ºå¯¾è±¡åˆ¤å®š
 	virtual bool Disp(void) const
 	{
 		return true;
 	}
 };
 
-//! Šeí‹ó”’i”¼Šp‹ó”’^‘SŠp‹ó”’^ƒ^ƒu^‰üsj•`‰æ—p‚ÌŠî–{ƒNƒ‰ƒX
+//! å„ç¨®ç©ºç™½ï¼ˆåŠè§’ç©ºç™½ï¼å…¨è§’ç©ºç™½ï¼ã‚¿ãƒ–ï¼æ”¹è¡Œï¼‰æç”»ç”¨ã®åŸºæœ¬ã‚¯ãƒ©ã‚¹
 class CFigureSpace : public CFigure{
 public:
 	virtual bool DrawImp(SColorStrategyInfo* pInfo);
@@ -72,7 +72,7 @@ protected:
 	virtual void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const = 0;
 	virtual EColorIndexType GetColorIdx(void) const = 0;
 
-	//! F•ª‚¯•\¦‘ÎÛ”»’è
+	//! è‰²åˆ†ã‘è¡¨ç¤ºå¯¾è±¡åˆ¤å®š
 	virtual bool Disp(void) const
 	{
 		EColorIndexType nColorIndex = GetColorIdx();
@@ -93,7 +93,7 @@ protected:
 
 	EColorIndexType GetDispColorIdx(void) const{ return m_nDispColorIndex; }
 
-	// À‘••â•
+	// å®Ÿè£…è£œåŠ©
 	bool DrawImp_StyleSelect(SColorStrategyInfo* pInfo);
 	void DrawImp_StylePop(SColorStrategyInfo* pInfo);
 	void DrawImp_DrawUnderline(SColorStrategyInfo* pInfo, DispPos&);

--- a/sakura_core/view/figures/CFigure_Comma.cpp
+++ b/sakura_core/view/figures/CFigure_Comma.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+Ôªø#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CFigure_Comma.h"
 #include "env/CShareData.h"
@@ -23,25 +23,25 @@ bool CFigure_Comma::Match(const wchar_t* pText, int nTextLen) const
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ï`âÊé¿ëï                            //
+//                         ÊèèÁîªÂÆüË£Ö                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*! ÉJÉìÉ}ï`âÊ
+/*! „Ç´„É≥„ÉûÊèèÁîª
 */
 void CFigure_Comma::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const
 {
 	DispPos& sPos=*pDispPos;
 
-	//ïKóvÇ»ÉCÉìÉ^Å[ÉtÉFÅ[ÉX
+	//ÂøÖË¶Å„Å™„Ç§„É≥„Çø„Éº„Éï„Çß„Éº„Çπ
 	const CTextMetrics* pMetrics=&pcView->GetTextMetrics();
 	const CTextArea* pArea=&pcView->GetTextArea();
 
 	int nLineHeight = pMetrics->GetHankakuDy();
-	int nCharWidth = pMetrics->GetCharPxWidth();	// LayoutÅ®Px
+	int nCharWidth = pMetrics->GetCharPxWidth();	// Layout‚ÜíPx
 
 	CTypeSupport cTabType(pcView,COLORIDX_TAB);
 
-	// Ç±ÇÍÇ©ÇÁï`âÊÇ∑ÇÈÉ^Éuïù
+	// „Åì„Çå„Åã„ÇâÊèèÁîª„Åô„Çã„Çø„ÉñÂπÖ
 	CLayoutXInt tabDispWidthLayout = pcView->m_pcEditDoc->m_cLayoutMgr.GetActualTsvSpace( sPos.GetDrawCol(), L',' );
 	int tabDispWidth = (Int)tabDispWidthLayout;
 	if( pcView->m_bMiniMap ){
@@ -52,7 +52,7 @@ void CFigure_Comma::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcVie
 		tabDispWidth = (Int)tabDispWidthLayout;
 	}
 
-	// É^ÉuãLçÜóÃàÊ
+	// „Çø„ÉñË®òÂè∑È†òÂüü
 	RECT rcClip2;
 	rcClip2.left = sPos.GetDrawPos().x;
 	rcClip2.right = rcClip2.left + nCharWidth * tabDispWidth;
@@ -64,7 +64,7 @@ void CFigure_Comma::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcVie
 	int nLen = wcslen( m_pTypeData->m_szTabViewString );
 
 	if( pArea->IsRectIntersected(rcClip2) ){
-		if( cTabType.IsDisp() ){	//CSVÉÇÅ[Éh
+		if( cTabType.IsDisp() ){	//CSV„É¢„Éº„Éâ
 			::ExtTextOutW_AnyBuild(
 				gr,
 				sPos.GetDrawPos().x,
@@ -78,7 +78,7 @@ void CFigure_Comma::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcVie
 		}
 	}
 
-	//XÇêiÇﬂÇÈ
+	//X„ÇíÈÄ≤„ÇÅ„Çã
 	sPos.ForwardDrawCol(tabDispWidthLayout);
 }
 

--- a/sakura_core/view/figures/CFigure_Comma.h
+++ b/sakura_core/view/figures/CFigure_Comma.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2015, syat
 
 	This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@
 
 #include "view/figures/CFigureStrategy.h"
 
-//! ƒJƒ“ƒ}•`‰æiCSVƒ‚[ƒhj
+//! ã‚«ãƒ³ãƒæç”»ï¼ˆCSVãƒ¢ãƒ¼ãƒ‰ï¼‰
 class CFigure_Comma : public CFigureSpace{
 public:
 	//traits

--- a/sakura_core/view/figures/CFigure_CtrlCode.cpp
+++ b/sakura_core/view/figures/CFigure_CtrlCode.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CFigure_CtrlCode.h"
 #include "types/CTypeSupport.h"
@@ -9,8 +9,8 @@
 
 bool CFigure_CtrlCode::Match(const wchar_t* pText, int nTextLen) const
 {
-	//“––Ê‚ÍASCII§Œä•¶šiC0 Controls, IsHankaku()‚Å”¼Špˆµ‚¢j‚¾‚¯‚ğ§Œä•¶š•\¦‚É‚·‚é
-	//‚»‚¤‚µ‚È‚¢‚Æ IsHankaku(0x0600)==false ‚È‚Ì‚É iswcntrl(0x0600)!=0 ‚Ì‚æ‚¤‚ÈƒP[ƒX‚Å•\¦Œ…‚ª‚¸‚ê‚é
+	//å½“é¢ã¯ASCIIåˆ¶å¾¡æ–‡å­—ï¼ˆC0 Controls, IsHankaku()ã§åŠè§’æ‰±ã„ï¼‰ã ã‘ã‚’åˆ¶å¾¡æ–‡å­—è¡¨ç¤ºã«ã™ã‚‹
+	//ãã†ã—ãªã„ã¨ IsHankaku(0x0600)==false ãªã®ã« iswcntrl(0x0600)!=0 ã®ã‚ˆã†ãªã‚±ãƒ¼ã‚¹ã§è¡¨ç¤ºæ¡ãŒãšã‚Œã‚‹
 	//U+0600: ARABIC NUMBER SIGN
 	if(WCODE::IsControlCode(pText[0])){
 		return true;
@@ -21,13 +21,13 @@ bool CFigure_CtrlCode::Match(const wchar_t* pText, int nTextLen) const
 bool CFigure_CtrlCode::DrawImp(SColorStrategyInfo* pInfo)
 {
 	bool bTrans = DrawImp_StyleSelect(pInfo);
-	DispPos sPos(*pInfo->m_pDispPos);	// Œ»İˆÊ’u‚ğŠo‚¦‚Ä‚¨‚­
+	DispPos sPos(*pInfo->m_pDispPos);	// ç¾åœ¨ä½ç½®ã‚’è¦šãˆã¦ãŠã
 	int width = pInfo->m_pcView->GetTextMetrics().CalcTextWidth3(&pInfo->m_pLineOfLogic[pInfo->GetPosInLogic()], 1);
-	DispSpaceEx(pInfo->m_gr, pInfo->m_pDispPos,pInfo->m_pcView, bTrans, width);	// ‹ó”’•`‰æ
+	DispSpaceEx(pInfo->m_gr, pInfo->m_pDispPos,pInfo->m_pcView, bTrans, width);	// ç©ºç™½æç”»
 	DrawImp_StylePop(pInfo);
 	DrawImp_DrawUnderline(pInfo, sPos);
-	// 1•¶š‘O’ñ
-	pInfo->m_nPosInLogic += CNativeW::GetSizeOfChar(	// s––ˆÈŠO‚Í‚±‚±‚ÅƒXƒLƒƒƒ“ˆÊ’u‚ğ‚Pši‚ß‚é
+	// 1æ–‡å­—å‰æ
+	pInfo->m_nPosInLogic += CNativeW::GetSizeOfChar(	// è¡Œæœ«ä»¥å¤–ã¯ã“ã“ã§ã‚¹ã‚­ãƒ£ãƒ³ä½ç½®ã‚’ï¼‘å­—é€²ã‚ã‚‹
 		pInfo->m_pLineOfLogic,
 		pInfo->GetDocLine()->GetLengthWithoutEOL(),
 		pInfo->GetPosInLogic()
@@ -41,10 +41,10 @@ void CFigure_CtrlCode::DispSpaceEx(CGraphics& gr, DispPos* pDispPos, CEditView* 
 	dx[0] = width;
 
 	RECT rc;
-	//ƒNƒŠƒbƒsƒ“ƒO‹éŒ`‚ğŒvZB‰æ–ÊŠO‚È‚ç•`‰æ‚µ‚È‚¢
+	//ã‚¯ãƒªãƒƒãƒ”ãƒ³ã‚°çŸ©å½¢ã‚’è¨ˆç®—ã€‚ç”»é¢å¤–ãªã‚‰æç”»ã—ãªã„
 	if(pcView->GetTextArea().GenerateClipRect(&rc, *pDispPos, CHabaXInt(dx[0])))
 	{
-		//•`‰æ
+		//æç”»
 		int fontNo = WCODE::GetFontNo(GetAlternateChar());
 		if( fontNo ){
 			SFONT sFont;

--- a/sakura_core/view/figures/CFigure_CtrlCode.h
+++ b/sakura_core/view/figures/CFigure_CtrlCode.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@
 
 #include "view/figures/CFigureStrategy.h"
 
-//! ƒRƒ“ƒgƒ[ƒ‹ƒR[ƒh•`‰æ
+//! ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã‚³ãƒ¼ãƒ‰æç”»
 class CFigure_CtrlCode : public CFigureSpace{
 public:
 	//traits
@@ -35,30 +35,30 @@ public:
 	//action
 	bool DrawImp(SColorStrategyInfo* pInfo);
 	virtual void DispSpaceEx(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans, int width) const;
-	virtual wchar_t GetAlternateChar() const{ return L'¥'; }
+	virtual wchar_t GetAlternateChar() const{ return L'ï½¥'; }
 	void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const{assert(0);};
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_CTRLCODE; }
 };
 
-//! ƒoƒCƒiƒŠ”¼Šp•`‰æ
+//! ãƒã‚¤ãƒŠãƒªåŠè§’æç”»
 class CFigure_HanBinary : public CFigure_CtrlCode{
 public:
 	//traits
 	bool Match(const wchar_t* pText, int nTextLen) const;
 
 	//action
-	virtual wchar_t GetAlternateChar() const{ return L'¬'; }
+	virtual wchar_t GetAlternateChar() const{ return L'ã€“'; }
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_CTRLCODE; }
 };
 
-//! ƒoƒCƒiƒŠ‘SŠp•`‰æ
+//! ãƒã‚¤ãƒŠãƒªå…¨è§’æç”»
 class CFigure_ZenBinary : public CFigure_CtrlCode{
 public:
 	//traits
 	bool Match(const wchar_t* pText, int nTextLen) const;
 
 	//action
-	virtual wchar_t GetAlternateChar() const{ return L'¬'; }
+	virtual wchar_t GetAlternateChar() const{ return L'ã€“'; }
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_CTRLCODE; }
 };
 

--- a/sakura_core/view/figures/CFigure_Eol.cpp
+++ b/sakura_core/view/figures/CFigure_Eol.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -30,19 +30,19 @@
 #include "env/DLLSHAREDATA.h"
 #include "window/CEditWnd.h"
 
-//�܂�Ԃ��`��
+//折り返し描画
 void _DispWrap(CGraphics& gr, DispPos* pDispPos, const CEditView* pcView);
 
-//EOF�`��֐�
-//���ۂɂ� pX �� nX ���X�V�����B
+//EOF描画関数
+//実際には pX と nX が更新される。
 //2004.05.29 genta
-//2007.08.25 kobake �߂�l�� void �ɕύX�B���� x, y �� DispPos �ɕύX
-//2007.08.25 kobake �������� nCharWidth, nLineHeight ���폜
-//2007.08.28 kobake ���� fuOptions ���폜
+//2007.08.25 kobake 戻り値を void に変更。引数 x, y を DispPos に変更
+//2007.08.25 kobake 引数から nCharWidth, nLineHeight を削除
+//2007.08.28 kobake 引数 fuOptions を削除
 //void _DispEOF( CGraphics& gr, DispPos* pDispPos, const CEditView* pcView, bool bTrans);
 
-//���s�L���`��
-//2007.08.30 kobake �ǉ�
+//改行記号描画
+//2007.08.30 kobake 追加
 void _DispEOL(CGraphics& gr, DispPos* pDispPos, CEol cEol, const CEditView* pcView, bool bTrans);
 
 
@@ -52,43 +52,43 @@ void _DispEOL(CGraphics& gr, DispPos* pDispPos, CEol cEol, const CEditView* pcVi
 
 bool CFigure_Eol::Match(const wchar_t* pText, int nTextLen) const
 {
-	// 2014.06.18 �܂�Ԃ��E�ŏI�s����DrawImp��cEol.GetLen()==0�ɂȂ薳�����[�v����̂�
-	// �������s�̓r���ɉ��s�R�[�h���������ꍇ��Match�����Ȃ�
+	// 2014.06.18 折り返し・最終行だとDrawImpでcEol.GetLen()==0になり無限ループするので
+	// もしも行の途中に改行コードがあった場合はMatchさせない
 	if(nTextLen == 2 && pText[0]==L'\r' && pText[1]==L'\n')return true;
 	if(nTextLen == 1 && WCODE::IsLineDelimiterExt(pText[0]))return true;
 	return false;
 }
 
-// 2006.04.29 Moca �I�������̂��ߏc��������ǉ�
-//$$ �������\�B
+// 2006.04.29 Moca 選択処理のため縦線処理を追加
+//$$ 高速化可能。
 bool CFigure_Eol::DrawImp(SColorStrategyInfo* pInfo)
 {
 	CEditView* pcView = pInfo->m_pcView;
 
-	// ���s�擾
+	// 改行取得
 	const CLayout* pcLayout = pInfo->m_pDispPos->GetLayoutRef();
 	CEol cEol = pcLayout->GetLayoutEol();
 	if(cEol.GetLen()){
-		// CFigureSpace::DrawImp_StyleSelect���ǂ��B�I���E�����F��D�悷��
-		CTypeSupport cCurrentType(pcView, pInfo->GetCurrentColor());	// ���ӂ̐F�i���݂̎w��F/�I��F�j
-		CTypeSupport cCurrentType2(pcView, pInfo->GetCurrentColor2());	// ���ӂ̐F�i���݂̎w��F�j
-		CTypeSupport cTextType(pcView, COLORIDX_TEXT);				// �e�L�X�g�̎w��F
-		CTypeSupport cSpaceType(pcView, GetDispColorIdx());	// �󔒂̎w��F
-		CTypeSupport cSearchType(pcView, COLORIDX_SEARCH);	// �����F(EOL�ŗL)
+		// CFigureSpace::DrawImp_StyleSelectもどき。選択・検索色を優先する
+		CTypeSupport cCurrentType(pcView, pInfo->GetCurrentColor());	// 周辺の色（現在の指定色/選択色）
+		CTypeSupport cCurrentType2(pcView, pInfo->GetCurrentColor2());	// 周辺の色（現在の指定色）
+		CTypeSupport cTextType(pcView, COLORIDX_TEXT);				// テキストの指定色
+		CTypeSupport cSpaceType(pcView, GetDispColorIdx());	// 空白の指定色
+		CTypeSupport cSearchType(pcView, COLORIDX_SEARCH);	// 検索色(EOL固有)
 		CTypeSupport cCurrentTypeBg(pcView, pInfo->GetCurrentColorBg());
 		CTypeSupport& cCurrentType3 = (cCurrentType2.GetBackColor() == cTextType.GetBackColor() ? cCurrentTypeBg: cCurrentType2);
 		COLORREF crText;
 		COLORREF crBack;
 		bool bSelecting = pInfo->GetCurrentColor() != pInfo->GetCurrentColor2();
-		bool blendColor = bSelecting && cCurrentType.GetTextColor() == cCurrentType.GetBackColor(); // �I�������F
+		bool blendColor = bSelecting && cCurrentType.GetTextColor() == cCurrentType.GetBackColor(); // 選択混合色
 		CTypeSupport& currentStyle = blendColor ? cCurrentType2 : cCurrentType;
 		CTypeSupport *pcText, *pcBack;
 		if( bSelecting && !blendColor ){
-			// �I�𕶎��F�Œ�w��
+			// 選択文字色固定指定
 			pcText = &cCurrentType;
 			pcBack = &cCurrentType;
 		}else if( pInfo->GetCurrentColor2() == COLORIDX_SEARCH ){
-			// �����F�D��
+			// 検索色優先
 			pcText = &cSearchType;
 			pcBack = &cSearchType;
 		}else{
@@ -96,7 +96,7 @@ bool CFigure_Eol::DrawImp(SColorStrategyInfo* pInfo)
 			pcBack = cSpaceType.GetBackColor() == cTextType.GetBackColor() ? &cCurrentType3 : &cSpaceType;
 		}
 		if( blendColor ){
-			// �����F(�����F��D�悵��)
+			// 混合色(検索色を優先しつつ)
 			crText = pcView->GetTextColorByColorInfo2(cCurrentType.GetColorInfo(), pcText->GetColorInfo());
 			crBack = pcView->GetBackColorByColorInfo2(cCurrentType.GetColorInfo(), pcBack->GetColorInfo());
 		}else{
@@ -112,14 +112,14 @@ bool CFigure_Eol::DrawImp(SColorStrategyInfo* pInfo)
 		sFont.m_hFont = pInfo->m_pcView->GetFontset().ChooseFontHandle( 0, sFont.m_sFontAttr );
 		pInfo->m_gr.PushMyFont(sFont);
 
-		DispPos sPos(*pInfo->m_pDispPos);	// ���݈ʒu���o���Ă���
+		DispPos sPos(*pInfo->m_pDispPos);	// 現在位置を覚えておく
 		_DispEOL(pInfo->m_gr, pInfo->m_pDispPos, cEol, pcView, bTrans);
 		DrawImp_StylePop(pInfo);
 		DrawImp_DrawUnderline(pInfo, sPos);
 
 		pInfo->m_nPosInLogic+=cEol.GetLen();
 	}else{
-		// �������[�v�΍�
+		// 無限ループ対策
 		pInfo->m_nPosInLogic += 1;
 		assert_warning( 1 );
 	}
@@ -128,10 +128,10 @@ bool CFigure_Eol::DrawImp(SColorStrategyInfo* pInfo)
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     �܂�Ԃ��`�����                        //
+//                     折り返し描画実装                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-// �܂�Ԃ��`��
+// 折り返し描画
 void _DispWrap(CGraphics& gr, DispPos* pDispPos, const CEditView* pcView, CLayoutYInt nLineNum )
 {
 	CTypeSupport cWrapType(pcView,COLORIDX_WRAP);
@@ -145,7 +145,7 @@ void _DispWrap(CGraphics& gr, DispPos* pDispPos, const CEditView* pcView, CLayou
 	RECT rcClip2;
 	if(pcView->GetTextArea().GenerateClipRect(&rcClip2, *pDispPos, width))
 	{
-		//�T�|�[�g�N���X
+		//サポートクラス
 		CTypeSupport cWrapType(pcView,COLORIDX_WRAP);
 		CTypeSupport cTextType(pcView,COLORIDX_TEXT);
 		CTypeSupport cBgLineType(pcView,COLORIDX_CARETLINEBG);
@@ -173,7 +173,7 @@ void _DispWrap(CGraphics& gr, DispPos* pDispPos, const CEditView* pcView, CLayou
 		}
 		bool bChangeColor = false;
 
-		//�`�敶����ƐF�̌���
+		//描画文字列と色の決定
 		if( cWrapType.IsDisp() )
 		{
 			cWrapType.SetGraphicsState_WhileThisObj(gr);
@@ -186,7 +186,7 @@ void _DispWrap(CGraphics& gr, DispPos* pDispPos, const CEditView* pcView, CLayou
 		int nHeightMargin = pcView->GetTextMetrics().GetCharHeightMarginByFontNo(fontNo);
 		int nDx[1] = {(Int)width};
 
-		//�`��
+		//描画
 		::ExtTextOutW_AnyBuild(
 			gr,
 			pDispPos->GetDrawPos().x,
@@ -204,33 +204,33 @@ void _DispWrap(CGraphics& gr, DispPos* pDispPos, const CEditView* pcView, CLayou
 	pDispPos->ForwardDrawCol(width);
 }
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       EOF�`�����                           //
+//                       EOF描画実装                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 /*!
-EOF�L���̕`��
-@date 2004.05.29 genta  MIK����̃A�h�o�C�X�ɂ��֐��ɂ����肾��
-@date 2007.08.28 kobake ���� nCharWidth �폜
-@date 2007.08.28 kobake ���� fuOptions �폜
-@date 2007.08.30 kobake ���� EofColInfo �폜
+EOF記号の描画
+@date 2004.05.29 genta  MIKさんのアドバイスにより関数にくくりだし
+@date 2007.08.28 kobake 引数 nCharWidth 削除
+@date 2007.08.28 kobake 引数 fuOptions 削除
+@date 2007.08.30 kobake 引数 EofColInfo 削除
 */
 void _DispEOF(
-	CGraphics&			gr,			//!< [in] �`��Ώۂ�Device Context
-	DispPos*			pDispPos,	//!< [in] �\�����W
+	CGraphics&			gr,			//!< [in] 描画対象のDevice Context
+	DispPos*			pDispPos,	//!< [in] 表示座標
 	const CEditView*	pcView
 )
 {
-	// �`��Ɏg���F���
+	// 描画に使う色情報
 	CTypeSupport cEofType(pcView,COLORIDX_EOF);
 	if(!cEofType.IsDisp())
 		return;
 	CTypeSupport cTextType(pcView,COLORIDX_TEXT);
 	bool bTrans = pcView->IsBkBitmap() && cEofType.GetBackColor() == cTextType.GetBackColor();
 
-	//�K�v�ȃC���^�[�t�F�[�X���擾
+	//必要なインターフェースを取得
 	const CTextMetrics* pMetrics=&pcView->GetTextMetrics();
 	const CTextArea* pArea=&pcView->GetTextArea();
 
-	//�萔
+	//定数
 	static const wchar_t	szEof[] = L"[EOF]";
 	const int		nEofLen = _countof(szEof) - 1;
 
@@ -242,12 +242,12 @@ void _DispEOF(
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                       ���s�`�����                          //
+//                       改行描画実装                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//��ʕ`��⏕�֐�
+//画面描画補助関数
 //May 23, 2000 genta
-//@@@ 2001.12.21 YAZAKI ���s�L���̏����������ς������̂ŏC��
+//@@@ 2001.12.21 YAZAKI 改行記号の書きかたが変だったので修正
 void _DrawEOL(
 	CGraphics&		gr,
 	const CMyRect&	rcEol,
@@ -256,17 +256,17 @@ void _DrawEOL(
 	COLORREF		pColor
 );
 
-//2007.08.30 kobake �ǉ�
+//2007.08.30 kobake 追加
 void _DispEOL(CGraphics& gr, DispPos* pDispPos, CEol cEol, const CEditView* pcView, bool bTrans)
 {
 	const CLayoutXInt nCol = CTypeSupport(pcView,COLORIDX_EOL).IsDisp()
-		? pcView->GetTextMetrics().GetLayoutXDefault(CKetaXInt(1)) + CLayoutXInt(4) // ON�̂Ƃ���1��+4px
-		: CLayoutXInt(2); // HACK:EOL off �Ȃ�2px
+		? pcView->GetTextMetrics().GetLayoutXDefault(CKetaXInt(1)) + CLayoutXInt(4) // ONのときは1幅+4px
+		: CLayoutXInt(2); // HACK:EOL off なら2px
 	RECT rcClip2;
 	if(pcView->GetTextArea().GenerateClipRect(&rcClip2,*pDispPos,nCol)){
 		int fontNo = WCODE::GetFontNo(' ');
 		int nHeightMargin = pcView->GetTextMetrics().GetCharHeightMarginByFontNo(fontNo);
-		// 2003.08.17 ryoji ���s�����������Ȃ��悤��
+		// 2003.08.17 ryoji 改行文字が欠けないように
 		::ExtTextOutW_AnyBuild(
 			gr,
 			pDispPos->GetDrawPos().x,
@@ -278,158 +278,158 @@ void _DispEOL(CGraphics& gr, DispPos* pDispPos, CEol cEol, const CEditView* pcVi
 			pcView->GetTextMetrics().GetDxArray_AllHankaku()
 		);
 
-		// ���s�L���̕\��
+		// 改行記号の表示
 		if( CTypeSupport(pcView,COLORIDX_EOL).IsDisp() ){
-			// From Here 2003.08.17 ryoji ���s�����������Ȃ��悤��
+			// From Here 2003.08.17 ryoji 改行文字が欠けないように
 
-			// ���[�W�����쐬�A�I���B
+			// リージョン作成、選択。
 			gr.PushClipping(rcClip2);
 			
-			// �`��̈�
+			// 描画領域
 			CMyRect rcEol;
 			rcEol.SetPos(pDispPos->GetDrawPos().x + 1, pDispPos->GetDrawPos().y);
 			rcEol.SetSize(pcView->GetTextMetrics().GetHankakuWidth(), pcView->GetTextMetrics().GetHankakuHeight());
 
-			// �`��
-			// �����F�⑾�����ǂ��������݂� DC ���璲�ׂ�	// 2009.05.29 ryoji 
-			// �i�����}�b�`���̏󋵂ɏ_��ɑΉ����邽�߁A�����͋L���̐F�w��ɂ͌��ߑł����Ȃ��j
-			// 2013.06.21 novice �����F�A������CGraphics����擾
+			// 描画
+			// 文字色や太字かどうかを現在の DC から調べる	// 2009.05.29 ryoji 
+			// （検索マッチ等の状況に柔軟に対応するため、ここは記号の色指定には決め打ちしない）
+			// 2013.06.21 novice 文字色、太字をCGraphicsから取得
 			_DrawEOL(gr, rcEol, cEol, gr.GetCurrentMyFontBold(), gr.GetCurrentTextForeColor());
 
-			// ���[�W�����j��
+			// リージョン破棄
 			gr.PopClipping();
 
-			// To Here 2003.08.17 ryoji ���s�����������Ȃ��悤��
+			// To Here 2003.08.17 ryoji 改行文字が欠けないように
 		}
 	}
 
-	//�`��ʒu��i�߂�(2��)
+	//描画位置を進める(2桁)
 	pDispPos->ForwardDrawCol(nCol);
 }
 
 
 //	May 23, 2000 genta
 /*!
-��ʕ`��⏕�֐�:
-�s���̉��s�}�[�N�����s�R�[�h�ɂ���ď���������i���C���j
+画面描画補助関数:
+行末の改行マークを改行コードによって書き分ける（メイン）
 
-@note bBold��TRUE�̎��͉���1�h�b�g���炵�ďd�ˏ������s�����A
-���܂葾�������Ȃ��B
+@note bBoldがTRUEの時は横に1ドットずらして重ね書きを行うが、
+あまり太く見えない。
 
-@date 2001.12.21 YAZAKI ���s�L���̕`��������ύX�B�y���͂��̊֐����ō��悤�ɂ����B
-						���̐擪���Asx, sy�ɂ��ĕ`�惋�[�`�����������B
+@date 2001.12.21 YAZAKI 改行記号の描きかたを変更。ペンはこの関数内で作るようにした。
+						矢印の先頭を、sx, syにして描画ルーチン書き直し。
 */
 void _DrawEOL(
 	CGraphics&		gr,		//!< Device Context Handle
-	const CMyRect&	rcEol,		//!< �`��̈�
-	CEol			cEol,		//!< �s���R�[�h���
-	bool			bBold,		//!< TRUE: ����
-	COLORREF		pColor		//!< �F
+	const CMyRect&	rcEol,		//!< 描画領域
+	CEol			cEol,		//!< 行末コード種別
+	bool			bBold,		//!< TRUE: 太字
+	COLORREF		pColor		//!< 色
 )
 {
-	int sx, sy;	//	���̐擪
+	int sx, sy;	//	矢印の先頭
 	gr.SetPen( pColor );
 
 	switch( cEol.GetType() ){
-	case EOL_CRLF:	//	�������
+	case EOL_CRLF:	//	下左矢印
 		{
-			sx = rcEol.left;						//X���[
-			sy = rcEol.top + ( rcEol.Height() / 2);	//Y���S
+			sx = rcEol.left;						//X左端
+			sy = rcEol.top + ( rcEol.Height() / 2);	//Y中心
 			DWORD pp[] = { 3, 3 };
 			POINT pt[6];
-			pt[0].x = sx + rcEol.Width();	//	���
+			pt[0].x = sx + rcEol.Width();	//	上へ
 			pt[0].y = sy - rcEol.Height() / 4;
-			pt[1].x = sx + rcEol.Width();	//	����
+			pt[1].x = sx + rcEol.Width();	//	下へ
 			pt[1].y = sy;
-			pt[2].x = sx;	//	�擪��
+			pt[2].x = sx;	//	先頭へ
 			pt[2].y = sy;
-			pt[3].x = sx + rcEol.Height() / 4;	//	�擪���牺��
+			pt[3].x = sx + rcEol.Height() / 4;	//	先頭から下へ
 			pt[3].y = sy + rcEol.Height() / 4;
-			pt[4].x = sx;	//	�擪�֖߂�
+			pt[4].x = sx;	//	先頭へ戻り
 			pt[4].y = sy;
-			pt[5].x = sx + rcEol.Height() / 4;	//	�擪������
+			pt[5].x = sx + rcEol.Height() / 4;	//	先頭から上へ
 			pt[5].y = sy - rcEol.Height() / 4;
 			::PolyPolyline( gr, pt, pp, _countof(pp));
 
 			if ( bBold ) {
-				pt[0].x += 1;	//	��ցi�E�ւ��炷�j
+				pt[0].x += 1;	//	上へ（右へずらす）
 				pt[0].y += 0;
-				pt[1].x += 1;	//	�E�ցi�E�ɂЂƂ���Ă���j
+				pt[1].x += 1;	//	右へ（右にひとつずれている）
 				pt[1].y += 1;
-				pt[2].x += 0;	//	�擪��
+				pt[2].x += 0;	//	先頭へ
 				pt[2].y += 1;
-				pt[3].x += 0;	//	�擪���牺��
+				pt[3].x += 0;	//	先頭から下へ
 				pt[3].y += 1;
-				pt[4].x += 0;	//	�擪�֖߂�
+				pt[4].x += 0;	//	先頭へ戻り
 				pt[4].y += 1;
-				pt[5].x += 0;	//	�擪������
+				pt[5].x += 0;	//	先頭から上へ
 				pt[5].y += 1;
 				::PolyPolyline( gr, pt, pp, _countof(pp));
 			}
 		}
 		break;
-	case EOL_CR:	//	���������	// 2007.08.17 ryoji EOL_LF -> EOL_CR
+	case EOL_CR:	//	左向き矢印	// 2007.08.17 ryoji EOL_LF -> EOL_CR
 		{
 			sx = rcEol.left;
 			sy = rcEol.top + ( rcEol.Height() / 2 );
 			DWORD pp[] = { 3, 2 };
 			POINT pt[5];
-			pt[0].x = sx + rcEol.Width();	//	�E��
+			pt[0].x = sx + rcEol.Width();	//	右へ
 			pt[0].y = sy;
-			pt[1].x = sx;	//	�擪��
+			pt[1].x = sx;	//	先頭へ
 			pt[1].y = sy;
-			pt[2].x = sx + rcEol.Height() / 4;	//	�擪���牺��
+			pt[2].x = sx + rcEol.Height() / 4;	//	先頭から下へ
 			pt[2].y = sy + rcEol.Height() / 4;
-			pt[3].x = sx;	//	�擪�֖߂�
+			pt[3].x = sx;	//	先頭へ戻り
 			pt[3].y = sy;
-			pt[4].x = sx + rcEol.Height() / 4;	//	�擪������
+			pt[4].x = sx + rcEol.Height() / 4;	//	先頭から上へ
 			pt[4].y = sy - rcEol.Height() / 4;
 			::PolyPolyline( gr, pt, pp, _countof(pp));
 
 			if ( bBold ) {
-				pt[0].x += 0;	//	�E��
+				pt[0].x += 0;	//	右へ
 				pt[0].y += 1;
-				pt[1].x += 0;	//	�擪��
+				pt[1].x += 0;	//	先頭へ
 				pt[1].y += 1;
-				pt[2].x += 0;	//	�擪���牺��
+				pt[2].x += 0;	//	先頭から下へ
 				pt[2].y += 1;
-				pt[3].x += 0;	//	�擪�֖߂�
+				pt[3].x += 0;	//	先頭へ戻り
 				pt[3].y += 1;
-				pt[4].x += 0;	//	�擪������
+				pt[4].x += 0;	//	先頭から上へ
 				pt[4].y += 1;
 				::PolyPolyline( gr, pt, pp, _countof(pp));
 			}
 		}
 		break;
-	case EOL_LF:	//	���������	// 2007.08.17 ryoji EOL_CR -> EOL_LF
-	// 2013.04.22 Moca NEL,LS,PS�Ή��B�b���LF�Ɠ����ɂ���
+	case EOL_LF:	//	下向き矢印	// 2007.08.17 ryoji EOL_CR -> EOL_LF
+	// 2013.04.22 Moca NEL,LS,PS対応。暫定でLFと同じにする
 		{
 			sx = rcEol.left + ( rcEol.Width() / 2 );
 			sy = rcEol.top + ( rcEol.Height() * 3 / 4 );
 			DWORD pp[] = { 3, 2 };
 			POINT pt[5];
-			pt[0].x = sx;	//	���
+			pt[0].x = sx;	//	上へ
 			pt[0].y = rcEol.top + rcEol.Height() / 4 + 1;
-			pt[1].x = sx;	//	�ォ�牺��
+			pt[1].x = sx;	//	上から下へ
 			pt[1].y = sy;
-			pt[2].x = sx - rcEol.Height() / 4;	//	���̂܂܍����
+			pt[2].x = sx - rcEol.Height() / 4;	//	そのまま左上へ
 			pt[2].y = sy - rcEol.Height() / 4;
-			pt[3].x = sx;	//	���̐�[�ɖ߂�
+			pt[3].x = sx;	//	矢印の先端に戻る
 			pt[3].y = sy;
-			pt[4].x = sx + rcEol.Height() / 4;	//	�����ĉE���
+			pt[4].x = sx + rcEol.Height() / 4;	//	そして右上へ
 			pt[4].y = sy - rcEol.Height() / 4;
 			::PolyPolyline( gr, pt, pp, _countof(pp));
 
 			if( bBold ){
-				pt[0].x += 1;	//	���
+				pt[0].x += 1;	//	上へ
 				pt[0].y += 0;
-				pt[1].x += 1;	//	�ォ�牺��
+				pt[1].x += 1;	//	上から下へ
 				pt[1].y += 0;
-				pt[2].x += 1;	//	���̂܂܍����
+				pt[2].x += 1;	//	そのまま左上へ
 				pt[2].y += 0;
-				pt[3].x += 1;	//	���̐�[�ɖ߂�
+				pt[3].x += 1;	//	矢印の先端に戻る
 				pt[3].y += 0;
-				pt[4].x += 1;	//	�����ĉE���
+				pt[4].x += 1;	//	そして右上へ
 				pt[4].y += 0;
 				::PolyPolyline( gr, pt, pp, _countof(pp));
 			}
@@ -439,34 +439,34 @@ void _DrawEOL(
 	case EOL_LS:
 	case EOL_PS:
 		{
-			// �������(�܂�Ȃ���Ȃ�)
-			sx = rcEol.left;			//X���[
-			sy = rcEol.top + ( rcEol.Height() * 3 / 4 );	//Y�ォ��3/4
+			// 左下矢印(折れ曲がりなし)
+			sx = rcEol.left;			//X左端
+			sy = rcEol.top + ( rcEol.Height() * 3 / 4 );	//Y上から3/4
 			DWORD pp[] = { 2, 3 };
 			POINT pt[5];
 			int nWidth = t_min(rcEol.Width(), rcEol.Height() / 2);
-			pt[0].x = sx + nWidth;	//	�E�ォ��
+			pt[0].x = sx + nWidth;	//	右上から
 			pt[0].y = sy - nWidth;
-			pt[1].x = sx;	//	�擪��
+			pt[1].x = sx;	//	先頭へ
 			pt[1].y = sy;
-			pt[2].x = sx + nWidth;	//	�E����
+			pt[2].x = sx + nWidth;	//	右から
 			pt[2].y = sy;
-			pt[3].x = sx;	//	�擪�֖߂�
+			pt[3].x = sx;	//	先頭へ戻り
 			pt[3].y = sy;
-			pt[4].x = sx;	//	�擪������
+			pt[4].x = sx;	//	先頭から上へ
 			pt[4].y = sy - nWidth;
 			::PolyPolyline( gr, pt, pp, _countof(pp));
 
 			if ( bBold ) {
-				pt[0].x += 0;	//	�E�ォ��
+				pt[0].x += 0;	//	右上から
 				pt[0].y += 1;
-				pt[1].x += 0;	//	�擪��
+				pt[1].x += 0;	//	先頭へ
 				pt[1].y += 1;
-				pt[2].x += 0;	//	�E����
+				pt[2].x += 0;	//	右から
 				pt[2].y -= 1;
-				pt[3].x += 1;	//	�擪�֖߂�
+				pt[3].x += 1;	//	先頭へ戻り
 				pt[3].y -= 1;
-				pt[4].x += 1;	//	�擪������
+				pt[4].x += 1;	//	先頭から上へ
 				pt[4].y += 0;
 				::PolyPolyline( gr, pt, pp, _countof(pp));
 			}

--- a/sakura_core/view/figures/CFigure_Eol.h
+++ b/sakura_core/view/figures/CFigure_Eol.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@
 
 #include "view/figures/CFigureStrategy.h"
 
-//! ‰üs•`‰æ
+//! æ”¹è¡Œæç”»
 class CFigure_Eol : public CFigureSpace{
 public:
 	//traits

--- a/sakura_core/view/figures/CFigure_HanSpace.cpp
+++ b/sakura_core/view/figures/CFigure_HanSpace.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 
 #include "CFigure_HanSpace.h"
@@ -18,19 +18,19 @@ bool CFigure_HanSpace::Match(const wchar_t* pText, int nTextLen) const
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         •`‰æŽÀ‘•                            //
+//                         æç”»å®Ÿè£…                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! ”¼ŠpƒXƒy[ƒX•`‰æ
+//! åŠè§’ã‚¹ãƒšãƒ¼ã‚¹æç”»
 void CFigure_HanSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const
 {
-	//ƒNƒŠƒbƒsƒ“ƒO‹éŒ`‚ðŒvŽZB‰æ–ÊŠO‚È‚ç•`‰æ‚µ‚È‚¢
+	//ã‚¯ãƒªãƒƒãƒ”ãƒ³ã‚°çŸ©å½¢ã‚’è¨ˆç®—ã€‚ç”»é¢å¤–ãªã‚‰æç”»ã—ãªã„
 	CMyRect rcClip;
 	const int Dx = pcView->GetTextMetrics().CalcTextWidth3(L" ", 1);
 	const CLayoutXInt nCol = CLayoutXInt(Dx);
 	if(pcView->GetTextArea().GenerateClipRect(&rcClip,*pDispPos,nCol))
 	{
-		//¬•¶Žš"o"‚Ì‰º”¼•ª‚ðo—Í
+		//å°æ–‡å­—"o"ã®ä¸‹åŠåˆ†ã‚’å‡ºåŠ›
 		CMyRect rcClipBottom=rcClip;
 		rcClipBottom.top=rcClip.top+pcView->GetTextMetrics().GetHankakuHeight()/2;
 		::ExtTextOutW_AnyBuild(
@@ -39,13 +39,13 @@ void CFigure_HanSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pc
 			pDispPos->GetDrawPos().y,
 			ExtTextOutOption() & ~(bTrans? ETO_OPAQUE: 0),
 			&rcClipBottom,
-//FIXME:•‚ªˆá‚¤
+//FIXME:å¹…ãŒé•ã†
 			L"o",
 			1,
 			&Dx
 		);
 		
-		//ã”¼•ª‚Í•’Ê‚Ì‹ó”’‚Åo—Íi"o"‚Ìã”¼•ª‚ðÁ‚·j
+		//ä¸ŠåŠåˆ†ã¯æ™®é€šã®ç©ºç™½ã§å‡ºåŠ›ï¼ˆ"o"ã®ä¸ŠåŠåˆ†ã‚’æ¶ˆã™ï¼‰
 		CMyRect rcClipTop=rcClip;
 		rcClipTop.bottom=rcClip.top+pcView->GetTextMetrics().GetHankakuHeight()/2;
 		::ExtTextOutW_AnyBuild(
@@ -60,6 +60,6 @@ void CFigure_HanSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pc
 		);
 	}
 
-	//ˆÊ’ui‚ß‚é
+	//ä½ç½®é€²ã‚ã‚‹
 	pDispPos->ForwardDrawCol(nCol);
 }

--- a/sakura_core/view/figures/CFigure_HanSpace.h
+++ b/sakura_core/view/figures/CFigure_HanSpace.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@
 
 #include "view/figures/CFigureStrategy.h"
 
-//! ”¼ŠpƒXƒy[ƒX•`‰æ
+//! åŠè§’ã‚¹ãƒšãƒ¼ã‚¹æç”»
 class CFigure_HanSpace : public CFigureSpace{
 public:
 	//traits

--- a/sakura_core/view/figures/CFigure_Tab.cpp
+++ b/sakura_core/view/figures/CFigure_Tab.cpp
@@ -1,13 +1,13 @@
-#include "StdAfx.h"
+ï»¿#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CFigure_Tab.h"
 #include "env/CShareData.h"
 #include "env/DLLSHAREDATA.h"
 #include "types/CTypeSupport.h"
 
-//2007.08.28 kobake ’Ç‰Á
+//2007.08.28 kobake è¿½åŠ 
 void _DispTab( CGraphics& gr, DispPos* pDispPos, const CEditView* pcView );
-//ƒ^ƒu–îˆó•`‰æŠÖ”	//@@@ 2003.03.26 MIK
+//ã‚¿ãƒ–çŸ¢å°æç”»é–¢æ•°	//@@@ 2003.03.26 MIK
 void _DrawTabArrow( CGraphics& gr, int nPosX, int nPosY, int nWidth, int nHeight, bool bBold, COLORREF pColor );
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -26,30 +26,30 @@ bool CFigure_Tab::Match(const wchar_t* pText, int nTextLen) const
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         •`‰æÀ‘•                            //
+//                         æç”»å®Ÿè£…                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-/*! TAB•`‰æ
+/*! TABæç”»
 	@date 2001.03.16 by MIK
-	@date 2002.09.22 genta ‹¤’Ê®‚Ì‚­‚­‚è‚¾‚µ
-	@date 2002.09.23 genta LayoutMgr‚Ì’l‚ğg‚¤
-	@date 2003.03.26 MIK ƒ^ƒu–îˆó•\¦
-	@date 2013.05.31 novice TAB•\¦‘Î‰(•¶šw’è/’Z‚¢–îˆó/’·‚¢–îˆó)
+	@date 2002.09.22 genta å…±é€šå¼ã®ããã‚Šã ã—
+	@date 2002.09.23 genta LayoutMgrã®å€¤ã‚’ä½¿ã†
+	@date 2003.03.26 MIK ã‚¿ãƒ–çŸ¢å°è¡¨ç¤º
+	@date 2013.05.31 novice TABè¡¨ç¤ºå¯¾å¿œ(æ–‡å­—æŒ‡å®š/çŸ­ã„çŸ¢å°/é•·ã„çŸ¢å°)
 */
 void CFigure_Tab::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const
 {
 	DispPos& sPos=*pDispPos;
 
-	//•K—v‚ÈƒCƒ“ƒ^[ƒtƒF[ƒX
+	//å¿…è¦ãªã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹
 	const CTextMetrics* pMetrics=&pcView->GetTextMetrics();
 	const CTextArea* pArea=&pcView->GetTextArea();
 
 	int nLineHeight = pMetrics->GetHankakuDy();
-	int nCharWidth = pMetrics->GetCharPxWidth();	// Layout¨Px
+	int nCharWidth = pMetrics->GetCharPxWidth();	// Layoutâ†’Px
 
 	CTypeSupport cTabType(pcView,COLORIDX_TAB);
 
-	// ‚±‚ê‚©‚ç•`‰æ‚·‚éƒ^ƒu•
+	// ã“ã‚Œã‹ã‚‰æç”»ã™ã‚‹ã‚¿ãƒ–å¹…
 	CLayoutXInt tabDispWidthLayout = pcView->m_pcEditDoc->m_cLayoutMgr.GetActualTsvSpace( sPos.GetDrawCol(), WCODE::TAB );
 	int tabDispWidth = (Int)tabDispWidthLayout;
 	if( pcView->m_bMiniMap ){
@@ -60,7 +60,7 @@ void CFigure_Tab::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView,
 		tabDispWidth = (Int)tabDispWidthLayout;
 	}
 
-	// ƒ^ƒu‹L†—Ìˆæ
+	// ã‚¿ãƒ–è¨˜å·é ˜åŸŸ
 	RECT rcClip2;
 	rcClip2.left = sPos.GetDrawPos().x;
 	rcClip2.right = rcClip2.left + nCharWidth * tabDispWidth;
@@ -72,7 +72,7 @@ void CFigure_Tab::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView,
 	int nLen = wcslen( m_pTypeData->m_szTabViewString );
 
 	if( pArea->IsRectIntersected(rcClip2) ){
-		if( cTabType.IsDisp() && TABARROW_STRING == m_pTypeData->m_bTabArrow ){	//ƒ^ƒu’Êí•\¦	//@@@ 2003.03.26 MIK
+		if( cTabType.IsDisp() && TABARROW_STRING == m_pTypeData->m_bTabArrow ){	//ã‚¿ãƒ–é€šå¸¸è¡¨ç¤º	//@@@ 2003.03.26 MIK
 			int fontNo = WCODE::GetFontNo(m_pTypeData->m_szTabViewString[0]);
 			if( fontNo ){
 				SFONT sFont;
@@ -91,13 +91,13 @@ void CFigure_Tab::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView,
 				m_pTypeData->m_szTabViewString,
 				// tabDispWidth <= 8 ? tabDispWidth : 8, // Sep. 22, 2002 genta
 				nLen,
-				pMetrics->GetDxArray_AllHankaku()	// FIXME:”¼ŠpŒÅ’èH
+				pMetrics->GetDxArray_AllHankaku()	// FIXME:åŠè§’å›ºå®šï¼Ÿ
 			);
 			if( fontNo ){
 				gr.PopMyFont();
 			}
 		}else{
-			//”wŒi
+			//èƒŒæ™¯
 			::ExtTextOutW_AnyBuild(
 				gr,
 				sPos.GetDrawPos().x,
@@ -109,15 +109,15 @@ void CFigure_Tab::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView,
 				pMetrics->GetDxArray_AllHankaku()
 			);
 
-			//ƒ^ƒu–îˆó•\¦
+			//ã‚¿ãƒ–çŸ¢å°è¡¨ç¤º
 			if( cTabType.IsDisp() ){
-				// •¶šF‚â‘¾š‚©‚Ç‚¤‚©‚ğŒ»İ‚Ì DC ‚©‚ç’²‚×‚é	// 2009.05.29 ryoji 
-				// iŒŸõƒ}ƒbƒ`“™‚Ìó‹µ‚É_“î‚É‘Î‰‚·‚é‚½‚ßA‚±‚±‚Í‹L†‚ÌFw’è‚É‚ÍŒˆ‚ß‘Å‚¿‚µ‚È‚¢j
-				//	‘¾š‚©‚Ç‚¤‚©İ’è‚àŒ©‚é—l‚É‚·‚é 2013/4/11 Uchi
-				// 2013.06.21 novice •¶šFA‘¾š‚ğCGraphics‚©‚çæ“¾
+				// æ–‡å­—è‰²ã‚„å¤ªå­—ã‹ã©ã†ã‹ã‚’ç¾åœ¨ã® DC ã‹ã‚‰èª¿ã¹ã‚‹	// 2009.05.29 ryoji 
+				// ï¼ˆæ¤œç´¢ãƒãƒƒãƒç­‰ã®çŠ¶æ³ã«æŸ”è»Ÿã«å¯¾å¿œã™ã‚‹ãŸã‚ã€ã“ã“ã¯è¨˜å·ã®è‰²æŒ‡å®šã«ã¯æ±ºã‚æ‰“ã¡ã—ãªã„ï¼‰
+				//	å¤ªå­—ã‹ã©ã†ã‹è¨­å®šã‚‚è¦‹ã‚‹æ§˜ã«ã™ã‚‹ 2013/4/11 Uchi
+				// 2013.06.21 novice æ–‡å­—è‰²ã€å¤ªå­—ã‚’CGraphicsã‹ã‚‰å–å¾—
 
 				if( TABARROW_SHORT == m_pTypeData->m_bTabArrow ){
-					if( rcClip2.left <= sPos.GetDrawPos().x ){ // Apr. 1, 2003 MIK s”Ô†‚Æd‚È‚é
+					if( rcClip2.left <= sPos.GetDrawPos().x ){ // Apr. 1, 2003 MIK è¡Œç•ªå·ã¨é‡ãªã‚‹
 						_DrawTabArrow(
 							gr,
 							sPos.GetDrawPos().x,
@@ -134,7 +134,7 @@ void CFigure_Tab::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView,
 						gr,
 						nPosLeft,
 						sPos.GetDrawPos().y,
-						nCharWidth * tabDispWidth - (nPosLeft -  sPos.GetDrawPos().x),	// Tab Areaˆê”t‚É 2013/4/11 Uchi
+						nCharWidth * tabDispWidth - (nPosLeft -  sPos.GetDrawPos().x),	// Tab Areaä¸€æ¯ã« 2013/4/11 Uchi
 						pMetrics->GetHankakuHeight(),
 						gr.GetCurrentMyFontBold() || m_pTypeData->m_ColorInfoArr[COLORIDX_TAB].m_sFontAttr.m_bBoldFont,
 						gr.GetCurrentTextForeColor()
@@ -144,55 +144,55 @@ void CFigure_Tab::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView,
 		}
 	}
 
-	//X‚ği‚ß‚é
+	//Xã‚’é€²ã‚ã‚‹
 	sPos.ForwardDrawCol(tabDispWidthLayout);
 }
 
 
 
 /*
-	ƒ^ƒu–îˆó•`‰æŠÖ”
+	ã‚¿ãƒ–çŸ¢å°æç”»é–¢æ•°
 */
 void _DrawTabArrow(
 	CGraphics&	gr,
-	int			nPosX,   //ƒsƒNƒZƒ‹X
-	int			nPosY,   //ƒsƒNƒZƒ‹Y
-	int			nWidth,  //ƒsƒNƒZƒ‹W
-	int			nHeight, //ƒsƒNƒZƒ‹H
+	int			nPosX,   //ãƒ”ã‚¯ã‚»ãƒ«X
+	int			nPosY,   //ãƒ”ã‚¯ã‚»ãƒ«Y
+	int			nWidth,  //ãƒ”ã‚¯ã‚»ãƒ«W
+	int			nHeight, //ãƒ”ã‚¯ã‚»ãƒ«H
 	bool		bBold,
 	COLORREF	pColor
 )
 {
-	// ƒyƒ“İ’è
+	// ãƒšãƒ³è¨­å®š
 	gr.PushPen( pColor, 0 );
 
-	// –îˆó‚Ìæ“ª
+	// çŸ¢å°ã®å…ˆé ­
 	int sx = nPosX + nWidth - 2;
 	int sy = nPosY + ( nHeight / 2 );
-	int sa = nHeight / 4;								// èV‚Ìsize
+	int sa = nHeight / 4;								// éƒã®size
 
 	DWORD pp[] = { 3, 2 };
 	POINT pt[5];
-	pt[0].x = nPosX;	//u„Ÿv¶’[‚©‚ç‰E’[
+	pt[0].x = nPosX;	//ã€Œâ”€ã€å·¦ç«¯ã‹ã‚‰å³ç«¯
 	pt[0].y = sy;
-	pt[1].x = sx;		//u^v‰E’[‚©‚çÎ‚ß¶‰º
+	pt[1].x = sx;		//ã€Œï¼ã€å³ç«¯ã‹ã‚‰æ–œã‚å·¦ä¸‹
 	pt[1].y = sy;
-	pt[2].x = sx - sa;	//	–îˆó‚Ìæ’[‚É–ß‚é
+	pt[2].x = sx - sa;	//	çŸ¢å°ã®å…ˆç«¯ã«æˆ»ã‚‹
 	pt[2].y = sy + sa;
-	pt[3].x = sx;		//u_v‰E’[‚©‚çÎ‚ß¶ã
+	pt[3].x = sx;		//ã€Œï¼¼ã€å³ç«¯ã‹ã‚‰æ–œã‚å·¦ä¸Š
 	pt[3].y = sy;
 	pt[4].x = sx - sa;
 	pt[4].y = sy - sa;
 	::PolyPolyline( gr, pt, pp, _countof(pp));
 
 	if( bBold ){
-		pt[0].x += 0;	//u„Ÿv¶’[‚©‚ç‰E’[
+		pt[0].x += 0;	//ã€Œâ”€ã€å·¦ç«¯ã‹ã‚‰å³ç«¯
 		pt[0].y += 1;
-		pt[1].x += 0;	//u^v‰E’[‚©‚çÎ‚ß¶‰º
+		pt[1].x += 0;	//ã€Œï¼ã€å³ç«¯ã‹ã‚‰æ–œã‚å·¦ä¸‹
 		pt[1].y += 1;
-		pt[2].x += 0;	//	–îˆó‚Ìæ’[‚É–ß‚é
+		pt[2].x += 0;	//	çŸ¢å°ã®å…ˆç«¯ã«æˆ»ã‚‹
 		pt[2].y += 1;
-		pt[3].x += 0;	//u_v‰E’[‚©‚çÎ‚ß¶ã
+		pt[3].x += 0;	//ã€Œï¼¼ã€å³ç«¯ã‹ã‚‰æ–œã‚å·¦ä¸Š
 		pt[3].y += 1;
 		pt[4].x += 0;
 		pt[4].y += 1;

--- a/sakura_core/view/figures/CFigure_Tab.h
+++ b/sakura_core/view/figures/CFigure_Tab.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@
 
 #include "view/figures/CFigureStrategy.h"
 
-//! ƒ^ƒu•`‰æ
+//! ã‚¿ãƒ–æç”»
 class CFigure_Tab : public CFigureSpace{
 public:
 	//traits

--- a/sakura_core/view/figures/CFigure_ZenSpace.cpp
+++ b/sakura_core/view/figures/CFigure_ZenSpace.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+Ôªø#include "StdAfx.h"
 #include "view/CEditView.h" // SColorStrategyInfo
 #include "CFigure_ZenSpace.h"
 #include "types/CTypeSupport.h"
@@ -11,7 +11,7 @@ void Draw_ZenSpace( CGraphics& gr, const CMyRect& rc );
 
 bool CFigure_ZenSpace::Match(const wchar_t* pText, int nTextLen) const
 {
-	if( pText[0] == L'Å@' ){
+	if( pText[0] == L'„ÄÄ' ){
 		return true;
 	}
 	return false;
@@ -19,26 +19,26 @@ bool CFigure_ZenSpace::Match(const wchar_t* pText, int nTextLen) const
 
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         ï`âÊé¿ëï                            //
+//                         ÊèèÁîªÂÆüË£Ö                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//! ëSäpÉXÉyÅ[ÉXï`âÊ
+//! ÂÖ®Ëßí„Çπ„Éö„Éº„ÇπÊèèÁîª
 void CFigure_ZenSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const
 {
-	// 2010.09.21 PPópé¿ëïí«â¡
-	// ÉvÉçÉ|Å[ÉVÉáÉiÉãÇ≈ÇÕÅAëSäpSPÇ∆Å†ÇÃïùÇ™à·Ç§Ç±Ç∆Ç™Ç†ÇÈÅBà·Ç§èÍçáÇÕì∆é©Ç…ï`âÊ
+	// 2010.09.21 PPÁî®ÂÆüË£ÖËøΩÂä†
+	// „Éó„É≠„Éù„Éº„Ç∑„Éß„Éä„É´„Åß„ÅØ„ÄÅÂÖ®ËßíSP„Å®‚ñ°„ÅÆÂπÖ„ÅåÈÅï„ÅÜ„Åì„Å®„Åå„ÅÇ„Çã„ÄÇÈÅï„ÅÜÂ†¥Âêà„ÅØÁã¨Ëá™„Å´ÊèèÁîª
 	CTypeSupport cZenSpace(pcView, COLORIDX_ZENSPACE);
 
 	int dx[1];
-	dx[0] = pcView->GetTextMetrics().CalcTextWidth3(L"Å@", 1);
+	dx[0] = pcView->GetTextMetrics().CalcTextWidth3(L"„ÄÄ", 1);
 
 	RECT rc;
-	//ÉNÉäÉbÉsÉìÉOãÈå`ÇåvéZÅBâÊñ äOÇ»ÇÁï`âÊÇµÇ»Ç¢
+	//„ÇØ„É™„ÉÉ„Éî„É≥„Ç∞Áü©ÂΩ¢„ÇíË®àÁÆó„ÄÇÁîªÈù¢Â§ñ„Å™„ÇâÊèèÁîª„Åó„Å™„ÅÑ
 	if(pcView->GetTextArea().GenerateClipRect(&rc, *pDispPos, CHabaXInt(dx[0])))
 	{
-		int u25a1Dx = pcView->GetTextMetrics().CalcTextWidth3(L"Å†", 1);
+		int u25a1Dx = pcView->GetTextMetrics().CalcTextWidth3(L"‚ñ°", 1);
 		bool bDrawMySelf = dx[0] != u25a1Dx;
-		const wchar_t* pZenSp = (bDrawMySelf ? L"Å@" : L"Å†");
+		const wchar_t* pZenSp = (bDrawMySelf ? L"„ÄÄ" : L"‚ñ°");
 		int fontNo = WCODE::GetFontNo(*pZenSp);
 		if( fontNo ){
 			SFONT sFont;
@@ -47,7 +47,7 @@ void CFigure_ZenSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pc
 			gr.PushMyFont(sFont);
 		}
 		int nHeightMargin = pcView->GetTextMetrics().GetCharHeightMarginByFontNo(fontNo);
-		//ï`âÊ
+		//ÊèèÁîª
 		ExtTextOutW_AnyBuild(
 			gr,
 			pDispPos->GetDrawPos().x,
@@ -62,29 +62,29 @@ void CFigure_ZenSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pc
 			gr.PopMyFont();
 		}
 		if( bDrawMySelf ){
-			gr.PushClipping(rc); // FIXME: ê≥ämÇ…ÇÕCombineRgn RGN_AND Ç™ïKóv
+			gr.PushClipping(rc); // FIXME: Ê≠£Á¢∫„Å´„ÅØCombineRgn RGN_AND „ÅåÂøÖË¶Å
 			
-			// ëSäpSPÇÃëÂÇ´Ç≥éwíË
+			// ÂÖ®ËßíSP„ÅÆÂ§ß„Åç„ÅïÊåáÂÆö
 			CMyRect rcZenSp;
-			// íçÅFÉxÅ[ÉXÉâÉCÉìñ≥éã
+			// Ê≥®Ôºö„Éô„Éº„Çπ„É©„Ç§„É≥ÁÑ°Ë¶ñ
 			rcZenSp.SetPos(pDispPos->GetDrawPos().x, pDispPos->GetDrawPos().y);
 			rcZenSp.SetSize(dx[0]- pcView->m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_nColumnSpace,
 				pcView->GetTextMetrics().GetHankakuHeight());
 
-			// ï`âÊ
-			// ï∂éöêFÇ‚ëæéöÇ©Ç«Ç§Ç©Çåªç›ÇÃ DC Ç©ÇÁí≤Ç◊ÇÈ	// 2009.05.29 ryoji 
-			// ÅiåüçıÉ}ÉbÉ`ìôÇÃèÛãµÇ…è_ìÓÇ…ëŒâûÇ∑ÇÈÇΩÇﬂÅAÇ±Ç±ÇÕãLçÜÇÃêFéwíËÇ…ÇÕåàÇﬂë≈ÇøÇµÇ»Ç¢Åj
+			// ÊèèÁîª
+			// ÊñáÂ≠óËâ≤„ÇÑÂ§™Â≠ó„Åã„Å©„ÅÜ„Åã„ÇíÁèæÂú®„ÅÆ DC „Åã„ÇâË™ø„Åπ„Çã	// 2009.05.29 ryoji 
+			// ÔºàÊ§úÁ¥¢„Éû„ÉÉ„ÉÅÁ≠â„ÅÆÁä∂Ê≥Å„Å´ÊüîËªü„Å´ÂØæÂøú„Åô„Çã„Åü„ÇÅ„ÄÅ„Åì„Åì„ÅØË®òÂè∑„ÅÆËâ≤ÊåáÂÆö„Å´„ÅØÊ±∫„ÇÅÊâì„Å°„Åó„Å™„ÅÑÔºâ
 			Draw_ZenSpace(gr, rcZenSp);
 
-			// ÉäÅ[ÉWÉáÉìîjä¸
+			// „É™„Éº„Ç∏„Éß„É≥Á†¥Ê£Ñ
 			gr.PopClipping();
 			
-			// To Here 2003.08.17 ryoji â¸çsï∂éöÇ™åáÇØÇ»Ç¢ÇÊÇ§Ç…
+			// To Here 2003.08.17 ryoji ÊîπË°åÊñáÂ≠ó„ÅåÊ¨†„Åë„Å™„ÅÑ„Çà„ÅÜ„Å´
 		}
 		
 	}
 
-	//à íuêiÇﬂÇÈ
+	//‰ΩçÁΩÆÈÄ≤„ÇÅ„Çã
 	pDispPos->ForwardDrawCol(CLayoutXInt(dx[0]));
 }
 
@@ -93,7 +93,7 @@ void Draw_ZenSpace( CGraphics& gr, const CMyRect& rc )
 	TEXTMETRIC tm;
 	tm.tmAscent = 0;
 	::GetTextMetrics(gr, &tm);
-	// ê≥ï˚å`Ç…Ç∑ÇÈ
+	// Ê≠£ÊñπÂΩ¢„Å´„Åô„Çã
 	CMyRect rc2;
 	int minWidth = std::max<int>(1, std::min<int>(tm.tmAscent, std::min<int>(rc.Height(), rc.Width())) - 2);
 	minWidth -= (minWidth + 5) / 10;

--- a/sakura_core/view/figures/CFigure_ZenSpace.h
+++ b/sakura_core/view/figures/CFigure_ZenSpace.h
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
 	Copyright (C) 2008, kobake
 
 	This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@
 
 #include "view/figures/CFigureStrategy.h"
 
-//! ‘SŠpƒXƒy[ƒX•`‰æ
+//! å…¨è§’ã‚¹ãƒšãƒ¼ã‚¹æç”»
 class CFigure_ZenSpace : public CFigureSpace{
 public:
 	//traits


### PR DESCRIPTION
該当フォルダ内の文字コードをすべて UTF-8 (BOM付) に変換しました。

```
cd sakura_core/view
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h

cd sakura_core/view/colors
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h

cd sakura_core/view/figures
nkf --overwrite --oc=UTF-8-BOM *.cpp
nkf --overwrite --oc=UTF-8-BOM *.h
```

## 確認方法
WinMerge で変更前と変更後を比較すると、文字コード以外の変更が無いことが確認できます。

## 関連 Issues
ソースコードのUnicode化 #112

## 特記事項
これまでの経緯から、マルチバイトを含む文字列リテラルについてもファイルのエンコーディングを変更したところで悪影響が起こらないように感じています。

今回の変更ではマルチバイトを含む文字列リテラルを含むファイルも含めてファイルエンコーディングの変更を行っています。

主に動作影響について対応前後で挙動に変化がないことのご確認をいただけると助かります。
