### PR TITLE
背景塗りつぶしにPatBltを使う Part1

### DIFF
--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -479,15 +479,18 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 		// 背景描画
 		if( pUrlWnd->m_bHilighted ){
 			// ハイライト時背景描画
-			SetBkColor( hdc, RGB( 0xff, 0xff, 0 ) );
-			::ExtTextOutW_AnyBuild( hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL );
+			HBRUSH brush = ::CreateSolidBrush( RGB( 0xff, 0xff, 0 ) );
+			HGDIOBJ brushOld = ::SelectObject( hdc, brush );
+			::PatBlt( hdc, rc.left, rc.top, rc.right, rc.bottom, PATCOPY );
+			::SelectObject( hdc, brushOld );
+			::DeleteObject( brush );
 		}else{
 			// 親にWM_CTLCOLORSTATICを送って背景ブラシを取得し、背景描画する
 			HBRUSH hbr;
 			HBRUSH hbrOld;
 			hbr = (HBRUSH)SendMessageAny( GetParent( hWnd ), WM_CTLCOLORSTATIC, wParam, (LPARAM)hWnd );
 			hbrOld = (HBRUSH)SelectObject( hdc, hbr );
-			FillRect( hdc, &rc, hbr );
+			::PatBlt( hdc, rc.left, rc.top, rc.right, rc.bottom, PATCOPY );
 			SelectObject( hdc, hbrOld );
 		}
 		return (LRESULT)1;


### PR DESCRIPTION
## 目的

背景塗りつぶしに使うAPIを変更します。

まずは、試しに1箇所だけ変更して、どのような違いになるのかを示します。
根拠説明のところで、変更すべき状況を示すので、横展開は別PRとするつもりです。

## 経緯

描画速度は FillRect > ExtTextOut > PatBlt と言われています。
サクラエディタでは元々 ExtTextOut を改変した独自関数を使っています。

各関数の概要は以下のとおりです。

関数名 | 本来の用途 | 必要なパラメータ | 速度
-- | -- | -- | -- 
FillRect | 領域の塗りつぶし | ブラシハンドル | 低
ExtTextOut | 文字列の描画 | なし(事前に背景色を設定する) | 中
PatBlt | ブラシパターンの転送 | ブラシハンドル | 高

ExtTextOut関数は文字列描画が目的の関数ですが、渡した矩形領域を塗りつぶす機能があります。
サクラエディタの塗りつぶし処理のほとんどは、空文字列をExtTextOut関数に渡すことで行われています。

## 根拠説明

プログラムを変更するには一定の根拠が必要だと思います。

**FillRectよりPatBltのが速い？そんなの常識じゃん？** で突き進むのはなんか違うと思います。
形式的にでも相応の根拠が必要だと思ったので、探してみました。

とりあえずググってみるとこんなページがヒットします。
  [テテのつぶやき - ベンチマークテスト(長方形の単色塗りつぶし)](http://tete009.seesaa.net/article/19578707.html)

ベンチマークテストの実施条件と結果が載っています。
（GetDCでデスクトップのDCを取得し、5000回ずつ塗りつぶしさせた結果を比較）

せっかく実施条件が書いてあるので [検証資材](https://github.com/sakura-editor/sandbox/commit/70de4e37a0a47b36d30cfca9473a8e77bda5cefb) を作って似た検証ができるようにしてみました。
サクラエディタの事情で検証内容を少し変えていますが、以下が実行結果です。

速度考慮 | FillRect | ExtTextOut | PatBlt(PATCOPY)
-- | -- | -- | --
なし | 1,454,860,380 | 7,179,924 | 6,216,724
あり | 1,435,629,087 | 5,075,016 | 5,368,788

「速度考慮」の有無は、該当関数を使うための準備(オブジェクト生成等)を
ループの外で行うか中で行うかの違いです。

速度考慮なしでPatBltが最速、
速度考慮ありでExtTextOutが最速
という結果になりました。

サクラエディタの塗りつぶしは、基本ExtTextOutになっています。
過去の開発者も似たような感じで「ExtTextOut最速じゃん！」ってなったんだと思います。

ただ、ExtTextOutが最速なのは「下準備を行わない場合」です。
背景塗りつぶしのためにExtTextOut関数を使うにあたっての下準備はSetBkColorの呼出です。
他の理由でSetBkColorを呼出済みの状態から塗り潰す場合はExtTextOutでいいんですが、
単純に背景色を指定して塗りつぶしたい場合はPatBltのほうが速いです。

つまり、
**SetBkColorとセットで呼び出しているExtTextOut**は
変更した方が「（速度効果的に）良い」になります。

## このPRの確認方法

バージョン情報ダイアログのURL部分を変更しています。
URL部分のウインドウにカーソルを当てた時に背景色を変更する処理です。
デバッグ版ビルドで確認すると以下のような違いを確認できます。

変更前）URL部分にカーソルを当てると背景色が黄色になり、左上に黒点が打たれる
変更後）URL部分にカーソルを当てると背景色が黄色になり、黒点は打たれない

変更前が黒点を打つ挙動はvista向けのデバッグ仕様だそうです。