### PR TITLE
プログラム内からドキュメントにアクセスする方法を分かりやすくする

### DIFF
--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -610,7 +610,7 @@ bool CClipboard::GetClipboradByFormat(CNativeW& mem, const wchar_t* pFormatName,
 				if( nBomCode != CODE_NONE ){
 					eMode = nBomCode;
 				}else{
-					const STypeConfig& type = CEditDoc::GetInstance(0)->m_cDocType.GetDocumentAttribute();
+					const STypeConfig& type = CEditDoc::getInstance()->m_cDocType.GetDocumentAttribute();
 					CCodeMediator mediator(type.m_encoding);
 					eMode = mediator.CheckKanjiCode((const char*)pData, nLength);
 				}

--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -60,7 +60,7 @@ static const int codeTable2[] = { 0x00, 0x10, 0x100 };
 int CDlgExec::DoModal( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam )
 {
 	m_szCommand[0] = L'\0';	/* コマンドライン */
-	m_bEditable = CEditDoc::GetInstance(0)->IsEditable();
+	m_bEditable = CEditDoc::getInstance()->IsEditable();
 	return (int)CDialog::DoModal( hInstance, hwndParent, IDD_EXEC, lParam );
 }
 

--- a/sakura_core/doc/CDocListener.cpp
+++ b/sakura_core/doc/CDocListener.cpp
@@ -128,7 +128,7 @@ DEF_NOTIFY(BeforeClose)
 
 CDocListener::CDocListener(CDocSubject* pcDoc)
 {
-	if(pcDoc==NULL)pcDoc = CEditDoc::GetInstance(0); //$$ インチキ
+	if(pcDoc==NULL)pcDoc = CEditDoc::getInstance(); //$$ インチキ
 	assert( pcDoc );
 	Listen(pcDoc);
 }

--- a/sakura_core/doc/CDocListener.cpp
+++ b/sakura_core/doc/CDocListener.cpp
@@ -128,7 +128,7 @@ DEF_NOTIFY(BeforeClose)
 
 CDocListener::CDocListener(CDocSubject* pcDoc)
 {
-	if(pcDoc==NULL)pcDoc = CEditDoc::getInstance(); //$$ インチキ
+	if(pcDoc==NULL)pcDoc = const_cast<CEditDoc*>(CEditDoc::getInstance()); //$$ インチキ
 	assert( pcDoc );
 	Listen(pcDoc);
 }

--- a/sakura_core/doc/CDocVisitor.cpp
+++ b/sakura_core/doc/CDocVisitor.cpp
@@ -53,7 +53,7 @@ void CDocVisitor::SetAllEol(CEol cEol)
 			nLine++;
 		}
 		//編集時入力改行コード
-		CEditDoc::GetInstance(0)->m_cDocEditor.SetNewLineCode(cEol);
+		CEditDoc::getInstance()->m_cDocEditor.SetNewLineCode(cEol);
 	}
 
 	if( bReplace ){

--- a/sakura_core/doc/CDocVisitor.cpp
+++ b/sakura_core/doc/CDocVisitor.cpp
@@ -53,7 +53,7 @@ void CDocVisitor::SetAllEol(CEol cEol)
 			nLine++;
 		}
 		//編集時入力改行コード
-		CEditDoc::getInstance()->m_cDocEditor.SetNewLineCode(cEol);
+		m_pcDocRef->m_cDocEditor.SetNewLineCode(cEol);
 	}
 
 	if( bReplace ){

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -156,7 +156,7 @@ static const EFunctionCode EIsModificationForbidden[] = {
  * @note CEditDocは、エディタのプロセス内に1つだけ存在する。
  * @note CEditDocは、コントロールプロセス内には存在しない。
  */
-CEditDoc* TSingleton<CEditDoc>::getInstance()
+const CEditDoc* TSingleton<CEditDoc>::getInstance()
 {
 	auto pEditApp = CEditApp::getInstance();
 	if (!pEditApp) return nullptr;

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -150,6 +150,19 @@ static const EFunctionCode EIsModificationForbidden[] = {
 	F_HOKAN,
 };
 
+/*!
+ * @brief CEditDocのインスタンスを取得する
+ * 
+ * @note CEditDocは、エディタのプロセス内に1つだけ存在する。
+ * @note CEditDocは、コントロールプロセス内には存在しない。
+ */
+CEditDoc* TSingleton<CEditDoc>::getInstance()
+{
+	auto pEditApp = CEditApp::getInstance();
+	if (!pEditApp) return nullptr;
+	return pEditApp->GetDocument();
+}
+
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                        生成と破棄                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/doc/CEditDoc.h
+++ b/sakura_core/doc/CEditDoc.h
@@ -70,7 +70,7 @@ class CEditApp;
 template <>
 class TSingleton<class CEditDoc> {
 public:
-	static CEditDoc* getInstance();
+	static const CEditDoc* getInstance();
 
 	TSingleton() = default;
 };

--- a/sakura_core/doc/CEditDoc.h
+++ b/sakura_core/doc/CEditDoc.h
@@ -65,6 +65,17 @@ class CFuncInfoArr;
 class CEditApp;
 
 /*!
+ * @brief TSingletonの特殊化(CEditDoc向け)
+ */
+template <>
+class TSingleton<class CEditDoc> {
+public:
+	static CEditDoc* getInstance();
+
+	TSingleton() = default;
+};
+
+/*!
 	文書関連情報の管理
 
 	@date 2002.02.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
@@ -73,12 +84,16 @@ class CEditApp;
 	@date 2007.12.13 kobake IsViewMode作成
 */
 class CEditDoc
-: public CDocSubject
-, public TInstanceHolder<CEditDoc>
+	: public TSingleton<CEditDoc>
+	, public CDocSubject
 {
+	using _Myt = CEditDoc;
+
 public:
 	//コンストラクタ・デストラクタ
 	CEditDoc(CEditApp* pcApp);
+	CEditDoc(const _Myt&) = delete;
+	CEditDoc(_Myt&&) = delete;
 	~CEditDoc();
 
 	//初期化
@@ -115,6 +130,9 @@ public:
 	void SetBackgroundImage();
 
 	void SetCurDirNotitle();
+
+	_Myt& operator=(const _Myt&) = delete;
+	_Myt& operator=(_Myt&&) = delete;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                       メンバ変数群                          //

--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -110,7 +110,7 @@ wchar_t* ExParam_LongName( wchar_t* q, wchar_t* q_max, EExpParamName eLongParam 
 */
 void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszBuffer, int nBufferLen)
 {
-	const CEditDoc* pcDoc = CEditDoc::GetInstance(0); //###
+	const CEditDoc* pcDoc = CEditDoc::getInstance(); //###
 
 	// Apr. 03, 2003 genta 固定文字列をまとめる
 	const wstring	PRINT_PREVIEW_ONLY		= LS( STR_PREVIEW_ONLY );	//L"(印刷プレビューでのみ使用できます)";
@@ -636,14 +636,14 @@ const wchar_t* CSakuraEnvironment::_ExParam_SkipCond(const wchar_t* pszSource, i
 */
 int CSakuraEnvironment::_ExParam_Evaluate( const wchar_t* pCond )
 {
-	const CEditDoc* pcDoc = CEditDoc::GetInstance(0); //###
+	const CEditDoc* pcDoc = CEditDoc::getInstance(); //###
 
 	switch( *pCond ){
 	case L'R': // $R ビューモードおよび読み取り専用属性
 		if( CAppMode::getInstance()->IsViewMode() ){
 			return 0; // ビューモード
 		}
-		else if( !CEditDoc::GetInstance(0)->m_cDocLocker.IsDocWritable() ){
+		else if( !CEditDoc::getInstance()->m_cDocLocker.IsDocWritable() ){
 			return 1; // 上書き禁止
 		}
 		else{
@@ -713,7 +713,7 @@ wchar_t* ExParam_LongName( wchar_t* q, wchar_t* q_max, EExpParamName eLongParam 
 */
 std::wstring CSakuraEnvironment::GetDlgInitialDir(bool bControlProcess)
 {
-	CEditDoc* pcDoc = CEditDoc::GetInstance(0); //######
+	CEditDoc* pcDoc = CEditDoc::getInstance(); //######
 	if( pcDoc && pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 		return pcDoc->m_cDocFile.GetFilePathClass().GetDirPath().c_str();
 	}

--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -713,7 +713,7 @@ wchar_t* ExParam_LongName( wchar_t* q, wchar_t* q_max, EExpParamName eLongParam 
 */
 std::wstring CSakuraEnvironment::GetDlgInitialDir(bool bControlProcess)
 {
-	CEditDoc* pcDoc = CEditDoc::getInstance(); //######
+	const CEditDoc* pcDoc = CEditDoc::getInstance(); //######
 	if( pcDoc && pcDoc->m_cDocFile.GetFilePathClass().IsValidPath() ){
 		return pcDoc->m_cDocFile.GetFilePathClass().GetDirPath().c_str();
 	}

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3555,7 +3555,7 @@ bool CDlgFuncList::ChangeLayout( int nId )
 		bool* m_pbSwitch;
 	} SAutoSwitch( &m_bInChangeLayout );	// 処理中は m_bInChangeLayout フラグを ON にしておく
 
-	CEditDoc* pDoc = CEditDoc::getInstance();	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
+	const CEditDoc* pDoc = CEditDoc::getInstance();	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
 	m_nDocType = pDoc->m_cDocType.GetDocumentType().GetIndex();
 	CDocTypeManager().GetTypeConfig( CTypeConfig(m_nDocType), m_type );
 
@@ -3676,7 +3676,7 @@ bool CDlgFuncList::ChangeLayout( int nId )
 */
 void CDlgFuncList::OnOutlineNotify( WPARAM wParam, LPARAM lParam )
 {
-	CEditDoc* pDoc = CEditDoc::getInstance();	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
+	const CEditDoc* pDoc = CEditDoc::getInstance();	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
 	switch( wParam ){
 	case 0:	// 設定変更通知（ドッキングモード or サイズ）, lParam: 通知元の HWND
 		if( (HWND)lParam == pDoc->m_pcEditWnd->GetHwnd() )

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3317,7 +3317,7 @@ INT_PTR CDlgFuncList::OnNcPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 void CDlgFuncList::DoMenu( POINT pt, HWND hwndFrom )
 {
 	// メニューを作成する
-	CEditView* pcEditView = &CEditDoc::GetInstance(0)->m_pcEditWnd->GetActiveView();
+	CEditView* pcEditView = &CEditDoc::getInstance()->m_pcEditWnd->GetActiveView();
 	CDocTypeManager().GetTypeConfig( CTypeConfig(m_nDocType), m_type );
 	EDockSide eDockSide = ProfDockSide();	// 設定上の配置
 	UINT uFlags = MF_BYPOSITION | MF_STRING;
@@ -3529,7 +3529,7 @@ void CDlgFuncList::DoMenu( POINT pt, HWND hwndFrom )
 */
 void CDlgFuncList::Refresh( void )
 {
-	CEditWnd* pcEditWnd = CEditDoc::GetInstance(0)->m_pcEditWnd;
+	CEditWnd* pcEditWnd = CEditDoc::getInstance()->m_pcEditWnd;
 	BOOL bReloaded = ChangeLayout( OUTLINE_LAYOUT_FILECHANGED );	// 現在設定に従ってアウトライン画面を再配置する
 	if( !bReloaded && pcEditWnd->m_cDlgFuncList.GetHwnd() ){
 		EOutlineType nOutlineType = GetOutlineTypeRedraw(m_nOutlineType);
@@ -3555,7 +3555,7 @@ bool CDlgFuncList::ChangeLayout( int nId )
 		bool* m_pbSwitch;
 	} SAutoSwitch( &m_bInChangeLayout );	// 処理中は m_bInChangeLayout フラグを ON にしておく
 
-	CEditDoc* pDoc = CEditDoc::GetInstance(0);	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
+	CEditDoc* pDoc = CEditDoc::getInstance();	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
 	m_nDocType = pDoc->m_cDocType.GetDocumentType().GetIndex();
 	CDocTypeManager().GetTypeConfig( CTypeConfig(m_nDocType), m_type );
 
@@ -3676,7 +3676,7 @@ bool CDlgFuncList::ChangeLayout( int nId )
 */
 void CDlgFuncList::OnOutlineNotify( WPARAM wParam, LPARAM lParam )
 {
-	CEditDoc* pDoc = CEditDoc::GetInstance(0);	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
+	CEditDoc* pDoc = CEditDoc::getInstance();	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
 	switch( wParam ){
 	case 0:	// 設定変更通知（ドッキングモード or サイズ）, lParam: 通知元の HWND
 		if( (HWND)lParam == pDoc->m_pcEditWnd->GetHwnd() )

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3317,7 +3317,7 @@ INT_PTR CDlgFuncList::OnNcPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 void CDlgFuncList::DoMenu( POINT pt, HWND hwndFrom )
 {
 	// メニューを作成する
-	CEditView* pcEditView = &CEditDoc::getInstance()->m_pcEditWnd->GetActiveView();
+	CEditView* pcEditView = &CEditWnd::getInstance()->GetActiveView();
 	CDocTypeManager().GetTypeConfig( CTypeConfig(m_nDocType), m_type );
 	EDockSide eDockSide = ProfDockSide();	// 設定上の配置
 	UINT uFlags = MF_BYPOSITION | MF_STRING;
@@ -3529,7 +3529,7 @@ void CDlgFuncList::DoMenu( POINT pt, HWND hwndFrom )
 */
 void CDlgFuncList::Refresh( void )
 {
-	CEditWnd* pcEditWnd = CEditDoc::getInstance()->m_pcEditWnd;
+	CEditWnd* pcEditWnd = CEditWnd::getInstance();
 	BOOL bReloaded = ChangeLayout( OUTLINE_LAYOUT_FILECHANGED );	// 現在設定に従ってアウトライン画面を再配置する
 	if( !bReloaded && pcEditWnd->m_cDlgFuncList.GetHwnd() ){
 		EOutlineType nOutlineType = GetOutlineTypeRedraw(m_nOutlineType);
@@ -3676,10 +3676,11 @@ bool CDlgFuncList::ChangeLayout( int nId )
 */
 void CDlgFuncList::OnOutlineNotify( WPARAM wParam, LPARAM lParam )
 {
-	const CEditDoc* pDoc = CEditDoc::getInstance();	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
+	// 今は非表示かもしれないので (CEditView*)m_lParam は使えない
+	const CEditWnd* pcEditWnd = CEditWnd::getInstance();
 	switch( wParam ){
 	case 0:	// 設定変更通知（ドッキングモード or サイズ）, lParam: 通知元の HWND
-		if( (HWND)lParam == pDoc->m_pcEditWnd->GetHwnd() )
+		if( pcEditWnd && pcEditWnd->GetHwnd() == reinterpret_cast<HWND>(lParam) )
 			return;	// 自分からの通知は無視
 		ChangeLayout( OUTLINE_LAYOUT_BACKGROUND );	// アウトライン画面を再配置
 		break;

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -81,37 +81,5 @@ private:
 template <class T>
 T* TSingleInstance<T>::gm_instance = NULL;
 
-//記録もする
-#include <vector>
-template <class T> class TInstanceHolder{
-public:
-	TInstanceHolder()
-	{
-		gm_table.push_back(static_cast<T*>(this));
-	}
-	virtual ~TInstanceHolder()
-	{
-		for(size_t i=0;i<gm_table.size();i++){
-			if(gm_table[i]==static_cast<T*>(this)){
-				gm_table.erase(gm_table.begin()+i);
-				break;
-			}
-		}
-	}
-	static int GetInstanceCount(){ return (int)gm_table.size(); }
-	static T* GetInstance(int nIndex)
-	{
-		if(nIndex>=0 && nIndex<(int)gm_table.size()){
-			return gm_table[nIndex];
-		}else{
-			return 0;
-		}
-	}
-
-private:
-	static std::vector<T*> gm_table;
-};
-template <class T> std::vector<T*> TInstanceHolder<T>::gm_table;
-
 #endif /* SAKURA_DESIGN_TEMPLATE_8F7F7545_B66E_47C3_AE3A_0E406B3A0B0B_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -359,7 +359,7 @@ void CTextDrawer::DispLineNumber(
 ) const
 {
 	//$$ 高速化：SearchLineByLayoutYにキャッシュを持たせる
-	const CLayout*	pcLayout = CEditDoc::GetInstance(0)->m_cLayoutMgr.SearchLineByLayoutY( nLineNum );
+	const CLayout*	pcLayout = CEditDoc::getInstance()->m_cLayoutMgr.SearchLineByLayoutY( nLineNum );
 
 	const CEditView* pView=m_pEditView;
 	const STypeConfig* pTypes=&pView->m_pcEditDoc->m_cDocType.GetDocumentAttribute();

--- a/sakura_core/view/DispPos.cpp
+++ b/sakura_core/view/DispPos.cpp
@@ -20,6 +20,6 @@ void DispPos::ForwardLayoutLineRef(int nOffsetLine)
 		}
 	}
 	else{
-		m_pcLayoutRef = CEditDoc::GetInstance(0)->m_cLayoutMgr.SearchLineByLayoutY( m_nLineRef );
+		m_pcLayoutRef = CEditDoc::getInstance()->m_cLayoutMgr.SearchLineByLayoutY( m_nLineRef );
 	}
 }

--- a/sakura_core/view/DispPos.h
+++ b/sakura_core/view/DispPos.h
@@ -41,7 +41,7 @@ public:
 		m_ptDrawLayout.y=CLayoutInt(0);
 		m_nLineRef=CLayoutInt(0);
 		//キャッシュ
-		m_pcLayoutRef = CEditDoc::GetInstance(0)->m_cLayoutMgr.GetTopLayout();
+		m_pcLayoutRef = CEditDoc::getInstance()->m_cLayoutMgr.GetTopLayout();
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -91,7 +91,7 @@ public:
 	{
 		m_nLineRef = nOffsetLine;
 		//キャッシュ更新
-		m_pcLayoutRef = CEditDoc::GetInstance(0)->m_cLayoutMgr.SearchLineByLayoutY( m_nLineRef );
+		m_pcLayoutRef = CEditDoc::getInstance()->m_cLayoutMgr.SearchLineByLayoutY( m_nLineRef );
 	}
 	void ForwardLayoutLineRef(int nOffsetLine);
 

--- a/sakura_core/view/colors/CColorStrategy.cpp
+++ b/sakura_core/view/colors/CColorStrategy.cpp
@@ -301,7 +301,7 @@ void CColorStrategyPool::OnChangeSetting(void)
 	m_pcDoubleQuote = static_cast<CColor_DoubleQuote*>(GetStrategyByColor(COLORIDX_WSTRING));	// ダブルクォーテーション文字列
 
 	// 色分けをしない場合に、処理をスキップできるように確認する
-	const STypeConfig& type = CEditDoc::GetInstance(0)->m_cDocType.GetDocumentAttribute();
+	const STypeConfig& type = CEditDoc::getInstance()->m_cDocType.GetDocumentAttribute();
 	EColorIndexType bSkipColorTypeTable[] = {
 		COLORIDX_DIGIT,
 		COLORIDX_COMMENT,

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -153,7 +153,7 @@ public:
 	//! 設定更新
 	virtual void Update(void)
 	{
-		const CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
+		const CEditDoc* pCEditDoc = CEditDoc::getInstance();
 		m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
 	}
 

--- a/sakura_core/view/colors/CColor_Comment.h
+++ b/sakura_core/view/colors/CColor_Comment.h
@@ -60,7 +60,7 @@ public:
 	CColor_BlockComment(EColorIndexType nType) : m_nType(nType), m_nCOMMENTEND(0){}
 	virtual void Update(void)
 	{
-		const CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
+		const CEditDoc* pCEditDoc = CEditDoc::getInstance();
 		m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
 		m_pcBlockComment = &m_pTypeData->m_cBlockComments[m_nType - COLORIDX_BLOCK1];
 	}

--- a/sakura_core/view/colors/CColor_Quote.cpp
+++ b/sakura_core/view/colors/CColor_Quote.cpp
@@ -24,7 +24,7 @@ public:
 
 void CColor_Quote::Update(void)
 {
-	const CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
+	const CEditDoc* pCEditDoc = CEditDoc::getInstance();
 	m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
 	m_nStringType = m_pTypeData->m_nStringType;
 	int nEspaceTypeList[] = {

--- a/sakura_core/view/figures/CFigureStrategy.h
+++ b/sakura_core/view/figures/CFigureStrategy.h
@@ -41,7 +41,7 @@ public:
 	//! 設定更新
 	virtual void Update(void)
 	{
-		CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
+		CEditDoc* pCEditDoc = CEditDoc::getInstance();
 		m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
 	}
 protected:

--- a/sakura_core/view/figures/CFigureStrategy.h
+++ b/sakura_core/view/figures/CFigureStrategy.h
@@ -41,7 +41,7 @@ public:
 	//! 設定更新
 	virtual void Update(void)
 	{
-		CEditDoc* pCEditDoc = CEditDoc::getInstance();
+		const CEditDoc* pCEditDoc = CEditDoc::getInstance();
 		m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
 	}
 protected:


### PR DESCRIPTION
# PR の目的

CEditDocの派生元クラスを変更することにより、
プログラム内からドキュメントにアクセスする方法を分かりやすくします。


## カテゴリ

- リファクタリング


## PR の背景

Javaのデザインパターンに [シングルトンパターン](https://ja.wikipedia.org/wiki/Singleton_パターン) というのがあります。
現代っ子なプログラマであれば、Java屋じゃなくても名前くらいは聞いたことがあると思います。

あちこちで自由に new されると困る感じのオブジェクトの生成方法に制約をかけ、特定のオブジェクトのインスタンス数を 1つ に限定する手法を指す言葉です。

サクラエディタにも、シングルトンパターンを採用したクラスがあります。
- エディタアプリクラス(CEditApp)
- ドキュメントクラス(CEditDoc)
- 編集ウインドウクラス(CEditWnd)
- 現在のアプリモードを表すクラス(CAppMode)
※他にもたくさんありますが、諸事情により割愛します。

これらのクラスは、プロセス内に2つ以上存在させるとおかしなことになる概念を表しています。
- Windowsアプリは通常、まずメインウインドウを作成し、作成したメインウインドウが閉じられるまでを生存期間とします。サクラエディタのメインウインドウは「編集ウインドウ」なので、1プロセス内に複数の「編集ウインドウ」が存在する事態はありえません。2個目の「編集ウインドウ」を開く機能はサクラエディタには存在しないので、「そうしたいとき」には新しいプロセスを起動することになります。
- サクラエディタは、いわゆる [SDI アプリ](https://ja.wikipedia.org/wiki/Single_Document_Interface) です。MFCの影響を強く受けているので、タブモードにすると MDIアプリのような 外観 で動作させることもできますが、基本的には 1プロセスあたり1ドキュメント の SDI アプリ です。タブモード時に2つ目のファイルを開いた場合、見た目的には1つの編集ウインドウ内に2つのドキュメントが開いているように見えます。これは視覚的なトリックで、実際には3つのプロセスが起動した状態になっています。1つ目が非表示のコントロールプロセス、2つ目と3つ目がエディタのプロセスです。ファイルを新たに開くときの動作が「新規プロセス起動」になっている都合、1プロセス内に複数のドキュメントが存在する事態はありえません。
- 普通に考えてプロセスとエディタアプリは同義です。1プロセス内に複数のエディタアプリが存在する事態はありえません。
- いくつかの動作モードを定義してアプリの挙動を制御するのは、よくある設計手法だと思います。1プロセス内に複数の動作モードを共存させることは普通はありません。できないことはないけれど、それをやるとアプリ構造が複雑になってしまうから。1プロセス内に複数のアプリモードが存在する事態は、たぶんないと言えると思います。

さて、このPRの変更内容なんですが・・・。

- ドキュメントクラス(CEditDoc)

上記で説明した通り、1プロセス内に複数のドキュメントが存在する事態は、現在のサクラエディタの設計ではありえません。もしそんな状態を作ってしまうと、いろんなところでロジックが破たんすると考えられます。しかし、ドキュメントクラスはシングルトンになっていないんです。

変更内容を一言でまとめると、
ドキュメントクラスをシングルトンにする
です。

他にもいくつか変更をしていますが、どんなレベル感で説明すればいいか判断付かないのであえて説明を省略します。


## PR のメリット

- プログラム内からドキュメントにアクセスする方法が分かりやすくなります。
  - 変更前）　`CEditDoc::GetInstance(0);`  // 引数0は省略不可。
  - 変更後）　`CEditDoc::getInstance();`  // 引数は不要。
- CEditDocの状態を変更する処理を実行できる状況が限定されるようになります。
  - 変更前）　`CEditDoc::GetInstance(0)` の戻り値は非constなので自由に状態を変更できた。
  - 変更後）　`CEditDoc::getInstance();` の戻り値がconstなので状態変更できなくなる。
- CEditWndのインスタンスを取得するために CEditDoc を取得するコードがあったので修正しました。


## PR のデメリット (トレードオフとかあれば)

- 似た理屈で横展開整理が可能なクラスが結構ありますが、一旦放置してます。


## PR の影響範囲

- サクラエディタのコア部分に関する概念上の変更です。
- アプリへの実影響がないことは確認していますが、影響範囲はアプリ全域に及びます。


## 関連チケット

いまのところありません。
これがマージできたら、同様の変更を５～６個するので被参照は多くなる予想です。


## 参考資料

https://ja.wikipedia.org/wiki/Singleton_パターン
