### PR TITLE
ソースコード中のオンラインヘルプのアドレス更新

### DIFF
--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -607,7 +607,7 @@ BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData)
 			dwData = 1;	// 目次ページ
 
 		TCHAR buf[256];
-		_stprintf( buf, _T("https://sakura-editor.github.io/help/HLP%06lu.html"), dwData );
+		_stprintf( buf, _T("https://sakura-editor.github.io/help/HLP%06Iu.html"), dwData );
 		ShellExecute( ::GetActiveWindow(), NULL, buf, NULL, NULL, SW_SHOWNORMAL );
 	}
 


### PR DESCRIPTION
ローカル上にヘルプファイルが無かった場合に開くオンラインヘルプのアドレスを更新しました。

- `メニュー上での[F1]キー／ダイアログの[ヘルプ]ボタン` を押すと該当するページが表示されます。
- `[？]ボタンを押してコントロールをクリック／コントロールにフォーカスを置いて[F1]キー` の場合は目次が表示されます。
