### PR TITLE
find-tools.batにクリア機能を付けたい

### DIFF
--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -1,6 +1,21 @@
 @echo off
 setlocal
 
+if "%1" equ "clear" (
+    if not defined FIND_TOOLS_CALLED echo nothing to do. && exit /b 0
+    endlocal
+    set CMD_GIT=
+    set CMD_7Z=
+    set CMD_HHC=
+    set CMD_ISCC=
+    set CMD_CPPCHECK=
+    set CMD_DOXYGEN=
+    set CMD_VSWHERE=
+    set CMD_MSBUILD=
+    set FIND_TOOLS_CALLED=
+    echo find-tools.bat has been cleared
+    exit /b
+)
 if defined FIND_TOOLS_CALLED (
     echo find-tools.bat already called
     exit /b

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -2,7 +2,6 @@
 setlocal
 
 if "%1" equ "clear" (
-    if not defined FIND_TOOLS_CALLED echo nothing to do. && exit /b 0
     endlocal
     set CMD_GIT=
     set CMD_7Z=


### PR DESCRIPTION
# PR の目的

ビルドに必要なツールを検索するバッチ `tools\find-tools.bat` の改善提案です。
`find-tools.bat` にクリア機能を付けて、デバッグしやすくします。


## カテゴリ

- リファクタリング
- ビルド手順
- その他


## PR の背景
ビルドに使うツールのパスを集めてくる `find-tools.bat` の改善です。
このツールは、ビルドバッチのあちこちで使う「ツールの検索」を一か所にまとめたものです。

検索処理は基本的に1～2秒で終わります。
が、何度も同じ処理を走らせるのは効率が良くないので、
「一度検索したら再検索はしない」という仕様になっています。

この仕様に特に文句はないのですが、デバッグするときは面倒です。
「一度検索したら再検索はしない」ということは、
「一度実行したら二回目以降は処理が走らない」ということです。

デバッグするときは、一度実行したらコマンドプロンプトを開きなおすか、
コマンドプロンプトで `set XXX=` を乱打するかで初期状態に戻してやる必要があります。

この問題を解決するため、スクリプト本体にクリア機能を付けたいです。


## PR のメリット

* `find-tools.bat` がセットする環境変数を一括でリセットできるようになります。
（ `find-tools.bat` のデバッグがしやすくなります。）


## PR のデメリット (トレードオフとかあれば)

* `find-tools.bat` に新規環境変数を追加するときの修正箇所が1つ増えます。
* 現在出ている `find-tools.bat` に対する修正とコンフリクトします。
（コンフリクトしてなくても、rebaseして追加修正を行う必要があると思います。）


## PR の影響範囲

* `find-tools.bat` をデバッグするときの手順に影響します。
* ビルドツールに対する変更ですが、ビルド処理への影響はありません。
* アプリ（＝サクラエディタ）への影響はありません。


## 関連チケット

#958 find-tool.bat で Visual Studio のバージョンを指定できるようにする (たぶんコンフリクト)
#955 cmake のパスを find-tools.bat で検索して cmake のパスが通っていなくてもビルドできるようにする (たぶんコンフリクト)


## 参考資料

とくにありません。
