### PR TITLE
新規インストール時に言語設定に英語を適用する処理方法の変更

### DIFF
--- a/installer/sakura-common.iss
+++ b/installer/sakura-common.iss
@@ -111,8 +111,6 @@ en.ReadyMemo_ExecProfileDir=Same as the executable file
 ja.ReadyMemo_ExecProfileDir=実行ファイルと同一ディレクトリ
 en.ReadyMemo_VirtualStoreEnable=Enable
 ja.ReadyMemo_VirtualStoreEnable=有効
-en.languageDLL=sakura_lang_en_US.dll
-ja.languageDLL=
 
 
 
@@ -248,10 +246,6 @@ FileName: "{app}\sakura.exe"; Description: "{cm:StartNow}"; WorkingDir: "{app}";
 
 [Dirs]
 Name: "{userappdata}\sakura"; Components: main; Tasks: startmenu; Check: isMultiUserEnabled
-
-[Ini]
-Filename: "{userappdata}\sakura\sakura.ini"; Section: "Common"; Key: "szLanguageDll"; String: "{cm:languageDLL}"; Check: isMultiUserEnabled
-Filename: "{app}\sakura.ini";                Section: "Common"; Key: "szLanguageDll"; String: "{cm:languageDLL}"; Check: isMultiUserDisabled
 
 [Code]
 var

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -97,7 +97,7 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 			/* 設定ファイルが存在しない */
 			LANGID langId = GetUserDefaultUILanguage();
 			// Windowsの表示言語が日本語でない場合は言語設定を英語にする
-			if (langId != 0x0411) {
+			if (langId != MAKELANGID( LANG_JAPANESE, SUBLANG_JAPANESE_JAPAN )) {
 				DLLSHAREDATA* pShareData = &GetDllShareData();
 				_tcscpy(pShareData->m_Common.m_sWindow.m_szLanguageDll, L"sakura_lang_en_US.dll");
 				cProfile.IOProfileData( L"Common", L"szLanguageDll", MakeStringBufferT( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -68,7 +68,6 @@ void CShareData_IO::SaveShareData()
 
 	@param[in] bRead true: 読み込み / false: 書き込み
 	@return 設定データの読み込み/保存が成功したかどうか
-	@note 読み込みの場合、言語設定切り替え後にMRUエントリが無い場合は新規インストール後とみなし false を返す事で初期設定を適用させる
 
 	@date 2004-01-11 D.S.Koba CProfile変更によるコード簡略化
 	@date 2005-04-05 D.S.Koba 各セクションの入出力を関数として分離
@@ -96,6 +95,15 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 	if( bRead ){
 		if( !cProfile.ReadProfile( szIniFileName ) ){
 			/* 設定ファイルが存在しない */
+			LANGID langId = GetUserDefaultUILanguage();
+			// Windowsの表示言語が日本語でない場合は言語設定を英語にする
+			if (langId != 0x0411) {
+				DLLSHAREDATA* pShareData = &GetDllShareData();
+				_tcscpy(pShareData->m_Common.m_sWindow.m_szLanguageDll, L"sakura_lang_en_US.dll");
+				cProfile.IOProfileData( L"Common", L"szLanguageDll", MakeStringBufferT( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );
+				CSelectLang::ChangeLang( pShareData->m_Common.m_sWindow.m_szLanguageDll );
+				pcShare->RefreshString();
+			}
 			return false;
 		}
 
@@ -126,14 +134,6 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 		cProfile.IOProfileData( L"Common", L"szLanguageDll", MakeStringBufferT( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );
 		CSelectLang::ChangeLang( pShareData->m_Common.m_sWindow.m_szLanguageDll );
 		pcShare->RefreshString();
-
-		// 新規インストール後の設定ファイルは言語設定しか存在しない
-		// MRUのエントリが無い場合は新規と判断
-		int _MRU_Counts = 0;
-		if (!cProfile.IOProfileData( LTEXT("MRU"), LTEXT("_MRU_Counts"), _MRU_Counts )){
-			// 言語設定の切り替えだけして false を返す事で初期設定を適用させる
-			return false;
-		}
 	}
 
 	// Feb. 12, 2006 D.S.Koba


### PR DESCRIPTION
このPRでは下記の3つの変更を加えています。

- インストーラーで言語設定の為だけに不完全なINIファイルを作成するのはプログラム側が不完全なINIファイルに対応するのが難しいので止める

- `設定ファイルのMRUのエントリが無い場合に新規インストール後と判断して初期設定を適用させる` 処理の記述は削除する

- `起動時に設定ファイルが存在しない場合はWindowsの表示言語を調べて日本語じゃなかった場合はサクラエディタの言語設定を英語にする` 処理を新規追加

#616 の問題に対処する為に #620 で変更を加えましたが、新規インストールの判定方法が微妙なのでこのPRのやり方に変えたいです。