### PR TITLE
wcscat 関数の第2引数が文字列リテラルの場合に wcscat_literal 関数を呼び出すように変更

### DIFF
--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -363,22 +363,22 @@ bool CBackupAgent::FormatBackUpPath(
 
 			szForm[0] = L'\0';
 			if( bup_setting.GetBackupOpt(BKUP_YEAR) ){	/* バックアップファイル名：日付の年 */
-				wcscat( szForm, L"%Y" );
+				wcsncat_s( szForm, _countof(szForm), L"%Y", 2 );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_MONTH) ){	/* バックアップファイル名：日付の月 */
-				wcscat( szForm, L"%m" );
+				wcsncat_s( szForm, _countof(szForm), L"%m", 2 );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_DAY) ){	/* バックアップファイル名：日付の日 */
-				wcscat( szForm, L"%d" );
+				wcsncat_s( szForm, _countof(szForm), L"%d", 2 );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_HOUR) ){	/* バックアップファイル名：日付の時 */
-				wcscat( szForm, L"%H" );
+				wcsncat_s( szForm, _countof(szForm), L"%H", 2 );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_MIN) ){	/* バックアップファイル名：日付の分 */
-				wcscat( szForm, L"%M" );
+				wcsncat_s( szForm, _countof(szForm), L"%M", 2 );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_SEC) ){	/* バックアップファイル名：日付の秒 */
-				wcscat( szForm, L"%S" );
+				wcsncat_s( szForm, _countof(szForm), L"%S", 2 );
 			}
 			/* YYYYMMDD時分秒 形式に変換 */
 			wcsftime( szTime, _countof( szTime ) - 1, szForm, &result );

--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -363,22 +363,22 @@ bool CBackupAgent::FormatBackUpPath(
 
 			szForm[0] = L'\0';
 			if( bup_setting.GetBackupOpt(BKUP_YEAR) ){	/* バックアップファイル名：日付の年 */
-				wcscat( szForm, L"%Y" );
+				wcscat_literal( szForm, L"%Y" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_MONTH) ){	/* バックアップファイル名：日付の月 */
-				wcscat( szForm, L"%m" );
+				wcscat_literal( szForm, L"%m" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_DAY) ){	/* バックアップファイル名：日付の日 */
-				wcscat( szForm, L"%d" );
+				wcscat_literal( szForm, L"%d" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_HOUR) ){	/* バックアップファイル名：日付の時 */
-				wcscat( szForm, L"%H" );
+				wcscat_literal( szForm, L"%H" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_MIN) ){	/* バックアップファイル名：日付の分 */
-				wcscat( szForm, L"%M" );
+				wcscat_literal( szForm, L"%M" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_SEC) ){	/* バックアップファイル名：日付の秒 */
-				wcscat( szForm, L"%S" );
+				wcscat_literal( szForm, L"%S" );
 			}
 			/* YYYYMMDD時分秒 形式に変換 */
 			wcsftime( szTime, _countof( szTime ) - 1, szForm, &result );

--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -363,22 +363,22 @@ bool CBackupAgent::FormatBackUpPath(
 
 			szForm[0] = L'\0';
 			if( bup_setting.GetBackupOpt(BKUP_YEAR) ){	/* バックアップファイル名：日付の年 */
-				wcscat_literal( szForm, L"%Y" );
+				wcscat( szForm, L"%Y" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_MONTH) ){	/* バックアップファイル名：日付の月 */
-				wcscat_literal( szForm, L"%m" );
+				wcscat( szForm, L"%m" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_DAY) ){	/* バックアップファイル名：日付の日 */
-				wcscat_literal( szForm, L"%d" );
+				wcscat( szForm, L"%d" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_HOUR) ){	/* バックアップファイル名：日付の時 */
-				wcscat_literal( szForm, L"%H" );
+				wcscat( szForm, L"%H" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_MIN) ){	/* バックアップファイル名：日付の分 */
-				wcscat_literal( szForm, L"%M" );
+				wcscat( szForm, L"%M" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_SEC) ){	/* バックアップファイル名：日付の秒 */
-				wcscat_literal( szForm, L"%S" );
+				wcscat( szForm, L"%S" );
 			}
 			/* YYYYMMDD時分秒 形式に変換 */
 			wcsftime( szTime, _countof( szTime ) - 1, szForm, &result );

--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -363,22 +363,22 @@ bool CBackupAgent::FormatBackUpPath(
 
 			szForm[0] = L'\0';
 			if( bup_setting.GetBackupOpt(BKUP_YEAR) ){	/* バックアップファイル名：日付の年 */
-				wcsncat_s( szForm, _countof(szForm), L"%Y", 2 );
+				wcscat_literal( szForm, L"%Y" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_MONTH) ){	/* バックアップファイル名：日付の月 */
-				wcsncat_s( szForm, _countof(szForm), L"%m", 2 );
+				wcscat_literal( szForm, L"%m" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_DAY) ){	/* バックアップファイル名：日付の日 */
-				wcsncat_s( szForm, _countof(szForm), L"%d", 2 );
+				wcscat_literal( szForm, L"%d" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_HOUR) ){	/* バックアップファイル名：日付の時 */
-				wcsncat_s( szForm, _countof(szForm), L"%H", 2 );
+				wcscat_literal( szForm, L"%H" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_MIN) ){	/* バックアップファイル名：日付の分 */
-				wcsncat_s( szForm, _countof(szForm), L"%M", 2 );
+				wcscat_literal( szForm, L"%M" );
 			}
 			if( bup_setting.GetBackupOpt(BKUP_SEC) ){	/* バックアップファイル名：日付の秒 */
-				wcsncat_s( szForm, _countof(szForm), L"%S", 2 );
+				wcscat_literal( szForm, L"%S" );
 			}
 			/* YYYYMMDD時分秒 形式に変換 */
 			wcsftime( szTime, _countof( szTime ) - 1, szForm, &result );

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -203,18 +203,18 @@ void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep&
 
 	//GOPTオプション
 	WCHAR pOpt[64] = L"";
-	if( cDlgGrep.m_bSubFolder					)wcscat( pOpt, L"S" );	// サブフォルダからも検索する
-	if( cDlgGrep.m_sSearchOption.bLoHiCase		)wcscat( pOpt, L"L" );	// 英大文字と英小文字を区別する
-	if( cDlgGrep.m_sSearchOption.bRegularExp	)wcscat( pOpt, L"R" );	// 正規表現
-	if( cDlgGrep.m_nGrepOutputLineType == 1     )wcscat( pOpt, L"P" );	// 行を出力する
-	if( cDlgGrep.m_nGrepOutputLineType == 2     )wcscat( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
-	if( cDlgGrep.m_sSearchOption.bWordOnly		)wcscat( pOpt, L"W" );	// 単語単位で探す
-	if( 1 == cDlgGrep.m_nGrepOutputStyle		)wcscat( pOpt, L"1" );	// Grep: 出力形式
-	if( 2 == cDlgGrep.m_nGrepOutputStyle		)wcscat( pOpt, L"2" );	// Grep: 出力形式
-	if( 3 == cDlgGrep.m_nGrepOutputStyle		)wcscat( pOpt, L"3" );
-	if( cDlgGrep.m_bGrepOutputFileOnly		)wcscat( pOpt, L"F" );
-	if( cDlgGrep.m_bGrepOutputBaseFolder		)wcscat( pOpt, L"B" );
-	if( cDlgGrep.m_bGrepSeparateFolder		)wcscat( pOpt, L"D" );
+	if( cDlgGrep.m_bSubFolder					)wcscat_literal( pOpt, L"S" );	// サブフォルダからも検索する
+	if( cDlgGrep.m_sSearchOption.bLoHiCase		)wcscat_literal( pOpt, L"L" );	// 英大文字と英小文字を区別する
+	if( cDlgGrep.m_sSearchOption.bRegularExp	)wcscat_literal( pOpt, L"R" );	// 正規表現
+	if( cDlgGrep.m_nGrepOutputLineType == 1     )wcscat_literal( pOpt, L"P" );	// 行を出力する
+	if( cDlgGrep.m_nGrepOutputLineType == 2     )wcscat_literal( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
+	if( cDlgGrep.m_sSearchOption.bWordOnly		)wcscat_literal( pOpt, L"W" );	// 単語単位で探す
+	if( 1 == cDlgGrep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"1" );	// Grep: 出力形式
+	if( 2 == cDlgGrep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"2" );	// Grep: 出力形式
+	if( 3 == cDlgGrep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"3" );
+	if( cDlgGrep.m_bGrepOutputFileOnly			)wcscat_literal( pOpt, L"F" );
+	if( cDlgGrep.m_bGrepOutputBaseFolder		)wcscat_literal( pOpt, L"B" );
+	if( cDlgGrep.m_bGrepSeparateFolder			)wcscat_literal( pOpt, L"D" );
 	if( pOpt[0] != L'\0' ){
 		cCmdLine.AppendString( L" -GOPT=" );
 		cCmdLine.AppendString( pOpt );

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -203,18 +203,18 @@ void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep&
 
 	//GOPTオプション
 	WCHAR pOpt[64] = L"";
-	if( cDlgGrep.m_bSubFolder					)wcsncat_s( pOpt, _countof(pOpt), L"S", 1 );	// サブフォルダからも検索する
-	if( cDlgGrep.m_sSearchOption.bLoHiCase		)wcsncat_s( pOpt, _countof(pOpt), L"L", 1 );	// 英大文字と英小文字を区別する
-	if( cDlgGrep.m_sSearchOption.bRegularExp	)wcsncat_s( pOpt, _countof(pOpt), L"R", 1 );	// 正規表現
-	if( cDlgGrep.m_nGrepOutputLineType == 1     )wcsncat_s( pOpt, _countof(pOpt), L"P", 1 );	// 行を出力する
-	if( cDlgGrep.m_nGrepOutputLineType == 2     )wcsncat_s( pOpt, _countof(pOpt), L"N", 1 );	// 否ヒット行を出力する 2014.09.23
-	if( cDlgGrep.m_sSearchOption.bWordOnly		)wcsncat_s( pOpt, _countof(pOpt), L"W", 1 );	// 単語単位で探す
-	if( 1 == cDlgGrep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"1", 1 );	// Grep: 出力形式
-	if( 2 == cDlgGrep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"2", 1 );	// Grep: 出力形式
-	if( 3 == cDlgGrep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"3", 1 );
-	if( cDlgGrep.m_bGrepOutputFileOnly			)wcsncat_s( pOpt, _countof(pOpt), L"F", 1 );
-	if( cDlgGrep.m_bGrepOutputBaseFolder		)wcsncat_s( pOpt, _countof(pOpt), L"B", 1 );
-	if( cDlgGrep.m_bGrepSeparateFolder			)wcsncat_s( pOpt, _countof(pOpt), L"D", 1 );
+	if( cDlgGrep.m_bSubFolder					)wcscat_literal( pOpt, L"S" );	// サブフォルダからも検索する
+	if( cDlgGrep.m_sSearchOption.bLoHiCase		)wcscat_literal( pOpt, L"L" );	// 英大文字と英小文字を区別する
+	if( cDlgGrep.m_sSearchOption.bRegularExp	)wcscat_literal( pOpt, L"R" );	// 正規表現
+	if( cDlgGrep.m_nGrepOutputLineType == 1     )wcscat_literal( pOpt, L"P" );	// 行を出力する
+	if( cDlgGrep.m_nGrepOutputLineType == 2     )wcscat_literal( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
+	if( cDlgGrep.m_sSearchOption.bWordOnly		)wcscat_literal( pOpt, L"W" );	// 単語単位で探す
+	if( 1 == cDlgGrep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"1" );	// Grep: 出力形式
+	if( 2 == cDlgGrep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"2" );	// Grep: 出力形式
+	if( 3 == cDlgGrep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"3" );
+	if( cDlgGrep.m_bGrepOutputFileOnly			)wcscat_literal( pOpt, L"F" );
+	if( cDlgGrep.m_bGrepOutputBaseFolder		)wcscat_literal( pOpt, L"B" );
+	if( cDlgGrep.m_bGrepSeparateFolder			)wcscat_literal( pOpt, L"D" );
 	if( pOpt[0] != L'\0' ){
 		cCmdLine.AppendString( L" -GOPT=" );
 		cCmdLine.AppendString( pOpt );

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -203,18 +203,18 @@ void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep&
 
 	//GOPTオプション
 	WCHAR pOpt[64] = L"";
-	if( cDlgGrep.m_bSubFolder					)wcscat_literal( pOpt, L"S" );	// サブフォルダからも検索する
-	if( cDlgGrep.m_sSearchOption.bLoHiCase		)wcscat_literal( pOpt, L"L" );	// 英大文字と英小文字を区別する
-	if( cDlgGrep.m_sSearchOption.bRegularExp	)wcscat_literal( pOpt, L"R" );	// 正規表現
-	if( cDlgGrep.m_nGrepOutputLineType == 1     )wcscat_literal( pOpt, L"P" );	// 行を出力する
-	if( cDlgGrep.m_nGrepOutputLineType == 2     )wcscat_literal( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
-	if( cDlgGrep.m_sSearchOption.bWordOnly		)wcscat_literal( pOpt, L"W" );	// 単語単位で探す
-	if( 1 == cDlgGrep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"1" );	// Grep: 出力形式
-	if( 2 == cDlgGrep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"2" );	// Grep: 出力形式
-	if( 3 == cDlgGrep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"3" );
-	if( cDlgGrep.m_bGrepOutputFileOnly			)wcscat_literal( pOpt, L"F" );
-	if( cDlgGrep.m_bGrepOutputBaseFolder		)wcscat_literal( pOpt, L"B" );
-	if( cDlgGrep.m_bGrepSeparateFolder			)wcscat_literal( pOpt, L"D" );
+	if( cDlgGrep.m_bSubFolder					)wcscat( pOpt, L"S" );	// サブフォルダからも検索する
+	if( cDlgGrep.m_sSearchOption.bLoHiCase		)wcscat( pOpt, L"L" );	// 英大文字と英小文字を区別する
+	if( cDlgGrep.m_sSearchOption.bRegularExp	)wcscat( pOpt, L"R" );	// 正規表現
+	if( cDlgGrep.m_nGrepOutputLineType == 1     )wcscat( pOpt, L"P" );	// 行を出力する
+	if( cDlgGrep.m_nGrepOutputLineType == 2     )wcscat( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
+	if( cDlgGrep.m_sSearchOption.bWordOnly		)wcscat( pOpt, L"W" );	// 単語単位で探す
+	if( 1 == cDlgGrep.m_nGrepOutputStyle		)wcscat( pOpt, L"1" );	// Grep: 出力形式
+	if( 2 == cDlgGrep.m_nGrepOutputStyle		)wcscat( pOpt, L"2" );	// Grep: 出力形式
+	if( 3 == cDlgGrep.m_nGrepOutputStyle		)wcscat( pOpt, L"3" );
+	if( cDlgGrep.m_bGrepOutputFileOnly		)wcscat( pOpt, L"F" );
+	if( cDlgGrep.m_bGrepOutputBaseFolder		)wcscat( pOpt, L"B" );
+	if( cDlgGrep.m_bGrepSeparateFolder		)wcscat( pOpt, L"D" );
 	if( pOpt[0] != L'\0' ){
 		cCmdLine.AppendString( L" -GOPT=" );
 		cCmdLine.AppendString( pOpt );

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -203,18 +203,18 @@ void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep&
 
 	//GOPTオプション
 	WCHAR pOpt[64] = L"";
-	if( cDlgGrep.m_bSubFolder					)wcscat( pOpt, L"S" );	// サブフォルダからも検索する
-	if( cDlgGrep.m_sSearchOption.bLoHiCase		)wcscat( pOpt, L"L" );	// 英大文字と英小文字を区別する
-	if( cDlgGrep.m_sSearchOption.bRegularExp	)wcscat( pOpt, L"R" );	// 正規表現
-	if( cDlgGrep.m_nGrepOutputLineType == 1     )wcscat( pOpt, L"P" );	// 行を出力する
-	if( cDlgGrep.m_nGrepOutputLineType == 2     )wcscat( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
-	if( cDlgGrep.m_sSearchOption.bWordOnly		)wcscat( pOpt, L"W" );	// 単語単位で探す
-	if( 1 == cDlgGrep.m_nGrepOutputStyle		)wcscat( pOpt, L"1" );	// Grep: 出力形式
-	if( 2 == cDlgGrep.m_nGrepOutputStyle		)wcscat( pOpt, L"2" );	// Grep: 出力形式
-	if( 3 == cDlgGrep.m_nGrepOutputStyle		)wcscat( pOpt, L"3" );
-	if( cDlgGrep.m_bGrepOutputFileOnly		)wcscat( pOpt, L"F" );
-	if( cDlgGrep.m_bGrepOutputBaseFolder		)wcscat( pOpt, L"B" );
-	if( cDlgGrep.m_bGrepSeparateFolder		)wcscat( pOpt, L"D" );
+	if( cDlgGrep.m_bSubFolder					)wcsncat_s( pOpt, _countof(pOpt), L"S", 1 );	// サブフォルダからも検索する
+	if( cDlgGrep.m_sSearchOption.bLoHiCase		)wcsncat_s( pOpt, _countof(pOpt), L"L", 1 );	// 英大文字と英小文字を区別する
+	if( cDlgGrep.m_sSearchOption.bRegularExp	)wcsncat_s( pOpt, _countof(pOpt), L"R", 1 );	// 正規表現
+	if( cDlgGrep.m_nGrepOutputLineType == 1     )wcsncat_s( pOpt, _countof(pOpt), L"P", 1 );	// 行を出力する
+	if( cDlgGrep.m_nGrepOutputLineType == 2     )wcsncat_s( pOpt, _countof(pOpt), L"N", 1 );	// 否ヒット行を出力する 2014.09.23
+	if( cDlgGrep.m_sSearchOption.bWordOnly		)wcsncat_s( pOpt, _countof(pOpt), L"W", 1 );	// 単語単位で探す
+	if( 1 == cDlgGrep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"1", 1 );	// Grep: 出力形式
+	if( 2 == cDlgGrep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"2", 1 );	// Grep: 出力形式
+	if( 3 == cDlgGrep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"3", 1 );
+	if( cDlgGrep.m_bGrepOutputFileOnly			)wcsncat_s( pOpt, _countof(pOpt), L"F", 1 );
+	if( cDlgGrep.m_bGrepOutputBaseFolder		)wcsncat_s( pOpt, _countof(pOpt), L"B", 1 );
+	if( cDlgGrep.m_bGrepSeparateFolder			)wcsncat_s( pOpt, _countof(pOpt), L"D", 1 );
 	if( pOpt[0] != L'\0' ){
 		cCmdLine.AppendString( L" -GOPT=" );
 		cCmdLine.AppendString( pOpt );

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -243,20 +243,20 @@ void CViewCommander::Command_GREP_REPLACE( void )
 		//GOPTオプション
 		WCHAR	pOpt[64];
 		pOpt[0] = L'\0';
-		if( cDlgGrepRep.m_bSubFolder				)wcsncat_s( pOpt, _countof(pOpt), L"S", 1 );	// サブフォルダからも検索する
-		if( cDlgGrepRep.m_sSearchOption.bWordOnly	)wcsncat_s( pOpt, _countof(pOpt), L"W", 1 );	// 単語単位で探す
-		if( cDlgGrepRep.m_sSearchOption.bLoHiCase	)wcsncat_s( pOpt, _countof(pOpt), L"L", 1 );	// 英大文字と英小文字を区別する
-		if( cDlgGrepRep.m_sSearchOption.bRegularExp	)wcsncat_s( pOpt, _countof(pOpt), L"R", 1 );	// 正規表現
-		if( cDlgGrepRep.m_nGrepOutputLineType == 1  )wcsncat_s( pOpt, _countof(pOpt), L"P", 1 );	// 行を出力する
-		// if( cDlgGrepRep.m_nGrepOutputLineType == 2     )wcsncat_s( pOpt, _countof(pOpt), L"N", 1 );	// 否ヒット行を出力する 2014.09.23
-		if( 1 == cDlgGrepRep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"1", 1 );	// Grep: 出力形式
-		if( 2 == cDlgGrepRep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"2", 1 );	// Grep: 出力形式
-		if( 3 == cDlgGrepRep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"3", 1 );
-		if( cDlgGrepRep.m_bGrepOutputFileOnly		)wcsncat_s( pOpt, _countof(pOpt), L"F", 1 );
-		if( cDlgGrepRep.m_bGrepOutputBaseFolder		)wcsncat_s( pOpt, _countof(pOpt), L"B", 1 );
-		if( cDlgGrepRep.m_bGrepSeparateFolder		)wcsncat_s( pOpt, _countof(pOpt), L"D", 1 );
-		if( cDlgGrepRep.m_bPaste					)wcsncat_s( pOpt, _countof(pOpt), L"C", 1 );	// クリップボードから貼り付け
-		if( cDlgGrepRep.m_bBackup					)wcsncat_s( pOpt, _countof(pOpt), L"O", 1 );	// バックアップ作成
+		if( cDlgGrepRep.m_bSubFolder				)wcscat_literal( pOpt, L"S" );	// サブフォルダからも検索する
+		if( cDlgGrepRep.m_sSearchOption.bWordOnly	)wcscat_literal( pOpt, L"W" );	// 単語単位で探す
+		if( cDlgGrepRep.m_sSearchOption.bLoHiCase	)wcscat_literal( pOpt, L"L" );	// 英大文字と英小文字を区別する
+		if( cDlgGrepRep.m_sSearchOption.bRegularExp	)wcscat_literal( pOpt, L"R" );	// 正規表現
+		if( cDlgGrepRep.m_nGrepOutputLineType == 1	)wcscat_literal( pOpt, L"P" );	// 行を出力する
+		// if( cDlgGrepRep.m_nGrepOutputLineType == 2     )wcscat_literal( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
+		if( 1 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"1" );	// Grep: 出力形式
+		if( 2 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"2" );	// Grep: 出力形式
+		if( 3 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"3" );
+		if( cDlgGrepRep.m_bGrepOutputFileOnly		)wcscat_literal( pOpt, L"F" );
+		if( cDlgGrepRep.m_bGrepOutputBaseFolder		)wcscat_literal( pOpt, L"B" );
+		if( cDlgGrepRep.m_bGrepSeparateFolder		)wcscat_literal( pOpt, L"D" );
+		if( cDlgGrepRep.m_bPaste					)wcscat_literal( pOpt, L"C" );	// クリップボードから貼り付け
+		if( cDlgGrepRep.m_bBackup					)wcscat_literal( pOpt, L"O" );	// バックアップ作成
 		if( 0 < wcslen( pOpt ) ){
 			cCmdLine.AppendString( L" -GOPT=" );
 			cCmdLine.AppendString( pOpt );

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -243,20 +243,20 @@ void CViewCommander::Command_GREP_REPLACE( void )
 		//GOPTオプション
 		WCHAR	pOpt[64];
 		pOpt[0] = L'\0';
-		if( cDlgGrepRep.m_bSubFolder				)wcscat( pOpt, L"S" );	// サブフォルダからも検索する
-		if( cDlgGrepRep.m_sSearchOption.bWordOnly	)wcscat( pOpt, L"W" );	// 単語単位で探す
-		if( cDlgGrepRep.m_sSearchOption.bLoHiCase	)wcscat( pOpt, L"L" );	// 英大文字と英小文字を区別する
-		if( cDlgGrepRep.m_sSearchOption.bRegularExp	)wcscat( pOpt, L"R" );	// 正規表現
-		if( cDlgGrepRep.m_nGrepOutputLineType == 1     )wcscat( pOpt, L"P" );	// 行を出力する
-		// if( cDlgGrepRep.m_nGrepOutputLineType == 2     )wcscat( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
-		if( 1 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat( pOpt, L"1" );	// Grep: 出力形式
-		if( 2 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat( pOpt, L"2" );	// Grep: 出力形式
-		if( 3 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat( pOpt, L"3" );
-		if( cDlgGrepRep.m_bGrepOutputFileOnly		)wcscat( pOpt, L"F" );
-		if( cDlgGrepRep.m_bGrepOutputBaseFolder		)wcscat( pOpt, L"B" );
-		if( cDlgGrepRep.m_bGrepSeparateFolder		)wcscat( pOpt, L"D" );
-		if( cDlgGrepRep.m_bPaste					)wcscat( pOpt, L"C" );	// クリップボードから貼り付け
-		if( cDlgGrepRep.m_bBackup					)wcscat( pOpt, L"O" );	// バックアップ作成
+		if( cDlgGrepRep.m_bSubFolder				)wcscat_literal( pOpt, L"S" );	// サブフォルダからも検索する
+		if( cDlgGrepRep.m_sSearchOption.bWordOnly	)wcscat_literal( pOpt, L"W" );	// 単語単位で探す
+		if( cDlgGrepRep.m_sSearchOption.bLoHiCase	)wcscat_literal( pOpt, L"L" );	// 英大文字と英小文字を区別する
+		if( cDlgGrepRep.m_sSearchOption.bRegularExp	)wcscat_literal( pOpt, L"R" );	// 正規表現
+		if( cDlgGrepRep.m_nGrepOutputLineType == 1	)wcscat_literal( pOpt, L"P" );	// 行を出力する
+		// if( cDlgGrepRep.m_nGrepOutputLineType == 2     )wcscat_literal( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
+		if( 1 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"1" );	// Grep: 出力形式
+		if( 2 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"2" );	// Grep: 出力形式
+		if( 3 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"3" );
+		if( cDlgGrepRep.m_bGrepOutputFileOnly		)wcscat_literal( pOpt, L"F" );
+		if( cDlgGrepRep.m_bGrepOutputBaseFolder		)wcscat_literal( pOpt, L"B" );
+		if( cDlgGrepRep.m_bGrepSeparateFolder		)wcscat_literal( pOpt, L"D" );
+		if( cDlgGrepRep.m_bPaste					)wcscat_literal( pOpt, L"C" );	// クリップボードから貼り付け
+		if( cDlgGrepRep.m_bBackup					)wcscat_literal( pOpt, L"O" );	// バックアップ作成
 		if( 0 < wcslen( pOpt ) ){
 			cCmdLine.AppendString( L" -GOPT=" );
 			cCmdLine.AppendString( pOpt );

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -243,20 +243,20 @@ void CViewCommander::Command_GREP_REPLACE( void )
 		//GOPTオプション
 		WCHAR	pOpt[64];
 		pOpt[0] = L'\0';
-		if( cDlgGrepRep.m_bSubFolder				)wcscat( pOpt, L"S" );	// サブフォルダからも検索する
-		if( cDlgGrepRep.m_sSearchOption.bWordOnly	)wcscat( pOpt, L"W" );	// 単語単位で探す
-		if( cDlgGrepRep.m_sSearchOption.bLoHiCase	)wcscat( pOpt, L"L" );	// 英大文字と英小文字を区別する
-		if( cDlgGrepRep.m_sSearchOption.bRegularExp	)wcscat( pOpt, L"R" );	// 正規表現
-		if( cDlgGrepRep.m_nGrepOutputLineType == 1     )wcscat( pOpt, L"P" );	// 行を出力する
-		// if( cDlgGrepRep.m_nGrepOutputLineType == 2     )wcscat( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
-		if( 1 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat( pOpt, L"1" );	// Grep: 出力形式
-		if( 2 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat( pOpt, L"2" );	// Grep: 出力形式
-		if( 3 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat( pOpt, L"3" );
-		if( cDlgGrepRep.m_bGrepOutputFileOnly		)wcscat( pOpt, L"F" );
-		if( cDlgGrepRep.m_bGrepOutputBaseFolder		)wcscat( pOpt, L"B" );
-		if( cDlgGrepRep.m_bGrepSeparateFolder		)wcscat( pOpt, L"D" );
-		if( cDlgGrepRep.m_bPaste					)wcscat( pOpt, L"C" );	// クリップボードから貼り付け
-		if( cDlgGrepRep.m_bBackup					)wcscat( pOpt, L"O" );	// バックアップ作成
+		if( cDlgGrepRep.m_bSubFolder				)wcsncat_s( pOpt, _countof(pOpt), L"S", 1 );	// サブフォルダからも検索する
+		if( cDlgGrepRep.m_sSearchOption.bWordOnly	)wcsncat_s( pOpt, _countof(pOpt), L"W", 1 );	// 単語単位で探す
+		if( cDlgGrepRep.m_sSearchOption.bLoHiCase	)wcsncat_s( pOpt, _countof(pOpt), L"L", 1 );	// 英大文字と英小文字を区別する
+		if( cDlgGrepRep.m_sSearchOption.bRegularExp	)wcsncat_s( pOpt, _countof(pOpt), L"R", 1 );	// 正規表現
+		if( cDlgGrepRep.m_nGrepOutputLineType == 1  )wcsncat_s( pOpt, _countof(pOpt), L"P", 1 );	// 行を出力する
+		// if( cDlgGrepRep.m_nGrepOutputLineType == 2     )wcsncat_s( pOpt, _countof(pOpt), L"N", 1 );	// 否ヒット行を出力する 2014.09.23
+		if( 1 == cDlgGrepRep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"1", 1 );	// Grep: 出力形式
+		if( 2 == cDlgGrepRep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"2", 1 );	// Grep: 出力形式
+		if( 3 == cDlgGrepRep.m_nGrepOutputStyle		)wcsncat_s( pOpt, _countof(pOpt), L"3", 1 );
+		if( cDlgGrepRep.m_bGrepOutputFileOnly		)wcsncat_s( pOpt, _countof(pOpt), L"F", 1 );
+		if( cDlgGrepRep.m_bGrepOutputBaseFolder		)wcsncat_s( pOpt, _countof(pOpt), L"B", 1 );
+		if( cDlgGrepRep.m_bGrepSeparateFolder		)wcsncat_s( pOpt, _countof(pOpt), L"D", 1 );
+		if( cDlgGrepRep.m_bPaste					)wcsncat_s( pOpt, _countof(pOpt), L"C", 1 );	// クリップボードから貼り付け
+		if( cDlgGrepRep.m_bBackup					)wcsncat_s( pOpt, _countof(pOpt), L"O", 1 );	// バックアップ作成
 		if( 0 < wcslen( pOpt ) ){
 			cCmdLine.AppendString( L" -GOPT=" );
 			cCmdLine.AppendString( pOpt );

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -243,20 +243,20 @@ void CViewCommander::Command_GREP_REPLACE( void )
 		//GOPTオプション
 		WCHAR	pOpt[64];
 		pOpt[0] = L'\0';
-		if( cDlgGrepRep.m_bSubFolder				)wcscat_literal( pOpt, L"S" );	// サブフォルダからも検索する
-		if( cDlgGrepRep.m_sSearchOption.bWordOnly	)wcscat_literal( pOpt, L"W" );	// 単語単位で探す
-		if( cDlgGrepRep.m_sSearchOption.bLoHiCase	)wcscat_literal( pOpt, L"L" );	// 英大文字と英小文字を区別する
-		if( cDlgGrepRep.m_sSearchOption.bRegularExp	)wcscat_literal( pOpt, L"R" );	// 正規表現
-		if( cDlgGrepRep.m_nGrepOutputLineType == 1	)wcscat_literal( pOpt, L"P" );	// 行を出力する
-		// if( cDlgGrepRep.m_nGrepOutputLineType == 2     )wcscat_literal( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
-		if( 1 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"1" );	// Grep: 出力形式
-		if( 2 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"2" );	// Grep: 出力形式
-		if( 3 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat_literal( pOpt, L"3" );
-		if( cDlgGrepRep.m_bGrepOutputFileOnly		)wcscat_literal( pOpt, L"F" );
-		if( cDlgGrepRep.m_bGrepOutputBaseFolder		)wcscat_literal( pOpt, L"B" );
-		if( cDlgGrepRep.m_bGrepSeparateFolder		)wcscat_literal( pOpt, L"D" );
-		if( cDlgGrepRep.m_bPaste					)wcscat_literal( pOpt, L"C" );	// クリップボードから貼り付け
-		if( cDlgGrepRep.m_bBackup					)wcscat_literal( pOpt, L"O" );	// バックアップ作成
+		if( cDlgGrepRep.m_bSubFolder				)wcscat( pOpt, L"S" );	// サブフォルダからも検索する
+		if( cDlgGrepRep.m_sSearchOption.bWordOnly	)wcscat( pOpt, L"W" );	// 単語単位で探す
+		if( cDlgGrepRep.m_sSearchOption.bLoHiCase	)wcscat( pOpt, L"L" );	// 英大文字と英小文字を区別する
+		if( cDlgGrepRep.m_sSearchOption.bRegularExp	)wcscat( pOpt, L"R" );	// 正規表現
+		if( cDlgGrepRep.m_nGrepOutputLineType == 1     )wcscat( pOpt, L"P" );	// 行を出力する
+		// if( cDlgGrepRep.m_nGrepOutputLineType == 2     )wcscat( pOpt, L"N" );	// 否ヒット行を出力する 2014.09.23
+		if( 1 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat( pOpt, L"1" );	// Grep: 出力形式
+		if( 2 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat( pOpt, L"2" );	// Grep: 出力形式
+		if( 3 == cDlgGrepRep.m_nGrepOutputStyle		)wcscat( pOpt, L"3" );
+		if( cDlgGrepRep.m_bGrepOutputFileOnly		)wcscat( pOpt, L"F" );
+		if( cDlgGrepRep.m_bGrepOutputBaseFolder		)wcscat( pOpt, L"B" );
+		if( cDlgGrepRep.m_bGrepSeparateFolder		)wcscat( pOpt, L"D" );
+		if( cDlgGrepRep.m_bPaste					)wcscat( pOpt, L"C" );	// クリップボードから貼り付け
+		if( cDlgGrepRep.m_bBackup					)wcscat( pOpt, L"O" );	// バックアップ作成
 		if( 0 < wcslen( pOpt ) ){
 			cCmdLine.AppendString( L" -GOPT=" );
 			cCmdLine.AppendString( pOpt );

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -111,7 +111,7 @@ void CViewCommander::Command_SAVEKEYMACRO( void )
 	/* ファイルのフルパスを、フォルダとファイル名に分割 */
 	/* [c:\work\test\aaa.txt] → [c:\work\test] + [aaa.txt] */
 //	::SplitPath_FolderAndFile( szPath, GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER, NULL );
-//	wcscat_literal( GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER, L"\\" );
+//	wcscat( GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER, L"\\" );
 
 	/* キーボードマクロの保存 */
 	//@@@ 2002.2.2 YAZAKI マクロをCSMacroMgrに統一

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -111,7 +111,7 @@ void CViewCommander::Command_SAVEKEYMACRO( void )
 	/* ファイルのフルパスを、フォルダとファイル名に分割 */
 	/* [c:\work\test\aaa.txt] → [c:\work\test] + [aaa.txt] */
 //	::SplitPath_FolderAndFile( szPath, GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER, NULL );
-//	wcscat( GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER, L"\\" );
+//	wcscat_literal( GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER, L"\\" );
 
 	/* キーボードマクロの保存 */
 	//@@@ 2002.2.2 YAZAKI マクロをCSMacroMgrに統一

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -456,13 +456,13 @@ bool CViewCommander::Command_TagsMake( void )
 
 	WCHAR	options[1024];
 	wcscpy( options, L"--excmd=n" );	//デフォルトのオプション
-	if( cDlgTagsMake.m_nTagsOpt & 0x0001 ) wcscat( options, L" -R" );	//サブフォルダも対象
+	if( cDlgTagsMake.m_nTagsOpt & 0x0001 ) wcscat_literal( options, L" -R" );	//サブフォルダも対象
 	if( cDlgTagsMake.m_szTagsCmdLine[0] != L'\0' )	//個別指定のコマンドライン
 	{
-		wcscat( options, L" " );
+		wcscat_literal( options, L" " );
 		wcscat( options, cDlgTagsMake.m_szTagsCmdLine );
 	}
-	wcscat( options, L" *" );	//配下のすべてのファイル
+	wcscat_literal( options, L" *" );	//配下のすべてのファイル
 
 	//コマンドライン文字列作成(MAX:1024)
 	{
@@ -711,9 +711,9 @@ bool CViewCommander::Sub_PreProcTagJumpByTagsFile( WCHAR* szCurrentPath, int cou
 		WCHAR szExts[MAX_TYPES_EXTS];
 		CDocTypeManager::GetFirstExt(m_pCommanderView->m_pTypeData->m_szTypeExts, szExts, _countof(szExts));
 		int nExtLen = wcslen( szExts );
-		wcscat( szCurrentPath, L"\\dmy" );
+		wcscat_literal( szCurrentPath, L"\\dmy" );
 		if( nExtLen ){
-			wcscat( szCurrentPath, L"." );
+			wcscat_literal( szCurrentPath, L"." );
 			wcscat( szCurrentPath, szExts );
 		}
 	}

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -456,13 +456,13 @@ bool CViewCommander::Command_TagsMake( void )
 
 	WCHAR	options[1024];
 	wcscpy( options, L"--excmd=n" );	//デフォルトのオプション
-	if( cDlgTagsMake.m_nTagsOpt & 0x0001 ) wcsncat_s( options, _countof(options), L" -R", 3 );	//サブフォルダも対象
+	if( cDlgTagsMake.m_nTagsOpt & 0x0001 ) wcscat_literal( options, L" -R" );	//サブフォルダも対象
 	if( cDlgTagsMake.m_szTagsCmdLine[0] != L'\0' )	//個別指定のコマンドライン
 	{
-		wcsncat_s( options, _countof(options), L" ", 1 );
-		wcsncat_s( options, _countof(options), cDlgTagsMake.m_szTagsCmdLine, _countof(cDlgTagsMake.m_szTagsCmdLine) - 1 );
+		wcscat_literal( options, L" " );
+		wcscat( options, cDlgTagsMake.m_szTagsCmdLine );
 	}
-	wcsncat_s( options, _countof(options), L" *", 2 );	//配下のすべてのファイル
+	wcscat_literal( options, L" *" );	//配下のすべてのファイル
 
 	//コマンドライン文字列作成(MAX:1024)
 	{
@@ -711,9 +711,9 @@ bool CViewCommander::Sub_PreProcTagJumpByTagsFile( WCHAR* szCurrentPath, int cou
 		WCHAR szExts[MAX_TYPES_EXTS];
 		CDocTypeManager::GetFirstExt(m_pCommanderView->m_pTypeData->m_szTypeExts, szExts, _countof(szExts));
 		int nExtLen = wcslen( szExts );
-		wcscat( szCurrentPath, L"\\dmy" );
+		wcscat_literal( szCurrentPath, L"\\dmy" );
 		if( nExtLen ){
-			wcscat( szCurrentPath, L"." );
+			wcscat_literal( szCurrentPath, L"." );
 			wcscat( szCurrentPath, szExts );
 		}
 	}

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -456,13 +456,13 @@ bool CViewCommander::Command_TagsMake( void )
 
 	WCHAR	options[1024];
 	wcscpy( options, L"--excmd=n" );	//デフォルトのオプション
-	if( cDlgTagsMake.m_nTagsOpt & 0x0001 ) wcscat_literal( options, L" -R" );	//サブフォルダも対象
+	if( cDlgTagsMake.m_nTagsOpt & 0x0001 ) wcscat( options, L" -R" );	//サブフォルダも対象
 	if( cDlgTagsMake.m_szTagsCmdLine[0] != L'\0' )	//個別指定のコマンドライン
 	{
-		wcscat_literal( options, L" " );
+		wcscat( options, L" " );
 		wcscat( options, cDlgTagsMake.m_szTagsCmdLine );
 	}
-	wcscat_literal( options, L" *" );	//配下のすべてのファイル
+	wcscat( options, L" *" );	//配下のすべてのファイル
 
 	//コマンドライン文字列作成(MAX:1024)
 	{
@@ -711,9 +711,9 @@ bool CViewCommander::Sub_PreProcTagJumpByTagsFile( WCHAR* szCurrentPath, int cou
 		WCHAR szExts[MAX_TYPES_EXTS];
 		CDocTypeManager::GetFirstExt(m_pCommanderView->m_pTypeData->m_szTypeExts, szExts, _countof(szExts));
 		int nExtLen = wcslen( szExts );
-		wcscat_literal( szCurrentPath, L"\\dmy" );
+		wcscat( szCurrentPath, L"\\dmy" );
 		if( nExtLen ){
-			wcscat_literal( szCurrentPath, L"." );
+			wcscat( szCurrentPath, L"." );
 			wcscat( szCurrentPath, szExts );
 		}
 	}

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -456,13 +456,13 @@ bool CViewCommander::Command_TagsMake( void )
 
 	WCHAR	options[1024];
 	wcscpy( options, L"--excmd=n" );	//デフォルトのオプション
-	if( cDlgTagsMake.m_nTagsOpt & 0x0001 ) wcscat( options, L" -R" );	//サブフォルダも対象
+	if( cDlgTagsMake.m_nTagsOpt & 0x0001 ) wcsncat_s( options, _countof(options), L" -R", 3 );	//サブフォルダも対象
 	if( cDlgTagsMake.m_szTagsCmdLine[0] != L'\0' )	//個別指定のコマンドライン
 	{
-		wcscat( options, L" " );
-		wcscat( options, cDlgTagsMake.m_szTagsCmdLine );
+		wcsncat_s( options, _countof(options), L" ", 1 );
+		wcsncat_s( options, _countof(options), cDlgTagsMake.m_szTagsCmdLine, _countof(cDlgTagsMake.m_szTagsCmdLine) - 1 );
 	}
-	wcscat( options, L" *" );	//配下のすべてのファイル
+	wcsncat_s( options, _countof(options), L" *", 2 );	//配下のすべてのファイル
 
 	//コマンドライン文字列作成(MAX:1024)
 	{

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -360,11 +360,11 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 							szFolderItem[0] = L'"';
 							wcsncpy( szFolderItem + 1, vPaths[i].c_str(), nMaxPath - 1 );
 							szFolderItem[nMaxPath-1] = L'\0';
-							wcscat( szFolderItem, L"\"" );
+							wcscat_literal( szFolderItem, L"\"" );
 							szFolderItem[nMaxPath-1] = L'\0';
 						}
 						if( i ){
-							wcscat( szFolder, L";" );
+							wcscat_literal( szFolder, L";" );
 							szFolder[nMaxPath-1] = L'\0';
 						}
 						wcscat_s( szFolder, nMaxPath, szFolderItem );
@@ -619,7 +619,7 @@ void CDlgGrep::SetDataFromThisText( bool bChecked )
 		// 2003.08.01 Moca ファイル名はスペースなどは区切り記号になるので、""で囲い、エスケープする
 		szWorkFile[0] = L'"';
 		SplitPath_FolderAndFile( m_szCurrentFilePath, szWorkFolder, szWorkFile + 1 );
-		wcscat( szWorkFile, L"\"" ); // 2003.08.01 Moca
+		wcscat_literal( szWorkFile, L"\"" ); // 2003.08.01 Moca
 		::DlgItem_SetText( GetHwnd(), IDC_COMBO_FILE, szWorkFile );
 		
 		SetGrepFolder( GetItemHwnd(IDC_COMBO_FOLDER), szWorkFolder );
@@ -759,7 +759,7 @@ int CDlgGrep::GetData( void )
 			if( wcschr( szFolderItem, L';' ) ){
 				szFolderItem[0] = L'"';
 				::GetCurrentDirectory( nMaxPath, szFolderItem + 1 );
-				wcscat(szFolderItem, L"\"");
+				wcscat_literal(szFolderItem, L"\"");
 			}
 			int nFolderItemLen = wcslen( szFolderItem );
 			if( nMaxPath < nFolderLen + nFolderItemLen + 1 ){
@@ -767,7 +767,7 @@ int CDlgGrep::GetData( void )
 				return FALSE;
 			}
 			if( i ){
-				wcscat( szFolder, L";" );
+				wcscat_literal( szFolder, L";" );
 			}
 			wcscat( szFolder, szFolderItem );
 			nFolderLen = wcslen( szFolder );
@@ -830,7 +830,7 @@ static void SetGrepFolder( HWND hwndCtrl, LPCWSTR folder )
 		WCHAR szQuoteFolder[MAX_PATH];
 		szQuoteFolder[0] = L'"';
 		wcscpy( szQuoteFolder + 1, folder );
-		wcscat( szQuoteFolder, L"\"" );
+		wcscat_literal( szQuoteFolder, L"\"" );
 		::SetWindowText( hwndCtrl, szQuoteFolder );
 	}else{
 		::SetWindowText( hwndCtrl, folder );

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -360,14 +360,14 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 							szFolderItem[0] = L'"';
 							wcsncpy( szFolderItem + 1, vPaths[i].c_str(), nMaxPath - 1 );
 							szFolderItem[nMaxPath-1] = L'\0';
-							wcscat( szFolderItem, L"\"" );
+							wcsncat_s( szFolderItem, _countof(szFolderItem), L"\"", 2 );
 							szFolderItem[nMaxPath-1] = L'\0';
 						}
 						if( i ){
-							wcscat( szFolder, L";" );
+							wcsncat_s( szFolder, _countof(szFolderItem), L";", 1 );
 							szFolder[nMaxPath-1] = L'\0';
 						}
-						wcscat_s( szFolder, nMaxPath, szFolderItem );
+						wcsncat_s( szFolder, _countof(szFolderItem), szFolderItem, _countof(szFolderItem) - 1 );
 					}
 					::SetWindowText( hwnd, szFolder );
 				}
@@ -619,7 +619,7 @@ void CDlgGrep::SetDataFromThisText( bool bChecked )
 		// 2003.08.01 Moca ファイル名はスペースなどは区切り記号になるので、""で囲い、エスケープする
 		szWorkFile[0] = L'"';
 		SplitPath_FolderAndFile( m_szCurrentFilePath, szWorkFolder, szWorkFile + 1 );
-		wcscat( szWorkFile, L"\"" ); // 2003.08.01 Moca
+		wcsncat_s( szWorkFile, _countof(szWorkFile), L"\"", 2 ); // 2003.08.01 Moca
 		::DlgItem_SetText( GetHwnd(), IDC_COMBO_FILE, szWorkFile );
 		
 		SetGrepFolder( GetItemHwnd(IDC_COMBO_FOLDER), szWorkFolder );
@@ -759,7 +759,7 @@ int CDlgGrep::GetData( void )
 			if( wcschr( szFolderItem, L';' ) ){
 				szFolderItem[0] = L'"';
 				::GetCurrentDirectory( nMaxPath, szFolderItem + 1 );
-				wcscat(szFolderItem, L"\"");
+				wcsncat_s(szFolderItem, _countof(szFolderItem), L"\"", 1);
 			}
 			int nFolderItemLen = wcslen( szFolderItem );
 			if( nMaxPath < nFolderLen + nFolderItemLen + 1 ){
@@ -767,9 +767,9 @@ int CDlgGrep::GetData( void )
 				return FALSE;
 			}
 			if( i ){
-				wcscat( szFolder, L";" );
+				wcsncat_s( szFolder, _countof(szFolder), L";", 1 );
 			}
-			wcscat( szFolder, szFolderItem );
+			wcsncat_s( szFolder, _countof(szFolder), szFolderItem, _countof(szFolderItem) - 1 );
 			nFolderLen = wcslen( szFolder );
 		}
 		wcscpy( m_szFolder, szFolder );
@@ -830,7 +830,7 @@ static void SetGrepFolder( HWND hwndCtrl, LPCWSTR folder )
 		WCHAR szQuoteFolder[MAX_PATH];
 		szQuoteFolder[0] = L'"';
 		wcscpy( szQuoteFolder + 1, folder );
-		wcscat( szQuoteFolder, L"\"" );
+		wcsncat_s( szQuoteFolder, _countof(szQuoteFolder), L"\"", 1 );
 		::SetWindowText( hwndCtrl, szQuoteFolder );
 	}else{
 		::SetWindowText( hwndCtrl, folder );

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -360,11 +360,11 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 							szFolderItem[0] = L'"';
 							wcsncpy( szFolderItem + 1, vPaths[i].c_str(), nMaxPath - 1 );
 							szFolderItem[nMaxPath-1] = L'\0';
-							wcscat_literal( szFolderItem, L"\"" );
+							wcscat( szFolderItem, L"\"" );
 							szFolderItem[nMaxPath-1] = L'\0';
 						}
 						if( i ){
-							wcscat_literal( szFolder, L";" );
+							wcscat( szFolder, L";" );
 							szFolder[nMaxPath-1] = L'\0';
 						}
 						wcscat_s( szFolder, nMaxPath, szFolderItem );
@@ -619,7 +619,7 @@ void CDlgGrep::SetDataFromThisText( bool bChecked )
 		// 2003.08.01 Moca ファイル名はスペースなどは区切り記号になるので、""で囲い、エスケープする
 		szWorkFile[0] = L'"';
 		SplitPath_FolderAndFile( m_szCurrentFilePath, szWorkFolder, szWorkFile + 1 );
-		wcscat_literal( szWorkFile, L"\"" ); // 2003.08.01 Moca
+		wcscat( szWorkFile, L"\"" ); // 2003.08.01 Moca
 		::DlgItem_SetText( GetHwnd(), IDC_COMBO_FILE, szWorkFile );
 		
 		SetGrepFolder( GetItemHwnd(IDC_COMBO_FOLDER), szWorkFolder );
@@ -759,7 +759,7 @@ int CDlgGrep::GetData( void )
 			if( wcschr( szFolderItem, L';' ) ){
 				szFolderItem[0] = L'"';
 				::GetCurrentDirectory( nMaxPath, szFolderItem + 1 );
-				wcscat_literal(szFolderItem, L"\"");
+				wcscat(szFolderItem, L"\"");
 			}
 			int nFolderItemLen = wcslen( szFolderItem );
 			if( nMaxPath < nFolderLen + nFolderItemLen + 1 ){
@@ -767,7 +767,7 @@ int CDlgGrep::GetData( void )
 				return FALSE;
 			}
 			if( i ){
-				wcscat_literal( szFolder, L";" );
+				wcscat( szFolder, L";" );
 			}
 			wcscat( szFolder, szFolderItem );
 			nFolderLen = wcslen( szFolder );
@@ -830,7 +830,7 @@ static void SetGrepFolder( HWND hwndCtrl, LPCWSTR folder )
 		WCHAR szQuoteFolder[MAX_PATH];
 		szQuoteFolder[0] = L'"';
 		wcscpy( szQuoteFolder + 1, folder );
-		wcscat_literal( szQuoteFolder, L"\"" );
+		wcscat( szQuoteFolder, L"\"" );
 		::SetWindowText( hwndCtrl, szQuoteFolder );
 	}else{
 		::SetWindowText( hwndCtrl, folder );

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -360,14 +360,14 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 							szFolderItem[0] = L'"';
 							wcsncpy( szFolderItem + 1, vPaths[i].c_str(), nMaxPath - 1 );
 							szFolderItem[nMaxPath-1] = L'\0';
-							wcsncat_s( szFolderItem, _countof(szFolderItem), L"\"", 2 );
+							wcscat_literal( szFolderItem, L"\"" );
 							szFolderItem[nMaxPath-1] = L'\0';
 						}
 						if( i ){
-							wcsncat_s( szFolder, _countof(szFolderItem), L";", 1 );
+							wcscat_literal( szFolder, L";" );
 							szFolder[nMaxPath-1] = L'\0';
 						}
-						wcsncat_s( szFolder, _countof(szFolderItem), szFolderItem, _countof(szFolderItem) - 1 );
+						wcscat_s( szFolder, nMaxPath, szFolderItem );
 					}
 					::SetWindowText( hwnd, szFolder );
 				}
@@ -619,7 +619,7 @@ void CDlgGrep::SetDataFromThisText( bool bChecked )
 		// 2003.08.01 Moca ファイル名はスペースなどは区切り記号になるので、""で囲い、エスケープする
 		szWorkFile[0] = L'"';
 		SplitPath_FolderAndFile( m_szCurrentFilePath, szWorkFolder, szWorkFile + 1 );
-		wcsncat_s( szWorkFile, _countof(szWorkFile), L"\"", 2 ); // 2003.08.01 Moca
+		wcscat_literal( szWorkFile, L"\"" ); // 2003.08.01 Moca
 		::DlgItem_SetText( GetHwnd(), IDC_COMBO_FILE, szWorkFile );
 		
 		SetGrepFolder( GetItemHwnd(IDC_COMBO_FOLDER), szWorkFolder );
@@ -759,7 +759,7 @@ int CDlgGrep::GetData( void )
 			if( wcschr( szFolderItem, L';' ) ){
 				szFolderItem[0] = L'"';
 				::GetCurrentDirectory( nMaxPath, szFolderItem + 1 );
-				wcsncat_s(szFolderItem, _countof(szFolderItem), L"\"", 1);
+				wcscat_literal(szFolderItem, L"\"");
 			}
 			int nFolderItemLen = wcslen( szFolderItem );
 			if( nMaxPath < nFolderLen + nFolderItemLen + 1 ){
@@ -767,9 +767,9 @@ int CDlgGrep::GetData( void )
 				return FALSE;
 			}
 			if( i ){
-				wcsncat_s( szFolder, _countof(szFolder), L";", 1 );
+				wcscat_literal( szFolder, L";" );
 			}
-			wcsncat_s( szFolder, _countof(szFolder), szFolderItem, _countof(szFolderItem) - 1 );
+			wcscat( szFolder, szFolderItem );
 			nFolderLen = wcslen( szFolder );
 		}
 		wcscpy( m_szFolder, szFolder );
@@ -830,7 +830,7 @@ static void SetGrepFolder( HWND hwndCtrl, LPCWSTR folder )
 		WCHAR szQuoteFolder[MAX_PATH];
 		szQuoteFolder[0] = L'"';
 		wcscpy( szQuoteFolder + 1, folder );
-		wcsncat_s( szQuoteFolder, _countof(szQuoteFolder), L"\"", 1 );
+		wcscat_literal( szQuoteFolder, L"\"" );
 		::SetWindowText( hwndCtrl, szQuoteFolder );
 	}else{
 		::SetWindowText( hwndCtrl, folder );

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -412,7 +412,7 @@ void CDlgProfileMgr::RenameProf()
 		}
 	}
 	if( bDefault ){
-		wcscat(szText, L"*");
+		wcsncat_s(szText, _countof(szText), L"*", 1);
 	}
 	List_DeleteString( hwndList, nCurIndex );
 	List_InsertString( hwndList, nCurIndex, szText );
@@ -427,7 +427,7 @@ void CDlgProfileMgr::SetDefaultProf(int index)
 	WCHAR szProfileName[_MAX_PATH];
 	MyList_GetText( hwndList, index, szProfileName );
 	List_DeleteString( hwndList, index );
-	wcscat( szProfileName, L"*" );
+	wcsncat_s( szProfileName, _countof(szProfileName), L"*", 1 );
 	List_InsertString( hwndList, index, szProfileName );
 }
 

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -412,7 +412,7 @@ void CDlgProfileMgr::RenameProf()
 		}
 	}
 	if( bDefault ){
-		wcscat_literal(szText, L"*");
+		wcscat(szText, L"*");
 	}
 	List_DeleteString( hwndList, nCurIndex );
 	List_InsertString( hwndList, nCurIndex, szText );
@@ -427,7 +427,7 @@ void CDlgProfileMgr::SetDefaultProf(int index)
 	WCHAR szProfileName[_MAX_PATH];
 	MyList_GetText( hwndList, index, szProfileName );
 	List_DeleteString( hwndList, index );
-	wcscat_literal( szProfileName, L"*" );
+	wcscat( szProfileName, L"*" );
 	List_InsertString( hwndList, index, szProfileName );
 }
 

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -412,7 +412,7 @@ void CDlgProfileMgr::RenameProf()
 		}
 	}
 	if( bDefault ){
-		wcsncat_s(szText, _countof(szText), L"*", 1);
+		wcscat_literal(szText, L"*");
 	}
 	List_DeleteString( hwndList, nCurIndex );
 	List_InsertString( hwndList, nCurIndex, szText );
@@ -427,7 +427,7 @@ void CDlgProfileMgr::SetDefaultProf(int index)
 	WCHAR szProfileName[_MAX_PATH];
 	MyList_GetText( hwndList, index, szProfileName );
 	List_DeleteString( hwndList, index );
-	wcsncat_s( szProfileName, _countof(szProfileName), L"*", 1 );
+	wcscat_literal( szProfileName, L"*" );
 	List_InsertString( hwndList, index, szProfileName );
 }
 

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -412,7 +412,7 @@ void CDlgProfileMgr::RenameProf()
 		}
 	}
 	if( bDefault ){
-		wcscat(szText, L"*");
+		wcscat_literal(szText, L"*");
 	}
 	List_DeleteString( hwndList, nCurIndex );
 	List_InsertString( hwndList, nCurIndex, szText );
@@ -427,7 +427,7 @@ void CDlgProfileMgr::SetDefaultProf(int index)
 	WCHAR szProfileName[_MAX_PATH];
 	MyList_GetText( hwndList, index, szProfileName );
 	List_DeleteString( hwndList, index );
-	wcscat( szProfileName, L"*" );
+	wcscat_literal( szProfileName, L"*" );
 	List_InsertString( hwndList, index, szProfileName );
 }
 

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -1209,7 +1209,7 @@ int CDlgTagJumpList::find_key_core(
 			state.m_nDepth = 0;
 			szNextPath[0] = 0;
 		}else{
-//			wcscat( state.m_szCurPath, L"..\\" );
+//			wcscat_literal( state.m_szCurPath, L"..\\" );
 			//カレントパスを1階層上へ。
 			DirUp( state.m_szCurPath );
 		}
@@ -1645,7 +1645,7 @@ WCHAR* CDlgTagJumpList::GetFullPathFromDepth( WCHAR* pszOutput, int count,
 		wcscpy( pszOutput, p );	//何も加工しない。
 	}else{
 		for( int i = 0; i < depth; i++ ){
-			//wcscat( basePath, L"..\\" );
+			//wcscat_literal( basePath, L"..\\" );
 			DirUp( basePath );
 		}
 		if( -1 == auto_snprintf_s( pszOutput, count, L"%s%s", basePath, p ) ){

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -1209,7 +1209,7 @@ int CDlgTagJumpList::find_key_core(
 			state.m_nDepth = 0;
 			szNextPath[0] = 0;
 		}else{
-//			wcscat_literal( state.m_szCurPath, L"..\\" );
+//			wcscat( state.m_szCurPath, L"..\\" );
 			//カレントパスを1階層上へ。
 			DirUp( state.m_szCurPath );
 		}
@@ -1645,7 +1645,7 @@ WCHAR* CDlgTagJumpList::GetFullPathFromDepth( WCHAR* pszOutput, int count,
 		wcscpy( pszOutput, p );	//何も加工しない。
 	}else{
 		for( int i = 0; i < depth; i++ ){
-			//wcscat_literal( basePath, L"..\\" );
+			//wcscat( basePath, L"..\\" );
 			DirUp( basePath );
 		}
 		if( -1 == auto_snprintf_s( pszOutput, count, L"%s%s", basePath, p ) ){

--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -163,7 +163,7 @@ int CDlgTagsMake::GetData( void )
 	int length = wcslen( m_szPath );
 	if( length > 0 )
 	{
-		if( m_szPath[ length - 1 ] != L'\\' ) wcscat_literal( m_szPath, L"\\" );
+		if( m_szPath[ length - 1 ] != L'\\' ) wcscat( m_szPath, L"\\" );
 	}
 
 	//CTAGSオプション

--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -163,7 +163,7 @@ int CDlgTagsMake::GetData( void )
 	int length = wcslen( m_szPath );
 	if( length > 0 )
 	{
-		if( m_szPath[ length - 1 ] != L'\\' ) wcscat( m_szPath, L"\\" );
+		if( m_szPath[ length - 1 ] != L'\\' ) wcscat_literal( m_szPath, L"\\" );
 	}
 
 	//CTAGSオプション

--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -163,7 +163,7 @@ int CDlgTagsMake::GetData( void )
 	int length = wcslen( m_szPath );
 	if( length > 0 )
 	{
-		if( m_szPath[ length - 1 ] != L'\\' ) wcsncat_s( m_szPath, _countof(m_szPath), L"\\", 1 );
+		if( m_szPath[ length - 1 ] != L'\\' ) wcscat_literal( m_szPath, L"\\" );
 	}
 
 	//CTAGSオプション

--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -163,7 +163,7 @@ int CDlgTagsMake::GetData( void )
 	int length = wcslen( m_szPath );
 	if( length > 0 )
 	{
-		if( m_szPath[ length - 1 ] != L'\\' ) wcscat( m_szPath, L"\\" );
+		if( m_szPath[ length - 1 ] != L'\\' ) wcsncat_s( m_szPath, _countof(m_szPath), L"\\", 1 );
 	}
 
 	//CTAGSオプション

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -255,12 +255,12 @@ bool CDocFileOperation::SaveFileDialog(
 		if(!this->m_pcDocRef->m_cDocFile.GetFilePathClass().IsValidPath()){
 			//「新規から保存時は全ファイル表示」オプション	// 2008/6/15 バグフィックス Uchi
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveNew )
-				wcscat_literal(szDefaultWildCard, L";*.*");	// 全ファイル表示
+				wcscat(szDefaultWildCard, L";*.*");	// 全ファイル表示
 		}
 		else {
 			//「新規以外から保存時は全ファイル表示」オプション
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveFile )
-				wcscat_literal(szDefaultWildCard, L";*.*");	// 全ファイル表示
+				wcscat(szDefaultWildCard, L";*.*");	// 全ファイル表示
 		}
 	}
 	// 無題に、無題番号を付ける

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -255,12 +255,12 @@ bool CDocFileOperation::SaveFileDialog(
 		if(!this->m_pcDocRef->m_cDocFile.GetFilePathClass().IsValidPath()){
 			//「新規から保存時は全ファイル表示」オプション	// 2008/6/15 バグフィックス Uchi
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveNew )
-				wcscat(szDefaultWildCard, L";*.*");	// 全ファイル表示
+				wcsncat_s(szDefaultWildCard, _countof(szDefaultWildCard), L";*.*", 4);	// 全ファイル表示
 		}
 		else {
 			//「新規以外から保存時は全ファイル表示」オプション
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveFile )
-				wcscat(szDefaultWildCard, L";*.*");	// 全ファイル表示
+				wcsncat_s(szDefaultWildCard, _countof(szDefaultWildCard), L";*.*", 4);	// 全ファイル表示
 		}
 	}
 	// 無題に、無題番号を付ける

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -255,12 +255,12 @@ bool CDocFileOperation::SaveFileDialog(
 		if(!this->m_pcDocRef->m_cDocFile.GetFilePathClass().IsValidPath()){
 			//「新規から保存時は全ファイル表示」オプション	// 2008/6/15 バグフィックス Uchi
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveNew )
-				wcscat(szDefaultWildCard, L";*.*");	// 全ファイル表示
+				wcscat_literal(szDefaultWildCard, L";*.*");	// 全ファイル表示
 		}
 		else {
 			//「新規以外から保存時は全ファイル表示」オプション
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveFile )
-				wcscat(szDefaultWildCard, L";*.*");	// 全ファイル表示
+				wcscat_literal(szDefaultWildCard, L";*.*");	// 全ファイル表示
 		}
 	}
 	// 無題に、無題番号を付ける

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -255,12 +255,12 @@ bool CDocFileOperation::SaveFileDialog(
 		if(!this->m_pcDocRef->m_cDocFile.GetFilePathClass().IsValidPath()){
 			//「新規から保存時は全ファイル表示」オプション	// 2008/6/15 バグフィックス Uchi
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveNew )
-				wcsncat_s(szDefaultWildCard, _countof(szDefaultWildCard), L";*.*", 4);	// 全ファイル表示
+				wcscat_literal(szDefaultWildCard, L";*.*");	// 全ファイル表示
 		}
 		else {
 			//「新規以外から保存時は全ファイル表示」オプション
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveFile )
-				wcsncat_s(szDefaultWildCard, _countof(szDefaultWildCard), L";*.*", 4);	// 全ファイル表示
+				wcscat_literal(szDefaultWildCard, L";*.*");	// 全ファイル表示
 		}
 	}
 	// 無題に、無題番号を付ける

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -242,11 +242,11 @@ bool CDocTypeManager::ConvertTypesExtToDlgExt( const WCHAR *pszSrcExt, const WCH
 	while( token )
 	{
 		if (szExt == NULL || szExt[0] == L'\0' || wmemicmp(token, szExt + 1) != 0) {
-			if( pszDstExt[0] != '\0' ) wcscat( pszDstExt, L";" );
+			if( pszDstExt[0] != '\0' ) wcscat_literal( pszDstExt, L";" );
 			// 拡張子指定なし、またはマッチした拡張子でない
 			if (wcspbrk(token, m_typeExtWildcards) == NULL) {
-				if (L'.' == *token) wcscat(pszDstExt, L"*");
-				else                 wcscat(pszDstExt, L"*.");
+				if (L'.' == *token) wcscat_literal(pszDstExt, L"*");
+				else                 wcscat_literal(pszDstExt, L"*.");
 			}
 			wcscat(pszDstExt, token);
 		}

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -242,11 +242,11 @@ bool CDocTypeManager::ConvertTypesExtToDlgExt( const WCHAR *pszSrcExt, const WCH
 	while( token )
 	{
 		if (szExt == NULL || szExt[0] == L'\0' || wmemicmp(token, szExt + 1) != 0) {
-			if( pszDstExt[0] != '\0' ) wcscat_literal( pszDstExt, L";" );
+			if( pszDstExt[0] != '\0' ) wcscat( pszDstExt, L";" );
 			// 拡張子指定なし、またはマッチした拡張子でない
 			if (wcspbrk(token, m_typeExtWildcards) == NULL) {
-				if (L'.' == *token) wcscat_literal(pszDstExt, L"*");
-				else                 wcscat_literal(pszDstExt, L"*.");
+				if (L'.' == *token) wcscat(pszDstExt, L"*");
+				else                 wcscat(pszDstExt, L"*.");
 			}
 			wcscat(pszDstExt, token);
 		}

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -245,7 +245,7 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("MRUFOLDER[%02d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_szOPENFOLDERArr[i] );
 		//お気に入り	//@@@ 2003.04.08 MIK
-		wcscat( szKeyName, LTEXT(".bFavorite") );
+		wcscat_literal( szKeyName, LTEXT(".bFavorite") );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_bOPENFOLDERArrFavorite[i] );
 	}
 	//読み込み時は残りを初期化
@@ -540,7 +540,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 			- CNativeW::GetCharPrev( common.m_sBackup.m_szBackUpFolder, nDummy, &common.m_sBackup.m_szBackUpFolder[nDummy] );
 		if( 1 == nCharChars && common.m_sBackup.m_szBackUpFolder[nDummy - 1] == '\\' ){
 		}else{
-			wcscat( common.m_sBackup.m_szBackUpFolder, L"\\" );
+			wcscat_literal( common.m_sBackup.m_szBackUpFolder, L"\\" );
 		}
 	}
 	cProfile.IOProfileData( pszSecName, LTEXT("szBackUpFolder"), common.m_sBackup.m_szBackUpFolder );
@@ -553,7 +553,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 			- CNativeW::GetCharPrev( common.m_sBackup.m_szBackUpFolder, nDummy, &common.m_sBackup.m_szBackUpFolder[nDummy] );
 		if( 1 == nCharChars && common.m_sBackup.m_szBackUpFolder[nDummy - 1] == '\\' ){
 		}else{
-			wcscat( common.m_sBackup.m_szBackUpFolder, L"\\" );
+			wcscat_literal( common.m_sBackup.m_szBackUpFolder, L"\\" );
 		}
 	}
 	

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -245,7 +245,7 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("MRUFOLDER[%02d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_szOPENFOLDERArr[i] );
 		//お気に入り	//@@@ 2003.04.08 MIK
-		wcscat_literal( szKeyName, LTEXT(".bFavorite") );
+		wcscat( szKeyName, LTEXT(".bFavorite") );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_bOPENFOLDERArrFavorite[i] );
 	}
 	//読み込み時は残りを初期化
@@ -540,7 +540,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 			- CNativeW::GetCharPrev( common.m_sBackup.m_szBackUpFolder, nDummy, &common.m_sBackup.m_szBackUpFolder[nDummy] );
 		if( 1 == nCharChars && common.m_sBackup.m_szBackUpFolder[nDummy - 1] == '\\' ){
 		}else{
-			wcscat_literal( common.m_sBackup.m_szBackUpFolder, L"\\" );
+			wcscat( common.m_sBackup.m_szBackUpFolder, L"\\" );
 		}
 	}
 	cProfile.IOProfileData( pszSecName, LTEXT("szBackUpFolder"), common.m_sBackup.m_szBackUpFolder );
@@ -553,7 +553,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 			- CNativeW::GetCharPrev( common.m_sBackup.m_szBackUpFolder, nDummy, &common.m_sBackup.m_szBackUpFolder[nDummy] );
 		if( 1 == nCharChars && common.m_sBackup.m_szBackUpFolder[nDummy - 1] == '\\' ){
 		}else{
-			wcscat_literal( common.m_sBackup.m_szBackUpFolder, L"\\" );
+			wcscat( common.m_sBackup.m_szBackUpFolder, L"\\" );
 		}
 	}
 	

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -245,7 +245,7 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("MRUFOLDER[%02d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_szOPENFOLDERArr[i] );
 		//お気に入り	//@@@ 2003.04.08 MIK
-		wcsncat_s( szKeyName, _countof(szKeyName), LTEXT(".bFavorite"), 10 );
+		wcscat_literal( szKeyName, LTEXT(".bFavorite") );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_bOPENFOLDERArrFavorite[i] );
 	}
 	//読み込み時は残りを初期化
@@ -540,7 +540,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 			- CNativeW::GetCharPrev( common.m_sBackup.m_szBackUpFolder, nDummy, &common.m_sBackup.m_szBackUpFolder[nDummy] );
 		if( 1 == nCharChars && common.m_sBackup.m_szBackUpFolder[nDummy - 1] == '\\' ){
 		}else{
-			wcscat( common.m_sBackup.m_szBackUpFolder, L"\\" );
+			wcscat_literal( common.m_sBackup.m_szBackUpFolder, L"\\" );
 		}
 	}
 	cProfile.IOProfileData( pszSecName, LTEXT("szBackUpFolder"), common.m_sBackup.m_szBackUpFolder );
@@ -553,7 +553,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 			- CNativeW::GetCharPrev( common.m_sBackup.m_szBackUpFolder, nDummy, &common.m_sBackup.m_szBackUpFolder[nDummy] );
 		if( 1 == nCharChars && common.m_sBackup.m_szBackUpFolder[nDummy - 1] == '\\' ){
 		}else{
-			wcscat( common.m_sBackup.m_szBackUpFolder, L"\\" );
+			wcscat_literal( common.m_sBackup.m_szBackUpFolder, L"\\" );
 		}
 	}
 	

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -245,7 +245,7 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("MRUFOLDER[%02d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_szOPENFOLDERArr[i] );
 		//お気に入り	//@@@ 2003.04.08 MIK
-		wcscat( szKeyName, LTEXT(".bFavorite") );
+		wcsncat_s( szKeyName, _countof(szKeyName), LTEXT(".bFavorite"), 10 );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_bOPENFOLDERArrFavorite[i] );
 	}
 	//読み込み時は残りを初期化

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -462,7 +462,7 @@ WCHAR* CKeyBind::GetMenuLabel(
 		if( GetKeyStr( hInstance, nKeyNameArrNum, pKeyNameArr, cMemAccessKey, nFuncId, bGetDefFuncCode ) ){
 			// バッファが足りないときは入れない
 			if( wcslen( pszLabel ) + (Int)cMemAccessKey.GetStringLength() + 1 < LABEL_MAX ){
-				wcscat_literal( pszLabel, L"\t" );
+				wcscat( pszLabel, L"\t" );
 				wcscat( pszLabel, cMemAccessKey.GetStringPtr() );
 			}
 		}

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -462,7 +462,7 @@ WCHAR* CKeyBind::GetMenuLabel(
 		if( GetKeyStr( hInstance, nKeyNameArrNum, pKeyNameArr, cMemAccessKey, nFuncId, bGetDefFuncCode ) ){
 			// バッファが足りないときは入れない
 			if( wcslen( pszLabel ) + (Int)cMemAccessKey.GetStringLength() + 1 < LABEL_MAX ){
-				wcscat( pszLabel, L"\t" );
+				wcscat_literal( pszLabel, L"\t" );
 				wcscat( pszLabel, cMemAccessKey.GetStringPtr() );
 			}
 		}

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1124,21 +1124,21 @@ bool CMacro::HandleCommand(
 
 			//GOPTオプション
 			pOpt[0] = '\0';
-			if( lFlag & 0x01 )wcsncat_s( pOpt, _countof(pOpt), L"S", 1 );	/* サブフォルダからも検索する */
-			if( lFlag & 0x04 )wcsncat_s( pOpt, _countof(pOpt), L"L", 1 );	/* 英大文字と英小文字を区別する */
-			if( lFlag & 0x08 )wcsncat_s( pOpt, _countof(pOpt), L"R", 1 );	/* 正規表現 */
-			if(          0x20 == (lFlag & 0x400020) )wcsncat_s( pOpt, _countof(pOpt), L"P", 1 );	// 行を出力する
-			else if( 0x400000 == (lFlag & 0x400020) )wcsncat_s( pOpt, _countof(pOpt), L"N", 1 );	// 否ヒット行を出力する
-			if(      0x40 == (lFlag & 0xC0) )wcsncat_s( pOpt, _countof(pOpt), L"2", 1 );	/* Grep: 出力形式 */
-			else if( 0x80 == (lFlag & 0xC0) )wcsncat_s( pOpt, _countof(pOpt), L"3", 1 );
-			else wcsncat_s( pOpt, _countof(pOpt), L"1", 1 );
-			if( lFlag & 0x10000 )wcsncat_s( pOpt, _countof(pOpt), L"W", 1 );
-			if( lFlag & 0x20000 )wcsncat_s( pOpt, _countof(pOpt), L"F", 1 );
-			if( lFlag & 0x40000 )wcsncat_s( pOpt, _countof(pOpt), L"B", 1 );
-			if( lFlag & 0x80000 )wcsncat_s( pOpt, _countof(pOpt), L"D", 1 );
+			if( lFlag & 0x01 )wcscat_literal( pOpt, L"S" );	/* サブフォルダからも検索する */
+			if( lFlag & 0x04 )wcscat_literal( pOpt, L"L" );	/* 英大文字と英小文字を区別する */
+			if( lFlag & 0x08 )wcscat_literal( pOpt, L"R" );	/* 正規表現 */
+			if(          0x20 == (lFlag & 0x400020) )wcscat_literal( pOpt, L"P" );	// 行を出力する
+			else if( 0x400000 == (lFlag & 0x400020) )wcscat_literal( pOpt, L"N" );	// 否ヒット行を出力する
+			if(      0x40 == (lFlag & 0xC0) )wcscat_literal( pOpt, L"2" );	/* Grep: 出力形式 */
+			else if( 0x80 == (lFlag & 0xC0) )wcscat_literal( pOpt, L"3" );
+			else wcscat_literal( pOpt, L"1" );
+			if( lFlag & 0x10000 )wcscat_literal( pOpt, L"W" );
+			if( lFlag & 0x20000 )wcscat_literal( pOpt, L"F" );
+			if( lFlag & 0x40000 )wcscat_literal( pOpt, L"B" );
+			if( lFlag & 0x80000 )wcscat_literal( pOpt, L"D" );
 			if( bGrepReplace ){
-				if( lFlag & 0x100000 )wcsncat_s( pOpt, _countof(pOpt), L"C", 1 );
-				if( lFlag & 0x200000 )wcsncat_s( pOpt, _countof(pOpt), L"O", 1 );
+				if( lFlag & 0x100000 )wcscat_literal( pOpt, L"C" );
+				if( lFlag & 0x200000 )wcscat_literal( pOpt, L"O" );
 			}
 			if( pOpt[0] != L'\0' ){
 				auto_sprintf( szTemp, L" -GOPT=%s", pOpt );

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1124,21 +1124,21 @@ bool CMacro::HandleCommand(
 
 			//GOPTオプション
 			pOpt[0] = '\0';
-			if( lFlag & 0x01 )wcscat_literal( pOpt, L"S" );	/* サブフォルダからも検索する */
-			if( lFlag & 0x04 )wcscat_literal( pOpt, L"L" );	/* 英大文字と英小文字を区別する */
-			if( lFlag & 0x08 )wcscat_literal( pOpt, L"R" );	/* 正規表現 */
-			if(          0x20 == (lFlag & 0x400020) )wcscat_literal( pOpt, L"P" );	// 行を出力する
-			else if( 0x400000 == (lFlag & 0x400020) )wcscat_literal( pOpt, L"N" );	// 否ヒット行を出力する
-			if(      0x40 == (lFlag & 0xC0) )wcscat_literal( pOpt, L"2" );	/* Grep: 出力形式 */
-			else if( 0x80 == (lFlag & 0xC0) )wcscat_literal( pOpt, L"3" );
-			else wcscat_literal( pOpt, L"1" );
-			if( lFlag & 0x10000 )wcscat_literal( pOpt, L"W" );
-			if( lFlag & 0x20000 )wcscat_literal( pOpt, L"F" );
-			if( lFlag & 0x40000 )wcscat_literal( pOpt, L"B" );
-			if( lFlag & 0x80000 )wcscat_literal( pOpt, L"D" );
+			if( lFlag & 0x01 )wcscat( pOpt, L"S" );	/* サブフォルダからも検索する */
+			if( lFlag & 0x04 )wcscat( pOpt, L"L" );	/* 英大文字と英小文字を区別する */
+			if( lFlag & 0x08 )wcscat( pOpt, L"R" );	/* 正規表現 */
+			if(          0x20 == (lFlag & 0x400020) )wcscat( pOpt, L"P" );	// 行を出力する
+			else if( 0x400000 == (lFlag & 0x400020) )wcscat( pOpt, L"N" );	// 否ヒット行を出力する
+			if(      0x40 == (lFlag & 0xC0) )wcscat( pOpt, L"2" );	/* Grep: 出力形式 */
+			else if( 0x80 == (lFlag & 0xC0) )wcscat( pOpt, L"3" );
+			else wcscat( pOpt, L"1" );
+			if( lFlag & 0x10000 )wcscat( pOpt, L"W" );
+			if( lFlag & 0x20000 )wcscat( pOpt, L"F" );
+			if( lFlag & 0x40000 )wcscat( pOpt, L"B" );
+			if( lFlag & 0x80000 )wcscat( pOpt, L"D" );
 			if( bGrepReplace ){
-				if( lFlag & 0x100000 )wcscat_literal( pOpt, L"C" );
-				if( lFlag & 0x200000 )wcscat_literal( pOpt, L"O" );
+				if( lFlag & 0x100000 )wcscat( pOpt, L"C" );
+				if( lFlag & 0x200000 )wcscat( pOpt, L"O" );
 			}
 			if( pOpt[0] != L'\0' ){
 				auto_sprintf( szTemp, L" -GOPT=%s", pOpt );

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1124,21 +1124,21 @@ bool CMacro::HandleCommand(
 
 			//GOPTオプション
 			pOpt[0] = '\0';
-			if( lFlag & 0x01 )wcscat( pOpt, L"S" );	/* サブフォルダからも検索する */
-			if( lFlag & 0x04 )wcscat( pOpt, L"L" );	/* 英大文字と英小文字を区別する */
-			if( lFlag & 0x08 )wcscat( pOpt, L"R" );	/* 正規表現 */
-			if(          0x20 == (lFlag & 0x400020) )wcscat( pOpt, L"P" );	// 行を出力する
-			else if( 0x400000 == (lFlag & 0x400020) )wcscat( pOpt, L"N" );	// 否ヒット行を出力する
-			if(      0x40 == (lFlag & 0xC0) )wcscat( pOpt, L"2" );	/* Grep: 出力形式 */
-			else if( 0x80 == (lFlag & 0xC0) )wcscat( pOpt, L"3" );
-			else wcscat( pOpt, L"1" );
-			if( lFlag & 0x10000 )wcscat( pOpt, L"W" );
-			if( lFlag & 0x20000 )wcscat( pOpt, L"F" );
-			if( lFlag & 0x40000 )wcscat( pOpt, L"B" );
-			if( lFlag & 0x80000 )wcscat( pOpt, L"D" );
+			if( lFlag & 0x01 )wcsncat_s( pOpt, _countof(pOpt), L"S", 1 );	/* サブフォルダからも検索する */
+			if( lFlag & 0x04 )wcsncat_s( pOpt, _countof(pOpt), L"L", 1 );	/* 英大文字と英小文字を区別する */
+			if( lFlag & 0x08 )wcsncat_s( pOpt, _countof(pOpt), L"R", 1 );	/* 正規表現 */
+			if(          0x20 == (lFlag & 0x400020) )wcsncat_s( pOpt, _countof(pOpt), L"P", 1 );	// 行を出力する
+			else if( 0x400000 == (lFlag & 0x400020) )wcsncat_s( pOpt, _countof(pOpt), L"N", 1 );	// 否ヒット行を出力する
+			if(      0x40 == (lFlag & 0xC0) )wcsncat_s( pOpt, _countof(pOpt), L"2", 1 );	/* Grep: 出力形式 */
+			else if( 0x80 == (lFlag & 0xC0) )wcsncat_s( pOpt, _countof(pOpt), L"3", 1 );
+			else wcsncat_s( pOpt, _countof(pOpt), L"1", 1 );
+			if( lFlag & 0x10000 )wcsncat_s( pOpt, _countof(pOpt), L"W", 1 );
+			if( lFlag & 0x20000 )wcsncat_s( pOpt, _countof(pOpt), L"F", 1 );
+			if( lFlag & 0x40000 )wcsncat_s( pOpt, _countof(pOpt), L"B", 1 );
+			if( lFlag & 0x80000 )wcsncat_s( pOpt, _countof(pOpt), L"D", 1 );
 			if( bGrepReplace ){
-				if( lFlag & 0x100000 )wcscat( pOpt, L"C" );
-				if( lFlag & 0x200000 )wcscat( pOpt, L"O" );
+				if( lFlag & 0x100000 )wcsncat_s( pOpt, _countof(pOpt), L"C", 1 );
+				if( lFlag & 0x200000 )wcsncat_s( pOpt, _countof(pOpt), L"O", 1 );
 			}
 			if( pOpt[0] != L'\0' ){
 				auto_sprintf( szTemp, L" -GOPT=%s", pOpt );

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1124,21 +1124,21 @@ bool CMacro::HandleCommand(
 
 			//GOPTオプション
 			pOpt[0] = '\0';
-			if( lFlag & 0x01 )wcscat( pOpt, L"S" );	/* サブフォルダからも検索する */
-			if( lFlag & 0x04 )wcscat( pOpt, L"L" );	/* 英大文字と英小文字を区別する */
-			if( lFlag & 0x08 )wcscat( pOpt, L"R" );	/* 正規表現 */
-			if(          0x20 == (lFlag & 0x400020) )wcscat( pOpt, L"P" );	// 行を出力する
-			else if( 0x400000 == (lFlag & 0x400020) )wcscat( pOpt, L"N" );	// 否ヒット行を出力する
-			if(      0x40 == (lFlag & 0xC0) )wcscat( pOpt, L"2" );	/* Grep: 出力形式 */
-			else if( 0x80 == (lFlag & 0xC0) )wcscat( pOpt, L"3" );
-			else wcscat( pOpt, L"1" );
-			if( lFlag & 0x10000 )wcscat( pOpt, L"W" );
-			if( lFlag & 0x20000 )wcscat( pOpt, L"F" );
-			if( lFlag & 0x40000 )wcscat( pOpt, L"B" );
-			if( lFlag & 0x80000 )wcscat( pOpt, L"D" );
+			if( lFlag & 0x01 )wcscat_literal( pOpt, L"S" );	/* サブフォルダからも検索する */
+			if( lFlag & 0x04 )wcscat_literal( pOpt, L"L" );	/* 英大文字と英小文字を区別する */
+			if( lFlag & 0x08 )wcscat_literal( pOpt, L"R" );	/* 正規表現 */
+			if(          0x20 == (lFlag & 0x400020) )wcscat_literal( pOpt, L"P" );	// 行を出力する
+			else if( 0x400000 == (lFlag & 0x400020) )wcscat_literal( pOpt, L"N" );	// 否ヒット行を出力する
+			if(      0x40 == (lFlag & 0xC0) )wcscat_literal( pOpt, L"2" );	/* Grep: 出力形式 */
+			else if( 0x80 == (lFlag & 0xC0) )wcscat_literal( pOpt, L"3" );
+			else wcscat_literal( pOpt, L"1" );
+			if( lFlag & 0x10000 )wcscat_literal( pOpt, L"W" );
+			if( lFlag & 0x20000 )wcscat_literal( pOpt, L"F" );
+			if( lFlag & 0x40000 )wcscat_literal( pOpt, L"B" );
+			if( lFlag & 0x80000 )wcscat_literal( pOpt, L"D" );
 			if( bGrepReplace ){
-				if( lFlag & 0x100000 )wcscat( pOpt, L"C" );
-				if( lFlag & 0x200000 )wcscat( pOpt, L"O" );
+				if( lFlag & 0x100000 )wcscat_literal( pOpt, L"C" );
+				if( lFlag & 0x200000 )wcscat_literal( pOpt, L"O" );
 			}
 			if( pOpt[0] != L'\0' ){
 				auto_sprintf( szTemp, L" -GOPT=%s", pOpt );

--- a/sakura_core/macro/CPPA.cpp
+++ b/sakura_core/macro/CPPA.cpp
@@ -268,7 +268,7 @@ char* CPPA::GetDeclarations( const MacroFuncInfo& cMacroFuncInfo, char* szBuffer
 		// 2002.12.06 Moca 原因不明だが，strcatがVC6Proでうまく動かなかったため，strcpyにしてみたら動いた
 		strcpy( szArgument, szArguments[0] );
 		for ( j=1; j<i; j++){
-			strcat( szArgument, "; " );
+			strcat_literal( szArgument, "; " );
 			strcat( szArgument, szArguments[j] );
 		}
 		auto_sprintf( szBuffer, "%hs S_%ls(%hs)%hs; index %d;",

--- a/sakura_core/macro/CPPA.cpp
+++ b/sakura_core/macro/CPPA.cpp
@@ -268,8 +268,8 @@ char* CPPA::GetDeclarations( const MacroFuncInfo& cMacroFuncInfo, char* szBuffer
 		// 2002.12.06 Moca 原因不明だが，strcatがVC6Proでうまく動かなかったため，strcpyにしてみたら動いた
 		strcpy( szArgument, szArguments[0] );
 		for ( j=1; j<i; j++){
-			strcat( szArgument, "; " );
-			strcat( szArgument, szArguments[j] );
+			strncat_s( szArgument, _countof(szArgument), "; ", 2 );
+			strncat_s( szArgument, _countof(szArgument), szArguments[j], _countof(szArguments[j]) - 1 );
 		}
 		auto_sprintf( szBuffer, "%hs S_%ls(%hs)%hs; index %d;",
 			szType,

--- a/sakura_core/macro/CPPA.cpp
+++ b/sakura_core/macro/CPPA.cpp
@@ -268,8 +268,8 @@ char* CPPA::GetDeclarations( const MacroFuncInfo& cMacroFuncInfo, char* szBuffer
 		// 2002.12.06 Moca 原因不明だが，strcatがVC6Proでうまく動かなかったため，strcpyにしてみたら動いた
 		strcpy( szArgument, szArguments[0] );
 		for ( j=1; j<i; j++){
-			strncat_s( szArgument, _countof(szArgument), "; ", 2 );
-			strncat_s( szArgument, _countof(szArgument), szArguments[j], _countof(szArguments[j]) - 1 );
+			strcat_literal( szArgument, "; " );
+			strcat( szArgument, szArguments[j] );
 		}
 		auto_sprintf( szBuffer, "%hs S_%ls(%hs)%hs; index %d;",
 			szType,

--- a/sakura_core/macro/CPPA.cpp
+++ b/sakura_core/macro/CPPA.cpp
@@ -268,7 +268,7 @@ char* CPPA::GetDeclarations( const MacroFuncInfo& cMacroFuncInfo, char* szBuffer
 		// 2002.12.06 Moca 原因不明だが，strcatがVC6Proでうまく動かなかったため，strcpyにしてみたら動いた
 		strcpy( szArgument, szArguments[0] );
 		for ( j=1; j<i; j++){
-			strcat_literal( szArgument, "; " );
+			strcat( szArgument, "; " );
 			strcat( szArgument, szArguments[j] );
 		}
 		auto_sprintf( szBuffer, "%hs S_%ls(%hs)%hs; index %d;",

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3991,7 +3991,7 @@ void CDlgFuncList::LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDi
 		// 各フォルダのプロジェクトファイル読み込み
 		WCHAR szPath[_MAX_PATH];
 		::GetLongFileName( L".", szPath );
-		wcscat( szPath, L"\\" );
+		wcsncat_s( szPath, _countof(szPath), L"\\", 1 );
 		int maxDir = CDlgTagJumpList::CalcMaxUpDirectory( szPath );
 		for( int i = 0; i <= maxDir; i++ ){
 			CDataProfile cProfile;

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -1071,11 +1071,11 @@ void CDlgFuncList::SetTreeJava( HWND hwndDlg, BOOL bAddClass )
 					{
 						if( pcFuncInfo->m_nInfo == FL_OBJ_NAMESPACE )
 						{
-							//wcscat( pClassName, L" 名前空間" );
+							//wcscat_literal( pClassName, L" 名前空間" );
 							strClassName += m_pcFuncInfoArr->GetAppendText(FL_OBJ_NAMESPACE);
 						}
 						else
-							//wcscat( pClassName, L" クラス" );
+							//wcscat_literal( pClassName, L" クラス" );
 							strClassName += m_pcFuncInfoArr->GetAppendText(FL_OBJ_CLASS);
 					}
 					tvis.hParent = htiParent;
@@ -3991,7 +3991,7 @@ void CDlgFuncList::LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDi
 		// 各フォルダのプロジェクトファイル読み込み
 		WCHAR szPath[_MAX_PATH];
 		::GetLongFileName( L".", szPath );
-		wcscat( szPath, L"\\" );
+		wcscat_literal( szPath, L"\\" );
 		int maxDir = CDlgTagJumpList::CalcMaxUpDirectory( szPath );
 		for( int i = 0; i <= maxDir; i++ ){
 			CDataProfile cProfile;

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -1071,11 +1071,11 @@ void CDlgFuncList::SetTreeJava( HWND hwndDlg, BOOL bAddClass )
 					{
 						if( pcFuncInfo->m_nInfo == FL_OBJ_NAMESPACE )
 						{
-							//wcscat_literal( pClassName, L" 名前空間" );
+							//wcscat( pClassName, L" 名前空間" );
 							strClassName += m_pcFuncInfoArr->GetAppendText(FL_OBJ_NAMESPACE);
 						}
 						else
-							//wcscat_literal( pClassName, L" クラス" );
+							//wcscat( pClassName, L" クラス" );
 							strClassName += m_pcFuncInfoArr->GetAppendText(FL_OBJ_CLASS);
 					}
 					tvis.hParent = htiParent;
@@ -3991,7 +3991,7 @@ void CDlgFuncList::LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDi
 		// 各フォルダのプロジェクトファイル読み込み
 		WCHAR szPath[_MAX_PATH];
 		::GetLongFileName( L".", szPath );
-		wcscat_literal( szPath, L"\\" );
+		wcscat( szPath, L"\\" );
 		int maxDir = CDlgTagJumpList::CalcMaxUpDirectory( szPath );
 		for( int i = 0; i <= maxDir; i++ ){
 			CDataProfile cProfile;

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -1071,11 +1071,11 @@ void CDlgFuncList::SetTreeJava( HWND hwndDlg, BOOL bAddClass )
 					{
 						if( pcFuncInfo->m_nInfo == FL_OBJ_NAMESPACE )
 						{
-							//wcscat( pClassName, L" 名前空間" );
+							//wcscat_literal( pClassName, L" 名前空間" );
 							strClassName += m_pcFuncInfoArr->GetAppendText(FL_OBJ_NAMESPACE);
 						}
 						else
-							//wcscat( pClassName, L" クラス" );
+							//wcscat_literal( pClassName, L" クラス" );
 							strClassName += m_pcFuncInfoArr->GetAppendText(FL_OBJ_CLASS);
 					}
 					tvis.hParent = htiParent;
@@ -3991,7 +3991,7 @@ void CDlgFuncList::LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDi
 		// 各フォルダのプロジェクトファイル読み込み
 		WCHAR szPath[_MAX_PATH];
 		::GetLongFileName( L".", szPath );
-		wcsncat_s( szPath, _countof(szPath), L"\\", 1 );
+		wcscat_literal( szPath, L"\\" );
 		int maxDir = CDlgTagJumpList::CalcMaxUpDirectory( szPath );
 		for( int i = 0; i <= maxDir; i++ ){
 			CDataProfile cProfile;

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -1504,7 +1504,7 @@ CColorStrategy* CPrintPreview::DrawPageText(
 					wcscat( szLineNum, szLineTerm );
 				}
 				else{
-					wcscat_literal( szLineNum, L" " );
+					wcscat( szLineNum, L" " );
 				}
 
 				//文字列長

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -1501,10 +1501,10 @@ CColorStrategy* CPrintPreview::DrawPageText(
 					wchar_t szLineTerm[2];
 					szLineTerm[0] = m_pParentWnd->GetDocument()->m_cDocType.GetDocumentAttribute().m_cLineTermChar;	/* 行番号区切り文字 */
 					szLineTerm[1] = L'\0';
-					wcscat( szLineNum, szLineTerm );
+					wcsncat_s( szLineNum, _countof(szLineNum), szLineTerm, 1 );
 				}
 				else{
-					wcscat( szLineNum, L" " );
+					wcsncat_s( szLineNum, _countof(szLineNum), L" ", 1 );
 				}
 
 				//文字列長

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -1504,7 +1504,7 @@ CColorStrategy* CPrintPreview::DrawPageText(
 					wcscat( szLineNum, szLineTerm );
 				}
 				else{
-					wcscat( szLineNum, L" " );
+					wcscat_literal( szLineNum, L" " );
 				}
 
 				//文字列長

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -1501,10 +1501,10 @@ CColorStrategy* CPrintPreview::DrawPageText(
 					wchar_t szLineTerm[2];
 					szLineTerm[0] = m_pParentWnd->GetDocument()->m_cDocType.GetDocumentAttribute().m_cLineTermChar;	/* 行番号区切り文字 */
 					szLineTerm[1] = L'\0';
-					wcsncat_s( szLineNum, _countof(szLineNum), szLineTerm, 1 );
+					wcscat( szLineNum, szLineTerm );
 				}
 				else{
-					wcsncat_s( szLineNum, _countof(szLineNum), L" ", 1 );
+					wcscat_literal( szLineNum, L" " );
 				}
 
 				//文字列長

--- a/sakura_core/prop/CPropComBackup.cpp
+++ b/sakura_core/prop/CPropComBackup.cpp
@@ -516,41 +516,41 @@ void CPropBackup::UpdateBackupFile(HWND hwndDlg)	//	バックアップファイ�
 
 		switch( m_Common.m_sBackup.GetBackupType() ){
 		case 1: // .bak
-			wcscat( temp, LTEXT("$0.bak") );
+			wcscat_literal( temp, LTEXT("$0.bak") );
 			break;
 		case 5: // .*.bak
-			wcscat( temp, LTEXT("$0.*.bak") );
+			wcscat_literal( temp, LTEXT("$0.*.bak") );
 			break;
 		case 3: // .b??
-			wcscat( temp, LTEXT("$0.b??") );
+			wcscat_literal( temp, LTEXT("$0.b??") );
 			break;
 		case 6: // .*.b??
-			wcscat( temp, LTEXT("$0.*.b??") );
+			wcscat_literal( temp, LTEXT("$0.*.b??") );
 			break;
 		case 2:	//	日付，時刻
 		case 4:	//	日付，時刻
-			wcscat( temp, LTEXT("$0_") );
+			wcscat_literal( temp, LTEXT("$0_") );
 
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_YEAR) ){	/* バックアップファイル名：日付の年 */
-				wcscat( temp, LTEXT("%Y") );
+				wcscat_literal( temp, LTEXT("%Y") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MONTH) ){	/* バックアップファイル名：日付の月 */
-				wcscat( temp, LTEXT("%m") );
+				wcscat_literal( temp, LTEXT("%m") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_DAY) ){	/* バックアップファイル名：日付の日 */
-				wcscat( temp, LTEXT("%d") );
+				wcscat_literal( temp, LTEXT("%d") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_HOUR) ){	/* バックアップファイル名：日付の時 */
-				wcscat( temp, LTEXT("%H") );
+				wcscat_literal( temp, LTEXT("%H") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MIN) ){	/* バックアップファイル名：日付の分 */
-				wcscat( temp, LTEXT("%M") );
+				wcscat_literal( temp, LTEXT("%M") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_SEC) ){	/* バックアップファイル名：日付の秒 */
-				wcscat( temp, LTEXT("%S") );
+				wcscat_literal( temp, LTEXT("%S") );
 			}
 
-			wcscat( temp, LTEXT(".*") );
+			wcscat_literal( temp, LTEXT(".*") );
 			break;
 		default:
 			break;

--- a/sakura_core/prop/CPropComBackup.cpp
+++ b/sakura_core/prop/CPropComBackup.cpp
@@ -516,41 +516,41 @@ void CPropBackup::UpdateBackupFile(HWND hwndDlg)	//	バックアップファイ�
 
 		switch( m_Common.m_sBackup.GetBackupType() ){
 		case 1: // .bak
-			wcscat( temp, LTEXT("$0.bak") );
+			wcsncat_s( temp, _countof(temp), LTEXT("$0.bak"), 6 );
 			break;
 		case 5: // .*.bak
-			wcscat( temp, LTEXT("$0.*.bak") );
+			wcsncat_s( temp, _countof(temp), LTEXT("$0.*.bak"), 8 );
 			break;
 		case 3: // .b??
-			wcscat( temp, LTEXT("$0.b??") );
+			wcsncat_s( temp, _countof(temp), LTEXT("$0.b??"), 6 );
 			break;
 		case 6: // .*.b??
-			wcscat( temp, LTEXT("$0.*.b??") );
+			wcsncat_s( temp, _countof(temp), LTEXT("$0.*.b??"), 8 );
 			break;
 		case 2:	//	日付，時刻
 		case 4:	//	日付，時刻
-			wcscat( temp, LTEXT("$0_") );
+			wcsncat_s( temp, _countof(temp), LTEXT("$0_"), 3 );
 
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_YEAR) ){	/* バックアップファイル名：日付の年 */
-				wcscat( temp, LTEXT("%Y") );
+				wcsncat_s( temp, _countof(temp), LTEXT("%Y"), 2 );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MONTH) ){	/* バックアップファイル名：日付の月 */
-				wcscat( temp, LTEXT("%m") );
+				wcsncat_s( temp, _countof(temp), LTEXT("%m"), 2 );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_DAY) ){	/* バックアップファイル名：日付の日 */
-				wcscat( temp, LTEXT("%d") );
+				wcsncat_s( temp, _countof(temp), LTEXT("%d"), 2 );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_HOUR) ){	/* バックアップファイル名：日付の時 */
-				wcscat( temp, LTEXT("%H") );
+				wcsncat_s( temp, _countof(temp), LTEXT("%H"), 2 );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MIN) ){	/* バックアップファイル名：日付の分 */
-				wcscat( temp, LTEXT("%M") );
+				wcsncat_s( temp, _countof(temp), LTEXT("%M"), 2 );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_SEC) ){	/* バックアップファイル名：日付の秒 */
-				wcscat( temp, LTEXT("%S") );
+				wcsncat_s( temp, _countof(temp), LTEXT("%S"), 2 );
 			}
 
-			wcscat( temp, LTEXT(".*") );
+			wcsncat_s( temp, _countof(temp), LTEXT(".*"), 2 );
 			break;
 		default:
 			break;

--- a/sakura_core/prop/CPropComBackup.cpp
+++ b/sakura_core/prop/CPropComBackup.cpp
@@ -516,41 +516,41 @@ void CPropBackup::UpdateBackupFile(HWND hwndDlg)	//	バックアップファイ�
 
 		switch( m_Common.m_sBackup.GetBackupType() ){
 		case 1: // .bak
-			wcscat_literal( temp, LTEXT("$0.bak") );
+			wcscat( temp, LTEXT("$0.bak") );
 			break;
 		case 5: // .*.bak
-			wcscat_literal( temp, LTEXT("$0.*.bak") );
+			wcscat( temp, LTEXT("$0.*.bak") );
 			break;
 		case 3: // .b??
-			wcscat_literal( temp, LTEXT("$0.b??") );
+			wcscat( temp, LTEXT("$0.b??") );
 			break;
 		case 6: // .*.b??
-			wcscat_literal( temp, LTEXT("$0.*.b??") );
+			wcscat( temp, LTEXT("$0.*.b??") );
 			break;
 		case 2:	//	日付，時刻
 		case 4:	//	日付，時刻
-			wcscat_literal( temp, LTEXT("$0_") );
+			wcscat( temp, LTEXT("$0_") );
 
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_YEAR) ){	/* バックアップファイル名：日付の年 */
-				wcscat_literal( temp, LTEXT("%Y") );
+				wcscat( temp, LTEXT("%Y") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MONTH) ){	/* バックアップファイル名：日付の月 */
-				wcscat_literal( temp, LTEXT("%m") );
+				wcscat( temp, LTEXT("%m") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_DAY) ){	/* バックアップファイル名：日付の日 */
-				wcscat_literal( temp, LTEXT("%d") );
+				wcscat( temp, LTEXT("%d") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_HOUR) ){	/* バックアップファイル名：日付の時 */
-				wcscat_literal( temp, LTEXT("%H") );
+				wcscat( temp, LTEXT("%H") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MIN) ){	/* バックアップファイル名：日付の分 */
-				wcscat_literal( temp, LTEXT("%M") );
+				wcscat( temp, LTEXT("%M") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_SEC) ){	/* バックアップファイル名：日付の秒 */
-				wcscat_literal( temp, LTEXT("%S") );
+				wcscat( temp, LTEXT("%S") );
 			}
 
-			wcscat_literal( temp, LTEXT(".*") );
+			wcscat( temp, LTEXT(".*") );
 			break;
 		default:
 			break;

--- a/sakura_core/prop/CPropComBackup.cpp
+++ b/sakura_core/prop/CPropComBackup.cpp
@@ -516,41 +516,41 @@ void CPropBackup::UpdateBackupFile(HWND hwndDlg)	//	バックアップファイ�
 
 		switch( m_Common.m_sBackup.GetBackupType() ){
 		case 1: // .bak
-			wcsncat_s( temp, _countof(temp), LTEXT("$0.bak"), 6 );
+			wcscat_literal( temp, LTEXT("$0.bak") );
 			break;
 		case 5: // .*.bak
-			wcsncat_s( temp, _countof(temp), LTEXT("$0.*.bak"), 8 );
+			wcscat_literal( temp, LTEXT("$0.*.bak") );
 			break;
 		case 3: // .b??
-			wcsncat_s( temp, _countof(temp), LTEXT("$0.b??"), 6 );
+			wcscat_literal( temp, LTEXT("$0.b??") );
 			break;
 		case 6: // .*.b??
-			wcsncat_s( temp, _countof(temp), LTEXT("$0.*.b??"), 8 );
+			wcscat_literal( temp, LTEXT("$0.*.b??") );
 			break;
 		case 2:	//	日付，時刻
 		case 4:	//	日付，時刻
-			wcsncat_s( temp, _countof(temp), LTEXT("$0_"), 3 );
+			wcscat_literal( temp, LTEXT("$0_") );
 
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_YEAR) ){	/* バックアップファイル名：日付の年 */
-				wcsncat_s( temp, _countof(temp), LTEXT("%Y"), 2 );
+				wcscat_literal( temp, LTEXT("%Y") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MONTH) ){	/* バックアップファイル名：日付の月 */
-				wcsncat_s( temp, _countof(temp), LTEXT("%m"), 2 );
+				wcscat_literal( temp, LTEXT("%m") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_DAY) ){	/* バックアップファイル名：日付の日 */
-				wcsncat_s( temp, _countof(temp), LTEXT("%d"), 2 );
+				wcscat_literal( temp, LTEXT("%d") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_HOUR) ){	/* バックアップファイル名：日付の時 */
-				wcsncat_s( temp, _countof(temp), LTEXT("%H"), 2 );
+				wcscat_literal( temp, LTEXT("%H") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_MIN) ){	/* バックアップファイル名：日付の分 */
-				wcsncat_s( temp, _countof(temp), LTEXT("%M"), 2 );
+				wcscat_literal( temp, LTEXT("%M") );
 			}
 			if( m_Common.m_sBackup.GetBackupOpt(BKUP_SEC) ){	/* バックアップファイル名：日付の秒 */
-				wcsncat_s( temp, _countof(temp), LTEXT("%S"), 2 );
+				wcscat_literal( temp, LTEXT("%S") );
 			}
 
-			wcsncat_s( temp, _countof(temp), LTEXT(".*"), 2 );
+			wcscat_literal( temp, LTEXT(".*") );
 			break;
 		default:
 			break;

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -450,15 +450,15 @@ void CPropKeybind::ChangeKeyList( HWND hwndDlg){
 	i = 0;
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_SHIFT ) ){
 		i |= _SHIFT;
-		wcscat_literal( szKeyState, L"Shift+" );
+		wcscat( szKeyState, L"Shift+" );
 	}
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_CTRL ) ){
 		i |= _CTRL;
-		wcscat_literal( szKeyState, L"Ctrl+" );
+		wcscat( szKeyState, L"Ctrl+" );
 	}
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_ALT ) ){
 		i |= _ALT;
-		wcscat_literal( szKeyState, L"Alt+" );
+		wcscat( szKeyState, L"Alt+" );
 	}
 	/* キー一覧に文字列をセット（リストボックス）*/
 	List_ResetContent( hwndKeyList );

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -450,15 +450,15 @@ void CPropKeybind::ChangeKeyList( HWND hwndDlg){
 	i = 0;
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_SHIFT ) ){
 		i |= _SHIFT;
-		wcsncat_s( szKeyState, _countof(szKeyState), L"Shift+", 6 );
+		wcscat_literal( szKeyState, L"Shift+" );
 	}
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_CTRL ) ){
 		i |= _CTRL;
-		wcsncat_s( szKeyState, _countof(szKeyState), L"Ctrl+", 5 );
+		wcscat_literal( szKeyState, L"Ctrl+" );
 	}
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_ALT ) ){
 		i |= _ALT;
-		wcsncat_s( szKeyState, _countof(szKeyState), L"Alt+", 4 );
+		wcscat_literal( szKeyState, L"Alt+" );
 	}
 	/* キー一覧に文字列をセット（リストボックス）*/
 	List_ResetContent( hwndKeyList );

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -450,15 +450,15 @@ void CPropKeybind::ChangeKeyList( HWND hwndDlg){
 	i = 0;
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_SHIFT ) ){
 		i |= _SHIFT;
-		wcscat( szKeyState, L"Shift+" );
+		wcscat_literal( szKeyState, L"Shift+" );
 	}
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_CTRL ) ){
 		i |= _CTRL;
-		wcscat( szKeyState, L"Ctrl+" );
+		wcscat_literal( szKeyState, L"Ctrl+" );
 	}
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_ALT ) ){
 		i |= _ALT;
-		wcscat( szKeyState, L"Alt+" );
+		wcscat_literal( szKeyState, L"Alt+" );
 	}
 	/* キー一覧に文字列をセット（リストボックス）*/
 	List_ResetContent( hwndKeyList );

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -450,15 +450,15 @@ void CPropKeybind::ChangeKeyList( HWND hwndDlg){
 	i = 0;
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_SHIFT ) ){
 		i |= _SHIFT;
-		wcscat( szKeyState, L"Shift+" );
+		wcsncat_s( szKeyState, _countof(szKeyState), L"Shift+", 6 );
 	}
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_CTRL ) ){
 		i |= _CTRL;
-		wcscat( szKeyState, L"Ctrl+" );
+		wcsncat_s( szKeyState, _countof(szKeyState), L"Ctrl+", 5 );
 	}
 	if( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_ALT ) ){
 		i |= _ALT;
-		wcscat( szKeyState, L"Alt+" );
+		wcsncat_s( szKeyState, _countof(szKeyState), L"Alt+", 4 );
 	}
 	/* キー一覧に文字列をセット（リストボックス）*/
 	List_ResetContent( hwndKeyList );

--- a/sakura_core/prop/CPropComMacro.cpp
+++ b/sakura_core/prop/CPropComMacro.cpp
@@ -585,7 +585,7 @@ void CPropMacro::OnFileDropdown_Macro( HWND hwndDlg )
 		wcscpy( folder, path );
 		GetInidirOrExedir( path, folder );
 	}
-	wcscat( path, L"*.*" );	//	2002/05/01 YAZAKI どんなファイルもどんと来い。
+	wcsncat_s( path, _countof(path), L"*.*", 3 );	//	2002/05/01 YAZAKI どんなファイルもどんと来い。
 
 	//	候補の初期化
 	Combo_ResetContent( hCombo );

--- a/sakura_core/prop/CPropComMacro.cpp
+++ b/sakura_core/prop/CPropComMacro.cpp
@@ -585,7 +585,7 @@ void CPropMacro::OnFileDropdown_Macro( HWND hwndDlg )
 		wcscpy( folder, path );
 		GetInidirOrExedir( path, folder );
 	}
-	wcscat_literal( path, L"*.*" );	//	2002/05/01 YAZAKI どんなファイルもどんと来い。
+	wcscat( path, L"*.*" );	//	2002/05/01 YAZAKI どんなファイルもどんと来い。
 
 	//	候補の初期化
 	Combo_ResetContent( hCombo );

--- a/sakura_core/prop/CPropComMacro.cpp
+++ b/sakura_core/prop/CPropComMacro.cpp
@@ -585,7 +585,7 @@ void CPropMacro::OnFileDropdown_Macro( HWND hwndDlg )
 		wcscpy( folder, path );
 		GetInidirOrExedir( path, folder );
 	}
-	wcsncat_s( path, _countof(path), L"*.*", 3 );	//	2002/05/01 YAZAKI どんなファイルもどんと来い。
+	wcscat_literal( path, L"*.*" );	//	2002/05/01 YAZAKI どんなファイルもどんと来い。
 
 	//	候補の初期化
 	Combo_ResetContent( hCombo );

--- a/sakura_core/prop/CPropComMacro.cpp
+++ b/sakura_core/prop/CPropComMacro.cpp
@@ -585,7 +585,7 @@ void CPropMacro::OnFileDropdown_Macro( HWND hwndDlg )
 		wcscpy( folder, path );
 		GetInidirOrExedir( path, folder );
 	}
-	wcscat( path, L"*.*" );	//	2002/05/01 YAZAKI どんなファイルもどんと来い。
+	wcscat_literal( path, L"*.*" );	//	2002/05/01 YAZAKI どんなファイルもどんと来い。
 
 	//	候補の初期化
 	Combo_ResetContent( hCombo );

--- a/sakura_core/typeprop/CDlgTypeAscertain.cpp
+++ b/sakura_core/typeprop/CDlgTypeAscertain.cpp
@@ -137,7 +137,7 @@ void CDlgTypeAscertain::SetData( void )
 	WCHAR	sTrgCol[_MAX_PATH + 1];
 
 	::SplitPath_FolderAndFile( m_psi->sImportFile.c_str(), sTrgCol, NULL );
-	wcscat_literal( sTrgCol, L"\\*.col" );
+	wcscat( sTrgCol, L"\\*.col" );
 	for (bFind = ( ( hFind = FindFirstFile( sTrgCol, &wf ) ) != INVALID_HANDLE_VALUE );
 		bFind;
 		bFind = FindNextFile( hFind, &wf )) {

--- a/sakura_core/typeprop/CDlgTypeAscertain.cpp
+++ b/sakura_core/typeprop/CDlgTypeAscertain.cpp
@@ -137,7 +137,7 @@ void CDlgTypeAscertain::SetData( void )
 	WCHAR	sTrgCol[_MAX_PATH + 1];
 
 	::SplitPath_FolderAndFile( m_psi->sImportFile.c_str(), sTrgCol, NULL );
-	wcsncat_s( sTrgCol, _countof(sTrgCol), L"\\*.col", 6 );
+	wcscat_literal( sTrgCol, L"\\*.col" );
 	for (bFind = ( ( hFind = FindFirstFile( sTrgCol, &wf ) ) != INVALID_HANDLE_VALUE );
 		bFind;
 		bFind = FindNextFile( hFind, &wf )) {

--- a/sakura_core/typeprop/CDlgTypeAscertain.cpp
+++ b/sakura_core/typeprop/CDlgTypeAscertain.cpp
@@ -137,7 +137,7 @@ void CDlgTypeAscertain::SetData( void )
 	WCHAR	sTrgCol[_MAX_PATH + 1];
 
 	::SplitPath_FolderAndFile( m_psi->sImportFile.c_str(), sTrgCol, NULL );
-	wcscat( sTrgCol, L"\\*.col" );
+	wcscat_literal( sTrgCol, L"\\*.col" );
 	for (bFind = ( ( hFind = FindFirstFile( sTrgCol, &wf ) ) != INVALID_HANDLE_VALUE );
 		bFind;
 		bFind = FindNextFile( hFind, &wf )) {

--- a/sakura_core/typeprop/CDlgTypeAscertain.cpp
+++ b/sakura_core/typeprop/CDlgTypeAscertain.cpp
@@ -137,7 +137,7 @@ void CDlgTypeAscertain::SetData( void )
 	WCHAR	sTrgCol[_MAX_PATH + 1];
 
 	::SplitPath_FolderAndFile( m_psi->sImportFile.c_str(), sTrgCol, NULL );
-	wcscat( sTrgCol, L"\\*.col" );
+	wcsncat_s( sTrgCol, _countof(sTrgCol), L"\\*.col", 6 );
 	for (bFind = ( ( hFind = FindFirstFile( sTrgCol, &wf ) ) != INVALID_HANDLE_VALUE );
 		bFind;
 		bFind = FindNextFile( hFind, &wf )) {

--- a/sakura_core/typeprop/CImpExpManager.h
+++ b/sakura_core/typeprop/CImpExpManager.h
@@ -66,7 +66,7 @@ protected:
 		/* ファイルのフルパスをフォルダとファイル名に分割 */
 		/* [c:\work\test\aaa.txt] → [c:\work\test] + [aaa.txt] */
 		::SplitPath_FolderAndFile( szPath, GetDllShareData().m_sHistory.m_szIMPORTFOLDER, NULL );
-		wcscat( GetDllShareData().m_sHistory.m_szIMPORTFOLDER, L"\\" );
+		wcscat_literal( GetDllShareData().m_sHistory.m_szIMPORTFOLDER, L"\\" );
 	}
 
 	// デフォルト拡張子の取得(「*.txt」形式)

--- a/sakura_core/typeprop/CImpExpManager.h
+++ b/sakura_core/typeprop/CImpExpManager.h
@@ -66,7 +66,7 @@ protected:
 		/* ファイルのフルパスをフォルダとファイル名に分割 */
 		/* [c:\work\test\aaa.txt] → [c:\work\test] + [aaa.txt] */
 		::SplitPath_FolderAndFile( szPath, GetDllShareData().m_sHistory.m_szIMPORTFOLDER, NULL );
-		wcscat_literal( GetDllShareData().m_sHistory.m_szIMPORTFOLDER, L"\\" );
+		wcscat( GetDllShareData().m_sHistory.m_szIMPORTFOLDER, L"\\" );
 	}
 
 	// デフォルト拡張子の取得(「*.txt」形式)

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -601,7 +601,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							if( 0 < nLen && C_IsWordChar(szTemplateName[nLen - 1]) && szTemplateName[nLen - 1] != L':' && szWord[nWordIdx] != L':' ){
 								// template func<const x>() のような場合にconstの後ろにスペースを挿入
 								if( nLen + 1 < nItemNameLenMax ){
-									wcscat( szTemplateName, L" " );
+									wcscat_literal( szTemplateName, L" " );
 									nLen++;
 								}
 							}

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -601,7 +601,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							if( 0 < nLen && C_IsWordChar(szTemplateName[nLen - 1]) && szTemplateName[nLen - 1] != L':' && szWord[nWordIdx] != L':' ){
 								// template func<const x>() のような場合にconstの後ろにスペースを挿入
 								if( nLen + 1 < nItemNameLenMax ){
-									wcsncat_s( szTemplateName, _countof(szTemplateName), L" ", 1 );
+									wcscat_literal( szTemplateName, L" " );
 									nLen++;
 								}
 							}

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -601,7 +601,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							if( 0 < nLen && C_IsWordChar(szTemplateName[nLen - 1]) && szTemplateName[nLen - 1] != L':' && szWord[nWordIdx] != L':' ){
 								// template func<const x>() のような場合にconstの後ろにスペースを挿入
 								if( nLen + 1 < nItemNameLenMax ){
-									wcscat_literal( szTemplateName, L" " );
+									wcscat( szTemplateName, L" " );
 									nLen++;
 								}
 							}

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -601,7 +601,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							if( 0 < nLen && C_IsWordChar(szTemplateName[nLen - 1]) && szTemplateName[nLen - 1] != L':' && szWord[nWordIdx] != L':' ){
 								// template func<const x>() のような場合にconstの後ろにスペースを挿入
 								if( nLen + 1 < nItemNameLenMax ){
-									wcscat( szTemplateName, L" " );
+									wcsncat_s( szTemplateName, _countof(szTemplateName), L" ", 1 );
 									nLen++;
 								}
 							}

--- a/sakura_core/types/CType_Java.cpp
+++ b/sakura_core/types/CType_Java.cpp
@@ -155,7 +155,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 						nNestLevel2Arr.push_back( 0 );
 						++nClassNestArrNum;
 						if( 0 < nNestLevel	){
-							wcscat( szClass, L"\\" );
+							wcscat_literal( szClass, L"\\" );
 						}
 						wcscat( szClass, szWord );
 

--- a/sakura_core/types/CType_Java.cpp
+++ b/sakura_core/types/CType_Java.cpp
@@ -155,9 +155,9 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 						nNestLevel2Arr.push_back( 0 );
 						++nClassNestArrNum;
 						if( 0 < nNestLevel	){
-							wcscat( szClass, L"\\" );
+							wcsncat_s( szClass, _countof(szClass), L"\\", 1 );
 						}
-						wcscat( szClass, szWord );
+						wcsncat_s( szClass, _countof(szClass), szWord, _countof(szWord) - 1 );
 
 						nFuncId = FL_OBJ_DEFINITION;
 						++nFuncNum;

--- a/sakura_core/types/CType_Java.cpp
+++ b/sakura_core/types/CType_Java.cpp
@@ -155,7 +155,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 						nNestLevel2Arr.push_back( 0 );
 						++nClassNestArrNum;
 						if( 0 < nNestLevel	){
-							wcscat_literal( szClass, L"\\" );
+							wcscat( szClass, L"\\" );
 						}
 						wcscat( szClass, szWord );
 

--- a/sakura_core/types/CType_Java.cpp
+++ b/sakura_core/types/CType_Java.cpp
@@ -155,9 +155,9 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 						nNestLevel2Arr.push_back( 0 );
 						++nClassNestArrNum;
 						if( 0 < nNestLevel	){
-							wcsncat_s( szClass, _countof(szClass), L"\\", 1 );
+							wcscat_literal( szClass, L"\\" );
 						}
-						wcsncat_s( szClass, _countof(szClass), szWord, _countof(szWord) - 1 );
+						wcscat( szClass, szWord );
 
 						nFuncId = FL_OBJ_DEFINITION;
 						++nFuncNum;

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -245,5 +245,51 @@ inline int wcsncmp_auto(const wchar_t* strData1, const wchar_t* szData2)
 #define strncmp_literal(strData1, literalData2) \
 	::strncmp(strData1, literalData2, _countof(literalData2) - 1 ) //※終端ヌルを含めないので、_countofからマイナス1する
 
+template <typename T, size_t SourceSize>
+char *strcat_literal(T& strDest, const char (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	return strncat(strDest, strSource, SourceSize - 1);
+}
+
+template <size_t SourceSize>
+char *strcat_literal(char*& strDest, const char (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	return strncat(strDest, strSource, SourceSize - 1);
+}
+
+template <size_t DestSize, size_t SourceSize>
+char *strcat_literal(char (&strDest)[DestSize], const char (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	assert(strnlen_s(strDest, DestSize) + SourceSize <= DestSize);
+	strncat_s(strDest, strSource, SourceSize - 1);
+	return strDest;
+}
+
+template <typename T, size_t SourceSize>
+wchar_t *wcscat_literal(T& strDest, const wchar_t (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	return wcsncat(strDest, strSource, SourceSize - 1);
+}
+
+template <size_t SourceSize>
+wchar_t *wcscat_literal(wchar_t*& strDest, const wchar_t (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	return wcsncat(strDest, strSource, SourceSize - 1);
+}
+
+template <size_t DestSize, size_t SourceSize>
+wchar_t *wcscat_literal(wchar_t (&strDest)[DestSize], const wchar_t (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	assert(wcsnlen_s(strDest, DestSize) + SourceSize <= DestSize);
+	wcsncat_s(strDest, strSource, SourceSize - 1);
+	return strDest;
+}
+
 #endif /* SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -277,7 +277,7 @@ template <size_t DestSize, size_t SourceSize>
 inline char *strcat_literal(char (&strDest)[DestSize], const char (&strSource)[SourceSize])
 {
 	assert(strSource[SourceSize - 1] == 0);
-	assert(strnlen_s(strDest, DestSize) + SourceSize <= DestSize);
+	assert(strnlen(strDest, DestSize - 1) + SourceSize <= DestSize);
 	char* dst = strDest;
 	return strcat_literal(dst, strSource);
 }
@@ -310,7 +310,7 @@ template <size_t DestSize, size_t SourceSize>
 inline wchar_t *wcscat_literal(wchar_t (&strDest)[DestSize], const wchar_t (&strSource)[SourceSize])
 {
 	assert(strSource[SourceSize - 1] == 0);
-	assert(wcsnlen_s(strDest, DestSize) + SourceSize <= DestSize);
+	assert(wcsnlen(strDest, DestSize - 1) + SourceSize <= DestSize);
 	wchar_t* dst = strDest;
 	return wcscat_literal(dst, strSource);
 }

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -39,6 +39,10 @@
 	auto_～:  引数の型により、自動で処理が決定される版 (例: auto_strcpy)
 */
 
+#if defined(_M_X64) || defined(_M_IX86)
+#include <intrin.h>
+#endif
+
 #include "util/tchar_printf.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -264,7 +264,7 @@ char *strcat_literal(char (&strDest)[DestSize], const char (&strSource)[SourceSi
 {
 	assert(strSource[SourceSize - 1] == 0);
 	assert(strnlen_s(strDest, DestSize) + SourceSize <= DestSize);
-	strncat_s(strDest, strSource, SourceSize - 1);
+	strncat_s(strDest, DestSize, strSource, SourceSize - 1);
 	return strDest;
 }
 
@@ -287,7 +287,7 @@ wchar_t *wcscat_literal(wchar_t (&strDest)[DestSize], const wchar_t (&strSource)
 {
 	assert(strSource[SourceSize - 1] == 0);
 	assert(wcsnlen_s(strDest, DestSize) + SourceSize <= DestSize);
-	wcsncat_s(strDest, strSource, SourceSize - 1);
+	wcsncat_s(strDest, DestSize, strSource, SourceSize - 1);
 	return strDest;
 }
 

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -245,5 +245,51 @@ inline int wcsncmp_auto(const wchar_t* strData1, const wchar_t* szData2)
 #define strncmp_literal(strData1, literalData2) \
 	::strncmp(strData1, literalData2, _countof(literalData2) - 1 ) //※終端ヌルを含めないので、_countofからマイナス1する
 
+template <typename T, size_t SourceSize>
+char *strcat_literal(T& strDest, const char (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	return strncat(strDest, strSource, SourceSize - 1);
+}
+
+template <size_t SourceSize>
+char *strcat_literal(char*& strDest, const char (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	return strncat(strDest, strSource, SourceSize - 1);
+}
+
+template <size_t DestSize, size_t SourceSize>
+char *strcat_literal(char (&strDest)[DestSize], const char (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	assert(strnlen_s(strDest, DestSize) + SourceSize <= DestSize);
+	strncat_s(strDest, DestSize, strSource, SourceSize - 1);
+	return strDest;
+}
+
+template <typename T, size_t SourceSize>
+wchar_t *wcscat_literal(T& strDest, const wchar_t (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	return wcsncat(strDest, strSource, SourceSize - 1);
+}
+
+template <size_t SourceSize>
+wchar_t *wcscat_literal(wchar_t*& strDest, const wchar_t (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	return wcsncat(strDest, strSource, SourceSize - 1);
+}
+
+template <size_t DestSize, size_t SourceSize>
+wchar_t *wcscat_literal(wchar_t (&strDest)[DestSize], const wchar_t (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	assert(wcsnlen_s(strDest, DestSize) + SourceSize <= DestSize);
+	wcsncat_s(strDest, DestSize, strSource, SourceSize - 1);
+	return strDest;
+}
+
 #endif /* SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -245,51 +245,5 @@ inline int wcsncmp_auto(const wchar_t* strData1, const wchar_t* szData2)
 #define strncmp_literal(strData1, literalData2) \
 	::strncmp(strData1, literalData2, _countof(literalData2) - 1 ) //※終端ヌルを含めないので、_countofからマイナス1する
 
-template <typename T, size_t SourceSize>
-char *strcat_literal(T& strDest, const char (&strSource)[SourceSize])
-{
-	assert(strSource[SourceSize - 1] == 0);
-	return strncat(strDest, strSource, SourceSize - 1);
-}
-
-template <size_t SourceSize>
-char *strcat_literal(char*& strDest, const char (&strSource)[SourceSize])
-{
-	assert(strSource[SourceSize - 1] == 0);
-	return strncat(strDest, strSource, SourceSize - 1);
-}
-
-template <size_t DestSize, size_t SourceSize>
-char *strcat_literal(char (&strDest)[DestSize], const char (&strSource)[SourceSize])
-{
-	assert(strSource[SourceSize - 1] == 0);
-	assert(strnlen_s(strDest, DestSize) + SourceSize <= DestSize);
-	strncat_s(strDest, DestSize, strSource, SourceSize - 1);
-	return strDest;
-}
-
-template <typename T, size_t SourceSize>
-wchar_t *wcscat_literal(T& strDest, const wchar_t (&strSource)[SourceSize])
-{
-	assert(strSource[SourceSize - 1] == 0);
-	return wcsncat(strDest, strSource, SourceSize - 1);
-}
-
-template <size_t SourceSize>
-wchar_t *wcscat_literal(wchar_t*& strDest, const wchar_t (&strSource)[SourceSize])
-{
-	assert(strSource[SourceSize - 1] == 0);
-	return wcsncat(strDest, strSource, SourceSize - 1);
-}
-
-template <size_t DestSize, size_t SourceSize>
-wchar_t *wcscat_literal(wchar_t (&strDest)[DestSize], const wchar_t (&strSource)[SourceSize])
-{
-	assert(strSource[SourceSize - 1] == 0);
-	assert(wcsnlen_s(strDest, DestSize) + SourceSize <= DestSize);
-	wcsncat_s(strDest, DestSize, strSource, SourceSize - 1);
-	return strDest;
-}
-
 #endif /* SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -245,50 +245,70 @@ inline int wcsncmp_auto(const wchar_t* strData1, const wchar_t* szData2)
 #define strncmp_literal(strData1, literalData2) \
 	::strncmp(strData1, literalData2, _countof(literalData2) - 1 ) //※終端ヌルを含めないので、_countofからマイナス1する
 
-template <typename T, size_t SourceSize>
-char *strcat_literal(T& strDest, const char (&strSource)[SourceSize])
+template <size_t SourceSize>
+inline char *strcat_literal(char*& strDest, const char (&strSource)[SourceSize])
 {
 	assert(strSource[SourceSize - 1] == 0);
-	return strncat(strDest, strSource, SourceSize - 1);
+	char* dst = strDest;
+	// iterate to string terminator
+	while (*dst)
+		++dst;
+#if defined(_M_X64) || defined(_M_IX86)
+	__movsb((PBYTE)dst, (BYTE const*)strSource, SourceSize);
+#else
+	for (size_t i=0; i<SourceSize; ++i)
+		dst[i] = strSource[i];
+#endif
+	return strDest;
 }
 
-template <size_t SourceSize>
-char *strcat_literal(char*& strDest, const char (&strSource)[SourceSize])
+template <typename T, size_t SourceSize>
+inline char *strcat_literal(T& strDest, const char (&strSource)[SourceSize])
 {
-	assert(strSource[SourceSize - 1] == 0);
-	return strncat(strDest, strSource, SourceSize - 1);
+	char* dst = strDest;
+	return strcat_literal(dst, strSource);
 }
 
 template <size_t DestSize, size_t SourceSize>
-char *strcat_literal(char (&strDest)[DestSize], const char (&strSource)[SourceSize])
+inline char *strcat_literal(char (&strDest)[DestSize], const char (&strSource)[SourceSize])
 {
 	assert(strSource[SourceSize - 1] == 0);
 	assert(strnlen_s(strDest, DestSize) + SourceSize <= DestSize);
-	strncat_s(strDest, DestSize, strSource, SourceSize - 1);
+	char* dst = strDest;
+	return strcat_literal(dst, strSource);
+}
+
+template <size_t SourceSize>
+inline wchar_t *wcscat_literal(wchar_t*& strDest, const wchar_t (&strSource)[SourceSize])
+{
+	assert(strSource[SourceSize - 1] == 0);
+	wchar_t* dst = strDest;
+	// iterate to string terminator
+	while (*dst)
+		++dst;
+#if defined(_M_X64) || defined(_M_IX86)
+	__movsw((PWORD)dst, (WORD const*)strSource, SourceSize);
+#else
+	for (size_t i=0; i<SourceSize; ++i)
+		dst[i] = strSource[i];
+#endif
 	return strDest;
 }
 
 template <typename T, size_t SourceSize>
-wchar_t *wcscat_literal(T& strDest, const wchar_t (&strSource)[SourceSize])
+inline wchar_t *wcscat_literal(T& strDest, const wchar_t (&strSource)[SourceSize])
 {
-	assert(strSource[SourceSize - 1] == 0);
-	return wcsncat(strDest, strSource, SourceSize - 1);
-}
-
-template <size_t SourceSize>
-wchar_t *wcscat_literal(wchar_t*& strDest, const wchar_t (&strSource)[SourceSize])
-{
-	assert(strSource[SourceSize - 1] == 0);
-	return wcsncat(strDest, strSource, SourceSize - 1);
+	wchar_t* dst = strDest;
+	return wcscat_literal(dst, strSource);
 }
 
 template <size_t DestSize, size_t SourceSize>
-wchar_t *wcscat_literal(wchar_t (&strDest)[DestSize], const wchar_t (&strSource)[SourceSize])
+inline wchar_t *wcscat_literal(wchar_t (&strDest)[DestSize], const wchar_t (&strSource)[SourceSize])
 {
 	assert(strSource[SourceSize - 1] == 0);
 	assert(wcsnlen_s(strDest, DestSize) + SourceSize <= DestSize);
-	wcsncat_s(strDest, DestSize, strSource, SourceSize - 1);
-	return strDest;
+	wchar_t* dst = strDest;
+	return wcscat_literal(dst, strSource);
 }
 
 #endif /* SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_ */

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -150,11 +150,11 @@ void CEditView::ViewDiffInfo(
 	//オプションを作成する
 	WCHAR	szOption[16];	// "-cwbBt"
 	wcscpy( szOption, L"-" );
-	if( nFlgOpt & 0x0001 ) wcscat( szOption, L"i" );	//-i ignore-case         大文字小文字同一視
-	if( nFlgOpt & 0x0002 ) wcscat( szOption, L"w" );	//-w ignore-all-space    空白無視
-	if( nFlgOpt & 0x0004 ) wcscat( szOption, L"b" );	//-b ignore-space-change 空白変更無視
-	if( nFlgOpt & 0x0008 ) wcscat( szOption, L"B" );	//-B ignore-blank-lines  空行無視
-	if( nFlgOpt & 0x0010 ) wcscat( szOption, L"t" );	//-t expand-tabs         TAB-SPACE変換
+	if( nFlgOpt & 0x0001 ) wcscat_literal( szOption, L"i" );	//-i ignore-case         大文字小文字同一視
+	if( nFlgOpt & 0x0002 ) wcscat_literal( szOption, L"w" );	//-w ignore-all-space    空白無視
+	if( nFlgOpt & 0x0004 ) wcscat_literal( szOption, L"b" );	//-b ignore-space-change 空白変更無視
+	if( nFlgOpt & 0x0008 ) wcscat_literal( szOption, L"B" );	//-B ignore-blank-lines  空行無視
+	if( nFlgOpt & 0x0010 ) wcscat_literal( szOption, L"t" );	//-t expand-tabs         TAB-SPACE変換
 	if( wcscmp( szOption, L"-" ) == 0 ) szOption[0] = L'\0';	//オプションなし
 	if( nFlgOpt & 0x0020 ) nFlgFile12 = 0;
 	else                   nFlgFile12 = 1;

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -150,11 +150,11 @@ void CEditView::ViewDiffInfo(
 	//オプションを作成する
 	WCHAR	szOption[16];	// "-cwbBt"
 	wcscpy( szOption, L"-" );
-	if( nFlgOpt & 0x0001 ) wcsncat_s( szOption, _countof(szOption), L"i", 1 );	//-i ignore-case         大文字小文字同一視
-	if( nFlgOpt & 0x0002 ) wcsncat_s( szOption, _countof(szOption), L"w", 1 );	//-w ignore-all-space    空白無視
-	if( nFlgOpt & 0x0004 ) wcsncat_s( szOption, _countof(szOption), L"b", 1 );	//-b ignore-space-change 空白変更無視
-	if( nFlgOpt & 0x0008 ) wcsncat_s( szOption, _countof(szOption), L"B", 1 );	//-B ignore-blank-lines  空行無視
-	if( nFlgOpt & 0x0010 ) wcsncat_s( szOption, _countof(szOption), L"t", 1 );	//-t expand-tabs         TAB-SPACE変換
+	if( nFlgOpt & 0x0001 ) wcscat_literal( szOption, L"i" );	//-i ignore-case         大文字小文字同一視
+	if( nFlgOpt & 0x0002 ) wcscat_literal( szOption, L"w" );	//-w ignore-all-space    空白無視
+	if( nFlgOpt & 0x0004 ) wcscat_literal( szOption, L"b" );	//-b ignore-space-change 空白変更無視
+	if( nFlgOpt & 0x0008 ) wcscat_literal( szOption, L"B" );	//-B ignore-blank-lines  空行無視
+	if( nFlgOpt & 0x0010 ) wcscat_literal( szOption, L"t" );	//-t expand-tabs         TAB-SPACE変換
 	if( wcscmp( szOption, L"-" ) == 0 ) szOption[0] = L'\0';	//オプションなし
 	if( nFlgOpt & 0x0020 ) nFlgFile12 = 0;
 	else                   nFlgFile12 = 1;

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -150,11 +150,11 @@ void CEditView::ViewDiffInfo(
 	//オプションを作成する
 	WCHAR	szOption[16];	// "-cwbBt"
 	wcscpy( szOption, L"-" );
-	if( nFlgOpt & 0x0001 ) wcscat( szOption, L"i" );	//-i ignore-case         大文字小文字同一視
-	if( nFlgOpt & 0x0002 ) wcscat( szOption, L"w" );	//-w ignore-all-space    空白無視
-	if( nFlgOpt & 0x0004 ) wcscat( szOption, L"b" );	//-b ignore-space-change 空白変更無視
-	if( nFlgOpt & 0x0008 ) wcscat( szOption, L"B" );	//-B ignore-blank-lines  空行無視
-	if( nFlgOpt & 0x0010 ) wcscat( szOption, L"t" );	//-t expand-tabs         TAB-SPACE変換
+	if( nFlgOpt & 0x0001 ) wcsncat_s( szOption, _countof(szOption), L"i", 1 );	//-i ignore-case         大文字小文字同一視
+	if( nFlgOpt & 0x0002 ) wcsncat_s( szOption, _countof(szOption), L"w", 1 );	//-w ignore-all-space    空白無視
+	if( nFlgOpt & 0x0004 ) wcsncat_s( szOption, _countof(szOption), L"b", 1 );	//-b ignore-space-change 空白変更無視
+	if( nFlgOpt & 0x0008 ) wcsncat_s( szOption, _countof(szOption), L"B", 1 );	//-B ignore-blank-lines  空行無視
+	if( nFlgOpt & 0x0010 ) wcsncat_s( szOption, _countof(szOption), L"t", 1 );	//-t expand-tabs         TAB-SPACE変換
 	if( wcscmp( szOption, L"-" ) == 0 ) szOption[0] = L'\0';	//オプションなし
 	if( nFlgOpt & 0x0020 ) nFlgFile12 = 0;
 	else                   nFlgFile12 = 1;

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -150,11 +150,11 @@ void CEditView::ViewDiffInfo(
 	//オプションを作成する
 	WCHAR	szOption[16];	// "-cwbBt"
 	wcscpy( szOption, L"-" );
-	if( nFlgOpt & 0x0001 ) wcscat_literal( szOption, L"i" );	//-i ignore-case         大文字小文字同一視
-	if( nFlgOpt & 0x0002 ) wcscat_literal( szOption, L"w" );	//-w ignore-all-space    空白無視
-	if( nFlgOpt & 0x0004 ) wcscat_literal( szOption, L"b" );	//-b ignore-space-change 空白変更無視
-	if( nFlgOpt & 0x0008 ) wcscat_literal( szOption, L"B" );	//-B ignore-blank-lines  空行無視
-	if( nFlgOpt & 0x0010 ) wcscat_literal( szOption, L"t" );	//-t expand-tabs         TAB-SPACE変換
+	if( nFlgOpt & 0x0001 ) wcscat( szOption, L"i" );	//-i ignore-case         大文字小文字同一視
+	if( nFlgOpt & 0x0002 ) wcscat( szOption, L"w" );	//-w ignore-all-space    空白無視
+	if( nFlgOpt & 0x0004 ) wcscat( szOption, L"b" );	//-b ignore-space-change 空白変更無視
+	if( nFlgOpt & 0x0008 ) wcscat( szOption, L"B" );	//-B ignore-blank-lines  空行無視
+	if( nFlgOpt & 0x0010 ) wcscat( szOption, L"t" );	//-t expand-tabs         TAB-SPACE変換
 	if( wcscmp( szOption, L"-" ) == 0 ) szOption[0] = L'\0';	//オプションなし
 	if( nFlgOpt & 0x0020 ) nFlgFile12 = 0;
 	else                   nFlgFile12 = 1;

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -3858,7 +3858,7 @@ bool CEditWnd::GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIcon
 		_wsplitpath( szFile, NULL, NULL, NULL, szExt );
 		
 		if( ReadRegistry(HKEY_CLASSES_ROOT, szExt, NULL, FileType, _countof(FileType) - 13)){
-			wcsncat_s( FileType, _countof(FileType), L"\\DefaultIcon", 12 );
+			wcscat_literal( FileType, L"\\DefaultIcon" );
 			if( ReadRegistry(HKEY_CLASSES_ROOT, FileType, NULL, NULL, 0)){
 				// 関連づけられたアイコンを取得する
 				SHFILEINFO shfi;

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -3858,7 +3858,7 @@ bool CEditWnd::GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIcon
 		_wsplitpath( szFile, NULL, NULL, NULL, szExt );
 		
 		if( ReadRegistry(HKEY_CLASSES_ROOT, szExt, NULL, FileType, _countof(FileType) - 13)){
-			wcscat_literal( FileType, L"\\DefaultIcon" );
+			wcscat( FileType, L"\\DefaultIcon" );
 			if( ReadRegistry(HKEY_CLASSES_ROOT, FileType, NULL, NULL, 0)){
 				// 関連づけられたアイコンを取得する
 				SHFILEINFO shfi;

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -3858,7 +3858,7 @@ bool CEditWnd::GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIcon
 		_wsplitpath( szFile, NULL, NULL, NULL, szExt );
 		
 		if( ReadRegistry(HKEY_CLASSES_ROOT, szExt, NULL, FileType, _countof(FileType) - 13)){
-			wcscat( FileType, L"\\DefaultIcon" );
+			wcscat_literal( FileType, L"\\DefaultIcon" );
 			if( ReadRegistry(HKEY_CLASSES_ROOT, FileType, NULL, NULL, 0)){
 				// 関連づけられたアイコンを取得する
 				SHFILEINFO shfi;

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -3858,7 +3858,7 @@ bool CEditWnd::GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIcon
 		_wsplitpath( szFile, NULL, NULL, NULL, szExt );
 		
 		if( ReadRegistry(HKEY_CLASSES_ROOT, szExt, NULL, FileType, _countof(FileType) - 13)){
-			wcscat( FileType, L"\\DefaultIcon" );
+			wcsncat_s( FileType, _countof(FileType), L"\\DefaultIcon", 12 );
 			if( ReadRegistry(HKEY_CLASSES_ROOT, FileType, NULL, NULL, 0)){
 				// 関連づけられたアイコンを取得する
 				SHFILEINFO shfi;


### PR DESCRIPTION
# PR の目的

文字列追加を行う `wcscat` 関数の第2引数に文字列リテラルを指定している箇所を、テンプレート関数 `wcscat_literal` への呼び出しに変更しました。

## カテゴリ

- リファクタリング

## PR の背景

#1042 で文字列の追加処理についてもリテラル文字列を使う個所について対応をしたところ、まとめて対応をするのは良くないという感じのコメントを頂いたので、別PRにしました。

## PR のメリット

`wcscat` 関数に比べて処理が速くなっていると考えます。

- `wcscat` 関数ではソース文字列の終端文字列の位置を調べる処理が走りますが、`wcscat_literal` 関数の実装では調べないのでその分処理内容が減ります。リテラル文字列前提なので調べる必要が無いと判断しました。
- x86/x86_64 向けのビルドの場合には intrinsics 関数 `__movsb` や `__movsw` を使いました。
  - コピーするリテラル文字列の長さはかなり短いので高速化はほぼ無いと思います。むしろマイクロコード実行の分微妙に速度が低下するかも？コードサイズを減らせる利点はあります。詳しくは[ここ](https://stackoverflow.com/questions/43343231/enhanced-rep-movsb-for-memcpy)に書かれてます。
  
- 関数に inline 指定を付けて呼び出し元にコードが展開されるようにして実行される命令数を減らしました。コードサイズが膨らむ懸念が生じますが、実際に確認してみると `wcscat_literal` 関数をインライン化しても呼び出し元の命令数が 3 から 9 に増加したぐらいなので大きな問題にならないと思います。


## PR のデメリット (トレードオフとかあれば)

関数名が長いので記述が冗長になります。

## 関連チケット

#1042 
