### PR TITLE
Copyright を 2019 にする

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ﻿zlib License
 
-Copyright (C) 2018 Sakura Editor Organization
+Copyright (C) 2018-2019 Sakura Editor Organization
 
 This software is provided 'as-is', without any express or implied
 warranty.  In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFile.cpp
+++ b/sakura_core/recent/CRecentExcludeFile.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018 Sakura Editor Organization
+	Copyright (C) 2018-2019 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFile.h
+++ b/sakura_core/recent/CRecentExcludeFile.h
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018 Sakura Editor Organization
+	Copyright (C) 2018-2019 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFolder.cpp
+++ b/sakura_core/recent/CRecentExcludeFolder.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018 Sakura Editor Organization
+	Copyright (C) 2018-2019 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFolder.h
+++ b/sakura_core/recent/CRecentExcludeFolder.h
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018 Sakura Editor Organization
+	Copyright (C) 2018-2019 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -37,7 +37,7 @@
 LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
 #endif //_WIN32
 
-#define	S_COPYRIGHT	"Copyright (C) 1998-2018  by Norio Nakatani & Collaborators"
+#define	S_COPYRIGHT	"Copyright (C) 1998-2019  by Norio Nakatani & Collaborators"
 #define FL_VER		PR_VER
 #define FL_VER_STR	PR_VER_STR
 

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -39,8 +39,8 @@
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
 #endif //_WIN32
 
-#define	S_COPYRIGHT				"Copyright (C) 1998-2018  by Norio Nakatani & Collaborators"
-#define	S_COPYRIGHT_TRANSLATION	"Copyright (C) 2011-2018  by Lucien & Collaborators"
+#define	S_COPYRIGHT				"Copyright (C) 1998-2019  by Norio Nakatani & Collaborators"
+#define	S_COPYRIGHT_TRANSLATION	"Copyright (C) 2011-2019  by Lucien & Collaborators"
 #define FL_VER		PR_VER
 #define FL_VER_STR	PR_VER_STR
 


### PR DESCRIPTION
[リマインダー](https://github.com/sakura-editor/sakura/pull/232#issuecomment-452304781) が来たので  Copyright を 2019 にする

`LICENSE` の年で開始の年を変えていいものか不明だったのでそのままにしている。

