### PR TITLE
CI環境でvs2019を選択できるようにしてみる Take2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ skip_commits:
     - '.github/ISSUE_TEMPLATE/*.md'
 
 install:
+- cup vswhere
 - cmd: |
     pip install openpyxl --user
     C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gtest"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: 1.0.{build}
-image: Visual Studio 2017
+image:
+  - Visual Studio 2017
+  - Visual Studio 2019 Preview
 
 configuration:
   - Debug
@@ -36,3 +38,10 @@ artifacts:
   - path: 'sakura-*$(platform)-$(configuration)*.zip'
   - path: 'sakura-*$(platform)-$(configuration)*.zip.md5'
   - path: 'sha256.txt'
+
+matrix:
+  exclude:
+    - image: Visual Studio 2017
+      platform: x64
+    - image: Visual Studio 2019 Preview
+      platform: MinGW

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ pr:
 ###############################################################################################################################
 jobs:
 
-# サクラエディタのビルドを行う JOB
+# サクラエディタのビルドを行う JOB (VS2017)
 # * サクラエディタ本体
 # * HTML Help
 # * Installer
@@ -55,6 +55,19 @@ jobs:
     name: VS2017
     vmImage: 'VS2017-Win2016'
     displayName: VS2017
+
+# サクラエディタのビルドを行う JOB (VS2019)
+# * サクラエディタ本体
+# * HTML Help
+# * Installer
+# * 単体テスト
+# https://devblogs.microsoft.com/devops/hosted-pipelines-announcements-vs-2019-mojave-and-more/
+#
+- template: ci/azure-pipelines/template.job.build-unittest.yml
+  parameters:
+    name: VS2019
+    vmImage: 'windows-2019'
+    displayName: VS2019
 
 # SonarQube で解析を行う JOB
 - template: ci/azure-pipelines/template.job.SonarQube.yml

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -33,6 +33,10 @@ jobs:
 
   - template: /ci/azure-pipelines/template.steps.install-python-modules.yml
 
+  # Update vswhere
+  - script: choco update vswhere -y
+    displayName: update vswhere
+
   # Build solution
   - script: build-sln.bat       $(BuildPlatform) $(Configuration)
     displayName: Build solution

--- a/tests/create-project.bat
+++ b/tests/create-project.bat
@@ -49,7 +49,11 @@ exit /b
 
 :setenv_Win32
 :setenv_x64
-	set CMAKE_GEN_OPT=-G "Visual Studio 15 2017" -A "%~1" -D BUILD_GTEST=ON
+	set /A NUM_NEXTVSVERSION=%NUM_VSVERSION% + 1
+	for /f "usebackq" %%b in (`vswhere -version [%NUM_VSVERSION%^,%NUM_NEXTVSVERSION%^) -property catalog_productLineVersion`) do (
+		set /A productLineVersion=%%b
+	)
+	set CMAKE_GEN_OPT=-G "Visual Studio %NUM_VSVERSION% %productLineVersion%" -A "%~1" -D BUILD_GTEST=ON
 exit /b
 
 :setenv_MinGW

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -10,6 +10,8 @@
 
 外部ツールのインストール時にデフォルトパスにインストールしていない場合や別の実行ファイルを使いたい場合、実行前にパスを通しておくかCMD_7Zなどの対応する環境変数に絶対パスをセットしておいてください。
 
+vswhereはv2.6.2以降をインストールしておいてください。
+
 ## 外部ツールの一覧
 |      ツール名      |   環境変数   |   デフォルトパス   |  ファイル名  |
 | ------------------ | ------------ | ------------------ | ------------ |
@@ -19,7 +21,6 @@
 | Inno Setup 5       | CMD_ISCC     | Inno Setup 5       | ISCC.exe     |
 | cppcheck           | CMD_CPPCHECK | cppcheck           | cppcheck.exe |
 | doxygen            | CMD_DOXYGEN  | doxygen\bin        | doxygen.exe  |
-| vswhere            | CMD_VSWHERE  | Microsoft Visual Studio\Installer | vswhere.exe  |
 | MSBuild            | CMD_MSBUILD  | 特殊               | MSBuild.exe  |
 
 ## MSBuild以外の探索手順
@@ -35,14 +36,14 @@ MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。
 
 ## MSBuild
 1. CMD_MSBUILDがセットされていればそれを使う
-2. vswhere.exe(Visual Studio 2017に搭載されているバージョン)とwhereコマンド(windows標準)を利用し、Visual Studio 2017のmsbuild.exeを探す
-3. USE_LATEST_MSBUILDがセットされている場合、または、2.でmsbuild.exeが見つからない場合、vswhere.exe(Visual Studio 2019以降に搭載されたバージョン)を利用しmsbuild.exeを探す
-4. 2.および3.でmsbuild.exeが見つからない場合、whereコマンド(windows標準)を利用し、システム標準のmsbuild.exeを探す(MsBuild以外の探索手順にある「パスが通っている」と同じ意味)
-5. 2～4で見つからなければCMD_MSBUILDには何もセットしない
+2. NUM_VSVERSIONがセットされていない場合、最新verをセットする
+3  NUM_VSVERSIONに対応するmsbuild.exeをvswhereで探索し、見つかればそれを使う
+4. 1～3で見つからなければCMD_MSBUILDには何もセットしない
 
 ### 参照
 * https://github.com/Microsoft/vswhere
 * https://github.com/Microsoft/vswhere/wiki/Find-MSBuild
+* https://github.com/microsoft/vswhere/releases/tag/2.6.2%2Bf078b21784
 
 ## zipの処理に7zではなくPowerShellを強制する
 事前に環境変数の`FORCE_POWERSHELL_ZIP`を1にセットすることで、7zの検索をスキップできます。


### PR DESCRIPTION
# PR の目的

技術的な実現可能性を示すことを第一の目的とします。
このPRはマージを目的としません。

CI環境でvs2017以外（＝vs2019以降のvisual studio）を選択できるように、
テストプロジェクトでcmakeのジェネレータ名をベタ書きにしているのをやめてみます。

## カテゴリ

- ビルド手順
- CI関連
  - Appveyor
  - Azure Pipelines
- 実験 (master へのマージを目的としない)
- その他

## PR の背景

vs2019が正式にリリースされ、CI環境でも vs2019 を使えるようになりました。
ビルド環境の移行ができるように準備を進めていますが、テストプロジェクトの生成に使うcreate-project.batに問題があり、このままでは移行できないことが分かっています。

https://github.com/sakura-editor/sakura/blob/139d567ccea7fe2110a577014ccb5c9c552a0bd6/tests/create-project.bat#L50-L53

ジェネレータ名(`-A Visual Studio 15 2017`)がベタ書きされているので、
他の部分を vs2019 に対応させたとしてもここで引っかかってしまいます。

解決するためには ‘-G "Visual Studio 15 2017"‘ を何とかする必要があります。

やり方は大きく2つあります。
* リテラル定義を増やし、パラメータを使ってどの定義を使うか選択する
* ジェネレータ名の生成規則に従い、動的にジェネレータ名を生成する

いま PR が出てる ~~#931~~#934 は前者のやり方です。
前回検証 #938 は後者のやり方です。
この PR も後者のやり方ですが、指定できるパラメータの意味が逆転しています。

前回検証 #938 との違い
* 最新版でビルドしたければフラグを指定する（指定しなければ「vs2017」を使う）
* ビルドに使いたいバージョンがあれば指定する（指定しなければ「最新版」を使う）


## PR のメリット

vsバージョンの変化に対してメンテナンスフリーになります。
対応環境を増やすときにバッチをメンテする必要がなくなります。
（vs2023しか入ってないマシンでビルドかけてもそれなりに動くはず）

## PR のデメリット (トレードオフとかあれば)

比較的新しいバージョンのvswhereが必要になります。（`vswhere  v2.6.2以上`）
vs2017に標準搭載の vswhere ではビルドできなくなります。
正式リリース版のvswhereをchocolatey等でインストールする必要があります。

chocolatey で vswhere をインストールするとパスが通ることを利用して、
vswhere にはパスが通っているものとするバッチコードに書き換えることで
vs2017標準搭載の vswhere ではビルドできない問題の対策としようとしています。

基準となる「標準」のビルド環境がバッチに現れなくなります。
のちの世で考古学的に発掘された場合を考えると「どんな環境で開発されていたか」を知る手がかりを消すことになるかも知れません。

## PR の影響範囲

コマンドラインからのビルド
（主にテストプロジェクトの、GoogleTestのビルド）

## 関連チケット

#698
#892
#931
#934 ←追加
#938

## 参考資料
https://github.com/microsoft/vswhere/releases/tag/2.6.2%2Bf078b21784

