### PR TITLE
(#930 の不備修正) help\sakura\sakura.hh が存在しない環境で chm をビルドしたときにエラーメッセージが出るのを修正

### DIFF
--- a/build-chm.bat
+++ b/build-chm.bat
@@ -15,7 +15,7 @@ set HH_SCRIPT=%~dp0help\remove-comment.py
 set HH_INPUT=sakura_core\sakura.hh
 set HH_OUTPUT=help\sakura\sakura.hh
 
-del /F "%HH_OUTPUT%"
+if exist "%HH_OUTPUT%" del /F "%HH_OUTPUT%"
 python "%HH_SCRIPT%" "%HH_INPUT%" "%HH_OUTPUT%"  || (echo error && exit /b 1)
 
 call :BuildChm %HHP_MACRO%  %CHM_MACRO%   || (echo error && exit /b 1)


### PR DESCRIPTION
# PR の目的

help\sakura\sakura.hh が存在しない環境で chm をビルドしたときにエラーメッセージが出るのを修正
#930 の不備修正

## カテゴリ

- 不具合修正

## PR の背景

#930 を対応したが、クリーン環境でビルドしたときに help\sakura\sakura.hh を削除しようとして
ファイルが存在しないというエラーが出る。

## PR のメリット

無害だけど、紛らわしいエラーが出るのを修正

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

compile html help のビルド

## 関連チケット

#930

## 参考資料

なし