### PR TITLE
githash.batでgitを探すようにする

### DIFF
--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -16,11 +16,28 @@ pushd "%~dp0"
 
 : Git enabled checking
 set GIT_ENABLED=1
+if defined GIT_CMD goto :end_of_find_git
 where git 1>nul 2>&1
+if errorlevel 1 (
+	@echo no git in PATH
+) else (
+	set GIT_CMD=git
+	goto :end_of_find_git
+)
+where /R "%ProgramFiles%\Git\cmd" git.exe > NUL 2>&1
 if errorlevel 1 (
 	set GIT_ENABLED=0
 	@echo NOTE: No git command
+	goto :end_of_find_git
 )
+set GIT_CMD=%ProgramFiles%\Git\cmd\git.exe
+if not exist "%GIT_CMD%" (
+	set GIT_ENABLED=0
+	@echo NOTE: No git command
+	goto :end_of_find_git
+)
+
+:end_of_find_git
 if not exist ..\.git (
 	set GIT_ENABLED=0
 	@echo NOTE: No .git directory
@@ -28,13 +45,13 @@ if not exist ..\.git (
 
 : Get git hash if git is enabled
 if "%GIT_ENABLED%" == "1" (
-	for /f "usebackq" %%s in (`git show -s --format^=%%h`) do (
+	for /f "usebackq" %%s in (`"%GIT_CMD%" show -s --format^=%%h`) do (
 		set GIT_SHORT_COMMIT_HASH=%%s
 	)
-	for /f "usebackq" %%s in (`git show -s --format^=%%H`) do (
+	for /f "usebackq" %%s in (`"%GIT_CMD%" show -s --format^=%%H`) do (
 		set GIT_COMMIT_HASH=%%s
 	)
-	for /f "usebackq" %%s in (`git config --get remote.origin.url`) do (
+	for /f "usebackq" %%s in (`"%GIT_CMD%" config --get remote.origin.url`) do (
 		set GIT_REMOTE_ORIGIN_URL=%%s
 	)
 ) else (

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -1,4 +1,4 @@
-@echo off
+@rem echo off
 
 set OUT_DIR=%~1
 if "%OUT_DIR%" == "" (
@@ -16,28 +16,11 @@ pushd "%~dp0"
 
 : Git enabled checking
 set GIT_ENABLED=1
-if defined GIT_CMD goto :end_of_find_git
-where git 1>nul 2>&1
-if errorlevel 1 (
-	@echo no git in PATH
-) else (
-	set GIT_CMD=git
-	goto :end_of_find_git
-)
-where /R "%ProgramFiles%\Git\cmd" git.exe > NUL 2>&1
-if errorlevel 1 (
+if not defined CMD_GIT call "%~dp0..\tools\find-tools.bat"
+if not defined CMD_GIT (
 	set GIT_ENABLED=0
 	@echo NOTE: No git command
-	goto :end_of_find_git
 )
-set GIT_CMD=%ProgramFiles%\Git\cmd\git.exe
-if not exist "%GIT_CMD%" (
-	set GIT_ENABLED=0
-	@echo NOTE: No git command
-	goto :end_of_find_git
-)
-
-:end_of_find_git
 if not exist ..\.git (
 	set GIT_ENABLED=0
 	@echo NOTE: No .git directory
@@ -45,13 +28,13 @@ if not exist ..\.git (
 
 : Get git hash if git is enabled
 if "%GIT_ENABLED%" == "1" (
-	for /f "usebackq" %%s in (`"%GIT_CMD%" show -s --format^=%%h`) do (
+	for /f "usebackq" %%s in (`"%CMD_GIT%" show -s --format^=%%h`) do (
 		set GIT_SHORT_COMMIT_HASH=%%s
 	)
-	for /f "usebackq" %%s in (`"%GIT_CMD%" show -s --format^=%%H`) do (
+	for /f "usebackq" %%s in (`"%CMD_GIT%" show -s --format^=%%H`) do (
 		set GIT_COMMIT_HASH=%%s
 	)
-	for /f "usebackq" %%s in (`"%GIT_CMD%" config --get remote.origin.url`) do (
+	for /f "usebackq" %%s in (`"%CMD_GIT%" config --get remote.origin.url`) do (
 		set GIT_REMOTE_ORIGIN_URL=%%s
 	)
 ) else (

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -1,4 +1,4 @@
-@rem echo off
+@echo off
 
 set OUT_DIR=%~1
 if "%OUT_DIR%" == "" (

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -7,20 +7,31 @@ if defined FIND_TOOLS_CALLED (
 )
 
 echo find-tools.bat
+if not defined CMD_GIT call :Git 2> nul
 if not defined CMD_7Z call :7z 2> nul
 if not defined CMD_HHC call :hhc 2> nul
 if not defined CMD_ISCC call :iscc 2> nul
 if not defined CMD_CPPCHECK call :cppcheck 2> nul
 if not defined CMD_DOXYGEN call :doxygen 2> nul
 if not defined CMD_MSBUILD call :msbuild 2> nul
+echo ^|- CMD_GIT=%CMD_GIT%
 echo ^|- CMD_7Z=%CMD_7Z%
 echo ^|- CMD_HHC=%CMD_HHC%
 echo ^|- CMD_ISCC=%CMD_ISCC%
 echo ^|- CMD_CPPCHECK=%CMD_CPPCHECK%
 echo ^|- CMD_DOXYGEN=%CMD_DOXYGEN%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
-endlocal && set "CMD_7Z=%CMD_7Z%" && set "CMD_HHC=%CMD_HHC%" && set "CMD_ISCC=%CMD_ISCC%" && set "CMD_CPPCHECK=%CMD_CPPCHECK%" && set "CMD_DOXYGEN=%CMD_DOXYGEN%"&& set "CMD_MSBUILD=%CMD_MSBUILD%"
+endlocal && set "CMD_GIT=%CMD_GIT%" && set "CMD_7Z=%CMD_7Z%" && set "CMD_HHC=%CMD_HHC%" && set "CMD_ISCC=%CMD_ISCC%" && set "CMD_CPPCHECK=%CMD_CPPCHECK%" && set "CMD_DOXYGEN=%CMD_DOXYGEN%"&& set "CMD_MSBUILD=%CMD_MSBUILD%"
 set FIND_TOOLS_CALLED=1
+exit /b
+
+:Git
+set APPDIR=Git\Cmd
+set PATH2=%PATH%;%ProgramFiles%\%APPDIR%\;%ProgramFiles(x86)%\%APPDIR%\;%ProgramW6432%\%APPDIR%\;
+for /f "usebackq delims=" %%a in (`where $PATH2:Git`) do ( 
+    set "CMD_GIT=%%a"
+    exit /b
+)
 exit /b
 
 :7z

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -13,6 +13,7 @@
 ## 外部ツールの一覧
 |      ツール名      |   環境変数   |   デフォルトパス   |  ファイル名  |
 | ------------------ | ------------ | ------------------ | ------------ |
+| Git for Windows    | CMD_GIT      | Git\Cmd            | git.exe      |
 | 7-Zip              | CMD_7Z       | 7-Zip              | 7z           |
 | HTML Help Workshop | CMD_HHC      | HTML Help Workshop | hhc.exe      |
 | Inno Setup 5       | CMD_ISCC     | Inno Setup 5       | ISCC.exe     |


### PR DESCRIPTION
表題の通り、githash.batに対する微改善です。

現在のコードは、`git hash`する前に `where git` して、
見つからなければ `No git command` と表示しています。
これは Git に PATH を通している場合にだけ有効なコードです。
ぼくが愛用している自宅環境では、毎回コレが出ます...orz

まぁ、PATH通したらいいだけの話なんですけども、
PATHを通すかどうかは、一応「個人の自由」だと思います。
他のツール向けの `find-tools.bat` では結構色々探す努力をしているので、
そちらとの差が大きいのも少し気になっていました。

~~対策として以下2点を対応してみました。~~

1. ~~他ツール同様に環境変数 `GIT_CMD` を定義できるようにする。~~
1. ~~標準のインストールパス`(%ProgramFiles%\Git\Cmd)`も見るようにする。~~

----

コメントで `find-tools.bat` に組み込んだほうが良いとの指摘を貰ったので、「`find-tools.bat`に機能追加」 + 「`githash.bat` で `find-tools.bat` を使う」に組み替えました。

利用する環境変数は `GIT_CMD` ⇒ `CMD_GIT` になります。