### PR TITLE
ctestを有効にする

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,3 +32,8 @@ set_target_properties(tests1      PROPERTIES FOLDER Tests)
 # specify startup project
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tests1)
 
+# enable testing
+enable_testing()
+
+# add test
+add_test(NAME unitTest1 COMMAND tests1)


### PR DESCRIPTION
CMakeLists.txtにテスト設定を追加します。

これにより、CMakeのテスト機構が有効になります。
vs2017のGUIメニューCMakeにTestの項目が追加され、
メニューからテスト実行を行うことができるようになります。
（スタートアッププロジェクトの設定と関係なくテスト実行可能）
