### PR TITLE
CViewSelect::PrintSelectionInfoMsg の高速化、及び行のEOL長を取得する処理の高速化

### DIFF
--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -46,18 +46,7 @@ const EEolType gm_pnEolTypeArr[EOL_TYPE_NUM] = {
 //	固定データ
 //-----------------------------------------------
 
-struct SEolDefinition{
-	const TCHAR*	m_szName;
-	const WCHAR*	m_szDataW;
-	const ACHAR*	m_szDataA;
-	int				m_nLen;
-
-	bool StartsWith(const WCHAR* pData, int nLen) const{ return m_nLen<=nLen && 0==auto_memcmp(pData,m_szDataW,m_nLen); }
-	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==auto_memcmp(pData,m_szDataA,m_nLen); }
-};
-
-/* g_aEolLengths といっしょに保守する事 */
-static const SEolDefinition g_aEolTable[] = {
+const SEolDefinition g_aEolTable[] = {
 	{ _T("改行無"),	L"",			"",			0 },
 	{ _T("CRLF"),	L"\x0d\x0a",	"\x0d\x0a",	2 },
 	{ _T("LF"),		L"\x0a",		"\x0a",		1 },

--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -55,6 +55,8 @@ struct SEolDefinition{
 	bool StartsWith(const WCHAR* pData, int nLen) const{ return m_nLen<=nLen && 0==auto_memcmp(pData,m_szDataW,m_nLen); }
 	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==auto_memcmp(pData,m_szDataA,m_nLen); }
 };
+
+/* g_aEolLengths といっしょに保守する事 */
 static const SEolDefinition g_aEolTable[] = {
 	{ _T("改行無"),	L"",			"",			0 },
 	{ _T("CRLF"),	L"\x0d\x0a",	"\x0d\x0a",	2 },
@@ -128,12 +130,6 @@ EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
 //-----------------------------------------------
 //	実装部
 //-----------------------------------------------
-
-//! 現在のEOL長を取得。文字単位。
-CLogicInt CEol::GetLen() const
-{
-	return CLogicInt(g_aEolTable[ m_eEolType ].m_nLen);
-}
 
 //! 現在のEOLの名称取得
 const TCHAR* CEol::GetName() const

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -48,6 +48,18 @@ enum EEolType {
 	EOL_UNKNOWN = -1	//
 };
 
+/* 行終端子の長さ */
+/* g_aEolTable といっしょに保守する事 */
+static const uint8_t g_aEolLengths[] = {
+	0,
+	2,
+	1,
+	1,
+	1,
+	1,
+	1,
+};
+
 #define EOL_TYPE_NUM	EOL_CODEMAX // 8
 
 /* 行終端子の配列 */
@@ -90,7 +102,7 @@ public:
 
 	//取得
 	EEolType		GetType()	const{ return m_eEolType; }		//!< 現在のTypeを取得
-	CLogicInt		GetLen()	const;	//!< 現在のEOL長を取得。文字単位。
+	CLogicInt		GetLen()	const { return CLogicInt(g_aEolLengths[ m_eEolType ]); }	//!< 現在のEOL長を取得。文字単位。
 	const TCHAR*	GetName()	const;	//!< 現在のEOLの名称取得
 	const wchar_t*	GetValue2()	const;	//!< 現在のEOL文字列先頭へのポインタを取得
 	//#####

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -48,17 +48,16 @@ enum EEolType {
 	EOL_UNKNOWN = -1	//
 };
 
-/* 行終端子の長さ */
-/* g_aEolTable といっしょに保守する事 */
-static const uint8_t g_aEolLengths[] = {
-	0,
-	2,
-	1,
-	1,
-	1,
-	1,
-	1,
+struct SEolDefinition{
+	const TCHAR*	m_szName;
+	const WCHAR*	m_szDataW;
+	const ACHAR*	m_szDataA;
+	int				m_nLen;
+
+	bool StartsWith(const WCHAR* pData, int nLen) const{ return m_nLen<=nLen && 0==auto_memcmp(pData,m_szDataW,m_nLen); }
+	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==auto_memcmp(pData,m_szDataA,m_nLen); }
 };
+extern const SEolDefinition g_aEolTable[];
 
 #define EOL_TYPE_NUM	EOL_CODEMAX // 8
 
@@ -102,7 +101,7 @@ public:
 
 	//取得
 	EEolType		GetType()	const{ return m_eEolType; }		//!< 現在のTypeを取得
-	CLogicInt		GetLen()	const { return CLogicInt(g_aEolLengths[ m_eEolType ]); }	//!< 現在のEOL長を取得。文字単位。
+	CLogicInt		GetLen()	const { return CLogicInt(g_aEolTable[ m_eEolType ].m_nLen); }	//!< 現在のEOL長を取得。文字単位。
 	const TCHAR*	GetName()	const;	//!< 現在のEOLの名称取得
 	const wchar_t*	GetValue2()	const;	//!< 現在のEOL文字列先頭へのポインタを取得
 	//#####


### PR DESCRIPTION
# PR の目的

選択範囲情報メッセージの表示処理を速くする事でレスポンスを上げるのが目的です。

ステータスバーを表示している場合は選択範囲の文字数がそこに表示されます。

`CViewSelect::PrintSelectionInfoMsg` メソッドは選択範囲情報メッセージを作成してステータスバーに表示する処理ですが、そこの記述を更新しました。主に最適化したのは選択文字数をカウントする処理です。

## カテゴリ

- 速度向上

## PR の背景

ステータスバーを表示している場合の選択範囲操作のレスポンスが上がります。

2^24 (16777216) 行あるファイルを開いた後に、Ctrl + A を押して全選択した後に Shift キーを押しながらカーソルキーを押して選択範囲を変更すると結構操作のレスポンスが良くない事が確認出来ます。

実はこのPRの変更よりも #985 を適用した後の方が効果が高いです。それはレイアウト情報の確保をメモリプールを使って行っているので（メモリの利用効率が良くなった為に）キャッシュヒット率が向上している為と考えられます。

[Mery](https://www.haijin-boys.com/software/mery) というテキストエディタがありますが、このテキストエディタは様々な操作に掛かる時間がサクラエディタより大分高速です。

最近の一連のPRでパフォーマンスの改善を行う事で速度差を縮める事が出来ればと考えています。

このPRでの細かい変更内容について記載します。

従来実装では `CLayoutMgr::GetLineStr` メソッドが使われていましたが、`CLayoutMgr::SearchLineByLayoutY` メソッドで置き換えました。
取得した値のうちレイアウトデータしか使っていなかったので、`CLayoutMgr::GetLineStr` メソッドは使うまでも無いと判断したからです。

`CEol::GetLen` メソッドもアプリケーションの色々なところから呼び出されているのでインライン化されるようにヘッダ側に記述を移しました。
行終端子の長さのテーブルもヘッダファイル `CEol.h` 側に用意しました。`CEol.cpp` ファイルにある `g_aEolTable` 配列と一部内容が重複しているので保守の手間が増えますが処理時間を削減するには必要な事です。

## PR のメリット

ステータスバーを表示しているケースで、行数が多い文書を扱っている際の範囲選択操作のレスポンスを改善します。

## PR のデメリット (トレードオフとかあれば)

`CEol::GetLen` メソッドをインライン化する為にヘッダーファイルにテーブルを新規追加したので保守の手間が増えます。

## PR の影響範囲

`CViewSelect::PrintSelectionInfoMsg` メソッド関連

`CEol::GetLen` メソッド関連

## 関連チケット

#985

