### PR TITLE
パッケージ関連のログ出力を抑制する

### DIFF
--- a/build-installer.bat
+++ b/build-installer.bat
@@ -41,22 +41,22 @@ mkdir %INSTALLER_WORK%\license\bregonig
 mkdir %INSTALLER_WORK%\keyword
 mkdir %INSTALLER_WORK%\license\ctags\
 
-copy /Y %INSTALLER_RESOURCES_SINT%\sakura.exe.manifest.x %INSTALLER_WORK%\
-copy /Y %INSTALLER_RESOURCES_SINT%\sakura.exe.manifest.v %INSTALLER_WORK%\
-copy /Y %INSTALLER_RESOURCES_SINT%\sakura.exe.ini        %INSTALLER_WORK%\
-copy /Y %INSTALLER_RESOURCES_SINT%\keyword\*.*           %INSTALLER_WORK%\keyword\
-copy /Y %INSTALLER_RESOURCES_BRON%\*.txt                 %INSTALLER_WORK%\license\bregonig\
-copy /Y %INSTALLER_RESOURCES_CTAGS%\license\*.*          %INSTALLER_WORK%\license\ctags\
+copy /Y %INSTALLER_RESOURCES_SINT%\sakura.exe.manifest.x    %INSTALLER_WORK%\ > NUL
+copy /Y %INSTALLER_RESOURCES_SINT%\sakura.exe.manifest.v    %INSTALLER_WORK%\ > NUL
+copy /Y %INSTALLER_RESOURCES_SINT%\sakura.exe.ini           %INSTALLER_WORK%\ > NUL
+copy /Y %INSTALLER_RESOURCES_SINT%\keyword\*.*              %INSTALLER_WORK%\keyword\ > NUL
+copy /Y %INSTALLER_RESOURCES_BRON%\*.txt                    %INSTALLER_WORK%\license\bregonig\ > NUL
+copy /Y %INSTALLER_RESOURCES_CTAGS%\license\*.*             %INSTALLER_WORK%\license\ctags\ > NUL
 
-copy /Y /B help\sakura\sakura.chm                           %INSTALLER_WORK%\
-copy /Y /B help\plugin\plugin.chm                           %INSTALLER_WORK%\
-copy /Y /B help\macro\macro.chm                             %INSTALLER_WORK%\
+copy /Y /B help\sakura\sakura.chm                           %INSTALLER_WORK%\ > NUL
+copy /Y /B help\plugin\plugin.chm                           %INSTALLER_WORK%\ > NUL
+copy /Y /B help\macro\macro.chm                             %INSTALLER_WORK%\ > NUL
 
-copy /Y /B %platform%\%configuration%\*.exe                 %INSTALLER_WORK%\
-copy /Y /B %platform%\%configuration%\*.dll                 %INSTALLER_WORK%\
+copy /Y /B %platform%\%configuration%\*.exe                 %INSTALLER_WORK%\ > NUL
+copy /Y /B %platform%\%configuration%\*.dll                 %INSTALLER_WORK%\ > NUL
 
 set SAKURA_ISS=installer\sakura-%platform%.iss
-"%CMD_ISCC%" %SAKURA_ISS% || (echo error && exit /b 1)
+"%CMD_ISCC%" %SAKURA_ISS% > NUL || (echo error && exit /b 1)
 exit /b 0
 
 @rem ------------------------------------------------------------------------------

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -131,8 +131,6 @@ if not "%RELEASE_PHASE%" == "" (
 @rem RELEASE_PHASE: (option) "alpha" (x64 build only)
 @rem ----------------------------------------------------------------
 
-@echo on
-
 @rem ----------------------------------------------------------------
 @rem build WORKDIR
 @rem ----------------------------------------------------------------
@@ -215,16 +213,13 @@ if exist "%HASHFILE%" (
 	copy /Y %HASHFILE%           %WORKDIR%\
 )
 call %ZIP_CMD%       %OUTFILE%      %WORKDIR%
-call %LIST_ZIP_CMD%  %OUTFILE%
 
 call %ZIP_CMD%       %OUTFILE_LOG%  %WORKDIR_LOG%
-call %LIST_ZIP_CMD%  %OUTFILE_LOG%
 
 @echo start zip asm
 mkdir %WORKDIR_ASM%
-copy /Y sakura\%platform%\%configuration%\*.asm %WORKDIR_ASM%\
+copy /Y sakura\%platform%\%configuration%\*.asm %WORKDIR_ASM%\ > NUL
 call %ZIP_CMD%       %OUTFILE_ASM%  %WORKDIR_ASM%
-call %LIST_ZIP_CMD%  %OUTFILE_ASM%
 
 @echo end   zip asm
 


### PR DESCRIPTION
appveyorの実行ログ画面を使いやすくするPRです。

以下は最新のappveyorログ出力です。
https://ci.appveyor.com/project/sakuraeditor/sakura/build/1.0.866/job/y2i6e96e2es8bj27

「2000行を超えるログ」は最新2000行くらいを表示する仕様らしく、
パッケージ工程のログで、ビルドログが流れてしまっています。

とりあえず、今の状態には困っています。

このPRでは、ぼくが見て「要らなさそう」と思ったログを削ってみました。
https://ci.appveyor.com/project/berryzplus/sakura/build/1.0.147/job/heasekyaat9nysgs
