### PR TITLE
Azure Pipelines 環境で test_result_filter_tell_AppVeyor.bat が実行されないようにする

### DIFF
--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -39,9 +39,9 @@ set XMLPATH=%2
 
 if defined FILTER_BAT (
 	@echo %EXEPATH% --gtest_output=xml:%XMLPATH% ^| "%FILTER_BAT%"
-	      %EXEPATH% --gtest_output=xml:%XMLPATH%  | "%FILTER_BAT%" || set ERROR_RESULT=1
+	      %EXEPATH% --gtest_output=xml:%XMLPATH%  | "%FILTER_BAT%" || set TEMP_RESULT=1
 ) else (
 	@echo %EXEPATH% --gtest_output=xml:%XMLPATH%
-	      %EXEPATH% --gtest_output=xml:%XMLPATH%                   || set ERROR_RESULT=1
+	      %EXEPATH% --gtest_output=xml:%XMLPATH%                   || set TEMP_RESULT=1
 )
-exit /b %ERROR_RESULT%
+exit /b %TEMP_RESULT%

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -4,11 +4,12 @@ set configuration=%2
 set TEST_LAUNCHED=0
 set ERROR_RESULT=0
 
-set FILTER_BAT=%~dp0test_result_filter_tell_AppVeyor.bat
+if defined APPVEYOR (
+	set FILTER_BAT=%~dp0test_result_filter_tell_AppVeyor.bat
+)
 
-pushd %~dp0
 set BUILDDIR=build\%platform%
-set BINARY_DIR=%BUILDDIR%\unittests\%platform%\%configuration%
+set BINARY_DIR=%~dp0%BUILDDIR%\unittests\%platform%\%configuration%
 
 pushd %BINARY_DIR%
 for /r %%i in (tests*.exe) do (
@@ -17,10 +18,8 @@ for /r %%i in (tests*.exe) do (
 	@echo %%i --gtest_list_tests
 	%%i --gtest_list_tests || set ERROR_RESULT=1
 
-	@echo %%i --gtest_output=xml:%%i-googletest-%platform%-%configuration%.xml ^| "%FILTER_BAT%"
-	%%i --gtest_output=xml:%%i-googletest-%platform%-%configuration%.xml  | "%FILTER_BAT%" || set ERROR_RESULT=1
+	call :RunTest %%i %%i-googletest-%platform%-%configuration%.xml || set ERROR_RESULT=1
 )
-popd
 popd
 
 if "%TEST_LAUNCHED%" == "0" (
@@ -32,3 +31,17 @@ if "%ERROR_RESULT%" == "1" (
 	@echo ERROR
 	exit /b 1
 )
+exit /b 0
+
+:RunTest
+set EXEPATH=%1
+set XMLPATH=%2
+
+if defined FILTER_BAT (
+	@echo %EXEPATH% --gtest_output=xml:%XMLPATH% ^| "%FILTER_BAT%"
+	      %EXEPATH% --gtest_output=xml:%XMLPATH%  | "%FILTER_BAT%" || set ERROR_RESULT=1
+) else (
+	@echo %EXEPATH% --gtest_output=xml:%XMLPATH%
+	      %EXEPATH% --gtest_output=xml:%XMLPATH%                   || set ERROR_RESULT=1
+)
+exit /b %ERROR_RESULT%


### PR DESCRIPTION
# PR の目的

Azure Pipelines 環境で test_result_filter_tell_AppVeyor.bat が実行されないようにする

## カテゴリ

- CI関連
  - Appveyor
  - Azure Pipelines

## PR の背景

#935 で appveyor 環境以外で単体テストの実行時に標準エラーにメッセージが表示されている。

https://github.com/sakura-editor/sakura/issues/935#issuecomment-500216448

しかし、test_result_filter_tell_AppVeyor.bat に対応した当時は Azure Pipelines は想定になかった。


## PR のメリット

Azure Pipelines で標準エラーにメッセージが表示されない。
(※ VS2017 用のイメージでは #935 にあるような赤いエラーメッセージとしては表示されない)

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

単体テストの実行

## 関連チケット

closes #935 
#698

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
