### PR TITLE
ツールバーの状態更新を必要な場合にのみ行うように変更

### DIFF
--- a/sakura_core/apiwrap/CommonControl.h
+++ b/sakura_core/apiwrap/CommonControl.h
@@ -78,6 +78,8 @@ namespace ApiWrap
 	inline int Toolbar_SetButtonInfo(HWND hwndCtl, int index, TBBUTTONINFO* info)	{ return (int)(DWORD)::SendMessage(hwndCtl, TB_SETBUTTONINFO, (WPARAM)index, (LPARAM)info); }
 	inline BOOL Toolbar_SetButtonSize(HWND hwndCtl, int width, int height)			{ return (BOOL)(DWORD)::SendMessage(hwndCtl, TB_SETBUTTONSIZE, 0L, MAKELONG(width, height)); }
 	inline DWORD Toolbar_SetExtendedStyle(HWND hwndCtl, DWORD styles)				{ return (DWORD)::SendMessage(hwndCtl, TB_SETEXTENDEDSTYLE, 0L, (LPARAM)styles); }
+	inline int Toolbar_GetState(HWND hwndCtl, int index)							{ return (int)(DWORD)::SendMessage(hwndCtl, TB_GETSTATE, (WPARAM)index, 0L); }
+	inline int Toolbar_SetState(HWND hwndCtl, int index, WORD state)				{ return (int)(DWORD)::SendMessage(hwndCtl, TB_SETSTATE, (WPARAM)index, state); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      Tooltip コントロール                   //

--- a/sakura_core/apiwrap/CommonControl.h
+++ b/sakura_core/apiwrap/CommonControl.h
@@ -78,8 +78,8 @@ namespace ApiWrap
 	inline int Toolbar_SetButtonInfo(HWND hwndCtl, int index, TBBUTTONINFO* info)	{ return (int)(DWORD)::SendMessage(hwndCtl, TB_SETBUTTONINFO, (WPARAM)index, (LPARAM)info); }
 	inline BOOL Toolbar_SetButtonSize(HWND hwndCtl, int width, int height)			{ return (BOOL)(DWORD)::SendMessage(hwndCtl, TB_SETBUTTONSIZE, 0L, MAKELONG(width, height)); }
 	inline DWORD Toolbar_SetExtendedStyle(HWND hwndCtl, DWORD styles)				{ return (DWORD)::SendMessage(hwndCtl, TB_SETEXTENDEDSTYLE, 0L, (LPARAM)styles); }
-	inline int Toolbar_GetState(HWND hwndCtl, int index)							{ return (int)(DWORD)::SendMessage(hwndCtl, TB_GETSTATE, (WPARAM)index, 0L); }
-	inline int Toolbar_SetState(HWND hwndCtl, int index, WORD state)				{ return (int)(DWORD)::SendMessage(hwndCtl, TB_SETSTATE, (WPARAM)index, state); }
+	inline int Toolbar_GetState(HWND hwndCtl, int index)							{ return (int)::SendMessage(hwndCtl, TB_GETSTATE, (WPARAM)index, 0L); }
+	inline BOOL Toolbar_SetState(HWND hwndCtl, int index, WORD state)				{ return (BOOL)::SendMessage(hwndCtl, TB_SETSTATE, (WPARAM)index, state); }
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      Tooltip コントロール                   //

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -506,20 +506,21 @@ void CMainToolBar::UpdateToolbar( void )
 			TBBUTTON tbb = m_pOwner->GetMenuDrawer().getButton(
 				GetDllShareData().m_Common.m_sToolBar.m_nToolBarButtonIdxArr[i]
 			);
-
-			// 機能が利用可能か調べる
-			Toolbar_EnableButton(
-				m_hwndToolBar,
-				tbb.idCommand,
-				IsFuncEnable( m_pOwner->GetDocument(), &GetDllShareData(), (EFunctionCode)tbb.idCommand )
-			);
-
-			// 機能がチェック状態か調べる
-			Toolbar_CheckButton(
-				m_hwndToolBar,
-				tbb.idCommand,
-				IsFuncChecked( m_pOwner->GetDocument(), &GetDllShareData(), (EFunctionCode)tbb.idCommand )
-			);
+			int state = Toolbar_GetState(m_hwndToolBar, tbb.idCommand);
+			if( state != -1 )
+			{
+				WORD stateToSet = 0;
+				// 機能が利用可能か調べる
+				if( IsFuncEnable( m_pOwner->GetDocument(), &GetDllShareData(), (EFunctionCode)tbb.idCommand ) )
+					stateToSet |= TBSTATE_ENABLED;
+				// 機能がチェック状態か調べる
+				if( IsFuncChecked( m_pOwner->GetDocument(), &GetDllShareData(), (EFunctionCode)tbb.idCommand ) )
+					stateToSet |= TBSTATE_CHECKED;
+				if( state != stateToSet )
+				{
+					Toolbar_SetState(m_hwndToolBar, tbb.idCommand, stateToSet);
+				}
+			}
 		}
 	}
 }

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -506,19 +506,23 @@ void CMainToolBar::UpdateToolbar( void )
 			TBBUTTON tbb = m_pOwner->GetMenuDrawer().getButton(
 				GetDllShareData().m_Common.m_sToolBar.m_nToolBarButtonIdxArr[i]
 			);
-			int state = Toolbar_GetState(m_hwndToolBar, tbb.idCommand);
+			int state = Toolbar_GetState( m_hwndToolBar, tbb.idCommand );
 			if( state != -1 )
 			{
 				WORD stateToSet = 0;
 				// 機能が利用可能か調べる
 				if( IsFuncEnable( m_pOwner->GetDocument(), &GetDllShareData(), (EFunctionCode)tbb.idCommand ) )
+				{
 					stateToSet |= TBSTATE_ENABLED;
+				}
 				// 機能がチェック状態か調べる
 				if( IsFuncChecked( m_pOwner->GetDocument(), &GetDllShareData(), (EFunctionCode)tbb.idCommand ) )
+				{
 					stateToSet |= TBSTATE_CHECKED;
+				}
 				if( state != stateToSet )
 				{
-					Toolbar_SetState(m_hwndToolBar, tbb.idCommand, stateToSet);
+					Toolbar_SetState( m_hwndToolBar, tbb.idCommand, stateToSet );
 				}
 			}
 		}


### PR DESCRIPTION
`CEditWnd::Timer_ONOFF` にて 300ミリ秒間隔でツールバー更新用のタイマーが起動されて、`CMainToolBar::UpdateToolbar` メソッドが定期的に実行されます。

その中で行われているツールバーのボタンを設定する処理方法を変更しました。

有効無効の設定で `Toolbar_EnableButton` 関数が、
チェック状態の設定で `Toolbar_CheckButton` 関数が使われていましたが、
新規に追加した `Toolbar_SetState` 関数を使って一括で行うようにしました。

また事前に、新規に追加した  `Toolbar_GetState` 関数を使ってボタンの状態を取得して、
設定が必要ない場合は `Toolbar_SetState` 関数を呼ばないようにしています。

無駄に処理を行わない事でCPU使用率をとてもわずかですが下げる効果が有ります。