### PR TITLE
C++規格で非推奨となった関数名を置換する

### DIFF
--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -25,7 +25,7 @@
 
 #include "StdAfx.h"
 #include <time.h>
-#include <io.h>	// access
+#include <io.h>	// _access
 #include "CBackupAgent.h"
 #include "window/CEditWnd.h"
 #include "util/format.h" //GetDateTimeFormat

--- a/sakura_core/CKeyWordSetMgr.cpp
+++ b/sakura_core/CKeyWordSetMgr.cpp
@@ -399,7 +399,7 @@ int CKeyWordSetMgr::SearchKeyWord2( int nIdx, const wchar_t* pszKeyWord, int nKe
 	int pl = m_nStartIdx[nIdx];
 	int pr = m_nStartIdx[nIdx] + m_nKeyWordNumArr[nIdx] - 1;
 	int pc = (pr + 1 - pl) / 2 + pl;
-	int (*const cmp)(const wchar_t*, const wchar_t*, size_t) = m_bKEYWORDCASEArr[nIdx] ? wcsncmp : wcsnicmp;
+	int (*const cmp)(const wchar_t*, const wchar_t*, size_t) = m_bKEYWORDCASEArr[nIdx] ? wcsncmp : _wcsnicmp;
 	while( pl <= pr ) {
 		const int ret = cmp( pszKeyWord, m_szKeyWordArr[pc], nKeyWordLen );
 		if( 0 < ret ) {

--- a/sakura_core/CKeyWordSetMgr.cpp
+++ b/sakura_core/CKeyWordSetMgr.cpp
@@ -354,7 +354,7 @@ void CKeyWordSetMgr::SortKeyWord( int nIdx )
 			m_szKeyWordArr[m_nStartIdx[nIdx]],
 			m_nKeyWordNumArr[nIdx],
 			sizeof(m_szKeyWordArr[0]),
-			(qsort_callback)wcsicmp
+			(qsort_callback)_wcsicmp
 		);
 	}
 	KeywordMaxLen(nIdx);

--- a/sakura_core/CReadManager.cpp
+++ b/sakura_core/CReadManager.cpp
@@ -23,7 +23,7 @@
 		   distribution.
 */
 #include "StdAfx.h"
-#include <io.h>	// access
+#include <io.h>	// _access
 #include "CReadManager.h"
 #include "CEditApp.h"	// CAppExitException
 #include "window/CEditWnd.h"

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -416,7 +416,7 @@ bool CNormalProcess::InitializeProcess()
 	LPCWSTR pszMacro = CCommandLine::getInstance()->GetMacro();
 	if( pEditWnd->GetHwnd()  &&  pszMacro  &&  pszMacro[0] != L'\0' ){
 		LPCWSTR pszMacroType = CCommandLine::getInstance()->GetMacroType();
-		if( pszMacroType == NULL || pszMacroType[0] == L'\0' || wcsicmp(pszMacroType, L"file") == 0 ){
+		if( pszMacroType == NULL || pszMacroType[0] == L'\0' || _wcsicmp(pszMacroType, L"file") == 0 ){
 			pszMacroType = NULL;
 		}
 		CEditView& view = pEditWnd->GetActiveView();

--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -408,7 +408,7 @@ static CLIPFORMAT GetClipFormat(const wchar_t* pFormatName)
 		return uFormat;
 	}
 	for(int i = 0; i < _countof(sClipFormatNames); i++){
-		if( 0 == wcsicmp(pFormatName, sClipFormatNames[i].m_pszName) ){
+		if( 0 == _wcsicmp(pFormatName, sClipFormatNames[i].m_pszName) ){
 			uFormat = sClipFormatNames[i].m_nClipFormat;
 		}
 	}

--- a/sakura_core/charset/CESI.cpp
+++ b/sakura_core/charset/CESI.cpp
@@ -917,7 +917,7 @@ ECodeType CESI::AutoDetectByXML( const char* pBuf, int nSize )
 					const int nLen = encodingNameToCode[k].nLen;
 					if( i + nLen < nSize - 1
 					  && pBuf[i + nLen] == quoteChar
-					  && 0 == memicmp( encodingNameToCode[k].name, pBuf + i, nLen ) ){
+					  && 0 == _memicmp( encodingNameToCode[k].name, pBuf + i, nLen ) ){
 						return static_cast<ECodeType>(encodingNameToCode[k].nCode);
 					}
 				}
@@ -961,7 +961,7 @@ ECodeType CESI::AutoDetectByHTML( const char* pBuf, int nSize )
 	for( int i = 0; i + 14 < nSize; i++ ){
 		// 「<meta http-equiv="Content-Type" content="text/html; Charset=Shift_JIS">」
 		// 「<meta charset="utf-8">」
-		if( pBuf[i] == '<' && 0 == memicmp(&pBuf[i+1], "meta", 4) && IsXMLWhiteSpace(pBuf[i+5]) ){
+		if( pBuf[i] == '<' && 0 == _memicmp(&pBuf[i+1], "meta", 4) && IsXMLWhiteSpace(pBuf[i+5]) ){
 			i += 5;
 			ECodeType encoding = CODE_NONE;
 			bool bContentType = false;
@@ -969,15 +969,15 @@ ECodeType CESI::AutoDetectByHTML( const char* pBuf, int nSize )
 				if( IsXMLWhiteSpace(pBuf[i]) && i + 1 < nSize && !IsXMLWhiteSpace(pBuf[i+1]) ){
 					int nAttType = 0;
 					i++;
-					if( i + 12 < nSize && 0 == memicmp(pBuf + i, "http-equiv", 10)
+					if( i + 12 < nSize && 0 == _memicmp(pBuf + i, "http-equiv", 10)
 						&& (IsXMLWhiteSpace(pBuf[i+10]) || '=' == pBuf[i+10]) ){
 						i += 10;
 						nAttType = 1; // http-equiv
-					}else if( i + 9 < nSize && 0 == memicmp(pBuf + i, "content", 7)
+					}else if( i + 9 < nSize && 0 == _memicmp(pBuf + i, "content", 7)
 						&& (IsXMLWhiteSpace(pBuf[i+7]) || '=' == pBuf[i+7]) ){
 						i += 7;
 						nAttType = 2; // content
-					}else if( i + 9 < nSize && 0 == memicmp(pBuf + i, "charset", 7)
+					}else if( i + 9 < nSize && 0 == _memicmp(pBuf + i, "charset", 7)
 						&& (IsXMLWhiteSpace(pBuf[i+7]) || '=' == pBuf[i+7]) ){
 						i += 7;
 						nAttType = 3; // charset
@@ -1018,7 +1018,7 @@ ECodeType CESI::AutoDetectByHTML( const char* pBuf, int nSize )
 					}
 					if( 1 == nAttType ){
 						// http-equiv
-						if( 12 == nEndAttVal - nBeginAttVal && 0 == memicmp(pBuf + nBeginAttVal, "content-type", 12) ){
+						if( 12 == nEndAttVal - nBeginAttVal && 0 == _memicmp(pBuf + nBeginAttVal, "content-type", 12) ){
 							bContentType = true;
 							if( encoding != CODE_NONE ){
 								return encoding;
@@ -1031,7 +1031,7 @@ ECodeType CESI::AutoDetectByHTML( const char* pBuf, int nSize )
 						i++; // Skip ';'
 						while( i < nEndAttVal && IsXMLWhiteSpace(pBuf[i]) ){ i++; }
 						if( nEndAttVal <= i ){ i = nNextPos; continue; }
-						if( i + 7 < nEndAttVal && 0 == memicmp(pBuf + i, "charset", 7) ){
+						if( i + 7 < nEndAttVal && 0 == _memicmp(pBuf + i, "charset", 7) ){
 							i += 7;
 							while( i < nEndAttVal && IsXMLWhiteSpace(pBuf[i]) ){ i++; }
 							if( nEndAttVal <= i ){ i = nNextPos; continue; }
@@ -1045,7 +1045,7 @@ ECodeType CESI::AutoDetectByHTML( const char* pBuf, int nSize )
 							for( k = 0; encodingNameToCode[k].name != NULL; k++ ){
 								const int nLen = encodingNameToCode[k].nLen;
 								if( i - nCharsetBegin == nLen
-								  && 0 == memicmp( encodingNameToCode[k].name, pBuf + nCharsetBegin, nLen ) ){
+								  && 0 == _memicmp( encodingNameToCode[k].name, pBuf + nCharsetBegin, nLen ) ){
 									if( bContentType ){
 										return static_cast<ECodeType>(encodingNameToCode[k].nCode);
 									}else{
@@ -1061,7 +1061,7 @@ ECodeType CESI::AutoDetectByHTML( const char* pBuf, int nSize )
 						for( k = 0; encodingNameToCode[k].name != NULL; k++ ){
 							const int nLen = encodingNameToCode[k].nLen;
 							if( nEndAttVal - nBeginAttVal == nLen
-							  && 0 == memicmp( encodingNameToCode[k].name, pBuf + nBeginAttVal, nLen ) ){
+							  && 0 == _memicmp( encodingNameToCode[k].name, pBuf + nBeginAttVal, nLen ) ){
 								return static_cast<ECodeType>(encodingNameToCode[k].nCode);
 							}
 						}
@@ -1114,7 +1114,7 @@ ECodeType CESI::AutoDetectByCoding( const char* pBuf, int nSize )
 			for( k = 0; encodingNameToCode[k].name != NULL; k++ ){
 				const int nLen = encodingNameToCode[k].nLen;
 				if( i - nBegin == nLen
-				  && 0 == memicmp( encodingNameToCode[k].name, pBuf + nBegin, nLen ) ){
+				  && 0 == _memicmp( encodingNameToCode[k].name, pBuf + nBegin, nLen ) ){
 					return static_cast<ECodeType>(encodingNameToCode[k].nCode);
 				}
 			}

--- a/sakura_core/convert/convert_util2.h
+++ b/sakura_core/convert/convert_util2.h
@@ -617,7 +617,7 @@ int _DecodeMimeHeader( const CHAR_TYPE* pSrc, const int nSrcLen, CMemory* pcMem_
 	if( pSrc+14 < pSrc+nSrcLen ){
 		// JIS の場合
 		if( sizeof(CHAR_TYPE) == 2 ){
-			ncmpresult = wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[0]), L"=?ISO-2022-JP?", 14 );
+			ncmpresult = _wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[0]), L"=?ISO-2022-JP?", 14 );
 		}else{
 			ncmpresult = strnicmp( &pSrc[0], "=?ISO-2022-JP?", 14 );
 		}
@@ -630,7 +630,7 @@ int _DecodeMimeHeader( const CHAR_TYPE* pSrc, const int nSrcLen, CMemory* pcMem_
 	if( pSrc+8 < pSrc+nSrcLen ){
 		// UTF-8 の場合
 		if( sizeof(CHAR_TYPE) == 2 ){
-			ncmpresult = wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[0]), L"=?UTF-8?", 8 );
+			ncmpresult = _wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[0]), L"=?UTF-8?", 8 );
 		}else{
 			ncmpresult = strnicmp( &pSrc[0], "=?UTF-8?", 8 );
 		}
@@ -664,8 +664,8 @@ finish_first_detect:;
 		return 0;
 	}
 	if( sizeof(CHAR_TYPE) == 2 ){
-		ncmpresult1 = wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[nLen_part1]), L"B?", 2 );
-		ncmpresult2 = wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[nLen_part1]), L"Q?", 2 );
+		ncmpresult1 = _wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[nLen_part1]), L"B?", 2 );
+		ncmpresult2 = _wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[nLen_part1]), L"Q?", 2 );
 	}else{
 		ncmpresult1 = strnicmp( &pSrc[nLen_part1], "B?", 2 );
 		ncmpresult2 = strnicmp( &pSrc[nLen_part1], "Q?", 2 );

--- a/sakura_core/convert/convert_util2.h
+++ b/sakura_core/convert/convert_util2.h
@@ -619,7 +619,7 @@ int _DecodeMimeHeader( const CHAR_TYPE* pSrc, const int nSrcLen, CMemory* pcMem_
 		if( sizeof(CHAR_TYPE) == 2 ){
 			ncmpresult = _wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[0]), L"=?ISO-2022-JP?", 14 );
 		}else{
-			ncmpresult = strnicmp( &pSrc[0], "=?ISO-2022-JP?", 14 );
+			ncmpresult = _strnicmp( &pSrc[0], "=?ISO-2022-JP?", 14 );
 		}
 		if( ncmpresult == 0 ){  // 
 			ecode = CODE_JIS;
@@ -632,7 +632,7 @@ int _DecodeMimeHeader( const CHAR_TYPE* pSrc, const int nSrcLen, CMemory* pcMem_
 		if( sizeof(CHAR_TYPE) == 2 ){
 			ncmpresult = _wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[0]), L"=?UTF-8?", 8 );
 		}else{
-			ncmpresult = strnicmp( &pSrc[0], "=?UTF-8?", 8 );
+			ncmpresult = _strnicmp( &pSrc[0], "=?UTF-8?", 8 );
 		}
 		if( ncmpresult == 0 ){
 			ecode = CODE_UTF8;
@@ -667,8 +667,8 @@ finish_first_detect:;
 		ncmpresult1 = _wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[nLen_part1]), L"B?", 2 );
 		ncmpresult2 = _wcsnicmp( reinterpret_cast<const wchar_t*>(&pSrc[nLen_part1]), L"Q?", 2 );
 	}else{
-		ncmpresult1 = strnicmp( &pSrc[nLen_part1], "B?", 2 );
-		ncmpresult2 = strnicmp( &pSrc[nLen_part1], "Q?", 2 );
+		ncmpresult1 = _strnicmp( &pSrc[nLen_part1], "B?", 2 );
+		ncmpresult2 = _strnicmp( &pSrc[nLen_part1], "Q?", 2 );
 	}
 	if( ncmpresult1 == 0 ){
 		emethod = EM_BASE64;

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -847,7 +847,7 @@ void CDlgTagJumpList::SetKeyword( const wchar_t *pszKeyword )
 
 	if( m_pszKeyword ) free( m_pszKeyword );
 
-	m_pszKeyword = wcsdup( pszKeyword );
+	m_pszKeyword = _wcsdup( pszKeyword );
 
 	return;
 }

--- a/sakura_core/doc/CDocOutline.cpp
+++ b/sakura_core/doc/CDocOutline.cpp
@@ -164,10 +164,10 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 					}else{
 						cComment = strLine[13];
 					}
-				}else if( 11 == strLine.length() && 0 == wcsicmp( strLine.c_str() + 1, L"Mode=Regex" ) ){
+				}else if( 11 == strLine.length() && 0 == _wcsicmp( strLine.c_str() + 1, L"Mode=Regex" ) ){
 					bRegex = true;
 					bRegexReplace = false;
-				}else if( 18 == strLine.length() && 0 == wcsicmp( strLine.c_str() + 1, L"Mode=RegexReplace" ) ){
+				}else if( 18 == strLine.length() && 0 == _wcsicmp( strLine.c_str() + 1, L"Mode=RegexReplace" ) ){
 					bRegex = true;
 					bRegexReplace = true;
 				}else if( 7 <= strLine.length() && 0 == _wcsnicmp( strLine.c_str() + 1, L"Title=", 6 ) ){

--- a/sakura_core/env/CFileNameManager.cpp
+++ b/sakura_core/env/CFileNameManager.cpp
@@ -135,7 +135,7 @@ LPCTSTR CFileNameManager::GetFilePathFormat( LPCTSTR pszSrc, LPTSTR pszDest, int
 
 	for( i = 0, j = 0; i < nSrcLen && j < nDestLen; i++ ){
 #if defined(_MBCS)
-		if( 0 == strnicmp( &pszSrc[i], pszFrom, nFromLen ) )
+		if( 0 == _strnicmp( &pszSrc[i], pszFrom, nFromLen ) )
 #else
 		if( 0 == _tcsncicmp( &pszSrc[i], pszFrom, nFromLen ) )
 #endif

--- a/sakura_core/plugin/CPluginManager.cpp
+++ b/sakura_core/plugin/CPluginManager.cpp
@@ -541,9 +541,9 @@ CPlugin* CPluginManager::LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* psz
 	std::wstring sPlugType;
 	cProfDef.IOProfileData( PII_PLUGIN, PII_PLUGIN_PLUGTYPE, sPlugType );
 
-	if( wcsicmp( sPlugType.c_str(), L"wsh" ) == 0 ){
+	if( _wcsicmp( sPlugType.c_str(), L"wsh" ) == 0 ){
 		plugin = new CWSHPlugin( tstring(pszBasePath) );
-	}else if( wcsicmp( sPlugType.c_str(), L"dll" ) == 0 ){
+	}else if( _wcsicmp( sPlugType.c_str(), L"dll" ) == 0 ){
 		plugin = new CDllPlugin( tstring(pszBasePath) );
 	}else{
 		return NULL;

--- a/sakura_core/types/CType_Asm.cpp
+++ b/sakura_core/types/CType_Asm.cpp
@@ -112,11 +112,11 @@ void CDocOutline::MakeTopicList_asm( CFuncInfoArr* pcFuncInfoArr )
 				entry_token = token[ 0 ];
 			}
 			else if( token[ 1 ] != NULL ){	//トークンが2個以上ある
-				if( wcsicmp( token[ 1 ], L"proc" ) == 0 ){	//関数
+				if( _wcsicmp( token[ 1 ], L"proc" ) == 0 ){	//関数
 					nFuncId = 50;
 					entry_token = token[ 0 ];
 				}else
-				if( wcsicmp( token[ 1 ], L"endp" ) == 0 ){	//関数終了
+				if( _wcsicmp( token[ 1 ], L"endp" ) == 0 ){	//関数終了
 					nFuncId = 52;
 					entry_token = token[ 0 ];
 				//}else

--- a/sakura_core/types/CType_Asm.cpp
+++ b/sakura_core/types/CType_Asm.cpp
@@ -73,7 +73,7 @@ void CDocOutline::MakeTopicList_asm( CFuncInfoArr* pcFuncInfoArr )
 		if( pLine == NULL ) break;
 
 		//作業用にコピーを作成する。バイナリがあったらその後ろは知らない。
-		pTmpLine = wcsdup( pLine );
+		pTmpLine = _wcsdup( pLine );
 		if( pTmpLine == NULL ) break;
 		if( wcslen( pTmpLine ) >= (unsigned int)nLineLen ){	//バイナリを含んでいたら短くなるので...
 			pTmpLine[ nLineLen ] = L'\0';	//指定長で切り詰め

--- a/sakura_core/types/CType_Html.cpp
+++ b/sakura_core/types/CType_Html.cpp
@@ -355,7 +355,7 @@ void CDocOutline::MakeTopicList_html(CFuncInfoArr* pcFuncInfoArr, bool bXml)
 							break;
 						}
 					}else{
-						if(!wcsicmp(pszStack[nDepth],szTitle)){
+						if(!_wcsicmp(pszStack[nDepth],szTitle)){
 							break;
 						}
 					}
@@ -368,7 +368,7 @@ void CDocOutline::MakeTopicList_html(CFuncInfoArr* pcFuncInfoArr, bool bXml)
 							nDepth = nDepthOrg;
 						}
 					}else{
-						if(wcsicmp(pszStack[nDepth],szTitle)){
+						if(_wcsicmp(pszStack[nDepth],szTitle)){
 							nDepth = nDepthOrg;
 						}
 					}

--- a/sakura_core/types/CType_Sql.cpp
+++ b/sakura_core/types/CType_Sql.cpp
@@ -131,22 +131,22 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 					}
 				}
 				else{
-					if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"FUNCTION" ) ){
+					if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"FUNCTION" ) ){
 						nFuncOrProc = 1;
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"PROCEDURE" ) ){
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"PROCEDURE" ) ){
 						nFuncOrProc = 2;
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"PACKAGE" ) ){
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"PACKAGE" ) ){
 						nFuncOrProc = 3;
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 1 == nParseCnt && 3 == nFuncOrProc && 0 == wcsicmp( szWord, L"BODY" ) ){
+					else if( 1 == nParseCnt && 3 == nFuncOrProc && 0 == _wcsicmp( szWord, L"BODY" ) ){
 						nFuncOrProc = 4;
 						nParseCnt = 1;
 					}
@@ -162,7 +162,7 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 						}
 					}else
 					if( 2 == nParseCnt ){
-						if( 0 == wcsicmp( szWord, L"IS" ) ){
+						if( 0 == _wcsicmp( szWord, L"IS" ) ){
 							if( 1 == nFuncOrProc ){
 								nFuncId = 11;	/* ファンクション本体 */
 							}else
@@ -190,7 +190,7 @@ void CDocOutline::MakeFuncList_PLSQL( CFuncInfoArr* pcFuncInfoArr )
 							pcFuncInfoArr->AppendData( nFuncLine, ptPos.GetY2() + CLayoutInt(1), szFuncName, nFuncId );
 							nParseCnt = 0;
 						}
-						if( 0 == wcsicmp( szWord, L"AS" ) ){
+						if( 0 == _wcsicmp( szWord, L"AS" ) ){
 							if( 3 == nFuncOrProc ){
 								nFuncId = 31;	/* パッケージ仕様部 */
 								++nFuncNum;

--- a/sakura_core/types/CType_Vb.cpp
+++ b/sakura_core/types/CType_Vb.cpp
@@ -140,29 +140,29 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					// テキストの中は無視します。
 					nMode	= 3;
 				}else{
-					if ( 0 == nParseCnt && 0 == wcsicmp(szWord, L"Public") ) {
+					if ( 0 == nParseCnt && 0 == _wcsicmp(szWord, L"Public") ) {
 						// パブリック宣言を見つけた！
 						nFuncId |= 0x10;
 					}else
-					if ( 0 == nParseCnt && 0 == wcsicmp(szWord, L"Private") ) {
+					if ( 0 == nParseCnt && 0 == _wcsicmp(szWord, L"Private") ) {
 						// プライベート宣言を見つけた！
 						nFuncId |= 0x20;
 					}else
-					if ( 0 == nParseCnt && 0 == wcsicmp(szWord, L"Friend") ) {
+					if ( 0 == nParseCnt && 0 == _wcsicmp(szWord, L"Friend") ) {
 						// フレンド宣言を見つけた！
 						nFuncId |= 0x30;
 					}else
-					if ( 0 == nParseCnt && 0 == wcsicmp(szWord, L"Static") ) {
+					if ( 0 == nParseCnt && 0 == _wcsicmp(szWord, L"Static") ) {
 						// スタティック宣言を見つけた！
 						nFuncId |= 0x100;
 					}else
-					if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Function" ) ){
-						if ( 0 == wcsicmp( szWordPrev, L"End" ) ){
+					if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Function" ) ){
+						if ( 0 == _wcsicmp( szWordPrev, L"End" ) ){
 							// プロシージャフラグをクリア
 							bProcedure	= false;
 						}else
-						if( 0 != wcsicmp( szWordPrev, L"Exit" ) ){
-							if( 0 == wcsicmp( szWordPrev, L"Declare" ) ){
+						if( 0 != _wcsicmp( szWordPrev, L"Exit" ) ){
+							if( 0 == _wcsicmp( szWordPrev, L"Declare" ) ){
 								nFuncId |= 0x200;	// DLL参照宣言
 							}else{
 								bProcedure	= true;	// プロシージャフラグをセット
@@ -172,13 +172,13 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 							nFuncLine = nLineCount + CLogicInt(1);
 						}
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Sub" ) ){
-						if ( 0 == wcsicmp( szWordPrev, L"End" ) ){
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Sub" ) ){
+						if ( 0 == _wcsicmp( szWordPrev, L"End" ) ){
 							// プロシージャフラグをクリア
 							bProcedure	= false;
 						}else
-						if( 0 != wcsicmp( szWordPrev, L"Exit" ) ){
-							if( 0 == wcsicmp( szWordPrev, L"Declare" ) ){
+						if( 0 != _wcsicmp( szWordPrev, L"Exit" ) ){
+							if( 0 == _wcsicmp( szWordPrev, L"Declare" ) ){
 								nFuncId |= 0x200;	// DLL参照宣言
 							}else{
 								bProcedure	= true;	// プロシージャフラグをセット
@@ -188,32 +188,32 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 							nFuncLine = nLineCount + CLogicInt(1);
 						}
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Get" )
-					 && 0 == wcsicmp( szWordPrev, L"Property" )
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Get" )
+					 && 0 == _wcsicmp( szWordPrev, L"Property" )
 					){
 						bProcedure	= true;	// プロシージャフラグをセット
 						nFuncId	|= 0x03;		// プロパティ取得
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Let" )
-					 && 0 == wcsicmp( szWordPrev, L"Property" )
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Let" )
+					 && 0 == _wcsicmp( szWordPrev, L"Property" )
 					){
 						bProcedure	= true;	// プロシージャフラグをセット
 						nFuncId |= 0x04;		// プロパティ設定
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Set" )
-					 && 0 == wcsicmp( szWordPrev, L"Property" )
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Set" )
+					 && 0 == _wcsicmp( szWordPrev, L"Property" )
 					){
 						bProcedure	= true;	// プロシージャフラグをセット
 						nFuncId |= 0x05;		// プロパティ参照
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Const" )
-					 && 0 != wcsicmp( szWordPrev, L"#" )
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Const" )
+					 && 0 != _wcsicmp( szWordPrev, L"#" )
 					){
 						if ( bClass || bProcedure || 0 == ((nFuncId >> 4) & 0x0f) ) {
 							// クラスモジュールでは強制的にPrivate
@@ -226,13 +226,13 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Enum" )
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Enum" )
 					){
 						nFuncId	|= 0x207;		// 列挙型宣言
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Type" )
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Type" )
 					){
 						if ( bClass ) {
 							// クラスモジュールでは強制的にPrivate
@@ -243,14 +243,14 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Event" )
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Event" )
 					){
 						nFuncId	|= 0x209;		// イベント宣言
 						nParseCnt = 1;
 						nFuncLine = nLineCount + CLogicInt(1);
 					}
-					else if( 0 == nParseCnt && 0 == wcsicmp( szWord, L"Property" )
-					 && 0 == wcsicmp( szWordPrev, L"End")
+					else if( 0 == nParseCnt && 0 == _wcsicmp( szWord, L"Property" )
+					 && 0 == _wcsicmp( szWordPrev, L"End")
 					){
 						bProcedure	= false;	// プロシージャフラグをクリア
 					}

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -787,7 +787,7 @@ void	GetExistPath( char *po , const char *pi )
 		( ACODE::IsAZ(*po) )
 	){	/* 先頭にドライブレターがある。そのドライブが有効かどうか判定する */
 		drv[0] = *po;
-		if( access(drv,0) == 0 )	dl = GetExistPath_AV_Drive;		/* 有効 */
+		if( _access(drv,0) == 0 )	dl = GetExistPath_AV_Drive;		/* 有効 */
 		else						dl = GetExistPath_IV_Drive;		/* 無効 */
 	}
 
@@ -808,7 +808,7 @@ void	GetExistPath( char *po , const char *pi )
 	}
 
 	for(;;){
-		if( access(po,0) == 0 )	break;	/* 有効なパス文字列が見つかった */
+		if( _access(po,0) == 0 )	break;	/* 有効なパス文字列が見つかった */
 		/* ↓文字列最後尾の \ または ' ' を探し出し、そこを文字列終端にする。*/
 
 		pw = sjis_strrchr2(ps,'\\',' ');	/* 最末尾の \ か ' ' を探す。 */
@@ -828,7 +828,7 @@ void	GetExistPath( char *po , const char *pi )
 		/* ↓ルートディレクトリを引っかけるための処理 */
 		if( ( *pw == '\\' )&&( *(pw-1) == ':' ) ){	/* C:\ とかの \ っぽい */
 			* (pw+1) = '\0';		/* \ の後ろの位置を文字列の終端にする。 */
-			if( access(po,0) == 0 )	break;	/* 有効なパス文字列が見つかった */
+			if( _access(po,0) == 0 )	break;	/* 有効なパス文字列が見つかった */
 		}
 		*pw = '\0';		/* \ か ' ' の位置を文字列の終端にする。 */
 		/* ↓末尾がスペースなら、スペースを全て削除する */

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -716,8 +716,8 @@ int my_mbisalpha2( int c )
 	@param s1   [in] 文字列１
 	@param s2   [in] 文字列２
 	@param n    [in] 文字長
-	@param dcount  [in] ステップ値 (1=strnicmp,memicmp, 0=stricmp)
-	@param flag [in] 文字列終端チェック (true=stricmp,strnicmp, false=memicmp)
+	@param dcount  [in] ステップ値 (1=strnicmp,_memicmp, 0=stricmp)
+	@param flag [in] 文字列終端チェック (true=stricmp,strnicmp, false=_memicmp)
 
 	@retval 0	一致
 	@date 2002.11.29 Moca 0以外の時の戻り値を，「元の値の差」から「大文字としたときの差」に変更

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -716,8 +716,8 @@ int my_mbisalpha2( int c )
 	@param s1   [in] 文字列１
 	@param s2   [in] 文字列２
 	@param n    [in] 文字長
-	@param dcount  [in] ステップ値 (1=strnicmp,_memicmp, 0=stricmp)
-	@param flag [in] 文字列終端チェック (true=stricmp,strnicmp, false=_memicmp)
+	@param dcount  [in] ステップ値 (1=_strnicmp,_memicmp, 0=stricmp)
+	@param flag [in] 文字列終端チェック (true=stricmp,_strnicmp, false=_memicmp)
 
 	@retval 0	一致
 	@date 2002.11.29 Moca 0以外の時の戻り値を，「元の値の差」から「大文字としたときの差」に変更

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -55,7 +55,7 @@
 inline int amemcmp(const ACHAR* p1, const ACHAR* p2, size_t count){ return ::memcmp(p1,p2,count); }
 
 //大文字小文字を区別せずにメモリ比較
-inline int amemicmp(const ACHAR* p1, const ACHAR* p2, size_t count){ return ::memicmp(p1,p2,count); }
+inline int amemicmp(const ACHAR* p1, const ACHAR* p2, size_t count){ return ::_memicmp(p1,p2,count); }
        int wmemicmp(const WCHAR* p1, const WCHAR* p2, size_t count);
        int wmemicmp(const WCHAR* p1, const WCHAR* p2 );
        int wmemicmp_ascii(const WCHAR* p1, const WCHAR* p2, size_t count);

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -1561,10 +1561,10 @@ void CEditView::OnLBUTTONDBLCLK( WPARAM fwKeys, int _xPos , int _yPos )
 				wstrOPEN = pszMailTo + wstrURL;
 			}
 			else{
-				if( wcsnicmp( wstrURL.c_str(), L"ttp://", 6 ) == 0 ){	//抑止URL
+				if( _wcsnicmp( wstrURL.c_str(), L"ttp://", 6 ) == 0 ){	//抑止URL
 					wstrOPEN = L"h" + wstrURL;
 				}
-				else if( wcsnicmp( wstrURL.c_str(), L"tp://", 5 ) == 0 ){	//抑止URL
+				else if( _wcsnicmp( wstrURL.c_str(), L"tp://", 5 ) == 0 ){	//抑止URL
 					wstrOPEN = L"ht" + wstrURL;
 				}
 				else{

--- a/sakura_core/view/CEditView_Search.cpp
+++ b/sakura_core/view/CEditView_Search.cpp
@@ -472,7 +472,7 @@ int CEditView::IsSearchString(
 		const wchar_t *const pWordHead = cStr.GetPtr() + posWordHead;
 
 		// 比較関数
-		int (*const fcmp)( const wchar_t*, const wchar_t*, size_t ) = m_sCurSearchOption.bLoHiCase ? wcsncmp : wcsnicmp;
+		int (*const fcmp)( const wchar_t*, const wchar_t*, size_t ) = m_sCurSearchOption.bLoHiCase ? wcsncmp : _wcsnicmp;
 
 		// 検索語を単語に分割しながら指定位置の単語と照合する。
 		int wordIndex = 0;

--- a/sakura_core/view/CEditView_Search.cpp
+++ b/sakura_core/view/CEditView_Search.cpp
@@ -30,7 +30,7 @@
 #include "parse/CWordParse.h"
 #include "util/string_ex2.h"
 
-const int STRNCMP_MAX = 100;	/* MAXキーワード長：strnicmp文字列比較最大値(CEditView::KeySearchCore) */	// 2006.04.10 fon
+const int STRNCMP_MAX = 100;	/* MAXキーワード長：_strnicmp文字列比較最大値(CEditView::KeySearchCore) */	// 2006.04.10 fon
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           検索                              //


### PR DESCRIPTION
# PR の目的

一部のPOSIX由来の関数には最新のC++規格で別名が振られています。

非推奨となったPOSIX名をC++規格に準拠した名前に置換することにより、
サクラエディタのコードの品質をわずかに向上させます。


## カテゴリ

- リファクタリング


## PR の背景

この PR は #893(SDLチェックを有効にする) の抜き出しです。

SDLチェックは、visual studio が本来持っている bad code 検出機構です。
#872(開発環境をvs2017に対応させる)の一環として、SDLチェックを有効にしようとしています。

SDLチェックを有効にすると bad code 臭いコードがビルドエラーになります。
考えなしに有効にしてみんなで路頭に迷うのも寒いので、事前に bad code を除去する試みをしたいと考えています。


## 修正される bad code の内容

最新C++規格で別名を振られてPOSIX名が非推奨になっているにも関わらず、
以前のままのPOSIX名を使っている関数を置換します。

対象関数は以下の通りです。

- error C4996: 'access': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _access. See online help for details.
- error C4996: 'memicmp': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _memicmp. See online help for details.
- error C4996: 'wcsdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _wcsdup. See online help for details.
- error C4996: 'wcsicmp': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _wcsicmp. See online help for details.
- error C4996: 'wcsnicmp': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _wcsnicmp. See online help for details.


## PR のメリット

サクラエディタのコード品質をわずかに向上させることができます。


## PR のデメリット (トレードオフとかあれば)

ありません。


## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響がある変更です。
  - ただし、実害はないと考えられます。


## 関連チケット

#872 開発環境をvs2017に対応させる
#893 SDLチェックを有効にする
