### PR TITLE
find-tool.bat で Visual Studio 2017 か Visual Studio 2019 かを指定できるようにする

### DIFF
--- a/tests/create-project.bat
+++ b/tests/create-project.bat
@@ -2,6 +2,8 @@ set platform=%1
 set configuration=%2
 set ERROR_RESULT=0
 
+call %~dp0..\tools\find-tools.bat
+
 @rem produces header files necessary in creating the project.
 if "%platform%" == "MinGW" (
 	set BUILD_EDITOR_BAT=build-gnu.bat
@@ -32,6 +34,7 @@ if exist "%BUILDDIR%" (
 mkdir "%BUILDDIR%"
 
 call :setenv_%platform% %platform% %configuration%
+@echo cmake %CMAKE_GEN_OPT% -H. -B"%BUILDDIR%"
 cmake %CMAKE_GEN_OPT% -H. -B"%BUILDDIR%" || set ERROR_RESULT=1
 
 popd
@@ -49,7 +52,12 @@ exit /b
 
 :setenv_Win32
 :setenv_x64
-	set CMAKE_GEN_OPT=-G "Visual Studio 15 2017" -A "%~1" -D BUILD_GTEST=ON
+	if defined CMAKE_G_PARAM (
+		set CMAKE_G_OPTION=-G "%CMAKE_G_PARAM%"
+	) else (
+		set CMAKE_G_OPTION=
+	)
+	set CMAKE_GEN_OPT=%CMAKE_G_OPTION% -A "%~1" -D BUILD_GTEST=ON
 exit /b
 
 :setenv_MinGW

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -120,7 +120,7 @@ exit /b
 		set "CMAKE_G_PARAM=Visual Studio 15 2017"
 		call :msbuild_vs2017 2> nul
 	) else if "%VSVERSION%" == "2019" (
-		set "CMAKE_G_PARAM=Visual Studio 15 2019"
+		set "CMAKE_G_PARAM=Visual Studio 16 2019"
 		call :msbuild_vs2019 2> nul
 	)
 	if not defined CMD_MSBUILD (

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -105,66 +105,72 @@ for /f "usebackq delims=" %%a in (`where $PATH2:vswhere.exe`) do (
 exit /b
 
 :: ---------------------------------------------------------------------------------------------------------------------
-:msbuild
-if "%SELECT_VSVERSION%" == "" (
-	set VSVERSION=2017
-) else if "%SELECT_VSVERSION%" == "2017" (
-	set VSVERSION=2017
-) else if "%SELECT_VSVERSION%" == "2019" (
-	set VSVERSION=2019
-)
-
-if "%VSVERSION%" == "2017" (
-	set "CMAKE_GENERATER_VERSION=Visual Studio 15 2017"
-	call :msbuild_vs2017 2> nul
-) else if "%VSVERSION%" == "2019" (
-	set "CMAKE_GENERATER_VERSION=Visual Studio 15 2019"
-	call :msbuild_vs2019 2> nul
-)
-if not defined CMD_MSBUILD (
-	set "CMAKE_GENERATER_VERSION="
-	call :msbuild_from_env_path 2> nul
-)
-
-exit /b
+:: sub routine for finding msbuild
 :: ---------------------------------------------------------------------------------------------------------------------
+:msbuild
+	if "%SELECT_VSVERSION%" == "" (
+		set VSVERSION=2017
+	) else if "%SELECT_VSVERSION%" == "2017" (
+		set VSVERSION=2017
+	) else if "%SELECT_VSVERSION%" == "2019" (
+		set VSVERSION=2019
+	)
 
+	if "%VSVERSION%" == "2017" (
+		set "CMAKE_GENERATER_VERSION=Visual Studio 15 2017"
+		call :msbuild_vs2017 2> nul
+	) else if "%VSVERSION%" == "2019" (
+		set "CMAKE_GENERATER_VERSION=Visual Studio 15 2019"
+		call :msbuild_vs2019 2> nul
+	)
+	if not defined CMD_MSBUILD (
+		set "CMAKE_GENERATER_VERSION="
+		call :msbuild_from_env_path 2> nul
+	)
+
+	exit /b
+
+:: ---------------------------------------------------------------------------------------------------------------------
+:: sub routine for finding msbuild of VS2017
 :: ---------------------------------------------------------------------------------------------------------------------
 :msbuild_vs2017
-::find vs2017 install directory
-for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath`) do (
-    set "Vs2017InstallRoot=%%d"
-)
-if not defined Vs2017InstallRoot exit /b
+	::find vs2017 install directory
+	for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath`) do (
+	    set "Vs2017InstallRoot=%%d"
+	)
+	if not defined Vs2017InstallRoot exit /b
 
-::find msbuild under vs2017 install directory
-if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe" (
-    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe"
-    if defined CMD_MSBUILD exit /b
-)
-if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe" (
-    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe"
-    if defined CMD_MSBUILD exit /b
-)
-exit /b
+	::find msbuild under vs2017 install directory
+	if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe" (
+	    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+	    if defined CMD_MSBUILD exit /b
+	)
+	if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe" (
+	    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe"
+	    if defined CMD_MSBUILD exit /b
+	)
+	exit /b
+
 :: ---------------------------------------------------------------------------------------------------------------------
-
+:: sub routine for finding msbuild of VS2019
 :: ---------------------------------------------------------------------------------------------------------------------
 :msbuild_vs2019
-for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -version [16^,17^) -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
-    set "CMD_MSBUILD=%%a"
-    exit /b
-)
-exit /b
+	for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -version [16^,17^) -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
+	    set "CMD_MSBUILD=%%a"
+	    exit /b
+	)
+	exit /b
 :: ---------------------------------------------------------------------------------------------------------------------
 
 
+:: ---------------------------------------------------------------------------------------------------------------------
+:: sub routine for finding msbuild from PATH env
 :: ---------------------------------------------------------------------------------------------------------------------
 ::find msbuild in $env[PATH].
 :msbuild_from_env_path
-for /f "usebackq delims=" %%a in (`where msbuild.exe`) do ( 
-    set "CMD_MSBUILD=%%a"
-    exit /b
-)
-exit /b
+	for /f "usebackq delims=" %%a in (`where msbuild.exe`) do ( 
+	    set "CMD_MSBUILD=%%a"
+	    exit /b
+	)
+	exit /b
 :: ---------------------------------------------------------------------------------------------------------------------

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -117,14 +117,14 @@ exit /b
 	)
 
 	if "%VSVERSION%" == "2017" (
-		set "CMAKE_GENERATER_VERSION=Visual Studio 15 2017"
+		set "CMAKE_G_PARAM=Visual Studio 15 2017"
 		call :msbuild_vs2017 2> nul
 	) else if "%VSVERSION%" == "2019" (
-		set "CMAKE_GENERATER_VERSION=Visual Studio 15 2019"
+		set "CMAKE_G_PARAM=Visual Studio 15 2019"
 		call :msbuild_vs2019 2> nul
 	)
 	if not defined CMD_MSBUILD (
-		set "CMAKE_GENERATER_VERSION="
+		set "CMAKE_G_PARAM="
 		call :msbuild_from_env_path 2> nul
 	)
 

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -104,12 +104,38 @@ for /f "usebackq delims=" %%a in (`where $PATH2:vswhere.exe`) do (
 )
 exit /b
 
+:: ---------------------------------------------------------------------------------------------------------------------
 :msbuild
+if "%SELECT_VSVERSION%" == "" (
+	set VSVERSION=2017
+) else if "%SELECT_VSVERSION%" == "2017" (
+	set VSVERSION=2017
+) else if "%SELECT_VSVERSION%" == "2019" (
+	set VSVERSION=2019
+)
+
+if "%VSVERSION%" == "2017" (
+	set "CMAKE_GENERATER_VERSION=Visual Studio 15 2017"
+	call :msbuild_vs2017 2> nul
+) else if "%VSVERSION%" == "2019" (
+	set "CMAKE_GENERATER_VERSION=Visual Studio 15 2019"
+	call :msbuild_vs2019 2> nul
+)
+if not defined CMD_MSBUILD (
+	set "CMAKE_GENERATER_VERSION="
+	call :msbuild_from_env_path 2> nul
+)
+
+exit /b
+:: ---------------------------------------------------------------------------------------------------------------------
+
+:: ---------------------------------------------------------------------------------------------------------------------
+:msbuild_vs2017
 ::find vs2017 install directory
 for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath`) do (
     set "Vs2017InstallRoot=%%d"
 )
-if not defined Vs2017InstallRoot goto :msbuild_latest
+if not defined Vs2017InstallRoot exit /b
 
 ::find msbuild under vs2017 install directory
 if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe" (
@@ -120,20 +146,25 @@ if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe" (
     set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe"
     if defined CMD_MSBUILD exit /b
 )
-if not defined USE_LATEST_MSBUILD (
-    if defined CMD_MSBUILD exit /b
-)
+exit /b
+:: ---------------------------------------------------------------------------------------------------------------------
 
-:msbuild_latest
-::find msbuild bundled with latest visual studio(vs2019 or lator).
-for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
+:: ---------------------------------------------------------------------------------------------------------------------
+:msbuild_vs2019
+for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -version [16^,17^) -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
     set "CMD_MSBUILD=%%a"
     exit /b
 )
+exit /b
+:: ---------------------------------------------------------------------------------------------------------------------
 
+
+:: ---------------------------------------------------------------------------------------------------------------------
 ::find msbuild in $env[PATH].
+:msbuild_from_env_path
 for /f "usebackq delims=" %%a in (`where msbuild.exe`) do ( 
     set "CMD_MSBUILD=%%a"
     exit /b
 )
 exit /b
+:: ---------------------------------------------------------------------------------------------------------------------

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -35,10 +35,16 @@ MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。
 
 ## MSBuild
 1. CMD_MSBUILDがセットされていればそれを使う
-2. vswhere.exe(Visual Studio 2017に搭載されているバージョン)とwhereコマンド(windows標準)を利用し、Visual Studio 2017のmsbuild.exeを探す
-3. USE_LATEST_MSBUILDがセットされている場合、または、2.でmsbuild.exeが見つからない場合、vswhere.exe(Visual Studio 2019以降に搭載されたバージョン)を利用しmsbuild.exeを探す
-4. 2.および3.でmsbuild.exeが見つからない場合、whereコマンド(windows標準)を利用し、システム標準のmsbuild.exeを探す(MsBuild以外の探索手順にある「パスが通っている」と同じ意味)
-5. 2～4で見つからなければCMD_MSBUILDには何もセットしない
+2. SELECT_VSVERSION の値によって以下を行う
+    1. `SELECT_VSVERSION` の値が未定義の場合 → `VS2017` を使う
+    2. `SELECT_VSVERSION` の値が `2017` の場合 → `VS2017` を使う
+    3. `SELECT_VSVERSION` の値が `2019` の場合 → `VS2019` を使う
+3. 選択された Visual Studio のバージョンによって以下を行う
+    1. `VS2017` が選択されていれば `CMAKE_G_PARAM` に `Visual Studio 15 2017` を設定する。
+    2. `VS2017` が選択されていれば `CMAKE_G_PARAM` に `Visual Studio 15 2019` を設定する。
+3. msbuild.exeが見つからない場合、whereコマンド(windows標準)を利用し、システム標準のmsbuild.exeを探す(MsBuild以外の探索手順にある「パスが通っている」と同じ意味) `CMAKE_G_PARAM` は空にセットする。
+
+(`CMAKE_G_PARAM` は cmake の `-G' パラメータとして使用する)
 
 ### 参照
 * https://github.com/Microsoft/vswhere


### PR DESCRIPTION
# PR の目的

find-tool.bat で Visual Studio 2017 か Visual Studio 2019 かを指定できるようにする

## カテゴリ

- 仕様変更
- CI関連
  - Appveyor
  - Azure Pipelines

## PR の背景

#931 の `背景` にある通り、ビルドに使用する Visual Studio のバージョンで最新バージョンを使うのではなく明示的に指定することにより、cmake で使用するバージョンと ソリューションのビルドに使用する Visual Studio のバージョンを合わせることができるようにする。(デフォルトは VS2017)

## PR のメリット

Visaul Studio 2019 でのビルドができるようになる。

## PR のデメリット (トレードオフとかあれば)

特になし

## PR の影響範囲

ソリューションのビルド処理、Cmake でのビルド処理で使用される Visual Studio の選択


## 関連チケット

#951
close #931
#698
