### PR TITLE
文字列リテラルを格納する型の誤りを訂正

### DIFF
--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -589,7 +589,7 @@ void CViewCommander::Command_OPEN_COMMAND_PROMPT(BOOL isAdmin)
 		return;
 	}
 
-	LPWSTR pVerb = L"open";
+	LPCWSTR pVerb = L"open";
 	if (isAdmin)
 	{
 		pVerb = L"runas";
@@ -633,7 +633,7 @@ void CViewCommander::Command_OPEN_POWERSHELL(BOOL isAdmin)
 	cmdExeParam.AppendStringF(L"-NoExit -Command \"Set-Location -Path '%s'\"", strFolder.c_str());
 	LPCWSTR pszcmdExeParam = cmdExeParam.GetStringPtr();
 
-	LPWSTR pVerb = L"open";
+	LPCWSTR pVerb = L"open";
 	if (isAdmin)
 	{
 		pVerb = L"runas";


### PR DESCRIPTION
# PR の目的

C++的に好ましくない記述を訂正することにより、
サクラエディタのコードの品質をわずかに向上させます。

何が好ましくないのかは後述します...orz


## カテゴリ

- リファクタリング


## PR の背景

この PR は #893 SDLチェックを有効にする の抜き出しです。

SDLチェックは、visual studio が本来持っている bad code 検出機構です。
#872(開発環境をvs2017に対応させる)の一環として、SDLチェックを有効にしようとしています。

SDLチェックを有効にすると bad code 臭いコードがビルドエラーになります。
考えなしに有効にしてみんなで路頭に迷うのも寒いので、事前に bad code を除去する試みをしたいと考えています。


## 修正される bad code の内容

C++の強化された型付け規則では、
変更可能な文字列ポインタに文字列リテラルへのポインタを代入できません。

```c++
char* buf1 = "read only"; //← 1, NG
const char* buf2 = "read only"; //← 2, OK
char buf3[] = "read only"; //← 3, OK
```

1. 文字列リテラルの実態は変更不可のコードブロックに置かれます。変更不可領域を指す、変更可能ポインタを宣言できてはおかしいので、最近のC++コンパイラではこの書き方がエラーになります。
2. 変更不可の文字列を参照する、変更不可のポインタを宣言する書き方なので正しいです。
3. 文字列リテラルを基にしてスタック上に変更可能な文字配列を作成する書き方なので正しいです。

PRでは 1 を 2 に修正して、問題のないコードにします。

ぶっちゃけるとぼくがレビューで見落としたコーディングバグの修正なんですよね・・・(ﾏﾃ


## PR のメリット

サクラエディタのコード品質をわずかに向上させることができます。


## PR のデメリット (トレードオフとかあれば)

ありません。


## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響がある変更です。
  - ただし、実害はないと考えられます。
- 機能 コマンドプロンプトで開く
  - 実質的な機能影響はないと考えられます。
- 機能 PowerShellで開く
  - 実質的な機能影響はないと考えられます。


## 関連チケット

#618 管理者としてコマンドプロンプトを開くメニュー項目を追加
#872 開発環境をvs2017に対応させる
#893 SDLチェックを有効にする の抜き出しです。
