### PR TITLE
[WIP] テストのビルド、実行を before_test と test_script に移動する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,11 @@ build_script:
 
 before_test:
 - cmd: >-
-    call tests\create-project.bat %platform% %configuration%
-
-    call tests\build-project.bat %platform% %configuration%
+    call tests\before_test.bat %platform% %configuration%
 
 test_script:
 - cmd: >-
-    call tests\run-tests.bat %platform% %configuration%
+    call tests\test_script.bat %platform% %configuration%
 
 artifacts:
 - path: 'sakura-*$(platform)-$(configuration)*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,15 @@ build_script:
 
     call build-all.bat %PLATFORM% %CONFIGURATION%
 
-    call tests\build-and-test.bat %PLATFORM% %CONFIGURATION%
+before_test:
+- cmd: >-
+    call tests\create-project.bat %platform% %configuration%
+
+    call tests\build-project.bat %platform% %configuration%
+
+test_script:
+- cmd: >-
+    call tests\run-tests.bat %platform% %configuration%
 
 artifacts:
 - path: 'sakura-*$(platform)-$(configuration)*.zip'

--- a/tests/before_test.bat
+++ b/tests/before_test.bat
@@ -17,11 +17,3 @@ if errorlevel 1 (
 	exit /b 1
 )
 @echo ---- end   build-project.bat ----
-
-@echo ---- start run-tests.bat ----
-call "%~dp0run-tests.bat" %platform% %configuration%
-if errorlevel 1 (
-	@echo ERROR in run-tests.bat %errorlevel%
-	exit /b 1
-)
-@echo ---- end   run-tests.bat ----

--- a/tests/build-and-test.bat
+++ b/tests/build-and-test.bat
@@ -1,0 +1,19 @@
+set platform=%1
+set configuration=%2
+set ERROR_RESULT=0
+
+@echo ---- start before_test.bat ----
+call "%~dp0before_test.bat" %platform% %configuration%
+if errorlevel 1 (
+	@echo ERROR in before_test.bat %errorlevel%
+	exit /b 1
+)
+@echo ---- end   before_test.bat ----
+
+@echo ---- start test_script.bat ----
+call "%~dp0test_script.bat" %platform% %configuration%
+if errorlevel 1 (
+	@echo ERROR in test_script.bat %errorlevel%
+	exit /b 1
+)
+@echo ---- end   test_script.bat ----

--- a/tests/test_script.bat
+++ b/tests/test_script.bat
@@ -1,0 +1,11 @@
+set platform=%1
+set configuration=%2
+set ERROR_RESULT=0
+
+@echo ---- start run-tests.bat ----
+call "%~dp0run-tests.bat" %platform% %configuration%
+if errorlevel 1 (
+	@echo ERROR in run-tests.bat %errorlevel%
+	exit /b 1
+)
+@echo ---- end   run-tests.bat ----


### PR DESCRIPTION
テストのビルド、実行を `before_test `と `test_script `に移動する

もともと #628 で別の目的で調査し始めたが、
`before_test `と `test_script ` に分けることで構造の見通しがよくなるので分けてみました。

差分が見にくいですが、
tests/build-and-test.bat を tests/before_test.bat と tests/test_script.bat に分割した上で
tests/build-and-test.bat で tests/before_test.bat と tests/test_script.bat を呼び出すようにしています。

この構成で問題ないようであれば、この PR で markdown も更新するようにコミットを
積んだ上で WIP を外します。




