### PR TITLE
単体テストのプロジェクト設定で sakura editor 本体のソースコードのインクルードディレクトリの指定を追加する

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -10,6 +10,9 @@ file(GLOB SRC ${CMAKE_CURRENT_LIST_DIR}/test*.cpp)
 # add include directories
 include_directories(${googletest_SOURCE_DIR}/include)
 
+# add include directories for sakura_core
+include_directories(${CMAKE_SOURCE_DIR}/../sakura_core)
+
 # define sources files of an executable
 add_executable(${project_name} ${SRC})
 

--- a/unittest.md
+++ b/unittest.md
@@ -10,6 +10,7 @@
         - [一覧](#一覧)
         - [呼び出し構造](#呼び出し構造)
         - [使用するバッチファイルの引数](#使用するバッチファイルの引数)
+    - [インクルードディレクトリ](#インクルードディレクトリ)
 
 <!-- /TOC -->
 
@@ -72,3 +73,8 @@ GUI でステップ実行することができます。
 |[tests\build-project.bat](tests/build-project.bat)  | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
 |[tests\run-tests.bat](tests/run-tests.bat)          | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
 |[tests\build-and-test.bat](tests/build-and-test.bat)| platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
+
+## インクルードディレクトリ
+
+[単体テスト用のCMakeLists.txt](tests/unittests/CMakeLists.txt) で [サクラエディタ用のディレクトリ](sakura_core) に
+インクルードディレクトリを指定するので、そこからの相対パスを指定すれば、サクラエディタのヘッダをインクルードできます。


### PR DESCRIPTION
単体テストのプロジェクト設定で sakura editor 本体のソースコードのインクルードディレクトリの指定を追加する

PR #418 で以下のように sakura_core へのパスを指定しているが、ソースコードに埋め込まなくてもいいようにするためです。

https://github.com/sakura-editor/sakura/blob/d1f7b3b0cce932104992b4bd95fabd12f78d6980/tests/unittests/test-int2dec.cpp#L7-L10
