### PR TITLE
Appveyorのビルド順をRelease⇒Debugに戻したい

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ version: 1.0.{build}
 image: Visual Studio 2017
 
 configuration:
-  - Debug
   - Release
+  - Debug
 
 platform:
   - BuildChm


### PR DESCRIPTION
# PR の目的
Appveyorのビルド順をRelease⇒Debugに戻して、Debug版でinstallerを作れるようにします。

This reverts commit df6c71dc2c764135b10e2d8d1dddc6375e794c69.
Release⇒Debugの順でビルドしたくなったのでrevertします。
https://github.com/sakura-editor/sakura/pull/968#issuecomment-513533478

azure pipelinesによる併行ビルドがあるので、逆順にしても問題ないと考えられます。


## カテゴリ

- CI関連
  - Appveyor


## PR の背景

https://github.com/sakura-editor/sakura/pull/968#issuecomment-513533478


## PR のメリット

BuildChmの構成をReleaseとしたまま、Debugビルドでinstallerを作成できるようになります。


## PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくにありません。


## PR の影響範囲

appveyorのビルド順がRelease⇒Debugになります。


## 関連チケット

#968 close;
#966 
#820 appveyor で Debug/Release の順番を逆にする


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
