### PR TITLE
【検証】忍者 vs Visual Studio 15 2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ configuration:
 platform:
   - Win32
   - x64
-  - MinGW
 
 # see "Skip commits" at https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only
 skip_commits:
@@ -22,14 +21,11 @@ skip_commits:
     - '.github/ISSUE_TEMPLATE/*.md'
 
 install:
-- cmd: |
-    pip install openpyxl --user
-    C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gtest"
+- cup vswhere
 
 build_script:
 - cmd: |
-    build-all.bat %PLATFORM% %CONFIGURATION%
-    tests\build-and-test.bat %PLATFORM% %CONFIGURATION%
+    tests/create-project-test.bat %PLATFORM% %CONFIGURATION%
 
 artifacts:
   - path: 'sakura-*$(platform)-$(configuration)*.zip'

--- a/tests/create-project-test.bat
+++ b/tests/create-project-test.bat
@@ -1,0 +1,66 @@
+@echo off
+setlocal
+set platform=%1
+set configuration=%2
+
+:: remove CMake binary dir in the PATH.
+PATH=%PATH:C:\Program Files (x86)\CMake\bin;=%
+
+pushd "%~dp0"
+
+if not exist "googletest\CMakeLists.txt" (
+    git submodule init
+    git submodule update
+)
+
+if not exist build mkdir build
+
+if not defined NUM_VSVERSION (
+    for /f "usebackq delims=. tokens=1" %%a in (`vswhere -latest -requires Microsoft.Component.MSBuild -property installationVersion`) do (
+        set /A NUM_VSVERSION=%%a
+    )
+)
+
+set /A NUM_NEXTVSVERSION=%NUM_VSVERSION% + 1
+for /f "usebackq" %%b in (`vswhere -version [%NUM_VSVERSION%^,%NUM_NEXTVSVERSION%^) -property catalog_productLineVersion`) do ( 
+	set /A productLineVersion=%%b 
+) 
+
+for /f "usebackq delims=" %%a in (`vswhere -version [%NUM_VSVERSION%^,%NUM_NEXTVSVERSION%^) -find Common7\Tools\vsdevcmd.bat`) do (
+    call "%%a" || exit /b 1
+)
+
+echo test for 'Visual Studio' generator.
+set CMAKE_GEN_OPT=-G "Visual Studio %NUM_VSVERSION% %productLineVersion%" -A "%platform%"
+for /L %%a IN (0,1,10) DO (
+	set BUILDDIR=build\vs%%a
+	call :run_cmake vs %%a || exit /b 1
+)
+
+echo test for 'Ninja' generator.
+for /f "usebackq delims=;" %%c in (`vswhere -version [%NUM_VSVERSION%^,%NUM_NEXTVSVERSION%^) -find VC/Tools/MSVC/**/bin/Hostx86/x86/cl.exe`) do ( 
+	set "CMD_CL=%%c"
+)
+set "CMD_CL=%CMD_CL:\=/%"
+set CMAKE_GEN_OPT=-G "Ninja" "-DCMAKE_C_COMPILER=%CMD_CL%" "-DCMAKE_CXX_COMPILER=%CMD_CL%"
+for /L %%a IN (0,1,10) DO (
+	set BUILDDIR=build\nj%%a
+	call :run_cmake Ninja %%a || exit /b 1
+)
+
+exit /b 0
+
+@rem ----------------------------------------------
+@rem  sub-routines
+@rem ----------------------------------------------
+
+:run_cmake
+echo .
+echo %1(%2) - start
+cmake %CMAKE_GEN_OPT% -D BUILD_GMOCK=OFF -B"%BUILDDIR%" -Hgoogletest || exit /b 1
+cmake --build "%BUILDDIR%" --config %configuration% || exit /b 1
+echo %1(%2) - end
+echo .
+exit /b 0
+
+:EOF

--- a/tests/create-project-test.bat
+++ b/tests/create-project-test.bat
@@ -26,24 +26,39 @@ for /f "usebackq" %%b in (`vswhere -version [%NUM_VSVERSION%^,%NUM_NEXTVSVERSION
 	set /A productLineVersion=%%b 
 ) 
 
-for /f "usebackq delims=" %%a in (`vswhere -version [%NUM_VSVERSION%^,%NUM_NEXTVSVERSION%^) -find Common7\Tools\vsdevcmd.bat`) do (
-    call "%%a" || exit /b 1
+set vcvarsArchitecture=
+if "%PROCESSOR_ARCHITECTURE%" == "x86" (
+	if "%platform%" == "x64" (
+		set vcvarsArchitecture=x86_x64
+	) else (
+		set vcvarsArchitecture=x86
+	)
+) else (
+	if "%platform%" == "x64" (
+		set vcvarsArchitecture=x64
+	) else (
+		set vcvarsArchitecture=x64_x86
+	)
+)
+
+for /f "usebackq delims=" %%a in (`vswhere -version [%NUM_VSVERSION%^,%NUM_NEXTVSVERSION%^) -find VC/Auxiliary/Build/vcvarsall.bat`) do (
+    call "%%a" %vcvarsArchitecture% || exit /b 1
 )
 
 echo test for 'Visual Studio' generator.
-set CMAKE_GEN_OPT=-G "Visual Studio %NUM_VSVERSION% %productLineVersion%" -A "%platform%"
-for /L %%a IN (0,1,10) DO (
+if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
+	set CMAKE_GEN_OPT=-G "Visual Studio %NUM_VSVERSION% %productLineVersion% Win64"
+) else (
+	set CMAKE_GEN_OPT=-G "Visual Studio %NUM_VSVERSION% %productLineVersion%" -A "%platform%"
+)
+for /L %%a IN (0,1,9) DO (
 	set BUILDDIR=build\vs%%a
 	call :run_cmake vs %%a || exit /b 1
 )
 
 echo test for 'Ninja' generator.
-for /f "usebackq delims=;" %%c in (`vswhere -version [%NUM_VSVERSION%^,%NUM_NEXTVSVERSION%^) -find VC/Tools/MSVC/**/bin/Hostx86/x86/cl.exe`) do ( 
-	set "CMD_CL=%%c"
-)
-set "CMD_CL=%CMD_CL:\=/%"
-set CMAKE_GEN_OPT=-G "Ninja" "-DCMAKE_C_COMPILER=%CMD_CL%" "-DCMAKE_CXX_COMPILER=%CMD_CL%"
-for /L %%a IN (0,1,10) DO (
+set CMAKE_GEN_OPT=-G "Ninja"
+for /L %%a IN (0,1,9) DO (
 	set BUILDDIR=build\nj%%a
 	call :run_cmake Ninja %%a || exit /b 1
 )
@@ -57,7 +72,7 @@ exit /b 0
 :run_cmake
 echo .
 echo %1(%2) - start
-cmake %CMAKE_GEN_OPT% -D BUILD_GMOCK=OFF -B"%BUILDDIR%" -Hgoogletest || exit /b 1
+cmake %CMAKE_GEN_OPT% -DCMAKE_BUILD_TYPE=%configuration% -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF -D BUILD_GMOCK=OFF -B"%BUILDDIR%" -Hgoogletest || exit /b 1
 cmake --build "%BUILDDIR%" --config %configuration% || exit /b 1
 echo %1(%2) - end
 echo .


### PR DESCRIPTION
## PR の目的
cmakeのジェネレータ「ninja」の有効性を検証します。

現在利用中の「Visual Studio 15 2017」と同じ条件で10回ずつコンフィグ＆ビルドを行ってビルドにかかる所要時間を比較できるようにします。

## カテゴリ

- 速度向上
- ビルド手順
- CI関連
  - Appveyor
  - Azure Pipelines
  - その他連携サービス

## PR の背景
現在のビルドスクリプトは、Visual Studioジェネレータを使っています。
Visual Studioジェネレータを使うにはバージョン指定が必須なので、
当初唯一の対応環境だった「vs2017」向けのスクリプトが作られました。

つい先日(もう3か月前ですが）vs2019がリリースされたので、対応環境は「唯一」ではなくなっていまいました。

visual studioジェネレータを使う限り、バージョンの問題は付いて回ります。

他に解決策はないものか？と検討しているうちに、普段ぼくのローカルで活躍している忍者クンをappveyorで稼働させてみる作戦に気付いたわけです。

## PR のメリット

このPRはマージ目的じゃないんで、とくにありません。

## PR のデメリット (トレードオフとかあれば)

このPRはマージ目的じゃないんで、とくにありません。

## PR の影響範囲

プロジェクトのビルド。
サクラエディタの機能には一切影響しません。

## 関連チケット


## 参考資料
