### PR TITLE
ウィンドウ一覧画面を開いた後にウィンドウサイズを大きくしてから閉じて開き直すとウィンドウサイズにコントロールが追従していない問題を修正

### DIFF
--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -186,7 +186,6 @@ BOOL CDlgWindowList::OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam)
 	_SetHwnd(hwndDlg);
 
 	CreateSizeBox();
-	CDialog::OnSize();
 
 	RECT rc;
 	::GetWindowRect(hwndDlg, &rc);
@@ -205,6 +204,7 @@ BOOL CDlgWindowList::OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam)
 		m_nHeight = rcDialog.bottom - rcDialog.top;
 	}
 	SetDialogPosSize();
+	OnSize(0, 0);
 
 	HWND hwndList = GetItemHwnd(IDC_LIST_WINDOW);
 	RECT rcListView;


### PR DESCRIPTION
問題の再現手順はタイトルに書いた通りです。

なお、ウィンドウ一覧画面は #687 にも関係しています。そちらの確認をしていてこの問題に気付きました。
