### PR TITLE
FORCE_POWERSHELL_ZIP オプションを削除

### DIFF
--- a/build.md
+++ b/build.md
@@ -128,31 +128,6 @@ build-sln.bat x64   Release
 build-sln.bat x64   Debug
 ```
 
-
-### Powershell によるZIPファイルの圧縮、解凍、内容確認の強制
-
-`7z.exe` へのパスが通っている場合または `C:\Program Files\7-Zip\7z.exe` が存在している場合は
-`7z.exe` を、ZIP ファイルの解凍、圧縮、内容確認に使用します。
-
-上記以外の場合は [powershell によるスクリプト](tools/zip/readme.md) により処理を行います。
-
-`7z.exe` のほうがはるかに処理速度が速いので `7z.exe` が利用可能なら [powershell によるスクリプト](tools/zip/readme.md) を
-使う理由は殆どないのですが、デバッグ目的で強制的に [powershell によるスクリプト](tools/zip/readme.md) を使用する手段を
-提供します。
-
-コマンドラインでビルドするときに事前に FORCE_POWERSHELL_ZIP を 1 に設定することにより
-強制的に [powershell によるスクリプト](tools/zip/readme.md) を使用します。
-
-コマンド実行例
-
-```
-set FORCE_POWERSHELL_ZIP=1
-build-sln.bat Win32 Release
-build-sln.bat Win32 Debug
-build-sln.bat x64   Release
-build-sln.bat x64   Debug
-```
-
 ### MinGW w64 ビルド
 
 生成されるバイナリは正しく動作しないが、MinGWでのビルドも可能。

--- a/tools/zip/find-7z.bat
+++ b/tools/zip/find-7z.bat
@@ -1,9 +1,6 @@
 @rem see readme.md
 @echo off
 set CMD_7Z=
-if "%FORCE_POWERSHELL_ZIP%" == "1" (
-	exit /b 0
-)
 set PATH_7Z_1=
 set PATH_7Z_2=
 set PATH_7Z_3=


### PR DESCRIPTION
関連: #653 

必要度の低いFORCE_POWERSHELL_ZIP を削除します。

zip系のバッチは独立性が高いためデバッグが<del>用意</del><ins>容易</ins>で、build.mdにあるような目的はほとんど不要と考えています。