### PR TITLE
テストコード中の文字列型を訂正する

### DIFF
--- a/tests/unittests/test-is_mailaddress.cpp
+++ b/tests/unittests/test-is_mailaddress.cpp
@@ -313,9 +313,9 @@ TEST(testIsMailAddress, OffsetParameter2)
 		actual.is_address = IsMailAddress(p1, p2 - p1, p3 - p1, &(actual.length));
 
 		EXPECT_TRUE(IsEqualResult(ExpectedResult(p1, p2, p3), actual))
-		<< "1st param of IsMailAddress: pszBuf is \"" << (p1 <= p3 ? std::string(p1, p3) : "") << "\"\n"
+		<< "1st param of IsMailAddress: pszBuf is \"" << (p1 <= p3 ? std::wstring(p1, p3) : L"") << "\"\n"
 		<< "2nd param of IsMailAddress: offset is "   << (p2 - p1) << "\n"
-		<< "pszBuf + offset is \"" << (p2 <= p3 ? std::string(p2, p3) : "") << "\"";
+		<< "pszBuf + offset is \"" << (p2 <= p3 ? std::wstring(p2, p3) : L"") << "\"";
 	}
 }
 


### PR DESCRIPTION
## PR の目的

テストコード中の文字列型を訂正して、ビルド時警告を削減します。


## カテゴリ

- リファクタリング


## PR の背景

vs2019単体インストールでビルドを試したら、変な警告が出たので対処を入れます。

```
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :  see reference to function template instantiation 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>::basic_string<const wchar_t*,void>(_Iter,_Iter,const _Alloc &)' being compiled
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :         with
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :         [
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :             _Iter=const wchar_t *,
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :             _Alloc=std::allocator<char>
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :         ]
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :  see reference to function template instantiation 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>::basic_string<const wchar_t*,void>(_Iter,_Iter,const _Alloc &)' being compiled
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :         with
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :         [
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :             _Iter=const wchar_t *,
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :             _Alloc=std::allocator<char>
1>C:\work\sakura\tests\unittests\test-is_mailaddress.cpp(315): message :         ]
```




## PR のメリット

- 警告が1つ消えます。


## PR のデメリット (トレードオフとかあれば)

- とくにありません。


## PR の影響範囲

- テストコードのビルド時警告が消えます。
- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット

ありません。

## 参考資料

ありません。
