### PR TITLE
NOMINMAXの定義をifndefで括る

### DIFF
--- a/tests/unittests/test-int2dec.cpp
+++ b/tests/unittests/test-int2dec.cpp
@@ -1,7 +1,11 @@
 ﻿#include <gtest/gtest.h>
 
 #include <limits>
+
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
 #include <Windows.h>
 #include <tchar.h>
 #include "basis/primitive.h"

--- a/tests/unittests/test-is_mailaddress.cpp
+++ b/tests/unittests/test-is_mailaddress.cpp
@@ -24,7 +24,10 @@
 */
 #include <gtest/gtest.h>
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
 #include <tchar.h>
 #include <wchar.h>
 #include <assert.h>


### PR DESCRIPTION
テストコードの`#define NOMINMAX`が警告を吐いています。
CMake対応で `-G=Ninja` の調整をしていて気になったのでPR出します。

```
C:\projects\sakura\tests\unittests\test-int2dec.cpp:4: warning: "NOMINMAX" redefined
 #define NOMINMAX
 
In file included from C:/msys64/mingw64/include/c++/8.2.0/x86_64-w64-mingw32/bits/c++config.h:508,
                 from C:/msys64/mingw64/include/c++/8.2.0/limits:42,
                 from C:/projects/sakura/tests/googletest/googletest/include/gtest/gtest.h:56,
                 from C:\projects\sakura\tests\unittests\test-int2dec.cpp:1:
C:/msys64/mingw64/include/c++/8.2.0/x86_64-w64-mingw32/bits/os_defines.h:45: note: this is the location of the previous definition
 #define NOMINMAX 1
 
[ 76%] Building CXX object unittests/CMakeFiles/tests1.dir/test-is_mailaddress.cpp.obj
```

本件、https://github.com/sakura-editor/sakura/issues/592 単体テストコードで NOMINMAX を定義しているのを削除する で話題になってる件です。

「削除しよう。」は違う気がするので、ifndefで括って二重定義を回避します。

closes #592;

と書いておけばマージと同時にissueも閉じられるのかな？
