### PR TITLE
「同名のC/C++ヘッダ(ソース)を開く」機能が利用可能か調べる処理で拡張子の確認が行われるように記述追加

### DIFF
--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -309,7 +309,7 @@ BOOL CViewCommander::Command_OPEN_HfromtoC( BOOL bCheckOnly )
 {
 	if ( Command_OPEN_HHPP( bCheckOnly, FALSE ) )	return TRUE;
 	if ( Command_OPEN_CCPP( bCheckOnly, FALSE ) )	return TRUE;
-	ErrorBeep();
+	if (!bCheckOnly) ErrorBeep();
 	return FALSE;
 // 2002/03/24 YAZAKI コードの重複を削減
 // 2003.06.28 Moca コメントとして残っていたコードを削除

--- a/sakura_core/func/Funccode.cpp
+++ b/sakura_core/func/Funccode.cpp
@@ -1174,13 +1174,14 @@ bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EF
 	case F_UNDO:		return pcEditDoc->m_cDocEditor.IsEnableUndo();	/* Undo(元に戻す)可能な状態か？ */
 	case F_REDO:		return pcEditDoc->m_cDocEditor.IsEnableRedo();	/* Redo(やり直し)可能な状態か？ */
 
+	case F_OPEN_HfromtoC:				//同名のC/C++ヘッダ(ソース)を開く	//Feb. 7, 2001 JEPRO 追加
+//	case F_OPEN_HHPP:					//同名のC/C++ヘッダファイルを開く	//Feb. 9, 2001 jepro「.cまたは.cppと同名の.hを開く」から変更		del 2008/6/23 Uchi
+//	case F_OPEN_CCPP:					//同名のC/C++ソースファイルを開く	//Feb. 9, 2001 jepro「.hと同名の.c(なければ.cpp)を開く」から変更	del 2008/6/23 Uchi
+		return pcEditDoc->m_cDocFile.GetFilePathClass().IsValidPath() && pcEditDoc->m_pcEditWnd->GetActiveView().GetCommander().Command_OPEN_HfromtoC(TRUE);
 	case F_COPYPATH:
 	case F_COPYDIRPATH:
 	case F_COPYTAG:
 	case F_COPYFNAME:					// 2002/2/3 aroka
-	case F_OPEN_HfromtoC:				//同名のC/C++ヘッダ(ソース)を開く	//Feb. 7, 2001 JEPRO 追加
-//	case F_OPEN_HHPP:					//同名のC/C++ヘッダファイルを開く	//Feb. 9, 2001 jepro「.cまたは.cppと同名の.hを開く」から変更		del 2008/6/23 Uchi
-//	case F_OPEN_CCPP:					//同名のC/C++ソースファイルを開く	//Feb. 9, 2001 jepro「.hと同名の.c(なければ.cpp)を開く」から変更	del 2008/6/23 Uchi
 	case F_PLSQL_COMPILE_ON_SQLPLUS:	/* Oracle SQL*Plusで実行 */
 	case F_BROWSE:						//ブラウズ
 	//case F_VIEWMODE:					//ビューモード	//	Sep. 10, 2002 genta 常に使えるように


### PR DESCRIPTION
変更内容は件名の通りです。

該当処理（`CViewCommander::Command_OPEN_HfromtoC`）の第1引数の値が TRUE だとチェックのみを行うのでそれを使用しました。
