### PR TITLE
Unicode版のみのサポートなので、不要なプリプロセッサ記述やコードを削除

### DIFF
--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -57,11 +57,7 @@ struct StringBufferA_{
 };
 typedef const StringBufferA_ StringBufferA;
 typedef const StringBufferW_ StringBufferW;
-#ifdef _UNICODE
-	typedef StringBufferW StringBufferT;
-#else
-	typedef StringBufferA StringBufferT;
-#endif
+typedef StringBufferW StringBufferT;
 
 //文字列バッファ型インスタンスの生成マクロ
 #define MakeStringBufferW(S) StringBufferW(S,_countof(S))
@@ -76,9 +72,6 @@ class CDataProfile : public CProfile{
 private:
 	//専用型
 	typedef std::wstring wstring;
-#ifndef _UNICODE
-	typedef std::tstring tstring;
-#endif
 
 protected:
 	static const wchar_t* _work_itow(int n)

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -30,11 +30,7 @@
 #include "version.h"
 
 // アプリ名。2007.09.21 kobake 整理
-#ifdef _UNICODE
 #define _APP_NAME_(TYPE) TYPE("sakura")
-#else
-#define _APP_NAME_(TYPE) TYPE("sakura")
-#endif
 
 #ifdef _DEBUG
 #define _APP_NAME_2_(TYPE) TYPE("(デバッグ版)")

--- a/sakura_core/_os/OleTypes.h
+++ b/sakura_core/_os/OleTypes.h
@@ -66,13 +66,8 @@ struct SysString
 		int Len = ::SysStringLen(Data);
 		str->assign(Data, Len);
 	}
-#ifdef _UNICODE
 	void GetT(TCHAR **S, int *L){GetW(S, L);}
 	void GetT(std::wstring* str){GetW(str);}
-#else
-	void GetT(TCHAR **S, int *L){Get(S, L);}
-	void GetT(std::string* str){Get(str);}
-#endif
 };
 
 /*! VARIANTのWrapper class

--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -54,71 +54,11 @@ namespace ApiWrap
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//W版が無いので、自作
 	BOOL MakeSureDirectoryPathExistsW(LPCWSTR wszDirPath);
-#ifdef _UNICODE
 	#define MakeSureDirectoryPathExistsT MakeSureDirectoryPathExistsW
-#else
-	#define MakeSureDirectoryPathExistsT MakeSureDirectoryPathExists
-#endif
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//              W系描画API (ANSI版でも利用可能)                //
+	//              W系描画API                                      //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-
-	/*!
-		ANSI版でも使えるExtTextOutW_AnyBuild。
-		文字数制限1024半角文字。(文字間隔配列を1024半角文字分しか用意していないため)
-	*/
-#ifdef _UNICODE
-	inline BOOL ExtTextOutW_AnyBuild(
-		HDC				hdc,
-		int				x,
-		int				y,
-		UINT			fuOptions,
-		const RECT*		lprc,
-		LPCWSTR			lpwString,
-		UINT			cbCount,
-		const int*		lpDx
-	)
-	{
-		BOOL ret=::ExtTextOut(hdc,x,y,fuOptions,lprc,lpwString,cbCount,lpDx);
-		DEBUG_SETPIXEL(hdc);
-		return ret;
-	}
-#else
-	BOOL ExtTextOutW_AnyBuild(
-		HDC				hdc,
-		int				x,
-		int				y,
-		UINT			fuOptions,
-		const RECT*		lprc,
-		LPCWSTR			lpwString,
-		UINT			cbCount,
-		const int*		lpDx
-	);
-#endif
-
-#ifdef _UNICODE
-	inline BOOL TextOutW_AnyBuild(
-		HDC		hdc,
-		int		nXStart,
-		int		nYStart,
-		LPCWSTR	lpwString,
-		int		cbString
-	)
-	{
-		BOOL ret=::TextOut(hdc,nXStart,nYStart,lpwString,cbString);
-		DEBUG_SETPIXEL(hdc);
-		return ret;
-	}
-#else
-	BOOL TextOutW_AnyBuild(
-		HDC		hdc,
-		int		nXStart,
-		int		nYStart,
-		LPCWSTR	lpwString,
-		int		cbString
-	);
-#endif
 
 	LPWSTR CharNextW_AnyBuild(
 		LPCWSTR lpsz
@@ -129,22 +69,12 @@ namespace ApiWrap
 		LPCWSTR lpszCurrent
 	);
 
-#ifdef _UNICODE
 	#define GetTextExtentPoint32W_AnyBuild GetTextExtentPoint32
-#else
-	BOOL GetTextExtentPoint32W_AnyBuild(
-		HDC		hdc, 
-		LPCWSTR	lpString, 
-		int		cbString, 
-		LPSIZE	lpSize
-	);
-#endif
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//             その他W系API (ANSI版でも利用可能)               //
+	//             その他W系API                                     //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-#ifdef _UNICODE
 	inline int LoadStringW_AnyBuild(
 		HINSTANCE	hInstance,
 		UINT		uID,
@@ -154,14 +84,6 @@ namespace ApiWrap
 	{
 		return ::LoadStringW(hInstance, uID, lpBuffer, nBufferCount);
 	}
-#else
-	int LoadStringW_AnyBuild(
-		HINSTANCE	hInstance,
-		UINT		uID,
-		LPWSTR		lpBuffer,
-		int			nBufferCount	//!< バッファのサイズ。文字単位。
-	);
-#endif
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                    描画API 不具合ラップ                     //

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -54,11 +54,7 @@ namespace ApiWrap{
 	}
 	inline BOOL Wnd_SetText(HWND hwnd, const WCHAR* str)
 	{
-#ifdef _UNICODE
 		return SetWindowTextW(hwnd, str);
-#else
-		return SetWindowTextA(hwnd, to_achar(str));
-#endif
 	}
 
 	/*!

--- a/sakura_core/basis/CMyString.h
+++ b/sakura_core/basis/CMyString.h
@@ -61,11 +61,7 @@ public:
 	int alength() const{ return strlen(c_astr()); }
 
 	//TCHAR
-#ifdef _UNICODE
 	const TCHAR* c_tstr() const{ return c_wstr(); }
-#else
-	const TCHAR* c_tstr() const{ return c_astr(); }
-#endif
 
 private:
 	std::wstring m_wstr;
@@ -73,11 +69,7 @@ private:
 };
 
 //std::string の TCHAR 対応用マクロ定義
-#ifdef _UNICODE
 #define tstring wstring
-#else
-#define tstring string
-#endif
 #define astring string
 
 //共通マクロ

--- a/sakura_core/basis/primitive.h
+++ b/sakura_core/basis/primitive.h
@@ -32,11 +32,7 @@ typedef char ACHAR;
 
 //TCHAR追加機能
 //TCHARと逆の文字型をNOT_TCHARとして定義する
-#ifdef _UNICODE
 typedef char NOT_TCHAR;
-#else
-typedef wchar_t NOT_TCHAR;
-#endif
 
 //WIN_CHAR (WinAPIに渡すので、必ずTCHARでなければならないもの)
 typedef TCHAR WIN_CHAR;

--- a/sakura_core/charset/CharPointer.h
+++ b/sakura_core/charset/CharPointer.h
@@ -108,11 +108,7 @@ private:
 	const wchar_t* m_p;
 };
 
-#ifdef _UNICODE
 typedef CharPointerW CharPointerT;
-#else
-typedef CharPointerA CharPointerT;
-#endif
 
 #endif /* SAKURA_CHARPOINTER_6EAF62A9_67F6_4CEF_80C2_B7C34014C253_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -315,11 +315,7 @@ namespace ACODE
 //TCHAR判定関数群
 namespace TCODE
 {
-	#ifdef _UNICODE
-		using namespace WCODE;
-	#else
-		using namespace ACODE;
-	#endif
+	using namespace WCODE;
 }
 
 // 文字幅の動的計算用キャッシュ関連

--- a/sakura_core/cmd/CViewCommander_Edit.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit.cpp
@@ -240,13 +240,7 @@ void CViewCommander::Command_IME_CHAR( WORD wChar )
 
 	// Oct. 6 ,2002 genta バッファに格納する
 	// Aug. 15, 2007 kobake WCHARバッファに変換する
-#ifdef _UNICODE
 	wchar_t szWord[2]={wChar,0};
-#else
-	ACHAR szAnsiWord[3]={(wChar >> 8) & 0xff, wChar & 0xff, 0};
-	const wchar_t* pUniData = to_wchar(szAnsiWord);
-	wchar_t szWord[2]={pUniData[0],0};
-#endif
 	CLogicInt nWord=CLogicInt(1);
 
 	/* テキストが選択されているか */

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -53,11 +53,7 @@
 //#define USE_UNFIXED_FONT
 
 //UNICODE BOOL定数.
-#ifdef _UNICODE
 static const bool UNICODE_BOOL=true;
-#else
-static const bool UNICODE_BOOL=false;
-#endif
 
 //DebugMonitorLib(仮)を使うかどうか
 //#define USE_DEBUGMON

--- a/sakura_core/config/system_constants.h
+++ b/sakura_core/config/system_constants.h
@@ -50,11 +50,7 @@
 #endif
 
 //! ビルドコード判別、定数サフィックス 2007.09.20 kobake
-#ifdef _UNICODE
-	#define _CODE_SUFFIX_ "WP"
-#else
-	#define _CODE_SUFFIX_ "AP"
-#endif
+#define _CODE_SUFFIX_ "WP"
 
 //! ターゲットマシン判別 2010.08.21 Moca 追加
 #ifdef _WIN64

--- a/sakura_core/debug/Debug1.cpp
+++ b/sakura_core/debug/Debug1.cpp
@@ -46,7 +46,6 @@ void Test()
 
 	引数で与えられた情報をDebugStringとして出力する．
 */
-#ifdef _UNICODE
 void DebugOutW( LPCWSTR lpFmt, ...)
 {
 	//整形
@@ -70,7 +69,6 @@ void DebugOutW( LPCWSTR lpFmt, ...)
 	va_end(argList);
 	return;
 }
-#endif
 
 void DebugOutA( LPCSTR lpFmt, ...)
 {

--- a/sakura_core/debug/Debug1.h
+++ b/sakura_core/debug/Debug1.h
@@ -31,22 +31,14 @@ void DebugOutA( LPCSTR lpFmt, ...);
 	MYTRACEを使う場合には必ず#ifdef _DEBUG ～ #endif で囲む必要がある．
 */
 #ifdef _DEBUG
-	#ifdef _UNICODE
 	#define MYTRACE DebugOutW
-	#else
-	#define MYTRACE DebugOutA
-	#endif
 #else
 	#define MYTRACE   Do_not_use_the_MYTRACE_function_if_release_mode
 #endif
 
 //#ifdef _DEBUG～#endifで囲まなくても良い版
 #ifdef _DEBUG
-	#ifdef _UNICODE
 	#define DEBUG_TRACE DebugOutW
-	#else
-	#define DEBUG_TRACE DebugOutA
-	#endif
 #elif (defined(_MSC_VER) && 1400 <= _MSC_VER) || (defined(__GNUC__) && 3 <= __GNUC__ )
 	#define DEBUG_TRACE(...)
 #else
@@ -56,11 +48,7 @@ void DebugOutA( LPCSTR lpFmt, ...);
 
 //RELEASE版でも出力する版 (RELEASEでのみ発生するバグを監視する目的)
 #ifdef USE_RELPRINT
-	#ifdef _UNICODE
 	#define RELPRINT DebugOutW
-	#else
-	#define RELPRINT DebugOutA
-	#endif
 #else
 	#define RELPRINT   Do_not_define_USE_RELPRINT
 #endif	// USE_RELPRINT

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -85,11 +85,7 @@ const DWORD p_helpids[] = {	//12900
 #endif
 //	To Here Feb. 7, 2002 genta
 
-#ifdef _UNICODE
-	#define TARGET_STRING_MODEL "WP"
-#else
-	#define TARGET_STRING_MODEL "AP"
-#endif
+#define TARGET_STRING_MODEL "WP"
 
 #ifdef _DEBUG
 	#define TARGET_DEBUG_MODE "D"

--- a/sakura_core/dlg/CDlgPluginOption.cpp
+++ b/sakura_core/dlg/CDlgPluginOption.cpp
@@ -40,13 +40,8 @@
 #include "sakura.hh"
 
 // BOOL変数の表示
-#ifdef _UNICODE
 #define	BOOL_DISP_TRUE	_T("\u2611")
 #define	BOOL_DISP_FALSE	_T("\u2610")
-#else
-#define	BOOL_DISP_TRUE	_T("<True>")
-#define	BOOL_DISP_FALSE	_T("<False>")
-#endif
 
 // 編集領域を表示、非表示にする
 static inline void CtrlShow(HWND hwndDlg, int id, BOOL bShow)

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -577,7 +577,7 @@ void CLayoutMgr::CalculateTextWidth_Range( const CalTextWidthArg* pctwArg )
 			bCalTextWidth = FALSE;		// テキスト最大幅の算出要求をOFF
 		}
 
-#if defined( _DEBUG ) && defined( _UNICODE )
+#if defined( _DEBUG )
 		static int testcount = 0;
 		testcount++;
 

--- a/sakura_core/extmodule/CMigemo.h
+++ b/sakura_core/extmodule/CMigemo.h
@@ -131,11 +131,7 @@ public:
 	void migemo_setproc_int2char(MIGEMO_PROC_INT2CHAR proc);
 	int migemo_load_a(int dict_id, const char* dict_file);
 	int migemo_load_w(int dict_id, const wchar_t* dict_file);
-#ifdef _UNICODE
 	#define migemo_load_t migemo_load_w
-#else
-	#define migemo_load_t migemo_load_a
-#endif
 	int migemo_is_enable();
 	int migemo_load_all();
 };

--- a/sakura_core/macro/CIfObj.cpp
+++ b/sakura_core/macro/CIfObj.cpp
@@ -37,7 +37,7 @@
 #include "macro/CIfObj.h"
 
 //トレースメッセージ有無
-#if defined( _DEBUG ) && defined( _UNICODE )
+#if defined( _DEBUG )
 #define TEST
 #endif
 

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -100,13 +100,8 @@ public:
 	const wchar_t* GetStringW() const;
 
 	//TCHAR
-#ifdef _UNICODE
 	void SetStringT( const TCHAR* pszData )				{ return SetStringNew(pszData); }
 	void SetStringT( const TCHAR* pData, int nLength )	{ return SetStringNew(pData,nLength); }
-#else
-	void SetStringT( const TCHAR* pszData )				{ return SetString(pszData); }
-	void SetStringT( const TCHAR* pData, int nLength )	{ return SetString(pData,nLength); }
-#endif
 
 public:
 	// -- -- staticインターフェース -- -- //

--- a/sakura_core/mem/CNativeT.h
+++ b/sakura_core/mem/CNativeT.h
@@ -28,11 +28,7 @@
 class CNativeW;
 class CNativeA;
 
-#ifdef _UNICODE
 typedef CNativeW CNativeT;
-#else
-typedef CNativeA CNativeT;
-#endif
 
 #include "mem/CNativeA.h"
 #include "mem/CNativeW.h"

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -173,21 +173,12 @@ public:
 	const wchar_t* GetStringW() const						{ return GetStringPtr(); }
 
 	//TCHAR
-#ifdef _UNICODE
 	void SetStringT( const TCHAR* pData, int nDataLen )	{ return SetString(pData,nDataLen); }
 	void SetStringT( const TCHAR* pszData )				{ return SetString(pszData); }
 	void AppendStringT(const TCHAR* pszData)			{ return AppendString(pszData); }
 	void AppendStringT(const TCHAR* pData, int nLength)	{ return AppendString(pData,nLength); }
 	void AppendNativeDataT(const CNativeT& rhs)			{ return AppendNativeData(rhs); }
 	const TCHAR* GetStringT() const						{ return GetStringPtr(); }
-#else
-	void SetStringT( const TCHAR* pData, int nDataLen )	{ return SetStringOld(pData,nDataLen); }
-	void SetStringT( const TCHAR* pszData )				{ return SetStringOld(pszData); }
-	void AppendStringT(const TCHAR* pszData)			{ return AppendStringOld(pszData); }
-	void AppendStringT(const TCHAR* pData, int nLength)	{ return AppendStringOld(pData,nLength); }
-	void AppendNativeDataT(const CNativeT& rhs)			{ return AppendStringOld(rhs.GetStringPtr(), rhs.GetStringLength()); }
-	const TCHAR* GetStringT() const						{ return GetStringPtrOld(); }
-#endif
 
 public:
 	// -- -- staticインターフェース -- -- //

--- a/sakura_core/outline/CFuncInfoArr.cpp
+++ b/sakura_core/outline/CFuncInfoArr.cpp
@@ -160,12 +160,6 @@ void CFuncInfoArr::SetAppendText( int info, std::wstring s, bool overwrite )
 		if( m_nAppendTextLenMax < (int)s.length() ){
 			m_nAppendTextLenMax = s.length();
 		}
-#ifndef	_UNICODE
-		std::tstring t = to_tchar(s.c_str());
-		if( m_nAppendTextLenMax < (int)t.length() ){
-			m_nAppendTextLenMax = t.length();
-		}
-#endif
 	}else{
 		// キーが存在する場合、値を書き換える
 		if( overwrite ){

--- a/sakura_core/plugin/CPlugin.cpp
+++ b/sakura_core/plugin/CPlugin.cpp
@@ -73,13 +73,11 @@ bool CPlugin::ReadPluginDefCommon( CDataProfile *cProfile, CDataProfile *cProfil
 		cProfileMlang->IOProfileData( PII_PLUGIN, PII_PLUGIN_URL, m_sUrl );
 	}
 
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("    Name:%ls\n"), m_sName.c_str());
 	DEBUG_TRACE(_T("    Description:%ls\n"), m_sDescription.c_str());
 	DEBUG_TRACE(_T("    Author:%ls\n"), m_sAuthor.c_str());
 	DEBUG_TRACE(_T("    Version:%ls\n"), m_sVersion.c_str());
 	DEBUG_TRACE(_T("    Url:%ls\n"), m_sUrl.c_str());
-#endif
 
 	return true;
 }

--- a/sakura_core/plugin/CPluginManager.cpp
+++ b/sakura_core/plugin/CPluginManager.cpp
@@ -71,9 +71,7 @@ void CPluginManager::UnloadAllPlugin()
 //新規プラグインを追加する
 bool CPluginManager::SearchNewPlugin( CommonSetting& common, HWND hWndOwner )
 {
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("Enter SearchNewPlugin\n"));
-#endif
 
 	HANDLE hFind;
 	CZipFile	cZipFile;
@@ -116,9 +114,7 @@ bool CPluginManager::SearchNewPlugin( CommonSetting& common, HWND hWndOwner )
 //新規プラグインを追加する(下請け)
 bool CPluginManager::SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, const tstring& sSearchDir, bool& bCancel )
 {
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("Enter SearchNewPluginDir\n"));
-#endif
 
 	PluginRec* plugin_table = common.m_sPlugin.m_PluginTable;
 	HANDLE hFind;
@@ -176,9 +172,7 @@ bool CPluginManager::SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, 
 //新規プラグインを追加する(下請け)Zip File
 bool CPluginManager::SearchNewPluginZip( CommonSetting& common, HWND hWndOwner, const tstring& sSearchDir, bool& bCancel )
 {
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("Enter SearchNewPluginZip\n"));
-#endif
 
 	HANDLE hFind;
 
@@ -211,9 +205,7 @@ bool CPluginManager::SearchNewPluginZip( CommonSetting& common, HWND hWndOwner, 
 //Zipプラグインを導入する
 bool CPluginManager::InstZipPlugin( CommonSetting& common, HWND hWndOwner, const tstring& sZipFile, bool bInSearch )
 {
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("Entry InstZipPlugin\n"));
-#endif
 
 	CZipFile		cZipFile;
 	TCHAR			msg[512];
@@ -440,9 +432,8 @@ int CPluginManager::InstallPlugin( CommonSetting& common, const TCHAR* pszPlugin
 //全プラグインを読み込む
 bool CPluginManager::LoadAllPlugin(CommonSetting* common)
 {
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("Enter LoadAllPlugin\n"));
-#endif
+
 	CommonSetting_Plugin& pluginSetting = (common ? common->m_sPlugin : GetDllShareData().m_Common.m_sPlugin);
 
 	if( ! pluginSetting.m_bEnablePlugin ) return true;
@@ -507,9 +498,8 @@ CPlugin* CPluginManager::LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* psz
 	CDataProfile cProfOption;			//オプションファイル
 	CPlugin* plugin = NULL;
 
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("Load Plugin %ts\n"),  pszPluginName );
-#endif
+
 	//プラグイン定義ファイルを読み込む
 	Concat_FolderAndFile( pszPluginDir, pszPluginName, pszBasePath );
 	Concat_FolderAndFile( pszBasePath, PII_FILENAME, pszPath );
@@ -518,9 +508,7 @@ CPlugin* CPluginManager::LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* psz
 		//プラグイン定義ファイルが存在しない
 		return NULL;
 	}
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("  定義ファイル読込 %ts\n"),  pszPath );
-#endif
 
 	//L10N定義ファイルを読む
 	//プラグイン定義ファイルを読み込む base\pluginname\local\plugin_en_us.def
@@ -529,13 +517,9 @@ CPlugin* CPluginManager::LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* psz
 	if( !cProfDefMLang.ReadProfile( strMlang.c_str() ) ){
 		//プラグイン定義ファイルが存在しない
 		pcProfDefMLang = NULL;
-#ifdef _UNICODE
 		DEBUG_TRACE(_T("  L10N定義ファイル読込 %ts Not Found\n"),  strMlang.c_str() );
-#endif
 	}else{
-#ifdef _UNICODE
 		DEBUG_TRACE(_T("  L10N定義ファイル読込 %ts\n"),  strMlang.c_str() );
-#endif
 	}
 
 	std::wstring sPlugType;
@@ -551,9 +535,7 @@ CPlugin* CPluginManager::LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* psz
 	plugin->m_sOptionDir = m_sBaseDir + pszPluginName;
 	plugin->m_sLangName = pszLangName;
 	plugin->ReadPluginDef( &cProfDef, pcProfDefMLang );
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("  プラグインタイプ %ls\n"), sPlugType.c_str() );
-#endif
 
 	//オプションファイルを読み込む
 	cProfOption.SetReadingMode();
@@ -561,9 +543,7 @@ CPlugin* CPluginManager::LoadPlugin( const TCHAR* pszPluginDir, const TCHAR* psz
 		//オプションファイルが存在する場合、読み込む
 		plugin->ReadPluginOption( &cProfOption );
 	}
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("  オプションファイル読込 %ts\n"),  plugin->GetOptionPath().c_str() );
-#endif
 
 	return plugin;
 }

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -1263,7 +1263,7 @@ void CPrintPreview::DrawHeaderFooter( HDC hdc, const CMyRect& rect, bool bHeader
 			bHeader ? m_pPrintSetting->m_szHeaderForm[POS_LEFT] : m_pPrintSetting->m_szFooterForm[POS_LEFT],
 			szWork, nWorkLen);
 		Tab2Space( szWork );
-		::ExtTextOutW_AnyBuild(
+		::ExtTextOut(
 			hdc,
 			rect.left,
 			nY,
@@ -1282,7 +1282,7 @@ void CPrintPreview::DrawHeaderFooter( HDC hdc, const CMyRect& rect, bool bHeader
 		SIZE	Size;
 		nLen = wcslen(szWork);
 		::GetTextExtentPoint32W( hdc, szWork, nLen, &Size);		//テキスト幅
-		::ExtTextOutW_AnyBuild(
+		::ExtTextOut(
 			hdc,
 			( rect.right + rect.left - Size.cx) / 2,
 			nY,
@@ -1300,7 +1300,7 @@ void CPrintPreview::DrawHeaderFooter( HDC hdc, const CMyRect& rect, bool bHeader
 		Tab2Space( szWork );
 		nLen = wcslen(szWork);
 		::GetTextExtentPoint32W( hdc, szWork, nLen, &Size);		//テキスト幅
-		::ExtTextOutW_AnyBuild(
+		::ExtTextOut(
 			hdc,
 			rect.right - Size.cx,
 			nY,
@@ -1515,7 +1515,7 @@ CColorStrategy* CPrintPreview::DrawPageText(
 				int spacing = 0;
 				const int* pDxArray = CTextMetrics::GenerateDxArray(&vDxArray, szLineNum, nLineCols, m_pPrintSetting->m_nPrintFontWidth, spacing);
 
-				ApiWrap::ExtTextOutW_AnyBuild(
+				::ExtTextOut(
 					hdc,
 					nBasePosX - nLineCols * charWidth,
 					nDirectY * ( nOffY + nLineHeight * i + ( m_pPrintSetting->m_nPrintFontHeight - m_nAscentHan ) ),
@@ -1834,7 +1834,7 @@ void CPrintPreview::Print_DrawBlock(
 	}
 	const int charWidth = 1;
 	::SelectObject( hdc, hFont );
-	::ExtTextOutW_AnyBuild(
+	::ExtTextOut(
 		hdc,
 		ptDraw.x + (Int)nLayoutX * charWidth,
 		ptDraw.y - ( m_pPrintSetting->m_nPrintFontHeight - (nKind == 1 ? m_nAscentZen : m_nAscentHan) ),

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -1127,11 +1127,7 @@ static HTREEITEM TreeCopy( HWND hwndTree, HTREEITEM dst, HTREEITEM src, bool fCh
 	TV_INSERTSTRUCT	tvis;		// 挿入用
 	TV_ITEM			tvi;		// 取得用
 	int				n = 0;
-#ifdef _UNICODE
 	const int		MAX_LABEL_CCH = 256+10;
-#else
-	const int		MAX_LABEL_CCH = (256+10)*2;
-#endif
 	TCHAR			szLabel[MAX_LABEL_CCH];
 
 	for (s = src; s != NULL; s = fOnryOne ? NULL:TreeView_GetNextSibling( hwndTree, s )) {

--- a/sakura_core/uiparts/CImageListMgr.cpp
+++ b/sakura_core/uiparts/CImageListMgr.cpp
@@ -55,7 +55,7 @@ static void FillSolidRect( HDC hdc, int x, int y, int cx, int cy, COLORREF clr)
 	RECT rect;
 	::SetBkColor( hdc, clr );
 	::SetRect( &rect, x, y, x + cx, y + cy );
-	::ExtTextOutW_AnyBuild( hdc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL );
+	::ExtTextOut( hdc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL );
 }
 
 //	Destructor

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -913,91 +913,6 @@ void GetExistPathW( wchar_t *po , const wchar_t *pi )
 	return;
 }
 
-#ifndef _UNICODE
-/* 与えられたコマンドライン文字列の先頭部分から実在するファイル・ディレクトリ
-　 のパス文字列を抽出し、そのパスを分解して drv dir fnm ext に書き込む。
-　 先頭部分に有効なパス名が存在しない場合、全てに空文字列が返る。 */
-void	my_splitpath ( const char *comln , char *drv,char *dir,char *fnm,char *ext )
-{
-	char	ppp[_MAX_PATH];		/* パス格納（作業用） */
-	char	*pd;
-	char	*pf;
-	char	*pe;
-	char	ch;
-	DWORD	attr;
-	int		a_dir;
-
-	if( drv != NULL )	*drv = '\0';
-	if( dir != NULL )	*dir = '\0';
-	if( fnm != NULL )	*fnm = '\0';
-	if( ext != NULL )	*ext = '\0';
-	if( *comln == '\0' )	return;
-
-	/* コマンドライン先頭部分の実在するパス名を ppp に書き出す。 */
-	GetExistPath( ppp , comln );
-
-	if( *ppp != '\0' ) {	/* ファイル・ディレクトリが存在する場合 */
-		/* 先頭文字がドライブレターかどうか判定し、
-		　 pd = ディレクトリ名の先頭位置に設定する。 */
-		pd = ppp;
-		if(
-			( *(pd+1)==':' )&&
-			( ACODE::IsAZ(*pd) )
-		){	/* 先頭にドライブレターがある。 */
-			pd += 2;	/* pd = ドライブレター部の後ろ         */
-		}				/*      ( = ディレクトリ名の先頭位置 ) */
-		/* ここまでで、pd = ディレクトリ名の先頭位置 */
-
-		attr =  GetFileAttributesA(ppp);
-		a_dir = ( attr & FILE_ATTRIBUTE_DIRECTORY ) ?  1 : 0;
-		if( ! a_dir ){	/* 見つけた物がファイルだった場合。 */
-			pf = sjis_strrchr2(ppp,'\\','\\');	/* 最末尾の \ を探す。 */
-			if(pf != NULL)	pf++;		/* 見つかった→  pf=\の次の文字の位置*/
-			else			pf = pd;	/* 見つからない→pf=パス名の先頭位置 */
-			/* ここまでで pf = ファイル名の先頭位置 */
-			pe = sjis_strrchr2(pf,'.','.');		/* 最末尾の '.' を探す。 */
-			if( pe != NULL ){					/* 見つかった(pe = '.'の位置)*/
-				if( ext != NULL ){	/* 拡張子を返値として書き込む。 */
-					strncpy(ext,pe,_MAX_EXT -1);
-					ext[_MAX_EXT -1] = '\0';
-				}
-				*pe = '\0';	/* 区切り位置を文字列終端にする。pe = 拡張子名の先頭位置。 */
-			}
-			if( fnm != NULL ){	/* ファイル名を返値として書き込む。 */
-				strncpy(fnm,pf,_MAX_FNAME -1);
-				fnm[_MAX_FNAME -1] = '\0';
-			}
-			*pf = '\0';	/* ファイル名の先頭位置を文字列終端にする。 */
-		}
-		/* ここまでで文字列 ppp はドライブレター＋ディレクトリ名のみになっている */
-		if( dir != NULL ){
-			/* ディレクトリ名の最後の文字が \ ではない場合、\ にする。 */
-
-			/* ↓最後の文字を ch に得る。(ディレクトリ文字列が空の場合 ch='\\' となる) */
-			for( ch = '\\' , pf = pd ; *pf != '\0' ; pf++ ){
-				ch = *pf;
-				if( _IS_SJIS_1(*pf) )	pf++;	/* Shift_JIS の1文字目なら次の1文字をスキップ */
-			}
-			/* 文字列が空でなく、かつ、最後の文字が \ でなかったならば \ を追加。 */
-			if( ( ch != '\\' ) && ( strlen(ppp) < _MAX_PATH -1 ) ){
-				*pf++ = '\\';	*pf = '\0';
-			}
-
-			/* ディレクトリ名を返値として書き込む。 */
-			strncpy(dir,pd,_MAX_DIR -1);
-			dir[_MAX_DIR -1] = '\0';
-		}
-		*pd = '\0';		/* ディレクトリ名の先頭位置を文字列終端にする。 */
-		if( drv != NULL ){	/* ドライブレターを返値として書き込む。 */
-			strncpy(drv,ppp,_MAX_DRIVE -1);
-			drv[_MAX_DRIVE -1] = '\0';
-		}
-	}
-	return;
-}
-
-#else
-
 /* 与えられたコマンドライン文字列の先頭部分から実在するファイル・ディレクトリ
 　 のパス文字列を抽出し、そのパスを分解して drv dir fnm ext に書き込む。
 　 先頭部分に有効なパス名が存在しない場合、全てに空文字列が返る。 */
@@ -1082,7 +997,6 @@ void my_splitpath_w (
 	}
 	return;
 }
-#endif
 
 //
 //

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -102,11 +102,7 @@ bool GetLastWriteTimestamp( const TCHAR* filename, CFileTime* pcFileTime ); //	O
 void my_splitpath ( const char *comln , char *drv,char *dir,char *fnm,char *ext );
 void my_splitpath_w ( const wchar_t *comln , wchar_t *drv,wchar_t *dir,wchar_t *fnm,wchar_t *ext );
 void my_splitpath_t ( const TCHAR *comln , TCHAR *drv,TCHAR *dir,TCHAR *fnm,TCHAR *ext );
-#ifdef _UNICODE
 #define my_splitpath_t my_splitpath_w
-#else
-#define my_splitpath_t my_splitpath
-#endif
 
 int FileMatchScoreSepExt( const TCHAR *file1, const TCHAR *file2 );
 

--- a/sakura_core/util/format.cpp
+++ b/sakura_core/util/format.cpp
@@ -163,9 +163,7 @@ UINT32 ParseVersion( const TCHAR* sVer )
 		ret |= ( 128 << (24-8*i) );
 	}
 
-#ifdef _UNICODE
 	DEBUG_TRACE(_T("ParseVersion %ls -> %08x\n"), sVer, ret);
-#endif
 	return ret;
 }
 

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -210,13 +210,7 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 						LPITEMIDLIST pIDL;
 						WCHAR pwszDisplayName[_MAX_PATH];
 						_tcstowcs(pwszDisplayName, szPath, _countof(pwszDisplayName));
-//#ifdef _UNICODE
 //						pwszDisplayName = szPath;
-//#else
-//						WCHAR wszPath[_MAX_PATH];
-//						::MultiByteToWideChar( CP_ACP, 0, szPath, -1, wszPath, _MAX_PATH );
-//						pwszDisplayName = wszPath;
-//#endif
 						if( SUCCEEDED(pDesktopFolder->ParseDisplayName(NULL, NULL, pwszDisplayName, NULL, &pIDL, NULL)) ){
 							SHELLEXECUTEINFO si;
 							::ZeroMemory( &si, sizeof(si) );

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -521,64 +521,33 @@ void wcstombs_vector(const wchar_t* pSrc, int nSrcLen, std::vector<char>* ret)
 	(*ret)[nNewLen]='\0';
 }
 
-#ifdef _UNICODE
-	size_t _tcstowcs(WCHAR* wszDst, const TCHAR* tszSrc, size_t nDstCount)
-	{
-		wcsncpy_s(wszDst, nDstCount, tszSrc, _TRUNCATE);
-		return wcslen(wszDst);
-	}
-	size_t _tcstombs(CHAR*  szDst,  const TCHAR* tszSrc, size_t nDstCount)
-	{
-		return wcstombs2(szDst, tszSrc, nDstCount);
-	}
-	size_t _wcstotcs(TCHAR* tszDst, const WCHAR* wszSrc, size_t nDstCount)
-	{
-		wcsncpy_s(tszDst, nDstCount, wszSrc, _TRUNCATE);
-		return wcslen(tszDst);
-	}
-	size_t _mbstotcs(TCHAR* tszDst, const CHAR*  szSrc,  size_t nDstCount)
-	{
-		return mbstowcs2(tszDst, szSrc, nDstCount);
-	}
-	int _tctomb(const TCHAR* p,ACHAR* mb)
-	{
-		return wctomb(mb,*p);
-	}
-	int _tctowc(const TCHAR* p,WCHAR* wc)
-	{
-		*wc=*p;
-		return 1;
-	}
-#else
-	size_t _tcstowcs(WCHAR* wszDst, const TCHAR* tszSrc, size_t nDstCount)
-	{
-		return mbstowcs2(wszDst, tszSrc, nDstCount);
-	}
-	size_t _tcstombs(CHAR*  szDst,  const TCHAR* tszSrc, size_t nDstCount)
-	{
-		strncpy_s(szDst, nDstCount, tszSrc, _TRUNCATE);
-		return strlen(szDst);
-	}
-	size_t _wcstotcs(TCHAR* tszDst, const WCHAR* wszSrc, size_t nDstCount)
-	{
-		return wcstombs2(tszDst, wszSrc, nDstCount);
-	}
-	size_t _mbstotcs(TCHAR* tszDst, const CHAR*  szSrc,  size_t nDstCount)
-	{
-		strncpy_s(tszDst, nDstCount, szSrc, _TRUNCATE);
-		return strlen(tszDst);
-	}
-	int _tctomb(const TCHAR* tc,ACHAR* mb)
-	{
-		mb[0]=tc[0];
-		if(_IS_SJIS_1(tc[0])){ mb[1]=tc[1]; return 2; }
-		return 1;
-	}
-	int _tctowc(const TCHAR* tc,WCHAR* wc)
-	{
-		return mbtowc(wc,tc,_IS_SJIS_1(tc[0])?2:1);
-	}
-#endif
+size_t _tcstowcs(WCHAR* wszDst, const TCHAR* tszSrc, size_t nDstCount)
+{
+	wcsncpy_s(wszDst, nDstCount, tszSrc, _TRUNCATE);
+	return wcslen(wszDst);
+}
+size_t _tcstombs(CHAR*  szDst,  const TCHAR* tszSrc, size_t nDstCount)
+{
+	return wcstombs2(szDst, tszSrc, nDstCount);
+}
+size_t _wcstotcs(TCHAR* tszDst, const WCHAR* wszSrc, size_t nDstCount)
+{
+	wcsncpy_s(tszDst, nDstCount, wszSrc, _TRUNCATE);
+	return wcslen(tszDst);
+}
+size_t _mbstotcs(TCHAR* tszDst, const CHAR*  szSrc,  size_t nDstCount)
+{
+	return mbstowcs2(tszDst, szSrc, nDstCount);
+}
+int _tctomb(const TCHAR* p,ACHAR* mb)
+{
+	return wctomb(mb,*p);
+}
+int _tctowc(const TCHAR* p,WCHAR* wc)
+{
+	*wc=*p;
+	return 1;
+}
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                          メモリ                             //

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -78,13 +78,8 @@ inline wchar_t my_towupper2( wchar_t c ){ return my_towupper(c); }
 inline wchar_t my_towlower2( wchar_t c ){ return my_towlower(c); }
 int skr_towupper( int c );
 int skr_towlower( int c );
-#ifdef _UNICODE
 #define _tcs_toupper skr_towupper
 #define _tcs_tolower skr_towlower
-#else
-#define _tcs_toupper my_toupper
-#define _tcs_tolower my_tolower
-#endif
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           拡張・独自実装                    //
@@ -101,11 +96,7 @@ const WCHAR* wcsistr( const WCHAR* s1, const WCHAR* s2 );
 const ACHAR* stristr( const ACHAR* s1, const ACHAR* s2 );
 inline WCHAR* wcsistr( WCHAR* s1, const WCHAR* s2 ){ return const_cast<WCHAR*>(wcsistr(static_cast<const WCHAR*>(s1),s2)); }
 inline ACHAR* stristr( ACHAR* s1, const ACHAR* s2 ){ return const_cast<ACHAR*>(stristr(static_cast<const ACHAR*>(s1),s2)); }
-#ifdef _UNICODE
 #define _tcsistr wcsistr
-#else
-#define _tcsistr stristr
-#endif
 
 //大文字小文字を区別せずに文字列を検索（日本語対応版）
 const char* strchr_j(const char* s1, char c);				//!< strchr の日本語対応版。
@@ -116,11 +107,7 @@ inline char* strchr_j ( char* s1, char c         ){ return const_cast<char*>(str
 inline char* strichr_j( char* s1, char c         ){ return const_cast<char*>(strichr_j((const char*)s1, c )); }
 inline char* strstr_j ( char* s1, const char* s2 ){ return const_cast<char*>(strstr_j ((const char*)s1, s2)); }
 inline char* stristr_j( char* s1, const char* s2 ){ return const_cast<char*>(stristr_j((const char*)s1, s2)); }
-#ifdef _UNICODE
 #define _tcsistr_j wcsistr
-#else
-#define _tcsistr_j stristr_j
-#endif
 
 template <class CHAR_TYPE>
 CHAR_TYPE* my_strtok(
@@ -159,7 +146,6 @@ int my_strnicmp( const char *s1, const char *s2, size_t n );
 
 	size_t strnlen(const char *str, size_t num);
 	size_t wcsnlen(const wchar_t *str, size_t num);
-#ifdef _UNICODE
 #define _tcscpy_s wcscpy_s
 #define _tcsncpy_s wcsncpy_s
 #define _tcscat_s wcscat_s
@@ -167,15 +153,6 @@ int my_strnicmp( const char *s1, const char *s2, size_t n );
 #define _tcsncicmp _wcsnicmp
 #define _ttempnam _wtempnam
 #define _tWinMain wWinMain
-#else
-#define _tcscpy_s strcpy_s
-#define _tcsncpy_s strncpy_s
-#define _tcscat_s strcat_s
-#define _tcsnlen strnlen
-#define _tcsncicmp _strnicmp
-#define _ttempnam tempnam
-#define _tWinMain WinMain
-#endif
 #endif
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -322,11 +299,7 @@ inline int wcsncmp_auto(const wchar_t* strData1, const wchar_t* szData2)
 	::strncmp(strData1, literalData2, _countof(literalData2) - 1 ) //※終端ヌルを含めないので、_countofからマイナス1する
 
 //TCHAR
-#ifdef _UNICODE
-	#define _tcsncmp_literal wcsncmp_literal
-#else
-	#define _tcsncmp_literal strncmp_literal
-#endif
+#define _tcsncmp_literal wcsncmp_literal
 
 #endif /* SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/string_ex2.h
+++ b/sakura_core/util/string_ex2.h
@@ -35,20 +35,12 @@ wchar_t *wcs_pushW(wchar_t *dst, size_t dst_count, const wchar_t* src, size_t sr
 wchar_t *wcs_pushW(wchar_t *dst, size_t dst_count, const wchar_t* src);
 wchar_t *wcs_pushA(wchar_t *dst, size_t dst_count, const char* src, size_t src_count);
 wchar_t *wcs_pushA(wchar_t *dst, size_t dst_count, const char* src);
-#ifdef _UNICODE
 #define wcs_pushT wcs_pushW
-#else
-#define wcs_pushT wcs_pushA
-#endif
 
 int AddLastChar( TCHAR* pszPath, int nMaxLen, TCHAR c );/* 2003.06.24 Moca 最後の文字が指定された文字でないときは付加する */
 int LimitStringLengthA( const ACHAR* pszData, int nDataLength, int nLimitLength, CNativeA& cmemDes );/* データを指定「文字数」以内に切り詰める */
 int LimitStringLengthW( const WCHAR* pszData, int nDataLength, int nLimitLength, CNativeW& cmemDes );/* データを指定「文字数」以内に切り詰める */
-#ifdef _UNICODE
 #define LimitStringLengthT LimitStringLengthW
-#else
-#define LimitStringLengthT LimitStringLengthA
-#endif
 
 const char* GetNextLimitedLengthText( const char* pText, int nTextLen, int nLimitLen, int* pnLineLen, int* pnBgn );/* 指定長以下のテキストに切り分ける */
 const char*    GetNextLine  ( const char* pData, int nDataLen, int* pnLineLen, int* pnBgn, CEol* pcEol); /* CR0LF0,CRLF,LF,CRで区切られる「行」を返す。改行コードは行長に加えない */

--- a/sakura_core/util/tchar_convert.h
+++ b/sakura_core/util/tchar_convert.h
@@ -38,13 +38,8 @@ const ACHAR* to_achar(const WCHAR* src);
 const ACHAR* to_achar(const WCHAR* pSrc, int nSrcLength);
 
 //TCHARに変換
-#ifdef _UNICODE
-	#define to_tchar     to_wchar
-	#define to_not_tchar to_achar
-#else
-	#define to_tchar     to_achar
-	#define to_not_tchar to_wchar
-#endif
+#define to_tchar     to_wchar
+#define to_not_tchar to_achar
 
 //その他
 const WCHAR* easy_format(const WCHAR* format, ...);

--- a/sakura_core/util/tchar_printf.cpp
+++ b/sakura_core/util/tchar_printf.cpp
@@ -219,22 +219,14 @@ static void my_va_forward(va_list& v, const wchar_t* field, const wchar_t* prefi
 static void field_convert(char* src)
 {
 	if(strncmp(src,"%ts",3)==0 || strncmp(src,"%tc",3)==0){
-#ifdef _UNICODE
 		src[1]='l';
-#else
-		src[1]='h';
-#endif
 	}
 }
 
 static void field_convert(wchar_t* src)
 {
 	if(wcsncmp(src,L"%ts",3)==0 || wcsncmp(src,L"%tc",3)==0){
-#ifdef _UNICODE
 		src[1]=L'l';
-#else
-		src[1]=L'h';
-#endif
 	}
 }
 

--- a/sakura_core/util/tchar_receive.cpp
+++ b/sakura_core/util/tchar_receive.cpp
@@ -4,25 +4,13 @@
 using namespace std;
 
 //TcharReceiver実装
-#ifdef _UNICODE
-	//UNICODEビルドで、WCHARを受け取る
-	template <> TCHAR* TcharReceiver<WCHAR>::GetBufferPointer(){ return m_pReceiver; }
-	template <> void   TcharReceiver<WCHAR>::Apply(){} //何もしない
+//UNICODEビルドで、WCHARを受け取る
+template <> TCHAR* TcharReceiver<WCHAR>::GetBufferPointer(){ return m_pReceiver; }
+template <> void   TcharReceiver<WCHAR>::Apply(){} //何もしない
 
-	//UNICODEビルドで、ACHARを受け取る
-	template <> TCHAR* TcharReceiver<ACHAR>::GetBufferPointer(){ return (m_pBuff = new TCHAR[m_nReceiverCount]); }
-	template <> void   TcharReceiver<ACHAR>::Apply(){ _tcstombs(m_pReceiver, m_pBuff, m_nReceiverCount); delete []m_pBuff; }
-
-#else
-	//ANSIビルドで、WCHARを受け取る
-	template <> TCHAR* TcharReceiver<WCHAR>::GetBufferPointer(){ return (m_pBuff = new TCHAR[m_nReceiverCount]); }
-	template <> void   TcharReceiver<WCHAR>::Apply(){ _tcstowcs(m_pReceiver, m_pBuff, m_nReceiverCount); delete []m_pBuff; }
-
-	//ANSIビルドで、ACHARを受け取る
-	template <> TCHAR* TcharReceiver<ACHAR>::GetBufferPointer(){ return m_pReceiver; }
-	template <> void   TcharReceiver<ACHAR>::Apply(){} //何もしない
-
-#endif
+//UNICODEビルドで、ACHARを受け取る
+template <> TCHAR* TcharReceiver<ACHAR>::GetBufferPointer(){ return (m_pBuff = new TCHAR[m_nReceiverCount]); }
+template <> void   TcharReceiver<ACHAR>::Apply(){ _tcstombs(m_pReceiver, m_pBuff, m_nReceiverCount); delete []m_pBuff; }
 
 //インスタンス化
 template class TcharReceiver<WCHAR>;

--- a/sakura_core/version.h
+++ b/sakura_core/version.h
@@ -28,11 +28,7 @@
 #define PR_VER_STR  MAKE_VERSION_STR_PERIOD(VER_A, VER_B, VER_C, VER_D)
 #define PR_VER      MAKE_VERSION_COMMA(VER_A, VER_B, VER_C, VER_D)
 
-#ifdef _UNICODE
 #define VER_CHARSET "UNICODE"
-#else
-#define VER_CHARSET "ANSI"
-#endif
 
 #ifdef _WIN64
 #define VER_PLATFORM "64bit"

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -420,13 +420,7 @@ void CEditView::Close()
 //TCHAR→WCHAR変換。
 inline wchar_t tchar_to_wchar(TCHAR tc)
 {
-#ifdef _UNICODE
 	return tc;
-#else
-	WCHAR wc=0;
-	mbtowc(&wc,&tc,sizeof(tc));
-	return wc;
-#endif
 }
 
 /*
@@ -519,35 +513,12 @@ LRESULT CEditView::DispatchEvent(
 
 		return 0L;
 	case WM_CHAR:
-#ifdef _UNICODE
 		// コントロールコード入力禁止
 		if( WCODE::IsControlCode((wchar_t)wParam) ){
 			ErrorBeep();
 		}else{
 			GetCommander().HandleCommand( F_WCHAR, true, WCHAR(wParam), 0, 0, 0 );
 		}
-#else
-		// SJIS固有
-		{
-			static BYTE preChar = 0;
-			if( preChar == 0 && ! _IS_SJIS_1((unsigned char)wParam) ){
-				// ASCII , 半角カタカナ
-				if( ACODE::IsControlCode((char)wParam) ){
-					ErrorBeep();
-				}else{
-					GetCommander().HandleCommand( F_WCHAR, true, tchar_to_wchar((ACHAR)wParam), 0, 0, 0 );
-				}
-			}else{
-				if( preChar ){
-					WORD wordData = MAKEWORD((BYTE)wParam, preChar);
-					GetCommander().HandleCommand( F_IME_CHAR, true, wordData, 0, 0, 0 );
-					preChar = 0;
-				}else{
-					preChar = (BYTE)wParam;
-				}
-			}
-		}
-#endif
 		return 0L;
 
 	case WM_IME_NOTIFY:	// Nov. 26, 2006 genta
@@ -600,12 +571,7 @@ LRESULT CEditView::DispatchEvent(
 				m_nMousePouse = -1;
 				::SetCursor( NULL );
 			}
-#ifdef _UNICODE
 			GetCommander().HandleCommand( F_INSTEXT_W, true, (LPARAM)lptstr, wcslen(lptstr), TRUE, 0 );
-#else
-			std::wstring wstr = to_wchar(lptstr);
-			GetCommander().HandleCommand( F_INSTEXT_W, true, (LPARAM)wstr.c_str(), wstr.length(), TRUE, 0 );
-#endif
 			m_bHokan = bHokan;	// 消されても表示中であるかのように誤魔化して入力補完を動作させる
 			ImmReleaseContext( hwnd, hIMC );
 
@@ -918,12 +884,7 @@ LRESULT CEditView::DispatchEvent(
 	{
 		// wParam RedoUndoフラグは無視する
 		if( lParam ){
-#ifdef _UNICODE
 			GetCommander().HandleCommand( F_INSTEXT_W, true, lParam, wcslen((wchar_t*)lParam), TRUE, 0 );
-#else
-			std::wstring text = to_wchar((LPCTSTR)lParam);
-			GetCommander().HandleCommand( F_INSTEXT_W, true, (LPARAM)text.c_str(), text.length(), TRUE, 0 );
-#endif
 		}
 		return 0L; // not use.
 	}

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -2136,11 +2136,7 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 				_tsplitpath( szWork, NULL, NULL, szPath, szExt );
 				::lstrcat( szPath, szExt );
 			}
-#ifdef _UNICODE
 			cmemBuf.AppendString( szPath );
-#else
-			cmemBuf.AppendStringOld( szPath );
-#endif
 			if( nFiles > 1 ){
 				cmemBuf.AppendString( m_pcEditDoc->m_cDocEditor.GetNewLineCode().GetValue2() );
 			}

--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -163,7 +163,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 			::MoveToEx( gr, nX, nY, NULL );
 			::LineTo( gr, nX, 0 );
 			_itow( ((Int)keta) / 10, szColumn, 10 );
-			::TextOutW_AnyBuild( gr, nX + 2 + 0, -1 + 0, szColumn, wcslen( szColumn ) );
+			::TextOut( gr, nX + 2 + 0, -1 + 0, szColumn, wcslen( szColumn ) );
 		}
 		//5目盛おきの区切り(中)
 		else if( 0 == keta % 5 ){

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -136,7 +136,7 @@ void CTextDrawer::DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar
 		}
 
 		//描画
-		::ExtTextOutW_AnyBuild(
+		::ExtTextOut(
 			hdc,
 			nDrawX,					//X
 			y + marginy,			//Y
@@ -507,7 +507,7 @@ void CTextDrawer::DispLineNumber(
 		int drawNumTop = (pView->GetTextArea().m_nViewAlignLeftCols - nLineNumCols - 1) * ( nCharWidth );
 		int fontNo = WCODE::GetFontNo('0');
 		int nHeightMargin = pView->GetTextMetrics().GetCharHeightMarginByFontNo(fontNo);
-		::ExtTextOutW_AnyBuild( gr,
+		::ExtTextOut( gr,
 			drawNumTop,
 			y + nHeightMargin,
 			ExtTextOutOption() & ~(bTrans? ETO_OPAQUE: 0),

--- a/sakura_core/view/figures/CFigureStrategy.cpp
+++ b/sakura_core/view/figures/CFigureStrategy.cpp
@@ -195,7 +195,7 @@ void CFigureSpace::DrawImp_DrawUnderline(SColorStrategyInfo* pInfo, DispPos& sPo
 		}
 		rcClip2.top = sPos.GetDrawPos().y;
 		rcClip2.bottom = sPos.GetDrawPos().y + sPos.GetCharHeight();
-		::ExtTextOutW_AnyBuild(
+		::ExtTextOut(
 			pInfo->m_gr,
 			sPos.GetDrawPos().x,
 			sPos.GetDrawPos().y + nHeightMargin,

--- a/sakura_core/view/figures/CFigure_Comma.cpp
+++ b/sakura_core/view/figures/CFigure_Comma.cpp
@@ -63,7 +63,7 @@ void CFigure_Comma::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcVie
 
 	if( pArea->IsRectIntersected(rcClip2) ){
 		if( cTabType.IsDisp() ){	//CSVモード
-			::ExtTextOutW_AnyBuild(
+			::ExtTextOut(
 				gr,
 				sPos.GetDrawPos().x,
 				sPos.GetDrawPos().y,

--- a/sakura_core/view/figures/CFigure_CtrlCode.cpp
+++ b/sakura_core/view/figures/CFigure_CtrlCode.cpp
@@ -55,7 +55,7 @@ void CFigure_CtrlCode::DispSpaceEx(CGraphics& gr, DispPos* pDispPos, CEditView* 
 		}
 		int nHeightMargin = pcView->GetTextMetrics().GetCharHeightMarginByFontNo(fontNo);
 		wchar_t wc[1] = {GetAlternateChar()};
-		ExtTextOutW_AnyBuild(
+		ExtTextOut(
 			gr,
 			pDispPos->GetDrawPos().x,
 			pDispPos->GetDrawPos().y + nHeightMargin,

--- a/sakura_core/view/figures/CFigure_Eol.cpp
+++ b/sakura_core/view/figures/CFigure_Eol.cpp
@@ -187,7 +187,7 @@ void _DispWrap(CGraphics& gr, DispPos* pDispPos, const CEditView* pcView, CLayou
 		int nDx[1] = {(Int)width};
 
 		//描画
-		::ExtTextOutW_AnyBuild(
+		::ExtTextOut(
 			gr,
 			pDispPos->GetDrawPos().x,
 			pDispPos->GetDrawPos().y + nHeightMargin,
@@ -266,7 +266,7 @@ void _DispEOL(CGraphics& gr, DispPos* pDispPos, CEol cEol, const CEditView* pcVi
 		int fontNo = WCODE::GetFontNo(' ');
 		int nHeightMargin = pcView->GetTextMetrics().GetCharHeightMarginByFontNo(fontNo);
 		// 2003.08.17 ryoji 改行文字が欠けないように
-		::ExtTextOutW_AnyBuild(
+		::ExtTextOut(
 			gr,
 			pDispPos->GetDrawPos().x,
 			pDispPos->GetDrawPos().y + nHeightMargin,

--- a/sakura_core/view/figures/CFigure_HanSpace.cpp
+++ b/sakura_core/view/figures/CFigure_HanSpace.cpp
@@ -33,7 +33,7 @@ void CFigure_HanSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pc
 		//小文字"o"の下半分を出力
 		CMyRect rcClipBottom=rcClip;
 		rcClipBottom.top=rcClip.top+pcView->GetTextMetrics().GetHankakuHeight()/2;
-		::ExtTextOutW_AnyBuild(
+		::ExtTextOut(
 			gr,
 			pDispPos->GetDrawPos().x,
 			pDispPos->GetDrawPos().y,
@@ -48,7 +48,7 @@ void CFigure_HanSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pc
 		//上半分は普通の空白で出力（"o"の上半分を消す）
 		CMyRect rcClipTop=rcClip;
 		rcClipTop.bottom=rcClip.top+pcView->GetTextMetrics().GetHankakuHeight()/2;
-		::ExtTextOutW_AnyBuild(
+		::ExtTextOut(
 			gr,
 			pDispPos->GetDrawPos().x,
 			pDispPos->GetDrawPos().y,

--- a/sakura_core/view/figures/CFigure_Tab.cpp
+++ b/sakura_core/view/figures/CFigure_Tab.cpp
@@ -80,7 +80,7 @@ void CFigure_Tab::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView,
 			}
 			int nHeightMargin = pcView->GetTextMetrics().GetCharHeightMarginByFontNo(fontNo);
 			//@@@ 2001.03.16 by MIK
-			::ExtTextOutW_AnyBuild(
+			::ExtTextOut(
 				gr,
 				sPos.GetDrawPos().x,
 				sPos.GetDrawPos().y + nHeightMargin,
@@ -96,7 +96,7 @@ void CFigure_Tab::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView,
 			}
 		}else{
 			//背景
-			::ExtTextOutW_AnyBuild(
+			::ExtTextOut(
 				gr,
 				sPos.GetDrawPos().x,
 				sPos.GetDrawPos().y,

--- a/sakura_core/view/figures/CFigure_ZenSpace.cpp
+++ b/sakura_core/view/figures/CFigure_ZenSpace.cpp
@@ -48,7 +48,7 @@ void CFigure_ZenSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pc
 		}
 		int nHeightMargin = pcView->GetTextMetrics().GetCharHeightMarginByFontNo(fontNo);
 		//描画
-		ExtTextOutW_AnyBuild(
+		ExtTextOut(
 			gr,
 			pDispPos->GetDrawPos().x,
 			pDispPos->GetDrawPos().y + nHeightMargin,

--- a/sakura_core/window/CSplitBoxWnd.cpp
+++ b/sakura_core/window/CSplitBoxWnd.cpp
@@ -99,7 +99,7 @@ void CSplitBoxWnd::FillSolidRect( HDC hdc, int x, int y, int cx, int cy, COLORRE
 	RECT	rc;
 	::SetBkColor( hdc, clr );
 	::SetRect( &rc, x, y, x + cx, y + cy );
-	::ExtTextOutW_AnyBuild( hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL );
+	::ExtTextOut( hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL );
 	return;
 }
 


### PR DESCRIPTION
# PR の目的

デッドコードの削除

## カテゴリ

- リファクタリング

## PR の背景

Unicode版のみをサポートしている為、不要な記述を削除しました。

## PR のメリット

余計な記述が消えることによってコードの見通しが良くなります。

## PR のデメリット (トレードオフとかあれば)

Unicode版とAnsi版の両対応をどのように行っていたのかが読み取りにくくなります。

## PR の影響範囲

未使用コードなので影響は有りません。

