### PR TITLE
[WIP] 行番号描画内のノート線描画を関数の外に出す。

### DIFF
--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -239,12 +239,13 @@ public:
 protected:
 	//! ロジック行を1行描画
 	bool DrawLogicLine(
-		SColorStrategyInfo* pInfo,		//!< [in,out] 
-		CLayoutInt		nLineTo			//!< [in]     作画終了するレイアウト行番号
+		SColorStrategyInfo* pInfo,				//!< [in,out] 
+		const CLayoutInt	nLineTo,			//!< [in]     作画終了するレイアウト行番号
+		bool&				bDispLineNumTrans
 	);
 
 	//! レイアウト行を1行描画
-	bool DrawLayoutLine(SColorStrategyInfo* pInfo);
+	bool DrawLayoutLine(SColorStrategyInfo* pInfo, bool& bDispLineNumTrans);
 
 	//色分け
 public:

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -763,6 +763,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 
 	//必要な行を描画する	// 2009.03.26 ryoji 行番号のみ描画を通常の行描画と分離（効率化）
 	if(pPs->rcPaint.right <= GetTextArea().GetAreaLeft()){
+		auto y0 = sPos.GetDrawPos().y;
 		while(sPos.GetLayoutLineRef() <= nLayoutLineTo)
 		{
 			if(!sPos.GetLayoutRef())
@@ -778,6 +779,17 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 			sPos.ForwardDrawLine(1);		//描画Y座標＋＋
 			sPos.ForwardLayoutLineRef(1);	//レイアウト行＋＋
 		}
+		auto y1 = sPos.GetDrawPos().y;
+
+		// 行番号部分のノート線描画
+		if( !m_bMiniMap ){
+			LONG left   = std::max<LONG>(pPs->rcPaint.left, 0);
+			LONG top    = y0;
+			LONG right  = std::min<LONG>(pPs->rcPaint.right, GetTextArea().GetAreaLeft());
+			LONG bottom = y1;
+			GetTextDrawer().DispNoteLines( gr, left, top, right, bottom );
+		}
+
 	}else{
 
 		SColorStrategyInfo _sInfo;
@@ -821,7 +833,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 
 		// ノート線描画
 		if( !m_bMiniMap ){
-			LONG left = GetTextArea().GetAreaLeft();
+			LONG left = std::min<LONG>(pPs->rcPaint.left, GetTextArea().GetAreaLeft());
 			LONG top = y0;
 			LONG right = GetTextArea().GetAreaRight();
 			LONG bottom = y1;

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -569,14 +569,5 @@ void CTextDrawer::DispLineNumber(
 		rcRest.bottom = y + nLineHeight;
 		cBackType.FillBack(gr,rcRest);
 	}
-
-	// 行番号部分のノート線描画
-	if( !pView->m_bMiniMap ){
-		LONG left   = bDispLineNumTrans ? 0 : rcLineNum.right;
-		LONG top    = y;
-		LONG right  = pView->GetTextArea().GetAreaLeft();
-		LONG bottom = y + nLineHeight;
-		DispNoteLines( gr, left, top, right, bottom );
-	}
 }
 

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -355,7 +355,8 @@ void CTextDrawer::DispWrapLine(
 void CTextDrawer::DispLineNumber(
 	CGraphics&		gr,
 	CLayoutInt		nLineNum,
-	int				y
+	LONG			y,
+	bool&			bDispLineNumTrans
 ) const
 {
 	//$$ 高速化：SearchLineByLayoutYにキャッシュを持たせる
@@ -426,7 +427,6 @@ void CTextDrawer::DispLineNumber(
 	
 	bool bTrans = pView->IsBkBitmap() && cTextType.GetBackColor() == cColorType.GetBackColor();
 	bool bTransText = pView->IsBkBitmap() && cTextType.GetBackColor() == cBackType.GetBackColor();
-	bool bDispLineNumTrans = false;
 
 	COLORREF fgcolor = cColorType.GetTextColor();
 	COLORREF bgcolor = cColorType.GetBackColor();

--- a/sakura_core/view/CTextDrawer.h
+++ b/sakura_core/view/CTextDrawer.h
@@ -65,7 +65,7 @@ public:
 	void DispWrapLine( CGraphics& gr, int nTop, int nBottom ) const;
 
 	// -- -- 行番号 -- -- //
-	void DispLineNumber( CGraphics& gr, CLayoutInt nLineNum, int y ) const;		// 行番号表示
+	void DispLineNumber( CGraphics& gr, CLayoutInt nLineNum, LONG y, bool& bDispLineNumTrans ) const;		// 行番号表示
 
 private:
 	const CEditView* m_pEditView;


### PR DESCRIPTION
# PR の目的

行番号描画内のノート線描画を関数の外に出すことにより、Windows APIの呼出回数を減らします。(高速化)


## カテゴリ

- 速度向上
- リファクタリング


## PR の背景

https://github.com/sakura-editor/sakura/pull/1066#issuecomment-538719255 で書いたことを実装してみました。

呼出階層
- CEditView::OnPaint2 編集ビューの描画処理関数
  - CTextDrawer::DispLineNumber 行単位で行番号を描画する関数
    - CTextDrawer::DispNoteLines 範囲指定で複数のノート線を描画する関数

CTextDrawer::DispNoteLinesは、指定範囲に含まれる複数のノート線を描けるので、行単位描画のCTextDrawer::DispLineNumberから呼び出すよりも、ループの外側で呼んだほうが効率がいいんじゃないか？という話です。


## PR のメリット

- Windows APIの呼出回数が減るので速度向上を期待できます。
- 描画処理の構成が少しだけ分かりやすくなります。(主観)


## PR のデメリット (トレードオフとかあれば)

- 行番号表示 CTextDrawer::DispLineNumber の処理内容からノート線描画が外れるため、「行番号＋行データ」のノート線描画の描画範囲を拡張する必要があります。
- 変更前の「行番号のみ」の left の算出方法が謎だったので、その部分の仕様をカットしています。
  - ひょっとすると「特定の場合に行番号部分のノート線を表示しない」という仕様があったかも知れず、その仕様を消してるかもしれません。
    - 実用上の影響はほとんどないだろうと考えていますが。


## PR の影響範囲

- アプリ(=サクラエディタ)の機能に影響がある変更です。
  - 具体的な影響は体感できていません。
- ノート線表示時のノート線描画に影響します。
  - 変更前) 行番号部分と行データ部分のノート線を別々に描画していた。
  - 変更後) 行番号部分と行データ部分のノート線を一緒に描画するように変更。


## 関連チケット
#1065 ノート線描画、指定桁縦線描画、折り返し桁縦線描画、を行毎ではなく一括で行うように変更
#1066 ノート線描画を少し分かりやすくする


## 参考資料
とくになし
