### PR TITLE
フォント高さの設定もれを横展開する

### DIFF
--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -271,6 +271,11 @@ INT_PTR CPropToolbar::DispatchEvent(
 
 				List_ResetContent( hwndFuncList );
 
+				// 2014.11.25 フォントの高さが正しくなかったバグを修正
+				int nFontHeight = CTextWidthCalc(hwndFuncList).GetTextHeight();
+
+				nListItemHeight = std::max(nFontHeight, GetSystemMetrics(SM_CYSMICON)) + DpiScaleY(2);
+
 				/* 機能一覧に文字列をセット (リストボックス) */
 				//	From Here Oct. 15, 2001 genta Lookupを使うように変更
 				nNum = m_cLookup.GetItemCount( nIndex2 );


### PR DESCRIPTION
過去の修正の横展開。
同画面に似たようなリストボックスが２つあるが、片方にしか修正が適用されていなかった。

HighDPI対応の準備としてこの不具合の修正を先にいれておく必要がありそう。

共通設定　⇒　ツールバー　で表示させた画面の左側のリストボックスの高さを調整する修正です。
フォントサイズを大きくして試してみてください。