### PR TITLE
PR #894 の不備・不整合を正します。

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ skip_commits:
 install:
 - cmd: |
     pip install openpyxl --user
-    C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gtest"
+    if "%platform%" == "MinGW" C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gtest"
 
 build_script:
 - cmd: |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ include(${CMAKE_SOURCE_DIR}/runtime.cmake)
 
 project (sakura-unittest)
 
-option(BUILD_GTEST "Build GoogleTest." ON)
+option(GTEST_PACKAGE "Use pre-built Google Test package." ON)
 option(BUILD_SHARED_LIBS "Build shared libraries (DLLs)." OFF)
 
 # switch DLL or static libary by specifying by command line
@@ -17,8 +17,16 @@ endif (BUILD_SHARED_LIBS)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-if(BUILD_GTEST)
+if(GTEST_PACKAGE)
+	find_package(GTest)
+	set (GTEST      GTest::GTest)
+	set (GTEST_MAIN GTest::Main)
+endif()
+if(NOT GTEST_FOUND)
+	set (BUILD_GMOCK OFF CACHE BOOL "overwrite default value of BUILD_GMOCK")
 	add_subdirectory(googletest)
+	set (GTEST      gtest)
+	set (GTEST_MAIN gtest_main)
 endif()
 add_subdirectory(unittests)
 
@@ -26,11 +34,9 @@ add_subdirectory(unittests)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # create solution folder
-if(BUILD_GTEST)
-	set_target_properties(gtest       PROPERTIES FOLDER GoogleTest)
-	set_target_properties(gtest_main  PROPERTIES FOLDER GoogleTest)
-endif()
-set_target_properties(tests1      PROPERTIES FOLDER Tests)
+set_target_properties(${GTEST}      PROPERTIES FOLDER GoogleTest)
+set_target_properties(${GTEST_MAIN} PROPERTIES FOLDER GoogleTest)
+set_target_properties(tests1        PROPERTIES FOLDER Tests)
 
 # specify startup project
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tests1)

--- a/tests/create-project.bat
+++ b/tests/create-project.bat
@@ -49,10 +49,10 @@ exit /b
 
 :setenv_Win32
 :setenv_x64
-	set CMAKE_GEN_OPT=-G "Visual Studio 15 2017" -A "%~1" -D BUILD_GTEST=ON
+	set CMAKE_GEN_OPT=-G "Visual Studio 15 2017" -A "%~1"
 exit /b
 
 :setenv_MinGW
-	set CMAKE_GEN_OPT=-G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="%~2" -D BUILD_GTEST=OFF
+	set CMAKE_GEN_OPT=-G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="%~2" -D GTEST_PACKAGE=ON
 	set PATH=C:\msys64\mingw64\bin;%PATH:C:\Program Files\Git\usr\bin;=%
 exit /b

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -29,6 +29,9 @@ if (BUILD_SHARED_LIBS)
 	endif(MSVC)
 endif (BUILD_SHARED_LIBS)
 
+# link with GoogleTest
+target_link_libraries (${project_name} PRIVATE ${GTEST_MAIN} ${GTEST})
+
 # Hacks to reuse compiled editor objects.
 target_compile_definitions(${project_name} PRIVATE WIN32 _WIN32_WINNT=_WIN32_WINNT_WIN7)
 if (MSVC)
@@ -47,18 +50,4 @@ elseif (MINGW)
 	list (TRANSFORM ALL_O REPLACE "\\.(cpp|rc)$" ".o")
 	target_link_libraries (${project_name} PRIVATE ${ALL_O})
 endif ()
-
-# link with GoogleTest
-if(BUILD_GTEST)
-	# Build GoogleTest from source code.
-	target_link_libraries(${project_name} PRIVATE gtest)
-	target_link_libraries(${project_name} PRIVATE gtest_main)
-else()
-	# Build without GoogleTest(use system library).
-	find_package(GTest REQUIRED)
-	target_link_libraries(${project_name} PRIVATE GTest::GTest)
-	target_link_libraries(${project_name} PRIVATE GTest::Main)
-endif()
-
-# link libraries
 target_link_libraries (${project_name} PRIVATE winspool ole32 oleaut32 uuid comctl32 imm32 mpr imagehlp shlwapi winmm windowscodecs msimg32)


### PR DESCRIPTION
**この PR 文は大幅に修正されました。**

修正されるのは以下の通り。
    
* 一部の環境でしかテストプログラムを作成できなくなっていた。
* パッケージ版で gmock が利用できなかった。
  => 必要になるまで gmock 非対応とし、ソースビルド版から gmock を削除することで足並みを揃えた。
* AppVeyor で、パッケージを使わないときにもインストールしていた。
