### PR TITLE
ShiftJISの文字を数えるのに使う型を訂正

### DIFF
--- a/sakura_core/view/CEditView_ExecCmd.cpp
+++ b/sakura_core/view/CEditView_ExecCmd.cpp
@@ -29,6 +29,7 @@
 #include "dlg/CDlgCancel.h"
 #include "charset/CCodeFactory.h"
 #include "charset/CUtf8.h"
+#include "charset/CShiftJis.h"
 #include "util/window.h"
 #include "util/tchar_template.h"
 #include "sakura_rc.h" // IDD_EXECRUNNING
@@ -427,7 +428,7 @@ bool CEditView::ExecCmd( const TCHAR* pszCmd, int nFlgOpt, const TCHAR* pszCurDi
 						int		j;
 						for( j=0; j<(int)read_cnt - 1; j++ ) {
 							//	2007.09.10 ryoji
-							if( CNativeA::GetSizeOfChar(work, read_cnt, j) == 2 ) {
+							if( CShiftJis::GetSizeOfChar(work, read_cnt, j) == 2 ) {
 								j++;
 							} else {
 								if( work[j] == _T2(PIPE_CHAR,'\r') && work[j+1] == _T2(PIPE_CHAR,'\n') ) {


### PR DESCRIPTION
# PR の目的

CNativeAの未使用メソッドを削除してソースコードをすっきりさせる対応のために、
CNativeA::GetSizeOfCharメソッドの利用箇所を削減します。


## カテゴリ

- リファクタリング


## PR の背景

現在のサクラエディタは wchar_t 型を文字型とする UNICODE アプリですが、
もともとは char 型を文字型とする ANSI アプリでした。

このため、独自関数は ANSI 版(コピペ元) と UNICODE 版(コピペ先) の2つの実装が存在しています。

対策として、現在使用していない ANSI 版独自関数の撤去を検討していますが、
CNativeAに実装されているいくつかの関数で ANSI 版独自関数を利用しており、身動きがとりづらい状態になっています。

この PR ではCNativeAの未使用関数撤去の前準備として、
CNativeA::GetSizeOfCharメソッドの唯一のアクティブな利用箇所を書換えることを目的とします。

## PR の修正内容

修正箇所は以下のコンテキストで呼ばれています。

https://github.com/sakura-editor/sakura/blob/d1fb8e120d73831e8d63bfb31e66044baf267b60/sakura_core/view/CEditView_ExecCmd.cpp#L422-L437

外部コマンド実行機能で、外部プログラムを実行した後に標準出力を読み取る処理の一部です。

出力の文字コードがShiftJISの場合の処理として CNativeA::GetSizeOfCharメソッド を呼ぶようになっています。

ここでやりたいことは、バイトシーケンス内の指定した位置にある文字が、
ShiftJISで2バイト文字なのかどうかを調べることです。

CNativeA::GetSizeOfCharメソッドの実装の中身は、
CShiftJis::GetSizeOfCharメソッドです。
なので、処理が間違っているわけではありません。

修正内容は、元々「厳密には正しくなかったコード」を是正する感じになります。

正確には、CShiftJis::GetSizeOfCharメソッドを直接呼び出すべき処理だと思います。


## PR のメリット

- CNativeA::GetSizeOfCharメソッドの唯一のアクティブな利用箇所を削ることができます。
- 修正箇所のロジックを、本来の意図を読み取りやすいコードにすることができます。


## PR のデメリット (トレードオフとかあれば)

ありません。

## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響はありません。
