### PR TITLE
#877 で導入した単体テストで DISABLED テストを実装

### DIFF
--- a/tests/unittests/test-mydevmode.cpp
+++ b/tests/unittests/test-mydevmode.cpp
@@ -260,6 +260,8 @@ TEST(MYDEVMODETest, operatorNotEqual)
 
 /* アクセス不可のメモリ領域にアクセスしても、例外が発生しない事象があるので、
  * 当面MSVCのリリース版では以下のテストを実行しない。
+ *
+ * 参考: https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
  */
 #if defined(_DEBUG) || defined(__MINGW64__)
 /*!
@@ -269,6 +271,9 @@ TEST(MYDEVMODETest, operatorNotEqual)
  *  実際にどういうケースで一般保護例外違反となるか、コード的に発生させる方法の共有を兼ねて実装したもの。
  */
 TEST(MYDEVMODETest, StrategyForSegmentationFault)
+#else
+TEST(MYDEVMODETest, DISABLED_StrategyForSegmentationFault)
+#endif /* if defined(_DEBUG) || defined(__MINGW64__) */
 {
 	// システムのページサイズを取得する
 	SYSTEM_INFO systemInfo = { 0 };
@@ -315,4 +320,3 @@ TEST(MYDEVMODETest, StrategyForSegmentationFault)
 	// 仮想メモリ範囲を解放する。
 	::VirtualFree(memBlock1, 0, MEM_RELEASE);
 }
-#endif /* if defined(_DEBUG) || defined(__MINGW64__) */


### PR DESCRIPTION
DISABLED テストを実装

#877 で導入した単体テストで `TEST(MYDEVMODETest, StrategyForSegmentationFault)` のテストは
VC の Release の構成では無効化されているので、ビルド構成によってテストの数に違いが出る。

テスト数が異なると一瞬バグのように見えるので、テスト数を合わせるために、GoogleTest の
[DISABLED テスト](https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests) という扱いにする。

なお、xml 形式でテスト結果を出力すると以下のような感じで `notrun` として出力されるので
azure pipelines 上でテスト項目として認識される。

```
  <testsuite name="MYDEVMODETest" tests="5" failures="0" disabled="1" errors="0" time="0">
    <testcase name="operatorEqualByCopy" status="run" time="0" classname="MYDEVMODETest" />
    <testcase name="operatorEqualBySelf" status="run" time="0" classname="MYDEVMODETest" />
    <testcase name="operatorEqualByMemCpy" status="run" time="0" classname="MYDEVMODETest" />
    <testcase name="operatorNotEqual" status="run" time="0" classname="MYDEVMODETest" />
    <testcase name="DISABLED_StrategyForSegmentationFault" status="notrun" time="0" classname="MYDEVMODETest" />
  </testsuite>
```

また実行結果のテキストでは最後に以下のような形で出力される。

```
[  PASSED  ] 71 tests.
  YOU HAVE 1 DISABLED TEST
```

## 制限事項

Appveyor 側では xml 出力を使用せず、コンソール出力を解析して対応しています。
上記出力の解析に対応していないので VC の Release 構成でのテスト項目数に変化はないです。



