### PR TITLE
スクロールバーの再描画を常には行わないように変更

### DIFF
--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -288,7 +288,7 @@ public:
 	//                        スクロール                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	void AdjustScrollBars();											/* スクロールバーの状態を更新する */
+	void AdjustScrollBars( BOOL bRedraw = TRUE );						/* スクロールバーの状態を更新する */
 	BOOL CreateScrollBar();												/* スクロールバー作成 */	// 2006.12.19 ryoji
 	void DestroyScrollBar();											/* スクロールバー破棄 */	// 2006.12.19 ryoji
 	CLayoutInt GetWrapOverhang( void ) const;							/* 折り返し桁以後のぶら下げ余白計算 */	// 2008.06.08 ryoji
@@ -306,8 +306,8 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                        スクロール                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	CLayoutInt  ScrollAtV(CLayoutInt nPos);										/* 指定上端行位置へスクロール */
-	CLayoutInt  ScrollAtH(CLayoutInt nPos);										/* 指定左端桁位置へスクロール */
+	CLayoutInt  ScrollAtV(CLayoutInt nPos, BOOL bRedrawScrollBar = TRUE);		/* 指定上端行位置へスクロール */
+	CLayoutInt  ScrollAtH(CLayoutInt nPos, BOOL bRedrawScrollBar = TRUE);		/* 指定左端桁位置へスクロール */
 	//	From Here Sep. 11, 2004 genta ずれ維持の同期スクロール
 	CLayoutInt  ScrollByV( CLayoutInt vl ){	return ScrollAtV( GetTextArea().GetViewTopLine() + vl );}	/* 指定行スクロール*/
 	CLayoutInt  ScrollByH( CLayoutInt hl ){	return ScrollAtH( GetTextArea().GetViewLeftCol() + hl );}	/* 指定桁スクロール */

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -267,7 +267,7 @@ CLayoutInt CEditView::OnHScroll( int nScrollCode, int nPos )
 		break;
 	case SB_RIGHT:
 		//	Aug. 14, 2005 genta 折り返し幅をLayoutMgrから取得するように
-		nScrollVal = ScrollAtH( m_pcEditDoc->m_cLayoutMgr.GetMaxLineKetas() - GetTextArea().m_nViewColNum, FALSE );
+		nScrollVal = ScrollAtH( m_pcEditDoc->m_cLayoutMgr.GetMaxLineKetas() - GetTextArea().m_nViewColNum );
 		break;
 	}
 	return nScrollVal;

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -197,10 +197,10 @@ CLayoutInt CEditView::OnVScroll( int nScrollCode, int nPos )
 		nScrollVal = ScrollAtV( GetTextArea().GetViewTopLine() - GetTextArea().m_nViewRowNum );
 		break;
 	case SB_THUMBPOSITION:
-		nScrollVal = ScrollAtV( CLayoutInt(nPos) );
+		nScrollVal = ScrollAtV( CLayoutInt(nPos), FALSE );
 		break;
 	case SB_THUMBTRACK:
-		nScrollVal = ScrollAtV( CLayoutInt(nPos) );
+		nScrollVal = ScrollAtV( CLayoutInt(nPos), FALSE );
 		break;
 	case SB_TOP:
 		nScrollVal = ScrollAtV( CLayoutInt(0) );
@@ -255,11 +255,11 @@ CLayoutInt CEditView::OnHScroll( int nScrollCode, int nPos )
 		nScrollVal = ScrollAtH( GetTextArea().GetRightCol() );
 		break;
 	case SB_THUMBPOSITION:
-		nScrollVal = ScrollAtH( CLayoutInt(nPos) );
+		nScrollVal = ScrollAtH( CLayoutInt(nPos), FALSE );
 //		MYTRACE( _T("nPos=%d\n"), nPos );
 		break;
 	case SB_THUMBTRACK:
-		nScrollVal = ScrollAtH( CLayoutInt(nPos) );
+		nScrollVal = ScrollAtH( CLayoutInt(nPos), FALSE );
 //		MYTRACE( _T("nPos=%d\n"), nPos );
 		break;
 	case SB_LEFT:
@@ -267,13 +267,13 @@ CLayoutInt CEditView::OnHScroll( int nScrollCode, int nPos )
 		break;
 	case SB_RIGHT:
 		//	Aug. 14, 2005 genta 折り返し幅をLayoutMgrから取得するように
-		nScrollVal = ScrollAtH( m_pcEditDoc->m_cLayoutMgr.GetMaxLineKetas() - GetTextArea().m_nViewColNum );
+		nScrollVal = ScrollAtH( m_pcEditDoc->m_cLayoutMgr.GetMaxLineKetas() - GetTextArea().m_nViewColNum, FALSE );
 		break;
 	}
 	return nScrollVal;
 }
 
-static void setScrollInfoIfNeeded(HWND hWndScrollBar, int nMax, UINT nPage, int nPos)
+static void setScrollInfoIfNeeded(HWND hWndScrollBar, int nMax, UINT nPage, int nPos, BOOL bRedraw)
 {
 	SCROLLINFO siPrev;
 	siPrev.cbSize = sizeof(siPrev);
@@ -306,7 +306,7 @@ static void setScrollInfoIfNeeded(HWND hWndScrollBar, int nMax, UINT nPage, int 
 		si.nMax  = nMax;
 		si.nPage = nPage;
 		si.nPos  = nPos;
-		::SetScrollInfo( hWndScrollBar, SB_CTL, &si, TRUE );
+		::SetScrollInfo( hWndScrollBar, SB_CTL, &si, bRedraw );
 	}
 }
 
@@ -320,7 +320,7 @@ static void setScrollInfoIfNeeded(HWND hWndScrollBar, int nMax, UINT nPage, int 
 	@date 2008.06.08 ryoji 水平スクロール範囲にぶら下げ余白を追加
 	@date 2009.08.28 nasukoji	「折り返さない」選択時のスクロールバー調整
 */
-void CEditView::AdjustScrollBars()
+void CEditView::AdjustScrollBars( BOOL bRedraw )
 {
 	if( !GetDrawSwitch() ){
 		return;
@@ -344,7 +344,8 @@ void CEditView::AdjustScrollBars()
 		setScrollInfoIfNeeded(m_hwndVScrollBar,
 							  (Int)nAllLines / nVScrollRate - 1,					/* 全行数 */
 							  (Int)GetTextArea().m_nViewRowNum / nVScrollRate,		/* 表示域の行数 */
-							  (Int)GetTextArea().GetViewTopLine() / nVScrollRate	/* 表示域の一番上の行(0開始) */
+							  (Int)GetTextArea().GetViewTopLine() / nVScrollRate,	/* 表示域の一番上の行(0開始) */
+							  bRedraw
 		);
 		m_nVScrollRate = nVScrollRate;				/* 垂直スクロールバーの縮尺 */
 		
@@ -365,7 +366,8 @@ void CEditView::AdjustScrollBars()
 		setScrollInfoIfNeeded(m_hwndHScrollBar,
 							  (Int)GetRightEdgeForScrollBar() - 1,		// 2009.08.28 nasukoji	スクロールバー制御用の右端座標を取得
 							  (Int)GetTextArea().m_nViewColNum,			/* 表示域の桁数 */
-							  (Int)GetTextArea().GetViewLeftCol()		/* 表示域の一番左の桁(0開始) */
+							  (Int)GetTextArea().GetViewLeftCol(),		/* 表示域の一番左の桁(0開始) */
+							  bRedraw
 		);
 
 		//	2006.1.28 aroka 判定条件誤り修正 (バーが消えてもスクロールしない)
@@ -382,11 +384,12 @@ void CEditView::AdjustScrollBars()
 /*! 指定上端行位置へスクロール
 
 	@param nPos [in] スクロール位置
+	@param bRedrawScrollBar [in] スクロールバーを再描画するかどうか
 	@retval 実際にスクロールした行数 (正:下方向/負:上方向)
 
 	@date 2004.09.11 genta 行数を戻り値として返すように．(同期スクロール用)
 */
-CLayoutInt CEditView::ScrollAtV( CLayoutInt nPos )
+CLayoutInt CEditView::ScrollAtV( CLayoutInt nPos, BOOL bRedrawScrollBar )
 {
 	CLayoutInt	nScrollRowNum;
 	RECT		rcScrol;
@@ -445,7 +448,7 @@ CLayoutInt CEditView::ScrollAtV( CLayoutInt nPos )
 	}
 
 	/* スクロールバーの状態を更新する */
-	AdjustScrollBars();
+	AdjustScrollBars(bRedrawScrollBar);
 
 	/* キャレットの表示・更新 */
 	GetCaret().ShowEditCaret();
@@ -461,13 +464,14 @@ CLayoutInt CEditView::ScrollAtV( CLayoutInt nPos )
 /*! 指定左端桁位置へスクロール
 
 	@param nPos [in] スクロール位置
+	@param bRedrawScrollBar [in] スクロールバーを再描画するかどうか
 	@retval 実際にスクロールした桁数 (正:右方向/負:左方向)
 
 	@date 2004.09.11 genta 桁数を戻り値として返すように．(同期スクロール用)
 	@date 2008.06.08 ryoji 水平スクロール範囲にぶら下げ余白を追加
 	@date 2009.08.28 nasukoji	「折り返さない」選択時右に行き過ぎないようにする
 */
-CLayoutInt CEditView::ScrollAtH( CLayoutInt nPos )
+CLayoutInt CEditView::ScrollAtH( CLayoutInt nPos, BOOL bRedrawScrollBar )
 {
 	RECT		rcScrol;
 	RECT		rcClip2;
@@ -534,7 +538,7 @@ CLayoutInt CEditView::ScrollAtH( CLayoutInt nPos )
 	::ReleaseDC( GetHwnd(), hdc );
 
 	/* スクロールバーの状態を更新する */
-	AdjustScrollBars();
+	AdjustScrollBars(bRedrawScrollBar);
 
 	/* キャレットの表示・更新 */
 	GetCaret().ShowEditCaret();


### PR DESCRIPTION
スクロールバーのサム（つまみ）をドラッグしてスクロールした場合はスクロールバーの再描画は行わないようにしました。

プログラムの記述が少し増えるのと引き換えにスクロール操作時に不必要な処理を行わないようにする事でCPU使用率を下げる効果が有ります。自分の環境だとPerformance Profiler で起動後に何かテキストファイル（例えば `sakura_core/CBackupAgent.cpp`） を開いて縦スクロールバーをひたすら上下に動かす操作をした場合の `setScrollInfoIfNeeded` のCPU使用率が、10% 近くあったのが 1% 未満に低下します。`SetScrollInfo` API関数のパーセンテージが低下する事が確認できます。
