### PR TITLE
ツールバー検索ボックスの垂直位置を調整する

### DIFF
--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -291,11 +291,10 @@ void CMainToolBar::CreateToolBar( void )
 						Toolbar_GetItemRect( m_hwndToolBar, count-1, &rc );
 
 						//コンボボックスを作る
-						//	Mar. 8, 2003 genta 検索ボックスを1ドット下にずらした
 						m_hwndSearchBox = CreateWindow( _T("COMBOBOX"), _T("Combo"),
 								WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_VSCROLL | CBS_DROPDOWN
 								/*| CBS_SORT*/ | CBS_AUTOHSCROLL /*| CBS_DISABLENOSCROLL*/,
-								rc.left, rc.top + 1, rc.right - rc.left, (rc.bottom - rc.top) * 10,
+								rc.left, rc.top, rc.right - rc.left, (rc.bottom - rc.top) * 10,
 								m_hwndToolBar, (HMENU)(INT_PTR)tbb.idCommand, CEditApp::getInstance()->GetAppInstance(), NULL );
 						if( m_hwndSearchBox )
 						{

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -332,6 +332,16 @@ void CMainToolBar::CreateToolBar( void )
 							m_comboDel = SComboBoxItemDeleter(); // 再表示用の初期化
 							m_comboDel.pRecent = &m_cRecentSearch;
 							CDialog::SetComboBoxDeleter(m_hwndSearchBox, &m_comboDel);
+
+							// コンボボックスの垂直位置を調整する
+							CMyRect rcCombo;
+							::GetWindowRect( m_hwndSearchBox, &rcCombo );
+							::SetWindowPos( m_hwndSearchBox, NULL,
+								rc.left,	//作ったときと同じ値を指定
+								(rc.bottom - rc.top - rcCombo.Height()) / 2,	//上下中央に配置する
+								0,			//rcCombo.Width()のまま変えない
+								0,			//rcCombo.Height()のまま変えない
+								SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSENDCHANGING );
 						}
 						break;
 


### PR DESCRIPTION
検索ボックスを表示させたときにボックスの下側に大きな隙間ができるので、上下中央になるように位置調整を行います。



... | 画像
-- | --
変更前 | <img alt="prev" src="https://user-images.githubusercontent.com/3253151/51423019-54cde900-1bfc-11e9-988c-0d01f86aa6bb.png" width="512" />
変更後 | <img alt="thispr" src="https://user-images.githubusercontent.com/3253151/51423023-5bf4f700-1bfc-11e9-8e8a-dd1814d256b4.png" width="512" />

キャプチャは200%表示です。
表示倍率が高いほど下端の余白が大きくなります。
(4Kディスプレイで最大表示(=350%)すると大変なことに・・・。)

周囲のボタンと上端が揃うように位置調整していますが、
下端が揃うほうがいいという人がいるかも知れません。
細かい調整の話はおいておいて、まずは位置調整の機構を入れたいです。
