### PR TITLE
rmdir で削除対象のディレクトリパスをダブルクォートで囲む

### DIFF
--- a/tests/create-project.bat
+++ b/tests/create-project.bat
@@ -11,7 +11,7 @@ if not exist "googletest\CMakeLists.txt" (
 
 set BUILDDIR=build\%platform%
 if exist "%BUILDDIR%" (
-	rmdir /s /q %BUILDDIR%
+	rmdir /s /q "%BUILDDIR%"
 )
 mkdir %BUILDDIR%
 cmake -DCMAKE_GENERATOR_PLATFORM=%platform% -B%BUILDDIR% -H. || set ERROR_RESULT=1

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -169,10 +169,10 @@ if exist "%OUTFILE_EXE%" (
 	del %OUTFILE_EXE%
 )
 if exist "%WORKDIR%" (
-	rmdir /s /q %WORKDIR%
+	rmdir /s /q "%WORKDIR%"
 )
 if exist "%WORKDIR_ASM%" (
-	rmdir /s /q %WORKDIR_ASM%
+	rmdir /s /q "%WORKDIR_ASM%"
 )
 
 mkdir %WORKDIR%
@@ -264,10 +264,10 @@ call %ZIP_CMD%       %OUTFILE_ASM%  %WORKDIR_ASM%
 @echo end   zip asm
 
 if exist "%WORKDIR%" (
-	rmdir /s /q %WORKDIR%
+	rmdir /s /q "%WORKDIR%"
 )
 if exist "%WORKDIR_ASM%" (
-	rmdir /s /q %WORKDIR_ASM%
+	rmdir /s /q "%WORKDIR_ASM%"
 )
 
 exit /b 0


### PR DESCRIPTION
rmdir で削除対象のディレクトリパスをダブルクォートで囲む

特に害はないが、念のため
