### PR TITLE
LICENSEファイルを追加する

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+﻿zlib License
+
+Copyright (C) 2018 Sakura Editor Organization
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+Sakura Editor Organization
+https://sakura-editor.github.io/


### PR DESCRIPTION
## 目的

GitHubのリポジトリ一覧でライセンス表示が出るようにします。
（`zlib license` は `Other` と表示されます。）

インストーラに同梱するライセンスファイルの話 #41 と関連します。
