### PR TITLE
Vistaスタイルのファイルダイアログ使用時に名前を付けて保存の文字コードセット, 改行コード, BOM指定が有効に動作しない問題を修正

### DIFF
--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -812,6 +812,7 @@ bool CDlgOpenFile_CommonItemDialog::DoModalSaveDlg( SSaveInfo* pSaveInfo, bool b
 	else {
 		m_nCharCode = pSaveInfo->eCharCode;
 		m_bBom = pSaveInfo->bBomExist;
+		m_cEol = pSaveInfo->cEol;
 		m_customizeSetting.bCustomize = true;
 		m_customizeSetting.bUseCharCode = true;
 		m_customizeSetting.bUseEol = true;
@@ -857,6 +858,14 @@ HRESULT CDlgOpenFile_CommonItemDialog::OnItemSelected(
 			}
 			SetControlState(CtrlId::CHECK_BOM, state);
 			SetCheckButtonState(CtrlId::CHECK_BOM, bChecked ? TRUE : FALSE);
+			m_nCharCode = (ECodeType)dwIDItem;
+		}
+		break;
+	case CtrlId::COMBO_EOL:
+		switch (dwIDItem) {
+		case 1: m_cEol = EOL_CRLF; break;
+		case 2: m_cEol = EOL_LF; break;
+		case 3: m_cEol = EOL_CR; break;
 		}
 		break;
 	case CtrlId::COMBO_MRU:
@@ -888,6 +897,9 @@ HRESULT CDlgOpenFile_CommonItemDialog::OnCheckButtonToggled(
 	case CtrlId::CHECK_CP:
 		SetControlState(CtrlId::CHECK_CP, CDCS_VISIBLE);
 		AddComboCodePages(m_nCharCode);
+		break;
+	case CtrlId::CHECK_BOM:
+		m_bBom = bChecked ? true : false;
 		break;
 	}
 	return S_OK;

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -567,10 +567,10 @@ HRESULT CDlgOpenFile_CommonItemDialog::Customize()
 	if (m_customizeSetting.bUseEol) {
 		hr = StartVisualGroup(CtrlId::LABEL_EOL, LS(STR_FILEDIALOG_EOL)); RETURN_IF_FAILED
 		hr = AddComboBox(CtrlId::COMBO_EOL); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, 0, LS(STR_DLGOPNFL1)); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, 1, L"CR+LF"); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, 2, L"LF (UNIX)"); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, 3, L"CR (Mac)"); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, EOL_NONE, LS(STR_DLGOPNFL1)); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, EOL_CRLF, L"CR+LF"); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, EOL_LF, L"LF (UNIX)"); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, EOL_CR, L"CR (Mac)"); RETURN_IF_FAILED
 		hr = SetSelectedControlItem(CtrlId::COMBO_EOL, 0); RETURN_IF_FAILED
 		hr = EndVisualGroup(); RETURN_IF_FAILED
 	}
@@ -862,11 +862,7 @@ HRESULT CDlgOpenFile_CommonItemDialog::OnItemSelected(
 		}
 		break;
 	case CtrlId::COMBO_EOL:
-		switch (dwIDItem) {
-		case 1: m_cEol = EOL_CRLF; break;
-		case 2: m_cEol = EOL_LF; break;
-		case 3: m_cEol = EOL_CR; break;
-		}
+		m_cEol = (EEolType)dwIDItem;
 		break;
 	case CtrlId::COMBO_MRU:
 		if (dwIDItem != 0) {

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -858,11 +858,11 @@ HRESULT CDlgOpenFile_CommonItemDialog::OnItemSelected(
 			}
 			SetControlState(CtrlId::CHECK_BOM, state);
 			SetCheckButtonState(CtrlId::CHECK_BOM, bChecked ? TRUE : FALSE);
-			m_nCharCode = (ECodeType)dwIDItem;
+			m_nCharCode = static_cast<ECodeType>(dwIDItem);
 		}
 		break;
 	case CtrlId::COMBO_EOL:
-		m_cEol = (EEolType)dwIDItem;
+		m_cEol = static_cast<EEolType>(dwIDItem);
 		break;
 	case CtrlId::COMBO_MRU:
 		if (dwIDItem != 0) {


### PR DESCRIPTION
#873 で報告した問題を解消する修正を行いました。

