### PR TITLE
vs2017ビルド時のビルドログを整理する

### DIFF
--- a/calc-hash-res.bat
+++ b/calc-hash-res.bat
@@ -1,4 +1,3 @@
-@echo off
 set OUTHASHFILE=%1
 set SRCDIR=%2
 
@@ -24,7 +23,6 @@ if errorlevel 1 (
 ) else (
 	python calc-hash.py %OUTHASHFILE% %SRCDIR% .res
 )
-@echo on
 exit /b 0
 
 @rem ------------------------------------------------------------------------------

--- a/calc-hash.bat
+++ b/calc-hash.bat
@@ -1,4 +1,3 @@
-@echo off
 set OUTHASHFILE=%1
 set SRCDIR=%2
 
@@ -24,7 +23,6 @@ if errorlevel 1 (
 ) else (
 	python calc-hash.py %OUTHASHFILE% %SRCDIR%
 )
-@echo on
 exit /b 0
 
 @rem ------------------------------------------------------------------------------

--- a/sakura/postBuild.bat
+++ b/sakura/postBuild.bat
@@ -17,48 +17,45 @@ set PLATFORM=%1
 set CONFIGURATION=%2
 @echo CONFIGURATION=%CONFIGURATION%
 
-set DEST_DIR=..\%PLATFORM%\%CONFIGURATION%
+set DEST_DIR=%PLATFORM%\%CONFIGURATION%
+set OUT_DIR=%~dp0..\%DEST_DIR%
 
 : ---- bron412 ---- :
-set INSTALLER_RESOURCES_BRON=%~dp0..\installer\temp\bron
-set BRON_ZIP=%~dp0..\installer\externals\bregonig\bron412.zip
-set DLL_BREGONIG_NAME=bregonig.dll
+set BREGONIG_DLL=bregonig.dll
+set BRON_ZIP=..\installer\externals\bregonig\bron412.zip
+set BRON_TMP=..\installer\temp\bron
 if "%platform%" == "x64" (
-	set INSTALLER_RESOURCES_BRON_DLL=%INSTALLER_RESOURCES_BRON%\x64
+	set BRON_DIR=%~dp0%BRON_TMP%\x64
 ) else (
-	set INSTALLER_RESOURCES_BRON_DLL=%INSTALLER_RESOURCES_BRON%
+	set BRON_DIR=%~dp0%BRON_TMP%
 )
-
-if not exist "%INSTALLER_RESOURCES_BRON_DLL%\%DLL_BREGONIG_NAME%" (
-	@echo extract %BRON_ZIP%
-	call %UNZIP_CMD% %BRON_ZIP% %INSTALLER_RESOURCES_BRON% || (echo error && exit /b 1)
-)
-if not exist "%DEST_DIR%\%DLL_BREGONIG_NAME%" (
-	@echo %DLL_BREGONIG_NAME% to destination directory.
-	copy /Y /B %INSTALLER_RESOURCES_BRON_DLL%\%DLL_BREGONIG_NAME%  %DEST_DIR%\
+if not exist "%OUT_DIR%\%BREGONIG_DLL%" (
+	@echo %BRON_ZIP% -^> %DEST_DIR%\%BREGONIG_DLL%
+	if not exist "%BRON_DIR%\%BREGONIG_DLL%" (
+		call "%UNZIP_CMD%" "%~dp0%BRON_ZIP%" "%~dp0%BRON_TMP%" > NUL || (echo error && exit /b 1)
+	)
+	copy /Y /B "%BRON_DIR%\%BREGONIG_DLL%" "%OUT_DIR%\" > NUL
 )
 
 : ---- ctags.exe ---- :
-set INSTALLER_RESOURCES_CTAGS=%~dp0..\installer\temp\ctags
-set INSTALLER_RESOURCES_CTAGS_EXE=%INSTALLER_RESOURCES_CTAGS%
+set CTAGS_EXE=ctags.exe
 if "%PLATFORM%" == "Win32" (
 	set CTAGS_PREFIX=x86
 ) else if "%PLATFORM%" == "x64" (
 	set CTAGS_PREFIX=x64
 ) else (
-	@echo unknown PLATFORM %PLATFORM%
+	echo unknown PLATFORM %PLATFORM%
 	exit /b 1
 )
-set CTAGS_ZIP=%~dp0..\installer\externals\universal-ctags\ctags-2018-09-16_e522743d-%CTAGS_PREFIX%.zip
-set EXE_CTAGS_NAME=ctags.exe
-
-if not exist "%INSTALLER_RESOURCES_CTAGS_DLL%\%EXE_CTAGS_NAME%" (
-	@echo extract %CTAGS_ZIP%
-	call %UNZIP_CMD% %CTAGS_ZIP% %INSTALLER_RESOURCES_CTAGS% || (echo error && exit /b 1)
-)
-if not exist "%DEST_DIR%\%EXE_CTAGS_NAME%" (
-	@echo %EXE_CTAGS_NAME% to destination directory.
-	copy /Y /B %INSTALLER_RESOURCES_CTAGS_EXE%\%EXE_CTAGS_NAME%  %DEST_DIR%\
+set CTAGS_ZIP=..\installer\externals\universal-ctags\ctags-2018-09-16_e522743d-%CTAGS_PREFIX%.zip
+set CTAGS_TMP=..\installer\temp\ctags
+set CTAGS_DIR=%~dp0%CTAGS_TMP%
+if not exist "%OUT_DIR%\%CTAGS_EXE%" (
+	@echo %CTAGS_ZIP% -^> %DEST_DIR%\%CTAGS_EXE%
+	if not exist "%CTAGS_DIR%\%CTAGS_EXE%" (
+		call "%UNZIP_CMD%" "%~dp0%CTAGS_ZIP%" "%CTAGS_DIR%" > NUL || (echo error && exit /b 1)
+	)
+	copy /Y /B "%CTAGS_DIR%\%CTAGS_EXE%" "%OUT_DIR%\" > NUL
 )
 
 ENDLOCAL

--- a/tools/zip/listzip.bat
+++ b/tools/zip/listzip.bat
@@ -4,9 +4,9 @@ set SRCZIP=%1
 @rem CMD_7Z contains double quotes.
 if not defined CMD_7Z call "%~dp0..\find-tools.bat" > NUL
 if not defined CMD_7Z (
-	@echo -------------------------------------------------------
-	@echo ---- you can make this faster by installing 7-zip. ----
-	@echo -------------------------------------------------------
+	@echo ------------------------------------------------------- >&2
+	@echo ---- you can make this faster by installing 7-zip. ---- >&2
+	@echo ------------------------------------------------------- >&2
 	powershell -ExecutionPolicy RemoteSigned -File %~dp0listzip.ps1 %SRCZIP%
 ) else (
 	"%CMD_7Z%" l "%SRCZIP%"

--- a/tools/zip/listzip.bat
+++ b/tools/zip/listzip.bat
@@ -1,9 +1,8 @@
 set SRCZIP=%1
 
-
 @echo examining %SRCZIP%.
 @rem CMD_7Z contains double quotes.
-if not defined CMD_7Z call %~dp0..\find-tools.bat
+if not defined CMD_7Z call "%~dp0..\find-tools.bat" > NUL
 if not defined CMD_7Z (
 	@echo -------------------------------------------------------
 	@echo ---- you can make this faster by installing 7-zip. ----

--- a/tools/zip/listzip.bat
+++ b/tools/zip/listzip.bat
@@ -1,4 +1,3 @@
-@echo off
 set SRCZIP=%1
 
 
@@ -13,4 +12,3 @@ if not defined CMD_7Z (
 ) else (
 	"%CMD_7Z%" l "%SRCZIP%"
 )
-@echo on

--- a/tools/zip/unzip.bat
+++ b/tools/zip/unzip.bat
@@ -6,10 +6,10 @@ if exist "%OUTDIR%" rmdir /s /q "%OUTDIR%" > NUL
 @echo extracting %SRCZIP%.
 if not defined CMD_7Z call "%~dp0..\find-tools.bat" > NUL
 if not defined CMD_7Z (
-	@echo -------------------------------------------------------
-	@echo ---- you can make this faster by installing 7-zip. ----
-	@echo -------------------------------------------------------
+	@echo ------------------------------------------------------- >&2
+	@echo ---- you can make this faster by installing 7-zip. ---- >&2
+	@echo ------------------------------------------------------- >&2
 	powershell -ExecutionPolicy RemoteSigned -File %~dp0unzip.ps1 %SRCZIP% %OUTDIR%
 ) else (
-	"%CMD_7Z%" x "%SRCZIP%" "-o%OUTDIR%" > NUL
+	"%CMD_7Z%" x "%SRCZIP%" "-o%OUTDIR%"
 )

--- a/tools/zip/unzip.bat
+++ b/tools/zip/unzip.bat
@@ -1,15 +1,15 @@
 set SRCZIP=%1
 set OUTDIR=%2
 
-if exist "%OUTDIR%" rmdir /s /q "%OUTDIR%"
+if exist "%OUTDIR%" rmdir /s /q "%OUTDIR%" > NUL
 
 @echo extracting %SRCZIP%.
-if not defined CMD_7Z call %~dp0..\find-tools.bat
+if not defined CMD_7Z call "%~dp0..\find-tools.bat" > NUL
 if not defined CMD_7Z (
 	@echo -------------------------------------------------------
 	@echo ---- you can make this faster by installing 7-zip. ----
 	@echo -------------------------------------------------------
 	powershell -ExecutionPolicy RemoteSigned -File %~dp0unzip.ps1 %SRCZIP% %OUTDIR%
 ) else (
-	"%CMD_7Z%" x "%SRCZIP%"  -O"%OUTDIR%"
+	"%CMD_7Z%" x "%SRCZIP%" "-o%OUTDIR%" > NUL
 )

--- a/tools/zip/unzip.bat
+++ b/tools/zip/unzip.bat
@@ -1,4 +1,3 @@
-@echo off
 set SRCZIP=%1
 set OUTDIR=%2
 
@@ -14,4 +13,3 @@ if not defined CMD_7Z (
 ) else (
 	"%CMD_7Z%" x "%SRCZIP%"  -O"%OUTDIR%"
 )
-@echo on

--- a/tools/zip/zip.bat
+++ b/tools/zip/zip.bat
@@ -6,10 +6,10 @@ if exist "%DSTZIP%" del "%DSTZIP%"
 
 if not defined CMD_7Z call "%~dp0..\find-tools.bat" > NUL
 if not defined CMD_7Z (
-	@echo -------------------------------------------------------
-	@echo ---- you can make this faster by installing 7-zip. ----
-	@echo -------------------------------------------------------
+	@echo ------------------------------------------------------- >&2
+	@echo ---- you can make this faster by installing 7-zip. ---- >&2
+	@echo ------------------------------------------------------- >&2
 	powershell -ExecutionPolicy RemoteSigned -File %~dp0zip.ps1 %DSTZIP% %SRCDIR%
 ) else (
-	"%CMD_7Z%" a "%DSTZIP%" -r "%SRCDIR%" > NUL
+	"%CMD_7Z%" a "%DSTZIP%" -r "%SRCDIR%"
 )

--- a/tools/zip/zip.bat
+++ b/tools/zip/zip.bat
@@ -4,12 +4,12 @@ set SRCDIR=%2
 if exist "%DSTZIP%" del "%DSTZIP%"
 @echo archiving %SRCZIP%.
 
-if not defined CMD_7Z call %~dp0..\find-tools.bat
+if not defined CMD_7Z call "%~dp0..\find-tools.bat" > NUL
 if not defined CMD_7Z (
 	@echo -------------------------------------------------------
 	@echo ---- you can make this faster by installing 7-zip. ----
 	@echo -------------------------------------------------------
 	powershell -ExecutionPolicy RemoteSigned -File %~dp0zip.ps1 %DSTZIP% %SRCDIR%
 ) else (
-	"%CMD_7Z%" a "%DSTZIP%"  -r "%SRCDIR%"
+	"%CMD_7Z%" a "%DSTZIP%" -r "%SRCDIR%" > NUL
 )

--- a/tools/zip/zip.bat
+++ b/tools/zip/zip.bat
@@ -1,4 +1,3 @@
-@echo off
 set DSTZIP=%1
 set SRCDIR=%2
 
@@ -14,4 +13,3 @@ if not defined CMD_7Z (
 ) else (
 	"%CMD_7Z%" a "%DSTZIP%"  -r "%SRCDIR%"
 )
-@echo on


### PR DESCRIPTION
## 目的

ビルド後に実行している`postBuild.bat`の出力を整理します。
ログを整理することで、コンパイラ警告やエラーメッセージに集中できるようになります。

バッチの変更だけだとイメージしづらいので、具体的にどうなるかをキャプチャで示します。

### 変更前
![2019-02-17 2](https://user-images.githubusercontent.com/3253151/53067963-eab9a400-3519-11e9-96fe-6f90c7153207.png)

### 変更後
![2019-02-17 1](https://user-images.githubusercontent.com/3253151/53067973-f2794880-3519-11e9-9ac8-9b66675b108a.png)

## 説明

キャプチャはvs2017でsakura.slnをビルドしたときの`postBuild.bat`実行開始付近を撮ったものです。
変更後は `zip->dll(exe)` だけが出力されるようになります。

このバッチの出力が誰のためのものか？
なにか問題が起こったときに対処するのはどんな人か？

と考えて「これ以上の情報は不要」と判断しました。

@KageShiron さんのPRと修正ファイルが被りますが、修正軸が異なるので別件として検討可能だと思っています。