### PR TITLE
ルーラー上の数字フォントの幅が自動的に指定されるように LOGFONT 構造体の lfWidth メンバの値を 0 に変更

### DIFF
--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -92,7 +92,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 	HFONT		hFontOld;
 	memset_raw( &lf, 0, sizeof(lf) );
 	lf.lfHeight			= 1 - pCommon->m_sWindow.m_nRulerHeight;	//	2002/05/13 ai
-	lf.lfWidth			= 5;
+	lf.lfWidth			= 0;
 	lf.lfEscapement		= 0;
 	lf.lfOrientation	= 0;
 	lf.lfWeight			= 400;


### PR DESCRIPTION
共通設定画面のウィンドウタブのルーラーの高さを大きくすると、ルーラー上の数字フォント（目盛り見出し？）の高さが大きくなりますが幅が広くならない為に不自然な表示になります。

![100_before_32dots](https://user-images.githubusercontent.com/1131125/46258454-f2929080-c505-11e8-9cd8-6929498067e4.png)

LOGFONT 構造体の lfWidth メンバの値を 0 にする事で GDI 側で幅を自動的に計算してくれるのでそれを使うようにしました。

余談ですが、目盛り線の高さはルーラーの高さを変えても大きくなりません。しかしルーラーの高さに合わせて目盛り線の高さを調整すると数字とぶつかったりします（というかこのPRで横幅が広がると接触する）。個人的な意見としては、それぞれの要素の大きさを調整できるように設定項目を増やすのが良いと思います。
設定項目がむやみやたらに増えるとそれはそれで良くないので自動で良い塩梅に調整出来れば良いんですが、難しいです。
