### PR TITLE
簡単なtypo修正

### DIFF
--- a/sakura_core/charset/CJis.cpp
+++ b/sakura_core/charset/CJis.cpp
@@ -307,7 +307,7 @@ int CJis::_SjisToJis_char( const unsigned char* pSrc, unsigned char* pDst, EChar
 		ctemp_ = SjisFilter_ibm2nec( ctemp_ );
 		ctemp = _mbcjmstojis( ctemp_ );
 		if( ctemp != 0 ){
-			// 返還に成功。
+			// 変換に成功。
 			pDst[0] = static_cast<char>( (ctemp & 0x0000ff00) >> 8 );
 			pDst[1] = static_cast<char>( ctemp & 0x000000ff );
 			nret = 2;

--- a/sakura_core/charset/codeutil.h
+++ b/sakura_core/charset/codeutil.h
@@ -179,7 +179,7 @@ inline int MyWideCharToMultiByte_JP( const unsigned short* pSrc, const int nSrcL
 /*!
 	MultiByteToWideChar のラッパー関数
 
-	@param[out] pbNonroundtrip 返還に成功したものの、相互変換性が失われた場合に true
+	@param[out] pbNonroundtrip 変換に成功したものの、相互変換性が失われた場合に true
 
 	nSrcLen は 1 か 2
 */

--- a/sakura_core/util/string_ex2.cpp
+++ b/sakura_core/util/string_ex2.cpp
@@ -20,7 +20,7 @@ wchar_t *wcs_pushW(wchar_t *dst, size_t dst_count, const wchar_t* src)
 /*! 文字のエスケープ
 
 	@param org [in] 変換したい文字列
-	@param buf [out] 返還後の文字列を入れるバッファ
+	@param buf [out] 変換後の文字列を入れるバッファ
 	@param cesc  [in] エスケープしないといけない文字
 	@param cwith [in] エスケープに使う文字
 	


### PR DESCRIPTION
# PR の目的

typo（＝誤変換）を見つけたのでなんとなくPRしてみます。

返還に成功したら…

沖縄かいっ！

## カテゴリ
- ドキュメント修正

## PR の背景
vs2019のプラグインから直接PR発行できるみたいなんで、試しにPR作ってみました。

## PR のメリット
一応、誤字が3か所減ります。

## PR のデメリット (トレードオフとかあれば)
コードが修正されます。
既存PRと修正ファイルがかぶるかも。（修正箇所はかぶらない。

## PR の影響範囲
ソースコードがちょっとだけきれいになります。
アプリ動作への影響は一切発生しないと思われます。

## 関連チケット


## 参考資料
