### PR TITLE
[WIP] x64での警告修正(CMemory::AllocBuffer の引数を size_t に変更)

### DIFF
--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -59,10 +59,10 @@ const SEolDefinition g_aEolTable[] = {
 struct SEolDefinitionForUniFile{
 	const char*	m_szDataW;
 	const char* m_szDataWB;
-	int			m_nLen;
+	SSIZE_T		m_nLen;
 
-	bool StartsWithW(const char* pData, int nLen) const{ return m_nLen<=nLen && 0==memcmp(pData,m_szDataW,m_nLen); }
-	bool StartsWithWB(const char* pData, int nLen) const{ return m_nLen<=nLen && 0==memcmp(pData,m_szDataWB,m_nLen); }
+	bool StartsWithW(const char* pData, SSIZE_T nLen) const{ return m_nLen<=nLen && 0==memcmp(pData,m_szDataW,m_nLen); }
+	bool StartsWithWB(const char* pData, SSIZE_T nLen) const{ return m_nLen<=nLen && 0==memcmp(pData,m_szDataWB,m_nLen); }
 };
 static const SEolDefinitionForUniFile g_aEolTable_uni_file[] = {
 	{ "",					"", 					0 },

--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -85,7 +85,7 @@ static const SEolDefinitionForUniFile g_aEolTable_uni_file[] = {
 	@return 改行コードの種類。終端子が見つからなかったときはEOL_NONEを返す。
 */
 template <class T>
-EEolType GetEOLType( const T* pszData, int nDataLen )
+EEolType GetEOLType( const T* pszData, SSIZE_T nDataLen )
 {
 	for( int i = 1; i < EOL_TYPE_NUM; ++i ){
 		if( g_aEolTable[i].StartsWith(pszData, nDataLen) )
@@ -98,7 +98,7 @@ EEolType GetEOLType( const T* pszData, int nDataLen )
 	ファイルを読み込むときに使用するもの
 */
 
-EEolType _GetEOLType_uni( const char* pszData, int nDataLen )
+EEolType _GetEOLType_uni( const char* pszData, SSIZE_T nDataLen )
 {
 	for( int i = 1; i < EOL_TYPE_NUM; ++i ){
 		if( g_aEolTable_uni_file[i].StartsWithW(pszData, nDataLen) )
@@ -107,7 +107,7 @@ EEolType _GetEOLType_uni( const char* pszData, int nDataLen )
 	return EOL_NONE;
 }
 
-EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
+EEolType _GetEOLType_unibe( const char* pszData, SSIZE_T nDataLen )
 {
 	for( int i = 1; i < EOL_TYPE_NUM; ++i ){
 		if( g_aEolTable_uni_file[i].StartsWithWB(pszData, nDataLen) )
@@ -150,22 +150,22 @@ bool CEol::SetType( EEolType t )
 	return true;
 }
 
-void CEol::SetTypeByString( const wchar_t* pszData, int nDataLen )
+void CEol::SetTypeByString( const wchar_t* pszData, SSIZE_T nDataLen )
 {
 	SetType( GetEOLType( pszData, nDataLen ) );
 }
 
-void CEol::SetTypeByString( const char* pszData, int nDataLen )
+void CEol::SetTypeByString( const char* pszData, SSIZE_T nDataLen )
 {
 	SetType( GetEOLType( pszData, nDataLen ) );
 }
 
-void CEol::SetTypeByStringForFile_uni( const char* pszData, int nDataLen )
+void CEol::SetTypeByStringForFile_uni( const char* pszData, SSIZE_T nDataLen )
 {
 	SetType( _GetEOLType_uni( pszData, nDataLen ) );
 }
 
-void CEol::SetTypeByStringForFile_unibe( const char* pszData, int nDataLen )
+void CEol::SetTypeByStringForFile_unibe( const char* pszData, SSIZE_T nDataLen )
 {
 	SetType( _GetEOLType_unibe( pszData, nDataLen ) );
 }

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -90,13 +90,13 @@ public:
 
 	//設定
 	bool SetType( EEolType t);	//	Typeの設定
-	void SetTypeByString( const wchar_t* pszData, int nDataLen );
-	void SetTypeByString( const char* pszData, int nDataLen );
+	void SetTypeByString( const wchar_t* pszData, SSIZE_T nDataLen );
+	void SetTypeByString( const char* pszData, SSIZE_T nDataLen );
 
 	//設定（ファイル読み込み時に使用）
-	void SetTypeByStringForFile( const char* pszData, int nDataLen ){ SetTypeByString( pszData, nDataLen ); }
-	void SetTypeByStringForFile_uni( const char* pszData, int nDataLen );
-	void SetTypeByStringForFile_unibe( const char* pszData, int nDataLen );
+	void SetTypeByStringForFile( const char* pszData, SSIZE_T nDataLen ){ SetTypeByString( pszData, nDataLen ); }
+	void SetTypeByStringForFile_uni( const char* pszData, SSIZE_T nDataLen );
+	void SetTypeByStringForFile_unibe( const char* pszData, SSIZE_T nDataLen );
 
 	//取得
 	EEolType		GetType()	const{ return m_eEolType; }		//!< 現在のTypeを取得

--- a/sakura_core/charset/CCesu8.h
+++ b/sakura_core/charset/CCesu8.h
@@ -39,7 +39,7 @@ public:
 	}
 	void GetBom(CMemory* pcmemBom) override;																			//!< BOMデータ取得
 // GetEolはCCodeBaseに移動	2010/6/13 Uchi
-	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar){			//!< UNICODE → Hex 変換
+	EConvertResult UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar){			//!< UNICODE → Hex 変換
 		return CUtf8()._UnicodeToHex( cSrc, iSLen, pDst, psStatusbar, true );
 	}
 };

--- a/sakura_core/charset/CCodeBase.cpp
+++ b/sakura_core/charset/CCodeBase.cpp
@@ -13,7 +13,7 @@
 void CCodeBase::GetBom(CMemory* pcmemBom){ pcmemBom->Clear(); }					//!< BOMデータ取得
 
 // 表示用16表示	UNICODE → Hex 変換	2008/6/9 Uchi
-EConvertResult CCodeBase::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
+EConvertResult CCodeBase::UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
 {
 	if (IsUTF16High(cSrc[0]) && iSLen >= 2 && IsUTF16Low(cSrc[1])) {
 		// サロゲートペア
@@ -36,7 +36,7 @@ EConvertResult CCodeBase::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCH
 
 	@param[out] pcMem デコード済みの文字列を格納
 */
-bool CCodeBase::MIMEHeaderDecode( const char* pSrc, const int nSrcLen, CMemory* pcMem, const ECodeType eCodetype )
+bool CCodeBase::MIMEHeaderDecode( const char* pSrc, const SSIZE_T nSrcLen, CMemory* pcMem, const ECodeType eCodetype )
 {
 	ECodeType ecodetype;
 	int nskip_bytes;

--- a/sakura_core/charset/CCodeBase.cpp
+++ b/sakura_core/charset/CCodeBase.cpp
@@ -50,8 +50,8 @@ bool CCodeBase::MIMEHeaderDecode( const char* pSrc, const int nSrcLen, CMemory* 
 	}
 
 	CMemory cmembuf;
-	int i = 0;
-	int j = 0;
+	SSIZE_T i = 0;
+	SSIZE_T j = 0;
 	while( i < nSrcLen ){
 		if( pSrc[i] != '=' ){
 			pdst[j] = pSrc[i];

--- a/sakura_core/charset/CCodeBase.cpp
+++ b/sakura_core/charset/CCodeBase.cpp
@@ -39,7 +39,7 @@ EConvertResult CCodeBase::UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen,
 bool CCodeBase::MIMEHeaderDecode( const char* pSrc, const SSIZE_T nSrcLen, CMemory* pcMem, const ECodeType eCodetype )
 {
 	ECodeType ecodetype;
-	int nskip_bytes;
+	SSIZE_T nskip_bytes;
 
 	// ソースを取得
 	pcMem->AllocBuffer( nSrcLen );

--- a/sakura_core/charset/CCodeBase.h
+++ b/sakura_core/charset/CCodeBase.h
@@ -64,7 +64,7 @@ public:
 	virtual EConvertResult UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
 
 	// 変換エラー処理（１バイト <-> U+D800 から U+D8FF）
-	static int BinToText(const unsigned char *pSrc, const SSIZE_T nLen, unsigned short *pDst);
+	static SSIZE_T BinToText(const unsigned char *pSrc, const SSIZE_T nLen, unsigned short *pDst);
 	static int TextToBin(const unsigned short cSrc);
 
 	// MIME Header デコーダ
@@ -77,7 +77,7 @@ public:
 /*!
 	バイナリ１バイトを U+DC00 から U+DCFF までに対応付ける
 */
-inline int CCodeBase::BinToText( const unsigned char *pSrc, const SSIZE_T nLen, unsigned short *pDst )
+inline SSIZE_T CCodeBase::BinToText( const unsigned char *pSrc, const SSIZE_T nLen, unsigned short *pDst )
 {
 	SSIZE_T i;
 

--- a/sakura_core/charset/CCodeBase.h
+++ b/sakura_core/charset/CCodeBase.h
@@ -61,14 +61,14 @@ public:
 	virtual void GetEol(CMemory* pcmemEol, EEolType eEolType){ S_GetEol(pcmemEol,eEolType); }	//!< 改行データ取得
 
 	// 文字コード表示用		2008/6/9 Uchi
-	virtual EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
+	virtual EConvertResult UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
 
 	// 変換エラー処理（１バイト <-> U+D800 から U+D8FF）
-	static int BinToText(const unsigned char *pSrc, const int nLen, unsigned short *pDst);
+	static int BinToText(const unsigned char *pSrc, const SSIZE_T nLen, unsigned short *pDst);
 	static int TextToBin(const unsigned short cSrc);
 
 	// MIME Header デコーダ
-	static bool MIMEHeaderDecode(const char* pSrc, const int nSrcLen, CMemory* pcMem, const ECodeType eCodetype);
+	static bool MIMEHeaderDecode(const char* pSrc, const SSIZE_T nSrcLen, CMemory* pcMem, const ECodeType eCodetype);
 
 	// CShiftJisより移動 2010/6/13 Uchi
 	static void S_GetEol(CMemory* pcmemEol, EEolType eEolType);	//!< 改行データ取得
@@ -77,9 +77,9 @@ public:
 /*!
 	バイナリ１バイトを U+DC00 から U+DCFF までに対応付ける
 */
-inline int CCodeBase::BinToText( const unsigned char *pSrc, const int nLen, unsigned short *pDst )
+inline int CCodeBase::BinToText( const unsigned char *pSrc, const SSIZE_T nLen, unsigned short *pDst )
 {
-	int i;
+	SSIZE_T i;
 
 	for( i = 0; i < nLen; ++i ){
 		pDst[i] = static_cast<unsigned short>(pSrc[i]) + 0xdc00;

--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -240,7 +240,7 @@ void CCodePage::GetBom(CMemory* pcmemBom)
 }
 
 // 文字コード表示用	UNICODE → Hex 変換
-EConvertResult CCodePage::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
+EConvertResult CCodePage::UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
 {
 	// コードの特性がわからないので何もしない
 	return CCodeBase::UnicodeToHex(cSrc, iSLen, pDst, psStatusbar);

--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -113,7 +113,7 @@ EConvertResult CCodePage::CPToUnicode(const CMemory& cSrc, CNativeW* pDst, int c
 	bool bError = false;
 
 	// ソース取得
-	int nSrcLen = cSrc.GetRawLength();
+	SSIZE_T nSrcLen = cSrc.GetRawLength();
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	UINT codepage = CodePageExToMSCP(codepageEx);

--- a/sakura_core/charset/CCodePage.h
+++ b/sakura_core/charset/CCodePage.h
@@ -58,7 +58,7 @@ public:
 	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToCP(cSrc, pDst, m_nCodePageEx); }	//!< UNICODE    → 特定コード 変換
 	void GetEol(CMemory* pcmemEol, EEolType eEolType) override;	//!< 改行データ取得
 	void GetBom(CMemory* pcmemBom) override;	//!< BOMデータ取得
-	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
+	EConvertResult UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
 
 public:
 	//実装

--- a/sakura_core/charset/CEuc.cpp
+++ b/sakura_core/charset/CEuc.cpp
@@ -79,7 +79,7 @@ EConvertResult CEuc::EUCToUnicode(const CMemory& cSrc, CNativeW* pDstMem)
 	bool bError = false;
 
 	// ソース取得
-	int nSrcLen = cSrc.GetRawLength();
+	SSIZE_T nSrcLen = cSrc.GetRawLength();
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	// 変換先バッファサイズとその確保

--- a/sakura_core/charset/CEuc.cpp
+++ b/sakura_core/charset/CEuc.cpp
@@ -190,7 +190,7 @@ EConvertResult CEuc::UnicodeToEUC(const CNativeW& cSrc, CMemory* pDstMem)
 }
 
 // 文字コード表示用	UNICODE → Hex 変換	2008/6/9 Uchi
-EConvertResult CEuc::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
+EConvertResult CEuc::UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
 {
 	CNativeW		cCharBuffer;
 	EConvertResult	res;

--- a/sakura_core/charset/CEuc.h
+++ b/sakura_core/charset/CEuc.h
@@ -34,7 +34,7 @@ public:
 	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return EUCToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
 	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToEUC(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
 // GetEolはCCodeBaseに移動	2010/6/13 Uchi
-	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
+	EConvertResult UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
 
 public:
 	//実装

--- a/sakura_core/charset/CJis.cpp
+++ b/sakura_core/charset/CJis.cpp
@@ -245,7 +245,7 @@ EConvertResult CJis::JISToUnicode(const CMemory& cSrc, CNativeW* pDstMem, bool b
 	bool berror;
 
 	// ソースを取得
-	int nSrcLen = cSrc.GetRawLength();
+	SSIZE_T nSrcLen = cSrc.GetRawLength();
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	// ソースバッファポインタとソースの長さ

--- a/sakura_core/charset/CJis.cpp
+++ b/sakura_core/charset/CJis.cpp
@@ -250,7 +250,7 @@ EConvertResult CJis::JISToUnicode(const CMemory& cSrc, CNativeW* pDstMem, bool b
 
 	// ソースバッファポインタとソースの長さ
 	const char* psrc = pSrc;
-	int nsrclen = nSrcLen;
+	SSIZE_T nsrclen = nSrcLen;
 	CMemory cmem;
 
 	if( base64decode == true ){
@@ -474,7 +474,7 @@ EConvertResult CJis::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* p
 {
 	CNativeW		cCharBuffer;
 	EConvertResult	res;
-	int				i;
+	SSIZE_T			i;
 	WCHAR*			pd; 
 	unsigned char*	ps; 
 

--- a/sakura_core/charset/CJis.cpp
+++ b/sakura_core/charset/CJis.cpp
@@ -470,7 +470,7 @@ EConvertResult CJis::UnicodeToJIS(const CNativeW& cSrc, CMemory* pDstMem)
 }
 
 // 文字コード表示用	UNICODE → Hex 変換	2008/6/9 Uchi
-EConvertResult CJis::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
+EConvertResult CJis::UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
 {
 	CNativeW		cCharBuffer;
 	EConvertResult	res;

--- a/sakura_core/charset/CJis.h
+++ b/sakura_core/charset/CJis.h
@@ -34,7 +34,7 @@ public:
 	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return JISToUnicode(cSrc, pDst, m_base64decode); }	//!< 特定コード → UNICODE    変換
 	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToJIS(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
 // GetEolはCCodeBaseに移動	2010/6/13 Uchi
-	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
+	EConvertResult UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
 
 public:
 	//実装

--- a/sakura_core/charset/CLatin1.cpp
+++ b/sakura_core/charset/CLatin1.cpp
@@ -99,7 +99,7 @@ EConvertResult CLatin1::Latin1ToUnicode( const CMemory& cSrc, CNativeW* pDstMem 
 	bool bError;
 
 	//ソース取得
-	int nSrcLen = cSrc.GetRawLength();
+	SSIZE_T nSrcLen = cSrc.GetRawLength();
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	// 変換先バッファサイズを設定してメモリ領域確保

--- a/sakura_core/charset/CLatin1.cpp
+++ b/sakura_core/charset/CLatin1.cpp
@@ -223,7 +223,7 @@ EConvertResult CLatin1::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR
 {
 	CNativeW		cCharBuffer;
 	EConvertResult	res;
-	int				i;
+	SSIZE_T			i;
 	unsigned char*	ps;
 	WCHAR*			pd;
 	bool			bbinary=false;

--- a/sakura_core/charset/CLatin1.cpp
+++ b/sakura_core/charset/CLatin1.cpp
@@ -219,7 +219,7 @@ EConvertResult CLatin1::UnicodeToLatin1( const CNativeW& cSrc, CMemory* pDstMem 
 }
 
 // 文字コード表示用	UNICODE → Hex 変換	2008/6/9 Uchi
-EConvertResult CLatin1::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
+EConvertResult CLatin1::UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
 {
 	CNativeW		cCharBuffer;
 	EConvertResult	res;

--- a/sakura_core/charset/CLatin1.h
+++ b/sakura_core/charset/CLatin1.h
@@ -37,7 +37,7 @@ public:
 	//CCodeBaseインターフェース
 	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return Latin1ToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
 	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToLatin1(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
-	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar) override;			//!< UNICODE → Hex 変換
+	EConvertResult UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar) override;			//!< UNICODE → Hex 変換
 
 public:
 	//実装

--- a/sakura_core/charset/CShiftJis.cpp
+++ b/sakura_core/charset/CShiftJis.cpp
@@ -110,7 +110,7 @@ EConvertResult CShiftJis::SJISToUnicode( const CMemory& cSrc, CNativeW* pDstMem 
 	bool bError;
 
 	//ソース取得
-	int nSrcLen = cSrc.GetRawLength();
+	SSIZE_T nSrcLen = cSrc.GetRawLength();
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	if( &cSrc == pDstMem->_GetMemory() )

--- a/sakura_core/charset/CShiftJis.cpp
+++ b/sakura_core/charset/CShiftJis.cpp
@@ -249,7 +249,7 @@ EConvertResult CShiftJis::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCH
 {
 	CNativeW		cCharBuffer;
 	EConvertResult	res;
-	int				i;
+	SSIZE_T			i;
 	unsigned char*	ps;
 	WCHAR*			pd;
 	bool			bbinary=false;

--- a/sakura_core/charset/CShiftJis.cpp
+++ b/sakura_core/charset/CShiftJis.cpp
@@ -219,7 +219,7 @@ EConvertResult CShiftJis::UnicodeToSJIS( const CNativeW& cSrc, CMemory* pDstMem 
 
 	// ソース取得
 	const wchar_t* pSrc = reinterpret_cast<const wchar_t*>( pMem->GetRawPtr() );
-	int nSrcLen = pMem->GetRawLength() / sizeof(wchar_t);
+	SSIZE_T nSrcLen = pMem->GetRawLength() / sizeof(wchar_t);
 
 	// 変換先バッファサイズを設定してバッファを確保
 	char* pDst = new (std::nothrow) char[ nSrcLen * 2 ];

--- a/sakura_core/charset/CShiftJis.cpp
+++ b/sakura_core/charset/CShiftJis.cpp
@@ -245,7 +245,7 @@ EConvertResult CShiftJis::UnicodeToSJIS( const CNativeW& cSrc, CMemory* pDstMem 
 }
 
 // 文字コード表示用	UNICODE → Hex 変換	2008/6/9 Uchi
-EConvertResult CShiftJis::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
+EConvertResult CShiftJis::UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)
 {
 	CNativeW		cCharBuffer;
 	EConvertResult	res;

--- a/sakura_core/charset/CShiftJis.h
+++ b/sakura_core/charset/CShiftJis.h
@@ -36,7 +36,7 @@ public:
 	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return SJISToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
 	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToSJIS(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
 // GetEolはCCodeBaseに移動	2010/6/13 Uchi
-	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar) override;			//!< UNICODE → Hex 変換
+	EConvertResult UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar) override;			//!< UNICODE → Hex 変換
 
 public:
 	//実装

--- a/sakura_core/charset/CUnicode.cpp
+++ b/sakura_core/charset/CUnicode.cpp
@@ -9,7 +9,7 @@
 EConvertResult CUnicode::_UnicodeToUnicode_in( const CMemory& cSrc, CNativeW* pDstMem, const bool bBigEndian )
 {
 	// ソース取得
-	int nSrcLen = cSrc.GetRawLength();
+	SSIZE_T nSrcLen = cSrc.GetRawLength();
 	const unsigned char* pSrc = reinterpret_cast<const unsigned char*>( cSrc.GetRawPtr() );
 	CMemory* pDstMem2 = pDstMem->_GetMemory();
 

--- a/sakura_core/charset/CUtf7.cpp
+++ b/sakura_core/charset/CUtf7.cpp
@@ -116,7 +116,7 @@ EConvertResult CUtf7::UTF7ToUnicode( const CMemory& cSrc, CNativeW* pDstMem )
 	bool bError;
 
 	// データ取得
-	int nDataLen = cSrc.GetRawLength();
+	SSIZE_T nDataLen = cSrc.GetRawLength();
 	const char* pData = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	// 必要なバッファサイズを調べて確保

--- a/sakura_core/charset/CUtf7.cpp
+++ b/sakura_core/charset/CUtf7.cpp
@@ -11,7 +11,7 @@
 /*!
 	UTF-7 Set D 部分の読み込み。
 */
-int CUtf7::_Utf7SetDToUni_block( const char* pSrc, const int nSrcLen, wchar_t* pDst )
+int CUtf7::_Utf7SetDToUni_block( const char* pSrc, const SSIZE_T nSrcLen, wchar_t* pDst )
 {
 	const char* pr = pSrc;
 	wchar_t* pw = pDst;
@@ -30,7 +30,7 @@ int CUtf7::_Utf7SetDToUni_block( const char* pSrc, const int nSrcLen, wchar_t* p
 /*!
 	UTF-7 Set B 部分の読み込み
 */
-int CUtf7::_Utf7SetBToUni_block( const char* pSrc, const int nSrcLen, wchar_t* pDst, bool* pbError )
+int CUtf7::_Utf7SetBToUni_block( const char* pSrc, const SSIZE_T nSrcLen, wchar_t* pDst, bool* pbError )
 {
 	char* pbuf = new (std::nothrow) char[nSrcLen];
 	if (pbuf == NULL) {
@@ -39,7 +39,7 @@ int CUtf7::_Utf7SetBToUni_block( const char* pSrc, const int nSrcLen, wchar_t* p
 		}
 		return 0;
 	}
-	int ndecoded_len = _DecodeBase64( pSrc, nSrcLen, pbuf );
+	SSIZE_T ndecoded_len = _DecodeBase64( pSrc, nSrcLen, pbuf );
 	int nModLen = ndecoded_len % sizeof(wchar_t);
 	ndecoded_len = ndecoded_len - nModLen;
 	CMemory::SwapHLByte( pbuf, ndecoded_len );  // UTF-16 BE を UTF-16 LE に直す
@@ -55,7 +55,7 @@ int CUtf7::_Utf7SetBToUni_block( const char* pSrc, const int nSrcLen, wchar_t* p
 	return ndecoded_len / sizeof(wchar_t);
 }
 
-int CUtf7::Utf7ToUni( const char* pSrc, const int nSrcLen, wchar_t* pDst, bool* pbError )
+int CUtf7::Utf7ToUni( const char* pSrc, const SSIZE_T nSrcLen, wchar_t* pDst, bool* pbError )
 {
 	const char *pr, *pr_end;
 	char *pr_next;
@@ -140,9 +140,9 @@ EConvertResult CUtf7::UTF7ToUnicode( const CMemory& cSrc, CNativeW* pDstMem )
 	}
 }
 
-int CUtf7::_UniToUtf7SetD_block( const wchar_t* pSrc, const int nSrcLen, char* pDst )
+int CUtf7::_UniToUtf7SetD_block( const wchar_t* pSrc, const SSIZE_T nSrcLen, char* pDst )
 {
-	int i;
+	SSIZE_T i;
 
 	if( nSrcLen < 1 ){
 		return 0;
@@ -155,7 +155,7 @@ int CUtf7::_UniToUtf7SetD_block( const wchar_t* pSrc, const int nSrcLen, char* p
 	return i;
 }
 
-int CUtf7::_UniToUtf7SetB_block( const wchar_t* pSrc, const int nSrcLen, char* pDst )
+int CUtf7::_UniToUtf7SetB_block( const wchar_t* pSrc, const SSIZE_T nSrcLen, char* pDst )
 {
 	char* pw;
 
@@ -185,7 +185,7 @@ int CUtf7::_UniToUtf7SetB_block( const wchar_t* pSrc, const int nSrcLen, char* p
 	return pw - pDst;
 }
 
-int CUtf7::UniToUtf7( const wchar_t* pSrc, const int nSrcLen, char* pDst )
+int CUtf7::UniToUtf7( const wchar_t* pSrc, const SSIZE_T nSrcLen, char* pDst )
 {
 	const wchar_t *pr, *pr_base;
 	const wchar_t* pr_end;

--- a/sakura_core/charset/CUtf7.h
+++ b/sakura_core/charset/CUtf7.h
@@ -43,11 +43,11 @@ public:
 protected:
 
 	// 2008.11.10 変換ロジックを書き直す
-	static int _Utf7SetDToUni_block( const char* pSrc, const int nSrcLen, wchar_t* pDst );
-	static int _Utf7SetBToUni_block( const char* pSrc, const int nSrcLen, wchar_t* pDst, bool* pbError );
-	static int Utf7ToUni( const char* pSrc, const int nSrcLen, wchar_t* pDst, bool* pbError );
+	static int _Utf7SetDToUni_block( const char* pSrc, const SSIZE_T nSrcLen, wchar_t* pDst );
+	static int _Utf7SetBToUni_block( const char* pSrc, const SSIZE_T nSrcLen, wchar_t* pDst, bool* pbError );
+	static int Utf7ToUni( const char* pSrc, const SSIZE_T nSrcLen, wchar_t* pDst, bool* pbError );
 
-	static int _UniToUtf7SetD_block( const wchar_t* pSrc, const int nSrcLen, char* pDst );
-	static int _UniToUtf7SetB_block( const wchar_t* pSrc, const int nSrcLen, char* pDst );
-	static int UniToUtf7( const wchar_t* pSrc, const int nSrcLen, char* pDst );
+	static int _UniToUtf7SetD_block( const wchar_t* pSrc, const SSIZE_T nSrcLen, char* pDst );
+	static int _UniToUtf7SetB_block( const wchar_t* pSrc, const SSIZE_T nSrcLen, char* pDst );
+	static int UniToUtf7( const wchar_t* pSrc, const SSIZE_T nSrcLen, char* pDst );
 };

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -212,7 +212,7 @@ EConvertResult CUtf8::_UnicodeToUTF8( const CNativeW& cSrc, CMemory* pDstMem, bo
 }
 
 // 文字コード表示用	UNICODE → Hex 変換	2008/6/21 Uchi
-EConvertResult CUtf8::_UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar, const bool bCESUMode)
+EConvertResult CUtf8::_UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar, const bool bCESUMode)
 {
 	CNativeW		cBuff;
 	EConvertResult	res;

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -89,7 +89,7 @@ EConvertResult CUtf8::_UTF8ToUnicode( const CMemory& cSrc, CNativeW* pDstMem, bo
 	bool bError = false;
 
 	// データ取得
-	int nSrcLen = cSrc.GetRawLength();
+	SSIZE_T nSrcLen = cSrc.GetRawLength();
 	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	if( &cSrc == pDstMem->_GetMemory() )

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -216,7 +216,7 @@ EConvertResult CUtf8::_UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR*
 {
 	CNativeW		cBuff;
 	EConvertResult	res;
-	int				i;
+	SSIZE_T			i;
 	WCHAR*			pd;
 	unsigned char*	ps;
 	bool			bbinary=false;

--- a/sakura_core/charset/CUtf8.h
+++ b/sakura_core/charset/CUtf8.h
@@ -41,8 +41,8 @@ public:
 	}
 	void GetBom(CMemory* pcmemBom) override;																			//!< BOMデータ取得
 	void GetEol(CMemory* pcmemEol, EEolType eEolType) override;
-	EConvertResult _UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar, const bool CESU8Mode);			//!< UNICODE → Hex 変換
-	EConvertResult UnicodeToHex(const wchar_t* ps, const int nsl, WCHAR* pd, const CommonSetting_Statusbar* psStatusbar) override{ return _UnicodeToHex(ps, nsl, pd, psStatusbar, false); }
+	EConvertResult _UnicodeToHex(const wchar_t* cSrc, const SSIZE_T iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar, const bool CESU8Mode);			//!< UNICODE → Hex 変換
+	EConvertResult UnicodeToHex(const wchar_t* ps, const SSIZE_T nsl, WCHAR* pd, const CommonSetting_Statusbar* psStatusbar) override{ return _UnicodeToHex(ps, nsl, pd, psStatusbar, false); }
 
 public:
 	// UTF-8 / CESU-8 <-> Unicodeコード変換

--- a/sakura_core/cmd/CViewCommander_Convert.cpp
+++ b/sakura_core/cmd/CViewCommander_Convert.cpp
@@ -236,7 +236,7 @@ void CViewCommander::Command_BASE64DECODE( void )
 	}
 
 	//データ
-	int nDataLen = cmemBuf.GetRawLength();
+	SSIZE_T nDataLen = cmemBuf.GetRawLength();
 	const void* pData = cmemBuf.GetRawPtr();
 
 	//カキコ
@@ -284,7 +284,7 @@ void CViewCommander::Command_UUDECODE( void )
 	}
 
 	//データ
-	int nDataLen = cmemBin.GetRawLength();
+	SSIZE_T nDataLen = cmemBin.GetRawLength();
 	const void* pData = cmemBin.GetRawPtr();
 
 	//カキコ

--- a/sakura_core/convert/convert_util2.h
+++ b/sakura_core/convert/convert_util2.h
@@ -594,16 +594,16 @@ enum EEncodingMethod {
 	@return  CMemory と置き換えられる入力文字列長 (nSkipLen)
 */
 template< class CHAR_TYPE >
-int _DecodeMimeHeader( const CHAR_TYPE* pSrc, const SSIZE_T nSrcLen, CMemory* pcMem_alt, ECodeType* peCodetype )
+SSIZE_T _DecodeMimeHeader( const CHAR_TYPE* pSrc, const SSIZE_T nSrcLen, CMemory* pcMem_alt, ECodeType* peCodetype )
 {
 	ECodeType ecode = CODE_NONE;
 	EEncodingMethod emethod = EM_NONE;
-	int nLen_part1, nLen_part2, nskipped_len;
+	SSIZE_T nLen_part1, nLen_part2, nskipped_len;
 	int ncmpresult1, ncmpresult2, ncmpresult;
 
 	const CHAR_TYPE *pr, *pr_base;
 	char* pdst;
-	int ndecoded_len;
+	SSIZE_T ndecoded_len;
 
 	// MIME の該当部分を検出。----------------------------------------
 	//

--- a/sakura_core/convert/convert_util2.h
+++ b/sakura_core/convert/convert_util2.h
@@ -594,7 +594,7 @@ enum EEncodingMethod {
 	@return  CMemory と置き換えられる入力文字列長 (nSkipLen)
 */
 template< class CHAR_TYPE >
-int _DecodeMimeHeader( const CHAR_TYPE* pSrc, const int nSrcLen, CMemory* pcMem_alt, ECodeType* peCodetype )
+int _DecodeMimeHeader( const CHAR_TYPE* pSrc, const SSIZE_T nSrcLen, CMemory* pcMem_alt, ECodeType* peCodetype )
 {
 	ECodeType ecode = CODE_NONE;
 	EEncodingMethod emethod = EM_NONE;

--- a/sakura_core/io/CFileLoad.h
+++ b/sakura_core/io/CFileLoad.h
@@ -93,7 +93,7 @@ protected:
 	void ReadBufEmpty( void );	// バッファを空にする
 
 	// GetLextLine の 文字コード考慮版
-	const char* GetNextLineCharCode(const char*	pData, int nDataLen, int* pnLineLen, int* pnBgn, CEol* pcEol, int* pnEolLen, int* pnBufferNext);
+	const char* GetNextLineCharCode(const char*	pData, SSIZE_T nDataLen, SSIZE_T* pnLineLen, SSIZE_T* pnBgn, CEol* pcEol, SSIZE_T* pnEolLen, SSIZE_T* pnBufferNext);
 	EConvertResult ReadLine_core(CNativeW* pUnicodeBuffer, CEol* pcEol);
 
 	int Read(void* pBuf, size_t nSize); // inline
@@ -113,7 +113,7 @@ protected:
 	EEncodingTrait	m_encodingTrait;
 	CMemory			m_memEols[3];
 	bool	m_bEolEx;		//!< CR/LF以外のEOLが有効か
-	int		m_nMaxEolLen;	//!< EOLの長さ
+	SSIZE_T m_nMaxEolLen;	//!< EOLの長さ
 	bool	m_bBomExist;	// ファイルのBOMが付いているか Jun. 08, 2003 Moca 
 	int		m_nFlag;		// 文字コードの変換オプション
 	//	Jun. 13, 2003 Moca
@@ -129,8 +129,8 @@ protected:
 	// 読み込みバッファ系
 	char*	m_pReadBuf;			// 読み込みバッファへのポインタ
 	int		m_nReadBufSize;		// 読み込みバッファの実際に確保しているサイズ
-	int		m_nReadDataLen;		// 読み込みバッファの有効データサイズ
-	int		m_nReadBufOffSet;	// 読み込みバッファ中のオフセット(次の行頭位置)
+	SSIZE_T	m_nReadDataLen;		// 読み込みバッファの有効データサイズ
+	SSIZE_T	m_nReadBufOffSet;	// 読み込みバッファ中のオフセット(次の行頭位置)
 //	int		m_nReadBufSumSize;	// 今までにバッファに読み込んだデータの合計サイズ
 	CMemory m_cLineBuffer;
 	CNativeW m_cLineTemp;

--- a/sakura_core/io/CStream.h
+++ b/sakura_core/io/CStream.h
@@ -90,7 +90,7 @@ public:
 	}
 
 	//! データを無変換で書き込む。戻り値は書き込んだバイト数。
-	int Write(const void* pBuffer, int nSizeInBytes)
+	int Write(const void* pBuffer, SSIZE_T nSizeInBytes)
 	{
 		int nRet = fwrite(pBuffer,1,nSizeInBytes,GetFp());
 		if(nRet!=nSizeInBytes && IsExceptionMode())throw CError_FileWrite();

--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -57,7 +57,7 @@ CMemory::CMemory() noexcept
 */
 CMemory::CMemory(
 	const void*	pData,			//!< 格納データアドレス
-	int			nDataLenBytes	//!< 格納データの有効長
+	SSIZE_T		nDataLenBytes	//!< 格納データの有効長
 )	: CMemory()
 {
 	SetRawData( pData, nDataLenBytes );
@@ -93,7 +93,7 @@ CMemory::~CMemory()
 /*
 || バッファの最後にデータを追加する（protectメンバ
 */
-void CMemory::_AddData( const void* pData, int nDataLen )
+void CMemory::_AddData( const void* pData, SSIZE_T nDataLen )
 {
 	if( NULL == m_pRawData ){
 		return;
@@ -108,8 +108,8 @@ void CMemory::_AddData( const void* pData, int nDataLen )
 /* 等しい内容か */
 int CMemory::IsEqual(const CMemory& cmem1, const CMemory& cmem2)
 {
-	const int nLen1 = cmem1.GetRawLength();
-	const int nLen2 = cmem2.GetRawLength();
+	const SSIZE_T nLen1 = cmem1.GetRawLength();
+	const SSIZE_T nLen2 = cmem2.GetRawLength();
 	if( nLen1 == nLen2 ){
 		const char* psz1 = reinterpret_cast<const char*>(cmem1.GetRawPtr());
 		const char* psz2 = reinterpret_cast<const char*>(cmem2.GetRawPtr());
@@ -127,13 +127,13 @@ int CMemory::IsEqual(const CMemory& cmem1, const CMemory& cmem2)
 	
 	@note	nBufLen が2の倍数でないときは、最後の1バイトは交換されない
 */
-void CMemory::SwapHLByte( char* pData, const int nDataLen ){
+void CMemory::SwapHLByte( char* pData, const SSIZE_T nDataLen ){
 	unsigned char *p;
 	unsigned char *p_end;
 	unsigned int *pdwchar;
 	unsigned int *pdw_end;
 	unsigned char*	pBuf;
-	int			nBufLen;
+	SSIZE_T			nBufLen;
 
 	//pBuf = (unsigned char*)GetRawPtr( &nBufLen );
 	pBuf = reinterpret_cast<unsigned char*>( pData );
@@ -173,7 +173,7 @@ void CMemory::SwapHLByte( char* pData, const int nDataLen ){
 	@note	nBufLen が2の倍数でないときは、最後の1バイトは交換されない
 */
 void CMemory::SwapHLByte( void ){
-	int nBufLen = GetRawLength();
+	SSIZE_T nBufLen = GetRawLength();
 	char* pBuf = reinterpret_cast<char*>( GetRawPtr() );
 	SwapHLByte( pBuf, nBufLen );
 	return;
@@ -289,7 +289,7 @@ void CMemory::AllocBuffer( SSIZE_T nNewDataLen )
 }
 
 /* バッファの内容を置き換える */
-void CMemory::SetRawData( const void* pData, int nDataLen )
+void CMemory::SetRawData( const void* pData, SSIZE_T nDataLen )
 {
 	_Empty();
 	AllocBuffer( nDataLen );
@@ -300,7 +300,7 @@ void CMemory::SetRawData( const void* pData, int nDataLen )
 /* バッファの内容を置き換える */
 void CMemory::SetRawData( const CMemory& pcmemData )
 {
-	int nDataLen = pcmemData.GetRawLength();
+	SSIZE_T nDataLen = pcmemData.GetRawLength();
 	const void*	pData = pcmemData.GetRawPtr();
 	_Empty();
 	AllocBuffer( nDataLen );
@@ -309,7 +309,7 @@ void CMemory::SetRawData( const CMemory& pcmemData )
 }
 
 /*! バッファの内容を置き換える */
-void CMemory::SetRawDataHoldBuffer( const void* pData, int nDataLen )
+void CMemory::SetRawDataHoldBuffer( const void* pData, SSIZE_T nDataLen )
 {
 	// this 重複不可
 	assert( m_pRawData != pData );
@@ -327,14 +327,14 @@ void CMemory::SetRawDataHoldBuffer( const CMemory& pcmemData )
 	if( this == &pcmemData ){
 		return;
 	}
-	int	nDataLen = pcmemData.GetRawLength();
+	SSIZE_T		nDataLen = pcmemData.GetRawLength();
 	const void*	pData = pcmemData.GetRawPtr();
 	SetRawDataHoldBuffer( pData, nDataLen );
 	return;
 }
 
 /* バッファの最後にデータを追加する（publicメンバ）*/
-void CMemory::AppendRawData( const void* pData, int nDataLenBytes )
+void CMemory::AppendRawData( const void* pData, SSIZE_T nDataLenBytes )
 {
 	if(nDataLenBytes<=0)return;
 	AllocBuffer( m_nRawLen + nDataLenBytes );
@@ -348,7 +348,7 @@ void CMemory::AppendRawData( const CMemory* pcmemData )
 		CMemory cm = *pcmemData;
 		AppendRawData(&cm);
 	}
-	int	nDataLen = pcmemData->GetRawLength();
+	SSIZE_T		nDataLen = pcmemData->GetRawLength();
 	const void*	pData = pcmemData->GetRawPtr();
 	AllocBuffer( m_nRawLen + nDataLen );
 	_AddData( pData, nDataLen );
@@ -370,7 +370,7 @@ void CMemory::_AppendSz(const char* str)
 	_AddData(str,len);
 }
 
-void CMemory::_SetRawLength(int nLength)
+void CMemory::_SetRawLength(SSIZE_T nLength)
 {
 	if (m_pRawData == NULL || m_nDataBufSize <= 0)
 	{

--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -246,7 +246,7 @@ bool CMemory::SwabHLByte( const CMemory& mem )
 /*
 || バッファサイズの調整
 */
-void CMemory::AllocBuffer( int nNewDataLen )
+void CMemory::AllocBuffer( SSIZE_T nNewDataLen )
 {
 	int		nWorkLen;
 	char*	pWork = NULL;

--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -248,7 +248,7 @@ bool CMemory::SwabHLByte( const CMemory& mem )
 */
 void CMemory::AllocBuffer( SSIZE_T nNewDataLen )
 {
-	int		nWorkLen;
+	SSIZE_T	nWorkLen;
 	char*	pWork = NULL;
 
 	// 2バイト多くメモリ確保しておく('\0'またはL'\0'を入れるため) 2007.08.13 kobake 変更

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -65,7 +65,7 @@ public:
 
 	inline const void* GetRawPtr() const{ return m_pRawData; } //!< データへのポインタを返す
 	inline void* GetRawPtr(){ return m_pRawData; }             //!< データへのポインタを返す
-	int GetRawLength() const { return m_nRawLen; }                //!<データ長を返す。バイト単位。
+	SSIZE_T GetRawLength() const { return m_nRawLen; }                //!<データ長を返す。バイト単位。
 
 	// 演算子
 	//! コピー代入演算子

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -106,7 +106,7 @@ public:
 		std::swap( m_pRawData, left.m_pRawData );
 		std::swap( m_nRawLen, left.m_nRawLen );
 	}
-	SSIZE_T capacity() const { return m_nDataBufSize ? m_nDataBufSize - 2: 0; }
+	int capacity() const { return m_nDataBufSize ? m_nDataBufSize - 2: 0; }
 
 private: // 2002/2/10 aroka アクセス権変更
 	/*

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -113,8 +113,8 @@ private: // 2002/2/10 aroka アクセス権変更
 	|| メンバ変数
 	*/
 	char*	m_pRawData;		//バッファ
-	int		m_nRawLen;		//データサイズ(m_nDataBufSize以内)。バイト単位。
-	int		m_nDataBufSize;	//バッファサイズ。バイト単位。
+	SSIZE_T	m_nRawLen;		//データサイズ(m_nDataBufSize以内)。バイト単位。
+	SSIZE_T	m_nDataBufSize;	//バッファサイズ。バイト単位。
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -53,7 +53,7 @@ public:
 
 	//インターフェース
 public:
-	void AllocBuffer(int nNewDataLen);                               //!< バッファサイズの調整。必要に応じて拡大する。
+	void AllocBuffer(SSIZE_T nNewDataLen);                               //!< バッファサイズの調整。必要に応じて拡大する。
 	void SetRawData( const void* pData, int nDataLen );    //!< バッファの内容を置き換える
 	void SetRawData(const CMemory& pcmemData);                     //!< バッファの内容を置き換える
 	void SetRawDataHoldBuffer( const void* pData, int nDataLen );    //!< バッファの内容を置き換える(バッファを保持)

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -44,7 +44,7 @@ class CMemory
 	//コンストラクタ・デストラクタ
 public:
 	CMemory() noexcept;
-	CMemory(const void* pData, int nDataLenBytes);
+	CMemory(const void* pData, SSIZE_T nDataLenBytes);
 	CMemory(const CMemory& rhs);
 	CMemory(CMemory&& other) noexcept;
 	// デストラクタを仮想にすると仮想関数テーブルへのポインタを持つ為にインスタンスの容量が増えてしまうので仮想にしない
@@ -54,11 +54,11 @@ public:
 	//インターフェース
 public:
 	void AllocBuffer(SSIZE_T nNewDataLen);                               //!< バッファサイズの調整。必要に応じて拡大する。
-	void SetRawData( const void* pData, int nDataLen );    //!< バッファの内容を置き換える
+	void SetRawData( const void* pData, SSIZE_T nDataLen );    //!< バッファの内容を置き換える
 	void SetRawData(const CMemory& pcmemData);                     //!< バッファの内容を置き換える
-	void SetRawDataHoldBuffer( const void* pData, int nDataLen );    //!< バッファの内容を置き換える(バッファを保持)
+	void SetRawDataHoldBuffer( const void* pData, SSIZE_T nDataLen );    //!< バッファの内容を置き換える(バッファを保持)
 	void SetRawDataHoldBuffer(const CMemory& pcmemData);                     //!< バッファの内容を置き換える(バッファを保持)
-	void AppendRawData( const void* pData, int nDataLen ); //!< バッファの最後にデータを追加する
+	void AppendRawData( const void* pData, SSIZE_T nDataLen ); //!< バッファの最後にデータを追加する
 	void AppendRawData(const CMemory* pcmemData);                  //!< バッファの最後にデータを追加する
 	void Clean(){ _Empty(); }
 	void Clear(){ _Empty(); }
@@ -88,7 +88,7 @@ public:
 	static int IsEqual(const CMemory& cmem1, const CMemory& cmem2);	/* 等しい内容か */
 
 	// 変換関数
-	static void SwapHLByte(char* pData, const int nDataLen); // 下記関数のstatic関数版
+	static void SwapHLByte(char* pData, const SSIZE_T nDataLen); // 下記関数のstatic関数版
 	void SwapHLByte();			// Byteを交換する
 	bool SwabHLByte(const CMemory& mem); // Byteを交換する(コピー版)
 
@@ -97,16 +97,16 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	void _Empty( void ); //!< 解放する。m_pRawDataはNULLになる。
-	void _AddData(const void* pData, int nDataLen);
+	void _AddData(const void* pData, SSIZE_T nDataLen);
 public:
 	void _AppendSz(const char* str);
-	void _SetRawLength(int nLength);
+	void _SetRawLength(SSIZE_T nLength);
 	void swap( CMemory& left ) noexcept {
 		std::swap( m_nDataBufSize, left.m_nDataBufSize );
 		std::swap( m_pRawData, left.m_pRawData );
 		std::swap( m_nRawLen, left.m_nRawLen );
 	}
-	int capacity() const { return m_nDataBufSize ? m_nDataBufSize - 2: 0; }
+	SSIZE_T capacity() const { return m_nDataBufSize ? m_nDataBufSize - 2: 0; }
 
 private: // 2002/2/10 aroka アクセス権変更
 	/*

--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -101,7 +101,7 @@ void CNativeA::AppendNativeData( const CNativeA& pcNative )
 }
 
 //! (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
-void CNativeA::AllocStringBuffer( int nDataLen )
+void CNativeA::AllocStringBuffer(SSIZE_T nDataLen )
 {
 	CNative::AllocBuffer(nDataLen * sizeof(char));
 }

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -42,7 +42,7 @@ public:
 	void AppendString( const char* pszData, int nLength );  //!< バッファの最後にデータを追加する。nLengthは文字単位。
 	void AppendStringF(const char* pszData, ...);           //!< バッファの最後にデータを追加する (フォーマット機能付き)
 	void AppendNativeData( const CNativeA& pcNative );      //!< バッファの最後にデータを追加する
-	void AllocStringBuffer( int nDataLen );            //!< (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
+	void AllocStringBuffer(SSIZE_T nDataLen );               //!< (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
 
 	//ネイティブ取得
 	int GetStringLength() const;

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -66,7 +66,7 @@ void CNativeW::SetNativeData( const CNativeW& pcNative )
 }
 
 //! (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
-void CNativeW::AllocStringBuffer( int nDataLen )
+void CNativeW::AllocStringBuffer( SSIZE_T nDataLen )
 {
 	CNative::AllocBuffer(nDataLen * sizeof(wchar_t));
 }

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -135,7 +135,7 @@ public:
 	void swap( CNativeW& left ){
 		CNative::swap(left);
 	}
-	SSIZE_T capacity() const noexcept {
+	int capacity() const noexcept {
 		return CNative::capacity() / sizeof(wchar_t);
 	}
 

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -80,7 +80,7 @@ public:
 	bool IsValid() const noexcept { return GetStringPtr() != nullptr; }
 
 	//管理
-	void AllocStringBuffer( int nDataLen );                    //!< (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
+	void AllocStringBuffer( SSIZE_T nDataLen );                    //!< (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
 
 	//WCHAR
 	void SetString( const wchar_t* pData, int nDataLen );      //!< バッファの内容を置き換える。nDataLenは文字単位。
@@ -119,14 +119,14 @@ public:
 	}
 
 	//特殊
-	void _SetStringLength(int nLength)
+	void _SetStringLength(SSIZE_T nLength)
 	{
 		CNative::_SetRawLength(nLength*sizeof(wchar_t));
 	}
 	//末尾を1文字削る
 	void Chop()
 	{
-		int n = GetStringLength();
+		SSIZE_T n = GetStringLength();
 		n-=1;
 		if(n>=0){
 			_SetStringLength(n);
@@ -135,7 +135,7 @@ public:
 	void swap( CNativeW& left ){
 		CNative::swap(left);
 	}
-	int capacity() const noexcept {
+	SSIZE_T capacity() const noexcept {
 		return CNative::capacity() / sizeof(wchar_t);
 	}
 


### PR DESCRIPTION
x64での警告修正

CMemory::AllocBuffer の引数を size_t に変更するのを開始点に、その修正によって
増えた警告を減らしながら対応を進める。

