### PR TITLE
キーボードの文字の入力の表示の間隔設定をミリ秒に変換してからタイマーの間隔に使用するように修正

### DIFF
--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -384,11 +384,12 @@ BOOL CEditView::Create(
 	}
 
 	/* キーボードの現在のリピート間隔を取得 */
-	int nKeyBoardSpeed;
-	SystemParametersInfo( SPI_GETKEYBOARDSPEED, 0, &nKeyBoardSpeed, 0 );
-
+	DWORD dwKeyBoardSpeed;
+	SystemParametersInfo( SPI_GETKEYBOARDSPEED, 0, &dwKeyBoardSpeed, 0 );
+	/* リピート速度の設定をミリ秒に変換 */
+	UINT uElapse = 400 - dwKeyBoardSpeed * (400 - 33) / 31;
 	/* タイマー起動 */
-	if( 0 == ::SetTimer( GetHwnd(), IDT_ROLLMOUSE, nKeyBoardSpeed, EditViewTimerProc ) ){
+	if( 0 == ::SetTimer( GetHwnd(), IDT_ROLLMOUSE, uElapse, EditViewTimerProc ) ){
 		WarningMessage( GetHwnd(), LS(STR_VIEW_TIMER) );
 	}
 


### PR DESCRIPTION
#506 で報告した内容に対応する PR です。

SystemParametersInfo 関数に SPI_GETKEYBOARDSPEED を指定してキーボードのリピート速度の設定を取得後にそれをミリ秒に単位変換せずに SetTimer に渡している記述があるので、それへの対処です。

