### PR TITLE
deleteのオーバーロードがGCCに怒られる対応

### DIFF
--- a/sakura_core/config/build_config.cpp
+++ b/sakura_core/config/build_config.cpp
@@ -35,12 +35,12 @@ void* operator new[](size_t nSize)
 	return p;
 }
 
-void operator delete(void* p)
+void operator delete(void* p) noexcept
 {
 	::free(p);
 }
 
-void operator delete[](void* p)
+void operator delete[](void* p) noexcept
 {
 	::free(p);
 }

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -67,7 +67,7 @@ static const bool UNICODE_BOOL=false;
 
 //newされた領域をわざと汚すかどうか (デバッグ用)
 #ifdef _DEBUG
-#define FILL_STRANGE_IN_NEW_MEMORY
+#    define FILL_STRANGE_IN_NEW_MEMORY
 #endif
 
 
@@ -95,8 +95,8 @@ static const bool UNICODE_BOOL=false;
 		#endif
 	#endif
 	void* operator new[](size_t nSize);
-	void operator delete(void* p);
-	void operator delete[](void* p);
+	void operator delete(void* p) noexcept;
+	void operator delete[](void* p) noexcept;
 #endif
 
 

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -67,7 +67,7 @@ static const bool UNICODE_BOOL=false;
 
 //newされた領域をわざと汚すかどうか (デバッグ用)
 #ifdef _DEBUG
-#    define FILL_STRANGE_IN_NEW_MEMORY
+#define FILL_STRANGE_IN_NEW_MEMORY
 #endif
 
 


### PR DESCRIPTION
#381 の本対応です。

MinGW でデバッグビルドを行った場合に、
deleteのオーバーロード定義のところでビルドエラーが発生しています。

```cmd
In file included from D:/eclipse4.6/eclipse/mingw/lib/gcc/x86_64-w64-mingw32/6.2
.0/include/c++/ext/new_allocator.h:33:0,
                 from D:/eclipse4.6/eclipse/mingw/lib/gcc/x86_64-w64-mingw32/6.2
.0/include/c++/x86_64-w64-mingw32/bits/c++allocator.h:33,
                 from D:/eclipse4.6/eclipse/mingw/lib/gcc/x86_64-w64-mingw32/6.2
.0/include/c++/bits/allocator.h:46,
                 from D:/eclipse4.6/eclipse/mingw/lib/gcc/x86_64-w64-mingw32/6.2
.0/include/c++/string:41,
                 from C:\gitroot\sakura-mygithub\sakura_core\StdAfx.h:64,
                 from C:\gitroot\sakura-mygithub\sakura_core\CAutoReloadAgent.cp
p:24:
D:/eclipse4.6/eclipse/mingw/lib/gcc/x86_64-w64-mingw32/6.2.0/include/c++/new:120
:6: error: declaration of 'void operator delete(void*) noexcept' has a different
 exception specifier
 void operator delete(void*) _GLIBCXX_USE_NOEXCEPT
      ^~~~~~~~
```

ポイントは `declaration of 'void operator delete(void*) noexcept' has a different`の部分と考えられるのでシグニチャを合わせる対応を行います。MinGW版はまだビルドできないため、動作確認は行っていません。
