### PR TITLE
ドロップダウンメニューに履歴の管理を追加

### DIFF
--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -1543,10 +1543,6 @@ int	CControlTray::CreatePopUpMenu_L( void )
 	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_GREP_DIALOG, _T(""), _T("G"), FALSE );
 	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
 
-	/* 履歴の管理のメニューを作成 */
-	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_FAVORITE, _T(""), _T("M"), FALSE );
-	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
-
 	/* MRUリストのファイルのリストをメニューにする */
 //@@@ 2001.12.26 YAZAKI MRUリストは、CMRUに依頼する
 	const CMRUFile cMRU;
@@ -1560,6 +1556,10 @@ int	CControlTray::CreatePopUpMenu_L( void )
 	hMenuPopUp = cMRUFolder.CreateMenu( &m_cMenuDrawer );
 	nEnable = (cMRUFolder.MenuLength() > 0 ? 0 : MF_GRAYED);
 	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING | MF_POPUP| nEnable, (UINT_PTR)hMenuPopUp, LS( F_FILE_RCNTFLDR_SUBMENU ), _T("D") );
+
+	/* 履歴の管理のメニューを作成 */
+	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
+	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_FAVORITE, _T(""), _T("M"), FALSE );
 
 	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
 	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_FILESAVEALL, _T(""), _T("Z"), FALSE );	// Jan. 24, 2005 genta

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -1543,6 +1543,10 @@ int	CControlTray::CreatePopUpMenu_L( void )
 	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_GREP_DIALOG, _T(""), _T("G"), FALSE );
 	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
 
+	/* 履歴の管理のメニューを作成 */
+	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_FAVORITE, _T(""), _T("M"), FALSE );
+	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
+
 	/* MRUリストのファイルのリストをメニューにする */
 //@@@ 2001.12.26 YAZAKI MRUリストは、CMRUに依頼する
 	const CMRUFile cMRU;

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -3862,10 +3862,6 @@ int	CEditWnd::CreateFileDropDownMenu( HWND hwnd )
 	/* 空メニューを作る */
 	hMenu = ::CreatePopupMenu();
 
-	/* 履歴の管理のメニューを作成 */
-	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_FAVORITE, _T(""), _T("M"), FALSE );
-	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
-
 	/* MRUリストのファイルのリストをメニューにする */
 	const CMRUFile cMRU;
 	hMenu = cMRU.CreateMenu( hMenu, &m_cMenuDrawer );
@@ -3888,6 +3884,10 @@ int	CEditWnd::CreateFileDropDownMenu( HWND hwnd )
 		m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING | MF_POPUP | MF_GRAYED, (UINT_PTR)hMenuPopUp, LS(F_FOLDER_USED_RECENTLY), _T("") );
 	}
 
+	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
+
+	/* 履歴の管理のメニューを作成 */
+	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_FAVORITE, _T(""), _T("M"), FALSE );
 	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
 
 	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_FILENEW, _T(""), _T("N"), FALSE );

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -3859,9 +3859,16 @@ int	CEditWnd::CreateFileDropDownMenu( HWND hwnd )
 
 	m_cMenuDrawer.ResetContents();
 
+	/* 空メニューを作る */
+	hMenu = ::CreatePopupMenu();
+
+	/* 履歴の管理のメニューを作成 */
+	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, F_FAVORITE, _T(""), _T("M"), FALSE );
+	m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );
+
 	/* MRUリストのファイルのリストをメニューにする */
 	const CMRUFile cMRU;
-	hMenu = cMRU.CreateMenu( &m_cMenuDrawer );
+	hMenu = cMRU.CreateMenu( hMenu, &m_cMenuDrawer );
 	if( cMRU.MenuLength() > 0 )
 	{
 		m_cMenuDrawer.MyAppendMenuSep( hMenu, MF_BYPOSITION | MF_SEPARATOR, 0, NULL, FALSE );


### PR DESCRIPTION
ドロップダウンメニューに「履歴の管理」を表示することで、履歴が増えすぎた場合に簡単に管理を行えるようにします。 #550
![2018-10-14 10](https://user-images.githubusercontent.com/3253151/46916668-9eed7000-cff8-11e8-9844-1582755d3a4c.png)

追加箇所は２箇所です。
* ツールバーの「ファイルを開く（ドロップダウン）」で開くメニュー
* タスクトレイアイコンの左クリックメニュー
![2018-10-14 11](https://user-images.githubusercontent.com/3253151/46916671-a3198d80-cff8-11e8-925c-fedd26a4a233.png)

タスクトレイのほうは要らんかもですが・・・。
追記）キャプチャ追加すんの忘れてたので付けました :sob:
