### PR TITLE
googletestのビルドに使うジェネレータをお任せにしないように変える

### DIFF
--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -1,10 +1,9 @@
-@rem echo off
 setlocal
 set SOURCE_DIR=%1
-set GENERATOR=%2
-set CONFIGURATION=%3
+set GENERATOR=%~2
+set CONFIGURATION=%~3
 set VCVARSALL_PATH=%4
-set VCVARS_ARCH=%5
+set VCVARS_ARCH=%~5
 
 if not defined CMD_GIT call %~dp0..\tools\find-tools.bat
 if not defined CMD_GIT (
@@ -37,12 +36,12 @@ if not defined CMD_CL (
 set CMD_CL=%CMD_CL:\=/%
 
 cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
-  "-DCMAKE_C_COMPILER=%CMD_CL%"                      ^
-  "-DCMAKE_CXX_COMPILER=%CMD_CL%"                    ^
-  -DBUILD_GMOCK=OFF                                  ^
-  -Dgtest_build_tests=OFF                            ^
-  -Dgtest_build_samples=OFF                          ^
-  %SOURCE_DIR%                                       ^
+  "-DCMAKE_C_COMPILER=%CMD_CL%"                           ^
+  "-DCMAKE_CXX_COMPILER=%CMD_CL%"                         ^
+  -DBUILD_GMOCK=OFF                                       ^
+  -Dgtest_build_tests=OFF                                 ^
+  -Dgtest_build_samples=OFF                               ^
+  %SOURCE_DIR%                                            ^
   || endlocal && exit /b 1
 
 cmake --build . || endlocal && exit /b 1

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -44,7 +44,7 @@ cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
   %SOURCE_DIR%                                            ^
   || endlocal && exit /b 1
 
-cmake --build . || endlocal && exit /b 1
+cmake --build . --config %CONFIGURATION% || endlocal && exit /b 1
 
 endlocal && exit /b 0
 

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -1,9 +1,10 @@
 @rem echo off
 setlocal
 set SOURCE_DIR=%1
-set CONFIGURATION=%2
-set VCVARSALL_PATH=%3
-set VCVARS_ARCH=%4
+set GENERATOR=%2
+set CONFIGURATION=%3
+set VCVARSALL_PATH=%4
+set VCVARS_ARCH=%5
 
 if not defined CMD_GIT call %~dp0..\tools\find-tools.bat
 if not defined CMD_GIT (
@@ -16,8 +17,6 @@ if not exist "%~dp0googletest\CMakeLists.txt" (
 	"%CMD_GIT%" submodule update %~dp0googletest || endlocal && exit /b 1
 )
 
-set GENERATOR=
-
 @rem call vcvasall.bat when we run in the Visual Studio IDE.
 if defined VCVARSALL_PATH (
 	call %VCVARSALL_PATH% %VCVARS_ARCH% || endlocal && exit /b 1
@@ -25,7 +24,7 @@ if defined VCVARSALL_PATH (
 
 where ninja.exe > NUL 2>&1
 if not errorlevel 1 (
-	set GENERATOR=-G "Ninja"
+	set GENERATOR=Ninja
 )
 
 @rem find cl.exe in the PATH
@@ -37,7 +36,7 @@ if not defined CMD_CL (
 )
 set CMD_CL=%CMD_CL:\=/%
 
-cmake %GENERATOR% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
+cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
   "-DCMAKE_C_COMPILER=%CMD_CL%"                      ^
   "-DCMAKE_CXX_COMPILER=%CMD_CL%"                    ^
   -DBUILD_GMOCK=OFF                                  ^

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -38,13 +38,15 @@
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x64'">amd64</VcVarsArchitecture>
       <NumVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioVersion)', '^(\d+).*', '$1'))</NumVersion>
       <NextVersion>$([MSBuild]::Add($(NumVersion), 1))</NextVersion>
+      <GeneratorSurfix Condition="'$(PlatformTarget)' == 'x86'"></GeneratorSurfix>
+      <GeneratorSurfix Condition="'$(PlatformTarget)' == 'x64'"> Win64</GeneratorSurfix>
     </PropertyGroup>
     <MakeDir Condition="!Exists('$(GoogleTestBuildDir)')" Directories="$(GoogleTestBuildDir)" />
     <Message Text="Cheking product line version of the Visual Studio." Importance="high" />
     <Exec Command="&quot;$(VSInstallDir)..\..\Installer\vswhere.exe&quot; -version [$(NumVersion),$(NextVersion)] -property catalog_productLineVersion" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ProductLineVersion" />
     </Exec>
-    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;Visual Studio $(NumVersion) $(ProductLineVersion)&quot; $(Configuration) &quot;$(VCInstallDir)Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
+    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;Visual Studio $(NumVersion) $(ProductLineVersion)$(GeneratorSurfix)&quot; $(Configuration) &quot;$(VCInstallDir)Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
   </Target>
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <!-- Add files to @Clean just before running CoreClean. -->

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -42,15 +42,15 @@
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x64'">amd64</VcVarsArchitecture>
       <NumVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioVersion)', '^(\d+).*', '$1'))</NumVersion>
       <NextVersion>$([MSBuild]::Add($(NumVersion), 1))</NextVersion>
-      <GeneratorSurfix Condition="'$(PlatformTarget)' == 'x86'"></GeneratorSurfix>
-      <GeneratorSurfix Condition="'$(PlatformTarget)' == 'x64'"> Win64</GeneratorSurfix>
+      <GeneratorSuffix Condition="'$(PlatformTarget)' == 'x86'"></GeneratorSuffix>
+      <GeneratorSuffix Condition="'$(PlatformTarget)' == 'x64'"> Win64</GeneratorSuffix>
     </PropertyGroup>
     <MakeDir Condition="!Exists('$(GoogleTestBuildDir)')" Directories="$(GoogleTestBuildDir)" />
     <Message Text="Cheking product line version of the Visual Studio." Importance="high" />
     <Exec Command="&quot;$(VSInstallDir)..\..\Installer\vswhere.exe&quot; -version [$(NumVersion),$(NextVersion)] -property catalog_productLineVersion" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ProductLineVersion" />
     </Exec>
-    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;Visual Studio $(NumVersion) $(ProductLineVersion)$(GeneratorSurfix)&quot; $(Configuration) &quot;$(VCInstallDir)Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
+    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;Visual Studio $(NumVersion) $(ProductLineVersion)$(GeneratorSuffix)&quot; $(Configuration) &quot;$(VSInstallRoot)/VC/Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
   </Target>
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <!-- Add files to @Clean just before running CoreClean. -->

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -3,7 +3,7 @@
     <GoogleTestSourceDir>$(MSBuildThisFileDirectory)googletest\</GoogleTestSourceDir>
     <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\$(Platform)\$(Configuration)\googletest\</GoogleTestBuildDir>
     <IncludePath>$(GoogleTestSourceDir)googletest\include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(GoogleTestBuildDir)\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(GoogleTestBuildDir)\lib;$(GoogleTestBuildDir)\lib\$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Label="GoogleTest.Requirements">
     <ClCompile>
@@ -23,12 +23,16 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup Label="GoogleTest.Pdbs" Condition="'$(Configuration)' == 'Debug'">
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtestd.pdb" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_maind.pdb" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtestd.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtestd.pdb')" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_maind.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest_maind.pdb')" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtestd.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtestd.pdb')" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_maind.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_maind.pdb')" />
   </ItemGroup>
   <ItemGroup Label="GoogleTest.Pdbs" Condition="'$(Configuration)' == 'Release'">
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest.pdb" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_main.pdb" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest.pdb')" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_main.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest_main.pdb')" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest.pdb')" />
+    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main.pdb')" />
   </ItemGroup>
   <Target Name="BuildGoogleTest" BeforeTargets="ClCompile">
     <PropertyGroup>

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -36,9 +36,15 @@
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'x86' And '$(PlatformTarget)' == 'x64'">x86_amd64</VcVarsArchitecture>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x86'">amd64_x86</VcVarsArchitecture>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x64'">amd64</VcVarsArchitecture>
+      <NumVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioVersion)', '^(\d+).*', '$1'))</NumVersion>
+      <NextVersion>$([MSBuild]::Add($(NumVersion), 1))</NextVersion>
     </PropertyGroup>
     <MakeDir Condition="!Exists('$(GoogleTestBuildDir)')" Directories="$(GoogleTestBuildDir)" />
-    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) $(Configuration) &quot;$(VCInstallDir)Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
+    <Message Text="Cheking product line version of the Visual Studio." Importance="high" />
+    <Exec Command="&quot;$(VSInstallDir)..\..\Installer\vswhere.exe&quot; -version [$(NumVersion),$(NextVersion)] -property catalog_productLineVersion" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="ProductLineVersion" />
+    </Exec>
+    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;Visual Studio $(NumVersion) $(ProductLineVersion)&quot; $(Configuration) &quot;$(VCInstallDir)Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
   </Target>
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <!-- Add files to @Clean just before running CoreClean. -->


### PR DESCRIPTION
# PR の目的

googletestのビルドに使うジェネレータを選択する仕組みを修正して、
vs2017とvs2019が両方インストールされたPCでもテストのビルドができるようにします。


## カテゴリ

- ビルド手順
  - vs2019 IDE からのビルド
- CI関連
  - Appveyor (実質的には影響ありません。)
  - Azure Pipelines (実質的には影響ありません。)


## PR の背景

#999 で入れたテストプロジェクトのビルドに問題があることが分かりました。
https://github.com/sakura-editor/sakura/pull/999#issuecomment-522293786

vs2017とvs2019の両方がインストールされている端末で、googletestのビルドに失敗する、という問題が発生しています。

原因
PATHにNinjaが居ないとき、CMakeジェネレータを指定していなかった。

対策
googletestのCMakeジェネレータを常に指定するように修正します。


## PR のメリット

ビルドが通るようになります。


## PR のデメリット (トレードオフとかあれば)

とくにありません。


## PR の影響範囲

- MSVC版のテストのビルドに影響します。
- vs2017とvs2019が両方インストールされた端末で、かつ、Ninjaがインストールされていない、かつ、優先がvs2019になっている場合にビルドに失敗する問題が解消できます。


## 関連チケット

#999

