### PR TITLE
grep で 除外ファイル、除外フォルダが効かない問題を修正するため、除外パターンを指定するコマンドラインを復活する

### DIFF
--- a/help/sakura/_RESOURCE/HLP000109.html
+++ b/help/sakura/_RESOURCE/HLP000109.html
@@ -85,6 +85,8 @@ Windows‚Ì‹N“®‚Æ“¯Žž‚ÉƒTƒNƒ‰ƒGƒfƒBƒ^‚ðí’“‚µ‚½‚¢ê‡AƒVƒ‡[ƒgƒJƒbƒg‚ÌƒvƒƒpƒeƒB‚
 <tr><td>-GREPDLG</td><td>ƒTƒNƒ‰ƒGƒfƒBƒ^‚ª‹N“®‚·‚é‚Æ“¯Žž‚ÉGrepƒ_ƒCƒAƒƒO‚ð•\Ž¦‚µ‚Ü‚·B<br></td></tr>
 <tr><td>-GCODE=</td><td>Grep‚Å‚Ì•¶ŽšƒR[ƒh‚ðŽw’è‚µ‚Ü‚·B<br>-CODE‚Æ“¯‚¶‚æ‚¤‚É”Žš‚ÅŽw’è‚µ‚Ü‚·B</td></tr>
 <tr><td>-GOPT=</td><td>Grep‚ÌŒŸõðŒ<br>[S][L][R][P][W][1|2|3][K][F][B][G][X][C][O][U][H]</td></tr>
+<tr><td>-GEXCLUDEFILE=</td><td>Grep‚ÌœŠOƒtƒ@ƒCƒ‹ (sakura:2.4.0.0ˆÈ~)<br></td></tr>
+<tr><td>-GEXCLUDEFOLDER=</td><td>Grep‚ÌœŠOƒtƒHƒ‹ƒ_ (sakura:2.4.0.0ˆÈ~)<br></td></tr>
 </table>
 <br>
 -GOPT‚ÌƒIƒvƒVƒ‡ƒ“<br>

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -57,6 +57,8 @@
 #define CMDLINEOPT_M			106  //!< 起動時に実行するマクロのファイル名を指定
 #define CMDLINEOPT_MTYPE		107  //!< マクロの種類を拡張子名で指定
 #define CMDLINEOPT_GREPR		108  //!< Grepの置換文字列
+#define CMDLINEOPT_GEXCLUDEFILE		109  //!< Grepの検索除外のファイル
+#define CMDLINEOPT_GEXCLUDEFOLDER	110  //!< Grepの検索除外のフォルダ
 #define CMDLINEOPT_GROUP		500  //!< タブモードのグループを指定して開く
 #define CMDLINEOPT_PROF			501  //!< プロファイルを選択
 #define CMDLINEOPT_PROFMGR		502  //!< プロファイルマネージャを起動時に表示
@@ -124,6 +126,8 @@ int CCommandLine::CheckCommandLine(
 		{_T("GREPR"),	5,			CMDLINEOPT_GREPR, true},
 		{_T("GFILE"),	5,			CMDLINEOPT_GFILE, false},
 		{_T("GFOLDER"),	7,			CMDLINEOPT_GFOLDER, false},
+		{_T("GEXCLUDEFILE"),	12,	CMDLINEOPT_GEXCLUDEFILE, false},
+		{_T("GEXCLUDEFOLDER"),	14,	CMDLINEOPT_GEXCLUDEFOLDER, false},
 		{_T("GOPT"),	4,			CMDLINEOPT_GOPT, false},
 		{_T("GCODE"),	5,			CMDLINEOPT_GCODE, false},	// 2002/09/21 Moca 追加
 		{_T("GROUP"),	5,			CMDLINEOPT_GROUP, false},	// 2007.06.26 ryoji
@@ -413,6 +417,14 @@ void CCommandLine::ParseCommandLine( LPCTSTR pszCmdLineSrc, bool bResponse )
 			case CMDLINEOPT_GFOLDER:	//	GFOLDER
 				m_gi.cmGrepFolder.SetString( arg,  lstrlen( arg ) );
 				m_gi.cmGrepFolder.Replace( _T("\"\""), _T("\"") );
+				break;
+			case CMDLINEOPT_GEXCLUDEFILE:	//	GEXCLUDEFILE
+				m_gi.cmExcludeFile.SetString(arg, lstrlen(arg));
+				m_gi.cmExcludeFile.Replace(_T("\"\""), _T("\""));
+				break;
+			case CMDLINEOPT_GEXCLUDEFOLDER:	//	GEXCLUDEFOLDER
+				m_gi.cmExcludeFolder.SetString(arg, lstrlen(arg));
+				m_gi.cmExcludeFolder.Replace(_T("\"\""), _T("\""));
 				break;
 			case CMDLINEOPT_GOPT:	//	GOPT
 				for( ; *arg != '\0' ; ++arg ){

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -128,6 +128,13 @@ void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep&
 	cCmdLine.AppendString(cmWork2.GetStringPtr());
 	cCmdLine.AppendString(_T("\" -GFOLDER=\""));
 	cCmdLine.AppendString(cmWork3.GetStringPtr());
+
+	cCmdLine.AppendString(_T("\" -GEXCLUDEFILE=\""));
+	cCmdLine.AppendString(cmWorkExcludeFile.GetStringPtr());
+
+	cCmdLine.AppendString(_T("\" -GEXCLUDEFOLDER=\""));
+	cCmdLine.AppendString(cmWorkExcludeFolder.GetStringPtr());
+
 	cCmdLine.AppendString(_T("\" -GCODE="));
 	auto_sprintf( szTemp, _T("%d"), cDlgGrep.m_nGrepCharSet );
 	cCmdLine.AppendString(szTemp);


### PR DESCRIPTION
#743: grep で 除外ファイル、除外フォルダが効かない問題を修正するため、除外パターンを指定するコマンドラインを復活する

https://github.com/sakura-editor/sakura/issues/743#issuecomment-451342139

