### PR TITLE
C++の準拠規格をC++17に更新する

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -102,6 +102,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,6 +144,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -181,6 +183,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -219,6 +222,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -33,7 +33,9 @@ CFLAGS= \
  -fexec-charset=cp932 \
  -I. \
  $(DEFINES) $(MYCFLAGS)
-CXXFLAGS= $(CFLAGS) $(MYCXXFLAGS)
+CXXFLAGS= $(CFLAGS) \
+ -std=c++17 \
+ $(MYCXXFLAGS)
 LIBS= \
  -static \
  -lwinspool \

--- a/sakura_core/macro/CWSH.cpp
+++ b/sakura_core/macro/CWSH.cpp
@@ -79,11 +79,11 @@ public:
 	{
 	}
 
-	virtual ULONG _stdcall AddRef() {
+	virtual ULONG STDMETHODCALLTYPE AddRef() {
 		return ++m_RefCount;
 	}
 
-	virtual ULONG _stdcall Release() {
+	virtual ULONG STDMETHODCALLTYPE Release() {
 		if(--m_RefCount == 0)
 		{
 			delete this;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,10 @@ project (sakura-unittest)
 option(BUILD_GTEST "Build GoogleTest." ON)
 option(BUILD_SHARED_LIBS "Build shared libraries (DLLs)." OFF)
 
+enable_language(CXX)
+set(CMAKE_CXX_STANDARD 17)    # C++17...
+set(CMAKE_CXX_STANDARD_REQUIRED ON) #...is required...
+
 # switch DLL or static libary by specifying by command line
 set (LIB_TYPE STATIC)
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
# PR の目的

C++のコンパイラオプションを追加することにより、C++17規格のコーディングを行えるようにします。同時に、準拠規格の変更により発生するビルドエラーを修正します。

- C++ 11/14/17 で出来ることを最低限を把握するための参考リンク
  - https://qiita.com/leon-joel/items/81415c1ef355c6246280
    - 構造化束縛 = 2つ以上の戻り値を返す仕組み
    - 入れ子名前空間 = `namespace my::mem::allocation {}` を可能にする仕組み 
- C++17 とは何ぞや？ をざっくり理解するための参考リンク
  - https://cpprefjp.github.io/lang/cpp17.html
    - ざっくりとした改廃機能一覧があるので、ここを見れば大枠が把握できます。
    - Technical Specifications について記載があります。
- 困ったときの Wikipedia
  - https://ja.wikipedia.org/wiki/C%2B%2B17
    - 最新規格すぎて現状ではあまり頼りにならない...orz

こんだけ書いとけば、嵐のように ggrks を連発しても大丈夫でしょう・・・。


## カテゴリ

- ビルド環境(実装言語の変更)
- リファクタリング
- その他


## PR のメリット

現代の標準C++規格に則ったコーディングを行えるようになります。
C++17は現状の最新規格で、言語機能を強化するためのいくつかのライブラリが追加されています。


## PR のデメリット (トレードオフとかあれば)

サクラエディタが最初に書かれた当初の規格はC89/90(MS独自仕様)です。
歴史的には C++98, C++03, C++11, C++14, C++17 と多くの改訂が行われていて、最終的に廃止となった機能が多く存在しています。

std::auto_ptrやregisterキーワードなど、C++規格から削除された仕様に依存するコードがあるので、それらについておって対応が必要と考えられます。
　⇒　エラーにはならないみたいなので、ぼちぼち対応していけばよいと考えています。

最新規格に追随することにより、経験のある優秀なプログラマの書いたコードが、時代遅れのうんこコードに見えてしまう状況を生み出す恐れがあります。


## PR の影響範囲

機能的な影響はおそらく発生しません。
影響のあるなしだけを語れば、C/C++コード全般に影響します。
修正対象は、コンパイラオプションの変更と、変更によりエラーが発生する箇所のみです。


## 関連チケット

#986 使用する言語規格に C++17 を指定
#985 メモリプールを使う事でメモリ確保と解放を高速化 ← このPRに依存
#893 [WIP] SDLチェックを有効にする ← 関連
