### PR TITLE
ビルドで生成されるファイルをクリーン対象に含める

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -1010,6 +1010,9 @@
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <!-- Add files to @Clean just before running CoreClean. -->
     <ItemGroup>
+      <Clean Include="..\sakura_core\githash.h" />
+      <Clean Include="..\sakura_core\Funccode_enum.h" />
+      <Clean Include="..\sakura_core\Funccode_define.h" />
       <Clean Include="$(OutDir)sakura.ini" />
       <Clean Include="$(OutDir)bregonig.dll" />
       <Clean Include="$(OutDir)ctags.exe" />


### PR DESCRIPTION
## 目的
ビルド中に生成されるファイルをクリーン対象に含め、ビルド⇒リビルドができるようにする。

## 対処内容
ビルド中に生成される以下ファイルをクリーン対象に含めます。
 - sakura_core\githash.h
 - sakura_core\Funccode_enum.h
 - sakura_core\Funccode_define.h

これまでは一度ビルドした後にビルド前の状態に戻すには git clean コマンドを使う必要がありました。変更後は クリーン だけでビルド前状態に戻せるようになります。

## 確認方法
1. この PR 適用前のブランチ(master)をcheckoutする　⇒　上記3ファイルは存在しない
1. この PR 適用前のブランチ(master)をビルドする　⇒　上記3ファイルが生成される
1. visual studio で Build -> Clean Solution を実行する　⇒　**上記3ファイルが残る**
1. この PR をcheckoutしてビルドする
1. visual studio で Build -> Clean Solution を実行する　⇒　**上記3ファイルが削除される**
 
closes #358;
