### PR TITLE
Debugger Visualizer(.natvis) を導入する

### DIFF
--- a/sakura/sakura.natvis
+++ b/sakura/sakura.natvis
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="CNativeW">
+    <DisplayString Condition="m_pRawData == 0">empty</DisplayString>
+    <DisplayString Condition="m_pRawData != 0">{m_pRawData,su}</DisplayString>
+    <Expand>
+      <Item Condition="m_pRawData != 0" Name="_Data">m_pRawData,su</Item>
+      <Item Name="_Length">m_nRawLen / 2</Item>
+      <Item Name="_Size">m_nDataBufSize / 2</Item>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -976,6 +976,9 @@
     <ClCompile Include="..\sakura_core\_os\CDropTarget.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <Natvis Include="sakura.natvis" />
+  </ItemGroup>
+  <ItemGroup>
     <Image Include="..\resource\auto_scroll_center.bmp" />
     <Image Include="..\resource\auto_scroll_horizontal.bmp" />
     <Image Include="..\resource\auto_scroll_vertical.bmp" />

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -2296,4 +2296,7 @@
       <Filter>Cpp Source Files\util</Filter>
     </Text>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="sakura.natvis" />
+  </ItemGroup>
 </Project>

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -96,12 +96,6 @@ public:
 	}
 	int capacity() const { return m_nDataBufSize ? m_nDataBufSize - 2: 0; }
 
-#ifdef _DEBUG
-protected:
-	typedef char* PCHAR;
-	PCHAR& _DebugGetPointerRef(){ return m_pRawData; } //デバッグ用。バッファポインタの参照を返す。
-#endif
-
 private: // 2002/2/10 aroka アクセス権変更
 	/*
 	|| メンバ変数

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -8,33 +8,21 @@
 //               コンストラクタ・デストラクタ                  //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 CNativeW::CNativeW()
-#if _DEBUG
-: m_pDebugData((PWCHAR&)_DebugGetPointerRef())
-#endif
 {
 }
 
 CNativeW::CNativeW(const CNativeW& rhs)
-#if _DEBUG
-: m_pDebugData((PWCHAR&)_DebugGetPointerRef())
-#endif
 {
 	SetNativeData(rhs);
 }
 
 //! nDataLenは文字単位。
 CNativeW::CNativeW( const wchar_t* pData, int nDataLen )
-#if _DEBUG
-: m_pDebugData((PWCHAR&)_DebugGetPointerRef())
-#endif
 {
 	SetString(pData,nDataLen);
 }
 
 CNativeW::CNativeW( const wchar_t* pData)
-#if _DEBUG
-: m_pDebugData((PWCHAR&)_DebugGetPointerRef())
-#endif
 {
 	SetString(pData,wcslen(pData));
 }

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -189,12 +189,6 @@ public:
 	const TCHAR* GetStringT() const						{ return GetStringPtrOld(); }
 #endif
 
-#if _DEBUG
-private:
-	typedef wchar_t* PWCHAR;
-	PWCHAR& m_pDebugData; //デバッグ用。CMemoryの内容をwchar_t*型でウォッチするためのモノ
-#endif
-
 public:
 	// -- -- staticインターフェース -- -- //
 	static CLogicInt GetSizeOfChar( const wchar_t* pData, int nDataLen, int nIdx ); //!< 指定した位置の文字がwchar_t何個分かを返す


### PR DESCRIPTION
# PR の目的

`Debugger Visualizer(.natvis)` を導入することにより、
デバッグ用のモニター変数を用意しなくても、任意型のデータを参照できるようにします。

.natvis活用の具体例として、CNativeWのデバッグ専用メンバm_pDebugDataを置き換えます。

  - CNativeW は UNICODE 文字列を保持する文字列バッファクラス
  - CNativeW のバッファは、基本クラスCMemoryのバッファ(char*型)を流用している
    - char*型バッファをwchar_t*型バッファに見せるための機構が存在していた
      - .natvisを使うと、char*型バッファをwchar_t*型バッファとして表示できる
        - このPRは .natvisでchar*型バッファをwchar_t*型バッファとして表示させる設定例を提供する
      - バッファ型読み替えのための機構は、.natvis導入によって不要になる
        - このPRは不要となるCNativeW::m_pDebugDataとCMemory::_DebugGetPointerRef()を削除する
          - CNativeWは多量に確保されるクラスなので、ポインタ変数を削ると使用メモリ削減の効果があります。


## カテゴリ

- リファクタリング
- その他


## PR の背景

元ネタは #988 `CDocLine の容量削減` です。

容量削減のためデバッグ用モニター変数が純粋削除されようとしていたので、代替を提供するべく.natvisの話が出てきました :smile:


## PR のメリット

プログラム的なデータ構造と、デバッグ表示を別物として扱うことができるようになります。
（モニター変数を用意しなくても、任意型のデータを参照できるようになります。）

既存のモニター変数を躊躇なく削ることができます :smile:

## PR のデメリット (トレードオフとかあれば)

実質的なデメリットはないと思います。

.natvis非対応のビルド環境(MinGW-w64-gccなど)にとっては、単にDebug用参照変数を削る変更になります。
元来、本流でないビルド環境を使って開発を行うには、それなりの技術が必要なので「影響なし」と考えてよいと思います。


## PR の影響範囲

アプリ（＝サクラエディタ）のデバッグに影響します。
アプリの機能には影響しません。

## 関連チケット

#988
#782

## 参考資料

https://blogs.msdn.microsoft.com/vcblog/2015/09/28/debug-visualizers-in-visual-c-2015/
https://devblogs.microsoft.com/cppblog/project-support-for-natvis/
