### PR TITLE
bregonig.dll のファイル内容とタイムスタンプを比較する

### DIFF
--- a/build-installer.bat
+++ b/build-installer.bat
@@ -23,11 +23,13 @@ copy %INSTALLER_RESOURCES_SINT%\sakura.exe.manifest.v %INSTALLER_WORK%\
 copy %INSTALLER_RESOURCES_SINT%\sakura.exe.ini        %INSTALLER_WORK%\
 copy %INSTALLER_RESOURCES_SINT%\keyword\*.*           %INSTALLER_WORK%\keyword\
 
+set DLL_BREGONIG_NAME=bregonig.dll
 if "%platform%" == "x64" (
-	copy %INSTALLER_RESOURCES_BRON%\x64\*.dll         %INSTALLER_WORK%\
+	set INSTALLER_RESOURCES_BRON_DLL=%INSTALLER_RESOURCES_BRON%\x64
 ) else (
-	copy %INSTALLER_RESOURCES_BRON%\*.dll             %INSTALLER_WORK%\
+	set INSTALLER_RESOURCES_BRON_DLL=%INSTALLER_RESOURCES_BRON%
 )
+copy %INSTALLER_RESOURCES_BRON_DLL%\*.dll             %INSTALLER_WORK%\
 copy %INSTALLER_RESOURCES_BRON%\*.txt                 %INSTALLER_WORK%\
 
 copy help\sakura\sakura.chm                      %INSTALLER_WORK%\
@@ -36,6 +38,40 @@ copy help\macro\macro.chm                        %INSTALLER_WORK%\
 
 copy %platform%\%configuration%\*.exe                 %INSTALLER_WORK%\
 copy %platform%\%configuration%\sakura_lang_en_US.dll %INSTALLER_WORK%\
+
+set DLL_BREGONIG_0=%INSTALLER_RESOURCES_BRON_DLL%\%DLL_BREGONIG_NAME%
+set DLL_BREGONIG_1=%INSTALLER_WORK%\%DLL_BREGONIG_NAME%
+set DLL_BREGONIG_2=installer\externals\bregonig\%platform%\%DLL_BREGONIG_NAME%
+set DLL_BREGONIG_3=%platform%\%configuration%\%DLL_BREGONIG_NAME%
+
+set COMPARE_RESULT=0
+fc %DLL_BREGONIG_0% %DLL_BREGONIG_1% 1>nul 2>&1
+if "%ERRORLEVEL%" == "0" (
+	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_1% for %platform%: matched
+) else (
+	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_1% for %platform%: unmatched
+	set COMPARE_RESULT=1
+)
+
+fc %DLL_BREGONIG_0% %DLL_BREGONIG_2% 1>nul 2>&1
+if "%ERRORLEVEL%" == "0" (
+	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_2% for %platform%: matched
+) else (
+	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_2% for %platform%: unmatched
+	set COMPARE_RESULT=1
+)
+
+fc %DLL_BREGONIG_0% %DLL_BREGONIG_3% 1>nul 2>&1
+if "%ERRORLEVEL%" == "0" (
+	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_3% for %platform%: matched
+) else (
+	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_3% for %platform%: unmatched
+	set COMPARE_RESULT=1
+)
+if "%COMPARE_RESULT%" == "1" (
+	echo unmatch
+	exit /b 1
+)
 
 set SAKURA_ISS=installer\sakura-%platform%.iss
 "C:\Program Files (x86)\Inno Setup 5\ISCC.exe" %SAKURA_ISS% || (echo error && exit /b 1)

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -56,7 +56,7 @@ FOR %%d IN (%DLL_BREGONIG_3%) DO SET TIMESTAMP_3=%%~td
 
 @rem compare file contents
 set COMPARE_RESULT=0
-fc %DLL_BREGONIG_0% %DLL_BREGONIG_1% 1>nul 2>&1
+fc /B %DLL_BREGONIG_0% %DLL_BREGONIG_1% 1>nul 2>&1
 if "%ERRORLEVEL%" == "0" (
 	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_1% for %platform%: matched
 ) else (
@@ -64,7 +64,7 @@ if "%ERRORLEVEL%" == "0" (
 	set COMPARE_RESULT=1
 )
 
-fc %DLL_BREGONIG_0% %DLL_BREGONIG_2% 1>nul 2>&1
+fc /B %DLL_BREGONIG_0% %DLL_BREGONIG_2% 1>nul 2>&1
 if "%ERRORLEVEL%" == "0" (
 	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_2% for %platform%: matched
 ) else (
@@ -72,7 +72,7 @@ if "%ERRORLEVEL%" == "0" (
 	set COMPARE_RESULT=1
 )
 
-fc %DLL_BREGONIG_0% %DLL_BREGONIG_3% 1>nul 2>&1
+fc /B %DLL_BREGONIG_0% %DLL_BREGONIG_3% 1>nul 2>&1
 if "%ERRORLEVEL%" == "0" (
 	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_3% for %platform%: matched
 ) else (

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -44,6 +44,17 @@ set DLL_BREGONIG_1=%INSTALLER_WORK%\%DLL_BREGONIG_NAME%
 set DLL_BREGONIG_2=installer\externals\bregonig\%platform%\%DLL_BREGONIG_NAME%
 set DLL_BREGONIG_3=%platform%\%configuration%\%DLL_BREGONIG_NAME%
 
+FOR %%a IN (%DLL_BREGONIG_0%) DO SET TIMESTAMP_0=%%~ta
+FOR %%b IN (%DLL_BREGONIG_1%) DO SET TIMESTAMP_1=%%~tb
+FOR %%c IN (%DLL_BREGONIG_2%) DO SET TIMESTAMP_2=%%~tc
+FOR %%d IN (%DLL_BREGONIG_3%) DO SET TIMESTAMP_3=%%~td
+
+@echo %TIMESTAMP_0% %DLL_BREGONIG_0%
+@echo %TIMESTAMP_1% %DLL_BREGONIG_1%
+@echo %TIMESTAMP_2% %DLL_BREGONIG_2%
+@echo %TIMESTAMP_3% %DLL_BREGONIG_3%
+
+@rem compare file contents
 set COMPARE_RESULT=0
 fc %DLL_BREGONIG_0% %DLL_BREGONIG_1% 1>nul 2>&1
 if "%ERRORLEVEL%" == "0" (
@@ -68,8 +79,21 @@ if "%ERRORLEVEL%" == "0" (
 	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_3% for %platform%: unmatched
 	set COMPARE_RESULT=1
 )
+
 if "%COMPARE_RESULT%" == "1" (
-	echo unmatch
+	echo unmatch file contents
+	exit /b 1
+)
+@rem compare timestamps
+if "%TIMESTAMP_0%" == "%TIMESTAMP_1%" (
+	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_1% for %platform%: timestamps matched
+) else (
+	@echo %DLL_BREGONIG_0% and %DLL_BREGONIG_1% for %platform%: timestamps unmatched
+	set COMPARE_RESULT=1
+)
+
+if "%COMPARE_RESULT%" == "1" (
+	echo unmatch timestamps
 	exit /b 1
 )
 


### PR DESCRIPTION
bregonig.dll のファイル内容とタイムスタンプを比較する
#332 のような不具合を防ぐ

## 確認手順

### ビルド成功の確認

build-all.bat Win32 Release
build-all.bat x64   Release

### ビルド失敗の確認 (Win32)

echo "" > installer\externals\bregonig\Win32\bregonig.dll
build-all.bat Win32 Release

### ビルド失敗してエラー解消後のビルド成功の確認 (Win32)

git checkout installer\externals\bregonig\Win32\bregonig.dll
build-all.bat Win32 Release

### ビルド失敗の確認 (x64)

echo "" > installer\externals\bregonig\x64\bregonig.dll
build-all.bat x64   Release

### ビルド失敗してエラー解消後のビルド成功の確認 (x64)

git checkout installer\externals\bregonig\x64\bregonig.dll
build-all.bat x64   Release
