### PR TITLE
独自拡張プロパティシートの「設定フォルダ」ボタンの位置調整処理でDPIを考慮

### DIFF
--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -33,6 +33,7 @@
 #include "util/file.h"
 #include "util/os.h"
 #include "util/module.h"
+#include "util/window.h"
 #include "env/CShareData.h"
 #include "env/DLLSHAREDATA.h"
 #include "extmodule/CHtmlHelp.h"
@@ -170,7 +171,7 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 			pt.x = rcTab.left;
 			pt.y = rcOk.top;
 			::ScreenToClient( hwnd, &pt );
-			::MoveWindow( hwndBtn, pt.x, pt.y, 140, rcOk.bottom - rcOk.top, FALSE );
+			::MoveWindow( hwndBtn, pt.x, pt.y, DpiScaleX(140), rcOk.bottom - rcOk.top, FALSE );
 		}
 		break;
 


### PR DESCRIPTION
タイプ別設定や共通設定の画面の左下のボタンの横幅が（ディスプレイ設定によっては）狭くなっていたので修正しました。

| 拡大率 | Before (ace82c2d80a2ca97af6c73d6f6984aa07a4cd5f4) | After (7159afe7d1097e45d073cb2b95dd88814d29c57e) |
| --- | --- | --- |
| 100% | ![image](https://user-images.githubusercontent.com/1131125/48959614-ef69cd00-efa9-11e8-9486-5474941eca92.png) | ![image](https://user-images.githubusercontent.com/1131125/48959601-cfd2a480-efa9-11e8-8c2a-ba8de7962b60.png) |
| 200% | ![image](https://user-images.githubusercontent.com/1131125/48959481-04922c00-efa9-11e8-9553-1c078a0b2b9e.png) | ![image](https://user-images.githubusercontent.com/1131125/48959458-dad90500-efa8-11e8-8910-6aed97e649ea.png) |
| 300% | ![image](https://user-images.githubusercontent.com/1131125/48959656-2e981e00-efaa-11e8-9252-6f3a0a941fa3.png) | ![image](https://user-images.githubusercontent.com/1131125/48959666-42438480-efaa-11e8-8b4f-89a5ec7715e8.png) |
