### PR TITLE
インストーラの生成先のフォルダにプラットフォーム名を含める

### DIFF
--- a/build-installer.bat
+++ b/build-installer.bat
@@ -2,7 +2,7 @@ set platform=%1
 set configuration=%2
 set INSTALLER_RESOURCES=installer\temp
 set INSTALLER_WORK=installer\sakura
-set INSTALLER_OUTPUT=installer\Output
+set INSTALLER_OUTPUT=installer\Output-%platform%
 
 set INSTALLER_RESOURCES_SINT=installer\sinst_src
 set INSTALLER_RESOURCES_BRON=installer\temp\bron

--- a/installer/sakura-Win32.iss
+++ b/installer/sakura-Win32.iss
@@ -1,2 +1,3 @@
 ﻿#define MyArchitecture "x86"
+#define OutputSuffix   "Win32"
 #include "sakura-common.iss"

--- a/installer/sakura-common.iss
+++ b/installer/sakura-common.iss
@@ -31,8 +31,10 @@ DisableStartupPrompt=no
 
 PrivilegesRequired=None
 
-; エディタのバージョンに応じて書き換える場所
+; 出力先ディレクトリ
 OutputDir=Output-{#OutputSuffix}
+
+; エディタのバージョンに応じて書き換える場所
 OutputBaseFilename=sakura_install{#MyAppVerH}-{#MyArchitecture}
 VersionInfoVersion={#MyAppVer}
 VersionInfoProductVersion={#MyAppVer}

--- a/installer/sakura-common.iss
+++ b/installer/sakura-common.iss
@@ -32,6 +32,7 @@ DisableStartupPrompt=no
 PrivilegesRequired=None
 
 ; エディタのバージョンに応じて書き換える場所
+OutputDir=Output-{#OutputSuffix}
 OutputBaseFilename=sakura_install{#MyAppVerH}-{#MyArchitecture}
 VersionInfoVersion={#MyAppVer}
 VersionInfoProductVersion={#MyAppVer}

--- a/installer/sakura-x64.iss
+++ b/installer/sakura-x64.iss
@@ -1,2 +1,3 @@
 ﻿#define MyArchitecture "x64"
+#define OutputSuffix   "x64"
 #include "sakura-common.iss"

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -156,7 +156,7 @@ copy installer\warning.txt   %WORKDIR%\
 if "%ALPHA%" == "1" (
 	copy installer\warning-alpha.txt   %WORKDIR%\
 )
-copy installer\Output\*.exe  %WORKDIR_INST%\
+copy installer\Output-%platform%\*.exe  %WORKDIR_INST%\
 copy msbuild-%platform%-%configuration%.log     %WORKDIR_LOG%\
 copy msbuild-%platform%-%configuration%.log.csv %WORKDIR_LOG%\
 if exist "msbuild-%platform%-%configuration%.log.xlsx" (


### PR DESCRIPTION
インストーラの生成先のフォルダにプラットフォーム名を含める

同じディレクトリだとローカルでビルドすとき一度退避しないといけないので面倒だから。

#328 でインストーラをローカルビルドするためのドキュメントを書く前に
ローカルビルドをしやすいようにするため。

※ OutputBaseFilename に対しては MyArchitecture を使っていますが、
OutputDir に対しては OutputSuffix  というのを使っているのは
innosetup では 32bit は x86 を使うのに対して appveyor や Visual studio の
プラットフォームが Win32 になっていてそれを継承しているためです。

OutputBaseFilename に対しても同様に Win32 にすることも可能です。



