### PR TITLE
コンパイラ警告の抑制を解除する

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -25,11 +25,6 @@
 
 #ifdef _MSC_VER
 
-//#pragma warning(disable: 4786)
-#pragma warning(disable: 4345)	//warning C4345: 動作変更 : 形式 () の初期化子で構築される POD 型のオブジェクトは既定初期化されます。
-#pragma warning(disable: 4996)	//warning C4996: 'xxxx': This function or variable may be unsafe. Consider using wcscpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
-#pragma warning(disable: 4355)	//warning C4355: 'this' : ベース メンバ初期化リストで使用されました。
-
 #if defined _M_IX86
 #pragma comment(linker,"/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='x86' publicKeyToken='6595b64144ccf1df' language='*'\"")
 #elif defined _M_IA64

--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -26,16 +26,8 @@
 #define SAKURA_STDAPI_85471C2C_6AEE_410D_BD09_A59056A5BA68_H_
 
 //ランタイム情報ライブラリにアクセスするWindowsヘッダを参照する
-//c++規格への準拠が厳しくなったため、WindowsSDKが無名enumをtypedefするコードが怒られる。
-#ifdef _MSC_VER
-	//一時的に警告を無効にしてインクルードする
-	#pragma warning(push)
-	#pragma warning(disable:4091)
-	#include <ImageHlp.h> //MakeSureDirectoryPathExists
-	#pragma warning(pop)
-#else
-	#include <ImageHlp.h> //MakeSureDirectoryPathExists
-#endif
+#include <ImageHlp.h>
+
 #include "mem/CNativeW.h"
 
 //デバッグ用。

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -106,15 +106,12 @@ struct CDlgOpenFile_CommonItemDialog final
 	int m_RefCount = 0;
 
 	HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void ** ppvObject) override {
-#pragma warning(push)
-#pragma warning(disable: 4838) // conversion from 'DWORD' to 'int' requires a narrowing conversion
 		static const QITAB qit[] = {
 			QITABENT(CDlgOpenFile_CommonItemDialog, IFileDialogEvents),
 			QITABENT(CDlgOpenFile_CommonItemDialog, IFileDialogControlEvents),
 			{ 0 },
 		};
 		return QISearch(this, qit, iid, ppvObject);
-#pragma warning(pop)
 	}
 
 	ULONG STDMETHODCALLTYPE AddRef() override {


### PR DESCRIPTION
# PR の目的

不要になった `warning(disable)` のpragma定義を除去します。


## カテゴリ

- リファクタリング


## PR の背景

VC++ では `#pragma warning(disable: WARNING_NUMBER)` と書くことによって、
特定のコンパイラ警告を無効にすることができます。

コンパイラ警告を無効にする動機としてよくあるのは、以下のケースです。
- 古いC/C++プログラムから移植を行った場合、現代のC++規格に準拠していない部分の警告を抑制しないとビルドが通らない場合があります。
- 古いWindows SDKを使っている場合、昔のWindows SDKのヘッダーファイルはC++規格に準拠していないので警告を抑制する必要がありました。

サクラエディタは、上記のどちらにも当てはまるプログラムです。
歴史的な理由で `warning (disable)` の記述がいくつか残っています。
しかし、これまでに行ってきた様々な対応により、これらの警告抑制は不要になっています。

このPRでは、不要となった `warning (disable)` を除去して警告の抑制を解除します。


## PR のメリット

- pragma定義が消えることにより、「 `/wd4996` ってなんだっけ？」と悩まなくてよくなります。


## PR のデメリット (トレードオフとかあれば)

- とくにありません。


## PR の影響範囲

- ソースコードのビルドに影響します。
- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット

#1044 プロジェクトのビルドにWindows10 SDKを使う


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
