### PR TITLE
Debugビルドでchmとinstallerを作らないようにしたい

### DIFF
--- a/build-all.bat
+++ b/build-all.bat
@@ -37,6 +37,8 @@ call build-sln.bat       %PLATFORM% %CONFIGURATION% || (echo error build-sln.bat
 @echo ---- end   build-sln.bat ----
 @echo.
 
+if "%CONFIGURATION%" == "Debug" goto :make_artifacts
+
 @echo ---- start build-chm.bat ----
 call build-chm.bat                                  || (echo error build-chm.bat       && exit /b 1)
 @echo ---- end   build-chm.bat ----
@@ -46,6 +48,8 @@ call build-chm.bat                                  || (echo error build-chm.bat
 call build-installer.bat %PLATFORM% %CONFIGURATION% || (echo error build-installer.bat && exit /b 1)
 @echo ---- end   build-installer.bat ----
 @echo.
+
+:make_artifacts
 
 @echo ---- start zipArtifacts.bat ----
 call zipArtifacts.bat    %PLATFORM% %CONFIGURATION% || (echo error zipArtifacts.bat    && exit /b 1)


### PR DESCRIPTION
# PR の目的

Debug版ビルドでは chm と installer を作らないように変更して、ビルドエラーを防止します。


## カテゴリ

- CI関連
  - Appveyor

## PR の背景

#965 の焼き直しPRです。
変更点は、成果物を作る処理をスキップさせないように変えていることです。
背景、メリットは変わらないですが、説明は少し書き加えてみました。

現在 chm のビルドは build-chm.bat で行っていますが、HTML Helpのビルドにはシステムロケールの変更が必要だと分かったのでHTML Helpの構築を分離しました。分離したビルドの成果物を取得して、build-chm.bat で実際のビルドが行われたかのように動作させる修正を準備中です。

HTML Helpのビルドにはロケール変更が必要で、ロケール変更にはOSの再起動が必要です。OSの再起動にはかなりの時間がかかります(約2分)。HTML Helpのビルドにはデバッグの概念がないので、Release側のconfigurationでだけビルドが走るように構成しています。

現在設定で、Debug⇒Releaseの順にビルドさせるようにしている関係で、Win32/x64のDebugビルドの時点ではHTML Helpのビルドが終わっていない状況が発生します。HTML Helpのビルドには時間がかかるので、Debug版にchmを同梱するためにビルドを増やすのには抵抗があります。対策として、Debug版では build-chm.bat を実行しないこととし、これに依存する build-installer.bat も実行しないようにします。

この変更により、build-chm.batの処理をReleaseビルド専用処理と考えることができるようになります。

## PR のメリット

<!-- PR のメリットを記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

## PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

## 関連チケット

#964
#965
#967

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
