### PR TITLE
[WIP] 独自拡張プロパティシート（共通設定／タイプ別設定画面用）のタブや「設定フォルダ」ボタンのフォント設定を行う処理を追加

### DIFF
--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -33,6 +33,7 @@
 #include "util/file.h"
 #include "util/os.h"
 #include "util/module.h"
+#include "util/window.h"
 #include "env/CShareData.h"
 #include "env/DLLSHAREDATA.h"
 #include "extmodule/CHtmlHelp.h"
@@ -293,11 +294,7 @@ INT_PTR MyPropertySheet( LPPROPSHEETHEADER lppsph )
 {
 	// 言語を日本語以外にすると何故かタブ等のフォントサイズが小さく表示されるので対策
 	// ダイアログリソース部分は問題無いのだが…。
-	HDC hDC = GetDC(NULL);
-	const int nDpiY = GetDeviceCaps(hDC, LOGPIXELSY);
-	ReleaseDC(NULL, hDC);
-	const int nHeight = -MulDiv(9, nDpiY, 72);
-	g_hFont = CreateFont(nHeight, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
+	g_hFont = CreateFont(-DpiPointsToPixels(9), 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
 		OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, DEFAULT_QUALITY,
 		DEFAULT_PITCH | FF_DONTCARE, L"MS Shell Dlg 2");
 	// 個人設定フォルダを使用するときは「設定フォルダ」ボタンを追加する


### PR DESCRIPTION
高DPI環境限定かどうかは不明ですが、言語を英語にするとフォントサイズが小さい事への対策として入れました。
ただこのやり方が解決方法として適切なのかは分かりません。。

なお言語が日本語の場合にはこの対策は不要ですが、その場合でも処理を行ってしまっています。

| before (f1122b831661cf6a91b89b200f1a5f547674b59a) | after (2d6467d80bfa969a72bf8141838532a8ac9db507) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1131125/48962880-7b8bec80-efca-11e8-9e7b-8cec5c6936fc.png) | ![image](https://user-images.githubusercontent.com/1131125/48962871-4d0e1180-efca-11e8-82d6-7787b5e3e157.png) |

言語を英語にすると `SetThreadUILanguage` が呼び出されますが、そうするとコモンダイアログのフォントサイズが言語が日本語の時に比べて小さくなってしまうのでそれらもいっしょに解決出来ると良いんですが…。何で小さくなっちゃうのかは謎です。

| 種別 | 日本語 | 英語 |
| --- | --- | --- |
| ファイル | ![image](https://user-images.githubusercontent.com/1131125/48962896-079e1400-efcb-11e8-9205-c7609b8b550e.png) | ![image](https://user-images.githubusercontent.com/1131125/48962889-ec330900-efca-11e8-8152-142b0bf809b6.png) |
| カラー | ![image](https://user-images.githubusercontent.com/1131125/48962899-1be21100-efcb-11e8-8870-071792fc8026.png) | ![image](https://user-images.githubusercontent.com/1131125/48962903-27353c80-efcb-11e8-8f11-5d604cb9870a.png) |
| プリント | ![image](https://user-images.githubusercontent.com/1131125/48962911-403ded80-efcb-11e8-9734-e580dff53e11.png) | ![image](https://user-images.githubusercontent.com/1131125/48962907-3320fe80-efcb-11e8-8799-e27a2092766a.png) |
