### PR TITLE
RFC5321解釈の誤りを訂正する

### DIFF
--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -1154,23 +1154,7 @@ inline static bool IsMailAddressDomain(
 	// ドメイン形式だけチェックする
 	// 生IPを書く形式にはいったん対応しない
 	// 将来的に生IPに対応する場合は 短絡OR で条件をつなげる
-	bool result = IsDomain(pszScan, pszScanEnd, ppszEndOfMailBox);
-
-	if (!result) {
-		return false;
-	}
-
-	// スキャン範囲が余った場合の追加チェック
-	if (*ppszEndOfMailBox < pszScanEnd) {
-		const wchar_t trailingChar = **ppszEndOfMailBox;
-		if (trailingChar == L'.'
-			|| trailingChar == L'-'
-			|| IsLetDig(trailingChar)) {
-			return false;
-		}
-	}
-
-	return true;
+	return IsDomain(pszScan, pszScanEnd, ppszEndOfMailBox);
 }
 
 /*!

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -1086,8 +1086,7 @@ BOOL IsMailAddress( const wchar_t* pszBuf, int nBufLen, int* pnAddressLength )
 
 	// IsMailAddressDomainがtrueを返したら、以下は必ず成立する
 	assert(pszEndOfMailBox != nullptr);
-	assert(pszEndOfMailBox > pszAtmark + 1);
-	assert(pszEndOfMailBox < pszBuf + MAX_MAILBOX + 1);
+	assert(pszAtmark < pszEndOfMailBox);
 
 	// メールアドレス全体の長さを再度チェックする
 	if (pszBuf + MAX_MAILBOX < pszEndOfMailBox) {

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -1084,6 +1084,16 @@ BOOL IsMailAddress( const wchar_t* pszBuf, int nBufLen, int* pnAddressLength )
 		return FALSE;
 	}
 
+	// スキャン範囲が余った場合の追加チェック
+	if (pszEndOfMailBox < pszBuf + nBufLen) {
+		const wchar_t trailingChar = *pszEndOfMailBox;
+		if (trailingChar == L'.'
+			|| trailingChar == L'-'
+			|| IsLetDig(trailingChar)) {
+			return false;
+		}
+	}
+
 	// アドレス長を受け取る変数が設定されている場合
 	if (pnAddressLength != nullptr) {
 		*pnAddressLength = pszEndOfMailBox - pszBuf;
@@ -1296,6 +1306,11 @@ inline static bool IsDomain(
 			return false;
 		}
 		assert(ppszDotOrNotAlnum != nullptr);
+
+		// 見付かった終端(=スキャン位置)が終端に達しているかチェックする
+		if (*ppszDotOrNotAlnum == pszScanEnd) {
+			break;
+		}
 
 		// サブドメインの後ろに '.' があるかチェックする
 		if (**ppszDotOrNotAlnum != L'.') {

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -1032,6 +1032,10 @@ inline static bool IsSubDomain(
 	_Out_ const wchar_t** ppszDotOrNotAlnum
 ) noexcept;
 
+inline static bool IsLetDig(
+	_In_ const wchar_t ch
+) noexcept;
+
 inline static bool IsAtomChar(
 	_In_ const wchar_t ch
 ) noexcept;
@@ -1321,8 +1325,7 @@ inline static bool IsDomain(
 
 	assert(ppszDotOrNotAlnum != nullptr);
 
-	if (pszScan == *ppszDotOrNotAlnum
-		|| (**ppszDotOrNotAlnum <= 0xFF && ::isalnum(**ppszDotOrNotAlnum))) {
+	if (IsLetDig(**ppszDotOrNotAlnum)) {
 		return false;
 	}
 
@@ -1365,7 +1368,7 @@ inline static bool IsSubDomain(
 	ParseState state = OTHER;
 
 	// 文字列がlet-digで始まっているかチェックする
-	if (!(*pszScan <= 0xFF && ::isalnum(*pszScan))) {
+	if (!IsLetDig(*pszScan)) {
 		return false;
 	}
 
@@ -1382,7 +1385,7 @@ inline static bool IsSubDomain(
 			state = DOT;
 			break;
 		default:
-			if (*pszScan <= 0xFF && ::isalnum(*pszScan)) {
+			if (IsLetDig(*pszScan)) {
 				state = ALNUM;
 			} else {
 				state = OTHER;
@@ -1407,7 +1410,17 @@ inline static bool IsSubDomain(
 	return true;
 }
 
-/*/*
+/*
+ * RFC5321 let-dig の要件を満たすかどうか判定する
+ */
+inline static bool IsLetDig(
+	_In_ const wchar_t ch
+) noexcept
+{
+	return ch <= 0xFF && ::isalnum( ch );
+}
+
+/*
  * RFC5322 atom の要件を満たすかどうか判定する
  *
  * 高速化目的で可読性を捨て、あえて冗長な switch 分岐にしている。

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -1085,7 +1085,9 @@ BOOL IsMailAddress( const wchar_t* pszBuf, int nBufLen, int* pnAddressLength )
 	}
 
 	// IsMailAddressDomainがtrueを返したら、以下は必ず成立する
-	assert(pszEndOfMailBox);
+	assert(pszEndOfMailBox != nullptr);
+	assert(pszEndOfMailBox > pszAtmark + 1);
+	assert(pszEndOfMailBox < pszBuf + MAX_MAILBOX + 1);
 
 	// メールアドレス全体の長さを再度チェックする
 	if (pszBuf + MAX_MAILBOX < pszEndOfMailBox) {
@@ -1114,6 +1116,7 @@ inline static bool IsMailAddressLocalPart(
 {
 	// 関数仕様
 	assert(pszScan < pszScanEnd); // 開始位置と終了位置は逆転してはならない
+	assert(ppszAtmark != nullptr); // _Out_ 引数は NULL 指定不可
 
 	// 出力値を初期化する
 	*ppszAtmark = nullptr;
@@ -1142,6 +1145,7 @@ inline static bool IsMailAddressDomain(
 {
 	// 関数仕様
 	assert(pszScan < pszScanEnd); // 開始位置と終了位置は逆転してはならない
+	assert(ppszEndOfMailBox != nullptr); // _Out_ 引数は NULL 指定不可
 
 	// 出力値を初期化する
 	*ppszEndOfMailBox = nullptr;
@@ -1171,6 +1175,7 @@ inline static bool IsDotString(
 {
 	// 関数仕様
 	assert(pszScan < pszScanEnd); // 開始位置と終了位置は逆転してはならない
+	assert(ppszAtmark != nullptr); // _Out_ 引数は NULL 指定不可
 
 	// 出力値を初期化する
 	*ppszAtmark = nullptr;
@@ -1219,6 +1224,7 @@ inline static bool IsQuotedString(
 {
 	// 関数仕様
 	assert(pszScan < pszScanEnd); // 開始位置と終了位置は逆転してはならない
+	assert(ppszAtmark != nullptr); // _Out_ 引数は NULL 指定不可
 
 	// 出力値を初期化する
 	*ppszAtmark = nullptr;
@@ -1287,6 +1293,7 @@ inline static bool IsDomain(
 
 	// 関数仕様
 	assert(pszScan < pszScanEnd); // 開始位置と終了位置は逆転してはならない
+	assert(ppszDotOrNotAlnum != nullptr); // _Out_ 引数は NULL 指定不可
 
 	// 出力値を初期化する
 	*ppszDotOrNotAlnum = nullptr;
@@ -1343,6 +1350,7 @@ inline static bool IsSubDomain(
 {
 	// 関数仕様
 	assert(pszScan < pszScanEnd); // 開始位置と終了位置は逆転してはならない
+	assert(ppszDotOrNotAlnum != nullptr); // _Out_ 引数は NULL 指定不可
 
 	// 出力値を初期化する
 	*ppszDotOrNotAlnum = nullptr;

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -1417,7 +1417,8 @@ inline static bool IsLetDig(
 	_In_ const wchar_t ch
 ) noexcept
 {
-	return ch <= 0xFF && ::isalnum( ch );
+	// コードポイントがASCII範囲、かつ、isalnumがtrueを返す場合にtrue.
+	return ch <= 0x7F && ::isalnum( ch );
 }
 
 /*


### PR DESCRIPTION
## 目的

#421 の改善です。

取込済みPRでRFC5321を誤って解釈していたのを訂正します。

誤解釈によって、正しくないメールアドレスをメールアドレスと判定しています。
GitHub移行後に組み込んだバグなので対処は必須と考えています。


## 経緯

@berryzplus 
> #398 の対策 PR です。

@ds14050 さん https://github.com/sakura-editor/sakura/pull/421#issuecomment-421390488
> 終わったことですが、疑問点はつぶしておきたい性分です。
> 
> > dot-String という構文規則がオクテットのくだりの根拠になります。
> 
> その構文規則は読んでいましたが、Atom = 1*atext の解釈ができませんでした。しかし、Wikipedia(ja) による ローカル部に使用できる文字は以下のASCII文字である。まず、次のASCII文字をそのまま並べた形式（RFC 5321ではDot-string、RFC 5322ではdot-atomと呼ぶ）が使用できる。 という説明を読んでいたので、単一の(=連続しない)ドットで区切られた半角英数記号の連続であろうという予想をしていました。
> 
> dot-string は「ドット区切りの 3桁8進数」の定義ではなさそうです。quoted-string 以外のすべての local-part が dot-string なのだから、通常見かけるメールアドレスのローカル部が dot-string であるはずなのです。

@ds14050 さん https://github.com/sakura-editor/sakura/pull/421#issuecomment-421399913
> `a@vvvv[EOF]` という６文字のテキストがメールアドレスであると判定されたのですが、間違ったものをダウンロードしていますか？

@berryzplus https://github.com/sakura-editor/sakura/pull/421#issuecomment-421403047
> > `a@vvvv[EOF]` という６文字のテキストがメールアドレスであると判定されたのですが、間違ったものをダウンロードしていますか？
> 
> コードのコメントとずれてますが、正しい判定結果だと思います。
>  大きな影響はないと思いますが、判定結果やや微妙なのでもう一度整理が必要だと思っています。
>  後日、別issueを立てて書いていただいたコメントで未回答のものも対策していきたいと考えています。


@ds14050 さん https://github.com/sakura-editor/sakura/pull/421#issuecomment-421408029
> 後ろが[EOF]である場合にだけ起こるバグ(判定ミス)だと思います。
> 
> もうひとつ、a a@example.com が全体としてメールアドレスであると判定されますが、以前はスペースで途切れていました。これは RFC 対応による違いなのでしょうか(と調べる前に質問します)。なお、ダブルクリックして Thunderbird が起動すると宛先は自動的に "a a"@example.com になっていました。


@berryzplus https://github.com/sakura-editor/sakura/pull/421#issuecomment-421413213
> > dot-string は「ドット区切りの 3桁8進数」の定義ではなさそうです。
> 
> そういわれると正直あやしいので、解釈の流れを説明してみます。
> 
> まず、メールアドレスのBNFがこれです。
>    Mailbox        = Local-part "@" ( Domain / address-literal )
> 
>    Local-part     = Dot-string / Quoted-string
>                   ; 大文字・小文字を区別しなくてもよい(MAY)
> 
> 
> local-part は dot-string または qutoted-string で構成される・・・
>    Dot-string     = Atom *("."  Atom)
> 
> 
> dot-string は atom とそれに続く0個以上の( "." に続く atom )で構成される・・・
>    Atom           = 1*atext
> 
> 
> atom は 1 とそれに続く0個以上の atext で構成される・・・
> 
> 
> atext についての説明は見つからず。ここからは想像・・・
> 
> C言語の世界ならば 8進数 は 077 のように書くのが普通だと思います。
> 
> 何故「1 始まりの任意のテキスト」と解釈したかというと、
> これが SendMail (=SMTP) について書かれた文書だから、ということになります。
> 
> chmod 755 test.sh と書くときの 755 が 8進数 であることはご存じだと思います。
> unix系文化では 8進数 の 3桁数字 が結構使われているような気がします。
> 
> ここで「1 始まりの任意のテキスト」に何か特定の意味を当てはめようとしてみます。
> ASCIIコード 100 ～ 177 (0x40～0x7F) だと考えるとしっくりくるんです。
> アメリカ人は文字を表現するのに 7bit しか使わないので、
> この範囲で文字の大半を表せてしまうのです・・・
> 
> 
> 一番肝心な部分が「想像だった」ってオチなんですけどね。


@berryzplus https://github.com/sakura-editor/sakura/pull/421#issuecomment-421415234
> > もうひとつ、a a@example.com が全体としてメールアドレスであると判定されますが、以前はスペースで途切れていました。これは RFC 対応による結果なのでしょうか(と調べる前に質問します)。
> 
> これはバグですね。次リリースまでには直すべきものと認識しました。



@k-takata さん https://github.com/sakura-editor/sakura/pull/421#issuecomment-421529694
> > Atom = 1*atext
> 
> 1* の表記はRFC 5234で定義されており、1個以上のatextの連続を意味します。atextはなぜかRFC 5321では一切言及がありませんが、RFC 5322には
>    atext           =   ALPHA / DIGIT /    ; Printable US-ASCII
>                        "!" / "#" /        ;  characters not including
>                        "$" / "%" /        ;  specials.  Used for atoms.
>                        "&" / "'" /
>                        "*" / "+" /
>                        "-" / "/" /
>                        "=" / "?" /
>                        "^" / "_" /
>                        "`" / "{" /
>                        "|" / "}" /
>                        "~"
> 
> 
> と定義されています。「ドット区切りの 3桁8進数」ではありません。


@berryzplus https://github.com/sakura-editor/sakura/pull/421#issuecomment-421540302
> >「ドット区切りの 3桁8進数」ではありません。
> 
> ありがとうございます。
>  条件修正しておかしくなってるのを直したいと思います。

