### PR TITLE
ヘッダのプロトタイプ宣言で明示的に変数名を指定する (CCodeBase の派生クラス)

### DIFF
--- a/sakura_core/charset/CCodePage.h
+++ b/sakura_core/charset/CCodePage.h
@@ -82,19 +82,19 @@ public:
 	
 protected:
 	// 実装
-	static EConvertResult CPToUni( const char*, const int, wchar_t*, int, int&, UINT );
-	static EConvertResult UniToCP( const wchar_t*, const int, char*, int, int&, UINT );
+	static EConvertResult CPToUni( const char* pSrc, const int nSrcLen, wchar_t* pDst, int nDstCchLen, int& nRetLen, UINT codepage );
+	static EConvertResult UniToCP( const wchar_t* pSrc, const int nSrcLen, char* pDst, int nDstByteLen, int& nRetLen, UINT codepage );
 	
 	int m_nCodePageEx;
 	
 	static BOOL CALLBACK CallBackEnumCodePages( LPCTSTR );
 
-	static int MultiByteToWideChar2(UINT, int, const char*, int, wchar_t*, int);
-	static int WideCharToMultiByte2(UINT, int, const wchar_t*, int, char*, int);
-	static int S_UTF32LEToUnicode( const char*, int, wchar_t*, int );
-	static int S_UTF32BEToUnicode( const char*, int, wchar_t*, int );
-	static int S_UnicodeToUTF32LE( const wchar_t*, int, char*, int );
-	static int S_UnicodeToUTF32BE( const wchar_t*, int, char*, int );
+	static int MultiByteToWideChar2(UINT codepage, int flags, const char* pSrc, int nSrcLen, wchar_t* pDst, int nDstLen);
+	static int WideCharToMultiByte2(UINT codepage, int flags, const wchar_t* pSrc, int nSrcLen, char* pDst, int nDstLen);
+	static int S_UTF32LEToUnicode(const char* pSrc, int nSrcLen, wchar_t* pDst, int nDstLen);
+	static int S_UTF32BEToUnicode(const char* pSrc, int nSrcLen, wchar_t* pDst, int nDstLen);
+	static int S_UnicodeToUTF32LE(const wchar_t* pSrc, int nSrcLen, char* pDst, int nDstLen);
+	static int S_UnicodeToUTF32BE(const wchar_t* pSrc, int nSrcLen, char* pDst, int nDstLen);
 };
 
 #endif // SAKURA_CCODEPAGE_H_

--- a/sakura_core/charset/CEuc.h
+++ b/sakura_core/charset/CEuc.h
@@ -44,11 +44,11 @@ public:
 public:
 	// 実装
 	// 2008.11.10 変換ロジックを書き直す
-	inline static int _EucjpToUni_char( const unsigned char*, unsigned short*, const ECharSet, bool* pbError, bool* pbHex );
+	inline static int _EucjpToUni_char( const unsigned char* pSrc, unsigned short* pDst, const ECharSet eCharset, bool* pbError, bool* pbHex );
 protected:
-	static int EucjpToUni( const char*, const int, wchar_t*, bool* pbError );
-	inline static int _UniToEucjp_char( const unsigned short*, unsigned char*, const ECharSet, bool* pbError );
-	static int UniToEucjp( const wchar_t*, const int, char*, bool* pbError );
+	static int EucjpToUni( const char* pSrc, const int nSrcLen, wchar_t* pDst, bool* pbError );
+	inline static int _UniToEucjp_char( const unsigned short* pSrc, unsigned char* pDst, const ECharSet eCharset, bool* pbError );
+	static int UniToEucjp( const wchar_t* pSrc, const int nSrcLen, char* pDst, bool* pbError );
 };
 
 

--- a/sakura_core/charset/CJis.h
+++ b/sakura_core/charset/CJis.h
@@ -43,10 +43,10 @@ public:
 
 protected:
 	// 2008.11.10  変換ロジックを書き直す
-	static int _JisToUni_block( const unsigned char*, const int, unsigned short*, const EMyJisEscseq, bool* pbError );
-	static int JisToUni( const char*, const int, wchar_t*, bool* pbError );
-	static int _SjisToJis_char( const unsigned char*, unsigned char*, const ECharSet, bool* pbError );
-	static int UniToJis( const wchar_t*, const int, char*, bool* pbError );
+	static int _JisToUni_block( const unsigned char* pSrc, const int nSrcLen, unsigned short* pDst, const EMyJisEscseq eMyJisesc, bool* pbError );
+	static int JisToUni( const char* pSrc, const int nSrcLen, wchar_t* pDst, bool* pbError );
+	static int _SjisToJis_char( const unsigned char* pSrc, unsigned char* pDst, ECharSet eCharset, bool* pbError );
+	static int UniToJis( const wchar_t* pSrc, const int nSrcLen, char* pDst, bool* pbError );
 
 private:
 	//変換方針

--- a/sakura_core/charset/CLatin1.h
+++ b/sakura_core/charset/CLatin1.h
@@ -48,9 +48,9 @@ public:
 
 protected:
 	// 実装
-	static int Latin1ToUni( const char*, const int, wchar_t *, bool* pbError );
-	inline static int _UniToLatin1_char( const unsigned short*, unsigned char*, const ECharSet, bool* pbError );
-	static int UniToLatin1( const wchar_t*, const int, char*, bool *pbError );
+	static int Latin1ToUni( const char *pSrc, const int nSrcLen, wchar_t *pDst, bool* pbError );
+	inline static int _UniToLatin1_char( const unsigned short* pSrc, unsigned char* pDst, const ECharSet eCharset, bool* pbError );
+	static int UniToLatin1( const wchar_t* pSrc, const int nSrcLen, char* pDst, bool *pbError );
 };
 
 /*!

--- a/sakura_core/charset/CShiftJis.h
+++ b/sakura_core/charset/CShiftJis.h
@@ -50,10 +50,10 @@ public:
 protected:
 	// 実装
 	// 2008.11.10 変換ロジックを書き直す
-	inline static int _SjisToUni_char( const unsigned char*, unsigned short*, const ECharSet, bool* pbError );
-	static int SjisToUni( const char*, const int, wchar_t *, bool* pbError );
+	inline static int _SjisToUni_char( const unsigned char *pSrc, unsigned short *pDst, const ECharSet eCharset, bool* pbError );
+	static int SjisToUni( const char *pSrc, const int nSrcLen, wchar_t *pDst, bool* pbError );
 	inline static int _UniToSjis_char( const unsigned short*, unsigned char*, const ECharSet, bool* pbError );
-	static int UniToSjis( const wchar_t*, const int, char*, bool *pbError );
+	static int UniToSjis( const wchar_t* pSrc, const int nSrcLen, char* pDst, bool *pbError );
 };
 
 

--- a/sakura_core/charset/CShiftJis.h
+++ b/sakura_core/charset/CShiftJis.h
@@ -52,7 +52,7 @@ protected:
 	// 2008.11.10 変換ロジックを書き直す
 	inline static int _SjisToUni_char( const unsigned char *pSrc, unsigned short *pDst, const ECharSet eCharset, bool* pbError );
 	static int SjisToUni( const char *pSrc, const int nSrcLen, wchar_t *pDst, bool* pbError );
-	inline static int _UniToSjis_char( const unsigned short*, unsigned char*, const ECharSet, bool* pbError );
+	inline static int _UniToSjis_char( const unsigned short* pSrc, unsigned char* pDst, const ECharSet eCharset, bool* pbError );
 	static int UniToSjis( const wchar_t* pSrc, const int nSrcLen, char* pDst, bool *pbError );
 };
 

--- a/sakura_core/charset/CUtf7.h
+++ b/sakura_core/charset/CUtf7.h
@@ -43,9 +43,9 @@ public:
 protected:
 
 	// 2008.11.10 変換ロジックを書き直す
-	static int _Utf7SetDToUni_block( const char*, const int, wchar_t* );
-	static int _Utf7SetBToUni_block( const char*, const int, wchar_t*, bool* );
-	static int Utf7ToUni( const char*, const int, wchar_t*, bool* pbError );
+	static int _Utf7SetDToUni_block( const char* pSrc, const int nSrcLen, wchar_t* pDst );
+	static int _Utf7SetBToUni_block( const char* pSrc, const int nSrcLen, wchar_t* pDst, bool* pbError );
+	static int Utf7ToUni( const char* pSrc, const int nSrcLen, wchar_t* pDst, bool* pbError );
 
 	static int _UniToUtf7SetD_block( const wchar_t* pSrc, const int nSrcLen, char* pDst );
 	static int _UniToUtf7SetB_block( const wchar_t* pSrc, const int nSrcLen, char* pDst );

--- a/sakura_core/charset/CUtf8.h
+++ b/sakura_core/charset/CUtf8.h
@@ -59,10 +59,10 @@ protected:
 
 	//変換の実装
 	// 2008.11.10 変換ロジックを書き直す
-	inline static int _Utf8ToUni_char( const unsigned char*, const int, unsigned short*, bool bCESU8Mode );
-	static int Utf8ToUni( const char*, const int, wchar_t*, bool bCESU8Mode );
-	inline static int _UniToUtf8_char( const unsigned short*, const int, unsigned char*, const bool bCSU8Mode );
-	static int UniToUtf8( const wchar_t*, const int, char*, bool* pbError, bool bCSU8Mode );
+	inline static int _Utf8ToUni_char( const unsigned char* pSrc, const int nSrcLen, unsigned short* pDst, bool bCESUMode );
+	static int Utf8ToUni( const char* pSrc, const int nSrcLen, wchar_t* pDst, bool bCESU8Mode );
+	inline static int _UniToUtf8_char( const unsigned short* pSrc, const int nSrcLen, unsigned char* pDst, bool bCESU8Mode );
+	static int UniToUtf8( const wchar_t* pSrc, const int nSrcLen, char* pDst, bool* pbError, bool bCESU8Mode );
 };
 
 


### PR DESCRIPTION
ヘッダのプロトタイプ宣言で明示的に変数名を指定する (CCodeBase の派生クラス)

- #495, #501, #521, #522, #525 の続き
- x64 対応の準備 (#524)
