### PR TITLE
markdown のスペルミス修正

### DIFF
--- a/appveyor.md
+++ b/appveyor.md
@@ -94,14 +94,14 @@
 
 | バッチファイル | 第一引数 | 第二引数 |
 ----|----|----
-|build-all.bat       | platform ("Win32" または "x64") | configuration ("Debug" または "Relelase)"  |
-|build-sln.bat       | platform ("Win32" または "x64") | configuration ("Debug" または "Relelase)"  |
+|build-all.bat       | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
+|build-sln.bat       | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
 |sakura\preBuild.bat | HeaderMake.exe または MakefileMake.exe の実行ファイルのフォルダパス | なし |
-|sakura\postBuild.bat| platform ("Win32" または "x64") | configuration ("Debug" または "Relelase)"  |
+|sakura\postBuild.bat| platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
 |parse-buildlog.bat  | msbuild のビルドログパス | なし |
 |build-chm.bat       | なし | なし |
-|build-installer.bat | platform ("Win32" または "x64") | configuration ("Debug" または "Relelase)"  |
-|zipArtifacts.bat    | platform ("Win32" または "x64") | configuration ("Debug" または "Relelase)"  |
+|build-installer.bat | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
+|zipArtifacts.bat    | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
 |calc-hash.bat       | sha256 のハッシュ値の出力先ファイル | ハッシュ値を計算するフォルダパス |
 
 ## バッチファイルの仕組み

--- a/appveyor.md
+++ b/appveyor.md
@@ -94,14 +94,14 @@
 
 | バッチファイル | 第一引数 | 第二引数 |
 ----|----|----
-|build-all.bat       | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
-|build-sln.bat       | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
+|build-all.bat       | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
+|build-sln.bat       | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
 |sakura\preBuild.bat | HeaderMake.exe または MakefileMake.exe の実行ファイルのフォルダパス | なし |
-|sakura\postBuild.bat| platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
+|sakura\postBuild.bat| platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
 |parse-buildlog.bat  | msbuild のビルドログパス | なし |
 |build-chm.bat       | なし | なし |
-|build-installer.bat | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
-|zipArtifacts.bat    | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
+|build-installer.bat | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
+|zipArtifacts.bat    | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
 |calc-hash.bat       | sha256 のハッシュ値の出力先ファイル | ハッシュ値を計算するフォルダパス |
 
 ## バッチファイルの仕組み

--- a/unittest.md
+++ b/unittest.md
@@ -68,7 +68,7 @@ GUI でステップ実行することができます。
 
 | バッチファイル | 第一引数 | 第二引数 |
 ----|----|----
-|[tests\create-project.bat](tests/create-project.bat)| platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
-|[tests\build-project.bat](tests/build-project.bat)  | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
-|[tests\run-tests.bat](tests/run-tests.bat)          | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
-|[tests\build-and-test.bat](tests/build-and-test.bat)| platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
+|[tests\create-project.bat](tests/create-project.bat)| platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
+|[tests\build-project.bat](tests/build-project.bat)  | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
+|[tests\run-tests.bat](tests/run-tests.bat)          | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
+|[tests\build-and-test.bat](tests/build-and-test.bat)| platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |

--- a/unittest.md
+++ b/unittest.md
@@ -68,7 +68,7 @@ GUI でステップ実行することができます。
 
 | バッチファイル | 第一引数 | 第二引数 |
 ----|----|----
-|[tests\create-project.bat](tests/create-project.bat)| platform ("Win32" または "x64") | configuration ("Debug" または "Relelase)"  |
-|[tests\build-project.bat](tests/build-project.bat)  | platform ("Win32" または "x64") | configuration ("Debug" または "Relelase)"  |
-|[tests\run-tests.bat](tests/run-tests.bat)          | platform ("Win32" または "x64") | configuration ("Debug" または "Relelase)"  |
-|[tests\build-and-test.bat](tests/build-and-test.bat)| platform ("Win32" または "x64") | configuration ("Debug" または "Relelase)"  |
+|[tests\create-project.bat](tests/create-project.bat)| platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
+|[tests\build-project.bat](tests/build-project.bat)  | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
+|[tests\run-tests.bat](tests/run-tests.bat)          | platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |
+|[tests\build-and-test.bat](tests/build-and-test.bat)| platform ("Win32" または "x64") | configuration ("Debug" または "Release)"  |


### PR DESCRIPTION
markdown のスペルミス修正

- Relelase → Release (https://github.com/sakura-editor/sakura/issues/334#issuecomment-412510935)
- " と ) が逆になっているのを修正 (https://github.com/sakura-editor/sakura/issues/334#issuecomment-412510210)


