### PR TITLE
IME編集エリアの位置変更を行う ImmSetCompositionWindow の呼び出しは IMEが開いている時だけに限定

### DIFF
--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -79,7 +79,7 @@ void CEditView::SetIMECompFormPos( void )
 		if ( ::ImmGetOpenStatus( hIMC ) ){
 			POINT point;
 			::GetCaretPos( &point );
-			COMPOSITIONFORM	CompForm;
+			COMPOSITIONFORM CompForm;
 			CompForm.dwStyle = CFS_POINT;
 			CompForm.ptCurrentPos.x = (long) point.x;
 			CompForm.ptCurrentPos.y = (long) point.y + GetCaret().GetCaretSize().cy - GetTextMetrics().GetHankakuHeight();

--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -74,16 +74,14 @@ void CEditView::SetIMECompFormPos( void )
 	// composition window position.
 	//
 	//
-	COMPOSITIONFORM	CompForm;
-	HIMC			hIMC = ::ImmGetContext( GetHwnd() );
-	POINT			point;
-
-	::GetCaretPos( &point );
-	CompForm.dwStyle = CFS_POINT;
-	CompForm.ptCurrentPos.x = (long) point.x;
-	CompForm.ptCurrentPos.y = (long) point.y + GetCaret().GetCaretSize().cy - GetTextMetrics().GetHankakuHeight();
-
-	if ( hIMC ){
+	HIMC hIMC = ::ImmGetContext( GetHwnd() );
+	if ( hIMC && ::ImmGetOpenStatus(hIMC) ){
+		POINT point;
+		::GetCaretPos( &point );
+		COMPOSITIONFORM	CompForm;
+		CompForm.dwStyle = CFS_POINT;
+		CompForm.ptCurrentPos.x = (long) point.x;
+		CompForm.ptCurrentPos.y = (long) point.y + GetCaret().GetCaretSize().cy - GetTextMetrics().GetHankakuHeight();
 		::ImmSetCompositionWindow( hIMC, &CompForm );
 	}
 	::ImmReleaseContext( GetHwnd() , hIMC );

--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -75,16 +75,18 @@ void CEditView::SetIMECompFormPos( void )
 	//
 	//
 	HIMC hIMC = ::ImmGetContext( GetHwnd() );
-	if ( hIMC && ::ImmGetOpenStatus(hIMC) ){
-		POINT point;
-		::GetCaretPos( &point );
-		COMPOSITIONFORM	CompForm;
-		CompForm.dwStyle = CFS_POINT;
-		CompForm.ptCurrentPos.x = (long) point.x;
-		CompForm.ptCurrentPos.y = (long) point.y + GetCaret().GetCaretSize().cy - GetTextMetrics().GetHankakuHeight();
-		::ImmSetCompositionWindow( hIMC, &CompForm );
+	if ( hIMC ){
+		if ( ::ImmGetOpenStatus( hIMC ) ){
+			POINT point;
+			::GetCaretPos( &point );
+			COMPOSITIONFORM	CompForm;
+			CompForm.dwStyle = CFS_POINT;
+			CompForm.ptCurrentPos.x = (long) point.x;
+			CompForm.ptCurrentPos.y = (long) point.y + GetCaret().GetCaretSize().cy - GetTextMetrics().GetHankakuHeight();
+			::ImmSetCompositionWindow( hIMC, &CompForm );
+		}
+		::ImmReleaseContext( GetHwnd() , hIMC );
 	}
-	::ImmReleaseContext( GetHwnd() , hIMC );
 }
 
 


### PR DESCRIPTION
スクロールや範囲選択の操作中に `CEditView::SetIMECompFormPos` メソッド内で呼ばれている `ImmSetCompositionWindow` 関数の呼び出しに CPU 時間を結構消費している事をプロファイラで確認しました。

対策として、IMEが開いているかを `ImmGetOpenStatus` で確認して開いている場合にのみ呼び出すようにしました。