### PR TITLE
HTML の Help 中の JavaScript の文字コードを UTF-8 に修正

### DIFF
--- a/help/plugin/Text/item.js
+++ b/help/plugin/Text/item.js
@@ -1,4 +1,4 @@
-// HHCtrls
+﻿// HHCtrls
 function HHCtrlClose()
 {
 	document.writeln('<OBJECT id="aaHHCtlCloseWin" type="application/x-oleobject"');
@@ -26,7 +26,7 @@ function IsChm(){return (-1 !=(""+window.location.href).search(/\.chm::/i));}
 if(IsChm()){
 	HHCtrlClose();
 }else{
-	document.writeln('[<a href="index.html">�ڎ�</a>]');
+	document.writeln('[<a href="index.html">目次</a>]');
 }
 
 function hideDiv (targetId)

--- a/help/sakura/res/item.js
+++ b/help/sakura/res/item.js
@@ -1,4 +1,4 @@
-// HHCtrls
+﻿// HHCtrls
 function HHCtrlClose()
 {
 	document.writeln('<OBJECT id="aaHHCtlCloseWin" type="application/x-oleobject"');
@@ -26,6 +26,6 @@ function IsChm(){return (-1 !=(""+window.location.href).search(/\.chm::/i));}
 if(IsChm()){
 	HHCtrlClose();
 }else{
-	document.writeln('[<a href="HLP000001.html">�ڎ�</a>]');
+	document.writeln('[<a href="HLP000001.html">目次</a>]');
 }
 


### PR DESCRIPTION
# PR の目的

HTML の Help 中の JavaScript の文字コードを UTF-8 に修正する
#937 の対応漏れ

## カテゴリ

- ドキュメント修正

## PR の背景

#937 で Help 用の HTML の中で使う javascript の文字コード変換が漏れていた。
(https://github.com/sakura-editor/sakura-editor.github.io/issues/47 に着手しようとして気づいた)

## PR のメリット


-   Web サイトのデータと簡単に同期がとれる
-   GitHub 上で差分をレビューしやすくなる。


## PR のデメリット (トレードオフとかあれば)

特になし

## PR の影響範囲

- Compiled HTML (chm) の場合は通らない処理に日本語を含むため、コンテンツとしては chm には影響ないはず。
- 未確認だが chm のコンパイルには影響するかも (master で https://ci.appveyor.com/project/sakuraeditor/sakura/builds/24967995/job/yojlk5peifeeurmr でビルドに失敗しているから)

## 関連チケット

- #937
- #906
- https://github.com/sakura-editor/sakura-editor.github.io/issues/47


## 参考資料

なし
