### PR TITLE
MSVCリリースビルドで失敗するテストを修正する

### DIFF
--- a/tests/unittests/test-mydevmode.cpp
+++ b/tests/unittests/test-mydevmode.cpp
@@ -260,8 +260,6 @@ TEST(MYDEVMODETest, operatorNotEqual)
 
 /* アクセス不可のメモリ領域にアクセスしても、例外が発生しない事象があるので、
  * 当面MSVCのリリース版では以下のテストを実行しない。
- *
- * 参考: https://github.com/google/googletest/blob/9d4cde44a4a3952cf21861f9370b3bed9265dfd7/googletest/docs/advanced.md#temporarily-disabling-tests
  */
 #if defined(_DEBUG) || defined(__MINGW64__)
 /*!
@@ -271,9 +269,6 @@ TEST(MYDEVMODETest, operatorNotEqual)
  *  実際にどういうケースで一般保護例外違反となるか、コード的に発生させる方法の共有を兼ねて実装したもの。
  */
 TEST(MYDEVMODETest, StrategyForSegmentationFault)
-#else
-TEST(MYDEVMODETest, DISABLED_StrategyForSegmentationFault)
-#endif /* if defined(_DEBUG) || defined(__MINGW64__) */
 {
 	// システムのページサイズを取得する
 	SYSTEM_INFO systemInfo = { 0 };
@@ -320,3 +315,4 @@ TEST(MYDEVMODETest, DISABLED_StrategyForSegmentationFault)
 	// 仮想メモリ範囲を解放する。
 	::VirtualFree(memBlock1, 0, MEM_RELEASE);
 }
+#endif /* if defined(_DEBUG) || defined(__MINGW64__) */

--- a/tests/unittests/test-mydevmode.cpp
+++ b/tests/unittests/test-mydevmode.cpp
@@ -277,19 +277,19 @@ TEST(MYDEVMODETest, StrategyForSegmentationFault)
 
 	// 仮想メモリ範囲を予約する。予約時点では全体をNOACCESS指定にしておく。
 	LPVOID memBlock1 = ::VirtualAlloc(NULL, allocSize, MEM_RESERVE, PAGE_NOACCESS);
-	assert(memBlock1);
+	EXPECT_TRUE(memBlock1 != NULL);
 
 	// 仮想メモリ全域をコミット(=確保)する。
 	wchar_t* buf1 = static_cast<wchar_t*>(::VirtualAlloc(memBlock1, allocSize, MEM_COMMIT, PAGE_READWRITE));
-	assert(buf1);
+	EXPECT_TRUE(buf1 != NULL);
 
 	// 確保したメモリ全域をASCII文字'a'で埋める
 	::wmemset(buf1, L'a', pageSize);
 
 	// 2ページ目の保護モードをNOACCESSにする。
 	DWORD flOldProtect = 0;
-	volatile bool retVirtualProtect = ::VirtualProtect(&buf1[pageSize / sizeof(wchar_t)], pageSize, PAGE_NOACCESS, &flOldProtect);
-	assert(retVirtualProtect);
+	volatile BOOL retVirtualProtect = ::VirtualProtect((char*)buf1 + pageSize, pageSize, PAGE_NOACCESS, &flOldProtect);
+	EXPECT_TRUE(retVirtualProtect);
 
 	// メモリデータをテスト対象型にマップする。実態として配列のように扱えるポインタを取得している。
 	MYDEVMODE* pValues = reinterpret_cast<MYDEVMODE*>(buf1);


### PR DESCRIPTION
# PR の目的
単体テストのコードを修正します。

## カテゴリ
- 単体テストのコード改善

## PR の背景
関連 PR と被りますが以下のような流れで今回の修正に至りました。

 - #877 構造体比較にmemcmpを使うのをやめる
 - SonarQube導入PRのレビューで実験的に行った修正を PR に出した。
 - 「せっかくだからテストも書こう」でテストを書いた。
 - (A) MSVCリリース版でテストが失敗する事象が起きた。
 - (B) 暫定対応として、MSVCリリース版ではテストが実行されないようにした。
　↓
 - #905 DISABLED テストを実装
 - (C) MSVCリリース版だけ件数が減ることに対処を入れた。

説明のために、やや主観的にラベル振っています。

(A) の問題に対処するために (B) を入れたけど、
(B) の対応を補完するために (C) を入れたって経緯です。

今回は、(A) の問題の原因が分かったので (B’) を入れる提案になります。

【(A) の問題の原因】
　MSVC の 最適化 によってコードが省略されてしまったため。

【(A) の問題への対策】
　MSVC の 最適化 を局所的に無効化する。（C言語の volatile キーワードを使う）

## PR のメリット
- 単体テスト `MYDEVMODETest - StrategyForSegmentationFault` を失敗させずに実行できるようになります。
- 書いたコードが 最適化によって消失する実例(とその対処方法) を共有できます。

## PR のデメリット (トレードオフとかあれば)
- volatile 変数導入の副作用がどれくらいあるか読めません。
- issue #942 で説明している通り、 #905 の対応を revert します。

## PR の影響範囲
単体テスト `MYDEVMODETest - StrategyForSegmentationFault` が常に実行されるようになります。

## 関連チケット
#877 元ネタ。修正対象はこのPRで入れたテスト。
#905 DISABLE対応。単に無効化するんじゃなく、GoogleTestの機能で無効化。
#942 DISABLE対応のサンプル化提案。
#943 DISABLE対応のサンプル化提案のPR。

## 参考資料
「MSVC 最適化 抑制」でググった1件と「volatile デメリット」でググった2件を貼っときます。
https://qiita.com/YukiMiyatake/items/1191ab03b6c0b5a22876
https://teratail.com/questions/39986
https://yamasa.hatenablog.jp/entry/20090720/1248089123

