### PR TITLE
githash.bat のエラー耐性を上げる

### DIFF
--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -3,6 +3,9 @@
 SETLOCAL
 
 set OUT_DIR=%1
+if "%OUT_DIR%" == "" (
+	set OUT_DIR=.
+)
 
 @rem replace '/' with '\'
 set OUT_DIR=%OUT_DIR:/=\%

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -4,8 +4,15 @@ SETLOCAL
 
 set OUT_DIR=%1
 
+@rem replace '/' with '\'
+set OUT_DIR=%OUT_DIR:/=\%
+
 @echo.
 @echo ---- Make githash.h ----
+
+@rem ensure to be in the proper directory
+pushd %~dp0
+
 : Git enabled checking
 set GIT_ENABLED=1
 where git 1>nul 2>&1
@@ -34,6 +41,9 @@ if "%GIT_ENABLED%" == "1" (
 	set COMMITID=
 	set GIT_URL=
 )
+
+@rem get back to the original directory
+popd
 
 set PREFIX_GITHUB=https://github.com
 if "%APPVEYOR_REPO_PROVIDER%" == "gitHub" (

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -14,7 +14,7 @@ set OUT_DIR=%OUT_DIR:/=\%
 @echo ---- Make githash.h ----
 
 @rem ensure to be in the proper directory
-pushd %~dp0
+pushd "%~dp0"
 
 : Git enabled checking
 set GIT_ENABLED=1


### PR DESCRIPTION
githash.bat のエラー耐性を上げる

- 引数に / が含まれていても動くようにする
- カレントディレクトリが意図していない場所になっていても動作するようにする