### PR TITLE
ヘッダのプロトタイプ宣言で明示的に変数名を指定する

### DIFF
--- a/sakura_core/CDicMgr.h
+++ b/sakura_core/CDicMgr.h
@@ -34,8 +34,12 @@ public:
 	||  Attributes & Operations
 	*/
 //	BOOL Open( char* );
-	static BOOL Search( const wchar_t*, const int, CNativeW**, CNativeW**, const TCHAR*, int * );	// 2006.04.10 fon (const int,CMemory**,int*)引数を追加
-	static int HokanSearch( const wchar_t* , bool, vector_ex<std::wstring>&, int, const TCHAR* );
+	static BOOL Search( const wchar_t* pszKey, const int nCmpLen,
+						CNativeW** ppcmemKey, CNativeW** ppcmemMean,
+						const TCHAR* pszKeyWordHelpFile, int * pLine );	// 2006.04.10 fon (const int,CMemory**,int*)引数を追加
+	static int HokanSearch( const wchar_t* pszKey, bool bHokanLoHiCase,
+							vector_ex<std::wstring>& vKouho, int nMaxKouho,
+							const TCHAR* pszKeyWordFile );
 //	BOOL Close( char* );
 
 

--- a/sakura_core/CKeyWordSetMgr.h
+++ b/sakura_core/CKeyWordSetMgr.h
@@ -89,7 +89,7 @@ public:
 	void SortKeyWord( int nIdx ); /* ｎ番目のセットのキーワードをソートする */  //MIK
 
 	// From Here 2004.07.29 Moca 追加 可変長記憶
-	int SetKeyWordArr( int, int, const wchar_t* );			//!< iniからキーワードを設定する
+	int SetKeyWordArr( int nIdx, int nSize, const wchar_t* pszKeyWordArr );			//!< iniからキーワードを設定する
 	int SetKeyWordArr(						//!< キーワードの配列から設定する
 		int				nIdx,				//!< [in] キーワードセット番号
 		int				nSize,				//!< [in] ppszKeyWordArrの要素数

--- a/sakura_core/CSearchAgent.h
+++ b/sakura_core/CSearchAgent.h
@@ -120,13 +120,16 @@ public:
 public:
 	CSearchAgent(CDocLineMgr* pcDocLineMgr) : m_pcDocLineMgr(pcDocLineMgr) { }
 
-	bool WhereCurrentWord( CLogicInt , CLogicInt , CLogicInt* , CLogicInt*, CNativeW*, CNativeW* );	/* 現在位置の単語の範囲を調べる */
+	bool WhereCurrentWord( CLogicInt nLineNum, CLogicInt nIdx,
+						   CLogicInt* pnIdxFrom, CLogicInt* pnIdxTo,
+						   CNativeW* pcmcmWord, CNativeW* pcmcmWordLeft );	/* 現在位置の単語の範囲を調べる */
 
-	bool PrevOrNextWord( CLogicInt , CLogicInt , CLogicInt* , BOOL bLEFT, BOOL bStopsBothEnds );	/* 現在位置の左右の単語の先頭位置を調べる */
+	bool PrevOrNextWord( CLogicInt nLineNum, CLogicInt nIdx, CLogicInt* pnColumnNew,
+						 BOOL bLEFT, BOOL bStopsBothEnds );	/* 現在位置の左右の単語の先頭位置を調べる */
 	//	Jun. 26, 2001 genta	正規表現ライブラリの差し替え
 	int SearchWord( CLogicPoint ptSerachBegin, ESearchDirection eDirection, CLogicRange* pMatchRange, const CSearchStringPattern& pattern ); /* 単語検索 */
 
-	void ReplaceData( DocLineReplaceArg* );
+	void ReplaceData( DocLineReplaceArg* pArg );
 private:
 	CDocLineMgr* m_pcDocLineMgr;
 };

--- a/sakura_core/dlg/CDlgCompare.h
+++ b/sakura_core/dlg/CDlgCompare.h
@@ -31,7 +31,8 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM, const TCHAR*, TCHAR*, HWND* );	/* モーダルダイアログの表示 */
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam,
+				 const TCHAR* pszPath, TCHAR* pszCompareLabel, HWND* phwndCompareWnd );	/* モーダルダイアログの表示 */
 
 	const TCHAR*	m_pszPath;
 	TCHAR*			m_pszCompareLabel;

--- a/sakura_core/dlg/CDlgDiff.h
+++ b/sakura_core/dlg/CDlgDiff.h
@@ -50,7 +50,7 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM, const TCHAR* );	/* モーダルダイアログの表示 */
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam, const TCHAR* pszPath );	/* モーダルダイアログの表示 */
 
 protected:
 	/*

--- a/sakura_core/dlg/CDlgFileUpdateQuery.h
+++ b/sakura_core/dlg/CDlgFileUpdateQuery.h
@@ -49,8 +49,8 @@ public:
 	, m_bModified( IsModified )
 	{
 	}
-	virtual BOOL OnInitDialog( HWND, WPARAM wParam, LPARAM lParam );
-	virtual BOOL OnBnClicked( int );
+	virtual BOOL OnInitDialog( HWND hWnd, WPARAM wParam, LPARAM lParam );
+	virtual BOOL OnBnClicked( int id );
 
 private:
 	const TCHAR* m_pFilename;

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -32,7 +32,7 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, const TCHAR*, LPARAM );	/* モーダルダイアログの表示 */
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, const TCHAR* pszCurrentFilePath, LPARAM lParam );	/* モーダルダイアログの表示 */
 
 	bool		m_bPaste;
 	bool		m_bBackup;

--- a/sakura_core/dlg/CDlgInput1.h
+++ b/sakura_core/dlg/CDlgInput1.h
@@ -30,8 +30,10 @@ public:
 	*/
 	CDlgInput1();
 	~CDlgInput1();
-	BOOL DoModal( HINSTANCE , HWND , const TCHAR* , const TCHAR* , int , TCHAR*  );	/* モードレスダイアログの表示 */
-	BOOL DoModal( HINSTANCE , HWND , const TCHAR* , const TCHAR* , int , NOT_TCHAR*  );	/* モードレスダイアログの表示 */
+	BOOL DoModal( HINSTANCE hInstApp, HWND hwndParent, const TCHAR* pszTitle,
+				  const TCHAR* pszMessage, int nMaxTextLen, TCHAR* pszText );	/* モードレスダイアログの表示 */
+	BOOL DoModal( HINSTANCE hInstApp, HWND hwndParent, const TCHAR* pszTitle,
+				  const TCHAR* pszMessage, int nMaxTextLen, NOT_TCHAR* pszText );	/* モードレスダイアログの表示 */
 	/*
 	||  Attributes & Operations
 	*/

--- a/sakura_core/dlg/CDlgOpenFile.h
+++ b/sakura_core/dlg/CDlgOpenFile.h
@@ -59,8 +59,8 @@ public:
 	);
 
 	//操作
-	bool DoModal_GetOpenFileName( TCHAR*, EFilter eAddFileter = EFITER_TEXT );	/* 開くダイアログ モーダルダイアログの表示 */	//2002/08/21 moca	引数追加
-	bool DoModal_GetSaveFileName( TCHAR* );	/* 保存ダイアログ モーダルダイアログの表示 */	//2002/08/21 30,2002 moca	引数追加
+	bool DoModal_GetOpenFileName( TCHAR* pszPath, EFilter eAddFileter = EFITER_TEXT );	/* 開くダイアログ モーダルダイアログの表示 */	//2002/08/21 moca	引数追加
+	bool DoModal_GetSaveFileName( TCHAR* pszPath );	/* 保存ダイアログ モーダルダイアログの表示 */	//2002/08/21 30,2002 moca	引数追加
 	bool DoModalOpenDlg( SLoadInfo* pLoadInfo, std::vector<std::tstring>*, bool bOptions = true );	/* 開くダイアグ モーダルダイアログの表示 */
 	bool DoModalSaveDlg( SSaveInfo*	pSaveInfo, bool bSimpleMode );	/* 保存ダイアログ モーダルダイアログの表示 */
 
@@ -75,7 +75,7 @@ protected:
 	void	DlgOpenFail(void);
 
 	// 2005.11.02 ryoji OS バージョン対応の OPENFILENAME 初期化用関数
-	void InitOfn( OPENFILENAME* );
+	void InitOfn( OPENFILENAME* ofn );
 
 	// 2005.11.02 ryoji 初期レイアウト設定処理
 	static void InitLayout( HWND hwndOpenDlg, HWND hwndDlg, HWND hwndBaseCtrl );

--- a/sakura_core/dlg/CDlgPluginOption.h
+++ b/sakura_core/dlg/CDlgPluginOption.h
@@ -64,13 +64,13 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, CPropPlugin*, int );	/* モーダルダイアログの表示 */
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, CPropPlugin* cPropPlugin, int ID );	/* モーダルダイアログの表示 */
 
 protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL	OnInitDialog( HWND, WPARAM wParam, LPARAM lParam );
+	BOOL	OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam );
 	BOOL	OnBnClicked(int wID);
 	BOOL	OnNotify( WPARAM wParam, LPARAM lParam );
 	BOOL	OnCbnSelChange( HWND hwndCtl, int wID );

--- a/sakura_core/dlg/CDlgPrintSetting.h
+++ b/sakura_core/dlg/CDlgPrintSetting.h
@@ -48,7 +48,8 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, int*, PRINTSETTING*, int );	/* モーダルダイアログの表示 */
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, int* pnCurrentPrintSetting,
+				 PRINTSETTING* pPrintSettingArr, int nLineNumberColumns );	/* モーダルダイアログの表示 */
 
 private:
 	int				m_nCurrentPrintSetting;

--- a/sakura_core/dlg/CDlgSetCharSet.h
+++ b/sakura_core/dlg/CDlgSetCharSet.h
@@ -27,7 +27,7 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, ECodeType*, bool* );	/* モーダルダイアログの表示 */
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, ECodeType* pnCharSet, bool* pbBom );	/* モーダルダイアログの表示 */
 
 
 	ECodeType*	m_pnCharSet;			// 文字コードセット

--- a/sakura_core/dlg/CDlgTagsMake.h
+++ b/sakura_core/dlg/CDlgTagsMake.h
@@ -48,7 +48,7 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	int DoModal( HINSTANCE, HWND, LPARAM, const TCHAR* );	/* モーダルダイアログの表示 */
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam, const TCHAR* pszPath );	/* モーダルダイアログの表示 */
 
 	TCHAR	m_szPath[_MAX_PATH+1];	/* フォルダ */
 	TCHAR	m_szTagsCmdLine[_MAX_PATH];	/* コマンドラインオプション(個別) */

--- a/sakura_core/dlg/CDlgWinSize.h
+++ b/sakura_core/dlg/CDlgWinSize.h
@@ -44,7 +44,8 @@ class CDlgWinSize : public CDialog
 public:
 	CDlgWinSize();
 	~CDlgWinSize();
-	int DoModal( HINSTANCE, HWND, EWinSizeMode&, EWinSizeMode&, int&, RECT& );	//!< モーダルダイアログの表示
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, EWinSizeMode& eSaveWinSize,
+				 EWinSizeMode& eSaveWinPos, int& nWinSizeType, RECT& rc );	//!< モーダルダイアログの表示
 
 protected:
 

--- a/sakura_core/doc/CDocOutline.h
+++ b/sakura_core/doc/CDocOutline.h
@@ -32,23 +32,27 @@ struct SOneRule;
 class CDocOutline{
 public:
 	CDocOutline(CEditDoc* pcDoc) : m_pcDocRef(pcDoc) { }
-	void	MakeFuncList_C( CFuncInfoArr*, EOutlineType& nOutlineType, const TCHAR* pszFileName,
-		bool bVisibleMemberFunc = true );					//!< C/C++関数リスト作成
-	void	MakeFuncList_PLSQL( CFuncInfoArr* );											//!< PL/SQL関数リスト作成
-	void	MakeTopicList_txt( CFuncInfoArr* );												//!< テキスト・トピックリスト作成
-	void	MakeFuncList_Java( CFuncInfoArr* );												//!< Java関数リスト作成
-	void	MakeTopicList_cobol( CFuncInfoArr* );											//!< COBOL アウトライン解析
-	void	MakeTopicList_asm( CFuncInfoArr* );												//!< アセンブラ アウトライン解析
-	void	MakeFuncList_Perl( CFuncInfoArr* );												//!< Perl関数リスト作成	//	Sep. 8, 2000 genta
-	void	MakeFuncList_VisualBasic( CFuncInfoArr* );										//!< Visual Basic関数リスト作成 //June 23, 2001 N.Nakatani
-	void	MakeFuncList_python( CFuncInfoArr* pcFuncInfoArr );								//!< Python アウトライン解析 // 2007.02.08 genta
-	void	MakeFuncList_Erlang( CFuncInfoArr* pcFuncInfoArr );								//!< Erlang アウトライン解析 // 2009.08.10 genta
-	void	MakeTopicList_wztxt(CFuncInfoArr*);												//!< 階層付きテキスト アウトライン解析 // 2003.05.20 zenryaku
-	void	MakeTopicList_html(CFuncInfoArr*, bool bXml);									//!< HTML アウトライン解析 // 2003.05.20 zenryaku
-	void	MakeTopicList_tex(CFuncInfoArr*);												//!< TeX アウトライン解析 // 2003.07.20 naoh
-	void	MakeFuncList_RuleFile( CFuncInfoArr*, std::tstring& );											//!< ルールファイルを使ってリスト作成 2002.04.01 YAZAKI
-	int		ReadRuleFile( const TCHAR*, SOneRule*, int, bool&, std::wstring& );	//!< ルールファイル読込 2002.04.01 YAZAKI
-	void	MakeFuncList_BookMark( CFuncInfoArr* );											//!< ブックマークリスト作成 //2001.12.03 hor
+	void	MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr,
+							EOutlineType& nOutlineType,
+						    const TCHAR* pszFileName,
+							bool bVisibleMemberFunc = true );					//!< C/C++関数リスト作成
+	void	MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr );					//!< PL/SQL関数リスト作成
+	void	MakeTopicList_txt( CFuncInfoArr* pcFuncInfoArr );					//!< テキスト・トピックリスト作成
+	void	MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr );					//!< Java関数リスト作成
+	void	MakeTopicList_cobol( CFuncInfoArr* pcFuncInfoArr );					//!< COBOL アウトライン解析
+	void	MakeTopicList_asm( CFuncInfoArr* pcFuncInfoArr );					//!< アセンブラ アウトライン解析
+	void	MakeFuncList_Perl( CFuncInfoArr* pcFuncInfoArr );					//!< Perl関数リスト作成	//	Sep. 8, 2000 genta
+	void	MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr );			//!< Visual Basic関数リスト作成 //June 23, 2001 N.Nakatani
+	void	MakeFuncList_python( CFuncInfoArr* pcFuncInfoArr );					//!< Python アウトライン解析 // 2007.02.08 genta
+	void	MakeFuncList_Erlang( CFuncInfoArr* pcFuncInfoArr );					//!< Erlang アウトライン解析 // 2009.08.10 genta
+	void	MakeTopicList_wztxt( CFuncInfoArr* pcFuncInfoArr );					//!< 階層付きテキスト アウトライン解析 // 2003.05.20 zenryaku
+	void	MakeTopicList_html(CFuncInfoArr* pcFuncInfoArr, bool bXml);			//!< HTML アウトライン解析 // 2003.05.20 zenryaku
+	void	MakeTopicList_tex(CFuncInfoArr* pcFuncInfoArr);						//!< TeX アウトライン解析 // 2003.07.20 naoh
+	void	MakeFuncList_RuleFile( CFuncInfoArr* pcFuncInfoArr,
+								   std::tstring& sTitleOverride );				//!< ルールファイルを使ってリスト作成 2002.04.01 YAZAKI
+	int		ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule,
+						  int nMaxCount, bool& bRegex, std::wstring& title );	//!< ルールファイル読込 2002.04.01 YAZAKI
+	void	MakeFuncList_BookMark( CFuncInfoArr* );								//!< ブックマークリスト作成 //2001.12.03 hor
 private:
 	CEditDoc* m_pcDocRef;
 };

--- a/sakura_core/doc/CDocReader.h
+++ b/sakura_core/doc/CDocReader.h
@@ -33,10 +33,10 @@ public:
 	CDocReader(const CDocLineMgr& pcDocLineMgr) : m_pcDocLineMgr(&pcDocLineMgr) { }
 
 	wchar_t* GetAllData(int* pnDataLen);	/* 全行データを返す */
-	const wchar_t* GetLineStr( CLogicInt , CLogicInt* );
-	const wchar_t* GetLineStrWithoutEOL( CLogicInt , int* ); // 2003.06.22 Moca
-	const wchar_t* GetFirstLinrStr( int* );	/* 順アクセスモード：先頭行を得る */
-	const wchar_t* GetNextLinrStr( int* );	/* 順アクセスモード：次の行を得る */
+	const wchar_t* GetLineStr( CLogicInt nLine, CLogicInt* pnLineLen );
+	const wchar_t* GetLineStrWithoutEOL( CLogicInt nLine, int* pnLineLen ); // 2003.06.22 Moca
+	const wchar_t* GetFirstLinrStr( int* pnLineLen );	/* 順アクセスモード：先頭行を得る */
+	const wchar_t* GetNextLinrStr( int* pnLineLen );	/* 順アクセスモード：次の行を得る */
 
 private:
 	const CDocLineMgr* m_pcDocLineMgr;

--- a/sakura_core/docplus/CBookmarkManager.h
+++ b/sakura_core/docplus/CBookmarkManager.h
@@ -68,7 +68,7 @@ public:
 
 	void ResetAllBookMark();															//!< ブックマークの全解除
 	bool SearchBookMark( CLogicInt nLineNum, ESearchDirection , CLogicInt* pnLineNum );	//!< ブックマーク検索
-	void SetBookMarks( wchar_t* );														//!< 物理行番号のリストからまとめて行マーク
+	void SetBookMarks( wchar_t* pMarkLines );											//!< 物理行番号のリストからまとめて行マーク
 	LPCWSTR GetBookMarks();																//!< 行マークされてる物理行番号のリストを作る
 	void MarkSearchWord( const CSearchStringPattern& );			//!< 検索条件に該当する行にブックマークをセットする
 

--- a/sakura_core/docplus/CDiffManager.h
+++ b/sakura_core/docplus/CDiffManager.h
@@ -91,7 +91,7 @@ class CDiffLineMgr{
 public:
 	CDiffLineMgr(CDocLineMgr* pcDocLineMgr) : m_pcDocLineMgr(pcDocLineMgr) { }
 	void ResetAllDiffMark();															//!< 差分表示の全解除
-	bool SearchDiffMark( CLogicInt , ESearchDirection , CLogicInt* );					//!< 差分検索
+	bool SearchDiffMark( CLogicInt nLineNum, ESearchDirection bPrevOrNext, CLogicInt* pnLineNum );	//!< 差分検索
 	void SetDiffMarkRange( EDiffMark nMode, CLogicInt nStartLine, CLogicInt nEndLine );	//!< 差分範囲の登録
 private:
 	CDocLineMgr* m_pcDocLineMgr;

--- a/sakura_core/docplus/CFuncListManager.h
+++ b/sakura_core/docplus/CFuncListManager.h
@@ -50,7 +50,8 @@ public:
 	bool IsLineFuncList(const CDocLine* pcDocLine, bool bFlag) const;
 	bool GetLineFuncList(const CDocLine* pcDocLine) const;
 	void SetLineFuncList(CDocLine* pcDocLine, bool bFlag);
-	bool SearchFuncListMark(const CDocLineMgr*, CLogicInt, ESearchDirection, CLogicInt* ) const;					//!< 関数リストマーク検索
+	bool SearchFuncListMark(const CDocLineMgr* pcDocLineMgr, CLogicInt nLineNum,
+							ESearchDirection bPrevOrNext, CLogicInt* pnLineNum) const;	//!< 関数リストマーク検索
 
 	//一括操作
 	void ResetAllFucListMark(CDocLineMgr* pcDocLineMgr, bool bFlag);	// 関数リストマークをすべてリセット

--- a/sakura_core/env/CShareData.h
+++ b/sakura_core/env/CShareData.h
@@ -101,12 +101,12 @@ protected:
 	*/
 
 	//	Jan. 30, 2005 genta 初期化関数の分割
-	void InitKeyword(DLLSHAREDATA*);
-	bool InitKeyAssign(DLLSHAREDATA*); // 2007.11.04 genta 起動中止のため値を返す
-	void RefreshKeyAssignString(DLLSHAREDATA*);
-	void InitToolButtons(DLLSHAREDATA*);
-	void InitTypeConfigs(DLLSHAREDATA*, std::vector<STypeConfig*>&);
-	void InitPopupMenu(DLLSHAREDATA*);
+	void InitKeyword(DLLSHAREDATA* pShareData);
+	bool InitKeyAssign(DLLSHAREDATA* pShareData); // 2007.11.04 genta 起動中止のため値を返す
+	void RefreshKeyAssignString(DLLSHAREDATA* pShareData);
+	void InitToolButtons(DLLSHAREDATA* pShareData);
+	void InitTypeConfigs(DLLSHAREDATA* pShareData, std::vector<STypeConfig*>& types);
+	void InitPopupMenu(DLLSHAREDATA* pShareData);
 
 public:
 	static void InitFileTree(SFileTree*);

--- a/sakura_core/env/CShareData_IO.h
+++ b/sakura_core/env/CShareData_IO.h
@@ -43,43 +43,44 @@ public:
 	static void SaveShareData();	/* 共有データの保存 */
 
 protected:
-	static bool ShareData_IO_2( bool );	/* 共有データの保存 */
+	static bool ShareData_IO_2( bool bRead );	/* 共有データの保存 */
 
 	// Feb. 12, 2006 D.S.Koba
-	static void ShareData_IO_Mru( CDataProfile& );
-	static void ShareData_IO_Keys( CDataProfile& );
-	static void ShareData_IO_Grep( CDataProfile& );
-	static void ShareData_IO_Folders( CDataProfile& );
-	static void ShareData_IO_Cmd( CDataProfile& );
-	static void ShareData_IO_Nickname( CDataProfile& );
-	static void ShareData_IO_Common( CDataProfile& );
-	static void ShareData_IO_Toolbar( CDataProfile&, CMenuDrawer* );
-	static void ShareData_IO_CustMenu( CDataProfile& );
-	static void ShareData_IO_Font( CDataProfile& );
-	static void ShareData_IO_KeyBind( CDataProfile& );
-	static void ShareData_IO_Print( CDataProfile& );
-	static void ShareData_IO_Types( CDataProfile& );
-	static void ShareData_IO_KeyWords( CDataProfile& );
-	static void ShareData_IO_Macro( CDataProfile& );
-	static void ShareData_IO_Statusbar( CDataProfile& );	// 2008/6/21 Uchi
-	static void ShareData_IO_Plugin( CDataProfile&, CMenuDrawer* );		// 2009/11/30 syat
-	static void ShareData_IO_MainMenu( CDataProfile& );		// 2010/5/15 Uchi
-	static void ShareData_IO_Other( CDataProfile& );
+	static void ShareData_IO_Mru( CDataProfile& cProfile );
+	static void ShareData_IO_Keys( CDataProfile& cProfile );
+	static void ShareData_IO_Grep( CDataProfile& cProfile );
+	static void ShareData_IO_Folders( CDataProfile& cProfile );
+	static void ShareData_IO_Cmd( CDataProfile& cProfile );
+	static void ShareData_IO_Nickname( CDataProfile& cProfile );
+	static void ShareData_IO_Common( CDataProfile& cProfile );
+	static void ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* pcMenuDrawer );
+	static void ShareData_IO_CustMenu( CDataProfile& cProfile );
+	static void ShareData_IO_Font( CDataProfile& cProfile );
+	static void ShareData_IO_KeyBind( CDataProfile& cProfile );
+	static void ShareData_IO_Print( CDataProfile& cProfile );
+	static void ShareData_IO_Types( CDataProfile& cProfile );
+	static void ShareData_IO_KeyWords( CDataProfile& cProfile );
+	static void ShareData_IO_Macro( CDataProfile& cProfile );
+	static void ShareData_IO_Statusbar( CDataProfile& cProfile );	// 2008/6/21 Uchi
+	static void ShareData_IO_Plugin( CDataProfile& cProfile, CMenuDrawer* pcMenuDrawer );	// 2009/11/30 syat
+	static void ShareData_IO_MainMenu( CDataProfile& cProfile );		// 2010/5/15 Uchi
+	static void ShareData_IO_Other( CDataProfile& cProfile );
 
 public:
-	static void ShareData_IO_FileTree( CDataProfile&, SFileTree&, const WCHAR* );
-	static void ShareData_IO_FileTreeItem( CDataProfile&, SFileTreeItem&, const WCHAR*, int i );
-	static void ShareData_IO_Type_One( CDataProfile&, STypeConfig& , const WCHAR* );	// 2010/04/12 Uchi 分離
+	static void ShareData_IO_FileTree( CDataProfile& cProfile, SFileTree& fileTree, const WCHAR* pszSecName );
+	static void ShareData_IO_FileTreeItem( CDataProfile& cProfile, SFileTreeItem& item,
+										   const WCHAR* pszSecName, int i );
+	static void ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& types, const WCHAR* pszSecName);	// 2010/04/12 Uchi 分離
 
 public:
-	static void IO_CustMenu( CDataProfile&, CommonSetting_CustomMenu&, bool );
-	static void IO_KeyBind( CDataProfile&, CommonSetting_KeyBind&, bool);		// 2012.11.22 aroka
+	static void IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMenu& menu, bool bOutCmdName);
+	static void IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& sKeyBind, bool bOutCmdName);		// 2012.11.22 aroka
 	static void IO_MainMenu( CDataProfile& c, CommonSetting_MainMenu& s, bool b ){		// 2010/5/15 Uchi
 		IO_MainMenu(c, NULL, s, b);
 	}
 	static void IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstring>* pData,
 		CommonSetting_MainMenu& mainmenu, bool bOutCmdName);
-	static void IO_ColorSet( CDataProfile* , const WCHAR* , ColorInfo* );	/* 色設定 I/O */ // Feb. 12, 2006 D.S.Koba
+	static void IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecName, ColorInfo* pColorInfoArr );	/* 色設定 I/O */ // Feb. 12, 2006 D.S.Koba
 };
 
 #endif /* SAKURA_CSHAREDATA_IO_AA81C249_631D_40B0_AAFF_2F163748954B9_H_ */

--- a/sakura_core/env/CTagJumpManager.h
+++ b/sakura_core/env/CTagJumpManager.h
@@ -67,8 +67,8 @@ public:
 		m_pShareData = &GetDllShareData();
 	}
 	//タグジャンプ関連	// 2004/06/21 novice タグジャンプ機能追加
-	void PushTagJump(const TagJump *);		//!< タグジャンプ情報の保存
-	bool PopTagJump(TagJump *);				//!< タグジャンプ情報の参照
+	void PushTagJump(const TagJump * pTagJump);		//!< タグジャンプ情報の保存
+	bool PopTagJump(TagJump *pTagJump);				//!< タグジャンプ情報の参照
 private:
 	DLLSHAREDATA* m_pShareData;
 };

--- a/sakura_core/env/DLLSHAREDATA.h
+++ b/sakura_core/env/DLLSHAREDATA.h
@@ -190,7 +190,7 @@ public:
 	~CShareDataLockCounter();
 
 	static int GetLockCounter();
-	static void WaitLock( HWND, CShareDataLockCounter** = NULL );
+	static void WaitLock( HWND hwndParent, CShareDataLockCounter** ppLock = NULL );
 private:
 };
 #endif /* SAKURA_DLLSHAREDATA_3A6DD7E0_90DC_4219_8570_F5C1B8B6A306_H_ */

--- a/sakura_core/func/CKeyBind.h
+++ b/sakura_core/func/CKeyBind.h
@@ -74,7 +74,7 @@ public:
 	/*
 	||  参照系メンバ関数
 	*/
-	static HACCEL CreateAccerelator( int, KEYDATA* );
+	static HACCEL CreateAccerelator( int nKeyNameArrNum, KEYDATA* pKeyNameArr );
 	static EFunctionCode GetFuncCode( WORD nAccelCmd, int nKeyNameArrNum, KEYDATA* pKeyNameArr, BOOL bGetDefFuncCode = TRUE );
 	static EFunctionCode GetFuncCodeAt( KEYDATA& KeyData, int nState, BOOL bGetDefFuncCode = TRUE );	/* 特定のキー情報から機能コードを取得する */	// 2007.02.24 ryoji
 	static EFunctionCode GetDefFuncCode( int nKeyCode, int nState );	/* キーのデフォルト機能を取得する */	// 2007.02.22 ryoji

--- a/sakura_core/func/Funccode.h
+++ b/sakura_core/func/Funccode.h
@@ -184,7 +184,7 @@ class CEditDoc;
 struct DLLSHAREDATA;
 
 //2007.10.30 kobake 機能チェックをCEditWndからここへ移動
-bool IsFuncEnable( const CEditDoc*, const DLLSHAREDATA*, EFunctionCode );	/* 機能が利用可能か調べる */
-bool IsFuncChecked( const CEditDoc*, const DLLSHAREDATA*, EFunctionCode );	/* 機能がチェック状態か調べる */
+bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EFunctionCode nId );	/* 機能が利用可能か調べる */
+bool IsFuncChecked( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EFunctionCode nId );	/* 機能がチェック状態か調べる */
 
 #endif // _FUNCCODE_H_

--- a/sakura_core/io/CFileLoad.h
+++ b/sakura_core/io/CFileLoad.h
@@ -77,7 +77,7 @@ public:
 //	bool ReadIgnoreLine( void ); // 1行読み飛ばす
 
 	//! ファイルの日時を取得する
-	BOOL GetFileTime( FILETIME*, FILETIME*, FILETIME* ); // inline
+	BOOL GetFileTime( FILETIME* pftCreate, FILETIME* pftLastAccess, FILETIME* pftLastWrite ); // inline
 
 	//	Jun. 08, 2003 Moca
 	//! 開いたファイルにはBOMがあるか？

--- a/sakura_core/macro/CKeyMacroMgr.h
+++ b/sakura_core/macro/CKeyMacroMgr.h
@@ -43,7 +43,7 @@ public:
 	||  Attributes & Operations
 	*/
 	void ClearAll( void );				/* キーマクロのバッファをクリアする */
-	void Append( EFunctionCode, const LPARAM*, class CEditView* pcEditView );		/* キーマクロのバッファにデータ追加 */
+	void Append( EFunctionCode nFuncID, const LPARAM* lParams, class CEditView* pcEditView );		/* キーマクロのバッファにデータ追加 */
 	void Append( class CMacro* macro );		/* キーマクロのバッファにデータ追加 */
 	
 	/* キーボードマクロをまとめて取り扱う */

--- a/sakura_core/macro/CPPA.h
+++ b/sakura_core/macro/CPPA.h
@@ -75,7 +75,7 @@ public:
 	const char* GetLastMessage(void) const { return m_szMsg; }
 
 	//	Jun. 16, 2003 genta 引数追加
-	static char* GetDeclarations( const MacroFuncInfo&, char* buf );
+	static char* GetDeclarations( const MacroFuncInfo& cMacroFuncInfo, char* szBuffer );
 
 protected:
 	//	Jul. 5, 2001 genta インターフェース変更に伴う引数追加
@@ -253,7 +253,7 @@ public:
 
 private:
 	// コールバックプロシージャ群
-	static void __stdcall stdStrObj(const char*, int, BYTE, int*, char**);	//	2003.06.01 Moca
+	static void __stdcall stdStrObj(const char* ObjName, int Index, BYTE GS_Mode, int* Err_CD, char** Value);	//	2003.06.01 Moca
 
 	static void __stdcall stdProc( const char* FuncName, const int Index, const char* Argument[], const int ArgSize, int* Err_CD);
 	static void __stdcall stdIntFunc( const char* FuncName, const int Index,
@@ -261,7 +261,7 @@ private:
 	static void __stdcall stdStrFunc( const char* FuncName, const int Index, const char* Argument[], const int ArgSize, int* Err_CD, char** ResultValue);
 	static bool CallHandleFunction( const int Index, const char* Arg[], int ArgSize, VARIANT* Result ); // 2002.02.24 Moca
 
-	static void __stdcall stdError( int, const char* );	//	2003.06.01 Moca
+	static void __stdcall stdError( int Err_CD, const char* Err_Mes );	//	2003.06.01 Moca
 	static void __stdcall stdFinishProc();	//	2003.06.01 Moca
 
 	//	メンバ変数

--- a/sakura_core/macro/CSMacroMgr.h
+++ b/sakura_core/macro/CSMacroMgr.h
@@ -144,12 +144,12 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	static WCHAR* GetFuncInfoByID( HINSTANCE , int , WCHAR* , WCHAR* );	/* 機能ID→関数名，機能名日本語 */
-	static EFunctionCode GetFuncInfoByName( HINSTANCE , const WCHAR* , WCHAR* );	/* 関数名→機能ID，機能名日本語 */
-	static BOOL CanFuncIsKeyMacro( int );	/* キーマクロに記録可能な機能かどうかを調べる */
+	static WCHAR* GetFuncInfoByID( HINSTANCE hInstance, int nFuncID, WCHAR* pszFuncName, WCHAR* pszFuncNameJapanese );	/* 機能ID→関数名，機能名日本語 */
+	static EFunctionCode GetFuncInfoByName( HINSTANCE hInstance, const WCHAR* pszFuncName, WCHAR* pszFuncNameJapanese );	/* 関数名→機能ID，機能名日本語 */
+	static BOOL CanFuncIsKeyMacro( int nFuncID );	/* キーマクロに記録可能な機能かどうかを調べる */
 	
 	//	Jun. 16, 2002 genta
-	static const MacroFuncInfo* GetFuncInfoByID( int );
+	static const MacroFuncInfo* GetFuncInfoByID( int nFuncID );
 	
 	bool IsSaveOk(void);
 

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -100,8 +100,7 @@ public:
 	void SyncColor( void );
 	void SetWindowText( const TCHAR* szTitle );		//ダイアログタイトルの設定
 	EFunctionCode GetFuncCodeRedraw(int outlineType);
-	void LoadFileTreeSetting( CFileTreeSetting&, SFilePath& );
-	static void ReadFileTreeIni( CDataProfile&, CFileTreeSetting& );
+	void LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDirPath );
 
 protected:
 	bool m_bInChangeLayout;
@@ -153,8 +152,8 @@ protected:
 
 	//	Apr. 23, 2005 genta リストビューのソートを関数として独立させた
 	void SortListView(HWND hwndList, int sortcol);
-	static int CALLBACK CompareFunc_Asc( LPARAM, LPARAM, LPARAM );
-	static int CALLBACK CompareFunc_Desc( LPARAM, LPARAM, LPARAM );
+	static int CALLBACK CompareFunc_Asc( LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort );
+	static int CALLBACK CompareFunc_Desc( LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort );
 
 	// 2001.12.03 hor
 //	void SetTreeBookMark( HWND );		/* ツリーコントロールの初期化：ブックマーク */

--- a/sakura_core/outline/CFuncInfo.h
+++ b/sakura_core/outline/CFuncInfo.h
@@ -30,7 +30,10 @@ class CFuncInfo;
 //@date 2002.04.01 YAZAKI 深さ導入
 class CFuncInfo {
 	public:
-		CFuncInfo( CLogicInt, CLogicInt, CLayoutInt, CLayoutInt, const TCHAR*, const TCHAR*, int );	/* CFuncInfoクラス構築 */
+		CFuncInfo( CLogicInt nFuncLineCRLF, CLogicInt nFuncColCRLF,
+				   CLayoutInt nFuncLineLAYOUT, CLayoutInt nFuncColLAYOUT,
+				   const TCHAR* pszFuncName, const TCHAR* pszFileName,
+				   int nInfo );	/* CFuncInfoクラス構築 */
 		~CFuncInfo();	/* CFuncInfoクラス消滅 */
 
 		//! クリップボードに追加する要素か？

--- a/sakura_core/outline/CFuncInfoArr.h
+++ b/sakura_core/outline/CFuncInfoArr.h
@@ -38,10 +38,12 @@ class CFuncInfoArr {
 public:
 	CFuncInfoArr();	/* CFuncInfoArrクラス構築 */
 	~CFuncInfoArr();	/* CFuncInfoArrクラス消滅 */
-	CFuncInfo* GetAt( int );	/* 0<=の指定番号のデータを返す */
-	void AppendData( CFuncInfo* );	/* 配列の最後にデータを追加する */
-	void AppendData( CLogicInt, CLayoutInt, const TCHAR*, int, int nDepth = 0 );	/* 配列の最後にデータを追加する 2002.04.01 YAZAKI 深さ導入*/
-	void AppendData( CLogicInt, CLayoutInt, const NOT_TCHAR*, int, int nDepth = 0 );	/* 配列の最後にデータを追加する 2002.04.01 YAZAKI 深さ導入*/
+	CFuncInfo* GetAt( int nIdx );	/* 0<=の指定番号のデータを返す */
+	void AppendData( CFuncInfo* pcFuncInfo );	/* 配列の最後にデータを追加する */
+	void AppendData( CLogicInt nFuncLineCRLF, CLayoutInt nFuncLineLAYOUT, const TCHAR* pszFuncName,
+					 int nInfo, int nDepth = 0 );	/* 配列の最後にデータを追加する 2002.04.01 YAZAKI 深さ導入*/
+	void AppendData( CLogicInt nFuncLineCRLF, CLayoutInt nFuncLineLAYOUT, const NOT_TCHAR* pszFuncName,
+					 int nInfo, int nDepth = 0 );	/* 配列の最後にデータを追加する 2002.04.01 YAZAKI 深さ導入*/
 	void AppendData( CLogicInt nLogicLine, CLogicInt nLogicCol, CLayoutInt nLayoutLine, CLayoutInt nLayoutCol, const TCHAR*, const TCHAR*, int, int nDepth = 0 );	/* 配列の最後にデータを追加する 2010.03.01 syat 桁導入*/
 	void AppendData( CLogicInt nLogicLine, CLogicInt nLogicCol, CLayoutInt nLayoutLine, CLayoutInt nLayoutCol, const NOT_TCHAR*, const NOT_TCHAR*, int, int nDepth = 0 );	/* 配列の最後にデータを追加する 2010.03.01 syat 桁導入*/
 	int	GetNum( void ){	return m_nFuncInfoArrNum; }	/* 配列要素数を返す */

--- a/sakura_core/parse/CWordParse.h
+++ b/sakura_core/parse/CWordParse.h
@@ -117,7 +117,7 @@ public:
 
 
 	template< class CHAR_TYPE >
-	static int GetWord( const CHAR_TYPE*, const int, const CHAR_TYPE *pszSplitCharList,
+	static int GetWord( const CHAR_TYPE* pS, const int nLen, const CHAR_TYPE *pszSplitCharList,
 		CHAR_TYPE **ppWordStart, int *pnWordLen );
 
 protected:

--- a/sakura_core/print/CPrintPreview.h
+++ b/sakura_core/print/CPrintPreview.h
@@ -114,7 +114,8 @@ protected:
 	*/
 	void DrawHeaderFooter( HDC hdc, const CMyRect& rect , bool bHeader );
 	CColorStrategy* DrawPageTextFirst( int nPageNum );
-	CColorStrategy* DrawPageText( HDC, int, int, int nPageNum, CDlgCancel*, CColorStrategy* pStrategyStart );
+	CColorStrategy* DrawPageText( HDC hdc, int nOffX, int nOffY, int nPageNum,
+								  CDlgCancel* pCDlgCancel, CColorStrategy* pStrategyStart );
 
 	// 印刷／プレビュー 行描画
 	CColorStrategy* Print_DrawLine(

--- a/sakura_core/prop/CPropCommon.h
+++ b/sakura_core/prop/CPropCommon.h
@@ -93,7 +93,7 @@ public:
 	~CPropCommon();
 	//	Sep. 29, 2001 genta マクロクラスを渡すように;
 //@@@ 2002.01.03 YAZAKI m_tbMyButtonなどをCShareDataからCMenuDrawerへ移動したことによる修正。
-	void Create( HWND, CImageListMgr*, CMenuDrawer* );	/* 初期化 */
+	void Create( HWND hwndParent, CImageListMgr* pcIcons, CMenuDrawer* pMenuDrawer );	/* 初期化 */
 
 	/*
 	||  Attributes & Operations

--- a/sakura_core/typeprop/CDlgKeywordSelect.h
+++ b/sakura_core/typeprop/CDlgKeywordSelect.h
@@ -50,7 +50,7 @@ class CDlgKeywordSelect : public CDialog
 public:
 	CDlgKeywordSelect();
 	~CDlgKeywordSelect();
-	int DoModal( HINSTANCE, HWND, int* pnSet );
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, int* pnSet );
 
 protected:
 

--- a/sakura_core/typeprop/CDlgSameColor.h
+++ b/sakura_core/typeprop/CDlgSameColor.h
@@ -45,14 +45,14 @@ class CDlgSameColor : public CDialog
 public:
 	CDlgSameColor();
 	~CDlgSameColor();
-	int DoModal( HINSTANCE, HWND, WORD, STypeConfig*, COLORREF );		//!< モーダルダイアログの表示
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, WORD wID, STypeConfig* pTypes, COLORREF cr );		//!< モーダルダイアログの表示
 
 protected:
 
 	virtual LPVOID GetHelpIdTable( void );
-	virtual INT_PTR DispatchEvent( HWND, UINT, WPARAM, LPARAM );	//! ダイアログのメッセージ処理
-	virtual BOOL OnInitDialog( HWND, WPARAM, LPARAM );			//!< WM_INITDIALOG 処理
-	virtual BOOL OnBnClicked( int );							//!< BN_CLICKED 処理
+	virtual INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	//! ダイアログのメッセージ処理
+	virtual BOOL OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam );			//!< WM_INITDIALOG 処理
+	virtual BOOL OnBnClicked( int wID );							//!< BN_CLICKED 処理
 	virtual BOOL OnDrawItem( WPARAM wParam, LPARAM lParam );	//!< WM_DRAWITEM 処理
 	BOOL OnSelChangeListColors( HWND hwndCtl );					//!< 色選択リストの LBN_SELCHANGE 処理
 

--- a/sakura_core/typeprop/CDlgTypeAscertain.h
+++ b/sakura_core/typeprop/CDlgTypeAscertain.h
@@ -59,7 +59,7 @@ public:
 	//  Constructors
 	CDlgTypeAscertain();
 	// モーダルダイアログの表示
-	int DoModal( HINSTANCE, HWND, SAscertainInfo* );	/* モーダルダイアログの表示 */
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, SAscertainInfo* psAscertainInfo );	/* モーダルダイアログの表示 */
 
 protected:
 	// 実装ヘルパ関数

--- a/sakura_core/typeprop/CDlgTypeList.h
+++ b/sakura_core/typeprop/CDlgTypeList.h
@@ -37,7 +37,7 @@ public:
 
 public:
 	// インターフェース
-	int DoModal( HINSTANCE, HWND, SResult* );	/* モーダルダイアログの表示 */
+	int DoModal( HINSTANCE hInstance, HWND hwndParent, SResult* psResult );	/* モーダルダイアログの表示 */
 
 protected:
 	// 実装ヘルパ関数

--- a/sakura_core/uiparts/CMenuDrawer.h
+++ b/sakura_core/uiparts/CMenuDrawer.h
@@ -51,7 +51,7 @@ public:
 	*/
 	CMenuDrawer();
 	~CMenuDrawer();
-	void Create( HINSTANCE, HWND, CImageListMgr* );
+	void Create( HINSTANCE hInstance, HWND hWndOwner, CImageListMgr* pcIcons );
 
 
 	/*
@@ -68,7 +68,7 @@ public:
 	{
 		MyAppendMenu(hMenu,nFlag,nFuncId,pszLabel,_T(""),bAddKeyStr,nForceIconId);
 	}
-	int MeasureItem( int, int* );	/* メニューアイテムの描画サイズを計算 */
+	int MeasureItem( int nFuncID, int* pnItemHeight );	/* メニューアイテムの描画サイズを計算 */
 	void DrawItem( DRAWITEMSTRUCT* );	/* メニューアイテム描画 */
 	void EndDrawMenu();
 	LRESULT OnMenuChar( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam );
@@ -127,13 +127,11 @@ public:
 	CImageListMgr	*m_pcIcons;	//	Image List
 
 protected:
-	/*
-	||  実装ヘルパ関数
-	*/
-	int GetData( void );	/* ダイアログデータの取得 */
 
 //@@@ 2002.01.03 YAZAKI m_tbMyButtonなどをCShareDataからCMenuDrawerへ移動したことによる修正。
-	void SetTBBUTTONVal( TBBUTTON*, int, int, BYTE, BYTE, DWORD_PTR, INT_PTR ) const;	/* TBBUTTON構造体にデータをセット */
+	void SetTBBUTTONVal( TBBUTTON* ptb, int iBitmap, int idCommand,
+						 BYTE fsState, BYTE fsStyle, DWORD_PTR dwData,
+						 INT_PTR iString ) const;	/* TBBUTTON構造体にデータをセット */
 };
 
 

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -28,7 +28,7 @@
 
 bool fexist(LPCTSTR pszPath); //!< ファイルまたはディレクトリが存在すればtrue
 
-bool IsFilePath( const wchar_t*, size_t*, size_t*, bool = true );
+bool IsFilePath( const wchar_t* pLine, size_t* pnBgn, size_t* pnPathLen, bool bFileOnly = true );
 bool IsFileExists(const TCHAR* path, bool bFileOnly = false);
 bool IsDirectory(LPCTSTR pszPath);	// 2009.08.20 ryoji
 
@@ -44,13 +44,13 @@ FILE *_tfopen_absexe(LPCTSTR fname, LPCTSTR mode); // 2003.06.23 Moca
 FILE *_tfopen_absini(LPCTSTR fname, LPCTSTR mode, BOOL bOrExedir = TRUE); // 2007.05.19 ryoji
 
 //パス文字列処理
-void CutLastYenFromDirectoryPath( TCHAR* );						/* フォルダの最後が半角かつ'\\'の場合は、取り除く "c:\\"等のルートは取り除かない*/
-void AddLastYenFromDirectoryPath(  CHAR* );						/* フォルダの最後が半角かつ'\\'でない場合は、付加する */
-void AddLastYenFromDirectoryPath( WCHAR* );						/* フォルダの最後が半角かつ'\\'でない場合は、付加する */
-void SplitPath_FolderAndFile( const TCHAR*, TCHAR*, TCHAR* );	/* ファイルのフルパスを、フォルダとファイル名に分割 */
-void Concat_FolderAndFile( const TCHAR*, const TCHAR*, TCHAR* );/* フォルダ、ファイル名から、結合したパスを作成 */
-BOOL GetLongFileName( const TCHAR*, TCHAR* );					/* ロングファイル名を取得する */
-BOOL CheckEXT( const TCHAR*, const TCHAR* );					/* 拡張子を調べる */
+void CutLastYenFromDirectoryPath( TCHAR* pszFolder );			/* フォルダの最後が半角かつ'\\'の場合は、取り除く "c:\\"等のルートは取り除かない*/
+void AddLastYenFromDirectoryPath(  CHAR* pszFolder );			/* フォルダの最後が半角かつ'\\'でない場合は、付加する */
+void AddLastYenFromDirectoryPath( WCHAR* pszFolder );			/* フォルダの最後が半角かつ'\\'でない場合は、付加する */
+void SplitPath_FolderAndFile( const TCHAR* pszFilePath, TCHAR* pszFolder, TCHAR* pszFile );	/* ファイルのフルパスを、フォルダとファイル名に分割 */
+void Concat_FolderAndFile( const TCHAR* pszDir, const TCHAR* pszTitle, TCHAR* pszPath );/* フォルダ、ファイル名から、結合したパスを作成 */
+BOOL GetLongFileName( const TCHAR* pszFilePathSrc, TCHAR* pszFilePathDes );					/* ロングファイル名を取得する */
+BOOL CheckEXT( const TCHAR* pszPath, const TCHAR* pszExt );					/* 拡張子を調べる */
 const TCHAR* GetFileTitlePointer(const TCHAR* tszPath);							//!< ファイルフルパス内のファイル名を指すポインタを取得。2007.09.20 kobake 作成
 bool _IS_REL_PATH(const TCHAR* path);											//!< 相対パスか判定する。2003.06.23 Moca
 

--- a/sakura_core/util/module.h
+++ b/sakura_core/util/module.h
@@ -25,7 +25,8 @@
 #ifndef SAKURA_MODULE_4F382EF5_EF52_47E1_A774_5CDFB545AB25_H_
 #define SAKURA_MODULE_4F382EF5_EF52_47E1_A774_5CDFB545AB25_H_
 
-void GetAppVersionInfo( HINSTANCE, int, DWORD*, DWORD* );	/* リソースから製品バージョンの取得 */
+void GetAppVersionInfo( HINSTANCE hInstance, int nVersionResourceID,
+					    DWORD* pdwProductVersionMS, DWORD* pdwProductVersionLS );	/* リソースから製品バージョンの取得 */
 
 HICON GetAppIcon( HINSTANCE hInst, int nResource, const TCHAR* szFile, bool bSmall = false);
 

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -29,8 +29,8 @@
 
 
 //システム資源
-BOOL GetSystemResources( int*, int*, int* );	/* システムリソースを調べる */
-BOOL CheckSystemResources( const TCHAR* );	/* システムリソースのチェック */
+BOOL GetSystemResources( int* pnSystemResources, int* pnUserResources, int* pnGDIResources );	/* システムリソースを調べる */
+BOOL CheckSystemResources( const TCHAR* pszAppName );	/* システムリソースのチェック */
 
 //クリップボード
 bool SetClipboardText( HWND hwnd, const ACHAR* pszText, int nLength );    //!< クリープボードにText形式でコピーする。ANSI版。nLengthは文字単位。

--- a/sakura_core/util/shell.h
+++ b/sakura_core/util/shell.h
@@ -30,7 +30,7 @@
 BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData);	/* WinHelp のかわりに HtmlHelp を呼び出す */	// 2006.07.22 ryoji
 
 /* Shell Interface系(?) */
-BOOL SelectDir(HWND, const TCHAR*, const TCHAR*, TCHAR* );	/* フォルダ選択ダイアログ */
+BOOL SelectDir(HWND hWnd, const TCHAR* pszTitle, const TCHAR* pszInitFolder, TCHAR* strFolderName );	/* フォルダ選択ダイアログ */
 BOOL ResolveShortcutLink(HWND hwnd, LPCTSTR lpszLinkFile, LPTSTR lpszPath);/* ショートカット(.lnk)の解決 */
 
 HWND OpenHtmlHelp( HWND hWnd, LPCTSTR szFile, UINT uCmd, DWORD_PTR data,bool msgflag = true);

--- a/sakura_core/util/string_ex2.h
+++ b/sakura_core/util/string_ex2.h
@@ -41,20 +41,20 @@ wchar_t *wcs_pushA(wchar_t *dst, size_t dst_count, const char* src);
 #define wcs_pushT wcs_pushA
 #endif
 
-int AddLastChar( TCHAR*, int, TCHAR );/* 2003.06.24 Moca 最後の文字が指定された文字でないときは付加する */
-int LimitStringLengthA( const ACHAR*, int, int, CNativeA& );/* データを指定「文字数」以内に切り詰める */
-int LimitStringLengthW( const WCHAR*, int, int, CNativeW& );/* データを指定「文字数」以内に切り詰める */
+int AddLastChar( TCHAR* pszPath, int nMaxLen, TCHAR c );/* 2003.06.24 Moca 最後の文字が指定された文字でないときは付加する */
+int LimitStringLengthA( const ACHAR* pszData, int nDataLength, int nLimitLength, CNativeA& cmemDes );/* データを指定「文字数」以内に切り詰める */
+int LimitStringLengthW( const WCHAR* pszData, int nDataLength, int nLimitLength, CNativeW& cmemDes );/* データを指定「文字数」以内に切り詰める */
 #ifdef _UNICODE
 #define LimitStringLengthT LimitStringLengthW
 #else
 #define LimitStringLengthT LimitStringLengthA
 #endif
 
-const char* GetNextLimitedLengthText( const char*, int, int, int*, int* );/* 指定長以下のテキストに切り分ける */
-const char*    GetNextLine  ( const char*   , int, int*, int*, CEol* ); /* CR0LF0,CRLF,LF,CRで区切られる「行」を返す。改行コードは行長に加えない */
-const wchar_t* GetNextLineW ( const wchar_t*, int, int*, int*, CEol*, bool ); // GetNextLineのwchar_t版
+const char* GetNextLimitedLengthText( const char* pText, int nTextLen, int nLimitLen, int* pnLineLen, int* pnBgn );/* 指定長以下のテキストに切り分ける */
+const char*    GetNextLine  ( const char* pData, int nDataLen, int* pnLineLen, int* pnBgn, CEol* pcEol); /* CR0LF0,CRLF,LF,CRで区切られる「行」を返す。改行コードは行長に加えない */
+const wchar_t* GetNextLineW ( const wchar_t* pData, int nDataLen, int* pnLineLen, int* pnBgn, CEol* pcEol, bool bExtEol); // GetNextLineのwchar_t版
 //wchar_t* GetNextLineWB( const wchar_t*, int, int*, int*, CEol* ); // GetNextLineのwchar_t版(ビックエンディアン用)  // 未使用
-void GetLineColumn( const wchar_t*, int*, int* );
+void GetLineColumn( const wchar_t* pLine, int* pnJumpToLine, int* pnJumpToColumn );
 
 
 int cescape(const TCHAR* org, TCHAR* buf, TCHAR cesc, TCHAR cwith);

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -180,15 +180,15 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	//取得
-	bool MyGetClipboardData( CNativeW&, bool*, bool* = NULL );			/* クリップボードからデータを取得 */
+	bool MyGetClipboardData( CNativeW& cmemBuf, bool* pbColumnSelect, bool* pbLineSelect = NULL );			/* クリップボードからデータを取得 */
 
 	//設定
-	bool MySetClipboardData( const ACHAR*, int, bool bColumnSelect, bool = false );	/* クリップボードにデータを設定 */
-	bool MySetClipboardData( const WCHAR*, int, bool bColumnSelect, bool = false );	/* クリップボードにデータを設定 */
+	bool MySetClipboardData( const ACHAR* pszText, int nTextLen, bool bColumnSelect, bool bLineSelect = false );	/* クリップボードにデータを設定 */
+	bool MySetClipboardData( const WCHAR* pszText, int nTextLen, bool bColumnSelect, bool bLineSelect = false );	/* クリップボードにデータを設定 */
 
 	//利用
 	void CopyCurLine( bool bAddCRLFWhenCopy, EEolType neweol, bool bEnableLineModePaste );	/* カーソル行をクリップボードにコピーする */	// 2007.10.08 ryoji
-	void CopySelectedAllLines( const wchar_t*, BOOL );			/* 選択範囲内の全行をクリップボードにコピーする */
+	void CopySelectedAllLines( const wchar_t* pszQuote, BOOL bWithLineNumber );			/* 選択範囲内の全行をクリップボードにコピーする */
 
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -337,7 +337,7 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	// 2002/01/19 novice public属性に変更
-	bool GetSelectedDataSimple( CNativeW& );// 選択範囲のデータを取得
+	bool GetSelectedDataSimple( CNativeW& cmemBuf );// 選択範囲のデータを取得
 	bool GetSelectedDataOne( CNativeW& cmemBuf, int nMaxLen );
 	bool GetSelectedData( CNativeW*, BOOL, const wchar_t*, BOOL, bool bAddCRLFWhenCopy, EEolType neweol = EOL_UNKNOWN);/* 選択範囲のデータを取得 */
 	int IsCurrentPositionSelected( CLayoutPoint ptCaretPos );					/* 指定カーソル位置が選択エリア内にあるか */
@@ -555,7 +555,9 @@ public:
 	//                          その他                             //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	BOOL OPEN_ExtFromtoExt( BOOL, BOOL, const TCHAR* [], const TCHAR* [], int, int, const TCHAR* ); // 指定拡張子のファイルに対応するファイルを開く補助関数 // 2003.08.12 Moca
+	BOOL OPEN_ExtFromtoExt( BOOL bCheckOnly, BOOL bBeepWhenMiss,
+							const TCHAR* file_ext[], const TCHAR* open_ext[],
+							int file_extno, int open_extno, const TCHAR* errmes ); // 指定拡張子のファイルに対応するファイルを開く補助関数 // 2003.08.12 Moca
 	//	Jan.  8, 2006 genta 折り返しトグル動作判定
 	enum TOGGLE_WRAP_ACTION {
 		TGWRAP_NONE = 0,

--- a/sakura_core/window/CAutoScrollWnd.h
+++ b/sakura_core/window/CAutoScrollWnd.h
@@ -33,7 +33,8 @@ class CAutoScrollWnd: public CWnd
 public:
 	CAutoScrollWnd();
 	virtual ~CAutoScrollWnd();
-	HWND Create( HINSTANCE, HWND , bool, bool, const CMyPoint&, CEditView* );
+	HWND Create( HINSTANCE hInstance, HWND hwndParent, bool bVertical, bool bHorizontal,
+				 const CMyPoint& point, CEditView* view );
 	void Close();
 
 private:

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -58,7 +58,7 @@ public:
 	/*
 	|| メンバ関数
 	*/
-	HWND Open( HINSTANCE, HWND );		/*!< ウィンドウ オープン */
+	HWND Open( HINSTANCE hInstance, HWND hwndParent );		/*!< ウィンドウ オープン */
 	void Close( void );					/*!< ウィンドウ クローズ */
 	void TabWindowNotify( WPARAM wParam, LPARAM lParam );
 	void Refresh( BOOL bEnsureVisible = TRUE, BOOL bRebuild = FALSE );			// 2006.02.06 ryoji 引数削除
@@ -100,19 +100,19 @@ protected:
 	virtual void AfterCreateWindow( void ){}	/*!< ウィンドウ作成後の処理 */	// 2007.03.13 ryoji 可視化しない
 
 	/* 仮想関数 メッセージ処理 */
-	virtual LRESULT OnSize( HWND, UINT, WPARAM, LPARAM );		/*!< WM_SIZE処理 */
-	virtual LRESULT OnDestroy( HWND, UINT, WPARAM, LPARAM );	/*!< WM_DSESTROY処理 */
-	virtual LRESULT OnNotify( HWND, UINT, WPARAM, LPARAM );		/*!< WM_NOTIFY処理 */
-	virtual LRESULT OnPaint( HWND, UINT, WPARAM, LPARAM );		/*!< WM_PAINT処理 */
-	virtual LRESULT OnCaptureChanged( HWND, UINT, WPARAM, LPARAM );	/*!< WM_CAPTURECHANGED 処理 */
-	virtual LRESULT OnLButtonDown( HWND, UINT, WPARAM, LPARAM );	/*!< WM_LBUTTONDOWN処理 */
-	virtual LRESULT OnLButtonUp( HWND, UINT, WPARAM, LPARAM );	/*!< WM_LBUTTONUP処理 */
-	virtual LRESULT OnRButtonDown( HWND, UINT, WPARAM, LPARAM );	/*!< WM_RBUTTONDOWN処理 */
-	virtual LRESULT OnLButtonDblClk( HWND, UINT, WPARAM, LPARAM );	/*!< WM_LBUTTONDBLCLK処理 */
-	virtual LRESULT OnMouseMove( HWND, UINT, WPARAM, LPARAM );	/*!< WM_MOUSEMOVE処理 */
-	virtual LRESULT OnTimer( HWND, UINT, WPARAM, LPARAM );		/*!< WM_TIMER処理 */
-	virtual LRESULT OnMeasureItem( HWND, UINT, WPARAM, LPARAM );	/*!< WM_MEASUREITEM処理 */
-	virtual LRESULT OnDrawItem( HWND, UINT, WPARAM, LPARAM );		/*!< WM_DRAWITEM処理 */
+	virtual LRESULT OnSize( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_SIZE処理 */
+	virtual LRESULT OnDestroy( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_DSESTROY処理 */
+	virtual LRESULT OnNotify( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_NOTIFY処理 */
+	virtual LRESULT OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_PAINT処理 */
+	virtual LRESULT OnCaptureChanged( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_CAPTURECHANGED 処理 */
+	virtual LRESULT OnLButtonDown( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_LBUTTONDOWN処理 */
+	virtual LRESULT OnLButtonUp( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_LBUTTONUP処理 */
+	virtual LRESULT OnRButtonDown( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_RBUTTONDOWN処理 */
+	virtual LRESULT OnLButtonDblClk( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_LBUTTONDBLCLK処理 */
+	virtual LRESULT OnMouseMove( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_MOUSEMOVE処理 */
+	virtual LRESULT OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_TIMER処理 */
+	virtual LRESULT OnMeasureItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_MEASUREITEM処理 */
+	virtual LRESULT OnDrawItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_DRAWITEM処理 */
 
 	// 2005.09.01 ryoji ドラッグアンドドロップでタブの順序変更を可能に
 	/* サブクラス化した Tab でのメッセージ処理 */

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -32,12 +32,12 @@ public:
 	*/
 	CTipWnd();
 	~CTipWnd();
-	void Create( HINSTANCE, HWND );	/* 初期化 */
+	void Create( HINSTANCE hInstance, HWND hwndParent );	/* 初期化 */
 
 	/*
 	||  Attributes & Operations
 	*/
-	void Show( int, int, const TCHAR*, RECT* pRect = NULL );	/* Tipを表示 */
+	void Show( int nX, int nY, const TCHAR* szText, RECT* pRect = NULL );	/* Tipを表示 */
 	void Hide( void );	/* Tipを消す */
 	void GetWindowSize(LPRECT pRect);		// 2001/06/19 asa-o ウィンドウのサイズを得る
 

--- a/sakura_core/window/CWnd.h
+++ b/sakura_core/window/CWnd.h
@@ -70,10 +70,10 @@ public:
 		HMENU		hMenu			// handle to menu, or child-window identifier
 	);
 
-	virtual LRESULT DispatchEvent( HWND, UINT, WPARAM, LPARAM );/* メッセージ配送 */
+	virtual LRESULT DispatchEvent( HWND hwnd, UINT msg, WPARAM wp, LPARAM lp );/* メッセージ配送 */
 protected:
 	/* 仮想関数 */
-	virtual LRESULT DispatchEvent_WM_APP( HWND, UINT, WPARAM, LPARAM );/* アプリケーション定義のメッセージ(WM_APP <= msg <= 0xBFFF) */
+	virtual LRESULT DispatchEvent_WM_APP( HWND hwnd, UINT msg, WPARAM wp, LPARAM lp );/* アプリケーション定義のメッセージ(WM_APP <= msg <= 0xBFFF) */
 	virtual void PreviCreateWindow( void ){return;}/* ウィンドウ作成前の処理(クラス登録前) ( virtual )*/
 	virtual void AfterCreateWindow( void ){::ShowWindow( m_hWnd, SW_SHOW );}/* ウィンドウ作成後の処理 ( virtual )*/
 
@@ -108,7 +108,7 @@ protected:
 	virtual DECLH( OnCaptureChanged	);	// WM_CAPTURECHANGED	// 2006.11.30 ryoji
 
 	/* デフォルトメッセージ処理 */
-	virtual LRESULT CallDefWndProc( HWND, UINT, WPARAM, LPARAM );
+	virtual LRESULT CallDefWndProc( HWND hwnd, UINT msg, WPARAM wp, LPARAM lp );
 
 public:
 	//インターフェース


### PR DESCRIPTION
プロトタイプ宣言に引数の名前が書かれていない箇所があったので対応しました。
目視でチェックしているので抜けはあると思います。
