### PR TITLE
APPVEYOR_REPO_TAG_NAME を使うのをやめて `git describe --tags --contains` を使うようにする

### DIFF
--- a/appveyor.md
+++ b/appveyor.md
@@ -15,9 +15,11 @@
             - [処理の流れ](#処理の流れ)
         - [postBuild.bat の構造](#postbuildbat-の構造)
             - [処理の流れ](#処理の流れ-1)
+        - [mingw32-del.bat の構造](#mingw32-delbat-の構造)
+            - [処理の流れ](#処理の流れ-2)
         - [zipArtifacts.bat の構造](#zipartifactsbat-の構造)
             - [生成する環境変数](#生成する環境変数-1)
-            - [処理の流れ](#処理の流れ-2)
+            - [処理の流れ](#処理の流れ-3)
 
 <!-- /TOC -->
 
@@ -40,7 +42,7 @@
 |APPVEYOR_ACCOUNT_NAME              | appveyor のアカウント名 (sakura editor の場合 "sakuraeditor") |
 |APPVEYOR_BUILD_NUMBER              | ビルド番号 |
 |APPVEYOR_REPO_COMMIT               | commit Hash |
-|APPVEYOR_REPO_TAG_NAME             | tag 名 |
+|~~APPVEYOR_REPO_TAG_NAME~~ (代わりに GIT_TAG_NAME を使う)        | tag 名 |
 |APPVEYOR_URL                       | https://ci.appveyor.com |
 |APPVEYOR_BUILD_VERSION             | appveyor.yml の version フィールドの値 |
 |APPVEYOR_PROJECT_SLUG              | project slug (appveyor の URL 名) |
@@ -135,6 +137,7 @@
 | GIT_SHORT_COMMIT_HASH         | git の commit Hash の先頭8文字                      | git 環境が有効な場合              |
 | GIT_COMMIT_HASH               | git の commit Hash                                  | git 環境が有効な場合              |
 | GIT_REMOTE_ORIGIN_URL         | git remote origin URL                               | git 環境が有効な場合              |
+| GIT_TAG_NAME                  | git の tag                                        | git 環境が有効な場合              |
 | GITHUB_COMMIT_URL             | gitHub で対応する commit に対する URL               | appveyor でのビルドのみ有効       |
 | GITHUB_COMMIT_URL_PR_HEAD     | gitHub の Pull Request の commit に対応する URL     | appveyor での PR のビルドのみ有効 |
 | APPVEYOR_SHORTHASH            | commit hash の先頭8文字                             | appveyor でのビルドのみ有効       |
@@ -154,6 +157,7 @@
 | GIT_SHORT_COMMIT_HASH           | GIT_SHORT_COMMIT_HASH           | 文字列   |
 | GIT_COMMIT_HASH                 | GIT_COMMIT_HASH                 | 文字列   |
 | GIT_REMOTE_ORIGIN_URL           | GIT_REMOTE_ORIGIN_URL           | 文字列   |
+| GIT_TAG_NAME                    | GIT_TAG_NAME                    | 文字列   |
 | APPVEYOR_URL                    | APPVEYOR_URL                    | 文字列   |
 | APPVEYOR_REPO_NAME              | APPVEYOR_REPO_NAME              | 文字列   |
 | APPVEYOR_REPO_TAG_NAME          | APPVEYOR_REPO_TAG_NAME          | 文字列   |

--- a/appveyor.md
+++ b/appveyor.md
@@ -42,7 +42,6 @@
 |APPVEYOR_ACCOUNT_NAME              | appveyor のアカウント名 (sakura editor の場合 "sakuraeditor") |
 |APPVEYOR_BUILD_NUMBER              | ビルド番号 |
 |APPVEYOR_REPO_COMMIT               | commit Hash |
-|~~APPVEYOR_REPO_TAG_NAME~~ (代わりに GIT_TAG_NAME を使う)        | tag 名 |
 |APPVEYOR_URL                       | https://ci.appveyor.com |
 |APPVEYOR_BUILD_VERSION             | appveyor.yml の version フィールドの値 |
 |APPVEYOR_PROJECT_SLUG              | project slug (appveyor の URL 名) |
@@ -50,6 +49,8 @@
 |APPVEYOR_PULL_REQUEST_HEAD_COMMIT  | Pull Request の Head commit Hash |
 |APPVEYOR_REPO_NAME                 | リポジトリ名 (owner-name/repo-name) |
 |APPVEYOR_REPO_PROVIDER             | appveyor の参照するリポジトリ種別 (GitHub の場合 "gitHub") |
+
+APPVEYOR_REPO_TAG_NAME は利用をやめて 代わりに GIT_TAG_NAME を使うようにしました。[#876](https://github.com/sakura-editor/sakura/pull/876)
 
 * 上記環境変数をローカル環境で set コマンドで設定することにより appveyor でビルドしなくてもローカルでテストできます。
 * 上記の環境変数がどんな値になるのかは、過去の appveyor ビルドでのログを見ることによって確認できます。

--- a/appveyor.md
+++ b/appveyor.md
@@ -161,7 +161,6 @@ APPVEYOR_REPO_TAG_NAME は利用をやめて 代わりに GIT_TAG_NAME を使う
 | GIT_TAG_NAME                    | GIT_TAG_NAME                    | 文字列   |
 | APPVEYOR_URL                    | APPVEYOR_URL                    | 文字列   |
 | APPVEYOR_REPO_NAME              | APPVEYOR_REPO_NAME              | 文字列   |
-| APPVEYOR_REPO_TAG_NAME          | APPVEYOR_REPO_TAG_NAME          | 文字列   |
 | APPVEYOR_ACCOUNT_NAME           | APPVEYOR_ACCOUNT_NAME           | 文字列   |
 | APPVEYOR_PROJECT_SLUG           | APPVEYOR_PROJECT_SLUG           | 文字列   |
 | APPVEYOR_BUILD_VERSION          | APPVEYOR_BUILD_VERSION          | 文字列   |

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -113,6 +113,7 @@ if not errorlevel 1 (
 	@echo GIT_SHORT_COMMIT_HASH : %GIT_SHORT_COMMIT_HASH%
 	@echo GIT_COMMIT_HASH       : %GIT_COMMIT_HASH%
 	@echo GIT_REMOTE_ORIGIN_URL : %GIT_REMOTE_ORIGIN_URL%
+	@echo GIT_TAG_NAME          : %GIT_TAG_NAME%
 	@echo APPVEYOR_URL          : %APPVEYOR_URL%
 	@echo APPVEYOR_REPO_NAME    : %APPVEYOR_REPO_NAME%
 	@echo APPVEYOR_REPO_TAG_NAME: %APPVEYOR_REPO_TAG_NAME%
@@ -150,6 +151,11 @@ if "%GIT_REMOTE_ORIGIN_URL%" == "" (
 	echo // GIT_REMOTE_ORIGIN_URL is not defined
 ) else (
 	echo #define GIT_REMOTE_ORIGIN_URL "%GIT_REMOTE_ORIGIN_URL%"
+)
+if "%GIT_TAG_NAME%" == "" (
+	echo // GIT_TAG_NAME is not defined
+) else (
+	echo #define GIT_TAG_NAME "%GIT_TAG_NAME%"
 )
 
 if "%APPVEYOR_URL%" == "" (

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -126,7 +126,7 @@ if not errorlevel 1 (
 	@echo GIT_TAG_NAME          : %GIT_TAG_NAME%
 	@echo APPVEYOR_URL          : %APPVEYOR_URL%
 	@echo APPVEYOR_REPO_NAME    : %APPVEYOR_REPO_NAME%
-	@echo APPVEYOR_REPO_TAG_NAME: %APPVEYOR_REPO_TAG_NAME%
+	@echo GIT_TAG_NAME: %GIT_TAG_NAME%
 	@echo APPVEYOR_ACCOUNT_NAME : %APPVEYOR_ACCOUNT_NAME%
 	@echo APPVEYOR_PROJECT_SLUG : %APPVEYOR_PROJECT_SLUG%
 	@echo APPVEYOR_BUILD_VERSION: %APPVEYOR_BUILD_VERSION%
@@ -183,10 +183,10 @@ if "%APPVEYOR_REPO_NAME%" == "" (
 @rem enable 'dev version' macro which will be disabled on release branches
 echo #define APPVEYOR_DEV_VERSION
 
-if "%APPVEYOR_REPO_TAG_NAME%" == "" (
-	echo // APPVEYOR_REPO_TAG_NAME is not defined
+if "%GIT_TAG_NAME%" == "" (
+	echo // GIT_TAG_NAME is not defined
 ) else (
-	echo #define APPVEYOR_REPO_TAG_NAME "%APPVEYOR_REPO_TAG_NAME%"
+	echo #define GIT_TAG_NAME "%GIT_TAG_NAME%"
 )
 
 if "%APPVEYOR_ACCOUNT_NAME%" == "" (

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -26,6 +26,12 @@ if not exist ..\.git (
 	@echo NOTE: No .git directory
 )
 
+@rem clear variable in advance
+set GIT_SHORT_COMMIT_HASH=
+set GIT_COMMIT_HASH=
+set GIT_REMOTE_ORIGIN_URL=
+set GIT_TAG_NAME=
+
 : Get git hash if git is enabled
 if "%GIT_ENABLED%" == "1" (
 	for /f "usebackq" %%s in (`"%CMD_GIT%" show -s --format^=%%h`) do (

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -37,10 +37,14 @@ if "%GIT_ENABLED%" == "1" (
 	for /f "usebackq" %%s in (`"%CMD_GIT%" config --get remote.origin.url`) do (
 		set GIT_REMOTE_ORIGIN_URL=%%s
 	)
+	for /f "usebackq" %%s in (`"%CMD_GIT%" describe --tags`) do (
+		set GIT_TAG_NAME=%%s
+	)
 ) else (
 	set GIT_SHORT_COMMIT_HASH=
 	set GIT_COMMIT_HASH=
 	set GIT_REMOTE_ORIGIN_URL=
+	set GIT_TAG_NAME=
 )
 
 @rem get back to the original directory

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -37,7 +37,11 @@ if "%GIT_ENABLED%" == "1" (
 	for /f "usebackq" %%s in (`"%CMD_GIT%" config --get remote.origin.url`) do (
 		set GIT_REMOTE_ORIGIN_URL=%%s
 	)
-	for /f "usebackq" %%s in (`"%CMD_GIT%" describe --tags`) do (
+	
+	@rem get tag of 'HEAD'
+	@rem Ignore errors when `HEAD` is not tagged.
+	@rem https://superuser.com/questions/743735/suppressing-errors-from-an-embedded-command-in-a-batch-file-for-loop
+	for /f "usebackq" %%s in (`"%CMD_GIT%" describe --tags --contains 2^>nul`) do (
 		set GIT_TAG_NAME=%%s
 	)
 ) else (

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -126,7 +126,6 @@ if not errorlevel 1 (
 	@echo GIT_TAG_NAME          : %GIT_TAG_NAME%
 	@echo APPVEYOR_URL          : %APPVEYOR_URL%
 	@echo APPVEYOR_REPO_NAME    : %APPVEYOR_REPO_NAME%
-	@echo GIT_TAG_NAME: %GIT_TAG_NAME%
 	@echo APPVEYOR_ACCOUNT_NAME : %APPVEYOR_ACCOUNT_NAME%
 	@echo APPVEYOR_PROJECT_SLUG : %APPVEYOR_PROJECT_SLUG%
 	@echo APPVEYOR_BUILD_VERSION: %APPVEYOR_BUILD_VERSION%
@@ -182,12 +181,6 @@ if "%APPVEYOR_REPO_NAME%" == "" (
 
 @rem enable 'dev version' macro which will be disabled on release branches
 echo #define APPVEYOR_DEV_VERSION
-
-if "%GIT_TAG_NAME%" == "" (
-	echo // GIT_TAG_NAME is not defined
-) else (
-	echo #define GIT_TAG_NAME "%GIT_TAG_NAME%"
-)
 
 if "%APPVEYOR_ACCOUNT_NAME%" == "" (
 	echo // APPVEYOR_ACCOUNT_NAME is not defined

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -202,8 +202,8 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 #ifdef ALPHA_VERSION
 	cmemMsg.AppendString( _T(" ") _T(ALPHA_VERSION_STR));
 #endif
-#ifdef APPVEYOR_REPO_TAG_NAME
-	cmemMsg.AppendStringF(_T(" (tag %s)"), _T(APPVEYOR_REPO_TAG_NAME));
+#ifdef GIT_TAG_NAME
+	cmemMsg.AppendStringF(_T(" (tag %s)"), _T(GIT_TAG_NAME));
 #endif
 	cmemMsg.AppendString( _T("\r\n") );
 

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -50,10 +50,10 @@ if not "%APPVEYOR_BUILD_NUMBER%" == "" (
 	set BUILD_NUMBER=buildLocal
 )
 
-@echo checking APPVEYOR_REPO_TAG_NAME %APPVEYOR_REPO_TAG_NAME%
-if not "%APPVEYOR_REPO_TAG_NAME%" == "" (
+@echo checking GIT_TAG_NAME %GIT_TAG_NAME%
+if not "%GIT_TAG_NAME%" == "" (
 	@rem replace '/' with '_'
-	set TEMP_NAME1=!APPVEYOR_REPO_TAG_NAME:/=_!
+	set TEMP_NAME1=!GIT_TAG_NAME:/=_!
 	@echo TEMP_NAME1 = !TEMP_NAME1!
 	
 	@rem replace ' ' with '_'


### PR DESCRIPTION
APPVEYOR_REPO_TAG_NAME を使うのをやめて `git describe --tags --contains` を使うようにする

## 背景

#821 で Azure Pipelines で環境変数の定義を検討中だが、
[Azure Pipelinse の Predefined variables](https://docs.microsoft.com/ja-jp/azure/devops/pipelines/build/variables?tabs=yaml&view=azure-devops#predefined-variables) では git のタグに相当する環境変数が存在しない。

