### PR TITLE
ThreadProcのシグニチャを訂正する

### DIFF
--- a/sakura_core/macro/CWSH.cpp
+++ b/sakura_core/macro/CWSH.cpp
@@ -293,7 +293,8 @@ typedef struct {
 } SAbortMacroParam;
 
 // WSHマクロ実行を中止するスレッド
-static unsigned __stdcall AbortMacroProc( LPVOID lpParameter )
+// @see https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms686736(v=vs.85)
+static DWORD WINAPI AbortMacroProc( LPVOID lpParameter )
 {
 	SAbortMacroParam* pParam = (SAbortMacroParam*) lpParameter;
 


### PR DESCRIPTION
# PR の目的

ThreadProcのシグニチャを Windows SDK 標準に合わせて訂正します。
https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms686736(v=vs.85)

誤）　`unsigned __stdcall AbortMacroProc( LPVOID lpParameter )`
正）　`DWORD WINAPI AbortMacroProc( LPVOID lpParameter )`

- unsigned は unsigned int(32ビット符号なし整数型) の略記。
- DWORD は Windows SDK の固有定義で32ビット符号なし整数型を表す。
- __stdcall は 32bit版MSCコンパイラにstdcall呼出規約を指示するキーワード。
- WINAPI は Windows API と同じ呼出規約を指示するためのキーワード。
  - 32bit版MSCコンパイラ向けの実態は `__stdcall`なので、実質は同じ。


## カテゴリ

- リファクタリング

## PR の背景

#986 を元に #989 を作成する過程で発見した小改善です。

`__stdcall` を使っている箇所が他にないかチェックした結果、
この「誤りとはいえないが正しくはない記述」を発見した次第です。


## PR のメリット

自明だと思うので省略します。


## PR のデメリット (トレードオフとかあれば)

とくにありません。


## PR の影響範囲

人間がコードを読むときの読みやすさに影響します。
アプリ（＝サクラエディタ）の機能には影響しません。


## 関連チケット

#986
#989

