### PR TITLE
背景塗りつぶしにPatBltを使う Part2

### DIFF
--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3223,9 +3223,6 @@ INT_PTR CDlgFuncList::OnNcPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 	rc = rcScr;
 	::OffsetRect( &rc, -rcScr.left, -rcScr.top );
 
-	// 背景を描画する
-	//::FillRect( gr, &rc, (HBRUSH)(COLOR_3DFACE + 1) );
-
 	// 分割線を描画する
 	rcWk = rc;
 	switch( eDockSide ){
@@ -3234,7 +3231,7 @@ INT_PTR CDlgFuncList::OnNcPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 	case DOCKSIDE_RIGHT:	rcWk.right = rcWk.left + DOCK_SPLITTER_WIDTH; break;
 	case DOCKSIDE_BOTTOM:	rcWk.bottom = rcWk.top + DOCK_SPLITTER_WIDTH; break;
 	}
-	::FillRect( gr, &rcWk, (HBRUSH)(COLOR_3DFACE + 1) );
+	::MyFillRect( gr, rcWk, COLOR_3DFACE );
 	::DrawEdge( gr, &rcWk, EDGE_ETCHED, BF_TOPLEFT );
 
 	// タイトルを描画する
@@ -3259,7 +3256,7 @@ INT_PTR CDlgFuncList::OnNcPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 		nClrCaption = ( bActive? COLOR_GRADIENTACTIVECAPTION: COLOR_GRADIENTINACTIVECAPTION );
 	else
 		nClrCaption = ( bActive? COLOR_ACTIVECAPTION: COLOR_INACTIVECAPTION );
-	::FillRect( gr, &rcWk, ::GetSysColorBrush( nClrCaption ) );
+	::MyFillRect( gr, rcWk, nClrCaption );
 	::DrawEdge( gr, &rcCaption, BDR_SUNKENOUTER, BF_TOP );
 
 	// タイトル上のボタンを描画する
@@ -3290,7 +3287,7 @@ INT_PTR CDlgFuncList::OnNcPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 		int nClrCaptionText;
 		// マウスカーソルがボタン上にあればハイライト
 		if( ::PtInRect( &rcBtn, pt ) ){
-			::FillRect( gr, &rcBtn, ::GetSysColorBrush( (bGradient && !bActive)? COLOR_INACTIVECAPTION: COLOR_ACTIVECAPTION ) );
+			::MyFillRect( gr, rcBtn, (bGradient && !bActive)? COLOR_INACTIVECAPTION: COLOR_ACTIVECAPTION );
 			nClrCaptionText = ( (bGradient && !bActive)? COLOR_INACTIVECAPTIONTEXT: COLOR_CAPTIONTEXT );
 		}else{
 			nClrCaptionText = ( bActive? COLOR_CAPTIONTEXT: COLOR_INACTIVECAPTIONTEXT );

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -43,6 +43,7 @@
 #include "dlg/CDlgCancel.h" /// 2002/2/3 aroka from here
 #include "dlg/CDlgInput1.h" /// 2007.02.11 Moca
 #include "CEditApp.h"
+#include "uiparts/CGraphics.h"
 #include "util/window.h"
 #include "util/shell.h"
 #include "env/CSakuraEnvironment.h"
@@ -145,7 +146,7 @@ LRESULT CPrintPreview::OnPaint(
 		::GetClientRect( hwnd, &bmpRc );
 		bmpRc.right  = (bmpRc.right  * m_nbmpCompatScale) / COMPAT_BMP_BASE;
 		bmpRc.bottom = (bmpRc.bottom * m_nbmpCompatScale) / COMPAT_BMP_BASE;
-		::FillRect( hdc, &bmpRc, (HBRUSH)::GetStockObject( GRAY_BRUSH ) );
+		::MyFillRect( hdc, bmpRc, (HBRUSH)::GetStockObject( GRAY_BRUSH ) );
 	}
 
 	// ツールバー高さ -> nToolBarHeight

--- a/sakura_core/typeprop/CDlgSameColor.cpp
+++ b/sakura_core/typeprop/CDlgSameColor.cpp
@@ -284,13 +284,13 @@ BOOL CDlgSameColor::OnDrawItem( WPARAM wParam, LPARAM lParam )
 	rc = pDis->rcItem;
 
 	// アイテム矩形塗りつぶし
-	::FillRect( gr, &pDis->rcItem, ::GetSysColorBrush( COLOR_WINDOW ) );
+	::MyFillRect( gr, pDis->rcItem, COLOR_WINDOW );
 
 	// アイテムが選択状態
 	if( pDis->itemState & ODS_SELECTED ){
 		rc = pDis->rcItem;
 		rc.left += (rc.bottom - rc.top);
-		::FillRect( gr, &rc, ::GetSysColorBrush( COLOR_HIGHLIGHT ) );
+		::MyFillRect( gr, rc, COLOR_HIGHLIGHT );
 	}
 
 	// アイテムにフォーカスがある
@@ -415,9 +415,7 @@ LRESULT CALLBACK CDlgSameColor::ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, 
 		// 親にWM_CTLCOLORSTATICを送って背景ブラシを取得し、背景描画する
 		{
 			HBRUSH	hBrush = (HBRUSH)::SendMessageAny( GetParent( hwnd ), WM_CTLCOLORSTATIC, wParam, (LPARAM)hwnd );
-			HBRUSH	hBrushOld = (HBRUSH)::SelectObject( hDC, hBrush );
-			::FillRect( hDC, &rc, hBrush );
-			::SelectObject( hDC, hBrushOld );
+			::MyFillRect( hDC, rc, hBrush );
 		}
 		return (LRESULT)1;
 

--- a/sakura_core/uiparts/CGraphics.h
+++ b/sakura_core/uiparts/CGraphics.h
@@ -30,7 +30,77 @@
 */
 
 #include <Windows.h>
+#include <cassert>
 #include <vector>
+
+/*!
+ * @brief API関数FillRectの高速版(ブラシ用)
+ *
+ * @param [in] hDC デバイスコンテキスト
+ * @param [in] rc 塗りつぶし対象の矩形
+ * @param [in] hBrush 塗りつぶしに使うブラシハンドル
+ */
+inline bool MyFillRect( const HDC hDC, const RECT &rc, const HBRUSH hBrush ) noexcept
+{
+	assert( hDC );
+	assert( hBrush );
+	assert( !IS_INTRESOURCE( hBrush ) );
+
+	if ( !hDC || IS_INTRESOURCE( hBrush ) ) return false;
+
+	HGDIOBJ hBrushOld = ::SelectObject( hDC, hBrush );
+	if ( hBrushOld == HGDI_ERROR ) return false;
+
+	int retPatBlt = ::PatBlt( hDC, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, PATCOPY );
+	::SelectObject( hDC, hBrushOld );
+
+	return retPatBlt != 0;
+}
+
+/*!
+ * @brief API関数FillRectの高速版(カラーインデックス用)
+ *
+ * @param [in] hDC デバイスコンテキスト
+ * @param [in] rc 塗りつぶし対象の矩形
+ * @param [in] sysColor システムカラーのインデックス
+ */
+inline bool MyFillRect( const HDC hDC, const RECT &rc, const int sysColor ) noexcept
+{
+	assert( hDC );
+	assert( sysColor );
+	assert( IS_INTRESOURCE( sysColor ) );
+
+	if ( !hDC || !IS_INTRESOURCE( sysColor ) ) return false;
+
+	HBRUSH hBrush = ::GetSysColorBrush( sysColor );
+	if ( hBrush == NULL ) return false;
+
+	bool retMyFillRect = MyFillRect( hDC, rc, hBrush );
+
+	return retMyFillRect;
+}
+
+/*!
+ * @brief API関数FillRectの高速版(色指定用)
+ *
+ * @param [in] hDC デバイスコンテキスト
+ * @param [in] rc 塗りつぶし対象の矩形
+ * @param [in] color 塗りつぶし色
+ */
+inline bool MyFillRect( const HDC hDC, const RECT &rc, const COLORREF color ) noexcept
+{
+	assert( hDC );
+
+	if ( !hDC ) return false;
+
+	HBRUSH hBrush = ::CreateSolidBrush( color );
+	if ( hBrush == NULL ) return false;
+
+	bool retMyFillRect = MyFillRect( hDC, rc, hBrush );
+	::DeleteObject( hBrush );
+
+	return retMyFillRect;
+}
 
 //! オリジナル値保存クラス
 template <class T>
@@ -71,9 +141,6 @@ struct SFONT {
 	SFontAttr	m_sFontAttr;
 	HFONT		m_hFont;      //!< フォントハンドル
 };
-
-// 先行定義
-inline bool MyFillRect( const HDC hDC, const RECT &rc, const HBRUSH hBrush ) noexcept;
 
 //! 描画管理
 //最新実装：ブラシ
@@ -264,63 +331,6 @@ private:
 	HBRUSH				m_hbrCurrent;
 	bool				m_bDynamicBrush;	//m_hbrCurrentを動的に作成した場合はtrue
 };
-
-/*!
- * @brief API関数FillRectの高速版(ブラシ用)
- *
- * @param [in] hDC デバイスコンテキスト
- * @param [in] rc 塗りつぶし対象の矩形
- * @param [in] hBrush 塗りつぶしに使うブラシハンドル
- */
-inline bool MyFillRect( const HDC hDC, const RECT &rc, const HBRUSH hBrush ) noexcept
-{
-	assert( hDC );
-	assert( hBrush );
-	assert( !IS_INTRESOURCE( hBrush ) );
-
-	HGDIOBJ hBrushOld = ::SelectObject( hDC, hBrush );
-	int retPatBlt = ::PatBlt( hDC, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, PATCOPY );
-	::SelectObject( hDC, hBrushOld );
-
-	return retPatBlt != 0;
-}
-
-/*!
- * @brief API関数FillRectの高速版(カラーインデックス用)
- *
- * @param [in] hDC デバイスコンテキスト
- * @param [in] rc 塗りつぶし対象の矩形
- * @param [in] sysColor システムカラーのインデックス
- */
-inline bool MyFillRect( const HDC hDC, const RECT &rc, const int sysColor ) noexcept
-{
-	assert( hDC );
-	assert( sysColor );
-	assert( IS_INTRESOURCE( sysColor ) );
-
-	HBRUSH hBrush = ::GetSysColorBrush( sysColor );
-	bool retMyFillRect = MyFillRect( hDC, rc, hBrush );
-
-	return retMyFillRect;
-}
-
-/*!
- * @brief API関数FillRectの高速版(色指定用)
- *
- * @param [in] hDC デバイスコンテキスト
- * @param [in] rc 塗りつぶし対象の矩形
- * @param [in] color 塗りつぶし色
- */
-inline bool MyFillRect( const HDC hDC, const RECT &rc, const COLORREF color ) noexcept
-{
-	assert( hDC );
-
-	HBRUSH hBrush = ::CreateSolidBrush( color );
-	bool retMyFillRect = MyFillRect( hDC, rc, hBrush );
-	::DeleteObject( hBrush );
-
-	return retMyFillRect;
-}
 
 #endif /* SAKURA_CGRAPHICS_BA5156BF_99C6_4854_8131_CE8B091A5EFF9_H_ */
 /*[EOF]*/

--- a/sakura_core/uiparts/CGraphics.h
+++ b/sakura_core/uiparts/CGraphics.h
@@ -44,9 +44,8 @@ inline bool MyFillRect( const HDC hDC, const RECT &rc, const HBRUSH hBrush ) noe
 {
 	assert( hDC );
 	assert( hBrush );
-	assert( !IS_INTRESOURCE( hBrush ) );
 
-	if ( !hDC || IS_INTRESOURCE( hBrush ) ) return false;
+	if ( !hDC || !hBrush ) return false;
 
 	HGDIOBJ hBrushOld = ::SelectObject( hDC, hBrush );
 	if ( hBrushOld == HGDI_ERROR ) return false;
@@ -67,9 +66,8 @@ inline bool MyFillRect( const HDC hDC, const RECT &rc, const HBRUSH hBrush ) noe
 inline bool MyFillRect( const HDC hDC, const RECT &rc, const int sysColor ) noexcept
 {
 	assert( hDC );
-	assert( IS_INTRESOURCE( sysColor ) );
 
-	if ( !hDC || !IS_INTRESOURCE( sysColor ) ) return false;
+	if ( !hDC ) return false;
 
 	HBRUSH hBrush = ::GetSysColorBrush( sysColor );
 	if ( hBrush == NULL ) return false;

--- a/sakura_core/uiparts/CGraphics.h
+++ b/sakura_core/uiparts/CGraphics.h
@@ -67,7 +67,6 @@ inline bool MyFillRect( const HDC hDC, const RECT &rc, const HBRUSH hBrush ) noe
 inline bool MyFillRect( const HDC hDC, const RECT &rc, const int sysColor ) noexcept
 {
 	assert( hDC );
-	assert( sysColor );
 	assert( IS_INTRESOURCE( sysColor ) );
 
 	if ( !hDC || !IS_INTRESOURCE( sysColor ) ) return false;

--- a/sakura_core/uiparts/CGraphics.h
+++ b/sakura_core/uiparts/CGraphics.h
@@ -262,5 +262,62 @@ private:
 	bool				m_bDynamicBrush;	//m_hbrCurrentを動的に作成した場合はtrue
 };
 
+/*!
+ * @brief API関数FillRectの高速版(ブラシ用)
+ *
+ * @param [in] hDC デバイスコンテキスト
+ * @param [in] rc 塗りつぶし対象の矩形
+ * @param [in] hBrush 塗りつぶしに使うブラシハンドル
+ */
+inline bool MyFillRect( const HDC hDC, const RECT &rc, const HBRUSH hBrush ) noexcept
+{
+	assert( hDC );
+	assert( hBrush );
+	assert( !IS_INTRESOURCE( hBrush ) );
+
+	HGDIOBJ hBrushOld = ::SelectObject( hDC, hBrush );
+	int retPatBlt = ::PatBlt( hDC, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, PATCOPY );
+	::SelectObject( hDC, hBrushOld );
+
+	return retPatBlt != 0;
+}
+
+/*!
+ * @brief API関数FillRectの高速版(カラーインデックス用)
+ *
+ * @param [in] hDC デバイスコンテキスト
+ * @param [in] rc 塗りつぶし対象の矩形
+ * @param [in] sysColor システムカラーのインデックス
+ */
+inline bool MyFillRect( const HDC hDC, const RECT &rc, const int sysColor ) noexcept
+{
+	assert( hDC );
+	assert( sysColor );
+	assert( IS_INTRESOURCE( sysColor ) );
+
+	HBRUSH hBrush = ::GetSysColorBrush( sysColor );
+	bool retMyFillRect = MyFillRect( hDC, rc, hBrush );
+
+	return retMyFillRect;
+}
+
+/*!
+ * @brief API関数FillRectの高速版(色指定用)
+ *
+ * @param [in] hDC デバイスコンテキスト
+ * @param [in] rc 塗りつぶし対象の矩形
+ * @param [in] color 塗りつぶし色
+ */
+inline bool MyFillRect( const HDC hDC, const RECT &rc, const COLORREF color ) noexcept
+{
+	assert( hDC );
+
+	HBRUSH hBrush = ::CreateSolidBrush( color );
+	bool retMyFillRect = MyFillRect( hDC, rc, hBrush );
+	::DeleteObject( hBrush );
+
+	return retMyFillRect;
+}
+
 #endif /* SAKURA_CGRAPHICS_BA5156BF_99C6_4854_8131_CE8B091A5EFF9_H_ */
 /*[EOF]*/

--- a/sakura_core/uiparts/CGraphics.h
+++ b/sakura_core/uiparts/CGraphics.h
@@ -48,9 +48,9 @@ inline bool MyFillRect( const HDC hDC, const RECT &rc, const HBRUSH hBrush ) noe
 	if ( !hDC || !hBrush ) return false;
 
 	HGDIOBJ hBrushOld = ::SelectObject( hDC, hBrush );
-	if ( hBrushOld == HGDI_ERROR ) return false;
+	if ( !hBrushOld || hBrushOld == HGDI_ERROR ) return false;
 
-	int retPatBlt = ::PatBlt( hDC, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, PATCOPY );
+	auto retPatBlt = ::PatBlt( hDC, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, PATCOPY );
 	::SelectObject( hDC, hBrushOld );
 
 	return retPatBlt != 0;

--- a/sakura_core/uiparts/CGraphics.h
+++ b/sakura_core/uiparts/CGraphics.h
@@ -72,6 +72,9 @@ struct SFONT {
 	HFONT		m_hFont;      //!< フォントハンドル
 };
 
+// 先行定義
+inline bool MyFillRect( const HDC hDC, const RECT &rc, const HBRUSH hBrush ) noexcept;
+
 //! 描画管理
 //最新実装：ブラシ
 class CGraphics{
@@ -211,7 +214,7 @@ public:
 	//! 矩形塗り潰し
 	void FillMyRect(const RECT& rc)
 	{
-		::FillRect(m_hdc,&rc,GetCurrentBrush());
+		::MyFillRect( m_hdc, rc, GetCurrentBrush() );
 #ifdef _DEBUG
 		::SetPixel(m_hdc,-1,-1,0); //###########実験
 #endif

--- a/sakura_core/uiparts/CMenuDrawer.cpp
+++ b/sakura_core/uiparts/CMenuDrawer.cpp
@@ -25,6 +25,7 @@
 #include "window/CSplitBoxWnd.h"
 #include "CImageListMgr.h"
 #include "func/CKeyBind.h"
+#include "uiparts/CGraphics.h"
 #include "util/window.h"
 
 // メニューアイコンの背景をボタンの色にする
@@ -979,8 +980,6 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 	const int cxSmIcon = ::GetSystemMetrics(SM_CXSMICON);
 	const int cySmIcon = ::GetSystemMetrics(SM_CYSMICON);
 
-	HBRUSH		hBrush;
-
 	CMyRect rcItem( lpdis->rcItem );
 
 	const bool bMenuIconDraw = !!m_pShareData->m_Common.m_sWindow.m_bMenuIcon;
@@ -1040,7 +1039,7 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 		BYTE valR = ((GetRValue(colHilight) * 4 + GetRValue(colMenu) * 6) / 10) | 0x18;
 		BYTE valG = ((GetGValue(colHilight) * 4 + GetGValue(colMenu) * 6) / 10) | 0x18;
 		BYTE valB = ((GetBValue(colHilight) * 4 + GetBValue(colMenu) * 6) / 10) | 0x18;
-		hBrush = ::CreateSolidBrush( RGB(valR, valG, valB) );
+		HBRUSH hBrush = ::CreateSolidBrush( RGB(valR, valG, valB) );
 		HBRUSH hOldBrush = (HBRUSH)::SelectObject( hdc, hBrush );
 		::Rectangle( hdc, rc1.left, rc1.top, rc1.right, rc1.bottom );
 		::SelectObject( hdc, hOldPen );
@@ -1048,17 +1047,15 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 		::DeleteObject( hPenBorder );
 		::DeleteObject( hBrush );
 #else
-		hBrush = ::GetSysColorBrush( COLOR_HIGHLIGHT );
 		/* 選択ハイライト矩形 */
-		::FillRect( hdc, &rc1, hBrush );
+		::MyFillRect( hdc, rc1, COLOR_HIGHLIGHT );
 #endif
 #ifdef DRAW_MENU_ICON_BACKGROUND_3DFACE
 	}else if( bMenuIconDraw ){
 		// アイコン部分の背景を灰色にする
-		hBrush = ::GetSysColorBrush( COLOR_MENU );
 		CMyRect rcFillMenuBack( rcItem );
 		rcFillMenuBack.left += nIndentLeft;
-		::FillRect( hdc, &rcFillMenuBack, hBrush );
+		::MyFillRect( hdc, rcFillMenuBack, COLOR_MENU );
 
 //		hBrush = ::GetSysColorBrush( COLOR_3DFACE );
 		COLORREF colMenu   = ::GetSysColor( COLOR_MENU );
@@ -1075,22 +1072,18 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 			BYTE valB = ((GetBValue(colFace) * 7 + GetBValue(colMenu) * 3) / 10);
 			colIconBack = RGB(valR, valG, valB);
 		}
-		HBRUSH hbr = ::CreateSolidBrush( colIconBack );
 		
 		CMyRect rcIconBk( rcItem );
 		rcIconBk.right = rcItem.left + nIndentLeft;
-		::FillRect( hdc, &rcIconBk, hbr );
-		::DeleteObject( hbr );
+		::MyFillRect( hdc, rcIconBk, colIconBack );
 
 	}else{
 		// アイテム矩形塗りつぶし
-		hBrush = ::GetSysColorBrush( COLOR_MENU );
-		::FillRect( hdc, &lpdis->rcItem, hBrush );
+		::MyFillRect( hdc, lpdis->rcItem, COLOR_MENU );
 	}
 #else
 	}else{
-		hBrush = ::GetSysColorBrush( COLOR_MENU );
-		::FillRect( hdc, &lpdis->rcItem, hBrush );
+		::MyFillRect( hdc, lpdis->rcItem, COLOR_MENU );
 	}
 #endif
 
@@ -1212,8 +1205,7 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 			// フラットな枠 + 半透明の背景色
 			CMyRect rcFrame( rcIcon );
 			::InflateRect( &rcFrame, cxEdge * 2, cyEdge * 2 );
-			HBRUSH hBrush = ::GetSysColorBrush( COLOR_HIGHLIGHT );
-			::FillRect( hdc, &rcFrame, hBrush );
+			::MyFillRect( hdc, rcFrame, COLOR_HIGHLIGHT );
 
 			COLORREF colHilight = ::GetSysColor( COLOR_HIGHLIGHT );
 			COLORREF colMenu = ::GetSysColor( COLOR_MENU );
@@ -1232,9 +1224,7 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 			}
 			CMyRect rcBkFrame( rcIcon );
 			::InflateRect( &rcBkFrame, cxEdge , cyEdge );
-			HBRUSH hbr = ::CreateSolidBrush( RGB(valR, valG, valB) );
-			::FillRect( hdc, &rcBkFrame, hbr );
-			::DeleteObject( hbr );
+			::MyFillRect( hdc, rcBkFrame, RGB( valR, valG, valB ) );
 		}
 	}
 

--- a/sakura_core/window/CSplitBoxWnd.cpp
+++ b/sakura_core/window/CSplitBoxWnd.cpp
@@ -14,6 +14,7 @@
 */
 #include "StdAfx.h"
 #include "window/CSplitBoxWnd.h"
+#include "uiparts/CGraphics.h"
 
 CSplitBoxWnd::CSplitBoxWnd()
 : CWnd(_T("::CSplitBoxWnd"))
@@ -80,21 +81,16 @@ HWND CSplitBoxWnd::Create( HINSTANCE hInstance, HWND hwndParent, int bVertical )
 void CSplitBoxWnd::Draw3dRect( HDC hdc, int x, int y, int cx, int cy,
 	COLORREF clrTopLeft, COLORREF clrBottomRight )
 {
-	HBRUSH	hBrush;
 	RECT	rc;
-	hBrush = ::CreateSolidBrush( clrTopLeft );
 	::SetRect( &rc, x, y, x + cx - 1, y + 1 );
-	::FillRect( hdc, &rc, hBrush );
+	::MyFillRect( hdc, rc, clrTopLeft );
 	::SetRect( &rc, x, y, x + 1, y + cy - 1 );
-	::FillRect( hdc, &rc, hBrush );
-	::DeleteObject( hBrush );
+	::MyFillRect( hdc, rc, clrTopLeft );
 
-	hBrush = ::CreateSolidBrush( clrBottomRight );
 	::SetRect( &rc, x + cx - 1, y, x + cx, y + cy );
-	::FillRect( hdc, &rc, hBrush );
+	::MyFillRect( hdc, rc, clrBottomRight );
 	::SetRect( &rc, x, y + cy - 1, x + cx, y + cy );
-	::FillRect( hdc, &rc, hBrush );
-	::DeleteObject( hBrush );
+	::MyFillRect( hdc, rc, clrBottomRight );
 	return;
 }
 

--- a/sakura_core/window/CSplitterWnd.cpp
+++ b/sakura_core/window/CSplitterWnd.cpp
@@ -21,6 +21,7 @@
 #include "view/CEditView.h"
 #include "outline/CDlgFuncList.h"
 #include "env/DLLSHAREDATA.h"
+#include "uiparts/CGraphics.h"
 
 constexpr auto SPLITTER_FRAME_WIDTH = 3;
 constexpr auto SPLITTER_MARGIN = 2;
@@ -782,19 +783,16 @@ LRESULT CSplitterWnd::OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 	RECT		rc;
 	RECT		rcFrame;
 	const int	nFrameWidth = DpiScaleX(SPLITTER_FRAME_WIDTH);
-	HBRUSH		hBrush;
 	hdc = ::BeginPaint( hwnd, &ps );
 	::GetClientRect( GetHwnd(), &rc );
-	hBrush = ::CreateSolidBrush( ::GetSysColor( COLOR_3DFACE ) );
 	if( m_nAllSplitRows > 1 ){
 		::SetRect( &rcFrame, rc.left, m_nVSplitPos, rc.right, m_nVSplitPos + nFrameWidth );
-		::FillRect( hdc, &rcFrame, hBrush );
+		::MyFillRect( hdc, rcFrame, COLOR_3DFACE );
 	}
 	if( m_nAllSplitCols > 1 ){
 		::SetRect( &rcFrame, m_nHSplitPos, rc.top, m_nHSplitPos + nFrameWidth, rc.bottom );
-		::FillRect( hdc, &rcFrame, hBrush );
+		::MyFillRect( hdc, rcFrame, COLOR_3DFACE );
 	}
-	::DeleteObject( hBrush );
 	::EndPaint(hwnd, &ps);
 	return 0L;
 }

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -1266,7 +1266,7 @@ LRESULT CTabWnd::OnDrawItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam 
 
 		// 状態に従ってテキストと背景色を決める
 		COLORREF clrText;
-		INT_PTR nSysClrBk;
+		int nSysClrBk;
 		if (lpdis->itemState & ODS_SELECTED)
 		{
 			clrText = ::GetSysColor( COLOR_HIGHLIGHTTEXT );

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -1279,7 +1279,7 @@ LRESULT CTabWnd::OnDrawItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam 
 		}
 
 		// 背景描画
-		::FillRect( gr, &rcItem, (HBRUSH)(nSysClrBk + 1) );
+		::MyFillRect( gr, rcItem, nSysClrBk );
 
 		// アイコン描画
 		int cxIcon = CX_SMICON;
@@ -1341,7 +1341,7 @@ LRESULT CTabWnd::OnDrawItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam 
 
 		// 背景描画
 		if( !IsVisualStyle() ) {
-			::FillRect( gr, &rcItem, (HBRUSH)(COLOR_BTNFACE + 1) );
+			::MyFillRect( gr, rcItem, COLOR_BTNFACE );
 		}else{
 			CUxTheme& uxTheme = *CUxTheme::getInstance();
 			int iPartId = TABP_TABITEM;
@@ -1587,7 +1587,7 @@ LRESULT CTabWnd::OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 
 	// 背景を描画する
 	::GetClientRect( hwnd, &rc );
-	::FillRect( gr, &rc, (HBRUSH)(COLOR_3DFACE + 1) );
+	::MyFillRect( gr, rc, COLOR_3DFACE );
 
 	// ボタンを描画する
 	DrawListBtn( gr, &rc );
@@ -1634,9 +1634,7 @@ LRESULT CTabWnd::OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 
 			if( rcCurSel.left < rcCurSel.right )
 			{
-				HBRUSH hBr = ::CreateSolidBrush( RGB( 255, 128, 0 ) );
-				::FillRect( gr, &rcCurSel, hBr );
-				::DeleteObject( hBr );
+				::MyFillRect( gr, rcCurSel, RGB( 255, 128, 0 ) );
 			}
 		}
 	}


### PR DESCRIPTION
## 目的

背景塗りつぶしに使うAPIを変更します。

#765 の展開として FillRect 関数の独自版(内部的にPatBltを使用)を用意し、全数を置き換えます。

注意

* sakura_core\dlg\CDlgAbout.cpp にある FillRect は #765 で修正予定です。
* sakura_core\prop\CPropComToolbar.cpp にある FillRect は利用状況の都合で ExtTextOut に変更します。

## 変更で導入する独自関数

この変更により新たに独自関数を導入します。
既存FillRectとなるべく近い使い勝手となるように3オーバーロードを用意します。
速度影響をなるべく少なくしたいので全関数inline指定です。

FillRectとの主な相違点は実行速度と第二引数ですが、だいたい似た感じに使えるように作っています。

```c++
int WINAPI FillRect( HDC hDC, RECT* lpRc, HBRUSH hBrush );
inline bool MyFillRect( const HDC hDC, const RECT &rc, HBRUSH hBrush ) noexcept;
inline bool MyFillRect( const HDC hDC, const RECT &rc, int sysColor ) noexcept;
inline bool MyFillRect( const HDC hDC, const RECT &rc, COLORREF color ) noexcept;
```

関数名 | 最後の引数 | 説明
-- | -- | --
MyFillRect | HBRUSH | 指定したブラシをSelectObjectしてPatBltします。基本形です。
MyFillRect | int | 指定したカラーインデックスでGetSysColorBrushしてMyFillRectします。使い終わったブラシを削除する必要はないのでそのまま戻ります。FillRectの第3引数の仕様に合わせ、カラーインデックスを受けつけるようにしています。
MyFillRect | COLORREF | 指定した色でCreateSolidBrushしてMyFillRectします。使い終わったブラシは削除してから戻ります。サクラエディタではRGB指定で色を渡すケースが多いので独自実装を用意します。

## PRの評価方法について

このPRの目的は、FillRect関数の置換です。
実際の速度改善は目的ではないので、置換が正しく行われているか（明らかな置き換えミスがないか）に納得がいけば問題なしとしてよいと考えております。

