### PR TITLE
テストのディレクトリの誤りを修正 (単体テストが走らない件の対策としても有効) 

### DIFF
--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -7,7 +7,7 @@ set FILTER_BAT=%~dp0test_result_filter_tell_AppVeyor.bat
 
 pushd %~dp0
 set BUILDDIR=build\%platform%
-set BINARY_DIR=%BUILDDIR%\bin\%configuration%
+set BINARY_DIR=%BUILDDIR%\unittests\%platform%\%configuration%
 
 pushd %BINARY_DIR%
 for /r %%i in (tests*.exe) do (


### PR DESCRIPTION
テストのディレクトリの誤りを修正

pushd するディレクトリが間違ってるので pushd が失敗する
https://github.com/sakura-editor/sakura/blob/ff766070dedc2041fc257950ee4e2228e6490389/tests/run-tests.bat#L10-L19
