### PR TITLE
WIP: HDC を再利用して CaretUnderLineON に使う

### DIFF
--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -79,10 +79,17 @@ inline int CCaret::GetHankakuDy() const
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /* カーソル行アンダーラインのON */
-void CCaretUnderLine::CaretUnderLineON( bool bDraw, bool bPaintDraw )
+void CCaretUnderLine::CaretUnderLineON(HDC hdc, bool bDraw, bool bPaintDraw )
 {
 	if( m_nLockCounter ) return;	//	ロックされていたら何もできない。
-	m_pcEditView->CaretUnderLineON( bDraw, bPaintDraw, m_nUnderLineLockCounter != 0 );
+	m_pcEditView->CaretUnderLineON(hdc, bDraw, bPaintDraw, m_nUnderLineLockCounter != 0 );
+}
+
+/* カーソル行アンダーラインのON */
+void CCaretUnderLine::CaretUnderLineON(bool bDraw, bool bPaintDraw )
+{
+	if( m_nLockCounter ) return;	//	ロックされていたら何もできない。
+	m_pcEditView->CaretUnderLineON(bDraw, bPaintDraw, m_nUnderLineLockCounter != 0 );
 }
 
 /* カーソル行アンダーラインのOFF */
@@ -353,13 +360,12 @@ CLayoutInt CCaret::MoveCursor(
 		/* キャレットの表示・更新 */
 		ShowEditCaret();
 
+		HDC hdc = m_pEditView->GetDC();
 		/* ルーラの再描画 */
-		HDC		hdc = m_pEditView->GetDC();
 		m_pEditView->GetRuler().DispRuler( hdc );
-		m_pEditView->ReleaseDC( hdc );
-
 		/* アンダーラインの再描画 */
-		m_cUnderLine.CaretUnderLineON(true, bDrawPaint);
+		m_cUnderLine.CaretUnderLineON(hdc, true, bDrawPaint);
+		m_pEditView->ReleaseDC( hdc );
 
 		/* キャレットの行桁位置を表示する */
 		ShowCaretPosInfo();

--- a/sakura_core/view/CCaret.h
+++ b/sakura_core/view/CCaret.h
@@ -67,6 +67,7 @@ public:
 			m_nUnderLineLockCounter = 0;
 		}
 	}
+	void CaretUnderLineON(HDC hdc, bool bDraw, bool bPaintDraw);	// カーソル行アンダーラインのON
 	void CaretUnderLineON(bool bDraw, bool bPaintDraw);	// カーソル行アンダーラインのON
 	void CaretUnderLineOFF(bool bDraw, bool bDrawPaint = true, bool bResetFlag = false );	// カーソル行アンダーラインのOFF
 	void SetUnderLineDoNotOFF( bool flag ){ if( !m_nLockCounter )m_bUnderLineDoNotOFF = flag; }

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -267,8 +267,9 @@ public:
 	void RedrawAll();											/* フォーカス移動時の再描画 */
 	void Redraw();										// 2001/06/21 asa-o 再描画
 	void RedrawLines( CLayoutYInt top, CLayoutYInt bottom );
-	void CaretUnderLineON(bool bDraw, bool bDrawPaint, bool DisalbeUnderLine);						/* カーソル行アンダーラインのON */
-	void CaretUnderLineOFF(bool bDraw, bool bDrawPaint, bool bResetFlag, bool DisalbeUnderLine);				/* カーソル行アンダーラインのOFF */
+	void CaretUnderLineON(HDC hdc, bool bDraw, bool bDrawPaint, bool DisableUnderLine);		/* カーソル行アンダーラインのON */
+	void CaretUnderLineON(bool bDraw, bool bDrawPaint, bool DisableUnderLine);				/* カーソル行アンダーラインのON */
+	void CaretUnderLineOFF(bool bDraw, bool bDrawPaint, bool bResetFlag, bool DisableUnderLine);				/* カーソル行アンダーラインのOFF */
 	bool GetDrawSwitch() const
 	{
 		return m_bDrawSWITCH;

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -622,7 +622,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 		);
 		if ( m_pcEditWnd->GetActivePane() == m_nMyIndex ){
 			/* アクティブペインは、アンダーライン描画 */
-			GetCaret().m_cUnderLine.CaretUnderLineON( true, false );
+			GetCaret().m_cUnderLine.CaretUnderLineON( _hdc, true, false );
 		}
 		return;
 	}
@@ -847,7 +847,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 	//     アンダーライン描画をメモリDCからのコピー前処理から後に移動
 	if ( m_pcEditWnd->GetActivePane() == m_nMyIndex ){
 		/* アクティブペインは、アンダーライン描画 */
-		GetCaret().m_cUnderLine.CaretUnderLineON( true, false );
+		GetCaret().m_cUnderLine.CaretUnderLineON( _hdc, true, false );
 	}
 	// To Here 2007.09.09 Moca
 

--- a/sakura_core/view/CEditView_Paint_Bracket.cpp
+++ b/sakura_core/view/CEditView_Paint_Bracket.cpp
@@ -240,7 +240,7 @@ void CEditView::DrawBracketPair( bool bDraw )
 
 				if( ( m_pcEditWnd->GetActivePane() == m_nMyIndex )
 					&& ( ( ptColLine.y == GetCaret().GetCaretLayoutPos().GetY() ) || ( ptColLine.y - 1 == GetCaret().GetCaretLayoutPos().GetY() ) ) ){	// 03/02/27 ai 行の間隔が"0"の時にアンダーラインが欠ける事がある為修正
-					GetCaret().m_cUnderLine.CaretUnderLineON( true, false );
+					GetCaret().m_cUnderLine.CaretUnderLineON(gr, true, false );
 				}
 			}
 		}

--- a/sakura_core/view/CViewSelect.cpp
+++ b/sakura_core/view/CViewSelect.cpp
@@ -248,7 +248,7 @@ void CViewSelect::DrawSelectArea(bool bDrawBracketCursorLine)
 		DrawSelectArea2( hdc );
 		// 2011.12.02 選択解除状態での、カーソル位置ライン復帰
 		if( bDrawBracketCursorLine ){
-			pView->GetCaret().m_cUnderLine.CaretUnderLineON(true, false);
+			pView->GetCaret().m_cUnderLine.CaretUnderLineON(hdc, true, false);
 		}
 		pView->ReleaseDC( hdc );
 	}


### PR DESCRIPTION
このPRの目的は描画処理の軽量化(高速化)です。ただし改善度合いは微々たるものです。

HDC の引数を持つ `CEditView::CaretUnderLineON` メソッドのオーバーロードを追加して、呼び出し元で既に HDC を持っている場合にそれを再利用する事で GetDC, ReleaseDC の呼び出し回数を減らしました。

ついでに Disable の綴り間違いを修正しました。
