### PR TITLE
#329 によるデグレを修正 (bron412.zip の bregonig.dll が使われなくなる)

### DIFF
--- a/build-installer.bat
+++ b/build-installer.bat
@@ -34,8 +34,8 @@ copy help\sakura\sakura.chm                      %INSTALLER_WORK%\
 copy help\plugin\plugin.chm                      %INSTALLER_WORK%\
 copy help\macro\macro.chm                        %INSTALLER_WORK%\
 
-copy %platform%\%configuration%\*.exe            %INSTALLER_WORK%\
-copy %platform%\%configuration%\*.dll            %INSTALLER_WORK%\
+copy %platform%\%configuration%\*.exe                 %INSTALLER_WORK%\
+copy %platform%\%configuration%\sakura_lang_en_US.dll %INSTALLER_WORK%\
 
 set SAKURA_ISS=installer\sakura-%platform%.iss
 "C:\Program Files (x86)\Inno Setup 5\ISCC.exe" %SAKURA_ISS% || (echo error && exit /b 1)


### PR DESCRIPTION
bregonig.dll を sakura.exe と同じ場所に自動配置することにより 38行目のコピーで bregonig.dll が
bron412.zip のものではなく、リポジトリに登録しているものが直接組み込まれるようになってしまう。

このため 38行目のコピーではワイルドカードでコピーせずに、ビルドした DLL を明示的にファイル名指定でコピーする。

※ #331 をこの PR より 先に適用すると確認しやすいと思います。

