### PR TITLE
Window テキストをCNativeT で取得/設定するユーティリティ関数を追加

### DIFF
--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -36,6 +36,7 @@
 #else
 	#include <ImageHlp.h> //MakeSureDirectoryPathExists
 #endif
+#include "mem/CNativeT.h"
 
 //デバッグ用。
 //VistaだとExtTextOutの結果が即反映されない。この関数を用いると即反映されるので、

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -58,6 +58,41 @@ namespace ApiWrap{
 #endif
 	}
 
+	/*!
+		@brief Window テキストを設定する
+		@param[in]  hwnd	ウィンドウハンドル
+		@param[in]  str		ウィンドウテキスト
+	*/
+	inline BOOL Wnd_SetText(HWND hwnd, const CNativeT& str)
+	{
+		return SetWindowText(hwnd, str.GetStringPtr());
+	}
+
+	/*!
+		@brief Window テキストを取得する
+		@param[in]  hwnd	ウィンドウハンドル
+		@param[out] str		ウィンドウテキスト
+	*/
+	inline BOOL Wnd_GetText(HWND hwnd, CNativeT& str)
+	{
+		// バッファをクリアしておく
+		str.Clear();
+
+		const int length = ::GetWindowTextLength(hwnd);
+		const int bufsize = length + 1;
+		if (str.capacity() < bufsize)
+		{
+			str.AllocStringBuffer(bufsize);
+		}
+		BOOL ret = ::GetWindowText(hwnd, str.GetStringPtr(), str.capacity());
+		if (ret)
+		{
+			str._SetStringLength(length);
+			assert(str.GetStringLength() == length);
+		}
+		return ret;
+	}
+
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      コンボボックス                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -120,7 +120,7 @@ namespace ApiWrap{
 		}
 		else if(actualCount >= str.capacity())
 		{
-			// 仕様上はありえないはず
+			// GetWindowText() の仕様上はありえないはず
 			return false;
 		}
 

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -37,6 +37,9 @@ UNICODE版では問題無いが、ANSI版では設定の前にコード変換す
 そういった意味でも、このファイル内のラップ関数を使うことを推奨する。
 */
 
+#include <windows.h>
+#include <Commctrl.h>
+#include "mem/CNativeW.h"
 #include "../util/tchar_convert.h"
 #include <vector>
 

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -80,14 +80,21 @@ namespace ApiWrap{
 
 		const int length = ::GetWindowTextLength(hwnd);
 		const int bufsize = length + 1;
+		
+		// ウィンドウタイトルを設定するのに必要なバッファを確保する
 		if (str.capacity() < bufsize)
 		{
 			str.AllocStringBuffer(bufsize);
 		}
+
 		BOOL ret = ::GetWindowText(hwnd, str.GetStringPtr(), str.capacity());
 		if (ret)
 		{
+			// Win32 API の GetWindowText() を呼んだだけでは CNativeT 内部の
+			// データサイズが更新されないのでデータサイズを反映する
 			str._SetStringLength(length);
+
+			// 正しく設定されているはず
 			assert(str.GetStringLength() == length);
 		}
 		return ret;

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -118,11 +118,7 @@ namespace ApiWrap{
 				return false;
 			}
 		}
-		else if(actualCount < str.capacity())
-		{
-			assert(actualCount <= bufsize);
-		}
-		else
+		else if(actualCount >= str.capacity())
 		{
 			// 仕様上はありえないはず
 			return false;

--- a/tests/unittests/test-StdControl.cpp
+++ b/tests/unittests/test-StdControl.cpp
@@ -30,5 +30,5 @@
 TEST(StdControl, Wnd_GetText)
 {
 	CNativeT tempText;
-	EXPECT_EQ(Wnd_GetText(NULL, tempText), false);
+	ASSERT_FALSE(Wnd_GetText(NULL, tempText));
 }

--- a/tests/unittests/test-StdControl.cpp
+++ b/tests/unittests/test-StdControl.cpp
@@ -1,0 +1,34 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+#include "apiwrap/StdControl.h"
+
+/*!
+*/
+TEST(StdControl, Wnd_GetText)
+{
+	CNativeT tempText;
+	EXPECT_EQ(Wnd_GetText(NULL, tempText), false);
+}


### PR DESCRIPTION
Window テキストをCNativeT で取得/設定するユーティリティ関数を追加

## 段取り

1. ~#778  (説明欄を参照) を マージをする~ (https://github.com/sakura-editor/sakura/pull/778#issuecomment-459944779)
2. #777 を rebase してマージする (完了)
3. #776 を rebase してマージする (この PR)
