### PR TITLE
sakura_lang_en_US 配下のヘッダファイルを UTF-8(BOM付き) に変換

### DIFF
--- a/sakura_lang_en_US/sakura_lang.h
+++ b/sakura_lang_en_US/sakura_lang.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 	Copyright (C) 2013, syat
 
 	This software is provided 'as-is', without any express or implied


### PR DESCRIPTION
sakura-editor 配下のソースコードのほとんどがエンコーディングを UTF-8 に変換完了しました。
一部だけエンコーディングが食い違うのにも違和感があるため、残りの sakura_lang_en_US 配下のソースコードも UTF-8 に変換しておきます。

```
cd sakura_lang_en_US
nkf --overwrite --oc=UTF-8-BOM *.h
```

この PR をもって sakura-editor 配下の全 *cpp, *.h のエンコーディングは UTF-8 (BOM付き) になります。

## 注記
今回の変更対象である sakura_lang.h はもともと ASCII 文字しか含まれていないため、さほど意味のある変更には見えないかもしれませんが、BOM を入れておくことにより今後のヘッダ編集で非 ASCII 文字が混ざったときにも誤って UTF-8 以外で保存されるようなミスが防げます。
