### PR TITLE
 chm のビルド前に chm ファイルを削除する 

### DIFF
--- a/build-chm.bat
+++ b/build-chm.bat
@@ -8,34 +8,29 @@ set HHP_MACRO=help\macro\macro.HHP
 set HHP_PLUGIN=help\plugin\plugin.hhp
 set HHP_SAKURA=help\sakura\sakura.hhp
 
+set CHM_MACRO=help\macro\macro.chm
+set CHM_PLUGIN=help\plugin\plugin.chm
+set CHM_SAKURA=help\sakura\sakura.chm
+
+call :BuildChm %HHP_MACRO%  %CHM_MACRO%   || (echo error && exit /b 1)
+call :BuildChm %HHP_PLUGIN% %CHM_PLUGIN%  || (echo error && exit /b 1)
+call :BuildChm %HHP_SAKURA% %CHM_SAKURA%  || (echo error && exit /b 1)
+exit /b 0
+
+@rem ------------------------------------------------------------------------------
+@rem BuildChm
+@rem ------------------------------------------------------------------------------
+:BuildChm
+set PROJECT_HHP=%1
+set PROJECT_CHM=%2
 @rem hhc.exe returns 1 on success, and returns 0 on failure
-"%CMD_HHC%" %HHP_MACRO%
+"%CMD_HHC%" %PROJECT_HHP%
 if not errorlevel 1 (
-	echo error %HHP_MACRO% errorlevel %errorlevel%
-	"%CMD_HHC%" %HHP_MACRO%
+	echo error %PROJECT_HHP% errorlevel %errorlevel%
+	"%CMD_HHC%" %PROJECT_HHP%
 )
 if not errorlevel 1 (
-	echo error %HHP_MACRO% errorlevel %errorlevel%
-	exit /b 1
-)
-
-"%CMD_HHC%" %HHP_PLUGIN%
-if not errorlevel 1 (
-	echo error %HHP_PLUGIN% errorlevel %errorlevel%
-	"%CMD_HHC%" %HHP_PLUGIN%
-)
-if not errorlevel 1 (
-	echo error %HHP_PLUGIN% errorlevel %errorlevel%
-	exit /b 1
-)
-
-"%CMD_HHC%" %HHP_SAKURA%
-if not errorlevel 1 (
-	echo error %HHP_SAKURA% errorlevel %errorlevel%
-	"%CMD_HHC%" %HHP_SAKURA%
-)
-if not errorlevel 1 (
-	echo error %HHP_SAKURA% errorlevel %errorlevel%
+	echo error %PROJECT_HHP% errorlevel %errorlevel%
 	exit /b 1
 )
 exit /b 0

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -23,14 +23,19 @@ exit /b 0
 :BuildChm
 set PROJECT_HHP=%1
 set PROJECT_CHM=%2
+
+if exist "%PROJECT_CHM%" del /F "%PROJECT_CHM%"
+
 @rem hhc.exe returns 1 on success, and returns 0 on failure
 "%CMD_HHC%" %PROJECT_HHP%
 if not errorlevel 1 (
 	echo error %PROJECT_HHP% errorlevel %errorlevel%
+
+	del /F "%PROJECT_CHM%"
 	"%CMD_HHC%" %PROJECT_HHP%
 )
 if not errorlevel 1 (
-	echo error %PROJECT_HHP% errorlevel %errorlevel%
+	echo retry error %PROJECT_HHP% errorlevel %errorlevel%
 	exit /b 1
 )
 exit /b 0


### PR DESCRIPTION
 chm のビルド前に chm ファイルを削除する 

作業しやすいように最初の commit でリファクリタングしてから、対応を入れています。