### PR TITLE
readme.md でドキュメントの項目の分類の誤りを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
         - [ビルド成果物のダウンロード(バイナリ、インストーラなど)](#ビルド成果物のダウンロードバイナリインストーラなど)
             - [master の 最新](#master-の-最新)
             - [master の 最新以外](#master-の-最新以外)
+    - [開発情報](#開発情報)
         - [単体テスト](#単体テスト)
         - [デバッグ方法](#デバッグ方法)
     - [変更履歴](#変更履歴)
@@ -103,6 +104,8 @@ More information: https://github.com/sakura-editor/sakura/issues/6
 
 以下から取得したいビルドを選択後、同様にしてダウンロードできます。  
 https://ci.appveyor.com/project/sakuraeditor/sakura/history
+
+## 開発情報
 
 ### 単体テスト
 


### PR DESCRIPTION
readme.md でドキュメントの項目の分類の誤りを修正

`単体テスト` と `デバッグ方法` が `CI Build (AppVeyor)` の中の項目になっていた。