### PR TITLE
Vistaスタイルのファイルダイアログ使用時に新規ファイルの保存が行えない問題を修正

### DIFF
--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -772,7 +772,7 @@ HRESULT CDlgOpenFile_CommonItemDialog::DoModalSaveDlgImpl1(
 		hr = pFileSaveDialog->GetResult(&pShellItem); RETURN_IF_FAILED
 		PWSTR pszFilePath;
 		hr = pShellItem->GetDisplayName(SIGDN_FILESYSPATH, &pszFilePath); RETURN_IF_FAILED
-		_tcscpy(pszPath, pszFilePath);
+		wcscpy(pszPath, pszFilePath);
 		CoTaskMemFree(pszFilePath);
 	}
 


### PR DESCRIPTION
#862 で報告した問題を解消する修正を行いました。

従来から存在する CommonFileDialog を使った実装ではファイル拡張子の補完処理を自前で色々やっていますが、Vistaスタイルのファイルダイアログ（CommonItemDialog）の実装では同様の処理を端折っている為に再現は出来てません。

https://github.com/sakura-editor/sakura/blob/4edee2b192eef92398e651dddd27d4b6c1002f2f/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp#L402

