### PR TITLE
マージ済みの Pull Request をGitHub 上の Revert ボタンでもとに戻すときに Azure Pipelines でビルドが走るようにする

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ trigger:
       - master
       - develop
       - feature/*
+      - revert-*
   paths:
     exclude:
       - "*.md"
@@ -29,6 +30,7 @@ pr:
       - master
       - develop
       - feature/*
+      - revert-*
   paths:
     exclude:
       - "*.md"


### PR DESCRIPTION
# PR の目的

マージ済みの Pull Request をGitHub 上の Revert ボタンでもとに戻すときに Azure Pipelines でビルドが走るようにする

## カテゴリ

- CI関連
  - Azure Pipelines

## PR の背景

#954 の対応を入れることにより、chm のビルドに失敗する問題が解消する見込みです。
そのため HTML Help のソースを UTF-8 にしたのをもとに戻した対応 (#940) を
もとに戻す予定です。

その際、[GitHub の Revert ボタン](https://github.blog/2014-06-24-introducing-the-revert-button/) でもとに戻したい。

しかし、 https://ci.appveyor.com/project/sakuraeditor/sakura/builds/26274503 や https://github.blog/2014-06-24-introducing-the-revert-button/ にあるとおり、
GitHub で作成される feature ブランチ名が `revert-<PR番号>-<もともとのブランチ名>` として
作成される模様です。

この場合、現状の Azure Pipelines の設定ではビルドが走らないのでビルドが走るように
ブランチ名のパターンを追加する。

## PR のメリット

Pull Request の Revert ボタンで作成されたブランチおよび Pull Request に対してビルドが走る

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

Azure Pipelines でビルド対象ブランチ

## 関連チケット

#954
#940

## 参考資料

https://github.blog/2014-06-24-introducing-the-revert-button/