### PR TITLE
cppcheck の標準出力をリダイレクトしてファイルに落とす

### DIFF
--- a/run-cppcheck.bat
+++ b/run-cppcheck.bat
@@ -23,6 +23,7 @@ if "%configuration%" == "Release" (
 
 set CPPCHECK_EXE=C:\Program Files\Cppcheck\cppcheck.exe
 set CPPCHECK_OUT=cppcheck-%platform%-%configuration%.xml
+set CPPCHECK_LOG=cppcheck-%platform%-%configuration%.log
 
 set CPPCHECK_PLATFORM=
 if "%PLATFORM%" == "Win32" (
@@ -38,6 +39,10 @@ if exist "%CPPCHECK_OUT%" (
 	del %CPPCHECK_OUT%
 )
 
+if exist "%CPPCHECK_LOG%" (
+	del %CPPCHECK_LOG%
+)
+
 set CPPCHECK_PARAMS=
 set CPPCHECK_PARAMS=%CPPCHECK_PARAMS% --force
 set CPPCHECK_PARAMS=%CPPCHECK_PARAMS% --enable=all
@@ -49,7 +54,10 @@ set CPPCHECK_PARAMS=%CPPCHECK_PARAMS% %~dp0sakura_core
 set ERROR_RESULT=0
 if exist "%CPPCHECK_EXE%" (
 	@echo "%CPPCHECK_EXE%" %CPPCHECK_PARAMS%
-	"%CPPCHECK_EXE%" %CPPCHECK_PARAMS% || set ERROR_RESULT=1
+	"%CPPCHECK_EXE%" %CPPCHECK_PARAMS% > %CPPCHECK_LOG% || set ERROR_RESULT=1
+	@echo.
+	@echo The log files are %CPPCHECK_LOG% and %CPPCHECK_OUT%
+	@echo cppcheck success
 )
 exit /b %ERROR_RESULT%
 

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -191,6 +191,9 @@ if exist "cppcheck-install.log" (
 if exist "cppcheck-%platform%-%configuration%.xml" (
 	copy /Y "cppcheck-%platform%-%configuration%.xml" %WORKDIR_LOG%\
 )
+if exist "cppcheck-%platform%-%configuration%.log" (
+	copy /Y "cppcheck-%platform%-%configuration%.log" %WORKDIR_LOG%\
+)
 
 if exist "set_appveyor_env.bat" (
 	copy /Y "set_appveyor_env.bat" %WORKDIR_LOG%\


### PR DESCRIPTION
cppcheck の標準出力をリダイレクトしてファイルに落とす
(appveyor での出力を減らす)

https://github.com/sakura-editor/sakura/issues/372#issuecomment-416030291
