### PR TITLE
build-and-test.bat でログ表示がおかしい

### DIFF
--- a/tests/build-and-test.bat
+++ b/tests/build-and-test.bat
@@ -3,7 +3,7 @@ set configuration=%2
 set ERROR_RESULT=0
 
 if "%platform%" == "MinGW" (
-	@echo   test for MinGW will be skipped. (platform: %platform%, configuration: %configuration%)
+	@echo   test for MinGW will be skipped. ^(platform: %platform%, configuration: %configuration%^)
 	exit /b 0
 )
 


### PR DESCRIPTION
build-and-test.bat でログ表示がおかしい (括弧がエスケープされていない)
https://github.com/sakura-editor/sakura/pull/494#discussion_r226369324

https://ci.appveyor.com/project/sakuraeditor/sakura/build/1.0.923/job/qydp82oym0knplj4#L473
`test for MinGW will be skipped. (platform: MinGW, configuration: Release`
