### PR TITLE
SonarQube で `/d:sonar.cfamily.threads` を指定して SonarQube を高速化する

### DIFF
--- a/build-sonar-qube-start.bat
+++ b/build-sonar-qube-start.bat
@@ -18,6 +18,8 @@ call %~dp0tools\zip\unzip.bat %BUILDWRAPPER_ZIP% %BUILDWRAPPER_DIR%
 
 if exist .sonarqube rmdir /s /q .sonarqube
 
+@echo NUMBER_OF_PROCESSORS : %NUMBER_OF_PROCESSORS%
+
 @rem to ensure hide variable SONAR_QUBE_TOKEN
 @echo off
 "%SonarScanner_MSBUILD%" begin                      ^

--- a/build-sonar-qube-start.bat
+++ b/build-sonar-qube-start.bat
@@ -24,6 +24,7 @@ if exist .sonarqube rmdir /s /q .sonarqube
 	/k:"%SONAR_QUBE_PROJECT%"                       ^
 	/o:"%SONAR_QUBE_ORG%"                           ^
 	/d:sonar.cfamily.build-wrapper-output=%~dp0bw-output ^
+	/d:sonar.cfamily.threads=%NUMBER_OF_PROCESSORS% ^
 	/d:sonar.sourceEncoding=UTF-8                   ^
 	/d:sonar.host.url="https://sonarcloud.io"       ^
 	/d:sonar.login="%SONAR_QUBE_TOKEN%"

--- a/ci/azure-pipelines/template.job.SonarQube.yml
+++ b/ci/azure-pipelines/template.job.SonarQube.yml
@@ -32,15 +32,15 @@ jobs:
   variables:
     SONAR_QUBE: Yes
 
-  ## set condition    at https://docs.microsoft.com/ja-jp/azure/devops/pipelines/process/conditions?view=azure-devops&viewFallbackFrom=vsts&tabs=yaml
-  ## see Build.Reason at https://docs.microsoft.com/ja-jp/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
-  #condition:
-  #  #and
-  #  #(
-  #  #  ne(variables['Build.Reason'], 'Schedule'),
-  #  #  ne(variables['Build.Reason'], 'PullRequest')
-  #  #)
-  #  eq(variables['Build.Reason'], 'Schedule')
+  # set condition    at https://docs.microsoft.com/ja-jp/azure/devops/pipelines/process/conditions?view=azure-devops&viewFallbackFrom=vsts&tabs=yaml
+  # see Build.Reason at https://docs.microsoft.com/ja-jp/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+  condition:
+    #and
+    #(
+    #  ne(variables['Build.Reason'], 'Schedule'),
+    #  ne(variables['Build.Reason'], 'PullRequest')
+    #)
+    eq(variables['Build.Reason'], 'Schedule')
 
   steps:
   - script: choco install "msbuild-sonarqube-runner" -y

--- a/ci/azure-pipelines/template.job.SonarQube.yml
+++ b/ci/azure-pipelines/template.job.SonarQube.yml
@@ -32,15 +32,15 @@ jobs:
   variables:
     SONAR_QUBE: Yes
 
-  # set condition    at https://docs.microsoft.com/ja-jp/azure/devops/pipelines/process/conditions?view=azure-devops&viewFallbackFrom=vsts&tabs=yaml
-  # see Build.Reason at https://docs.microsoft.com/ja-jp/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
-  condition:
-    #and
-    #(
-    #  ne(variables['Build.Reason'], 'Schedule'),
-    #  ne(variables['Build.Reason'], 'PullRequest')
-    #)
-    eq(variables['Build.Reason'], 'Schedule')
+  ## set condition    at https://docs.microsoft.com/ja-jp/azure/devops/pipelines/process/conditions?view=azure-devops&viewFallbackFrom=vsts&tabs=yaml
+  ## see Build.Reason at https://docs.microsoft.com/ja-jp/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+  #condition:
+  #  #and
+  #  #(
+  #  #  ne(variables['Build.Reason'], 'Schedule'),
+  #  #  ne(variables['Build.Reason'], 'PullRequest')
+  #  #)
+  #  eq(variables['Build.Reason'], 'Schedule')
 
   steps:
   - script: choco install "msbuild-sonarqube-runner" -y


### PR DESCRIPTION
SonarQube で `/d:sonar.cfamily.threads` を指定して SonarQube を高速化する

fixes: #880

以下ビルドで試したところ、
https://m-tmatma.visualstudio.com/sakura/_build/results?buildId=226

26分になった。(JOB では 30分)

```
INFO: ------------------------------------------------------------------------
INFO: EXECUTION SUCCESS
INFO: ------------------------------------------------------------------------
INFO: Total time: 26:50.866s
INFO: Final Memory: 32M/720M
INFO: ------------------------------------------------------------------------

```