### PR TITLE
ログの警告の解析結果の CSV に blobURL を追加

### DIFF
--- a/parse-buildlog.py
+++ b/parse-buildlog.py
@@ -27,6 +27,7 @@ csvKeys = [
 	'path',
 	'lineNumber',
 	'message',
+	'blobURL',
 ]
 
 excelKeys = [


### PR DESCRIPTION
ログの警告の解析結果の CSV に blobURL を追加

xlsx ファイルのリンクはクリックできて便利だが、
blobURL をコピーするのは不便なので CSV にリンクを追加する
