### PR TITLE
ノート線描画、指定桁縦線描画、折り返し桁縦線描画、を行毎ではなく一括で行うように変更

### DIFF
--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -239,8 +239,7 @@ public:
 protected:
 	//! ロジック行を1行描画
 	bool DrawLogicLine(
-		HDC				hdc,			//!< [in]     作画対象
-		DispPos*		pDispPos,		//!< [in,out] 描画する箇所、描画元ソース
+		SColorStrategyInfo* pInfo,		//!< [in,out] 
 		CLayoutInt		nLineTo			//!< [in]     作画終了するレイアウト行番号
 	);
 


### PR DESCRIPTION
# PR の目的

描画処理の負荷軽減＆高速化が目的で以下の変更を行いました。

- `CEditView::DrawLogicLine` のローカル変数で `SColorStrategyInfo` 型のインスタンスを用意するのではなく引数で渡すように変更
  - `CEditView::DrawLogicLine` メソッドのローカル変数にしてしまうと、インスタンスの破棄が論理行毎に行われます。`SColorStrategyInfo::m_gr` の型が `CGraphics` で解放処理が比較的重いようです。

- ノート線描画、指定桁縦線描画、折り返し桁縦線描画 は `CEditView::DrawLayoutLine` 内で行毎に行うのではなく、`CEditView::OnPaint2` において一括で行うように変更
  - 一括で行うようにしても問題が無いと思います。行毎に呼び出すのではなく一括で描画するようにすれば呼び出し回数が減るので処理負荷を下げる事が出来ます。

## カテゴリ

- 速度向上

## PR の背景

Performance Profiler で確認すると描画処理の割合がかなり大きいので、少しでも減らせないかと対策を入れました。

## PR のメリット

同等の処理をより少ない負担で行えるようになるので軽くなります。

## PR のデメリット (トレードオフとかあれば)

不明

## PR の影響範囲

描画処理

## 関連チケット

#998 
