### PR TITLE
postBuild.bat から失われた build-installer.bat が依存する処理を復元する。

### DIFF
--- a/sakura/postBuild.bat
+++ b/sakura/postBuild.bat
@@ -29,11 +29,11 @@ if "%platform%" == "x64" (
 ) else (
 	set BRON_DIR=%~dp0%BRON_TMP%
 )
+if not exist "%BRON_DIR%\%BREGONIG_DLL%" (
+	call "%UNZIP_CMD%" "%~dp0%BRON_ZIP%" "%~dp0%BRON_TMP%" > NUL || (echo error && exit /b 1)
+)
 if not exist "%OUT_DIR%\%BREGONIG_DLL%" (
 	@echo %BRON_ZIP% -^> %DEST_DIR%\%BREGONIG_DLL%
-	if not exist "%BRON_DIR%\%BREGONIG_DLL%" (
-		call "%UNZIP_CMD%" "%~dp0%BRON_ZIP%" "%~dp0%BRON_TMP%" > NUL || (echo error && exit /b 1)
-	)
 	copy /Y /B "%BRON_DIR%\%BREGONIG_DLL%" "%OUT_DIR%\" > NUL
 )
 
@@ -50,11 +50,11 @@ if "%PLATFORM%" == "Win32" (
 set CTAGS_ZIP=..\installer\externals\universal-ctags\ctags-2018-09-16_e522743d-%CTAGS_PREFIX%.zip
 set CTAGS_TMP=..\installer\temp\ctags
 set CTAGS_DIR=%~dp0%CTAGS_TMP%
+if not exist "%CTAGS_DIR%\%CTAGS_EXE%" (
+	call "%UNZIP_CMD%" "%~dp0%CTAGS_ZIP%" "%CTAGS_DIR%" > NUL || (echo error && exit /b 1)
+)
 if not exist "%OUT_DIR%\%CTAGS_EXE%" (
 	@echo %CTAGS_ZIP% -^> %DEST_DIR%\%CTAGS_EXE%
-	if not exist "%CTAGS_DIR%\%CTAGS_EXE%" (
-		call "%UNZIP_CMD%" "%~dp0%CTAGS_ZIP%" "%CTAGS_DIR%" > NUL || (echo error && exit /b 1)
-	)
 	copy /Y /B "%CTAGS_DIR%\%CTAGS_EXE%" "%OUT_DIR%\" > NUL
 )
 


### PR DESCRIPTION
https://github.com/sakura-editor/sakura/pull/790#issuecomment-485269873 から転載します。

>[postBuild.batの整理](https://github.com/sakura-editor/sakura/pull/790/commits/e91fb13eb3cba94ce5d0d40ca363041e2c3ec588) に問題を見つけました。
>
>「[installer\externals\bregonig\bron412.zip がビルド要件になっている件について #388](https://github.com/sakura-editor/sakura/issues/388)」において @yoshinrt さんから bron412.zip の展開をインストーラビルド時に移動してはどうかという提案がありましたが、そのときは「[bron412.zip の解凍が必要ないときは bron412.zip の解凍をスキップする #390](https://github.com/sakura-editor/sakura/issues/388)」ことで決着しました。
>
>yoshinrt さんの提案は故のあることで、build-installer.bat は postBuild.bat が展開する一時ファイルに依存する造りになっています。そのことの是非はともかくそういう関係があるので、(出力フォルダの)bregonig.dll の存在だけを確認して一時フォルダへの展開をスキップしてしまうと、build-installer.bat の期待を満たせなくなってしまいます。
>
>そのことが「[AppVeyor のビルドキャッシュを利用してビルド時間を削減(※およそ５分)できるようなオプションを用意します。 #650](https://github.com/sakura-editor/sakura/pull/650)」で[キャッシュを有効にしたビルド](https://ci.appveyor.com/project/ds14050/sakura-clone/builds/23948667)によって明らかになりました。
