### PR TITLE
バッファが空の状態で CNativeW::Clear を呼び出したときに落ちる不具合修正

### DIFF
--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -382,9 +382,17 @@ void CMemory::_AppendSz(const char* str)
 
 void CMemory::_SetRawLength(int nLength)
 {
-	assert(m_nRawLen <= m_nDataBufSize-2);
-	m_nRawLen = nLength;
-	assert(m_nRawLen <= m_nDataBufSize-2);
-	m_pRawData[m_nRawLen  ]=0;
-	m_pRawData[m_nRawLen+1]=0; //終端'\0'を2つ付加する('\0''\0'==L'\0')。
+	if (m_nDataBufSize > 0)
+	{
+		assert(m_nRawLen <= m_nDataBufSize-2);
+		m_nRawLen = nLength;
+		assert(m_nRawLen <= m_nDataBufSize-2);
+		m_pRawData[m_nRawLen  ]=0;
+		m_pRawData[m_nRawLen+1]=0; //終端'\0'を2つ付加する('\0''\0'==L'\0')。
+	}
+	else
+	{
+		// バッファが確保されていない状態の場合、有効データサイズを 0 にする要求しか来ないはず
+		assert(nLength == 0);
+	}
 }

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -29,6 +29,8 @@
 /*!
 	CNativeW::Clear のデータサイズのクリアをテストする
 
+	0. バッファが空の状態でクリアする
+
 	1-1. 固定データを追加する
 	1-2. バッファの状態を取得する
 	1-3. バッファの状態をチェックする
@@ -47,6 +49,9 @@ TEST(CNativeW, Clear)
 	constexpr const int		fixedPatternLen = 3;
 	
 	CNativeW stringW;
+	
+	// 0. バッファが空の状態でクリアする
+	stringW.Clear();
 
 	// 1-1. 固定データを追加する
 


### PR DESCRIPTION
バッファが空の状態で CNativeW::Clear を呼び出したときに落ちる不具合修正
(#777 によるデグレ)
