### PR TITLE
#include <locale.h> 追加

### DIFF
--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -21,6 +21,7 @@
 
 #include "StdAfx.h"
 #include <Ole2.h>
+#include <locale.h>
 #include "CProcessFactory.h"
 #include "CProcess.h"
 #include "util/os.h"

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -4,6 +4,7 @@
 #include "charset/charcode.h"
 #include "util/std_macro.h"
 #include <limits.h>
+#include <locale.h>
 
 int __cdecl my_internal_icmp( const char *s1, const char *s2, unsigned int n, unsigned int dcount, bool flag );
 


### PR DESCRIPTION
Visual Studio 2019 Preview で Debug Win32 でビルドするとエラーになるので追加しました。
今まで無くても何で大丈夫だったのかは良く分かりません。どこかの標準ヘッダーで include してるんでしょうか。。

