### PR TITLE
クリーン時に成果物が削除されるようにする

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -1007,4 +1007,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
+    <ItemGroup>
+      <DeleteOnClean Include="$(OutDir)sakura.ini" />
+      <DeleteOnClean Include="$(OutDir)bregonig.dll" />
+      <DeleteOnClean Include="$(OutDir)ctags.exe" />
+    </ItemGroup>
+    <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" /> 
+    <WriteLinesToFile File="$(IntermediateOutputPath)$(CleanFile)" Lines="@(DeleteOnClean)" Overwrite="false" /> 
+  </Target>
 </Project>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -1008,12 +1008,11 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
+    <!-- Add files to @Clean just before running CoreClean. -->
     <ItemGroup>
-      <DeleteOnClean Include="$(OutDir)sakura.ini" />
-      <DeleteOnClean Include="$(OutDir)bregonig.dll" />
-      <DeleteOnClean Include="$(OutDir)ctags.exe" />
+      <Clean Include="$(OutDir)sakura.ini" />
+      <Clean Include="$(OutDir)bregonig.dll" />
+      <Clean Include="$(OutDir)ctags.exe" />
     </ItemGroup>
-    <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" /> 
-    <WriteLinesToFile File="$(IntermediateOutputPath)$(CleanFile)" Lines="@(DeleteOnClean)" Overwrite="false" /> 
   </Target>
 </Project>


### PR DESCRIPTION
## 目的

クリーン時に、bregonig.dllとtags.exeが出力フォルダに残るので消すようにする。

## 対処内容

MsBuildがクリーン時に参照する削除ファイルリストにファイル名を追加し、
カスタムビルドの成果物がクリーン対象になるようにする。

$(IntDir)と$(OutDir)に出力するファイルは、同様にクリーン対象に含めることができるので、今後カスタムビルド成果物を増やした場合に枠組みを流用することができる。

## 確認方法

1. PR適用前のブランチ(master等)を fetch してビルドし、`Win32/$(Configuration)` にビルド成果物が生成されるのを確認する。
2. Cleanを実行して`Win32/$(Configuration)`を確認する。**bregonig.dllが削除されず残っている**
3. この PR のブランチを fetch してビルドし、`Win32/$(Configuration)` にビルド成果物が生成されるのを確認する。
4. Cleanを実行して`Win32/$(Configuration)`を確認する。**フォルダは空になる**
5. 再度ビルドを実行して、`Win32/$(Configuration)` にビルド成果物が生成されるのを確認する。

## 関連する課題

他のパスに出力する生成ファイル(githash.hやfunccode_enum.h等) はこの方法では削除できないので別の手を考える必要がある。

ファイルが残る原因は、現状のカスタムタスクが「ビルドステップの一部」ではなく「単なるバッチ処理」として書かれているために、MsBuildから見て生成ファイルを「出力ファイル」と認識できないことにある。本来は「出力ファイルがあるカスタムタスク」に書き換えていく試みが必要と考えられる。

この PR では、本当に必要な対処に目をつぶり、当座の「クリーンしたけどファイルが消えない」を解消するだけの単純対処を提供する。
