### PR TITLE
プロジェクトのビルドにWindows10 SDKを使う

### DIFF
--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -5,25 +5,24 @@ set CONFIGURATION=%~3
 set VCVARSALL_PATH=%4
 set VCVARS_ARCH=%~5
 
-if not defined CMD_GIT call %~dp0..\tools\find-tools.bat
-if not defined CMD_GIT (
-	echo git.exe was not found.
-	endlocal && exit /b 1
-)
-
-if not exist "%~dp0googletest\CMakeLists.txt" (
-	"%CMD_GIT%" submodule init   %~dp0googletest || endlocal && exit /b 1
-	"%CMD_GIT%" submodule update %~dp0googletest || endlocal && exit /b 1
-)
-
 @rem call vcvasall.bat when we run in the Visual Studio IDE.
 if defined VCVARSALL_PATH (
 	call %VCVARSALL_PATH% %VCVARS_ARCH% || endlocal && exit /b 1
 )
 
+if not exist CMakeCache.txt (
+	call :run_cmake_configure
+)
+
+cmake --build . --config %CONFIGURATION% || endlocal && exit /b 1
+
+endlocal && exit /b 0
+
+:run_cmake_configure
 where ninja.exe > NUL 2>&1
 if not errorlevel 1 (
 	set GENERATOR=Ninja
+	set GENERATOR_OPTS=-DCMAKE_BUILD_TYPE=%CONFIGURATION%
 )
 
 @rem find cl.exe in the PATH
@@ -35,7 +34,7 @@ if not defined CMD_CL (
 )
 set CMD_CL=%CMD_CL:\=/%
 
-cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
+cmake -G "%GENERATOR%" %GENERATOR_OPTS%                   ^
   "-DCMAKE_C_COMPILER=%CMD_CL%"                           ^
   "-DCMAKE_CXX_COMPILER=%CMD_CL%"                         ^
   -DBUILD_GMOCK=OFF                                       ^
@@ -44,9 +43,8 @@ cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
   %SOURCE_DIR%                                            ^
   || endlocal && exit /b 1
 
-cmake --build . --config %CONFIGURATION% || endlocal && exit /b 1
+goto :EOF
 
-endlocal && exit /b 0
 
 :find_cl_exe
 for /f "usebackq delims=" %%a in (`where cl.exe`) do (

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -1,64 +1,64 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="GoogleTest">
     <GoogleTestSourceDir>$(MSBuildThisFileDirectory)googletest\</GoogleTestSourceDir>
-    <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\$(Platform)\$(Configuration)\googletest\</GoogleTestBuildDir>
+    <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\$(Platform)\$(Configuration)\googletest</GoogleTestBuildDir>
     <IncludePath>$(GoogleTestSourceDir)googletest\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(GoogleTestBuildDir)\lib;$(GoogleTestBuildDir)\lib\$(Configuration);$(LibraryPath)</LibraryPath>
+    <NameSuffix Condition="'$(Configuration)' == 'Debug'">d</NameSuffix>
+    <NameSuffix Condition="'$(Configuration)' == 'Release'"></NameSuffix>
   </PropertyGroup>
   <ItemDefinitionGroup Label="GoogleTest.Requirements">
     <ClCompile>
       <PreprocessorDefinitions>_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="GoogleTest.Libs" Condition="'$(Configuration)' == 'Debug'">
+  <ItemDefinitionGroup Label="GoogleTest.Libs">
     <Link>
-      <AdditionalDependencies>gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest$(NameSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest_main$(NameSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="GoogleTest.Libs" Condition="'$(Configuration)' == 'Release'">
-    <Link>
-      <AdditionalDependencies>gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemGroup Label="GoogleTest.Pdbs" Condition="'$(Configuration)' == 'Debug'">
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtestd.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtestd.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_maind.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest_maind.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtestd.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtestd.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_maind.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_maind.pdb')" />
-  </ItemGroup>
-  <ItemGroup Label="GoogleTest.Pdbs" Condition="'$(Configuration)' == 'Release'">
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\gtest_main.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest_main.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest.pdb')" />
-    <ReferenceCopyLocalPaths Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main.pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main.pdb')" />
-  </ItemGroup>
-  <Target Name="BuildGoogleTest" BeforeTargets="ClCompile">
+  <Target Name="FindGit" Condition="'$(GitCmd)' == ''">
+    <Message Text="Checking Git for Windows" Importance="high" />
+    <Exec Command="where &quot;$(PATH);$(ProgramW6432)\Git\Cmd;$(ProgramFiles)\Git\Cmd:git&quot;" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCmd" />
+    </Exec>
+  </Target>
+  <Target Name="UpdateGoogleTest" DependsOnTargets="FindGit" Condition="!Exists('$(GoogleTestSourceDir)\CMakeLists.txt')">
+    <Exec Command="&quot;$(GitCmd)&quot; submodule init" WorkingDirectory="$(GoogleTestSourceDir)" />
+    <Exec Command="&quot;$(GitCmd)&quot; submodule update" WorkingDirectory="$(GoogleTestSourceDir)" />
+  </Target>
+  <Target Name="MakeGoogleTestBuildDir" Condition="!Exists('$(GoogleTestBuildDir)')">
+    <MakeDir Directories="$(GoogleTestBuildDir)" />
+  </Target>
+  <Target Name="BuildGoogleTest" DependsOnTargets="UpdateGoogleTest;MakeGoogleTestBuildDir" BeforeTargets="ClCompile">
     <PropertyGroup>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'x86' And '$(PlatformTarget)' == 'x86'">x86</VcVarsArchitecture>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'x86' And '$(PlatformTarget)' == 'x64'">x86_amd64</VcVarsArchitecture>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x86'">amd64_x86</VcVarsArchitecture>
       <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x64'">amd64</VcVarsArchitecture>
       <NumVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioVersion)', '^(\d+).*', '$1'))</NumVersion>
-      <NextVersion>$([MSBuild]::Add($(NumVersion), 1))</NextVersion>
+      <ProductLineVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioEdition)', '^.* (\d+).*', '$1'))</ProductLineVersion>
       <GeneratorSuffix Condition="'$(PlatformTarget)' == 'x86'"></GeneratorSuffix>
       <GeneratorSuffix Condition="'$(PlatformTarget)' == 'x64'"> Win64</GeneratorSuffix>
+      <VsGeneratorName>Visual Studio $(NumVersion) $(ProductLineVersion)$(GeneratorSuffix)</VsGeneratorName>
     </PropertyGroup>
-    <MakeDir Condition="!Exists('$(GoogleTestBuildDir)')" Directories="$(GoogleTestBuildDir)" />
-    <Message Text="Cheking product line version of the Visual Studio." Importance="high" />
-    <Exec Command="&quot;$(VSInstallDir)..\..\Installer\vswhere.exe&quot; -version [$(NumVersion),$(NextVersion)] -property catalog_productLineVersion" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="ProductLineVersion" />
-    </Exec>
-    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;Visual Studio $(NumVersion) $(ProductLineVersion)$(GeneratorSuffix)&quot; $(Configuration) &quot;$(VSInstallRoot)/VC/Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
+    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;$(VsGeneratorName)&quot; $(Configuration) &quot;$(VSInstallRoot)/VC/Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
+  </Target>
+  <Target Name="CopyGoogleTestPdb" AfterTargets="BuildGoogleTest">
+    <ItemGroup>
+      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\gtest$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest$(NameSuffix).pdb')" />
+      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\gtest_main$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest_main$(NameSuffix).pdb')" />
+      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest$(NameSuffix).pdb')" />
+      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main$(NameSuffix).pdb')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(GoogleTestPdbFound)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" UseHardlinksIfPossible="true" />
   </Target>
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <!-- Add files to @Clean just before running CoreClean. -->
     <ItemGroup>
-      <Clean Include="$(OutDir)gtestd.pdb" />
-      <Clean Include="$(OutDir)gtest_maind.pdb" />
-      <Clean Include="$(OutDir)gtest.pdb" />
-      <Clean Include="$(OutDir)gtest_main.pdb" />
+      <Clean Include="$(OutDir)gtest$(NameSuffix).pdb" />
+      <Clean Include="$(OutDir)gtest_main$(NameSuffix).pdb" />
     </ItemGroup>
     <RemoveDir Directories="$(GoogleTestBuildDir)" />
   </Target>

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -23,6 +23,9 @@
     <Exec Command="where &quot;$(PATH);$(ProgramW6432)\Git\Cmd;$(ProgramFiles)\Git\Cmd:git&quot;" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitCmd" />
     </Exec>
+    <PropertyGroup>
+      <GitCmd>$([System.Text.RegularExpressions.Regex]::Replace('$(GitCmd)', '^([^;]+);.*', '$1'))</GitCmd>
+    </PropertyGroup>
   </Target>
   <Target Name="UpdateGoogleTest" DependsOnTargets="FindGit" Condition="!Exists('$(GoogleTestSourceDir)\CMakeLists.txt')">
     <Exec Command="&quot;$(GitCmd)&quot; submodule init" WorkingDirectory="$(GoogleTestSourceDir)" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -21,14 +21,15 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{701e3407-ec27-49f7-adc7-520cf2b4b438}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(ProjectDir)..\..\vcx-props\vcxcompat.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets">

--- a/vcx-props/vcxcompat.props
+++ b/vcx-props/vcxcompat.props
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals" Condition="'$(VisualStudioVersion)' == '15.0'">
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Label="Globals" Condition="'$(VisualStudioVersion)' == '16.0'">
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '15.0'">
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>


### PR DESCRIPTION
# PR の目的

プロジェクトのビルドにWindows SDKを使うようにして、
Windows SDKがC++規格に準拠してない旨のビルド時警告が出ないようにします。

## カテゴリ

- 仕様変更

## PR の背景

歴史的な理由で、昔のWindows SDKはC++規格に準拠していません。

ごく最近Microsoftが方針を変える前まで、
「Windows APIプログラムでは警告は無視してよいもの」でした。

MSVCのコンパイラに `/permissive` が追加されたことにより、状況が変わりました。
Windows SDK内の警告は、新しいWindows 10 SDK を使うことで解消できます。

[/permissive-](https://docs.microsoft.com/ja-jp/cpp/build/reference/permissive-standards-conformance)
> The /permissive- option is compatible with almost all of the header files from the latest Windows Kits, 
> such as the Software Development Kit (SDK) or Windows Driver Kit (WDK), starting in the Windows Fall Creators SDK (10.0.16299.0). 
> Older versions of the SDK may fail to compile under /permissive- for various source code conformance reasons. 

ビルド番号 | バージョン | 通称 | vs2017 | vs2019
-- | -- | -- | -- | --
10.0.16299 | 1709 | Fall Creators Update | ○ | ○
10.0.17134 | 1803 | April 2018 Update    | ○ | ○
10.0.17763 | 1809 | October 2018 Update  | ◎ | ○
10.0.18362 | 1903 | May 2019 Update  | × | ◎
凡例：◎標準、○インストールできる、×インストールできない

現状は、プログラムにビルドに使うWindows SDKのバージョンを指定していません。
指定しなかった場合に使われるWindows SDKのバージョンは8.1になります。

このPRでは、プロジェクトのビルドに使う Windows SDK のバージョンを、
現状の標準インストールバージョンに固定します。


## PR のメリット

- issue #1043 の問題を解決できます。
- conformance mode(/permissive) の導入準備ができます。


## PR のデメリット (トレードオフとかあれば)

- 対処方法が #1039 で tests1 の不具合が修正されることに依存します。
- vs2017でビルドするには Windows SDK 10.0.17763 のインストールが必須になります。
  - vs2017でインストールできるWindows SDKの最終バージョンなので問題ないと思います。
- vs2019でビルドするには Windows SDK 10.0.18362 のインストールが必須になります。
  - Windows 10 SDKは半期に1度出荷されるため、やや問題ありだと思います。
    - 2019年下期リリースが出荷されれば、直ちに問題がでるはずです。
    - 問題が出た時に対処すればよい話だと思います。
- Windows SDK 8.1 のインストールが不要になりますが、このPRではドキュメントを更新しません。


## PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
- 開発環境の使い勝手に影響します。
- ビルドに必要なSDKの選択に影響します。
- アプリ(=サクラエディタ)の機能に影響はありません。

## 関連チケット

close #1043 Windows SDKのヘッダで警告が出ている件に対応したい 
#1039 testsプロジェクトのビルドを速くする Take2
#1013 tests1 プロジェクトをリビルドしたりクリーンすると異なる構成のビルドに影響してしまう
#872 開発環境(Visual Studio)の機能をもっと活用するためにコード改善を行いたい


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
[あなたが使っているWindows 10のバージョン、本当にご存じですか？](https://www.sbbit.jp/article/cont1/35790)
[Microsoft公式のバージョン情報](https://docs.microsoft.com/ja-jp/windows/release-information/)
https://en.wikipedia.org/wiki/Windows_10_version_history

