### PR TITLE
最新版msys2でビルドできるようにHeaderMakeを修正する

### DIFF
--- a/HeaderMake/HeaderMake.cpp
+++ b/HeaderMake/HeaderMake.cpp
@@ -47,13 +47,6 @@
 	usage() を参照
 */
 
-#ifdef __MINGW32__
-#include <_mingw.h>
-#ifdef MINGW_HAS_SECURE_API
-#undef MINGW_HAS_SECURE_API
-#endif  // MINGW_HAS_SECURE_API
-#endif  // __MINGW32__
-
 #include <stdio.h>
 #include <string>
 #include <vector>
@@ -64,38 +57,10 @@
 #include <errno.h>
 using namespace std;
 
-#define PREPROCESSOR "cl.exe /nologo /source-charset:utf-8 /execution-charset:shift_jis /EP %s"
-
-#ifdef __MINGW32__
-#include <windows.h>
-#ifndef _countof
-#define _countof(A) (sizeof(A)/sizeof(A[0]))
-#endif
-#define sprintf_s(A, B, C, ...) sprintf((A), (C), (__VA_ARGS__))
-#define strncpy_s(A, B, C, D) strncpy((A), (C), (D))
-
-#undef PREPROCESSOR
-#define PREPROCESSOR "gcc -x c++ -finput-charset=utf-8 -fexec-charset=cp932 -E %s"
-
-void fopen_s( 
-   FILE** pFile,
-   const char *filename,
-   const char *mode 
-)
-{
-	*pFile = fopen(filename, mode);
-}
-#endif	// __MINGW32__
-
 #ifdef _MSC_VER
-#if _MSC_VER < 1400	// VC2003
-#ifndef _countof
-#define _countof(A) (sizeof(A)/sizeof(A[0]))
-#endif
-#define sprintf_s(A, B, C, D) sprintf((A), (C), (D))
-#define strncpy_s(A, B, C, D) strncpy((A), (C), (D))
-#define fopen_s(A, B, C) ( *(A) = fopen((B), (C)) )
-#endif	// VC2003
+#define PREPROCESSOR "cl.exe /nologo /source-charset:utf-8 /execution-charset:shift_jis /EP %s"
+#elif defined(__GNUC__)
+#define PREPROCESSOR "gcc.exe -x c++ -finput-charset=utf-8 -fexec-charset=cp932 -E %s"
 #endif	// _MSC_VER
 
 enum EMode{


### PR DESCRIPTION
# PR の目的

HeaderMakeのソースコードを修正することで、
最新版 msys2 でビルドできるようにします。

## カテゴリ

- CI関連
  - Appveyor(MinGWビルド)
  - Azure Pipelines(MinGWビルド) ※

※現状 Azure Pipelines にはまだ MinGW ビルドがないので、実質的には「影響なし」です。

## PR の背景

appveyorにインストールされているmsys2のバージョンがアップデートされました。（推定
アップデートの影響で、MinGW版のHeaderMake.exeのビルドが通らなくなっています。

https://github.com/sakura-editor/sakura/issues/979#issuecomment-517893363 で説明している通り、元々この事象（＝最新版msys2ではビルドが通らない）は把握していて、別件（＝azure pipelinesにmsys2を入れてMinGWビルドできるようにする）で対策を検討していました。

対策の投入前に appveyor の msys2 がアップデートされてしまったようなので、急遽準備していた対策を投入する感じになりました。

## PR のメリット

* MinGWビルドが失敗しなくなります。
* azure pipelines移行のために必要な前提条件を事前に1つクリアすることができます。


## PR のデメリット (トレードオフとかあれば)

とくにありません。

セキュア対応版関数を含まないGCC、VC++2005より前のMSVCではビルドできなくなります。
これらのビルド環境については、元々サポート対象外なので「影響なし」と考えています。


## PR の影響範囲

サクラエディタ本体のビルドに必要な自動生成ファイル、
`FuncCode_Enum.h` と `FuncCode_Define.h` の生成処理に影響します。
ただし、正常ルートでは通らない部分の変更なので、実質的に「影響なし」です。
アプリ本体（＝サクラエディタ）への影響はありません。


## 関連チケット

#978 REST通信をリトライさせる　←このPRのマージ後ビルドで問題発覚
close #979 Appveyor で MinGW ビルドが失敗する
#974 Appveyor から MinGW ビルドを外したい 

## 参考資料

* https://github.com/sakura-editor/sakura/issues/979#issuecomment-517893363
