### PR TITLE
Azure Pipelines向けのhelp、インストーラーの生成を一旦やめる

### DIFF
--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -37,13 +37,13 @@ jobs:
   - script: build-sln.bat       $(BuildPlatform) $(Configuration)
     displayName: Build solution
 
-  # Build HTML Help
-  - script: build-chm.bat
-    displayName: Build HTML Help
-
-  # Build instaler with Inno Setup
-  - script: build-installer.bat $(BuildPlatform) $(Configuration)
-    displayName: Build instaler with Inno Setup
+#  # Build HTML Help
+#  - script: build-chm.bat
+#    displayName: Build HTML Help
+#
+#  # Build instaler with Inno Setup
+#  - script: build-installer.bat $(BuildPlatform) $(Configuration)
+#    displayName: Build instaler with Inno Setup
 
   # zip files for artifacts
   - script: zipArtifacts.bat    $(BuildPlatform) $(Configuration)


### PR DESCRIPTION
# PR の目的

・Azure Pipelinesでhelp/インストーラのビルドが走らないようにして、azure pipelinesでビルドエラーが起きないようにします。

## カテゴリ

- CI関連
  - Azure Pipelines

## PR の背景

#964 の焼き直しPRです。
目的が少し変わっていますが、背景やメリットなどは同じなので以下ほぼコピーです。

azure pipelinesのビルドは、たまに原因不明のエラーで失敗しています。
 失敗するステップは決まってHTML Helpのビルド工程なのですが、具体的な原因は分かっていません。

別の課題で「#962 HTML Helpのビルドを日本語環境下で行うことによりキーワードの文字化けを解消する」という対応しています。azure pipelinesのビルド環境もappveyorと同じくenなので、HTML Helpのビルドを続行するなら同様の対処が必要と考えられます。現状、azure pipelinesでchmを正しくビルドできる手段は見つかっていません。

appveyor側の成果物作成処理は、先行して走らせたBuildChmの成果物をREST APIで取得することによって実現しようとしています。現状で、build-chm.batの処理はazure-pipelinesでも呼び出しているので、appveyor側で改修をするとazure pipelines側でも同じ処理が走ることになります。

直接影響を受ける build-chm.bat の呼出を azure pipelines から外すことで HTML Help作成(ダウンロード)を appveyor 専用処理とすることで azure pipelines 側でエラーとなる事態を防ぎます。

同様に、help作成に依存しているインストーラーのビルドも外してエラーにならないようにします。

成果物については、help/インストーラを作らないなりのものが生成されます。


## PR のメリット

help/インストーラー作成を 「appveyor 専用」とすることで、修正がやりやすくなります。
build-chm.batをazure pipelinesで実行しないことにより、原因不明のエラーがなくなります。

## PR のデメリット (トレードオフとかあれば)

zipArtifacts.batには手を入れないので、一部のzipの中身が足りない状態になります。

## PR の影響範囲

build-chm.bat が実行されなくなるため、原因不明の異常終了がなくなります。
azure pipelines の ビルドで出力される成果物が、一時的に微妙な状態になります。

## 関連チケット

#964

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
