### PR TITLE
テストコードで_swprintf_pの利用をやめる

### DIFF
--- a/tests/unittests/test-is_mailaddress.cpp
+++ b/tests/unittests/test-is_mailaddress.cpp
@@ -73,7 +73,7 @@ TEST(testIsMailAddress, CheckMaxLocalPart)
 {
 	wchar_t szTest[256];
 	wchar_t szSeed[] = L"0123456789ABCDEF"; // 16文字の素片
-	::_swprintf_p(szTest, _countof(szTest), L"%1$s%1$s%1$s%1$s@example.com", szSeed); //4個繋げて64文字にする
+	::swprintf_s(szTest, _countof(szTest), L"%s%s%s%s@example.com", szSeed, szSeed, szSeed, szSeed); //4個繋げて64文字にする
 	ASSERT_SAME(TRUE, szTest, ::wcslen(szTest), NULL);
 }
 
@@ -82,7 +82,7 @@ TEST(testIsMailAddress, CheckExceedMaxLocalPart)
 {
 	wchar_t szTest[256];
 	wchar_t szSeed[] = L"0123456789ABCDEF"; // 16文字の素片
-	::_swprintf_p(szTest, _countof(szTest), L"%1$s%1$s%1$s%1$s0@example.com", szSeed); //4個繋げて64文字 + 1
+	::swprintf_s(szTest, _countof(szTest), L"%s%s%s%s0@example.com", szSeed, szSeed, szSeed, szSeed); //4個繋げて64文字 + 1
 	ASSERT_CHANGE(FALSE, szTest, _countof(szTest) - 1, NULL);
 }
 
@@ -91,8 +91,8 @@ TEST(testIsMailAddress, CheckMaxMailbox)
 	wchar_t szTest[256];
 	wchar_t szSeed64[64 + 1];
 	wchar_t szSeed[] = L"0123456789ABCDEF"; // 16文字の素片
-	::_swprintf_p(szSeed64, _countof(szSeed64), L"%1$s%1$s%1$s%1$s", szSeed); //4個繋げて64文字にする
-	::_swprintf_p(szTest, _countof(szTest), L"%1$s@%1$.63s.%1$.63s.%1$.58s.com", szSeed64); //最大255文字のチェック
+	::swprintf_s(szSeed64, _countof(szSeed64), L"%s%s%s%s", szSeed, szSeed, szSeed, szSeed); //4個繋げて64文字にする
+	::swprintf_s(szTest, _countof(szTest), L"%s@%.63s.%.63s.%.58s.com", szSeed64, szSeed64, szSeed64, szSeed64); //最大255文字のチェック
 	int mailboxLength;
 	ASSERT_SAME(TRUE, szTest, _countof(szTest) - 1, &mailboxLength);
 	ASSERT_EQ(255, mailboxLength);
@@ -104,8 +104,8 @@ TEST(testIsMailAddress, CheckMaxExceedMailbox)
 	wchar_t szTest[256 + 1];
 	wchar_t szSeed64[64 + 1];
 	wchar_t szSeed[] = L"0123456789ABCDEF"; // 16文字の素片
-	::_swprintf_p(szSeed64, _countof(szSeed64), L"%1$s%1$s%1$s%1$s", szSeed); //4個繋げて64文字にする
-	::_swprintf_p(szTest, _countof(szTest), L"%1$s@%1$.63s.%1$.63s.%1$.58s0.com", szSeed64); //最大255文字オーバーのチェック
+	::swprintf_s(szSeed64, _countof(szSeed64), L"%s%s%s%s", szSeed, szSeed, szSeed, szSeed); //4個繋げて64文字にする
+	::swprintf_s(szTest, _countof(szTest), L"%s@%.63s.%.63s.%.58s0.com", szSeed64, szSeed64, szSeed64, szSeed64); //最大255文字オーバーのチェック
 	ASSERT_CHANGE(FALSE, szTest, _countof(szTest) - 1, NULL);
 }
 
@@ -115,8 +115,8 @@ TEST(testIsMailAddress, CheckTooLongDomain)
 	wchar_t szTest[256];
 	wchar_t szSeed64[64 + 1];
 	wchar_t szSeed[] = L"0123456789ABCDEF"; // 16文字の素片
-	::_swprintf_p(szSeed64, _countof(szSeed64), L"%1$s%1$s%1$s%1$s", szSeed); //4個繋げて64文字にする
-	::_swprintf_p(szTest, _countof(szTest), L"%1$s@%1$s.com", szSeed64); //63文字を超えるドメイン
+	::swprintf_s(szSeed64, _countof(szSeed64), L"%s%s%s%s", szSeed, szSeed, szSeed, szSeed); //4個繋げて64文字にする
+	::swprintf_s(szTest, _countof(szTest), L"%s@%s.com", szSeed64, szSeed64); //63文字を超えるドメイン
 	ASSERT_CHANGE(FALSE, szTest, ::wcslen(szTest), NULL);
 }
 
@@ -139,7 +139,7 @@ TEST(testIsMailAddress, CheckDomainIncludesUnderScore)
 {
 	wchar_t szTest[256];
 	wchar_t szSeed[] = L"0123456789ABCDEF"; // 16文字の素片
-	::_swprintf_p(szTest, _countof(szTest), L"%1$s@test_domain.com", szSeed); //_を含むドメイン
+	::swprintf(szTest, _countof(szTest), L"%s@test_domain.com", szSeed); //_を含むドメイン
 	ASSERT_CHANGE(FALSE, szTest, ::wcslen(szTest), NULL);
 }
 
@@ -147,7 +147,7 @@ TEST(testIsMailAddress, CheckDomainIncludesSingleHyphen)
 {
 	wchar_t szTest[256];
 	wchar_t szSeed[] = L"0123456789ABCDEF"; // 16文字の素片
-	::_swprintf_p(szTest, _countof(szTest), L"%1$s@test-domain.com", szSeed); //途中に-を含むドメイン
+	::swprintf_s(szTest, _countof(szTest), L"%s@test-domain.com", szSeed); //途中に-を含むドメイン
 	ASSERT_SAME(TRUE, szTest, ::wcslen(szTest), NULL);
 }
 
@@ -156,7 +156,7 @@ TEST(testIsMailAddress, CheckDomainIncludesDoubleHyphen)
 {
 	wchar_t szTest[256];
 	wchar_t szSeed[] = L"0123456789ABCDEF"; // 16文字の素片
-	::_swprintf_p(szTest, _countof(szTest), L"%1$s@test--domain.com", szSeed); //途中に-を含むドメイン
+	::swprintf_s(szTest, _countof(szTest), L"%s@test--domain.com", szSeed); //途中に-を含むドメイン
 	ASSERT_CHANGE(FALSE, szTest, ::wcslen(szTest), NULL);
 }
 


### PR DESCRIPTION
テストコードで利用していた`_swprintf_p`の利用をやめます。

https://github.com/sakura-editor/sakura/pull/591#issuecomment-435556829
https://github.com/sakura-editor/sakura/pull/559#issuecomment-433756837

`_swprintf_p`関数は、引数で与えたパラメータの順番を書式文字列で制御することができます。
この関数をあえて使ったのは国際化対応に活用したい動機があったためです。

関数名 | 説明 | 備考
---- | ---- | ----
`_swprintf_p` | 書式指定に引数の順序を含めることができる | MinGWが非対応
`swprintf_s` | 書式指定に引数の順序を含めることができない | MinGWも対応

置き換え対象コードはテストコードなので、本筋の対応には一切影響を与えません。
本筋の国際化対応には別の方法(FormatMessage関数)が使えそうなので、テストコードの試みは単純にひっこめます。

masterブランチはまだMinGWのテストが有効になってないので、これのappveyor結果を見ても効果の有無は確認できませんが、一応ローカルでビルド確認済みです。

#591をフェッチしてビルドしたときに発生したエラーがこれです。
```cmd
CMakeFiles\tests1.dir/objects.a(test-is_mailaddress.cpp.obj):test-is_mailaddress
.cpp:(.text+0x1029): undefined reference to `__imp__swprintf_p'
CMakeFiles\tests1.dir/objects.a(test-is_mailaddress.cpp.obj):test-is_mailaddress
.cpp:(.text+0x138d): undefined reference to `__imp__swprintf_p'
CMakeFiles\tests1.dir/objects.a(test-is_mailaddress.cpp.obj):test-is_mailaddress
.cpp:(.text+0x16b2): undefined reference to `__imp__swprintf_p'
CMakeFiles\tests1.dir/objects.a(test-is_mailaddress.cpp.obj):test-is_mailaddress
.cpp:(.text+0x16d8): undefined reference to `__imp__swprintf_p'
CMakeFiles\tests1.dir/objects.a(test-is_mailaddress.cpp.obj):test-is_mailaddress
.cpp:(.text+0x1b59): undefined reference to `__imp__swprintf_p'
CMakeFiles\tests1.dir/objects.a(test-is_mailaddress.cpp.obj):test-is_mailaddress
.cpp:(.text+0x1b7e): more undefined references to `__imp__swprintf_p' follow
collect2.exe: error: ld returned 1 exit status
unittests\CMakeFiles\tests1.dir\build.make:501: recipe for target 'bin/tests1.ex
e' failed
```

このPRのコミット f658102 をcherry pickした状態でビルド正常、テストOKを確認しています。
