### PR TITLE
CNative::Clear の実装を改善

### DIFF
--- a/sakura_core/basis/CStrictInteger.h
+++ b/sakura_core/basis/CStrictInteger.h
@@ -31,6 +31,8 @@
 #ifndef SAKURA_CSTRICTINTEGER_6F202774_0F82_4BB7_B107_37DE5443309E_H_
 #define SAKURA_CSTRICTINTEGER_6F202774_0F82_4BB7_B107_37DE5443309E_H_
 
+#include "primitive.h" // for Int
+
 //int以外の整数型もintにキャストして扱う
 #define STRICTINT_OTHER_TYPE_AS_INT(TYPE) \
 	Me& operator += (TYPE rhs)			{ return operator += ((int)rhs); } \

--- a/sakura_core/basis/SakuraBasis.h
+++ b/sakura_core/basis/SakuraBasis.h
@@ -58,6 +58,7 @@
 
 #else
 	// -- -- 通常のintで単位型を定義
+	#include "primitive.h"
 
 	//ロジック単位
 	typedef int CLogicInt;

--- a/sakura_core/basis/SakuraBasis.h
+++ b/sakura_core/basis/SakuraBasis.h
@@ -58,7 +58,7 @@
 
 #else
 	// -- -- 通常のintで単位型を定義
-	#include "primitive.h"
+	#include "primitive.h" // for Int
 
 	//ロジック単位
 	typedef int CLogicInt;

--- a/sakura_core/mem/CNative.cpp
+++ b/sakura_core/mem/CNative.cpp
@@ -5,5 +5,5 @@
 //! 空っぽにする
 void CNative::Clear()
 {
-	this->SetRawData("",0);
+	this->_GetMemory()->_SetRawLength(0);
 }

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -26,29 +26,67 @@
 #include "mem/CNativeW.h"
 #include "mem/CNativeA.h"
 
+/*!
+	CNativeW::Clear のデータサイズのクリアをテストする
+
+	1-1. 固定データを追加する
+	1-2. バッファの状態を取得する
+	1-3. バッファの状態をチェックする
+
+	2-1. CNativeW をクリアする
+	2-2. クリア後のバッファの状態を取得する
+	2-3. クリア後のバッファの状態をチェックする
+
+	3-1. 固定データを再追加する
+	3-2. バッファの状態を取得する
+	3-3. バッファの状態をチェックする
+*/
 TEST(CNativeW, Clear)
 {
-	CNativeW stringW;
-	stringW.AppendString(L"abc");
+	constexpr const WCHAR*	fixedPatternStr = L"abc";
+	constexpr const int		fixedPatternLen = 3;
 	
-	/* Clear() 前にバッファサイズを取得する */
-	auto orgCapacity = stringW.capacity();
+	CNativeW stringW;
 
-	/* Clear() 前にデータサイズを取得する */
-	auto orgLength   = stringW.GetStringLength();
-	EXPECT_EQ(orgLength, 3);
+	// 1-1. 固定データを追加する
 
-	stringW.Clear();
+	stringW.AppendString(fixedPatternStr);			// 固定データを追加する
 
-	/* Clear() 後にバッファサイズを取得する */
-	auto newCapacity = stringW.capacity();
+	// 1-2. バッファの状態を取得する
+	
+	auto orgCapacity = stringW.capacity();			// データ追加後にバッファサイズを取得する
+	auto orgLength   = stringW.GetStringLength();	// Clear() 前にデータサイズを取得する
 
-	/* Clear() 後にデータサイズを取得する */
-	auto newLength   = stringW.GetStringLength();
+	// 1-3. バッファの状態をチェックする
 
-	/* Clear() 後にバッファサイズが変わっていないのを確認する */
-	EXPECT_EQ(orgCapacity, newCapacity);
+	EXPECT_GT(orgCapacity, 0);						// データ追加後のバッファサイズを確認する
+	EXPECT_EQ(orgLength, fixedPatternLen);			// データ追加後のデータサイズを確認する
 
-	/* Clear() 後にデータが空なのを確認する */
-	EXPECT_EQ(newLength, 0);
+	// 2-1. CNativeW をクリアする
+	
+	stringW.Clear();								// CNativeW をクリアする
+
+	// 2-2. クリア後のバッファの状態を取得する
+
+	auto newCapacity = stringW.capacity();			// Clear() 後にバッファサイズを取得する
+	auto newLength   = stringW.GetStringLength();	// Clear() 後にデータサイズを取得する
+
+	// 2-3. クリア後のバッファの状態をチェックする
+	
+	EXPECT_EQ(orgCapacity, newCapacity);			// Clear() 後にバッファサイズが変わっていないのを確認する
+	EXPECT_EQ(newLength, 0);						// Clear() 後にデータが空なのを確認する
+
+	// 3-1. 固定データを再追加する
+
+	stringW.AppendString(fixedPatternStr);			// Clear() 後に固定データを再追加する
+
+	// 3-2. バッファの状態を取得する
+	
+	auto newCapacity2 = stringW.capacity();			// 再追加後にバッファサイズを取得する
+	auto newLength2   = stringW.GetStringLength();	// 再追加後にデータサイズを取得する
+
+	// 3-3. バッファの状態をチェックする
+	
+	EXPECT_EQ(orgCapacity, newCapacity2);			// 再追加後にバッファサイズが変わっていないのを確認する
+	EXPECT_EQ(newLength2, fixedPatternLen);			// 再追加後にデータサイズを確認する
 }

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -1,0 +1,54 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+#include "mem/CNativeW.h"
+#include "mem/CNativeA.h"
+
+TEST(CNativeW, Clear)
+{
+	CNativeW stringW;
+	stringW.AppendString(L"abc");
+	
+	/* Clear() 前にバッファサイズを取得する */
+	auto orgCapacity = stringW.capacity();
+
+	/* Clear() 前にデータサイズを取得する */
+	auto orgLength   = stringW.GetStringLength();
+	EXPECT_EQ(orgLength, 3);
+
+	stringW.Clear();
+
+	/* Clear() 後にバッファサイズを取得する */
+	auto newCapacity = stringW.capacity();
+
+	/* Clear() 後にデータサイズを取得する */
+	auto newLength   = stringW.GetStringLength();
+
+	/* Clear() 後にバッファサイズが変わっていないのを確認する */
+	EXPECT_EQ(orgCapacity, newCapacity);
+
+	/* Clear() 後にデータが空なのを確認する */
+	EXPECT_EQ(newLength, 0);
+}


### PR DESCRIPTION
CNative::Clear の実装を改善

## 段取り

1. ~#778  (説明欄を参照) を マージをする~ (https://github.com/sakura-editor/sakura/pull/778#issuecomment-459944779)
2. #777 を rebase してマージする (この PR)
3. #776 を rebase してマージする

