### PR TITLE
githash.batも exit /b 0 にする

### DIFF
--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -129,7 +129,7 @@ if "%ERRORLEVEL%" == "0" (
 )
 
 ENDLOCAL
-exit /b
+exit /b 0
 
 :output_githash
 echo #pragma once
@@ -225,4 +225,4 @@ if "%APPVEYOR_BUILD_URL%" == "" (
 	echo #define APPVEYOR_BUILD_URL             "%APPVEYOR_BUILD_URL%"
 )
 
-exit /b
+exit /b 0


### PR DESCRIPTION
#361 指摘の横展開です。

このファイルは直近 #360 で修正されていますが、修正範囲に `exit /b` がなかったため気付きませんでした。

MinGWデバッグ環境作成のために Makefile を弄っていて気付きました。