### PR TITLE
ヘッダのプロトタイプ宣言で明示的に変数名を指定する (CMemory)

### DIFF
--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -70,15 +70,15 @@ public:
 	int GetRawLength() const { return m_nRawLen; }                //!<データ長を返す。バイト単位。
 
 	// 演算子
-	const CMemory& operator=( const CMemory& );
+	const CMemory& operator=(const CMemory& rhs);
 
 	// 比較
-	static int IsEqual( CMemory&, CMemory& );	/* 等しい内容か */
+	static int IsEqual(CMemory& cmem1, CMemory& cmem2);	/* 等しい内容か */
 
 	// 変換関数
-	static void SwapHLByte( char*, const int ); // 下記関数のstatic関数版
+	static void SwapHLByte(char* pData, const int nDataLen); // 下記関数のstatic関数版
 	void SwapHLByte();			// Byteを交換する
-	bool SwabHLByte( const CMemory& ); // Byteを交換する(コピー版)
+	bool SwabHLByte(const CMemory& mem); // Byteを交換する(コピー版)
 
 
 protected:
@@ -86,7 +86,7 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	void _Empty( void ); //!< 解放する。m_pRawDataはNULLになる。
-	void _AddData( const void*, int );
+	void _AddData(const void* pData, int nDataLen);
 public:
 	void _AppendSz(const char* str);
 	void _SetRawLength(int nLength);


### PR DESCRIPTION
ヘッダのプロトタイプ宣言で明示的に変数名を指定する (CMemory)

- #495 の対応漏れを修正
- 他にもあると思いますが、気づくたびにこつこつ修正予定

