### PR TITLE
LimitStringLengthTマクロを廃止する

### DIFF
--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -585,7 +585,7 @@ bool CDlgTypeList::CopyType()
 			int nTempLen = auto_strlen( szTemp );
 			CNativeT cmem;
 			// バッファをはみ出さないように
-			LimitStringLengthT( szTemp, nTempLen, _countof(type.m_szTypeName) - nLen - 1, cmem );
+			LimitStringLengthW( szTemp, nTempLen, _countof(type.m_szTypeName) - nLen - 1, cmem );
 			auto_strcpy( type.m_szTypeName, cmem.GetStringPtr() );
 			auto_strcat( type.m_szTypeName, szNum );
 			bUpdate = false;

--- a/sakura_core/util/string_ex2.h
+++ b/sakura_core/util/string_ex2.h
@@ -37,7 +37,6 @@ wchar_t *wcs_pushW(wchar_t *dst, size_t dst_count, const wchar_t* src);
 
 int AddLastChar( TCHAR* pszPath, int nMaxLen, TCHAR c );/* 2003.06.24 Moca 最後の文字が指定された文字でないときは付加する */
 int LimitStringLengthW( const WCHAR* pszData, int nDataLength, int nLimitLength, CNativeW& cmemDes );/* データを指定「文字数」以内に切り詰める */
-#define LimitStringLengthT LimitStringLengthW
 
 const char*    GetNextLine  ( const char* pData, int nDataLen, int* pnLineLen, int* pnBgn, CEol* pcEol); /* CR0LF0,CRLF,LF,CRで区切られる「行」を返す。改行コードは行長に加えない */
 const wchar_t* GetNextLineW ( const wchar_t* pData, int nDataLen, int* pnLineLen, int* pnBgn, CEol* pcEol, bool bExtEol); // GetNextLineのwchar_t版


### PR DESCRIPTION
# PR の目的

UNICODE一本化により形骸化したマクロを除去し、
ソースコードをすっきりさせます。

## カテゴリ

- リファクタリング


## PR の背景

#1008, #1019 の対応でソースコードを整理した結果、
マクロシンボル LimitStringLengthT が1箇所でしか使われていないことが分かりました。


## PR のメリット

マクロによる読み替えが減るので、ソースコードがわずかに読みやすくなります。


## PR のデメリット (トレードオフとかあれば)

とくにありません。


## PR の影響範囲

- ソースコードの見やすさに影響します。
  - ソースコードが若干読みやすくなります。
- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット

#1008 Unicode版のみのサポートなので、不要なプリプロセッサ記述やコードを削除 
#1019 未使用の ANSI 系独自関数を削る


## 参考資料

