### PR TITLE
auto_ 系の関数を使う必要が無いところで使わないように変更

### DIFF
--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -38,7 +38,7 @@ struct StringBufferW_{
 
 	StringBufferW_& operator = (const StringBufferW_& rhs)
 	{
-		auto_strcpy_s(pData,nDataCount,rhs.pData);
+		wcscpy_s(pData,nDataCount,rhs.pData);
 		return *this;
 	}
 };
@@ -51,7 +51,7 @@ struct StringBufferA_{
 
 	StringBufferA_& operator = (const StringBufferA_& rhs)
 	{
-		auto_strcpy_s(pData,nDataCount,rhs.pData);
+		strcpy_s(pData,nDataCount,rhs.pData);
 		return *this;
 	}
 };

--- a/sakura_core/CDicMgr.cpp
+++ b/sakura_core/CDicMgr.cpp
@@ -155,7 +155,7 @@ int CDicMgr::HokanSearch(
 		if( bHokanLoHiCase ){	/* 英大文字小文字を同一視する */
 			nRet = auto_memicmp( pszKey, szLine.c_str(), nKeyLen );
 		}else{
-			nRet = auto_memcmp( pszKey, szLine.c_str(), nKeyLen );
+			nRet = wmemcmp( pszKey, szLine.c_str(), nKeyLen );
 		}
 		if( 0 == nRet ){
 			vKouho.push_back( szLine );

--- a/sakura_core/CDicMgr.cpp
+++ b/sakura_core/CDicMgr.cpp
@@ -153,7 +153,7 @@ int CDicMgr::HokanSearch(
 		if( szLine.length() == 0 )continue;
 
 		if( bHokanLoHiCase ){	/* 英大文字小文字を同一視する */
-			nRet = auto_memicmp( pszKey, szLine.c_str(), nKeyLen );
+			nRet = wmemicmp( pszKey, szLine.c_str(), nKeyLen );
 		}else{
 			nRet = wmemcmp( pszKey, szLine.c_str(), nKeyLen );
 		}

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -54,8 +54,8 @@ struct SEolDefinition{
 	const ACHAR*	m_szDataA;
 	int				m_nLen;
 
-	bool StartsWith(const WCHAR* pData, int nLen) const{ return m_nLen<=nLen && 0==auto_memcmp(pData,m_szDataW,m_nLen); }
-	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==auto_memcmp(pData,m_szDataA,m_nLen); }
+	bool StartsWith(const WCHAR* pData, int nLen) const{ return m_nLen<=nLen && 0==wmemcmp(pData,m_szDataW,m_nLen); }
+	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==amemcmp(pData,m_szDataA,m_nLen); }
 };
 extern const SEolDefinition g_aEolTable[];
 

--- a/sakura_core/CFileExt.cpp
+++ b/sakura_core/CFileExt.cpp
@@ -122,7 +122,7 @@ const WCHAR *CFileExt::GetExtFilter( void )
 
 		int i = (int)m_vstrFilter.size();
 		m_vstrFilter.resize( i + work.length() );
-		auto_memcpy( &m_vstrFilter[i], &work[0], work.length() );
+		wmemcpy( &m_vstrFilter[i], &work[0], work.length() );
 	}
 	if( 0 == m_nCount ){
 		m_vstrFilter.push_back( L'\0' );

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -64,7 +64,7 @@ void CGrepAgent::OnAfterSave(const SSaveInfo& sSaveInfo)
 */
 void CGrepAgent::CreateFolders( const WCHAR* pszPath, std::vector<std::wstring>& vPaths )
 {
-	const int nPathLen = auto_strlen( pszPath );
+	const int nPathLen = wcslen( pszPath );
 	auto szPath = std::make_unique<WCHAR[]>(nPathLen + 1);
 	auto szTmp = std::make_unique<WCHAR[]>(nPathLen + 1);
 	auto_strcpy( &szPath[0], pszPath );
@@ -711,7 +711,7 @@ int CGrepAgent::DoGrepTree(
 	int			nWork = 0;
 	int			nHitCountOld = -100;
 	bool		bOutputFolderName = false;
-	int			nBasePathLen = auto_strlen(pszBasePath);
+	int			nBasePathLen = wcslen(pszBasePath);
 	CGrepEnumOptions cGrepEnumOptions;
 	CGrepEnumFilterFiles cGrepEnumFilterFiles;
 	cGrepEnumFilterFiles.Enumerates( pszPath, cGrepEnumKeys, cGrepEnumOptions, cGrepExceptAbsFiles );
@@ -751,7 +751,7 @@ int CGrepAgent::DoGrepTree(
 		currentFile += L"\\";
 		currentFile += lpFileName;
 		int nBasePathLen2 = nBasePathLen + 1;
-		if( (int)auto_strlen(pszPath) < nBasePathLen2 ){
+		if( wcslen(pszPath) < nBasePathLen2 ){
 			nBasePathLen2 = nBasePathLen;
 		}
 
@@ -1196,7 +1196,7 @@ int CGrepAgent::DoGrepFile(
 			X / O  :                  (D)Folder(Abs) -> (G)RelPath(File)
 			X / X  : (H)FullPath
 */
-			auto pszWork = std::make_unique<wchar_t[]>(auto_strlen(pszFullPath) + auto_strlen(pszCodeName) + 10);
+			auto pszWork = std::make_unique<wchar_t[]>(wcslen(pszFullPath) + wcslen(pszCodeName) + 10);
 			wchar_t* szWork0 = &pszWork[0];
 			if( sGrepOption.bGrepOutputBaseFolder || sGrepOption.bGrepSeparateFolder ){
 				if( !bOutputBaseFolder && sGrepOption.bGrepOutputBaseFolder ){

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -751,7 +751,7 @@ int CGrepAgent::DoGrepTree(
 		currentFile += L"\\";
 		currentFile += lpFileName;
 		int nBasePathLen2 = nBasePathLen + 1;
-		if( wcslen(pszPath) < nBasePathLen2 ){
+		if( (int)wcslen(pszPath) < nBasePathLen2 ){
 			nBasePathLen2 = nBasePathLen;
 		}
 

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -67,11 +67,11 @@ void CGrepAgent::CreateFolders( const WCHAR* pszPath, std::vector<std::wstring>&
 	const int nPathLen = wcslen( pszPath );
 	auto szPath = std::make_unique<WCHAR[]>(nPathLen + 1);
 	auto szTmp = std::make_unique<WCHAR[]>(nPathLen + 1);
-	auto_strcpy( &szPath[0], pszPath );
+	wcscpy( &szPath[0], pszPath );
 	WCHAR* token;
 	int nPathPos = 0;
 	while( NULL != (token = my_strtok<WCHAR>( &szPath[0], nPathLen, &nPathPos, L";")) ){
-		auto_strcpy( &szTmp[0], token );
+		wcscpy( &szTmp[0], token );
 		WCHAR* p;
 		WCHAR* q;
 		p = q = &szTmp[0];
@@ -1214,7 +1214,7 @@ int CGrepAgent::DoGrepFile(
 					if( pszFolder[0] ){
 						auto_sprintf( szWork0, L"■\"%s\"\r\n", pszFolder );	// (C), (D)
 					}else{
-						auto_strcpy( szWork0, L"■\r\n" );
+						wcscpy( szWork0, L"■\r\n" );
 					}
 					cmemMessage.AppendString( szWork0 );
 					bOutputFolderName = true;
@@ -1243,7 +1243,7 @@ int CGrepAgent::DoGrepFile(
 	{
 		if( CODE_AUTODETECT == sGrepOption.nGrepCharSet ){
 			if( IsValidCodeType(nCharCode) ){
-				auto_strcpy( szCpName, CCodeTypeName(nCharCode).Bracket() );
+				wcscpy( szCpName, CCodeTypeName(nCharCode).Bracket() );
 				pszCodeName = szCpName;
 			}else{
 				CCodePage::GetNameBracket(szCpName, nCharCode);
@@ -1694,7 +1694,7 @@ int CGrepAgent::DoGrepReplaceFile(
 	{
 		if( CODE_AUTODETECT == sGrepOption.nGrepCharSet ){
 			if( IsValidCodeType(nCharCode) ){
-				auto_strcpy( szCpName, CCodeTypeName(nCharCode).Bracket() );
+				wcscpy( szCpName, CCodeTypeName(nCharCode).Bracket() );
 				pszCodeName = szCpName;
 			}else{
 				CCodePage::GetNameBracket(szCpName, nCharCode);

--- a/sakura_core/CGrepEnumFileBase.h
+++ b/sakura_core/CGrepEnumFileBase.h
@@ -112,9 +112,9 @@ public:
 			int baseLen = wcslen( lpBaseFolder );
 			LPWSTR lpPath = new WCHAR[ baseLen + wcslen( vecKeys[ i ] ) + 2 ];
 			if( NULL == lpPath ) break;
-			auto_strcpy( lpPath, lpBaseFolder );
-			auto_strcpy( lpPath + baseLen, L"\\" );
-			auto_strcpy( lpPath + baseLen + 1, vecKeys[ i ] );
+			wcscpy( lpPath, lpBaseFolder );
+			wcscpy( lpPath + baseLen, L"\\" );
+			wcscpy( lpPath + baseLen + 1, vecKeys[ i ] );
 			// vecKeys[ i ] ==> "subdir\*.h" 等の場合に後で(ファイル|フォルダ)名に "subdir\" を連結する
 			const WCHAR* keyDirYen = wcsrchr( vecKeys[ i ], L'\\' );
 			const WCHAR* keyDirSlash = wcsrchr( vecKeys[ i ], L'/' );
@@ -150,9 +150,9 @@ public:
 					wcsncpy( lpName, vecKeys[ i ], nKeyDirLen );
 					wcscpy( lpName + nKeyDirLen, w32fd.cFileName );
 					LPWSTR lpFullPath = new WCHAR[ baseLen + wcslen(lpName) + 2 ];
-					auto_strcpy( lpFullPath, lpBaseFolder );
-					auto_strcpy( lpFullPath + baseLen, L"\\" );
-					auto_strcpy( lpFullPath + baseLen + 1, lpName );
+					wcscpy( lpFullPath, lpBaseFolder );
+					wcscpy( lpFullPath + baseLen, L"\\" );
+					wcscpy( lpFullPath + baseLen + 1, lpName );
 					if( IsValid( w32fd, lpName ) ){
 						if( pExceptItems && pExceptItems->IsExist( lpFullPath ) ){
 						}else{

--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -329,7 +329,7 @@ void CHokanMgr::HokanSearchByKeyword(
 			if( bHokanLoHiCase ){
 				nRet = auto_memicmp(pszCurWord, word, nKeyLen );
 			}else{
-				nRet = auto_memcmp(pszCurWord, word, nKeyLen );
+				nRet = wmemcmp(pszCurWord, word, nKeyLen );
 			}
 			if( nRet != 0 ){
 				continue;

--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -327,7 +327,7 @@ void CHokanMgr::HokanSearchByKeyword(
 			const wchar_t* word = keywordMgr.GetKeyWord(kwdset,i);
 			int nRet;
 			if( bHokanLoHiCase ){
-				nRet = auto_memicmp(pszCurWord, word, nKeyLen );
+				nRet = wmemicmp(pszCurWord, word, nKeyLen );
 			}else{
 				nRet = wmemcmp(pszCurWord, word, nKeyLen );
 			}

--- a/sakura_core/CKeyWordSetMgr.cpp
+++ b/sakura_core/CKeyWordSetMgr.cpp
@@ -538,7 +538,7 @@ int CKeyWordSetMgr::CleanKeyWords( int nIdx )
 					bDelKey = true;
 				}
 			}else{
-				if( 0 == auto_memicmp( p, r, nKeyWordLen ) ){
+				if( 0 == wmemicmp( p, r, nKeyWordLen ) ){
 					bDelKey = true;
 				}
 			}

--- a/sakura_core/CKeyWordSetMgr.cpp
+++ b/sakura_core/CKeyWordSetMgr.cpp
@@ -534,7 +534,7 @@ int CKeyWordSetMgr::CleanKeyWords( int nIdx )
 		unsigned int nKeyWordLen = wcslen( p );
 		if( nKeyWordLen == wcslen( r ) ){
 			if( m_bKEYWORDCASEArr[nIdx] ){
-				if( 0 == auto_memcmp( p, r, nKeyWordLen ) ){
+				if( 0 == wmemcmp( p, r, nKeyWordLen ) ){
 					bDelKey = true;
 				}
 			}else{

--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -330,7 +330,7 @@ const wchar_t* CSearchAgent::SearchStringWord(
 			if( searchWords[iSW].second == nNextWordTo2 - nNextWordFrom2 ){
 				/* 1==大文字小文字の区別 */
 				if( (!bLoHiCase && 0 == auto_memicmp( &(pLine[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) ) ||
-					(bLoHiCase && 0 == auto_memcmp( &(pLine[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) )
+					(bLoHiCase && 0 == wmemcmp( &(pLine[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) )
 				){
 					*pnMatchLen = searchWords[iSW].second;
 					return &pLine[nNextWordFrom2];
@@ -604,7 +604,7 @@ int CSearchAgent::SearchWord(
 								const wchar_t* pData = pDocLine->GetPtr();	// 2002/2/10 aroka CMemory変更
 								/* 1==大文字小文字の区別 */
 								if( (!sSearchOption.bLoHiCase && 0 == auto_memicmp( &(pData[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) ) ||
-									(sSearchOption.bLoHiCase && 0 ==	 auto_memcmp( &(pData[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) )
+									(sSearchOption.bLoHiCase && 0 ==	 wmemcmp( &(pData[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) )
 								){
 									pMatchRange->SetFromY(nLinePos);	// マッチ行
 									pMatchRange->SetToY  (nLinePos);	// マッチ行

--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -329,7 +329,7 @@ const wchar_t* CSearchAgent::SearchStringWord(
 		for( size_t iSW = 0; iSW < nSize; ++iSW ) {
 			if( searchWords[iSW].second == nNextWordTo2 - nNextWordFrom2 ){
 				/* 1==大文字小文字の区別 */
-				if( (!bLoHiCase && 0 == auto_memicmp( &(pLine[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) ) ||
+				if( (!bLoHiCase && 0 == wmemicmp( &(pLine[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) ) ||
 					(bLoHiCase && 0 == wmemcmp( &(pLine[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) )
 				){
 					*pnMatchLen = searchWords[iSW].second;
@@ -603,8 +603,8 @@ int CSearchAgent::SearchWord(
 							if( searchWords[iSW].second == nNextWordTo2 - nNextWordFrom2 ){
 								const wchar_t* pData = pDocLine->GetPtr();	// 2002/2/10 aroka CMemory変更
 								/* 1==大文字小文字の区別 */
-								if( (!sSearchOption.bLoHiCase && 0 == auto_memicmp( &(pData[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) ) ||
-									(sSearchOption.bLoHiCase && 0 ==	 wmemcmp( &(pData[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) )
+								if( (!sSearchOption.bLoHiCase && 0 == wmemicmp( &(pData[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) ) ||
+									(sSearchOption.bLoHiCase && 0 ==   wmemcmp( &(pData[nNextWordFrom2]) , searchWords[iSW].first, searchWords[iSW].second ) )
 								){
 									pMatchRange->SetFromY(nLinePos);	// マッチ行
 									pMatchRange->SetToY  (nLinePos);	// マッチ行

--- a/sakura_core/CSortedTagJumpList.cpp
+++ b/sakura_core/CSortedTagJumpList.cpp
@@ -192,7 +192,7 @@ BOOL CSortedTagJumpList::GetParam( int index, WCHAR* keyword, WCHAR* filename, i
 		if( depth    ) *depth = p->depth;
 		if( baseDir ){
 			if( 0 <= p->baseDirId && (size_t)p->baseDirId < m_baseDirArr.size() ){
-				auto_strcpy( baseDir, m_baseDirArr[p->baseDirId].c_str() );
+				wcscpy( baseDir, m_baseDirArr[p->baseDirId].c_str() );
 			}
 		}
 		return TRUE;

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -384,7 +384,7 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 			case CMDLINEOPT_GREPMODE:	//	GREPMODE
 				m_bGrepMode = true;
 				if( L'\0' == m_fi.m_szDocType[0] ){
-					auto_strcpy( m_fi.m_szDocType , L"grepout" );
+					wcscpy( m_fi.m_szDocType , L"grepout" );
 				}
 				break;
 			case CMDLINEOPT_GREPDLG:	//	GREPDLG
@@ -473,7 +473,7 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 				m_bDebugMode = true;
 				// 2010.06.16 Moca -TYPE=output 扱いとする
 				if( L'\0' == m_fi.m_szDocType[0] ){
-					auto_strcpy( m_fi.m_szDocType , L"output" );
+					wcscpy( m_fi.m_szDocType , L"output" );
 				}
 				break;
 			case CMDLINEOPT_NOMOREOPT:	// 2007.09.09 genta これ以降引数無効

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -141,7 +141,7 @@ int CCommandLine::CheckCommandLine(
 	{
 		if( len >= ptr->len &&	//	長さが足りているか
 			( str[ptr->len] == '=' || str[ptr->len] == ':' ) &&	//	オプション部分の長さチェック
-			auto_memicmp( str, ptr->opt, ptr->len ) == 0 )	//	文字列の比較	// 2006.10.25 ryoji memcmp() -> _memicmp()
+			wmemicmp( str, ptr->opt, ptr->len ) == 0 )	//	文字列の比較	// 2006.10.25 ryoji memcmp() -> _memicmp()
 		{
 			*arg = str + ptr->len + 1;				// 引数開始位置
 			*arglen = len - ptr->len - 1;
@@ -164,7 +164,7 @@ int CCommandLine::CheckCommandLine(
 	for( ptr = _COptWoA; ptr->opt != NULL; ptr++ )
 	{
 		if( len == ptr->len &&	//	長さチェック
-			auto_memicmp( str, ptr->opt, ptr->len ) == 0 )	//	文字列の比較
+			wmemicmp( str, ptr->opt, ptr->len ) == 0 )	//	文字列の比較
 		{
 			*arglen = 0;
 			return ptr->value;

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -288,7 +288,7 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 			// Nov. 11, 2005 susu
 			// 不正なファイル名のままだとファイル保存時ダイアログが出なくなるので
 			// 簡単なファイルチェックを行うように修正
-			if (_tcsncmp_literal(szPath, L"file:///")==0) {
+			if (wcsncmp_literal(szPath, L"file:///")==0) {
 				wcscpy(szPath, &(szPath[8]));
 			}
 			int len = wcslen(szPath);

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -354,7 +354,7 @@ HWND CControlTray::Create( HINSTANCE hInstance )
 	m_pcPropertyManager = new CPropertyManager();
 	m_pcPropertyManager->Create( GetTrayHwnd(), &m_hIcons, &m_cMenuDrawer );
 
-	auto_strcpy(m_szLanguageDll, GetDllShareData().m_Common.m_sWindow.m_szLanguageDll);
+	wcscpy(m_szLanguageDll, GetDllShareData().m_Common.m_sWindow.m_szLanguageDll);
 
 	return GetTrayHwnd();
 }
@@ -673,7 +673,7 @@ LRESULT CControlTray::DispatchEvent(
 			case PM_CHANGESETTING_ALL:
 				{
 					bool bChangeLang = auto_strcmp( GetDllShareData().m_Common.m_sWindow.m_szLanguageDll, m_szLanguageDll ) != 0;
-					auto_strcpy( m_szLanguageDll, GetDllShareData().m_Common.m_sWindow.m_szLanguageDll );
+					wcscpy( m_szLanguageDll, GetDllShareData().m_Common.m_sWindow.m_szLanguageDll );
 					std::vector<std::wstring> values;
 					if( bChangeLang ){
 						CShareData::getInstance()->ConvertLangValues(values, true);
@@ -732,8 +732,8 @@ LRESULT CControlTray::DispatchEvent(
 					}
 					*(CShareData::getInstance()->GetTypeSettings()[nIdx]) = type;
 					CShareData::getInstance()->GetTypeSettings()[nIdx]->m_nIdx = nIdx;
-					auto_strcpy(m_pShareData->m_TypeMini[nIdx].m_szTypeName, type.m_szTypeName);
-					auto_strcpy(m_pShareData->m_TypeMini[nIdx].m_szTypeExts, type.m_szTypeExts);
+					wcscpy(m_pShareData->m_TypeMini[nIdx].m_szTypeName, type.m_szTypeName);
+					wcscpy(m_pShareData->m_TypeMini[nIdx].m_szTypeExts, type.m_szTypeExts);
 					m_pShareData->m_TypeMini[nIdx].m_id = type.m_id;
 					m_pShareData->m_TypeMini[nIdx].m_encoding = type.m_encoding;
 				}else{
@@ -782,8 +782,8 @@ LRESULT CControlTray::DispatchEvent(
 						m_pShareData->m_TypeMini[i] = m_pShareData->m_TypeMini[i-1];
 					}
 					types[nInsert] = type;
-					auto_strcpy(m_pShareData->m_TypeMini[nInsert].m_szTypeName, type->m_szTypeName);
-					auto_strcpy(m_pShareData->m_TypeMini[nInsert].m_szTypeExts, type->m_szTypeExts);
+					wcscpy(m_pShareData->m_TypeMini[nInsert].m_szTypeName, type->m_szTypeName);
+					wcscpy(m_pShareData->m_TypeMini[nInsert].m_szTypeExts, type->m_szTypeExts);
 					m_pShareData->m_TypeMini[nInsert].m_id = type->m_id;
 					m_pShareData->m_TypeMini[nInsert].m_encoding = type->m_encoding;
 				}else{
@@ -1242,7 +1242,7 @@ bool CControlTray::OpenNewEditor(
 				ErrorMessage(hWndParent, LS(STR_TRAY_RESPONSEFILE));
 				return false;
 			}
-			auto_strcpy(szResponseFile, pszTempFile);
+			wcscpy(szResponseFile, pszTempFile);
 			free(pszTempFile);
 			CTextOutputStream output(szResponseFile);
 			if( !output ){

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -1234,7 +1234,7 @@ bool CControlTray::OpenNewEditor(
 	CResponsefileDeleter respDeleter;
 	if( szCmdLineOption ){
 		// Grepなどで入りきらない場合はレスポンスファイルを利用する
-		if( cCmdLineBuf.max_size() < cCmdLineBuf.size() + auto_strlen(szCmdLineOption) ){
+		if( cCmdLineBuf.max_size() < cCmdLineBuf.size() + wcslen(szCmdLineOption) ){
 			WCHAR szIniDir[_MAX_PATH];
 			GetInidir(szIniDir);
 			LPWSTR pszTempFile = _wtempnam(szIniDir, L"skr_resp");

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -672,7 +672,7 @@ LRESULT CControlTray::DispatchEvent(
 			switch( (e_PM_CHANGESETTING_SELECT)lParam ){
 			case PM_CHANGESETTING_ALL:
 				{
-					bool bChangeLang = auto_strcmp( GetDllShareData().m_Common.m_sWindow.m_szLanguageDll, m_szLanguageDll ) != 0;
+					bool bChangeLang = wcscmp( GetDllShareData().m_Common.m_sWindow.m_szLanguageDll, m_szLanguageDll ) != 0;
 					wcscpy( m_szLanguageDll, GetDllShareData().m_Common.m_sWindow.m_szLanguageDll );
 					std::vector<std::wstring> values;
 					if( bChangeLang ){
@@ -765,7 +765,7 @@ LRESULT CControlTray::DispatchEvent(
 					int nAddNameNum = nInsert + 1;
 					auto_sprintf( type->m_szTypeName, LS(STR_TRAY_TYPE_NAME), nAddNameNum ); 
 					for(int k = 1; k < m_pShareData->m_nTypesCount; k++){
-						if( auto_strcmp(types[k]->m_szTypeName, type->m_szTypeName) == 0 ){
+						if( wcscmp(types[k]->m_szTypeName, type->m_szTypeName) == 0 ){
 							nAddNameNum++;
 							auto_sprintf( type->m_szTypeName, LS(STR_TRAY_TYPE_NAME), nAddNameNum ); 
 							k = 0;

--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -345,7 +345,7 @@ bool CClipboard::GetText(CNativeW* cmemBuf, bool* pbColumnSelect, bool* pbLineSe
 		CShiftJis::SJISToUnicode(cmemSjis, &cmemUni);
 		cmemSjis.Clean();
 		// '\0'までを取得
-		cmemUni._SetStringLength(auto_strlen(cmemUni.GetStringPtr()));
+		cmemUni._SetStringLength(wcslen(cmemUni.GetStringPtr()));
 		cmemUni.swap(*cmemBuf);
 		::GlobalUnlock(hText);
 		return true;

--- a/sakura_core/basis/CMyString.h
+++ b/sakura_core/basis/CMyString.h
@@ -61,7 +61,7 @@ public:
 	LPCWSTR GetExt( bool bWithoutDot = false ) const
 	{
 		const WCHAR* head = c_str();
-		const WCHAR* p = auto_strchr(head,L'\0') - 1;
+		const WCHAR* p = wcschr(head,L'\0') - 1;
 		while(p>=head){
 			if(*p==L'.')break;
 			if(*p==L'\\')break;
@@ -71,7 +71,7 @@ public:
 		if(p>=head && *p==L'.'){
 			return bWithoutDot ? p+1 : p;	//bWithoutDot==trueならドットなしを返す
 		}else{
-			return auto_strchr(head,L'\0');
+			return wcschr(head,L'\0');
 		}
 	}
 };

--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -249,14 +249,14 @@ EConvertResult CCodePage::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCH
 int CCodePage::GetNameNormal(LPWSTR outName, int charcodeEx)
 {
 	if( IsValidCodeType(charcodeEx) ){
-		auto_strcpy(outName, CCodeTypeName(static_cast<ECodeType>(charcodeEx)).Normal());
+		wcscpy(outName, CCodeTypeName(static_cast<ECodeType>(charcodeEx)).Normal());
 		return 1;
 	}
 	UINT codepage = CodePageExToMSCP(charcodeEx);
 	if( codepage == CP_ACP ){
-		auto_strcpy(outName, L"CP_ACP");
+		wcscpy(outName, L"CP_ACP");
 	}else if( codepage == CP_OEMCP ){
-		auto_strcpy(outName, L"CP_OEM");
+		wcscpy(outName, L"CP_OEM");
 	}else{
 		auto_sprintf(outName, L"CP%d", codepage);
 	}
@@ -266,14 +266,14 @@ int CCodePage::GetNameNormal(LPWSTR outName, int charcodeEx)
 int CCodePage::GetNameShort(LPWSTR outName, int charcodeEx)
 {
 	if( IsValidCodeType(charcodeEx) ){
-		auto_strcpy(outName, CCodeTypeName(static_cast<ECodeType>(charcodeEx)).Short());
+		wcscpy(outName, CCodeTypeName(static_cast<ECodeType>(charcodeEx)).Short());
 		return 1;
 	}
 	UINT codepage = CodePageExToMSCP(charcodeEx);
 	if( codepage == CP_ACP ){
-		auto_strcpy(outName, L"cp_acp");
+		wcscpy(outName, L"cp_acp");
 	}else if( codepage == CP_OEMCP ){
-		auto_strcpy(outName, L"cp_oem");
+		wcscpy(outName, L"cp_oem");
 	}else{
 		auto_sprintf(outName, L"cp%d", codepage);
 	}
@@ -283,19 +283,19 @@ int CCodePage::GetNameShort(LPWSTR outName, int charcodeEx)
 int CCodePage::GetNameLong(LPWSTR outName, int charcodeEx)
 {
 	if( IsValidCodeType(charcodeEx) ){
-		auto_strcpy(outName, CCodeTypeName(static_cast<ECodeType>(charcodeEx)).Normal());
+		wcscpy(outName, CCodeTypeName(static_cast<ECodeType>(charcodeEx)).Normal());
 		return 1;
 	}
 	UINT codepage = CodePageExToMSCP(charcodeEx);
 	if( codepage == CP_ACP ){
-		auto_strcpy(outName, L"CP_ACP");
+		wcscpy(outName, L"CP_ACP");
 	}else if( codepage == CP_OEMCP ){
-		auto_strcpy(outName, L"CP_OEMCP");
+		wcscpy(outName, L"CP_OEMCP");
 	}else{
 		CPINFOEX cpInfo;
 		cpInfo.CodePageName[0] = L'\0';
 		if( ::GetCPInfoEx(codepage, 0, &cpInfo) ){
-			auto_strcpy(outName, cpInfo.CodePageName);
+			wcscpy(outName, cpInfo.CodePageName);
 		}else{
 			auto_sprintf(outName, L"CP%d", codepage);
 		}
@@ -306,14 +306,14 @@ int CCodePage::GetNameLong(LPWSTR outName, int charcodeEx)
 int CCodePage::GetNameBracket(LPWSTR outName, int charcodeEx)
 {
 	if( IsValidCodeType(charcodeEx) ){
-		auto_strcpy(outName, CCodeTypeName(static_cast<ECodeType>(charcodeEx)).Bracket());
+		wcscpy(outName, CCodeTypeName(static_cast<ECodeType>(charcodeEx)).Bracket());
 		return 1;
 	}
 	UINT codepage = CodePageExToMSCP(charcodeEx);
 	if( codepage == CP_ACP ){
-		auto_strcpy(outName, L"  [CP_ACP]");
+		wcscpy(outName, L"  [CP_ACP]");
 	}else if( codepage == CP_OEMCP ){
-		auto_strcpy(outName, L"  [CP_OEM]");
+		wcscpy(outName, L"  [CP_OEM]");
 	}else{
 		auto_sprintf(outName, L"  [CP%d]", charcodeEx);
 	}

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -114,7 +114,7 @@ void CViewCommander::Command_FILEOPEN( const WCHAR* filename, ECodeType nCharCod
 			WCHAR szName[_MAX_FNAME];
 			WCHAR szExt  [_MAX_EXT];
 			my_splitpath_t(defName.c_str(), szPath, szDir, szName, szExt);
-			auto_strcat(szPath, szDir);
+			wcscat(szPath, szDir);
 			if( 0 == auto_stricmp(defName.c_str(), szPath) ){
 				// defNameはフォルダ名だった
 			}else{

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -115,11 +115,11 @@ void CViewCommander::Command_FILEOPEN( const WCHAR* filename, ECodeType nCharCod
 			WCHAR szExt  [_MAX_EXT];
 			my_splitpath_t(defName.c_str(), szPath, szDir, szName, szExt);
 			wcscat(szPath, szDir);
-			if( 0 == auto_stricmp(defName.c_str(), szPath) ){
+			if( 0 == wmemicmp(defName.c_str(), szPath) ){
 				// defNameはフォルダ名だった
 			}else{
 				CFilePath path = defName.c_str();
-				if( 0 == auto_stricmp(path.GetDirPath().c_str(), szPath) ){
+				if( 0 == wmemicmp(path.GetDirPath().c_str(), szPath) ){
 					// フォルダ名までは実在している
 					sLoadInfo.cFilePath = defName.c_str();
 				}

--- a/sakura_core/cmd/CViewCommander_Support.cpp
+++ b/sakura_core/cmd/CViewCommander_Support.cpp
@@ -223,7 +223,7 @@ retry:;
 		// 2007.05.21 ryoji 相対パスは設定ファイルからのパスを優先
 		GetInidirOrExedir( path, helpfile );
 	}else{
-		auto_strcpy( path, helpfile );
+		wcscpy( path, helpfile );
 	}
 	// 2012.09.26 Moca HTMLHELP対応
 	WCHAR	szExt[_MAX_EXT];

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -710,7 +710,7 @@ bool CViewCommander::Sub_PreProcTagJumpByTagsFile( WCHAR* szCurrentPath, int cou
 		// 現在のタイプ別の1番目の拡張子を拝借
 		WCHAR szExts[MAX_TYPES_EXTS];
 		CDocTypeManager::GetFirstExt(m_pCommanderView->m_pTypeData->m_szTypeExts, szExts, _countof(szExts));
-		int nExtLen = auto_strlen( szExts );
+		int nExtLen = wcslen( szExts );
 		wcscat( szCurrentPath, L"\\dmy" );
 		if( nExtLen ){
 			wcscat( szCurrentPath, L"." );

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -272,7 +272,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 					if( szFile[0] ){
 						AddLastYenFromDirectoryPath( szPath );
 					}
-					auto_strcat( szPath, szFile );
+					wcscat( szPath, szFile );
 					if( IsFileExists2( szPath ) ){
 						wcscpy( szJumpToFile, szPath );
 						break;
@@ -286,7 +286,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 			}else if( 3 <= nLineLen && 0 == wmemcmp( pLine, L"◎\"", 2 ) ){
 				if( GetQuoteFilePath( &pLine[2], szJumpToFile, _countof(szJumpToFile) ) ){
 					AddLastYenFromDirectoryPath( szJumpToFile );
-					auto_strcat( szJumpToFile, szFile );
+					wcscat( szJumpToFile, szFile );
 					if( IsFileExists2( szJumpToFile ) ){
 						break;
 					}

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -274,11 +274,11 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 					}
 					auto_strcat( szPath, szFile );
 					if( IsFileExists2( szPath ) ){
-						auto_strcpy( szJumpToFile, szPath );
+						wcscpy( szJumpToFile, szPath );
 						break;
 					}
 					// 相対パスだった→◎”を探す
-					auto_strcpy( szFile, szPath );
+					wcscpy( szFile, szPath );
 					searchMode = TAGLIST_ROOT;
 					continue;
 				}
@@ -701,7 +701,7 @@ bool CViewCommander::Sub_PreProcTagJumpByTagsFile( WCHAR* szCurrentPath, int cou
 	
 	// 基準ファイル名の設定
 	if( GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
-		auto_strcpy( szCurrentPath, GetDocument()->m_cDocFile.GetFilePath() );
+		wcscpy( szCurrentPath, GetDocument()->m_cDocFile.GetFilePath() );
 	}else{
 		if( 0 == ::GetCurrentDirectory( count - _countof(L"\\dmy") - MAX_TYPES_EXTS, szCurrentPath ) ){
 			return false;

--- a/sakura_core/convert/CConvert_SpaceToTab.cpp
+++ b/sakura_core/convert/CConvert_SpaceToTab.cpp
@@ -110,7 +110,7 @@ bool CConvert_SpaceToTab::DoConvert(CNativeW* pcData)
 		}
 
 		/* 行末の処理 */
-		auto_memcpy( &pDes[nPosDes], cEol.GetValue2(), cEol.GetLen() );
+		wmemcpy( &pDes[nPosDes], cEol.GetValue2(), cEol.GetLen() );
 		nPosDes += cEol.GetLen();
 	}
 	pDes[nPosDes] = L'\0';

--- a/sakura_core/convert/CConvert_TabToSpace.cpp
+++ b/sakura_core/convert/CConvert_TabToSpace.cpp
@@ -54,7 +54,7 @@ bool CConvert_TabToSpace::DoConvert(CNativeW* pcData)
 			for( i = 0; i < nLineLen; ++i ){
 				if( TAB == pLine[i]	){
 					nWork = m_nTabWidth - ( nPosX % m_nTabWidth );
-					auto_memset( &pDes[nPosDes], L' ', nWork );
+					wmemset( &pDes[nPosDes], L' ', nWork );
 					nPosDes += nWork;
 					nPosX += nWork;
 				}else{

--- a/sakura_core/convert/CConvert_TabToSpace.cpp
+++ b/sakura_core/convert/CConvert_TabToSpace.cpp
@@ -65,7 +65,7 @@ bool CConvert_TabToSpace::DoConvert(CNativeW* pcData)
 				}
 			}
 		}
-		auto_memcpy( &pDes[nPosDes], cEol.GetValue2(), cEol.GetLen() );
+		wmemcpy( &pDes[nPosDes], cEol.GetValue2(), cEol.GetLen() );
 		nPosDes += cEol.GetLen();
 	}
 	pDes[nPosDes] = L'\0';

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -576,7 +576,7 @@ BOOL CDialog::OnCbnDropDown( HWND hwndCtl, bool scrollBar )
 // static
 bool CDialog::DirectoryUp( WCHAR* szDir )
 {
-	size_t nLen = auto_strlen( szDir );
+	size_t nLen = wcslen( szDir );
 	if( 3 < nLen ){
 		// X:\ や\\. より長い
 		CutLastYenFromDirectoryPath( szDir );

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -553,7 +553,7 @@ BOOL CDlgFavorite::OnBnClicked( int wID )
 
 					// 存在しないパスの削除
 					for( int i = pRecent->GetItemCount() - 1; i >= 0; i-- ){
-						size_t nLen = auto_strlen(pRecent->GetItemText(i));
+						size_t nLen = wcslen(pRecent->GetItemText(i));
 						std::vector<WCHAR> vecPath(nLen + 2);
 						WCHAR* szPath = &vecPath[0];
 						auto_strcpy( szPath, pRecent->GetItemText(i) );

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -1165,7 +1165,7 @@ static int CALLBACK CompareListViewFunc( LPARAM lParamItem1, LPARAM lParamItem2,
 		nRet = lParamItem1 - lParamItem2;
 	}else{
 		const CRecent* p = pCompInfo->pRecent;
-		nRet = auto_stricmp(p->GetItemText((int)lParamItem1), p->GetItemText((int)lParamItem2));
+		nRet = wmemicmp(p->GetItemText((int)lParamItem1), p->GetItemText((int)lParamItem2));
 	}
 	return pCompInfo->bAbsOrder ? nRet : -nRet;
 }

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -556,7 +556,7 @@ BOOL CDlgFavorite::OnBnClicked( int wID )
 						size_t nLen = wcslen(pRecent->GetItemText(i));
 						std::vector<WCHAR> vecPath(nLen + 2);
 						WCHAR* szPath = &vecPath[0];
-						auto_strcpy( szPath, pRecent->GetItemText(i) );
+						wcscpy( szPath, pRecent->GetItemText(i) );
 						CutLastYenFromDirectoryPath(szPath);
 						if( false == IsFileExists(szPath, false ) ){
 							pRecent->DeleteItem(i);

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -792,7 +792,7 @@ bool CDlgFavorite::RefreshListOne( int nIndex )
 	for( i = 0; i < nCount; i++ )
 	{
 		WCHAR	szText[1024];
-		auto_memset( szText, 0, _countof( szText ) );
+		wmemset( szText, 0, _countof( szText ) );
 		memset_raw( &lvitem, 0, sizeof( lvitem ) );
 		lvitem.mask       = LVIF_TEXT | LVIF_PARAM;
 		lvitem.pszText    = szText;

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -772,7 +772,7 @@ int CDlgGrep::GetData( void )
 			auto_strcat( szFolder, szFolderItem );
 			nFolderLen = wcslen( szFolder );
 		}
-		auto_strcpy( m_szFolder, szFolder );
+		wcscpy( m_szFolder, szFolder );
 	}
 
 //@@@ 2002.2.2 YAZAKI CShareData.AddToSearchKeyArr()追加に伴う変更
@@ -829,7 +829,7 @@ static void SetGrepFolder( HWND hwndCtrl, LPCWSTR folder )
 	if( auto_strchr( folder, L';') ){
 		WCHAR szQuoteFolder[MAX_PATH];
 		szQuoteFolder[0] = L'"';
-		auto_strcpy( szQuoteFolder + 1, folder );
+		wcscpy( szQuoteFolder + 1, folder );
 		auto_strcat( szQuoteFolder, L"\"" );
 		::SetWindowText( hwndCtrl, szQuoteFolder );
 	}else{

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -347,18 +347,18 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 			CGrepAgent::CreateFolders( szFolder, vPaths );
 			if( 0 < vPaths.size() ){
 				// 最後のパスが操作対象
-				auto_strncpy( szFolder, vPaths.rbegin()->c_str(), nMaxPath );
+				wcsncpy( szFolder, vPaths.rbegin()->c_str(), nMaxPath );
 				szFolder[nMaxPath-1] = L'\0';
 				if( DirectoryUp( szFolder ) ){
 					*(vPaths.rbegin()) = szFolder;
 					szFolder[0] = L'\0';
 					for( int i = 0 ; i < (int)vPaths.size(); i++ ){
 						WCHAR szFolderItem[nMaxPath];
-						auto_strncpy( szFolderItem, vPaths[i].c_str(), nMaxPath );
+						wcsncpy( szFolderItem, vPaths[i].c_str(), nMaxPath );
 						szFolderItem[nMaxPath-1] = L'\0';
 						if( auto_strchr( szFolderItem, L';' ) ){
 							szFolderItem[0] = L'"';
-							auto_strncpy( szFolderItem + 1, vPaths[i].c_str(), nMaxPath - 1 );
+							wcsncpy( szFolderItem + 1, vPaths[i].c_str(), nMaxPath - 1 );
 							szFolderItem[nMaxPath-1] = L'\0';
 							auto_strcat( szFolderItem, L"\"" );
 							szFolderItem[nMaxPath-1] = L'\0';

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -360,11 +360,11 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 							szFolderItem[0] = L'"';
 							wcsncpy( szFolderItem + 1, vPaths[i].c_str(), nMaxPath - 1 );
 							szFolderItem[nMaxPath-1] = L'\0';
-							auto_strcat( szFolderItem, L"\"" );
+							wcscat( szFolderItem, L"\"" );
 							szFolderItem[nMaxPath-1] = L'\0';
 						}
 						if( i ){
-							auto_strcat( szFolder, L";" );
+							wcscat( szFolder, L";" );
 							szFolder[nMaxPath-1] = L'\0';
 						}
 						auto_strcat_s( szFolder, nMaxPath, szFolderItem );
@@ -759,7 +759,7 @@ int CDlgGrep::GetData( void )
 			if( auto_strchr( szFolderItem, L';' ) ){
 				szFolderItem[0] = L'"';
 				::GetCurrentDirectory( nMaxPath, szFolderItem + 1 );
-				auto_strcat(szFolderItem, L"\"");
+				wcscat(szFolderItem, L"\"");
 			}
 			int nFolderItemLen = wcslen( szFolderItem );
 			if( nMaxPath < nFolderLen + nFolderItemLen + 1 ){
@@ -767,9 +767,9 @@ int CDlgGrep::GetData( void )
 				return FALSE;
 			}
 			if( i ){
-				auto_strcat( szFolder, L";" );
+				wcscat( szFolder, L";" );
 			}
-			auto_strcat( szFolder, szFolderItem );
+			wcscat( szFolder, szFolderItem );
 			nFolderLen = wcslen( szFolder );
 		}
 		wcscpy( m_szFolder, szFolder );
@@ -830,7 +830,7 @@ static void SetGrepFolder( HWND hwndCtrl, LPCWSTR folder )
 		WCHAR szQuoteFolder[MAX_PATH];
 		szQuoteFolder[0] = L'"';
 		wcscpy( szQuoteFolder + 1, folder );
-		auto_strcat( szQuoteFolder, L"\"" );
+		wcscat( szQuoteFolder, L"\"" );
 		::SetWindowText( hwndCtrl, szQuoteFolder );
 	}else{
 		::SetWindowText( hwndCtrl, folder );

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -356,7 +356,7 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 						WCHAR szFolderItem[nMaxPath];
 						wcsncpy( szFolderItem, vPaths[i].c_str(), nMaxPath );
 						szFolderItem[nMaxPath-1] = L'\0';
-						if( auto_strchr( szFolderItem, L';' ) ){
+						if( wcschr( szFolderItem, L';' ) ){
 							szFolderItem[0] = L'"';
 							wcsncpy( szFolderItem + 1, vPaths[i].c_str(), nMaxPath - 1 );
 							szFolderItem[nMaxPath-1] = L'\0';
@@ -756,7 +756,7 @@ int CDlgGrep::GetData( void )
 			WCHAR szFolderItem[nMaxPath];
 			::GetCurrentDirectory( nMaxPath, szFolderItem );
 			// ;がフォルダ名に含まれていたら""で囲う
-			if( auto_strchr( szFolderItem, L';' ) ){
+			if( wcschr( szFolderItem, L';' ) ){
 				szFolderItem[0] = L'"';
 				::GetCurrentDirectory( nMaxPath, szFolderItem + 1 );
 				wcscat(szFolderItem, L"\"");
@@ -826,7 +826,7 @@ LPVOID CDlgGrep::GetHelpIdTable(void)
 
 static void SetGrepFolder( HWND hwndCtrl, LPCWSTR folder )
 {
-	if( auto_strchr( folder, L';') ){
+	if( wcschr( folder, L';') ){
 		WCHAR szQuoteFolder[MAX_PATH];
 		szQuoteFolder[0] = L'"';
 		wcscpy( szQuoteFolder + 1, folder );

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -713,7 +713,7 @@ int CDlgGrep::GetData( void )
 	m_pShareData->m_Common.m_sSearch.m_bGrepOutputBaseFolder = m_bGrepOutputBaseFolder;
 	m_pShareData->m_Common.m_sSearch.m_bGrepSeparateFolder = m_bGrepSeparateFolder;
 
-	if( 0 != auto_strlen( m_szFile ) ){
+	if( 0 != wcslen( m_szFile ) ){
 		CGrepEnumKeys enumKeys;
 		int nErrorNo = enumKeys.SetFileKeys( m_szFile );
 		if( 1 == nErrorNo ){
@@ -761,7 +761,7 @@ int CDlgGrep::GetData( void )
 				::GetCurrentDirectory( nMaxPath, szFolderItem + 1 );
 				auto_strcat(szFolderItem, L"\"");
 			}
-			int nFolderItemLen = auto_strlen( szFolderItem );
+			int nFolderItemLen = wcslen( szFolderItem );
 			if( nMaxPath < nFolderLen + nFolderItemLen + 1 ){
 				WarningMessage(	GetHwnd(), LS(STR_DLGGREP6) );
 				return FALSE;
@@ -770,7 +770,7 @@ int CDlgGrep::GetData( void )
 				auto_strcat( szFolder, L";" );
 			}
 			auto_strcat( szFolder, szFolderItem );
-			nFolderLen = auto_strlen( szFolder );
+			nFolderLen = wcslen( szFolder );
 		}
 		auto_strcpy( m_szFolder, szFolder );
 	}

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -367,7 +367,7 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 							wcscat( szFolder, L";" );
 							szFolder[nMaxPath-1] = L'\0';
 						}
-						auto_strcat_s( szFolder, nMaxPath, szFolderItem );
+						wcscat_s( szFolder, nMaxPath, szFolderItem );
 					}
 					::SetWindowText( hwnd, szFolder );
 				}

--- a/sakura_core/dlg/CDlgOpenFile.cpp
+++ b/sakura_core/dlg/CDlgOpenFile.cpp
@@ -91,7 +91,7 @@ BOOL CDlgOpenFile::SelectFile(
 	if( resolvePath && _IS_REL_PATH( szFilePath ) ){
 		GetInidirOrExedir(szPath, szFilePath);
 	}else{
-		auto_strcpy(szPath, szFilePath);
+		wcscpy(szPath, szFilePath);
 	}
 	/* ファイルオープンダイアログの初期化 */
 	cDlgOpenFile.Create(

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -746,7 +746,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 		break;
 	}
 
-	if( 0 != auto_strcmp(m_szDefaultWildCard, L"*.*") ){
+	if( 0 != wcscmp(m_szDefaultWildCard, L"*.*") ){
 		cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME3), L"*.*" );
 	}
 

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -707,7 +707,7 @@ void CDlgOpenFile_CommonFileDialog::Create(
 		auto_sprintf( szRelPath, L"%s%s", szDrive, szDir );
 		const WCHAR* p = szRelPath;
 		if( ! ::GetLongFileName( p, m_szInitialDir ) ){
-			auto_strcpy(m_szInitialDir, p );
+			wcscpy(m_szInitialDir, p );
 		}
 	}
 	m_vMRU = vMRU;
@@ -782,7 +782,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 			auto_sprintf( szRelPath, L"%s%s%s%s", szDrive, szDir, szName, szExt );
 			const WCHAR* p = szRelPath;
 			if( ! ::GetLongFileName( p, pszPath ) ){
-				auto_strcpy( pszPath, p );
+				wcscpy( pszPath, p );
 			}
 		}
 	}
@@ -831,7 +831,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetSaveFileName( WCHAR* pszPath )
 		const WCHAR* pOrg = pszPath;
 		if( ::GetLongFileName( pOrg, szFullPath ) ){
 			// 成功。書き戻す
-			auto_strcpy( pszPath , szFullPath );
+			wcscpy( pszPath , szFullPath );
 		}
 	}
 
@@ -899,7 +899,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModalOpenDlg(
 
 	//ファイルパス受け取りバッファ
 	WCHAR* pszPathBuf = new WCHAR[2000];
-	auto_strcpy(pszPathBuf, pLoadInfo->cFilePath); // 2013.05.27 デフォルトファイル名を設定する
+	wcscpy(pszPathBuf, pLoadInfo->cFilePath); // 2013.05.27 デフォルトファイル名を設定する
 
 	//OPENFILENAME構造体の初期化
 	InitOfn( &pData->m_ofn );		// 2005.10.29 ryoji

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -486,7 +486,7 @@ bool CDlgOpenFile_CommonItemDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 		break;
 	}
 
-	if( 0 != auto_strcmp(m_szDefaultWildCard, L"*.*") ){
+	if( 0 != wcscmp(m_szDefaultWildCard, L"*.*") ){
 		strs.push_back(LS(STR_DLGOPNFL_EXTNAME3));
 		specs.push_back(COMDLG_FILTERSPEC{strs.back().c_str(), L"*.*"});
 	}

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -451,7 +451,7 @@ void CDlgOpenFile_CommonItemDialog::Create(
 		auto_sprintf( szRelPath, L"%s%s", szDrive, szDir );
 		const WCHAR* p = szRelPath;
 		if( ! ::GetLongFileName( p, m_szInitialDir ) ){
-			auto_strcpy(m_szInitialDir, p );
+			wcscpy(m_szInitialDir, p );
 		}
 	}
 	m_vMRU = vMRU;
@@ -511,7 +511,7 @@ bool CDlgOpenFile_CommonItemDialog::DoModal_GetSaveFileName( WCHAR* pszPath )
 		const WCHAR* pOrg = pszPath;
 		if( ::GetLongFileName( pOrg, szFullPath ) ){
 			// 成功。書き戻す
-			auto_strcpy( pszPath , szFullPath );
+			wcscpy( pszPath , szFullPath );
 		}
 	}
 

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -287,7 +287,7 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 
 			if (lf.lfFaceName[0] == L'\0') {
 				// 半角フォントを設定
-				auto_strcpy( lf.lfFaceName, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintFontFaceHan );
+				wcscpy( lf.lfFaceName, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintFontFaceHan );
 				// 1/10mm→画面ドット数
 				lf.lfHeight = -( m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintFontHeight * 
 					::GetDeviceCaps ( ::GetDC( m_hwndParent ), LOGPIXELSY ) / 254 );
@@ -310,7 +310,7 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 
 			if (lf.lfFaceName[0] == L'\0') {
 				// 半角フォントを設定
-				auto_strcpy( lf.lfFaceName, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintFontFaceHan );
+				wcscpy( lf.lfFaceName, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintFontFaceHan );
 				// 1/10mm→画面ドット数
 				lf.lfHeight = -( m_PrintSettingArr[m_nCurrentPrintSetting].m_nPrintFontHeight * 
 					::GetDeviceCaps ( ::GetDC( m_hwndParent ), LOGPIXELSY ) / 254 );

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -144,7 +144,7 @@ template <size_t cchText>
 static bool MyList_GetText(HWND hwndList, int index, WCHAR(&szText)[cchText])
 {
 	List_GetText( hwndList, index, szText );
-	WCHAR* pos = auto_strchr( szText, L'*' );
+	WCHAR* pos = wcschr( szText, L'*' );
 	if( pos != NULL ){
 		*pos = L'\0';
 		return true;

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -412,7 +412,7 @@ void CDlgProfileMgr::RenameProf()
 		}
 	}
 	if( bDefault ){
-		auto_strcat(szText, L"*");
+		wcscat(szText, L"*");
 	}
 	List_DeleteString( hwndList, nCurIndex );
 	List_InsertString( hwndList, nCurIndex, szText );
@@ -427,7 +427,7 @@ void CDlgProfileMgr::SetDefaultProf(int index)
 	WCHAR szProfileName[_MAX_PATH];
 	MyList_GetText( hwndList, index, szProfileName );
 	List_DeleteString( hwndList, index );
-	auto_strcat( szProfileName, L"*" );
+	wcscat( szProfileName, L"*" );
 	List_InsertString( hwndList, index, szProfileName );
 }
 

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -324,7 +324,7 @@ void CDlgProfileMgr::CreateProf()
 			return;
 		}
 	}
-	if( 0 == auto_strcmp( szText, L".." ) ){
+	if( 0 == wcscmp( szText, L".." ) ){
 		ErrorMessage( GetHwnd(), LS(STR_DLGPROFILE_ERR_INVALID_CHAR) );
 		return;
 	}
@@ -375,7 +375,7 @@ void CDlgProfileMgr::RenameProf()
 	if( szText[0] == L'\0' ){
 		return;
 	}
-	if( 0 == auto_strcmp( szTextOld, szText ) ){
+	if( 0 == wcscmp( szTextOld, szText ) ){
 		return; // 未変更
 	}
 	std::wstring strText = szText;
@@ -386,7 +386,7 @@ void CDlgProfileMgr::RenameProf()
 			return;
 		}
 	}
-	if( 0 == auto_strcmp( szText, L".." ) ){
+	if( 0 == wcscmp( szText, L".." ) ){
 		ErrorMessage( GetHwnd(), LS(STR_DLGPROFILE_ERR_INVALID_CHAR) );
 		return;
 	}

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -365,7 +365,7 @@ void CDlgProfileMgr::RenameProf()
 	WCHAR szText[_MAX_PATH];
 	bool bDefault = MyList_GetText( hwndList, nCurIndex, szText );
 	WCHAR szTextOld[_MAX_PATH];
-	auto_strcpy( szTextOld, szText );
+	wcscpy( szTextOld, szText );
 	std::wstring strTitle = LS(STR_DLGPROFILE_RENAME_TITLE);
 	std::wstring strMessage = LS(STR_DLGPROFILE_RENAME_MSG);
 	int max_size = _MAX_PATH;

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -295,7 +295,7 @@ static bool IsProfileDuplicate(HWND hwndList, LPCWSTR szProfName, int skipIndex)
 		}
 		WCHAR szProfileName[_MAX_PATH];
 		MyList_GetText( hwndList, i, szProfileName );
-		if( 0 == auto_stricmp( szProfName, szProfileName ) ){
+		if( 0 == wmemicmp( szProfName, szProfileName ) ){
 			return true;
 		}
 	}

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -1433,7 +1433,7 @@ void CDlgTagJumpList::find_key_for_BinarySearch(
 
 		// 完全一致検索
 		int  cmp;
-		cmp = auto_strcmp( s[0], paszKeyword );
+		cmp = strcmp( s[0], paszKeyword );
 
 		if( 0 == cmp ){
 			//一致
@@ -1552,7 +1552,7 @@ void CDlgTagJumpList::find_key_for_LinearSearch(
 				if( rule->bTagJumpICase ){
 					cmp = my_stricmp( s[0], paszKeyword );
 				}else{
-					cmp = auto_strcmp( s[0], paszKeyword );
+					cmp = strcmp( s[0], paszKeyword );
 				}
 			}else{
 				// 前方一致

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -1550,7 +1550,7 @@ void CDlgTagJumpList::find_key_for_LinearSearch(
 			if( rule->bTagJumpExactMatch ){
 				// 完全一致
 				if( rule->bTagJumpICase ){
-					cmp = auto_stricmp( s[0], paszKeyword );
+					cmp = my_stricmp( s[0], paszKeyword );
 				}else{
 					cmp = auto_strcmp( s[0], paszKeyword );
 				}

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -761,7 +761,7 @@ bool CDlgTagJumpList::GetFullPathAndLine( int index, WCHAR *fullPath, int count,
 			wcscpy( dirFileName, p );
 		}else{
 			// 相対パス：連結する
-			auto_strcat( dirFileName, p );
+			wcscat( dirFileName, p );
 		}
 		fileNamePath = dirFileName;
 	}else{
@@ -1663,7 +1663,7 @@ WCHAR* CDlgTagJumpList::CopyDirDir( WCHAR* dest, const WCHAR* target, const WCHA
 	if( _IS_REL_PATH( target ) ){
 		wcscpy( dest, base );
 		AddLastYenFromDirectoryPath( dest );
-		auto_strcat( dest, target );
+		wcscat( dest, target );
 	}else{
 		wcscpy( dest, target );
 	}

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -753,12 +753,12 @@ bool CDlgTagJumpList::GetFullPathAndLine( int index, WCHAR *fullPath, int count,
 		const WCHAR	*p = fileName;
 		if( p[0] == L'\\' ){
 			if( p[1] == L'\\' ){
-				auto_strcpy( dirFileName, p );
+				wcscpy( dirFileName, p );
 			}else{
-				auto_strcpy( dirFileName, p );
+				wcscpy( dirFileName, p );
 			}
 		}else if( _istalpha( p[0] ) && p[1] == L':' ){
-			auto_strcpy( dirFileName, p );
+			wcscpy( dirFileName, p );
 		}else{
 			// 相対パス：連結する
 			auto_strcat( dirFileName, p );
@@ -1202,7 +1202,7 @@ int CDlgTagJumpList::find_key_core(
 		
 		if( szNextPath[0] ){
 			state.m_bJumpPath = true;
-			auto_strcpy( state.m_szCurPath, szNextPath );
+			wcscpy( state.m_szCurPath, szNextPath );
 			std::wstring path = state.m_szCurPath;
 			path += L"\\dummy";
 			state.m_nLoop = CalcMaxUpDirectory( path.c_str() );
@@ -1315,7 +1315,7 @@ bool CDlgTagJumpList::ReadTagsParameter(
 							szNextPath[0] = 0;
 							if (!GetLongFileName(baseWork, szNextPath)) {
 								// エラーなら変換前を適用
-								auto_strcpy(szNextPath, baseWork);
+								wcscpy(szNextPath, baseWork);
 							}
 						}
 					}
@@ -1329,7 +1329,7 @@ bool CDlgTagJumpList::ReadTagsParameter(
 						*baseDirId = cList.AddBaseDir(baseWork);
 					}
 					else {
-						auto_strcpy(baseWork, to_wchar(s[1]));
+						wcscpy(baseWork, to_wchar(s[1]));
 						AddLastYenFromDirectoryPath(baseWork);
 						*baseDirId = cList.AddBaseDir(baseWork);
 					}
@@ -1661,11 +1661,11 @@ WCHAR* CDlgTagJumpList::GetFullPathFromDepth( WCHAR* pszOutput, int count,
 WCHAR* CDlgTagJumpList::CopyDirDir( WCHAR* dest, const WCHAR* target, const WCHAR* base )
 {
 	if( _IS_REL_PATH( target ) ){
-		auto_strcpy( dest, base );
+		wcscpy( dest, base );
 		AddLastYenFromDirectoryPath( dest );
 		auto_strcat( dest, target );
 	}else{
-		auto_strcpy( dest, target );
+		wcscpy( dest, target );
 	}
 	AddLastYenFromDirectoryPath( dest );
 	return dest;

--- a/sakura_core/doc/CBlockComment.cpp
+++ b/sakura_core/doc/CBlockComment.cpp
@@ -71,7 +71,7 @@ bool CBlockComment::Match_CommentFrom(
 		L'\0' != m_szBlockCommentFrom[0] &&
 		L'\0' != m_szBlockCommentTo[0]  &&
 		nPos <= cStr.GetLength() - m_nBlockFromLen &&	/* ブロックコメントデリミタ(From) */
-		//0 == auto_memicmp( &cStr.GetPtr()[nPos], m_szBlockCommentFrom, m_nBlockFromLen )	//非ASCIIも大文字小文字を区別しない	//###locale 依存
+		//0 == wmemicmp( &cStr.GetPtr()[nPos], m_szBlockCommentFrom, m_nBlockFromLen )	//非ASCIIも大文字小文字を区別しない	//###locale 依存
 		0 == wmemicmp_ascii( &cStr.GetPtr()[nPos], m_szBlockCommentFrom, m_nBlockFromLen )	//ASCIIのみ大文字小文字を区別しない（高速）
 	){
 		return true;
@@ -94,7 +94,7 @@ int CBlockComment::Match_CommentTo(
 ) const
 {
 	for( int i = nPos; i <= cStr.GetLength() - m_nBlockToLen; ++i ){
-		//if( 0 == auto_memicmp( &cStr.GetPtr()[i], m_szBlockCommentTo, m_nBlockToLen ) ){	//非ASCIIも大文字小文字を区別しない	//###locale 依存
+		//if( 0 == wmemicmp( &cStr.GetPtr()[i], m_szBlockCommentTo, m_nBlockToLen ) ){	//非ASCIIも大文字小文字を区別しない	//###locale 依存
 		if( 0 == wmemicmp_ascii( &cStr.GetPtr()[i], m_szBlockCommentTo, m_nBlockToLen ) ){	//ASCIIのみ大文字小文字を区別しない（高速）
 			return i + m_nBlockToLen;
 		}

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -270,7 +270,7 @@ bool CDocFileOperation::SaveFileDialog(
 			WCHAR szText[16];
 			auto_sprintf(szText, L"%d", node->m_nId);
 			wcscpy(pSaveInfo->cFilePath, LS(STR_NO_TITLE2));	// 無題
-			auto_strcat(pSaveInfo->cFilePath, szText);
+			wcscat(pSaveInfo->cFilePath, szText);
 		}
 	}
 

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -269,7 +269,7 @@ bool CDocFileOperation::SaveFileDialog(
 		if( 0 < node->m_nId ){
 			WCHAR szText[16];
 			auto_sprintf(szText, L"%d", node->m_nId);
-			auto_strcpy(pSaveInfo->cFilePath, LS(STR_NO_TITLE2));	// 無題
+			wcscpy(pSaveInfo->cFilePath, LS(STR_NO_TITLE2));	// 無題
 			auto_strcat(pSaveInfo->cFilePath, szText);
 		}
 	}

--- a/sakura_core/doc/CLineComment.cpp
+++ b/sakura_core/doc/CLineComment.cpp
@@ -52,7 +52,7 @@ bool CLineComment::Match( int nPos, const CStringRef& cStr ) const
 			L'\0' != m_pszLineComment[i][0] &&	/* 行コメントデリミタ */
 			( m_nLineCommentPos[i] < 0 || nPos == m_nLineCommentPos[i] ) &&	//	位置指定ON.
 			nPos <= cStr.GetLength() - m_nLineCommentLen[i] &&	/* 行コメントデリミタ */
-			//0 == auto_memicmp( &cStr.GetPtr()[nPos], m_pszLineComment[i], m_nLineCommentLen[i] )	//非ASCIIも大文字小文字を区別しない	//###locale 依存
+			//0 == wmemicmp( &cStr.GetPtr()[nPos], m_pszLineComment[i], m_nLineCommentLen[i] )	//非ASCIIも大文字小文字を区別しない	//###locale 依存
 			0 == wmemicmp_ascii( &cStr.GetPtr()[nPos], m_pszLineComment[i], m_nLineCommentLen[i] )	//ASCIIのみ大文字小文字を区別しない（高速）
 		){
 			return true;

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -241,7 +241,7 @@ bool CDocTypeManager::ConvertTypesExtToDlgExt( const WCHAR *pszSrcExt, const WCH
 	token = _wcstok(p, m_typeExtSeps);
 	while( token )
 	{
-		if (szExt == NULL || szExt[0] == L'\0' || auto_stricmp(token, szExt + 1) != 0) {
+		if (szExt == NULL || szExt[0] == L'\0' || wmemicmp(token, szExt + 1) != 0) {
 			if( pszDstExt[0] != '\0' ) wcscat( pszDstExt, L";" );
 			// 拡張子指定なし、またはマッチした拡張子でない
 			if (wcspbrk(token, m_typeExtWildcards) == NULL) {

--- a/sakura_core/env/CFileNameManager.cpp
+++ b/sakura_core/env/CFileNameManager.cpp
@@ -249,7 +249,7 @@ bool CFileNameManager::ExpandMetaToFolder( LPCWSTR pszSrc, LPWSTR pszDes, int nD
 			else if( NULL != (pStr = wcschr( ps, L'%' ) )){
 				nMetaLen = pStr - ps;
 				if( nMetaLen < _MAX_PATH ){
-					auto_memcpy( szMeta, ps, nMetaLen );
+					wmemcpy( szMeta, ps, nMetaLen );
 					szMeta[nMetaLen] = L'\0';
 				}
 				else{
@@ -293,7 +293,7 @@ bool CFileNameManager::ExpandMetaToFolder( LPCWSTR pszSrc, LPWSTR pszDes, int nD
 					// 未定義のメタ文字列は 入力された%...%を，そのまま文字として処理する
 					else if(  pd + ( nMetaLen + 2 ) < pd_end ){
 						*pd = L'%';
-						auto_memcpy( &pd[1], ps, nMetaLen );
+						wmemcpy( &pd[1], ps, nMetaLen );
 						pd[nMetaLen + 1] = L'%';
 						pd += nMetaLen + 2;
 						ps += nMetaLen;
@@ -336,7 +336,7 @@ bool CFileNameManager::ExpandMetaToFolder( LPCWSTR pszSrc, LPWSTR pszDes, int nD
 			}
 
 			if( pd + nPathLen < pd_end && 0 != nPathLen ){
-				auto_memcpy( pd, pStr2, nPathLen );
+				wmemcpy( pd, pStr2, nPathLen );
 				pd += nPathLen;
 				ps += nMetaLen;
 			}else{

--- a/sakura_core/env/CFileNameManager.cpp
+++ b/sakura_core/env/CFileNameManager.cpp
@@ -234,13 +234,13 @@ bool CFileNameManager::ExpandMetaToFolder( LPCWSTR pszSrc, LPWSTR pszDes, int nD
 			LPCWSTR  pStr;
 			ps++;
 			// %SAKURA%
-			if( 0 == auto_strnicmp( L"SAKURA%", ps, 7 ) ){
+			if( 0 == wmemicmp( L"SAKURA%", ps, 7 ) ){
 				// exeのあるフォルダ
 				GetExedir( szPath );
 				nMetaLen = 6;
 			}
 			// %SAKURADATA%	// 2007.06.06 ryoji
-			else if( 0 == auto_strnicmp( L"SAKURADATA%", ps, 11 ) ){
+			else if( 0 == wmemicmp( L"SAKURADATA%", ps, 11 ) ){
 				// iniのあるフォルダ
 				GetInidir( szPath );
 				nMetaLen = 10;

--- a/sakura_core/env/CFileNameManager.cpp
+++ b/sakura_core/env/CFileNameManager.cpp
@@ -262,7 +262,7 @@ bool CFileNameManager::ExpandMetaToFolder( LPCWSTR pszSrc, LPWSTR pszDes, int nD
 				for( pAlias = &AliasList[0]; nMetaLen < pAlias->nLenth; pAlias++ )
 					; // 読み飛ばす
 				for( ; nMetaLen == pAlias->nLenth; pAlias++ ){
-					if( 0 == auto_stricmp( pAlias->szAlias, szMeta ) ){
+					if( 0 == wmemicmp( pAlias->szAlias, szMeta ) ){
 						wcscpy( szMeta, pAlias->szOrig );
 						break;
 					}

--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -551,7 +551,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				int nParamNameIdx = EExpParamName_begin;
 				for(; nParamNameIdx != EExpParamName_end; nParamNameIdx++ ){
 					if( SExpParamNameTable[nParamNameIdx].m_nLen == p - pBegin &&
-						0 == auto_strnicmp(SExpParamNameTable[nParamNameIdx].m_szName,
+						0 == wmemicmp(SExpParamNameTable[nParamNameIdx].m_szName,
 							pBegin, p - pBegin) ){
 						q = ExParam_LongName( q, q_max, static_cast<EExpParamName>(nParamNameIdx) );
 						break;

--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -279,7 +279,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				const WCHAR*	p;
 
 				pStr = pcDoc->m_cDocFile.GetFilePath();
-				pEnd = pStr - auto_strlen(pStr) - 1;
+				pEnd = pStr - wcslen(pStr) - 1;
 				for ( p = pStr; *p != '\0'; p++) {
 					if (*p == L'\\') {
 						pEnd = p;

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -751,7 +751,7 @@ static void ConvertLangString( wchar_t* pBuf, size_t chBufSize, std::wstring& or
 	CNativeW mem;
 	mem.SetString(pBuf);
 	mem.Replace(org.c_str(), to.c_str());
-	auto_strncpy(pBuf, mem.GetStringPtr(), chBufSize);
+	wcsncpy(pBuf, mem.GetStringPtr(), chBufSize);
 	pBuf[chBufSize - 1] = L'\0';
 }
 
@@ -760,7 +760,7 @@ static void ConvertLangString( char* pBuf, size_t chBufSize, std::wstring& org, 
 	CNativeA mem;
 	mem.SetString(pBuf);
 	mem.Replace_j(to_achar(org.c_str()), to_achar(to.c_str()));
-	auto_strncpy(pBuf, mem.GetStringPtr(), chBufSize);
+	strncpy(pBuf, mem.GetStringPtr(), chBufSize);
 	pBuf[chBufSize - 1] = '\0';
 }
 

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -1004,7 +1004,7 @@ void CShareData::TraceOut( LPCWSTR lpFmt, ... )
 	va_end( argList );
 	if( -1 == ret ){
 		// 切り詰められた
-		ret = auto_strlen( m_pShareData->m_sWorkBuffer.GetWorkBuffer<WCHAR>() );
+		ret = wcslen( m_pShareData->m_sWorkBuffer.GetWorkBuffer<WCHAR>() );
 	}else if( ret < 0 ){
 		// 保護コード:受け側はwParam→size_tで符号なしのため
 		ret = 0;

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -351,7 +351,7 @@ bool CShareData::InitShareData()
 
 			sEdit.m_bOverWriteBoxDelete = false;
 			sEdit.m_eOpenDialogDir = OPENDIALOGDIR_CUR;
-			auto_strcpy(sEdit.m_OpenDialogSelDir, L"%Personal%\\");
+			wcscpy(sEdit.m_OpenDialogSelDir, L"%Personal%\\");
 			sEdit.m_bAutoColumnPaste = TRUE;			/* 矩形コピーのテキストは常に矩形貼り付け */
 		}
 

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1689,7 +1689,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 							types.m_RegexKeywordArr[j].m_nColorIndex = COLORIDX_REGEX1;
 						}
 						if( pKeyword[nPos] ){
-							nPos += auto_strlen(&pKeyword[nPos]) + 1;
+							nPos += wcslen(&pKeyword[nPos]) + 1;
 						}
 					}
 				}else{
@@ -1704,7 +1704,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 					GetColorNameByIndex( types.m_RegexKeywordArr[j].m_nColorIndex ),
 					&pKeyword[nPos]);
 				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
-				nPos += auto_strlen(&pKeyword[nPos]) + 1;
+				nPos += wcslen(&pKeyword[nPos]) + 1;
 			}
 		}
 		if( cProfile.IsReadingMode() ){

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1858,7 +1858,7 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 			for( j = 0; j < pCKeyWordSetMgr->m_nKeyWordNumArr[i]; ++j ){
 				//	May 25, 2003 genta 区切りをTABに変更
 				int kwlen = wcslen( pCKeyWordSetMgr->GetKeyWord( i, j ) );
-				auto_memcpy( pMem, pCKeyWordSetMgr->GetKeyWord( i, j ), kwlen );
+				wmemcpy( pMem, pCKeyWordSetMgr->GetKeyWord( i, j ), kwlen );
 				pMem += kwlen;
 				*pMem++ = L'\t';
 			}

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -780,7 +780,7 @@ EFunctionCode GetPlugCmdInfoByName(
 	nId = -1;
 	for (i = 0; i < MAX_PLUGIN; i++) {
 		PluginRec& pluginrec = plugin.m_PluginTable[i];
-		if (auto_strcmp( pluginrec.m_szId, sPluginName ) == 0) {
+		if (wcscmp( pluginrec.m_szId, sPluginName ) == 0) {
 			nId = i;
 			break;
 		}

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1304,9 +1304,9 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 		if(0==wcscmp(printsetting.m_szHeaderForm[0],_EDITL("&f")) &&
 		   0==wcscmp(printsetting.m_szFooterForm[0],_EDITL("&C- &P -"))
 		){
-			auto_strcpy( printsetting.m_szHeaderForm[0], _EDITL("$f") );
-			auto_strcpy( printsetting.m_szFooterForm[0], _EDITL("") );
-			auto_strcpy( printsetting.m_szFooterForm[1], _EDITL("- $p -") );
+			wcscpy( printsetting.m_szHeaderForm[0], _EDITL("$f") );
+			wcscpy( printsetting.m_szFooterForm[0], _EDITL("") );
+			wcscpy( printsetting.m_szFooterForm[1], _EDITL("- $p -") );
 		}
 
 		//禁則	//@@@ 2002.04.09 MIK
@@ -1362,8 +1362,8 @@ void CShareData_IO::ShareData_IO_Types( CDataProfile& cProfile )
 			if( i == 0 ){
 				pShare->m_TypeBasis = type;
 			}
-			auto_strcpy(pShare->m_TypeMini[i].m_szTypeExts, type.m_szTypeExts);
-			auto_strcpy(pShare->m_TypeMini[i].m_szTypeName, type.m_szTypeName);
+			wcscpy(pShare->m_TypeMini[i].m_szTypeExts, type.m_szTypeExts);
+			wcscpy(pShare->m_TypeMini[i].m_szTypeName, type.m_szTypeName);
 			pShare->m_TypeMini[i].m_id = type.m_id;
 			pShare->m_TypeMini[i].m_encoding = type.m_encoding;
 		}
@@ -1400,7 +1400,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 
 	// 2005.04.07 D.S.Koba
 	static const WCHAR* pszForm = LTEXT("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d");	//MIK
-	auto_strcpy( szKeyName, LTEXT("nInts") );
+	wcscpy( szKeyName, LTEXT("nInts") );
 	if( cProfile.IsReadingMode() ){
 		if( cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
 			int buf[12];

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -2210,7 +2210,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 
 			// 表示名
 			p++;
-			auto_strcpy_s( pcMenu->m_sName, MAX_MAIN_MENU_NAME_LEN+1, p );
+			wcscpy_s( pcMenu->m_sName, MAX_MAIN_MENU_NAME_LEN+1, p );
 		}
 		else {
 			if (GetPlugCmdInfoByFuncCode( pcMenu->m_nFunc, szFuncName )) {

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1083,7 +1083,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 					p = szKeyData;
 					// keycode取得
 					int keycode;
-					pn = auto_strchr(p,',');
+					pn = wcschr(p,',');
 					if (pn == NULL)	continue;
 					*pn = 0;
 					nRes = scan_ints(p, L"%04x", &keycode);
@@ -1096,7 +1096,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 						EFunctionCode n;
 						//機能名を数値に置き換える。(数値の機能名もあるかも)
 						//@@@ 2002.2.2 YAZAKI マクロをCSMacroMgrに統一
-						pn = auto_strchr(p,',');
+						pn = wcschr(p,',');
 						if (pn == NULL)	break;
 						*pn = 0;
 						n = GetFunctionStrToFunctionCode(p);

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -831,7 +831,7 @@ static EFunctionCode GetFunctionStrToFunctionCode(const WCHAR* pszFuncName)
 		n = GetPlugCmdInfoByName(pszFuncName);
 	}else if (WCODE::Is09(pszFuncName[0]) 
 	  && (pszFuncName[1] == L'\0' || WCODE::Is09(pszFuncName[1]))) {
-		n = (EFunctionCode)auto_atol(pszFuncName);
+		n = (EFunctionCode)_wtol(pszFuncName);
 	}else {
 		n = CSMacroMgr::GetFuncInfoByName(0, pszFuncName, NULL);
 	}
@@ -2168,7 +2168,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 			p = szLine;
 			pn = wcschr( p, L',' );
 			if (pn != NULL)		*pn++ = L'\0';
-			pcMenu->m_nLevel = auto_atol( p );
+			pcMenu->m_nLevel = _wtol( p );
 			if (pn == NULL) {
 				continue;
 			}
@@ -2177,7 +2177,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 			p = pn;
 			pn = wcschr( p, L',' );
 			if (pn != NULL)		*pn++ = L'\0';
-			pcMenu->m_nType = (EMainMenuType)auto_atol( p );
+			pcMenu->m_nType = (EMainMenuType)_wtol( p );
 			if (pn == NULL) {
 				continue;
 			}

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1104,7 +1104,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 						p = pn+1;
 					}
 					// KeyName
-					auto_strncpy(tmpKeydata.m_szKeyName, p, _countof(tmpKeydata.m_szKeyName)-1);
+					wcsncpy(tmpKeydata.m_szKeyName, p, _countof(tmpKeydata.m_szKeyName)-1);
 					tmpKeydata.m_szKeyName[_countof(tmpKeydata.m_szKeyName)-1] = '\0';
 
 					if( tmpKeydata.m_nKeyCode <= 0 ){ // マウスコードは先頭に固定されている KeyCodeが同じなのでKeyNameで判別

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -395,7 +395,7 @@ WCHAR*	CKeyBind::MakeMenuLabel(const WCHAR* sName, const WCHAR* sKey)
 	}
 	else {
 		if( !GetDllShareData().m_Common.m_sMainMenu.m_bMainMenuKeyParentheses
-			  && (((p = wcschr( sName, sKey[0])) != NULL) || ((p = auto_strchr( sName, _totlower(sKey[0]))) != NULL)) ){
+			  && (((p = wcschr( sName, sKey[0])) != NULL) || ((p = wcschr( sName, _totlower(sKey[0]))) != NULL)) ){
 			// 欧文風、使用している文字をアクセスキーに
 			wcscpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[p-sName] = L'&';
@@ -412,9 +412,9 @@ WCHAR*	CKeyBind::MakeMenuLabel(const WCHAR* sName, const WCHAR* sKey)
 			// 末尾...
 			wcscpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[wcslen(sName) - 3] = '\0';						// 末尾の...を取る
-			wcscat_s( sLabel, _countof(sLabel), L"(&" );
-			wcscat_s( sLabel, _countof(sLabel), sKey );
-			wcscat_s( sLabel, _countof(sLabel), L")..." );
+			wcscat_s( sLabel, L"(&" );
+			wcscat_s( sLabel, sKey );
+			wcscat_s( sLabel, L")..." );
 		}
 		else {
 			auto_sprintf_s( sLabel, _countof(sLabel), L"%s(&%s)", sName, sKey );

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -412,9 +412,9 @@ WCHAR*	CKeyBind::MakeMenuLabel(const WCHAR* sName, const WCHAR* sKey)
 			// 末尾...
 			wcscpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[wcslen(sName) - 3] = '\0';						// 末尾の...を取る
-			auto_strcat_s( sLabel, _countof(sLabel), L"(&" );
-			auto_strcat_s( sLabel, _countof(sLabel), sKey );
-			auto_strcat_s( sLabel, _countof(sLabel), L")..." );
+			wcscat_s( sLabel, _countof(sLabel), L"(&" );
+			wcscat_s( sLabel, _countof(sLabel), sKey );
+			wcscat_s( sLabel, _countof(sLabel), L")..." );
 		}
 		else {
 			auto_sprintf_s( sLabel, _countof(sLabel), L"%s(&%s)", sName, sKey );

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -395,14 +395,14 @@ WCHAR*	CKeyBind::MakeMenuLabel(const WCHAR* sName, const WCHAR* sKey)
 	}
 	else {
 		if( !GetDllShareData().m_Common.m_sMainMenu.m_bMainMenuKeyParentheses
-			  && (((p = auto_strchr( sName, sKey[0])) != NULL) || ((p = auto_strchr( sName, _totlower(sKey[0]))) != NULL)) ){
+			  && (((p = wcschr( sName, sKey[0])) != NULL) || ((p = auto_strchr( sName, _totlower(sKey[0]))) != NULL)) ){
 			// 欧文風、使用している文字をアクセスキーに
 			wcscpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[p-sName] = L'&';
 			wcscpy_s( sLabel + (p-sName) + 1, _countof(sLabel), p );
 		}
-		else if( (p = auto_strchr( sName, L'(' )) != NULL
-			  && (p = auto_strchr( p, sKey[0] )) != NULL) {
+		else if( (p = wcschr( sName, L'(' )) != NULL
+			  && (p = wcschr( p, sKey[0] )) != NULL) {
 			// (付その後にアクセスキー
 			wcscpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[p-sName] = L'&';

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -190,7 +190,7 @@ int CKeyBind::CreateKeyBindList(
 				if( !pcFuncLookup->Funccode2Name(
 					iFunc,
 					szFuncNameJapanese, 255 )){
-					auto_strcpy( szFuncNameJapanese, LS(STR_ERR_DLGKEYBIND2) );
+					wcscpy( szFuncNameJapanese, LS(STR_ERR_DLGKEYBIND2) );
 				}
 				szFuncName[0] = LTEXT('\0'); /*"---unknown()--"*/
 

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -397,20 +397,20 @@ WCHAR*	CKeyBind::MakeMenuLabel(const WCHAR* sName, const WCHAR* sKey)
 		if( !GetDllShareData().m_Common.m_sMainMenu.m_bMainMenuKeyParentheses
 			  && (((p = auto_strchr( sName, sKey[0])) != NULL) || ((p = auto_strchr( sName, _totlower(sKey[0]))) != NULL)) ){
 			// 欧文風、使用している文字をアクセスキーに
-			auto_strcpy_s( sLabel, _countof(sLabel), sName );
+			wcscpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[p-sName] = L'&';
-			auto_strcpy_s( sLabel + (p-sName) + 1, _countof(sLabel), p );
+			wcscpy_s( sLabel + (p-sName) + 1, _countof(sLabel), p );
 		}
 		else if( (p = auto_strchr( sName, L'(' )) != NULL
 			  && (p = auto_strchr( p, sKey[0] )) != NULL) {
 			// (付その後にアクセスキー
-			auto_strcpy_s( sLabel, _countof(sLabel), sName );
+			wcscpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[p-sName] = L'&';
-			auto_strcpy_s( sLabel + (p-sName) + 1, _countof(sLabel), p );
+			wcscpy_s( sLabel + (p-sName) + 1, _countof(sLabel), p );
 		}
 		else if (wcscmp( sName + wcslen(sName) - 3, L"..." ) == 0) {
 			// 末尾...
-			auto_strcpy_s( sLabel, _countof(sLabel), sName );
+			wcscpy_s( sLabel, _countof(sLabel), sName );
 			sLabel[wcslen(sName) - 3] = '\0';						// 末尾の...を取る
 			auto_strcat_s( sLabel, _countof(sLabel), L"(&" );
 			auto_strcat_s( sLabel, _countof(sLabel), sKey );

--- a/sakura_core/io/CZipFile.cpp
+++ b/sakura_core/io/CZipFile.cpp
@@ -132,9 +132,9 @@ bool CZipFile::ChkPluginDef(const std::wstring& sDefFile, std::wstring& sFolderN
 
 				// 定義ファイルか
 				if (!vFolder && wcslen(bps) >= sDefFile.length()
-					&& (auto_stricmp(bps, ((sFolderName + L"/" + sDefFile).c_str())) == 0
-					|| auto_stricmp(bps, ((sFolderName + L"\\" + sDefFile).c_str())) == 0
-					|| auto_stricmp(bps, ((sZipName + L"\\" + sFolderName + L"\\" + sDefFile).c_str())) == 0)) {
+					&& (wmemicmp(bps, ((sFolderName + L"/" + sDefFile).c_str())) == 0
+					|| wmemicmp(bps, ((sFolderName + L"\\" + sDefFile).c_str())) == 0
+					|| wmemicmp(bps, ((sZipName + L"\\" + sFolderName + L"\\" + sDefFile).c_str())) == 0)) {
 					bFoundDef = true;
 					break;
 				}

--- a/sakura_core/io/CZipFile.cpp
+++ b/sakura_core/io/CZipFile.cpp
@@ -131,7 +131,7 @@ bool CZipFile::ChkPluginDef(const std::wstring& sDefFile, std::wstring& sFolderN
 				if (hr != S_OK) { continue; }
 
 				// 定義ファイルか
-				if (!vFolder && auto_strlen(bps) >= sDefFile.length()
+				if (!vFolder && wcslen(bps) >= sDefFile.length()
 					&& (auto_stricmp(bps, ((sFolderName + L"/" + sDefFile).c_str())) == 0
 					|| auto_stricmp(bps, ((sFolderName + L"\\" + sDefFile).c_str())) == 0
 					|| auto_stricmp(bps, ((sZipName + L"\\" + sFolderName + L"\\" + sDefFile).c_str())) == 0)) {

--- a/sakura_core/macro/CIfObj.cpp
+++ b/sakura_core/macro/CIfObj.cpp
@@ -376,7 +376,7 @@ void CIfObj::AddMethod(
 	Info->Desc.cParams = (SHORT)ArgumentCount + 1; //戻り値の分
 	Info->Desc.lprgelemdescParam = Info->Arguments;
 	//	Nov. 10, 2003 FILE Win9Xでは、[lstrcpyW]が無効のため、[wcscpy]に修正
-	assert( auto_strlen(Name)<_countof(Info->Name) );
+	assert( wcslen(Name)<_countof(Info->Name) );
 	wcscpy(Info->Name, Name);
 	Info->Method = Method;
 	Info->ID = ID;

--- a/sakura_core/macro/CKeyMacroMgr.cpp
+++ b/sakura_core/macro/CKeyMacroMgr.cpp
@@ -192,7 +192,7 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const WCHAR* pszPath )
 		for( ; i < nLineLen; ++i ){
 			//# バッファオーバーランチェック
 			if( szLine[i] == LTEXT('(') && (i - nBgn)< _countof(szFuncName) ){
-				auto_memcpy( szFuncName, &szLine[nBgn], i - nBgn );
+				wmemcpy( szFuncName, &szLine[nBgn], i - nBgn );
 				szFuncName[i - nBgn] = L'\0';
 				++i;
 				nBgn = i;

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -329,7 +329,7 @@ void CMacroParam::SetStringParam( const WCHAR* szParam, int nLength )
 		nLen = nLength;
 	}
 	m_pData = new WCHAR[nLen + 1];
-	auto_memcpy( m_pData, szParam, nLen );
+	wmemcpy( m_pData, szParam, nLen );
 	m_pData[nLen] = LTEXT('\0');
 	m_nDataLen = nLen;
 	m_eType = EMacroParamTypeStr;
@@ -1770,7 +1770,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 
 			WCHAR *Buffer = new WCHAR[ nMaxLen+1 ];
 			size_t nLen = t_min( sDefaultValue.length(), (size_t)nMaxLen);
-			auto_memcpy( Buffer, sDefaultValue.c_str(), nLen );
+			wmemcpy( Buffer, sDefaultValue.c_str(), nLen );
 			Buffer[nLen] = L'\0';
 			CDlgInput1 cDlgInput1;
 			if( cDlgInput1.DoModal( G_AppInstance(), View->GetHwnd(), L"sakura macro", sMessage.c_str(), nMaxLen, Buffer ) ) {

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -324,7 +324,7 @@ void CMacroParam::SetStringParam( const WCHAR* szParam, int nLength )
 	Clear();
 	int nLen;
 	if( nLength == -1 ){
-		nLen = auto_strlen( szParam );
+		nLen = wcslen( szParam );
 	}else{
 		nLen = nLength;
 	}
@@ -340,7 +340,7 @@ void CMacroParam::SetIntParam( const int nParam )
 	Clear();
 	m_pData = new WCHAR[16];	//	数値格納（最大16桁）用
 	_itow(nParam, m_pData, 10);
-	m_nDataLen = auto_strlen(m_pData);
+	m_nDataLen = wcslen(m_pData);
 	m_eType = EMacroParamTypeInt;
 }
 
@@ -2344,7 +2344,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 				if( !VariantToI4(varCopy, Arguments[0]) ) return false;
 				if( !VariantToBStr(varCopy2, Arguments[1]) ) return false;
 				std::vector<wchar_t> vStrMenu;
-				int nLen = (int)auto_strlen(varCopy2.Data.bstrVal);
+				int nLen = (int)wcslen(varCopy2.Data.bstrVal);
 				vStrMenu.assign( nLen + 1, L'\0' );
 				auto_strcpy(&vStrMenu[0], varCopy2.Data.bstrVal);
 				HMENU hMenu = ::CreatePopupMenu();

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -2346,7 +2346,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 				std::vector<wchar_t> vStrMenu;
 				int nLen = (int)wcslen(varCopy2.Data.bstrVal);
 				vStrMenu.assign( nLen + 1, L'\0' );
-				auto_strcpy(&vStrMenu[0], varCopy2.Data.bstrVal);
+				wcscpy(&vStrMenu[0], varCopy2.Data.bstrVal);
 				HMENU hMenu = ::CreatePopupMenu();
 				std::vector<HMENU> vHmenu;
 				vHmenu.push_back( hMenu );

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -861,7 +861,7 @@ EFunctionCode CSMacroMgr::GetFuncInfoByName(
 
 	// コマンド関数を検索
 	for( int i = 0; m_MacroFuncInfoCommandArr[i].m_pszFuncName != NULL; ++i ){
-		if( 0 == auto_strcmp( normalizedFuncName, m_MacroFuncInfoCommandArr[i].m_pszFuncName )){
+		if( 0 == wcscmp( normalizedFuncName, m_MacroFuncInfoCommandArr[i].m_pszFuncName )){
 			EFunctionCode nFuncID = EFunctionCode(m_MacroFuncInfoCommandArr[i].m_nFuncID);
 			if( pszFuncNameJapanese != NULL ){
 				wcsncpy( pszFuncNameJapanese, LS( nFuncID ), 255 );
@@ -872,7 +872,7 @@ EFunctionCode CSMacroMgr::GetFuncInfoByName(
 	}
 	// 非コマンド関数を検索
 	for( int i = 0; m_MacroFuncInfoArr[i].m_pszFuncName != NULL; ++i ){
-		if( 0 == auto_strcmp( normalizedFuncName, m_MacroFuncInfoArr[i].m_pszFuncName )){
+		if( 0 == wcscmp( normalizedFuncName, m_MacroFuncInfoArr[i].m_pszFuncName )){
 			EFunctionCode nFuncID = EFunctionCode(m_MacroFuncInfoArr[i].m_nFuncID);
 			if( pszFuncNameJapanese != NULL ){
 				wcsncpy( pszFuncNameJapanese, LS( nFuncID ), 255 );

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -809,7 +809,7 @@ WCHAR* CSMacroMgr::GetFuncInfoByID(
 	const MacroFuncInfo* MacroInfo = GetFuncInfoByID( nFuncID );
 	if( MacroInfo != NULL ){
 		if( pszFuncName != NULL ){
-			auto_strcpy( pszFuncName, MacroInfo->m_pszFuncName );
+			wcscpy( pszFuncName, MacroInfo->m_pszFuncName );
 			WCHAR *p = pszFuncName;
 			while (*p){
 				if (*p == LTEXT('(')){

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -112,9 +112,9 @@ static WCHAR* GetFileTreeLabel( const SFileTreeItem& item )
 		pszLabel = item.m_szLabelName;
 		if( item.m_szLabelName[0] == L'\0' ){
 			pszLabel = item.m_szTargetPath;
-			if( 0 == auto_strcmp(pszLabel, L".")
-			  || 0 == auto_strcmp(pszLabel, L".\\") 
-			  || 0 == auto_strcmp(pszLabel, L"./") ){
+			if( 0 == wcscmp(pszLabel, L".")
+			  || 0 == wcscmp(pszLabel, L".\\") 
+			  || 0 == wcscmp(pszLabel, L"./") ){
 				pszLabel = LS(STR_FILETREE_CURDIR);
 			}
 		}

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3991,7 +3991,7 @@ void CDlgFuncList::LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDi
 		// 各フォルダのプロジェクトファイル読み込み
 		WCHAR szPath[_MAX_PATH];
 		::GetLongFileName( L".", szPath );
-		auto_strcat( szPath, L"\\" );
+		wcscat( szPath, L"\\" );
 		int maxDir = CDlgTagJumpList::CalcMaxUpDirectory( szPath );
 		for( int i = 0; i <= maxDir; i++ ){
 			CDataProfile cProfile;

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -1669,7 +1669,7 @@ void CDlgFuncList::SetTreeFile()
 		const SFileTreeItem& item = m_fileTreeSetting.m_aItems[i];
 		// item.m_szTargetPath => szPath メタ文字の展開
 		if( !CFileNameManager::ExpandMetaToFolder(item.m_szTargetPath, szPath, _countof(szPath)) ){
-			auto_strcpy_s(szPath, _countof(szPath), L"<Error:Long Path>");
+			wcscpy_s(szPath, _countof(szPath), L"<Error:Long Path>");
 		}
 		// szPath => szPath2 <iniroot>展開
 		const WCHAR* pszFrom = szPath;
@@ -1677,9 +1677,9 @@ void CDlgFuncList::SetTreeFile()
 			CNativeW strTemp(pszFrom);
 			strTemp.Replace(L"<iniroot>", IniDirPath);
 			if( _countof(szPath2) <= strTemp.GetStringLength() ){
-				auto_strcpy_s(szPath2, _countof(szPath), L"<Error:Long Path>");
+				wcscpy_s(szPath2, _countof(szPath), L"<Error:Long Path>");
 			}else{
-				auto_strcpy_s(szPath2, _countof(szPath), strTemp.GetStringPtr());
+				wcscpy_s(szPath2, _countof(szPath), strTemp.GetStringPtr());
 			}
 		}else{
 			wcscpy(szPath2, pszFrom);

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -1682,13 +1682,13 @@ void CDlgFuncList::SetTreeFile()
 				auto_strcpy_s(szPath2, _countof(szPath), strTemp.GetStringPtr());
 			}
 		}else{
-			auto_strcpy(szPath2, pszFrom);
+			wcscpy(szPath2, pszFrom);
 		}
 		// szPath2 => szPath 「.」やショートパス等の展開
 		pszFrom = szPath2;
 		if( ::GetLongFileName(pszFrom, szPath) ){
 		}else{
-			auto_strcpy(szPath, pszFrom);
+			wcscpy(szPath, pszFrom);
 		}
 		while( item.m_nDepth < (int)hParentTree.size() - 1 ){
 			hParentTree.resize(hParentTree.size() - 1);

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -120,7 +120,7 @@ int CALLBACK CDlgFuncList::CompareFunc_Asc( LPARAM lParam1, LPARAM lParam2, LPAR
 	}
 	//	Apr. 23, 2005 genta 行番号を左端へ
 	if( FL_COL_NAME == pcDlgFuncList->m_nSortCol){	/* 名前でソート */
-		return auto_stricmp( pcFuncInfo1->m_cmemFuncName.GetStringPtr(), pcFuncInfo2->m_cmemFuncName.GetStringPtr() );
+		return wmemicmp( pcFuncInfo1->m_cmemFuncName.GetStringPtr(), pcFuncInfo2->m_cmemFuncName.GetStringPtr() );
 	}
 	//	Apr. 23, 2005 genta 行番号を左端へ
 	if( FL_COL_ROW == pcDlgFuncList->m_nSortCol){	/* 行（＋桁）でソート */
@@ -1543,7 +1543,7 @@ void CDlgFuncList::SetTree(bool tagjump, bool nolabel)
 		*/
 		bool bFileSelect = false;
 		if( pcFuncInfo->m_cmemFileName.GetStringPtr() && m_pcFuncInfoArr->m_szFilePath[0] ){
-			if( 0 == auto_stricmp( pcFuncInfo->m_cmemFileName.GetStringPtr(), m_pcFuncInfoArr->m_szFilePath.c_str() ) ){
+			if( 0 == wmemicmp( pcFuncInfo->m_cmemFileName.GetStringPtr(), m_pcFuncInfoArr->m_szFilePath.c_str() ) ){
 				bFileSelect = true;
 			}
 		}else{
@@ -1797,7 +1797,7 @@ void CDlgFuncList::SetTreeFileSub( HTREEITEM hParent, const WCHAR* pszFile )
 		tvis.item.pszText = const_cast<WCHAR*>(pFile);
 		tvis.item.lParam  = -1;
 		HTREEITEM hItem = TreeView_InsertItem(hwndTree, &tvis);
-		if( pszFile && auto_stricmp(pszFile, pFile) == 0 ){
+		if( pszFile && wmemicmp(pszFile, pFile) == 0 ){
 			hItemSelected = hItem;
 		}
 	}

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -1319,9 +1319,9 @@ void CDlgFuncList::SetListVB (void)
 
 		// 2001/06/23 N.Nakatani for Visual Basic
 		//	Jun. 26, 2001 genta 半角かな→全角に
-		auto_memset(szText, L'\0', _countof(szText));
-		auto_memset(szType, L'\0', _countof(szType));
-		auto_memset(szOption, L'\0', _countof(szOption));
+		wmemset(szText, L'\0', _countof(szText));
+		wmemset(szType, L'\0', _countof(szType));
+		wmemset(szOption, L'\0', _countof(szOption));
 		if( 1 == ((pcFuncInfo->m_nInfo >> 8) & 0x01) ){
 			// スタティック宣言(Static)
 			// 2006.12.12 Moca 末尾にスペース追加

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -968,7 +968,7 @@ void CDlgFuncList::SetTreeJava( HWND hwndDlg, BOOL bAddClass )
 		nClassNest = 0;
 		/* クラス名::メソッドの場合 */
 		if( NULL != ( pPos = wcsstr( pWork, L"::" ) )
-			&& auto_strncmp( L"operator ", pWork, 9) != 0 ){
+			&& wcsncmp( L"operator ", pWork, 9) != 0 ){
 			/* インナークラスのネストレベルを調べる */
 			int	k;
 			int	nWorkLen;
@@ -992,7 +992,7 @@ void CDlgFuncList::SetTreeJava( HWND hwndDlg, BOOL bAddClass )
 						m = k + 2;
 						++k;
 						// Klass::operator std::string
-						if( auto_strncmp( L"operator ", pWork + m, 9) == 0 ){
+						if( wcsncmp( L"operator ", pWork + m, 9) == 0 ){
 							break;
 						}
 					}

--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -406,7 +406,7 @@ BOOL IsURL(
 	if( wc_to_c(*begin)==0 ) return FALSE;	/* 2バイト文字 */
 	if( 0 < url_char[wc_to_c(*begin)] ){	/* URL開始文字 */
 		for(urlp = &url_table[url_char[wc_to_c(*begin)]-1]; urlp->name[0] == wc_to_c(*begin); urlp++){	/* URLテーブルを探索 */
-			if( (urlp->length <= end - begin) && (auto_memcmp(urlp->name, begin, urlp->length) == 0) ){	/* URLヘッダは一致した */
+			if( (urlp->length <= end - begin) && (wmemcmp(urlp->name, begin, urlp->length) == 0) ){	/* URLヘッダは一致した */
 				if( urlp->is_mail ){	/* メール専用の解析へ */
 					if( IsMailAddress(begin, urlp->length, end - begin - urlp->length, pnMatchLen) ){
 						*pnMatchLen = *pnMatchLen + urlp->length;

--- a/sakura_core/plugin/CPluginManager.cpp
+++ b/sakura_core/plugin/CPluginManager.cpp
@@ -472,7 +472,7 @@ bool CPluginManager::LoadAllPlugin(CommonSetting* common)
 		}
 		if( plugin ){
 			// 要検討：plugin.defのidとsakuraw.iniのidの不一致処理
-			assert_warning( 0 == auto_strcmp( plugin_table[iNo].m_szId, plugin->m_sId.c_str() ) );
+			assert_warning( 0 == wcscmp( plugin_table[iNo].m_szId, plugin->m_sId.c_str() ) );
 			plugin->m_id = iNo;		//プラグインテーブルの行番号をIDとする
 			m_plugins.push_back( plugin );
 			plugin_table[iNo].m_state = PLS_LOADED;

--- a/sakura_core/plugin/CPluginManager.cpp
+++ b/sakura_core/plugin/CPluginManager.cpp
@@ -130,13 +130,13 @@ bool CPluginManager::SearchNewPluginDir( CommonSetting& common, HWND hWndOwner, 
 		if( (wf.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == FILE_ATTRIBUTE_DIRECTORY &&
 			(wf.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) == 0 &&
 			wcscmp(wf.cFileName, L".")!=0 && wcscmp(wf.cFileName, L"..")!=0 &&
-			auto_stricmp(wf.cFileName, L"unuse") !=0 )
+			wmemicmp(wf.cFileName, L"unuse") !=0 )
 		{
 			//インストール済みチェック。フォルダ名＝プラグインテーブルの名前ならインストールしない
 			// 2010.08.04 大文字小文字同一視にする
 			bool isNotInstalled = true;
 			for( int iNo=0; iNo < MAX_PLUGIN; iNo++ ){
-				if( auto_stricmp( wf.cFileName, plugin_table[iNo].m_szName ) == 0 ){
+				if( wmemicmp( wf.cFileName, plugin_table[iNo].m_szName ) == 0 ){
 					isNotInstalled = false;
 					break;
 				}
@@ -274,7 +274,7 @@ bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, co
 		int		iNo;
 		if (bOk) {
 			for( iNo=0; iNo < MAX_PLUGIN; iNo++ ){
-				if( auto_stricmp( sFolderName.c_str(), plugin_table[iNo].m_szName ) == 0 ){
+				if( wmemicmp( sFolderName.c_str(), plugin_table[iNo].m_szName ) == 0 ){
 					isNotInstalled = false;
 					break;
 				}

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -2213,7 +2213,7 @@ void CPrintPreview::CreateFonts( HDC hdc )
 	m_nAscentHan = tm.tmAscent;
 
 	// 印刷用全角フォントを作成 -> m_hFontZen
-	if (auto_strcmp(m_pPrintSetting->m_szPrintFontFaceHan, m_pPrintSetting->m_szPrintFontFaceZen)) {
+	if (wcscmp(m_pPrintSetting->m_szPrintFontFaceHan, m_pPrintSetting->m_szPrintFontFaceZen)) {
 		m_lfPreviewZen.lfHeight	= m_pPrintSetting->m_nPrintFontHeight;
 		m_lfPreviewZen.lfWidth	= 0;
 		wcscpy( m_lfPreviewZen.lfFaceName, m_pPrintSetting->m_szPrintFontFaceZen );

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -680,7 +680,7 @@ void CPropCustmenu::SetDataMenuList(HWND hwndDlg, int nIdx)
 		}
 		/* キー */
 		if( '\0' == m_Common.m_sCustomMenu.m_nCustMenuItemKeyArr[nIdx][i] ){
-			auto_strcpy( szLabel2, szLabel );
+			wcscpy( szLabel2, szLabel );
 		}else{
 			auto_sprintf( szLabel2, LTEXT("%ls(%hc)"),
 				szLabel,

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -671,7 +671,7 @@ void CPropCustmenu::SetDataMenuList(HWND hwndDlg, int nIdx)
 	List_ResetContent( hwndLIST_RES );
 	for( i = 0; i < m_Common.m_sCustomMenu.m_nCustMenuItemNumArr[nIdx]; ++i ){
 		if( 0 == m_Common.m_sCustomMenu.m_nCustMenuItemFuncArr[nIdx][i] ){
-			auto_strncpy( szLabel, LS(STR_PROPCOMCUSTMENU_SEP), _countof(szLabel) - 1 );	//Oct. 18, 2000 JEPRO 「ツールバー」タブで使っているセパレータと同じ線種に統一した
+			wcsncpy( szLabel, LS(STR_PROPCOMCUSTMENU_SEP), _countof(szLabel) - 1 );	//Oct. 18, 2000 JEPRO 「ツールバー」タブで使っているセパレータと同じ線種に統一した
 			szLabel[_countof(szLabel) - 1] = L'\0';
 		}else{
 			EFunctionCode code = m_Common.m_sCustomMenu.m_nCustMenuItemFuncArr[nIdx][i];

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -268,7 +268,7 @@ INT_PTR CPropKeybind::DispatchEvent(
 				// Oct. 2, 2001 genta
 				// 2007.11.02 ryoji F_DISABLEなら未割付
 				if( nFuncCode == F_DISABLE ){
-					auto_strncpy( pszLabel, LS(STR_PROPCOMKEYBIND_UNASSIGN), _countof(pszLabel) - 1 );
+					wcsncpy( pszLabel, LS(STR_PROPCOMKEYBIND_UNASSIGN), _countof(pszLabel) - 1 );
 					pszLabel[_countof(pszLabel) - 1] = L'\0';
 				}else{
 					m_cLookup.Funccode2Name( nFuncCode, pszLabel, 255 );

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -332,17 +332,17 @@ INT_PTR CPropKeybind::DispatchEvent(
 						i = 0;
 						p = buff;
 						//SHIFT
-						if( auto_memcmp(p, STR_SHIFT_PLUS, wcslen(STR_SHIFT_PLUS)) == 0 ){
+						if( wmemcmp(p, STR_SHIFT_PLUS, wcslen(STR_SHIFT_PLUS)) == 0 ){
 							p += wcslen(STR_SHIFT_PLUS);
 							i |= _SHIFT;
 						}
 						//CTRL
-						if( auto_memcmp(p, STR_CTRL_PLUS, wcslen(STR_CTRL_PLUS)) == 0 ){
+						if( wmemcmp(p, STR_CTRL_PLUS, wcslen(STR_CTRL_PLUS)) == 0 ){
 							p += wcslen(STR_CTRL_PLUS);
 							i |= _CTRL;
 						}
 						//ALT
-						if( auto_memcmp(p, STR_ALT_PLUS, wcslen(STR_ALT_PLUS)) == 0 ){
+						if( wmemcmp(p, STR_ALT_PLUS, wcslen(STR_ALT_PLUS)) == 0 ){
 							p += wcslen(STR_ALT_PLUS);
 							i |= _ALT;
 						}

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -325,7 +325,7 @@ INT_PTR CPropKeybind::DispatchEvent(
 					int	ret;
 
 					nIndex = List_GetCurSel( hwndAssignedkeyList );
-					auto_memset(buff, 0, _countof(buff));
+					wmemset(buff, 0, _countof(buff));
 					ret = List_GetText( hwndAssignedkeyList, nIndex, buff);
 					if( ret != LB_ERR )
 					{

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -527,7 +527,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 						}
 						if (nIdxFIdx == nSpecialFuncsNum) {
 							// 特殊機能
-							auto_strcpy( szLabel, LS(nsFuncCode::pnFuncList_Special[nIdxFunc]) );
+							wcscpy( szLabel, LS(nsFuncCode::pnFuncList_Special[nIdxFunc]) );
 							eFuncCode = nsFuncCode::pnFuncList_Special[nIdxFunc];
 						}
 						else if (m_cLookup.Pos2FuncCode( nIdxFIdx, nIdxFunc ) != 0) {
@@ -535,7 +535,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 							eFuncCode = m_cLookup.Pos2FuncCode( nIdxFIdx, nIdxFunc );
 						}
 						else {
-							auto_strcpy( szLabel, L"?" );
+							wcscpy( szLabel, L"?" );
 							eFuncCode = F_SEPARATOR;
 						}
 						break;
@@ -935,7 +935,7 @@ void CPropMainMenu::SetData( HWND hwndDlg )
 				}
 				break;
 		}
-		auto_strcpy(pFuncWk->m_sKey, pcFunc->m_sKey);
+		wcscpy(pFuncWk->m_sKey, pcFunc->m_sKey);
 		pFuncWk->m_bDupErr = false;
 		// TreeViewに挿入
 		tvis.item.mask = TVIF_TEXT | TVIF_PARAM | TVIF_CHILDREN;
@@ -1041,7 +1041,7 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 			break;
 		}
 		pcFunc->m_nFunc = pFuncWk->m_nFunc;
-		auto_strcpy( pcFunc->m_sKey, pFuncWk->m_sKey );
+		wcscpy( pcFunc->m_sKey, pFuncWk->m_sKey );
 		pcFunc->m_nLevel = nLevel;
 
 		if (tvi.cChildren) {
@@ -1063,7 +1063,7 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 			pcFunc = &pcMenuTBL[m_Common.m_sMainMenu.m_nMainMenuNum++];
 			pcFunc->m_nType = T_NODE;
 			pcFunc->m_nFunc = F_NODE;
-			auto_strcpy( pcFunc->m_sName, L"auto_add" );
+			wcscpy( pcFunc->m_sName, L"auto_add" );
 			pcFunc->m_sKey[0] = L'\0';
 			pcFunc->m_nLevel = nLevel++;
 		}

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -1013,7 +1013,7 @@ bool CPropMainMenu::GetDataTree( HWND hwndTree, HTREEITEM htiTrg, int nLevel )
 		switch(pFuncWk->m_nFunc) {
 		case F_NODE:
 			pcFunc->m_nType = T_NODE;
-			auto_strcpy_s( pcFunc->m_sName, MAX_MAIN_MENU_NAME_LEN+1, SupplementAmpersand( pFuncWk->m_sName ).c_str() );
+			wcscpy_s( pcFunc->m_sName, MAX_MAIN_MENU_NAME_LEN+1, SupplementAmpersand( pFuncWk->m_sName ).c_str() );
 			break;
 		case F_SEPARATOR:
 			pcFunc->m_nType = T_SEPARATOR;

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -507,12 +507,12 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					case IDC_BUTTON_INSERT_NODE:		// ノード挿入
 						eFuncCode = F_NODE;
 						bIsNode = true;
-						auto_strncpy( szLabel , LS(STR_PROPCOMMAINMENU_EDIT), _countof(szLabel) - 1 );
+						wcsncpy( szLabel , LS(STR_PROPCOMMAINMENU_EDIT), _countof(szLabel) - 1 );
 						szLabel[_countof(szLabel) - 1] = L'\0';
 						break;
 					case IDC_BUTTON_INSERTSEPARATOR:	// 区切線挿入
 						eFuncCode = F_SEPARATOR;
-						auto_strncpy( szLabel , LS(STR_PROPCOMMAINMENU_SEP), _countof(szLabel) - 1 );
+						wcsncpy( szLabel , LS(STR_PROPCOMMAINMENU_SEP), _countof(szLabel) - 1 );
 						szLabel[_countof(szLabel) - 1] = L'\0';
 						break;
 					case IDC_BUTTON_INSERT:				// 挿入

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -338,7 +338,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					// Esc
 					//	何も設定しない（元のまま）
 				}
-				else if (auto_strcmp(ptdi->item.pszText, L"") == 0) {
+				else if (wcscmp(ptdi->item.pszText, L"") == 0) {
 					// 空
 					pFuncWk->m_sName = LS(STR_PROPCOMMAINMENU_EDIT);
 				}

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -221,7 +221,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 						// 2010.08.21 プラグイン名(フォルダ名)の同一性の確認
 						CPlugin* plugin = CPluginManager::getInstance()->GetPlugin(sel);
 						wstring sDirName = plugin->GetFolderName().c_str();
-						if( plugin && 0 == auto_stricmp(sDirName.c_str(), m_Common.m_sPlugin.m_PluginTable[sel].m_szName ) ){
+						if( plugin && 0 == wmemicmp(sDirName.c_str(), m_Common.m_sPlugin.m_PluginTable[sel].m_szName ) ){
 							CDlgPluginOption cDlgPluginOption;
 							cDlgPluginOption.DoModal( ::GetModuleHandle(NULL), hwndDlg, this, sel );
 						}else{

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -583,7 +583,7 @@ bool CPropPlugin::BrowseReadMe(const std::wstring& sReadMeName)
 	ZeroMemory( &pi, sizeof(pi) );
 
 	WCHAR	szCmdLine[1024];
-	auto_strcpy_s(szCmdLine, _countof(szCmdLine), cCmdLineBuf.c_str());
+	wcscpy_s(szCmdLine, _countof(szCmdLine), cCmdLineBuf.c_str());
 	//リソースリーク対策
 	BOOL bRet = ::CreateProcess( NULL, szCmdLine, NULL, NULL, TRUE,
 		CREATE_NEW_CONSOLE, NULL, NULL, &sui, &pi );

--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -588,14 +588,14 @@ void CPropToolbar::DrawToolBarItemList( DRAWITEMSTRUCT* pDis )
 	if( tbb.fsStyle & TBSTYLE_SEP ){
 		// テキストだけ表示する
 		if( tbb.idCommand == F_SEPARATOR ){
-			auto_strncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM1), _countof(szLabel) - 1 );	// nLength 未使用 2003/01/09 Moca
+			wcsncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM1), _countof(szLabel) - 1 );	// nLength 未使用 2003/01/09 Moca
 			szLabel[_countof(szLabel) - 1] = L'\0';
 		}else if( tbb.idCommand == F_MENU_NOT_USED_FIRST ){
 			// ツールバー折返
-			auto_strncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM2), _countof(szLabel) - 1 );
+			wcsncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM2), _countof(szLabel) - 1 );
 			szLabel[_countof(szLabel) - 1] = L'\0';
 		}else{
-			auto_strncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM3), _countof(szLabel) - 1 );
+			wcsncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM3), _countof(szLabel) - 1 );
 			szLabel[_countof(szLabel) - 1] = L'\0';
 		}
 	}else{

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -314,8 +314,8 @@ void CPropCommon::InitData( const int* tempTypeKeywordSet, const WCHAR* name, co
 	//2002/04/25 YAZAKI STypeConfig全体を保持する必要はない。
 	if( tempTypeKeywordSet ){
 		m_nKeywordSet1 = tempTypeKeywordSet[0];
-		auto_strcpy(m_tempTypeName, name);
-		auto_strcpy(m_tempTypeExts, exts);
+		wcscpy(m_tempTypeName, name);
+		wcscpy(m_tempTypeExts, exts);
 		SKeywordSetIndex indexs;
 		indexs.typeId = -1;
 		for( int j = 0; j < MAX_KEYWORDSET_PER_TYPE; j++ ){

--- a/sakura_core/recent/CMRUFile.cpp
+++ b/sakura_core/recent/CMRUFile.cpp
@@ -203,7 +203,7 @@ void CMRUFile::Add( EditInfo* pEditInfo )
 		for( int i = 0 ; i < nSize; i++ ){
 			WCHAR szExceptMRU[_MAX_PATH];
 			CFileNameManager::ExpandMetaToFolder( m_pShareData->m_sHistory.m_aExceptMRU[i], szExceptMRU, _countof(szExceptMRU) );
-			if( NULL != _tcsistr( pEditInfo->m_szPath,  szExceptMRU) ){
+			if( NULL != wcsistr( pEditInfo->m_szPath,  szExceptMRU) ){
 				return;
 			}
 		}

--- a/sakura_core/recent/CMRUFolder.cpp
+++ b/sakura_core/recent/CMRUFolder.cpp
@@ -132,7 +132,7 @@ void CMRUFolder::Add( const WCHAR* pszFolder )
 		for( int i = 0 ; i < nSize; i++ ){
 			WCHAR szExceptMRU[_MAX_PATH];
 			CFileNameManager::ExpandMetaToFolder( m_pShareData->m_sHistory.m_aExceptMRU[i], szExceptMRU, _countof(szExceptMRU) );
-			if( NULL != _tcsistr( pszFolder, szExceptMRU ) ){
+			if( NULL != wcsistr( pszFolder, szExceptMRU ) ){
 				return;
 			}
 		}

--- a/sakura_core/recent/CMruListener.cpp
+++ b/sakura_core/recent/CMruListener.cpp
@@ -199,7 +199,7 @@ void CMruListener::OnAfterLoad(const SLoadInfo& sLoadInfo)
 		if( GetDllShareData().m_Common.m_sFile.GetRestoreBookmarks() ){
 			// SetBookMarksでデータがNUL区切りに書き換わっているので再取得
 			cMRU.GetEditInfo(pcDoc->m_cDocFile.GetFilePath(),&eiOld);
-			auto_strcpy(eiNew.m_szMarkLines, eiOld.m_szMarkLines);
+			wcscpy(eiNew.m_szMarkLines, eiOld.m_szMarkLines);
 		}
 	}
 	cMRU.Add( &eiNew );

--- a/sakura_core/recent/CRecentFile.cpp
+++ b/sakura_core/recent/CRecentFile.cpp
@@ -62,7 +62,7 @@ bool CRecentFile::DataToReceiveType( const EditInfo** dst, const EditInfo* src )
 
 bool CRecentFile::TextToDataType( EditInfo* dst, LPCWSTR pszText ) const
 {
-	if( _countof(dst->m_szPath) < auto_strlen(pszText) + 1 ){
+	if( _countof(dst->m_szPath) < wcslen(pszText) + 1 ){
 		return false;
 	}
 	wcscpy(dst->m_szPath, pszText);

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -587,7 +587,7 @@ bool CDlgTypeList::CopyType()
 			// バッファをはみ出さないように
 			LimitStringLengthW( szTemp, nTempLen, _countof(type.m_szTypeName) - nLen - 1, cmem );
 			wcscpy( type.m_szTypeName, cmem.GetStringPtr() );
-			auto_strcat( type.m_szTypeName, szNum );
+			wcscat( type.m_szTypeName, szNum );
 			bUpdate = false;
 		}
 		const STypeConfigMini* typeMini;

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -523,7 +523,7 @@ bool CDlgTypeList::InitializeType( void )
 			}
 			const STypeConfigMini* typeMini2;
 			CDocTypeManager().GetTypeConfigMini(CTypeConfig(i), &typeMini2);
-			if( auto_strcmp(typeMini2->m_szTypeName, type->m_szTypeName) == 0 ){
+			if( wcscmp(typeMini2->m_szTypeName, type->m_szTypeName) == 0 ){
 				i = 0;
 				bUpdate = true;
 			}
@@ -592,7 +592,7 @@ bool CDlgTypeList::CopyType()
 		}
 		const STypeConfigMini* typeMini;
 		CDocTypeManager().GetTypeConfigMini(CTypeConfig(i), &typeMini);
-		if( auto_strcmp(typeMini->m_szTypeName, type.m_szTypeName) == 0 ){
+		if( wcscmp(typeMini->m_szTypeName, type.m_szTypeName) == 0 ){
 			i = -1;
 			bUpdate = true;
 		}

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -564,7 +564,7 @@ bool CDlgTypeList::CopyType()
 	for(int i = 0; i < nNewTypeIndex; i++){
 		if( bUpdate ){
 			WCHAR* p = NULL;
-			for(int k = (int)auto_strlen(type.m_szTypeName) - 1; 0 <= k; k--){
+			for(int k = (int)wcslen(type.m_szTypeName) - 1; 0 <= k; k--){
 				if( WCODE::Is09(type.m_szTypeName[k]) ){
 					p = &type.m_szTypeName[k];
 				}else{
@@ -579,10 +579,10 @@ bool CDlgTypeList::CopyType()
 			}
 			WCHAR szNum[12];
 			auto_sprintf( szNum, L"%d", n );
-			int nLen = auto_strlen( szNum );
+			int nLen = wcslen( szNum );
 			WCHAR szTemp[_countof(type.m_szTypeName) + 12];
 			auto_strcpy( szTemp, type.m_szTypeName );
-			int nTempLen = auto_strlen( szTemp );
+			int nTempLen = wcslen( szTemp );
 			CNativeW cmem;
 			// バッファをはみ出さないように
 			LimitStringLengthW( szTemp, nTempLen, _countof(type.m_szTypeName) - nLen - 1, cmem );

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -581,12 +581,12 @@ bool CDlgTypeList::CopyType()
 			auto_sprintf( szNum, L"%d", n );
 			int nLen = wcslen( szNum );
 			WCHAR szTemp[_countof(type.m_szTypeName) + 12];
-			auto_strcpy( szTemp, type.m_szTypeName );
+			wcscpy( szTemp, type.m_szTypeName );
 			int nTempLen = wcslen( szTemp );
 			CNativeW cmem;
 			// バッファをはみ出さないように
 			LimitStringLengthW( szTemp, nTempLen, _countof(type.m_szTypeName) - nLen - 1, cmem );
-			auto_strcpy( type.m_szTypeName, cmem.GetStringPtr() );
+			wcscpy( type.m_szTypeName, cmem.GetStringPtr() );
 			auto_strcat( type.m_szTypeName, szNum );
 			bUpdate = false;
 		}

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -633,7 +633,7 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 		if( wcslen(buff) < 12 ) continue;
 		if( wmemcmp(buff, L"RxKey[", 6) != 0 ) continue;
 		if( wmemcmp(&buff[9], L"]=", 2) != 0 ) continue;
-		WCHAR *p = auto_strstr(&buff[11], L",");
+		WCHAR *p = wcsstr(&buff[11], L",");
 		if( p )
 		{
 			*p = L'\0';

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -631,8 +631,8 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 
 		//RxKey[999]=ColorName,RegexKeyword
 		if( wcslen(buff) < 12 ) continue;
-		if( auto_memcmp(buff, L"RxKey[", 6) != 0 ) continue;
-		if( auto_memcmp(&buff[9], L"]=", 2) != 0 ) continue;
+		if( wmemcmp(buff, L"RxKey[", 6) != 0 ) continue;
+		if( wmemcmp(&buff[9], L"]=", 2) != 0 ) continue;
 		WCHAR *p = auto_strstr(&buff[11], L",");
 		if( p )
 		{
@@ -744,8 +744,8 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 
 		//KDct[99]=ON/OFF,DictAbout,KeyHelpPath
 		if( buff.length() < 10 ||
-			auto_memcmp(buff.c_str(), LTEXT("KDct["), 5) != 0 ||
-			auto_memcmp(&buff[7], LTEXT("]="), 2) != 0
+			wmemcmp(buff.c_str(), LTEXT("KDct["), 5) != 0 ||
+			wmemcmp(&buff[7], LTEXT("]="), 2) != 0
 			){
 			//	2007.02.03 genta 処理を継続
 			++invalid_record;
@@ -1127,7 +1127,7 @@ bool CImpExpKeyWord::Import( const wstring& sFileName, wstring& sErrMsg )
 		if (szLine.length() == 0) {
 			continue;
 		}
-		if (2 <= szLine.length() && 0 == auto_memcmp( szLine.c_str(), L"//", 2 )) {
+		if (2 <= szLine.length() && 0 == wmemcmp( szLine.c_str(), L"//", 2 )) {
 			if (szLine == WSTR_CASE_TRUE) {
 				m_bCase = true;
 			}

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -919,7 +919,7 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 				int n, kc, nc;
 				//値 -> szData
 				wchar_t szData[1024];
-				auto_strncpy(szData, in.ReadLineW().c_str(), _countof(szData) - 1);
+				wcsncpy(szData, in.ReadLineW().c_str(), _countof(szData) - 1);
 				szData[_countof(szData) - 1] = L'\0';
 
 				//解析開始
@@ -955,7 +955,7 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 					p = q + 1;
 				}
 
-				auto_strncpy(sKeyBind.m_pKeyNameArr[i].m_szKeyName, p, _countof(sKeyBind.m_pKeyNameArr[i].m_szKeyName)-1);
+				wcsncpy(sKeyBind.m_pKeyNameArr[i].m_szKeyName, p, _countof(sKeyBind.m_pKeyNameArr[i].m_szKeyName)-1);
 				sKeyBind.m_pKeyNameArr[i].m_szKeyName[_countof(sKeyBind.m_pKeyNameArr[i].m_szKeyName)-1] = '\0';
 			}
 		}

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -944,7 +944,7 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 					{
 						if( WCODE::Is09(*p) )
 						{
-							n = (EFunctionCode)auto_atol(p);
+							n = (EFunctionCode)_wtol(p);
 						}
 						else
 						{

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -630,7 +630,7 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 		}
 
 		//RxKey[999]=ColorName,RegexKeyword
-		if( auto_strlen(buff) < 12 ) continue;
+		if( wcslen(buff) < 12 ) continue;
 		if( auto_memcmp(buff, L"RxKey[", 6) != 0 ) continue;
 		if( auto_memcmp(&buff[9], L"]=", 2) != 0 ) continue;
 		WCHAR *p = auto_strstr(&buff[11], L",");

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -645,7 +645,7 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 				if( k == -1 ){
 					/* 日本語名からインデックス番号に変換する */
 					for(int m = 0; m < COLORIDX_LAST; m++){
-						if( auto_strcmp(m_Types.m_ColorInfoArr[m].m_szName, &buff[11]) == 0 ){
+						if( wcscmp(m_Types.m_ColorInfoArr[m].m_szName, &buff[11]) == 0 ){
 							k = m;
 							break;
 						}

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -397,7 +397,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 		pSlashPos = wcschr( szKeyData, L'/' );
 		nIdx = -1;
 		for (i = 0; i < MAX_PLUGIN; i++) {
-			if (auto_strncmp(szKeyData, plugin.m_PluginTable[i].m_szId, pSlashPos ? pSlashPos-szKeyData : nDataLen) == 0) {
+			if (wcsncmp(szKeyData, plugin.m_PluginTable[i].m_szId, pSlashPos ? pSlashPos-szKeyData : nDataLen) == 0) {
 				nIdx = i;
 				if (pSlashPos) {	// スラッシュの後ろのプラグIDを取得
 					nPlug = _wtoi( pSlashPos + 1 );
@@ -418,7 +418,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 		pSlashPos = wcschr( szKeyData, L'/' );
 		nIdx = -1;
 		for (i = 0; i < MAX_PLUGIN; i++) {
-			if (auto_strncmp(szKeyData, plugin.m_PluginTable[i].m_szId, pSlashPos ? pSlashPos-szKeyData : nDataLen) == 0) {
+			if (wcsncmp(szKeyData, plugin.m_PluginTable[i].m_szId, pSlashPos ? pSlashPos-szKeyData : nDataLen) == 0) {
 				nIdx = i;
 				if (pSlashPos) {	// スラッシュの後ろのプラグIDを取得
 					nPlug = _wtoi( pSlashPos + 1 );

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -102,7 +102,7 @@ static wchar_t* MakeExportFileName(wchar_t* res, const wchar_t* trg, const wchar
 	wchar_t		conv[_MAX_PATH+1];
 	wchar_t*	p;
 
-	auto_strcpy( conv, trg );
+	wcscpy( conv, trg );
 
 	p = conv;
 	while ( (p = wcspbrk( p, L"\t\\:*?\"<>|" )) != NULL ) {
@@ -133,7 +133,7 @@ bool CImpExpManager::ImportUI( HINSTANCE hInstance, HWND hwndParent )
 	WCHAR	szPath[_MAX_PATH + 1];
 	szPath[0] = L'\0';
 	if( !GetFileName().empty() ){
-		auto_strcpy( szPath, GetFullPath().c_str());
+		wcscpy( szPath, GetFullPath().c_str());
 	}
 	if( !cDlgOpenFile.DoModal_GetOpenFileName( szPath ) ){
 		return false;
@@ -180,7 +180,7 @@ bool CImpExpManager::ExportUI( HINSTANCE hInstance, HWND hwndParent )
 	WCHAR			szPath[_MAX_PATH + 1];
 	szPath[0] = L'\0';
 	if( !GetFileName().empty() ){
-		auto_strcpy( szPath, GetFullPath().c_str());
+		wcscpy( szPath, GetFullPath().c_str());
 	}
 	if( !cDlgOpenFile.DoModal_GetSaveFileName( szPath ) ){
 		return false;
@@ -255,7 +255,7 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 		return false;
 	}
 	if ((unsigned int)nStructureVersion != m_pShareData->m_vStructureVersion) {
-		auto_strcpy( szKeyVersion, L"?" );
+		wcscpy( szKeyVersion, L"?" );
 		m_cProfile.IOProfileData( szSecInfo, szKeyVersion, MakeStringBufferW( szKeyVersion ) );
 		int nRet = ConfirmMessage( hwndParent,
 			LS(STR_IMPEXP_VER), 
@@ -465,7 +465,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 		if (m_Types.m_nKeyWordSetIdx[i] >= 0) {
 			nIdx = m_Types.m_nKeyWordSetIdx[i];
 			auto_sprintf( szKeyName, szKeyKeywordTemp, i+1 );
-			auto_strcpy( buff, cKeyWordSetMgr.GetTypeName( nIdx ));
+			wcscpy( buff, cKeyWordSetMgr.GetTypeName( nIdx ));
 			cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( buff ));
 
 			// 大文字小文字区別
@@ -476,7 +476,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 			cImpExpKeyWord.SetBaseName( common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetTypeName( nIdx ));
 
 			if ( cImpExpKeyWord.Export( cImpExpKeyWord.GetFullPath(), sTmpMsg ) ) {
-				auto_strcpy( szFileName, cImpExpKeyWord.GetFileName().c_str());
+				wcscpy( szFileName, cImpExpKeyWord.GetFileName().c_str());
 				auto_sprintf( szKeyName, szKeyKeywordFileTemp, i+1 );
 				if (cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( szFileName ))) {
 					files += wstring( L"\n" ) + cImpExpKeyWord.GetFileName();

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -933,7 +933,7 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 				//後に続くトークン
 				for(int j=0;j<8;j++)
 				{
-					wchar_t* q=auto_strchr(p,L',');
+					wchar_t* q=wcschr(p,L',');
 					if(!q)	{ bVer2= false; break;}
 					*q=L'\0';
 

--- a/sakura_core/typeprop/CPropTypesKeyHelp.cpp
+++ b/sakura_core/typeprop/CPropTypesKeyHelp.cpp
@@ -207,7 +207,7 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 					}
 				}
 				/* 更新するキー情報を取得する。 */
-				auto_memset(szPath, 0, _countof(szPath));
+				wmemset(szPath, 0, _countof(szPath));
 				::DlgItem_GetText( hwndDlg, IDC_EDIT_KEYHELP, szPath, _countof(szPath) );
 				if( szPath[0] == L'\0' ) return FALSE;
 				/* 重複検査 */
@@ -215,7 +215,7 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 				WCHAR szPath2[_MAX_PATH];
 				int i;
 				for(i = 0; i < nIndex2; i++){
-					auto_memset(szPath2, 0, _countof(szPath2));
+					wmemset(szPath2, 0, _countof(szPath2));
 					ListView_GetItemText(hwndList, i, 2, szPath2, _countof(szPath2));
 					if( wcscmp(szPath, szPath2) == 0 ){
 						if( (wID ==IDC_BUTTON_KEYHELP_UPD) && (i == nIndex) ){	/* 更新時、変わっていなかったら何もしない */

--- a/sakura_core/typeprop/CPropTypesRegex.cpp
+++ b/sakura_core/typeprop/CPropTypesRegex.cpp
@@ -205,7 +205,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				}
 				
 				//挿入するキー情報を取得する。
-				auto_memset(szColorIndex, 0, _countof(szColorIndex));
+				wmemset(szColorIndex, 0, _countof(szColorIndex));
 				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, _countof(szColorIndex) );
 				//キー情報を挿入する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
@@ -244,7 +244,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 					return FALSE;
 				}
 				//追加するキー情報を取得する。
-				auto_memset(szColorIndex, 0, _countof(szColorIndex));
+				wmemset(szColorIndex, 0, _countof(szColorIndex));
 				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, _countof(szColorIndex) );
 				//キーを追加する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
@@ -282,7 +282,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 					return FALSE;
 				}
 				//追加するキー情報を取得する。
-				auto_memset(szColorIndex, 0, _countof(szColorIndex));
+				wmemset(szColorIndex, 0, _countof(szColorIndex));
 				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, _countof(szColorIndex) );
 				//キーを更新する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;

--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -91,8 +91,8 @@ void CShareData::InitTypeConfigs(DLLSHAREDATA* pShareData, std::vector<STypeConf
 		STypeConfig* type = new STypeConfig;
 		types.push_back(type);
 		table[i]->InitTypeConfig(i, *type);
-		auto_strcpy(pShareData->m_TypeMini[i].m_szTypeExts, type->m_szTypeExts);
-		auto_strcpy(pShareData->m_TypeMini[i].m_szTypeName, type->m_szTypeName);
+		wcscpy(pShareData->m_TypeMini[i].m_szTypeExts, type->m_szTypeExts);
+		wcscpy(pShareData->m_TypeMini[i].m_szTypeName, type->m_szTypeName);
 		pShareData->m_TypeMini[i].m_encoding = type->m_encoding;
 		pShareData->m_TypeMini[i].m_id = type->m_id;
 		SAFE_DELETE(table[i]);

--- a/sakura_core/types/CType_Cobol.cpp
+++ b/sakura_core/types/CType_Cobol.cpp
@@ -108,7 +108,7 @@ void CDocOutline::MakeTopicList_cobol( CFuncInfoArr* pcFuncInfoArr )
 			bDivision = FALSE;
 			int nLen = (int)wcslen( szLabel ) - nKeyWordLen;
 			for( i = 0; i <= nLen ; ++i ){
-				if( 0 == auto_memicmp( &szLabel[i], pszKeyWord, nKeyWordLen ) ){
+				if( 0 == wmemicmp( &szLabel[i], pszKeyWord, nKeyWordLen ) ){
 					szLabel[i + nKeyWordLen] = L'\0';
 					wcscpy( szDivision, szLabel );
 					bDivision = TRUE;

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -778,7 +778,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 									szRawStringTag[0] = L')';
 									wcsncpy( szRawStringTag + 1, &pLine[i+1], tagLen );
 									szRawStringTag[nRawStringTagLen] = L'\0';
-									nRawStringTagCompLen = auto_strlen(szRawStringTag);
+									nRawStringTagCompLen = wcslen(szRawStringTag);
 									break;
 								}
 							}

--- a/sakura_core/types/CType_Text.cpp
+++ b/sakura_core/types/CType_Text.cpp
@@ -71,12 +71,12 @@ void CType_Text::InitTypeConfigImp(STypeConfig* pType)
 	wcscpyn( &pKeyword[keywordPos],			// 正規表現キーワード
 		L"/(?<=\")(\\b[a-zA-Z]:|\\B\\\\\\\\)[^\"\\r\\n]*/k",			//   ""で挟まれた C:\～, \\～ にマッチするパターン
 		_countof(pType->m_RegexKeywordList) - 1 );
-	keywordPos += auto_strlen(&pKeyword[keywordPos]) + 1;
+	keywordPos += wcslen(&pKeyword[keywordPos]) + 1;
 	pType->m_RegexKeywordArr[1].m_nColorIndex = COLORIDX_URL;	// 色指定番号
 	wcscpyn( &pKeyword[keywordPos],			// 正規表現キーワード
 		L"/(\\b[a-zA-Z]:\\\\|\\B\\\\\\\\)[\\w\\-_.\\\\\\/$%~]*/k",		//   C:\～, \\～ にマッチするパターン
 		_countof(pType->m_RegexKeywordList) - keywordPos - 1 );
-	keywordPos += auto_strlen(&pKeyword[keywordPos]) + 1;
+	keywordPos += wcslen(&pKeyword[keywordPos]) + 1;
 	pKeyword[keywordPos] = L'\0';
 }
 

--- a/sakura_core/types/CType_Vb.cpp
+++ b/sakura_core/types/CType_Vb.cpp
@@ -131,7 +131,7 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 						i += (nCharChars - 1);
 						continue;
 					}else{
-						auto_memcpy( &szWord[nWordIdx], &pLine[i], nCharChars );
+						wmemcpy( &szWord[nWordIdx], &pLine[i], nCharChars );
 						szWord[nWordIdx + nCharChars] = L'\0';
 						nWordIdx += (nCharChars);
 					}
@@ -360,14 +360,14 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 					){
 						nWordIdx = 0;
 
-						auto_memcpy( &szWord[nWordIdx], &pLine[i], nCharChars );
+						wmemcpy( &szWord[nWordIdx], &pLine[i], nCharChars );
 						szWord[nWordIdx + nCharChars] = L'\0';
 						nWordIdx += (nCharChars);
 
 						nMode = 1;
 					}else{
 						nWordIdx = 0;
-						auto_memcpy( &szWord[nWordIdx], &pLine[i], nCharChars );
+						wmemcpy( &szWord[nWordIdx], &pLine[i], nCharChars );
 						szWord[nWordIdx + nCharChars] = L'\0';
 						nWordIdx += (nCharChars);
 

--- a/sakura_core/uiparts/CMenuDrawer.cpp
+++ b/sakura_core/uiparts/CMenuDrawer.cpp
@@ -793,7 +793,7 @@ void CMenuDrawer::MyAppendMenu(
 		wcsncpy( szLabel, pszLabel, _countof( szLabel ) - 1 );
 		szLabel[ _countof( szLabel ) - 1 ] = L'\0';
 	}
-	auto_strcpy( szKey, pszKey); 
+	wcscpy( szKey, pszKey); 
 	if( nFuncId != 0 ){
 		/* メニューラベルの作成 */
 		CKeyBind::GetMenuLabel(

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -88,7 +88,7 @@ public:
 public:
 	//コンストラクタ・デストラクタ
 	StaticString(){ m_szData[0]=0; }
-	StaticString(const CHAR_TYPE* rhs){ if(!rhs) m_szData[0]=0; else auto_strcpy(m_szData,rhs); }
+	StaticString(const CHAR_TYPE* rhs){ if(!rhs) m_szData[0]=0; else wcscpy(m_szData,rhs); }
 
 	//クラス属性
 	size_t GetBufferCount() const{ return N_BUFFER_COUNT; }

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -104,7 +104,7 @@ public:
 	CHAR_TYPE At(int nIndex) const{ return m_szData[nIndex]; }
 
 	//簡易コピー
-	void Assign(const CHAR_TYPE* src){ if(!src) m_szData[0]=0; else auto_strcpy_s(m_szData,_countof(m_szData),src); }
+	void Assign(const CHAR_TYPE* src){ if(!src) m_szData[0]=0; else wcscpy_s(m_szData,_countof(m_szData),src); }
 	Me& operator = (const CHAR_TYPE* src){ Assign(src); return *this; }
 
 	//各種メソッド

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -1039,7 +1039,7 @@ int FileMatchScore( const WCHAR *file1, const WCHAR *file2 )
 				int chars2 = (Int)CNativeW::GetSizeOfChar(file2, len2, m);
 				if( chars1 == chars2 ){
 					if( chars1 == 1 ){
-						if( _tcs_tolower(file1[pos1]) == _tcs_tolower(file2[m]) ){
+						if( skr_towlower(file1[pos1]) == skr_towlower(file2[m]) ){
 							tmpScore += chars1;
 						}else{
 							break;

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -995,9 +995,9 @@ static void FileNameSepExt( const WCHAR *file, WCHAR* pszFile, WCHAR* pszExt )
 	if( p ){
 		auto_memcpy(pszFile, file, p - file);
 		pszFile[p - file] = L'\0';
-		auto_strcpy(pszExt, p);
+		wcscpy(pszExt, p);
 	}else{
-		auto_strcpy(pszFile, file);
+		wcscpy(pszFile, file);
 		pszExt[0] = L'\0';
 	}
 }

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -254,7 +254,7 @@ void CutLastYenFromDirectoryPath( WCHAR* pszFolder )
 
 void AddLastYenFromDirectoryPath( WCHAR* pszFolder )
 {
-	if( 3 == auto_strlen( pszFolder )
+	if( 3 == wcslen( pszFolder )
 	 && pszFolder[1] == L':'
 	 && pszFolder[2] == L'\\'
 	){
@@ -262,7 +262,7 @@ void AddLastYenFromDirectoryPath( WCHAR* pszFolder )
 	}else{
 		/* フォルダの最後が半角かつ'\\'でない場合は、付加する */
 		int	nFolderLen;
-		nFolderLen = auto_strlen( pszFolder );
+		nFolderLen = wcslen( pszFolder );
 		if( 0 < nFolderLen ){
 			if( L'\\' == pszFolder[nFolderLen - 1] || L'/' == pszFolder[nFolderLen - 1] ){
 			}else{
@@ -556,12 +556,12 @@ LPCWSTR GetRelPath( LPCWSTR pszPath )
 	LPCWSTR pszFileName = pszPath;
 
 	GetInidir( szPath, L"" );
-	int nLen = auto_strlen( szPath );
+	int nLen = wcslen( szPath );
 	if( 0 == auto_strnicmp( szPath, pszPath, nLen ) ){
 		pszFileName = pszPath + nLen;
 	}else{
 		GetExedir( szPath, L"" );
-		nLen = auto_strlen( szPath );
+		nLen = wcslen( szPath );
 		if( 0 == auto_strnicmp( szPath, pszPath, nLen ) ){
 			pszFileName = pszPath + nLen;
 		}
@@ -1020,8 +1020,8 @@ int FileMatchScoreSepExt( const WCHAR *file1, const WCHAR *file2 )
 int FileMatchScore( const WCHAR *file1, const WCHAR *file2 )
 {
 	int score = 0;
-	int len1 = auto_strlen(file1);
-	int len2 = auto_strlen(file2);
+	int len1 = wcslen(file1);
+	int len2 = wcslen(file2);
 	if( len1 < len2 ){
 		const WCHAR * tmp = file1;
 		file1 = file2;
@@ -1073,7 +1073,7 @@ void GetStrTrancateWidth( WCHAR* dest, int nSize, const WCHAR* path, HDC hDC, in
 {
 	// できるだけ左側から表示
 	// \\server\dir...
-	const int nPathLen = auto_strlen(path);
+	const int nPathLen = wcslen(path);
 	CTextWidthCalc calc(hDC);
 	if( calc.GetTextWidth(path) <= nPxWidth ){
 		wcsncpy_s(dest, nSize, path, _TRUNCATE);
@@ -1108,7 +1108,7 @@ void GetShortViewPath( WCHAR* dest, int nSize, const WCHAR* path, HDC hDC, int n
 {
 	int nLeft = 0; // 左側固定表示部分
 	int nSkipLevel = 1;
-	const int nPathLen = auto_strlen(path);
+	const int nPathLen = wcslen(path);
 	CTextWidthCalc calc(hDC);
 	if( calc.GetTextWidth(path) <= nPxWidth ){
 		// 全部表示可能

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -993,7 +993,7 @@ static void FileNameSepExt( const WCHAR *file, WCHAR* pszFile, WCHAR* pszExt )
 	}
 	const WCHAR* p = auto_strchr(folderPos, L'.');
 	if( p ){
-		auto_memcpy(pszFile, file, p - file);
+		wmemcpy(pszFile, file, p - file);
 		pszFile[p - file] = L'\0';
 		wcscpy(pszExt, p);
 	}else{

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -557,12 +557,12 @@ LPCWSTR GetRelPath( LPCWSTR pszPath )
 
 	GetInidir( szPath, L"" );
 	int nLen = wcslen( szPath );
-	if( 0 == auto_strnicmp( szPath, pszPath, nLen ) ){
+	if( 0 == wmemicmp( szPath, pszPath, nLen ) ){
 		pszFileName = pszPath + nLen;
 	}else{
 		GetExedir( szPath, L"" );
 		nLen = wcslen( szPath );
-		if( 0 == auto_strnicmp( szPath, pszPath, nLen ) ){
+		if( 0 == wmemicmp( szPath, pszPath, nLen ) ){
 			pszFileName = pszPath + nLen;
 		}
 	}
@@ -1045,7 +1045,7 @@ int FileMatchScore( const WCHAR *file1, const WCHAR *file2 )
 							break;
 						}
 					}else{
-						if( 0 == auto_strnicmp(&file1[pos1], &file2[m], chars1) ){
+						if( 0 == wmemicmp(&file1[pos1], &file2[m], chars1) ){
 							tmpScore += chars1;
 						}else{
 							break;

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -985,13 +985,13 @@ static void FileNameSepExt( const WCHAR *file, WCHAR* pszFile, WCHAR* pszExt )
 	const WCHAR* folderPos = file;
 	const WCHAR* x = folderPos;
 	while( x ){
-		x = auto_strchr(folderPos, L'\\');
+		x = wcschr(folderPos, L'\\');
 		if( x ){
 			x++;
 			folderPos = x;
 		}
 	}
-	const WCHAR* p = auto_strchr(folderPos, L'.');
+	const WCHAR* p = wcschr(folderPos, L'.');
 	if( p ){
 		wmemcpy(pszFile, file, p - file);
 		pszFile[p - file] = L'\0';

--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -141,7 +141,7 @@ bool ReadRegistry(HKEY Hive, const WCHAR* Path, const WCHAR* Item, WCHAR* Buffer
 	HKEY Key;
 	if(RegOpenKeyEx(Hive, Path, 0, KEY_READ, &Key) == ERROR_SUCCESS)
 	{
-		auto_memset(Buffer, 0, BufferCount);
+		wmemset(Buffer, 0, BufferCount);
 
 		DWORD dwType = REG_SZ;
 		DWORD dwDataLen = (BufferCount - 1) * sizeof(WCHAR); //※バイト単位！

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -115,7 +115,7 @@ char *strncpy_ex(char *dst, size_t dst_count, const char* src, size_t src_count)
 	if( src_count >= dst_count ){
 		src_count = dst_count - 1;
 	}
-	auto_memcpy( dst, src, src_count );
+	memcpy( dst, src, src_count );
 	return dst + src_count;
 }
 

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -125,7 +125,7 @@ const wchar_t* wcsistr( const wchar_t* s1, const wchar_t* s2 )
 	const wchar_t* p=s1;
 	const wchar_t* q=wcschr(s1,L'\0')-len2;
 	while(p<=q){
-		if(auto_memicmp(p,s2,len2)==0)return p;
+		if(wmemicmp(p,s2,len2)==0)return p;
 		p++;
 	}
 	return NULL;
@@ -138,7 +138,7 @@ const char* stristr(const char* s1, const char* s2)
 	const char* p=s1;
 	const char* q=strchr(s1,L'\0')-len2;
 	while(p<=q){
-		if(auto_memicmp(p,s2,len2)==0)return p;
+		if(amemicmp(p,s2,len2)==0)return p;
 		p++;
 	}
 	return NULL;

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -78,8 +78,6 @@ inline wchar_t my_towupper2( wchar_t c ){ return my_towupper(c); }
 inline wchar_t my_towlower2( wchar_t c ){ return my_towlower(c); }
 int skr_towupper( int c );
 int skr_towlower( int c );
-#define _tcs_toupper skr_towupper
-#define _tcs_tolower skr_towlower
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           拡張・独自実装                    //
@@ -106,7 +104,6 @@ inline char* strchr_j ( char* s1, char c         ){ return const_cast<char*>(str
 inline char* strichr_j( char* s1, char c         ){ return const_cast<char*>(strichr_j((const char*)s1, c )); }
 inline char* strstr_j ( char* s1, const char* s2 ){ return const_cast<char*>(strstr_j ((const char*)s1, s2)); }
 inline char* stristr_j( char* s1, const char* s2 ){ return const_cast<char*>(stristr_j((const char*)s1, s2)); }
-#define _tcsistr_j wcsistr
 
 template <class CHAR_TYPE>
 CHAR_TYPE* my_strtok(
@@ -247,9 +244,6 @@ inline int wcsncmp_auto(const wchar_t* strData1, const wchar_t* szData2)
 //strncmpの文字数指定をliteralData2の大きさで取得してくれる版
 #define strncmp_literal(strData1, literalData2) \
 	::strncmp(strData1, literalData2, _countof(literalData2) - 1 ) //※終端ヌルを含めないので、_countofからマイナス1する
-
-//WCHAR
-#define _tcsncmp_literal wcsncmp_literal
 
 #endif /* SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -96,7 +96,6 @@ const WCHAR* wcsistr( const WCHAR* s1, const WCHAR* s2 );
 const ACHAR* stristr( const ACHAR* s1, const ACHAR* s2 );
 inline WCHAR* wcsistr( WCHAR* s1, const WCHAR* s2 ){ return const_cast<WCHAR*>(wcsistr(static_cast<const WCHAR*>(s1),s2)); }
 inline ACHAR* stristr( ACHAR* s1, const ACHAR* s2 ){ return const_cast<ACHAR*>(stristr(static_cast<const ACHAR*>(s1),s2)); }
-#define _tcsistr wcsistr
 
 //大文字小文字を区別せずに文字列を検索（日本語対応版）
 const char* strchr_j(const char* s1, char c);				//!< strchr の日本語対応版。

--- a/sakura_core/util/string_ex2.cpp
+++ b/sakura_core/util/string_ex2.cpp
@@ -173,7 +173,7 @@ static EEolType GetEOLTypeUniBE( const wchar_t* pszData, int nDataLen )
 
 	for( int i = 1; i < EOL_TYPE_NUM; ++i ){
 		CEol cEol((EEolType)i);
-		if( cEol.GetLen()<=nDataLen && 0==auto_memcmp(pszData,aEolTable[i],cEol.GetLen()) ){
+		if( cEol.GetLen()<=nDataLen && 0==wmemcmp(pszData,aEolTable[i],cEol.GetLen()) ){
 			return gm_pnEolTypeArr[i];
 		}
 	}

--- a/sakura_core/util/string_ex2.cpp
+++ b/sakura_core/util/string_ex2.cpp
@@ -9,7 +9,7 @@ wchar_t *wcs_pushW(wchar_t *dst, size_t dst_count, const wchar_t* src, size_t sr
 	if( src_count >= dst_count ){
 		src_count = dst_count - 1;
 	}
-	auto_memcpy( dst, src, src_count );
+	wmemcpy( dst, src, src_count );
 	return dst + src_count;
 }
 wchar_t *wcs_pushW(wchar_t *dst, size_t dst_count, const wchar_t* src)

--- a/sakura_core/view/CEditView_CmdHokan.cpp
+++ b/sakura_core/view/CEditView_CmdHokan.cpp
@@ -275,7 +275,7 @@ int CEditView::HokanSearchByFile(
 			if( bHokanLoHiCase ){
 				nRet = auto_memicmp( pszKey, word, nKeyLen );
 			}else{
-				nRet = auto_memcmp( pszKey, word, nKeyLen );
+				nRet = wmemcmp( pszKey, word, nKeyLen );
 			}
 			if( nRet!=0 )continue;
 

--- a/sakura_core/view/CEditView_CmdHokan.cpp
+++ b/sakura_core/view/CEditView_CmdHokan.cpp
@@ -273,7 +273,7 @@ int CEditView::HokanSearchByFile(
 
 			// キーと比較する
 			if( bHokanLoHiCase ){
-				nRet = auto_memicmp( pszKey, word, nKeyLen );
+				nRet = wmemicmp( pszKey, word, nKeyLen );
 			}else{
 				nRet = wmemcmp( pszKey, word, nKeyLen );
 			}

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -212,7 +212,7 @@ void CEditView::ViewDiffInfo(
 bool COutputAdapterDiff::OutputA(const ACHAR* pBuf, int size)
 {
 	if( size == -1 ){
-		size = auto_strlen(pBuf);
+		size = strlen(pBuf);
 	}
 	//@@@ 2003.05.31 MIK
 	//	先頭がBinary filesならバイナリファイルのため意味のある差分が取られなかった

--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -262,7 +262,7 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 			if( !hIMC ){
 				return 0;
 			}
-			auto_memset(m_szComposition, L'\0', _countof(m_szComposition));
+			wmemset(m_szComposition, L'\0', _countof(m_szComposition));
 			LONG immRet = ::ImmGetCompositionString(hIMC, GCS_COMPSTR, m_szComposition, _countof(m_szComposition));
 			if( immRet == IMM_ERROR_NODATA || immRet == IMM_ERROR_GENERAL ){
 				m_szComposition[0] = L'\0';

--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -254,7 +254,7 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 	
 	if( bDocumentFeed ){
 		// IMR_DOCUMENTFEEDでは、再変換対象はIMEから取得した入力中文字列
-		nInsertCompLen = auto_strlen(m_szComposition);
+		nInsertCompLen = wcslen(m_szComposition);
 		if( 0 == nInsertCompLen ){
 			// 2回呼ばれるので、m_szCompositionに覚えておく
 			HWND hwnd = GetHwnd();
@@ -268,7 +268,7 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 				m_szComposition[0] = L'\0';
 			}
 			::ImmReleaseContext( hwnd, hIMC );
-			nInsertCompLen = auto_strlen(m_szComposition);
+			nInsertCompLen = wcslen(m_szComposition);
 		}
 	}
 

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -146,7 +146,7 @@ static void ShowCodeBox( HWND hWnd, CEditDoc* pcEditDoc )
 						delete pCode;
 						if (ret != RESULT_COMPLETE) {
 							// うまくコードが取れなかった
-							auto_strcpy(szCode[i], L"-");
+							wcscpy(szCode[i], L"-");
 						}
 					}
 				}
@@ -158,7 +158,7 @@ static void ShowCodeBox( HWND hWnd, CEditDoc* pcEditDoc )
 				delete pCode;
 				if (ret != RESULT_COMPLETE) {
 					// うまくコードが取れなかった
-					auto_strcpy(szCodeCP, L"-");
+					wcscpy(szCodeCP, L"-");
 				}
 
 				// メッセージボックス表示
@@ -844,7 +844,7 @@ void CEditWnd::LayoutMainMenu()
 			/* メニューラベルの作成 */
 			// 2014.05.04 Moca プラグイン/マクロ等を置けるようにFunccode2Nameを使うように
 			GetDocument()->m_cFuncLookup.Funccode2Name( cMainMenu->m_nFunc, szLabel, _countof(szLabel) );
-			auto_strcpy( szKey, cMainMenu->m_sKey );
+			wcscpy( szKey, cMainMenu->m_sKey );
 			if (CKeyBind::GetMenuLabel(
 				G_AppInstance(),
 				m_pShareData->m_Common.m_sKeyBind.m_nKeyNameArrNum,
@@ -854,7 +854,7 @@ void CEditWnd::LayoutMainMenu()
 				cMainMenu->m_sKey,
 				FALSE,
 				_countof(szLabel)) == NULL) {
-				auto_strcpy( szLabel, L"?" );
+				wcscpy( szLabel, L"?" );
 			}
 			::AppendMenu( hMenu, MF_STRING, cMainMenu->m_nFunc, szLabel );
 			break;

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -603,7 +603,7 @@ HWND CEditWnd::Create(
 
 	m_pcViewFontMiniMap = new CViewFont(&GetLogfont(), true);
 
-	auto_memset( m_pszMenubarMessage, L' ', MENUBAR_MESSAGE_MAX_LEN );	// null終端は不要
+	wmemset( m_pszMenubarMessage, L' ', MENUBAR_MESSAGE_MAX_LEN );	// null終端は不要
 
 	//	Dec. 4, 2002 genta
 	InitMenubarMessageFont();
@@ -3941,7 +3941,7 @@ void CEditWnd::PrintMenubarMessage( const WCHAR* msg )
 		int len = wcslen( msg );
 		wcsncpy( m_pszMenubarMessage, msg, MENUBAR_MESSAGE_MAX_LEN );
 		if( len < MENUBAR_MESSAGE_MAX_LEN ){
-			auto_memset( m_pszMenubarMessage + len, L' ', MENUBAR_MESSAGE_MAX_LEN - len );	//  null終端は不要
+			wmemset( m_pszMenubarMessage + len, L' ', MENUBAR_MESSAGE_MAX_LEN - len );	//  null終端は不要
 		}
 	}
 

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -1936,7 +1936,7 @@ LRESULT CEditWnd::DispatchEvent(
 		pLine += nLineOffset;
 		nLineLen -= nLineOffset;
 		size_t nEnd = t_min<size_t>(nLineLen, m_pShareData->m_sWorkBuffer.GetWorkBufferCount<EDIT_CHAR>());
-		auto_memcpy( m_pShareData->m_sWorkBuffer.GetWorkBuffer<EDIT_CHAR>(), pLine, nEnd );
+		wmemcpy( m_pShareData->m_sWorkBuffer.GetWorkBuffer<EDIT_CHAR>(), pLine, nEnd );
 		return nLineLen;
 	}
 

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -2695,7 +2695,7 @@ void CEditWnd::SetMenuFuncSel( HMENU hMenu, EFunctionCode nFunc, const WCHAR* sK
 			sName = flag ? LS( sFuncMenuName[i].nNameId[0] ) : LS( sFuncMenuName[i].nNameId[1] );
 		}
 	}
-	assert( auto_strlen(sName) );
+	assert( wcslen(sName) );
 
 	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, nFunc, sName, sKey );
 }

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -1823,7 +1823,7 @@ void CTabWnd::TabWindowNotify( WPARAM wParam, LPARAM lParam )
 			tcitem.pszText = szNameOld;
 			tcitem.cchTextMax = _countof(szNameOld);
 			TabCtrl_GetItem( m_hwndTab, nIndex, &tcitem );
-			if( 0 != auto_strcmp( szNameOld, szName )
+			if( 0 != wcscmp( szNameOld, szName )
 				|| tcitem.iImage != GetImageIndex( p ) ){
 
 				tcitem.mask    = TCIF_TEXT | TCIF_PARAM;


### PR DESCRIPTION
# PR の目的

目的はリファクタリングを行ってコードの読み易さを向上する事です。

## カテゴリ

- リファクタリング

## PR の背景


`sakura_core/util/string_ex.h` にある、接頭辞が `auto_` のオーバーロード関数を使う必要が無い箇所では使わないように変更しました。以前は TCHAR を使用していたので ACHAR と WCHAR てオーバーロードされた関数を使う意味が有りましたが TCHAR を使わなくなったので WCHAR 用の関数を直接呼ぶようにしました。

なお `auto_` 系の関数はインライン関数なので、経由しなくなったとしてもパフォーマンスの改善にはならないと思います。

## PR のメリット

不要になった間接コードを経由しなくなる事で記述が明確になると思います。

## PR のデメリット (トレードオフとかあれば)

ワイド文字列を処理する関数名になじみが無い人にとっては関数名から処理の内容を読み取るのが難しく感じるかもしれません。

## PR の影響範囲

動作に影響はないはずです。

## 関連チケット

#1034 #1038 
