### PR TITLE
bregonig のライセンスファイルをライセンス用のサブフォルダに配置する

### DIFF
--- a/build-installer.bat
+++ b/build-installer.bat
@@ -36,13 +36,14 @@ if exist "%INSTALLER_WORK%"      rmdir /s /q "%INSTALLER_WORK%"
 if exist "%INSTALLER_OUTPUT%"    rmdir /s /q "%INSTALLER_OUTPUT%"
 
 mkdir %INSTALLER_WORK%
+mkdir %INSTALLER_WORK%\license\bregonig
 mkdir %INSTALLER_WORK%\keyword
 
 copy /Y %INSTALLER_RESOURCES_SINT%\sakura.exe.manifest.x %INSTALLER_WORK%\
 copy /Y %INSTALLER_RESOURCES_SINT%\sakura.exe.manifest.v %INSTALLER_WORK%\
 copy /Y %INSTALLER_RESOURCES_SINT%\sakura.exe.ini        %INSTALLER_WORK%\
 copy /Y %INSTALLER_RESOURCES_SINT%\keyword\*.*           %INSTALLER_WORK%\keyword\
-copy /Y %INSTALLER_RESOURCES_BRON%\*.txt                 %INSTALLER_WORK%\
+copy /Y %INSTALLER_RESOURCES_BRON%\*.txt                 %INSTALLER_WORK%\license\bregonig\
 
 copy /Y /B help\sakura\sakura.chm                           %INSTALLER_WORK%\
 copy /Y /B help\plugin\plugin.chm                           %INSTALLER_WORK%\

--- a/installer/sakura-common.iss
+++ b/installer/sakura-common.iss
@@ -69,9 +69,7 @@ Name: sendto;      Description: "送るに追加(&T)";                     Compo
 Source: "sakura\sakura.exe";           DestDir: "{app}";         Components: main; Flags: ignoreversion;
 Source: "sakura\sakura_lang_en_US.dll";DestDir: "{app}";         Components: main; Flags: ignoreversion;
 Source: "sakura\bregonig.dll";         DestDir: "{app}";         Components: main
-Source: "sakura\bsd_license.txt";      DestDir: "{app}";         Components: main
-Source: "sakura\perl_license.txt";     DestDir: "{app}";         Components: main
-Source: "sakura\perl_license_jp.txt";  DestDir: "{app}";         Components: main
+Source: "sakura\license\bregonig\*";   DestDir: "{app}\license\bregonig"; Components: main
 Source: "sakura\sakura.exe.manifest.x";DestDir: "{app}";         Components: main; DestName: "sakura.exe.manifest"; Check: isMultiUserDisabled; Flags: onlyifdoesntexist;
 Source: "sakura\sakura.exe.manifest.v";DestDir: "{app}";         Components: main; DestName: "sakura.exe.manifest"; Check: isMultiUserEnabled; Flags: onlyifdoesntexist;
 Source: "sakura\sakura.chm";           DestDir: "{app}";         Components: help


### PR DESCRIPTION
bregonig のライセンスファイルをライセンス用のサブフォルダに配置する

- #454 の対応で思いつきました。
- この PR 対応前のインストーラでインストールした状況でアップデートインストールすると アプリフォルダ直下の ライセンスファイルは残ります。
- いったんアンインストールしてからインストールするとアプリフォルダ直下の ライセンスファイルは消えます。