### PR TITLE
[WIP] tag の置換が正しく動かないのを修正

### DIFF
--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -52,10 +52,16 @@ if not "%APPVEYOR_BUILD_NUMBER%" == "" (
 @echo checking APPVEYOR_REPO_TAG_NAME %APPVEYOR_REPO_TAG_NAME%
 if not "%APPVEYOR_REPO_TAG_NAME%" == "" (
 	@rem replace '/' with '_'
-	set TEMP_NAME=%APPVEYOR_REPO_TAG_NAME:/=_%
+	set TEMP_NAME1=%APPVEYOR_REPO_TAG_NAME:/=_%
+	@echo TEMP_NAME1 = %TEMP_NAME1%
+	
+	@rem replace ' ' with '_'
+	set TEMP_NAME2=%TEMP_NAME1: =_%
+	@echo TEMP_NAME2 = %TEMP_NAME2%
 
 	@rem replace ' ' with '_'
-	set TAG_NAME=tag_%TEMP_NAME: =_%
+	set TAG_NAME=tag-%TEMP_NAME2%
+	@echo TAG_NAME = %TAG_NAME%
 )
 
 @echo checking APPVEYOR_PULL_REQUEST_NUMBER %APPVEYOR_PULL_REQUEST_NUMBER%


### PR DESCRIPTION
[WIP] tag の置換が正しく動かないのを修正

まだ意図通り、動作していないが、#485 が作成されたので情報共有のために PR しておく。
