### PR TITLE
正規表現キーワードのURLで0文字マッチすると無限ループになる問題に対処

### DIFF
--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1253,7 +1253,7 @@ bool CEditView::IsCurrentPositionURL(
 						&& (i == 0 || !IS_KEYWORD_CHAR(pLine[i - 1]))	// 2009.05.22 ryoji CColor_Url::BeginColor()と同条件に
 						&& IsURL(&pLine[i], (Int)(nLineLen - i), &nUrlLen) );	/* 指定アドレスがURLの先頭ならばTRUEとその長さを返す */
 		}
-		if( bMatch ){
+		if( bMatch && nUrlLen > 0 ){
 			if( i <= ptXY.GetX2() && ptXY.GetX2() < i + CLogicInt(nUrlLen) ){
 				/* URLを返す場合 */
 				if( pwstrURL ){


### PR DESCRIPTION
# PR の目的

#1027 の問題を解消するのが目的です。

## カテゴリ

- 不具合修正

## PR の背景

#1027 のような背景があります。

処理の流れとしては、
```
CEditView::OnMOUSEMOVE
CEditView::IsCurrentPositionURL
```

となっています。マウスカーソルをエディタのウィンドウ上にもってこなければ無限ループは発生しません。

## PR のメリット

#1027 の問題が解消します。

## PR のデメリット (トレードオフとかあれば)

#1027 の問題が解消してしまいます。

## PR の影響範囲

正規表現キーワードのURL

## 関連チケット

#1027, #1020
