### PR TITLE
変換先バッファ確保の new で例外処理を行わないように std::nothrow 指定追加

### DIFF
--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -120,12 +120,7 @@ EConvertResult CCodePage::CPToUnicode(const CMemory& cSrc, CNativeW* pDst, int c
 	UINT codepage = CodePageExToMSCP(codepageEx);
 	int nDstCch = MultiByteToWideChar2(codepage, nToWideCharFlags, pSrc, nSrcLen, NULL, 0);
 	// 変換先バッファサイズとその確保
-	wchar_t* pDstBuffer;
-	try{
-		pDstBuffer = new wchar_t[nDstCch];
-	}catch( ... ){
-		pDstBuffer = NULL;
-	}
+	wchar_t* pDstBuffer = new (std::nothrow) wchar_t[nDstCch];
 	if( pDstBuffer == NULL ){
 		return RESULT_FAILURE;
 	}
@@ -209,12 +204,7 @@ EConvertResult CCodePage::UnicodeToCP(const CNativeW& cSrc, CMemory* pDst, int c
 #endif
 		return RESULT_FAILURE;
 	}
-	char* pDstBuffer;
-	try{
-		pDstBuffer = new char[nBuffSize];
-	}catch( ... ){
-		pDstBuffer = NULL;
-	}
+	char* pDstBuffer = new (std::nothrow) char[nBuffSize];
 	if( pDstBuffer == NULL ){
 		return RESULT_FAILURE;
 	}

--- a/sakura_core/charset/CEuc.cpp
+++ b/sakura_core/charset/CEuc.cpp
@@ -83,12 +83,7 @@ EConvertResult CEuc::EUCToUnicode(const CMemory& cSrc, CNativeW* pDstMem)
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
 
 	// 変換先バッファサイズとその確保
-	wchar_t* pDst;
-	try{
-		pDst = new wchar_t[nSrcLen];
-	}catch( ... ){
-		pDst = NULL;
-	}
+	wchar_t* pDst = new (std::nothrow) wchar_t[nSrcLen];
 	if( pDst == NULL ){
 		return RESULT_FAILURE;
 	}
@@ -178,12 +173,7 @@ EConvertResult CEuc::UnicodeToEUC(const CNativeW& cSrc, CMemory* pDstMem)
 	int nSrcLen = cSrc.GetStringLength();
 
 	// 必要なバッファサイズを調べてメモリを確保
-	char* pDst;
-	try{
-		pDst = new char[nSrcLen * 2];
-	}catch( ... ){
-		pDst = NULL;
-	}
+	char* pDst = new (std::nothrow) char[nSrcLen * 2];
 	if( pDst == NULL ){
 		return RESULT_FAILURE;
 	}

--- a/sakura_core/charset/CJis.cpp
+++ b/sakura_core/charset/CJis.cpp
@@ -270,13 +270,8 @@ EConvertResult CJis::JISToUnicode(const CMemory& cSrc, CNativeW* pDstMem, bool b
 
 
 	// 変換先バッファを取得
-	wchar_t* pDst;
-	try{
-		pDst = new wchar_t[nsrclen * 3 + 1];
-		if( pDst == NULL ){
-			return RESULT_FAILURE;
-		}
-	}catch( ... ){
+	wchar_t* pDst = new (std::nothrow) wchar_t[nsrclen * 3 + 1];
+	if( pDst == NULL ){
 		return RESULT_FAILURE;
 	}
 
@@ -466,12 +461,7 @@ EConvertResult CJis::UnicodeToJIS(const CNativeW& cSrc, CMemory* pDstMem)
 	int nSrcLen = cSrc.GetStringLength();
 
 	// 必要なバッファ容量を確認してバッファを確保
-	char* pDst;
-	try{
-		pDst = new char[nSrcLen * 8];
-	}catch( ... ){
-		pDst = NULL;
-	}
+	char* pDst = new (std::nothrow) char[nSrcLen * 8];
 	if( pDst == NULL ){
 		return RESULT_FAILURE;
 	}

--- a/sakura_core/charset/CLatin1.cpp
+++ b/sakura_core/charset/CLatin1.cpp
@@ -110,12 +110,7 @@ EConvertResult CLatin1::Latin1ToUnicode( const CMemory& cSrc, CNativeW* pDstMem 
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
 
 	// 変換先バッファサイズを設定してメモリ領域確保
-	wchar_t* pDst;
-	try{
-		pDst = new wchar_t[nSrcLen];
-	}catch( ... ){
-		pDst = NULL;
-	}
+	wchar_t* pDst = new (std::nothrow) wchar_t[nSrcLen];
 	if( pDst == NULL ){
 		return RESULT_FAILURE;
 	}
@@ -217,12 +212,7 @@ EConvertResult CLatin1::UnicodeToLatin1( const CNativeW& cSrc, CMemory* pDstMem 
 	int nSrcLen = cSrc.GetStringLength();
 
 	// 変換先バッファサイズを設定してバッファを確保
-	char* pDst;
-	try{
-		pDst = new char[ nSrcLen * 2 ];
-	}catch( ... ){
-		pDst = NULL;
-	}
+	char* pDst = new (std::nothrow) char[ nSrcLen * 2 ];
 	if( pDst == NULL ){
 		return RESULT_FAILURE;
 	}

--- a/sakura_core/charset/CShiftJis.cpp
+++ b/sakura_core/charset/CShiftJis.cpp
@@ -7,6 +7,7 @@
 #include "env/CShareData.h"
 #include "env/DLLSHAREDATA.h"
 
+#include <new>
 
 //! 指定した位置の文字が何バイト文字かを返す
 /*!
@@ -119,12 +120,7 @@ EConvertResult CShiftJis::SJISToUnicode( const CMemory& cSrc, CNativeW* pDstMem 
 	if( &cSrc == pDstMem->_GetMemory() )
 	{
 		// 変換先バッファサイズを設定してメモリ領域確保
-		wchar_t* pDst;
-		try{
-			pDst = new wchar_t[nSrcLen];
-		}catch( ... ){
-			pDst = NULL;
-		}
+		wchar_t* pDst = new (std::nothrow) wchar_t[nSrcLen];
 		if( pDst == NULL ){
 			return RESULT_FAILURE;
 		}
@@ -239,12 +235,7 @@ EConvertResult CShiftJis::UnicodeToSJIS( const CNativeW& cSrc, CMemory* pDstMem 
 	int nSrcLen = pMem->GetRawLength() / sizeof(wchar_t);
 
 	// 変換先バッファサイズを設定してバッファを確保
-	char* pDst;
-	try{
-		pDst = new char[ nSrcLen * 2 ];
-	}catch( ... ){
-		pDst = NULL;
-	}
+	char* pDst = new (std::nothrow) char[ nSrcLen * 2 ];
 	if( pDst == NULL ){
 		return RESULT_FAILURE;
 	}

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -99,12 +99,7 @@ EConvertResult CUtf8::_UTF8ToUnicode( const CMemory& cSrc, CNativeW* pDstMem, bo
 	if( &cSrc == pDstMem->_GetMemory() )
 	{
 		// 必要なバッファサイズを調べて確保する
-		wchar_t* pDst;
-		try{
-			pDst = new wchar_t[nSrcLen];
-		}catch( ... ){
-			pDst = NULL;
-		}
+		wchar_t* pDst = new (std::nothrow) wchar_t[nSrcLen];
 		if( pDst == NULL ){
 			return RESULT_FAILURE;
 		}
@@ -208,12 +203,7 @@ EConvertResult CUtf8::_UnicodeToUTF8( const CNativeW& cSrc, CMemory* pDstMem, bo
 
 
 	// 必要なバッファサイズを調べてメモリを確保
-	char* pDst;
-	try{
-		pDst = new char[nSrcLen * 3];
-	}catch( ... ){
-		pDst = NULL;
-	}
+	char* pDst = new (std::nothrow) char[nSrcLen * 3];
 	if( pDst == NULL ){
 		return RESULT_FAILURE;
 	}


### PR DESCRIPTION
new で例外が起きたら catch で捕まえてポインタに NULL を設定する記述を置き換えました。

new している箇所は他にもいっぱいありますが、それらについてどうしてるのかは良く分かっていません。