### PR TITLE
変数のregister修飾を外す

### DIFF
--- a/sakura_core/charset/CESI.cpp
+++ b/sakura_core/charset/CESI.cpp
@@ -554,7 +554,7 @@ void CESI::GetEncodingInfo_uni( const char* pS, const int nLen )
 	const char *pr1, *pr2, *pr_end;
 	int nillbytes1, nillbytes2;
 	int nnewlinew1, nnewlinew2;
-	register int nret1, nret2;
+	int nret1, nret2;
 	ECharSet echarset1, echarset2;
 
 	if( nLen < 1 || pS == NULL ){

--- a/sakura_core/view/colors/CColor_Numeric.cpp
+++ b/sakura_core/view/colors/CColor_Numeric.cpp
@@ -68,11 +68,11 @@ bool CColor_Numeric::EndColor(const CStringRef& cStr, int nPos)
  */
 static int IsNumber(const CStringRef& cStr,/*const wchar_t *buf,*/ int offset/*, int length*/)
 {
-	register const wchar_t* p;
-	register const wchar_t* q;
-	register int i = 0;
-	register int d = 0;
-	register int f = 0;
+	const wchar_t* p;
+	const wchar_t* q;
+	int i = 0;
+	int d = 0;
+	int f = 0;
 
 	p = cStr.GetPtr() + offset;
 	q = cStr.GetPtr() + cStr.GetLength();


### PR DESCRIPTION
# PR の目的

「このキーワードは廃止されました」という警告を消します。
原因になっているキーワードを削除することにより、ビルド出力をすっきりさせます。


## カテゴリ

- リファクタリング


## PR の背景

現状のビルド出力には以下の警告が出ています。

> ```warning C5033: 'register' is no longer a supported storage class```

意訳) ストレージクラス指定子 'register' はサポートされなくなりました。

この警告が出るようになったのは #989 で準拠規格を C++17 に引き上げたのが原因です。

registerキーワードの効果は「修飾した変数をCPUレジスタに載せる」です。

一般に、スタックを参照するよりもレジスタを参照するほうが高速です。
CPU的にいうとスタックは「外部メモリ」に当たるので、参照するにはロードが必要になるからです。
他のすべてを犠牲にしてでも速度を優先したいなら「値のレジスタ載せ」は有効な手段です。

C++のコンパイラには最適化機能が付いています。
最適化がオンになっているときは、register指定しなくても「必要なら」変数がレジスタに載るように調整してくれます。
どうしても自分で細かい調整をしたい時は、アセンブラ言語を使うことになっています。

register指定が不適切な場合にどうなるか？・・・たぶん無視されるんではないかと思います。
修正対象の IsNumber には register 修飾された変数が 5つ あります。

サクラエディタは x86 向けアプリなので、対象CPUアーキテクチャは intel x86 で公開しています。
x86 アーキテクチャのCPUに搭載される[算術レジスタ](https://ja.wikibooks.org/wiki/X86%E3%82%A2%E3%82%BB%E3%83%B3%E3%83%96%E3%83%A9/x86%E3%82%A2%E3%83%BC%E3%82%AD%E3%83%86%E3%82%AF%E3%83%81%E3%83%A3)は 3本(EAX, ECX, EDX) です。
※レジスタは他にもたくさんありますが、Windows上で動かす場合に用途外の使用はできないので 3本 です。

使えるレジスタが 3本 しかないのに、 5つ の変数をレジスタに載せることを要求しとります。
明らかな論理エラーですが、ビルドは通っていますし、実行もできている。
「エラーになったら無視する」な実装になっていそうだと考える根拠にはなるんじゃないかと思います。

やや話が逸れました。

要約すると「付けても無駄なキーワードだから削るよ」に追随する、ってことになります。


## PR のメリット

ビルド時の警告が出力されなくなります。


## PR のデメリット (トレードオフとかあれば)

ありません。


## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット

#872 開発環境(Visual Studio)の機能をもっと活用するためにコード改善を行いたい 
#989 C++の準拠規格をC++17に更新する

## 参考情報

https://cpprefjp.github.io/lang/cpp11/deprecation_of_the_register_keyword.html
https://docs.microsoft.com/en-us/cpp/cpp/storage-classes-cpp?view=vs-2019
