### PR TITLE
VC++の規格準拠モードをONにする

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -105,6 +105,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -148,6 +149,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -188,6 +190,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -228,6 +231,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -1562,7 +1562,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 				nDataLen = CLogicInt(m);
 			}
 
-			nCharChars = (m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_bInsSpace)? (Int)m_pcEditDoc->m_cLayoutMgr.GetTabSpaceKetas(): 1;
+			nCharChars = (m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_bInsSpace)? (Int)m_pcEditDoc->m_cLayoutMgr.GetTabSpaceKetas(): Int(1);
 			pszData = new wchar_t[nDataLen + nCharChars + 1];
 			wmemcpy( pszData, pLine2, nDataLen );
 			if( WCODE::CR  == wcChar || L'{' == wcChar || L'(' == wcChar ){

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -191,7 +191,7 @@ void CTextDrawer::DispVerticalLines(
 	const int nPosXLeft   = t_max(pView->GetTextMetrics().GetCharPxWidth(pView->GetTextArea().GetAreaLeft() + (nLeftCol  - nViewLeftCol)), pView->GetTextArea().GetAreaLeft() );
 	const int nPosXRight  = t_min(pView->GetTextMetrics().GetCharPxWidth(pView->GetTextArea().GetAreaLeft() + (nRightCol - nViewLeftCol)), pView->GetTextArea().GetAreaRight() );
 	const int nLineHeight = pView->GetTextMetrics().GetHankakuDy();
-	bool bOddLine = ((((nLineHeight % 2) ? (Int)pView->GetTextArea().GetViewTopLine() : 0) + pView->GetTextArea().GetAreaTop() + nTop) % 2 == 1);
+	bool bOddLine = ((((nLineHeight % 2) ? (Int)pView->GetTextArea().GetViewTopLine() : Int(0)) + pView->GetTextArea().GetAreaTop() + nTop) % 2 == 1);
 
 	// 太線
 	const bool bBold = cVertType.IsBoldFont();


### PR DESCRIPTION
# PR の目的

VC++のC++規格準拠モードをONにすることにより、
今後、コードベースに変なコードが混入するリスクを軽減します。

同時に、現状でC++規格に準拠できていないコードに対策を入れます。


## カテゴリ

- リファクタリング


## PR の背景

issue #872 「開発環境(Visual Studio)の機能をもっと活用するためにコード改善を行いたい」の残課題です。

残課題として残っていた理由は `/permissive-` を利用するためには、やっかいな課題をいくつかクリアしないといけなかったからです。

#1044 の対応で、 `/permissive-` を使うための前提条件「けっこう新しいWindows 10 SDKを使う」が解決できたので、投入を試みることにしました。

で、やってみたらビルドエラーが出たので過去の検証で作った暫定対処コードをくっつけて、ビルド可能な状態にしてPRとしました。


## PR のメリット

- コードベースに変なコードが混入するリスクを軽減できます。


## PR のデメリット (トレードオフとかあれば)

- とくにありません。



## PR の影響範囲

- C++規格に準拠しないコードをビルドエラーになります。
- アプリ(=サクラエディタ)の機能に影響はありません。

## 関連チケット

#1044 プロジェクトのビルドにWindows10 SDKを使う
close #872 開発環境(Visual Studio)の機能をもっと活用するためにコード改善を行いたい


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
