### PR TITLE
テストが全く実行されない場合に appveyor を失敗させる

### DIFF
--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -1,6 +1,7 @@
 @echo off
 set platform=%1
 set configuration=%2
+set TEST_LAUNCHED=0
 set ERROR_RESULT=0
 
 set FILTER_BAT=%~dp0test_result_filter_tell_AppVeyor.bat
@@ -11,6 +12,8 @@ set BINARY_DIR=%BUILDDIR%\unittests\%platform%\%configuration%
 
 pushd %BINARY_DIR%
 for /r %%i in (tests*.exe) do (
+	set TEST_LAUNCHED=1
+
 	@echo %%i --gtest_list_tests
 	%%i --gtest_list_tests || set ERROR_RESULT=1
 
@@ -19,6 +22,11 @@ for /r %%i in (tests*.exe) do (
 )
 popd
 popd
+
+if "%TEST_LAUNCHED%" == "0" (
+	@echo ERROR: no tests are available.
+	exit /b 1
+)
 
 if "%ERROR_RESULT%" == "1" (
 	@echo ERROR


### PR DESCRIPTION
テストが全く実行されない場合に appveyor を失敗させる

#646 の問題が起きたが気づかなかった。
→ もう一度起きた場合にすぐに検出できるように、テストが走らなかったら(正確には見つけられなかったら)テストを失敗させる。

※ #646 の問題は解消してないので、appveyor が失敗することが期待値です。(2018/11/25 現在)
※ #646 の問題を #633 で対策いれたので、appveyor が成功することが期待値です。(2018/11/26 現在)
