### PR TITLE
STR_IMPEXP_VER の書式フォーマット指定を見直す

### DIFF
--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -3859,7 +3859,7 @@ BEGIN
 	STR_IMPEXP_OK_IMPORT			"ファイルをインポートしました。\n\n"
 	STR_IMPEXP_ERR_COLOR_OLD		"色設定ファイルの形式が違います。古い形式はサポートされなくなりました。\n"
 	STR_IMPEXP_ERR_TYPE				"不正な形式です。\nインポートを中止します"
-	STR_IMPEXP_VER					"エクスポートした %ls(%ls/%d) とバージョンが異なります。\n\nインポートしてもよろしいですか？"
+	STR_IMPEXP_VER					"エクスポートした %s(%s/%d) とバージョンが異なります。\n\nインポートしてもよろしいですか？"
 	STR_IMPEXP_REGEX1				"キーワード数が上限に達したため切り捨てました。"
 	STR_IMPEXP_REGEX2				"キーワード領域がいっぱいなため切り捨てました。"
 	STR_IMPEXP_REGEX3				"不正なキーワードを無視しました。"

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -3867,7 +3867,7 @@ BEGIN
 	STR_IMPEXP_OK_IMPORT			"Imported to the file.\n\n"
 	STR_IMPEXP_ERR_COLOR_OLD		"Is different format color settings file. Not support old version format.\n"
 	STR_IMPEXP_ERR_TYPE				"Invalid format.\nStop import."
-	STR_IMPEXP_VER					"Export %ls(%ls/%d) Different version.\n\nAre you sure you want to import?"
+	STR_IMPEXP_VER					"Export %s(%s/%d) Different version.\n\nAre you sure you want to import?"
 	STR_IMPEXP_REGEX1				"keyword truncated because the number of keywords has reached the upper limit."
 	STR_IMPEXP_REGEX2				"keyword truncated because keyword are is full."
 	STR_IMPEXP_REGEX3				"Ignore invalid keyword."


### PR DESCRIPTION
fixes #712: STR_IMPEXP_VER の書式フォーマット指定を見直す

関連: https://github.com/sakura-editor/sakura/pull/710#discussion_r242606425