### PR TITLE
インストーラーの作成にビルド済みヘルプを使いたい

### DIFF
--- a/appveyor.md
+++ b/appveyor.md
@@ -39,10 +39,12 @@
 
 | 環境変数 | 説明 |
 ----|---- 
+|APPVEYOR                           | バッチが appveyor で実行されているかどうか  |
 |APPVEYOR_ACCOUNT_NAME              | appveyor のアカウント名 (sakura editor の場合 "sakuraeditor") |
 |APPVEYOR_BUILD_NUMBER              | ビルド番号 |
 |APPVEYOR_URL                       | https://ci.appveyor.com |
 |APPVEYOR_BUILD_VERSION             | appveyor.yml の version フィールドの値 |
+|APPVEYOR_BUILD_ID                  | ビルドID (ビルド結果URLに含まれる数値です。`build-chm.bat`が実行中のビルドを識別するために使います。) |
 |APPVEYOR_PROJECT_SLUG              | project slug (appveyor の URL 名) |
 |APPVEYOR_PULL_REQUEST_NUMBER       | Pull Request 番号 |
 |APPVEYOR_PULL_REQUEST_HEAD_COMMIT  | Pull Request の Head commit Hash |
@@ -53,6 +55,7 @@ APPVEYOR_REPO_TAG_NAME は利用をやめて 代わりに GIT_TAG_NAME を使う
 
 * 上記環境変数をローカル環境で set コマンドで設定することにより appveyor でビルドしなくてもローカルでテストできます。
 * 上記の環境変数がどんな値になるのかは、過去の appveyor ビルドでのログを見ることによって確認できます。
+* `build-chm.bat`をローカルでテストするには完了済みのビルドIDが必要です。ビルドIDは[history](https://ci.appveyor.com/project/sakuraeditor/sakura/history)から各ビルド結果を表示するとURL末尾に付いている数字です。
 
 ## ビルドに使用するバッチファイル
 
@@ -66,6 +69,8 @@ APPVEYOR_REPO_TAG_NAME は利用をやめて 代わりに GIT_TAG_NAME を使う
 |[sakura\mingw32-del.bat](sakura/mingw32-del.bat)| MinGW の clean でファイルを削除するバッチファイル |
 |[parse-buildlog.bat](parse-buildlog.bat)    | ビルドログを解析するバッチファイル |
 |[build-chm.bat](build-chm.bat)       | compiled HTML ファイルをビルドするバッチファイル |
+|[help\make-artifacts.bat](help\make-artifacts.bat) | compiled HTML ファイルを zip に固めるバッチファイル |
+|[help\extract-chm-from-artifact.ps1](help\extract-chm-from-artifact.ps1) | ビルド済み compiled HTML ファイルをダウンロードして解凍するバッチファイル |
 |[build-installer.bat](build-installer.bat) | インストーラをビルドするバッチファイル |
 |[run-cppcheck.bat](run-cppcheck.bat)       | cppcheck を実行するバッチファイル |
 |[run-doxygen.bat](run-doxygen.bat)         | doxygen を実行するバッチファイル |
@@ -92,7 +97,9 @@ APPVEYOR_REPO_TAG_NAME は利用をやめて 代わりに GIT_TAG_NAME を使う
     - [build-gnu.bat](build-gnu.bat) : (Platform="MinGW"のみ) Makefileをビルドしてbuild-all.batの処理を終了する
     - [build-chm.bat](build-chm.bat) : HTML Help をビルドする
         - [remove-comment.py](help/remove-comment.py) : UTF-8 でのコンパイルエラーの回避のために日本語を削除するために [sakura.hh](sakura_core/sakura.hh) から一行コメントを削除する
-        - hhc.exe (Visual Studio 2017 に同梱)
+        - hhc.exe (Visual Studio 2017 に同梱) : compiled HTML をビルドするコンパイラ。かなり古いツールであり、日本語HTMLをビルドするためにはWindowsのシステムロケールを日本語に変更する必要がある。
+        - [help\extract-chm-from-artifact.ps1](help\extract-chm-from-artifact.ps1) : compiled HTML が必要なタイミングで、あらかじめ作成したビルド済みCHMをダウンロード＆解凍してその場でビルドを行ったのと同じ状態にする。
+    - [help\make-artifacts.bat](help\make-artifacts.bat) : HTML Help を zip に固める
     - [run-cppcheck.bat](run-cppcheck.bat) : cppcheck を実行する
         - cppcheck.exe
     - [run-doxygen.bat](run-doxygen.bat) : doxygen を実行する
@@ -121,6 +128,8 @@ APPVEYOR_REPO_TAG_NAME は利用をやめて 代わりに GIT_TAG_NAME を使う
 |sakura\mingw32-del.bat| 削除するファイルパス1 | 削除するファイルパス2(2つ目以降は省略可能)  |
 |parse-buildlog.bat  | msbuild のビルドログパス | なし |
 |build-chm.bat       | なし | なし |
+|help\make-artifacts.bat | なし | なし |
+|help\extract-chm-from-artifact.ps1 | なし | なし |
 |build-installer.bat | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
 |run-cppcheck.bat                        | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |
 |run-doxygen.bat                         | platform ("Win32" または "x64") | configuration ("Debug" または "Release")  |

--- a/appveyor.md
+++ b/appveyor.md
@@ -50,6 +50,7 @@
 |APPVEYOR_PULL_REQUEST_HEAD_COMMIT  | Pull Request の Head commit Hash |
 |APPVEYOR_REPO_NAME                 | リポジトリ名 (owner-name/repo-name) |
 |APPVEYOR_REPO_PROVIDER             | appveyor の参照するリポジトリ種別 (GitHub の場合 "gitHub") |
+|~~READONLY_TOKEN~~                 | デバッグ用です。 appveyor の REST API に渡す [Bearer Token](https://www.appveyor.com/docs/api/#Authentication) をスクリプト外から渡せるように定義しています。 appveyor では使いません。(未定義なので値は''になります。) |
 
 APPVEYOR_REPO_TAG_NAME は利用をやめて 代わりに GIT_TAG_NAME を使うようにしました。[#876](https://github.com/sakura-editor/sakura/pull/876)
 

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -15,6 +15,11 @@ set HH_SCRIPT=%~dp0help\remove-comment.py
 set HH_INPUT=sakura_core\sakura.hh
 set HH_OUTPUT=help\sakura\sakura.hh
 
+if "%PLATFORM%" neq "BuildChm" (
+	goto :download_archive
+	exit /b 0
+)
+
 if exist "%HH_OUTPUT%" del /F "%HH_OUTPUT%"
 python "%HH_SCRIPT%" "%HH_INPUT%" "%HH_OUTPUT%"  || (echo error && exit /b 1)
 
@@ -44,4 +49,9 @@ if not errorlevel 1 (
 	echo retry error %PROJECT_HHP% errorlevel %errorlevel%
 	exit /b 1
 )
+exit /b 0
+
+:download_archive
+powershell -ExecutionPolicy RemoteSigned -File %~dp0help\extract-chm-from-artifact.ps1
+if errorlevel 1 exit /b 1
 exit /b 0

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -15,9 +15,11 @@ set HH_SCRIPT=%~dp0help\remove-comment.py
 set HH_INPUT=sakura_core\sakura.hh
 set HH_OUTPUT=help\sakura\sakura.hh
 
-if "%PLATFORM%" neq "BuildChm" (
-	goto :download_archive
-	exit /b 0
+if defined APPVEYOR (
+	if "%PLATFORM%" neq "BuildChm" (
+		goto :download_archive
+		exit /b 0
+	)
 )
 
 if exist "%HH_OUTPUT%" del /F "%HH_OUTPUT%"

--- a/help/extract-chm-from-artifact.ps1
+++ b/help/extract-chm-from-artifact.ps1
@@ -39,18 +39,19 @@ try {
 		-OutFile $localArtifactPath -Headers @{ "Authorization" = "Bearer $token" } `
 		-ErrorAction Stop
 
+	$unzipErrorFile = "$PSScriptRoot\unzip.err"
 	Start-Process -FilePath $env:CMD_7Z -ArgumentList "x -y $localArtifactPath" `
 		-NoNewWindow `
 		-WorkingDirectory $PSScriptRoot `
-		-RedirectStandardError "$PSScriptRoot\unzip.err" `
+		-RedirectStandardError $unzipErrorFile `
 		-Wait
 
-	$unzipResult = Get-Content -Path "$PSScriptRoot\unzip.err" -TotalCount 3
+	$unzipResult = Get-Content -Path $unzipErrorFile -TotalCount 3
 	if ($unzipResult -is [array]) {
 		throw "$unzipResult"
 	}
 
-	Remove-Item "$PSScriptRoot\unzip.err"
+	Remove-Item $unzipErrorFile
 
 } catch {
 	Write-Output 'caught an error.'

--- a/help/extract-chm-from-artifact.ps1
+++ b/help/extract-chm-from-artifact.ps1
@@ -1,0 +1,61 @@
+# this script was designed to run only for appveyor.
+# https://www.appveyor.com/docs/api/samples/download-artifacts-ps/
+
+$apiUrl = 'https://ci.appveyor.com/api'
+$token = ''
+$headers = @{
+  "Authorization" = "Bearer $token"
+  "Content-type" = "application/json"
+}
+
+if ($env:APPVEYOR_ACCOUNT_NAME -eq 'sakuraeditor') {
+	# get project with current build details
+	$getProjectApi = "$apiUrl/projects/sakuraeditor/sakura/build/$env:APPVEYOR_BUILD_VERSION"
+} else {
+	# get project with last build details
+	$getProjectApi = "$apiUrl/projects/sakuraeditor/sakura"
+}
+
+try {
+	# get project with build details
+	$project = Invoke-RestMethod -Method Get -Uri $getProjectApi -Headers $headers -ErrorAction Stop
+
+	$chmJob = $project.build.jobs | Where-Object name -eq 'Configuration: Release; Platform: BuildChm'
+	$jobId = $chmJob.jobId
+
+	# get job artifacts (just to see what we've got)
+	$artifacts = Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts" -Headers $headers -ErrorAction Stop
+
+	# here we just take the first artifact, but you could specify its file name
+	# $artifactFileName = 'sakura-Chm.zip'
+	$artifactFileName = $artifacts[0].fileName
+	if ($artifactFileName -notmatch '^sakura-.*-Chm.zip$') {
+		throw "unexpected file name $artifactFileName."
+	}
+
+	# artifact will be downloaded as
+	$localArtifactPath = "$PSScriptRoot\$artifactFileName"
+
+	# download artifact
+	# -OutFile - is local file name where artifact will be downloaded into
+	# the Headers in this call should only contain the bearer token, and no Content-type, otherwise it will fail!
+	Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts/$artifactFileName" `
+		-OutFile $localArtifactPath -Headers @{ "Authorization" = "Bearer $token" } `
+		-ErrorAction Stop
+
+	Start-Process -FilePath $env:CMD_7Z -ArgumentList "x -y $localArtifactPath" `
+		-NoNewWindow `
+		-WorkingDirectory $PSScriptRoot `
+		-RedirectStandardError "$PSScriptRoot\unzip.err" `
+		-Wait
+
+	$unzipResult = Get-Content -Path "$PSScriptRoot\unzip.err" -TotalCount 3
+	if ($unzipResult -is [array]) {
+		throw "$unzipResult"
+	}
+
+} catch {
+	Write-Output 'caught an error.'
+	Write-Output $error[0]
+	exit 1
+}

--- a/help/extract-chm-from-artifact.ps1
+++ b/help/extract-chm-from-artifact.ps1
@@ -5,6 +5,11 @@ $apiUrl = 'https://ci.appveyor.com/api'
 $accountName = $env:APPVEYOR_ACCOUNT_NAME
 $projectSlug = $env:APPVEYOR_PROJECT_SLUG
 $buildId = $env:APPVEYOR_BUILD_ID
+
+# appveyor REST API requires Bearer token.
+# https://www.appveyor.com/docs/api/#Authentication
+# Because the Bearer token can be empty, we won't define the variable named `READONLY_TOKEN`.
+# To be ease of testing, you can define it from the outside of this script.
 $token = $env:READONLY_TOKEN
 $headers = @{
   "Authorization" = "Bearer $token"

--- a/help/extract-chm-from-artifact.ps1
+++ b/help/extract-chm-from-artifact.ps1
@@ -1,24 +1,20 @@
 # this script was designed to run only for appveyor.
 # https://www.appveyor.com/docs/api/samples/download-artifacts-ps/
-
+#
 $apiUrl = 'https://ci.appveyor.com/api'
-$token = ''
+$accountName = $env:APPVEYOR_ACCOUNT_NAME
+$projectSlug = $env:APPVEYOR_PROJECT_SLUG
+$buildId = $env:APPVEYOR_BUILD_ID
+$token = $env:READONLY_TOKEN
 $headers = @{
   "Authorization" = "Bearer $token"
   "Content-type" = "application/json"
 }
 
-if ($env:APPVEYOR_ACCOUNT_NAME -eq 'sakuraeditor') {
-	# get project with current build details
-	$getProjectApi = "$apiUrl/projects/sakuraeditor/sakura/build/$env:APPVEYOR_BUILD_VERSION"
-} else {
-	# get project with last build details
-	$getProjectApi = "$apiUrl/projects/sakuraeditor/sakura"
-}
-
 try {
-	# get project with build details
-	$project = Invoke-RestMethod -Method Get -Uri $getProjectApi -Headers $headers -ErrorAction Stop
+	# get project with current build details
+	Write-Output "checking $env:APPVEYOR_URL/projects/$accountName/$projectSlug/builds/$buildId"
+	$project = Invoke-RestMethod -Method Get -Uri "$apiUrl/projects/$accountName/$projectSlug/builds/$buildId" -Headers $headers -ErrorAction Stop
 
 	$chmJob = $project.build.jobs | Where-Object name -eq 'Configuration: Release; Platform: BuildChm'
 	$jobId = $chmJob.jobId
@@ -53,6 +49,8 @@ try {
 	if ($unzipResult -is [array]) {
 		throw "$unzipResult"
 	}
+
+	Remove-Item "$PSScriptRoot\unzip.err"
 
 } catch {
 	Write-Output 'caught an error.'


### PR DESCRIPTION
# PR の目的

HTML Helpのキーワード文字化け問題を解消します。

キーワードを文字化けさせないために、HTML Helpのビルドを切り離しました(#962)。
　↓
切り離したHTML Helpのビルド結果を、使えるようにする対処が必要です。

このPRは、切り離したビルドの結果を使えるようにする部分の修正です。


## カテゴリ

- CI関連
  - Appveyor


## PR の背景

関連チケットの項を見てください。

当初、かなり多くの課題があるように感じていましたが、
https://github.com/sakura-editor/sakura/issues/954#issuecomment-511212723  
フタを開けてみたらそうでもなかったようです。
https://github.com/sakura-editor/sakura/issues/954#issuecomment-513434502  


## PR のメリット

<!-- PR のメリットを記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
HTML Helpのキーワード文字化け問題を解消できます。


## PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
インストーラー作成を含むバッチ群はローカルで動かすこともあると思います。
~~修正内容は、ローカルで動かす場合の動作にも影響します。~~
~~sakura-editor/sakura以外で動かす場合には、最新ビルドの成果物を参照するのでタイミングによっては**ビルド対象のソースに何も問題がないのにビルドが失敗するケース**が起こりえます。~~
(https://github.com/sakura-editor/sakura/pull/971#discussion_r305636241 の指摘対応により、環境変数`APPVEYOR`を定義しない限り、ローカルビルドは変更の影響を受けないようになりました。)

とりあえずで導入するには問題ないと考えています~~が、もう少しなんとかならんかな？とも思っています。この件は今後の課題としたいです~~。
(もうかなりなんとかなったと思っています :smile:)


## PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
HTML Helpを含んだartifactsに影響があります。
具体的にはインストーラー作成処理に影響します。


## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->
#922 v2.4のヘルプ キーワード検索画面のリストが文字化けしている
close #954 Appveyorのロケール設定を復活したい 
#960 appveyor.yml に test_script を導入する
#961 成果物を個別定義にする
#962 help構築用にplatform定義を追加する
#964 -> #967 Azure Pipelines向けのhelp、インストーラーの生成を一旦やめる
#968 -> #970 Appveyorのビルド順をRelease⇒Debugに戻したい


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://www.appveyor.com/docs/api/samples/download-artifacts-ps/
https://www.appveyor.com/docs/api/projects-builds/#get-project-last-build
https://www.appveyor.com/docs/api/projects-builds/#get-project-build-by-version
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/start-process?view=powershell-6
https://qiita.com/NakaD/items/6979223ef9e6560d047c
https://qiita.com/bounoki/items/b371d1f91a9cb3aec8f4
