### PR TITLE
azure pipelines で代用可能な処理を appveyor で実施しないようにする

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,13 +22,9 @@ skip_commits:
 install:
 - cmd: |
     pip install openpyxl --user
-    pip install chardet --user
-    msiexec /i externals\cppcheck\cppcheck-1.84-x64-Setup.msi /quiet /qn /norestart /log cppcheck-install.log
-    externals\doxygen\doxygen-1.8.14-setup.exe /silent /suppressmsgboxes
 
 build_script:
 - cmd: |
-    checkEncoding.bat
     build-all.bat %PLATFORM% %CONFIGURATION%
     tests\build-and-test.bat %PLATFORM% %CONFIGURATION%
 

--- a/build-all.bat
+++ b/build-all.bat
@@ -47,16 +47,6 @@ call build-installer.bat %PLATFORM% %CONFIGURATION% || (echo error build-install
 @echo ---- end   build-installer.bat ----
 @echo.
 
-@echo ---- start run-cppcheck.bat ----
-call run-cppcheck.bat %PLATFORM% %CONFIGURATION%    || (echo error run-cppcheck.bat    && exit /b 1)
-@echo ---- end   run-cppcheck.bat ----
-@echo.
-
-@echo ---- start run-doxygen.bat ----
-call run-doxygen.bat %PLATFORM% %CONFIGURATION%     || (echo error run-doxygen.bat     && exit /b 1)
-@echo ---- end   run-doxygen.bat ----
-@echo.
-
 @echo ---- start zipArtifacts.bat ----
 call zipArtifacts.bat    %PLATFORM% %CONFIGURATION% || (echo error zipArtifacts.bat    && exit /b 1)
 @echo ---- end   zipArtifacts.bat ----


### PR DESCRIPTION
azure pipelines で代用可能な処理を appveyor で実施しないようにする