### PR TITLE
parse-buildlog.py での不要なログを削除

### DIFF
--- a/appveyor_env.py
+++ b/appveyor_env.py
@@ -150,7 +150,6 @@ class AppveyorEnv():
 			relpath = path
 			
 		relpath = self.convertRealPath(relpath)
-		print (relpath)
 		relpath = relpath.replace('\\', '/')
 
 		blobURL = ""


### PR DESCRIPTION
parse-buildlog.py での不要なログを削除

parse-buildlog.py から以下の流れで無駄なログが出力されるので削除する

https://github.com/sakura-editor/sakura/blob/d0e7c5dd2830798a95a01301186ad9c7c0c17952/parse-buildlog.py#L105

https://github.com/sakura-editor/sakura/blob/d0e7c5dd2830798a95a01301186ad9c7c0c17952/appveyor_env.py#L161-L162

https://github.com/sakura-editor/sakura/blob/d0e7c5dd2830798a95a01301186ad9c7c0c17952/appveyor_env.py#L146-L154