### PR TITLE
マルチユーザ設定を有効にする

### DIFF
--- a/resource/sakura.exe.ini
+++ b/resource/sakura.exe.ini
@@ -23,6 +23,6 @@
 ;			UserSubFolder=sakura_settings
 ;		Ë ex. C:\Documents and Settings\<username>\My Documents\sakura_settings\sakura.ini
 
-MultiUser=0
+MultiUser=1
 UserRootFolder=0
 UserSubFolder=sakura


### PR DESCRIPTION
exe.iniのデフォルト値を変更します。

このファイルはインストーラのテンプレートとして使われるファイルなので、変更によるインストーラへの影響はないと考えられます。

変更を適用すると、このファイルを Debug にコピーするだけで、
インストール済みの SAKURA editor の設定を流用することができるようになります。

設定の意味については、変更対象のiniに書かれているコメントを参照してください。
