### PR TITLE
サイズボックスウィンドウをその都度作り直すのではなく表示・非表示を切り替えて使いまわす

### DIFF
--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -204,6 +204,7 @@ BOOL CEditView::Create(
 	m_nVScrollRate = 1;			/* 垂直スクロールバーの縮尺 */
 	m_hwndHScrollBar = NULL;
 	m_hwndSizeBox = NULL;
+	m_hwndSizeBoxPlaceholder = NULL;
 
 	m_ptSrchStartPos_PHY.Set(CLogicInt(-1), CLogicInt(-1));	//検索/置換開始時のカーソル位置  (改行単位行先頭からのバイト数(0開始), 改行単位行の行番号(0開始))
 	m_bSearch = FALSE;					// 検索/置換開始位置を登録するか */											// 02/06/26 ai
@@ -468,7 +469,34 @@ LRESULT CEditView::DispatchEvent(
 
 	case WM_CREATE:
 		::SetWindowLongPtr( hwnd, 0, (LONG_PTR) this );
-
+		m_hwndSizeBox = ::CreateWindowEx(
+			WS_EX_CONTROLPARENT/*0L*/, 			/* no extended styles */
+			_T("SCROLLBAR"),					/* scroll bar control class */
+			NULL,								/* text for window title bar */
+			WS_CHILD | SBS_SIZEBOX | SBS_SIZEGRIP, /* scroll bar styles */
+			0,									/* horizontal position */
+			0,									/* vertical position */
+			200,								/* width of the scroll bar */
+			CW_USEDEFAULT,						/* default height */
+			hwnd, 								/* handle of main window */
+			(HMENU) NULL,						/* no menu for a scroll bar */
+			G_AppInstance(),						/* instance owning this window */
+			(LPVOID) NULL						/* pointer not needed */
+		);
+		m_hwndSizeBoxPlaceholder = ::CreateWindowEx(
+			0L, 								/* no extended styles */
+			_T("STATIC"),						/* scroll bar control class */
+			NULL,								/* text for window title bar */
+			WS_CHILD/* | SBS_SIZEBOX | SBS_SIZEGRIP*/, /* scroll bar styles */
+			0,									/* horizontal position */
+			0,									/* vertical position */
+			200,								/* width of the scroll bar */
+			CW_USEDEFAULT,						/* default height */
+			hwnd, 								/* handle of main window */
+			(HMENU) NULL,						/* no menu for a scroll bar */
+			G_AppInstance(),						/* instance owning this window */
+			(LPVOID) NULL						/* pointer not needed */
+		);
 		return 0L;
 
 		// From Here 2007.09.09 Moca 互換BMPによる画面バッファ
@@ -800,10 +828,10 @@ LRESULT CEditView::DispatchEvent(
 			::DestroyWindow( m_hwndHScrollBar );
 			m_hwndHScrollBar = NULL;
 		}
-		if( NULL != m_hwndSizeBox ){
-			::DestroyWindow( m_hwndSizeBox );
-			m_hwndSizeBox = NULL;
-		}
+		::DestroyWindow( m_hwndSizeBox );
+		m_hwndSizeBox = NULL;
+		::DestroyWindow( m_hwndSizeBoxPlaceholder );
+		m_hwndSizeBoxPlaceholder = NULL;
 		SAFE_DELETE(m_pcsbwVSplitBox);	/* 垂直分割ボックス */
 		SAFE_DELETE(m_pcsbwHSplitBox);	/* 水平分割ボックス */
 
@@ -969,9 +997,8 @@ void CEditView::OnSize( int cx, int cy )
 	}
 
 	/* サイズボックス */
-	if( NULL != m_hwndSizeBox ){
-		::MoveWindow( m_hwndSizeBox, cx - nCxVScroll, cy - nCyHScroll, nCxHScroll, nCyVScroll, TRUE );
-	}
+	::MoveWindow( m_hwndSizeBox, cx - nCxVScroll, cy - nCyHScroll, nCxHScroll, nCyVScroll, TRUE );
+	::MoveWindow( m_hwndSizeBoxPlaceholder, cx - nCxVScroll, cy - nCyHScroll, nCxHScroll, nCyVScroll, TRUE );
 	int nAreaWidthOld  = GetTextArea().GetAreaWidth();
 	int nAreaHeightOld = GetTextArea().GetAreaHeight();
 
@@ -1825,45 +1852,12 @@ void CEditView::SplitBoxOnOff( BOOL bVert, BOOL bHorz, BOOL bSizeBox )
 	}
 
 	if( bSizeBox ){
-		if( NULL != m_hwndSizeBox ){
-			::DestroyWindow( m_hwndSizeBox );
-			m_hwndSizeBox = NULL;
-		}
-		m_hwndSizeBox = ::CreateWindowEx(
-			0L,													/* no extended styles */
-			_T("SCROLLBAR"),										/* scroll bar control class */
-			NULL,												/* text for window title bar */
-			WS_VISIBLE | WS_CHILD | SBS_SIZEBOX | SBS_SIZEGRIP, /* scroll bar styles */
-			0,													/* horizontal position */
-			0,													/* vertical position */
-			200,												/* width of the scroll bar */
-			CW_USEDEFAULT,										/* default height */
-			GetHwnd(),												/* handle of main window */
-			(HMENU) NULL,										/* no menu for a scroll bar */
-			G_AppInstance(),										/* instance owning this window */
-			(LPVOID) NULL										/* pointer not needed */
-		);
+		::ShowWindow( m_hwndSizeBoxPlaceholder, SW_HIDE );
+		::ShowWindow( m_hwndSizeBox, SW_SHOW );
 	}else{
-		if( NULL != m_hwndSizeBox ){
-			::DestroyWindow( m_hwndSizeBox );
-			m_hwndSizeBox = NULL;
-		}
-		m_hwndSizeBox = ::CreateWindowEx(
-			0L,														/* no extended styles */
-			_T("STATIC"),											/* scroll bar control class */
-			NULL,													/* text for window title bar */
-			WS_VISIBLE | WS_CHILD /*| SBS_SIZEBOX | SBS_SIZEGRIP*/, /* scroll bar styles */
-			0,														/* horizontal position */
-			0,														/* vertical position */
-			200,													/* width of the scroll bar */
-			CW_USEDEFAULT,											/* default height */
-			GetHwnd(),													/* handle of main window */
-			(HMENU) NULL,											/* no menu for a scroll bar */
-			G_AppInstance(),											/* instance owning this window */
-			(LPVOID) NULL											/* pointer not needed */
-		);
+		::ShowWindow( m_hwndSizeBox, SW_HIDE );
+		::ShowWindow( m_hwndSizeBoxPlaceholder, SW_SHOW );
 	}
-	::ShowWindow( m_hwndSizeBox, SW_SHOW );
 
 	::GetClientRect( GetHwnd(), &rc );
 	OnSize( rc.right, rc.bottom );

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -638,6 +638,7 @@ public:
 	int				m_nVScrollRate;		/* 垂直スクロールバーの縮尺 */
 	HWND			m_hwndHScrollBar;	/* 水平スクロールバーウィンドウハンドル */
 	HWND			m_hwndSizeBox;		/* サイズボックスウィンドウハンドル */
+	HWND			m_hwndSizeBoxPlaceholder;	/* サイズボックス代替スタティックウィンドウハンドル */
 	CSplitBoxWnd*	m_pcsbwVSplitBox;	/* 垂直分割ボックス */
 	CSplitBoxWnd*	m_pcsbwHSplitBox;	/* 水平分割ボックス */
 	CAutoScrollWnd	m_cAutoScrollWnd;	//!< オートスクロール

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -93,35 +93,11 @@ BOOL CEditView::CreateScrollBar()
 
 	/* サイズボックス */
 	if( GetDllShareData().m_Common.m_sWindow.m_nFUNCKEYWND_Place == 0 ){	/* ファンクションキー表示位置／0:上 1:下 */
-		m_hwndSizeBox = ::CreateWindowEx(
-			WS_EX_CONTROLPARENT/*0L*/, 			/* no extended styles */
-			_T("SCROLLBAR"),					/* scroll bar control class */
-			NULL,								/* text for window title bar */
-			WS_VISIBLE | WS_CHILD | SBS_SIZEBOX | SBS_SIZEGRIP, /* scroll bar styles */
-			0,									/* horizontal position */
-			0,									/* vertical position */
-			200,								/* width of the scroll bar */
-			CW_USEDEFAULT,						/* default height */
-			GetHwnd(), 							/* handle of main window */
-			(HMENU) NULL,						/* no menu for a scroll bar */
-			G_AppInstance(),						/* instance owning this window */
-			(LPVOID) NULL						/* pointer not needed */
-		);
+		::ShowWindow( m_hwndSizeBoxPlaceholder, SW_HIDE );
+		::ShowWindow( m_hwndSizeBox, SW_SHOW );
 	}else{
-		m_hwndSizeBox = ::CreateWindowEx(
-			0L, 								/* no extended styles */
-			_T("STATIC"),						/* scroll bar control class */
-			NULL,								/* text for window title bar */
-			WS_VISIBLE | WS_CHILD/* | SBS_SIZEBOX | SBS_SIZEGRIP*/, /* scroll bar styles */
-			0,									/* horizontal position */
-			0,									/* vertical position */
-			200,								/* width of the scroll bar */
-			CW_USEDEFAULT,						/* default height */
-			GetHwnd(), 							/* handle of main window */
-			(HMENU) NULL,						/* no menu for a scroll bar */
-			G_AppInstance(),						/* instance owning this window */
-			(LPVOID) NULL						/* pointer not needed */
-		);
+		::ShowWindow( m_hwndSizeBox, SW_HIDE );
+		::ShowWindow( m_hwndSizeBoxPlaceholder, SW_SHOW );
 	}
 	return TRUE;
 }
@@ -145,11 +121,8 @@ void CEditView::DestroyScrollBar()
 		m_hwndHScrollBar = NULL;
 	}
 
-	if( m_hwndSizeBox )
-	{
-		::DestroyWindow( m_hwndSizeBox );
-		m_hwndSizeBox = NULL;
-	}
+	::ShowWindow( m_hwndSizeBox, SW_HIDE );
+	::ShowWindow( m_hwndSizeBoxPlaceholder, SW_HIDE );
 }
 
 /*! 垂直スクロールバーメッセージ処理


### PR DESCRIPTION
ウィンドウの分割表示中にリサイズする度にサイズボックスのウィンドウを毎回再作成していて勿体ないなと思ったので、表示非表示を切り替える方式に変更しました。

なおサイズボックスの代わりに空表示用にスタティックウィンドウの表示も行いますが、そのウィンドウのハンドル用のメンバー名は `m_hwndSizeBoxPlaceholder` にしました。