### PR TITLE
new/deleteのオーバーロードがGCCに怒られる対応

### DIFF
--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -67,8 +67,10 @@ static const bool UNICODE_BOOL=false;
 
 //newされた領域をわざと汚すかどうか (デバッグ用)
 #ifdef _DEBUG
-#define FILL_STRANGE_IN_NEW_MEMORY
-#endif
+#  ifndef __MINGW32__
+#    define FILL_STRANGE_IN_NEW_MEMORY
+#  endif /* __MINGW32__ */
+#endif /* _DEBUG */
 
 
 //crtdbg.hによるメモリーリークチェックを使うかどうか (デバッグ用)


### PR DESCRIPTION
Debugビルドを行った場合、FILL_STRANGE_IN_NEW_MEMORYを有効にした場合の、new/deleteのオーバーロード定義のシグニチャがgccに怒られてしまいます。

いわく、MinGWが独自に定義したシグニチャの先行定義と異なっている、です。
MinGWのオーバーロード定義は MinGW 独自のマクロが使われています。
（ちょっと正確なシグニチャを覚えていないですが nothrow っぽいものです。）

対処方法が不明なので、一旦はMinGWビルド時は無効となるようにしておきたいです。

このフラグはこれまでに何度か話題に出ているもので
無効化は一時的な対応、という認識です。 → #36, #48, #51  
恒久対応をどうするかについては別件としたいです。
