### PR TITLE
アウトライン解析の更新アイコンを変更する

### DIFF
--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3301,11 +3301,11 @@ INT_PTR CDlgFuncList::OnNcPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 	lf.lfHeight = ncm.lfCaptionFont.lfHeight;
 	::lstrcpy( lf.lfFaceName, _T("Marlett") );
 	HFONT hFont = ::CreateFontIndirect( &lf );
-	::lstrcpy( lf.lfFaceName, _T("Wingdings") );
+	::lstrcpy( lf.lfFaceName, _T("Webdings") );
 	HFONT hFont2 = ::CreateFontIndirect( &lf );
 	gr.SetTextBackTransparent( true );
 
-	static const TCHAR szBtn[DOCK_BUTTON_NUM] = { (TCHAR)0x72/* 閉じる */, (TCHAR)0x36/* メニュー */, (TCHAR)0xFF/* 更新 */ };
+	static const TCHAR szBtn[DOCK_BUTTON_NUM] = { (TCHAR)0x72/* 閉じる */, (TCHAR)0x36/* メニュー */, (TCHAR)0x71/* 更新 */ };
 	HFONT hFontBtn[DOCK_BUTTON_NUM] = { hFont/* 閉じる */, hFont/* メニュー */, hFont2/* 更新 */ };
 	POINT pt;
 	::GetCursorPos( &pt );


### PR DESCRIPTION
https://github.com/sakura-editor/sakura/issues/543#issuecomment-430283530 の話です。

旧）　フォント Windings 0xFF　windowsロゴマーク？
新）　フォント Webdings 0x71　ブラウザの更新マーク
