### PR TITLE
cmake のパスを find-tools.bat で検索して cmake のパスが通っていなくてもビルドできるようにする

### DIFF
--- a/tests/build-project.bat
+++ b/tests/build-project.bat
@@ -2,6 +2,8 @@ set platform=%1
 set configuration=%2
 set ERROR_RESULT=0
 
+call %~dp0..\tools\find-tools.bat
+
 pushd %~dp0
 if not exist googletest (
     git submodule init
@@ -9,7 +11,7 @@ if not exist googletest (
 )
 
 set BUILDDIR=build\%platform%
-cmake --build %BUILDDIR%  --config %configuration% || set ERROR_RESULT=1
+"%CMD_CMAKE%" --build %BUILDDIR%  --config %configuration% || set ERROR_RESULT=1
 
 popd
 

--- a/tests/build-project.bat
+++ b/tests/build-project.bat
@@ -2,7 +2,11 @@ set platform=%1
 set configuration=%2
 set ERROR_RESULT=0
 
-call %~dp0..\tools\find-tools.bat
+if not defined CMD_CMAKE call "%~dp0..\tools\find-tools.bat"
+if not defined CMD_CMAKE (
+	echo cmake.exe was not found.
+	exit /b 1
+)
 
 pushd %~dp0
 if not exist googletest (

--- a/tests/create-project.bat
+++ b/tests/create-project.bat
@@ -2,7 +2,11 @@ set platform=%1
 set configuration=%2
 set ERROR_RESULT=0
 
-call %~dp0..\tools\find-tools.bat
+if not defined CMD_CMAKE call "%~dp0..\tools\find-tools.bat"
+if not defined CMD_CMAKE (
+	echo cmake.exe was not found.
+	exit /b 1
+)
 
 @rem produces header files necessary in creating the project.
 if "%platform%" == "MinGW" (

--- a/tests/create-project.bat
+++ b/tests/create-project.bat
@@ -2,6 +2,8 @@ set platform=%1
 set configuration=%2
 set ERROR_RESULT=0
 
+call %~dp0..\tools\find-tools.bat
+
 @rem produces header files necessary in creating the project.
 if "%platform%" == "MinGW" (
 	set BUILD_EDITOR_BAT=build-gnu.bat
@@ -32,7 +34,7 @@ if exist "%BUILDDIR%" (
 mkdir "%BUILDDIR%"
 
 call :setenv_%platform% %platform% %configuration%
-cmake %CMAKE_GEN_OPT% -H. -B"%BUILDDIR%" || set ERROR_RESULT=1
+"%CMD_CMAKE%" %CMAKE_GEN_OPT% -H. -B"%BUILDDIR%" || set ERROR_RESULT=1
 
 popd
 

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -29,6 +29,7 @@ if not defined CMD_CPPCHECK call :cppcheck 2> nul
 if not defined CMD_DOXYGEN call :doxygen 2> nul
 if not defined CMD_VSWHERE call :vswhere 2> nul
 if not defined CMD_MSBUILD call :msbuild 2> nul
+if not defined CMD_CMAKE   call :cmake   2> nul
 echo ^|- CMD_GIT=%CMD_GIT%
 echo ^|- CMD_7Z=%CMD_7Z%
 echo ^|- CMD_HHC=%CMD_HHC%
@@ -37,6 +38,7 @@ echo ^|- CMD_CPPCHECK=%CMD_CPPCHECK%
 echo ^|- CMD_DOXYGEN=%CMD_DOXYGEN%
 echo ^|- CMD_VSWHERE=%CMD_VSWHERE%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
+echo ^|- CMD_CMAKE=%CMD_CMAKE%
 endlocal ^
     && set "CMD_GIT=%CMD_GIT%"                  ^
     && set "CMD_7Z=%CMD_7Z%"                    ^
@@ -46,6 +48,7 @@ endlocal ^
     && set "CMD_DOXYGEN=%CMD_DOXYGEN%"          ^
     && set "CMD_VSWHERE=%CMD_VSWHERE%"          ^
     && set "CMD_MSBUILD=%CMD_MSBUILD%"          ^
+    && set "CMD_CMAKE=%CMD_CMAKE%"              ^
     && echo end
 
 set FIND_TOOLS_CALLED=1
@@ -148,6 +151,16 @@ for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -latest -requires Microsoft.C
 ::find msbuild in $env[PATH].
 for /f "usebackq delims=" %%a in (`where msbuild.exe`) do ( 
     set "CMD_MSBUILD=%%a"
+    exit /b
+)
+exit /b
+
+
+:cmake
+set APPDIR=CMake\bin
+set PATH2=%PATH%;%ProgramFiles%\%APPDIR%\;%ProgramFiles(x86)%\%APPDIR%\;%ProgramW6432%\%APPDIR%\;
+for /f "usebackq delims=" %%a in (`where $PATH2:cmake`) do ( 
+    set "CMD_CMAKE=%%a"
     exit /b
 )
 exit /b


### PR DESCRIPTION
# PR の目的

cmake のパスを find-tools.bat で検索して cmake のパスが通っていなくてもビルドできるようにする

## カテゴリ

- 機能追加
- ビルド手順

## PR の背景

cmake は他のツールとは異なり、パス検索を行っていなかったので行うようにする
https://github.com/sakura-editor/sakura/pull/934#issuecomment-497911490 

## PR のメリット

cmake のパスが通っていなくてもビルドできる

## PR のデメリット (トレードオフとかあれば)

特になし

## PR の影響範囲

単体テストのビルドの際のパス検索および cmake の実行

## 関連チケット

#951
#934 

## テスト

cmake のパスを 環境変数 PATH から外して `tests\build-and-test.bat Win32 Release` のビルドが通ることを確認する
