### PR TITLE
find-tools.bat の endlocal の後の set を複数行に分けて書く

### DIFF
--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -23,7 +23,16 @@ echo ^|- CMD_CPPCHECK=%CMD_CPPCHECK%
 echo ^|- CMD_DOXYGEN=%CMD_DOXYGEN%
 echo ^|- CMD_VSWHERE=%CMD_VSWHERE%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
-endlocal && set "CMD_GIT=%CMD_GIT%" && set "CMD_7Z=%CMD_7Z%" && set "CMD_HHC=%CMD_HHC%" && set "CMD_ISCC=%CMD_ISCC%" && set "CMD_CPPCHECK=%CMD_CPPCHECK%" && set "CMD_DOXYGEN=%CMD_DOXYGEN%" && set "CMD_VSWHERE=%CMD_VSWHERE%" && set "CMD_MSBUILD=%CMD_MSBUILD%"
+endlocal && ^
+set "CMD_GIT=%CMD_GIT%"                   && ^
+set "CMD_7Z=%CMD_7Z%"                     && ^
+set "CMD_HHC=%CMD_HHC%"                   && ^
+set "CMD_ISCC=%CMD_ISCC%"                 && ^
+set "CMD_CPPCHECK=%CMD_CPPCHECK%"         && ^
+set "CMD_DOXYGEN=%CMD_DOXYGEN%"           && ^
+set "CMD_VSWHERE=%CMD_VSWHERE%"           && ^
+set "CMD_MSBUILD=%CMD_MSBUILD%"
+
 set FIND_TOOLS_CALLED=1
 exit /b
 

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -23,15 +23,16 @@ echo ^|- CMD_CPPCHECK=%CMD_CPPCHECK%
 echo ^|- CMD_DOXYGEN=%CMD_DOXYGEN%
 echo ^|- CMD_VSWHERE=%CMD_VSWHERE%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
-endlocal && ^
-set "CMD_GIT=%CMD_GIT%"                   && ^
-set "CMD_7Z=%CMD_7Z%"                     && ^
-set "CMD_HHC=%CMD_HHC%"                   && ^
-set "CMD_ISCC=%CMD_ISCC%"                 && ^
-set "CMD_CPPCHECK=%CMD_CPPCHECK%"         && ^
-set "CMD_DOXYGEN=%CMD_DOXYGEN%"           && ^
-set "CMD_VSWHERE=%CMD_VSWHERE%"           && ^
-set "CMD_MSBUILD=%CMD_MSBUILD%"
+endlocal ^
+    && set "CMD_GIT=%CMD_GIT%"                  ^
+    && set "CMD_7Z=%CMD_7Z%"                    ^
+    && set "CMD_HHC=%CMD_HHC%"                  ^
+    && set "CMD_ISCC=%CMD_ISCC%"                ^
+    && set "CMD_CPPCHECK=%CMD_CPPCHECK%"        ^
+    && set "CMD_DOXYGEN=%CMD_DOXYGEN%"          ^
+    && set "CMD_VSWHERE=%CMD_VSWHERE%"          ^
+    && set "CMD_MSBUILD=%CMD_MSBUILD%"          ^
+    && echo end
 
 set FIND_TOOLS_CALLED=1
 exit /b


### PR DESCRIPTION
# PR の目的

find-tools.bat で `endlocal && set CMD_XXX="%CMD_XXX%" && ....` を複数行に分割して
メンテしやすくする。

## カテゴリ

- リファクタリング


## PR の背景

find-tools.bat で `endlocal && set CMD_XXX="%CMD_XXX%" && ....` という方法で
setlocal ～ endlocal の間に定義したローカル変数を endlocal の外でも使えるようにしている。

しかし、現在は一行で書いているので定義する変数が増えていくと非常に読みにくくメンテしにくくなる。

このため http://orangeclover.hatenablog.com/entry/20100810/1281450669 等にあるように
行末に `^` を置くことでバッチファイルの一行のコードを複数行に分割するやり方でリファクタリングです。

※ この PR マージ後に `CMD_CMAKE`を追加する PR を投げる予定です。

## PR のメリット

find-tools.bat で設定する変数を追加しやすくなる

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

find-tools.bat 

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

- [バッチファイルで、setlocal〜endlocal内での変数の値を外部に引き継ぎたい！](https://iijimas.hatenadiary.org/entry/20101023/1287772847)
- [バッチファイルで長い1行の処理を改行を入れて複数行に分けて書きたい](http://orangeclover.hatenablog.com/entry/20100810/1281450669)

