### PR TITLE
セキュリティに問題のあるCRT関数の使用を容認する

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -20,6 +20,9 @@
 // Windows SDKのmin/maxマクロは使いません
 #define NOMINMAX
 
+// MS Cランタイムの非セキュア関数の使用を容認します
+#define _CRT_SECURE_NO_WARNINGS
+
 #if defined(_MSC_VER) && _MSC_VER >= 1400
 
 //#pragma warning(disable: 4786)


### PR DESCRIPTION
# PR の目的

セキュリティに問題のあるCRT関数の使用を一時的に容認することにより、
歴史的に累積してきたコードの問題の対応時期を遅らせます。
（対応すべき問題への対処を、先延ばしにするのが目的です。）

一部のCRT関数にはセキュリティの問題があることが知られています。

バッファを扱う関数でバッファオーバーフローを考慮していないと、
プログラムの一部が書き替わってしまい、誤動作の原因になります。

Visual Studioの製造元であるマイクロソフトは、比較的早くからこの問題に取り組んでいます。
_swprintfに対する_swprintf_sなど、_s付き関数がこれにあたります。

問題のある関数: swprintf
問題のない関数: swprintf_s

C言語やC++の規格策定団体もこの事実を気にしていて、
いくつかのCRT関数をバッファオーバーフローの問題を起こさないように再定義しています。

規格標準がセキュア対応を果たしたのは喜ばしいことなのですが、
ここで困った問題がおきました・・・C言語にはオーバーロードの概念がないのです。

問題のあった関数: swprintf(wchar_t*, const wchar_t*, ...)
問題を潰した関数: swprintf(wchar_t*, size_t, const wchar_t*, ...)
※C言語には「関数のオーバーロード(引数違いの同名関数)」がないので両者を区別できない。

サクラエディタは、ずっとMSVCで開発されてきましたが、残念なことに_s付き関数への移行が済んでいません。

- 旧MS版問題のある関数
  - **最新C++規格の非セキュア関数**
    - これにするには、このPRの対応が必要。
  - MS版セキュア関数
    - セキュリティの考え方が違うので単なる置換では移行できない。
    - これにすると、オーバーフロー時にクラッシュする。
  - 最新C++規格のCRT関数(セキュリティ対応済み)
    - 最終的にこれにしたいが、ないものもおおい。


## カテゴリ

- リファクタリング


## PR の背景

この PR は #893 SDLチェックを有効にする の抜き出しです。

SDLチェックは、visual studio が本来持っている bad code 検出機構です。
#872(開発環境をvs2017に対応させる)の一環として、SDLチェックを有効にしようとしています。

SDLチェックを有効にすると bad code 臭いコードがビルドエラーになります。
考えなしに有効にしてみんなで路頭に迷うのも寒いので、事前に bad code を除去する試みをしたいと考えています。


## 修正される bad code の内容

このPRは bad code を修正しません。
特定パターンの bad code を検出しないようにコンパイラに指示を加えるだけです。


## PR のメリット

対処すべき問題を一旦無視することができるようになります。


## PR のデメリット (トレードオフとかあれば)

対処すべき警告を無効化してしまいます。


## PR の影響範囲

- セキュア版関数の使用が警告の対象から外れます。
- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット

#872 開発環境をvs2017に対応させる
#893 SDLチェックを有効にする

