### PR TITLE
`ファイルの場所を コマンドプロンプトを開く` で 管理者ではないときに 32bit アプリから 64bit OS上で起動したときに 32bit で起動してしまうのを修正

### DIFF
--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -649,13 +649,13 @@ void CViewCommander::Command_OPEN_COMMAND_PROMPT(BOOL isAdmin)
 
 #ifndef _WIN64
 	/*
-		64bit OS で 32bit アプリから管理者権限でコマンドプロンプトを起動する場合
+		64bit OS で 32bit アプリからコマンドプロンプトを起動する場合
 		通常は 32bit 版のコマンドプロンプトが開かれる。
 
 		Wow64 の FileSystem Redirection を一時的にオフにすることにより 64bit 版の
 		コマンドプロンプトを起動する
 	*/
-	CDisableWow64FsRedirect wow64Redirect(isAdmin);
+	CDisableWow64FsRedirect wow64Redirect(TRUE);
 #endif
 	auto hInstance = ::ShellExecuteW(NULL, pVerb, szCmdExePathBuf, pszcmdExeParam, strFolder.c_str(), SW_SHOWNORMAL);
 	// If the function succeeds, it returns a value greater than 32. 


### PR DESCRIPTION
`ファイルの場所を コマンドプロンプトを開く` で 管理者ではないときに 32bit アプリから 64bit OS上で
起動したときに 32bit で起動してしまうのを修正

https://github.com/sakura-editor/sakura/pull/623#issuecomment-440082853
