### PR TITLE
英語windowsでメッセージがおかしい件に対処する

### DIFF
--- a/sakura_core/CSelectLang.cpp
+++ b/sakura_core/CSelectLang.cpp
@@ -98,9 +98,21 @@ HINSTANCE CSelectLang::InitializeLanguageEnvironment( void )
 		// デフォルト情報を作成する
 		psLangInfo = new SSelLangInfo();
 		psLangInfo->hInstance = GetModuleHandle(NULL);
-
+		
 		// 言語情報ダイアログで "System default" に表示する文字列を作成する
-		::LoadString( GetModuleHandle(NULL), STR_SELLANG_NAME, psLangInfo->szLangName, _countof(psLangInfo->szLangName) );
+		auto nCount = ::LoadString( GetModuleHandle(NULL), STR_SELLANG_NAME, psLangInfo->szLangName, _countof(psLangInfo->szLangName) );
+		assert(0 < nCount);
+
+		// 言語IDを取得
+		TCHAR szBuf[7];		// "0x" + 4桁 + 番兵
+		nCount = ::LoadString( GetModuleHandle(NULL), STR_SELLANG_LANGID, szBuf, _countof(szBuf));
+		assert(nCount == _countof(szBuf) - 1);
+		szBuf[_countof(szBuf) - 1] = _T('\0');
+
+		psLangInfo->wLangId = (WORD)_tcstoul(szBuf, NULL, 16);		// 言語IDを数値化
+		assert(0 < psLangInfo->wLangId);
+
+		psLangInfo->bValid = TRUE;		// メッセージリソースDLLとして有効
 
 		m_psLangInfoList.push_back( psLangInfo );
 	}

--- a/sakura_core/CSelectLang.cpp
+++ b/sakura_core/CSelectLang.cpp
@@ -100,12 +100,12 @@ HINSTANCE CSelectLang::InitializeLanguageEnvironment( void )
 		psLangInfo->hInstance = GetModuleHandle(NULL);
 		
 		// 言語情報ダイアログで "System default" に表示する文字列を作成する
-		auto nCount = ::LoadString( GetModuleHandle(NULL), STR_SELLANG_NAME, psLangInfo->szLangName, _countof(psLangInfo->szLangName) );
+		auto nCount = ::LoadString( psLangInfo->hInstance, STR_SELLANG_NAME, psLangInfo->szLangName, _countof(psLangInfo->szLangName) );
 		assert(0 < nCount);
 
 		// 言語IDを取得
 		TCHAR szBuf[7];		// "0x" + 4桁 + 番兵
-		nCount = ::LoadString( GetModuleHandle(NULL), STR_SELLANG_LANGID, szBuf, _countof(szBuf));
+		nCount = ::LoadString( psLangInfo->hInstance, STR_SELLANG_LANGID, szBuf, _countof(szBuf));
 		assert(nCount == _countof(szBuf) - 1);
 		szBuf[_countof(szBuf) - 1] = _T('\0');
 


### PR DESCRIPTION
表示言語が日本語以外になっているwindowsで、
サクラエディタを日本語表示しているときのメッセージがおかしい件に対処します。
（メッセージの下に出るボタン類が日本語でなくなってしまう。）

変更前 | 変更後
---- | ----
<img src="https://user-images.githubusercontent.com/3253151/46591582-94ae0c00-caf6-11e8-95a8-76a429105deb.png" width="300"> | <img src="https://user-images.githubusercontent.com/3253151/46591574-8eb82b00-caf6-11e8-95de-c4dca9e89f94.png" width="300">

対応内容は、言語リソース構造体の初期化漏れ対策です。
日本語の言語リソースについても言語IDを設定するように修正します。

