### PR TITLE
インストーラのビルドログをファイルに出力する

### DIFF
--- a/build-installer.bat
+++ b/build-installer.bat
@@ -1,6 +1,7 @@
 @echo off
 set platform=%1
 set configuration=%2
+set ISS_LOG_FILE=iss-%platform%-%configuration%.log
 
 if "%platform%" == "Win32" (
 	@rem OK
@@ -56,7 +57,8 @@ copy /Y /B %platform%\%configuration%\*.exe                 %INSTALLER_WORK%\ > 
 copy /Y /B %platform%\%configuration%\*.dll                 %INSTALLER_WORK%\ > NUL
 
 set SAKURA_ISS=installer\sakura-%platform%.iss
-"%CMD_ISCC%" %SAKURA_ISS% > NUL || (echo error && exit /b 1)
+@echo running "%CMD_ISCC%" %SAKURA_ISS%
+"%CMD_ISCC%" %SAKURA_ISS% > %ISS_LOG_FILE% || (echo error && exit /b 1)
 exit /b 0
 
 @rem ------------------------------------------------------------------------------

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -189,6 +189,11 @@ copy /Y msbuild-%platform%-%configuration%.log.csv %WORKDIR_LOG%\
 if exist "msbuild-%platform%-%configuration%.log.xlsx" (
 	copy /Y /B "msbuild-%platform%-%configuration%.log.xlsx" %WORKDIR_LOG%\
 )
+set ISS_LOG_FILE=iss-%platform%-%configuration%.log
+if exist "%ISS_LOG_FILE%" (
+	copy /Y /B "%ISS_LOG_FILE%" %WORKDIR_LOG%\
+)
+
 copy /Y sakura_core\githash.h                      %WORKDIR_LOG%\
 if exist "cppcheck-install.log" (
 	copy /Y "cppcheck-install.log" %WORKDIR_LOG%\


### PR DESCRIPTION
#480 でインストーラのビルドログが抑制されたのでビルド内容を確認できなくなるので
インストーラのビルドログをファイルに出力する

※ ただしビルドに失敗した場合、成果物は収集されない。

