### PR TITLE
sakura.hhp` で `sakura_core\sakura.hh` を参照するのをやめてコメントをカットした sakura.hh を使うようにする (python 版)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.vs
 /cppcheck-*.xml
 /cppcheck-install.log
+/help/sakura/sakura.hh
 /tests/build
 /Win32
 /x64

--- a/appveyor.md
+++ b/appveyor.md
@@ -92,6 +92,7 @@ APPVEYOR_REPO_TAG_NAME は利用をやめて 代わりに GIT_TAG_NAME を使う
                 - [appveyor_env.py](appveyor_env.py)
     - [build-gnu.bat](build-gnu.bat) : (Platform="MinGW"のみ) Makefileをビルドしてbuild-all.batの処理を終了する
     - [build-chm.bat](build-chm.bat) : HTML Help をビルドする
+        - [remove-comment.py](help/remove-comment.py) : UTF-8 でのコンパイルエラーの回避のために日本語を削除するために [sakura.hh](sakura_core/sakura.hh) から一行コメントを削除する
         - hhc.exe (Visual Studio 2017 に同梱)
     - [run-cppcheck.bat](run-cppcheck.bat) : cppcheck を実行する
         - cppcheck.exe

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -11,6 +11,12 @@ set HHP_SAKURA=help\sakura\sakura.hhp
 set CHM_MACRO=help\macro\macro.chm
 set CHM_PLUGIN=help\plugin\plugin.chm
 set CHM_SAKURA=help\sakura\sakura.chm
+set HH_SCRIPT=%~dp0help\remove-comment.py
+set HH_INPUT=sakura_core\sakura.hh
+set HH_OUTPUT=help\sakura\sakura.hh
+
+del /F "%HH_OUTPUT%"
+python "%HH_SCRIPT%" "%HH_INPUT%" "%HH_OUTPUT%"  || (echo error && exit /b 1)
 
 call :BuildChm %HHP_MACRO%  %CHM_MACRO%   || (echo error && exit /b 1)
 call :BuildChm %HHP_PLUGIN% %CHM_PLUGIN%  || (echo error && exit /b 1)

--- a/help/remove-comment.py
+++ b/help/remove-comment.py
@@ -8,10 +8,11 @@ import codecs
 def clipEndOfLine(line):
 	return line.rstrip('\r\n')
 
+# 行からコメントを削除する
 def clipCommet(line):
 	return re.sub(r'//.*', r'', line)
 
-# コメントを削除する
+# ファイルからコメントを削除する
 def removeComment(inFile, outFile):
 	with codecs.open(inFile, "r", "utf_8_sig") as fin:
 		with codecs.open(outFile, "w", "utf_8_sig") as fout:

--- a/help/remove-comment.py
+++ b/help/remove-comment.py
@@ -1,0 +1,32 @@
+﻿# -*- coding: utf-8 -*-
+import os
+import sys
+import re
+import codecs
+
+# 引数で指定した文字列から改行コードを取り除く
+def clipEndOfLine(line):
+	return line.rstrip('\r\n')
+
+def clipCommet(line):
+	return re.sub(r'//.*', r'', line)
+
+# コメントを削除する
+def removeComment(inFile, outFile):
+	with codecs.open(inFile, "r", "utf_8_sig") as fin:
+		with codecs.open(outFile, "w", "utf_8_sig") as fout:
+			for line in fin:
+				text = clipEndOfLine(line)
+				text = clipCommet(text)
+				fout.write(text + "\r\n")
+
+if __name__ == '__main__':
+	if len(sys.argv) < 3:
+		print ("usage: " + os.path.basename(sys.argv[0]) + " <src file> <dst file>")
+		sys.exit(1)
+		
+	if not os.path.exists(sys.argv[1]):
+		print (sys.argv[1] + " doesn't exist")
+		sys.exit(1)
+
+	removeComment(sys.argv[1], sys.argv[2])

--- a/help/sakura/sakura.hhp
+++ b/help/sakura/sakura.hhp
@@ -805,7 +805,7 @@ HLP_UR001=res\HLP_UR001.html
 HLP_HISTORY=res\HLP_HISTORY.html
 
 [MAP]
-#include ../../sakura_core/sakura.hh
+#include sakura.hh
 
 [TEXT POPUPS]
 Cshelp.txt


### PR DESCRIPTION
# PR の目的

sakura.hhp` で `sakura_core\sakura.hh` を参照するのをやめてコメントをカットした sakura.hh を使うようにする

## カテゴリ

- リファクタリング
- ビルド手順
- CI関連
  - Appveyor
  - Azure Pipelines

## PR の背景

#929 の説明欄に詳説しているが、「 #807: HTML ヘルプの文字コードを UTF-8 BOM 付きに変換する 」
で sakura.hhp のコンパイルに失敗する問題を回避するため

## PR のメリット

HTML ヘルプの文字コードを UTF-8 BOM 付きに変換しても CI でビルドできる。

## PR のデメリット (トレードオフとかあれば)

HTML Help のビルドに python が必要になる。

## PR の影響範囲

HTML Help のビルド

## 関連チケット

- #584
- #807
- #929
- #906


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
