### PR TITLE
Fix: Make githash.h before doxygen.

### DIFF
--- a/run-doxygen.bat
+++ b/run-doxygen.bat
@@ -1,4 +1,4 @@
-call sakura\githash.bat
+call sakura\githash.bat "%~dp0sakura_core"
 call tools\hhc\find-hhc.bat
 call tools\doxygen\find-doxygen.bat
 


### PR DESCRIPTION
doxygen を実行する前に誤ってソースディレクトリのトップに作成していた githash.h を sakura_core/githash.h に作成します。
