### PR TITLE
縦スクロール時に不必要にルーラーの再描画がされないように対策

### DIFF
--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -409,7 +409,9 @@ CLayoutInt CEditView::ScrollAtV( CLayoutInt nPos )
 	/* スクロール */
 	if( t_abs( nScrollRowNum ) >= GetTextArea().m_nViewRowNum ){
 		GetTextArea().SetViewTopLine( CLayoutInt(nPos) );
-		::InvalidateRect( GetHwnd(), NULL, TRUE );
+		CMyRect rect = GetTextArea().GetAreaRect();
+		rect.left = 0;
+		::InvalidateRect( GetHwnd(), &rect, TRUE );
 	}else{
 		rcScrol.left = 0;
 		rcScrol.right = GetTextArea().GetAreaRight();


### PR DESCRIPTION
スクロール行数が表示行数を超える場合にクライアント領域全体が再描画の対象領域にされていましたが、それを限定してルーラー部分の再描画がされないように対策しました。

スクロールバーのサム（つまみ）をドラッグ操作で縦スクロールする際のCPU負荷を下げるのが目的です。自分の環境だとPerformance Profiler で起動後に何かテキストファイル（例えば `C:\Windows\PolicyDefinitions\inetres.admx`） を開いて縦スクロールバーをひたすら上下に動かす操作をした場合の `CRuler::DispRuler` のCPU使用率が、3% 近くあったのが 0.25% 辺りに低下します。