### PR TITLE
関数ポインタの代入式を簡潔にする

### DIFF
--- a/sakura_core/CKeyWordSetMgr.cpp
+++ b/sakura_core/CKeyWordSetMgr.cpp
@@ -399,7 +399,7 @@ int CKeyWordSetMgr::SearchKeyWord2( int nIdx, const wchar_t* pszKeyWord, int nKe
 	int pl = m_nStartIdx[nIdx];
 	int pr = m_nStartIdx[nIdx] + m_nKeyWordNumArr[nIdx] - 1;
 	int pc = (pr + 1 - pl) / 2 + pl;
-	int (*const cmp)(const wchar_t*, const wchar_t*, size_t) = m_bKEYWORDCASEArr[nIdx] ? wcsncmp : _wcsnicmp;
+	auto cmp = m_bKEYWORDCASEArr[nIdx] ? wcsncmp : _wcsnicmp;
 	while( pl <= pr ) {
 		const int ret = cmp( pszKeyWord, m_szKeyWordArr[pc], nKeyWordLen );
 		if( 0 < ret ) {

--- a/sakura_core/view/CEditView_Search.cpp
+++ b/sakura_core/view/CEditView_Search.cpp
@@ -472,7 +472,7 @@ int CEditView::IsSearchString(
 		const wchar_t *const pWordHead = cStr.GetPtr() + posWordHead;
 
 		// 比較関数
-		int (*const fcmp)( const wchar_t*, const wchar_t*, size_t ) = m_sCurSearchOption.bLoHiCase ? wcsncmp : _wcsnicmp;
+		auto fcmp = m_sCurSearchOption.bLoHiCase ? wcsncmp : _wcsnicmp;
 
 		// 検索語を単語に分割しながら指定位置の単語と照合する。
 		int wordIndex = 0;


### PR DESCRIPTION
# PR の目的

c++のautoキーワードを使って
関数ポインタの代入式を簡潔にし、
コードの可読性を向上させます。


## カテゴリ

- リファクタリング


## PR の背景

この PR は https://github.com/sakura-editor/sakura/pull/1005#discussion_r317159939 に対応します。

引用
> ```int (*const cmp)(const wchar_t*, const wchar_t*, size_t) = m_bKEYWORDCASEArr[nIdx] ? wcsncmp : _wcsnicmp;```
> と書くのではなく、
> ```auto cmp = m_bKEYWORDCASEArr[nIdx] ? wcsncmp : _wcsnicmp;```
> という記述でも良いと思います。


## PR のメリット

コードの可読性を向上させることができます。


## PR のデメリット (トレードオフとかあれば)

ありません。


## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット

#1005 C++規格で非推奨となった関数名を置換する 
