### PR TITLE
MINGW_HAS_SECURE_APIが無効か判定する式の修正

### DIFF
--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -223,7 +223,7 @@ const char* stristr_j( const char* s1, const char* s2 )
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 #if (defined(_MSC_VER) && _MSC_VER<1400) \
-|| (defined(__MINGW32__) && defined(MINGW_HAS_SECURE_API) && MINGW_HAS_SECURE_API) //VS2005より前なら
+	|| (defined(__MINGW32__) && (!defined(MINGW_HAS_SECURE_API) || MINGW_HAS_SECURE_API != 1)) //VS2005より前なら
 
 errno_t wcscat_s(wchar_t* szDst, size_t nDstCount, const wchar_t* szSrc)
 {

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -145,7 +145,7 @@ int my_strnicmp( const char *s1, const char *s2, size_t n );
 
 // VS2005以降の安全版文字列関数
 #if (defined(_MSC_VER) && _MSC_VER<1400) \
-	|| (defined(__MINGW32__) && defined(MINGW_HAS_SECURE_API) && MINGW_HAS_SECURE_API) //VS2005より前なら
+	|| (defined(__MINGW32__) && (!defined(MINGW_HAS_SECURE_API) || MINGW_HAS_SECURE_API != 1)) //VS2005より前なら
 	typedef int errno_t;
 #define _TRUNCATE ((size_t)-1)
 	errno_t strcpy_s(char *dest, size_t num, const char *src);


### PR DESCRIPTION
デバッグビルドできるように設定をいじっていて誤りに気づきました。
PRのレビューでも指摘をいただいていた部分です。

https://github.com/sakura-editor/sakura/pull/351#pullrequestreview-147449794

 k_takata
> `\` での行継続が必要ですね。
> あと、MinGWの判定合ってますか？

 berryzplus
> レビューありがとうございます。
> 
> > `\` での行継続が必要ですね。
> 
> ビルドが通ったのは _MSC_VER が定義されていなかったからですね。
> 
> 
> > あと、MinGWの判定合ってますか？
> 
> MinGW側の判定はたぶん合ってると思います。
> 定義するときは `-DMINGW_HAS_SECURE_API=1` としますが、
> 0とされたときに正しく動くようにする意図です。

 k_takata
> `sec_api/tchar_s.h` などを見ると、`#ifdef` で判定しています。
> そして、MinGW自身がセキュア系関数を持っているはずです。

このPRで一旦条件式の誤りを直したいです。

仮に `-DMINGW_HAS_SECURE_API=0` とされたらどうすべきかは別件としたいです。

