### PR TITLE
単体テスト向けの CMakeLists.txt で Visual Studio のスタートアッププロジェクトの設定

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,3 +28,7 @@ set_target_properties(gmock_main  PROPERTIES FOLDER GoogleTest)
 set_target_properties(gtest       PROPERTIES FOLDER GoogleTest)
 set_target_properties(gtest_main  PROPERTIES FOLDER GoogleTest)
 set_target_properties(tests1      PROPERTIES FOLDER Tests)
+
+# specify startup project
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tests1)
+


### PR DESCRIPTION
https://github.com/sakura-editor/sakura/issues/427#issuecomment-419750388

単体テストのプロジェクトがスタートアップ プロジェクトに設定されるようにしました。
