### PR TITLE
MinGWビルドを引っ越しする

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ platform:
   - BuildChm
   - Win32
   - x64
-  - MinGW
 
 # set clone depth
 clone_depth: 5
@@ -28,7 +27,6 @@ skip_commits:
 install:
 - cmd: |
     pip install openpyxl --user
-    C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gtest"
 
 # to run our custom scripts instead of automatic MSBuild
 build_script:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,15 @@ jobs:
     vmImage: 'VS2017-Win2016'
     displayName: VS2017
 
+# サクラエディタのビルドを行う JOB(MinGW)
+# * サクラエディタ本体
+# * 単体テスト
+- template: ci/azure-pipelines/template.job.build-on-msys2.yml
+  parameters:
+    name: MinGW
+    vmImage: 'VS2017-Win2016'
+    displayName: MinGW
+
 # SonarQube で解析を行う JOB
 - template: ci/azure-pipelines/template.job.SonarQube.yml
   parameters:

--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -24,6 +24,11 @@ if "%configuration%" == "Release" (
 	exit /b 1
 )
 
+@rem  remove sh.exe in the PATH(for azure pipelines).
+PATH=%PATH:C:\Program Files\Git\cmd;=%
+PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+PATH=%PATH:C:\Program Files\Git\bin;=%
+
 @rem https://www.appveyor.com/docs/environment-variables/
 @rem path=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%path%
 path=C:\msys64\mingw64\bin;%path%

--- a/ci/azure-pipelines/template.job.build-on-msys2.yml
+++ b/ci/azure-pipelines/template.job.build-on-msys2.yml
@@ -1,0 +1,80 @@
+# see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops&viewFallbackFrom=vsts#passing-parameters
+parameters:
+  name: ''
+  vmImage: ''
+  displayName: ''
+
+jobs:
+- job: ${{ parameters.name }}
+  displayName: ${{ parameters.displayName }}
+  dependsOn: script_check
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+
+  strategy:
+    maxParallel: 2
+    matrix:
+      MinGW_Debug:
+        BuildPlatform: 'MinGW'
+        Configuration: 'Debug'
+      MinGW_Release:
+        BuildPlatform: 'MinGW'
+        Configuration: 'Release'
+
+  steps:
+  - checkout:   self       # self represents the repo where the initial Pipelines YAML file was found
+    clean:      all        # what to clean each time; if not mentioned, does not clean
+    fetchDepth: 5          # the depth of commits to ask Git to fetch; defaults to no limit
+
+  # show environmental variables for debug.
+  - script: set
+    displayName: Show environmental variables for debug
+
+  - template: /ci/azure-pipelines/template.steps.install-mingw-w64-gcc.yml
+
+  # Build GNU C++
+  - script: build-gnu.bat       $(BuildPlatform) $(Configuration)
+    displayName: Build with MinGW-w64-gcc
+
+  # Unit tests
+  - script: tests\build-and-test.bat $(BuildPlatform) $(Configuration)
+    displayName: Unit test
+
+  # see https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/copy-files?view=azure-devops&tabs=yaml
+  #
+  # "condition:" に関しては以下を参照
+  #     https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml
+  #
+  # "succeededOrFailed()" に関しては以下を参照
+  #     https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml#job-status-functions
+  #
+  - task: CopyFiles@1
+    condition: succeededOrFailed()
+    displayName: Copy to ArtifactStagingDirectory
+    inputs:
+      contents: |
+       **.zip
+       **.zip.md5
+      targetFolder: $(Build.ArtifactStagingDirectory)
+
+  # see https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml
+  - task: PublishBuildArtifacts@1
+    condition: succeededOrFailed()
+    displayName: Publish ArtifactStagingDirectory
+    inputs:
+       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+       artifactName: $(BuildPlatform)_$(Configuration)
+
+  # see https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '**/*-googletest-*.xml'
+      #searchFolder: '$(System.DefaultWorkingDirectory)' # Optional
+      #mergeTestResults: false # Optional
+      #failTaskOnFailedTests: false # Optional
+      #testRunTitle: # Optional
+      #buildPlatform: # Optional
+      #buildConfiguration: # Optional
+      #publishRunAttachments: true # Optional

--- a/ci/azure-pipelines/template.steps.install-mingw-w64-gcc.yml
+++ b/ci/azure-pipelines/template.steps.install-mingw-w64-gcc.yml
@@ -1,0 +1,18 @@
+#############################################################################################################
+#   必要な mingw-w64-gcc をインストール手順の 'steps' を定義するテンプレート
+#
+#   parameters
+#       なし
+#############################################################################################################
+steps:
+  - script: cinst msys2 --params "/InstallDir=C:/msys64" --no-progress
+    displayName: install msys2
+
+  - script: C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-libs"
+    displayName: install MinGW-w64-gcc
+
+  - script: C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-make"
+    displayName: install MinGW-w64-make
+
+  - script: C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gtest"
+    displayName: install MinGW-w64-gtest


### PR DESCRIPTION
# PR の目的

MinGWビルドを外すことによって、appveyorのビルド時間を短縮します。
除外したMinGWビルドはazure pipelinesに移転することにより、これまで通りMinGWビルドが行われるようにします。


## カテゴリ

- CI関連
  - Appveyor (MinGWビルド廃止)
  - Azure Pipelines (MinGWビルド新設)


## PR の背景

appveyorのビルドに時間が掛かっています。（おおむね30分

ビルド待ち時間が長いとレビューが辛いので、なんとか高速化したいです。
（詳細は #974 Appveyor から MinGW ビルドを外したい を参照。）

#819 で導入した Azure pipelines の特性（非課金状態でも並列ビルドを利用可能）を活用して、
MinGWビルドをazure pipelinesに引っ越しさせて appveyor のビルドを高速化したいです。


## PR のメリット
・MinGWビルドを行わない分、appveyorのビルド時間を短縮できます。
（MinGW Debug/Releaseの合計で6～15分程度短縮されます。）


## PR のデメリット (トレードオフとかあれば)
・azure pipelinesのビルド開始～終了までの時間が延びます。(5分程度⇒15分程度)

appveyor側は MinGW ビルドを抜きにしても 20分くらいはかかるので、大きな問題にならないと考えています。ビルド時間そのものを短縮する方策はいくつかあるので、基本的には今後短くなっていく方向だと考えています。ビルド時間短縮の対策については、ややこしくなるので今は投入しません。


## PR の影響範囲
・MinGWビルドのビルド環境が変わります。
・アプリ（＝サクラエディタ）の機能に影響はありません。


## 関連チケット
#427 appveyor のビルドで削れるものがないか検討する
#446 Azure Pipelines を調査する
close #974 Appveyor から MinGW ビルドを外したい
#979 Appveyor で MinGW ビルドが失敗する
#981 最新版msys2でビルドできるようにHeaderMakeを修正する


## 参考資料
https://chocolatey.org/packages/msys2
https://qiita.com/spiegel-im-spiegel/items/ba4e8d2418bdfe0c8049
