### PR TITLE
不要な CCaret::ShowCaretPosInfo の呼び出しを無くす

### DIFF
--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -927,7 +927,6 @@ void CViewCommander::Command_WndScrollDown( void )
 				GetCaret().Cursor_UPDOWN( (GetDocument()->m_cLayoutMgr.GetLineCount() - nCaretMarginY) - GetCaret().GetCaretLayoutPos().GetY2(), FALSE );
 			else
 				GetCaret().Cursor_UPDOWN( CLayoutInt(-1), FALSE);
-			GetCaret().ShowCaretPosInfo();
 		}
 	}
 	if( bCaretOff ){
@@ -965,7 +964,6 @@ void CViewCommander::Command_WndScrollUp(void)
 				GetCaret().Cursor_UPDOWN( nCaretMarginY + 1, FALSE );
 			else
 				GetCaret().Cursor_UPDOWN( CLayoutInt(1), FALSE );
-			GetCaret().ShowCaretPosInfo();
 		}
 	}
 	if( bCaretOff ){


### PR DESCRIPTION
CViewCommander::Command_WndScrollDown と CViewCommander::Command_WndScrollUp において CCaret::ShowCaretPosInfo の呼び出しを無くしました。

CCaret::Cursor_UPDOWN の呼び出しが事前に行われていて、その中で呼び出す CCaret::MoveCursor の中で CCaret::ShowCaretPosInfo の呼び出しの記述が存在する為に追加の呼び出しが不要な為です。

Performance Profiler で確認しましたが、ステータスバーのテキスト設定を行うのに結構処理時間が掛かってます。表示面積比でいうと大した事が無いので非効率な実装がされているんでしょうか…。