### PR TITLE
Azure Pipelinesの成果物を一旦廃止したい

### DIFF
--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -37,17 +37,17 @@ jobs:
   - script: build-sln.bat       $(BuildPlatform) $(Configuration)
     displayName: Build solution
 
-  # Build HTML Help
-  - script: build-chm.bat
-    displayName: Build HTML Help
-
-  # Build instaler with Inno Setup
-  - script: build-installer.bat $(BuildPlatform) $(Configuration)
-    displayName: Build instaler with Inno Setup
-
-  # zip files for artifacts
-  - script: zipArtifacts.bat    $(BuildPlatform) $(Configuration)
-    displayName: Zip files for artifacts
+#  # Build HTML Help
+#  - script: build-chm.bat
+#    displayName: Build HTML Help
+#
+#  # Build instaler with Inno Setup
+#  - script: build-installer.bat $(BuildPlatform) $(Configuration)
+#    displayName: Build instaler with Inno Setup
+#
+#  # zip files for artifacts
+#  - script: zipArtifacts.bat    $(BuildPlatform) $(Configuration)
+#    displayName: Zip files for artifacts
 
   # Unit tests
   - script: tests\build-and-test.bat $(BuildPlatform) $(Configuration)


### PR DESCRIPTION
# PR の目的

・Azure Pipelinesでインストーラ/配布用zipのビルドが走らないようにします。
　HTML Helpの作成処理に依存するビルドを外すことで、appveyor向けの修正をやりやすくします。

## カテゴリ

- CI関連
  - Azure Pipelines


## PR の背景

azure pipelinesのビルドは、たまに原因不明のエラーで失敗しています。
失敗するステップは決まってHTML Helpのビルド工程なのですが、具体的な原因は分かっていません。

別の課題で「#962 HTML Helpのビルドを日本語環境下で行うことによりキーワードの文字化けを解消する」という対応しています。azure pipelinesのビルド環境もappveyorと同じくenなので、HTML Helpのビルドを続行するなら同様の対処が必要と考えられます。現状、azure pipelinesでchmを正しくビルドできる手段は見つかっていません。

appveyor側の成果物作成処理は、先行して走らせたBuildChmの成果物をREST APIで取得することによって実現しようとしています。現状で、build-chm.batの処理はazure-pipelinesでも呼び出しているので、appveyor側で改修をするとazure pipelines側でも同じ処理が走ることになります。

将来的にどうするか？は別問題として、成果物作成処理を一旦azure pipelinesから外してappveyor側の改修を自由に行えるようにしたいです。

## PR のメリット

成果物作成を 「appveyor 専用」とすることで、修正がやりやすくなります。
build-chm.batをazure pipelinesで実行しないことにより、原因不明のエラーがなくなります。

## PR のデメリット (トレードオフとかあれば)

azure pipelines でビルドした成果物を取得できなくなります。
azure pipelines と appveyor で成果物の差はないはずなので特に問題はないと思います。


## PR の影響範囲

build-chm.bat が実行されなくなるため、原因不明の異常終了がなくなります。
azure pipelines の ビルドタスクで、成果物が出力されなくなります。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
