### PR TITLE
メモリプールを使う事でメモリ確保と解放を高速化

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -438,6 +438,7 @@
     <ClInclude Include="..\sakura_core\mem\CNativeA.h" />
     <ClInclude Include="..\sakura_core\mem\CNativeT.h" />
     <ClInclude Include="..\sakura_core\mem\CNativeW.h" />
+    <ClInclude Include="..\sakura_core\mem\CPoolResource.h" />
     <ClInclude Include="..\sakura_core\mem\CRecycledBuffer.h" />
     <ClInclude Include="..\sakura_core\mfclike\CMyWnd.h" />
     <ClInclude Include="..\sakura_core\outline\CDlgFileTree.h" />

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1088,6 +1088,9 @@
     <ClInclude Include="..\sakura_core\recent\CRecentExcludeFolder.h">
       <Filter>Cpp Source Files\recent</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\mem\CPoolResource.h">
+      <Filter>Cpp Source Files\mem</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\sakura_core\Funccode_x.hsrc">

--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -37,9 +37,9 @@
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CLayoutMgr::CLayoutMgr()
-: m_getIndentOffset( &CLayoutMgr::getIndentOffset_Normal ),	//	Oct. 1, 2002 genta	//	Nov. 16, 2002 メンバー関数ポインタにはクラス名が必要
-  m_layoutMemRes(new CPoolResource<CLayout>())
-  //m_layoutMemRes(new std::pmr::unsynchronized_pool_resource()) // メモリ使用量が大きい為に使用しないで、CPoolResource を代わりに使う
+: m_getIndentOffset( &CLayoutMgr::getIndentOffset_Normal )	//	Oct. 1, 2002 genta	//	Nov. 16, 2002 メンバー関数ポインタにはクラス名が必要
+  , m_layoutMemRes(new CPoolResource<CLayout>())
+  //, m_layoutMemRes(new std::pmr::unsynchronized_pool_resource()) // メモリ使用量が大きい為に使用しない
 {
 	m_pcDocLineMgr = NULL;
 	m_pTypeConfig = NULL;

--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -25,6 +25,7 @@
 #include "charset/charcode.h"
 #include "mem/CMemory.h"/// 2002/2/10 aroka
 #include "mem/CMemoryIterator.h" // 2006.07.29 genta
+#include "mem/CPoolResource.h"
 #include "view/CViewFont.h"
 #include "view/CTextMetrics.h"
 #include "basis/SakuraBasis.h"
@@ -37,7 +38,8 @@
 
 CLayoutMgr::CLayoutMgr()
 : m_getIndentOffset( &CLayoutMgr::getIndentOffset_Normal ),	//	Oct. 1, 2002 genta	//	Nov. 16, 2002 メンバー関数ポインタにはクラス名が必要
-  m_layoutAllocator( &m_layoutPool )
+  m_layoutMemRes(new CPoolResource<CLayout>())
+  //m_layoutMemRes(new std::pmr::unsynchronized_pool_resource()) // メモリ使用量が大きい為に使用しないで、CPoolResource を代わりに使う
 {
 	m_pcDocLineMgr = NULL;
 	m_pTypeConfig = NULL;
@@ -97,7 +99,7 @@ void CLayoutMgr::_Empty()
 	while( pLayout ){
 		CLayout* pLayoutNext = pLayout->GetNextLayout();
 		pLayout->~CLayout();
-		m_layoutAllocator.deallocate(pLayout, 1);
+		m_layoutMemRes->deallocate(pLayout, sizeof(CLayout), alignof(CLayout));
 		pLayout = pLayoutNext;
 	}
 }
@@ -383,8 +385,7 @@ CLayout* CLayoutMgr::CreateLayout(
 	CLayoutColorInfo*	colorInfo
 )
 {
-	CLayout* pLayout = m_layoutAllocator.allocate(1);
-	m_layoutAllocator.construct(pLayout,
+	CLayout* pLayout = new (m_layoutMemRes->allocate(sizeof(CLayout))) CLayout(
 		pCDocLine,
 		ptLogicPos,
 		nLength,
@@ -593,7 +594,7 @@ CLayout* CLayoutMgr::DeleteLayoutAsLogical(
 		}
 
 		pLayout->~CLayout();
-		m_layoutAllocator.deallocate(pLayout, 1);
+		m_layoutMemRes->deallocate(pLayout, sizeof(CLayout), alignof(CLayout));
 
 		m_nLines--;	/* 全物理行数 */
 		if( NULL == pLayoutNext ){

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -24,6 +24,7 @@
 
 #include <Windows.h>// 2002/2/10 aroka
 #include <vector>
+#include <memory_resource>
 #include "doc/CDocListener.h"
 #include "_main/global.h"// 2002/2/10 aroka
 #include "basis/SakuraBasis.h"
@@ -37,7 +38,6 @@
 #include "util/design_template.h"
 
 class CBregexp;// 2002/2/10 aroka
-class CLayout;// 2002/2/10 aroka
 class CDocLineMgr;// 2002/2/10 aroka
 class CDocLine;// 2002/2/10 aroka
 class CMemory;// 2002/2/10 aroka
@@ -399,6 +399,8 @@ protected:
 	//実データ
 	CLayout*				m_pLayoutTop;
 	CLayout*				m_pLayoutBot;
+	std::pmr::unsynchronized_pool_resource m_layoutPool;
+	std::pmr::polymorphic_allocator<CLayout> m_layoutAllocator;
 
 	//タイプ別設定
 	const STypeConfig*		m_pTypeConfig;

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -38,6 +38,7 @@
 #include "util/design_template.h"
 
 class CBregexp;// 2002/2/10 aroka
+class CLayout;// 2002/2/10 aroka
 class CDocLineMgr;// 2002/2/10 aroka
 class CDocLine;// 2002/2/10 aroka
 class CMemory;// 2002/2/10 aroka

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -399,8 +399,7 @@ protected:
 	//実データ
 	CLayout*				m_pLayoutTop;
 	CLayout*				m_pLayoutBot;
-	std::pmr::unsynchronized_pool_resource m_layoutPool;
-	std::pmr::polymorphic_allocator<CLayout> m_layoutAllocator;
+	std::unique_ptr<std::pmr::memory_resource> m_layoutMemRes;
 
 	//タイプ別設定
 	const STypeConfig*		m_pTypeConfig;

--- a/sakura_core/doc/logic/CDocLineMgr.cpp
+++ b/sakura_core/doc/logic/CDocLineMgr.cpp
@@ -53,10 +53,8 @@
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 CDocLineMgr::CDocLineMgr()
-	:
-	m_docLineMemRes(new CPoolResource<CDocLine>())
-	//m_docLineMemRes(new std::pmr::unsynchronized_pool_resource()) // メモリ使用量が大きい為に使用しないで、CPoolResource を代わりに使う
-
+	: m_docLineMemRes(new CPoolResource<CDocLine>())
+	//: m_docLineMemRes(new std::pmr::unsynchronized_pool_resource()) // メモリ使用量が大きい為に使用しない
 {
 	_Init();
 }

--- a/sakura_core/doc/logic/CDocLineMgr.h
+++ b/sakura_core/doc/logic/CDocLineMgr.h
@@ -90,8 +90,7 @@ private:
 	CDocLine*	m_pDocLineTop;		//!< 最初の行
 	CDocLine*	m_pDocLineBot;		//!< 最後の行(※1行しかない場合はm_pDocLineTopと等しくなる)
 	CLogicInt	m_nLines;			//!< 全行数
-	std::pmr::unsynchronized_pool_resource m_docLinePool;
-	std::pmr::polymorphic_allocator<CDocLine> m_docLineAllocator;
+	std::unique_ptr<std::pmr::memory_resource> m_docLineMemRes;
 
 public:
 	//$$ kobake注: 以下、絶対に切り離したい（最低切り離せなくても、変数の意味をコメントで明確に記すべき）変数群

--- a/sakura_core/doc/logic/CDocLineMgr.h
+++ b/sakura_core/doc/logic/CDocLineMgr.h
@@ -21,12 +21,13 @@
 #define _CDOCLINEMGR_H_
 
 #include <Windows.h>
+#include <memory_resource>
 #include "_main/global.h" // 2002/2/10 aroka
 #include "basis/SakuraBasis.h"
 #include "util/design_template.h"
 #include "COpe.h"
+#include "CDocLine.h"
 
-class CDocLine; // 2002/2/10 aroka
 class CBregexp; // 2002/2/10 aroka
 
 struct DocLineReplaceArg {
@@ -89,6 +90,8 @@ private:
 	CDocLine*	m_pDocLineTop;		//!< 最初の行
 	CDocLine*	m_pDocLineBot;		//!< 最後の行(※1行しかない場合はm_pDocLineTopと等しくなる)
 	CLogicInt	m_nLines;			//!< 全行数
+	std::pmr::unsynchronized_pool_resource m_docLinePool;
+	std::pmr::polymorphic_allocator<CDocLine> m_docLineAllocator;
 
 public:
 	//$$ kobake注: 以下、絶対に切り離したい（最低切り離せなくても、変数の意味をコメントで明確に記すべき）変数群

--- a/sakura_core/mem/CPoolResource.h
+++ b/sakura_core/mem/CPoolResource.h
@@ -1,0 +1,136 @@
+﻿/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+
+#ifndef SAKURA_CPOOLRESOURCE_H_
+#define SAKURA_CPOOLRESOURCE_H_
+
+#include <memory_resource>
+#include <Windows.h>
+
+// std::pmr::unsynchronized_pool_resource だとメモリ使用量が大きい為、自前実装を用意
+// T : 要素型
+template <typename T>
+class CPoolResource : public std::pmr::memory_resource
+{
+public:
+	CPoolResource()
+	{
+		// 始めのブロックをメモリ確保
+		AllocateBlock();
+	}
+
+	virtual ~CPoolResource()
+	{
+		// メモリ確保した領域の連結リストを辿って全てのブロック分のメモリ解放
+		Node* curr = m_currentBlock;
+		while (curr) {
+			Node* next = curr->next;
+			VirtualFree(curr, 0, MEM_RELEASE);
+			curr = next;
+		}
+	}
+
+protected:
+	// 要素のメモリ確保処理、要素の領域のポインタを返す
+	// bytes と alignment 引数は使用しない、template 引数の型で静的に決定する
+ 	void* do_allocate([[maybe_unused]] std::size_t bytes,
+ 					  [[maybe_unused]] std::size_t alignment) override
+	{
+		// メモリ確保時には未割当領域から使用していく
+		if (m_unassignedNode) {
+			T* ret = reinterpret_cast<T*>(m_unassignedNode);
+			m_unassignedNode = m_unassignedNode->next;
+			return ret;
+		}
+		else {
+			// 未割当領域が無い場合は、ブロックの中から切り出す
+			// 現在のブロックに新規確保するNodeサイズ分の領域が余っていない場合は新規のブロックを確保
+			Node* blockEnd = reinterpret_cast<Node*>(reinterpret_cast<char*>(m_currentBlock) + BlockSize);
+			if (m_currentNode + 1 >= blockEnd) {
+				AllocateBlock();
+			}
+			// 要素の領域のポインタを返すと同時にポインタを次に進めて切り出す位置を更新する
+			return reinterpret_cast<T*>(m_currentNode++);
+		}
+	}
+
+	// メモリ解放処理、要素の領域のポインタを受け取る
+	// 第1引数には、do_allocate メソッドで返したポインタを渡す事
+	// bytes と alignment 引数は使用しない、template 引数の型で静的に決定する
+	void do_deallocate(void* p,
+					   [[maybe_unused]] std::size_t bytes,
+					   [[maybe_unused]] std::size_t alignment) override
+	{
+		if (p) {
+			// メモリ解放した領域を未割当領域として自己参照共用体の片方向連結リストで繋げる
+			// 次回のメモリ確保時にその領域を再利用する
+			Node* next = m_unassignedNode;
+			m_unassignedNode = reinterpret_cast<Node*>(p);
+			m_unassignedNode->next = next;
+		}
+	}
+
+	bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override
+	{
+		return this == &other;
+	}
+
+private:
+	static constexpr size_t BlockSize = 1024 * 64; // VirtualAlloc を使用する為このサイズ
+
+	// 共用体を使う事で要素型と自己参照用のポインタを同じ領域に割り当てる
+	// 共用体のサイズは各メンバを格納できるサイズになる事を利用する
+	union Node {
+		~Node() {}
+		T element;	// 要素型
+		Node* next; // ブロックのヘッダの場合は、次のブロックに繋がる
+					// 解放後の未割当領域の場合は次の未割当領域に繋がる
+	};
+	
+	static_assert(2 * sizeof(Node) <= BlockSize, "sizeof(T) too big.");
+
+	// 呼び出しの度にメモリの動的確保を細かく行う事を避ける為に、一括でブロック領域を確保
+	// ブロックの先頭(head)にはブロックの連結用のポインタが配置され、残る領域（body）には要素が記録される
+	void AllocateBlock()
+	{
+		char* buff = reinterpret_cast<char*>(VirtualAlloc(NULL, BlockSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
+		Node* next = m_currentBlock;
+		// ブロック領域の先頭（head）はNodeのポインタとして扱い、以前に作成したブロックに連結する
+		m_currentBlock = reinterpret_cast<Node*>(buff);
+		m_currentBlock->next = next;
+
+		// ブロック領域の残る部分は要素の領域とするが、アライメントを取る
+		void* body = buff + sizeof(Node*);
+		size_t space = BlockSize - sizeof(Node*);
+		body = std::align(alignof(Node), sizeof(Node), body, space);
+		assert(body);
+		m_currentNode = reinterpret_cast<Node*>(body);
+	}
+
+	Node* m_unassignedNode = nullptr; // 未割当領域の先頭
+	Node* m_currentBlock = nullptr; // 現在のブロック
+	Node* m_currentNode = nullptr; // 要素確保処理時に現在のブロックの中から切り出すNodeを指すポインタ、メモリ確保時に未割当領域が無い場合はここを使う
+};
+
+#endif /* SAKURA_CPOOLRESOURCE_H_ */

--- a/sakura_core/mem/CPoolResource.h
+++ b/sakura_core/mem/CPoolResource.h
@@ -115,6 +115,7 @@ private:
 	void AllocateBlock()
 	{
 		char* buff = reinterpret_cast<char*>(VirtualAlloc(NULL, BlockSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
+		if (!buff) throw std::bad_alloc();
 		Node* next = m_currentBlock;
 		// ブロック領域の先頭（head）はNodeのポインタとして扱い、以前に作成したブロックに連結する
 		m_currentBlock = reinterpret_cast<Node*>(buff);


### PR DESCRIPTION
# PR の目的

ログファイル等の行数が多いファイルを読んで表示するのに掛かる時間を減らす。

## カテゴリ

- 速度向上

## PR のメリット

行数が極端に多いファイルを開く時の待ち時間が短くなります。またメモリ使用量も少し減ります。あと分かりづらいですがそのファイルを閉じる時の時間も短くなります。

テストケースとしてちょっと極端な例ですが、a\r\n という行が 16777216行連続しているファイルを開いてから編集出来るようになるまでの待ち時間が短くなるのが体感できます。

そのファイルをzipで圧縮したもの → [test.zip](https://github.com/sakura-editor/sakura/files/2238195/test.zip)

自分の環境では以前は 7.8 秒ぐらい掛かっていたのが 6.7 秒ぐらいになりました。Visual Studio 2017 の Performance Profiler で起動して上記の大きいファイルを開いて確認しました。

## PR のデメリット (トレードオフとかあれば)

以前は極端に行数が多い状態を作った後に行数が短い状態を作るとメモリ解放が行われてメモリ使用量が減りましたが、このメモリプールを使うやり方にすると減りません。

メモリ解放のタイミングが `CDocLineMgr` や `CLayoutMgr` が解放されるタイミングになるので、エディタのプロセスを閉じるまでメモリプールのメモリ解放がされません。

実際のユースケース的にそれで困るという事はあんまり考えられない気もします。

## PR の影響範囲

`CDocLineMgr` と `CLayoutMgr`

## 関連チケット

#312 #980
