### PR TITLE
テストの起動バッチを変更する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ build_script:
 
 # to run our custom scripts instead of automatic tests
 test_script:
-  - cmd: tests\build-and-test.bat %PLATFORM% %CONFIGURATION%
+  - cmd: tests\run-tests.bat %PLATFORM% %CONFIGURATION%
 
 matrix:
   exclude:

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -50,7 +50,7 @@ jobs:
     displayName: Zip files for artifacts
 
   # Unit tests
-  - script: tests\build-and-test.bat $(BuildPlatform) $(Configuration)
+  - script: tests\run-tests.bat $(BuildPlatform) $(Configuration)
     displayName: Unit test
 
   # see https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/copy-files?view=azure-devops&tabs=yaml


### PR DESCRIPTION
# PR の目的

テスト起動に使うバッチファイルを変更することにより、
テストのために2重ビルドが走る状況を解消してビルド時間を短縮します。


## カテゴリ

- CI関連
  - Appveyor (MSVC版のビルド)
  - Azure Pipelines (MSVC版のビルド)


## PR の背景

#999 でテストプロジェクトをソリューションに組み込んだ影響で、
テスト起動時に叩くバッチ(tests/build-and-test.bat) により2度目のビルドが走っています。

バッチファイル名 | 役割
-- | --
tests/build-and-test.bat | テストのビルドと実行を行う
tests/run-tests.bat | テストの実行を行う


## PR のメリット

CI環境でのビルドが速くなります。


## PR のデメリット (トレードオフとかあれば)

とくにありません。


## PR の影響範囲

CI環境でのビルド


## 関連チケット

#999
#893
