### PR TITLE
appveyor で文字コードをチェックして UTF-8 になっていなかったら処理を失敗させる

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,8 @@ platform:
 
 build_script:
 - cmd: >-
+    call checkEncoding.bat
+
     call build-all.bat %PLATFORM% %CONFIGURATION%
 
     call tests\build-and-test.bat %PLATFORM% %CONFIGURATION%

--- a/checkEncoding.bat
+++ b/checkEncoding.bat
@@ -6,5 +6,8 @@ if not "%APPVEYOR_BUILD_NUMBER%" == "" (
 	@echo skip installing chardet
 )
 
-python checkEncoding.py || exit /b 1
+@echo ---- start python checkEncoding.py ----
+python checkEncoding.py || (echo error checkEncoding.py  && exit /b 1)
+@echo ---- end   python checkEncoding.py ----
+@echo.
 exit /b 0

--- a/checkEncoding.bat
+++ b/checkEncoding.bat
@@ -1,0 +1,10 @@
+@echo off
+if not "%APPVEYOR_BUILD_NUMBER%" == "" (
+	@echo installing chardet
+	pip install chardet --user
+) else (
+	@echo skip installing chardet
+)
+
+python checkEncoding.py || exit /b 1
+exit /b 0

--- a/checkEncoding.py
+++ b/checkEncoding.py
@@ -28,7 +28,7 @@ def checkExtension(file):
 		return False
 		
 def getMergeBase():
-	output = subprocess.check_output('git show-branch --merge-base master HEAD')
+	output = subprocess.check_output('git show-branch --merge-base origin/master HEAD')
 	outputDec = output.decode()
 	mergeBase = outputDec.splitlines()
 	return mergeBase[0]

--- a/checkEncoding.py
+++ b/checkEncoding.py
@@ -1,0 +1,82 @@
+﻿from chardet.universaldetector import UniversalDetector
+import chardet
+import os
+import sys
+import subprocess 
+
+# 指定したファイルの文字コードを返す
+def check_encoding(file_path):
+	detector = UniversalDetector()
+	with open(file_path, mode='rb') as f:
+		for binary in f:
+			detector.feed(binary)
+			if detector.done:
+				break
+	detector.close()
+	return detector.result['encoding']
+
+# チェック対象の拡張子か判断する
+def checkExtension(file):
+	extensions = [
+		".cpp",
+		".h",
+	]
+	base, ext = os.path.splitext(file)
+	if ext in extensions:
+		return True
+	else:
+		return False
+		
+def getMergeBase():
+	output = subprocess.check_output('git show-branch --merge-base master HEAD')
+	outputDec = output.decode()
+	mergeBase = outputDec.splitlines()
+	return mergeBase[0]
+
+# ベースとの差分をチェック
+def getDiffFiles():
+	mergeBase = getMergeBase()
+
+	output = subprocess.check_output('git diff ' + mergeBase + ' --name-only --diff-filter=dr')
+	diffFiles = output.decode()
+	return diffFiles.splitlines()
+
+def checkEncodingResult(encoding):
+	expectEncoding = [
+		"utf-8",
+		"ascii",
+	]
+	encoding = encoding.lower()
+	if encoding in expectEncoding:
+		return True
+
+	return False
+
+# デバッグ用
+# すべてのファイルの文字コードを調べてチェックする
+def checkAll():
+	for rootdir, dirs, files in os.walk('.'):
+		for file in files:
+			if checkExtension(file):
+				full = os.path.join(rootdir, file)
+				encoding = check_encoding(full)
+				if not checkEncodingResult(encoding):
+					print (encoding, full)
+
+if __name__ == '__main__':
+	count = 0
+
+	files = getDiffFiles()
+	for file in files:
+		if checkExtension(file):
+			encoding = check_encoding(file)
+			if not checkEncodingResult(encoding):
+				print (encoding, file)
+				count = count + 1
+
+	if count > 0:
+		print ("return 1")
+		sys.exit(1)
+	else:
+		print ("return 0")
+		sys.exit(0)


### PR DESCRIPTION
#313: appveyor で文字コードをチェックして UTF-8 になっていなかったら処理を失敗させる

cpp/h ファイルの文字コードをチェックして、UTF-8 あるいは ascii で
なかったら appveyor ビルドを失敗させる

テスト的に shift-jiis で cpp ファイルを追加したもの
https://ci.appveyor.com/project/m-tmatma/sakura/build/1.0.645

参考
https://github.com/sakura-editor/sakura/issues/313#issuecomment-412760125
