### PR TITLE
テストのビルドにパッケージを使ってビルド時間を短縮する(MinGW版)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ skip_commits:
 install:
 - cmd: |
     pip install openpyxl --user
+    C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gtest"
 
 build_script:
 - cmd: |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ include(${CMAKE_SOURCE_DIR}/runtime.cmake)
 
 project (sakura-unittest)
 
+option(BUILD_GTEST "Build GoogleTest." ON)
 option(BUILD_SHARED_LIBS "Build shared libraries (DLLs)." OFF)
 
 # switch DLL or static libary by specifying by command line
@@ -16,17 +17,21 @@ endif (BUILD_SHARED_LIBS)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-add_subdirectory(googletest)
+if(BUILD_GTEST)
+	add_subdirectory(googletest)
+endif()
 add_subdirectory(unittests)
 
 # turn on solution folder
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # create solution folder
-set_target_properties(gmock       PROPERTIES FOLDER GoogleTest)
-set_target_properties(gmock_main  PROPERTIES FOLDER GoogleTest)
-set_target_properties(gtest       PROPERTIES FOLDER GoogleTest)
-set_target_properties(gtest_main  PROPERTIES FOLDER GoogleTest)
+if(BUILD_GTEST)
+	set_target_properties(gmock       PROPERTIES FOLDER GoogleTest)
+	set_target_properties(gmock_main  PROPERTIES FOLDER GoogleTest)
+	set_target_properties(gtest       PROPERTIES FOLDER GoogleTest)
+	set_target_properties(gtest_main  PROPERTIES FOLDER GoogleTest)
+endif()
 set_target_properties(tests1      PROPERTIES FOLDER Tests)
 
 # specify startup project

--- a/tests/create-project.bat
+++ b/tests/create-project.bat
@@ -49,10 +49,10 @@ exit /b
 
 :setenv_Win32
 :setenv_x64
-	set CMAKE_GEN_OPT=-G "Visual Studio 15 2017" -A "%~1"
+	set CMAKE_GEN_OPT=-G "Visual Studio 15 2017" -A "%~1" -D BUILD_GTEST=ON
 exit /b
 
 :setenv_MinGW
-	set CMAKE_GEN_OPT=-G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="%~2"
+	set CMAKE_GEN_OPT=-G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="%~2" -D BUILD_GTEST=OFF
 	set PATH=C:\msys64\mingw64\bin;%PATH:C:\Program Files\Git\usr\bin;=%
 exit /b

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -29,10 +29,6 @@ if (BUILD_SHARED_LIBS)
 	endif(MSVC)
 endif (BUILD_SHARED_LIBS)
 
-# link libraries
-target_link_libraries(${project_name} PRIVATE gtest)
-target_link_libraries(${project_name} PRIVATE gtest_main)
-
 # Hacks to reuse compiled editor objects.
 target_compile_definitions(${project_name} PRIVATE WIN32 _WIN32_WINNT=_WIN32_WINNT_WIN7)
 if (MSVC)
@@ -51,4 +47,18 @@ elseif (MINGW)
 	list (TRANSFORM ALL_O REPLACE "\\.(cpp|rc)$" ".o")
 	target_link_libraries (${project_name} PRIVATE ${ALL_O})
 endif ()
+
+# link with GoogleTest
+if(BUILD_GTEST)
+	# Build GoogleTest from source code.
+	target_link_libraries(${project_name} PRIVATE gtest)
+	target_link_libraries(${project_name} PRIVATE gtest_main)
+else()
+	# Build without GoogleTest(use system library).
+	find_package(GTest REQUIRED)
+	target_link_libraries(${project_name} PRIVATE GTest::GTest)
+	target_link_libraries(${project_name} PRIVATE GTest::Main)
+endif()
+
+# link libraries
 target_link_libraries (${project_name} PRIVATE winspool ole32 oleaut32 uuid comctl32 imm32 mpr imagehlp shlwapi winmm windowscodecs msimg32)


### PR DESCRIPTION
## 目的
MinGW向けテストのビルド時間を短縮します。

## 変更内容
1. cmakeのfind_packageを使い、インストール済みの GTest を検索するように変更
2. appveyorのinstallセクションにpacmanパッケージのインストールコマンドを追加して、必要なパッケージがインストールされた状態にするように変更
3. googletestのソースコードをビルドするための `subdirectory(googletest)` を MinGW ビルドでは実行されないようにします。

## メリット
MinGW版でGooleTestをビルドする必要がなくなるため、ビルドが少し速くなります。
他の有用なライブラリを取り込む際に参考にできる実績を作ることができます。

## デメリット
ビルド時にmsys2のパッケージをインストールする必要があります。
MinGW版ビルド環境が本格的にmsys2に依存するようになります。

## 備考
MSVCでは引き続きGoogleTestのビルドが必要です。
MSVC向けの変更は別件とします。
このPRがマージされ次第WIPを外す予定です。
