### PR TITLE
Azure Pipelines の Artifacts に md5 ファイルを追加

### DIFF
--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -57,7 +57,9 @@ jobs:
   - task: CopyFiles@1
     displayName: Copy to ArtifactStagingDirectory
     inputs:
-      contents: '**.zip'
+      contents: |
+       **.zip
+       **.zip.md5
       targetFolder: $(Build.ArtifactStagingDirectory)
 
   # see https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml


### PR DESCRIPTION
#888 で md5 ファイルを Azure Pipelines でも作れるようになったので Artifacts に追加しました。

yaml の `contents:` の記述は 
https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/copy-files?view=azure-devops&tabs=yaml#copy-everything-from-the-source-directory-except-the-git-folder を参考にしています。