### PR TITLE
開いているファイル名をクリップボードにコピーする機能をデフォルトでメニューに追加する

### DIFF
--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -1348,6 +1348,9 @@ void CShareData::InitPopupMenu(DLLSHAREDATA* pShareData)
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_0;
 	rMenu.m_nCustMenuItemKeyArr [0][n] = '\0';
 	n++;
+	rMenu.m_nCustMenuItemFuncArr[0][n] = F_COPYFNAME;
+	rMenu.m_nCustMenuItemKeyArr [0][n] = 'F';
+	n++;
 	rMenu.m_nCustMenuItemFuncArr[0][n] = F_COPYPATH;
 	rMenu.m_nCustMenuItemKeyArr [0][n] = '\\';
 	n++;
@@ -1416,6 +1419,9 @@ void CShareData::InitPopupMenu(DLLSHAREDATA* pShareData)
 	n++;
 	rMenu.m_nCustMenuItemFuncArr[CUSTMENU_INDEX_FOR_TABWND][n] = F_0;
 	rMenu.m_nCustMenuItemKeyArr [CUSTMENU_INDEX_FOR_TABWND][n] = '\0';
+	n++;
+	rMenu.m_nCustMenuItemFuncArr[CUSTMENU_INDEX_FOR_TABWND][n] = F_COPYFNAME;
+	rMenu.m_nCustMenuItemKeyArr [CUSTMENU_INDEX_FOR_TABWND][n] = 'F';
 	n++;
 	rMenu.m_nCustMenuItemFuncArr[CUSTMENU_INDEX_FOR_TABWND][n] = F_COPYPATH;
 	rMenu.m_nCustMenuItemKeyArr [CUSTMENU_INDEX_FOR_TABWND][n] = '\0';


### PR DESCRIPTION
#658: 開いているファイル名をクリップボードにコピーする機能をデフォルトでメニューに追加する

機能自体は実装されていたが、デフォルトでタブメニュー、右クリックメニューに追加されていなかったので追加する。

https://github.com/sakura-editor/sakura/issues/658#issuecomment-443403110 の手順を行わなくてもメニューに追加されるようになる。
