### PR TITLE
EXEとInstallerのzipのmd5ファイルを作成

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,4 +32,6 @@ build_script:
     tests\build-and-test.bat %PLATFORM% %CONFIGURATION%
 
 artifacts:
-- path: 'sakura-*$(platform)-$(configuration)*.zip'
+  - path: 'sakura-*$(platform)-$(configuration)*.zip'
+  - path: 'sakura-*$(platform)-$(configuration)*.zip.md5'
+  - path: 'sha256.txt'

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -292,6 +292,13 @@ if exist "%WORKDIR_ASM%" (
 	rmdir /s /q "%WORKDIR_ASM%"
 )
 
+
+@echo start generate MD5 hash
+certutil -hashfile %OUTFILE_EXE% MD5  | find /v "MD5" | find /v "CertUtil" > %OUTFILE_EXE%.md5
+certutil -hashfile %OUTFILE_INST% MD5 | find /v "MD5" | find /v "CertUtil" > %OUTFILE_INST%.md5
+@echo end generate MD5 hash
+
+
 exit /b 0
 
 @rem ------------------------------------------------------------------------------


### PR DESCRIPTION
[v2\.4\.0 alpha1 pre\-release 確認issue · Issue \#66 · sakura\-editor/management\-forum](https://github.com/sakura-editor/management-forum/issues/66) より、リリース時に md5 ファイルもappveyorで作りたいということなので対応してみました。

certutil で作っているので、そのままだと
```
MD5 hash of file C:\projects\sakura\sakura-takke-build4-5959d7f3-Win32-Debug-Exe.zip:
4f812ce8f1b4c5077777fa84cb386f57
CertUtil: -hashfile command completed successfully.
```
のように3行になってしまうので、`find /v` で1行目と3行目を削っています。
([バッチファイルで MD5 チェックサムを生成する \- norastepの日記](http://norastep.hatenablog.com/entry/2016/10/05/002304) を参考にしました)


また、sha256.txt も Artifacts にアップロードするようにしました。
あって困るものでもなさそうなので追加しただけですが、あえてArtifactsに含まないようにする意図があるなら元に戻します。