### PR TITLE
ヘルプの説明を exuberant ctags → Universal ctags に変更する

### DIFF
--- a/help/sakura/_RESOURCE/HLP000261.html
+++ b/help/sakura/_RESOURCE/HLP000261.html
@@ -58,7 +58,7 @@ i …INI形式(に見える)ファイル<br>
 	<dt><a href="HLP000251.html">GNU diff</a> 中のdiff.exe</dt>
 	<dd>Diff機能に必要です。</dd>
 
-	<dt><a href="HLP000278.html">Universal ctags</a> 中のctags.exe</dt>
+	<dt><a href="HLP000278.html">Universal Ctags</a> 中のctags.exe</dt>
 	<dd>ダイレクトタグジャンプのtagsファイル生成に必要です。(インストーラパッケージには含まれています)</dd>
 
 	<dt><a href="HLP000308.html">Migemo.dll</a></dt>

--- a/help/sakura/_RESOURCE/HLP000278.html
+++ b/help/sakura/_RESOURCE/HLP000278.html
@@ -15,7 +15,7 @@
 
 <b>ver 2.4.0.0 以降の場合</b><br>
 
-<div class=li200><a href="https://github.com/universal-ctags/ctags-win32/releases" target=_blank>Universal ctags</a> がインストーラパッケージおよび appveyor の成果物に同梱されています。<br>
+<div class=li200><a href="https://github.com/universal-ctags/ctags-win32/releases" target=_blank>Universal Ctags</a> がインストーラパッケージおよび appveyor の成果物に同梱されています。<br>
 同梱されているバージョンと異なるバージョンを使いたい場合以外何もする必要はありません。
 </div><br>
 
@@ -25,11 +25,11 @@
 以下のいずれかの ctags をダウンロードして ctags.exeを sakura.exe と同一フォルダに置きます。<br>
 
 <ul>
-<li><a href="https://github.com/universal-ctags/ctags-win32/releases" target=_blank>Universal ctags</a> (現在積極的に開発されている)</li>
+<li><a href="https://github.com/universal-ctags/ctags-win32/releases" target=_blank>Universal Ctags</a> (現在積極的に開発されている)</li>
 <li><a href="http://hp.vector.co.jp/authors/VA025040/" target=_blank>Exuberant Ctags 日本語対応版</a> (現在更新が止まっている)</li>
 </ul>
 
-Universal ctags には x86版 (32bit)と x64版(64bit) があります。sakura.exe と同じタイプ(x86版 or x64版)をダウンロードします。<br>
+Universal Ctags には x86版 (32bit)と x64版(64bit) があります。sakura.exe と同じタイプ(x86版 or x64版)をダウンロードします。<br>
 Exuberant Ctags の場合 Win32版をダウンロードします。<br>
 <br>
 アーカイブに含まれている ctags.exe を sakura.exeと同一フォルダに置きます。<br>


### PR DESCRIPTION
#454, #458:  ヘルプの説明を exuberant ctags → Universal ctags に変更する