### PR TITLE
doxygen の標準出力をファイルに保存して artifacts に含める

### DIFF
--- a/run-doxygen.bat
+++ b/run-doxygen.bat
@@ -6,11 +6,12 @@ if exist html rmdir /s /q html
 
 set PROJECT_NUMBER=%GIT_SHORT_COMMIT_HASH%
 set HHC_LOCATION=%CMD_HHC%
+set DOXYGEN_LOG=doxygen-%platform%-%configuration%.log
 
 if "%CMD_DOXYGEN%" == "" (
 	echo doxygen was not found
 ) else if exist "%CMD_DOXYGEN%" (
-	"%CMD_DOXYGEN%" doxygen.conf
+	"%CMD_DOXYGEN%" doxygen.conf > %DOXYGEN_LOG%
 ) else (
 	echo doxygen was not found
 )

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -226,6 +226,9 @@ if exist "cppcheck-%platform%-%configuration%.xml" (
 if exist "cppcheck-%platform%-%configuration%.log" (
 	copy /Y "cppcheck-%platform%-%configuration%.log" %WORKDIR_LOG%\
 )
+if exist "doxygen-%platform%-%configuration%.log" (
+	copy /Y "doxygen-%platform%-%configuration%.log" %WORKDIR_LOG%\
+)
 
 if exist "set_appveyor_env.bat" (
 	copy /Y "set_appveyor_env.bat" %WORKDIR_LOG%\


### PR DESCRIPTION
doxygen の標準出力をファイルに保存して artifacts に含める

- 画面出力が非常に多いので出力量削減のため
- 標準エラー出力はそのままにする