### PR TITLE
exeプロジェクトでライブラリを生成させる

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -1016,6 +1016,9 @@
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <ItemGroup>
       <DeleteOnClean Include="$(IntDir)sakura_core.lib" />
+      <DeleteOnClean Include="$(OutDir)sakura.ini" />
+      <DeleteOnClean Include="$(OutDir)bregonig.dll" />
+      <DeleteOnClean Include="$(OutDir)ctags.exe" />
     </ItemGroup>
     <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" /> 
     <WriteLinesToFile File="$(IntermediateOutputPath)$(CleanFile)" Lines="@(DeleteOnClean)" Overwrite="false" /> 

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -1013,4 +1013,11 @@
     </ItemGroup>
     <LIB OutputFile="$(IntDir)sakura_core.lib" Sources="@(SakuraCore)" SubSystem="Windows" LinkTimeCodeGeneration="$(WholeProgramOptimization)" SuppressStartupBanner="true" />
   </Target>
+  <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
+    <ItemGroup>
+      <DeleteOnClean Include="$(IntDir)sakura_core.lib" />
+    </ItemGroup>
+    <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" /> 
+    <WriteLinesToFile File="$(IntermediateOutputPath)$(CleanFile)" Lines="@(DeleteOnClean)" Overwrite="false" /> 
+  </Target>
 </Project>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -1007,4 +1007,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Target Name="MakeSakuraCoreLib" AfterTargets="Link" Inputs="@(ClCompile)" Outputs="$(IntDir)sakura_core.lib">
+    <ItemGroup>
+      <SakuraCore Include="$(IntDir)*.obj" />
+    </ItemGroup>
+    <LIB OutputFile="$(IntDir)sakura_core.lib" Sources="@(SakuraCore)" SubSystem="Windows" LinkTimeCodeGeneration="$(WholeProgramOptimization)" SuppressStartupBanner="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
## 目的

テストプロジェクトから利用するために、sakura.exeのobj群でライブラリを作るようにします。

## 変更内容

1. sakura.vcxprojにカスタムのビルド後タスク(LIBコマンド実行)を追加します。
2. LIBコマンドの出力ファイルをクリーン対象に含めるためにカスタムタスクを追加します。
3. ビルドで出力フォルダにコピーされるbregonig.dllなどをクリーンの削除対象に含めます。

## 関連PR

#796(vs2017ソリューションにテストを組み込みたい)

本来は他の変更と合わせて#796に入れるつもりでしたが、このPRの変更内容だけでもかなりお腹いっぱいになれるボリュームがあると感じたので、分割することにしました。

