### PR TITLE
設定データ読み込み処理において言語設定切り替え後にMRUエントリが無い場合は新規インストール後とみなし false を返すように変更

### DIFF
--- a/sakura_core/_main/CControlProcess.cpp
+++ b/sakura_core/_main/CControlProcess.cpp
@@ -90,10 +90,8 @@ bool CControlProcess::InitializeProcess()
 
 	/* 共有データのロード */
 	// 2007.05.19 ryoji 「設定を保存して終了する」オプション処理（sakuext連携用）を追加
-	TCHAR szIniFile[_MAX_PATH];
-	CShareData_IO::LoadShareData();
-	CFileNameManager::getInstance()->GetIniFileName( szIniFile, strProfileName.c_str() );	// 出力iniファイル名
-	if( !fexist(szIniFile) || CCommandLine::getInstance()->IsWriteQuit() ){
+	
+	if( !CShareData_IO::LoadShareData() || CCommandLine::getInstance()->IsWriteQuit() ){
 		/* レジストリ項目 作成 */
 		CShareData_IO::SaveShareData();
 		if( CCommandLine::getInstance()->IsWriteQuit() ){

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -67,6 +67,8 @@ void CShareData_IO::SaveShareData()
 	共有データの読み込み/保存 2
 
 	@param[in] bRead true: 読み込み / false: 書き込み
+	@return 設定データの読み込み/保存が成功したかどうか
+	@note 読み込みの場合、言語設定切り替え後にMRUエントリが無い場合は新規インストール後とみなし false を返す事で初期設定を適用させる
 
 	@date 2004-01-11 D.S.Koba CProfile変更によるコード簡略化
 	@date 2005-04-05 D.S.Koba 各セクションの入出力を関数として分離
@@ -125,6 +127,14 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 		cProfile.IOProfileData( L"Common", L"szLanguageDll", MakeStringBufferT( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );
 		CSelectLang::ChangeLang( pShareData->m_Common.m_sWindow.m_szLanguageDll );
 		pcShare->RefreshString();
+
+		// 新規インストール後の設定ファイルは言語設定しか存在しない
+		// MRUのエントリが無い場合は新規と判断
+		int _MRU_Counts = 0;
+		if (!cProfile.IOProfileData( LTEXT("MRU"), LTEXT("_MRU_Counts"), _MRU_Counts )){
+			// 言語設定の切り替えだけして false を返す事で初期設定を適用させる
+			return false;
+		}
 	}
 
 	// Feb. 12, 2006 D.S.Koba


### PR DESCRIPTION
このPRの変更の目的は、#616 で報告した問題に対処する為です。

`%APPDATA%/sakura.ini` ファイルの内容が新規インストール後のものかどうかの判断は、
`[MRU]`  セクションの `_MRU_Counts` エントリが存在しないかどうかで判定しています。
ちょっとこの判定方法だと単純すぎて危ないかも知れませんが…。。

新規インストールと判断した場合は `return false;` で処理を中断する事で後続する各設定読み込み処理を実行しないようにしました。ほぼ空な設定ファイルから設定情報を呼んでしまうとおかしな事になってしまうので。

それに加えて下記の変更も加えました。

- 管理プロセスから呼び出ししている設定データ読み込み処理（CShareData_IO::LoadShareData）の戻り値を使うように変更
  - 従来の処理では設定ファイル名を呼び出し側でも作ってそのファイルが存在するかどうかで判定していますが、設定データ読み込み処理内でも同じようにして設定ファイル名を作っているので、戻り値を有効活用出来るのではないかと判断しました。

- 後続する設定データ保存処理（CShareData_IO::SaveShareData）の呼び出しは設定ファイルが存在しないという判断ではなくて、設定データ読み込みに処理に失敗したらという判断に変更
  - 前述した内容にも関係しますが、新規インストール後はここで設定データ保存をさせる事で有効な初期設定ファイルに切り替えています。別にここで保存せずともプロセス終了時に設定保存が入るかもしれませんが…。



