### PR TITLE
auto キーワードを使って iterator 変数の宣言を簡潔にする

### DIFF
--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -178,7 +178,7 @@ int CHokanMgr::Search(
 			}
 		}
 
-		for( CPlug::Array::iterator it = plugs.begin(); it != plugs.end(); ++it ){
+		for( auto it = plugs.begin(); it != plugs.end(); ++it ){
 			//インタフェースオブジェクト準備
 			CWSHIfObj::List params;
 			std::wstring curWord = pszCurWord;

--- a/sakura_core/CProfile.cpp
+++ b/sakura_core/CProfile.cpp
@@ -225,15 +225,10 @@ bool CProfile::WriteProfile(
 		vecLine.push_back( LTEXT(";") + wstring( pszComment ) );		// //->;	2008/5/24 Uchi
 		vecLine.push_back( LTEXT("") );
 	}
-	std::vector< Section >::iterator iter;
-	std::vector< Section >::iterator iterEnd = m_ProfileData.end();
-	MAP_STR_STR::iterator mapiter;
-	MAP_STR_STR::iterator mapiterEnd;
-	for( iter = m_ProfileData.begin(); iter != iterEnd; iter++ ) {
+	for(auto iter = m_ProfileData.begin(); iter != m_ProfileData.end(); iter++ ) {
 		//セクション名を書き込む
 		vecLine.push_back( LTEXT("[") + iter->strSectionName + LTEXT("]") );
-		mapiterEnd = iter->mapEntries.end();
-		for( mapiter = iter->mapEntries.begin(); mapiter != mapiterEnd; mapiter++ ) {
+		for(auto mapiter = iter->mapEntries.cbegin(); mapiter != iter->mapEntries.end(); mapiter++ ) {
 			//エントリを書き込む
 			vecLine.push_back( mapiter->first + LTEXT("=") + mapiter->second );
 		}
@@ -329,12 +324,9 @@ bool CProfile::GetProfileDataImp(
 	wstring&		strEntryValue	//!< [out] エントリ値
 )
 {
-	std::vector< Section >::iterator iter;
-	std::vector< Section >::iterator iterEnd = m_ProfileData.end();
-	MAP_STR_STR::iterator mapiter;
-	for( iter = m_ProfileData.begin(); iter != iterEnd; iter++ ) {
+	for(auto iter = m_ProfileData.begin(); iter != m_ProfileData.end(); iter++ ) {
 		if( iter->strSectionName == strSectionName ) {
-			mapiter = iter->mapEntries.find( strEntryKey );
+			auto mapiter = iter->mapEntries.find( strEntryKey );
 			if( iter->mapEntries.end() != mapiter ) {
 				strEntryValue = mapiter->second;
 				return true;
@@ -357,14 +349,11 @@ bool CProfile::SetProfileDataImp(
 	const wstring&	strEntryValue	//!< [in] エントリ値
 )
 {
-	std::vector< Section >::iterator iter;
-	std::vector< Section >::iterator iterEnd = m_ProfileData.end();
-	MAP_STR_STR::iterator mapiter;
-	MAP_STR_STR::iterator mapiterEnd;
-	for( iter = m_ProfileData.begin(); iter != iterEnd; iter++ ) {
+	auto iter = m_ProfileData.begin();
+	for(; iter != m_ProfileData.end(); iter++ ) {
 		if( iter->strSectionName == strSectionName ) {
 			//既存のセクションの場合
-			mapiter = iter->mapEntries.find( strEntryKey );
+			auto mapiter = iter->mapEntries.find( strEntryKey );
 			if( iter->mapEntries.end() != mapiter ) {
 				//既存のエントリの場合は値を上書き
 				mapiter->second = strEntryValue;
@@ -378,7 +367,7 @@ bool CProfile::SetProfileDataImp(
 		}
 	}
 	//既存のセクションではない場合，セクション及びエントリを追加
-	if( iterEnd == iter ) {
+	if( iter != m_ProfileData.end() ) {
 		Section Buffer;
 		Buffer.strSectionName = strSectionName;
 		Buffer.mapEntries.insert( PAIR_STR_STR( strEntryKey, strEntryValue ) );
@@ -392,16 +381,11 @@ bool CProfile::SetProfileDataImp(
 void CProfile::DUMP( void )
 {
 #ifdef _DEBUG
-	std::vector< Section >::iterator iter;
-	std::vector< Section >::iterator iterEnd = m_ProfileData.end();
 	//	2006.02.20 ryoji: MAP_STR_STR_ITER削除時の修正漏れによるコンパイルエラー修正
-	MAP_STR_STR::iterator mapiter;
-	MAP_STR_STR::iterator mapiterEnd;
 	MYTRACE( _T("\n\nCProfile::DUMP()======================") );
-	for( iter = m_ProfileData.begin(); iter != iterEnd; iter++ ) {
+	for(auto iter = m_ProfileData.begin(); iter != m_ProfileData.end(); iter++ ) {
 		MYTRACE( _T("\n■strSectionName=%ls"), iter->strSectionName.c_str() );
-		mapiterEnd = iter->mapEntries.end();
-		for( mapiter = iter->mapEntries.begin(); mapiter != mapiterEnd; mapiter++ ) {
+		for(auto mapiter = iter->mapEntries.begin(); mapiter != iter->mapEntries.end(); mapiter++ ) {
 			MYTRACE( _T("\"%ls\" = \"%ls\"\n"), mapiter->first.c_str(), mapiter->second.c_str() );
 		}
 	}

--- a/sakura_core/CSelectLang.cpp
+++ b/sakura_core/CSelectLang.cpp
@@ -31,7 +31,7 @@ CSelectLang::PSSelLangInfoList CSelectLang::m_psLangInfoList;
 */
 CSelectLang::~CSelectLang( void )
 {
-	for (PSSelLangInfoList::iterator it = m_psLangInfoList.begin(); it != m_psLangInfoList.end(); it++) {
+	for (auto it = m_psLangInfoList.begin(); it != m_psLangInfoList.end(); it++) {
 		if( (*it)->hInstance ){
 			FreeLibrary( (*it)->hInstance );
 			(*it)->hInstance = NULL;

--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -438,7 +438,7 @@ CCodePage::CodePageList& CCodePage::GetCodePageList()
 #endif
 	pfn_GetCPInfoExT_t pfn_GetCPInfoExT = (pfn_GetCPInfoExT_t)::GetProcAddress(hDLLkernel, strFunc_GetCPInfoEx);
 	CPINFOEX cpInfo;
-	for( CodePageList::iterator it = result.begin(); it != result.end(); ++it ){
+	for( auto it = result.begin(); it != result.end(); ++it ){
 		cpInfo.CodePageName[0] = _T('\0');
 		if( pfn_GetCPInfoExT && pfn_GetCPInfoExT(it->first, 0, &cpInfo) ){
 			it->second = to_wchar(cpInfo.CodePageName);
@@ -482,7 +482,7 @@ int CCodePage::AddComboCodePages(HWND hwnd, HWND combo, int nSelCode)
 	}
 	Combo_SetItemData( combo, nIdx, CODE_CPOEM );
 	CCodePage::CodePageList& cpList = CCodePage::GetCodePageList();
-	for( CCodePage::CodePageList::iterator it = cpList.begin(); it != cpList.end(); ++it ){
+	for( auto it = cpList.begin(); it != cpList.end(); ++it ){
 		nIdx = Combo_AddString(combo, it->second.c_str());
 		Combo_SetItemData(combo, nIdx, it->first);
 		if( nSelCode == it->first ){

--- a/sakura_core/dlg/CDlgPluginOption.cpp
+++ b/sakura_core/dlg/CDlgPluginOption.cpp
@@ -176,7 +176,7 @@ void CDlgPluginOption::SetData( void )
 			selects = cOpt->GetSelects();
 
 			_tcscpy( buf, _T("") );
-			for (std::vector<wstring>::iterator it = selects.begin(); it != selects.end(); it++) {
+			for (auto it = selects.begin(); it != selects.end(); it++) {
 				SepSelect(*it, &sView, &sTrg);
 				if (sValue == sTrg) {
 					auto_snprintf_s( buf, _countof(buf), _T("%ls"), sView.c_str());
@@ -261,7 +261,7 @@ int CDlgPluginOption::GetData( void )
 			selects = cOpt->GetSelects();
 			wstring sWbuf = to_wchar(buf);
 
-			for (std::vector<wstring>::iterator it = selects.begin(); it != selects.end(); it++) {
+			for (auto it = selects.begin(); it != selects.end(); it++) {
 				SepSelect(*it, &sView, &sTrg);
 				if (sView == sWbuf) {
 					auto_sprintf( buf, _T("%ls"), sTrg.c_str());
@@ -611,7 +611,7 @@ void CDlgPluginOption::SetToEdit( int iLine )
 			wstring	sWbuf = to_wchar(buf);
 			nSelIdx = -1;		// ‘I‘ð
 			i = 0;
-			for (std::vector<wstring>::iterator it = selects.begin(); it != selects.end(); it++) {
+			for (auto it = selects.begin(); it != selects.end(); it++) {
 				SepSelect(*it, &sView, &sValue);
 				nItemIdx = Combo_AddString( hwndCombo, sView.c_str() );
 				if (sView == sWbuf) {

--- a/sakura_core/macro/CCookieManager.cpp
+++ b/sakura_core/macro/CCookieManager.cpp
@@ -37,7 +37,7 @@ SysString CCookieManager::GetCookie(LPCWSTR scope, LPCWSTR cookieName) const
 		return SysString(L"", 0);
 	}
 	wstring key = cookieName;
-	const auto& keyVal = cookies->find(key);
+	auto keyVal = cookies->find(key);
 	if( keyVal == cookies->end() ){
 		return SysString(L"", 0);
 	}
@@ -95,7 +95,7 @@ SysString CCookieManager::GetCookieNames(LPCWSTR scope) const
 	if( cookies == NULL ){
 		return SysString(L"", 0);
 	}
-	auto& it = cookies->begin();
+	auto it = cookies->begin();
 	wstring keyNames;
 	if( it != cookies->end() ){
 		keyNames += it->first;

--- a/sakura_core/macro/CCookieManager.cpp
+++ b/sakura_core/macro/CCookieManager.cpp
@@ -37,7 +37,7 @@ SysString CCookieManager::GetCookie(LPCWSTR scope, LPCWSTR cookieName) const
 		return SysString(L"", 0);
 	}
 	wstring key = cookieName;
-	std::map<wstring, wstring>::const_iterator keyVal = cookies->find(key);
+	const auto& keyVal = cookies->find(key);
 	if( keyVal == cookies->end() ){
 		return SysString(L"", 0);
 	}
@@ -51,7 +51,7 @@ SysString CCookieManager::GetCookieDefault(LPCWSTR scope, LPCWSTR cookieName, LP
 		return SysString(L"", 0);
 	}
 	wstring key = cookieName;
-	std::map<wstring, wstring>::iterator keyVal = cookies->find(key);
+	const auto& keyVal = cookies->find(key);
 	if( keyVal == cookies->end() ){
 		return SysString(defVal, len);
 	}
@@ -81,7 +81,7 @@ int CCookieManager::DeleteCookie(LPCWSTR scope, LPCWSTR cookieName)
 		return 2;
 	}
 	wstring key = cookieName;
-	std::map<wstring, wstring>::iterator keyVal = cookies->find(key);
+	const auto& keyVal = cookies->find(key);
 	if( keyVal == cookies->end() ){
 		return 5;
 	}
@@ -91,11 +91,11 @@ int CCookieManager::DeleteCookie(LPCWSTR scope, LPCWSTR cookieName)
 
 SysString CCookieManager::GetCookieNames(LPCWSTR scope) const
 {
-	std::map<wstring, wstring>* cookies = SelectCookieType(scope);
+	const std::map<wstring, wstring>* cookies = SelectCookieType(scope);
 	if( cookies == NULL ){
 		return SysString(L"", 0);
 	}
-	std::map<wstring, wstring>::iterator it = cookies->begin();
+	auto& it = cookies->begin();
 	wstring keyNames;
 	if( it != cookies->end() ){
 		keyNames += it->first;

--- a/sakura_core/macro/CMacroFactory.cpp
+++ b/sakura_core/macro/CMacroFactory.cpp
@@ -89,14 +89,12 @@ bool CMacroFactory::RegisterCreator( Creator f )
 bool CMacroFactory::Unregister( Creator f )
 {
 	//	Creator Listからの削除
-	MacroEngineRep::iterator c_it = m_mMacroCreators.begin();
+	auto& c_it = m_mMacroCreators.begin();
 	while( c_it != m_mMacroCreators.end() ){
 		if( *c_it == f ){
-			MacroEngineRep::iterator tmp_it;
-
 			//	いきなり削除するとiteratorが無効になるので，
 			//	iteratorを1つ進めてから現在位置を削除する．
-			tmp_it = c_it++;
+			auto tmp_it = c_it++;
 			m_mMacroCreators.erase( tmp_it );
 			//	重複登録されている場合を考慮して，
 			//	1つ見つかっても最後までチェックする
@@ -123,7 +121,7 @@ CMacroManagerBase* CMacroFactory::Create(const TCHAR* ext)
 	std::tstring key = Ext2Key( ext );
 
 	//	Creatorを順に試す
-	for( MacroEngineRep::iterator c_it = m_mMacroCreators.begin();
+	for( auto c_it = m_mMacroCreators.begin();
 		c_it != m_mMacroCreators.end(); ++ c_it ){
 		CMacroManagerBase* pobj = (*c_it)(key.c_str());
 		if( pobj != NULL ){

--- a/sakura_core/plugin/CJackManager.cpp
+++ b/sakura_core/plugin/CJackManager.cpp
@@ -183,7 +183,7 @@ bool CJackManager::GetUsablePlug(
 	CPlug::Array*	plugs		//!< [out] 利用可能プラグのリスト
 )
 {
-	for( CPlug::Array::iterator it = m_Jacks[jack].plugs.begin(); it != m_Jacks[jack].plugs.end(); it++ ){
+	for( auto it = m_Jacks[jack].plugs.begin(); it != m_Jacks[jack].plugs.end(); it++ ){
 		if( plugId == 0 || plugId == (*it)->GetFunctionCode() ){
 			plugs->push_back( *it );
 		}

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -1251,7 +1251,6 @@ bool CPropMainMenu::Check_MainMenu_Sub(
 	TV_ITEM			tvi;							// 取得用
 	SMainMenuWork*	pFuncWk;						// 機能(work)
 	std::map< WCHAR, HTREEITEM >	mKey;			// 重複エラー検出用
-	std::map< WCHAR, HTREEITEM >::iterator itKey;	// 同上
 
 	if (nLevel == 0) {
 		bOptionOk = false;
@@ -1309,7 +1308,7 @@ bool CPropMainMenu::Check_MainMenu_Sub(
 			}
 		}
 		else {
-			itKey = mKey.find( pFuncWk->m_sKey[0] );
+			auto itKey = mKey.find( pFuncWk->m_sKey[0] );
 			if (itKey == mKey.end()) {
 				mKey[pFuncWk->m_sKey[0]] = s;
 


### PR DESCRIPTION
C++11 の auto キーワードを使用して変数の型宣言を省きました。
カウンタ変数のスコープを狭めたりもしています。