### PR TITLE
vs2017ソリューションにテストプロジェクトを組み込みたい Take2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.iobj
 *.ipdb
 *.pyc
+**/packages
+**/TestResults
 .sonarqube
 /*.patch
 /.vs

--- a/sakura.sln
+++ b/sakura.sln
@@ -13,6 +13,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sakura_lang_en_US", "sakura
 		{AF03508C-515E-4A0E-87BE-67ED1E254BD0} = {AF03508C-515E-4A0E-87BE-67ED1E254BD0}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tests1", "tests\unittests\tests1.vcxproj", "{701E3407-EC27-49F7-ADC7-520CF2B4B438}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -53,6 +55,14 @@ Global
 		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Release|Win32.Build.0 = Release|Win32
 		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Release|x64.ActiveCfg = Release|x64
 		{7A6D0F29-E560-4985-835B-5F92A08EB242}.Release|x64.Build.0 = Release|x64
+		{701E3407-EC27-49F7-ADC7-520CF2B4B438}.Debug|Win32.ActiveCfg = Debug|Win32
+		{701E3407-EC27-49F7-ADC7-520CF2B4B438}.Debug|Win32.Build.0 = Debug|Win32
+		{701E3407-EC27-49F7-ADC7-520CF2B4B438}.Debug|x64.ActiveCfg = Debug|x64
+		{701E3407-EC27-49F7-ADC7-520CF2B4B438}.Debug|x64.Build.0 = Debug|x64
+		{701E3407-EC27-49F7-ADC7-520CF2B4B438}.Release|Win32.ActiveCfg = Release|Win32
+		{701E3407-EC27-49F7-ADC7-520CF2B4B438}.Release|Win32.Build.0 = Release|Win32
+		{701E3407-EC27-49F7-ADC7-520CF2B4B438}.Release|x64.ActiveCfg = Release|x64
+		{701E3407-EC27-49F7-ADC7-520CF2B4B438}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -16,9 +16,16 @@ if not exist "%~dp0googletest\CMakeLists.txt" (
 	"%CMD_GIT%" submodule update %~dp0googletest || endlocal && exit /b 1
 )
 
+set GENERATOR=
+
 @rem call vcvasall.bat when we run in the Visual Studio IDE.
 if defined VCVARSALL_PATH (
 	call %VCVARSALL_PATH% %VCVARS_ARCH% || endlocal && exit /b 1
+)
+
+where ninja.exe > NUL 2>&1
+if not errorlevel 1 (
+	set GENERATOR=-G "Ninja"
 )
 
 @rem find cl.exe in the PATH
@@ -31,7 +38,7 @@ if not defined CMD_CL (
 )
 set CMD_CL=%CMD_CL:\=/%
 
-cmake -G "Ninja" -DCMAKE_BUILD_TYPE=%CONFIGURATION%  ^
+cmake %GENERATOR% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
   "-DCMAKE_C_COMPILER=%CMD_CL%"                      ^
   "-DCMAKE_CXX_COMPILER=%CMD_CL%"                    ^
   -DBUILD_GMOCK=OFF                                  ^

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -29,9 +29,8 @@ if not errorlevel 1 (
 )
 
 @rem find cl.exe in the PATH
-for /f "usebackq delims=" %%a in (`where cl.exe`) do ( 
-    set CMD_CL=%%a
-)
+call :find_cl_exe
+
 if not defined CMD_CL (
 	echo cl.exe was not found.
 	endlocal && exit /b 1
@@ -50,3 +49,9 @@ cmake %GENERATOR% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
 cmake --build . || endlocal && exit /b 1
 
 endlocal && exit /b 0
+
+:find_cl_exe
+for /f "usebackq delims=" %%a in (`where cl.exe`) do (
+    set CMD_CL=%%a
+    goto :EOF
+)

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -1,0 +1,45 @@
+@rem echo off
+setlocal
+set SOURCE_DIR=%1
+set CONFIGURATION=%2
+set VCVARSALL_PATH=%3
+set VCVARS_ARCH=%4
+
+if not defined CMD_GIT call %~dp0..\tools\find-tools.bat
+if not defined CMD_GIT (
+	echo git.exe was not found.
+	endlocal && exit /b 1
+)
+
+if not exist "%~dp0googletest\CMakeLists.txt" (
+	"%CMD_GIT%" submodule init   %~dp0googletest || endlocal && exit /b 1
+	"%CMD_GIT%" submodule update %~dp0googletest || endlocal && exit /b 1
+)
+
+@rem call vcvasall.bat when we run in the Visual Studio IDE.
+if defined VCVARSALL_PATH (
+	call %VCVARSALL_PATH% %VCVARS_ARCH% || endlocal && exit /b 1
+)
+
+@rem find cl.exe in the PATH
+for /f "usebackq delims=" %%a in (`where cl.exe`) do ( 
+    set CMD_CL=%%a
+)
+if not defined CMD_CL (
+	echo cl.exe was not found.
+	endlocal && exit /b 1
+)
+set CMD_CL=%CMD_CL:\=/%
+
+cmake -G "Ninja" -DCMAKE_BUILD_TYPE=%CONFIGURATION%  ^
+  "-DCMAKE_C_COMPILER=%CMD_CL%"                      ^
+  "-DCMAKE_CXX_COMPILER=%CMD_CL%"                    ^
+  -DBUILD_GMOCK=OFF                                  ^
+  -Dgtest_build_tests=OFF                            ^
+  -Dgtest_build_samples=OFF                          ^
+  %SOURCE_DIR%                                       ^
+  || endlocal && exit /b 1
+
+cmake --build . || endlocal && exit /b 1
+
+endlocal && exit /b 0

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -1,0 +1,53 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="GoogleTest">
+    <GoogleTestSourceDir>$(MSBuildThisFileDirectory)googletest\</GoogleTestSourceDir>
+    <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\$(Platform)\$(Configuration)\googletest\</GoogleTestBuildDir>
+    <IncludePath>$(GoogleTestSourceDir)googletest\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(GoogleTestBuildDir)\lib;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Label="GoogleTest.Requirements">
+    <ClCompile>
+      <PreprocessorDefinitions>_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Label="GoogleTest.Libs" Condition="'$(Configuration)' == 'Debug'">
+    <Link>
+      <AdditionalDependencies>gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Label="GoogleTest.Libs" Condition="'$(Configuration)' == 'Release'">
+    <Link>
+      <AdditionalDependencies>gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup Label="GoogleTest.Pdbs" Condition="'$(Configuration)' == 'Debug'">
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtestd.pdb" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_maind.pdb" />
+  </ItemGroup>
+  <ItemGroup Label="GoogleTest.Pdbs" Condition="'$(Configuration)' == 'Release'">
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest.pdb" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_main.pdb" />
+  </ItemGroup>
+  <Target Name="BuildGoogleTest" BeforeTargets="ClCompile">
+    <PropertyGroup>
+      <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'x86' And '$(PlatformTarget)' == 'x86'">x86</VcVarsArchitecture>
+      <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'x86' And '$(PlatformTarget)' == 'x64'">x86_amd64</VcVarsArchitecture>
+      <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x86'">amd64_x86</VcVarsArchitecture>
+      <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x64'">amd64</VcVarsArchitecture>
+    </PropertyGroup>
+    <MakeDir Condition="!Exists('$(GoogleTestBuildDir)')" Directories="$(GoogleTestBuildDir)" />
+    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) $(Configuration) &quot;$(VCInstallDir)Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
+  </Target>
+  <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
+    <!-- Add files to @Clean just before running CoreClean. -->
+    <ItemGroup>
+      <Clean Include="$(OutDir)gtestd.pdb" />
+      <Clean Include="$(OutDir)gtest_maind.pdb" />
+      <Clean Include="$(OutDir)gtest.pdb" />
+      <Clean Include="$(OutDir)gtest_main.pdb" />
+    </ItemGroup>
+    <RemoveDir Directories="$(GoogleTestBuildDir)" />
+  </Target>
+</Project>

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -45,6 +45,7 @@
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{701e3407-ec27-49f7-adc7-520cf2b4b438}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(ProjectDir)..\..\vcx-props\vcxcompat.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros">
+    <OutDir>(ProjectDir)..\..\..\build\$(Platform)\$(Configuration)\unittests\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <Import Project="$(ProjectDir)..\googletest.targets" />
+  <ItemDefinitionGroup Label="tests1.common">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir)sakura_core;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <LargeAddressAware>true</LargeAddressAware>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>X64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Link Include="$(SolutionDir)sakura\$(Platform)\$(Configuration)\*.obj" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="test-cmemory.cpp" />
+    <ClCompile Include="test-cnative.cpp" />
+    <ClCompile Include="test-int2dec.cpp" />
+    <ClCompile Include="test-is_mailaddress.cpp" />
+    <ClCompile Include="test-mydevmode.cpp" />
+    <ClCompile Include="test-parameterized.cpp" />
+    <ClCompile Include="test-sample-disabled.cpp" />
+    <ClCompile Include="test-sample.cpp" />
+    <ClCompile Include="test-StdControl.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(ProjectDir)..\..\sakura\sakura.vcxproj">
+      <Project>{af03508c-515e-4a0e-87be-67ed1e254bd0}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Test Files">
+      <UniqueIdentifier>{690c7184-b796-460a-8fed-595dfa1930f4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Deprecated Codes">
+      <UniqueIdentifier>{594146a8-ae7c-401b-a064-af37dac4216e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Other Files">
+      <UniqueIdentifier>{0eefa0df-ca7f-489c-9844-9a182e1dba18}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt">
+      <Filter>Other Files</Filter>
+    </Text>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="test-cmemory.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-cnative.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-int2dec.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-is_mailaddress.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-mydevmode.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-parameterized.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-sample.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-sample-disabled.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-StdControl.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
# PR の目的

vs2017ソリューションにテストプロジェクトを組み込むことにより、
テストコードを従来より簡単に実行できるようにします。


## 経緯

あえて省略 :smiley:

目的や実現方法の妥当性判断にあたり必要な情報ではないと考えるので、今回は割愛します。
（情報量が多すぎて、何が目的でどう実現するのか、の把握の邪魔になると思うので）


## カテゴリ

- ビルド手順 (バッチを叩かなくてもテストを実行できるようになります)
- CI関連
  - Appveyor
  - Azure Pipelines
- その他 (googletestのビルドに使うジェネレータが変更になります)


## PR のメリット

- visual studio の IDE から直接テストのデバッグ実行ができるようになります。
  - テストコードと被テストコードが同じソリューション内に収まるので、デバッグ効率の改善を期待できます。


## PR のデメリット (トレードオフとかあれば)

- 新しいテストの追加時に、テストプロジェクトのメンテが必要になります。
  - 従来は cmake がビルド対象を拾ってくれる仕組みになっていました。

変更は、ソリューションにテストプロジェクトを組み込むことを最優先に作成しています。
従来のテストバッチとの互換性について「エラーにならないように」以上の配慮を行っていません。
テストバッチのフロー整理、重複タスクの排除などの改善は、別途行う必要があると思います。


## PR の影響範囲

- ソリューション内にテストプロジェクトが追加されます。
  - テスト対象コードとテストコードが同一ソリューション内に収まることにより、開発効率の改善を期待できます。
- テストプロジェクトのプロジェクトファイルが追加されます。
  - 新しいテストの追加時、既存テストの廃止時にメンテが必要になります。
- visual studio の IDE から直接テストのデバッグができるようになります。
  - 注：従来構成でも cmake が生成した sln を開けばデバッグは可能でしたが、手順が減ります。
- visual studio の IDE からもテストの実行ができるようになります。
  - テスト結果の確認、失敗したテストにジャンプなど、Test Explorer の機能を活用できるようになります。
  - 注：従来構成でも cmake が生成した sln を開けば(ry
- googletest のビルドに使うジェネレータが Ninja に変わります。
  - 変更前は Visual Stdio 15 2017 ジェネレータが使われていました。
  - 検証 #956 に基づき、ビルド速度の速い Ninja を採用します。
  - 最終的に使われるC++コンパイラが同じなので、影響はないと思います。
- テストモジュールの機能に影響はありません。
- アプリ（＝サクラエディタ）の機能に影響はありません。


## 関連チケット

close #793 vs2017ソリューションにテストを組み込みたい
#796 [WIP] vs2017ソリューションにテストを組み込みたい ← このPRで置換します。
#943 DISABLED テストのサンプルを追加する ← 入れてね、と依頼されている。対応済み。
#944 fixture テストのサンプルを追加する ← 入れたい、と要望があった。取り下げられたので対応してません。
#956 【検証】忍者 vs Visual Studio 15 2017 ← Ninja採用に至った経緯です。

