### PR TITLE
HighDPI対応 アプリケーションのアイコン表示

### DIFF
--- a/sakura_core/util/module.cpp
+++ b/sakura_core/util/module.cpp
@@ -132,7 +132,7 @@ DWORD GetDllVersion(LPCTSTR lpszDllName)
 HICON GetAppIcon( HINSTANCE hInst, int nResource, const TCHAR* szFile, bool bSmall )
 {
 	// サイズの設定
-	int size = ( bSmall ? 16 : 32 );
+	int size = GetSystemMetrics( bSmall ? SM_CXSMICON : SM_CXICON );
 
 	TCHAR szPath[_MAX_PATH];
 	HICON hIcon;

--- a/sakura_core/util/module.cpp
+++ b/sakura_core/util/module.cpp
@@ -121,7 +121,7 @@ DWORD GetDllVersion(LPCTSTR lpszDllName)
 	@param hInst [in] Instance Handle
 	@param nResource [in] デフォルトアイコン用Resource ID
 	@param szFile [in] アイコンファイル名
-	@param bSmall [in] true: small icon (16x16) / false: large icon (32x32)
+	@param bSmall [in] true: small icon (SM_CXSMICON) / false: large icon (SM_CXICON)
 	
 	@return アイコンハンドル．失敗した場合はNULL．
 	


### PR DESCRIPTION
| 変更前 | 変更後 |
|----|----|
| ![image](https://user-images.githubusercontent.com/1131125/46479454-0a318800-c82a-11e8-8292-f5d062a529a5.png) | ![image](https://user-images.githubusercontent.com/1131125/46479519-2af9dd80-c82a-11e8-9ec3-f242ae0980c4.png) |

GetAppIcon 関数は色々なところで使われているようで、色々な箇所が一気に直りました。
