### PR TITLE
Vistaスタイルのファイルダイアログでカスタマイズ部分が表示されない場合がある問題の修正

### DIFF
--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -717,6 +717,7 @@ bool CDlgOpenFile_CommonItemDialog::DoModalOpenDlg(
 	}
 	m_bViewMode = pLoadInfo->bViewMode;
 	m_nCharCode = pLoadInfo->eCharCode;	/* 文字コード自動判別 */
+	m_customizeSetting.bCustomize = true;
 	m_customizeSetting.bShowReadOnly = true;
 	m_customizeSetting.bSkipAutoDetect = false;
 	m_customizeSetting.bUseCharCode = bOptions;


### PR DESCRIPTION
#844 で報告した問題に対する対処です。

メンバ変数の初期化が漏れていて不定値のままになっていたのが原因でした。



