### PR TITLE
README にカンバンリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Sakura Editor
+[![Build status](https://ci.appveyor.com/api/projects/status/xlsp22h1q91mh96j/branch/master?svg=true)](https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master)
 
 <!-- TOC -->
 
 - [Sakura Editor](#sakura-editor)
+    - [Hot topic](#hot-topic)
     - [Web Site](#web-site)
     - [開発参加ポリシー](#開発参加ポリシー)
     - [Build Requirements](#build-requirements)
@@ -21,9 +23,13 @@
 
 <!-- /TOC -->
 
-[![Build status](https://ci.appveyor.com/api/projects/status/xlsp22h1q91mh96j/branch/master?svg=true)](https://ci.appveyor.com/project/sakuraeditor/sakura/branch/master)
-
 A free Japanese text editor for Windows
+
+## Hot topic
+カンバン運用を始めます。
+
+- [カンバン](https://github.com/orgs/sakura-editor/projects/1)
+- [カンバン運用に関する議論](https://github.com/sakura-editor/management-forum/issues/9)
 
 ## Web Site
 - [Sakura Editor Portal](https://sakura-editor.github.io/)


### PR DESCRIPTION
sakura の README がいわゆる開発ポータルの役目を果たしている（と自分は考えている）ため、トップ部にカンバンリンクを付けました。