### PR TITLE
ステータスバーのテキスト設定、既に同じ値が設定されている場合は再設定しないようにする

### DIFF
--- a/sakura_core/apiwrap/CommonControl.h
+++ b/sakura_core/apiwrap/CommonControl.h
@@ -35,6 +35,10 @@ namespace ApiWrap
 	{
 		return ::SendMessage( hwndStatus, SB_SETTEXT, opt, (LPARAM)str );
 	}
+	inline LRESULT StatusBar_GetText(HWND hwndStatus, WPARAM opt, TCHAR* str)
+	{
+		return ::SendMessage( hwndStatus, SB_GETTEXT, opt, (LPARAM)str );
+	}
 
 	inline int StatusBar_SetParts(HWND hwndCtl, int num, int* positions)		{ return (int)(DWORD)::SendMessage(hwndCtl, SB_SETPARTS, (WPARAM)num, (LPARAM)positions); }
 

--- a/sakura_core/apiwrap/CommonControl.h
+++ b/sakura_core/apiwrap/CommonControl.h
@@ -39,6 +39,10 @@ namespace ApiWrap
 	{
 		return ::SendMessage( hwndStatus, SB_GETTEXT, opt, (LPARAM)str );
 	}
+	inline LRESULT StatusBar_GetTextLength(HWND hwndStatus, WPARAM opt)
+	{
+		return ::SendMessage( hwndStatus, SB_GETTEXTLENGTH, opt, (LPARAM)0 );
+	}
 
 	inline int StatusBar_SetParts(HWND hwndCtl, int num, int* positions)		{ return (int)(DWORD)::SendMessage(hwndCtl, SB_SETPARTS, (WPARAM)num, (LPARAM)positions); }
 

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -862,18 +862,20 @@ void CCaret::ShowCaretPosInfo()
 		}
 		// ステータスバーを更新するためのインライン関数
 		auto updateStatusBarText = [hwndStatusBar](_In_ BYTE index, _In_ WORD opt, _In_z_ const TCHAR* text) {
-			if (opt != 0) {
+			if( opt != 0 ){
 				::StatusBar_SetText(hwndStatusBar, index | opt, text);
-			}
-			else {
-				// 既に同じ値が設定されている場合は再設定しないようにする
-				TCHAR prev[64] = _T(""); //←サイズは szText_1 に合わせている
-				if (::StatusBar_GetTextLength(hwndStatusBar, index) <= _countof(prev) - 1) {
-					//表示テキストがバッファに収まるようなら取得、そうでなければ取得しない。
-					::StatusBar_GetText(hwndStatusBar, index, prev);
-				}
-				if (::wcscmp(prev, text) != 0) {
+			}else{
+				TCHAR prev[64];
+				static_assert(sizeof(prev) >= sizeof(szText_1), "not sufficient size.");
+				WORD prevLen = LOWORD(::StatusBar_GetTextLength(hwndStatusBar, index));
+				if( prevLen >= _countof(prev) ){
 					::StatusBar_SetText(hwndStatusBar, index | opt, text);
+				}else{
+					// 既に同じ値が設定されている場合は再設定しないようにする
+					::StatusBar_GetText(hwndStatusBar, index, prev);
+					if( ::wcsncmp(prev, text, _countof(prev)-1) != 0 ){
+						::StatusBar_SetText(hwndStatusBar, index | opt, text);
+					}
 				}
 			}
 		};

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -860,31 +860,36 @@ void CCaret::ShowCaretPosInfo()
 		}else{
 			_tcscpy( szText_6, LS( STR_INS_MODE_OVR ) );	// "上書"
 		}
-		TCHAR szText_2[64];
-		auto updateStatusBarText = [&](WPARAM opt, const TCHAR* str){
-			if (HIBYTE(opt)) {
-				::StatusBar_SetText( hwndStatusBar, opt, str );
-			}else {
+		// ステータスバーを更新するためのインライン関数
+		auto updateStatusBarText = [hwndStatusBar](_In_ BYTE index, _In_ WORD opt, _In_z_ const TCHAR* text) {
+			if (opt != 0) {
+				::StatusBar_SetText(hwndStatusBar, index | opt, text);
+			}
+			else {
 				// 既に同じ値が設定されている場合は再設定しないようにする
-				assert(LOWORD(::StatusBar_GetTextLength( hwndStatusBar, LOBYTE(opt))) <= _countof(szText_2)-1);
-				::StatusBar_GetText( hwndStatusBar, LOBYTE(opt), szText_2 );
-				if (wcscmp(str, szText_2) != 0)
-					::StatusBar_SetText( hwndStatusBar, opt, str );
+				TCHAR prev[64] = _T(""); //←サイズは szText_1 に合わせている
+				if (::StatusBar_GetTextLength(hwndStatusBar, index) <= _countof(prev) - 1) {
+					//表示テキストがバッファに収まるようなら取得、そうでなければ取得しない。
+					::StatusBar_GetText(hwndStatusBar, index, prev);
+				}
+				if (::wcscmp(prev, text) != 0) {
+					::StatusBar_SetText(hwndStatusBar, index | opt, text);
+				}
 			}
 		};
 		if( m_bClearStatus ){
-			updateStatusBarText( 0 | SBT_NOBORDERS, _T("") );
+			updateStatusBarText( 0, SBT_NOBORDERS, _T("") );
 		}
-		updateStatusBarText( 1 | 0,             szText_1 );
+		updateStatusBarText( 1, NULL,          szText_1 );
 		//	May 12, 2000 genta
 		//	改行コードの表示を追加．後ろの番号を1つずつずらす
 		//	From Here
-		updateStatusBarText( 2 | 0,             szEolMode );
+		updateStatusBarText( 2, NULL,          szEolMode );
 		//	To Here
-		updateStatusBarText( 3 | 0,             szCaretChar );
-		updateStatusBarText( 4 | 0,             pszCodeName );
-		updateStatusBarText( 5 | SBT_OWNERDRAW, _T("") );
-		updateStatusBarText( 6 | 0,             szText_6 );
+		updateStatusBarText( 3, NULL,          szCaretChar );
+		updateStatusBarText( 4, NULL,          pszCodeName );
+		updateStatusBarText( 5, SBT_OWNERDRAW, _T("") );
+		updateStatusBarText( 6, NULL,          szText_6 );
 	}
 
 }

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -860,38 +860,22 @@ void CCaret::ShowCaretPosInfo()
 		}else{
 			_tcscpy( szText_6, LS( STR_INS_MODE_OVR ) );	// "上書"
 		}
-		// ステータスバーを更新するためのインライン関数
-		auto updateStatusBarText = [hwndStatusBar](_In_ BYTE index, _In_ WORD opt, _In_z_ const TCHAR* text) {
-			if( opt != 0 ){
-				::StatusBar_SetText(hwndStatusBar, index | opt, text);
-			}else{
-				TCHAR prev[64];
-				static_assert(sizeof(prev) >= sizeof(szText_1), "not sufficient size.");
-				WORD prevLen = LOWORD(::StatusBar_GetTextLength(hwndStatusBar, index));
-				if( prevLen >= _countof(prev) ){
-					::StatusBar_SetText(hwndStatusBar, index | opt, text);
-				}else{
-					// 既に同じ値が設定されている場合は再設定しないようにする
-					::StatusBar_GetText(hwndStatusBar, index, prev);
-					if( ::wcsncmp(prev, text, _countof(prev)-1) != 0 ){
-						::StatusBar_SetText(hwndStatusBar, index | opt, text);
-					}
-				}
-			}
-		};
+
+		auto& statusBar = m_pEditDoc->m_pcEditWnd->m_cStatusBar;
+
 		if( m_bClearStatus ){
-			updateStatusBarText( 0, SBT_NOBORDERS, _T("") );
+			statusBar.SetStatusText( 0, SBT_NOBORDERS, _T("") );
 		}
-		updateStatusBarText( 1, NULL,          szText_1 );
+		statusBar.SetStatusText( 1, NULL,          szText_1 );
 		//	May 12, 2000 genta
 		//	改行コードの表示を追加．後ろの番号を1つずつずらす
 		//	From Here
-		updateStatusBarText( 2, NULL,          szEolMode );
+		statusBar.SetStatusText( 2, NULL,          szEolMode );
 		//	To Here
-		updateStatusBarText( 3, NULL,          szCaretChar );
-		updateStatusBarText( 4, NULL,          pszCodeName );
-		updateStatusBarText( 5, SBT_OWNERDRAW, _T("") );
-		updateStatusBarText( 6, NULL,          szText_6 );
+		statusBar.SetStatusText( 3, NULL,          szCaretChar );
+		statusBar.SetStatusText( 4, NULL,          pszCodeName );
+		statusBar.SetStatusText( 5, SBT_OWNERDRAW, _T("") );
+		statusBar.SetStatusText( 6, NULL,          szText_6 );
 	}
 
 }

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -860,19 +860,26 @@ void CCaret::ShowCaretPosInfo()
 		}else{
 			_tcscpy( szText_6, LS( STR_INS_MODE_OVR ) );	// "上書"
 		}
+		TCHAR szText_2[64];
+		auto updateStatusBarText = [&](WPARAM opt, const TCHAR* str){
+			// 既に同じ値が設定されている場合は再設定しないようにする
+			::StatusBar_GetText( hwndStatusBar, opt, szText_2 );
+			if (wcscmp(str, szText_2) != 0)
+				::StatusBar_SetText( hwndStatusBar, opt, str );
+		};
 		if( m_bClearStatus ){
-			::StatusBar_SetText( hwndStatusBar, 0 | SBT_NOBORDERS, _T("") );
+			updateStatusBarText( 0 | SBT_NOBORDERS, _T("") );
 		}
-		::StatusBar_SetText( hwndStatusBar, 1 | 0,             szText_1 );
+		updateStatusBarText( 1 | 0,             szText_1 );
 		//	May 12, 2000 genta
 		//	改行コードの表示を追加．後ろの番号を1つずつずらす
 		//	From Here
-		::StatusBar_SetText( hwndStatusBar, 2 | 0,             szEolMode );
+		updateStatusBarText( 2 | 0,             szEolMode );
 		//	To Here
-		::StatusBar_SetText( hwndStatusBar, 3 | 0,             szCaretChar );
-		::StatusBar_SetText( hwndStatusBar, 4 | 0,             pszCodeName );
-		::StatusBar_SetText( hwndStatusBar, 5 | SBT_OWNERDRAW, _T("") );
-		::StatusBar_SetText( hwndStatusBar, 6 | 0,             szText_6 );
+		updateStatusBarText( 3 | 0,             szCaretChar );
+		updateStatusBarText( 4 | 0,             pszCodeName );
+		updateStatusBarText( 5 | SBT_OWNERDRAW, _T("") );
+		updateStatusBarText( 6 | 0,             szText_6 );
 	}
 
 }

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -862,11 +862,15 @@ void CCaret::ShowCaretPosInfo()
 		}
 		TCHAR szText_2[64];
 		auto updateStatusBarText = [&](WPARAM opt, const TCHAR* str){
-			// 既に同じ値が設定されている場合は再設定しないようにする
-			assert(LOWORD(::StatusBar_GetTextLength( hwndStatusBar, opt)) <= _countof(szText_2)-1);
-			::StatusBar_GetText( hwndStatusBar, opt, szText_2 );
-			if (wcscmp(str, szText_2) != 0)
+			if (HIBYTE(opt)) {
 				::StatusBar_SetText( hwndStatusBar, opt, str );
+			}else {
+				// 既に同じ値が設定されている場合は再設定しないようにする
+				assert(LOWORD(::StatusBar_GetTextLength( hwndStatusBar, LOBYTE(opt))) <= _countof(szText_2)-1);
+				::StatusBar_GetText( hwndStatusBar, LOBYTE(opt), szText_2 );
+				if (wcscmp(str, szText_2) != 0)
+					::StatusBar_SetText( hwndStatusBar, opt, str );
+			}
 		};
 		if( m_bClearStatus ){
 			updateStatusBarText( 0 | SBT_NOBORDERS, _T("") );

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -863,6 +863,7 @@ void CCaret::ShowCaretPosInfo()
 		TCHAR szText_2[64];
 		auto updateStatusBarText = [&](WPARAM opt, const TCHAR* str){
 			// 既に同じ値が設定されている場合は再設定しないようにする
+			assert(LOWORD(::StatusBar_GetTextLength( hwndStatusBar, opt)) <= _countof(szText_2)-1);
 			::StatusBar_GetText( hwndStatusBar, opt, szText_2 );
 			if (wcscmp(str, szText_2) != 0)
 				::StatusBar_SetText( hwndStatusBar, opt, str );

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -115,28 +115,25 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const TCHAR* pszText
 		assert(m_hwndStatusBar != NULL);
 		return;
 	}
-	do{
+	[&]() -> bool {
 		if( pszText == NULL || nOption == SBT_OWNERDRAW){
-			break;
+			return true;
 		}
 		LRESULT res = ::StatusBar_GetTextLength( m_hwndStatusBar, nIndex );
 		size_t prevTextLen = LOWORD(res);
 		TCHAR prev[1024];
 		if( prevTextLen >= _countof(prev) || HIWORD(res) != nOption ){
-			break;
+			return true;
 		}
 		if( textLen == SIZE_MAX ){
 			textLen = wcslen(pszText);
 		}
 		if( prevTextLen != textLen ){
-			break;
+			return true;
 		}
 		::StatusBar_GetText( m_hwndStatusBar, nIndex, prev );
-		if( wcscmp(prev, pszText) == 0 ){
-			return;
-		}
-	}while( false );
-	StatusBar_SetText( m_hwndStatusBar, nIndex | nOption, pszText );
+		return (wcscmp(prev, pszText) != 0);
+	}() ? StatusBar_SetText( m_hwndStatusBar, nIndex | nOption, pszText ) : 0;
 }
 
 

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -116,7 +116,7 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const TCHAR* pszText
 		return;
 	}
 	do{
-		if( pszText == NULL ){
+		if( pszText == NULL || nOption == SBT_OWNERDRAW){
 			break;
 		}
 		LRESULT res = ::StatusBar_GetTextLength( m_hwndStatusBar, nIndex );

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -98,7 +98,12 @@ void CMainStatusBar::SendStatusMessage2( const TCHAR* msg )
 {
 	if( NULL != m_hwndStatusBar ){
 		// ステータスバーへ
-		StatusBar_SetText( m_hwndStatusBar,0 | SBT_NOBORDERS,msg );
+		// 既に同じ値が設定されている場合は再設定しないようにする
+		TCHAR msg2[256];
+		assert(LOWORD(::StatusBar_GetTextLength( m_hwndStatusBar, 0)) <= _countof(msg2)-1);
+		::StatusBar_GetText( m_hwndStatusBar, 0, msg2 );
+		if (wcscmp(msg, msg2) != 0)
+			StatusBar_SetText( m_hwndStatusBar,0 | SBT_NOBORDERS,msg );
 	}
 }
 

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -101,11 +101,18 @@ void CMainStatusBar::SendStatusMessage2( const TCHAR* msg )
 	}
 }
 
-
+/*!
+	@brief 文字列をステータスバーの指定されたパートに表示する
+	
+	@param nIndex [in] パートのインデクス
+	@param nOption [in] 描画オペレーションタイプ
+	@param pszText [in] 表示テキスト
+	@param textLen [in] 表示テキストの文字数
+*/
 void CMainStatusBar::SetStatusText(int nIndex, int nOption, const TCHAR* pszText, size_t textLen /* = SIZE_MAX */)
 {
 	if( !m_hwndStatusBar ){
-		assert(false);
+		assert(m_hwndStatusBar != NULL);
 		return;
 	}
 	do{

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -131,7 +131,7 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const TCHAR* pszText
 		if( prevTextLen != textLen ){
 			break;
 		}
-		::StatusBar_GetText( m_hwndStatusBar, nIndex | nOption, prev );
+		::StatusBar_GetText( m_hwndStatusBar, nIndex, prev );
 		if( wcscmp(prev, pszText) == 0 ){
 			return;
 		}

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -97,24 +97,38 @@ void CMainStatusBar::DestroyStatusBar()
 void CMainStatusBar::SendStatusMessage2( const TCHAR* msg )
 {
 	if( NULL != m_hwndStatusBar ){
-		// ステータスバーへ
-		TCHAR prev[256];
-		WORD prevLen = LOWORD(::StatusBar_GetTextLength( m_hwndStatusBar, 0));
-		if (prevLen >= _countof(prev)) {
-			StatusBar_SetText( m_hwndStatusBar,0 | SBT_NOBORDERS,msg );
-		}else {
-			// 既に同じ値が設定されている場合は再設定しないようにする
-			::StatusBar_GetText( m_hwndStatusBar, 0, prev );
-			if (wcsncmp(msg, prev, _countof(prev)-1) != 0) {
-				StatusBar_SetText( m_hwndStatusBar,0 | SBT_NOBORDERS,msg );
-			}
-		}
+		SetStatusText(0, SBT_NOBORDERS, msg);
 	}
 }
 
 
-void CMainStatusBar::SetStatusText(int nIndex, int nOption, const TCHAR* pszText)
+void CMainStatusBar::SetStatusText(int nIndex, int nOption, const TCHAR* pszText, size_t textLen /* = SIZE_MAX */)
 {
+	if( !m_hwndStatusBar ){
+		assert(false);
+		return;
+	}
+	do{
+		if( pszText == NULL ){
+			break;
+		}
+		LRESULT res = ::StatusBar_GetTextLength( m_hwndStatusBar, nIndex );
+		size_t prevTextLen = LOWORD(res);
+		TCHAR prev[1024];
+		if( prevTextLen >= _countof(prev) || HIWORD(res) != nOption ){
+			break;
+		}
+		if( textLen == SIZE_MAX ){
+			textLen = wcslen(pszText);
+		}
+		if( prevTextLen != textLen ){
+			break;
+		}
+		::StatusBar_GetText( m_hwndStatusBar, nIndex | nOption, prev );
+		if( wcscmp(prev, pszText) == 0 ){
+			return;
+		}
+	}while( false );
 	StatusBar_SetText( m_hwndStatusBar, nIndex | nOption, pszText );
 }
 

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -98,12 +98,17 @@ void CMainStatusBar::SendStatusMessage2( const TCHAR* msg )
 {
 	if( NULL != m_hwndStatusBar ){
 		// ステータスバーへ
-		// 既に同じ値が設定されている場合は再設定しないようにする
-		TCHAR msg2[256];
-		assert(LOWORD(::StatusBar_GetTextLength( m_hwndStatusBar, 0)) <= _countof(msg2)-1);
-		::StatusBar_GetText( m_hwndStatusBar, 0, msg2 );
-		if (wcscmp(msg, msg2) != 0)
+		TCHAR prev[256];
+		WORD prevLen = LOWORD(::StatusBar_GetTextLength( m_hwndStatusBar, 0));
+		if (prevLen >= _countof(prev)) {
 			StatusBar_SetText( m_hwndStatusBar,0 | SBT_NOBORDERS,msg );
+		}else {
+			// 既に同じ値が設定されている場合は再設定しないようにする
+			::StatusBar_GetText( m_hwndStatusBar, 0, prev );
+			if (wcsncmp(msg, prev, _countof(prev)-1) != 0) {
+				StatusBar_SetText( m_hwndStatusBar,0 | SBT_NOBORDERS,msg );
+			}
+		}
 	}
 }
 

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -52,7 +52,7 @@ public:
 	HWND GetProgressHwnd() const{ return m_hwndProgressBar; }
 
 	//設定
-	void SetStatusText(int nIndex, int nOption, const TCHAR* pszText);
+	void SetStatusText(int nIndex, int nOption, const TCHAR* pszText, size_t textLen = SIZE_MAX);
 private:
 	CEditWnd*	m_pOwner;
 	HWND		m_hwndStatusBar;


### PR DESCRIPTION
既に同じ値が設定されている場合は再設定しないようにする事で以下の効果がある事を確認しました。
- ステータスバーのテキストのちらつきが低減する
- カーソル移動操作時のCPU使用率が低減する

ステータスバーを表示した状態で、カーソルキーを押し続けてカーソル移動をリピートで行う事で確認が出来ます。

## `LockScreenUpdate` について

ステータスバーにテキストを設定する複数の呼び出しを `LockScreenUpdate` で囲む方法も試しましたが、下記の問題がある為に行わないようにしました。

- `画面キャッシュを使う` 設定にしないと画面がちらつく
- カーソル移動操作中のCPU使用率が上がる
  プロファイラで見ると `CCaret::ShowCaretPosInfo` のCPU使用率は下がりますが、タスクマネージャーで見ると上がっていました。