### PR TITLE
cppcheck で "Too many #ifdef configurations - cppcheck only checks 12 of 31 configurations. Use --force to check all configurations" の警告を修正

### DIFF
--- a/run-cppcheck.bat
+++ b/run-cppcheck.bat
@@ -40,7 +40,7 @@ if exist "%CPPCHECK_OUT%" (
 
 set ERROR_RESULT=0
 if exist "%CPPCHECK_EXE%" (
-	"%CPPCHECK_EXE%" --enable=all --xml --platform=%CPPCHECK_PLATFORM% %~dp0sakura_core 2> %CPPCHECK_OUT% || set ERROR_RESULT=1
+	"%CPPCHECK_EXE%" --force --enable=all --xml --platform=%CPPCHECK_PLATFORM% %~dp0sakura_core 2> %CPPCHECK_OUT% || set ERROR_RESULT=1
 )
 exit /b %ERROR_RESULT%
 


### PR DESCRIPTION
cppcheck で "Too many #ifdef configurations - cppcheck only checks 12 of 31 configurations. Use --force to check all configurations" の警告を修正