### PR TITLE
bregonig/ctags のライセンスが artifacts に含まれないバグを修正

### DIFF
--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -178,14 +178,19 @@ if exist "%WORKDIR_ASM%" (
 mkdir %WORKDIR%
 mkdir %WORKDIR_LOG%
 mkdir %WORKDIR_EXE%
+mkdir %WORKDIR_EXE%\license\bregonig\
 mkdir %WORKDIR_EXE%\license\ctags\
 mkdir %WORKDIR_INST%
 copy /Y /B %platform%\%configuration%\sakura.exe %WORKDIR_EXE%\
 copy /Y /B %platform%\%configuration%\*.dll      %WORKDIR_EXE%\
 copy /Y /B %platform%\%configuration%\*.pdb      %WORKDIR_EXE%\
 
+: bregonig
+set INSTALLER_RESOURCES_BRON=%~dp0installer\temp\bron
+copy /Y %INSTALLER_RESOURCES_BRON%\*.txt            %WORKDIR_EXE%\license\bregonig\
+
 : ctags.exe
-set INSTALLER_RESOURCES_CTAGS=%~dp0..\installer\temp\ctags
+set INSTALLER_RESOURCES_CTAGS=%~dp0installer\temp\ctags
 copy /Y /B %INSTALLER_RESOURCES_CTAGS%\ctags.exe    %WORKDIR_EXE%\
 copy /Y /B %INSTALLER_RESOURCES_CTAGS%\README.md    %WORKDIR_EXE%\license\ctags\
 copy /Y /B %INSTALLER_RESOURCES_CTAGS%\license\*.*  %WORKDIR_EXE%\license\ctags\


### PR DESCRIPTION
bregonig/ctags のライセンスが artifacts に含まれないバグを修正

#455 でインストーラの対応を行ったが、ZIP の artifacts にちゃんと入れられてなかったのを修正
