### PR TITLE
CNative::Clear() → CNative::shrink_to_empty() に名前変更する

### DIFF
--- a/sakura_core/cmd/CViewCommander_Clipboard.cpp
+++ b/sakura_core/cmd/CViewCommander_Clipboard.cpp
@@ -65,7 +65,7 @@ void CViewCommander::Command_CUT( void )
 		ErrorBeep();
 		return;
 	}
-	cmemBuf.Clear();
+	cmemBuf.shrink_to_empty();
 
 	/* カーソル位置または選択エリアを削除 */
 	m_pCommanderView->DeleteData( true );
@@ -116,7 +116,7 @@ void CViewCommander::Command_COPY(
 			return;
 		}
 	}
-	cmemBuf.Clear();
+	cmemBuf.shrink_to_empty();
 
 	/* 選択範囲の後片付け */
 	if( !bIgnoreLockAndDisable ){

--- a/sakura_core/cmd/CViewCommander_Convert.cpp
+++ b/sakura_core/cmd/CViewCommander_Convert.cpp
@@ -227,7 +227,7 @@ void CViewCommander::Command_BASE64DECODE( void )
 	if( !bret ){
 		return;
 	}
-	ctextBuf.Clear();
+	ctextBuf.shrink_to_empty();
 
 	/* 保存ダイアログ モーダルダイアログの表示 */
 	TCHAR		szPath[_MAX_PATH] = _T("");
@@ -276,7 +276,7 @@ void CViewCommander::Command_UUDECODE( void )
 		return;
 	}
 	decoder.CopyFilename( szPath );
-	ctextBuf.Clear();
+	ctextBuf.shrink_to_empty();
 
 	/* 保存ダイアログ モーダルダイアログの表示 */
 	if( !GetDocument()->m_cDocFileOperation.SaveFileDialog( szPath ) ){

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -728,7 +728,7 @@ BOOL CViewCommander::Command_PUTFILE(
 				pcUtf16->GetBom(cmemBom._GetMemory());
 				cMem2.AppendNativeData(cmemBom);
 				cMem2.AppendNativeData(cMem);
-				cMem.Clear();
+				cMem.shrink_to_empty();
 				pConvBuffer = &cMem2;
 			}else{
 				pConvBuffer = &cMem;

--- a/sakura_core/mem/CNative.cpp
+++ b/sakura_core/mem/CNative.cpp
@@ -2,8 +2,10 @@
 #include "StdAfx.h"
 #include "CNative.h"
 
-//! 空っぽにする
-void CNative::Clear()
+/*
+	バッファサイズを縮小して空にする。
+*/
+void CNative::shrink_to_empty()
 {
 	this->SetRawData("",0);
 }

--- a/sakura_core/mem/CNative.h
+++ b/sakura_core/mem/CNative.h
@@ -35,8 +35,14 @@ public:
 	const CMemory* _GetMemory() const{ return static_cast<const CMemory*>(this); }
 
 public:
-	//汎用
-	void Clear(); //!< 空っぽにする
+	/*!
+		バッファサイズを縮小して空にする。
+	
+		1. std::basic_string::shrink_to_fit() と同様にメモリサイズを縮小させる。
+		   (メモリサイズを縮小する際にメモリの再確保が行われる。)
+		2. それに加えてデータを空にする。
+	*/
+	void shrink_to_empty();
 };
 
 #include "mem/CNativeA.h"

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -160,7 +160,7 @@ void CEditView::InsertData_CEditView(
 				bHintNext = true;
 			}
 			StringToOpeLineData( cMem.GetStringPtr(), cMem.GetStringLength(), insData, opeSeq );
-			cMem.Clear();
+			cMem.shrink_to_empty();
 			nColumnFrom = LineIndexToColumn( pcLayout, nIdxFrom );
 		}
 		else{
@@ -181,7 +181,7 @@ void CEditView::InsertData_CEditView(
 			}
 			cMem.AppendString( pData, nDataLen );
 			StringToOpeLineData( cMem.GetStringPtr(), cMem.GetStringLength(), insData, opeSeq );
-			cMem.Clear();
+			cMem.shrink_to_empty();
 		}else{
 			StringToOpeLineData( pData, nDataLen, insData, opeSeq );
 		}


### PR DESCRIPTION
### 対応の背景

#776 でウィンドウタイトルを取得するユーティリティを実装する際に https://github.com/sakura-editor/sakura/pull/776#discussion_r250263344 のコメントをもらった。

それで https://github.com/sakura-editor/sakura/pull/776#discussion_r250271481 のコメントの通り
データサイズを空にするべく #777 を作成した。

そうした場合、https://github.com/sakura-editor/sakura/pull/777#pullrequestreview-196021096 のようにメモリサイズを減らしたい場合に対応できないというコメントをもらった。

### 対応内容

データサイズを空にするという処理を CNative::Clear()  で実装することにして
[std::basic_string::shrink_to_fit](https://cpprefjp.github.io/reference/vector/vector/shrink_to_fit.html) に近いバッファサイズを縮小する既存の CNative::Clear() を名前変更することにする。

この PR マージ後に  #777 を rebase して、 CNative::Clear()  でデータサイズを空にする処理を実装する予定。