### PR TITLE
文字コードの指定ダイアログのCPチェックの仕様を修正する

### DIFF
--- a/sakura_core/dlg/CDlgSetCharSet.cpp
+++ b/sakura_core/dlg/CDlgSetCharSet.cpp
@@ -34,7 +34,6 @@ CDlgSetCharSet::CDlgSetCharSet()
 {
 	m_pnCharSet = NULL;			// 文字コードセット
 	m_pbBom = NULL;				// 文字コードセット
-	m_bCP = false;
 }
 
 /* モーダルダイアログの表示 */
@@ -73,11 +72,9 @@ BOOL CDlgSetCharSet::OnBnClicked( int wID )
 {
 	switch( wID ){
 	case IDC_CHECK_CP:
-		if( !m_bCP ){
-			m_bCP = true;
-			::EnableWindow( GetItemHwnd( IDC_CHECK_CP ), FALSE );
-			CCodePage::AddComboCodePages( GetHwnd(), m_hwndCharSet, -1 );
-		}
+		::CheckDlgButton( GetHwnd(), IDC_CHECK_CP, TRUE );
+		::EnableWindow( GetItemHwnd( IDC_CHECK_CP ), FALSE );
+		CCodePage::AddComboCodePages( GetHwnd(), m_hwndCharSet, -1 );
 		return TRUE;
 	case IDC_BUTTON_HELP:
 		/* 「文字コードセット設定」のヘルプ */
@@ -179,7 +176,6 @@ void CDlgSetCharSet::SetData( void )
 		}
 	}
 	if( -1 == nCurIdx ){
-		m_bCP = true;
 		::CheckDlgButton( GetHwnd(), IDC_CHECK_CP, TRUE );
 		::EnableWindow( GetItemHwnd( IDC_CHECK_CP ), FALSE );
 		nCurIdx = CCodePage::AddComboCodePages( GetHwnd(), m_hwndCharSet, *m_pnCharSet );

--- a/sakura_core/dlg/CDlgSetCharSet.h
+++ b/sakura_core/dlg/CDlgSetCharSet.h
@@ -31,7 +31,6 @@ public:
 
 	ECodeType*	m_pnCharSet;			// 文字コードセット
 	bool*		m_pbBom;				// BOM
-	bool		m_bCP;
 
 	HWND		m_hwndCharSet;
 	HWND		m_hwndCheckBOM;


### PR DESCRIPTION
# PR の目的

文字コードの指定ダイアログのCPチェックの仕様を修正することにより、
issue #1037 の不具合(CPチェックが効かないことがある)を解消します。

## カテゴリ

- 仕様変更
- 不具合修正


## PR の背景

issue #1037 の対策PRです。

対応する不具合内容
- 文字コードの指定ダイアログのCPチェックが効かないことがある

不具合の原因
1. CPチェックの状態を格納するメンバ変数の初期化が漏れている
2. `IDC_CHECK_CP` を利用する他4つのダイアログと実装が異なっている

https://github.com/sakura-editor/sakura/issues/1037#issuecomment-531338231 でコメントしている通り、不具合を解消するだけならずっと少ない修正で事足ります。

この PR では、不具合原因のうち 2. の「他4つのダイアログと実装が違う」に着目し、実装を合わせてみました。
CPチェックの状態を格納するメンバ変数を削除し、`IDC_CHECK_CP` のイベント実装をシンプルにしました。


## PR のメリット

issue #1037 の不具合が解消します。


## PR のデメリット (トレードオフとかあれば)

とくにありません。

なお、Windows API [CheckDlgButton](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-checkdlgbutton) の使い方が誤っている件についてはスルーします。
※CheckDlgButton関数の第3引数はBOOLではなくintです。TRUEで動作している理由は、BST_CHECKEDの値が1でTRUEの定義とたまたま一致しているためです。


## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響があります。
  - issue #1037 の不具合が解消します。

## 関連チケット

close #1037 文字コードの指定ダイアログでCPのチェックが効かない事が有る


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
