### PR TITLE
static で定義している変数を通常のローカル変数に変える

### DIFF
--- a/sakura_core/debug/Debug2.cpp
+++ b/sakura_core/debug/Debug2.cpp
@@ -7,7 +7,7 @@
 //!デバッグメッセージ出力
 void debug_output(const char* str, ...)
 {
-	static char buf[_MAX_PATH+150];
+	char buf[_MAX_PATH+150];
 	va_list mark;
 	va_start(mark,str);
 	// FILE名, LINE 式 分必要


### PR DESCRIPTION
デバッグコードで static で定義している変数を通常のローカル変数に変える
#299 

ただ現状でも実害はない