### PR TITLE
Git hash 関連の環境変数をマクロ名に一致させる

### DIFF
--- a/appveyor.md
+++ b/appveyor.md
@@ -132,8 +132,8 @@
 
 | 生成する環境変数 | 説明 | 有効性 |
 ----|----|----
-| COMMITID                      | git の commit Hash                                  | git 環境が有効な場合              |
-| SHORT_COMMITID                | git の commit Hash の先頭8文字                      | git 環境が有効な場合              |
+| GIT_COMMIT_HASH               | git の commit Hash                                  | git 環境が有効な場合              |
+| GIT_SHORT_COMMIT_HASH         | git の commit Hash の先頭8文字                      | git 環境が有効な場合              |
 | GIT_URL                       | git remote URL (origin)                             | git 環境が有効な場合              |
 | GITHUB_COMMIT_URL             | gitHub で対応する commit に対する URL               | appveyor でのビルドのみ有効       |
 | GITHUB_COMMIT_URL_PR_HEAD     | gitHub の Pull Request の commit に対応する URL     | appveyor での PR のビルドのみ有効 |
@@ -151,8 +151,8 @@
 
 | 生成するマクロ名                | 元にする環境変数                | 型       |
 | ----                            | ----                            | ----     |
-| GIT_COMMIT_HASH                 | COMMITID                        | 文字列   |
-| SHORT_COMMITID                  | SHORT_COMMITID                  | 文字列   |
+| GIT_COMMIT_HASH                 | GIT_COMMIT_HASH                 | 文字列   |
+| GIT_SHORT_COMMIT_HASH           | GIT_SHORT_COMMIT_HASH           | 文字列   |
 | GIT_URL                         | GIT_URL                         | 文字列   |
 | APPVEYOR_URL                    | APPVEYOR_URL                    | 文字列   |
 | APPVEYOR_REPO_NAME              | APPVEYOR_REPO_NAME              | 文字列   |

--- a/appveyor.md
+++ b/appveyor.md
@@ -132,8 +132,8 @@
 
 | 生成する環境変数 | 説明 | 有効性 |
 ----|----|----
-| GIT_COMMIT_HASH               | git の commit Hash                                  | git 環境が有効な場合              |
 | GIT_SHORT_COMMIT_HASH         | git の commit Hash の先頭8文字                      | git 環境が有効な場合              |
+| GIT_COMMIT_HASH               | git の commit Hash                                  | git 環境が有効な場合              |
 | GIT_URL                       | git remote URL (origin)                             | git 環境が有効な場合              |
 | GITHUB_COMMIT_URL             | gitHub で対応する commit に対する URL               | appveyor でのビルドのみ有効       |
 | GITHUB_COMMIT_URL_PR_HEAD     | gitHub の Pull Request の commit に対応する URL     | appveyor での PR のビルドのみ有効 |
@@ -151,8 +151,8 @@
 
 | 生成するマクロ名                | 元にする環境変数                | 型       |
 | ----                            | ----                            | ----     |
-| GIT_COMMIT_HASH                 | GIT_COMMIT_HASH                 | 文字列   |
 | GIT_SHORT_COMMIT_HASH           | GIT_SHORT_COMMIT_HASH           | 文字列   |
+| GIT_COMMIT_HASH                 | GIT_COMMIT_HASH                 | 文字列   |
 | GIT_URL                         | GIT_URL                         | 文字列   |
 | APPVEYOR_URL                    | APPVEYOR_URL                    | 文字列   |
 | APPVEYOR_REPO_NAME              | APPVEYOR_REPO_NAME              | 文字列   |

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -30,11 +30,11 @@ if not exist ..\.git (
 
 : Get git hash if git is enabled
 if "%GIT_ENABLED%" == "1" (
-	for /f "usebackq" %%s in (`git show -s --format^=%%H`) do (
-		set GIT_COMMIT_HASH=%%s
-	)
 	for /f "usebackq" %%s in (`git show -s --format^=%%h`) do (
 		set GIT_SHORT_COMMIT_HASH=%%s
+	)
+	for /f "usebackq" %%s in (`git show -s --format^=%%H`) do (
+		set GIT_COMMIT_HASH=%%s
 	)
 	for /f "usebackq" %%s in (`git config --get remote.origin.url`) do (
 		set GIT_URL=%%s
@@ -135,15 +135,15 @@ exit /b 0
 :output_githash
 echo /*! @file */
 echo #pragma once
-if "%GIT_COMMIT_HASH%" == "" (
-	echo // GIT_COMMIT_HASH is not defined
-) else (
-	echo #define GIT_COMMIT_HASH "%GIT_COMMIT_HASH%"
-)
 if "%GIT_SHORT_COMMIT_HASH%" == "" (
 	echo // GIT_SHORT_COMMIT_HASH is not defined
 ) else (
 	echo #define GIT_SHORT_COMMIT_HASH "%GIT_SHORT_COMMIT_HASH%"
+)
+if "%GIT_COMMIT_HASH%" == "" (
+	echo // GIT_COMMIT_HASH is not defined
+) else (
+	echo #define GIT_COMMIT_HASH "%GIT_COMMIT_HASH%"
 )
 if "%GIT_URL%" == "" (
 	echo // GIT_URL is not defined

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -31,17 +31,17 @@ if not exist ..\.git (
 : Get git hash if git is enabled
 if "%GIT_ENABLED%" == "1" (
 	for /f "usebackq" %%s in (`git show -s --format^=%%H`) do (
-		set COMMITID=%%s
+		set GIT_COMMIT_HASH=%%s
 	)
 	for /f "usebackq" %%s in (`git show -s --format^=%%h`) do (
-		set SHORT_COMMITID=%%s
+		set GIT_SHORT_COMMIT_HASH=%%s
 	)
 	for /f "usebackq" %%s in (`git config --get remote.origin.url`) do (
 		set GIT_URL=%%s
 	)
 ) else (
-	set SHORT_COMMITID=
-	set COMMITID=
+	set GIT_SHORT_COMMIT_HASH=
+	set GIT_COMMIT_HASH=
 	set GIT_URL=
 )
 
@@ -71,9 +71,9 @@ if not "%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%" == "" (
 	set APPVEYOR_SHORTHASH_PR_HEAD=
 )
 
-@echo SHORT_COMMITID: %SHORT_COMMITID%
-@echo COMMITID: %COMMITID%
-@echo GIT_URL: %GIT_URL%
+@echo GIT_SHORT_COMMIT_HASH : %GIT_SHORT_COMMIT_HASH%
+@echo GIT_COMMIT_HASH       : %GIT_COMMIT_HASH%
+@echo GIT_URL               : %GIT_URL%
 @echo APPVEYOR_URL          : %APPVEYOR_URL%
 @echo APPVEYOR_REPO_NAME    : %APPVEYOR_REPO_NAME%
 @echo APPVEYOR_REPO_TAG_NAME: %APPVEYOR_REPO_TAG_NAME%
@@ -135,15 +135,15 @@ exit /b 0
 :output_githash
 echo /*! @file */
 echo #pragma once
-if "%COMMITID%" == "" (
+if "%GIT_COMMIT_HASH%" == "" (
 	echo // GIT_COMMIT_HASH is not defined
 ) else (
-	echo #define GIT_COMMIT_HASH "%COMMITID%"
+	echo #define GIT_COMMIT_HASH "%GIT_COMMIT_HASH%"
 )
-if "%SHORT_COMMITID%" == "" (
+if "%GIT_SHORT_COMMIT_HASH%" == "" (
 	echo // GIT_SHORT_COMMIT_HASH is not defined
 ) else (
-	echo #define GIT_SHORT_COMMIT_HASH "%SHORT_COMMITID%"
+	echo #define GIT_SHORT_COMMIT_HASH "%GIT_SHORT_COMMIT_HASH%"
 )
 if "%GIT_URL%" == "" (
 	echo // GIT_URL is not defined


### PR DESCRIPTION
#576: Git hash 関連の環境変数をマクロ名に一致させる

以下マクロに対応する環境変数名をマクロ名に合わせる

- GIT_COMMIT_HASH
- GIT_SHORT_COMMIT_HASH
