### PR TITLE
MinGWビルドのpch利用を中断する

### DIFF
--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -34,7 +34,7 @@ PATH=%PATH:C:\Program Files\Git\bin;=%
 path=C:\msys64\mingw64\bin;%path%
 
 @echo mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%"
-mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" githash stdafx Funccode_enum.h Funccode_define.h
+mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" githash.h Funccode_enum.h Funccode_define.h
 if errorlevel 1 (
 	echo error 1 errorlevel %errorlevel%
 	exit /b 1

--- a/build.md
+++ b/build.md
@@ -182,8 +182,7 @@ x86_64 | posix | sjlj | pthreadのDLLが必要
 コマンド実行例
 
 ```
-path=D:\eclipse4.6\eclipse\mingw\bin;%path%
-cd sakura_core
-mingw32-make githash stdafx sakura_rc.o
-mingw32-make -j4
+path=C:\msys64\mingw64\bin;%path%
+mingw32-make -C sakura_core githash.h Funccode_enum.h Funccode_define.h
+mingw32-make -C sakura_core -j4
 ```

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -438,7 +438,7 @@ HEADERMAKE= $(HEADERMAKETOOLDIR)/HeaderMake.exe
 
 all: $(exe)
 
-$(exe): githash $(OBJS)
+$(exe): $(OBJS)
 	$(CXX) -o $@ $(OBJS) $(LIBS)
 
 Funccode_define.h: $(HEADERMAKE) Funccode_x.hsrc
@@ -447,25 +447,22 @@ Funccode_define.h: $(HEADERMAKE) Funccode_x.hsrc
 Funccode_enum.h: $(HEADERMAKE) Funccode_x.hsrc
 	$(HEADERMAKE) -in=../sakura_core/Funccode_x.hsrc -out=../sakura_core/Funccode_enum.h -mode=enum -enum=EFunctionCode
 
-githash:
+githash.h:
 	"$(CURDIR)/../sakura/githash.bat" ../sakura_core
 
-stdafx: Funccode_enum.h StdAfx.h
-	$(CXX) $(CXXFLAGS) -c StdAfx.h
-
-.cpp.o: stdafx
+.cpp.o: githash.h Funccode_enum.h
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 $(HEADERMAKE): $(HEADERMAKETOOLDIR)/HeaderMake.cpp
 	$(CXX) $(CXXFLAGS) $(HEADERMAKETOOLDIR)/HeaderMake.cpp -o $@ -static-libgcc
 
-sakura_rc.o: Funccode_define.h githash sakura_rc.rc
+sakura_rc.o: githash.h Funccode_define.h sakura_rc.rc
 	$(RC) -c utf-8 --language=0411 $(DEFINES) sakura_rc.rc -o $@
 
 clean:
 	$(RM) $(exe) $(OBJS) $(HEADERMAKE) StdAfx.h.gch $(GENERATED_FILES) depend.mak
 
-depend: Funccode_enum.h githash
+depend: githash.h Funccode_enum.h
 	$(CXX) -E -MM -w $(DEFINES) $(CXXFLAGS) *.cpp > depend.mak
 
 .SUFFIXES: .cpp .o .rc


### PR DESCRIPTION
# PR の目的

MinGWビルドのpch利用を中断して、azure pipelinesのビルドエラーを回避します。

## カテゴリ

- CI関連
  - Azure Pipelines


## PR の背景

azure pipelinesに引っ越ししたMinGWビルドがエラーでコケています。

原因は不明です。

エラーメッセージを読む限り、pch読取に使うMapViewOfFileがエラーを返しているようなのですが、ローカルビルドでは再現しないエラーなので原因は分からないままです。

分かっていることは１つ、pchの処理中にエラーが起きているということです。

CI環境がエラーでコケているのを放っておくのもよくないので、一時的にpchの利用を止めておきたいと思います。


## PR のメリット

azure pipelinesのビルドエラーが起きなくなります。

## PR のデメリット (トレードオフとかあれば)

pch(=プリコンパイル済みヘッダー)の利用をやめる影響で、ビルド速度が遅くなります。
実績のビルド時間は19分ですが、ギリギリでappveyorより速いので許容範囲と思っています。

## PR の影響範囲

MinGWビルド。
アプリ（＝サクラエディタ）の機能に影響はありません。


## 関連チケット

#985 これの影響でビルドがコケている
#993 これの影響でビルドがコケている 

## 参考資料

とくになし
