### PR TITLE
Appveyor 関連の環境変数をバッチファイルの形で保存する

### DIFF
--- a/appveyor_env.py
+++ b/appveyor_env.py
@@ -179,7 +179,14 @@ class AppveyorEnv():
 		for key in self.var.keys():
 			print (key, self.var[key])
 
-def main():
+	# Appveyor 関連の環境変数をバッチファイルの形で保存する
+	def saveEnvAsBat(self, file):
+		with open(file, "w") as fout:
+			for key in self.keysEnv:
+				fout.write("set " + key + "=" + os.environ.get(key, "") + "\n")
+		print ("wrote: " + file)
+
+def main(fileBat):
 	appveyor = AppveyorEnv()
 	appveyor.printAll()
 	
@@ -195,5 +202,10 @@ def main():
 		print (appveyor.getBlobURLWithLine(file, 1))
 		print (appveyor.getBlobURLWithLines(file, 9, 15))
 
+	appveyor.saveEnvAsBat(fileBat)
+
 if __name__ == '__main__':
-	main()
+	fileBat = "set_appveyor_env.bat"
+	if len(sys.argv) > 1:
+		fileBat = sys.argv[1]
+	main(fileBat)

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -173,6 +173,10 @@ if exist "cppcheck.xml" (
 	copy /Y "cppcheck.xml" %WORKDIR_LOG%\
 )
 
+if exist "set_appveyor_env.bat" (
+	copy /Y "set_appveyor_env.bat" %WORKDIR_LOG%\
+)
+
 set HASHFILE=sha256.txt
 if exist "%HASHFILE%" (
 	del %HASHFILE%


### PR DESCRIPTION
Appveyor 関連の環境変数をバッチファイルの形で保存し、成果物に含める。
ローカルで appveyor 関連の環境変数に依存している処理をデバッグするときに使う。
