### PR TITLE
行毎ではなく一括で線を描く変更によって引き起こされた表示の不具合を起こさないように元に戻す

### DIFF
--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -239,7 +239,8 @@ public:
 protected:
 	//! ロジック行を1行描画
 	bool DrawLogicLine(
-		SColorStrategyInfo* pInfo,		//!< [in,out] 
+		HDC				hdc,			//!< [in]     作画対象
+		DispPos*		pDispPos,		//!< [in,out] 描画する箇所、描画元ソース
 		CLayoutInt		nLineTo			//!< [in]     作画終了するレイアウト行番号
 	);
 

--- a/sakura_core/view/CEditView_Paint_Bracket.cpp
+++ b/sakura_core/view/CEditView_Paint_Bracket.cpp
@@ -232,7 +232,7 @@ void CEditView::DrawBracketPair( bool bDraw )
 					DispPos sPos(nWidth, nHeight);
 					sPos.InitDrawPos(CMyPoint(nLeft, nTop));
 					GetTextDrawer().DispText(gr, &sPos, 0, &pLine[OutputX], 1, bTrans);
-					GetTextDrawer().DispNoteLines(gr, nLeft, nTop, nLeft + (Int)charsWidth * nWidth, nTop + nHeight);
+					GetTextDrawer().DispNoteLine(gr, nTop, nTop + nHeight, nLeft, nLeft + (Int)charsWidth * nWidth);
 					// 2006.04.30 Moca 対括弧の縦線対応
 					GetTextDrawer().DispVerticalLines(gr, nTop, nTop + nHeight, ptColLine.x, ptColLine.x + charsWidth); //※括弧が全角幅である場合を考慮
 					cTextType.RewindGraphicsState(gr);

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -281,12 +281,12 @@ void CTextDrawer::DispVerticalLines(
 	}
 }
 
-void CTextDrawer::DispNoteLines(
+void CTextDrawer::DispNoteLine(
 	CGraphics&	gr,			//!< 作画するウィンドウのDC
-	LONG		left,		//!< ノート線を引く領域の左端のクライアント座標x
-	LONG		top,		//!< ノート線を引く領域の上端のクライアント座標y
-	LONG		right,		//!< ノート線を引く領域の右端のクライアント座標x
-	LONG		bottom		//!< ノート線を引く領域の下端のクライアント座標y
+	int			nTop,		//!< 線を引く上端のクライアント座標y
+	int			nBottom,	//!< 線を引く下端のクライアント座標y
+	int			nLeft,		//!< 線を引く左端
+	int			nRight		//!< 線を引く右端
 ) const
 {
 	const CEditView* pView=m_pEditView;
@@ -294,25 +294,22 @@ void CTextDrawer::DispNoteLines(
 	CTypeSupport cNoteLine(pView, COLORIDX_NOTELINE);
 	if( cNoteLine.IsDisp() ){
 		gr.SetPen( cNoteLine.GetTextColor() );
-		const LONG nLineHeight = pView->GetTextMetrics().GetHankakuDy();
-		const LONG userOffset = pView->m_pTypeData->m_nNoteLineOffset;
-		LONG offset = pView->GetTextArea().GetAreaTop() + userOffset - 1;
+		const int nLineHeight = pView->GetTextMetrics().GetHankakuDy();
+		const int left = nLeft;
+		const int right = nRight;
+		int userOffset = pView->m_pTypeData->m_nNoteLineOffset;
+		int offset = pView->GetTextArea().GetAreaTop() + userOffset - 1;
 		while( offset < 0 ){
 			offset += nLineHeight;
 		}
-
-		std::vector<CMyPoint> vLineEnds;
-		LONG offsetMod = offset % nLineHeight;
-		LONG y = ((top - offset) / nLineHeight * nLineHeight) + offsetMod;
-		for( ; y < bottom; y += nLineHeight ){
-			if( top <= y ){
-				vLineEnds.push_back(CMyPoint(left, y));
-				vLineEnds.push_back(CMyPoint(right, y));
+		int offsetMod = offset % nLineHeight;
+		int y = ((nTop - offset) / nLineHeight * nLineHeight) + offsetMod;
+		for( ; y < nBottom; y += nLineHeight ){
+			if( nTop <= y ){
+				::MoveToEx( gr, left, y, NULL );
+				::LineTo( gr, right, y );
 			}
 		}
-
-		std::vector<DWORD> vNumPts(vLineEnds.size() / 2, 2);
-		::PolyPolyline(gr, vLineEnds.data(), vNumPts.data(), static_cast<DWORD>(vNumPts.size()));
 	}
 }
 
@@ -572,11 +569,11 @@ void CTextDrawer::DispLineNumber(
 
 	// 行番号部分のノート線描画
 	if( !pView->m_bMiniMap ){
-		LONG left   = bDispLineNumTrans ? 0 : rcLineNum.right;
-		LONG top    = y;
-		LONG right  = pView->GetTextArea().GetAreaLeft();
-		LONG bottom = y + nLineHeight;
-		DispNoteLines( gr, left, top, right, bottom );
+		int left   = bDispLineNumTrans ? 0 : rcLineNum.right;
+		int right  = pView->GetTextArea().GetAreaLeft();
+		int top    = y;
+		int bottom = y + nLineHeight;
+		DispNoteLine( gr, top, bottom, left, right );
 	}
 }
 

--- a/sakura_core/view/CTextDrawer.h
+++ b/sakura_core/view/CTextDrawer.h
@@ -55,7 +55,7 @@ public:
 	void DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar_t* pData, int nLength, bool bTransparent = false ) const; // テキスト表示
 
 	//!	ノート線描画
-	void DispNoteLines( CGraphics& gr, LONG left, LONG top, LONG right, LONG bottom ) const;
+	void DispNoteLine( CGraphics& gr, int nTop, int nBottom, int nLeft, int nRight ) const;
 
 	// -- -- 指定桁縦線描画 -- -- //
 	//!	指定桁縦線描画関数	// 2005.11.08 Moca


### PR DESCRIPTION
# PR の目的

https://github.com/sakura-editor/sakura/pull/1065#issuecomment-539565600 で @usagisita さんが報告してくれた問題を解消する為に下記の変更を revert します。

- #1065 ノート線描画、指定桁縦線描画、折り返し桁縦線描画、を行毎ではなく一括で行うように変更
- #1066 ノート線描画を少し分かりやすくする

## カテゴリ

- 不具合修正

## 関連チケット

#1071
