### PR TITLE
UTF8 BOMなし を文字コードのデフォルトにする

### DIFF
--- a/sakura_core/charset/charset.h
+++ b/sakura_core/charset/charset.h
@@ -47,7 +47,7 @@ enum ECodeType {
 	CODE_AUTODETECT	= 99,			//!< 文字コード自動判別
 	CODE_ERROR      = -1,			//!< エラー
 	CODE_NONE       = -1,			//!< 未検出
-	CODE_DEFAULT    = CODE_SJIS,	//!< デフォルトの文字コード
+	CODE_DEFAULT    = CODE_UTF8,	//!< デフォルトの文字コード
 	/*
 		- MS-CP50220 
 			Unicode から cp50220 への変換時に、

--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -199,9 +199,9 @@ void _DefaultConfig(STypeConfig* pType)
 
 	// 文字コード設定
 	pType->m_encoding.m_bPriorCesu8 = false;
-	pType->m_encoding.m_eDefaultCodetype = CODE_SJIS;
+	pType->m_encoding.m_eDefaultCodetype = CODE_UTF8;
 	pType->m_encoding.m_eDefaultEoltype = EOL_CRLF;
-	pType->m_encoding.m_bDefaultBom = false;
+	pType->m_encoding.m_bDefaultBom = true;
 
 	//@@@2002.2.4 YAZAKI
 	pType->m_szExtHelp[0] = L'\0';

--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -201,7 +201,7 @@ void _DefaultConfig(STypeConfig* pType)
 	pType->m_encoding.m_bPriorCesu8 = false;
 	pType->m_encoding.m_eDefaultCodetype = CODE_UTF8;
 	pType->m_encoding.m_eDefaultEoltype = EOL_CRLF;
-	pType->m_encoding.m_bDefaultBom = true;
+	pType->m_encoding.m_bDefaultBom = false;
 
 	//@@@2002.2.4 YAZAKI
 	pType->m_szExtHelp[0] = L'\0';


### PR DESCRIPTION
UTF8 BOMなし を文字コードのデフォルトにする

@arigayas  さんの要望 (#600) を受けて実装してみました。
適用するかどうか、また BOM を有効にするかどうか
皆様、意見をよろしくおねがいします。
