### PR TITLE
Funccode_x.hsrc の typo 修正

### DIFF
--- a/sakura_core/Funccode_x.hsrc
+++ b/sakura_core/Funccode_x.hsrc
@@ -265,7 +265,7 @@ F_COPYDIRPATH				= 30631,	//このファイルのフォルダ名をクリップ�
 F_INS_DATE				= 30790,	//日付挿入										なし
 F_INS_TIME				= 30791,	//時刻挿入										なし
 F_CTRL_CODE_DIALOG		= 30792,	//コントロールコードの入力(ダイアログ)			なし
-F_CTRL_CODE				= 30793.	//コントロールコードの入力						wchar_t code
+F_CTRL_CODE				= 30793,	//コントロールコードの入力						wchar_t code
 F_INS_FILE_USED_RECENTLY	= 30794,	// 最近使ったファイル挿入
 F_INS_FOLDER_USED_RECENTLY	= 30795,	// 最近使ったフォルダ挿入
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートに切り替えることで登録後にどのように見えるか確認することができます -->

# PR の目的

単なる typo の修正です．
HeaderMake は `.` `,` の違いを認識しないようなので，バイナリへの影響はありません．

## カテゴリ

- リファクタリング

## PR の背景

単なる typo の修正です．

## PR のメリット

他の行と記述の統一感が上がる，くらいでしょうか

## PR のデメリット (トレードオフとかあれば)

特になし

## PR の影響範囲

特になし

## 関連チケット

特になし

## 参考資料

特になし
