### PR TITLE
MinGWビルドをappveyorに組み込む

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ configuration:
 platform:
   - Win32
   - x64
+  - MinGW
 
 build_script:
 - cmd: >-

--- a/build-all.bat
+++ b/build-all.bat
@@ -6,6 +6,8 @@ if "%platform%" == "Win32" (
 	@rem OK
 ) else if "%platform%" == "x64" (
 	@rem OK
+) else if "%platform%" == "MinGW" (
+	@rem OK
 ) else (
 	call :showhelp %0
 	exit /b 1
@@ -23,6 +25,12 @@ if "%configuration%" == "Release" (
 @echo PLATFORM      %PLATFORM%
 @echo CONFIGURATION %CONFIGURATION%
 @echo.
+
+if "%platform%" == "MinGW" (
+	@echo call build-gnu.bat %PLATFORM% %CONFIGURATION%
+	call build-gnu.bat   %PLATFORM% %CONFIGURATION% || (echo error build-gnu.bat       && exit /b 1)
+	exit /b 0
+)
 
 @echo ---- start build-sln.bat ----
 call build-sln.bat       %PLATFORM% %CONFIGURATION% || (echo error build-sln.bat       && exit /b 1)
@@ -66,7 +74,7 @@ exit /b 0
 @echo    %~nx1 platform configuration
 @echo.
 @echo parameter
-@echo    platform      : Win32   or x64
+@echo    platform      : Win32   or x64   or MinGW
 @echo    configuration : Release or Debug
 @echo.
 @echo example
@@ -74,4 +82,6 @@ exit /b 0
 @echo    %~nx1 Win32 Debug
 @echo    %~nx1 x64   Release
 @echo    %~nx1 x64   Release
+@echo    %~nx1 MinGW Release
+@echo    %~nx1 MinGW Debug
 exit /b 0

--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -1,0 +1,56 @@
+@echo off
+set platform=%1
+set configuration=%2
+
+if "%platform%" == "MinGW" (
+	@rem OK
+) else (
+	call :showhelp %0
+	exit /b 1
+)
+
+if "%configuration%" == "Release" (
+	@rem OK
+    set MYDEFINES=-DNDEBUG
+    set MYCFLAGS=-O2
+    set MYLIBS=-s
+) else if "%configuration%" == "Debug" (
+	@rem OK
+    set MYDEFINES=-D_DEBUG
+    set MYCFLAGS=-g -O0
+    set MYLIBS=
+) else (
+	call :showhelp %0
+	exit /b 1
+)
+
+@rem https://www.appveyor.com/docs/environment-variables/
+path=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%path%
+
+@echo mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%"
+mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" githash stdafx Funccode_enum.h Funccode_define.h
+if %errorlevel% neq 0 (popd && exit /b 1)
+
+mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" -j4
+if %errorlevel% neq 0 (popd && exit /b 1)
+
+exit /b 0
+
+
+@rem ------------------------------------------------------------------------------
+@rem show help
+@rem see http://orangeclover.hatenablog.com/entry/20101004/1286120668
+@rem ------------------------------------------------------------------------------
+:showhelp
+@echo off
+@echo usage
+@echo    %~nx1 platform configuration
+@echo.
+@echo parameter
+@echo    platform      : MinGW
+@echo    configuration : Release or Debug
+@echo.
+@echo example
+@echo    %~nx1 MinGW Release
+@echo    %~nx1 MinGW Debug
+exit /b 0

--- a/sakura/mingw32-del.bat
+++ b/sakura/mingw32-del.bat
@@ -2,25 +2,20 @@
 
 SETLOCAL
 
-:引数で渡されたファイル群を取得
 set OUTFILES=%*
-:パス区切りを置換
 set OUTFILES=%OUTFILES:/=\%
 
 
 :del_file
-:1ファイルずつdelコマンドに渡して削除
 for /F "tokens=1,*" %%f in ("%OUTFILES%") DO (
   if exist %%f del /F /Q %%f
   set OUTFILES=%%g
 )
 
-:ぜんぶ削除できたら終了
-if "%OUTFILES%" == "" goto :EOF
+if "%OUTFILES%" == "" goto :END
 goto :del_file
 
 
 :END
-
 ENDLOCAL
 exit /b

--- a/tests/build-and-test.bat
+++ b/tests/build-and-test.bat
@@ -2,6 +2,11 @@ set platform=%1
 set configuration=%2
 set ERROR_RESULT=0
 
+if "%platform%" == "MinGW" (
+	@echo   test for MinGW will be skipped. (platform: %platform%, configuration: %configuration%)
+	exit /b 0
+)
+
 @echo ---- start create-project.bat ----
 call %~dp0create-project.bat %platform% %configuration%
 if %ERRORLEVEL% neq 0 (


### PR DESCRIPTION
## 目的

MinGWビルドをappveyorに組み込みます。
手元にMinGW環境を用意しなくても、
appveyorがビルドチェックをしてくれる環境を作ります。

## 変更内容

MinGWビルドでは成果物を作らず、ビルドテストのみを行うイメージを持っています。
純粋に MinGW でのビルドを行うだけの導入提案です。
　参考：https://github.com/sakura-editor/sakura/issues/427#issuecomment-419715803 

PR内容は #476 で共有した方法ほぼそのままです。

MinGWビルドを扱うコミットは稀なので、
同時に以下コメントで書いているバッチファイルのASCII化を行います。
https://github.com/sakura-editor/sakura/issues/112#issuecomment-423911395

