### PR TITLE
[WIP] CGraphics 関連の最適化

### DIFF
--- a/sakura_core/uiparts/CGraphics.h
+++ b/sakura_core/uiparts/CGraphics.h
@@ -143,16 +143,31 @@ struct SFONT {
 //最新実装：ブラシ
 class CGraphics{
 public:
-	CGraphics(const CGraphics& rhs){ Init(rhs.m_hdc); }
-	CGraphics(HDC hdc = NULL){ Init(hdc); }
+	CGraphics(const CGraphics& rhs){
+		if (rhs.m_hdc) {
+			m_hdcOrg = rhs.m_hdc;
+			m_dcState = SaveDC(m_hdcOrg);
+		}else {
+			m_hdcOrg = NULL;
+			m_dcState = 0;
+		}
+		Init(rhs.m_hdc);
+	}
+	CGraphics(HDC hdc = NULL){
+		if (hdc) {
+			m_hdcOrg = hdc;
+			m_dcState = SaveDC(hdc);
+		}else {
+			m_hdcOrg = NULL;
+			m_dcState = 0;
+		}
+		Init(hdc);
+	}
 	~CGraphics();
-	void Init(HDC hdc);
 
 	operator HDC() const{ return m_hdc; }
 
 	//クリッピング
-private:
-	void _InitClipping();
 public:
 	void PushClipping(const RECT& rc);
 	void PopClipping();
@@ -202,10 +217,6 @@ public:
 		m_nTextModeOrg.AssignOnce( ::SetBkMode(m_hdc,b?TRANSPARENT:OPAQUE) );
 	}
 
-	//テキスト
-public:
-	void RestoreTextColors();
-
 	//フォント
 public:
 	void PushMyFont(HFONT hFont)
@@ -252,7 +263,6 @@ public:
 
 	//ブラシ
 public:
-	void _InitBrushColor();
 	void PushBrushColor(
 		COLORREF color	//!< ブラシの色。(COLORREF)-1 にすると、透明ブラシとなる。
 	);
@@ -305,7 +315,10 @@ private:
 	typedef TOriginalHolder<COLORREF>	COrgColor;
 	typedef TOriginalHolder<int>		COrgInt;
 private:
+	void Init(HDC hdc);
 	HDC					m_hdc;
+	HDC					m_hdcOrg;
+	int					m_dcState;
 
 	//クリッピング
 	std::vector<HRGN>		m_vClippingRgns;
@@ -319,12 +332,10 @@ private:
 	COrgInt				m_nTextModeOrg;
 
 	//ペン
-	HPEN				m_hpnOrg;
 	std::vector<HPEN>	m_vPens;
 
 	//ブラシ
 	std::vector<HBRUSH>	m_vBrushes;
-	HBRUSH				m_hbrOrg;
 	HBRUSH				m_hbrCurrent;
 	bool				m_bDynamicBrush;	//m_hbrCurrentを動的に作成した場合はtrue
 };

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -240,7 +240,7 @@ public:
 protected:
 	//! ロジック行を1行描画
 	bool DrawLogicLine(
-		SColorStrategyInfo* pInfo,		//!< [in,out] 作画対象
+		SColorStrategyInfo* pInfo,		//!< [in,out] 作画情報
 		CLayoutInt		nLineTo			//!< [in]     作画終了するレイアウト行番号
 	);
 

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -240,8 +240,7 @@ public:
 protected:
 	//! ロジック行を1行描画
 	bool DrawLogicLine(
-		HDC				hdc,			//!< [in]     作画対象
-		DispPos*		pDispPos,		//!< [in,out] 描画する箇所、描画元ソース
+		SColorStrategyInfo* pInfo,		//!< [in,out] 作画対象
 		CLayoutInt		nLineTo			//!< [in]     作画終了するレイアウト行番号
 	);
 

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -779,6 +779,9 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 			sPos.ForwardLayoutLineRef(1);	//レイアウト行＋＋
 		}
 	}else{
+		SColorStrategyInfo sInfo(gr);
+		sInfo.m_pDispPos = &sPos;
+		sInfo.m_pcView = this;
 		while(sPos.GetLayoutLineRef() <= nLayoutLineTo)
 		{
 			//描画X位置リセット
@@ -786,8 +789,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 
 			//1行描画
 			bool bDispResult = DrawLogicLine(
-				gr,
-				&sPos,
+				&sInfo,
 				nLayoutLineTo
 			);
 
@@ -871,17 +873,12 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 	@date 2007.08.31 kobake 引数 bDispBkBitmap を削除
 */
 bool CEditView::DrawLogicLine(
-	HDC				_hdc,			//!< [in]     作画対象
-	DispPos*		_pDispPos,		//!< [in,out] 描画する箇所、描画元ソース
+	SColorStrategyInfo* pInfo,		//!< [in,out] 作画情報
 	CLayoutInt		nLineTo			//!< [in]     作画終了するレイアウト行番号
 )
 {
 //	MY_RUNNINGTIMER( cRunningTimer, "CEditView::DrawLogicLine" );
 	bool bDispEOF = false;
-	SColorStrategyInfo _sInfo(_hdc);
-	SColorStrategyInfo* pInfo = &_sInfo;
-	pInfo->m_pDispPos = _pDispPos;
-	pInfo->m_pcView = this;
 
 	//CColorStrategyPool初期化
 	CColorStrategyPool* pool = CColorStrategyPool::getInstance();

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -878,9 +878,8 @@ bool CEditView::DrawLogicLine(
 {
 //	MY_RUNNINGTIMER( cRunningTimer, "CEditView::DrawLogicLine" );
 	bool bDispEOF = false;
-	SColorStrategyInfo _sInfo;
+	SColorStrategyInfo _sInfo(_hdc);
 	SColorStrategyInfo* pInfo = &_sInfo;
-	pInfo->m_gr.Init(_hdc);
 	pInfo->m_pDispPos = _pDispPos;
 	pInfo->m_pcView = this;
 

--- a/sakura_core/view/CEditView_Paint_Bracket.cpp
+++ b/sakura_core/view/CEditView_Paint_Bracket.cpp
@@ -125,8 +125,7 @@ void CEditView::DrawBracketPair( bool bDraw )
 		return;
 	}
 
-	CGraphics gr;
-	gr.Init(::GetDC(GetHwnd()));
+	CGraphics gr(::GetDC(GetHwnd()));
 	bool bCaretChange = false;
 	gr.SetTextBackTransparent(true);
 

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -86,7 +86,14 @@ struct CColor3Setting {
 };
 
 struct SColorStrategyInfo{
-	SColorStrategyInfo() : m_sDispPosBegin(0,0), m_pStrategy(NULL), m_pStrategyFound(NULL), m_pStrategySelect(NULL), m_colorIdxBackLine(COLORIDX_TEXT) {
+	SColorStrategyInfo(HDC hDC = NULL)
+		: m_sDispPosBegin(0,0)
+		, m_pStrategy(NULL)
+		, m_pStrategyFound(NULL)
+		, m_pStrategySelect(NULL)
+		, m_colorIdxBackLine(COLORIDX_TEXT)
+		, m_gr(hDC)
+	{
 		m_cIndex.eColorIndex = COLORIDX_TEXT;
 		m_cIndex.eColorIndex2 = COLORIDX_TEXT;
 		m_cIndex.eColorIndexBg = COLORIDX_TEXT;


### PR DESCRIPTION
# PR の目的

描画処理を高速化してCPU負荷を減らすのが目的です。

## カテゴリ

- 速度向上
- リファクタリング

## PR の背景

従来実装では `CGraphics` クラスの構築時にクリッピング領域の取得操作が毎回行われており、その処理にいくらか時間を浪費していました。

各種GDIオブジェクトの保存と復帰処理の実装がいくらか煩雑な記述になっていました。このPRでは SaveDC と RestoreDC を使う事で保存復帰処理を単純化しました。

追記：while ループ内で呼び出す `CEditView::DrawLogicLine` メソッド内で `CGraphics` 型のインスタンスの生成と破棄を 行うのはコストが高いので、ループの外に用意して使いまわすようにしました。

## PR のメリット

描画処理が少し速くなります、体感で分かるかというと微妙かもです…。

`CGraphics` クラスの実装がシンプルになります。

## PR のデメリット (トレードオフとかあれば)

特にないはずです。

## PR の影響範囲

描画処理で `CGraphics` を使用している箇所

## 関連チケット

強いて挙げるなら #699
