### PR TITLE
ルーラー描画の高速化

### DIFF
--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -159,11 +159,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 	}
 
 	// 目盛り線を1本ずつ描画するのではなく後述する PolyPolyline でまとめて描画を行う
-#ifdef USE_STRICT_INT
-	const int nWidth = (m_pEditView->GetTextArea().GetRightCol() - i).GetValue();
-#else
-	const int nWidth = m_pEditView->GetTextArea().GetRightCol() - i;
-#endif
+	const int nWidth = (Int)(m_pEditView->GetTextArea().GetRightCol() - i);
 	const size_t nLinesToDraw = 1 + std::min<int>((nWidth + 1 + 1 + oneColumn - 1) / oneColumn, nMaxLineKetas - keta + 1);
 	auto& apt = m_apt;
 	auto& asz = m_asz;

--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -98,8 +98,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 		m_hFont = NULL;
 	}
 	if (m_hFont == NULL) {
-		LOGFONT	lf;
-		memset_raw( &lf, 0, sizeof(lf) );
+		LOGFONT	lf = {0};
 		lf.lfHeight			= 1 - pCommon->m_sWindow.m_nRulerHeight;	//	2002/05/13 ai
 		lf.lfWidth			= 0;
 		lf.lfEscapement		= 0;
@@ -113,7 +112,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 		lf.lfClipPrecision	= 2;
 		lf.lfQuality		= 1;
 		lf.lfPitchAndFamily	= 34;
-		wcscpy( lf.lfFaceName, L"Arial" );
+		wcscpy_s( lf.lfFaceName, L"Arial" );
 		m_hFont = ::CreateFontIndirect( &lf );
 		m_nRulerHeight = pCommon->m_sWindow.m_nRulerHeight;
 	}

--- a/sakura_core/view/CRuler.h
+++ b/sakura_core/view/CRuler.h
@@ -67,6 +67,11 @@ private:
 	bool	m_bRedrawRuler;		// ルーラー全体を描き直す時 = true      2002.02.25 Add By KK
 	int		m_nOldRulerDrawX;	// 前回描画したルーラーのキャレット位置 2002.02.25 Add By KK  2007.08.26 kobake 名前変更
 	int		m_nOldRulerWidth;	// 前回描画したルーラーのキャレット幅   2002.02.25 Add By KK  2007.08.26 kobake 名前変更
+
+	HFONT	m_hFont; // ルーラー上の数字用フォント
+	int		m_nRulerHeight;
+	std::vector<POINT> m_apt;
+	std::vector<DWORD> m_asz;
 };
 
 #endif /* SAKURA_CRULER_CF213704_1CF6_427E_AD78_D628D2D1F9029_H_ */


### PR DESCRIPTION
# PR の目的

ルーラー描画の高速化が目的です。同等の処理をより少ない負担で行う事で効率化を図ります。

## カテゴリ

- 速度向上

## PR の背景

ルーラーの背景描画で目盛り線を一本ずつ描くより、`PolyPolyline` 関数を使用してまとめて描くことで処理時間の短縮が出来るのではないかと考え変更しました。

Performance Profiler で確認する限りでは、`DrawRulerBg` に 3% 程度掛かっていたのが 1% 程度に減りました。

フォントのハンドルや `PolyPolyline` 関数のパラメータとして使用する動的配列はローカル変数ではなく `CRuler` クラスのメンバー変数にして再利用する事で、呼び出すたびに毎回作成と破棄される事が無いようにしました。

## PR のメリット

メリットとしては描画処理が幾分か軽くなります。

## PR のデメリット (トレードオフとかあれば)

実装が少し複雑になります。

## PR の影響範囲

ルーラーの描画処理
