### PR TITLE
#892 の対応の際、VS2017 用の msbuild.exe の探索で不必要に上の階層から検索していたために時間のかかるのを修正

### DIFF
--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -103,11 +103,11 @@ if not defined Vs2017InstallRoot goto :msbuild_latest
 
 ::find msbuild under vs2017 install directory
 if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe" (
-	set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe"
     if defined CMD_MSBUILD exit /b
 )
 if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe" (
-	set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe"
+    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe"
     if defined CMD_MSBUILD exit /b
 )
 if not defined USE_LATEST_MSBUILD (

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -102,8 +102,13 @@ for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -version [15^,16^) -requires 
 if not defined Vs2017InstallRoot goto :msbuild_latest
 
 ::find msbuild under vs2017 install directory
-for /f "usebackq delims=" %%a in (`where /R "%Vs2017InstallRoot%" msbuild.exe`) do (
-    set "CMD_MSBUILD=%%a"
+if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe" (
+	set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+    if defined CMD_MSBUILD exit /b
+)
+if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe" (
+	set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe"
+    if defined CMD_MSBUILD exit /b
 )
 if not defined USE_LATEST_MSBUILD (
     if defined CMD_MSBUILD exit /b


### PR DESCRIPTION
#892 の対応の際、VS2017 用の msbuild.exe の探索で不必要に上の階層から検索していたために
時間のかかるのを修正

https://github.com/sakura-editor/sakura/issues/907#issuecomment-493076281
https://github.com/sakura-editor/sakura/issues/907#issuecomment-493094434

closes  #907
