### PR TITLE
DISALLOW_COPY_AND_ASSIGN を更新

### DIFF
--- a/sakura_core/CFileExt.h
+++ b/sakura_core/CFileExt.h
@@ -67,7 +67,6 @@ private:
 	FileExtInfoTag	*m_puFileExtInfo;
 	std::vector<TCHAR>	m_vstrFilter;
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CFileExt);
 };
 

--- a/sakura_core/CSearchAgent.h
+++ b/sakura_core/CSearchAgent.h
@@ -79,7 +79,6 @@ private:
 	int* m_pnUseCharSkipArr;
 #endif
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CSearchStringPattern);
 };
 

--- a/sakura_core/CSortedTagJumpList.h
+++ b/sakura_core/CSortedTagJumpList.h
@@ -80,7 +80,6 @@ private:
 
 	void Free( TagJumpInfo* item );
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CSortedTagJumpList);
 };
 

--- a/sakura_core/_os/CDropTarget.h
+++ b/sakura_core/_os/CDropTarget.h
@@ -147,7 +147,6 @@ public:
 	STDMETHOD( DUnadvise )( DWORD );
 	STDMETHOD( EnumDAdvise )( LPENUMSTATDATA* );
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CDataObject);
 };
 

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -355,7 +355,6 @@ namespace WCODE
 		LocalCache m_localcache[3];
 		SCharWidthCache* m_parCache[3];
 		ECharWidthCacheMode m_eLastEditCacheMode;
-	private:
 		DISALLOW_COPY_AND_ASSIGN(LocalCacheSelector);
 	};
 

--- a/sakura_core/dlg/CDlgOpenFile.h
+++ b/sakura_core/dlg/CDlgOpenFile.h
@@ -92,7 +92,6 @@ public:
 	// 設定フォルダ相対ファイル選択(共有データ,ini位置依存)
 	static BOOL SelectFile(HWND parent, HWND hwndCtl, const TCHAR* filter, bool resolvePath, EFilter eAddFilter = EFITER_TEXT);
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CDlgOpenFile);
 };
 

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -160,7 +160,6 @@ private:
 	POINT	m_ptDefaultSize;
 	RECT	m_rcItems[11];
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CDlgTagJumpList);
 };
 

--- a/sakura_core/doc/layout/CLayout.h
+++ b/sakura_core/doc/layout/CLayout.h
@@ -124,7 +124,6 @@ private:
 	CLayoutInt			m_nLayoutWidth;		//!< このレイアウト行の改行を含むレイアウト長（「折り返さない」選択時のみ）	// 2009.08.28 nasukoji
 	CLayoutExInfo		m_cExInfo;			//!< 色分け詳細情報
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CLayout);
 };
 

--- a/sakura_core/doc/layout/CLayoutExInfo.h
+++ b/sakura_core/doc/layout/CLayoutExInfo.h
@@ -59,7 +59,6 @@ public:
 private:
 	CLayoutColorInfo* m_colorInfo;
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CLayoutExInfo);
 };
 

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -433,7 +433,6 @@ protected:
 	CLayoutInt				m_nTextWidth;				// テキスト最大幅の記憶
 	CLayoutInt				m_nTextWidthMaxLine;		// 最大幅のレイアウト行
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CLayoutMgr);
 };
 

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -110,7 +110,6 @@ public:
 	};
 	MarkType m_sMark;
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CDocLine);
 };
 

--- a/sakura_core/doc/logic/CDocLineMgr.h
+++ b/sakura_core/doc/logic/CDocLineMgr.h
@@ -97,7 +97,6 @@ public:
 	mutable CLogicInt	m_nPrevReferLine;
 	mutable CDocLine*	m_pCodePrevRefer;
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CDocLineMgr);
 };
 

--- a/sakura_core/io/CFileLoad.h
+++ b/sakura_core/io/CFileLoad.h
@@ -143,7 +143,6 @@ protected:
 	int		m_nReadOffset2;
 	EConvertResult m_nTempResult;
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CFileLoad);
 }; // class CFileLoad
 

--- a/sakura_core/macro/CSMacroMgr.h
+++ b/sakura_core/macro/CSMacroMgr.h
@@ -181,7 +181,6 @@ public:
 	static MacroFuncInfo	m_MacroFuncInfoCommandArr[];	// コマンド情報(戻り値なし)
 	static MacroFuncInfo	m_MacroFuncInfoArr[];		// 関数情報(戻り値あり)
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CSMacroMgr);
 };
 

--- a/sakura_core/outline/CFuncInfoArr.h
+++ b/sakura_core/outline/CFuncInfoArr.h
@@ -61,7 +61,6 @@ private:
 	std::map<int, std::wstring>	m_AppendTextArr;	// 追加文字列のリスト
 	int			m_nAppendTextLenMax;
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CFuncInfoArr);
 };
 

--- a/sakura_core/print/CPrintPreview.h
+++ b/sakura_core/print/CPrintPreview.h
@@ -266,7 +266,6 @@ protected:
 	bool			m_bLockSetting;				// 設定のロック
 	bool			m_bDemandUpdateSetting;		// 設定の更新要求
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CPrintPreview);
 };
 

--- a/sakura_core/uiparts/CVisualProgress.h
+++ b/sakura_core/uiparts/CVisualProgress.h
@@ -55,7 +55,6 @@ private:
 	CWaitCursor* m_pcWaitCursor;
 	int	nOldValue;
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CVisualProgress);
 };
 

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -33,10 +33,9 @@
 
 // http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Copy_Constructors
 // A macro to disallow the copy constructor and operator= functions
-// This should be used in the private: declarations for a class
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName&);               \
-  void operator=(const TypeName&)
+  TypeName(const TypeName&) = delete;      \
+  TypeName& operator=(const TypeName&) = delete;
 
 /*!
 	Singletonパターン
@@ -55,7 +54,6 @@ public:
 
 protected:
 	TSingleton(){}
-private:
 	DISALLOW_COPY_AND_ASSIGN(TSingleton);
 };
 

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -35,7 +35,9 @@
 // A macro to disallow the copy constructor and operator= functions
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
   TypeName(const TypeName&) = delete;      \
-  TypeName& operator=(const TypeName&) = delete;
+  TypeName& operator=(const TypeName&) = delete; \
+  TypeName(TypeName&&) = delete;           \
+  TypeName& operator=(TypeName&&) = delete;
 
 /*!
 	Singletonパターン

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -744,7 +744,6 @@ public:
 	CLayoutInt		m_nPageViewTop;
 	CLayoutInt		m_nPageViewBottom;
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CEditView);
 };
 

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -204,7 +204,6 @@ private:
 	HWND		m_hwndSizeBox;
 	bool		m_bSizeBox;
 
-private:
 	DISALLOW_COPY_AND_ASSIGN(CTabWnd);
 };
 


### PR DESCRIPTION
C++11 から追加された Deleted function declaration を使うように変更
DISALLOW_COPY_AND_ASSIGN マクロの為の private アクセス修飾子の存在が不要になるので削除
