### PR TITLE
string_ex2.h での CNativeA/CNativeW の先行宣言漏れを修正

### DIFF
--- a/sakura_core/util/string_ex2.h
+++ b/sakura_core/util/string_ex2.h
@@ -25,6 +25,8 @@
 #define SAKURA_STRING_EX2_AA243462_59E7_4F55_B206_FD9ED8836A09_H_
 
 class CEol;
+class CNativeA;
+class CNativeW;
 
 // Aug. 16, 2007 kobake
 wchar_t *wcsncpy_ex(wchar_t *dst, size_t dst_count, const wchar_t* src, size_t src_count);


### PR DESCRIPTION
string_ex2.h での CNativeA/CNativeW の先行宣言漏れを修正

PR #418 で見つけた問題
https://github.com/sakura-editor/sakura/pull/418/files#r216144516