### PR TITLE
共通設定のツールバー画面のリスト表示の項目の高さが表示スケール 100% の場合に不十分な問題を修正

### DIFF
--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -205,13 +205,8 @@ INT_PTR CPropToolbar::DispatchEvent(
 			// 2014.11.25 フォントの高さが正しくなかったバグを修正
 			CTextWidthCalc calc(hwndResList);
 			int nFontHeight = calc.GetTextHeight();
-			nListItemHeight = nFontHeight + DpiScaleY(2);
-			if( nListItemHeight < nFontHeight ){
-				nListItemHeight = nFontHeight;
-				nToolBarListBoxTopMargin = 0;
-			}else{
-				nToolBarListBoxTopMargin = (nListItemHeight - (nFontHeight + 1)) / 2;
-			}
+			nListItemHeight = std::max(nFontHeight, GetSystemMetrics(SM_CYSMICON)) + DpiScaleY(2);
+			nToolBarListBoxTopMargin = (nListItemHeight - (nFontHeight + 1)) / 2;
 		}
 		/* ダイアログデータの設定 Toolbar */
 		SetData( hwndDlg );
@@ -496,7 +491,7 @@ void CPropToolbar::SetData( HWND hwndDlg )
 	// 2014.11.25 フォントの高さが正しくなかったバグを修正
 	int nFontHeight = CTextWidthCalc(hwndResList).GetTextHeight();
 
-	nListItemHeight = nFontHeight + DpiScaleY(2);
+	nListItemHeight = std::max(nFontHeight, GetSystemMetrics(SM_CYSMICON)) + DpiScaleY(2);
 
 	/* ツールバーボタンの情報をセット(リストボックス)*/
 	for( i = 0; i < m_Common.m_sToolBar.m_nToolBarButtonNum; ++i ){
@@ -570,7 +565,7 @@ void CPropToolbar::DrawToolBarItemList( DRAWITEMSTRUCT* pDis )
 
 	rc  = pDis->rcItem;
 	rc0 = pDis->rcItem;
-	rc0.left += 18;//20 //Oct. 18, 2000 JEPRO 行先頭のアイコンとそれに続くキャプションとの間を少し詰めた(20→18)
+	rc0.left += GetSystemMetrics(SM_CXSMICON) + DpiScaleX(2);
 	rc1 = rc0;
 	rc2 = rc0;
 


### PR DESCRIPTION
#519 で報告した不具合で、自分が #513 の変更で入れてしまった問題を解消する PR です。

| 表示スケール | スクリーンショット |
|----|----|
| 100% | ![100 _after](https://user-images.githubusercontent.com/1131125/46568612-ce5e0600-c982-11e8-9d53-7389fb264f06.png) |
| 150% | ![150 _after](https://user-images.githubusercontent.com/1131125/46568613-cef69c80-c982-11e8-9ba7-fb1c2c1d143e.png) |
| 200% | ![200 _after](https://user-images.githubusercontent.com/1131125/46568614-cef69c80-c982-11e8-9ee2-67ce39c5af5f.png) |

アイコンのサイズが16ドットで、24ドットと32ドットのアイコンが無いのでそこは今後用意して改善したいですね。