### PR TITLE
CDocLine の容量削減

### DIFF
--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -36,7 +36,7 @@
 
 // 2002/09/22 Moca EOL_CRLF_UNICODEを廃止
 /* 行終端子の種類 */
-enum EEolType {
+enum EEolType : char {
 	EOL_NONE,			//!< 
 	EOL_CRLF,			//!< 0d0a
 	EOL_LF,				//!< 0a

--- a/sakura_core/charset/CCodeBase.h
+++ b/sakura_core/charset/CCodeBase.h
@@ -35,7 +35,7 @@ enum EConvertResult{
 class CMemory;
 class CNativeW;
 struct CommonSetting_Statusbar;
-enum EEolType;
+enum EEolType : char;
 
 /*!
 	文字コード基底クラス。

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -30,6 +30,8 @@
 class CDocLine;
 class COpeBlk;
 
+#pragma pack(push,1)
+
 //!	文書データ1行
 class CDocLine{
 protected:
@@ -98,7 +100,6 @@ private: //####
 	CDocLine*	m_pNext;	//!< 一つ後の要素
 private:
 	CNativeW	m_cLine;	//!< データ  2007.10.11 kobake ポインタではなく、実体を持つように変更
-	CEol		m_cEol;		//!< 行末コード
 public:
 	//拡張情報 $$分離中
 	struct MarkType{
@@ -108,9 +109,13 @@ public:
 		CLineDiffed		m_cDiffmarked;	//DIFF差分情報
 	};
 	MarkType m_sMark;
+private:
+	CEol		m_cEol;		//!< 行末コード
 
 	DISALLOW_COPY_AND_ASSIGN(CDocLine);
 };
+
+#pragma pack(pop)
 
 ///////////////////////////////////////////////////////////////////////
 #endif /* _CDOCLINE_H_ */

--- a/sakura_core/docplus/CDiffManager.h
+++ b/sakura_core/docplus/CDiffManager.h
@@ -35,7 +35,7 @@ class CDocLineMgr;
 class CGraphics;
 
 //! DIFF情報定数
-enum EDiffMark{
+enum EDiffMark : char {
 	MARK_DIFF_NONE		= 0,	//!< 無変更
 	MARK_DIFF_APPEND	= 1,	//!< 追加
 	MARK_DIFF_CHANGE	= 2,	//!< 変更

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -47,7 +47,9 @@ public:
 	CMemory();
 	CMemory(const CMemory& rhs);
 	CMemory(const void* pData, int nDataLenBytes);
-	virtual ~CMemory();
+	// デストラクタを仮想にすると仮想関数テーブルへのポインタを持つ為にインスタンスの容量が増えてしまうので仮想にしない
+	// 仮想デストラクタでは無いので派生クラスでメンバー変数を追加しない事
+	~CMemory();
 protected:
 	void _init_members();
 

--- a/sakura_core/mem/CNative.h
+++ b/sakura_core/mem/CNative.h
@@ -39,6 +39,9 @@ public:
 	void Clear(); //!< 空っぽにする
 };
 
+// 派生クラスでメンバー追加禁止
+static_assert(sizeof(CNative) == sizeof(CMemory), "size check");
+
 #include "mem/CNativeA.h"
 #include "mem/CNativeW.h"
 

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -207,6 +207,9 @@ public:
 		{ return GetHabaOfChar(cStr.GetPtr(), cStr.GetLength(), nIdx);}
 };
 
+// 派生クラスでメンバー追加禁止
+static_assert(sizeof(CNativeW) == sizeof(CNative), "size check");
+
 namespace std {
 template <>
 	inline void swap(CNativeW& n1, CNativeW& n2)


### PR DESCRIPTION
# PR の目的

`CDocLine` のインスタンスのサイズを削減する事でメモリ使用量を抑える

## カテゴリ

- その他

## PR の背景

行数の分だけ `CDocLine` のインスタンスが作成されるので行数が非常に多いファイルを開いたりするとその分だけ大量にメモリを使用します。

このPRでは x64 Release ビルドの場合に `sizeof(CDocLine)` を 56 から 40 に削減しました。インスタンス１つにつき16バイト減っているので16777216行あるファイルを開いた場合に消費されるメモリ使用量が256MiB削減される事になります。

どのようなやり方で `CDocLine` のサイズを削減したかについて下記に記載します。

容量を節約する為に一部の列挙型のサイズを1バイトにしたり、`CDocLine` クラスのメンバーの順序を入れ替えたりパディングを無しにして詰めました。

またメモリバッファクラス（`CMemory`）の容量を減らす為にデストラクタを仮想ではないように変更しました。仮想関数を持つとインスタンスに仮想関数テーブルへのポインタの隠しメンバがコンパイラによって自動的に挿入されるのでそれを避ける為です。メモリバッファクラスとその派生クラスはポリモーフィズムは使用していない為、不要と判断して削除しました。

`CNativeW` クラスにデバッグビルド時にデバッグ用のメンバー `m_pDebugData` が追加されていましたが、ウォッチウィンドウで書式指定すれば同じ事が実現出来るので不要と判断しました。

## PR のメリット

メモリ使用量が減ります。

## PR のデメリット (トレードオフとかあれば)

詰めて記録するようにした事により処理速度にわずかに悪影響が出るかもしれません（未確認）。

## PR の影響範囲

`CMemory`, `CNative`, `CNativeW` 関連<br>
`CDocLine` 関連

## 関連チケット

#985 ではメモリプールを使っていますがその変更もメモリ使用量を減らす効果が有ります。