### PR TITLE
GetProcAddress のラッパー関数を用意して使用

### DIFF
--- a/sakura_core/_main/CProcess.cpp
+++ b/sakura_core/_main/CProcess.cpp
@@ -74,7 +74,7 @@ bool CProcess::Run()
 		HMODULE hDllDbgHelp = LoadLibraryExedir( _T("dbghelp.dll") );
 		m_pfnMiniDumpWriteDump = NULL;
 		if( hDllDbgHelp ){
-			*(FARPROC*)&m_pfnMiniDumpWriteDump = ::GetProcAddress( hDllDbgHelp, "MiniDumpWriteDump" );
+			GetTypedProcAddress( m_pfnMiniDumpWriteDump, hDllDbgHelp, "MiniDumpWriteDump" );
 		}
 
 		__try {

--- a/sakura_core/debug/Debug3.cpp
+++ b/sakura_core/debug/Debug3.cpp
@@ -21,7 +21,7 @@ int DebugMonitor_Output(const wchar_t* szInstanceId, const wchar_t* szText)
 
 	static FN_DebugMonitor_Output f=NULL;
 	if(!f){
-		f=(FN_DebugMonitor_Output)GetProcAddress(hDll,"DebugMonitor_Output");
+		GetTypedProcAddress(f, hDll,"DebugMonitor_Output");
 	}
 	if(!f)return -1;
 
@@ -36,7 +36,7 @@ LPCWSTR GetWindowsMessageName(UINT msg)
 
 	static FN_GetWindowsMessageName f=NULL;
 	if(!f){
-		f=(FN_GetWindowsMessageName)GetProcAddress(hDll,"GetWindowsMessageName");
+		GetTypedProcAddress(f, hDll,"GetWindowsMessageName");
 	}
 	if(!f)return L"?";
 

--- a/sakura_core/extmodule/CDllHandler.cpp
+++ b/sakura_core/extmodule/CDllHandler.cpp
@@ -193,7 +193,7 @@ bool CDllImp::RegisterEntries(const ImportTable table[])
 	for(int i = 0; table[i].proc!=NULL; i++)
 	{
 		FARPROC proc;
-		if ((proc = ::GetProcAddress(GetInstance(), table[i].name)) == NULL) 
+		if (GetTypedProcAddress(proc, GetInstance(), table[i].name) == NULL) 
 		{
 			return false;
 		}

--- a/sakura_core/util/module.cpp
+++ b/sakura_core/util/module.cpp
@@ -82,15 +82,13 @@ DWORD GetDllVersion(LPCTSTR lpszDllName)
 	if(hinstDll)
 	{
 		DLLGETVERSIONPROC pDllGetVersion;
-		pDllGetVersion = (DLLGETVERSIONPROC)GetProcAddress(hinstDll,
-						  "DllGetVersion");
 
 		/* Because some DLLs might not implement this function, you
 		must test for it explicitly. Depending on the particular
 		DLL, the lack of a DllGetVersion function can be a useful
 		indicator of the version. */
 
-		if(pDllGetVersion)
+		if(GetTypedProcAddress(pDllGetVersion, hinstDll, "DllGetVersion"))
 		{
 			DLLVERSIONINFO dvi;
 			HRESULT hr;

--- a/sakura_core/util/module.h
+++ b/sakura_core/util/module.h
@@ -36,5 +36,13 @@ void ChangeCurrentDirectoryToExeDir();
 //! カレントディレクトリ移動機能付LoadLibrary
 HMODULE LoadLibraryExedir( LPCTSTR pszDll);
 
+template <typename PtrT>
+PtrT GetTypedProcAddress( PtrT& ptr, HMODULE hModule, LPCSTR lpProcName ) {
+	static_assert( std::is_pointer<PtrT>::value, "you must supply pointer argument." );
+	auto ret = ::GetProcAddress( hModule, lpProcName );
+	ptr = reinterpret_cast<decltype(ptr)>(ret);
+	return ptr;
+}
+
 #endif /* SAKURA_MODULE_4F382EF5_EF52_47E1_A774_5CDFB545AB25_H_ */
 /*[EOF]*/

--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -311,11 +311,8 @@ BOOL GetSystemResources(
 
 	hlib = ::LoadLibraryExedir( _T("RSRC32.dll") );
 	if( (INT_PTR)hlib > 32 ){
-		GetFreeSystemResources = (int (CALLBACK *)( int ))GetProcAddress(
-			hlib,
-			"_MyGetFreeSystemResources32@4"
-		);
-		if( GetFreeSystemResources != NULL ){
+		
+		if( GetTypedProcAddress(GetFreeSystemResources, hlib, "_MyGetFreeSystemResources32@4") != NULL ){
 			*pnSystemResources = GetFreeSystemResources( GFSR_SYSTEMRESOURCES );
 			*pnUserResources = GetFreeSystemResources( GFSR_USERRESOURCES );
 			*pnGDIResources = GetFreeSystemResources( GFSR_GDIRESOURCES );


### PR DESCRIPTION
リファクタとして以下の変更を行いました。

- WindowsAPI の GetProcAddress を ~~同名の~~ テンプレート関数でラップして使用、型推論を使ってコード記述量の削減
- CHtmlHelp クラスのメンバー変数名を HtmlHelp から m_HtmlHelp に変更、public にしないように変更、呼び出しは operator() 経由に変更
- CSelectLang::ChangeLang において kernel32 のハンドル取得に LoadLibrary ではなく GetModule を使うように変更