### PR TITLE
x64対応をスムーズに行うために、文字列長取得メソッドのオーバーロードを廃止する

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -559,7 +559,8 @@ DWORD CGrepAgent::DoGrep(
 	}
 
 	cmemMessage.AppendString( L"\r\n\r\n" );
-	pszWork = cmemMessage.GetStringPtr( &nWork );
+	nWork = cmemMessage.GetStringLength();
+	pszWork = cmemMessage.GetStringPtr();
 //@@@ 2002.01.03 YAZAKI Grep直後はカーソルをGrep直前の位置に動かす
 	CLayoutInt tmp_PosY_Layout = pcViewDst->m_pcEditDoc->m_cLayoutMgr.GetLineCount();
 	if( 0 < nWork && sGrepOption.bGrepHeader ){

--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -1128,7 +1128,8 @@ prev_line:;
 		// 2002/2/10 aroka 何度も GetPtr を呼ばない
 		if( !bInsertLineMode ){
 			cmemCurLine.swap(pCDocLine->_GetDocLineData());
-			pLine = cmemCurLine.GetStringPtr(&nLineLen);
+			nLineLen = cmemCurLine.GetStringLength();
+			pLine = cmemCurLine.GetStringPtr();
 			cPrevLine = CStringRef(pLine, pArg->sDelRange.GetFrom().x);
 			cNextLine = CStringRef(&pLine[pArg->sDelRange.GetFrom().x], nLineLen - pArg->sDelRange.GetFrom().x);
 			pArg->nInsSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLine);

--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -113,8 +113,8 @@ EConvertResult CCodePage::CPToUnicode(const CMemory& cSrc, CNativeW* pDst, int c
 	bool bError = false;
 
 	// ソース取得
-	int nSrcLen;
-	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
+	int nSrcLen = cSrc.GetRawLength();
+	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	UINT codepage = CodePageExToMSCP(codepageEx);
 	int nDstCch = MultiByteToWideChar2(codepage, nToWideCharFlags, pSrc, nSrcLen, NULL, 0);

--- a/sakura_core/charset/CEuc.cpp
+++ b/sakura_core/charset/CEuc.cpp
@@ -79,8 +79,8 @@ EConvertResult CEuc::EUCToUnicode(const CMemory& cSrc, CNativeW* pDstMem)
 	bool bError = false;
 
 	// ソース取得
-	int nSrcLen;
-	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
+	int nSrcLen = cSrc.GetRawLength();
+	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	// 変換先バッファサイズとその確保
 	wchar_t* pDst = new (std::nothrow) wchar_t[nSrcLen];

--- a/sakura_core/charset/CJis.cpp
+++ b/sakura_core/charset/CJis.cpp
@@ -245,8 +245,8 @@ EConvertResult CJis::JISToUnicode(const CMemory& cSrc, CNativeW* pDstMem, bool b
 	bool berror;
 
 	// ソースを取得
-	int nSrcLen;
-	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
+	int nSrcLen = cSrc.GetRawLength();
+	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	// ソースバッファポインタとソースの長さ
 	const char* psrc = pSrc;

--- a/sakura_core/charset/CLatin1.cpp
+++ b/sakura_core/charset/CLatin1.cpp
@@ -99,8 +99,8 @@ EConvertResult CLatin1::Latin1ToUnicode( const CMemory& cSrc, CNativeW* pDstMem 
 	bool bError;
 
 	//ソース取得
-	int nSrcLen;
-	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
+	int nSrcLen = cSrc.GetRawLength();
+	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	// 変換先バッファサイズを設定してメモリ領域確保
 	wchar_t* pDst = new (std::nothrow) wchar_t[nSrcLen];

--- a/sakura_core/charset/CShiftJis.cpp
+++ b/sakura_core/charset/CShiftJis.cpp
@@ -110,8 +110,8 @@ EConvertResult CShiftJis::SJISToUnicode( const CMemory& cSrc, CNativeW* pDstMem 
 	bool bError;
 
 	//ソース取得
-	int nSrcLen;
-	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
+	int nSrcLen = cSrc.GetRawLength();
+	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	if( &cSrc == pDstMem->_GetMemory() )
 	{

--- a/sakura_core/charset/CUnicode.cpp
+++ b/sakura_core/charset/CUnicode.cpp
@@ -9,8 +9,8 @@
 EConvertResult CUnicode::_UnicodeToUnicode_in( const CMemory& cSrc, CNativeW* pDstMem, const bool bBigEndian )
 {
 	// ソース取得
-	int nSrcLen;
-	const unsigned char* pSrc = reinterpret_cast<const unsigned char*>( cSrc.GetRawPtr(&nSrcLen) );
+	int nSrcLen = cSrc.GetRawLength();
+	const unsigned char* pSrc = reinterpret_cast<const unsigned char*>( cSrc.GetRawPtr() );
 	CMemory* pDstMem2 = pDstMem->_GetMemory();
 
 	EConvertResult res = RESULT_COMPLETE;

--- a/sakura_core/charset/CUtf7.cpp
+++ b/sakura_core/charset/CUtf7.cpp
@@ -116,8 +116,8 @@ EConvertResult CUtf7::UTF7ToUnicode( const CMemory& cSrc, CNativeW* pDstMem )
 	bool bError;
 
 	// データ取得
-	int nDataLen;
-	const char* pData = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nDataLen) );
+	int nDataLen = cSrc.GetRawLength();
+	const char* pData = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	// 必要なバッファサイズを調べて確保
 	wchar_t* pDst = new (std::nothrow) wchar_t[nDataLen + 1];

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -89,8 +89,8 @@ EConvertResult CUtf8::_UTF8ToUnicode( const CMemory& cSrc, CNativeW* pDstMem, bo
 	bool bError = false;
 
 	// データ取得
-	int nSrcLen;
-	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr(&nSrcLen) );
+	int nSrcLen = cSrc.GetRawLength();
+	const char* pSrc = reinterpret_cast<const char*>( cSrc.GetRawPtr() );
 
 	if( &cSrc == pDstMem->_GetMemory() )
 	{

--- a/sakura_core/cmd/CViewCommander_Clipboard.cpp
+++ b/sakura_core/cmd/CViewCommander_Clipboard.cpp
@@ -172,8 +172,8 @@ void CViewCommander::Command_PASTE( int option )
 	}
 
 	// クリップボードデータ取得 -> pszText, nTextLen
-	CLogicInt		nTextLen;
-	const wchar_t*	pszText = cmemClip.GetStringPtr(&nTextLen);
+	CLogicInt nTextLen = cmemClip.GetStringLength();
+	const wchar_t*	pszText = cmemClip.GetStringPtr();
 
 	bool bConvertEol = 
 		((option & 0x01) == 0x01) ? true :
@@ -209,7 +209,8 @@ void CViewCommander::Command_PASTE( int option )
 	if( bLineSelect ){
 		if( !WCODE::IsLineDelimiter(pszText[nTextLen - 1], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 			cmemClip.AppendString(GetDocument()->m_cDocEditor.GetNewLineCode().GetValue2());
-			pszText = cmemClip.GetStringPtr( &nTextLen );
+			nTextLen = cmemClip.GetStringLength();
+			pszText = cmemClip.GetStringPtr();
 		}
 	}
 

--- a/sakura_core/cmd/CViewCommander_Convert.cpp
+++ b/sakura_core/cmd/CViewCommander_Convert.cpp
@@ -236,8 +236,8 @@ void CViewCommander::Command_BASE64DECODE( void )
 	}
 
 	//データ
-	int nDataLen;
-	const void* pData = cmemBuf.GetRawPtr(&nDataLen);
+	int nDataLen = cmemBuf.GetRawLength();
+	const void* pData = cmemBuf.GetRawPtr();
 
 	//カキコ
 	CBinaryOutputStream out(szPath);
@@ -284,8 +284,8 @@ void CViewCommander::Command_UUDECODE( void )
 	}
 
 	//データ
-	int nDataLen;
-	const void* pData = cmemBin.GetRawPtr(&nDataLen);
+	int nDataLen = cmemBin.GetRawLength();
+	const void* pData = cmemBin.GetRawPtr();
 
 	//カキコ
 	CBinaryOutputStream out(szPath);

--- a/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
@@ -691,7 +691,8 @@ void CViewCommander::Command_SORT(BOOL bAsc)	//bAsc:TRUE=昇順,FALSE=降順
 	for( CLogicInt i = sSelectOld.GetFrom().GetY2(); i < sSelectOld.GetTo().y; i++ ){
 		const CDocLine* pcDocLine = GetDocument()->m_cDocLineMgr.GetLine( i );
 		const CNativeW& cmemLine = pcDocLine->_GetDocLineDataWithEOL();
-		pLine = cmemLine.GetStringPtr(&nLineLen);
+		nLineLen = cmemLine.GetStringLength();
+		pLine = cmemLine.GetStringPtr();
 		CLogicInt nLineLenWithoutEOL = pcDocLine->GetLengthWithoutEOL();
 		if( NULL == pLine ) continue;
 		SORTDATA* pst = new SORTDATA;

--- a/sakura_core/cmd/CViewCommander_Search.cpp
+++ b/sakura_core/cmd/CViewCommander_Search.cpp
@@ -848,7 +848,6 @@ void CViewCommander::Command_REPLACE_ALL()
 	//<< 2002/03/26 Azumaiya
 	// 速く動かすことを最優先に組んでみました。
 	// ループの外で文字列の長さを特定できるので、一時変数化。
-	const wchar_t *szREPLACEKEY;		// 置換後文字列。
 	bool		bColumnSelect = false;	// 矩形貼り付けを行うかどうか。
 	bool		bLineSelect = false;	// ラインモード貼り付けを行うかどうか
 	CNativeW	cmemClip;				// 置換後文字列のデータ（データを格納するだけで、ループ内ではこの形ではデータを扱いません）。
@@ -904,15 +903,16 @@ void CViewCommander::Command_REPLACE_ALL()
 		cmemClip.SetString( GetEditWindow()->m_cDlgReplace.m_strText2.c_str() );
 	}
 
-	CLogicInt nREPLACEKEY;			// 置換後文字列の長さ。
-	szREPLACEKEY = cmemClip.GetStringPtr(&nREPLACEKEY);
+	CLogicInt nREPLACEKEY = cmemClip.GetStringLength();
+	const wchar_t* szREPLACEKEY = cmemClip.GetStringPtr();
 
 	// 行コピー（MSDEVLineSelect形式）のテキストで末尾が改行になっていなければ改行を追加する
 	// ※レイアウト折り返しの行コピーだった場合は末尾が改行になっていない
 	if( bLineSelect ){
 		if( !WCODE::IsLineDelimiter(szREPLACEKEY[nREPLACEKEY - 1], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 			cmemClip.AppendString(GetDocument()->m_cDocEditor.GetNewLineCode().GetValue2());
-			szREPLACEKEY = cmemClip.GetStringPtr( &nREPLACEKEY );
+			nREPLACEKEY = cmemClip.GetStringLength();
+			szREPLACEKEY = cmemClip.GetStringPtr();
 		}
 	}
 
@@ -921,7 +921,8 @@ void CViewCommander::Command_REPLACE_ALL()
 		wchar_t	*pszConvertedText = new wchar_t[nConvertedTextLen];
 		ConvertEol(szREPLACEKEY, nREPLACEKEY, pszConvertedText);
 		cmemClip.SetString(pszConvertedText, nConvertedTextLen);
-		szREPLACEKEY = cmemClip.GetStringPtr(&nREPLACEKEY);
+		nREPLACEKEY = cmemClip.GetStringLength();
+		szREPLACEKEY = cmemClip.GetStringPtr();
 		delete [] pszConvertedText;
 	}
 

--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -108,14 +108,11 @@ void CMemory::_AddData( const void* pData, int nDataLen )
 /* 等しい内容か */
 int CMemory::IsEqual(const CMemory& cmem1, const CMemory& cmem2)
 {
-	const char*	psz1;
-	const char*	psz2;
-	int		nLen1;
-	int		nLen2;
-
-	psz1 = (const char*)cmem1.GetRawPtr( &nLen1 );
-	psz2 = (const char*)cmem2.GetRawPtr( &nLen2 );
+	const int nLen1 = cmem1.GetRawLength();
+	const int nLen2 = cmem2.GetRawLength();
 	if( nLen1 == nLen2 ){
+		const char* psz1 = reinterpret_cast<const char*>(cmem1.GetRawPtr());
+		const char* psz2 = reinterpret_cast<const char*>(cmem2.GetRawPtr());
 		if( 0 == memcmp( psz1, psz2, nLen1 ) ){
 			return TRUE;
 		}
@@ -303,9 +300,8 @@ void CMemory::SetRawData( const void* pData, int nDataLen )
 /* バッファの内容を置き換える */
 void CMemory::SetRawData( const CMemory& pcmemData )
 {
-	const void*	pData;
-	int		nDataLen;
-	pData = pcmemData.GetRawPtr( &nDataLen );
+	int nDataLen = pcmemData.GetRawLength();
+	const void*	pData = pcmemData.GetRawPtr();
 	_Empty();
 	AllocBuffer( nDataLen );
 	_AddData( pData, nDataLen );
@@ -331,9 +327,8 @@ void CMemory::SetRawDataHoldBuffer( const CMemory& pcmemData )
 	if( this == &pcmemData ){
 		return;
 	}
-	const void*	pData;
-	int		nDataLen;
-	pData = pcmemData.GetRawPtr( &nDataLen );
+	int	nDataLen = pcmemData.GetRawLength();
+	const void*	pData = pcmemData.GetRawPtr();
 	SetRawDataHoldBuffer( pData, nDataLen );
 	return;
 }
@@ -353,8 +348,8 @@ void CMemory::AppendRawData( const CMemory* pcmemData )
 		CMemory cm = *pcmemData;
 		AppendRawData(&cm);
 	}
-	int	nDataLen;
-	const void*	pData = pcmemData->GetRawPtr( &nDataLen );
+	int	nDataLen = pcmemData->GetRawLength();
+	const void*	pData = pcmemData->GetRawPtr();
 	AllocBuffer( m_nRawLen + nDataLen );
 	_AddData( pData, nDataLen );
 }

--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -176,9 +176,8 @@ void CMemory::SwapHLByte( char* pData, const int nDataLen ){
 	@note	nBufLen が2の倍数でないときは、最後の1バイトは交換されない
 */
 void CMemory::SwapHLByte( void ){
-	char *pBuf;
-	int nBufLen;
-	pBuf = reinterpret_cast<char*>( GetRawPtr(&nBufLen) );
+	int nBufLen = GetRawLength();
+	char* pBuf = reinterpret_cast<char*>( GetRawPtr() );
 	SwapHLByte( pBuf, nBufLen );
 	return;
 /*

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -65,7 +65,6 @@ public:
 	void Clear(){ _Empty(); }
 
 	inline const void* GetRawPtr(int* pnLength) const;      //!< データへのポインタと長さ返す
-	inline void* GetRawPtr(int* pnLength);                  //!< データへのポインタと長さ返す
 	inline const void* GetRawPtr() const{ return m_pRawData; } //!< データへのポインタを返す
 	inline void* GetRawPtr(){ return m_pRawData; }             //!< データへのポインタを返す
 	int GetRawLength() const { return m_nRawLen; }                //!<データ長を返す。バイト単位。
@@ -124,11 +123,6 @@ private: // 2002/2/10 aroka アクセス権変更
 //                     inline関数の実装                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 inline const void* CMemory::GetRawPtr(int* pnLength) const //!< データへのポインタと長さ返す
-{
-	if(pnLength) *pnLength = GetRawLength();
-	return m_pRawData;
-}
-inline void* CMemory::GetRawPtr(int* pnLength) //!< データへのポインタと長さ返す
 {
 	if(pnLength) *pnLength = GetRawLength();
 	return m_pRawData;

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -64,7 +64,6 @@ public:
 	void Clean(){ _Empty(); }
 	void Clear(){ _Empty(); }
 
-	inline const void* GetRawPtr(int* pnLength) const;      //!< データへのポインタと長さ返す
 	inline const void* GetRawPtr() const{ return m_pRawData; } //!< データへのポインタを返す
 	inline void* GetRawPtr(){ return m_pRawData; }             //!< データへのポインタを返す
 	int GetRawLength() const { return m_nRawLen; }                //!<データ長を返す。バイト単位。
@@ -122,11 +121,6 @@ private: // 2002/2/10 aroka アクセス権変更
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                     inline関数の実装                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-inline const void* CMemory::GetRawPtr(int* pnLength) const //!< データへのポインタと長さ返す
-{
-	if(pnLength) *pnLength = GetRawLength();
-	return m_pRawData;
-}
 
 ///////////////////////////////////////////////////////////////////////
 #endif /* _CMEMORY_H_ */

--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -122,12 +122,6 @@ int CNativeA::GetStringLength() const
 	return CNative::GetRawLength() / sizeof(char);
 }
 
-const char* CNativeA::GetStringPtr(int* pnLength) const
-{
-	if(pnLength)*pnLength=GetStringLength();
-	return GetStringPtr();
-}
-
 // 任意位置の文字取得。nIndexは文字単位。
 char CNativeA::operator[](int nIndex) const
 {

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -56,7 +56,6 @@ public:
 	{
 		return reinterpret_cast<char*>(GetRawPtr());
 	}
-	const char* GetStringPtr(int* pnLength) const; //[out]pnLengthは文字単位。
 
 	//演算子
 	CNativeA& operator = (const CNativeA& rhs)			{ CNative::operator=(rhs); return *this; }

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -125,14 +125,11 @@ bool CNativeW::IsEqual( const CNativeW& cmem1, const CNativeW& cmem2 )
 {
 	if(&cmem1==&cmem2)return true;
 
-	const wchar_t* psz1;
-	const wchar_t* psz2;
-	int nLen1;
-	int nLen2;
-
-	psz1 = cmem1.GetStringPtr( &nLen1 );
-	psz2 = cmem2.GetStringPtr( &nLen2 );
+	const int nLen1 = cmem1.GetStringLength();
+	const int nLen2 = cmem2.GetStringLength();
 	if( nLen1 == nLen2 ){
+		const wchar_t* psz1 = cmem1.GetStringPtr();
+		const wchar_t* psz2 = cmem2.GetStringPtr();
 		if( 0 == wmemcmp( psz1, psz2, nLen1 ) ){
 			return true;
 		}

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -99,20 +99,6 @@ public:
 	{
 		return reinterpret_cast<wchar_t*>(GetRawPtr());
 	}
-	const wchar_t* GetStringPtr(int* pnLength) const //[out]pnLengthは文字単位。
-	{
-		*pnLength=GetStringLength();
-		return reinterpret_cast<const wchar_t*>(GetRawPtr());
-	}
-#ifdef USE_STRICT_INT
-	const wchar_t* GetStringPtr(CLogicInt* pnLength) const //[out]pnLengthは文字単位。
-	{
-		int n;
-		const wchar_t* p=GetStringPtr(&n);
-		*pnLength=CLogicInt(n);
-		return p;
-	}
-#endif
 
 	//特殊
 	void _SetStringLength(int nLength)

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -541,9 +541,8 @@ BOOL CEditView::MakeDiffTmpFile2( WCHAR* tmpName, const WCHAR* orgName, ECodeTyp
 		CNativeW cLine;
 		CEol cEol;
 		while( RESULT_FAILURE != cfl.ReadLine( &cLine, &cEol ) ) {
-			const wchar_t*	pLineData;
-			CLogicInt		nLineLen;
-			pLineData= cLine.GetStringPtr(&nLineLen);
+			const CLogicInt nLineLen = cLine.GetStringLength();
+			const wchar_t* pLineData= cLine.GetStringPtr();
 			if( 0 == nLineLen || NULL == pLineData ) break;
 			if( bBom ){
 				CNativeW cLine2(L"\ufeff");


### PR DESCRIPTION
# PR の目的
x64対応をスムーズに行うために、文字列長取得メソッドのオーバーロードを廃止します。



## カテゴリ

- リファクタリング


## PR の背景

x64対応を行うための準備作業です。

- 次のような文字列ポインタと文字列長を同時に取得するメソッドを廃止します。
https://github.com/sakura-editor/sakura/blob/f1146c8c02838e7b247ef33cf671c5b0043ffeae/sakura_core/mem/CMemory.h#L126-L130


引数型 `int* pnLength` という宣言は、**呼出側に「文字列長を int 型で扱う」ことを強制** します。

int型というのは 32bit 符号付き整数を格納できる型です。
`int*` は **指定したアドレスから始まる4bytesデータ** を示します。

64bit環境のC++では文字列長を size_t 型(64bit 符号なし整数型)で扱います。
`size_t*` は **指定したアドレスから始まる8bytesデータ** を示します。

4bytesデータへのポインタを渡すべき関数に、
8bytesデータへのポインタを渡したらどうなるか？

それを考えるのは非常にめんどくさいので、引数型 `int* pnLength` 自体を廃止したいと思います。


## PR のメリット

これは準備PRなので具体的なメリットはありません。


## PR のデメリット (トレードオフとかあれば)

- 大した変更ではないのに変更量が多いです。
- CDocLine, CLayoutなどに存在する同種のメソッドは、利用箇所が多いので一旦放置します。


## PR の影響範囲

- アプリ(=サクラエディタ)の機能には、基本的に影響ありません。


## 関連チケット

とくにありません。


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
