### PR TITLE
DEBUG_SETPIXELを無効化する

### DIFF
--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -39,14 +39,9 @@
 #endif
 
 
-//デバッグ用。
-//VistaだとExtTextOutの結果が即反映されない。この関数を用いると即反映されるので、
-//デバッグ時ステップ実行する際に便利になる。ただし、当然重くなる。
-#ifdef _DEBUG
-#define DEBUG_SETPIXEL(hdc) SetPixel(hdc,-1,-1,0); //SetPixelをすると、結果が即反映される。
-#else
+//↓過去プロジェクトの残骸（そのうち削除予定）
 #define DEBUG_SETPIXEL(hdc)
-#endif
+
 
 namespace ApiWrap
 {


### PR DESCRIPTION
issue #568 「バージョン情報」のURL部分の1文字目より前の左上にドットがある を参照。

DEBUG_SETPIXELはvista以降で描画のデバッグをする際に発生した不具合の対策関数。
点を打つ命令(~~実際には2pxの線を引いている~~)を発行することで描画を即時反映させる目的のもの。
この関数の利用箇所は4箇所あるが、うち2箇所はデッドコード(ANSI版関数)。

aliveな関数呼出しが塗りつぶし処理の後にあるため、
描画結果にゴミが見えてしまっているバグの対策として、
~~点を打つ処理と塗りつぶし処理の呼出し順を入れ替える対応を行う。~~

追記：
現行windowsではDEBUG_SETPIXELの効果がまったくないことが判明。
ただ無駄に点を打つ処理と化しているので無効化するように修正します。
