### PR TITLE
MinGW向けMakefileからbtoolフォルダへの参照を取り除く

### DIFF
--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -422,8 +422,6 @@ Funccode_define.h \
 Funccode_enum.h \
 githash.h \
 
-RCTOOLDIR=../btool
-RCTOOL=$(RCTOOLDIR)/mrc2grc.exe
 HEADERMAKETOOLDIR= ../HeaderMake
 HEADERMAKE= $(HEADERMAKETOOLDIR)/HeaderMake.exe
 

--- a/sakura_lang_en_US/Makefile
+++ b/sakura_lang_en_US/Makefile
@@ -50,9 +50,6 @@ exe= sakura_lang_en_US.dll
 OBJS= \
 sakura_lang_rc.o \
 
-RCTOOLDIR=../btool
-RCTOOL=$(RCTOOLDIR)/mrc2grc.exe
-
 all: $(exe)
 
 $(exe): sakura_lang.h $(OBJS)


### PR DESCRIPTION
最近の修正により使わなくなったbtoolフォルダへの参照を除去します。

#369 がマージされたらリベースしてWIP外します。
#352 btool フォルダ削除 の前に実施すべき修正です。
