### PR TITLE
確保済みメモリサイズの更新タイミングを訂正する

### DIFF
--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -133,14 +133,14 @@ int WINAPI wWinMain(
 	mem.AllocBuffer(memorySizeLimit + 1);
 	assert(mem.GetRawPtr() == nullptr);
 	assert(mem.GetRawLength() == 0);
-	assert(mem.capacity() == 0);
+	//assert(mem.capacity() == 0);
 
 	//4. 大きなメモリの設定を試みる
 	char hugeBuf[memorySizeLimit + 1] = { 0 };
 	mem.SetRawData(hugeBuf, sizeof(hugeBuf));
 	assert(mem.GetRawPtr() == nullptr);
 	assert(mem.GetRawLength() == 0);
-	assert(mem.capacity() == 0);
+	//assert(mem.capacity() == 0);
 
 	//5. 小さなメモリの設定を試みる
 	char smallBuf[] = "test";
@@ -155,7 +155,7 @@ int WINAPI wWinMain(
 	mem.AppendRawData(hugeBuf, sizeof(hugeBuf));
 	assert(mem.GetRawPtr() == nullptr);
 	assert(mem.GetRawLength() == 0);
-	assert(mem.capacity() == 0);
+	//assert(mem.capacity() == 0);
 
 	//プロセスの生成とメッセージループ
 	CProcessFactory aFactory;

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -133,14 +133,14 @@ int WINAPI wWinMain(
 	mem.AllocBuffer(memorySizeLimit + 1);
 	assert(mem.GetRawPtr() == nullptr);
 	assert(mem.GetRawLength() == 0);
-	//assert(mem.capacity() == 0);
+	assert(mem.capacity() == 0);
 
 	//4. 大きなメモリの設定を試みる
 	char hugeBuf[memorySizeLimit + 1] = { 0 };
 	mem.SetRawData(hugeBuf, sizeof(hugeBuf));
 	assert(mem.GetRawPtr() == nullptr);
 	assert(mem.GetRawLength() == 0);
-	//assert(mem.capacity() == 0);
+	assert(mem.capacity() == 0);
 
 	//5. 小さなメモリの設定を試みる
 	char smallBuf[] = "test";
@@ -155,7 +155,7 @@ int WINAPI wWinMain(
 	mem.AppendRawData(hugeBuf, sizeof(hugeBuf));
 	assert(mem.GetRawPtr() == nullptr);
 	assert(mem.GetRawLength() == 0);
-	//assert(mem.capacity() == 0);
+	assert(mem.capacity() == 0);
 
 	//プロセスの生成とメッセージループ
 	CProcessFactory aFactory;

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -56,31 +56,6 @@ const WCHAR g_szGStrAppName[]  = (_GSTR_APPNAME_(_T)   ); // この変数を直�
 const CHAR  g_szGStrAppNameA[] = (_GSTR_APPNAME_(ATEXT)); // この変数を直接参照せずに GSTR_APPNAME_A を使うこと
 const WCHAR g_szGStrAppNameW[] = (_GSTR_APPNAME_(LTEXT)); // この変数を直接参照せずに GSTR_APPNAME_W を使うこと
 
-//! メモリ枯渇テスト用しきい値
-constexpr size_t memorySizeLimit = 2048;
-
-/*!
- * @brief メモリ枯渇テスト用アロケーションフック関数
- *
- * @see https://docs.microsoft.com/en-us/visualstudio/debugger/allocation-hook-functions
- * @note 大きなメモリの確保を失敗させるフック関数
- */
-int DenyHugeAllocHook( int allocType, void *userData, size_t size,
-                   int blockType, long requestNumber,
-                   const unsigned char *filename, int lineNumber)
-{
-	// Cランタイムが確保するメモリには干渉しない
-	// see https://docs.microsoft.com/en-us/visualstudio/debugger/allocation-hooks-and-c-run-time-memory-allocations
-	if (blockType == _CRT_BLOCK)
-		return TRUE;
-
-	// ちいさなメモリの確保は許容する
-	if (size <= memorySizeLimit)
-		return TRUE;
-
-	return FALSE;
-}
-
 /*!
 	Windows Entry point
 
@@ -118,44 +93,6 @@ int WINAPI wWinMain(
 	//開発情報
 	DEBUG_TRACE(L"-- -- WinMain -- --\n");
 	DEBUG_TRACE(L"sizeof(DLLSHAREDATA) = %d\n",sizeof(DLLSHAREDATA));
-
-	//メモリ枯渇テスト
-	//1. アロケーションフックを仕掛ける
-	::_CrtSetAllocHook(DenyHugeAllocHook);
-
-	//2. CMemoryを構築する
-	CMemory mem;
-	assert(mem.GetRawPtr() == nullptr);
-	assert(mem.GetRawLength() == 0);
-	assert(mem.capacity() == 0);
-
-	//3. 大きなメモリの確保を試みる
-	mem.AllocBuffer(memorySizeLimit + 1);
-	assert(mem.GetRawPtr() == nullptr);
-	assert(mem.GetRawLength() == 0);
-	//assert(mem.capacity() == 0);
-
-	//4. 大きなメモリの設定を試みる
-	char hugeBuf[memorySizeLimit + 1] = { 0 };
-	mem.SetRawData(hugeBuf, sizeof(hugeBuf));
-	assert(mem.GetRawPtr() == nullptr);
-	assert(mem.GetRawLength() == 0);
-	//assert(mem.capacity() == 0);
-
-	//5. 小さなメモリの設定を試みる
-	char smallBuf[] = "test";
-	mem.SetRawData(smallBuf, sizeof(smallBuf));
-	assert(mem.GetRawPtr());
-	assert(mem.GetRawLength());
-	assert(mem.capacity());
-	assert(strcmp((char*)mem.GetRawPtr(), smallBuf) == 0);
-
-	//6. 小さなメモリに大きなメモリをくっ付けてみる
-	mem.SetRawData(smallBuf, sizeof(smallBuf));
-	mem.AppendRawData(hugeBuf, sizeof(hugeBuf));
-	assert(mem.GetRawPtr() == nullptr);
-	assert(mem.GetRawLength() == 0);
-	//assert(mem.capacity() == 0);
 
 	//プロセスの生成とメッセージループ
 	CProcessFactory aFactory;

--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -261,7 +261,6 @@ void CMemory::AllocBuffer( int nNewDataLen )
 	if( m_nDataBufSize == 0 ){
 		/* 未確保の状態 */
 		pWork = malloc_char( nWorkLen );
-		m_nDataBufSize = nWorkLen;
 	}else{
 		/* 現在のバッファサイズより大きくなった場合のみ再確保する */
 		if( m_nDataBufSize < nWorkLen ){
@@ -273,7 +272,6 @@ void CMemory::AllocBuffer( int nNewDataLen )
 			}else{
 				pWork = (char*)realloc( m_pRawData, nWorkLen );
 			}
-			m_nDataBufSize = nWorkLen;
 		}else{
 			return;
 		}
@@ -290,6 +288,7 @@ void CMemory::AllocBuffer( int nNewDataLen )
 		return;
 	}
 	m_pRawData = pWork;
+	m_nDataBufSize = nWorkLen;
 	return;
 }
 


### PR DESCRIPTION
# PR の目的

CMemory::AllocBufferメソッドの潜在バグを修正します。

確保済みメモリサイズの更新タイミングを訂正することにより、
メモリ確保に失敗した場合にも確保済みサイズが更新されてしまう不具合を修正します。


## カテゴリ

- 不具合修正


## PR の背景

CMemoryはサクラエディタの中核をなすコアクラスです。

文字列バッファに使うメモリを動的に確保する役割を担っています。

このクラスは、いわゆる [レガシーコード](https://amzn.to/2lSE92C) です。 

レガシーコードという言葉の定義は諸説ありますが、
個人的には「単体テストがあるかないか」で切り分けるのがシンプルだと思います。

「単体テストがない」は大きく3つに分けられます。
1. めんどくさかったので作ってない　←　作ったらいいだけの軽傷パターン
2. 外部ライブラリに依存するので作れない　←　Mockingで回避できる重症パターン
3. ロジック的に自動テスト不能なので作れない　←　どうにもならない致命傷パターン

CMemory::AllocBufferは、残念ながら 3. に当てはまります。
どんなに古典的な手法を採用していたとしても **テストがあるならレガシーコードではない** んですが、ロジック的にテスト不能な場合はレガシーコードと言わざるを得ません。


今回は、CMemory::AllocBufferがレガシーコードであったために今まで検出されなかった潜在不具合に対処します。

以下、やったことを順を追って説明します。


### メモリ枯渇テスト用コードの追加

まず、メモリ枯渇テストを実装してみました。( 815d992 )

MSVCRTDを使う場合、 `_CrtSetAllocHook` によってメモリ確保の処理にフックを仕込むことができます。大きなメモリを要求された場合にメモリ確保が失敗するようなフック関数を定義してみました。

デバッグ実行するとこうなります。
![<img src="https://user-images.githubusercontent.com/3253151/65812416-c0436e00-e201-11e9-9840-100eeed4713f.png" width="320">](https://user-images.githubusercontent.com/3253151/65812416-c0436e00-e201-11e9-9840-100eeed4713f.png)

136行目をコメントアウトしてある理由は **メモリ確保が失敗時にも確保済みメモリサイズが更新されてしまうから** です。
![<img src="https://user-images.githubusercontent.com/3253151/65812501-b9692b00-e202-11e9-931d-b8a15528964d.png" width="160">](https://user-images.githubusercontent.com/3253151/65812501-b9692b00-e202-11e9-931d-b8a15528964d.png)

メモリが確保されていないのに確保済みメモリサイズが入ってるのはおかしいと思うので、メモリ確保失敗時には確保済みメモリサイズが入らないようにしたいです。これがこのPRの本題です。

### 確保済みメモリサイズの更新位置を訂正

確保済みメモリサイズの更新位置を訂正してみました。( e1778f1 )

CMemory::AllocBufferメソッドには一時変数が2つあります。
https://github.com/sakura-editor/sakura/blob/5c73fa4077723e66668e38dbf3d280ef1ab84814/sakura_core/mem/CMemory.cpp#L255-L256

`pWork` をメンバ変数 `m_pRawData` に反映するタイミングと、
`nWorkLen` をメンバ変数 `m_nDataBufSize` に反映するタイミングがずれています。

更新タイミングにズレがあるのが不具合原因と考えて、
2つのメンバ変数が同じタイミングで更新されるように修正しました。

### メモリ枯渇テスト用コードを修正して効果確認を行う

メモリ枯渇テストを修正して効果確認を行いました。( f322600 )

デバッグ実行するとこうなります。
![<img src="https://user-images.githubusercontent.com/3253151/65812669-267dc000-e205-11e9-8acb-3f2e8e89c4ae.png" width="320">](https://user-images.githubusercontent.com/3253151/65812669-267dc000-e205-11e9-8acb-3f2e8e89c4ae.png)

エラーメッセージ（？）が表示される挙動は変わっていません。

136行目をコメントインしてあるのが前回との相違点です。
![<img src="https://user-images.githubusercontent.com/3253151/65812670-2a114700-e205-11e9-8a1b-b0f3b034602c.png" width="160">](https://user-images.githubusercontent.com/3253151/65812670-2a114700-e205-11e9-8a1b-b0f3b034602c.png)

メモリが確保されていないので確保済みメモリサイズは0になります。
修正が期待通りに機能していることを確認できました。

残りのコミット(3f2f472, ef8f7f4)は、暫定的に入れたテストコードをrevertしています。


CMemory::AllocBufferメソッドをテスト可能にする試みは、別件としたいと考えています。


## PR のメリット

CMemory::AllocBufferメソッドの潜在バグが修正されます。


## PR のデメリット (トレードオフとかあれば)

とくにないと思います。


## PR の影響範囲

- CMemory::AllocBufferによるメモリ確保が失敗した場合の挙動に影響します。
- アプリ(=サクラエディタ)の機能には、基本的に影響ありません。


## 関連チケット

#53 メモリ確保失敗時の挙動について調査する


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
