### PR TITLE
md5 ファイルを git の無視リストに追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ UpgradeLog.htm
 /x64
 /.vs
 sakura-*.zip
+sakura-*.zip.md5
 msbuild-*.log
 msbuild-*.log.csv
 msbuild-*.log.xlsx


### PR DESCRIPTION
# PR の目的

ビルド時に生成される一時ファイルである md5 ファイルを git の無視リストに追加する。


## カテゴリ

- その他 (Git 関連)

## PR の背景

 #888 で md5 ファイルの生成に対応したときに無視リストに追加していなかった。

## PR のメリット

テンポラリファイルを誤って登録しないようにする。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

省略

## 関連チケット

#888

## 参考資料

なし
