### PR TITLE
HTML Help でビルド方法に関する説明で build.md を参照するように変更

### DIFF
--- a/help/sakura/_RESOURCE/HLP000112.html
+++ b/help/sakura/_RESOURCE/HLP000112.html
@@ -19,17 +19,14 @@
 サクラエディタはまだまだ発展途上のソフトウェアです。ユーザーの皆様により良いものを提供するため、改良や修正を続けています。<br>
 <br>
 ■<b>ソースコード公開</b><br>
-開発中のソースをすべて無償で配布しています。<br>
+開発中のソースを<a href="https://github.com/sakura-editor/sakura" target=_blank>ここ</a>からすべて無償で入手できます。<br>
+ZIP 形式でも取得できますが、<a href="https://gitforwindows.org/" target=_blank>git</a> を使って入手することをおすすめします。<br>
+
 <br>
-ソースから実行ファイルをビルドするには、以下のどれかが必要です。<br>
+ソースから実行ファイルをビルドするには、以下を参照してください<br>
 <ul>
-<li><a href="https://www.visualstudio.com/downloads/" target=_blank>MS Visual Studio 2017 Community</a></li>
-<li><a href="http://www.mingw.org/" target=_blank>MinGW</a></li>
+<li><a href="https://github.com/sakura-editor/sakura/blob/master/build.md" target=_blank>ビルド方法</a></li>
 </ul>
 
 <br>
-以下も参照
-<ul>
-<li><a href="https://github.com/sakura-editor/sakura/blob/master/README.md#build-requirements" target=_blank>Build Requirements</a></li>
-</ul>
 </BODY></HTML>


### PR DESCRIPTION
HTML Help でビルド方法に関する説明で build.md を参照するように変更