### PR TITLE
CEditView::CreateOrUpdateCompatibleBitmap において画面バッファを作成する条件を変更

### DIFF
--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -1325,7 +1325,7 @@ bool CEditView::CreateOrUpdateCompatibleBitmap( int cx, int cy )
 	// サイズを64の倍数で整列
 	int nBmpWidthNew  = ((cx + 63) & (0x7fffffff - 63));
 	int nBmpHeightNew = ((cy + 63) & (0x7fffffff - 63));
-	if( nBmpWidthNew != m_nCompatBMPWidth || nBmpHeightNew != m_nCompatBMPHeight ){
+	if( nBmpWidthNew > m_nCompatBMPWidth || nBmpHeightNew > m_nCompatBMPHeight ){
 #if 0
 	MYTRACE( _T("CEditView::CreateOrUpdateCompatibleBitmap( %d, %d ): resized\n"), cx, cy );
 #endif


### PR DESCRIPTION
# PR の目的

ウィンドウサイズの変更時に画面バッファの再作成処理が頻繁に動作しないようにする。

## カテゴリ

- 速度向上

## PR の背景

新規に作成する画面バッファの縦幅と横幅を既に作成済みの画面バッファの縦幅と横幅と比較して大きい場合のみ作成するように条件を変更する。

新規に作成する画面バッファの縦幅横幅ともに小さいならば、既に作成済みの画面バッファをわざわざ破棄して小さい画面バッファを作成する事はせずに使いまわすようにする。

## PR のメリット

ウィンドウサイズの変更時に画面バッファの再作成処理が頻繁に動作しないようになり、処理負担が減ります。

## PR のデメリット (トレードオフとかあれば)

ウィンドウサイズを小さくしても画面バッファの再作成を行わないため、メモリ使用量が減りません。

ただし画面バッファのメモリ使用量はそこまで大きいものでは無い為、実質的に問題無いと思います。

## PR の影響範囲

画面バッファを扱う箇所

