### PR TITLE
タイプ別設定画面のカラータブの色指定リストの背景色と前景色の色見本矩形の描画処理をDPIに合わせるように変更

### DIFF
--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -36,10 +36,15 @@
 
 using namespace std;
 
+namespace {
 //! カスタムカラー用の識別文字列
-static const TCHAR* TSTR_PTRCUSTOMCOLORS = _T("ptrCustomColors");
-
-WNDPROC	m_wpColorListProc;
+const TCHAR* TSTR_PTRCUSTOMCOLORS = _T("ptrCustomColors");
+WNDPROC m_wpColorListProc;
+int m_bgColorSampleLeft;
+int m_bgColorSampleRight;
+int m_fgColorSampleLeft;
+int m_fgColorSampleRight;
+}
 
 static const DWORD p_helpids2[] = {	//11400
 	IDC_LIST_COLORS,				HIDC_LIST_COLORS,				//色指定
@@ -229,7 +234,7 @@ LRESULT APIENTRY ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 			::InvalidateRect( hwnd, &rcItem, TRUE );
 		}else
 		/* 前景色見本 矩形 */
-		if( rcItem.right - 27 <= xPos && xPos <= rcItem.right - 27 + 12
+		if( m_fgColorSampleLeft <= xPos && xPos <= m_fgColorSampleRight
 			&& ( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_NO_TEXT) ) )
 		{
 			/* 色選択ダイアログ */
@@ -240,8 +245,8 @@ LRESULT APIENTRY ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 				::InvalidateRect( ::GetDlgItem( ::GetParent( hwnd ), IDC_BUTTON_TEXTCOLOR ), NULL, TRUE );
 			}
 		}else
-		/* 前景色見本 矩形 */
-		if( rcItem.right - 13 <= xPos && xPos <= rcItem.right - 13 + 12
+		/* 背景色見本 矩形 */
+		if( m_bgColorSampleLeft <= xPos && xPos <= m_bgColorSampleRight
 			&& ( 0 == (g_ColorAttributeArr[nIndex].fAttribute & COLOR_ATTRIB_NO_BACK) )	// 2006.12.18 ryoji フラグ利用で簡素化
 			)
 		{
@@ -1158,6 +1163,10 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 	}
 //	return;
 
+	const int colorSampleWidth = DpiScaleX(12);
+	const int scaled1 = DpiScaleX(1);
+	const int scaled2 = DpiScaleX(2);
+	const int scaled3 = DpiScaleX(3);
 
 	// 2002/11/02 Moca 比較方法変更
 //	if( 0 != strcmp( "カーソル行アンダーライン", pColorInfo->m_szName ) )
@@ -1165,14 +1174,17 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 	{
 		/* 背景色 見本矩形 */
 		rc1 = pDis->rcItem;
-		rc1.left = rc1.right - 13;
-		rc1.top += 2;
-		rc1.right = rc1.left + 12;
-		rc1.bottom -= 2;
+		rc1.left = rc1.right - (colorSampleWidth + scaled1);
+		rc1.top += scaled2;
+		rc1.right = rc1.left + colorSampleWidth;
+		rc1.bottom -= scaled2;
+
+		m_bgColorSampleLeft = rc1.left;
+		m_bgColorSampleRight = rc1.right;
 
 		gr.SetBrushColor( pColorInfo->m_sColorAttr.m_cBACK );
 		gr.SetPen( cRim );
-		::RoundRect( pDis->hDC, rc1.left, rc1.top, rc1.right, rc1.bottom , 3, 3 );
+		::RoundRect( pDis->hDC, rc1.left, rc1.top, rc1.right, rc1.bottom , scaled3, scaled3 );
 	}
 
 
@@ -1180,13 +1192,17 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 	{
 		/* 前景色 見本矩形 */
 		rc1 = pDis->rcItem;
-		rc1.left = rc1.right - 27;
-		rc1.top += 2;
-		rc1.right = rc1.left + 12;
-		rc1.bottom -= 2;
+		rc1.left = rc1.right - (2 * colorSampleWidth + scaled3);
+		rc1.top += scaled2;
+		rc1.right = rc1.left + colorSampleWidth;
+		rc1.bottom -= scaled2;
+
+		m_fgColorSampleLeft = rc1.left;
+		m_fgColorSampleRight = rc1.right;
+
 		gr.SetBrushColor( pColorInfo->m_sColorAttr.m_cTEXT );
 		gr.SetPen( cRim );
-		::RoundRect( pDis->hDC, rc1.left, rc1.top, rc1.right, rc1.bottom , 3, 3 );
+		::RoundRect( pDis->hDC, rc1.left, rc1.top, rc1.right, rc1.bottom , scaled3, scaled3 );
 	}
 }
 


### PR DESCRIPTION
高DPIだと色指定リストの色見本矩形の横幅が狭くて選択しにくかったのを改善しました。
左端のチェック描画には手を入れていません。そこは個人的に困っていないので。

スクリーンショットを貼り付けます。

| ディスプレイ設定 | 変更前 (4055e4f63ede85cea8c767abed9812e877ac1b9d) | 変更後 (dd0b317758d8c022f2dc691233f4d15951bbe122) |
|---|---|---|
| 100% | ![100_before](https://user-images.githubusercontent.com/1131125/46257277-ebfa1e00-c4f1-11e8-8b01-a7dfbda0ba7a.png) | ![100_after](https://user-images.githubusercontent.com/1131125/46257278-ef8da500-c4f1-11e8-8554-3ae5b372e9ca.png) |
| 150% | ![150_before](https://user-images.githubusercontent.com/1131125/46257288-25cb2480-c4f2-11e8-8cb2-693b6089a020.png) | ![150_after](https://user-images.githubusercontent.com/1131125/46257294-2d8ac900-c4f2-11e8-82bf-31d59e25a73c.png) |
| 200% | ![200_before](https://user-images.githubusercontent.com/1131125/46257297-39768b00-c4f2-11e8-9c9c-f298793f409c.png) | ![200_after](https://user-images.githubusercontent.com/1131125/46257299-3ed3d580-c4f2-11e8-8751-904246eb55f4.png) |

