### PR TITLE
ノート線描画を少し分かりやすくする

### DIFF
--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -821,13 +821,11 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 
 		// ノート線描画
 		if( !m_bMiniMap ){
-			GetTextDrawer().DispNoteLines(
-				pInfo->m_gr,
-				y0,
-				y1,
-				GetTextArea().GetAreaLeft(),
-				GetTextArea().GetAreaRight()
-			);
+			LONG left = GetTextArea().GetAreaLeft();
+			LONG top = y0;
+			LONG right = GetTextArea().GetAreaRight();
+			LONG bottom = y1;
+			GetTextDrawer().DispNoteLines( pInfo->m_gr, left, top, right, bottom );
 		}
 	
 		// 指定桁縦線描画

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -821,7 +821,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 
 		// ノート線描画
 		if( !m_bMiniMap ){
-			GetTextDrawer().DispNoteLine(
+			GetTextDrawer().DispNoteLines(
 				pInfo->m_gr,
 				y0,
 				y1,

--- a/sakura_core/view/CEditView_Paint_Bracket.cpp
+++ b/sakura_core/view/CEditView_Paint_Bracket.cpp
@@ -232,7 +232,7 @@ void CEditView::DrawBracketPair( bool bDraw )
 					DispPos sPos(nWidth, nHeight);
 					sPos.InitDrawPos(CMyPoint(nLeft, nTop));
 					GetTextDrawer().DispText(gr, &sPos, 0, &pLine[OutputX], 1, bTrans);
-					GetTextDrawer().DispNoteLines(gr, nTop, nTop + nHeight, nLeft, nLeft + (Int)charsWidth * nWidth);
+					GetTextDrawer().DispNoteLines(gr, nLeft, nTop, nLeft + (Int)charsWidth * nWidth, nTop + nHeight);
 					// 2006.04.30 Moca 対括弧の縦線対応
 					GetTextDrawer().DispVerticalLines(gr, nTop, nTop + nHeight, ptColLine.x, ptColLine.x + charsWidth); //※括弧が全角幅である場合を考慮
 					cTextType.RewindGraphicsState(gr);

--- a/sakura_core/view/CEditView_Paint_Bracket.cpp
+++ b/sakura_core/view/CEditView_Paint_Bracket.cpp
@@ -232,7 +232,7 @@ void CEditView::DrawBracketPair( bool bDraw )
 					DispPos sPos(nWidth, nHeight);
 					sPos.InitDrawPos(CMyPoint(nLeft, nTop));
 					GetTextDrawer().DispText(gr, &sPos, 0, &pLine[OutputX], 1, bTrans);
-					GetTextDrawer().DispNoteLine(gr, nTop, nTop + nHeight, nLeft, nLeft + (Int)charsWidth * nWidth);
+					GetTextDrawer().DispNoteLines(gr, nTop, nTop + nHeight, nLeft, nLeft + (Int)charsWidth * nWidth);
 					// 2006.04.30 Moca 対括弧の縦線対応
 					GetTextDrawer().DispVerticalLines(gr, nTop, nTop + nHeight, ptColLine.x, ptColLine.x + charsWidth); //※括弧が全角幅である場合を考慮
 					cTextType.RewindGraphicsState(gr);

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -281,7 +281,7 @@ void CTextDrawer::DispVerticalLines(
 	}
 }
 
-void CTextDrawer::DispNoteLine(
+void CTextDrawer::DispNoteLines(
 	CGraphics&	gr,			//!< 作画するウィンドウのDC
 	int			nTop,		//!< 線を引く上端のクライアント座標y
 	int			nBottom,	//!< 線を引く下端のクライアント座標y
@@ -573,7 +573,7 @@ void CTextDrawer::DispLineNumber(
 		int right  = pView->GetTextArea().GetAreaLeft();
 		int top    = y;
 		int bottom = y + nLineHeight;
-		DispNoteLine( gr, top, bottom, left, right );
+		DispNoteLines( gr, top, bottom, left, right );
 	}
 }
 

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -312,7 +312,7 @@ void CTextDrawer::DispNoteLines(
 		}
 
 		std::vector<DWORD> vNumPts(vLineEnds.size() / 2, 2);
-		::PolyPolyline(gr, vLineEnds.data(), vNumPts.data(), vNumPts.size());
+		::PolyPolyline(gr, vLineEnds.data(), vNumPts.data(), static_cast<DWORD>(vNumPts.size()));
 	}
 }
 

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -283,10 +283,10 @@ void CTextDrawer::DispVerticalLines(
 
 void CTextDrawer::DispNoteLines(
 	CGraphics&	gr,			//!< 作画するウィンドウのDC
-	int			nTop,		//!< 線を引く上端のクライアント座標y
-	int			nBottom,	//!< 線を引く下端のクライアント座標y
-	int			nLeft,		//!< 線を引く左端
-	int			nRight		//!< 線を引く右端
+	LONG		top,		//!< ノート線を引く領域の上端のクライアント座標y
+	LONG		bottom,		//!< ノート線を引く領域の下端のクライアント座標y
+	LONG		left,		//!< ノート線を引く領域の左端のクライアント座標x
+	LONG		right		//!< ノート線を引く領域の右端のクライアント座標x
 ) const
 {
 	const CEditView* pView=m_pEditView;
@@ -294,18 +294,16 @@ void CTextDrawer::DispNoteLines(
 	CTypeSupport cNoteLine(pView, COLORIDX_NOTELINE);
 	if( cNoteLine.IsDisp() ){
 		gr.SetPen( cNoteLine.GetTextColor() );
-		const int nLineHeight = pView->GetTextMetrics().GetHankakuDy();
-		const int left = nLeft;
-		const int right = nRight;
-		int userOffset = pView->m_pTypeData->m_nNoteLineOffset;
-		int offset = pView->GetTextArea().GetAreaTop() + userOffset - 1;
+		const LONG nLineHeight = pView->GetTextMetrics().GetHankakuDy();
+		const LONG userOffset = pView->m_pTypeData->m_nNoteLineOffset;
+		LONG offset = pView->GetTextArea().GetAreaTop() + userOffset - 1;
 		while( offset < 0 ){
 			offset += nLineHeight;
 		}
-		int offsetMod = offset % nLineHeight;
-		int y = ((nTop - offset) / nLineHeight * nLineHeight) + offsetMod;
-		for( ; y < nBottom; y += nLineHeight ){
-			if( nTop <= y ){
+		LONG offsetMod = offset % nLineHeight;
+		LONG y = ((top - offset) / nLineHeight * nLineHeight) + offsetMod;
+		for( ; y < bottom; y += nLineHeight ){
+			if( top <= y ){
 				::MoveToEx( gr, left, y, NULL );
 				::LineTo( gr, right, y );
 			}

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -283,10 +283,10 @@ void CTextDrawer::DispVerticalLines(
 
 void CTextDrawer::DispNoteLines(
 	CGraphics&	gr,			//!< 作画するウィンドウのDC
-	LONG		top,		//!< ノート線を引く領域の上端のクライアント座標y
-	LONG		bottom,		//!< ノート線を引く領域の下端のクライアント座標y
 	LONG		left,		//!< ノート線を引く領域の左端のクライアント座標x
-	LONG		right		//!< ノート線を引く領域の右端のクライアント座標x
+	LONG		top,		//!< ノート線を引く領域の上端のクライアント座標y
+	LONG		right,		//!< ノート線を引く領域の右端のクライアント座標x
+	LONG		bottom		//!< ノート線を引く領域の下端のクライアント座標y
 ) const
 {
 	const CEditView* pView=m_pEditView;
@@ -567,11 +567,11 @@ void CTextDrawer::DispLineNumber(
 
 	// 行番号部分のノート線描画
 	if( !pView->m_bMiniMap ){
-		int left   = bDispLineNumTrans ? 0 : rcLineNum.right;
-		int right  = pView->GetTextArea().GetAreaLeft();
-		int top    = y;
-		int bottom = y + nLineHeight;
-		DispNoteLines( gr, top, bottom, left, right );
+		LONG left   = bDispLineNumTrans ? 0 : rcLineNum.right;
+		LONG top    = y;
+		LONG right  = pView->GetTextArea().GetAreaLeft();
+		LONG bottom = y + nLineHeight;
+		DispNoteLines( gr, left, top, right, bottom );
 	}
 }
 

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -300,14 +300,19 @@ void CTextDrawer::DispNoteLines(
 		while( offset < 0 ){
 			offset += nLineHeight;
 		}
+
+		std::vector<CMyPoint> vLineEnds;
 		LONG offsetMod = offset % nLineHeight;
 		LONG y = ((top - offset) / nLineHeight * nLineHeight) + offsetMod;
 		for( ; y < bottom; y += nLineHeight ){
 			if( top <= y ){
-				::MoveToEx( gr, left, y, NULL );
-				::LineTo( gr, right, y );
+				vLineEnds.push_back(CMyPoint(left, y));
+				vLineEnds.push_back(CMyPoint(right, y));
 			}
 		}
+
+		std::vector<DWORD> vNumPts(vLineEnds.size() / 2, 2);
+		::PolyPolyline(gr, vLineEnds.data(), vNumPts.data(), vNumPts.size());
 	}
 }
 

--- a/sakura_core/view/CTextDrawer.h
+++ b/sakura_core/view/CTextDrawer.h
@@ -55,7 +55,7 @@ public:
 	void DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar_t* pData, int nLength, bool bTransparent = false ) const; // テキスト表示
 
 	//!	ノート線描画
-	void DispNoteLines( CGraphics& gr, int nTop, int nBottom, int nLeft, int nRight ) const;
+	void DispNoteLines( CGraphics& gr, LONG top, LONG bottom, LONG left, LONG right ) const;
 
 	// -- -- 指定桁縦線描画 -- -- //
 	//!	指定桁縦線描画関数	// 2005.11.08 Moca

--- a/sakura_core/view/CTextDrawer.h
+++ b/sakura_core/view/CTextDrawer.h
@@ -55,7 +55,7 @@ public:
 	void DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar_t* pData, int nLength, bool bTransparent = false ) const; // テキスト表示
 
 	//!	ノート線描画
-	void DispNoteLines( CGraphics& gr, LONG top, LONG bottom, LONG left, LONG right ) const;
+	void DispNoteLines( CGraphics& gr, LONG left, LONG top, LONG right, LONG bottom ) const;
 
 	// -- -- 指定桁縦線描画 -- -- //
 	//!	指定桁縦線描画関数	// 2005.11.08 Moca

--- a/sakura_core/view/CTextDrawer.h
+++ b/sakura_core/view/CTextDrawer.h
@@ -55,7 +55,7 @@ public:
 	void DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar_t* pData, int nLength, bool bTransparent = false ) const; // テキスト表示
 
 	//!	ノート線描画
-	void DispNoteLine( CGraphics& gr, int nTop, int nBottom, int nLeft, int nRight ) const;
+	void DispNoteLines( CGraphics& gr, int nTop, int nBottom, int nLeft, int nRight ) const;
 
 	// -- -- 指定桁縦線描画 -- -- //
 	//!	指定桁縦線描画関数	// 2005.11.08 Moca


### PR DESCRIPTION
# PR の目的

ノート線描画に関わるコードを整理して、メンテナンスしやすくします。


## カテゴリ

- リファクタリング


## PR の背景

https://github.com/sakura-editor/sakura/pull/1065#issuecomment-538615948 で指摘した内容を実装してみました。

1. 指定した範囲内にノート線を描くメソッドに単数形の名前が付いている  
⇒ 元々複数の横線を描く目的のメソッドだから改名しよう！
2. 引数の型が int になので、ピクセル指定か桁指定か紛らわしい(と思った)  
※ 最近の Windows GDI では、ピクセル位置を指定するのに LONG 型の変数を使います。  
⇒ 引数がピクセル指定であることを明示するために LONG 型に訂正しよう！
3. 領域を受け取る関数は left, top, right, bottom の順に指定するのが標準(だと思います)  
⇒ [標準](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setrect) に合わせて指定順を変更しよう！
4. 複数の線分を描く目的の関数なのに、線分を1本ずつ描いているのが効率悪い(気がする)  
⇒ 描画に必要なデータを作る処理とAPI呼出を分離して一撃で描画するように改善しよう！


## PR のメリット

- ノート線描画の処理が少し分かりやすくなります。


## PR のデメリット (トレードオフとかあれば)

- メソッドの引数変更を伴うので、影響範囲が広いです。
- この対応を行うことにより、ノート線描画にもDPI対応が必要であることに気付きましたが、放置しています。

## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響がある変更です。
  - ただし、見た目も体感速度も変化してない気がします。
- ノート線描画を行う処理に影響します。
  - 通常の描画処理(行番号を含む行データの描画)
  - 通常の描画処理(行番号のみの描画)
  - 対括弧の強調表示により上書き描画を行う際のノート線の描画処理
- ノート線描画の処理内容が変更になります。
  - 変更前) 描画するノート線の本数分だけ `MoveToEx + LineTo` 繰り返し。
  - 変更後) 描画するノート線の本数に関わらず `PolyPolyLine` 一発。
- 変更による影響として大きいのは、今後のメンテナンスがしやすくなる(主観)ことだと思っています。


## 関連チケット

#1065 ノート線描画、指定桁縦線描画、折り返し桁縦線描画、を行毎ではなく一括で行うように変更


## 参考資料

https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-polypolyline
https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-movetoex
https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-lineto
