### PR TITLE
正規表現キーワードの一致判定が0文字マッチをマッチとみなさないように変更する

### DIFF
--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -370,48 +370,49 @@ BOOL CRegexKeyword::RegexIsKeyword(
 
 	for(i = 0; i < m_nRegexKeyCount; i++)
 	{
-		if( m_sInfo[i].nMatch != RK_NOMATCH )  /* この行にキーワードがないと分かっていない */
+		auto &info = m_sInfo[i];
+		if( info.nMatch != RK_NOMATCH )  /* この行にキーワードがないと分かっていない */
 		{
-			if( m_sInfo[i].nOffset == nPos )  /* 以前検索した結果に一致する */
+			if( info.nOffset == nPos )  /* 以前検索した結果に一致する */
 			{
-				*nMatchLen   = m_sInfo[i].nLength;
+				*nMatchLen   = info.nLength;
 				*nMatchColor = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
 				return TRUE;  /* マッチした */
 			}
 
 			/* 以前の結果はもう古いので再検索する */
-			if( m_sInfo[i].nOffset < nPos )
+			if( info.nOffset < nPos )
 			{
 				matched = ExistBMatchEx()
-					? BMatchEx(NULL, cStr.GetPtr(), cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &m_sInfo[i].pBregexp, m_szMsg)
-					: BMatch(NULL,                  cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &m_sInfo[i].pBregexp, m_szMsg);
+					? BMatchEx(NULL, cStr.GetPtr(), cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &info.pBregexp, m_szMsg)
+					: BMatch(NULL,                  cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &info.pBregexp, m_szMsg);
 				if( 0 < matched )
 				{
-					m_sInfo[i].nOffset = m_sInfo[i].pBregexp->startp[0] - cStr.GetPtr();
-					m_sInfo[i].nLength = m_sInfo[i].pBregexp->endp[0] - m_sInfo[i].pBregexp->startp[0];
-					m_sInfo[i].nMatch  = RK_MATCH;
+					info.nOffset = info.pBregexp->startp[0] - cStr.GetPtr();
+					info.nLength = info.pBregexp->endp[0] - info.pBregexp->startp[0];
+					info.nMatch  = RK_MATCH;
 				
 					/* 指定の開始位置でマッチした */
-					if( m_sInfo[i].nOffset == nPos )
+					if( info.nOffset == nPos )
 					{
-						if( m_sInfo[i].nHead != 1 || nPos == 0 )
+						if( info.nHead != 1 || nPos == 0 )
 						{
-							*nMatchLen   = m_sInfo[i].nLength;
+							*nMatchLen   = info.nLength;
 							*nMatchColor = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
 							return TRUE;  /* マッチした */
 						}
 					}
 
 					/* 行先頭を要求する正規表現では次回から無視する */
-					if( m_sInfo[i].nHead == 1 )
+					if( info.nHead == 1 )
 					{
-						m_sInfo[i].nMatch = RK_NOMATCH;
+						info.nMatch = RK_NOMATCH;
 					}
 				}
 				else
 				{
 					/* この行にこのキーワードはない */
-					m_sInfo[i].nMatch = RK_NOMATCH;
+					info.nMatch = RK_NOMATCH;
 				}
 			}
 		}

--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -372,6 +372,7 @@ BOOL CRegexKeyword::RegexIsKeyword(
 	{
 		const auto colorIndex = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
 		auto &info = m_sInfo[i];
+		auto *pBregexp = info.pBregexp;
 		if( info.nMatch != RK_NOMATCH )  /* この行にキーワードがないと分かっていない */
 		{
 			if( info.nOffset == nPos )  /* 以前検索した結果に一致する */
@@ -385,12 +386,12 @@ BOOL CRegexKeyword::RegexIsKeyword(
 			if( info.nOffset < nPos )
 			{
 				matched = ExistBMatchEx()
-					? BMatchEx(NULL, cStr.GetPtr(), cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &info.pBregexp, m_szMsg)
-					: BMatch(NULL,                  cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &info.pBregexp, m_szMsg);
+					? BMatchEx(NULL, cStr.GetPtr(), cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &pBregexp, m_szMsg)
+					: BMatch(NULL,                  cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &pBregexp, m_szMsg);
 				if( 0 < matched )
 				{
-					info.nOffset = info.pBregexp->startp[0] - cStr.GetPtr();
-					info.nLength = info.pBregexp->endp[0] - info.pBregexp->startp[0];
+					info.nOffset = pBregexp->startp[0] - cStr.GetPtr();
+					info.nLength = pBregexp->endp[0] - pBregexp->startp[0];
 					info.nMatch  = RK_MATCH;
 				
 					/* 指定の開始位置でマッチした */

--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -385,12 +385,13 @@ BOOL CRegexKeyword::RegexIsKeyword(
 			/* 以前の結果はもう古いので再検索する */
 			if( info.nOffset < nPos )
 			{
+				const auto begp = cStr.GetPtr();		//!< 行頭位置
 				matched = ExistBMatchEx()
-					? BMatchEx(NULL, cStr.GetPtr(), cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &pBregexp, m_szMsg)
-					: BMatch(NULL,                  cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &pBregexp, m_szMsg);
+					? BMatchEx(NULL, begp, begp+nPos, begp+cStr.GetLength(), &pBregexp, m_szMsg)
+					: BMatch(NULL,         begp+nPos, begp+cStr.GetLength(), &pBregexp, m_szMsg);
 				if( 0 < matched )
 				{
-					info.nOffset = pBregexp->startp[0] - cStr.GetPtr();
+					info.nOffset = pBregexp->startp[0] - begp;
 					info.nLength = pBregexp->endp[0] - pBregexp->startp[0];
 					info.nMatch  = RK_MATCH;
 				

--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -389,7 +389,8 @@ BOOL CRegexKeyword::RegexIsKeyword(
 				int matched = ExistBMatchEx()
 					? BMatchEx(NULL, begp, startp, endp, &pBregexp, m_szMsg)
 					: BMatch(NULL,         startp, endp, &pBregexp, m_szMsg);
-				if( 0 < matched )
+				if( 0 < matched
+					&& pBregexp->endp[0] - pBregexp->startp[0] > 0 )
 				{
 					info.nOffset = pBregexp->startp[0] - begp;
 					info.nLength = pBregexp->endp[0] - pBregexp->startp[0];

--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -370,13 +370,14 @@ BOOL CRegexKeyword::RegexIsKeyword(
 
 	for(i = 0; i < m_nRegexKeyCount; i++)
 	{
+		const auto colorIndex = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
 		auto &info = m_sInfo[i];
 		if( info.nMatch != RK_NOMATCH )  /* この行にキーワードがないと分かっていない */
 		{
 			if( info.nOffset == nPos )  /* 以前検索した結果に一致する */
 			{
 				*nMatchLen   = info.nLength;
-				*nMatchColor = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
+				*nMatchColor = colorIndex;
 				return TRUE;  /* マッチした */
 			}
 
@@ -398,7 +399,7 @@ BOOL CRegexKeyword::RegexIsKeyword(
 						if( info.nHead != 1 || nPos == 0 )
 						{
 							*nMatchLen   = info.nLength;
-							*nMatchColor = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
+							*nMatchColor = colorIndex;
 							return TRUE;  /* マッチした */
 						}
 					}

--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -385,10 +385,11 @@ BOOL CRegexKeyword::RegexIsKeyword(
 			/* 以前の結果はもう古いので再検索する */
 			if( info.nOffset < nPos )
 			{
-				const auto begp = cStr.GetPtr();		//!< 行頭位置
+				const auto begp = cStr.GetPtr();			//!< 行頭位置
+				const auto endp = begp + cStr.GetLength();	//!< 行末位置
 				matched = ExistBMatchEx()
-					? BMatchEx(NULL, begp, begp+nPos, begp+cStr.GetLength(), &pBregexp, m_szMsg)
-					: BMatch(NULL,         begp+nPos, begp+cStr.GetLength(), &pBregexp, m_szMsg);
+					? BMatchEx(NULL, begp, begp+nPos, endp, &pBregexp, m_szMsg)
+					: BMatch(NULL,         begp+nPos, endp, &pBregexp, m_szMsg);
 				if( 0 < matched )
 				{
 					info.nOffset = pBregexp->startp[0] - begp;

--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -387,9 +387,10 @@ BOOL CRegexKeyword::RegexIsKeyword(
 			{
 				const auto begp = cStr.GetPtr();			//!< 行頭位置
 				const auto endp = begp + cStr.GetLength();	//!< 行末位置
+				const auto startp = begp + nPos;			//!< 検索開始位置
 				matched = ExistBMatchEx()
-					? BMatchEx(NULL, begp, begp+nPos, endp, &pBregexp, m_szMsg)
-					: BMatch(NULL,         begp+nPos, endp, &pBregexp, m_szMsg);
+					? BMatchEx(NULL, begp, startp, endp, &pBregexp, m_szMsg)
+					: BMatch(NULL,         startp, endp, &pBregexp, m_szMsg);
 				if( 0 < matched )
 				{
 					info.nOffset = pBregexp->startp[0] - begp;

--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -356,8 +356,6 @@ BOOL CRegexKeyword::RegexIsKeyword(
 	int*				nMatchColor	//!< [out] マッチした色番号
 )
 {
-	int	i, matched;
-
 	MYDBGMSG("RegexIsKeyword")
 
 	//動作に必要なチェックをする。
@@ -368,7 +366,7 @@ BOOL CRegexKeyword::RegexIsKeyword(
 		return FALSE;
 	}
 
-	for(i = 0; i < m_nRegexKeyCount; i++)
+	for( int i = 0; i < m_nRegexKeyCount; i++ )
 	{
 		const auto colorIndex = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
 		auto &info = m_sInfo[i];
@@ -388,7 +386,7 @@ BOOL CRegexKeyword::RegexIsKeyword(
 				const auto begp = cStr.GetPtr();			//!< 行頭位置
 				const auto endp = begp + cStr.GetLength();	//!< 行末位置
 				const auto startp = begp + nPos;			//!< 検索開始位置
-				matched = ExistBMatchEx()
+				int matched = ExistBMatchEx()
 					? BMatchEx(NULL, begp, startp, endp, &pBregexp, m_szMsg)
 					: BMatch(NULL,         startp, endp, &pBregexp, m_szMsg);
 				if( 0 < matched )

--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -133,15 +133,7 @@ BOOL CRegexKeyword::RegexKeyInit( void )
 	for(i = 0; i < MAX_REGEX_KEYWORD; i++)
 	{
 		m_sInfo[i].pBregexp = NULL;
-#ifdef USE_PARENT
-#else
-		m_sInfo[i].sRegexKey.m_nColorIndex = COLORIDX_REGEX1;
-#endif
 	}
-#ifdef USE_PARENT
-#else
-	wmemset( m_keywordList, _countof(m_keywordList), L'\0' );
-#endif
 
 	return TRUE;
 }
@@ -223,17 +215,9 @@ BOOL CRegexKeyword::RegexKeyCompile( void )
 	//コンパイルパターンを内部変数に移す。
 	m_nRegexKeyCount = 0;
 	const wchar_t * pKeyword = &m_pTypes->m_RegexKeywordList[0];
-#ifdef USE_PARENT
-#else
-	wmemcpy( m_keywordList,  m_pTypes->m_RegexKeywordList, _countof(m_RegexKeywordList) );
-#endif
 	for(i = 0; i < MAX_REGEX_KEYWORD; i++)
 	{
 		if( pKeyword[0] == L'\0' ) break;
-#ifdef USE_PARENT
-#else
-		m_sInfo[i].sRegexKey.m_nColorIndex = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
-#endif
 		m_nRegexKeyCount++;
 		for(; *pKeyword != '\0'; pKeyword++ ){}
 		pKeyword++;
@@ -251,19 +235,11 @@ BOOL CRegexKeyword::RegexKeyCompile( void )
 		return FALSE;
 	}
 
-#ifdef USE_PARENT
 	pKeyword = &m_pTypes->m_RegexKeywordList[0];
-#else
-	pKeyword = &m_keywordList[0];
-#endif
 	//パターンをコンパイルする。
 	for(i = 0; i < m_nRegexKeyCount; i++)
 	{
-#ifdef USE_PARENT
 		rp = &m_pTypes->m_RegexKeywordArr[i];
-#else
-		rp = &m_sInfo[i].sRegexKey;
-#endif
 
 		if( RegexKeyCheckSyntax( pKeyword ) != FALSE )
 		{
@@ -349,15 +325,6 @@ BOOL CRegexKeyword::RegexKeyLineStart( void )
 		return FALSE;
 	}
 
-#if 0	//RegexKeySetTypesで設定されているはずなので廃止
-	//情報不一致ならマスタから取得してコンパイルする。
-	if( m_nCompiledMagicNumber != m_pTypes->m_nRegexKeyMagicNumber
-	 || m_nTypeIndex           != m_pTypes->m_nIdx )
-	{
-		RegexKeyCompile();
-	}
-#endif
-
 	//検索開始のためにオフセット情報等をクリアする。
 	for(i = 0; i < m_nRegexKeyCount; i++)
 	{
@@ -394,11 +361,9 @@ BOOL CRegexKeyword::RegexIsKeyword(
 	MYDBGMSG("RegexIsKeyword")
 
 	//動作に必要なチェックをする。
-	if( !m_bUseRegexKeyword || !IsAvailable()
-#ifdef USE_PARENT
-	 || m_pTypes == NULL
-#endif
-	 /* || ( pLine == NULL ) */ )
+	if( !m_bUseRegexKeyword
+		|| !IsAvailable()
+		|| m_pTypes == NULL )
 	{
 		return FALSE;
 	}
@@ -410,26 +375,16 @@ BOOL CRegexKeyword::RegexIsKeyword(
 			if( m_sInfo[i].nOffset == nPos )  /* 以前検索した結果に一致する */
 			{
 				*nMatchLen   = m_sInfo[i].nLength;
-#ifdef USE_PARENT
 				*nMatchColor = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
-#else
-				*nMatchColor = m_sInfo[i].sRegexKey.m_nColorIndex;
-#endif
 				return TRUE;  /* マッチした */
 			}
 
 			/* 以前の結果はもう古いので再検索する */
 			if( m_sInfo[i].nOffset < nPos )
 			{
-#ifdef USE_PARENT
 				matched = ExistBMatchEx()
 					? BMatchEx(NULL, cStr.GetPtr(), cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &m_sInfo[i].pBregexp, m_szMsg)
 					: BMatch(NULL,                  cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &m_sInfo[i].pBregexp, m_szMsg);
-#else
-				matched = ExistBMatchEx()
-					? BMatchEx(NULL, cStr.GetPtr(), cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &m_sInfo[i].pBregexp, m_szMsg);
-					: BMatch(NULL,                  cStr.GetPtr()+nPos, cStr.GetPtr()+cStr.GetLength(), &m_sInfo[i].pBregexp, m_szMsg);
-#endif
 				if( 0 < matched )
 				{
 					m_sInfo[i].nOffset = m_sInfo[i].pBregexp->startp[0] - cStr.GetPtr();
@@ -442,11 +397,7 @@ BOOL CRegexKeyword::RegexIsKeyword(
 						if( m_sInfo[i].nHead != 1 || nPos == 0 )
 						{
 							*nMatchLen   = m_sInfo[i].nLength;
-#ifdef USE_PARENT
 							*nMatchColor = m_pTypes->m_RegexKeywordArr[i].m_nColorIndex;
-#else
-							*nMatchColor = m_sInfo[i].sRegexKey.m_nColorIndex;
-#endif
 							return TRUE;  /* マッチした */
 						}
 					}

--- a/sakura_core/CRegexKeyword.h
+++ b/sakura_core/CRegexKeyword.h
@@ -25,8 +25,6 @@
 
 struct STypeConfig;
 
-#define USE_PARENT	//親を使ってキーワード格納領域を削減する。
-
 //@@@ 2001.11.17 add start MIK
 struct RegexKeywordInfo {
 	int	m_nColorIndex;		//色指定番号
@@ -36,10 +34,6 @@ struct RegexKeywordInfo {
 //!	正規表現キーワード検索情報構造体
 typedef struct RegexInfo_t {
 	BREGEXP_W	*pBregexp;	//BREGEXP_W構造体
-#ifdef USE_PARENT
-#else
-	struct RegexKeywordInfo	sRegexKey;	//コンパイルパターンを保持
-#endif
 	int    nStatus;		//状態(EMPTY,CLOSE,OPEN,ACTIVE,ERROR)
 	int    nMatch;		//このキーワードのマッチ状態(EMPTY,MATCH,NOMATCH)
 	int    nOffset;		//マッチした位置
@@ -85,10 +79,6 @@ private:
 	DWORD			m_nCompiledMagicNumber;		//!< コンパイル済みか？
 	int				m_nRegexKeyCount;			//!< 現在のキーワード数
 	REGEX_INFO		m_sInfo[MAX_REGEX_KEYWORD];	//!< キーワード一覧(BREGEXPコンパイル対象)
-#ifdef USE_PARENT
-#else
-	wchar_t			m_keywordList[MAX_REGEX_KEYWORDLISTLEN];
-#endif
 	wchar_t			m_szMsg[256];				//!< BREGEXP_Wからのメッセージを保持する
 };
 


### PR DESCRIPTION
# PR の目的

正規表現キーワードのパターン一致条件を追加することにより、
0文字マッチをマッチと認識することによる不具合を解消します。

改修に当たっては、コード理解のために「未使用プリプロセッサの除去」と「部分式をローカル変数に切り出して意味を予測しやすい名前を付ける」の対応を行っています。レビューでも必要な情報だと思うので、あえて変更を残したままPRします。


## カテゴリ

- 不具合修正
- 仕様変更
- リファクタリング


## PR の背景

改修根拠については https://github.com/sakura-editor/sakura/issues/1020#issuecomment-526910281 を見てください。

そもそも、仕様的に、**正規表現キーワードって0文字マッチさせたらダメじゃね？** がこのPRの趣旨です。iniの読込みや設定画面にチェックを入れる話にするとややこしくなるので、設定に関しては従来通りとし、マッチ検出時に「マッチ幅が0文字だったらそのマッチを無視する」という変更を入れます。

## PR のメリット

- 正規表現キーワードのマッチ判定処理が分かりやすくなります。
- この修正単体でも #1027 の問題を解消できます。
  - #1028 の修正とは競合しません。


## PR のデメリット (トレードオフとかあれば)

- メインの修正内容よりも、前提作業で行ったリファクタリングのほうが修正量が多いです。
- 他にはとくにありません。


## PR の影響範囲

- アプリ（＝サクラエディタ）の機能に影響があります。
- 正規表現キーワードを使って0文字マッチになりうるパターンを指定したときの描画処理に影響します。
  - 従来：0文字マッチは色替えが行われて空振り
  - 今後：0文字マッチはマッチ扱いにならない
- 正規表現キーワードで色指定に「URL」を設定し、0文字マッチになりうるパターンを指定したときの挙動に影響します。
  - 従来：0文字マッチで無限ループ発生
  - 今後：0文字マッチはマッチ扱いにならないので無限ループも発生しない


## 関連チケット

#1027
#1028

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
