### PR TITLE
appveyor.yml に test_script を導入する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,13 @@ install:
     pip install openpyxl --user
     C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gtest"
 
+# to run our custom scripts instead of automatic MSBuild
 build_script:
-- cmd: |
-    build-all.bat %PLATFORM% %CONFIGURATION%
-    tests\build-and-test.bat %PLATFORM% %CONFIGURATION%
+  - cmd: build-all.bat %PLATFORM% %CONFIGURATION%
+
+# to run our custom scripts instead of automatic tests
+test_script:
+  - cmd: tests\build-and-test.bat %PLATFORM% %CONFIGURATION%
 
 artifacts:
   - path: 'sakura-*$(platform)-$(configuration)*.zip'


### PR DESCRIPTION
# PR の目的

appveyor.ymlをリファクタリングして文書構造を分かりやすくします。

## カテゴリ

- CI関連
  - Appveyor

## PR の背景

別件(#954)で、appveyor.ymlに手を入れようとしています。
appveyorのビルド結果確認中に[ログ](https://ci.appveyor.com/project/sakuraeditor/sakura/builds/25953400/job/9oodmdu62jrx58p1)が以下のようになっているのに気付きました。

```
 957 ---- end   run-tests.bat ----
 958 Discovering tests...OK
 959 Collecting artifacts...
 960 No artifacts found matching 'sakura-*MinGW-Debug*.zip' path
 961 No artifacts found matching 'sakura-*MinGW-Debug*.zip.md5' path
 962 No artifacts found matching 'sha256.txt' path
 963 Build success
 ※行頭の数字はログの行番号です。
```

958行目に注目してください。
957行目で `run-tests.bat` が end だと出してるのに、
「`Discovering tests...OK`」と出力しています。
テストの実行が終わったあとに「テストを検索してます・・・完了」と出してます。

これはおかしい！と思ったので、何が起こっているのか調べてみました。

どうやら **appveyorには test を自動検索して実行する機能がある** らしいです。

appveyor.yml に test としてテスト DLL の名前を書いておくと、テストフェーズで定義されたdllを検索して自動実行してくれます。[マニュアル](https://www.appveyor.com/docs/running-tests/#calling-test-runners-from-your-custom-scripts)を見る限り、内部的には vstest.console.exe を使っているようなのですが「自分でテスト起動方法を定義したい場合は test_script を使ってね！」と書いてあるように読めました。

いま、appveyor.ymlには test_script の定義がありません。
appveyor的には、テストフェーズに入ったから「 test の dll (＝定義してないので空っぽ)」を検索したけど「見つかりませんでした」という事実を報告してくれているようなんです。

このことから、
**独自のテスト起動方法を採るからこれを実行してね！**
とappveyorに教えてあげれば対策になるはずです。

具体的には「 test_script を導入する」ということになります。


## PR のメリット

* appveyorによるtestの自動検索を使っていないことを明確にできます。
* コメントの追加により、test_scriptで独自バッチを起動しているのが明確になります。
* コメントの追加により、buildでも独自バッチを起動しているのが明確になります。
* appveyorによるtest検索の空振りメッセージの出力を抑止することができます。
* appveyorによるtest検索が行われなくなるためビルド時間の短縮を期待できます。　←未検証

## PR のデメリット (トレードオフとかあれば)

デメリットは何もないと考えています。

関連チケットに挙げたissueの中で @ds14050 さんが触れているように、
「test_scriptの中でtestのビルドを行っているのはおかしいんじゃないか？」
という疑問はありますが、そこは別課題でよいと考えています。

## PR の影響範囲

appveyor による test の自動検索が走らなくなります。
今後の appveyor.yml の編集作業がやりやすくなります。　←主観です。
アプリ（＝サクラエディタ本体）への影響はありません。

## 関連チケット

#954 Appveyorのロケール設定を復活したい  
#628 appveyor.yml で test_script を調査する
#634 [WIP] テストのビルド、実行を before_test と test_script に移動する

## 参考資料

https://www.appveyor.com/docs/appveyor-yml/
https://www.appveyor.com/docs/running-tests/#calling-test-runners-from-your-custom-scripts
https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2019

## その他参考情報

単体テストで生成している tests1.exe は exe ですが、適切な[テストアダプター](https://github.com/microsoft/TestAdapterForGoogleTest)を指定すれば vstest.console.exe からのテスト実行が可能です。テストアダプターの指定は「詳細なパラメータ」に該当するらしく、[マニュアル](https://www.appveyor.com/docs/running-tests/#calling-test-runners-from-your-custom-scripts)にはフレームワーク別のオプション指定の解説があります。（GoogleTestの解説はありませんが。

appveyorには関係ないので完全に別件ですが、azure pipelinesに入っているvs2017はEnterprise（≒カバレッジが取れるエディション）なので、この話はそのうちまたする気がしています。