### PR TITLE
REST通信をリトライさせる

### DIFF
--- a/build-chm.bat
+++ b/build-chm.bat
@@ -54,6 +54,6 @@ if not errorlevel 1 (
 exit /b 0
 
 :download_archive
-powershell -ExecutionPolicy RemoteSigned -File %~dp0help\extract-chm-from-artifact.ps1
+pwsh.exe -ExecutionPolicy RemoteSigned -File %~dp0help\extract-chm-from-artifact.ps1
 if errorlevel 1 exit /b 1
 exit /b 0

--- a/help/extract-chm-from-artifact.ps1
+++ b/help/extract-chm-from-artifact.ps1
@@ -19,13 +19,15 @@ $headers = @{
 try {
 	# get project with current build details
 	Write-Output "checking $env:APPVEYOR_URL/projects/$accountName/$projectSlug/builds/$buildId"
-	$project = Invoke-RestMethod -Method Get -Uri "$apiUrl/projects/$accountName/$projectSlug/builds/$buildId" -Headers $headers -ErrorAction Stop
+	$project = Invoke-RestMethod -Method Get -Uri "$apiUrl/projects/$accountName/$projectSlug/builds/$buildId" -Headers $headers `
+		-MaximumRetryCount 3 -RetryIntervalSec 20 -ErrorAction Stop
 
 	$chmJob = $project.build.jobs | Where-Object name -eq 'Configuration: Release; Platform: BuildChm'
 	$jobId = $chmJob.jobId
 
 	# get job artifacts (just to see what we've got)
-	$artifacts = Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts" -Headers $headers -ErrorAction Stop
+	$artifacts = Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts" -Headers $headers `
+		-MaximumRetryCount 3 -RetryIntervalSec 20 -ErrorAction Stop
 
 	# here we just take the first artifact, but you could specify its file name
 	# $artifactFileName = 'sakura-Chm.zip'
@@ -42,7 +44,7 @@ try {
 	# the Headers in this call should only contain the bearer token, and no Content-type, otherwise it will fail!
 	Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts/$artifactFileName" `
 		-OutFile $localArtifactPath -Headers @{ "Authorization" = "Bearer $token" } `
-		-ErrorAction Stop
+		-MaximumRetryCount 3 -RetryIntervalSec 20 -ErrorAction Stop
 
 	$unzipErrorFile = "$PSScriptRoot\unzip.err"
 	Start-Process -FilePath $env:CMD_7Z -ArgumentList "x -y $localArtifactPath" `


### PR DESCRIPTION
# PR の目的

REST APIがコケたときリトライするようにすることで、appveyorが過負荷になってもビルドが失敗しないようにしたいです。

## カテゴリ

- CI関連
  - Appveyor


## PR の背景

#971 で HTML Help のビルド成果物をダウンロードする処理を組み込みました。

先に挙げた appveyor のビルド結果リンクは、 #971 マージ後のものです。
x64 - Release ビルドの途中、REST API が Service UnAvailable を返したことにより異常終了しています。

ネットワーク通信を行うプログラムでは、相手先サーバーの過負荷や通信エラーを考慮して「リトライ」を組み込むのが定石なんですが、#971 で投入したダウンロードスクリプトではリトライを行っていませんでした。
(#977 のコピペです :smile: )


## PR のメリット

appveyor が たまたま重くなってるときに走ったビルドが失敗する確率を下げることができます。


## PR のデメリット (トレードオフとかあれば)

とくにないと考えています。

`Invoke-RestMethod` のリトライ機能を使うために、
`powershell 6`を使うようにしますが、appveyorには元からインストールされています。


## PR の影響範囲

appveyor における `Win32/x64` のビルド。
help ダウンロードの処理にリトライを付けます。


## 関連チケット

close #977 
#971

## 参考資料

* https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-6
* https://note.mu/artrigger_jp/n/n0795148b062d
* https://github.com/sakura-editor/sakura/issues/977#issuecomment-516784743
* https://win.just4fun.biz/?PowerShell/Windows10%E3%81%ABPowerShell%20Core%206.x%E3%82%92%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%97%E3%81%A6%E3%81%BF%E3%81%9F

通信のリトライの方法論は、かなり古くからある古典ネタだと思っています。
とりあえず難しいことは考えず、お手軽に採用できる定間隔リトライを入れて、
しばらく様子を見てみたいと考えています。