### PR TITLE
GSTR_APPNAME の実体をグローバル変数に変える

### DIFF
--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -28,6 +28,32 @@
 #include "util/module.h"
 #include "debug/CRunningTimer.h"
 
+
+// アプリ名。2007.09.21 kobake 整理
+#ifdef _UNICODE
+#define _APP_NAME_(TYPE) TYPE("sakura")
+#else
+#define _APP_NAME_(TYPE) TYPE("sakura")
+#endif
+
+#ifdef _DEBUG
+#define _APP_NAME_2_(TYPE) TYPE("(デバッグ版)")
+#else
+#define _APP_NAME_2_(TYPE) TYPE("")
+#endif
+
+#ifdef ALPHA_VERSION
+#define _APP_NAME_3_(TYPE) TYPE("(Alpha Version)")
+#else
+#define _APP_NAME_3_(TYPE) TYPE("")
+#endif
+
+#define _GSTR_APPNAME_(TYPE)  _APP_NAME_(TYPE) _APP_NAME_2_(TYPE) _APP_NAME_3_(TYPE)
+
+const TCHAR g_szGStrAppName[]  = (_GSTR_APPNAME_(_T)   ); // この変数を直接参照せずに GSTR_APPNAME を使うこと
+const CHAR  g_szGStrAppNameA[] = (_GSTR_APPNAME_(ATEXT)); // この変数を直接参照せずに GSTR_APPNAME_A を使うこと
+const WCHAR g_szGStrAppNameW[] = (_GSTR_APPNAME_(LTEXT)); // この変数を直接参照せずに GSTR_APPNAME_W を使うこと
+
 /*!
 	Windows Entry point
 

--- a/sakura_core/config/app_constants.h
+++ b/sakura_core/config/app_constants.h
@@ -35,9 +35,9 @@ extern const TCHAR g_szGStrAppName[];
 extern const CHAR  g_szGStrAppNameA[];
 extern const WCHAR g_szGStrAppNameW[];
 
-#define GSTR_APPNAME    g_szGStrAppName
-#define GSTR_APPNAME_A  g_szGStrAppNameA
-#define GSTR_APPNAME_W  g_szGStrAppNameW
+#define GSTR_APPNAME    g_szGStrAppName		//!< アプリ名の文字列 (TCHAR版)
+#define GSTR_APPNAME_A  g_szGStrAppNameA	//!< アプリ名の文字列 (CHAR版)
+#define GSTR_APPNAME_W  g_szGStrAppNameW	//!< アプリ名の文字列 (UNICODE版)
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                      テキストエリア                         //

--- a/sakura_core/config/app_constants.h
+++ b/sakura_core/config/app_constants.h
@@ -31,32 +31,13 @@
 //                           名前                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-// アプリ名。2007.09.21 kobake 整理
-#ifdef _UNICODE
-	#define _APP_NAME_(TYPE) TYPE("sakura")
-#else
-	#define _APP_NAME_(TYPE) TYPE("sakura")
-#endif
+extern const TCHAR g_szGStrAppName[];
+extern const CHAR  g_szGStrAppNameA[];
+extern const WCHAR g_szGStrAppNameW[];
 
-#ifdef _DEBUG
-	#define _APP_NAME_2_(TYPE) TYPE("(デバッグ版)")
-#else
-	#define _APP_NAME_2_(TYPE) TYPE("")
-#endif
-
-#ifdef ALPHA_VERSION
-	#define _APP_NAME_3_(TYPE) TYPE("(Alpha Version)")
-#else
-	#define _APP_NAME_3_(TYPE) TYPE("")
-#endif
-
-//例:UNICODEデバッグ→_T("sakura(デバッグ版)")
-#define _GSTR_APPNAME_(TYPE)  _APP_NAME_(TYPE) _APP_NAME_2_(TYPE) _APP_NAME_3_(TYPE)
-
-#define GSTR_APPNAME    (_GSTR_APPNAME_(_T)   )
-#define GSTR_APPNAME_A  (_GSTR_APPNAME_(ATEXT))
-#define GSTR_APPNAME_W  (_GSTR_APPNAME_(LTEXT))
-
+#define GSTR_APPNAME    g_szGStrAppName
+#define GSTR_APPNAME_A  g_szGStrAppNameA
+#define GSTR_APPNAME_W  g_szGStrAppNameW
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                      テキストエリア                         //

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -259,7 +259,7 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 		m_cProfile.IOProfileData( szSecInfo, szKeyVersion, MakeStringBufferW( szKeyVersion ) );
 		int nRet = ConfirmMessage( hwndParent,
 			LS(STR_IMPEXP_VER), 
-			GSTR_APPNAME_W, szKeyVersion, nStructureVersion );
+			GSTR_APPNAME, szKeyVersion, nStructureVersion );
 		if ( IDYES != nRet ) {
 			return false;
 		}

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -259,7 +259,7 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 		m_cProfile.IOProfileData( szSecInfo, szKeyVersion, MakeStringBufferW( szKeyVersion ) );
 		int nRet = ConfirmMessage( hwndParent,
 			LS(STR_IMPEXP_VER), 
-			_APP_NAME_(LTEXT), szKeyVersion, nStructureVersion );
+			GSTR_APPNAME_W, szKeyVersion, nStructureVersion );
 		if ( IDYES != nRet ) {
 			return false;
 		}


### PR DESCRIPTION
#709: GSTR_APPNAME の実体をグローバル変数に変える

GSTR_APPNAME の実体が変わっても使用しているコードの再コンパイルが走らないようにするため。
