### PR TITLE
cpplint.py の whitespace/blank_line をチェック対象から外す

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -2,5 +2,5 @@ set noparent
 filter=-build,+build/deprecated,+build/printf_format,+build/explicit_make_pair
 filter=-readability,+readability/inheritance
 filter=-runtime,+runtime/memset,+runtime/threadsafe_fn,+runtime/vlog
-filter=-whitespace,+whitespace/blank_line,+whitespace/empty_if_body
+filter=-whitespace,+whitespace/empty_if_body
 filter=-legal


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートに切り替えることで登録後にどのように見えるか確認することができます -->

# PR の目的

cpplint.py の whitespace/blank_line をチェック対象から外すことにより CodeFactor の警告を抑える


## カテゴリ

- CI関連
  - その他連携サービス (CodeFactor)
- その他

## PR の背景

以前 #724 で空行に関する CodeFactor の警告を修正しようとしたが、対応すると
逆にわかりにくくなる箇所があり、適用しなかった。

#946 で CodeFactor によるチェック項目をカスタマイズできる仕組みを作ったので
空行に関する警告を無視する。


## PR のメリット

CodeFactor の警告が減る

## PR のデメリット (トレードオフとかあれば)

CodeFactor で指摘していることに気づかなくなる

## PR の影響範囲

CodeFactor 

## 関連チケット

#724
#946

## 参考資料

https://google.github.io/styleguide/cppguide.html#Vertical_Whitespace
https://github.com/google/styleguide/blob/6271f3f473ceb3a7fef99388a3040903b1a145f1/cpplint/cpplint.py#L156-L197


