### PR TITLE
ソリューションの clean/rebuild するのをやめて単にビルドする

### DIFF
--- a/build-sln.bat
+++ b/build-sln.bat
@@ -39,8 +39,8 @@ set LOG_FILE=msbuild-%platform%-%configuration%.log
 @rem https://msdn.microsoft.com/ja-jp/library/ms171470.aspx
 set LOG_OPTION=/flp:logfile=%LOG_FILE%
 
-@echo "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%      /t:"Clean","Rebuild"  %EXTRA_CMD% %LOG_OPTION%
-      "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%      /t:"Clean","Rebuild"  %EXTRA_CMD% %LOG_OPTION%
+@echo "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
+      "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
 if %errorlevel% neq 0 (echo error && exit /b 1)
 
 @echo call parse-buildlog.bat %LOG_FILE%


### PR DESCRIPTION
build-sln.bat でビルドのたびに毎回、クリーンして、リビルドするのをやめてインクリメンタルビルドにする。

以前誰かから、リビルドする必要ないんじゃない、という指摘を受けていたが、
当時 appveyor では、ビルド構成ごとにクリーン環境でビルドしていかなったために
クリーンして、リビルドするようになっていて、構成ごとに クリーン環境で
ビルドするようになってもそのままになっていた。

