### PR TITLE
C++規格が変更されて非推奨となった関数名を置換する

### DIFF
--- a/sakura_core/CDicMgr.cpp
+++ b/sakura_core/CDicMgr.cpp
@@ -84,7 +84,8 @@ BOOL CDicMgr::Search(
 			pszWork += wcslen( pszDelimit );
 
 			/* 最初のトークンを取得します。 */
-			pszToken = wcstok( szLine, pszKeySeps );
+			wchar_t *context = NULL;
+			pszToken = wcstok_s( szLine, pszKeySeps, &context );
 			while( NULL != pszToken ){
 				nRes = _wcsnicmp( pszKey, pszToken, nCmpLen );	// 2006.04.10 fon
 				if( 0 == nRes ){
@@ -105,7 +106,7 @@ BOOL CDicMgr::Search(
 					*pLine = line;	// 2006.04.10 fon
 					return TRUE;
 				}
-				pszToken = wcstok( NULL, pszKeySeps );
+				pszToken = wcstok_s( NULL, pszKeySeps, &context );
 			}
 		}
 	}

--- a/sakura_core/CDicMgr.cpp
+++ b/sakura_core/CDicMgr.cpp
@@ -84,7 +84,7 @@ BOOL CDicMgr::Search(
 			pszWork += wcslen( pszDelimit );
 
 			/* 最初のトークンを取得します。 */
-			pszToken = wcstok( szLine, pszKeySeps );
+			pszToken = _wcstok( szLine, pszKeySeps );
 			while( NULL != pszToken ){
 				nRes = _wcsnicmp( pszKey, pszToken, nCmpLen );	// 2006.04.10 fon
 				if( 0 == nRes ){
@@ -105,7 +105,7 @@ BOOL CDicMgr::Search(
 					*pLine = line;	// 2006.04.10 fon
 					return TRUE;
 				}
-				pszToken = wcstok( NULL, pszKeySeps );
+				pszToken = _wcstok( NULL, pszKeySeps );
 			}
 		}
 	}

--- a/sakura_core/CDicMgr.cpp
+++ b/sakura_core/CDicMgr.cpp
@@ -84,7 +84,7 @@ BOOL CDicMgr::Search(
 			pszWork += wcslen( pszDelimit );
 
 			/* 最初のトークンを取得します。 */
-			pszToken = _wcstok( szLine, pszKeySeps );
+			pszToken = wcstok( szLine, pszKeySeps );
 			while( NULL != pszToken ){
 				nRes = _wcsnicmp( pszKey, pszToken, nCmpLen );	// 2006.04.10 fon
 				if( 0 == nRes ){
@@ -105,7 +105,7 @@ BOOL CDicMgr::Search(
 					*pLine = line;	// 2006.04.10 fon
 					return TRUE;
 				}
-				pszToken = _wcstok( NULL, pszKeySeps );
+				pszToken = wcstok( NULL, pszKeySeps );
 			}
 		}
 	}

--- a/sakura_core/cmd/CViewCommander_Clipboard.cpp
+++ b/sakura_core/cmd/CViewCommander_Clipboard.cpp
@@ -689,7 +689,7 @@ static bool AppendHTMLColor(
 					WCHAR szColor[60];
 					DWORD dwTEXTColor = (GetRValue(sColorAttrLast.m_cTEXT) << 16) + (GetGValue(sColorAttrLast.m_cTEXT) << 8) + GetBValue(sColorAttrLast.m_cTEXT);
 					DWORD dwBACKColor = (GetRValue(sColorAttrLast.m_cBACK) << 16) + (GetGValue(sColorAttrLast.m_cBACK) << 8) + GetBValue(sColorAttrLast.m_cBACK);
-					swprintf( szColor, L"<span style=\"color:#%06x;background-color:#%06x\">", dwTEXTColor, dwBACKColor);
+					_swprintf( szColor, L"<span style=\"color:#%06x;background-color:#%06x\">", dwTEXTColor, dwBACKColor);
 					cmemClip.AppendString( szColor );
 				}
 			}
@@ -820,7 +820,7 @@ void CViewCommander::Command_COPY_COLOR_HTML(bool bLineNumber)
 		}
 		nLineNumberMaxLen = i + 1; // "%d:"
 		cmemNullLine.AppendString(L":");
-		swprintf(szLineFormat, L"%%%dd:", i);
+		_swprintf(szLineFormat, L"%%%dd:", i);
 	}
 	if( bLineNumLayout ){
 		nBuffSize += (Int)(nLineNumberMaxLen * (rcSel.bottom - rcSel.top + 1));
@@ -833,7 +833,7 @@ void CViewCommander::Command_COPY_COLOR_HTML(bool bLineNumber)
 		COLORREF cBACK = type.m_ColorInfoArr[COLORIDX_TEXT].m_sColorAttr.m_cBACK;
 		DWORD dwBACKColor = (GetRValue(cBACK) << 16) + (GetGValue(cBACK) << 8) + GetBValue(cBACK);
 		WCHAR szBuf[50];
-		swprintf(szBuf, L"<pre style=\"background-color:#%06x\">", dwBACKColor);
+		_swprintf(szBuf, L"<pre style=\"background-color:#%06x\">", dwBACKColor);
 		cmemClip.AppendString( szBuf );
 	}
 	CLayoutInt nLayoutLineNum = rcSel.top;
@@ -919,12 +919,12 @@ void CViewCommander::Command_COPY_COLOR_HTML(bool bLineNumber)
 							cmemClip.AppendNativeData(cmemNullLine);
 						}
 					}else{
-						int ret = swprintf(szLineNum, szLineFormat, nLineNum + 1);
+						int ret = _swprintf(szLineNum, szLineFormat, nLineNum + 1);
 						cmemClip.AppendString(szLineNum, ret);
 					}
 				}else{
 					if( bLineNumLayout || pcLayout->GetLogicOffset() == 0 ){
-						int ret = swprintf(szLineNum, szLineFormat, nLayoutLineNum + 1);
+						int ret = _swprintf(szLineNum, szLineFormat, nLayoutLineNum + 1);
 						cmemClip.AppendString(szLineNum, ret);
 					}
 				}

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -463,7 +463,7 @@ static bool IOProfSettings( SProfileSettings& settings, bool bWrite )
 	for(int i = 0; i < nCount; i++){
 		wchar_t szKey[64];
 		std::tstring strProfName;
-		swprintf( szKey, L"P[%d]", i + 1 ); // 1開始
+		_swprintf( szKey, L"P[%d]", i + 1 ); // 1開始
 		if( bWrite ){
 			strProfName = settings.m_vProfList[i];
 			std::wstring wstrProfName = to_wchar(strProfName.c_str());

--- a/sakura_core/doc/CDocOutline.cpp
+++ b/sakura_core/doc/CDocOutline.cpp
@@ -97,6 +97,7 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 			/* 最初のトークンを取得します。 */
 			const wchar_t* pszTextReplace = L"";
 			wchar_t* pszToken;
+			wchar_t* context{ nullptr };
 			bool bTopDummy = false;
 			bool bRegexRep2 = false;
 			if( bRegex ){
@@ -128,7 +129,7 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 					}
 				}
 			}else{
-				pszToken = wcstok( szLine, pszKeySeps );
+				pszToken = wcstok_s( szLine, pszKeySeps, &context );
 				if( nCount == 0 && pszToken == NULL ){
 					pszToken = szLine;
 					bTopDummy = true;
@@ -153,7 +154,7 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 				if( bTopDummy || bRegex ){
 					pszToken = NULL;
 				}else{
-					pszToken = wcstok( NULL, pszKeySeps );
+					pszToken = wcstok_s( NULL, pszKeySeps, &context );
 				}
 			}
 		}else{

--- a/sakura_core/doc/CDocOutline.cpp
+++ b/sakura_core/doc/CDocOutline.cpp
@@ -128,7 +128,7 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 					}
 				}
 			}else{
-				pszToken = _wcstok( szLine, pszKeySeps );
+				pszToken = wcstok( szLine, pszKeySeps );
 				if( nCount == 0 && pszToken == NULL ){
 					pszToken = szLine;
 					bTopDummy = true;
@@ -153,7 +153,7 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 				if( bTopDummy || bRegex ){
 					pszToken = NULL;
 				}else{
-					pszToken = _wcstok( NULL, pszKeySeps );
+					pszToken = wcstok( NULL, pszKeySeps );
 				}
 			}
 		}else{

--- a/sakura_core/doc/CDocOutline.cpp
+++ b/sakura_core/doc/CDocOutline.cpp
@@ -128,7 +128,7 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 					}
 				}
 			}else{
-				pszToken = wcstok( szLine, pszKeySeps );
+				pszToken = _wcstok( szLine, pszKeySeps );
 				if( nCount == 0 && pszToken == NULL ){
 					pszToken = szLine;
 					bTopDummy = true;
@@ -153,7 +153,7 @@ int CDocOutline::ReadRuleFile( const TCHAR* pszFilename, SOneRule* pcOneRule, in
 				if( bTopDummy || bRegex ){
 					pszToken = NULL;
 				}else{
-					pszToken = wcstok( NULL, pszKeySeps );
+					pszToken = _wcstok( NULL, pszKeySeps );
 				}
 			}
 		}else{

--- a/sakura_core/docplus/CBookmarkManager.cpp
+++ b/sakura_core/docplus/CBookmarkManager.cpp
@@ -121,7 +121,8 @@ void CBookmarkManager::SetBookMarks( wchar_t* pMarkLines )
 		}
 	}else{
 		// 旧形式 行番号,区切り
-		while(wcstok(p, delim) != NULL) {
+		wchar_t *context{ nullptr };
+		while(wcstok_s(p, delim, &context) != NULL) {
 			while(wcschr(delim, *p) != NULL)p++;
 			pCDocLine=m_pcDocLineMgr->GetLine( CLogicInt(_wtol(p)) );
 			if(pCDocLine)CBookmarkSetter(pCDocLine).SetBookmark(true);

--- a/sakura_core/docplus/CBookmarkManager.cpp
+++ b/sakura_core/docplus/CBookmarkManager.cpp
@@ -121,7 +121,7 @@ void CBookmarkManager::SetBookMarks( wchar_t* pMarkLines )
 		}
 	}else{
 		// 旧形式 行番号,区切り
-		while(wcstok(p, delim) != NULL) {
+		while(_wcstok(p, delim) != NULL) {
 			while(wcschr(delim, *p) != NULL)p++;
 			pCDocLine=m_pcDocLineMgr->GetLine( CLogicInt(_wtol(p)) );
 			if(pCDocLine)CBookmarkSetter(pCDocLine).SetBookmark(true);

--- a/sakura_core/docplus/CBookmarkManager.cpp
+++ b/sakura_core/docplus/CBookmarkManager.cpp
@@ -121,7 +121,7 @@ void CBookmarkManager::SetBookMarks( wchar_t* pMarkLines )
 		}
 	}else{
 		// 旧形式 行番号,区切り
-		while(_wcstok(p, delim) != NULL) {
+		while(wcstok(p, delim) != NULL) {
 			while(wcschr(delim, *p) != NULL)p++;
 			pCDocLine=m_pcDocLineMgr->GetLine( CLogicInt(_wtol(p)) );
 			if(pCDocLine)CBookmarkSetter(pCDocLine).SetBookmark(true);

--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -230,7 +230,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 					WCHAR szText[10];
 					const EditNode* node = CAppNodeManager::getInstance()->GetEditNode( GetMainWindow()->GetHwnd() );
 					if( 0 < node->m_nId ){
-						swprintf( szText, L"%d", node->m_nId );
+						_swprintf( szText, L"%d", node->m_nId );
 						q = wcs_pushW( q, q_max - q, szText );
 					}
 				}

--- a/sakura_core/func/CFuncLookup.cpp
+++ b/sakura_core/func/CFuncLookup.cpp
@@ -302,7 +302,7 @@ const WCHAR* CFuncLookup::Custmenu2Name( int index, WCHAR buf[], int bufSize ) c
 		return buf;
 	}
 	else {
-		swprintf( buf, LSW( STR_CUSTMENU_CUSTOM ), index );
+		_swprintf( buf, LSW( STR_CUSTMENU_CUSTOM ), index );
 		return buf;
 	}
 

--- a/sakura_core/plugin/CPlugin.cpp
+++ b/sakura_core/plugin/CPlugin.cpp
@@ -98,7 +98,7 @@ bool CPlugin::ReadPluginDefPlug( CDataProfile *cProfile, CDataProfile *cProfileM
 			if( nCount == 0 ){
 				szIndex[0] = L'\0';
 			}else{
-				swprintf(szIndex, L"[%d]", nCount);
+				_swprintf(szIndex, L"[%d]", nCount);
 			}
 			wstring sHandler;
 			if( cProfile->IOProfileData( PII_PLUG, (sKey + szIndex).c_str(), sHandler ) ){
@@ -131,13 +131,13 @@ bool CPlugin::ReadPluginDefCommand( CDataProfile *cProfile, CDataProfile *cProfi
 	WCHAR bufKey[64];
 
 	for( int nCount = 1; nCount < MAX_PLUG_CMD; nCount++ ){	//添え字は１から始める
-		swprintf( bufKey, L"C[%d]", nCount );
+		_swprintf( bufKey, L"C[%d]", nCount );
 		if( cProfile->IOProfileData( PII_COMMAND, bufKey, sHandler ) ){
 			wstring sLabel;
 			wstring sIcon;
 
 			//ラベルの取得
-			swprintf( bufKey, L"C[%d].Label", nCount );
+			_swprintf( bufKey, L"C[%d].Label", nCount );
 			cProfile->IOProfileData( PII_COMMAND, bufKey, sLabel );
 			if( cProfileMlang ){
 				cProfileMlang->IOProfileData( PII_COMMAND, bufKey, sLabel );
@@ -146,7 +146,7 @@ bool CPlugin::ReadPluginDefCommand( CDataProfile *cProfile, CDataProfile *cProfi
 				sLabel = sHandler;		// Labelが無ければハンドラ名で代用
 			}
 			//アイコンの取得
-			swprintf( bufKey, L"C[%d].Icon", nCount );
+			_swprintf( bufKey, L"C[%d].Icon", nCount );
 			cProfile->IOProfileData( PII_COMMAND, bufKey, sIcon );
 			if( cProfileMlang ){
 				cProfileMlang->IOProfileData( PII_COMMAND, bufKey, sIcon );
@@ -177,31 +177,31 @@ bool CPlugin::ReadPluginDefOption( CDataProfile *cProfile, CDataProfile *cProfil
 	for( int nCount = 1; nCount < MAX_PLUG_OPTION; nCount++ ){	//添え字は１から始める
 		sKey = sLabel = sType = sDefaultVal= L"";
 		//Keyの取得
-		swprintf( bufKey, L"O[%d].Key", nCount );
+		_swprintf( bufKey, L"O[%d].Key", nCount );
 		if( cProfile->IOProfileData( PII_OPTION, bufKey, sKey ) ){
 			//Sectionの取得
-			swprintf( bufKey, L"O[%d].Section", nCount );
+			_swprintf( bufKey, L"O[%d].Section", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sSection_wk );
 			if (!sSection_wk.empty()) {		// 指定が無ければ前を引き継ぐ
 				sSection = sSection_wk;
 			}
 			//ラベルの取得
-			swprintf( bufKey, L"O[%d].Label", nCount );
+			_swprintf( bufKey, L"O[%d].Label", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sLabel );
 			if( cProfileMlang ){
 				cProfileMlang->IOProfileData( PII_OPTION, bufKey, sLabel );
 			}
 			//Typeの取得
-			swprintf( bufKey, L"O[%d].Type", nCount );
+			_swprintf( bufKey, L"O[%d].Type", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sType );
 			// 項目選択候補
-			swprintf( bufKey, L"O[%d].Select", nCount );
+			_swprintf( bufKey, L"O[%d].Select", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sSelect );
 			if( cProfileMlang ){
 				cProfileMlang->IOProfileData( PII_OPTION, bufKey, sSelect );
 			}
 			// デフォルト値
-			swprintf( bufKey, L"O[%d].Default", nCount );
+			_swprintf( bufKey, L"O[%d].Default", nCount );
 			cProfile->IOProfileData( PII_OPTION, bufKey, sDefaultVal );
 
 			if (sSection.empty() || sKey.empty()) {
@@ -279,7 +279,7 @@ bool CPlugin::ReadPluginDefString( CDataProfile *cProfile, CDataProfile *cProfil
 	m_aStrings.push_back( wstring(L"") ); // 0番目ダミー
 	for( int nCount = 1; nCount < MAX_PLUG_STRING; nCount++ ){	//添え字は１から始める
 		wstring sVal = L"";
-		swprintf( bufKey, L"S[%d]", nCount );
+		_swprintf( bufKey, L"S[%d]", nCount );
 		if( cProfile->IOProfileData( PII_STRING, bufKey, sVal ) ){
 			if( cProfileMlang ){
 				cProfileMlang->IOProfileData( PII_STRING, bufKey, sVal );

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -499,7 +499,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, _countof(szId) );
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eDefaultOutline ))) != 0 ){
 			wchar_t szPlug[8];
-			swprintf( szPlug, L"/%d", nPlug );
+			_swprintf( szPlug, L"/%d", nPlug );
 			wcscat( szId, szPlug );
 		}
 		cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineId,   MakeStringBufferW(szId) );
@@ -510,7 +510,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, _countof(szId) );
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) != 0 ){
 			wchar_t szPlug[8];
-			swprintf( szPlug, L"/%d", nPlug );
+			_swprintf( szPlug, L"/%d", nPlug );
 			wcscat( szId, szPlug );
 		}
 		cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentId,   MakeStringBufferW(szId) );

--- a/sakura_core/util/tchar_printf.cpp
+++ b/sakura_core/util/tchar_printf.cpp
@@ -109,7 +109,7 @@ static inline int local_vsprintf(char* buf, const char* format, va_list& v)
 
 static inline int local_vsprintf(wchar_t* buf, const wchar_t* format, va_list& v)
 {
-	return vswprintf(buf,format,v);
+	return _vswprintf(buf,format,v);
 }
 
 //vsnprintf_s API


### PR DESCRIPTION
# PR の目的

一部のCRT関数は、歴史的な経緯でシグニチャが変更されています。

非推奨となった古い形式の関数をC++規格に準拠した別名に置換することにより、
サクラエディタのコードの品質をわずかに向上させます。


## カテゴリ

- リファクタリング


## PR の背景

この PR は #893 SDLチェックを有効にする の抜き出しです。

SDLチェックは、visual studio が本来持っている bad code 検出機構です。
#872(開発環境をvs2017に対応させる)の一環として、SDLチェックを有効にしようとしています。

SDLチェックを有効にすると bad code 臭いコードがビルドエラーになります。
考えなしに有効にしてみんなで路頭に迷うのも寒いので、事前に bad code を除去する試みをしたいと考えています。

#893 では _s付きバージョンへの置換 を提案していましたが、
このPRでは非セキュア版の別名に置換するだけの対応を行います。

【追記】
wcstok⇒_wcstokの変更が MinGW でビルドエラーになってしまったので、
wcstokの変更を wcstok⇒wcstok_s に差し替えます。


## 修正される bad code の内容

最新C++規格で関数のシグニチャが変更され、非推奨になっているにも関わらず、
以前のままのシグニチャを使っている関数を別名に置換します。

対象関数はswprintfとwcstokです。

- https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-sprintf-l-swprintf-swprintf-l-swprintf-l?view=vs-2019
- https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-s-sprintf-s-l-swprintf-s-swprintf-s-l?view=vs-2019
- https://docs.microsoft.com/ja-jp/cpp/c-runtime-library/reference/strtok-strtok-l-wcstok-wcstok-l-mbstok-mbstok-l?view=vs-2019
- https://docs.microsoft.com/ja-jp/cpp/c-runtime-library/reference/strtok-s-strtok-s-l-wcstok-s-wcstok-s-l-mbstok-s-mbstok-s-l?view=vs-2019

## PR のメリット

サクラエディタのコード品質をわずかに向上させることができます。


## PR のデメリット (トレードオフとかあれば)

ありません。


## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響がある変更です。
  - ただし、実害はないと考えられます。


## 関連チケット

#872 開発環境(Visual Studio)の機能をもっと活用するためにコード改善を行いたい 
#893 SDLチェックを有効にする
#1005 C++規格で非推奨となった関数名を置換する
#1006 セキュリティに問題のあるCRT関数の使用を容認する


## 参考情報

https://msdn.microsoft.com/ja-jp/windows/apps/bb531344(v=vs.94)
