### PR TITLE
EXE 用の artifacts を Developer 用の artifacts に分離 (EXE の ZIP に入れるファイルが多いのでは？)

### DIFF
--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -145,11 +145,13 @@ set WORKDIR=%BASENAME%
 
 set RELDIR_LOG=Log
 set RELDIR_EXE=EXE
+set RELDIR_DEV=DEV
 set RELDIR_INST=Installer
 set RELDIR_ASM=Asm
 
 set WORKDIR_LOG=%WORKDIR%\%RELDIR_LOG%
 set WORKDIR_EXE=%WORKDIR%\%RELDIR_EXE%
+set WORKDIR_DEV=%WORKDIR%\%RELDIR_DEV%
 set WORKDIR_INST=%WORKDIR%\%RELDIR_INST%
 set WORKDIR_ASM=%WORKDIR%\%RELDIR_ASM%
 
@@ -158,6 +160,7 @@ set OUTFILE_LOG=%~dp0%BASENAME%-Log.zip
 set OUTFILE_ASM=%~dp0%BASENAME%-Asm.zip
 set OUTFILE_INST=%~dp0%BASENAME%-Installer.zip
 set OUTFILE_EXE=%~dp0%BASENAME%-Exe.zip
+set OUTFILE_DEV=%~dp0%BASENAME%-Dev.zip
 
 @rem cleanup for local testing
 if exist "%OUTFILE%" (
@@ -175,6 +178,9 @@ if exist "%OUTFILE_INST%" (
 if exist "%OUTFILE_EXE%" (
 	del %OUTFILE_EXE%
 )
+if exist "%OUTFILE_DEV%" (
+	del %OUTFILE_DEV%
+)
 if exist "%WORKDIR%" (
 	rmdir /s /q "%WORKDIR%"
 )
@@ -188,10 +194,11 @@ mkdir %WORKDIR_EXE%
 mkdir %WORKDIR_EXE%\license\
 mkdir %WORKDIR_EXE%\license\bregonig\
 mkdir %WORKDIR_EXE%\license\ctags\
+mkdir %WORKDIR_DEV%
 mkdir %WORKDIR_INST%
 copy /Y /B %platform%\%configuration%\sakura.exe %WORKDIR_EXE%\
 copy /Y /B %platform%\%configuration%\*.dll      %WORKDIR_EXE%\
-copy /Y /B %platform%\%configuration%\*.pdb      %WORKDIR_EXE%\
+copy /Y /B %platform%\%configuration%\*.pdb      %WORKDIR_DEV%\
 
 : LICENSE
 copy /Y .\LICENSE                                   %WORKDIR_EXE%\license\ > NUL
@@ -209,8 +216,8 @@ copy /Y /B %INSTALLER_RESOURCES_CTAGS%\license\*.*  %WORKDIR_EXE%\license\ctags\
 copy /Y /B help\macro\macro.chm    %WORKDIR_EXE%\
 copy /Y /B help\plugin\plugin.chm  %WORKDIR_EXE%\
 copy /Y /B help\sakura\sakura.chm  %WORKDIR_EXE%\
-copy /Y /B html\sakura-doxygen.chm %WORKDIR_EXE%\
-copy /Y /B html\sakura-doxygen.chi %WORKDIR_EXE%\
+copy /Y /B html\sakura-doxygen.chm %WORKDIR_DEV%\
+copy /Y /B html\sakura-doxygen.chi %WORKDIR_DEV%\
 
 copy /Y /B installer\Output-%platform%\*.exe       %WORKDIR_INST%\
 copy /Y msbuild-%platform%-%configuration%.log     %WORKDIR_LOG%\
@@ -269,6 +276,7 @@ copy /Y installer\warning.txt        %WORKDIR_INST%\
 
 pushd %WORKDIR_INST% && call %ZIP_CMD%       %OUTFILE_INST% .  && popd
 pushd %WORKDIR_EXE%  && call %ZIP_CMD%       %OUTFILE_EXE%  .  && popd
+pushd %WORKDIR_DEV%  && call %ZIP_CMD%       %OUTFILE_DEV%  .  && popd
 
 @echo start zip asm
 mkdir %WORKDIR_ASM%


### PR DESCRIPTION
EXE 用の artifacts を Developer 用の artifacts に分離

- https://github.com/sakura-editor/management-forum/issues/66#issuecomment-477018403
- https://github.com/sakura-editor/management-forum/issues/66#issuecomment-477021757

※ sakura_lang_en_US.pdb はサイズ小さいし、含めたほうがバッチファイル中の pdb のコピールール作成するの簡単になるので含めたままにしています。
やはり、削除したほうが良ければコメントください。

