### PR TITLE
ファイル読み込み時のステータスバー上のプログレスバー更新やメッセージ配送処理の呼び出しは時間経過を契機に行う方式に変更

### DIFF
--- a/sakura_core/CReadManager.cpp
+++ b/sakura_core/CReadManager.cpp
@@ -105,7 +105,7 @@ EConvertResult CReadManager::ReadFile_To_CDocLineMgr(
 		CNativeW		cUnicodeBuffer;
 		EConvertResult	eRead;
 		constexpr DWORD timeInterval = 33;
-		DWORD nextTime = GetTickCount() + timeInterval;
+		ULONGLONG nextTime = GetTickCount64() + timeInterval;
 		while( RESULT_FAILURE != (eRead = cfl.ReadLine( &cUnicodeBuffer, &cEol )) ){
 			if(eRead==RESULT_LOSESOME){
 				eRet = RESULT_LOSESOME;
@@ -114,7 +114,7 @@ EConvertResult CReadManager::ReadFile_To_CDocLineMgr(
 			int		nLineLen = cUnicodeBuffer.GetStringLength();
 			CDocEditAgent(pcDocLineMgr).AddLineStrX( pLine, nLineLen );
 			//経過通知
-			DWORD currTime = GetTickCount();
+			ULONGLONG currTime = GetTickCount64();
 			if(currTime >= nextTime){
 				nextTime += timeInterval;
 				NotifyProgress(cfl.GetPercent());

--- a/sakura_core/CReadManager.cpp
+++ b/sakura_core/CReadManager.cpp
@@ -101,20 +101,22 @@ EConvertResult CReadManager::ReadFile_To_CDocLineMgr(
 
 		// ReadLineはファイルから 文字コード変換された1行を読み出します
 		// エラー時はthrow CError_FileRead を投げます
-		int				nLineNum = 0;
 		CEol			cEol;
 		CNativeW		cUnicodeBuffer;
 		EConvertResult	eRead;
+		constexpr DWORD timeInterval = 33;
+		DWORD nextTime = GetTickCount() + timeInterval;
 		while( RESULT_FAILURE != (eRead = cfl.ReadLine( &cUnicodeBuffer, &cEol )) ){
 			if(eRead==RESULT_LOSESOME){
 				eRet = RESULT_LOSESOME;
 			}
 			const wchar_t*	pLine = cUnicodeBuffer.GetStringPtr();
 			int		nLineLen = cUnicodeBuffer.GetStringLength();
-			++nLineNum;
 			CDocEditAgent(pcDocLineMgr).AddLineStrX( pLine, nLineLen );
 			//経過通知
-			if(nLineNum%512==0){
+			DWORD currTime = GetTickCount();
+			if(currTime >= nextTime){
+				nextTime += timeInterval;
 				NotifyProgress(cfl.GetPercent());
 				// 処理中のユーザー操作を可能にする
 				if( !::BlockingHook( NULL ) ){


### PR DESCRIPTION
# PR の目的

ファイル読み込みの処理時間を減らす為の対応です。

`CReadManager::ReadFile_To_CDocLineMgr` において `NotifyProgress` メソッドと `BlockingHook` 関数の呼び出しを 512行おきに行うのではなく前回から33ミリ秒以上経過したという条件に変更しました。

## カテゴリ

- 速度向上

## PR の背景

Visual Studio 2017 の Performance Profiler でファイル読み込み処理のどこに時間が掛かっているかを確認したところ、ステータスバー上に表示するプログレスバーの更新処理に思ったより処理時間が掛かっていました。

比率は全体の 1% 程度と僅かですがそれでも処理内容からすると時間が掛かり過ぎていると思ったので調べてみました。すると512行おきに `NotifyProgress` メソッドや `BlockingHook` 関数の呼び出しを行っている事が分かりました。この判定方法だと1行の文字数は短いけれどやけに行数が多いファイルを読み込んだ際には必要以上に呼び出される事になり、行数は少ないけれど1行の文字数がやたらと多いファイルを読み込んだ際には表示更新があまり行われない事になります。現実の利用状況ではそのような動きを体感するような事はあまりない（そんなファイルを開くことは滅多にない）と思いますが、経過時間で判定する方が挙動としては好ましくなると考えているので変更しました。

## PR のメリット

行数が多いファイルの場合に読み込みに掛かる時間がほんのわずかだと思いますが短縮されます。

プログレスバーの表示更新を一定の経過時間に応じて行う方式にしたので、様々なケースのファイルを開いた場合でも表示更新の間隔がより近くなり自然な動作になります。

## PR のデメリット (トレードオフとかあれば)

特になし

時間を取得するWindowsAPIの呼び出しコストは有る程度小さいので問題にならないと思います。

## PR の影響範囲

`CReadManager::ReadFile_To_CDocLineMgr` 関数

## 関連チケット

#987
