### PR TITLE
MsBuild探索方法を見直す

### DIFF
--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -13,6 +13,7 @@ if not defined CMD_HHC call :hhc 2> nul
 if not defined CMD_ISCC call :iscc 2> nul
 if not defined CMD_CPPCHECK call :cppcheck 2> nul
 if not defined CMD_DOXYGEN call :doxygen 2> nul
+if not defined CMD_VSWHERE call :vswhere 2> nul
 if not defined CMD_MSBUILD call :msbuild 2> nul
 echo ^|- CMD_GIT=%CMD_GIT%
 echo ^|- CMD_7Z=%CMD_7Z%
@@ -20,8 +21,9 @@ echo ^|- CMD_HHC=%CMD_HHC%
 echo ^|- CMD_ISCC=%CMD_ISCC%
 echo ^|- CMD_CPPCHECK=%CMD_CPPCHECK%
 echo ^|- CMD_DOXYGEN=%CMD_DOXYGEN%
+echo ^|- CMD_VSWHERE=%CMD_VSWHERE%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
-endlocal && set "CMD_GIT=%CMD_GIT%" && set "CMD_7Z=%CMD_7Z%" && set "CMD_HHC=%CMD_HHC%" && set "CMD_ISCC=%CMD_ISCC%" && set "CMD_CPPCHECK=%CMD_CPPCHECK%" && set "CMD_DOXYGEN=%CMD_DOXYGEN%"&& set "CMD_MSBUILD=%CMD_MSBUILD%"
+endlocal && set "CMD_GIT=%CMD_GIT%" && set "CMD_7Z=%CMD_7Z%" && set "CMD_HHC=%CMD_HHC%" && set "CMD_ISCC=%CMD_ISCC%" && set "CMD_CPPCHECK=%CMD_CPPCHECK%" && set "CMD_DOXYGEN=%CMD_DOXYGEN%" && set "CMD_VSWHERE=%CMD_VSWHERE%" && set "CMD_MSBUILD=%CMD_MSBUILD%"
 set FIND_TOOLS_CALLED=1
 exit /b
 
@@ -82,30 +84,41 @@ for /f "usebackq delims=" %%a in (`where $PATH2:doxygen.exe`) do (
 )
 exit /b
 
+:vswhere
 :: ref https://github.com/Microsoft/vswhere
+set APPDIR=Microsoft Visual Studio\Installer
+set PATH2=%PATH%;%ProgramFiles%\%APPDIR%\;%ProgramFiles(x86)%\%APPDIR%\;%ProgramW6432%\%APPDIR%\;
+for /f "usebackq delims=" %%a in (`where $PATH2:vswhere.exe`) do ( 
+    set "CMD_VSWHERE=%%a"
+    exit /b
+)
+exit /b
+
 :msbuild
-for /f "usebackq delims=" %%a in (`where MSBuild.exe`) do ( 
+::find vs2017 install directory
+for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath`) do (
+    set "Vs2017InstallRoot=%%d"
+)
+if not defined Vs2017InstallRoot goto :msbuild_latest
+
+::find msbuild under vs2017 install directory
+for /f "usebackq delims=" %%a in (`where /R "%Vs2017InstallRoot%" msbuild.exe`) do (
+    set "CMD_MSBUILD=%%a"
+)
+if not defined USE_LATEST_MSBUILD (
+    if defined CMD_MSBUILD exit /b
+)
+
+:msbuild_latest
+::find msbuild bundled with latest visual studio(vs2019 or lator).
+for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
     set "CMD_MSBUILD=%%a"
     exit /b
 )
 
-setlocal
-set APPDIR=Microsoft Visual Studio\Installer
-PATH=%PATH%;%ProgramFiles%\%APPDIR%\;%ProgramFiles(x86)%\%APPDIR%\;%ProgramW6432%\%APPDIR%\;
-for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
-    set "DIR_MSBUILD=%%i"
-)
-if exist "%DIR_MSBUILD%\MSBuild\15.0\Bin\MSBuild.exe" (
-    endlocal && set "CMD_MSBUILD=%DIR_MSBUILD%\MSBuild\15.0\Bin\MSBuild.exe"
+::find msbuild in $env[PATH].
+for /f "usebackq delims=" %%a in (`where msbuild.exe`) do ( 
+    set "CMD_MSBUILD=%%a"
     exit /b
 )
-if exist "%DIR_MSBUILD%\MSBuild\Current\Bin\amd64\MSBuild.exe" (
-    endlocal && set "CMD_MSBUILD=%DIR_MSBUILD%\MSBuild\Current\Bin\amd64\MSBuild.exe"
-    exit /b
-)
-if exist "%DIR_MSBUILD%\MSBuild\Current\Bin\MSBuild.exe" (
-    endlocal && set "CMD_MSBUILD=%DIR_MSBUILD%\MSBuild\Current\Bin\MSBuild.exe"
-    exit /b
-)
-endlocal
 exit /b

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -19,6 +19,7 @@
 | Inno Setup 5       | CMD_ISCC     | Inno Setup 5       | ISCC.exe     |
 | cppcheck           | CMD_CPPCHECK | cppcheck           | cppcheck.exe |
 | doxygen            | CMD_DOXYGEN  | doxygen\bin        | doxygen.exe  |
+| vswhere            | CMD_VSWHERE  | Microsoft Visual Studio\Installer | vswhere.exe  |
 | MSBuild            | CMD_MSBUILD  | 特殊               | MSBuild.exe  |
 
 ## MSBuild以外の探索手順
@@ -34,9 +35,10 @@ MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。
 
 ## MSBuild
 1. CMD_MSBUILDがセットされていればそれを使う
-2. パスが通っていればそれを使う
-3. Visual Studio 2017以降にあるMicrosoft Visual Studio\Installer\vswhere.exeを利用し、msbuild.exeを探す。
-4. 1～3で見つからなければCMD_MSBUILDには何もセットしない
+2. vswhere.exe(Visual Studio 2017に搭載されているバージョン)とwhereコマンド(windows標準)を利用し、Visual Studio 2017のmsbuild.exeを探す
+3. USE_LATEST_MSBUILDがセットされている場合、または、2.でmsbuild.exeが見つからない場合、vswhere.exe(Visual Studio 2019以降に搭載されたバージョン)を利用しmsbuild.exeを探す
+4. 2.および3.でmsbuild.exeが見つからない場合、whereコマンド(windows標準)を利用し、システム標準のmsbuild.exeを探す(MsBuild以外の探索手順にある「パスが通っている」と同じ意味)
+5. 2～4で見つからなければCMD_MSBUILDには何もセットしない
 
 ### 参照
 * https://github.com/Microsoft/vswhere


### PR DESCRIPTION
## 目的
ビルドに使うMsBuildの探索方法を見直して、  
MsBuild関連のトラブル発生を抑止します。

## 経緯
1. プロジェクトを移行した当初、ビルド方法は sakura.sln をダブルクリックしてビルドでした。(MsBuildは登場していません。)
2. しばらくしてバッチビルド環境を整備してCIを導入しました。  (この時にMsBuild.exeが登場します。appveyorの話はけっこう初期からあった気がします。)
3. パスが通ってないexeを探すバッチコードが増えてきたので、find-tools.batが作られます。  (この時にvswhere.exeが登場します。vswhereはvs2017以降標準装備らしいです。)
4. 2018年12月頃に、公開されていたvs2019 Previewとvs2017とのビルド非互換に対処が入り始めました。  #694, #698
5. 2019年4月にvs2019正式版が販売開始されました。  （同時に、vs2017インストール済みのサクラエディタをビルドできる環境にvs2019をインストールした場合にビルドができなくなる、という問題が発生しました。）
6. #832(Visual Studio 2019 インストール環境でのビルドエラー修正)が適用されました。  （vs2017とvs2019が両方存在する環境でもビルドができるようになりました。）
7. #889(VS2017 と VS2019 のどちらをビルドに使うか判定見直し)が立てられました。

## このPRで解決したい問題
開発環境の更新は、かなり大きな変化だと思っています。
現状、「vs2019に移行しても問題ないか？」という観点の調査は誰も行っていないので、「vs2019がインストールされていたらvs2019を使う」という自動判定には問題があるような気がしています。

**`最新版を使う`という意思表示がない限り、vs2017とvs2019の選択ではvs2017を選ぶようにして、  
意図せずvs2017⇔vs2019間の非互換に捕まることがないようにしたいです。**

## 変更内容
変更内容は [tools/find-tools.mdの差分(rich diff)](https://github.com/sakura-editor/sakura/pull/892/files?short_path=76d42b0#diff-76d42b0cfe79d80480cf3f0409fc362d) を先に見てもらうと分かりやすいと思います。

1. CMD_VSWHERE を追加
2. サブ処理内のsetlocalを除去(グローバルでやってるから要らない)
3. バージョン固定でvs2017を探す処理を追加
4. vs2017インストールフォルダ配下のMsBuild.exe探索にwhereコマンドを使うように変更
5. 環境変数に指定できるオプションUSE_LATEST_MSBUILDを追加
6. vs2017がない or USE_LATEST_MSBUILDの時に最新版vswhereの機能を使って最新vs付属のMsBuild.exeを探索する機構を追加

## 確認方法
全パターンの環境を用意するのはしんどいと思うので、確認方法はお任せします。

### こちらで確認したパターン

vsバージョン | USE_LATEST_MSBUILD | 確認結果
-- | -- | --
vs2017のみ | 未定義 | vs2017版が使われる
vs2017のみ | 1 | vs2017版が使われる
vs2017 + vs2019 | 未定義 | vs2017版が使われる
vs2017 + vs2019 | 1 | vs2019版が使われる
vs2019のみ | 未定義 | vs2019版が使われる
vs2019のみ | 1 | vs2019版が使われる

※vs2017,vs2019のいずれもインストールされていない場合、サクラエディタのビルドはできないので、そのパターンについては検証自体行っていません。
