### PR TITLE
cppcheck の出力 xml ファイルに platform 名や configuration 名を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ sha256.txt
 *.pyc
 /tests/build
 /cppcheck-install.log
-/cppcheck.xml
+/cppcheck-*.xml

--- a/run-cppcheck.bat
+++ b/run-cppcheck.bat
@@ -4,7 +4,7 @@ set platform=%1
 set configuration=%2
 
 set CPPCHECK_EXE=C:\Program Files\Cppcheck\cppcheck.exe
-set CPPCHECK_OUT=cppcheck.xml
+set CPPCHECK_OUT=cppcheck-%platform%-%configuration%.xml
 
 set CPPCHECK_PLATFORM=
 if "%PLATFORM%" == "Win32" (

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -169,8 +169,8 @@ copy /Y sakura_core\githash.h                      %WORKDIR_LOG%\
 if exist "cppcheck-install.log" (
 	copy /Y "cppcheck-install.log" %WORKDIR_LOG%\
 )
-if exist "cppcheck.xml" (
-	copy /Y "cppcheck.xml" %WORKDIR_LOG%\
+if exist "cppcheck-%platform%-%configuration%.xml" (
+	copy /Y "cppcheck-%platform%-%configuration%.xml" %WORKDIR_LOG%\
 )
 
 if exist "set_appveyor_env.bat" (


### PR DESCRIPTION
cppcheck の出力 xml ファイルに platform 名や configuration 名を追加
(ローカルビルド用)