### PR TITLE
成果物を個別定義にする

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,13 @@ build_script:
     build-all.bat %PLATFORM% %CONFIGURATION%
     tests\build-and-test.bat %PLATFORM% %CONFIGURATION%
 
-artifacts:
-  - path: 'sakura-*$(platform)-$(configuration)*.zip'
-  - path: 'sakura-*$(platform)-$(configuration)*.zip.md5'
-  - path: 'sha256.txt'
+for:
+-
+  matrix:
+    only:
+      - platform: Win32
+      - platform: x64
+
+  artifacts:
+    - path: 'sakura-*$(platform)-$(configuration)*.zip*'
+    - path: 'sha256.txt'


### PR DESCRIPTION
# PR の目的

appveyor.ymlをリファクタリングして文書構造を分かりやすくします。

## カテゴリ

- CI関連
  - Appveyor


## PR の背景

別件(#954)で、appveyor.ymlに手を入れようとしています。
appveyorのビルド結果確認中に[ログ](https://ci.appveyor.com/project/sakuraeditor/sakura/builds/25953400/job/9oodmdu62jrx58p1)が以下のようになっているのに気付きました。

```
 958 Discovering tests...OK
 959 Collecting artifacts...
 960 No artifacts found matching 'sakura-*MinGW-Debug*.zip' path
 961 No artifacts found matching 'sakura-*MinGW-Debug*.zip.md5' path
 962 No artifacts found matching 'sha256.txt' path
 963 Build success
 ※行頭の数字はログの行番号です。
```

959行目に注目してください。
MinGW向けビルドには成果物がありませんが、成果物を探しに行ってます。
何故検索が走るのかというと、成果物定義が「すべての環境向け」のところに書いてあるからです。

https://github.com/sakura-editor/sakura/blob/1449992c486a35cd26798a2797d817ad7b32f079/appveyor.yml#L34-L37

元々、成果物（＝配布用Zip、インストーラーZip）を作っているのは Win32/x64 向けだけでした。
Win32/x64はVC++のソースをビルドする構成なのでDebug/Releaseの区別があります。
成果物の名前にもDebug/Releaseが入っていて当然だと思います。

別件(#954)の対応で、Debug/Releaseの区別がない成果物を追加しようとしています。
HHC.exeにはDebugビルドの概念がないので、構成を分けるにしても成果物は同じものになります。
成果物の名前にDebug/Releaseを入れるとおかしな話になります。

対策として、成果物の定義場所を「すべての環境向け」の位置から「環境個別」の位置に移動します。
こうすることで、HTML Helpのビルド環境を定義するときに成果物定義を含めるだけでうまくいくようになります。
※現状のままビルド環境を追加すると、一致する成果物がなかった旨のメッセージが出てしまいます。


## PR のメリット

* 環境ごとの成果物を明確にできます。
* 成果物のないビルド環境において、appveyorによる検索を抑止できます。
* 新たなビルド環境を増やすときに、独自の成果物を定義できるようになります。　←そんな機会はほぼありませんが :smile:


## PR のデメリット (トレードオフとかあれば)

デメリットは何もないと考えています。


## PR の影響範囲

成果物のないビルド環境について、appveyor による成果物の検索が走らなくなります。
今後の appveyor.yml の編集作業がやりやすくなります。　←主観です。
アプリ（＝サクラエディタ本体）への影響はありません。


## 関連チケット

#954 Appveyorのロケール設定を復活したい  
#960 appveyor.yml に test_script を導入する


## 参考資料

https://www.appveyor.com/docs/appveyor-yml/
https://www.appveyor.com/docs/packaging-artifacts/#basics
https://www.appveyor.com/docs/build-configuration/#build-matrix
https://ci.appveyor.com/account/sakuraeditor/tools/validate-yaml
