### PR TITLE
help構築用にplatform定義を追加する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ configuration:
   - Release
 
 platform:
+  - BuildChm
   - Win32
   - x64
   - MinGW
@@ -31,7 +32,34 @@ build_script:
     build-all.bat %PLATFORM% %CONFIGURATION%
     tests\build-and-test.bat %PLATFORM% %CONFIGURATION%
 
+matrix:
+  exclude:
+    - platform: BuildChm
+      configuration: Debug
+
 for:
+-
+  matrix:
+    only:
+      - platform: BuildChm
+        configuration: Release
+
+  install:
+    - ps: Set-WinSystemLocale ja-JP
+    - ps: Start-Sleep -s 10
+    - ps: Restart-Computer
+    - ps: Start-Sleep -s 10
+
+  build_script:
+    - cmd: build-chm.bat
+    - cmd: help\make-artifacts.bat
+
+  test_script:
+    - cmd: echo This Platform has no tests.
+
+  artifacts:
+    - path: 'sakura-*-Chm.zip*'
+
 -
   matrix:
     only:

--- a/help/make-artifacts.bat
+++ b/help/make-artifacts.bat
@@ -1,0 +1,122 @@
+@echo off
+
+if not defined CMD_7Z call %~dp0..\tools\find-tools.bat
+if not defined CMD_7Z (
+	echo 7z.exe was not found.
+	exit /b 1
+)
+
+@rem ----------------------------------------------------------------
+@rem prepare environment variable
+@rem ----------------------------------------------------------------
+@echo checking APPVEYOR_ACCOUNT_NAME %APPVEYOR_ACCOUNT_NAME%
+set BUILD_ACCOUNT=
+if "%APPVEYOR_ACCOUNT_NAME%" == "sakuraeditor" (
+	set BUILD_ACCOUNT=
+) else if "%APPVEYOR_ACCOUNT_NAME%" == "" (
+	set BUILD_ACCOUNT=
+) else (
+	set BUILD_ACCOUNT=%APPVEYOR_ACCOUNT_NAME%
+)
+
+@echo checking APPVEYOR_BUILD_NUMBER %APPVEYOR_BUILD_NUMBER%
+if not "%APPVEYOR_BUILD_NUMBER%" == "" (
+	set BUILD_NUMBER=build%APPVEYOR_BUILD_NUMBER%
+) else (
+	set BUILD_NUMBER=buildLocal
+)
+
+@echo checking GIT_TAG_NAME %GIT_TAG_NAME%
+if not "%GIT_TAG_NAME%" == "" (
+	@rem replace '/' with '_'
+	set TEMP_NAME1=!GIT_TAG_NAME:/=_!
+	@echo TEMP_NAME1 = !TEMP_NAME1!
+	
+	@rem replace ' ' with '_'
+	set TEMP_NAME2=!TEMP_NAME1: =_!
+	@echo TEMP_NAME2 = !TEMP_NAME2!
+
+	@rem replace ' ' with '_'
+	set TAG_NAME=tag-!TEMP_NAME2!
+	@echo TAG_NAME = !TEMP_NAME2!
+)
+
+@echo checking APPVEYOR_PULL_REQUEST_NUMBER %APPVEYOR_PULL_REQUEST_NUMBER%
+if not "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" (
+	set PR_NAME=PR%APPVEYOR_PULL_REQUEST_NUMBER%
+)
+
+@echo checking APPVEYOR_REPO_COMMIT %APPVEYOR_REPO_COMMIT%
+if not "%APPVEYOR_REPO_COMMIT%" == "" (
+	set SHORTHASH=%APPVEYOR_REPO_COMMIT:~0,8%
+)
+
+@rem ----------------------------------------------------------------
+@rem build BASENAME
+@rem ----------------------------------------------------------------
+set BASENAME=sakura
+
+@echo adding BUILD_ACCOUNT
+if not "%BUILD_ACCOUNT%" == "" (
+	set BASENAME=%BASENAME%-%BUILD_ACCOUNT%
+)
+@echo BASENAME = %BASENAME%
+
+@echo adding TAG_NAME
+if not "%TAG_NAME%" == "" (
+	set BASENAME=%BASENAME%-%TAG_NAME%
+)
+@echo BASENAME = %BASENAME%
+
+@echo adding PR_NAME
+if not "%PR_NAME%" == "" (
+	set BASENAME=%BASENAME%-%PR_NAME%
+)
+@echo BASENAME = %BASENAME%
+
+@echo adding BUILD_NUMBER
+if not "%BUILD_NUMBER%" == "" (
+	set BASENAME=%BASENAME%-%BUILD_NUMBER%
+)
+@echo BASENAME = %BASENAME%
+
+@echo adding SHORTHASH
+if not "%SHORTHASH%" == "" (
+	set BASENAME=%BASENAME%-%SHORTHASH%
+)
+@echo BASENAME = %BASENAME%
+
+@rem ---------------------- BASENAME ---------------------------------
+@rem "sakura"
+@rem BUILD_ACCOUNT: (option) APPVEYOR_ACCOUNT_NAME
+@rem TAG_NAME     : (option) tag Name
+@rem PR_NAME      : (option) PRxxx (xxx is a PR number)
+@rem BUILD_NUMBER : (option) buildYYY or "buildLocal" (YYY is build number)
+@rem SHORTHASH    : (option) hash or "buildLocal" (hash is leading 8 charactors)
+@rem ----------------------------------------------------------------
+
+set CHM_ARCHIVE=%~dp0..\%BASENAME%-Chm.zip
+
+pushd "%~dp0"
+"%CMD_7Z%" a %CHM_ARCHIVE%		^
+	macro\macro.chm		^
+	macro\Compile.Log	^
+	plugin\plugin.chm	^
+	plugin\Compile.Log	^
+	sakura\sakura.chm	^
+	sakura\sakura.hh	^
+	sakura\Compile.Log  ^
+	|| exit /b 1
+
+@echo start generate MD5 hash
+set CMD_FIND=%SystemRoot%\System32\find.exe
+certutil -hashfile %CHM_ARCHIVE% MD5 ^
+	| %CMD_FIND% /v "MD5"		^
+	| %CMD_FIND% /v "CertUtil"	^
+	> %CHM_ARCHIVE%.md5			^
+	|| exit /b 1
+@echo end generate MD5 hash
+
+popd
+
+exit /b 0


### PR DESCRIPTION
# PR の目的

HTMLヘルプのキーワード文字化け問題を解消するために、
文字化けしない方法でHTMLヘルプをビルドする新Platformを追加します。


## カテゴリ

- CI関連
  - Appveyor


## PR の背景

#922 v2.4のヘルプ キーワード検索画面のリストが文字化けしている
　↓　原因はappveyorのロケール変更を廃止したことです。
#954 Appveyorのロケール設定を復活したい  
　↓　時間が掛かってもいいからロケール変更を復活しよう！
ただ、全環境で「ロケール変更（＝再起動）」をすると大変
　↓　再起動は必要な部分だけにしよう！
このPRは、再起動が必要な部分（＝HTML Helpのビルド）を切り出した新Platformを追加します。

何度かやってみている感じ、必要な時間は4分くらいです。
appveyorので表示される時間は、ロスタイムがあるのであてにならんです。
※再起動の間時計が止まってるので規定の時間になっても試合が終わらない・・・

#922 を 解消する PR はこれがマージできたら出します。


## PR のメリット

* appveyorの成果物に「文字化けしてないchm」を含めることができます。
* 文字化け問題解消の足掛かりとすることができます。

その気になれば「文字化けしてないchm」をダウンロードできる状況にすることは、大きな意味があると思っています。

## PR のデメリット (トレードオフとかあれば)

* appveyorのビルド時間が延びます。
* この対応だけでは文字化け問題は解消しません。


## PR の影響範囲

このPRは文字化け問題解消のために必須の「前提となる対処」です。
appveyorのビルド時間が延びます。(表示上は1分以内で終わりますが、実時間は4分くらいです。）
appveyorのgit cloneがたまに失敗する問題が再発する可能性があります。
アプリ（＝サクラエディタ本体）への影響はありません。


## 関連チケット

#922 v2.4のヘルプ キーワード検索画面のリストが文字化けしている
#954 Appveyorのロケール設定を復活したい  

