### PR TITLE
Debugビルドで配布用成果物を作らないようにしたい

### DIFF
--- a/build-all.bat
+++ b/build-all.bat
@@ -37,6 +37,8 @@ call build-sln.bat       %PLATFORM% %CONFIGURATION% || (echo error build-sln.bat
 @echo ---- end   build-sln.bat ----
 @echo.
 
+if "%CONFIGURATION%" == "Debug" goto :make_artifacts
+
 @echo ---- start build-chm.bat ----
 call build-chm.bat                                  || (echo error build-chm.bat       && exit /b 1)
 @echo ---- end   build-chm.bat ----
@@ -47,6 +49,7 @@ call build-installer.bat %PLATFORM% %CONFIGURATION% || (echo error build-install
 @echo ---- end   build-installer.bat ----
 @echo.
 
+:make_artifacts
 @echo ---- start zipArtifacts.bat ----
 call zipArtifacts.bat    %PLATFORM% %CONFIGURATION% || (echo error zipArtifacts.bat    && exit /b 1)
 @echo ---- end   zipArtifacts.bat ----

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -274,8 +274,10 @@ if "%ALPHA%" == "1" (
 copy /Y installer\warning.txt        %WORKDIR_EXE%\
 copy /Y installer\warning.txt        %WORKDIR_INST%\
 
+if "%CONFIGURATION%" == "Release" (
 pushd %WORKDIR_INST% && call %ZIP_CMD%       %OUTFILE_INST% .  && popd
 pushd %WORKDIR_EXE%  && call %ZIP_CMD%       %OUTFILE_EXE%  .  && popd
+)
 pushd %WORKDIR_DEV%  && call %ZIP_CMD%       %OUTFILE_DEV%  .  && popd
 
 @echo start zip asm
@@ -292,6 +294,7 @@ if exist "%WORKDIR_ASM%" (
 	rmdir /s /q "%WORKDIR_ASM%"
 )
 
+if "%CONFIGURATION%" == "Debug" goto :after_hash_out
 
 @echo start generate MD5 hash
 set CMD_FIND=%SystemRoot%\System32\find.exe
@@ -299,6 +302,7 @@ certutil -hashfile %OUTFILE_EXE% MD5  | %CMD_FIND% /v "MD5" | %CMD_FIND% /v "Cer
 certutil -hashfile %OUTFILE_INST% MD5 | %CMD_FIND% /v "MD5" | %CMD_FIND% /v "CertUtil" > %OUTFILE_INST%.md5
 @echo end generate MD5 hash
 
+:after_hash_out
 
 exit /b 0
 


### PR DESCRIPTION
# PR の目的

Debugビルドで、インストーラと配布用Zipを作成しないようにします。

これらを作成するためにはHTML Helpのビルドが必要ですが、HTML Helpのビルドにはロケール変更が必要で、ロケール変更にはOSの再起動が必要です。OSの再起動には余分な時間がかかりますが、その時間をかけてまでDebug版のインストーラーが欲しいかというとそうではないと考えるので、一旦Debug版ではこれらを作成しないようにします。

この変更により、build-chm.batの処理をReleaseビルド専用処理と考えることができるようになります。

## カテゴリ

- CI関連
  - Appveyor

## PR の背景

省略

## PR のメリット

build-chm.batをReleaseビルド専用処理として扱うことができるようになります。


## PR のデメリット (トレードオフとかあれば)

何もないと思っています。


## PR の影響範囲

appveyorのDebugビルドの成果物が減ります。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
