### PR TITLE
アセンブラ出力を行い、artifacts に含める

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -106,6 +106,7 @@
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -145,6 +146,7 @@
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -181,6 +183,7 @@
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -217,6 +220,7 @@
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -105,6 +105,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,6 +144,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -178,6 +180,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -213,6 +216,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -118,8 +118,10 @@ set WORKDIR=%BASENAME%
 set WORKDIR_LOG=%WORKDIR%\Log
 set WORKDIR_EXE=%WORKDIR%\EXE
 set WORKDIR_INST=%WORKDIR%\Installer
+set WORKDIR_ASM=%BASENAME%-Asm
 set OUTFILE=%BASENAME%.zip
 set OUTFILE_LOG=%BASENAME%-Log.zip
+set OUTFILE_ASM=%BASENAME%-Asm.zip
 
 @rem cleanup for local testing
 if exist "%OUTFILE%" (
@@ -128,8 +130,14 @@ if exist "%OUTFILE%" (
 if exist "%OUTFILE_LOG%" (
 	del %OUTFILE_LOG%
 )
+if exist "%OUTFILE_ASM%" (
+	del %OUTFILE_ASM%
+)
 if exist "%WORKDIR%" (
 	rmdir /s /q %WORKDIR%
+)
+if exist "%WORKDIR_ASM%" (
+	rmdir /s /q %WORKDIR_ASM%
 )
 
 mkdir %WORKDIR%
@@ -170,6 +178,16 @@ if exist "%HASHFILE%" (
 7z a %OUTFILE_LOG%  -r %WORKDIR_LOG%
 7z l %OUTFILE_LOG%
 
+@echo start zip asm
+mkdir %WORKDIR_ASM%
+copy sakura\%platform%\%configuration%\*.asm %WORKDIR_ASM%\
+7z a %OUTFILE_ASM%  -r %WORKDIR_ASM%
+7z l %OUTFILE_ASM%
+@echo end   zip asm
+
 if exist "%WORKDIR%" (
 	rmdir /s /q %WORKDIR%
+)
+if exist "%WORKDIR_ASM%" (
+	rmdir /s /q %WORKDIR_ASM%
 )


### PR DESCRIPTION
#286: アセンブラ出力を行い、artifacts に含める

コンパイラの設定でオブジェクトファイルの生成と同時にアセンブラ出力も行う。

| 構成 | サイズ | 圧縮にかかる時間 |
----|----|---- 
| x64 Debug     | 14MB | 12 秒 |
| Win32 Debug   | 13MB |  8 秒 |
| x64 Release   | 6MB  | 4 秒 |
| Win32 Release | 5MB  | 4 秒 |

