### PR TITLE
Build and run tests on MinGW environment.

### DIFF
--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -20,7 +20,7 @@ endif
 CC= $(PREFIX)gcc
 CXX= $(PREFIX)g++
 RC= $(RCPREFIX)windres
-RM= cmd /c $(CURDIR)/../sakura/mingw32-del.bat
+RM= "$(CURDIR)/../sakura/mingw32-del.bat"
 
 DEFINES= \
  -DWIN32 \
@@ -439,7 +439,7 @@ Funccode_enum.h: $(HEADERMAKE) Funccode_x.hsrc
 	$(HEADERMAKE) -in=../sakura_core/Funccode_x.hsrc -out=../sakura_core/Funccode_enum.h -mode=enum -enum=EFunctionCode
 
 githash:
-	cmd /c $(CURDIR)/../sakura/githash.bat ..\\sakura_core
+	"$(CURDIR)/../sakura/githash.bat" ../sakura_core
 
 stdafx: Funccode_enum.h StdAfx.h
 	$(CXX) $(CXXFLAGS) -c StdAfx.h

--- a/tests/build-and-test.bat
+++ b/tests/build-and-test.bat
@@ -2,13 +2,8 @@ set platform=%1
 set configuration=%2
 set ERROR_RESULT=0
 
-if "%platform%" == "MinGW" (
-	@echo   test for MinGW will be skipped. ^(platform: %platform%, configuration: %configuration%^)
-	exit /b 0
-)
-
 @echo ---- start create-project.bat ----
-call %~dp0create-project.bat %platform% %configuration%
+call "%~dp0create-project.bat" %platform% %configuration%
 if errorlevel 1 (
 	@echo ERROR in create-project.bat %errorlevel%
 	exit /b 1
@@ -16,7 +11,7 @@ if errorlevel 1 (
 @echo ---- end   create-project.bat ----
 
 @echo ---- start build-project.bat ----
-call %~dp0build-project.bat %platform% %configuration%
+call "%~dp0build-project.bat" %platform% %configuration%
 if errorlevel 1 (
 	@echo ERROR in build-project.bat %errorlevel%
 	exit /b 1
@@ -24,7 +19,7 @@ if errorlevel 1 (
 @echo ---- end   build-project.bat ----
 
 @echo ---- start run-tests.bat ----
-call %~dp0run-tests.bat %platform% %configuration%
+call "%~dp0run-tests.bat" %platform% %configuration%
 if errorlevel 1 (
 	@echo ERROR in run-tests.bat %errorlevel%
 	exit /b 1

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -30,13 +30,24 @@ if (BUILD_SHARED_LIBS)
 endif (BUILD_SHARED_LIBS)
 
 # link libraries
-target_link_libraries(${project_name} gtest)
-target_link_libraries(${project_name} gtest_main)
+target_link_libraries(${project_name} PRIVATE gtest)
+target_link_libraries(${project_name} PRIVATE gtest_main)
 
 # Hacks to reuse compiled editor objects.
-target_compile_definitions(${project_name} PUBLIC WIN32 _WIN32_WINNT=_WIN32_WINNT_WIN7)
-target_compile_options    (${project_name} PUBLIC $<$<CONFIG:Release>:/GL> /MT$<$<CONFIG:Debug>:d> /GF /FD /EHsc /Zi /TP /source-charset:utf-8 /execution-charset:shift_jis)
-target_link_libraries     (${project_name} $<$<CONFIG:Release>:-LTCG> comctl32.lib Imm32.lib mpr.lib imagehlp.lib Shlwapi.lib "${CMAKE_CURRENT_LIST_DIR}/../../sakura/${CMAKE_GENERATOR_PLATFORM}/$<CONFIG>/*.obj")
-set_target_properties     (${project_name} PROPERTIES
-	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_GENERATOR_PLATFORM}/$<CONFIG>"
-)
+target_compile_definitions(${project_name} PRIVATE WIN32 _WIN32_WINNT=_WIN32_WINNT_WIN7)
+if (MSVC)
+	target_compile_options (${project_name} PRIVATE $<$<CONFIG:Release>:/GL> /MT$<$<CONFIG:Debug>:d> /GF /FD /EHsc /Zi /TP /source-charset:utf-8 /execution-charset:shift_jis)
+	target_link_libraries  (${project_name} PRIVATE $<$<CONFIG:Release>:-LTCG> "${CMAKE_CURRENT_LIST_DIR}/../../sakura/${CMAKE_GENERATOR_PLATFORM}/$<CONFIG>/*.obj")
+	set_target_properties  (${project_name} PROPERTIES
+		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_GENERATOR_PLATFORM}/$<CONFIG>"
+	)
+elseif (MINGW)
+	target_compile_options (${project_name} PRIVATE -finput-charset=utf-8 -fexec-charset=cp932)
+	file (GLOB_RECURSE ALL_O
+		"${CMAKE_CURRENT_LIST_DIR}/../../sakura_core/*.cpp"
+		"${CMAKE_CURRENT_LIST_DIR}/../../sakura_core/*.rc"
+	)
+	list (TRANSFORM ALL_O REPLACE "\\.(cpp|rc)$" ".o")
+	target_link_libraries (${project_name} PRIVATE ${ALL_O})
+endif ()
+target_link_libraries (${project_name} PRIVATE winspool ole32 oleaut32 uuid comctl32 imm32 mpr imagehlp shlwapi winmm)


### PR DESCRIPTION
#579 の続きです。MinGW ビルドでテストプログラムを作成して実行します。AppVeyor が×を出すはずですが https://github.com/sakura-editor/sakura/pull/559#issuecomment-433756837 で予告していた通りであり、この PR の問題ではありません。

sakura_core/Makefile に対する修正はローカルの cmd.exe が / 区切りのパスを解釈しなかったことへの対処です。

tests/create-project.bat で cmake へのオプションを変えていますが、これは cmake 3.12 のドキュメントや `cmake --help`、`cmake --build` を読んでも -B オプションの説明が見つからなかったからです。-H オプションについては --help, -help, -usage, -h, /? と同じだと書かれていました。[Software pre-installed on Windows build VMs | AppVeyor](https://www.appveyor.com/docs/windows-images-software/) によると AppVeyor にプリインストールされているのは CMake 3.12.2 です。
