### PR TITLE
コマンドのエラー判定に if errorlevel を使うようにする

### DIFF
--- a/build-chm.bat
+++ b/build-chm.bat
@@ -6,12 +6,19 @@ if "%CMD_HHC%" == "" (
 
 @rem hhc.exe returns 1 on success, and returns 0 on failure
 "%CMD_HHC%" help\macro\macro.HHP
-if %errorlevel% equ 0 (echo error && exit /b 1)
+if not errorlevel 1 (
+	echo error macro.HHP errorlevel %errorlevel%
+	exit /b 1
+)
 
 "%CMD_HHC%" help\plugin\plugin.hhp
-if %errorlevel% equ 0 (echo error && exit /b 1)
-
+if not errorlevel 1 (
+	echo error plugin.hhp errorlevel %errorlevel%
+	exit /b 1
+)
 "%CMD_HHC%" help\sakura\sakura.hhp
-if %errorlevel% equ 0 (echo error && exit /b 1)
-
+if not errorlevel 1 (
+	echo error sakura.hhp errorlevel %errorlevel%
+	exit /b 1
+)
 exit /b 0

--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -32,13 +32,13 @@ path=C:\msys64\mingw64\bin;%path%
 mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" githash stdafx Funccode_enum.h Funccode_define.h
 if errorlevel 1 (
 	echo error 1 errorlevel %errorlevel%
-	exit /b %errorlevel%
+	exit /b 1
 )
 
 mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" -j4
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%
-	exit /b %errorlevel%
+	exit /b 1
 )
 exit /b 0
 

--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -30,11 +30,16 @@ path=C:\msys64\mingw64\bin;%path%
 
 @echo mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%"
 mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" githash stdafx Funccode_enum.h Funccode_define.h
-if %errorlevel% neq 0 (popd && exit /b 1)
+if errorlevel 1 (
+	echo error 1 errorlevel %errorlevel%
+	exit /b %errorlevel%
+)
 
 mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" -j4
-if %errorlevel% neq 0 (popd && exit /b 1)
-
+if errorlevel 1 (
+	echo error 2 errorlevel %errorlevel%
+	exit /b %errorlevel%
+)
 exit /b 0
 
 

--- a/build-sln.bat
+++ b/build-sln.bat
@@ -43,14 +43,14 @@ set LOG_OPTION=/flp:logfile=%LOG_FILE%
       "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
 if errorlevel 1 (
 	echo ERROR in msbuild.exe errorlevel %errorlevel%
-	exit /b %errorlevel%
+	exit /b 1
 )
 
 @echo call parse-buildlog.bat %LOG_FILE%
       call parse-buildlog.bat %LOG_FILE%
 if errorlevel 1 (
 	echo ERROR in parse-buildlog.bat errorlevel %errorlevel%
-	exit /b %errorlevel%
+	exit /b 1
 )
 exit /b 0
 

--- a/build-sln.bat
+++ b/build-sln.bat
@@ -41,12 +41,17 @@ set LOG_OPTION=/flp:logfile=%LOG_FILE%
 
 @echo "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
       "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
-if %errorlevel% neq 0 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo ERROR in msbuild.exe errorlevel %errorlevel%
+	exit /b %errorlevel%
+)
 
 @echo call parse-buildlog.bat %LOG_FILE%
       call parse-buildlog.bat %LOG_FILE%
-if %errorlevel% neq 0 (echo error && exit /b 1)
-
+if errorlevel 1 (
+	echo ERROR in parse-buildlog.bat errorlevel %errorlevel%
+	exit /b %errorlevel%
+)
 exit /b 0
 
 @rem ------------------------------------------------------------------------------

--- a/calc-hash-res.bat
+++ b/calc-hash-res.bat
@@ -19,7 +19,7 @@ if not exist "%SRCDIR%" (
 )
 
 where python --version 1>nul 2>&1
-if not "%ERRORLEVEL%" == "0" (
+if errorlevel 1 (
 	@echo NOTE: No python command
 ) else (
 	python calc-hash.py %OUTHASHFILE% %SRCDIR% .res

--- a/calc-hash.bat
+++ b/calc-hash.bat
@@ -19,7 +19,7 @@ if not exist "%SRCDIR%" (
 )
 
 where python --version 1>nul 2>&1
-if not "%ERRORLEVEL%" == "0" (
+if errorlevel 1 (
 	@echo NOTE: No python command
 ) else (
 	python calc-hash.py %OUTHASHFILE% %SRCDIR%

--- a/parse-buildlog.bat
+++ b/parse-buildlog.bat
@@ -25,7 +25,7 @@ if "%APPVEYOR%" == "True" (
 
 set ERROR_RESULT=0
 where python --version 1>nul 2>&1
-if not "%ERRORLEVEL%" == "0" (
+if errorlevel 1 (
 	@echo NOTE: No python command
 ) else (
 	python appveyor_env.py
@@ -37,7 +37,7 @@ exit /b %ERROR_RESULT%
 :openpyxl_install
 
 where pip 1>nul 2>&1
-if not "%ERRORLEVEL%" == "0" (
+if errorlevel 1 (
 	@echo NOTE: No pip command
 ) else (
 	@echo NOTE: found pip command

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -19,7 +19,7 @@ pushd "%~dp0"
 : Git enabled checking
 set GIT_ENABLED=1
 where git 1>nul 2>&1
-if not "%ERRORLEVEL%" == "0" (
+if errorlevel 1 (
 	set GIT_ENABLED=0
 	@echo NOTE: No git command
 )
@@ -120,7 +120,7 @@ if "%VALID_CREATE_GITHASH%" == "0" (
 call :output_githash > %GITHASH_H_TMP%
 
 fc %GITHASH_H% %GITHASH_H_TMP% 1>nul 2>&1
-if "%ERRORLEVEL%" == "0" (
+if not errorlevel 1 (
 	del %GITHASH_H_TMP%
 	@echo %GITHASH_H% was not updated.
 ) else (

--- a/tests/build-and-test.bat
+++ b/tests/build-and-test.bat
@@ -11,7 +11,7 @@ if "%platform%" == "MinGW" (
 call %~dp0create-project.bat %platform% %configuration%
 if errorlevel 1 (
 	@echo ERROR in create-project.bat %errorlevel%
-	exit /b %errorlevel%
+	exit /b 1
 )
 @echo ---- end   create-project.bat ----
 
@@ -19,7 +19,7 @@ if errorlevel 1 (
 call %~dp0build-project.bat %platform% %configuration%
 if errorlevel 1 (
 	@echo ERROR in build-project.bat %errorlevel%
-	exit /b %errorlevel%
+	exit /b 1
 )
 @echo ---- end   build-project.bat ----
 
@@ -27,6 +27,6 @@ if errorlevel 1 (
 call %~dp0run-tests.bat %platform% %configuration%
 if errorlevel 1 (
 	@echo ERROR in run-tests.bat %errorlevel%
-	exit /b %errorlevel%
+	exit /b 1
 )
 @echo ---- end   run-tests.bat ----

--- a/tests/build-and-test.bat
+++ b/tests/build-and-test.bat
@@ -9,24 +9,24 @@ if "%platform%" == "MinGW" (
 
 @echo ---- start create-project.bat ----
 call %~dp0create-project.bat %platform% %configuration%
-if %ERRORLEVEL% neq 0 (
-	@echo ERROR in create-project.bat
-	exit /b 1
+if errorlevel 1 (
+	@echo ERROR in create-project.bat %errorlevel%
+	exit /b %errorlevel%
 )
 @echo ---- end   create-project.bat ----
 
 @echo ---- start build-project.bat ----
 call %~dp0build-project.bat %platform% %configuration%
-if %ERRORLEVEL% neq 0 (
-	@echo ERROR in build-project.bat
-	exit /b 1
+if errorlevel 1 (
+	@echo ERROR in build-project.bat %errorlevel%
+	exit /b %errorlevel%
 )
 @echo ---- end   build-project.bat ----
 
 @echo ---- start run-tests.bat ----
 call %~dp0run-tests.bat %platform% %configuration%
-if %ERRORLEVEL% neq 0 (
-	@echo ERROR in run-tests.bat
-	exit /b 1
+if errorlevel 1 (
+	@echo ERROR in run-tests.bat %errorlevel%
+	exit /b %errorlevel%
 )
 @echo ---- end   run-tests.bat ----

--- a/tools/zip/find-7z.bat
+++ b/tools/zip/find-7z.bat
@@ -18,7 +18,7 @@ set RESULT_PATH_7Z_2=--
 set RESULT_PATH_7Z_3=--
 
 where 7z 1>nul 2>&1
-if "%ERRORLEVEL%" == "0" (
+if not errorlevel 1 (
 	set RESULT_PATH_7Z_0=OK
 	set CMD_7Z=7z
 ) else if exist "%PATH_7Z_1%" (


### PR DESCRIPTION
コマンドのエラー判定に if errorlevel を使うようにする

なお、https://github.com/sakura-editor/sakura/pull/559#issuecomment-434927447 のMinGWビルドのエラーをエラーとして検出できています。

このブランチで #559 適用前
https://ci.appveyor.com/project/m-tmatma/sakura/builds/19857732/job/9j6nv94ejb9qmdvl

このブランチで #559 適用後
https://ci.appveyor.com/project/m-tmatma/sakura/builds/19972548/job/rwxie98v4h7w5wj1