### PR TITLE
COM関数のシグニチャを標準に合わせて訂正する

### DIFF
--- a/sakura_core/macro/CWSH.cpp
+++ b/sakura_core/macro/CWSH.cpp
@@ -221,7 +221,7 @@ public:
 	}
 
 	//	Sep. 15, 2005 FILE IActiveScriptSiteWindow実装
-	virtual HRESULT __stdcall GetWindow(
+	virtual HRESULT STDMETHODCALLTYPE GetWindow(
 	    /* [out] */ HWND *phwnd)
 	{
 		*phwnd = CEditWnd::getInstance()->m_cSplitterWnd.GetHwnd();
@@ -229,7 +229,7 @@ public:
 	}
 
 	//	Sep. 15, 2005 FILE IActiveScriptSiteWindow実装
-	virtual HRESULT __stdcall EnableModeless(
+	virtual HRESULT STDMETHODCALLTYPE EnableModeless(
 	    /* [in] */ BOOL fEnable)
 	{
 		return S_OK;


### PR DESCRIPTION
# PR の目的

COM関数のシグニチャをWindows SDK標準に合わせて訂正します。

誤）　`virtual HRESULT __stdcall GetWindow(`
正）　`virtual HRESULT STDMETHODCALLTYPE GetWindow(`

`STDMETHODCALLTYPE` と `__stdcall` はおおむね同じ意味に解釈されますが、Windows SDK は `STDMETHODCALLTYPE` で統一されています。書き方をSDKに合わせることによって、これがCOM関数の実装であることが明確になると思います。また、誤って `_stdcall` と記載してしまう事態を防止できると考えます。


## カテゴリ

- リファクタリング

## PR の背景

#986 を元に #989 を作成する過程で発見した小改善です。
#989 には、ビルドエラーを解消する対策のみを含めたため、この修正が溢れました。


## PR のメリット

自明だと思うので省略します。


## PR のデメリット (トレードオフとかあれば)

とくにありません。


## PR の影響範囲

人間がコードを読むときの読みやすさに影響します。
アプリ（＝サクラエディタ）の機能には影響しません。


## 関連チケット

#986
#989

