### PR TITLE
デバッグにVC++のCランタイム機能を活用する

### DIFF
--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -111,9 +111,9 @@ int WINAPI wWinMain(
 	::OleUninitialize();	// 2009.01.07 ryoji 追加
 
 	// メモリリークチェック検証コード
-	auto leakCheck1 = DBG_NEW RECT;
-	auto leakCheck2 = DBG_NEW std::wstring(L"test");
-	auto leakCheck3 = DBG_NEW char[MAX_PATH];
+	auto leakCheck1 = new RECT;
+	auto leakCheck2 = new std::wstring(L"test");
+	auto leakCheck3 = new char[MAX_PATH];
 
 	return 0;
 }

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -111,9 +111,9 @@ int WINAPI wWinMain(
 	::OleUninitialize();	// 2009.01.07 ryoji 追加
 
 	// メモリリークチェック検証コード
-	auto leakCheck1 = new RECT;
-	auto leakCheck2 = new std::wstring(L"test");
-	auto leakCheck3 = new char[MAX_PATH];
+	auto leakCheck1 = DBG_NEW RECT;
+	auto leakCheck2 = DBG_NEW std::wstring(L"test");
+	auto leakCheck3 = DBG_NEW char[MAX_PATH];
 
 	return 0;
 }

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -109,6 +109,12 @@ int WINAPI wWinMain(
 	}
 
 	::OleUninitialize();	// 2009.01.07 ryoji 追加
+
+	// メモリリークチェック検証コード
+	auto leakCheck1 = new RECT;
+	auto leakCheck2 = new std::wstring(L"test");
+	auto leakCheck3 = new char[MAX_PATH];
+
 	return 0;
 }
 

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -109,12 +109,6 @@ int WINAPI wWinMain(
 	}
 
 	::OleUninitialize();	// 2009.01.07 ryoji 追加
-
-	// メモリリークチェック検証コード
-	auto leakCheck1 = new RECT;
-	auto leakCheck2 = new std::wstring(L"test");
-	auto leakCheck3 = new char[MAX_PATH];
-
 	return 0;
 }
 

--- a/sakura_core/config/build_config.cpp
+++ b/sakura_core/config/build_config.cpp
@@ -6,13 +6,17 @@
 //デバッグ検証用：newされた領域をわざと汚す。2007.11.27 kobake
 #ifdef FILL_STRANGE_IN_NEW_MEMORY
 
-inline void _fill_new_memory(void* p, size_t nSize, const char* pSrc, size_t nSrcLen)
+template <size_t srcCount>
+inline void _fill_new_memory(void* ptr, size_t size, const char(&src)[srcCount])
 {
-	char* s = (char*)p;
-	size_t i;
-	for (i = 0; i < nSize; i++)
+	const size_t srcLength = srcCount - 1;
+	size_t rest = size;
+	for (auto dst = reinterpret_cast<char*>(ptr); rest;)
 	{
-		*s++ = pSrc[i%nSrcLen];
+		auto unit = std::min(srcLength, rest);
+		memcpy_s(dst, rest, src, unit);
+		dst += unit;
+		rest -= unit;
 	}
 }
 
@@ -24,7 +28,7 @@ void* operator new(
 	)
 {
 	auto p = _malloc_dbg(size, block_use, file_name, line_number);
-	_fill_new_memory(p, size, "n_e_w_!_", 8); //確保されたばかりのメモリ状態は「n_e_w_!_....」となります
+	_fill_new_memory(p, size, "n_e_w_!_"); //確保されたばかりのメモリ状態は「n_e_w_!_....」となります
 	return p;
 }
 
@@ -35,7 +39,7 @@ void* operator new[](size_t const size,
 	)
 {
 	auto p = operator new(size, block_use, file_name, line_number);
-	_fill_new_memory(p, size, "N_E_W_!_", 8); //確保されたばかりのメモリ状態は「N_E_W_!_N_E_W_!_N_E_W_!_....」となります
+	_fill_new_memory(p, size, "N_E_W_!_"); //確保されたばかりのメモリ状態は「N_E_W_!_N_E_W_!_N_E_W_!_....」となります
 	return p;
 }
 #endif

--- a/sakura_core/config/build_config.cpp
+++ b/sakura_core/config/build_config.cpp
@@ -16,32 +16,26 @@ inline void _fill_new_memory(void* p, size_t nSize, const char* pSrc, size_t nSr
 	}
 }
 
-void* operator new(size_t nSize)
+void* operator new(
+	size_t const size,
+	int const    block_use,
+	char const*  file_name,
+	int const    line_number
+	)
 {
-	void* p = ::malloc(nSize);
-	_fill_new_memory(p, nSize, "n_e_w_!_", 8); //確保されたばかりのメモリ状態は「n_e_w_!_....」となります
+	auto p = _malloc_dbg(size, block_use, file_name, line_number);
+	_fill_new_memory(p, size, "n_e_w_!_", 8); //確保されたばかりのメモリ状態は「n_e_w_!_....」となります
 	return p;
 }
 
-#ifdef _MSC_VER
-_Ret_bytecap_(nSize)
-#endif
-
-void* operator new[](size_t nSize)
+void* operator new[](size_t const size,
+	int const    block_use,
+	char const*  file_name,
+	int const    line_number
+	)
 {
-	void* p = ::malloc(nSize);
-	_fill_new_memory(p, nSize, "N_E_W_!_", 8); //確保されたばかりのメモリ状態は「N_E_W_!_N_E_W_!_N_E_W_!_....」となります
+	auto p = operator new(size, block_use, file_name, line_number);
+	_fill_new_memory(p, size, "N_E_W_!_", 8); //確保されたばかりのメモリ状態は「N_E_W_!_N_E_W_!_N_E_W_!_....」となります
 	return p;
 }
-
-void operator delete(void* p) noexcept
-{
-	::free(p);
-}
-
-void operator delete[](void* p) noexcept
-{
-	::free(p);
-}
-
 #endif

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -59,12 +59,12 @@ static const bool UNICODE_BOOL=true;
 //#define USE_DEBUGMON
 
 //newされた領域をわざと汚すかどうか (デバッグ用)
-#ifdef _DEBUG
+#if defined(_MSC_VER) &&  defined(_DEBUG)
 #define FILL_STRANGE_IN_NEW_MEMORY
 #endif
 
 //crtdbg.hによるメモリーリークチェックを使うかどうか (デバッグ用)
-#ifdef _DEBUG
+#if defined(_MSC_VER) &&  defined(_DEBUG)
 #define USE_LEAK_CHECK_WITH_CRTDBG
 #endif
 
@@ -77,13 +77,17 @@ static const bool UNICODE_BOOL=true;
 
 //デバッグ検証用：newされた領域をわざと汚す。2007.11.27 kobake
 #ifdef FILL_STRANGE_IN_NEW_MEMORY
-	void* operator new(size_t nSize);
-	#ifdef _MSC_VER
-		_Ret_bytecap_(nSize)
-	#endif
-	void* operator new[](size_t nSize);
-	void operator delete(void* p) noexcept;
-	void operator delete[](void* p) noexcept;
+	void* operator new(
+		size_t const size,
+		int const    block_use,
+		char const*  file_name,
+		int const    line_number
+		);
+	void* operator new[](size_t const size,
+		int const    block_use,
+		char const*  file_name,
+		int const    line_number
+		);
 #endif
 
 //crtdbg.hによるメモリーリークチェックを使うかどうか (デバッグ用)

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -88,16 +88,20 @@ static const bool UNICODE_BOOL=true;
 
 //crtdbg.hによるメモリーリークチェックを使うかどうか (デバッグ用)
 #ifdef USE_LEAK_CHECK_WITH_CRTDBG
-	//new演算子をオーバーライドするヘッダはcrtdbg.hの前にincludeしないとコンパイルエラーとなる	
-	//参考：http://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=99818
-	#include <xiosbase>
-	#include <xlocale>
-	#include <xmemory>
-	#include <xtree>
-
+	//Cランタイムの機能を使ってメモリリークを検出する
+	//  メモリリークチェックの結果出力を得るには
+	//    wWinMainの最後で_CrtDumpMemoryLeaks()を呼び出すか
+	//    wWinMainの最初で_CrtSetDbgFlag()を呼び出す必要がある。
+	//see https://docs.microsoft.com/en-us/visualstudio/debugger/finding-memory-leaks-using-the-crt-library
+	#define _CRTDBG_MAP_ALLOC
+	#include <stdlib.h>
 	#include <crtdbg.h>
-	#define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
-	//それと、WinMainの先頭で _CrtSetDbgFlag() を呼ぶ.
+
+    #define DBG_NEW new ( _NORMAL_BLOCK , __FILE__ , __LINE__ )
+    // Replace _NORMAL_BLOCK with _CLIENT_BLOCK if you want the
+    // allocations to be of _CLIENT_BLOCK type
+#else
+    #define DBG_NEW new
 #endif
 
 #if _WIN64

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -65,7 +65,7 @@ static const bool UNICODE_BOOL=true;
 
 //crtdbg.hによるメモリーリークチェックを使うかどうか (デバッグ用)
 #ifdef _DEBUG
-//#define USE_LEAK_CHECK_WITH_CRTDBG
+#define USE_LEAK_CHECK_WITH_CRTDBG
 #endif
 
 // -- -- 仕様変更 -- -- //
@@ -96,7 +96,6 @@ static const bool UNICODE_BOOL=true;
 	#include <xtree>
 
 	#include <crtdbg.h>
-	#define new DEBUG_NEW
 	#define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
 	//それと、WinMainの先頭で _CrtSetDbgFlag() を呼ぶ.
 #endif


### PR DESCRIPTION
# PR の目的

デバッグにVC++のCランタイム機能を活用することにより、
ビルドの問題を解消すると共にデバッグ実装をシンプルにします。


## カテゴリ

- 仕様変更


## PR の背景

言葉で全貌を説明すると少しややこしいので、やってることを書きます。
#1045 のUSE_LEAK_CHECK_WITH_CRTDBGがビルドエラーになる件の対策PRとして作り始めました。

----
#1045 の解消方法自体は単純でした。( https://github.com/sakura-editor/sakura/commit/293493c118b67732859e248fed13838c7a18ade4 )

https://github.com/sakura-editor/sakura/issues/1045#issuecomment-532708550 で書いている通り、ビルドエラーの原因はこの部分です。
https://github.com/sakura-editor/sakura/blob/8b1f784c67c14d56f19411e690a6905181039e6f/sakura_core/config/build_config.h#L98-L100

ここで new ⇒ DEBUG_NEW とマクロ定義しているのを解除すれば、ビルドは通るようになります。
メモリリークを検出することだけを目的とするなら、この対応で十分です。

----
「十分です。」といっても、メモリリークチェックがどう動くものか知らん人が大半だと思います。

そこで、せっかくなので実際にメモリリークするコードを書いて、メモリリークチェックが正しく機能しているかどうか検証してみました。( https://github.com/sakura-editor/sakura/commit/9ac48d75eb487af8a9411ea23a1eae479f12da12 )

この修正によるメモリリークの検出結果はこんな感じになりました。
```
Detected memory leaks!
Dumping objects ->
{245222} normal block at 0x00B6DAE0, 260 bytes long.
 Data: <N_E_W_!_N_E_W_!_> 4E 5F 45 5F 57 5F 21 5F 4E 5F 45 5F 57 5F 21 5F 
{245221} normal block at 0x01A0EE40, 8 bytes long.
 Data: < D      > E8 44 9F 01 00 00 00 00 
{245220} normal block at 0x019F44E8, 28 bytes long.
 Data: <@   t e s t   !_> 40 EE A0 01 74 00 65 00 73 00 74 00 00 00 21 5F 
{245219} normal block at 0x00B98F08, 16 bytes long.
 Data: <n_e_w_!_n_e_w_!_> 6E 5F 65 5F 77 5F 21 5F 6E 5F 65 5F 77 5F 21 5F 
Object dump complete.
```

この出力内容ではソースコードのどこに問題があるかわかりませんが、ちゃんと検出できてますね :smile:

ソースコードの行番号が出てない理由は、`DEBUG_NEW` マクロを使ってないからなんですが、とりあえず、 **マクロを使わなくてもメモリリークの検出自体はできる** の検証材料にはなると思います。

----
ソースコード中の参考リンクがDeadLinkになってることから想像するに、
修正前のメモリリークの検出方式はだいぶ古い情報に基づくものです。
https://github.com/sakura-editor/sakura/blob/7471046db5f3a8294a99a849a43fc4d796ff07ff/sakura_core/config/build_config.h#L89-L92

せっかくの機会なので、最新のドキュメントに基づいた検出方式にアップデートしてみました。( https://github.com/sakura-editor/sakura/commit/6adb54d4007a10f3659ae32349b8fed72abc90c6 )

この修正によるメモリリークの検出結果はこんな感じになりました。
```
Detected memory leaks!
Dumping objects ->
C:\work\sakura\sakura_core\config\build_config.cpp(32) : {245222} normal block at 0x01AC6E18, 260 bytes long.
 Data: <N_E_W_!_N_E_W_!_> 4E 5F 45 5F 57 5F 21 5F 4E 5F 45 5F 57 5F 21 5F 
C:\work\sakura\sakura_core\config\build_config.cpp(21) : {245221} normal block at 0x03A8EF60, 8 bytes long.
 Data: <        > 18 D8 B9 01 00 00 00 00 
C:\work\sakura\sakura_core\config\build_config.cpp(21) : {245220} normal block at 0x01B9D818, 28 bytes long.
 Data: <`   t e s t   !_> 60 EF A8 03 74 00 65 00 73 00 74 00 00 00 21 5F 
C:\work\sakura\sakura_core\config\build_config.cpp(21) : {245219} normal block at 0x03A5E938, 16 bytes long.
 Data: <n_e_w_!_n_e_w_!_> 6E 5F 65 5F 77 5F 21 5F 6E 5F 65 5F 77 5F 21 5F 
Object dump complete.
```

デバッグ用マクロの名前が DEBUG_NEW ⇒ DBG_NEW になりました。
まだ DBG_NEW を使っていませんが、メモリ確保を行った行番号が出力されるようになっています。
これが最新の方法 _CRTDBG_MAP_ALLOC を使うメリットです。

ただ、この行番号って、mallocを記述した行番号だからあんまし意味ないですよね :cry:

----
普通に考えて、せっかく行番号を出すなら正しい行番号が出てくれたほうがよいです。
検証コードの new を DBG_NEW に書き換えて、正しい行番号を出力できるかチェックしてみました。( https://github.com/sakura-editor/sakura/commit/c9dbcc774a46c5c2b582c09ae5aa966096e6bfcd )

この修正によるメモリリークの検出結果はこんな感じになりました。
```
Detected memory leaks!
Dumping objects ->
C:\work\sakura\sakura_core\_main\WinMain.cpp(116) : {245222} normal block at 0x009A6F68, 260 bytes long.
 Data: <                > CD CD CD CD CD CD CD CD CD CD CD CD CD CD CD CD 
C:\work\sakura\sakura_core\config\build_config.cpp(21) : {245221} normal block at 0x0325EDC8, 8 bytes long.
 Data: < q      > B0 71 90 00 00 00 00 00 
C:\work\sakura\sakura_core\_main\WinMain.cpp(115) : {245220} normal block at 0x009071B0, 28 bytes long.
 Data: <  % t e s t     > C8 ED 25 03 74 00 65 00 73 00 74 00 00 00 CD CD 
C:\work\sakura\sakura_core\_main\WinMain.cpp(114) : {245219} normal block at 0x0325D618, 16 bytes long.
 Data: <                > CD CD CD CD CD CD CD CD CD CD CD CD CD CD CD CD 
Object dump complete.
```

デバッグ用マクロ DBG_NEW を使ったことにより、実際にメモリ確保を行った検証コードの行番号が出力されるようになっています。

ただ、これも「問題アリ」です。
ダンプデータの内容が CDCDCDCD になっています。
@kobake さん [肝煎り](https://nihongo.koakishiki.com/kanji/question-31.html
) の `n_e_w_!n_e_w_!n_e_w_!` の仕様が吹っ飛んでいます。

----
メモリを汚せなくなった原因は、カスタムnewの実装がMSVCのデバッグ版newと異なっているからです。単純にシグニチャを合わせることで、この問題を解決できます。個人的には `n_e_w_!n_e_w_!n_e_w_!` の仕様の必要性には疑問を持っているんですが、対処を入れてみました。( https://github.com/sakura-editor/sakura/commit/24641efd53b8717ef40f69c46ea9922f55b8af97 )

この修正によるメモリリークの検出結果はこんな感じになりました。
```
Detected memory leaks!
Dumping objects ->
C:\work\sakura\sakura_core\_main\WinMain.cpp(116) : {245222} normal block at 0x03531218, 260 bytes long.
 Data: <N_E_W_!_N_E_W_!_> 4E 5F 45 5F 57 5F 21 5F 4E 5F 45 5F 57 5F 21 5F 
{245221} normal block at 0x03520F40, 8 bytes long.
 Data: <  S     > 80 AF 53 03 00 00 00 00 
C:\work\sakura\sakura_core\_main\WinMain.cpp(115) : {245220} normal block at 0x0353AF80, 28 bytes long.
 Data: <@ R t e s t   !_> 40 0F 52 03 74 00 65 00 73 00 74 00 00 00 21 5F 
C:\work\sakura\sakura_core\_main\WinMain.cpp(114) : {245219} normal block at 0x0158CF58, 16 bytes long.
 Data: <n_e_w_!_n_e_w_!_> 6E 5F 65 5F 77 5F 21 5F 6E 5F 65 5F 77 5F 21 5F 
Object dump complete.
```

ここまでで当初の目的は果たせたと思っています。

----

あとのコミットは、リテラル文字列関連の微修正と検証コードの除去をしているだけです。



## PR のメリット

- デバッグ時のメモリリークチェックが機能するようになります。


## PR のデメリット (トレードオフとかあれば)

- とくにありません。



## PR の影響範囲

- デバッグ版ビルドでメモリリークチェックが使えるようになります。
- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット

close #1046 DEBUGのUSE_LEAK_CHECK_WITH_CRTDBGを有効にしたい
#1045 DEBUGのUSE_LEAK_CHECK_WITH_CRTDBGを有効にするとコンパイルエラー
#381 new/deleteのオーバーロードがGCCに怒られる対応
#51 ビルド時警告の削減：operator new/delete 部分
#48 ビルド時警告の削減
#36 プロジェクトファイルをsakura配下に集めませんか？の実装案

## 参考資料

https://docs.microsoft.com/en-us/visualstudio/debugger/finding-memory-leaks-using-the-crt-library
