### PR TITLE
#endifに続く文字列をコメントアウトする

### DIFF
--- a/tests/unittests/test-mydevmode.cpp
+++ b/tests/unittests/test-mydevmode.cpp
@@ -27,7 +27,7 @@
 
 #ifndef NOMINMAX
 #define NOMINMAX
-#endif NOMINMAX
+#endif /* #ifndef NOMINMAX */
 
 #include <tchar.h>
 #include <Windows.h>


### PR DESCRIPTION
https://github.com/sakura-editor/sakura/pull/877 構造体比較にmemcmpを使うのをやめる で導入したテストコードにC++規約的に正しくない記述が紛れていました。

```c++
#ifndef NOMINMAX 
#define NOMINMAX 
#endif NOMINMAX		//←これ。
```

現時点でビルドエラーにはなりませんが、コメントアウトして問題のない状態にしたいです。

`m/#[\t ]*endif[\t ]+\S/` で検索してチェックしましたが、
このようなミスコーディングは他にはありませんでした。
