### PR TITLE
test-int2dec.cpp を UTF-8 BOM 付きで保存する

### DIFF
--- a/tests/unittests/test-int2dec.cpp
+++ b/tests/unittests/test-int2dec.cpp
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+﻿#include <gtest/gtest.h>
 
 #include <limits>
 #define NOMINMAX


### PR DESCRIPTION
#112: test-int2dec.cpp を UTF-8 BOM 付きで保存する

test-int2dec.cpp は ASCII 文字しか含まないのでさしあたり UTF8 で
保存する必要はないが、日本語を使いたくなったときに間違って
Shift-JIS にならないのを保証するために UTF-8 BOM 付きで保存する
