### PR TITLE
Inno Setup での OS の対応バージョンを Windows 7 以降に変更

### DIFF
--- a/installer/sakura-common.iss
+++ b/installer/sakura-common.iss
@@ -41,8 +41,8 @@ OutputBaseFilename=sakura_install{#MyAppVerH}-{#MyArchitecture}
 VersionInfoVersion={#MyAppVer}
 VersionInfoProductVersion={#MyAppVer}
 
-; OSバージョン制限
-MinVersion=0,5.0
+; OSバージョン制限(Windows 7 以降に対応)
+MinVersion=0,6.1
 
 [Languages]
 Name: "ja"; MessagesFile: "compiler:Languages\Japanese.isl"

--- a/installer/sakura-common.iss
+++ b/installer/sakura-common.iss
@@ -42,7 +42,7 @@ VersionInfoVersion={#MyAppVer}
 VersionInfoProductVersion={#MyAppVer}
 
 ; OSバージョン制限(Windows 7 以降に対応)
-MinVersion=0,6.1
+MinVersion=6.1
 
 [Languages]
 Name: "ja"; MessagesFile: "compiler:Languages\Japanese.isl"


### PR DESCRIPTION
Inno Setup での OS の対応バージョンを Windows 7 以降に変更

#548 でサクラエディタ本体の対応バージョンを window 7 以降にしたので、
Inno Setup 側もそれに合わせる。

参考

- #548 (395c9258500a2011ec5a7e8b02401b7e3a054b47)
- https://github.com/sakura-editor/sakura/pull/884#discussion_r279742448
