### PR TITLE
doxygen の参考にならない警告を無効にします。WARN_IF_UNDOCUMENTED = NO

### DIFF
--- a/doxygen.conf
+++ b/doxygen.conf
@@ -741,7 +741,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters


### PR DESCRIPTION
Win32/Release ビルドでログ行数が 14002 行から 2315 行になりました。

無効にしたのは「ドキュメントがない」という警告だけです。

* 推奨されるすべての対象にドキュメントを付けるという目標は存在しない。
* ログの汚染がひどい。(後で調べて役に立つログというわけでもない)

というのが理由です。ファイルにリダイレクトしたからといって、やはりログの活用には同様のフィルタリングが必要になるでしょう。
