### PR TITLE
testsプロジェクトのビルドを速くする Take2

### DIFF
--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -5,25 +5,24 @@ set CONFIGURATION=%~3
 set VCVARSALL_PATH=%4
 set VCVARS_ARCH=%~5
 
-if not defined CMD_GIT call %~dp0..\tools\find-tools.bat
-if not defined CMD_GIT (
-	echo git.exe was not found.
-	endlocal && exit /b 1
-)
-
-if not exist "%~dp0googletest\CMakeLists.txt" (
-	"%CMD_GIT%" submodule init   %~dp0googletest || endlocal && exit /b 1
-	"%CMD_GIT%" submodule update %~dp0googletest || endlocal && exit /b 1
-)
-
 @rem call vcvasall.bat when we run in the Visual Studio IDE.
 if defined VCVARSALL_PATH (
 	call %VCVARSALL_PATH% %VCVARS_ARCH% || endlocal && exit /b 1
 )
 
+if not exist CMakeCache.txt (
+	call :run_cmake_configure
+)
+
+cmake --build . --config %CONFIGURATION% || endlocal && exit /b 1
+
+endlocal && exit /b 0
+
+:run_cmake_configure
 where ninja.exe > NUL 2>&1
 if not errorlevel 1 (
 	set GENERATOR=Ninja
+	set GENERATOR_OPTS=-DCMAKE_BUILD_TYPE=%CONFIGURATION%
 )
 
 @rem find cl.exe in the PATH
@@ -35,7 +34,7 @@ if not defined CMD_CL (
 )
 set CMD_CL=%CMD_CL:\=/%
 
-cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
+cmake -G "%GENERATOR%" %GENERATOR_OPTS%                   ^
   "-DCMAKE_C_COMPILER=%CMD_CL%"                           ^
   "-DCMAKE_CXX_COMPILER=%CMD_CL%"                         ^
   -DBUILD_GMOCK=OFF                                       ^
@@ -44,9 +43,8 @@ cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
   %SOURCE_DIR%                                            ^
   || endlocal && exit /b 1
 
-cmake --build . --config %CONFIGURATION% || endlocal && exit /b 1
+goto :EOF
 
-endlocal && exit /b 0
 
 :find_cl_exe
 for /f "usebackq delims=" %%a in (`where cl.exe`) do (

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -1,64 +1,64 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="GoogleTest">
     <GoogleTestSourceDir>$(MSBuildThisFileDirectory)googletest\</GoogleTestSourceDir>
-    <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\$(Platform)\$(Configuration)\googletest\</GoogleTestBuildDir>
+    <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\$(Platform)\$(Configuration)\googletest</GoogleTestBuildDir>
     <IncludePath>$(GoogleTestSourceDir)googletest\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(GoogleTestBuildDir)\lib;$(GoogleTestBuildDir)\lib\$(Configuration);$(LibraryPath)</LibraryPath>
+    <NameSuffix Condition="'$(Configuration)' == 'Debug'">d</NameSuffix>
+    <NameSuffix Condition="'$(Configuration)' == 'Release'"></NameSuffix>
   </PropertyGroup>
   <ItemDefinitionGroup Label="GoogleTest.Requirements">
     <ClCompile>
       <PreprocessorDefinitions>_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="GoogleTest.Libs" Condition="'$(Configuration)' == 'Debug'">
+  <ItemDefinitionGroup Label="GoogleTest.Libs">
     <Link>
-      <AdditionalDependencies>gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest$(NameSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest_main$(NameSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="GoogleTest.Libs" Condition="'$(Configuration)' == 'Release'">
-    <Link>
-      <AdditionalDependencies>gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemGroup Label="GoogleTest.Pdbs" Condition="'$(Configuration)' == 'Debug'">
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtestd.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtestd.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_maind.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest_maind.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtestd.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtestd.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_maind.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_maind.pdb')" />
-  </ItemGroup>
-  <ItemGroup Label="GoogleTest.Pdbs" Condition="'$(Configuration)' == 'Release'">
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_main.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest_main.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main.pdb')" />
-  </ItemGroup>
-  <Target Name="BuildGoogleTest" BeforeTargets="ClCompile">
+  <Target Name="FindGit" Condition="'$(GitCmd)' == ''">
+    <Message Text="Checking Git for Windows" Importance="high" />
+    <Exec Command="where &quot;$(PATH);$(ProgramW6432)\Git\Cmd;$(ProgramFiles)\Git\Cmd:git&quot;" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCmd" />
+    </Exec>
+  </Target>
+  <Target Name="UpdateGoogleTest" DependsOnTargets="FindGit" Condition="!Exists('$(GoogleTestSourceDir)\CMakeLists.txt')">
+    <Exec Command="&quot;$(GitCmd)&quot; submodule init" WorkingDirectory="$(GoogleTestSourceDir)" />
+    <Exec Command="&quot;$(GitCmd)&quot; submodule update" WorkingDirectory="$(GoogleTestSourceDir)" />
+  </Target>
+  <Target Name="MakeGoogleTestBuildDir" Condition="!Exists('$(GoogleTestBuildDir)')">
+    <MakeDir Directories="$(GoogleTestBuildDir)" />
+  </Target>
+  <Target Name="BuildGoogleTest" DependsOnTargets="UpdateGoogleTest;MakeGoogleTestBuildDir" BeforeTargets="ClCompile">
     <PropertyGroup>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'x86' And '$(PlatformTarget)' == 'x86'">x86</VcVarsArchitecture>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'x86' And '$(PlatformTarget)' == 'x64'">x86_amd64</VcVarsArchitecture>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x86'">amd64_x86</VcVarsArchitecture>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x64'">amd64</VcVarsArchitecture>
       <NumVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioVersion)', '^(\d+).*', '$1'))</NumVersion>
-      <NextVersion>$([MSBuild]::Add($(NumVersion), 1))</NextVersion>
+      <ProductLineVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioEdition)', '^.* (\d+).*', '$1'))</ProductLineVersion>
       <GeneratorSuffix Condition="'$(PlatformTarget)' == 'x86'"></GeneratorSuffix>
       <GeneratorSuffix Condition="'$(PlatformTarget)' == 'x64'"> Win64</GeneratorSuffix>
+      <VsGeneratorName>Visual Studio $(NumVersion) $(ProductLineVersion)$(GeneratorSuffix)</VsGeneratorName>
     </PropertyGroup>
-    <MakeDir Condition="!Exists('$(GoogleTestBuildDir)')" Directories="$(GoogleTestBuildDir)" />
-    <Message Text="Cheking product line version of the Visual Studio." Importance="high" />
-    <Exec Command="&quot;$(VSInstallDir)..\..\Installer\vswhere.exe&quot; -version [$(NumVersion),$(NextVersion)] -property catalog_productLineVersion" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="ProductLineVersion" />
-    </Exec>
-    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;Visual Studio $(NumVersion) $(ProductLineVersion)$(GeneratorSuffix)&quot; $(Configuration) &quot;$(VSInstallRoot)/VC/Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
+    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;$(VsGeneratorName)&quot; $(Configuration) &quot;$(VSInstallRoot)/VC/Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
+  </Target>
+  <Target Name="CopyGoogleTestPdb" AfterTargets="BuildGoogleTest">
+    <ItemGroup>
+      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\gtest$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest$(NameSuffix).pdb')" />
+      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\gtest_main$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest_main$(NameSuffix).pdb')" />
+      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest$(NameSuffix).pdb')" />
+      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main$(NameSuffix).pdb')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(GoogleTestPdbFound)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" UseHardlinksIfPossible="true" />
   </Target>
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <!-- Add files to @Clean just before running CoreClean. -->
     <ItemGroup>
-      <Clean Include="$(OutDir)gtestd.pdb" />
-      <Clean Include="$(OutDir)gtest_maind.pdb" />
-      <Clean Include="$(OutDir)gtest.pdb" />
-      <Clean Include="$(OutDir)gtest_main.pdb" />
+      <Clean Include="$(OutDir)gtest$(NameSuffix).pdb" />
+      <Clean Include="$(OutDir)gtest_main$(NameSuffix).pdb" />
     </ItemGroup>
     <RemoveDir Directories="$(GoogleTestBuildDir)" />
   </Target>

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -23,6 +23,9 @@
     <Exec Command="where &quot;$(PATH);$(ProgramW6432)\Git\Cmd;$(ProgramFiles)\Git\Cmd:git&quot;" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitCmd" />
     </Exec>
+    <PropertyGroup>
+      <GitCmd>$([System.Text.RegularExpressions.Regex]::Replace('$(GitCmd)', '^([^;]+);.*', '$1'))</GitCmd>
+    </PropertyGroup>
   </Target>
   <Target Name="UpdateGoogleTest" DependsOnTargets="FindGit" Condition="!Exists('$(GoogleTestSourceDir)\CMakeLists.txt')">
     <Exec Command="&quot;$(GitCmd)&quot; submodule init" WorkingDirectory="$(GoogleTestSourceDir)" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -21,14 +21,15 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{701e3407-ec27-49f7-adc7-520cf2b4b438}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(ProjectDir)..\..\vcx-props\vcxcompat.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets">


### PR DESCRIPTION
# PR の目的

テストプロジェクトのビルドステップの実行条件を見直すことにより、テストプロジェクトのビルドを速くします。また、プロジェクト設定に存在していた潜在的な不具合を取り除きます。


## カテゴリ

- 不具合修正
- 速度向上

## PR の背景

#1013 のコメントで書いていた、tests1 プロジェクトの改善です。
（そして #1033 の焼き直しです。）

やってること
1. find-tools.batを呼ばないようにする。(高速化)
2. googletestのcmakeコンフィグを毎回呼ばないようにする。(高速化)
3. googletest.targetsでBuildDirの末尾に\が付いていたのを削除。(不具合修正)
4. vcxcompat.propsを正しく読み込めていなかったのを修正。(不具合修正)

主に「2回目以降のビルド」に対して効果を発揮する改善です。
find-tools.batの絡みで「リビルド」も少しだけ速くなります。


追加の解説
- find-tools呼出削除について
  - find-toolsを呼んでたのは、gitコマンドのパスを取得するためでした。
    - 時間がかかっているのは、主に他ツールの捜索です。
      - 対策としてgitコマンドのパスを取得だけを抜き出してtargetsに実装しました。
- cmakeコンフィグを毎回呼ばない、について
  - cmakeを2回呼んでいるのは、1回目がコンフィグで、2回目がビルドだからです。
  - もし3回目の実行をビルドモードで行い、再コンフィグが必要だった場合、cmakeが変更を検出してくれます。
  - 再コンフィグは結構重たい処理なので、不要な場合はスキップしたいです。
  - 1度コンフィグが完了すると、必ず生成されるキャッシュファイルがあるので、それを使ってコンフィグが必要かどうか判断するように実装しました。
- BuildDirの末尾に\について
  - 単なるミスです。成果物のパスが `\\lib` のような感じになっていました。
- vcxcompat.propsを正しく読み込めていなかった、について
  - Import Projectの書き順が誤っていました。
    - PlatformToolset 141 が有効になっていたため、vs2019単体インストールのマシンでビルドが通らなかったようです。
    - WindowsTargetPlatformVersionに記載されたバージョンが、vs2019標準では入らないバージョンになってたので削りました。


## PR のメリット

- tests1プロジェクトの2回目以降のビルドが速くなります。
  - GoogleTest の cmake コンフィグ が毎回は走らなくなります。
- tests1プロジェクトの git clone 後2回目以降のリビルドが速くなります。
  - GoogleTest の git submodule init が毎回は走らなくなります。
  - GoogleTest の git submodule update が毎回は走らなくなります。
- GoogleTest のリポジトリ更新を行うための tools/find-tools.bat が毎回は呼ばれなくなります。
- tests1プロジェクト設定の不具合が解消されます。


## PR のデメリット (トレードオフとかあれば)

とくにありません。
（ #1033 に記載した既知の不具合は解消しました。）


## PR の影響範囲

- ローカル開発環境の使い勝手に影響します。
- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット

#1033 [WIP] testsプロジェクトのビルドを速くする
#1013 tests1 プロジェクトをリビルドしたりクリーンすると異なる構成のビルドに影響してしまう
#872 開発環境(Visual Studio)の機能をもっと活用するためにコード改善を行いたい


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
