### PR TITLE
[WIP] AppVeyor のビルドキャッシュを利用してビルド時間を削減(※およそ５分)できるようなオプションを用意します。

### DIFF
--- a/appveyor.md
+++ b/appveyor.md
@@ -18,6 +18,7 @@
         - [zipArtifacts.bat の構造](#zipartifactsbat-の構造)
             - [生成する環境変数](#生成する環境変数-1)
             - [処理の流れ](#処理の流れ-2)
+    - [キャッシュを利用する方法](#キャッシュを利用する方法)
 
 <!-- /TOC -->
 
@@ -219,3 +220,33 @@
 * 作業用フォルダに必要なファイルをコピーする
 * [calc-hash.bat](calc-hash.bat) で sha256 のハッシュを計算して、作業用フォルダにコピーする
 * 7z コマンドで作業用フォルダの中身を zip に固める
+
+## キャッシュを利用する方法
+
+ビルドの中間生成物をキャッシュすることで不要な再コンパイルを省きビルド時間を短縮できます。
+
+### 設定方法
+
+環境変数 `cache` に `enabled` という値を設定することで有効になります。
+
+#### Web ページで設定する場合
+
+1. AppVeyor のアカウントページでサクラエディタのプロジェクト(※クローンを含む)を開き Settings を選びます。
+2. Environment を選び Environment Variables の項目で Add variable ボタンをクリックします。
+3. name に `cache` を、value に `enabled` を入力します。
+4. ページ最下部で忘れずに Save ボタンを押します。
+
+#### appveyor.yml で設定する場合
+
+1. appveyor.yml に `cache: disabled` という行があるので `cache: enabled` に書き換えます。
+
+### 確認方法
+
+Console ログに `Restoring build cache`, `Updating build cache` という行があれば有効になっています。
+
+### その他の詳細
+
+導入経緯を参照してください。
+
+* [Issue #637 「ビルドキャッシュを使用するとすごく早いです。」](https://github.com/sakura-editor/sakura/issues/637)
+* [Pull request #650 「AppVeyor のビルドキャッシュを利用してビルド時間を削減(※およそ５分)できるようなオプションを用意します。」](https://github.com/sakura-editor/sakura/pull/650)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,3 +32,26 @@ artifacts:
   - path: 'sakura-*$(platform)-$(configuration)*.zip'
   - path: 'sakura-*$(platform)-$(configuration)*.zip.md5'
   - path: 'sha256.txt'
+
+# About using cache, see https://github.com/sakura-editor/sakura/pull/650
+environment:
+  cache: disabled
+cache:
+  # It seems that deleting cache is not performed
+  # without any valid cache entries.
+  - appveyor.yml
+
+# override some variables, enabling the cache.
+for:
+-
+  matrix:
+    only:
+    - cache: enabled
+  cache:
+  - .\%PLATFORM%\%CONFIGURATION%\
+  - .\sakura_core\Funccode_enum.h
+  - .\sakura_core\Funccode_define.h
+  - .\sakura_core\githash.h
+  - .\tests\build\
+  before_build:
+  - if exist ".\%PLATFORM%\%CONFIGURATION%" powershell -ExecutionPolicy RemoteSigned -File .\tools\RestoreCommitterDateRoughly.ps1

--- a/sakura/postBuild.bat
+++ b/sakura/postBuild.bat
@@ -29,11 +29,11 @@ if "%platform%" == "x64" (
 ) else (
 	set BRON_DIR=%~dp0%BRON_TMP%
 )
+if not exist "%BRON_DIR%\%BREGONIG_DLL%" (
+	call "%UNZIP_CMD%" "%~dp0%BRON_ZIP%" "%~dp0%BRON_TMP%" > NUL || (echo error && exit /b 1)
+)
 if not exist "%OUT_DIR%\%BREGONIG_DLL%" (
 	@echo %BRON_ZIP% -^> %DEST_DIR%\%BREGONIG_DLL%
-	if not exist "%BRON_DIR%\%BREGONIG_DLL%" (
-		call "%UNZIP_CMD%" "%~dp0%BRON_ZIP%" "%~dp0%BRON_TMP%" > NUL || (echo error && exit /b 1)
-	)
 	copy /Y /B "%BRON_DIR%\%BREGONIG_DLL%" "%OUT_DIR%\" > NUL
 )
 
@@ -50,11 +50,11 @@ if "%PLATFORM%" == "Win32" (
 set CTAGS_ZIP=..\installer\externals\universal-ctags\ctags-2018-09-16_e522743d-%CTAGS_PREFIX%.zip
 set CTAGS_TMP=..\installer\temp\ctags
 set CTAGS_DIR=%~dp0%CTAGS_TMP%
+if not exist "%CTAGS_DIR%\%CTAGS_EXE%" (
+	call "%UNZIP_CMD%" "%~dp0%CTAGS_ZIP%" "%CTAGS_DIR%" > NUL || (echo error && exit /b 1)
+)
 if not exist "%OUT_DIR%\%CTAGS_EXE%" (
 	@echo %CTAGS_ZIP% -^> %DEST_DIR%\%CTAGS_EXE%
-	if not exist "%CTAGS_DIR%\%CTAGS_EXE%" (
-		call "%UNZIP_CMD%" "%~dp0%CTAGS_ZIP%" "%CTAGS_DIR%" > NUL || (echo error && exit /b 1)
-	)
 	copy /Y /B "%CTAGS_DIR%\%CTAGS_EXE%" "%OUT_DIR%\" > NUL
 )
 

--- a/tools/RestoreCommitterDateRoughly.ps1
+++ b/tools/RestoreCommitterDateRoughly.ps1
@@ -3,25 +3,41 @@
 	Git ワーキングツリーに含まれるファイルの更新日時に最終コミット日時を設定します。
 
 	.DESCRIPTION
-	Git でチェックアウトしたファイルの更新日時はチェックアウト日時になります。これはファイルのタイムスタンプを比較する場合に不都合な場合があり、代わりに最終コミット日時をタイムスタンプに設定します。
+	Git でチェックアウトしたファイルの更新日時はチェックアウト日時になります。これはファイルのタイムスタンプを比較するのに不都合があるため、代わりに最終コミット日時を設定します。
 
-	Git リポジトリ内で実行します。すべての階層のファイルが対象になります。
+	Git ワーキングツリー内で実行します。すべての階層のファイルが対象になります。
 
 	制限: ログを遡りすべてのファイルの最終コミット日時を取得することは１分以上かかることがあるため、このスクリプトでは１か月を上限としてログを遡ります。そのため最も古いタイムスタンプは実行日時を基準として前月同日の00:00:00になります。
 #>
-$TopDir = git rev-parse --show-toplevel
+$TopDir = (git rev-parse --show-toplevel)
 $Oldest = [DateTime]::Today.AddMonths(-1) # Of course, this is incorrect for the oldest timestamp. That's what "Roughly" means.
 
+$waiting = @{}
+(git ls-files --full-name "$TopDir") | foreach {
+	$waiting[$_] = $NULL
+}
+
 @(
-	"?$($Oldest.ToString("yyyy-MM-dd HH:mm:ss"))"
+	(git log --format=format:?%ci --name-only --since="$($Oldest.ToString("yyyy-MM-dd HH:mm:ss"))")
+	, "?$($Oldest.ToString("yyyy-MM-dd HH:mm:ss"))"
 	, (git ls-files --full-name "$TopDir")
-	, (git log --format=format:?%ci --name-only --since="$($Oldest.ToString("yyyy-MM-dd HH:mm:ss"))" --reverse)
-) | foreach { $_ | foreach { $_ } } | foreach {
+) | foreach { $_ | foreach {
 	if ($_ -eq "") {
 	} elseif ($_[0] -eq "?") {
-		$t = $_.Substring(1) -as [DateTime]
+		$t = $_.Substring(1)
 	} else {
-		try { ([System.IO.FileInfo]"$TopDir\$_").LastWriteTime = $t }
-		catch { Write-Debug($_) }
+		$f = [System.IO.FileInfo] "$TopDir\$_"
+
+		# run once a file.
+		$c = $waiting.Count
+		$waiting.Remove($_)
+		if ($waiting.Count -ne $c -and $f.Exists) {
+			try {
+				$t = [System.DateTime] $t
+				$f.LastWriteTime = $t
+			} catch {
+				Write-Debug $_
+			}
+		}
 	}
-}
+} }

--- a/tools/RestoreCommitterDateRoughly.ps1
+++ b/tools/RestoreCommitterDateRoughly.ps1
@@ -1,0 +1,27 @@
+﻿<#
+	.SYNOPSIS
+	Git ワーキングツリーに含まれるファイルの更新日時に最終コミット日時を設定します。
+
+	.DESCRIPTION
+	Git でチェックアウトしたファイルの更新日時はチェックアウト日時になります。これはファイルのタイムスタンプを比較する場合に不都合な場合があり、代わりに最終コミット日時をタイムスタンプに設定します。
+
+	Git リポジトリ内で実行します。すべての階層のファイルが対象になります。
+
+	制限: ログを遡りすべてのファイルの最終コミット日時を取得することは１分以上かかることがあるため、このスクリプトでは１か月を上限としてログを遡ります。そのため最も古いタイムスタンプは実行日時を基準として前月同日の00:00:00になります。
+#>
+$TopDir = git rev-parse --show-toplevel
+$Oldest = [DateTime]::Today.AddMonths(-1) # Of course, this is incorrect for the oldest timestamp. That's what "Roughly" means.
+
+@(
+	"?$($Oldest.ToString("yyyy-MM-dd HH:mm:ss"))"
+	, (git ls-files --full-name "$TopDir")
+	, (git log --format=format:?%ci --name-only --since="$($Oldest.ToString("yyyy-MM-dd HH:mm:ss"))" --reverse)
+) | foreach { $_ | foreach { $_ } } | foreach {
+	if ($_ -eq "") {
+	} elseif ($_[0] -eq "?") {
+		$t = $_.Substring(1) -as [DateTime]
+	} else {
+		try { ([System.IO.FileInfo]"$TopDir\$_").LastWriteTime = $t }
+		catch { Write-Debug($_) }
+	}
+}

--- a/tools/RestoreCommitterDateRoughly.ps1
+++ b/tools/RestoreCommitterDateRoughly.ps1
@@ -10,7 +10,7 @@
 	制限: ログを遡りすべてのファイルの最終コミット日時を取得することは１分以上かかることがあるため、このスクリプトでは１か月を上限としてログを遡ります。そのため最も古いタイムスタンプは実行日時を基準として前月同日の00:00:00になります。
 #>
 $TopDir = (git rev-parse --show-toplevel)
-$Oldest = [DateTime]::Today.AddMonths(-1) # Of course, this is incorrect for the oldest timestamp. That's what "Roughly" means.
+$Oldest = [DateTime]::Today.AddMonths(-1).ToString("yyyy-MM-dd HH:mm:ss") # Of course, this is incorrect for the oldest timestamp. That's what "Roughly" means.
 
 $waiting = @{}
 (git ls-files --full-name "$TopDir") | foreach {
@@ -18,8 +18,8 @@ $waiting = @{}
 }
 
 @(
-	(git log --format=format:?%ci --name-only --since="$($Oldest.ToString("yyyy-MM-dd HH:mm:ss"))")
-	, "?$($Oldest.ToString("yyyy-MM-dd HH:mm:ss"))"
+	(git log --format=format:?%ci --name-only --since="$Oldest")
+	, "?$Oldest"
 	, (git ls-files --full-name "$TopDir")
 ) | foreach { $_ | foreach {
 	if ($_ -eq "") {

--- a/tools/RestoreCommitterDateRoughly.ps1
+++ b/tools/RestoreCommitterDateRoughly.ps1
@@ -7,6 +7,8 @@
 
 	Git ワーキングツリー内で実行します。すべての階層のファイルが対象になります。
 
+	特記: マージコミットについて。ブランチで実際に修正を行ったコミットの日時に優先して、主たるブランチにマージした日時を最終更新日時として採用しています。(-m --first-parent オプション)
+
 	制限: ログを遡りすべてのファイルの最終コミット日時を取得することは１分以上かかることがあるため、このスクリプトでは１か月を上限としてログを遡ります。そのため最も古いタイムスタンプは実行日時を基準として前月同日の00:00:00になります。
 #>
 $TopDir = (git rev-parse --show-toplevel)
@@ -18,7 +20,7 @@ $waiting = @{}
 }
 
 @(
-	(git log --format=format:?%ci --name-only --since="$Oldest")
+	(git log -m --first-parent --format=format:?%ci --name-only --since="$Oldest")
 	, "?$Oldest"
 	, (git ls-files --full-name "$TopDir")
 ) | foreach { $_ | foreach {


### PR DESCRIPTION
Closes #637 「ビルドキャッシュを使用するとすごく早いです。」

### コミットメッセージ
Save build time by caching intermediates.
* Enabled only when env:cache has a value:enabled.
  This can be set by Web UI, which overrides env. vars set by appveyor.yml

### 効果

省略されるのは変更されなかった .cpp ファイルのコンパイルと CMake によるプロジェクト生成(googletest)です。リンク時間は減らないのでリンク時コード生成が有効なリリースビルドでの効果は相対的に下がります。

tests/create-project.bat がビルドディレクトリの明示的削除を行っているので、CMake によるプロジェクト生成(unittests)を強制してキャッシュの効果を打ち消しています。

https://github.com/sakura-editor/sakura/blob/5524485fc807f46f55287fb5e7b8a257696e33bb/tests/create-project.bat#L28-L32

### 比較

キャッシュ無効|キャッシュ有効|diff
-|-|-
11:10| 6:51|-4:19
 8:49| 7:45|-1:04
 4:00| 3:26|-0:34
 7:13| 6:24|-0:49
 8:23| 7:19|-1:04
 4:14| 4:49|-0:30
-----| ----|-----
45:48|37:56|-7:52

### 条件

環境変数 cache が enabled という値を持っているときに限りキャッシュが有効になります。これは appveyor.yml で設定することができますし、アカウントの Web UI で設定した値で appveyor.yml の値を上書きすることもできます。

キャッシュ容量が有限であることと、クリーンな状態でビルドしたい要求があるだろうと考えて、リポジトリごとに提供するオプションです。

つまり、この PR をマージした時点でキャッシュが有効になるわけではないので、過度に慎重な判断は不要です。

### 副作用

キャッシュを削除する方便として appveyor.yml をキャッシュエントリに指定しています。これは PR をマージした時点で有効になります。

キャッシュされた appveyor.yml がビルドの邪魔になるケースでは、Web UI から appveyor.yml に代わるファイルの場所を指定する方法と、同じく Web UI により appveyor.yml ファイルを無視するチェックを入れる方法があります。

単純に空のキャッシュを指定しただけではキャッシュの削除が行われないために、あたりさわりのない有効なキャッシュエントリを指定することで、その他のキャッシュを削除する方便としています。そうしなければ環境変数でキャッシュを無効化した後もキャッシュが残存してしまいます。

キャッシュ容量の計量がアカウント毎ではなくプロジェクト毎リポジトリ毎であればキャッシュの残存を気にする必要はありませんが、そうではないようです。

[Build cache \| AppVeyor](https://www.appveyor.com/docs/build-cache/#cache-size-beta)
>Total cache size per account consist of all caches from all projects. If projects contain more than one job in build matrix or in parallel testing, each job has its own separate cache, which cannot be shared with other jobs or projects.
>
> Free | Basic | Pro | Premium
> -- | -- | -- | --
> 1 GB | 1 GB | 5 GB | 20 GB
>
>It’s a hard quota which means the build will fail while trying to upload cache item exceeding the quota.

* アカウント当たりのキャッシュサイズはプロジェクト毎の総計であり、プロジェクト当たりのサイズはジョブ毎の総計である。
* Free プランでは 1 GB.
* "hard quota" なので容量超過は即座にビルド失敗につながる。

らしいです。
