### PR TITLE
Fix #781 issue「googletest でテストに失敗しても ビルド結果が失敗にならない」

### DIFF
--- a/tests/test_result_filter_tell_AppVeyor.bat
+++ b/tests/test_result_filter_tell_AppVeyor.bat
@@ -22,30 +22,30 @@ set testMsg=
 for /F "usebackq delims=" %%L in (`FINDSTR /B "^"`) do (
 	echo %%L
 
-		for /F "tokens=1,2,3,5 delims=[]() " %%A in ("%%L") do (
-			if "%%A" == "----------" (
-				if not "%%D" == "" (
-					set fileName=%%D
-				)
-			) else if "%%A" == "RUN" (
-				set testName=%%B
-				set testMsg=
-			) else if "%%A" == "OK" (
-				if not "!testName!,!fileName!" == "," (
-					rem `start` does not wait for `%AppVeyor%` to return, so the main loop goes immediately.
-					start "" "%AppVeyor%" AddTest !testName! -Framework xUnit -FileName !fileName! -Outcome Passed -Duration %%C -StdOut "!testMsg!"
-				)
-			) else if "%%A" == "FAILED" (
-				if not "!testName!,!fileName!" == "," (
-					rem `start` does not wait for `%AppVeyor%` to return, so the main loop goes immediately.
-					start "" "%AppVeyor%" AddTest !testName! -Framework xUnit -FileName !fileName! -Outcome Failed -Duration %%C -ErrorMessage "!testMsg!"
-				)
-			) else if "%%A" == "PASSED" (
-				rem
-			) else if "%%A" == "==========" (
-				rem
-			) else (
-				set testMsg=!testMsg!%%L!NL!
+	for /F "tokens=1,2,3,5 delims=[]() " %%A in ("%%L") do (
+		if "%%A" == "----------" (
+			if not "%%D" == "" (
+				set fileName=%%D
 			)
+		) else if "%%A" == "RUN" (
+			set testName=%%B
+			set testMsg=
+		) else if "%%A" == "OK" (
+			if not "!testName!,!fileName!" == "," (
+				rem `start` does not wait for `%AppVeyor%` to return, so the main loop goes immediately.
+				start "" "%AppVeyor%" AddTest !testName! -Framework xUnit -FileName !fileName! -Outcome Passed -Duration %%C -StdOut "!testMsg!"
+			)
+		) else if "%%A" == "FAILED" (
+			if not "!testName!,!fileName!" == "," (
+				rem `start` does not wait for `%AppVeyor%` to return, so the main loop goes immediately.
+				start "" "%AppVeyor%" AddTest !testName! -Framework xUnit -FileName !fileName! -Outcome Failed -Duration %%C -ErrorMessage "!testMsg!"
+			)
+		) else if "%%A" == "PASSED" (
+			rem
+		) else if "%%A" == "==========" (
+			rem
+		) else (
+			set testMsg=!testMsg!%%L!NL!
 		)
+	)
 )

--- a/tests/test_result_filter_tell_AppVeyor.bat
+++ b/tests/test_result_filter_tell_AppVeyor.bat
@@ -15,6 +15,10 @@ if errorlevel 1 (
 	set AppVeyor=
 )
 
+::: Test result
+set PASSED=
+set FAILED=
+
 set fileName=
 set testName=
 set testMsg=
@@ -40,8 +44,9 @@ for /F "usebackq delims=" %%L in (`FINDSTR /B "^"`) do (
 				rem `start` does not wait for `%AppVeyor%` to return, so the main loop goes immediately.
 				if defined AppVeyor start "" "%AppVeyor%" AddTest !testName! -Framework xUnit -FileName !fileName! -Outcome Failed -Duration %%C -ErrorMessage "!testMsg!"
 			)
+			set FAILED=FAILED
 		) else if "%%A" == "PASSED" (
-			rem
+			set PASSED=PASSED
 		) else if "%%A" == "==========" (
 			rem
 		) else (
@@ -49,3 +54,7 @@ for /F "usebackq delims=" %%L in (`FINDSTR /B "^"`) do (
 		)
 	)
 )
+
+if     defined FAILED exit /b 1
+if not defined PASSED exit /b 1
+exit /b 0

--- a/tests/test_result_filter_tell_AppVeyor.bat
+++ b/tests/test_result_filter_tell_AppVeyor.bat
@@ -33,12 +33,12 @@ for /F "usebackq delims=" %%L in (`FINDSTR /B "^"`) do (
 		) else if "%%A" == "OK" (
 			if not "!testName!,!fileName!" == "," (
 				rem `start` does not wait for `%AppVeyor%` to return, so the main loop goes immediately.
-				start "" "%AppVeyor%" AddTest !testName! -Framework xUnit -FileName !fileName! -Outcome Passed -Duration %%C -StdOut "!testMsg!"
+				if defined AppVeyor start "" "%AppVeyor%" AddTest !testName! -Framework xUnit -FileName !fileName! -Outcome Passed -Duration %%C -StdOut "!testMsg!"
 			)
 		) else if "%%A" == "FAILED" (
 			if not "!testName!,!fileName!" == "," (
 				rem `start` does not wait for `%AppVeyor%` to return, so the main loop goes immediately.
-				start "" "%AppVeyor%" AddTest !testName! -Framework xUnit -FileName !fileName! -Outcome Failed -Duration %%C -ErrorMessage "!testMsg!"
+				if defined AppVeyor start "" "%AppVeyor%" AddTest !testName! -Framework xUnit -FileName !fileName! -Outcome Failed -Duration %%C -ErrorMessage "!testMsg!"
 			)
 		) else if "%%A" == "PASSED" (
 			rem

--- a/tests/test_result_filter_tell_AppVeyor.bat
+++ b/tests/test_result_filter_tell_AppVeyor.bat
@@ -22,7 +22,6 @@ set testMsg=
 for /F "usebackq delims=" %%L in (`FINDSTR /B "^"`) do (
 	echo %%L
 
-	if not "%AppVeyor%" == "" (
 		for /F "tokens=1,2,3,5 delims=[]() " %%A in ("%%L") do (
 			if "%%A" == "----------" (
 				if not "%%D" == "" (
@@ -49,5 +48,4 @@ for /F "usebackq delims=" %%L in (`FINDSTR /B "^"`) do (
 				set testMsg=!testMsg!%%L!NL!
 			)
 		)
-	)
 )


### PR DESCRIPTION
パイプで連結した複数のコマンドの終了コードは、最後のコマンドのもので代表されます。フィルタでテストの成功・失敗を判断しエラーレベルをセットします。

* 失敗の条件１ 失敗したテストがある
* 失敗の条件２ パスしたテスト数の報告(※０件の場合もある)がない。(テストのビルド・実行に失敗している可能性が高い)
* 成功の条件 失敗していないこと
