### PR TITLE
.gitignore を Azure Pipelines の無視リストに追加する

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ trigger:
       - "*.md"
       - .github/*.md
       - .github/ISSUE_TEMPLATE/*.md
+      - .gitignore
       - .travis.yml
       - appveyor.yml
 
@@ -33,6 +34,7 @@ pr:
       - "*.md"
       - .github/*.md
       - .github/ISSUE_TEMPLATE/*.md
+      - .gitignore
       - .travis.yml
       - appveyor.yml
 


### PR DESCRIPTION
# PR の目的

.gitignore はビルドには関係ないので更新されても CI ビルドが走らないように
.gitignore を Azure Pipelines の無視リストに追加する。

## カテゴリ

- CI関連
  - Azure Pipelines

## PR の背景

#923 を投げたときに Azure Pipelines のビルドが走ったが、
.gitignore が更新されてもCI を走らせる必要がないため。

なお Appveyor に関しては対処済みです。

## PR のメリット

gitignore が更新されてもCI を走らせない。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

gitignore が更新されたときの Azure Pipelines のビルドの有無

## 関連チケット

#923 

## 参考資料

なし
