### PR TITLE
skip_commits を追加して、appveyor のビルドで無視するファイルを追加する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ platform:
   - x64
   - MinGW
 
+# see "Skip commits" at https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only
 skip_commits:
   files:
     - '*.md'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,13 @@ platform:
   - x64
   - MinGW
 
+skip_commits:
+  files:
+    - '*.md'
+    - .gitignore
+    - .editorconfig
+    - 'azure-pipelines*.yml'
+
 install:
 - cmd: |
     pip install openpyxl --user


### PR DESCRIPTION
closes #817:  appveyor の [Commit files の Skip commits](https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only) を使用することにより、変更されても CI の対象から外すパスを指定する。

