### PR TITLE
[WIP] テストのビルドにパッケージを使ってビルド時間を短縮する(-G=Visual Studio(MSVC)版)  

### DIFF
--- a/cmake/FindNuGet.cmake
+++ b/cmake/FindNuGet.cmake
@@ -1,0 +1,93 @@
+﻿# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindNuGet
+-----------
+
+Find NuGet command line interface.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module defines any :ref:`Imported Targets <Imported Targets>`.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project
+(see :ref:`Standard Variable Names <CMake Developer Standard Variable Names>`):
+
+``NUGET_FOUND``
+  System has the NuGet command line interface.
+``NUGET_EXECUTABLE``
+  Path to the NuGet command line interface.
+``NUGET_VERSION``
+  File version of the NuGet command line interface.
+``NUGET_PACKAGES_DIR``
+  Path to a NuGet package directory.
+
+Hints
+^^^^^
+
+``NUGET_ROOT``
+  Define the root directory of a NuGet command line interface installation.
+``NUGET_PACKAGES_DIR``
+  Define the root directory of a NuGet package directory.
+
+Commands
+^^^^^^^^
+
+This module defines the following commands in your project
+
+  NuGet_restore_package(_packages_config)
+
+#]=======================================================================]
+
+# restore NuGet packages directly in configure phase.
+function(NuGet_restore_package _packages_config)
+  execute_process(
+    COMMAND
+	  ${NUGET_EXECUTABLE} restore
+	    -PackagesDirectory ${NUGET_PACKAGES_DIR}
+		${_packages_config}
+  )
+endfunction()
+
+if(NOT NUGET_PACKAGES_DIR)
+  set(NUGET_PACKAGES_DIR ${CMAKE_LIST_DIR}/packages)
+endif()
+mark_as_advanced(NUGET_PACKAGES_DIR)
+
+# find NuGet Command Line Interface.
+find_program(NUGET_EXECUTABLE nuget
+                        HINTS ${NUGET_ROOT})
+
+if(NUGET_EXECUTABLE)
+  ### NUGET_VERSION
+  set(NUGET_VERSION "Unknown")
+  # check if powershell interpreter is available.
+  find_program(POWERSHELL_EXECUTABLE powershell)
+  if(POWERSHELL_EXECUTABLE)
+    execute_process(
+      COMMAND
+        powershell -ExecutionPolicy RemoteSigned -Command "${NUGET_EXECUTABLE} help | select -First 1"
+        OUTPUT_VARIABLE
+          NUGET_VERSION_OUTPUT_VARIABLE
+        RESULT_VARIABLE
+          NUGET_VERSION_RESULT_VARIABLE
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
+  if(NUGET_VERSION_RESULT_VARIABLE)
+    string(REGEX REPLACE "NuGet Version: (.+)" "\\1" NUGET_VERSION ${NUGET_VERSION_OUTPUT_VARIABLE})
+  endif()
+endif()
+
+find_package(PackageHandleStandardArgs QUIET)
+find_package_handle_standard_args(NuGet
+                                  REQUIRED_VARS	NUGET_EXECUTABLE
+                                  VERSION_VAR	NUGET_VERSION)
+
+mark_as_advanced(NUGET_EXECUTABLE)

--- a/cmake/FindNuGetGTest.cmake
+++ b/cmake/FindNuGetGTest.cmake
@@ -1,0 +1,60 @@
+﻿# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindNuGetGTest
+-----------
+
+Find the GoogleTest from NuGet repository.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module defines any :ref:`Imported Targets <Imported Targets>`.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project
+(see :ref:`Standard Variable Names <CMake Developer Standard Variable Names>`):
+
+``NUGET_GTEST_FOUND``
+  System has the NuGet GoogleTest package.
+
+Commands
+^^^^^^^^
+
+This module defines the following commands.
+
+  NuGet_GTest_target_link_libraries(_target)
+
+#]=======================================================================]
+
+cmake_minimum_required(VERSION 3.12)
+
+function(NuGet_GTest_target_link_libraries _target)
+  # add preprocessor symbol definitions required for GoogleTest in MSVC
+  target_compile_definitions(${_target} PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+
+  # add NuGet.targets as a library
+  target_link_libraries(${_target} PRIVATE ${NuGet_GTest_Root}/build/${NuGet_GTest_Framework}/${NuGet_GTest_Id}.targets)
+endfunction()
+
+# the NuGet Command Line Interface required.
+find_package(NuGet REQUIRED)
+
+# define variables for NuGet package of GoogleTest.
+set(NuGet_GTest_Name		Microsoft.googletest)
+set(NuGet_GTest_Id			Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static)
+set(NuGet_GTest_Version		1.8.0)
+set(NuGet_GTest_Framework	native)
+set(NuGet_GTest_Root		${NUGET_PACKAGES_DIR}/${NuGet_GTest_Id}.${NuGet_GTest_Version})
+
+# find a NuGet.targets in the standard native NuGet package structure.
+find_path(GTEST_TARGET ${NuGet_GTest_Id}.targets
+              HINTS ${NuGet_GTest_Root}
+      PATH_SUFFIXES /build/${NuGet_GTest_Framework})
+
+find_package(PackageHandleStandardArgs QUIET)
+find_package_handle_standard_args(GTest
+                                  REQUIRED_VARS	GTEST_TARGET)

--- a/externals/nuget/TermsOfUse.txt
+++ b/externals/nuget/TermsOfUse.txt
@@ -1,0 +1,5 @@
+NuGet Version: 4.9.2.5706
+
+NuGet Terms of use
+  see an official documentations
+  https://www.nuget.org/policies/Terms

--- a/tests/create-project.bat
+++ b/tests/create-project.bat
@@ -49,7 +49,7 @@ exit /b
 
 :setenv_Win32
 :setenv_x64
-	set CMAKE_GEN_OPT=-G "Visual Studio 15 2017" -A "%~1" -D BUILD_GTEST=ON
+	set CMAKE_GEN_OPT=-G "Visual Studio 15 2017" -A "%~1" -D BUILD_GTEST=OFF
 exit /b
 
 :setenv_MinGW

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,8 +1,10 @@
-cmake_minimum_required(VERSION 3.6)
+﻿cmake_minimum_required(VERSION 3.6)
 include(${CMAKE_SOURCE_DIR}/runtime.cmake)
 
 # define a variable of project name
 set(project_name tests1)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 # define a variable SRC with file GLOB
 file(GLOB TEST_SRC ${CMAKE_CURRENT_LIST_DIR}/test*.cpp)
@@ -58,16 +60,9 @@ elseif(MSVC)
 	set(NUGET_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../externals/nuget)
 	set(NUGET_PACKAGES_DIR ${CMAKE_CURRENT_LIST_DIR}/../../packages)
 
-	# find NuGet Command Line Interface.
-	find_program(NUGET nuget.exe HINTS ${NUGET_ROOT})
-	if(NUGET)
-		# restore NuGet packages directly in configure phase.
-		execute_process(COMMAND ${NUGET} restore
-			-PackagesDirectory ${NUGET_PACKAGES_DIR}
-			${CMAKE_CURRENT_LIST_DIR}/packages.config)
-	else()
-		message(FATAL "Cannot find nuget command line tool.")
-	endif()
+	#execute nuget restore.
+	find_package(NuGet REQUIRED)
+	NuGet_restore_package(${CMAKE_CURRENT_LIST_DIR}/packages.config)
 
 	# define variables for NuGet package of GoogleTest.
 	set(NuGet_GTest_Name		Microsoft.googletest)

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -53,6 +53,34 @@ if(BUILD_GTEST)
 	# Build GoogleTest from source code.
 	target_link_libraries(${project_name} PRIVATE gtest)
 	target_link_libraries(${project_name} PRIVATE gtest_main)
+elseif(MSVC)
+	# Build without GoogleTest for MSVC(use NuGet package).
+	set(NUGET_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../externals/nuget)
+	set(NUGET_PACKAGES_DIR ${CMAKE_CURRENT_LIST_DIR}/../../packages)
+
+	# find NuGet Command Line Interface.
+	find_program(NUGET nuget.exe HINTS ${NUGET_ROOT})
+	if(NUGET)
+		# restore NuGet packages directly in configure phase.
+		execute_process(COMMAND ${NUGET} restore
+			-PackagesDirectory ${NUGET_PACKAGES_DIR}
+			${CMAKE_CURRENT_LIST_DIR}/packages.config)
+	else()
+		message(FATAL "Cannot find nuget command line tool.")
+	endif()
+
+	# define variables for NuGet package of GoogleTest.
+	set(NuGet_GTest_Name		Microsoft.googletest)
+	set(NuGet_GTest_Id			Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static)
+	set(NuGet_GTest_Version		1.8.0)
+	set(NuGet_GTest_Framework	native)
+	set(NuGet_GTest_Root		${NUGET_PACKAGES_DIR}/${NuGet_GTest_Id}.${NuGet_GTest_Version})
+
+	# add preprocessor symbol definitions required for GoogleTest in MSVC
+	target_compile_definitions(${project_name} PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+
+	# add NuGet.targets as a library
+	target_link_libraries(${project_name} PRIVATE ${NuGet_GTest_Root}/build/${NuGet_GTest_Framework}/${NuGet_GTest_Id}.targets)
 else()
 	# Build without GoogleTest(use system library).
 	find_package(GTest REQUIRED)

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -64,18 +64,9 @@ elseif(MSVC)
 	find_package(NuGet REQUIRED)
 	NuGet_restore_package(${CMAKE_CURRENT_LIST_DIR}/packages.config)
 
-	# define variables for NuGet package of GoogleTest.
-	set(NuGet_GTest_Name		Microsoft.googletest)
-	set(NuGet_GTest_Id			Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static)
-	set(NuGet_GTest_Version		1.8.0)
-	set(NuGet_GTest_Framework	native)
-	set(NuGet_GTest_Root		${NUGET_PACKAGES_DIR}/${NuGet_GTest_Id}.${NuGet_GTest_Version})
-
-	# add preprocessor symbol definitions required for GoogleTest in MSVC
-	target_compile_definitions(${project_name} PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-
-	# add NuGet.targets as a library
-	target_link_libraries(${project_name} PRIVATE ${NuGet_GTest_Root}/build/${NuGet_GTest_Framework}/${NuGet_GTest_Id}.targets)
+	#link with NuGet package of GoogleTest.
+	find_package(NuGetGTest)
+	NuGet_GTest_target_link_libraries(${project_name})
 else()
 	# Build without GoogleTest(use system library).
 	find_package(GTest REQUIRED)

--- a/tests/unittests/packages.config
+++ b/tests/unittests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.0" targetFramework="native" />
+</packages>


### PR DESCRIPTION
## 目的
MSVC向けテストのビルド時間を短縮します。

## 前提
1. MinGW向けのビルド時間短縮は #894 で実施済み。
2. MinGWと同じ方法でビルド時間短縮を行いたいが、MSVC向けのGTestライブラリを「システムライブラリ」としてインストールするのはあまり一般的ではない。
3. CMakeのGeneratorが `Visual Studio*` なら NuGetパッケージの取り込みは簡単にできる。
4. MSVC向けのGTestライブラリはNuGetパッケージとして提供されている。
5. NuGetパッケージを取得するにはNuGet.exeが必要。

## 変更内容
1. `BUILD_GTEST=OFF`の処理に分岐を入れてMSVCならNuGetパッケージを使うように変更。NuGet.exeを探してrestoreし、NuGet.targetsをtarget_link_librariesする処理を入れた。
2. MSVC向けテストプロジェクトを作成する`BUILD_GTEST`の値をONからOFFに変更。
3. 他用途に使いまわす可能性がある「NuGet.exeを探す処理」をパッケージ化して`FindNuGet.cmake`を作成。CMake公式の`FindPerl.cmake`をコピペして作った関係でライセンスはBSD 3 Clauseとしてある。
4. NuGet版GTestを探す処理をパッケージ化して`FindNuGetGTest.cmake`を作成。現段階では必ずしも分離する必要はないが、`-G=Ninja`の場合に処理を拡張する必要があるので先に分離した。`FindNuGet.cmake`と同様にCMake公式の`FindPerl.cmake`をコピペして作った関係でライセンスはBSD 3 Clauseとしてある。


## メリット
MSVC版でGooleTestをビルドする必要がなくなるため、ビルドがわずかに速くなります。
GoogleTestをビルドしないので、ログ出力が若干短くなります。
他の有用なライブラリを取り込む際に参考にできる実績を作ることができます。

## デメリット
MSVC版で本当にシステムライブラリを使いたい場合に対応できなくなります。
NuGet.exeがシステムにない場合を考慮してnuget.exe(約5MB)を取り込むのでgit cloneのサイズが大きくなります。

## 備考
主目的「ビルド時間を短縮する」の効果は、言うほどないと思っています。(数十秒程度:sob:
「PR出します」って言っといてださないのもアレなので、ちょっと残念な感じの効果ですがないよりましだろうってことで出してみます。

このPRの後継として`ソリューション全体のCMake化(-G Ninja対応)`を予定しています。作業過程として一旦この形にしたことを共有しておくことが、全体理解の助けになるんじゃないかという期待もあります。