### PR TITLE
SDLチェックを有効にする(Take2)

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -103,6 +103,7 @@
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -145,6 +146,7 @@
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -184,6 +186,7 @@
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -223,6 +226,7 @@
       <AdditionalOptions>/FAsu /Fa$(IntDir) /source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
# PR の目的

SDLチェックが使えるように sakura.vcxproj の設定を変更します。

SDLチェックを有効にすることにより、
Visual Studioが本来持っている bad code 検出機構を使える状態にします。


## カテゴリ

- リファクタリング


## PR の背景

この PR は #893 SDLチェックを有効にする の抜き出しです。

SDLチェックは、visual studio が本来持っている bad code 検出機構です。
#872(開発環境をvs2017に対応させる)の一環として、SDLチェックを有効にしようとしています。

SDLチェックを有効にすると bad code 臭いコードがビルドエラーになります。
考えなしに有効にしてみんなで路頭に迷うのも寒いので、事前に bad code を除去する試みを行ってきました。
ひととおりの準備ができたので、SDLチェックを有効にしたいと思います。


## PR のメリット

サクラエディタのコード品質をわずかに向上させることができます。


## PR のデメリット (トレードオフとかあれば)

ありません。


## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット

#872 開発環境(Visual Studio)の機能をもっと活用するためにコード改善を行いたい 
#893 SDLチェックを有効にする
#1004 文字列リテラルを格納する型の誤りを訂正
#1005 C++規格で非推奨となった関数名を置換する 
#1006 セキュリティに問題のあるCRT関数の使用を容認する
#1007 C++規格が変更されて非推奨となった関数名を置換する
