### PR TITLE
WinMainを整理したい

### DIFF
--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -49,6 +49,7 @@ LIBS= \
  -lwindowscodecs \
  -lmsimg32 \
  -mwindows \
+ -municode \
  $(MYLIBS)
 
 exe= sakura.exe

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -37,21 +37,12 @@
 	コントロールプロセスはCControlProcessクラスのインスタンスを作り、
 	エディタプロセスはCNormalProcessクラスのインスタンスを作る。
 */
-#ifdef __MINGW32__
-int WINAPI WinMain(
-	HINSTANCE	hInstance,		//!< handle to current instance
-	HINSTANCE	hPrevInstance,	//!< handle to previous instance
-	LPSTR		lpCmdLineA,		//!< pointer to command line
-	int			nCmdShow		//!< show state of window
-)
-#else
 int WINAPI _tWinMain(
 	HINSTANCE	hInstance,		//!< handle to current instance
 	HINSTANCE	hPrevInstance,	//!< handle to previous instance
 	LPTSTR		lpCmdLine,		//!< pointer to command line
 	int			nCmdShow		//!< show state of window
 )
-#endif
 {
 #ifdef USE_LEAK_CHECK_WITH_CRTDBG
 	// 2009.9.10 syat メモリリークチェックを追加
@@ -76,32 +67,7 @@ int WINAPI _tWinMain(
 	CProcessFactory aFactory;
 	CProcess *process = 0;
 	try{
-#ifdef __MINGW32__
-		LPTSTR pszCommandLine;
-		pszCommandLine = ::GetCommandLine();
-		// 実行ファイル名をスキップする
-		if( _T('\"') == *pszCommandLine ){
-			pszCommandLine++;
-			while( _T('\"') != *pszCommandLine && _T('\0') != *pszCommandLine ){
-				pszCommandLine++;
-			}
-			if( _T('\"') == *pszCommandLine ){
-				pszCommandLine++;
-			}
-		}else{
-			while( _T(' ') != *pszCommandLine && _T('\t') != *pszCommandLine
-				&& _T('\0') != *pszCommandLine ){
-				pszCommandLine++;
-			}
-		}
-		// 次のトークンまで進める
-		while( _T(' ') == *pszCommandLine || _T('\t') == *pszCommandLine ){
-			pszCommandLine++;
-		}
-		process = aFactory.Create( hInstance, pszCommandLine );
-#else
 		process = aFactory.Create( hInstance, lpCmdLine );
-#endif
 		MY_TRACETIME( cRunningTimer, "ProcessObject Created" );
 	}
 	catch(...){

--- a/sakura_lang_en_US/Makefile
+++ b/sakura_lang_en_US/Makefile
@@ -39,7 +39,7 @@ LIBS= \
  -lshell32 -lole32 -loleaut32 \
  -luuid -lcomctl32 -limm32 \
  -lmpr -limagehlp \
- -static-libgcc -static-libstdc++ -mwindows -s
+ -static-libgcc -static-libstdc++ -mwindows -municode -s
 
 exe= sakura_lang_en_US.dll
 


### PR DESCRIPTION
サクラエディタのWinMain関数はややこしいです。
古いMinGW向けコードを取り除くことにより、
WinMainの流れを見やすくしよう、というのがこのPRの趣旨です。

以前は MinGW-w64 に `-municode` オプションがあることを知りませんでした。
このオプションは MinGW ビルドも wWinMain を使えるようにするものです。
何気に [MinGW-w64 プロジェクト](https://mingw-w64.org/doku.php/start)のアピールポイントの1つでもあるようです。

このPR自体に大した意味はありませんが、この変更を入れておくことで、
今後CProcess/CProcessFactoryの整理を行うために変更前コードを見やすくすることができます。
