### PR TITLE
辞書Tipの描画改善、およびHighDPI対応

### DIFF
--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -242,9 +242,9 @@ void CTipWnd::DrawTipText(
 	rc.left = 4;
 	rc.top = 4;
 
-	int nBkMode_Old = ::SetBkMode( hdc, TRANSPARENT );
+	int nBkModeOld = ::SetBkMode( hdc, TRANSPARENT );
 	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
-	COLORREF colText_Old = ::SetTextColor( hdc, ::GetSysColor( COLOR_INFOTEXT ) );
+	COLORREF textColorOld = ::SetTextColor( hdc, ::GetSysColor( COLOR_INFOTEXT ) );
 
 	for ( size_t i = 0, nLineBgn = 0; i <= cchText; ) {
 		// iの位置にNUL終端、または"\n"がある場合
@@ -281,9 +281,9 @@ void CTipWnd::DrawTipText(
 		i = pNext - pszText;
 	}
 
-	::SetTextColor( hdc, colText_Old );
+	::SetTextColor( hdc, textColorOld );
 	::SelectObject( hdc, hFontOld );
-	::SetBkMode( hdc, nBkMode_Old );
+	::SetBkMode( hdc, nBkModeOld );
 
 	return;
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -267,12 +267,9 @@ void CTipWnd::DrawTipText(
 
 				nHeight = ::DrawText( hdc, pszWork, cchWork, &rc,
 					DT_WORDBREAK | DT_EXPANDTABS | DT_EXTERNALLEADING
-					DT_EXTERNALLEADING | DT_EXPANDTABS | DT_WORDBREAK /*| DT_TABSTOP | (0x0000ff00 & ( 4 << 8 ))*/
 				);
 			}else{
-				nHeight = ::DrawText( hdc, szDummy, _countof(szDummy) - 1, &rc,
-					DT_EXTERNALLEADING | DT_EXPANDTABS | DT_WORDBREAK /*| DT_TABSTOP | (0x0000ff00 & ( 4 << 8 ))*/
-				);
+				nHeight = ::DrawText( hdc, szDummy, _countof(szDummy) - 1, &rc, DT_CALCRECT );
 			}
 
 			// 描画領域の上端を1行分ずらす

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -145,25 +145,16 @@ void CTipWnd::ComputeWindowSize(
 	RECT*			pRect
 )
 {
-	int		nTextLength;
-	int		nCurMaxWidth;
-	int		nCurHeight;
-	int		nBgn;
-	RECT	rc;
-	HFONT	hFontOld;
-	int		i;
-	int		nCharChars;
+	HFONT hFontOld = (HFONT)::SelectObject( hdc, hFont );
 
-	hFontOld = (HFONT)::SelectObject( hdc, hFont );
-
-	nCurMaxWidth = 0;
-	nCurHeight = 0;
-	nTextLength = _tcslen( pszText );
-	nBgn = 0;
-	for( i = 0; i <= nTextLength; ++i ){
+	int nCurMaxWidth = 0;
+	int nCurHeight = 0;
+	const int nTextLength = _tcslen( pszText );
+	for( int i = 0, nBgn = 0; i <= nTextLength; ++i ){
 		// 2005-09-02 D.S.Koba GetSizeOfChar
-		nCharChars = CNativeT::GetSizeOfChar( pszText, nTextLength, i );
+		int nCharChars = CNativeT::GetSizeOfChar( pszText, nTextLength, i );
 		if( ( 1 == nCharChars && _T('\\') == pszText[i] && _T('n') == pszText[i + 1]) || _T('\0') == pszText[i] ){
+			RECT rc;
 			if( 0 < i - nBgn ){
 				TCHAR*	pszWork = new TCHAR[i - nBgn + 1];
 				auto_memcpy( pszWork, &pszText[nBgn], i - nBgn );

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -241,7 +241,6 @@ void CTipWnd::DrawTipText(
 	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
 	COLORREF colText_Old = ::SetTextColor( hdc, ::GetSysColor( COLOR_INFOTEXT ) );
 
-	int nCurMaxWidth = 0;
 	int nCurHeight = 0;
 	const TCHAR* pszText = m_cInfo.GetStringPtr();
 	const size_t cchText = m_cInfo.GetStringLength();
@@ -270,9 +269,6 @@ void CTipWnd::DrawTipText(
 				nCurHeight += ::DrawText( hdc, pszWork, cchWork, &rc,
 					DT_EXTERNALLEADING | DT_EXPANDTABS | DT_WORDBREAK /*| DT_TABSTOP | (0x0000ff00 & ( 4 << 8 ))*/
 				);
-				if( nCurMaxWidth < rc.right ){
-					nCurMaxWidth = rc.right;
-				}
 			}else{
 				rc.left = 4;
 				rc.top = 4 + nCurHeight;

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -192,8 +192,9 @@ void CTipWnd::ComputeWindowSize(
 				// ワードラップを有効にするため幅だけ指定しておく
 				rc.SetXYWH( 0, 0, cxScreen, 0 );
 
+				// テキスト描画に必要な矩形を計測する
 				::DrawText( hdc, pszWork, cchWork, &rc,
-					DT_CALCRECT | DT_EXTERNALLEADING | DT_EXPANDTABS | DT_WORDBREAK /*| DT_TABSTOP | (0x0000ff00 & ( 4 << 8 ))*/
+					DT_CALCRECT | DT_WORDBREAK | DT_EXPANDTABS | DT_EXTERNALLEADING
 				);
 
 				// 計測した幅が最大幅を越えたら更新する
@@ -201,9 +202,9 @@ void CTipWnd::ComputeWindowSize(
 					nCurMaxWidth = rc.Width();
 				}
 			}else{
-				::DrawText( hdc, _T(" "), 1, &rc,
-					DT_CALCRECT | DT_EXTERNALLEADING | DT_EXPANDTABS | DT_WORDBREAK /*| DT_TABSTOP | (0x0000ff00 & ( 4 << 8 ))*/
-				);
+				// ダミー文字列を計測して必要な高さを取得する
+				constexpr TCHAR szDummy[] = { _T(" ") };
+				::DrawText( hdc, szDummy, _countof( szDummy ) - 1, &rc, DT_CALCRECT );
 			}
 
 			// 計測した高さを加算する(行間は考慮しない)

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -230,30 +230,19 @@ void CTipWnd::DrawTipText(
 	const TCHAR*	pszText
 )
 {
-	int			nTextLength;
-	int			nCurMaxWidth;
-	int			nCurHeight;
-	int			nBgn;
-	RECT		rc;
-	HFONT		hFontOld;
-	int			i;
-	int			nBkMode_Old;
-	COLORREF	colText_Old;
-	int			nCharChars;
+	int nBkMode_Old = ::SetBkMode( hdc, TRANSPARENT );
+	HGDIOBJ hFontOld = ::SelectObject( hdc, hFont );
+	COLORREF colText_Old = ::SetTextColor( hdc, ::GetSysColor( COLOR_INFOTEXT ) );
 
-	nBkMode_Old = ::SetBkMode( hdc, TRANSPARENT );
-	hFontOld = (HFONT)::SelectObject( hdc, hFont );
-	colText_Old = ::SetTextColor( hdc, ::GetSysColor( COLOR_INFOTEXT ) );
-
-	nCurMaxWidth = 0;
-	nCurHeight = 0;
-	nTextLength = _tcslen( pszText );
-	nBgn = 0;
-	for( i = 0; i <= nTextLength; ++i ){
+	int nCurMaxWidth = 0;
+	int nCurHeight = 0;
+	const size_t nTextLength = _tcslen( pszText );
+	for ( size_t i = 0, nBgn = 0; i <= nTextLength; ++i ) {
 //		nCharChars = &pszText[i] - CMemory::MemCharPrev( pszText, nTextLength, &pszText[i] );
 		// 2005-09-02 D.S.Koba GetSizeOfChar
-		nCharChars = CNativeT::GetSizeOfChar( pszText, nTextLength, i );
+		size_t nCharChars = CNativeT::GetSizeOfChar( pszText, nTextLength, i );
 		if( ( 1 == nCharChars && _T('\\') == pszText[i] && _T('n') == pszText[i + 1]) || _T('\0') == pszText[i] ){
+			CMyRect rc;
 			if( 0 < i - nBgn ){
 				TCHAR*	pszWork;
 				pszWork = new TCHAR[i - nBgn + 1];

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -170,10 +170,10 @@ void CTipWnd::ComputeWindowSize(
 
 	for ( size_t i = 0, nLineBgn = 0; i <= cchText; ) {
 		// iの位置がNUL終端かどうか
-		const bool isEndOfText = ( pszText[i] == _T('\0') );
+		const bool isEndOfText = ( pszText[i] == '\0' );
 		// iの位置にNUL終端、または"\n"がある場合
-		if ( isEndOfText == true
-			|| ( i + 1 < cchText && pszText[i] == _T('\\') && pszText[i + 1] == _T('n') ) ) {
+		if ( isEndOfText
+			|| ( i + 1 < cchText && pszText[i] == '\\' && pszText[i + 1] == 'n' ) ) {
 			// 計測結果を格納する矩形
 			CMyRect rc;
 			// 計測対象の文字列がブランクでない場合
@@ -186,7 +186,7 @@ void CTipWnd::ComputeWindowSize(
 					DT_CALCRECT | DT_WORDBREAK | DT_EXPANDTABS | DT_EXTERNALLEADING
 				);
 
-				// 計測した幅が最大幅を越えたら更新する
+				// 計測した幅が最大幅を超えたら更新する
 				if ( nCurMaxWidth < rc.Width() ) {
 					nCurMaxWidth = rc.Width();
 				}
@@ -199,7 +199,7 @@ void CTipWnd::ComputeWindowSize(
 			nCurHeight += rc.Height() + cy4;
 
 			// NUL終端の後に文字はないのでここで確実に抜ける
-			if ( isEndOfText == true ) {
+			if ( isEndOfText ) {
 				break;
 			}
 
@@ -254,10 +254,10 @@ void CTipWnd::DrawTipText(
 
 	for ( size_t i = 0, nLineBgn = 0; i <= cchText; ) {
 		// iの位置がNUL終端かどうか
-		const bool isEndOfText = ( pszText[i] == _T('\0') );
+		const bool isEndOfText = ( pszText[i] == '\0' );
 		// iの位置にNUL終端、または"\n"がある場合
-		if ( isEndOfText == true
-			|| ( i + 1 < cchText && pszText[i] == _T('\\') && pszText[i + 1] == _T('n') ) ) {
+		if ( isEndOfText
+			|| ( i + 1 < cchText && pszText[i] == '\\' && pszText[i + 1] == 'n' ) ) {
 			int nHeight;
 			// 計測対象の文字列がブランクでない場合
 			if ( 0 < i - nLineBgn ) {
@@ -274,7 +274,7 @@ void CTipWnd::DrawTipText(
 			rc.top += nHeight + cy4;
 
 			// NUL終端の後に文字はないのでここで確実に抜ける
-			if ( isEndOfText == true ) {
+			if ( isEndOfText ) {
 				break;
 			}
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -19,6 +19,7 @@
 #include "CTipWnd.h"
 #include "env/CShareData.h"
 #include "env/DLLSHAREDATA.h"
+#include "util/window.h"
 
 
 // ダミー文字列
@@ -191,8 +192,8 @@ void CTipWnd::ComputeWindowSize(
 				::DrawText( hdc, szDummy, _countof( szDummy ) - 1, &rc, DT_CALCRECT );
 			}
 
-			// 計測した高さを加算する(行間は考慮しない)
-			nCurHeight += rc.Height();
+			// 計測した高さを加算する
+			nCurHeight += rc.Height() + DpiScaleY( 4 );
 
 			// NUL終端の後に文字はないのでここで確実に抜ける
 			if ( pszText[i] == _T('\0') ) {
@@ -214,8 +215,8 @@ void CTipWnd::ComputeWindowSize(
 
 	prcResult->left = 0;
 	prcResult->top = 0;
-	prcResult->right = nCurMaxWidth + 4;
-	prcResult->bottom = nCurHeight + 2;
+	prcResult->right = nCurMaxWidth + DpiScaleX( 4 * 2 );
+	prcResult->bottom = nCurHeight + DpiScaleY( 4 );
 
 	return;
 
@@ -239,8 +240,8 @@ void CTipWnd::DrawTipText(
 
 	// 描画矩形
 	CMyRect rc( *prcPaint );
-	rc.left = 4;
-	rc.top = 4;
+	rc.left = DpiScaleX( 4 );
+	rc.top = DpiScaleY( 4 );
 
 	int nBkModeOld = ::SetBkMode( hdc, TRANSPARENT );
 	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
@@ -263,7 +264,7 @@ void CTipWnd::DrawTipText(
 			}
 
 			// 描画領域の上端を1行分ずらす
-			rc.top += nHeight + 4;
+			rc.top += nHeight + DpiScaleY( 4 );
 
 			// NUL終端の後に文字はないのでここで確実に抜ける
 			if ( pszText[i] == _T('\0') ) {

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -155,7 +155,19 @@ void CTipWnd::ComputeWindowSize(
 	for( size_t i = 0, nBgn = 0; i <= cchText; ++i ){
 		// 2005-09-02 D.S.Koba GetSizeOfChar
 		size_t nCharChars = CNativeT::GetSizeOfChar( pszText, cchText, i );
-		if( ( 1 == nCharChars && _T('\\') == pszText[i] && _T('n') == pszText[i + 1]) || _T('\0') == pszText[i] ){
+		// ここの判定文がナゾ。
+		// nCharCharsが1で、iの位置に"\n"がある場合
+		// または、iの位置に"\0"がある場合
+		// ・・・なんじゃこりゃ？
+		//
+		// もしかしてSJIS時代のダメ文字対策の名残かな？
+		// 要するに、改行文字手前かNUL終端手前までを対象にしたいってことのようだ。
+		// 他にも突っ込みどころがあるので一旦保留。
+		if( ( 1 == nCharChars
+			&& _T('\\') == pszText[i]
+			&& _T('n') == pszText[i + 1]
+			)
+			|| _T('\0') == pszText[i] ){
 			RECT rc;
 			if( 0 < i - nBgn ){
 				TCHAR*	pszWork = new TCHAR[i - nBgn + 1];

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -149,10 +149,10 @@ void CTipWnd::ComputeWindowSize(
 	int nCurMaxWidth = 0;
 	int nCurHeight = 0;
 	const TCHAR* pszText = m_cInfo.GetStringPtr();
-	const size_t nTextLength = m_cInfo.GetStringLength();
-	for( size_t i = 0, nBgn = 0; i <= nTextLength; ++i ){
+	const size_t cchText = m_cInfo.GetStringLength();
+	for( size_t i = 0, nBgn = 0; i <= cchText; ++i ){
 		// 2005-09-02 D.S.Koba GetSizeOfChar
-		size_t nCharChars = CNativeT::GetSizeOfChar( pszText, nTextLength, i );
+		size_t nCharChars = CNativeT::GetSizeOfChar( pszText, cchText, i );
 		if( ( 1 == nCharChars && _T('\\') == pszText[i] && _T('n') == pszText[i + 1]) || _T('\0') == pszText[i] ){
 			RECT rc;
 			if( 0 < i - nBgn ){

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -164,14 +164,14 @@ void CTipWnd::ComputeWindowSize(
 
 	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
 
-	for ( size_t i = 0, nBgn = 0; i <= cchText; ) {
+	for ( size_t i = 0, nLineBgn = 0; i <= cchText; ) {
 		// iの位置にNUL終端、または"\n"がある場合
 		if ( pszText[i] == _T('\0')
 			|| ( i + 1 <= cchText && 0 == ::_tcsncmp( &pszText[i], szEscapedLF, _countof(szEscapedLF) - 1 ) ) ) {
 			// 計測結果を格納する矩形
 			CMyRect rc;
 			// 計測対象の文字列長
-			size_t cchWork = i - nBgn;
+			size_t cchWork = i - nLineBgn;
 			if ( 0 < cchWork ) {
 				// 1行の長さがバッファ長を越えたらバッファを拡張する
 				if ( maxBufWork < cchWork + 1 ) {
@@ -179,7 +179,7 @@ void CTipWnd::ComputeWindowSize(
 					bufWork = std::make_unique<TCHAR[]>( maxBufWork );
 				}
 				TCHAR* pszWork = bufWork.get();
-				::_tcsncpy_s( pszWork, maxBufWork, &pszText[nBgn], _TRUNCATE );
+				::_tcsncpy_s( pszWork, maxBufWork, &pszText[nLineBgn], _TRUNCATE );
 
 				// ワードラップを有効にするため幅だけ指定しておく
 				rc.SetXYWH( 0, 0, cxScreen, 0 );
@@ -208,8 +208,8 @@ void CTipWnd::ComputeWindowSize(
 			}
 
 			// 次の行の開始位置を設定する
-			nBgn = i + _countof(szEscapedLF) - 1;
-			i = nBgn;
+			nLineBgn = i + _countof(szEscapedLF) - 1;
+			i = nLineBgn;
 			continue;
 		}
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -225,11 +225,13 @@ void CTipWnd::ComputeWindowSize(
 
 /* ウィンドウのテキストを表示 */
 void CTipWnd::DrawTipText(
-	const HDC		hdc
+	const HDC		hdc,
+	const RECT*		prcPaint
 )
 {
 	assert( m_hFont != NULL );
 	assert( hdc != NULL );
+	assert( prcPaint != NULL );
 
 	int nBkMode_Old = ::SetBkMode( hdc, TRANSPARENT );
 	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
@@ -310,7 +312,7 @@ LRESULT CTipWnd::OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l_Param )
 	HDC			hdc = ::BeginPaint(	hwnd, &ps );
 
 	/* ウィンドウのテキストを表示 */
-	DrawTipText( hdc );
+	DrawTipText( hdc, &ps.rcPaint );
 
 	::EndPaint(	hwnd, &ps );
 	return 0L;

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -321,6 +321,12 @@ LRESULT CTipWnd::OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l_Param )
 // 2001/06/19 Start by asa-o: ウィンドウのサイズを得る
 void CTipWnd::GetWindowSize(LPRECT pRect)
 {
+	// CEditView::ShowKeywordHelpから呼ばれる
+	// 当面、pRectがNULLになることはないが、安全のため入れておく。
+	if ( pRect == NULL ) {
+		return;
+	}
+
 	HDC		hdc = ::GetDC( GetHwnd() );
 
 	// ウィンドウのサイズを得る

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -207,9 +207,9 @@ void CTipWnd::ComputeWindowSize(
 			nLineBgn = i + 2; // "\\n" の文字数
 			i = nLineBgn;
 		}else{
-			// 次の文字位置を取得する
-			LPCTSTR pNext = ::CharNext( &pszText[i] );
-			i = pNext - pszText;
+			// 現在位置の文字がTCHAR単位で何文字に当たるか計算してインデックスを進める
+			size_t nCharCount = CNativeT::GetSizeOfChar( pszText, cchText, i );
+			i += nCharCount;
 		}
 	}
 
@@ -282,9 +282,9 @@ void CTipWnd::DrawTipText(
 			nLineBgn = i + 2; // "\\n" の文字数
 			i = nLineBgn;
 		}else{
-			// 次の文字位置を取得する
-			LPCTSTR pNext = ::CharNext( &pszText[i] );
-			i = pNext - pszText;
+			// 現在位置の文字がTCHAR単位で何文字に当たるか計算してインデックスを進める
+			size_t nCharCount = CNativeT::GetSizeOfChar( pszText, cchText, i );
+			i += nCharCount;
 		}
 	}
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -176,7 +176,8 @@ void CTipWnd::ComputeWindowSize(
 			&& _T('n') == pszText[i + 1]
 			)
 			|| _T('\0') == pszText[i] ){
-			RECT rc;
+			// 計測結果を格納する矩形
+			CMyRect rc;
 			// 計測対象の文字列長
 			size_t cchWork = i - nBgn;
 			if ( 0 < cchWork ) {
@@ -188,22 +189,25 @@ void CTipWnd::ComputeWindowSize(
 				TCHAR* pszWork = bufWork.get();
 				::_tcsncpy_s( pszWork, maxBufWork, &pszText[nBgn], _TRUNCATE );
 
-				rc.left = 0;
-				rc.top = 0;
-				rc.right = cxScreen;
-				rc.bottom = 0;
+				// ワードラップを有効にするため幅だけ指定しておく
+				rc.SetXYWH( 0, 0, cxScreen, 0 );
+
 				::DrawText( hdc, pszWork, cchWork, &rc,
 					DT_CALCRECT | DT_EXTERNALLEADING | DT_EXPANDTABS | DT_WORDBREAK /*| DT_TABSTOP | (0x0000ff00 & ( 4 << 8 ))*/
 				);
-				if( nCurMaxWidth < rc.right ){
-					nCurMaxWidth = rc.right;
+
+				// 計測した幅が最大幅を越えたら更新する
+				if ( nCurMaxWidth < rc.Width() ) {
+					nCurMaxWidth = rc.Width();
 				}
 			}else{
 				::DrawText( hdc, _T(" "), 1, &rc,
 					DT_CALCRECT | DT_EXTERNALLEADING | DT_EXPANDTABS | DT_WORDBREAK /*| DT_TABSTOP | (0x0000ff00 & ( 4 << 8 ))*/
 				);
 			}
-			nCurHeight += rc.bottom;
+
+			// 計測した高さを加算する(行間は考慮しない)
+			nCurHeight += rc.Height();
 
 			nBgn = i + 2;
 		}

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -138,11 +138,13 @@ void CTipWnd::Show( int nX, int nY, const TCHAR* szText, RECT* pRect )
 
 /* ウィンドウのサイズを決める */
 void CTipWnd::ComputeWindowSize(
-	HDC				hdc,
-	RECT*			pRect
+	const HDC		hdc,
+	RECT*			prcResult
 )
 {
 	assert( m_hFont != NULL );
+	assert( hdc != NULL );
+	assert( prcResult != NULL );
 
 	HFONT hFontOld = (HFONT)::SelectObject( hdc, m_hFont );
 
@@ -185,10 +187,10 @@ void CTipWnd::ComputeWindowSize(
 		}
 	}
 
-	pRect->left = 0;
-	pRect->top = 0;
-	pRect->right = nCurMaxWidth + 4;
-	pRect->bottom = nCurHeight + 2;
+	prcResult->left = 0;
+	prcResult->top = 0;
+	prcResult->right = nCurMaxWidth + 4;
+	prcResult->bottom = nCurHeight + 2;
 
 	::SelectObject( hdc, hFontOld );
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -240,19 +240,19 @@ void CTipWnd::DrawTipText(
 	int nCurMaxWidth = 0;
 	int nCurHeight = 0;
 	const TCHAR* pszText = m_cInfo.GetStringPtr();
-	const size_t nTextLength = m_cInfo.GetStringLength();
+	const size_t cchText = m_cInfo.GetStringLength();
 
-	for ( size_t i = 0, nBgn = 0; i <= nTextLength; ++i ) {
-//		nCharChars = &pszText[i] - CMemory::MemCharPrev( pszText, nTextLength, &pszText[i] );
+	for ( size_t i = 0, nLineBgn = 0; i <= cchText; ++i ) {
+//		nCharChars = &pszText[i] - CMemory::MemCharPrev( pszText, cchText, &pszText[i] );
 		// 2005-09-02 D.S.Koba GetSizeOfChar
-		size_t nCharChars = CNativeT::GetSizeOfChar( pszText, nTextLength, i );
+		size_t nCharChars = CNativeT::GetSizeOfChar( pszText, cchText, i );
 		if( ( 1 == nCharChars && _T('\\') == pszText[i] && _T('n') == pszText[i + 1]) || _T('\0') == pszText[i] ){
 			CMyRect rc;
-			if( 0 < i - nBgn ){
+			if( 0 < i - nLineBgn ){
 				TCHAR*	pszWork;
-				pszWork = new TCHAR[i - nBgn + 1];
-				auto_memcpy( pszWork, &pszText[nBgn], i - nBgn );
-				pszWork[i - nBgn] = _T('\0');
+				pszWork = new TCHAR[i - nLineBgn + 1];
+				auto_memcpy( pszWork, &pszText[nLineBgn], i - nLineBgn );
+				pszWork[i - nLineBgn] = _T('\0');
 
 				rc.left = 4;
 				rc.top = 4 + nCurHeight;
@@ -275,7 +275,7 @@ void CTipWnd::DrawTipText(
 				);
 			}
 
-			nBgn = i + 2;
+			nLineBgn = i + 2;
 		}
 		if( 2 == nCharChars ){
 			++i;

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -146,6 +146,9 @@ void CTipWnd::ComputeWindowSize(
 	assert( hdc != NULL );
 	assert( prcResult != NULL );
 
+	// システム設定値を取得
+	const int cxScreen = ::GetSystemMetrics( SM_CXSCREEN );
+
 	HFONT hFontOld = (HFONT)::SelectObject( hdc, m_hFont );
 
 	int nCurMaxWidth = 0;
@@ -176,7 +179,7 @@ void CTipWnd::ComputeWindowSize(
 
 				rc.left = 0;
 				rc.top = 0;
-				rc.right = ::GetSystemMetrics( SM_CXSCREEN );
+				rc.right = cxScreen;
 				rc.bottom = 0;
 				::DrawText( hdc, pszWork, _tcslen(pszWork), &rc,
 					DT_CALCRECT | DT_EXTERNALLEADING | DT_EXPANDTABS | DT_WORDBREAK /*| DT_TABSTOP | (0x0000ff00 & ( 4 << 8 ))*/

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -158,10 +158,6 @@ void CTipWnd::ComputeWindowSize(
 	const TCHAR* pszText = m_cInfo.GetStringPtr();
 	const size_t cchText = m_cInfo.GetStringLength();
 
-	// 行バッファとして使いまわす領域を確保。
-	size_t maxBufWork = MAX_PATH;
-	auto bufWork = std::make_unique<TCHAR[]>( maxBufWork );
-
 	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
 
 	for ( size_t i = 0, nLineBgn = 0; i <= cchText; ) {
@@ -170,22 +166,13 @@ void CTipWnd::ComputeWindowSize(
 			|| ( i + 1 <= cchText && 0 == ::_tcsncmp( &pszText[i], szEscapedLF, _countof(szEscapedLF) - 1 ) ) ) {
 			// 計測結果を格納する矩形
 			CMyRect rc;
-			// 計測対象の文字列長
-			size_t cchWork = i - nLineBgn;
-			if ( 0 < cchWork ) {
-				// 1行の長さがバッファ長を越えたらバッファを拡張する
-				if ( maxBufWork < cchWork + 1 ) {
-					maxBufWork = cchWork + 1;
-					bufWork = std::make_unique<TCHAR[]>( maxBufWork );
-				}
-				TCHAR* pszWork = bufWork.get();
-				::_tcsncpy_s( pszWork, maxBufWork, &pszText[nLineBgn], _TRUNCATE );
-
+			// 計測対象の文字列がブランクでない場合
+			if ( 0 < i - nLineBgn ) {
 				// ワードラップを有効にするため幅だけ指定しておく
 				rc.SetXYWH( 0, 0, cxScreen, 0 );
 
 				// テキスト描画に必要な矩形を計測する
-				::DrawText( hdc, pszWork, cchWork, &rc,
+				::DrawText( hdc, &pszText[nLineBgn], i - nLineBgn, &rc,
 					DT_CALCRECT | DT_WORDBREAK | DT_EXPANDTABS | DT_EXTERNALLEADING
 				);
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -149,10 +149,10 @@ void CTipWnd::ComputeWindowSize(
 
 	int nCurMaxWidth = 0;
 	int nCurHeight = 0;
-	const int nTextLength = _tcslen( pszText );
-	for( int i = 0, nBgn = 0; i <= nTextLength; ++i ){
+	const size_t nTextLength = _tcslen( pszText );
+	for( size_t i = 0, nBgn = 0; i <= nTextLength; ++i ){
 		// 2005-09-02 D.S.Koba GetSizeOfChar
-		int nCharChars = CNativeT::GetSizeOfChar( pszText, nTextLength, i );
+		size_t nCharChars = CNativeT::GetSizeOfChar( pszText, nTextLength, i );
 		if( ( 1 == nCharChars && _T('\\') == pszText[i] && _T('n') == pszText[i + 1]) || _T('\0') == pszText[i] ){
 			RECT rc;
 			if( 0 < i - nBgn ){

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -172,16 +172,18 @@ void CTipWnd::ComputeWindowSize(
 			)
 			|| _T('\0') == pszText[i] ){
 			RECT rc;
-			if( 0 < i - nBgn ){
-				TCHAR*	pszWork = new TCHAR[i - nBgn + 1];
-				auto_memcpy( pszWork, &pszText[nBgn], i - nBgn );
-				pszWork[i - nBgn] = _T('\0');
+			// 計測対象の文字列長
+			size_t cchWork = i - nBgn;
+			if ( 0 < cchWork ) {
+				TCHAR*	pszWork = new TCHAR[cchWork + 1];
+				auto_memcpy( pszWork, &pszText[nBgn], cchWork);
+				pszWork[cchWork] = _T('\0');
 
 				rc.left = 0;
 				rc.top = 0;
 				rc.right = cxScreen;
 				rc.bottom = 0;
-				::DrawText( hdc, pszWork, _tcslen(pszWork), &rc,
+				::DrawText( hdc, pszWork, cchWork, &rc,
 					DT_CALCRECT | DT_EXTERNALLEADING | DT_EXPANDTABS | DT_WORDBREAK /*| DT_TABSTOP | (0x0000ff00 & ( 4 << 8 ))*/
 				);
 				delete [] pszWork;

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -233,6 +233,10 @@ void CTipWnd::DrawTipText(
 	assert( hdc != NULL );
 	assert( prcPaint != NULL );
 
+	// 描画対象をメンバ変数からローカル変数に取得
+	const TCHAR* pszText = m_cInfo.GetStringPtr();
+	const size_t cchText = m_cInfo.GetStringLength();
+
 	// 描画矩形
 	CMyRect rc( *prcPaint );
 	rc.left = 4;
@@ -241,9 +245,6 @@ void CTipWnd::DrawTipText(
 	int nBkMode_Old = ::SetBkMode( hdc, TRANSPARENT );
 	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
 	COLORREF colText_Old = ::SetTextColor( hdc, ::GetSysColor( COLOR_INFOTEXT ) );
-
-	const TCHAR* pszText = m_cInfo.GetStringPtr();
-	const size_t cchText = m_cInfo.GetStringLength();
 
 	for ( size_t i = 0, nLineBgn = 0; i <= cchText; ) {
 		// iの位置にNUL終端、または"\n"がある場合

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -152,11 +152,13 @@ void CTipWnd::ComputeWindowSize(
 	// システム設定値を取得
 	const int cxScreen = ::GetSystemMetrics( SM_CXSCREEN );
 
+	// 計測対象をメンバ変数からローカル変数に取得
+	const TCHAR* pszText = m_cInfo.GetStringPtr();
+	const size_t cchText = m_cInfo.GetStringLength();
+
 	// 計測結果を格納する変数
 	int nCurMaxWidth = 0;
 	int nCurHeight = 0;
-	const TCHAR* pszText = m_cInfo.GetStringPtr();
-	const size_t cchText = m_cInfo.GetStringLength();
 
 	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -21,6 +21,13 @@
 #include "env/DLLSHAREDATA.h"
 
 
+// ダミー文字列
+static constexpr TCHAR szDummy[] = { _T(" ") };
+
+// 改行コードを表す定数
+static constexpr TCHAR szEscapedLF[] = { _T("\\n") };
+
+
 /* CTipWndクラス デストラクタ */
 CTipWnd::CTipWnd()
 : CWnd(_T("::CTipWnd"))
@@ -146,9 +153,6 @@ void CTipWnd::ComputeWindowSize(
 	assert( hdc != NULL );
 	assert( prcResult != NULL );
 
-	// 改行コードを表す定数
-	constexpr TCHAR szEscapedLF[] = { _T("\\n") };
-
 	// システム設定値を取得
 	const int cxScreen = ::GetSystemMetrics( SM_CXSCREEN );
 
@@ -184,7 +188,6 @@ void CTipWnd::ComputeWindowSize(
 				}
 			}else{
 				// ダミー文字列を計測して必要な高さを取得する
-				constexpr TCHAR szDummy[] = { _T(" ") };
 				::DrawText( hdc, szDummy, _countof( szDummy ) - 1, &rc, DT_CALCRECT );
 			}
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -233,10 +233,6 @@ void CTipWnd::DrawTipText(
 	assert( hdc != NULL );
 	assert( prcPaint != NULL );
 
-	// 行バッファとして使いまわす領域を確保。
-	size_t maxBufWork = MAX_PATH;
-	auto bufWork = std::make_unique<TCHAR[]>( maxBufWork );
-
 	// 描画矩形
 	CMyRect rc( *prcPaint );
 	rc.left = 4;
@@ -254,21 +250,14 @@ void CTipWnd::DrawTipText(
 		if ( pszText[i] == _T('\0')
 			|| ( i + 1 <= cchText && 0 == ::_tcsncmp( &pszText[i], szEscapedLF, _countof(szEscapedLF) - 1 ) ) ) {
 			int nHeight;
-			// 描画対象の文字列長
-			size_t cchWork = i - nLineBgn;
-			if ( 0 < cchWork ) {
-				// 1行の長さがバッファ長を越えたらバッファを拡張する
-				if ( maxBufWork < cchWork + 1 ) {
-					maxBufWork = cchWork + 1;
-					bufWork = std::make_unique<TCHAR[]>( maxBufWork );
-				}
-				TCHAR* pszWork = bufWork.get();
-				::_tcsncpy_s( pszWork, maxBufWork, &pszText[nLineBgn], _TRUNCATE );
-
-				nHeight = ::DrawText( hdc, pszWork, cchWork, &rc,
+			// 計測対象の文字列がブランクでない場合
+			if ( 0 < i - nLineBgn ) {
+				// 指定されたテキストを描画する
+				nHeight = ::DrawText( hdc, &pszText[nLineBgn], i - nLineBgn, &rc,
 					DT_WORDBREAK | DT_EXPANDTABS | DT_EXTERNALLEADING
 				);
 			}else{
+				// ダミー文字列の高さを取得する
 				nHeight = ::DrawText( hdc, szDummy, _countof(szDummy) - 1, &rc, DT_CALCRECT );
 			}
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -169,9 +169,11 @@ void CTipWnd::ComputeWindowSize(
 	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
 
 	for ( size_t i = 0, nLineBgn = 0; i <= cchText; ) {
+		// iの位置がNUL終端かどうか
+		const bool isEndOfText = ( pszText[i] == _T('\0') );
 		// iの位置にNUL終端、または"\n"がある場合
-		if ( pszText[i] == _T('\0')
-			|| ( i + 1 <= cchText && pszText[i] == _T('\\') && pszText[i + 1] == _T('n') ) ) {
+		if ( isEndOfText == true
+			|| ( i + 1 < cchText && pszText[i] == _T('\\') && pszText[i + 1] == _T('n') ) ) {
 			// 計測結果を格納する矩形
 			CMyRect rc;
 			// 計測対象の文字列がブランクでない場合
@@ -197,7 +199,7 @@ void CTipWnd::ComputeWindowSize(
 			nCurHeight += rc.Height() + cy4;
 
 			// NUL終端の後に文字はないのでここで確実に抜ける
-			if ( pszText[i] == _T('\0') ) {
+			if ( isEndOfText == true ) {
 				break;
 			}
 
@@ -251,9 +253,11 @@ void CTipWnd::DrawTipText(
 	COLORREF textColorOld = ::SetTextColor( hdc, ::GetSysColor( COLOR_INFOTEXT ) );
 
 	for ( size_t i = 0, nLineBgn = 0; i <= cchText; ) {
+		// iの位置がNUL終端かどうか
+		const bool isEndOfText = ( pszText[i] == _T('\0') );
 		// iの位置にNUL終端、または"\n"がある場合
-		if ( pszText[i] == _T('\0')
-			|| ( i + 1 <= cchText && pszText[i] == _T('\\') && pszText[i + 1] == _T('n') ) ) {
+		if ( isEndOfText == true
+			|| ( i + 1 < cchText && pszText[i] == _T('\\') && pszText[i + 1] == _T('n') ) ) {
 			int nHeight;
 			// 計測対象の文字列がブランクでない場合
 			if ( 0 < i - nLineBgn ) {
@@ -270,7 +274,7 @@ void CTipWnd::DrawTipText(
 			rc.top += nHeight + cy4;
 
 			// NUL終端の後に文字はないのでここで確実に抜ける
-			if ( pszText[i] == _T('\0') ) {
+			if ( isEndOfText == true ) {
 				break;
 			}
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -225,18 +225,21 @@ void CTipWnd::ComputeWindowSize(
 
 /* ウィンドウのテキストを表示 */
 void CTipWnd::DrawTipText(
-	HDC				hdc,
-	HFONT			hFont,
-	const TCHAR*	pszText
+	const HDC		hdc
 )
 {
+	assert( m_hFont != NULL );
+	assert( hdc != NULL );
+
 	int nBkMode_Old = ::SetBkMode( hdc, TRANSPARENT );
-	HGDIOBJ hFontOld = ::SelectObject( hdc, hFont );
+	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
 	COLORREF colText_Old = ::SetTextColor( hdc, ::GetSysColor( COLOR_INFOTEXT ) );
 
 	int nCurMaxWidth = 0;
 	int nCurHeight = 0;
-	const size_t nTextLength = _tcslen( pszText );
+	const TCHAR* pszText = m_cInfo.GetStringPtr();
+	const size_t nTextLength = m_cInfo.GetStringLength();
+
 	for ( size_t i = 0, nBgn = 0; i <= nTextLength; ++i ) {
 //		nCharChars = &pszText[i] - CMemory::MemCharPrev( pszText, nTextLength, &pszText[i] );
 		// 2005-09-02 D.S.Koba GetSizeOfChar
@@ -304,12 +307,10 @@ void CTipWnd::Hide( void )
 LRESULT CTipWnd::OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l_Param )
 {
 	PAINTSTRUCT	ps;
-	RECT		rc;
 	HDC			hdc = ::BeginPaint(	hwnd, &ps );
-	::GetClientRect( hwnd, &rc );
 
 	/* ウィンドウのテキストを表示 */
-	DrawTipText( hdc, m_hFont, m_cInfo.GetStringPtr() );
+	DrawTipText( hdc );
 
 	::EndPaint(	hwnd, &ps );
 	return 0L;

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -152,8 +152,6 @@ void CTipWnd::ComputeWindowSize(
 	// システム設定値を取得
 	const int cxScreen = ::GetSystemMetrics( SM_CXSCREEN );
 
-	HFONT hFontOld = (HFONT)::SelectObject( hdc, m_hFont );
-
 	// 計測結果を格納する変数
 	int nCurMaxWidth = 0;
 	int nCurHeight = 0;
@@ -163,6 +161,8 @@ void CTipWnd::ComputeWindowSize(
 	// 行バッファとして使いまわす領域を確保。
 	size_t maxBufWork = MAX_PATH;
 	auto bufWork = std::make_unique<TCHAR[]>( maxBufWork );
+
+	HGDIOBJ hFontOld = ::SelectObject( hdc, m_hFont );
 
 	for ( size_t i = 0, nBgn = 0; i <= cchText; ) {
 		// iの位置にNUL終端、または"\n"がある場合
@@ -218,12 +218,12 @@ void CTipWnd::ComputeWindowSize(
 		i = pNext - pszText;
 	}
 
+	::SelectObject( hdc, hFontOld );
+
 	prcResult->left = 0;
 	prcResult->top = 0;
 	prcResult->right = nCurMaxWidth + 4;
 	prcResult->bottom = nCurHeight + 2;
-
-	::SelectObject( hdc, hFontOld );
 
 	return;
 

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -107,7 +107,6 @@ void CTipWnd::Show( int nX, int nY, const TCHAR* szText, RECT* pRect )
 	if( NULL != szText ){
 		m_cInfo.SetString( szText );
 	}
-	const TCHAR* pszInfo = m_cInfo.GetStringPtr();
 
 	hdc = ::GetDC( GetHwnd() );
 
@@ -306,11 +305,7 @@ LRESULT CTipWnd::OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l_Param )
 // 2001/06/19 Start by asa-o: ウィンドウのサイズを得る
 void CTipWnd::GetWindowSize(LPRECT pRect)
 {
-	const TCHAR*	pszText;
-
 	HDC		hdc = ::GetDC( GetHwnd() );
-
-	pszText = m_cInfo.GetStringPtr();
 
 	// ウィンドウのサイズを得る
 	ComputeWindowSize( hdc, pRect );

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -119,7 +119,7 @@ void CTipWnd::Show( int nX, int nY, const TCHAR* szText, RECT* pRect )
 	else
 	{
 		/* ウィンドウのサイズを決める */
-		ComputeWindowSize( hdc, m_hFont, pszInfo, &rc );
+		ComputeWindowSize( hdc, &rc );
 	}
 
 	::ReleaseDC( GetHwnd(), hdc );
@@ -140,16 +140,17 @@ void CTipWnd::Show( int nX, int nY, const TCHAR* szText, RECT* pRect )
 /* ウィンドウのサイズを決める */
 void CTipWnd::ComputeWindowSize(
 	HDC				hdc,
-	HFONT			hFont,
-	const TCHAR*	pszText,
 	RECT*			pRect
 )
 {
-	HFONT hFontOld = (HFONT)::SelectObject( hdc, hFont );
+	assert( m_hFont != NULL );
+
+	HFONT hFontOld = (HFONT)::SelectObject( hdc, m_hFont );
 
 	int nCurMaxWidth = 0;
 	int nCurHeight = 0;
-	const size_t nTextLength = _tcslen( pszText );
+	const TCHAR* pszText = m_cInfo.GetStringPtr();
+	const size_t nTextLength = m_cInfo.GetStringLength();
 	for( size_t i = 0, nBgn = 0; i <= nTextLength; ++i ){
 		// 2005-09-02 D.S.Koba GetSizeOfChar
 		size_t nCharChars = CNativeT::GetSizeOfChar( pszText, nTextLength, i );
@@ -312,7 +313,7 @@ void CTipWnd::GetWindowSize(LPRECT pRect)
 	pszText = m_cInfo.GetStringPtr();
 
 	// ウィンドウのサイズを得る
-	ComputeWindowSize( hdc, m_hFont, pszText , pRect );
+	ComputeWindowSize( hdc, pRect );
 
 	::ReleaseDC( GetHwnd(), hdc ); //2007.10.10 kobake ReleaseDCが抜けていたのを修正
 }

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -64,8 +64,8 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	void ComputeWindowSize( HDC, HFONT, const TCHAR*, RECT* );	/* ウィンドウのサイズを決める */
-	void DrawTipText( HDC, HFONT, const TCHAR* );	/* ウィンドウのテキストを表示 */
+	void ComputeWindowSize( HDC hdc, HFONT hFont, const TCHAR* pszText, RECT* pRect );	/* ウィンドウのサイズを決める */
+	void DrawTipText( HDC hdc, HFONT hFont, const TCHAR* pszText );	/* ウィンドウのテキストを表示 */
 
 	/* 仮想関数 */
 	//	Jan. 9, 2006 genta

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -65,7 +65,7 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	void ComputeWindowSize( HDC hdc, RECT* prcResult );	/* ウィンドウのサイズを決める */
-	void DrawTipText( HDC hdc, const RECT* prcPaint );	/* ウィンドウのテキストを表示 */
+	void DrawTipText( HDC hdc, const RECT& rcPaint );	/* ウィンドウのテキストを表示 */
 
 	/* 仮想関数 */
 	//	Jan. 9, 2006 genta

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -64,7 +64,7 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	void ComputeWindowSize( HDC hdc, HFONT hFont, const TCHAR* pszText, RECT* pRect );	/* ウィンドウのサイズを決める */
+	void ComputeWindowSize( HDC hdc, RECT* pRect );	/* ウィンドウのサイズを決める */
 	void DrawTipText( HDC hdc, HFONT hFont, const TCHAR* pszText );	/* ウィンドウのテキストを表示 */
 
 	/* 仮想関数 */

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -64,7 +64,7 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	void ComputeWindowSize( HDC hdc, RECT* pRect );	/* ウィンドウのサイズを決める */
+	void ComputeWindowSize( HDC hdc, RECT* prcResult );	/* ウィンドウのサイズを決める */
 	void DrawTipText( HDC hdc, HFONT hFont, const TCHAR* pszText );	/* ウィンドウのテキストを表示 */
 
 	/* 仮想関数 */

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -65,7 +65,7 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	void ComputeWindowSize( HDC hdc, RECT* prcResult );	/* ウィンドウのサイズを決める */
-	void DrawTipText( HDC hdc, HFONT hFont, const TCHAR* pszText );	/* ウィンドウのテキストを表示 */
+	void DrawTipText( HDC hdc );	/* ウィンドウのテキストを表示 */
 
 	/* 仮想関数 */
 	//	Jan. 9, 2006 genta

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -65,7 +65,7 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	void ComputeWindowSize( HDC hdc, RECT* prcResult );	/* ウィンドウのサイズを決める */
-	void DrawTipText( HDC hdc );	/* ウィンドウのテキストを表示 */
+	void DrawTipText( HDC hdc, const RECT* prcPaint );	/* ウィンドウのテキストを表示 */
 
 	/* 仮想関数 */
 	//	Jan. 9, 2006 genta


### PR DESCRIPTION
## 概要

CTipWndの描画コードが込み入っているのを改善します。
主としてリファクタリング（＝処理内容を変えない）です。
メチャメチャ変えてるように見えるかもしれませんが、これはリファクタリングです。

手を付ける動機となった #639 の問題を解決するために 33bb7c6 にてHighDPI対応を行っています。
HighDPI対応部分については、処理内容を変えています。
リファクタリングとHighDPI対応をバラすと、動機が不明瞭になるので一体として出します。

今回手を入れるのは描画に関連する部分のみですが、CTipWndは最も古くからある機能の一つであるようなのでどこかでコード整理（本来このクラスにあるべき処理がCEditViewにあったりする）を行った方がよいと考えています。

## 補足情報

辞書Tipウインドウは便利な機能ですが、最初の使い出しに少々手間がかかります。
使い出し部分の手順を載せますので検証時の参考にしてください。

キーワードヘルプファイルを持っていない場合、[ヘルプ](https://sakura-editor.github.io/help/HLP000105.html)を参照して自前で作るか、[これ](https://github.com/sakura-editor/sakura/files/2613057/sample.txt)を拡張子khpに変えて使ってください。

1. タイプ別設定のキーワードタブを開く
2. 「キーワードヘルプ機能を使う」にチェック
3. 辞書ファイルにkhpのパスを入れて「挿入」押下
4. タイプ別設定を「OK」で閉じる
5. メインメニュー　設定→キーワードヘルプ自動表示する
6. 辞書に入っているキーワードをダブルクリック

## 修正前後比較

修正前（標準フォント）
![2018-11-25 4](https://user-images.githubusercontent.com/3253151/48979279-ce18f600-f0fb-11e8-9bfb-2f9494dbde42.png)

修正後（標準フォント）
![2018-11-25 1](https://user-images.githubusercontent.com/3253151/48979280-d1ac7d00-f0fb-11e8-9648-9bba65f3c9bf.png)


修正前（游ゴシック72pt）
![2018-11-25 2](https://user-images.githubusercontent.com/3253151/48979282-d5d89a80-f0fb-11e8-9a6a-3bc724437a89.png)

修正後（游ゴシック72pt）
![2018-11-25 3](https://user-images.githubusercontent.com/3253151/48979286-dc671200-f0fb-11e8-9d66-a87ba570fd98.png)

