### PR TITLE
[WIP] innosetup-6.0.2.exe に対応する

### DIFF
--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -89,7 +89,15 @@ set APPDIR=Inno Setup 5
 set PATH2=%PATH%;%ProgramFiles%\%APPDIR%\;%ProgramFiles(x86)%\%APPDIR%\;%ProgramW6432%\%APPDIR%\;
 for /f "usebackq delims=" %%a in (`where $PATH2:ISCC.exe`) do ( 
     set "CMD_ISCC=%%a"
-    exit /b
+)
+if not "%CMD_ISCC%" == "" (
+	exit /b
+)
+
+set APPDIR=Inno Setup 6
+set PATH2=%PATH%;%ProgramFiles%\%APPDIR%\;%ProgramFiles(x86)%\%APPDIR%\;%ProgramW6432%\%APPDIR%\;
+for /f "usebackq delims=" %%a in (`where $PATH2:ISCC.exe`) do ( 
+    set "CMD_ISCC=%%a"
 )
 exit /b
 


### PR DESCRIPTION
innosetup-6.0.2.exe に対応する
fixes:  #875

 - Inno Setup 5 が見つからなければ Inno Setup 6 を探すようにする。
- https://jrsoftware.github.io/issrc/whatsnew.htm の OS の最低条件に対応する。

> 6.0.0-beta (2019-02-11)
> Other changes
> •OS requirements change: Windows 2000, XP, and Server 2003 are no longer supported. Windows Vista is now the minimum supported operating system.
