### PR TITLE
windows95向けの独自定義サイズマクロをやめる

### DIFF
--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -207,20 +207,6 @@ namespace ApiWrap
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           定数                              //
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-
-	//	Jan. 29, 2002 genta
-	//	Win95/NTが納得するsizeof( MENUITEMINFO )
-	//	これ以外の値を与えると古いOSでちゃんと動いてくれない．
-	#if defined(_WIN64) || defined(_UNICODE)
-		static const int SIZEOF_MENUITEMINFO = sizeof(MENUITEMINFO);
-	#else
-		static const int SIZEOF_MENUITEMINFO = 44;
-	#endif
-
-
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//             SendMessage,PostMessage意味付け                 //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	// 過去のUNICODE化の名残です。

--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -210,14 +210,6 @@ namespace ApiWrap
 	//                           定数                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	//	Jun. 29, 2002 こおり
-	//	Windows 95対策．Property SheetのサイズをWindows95が認識できる物に固定する．
-	#if defined(_WIN64) || defined(_UNICODE)
-		static const size_t sizeof_old_PROPSHEETHEADER = sizeof(PROPSHEETHEADER);
-	#else
-		static const size_t sizeof_old_PROPSHEETHEADER = 40;
-	#endif
-
 	//	Jan. 29, 2002 genta
 	//	Win95/NTが納得するsizeof( MENUITEMINFO )
 	//	これ以外の値を与えると古いOSでちゃんと動いてくれない．

--- a/sakura_core/dlg/CDlgOpenFile.cpp
+++ b/sakura_core/dlg/CDlgOpenFile.cpp
@@ -54,26 +54,6 @@ static const DWORD p_helpids[] = {	//13100
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
 
-// 2005.10.29 ryoji
-// Windows 2000 version of OPENFILENAME.
-// The new version has three extra members.
-// See CommDlg.h
-#if (_WIN32_WINNT >= 0x0500)
-struct OPENFILENAMEZ : public OPENFILENAME {
-};
-#else
-struct OPENFILENAMEZ : public OPENFILENAME {
-  void *        pvReserved;
-  DWORD         dwReserved;
-  DWORD         FlagsEx;
-};
-#define OPENFILENAME_SIZE_VERSION_400 sizeof(OPENFILENAME)
-#endif // (_WIN32_WINNT >= 0x0500)
-
-#ifndef OFN_ENABLESIZING
-	#define OFN_ENABLESIZING	0x00800000
-#endif
-
 static int AddComboCodePages(HWND hdlg, HWND combo, int nSelCode, bool& bInit);
 
 
@@ -117,7 +97,7 @@ public:
 	CRecentFolder			m_cRecentFolder;
 
 	OPENFILENAME*	m_pOf;
-	OPENFILENAMEZ	m_ofn;		/* 2005.10.29 ryoji OPENFILENAMEZ「ファイルを開く」ダイアログ用構造体 */
+	OPENFILENAME	m_ofn;		/* 2005.10.29 ryoji OPENFILENAME「ファイルを開く」ダイアログ用構造体 */
 	HWND			m_hwndOpenDlg;
 	HWND			m_hwndComboMRU;
 	HWND			m_hwndComboOPENFOLDER;
@@ -1149,11 +1129,11 @@ void CDlgOpenFile::DlgOpenFail(void)
 	@author ryoji
 	@date 2005.10.29
 */
-void CDlgOpenFile::InitOfn( OPENFILENAMEZ* ofn )
+void CDlgOpenFile::InitOfn( OPENFILENAME* ofn )
 {
 	memset_raw(ofn, 0, sizeof(*ofn));
 
-	ofn->lStructSize = IsWinV5forOfn()? sizeof(OPENFILENAMEZ): OPENFILENAME_SIZE_VERSION_400;
+	ofn->lStructSize = sizeof(OPENFILENAME);
 	ofn->lpfnHook = OFNHookProc;
 	ofn->lpTemplateName = MAKEINTRESOURCE(IDD_FILEOPEN);	// <-_T("IDD_FILEOPEN"); 2008/7/26 Uchi
 	ofn->nFilterIndex = 1;	//Jul. 09, 2001 JEPRO		/* 「開く」での最初のワイルドカード */
@@ -1238,7 +1218,7 @@ void CDlgOpenFile::InitLayout( HWND hwndOpenDlg, HWND hwndDlg, HWND hwndBaseCtrl
 	@author Moca
 	@date 2006.09.03 新規作成
 */
-bool CDlgOpenFile::_GetOpenFileNameRecover( OPENFILENAMEZ* ofn )
+bool CDlgOpenFile::_GetOpenFileNameRecover( OPENFILENAME* ofn )
 {
 	BOOL bRet = ::GetOpenFileName( ofn );
 	if( !bRet  ){
@@ -1255,7 +1235,7 @@ bool CDlgOpenFile::_GetOpenFileNameRecover( OPENFILENAMEZ* ofn )
 	@author Moca
 	@date 2006.09.03 新規作成
 */
-bool CDlgOpenFile::GetSaveFileNameRecover( OPENFILENAMEZ* ofn )
+bool CDlgOpenFile::GetSaveFileNameRecover( OPENFILENAME* ofn )
 {
 	BOOL bRet = ::GetSaveFileName( ofn );
 	if( !bRet  ){

--- a/sakura_core/dlg/CDlgOpenFile.h
+++ b/sakura_core/dlg/CDlgOpenFile.h
@@ -29,7 +29,6 @@
 
 struct SLoadInfo;	// doc/CDocListener.h
 struct SSaveInfo;	// doc/CDocListener.h
-struct OPENFILENAMEZ;
 class CDlgOpenFileMem;
 
 /*! フィルタ設定 */
@@ -76,16 +75,16 @@ protected:
 	void	DlgOpenFail(void);
 
 	// 2005.11.02 ryoji OS バージョン対応の OPENFILENAME 初期化用関数
-	void InitOfn( OPENFILENAMEZ* );
+	void InitOfn( OPENFILENAME* );
 
 	// 2005.11.02 ryoji 初期レイアウト設定処理
 	static void InitLayout( HWND hwndOpenDlg, HWND hwndDlg, HWND hwndBaseCtrl );
 
 	// 2006.09.03 Moca ファイルダイアログのエラー回避
 	//! リトライ機能付き GetOpenFileName
-	bool _GetOpenFileNameRecover( OPENFILENAMEZ* ofn );
+	bool _GetOpenFileNameRecover( OPENFILENAME* ofn );
 	//! リトライ機能付き GetOpenFileName
-	bool GetSaveFileNameRecover( OPENFILENAMEZ* ofn );
+	bool GetSaveFileNameRecover( OPENFILENAME* ofn );
 
 	friend UINT_PTR CALLBACK OFNHookProc( HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam );
 

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -260,14 +260,8 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 	}
 	//	To Here Jun. 2, 2001 genta
 
-	PROPSHEETHEADER		psh;
-	memset_raw( &psh, 0, sizeof_raw( psh ) );
-	
-	//	Jun. 29, 2002 こおり
-	//	Windows 95対策．Property SheetのサイズをWindows95が認識できる物に固定する．
-	psh.dwSize = sizeof_old_PROPSHEETHEADER;
-
-	//	JEPROtest Sept. 30, 2000 共通設定の隠れ[適用]ボタンの正体はここ。行頭のコメントアウトを入れ替えてみればわかる
+	PROPSHEETHEADER psh = { PROPSHEETHEADER_V2_SIZE };
+	psh.dwSize     = PROPSHEETHEADER_V2_SIZE;
 	psh.dwFlags    = PSH_NOAPPLYNOW | PSH_PROPSHEETPAGE | PSH_USEPAGELANG;
 	psh.hwndParent = m_hwndParent;
 	psh.hInstance  = CSelectLang::getLangRsrcInstance();

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -167,15 +167,9 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 		p->pfnCallback = NULL;
 	}
 
-	PROPSHEETHEADER		psh;
-	memset_raw( &psh, 0, sizeof_raw( psh ) );
-
-	//	Jun. 29, 2002 こおり
-	//	Windows 95対策．Property SheetのサイズをWindows95が認識できる物に固定する．
-	psh.dwSize = sizeof_old_PROPSHEETHEADER;
-
-	// JEPROtest Sept. 30, 2000 タイプ別設定の隠れ[適用]ボタンの正体はここ。行頭のコメントアウトを入れ替えてみればわかる
-	psh.dwFlags    = /*PSH_USEICONID |*/ PSH_NOAPPLYNOW | PSH_PROPSHEETPAGE/* | PSH_HASHELP*/ | PSH_USEPAGELANG;
+	PROPSHEETHEADER psh = { PROPSHEETHEADER_V2_SIZE };
+	psh.dwSize     = PROPSHEETHEADER_V2_SIZE;
+	psh.dwFlags    = PSH_NOAPPLYNOW | PSH_PROPSHEETPAGE | PSH_USEPAGELANG;
 	psh.hwndParent = m_hwndParent;
 	psh.hInstance  = CSelectLang::getLangRsrcInstance();
 	psh.pszIcon    = NULL;

--- a/sakura_core/uiparts/CMenuDrawer.cpp
+++ b/sakura_core/uiparts/CMenuDrawer.cpp
@@ -862,11 +862,9 @@ void CMenuDrawer::MyAppendMenu(
 #endif
 	}
 
-	MENUITEMINFO mii;
-	memset_raw( &mii, 0, sizeof( mii ) );
-	//	Aug. 31, 2001 genta
-	mii.cbSize = SIZEOF_MENUITEMINFO; //Win95対策済みのsizeof(MENUITEMINFO)値
-
+	// メニュー項目に関する情報を設定します。
+	MENUITEMINFO mii = { sizeof(MENUITEMINFO) };
+	mii.cbSize = sizeof(MENUITEMINFO);
 	mii.fMask = MIIM_CHECKMARKS | MIIM_DATA | MIIM_ID | MIIM_STATE | MIIM_SUBMENU | MIIM_TYPE;
 	mii.fType = 0;
 	if( MF_OWNERDRAW	& ( nFlag | nFlagAdd ) ) mii.fType |= MFT_OWNERDRAW;
@@ -1165,12 +1163,9 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 #ifdef _DEBUG
 	// デバッグ用：メニュー項目に対して、ヘルプがない場合に背景色を青くする
 	TCHAR	szText[1024];
-	MENUITEMINFO mii;
 	// メニュー項目に関する情報を取得します。
-	memset_raw( &mii, 0, sizeof( mii ) );
-
-	mii.cbSize = SIZEOF_MENUITEMINFO; // Win95対策済みのsizeof(MENUITEMINFO)値
-
+	MENUITEMINFO mii = { sizeof(MENUITEMINFO) };
+	mii.cbSize = sizeof(MENUITEMINFO);
 	mii.fMask = MIIM_CHECKMARKS | MIIM_DATA | MIIM_ID | MIIM_STATE | MIIM_SUBMENU | MIIM_TYPE;
 	mii.fType = MFT_STRING;
 	_tcscpy( szText, _T("--unknown--") );
@@ -1610,11 +1605,8 @@ LRESULT CMenuDrawer::OnMenuChar( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 	for( i = 0; i < ::GetMenuItemCount( hmenu ); i++ ){
 		TCHAR	szText[1024];
 		// メニュー項目に関する情報を取得します。
-		MENUITEMINFO		mii;
-		memset_raw( &mii, 0, sizeof( mii ) );
-
-		mii.cbSize = SIZEOF_MENUITEMINFO; //Win95対策済みのsizeof(MENUITEMINFO)値
-
+		MENUITEMINFO mii = { sizeof(MENUITEMINFO) };
+		mii.cbSize = sizeof(MENUITEMINFO);
 		mii.fMask = MIIM_CHECKMARKS | MIIM_DATA | MIIM_ID | MIIM_STATE | MIIM_SUBMENU | MIIM_TYPE;
 		mii.fType = MFT_STRING;
 		_tcscpy( szText, _T("--unknown--") );


### PR DESCRIPTION
旧コードを除去することで記述をシンプルにするPRです。

独自定義マクロを外すことにより、
現行windowsに対応したコードに変えて行くための下地を作ります。
これをやっておくことで、入手不能な過去windowsとの互換性を考えなくて良くなります。

構造体のサイズメンバ dwSize, cbSize にわざわざ代入してあるのは、
メンバ利用箇所のGrepをしたときに「構造体.メンバ = xxx」があるほうが便利と考えたからです。