### PR TITLE
インストーラの作成時の一時フォルダを削除しない

### DIFF
--- a/build-installer.bat
+++ b/build-installer.bat
@@ -39,6 +39,3 @@ copy %platform%\%configuration%\*.dll            %INSTALLER_WORK%\
 
 set SAKURA_ISS=installer\sakura-%platform%.iss
 "C:\Program Files (x86)\Inno Setup 5\ISCC.exe" %SAKURA_ISS% || (echo error && exit /b 1)
-
-if exist "%INSTALLER_RESOURCES%" rmdir /s /q "%INSTALLER_RESOURCES%"
-if exist "%INSTALLER_WORK%"      rmdir /s /q "%INSTALLER_WORK%"


### PR DESCRIPTION
インストーラの作成時の一時フォルダを削除しない

インストーラの作成に使用する一時フォルダを削除しているが、
正しく動作しているか確認するときに確認しにくいので
最後に削除するのをやめる。

ビルド実行前に削除しているので問題ないはず。

