### PR TITLE
CFile に GetDirPath を追加してディレクトリパスを簡単に取得できるようにする

### DIFF
--- a/sakura_core/io/CFile.h
+++ b/sakura_core/io/CFile.h
@@ -43,6 +43,7 @@ public:
 	//パス
 	const CFilePath& GetFilePathClass() const { return m_szFilePath; }
 	LPCTSTR GetFilePath() const { return m_szFilePath; }
+	std::tstring GetDirPath() const { return m_szFilePath.GetDirPath(); }
 	//設定
 	void SetFilePath(LPCTSTR pszPath){ m_szFilePath.Assign(pszPath); }
 	//各種判定


### PR DESCRIPTION
CFile に GetDirPath を追加してディレクトリパスを簡単に取得できるようにする

### 背景

#603 でファイルの存在するディレクトリをコマンドプロンプトで開く対応で
CDocFile のファイルのディレクトリを取得するために以下の部分のコードを
真似して実装した。

https://github.com/sakura-editor/sakura/pull/549#pullrequestreview-165182329

しかし、以下の指摘をもらった。
https://github.com/sakura-editor/sakura/pull/603#discussion_r232870084

### 対応

CDocFile の基底クラスである CFile で GetFilePath で参照しているが、
CFilePath のメソッドの中に GetDirPath があるのでこれを使えば
PathRemoveFileSpec を使わなくていい。



