### PR TITLE
googletest のテスト結果を成功、失敗含めて azure pipelines の Web サイトで確認できるようにする

### DIFF
--- a/azure-pipelines.md
+++ b/azure-pipelines.md
@@ -12,6 +12,8 @@
     - [Azure Pipelines の設定ファイルの構成](#azure-pipelines-の設定ファイルの構成)
     - [Azure Pipelines の template ファイルの命名規則](#azure-pipelines-の-template-ファイルの命名規則)
     - [Azure Pipelines のJOB の構成](#azure-pipelines-のjob-の構成)
+    - [Azure Pipelines の TIPS](#azure-pipelines-の-tips)
+        - [step または JOB の実行条件](#step-または-job-の実行条件)
 
 <!-- /TOC -->
 
@@ -76,3 +78,26 @@ https://azure.microsoft.com/ja-jp/services/devops/pipelines/ にアクセスし�
 |doxygen              | doxygen  を行う              | [ci/azure-pipelines/template.job.doxygen.yml](ci/azure-pipelines/template.job.doxygen.yml)               |
 |checkEncoding        | 文字コードのチェックを行う   | [ci/azure-pipelines/template.job.checkEncoding.yml](ci/azure-pipelines/template.job.checkEncoding.yml)   |
 |script_check         | python のコンパイルのチェックを行う   | [ci/azure-pipelines/template.job.python-check.yml](ci/azure-pipelines/template.job.python-check.yml)   |
+
+## Azure Pipelines の TIPS
+
+### step または JOB の実行条件
+
+googletest でテストを実施するにあたって、googletest のテスト結果にかからわず、テスト結果の公開を行いたい。(参考: [#837](https://github.com/sakura-editor/sakura/pull/837) )
+
+[Specify conditions](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml) で説明されているように
+[condition](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml) を指定することで指定した JOB または step を
+実行する条件を指定することができる。
+
+以下の例では `succeededOrFailed()` を指定しているので、前段の step が成功しても、失敗しても実行される。(ただし JOB がキャンセルされたときには実行しない)
+
+```
+  - task: CopyFiles@1
+    condition: succeededOrFailed()
+    displayName: Copy to ArtifactStagingDirectory
+    inputs:
+      contents: '**.zip'
+      targetFolder: $(Build.ArtifactStagingDirectory)
+```
+
+

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -54,7 +54,15 @@ jobs:
     displayName: Unit test
 
   # see https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/copy-files?view=azure-devops&tabs=yaml
+  #
+  # "condition:" に関しては以下を参照
+  #     https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml
+  #
+  # "succeededOrFailed()" に関しては以下を参照
+  #     https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml#job-status-functions
+  #
   - task: CopyFiles@1
+    condition: succeededOrFailed()
     displayName: Copy to ArtifactStagingDirectory
     inputs:
       contents: '**.zip'
@@ -62,6 +70,7 @@ jobs:
 
   # see https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml
   - task: PublishBuildArtifacts@1
+    condition: succeededOrFailed()
     displayName: Publish ArtifactStagingDirectory
     inputs:
        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
@@ -69,6 +78,7 @@ jobs:
 
   # see https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml
   - task: PublishTestResults@2
+    condition: succeededOrFailed()
     inputs:
       testResultsFormat: 'JUnit'
       testResultsFiles: '**/*-googletest-*.xml'

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -66,3 +66,16 @@ jobs:
     inputs:
        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
        artifactName: $(BuildPlatform)_$(Configuration)
+
+  # see https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '**/*-googletest-*.xml' 
+      #searchFolder: '$(System.DefaultWorkingDirectory)' # Optional
+      #mergeTestResults: false # Optional
+      #failTaskOnFailedTests: false # Optional
+      #testRunTitle: # Optional
+      #buildPlatform: # Optional
+      #buildConfiguration: # Optional
+      #publishRunAttachments: true # Optional

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -71,7 +71,7 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'JUnit'
-      testResultsFiles: '**/*-googletest-*.xml' 
+      testResultsFiles: '**/*-googletest-*.xml'
       #searchFolder: '$(System.DefaultWorkingDirectory)' # Optional
       #mergeTestResults: false # Optional
       #failTaskOnFailedTests: false # Optional

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -18,7 +18,7 @@ for /r %%i in (tests*.exe) do (
 	%%i --gtest_list_tests || set ERROR_RESULT=1
 
 	@echo %%i | "%FILTER_BAT%"
-	%%i | "%FILTER_BAT%" || set ERROR_RESULT=1
+	%%i --gtest_output=xml:%%i-googletest-%platform%-%configuration%.xml  | "%FILTER_BAT%" || set ERROR_RESULT=1
 )
 popd
 popd

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -17,7 +17,7 @@ for /r %%i in (tests*.exe) do (
 	@echo %%i --gtest_list_tests
 	%%i --gtest_list_tests || set ERROR_RESULT=1
 
-	@echo %%i --gtest_output=xml:%%i-googletest-%platform%-%configuration%.xml | "%FILTER_BAT%"
+	@echo %%i --gtest_output=xml:%%i-googletest-%platform%-%configuration%.xml ^| "%FILTER_BAT%"
 	%%i --gtest_output=xml:%%i-googletest-%platform%-%configuration%.xml  | "%FILTER_BAT%" || set ERROR_RESULT=1
 )
 popd

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -17,7 +17,7 @@ for /r %%i in (tests*.exe) do (
 	@echo %%i --gtest_list_tests
 	%%i --gtest_list_tests || set ERROR_RESULT=1
 
-	@echo %%i | "%FILTER_BAT%"
+	@echo %%i --gtest_output=xml:%%i-googletest-%platform%-%configuration%.xml | "%FILTER_BAT%"
 	%%i --gtest_output=xml:%%i-googletest-%platform%-%configuration%.xml  | "%FILTER_BAT%" || set ERROR_RESULT=1
 )
 popd


### PR DESCRIPTION
googletest のテスト結果を成功、失敗含めて azure pipelines の Web サイトで確認できるようにする
closes: #835

[Job status functions](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml#job-status-functions) の指定を行うことにより、googletest の実行用の step が失敗してもテスト結果を公開する。

参考資料
- https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/copy-files?view=azure-devops&tabs=yaml
- https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml
- https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml
- https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml#job-status-functions



※ appveyor には影響ないはずだが、共通で使用しているバッチファイルで実行ファイルに引数を追加している。
↑ 表示だけだが、appveyor に影響する修正が入った。