### PR TITLE
「すべて置換」処理の高速化

### DIFF
--- a/sakura_core/cmd/CViewCommander_Search.cpp
+++ b/sakura_core/cmd/CViewCommander_Search.cpp
@@ -974,9 +974,8 @@ void CViewCommander::Command_REPLACE_ALL()
 	CLogicPoint boxRight;      // 矩形選択の現在の行の右端。sRangeA.GetTo().x ではなく boxRight.x + colDif を使う。
 	/*CLogicInt*/int		linOldLen = (0);	//検査後の行の長さ
 
-	int nLoopCnt = -1;
-	constexpr DWORD wndRefreshInterval = 16;
-	DWORD prevTime = GetTickCount() + wndRefreshInterval;
+	constexpr DWORD userInterfaceInterval = 16;
+	DWORD prevTime = GetTickCount() + userInterfaceInterval;
 	/* テキストが選択されているか */
 	while( (!bFastMode && m_pCommanderView->GetSelectionInfo().IsTextSelected())
 		|| ( bFastMode && cSelectLogic.IsValid() ) )
@@ -987,50 +986,44 @@ void CViewCommander::Command_REPLACE_ALL()
 			break;
 		}
 
-		/* 処理中のユーザー操作を可能にする */
-		if( !::BlockingHook( hwndCancel ) )
+		DWORD currTime = GetTickCount();
+		DWORD diffTime = currTime - prevTime;
+		// 前回の表示更新時刻から一定時間以上経過していた場合のみ処理する
+		// 頻繁に表示更新すると表示更新処理自体の処理時間が目立ってしまう為
+		if (diffTime >= userInterfaceInterval)
 		{
-			m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
-			::EnableWindow( m_pCommanderView->GetHwnd(), TRUE );
-			::EnableWindow( ::GetParent( m_pCommanderView->GetHwnd() ), TRUE );
-			::EnableWindow( ::GetParent( ::GetParent( m_pCommanderView->GetHwnd() ) ), TRUE );
-			return;// -1;
-		}
-
-		nLoopCnt++;
-		// 128 ごとに表示。
-		if( 0 == (nLoopCnt & 0x7F ) )
-		{
-			DWORD currTime = GetTickCount();
-			DWORD diffTime = currTime - prevTime;
-			// 前回の表示更新時刻から一定時間以上経過していた場合のみ表示更新する
-			// 頻繁に表示更新すると表示更新処理自体の処理時間が目立ってしまう為
-			if (diffTime >= wndRefreshInterval)
+			prevTime = currTime;
+			/* 処理中のユーザー操作を可能にする */
+			if( !::BlockingHook( hwndCancel ) )
 			{
-				prevTime = currTime;
-				if( bFastMode ){
-					int nDiff = nAllLineNumOrg - (Int)GetDocument()->m_cDocLineMgr.GetLineCount();
-					if( 0 <= nDiff ){
-						nNewPos = (nDiff + (Int)cSelectLogic.GetFrom().GetY2()) >> nShiftCount;
-					}else{
-						nNewPos = ::MulDiv((Int)cSelectLogic.GetFrom().GetY(), nAllLineNum, (Int)GetDocument()->m_cDocLineMgr.GetLineCount());
-					}
-				}else{
-					int nDiff = nAllLineNumOrg - (Int)GetDocument()->m_cLayoutMgr.GetLineCount();
-					if( 0 <= nDiff ){
-						nNewPos = (nDiff + (Int)GetSelect().GetFrom().GetY2()) >> nShiftCount;
-					}else{
-						nNewPos = ::MulDiv((Int)GetSelect().GetFrom().GetY(), nAllLineNum, (Int)GetDocument()->m_cLayoutMgr.GetLineCount());
-					}
-				}
-				if( nOldPos != nNewPos ){
-					Progress_SetPos( hwndProgress, nNewPos +1 );
-					Progress_SetPos( hwndProgress, nNewPos );
-					nOldPos = nNewPos;
-				}
-				_itot( nReplaceNum, szLabel, 10 );
-				::SendMessage( hwndStatic, WM_SETTEXT, 0, (LPARAM)szLabel );
+				m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
+				::EnableWindow( m_pCommanderView->GetHwnd(), TRUE );
+				::EnableWindow( ::GetParent( m_pCommanderView->GetHwnd() ), TRUE );
+				::EnableWindow( ::GetParent( ::GetParent( m_pCommanderView->GetHwnd() ) ), TRUE );
+				return;// -1;
 			}
+			if( bFastMode ){
+				int nDiff = nAllLineNumOrg - (Int)GetDocument()->m_cDocLineMgr.GetLineCount();
+				if( 0 <= nDiff ){
+					nNewPos = (nDiff + (Int)cSelectLogic.GetFrom().GetY2()) >> nShiftCount;
+				}else{
+					nNewPos = ::MulDiv((Int)cSelectLogic.GetFrom().GetY(), nAllLineNum, (Int)GetDocument()->m_cDocLineMgr.GetLineCount());
+				}
+			}else{
+				int nDiff = nAllLineNumOrg - (Int)GetDocument()->m_cLayoutMgr.GetLineCount();
+				if( 0 <= nDiff ){
+					nNewPos = (nDiff + (Int)GetSelect().GetFrom().GetY2()) >> nShiftCount;
+				}else{
+					nNewPos = ::MulDiv((Int)GetSelect().GetFrom().GetY(), nAllLineNum, (Int)GetDocument()->m_cLayoutMgr.GetLineCount());
+				}
+			}
+			if( nOldPos != nNewPos ){
+				Progress_SetPos( hwndProgress, nNewPos +1 );
+				Progress_SetPos( hwndProgress, nNewPos );
+				nOldPos = nNewPos;
+			}
+			_itot( nReplaceNum, szLabel, 10 );
+			::SendMessage( hwndStatic, WM_SETTEXT, 0, (LPARAM)szLabel );
 		}
 
 		// From Here 2001.12.03 hor


### PR DESCRIPTION
# PR の目的

「すべて置換」処理の高速化

## カテゴリ

- 速度向上

## PR の背景

検索ダイアログから実行する「すべて置換」処理において、処理中のユーザー操作（中止）を可能にするメッセージループ呼び出しや進捗表示更新がループ中でかなり頻繁に行われています。その為にその処理に結構時間が掛かってしまい「すべて置換」処理が完了するまでの時間が余計に長くなってしまっています。そこで、前回から一定時間の間隔を空けるように判定を追加する事で頻度を下げて高速化しました。

## PR のメリット

やけに行数が多いデータを「すべて置換」する処理に掛かる時間が短くなります。

ちょっと極端な例ですが自分の環境では、`a` という1行に1文字だけが 465万行ぐらい連続しているファイルを開いた後に `a` を `b` に全て置換する操作が完了するのに掛かる時間が変更前は 11 秒ぐらい掛かっていたのが 5 秒ぐらいに削減されました。

## PR のデメリット (トレードオフとかあれば)

特になし

強いていうならば、16ms の間隔を空けるようにしたのでレスポンスが微妙に悪くなったかもしれません。ただその微妙な差が使い勝手に影響する事は無いと思います。

## PR の影響範囲

`CViewCommander::Command_REPLACE_ALL` 関数

## 関連チケット

過去に #125 #77  で同じような問題（UI更新を頻繁に行い過ぎて処理時間を浪費している）に対する対策を入れています。
