### PR TITLE
エントリをProfileへ書き込む処理（CProfile::SetProfileDataImp）に入れてしまった不具合の修正

### DIFF
--- a/sakura_core/CProfile.cpp
+++ b/sakura_core/CProfile.cpp
@@ -367,7 +367,7 @@ bool CProfile::SetProfileDataImp(
 		}
 	}
 	//既存のセクションではない場合，セクション及びエントリを追加
-	if( iter != m_ProfileData.end() ) {
+	if( iter == m_ProfileData.end() ) {
 		Section Buffer;
 		Buffer.strSectionName = strSectionName;
 		Buffer.mapEntries.insert( PAIR_STR_STR( strEntryKey, strEntryValue ) );


### PR DESCRIPTION
Issue #293 で報告した問題で、原因は #288 で自分が入れた変更内容にミス（判定条件を逆にしてしまった）が有りました。