### PR TITLE
CSearchKeywordManager のコメントの間違いを修正

### DIFF
--- a/sakura_core/env/CSearchKeywordManager.cpp
+++ b/sakura_core/env/CSearchKeywordManager.cpp
@@ -66,7 +66,7 @@ void CSearchKeywordManager::AddToGrepFileArr( const TCHAR* pszGrepFile )
 	cRecentGrepFile.Terminate();
 }
 
-/*!	m_aGrepFolders.size()にpszGrepFolderを追加する
+/*!	m_aGrepFolders にpszGrepFolder を追加する
 	YAZAKI
 */
 void CSearchKeywordManager::AddToGrepFolderArr( const TCHAR* pszGrepFolder )

--- a/sakura_core/env/CSearchKeywordManager.h
+++ b/sakura_core/env/CSearchKeywordManager.h
@@ -51,7 +51,7 @@ public:
 	void		AddToSearchKeyArr( const wchar_t* pszSearchKey );	//	m_aSearchKeysにpszSearchKeyを追加する
 	void		AddToReplaceKeyArr( const wchar_t* pszReplaceKey );	//	m_aReplaceKeysにpszReplaceKeyを追加する
 	void		AddToGrepFileArr( const TCHAR* pszGrepFile );		//	m_aGrepFilesにpszGrepFileを追加する
-	void		AddToGrepFolderArr( const TCHAR* pszGrepFolder );	//	m_aGrepFolders.size()にpszGrepFolderを追加する
+	void		AddToGrepFolderArr( const TCHAR* pszGrepFolder );	//	m_aGrepFolders にpszGrepFolder を追加する
 private:
 	DLLSHAREDATA* m_pShareData;
 };


### PR DESCRIPTION
CSearchKeywordManager のコメントの間違いを修正

#403 の対応で気づきました。
