### PR TITLE
フォントラベルのHighDPI対応

### DIFF
--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -498,7 +498,7 @@ HFONT CPropCommon::SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf
 	lfTemp = lf;
 
 	// 大きすぎるフォントは小さく表示
-	int limitSize = DpiScaleY( 16 );
+	LONG limitSize = ::DpiPointsToPixels( 16 );
 	if ( lfTemp.lfHeight < -limitSize ) {
 		lfTemp.lfHeight = -limitSize;
 	}

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -44,6 +44,7 @@
 #include "env/CDocTypeManager.h"
 #include "CEditApp.h"
 #include "util/shell.h"
+#include "util/window.h"
 #include "sakura_rc.h"
 
 int	CPropCommon::SearchIntArr( int nKey, int* pnArr, int nArrNum )
@@ -495,9 +496,11 @@ HFONT CPropCommon::SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf
 	TCHAR	szFontName[80];
 	LOGFONT lfTemp;
 	lfTemp = lf;
+
 	// 大きすぎるフォントは小さく表示
-	if( lfTemp.lfHeight < -16 ){
-		lfTemp.lfHeight = -16;
+	int limitSize = DpiScaleY( 16 );
+	if ( lfTemp.lfHeight < -limitSize ) {
+		lfTemp.lfHeight = -limitSize;
 	}
 
 	hFont = SetCtrlFont( hwndDlg, idc_static, lfTemp );

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -285,7 +285,7 @@ HFONT CPropTypes::SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf,
 	lfTemp = lf;
 
 	// 大きすぎるフォントは小さく表示
-	int limitSize = DpiScaleY( 16 );
+	LONG limitSize = ::DpiPointsToPixels( 16 );
 	if ( lfTemp.lfHeight < -limitSize ) {
 		lfTemp.lfHeight = -limitSize;
 	}

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -26,6 +26,7 @@
 #include "CEditApp.h"
 #include "view/colors/EColorIndexType.h"
 #include "util/shell.h"
+#include "util/window.h"
 #include "sakura_rc.h"
 
 
@@ -282,9 +283,11 @@ HFONT CPropTypes::SetFontLabel( HWND hwndDlg, int idc_static, const LOGFONT& lf,
 	TCHAR	szFontName[80];
 	LOGFONT lfTemp;
 	lfTemp = lf;
+
 	// 大きすぎるフォントは小さく表示
-	if( lfTemp.lfHeight < -16 ){
-		lfTemp.lfHeight = -16;
+	int limitSize = DpiScaleY( 16 );
+	if ( lfTemp.lfHeight < -limitSize ) {
+		lfTemp.lfHeight = -limitSize;
 	}
 
 	if (bUse) {


### PR DESCRIPTION
## 概要

#471 で上がってる問題の一つです。
#639 の対応を確認しようとしたら気になったので対応します。

## 対応の説明

選択したフォントをサイズ含めて表示するラベルの文字が、
HighDPI環境で小さくなる事象への対応です。

このラベルは、指定したフォントサイズに応じて文字が大きくなる仕様なんですが、
ダイアログではラベルサイズを動的に変えたりするのがめんどうなので
一定の大きさを超えたらそれ以上大きくしないようになっています。

フォントサイズの上限値がHighDPI対応してなかっために
強制的に小さなフォントで描画されてしまっていました。

上限値をHighDPI対応にすることでこの問題を回避します。
対応箇所は2か所あります~~が、タイプ別設定のほうは該当箇所の表示方法が分かりませんでした~~。


## 対応前後比較

ソース  | 初期表示
-- | --
[master](https://github.com/sakura-editor/sakura/commit/8b90cad250a17cc29e960f63ca6e65c9b5c59b4b) | ![2018-11-24](https://user-images.githubusercontent.com/3253151/48966441-f7ab2200-f014-11e8-8646-a22392fdaf75.png)
this PR | ![2018-11-24 1](https://user-images.githubusercontent.com/3253151/48966445-0396e400-f015-11e8-83de-e3fc4015fe58.png)


ソース  | 大きなフォントに設定時
-- | --
[master](https://github.com/sakura-editor/sakura/commit/8b90cad250a17cc29e960f63ca6e65c9b5c59b4b) | ![2018-11-24 3](https://user-images.githubusercontent.com/3253151/48966454-304afb80-f015-11e8-9c27-06db61e6ec82.png)
this PR | ![2018-11-24 2](https://user-images.githubusercontent.com/3253151/48966458-39d46380-f015-11e8-9d24-90ba220f534e.png)

## タイプ別設定の出し方が分かったので追記

1. タイプ別設定一覧で「基本」以外を選び、タイプ別設定を開く
2. スクリーンタブの「フォント」ボタンを押してフォントを選ぶ
3. フォントボタンの上にフォントラベルが表示される
（思いっきり見切れてる件はこのPRで対応すべきなんだろうか・・・？）
