### PR TITLE
gmockのターゲットを参照するのをやめる

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,8 +27,6 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # create solution folder
 if(BUILD_GTEST)
-	set_target_properties(gmock       PROPERTIES FOLDER GoogleTest)
-	set_target_properties(gmock_main  PROPERTIES FOLDER GoogleTest)
 	set_target_properties(gtest       PROPERTIES FOLDER GoogleTest)
 	set_target_properties(gtest_main  PROPERTIES FOLDER GoogleTest)
 endif()


### PR DESCRIPTION
gtestのパッケージ版を利用するに修正したが、
gmockのパッケージ版は現時点で利用できない。

gmockの利用を開始する時点でライブラリをどうするか考えればよいので、
一旦ターゲット参照を削り、gmockを利用していないことが分かるようにする。

https://github.com/sakura-editor/sakura/pull/899 より切り出して作成。

https://github.com/sakura-editor/sakura/pull/894 で行ったMinGW版でGTestのパッケージ版を利用するようにした修正の改善。