### PR TITLE
azure pipelines の badge を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Github Releases All](https://img.shields.io/github/downloads/sakura-editor/sakura/total.svg)](https://github.com/sakura-editor/sakura/releases "All Releases")
 [![License: Zlib](https://img.shields.io/badge/License-Zlib-lightgrey.svg)](https://opensource.org/licenses/Zlib)
 [![CodeFactor](https://www.codefactor.io/repository/github/sakura-editor/sakura/badge)](https://www.codefactor.io/repository/github/sakura-editor/sakura)
+[![Build Status](https://dev.azure.com/sakuraeditor/sakura/_apis/build/status/sakura-editor.sakura?branchName=master)](https://dev.azure.com/sakuraeditor/sakura/_build/latest?definitionId=3&branchName=master)
 
 <!-- TOC -->
 


### PR DESCRIPTION
azure pipelines の badge を追加

- ファイルの差分画面で `View File` を押していただけるとプレビュー表示できます。
- badge の記述に関しては https://mikepfeiffer.io/azure-devops-pipeline.html のページの`Set up a Build Badge for Your Project` のとこらへんに載っています。
