### PR TITLE
SonarQube 用の JOB 以外で SonarQube の解析が走らないようにする

### DIFF
--- a/build-sonar-qube-env.bat
+++ b/build-sonar-qube-env.bat
@@ -1,5 +1,13 @@
 @rem to ensure hide variable SONAR_QUBE_TOKEN
 @echo off
+
+if not "%SONAR_QUBE%" == "Yes" (
+	set SONAR_QUBE_TOKEN=
+	set SONAR_QUBE_ORG=
+	set SONAR_QUBE_PROJECT=
+	exit /b 0
+)
+
 if "%SONAR_QUBE_TOKEN%" == "" (
 	@echo SONAR_QUBE_TOKEN is not defined. Abort without building.
 	exit /b 0


### PR DESCRIPTION
SonarQube 用の JOB 以外で SonarQube の解析が走らないようにする

SONAR_QUBE が Yes でない場合は、SONAR_QUBE_TOKEN 等の変数をクリアして SonarQube の解析が走らないようにする。
