### PR TITLE
レイアウト処理の負荷を下げる為、コメントが色分け表示対象外になる機会を増やす

### DIFF
--- a/sakura_core/doc/CLineComment.h
+++ b/sakura_core/doc/CLineComment.h
@@ -38,7 +38,7 @@ public:
 	void CopyTo( const int n, const wchar_t* buffer, int nCommentPos );	//	行コメントデリミタをコピーする
 	bool Match( int nPos, const CStringRef& cStr ) const;	//	行コメントに値するか確認する
 
-	const wchar_t* getLineComment( const int n ){
+	const wchar_t* getLineComment( const int n ) const{
 		return m_pszLineComment[n];
 	}
 	int getLineCommentPos( const int n ) const {

--- a/sakura_core/view/colors/CColor_Comment.h
+++ b/sakura_core/view/colors/CColor_Comment.h
@@ -44,7 +44,7 @@ public:
 		// 行型コメントの始点記号が入力されているか
 		auto& lineComment = m_pTypeData->m_cLineComment;
 		for (int i = 0; i < COMMENT_DELIMITER_NUM; ++i) {
-			if (wcslen(lineComment.getLineComment(i)))
+			if (lineComment.getLineComment(i)[0])
 				return true;
 		}
 		return false;
@@ -73,7 +73,7 @@ public:
 		if (!m_pTypeData->m_ColorInfoArr[COLORIDX_COMMENT].m_bDisp)
 			return false;
 		// ブロック型の始点・終端記号が入力されているか
-		return m_pcBlockComment->getBlockFromLen() > 0 && m_pcBlockComment->getBlockToLen();
+		return m_pcBlockComment->getBlockFromLen() > 0 && m_pcBlockComment->getBlockToLen() > 0;
 	}
 private:
 	EColorIndexType m_nType;

--- a/sakura_core/view/colors/CColor_Comment.h
+++ b/sakura_core/view/colors/CColor_Comment.h
@@ -37,7 +37,18 @@ public:
 	virtual void InitStrategyStatus(){}
 	virtual bool BeginColor(const CStringRef& cStr, int nPos);
 	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return m_pTypeData->m_ColorInfoArr[COLORIDX_COMMENT].m_bDisp; }
+	virtual bool Disp() const {
+		// タイプ別設定 『カラー』プロパティのコメントのリストアイテムのチェックが付いているか
+		if (!m_pTypeData->m_ColorInfoArr[COLORIDX_COMMENT].m_bDisp)
+			return false;
+		// 行型コメントの始点記号が入力されているか
+		auto& lineComment = m_pTypeData->m_cLineComment;
+		for (int i = 0; i < COMMENT_DELIMITER_NUM; ++i) {
+			if (wcslen(lineComment.getLineComment(i)))
+				return true;
+		}
+		return false;
+	}
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -57,7 +68,13 @@ public:
 	virtual void InitStrategyStatus(){ m_nCOMMENTEND = 0; }
 	virtual bool BeginColor(const CStringRef& cStr, int nPos);
 	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return m_pTypeData->m_ColorInfoArr[COLORIDX_COMMENT].m_bDisp; }
+	virtual bool Disp() const {
+		// タイプ別設定 『カラー』プロパティのコメントのリストアイテムのチェックが付いているか
+		if (!m_pTypeData->m_ColorInfoArr[COLORIDX_COMMENT].m_bDisp)
+			return false;
+		// ブロック型の始点・終端記号が入力されているか
+		return m_pcBlockComment->getBlockFromLen() > 0 && m_pcBlockComment->getBlockToLen();
+	}
 private:
 	EColorIndexType m_nType;
 	const CBlockComment* m_pcBlockComment;


### PR DESCRIPTION
## PR の目的

コメントが色分け表示対象外になる機会を増やす事でレイアウト処理の負荷を減らすのが目的です。

## カテゴリ

- 速度向上

## PR の背景

`CColor_LineComment::Disp` と `CColor_BlockComment::Disp` メソッドの実装を更新して、タイプ別設定 『カラー』プロパティのコメントのリストアイテムのチェックが付いていても始点・終端記号が入力されていない場合は false を返すようにしました。

リストアイテムのチェックはデフォルト設定では付いているので、従来はコメントの始点・終端記号が空の場合でも true が返されていました。

`CColorStrategyPool::OnChangeSetting` で `Disp` メソッドが false を返すと 色分け表示対象外になり
`CColorStrategyPool::CheckColorMODE` において色開始処理が呼ばれない為にレイアウト処理の負荷が軽くなります。

## PR のメリット

従来に比べてレイアウト処理の負荷が下がる機会が増えます。

## PR のデメリット (トレードオフとかあれば)

Disp メソッドの実装がやや複雑になります。コメントを書く事で対策しました。

タイプ別設定 『カラー』プロパティのコメントのリストアイテムのチェックを既に外している場合はそれから比べて処理負荷の低減がされません。またタイプ別設定によってはコメントを有効にして使うと思うのでその場合も処理負荷の低減がされません。

かなり大きい文書を扱っている時でないとレイアウト処理から呼び出される `CColorStrategyPool::CheckColorMODE` の処理時間が体感出来るほどに膨らむことは無いかもしれません。

## PR の影響範囲

`CColorStrategyPool` クラス
