### PR TITLE
非推奨テンプレートstd::auto_ptrを一括置換する

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -136,7 +136,7 @@ void CGrepAgent::AddTail( CEditView* pcEditView, const CNativeW& cmem, bool bAdd
 		HANDLE out = ::GetStdHandle(STD_OUTPUT_HANDLE);
 		if( out && out != INVALID_HANDLE_VALUE ){
 			CMemory cmemOut;
-			std::auto_ptr<CCodeBase> pcCodeBase( CCodeFactory::CreateCodeBase(
+			std::unique_ptr<CCodeBase> pcCodeBase( CCodeFactory::CreateCodeBase(
 					pcEditView->GetDocument()->GetDocumentEncoding(), 0) );
 			pcCodeBase->UnicodeToCode( cmem, &cmemOut );
 			DWORD dwWrite = 0;
@@ -1593,7 +1593,7 @@ private:
 	size_t bufferSize;
 	std::deque<CNativeW> buffer;
 	CBinaryOutputStream* out;
-	std::auto_ptr<CCodeBase> pcCodeBase;
+	std::unique_ptr<CCodeBase> pcCodeBase;
 	CNativeW&	memMessage;
 };
 

--- a/sakura_core/CPropertyManager.cpp
+++ b/sakura_core/CPropertyManager.cpp
@@ -109,7 +109,7 @@ bool CPropertyManager::OpenPropertySheetTypes( HWND hWnd, int nPageNum, CTypeCon
 	CPropTypes* pcPropTypes = new CPropTypes();
 	pcPropTypes->Create( G_AppInstance(), m_hwndOwner );
 
-	std::auto_ptr<STypeConfig> pType(new STypeConfig());
+	std::unique_ptr<STypeConfig> pType(new STypeConfig());
 	CDocTypeManager().GetTypeConfig(nSettingType, *pType);
 	pcPropTypes->SetTypeData(*pType);
 	// Mar. 31, 2003 genta メモリ削減のためポインタに変更しProperySheet内で取得するように

--- a/sakura_core/CWriteManager.cpp
+++ b/sakura_core/CWriteManager.cpp
@@ -24,7 +24,7 @@ EConvertResult CWriteManager::WriteFile_From_CDocLineMgr(
 )
 {
 	EConvertResult		nRetVal = RESULT_COMPLETE;
-	std::auto_ptr<CCodeBase> pcCodeBase( CCodeFactory::CreateCodeBase(sSaveInfo.eCharCode,0) );
+	std::unique_ptr<CCodeBase> pcCodeBase( CCodeFactory::CreateCodeBase(sSaveInfo.eCharCode,0) );
 
 	{
 		// 変換テスト

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -613,7 +613,7 @@ BOOL CViewCommander::Command_PUTFILE(
 	//	2007.09.08 genta CEditDoc::FileWrite()にならって砂時計カーソル
 	CWaitCursor cWaitCursor( m_pCommanderView->GetHwnd() );
 
-	std::auto_ptr<CCodeBase> pcSaveCode( CCodeFactory::CreateCodeBase(nSaveCharCode,0) );
+	std::unique_ptr<CCodeBase> pcSaveCode( CCodeFactory::CreateCodeBase(nSaveCharCode,0) );
 
 	bool bBom = false;
 	if (CCodeTypeName(nSaveCharCode).UseBom()) {
@@ -635,7 +635,7 @@ BOOL CViewCommander::Command_PUTFILE(
 			const CNativeW* pConvBuffer;
 			if( bBom ){
 				CNativeW cmemBom;
-				std::auto_ptr<CCodeBase> pcUtf16( CCodeFactory::CreateCodeBase(CODE_UNICODE,0) );
+				std::unique_ptr<CCodeBase> pcUtf16( CCodeFactory::CreateCodeBase(CODE_UNICODE,0) );
 				pcUtf16->GetBom(cmemBom._GetMemory());
 				cMem2.AppendNativeData(cmemBom);
 				cMem2.AppendNativeData(cMem);

--- a/sakura_core/convert/CConvert.cpp
+++ b/sakura_core/convert/CConvert.cpp
@@ -95,7 +95,7 @@ void CConvertMediator::ConvMemory( CNativeW* pCMemory, EFunctionCode nFuncCode, 
 	case F_CODECNV_AUTO2SJIS:
 		{
 			int nFlag = true;
-			std::auto_ptr<CCodeBase> pcCode( CCodeFactory::CreateCodeBase(ecode, nFlag) );
+			std::unique_ptr<CCodeBase> pcCode( CCodeFactory::CreateCodeBase(ecode, nFlag) );
 			pcCode->CodeToUnicode(*(pCMemory->_GetMemory()), pCMemory);
 		}
 		break;

--- a/sakura_core/dlg/CDlgOpenFile.cpp
+++ b/sakura_core/dlg/CDlgOpenFile.cpp
@@ -786,7 +786,7 @@ bool CDlgOpenFile::DoModal_GetOpenFileName( TCHAR* pszPath, EFilter eAddFiler )
 	}
 
 	/* 構造体の初期化 */
-	std::auto_ptr<CDlgOpenFileData> pData( new CDlgOpenFileData() );
+	std::unique_ptr<CDlgOpenFileData> pData( new CDlgOpenFileData() );
 	InitOfn( &pData->m_ofn );		// 2005.10.29 ryoji
 	pData->m_pcDlgOpenFile = this;
 	pData->m_ofn.lCustData = (LPARAM)(pData.get());
@@ -872,7 +872,7 @@ bool CDlgOpenFile::DoModal_GetSaveFileName( TCHAR* pszPath )
 	}
 
 	/* 構造体の初期化 */
-	std::auto_ptr<CDlgOpenFileData> pData( new CDlgOpenFileData() );
+	std::unique_ptr<CDlgOpenFileData> pData( new CDlgOpenFileData() );
 	InitOfn( &pData->m_ofn );		// 2005.10.29 ryoji
 	pData->m_pcDlgOpenFile = this;
 	pData->m_ofn.lCustData = (LPARAM)(pData.get());
@@ -910,7 +910,7 @@ bool CDlgOpenFile::DoModal_GetSaveFileName( TCHAR* pszPath )
 */
 bool CDlgOpenFile::DoModalOpenDlg( SLoadInfo* pLoadInfo, std::vector<std::tstring>* pFileNames, bool bOptions )
 {
-	std::auto_ptr<CDlgOpenFileData> pData( new CDlgOpenFileData() );
+	std::unique_ptr<CDlgOpenFileData> pData( new CDlgOpenFileData() );
 	pData->m_bIsSaveDialog = FALSE;	/* 保存のダイアログか */
 
 	bool bMultiSelect = pFileNames != NULL;
@@ -1011,7 +1011,7 @@ bool CDlgOpenFile::DoModalOpenDlg( SLoadInfo* pLoadInfo, std::vector<std::tstrin
 */
 bool CDlgOpenFile::DoModalSaveDlg(SSaveInfo* pSaveInfo, bool bSimpleMode)
 {
-	std::auto_ptr<CDlgOpenFileData> pData( new CDlgOpenFileData() );
+	std::unique_ptr<CDlgOpenFileData> pData( new CDlgOpenFileData() );
 	pData->m_bIsSaveDialog = TRUE;	/* 保存のダイアログか */
 
 	//	2003.05.12 MIK

--- a/sakura_core/dlg/CDlgPluginOption.cpp
+++ b/sakura_core/dlg/CDlgPluginOption.cpp
@@ -122,7 +122,7 @@ void CDlgPluginOption::SetData( void )
 	ListView_DeleteAllItems( hwndList );	// リストを空にする
 	m_Line = -1;							// 行非選択
 
-	std::auto_ptr<CDataProfile> cProfile( new CDataProfile );
+	std::unique_ptr<CDataProfile> cProfile( new CDataProfile );
 	cProfile->SetReadingMode();
 	cProfile->ReadProfile( m_cPlugin->GetOptionPath().c_str() );
 
@@ -226,7 +226,7 @@ int CDlgPluginOption::GetData( void )
 	// リスト
 	hwndList = GetItemHwnd( IDC_LIST_PLUGIN_OPTIONS );
 
-	std::auto_ptr<CDataProfile> cProfile( new CDataProfile );
+	std::unique_ptr<CDataProfile> cProfile( new CDataProfile );
 	cProfile->SetReadingMode();
 	cProfile->ReadProfile( m_cPlugin->GetOptionPath().c_str() );
 	cProfile->SetWritingMode();

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -901,7 +901,7 @@ int CDlgTagJumpList::SearchBestTag( void )
 	if( m_pcList->GetCount() <= 0 ) return -1;	//選べません。
 	if( NULL == m_pszFileName ) return 0;
 
-	std::auto_ptr<TagPathInfo> mem_lpPathInfo( new TagPathInfo );
+	std::unique_ptr<TagPathInfo> mem_lpPathInfo( new TagPathInfo );
 	TagPathInfo* lpPathInfo= mem_lpPathInfo.get();
 	int nMatch1 = -1;
 	int nMatch2 = -1;

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -513,7 +513,7 @@ bool CDlgTypeList::InitializeType( void )
 		return false;
 	}
 //	_DefaultConfig(&types);		//規定値をコピー
-	std::auto_ptr<STypeConfig> type(new STypeConfig());
+	std::unique_ptr<STypeConfig> type(new STypeConfig());
 	if( 0 != iDocType ){
 		CDocTypeManager().GetTypeConfig(CTypeConfig(0), *type); 	// 基本をコピー
 
@@ -624,8 +624,8 @@ bool CDlgTypeList::UpType()
 		// 基本の場合には何もしない
 		return true;
 	}
-	std::auto_ptr<STypeConfig> type1(new STypeConfig());
-	std::auto_ptr<STypeConfig> type2(new STypeConfig());
+	std::unique_ptr<STypeConfig> type1(new STypeConfig());
+	std::unique_ptr<STypeConfig> type2(new STypeConfig());
 	CDocTypeManager().GetTypeConfig(CTypeConfig(iDocType), *type1);
 	CDocTypeManager().GetTypeConfig(CTypeConfig(iDocType - 1), *type2);
 	--(type1->m_nIdx);
@@ -646,8 +646,8 @@ bool CDlgTypeList::DownType()
 		// 基本、最後の場合には何もしない
 		return true;
 	}
-	std::auto_ptr<STypeConfig> type1(new STypeConfig());
-	std::auto_ptr<STypeConfig> type2(new STypeConfig());
+	std::unique_ptr<STypeConfig> type1(new STypeConfig());
+	std::unique_ptr<STypeConfig> type2(new STypeConfig());
 	CDocTypeManager().GetTypeConfig(CTypeConfig(iDocType), *type1);
 	CDocTypeManager().GetTypeConfig(CTypeConfig(iDocType + 1), *type2);
 	++(type1->m_nIdx);

--- a/sakura_core/view/CEditView_ExecCmd.cpp
+++ b/sakura_core/view/CEditView_ExecCmd.cpp
@@ -71,7 +71,7 @@ public:
 	bool OutputA(const ACHAR* pBuf, int size = -1);
 
 protected:
-	std::auto_ptr<CCodeBase> pcCodeBase;
+	std::unique_ptr<CCodeBase> pcCodeBase;
 };
 
 /*!	@brief	外部コマンドの実行


### PR DESCRIPTION
#389 の件です。
スマートポインタ std::auto_ptr はC++11で非推奨となったテンプレートなので 
代替テンプレート std::unique_ptr に置き換えします。

純粋な `s/std::auto_ptr/std::unique_ptr/g` 置換です。