### PR TITLE
GoogleTestのリンク方法を統一する

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 if(BUILD_GTEST)
 	add_subdirectory(googletest)
+	include(GoogleTest)
+	set(GTEST_FOUND TRUE)
+	add_library(GTest::GTest ALIAS gtest)
+	add_library(GTest::Main  ALIAS gtest_main)
+else()
+	find_package(GTest REQUIRED)
 endif()
 add_subdirectory(unittests)
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -49,16 +49,8 @@ elseif (MINGW)
 endif ()
 
 # link with GoogleTest
-if(BUILD_GTEST)
-	# Build GoogleTest from source code.
-	target_link_libraries(${project_name} PRIVATE gtest)
-	target_link_libraries(${project_name} PRIVATE gtest_main)
-else()
-	# Build without GoogleTest(use system library).
-	find_package(GTest REQUIRED)
-	target_link_libraries(${project_name} PRIVATE GTest::GTest)
-	target_link_libraries(${project_name} PRIVATE GTest::Main)
-endif()
+target_link_libraries(${project_name} PRIVATE GTest::GTest)
+target_link_libraries(${project_name} PRIVATE GTest::Main)
 
 # link libraries
 target_link_libraries (${project_name} PRIVATE winspool ole32 oleaut32 uuid comctl32 imm32 mpr imagehlp shlwapi winmm windowscodecs msimg32)


### PR DESCRIPTION
テストモジュールとGoogleTestのリンク方法を整理します。

https://github.com/sakura-editor/sakura/pull/894 で導入したGTest(CMakeパッケージ)の後始末を行います。

ブランチ | リンク方法
-- | --
#894適用前 | ソースからビルドしたGoogleTestのgtest, gtest_mainとリンク。どこにも判定なし。
#894適用後(＝現在のmaster) |  ソースからビルドする場合はGoogleTestのgtest, gtest_mainとリンク、パッケージを使う場合はGTest(CMakeパッケージ)のGTest::GTest, GTest::Mainとリンク。場合分けは実際にビルドしたか(=`BUILD_GTEST`)を見て判定。GoogleTestをビルドするかどうかとGooleTestをビルドしたかの2回判定を行っている。
このPR | GTest(CMakeパッケージ)のGTest::GTest, GTest::Mainとリンク。ソースからビルドする場合はgtest, gtest_mainがGTest::GTest, GTest::Mainに見えるようにエイリアスを設定。判定を行うのはGoogleTestをビルドするかどうかの1回。

https://github.com/sakura-editor/sakura/pull/899 で `BUILD_GTEST=OFF` のときの動きに調整が入る予定で、`tests/CMakeLists.txt` に入れる `else()` ブロックは消滅する見込みです。

リンクターゲット名を寄せる方向として  
`GTest ⇒ ソースビルド` ではなく  
`ソースビルド ⇒ GTest` を選択している理由は、  
既製パッケージを使うほうがCMakeコードを書く労力を省けると考えたからです。

https://github.com/sakura-editor/sakura/pull/899 にあった 「`target_link_libraries` を1つにまとめる」の対応は、依存ライブラリは1行ずつに分かれていたほうが増減があったときの差分チェックがしやすいのではないか？という考えのもと、引き継ぎませんでした。
