### PR TITLE
Inno Setup のログファイルを .gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ doxygen*.log
 .sonarqube
 build-wrapper-win-x86*
 bw-output
+iss-*-*.log


### PR DESCRIPTION
# PR の目的

Inno Setup のログファイルを git の無視リストに追加する。

## カテゴリ

- その他 (Git 関連)

## PR の背景

#923 で Inno Setup のログファイルも無視リストに登録する必要に気付いた。
https://github.com/sakura-editor/sakura/pull/923#issuecomment-495620296

## PR のメリット

テンポラリファイルを誤って登録しないようにする。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

省略

## 関連チケット

#923

## 参考資料

なし
