### PR TITLE
使用する言語規格に C++17 を指定

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -102,6 +102,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,6 +144,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -181,6 +183,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -219,6 +222,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -33,7 +33,8 @@ CFLAGS= \
  -fexec-charset=cp932 \
  -I. \
  $(DEFINES) $(MYCFLAGS)
-CXXFLAGS= $(CFLAGS) $(MYCXXFLAGS)
+CXXFLAGS= $(CFLAGS) $(MYCXXFLAGS) \
+ -std=c++17
 LIBS= \
  -static \
  -lwinspool \

--- a/sakura_core/macro/CWSH.cpp
+++ b/sakura_core/macro/CWSH.cpp
@@ -79,11 +79,11 @@ public:
 	{
 	}
 
-	virtual ULONG _stdcall AddRef() {
+	virtual ULONG STDMETHODCALLTYPE AddRef() {
 		return ++m_RefCount;
 	}
 
-	virtual ULONG _stdcall Release() {
+	virtual ULONG STDMETHODCALLTYPE Release() {
 		if(--m_RefCount == 0)
 		{
 			delete this;
@@ -221,7 +221,7 @@ public:
 	}
 
 	//	Sep. 15, 2005 FILE IActiveScriptSiteWindow実装
-	virtual HRESULT __stdcall GetWindow(
+	virtual HRESULT STDMETHODCALLTYPE GetWindow(
 	    /* [out] */ HWND *phwnd)
 	{
 		*phwnd = CEditWnd::getInstance()->m_cSplitterWnd.GetHwnd();
@@ -229,7 +229,7 @@ public:
 	}
 
 	//	Sep. 15, 2005 FILE IActiveScriptSiteWindow実装
-	virtual HRESULT __stdcall EnableModeless(
+	virtual HRESULT STDMETHODCALLTYPE EnableModeless(
 	    /* [in] */ BOOL fEnable)
 	{
 		return S_OK;


### PR DESCRIPTION
# PR の目的

C++17 以降で使えるようになる標準ライブラリのヘッダ等があるので、それらを使えるようにするのが目的です。

## カテゴリ

- その他

## 参考資料

C++17 は以前と何が違うのか？等の情報はぐぐってください。

Visual Studio 2017 の sakura プロジェクトのプロパティ画面で下記の場所で C++ 言語規格を指定出来ます。

![image](https://user-images.githubusercontent.com/1131125/62832527-dd7ca700-bc6a-11e9-832b-a6d7229b323b.png)

VC++ の言語規格への適応状況については下記のページにまとめられています。

https://docs.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=vs-2019
