### PR TITLE
ファイル保存の副次処理調整

### DIFF
--- a/sakura_core/CSaveAgent.cpp
+++ b/sakura_core/CSaveAgent.cpp
@@ -138,7 +138,11 @@ void CSaveAgent::OnAfterSave(const SSaveInfo& sSaveInfo)
 	// 上書き（明示的な上書きや自動保存）では変更しない
 	// ---> 上書きの場合は一時的な折り返し桁変更やタブ幅変更を維持したままにする
 	if(!sSaveInfo.bOverwriteMode){
-		pcDoc->OnChangeSetting();
+		// 文書種別が変更になった場合にのみ設定変更を反映させる
+		int prevIndex = pcDoc->m_cDocType.GetDocumentType().GetIndex();
+		int newIndex = CDocTypeManager().GetDocumentTypeOfPath( sSaveInfo.cFilePath ).GetIndex();
+		if(newIndex != prevIndex)
+			pcDoc->OnChangeSetting();
 	}
 }
 

--- a/sakura_core/CWriteManager.cpp
+++ b/sakura_core/CWriteManager.cpp
@@ -85,11 +85,16 @@ EConvertResult CWriteManager::WriteFile_From_CDocLineMgr(
 			}
 		}
 		CMemory cmemOutputBuffer;
+		constexpr DWORD userInterfaceInterval = 33;
+		DWORD prevTime = GetTickCount() + userInterfaceInterval;
 		while( pcDocLine ){
 			++nLineNumber;
 
 			//経過通知
-			if(pcDocLineMgr.GetLineCount()>0 && nLineNumber%1024==0){
+			DWORD currTime = GetTickCount();
+			DWORD diffTime = currTime - prevTime;
+			if(diffTime >= userInterfaceInterval){
+				prevTime = currTime;
 				NotifyProgress(nLineNumber * 100 / pcDocLineMgr.GetLineCount());
 				// 処理中のユーザー操作を可能にする
 				if( !::BlockingHook( NULL ) ){


### PR DESCRIPTION
# PR の目的

下記の2つの変更を行う目的があります。

- ファイル保存処理中のユーザーへの通知やメッセージループ回し（処理中のユーザー操作を可能にする）処理の呼び出しを、1024行間隔で行う方法から一定時間（33ミリ秒）間隔で行う方法に変更

- ファイル保存処理後に呼び出す設定変更の反映呼び出し（CEditDoc::OnChangeSetting）は文書種別が変更になった時だけ行うように変更

## カテゴリ

- 速度向上

## PR の背景

1行の文字数が少なく行数がやたらと多いファイルの場合（そんなファイルを日常的には扱わないので特殊なケースですが…）、1024行間隔で実行する方法だと必要以上に頻繁に処理が呼び出されてしまいます。UI更新は操作する人間向けの処理なので一定時間間隔で行う方法が良いと考えています。

設定変更の反映呼び出し（`CEditDoc::OnChangeSetting`）は色々な処理の呼び出しを行うので必要のないケースでは呼び出しをしない方が処理が軽くなります。`CEditDoc::OnChangeSetting` から呼び出す処理の中でも特に処理が重くなりがちなのは、 `CLayoutMgr::SetLayoutInfo` 経由で呼び出される `CLayoutMgr::_DoLayout` です。

## PR のメリット

ファイル保存時の処理が少し軽くなるケースが増えます。

## PR のデメリット (トレードオフとかあれば)

いつもの事ですが判定記述が増えるとコード量が増えて可読性が下がってメンテナンスの難易度が上がります。コメントは入れていますが…。

保存時に文書種別が変更されていない場合でももしかしたら設定変更の反映呼び出しを行った方が良い場合があるかもしれないので（把握していない）その場合は不具合になります。

## PR の影響範囲

ファイル保存時の処理

## 関連チケット

#1050
