### PR TITLE
rc ファイルも .editorconfig の対象にする

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 ﻿root = true
 
-[*.{cpp,h,hh,hsrc}]
+[*.{cpp,h,hh,hsrc,rc}]
 # インデントスタイル：タブ文字で4スペース幅
 indent_style = tab
 indent_size = 4


### PR DESCRIPTION
https://github.com/sakura-editor/sakura/pull/315#discussion_r208724373
により rc ファイルも .editorconfig の対象にする

Firefox ではタブサイズが 4 で表示されたが、
Edge ではタブサイズに変化はなかった。

https://github.com/m-tmatma/sakura/blob/feature/editorconfig-rc/sakura_lang_en_US/sakura_lang_rc.rc
