### PR TITLE
ツールバーを非表示から表示に切り替える際にアイコンの状態を設定する処理を呼び出し

### DIFF
--- a/sakura_core/cmd/CViewCommander_Settings.cpp
+++ b/sakura_core/cmd/CViewCommander_Settings.cpp
@@ -38,8 +38,11 @@ void CViewCommander::Command_SHOWTOOLBAR( void )
 {
 	CEditWnd*	pCEditWnd = GetEditWindow();	//	Sep. 10, 2002 genta
 
-	GetDllShareData().m_Common.m_sWindow.m_bDispTOOLBAR = ((NULL == pCEditWnd->m_cToolbar.GetToolbarHwnd())? TRUE: FALSE);	/* ツールバー表示 */
+	auto& cToolbar = pCEditWnd->m_cToolbar;
+	GetDllShareData().m_Common.m_sWindow.m_bDispTOOLBAR = ((NULL == cToolbar.GetToolbarHwnd())? TRUE: FALSE);	/* ツールバー表示 */
 	pCEditWnd->LayoutToolBar();
+	if (cToolbar.GetToolbarHwnd())
+		cToolbar.UpdateToolbar();
 	pCEditWnd->EndLayoutBars();
 
 	//全ウインドウに変更を通知する。

--- a/sakura_core/cmd/CViewCommander_Settings.cpp
+++ b/sakura_core/cmd/CViewCommander_Settings.cpp
@@ -41,8 +41,6 @@ void CViewCommander::Command_SHOWTOOLBAR( void )
 	auto& cToolbar = pCEditWnd->m_cToolbar;
 	GetDllShareData().m_Common.m_sWindow.m_bDispTOOLBAR = ((NULL == cToolbar.GetToolbarHwnd())? TRUE: FALSE);	/* ツールバー表示 */
 	pCEditWnd->LayoutToolBar();
-	if (cToolbar.GetToolbarHwnd())
-		cToolbar.UpdateToolbar();
 	pCEditWnd->EndLayoutBars();
 
 	//全ウインドウに変更を通知する。

--- a/sakura_core/cmd/CViewCommander_Settings.cpp
+++ b/sakura_core/cmd/CViewCommander_Settings.cpp
@@ -38,8 +38,7 @@ void CViewCommander::Command_SHOWTOOLBAR( void )
 {
 	CEditWnd*	pCEditWnd = GetEditWindow();	//	Sep. 10, 2002 genta
 
-	auto& cToolbar = pCEditWnd->m_cToolbar;
-	GetDllShareData().m_Common.m_sWindow.m_bDispTOOLBAR = ((NULL == cToolbar.GetToolbarHwnd())? TRUE: FALSE);	/* ツールバー表示 */
+	GetDllShareData().m_Common.m_sWindow.m_bDispTOOLBAR = ((NULL == pCEditWnd->m_cToolbar.GetToolbarHwnd())? TRUE: FALSE);	/* ツールバー表示 */
 	pCEditWnd->LayoutToolBar();
 	pCEditWnd->EndLayoutBars();
 

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -980,6 +980,7 @@ void CEditWnd::LayoutToolBar( void )
 {
 	if( m_pShareData->m_Common.m_sWindow.m_bDispTOOLBAR ){	/* ツールバーを表示する */
 		m_cToolbar.CreateToolBar();
+		m_cToolbar.UpdateToolbar();
 	}else{
 		m_cToolbar.DestroyToolBar();
 	}


### PR DESCRIPTION
キーボードの `Ctrl + 1` を繰り返し押してツールバーの表示切替を行っていると、非表示 → 表示 した直後にツールバーのアイコンの見た目が無効から有効に変化する場合がある事に気づきました。

これはタイマーでツールバーのアイコンを設定する `CMainToolBar::UpdateToolbar` が呼び出されている為に、切替タイミングによってはまだアイコンの見た目が設定されていない状態が見えてしまう為です。

この PR では `CViewCommander::Command_SHOWTOOLBAR` の中においても明示的に呼び出す事で、ツールバーを 非表示 → 表示 に切り替えた直後からアイコンが適切な表示状態になるようにしました。
