### PR TITLE
マウスクリックによるキャレット移動が出来なくなる不具合の解消

### DIFF
--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -83,9 +83,6 @@ void CEditView::OnLBUTTONDOWN( WPARAM fwKeys, int _xPos , int _yPos )
 	if( m_pcEditDoc->m_cLayoutMgr.GetLineCount() == 0 ){
 		return;
 	}
-	if( !GetCaret().ExistCaretFocus() ){ //フォーカスがないとき
-		return;
-	}
 
 	/* 辞書Tipが起動されている */
 	if( 0 == m_dwTipTimer ){


### PR DESCRIPTION
#547 に対する対策です。

マウス左ボタン押下でキャレットのフォーカスが無い時にも処理を行う事で、マウスによるキャレット移動が出来なくなる不具合を解消します。

既存のコードでマウス左ボタン押下でキャレットのフォーカスが無い時に処理を中断している理由は良く分かっていません。中断しないようにしても特に問題は確認出来ませんでした。何か見過ごしているかもしれませんが…。
