### PR TITLE
Fix: missing compile option of test1.exe on MinGW platform.

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -43,6 +43,7 @@ if (MSVC)
 	)
 elseif (MINGW)
 	target_compile_options (${project_name} PRIVATE -finput-charset=utf-8 -fexec-charset=cp932)
+	target_compile_definitions (${project_name} PUBLIC $<$<CONFIG:Debug>:_DEBUG>)
 	file (GLOB_RECURSE ALL_O
 		"${CMAKE_CURRENT_LIST_DIR}/../../sakura_core/*.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/../../sakura_core/*.rc"


### PR DESCRIPTION
Fix #782 issue「MinGW の Debug で CNativeW.Clear のテストに失敗する」

エディタ本体のコンパイルオプションとテストプログラムのコンパイルオプションの不一致を修正してプログラムの暴走を止めます。

pull #591 「Build and run tests on MinGW environment.」の作業漏れです。
