### PR TITLE
zip版でもgithash.hが作られるようにする

### DIFF
--- a/sakura/githash.targets
+++ b/sakura/githash.targets
@@ -12,4 +12,9 @@
       Outputs="$(GitHash)">
     <Exec Command="..\sakura\githash.bat ..\sakura_core $(GitHash)" />
   </Target>
+  <Target Name="GitHashForZip" BeforeTargets="ClCompile" AfterTargets="GitHash"
+      Condition="!Exists('$(GitHash)')"
+      Outputs="$(GitHash)">
+    <Exec Command="..\sakura\githash.bat ..\sakura_core $(GitHash)" />
+  </Target>
 </Project>


### PR DESCRIPTION
# PR の目的

githash.batを実行するタスクを追加して、zip版でもgithash.hが作られるようにします。


## カテゴリ

- 不具合修正


## PR の背景

#1041 「githash.h が無いためにローカルビルドが失敗します。」の対策PRです。

問題の原因は #1029 で githash.bat の呼出条件を変えたことです。

githash.h は git のリポジトリ情報を見て作られるファイルなので、
ブランチを変更したりコミットをした場合には再生成が必要です。
適切に再生成が行えるように呼出し条件を組み込んだのですが、
.gitフォルダがない場合の考慮が漏れていました。

zip版ソースには .git フォルダが含まれないので
「処理対象のInputファイルがない」と判断されてgithash.hが作られない結果となっていました。

対策として、新たに githash.bat の呼出タスクを作り、
「通常のビルドタスクの処理後にgithash.hが存在していなかったら」を実行契機とするように設定します。


結果、
zip版ではgithash.hが作られなくなっていたのを修正する。
通常のgithash呼出タスクの後にgithash.hが作られていなければgithash.batを呼び出すように変更。

## PR のメリット

- zip版のビルド時にもgithash.hが作られるようになります。


## PR のデメリット (トレードオフとかあれば)

とくにありません。


## PR の影響範囲

- zip版ソース(=.gitフォルダがない)のビルドに影響します。
- アプリ(=サクラエディタ)の機能に影響はありません。

## 関連チケット

#1041 githash.h が無いためにローカルビルドが失敗します。
#1029 自動生成ファイルの生成タスクを整理する


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
