### PR TITLE
関数の引数で const をつける (CMemory::IsEqual)

### DIFF
--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -132,7 +132,7 @@ void CMemory::_AddData( const void* pData, int nDataLen )
 
 
 /* 等しい内容か */
-int CMemory::IsEqual( CMemory& cmem1, CMemory& cmem2 )
+int CMemory::IsEqual(const CMemory& cmem1, const CMemory& cmem2)
 {
 	const char*	psz1;
 	const char*	psz2;

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -73,7 +73,7 @@ public:
 	const CMemory& operator=(const CMemory& rhs);
 
 	// 比較
-	static int IsEqual(CMemory& cmem1, CMemory& cmem2);	/* 等しい内容か */
+	static int IsEqual(const CMemory& cmem1, const CMemory& cmem2);	/* 等しい内容か */
 
 	// 変換関数
 	static void SwapHLByte(char* pData, const int nDataLen); // 下記関数のstatic関数版


### PR DESCRIPTION
#502: 関数の引数で const をつける#502: CMemory::IsEqual の引数に const をつける