### PR TITLE
バッチファイルのヘルプの誤りを修正

### DIFF
--- a/build-installer.bat
+++ b/build-installer.bat
@@ -79,5 +79,5 @@ exit /b 0
 @echo    %~nx1 Win32 Release
 @echo    %~nx1 Win32 Debug
 @echo    %~nx1 x64   Release
-@echo    %~nx1 x64   Release
+@echo    %~nx1 x64   Debug
 exit /b 0

--- a/build-sln.bat
+++ b/build-sln.bat
@@ -66,5 +66,5 @@ exit /b 0
 @echo    %~nx1 Win32 Release
 @echo    %~nx1 Win32 Debug
 @echo    %~nx1 x64   Release
-@echo    %~nx1 x64   Release
+@echo    %~nx1 x64   Debug
 exit /b 0

--- a/run-cppcheck.bat
+++ b/run-cppcheck.bat
@@ -85,5 +85,5 @@ exit /b %ERROR_RESULT%
 @echo    %~nx1 Win32 Release
 @echo    %~nx1 Win32 Debug
 @echo    %~nx1 x64   Release
-@echo    %~nx1 x64   Release
+@echo    %~nx1 x64   Debug
 exit /b 0

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -289,5 +289,5 @@ exit /b 0
 @echo    %~nx1 Win32 Release
 @echo    %~nx1 Win32 Debug
 @echo    %~nx1 x64   Release
-@echo    %~nx1 x64   Release
+@echo    %~nx1 x64   Debug
 exit /b 0


### PR DESCRIPTION
バッチファイルのヘルプの誤りを修正

※ x64 Release の構成の説明が重複している。