### PR TITLE
clone_depthを指定する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ platform:
   - x64
   - MinGW
 
+# set clone depth
+clone_depth: 5
+
 # see "Skip commits" at https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only
 skip_commits:
   files:


### PR DESCRIPTION
# PR の目的

apveyorのgit cloneで取得する履歴の深さを制限して、git clone が失敗する問題を抑止します。


## カテゴリ

- CI関連
  - Appveyor


## PR の背景

#954 で appveyor のシステムロケールを変更する処理を復活させようとしています。

システムロケールの変更をやめた理由は２つあります。
1. appveyor を再起動させると遅い（再起動だけで2分くらいかかる
2. git clone がたまに失敗していた

再起動に時間がかかる問題については、
#962 で提案しているように、再起動対象の環境を絞り込めば軽減できる気がします。

git cloneがたまにコケる問題についても何か手を打ちたいと考えています。
この問題については、原因が分かっているわけではありません。

* 他のプロジェクト（＝ほぼ海外PJ）では見たことがない
* 日本語化してるのはサクラエディタくらい
* 日本語化をやめていた期間、git clone失敗は発生しなかった（気がする

状況的なことから「日本語化していることが失敗の原因」と考えるのは正しい気がします。
まぁ、「弁護士を呼んでください！」な雰囲気ですけどね。

日本語化以外に、git cloneがコケる原因になることってないんだっけ？

fetch対象の物量によっては「非常に低い確率を踏む」ことがあるのかも知れません。
サクラエディタのコードベースは全部で12万行くらいで、決して大きいとは言えません。
履歴の量も5,000コミットに満たない程度なので、歴史は浅い方だと思います。

まー、その辺りの「現実」はサラッとスルーすることにして、
**I/O操作の絶対量が多いとコケる可能性もあるんじゃないか？**
と考えるなら、gitの機能を使って対策を打てるように思います。

gitには fetch 時に取得するリポジトリの履歴の深さを指定する機能があります。
5,000件の履歴すべてを取得するのと、最新1件の履歴を取得するのとでは、I/Oの絶対量が違います。
コケる原因がコレであるならば、深さ指定によってコケる確率を下げられるように思います。


## PR のメリット

* git clone がコケる対策になるかも知れません。
* 取得する履歴が少なくなる分、ビルド開始が早くなります。(実測7秒⇒5秒


## PR のデメリット (トレードオフとかあれば)

* 履歴を辿って何かする処理を組み込んでいたら、操作前に追加のfetchを行う記述が必要になります。メイン処理にはそういうのがなかったと思いますが、キャッシュ活用かなんかのPRでgitの履歴に依存するものがあった気がします。（探してきました #650 ですね。


## PR の影響範囲

* appveyor の git clone。
* git の履歴情報に依存するようなビルドスクリプトが使えなくなる
* アプリ（＝サクラエディタ本体）への影響はありません。


## 関連チケット

#962 help構築用にplatform定義を追加する
#650 [WIP] AppVeyor のビルドキャッシュを利用してビルド時間を削減(※およそ５分)できるようなオプションを用意します。


## 参考資料

https://pocke.hatenablog.com/entry/2018/12/19/015644
https://qiita.com/sonots/items/ce08c30d161ea0b4d5fd
https://www.appveyor.com/docs/how-to/repository-shallow-clone/

