### PR TITLE
MYDEVMODEの等価比較演算子の隠れバグを修正する

### DIFF
--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -66,9 +66,9 @@ struct	MYDEVMODE {
 	bool operator == (const MYDEVMODE& rhs) const noexcept {
 		if (this == &rhs) return true;
 		return m_bPrinterNotFound == rhs.m_bPrinterNotFound
-			&& 0 == wcsncmp(m_szPrinterDriverName, rhs.m_szPrinterDriverName, _countof(m_szPrinterDriverName) - 1)
-			&& 0 == wcsncmp(m_szPrinterDeviceName, rhs.m_szPrinterDeviceName, _countof(m_szPrinterDeviceName) - 1)
-			&& 0 == wcsncmp(m_szPrinterOutputName, rhs.m_szPrinterOutputName, _countof(m_szPrinterOutputName) - 1)
+			&& 0 == wcsncmp(m_szPrinterDriverName, rhs.m_szPrinterDriverName, _countof(m_szPrinterDriverName))
+			&& 0 == wcsncmp(m_szPrinterDeviceName, rhs.m_szPrinterDeviceName, _countof(m_szPrinterDeviceName))
+			&& 0 == wcsncmp(m_szPrinterOutputName, rhs.m_szPrinterOutputName, _countof(m_szPrinterOutputName))
 			&& dmFields == rhs.dmFields
 			&& dmOrientation == rhs.dmOrientation
 			&& dmPaperSize == rhs.dmPaperSize
@@ -83,7 +83,7 @@ struct	MYDEVMODE {
 			&& dmYResolution == rhs.dmYResolution
 			&& dmTTOption == rhs.dmTTOption
 			&& dmCollate == rhs.dmCollate
-			&& 0 == wcsncmp(dmFormName, rhs.dmFormName, _countof(dmFormName) - 1)
+			&& 0 == wcsncmp(dmFormName, rhs.dmFormName, _countof(dmFormName))
 			&& dmLogPixels == rhs.dmLogPixels
 			&& dmBitsPerPel == rhs.dmBitsPerPel
 			&& dmPelsWidth == rhs.dmPelsWidth

--- a/tests/unittests/test-mydevmode.cpp
+++ b/tests/unittests/test-mydevmode.cpp
@@ -259,6 +259,35 @@ TEST(MYDEVMODETest, operatorNotEqual)
 }
 
 /*!
+ * @brief 否定の等価演算子のテスト
+ *  文字列メンバの末尾(通常はNUL文字)が異なるパターンを検出できるかチェックする
+ */
+TEST(MYDEVMODETest, operatorNotEqualAntiLazyCode)
+{
+	// デフォルトで初期化
+	MYDEVMODE value, other;
+
+	// スタック変数のアドレスをchar*にキャストしてデータを書き替える
+	char* buf1 = reinterpret_cast<char*>(&value);
+	::memset(buf1, 'a', sizeof(MYDEVMODE));
+	char* buf2 = reinterpret_cast<char*>(&other);
+	::memset(buf2, 'a', sizeof(MYDEVMODE));
+
+	// まったく同じなので等価になる
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	EXPECT_EQ(other, value);
+
+	// 文字列メンバをNUL終端する
+	value.m_szPrinterDriverName[_countof(value.m_szPrinterDriverName) - 1] = 0;
+
+	// NUL終端された文字列 != NUL終端されてない文字列、となるはず。
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	EXPECT_NE(other, value);
+}
+
+/*!
  * @brief 等価比較演算子が一般保護違反を犯さないことを保証する非機能要件テスト
  *
  *  通常、ここまでやる必要はないが、修正の理由が「安全のため」なので、


### PR DESCRIPTION
# PR の目的
MYDEVMODEの等価比較演算子の実装に潜在バグを見付けたので修正します。


## カテゴリ
- 不具合修正


## PR の背景
他のクラスのテストを書くために、
等価比較演算子をコピペ実装していく作業の中で気付きました。

具体的に何がマズいのか説明しづらいので、少し変わったやり方で進めたいです。

1. 変更前実装で問題が起こるレアケースを再現するテストを投入する  
テストが失敗するので、何が問題なのか共有できます。
2. 変更後実装を投入する  
テストが成功するので、直ったような気分になれます。

MYDEVMODE自体はあまり重要なクラスでもないので、直さないとダメか？っていうとそうでもないんですが・・・。

## PR のメリット
- MYDEVMODEの等価比較演算子のバグを解消できます。


## PR のデメリット (トレードオフとかあれば)
- アプリ動作的にはなんの変化もないと思われます。


## PR の影響範囲
- 印刷機能のための内部構造体の比較処理を変更します。
- アプリ(=サクラエディタ)の機能に影響はありません。


## 関連チケット
#877 構造体比較にmemcmpを使うのをやめる


## 参考資料
とくにありません。
