### PR TITLE
CHANGELOG.md の生成方法や取得方法を簡単に参照できるように markdown に説明を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ https://ci.appveyor.com/project/sakuraeditor/sakura/history
 ダウンロードした `CHANGELOG.md` は
 [Markdown をローカルで確認する方法](https://github.com/sakura-editor/sakura/wiki/markdown-%E3%82%92%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E3%81%A7%E7%A2%BA%E8%AA%8D%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
 で説明している手順でローカルで確認できます。 
+
+[CHANGELOG.mdについて](https://github.com/sakura-editor/sakura/wiki/CHANGELOG.md%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6) のページに`CHANGELOG.md` に関する説明を記載しています。

--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ https://ci.appveyor.com/project/sakuraeditor/sakura/history
 
 [生成した CHANGELOG.md は ここからダウンロードできます](https://ci.appveyor.com/project/sakuraeditor/changelog-sakura/branch/master/artifacts) 
 
-ダウンロードした `CHANGELOG.md` は [changelog-sakura の README.md](https://github.com/sakura-editor/changelog-sakura) の記載の方法でローカルで確認できます。 
+ダウンロードした `CHANGELOG.md` は [changelog-sakura の README.md](https://github.com/sakura-editor/changelog-sakura) の方法でローカルで確認できます。 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
             - [master の 最新以外](#master-の-最新以外)
         - [単体テスト](#単体テスト)
         - [デバッグ方法](#デバッグ方法)
-
+        - [変更履歴](#変更履歴)
 <!-- /TOC -->
 
 A free Japanese text editor for Windows
@@ -108,3 +108,12 @@ https://ci.appveyor.com/project/sakuraeditor/sakura/history
 
 - [タスクトレイのメニュー項目のデバッグ方法](debug-tasktray-menu.md) を参照
 - [大きなファイルの作成方法](create-big-file.md)
+
+## 変更履歴
+
+変更履歴は [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) というソフトを使用して
+[changelog-sakura](https://github.com/sakura-editor/changelog-sakura) のリポジトリで [appveyor](https://ci.appveyor.com/project/sakuraeditor/changelog-sakura) で自動的に生成します。 
+
+[生成した CHANGELOG.md は ここからダウンロードできます](https://ci.appveyor.com/project/sakuraeditor/changelog-sakura/branch/master/artifacts) 
+
+ダウンロードした `CHANGELOG.md` は [changelog-sakura の README.md](https://github.com/sakura-editor/changelog-sakura) の記載の方法でローカルで確認できます。 

--- a/README.md
+++ b/README.md
@@ -116,4 +116,6 @@ https://ci.appveyor.com/project/sakuraeditor/sakura/history
 
 [生成した CHANGELOG.md は ここからダウンロードできます](https://ci.appveyor.com/project/sakuraeditor/changelog-sakura/branch/master/artifacts) 
 
-ダウンロードした `CHANGELOG.md` は [changelog-sakura の README.md](https://github.com/sakura-editor/changelog-sakura) の方法でローカルで確認できます。 
+ダウンロードした `CHANGELOG.md` は
+[Markdown をローカルで確認する方法](https://github.com/sakura-editor/sakura/wiki/markdown-%E3%82%92%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E3%81%A7%E7%A2%BA%E8%AA%8D%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
+で説明している手順でローカルで確認できます。 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
             - [master の 最新以外](#master-の-最新以外)
         - [単体テスト](#単体テスト)
         - [デバッグ方法](#デバッグ方法)
-        - [変更履歴](#変更履歴)
+    - [変更履歴](#変更履歴)
+
 <!-- /TOC -->
 
 A free Japanese text editor for Windows


### PR DESCRIPTION
CHANGELOG.md の生成方法や取得方法を簡単に参照できるように markdown に説明を追加する

関連
- https://github.com/sakura-editor/management-forum/issues/53
- https://github.com/sakura-editor/changelog-sakura/pull/1
