### PR TITLE
HTML Help 中のリンクを GitHub のものに変える

### DIFF
--- a/help/plugin/Text/index.html
+++ b/help/plugin/Text/index.html
@@ -17,7 +17,7 @@
 <center><hr width = "350px"></center>
 <center>サクラエディタ プラグイン開発ガイド</center>
 <center>最終更新日 2015/02/28</center>
-<center><a href="http://sakura-editor.sourceforge.net/" target=_blank>http://sakura-editor.sourceforge.net/</a></center>
+<center><a href="https://sakura-editor.github.io/" target=_blank>https://sakura-editor.github.io/</a></center>
 <center><a href="http://sakura.qp.land.to/?Plugin" target=_blank>http://sakura.qp.land.to/?Plugin</a></center>
 <center><hr width = "350px"></center>
 　本ヘルプは、サクラエディタのプラグインを開発する為のガイドです。<br>

--- a/help/sakura/_RESOURCE/HLP000001.html
+++ b/help/sakura/_RESOURCE/HLP000001.html
@@ -17,7 +17,7 @@
 <center><hr width = "350px"></center>
 <center>サクラエディタ   Ver 2.3.2.0</center>
 <center>ヘルプファイル最終更新日 2017/05/02</center>
-<center><a href="http://sakura-editor.sourceforge.net/" target=_blank>http://sakura-editor.sourceforge.net/</a></center>
+<center><a href="https://sakura-editor.github.io/" target=_blank>https://sakura-editor.github.io/</a></center>
 <center><hr width = "350px"></center>
 サクラエディタ(旧称:テキストエディタ)は、「たけ(竹パンダ)」さんのテキストエディタSAKURAの公開ソース(2000/02/21付)を元に不具合修正および機能拡張を行ったものです。<br>
 本ヘルプは、オリジナルのヘルプを元に、共同開発版で修正・変更された点について記述を加えています。<br>

--- a/help/sakura/_RESOURCE/HLP000104.html
+++ b/help/sakura/_RESOURCE/HLP000104.html
@@ -27,7 +27,7 @@
 			Orange<br />
 			Strawberry<br />
 			Š”®‰ïĞƒTƒNƒ‰¤–<br />
-			http://sakura-editor.sourceforge.net/<br />
+			https://sakura-editor.github.io/<br />
 		</div>
 		<br />
 		

--- a/help/sakura/_RESOURCE/HLP000112.html
+++ b/help/sakura/_RESOURCE/HLP000112.html
@@ -14,7 +14,7 @@
 サクラエディタの最新バージョン及びソースは、以下のWebページから入手可能です。<br>
 <div class=li200>
 ・Project Sakura-Editor<br>
-&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://sakura-editor.sourceforge.net/" target=_blank>http://sakura-editor.sourceforge.net/</a><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://sakura-editor.github.io/" target=_blank>https://sakura-editor.github.io/</a><br>
 </div><br>
 サクラエディタはまだまだ発展途上のソフトウェアです。ユーザーの皆様により良いものを提供するため、改良や修正を続けています。<br>
 <br>

--- a/help/sakura/_RESOURCE/HLP_UR000.html
+++ b/help/sakura/_RESOURCE/HLP_UR000.html
@@ -15,7 +15,7 @@
 <h2>プロジェクト連絡先</h2>
 サクラエディタの最新版及びそのソースを以下のサイトで公開しています。<br>
 <br>
-&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://sakura-editor.sourceforge.net/" target=_blank>http://sakura-editor.sourceforge.net/</a><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://sakura-editor.github.io/" target=_blank>https://sakura-editor.github.io/</a><br>
 <br>
 不具合や改善要望、質問等がありましたら、上記サイトの掲示板までお気軽にご連絡下さい。<br>
 連絡をいただいた場合、<b>できる限り</b>の対応をいたします。<br>


### PR DESCRIPTION
 #380: HTML Help 中のリンクを GitHub のものに変える

* web サイトのリンクを https://sakura-editor.github.io/ に変更する
* オンラインヘルプの URL は過去の履歴なので変更しない
* https://github.com/sakura-editor/sakura/blob/4c58aeb2fda06c5bc966a14233fc99cde351f774/help/sakura/_RESOURCE/HLP_HISTORY.html#L13-L15 は変更していない
 

