### PR TITLE
appveyorでロケール設定するのをやめる

### DIFF
--- a/HeaderMake/HeaderMake.cpp
+++ b/HeaderMake/HeaderMake.cpp
@@ -67,7 +67,7 @@
 #include <errno.h>
 using namespace std;
 
-#define PREPROCESSOR "cl.exe /EP %s"
+#define PREPROCESSOR "cl.exe /nologo /utf-8 /EP %s"
 
 #ifdef __MINGW32__
 #include <windows.h>
@@ -78,7 +78,7 @@ using namespace std;
 #define strncpy_s(A, B, C, D) strncpy((A), (C), (D))
 
 #undef PREPROCESSOR
-#define PREPROCESSOR "gcc -x c++ -finput-charset=cp932 -fexec-charset=cp932 -E %s"
+#define PREPROCESSOR "gcc -x c++ -finput-charset=utf-8 -fexec-charset=utf-8 -E %s"
 
 void fopen_s( 
    FILE** pFile,

--- a/HeaderMake/HeaderMake.cpp
+++ b/HeaderMake/HeaderMake.cpp
@@ -67,7 +67,7 @@
 #include <errno.h>
 using namespace std;
 
-#define PREPROCESSOR "cl.exe /nologo /utf-8 /EP %s"
+#define PREPROCESSOR "cl.exe /nologo /source-charset:utf-8 /execution-charset:shift_jis /EP %s"
 
 #ifdef __MINGW32__
 #include <windows.h>
@@ -78,7 +78,7 @@ using namespace std;
 #define strncpy_s(A, B, C, D) strncpy((A), (C), (D))
 
 #undef PREPROCESSOR
-#define PREPROCESSOR "gcc -x c++ -finput-charset=utf-8 -fexec-charset=utf-8 -E %s"
+#define PREPROCESSOR "gcc -x c++ -finput-charset=utf-8 -fexec-charset=cp932 -E %s"
 
 void fopen_s( 
    FILE** pFile,

--- a/MakefileMake/MakefileMake.cpp
+++ b/MakefileMake/MakefileMake.cpp
@@ -66,9 +66,6 @@
 #define sprintf_s(A, B, C, ...) sprintf((A), (C), (__VA_ARGS__))
 #define strncpy_s(A, B, C, D) strncpy((A), (C), (D))
 
-#undef PREPROCESSOR
-#define PREPROCESSOR "gcc -x c++ -finput-charset=cp932 -fexec-charset=cp932 -E %s"
-
 int fopen_s( 
    FILE** pFile,
    const char *filename,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,5 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-install:
-- ps: Set-WinSystemLocale ja-JP
-- ps: Start-Sleep -s 10
-- ps: Restart-Computer
-- ps: Start-Sleep -s 10
 
 configuration:
   - Release

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -103,7 +103,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
@@ -146,7 +146,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
@@ -186,7 +186,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
@@ -226,7 +226,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/source-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -103,7 +103,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
@@ -146,7 +146,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
@@ -186,7 +186,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
@@ -226,7 +226,7 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>

--- a/sakura_core/Funccode_x.hsrc
+++ b/sakura_core/Funccode_x.hsrc
@@ -1,25 +1,25 @@
-//���̃t�@�C������AFunccode_define.h �� Funccode_enum.h ����������܂��B
+﻿//このファイルから、Funccode_define.h と Funccode_enum.h が生成されます。
 
-//	�R�}���h�R�[�h
+//	コマンドコード
 //
-//	�G�f�B�^�����Ŏg����R�}���h�ԍ��D16bit�̐��l�D
+//	エディタ内部で使われるコマンド番号．16bitの数値．
 //
-//	Windows 95�ł�32768�ȏ�̃R�}���h�����j���[��A�N�Z�����[�^�ɐݒ肷���
-//	���삵�Ȃ��D
+//	Windows 95では32768以上のコマンドをメニューやアクセラレータに設定すると
+//	動作しない．
 //
-//  20000-21999 : �v���O�C���R�}���h�@�\�ԍ��i20�~100�j
-//	30000-32767 : �@�\�ԍ��D���j���[��L�[�Ɋ��蓖�Ă���D
-//	32768-39999 : ���j���[����͒��ڌĂ΂�Ȃ����A����ID����ԐړI�ɌĂ΂��@�\
-//	40000-49511 : �}�N���֐�
-//	49512-      : �ϊ��R�}���h�D�󋵂ɉ����ċ@�\��u��������ꍇ�ɗp����
+//  20000-21999 : プラグインコマンド機能番号（20個×100）
+//	30000-32767 : 機能番号．メニューやキーに割り当てられる．
+//	32768-39999 : メニューからは直接呼ばれないが、他のIDから間接的に呼ばれる機能
+//	40000-49511 : マクロ関数
+//	49512-      : 変換コマンド．状況に応じて機能を置き換える場合に用いる
 //
-//	HandleCommand�̈����Ƃ��Ă�32bit�������C���16bit�̓R�}���h������ꂽ�󋵂�
-//	�ʒm���邽�߂Ɏg�p����D
+//	HandleCommandの引数としては32bit幅だが，上位16bitはコマンドが送られた状況を
+//	通知するために使用する．
 //
-//	[�Q�l]
-//	10000- : �E�B���h�E�ꗗ�Ŏg�p����
-//	11000- : �ŋߎg�����t�@�C���Ŏg�p����
-//	12000- : �ŋߎg�����t�H���_�Ŏg�p����
+//	[参考]
+//	10000- : ウィンドウ一覧で使用する
+//	11000- : 最近使ったファイルで使用する
+//	12000- : 最近使ったフォルダで使用する
 
 //enum EFunctionCode{
 
@@ -28,552 +28,552 @@ F_INVALID		= -1,
 F_DEFAULT		= 0,
 F_0				= 0,
 
-// ����`�p(�_�~�[�Ƃ��Ă��g��) 	//Oct. 17, 2000 jepro noted
-F_DISABLE			= 0,	//���g�p
-F_NODE				= 0,	//�m�[�h(Main Menu�p)
-F_SEPARATOR			= 1,	//�Z�p���[�^
-F_TOOLBARWRAP		= 2,	//�c�[���o�[�ܕ�
-F_MACRO_EXTRA		= 2,	//�O���}�N���i50�Ԉȏ�j
-F_PLUGCOMMAND		= 3,	//�v���O�C��
-F_DUMMY_MAX_CODE    = 10,	//����10�ł���K�v�͂Ȃ����� 10�܂ŗ\��
+// 未定義用(ダミーとしても使う) 	//Oct. 17, 2000 jepro noted
+F_DISABLE			= 0,	//未使用
+F_NODE				= 0,	//ノード(Main Menu用)
+F_SEPARATOR			= 1,	//セパレータ
+F_TOOLBARWRAP		= 2,	//ツールバー折返
+F_MACRO_EXTRA		= 2,	//外部マクロ（50番以上）
+F_PLUGCOMMAND		= 3,	//プラグイン
+F_DUMMY_MAX_CODE    = 10,	//特別10である必要はないけど 10まで予約
 
-//	2007.07.07 genta �󋵒ʒm�t���O
-//	�R�}���h������ꂽ�󋵂��R�}���h�ƕ����Ēʒm����D
-FA_FROMKEYBOARD		 = 0x00010000,	//!< �L�[�{�[�h�A�N�Z�����[�^����̃R�}���h
-FA_FROMMACRO		 = 0x00020000,	//!< �}�N������̃R�}���h���s
-FA_NONRECORD		 = 0x00040000,	//!< �}�N���ւ̋L�^��}������
+//	2007.07.07 genta 状況通知フラグ
+//	コマンドが送られた状況をコマンドと併せて通知する．
+FA_FROMKEYBOARD		 = 0x00010000,	//!< キーボードアクセラレータからのコマンド
+FA_FROMMACRO		 = 0x00020000,	//!< マクロからのコマンド実行
+FA_NONRECORD		 = 0x00040000,	//!< マクロへの記録を抑制する
 
 F_PLUGCOMMAND_FIRST			= 20000,
 F_PLUGCOMMAND_LAST			= 21999,
 
-// Main Menu ����@�\
-F_WINDOW_LIST				= 29001,	// �E�B���h�E���X�g
-F_FILE_USED_RECENTLY		= 29002,	// �ŋߎg�����t�@�C��
-F_FOLDER_USED_RECENTLY		= 29003,	// �ŋߎg�����t�H���_
-F_CUSTMENU_LIST				= 29004,	// �J�X�^�����j���[���X�g
-F_USERMACRO_LIST			= 29005,	// �o�^�ς݃}�N�����X�g
-F_PLUGIN_LIST				= 29006,	// �v���O�C���R�}���h���X�g
+// Main Menu 特殊機能
+F_WINDOW_LIST				= 29001,	// ウィンドウリスト
+F_FILE_USED_RECENTLY		= 29002,	// 最近使ったファイル
+F_FOLDER_USED_RECENTLY		= 29003,	// 最近使ったフォルダ
+F_CUSTMENU_LIST				= 29004,	// カスタムメニューリスト
+F_USERMACRO_LIST			= 29005,	// 登録済みマクロリスト
+F_PLUGIN_LIST				= 29006,	// プラグインコマンドリスト
 F_SPECIAL_FIRST				= F_WINDOW_LIST,
 F_SPECIAL_LAST				= F_PLUGIN_LIST,
 
 F_MENU_FIRST				= 30000,
 
-// �t�@�C������n
-//											[�Ӗ�]								[����]
-F_FILENEW					= 30101,	//�V�K�쐬							�Ȃ�
-F_FILEOPEN					= 30102,	//�J��								const WCHAR* path
-F_FILESAVE					= 30103,	//�㏑���ۑ�						�Ȃ�
-F_FILESAVEAS_DIALOG			= 30104,	//���O��t���ĕۑ�					�Ȃ�
-F_FILESAVEAS				= 30106,	//���O��t���ĕۑ�					const WCHAR* path
-F_FILECLOSE					= 30105,	//����(����)						�Ȃ�
-F_FILECLOSE_OPEN			= 30107,	//���ĊJ��						�Ȃ�
-F_FILEOPEN_DROPDOWN			= 30108,	//�J��(�h���b�v�_�E��)				const WCHAR* path
-F_FILESAVECLOSE				= 30109,	//�ۑ����ĕ���					�Ȃ�
-F_FILENEW_NEWWINDOW			= 30110,	//�V�K�쐬�i�V�����E�C���h�E�ŊJ���j		
-F_FILE_REOPEN_SJIS			= 30111,	//SJIS�ŊJ������					bool bNoConfirm
-F_FILE_REOPEN_JIS			= 30112,	//JIS�ŊJ������						bool bNoConfirm
-F_FILE_REOPEN_EUC			= 30113,	//EUC�ŊJ������						bool bNoConfirm
-F_FILE_REOPEN_UNICODE		= 30114,	//Unicode�ŊJ������					bool bNoConfirm
-F_FILE_REOPEN_UTF8			= 30115,	//UTF-8�ŊJ������					bool bNoConfirm
-F_FILE_REOPEN_UTF7			= 30116,	//UTF-7�ŊJ������					bool bNoConfirm
-F_FILE_REOPEN_UNICODEBE		= 30117,	//UnicodeBE�ŊJ������				bool bNoConfirm
-F_FILE_REOPEN_CESU8			= 30118,	//CESU-8�ŊJ������					bool bNoConform
-F_FILE_REOPEN				= 30119,	//���݂Ɠ��������R�[�h�ŊJ������	bool bNoConfirm
-F_FILESAVEALL				= 30120,	//���ׂď㏑���ۑ�					�Ȃ�
-F_FILESAVE_QUIET			= 30121,	//�㏑���ۑ�(���蓮��)				�Ȃ�
-F_FILE_REOPEN_LATIN1		= 30122,	//Latin1�ŊJ������					bool bNoConform	// 2010/3/20 Uchi
-F_PRINT						= 30150,	//���								�Ȃ�
-F_PRINT_PREVIEW				= 30151,	//����v���r���[					�Ȃ�
-F_PRINT_PAGESETUP			= 30152,	//����y�[�W�ݒ�					�Ȃ�
-//F_PRINT_DIALOG			= 30151,	//����_�C�A���O					�H
-//F_OPEN_HHPP					= 30160,	//������C/C++�w�b�_�t�@�C�����J��	bool bCheckOnly	// del	2008/6/23 Uchi
-//F_OPEN_CCPP					= 30161,	//������C/C++�\�[�X�t�@�C�����J��	bool bCheckOnly	// del	2008/6/23 Uchi
-F_OPEN_HfromtoC				= 30162,	//������C/C++�w�b�_(�\�[�X)���J��	bool bCheckOnly
-F_ACTIVATE_SQLPLUS			= 30170,	//Oracle SQL*Plus���A�N�e�B�u�\��	�Ȃ�
-F_PLSQL_COMPILE_ON_SQLPLUS	= 30171,	//Oracle SQL*Plus�Ŏ��s				�Ȃ�
-F_BROWSE					= 30180,	//�u���E�Y							�Ȃ�
-F_VIEWMODE					= 30185,	//�r���[���[�h						�Ȃ�
-F_PROPERTY_FILE				= 30190,	//�t�@�C���̃v���p�e�B				�Ȃ�
-F_PROFILEMGR				= 30191,	//�v���t�@�C���}�l�[�W��			�Ȃ�
-F_EXITALLEDITORS			= 30194,	//�ҏW�̑S�I��						�Ȃ�
-F_EXITALL					= 30195,	//�T�N���G�f�B�^�̑S�I��			�Ȃ�
+// ファイル操作系
+//											[意味]								[引数]
+F_FILENEW					= 30101,	//新規作成							なし
+F_FILEOPEN					= 30102,	//開く								const WCHAR* path
+F_FILESAVE					= 30103,	//上書き保存						なし
+F_FILESAVEAS_DIALOG			= 30104,	//名前を付けて保存					なし
+F_FILESAVEAS				= 30106,	//名前を付けて保存					const WCHAR* path
+F_FILECLOSE					= 30105,	//閉じて(無題)						なし
+F_FILECLOSE_OPEN			= 30107,	//閉じて開く						なし
+F_FILEOPEN_DROPDOWN			= 30108,	//開く(ドロップダウン)				const WCHAR* path
+F_FILESAVECLOSE				= 30109,	//保存して閉じる					なし
+F_FILENEW_NEWWINDOW			= 30110,	//新規作成（新しいウインドウで開く）		
+F_FILE_REOPEN_SJIS			= 30111,	//SJISで開き直す					bool bNoConfirm
+F_FILE_REOPEN_JIS			= 30112,	//JISで開き直す						bool bNoConfirm
+F_FILE_REOPEN_EUC			= 30113,	//EUCで開き直す						bool bNoConfirm
+F_FILE_REOPEN_UNICODE		= 30114,	//Unicodeで開き直す					bool bNoConfirm
+F_FILE_REOPEN_UTF8			= 30115,	//UTF-8で開き直す					bool bNoConfirm
+F_FILE_REOPEN_UTF7			= 30116,	//UTF-7で開き直す					bool bNoConfirm
+F_FILE_REOPEN_UNICODEBE		= 30117,	//UnicodeBEで開き直す				bool bNoConfirm
+F_FILE_REOPEN_CESU8			= 30118,	//CESU-8で開き直す					bool bNoConform
+F_FILE_REOPEN				= 30119,	//現在と同じ文字コードで開き直す	bool bNoConfirm
+F_FILESAVEALL				= 30120,	//すべて上書き保存					なし
+F_FILESAVE_QUIET			= 30121,	//上書き保存(限定動作)				なし
+F_FILE_REOPEN_LATIN1		= 30122,	//Latin1で開き直す					bool bNoConform	// 2010/3/20 Uchi
+F_PRINT						= 30150,	//印刷								なし
+F_PRINT_PREVIEW				= 30151,	//印刷プレビュー					なし
+F_PRINT_PAGESETUP			= 30152,	//印刷ページ設定					なし
+//F_PRINT_DIALOG			= 30151,	//印刷ダイアログ					？
+//F_OPEN_HHPP					= 30160,	//同名のC/C++ヘッダファイルを開く	bool bCheckOnly	// del	2008/6/23 Uchi
+//F_OPEN_CCPP					= 30161,	//同名のC/C++ソースファイルを開く	bool bCheckOnly	// del	2008/6/23 Uchi
+F_OPEN_HfromtoC				= 30162,	//同名のC/C++ヘッダ(ソース)を開く	bool bCheckOnly
+F_ACTIVATE_SQLPLUS			= 30170,	//Oracle SQL*Plusをアクティブ表示	なし
+F_PLSQL_COMPILE_ON_SQLPLUS	= 30171,	//Oracle SQL*Plusで実行				なし
+F_BROWSE					= 30180,	//ブラウズ							なし
+F_VIEWMODE					= 30185,	//ビューモード						なし
+F_PROPERTY_FILE				= 30190,	//ファイルのプロパティ				なし
+F_PROFILEMGR				= 30191,	//プロファイルマネージャ			なし
+F_EXITALLEDITORS			= 30194,	//編集の全終了						なし
+F_EXITALL					= 30195,	//サクラエディタの全終了			なし
 
-// �ҏW�n
-F_WCHAR				= 30200,	//��������									WCHAR c
-F_IME_CHAR			= 30201,	//�S�p��������								WORD c
-F_UNDO				= 30210,	//���ɖ߂�(Undo)							�Ȃ�
-F_REDO				= 30211,	//��蒼��(Redo)							�Ȃ�
-F_DELETE			= 30221,	//�폜										�Ȃ�
-F_DELETE_BACK		= 30222,	//�J�[�\���O���폜							�Ȃ�
-F_WordDeleteToStart	= 30230,	//�P��̍��[�܂ō폜						�Ȃ�
-F_WordDeleteToEnd	= 30231,	//�P��̉E�[�܂ō폜						�Ȃ�
-F_WordCut			= 30232,	//�P��؂���								�Ȃ�
-F_WordDelete		= 30233,	//�P��폜									�Ȃ�
-F_LineCutToStart	= 30240,	//�s���܂Ő؂���(���s�P��)				�Ȃ�
-F_LineCutToEnd		= 30241,	//�s���܂Ő؂���(���s�P��)				�Ȃ�
-F_LineDeleteToStart	= 30242,	//�s���܂ō폜(���s�P��)					�Ȃ�
-F_LineDeleteToEnd	= 30243,	//�s���܂ō폜(���s�P��)					�Ȃ�
-F_CUT_LINE			= 30244,	//�s�؂���(�܂�Ԃ��P��)					�Ȃ�
-F_DELETE_LINE		= 30245,	//�s�폜(�܂�Ԃ��P��)						�Ȃ�
-F_DUPLICATELINE		= 30250,	//�s�̓�d��(�܂�Ԃ��P��)					�Ȃ�
-F_INDENT_TAB		= 30260,	//TAB�C���f���g								�Ȃ�
-F_UNINDENT_TAB		= 30261,	//�tTAB�C���f���g							�Ȃ�
-F_INDENT_SPACE		= 30262,	//SPACE�C���f���g							�Ȃ�
-F_UNINDENT_SPACE	= 30263,	//�tSPACE�C���f���g							�Ȃ�
-//F_WORDSREFERENCE	= 30270,	//�P�ꃊ�t�@�����X							�Ȃ��H
-F_LTRIM				= 30280,	//��(�擪)�̋󔒂��폜						�Ȃ�
-F_RTRIM				= 30281,	//�E(����)�̋󔒂��폜						�Ȃ�
-F_SORT_ASC			= 30282,	//�I���s�̏����\�[�g						�Ȃ�
-F_SORT_DESC			= 30283,	//�I���s�̍~���\�[�g						�Ȃ�
-F_MERGE				= 30284,	//�I���s�̃}�[�W							�Ȃ�
-F_RECONVERT			= 30285,	//�ĕϊ�									�Ȃ�
+// 編集系
+F_WCHAR				= 30200,	//文字入力									WCHAR c
+F_IME_CHAR			= 30201,	//全角文字入力								WORD c
+F_UNDO				= 30210,	//元に戻す(Undo)							なし
+F_REDO				= 30211,	//やり直し(Redo)							なし
+F_DELETE			= 30221,	//削除										なし
+F_DELETE_BACK		= 30222,	//カーソル前を削除							なし
+F_WordDeleteToStart	= 30230,	//単語の左端まで削除						なし
+F_WordDeleteToEnd	= 30231,	//単語の右端まで削除						なし
+F_WordCut			= 30232,	//単語切り取り								なし
+F_WordDelete		= 30233,	//単語削除									なし
+F_LineCutToStart	= 30240,	//行頭まで切り取り(改行単位)				なし
+F_LineCutToEnd		= 30241,	//行末まで切り取り(改行単位)				なし
+F_LineDeleteToStart	= 30242,	//行頭まで削除(改行単位)					なし
+F_LineDeleteToEnd	= 30243,	//行末まで削除(改行単位)					なし
+F_CUT_LINE			= 30244,	//行切り取り(折り返し単位)					なし
+F_DELETE_LINE		= 30245,	//行削除(折り返し単位)						なし
+F_DUPLICATELINE		= 30250,	//行の二重化(折り返し単位)					なし
+F_INDENT_TAB		= 30260,	//TABインデント								なし
+F_UNINDENT_TAB		= 30261,	//逆TABインデント							なし
+F_INDENT_SPACE		= 30262,	//SPACEインデント							なし
+F_UNINDENT_SPACE	= 30263,	//逆SPACEインデント							なし
+//F_WORDSREFERENCE	= 30270,	//単語リファレンス							なし？
+F_LTRIM				= 30280,	//左(先頭)の空白を削除						なし
+F_RTRIM				= 30281,	//右(末尾)の空白を削除						なし
+F_SORT_ASC			= 30282,	//選択行の昇順ソート						なし
+F_SORT_DESC			= 30283,	//選択行の降順ソート						なし
+F_MERGE				= 30284,	//選択行のマージ							なし
+F_RECONVERT			= 30285,	//再変換									なし
 
 
-// �J�[�\���ړ��n
-F_UP				= 30311,	//�J�[�\����ړ�							�Ȃ�
-F_DOWN				= 30312,	//�J�[�\�����ړ�							�Ȃ�
-F_LEFT				= 30313,	//�J�[�\�����ړ�							�Ȃ�
-F_RIGHT				= 30314,	//�J�[�\���E�ړ�							�Ȃ�
-F_UP2				= 30315,	//�J�[�\����ړ�(�Q�s����)					�Ȃ�
-F_DOWN2				= 30316,	//�J�[�\�����ړ�(�Q�s����)					�Ȃ�
-F_WORDLEFT			= 30320,	//�P��̍��[�Ɉړ�							�Ȃ�
-F_WORDRIGHT			= 30321,	//�P��̉E�[�Ɉړ�							�Ȃ�
-//F_GOLINETOP		= 30330,	//�s���Ɉړ�(���s�P��)						�H
-//F_GOLINEEND		= 30331,	//�s���Ɉړ�(���s�P��)						�H
-F_GOLINETOP			= 30332,	//�s���Ɉړ�(�܂�Ԃ��P��)					int param
-F_GOLINEEND			= 30333,	//�s���Ɉړ�(�܂�Ԃ��P��)					�Ȃ�
-//F_ROLLDOWN		= 30340,	//�X�N���[���_�E��							�Ȃ��H
-//F_ROLLUP			= 30341,	//�X�N���[���A�b�v							�Ȃ��H
-F_HalfPageUp		= 30340,	//���y�[�W�A�b�v							�Ȃ�
-F_HalfPageDown		= 30341,	//���y�[�W�_�E��							�Ȃ�
-F_1PageUp			= 30342,	//�P�y�[�W�A�b�v							�Ȃ�
-F_1PageDown			= 30343,	//�P�y�[�W�_�E��							�Ȃ�
-//F_DISPLAYTOP		= 30344,	//��ʂ̐擪�Ɉړ�(������)					�H
-//F_DISPLAYEND		= 30345,	//��ʂ̍Ō�Ɉړ�(������)					�H
-F_GOFILETOP			= 30350,	//�t�@�C���̐擪�Ɉړ�						�Ȃ�
-F_GOFILEEND			= 30351,	//�t�@�C���̍Ō�Ɉړ�						�Ȃ�
-F_CURLINECENTER		= 30360,	//�J�[�\���s���E�B���h�E������				�Ȃ�
-F_JUMPHIST_PREV		= 30370,	//�ړ�����: �O��							�Ȃ�
-F_JUMPHIST_NEXT		= 30371,	//�ړ�����: ����							�Ȃ�
-F_JUMPHIST_SET		= 30372,	//���݈ʒu���ړ������ɓo�^					�Ȃ�
-F_WndScrollDown		= 30380,	//�e�L�X�g���P�s���փX�N���[��				�Ȃ�
-F_WndScrollUp		= 30381,	//�e�L�X�g���P�s��փX�N���[��				�Ȃ�
-F_GONEXTPARAGRAPH	= 30382,	//���̒i����								�Ȃ�
-F_GOPREVPARAGRAPH	= 30383,	//�O�̒i����								�Ȃ�
-F_AUTOSCROLL 		= 30384,	//�I�[�g�X�N���[��
+// カーソル移動系
+F_UP				= 30311,	//カーソル上移動							なし
+F_DOWN				= 30312,	//カーソル下移動							なし
+F_LEFT				= 30313,	//カーソル左移動							なし
+F_RIGHT				= 30314,	//カーソル右移動							なし
+F_UP2				= 30315,	//カーソル上移動(２行ごと)					なし
+F_DOWN2				= 30316,	//カーソル下移動(２行ごと)					なし
+F_WORDLEFT			= 30320,	//単語の左端に移動							なし
+F_WORDRIGHT			= 30321,	//単語の右端に移動							なし
+//F_GOLINETOP		= 30330,	//行頭に移動(改行単位)						？
+//F_GOLINEEND		= 30331,	//行末に移動(改行単位)						？
+F_GOLINETOP			= 30332,	//行頭に移動(折り返し単位)					int param
+F_GOLINEEND			= 30333,	//行末に移動(折り返し単位)					なし
+//F_ROLLDOWN		= 30340,	//スクロールダウン							なし？
+//F_ROLLUP			= 30341,	//スクロールアップ							なし？
+F_HalfPageUp		= 30340,	//半ページアップ							なし
+F_HalfPageDown		= 30341,	//半ページダウン							なし
+F_1PageUp			= 30342,	//１ページアップ							なし
+F_1PageDown			= 30343,	//１ページダウン							なし
+//F_DISPLAYTOP		= 30344,	//画面の先頭に移動(未実装)					？
+//F_DISPLAYEND		= 30345,	//画面の最後に移動(未実装)					？
+F_GOFILETOP			= 30350,	//ファイルの先頭に移動						なし
+F_GOFILEEND			= 30351,	//ファイルの最後に移動						なし
+F_CURLINECENTER		= 30360,	//カーソル行をウィンドウ中央へ				なし
+F_JUMPHIST_PREV		= 30370,	//移動履歴: 前へ							なし
+F_JUMPHIST_NEXT		= 30371,	//移動履歴: 次へ							なし
+F_JUMPHIST_SET		= 30372,	//現在位置を移動履歴に登録					なし
+F_WndScrollDown		= 30380,	//テキストを１行下へスクロール				なし
+F_WndScrollUp		= 30381,	//テキストを１行上へスクロール				なし
+F_GONEXTPARAGRAPH	= 30382,	//次の段落へ								なし
+F_GOPREVPARAGRAPH	= 30383,	//前の段落へ								なし
+F_AUTOSCROLL 		= 30384,	//オートスクロール
 F_WHEEL_FIRST		= 30385,
-F_WHEELUP			= 30385,	//�z�C�[���A�b�v								int zDelta
-F_WHEELDOWN			= 30386,	//�z�C�[���_�E��								int zDelta
-F_WHEELLEFT			= 30387,	//�z�C�[����								int zDelta
-F_WHEELRIGHT		= 30388,	//�z�C�[���E								int zDelta
-F_WHEELPAGEUP		= 30389,	//�z�C�[���y�[�W�A�b�v						int zDelta
-F_WHEELPAGEDOWN		= 30390,	//�z�C�[���y�[�W�_�E��						int zDelta
-F_WHEELPAGELEFT		= 30391,	//�z�C�[���y�[�W��							int zDelta
-F_WHEELPAGERIGHT	= 30392,	//�z�C�[���y�[�W�E							int zDelta
+F_WHEELUP			= 30385,	//ホイールアップ								int zDelta
+F_WHEELDOWN			= 30386,	//ホイールダウン								int zDelta
+F_WHEELLEFT			= 30387,	//ホイール左								int zDelta
+F_WHEELRIGHT		= 30388,	//ホイール右								int zDelta
+F_WHEELPAGEUP		= 30389,	//ホイールページアップ						int zDelta
+F_WHEELPAGEDOWN		= 30390,	//ホイールページダウン						int zDelta
+F_WHEELPAGELEFT		= 30391,	//ホイールページ左							int zDelta
+F_WHEELPAGERIGHT	= 30392,	//ホイールページ右							int zDelta
 F_WHEEL_LAST		= 30392,
-F_MODIFYLINE_NEXT	= 30393,	//���̕ύX�s��								�Ȃ�
-F_MODIFYLINE_PREV	= 30394,	//�O�̕ύX�s��								�Ȃ�
+F_MODIFYLINE_NEXT	= 30393,	//次の変更行へ								なし
+F_MODIFYLINE_PREV	= 30394,	//前の変更行へ								なし
 
-// �I���n
-F_SELECTWORD		= 30400,	//���݈ʒu�̒P��I��						�Ȃ�
-F_SELECTALL			= 30401,	//���ׂđI��								�Ȃ�
-F_SELECTLINE		= 30403,	//1�s�I��									int param	// 2007.10.06 nasukoji
-F_BEGIN_SEL			= 30410,	//�͈͑I���J�n								�Ȃ�
-F_UP_SEL			= 30411,	//(�͈͑I��)�J�[�\����ړ�					int lines
-F_DOWN_SEL			= 30412,	//(�͈͑I��)�J�[�\�����ړ�					�Ȃ�
-F_LEFT_SEL			= 30413,	//(�͈͑I��)�J�[�\�����ړ�					�Ȃ�
-F_RIGHT_SEL			= 30414,	//(�͈͑I��)�J�[�\���E�ړ�					�Ȃ�
-F_UP2_SEL			= 30415,	//(�͈͑I��)�J�[�\����ړ�(�Q�s����)		�Ȃ�
-F_DOWN2_SEL			= 30416,	//(�͈͑I��)�J�[�\�����ړ�(�Q�s����)		�Ȃ�
-F_WORDLEFT_SEL		= 30420,	//(�͈͑I��)�P��̍��[�Ɉړ�				�Ȃ�
-F_WORDRIGHT_SEL		= 30421,	//(�͈͑I��)�P��̉E�[�Ɉړ�				�Ȃ�
-//F_GOLINETOP_SEL	= 30430,	//(�͈͑I��)�s���Ɉړ�(���s�P��)			�H
-//F_GOLINEEND_SEL	= 30431,	//(�͈͑I��)�s���Ɉړ�(���s�P��)			�H
-F_GOLINETOP_SEL		= 30432,	//(�͈͑I��)�s���Ɉړ�(�܂�Ԃ��P��)		�Ȃ�
-F_GOLINEEND_SEL		= 30433,	//(�͈͑I��)�s���Ɉړ�(�܂�Ԃ��P��)		�Ȃ�
-//F_ROLLDOWN_SEL	= 30440,	//(�͈͑I��)�X�N���[���_�E��				�Ȃ��H
-//F_ROLLUP_SEL		= 30441,	//(�͈͑I��)�X�N���[���A�b�v				�Ȃ��H
-F_HalfPageUp_Sel	= 30440,	//(�͈͑I��)���y�[�W�A�b�v					�Ȃ�
-F_HalfPageDown_Sel	= 30441,	//(�͈͑I��)���y�[�W�_�E��					�Ȃ�
-F_1PageUp_Sel		= 30442,	//(�͈͑I��)�P�y�[�W�A�b�v					�Ȃ�
-F_1PageDown_Sel		= 30443,	//(�͈͑I��)�P�y�[�W�_�E��					�Ȃ�
-//F_DISPLAYTOP_SEL	= 30444,	//(�͈͑I��)��ʂ̐擪�Ɉړ�(������)		�H
-//F_DISPLAYEND_SEL	= 30445,	//(�͈͑I��)��ʂ̍Ō�Ɉړ�(������)		�H
-F_GOFILETOP_SEL		= 30450,	//(�͈͑I��)�t�@�C���̐擪�Ɉړ�			�Ȃ�
-F_GOFILEEND_SEL		= 30451,	//(�͈͑I��)�t�@�C���̍Ō�Ɉړ�			�Ȃ�
-F_GONEXTPARAGRAPH_SEL	= 30482,	//(�͈͑I��)���̒i����					�Ȃ�
-F_GOPREVPARAGRAPH_SEL	= 30483,	//(�͈͑I��)�O�̒i����					�Ȃ�
-F_MODIFYLINE_NEXT_SEL	= 30484,	//(�͈͑I��)���̕ύX�s��					�Ȃ�
-F_MODIFYLINE_PREV_SEL	= 30485,	//(�͈͑I��)�O�̕ύX�s��					�Ȃ�
-
-
-// ��`�I���n
-//F_BOXSELALL			= 30500,	//��`�ł��ׂđI��
-F_BEGIN_BOX				= 30510,	//��`�͈͑I���J�n						�Ȃ�
-//Oct. 17, 2000 JEPRO �ȉ��ɋ�`�I���̃R�}���h���̂ݏ������Ă�����
-F_UP_BOX				= 30511,	//(��`�I��)�J�[�\����ړ�
-F_DOWN_BOX				= 30512,	//(��`�I��)�J�[�\�����ړ�
-F_LEFT_BOX				= 30513,	//(��`�I��)�J�[�\�����ړ�
-F_RIGHT_BOX				= 30514,	//(��`�I��)�J�[�\���E�ړ�
-F_UP2_BOX				= 30515,	//(��`�I��)�J�[�\����ړ�(�Q�s����)
-F_DOWN2_BOX				= 30516,	//(��`�I��)�J�[�\�����ړ�(�Q�s����)
-F_WORDLEFT_BOX			= 30520,	//(��`�I��)�P��̍��[�Ɉړ�
-F_WORDRIGHT_BOX			= 30521,	//(��`�I��)�P��̉E�[�Ɉړ�
-F_GOLOGICALLINETOP_BOX	= 30530,	//(��`�I��)�s���Ɉړ�(���s�P��)
-//F_GOLOGICALLINEEND_BOX	= 30531,	//(��`�I��)�s���Ɉړ�(���s�P��)
-F_GOLINETOP_BOX			= 30532,	//(��`�I��)�s���Ɉړ�(�܂�Ԃ��P��)
-F_GOLINEEND_BOX			= 30533,	//(��`�I��)�s���Ɉړ�(�܂�Ԃ��P��)
-F_HalfPageUp_BOX		= 30540,	//(��`�I��)���y�[�W�A�b�v
-F_HalfPageDown_BOX		= 30541,	//(��`�I��)���y�[�W�_�E��
-F_1PageUp_BOX			= 30542,	//(��`�I��)�P�y�[�W�A�b�v
-F_1PageDown_BOX			= 30543,	//(��`�I��)�P�y�[�W�_�E��
-//F_DISPLAYTOP_BOX		= 30444,	//(��`�I��)��ʂ̐擪�Ɉړ�(������)
-//F_DISPLAYEND_BOX		= 30445,	//(��`�I��)��ʂ̍Ō�Ɉړ�(������)
-F_GOFILETOP_BOX			= 30550,	//(��`�I��)�t�@�C���̐擪�Ɉړ�
-F_GOFILEEND_BOX			= 30551,	//(��`�I��)�t�@�C���̍Ō�Ɉړ�
+// 選択系
+F_SELECTWORD		= 30400,	//現在位置の単語選択						なし
+F_SELECTALL			= 30401,	//すべて選択								なし
+F_SELECTLINE		= 30403,	//1行選択									int param	// 2007.10.06 nasukoji
+F_BEGIN_SEL			= 30410,	//範囲選択開始								なし
+F_UP_SEL			= 30411,	//(範囲選択)カーソル上移動					int lines
+F_DOWN_SEL			= 30412,	//(範囲選択)カーソル下移動					なし
+F_LEFT_SEL			= 30413,	//(範囲選択)カーソル左移動					なし
+F_RIGHT_SEL			= 30414,	//(範囲選択)カーソル右移動					なし
+F_UP2_SEL			= 30415,	//(範囲選択)カーソル上移動(２行ごと)		なし
+F_DOWN2_SEL			= 30416,	//(範囲選択)カーソル下移動(２行ごと)		なし
+F_WORDLEFT_SEL		= 30420,	//(範囲選択)単語の左端に移動				なし
+F_WORDRIGHT_SEL		= 30421,	//(範囲選択)単語の右端に移動				なし
+//F_GOLINETOP_SEL	= 30430,	//(範囲選択)行頭に移動(改行単位)			？
+//F_GOLINEEND_SEL	= 30431,	//(範囲選択)行末に移動(改行単位)			？
+F_GOLINETOP_SEL		= 30432,	//(範囲選択)行頭に移動(折り返し単位)		なし
+F_GOLINEEND_SEL		= 30433,	//(範囲選択)行末に移動(折り返し単位)		なし
+//F_ROLLDOWN_SEL	= 30440,	//(範囲選択)スクロールダウン				なし？
+//F_ROLLUP_SEL		= 30441,	//(範囲選択)スクロールアップ				なし？
+F_HalfPageUp_Sel	= 30440,	//(範囲選択)半ページアップ					なし
+F_HalfPageDown_Sel	= 30441,	//(範囲選択)半ページダウン					なし
+F_1PageUp_Sel		= 30442,	//(範囲選択)１ページアップ					なし
+F_1PageDown_Sel		= 30443,	//(範囲選択)１ページダウン					なし
+//F_DISPLAYTOP_SEL	= 30444,	//(範囲選択)画面の先頭に移動(未実装)		？
+//F_DISPLAYEND_SEL	= 30445,	//(範囲選択)画面の最後に移動(未実装)		？
+F_GOFILETOP_SEL		= 30450,	//(範囲選択)ファイルの先頭に移動			なし
+F_GOFILEEND_SEL		= 30451,	//(範囲選択)ファイルの最後に移動			なし
+F_GONEXTPARAGRAPH_SEL	= 30482,	//(範囲選択)次の段落へ					なし
+F_GOPREVPARAGRAPH_SEL	= 30483,	//(範囲選択)前の段落へ					なし
+F_MODIFYLINE_NEXT_SEL	= 30484,	//(範囲選択)次の変更行へ					なし
+F_MODIFYLINE_PREV_SEL	= 30485,	//(範囲選択)前の変更行へ					なし
 
 
-// �N���b�v�{�[�h�n
-F_CUT			= 30601,	//�؂���(�I��͈͂��N���b�v�{�[�h�ɃR�s�[���č폜)	�Ȃ�
-F_COPY			= 30602,	//�R�s�[(�I��͈͂��N���b�v�{�[�h�ɃR�s�[)				�Ȃ�
-F_COPY_ADDCRLF	= 30608,	//�܂�Ԃ��ʒu�ɉ��s�����ăR�s�[						�Ȃ�
-F_COPY_CRLF		= 30603,	//CRLF���s�ŃR�s�[										�Ȃ�
-F_PASTE			= 30604,	//�\��t��(�N���b�v�{�[�h����\��t��)					�Ȃ�
-F_PASTEBOX		= 30605,	//��`�\��t��(�N���b�v�{�[�h�����`�\��t��)			�Ȃ�
-
-//2007.09.18 kobake WCHAR�����߂郁�b�Z�[�W�̃��b�Z�[�W����ύX: �u*�v���u*_W�v
-F_INSTEXT_W					= 30606,	//�e�L�X�g��\��t��							const WCHAR* text, bool bNoWaitCursor
-F_ADDTAIL_W					= 30607,	//�Ō�Ƀe�L�X�g��ǉ�							const WCHAR* text, int length
-F_COPYLINES					= 30610,	//�I��͈͓��S�s�R�s�[							�Ȃ�
-F_COPYLINESASPASSAGE		= 30611,	//�I��͈͓��S�s���p���t���R�s�[				�Ȃ�
-F_COPYLINESWITHLINENUMBER	= 30612,	//�I��͈͓��S�s�s�ԍ��t���R�s�[				�Ȃ�
-F_COPY_COLOR_HTML			= 30613,	//�I��͈͓��F�t��HTML�R�s�[					�Ȃ�
-F_COPY_COLOR_HTML_LINENUMBER	= 30614,	//�I��͈͓��s�ԍ��F�t��HTML�R�s�[		�Ȃ�
-F_COPYPATH					= 30620,	//���̃t�@�C���̃p�X�����N���b�v�{�[�h�ɃR�s�[	�Ȃ�
-F_COPYTAG					= 30621,	//���̃t�@�C���̃p�X���ƃJ�[�\���ʒu���R�s�[	�Ȃ�
-F_COPYFNAME					= 30622,	//���̃t�@�C�������N���b�v�{�[�h�ɃR�s�[		�Ȃ�
-F_CREATEKEYBINDLIST			= 30630,	//�L�[���蓖�Ĉꗗ���R�s�[						�Ȃ�
-
-
-// �}���n
-F_INS_DATE				= 30790,	//���t�}��										�Ȃ�
-F_INS_TIME				= 30791,	//�����}��										�Ȃ�
-F_CTRL_CODE_DIALOG		= 30792,	//�R���g���[���R�[�h�̓���(�_�C�A���O)			�Ȃ�
-F_CTRL_CODE				= 30793.	//�R���g���[���R�[�h�̓���						wchar_t code
+// 矩形選択系
+//F_BOXSELALL			= 30500,	//矩形ですべて選択
+F_BEGIN_BOX				= 30510,	//矩形範囲選択開始						なし
+//Oct. 17, 2000 JEPRO 以下に矩形選択のコマンド名のみ準備しておいた
+F_UP_BOX				= 30511,	//(矩形選択)カーソル上移動
+F_DOWN_BOX				= 30512,	//(矩形選択)カーソル下移動
+F_LEFT_BOX				= 30513,	//(矩形選択)カーソル左移動
+F_RIGHT_BOX				= 30514,	//(矩形選択)カーソル右移動
+F_UP2_BOX				= 30515,	//(矩形選択)カーソル上移動(２行ごと)
+F_DOWN2_BOX				= 30516,	//(矩形選択)カーソル下移動(２行ごと)
+F_WORDLEFT_BOX			= 30520,	//(矩形選択)単語の左端に移動
+F_WORDRIGHT_BOX			= 30521,	//(矩形選択)単語の右端に移動
+F_GOLOGICALLINETOP_BOX	= 30530,	//(矩形選択)行頭に移動(改行単位)
+//F_GOLOGICALLINEEND_BOX	= 30531,	//(矩形選択)行末に移動(改行単位)
+F_GOLINETOP_BOX			= 30532,	//(矩形選択)行頭に移動(折り返し単位)
+F_GOLINEEND_BOX			= 30533,	//(矩形選択)行末に移動(折り返し単位)
+F_HalfPageUp_BOX		= 30540,	//(矩形選択)半ページアップ
+F_HalfPageDown_BOX		= 30541,	//(矩形選択)半ページダウン
+F_1PageUp_BOX			= 30542,	//(矩形選択)１ページアップ
+F_1PageDown_BOX			= 30543,	//(矩形選択)１ページダウン
+//F_DISPLAYTOP_BOX		= 30444,	//(矩形選択)画面の先頭に移動(未実装)
+//F_DISPLAYEND_BOX		= 30445,	//(矩形選択)画面の最後に移動(未実装)
+F_GOFILETOP_BOX			= 30550,	//(矩形選択)ファイルの先頭に移動
+F_GOFILEEND_BOX			= 30551,	//(矩形選択)ファイルの最後に移動
 
 
-// �ϊ��n
-F_TOLOWER				= 30800,	//������							�Ȃ�
-F_TOUPPER				= 30801,	//�啶��							�Ȃ�
-F_TOHANKAKU				= 30810,	//�S�p�����p 						�Ȃ�
-F_TOHANKATA				= 30817,	//�S�p�J�^�J�i�����p�J�^�J�i		�Ȃ�
-F_TOZENKAKUKATA			= 30811,	//���p�{�S�Ђ灨�S�p�E�J�^�J�i		�Ȃ�
-F_TOZENKAKUHIRA			= 30812,	//���p�{�S�J�^���S�p�E�Ђ炪��		�Ȃ�
-F_HANKATATOZENKATA		= 30813,	//���p�J�^�J�i���S�p�J�^�J�i		�Ȃ�
-F_HANKATATOZENHIRA		= 30814,	//���p�J�^�J�i���S�p�Ђ炪��		�Ȃ�
-F_TOZENEI				= 30815,	//���p�p�����S�p�p��				�Ȃ�
-F_TOHANEI				= 30816,	//�S�p�p�������p�p��				�Ȃ�
-F_TABTOSPACE			= 30830,	//TAB���� 						�Ȃ�
-F_SPACETOTAB			= 30831,	//�󔒁�TAB							�Ȃ�
-F_CODECNV_AUTO2SJIS		= 30850,	//�������ʁ�SJIS�R�[�h�ϊ� 			�Ȃ�
-F_CODECNV_EMAIL			= 30851,	//E-Mail(JIS��SJIS)�R�[�h�ϊ�		�Ȃ�
-F_CODECNV_EUC2SJIS		= 30852,	//EUC��SJIS�R�[�h�ϊ�				�Ȃ�
-F_CODECNV_UNICODE2SJIS	= 30853,	//Unicode��SJIS�R�[�h�ϊ�			�Ȃ�
-F_CODECNV_UNICODEBE2SJIS	=30856,	//UnicodeBE��SJIS�R�[�h�ϊ�			�Ȃ�
-F_CODECNV_UTF82SJIS		= 30854,	//UTF-8��SJIS�R�[�h�ϊ� 			�Ȃ�
-F_CODECNV_UTF72SJIS		= 30855,	//UTF-7��SJIS�R�[�h�ϊ� 			�Ȃ�
-F_CODECNV_SJIS2JIS		= 30860,	//SJIS��JIS�R�[�h�ϊ� 				�Ȃ�
-F_CODECNV_SJIS2EUC		= 30861,	//SJIS��EUC�R�[�h�ϊ� 				�Ȃ�
-F_CODECNV_SJIS2UTF8		= 30862,	//SJIS��UTF-8�R�[�h�ϊ� 			�Ȃ�
-F_CODECNV_SJIS2UTF7		= 30863,	//SJIS��UTF-7�R�[�h�ϊ� 			�Ȃ�
-F_BASE64DECODE			= 30870,	//Base64�f�R�[�h���ĕۑ�			�Ȃ�
-F_UUDECODE				= 30880,	//uudecode���ĕۑ�					�Ȃ�
+// クリップボード系
+F_CUT			= 30601,	//切り取り(選択範囲をクリップボードにコピーして削除)	なし
+F_COPY			= 30602,	//コピー(選択範囲をクリップボードにコピー)				なし
+F_COPY_ADDCRLF	= 30608,	//折り返し位置に改行をつけてコピー						なし
+F_COPY_CRLF		= 30603,	//CRLF改行でコピー										なし
+F_PASTE			= 30604,	//貼り付け(クリップボードから貼り付け)					なし
+F_PASTEBOX		= 30605,	//矩形貼り付け(クリップボードから矩形貼り付け)			なし
+
+//2007.09.18 kobake WCHARを求めるメッセージのメッセージ名を変更: 「*」→「*_W」
+F_INSTEXT_W					= 30606,	//テキストを貼り付け							const WCHAR* text, bool bNoWaitCursor
+F_ADDTAIL_W					= 30607,	//最後にテキストを追加							const WCHAR* text, int length
+F_COPYLINES					= 30610,	//選択範囲内全行コピー							なし
+F_COPYLINESASPASSAGE		= 30611,	//選択範囲内全行引用符付きコピー				なし
+F_COPYLINESWITHLINENUMBER	= 30612,	//選択範囲内全行行番号付きコピー				なし
+F_COPY_COLOR_HTML			= 30613,	//選択範囲内色付きHTMLコピー					なし
+F_COPY_COLOR_HTML_LINENUMBER	= 30614,	//選択範囲内行番号色付きHTMLコピー		なし
+F_COPYPATH					= 30620,	//このファイルのパス名をクリップボードにコピー	なし
+F_COPYTAG					= 30621,	//このファイルのパス名とカーソル位置をコピー	なし
+F_COPYFNAME					= 30622,	//このファイル名をクリップボードにコピー		なし
+F_CREATEKEYBINDLIST			= 30630,	//キー割り当て一覧をコピー						なし
 
 
-// �����n 
-F_SEARCH_DIALOG		= 30901,	//����(�P�ꌟ���_�C�A���O)						�Ȃ�
-F_SEARCH_NEXT		= 30902,	//��������										HWND hwnd, const WCHAR* text
-F_SEARCH_PREV		= 30903,	//�O������										HWND hwnd
-F_REPLACE_DIALOG	= 30904,	//�u��(�u���_�C�A���O)							�Ȃ�
-F_REPLACE			= 30906,	//�u��(���s)									HWND hwnd
-F_REPLACE_ALL		= 30907,	//���ׂĒu��(���s)								�Ȃ�
-F_SEARCH_CLEARMARK	= 30905,	//�����}�[�N�̐ؑւ�							�Ȃ�
-F_JUMP_SRCHSTARTPOS	= 30909,	//�����J�n�ʒu�֖߂�							�Ȃ�
-F_SEARCH_BOX		= 30908,	//����(�{�b�N�X)								�Ȃ�
-F_GREP_DIALOG		= 30910,	//Grep											�Ȃ�
-F_GREP				= 30911,	//Grep											�Ȃ�
-F_GREP_REPLACE_DLG	= 30912,	//Grep�u��										�Ȃ�
-F_GREP_REPLACE		= 30913,	//Grep�u��										�Ȃ�
-F_JUMP_DIALOG		= 30920,	//�w��s�փW�����v								�Ȃ�
-F_JUMP				= 30921,	//�w��s�փW�����v								�Ȃ�
-F_OUTLINE			= 30930,	//�A�E�g���C�����								int nAction
-F_OUTLINE_TOGGLE	= 30931,	//�A�E�g���C�����(toggle)						�Ȃ�
-F_TAGJUMP			= 30940,	//�^�O�W�����v									bool bClose
-F_TAGJUMPBACK		= 30941,	//�^�O�W�����v�o�b�N							�Ȃ�
-F_TAGJUMP_LIST		= 30942,	//�^�O�W�����v���X�g							�H
-F_TAGS_MAKE			= 30943,	//�^�O�t�@�C���̍쐬							�Ȃ�
-F_DIRECT_TAGJUMP	= 30944,	//�_�C���N�g�^�O�W�����v						�Ȃ�
-F_TAGJUMP_CLOSE		= 30945,	//���ă^�O�W�����v(���E�B���h�Eclose)			�Ȃ�
-F_TAGJUMP_KEYWORD	= 30946,	//�L�[���[�h���w�肵�ă_�C���N�g�^�O�W�����v	const WCHAR* keyword
-F_COMPARE			= 30950,	//�t�@�C�����e��r								�Ȃ�
-F_BRACKETPAIR		= 30960,	//�Ί��ʂ̌���									�Ȃ�
-F_BOOKMARK_SET		= 30970,	//�u�b�N�}�[�N�ݒ�E����						�Ȃ�
-F_BOOKMARK_NEXT		= 30971,	//���̃u�b�N�}�[�N��							�Ȃ�
-F_BOOKMARK_PREV		= 30972,	//�O�̃u�b�N�}�[�N��							�Ȃ�
-F_BOOKMARK_RESET	= 30973,	//�u�b�N�}�[�N�̑S����							�Ȃ�
-F_BOOKMARK_VIEW		= 30974,	//�u�b�N�}�[�N�̈ꗗ							int nAction
-F_BOOKMARK_PATTERN	= 30975,	//�p�^�[���Ɉ�v����s���}�[�N					�Ȃ�
-F_DIFF_DIALOG		= 30976,	//DIFF�����\��(�_�C�A���O)						�Ȃ�
-F_DIFF				= 30977,	//DIFF�����\��									const WCHAR* szTmpFile2, int nFlgOpt
-F_DIFF_NEXT			= 30978,	//���̍�����									�Ȃ�
-F_DIFF_PREV			= 30979,	//�O�̍�����									�Ȃ�
-F_DIFF_RESET		= 30980,	//�����̑S����									�Ȃ�
-F_ISEARCH_NEXT	    = 30981,	//�O���C���N�������^���T�[�`					�H
-F_ISEARCH_PREV		= 30982,	//����C���N�������^���T�[�`					�H
-F_ISEARCH_REGEXP_NEXT	= 30983,	//�O�����K�\���C���N�������^���T�[�`		�H
-F_ISEARCH_REGEXP_PREV	= 30984,	//������K�\���C���N�������^���T�[�`		�H
-F_ISEARCH_MIGEMO_NEXT	= 30985,	//�O��MIGEMO�C���N�������^���T�[�`			�H
-F_ISEARCH_MIGEMO_PREV	= 30986,	//���MIGEMO�C���N�������^���T�[�`			�H
-F_FUNCLIST_NEXT		= 30988,	//���̊֐����X�g�}�[�N��						�Ȃ�
-F_FUNCLIST_PREV		= 30989,	//�O�̊֐����X�g�}�[�N��						�Ȃ�
-F_FILETREE			= 30990,	//�t�@�C���c���[								�Ȃ�
-
-// ���[�h�؂�ւ��n 
-F_CHGMOD_INS		= 31001,	//�}���^�㏑�����[�h�؂�ւ�			�Ȃ�
-F_CHG_CHARSET		= 31010,	//�����R�[�h�Z�b�g�w��					
-F_CHGMOD_EOL_CRLF	= 31081,	//���͉��s�R�[�h�w��(CRLF)				�Ȃ�
-F_CHGMOD_EOL_LF		= 31082,	//���͉��s�R�[�h�w��(LF)				�Ȃ�
-F_CHGMOD_EOL_CR		= 31083,	//���͉��s�R�[�h�w��(CR)				�Ȃ�
-F_CANCEL_MODE		= 31099,	//�e�탂�[�h�̎�����					�Ȃ�
-
-// �ݒ�n 
-F_SHOWTOOLBAR		= 31100,	//�c�[���o�[�̕\��						�Ȃ�
-F_SHOWFUNCKEY		= 31101,	//�t�@���N�V�����L�[�̕\�� 				�Ȃ�
-F_SHOWSTATUSBAR		= 31102,	//�X�e�[�^�X�o�[�̕\�� 					�Ȃ�
-F_SHOWTAB			= 31103,	//�^�u�̕\��							�Ȃ�
-F_SHOWMINIMAP		= 31104,	//�~�j�}�b�v�̕\��						�Ȃ�
-F_TYPE_LIST			= 31110,	//�^�C�v�ʐݒ�ꗗ 						�Ȃ�
-F_OPTION_TYPE		= 31111,	//�^�C�v�ʐݒ� 							�Ȃ�
-F_OPTION			= 31112,	//���ʐݒ� 								�Ȃ�
-F_FAVORITE			= 31113,	//�����̊Ǘ�							�Ȃ�
-F_FONT				= 31120,	// �t�H���g�ݒ�							�Ȃ�
-F_SETFONTSIZE		= 31121,	// �t�H���g�T�C�Y�ݒ�					int fontSize, int shift, int mode
-F_SETFONTSIZEUP		= 31122,	// �t�H���g�T�C�Y�g��					�Ȃ�
-F_SETFONTSIZEDOWN	= 31123,	// �t�H���g�T�C�Y�k��					�Ȃ�
-F_WRAPWINDOWWIDTH	= 31140,	// ���݂̃E�B���h�E���Ő܂�Ԃ�			�Ȃ�
-F_TMPWRAPNOWRAP		= 31141,	// �܂�Ԃ��Ȃ��i�ꎞ�ݒ�j				�Ȃ�
-F_TMPWRAPSETTING	= 31142,	// �w�茅�Ő܂�Ԃ��i�ꎞ�ݒ�j			�Ȃ�
-F_TMPWRAPWINDOW		= 31143,	// �E�[�Ő܂�Ԃ��i�ꎞ�ݒ�j			�Ȃ�
-F_SELECT_COUNT_MODE	= 31144,	// �����J�E���g�̕��@���擾�A�ݒ肷��	int nMode
-
-F_TYPE_SCREEN			= 31115,	// �^�C�v�ʐݒ�w�X�N���[���x			�H
-F_TYPE_COLOR			= 31116,	// �^�C�v�ʐݒ�w�J���[�x				�H
-F_TYPE_WINDOW			= 31114,	// �^�C�v�ʐݒ�w�E�B���h�E�x			�H
-F_TYPE_HELPER			= 31117,	// �^�C�v�ʐݒ�w�x���x					�H
-F_TYPE_REGEX_KEYWORD	= 31118,	// �^�C�v�ʐݒ�w���K�\���L�[���[�h�x	�H
-F_TYPE_KEYHELP			= 31119,	// �^�C�v�ʐݒ�w�L�[���[�h�w���v�x		�H
-F_OPTION_GENERAL		= 32000,	// ���ʐݒ�w�S�ʁx 					�H
-F_OPTION_WINDOW			= 32001,	// ���ʐݒ�w�E�B���h�E�x				�H 
-F_OPTION_EDIT			= 32002,	// ���ʐݒ�w�ҏW�x 					�H
-F_OPTION_FILE			= 32003,	// ���ʐݒ�w�t�@�C���x 				�H
-F_OPTION_BACKUP			= 32004,	// ���ʐݒ�w�o�b�N�A�b�v�x				�H
-F_OPTION_FORMAT			= 32005,	// ���ʐݒ�w�����x						�H
-//F_OPTION_URL			= 32006,	// ���ʐݒ�w�N���b�J�u��URL�x			�H
-F_OPTION_GREP			= 32007,	// ���ʐݒ�wGrep�x						�H
-F_OPTION_KEYBIND		= 32008,	// ���ʐݒ�w�L�[���蓖�āx				�H
-F_OPTION_CUSTMENU		= 32009,	// ���ʐݒ�w�J�X�^�����j���[�x			�H
-F_OPTION_TOOLBAR		= 32010,	// ���ʐݒ�w�c�[���o�[�x				�H
-F_OPTION_KEYWORD		= 32011,	// ���ʐݒ�w�����L�[���[�h�x			�H
-F_OPTION_HELPER			= 32012,	// ���ʐݒ�w�x���x						�H
-F_OPTION_MACRO			= 32013,	// ���ʐݒ�w�}�N���x					�H
-F_OPTION_FNAME			= 32014,	// ���ʐݒ�w�t�@�C�����\���x			�H
-F_OPTION_TAB			= 32015,	// ���ʐݒ�w�^�u�x						�H
-F_OPTION_STATUSBAR		= 32016,	// ���ʐݒ�w�X�e�[�^�X�o�[�x			�H
-F_OPTION_PLUGIN			= 32017,	// ���ʐݒ�w�v���O�C���x				�H
-F_OPTION_MAINMENU		= 32018,	// ���ʐݒ�w���C�����j���[�x			�H
-
-// �}�N���n
-F_RECKEYMACRO			= 31250,	// �L�[�}�N���̋L�^�J�n�^�I��		�Ȃ�
-F_SAVEKEYMACRO			= 31251,	// �L�[�}�N���̕ۑ�					�Ȃ�
-F_LOADKEYMACRO			= 31252,	// �L�[�}�N���̓ǂݍ���				�Ȃ�
-F_EXECKEYMACRO			= 31253,	// �L�[�}�N���̎��s					�Ȃ�
-F_EXECEXTMACRO			= 31254,	// ���O���w�肵�ă}�N�����s			const WCHAR* command
-F_EXECMD_DIALOG			= 31270,	// �O���R�}���h���s					const WCHAR* command
-F_EXECMD				= 31271,	// �O���R�}���h���s					const WCHAR* command
-
-// �E�B���h�E�n
-F_SPLIT_V			= 31310,	//�㉺�ɕ���								�Ȃ�
-F_SPLIT_H			= 31311,	//���E�ɕ���								�Ȃ�
-F_SPLIT_VH			= 31312,	//�c���ɕ���								�Ȃ�
-F_WINCLOSE			= 31320,	//����									�Ȃ�
-F_WIN_CLOSEALL		= 31321,	//���ׂĕ���								�Ȃ�
-F_CASCADE			= 31330,	//�d�˂ĕ\��								�Ȃ�
-F_TILE_V			= 31331,	//�㉺�ɕ��ׂĕ\��							�Ȃ�
-F_TILE_H			= 31332,	//���E�ɕ��ׂĕ\��							�Ȃ�
-F_BIND_WINDOW		= 31333,	//�O���[�v��								�Ȃ�
-F_TOPMOST			= 31334,	//��Ɏ�O�ɕ\��							int top
-F_NEXTWINDOW		= 31340,	//���̃E�B���h�E							�H
-F_PREVWINDOW		= 31341,	//�O�̃E�B���h�E							�H
-F_WINLIST			= 31336,	//�E�B���h�E�ꗗ							�Ȃ�
-F_DLGWINLIST		= 31337,	//�E�B���h�E�ꗗ�_�C�A���O					�Ȃ�
-F_MAXIMIZE_V		= 31350,	//�c�����ɍő剻							�Ȃ�
-F_MINIMIZE_ALL		= 31351,	//���ׂčŏ���								�Ȃ�
-F_MAXIMIZE_H		= 31352,	//�������ɍő剻							�Ȃ�
-F_REDRAW			= 31360,	//�ĕ`��									�Ȃ�
-F_WIN_OUTPUT		= 31370,	//�A�E�g�v�b�g�E�B���h�E�\��				�Ȃ�
-F_GROUPCLOSE		= 31380,	// �O���[�v�����							�Ȃ�
-F_NEXTGROUP			= 31381,	// ���̃O���[�v								�Ȃ�
-F_PREVGROUP			= 31382,	// �O�̃O���[�v								�Ȃ�
-F_TAB_MOVERIGHT		= 31383,	// �^�u���E�Ɉړ�							�Ȃ�
-F_TAB_MOVELEFT		= 31384,	// �^�u�����Ɉړ�							�Ȃ�
-F_TAB_SEPARATE		= 31385,	// �V�K�O���[�v								�Ȃ�
-F_TAB_JOINTNEXT		= 31386,	// ���̃O���[�v�Ɉړ�						�Ȃ�
-F_TAB_JOINTPREV		= 31387,	// �O�̃O���[�v�Ɉړ�						�Ȃ�
-F_TAB_CLOSEOTHER	= 31388,	// ���̃^�u�ȊO�����						�Ȃ�
-F_TAB_CLOSELEFT		= 31389,	// �������ׂĕ���							�Ȃ�
-F_TAB_CLOSERIGHT	= 31390,	// �E�����ׂĕ���							�Ȃ�
+// 挿入系
+F_INS_DATE				= 30790,	//日付挿入										なし
+F_INS_TIME				= 30791,	//時刻挿入										なし
+F_CTRL_CODE_DIALOG		= 30792,	//コントロールコードの入力(ダイアログ)			なし
+F_CTRL_CODE				= 30793.	//コントロールコードの入力						wchar_t code
 
 
-// �x��
-F_HOKAN				= 31430,	// ���͕⊮											�Ȃ�
-F_TOGGLE_KEY_SEARCH	= 31431,	// �L�[���[�h�w���v�����\��							int option
-F_HELP_CONTENTS		= 31440,	// �w���v�ڎ�										�Ȃ�
-F_HELP_SEARCH		= 31441,	// �w���v�L�[���[�h����								�Ȃ�
-F_MENU_ALLFUNC		= 31445,	// �R�}���h�ꗗ										�Ȃ�
-F_EXTHELP1			= 31450,	// �O���w���v�P										�Ȃ�
-F_EXTHTMLHELP		= 31451,	// �O��HTML�w���v									const WCHAR* helpfile, const WCHAR* keyword
-F_ABOUT				= 31455,	// �o�[�W�������									�Ȃ�
+// 変換系
+F_TOLOWER				= 30800,	//小文字							なし
+F_TOUPPER				= 30801,	//大文字							なし
+F_TOHANKAKU				= 30810,	//全角→半角 						なし
+F_TOHANKATA				= 30817,	//全角カタカナ→半角カタカナ		なし
+F_TOZENKAKUKATA			= 30811,	//半角＋全ひら→全角・カタカナ		なし
+F_TOZENKAKUHIRA			= 30812,	//半角＋全カタ→全角・ひらがな		なし
+F_HANKATATOZENKATA		= 30813,	//半角カタカナ→全角カタカナ		なし
+F_HANKATATOZENHIRA		= 30814,	//半角カタカナ→全角ひらがな		なし
+F_TOZENEI				= 30815,	//半角英数→全角英数				なし
+F_TOHANEI				= 30816,	//全角英数→半角英数				なし
+F_TABTOSPACE			= 30830,	//TAB→空白 						なし
+F_SPACETOTAB			= 30831,	//空白→TAB							なし
+F_CODECNV_AUTO2SJIS		= 30850,	//自動判別→SJISコード変換 			なし
+F_CODECNV_EMAIL			= 30851,	//E-Mail(JIS→SJIS)コード変換		なし
+F_CODECNV_EUC2SJIS		= 30852,	//EUC→SJISコード変換				なし
+F_CODECNV_UNICODE2SJIS	= 30853,	//Unicode→SJISコード変換			なし
+F_CODECNV_UNICODEBE2SJIS	=30856,	//UnicodeBE→SJISコード変換			なし
+F_CODECNV_UTF82SJIS		= 30854,	//UTF-8→SJISコード変換 			なし
+F_CODECNV_UTF72SJIS		= 30855,	//UTF-7→SJISコード変換 			なし
+F_CODECNV_SJIS2JIS		= 30860,	//SJIS→JISコード変換 				なし
+F_CODECNV_SJIS2EUC		= 30861,	//SJIS→EUCコード変換 				なし
+F_CODECNV_SJIS2UTF8		= 30862,	//SJIS→UTF-8コード変換 			なし
+F_CODECNV_SJIS2UTF7		= 30863,	//SJIS→UTF-7コード変換 			なし
+F_BASE64DECODE			= 30870,	//Base64デコードして保存			なし
+F_UUDECODE				= 30880,	//uudecodeして保存					なし
+
+
+// 検索系 
+F_SEARCH_DIALOG		= 30901,	//検索(単語検索ダイアログ)						なし
+F_SEARCH_NEXT		= 30902,	//次を検索										HWND hwnd, const WCHAR* text
+F_SEARCH_PREV		= 30903,	//前を検索										HWND hwnd
+F_REPLACE_DIALOG	= 30904,	//置換(置換ダイアログ)							なし
+F_REPLACE			= 30906,	//置換(実行)									HWND hwnd
+F_REPLACE_ALL		= 30907,	//すべて置換(実行)								なし
+F_SEARCH_CLEARMARK	= 30905,	//検索マークの切替え							なし
+F_JUMP_SRCHSTARTPOS	= 30909,	//検索開始位置へ戻る							なし
+F_SEARCH_BOX		= 30908,	//検索(ボックス)								なし
+F_GREP_DIALOG		= 30910,	//Grep											なし
+F_GREP				= 30911,	//Grep											なし
+F_GREP_REPLACE_DLG	= 30912,	//Grep置換										なし
+F_GREP_REPLACE		= 30913,	//Grep置換										なし
+F_JUMP_DIALOG		= 30920,	//指定行へジャンプ								なし
+F_JUMP				= 30921,	//指定行へジャンプ								なし
+F_OUTLINE			= 30930,	//アウトライン解析								int nAction
+F_OUTLINE_TOGGLE	= 30931,	//アウトライン解析(toggle)						なし
+F_TAGJUMP			= 30940,	//タグジャンプ									bool bClose
+F_TAGJUMPBACK		= 30941,	//タグジャンプバック							なし
+F_TAGJUMP_LIST		= 30942,	//タグジャンプリスト							？
+F_TAGS_MAKE			= 30943,	//タグファイルの作成							なし
+F_DIRECT_TAGJUMP	= 30944,	//ダイレクトタグジャンプ						なし
+F_TAGJUMP_CLOSE		= 30945,	//閉じてタグジャンプ(元ウィンドウclose)			なし
+F_TAGJUMP_KEYWORD	= 30946,	//キーワードを指定してダイレクトタグジャンプ	const WCHAR* keyword
+F_COMPARE			= 30950,	//ファイル内容比較								なし
+F_BRACKETPAIR		= 30960,	//対括弧の検索									なし
+F_BOOKMARK_SET		= 30970,	//ブックマーク設定・解除						なし
+F_BOOKMARK_NEXT		= 30971,	//次のブックマークへ							なし
+F_BOOKMARK_PREV		= 30972,	//前のブックマークへ							なし
+F_BOOKMARK_RESET	= 30973,	//ブックマークの全解除							なし
+F_BOOKMARK_VIEW		= 30974,	//ブックマークの一覧							int nAction
+F_BOOKMARK_PATTERN	= 30975,	//パターンに一致する行をマーク					なし
+F_DIFF_DIALOG		= 30976,	//DIFF差分表示(ダイアログ)						なし
+F_DIFF				= 30977,	//DIFF差分表示									const WCHAR* szTmpFile2, int nFlgOpt
+F_DIFF_NEXT			= 30978,	//次の差分へ									なし
+F_DIFF_PREV			= 30979,	//前の差分へ									なし
+F_DIFF_RESET		= 30980,	//差分の全解除									なし
+F_ISEARCH_NEXT	    = 30981,	//前方インクリメンタルサーチ					？
+F_ISEARCH_PREV		= 30982,	//後方インクリメンタルサーチ					？
+F_ISEARCH_REGEXP_NEXT	= 30983,	//前方正規表現インクリメンタルサーチ		？
+F_ISEARCH_REGEXP_PREV	= 30984,	//後方正規表現インクリメンタルサーチ		？
+F_ISEARCH_MIGEMO_NEXT	= 30985,	//前方MIGEMOインクリメンタルサーチ			？
+F_ISEARCH_MIGEMO_PREV	= 30986,	//後方MIGEMOインクリメンタルサーチ			？
+F_FUNCLIST_NEXT		= 30988,	//次の関数リストマークへ						なし
+F_FUNCLIST_PREV		= 30989,	//前の関数リストマークへ						なし
+F_FILETREE			= 30990,	//ファイルツリー								なし
+
+// モード切り替え系 
+F_CHGMOD_INS		= 31001,	//挿入／上書きモード切り替え			なし
+F_CHG_CHARSET		= 31010,	//文字コードセット指定					
+F_CHGMOD_EOL_CRLF	= 31081,	//入力改行コード指定(CRLF)				なし
+F_CHGMOD_EOL_LF		= 31082,	//入力改行コード指定(LF)				なし
+F_CHGMOD_EOL_CR		= 31083,	//入力改行コード指定(CR)				なし
+F_CANCEL_MODE		= 31099,	//各種モードの取り消し					なし
+
+// 設定系 
+F_SHOWTOOLBAR		= 31100,	//ツールバーの表示						なし
+F_SHOWFUNCKEY		= 31101,	//ファンクションキーの表示 				なし
+F_SHOWSTATUSBAR		= 31102,	//ステータスバーの表示 					なし
+F_SHOWTAB			= 31103,	//タブの表示							なし
+F_SHOWMINIMAP		= 31104,	//ミニマップの表示						なし
+F_TYPE_LIST			= 31110,	//タイプ別設定一覧 						なし
+F_OPTION_TYPE		= 31111,	//タイプ別設定 							なし
+F_OPTION			= 31112,	//共通設定 								なし
+F_FAVORITE			= 31113,	//履歴の管理							なし
+F_FONT				= 31120,	// フォント設定							なし
+F_SETFONTSIZE		= 31121,	// フォントサイズ設定					int fontSize, int shift, int mode
+F_SETFONTSIZEUP		= 31122,	// フォントサイズ拡大					なし
+F_SETFONTSIZEDOWN	= 31123,	// フォントサイズ縮小					なし
+F_WRAPWINDOWWIDTH	= 31140,	// 現在のウィンドウ幅で折り返し			なし
+F_TMPWRAPNOWRAP		= 31141,	// 折り返さない（一時設定）				なし
+F_TMPWRAPSETTING	= 31142,	// 指定桁で折り返す（一時設定）			なし
+F_TMPWRAPWINDOW		= 31143,	// 右端で折り返す（一時設定）			なし
+F_SELECT_COUNT_MODE	= 31144,	// 文字カウントの方法を取得、設定する	int nMode
+
+F_TYPE_SCREEN			= 31115,	// タイプ別設定『スクリーン』			？
+F_TYPE_COLOR			= 31116,	// タイプ別設定『カラー』				？
+F_TYPE_WINDOW			= 31114,	// タイプ別設定『ウィンドウ』			？
+F_TYPE_HELPER			= 31117,	// タイプ別設定『支援』					？
+F_TYPE_REGEX_KEYWORD	= 31118,	// タイプ別設定『正規表現キーワード』	？
+F_TYPE_KEYHELP			= 31119,	// タイプ別設定『キーワードヘルプ』		？
+F_OPTION_GENERAL		= 32000,	// 共通設定『全般』 					？
+F_OPTION_WINDOW			= 32001,	// 共通設定『ウィンドウ』				？ 
+F_OPTION_EDIT			= 32002,	// 共通設定『編集』 					？
+F_OPTION_FILE			= 32003,	// 共通設定『ファイル』 				？
+F_OPTION_BACKUP			= 32004,	// 共通設定『バックアップ』				？
+F_OPTION_FORMAT			= 32005,	// 共通設定『書式』						？
+//F_OPTION_URL			= 32006,	// 共通設定『クリッカブルURL』			？
+F_OPTION_GREP			= 32007,	// 共通設定『Grep』						？
+F_OPTION_KEYBIND		= 32008,	// 共通設定『キー割り当て』				？
+F_OPTION_CUSTMENU		= 32009,	// 共通設定『カスタムメニュー』			？
+F_OPTION_TOOLBAR		= 32010,	// 共通設定『ツールバー』				？
+F_OPTION_KEYWORD		= 32011,	// 共通設定『強調キーワード』			？
+F_OPTION_HELPER			= 32012,	// 共通設定『支援』						？
+F_OPTION_MACRO			= 32013,	// 共通設定『マクロ』					？
+F_OPTION_FNAME			= 32014,	// 共通設定『ファイル名表示』			？
+F_OPTION_TAB			= 32015,	// 共通設定『タブ』						？
+F_OPTION_STATUSBAR		= 32016,	// 共通設定『ステータスバー』			？
+F_OPTION_PLUGIN			= 32017,	// 共通設定『プラグイン』				？
+F_OPTION_MAINMENU		= 32018,	// 共通設定『メインメニュー』			？
+
+// マクロ系
+F_RECKEYMACRO			= 31250,	// キーマクロの記録開始／終了		なし
+F_SAVEKEYMACRO			= 31251,	// キーマクロの保存					なし
+F_LOADKEYMACRO			= 31252,	// キーマクロの読み込み				なし
+F_EXECKEYMACRO			= 31253,	// キーマクロの実行					なし
+F_EXECEXTMACRO			= 31254,	// 名前を指定してマクロ実行			const WCHAR* command
+F_EXECMD_DIALOG			= 31270,	// 外部コマンド実行					const WCHAR* command
+F_EXECMD				= 31271,	// 外部コマンド実行					const WCHAR* command
+
+// ウィンドウ系
+F_SPLIT_V			= 31310,	//上下に分割								なし
+F_SPLIT_H			= 31311,	//左右に分割								なし
+F_SPLIT_VH			= 31312,	//縦横に分割								なし
+F_WINCLOSE			= 31320,	//閉じる									なし
+F_WIN_CLOSEALL		= 31321,	//すべて閉じる								なし
+F_CASCADE			= 31330,	//重ねて表示								なし
+F_TILE_V			= 31331,	//上下に並べて表示							なし
+F_TILE_H			= 31332,	//左右に並べて表示							なし
+F_BIND_WINDOW		= 31333,	//グループ化								なし
+F_TOPMOST			= 31334,	//常に手前に表示							int top
+F_NEXTWINDOW		= 31340,	//次のウィンドウ							？
+F_PREVWINDOW		= 31341,	//前のウィンドウ							？
+F_WINLIST			= 31336,	//ウィンドウ一覧							なし
+F_DLGWINLIST		= 31337,	//ウィンドウ一覧ダイアログ					なし
+F_MAXIMIZE_V		= 31350,	//縦方向に最大化							なし
+F_MINIMIZE_ALL		= 31351,	//すべて最小化								なし
+F_MAXIMIZE_H		= 31352,	//横方向に最大化							なし
+F_REDRAW			= 31360,	//再描画									なし
+F_WIN_OUTPUT		= 31370,	//アウトプットウィンドウ表示				なし
+F_GROUPCLOSE		= 31380,	// グループを閉じる							なし
+F_NEXTGROUP			= 31381,	// 次のグループ								なし
+F_PREVGROUP			= 31382,	// 前のグループ								なし
+F_TAB_MOVERIGHT		= 31383,	// タブを右に移動							なし
+F_TAB_MOVELEFT		= 31384,	// タブを左に移動							なし
+F_TAB_SEPARATE		= 31385,	// 新規グループ								なし
+F_TAB_JOINTNEXT		= 31386,	// 次のグループに移動						なし
+F_TAB_JOINTPREV		= 31387,	// 前のグループに移動						なし
+F_TAB_CLOSEOTHER	= 31388,	// このタブ以外を閉じる						なし
+F_TAB_CLOSELEFT		= 31389,	// 左をすべて閉じる							なし
+F_TAB_CLOSERIGHT	= 31390,	// 右をすべて閉じる							なし
+
+
+// 支援
+F_HOKAN				= 31430,	// 入力補完											なし
+F_TOGGLE_KEY_SEARCH	= 31431,	// キーワードヘルプ自動表示							int option
+F_HELP_CONTENTS		= 31440,	// ヘルプ目次										なし
+F_HELP_SEARCH		= 31441,	// ヘルプキーワード検索								なし
+F_MENU_ALLFUNC		= 31445,	// コマンド一覧										なし
+F_EXTHELP1			= 31450,	// 外部ヘルプ１										なし
+F_EXTHTMLHELP		= 31451,	// 外部HTMLヘルプ									const WCHAR* helpfile, const WCHAR* keyword
+F_ABOUT				= 31455,	// バージョン情報									なし
 
 
 //	Jul. 4, 2000 genta
-F_USERMACRO_0		= 31600,	// �o�^�}�N���J�n
+F_USERMACRO_0		= 31600,	// 登録マクロ開始
 
 
-// �J�X�^�����j���[
-F_MENU_RBUTTON		= 31580,	// �E�N���b�N���j���[		�Ȃ�
-F_CUSTMENU_1		= 31501,	// �J�X�^�����j���[1		�Ȃ�
-F_CUSTMENU_2		= 31502,	// �J�X�^�����j���[2		�Ȃ�
-F_CUSTMENU_3		= 31503,	// �J�X�^�����j���[3		�Ȃ�
-F_CUSTMENU_4		= 31504,	// �J�X�^�����j���[4		�Ȃ�
-F_CUSTMENU_5		= 31505,	// �J�X�^�����j���[5		�Ȃ�
-F_CUSTMENU_6		= 31506,	// �J�X�^�����j���[6		�Ȃ�
-F_CUSTMENU_7		= 31507,	// �J�X�^�����j���[7		�Ȃ�
-F_CUSTMENU_8		= 31508,	// �J�X�^�����j���[8		�Ȃ�
-F_CUSTMENU_9		= 31509,	// �J�X�^�����j���[9		�Ȃ�
-F_CUSTMENU_10		= 31510,	// �J�X�^�����j���[10		�Ȃ�
-F_CUSTMENU_11		= 31511,	// �J�X�^�����j���[11		�Ȃ�
-F_CUSTMENU_12		= 31512,	// �J�X�^�����j���[12		�Ȃ�
-F_CUSTMENU_13		= 31513,	// �J�X�^�����j���[13		�Ȃ�
-F_CUSTMENU_14		= 31514,	// �J�X�^�����j���[14		�Ȃ�
-F_CUSTMENU_15		= 31515,	// �J�X�^�����j���[15		�Ȃ�
-F_CUSTMENU_16		= 31516,	// �J�X�^�����j���[16		�Ȃ�
-F_CUSTMENU_17		= 31517,	// �J�X�^�����j���[17		�Ȃ�
-F_CUSTMENU_18		= 31518,	// �J�X�^�����j���[18		�Ȃ�
-F_CUSTMENU_19		= 31519,	// �J�X�^�����j���[19		�Ȃ�
-F_CUSTMENU_20		= 31520,	// �J�X�^�����j���[20		�Ȃ�
-F_CUSTMENU_21		= 31521,	// �J�X�^�����j���[21		�Ȃ�
-F_CUSTMENU_22		= 31522,	// �J�X�^�����j���[22		�Ȃ�
-F_CUSTMENU_23		= 31523,	// �J�X�^�����j���[23		�Ȃ�
-F_CUSTMENU_24		= 31524,	// �J�X�^�����j���[24		�Ȃ�
+// カスタムメニュー
+F_MENU_RBUTTON		= 31580,	// 右クリックメニュー		なし
+F_CUSTMENU_1		= 31501,	// カスタムメニュー1		なし
+F_CUSTMENU_2		= 31502,	// カスタムメニュー2		なし
+F_CUSTMENU_3		= 31503,	// カスタムメニュー3		なし
+F_CUSTMENU_4		= 31504,	// カスタムメニュー4		なし
+F_CUSTMENU_5		= 31505,	// カスタムメニュー5		なし
+F_CUSTMENU_6		= 31506,	// カスタムメニュー6		なし
+F_CUSTMENU_7		= 31507,	// カスタムメニュー7		なし
+F_CUSTMENU_8		= 31508,	// カスタムメニュー8		なし
+F_CUSTMENU_9		= 31509,	// カスタムメニュー9		なし
+F_CUSTMENU_10		= 31510,	// カスタムメニュー10		なし
+F_CUSTMENU_11		= 31511,	// カスタムメニュー11		なし
+F_CUSTMENU_12		= 31512,	// カスタムメニュー12		なし
+F_CUSTMENU_13		= 31513,	// カスタムメニュー13		なし
+F_CUSTMENU_14		= 31514,	// カスタムメニュー14		なし
+F_CUSTMENU_15		= 31515,	// カスタムメニュー15		なし
+F_CUSTMENU_16		= 31516,	// カスタムメニュー16		なし
+F_CUSTMENU_17		= 31517,	// カスタムメニュー17		なし
+F_CUSTMENU_18		= 31518,	// カスタムメニュー18		なし
+F_CUSTMENU_19		= 31519,	// カスタムメニュー19		なし
+F_CUSTMENU_20		= 31520,	// カスタムメニュー20		なし
+F_CUSTMENU_21		= 31521,	// カスタムメニュー21		なし
+F_CUSTMENU_22		= 31522,	// カスタムメニュー22		なし
+F_CUSTMENU_23		= 31523,	// カスタムメニュー23		なし
+F_CUSTMENU_24		= 31524,	// カスタムメニュー24		なし
 F_CUSTMENU_LAST = F_CUSTMENU_24,
 
-F_CUSTMENU_BASE		= 31500,	// �J�X�^�����j���[��ԍ�
+F_CUSTMENU_BASE		= 31500,	// カスタムメニュー基準番号
 
-// ���̑�
-//F_SENDMAIL		= 31570,		// ���[�����M	//Oct. 17, 2000 JEPRO ���[���@�\�͎���ł���̂ŃR�����g�A�E�g�ɂ���
+// その他
+//F_SENDMAIL		= 31570,		// メール送信	//Oct. 17, 2000 JEPRO メール機能は死んでいるのでコメントアウトにした
 
-//	Windows 95�̐���ɂ��CWM_COMMAND�Ŏg���@�\�ԍ��Ƃ���32768�ȏ�̒l��p���邱�Ƃ��ł��܂���D
-//	���j���[���Ŏg���Ȃ��}�N����p�̃R�}���h�ɂ͂���ȏ�̒l�����蓖�Ă܂��傤�D
+//	Windows 95の制約により，WM_COMMANDで使う機能番号として32768以上の値を用いることができません．
+//	メニュー等で使われないマクロ専用のコマンドにはそれ以上の値を割り当てましょう．
 
-//	���j���[����͒��ڌĂ΂�Ȃ����A����ID����ԐړI�ɌĂ΂��@�\
+//	メニューからは直接呼ばれないが、他のIDから間接的に呼ばれる機能
 F_MENU_NOT_USED_FIRST	= 32768,
-F_CHGMOD_EOL			= 32800,		// ���͉��s�R�[�h�w��						enumEOLType e
-F_SET_QUOTESTRING		= 32801,		// ���ʐݒ�: ���p���̐ݒ�					const WCHAR* quotestr
-F_TRACEOUT				= 32802,		// �}�N���p�A�E�g�v�b�g�E�C���h�E�ɏo��		const WCHAR* outputstr, int nFlgOpt
-F_PUTFILE				= 32803,		// ��ƒ��t�@�C���̈ꎞ�o�� 2006.12.10 maru
-F_INSFILE				= 32804,		// �L�����b�g�ʒu�Ƀt�@�C���}�� 2006.12.10 maru
-F_TEXTWRAPMETHOD		= 32805,		// �e�L�X�g�̐܂�Ԃ����@					�Ȃ�
-F_INSBOXTEXT			= 32806,		// ��`�e�L�X�g�}��
-F_MOVECURSOR			= 32807,		// �J�[�\���ړ�
-F_MOVECURSORLAYOUT		= 32808,		// �J�[�\���ړ�(���C�A�E�g)
-F_STATUSMSG				= 32809,		// �X�e�[�^�X���b�Z�[�W
-F_MSGBEEP				= 32810,		// �r�[�v��
-F_CHANGETYPE			= 32811,		// �^�C�v�ʐݒ�ꎞ�K�p						int nTypeIndex
-F_FILEOPEN2				= 32812,		// �J��2									const WCHAR* filename, ECodeType nCharCode, bool bViewMode, const WCHAR* defaultName
-F_COMMITUNDOBUFFER	= 32813,	// OpeBlK�R�~�b�g
+F_CHGMOD_EOL			= 32800,		// 入力改行コード指定						enumEOLType e
+F_SET_QUOTESTRING		= 32801,		// 共通設定: 引用符の設定					const WCHAR* quotestr
+F_TRACEOUT				= 32802,		// マクロ用アウトプットウインドウに出力		const WCHAR* outputstr, int nFlgOpt
+F_PUTFILE				= 32803,		// 作業中ファイルの一時出力 2006.12.10 maru
+F_INSFILE				= 32804,		// キャレット位置にファイル挿入 2006.12.10 maru
+F_TEXTWRAPMETHOD		= 32805,		// テキストの折り返し方法					なし
+F_INSBOXTEXT			= 32806,		// 矩形テキスト挿入
+F_MOVECURSOR			= 32807,		// カーソル移動
+F_MOVECURSORLAYOUT		= 32808,		// カーソル移動(レイアウト)
+F_STATUSMSG				= 32809,		// ステータスメッセージ
+F_MSGBEEP				= 32810,		// ビープ音
+F_CHANGETYPE			= 32811,		// タイプ別設定一時適用						int nTypeIndex
+F_FILEOPEN2				= 32812,		// 開く2									const WCHAR* filename, ECodeType nCharCode, bool bViewMode, const WCHAR* defaultName
+F_COMMITUNDOBUFFER	= 32813,	// OpeBlKコミット
 F_ADDREFUNDOBUFFER	= 32814,	// OpeBlK AddRef
 F_SETUNDOBUFFER		= 32815,	// OpeBlK Release
-F_APPENDUNDOBUFFERCURSOR	= 32816,	// OpeBlK �ɃJ�[�\���ʒu��ǉ�
-F_CLIPBOARDEMPTY		= 32817,		// �N���b�v�{�[�h�N���A
-F_SETVIEWTOP			= 32818,		// �r���[�̏�̍s����ݒ�					CLayoutYInt nLineNumber
-F_SETVIEWLEFT			= 32819,		// �r���[�̍��[�̌�����ݒ�					CLayoutXInt nColumnIndex
+F_APPENDUNDOBUFFERCURSOR	= 32816,	// OpeBlK にカーソル位置を追加
+F_CLIPBOARDEMPTY		= 32817,		// クリップボードクリア
+F_SETVIEWTOP			= 32818,		// ビューの上の行数を設定					CLayoutYInt nLineNumber
+F_SETVIEWLEFT			= 32819,		// ビューの左端の桁数を設定					CLayoutXInt nColumnIndex
 
 
-F_FUNCTION_FIRST	= 40000,	// 2003-02-21 �S ����ȏゾ�Ɗ֐�
+F_FUNCTION_FIRST	= 40000,	// 2003-02-21 鬼 これ以上だと関数
 
-F_GETFILENAME		= 40001,	// �ҏW���̃t�@�C�������擾����
-F_GETSAVEFILENAME	= 40018,	// �ۑ����̃t�@�C�������擾����	// 2006.09.04 ryoji
-F_GETSELECTED		= 40002,	// �I��͈͂̎擾
-F_EXPANDPARAMETER	= 40003,	// �R�}���h���C���p�����[�^�W�J
-F_GETLINESTR		= 40004,	// �w��s�_���f�[�^���擾����
-F_GETLINECOUNT		= 40005,	// �_���s�����擾����
-F_CHGTABWIDTH		= 40006,	// �^�u�T�C�Y���擾�A�ݒ肷��
-F_ISTEXTSELECTED	= 40007,	// �e�L�X�g���I������Ă��邩
-F_GETSELLINEFROM	= 40008,	// �I���J�n�s�̎擾
-F_GETSELCOLUMNFROM	= 40009,	// �I���J�n���̎擾
-F_GETSELLINETO		= 40010,	// �I���I���s�̎擾
-F_GETSELCOLUMNTO	= 40011,	// �I���I�����̎擾
-F_ISINSMODE			= 40012,	// �}���^�㏑�����[�h�̎擾
-F_GETCHARCODE		= 40013,	// �����R�[�h�擾
-F_GETLINECODE		= 40014,	// ���s�R�[�h�擾
-F_ISPOSSIBLEUNDO	= 40015,	// Undo�\�����ׂ�
-F_ISPOSSIBLEREDO	= 40016,	// Redo�\�����ׂ�
-F_CHGWRAPCOLUMN		= 40017,	// �܂�Ԃ������擾�A�ݒ肷�� 2008.06.19 ryoji
-F_ISCURTYPEEXT		= 40019,	// �w�肵���g���q�����݂̃^�C�v�ʐݒ�Ɋ܂܂�Ă��邩�ǂ����𒲂ׂ� 2006.09.04 ryoji
-F_ISSAMETYPEEXT		= 40020,	// �Q�̊g���q�������^�C�v�ʐݒ�Ɋ܂܂�Ă��邩�ǂ����𒲂ׂ� 2006.09.04 ryoji
-F_INPUTBOX			= 40021,	// �e�L�X�g���̓_�C�A���O�̕\��
-F_MESSAGEBOX		= 40023,	// ���b�Z�[�W�{�b�N�X�̕\��
-F_ERRORMSG			= 40024,	// ���b�Z�[�W�{�b�N�X�i�G���[�j�̕\��
-F_WARNMSG			= 40025,	// ���b�Z�[�W�{�b�N�X�i�x���j�̕\��
-F_INFOMSG			= 40026,	// ���b�Z�[�W�{�b�N�X�i���j�̕\��
-F_OKCANCELBOX		= 40027,	// ���b�Z�[�W�{�b�N�X�i�m�F�FOK�^�L�����Z���j�̕\��
-F_YESNOBOX			= 40028,	// ���b�Z�[�W�{�b�N�X�i�m�F�F�͂��^�������j�̕\��
-F_COMPAREVERSION	= 40029,	// �o�[�W�����ԍ��̔�r
-F_MACROSLEEP		= 40030,	// �w�肵�����ԁi�~���b�j��~
-F_FILEOPENDIALOG	= 40031,	// �t�@�C�����J���_�C�A���O�̕\��
-F_FILESAVEDIALOG	= 40032,	// �t�@�C����ۑ��_�C�A���O�̕\��
-F_FOLDERDIALOG		= 40033,	// �t�H���_���J���_�C�A���O�̕\��
-F_GETCLIPBOARD		= 40034,	// �N���b�v�{�[�h�̕�������擾
-F_SETCLIPBOARD		= 40035,	// �N���b�v�{�[�h�ɕ������ݒ�
-F_LAYOUTTOLOGICLINENUM	= 40036,	// ���W�b�N�s�ԍ��擾
-F_LOGICTOLAYOUTLINENUM	= 40037,	// ���C�A�E�g�s�ԍ��擾
-F_LINECOLUMNTOINDEX	= 40038,	// ���W�b�N���ԍ��擾
-F_LINEINDEXTOCOLUMN	= 40039,	// ���C�A�E�g���ԍ��擾
-F_GETCOOKIE			= 40040,	// Cookie�擾
-F_GETCOOKIEDEFAULT	= 40041,	// Cookie�擾�f�t�H���g�l
-F_SETCOOKIE			= 40042,	// Cookie�ݒ�
-F_DELETECOOKIE		= 40043,	// Cookie�폜
-F_GETCOOKIENAMES	= 40044,	// Cookie���O�擾
-F_SETDRAWSWITCH		= 40045,	// �ĕ`��X�C�b�`�ݒ�
-F_GETDRAWSWITCH		= 40046,	// �ĕ`��X�C�b�`�擾
-F_ISSHOWNSTATUS		= 40047,	// �X�e�[�^�X�E�B���h�E���\������Ă��邩
-F_GETSTRWIDTH		= 40048,	// �����񕝎擾
-F_GETSTRLAYOUTLENGTH = 40049,	// ������̃��C�A�E�g���擾
-F_GETDEFAULTCHARLENGTH = 40050,	// �f�t�H���g�������̎擾
-F_ISINCLUDECLIPBOARDFORMAT	= 40051,	// �N���b�v�{�[�h�̌`���擾
-F_GETCLIPBOARDBYFORMAT	= 40052,	// �N���b�v�{�[�h�̎w��`���Ŏ擾
-F_SETCLIPBOARDBYFORMAT	= 40053,	// �N���b�v�{�[�h�̎w��`���Őݒ�
-F_GETLINEATTRIBUTE	= 40054,		// �s�����擾
-F_ISTEXTSELECTINGLOCK	= 40055,	// �I����Ԃ̃��b�N���擾
-F_GETVIEWLINES		= 40056,	// �r���[�̍s���擾
-F_GETVIEWCOLUMNS	= 40057,	// �r���[�̗񐔎擾
-F_CREATEMENU		= 40058,	// ���j���[�쐬
+F_GETFILENAME		= 40001,	// 編集中のファイル名を取得する
+F_GETSAVEFILENAME	= 40018,	// 保存時のファイル名を取得する	// 2006.09.04 ryoji
+F_GETSELECTED		= 40002,	// 選択範囲の取得
+F_EXPANDPARAMETER	= 40003,	// コマンドラインパラメータ展開
+F_GETLINESTR		= 40004,	// 指定行論理データを取得する
+F_GETLINECOUNT		= 40005,	// 論理行数を取得する
+F_CHGTABWIDTH		= 40006,	// タブサイズを取得、設定する
+F_ISTEXTSELECTED	= 40007,	// テキストが選択されているか
+F_GETSELLINEFROM	= 40008,	// 選択開始行の取得
+F_GETSELCOLUMNFROM	= 40009,	// 選択開始桁の取得
+F_GETSELLINETO		= 40010,	// 選択終了行の取得
+F_GETSELCOLUMNTO	= 40011,	// 選択終了桁の取得
+F_ISINSMODE			= 40012,	// 挿入／上書きモードの取得
+F_GETCHARCODE		= 40013,	// 文字コード取得
+F_GETLINECODE		= 40014,	// 改行コード取得
+F_ISPOSSIBLEUNDO	= 40015,	// Undo可能か調べる
+F_ISPOSSIBLEREDO	= 40016,	// Redo可能か調べる
+F_CHGWRAPCOLUMN		= 40017,	// 折り返し桁を取得、設定する 2008.06.19 ryoji
+F_ISCURTYPEEXT		= 40019,	// 指定した拡張子が現在のタイプ別設定に含まれているかどうかを調べる 2006.09.04 ryoji
+F_ISSAMETYPEEXT		= 40020,	// ２つの拡張子が同じタイプ別設定に含まれているかどうかを調べる 2006.09.04 ryoji
+F_INPUTBOX			= 40021,	// テキスト入力ダイアログの表示
+F_MESSAGEBOX		= 40023,	// メッセージボックスの表示
+F_ERRORMSG			= 40024,	// メッセージボックス（エラー）の表示
+F_WARNMSG			= 40025,	// メッセージボックス（警告）の表示
+F_INFOMSG			= 40026,	// メッセージボックス（情報）の表示
+F_OKCANCELBOX		= 40027,	// メッセージボックス（確認：OK／キャンセル）の表示
+F_YESNOBOX			= 40028,	// メッセージボックス（確認：はい／いいえ）の表示
+F_COMPAREVERSION	= 40029,	// バージョン番号の比較
+F_MACROSLEEP		= 40030,	// 指定した時間（ミリ秒）停止
+F_FILEOPENDIALOG	= 40031,	// ファイルを開くダイアログの表示
+F_FILESAVEDIALOG	= 40032,	// ファイルを保存ダイアログの表示
+F_FOLDERDIALOG		= 40033,	// フォルダを開くダイアログの表示
+F_GETCLIPBOARD		= 40034,	// クリップボードの文字列を取得
+F_SETCLIPBOARD		= 40035,	// クリップボードに文字列を設定
+F_LAYOUTTOLOGICLINENUM	= 40036,	// ロジック行番号取得
+F_LOGICTOLAYOUTLINENUM	= 40037,	// レイアウト行番号取得
+F_LINECOLUMNTOINDEX	= 40038,	// ロジック桁番号取得
+F_LINEINDEXTOCOLUMN	= 40039,	// レイアウト桁番号取得
+F_GETCOOKIE			= 40040,	// Cookie取得
+F_GETCOOKIEDEFAULT	= 40041,	// Cookie取得デフォルト値
+F_SETCOOKIE			= 40042,	// Cookie設定
+F_DELETECOOKIE		= 40043,	// Cookie削除
+F_GETCOOKIENAMES	= 40044,	// Cookie名前取得
+F_SETDRAWSWITCH		= 40045,	// 再描画スイッチ設定
+F_GETDRAWSWITCH		= 40046,	// 再描画スイッチ取得
+F_ISSHOWNSTATUS		= 40047,	// ステータスウィンドウが表示されているか
+F_GETSTRWIDTH		= 40048,	// 文字列幅取得
+F_GETSTRLAYOUTLENGTH = 40049,	// 文字列のレイアウト幅取得
+F_GETDEFAULTCHARLENGTH = 40050,	// デフォルト文字幅の取得
+F_ISINCLUDECLIPBOARDFORMAT	= 40051,	// クリップボードの形式取得
+F_GETCLIPBOARDBYFORMAT	= 40052,	// クリップボードの指定形式で取得
+F_SETCLIPBOARDBYFORMAT	= 40053,	// クリップボードの指定形式で設定
+F_GETLINEATTRIBUTE	= 40054,		// 行属性取得
+F_ISTEXTSELECTINGLOCK	= 40055,	// 選択状態のロックを取得
+F_GETVIEWLINES		= 40056,	// ビューの行数取得
+F_GETVIEWCOLUMNS	= 40057,	// ビューの列数取得
+F_CREATEMENU		= 40058,	// メニュー作成
 
 
-//	= 2005,.01.10 genta ISearch�p�⏕�R�[�h
-//	2007.07.07 genta 16bit�ȓ��Ɏ��߂Ȃ��Ə󋵃R�[�h�ƏՓ˂���̂ŃR�[�h��ύX
-F_ISEARCH_ADD_CHAR	= 0xC001,	//	Incremental Search��1�����֒ǉ�
-F_ISEARCH_ADD_STR	= 0xC002,	//	Incremental Search�֕�����֒ǉ�
-F_ISEARCH_DEL_BACK	= 0xC003,	//	Incremental Search�̖�������1�����폜
+//	= 2005,.01.10 genta ISearch用補助コード
+//	2007.07.07 genta 16bit以内に収めないと状況コードと衝突するのでコードを変更
+F_ISEARCH_ADD_CHAR	= 0xC001,	//	Incremental Searchへ1文字へ追加
+F_ISEARCH_ADD_STR	= 0xC002,	//	Incremental Searchへ文字列へ追加
+F_ISEARCH_DEL_BACK	= 0xC003,	//	Incremental Searchの末尾から1文字削除
 
 //}; //end of enum EFunction

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -33,7 +33,7 @@ DEFINES= \
  $(MYDEFINES)
 CFLAGS= \
  -finput-charset=utf-8 \
- -fexec-charset=utf-8 \
+ -fexec-charset=cp932 \
  -I. \
  $(DEFINES) $(MYCFLAGS)
 CXXFLAGS= $(CFLAGS) $(MYCXXFLAGS)

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -33,7 +33,7 @@ DEFINES= \
  $(MYDEFINES)
 CFLAGS= \
  -finput-charset=utf-8 \
- -fexec-charset=cp932 \
+ -fexec-charset=utf-8 \
  -I. \
  $(DEFINES) $(MYCFLAGS)
 CXXFLAGS= $(CFLAGS) $(MYCXXFLAGS)


### PR DESCRIPTION
## 目的

appveyorのビルドを速くする

## 概要

appveyorのビルドに時間がかかる要因として、
ビルド前にシステムロケールを変更して再起動を行っていることをあげられます。
ロケール変更に必要な時間は、混雑具合などにもよりますが2分くらいです。

何故ロケール変更をしているかというと、
サクラエディタが日本語アプリだからです。

もう少し厳密な言い方をすると、
日本語で書かれているソースコードをコンパイルするためには、
システムロケールを変える必要があったためです。
（日本語で書かれている＝文字コードがSJISだと思ってください。）

https://github.com/sakura-editor/sakura/issues/112#issuecomment-423911395 で書いた通り、
このロケール設定をしなくて済む方法がありそうです。


## 修正内容の説明

この修正は code&fix で検証しながら作ったものなので、やったことを書きます。

1. 単純にロケール設定を外すだけの修正をしてみた
　→[ビルドエラーになった。](https://ci.appveyor.com/project/berryzplus/sakura/build/1.0.141/job/ty85cm44pj5755bg)
2. HeaderMakeに異常がありそうなので調べてみた
　→Funccode_x.hsrcをcl.exeでプリプロセスするときに警告が出てることが分かった
3. Funccode_x.hsrcの文字コードがSJISであることに気付いた
　→Funccode_x.hsrcの文字コードを変換してみた
4. cl.exeのプリプロセスで警告がでるようになった
　→cl.exeのコマンドラインに/utf-8を足してみた
5. cl.exeのプリプロセスの警告が消えた
　→本体側のビルドで警告が消えないことに気付いた
6. sakura.vcxprojのadditional optionに文字コード指定(sjis)があることに気付いた
　→additional optionを/utf-8に差し替えた
7. 警告全部消えた

## 確認内容

ソースコードがすべてUNICODE化されたため、
英語環境でも問題なくビルドできるようになっているはずです。

ロケール変更をせずにビルドしています。

「asmに差が出ないこと」でチェックできるかも知れません。
生成されたexeはいちおう日本語表示できてそうです。

