### PR TITLE
std::wstring を使った記述の微調整

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -1608,7 +1608,7 @@ public:
 					return;
 				}
 			}
-			std::wstring name = std::wstring(fileName);
+			std::wstring name(fileName);
 			name += L".skrnew";
 			if( FALSE == ::MoveFile( name.c_str(), fileName ) ){
 				memMessage.AppendString( LS(STR_GREP_REP_ERR_REPLACE) );
@@ -1624,7 +1624,7 @@ public:
 			out->Close();
 			delete out;
 			out = NULL;
-			std::wstring name = std::wstring(fileName);
+			std::wstring name(fileName);
 			name += L".skrnew";
 			::DeleteFile( name.c_str() );
 		}

--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -334,7 +334,7 @@ void CHokanMgr::HokanSearchByKeyword(
 			if( nRet != 0 ){
 				continue;
 			}
-			std::wstring strWord = std::wstring(word);
+			std::wstring strWord(word);
 			AddKouhoUnique(vKouho, strWord);
 		}
 	}

--- a/sakura_core/charset/charset.cpp
+++ b/sakura_core/charset/charset.cpp
@@ -124,7 +124,9 @@ LPCWSTR CCodeTypeName::Bracket() const
 
 //	static	std::wstring	sWork = L"  [" + msCodeSet[m_eCodeType].m_sShort + L"]";
 	static	std::wstring	sWork;
-	sWork = std::wstring(L"  [") + msCodeSet[m_eCodeType].m_sShort + L"]";	// 変数の定義と値の設定を一緒にやるとバグる様なので分離	// 2013/4/20 Uchi
+	sWork = L"  [";
+	sWork += msCodeSet[m_eCodeType].m_sShort;
+	sWork += L"]";	// 変数の定義と値の設定を一緒にやるとバグる様なので分離	// 2013/4/20 Uchi
 
 	return sWork.c_str();
 }

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -934,7 +934,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModalOpenDlg(
 		if( bMultiSelect ){
 			pLoadInfo->cFilePath = L"";
 			if( pData->m_ofn.nFileOffset < wcslen( pData->m_ofn.lpstrFile ) ){
-				pFileNames->push_back( std::wstring(pData->m_ofn.lpstrFile) );
+				pFileNames->push_back( pData->m_ofn.lpstrFile );
 			}else{
 				std::wstring path;
 				WCHAR* pos = pData->m_ofn.lpstrFile;

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -768,7 +768,7 @@ static void ConvertLangValueImpl( wchar_t* pBuf, size_t chBufSize, int nStrId, s
 {
 	if( setValues ){
 		if( bUpdate ){
-			values.push_back( std::wstring(LS(nStrId)) );
+			values.push_back( LS(nStrId) );
 		}
 		return;
 	}
@@ -781,7 +781,7 @@ static void ConvertLangValueImpl( char* pBuf, size_t chBufSize, int nStrId, std:
 {
 	if( setValues ){
 		if( bUpdate ){
-			values.push_back( std::wstring(LS(nStrId)) );
+			values.push_back( LS(nStrId) );
 		}
 		return;
 	}

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -797,14 +797,20 @@ bool CDlgFuncList::GetTreeFileFullName(HWND hwndTree, HTREEITEM target, std::wst
 		TreeView_GetItem( hwndTree, &tvItem );
 		if( ((-tvItem.lParam) % 10) == 3 ){
 			*pnItem = (-tvItem.lParam) / 10;
-			*pPath = std::wstring(m_pcFuncInfoArr->GetAt(*pnItem)->m_cmemFileName.GetStringPtr()) + L"\\" + *pPath;
+			std::wstring path = m_pcFuncInfoArr->GetAt(*pnItem)->m_cmemFileName.GetStringPtr();
+			path += L"\\";
+			path += *pPath;
+			*pPath = path;
 			return true;
 		}
 		if( tvItem.lParam != -1 && tvItem.lParam != -2 ){
 			return false;
 		}
 		if( *pPath != L"" ){
-			*pPath = std::wstring(szFileName) + L"\\" + *pPath;
+			std::wstring path = szFileName;
+			path += L"\\";
+			path += *pPath;
+			*pPath = path;
 		}else{
 			*pPath = szFileName;
 		}

--- a/sakura_core/plugin/CComplementIfObj.h
+++ b/sakura_core/plugin/CComplementIfObj.h
@@ -86,7 +86,7 @@ public:
 				const wchar_t* word = keyword.c_str();
 				int nWordLen = keyword.length();
 				if( nWordLen <= 0 ) return false;
-				std::wstring strWord = std::wstring(word, nWordLen);
+				std::wstring strWord(word, nWordLen);
 				if( CHokanMgr::AddKouhoUnique( m_pHokanMgr->m_vKouho, strWord ) ){
 					Wrap( &Result )->Receive( m_pHokanMgr->m_vKouho.size() );
 				}else{

--- a/sakura_core/plugin/CPluginManager.cpp
+++ b/sakura_core/plugin/CPluginManager.cpp
@@ -365,7 +365,9 @@ int CPluginManager::InstallPlugin( CommonSetting& common, const WCHAR* pszPlugin
 	static const WCHAR szReservedChars[] = L"/\\,[]*?<>&|;:=\" \t";
 	for( int x = 0; x < _countof(szReservedChars); ++x ){
 		if( sId.npos != sId.find(szReservedChars[x]) ){
-			errorMsg = std::wstring(LS(STR_PLGMGR_INST_RESERVE1)) + szReservedChars + LS(STR_PLGMGR_INST_RESERVE2);
+			errorMsg = LS(STR_PLGMGR_INST_RESERVE1);
+			errorMsg += szReservedChars;
+			errorMsg += LS(STR_PLGMGR_INST_RESERVE2);
 			return -1;
 		}
 	}
@@ -512,7 +514,10 @@ CPlugin* CPluginManager::LoadPlugin( const WCHAR* pszPluginDir, const WCHAR* psz
 
 	//L10N定義ファイルを読む
 	//プラグイン定義ファイルを読み込む base\pluginname\local\plugin_en_us.def
-	strMlang = std::wstring(pszBasePath) + L"\\" + PII_L10NDIR + L"\\" + PII_L10NFILEBASE + pszLangName + PII_L10NFILEEXT;
+	strMlang = pszBasePath;
+	strMlang += L"\\" PII_L10NDIR L"\\" PII_L10NFILEBASE;
+	strMlang += pszLangName;
+	strMlang += PII_L10NFILEEXT;
 	cProfDefMLang.SetReadingMode();
 	if( !cProfDefMLang.ReadProfile( strMlang.c_str() ) ){
 		//プラグイン定義ファイルが存在しない

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -243,7 +243,8 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 
 	if (!m_cProfile.ReadProfile( sPath.c_str() )) {
 		/* 設定ファイルが存在しない */
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -434,8 +435,9 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 		}
 	}
 
-	sErrMsg = std::wstring(LS(STR_IMPEXP_OK_IMPORT)) + sFileName + files;
-
+	sErrMsg = LS(STR_IMPEXP_OK_IMPORT);
+	sErrMsg += sFileName;
+	sErrMsg += files;
 	return true;
 }
 
@@ -531,11 +533,14 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	// 書き込み
 	if (!cProfile.WriteProfile( sFileName.c_str(), WSTR_TYPE_HEAD )) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_EXPORT)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_EXPORT);
+		sErrMsg += sFileName;
 		return false;
 	}
 
-	sErrMsg =  std::wstring(LS(STR_IMPEXP_OK_EXPORT)) + sFileName + files;
+	sErrMsg = LS(STR_IMPEXP_OK_EXPORT);
+	sErrMsg += sFileName;
+	sErrMsg += files;
 
 	return true;
 }
@@ -551,7 +556,8 @@ bool CImpExpColors::Import( const wstring& sFileName, wstring& sErrMsg )
 	// 開けるか
 	CTextInputStream in( strPath.c_str() );
 	if (!in) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -565,8 +571,8 @@ bool CImpExpColors::Import( const wstring& sFileName, wstring& sErrMsg )
 	//比較
 	if (szHeader != WSTR_COLORDATA_HEAD3) {
 		in.Close();
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_COLOR_OLD))	// 旧バージョンの説明の削除 2010/4/22 Uchi
-			+ sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_COLOR_OLD);	// 旧バージョンの説明の削除 2010/4/22 Uchi
+		sErrMsg += sFileName;
 		return false;
 	}
 	in.Close();
@@ -593,7 +599,8 @@ bool CImpExpColors::Export( const wstring& sFileName, wstring& sErrMsg )
 	cProfile.SetWritingMode();
 	CShareData_IO::IO_ColorSet( &cProfile, szSecColor, m_ColorInfoArr );
 	if (!cProfile.WriteProfile( sFileName.c_str(), WSTR_COLORDATA_HEAD3 )) { //Jan. 15, 2001 Stonee
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_EXPORT)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_EXPORT);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -608,7 +615,8 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	CTextInputStream	in( sFileName.c_str() );
 	if (!in) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -686,7 +694,8 @@ bool CImpExpRegex::Export( const wstring& sFileName, wstring& sErrMsg )
 {
 	CTextOutputStream out( sFileName.c_str() );
 	if(!out){
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -721,7 +730,8 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 
 	CTextInputStream in( sFileName.c_str());
 	if (!in) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -830,7 +840,8 @@ bool CImpExpKeyHelp::Export( const wstring& sFileName, wstring& sErrMsg )
 {
 	CTextOutputStream out( sFileName.c_str() );
 	if (!out) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -864,7 +875,8 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 	CDataProfile in;
 	in.SetReadingMode();
 	if (!in.ReadProfile( sFileName.c_str())) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -893,7 +905,8 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 		// 新バージョンでない
 		CTextInputStream in(strPath.c_str());
 		if (!in) {
-			sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+			sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+			sErrMsg += sFileName;
 			return false;
 		}
 		// ヘッダチェック
@@ -1007,7 +1020,8 @@ bool CImpExpKeybind::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	CTextOutputStream out( strPath.c_str() );
 	if (!out) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -1029,7 +1043,8 @@ bool CImpExpKeybind::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	// 書き込み
 	if (!cProfile.WriteProfile( strPath.c_str(), WSTR_KEYBIND_HEAD4)) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_EXPORT)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_EXPORT);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -1047,7 +1062,8 @@ bool CImpExpCustMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 	//ヘッダ確認
 	CTextInputStream in(strPath.c_str());
 	if (!in) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -1076,7 +1092,8 @@ bool CImpExpCustMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 	// オープン
 	CTextOutputStream out(strPath.c_str());
 	if (!out) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -1100,7 +1117,8 @@ bool CImpExpCustMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	// 書き込み
 	if (!cProfile.WriteProfile( strPath.c_str(), WSTR_CUSTMENU_HEAD_V2)) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_EXPORT)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_EXPORT);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -1117,7 +1135,8 @@ bool CImpExpKeyWord::Import( const wstring& sFileName, wstring& sErrMsg )
 
 	CTextInputStream in(sFileName.c_str());
 	if (!in) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 	while( in ){
@@ -1167,7 +1186,8 @@ bool CImpExpKeyWord::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	CTextOutputStream out(sFileName.c_str());
 	if (!out) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 	out.WriteF( L"// " );
@@ -1206,7 +1226,8 @@ bool CImpExpMainMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 	//ヘッダ確認
 	CTextInputStream in(strPath.c_str());
 	if (!in) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -1235,7 +1256,8 @@ bool CImpExpMainMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 	// オープン
 	CTextOutputStream out( strPath.c_str() );
 	if (!out) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_FILEOPEN)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_FILEOPEN);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -1256,7 +1278,8 @@ bool CImpExpMainMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	// 書き込み
 	if (!cProfile.WriteProfile( strPath.c_str(), WSTR_MAINMENU_HEAD_V1)) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_EXPORT)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_EXPORT);
+		sErrMsg += sFileName;
 		return false;
 	}
 
@@ -1295,7 +1318,8 @@ bool CImpExpFileTree::Export( const wstring& sFileName, wstring& sErrMsg )
 
 	// 書き込み
 	if (!cProfile.WriteProfile( strPath.c_str(), WSTR_FILETREE_HEAD_V1)) {
-		sErrMsg = std::wstring(LS(STR_IMPEXP_ERR_EXPORT)) + sFileName;
+		sErrMsg = LS(STR_IMPEXP_ERR_EXPORT);
+		sErrMsg += sFileName;
 		return false;
 	}
 

--- a/sakura_core/typeprop/CPropTypesSupport.cpp
+++ b/sakura_core/typeprop/CPropTypesSupport.cpp
@@ -248,7 +248,7 @@ int CPropTypesSupport::GetData( HWND hwndDlg )
 /*/
 void CPropTypesSupport::AddHokanMethod(int nMethod, const WCHAR* szName)
 {
-	SHokanMethod item = { nMethod, std::wstring(szName) };
+	SHokanMethod item = { nMethod, szName };
 	GetHokanMethodList()->push_back(item);
 }
 

--- a/sakura_core/util/string_ex2.h
+++ b/sakura_core/util/string_ex2.h
@@ -30,7 +30,6 @@ class CNativeA;
 class CNativeW;
 
 // Aug. 16, 2007 kobake
-wchar_t *wcsncpy_ex(wchar_t *dst, size_t dst_count, const wchar_t* src, size_t src_count);
 wchar_t *wcs_pushW(wchar_t *dst, size_t dst_count, const wchar_t* src, size_t src_count);
 wchar_t *wcs_pushW(wchar_t *dst, size_t dst_count, const wchar_t* src);
 #define wcs_pushW wcs_pushW

--- a/sakura_core/view/CEditView_CmdHokan.cpp
+++ b/sakura_core/view/CEditView_CmdHokan.cpp
@@ -286,7 +286,7 @@ int CEditView::HokanSearchByFile(
 
 			// 候補を追加(重複は除く)
 			{
-				std::wstring strWord = std::wstring(word, nWordLen);
+				std::wstring strWord(word, nWordLen);
 				CHokanMgr::AddKouhoUnique(vKouho, strWord);
 			}
 			if( 0 != nMaxKouho && nMaxKouho <= (int)vKouho.size() ){

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -2279,7 +2279,7 @@ void CEditWnd::InitMenu( HMENU hMenu, UINT uPos, BOOL fSystemMenu )
 		int			nIdxEnd;
 		int			nLv;
 		std::vector<HMENU>	hSubMenu;
-		std::wstring tmpMenuName;
+		wchar_t tmpMenuName[MAX_MAIN_MENU_NAME_LEN+1];
 		const wchar_t *pMenuName;
 
 		nIdxStr = pcMenu->m_nMenuTopIdx[uPos];
@@ -2317,11 +2317,8 @@ void CEditWnd::InitMenu( HMENU hMenu, UINT uPos, BOOL fSystemMenu )
 				hMenuPopUp = ::CreatePopupMenu();
 				if (cMainMenu->m_nFunc != 0 && cMainMenu->m_sName[0] == L'\0') {
 					// ストリングテーブルから読み込み
-					tmpMenuName = LS( cMainMenu->m_nFunc );
-					if( MAX_MAIN_MENU_NAME_LEN < tmpMenuName.length() ){
-						tmpMenuName = tmpMenuName.substr( 0, MAX_MAIN_MENU_NAME_LEN );
-					}
-					pMenuName = tmpMenuName.c_str();
+					wcsncpy_s(tmpMenuName, _countof(tmpMenuName), LS( cMainMenu->m_nFunc ), _TRUNCATE);
+					pMenuName = tmpMenuName;
 				}else{
 					pMenuName = cMainMenu->m_sName;
 				}


### PR DESCRIPTION
# PR の目的

`std::wstring` を使った記述の微調整を行うのが目的です。

主に下記のような変更を行いました。

- 変数宣言時にコンストラクタを使えば済むところで代入演算子を使う記述を行っている場合が有るので使わないように変更
- 文字列の連結で + 演算子ではなく += 演算子を使う記述に変更

## カテゴリ

- リファクタリング

## PR のデメリット (トレードオフとかあれば)

記述が少し長くなる

