### PR TITLE
共通設定のツールバー画面のリスト表示の項目の高さをDPIに合わせて調整

### DIFF
--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -205,7 +205,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 			// 2014.11.25 フォントの高さが正しくなかったバグを修正
 			CTextWidthCalc calc(hwndResList);
 			int nFontHeight = calc.GetTextHeight();
-			nListItemHeight = 18; //Oct. 18, 2000 JEPRO 「ツールバー」タブでの機能アイテムの行間を少し狭くして表示行数を増やした(20→18 これ以上小さくしても効果はないようだ)
+			nListItemHeight = nFontHeight + DpiScaleY(2);
 			if( nListItemHeight < nFontHeight ){
 				nListItemHeight = nFontHeight;
 				nToolBarListBoxTopMargin = 0;
@@ -496,11 +496,7 @@ void CPropToolbar::SetData( HWND hwndDlg )
 	// 2014.11.25 フォントの高さが正しくなかったバグを修正
 	int nFontHeight = CTextWidthCalc(hwndResList).GetTextHeight();
 
-	nListItemHeight = 18; //Oct. 18, 2000 JEPRO 「ツールバー」タブでのツールバーアイテムの行間を少し狭くして表示行数を増やした(20→18 これ以上小さくしても効果はないようだ)
-	if( nListItemHeight < nFontHeight ){
-		nListItemHeight = nFontHeight;
-	}
-//	nListItemHeight+=2;
+	nListItemHeight = nFontHeight + DpiScaleY(2);
 
 	/* ツールバーボタンの情報をセット(リストボックス)*/
 	for( i = 0; i < m_Common.m_sToolBar.m_nToolBarButtonNum; ++i ){


### PR DESCRIPTION
| 変更前 | 変更後 |
|---|---|
| ![image](https://user-images.githubusercontent.com/1131125/46321650-94f26700-c61f-11e8-98d5-b9007a7e78ef.png) | ![image](https://user-images.githubusercontent.com/1131125/46321662-9d4aa200-c61f-11e8-986f-36bb2d4c8b37.png) |
