### PR TITLE
DISABLED テストのサンプルを追加する

### DIFF
--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -71,7 +71,7 @@ class TestsImcomplte2 : public ::testing::Test
 };
 
 /*!
-	fixture 全体を無効化するたに、DISABLED_ をつけた名前を typedef する
+	fixture 全体を無効化するために、DISABLED_ をつけた名前を typedef する
 */
 typedef TestsImcomplte2 DISABLED_TestsImcomplte2;
 

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -42,7 +42,7 @@ class DISABLED_TestsImcomplte1 : public ::testing::Test
 */
 TEST_F(DISABLED_TestsImcomplte1, Test1)
 {
-	/* 意図的に失敗させる */
+	/* テストに問題があって失敗している例 */
 	EXPECT_EQ(4, 1 + 2);
 }
 
@@ -51,7 +51,7 @@ TEST_F(DISABLED_TestsImcomplte1, Test1)
 */
 TEST_F(DISABLED_TestsImcomplte1, Test2)
 {
-	/* 意図的に失敗させる */
+	/* テストに問題があって失敗している例 */
 	EXPECT_EQ(4, 1 + 2);
 }
 
@@ -80,7 +80,7 @@ typedef TestsImcomplte2 DISABLED_TestsImcomplte2;
 */
 TEST_F(DISABLED_TestsImcomplte2, Test1)
 {
-	/* 意図的に失敗させる */
+	/* テストに問題があって失敗している例 */
 	EXPECT_EQ(4, 1 + 2);
 }
 
@@ -89,7 +89,7 @@ TEST_F(DISABLED_TestsImcomplte2, Test1)
 */
 TEST_F(DISABLED_TestsImcomplte2, Test2)
 {
-	/* 意図的に失敗させる */
+	/* テストに問題があって失敗している例 */
 	EXPECT_EQ(4, 1 + 2);
 }
 
@@ -103,6 +103,6 @@ TEST_F(DISABLED_TestsImcomplte2, Test2)
 */
 TEST(test, DISABLED_IncomplteTest)
 {
-	/* 意図的に失敗させる */
+	/* テストに問題があって失敗している例 */
 	EXPECT_EQ(4, 1 + 2);
 }

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -34,7 +34,20 @@
 */
 class DISABLED_TestsImcomplte1 : public ::testing::Test
 {
+protected:
+	/*!
+		テスト前の準備
+	*/
+	virtual void SetUp()
+	{
+	}
 
+	/*!
+		テスト後の後始末
+	*/
+	virtual void TearDown()
+	{
+	}
 };
 
 /*!
@@ -67,7 +80,20 @@ TEST_F(DISABLED_TestsImcomplte1, Test2)
 */
 class TestsImcomplte2 : public ::testing::Test
 {
+protected:
+	/*!
+		テスト前の準備
+	*/
+	virtual void SetUp()
+	{
+	}
 
+	/*!
+		テスト後の後始末
+	*/
+	virtual void TearDown()
+	{
+	}
 };
 
 /*!

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -35,7 +35,6 @@
 class DISABLED_TestsImcomplte1 : public ::testing::Test
 {
 
-
 };
 
 /*!
@@ -47,7 +46,6 @@ TEST_F(DISABLED_TestsImcomplte1, Test1)
 	EXPECT_EQ(1 + 2, 4);
 }
 
-
 /*!
 	DISABLED テストのサンプル
 */
@@ -56,8 +54,6 @@ TEST_F(DISABLED_TestsImcomplte1, Test2)
 	/* 意図的に失敗させる */
 	EXPECT_EQ(1 + 2, 4);
 }
-
-
 
 /*!
 	DISABLED テストのサンプル2
@@ -71,7 +67,6 @@ TEST_F(DISABLED_TestsImcomplte1, Test2)
 */
 class TestsImcomplte2 : public ::testing::Test
 {
-
 
 };
 

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -25,10 +25,10 @@
 #include <gtest/gtest.h>
 
 /*!
-	DISABLED テストのサンプル
+	DISABLED テストのサンプル1
 	
-	- このテストは通常実行されません
-	- --gtest_also_run_disabled_tests オプションを指定して実行することにより明示的に実行できます。
+	- このテスト fixture は通常実行されません
+	- `--gtest_also_run_disabled_tests` オプションを指定して実行することにより明示的に実行できます。
 
 	https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
 */
@@ -38,7 +38,9 @@ class DISABLED_TestsImcomplte1 : public ::testing::Test
 
 };
 
-
+/*!
+	DISABLED テストのサンプル
+*/
 TEST_F(DISABLED_TestsImcomplte1, Test1)
 {
 	/* 意図的に失敗させる */
@@ -46,6 +48,9 @@ TEST_F(DISABLED_TestsImcomplte1, Test1)
 }
 
 
+/*!
+	DISABLED テストのサンプル
+*/
 TEST_F(DISABLED_TestsImcomplte1, Test2)
 {
 	/* 意図的に失敗させる */
@@ -57,7 +62,7 @@ TEST_F(DISABLED_TestsImcomplte1, Test2)
 	DISABLED テストのサンプル
 	
 	- このテストは通常実行されません
-	- --gtest_also_run_disabled_tests オプションを指定して実行することにより明示的に実行できます。
+	- `--gtest_also_run_disabled_tests` オプションを指定して実行することにより明示的に実行できます。
 
 	https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
 */

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -58,6 +58,48 @@ TEST_F(DISABLED_TestsImcomplte1, Test2)
 }
 
 
+
+/*!
+	DISABLED テストのサンプル2
+	
+	- このテスト fixture は通常実行されません
+	- クラス名に DISABLED_ を含まない
+	- typedef した名前に DISABLED_ をつけて fixture にする
+	- `--gtest_also_run_disabled_tests` オプションを指定して実行することにより明示的に実行できます。
+
+	https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
+*/
+class TestsImcomplte2 : public ::testing::Test
+{
+
+
+};
+
+/*!
+	fixture 全体を無効化するたに、DISABLED_ をつけた名前を typedef する
+*/
+typedef TestsImcomplte2 DISABLED_TestsImcomplte2;
+
+/*!
+	DISABLED テストのサンプル
+*/
+TEST_F(DISABLED_TestsImcomplte2, Test1)
+{
+	/* 意図的に失敗させる */
+	EXPECT_EQ(1 + 2, 4);
+}
+
+/*!
+	DISABLED テストのサンプル
+*/
+TEST_F(DISABLED_TestsImcomplte2, Test2)
+{
+	/* 意図的に失敗させる */
+	EXPECT_EQ(1 + 2, 4);
+}
+
+
+
 /*!
 	DISABLED テストのサンプル
 	

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -26,7 +26,7 @@
 
 /*!
 	DISABLED テストのサンプル1
-	
+
 	- このテスト fixture は通常実行されません
 	- `--gtest_also_run_disabled_tests` オプションを指定して実行することにより明示的に実行できます。
 
@@ -61,7 +61,7 @@ TEST_F(DISABLED_TestsImcomplte1, Test2)
 
 /*!
 	DISABLED テストのサンプル2
-	
+
 	- このテスト fixture は通常実行されません
 	- クラス名に DISABLED_ を含まない
 	- typedef した名前に DISABLED_ をつけて fixture にする
@@ -102,7 +102,7 @@ TEST_F(DISABLED_TestsImcomplte2, Test2)
 
 /*!
 	DISABLED テストのサンプル
-	
+
 	- このテストは通常実行されません
 	- `--gtest_also_run_disabled_tests` オプションを指定して実行することにより明示的に実行できます。
 

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -93,8 +93,6 @@ TEST_F(DISABLED_TestsImcomplte2, Test2)
 	EXPECT_EQ(1 + 2, 4);
 }
 
-
-
 /*!
 	DISABLED テストのサンプル
 

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -32,7 +32,7 @@
 
 	https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
 */
-class DISABLED_TestsImcomplte1 : public ::testing::Test
+class DISABLED_TestsIncomplte1 : public ::testing::Test
 {
 protected:
 	/*!
@@ -53,7 +53,7 @@ protected:
 /*!
 	DISABLED テストのサンプル
 */
-TEST_F(DISABLED_TestsImcomplte1, Test1)
+TEST_F(DISABLED_TestsIncomplte1, Test1)
 {
 	/* テストに問題があって失敗している例 */
 	EXPECT_EQ(4, 1 + 2);
@@ -62,7 +62,7 @@ TEST_F(DISABLED_TestsImcomplte1, Test1)
 /*!
 	DISABLED テストのサンプル
 */
-TEST_F(DISABLED_TestsImcomplte1, Test2)
+TEST_F(DISABLED_TestsIncomplte1, Test2)
 {
 	/* テストに問題があって失敗している例 */
 	EXPECT_EQ(4, 1 + 2);
@@ -78,7 +78,7 @@ TEST_F(DISABLED_TestsImcomplte1, Test2)
 
 	https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
 */
-class TestsImcomplte2 : public ::testing::Test
+class TestsIncomplte2 : public ::testing::Test
 {
 protected:
 	/*!
@@ -99,12 +99,12 @@ protected:
 /*!
 	fixture 全体を無効化するために、DISABLED_ をつけた名前を typedef する
 */
-typedef TestsImcomplte2 DISABLED_TestsImcomplte2;
+typedef TestsIncomplte2 DISABLED_TestsIncomplte2;
 
 /*!
 	DISABLED テストのサンプル
 */
-TEST_F(DISABLED_TestsImcomplte2, Test1)
+TEST_F(DISABLED_TestsIncomplte2, Test1)
 {
 	/* テストに問題があって失敗している例 */
 	EXPECT_EQ(4, 1 + 2);
@@ -113,7 +113,7 @@ TEST_F(DISABLED_TestsImcomplte2, Test1)
 /*!
 	DISABLED テストのサンプル
 */
-TEST_F(DISABLED_TestsImcomplte2, Test2)
+TEST_F(DISABLED_TestsIncomplte2, Test2)
 {
 	/* テストに問題があって失敗している例 */
 	EXPECT_EQ(4, 1 + 2);

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -1,0 +1,68 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+/*!
+	DISABLED テストのサンプル
+	
+	- このテストは通常実行されません
+	- --gtest_also_run_disabled_tests オプションを指定して実行することにより明示的に実行できます。
+
+	https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
+*/
+class DISABLED_TestsImcomplte1 : public ::testing::Test
+{
+
+
+};
+
+
+TEST_F(DISABLED_TestsImcomplte1, Test1)
+{
+	/* 意図的に失敗させる */
+	EXPECT_EQ(1 + 2, 4);
+}
+
+
+TEST_F(DISABLED_TestsImcomplte1, Test2)
+{
+	/* 意図的に失敗させる */
+	EXPECT_EQ(1 + 2, 4);
+}
+
+
+/*!
+	DISABLED テストのサンプル
+	
+	- このテストは通常実行されません
+	- --gtest_also_run_disabled_tests オプションを指定して実行することにより明示的に実行できます。
+
+	https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
+*/
+TEST(test, DISABLED_IncomplteTest)
+{
+	/* 意図的に失敗させる */
+	EXPECT_EQ(1 + 2, 4);
+}

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -43,7 +43,7 @@ class DISABLED_TestsImcomplte1 : public ::testing::Test
 TEST_F(DISABLED_TestsImcomplte1, Test1)
 {
 	/* 意図的に失敗させる */
-	EXPECT_EQ(1 + 2, 4);
+	EXPECT_EQ(4, 1 + 2);
 }
 
 /*!
@@ -52,7 +52,7 @@ TEST_F(DISABLED_TestsImcomplte1, Test1)
 TEST_F(DISABLED_TestsImcomplte1, Test2)
 {
 	/* 意図的に失敗させる */
-	EXPECT_EQ(1 + 2, 4);
+	EXPECT_EQ(4, 1 + 2);
 }
 
 /*!
@@ -81,7 +81,7 @@ typedef TestsImcomplte2 DISABLED_TestsImcomplte2;
 TEST_F(DISABLED_TestsImcomplte2, Test1)
 {
 	/* 意図的に失敗させる */
-	EXPECT_EQ(1 + 2, 4);
+	EXPECT_EQ(4, 1 + 2);
 }
 
 /*!
@@ -90,7 +90,7 @@ TEST_F(DISABLED_TestsImcomplte2, Test1)
 TEST_F(DISABLED_TestsImcomplte2, Test2)
 {
 	/* 意図的に失敗させる */
-	EXPECT_EQ(1 + 2, 4);
+	EXPECT_EQ(4, 1 + 2);
 }
 
 /*!
@@ -104,5 +104,5 @@ TEST_F(DISABLED_TestsImcomplte2, Test2)
 TEST(test, DISABLED_IncomplteTest)
 {
 	/* 意図的に失敗させる */
-	EXPECT_EQ(1 + 2, 4);
+	EXPECT_EQ(4, 1 + 2);
 }


### PR DESCRIPTION
# PR の目的

#877 で入れたテストがパスできるようになったので、DISABLED テストを削除するが
サンプルとしては残せるようにする。

## カテゴリ

- その他 (単体テストのサンプル追加)

## PR の背景

#877 で入れたテストが失敗したテストを #905 で 無効化したが
パスできるようになったので、有効化したいが DISABLED テストのサンプルを残したい。

## PR のメリット

#877 で入れたテストをパスさせるようにした後でも DISABLED テストのサンプルを残す

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

- 通常無効化される単体テストが増える
- #796 (#793) のプロジェクトにこのPRで追加したファイルを追加する必要がある

## 関連チケット

- close #942
- #905
- #877 
- #796 (#793)

## 参考資料

https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
