### PR TITLE
[WIP] testsプロジェクトのビルドを速くする

### DIFF
--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -5,13 +5,12 @@ set CONFIGURATION=%~3
 set VCVARSALL_PATH=%4
 set VCVARS_ARCH=%~5
 
-if not defined CMD_GIT call %~dp0..\tools\find-tools.bat
-if not defined CMD_GIT (
-	echo git.exe was not found.
-	endlocal && exit /b 1
-)
-
 if not exist "%~dp0googletest\CMakeLists.txt" (
+	if not defined CMD_GIT call %~dp0..\tools\find-tools.bat
+	if not defined CMD_GIT (
+		echo git.exe was not found.
+		endlocal && exit /b 1
+	)
 	"%CMD_GIT%" submodule init   %~dp0googletest || endlocal && exit /b 1
 	"%CMD_GIT%" submodule update %~dp0googletest || endlocal && exit /b 1
 )

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -20,6 +20,15 @@ if defined VCVARSALL_PATH (
 	call %VCVARSALL_PATH% %VCVARS_ARCH% || endlocal && exit /b 1
 )
 
+if not exist CMakeCache.txt (
+	call :run_cmake_configure
+)
+
+cmake --build . --config %CONFIGURATION% || endlocal && exit /b 1
+
+endlocal && exit /b 0
+
+:run_cmake_configure
 where ninja.exe > NUL 2>&1
 if not errorlevel 1 (
 	set GENERATOR=Ninja
@@ -43,9 +52,8 @@ cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
   %SOURCE_DIR%                                            ^
   || endlocal && exit /b 1
 
-cmake --build . --config %CONFIGURATION% || endlocal && exit /b 1
+goto :EOF
 
-endlocal && exit /b 0
 
 :find_cl_exe
 for /f "usebackq delims=" %%a in (`where cl.exe`) do (

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="GoogleTest">
     <GoogleTestSourceDir>$(MSBuildThisFileDirectory)googletest\</GoogleTestSourceDir>
-    <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\$(Platform)\$(Configuration)\googletest\</GoogleTestBuildDir>
+    <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\$(Platform)\$(Configuration)\googletest</GoogleTestBuildDir>
     <IncludePath>$(GoogleTestSourceDir)googletest\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(GoogleTestBuildDir)\lib;$(GoogleTestBuildDir)\lib\$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
@@ -46,7 +46,7 @@
       <GeneratorSuffix Condition="'$(PlatformTarget)' == 'x64'"> Win64</GeneratorSuffix>
     </PropertyGroup>
     <MakeDir Condition="!Exists('$(GoogleTestBuildDir)')" Directories="$(GoogleTestBuildDir)" />
-    <Message Text="Cheking product line version of the Visual Studio." Importance="high" />
+    <Message Text="Checking product line version of the Visual Studio." Importance="high" />
     <Exec Command="&quot;$(VSInstallDir)..\..\Installer\vswhere.exe&quot; -version [$(NumVersion),$(NextVersion)] -property catalog_productLineVersion" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ProductLineVersion" />
     </Exec>


### PR DESCRIPTION
# PR の目的

テストプロジェクトのビルドステップに実行条件を追加することにより、2回目以降のビルドを速くします。


## カテゴリ

- その他


## PR の背景

#1013 のコメントで書いていた、tests1 プロジェクトの改善です。

やってること

1. メッセージのtypoが修正されます。(Chekingってｗ
2. googletestの生成物パスが `\\lib` とかなっていたのが直ります。
3. gitサブモジュールのためにfind-tools.bat(クソ重い)を毎回呼び出していたのが消えます。
4. cmakeコンフィグ(通常は1度すれば2回目以降は要らない)を毎回呼び出していたのが消えます。

主に「2回目以降のビルド」に対して効果を発揮する改善です。
find-tools.batの絡みで「リビルド」も少しだけ速くなります。


## PR のメリット

- tests1プロジェクトの2回目以降のビルドが速くなります。
  - GoogleTest の cmake コンフィグ が毎回は走らなくなります。
- tests1プロジェクトの `git clone` 後2回目以降のリビルドが速くなります。
  - GoogleTest の `git submodule init` が毎回は走らなくなります。
  - GoogleTest の `git submodule update` が毎回は走らなくなります。
  - GoogleTest のリポジトリ更新を行うための `tools/find-tools.bat` が毎回は呼ばれなくなります。


## PR のデメリット (トレードオフとかあれば)

- 既知の不具合が1つあります。
  - Ninjaの有無が変わったときの初回ビルドが、必ず失敗します。(再ビルドすると正常になる)
    - Ninjaの有無が変わる機会は通常利用ではありえないので、問題ないと思います。


## PR の影響範囲

- ローカル開発環境の使い勝手に影響します。
- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット
#1013 tests1 プロジェクトをリビルドしたりクリーンすると異なる構成のビルドに影響してしまう

## 参考情報
