### PR TITLE
PR でビルドに関係ないドキュメント等の更新の場合に CI ビルドが走らないようにする

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,13 @@ pr:
       - master
       - develop
       - feature/*
+  paths:
+    exclude:
+      - "*.md"
+      - .github/*.md
+      - .github/ISSUE_TEMPLATE/*.md
+      - .travis.yml
+      - appveyor.yml
 
 ###############################################################################################################################
 #   jobs/job 定義


### PR DESCRIPTION
# PR の目的

PR でビルドに関係ないドキュメント等の更新の場合に CI ビルドが走らないようにする

<!-- PR の目的を記載してください -->
<!-- 必須 -->

## カテゴリ

- 仕様変更
- CI関連
  - Azure Pipelines

## PR の背景

<!-- PR を行う背景を記載してください -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

https://github.com/sakura-editor/sakura/pull/918 はドキュメントの更新で本来 CI のビルドが走る必要のない PR ですが、実際にはビルドが走っています。

`branches` に対してはビルドをスキップする指定が行われていますが、PR に対しては指定していなかったので、不必要にビルドが走っている。

## PR のメリット

ドキュメントのみの更新で、CI の実行が必要ない PR のビルドをスキップできる。

<!-- PR のメリットを記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

## PR のデメリット (トレードオフとかあれば)

特にない。

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## PR の影響範囲

md ファイル等を commit & push したときに PR で azure pipelines のビルドが走らなくなる。

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

## 関連チケット

https://github.com/sakura-editor/sakura/pull/918

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->


## 参考資料

https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#pull-request-validation

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
