### PR TITLE
[WIP] コマンドライン解析をテストできるようにしたい

### DIFF
--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -55,7 +55,7 @@ struct SEolDefinition{
 	int				m_nLen;
 
 	bool StartsWith(const WCHAR* pData, int nLen) const{ return m_nLen<=nLen && 0==wmemcmp(pData,m_szDataW,m_nLen); }
-	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==amemcmp(pData,m_szDataA,m_nLen); }
+	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==memcmp(pData,m_szDataA,m_nLen); }
 };
 extern const SEolDefinition g_aEolTable[];
 

--- a/sakura_core/EditInfo.h
+++ b/sakura_core/EditInfo.h
@@ -72,25 +72,25 @@ struct EditInfo {
 	
 	// Mar. 7, 2002 genta
 	// Constructor 確実に初期化するため
-	EditInfo()
-	: m_nCharCode( CODE_AUTODETECT )
-	, m_bBom( false )
-	, m_nTypeId( -1 )
-	, m_nViewTopLine( -1 )
-	, m_nViewLeftCol( -1 )
-	, m_ptCursor(CLogicInt(-1), CLogicInt(-1))
-	, m_bIsModified( false )
-	, m_bIsGrep( false )
-	, m_szGrepKey{ 0 }
-	, m_bIsDebug( false )
-	, m_nWindowSizeX( -1 )
-	, m_nWindowSizeY( -1 )
-	, m_nWindowOriginX( CW_USEDEFAULT )	//	2004.05.13 Moca “指定無し”を-1からCW_USEDEFAULTに変更
-	, m_nWindowOriginY( CW_USEDEFAULT )
+	EditInfo() noexcept
+		: m_szPath{ 0 }
+		, m_nCharCode( CODE_AUTODETECT )
+		, m_bBom( false )
+		, m_szDocType{ 0 }
+		, m_nTypeId( -1 )
+		, m_nViewTopLine( -1 )
+		, m_nViewLeftCol( -1 )
+		, m_ptCursor{ -1, -1 }
+		, m_bIsModified( false )
+		, m_bIsGrep( false )
+		, m_szGrepKey{ 0 }
+		, m_bIsDebug( false )
+		, m_szMarkLines{ 0 }
+		, m_nWindowSizeX( -1 )
+		, m_nWindowSizeY( -1 )
+		, m_nWindowOriginX( CW_USEDEFAULT )	//	2004.05.13 Moca “指定無し”を-1からCW_USEDEFAULTに変更
+		, m_nWindowOriginY( CW_USEDEFAULT )
 	{
-		m_szPath[0] = '\0';
-		m_szMarkLines[0] = L'\0';
-		m_szDocType[0] = '\0';
 	}
 	bool operator == (const EditInfo& rhs) const noexcept {
 		if (this == &rhs) return true;

--- a/sakura_core/EditInfo.h
+++ b/sakura_core/EditInfo.h
@@ -27,6 +27,8 @@
 
 #include "basis/SakuraBasis.h"
 #include "config/maxdata.h"
+#include "charset/charcode.h"
+#include "mem/CNativeW.h"
 #include "types/CType.h"
 
 /*! ファイル情報
@@ -79,6 +81,7 @@ struct EditInfo {
 	, m_ptCursor(CLogicInt(-1), CLogicInt(-1))
 	, m_bIsModified( false )
 	, m_bIsGrep( false )
+	, m_szGrepKey{ 0 }
 	, m_bIsDebug( false )
 	, m_nWindowSizeX( -1 )
 	, m_nWindowSizeY( -1 )
@@ -89,6 +92,27 @@ struct EditInfo {
 		m_szMarkLines[0] = L'\0';
 		m_szDocType[0] = '\0';
 	}
+	bool operator == (const EditInfo& rhs) const noexcept {
+		if (this == &rhs) return true;
+		return 0 == wcsncmp(m_szPath, rhs.m_szPath, _countof(m_szPath))
+			&& m_nCharCode == rhs.m_nCharCode
+			&& m_bBom == rhs.m_bBom
+			&& 0 == wcsncmp(m_szDocType, rhs.m_szDocType, _countof(m_szDocType))
+			&& m_nTypeId == rhs.m_nTypeId
+			&& m_nViewTopLine == rhs.m_nViewTopLine
+			&& m_nViewLeftCol == rhs.m_nViewLeftCol
+			&& m_ptCursor == rhs.m_ptCursor
+			&& m_bIsModified == rhs.m_bIsModified
+			&& m_bIsGrep == rhs.m_bIsGrep
+			&& 0 == wcsncmp(m_szGrepKey, rhs.m_szGrepKey, _countof(m_szGrepKey))
+			&& m_bIsDebug == rhs.m_bIsDebug
+			&& 0 == wcsncmp(m_szMarkLines, rhs.m_szMarkLines, _countof(m_szMarkLines))
+			&& m_nWindowSizeX == rhs.m_nWindowSizeX
+			&& m_nWindowSizeY == rhs.m_nWindowSizeY
+			&& m_nWindowOriginX == rhs.m_nWindowOriginX
+			&& m_nWindowOriginY == rhs.m_nWindowOriginY;
+	}
+	bool operator != (const EditInfo& rhs) const noexcept { return !(*this == rhs); }
 };
 
 #endif /* SAKURA_EDITINFO_38A7E267_160D_4250_9012_AC3FC31993D69_H_ */

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -19,11 +19,13 @@
 #ifndef _CCOMMANDLINE_H_
 #define _CCOMMANDLINE_H_
 
+#include <vector>
+
 #include "global.h"
+#include "charset/charcode.h"
+#include "mem/CNativeW.h"
 #include "EditInfo.h"
 #include "util/design_template.h"
-
-class CMemory;
 
 /*!	検索オプション
 	20020118 aroka
@@ -60,8 +62,10 @@ struct GrepInfo {
 */
 class CCommandLine  : public TSingleton<CCommandLine> {
 	friend class TSingleton<CCommandLine>;
+public:
 	CCommandLine();
 
+private:
 	static int CheckCommandLine(
 		LPWSTR	str,		//!< [in] 検証する文字列（先頭の-は含まない）
 		WCHAR**	arg,		//!< [out] 引数がある場合はその先頭へのポインタ

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -51,6 +51,55 @@ struct GrepInfo {
 	bool			bGrepReplace;		//!< Grep置換
 	bool			bGrepPaste;			//!< クリップボードから貼り付け
 	bool			bGrepBackup;		//!< 置換でバックアップを保存
+
+	GrepInfo() noexcept
+		: cmGrepKey()
+		, cmGrepRep()
+		, cmGrepFile()
+		, cmGrepFolder()
+		, cmExcludeFile()
+		, cmExcludeFolder()
+		, sGrepSearchOption()
+		, bGrepCurFolder(false)
+		, bGrepStdout(false)
+		, bGrepHeader(true)
+		, bGrepSubFolder(false)
+		, nGrepCharSet(CODE_SJIS)
+		, nGrepOutputStyle(1)
+		, nGrepOutputLineType(0)
+		, bGrepOutputFileOnly(false)
+		, bGrepOutputBaseFolder(false)
+		, bGrepSeparateFolder(false)
+		, bGrepReplace(false)
+		, bGrepPaste(false)
+		, bGrepBackup(false)
+	{
+	}
+
+	bool operator == (const GrepInfo& rhs) const noexcept {
+		if (this == &rhs) return true;
+		return cmGrepKey == rhs.cmGrepKey
+			&& cmGrepRep == rhs.cmGrepRep
+			&& cmGrepFile == rhs.cmGrepFile
+			&& cmGrepFolder == rhs.cmGrepFolder
+			&& cmExcludeFile == rhs.cmExcludeFile
+			&& cmExcludeFolder == rhs.cmExcludeFolder
+			&& sGrepSearchOption == rhs.sGrepSearchOption
+			&& bGrepCurFolder == rhs.bGrepCurFolder
+			&& bGrepStdout == rhs.bGrepStdout
+			&& bGrepHeader == rhs.bGrepHeader
+			&& bGrepSubFolder == rhs.bGrepSubFolder
+			&& nGrepCharSet == rhs.nGrepCharSet
+			&& nGrepOutputStyle == rhs.nGrepOutputStyle
+			&& nGrepOutputLineType == rhs.nGrepOutputLineType
+			&& bGrepOutputFileOnly == rhs.bGrepOutputFileOnly
+			&& bGrepOutputBaseFolder == rhs.bGrepOutputBaseFolder
+			&& bGrepSeparateFolder == rhs.bGrepSeparateFolder
+			&& bGrepReplace == rhs.bGrepReplace
+			&& bGrepPaste == rhs.bGrepPaste
+			&& bGrepBackup == rhs.bGrepBackup;
+	}
+	bool operator != (const GrepInfo& rhs) const noexcept { return !(*this == rhs); }
 };
 
 /*-----------------------------------------------------------------------

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -90,6 +90,7 @@ public:
 	bool IsDebugMode() const noexcept { return m_bDebugMode; }
 	bool IsViewMode() const noexcept { return m_bViewMode; }
 	bool GetEditInfo(EditInfo* fi) const noexcept { *fi = m_fi; return true; }
+	const EditInfo& GetEditInfoRef() const noexcept { return m_fi; }
 	bool GetGrepInfo(GrepInfo* gi) const noexcept { *gi = m_gi; return true; }
 	int GetGroupId() const noexcept { return m_nGroup; }	// 2007.06.26 ryoji
 	LPCWSTR GetMacro() const noexcept { return m_cmMacro.GetStringPtr(); }
@@ -101,9 +102,16 @@ public:
 		m_cmProfile.SetString(s);
 	}
 	bool IsProfileMgr() const noexcept { return m_bProfileMgr; }
+	const CLogicPoint& GetCaretLocation() const noexcept { return m_fi.m_ptCursor; }
+	CLayoutPoint GetViewLocation() const noexcept { return { m_fi.m_nViewLeftCol,  m_fi.m_nViewTopLine }; }
+	tagSIZE GetWindowSize() const noexcept { return { m_fi.m_nWindowSizeX, m_fi.m_nWindowSizeY }; }
+	tagPOINT GetWindowOrigin() const noexcept { return { m_fi.m_nWindowOriginX, m_fi.m_nWindowOriginY }; }
+	LPCWSTR GetOpenFile() const noexcept { return m_fi.m_szPath; }
 	int GetFileNum(void) const noexcept { return m_vFiles.size(); }
 	const WCHAR* GetFileName(int i) const noexcept { return i < GetFileNum() ? m_vFiles[i].c_str() : NULL; }
 	void ClearFile(void) noexcept { m_vFiles.clear(); }
+	LPCWSTR GetDocType() const noexcept { return m_fi.m_szDocType; }
+	ECodeType GetDocCode() const noexcept { return m_fi.m_nCharCode; }
 	void ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse = true );
 
 // member valiables

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -141,6 +141,7 @@ public:
 	bool GetEditInfo(EditInfo* fi) const noexcept { *fi = m_fi; return true; }
 	const EditInfo& GetEditInfoRef() const noexcept { return m_fi; }
 	bool GetGrepInfo(GrepInfo* gi) const noexcept { *gi = m_gi; return true; }
+	const GrepInfo& GetGrepInfoRef() const noexcept { return m_gi; }
 	int GetGroupId() const noexcept { return m_nGroup; }	// 2007.06.26 ryoji
 	LPCWSTR GetMacro() const noexcept { return m_cmMacro.GetStringPtr(); }
 	LPCWSTR GetMacroType() const noexcept { return m_cmMacroType.GetStringPtr(); }

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -83,27 +83,27 @@ private:
 
 // member accessor method
 public:
-	bool IsNoWindow() const {return m_bNoWindow;}
-	bool IsWriteQuit() const {return m_bWriteQuit;}	// 2007.05.19 ryoji sakuext用に追加
-	bool IsGrepMode() const {return m_bGrepMode;}
-	bool IsGrepDlg() const {return m_bGrepDlg;}
-	bool IsDebugMode() const {return m_bDebugMode;}
-	bool IsViewMode() const {return m_bViewMode;}
-	bool GetEditInfo(EditInfo* fi) const { *fi = m_fi; return true; }
-	bool GetGrepInfo(GrepInfo* gi) const { *gi = m_gi; return true; }
-	int GetGroupId() const {return m_nGroup;}	// 2007.06.26 ryoji
-	LPCWSTR GetMacro() const{ return m_cmMacro.GetStringPtr(); }
-	LPCWSTR GetMacroType() const{ return m_cmMacroType.GetStringPtr(); }
-	LPCWSTR GetProfileName() const{ return m_cmProfile.GetStringPtr(); }
-	bool IsSetProfile() const{ return m_bSetProfile; }
+	bool IsNoWindow() const noexcept { return m_bNoWindow; }
+	bool IsWriteQuit() const noexcept { return m_bWriteQuit; }	// 2007.05.19 ryoji sakuext用に追加
+	bool IsGrepMode() const noexcept { return m_bGrepMode; }
+	bool IsGrepDlg() const noexcept { return m_bGrepDlg; }
+	bool IsDebugMode() const noexcept { return m_bDebugMode; }
+	bool IsViewMode() const noexcept { return m_bViewMode; }
+	bool GetEditInfo(EditInfo* fi) const noexcept { *fi = m_fi; return true; }
+	bool GetGrepInfo(GrepInfo* gi) const noexcept { *gi = m_gi; return true; }
+	int GetGroupId() const noexcept { return m_nGroup; }	// 2007.06.26 ryoji
+	LPCWSTR GetMacro() const noexcept { return m_cmMacro.GetStringPtr(); }
+	LPCWSTR GetMacroType() const noexcept { return m_cmMacroType.GetStringPtr(); }
+	LPCWSTR GetProfileName() const noexcept { return m_cmProfile.GetStringPtr(); }
+	bool IsSetProfile() const noexcept { return m_bSetProfile; }
 	void SetProfileName(LPCWSTR s){
 		m_bSetProfile = true;
 		m_cmProfile.SetString(s);
 	}
-	bool IsProfileMgr() { return m_bProfileMgr; }
-	int GetFileNum(void) { return m_vFiles.size(); }
-	const WCHAR* GetFileName(int i) { return i < GetFileNum() ? m_vFiles[i].c_str() : NULL; }
-	void ClearFile(void) { m_vFiles.clear(); }
+	bool IsProfileMgr() const noexcept { return m_bProfileMgr; }
+	int GetFileNum(void) const noexcept { return m_vFiles.size(); }
+	const WCHAR* GetFileName(int i) const noexcept { return i < GetFileNum() ? m_vFiles[i].c_str() : NULL; }
+	void ClearFile(void) noexcept { m_vFiles.clear(); }
 	void ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse = true );
 
 // member valiables

--- a/sakura_core/_main/global.h
+++ b/sakura_core/_main/global.h
@@ -156,15 +156,20 @@ struct SSearchOption{
 	bool	bLoHiCase;		//!< true==英大文字小文字の区別
 	bool	bWordOnly;		//!< true==単語のみ検索
 
-	SSearchOption() : bRegularExp(false), bLoHiCase(false), bWordOnly(false) { }
+	SSearchOption() noexcept
+		: bRegularExp(false)
+		, bLoHiCase(false)
+		, bWordOnly(false)
+	{
+	}
 	SSearchOption(
 		bool _bRegularExp,
 		bool _bLoHiCase,
 		bool _bWordOnly
-	)
-	: bRegularExp(_bRegularExp)
-	, bLoHiCase(_bLoHiCase)
-	, bWordOnly(_bWordOnly)
+	) noexcept
+		: bRegularExp(_bRegularExp)
+		, bLoHiCase(_bLoHiCase)
+		, bWordOnly(_bWordOnly)
 	{
 	}
 	void Reset()
@@ -175,15 +180,13 @@ struct SSearchOption{
 	}
 
 	//演算子
-	bool operator == (const SSearchOption& rhs) const
-	{
-		//とりあえずmemcmpでいいや
-		return memcmp(this,&rhs,sizeof(*this))==0;
+	bool operator == (const SSearchOption& rhs) const noexcept {
+		if (this == &rhs) return true;
+		return bRegularExp == rhs.bRegularExp
+			&& bLoHiCase == rhs.bLoHiCase
+			&& bWordOnly == rhs.bWordOnly;
 	}
-	bool operator != (const SSearchOption& rhs) const
-	{
-		return !operator==(rhs);
-	}
+	bool operator != (const SSearchOption& rhs) const noexcept { return !(*this == rhs); }
 };
 
 //2007.10.02 kobake CEditWndのインスタンスへのポインタをここに保存しておく

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -27,6 +27,7 @@
 
 //2007.09.13 kobake 作成
 #include "parse/CWordParse.h"
+#include "util/std_macro.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                         判定関数                            //

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -84,6 +84,20 @@ public:
 	const CNativeW& operator=(wchar_t wch)				{ SetString(&wch,1);      return *this; }
 	const CNativeW& operator+=(const CNativeW& rhs)		{ AppendNativeData(rhs); return *this; }
 	CNativeW operator+(const CNativeW& rhs) const		{ CNativeW tmp=*this; return tmp+=rhs; }
+	bool operator == (const CNativeW& rhs) const noexcept {
+		if (this == &rhs) return true;
+		if (!capacity() || !rhs.capacity()) return (capacity() == rhs.capacity());
+		return GetStringLength() == rhs.GetStringLength()
+			&& 0 == wmemcmp(GetStringPtr(), rhs.GetStringPtr(), GetStringLength() + 1);
+	}
+	bool operator != (const CNativeW& rhs) const noexcept { return !(*this == rhs); }
+	bool operator == (std::nullptr_t) const noexcept { return GetStringPtr() == nullptr; }
+	bool operator != (std::nullptr_t) const noexcept { return !(*this == nullptr); }
+	bool operator == (const wchar_t* rhs) const noexcept {
+		if (rhs == nullptr) return (*this == nullptr);
+		return 0 == wmemcmp(GetStringPtr(), rhs, GetStringLength() + 1);
+	}
+	bool operator != (const wchar_t* rhs) const noexcept { return !(*this == rhs); }
 
 	//ネイティブ取得インターフェース
 	wchar_t operator[](int nIndex) const;                    //!< 任意位置の文字取得。nIndexは文字単位。
@@ -117,7 +131,7 @@ public:
 	void swap( CNativeW& left ){
 		_GetMemory()->swap( *left._GetMemory() );
 	}
-	int capacity(){
+	int capacity() const {
 		return _GetMemory()->capacity() / sizeof(wchar_t);
 	}
 

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -96,7 +96,9 @@ public:
 	bool operator == (const wchar_t* rhs) const noexcept {
 		if (rhs == nullptr) return (*this == nullptr);
 		if (!capacity()) return false;
-		return 0 == wmemcmp(GetStringPtr(), rhs, GetStringLength() + 1);
+		size_t rhsLen = wcsnlen(rhs, GetStringLength());
+		if (GetStringLength() < rhsLen) return false;
+		return 0 == wmemcmp(GetStringPtr(), rhs, std::min<size_t>(GetStringLength(), rhsLen) + 1);
 	}
 	bool operator != (const wchar_t* rhs) const noexcept { return !(*this == rhs); }
 

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -95,6 +95,7 @@ public:
 	bool operator != (std::nullptr_t) const noexcept { return !(*this == nullptr); }
 	bool operator == (const wchar_t* rhs) const noexcept {
 		if (rhs == nullptr) return (*this == nullptr);
+		if (!capacity()) return false;
 		return 0 == wmemcmp(GetStringPtr(), rhs, GetStringLength() + 1);
 	}
 	bool operator != (const wchar_t* rhs) const noexcept { return !(*this == rhs); }

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -1,0 +1,425 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include "_main/CCommandLine.h"
+
+#include <cstdlib>
+#include <fstream>
+
+/*!
+ * @brief コンストラクタ(パラメータなし)の仕様
+ * @remark パラメータを何も指定しなかった状態になる
+ */
+TEST(CCommandLine, ConstructWithoutParam)
+{
+	CCommandLine cCommandLine;
+	EXPECT_FALSE(cCommandLine.IsNoWindow());
+	EXPECT_FALSE(cCommandLine.IsWriteQuit());
+	EXPECT_FALSE(cCommandLine.IsGrepMode());
+	EXPECT_FALSE(cCommandLine.IsGrepDlg());
+	EXPECT_FALSE(cCommandLine.IsDebugMode());
+	EXPECT_FALSE(cCommandLine.IsViewMode());
+
+	//GetEditInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
+	EditInfo fi;
+	EXPECT_TRUE(cCommandLine.GetEditInfo(&fi));
+	//TODO: EditInfoに等価比較演算子を実装する
+	//EXPECT_EQ(EditInfo(), fi);
+
+	//GetGrepInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
+	GrepInfo gi;
+	EXPECT_TRUE(cCommandLine.GetGrepInfo(&gi));
+	//TODO: GrepInfoに等価比較演算子を実装する
+	//EXPECT_EQ(GrepInfo(), gi);
+
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+	EXPECT_EQ(NULL, cCommandLine.GetMacro());
+	EXPECT_EQ(NULL, cCommandLine.GetMacroType());
+	//1つだけNULLを返さないのはバグの気配がします(^^;
+	EXPECT_STREQ(L"", cCommandLine.GetProfileName());
+	EXPECT_FALSE(cCommandLine.IsSetProfile());
+	EXPECT_FALSE(cCommandLine.IsProfileMgr());
+	EXPECT_EQ(0, cCommandLine.GetFileNum());
+	EXPECT_EQ(NULL, cCommandLine.GetFileName(0));
+}
+
+/*!
+ * @brief パラメータ解析(-NOWIN)の仕様
+ * @remark -NOWINが指定されていなければFALSE
+ * @remark -NOWINが指定されていたらTRUE
+ * @remark -WQが指定された場合、-NOWINがなくてもTRUE
+ */
+TEST(CCommandLine, ParseNoWin)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsNoWindow());
+	cCommandLine.ParseCommandLine(L"-NOWIN", false);
+	ASSERT_TRUE(cCommandLine.IsNoWindow());
+}
+
+/*!
+ * @brief パラメータ解析(-WQ)の仕様
+ * @remark -WQが指定されていなければFALSE
+ * @remark -WQが指定されていたらTRUE
+ * @remark -WQが指定された場合、-NOWINもTRUE
+ */
+TEST(CCommandLine, ParseWriteQuit)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsWriteQuit());
+	cCommandLine.ParseCommandLine(L"-WQ", false);
+	ASSERT_TRUE(cCommandLine.IsWriteQuit());
+	ASSERT_TRUE(cCommandLine.IsNoWindow());
+}
+
+/*!
+ * @brief パラメータ解析(-GREPMODE)の仕様
+ * @remark -GREPMODEが指定されていなければFALSE
+ * @remark -GREPMODEが指定されていたらTRUE
+ * @remark Grepモード時は文書タイプが"grepmode"になる
+ */
+TEST(CCommandLine, ParseGrepMode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsGrepMode());
+	cCommandLine.ParseCommandLine(L"-GREPMODE", false);
+	ASSERT_TRUE(cCommandLine.IsGrepMode());
+
+	//TODO: 現状のコードではテストを書きづらい...
+	//Grepモード時は文書タイプが"grepout"になる
+	//ASSERT_STREQ(L"grepout", cCommandLine.GetDocType());
+}
+
+/*!
+ * @brief パラメータ解析(-GREPDLG)の仕様
+ * @remark -GREPDLGが指定されていなければFALSE
+ * @remark -GREPDLGが指定されていたらTRUE
+ */
+TEST(CCommandLine, ParseGrepDialog)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsGrepDlg());
+	cCommandLine.ParseCommandLine(L"-GREPDLG", false);
+	ASSERT_TRUE(cCommandLine.IsGrepDlg());
+	//FIXME: Grepダイアログ指定時にGrepモードにならないのは不自然な気がする
+}
+
+/*!
+ * @brief パラメータ解析(-DEBUGMODE)の仕様
+ * @remark -DEBUGMODEが指定されていなければFALSE
+ * @remark -DEBUGMODEが指定されていたらTRUE
+ * @remark Debugモード時は文書タイプが"output"になる
+ */
+TEST(CCommandLine, ParseDebugMode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsDebugMode());
+	cCommandLine.ParseCommandLine(L"-DEBUGMODE", false);
+	ASSERT_TRUE(cCommandLine.IsDebugMode());
+
+	//TODO: 現状のコードではテストを書きづらい...
+	//Debugモード時は文書タイプが"output"になる
+	//ASSERT_STREQ(L"output", cCommandLine.GetDocType());
+}
+
+/*!
+ * @brief パラメータ解析(-R)の仕様
+ * @remark -Rが指定されていなければFALSE
+ * @remark -Rが指定されていたらTRUE
+ */
+TEST(CCommandLine, ParseViewMode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsViewMode());
+	cCommandLine.ParseCommandLine(L"-R", false);
+	ASSERT_TRUE(cCommandLine.IsViewMode());
+}
+
+/*!
+ * @brief パラメータ解析(-GROUP)の仕様
+ * @remark -GROUPが指定されていなければ-1
+ * @remark -GROUPが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseGroup)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+	cCommandLine.ParseCommandLine(L"-GROUP=2", false);
+	EXPECT_EQ(2, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief パラメータ解析(-M)の仕様
+ * @remark -Mが指定されていなければNULL
+ * @remark -Mが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseMacroFileName)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetMacro());
+#define TESTLOCAL_MACRO_NAME L"真っ黒.mac"
+	cCommandLine.ParseCommandLine(L"-M=" TESTLOCAL_MACRO_NAME, false);
+	ASSERT_STREQ(TESTLOCAL_MACRO_NAME, cCommandLine.GetMacro());
+#undef TESTLOCAL_MACRO_NAME
+}
+
+/*!
+ * @brief パラメータ解析(-MTYPE)の仕様
+ * @remark -MTYPEが指定されていなければNULL
+ * @remark -MTYPEが指定されていたら指定された文字列
+ * @remark MacroTypeには任意の文字列を指定できる
+ */
+TEST(CCommandLine, ParseMacroType)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetMacroType());
+#define TESTLOCAL_MACRO_TYPE L"PascalScript"
+	cCommandLine.ParseCommandLine(L"-MTYPE=" TESTLOCAL_MACRO_TYPE, false);
+	ASSERT_STREQ(TESTLOCAL_MACRO_TYPE, cCommandLine.GetMacroType());
+#undef TESTLOCAL_MACRO_TYPE
+}
+
+/*!
+ * @brief パラメータ解析(-PROF)の仕様
+ * @remark -PROFが指定されていなければ空文字列
+ * @remark -PROFが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseProfileName)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_STREQ(L"", cCommandLine.GetProfileName());
+	EXPECT_FALSE(cCommandLine.IsSetProfile());
+#define TESTLOCAL_PROFILE_NAME L"執筆用"
+	cCommandLine.ParseCommandLine(L"-PROF=" TESTLOCAL_PROFILE_NAME, false);
+	ASSERT_STREQ(TESTLOCAL_PROFILE_NAME, cCommandLine.GetProfileName());
+	EXPECT_TRUE(cCommandLine.IsSetProfile());
+#undef TESTLOCAL_PROFILE_NAME
+}
+
+/*!
+ * @brief パラメータ解析(-PROFMGR)の仕様
+ * @remark -PROFMGRが指定されていなければFALSE
+ * @remark -PROFMGRが指定されていたらTRUE
+ */
+TEST(CCommandLine, ParseProfileManager)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsProfileMgr());
+	cCommandLine.ParseCommandLine(L"-PROFMGR", false);
+	ASSERT_TRUE(cCommandLine.IsProfileMgr());
+}
+
+/*!
+ * @brief パラメータ解析(ファイル名)の仕様
+ * @remark GetFileNumで取得できるのは2つ目以降のファイル数
+ * @remark GetFileName(0)で取得できるのは2つ目のファイル名
+ */
+TEST(CCommandLine, ParseOpenFilename)
+{
+	//TODO: 現状のコードではテストを書きづらい...
+	//・ファイルは複数指定できる
+	//・1つ目のファイルは EditInfo に格納される
+	//・2つ目以降のファイルは vector に格納される
+
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(0, cCommandLine.GetFileNum());
+	EXPECT_EQ(NULL, cCommandLine.GetFileName(0));
+#define TESTLOCAL_OPEN_FILENAME L"test2.txt"
+	cCommandLine.ParseCommandLine(L"test1.txt " TESTLOCAL_OPEN_FILENAME, false);
+	EXPECT_EQ(1, cCommandLine.GetFileNum());
+	std::wstring additionalFile(cCommandLine.GetFileName(0));
+	ASSERT_NE(0, additionalFile.find(TESTLOCAL_OPEN_FILENAME));
+#undef TESTLOCAL_OPEN_FILENAME
+	cCommandLine.ClearFile();
+	EXPECT_EQ(0, cCommandLine.GetFileNum());
+}
+
+/*!
+ * @brief プロファイル指定済みフラグの仕様
+ * @remark SetProfileNameを呼び出したらTRUE
+ */
+TEST(CCommandLine, SetProfileName)
+{
+	CCommandLine cCommandLine;
+	EXPECT_FALSE(cCommandLine.IsSetProfile());
+	cCommandLine.SetProfileName(L"");
+	ASSERT_TRUE(cCommandLine.IsSetProfile());
+}
+
+/*!
+ * @brief パラメータ解析(-@)の仕様
+ * @remark -@が指定されていなければ何もしない
+ * @remark -@が指定されていたら指定されたファイルを読み込む
+ */
+TEST(CCommandLine, ParseFromResponseFile)
+{
+	// レスポンスファイルを作る
+	{
+		std::ofstream resp("test.response");
+		resp << "-R" << std::endl;
+	}
+
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-@=test.response", true);
+	EXPECT_TRUE(cCommandLine.IsViewMode());
+
+	std::remove("test.response");
+}
+
+/*!
+ * @brief オプションの仕様
+ * @remark オプションはダブルクォートで囲んでもよい
+ */
+TEST(CCommandLine, QuotedOption)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"\"-GROUP=1\"", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief オプションの仕様
+ * @remark ダブルクォートは終端記号がなくてもよい
+ */
+TEST(CCommandLine, QuotedOptionWithMissingEndQuote)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"\"-GROUP=1", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark '='または':'に続けて指定する
+ */
+TEST(CCommandLine, OptionWithArgumentAssign)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=1", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark '='または':'に続けて指定する
+ */
+TEST(CCommandLine, OptionWithArgumentColon)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP:1", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 引数はダブルクォートまたはシングルクォートで囲ってもよい
+ */
+TEST(CCommandLine, OptionWithDoubleQuotedArgument)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=\"1\"", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 引数はダブルクォートまたはシングルクォートで囲ってもよい
+ */
+TEST(CCommandLine, OptionWithSingleQuotedArgument)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=\'1\'", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 引数を指定しなかった場合、無視される
+ */
+TEST(CCommandLine, OptionWithoutNeededArgument)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 無効な引数を指定した場合、無視される
+ */
+TEST(CCommandLine, OptionWithInvalidArgumentEmpty)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+	cCommandLine.ParseCommandLine(L"-GROUP:", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 数値引数に非数を指定した場合、0を指定したものと看做される
+ */
+TEST(CCommandLine, OptionWithInvalidArgumentNAN)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=Admin", false);
+	EXPECT_EQ(0, cCommandLine.GetGroupId());
+	cCommandLine.ParseCommandLine(L"-GROUP:Admin", false);
+	EXPECT_EQ(0, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief パラメータ終端指定の仕様
+ * @remark "-" で始まるファイルを扱うための仕様
+ * @remark コマンドラインに "--" を含めると、
+ *   以降の"-"で始まる文字列をオプション指定と看做さなくなる。
+ */
+TEST(CCommandLine, EndOfOptionMark)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-- -GROUP=2", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+}

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -52,11 +52,7 @@ TEST(CCommandLine, ConstructWithoutParam)
 
 	EXPECT_EQ(EditInfo(), cCommandLine.GetEditInfoRef());
 
-	//GetGrepInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
-	GrepInfo gi;
-	EXPECT_TRUE(cCommandLine.GetGrepInfo(&gi));
-	//TODO: GrepInfoに等価比較演算子を実装する
-	//EXPECT_EQ(GrepInfo(), gi);
+	EXPECT_EQ(GrepInfo(), cCommandLine.GetGrepInfoRef());
 
 	EXPECT_EQ(-1, cCommandLine.GetGroupId());
 	EXPECT_EQ(NULL, cCommandLine.GetMacro());
@@ -426,6 +422,299 @@ TEST(CCommandLine, SetProfileName)
 	EXPECT_FALSE(cCommandLine.IsSetProfile());
 	cCommandLine.SetProfileName(L"");
 	ASSERT_TRUE(cCommandLine.IsSetProfile());
+}
+
+/*!
+ * @brief パラメータ解析(-GKEY)の仕様
+ * @remark -GKEYが指定されていなければNULL
+ * @remark -GKEYが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseGrepKey)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetGrepInfoRef().cmGrepKey.GetStringPtr());
+#define TESTLOCAL_GREP_KEY L"\\w+"
+	cCommandLine.ParseCommandLine(L"-GKEY=" TESTLOCAL_GREP_KEY, false);
+	ASSERT_STREQ(TESTLOCAL_GREP_KEY, cCommandLine.GetGrepInfoRef().cmGrepKey.GetStringPtr());
+#undef TESTLOCAL_GREP_KEY
+}
+
+/*!
+ * @brief パラメータ解析(-GREPR)の仕様
+ * @remark -GREPRが指定されていなければNULL
+ * @remark -GREPRが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseGrepReplaceKey)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetGrepInfoRef().cmGrepRep.GetStringPtr());
+#define TESTLOCAL_GREP_REPR L"$1。"
+	cCommandLine.ParseCommandLine(L"-GREPR=" TESTLOCAL_GREP_REPR, false);
+	ASSERT_STREQ(TESTLOCAL_GREP_REPR, cCommandLine.GetGrepInfoRef().cmGrepRep.GetStringPtr());
+#undef TESTLOCAL_GREP_REPR
+}
+
+/*!
+ * @brief パラメータ解析(-GFILE)の仕様
+ * @remark -GFILEが指定されていなければNULL
+ * @remark -GFILEが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseGrepFile)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetGrepInfoRef().cmGrepFile.GetStringPtr());
+#define TESTLOCAL_GREP_FILE L"#.git"
+	cCommandLine.ParseCommandLine(L"-GFILE=" TESTLOCAL_GREP_FILE, false);
+	ASSERT_STREQ(TESTLOCAL_GREP_FILE, cCommandLine.GetGrepInfoRef().cmGrepFile.GetStringPtr());
+#undef TESTLOCAL_GREP_FILE
+}
+
+/*!
+ * @brief パラメータ解析(-GFOLDER)の仕様
+ * @remark -GFOLDERが指定されていなければNULL
+ * @remark -GFOLDERが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseGrepFolder)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetGrepInfoRef().cmGrepFolder.GetStringPtr());
+#define TESTLOCAL_GREP_FOLDER L"C:\\work\\sakura"
+	cCommandLine.ParseCommandLine(L"-GFOLDER=" TESTLOCAL_GREP_FOLDER, false);
+	ASSERT_STREQ(TESTLOCAL_GREP_FOLDER, cCommandLine.GetGrepInfoRef().cmGrepFolder.GetStringPtr());
+#undef TESTLOCAL_GREP_FOLDER
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepCurFolder)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepCurFolder);
+	cCommandLine.ParseCommandLine(L"-GOPT=X", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepCurFolder);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepStdout)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepStdout);
+	cCommandLine.ParseCommandLine(L"-GOPT=U", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepStdout);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければTRUE
+* @remark -GOPTが指定されていたらFALSE
+*/
+TEST(CCommandLine, ParseGrepHeader)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(!cCommandLine.GetGrepInfoRef().bGrepHeader);
+	cCommandLine.ParseCommandLine(L"-GOPT=H", false);
+	EXPECT_TRUE(!cCommandLine.GetGrepInfoRef().bGrepHeader);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepSubFolder)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepSubFolder);
+	cCommandLine.ParseCommandLine(L"-GOPT=S", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepSubFolder);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepCaseSensitive)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bLoHiCase);
+	cCommandLine.ParseCommandLine(L"-GOPT=L", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bLoHiCase);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepUseRegularExpressions)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bRegularExp);
+	cCommandLine.ParseCommandLine(L"-GOPT=R", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bRegularExp);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければSJIS
+* @remark -GOPTが指定されていたら自動検知
+* @note このオプションは特殊
+*/
+TEST(CCommandLine, ParseGrepCodeAutoDetect)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(CODE_SJIS, cCommandLine.GetGrepInfoRef().nGrepCharSet);
+	cCommandLine.ParseCommandLine(L"-GOPT=K", false);
+	EXPECT_EQ(CODE_AUTODETECT, cCommandLine.GetGrepInfoRef().nGrepCharSet);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @note このオプションは特殊
+*/
+TEST(CCommandLine, ParseGrepOutputLineType)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(0, cCommandLine.GetGrepInfoRef().nGrepOutputLineType);
+	cCommandLine.ParseCommandLine(L"-GOPT=P", false); //Positive?
+	EXPECT_EQ(1, cCommandLine.GetGrepInfoRef().nGrepOutputLineType);
+	cCommandLine.ParseCommandLine(L"-GOPT=N", false); //Negative?
+	EXPECT_EQ(2, cCommandLine.GetGrepInfoRef().nGrepOutputLineType);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepUseWordParse)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bWordOnly);
+	cCommandLine.ParseCommandLine(L"-GOPT=W", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bWordOnly);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @note このオプションは特殊
+*/
+TEST(CCommandLine, ParseGrepOutputStyle)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(1, cCommandLine.GetGrepInfoRef().nGrepOutputStyle);
+	cCommandLine.ParseCommandLine(L"-GOPT=1", false);
+	EXPECT_EQ(1, cCommandLine.GetGrepInfoRef().nGrepOutputStyle);
+	cCommandLine.ParseCommandLine(L"-GOPT=2", false);
+	EXPECT_EQ(2, cCommandLine.GetGrepInfoRef().nGrepOutputStyle);
+	cCommandLine.ParseCommandLine(L"-GOPT=3", false);
+	EXPECT_EQ(3, cCommandLine.GetGrepInfoRef().nGrepOutputStyle);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepListFileNameOnly)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepOutputFileOnly);
+	cCommandLine.ParseCommandLine(L"-GOPT=F", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepOutputFileOnly);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepDisplayRoot)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepOutputBaseFolder);
+	cCommandLine.ParseCommandLine(L"-GOPT=B", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepOutputBaseFolder);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepSplitResultPerFolder)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepSeparateFolder);
+	cCommandLine.ParseCommandLine(L"-GOPT=D", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepSeparateFolder);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepReplacePasteFromClipBoard)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepPaste);
+	cCommandLine.ParseCommandLine(L"-GOPT=C", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepPaste);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepReplaceCreateBackupFiles)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepBackup);
+	cCommandLine.ParseCommandLine(L"-GOPT=O", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepBackup);
+}
+
+/*!
+ * @brief パラメータ解析(-GCODE)の仕様
+ * @remark -GCODEが指定されていなければSJIS
+ * @remark -GCODEが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseGrepCode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(CODE_SJIS, cCommandLine.GetGrepInfoRef().nGrepCharSet);
+	cCommandLine.ParseCommandLine(L"-GCODE=99", false);
+	EXPECT_EQ(CODE_AUTODETECT, cCommandLine.GetGrepInfoRef().nGrepCharSet);
 }
 
 /*!

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -53,8 +53,7 @@ TEST(CCommandLine, ConstructWithoutParam)
 	//GetEditInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
 	EditInfo fi;
 	EXPECT_TRUE(cCommandLine.GetEditInfo(&fi));
-	//TODO: EditInfoに等価比較演算子を実装する
-	//EXPECT_EQ(EditInfo(), fi);
+	EXPECT_EQ(EditInfo(), fi);
 
 	//GetGrepInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
 	GrepInfo gi;

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -50,10 +50,7 @@ TEST(CCommandLine, ConstructWithoutParam)
 	EXPECT_FALSE(cCommandLine.IsDebugMode());
 	EXPECT_FALSE(cCommandLine.IsViewMode());
 
-	//GetEditInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
-	EditInfo fi;
-	EXPECT_TRUE(cCommandLine.GetEditInfo(&fi));
-	EXPECT_EQ(EditInfo(), fi);
+	EXPECT_EQ(EditInfo(), cCommandLine.GetEditInfoRef());
 
 	//GetGrepInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
 	GrepInfo gi;
@@ -117,9 +114,8 @@ TEST(CCommandLine, ParseGrepMode)
 	cCommandLine.ParseCommandLine(L"-GREPMODE", false);
 	ASSERT_TRUE(cCommandLine.IsGrepMode());
 
-	//TODO: 現状のコードではテストを書きづらい...
 	//Grepモード時は文書タイプが"grepout"になる
-	//ASSERT_STREQ(L"grepout", cCommandLine.GetDocType());
+	ASSERT_STREQ(L"grepout", cCommandLine.GetDocType());
 }
 
 /*!
@@ -151,9 +147,8 @@ TEST(CCommandLine, ParseDebugMode)
 	cCommandLine.ParseCommandLine(L"-DEBUGMODE", false);
 	ASSERT_TRUE(cCommandLine.IsDebugMode());
 
-	//TODO: 現状のコードではテストを書きづらい...
 	//Debugモード時は文書タイプが"output"になる
-	//ASSERT_STREQ(L"output", cCommandLine.GetDocType());
+	ASSERT_STREQ(L"output", cCommandLine.GetDocType());
 }
 
 /*!
@@ -250,27 +245,173 @@ TEST(CCommandLine, ParseProfileManager)
 }
 
 /*!
+ * @brief パラメータ解析(-X)の仕様
+ * @remark -Xが指定されていなければ-1
+ * @remark -Xが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseCaretLocationX)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetCaretLocation().x);
+	cCommandLine.ParseCommandLine(L"-X=123", false);
+	ASSERT_EQ(122, cCommandLine.GetCaretLocation().x);
+}
+
+/*!
+ * @brief パラメータ解析(-Y)の仕様
+ * @remark -Yが指定されていなければ-1
+ * @remark -Yが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseCaretLocationY)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetCaretLocation().y);
+	cCommandLine.ParseCommandLine(L"-Y=123", false);
+	ASSERT_EQ(122, cCommandLine.GetCaretLocation().y);
+}
+
+/*!
+ * @brief パラメータ解析(-VX)の仕様
+ * @remark -VXが指定されていなければ-1
+ * @remark -VXが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseViewLeftCol)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetViewLocation().x);
+	cCommandLine.ParseCommandLine(L"-VX=123", false);
+	ASSERT_EQ(122, cCommandLine.GetViewLocation().x);
+}
+
+/*!
+ * @brief パラメータ解析(-VY)の仕様
+ * @remark -VYが指定されていなければ-1
+ * @remark -VYが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseViewTopLine)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetViewLocation().y);
+	cCommandLine.ParseCommandLine(L"-VY=123", false);
+	ASSERT_EQ(122, cCommandLine.GetViewLocation().y);
+}
+
+/*!
+ * @brief パラメータ解析(-SX)の仕様
+ * @remark -SXが指定されていなければ-1
+ * @remark -SXが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseWindowSizeX)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetWindowSize().cx);
+	cCommandLine.ParseCommandLine(L"-SX=123", false);
+	ASSERT_EQ(122, cCommandLine.GetWindowSize().cx);
+}
+
+/*!
+ * @brief パラメータ解析(-SY)の仕様
+ * @remark -SYが指定されていなければ-1
+ * @remark -SYが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseWindowSizeY)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetWindowSize().cy);
+	cCommandLine.ParseCommandLine(L"-SY=123", false);
+	ASSERT_EQ(122, cCommandLine.GetWindowSize().cy);
+}
+
+/*!
+ * @brief パラメータ解析(-WX)の仕様
+ * @remark -WXが指定されていなければCW_USEDEFAULT
+ * @remark -WXが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseWindowOriginX)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(CW_USEDEFAULT, cCommandLine.GetWindowOrigin().x);
+	cCommandLine.ParseCommandLine(L"-WX=123", false);
+	ASSERT_EQ(123, cCommandLine.GetWindowOrigin().x);
+}
+
+/*!
+ * @brief パラメータ解析(-WY)の仕様
+ * @remark -WYが指定されていなければCW_USEDEFAULT
+ * @remark -WYが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseWindowOriginY)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(CW_USEDEFAULT, cCommandLine.GetWindowOrigin().y);
+	cCommandLine.ParseCommandLine(L"-WY=123", false);
+	ASSERT_EQ(123, cCommandLine.GetWindowOrigin().y);
+}
+
+/*!
+ * @brief パラメータ解析(-TYPE)の仕様
+ * @remark -TYPEが指定されていなければNULL
+ * @remark -TYPEが指定されていたら指定された文字列
+ * @remark DocTypeには任意の文字列を指定できる
+ */
+TEST(CCommandLine, ParseDocType)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_STREQ(L"", cCommandLine.GetDocType());
+#define TESTLOCAL_DOC_TYPE L"C/C++"
+	cCommandLine.ParseCommandLine(L"-TYPE=" TESTLOCAL_DOC_TYPE, false);
+	ASSERT_STREQ(TESTLOCAL_DOC_TYPE, cCommandLine.GetDocType());
+#undef TESTLOCAL_DOC_TYPE
+}
+
+/*!
+ * @brief パラメータ解析(-CODE)の仕様
+ * @remark -CODEが指定されていなければJIS
+ * @remark -CODEが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseDocCode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(CODE_JIS, cCommandLine.GetDocCode());
+	cCommandLine.ParseCommandLine(L"-CODE=99", false);
+	EXPECT_EQ(CODE_AUTODETECT, cCommandLine.GetDocCode());
+}
+
+/*!
  * @brief パラメータ解析(ファイル名)の仕様
- * @remark GetFileNumで取得できるのは2つ目以降のファイル数
- * @remark GetFileName(0)で取得できるのは2つ目のファイル名
+ * @remark ファイルは複数指定できる
+ * @remark 1つ目のファイルは EditInfo(m_fi.m_szPath) に格納される
+ * @remark 2つ目以降のファイルは vector(m_vFiles) に格納される
+ * @remark 1つ目のファイルパスは、パス解決されてフルパスになる
+ * @remark 2つ目以降のファイルは、パス解決されない
  */
 TEST(CCommandLine, ParseOpenFilename)
 {
-	//TODO: 現状のコードではテストを書きづらい...
-	//・ファイルは複数指定できる
-	//・1つ目のファイルは EditInfo に格納される
-	//・2つ目以降のファイルは vector に格納される
-
 	CCommandLine cCommandLine;
 	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_STREQ(L"", cCommandLine.GetOpenFile());
 	EXPECT_EQ(0, cCommandLine.GetFileNum());
 	EXPECT_EQ(NULL, cCommandLine.GetFileName(0));
-#define TESTLOCAL_OPEN_FILENAME L"test2.txt"
-	cCommandLine.ParseCommandLine(L"test1.txt " TESTLOCAL_OPEN_FILENAME, false);
+#define TESTLOCAL_OPEN_FILENAME1 L"test1.txt"
+#define TESTLOCAL_OPEN_FILENAME2 L"test2.txt"
+	cCommandLine.ParseCommandLine(TESTLOCAL_OPEN_FILENAME1 " " TESTLOCAL_OPEN_FILENAME2, false);
+	//EXPECT_STREQ(TESTLOCAL_OPEN_FILENAME1, cCommandLine.GetOpenFile());
+	EXPECT_STRNE(L"", cCommandLine.GetOpenFile());
 	EXPECT_EQ(1, cCommandLine.GetFileNum());
 	std::wstring additionalFile(cCommandLine.GetFileName(0));
-	ASSERT_NE(0, additionalFile.find(TESTLOCAL_OPEN_FILENAME));
-#undef TESTLOCAL_OPEN_FILENAME
+	ASSERT_NE(0, additionalFile.find(TESTLOCAL_OPEN_FILENAME2));
+#undef TESTLOCAL_OPEN_FILENAME2
+#undef TESTLOCAL_OPEN_FILENAME1
 	cCommandLine.ClearFile();
 	EXPECT_EQ(0, cCommandLine.GetFileNum());
 }

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -345,6 +345,199 @@ TEST(CNativeW, AppendStringWithFormatting)
 }
 
 /*!
+ * @brief 等価比較演算子のテスト
+ *  初期値同士の等価比較を行う
+ */
+TEST(CNativeW, operatorEqualNull)
+{
+	CNativeW value, other;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  nullptrとの等価比較を行う
+ */
+TEST(CNativeW, operatorEqualNullptr)
+{
+	CNativeW value;
+
+	EXPECT_TRUE(value == nullptr);
+	EXPECT_FALSE(value != nullptr);
+	ASSERT_EQ(value, nullptr);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  ポインタ(値がNULL)との等価比較を行う
+ */
+TEST(CNativeW, operatorEqualStringNull)
+{
+	CNativeW value;
+	LPCTSTR str = NULL;
+
+	EXPECT_TRUE(value == str);
+	EXPECT_FALSE(value != str);
+	ASSERT_EQ(value, str);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  値あり同士の等価比較を行う
+ */
+TEST(CNativeW, operatorEqualSame)
+{
+	CNativeW value(L"これはテストです。");
+	CNativeW other(L"これはテストです。");
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  自分自身との等価比較を行う
+ */
+TEST(CNativeW, operatorEqualBySelf)
+{
+	CNativeW value;
+
+	EXPECT_TRUE(value == value);
+	EXPECT_FALSE(value != value);
+	ASSERT_EQ(value, value);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *  重要なクラスなので、テスト条件ごとにケースを分ける
+ *
+ *  合格条件：値あり vs NULL の比較で不一致を検出できること
+ */
+TEST(CNativeW, operatorNotEqualSomeValueVsNull)
+{
+	// 値あり vs NULL
+	CNativeW value(L"これはテストです。");
+	CNativeW other;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *  重要なクラスなので、テスト条件ごとにケースを分ける
+ *
+ *  合格条件：NULL vs 値あり の比較で不一致を検出できること
+ */
+TEST(CNativeW, operatorNotEqualNullVsSomeValue)
+{
+	// NULL vs 値あり
+	CNativeW value;
+	CNativeW other(L"これはテストです。");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *  重要なクラスなので、テスト条件ごとにケースを分ける
+ *
+ *  合格条件：長さの異なる場合の比較で不一致を検出できること
+ */
+TEST(CNativeW, operatorNotEqualNotSameLength)
+{
+	// 値あり vs 値あり(文字列長が違う)
+	CNativeW value(L"これはテストです。");
+	CNativeW other(L"これはテスト？");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *  重要なクラスなので、テスト条件ごとにケースを分ける
+ *
+ *  合格条件：長さが等しく内容の異なる場合の比較で不一致を検出できること
+ */
+TEST(CNativeW, operatorNotEqualNotSameContent)
+{
+	// 値あり vs 値あり(値が違う)
+	CNativeW value(L"これはテストです。");
+	CNativeW other(L"これはテストです？");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  ポインタとの等価比較を行う
+ */
+TEST(CNativeW, operatorEqualSameString)
+{
+	constexpr const wchar_t text[] = L"おっす！オラ(ry";
+	CNativeW value(text);
+	LPCTSTR str = text;
+
+	EXPECT_TRUE(value == str);
+	EXPECT_FALSE(value != str);
+	ASSERT_EQ(value, str);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  ポインタとの等価比較を行う
+ */
+TEST(CNativeW, operatorNotEqualAlmostSameString)
+{
+	CNativeW value(L"おっす！オラ(ry");
+	LPCTSTR str = L"おっと！オラ(ry";
+
+	EXPECT_FALSE(value == str);
+	EXPECT_TRUE(value != str);
+	ASSERT_NE(value, str);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  nullptrとの等価比較を行う
+ */
+TEST(CNativeW, operatorNotEqualNullptr)
+{
+	constexpr const wchar_t text[] = L"おっす！オラ(ry";
+	CNativeW value(text);
+
+	EXPECT_FALSE(value == nullptr);
+	EXPECT_TRUE(value != nullptr);
+	ASSERT_NE(value, nullptr);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  ポインタ(値がNULL)との等価比較を行う
+ */
+TEST(CNativeW, operatorNotEqualStringNull)
+{
+	constexpr const wchar_t text[] = L"おっす！オラ(ry";
+	CNativeW value(text);
+	LPCTSTR str = NULL;
+
+	EXPECT_FALSE(value == str);
+	EXPECT_TRUE(value != str);
+	ASSERT_NE(value, str);
+}
+
+/*!
  * @brief 独自関数Replaceの仕様
  * @remark バッファが確保される
  * @remark 文字列長は0になる

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -377,7 +377,7 @@ TEST(CNativeW, operatorEqualNullptr)
 TEST(CNativeW, operatorEqualStringNull)
 {
 	CNativeW value;
-	LPCTSTR str = NULL;
+	LPCWSTR str = NULL;
 
 	EXPECT_TRUE(value == str);
 	EXPECT_FALSE(value != str);
@@ -487,7 +487,7 @@ TEST(CNativeW, operatorEqualSameString)
 {
 	constexpr const wchar_t text[] = L"おっす！オラ(ry";
 	CNativeW value(text);
-	LPCTSTR str = text;
+	LPCWSTR str = text;
 
 	EXPECT_TRUE(value == str);
 	EXPECT_FALSE(value != str);
@@ -501,7 +501,7 @@ TEST(CNativeW, operatorEqualSameString)
 TEST(CNativeW, operatorNotEqualAlmostSameString)
 {
 	CNativeW value(L"おっす！オラ(ry");
-	LPCTSTR str = L"おっと！オラ(ry";
+	LPCWSTR str = L"おっと！オラ(ry";
 
 	EXPECT_FALSE(value == str);
 	EXPECT_TRUE(value != str);
@@ -530,7 +530,7 @@ TEST(CNativeW, operatorNotEqualStringNull)
 {
 	constexpr const wchar_t text[] = L"おっす！オラ(ry";
 	CNativeW value(text);
-	LPCTSTR str = NULL;
+	LPCWSTR str = NULL;
 
 	EXPECT_FALSE(value == str);
 	EXPECT_TRUE(value != str);

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -540,7 +540,7 @@ TEST(CNativeW, operatorNotEqualStringNull)
 /*!
  * @brief 否定の等価比較演算子のテスト
  *  文字列中のNULの位置によって一般保護違反になるかどうかの検証。
- *  このテストは成功したらNG!
+ *  このテストは成功したらNG!　⇒　分かりづらいので失敗したらNGに修正。
  */
 TEST(CNativeW, operatorNotEqualCNativeContainsNulVsBeginningWithPartial)
 {
@@ -581,21 +581,20 @@ TEST(CNativeW, operatorNotEqualCNativeContainsNulVsBeginningWithPartial)
 	volatile BOOL retVirtualProtect = ::VirtualProtect((char*)buf1 + pageSize, pageSize, PAGE_NOACCESS, &flOldProtect);
 	EXPECT_TRUE(retVirtualProtect);
 
-	/* DEATHテストで例外ケースの判定を行う。
-	 * pLargeStrには、コミットサイズの倍のデータが入っているので、
-	 * 単純にstrcmpするとreserveしただけの領域にアクセスしてしまい一般保護違反(access violation)が起きる。
-	 *
-	 * 想定結果：一般保護違反で落ちる
-	 * 備考：例外メッセージは無視する(例外が起きたことが検知できればよいから。)
-	 */
-	volatile bool ret = 0;
-	ASSERT_DEATH({ ret = (value == str); }, ".*");
-	(void)ret;
-
-	// 仮想メモリをデコミット(=解放)する。
-	::VirtualFree((LPVOID)buf1, pageSize, MEM_DECOMMIT);
-	// 仮想メモリ範囲を解放する。
-	::VirtualFree(memBlock1, 0, MEM_RELEASE);
+	try
+	{
+		bool ret = (value == str);
+		(void)ret;
+	}
+	catch(...)
+	{
+		// 仮想メモリをデコミット(=解放)する。
+		::VirtualFree((LPVOID)buf1, pageSize, MEM_DECOMMIT);
+		// 仮想メモリ範囲を解放する。
+		::VirtualFree(memBlock1, 0, MEM_RELEASE);
+		//
+		throw;
+	}
 }
 
 /*!

--- a/tests/unittests/test-editinfo.cpp
+++ b/tests/unittests/test-editinfo.cpp
@@ -34,7 +34,7 @@
 #include "EditInfo.h"
 
 /*!
- * @brief 等価演算子のテスト
+ * @brief 等価比較演算子のテスト
  *  初期値同士の等価比較を行う
  */
 TEST(EditInfo, operatorEqualSame)
@@ -47,7 +47,7 @@ TEST(EditInfo, operatorEqualSame)
 }
 
 /*!
- * @brief 等価演算子のテスト
+ * @brief 等価比較演算子のテスト
  *  自分自身との等価比較を行う
  */
 TEST(EditInfo, operatorEqualBySelf)
@@ -60,7 +60,7 @@ TEST(EditInfo, operatorEqualBySelf)
 }
 
 /*!
- * @brief 否定の等価演算子のテスト
+ * @brief 否定の等価比較演算子のテスト
  *  メンバの値を変えて、等価比較を行う
  *
  *  合格条件：メンバの値が1つでも違ったら不一致を検出できること。

--- a/tests/unittests/test-editinfo.cpp
+++ b/tests/unittests/test-editinfo.cpp
@@ -1,0 +1,173 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include "EditInfo.h"
+
+/*!
+ * @brief 等価演算子のテスト
+ *  初期値同士の等価比較を行う
+ */
+TEST(EditInfo, operatorEqualSame)
+{
+	EditInfo value, other;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価演算子のテスト
+ *  自分自身との等価比較を行う
+ */
+TEST(EditInfo, operatorEqualBySelf)
+{
+	EditInfo value;
+
+	EXPECT_TRUE(value == value);
+	EXPECT_FALSE(value != value);
+	ASSERT_EQ(value, value);
+}
+
+/*!
+ * @brief 否定の等価演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *
+ *  合格条件：メンバの値が1つでも違ったら不一致を検出できること。
+ */
+TEST(EditInfo, operatorNotEqual)
+{
+	EditInfo value, other;
+
+	wcscpy_s(value.m_szPath, L"test");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_szPath[0] = 0;
+	
+	value.m_nCharCode = CODE_JIS;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nCharCode = other.m_nCharCode;
+
+	value.m_bBom = !other.m_bBom;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_bBom = other.m_bBom;
+
+	wcscpy_s(value.m_szDocType, L"test");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_szDocType[0] = 0;
+
+	value.m_nTypeId = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nTypeId = other.m_nTypeId;
+
+	value.m_nViewTopLine = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nViewTopLine = other.m_nViewTopLine;
+
+	value.m_nViewLeftCol = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nViewLeftCol = other.m_nViewLeftCol;
+
+	value.m_ptCursor = CLogicPoint(1234, 5678);
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_ptCursor = other.m_ptCursor;
+
+	value.m_bIsModified = !other.m_bIsModified;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_bIsModified = other.m_bIsModified;
+
+	value.m_bIsGrep = !other.m_bIsGrep;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_bIsGrep = other.m_bIsGrep;
+
+	wcscpy_s(value.m_szGrepKey, L"test");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_szGrepKey[0] = 0;
+
+	value.m_bIsDebug = !other.m_bIsDebug;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_bIsDebug = other.m_bIsDebug;
+
+	wcscpy_s(value.m_szMarkLines, L"test");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_szMarkLines[0] = 0;
+
+	value.m_nWindowSizeX = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nWindowSizeX = other.m_nWindowSizeX;
+
+	value.m_nWindowSizeY = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nWindowSizeY = other.m_nWindowSizeY;
+
+	value.m_nWindowOriginX = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nWindowOriginX = other.m_nWindowOriginX;
+
+	value.m_nWindowOriginY = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nWindowOriginY = other.m_nWindowOriginY;
+}

--- a/tests/unittests/test-grepinfo.cpp
+++ b/tests/unittests/test-grepinfo.cpp
@@ -1,0 +1,203 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include "_main/CCommandLine.h"
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  初期値同士の等価比較を行う
+ */
+TEST(GrepInfo, operatorEqualSame)
+{
+	GrepInfo value, other;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  自分自身との等価比較を行う
+ */
+TEST(GrepInfo, operatorEqualBySelf)
+{
+	GrepInfo value;
+
+	EXPECT_TRUE(value == value);
+	EXPECT_FALSE(value != value);
+	ASSERT_EQ(value, value);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *
+ *  合格条件：メンバの値が1つでも違ったら不一致を検出できること。
+ */
+TEST(GrepInfo, operatorNotEqual)
+{
+	GrepInfo value, other;
+
+	value.cmGrepKey = L"ぐれっぷ";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmGrepKey = other.cmGrepKey;
+
+	value.cmGrepRep = L"ちかん";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmGrepRep = other.cmGrepRep;
+
+	value.cmGrepFile = L"#.git;*.*";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmGrepFile = other.cmGrepFile;
+
+	value.cmGrepFolder = L"C:\\work\\sakura";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmGrepFolder = other.cmGrepFolder;
+
+	value.cmExcludeFile = L"除外ファイルの仕様がなんでここに残ってんだっけ？";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmExcludeFile = other.cmExcludeFile;
+
+	value.cmExcludeFolder = L"除外フォルダの仕様がなんで(ry";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmExcludeFolder = other.cmExcludeFolder;
+
+	value.sGrepSearchOption.bRegularExp = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.sGrepSearchOption = other.sGrepSearchOption;
+
+	value.sGrepSearchOption.bLoHiCase = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.sGrepSearchOption = other.sGrepSearchOption;
+
+	value.sGrepSearchOption.bWordOnly = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.sGrepSearchOption = other.sGrepSearchOption;
+
+	value.bGrepCurFolder = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepCurFolder = other.bGrepCurFolder;
+
+	value.bGrepStdout = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepStdout = other.bGrepStdout;
+
+	value.bGrepHeader = false;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepHeader = other.bGrepHeader;
+
+	value.bGrepSubFolder = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepSubFolder = other.bGrepSubFolder;
+
+	value.nGrepCharSet = CODE_EUC;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.nGrepCharSet = other.nGrepCharSet;
+
+	value.nGrepOutputStyle = 2;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.nGrepOutputStyle = other.nGrepOutputStyle;
+
+	value.nGrepOutputLineType = 2;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.nGrepOutputLineType = other.nGrepOutputLineType;
+
+	value.bGrepOutputFileOnly = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepOutputFileOnly = other.bGrepOutputFileOnly;
+
+	value.bGrepOutputBaseFolder = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepOutputBaseFolder = other.bGrepOutputBaseFolder;
+
+	value.bGrepSeparateFolder = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepSeparateFolder = other.bGrepSeparateFolder;
+
+	value.bGrepReplace = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepReplace = other.bGrepReplace;
+
+	value.bGrepPaste = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepPaste = other.bGrepPaste;
+
+	value.bGrepBackup = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepBackup = other.bGrepBackup;
+}

--- a/tests/unittests/test-ssearchoption.cpp
+++ b/tests/unittests/test-ssearchoption.cpp
@@ -1,0 +1,93 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include "_main/global.h"
+
+/*!
+ * @brief 等価演算子のテスト
+ *  初期値同士の等価比較を行う
+ */
+TEST(SSearchOption, operatorEqualSame)
+{
+	SSearchOption value, other;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価演算子のテスト
+ *  自分自身との等価比較を行う
+ */
+TEST(SSearchOption, operatorEqualBySelf)
+{
+	SSearchOption value;
+
+	EXPECT_TRUE(value == value);
+	EXPECT_FALSE(value != value);
+	ASSERT_EQ(value, value);
+}
+
+/*!
+ * @brief 否定の等価演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *
+ *  合格条件：メンバの値が1つでも違ったら不一致を検出できること。
+ */
+TEST(SSearchOption, operatorNotEqual)
+{
+	SSearchOption value, other;
+
+	value.bRegularExp = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bRegularExp = false;
+
+	value.bLoHiCase = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bLoHiCase = false;
+
+	value.bWordOnly = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bWordOnly = false;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -106,6 +106,7 @@
     <ClCompile Include="test-ccommandline.cpp" />
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />
+    <ClCompile Include="test-editinfo.cpp" />
     <ClCompile Include="test-int2dec.cpp" />
     <ClCompile Include="test-is_mailaddress.cpp" />
     <ClCompile Include="test-mydevmode.cpp" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -103,6 +103,7 @@
     <Link Include="$(SolutionDir)sakura\$(Platform)\$(Configuration)\*.obj" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="test-ccommandline.cpp" />
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />
     <ClCompile Include="test-int2dec.cpp" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -107,6 +107,7 @@
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />
     <ClCompile Include="test-editinfo.cpp" />
+    <ClCompile Include="test-grepinfo.cpp" />
     <ClCompile Include="test-int2dec.cpp" />
     <ClCompile Include="test-is_mailaddress.cpp" />
     <ClCompile Include="test-mydevmode.cpp" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -113,6 +113,7 @@
     <ClCompile Include="test-parameterized.cpp" />
     <ClCompile Include="test-sample-disabled.cpp" />
     <ClCompile Include="test-sample.cpp" />
+    <ClCompile Include="test-ssearchoption.cpp" />
     <ClCompile Include="test-StdControl.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -47,5 +47,8 @@
     <ClCompile Include="test-ccommandline.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-editinfo.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -53,5 +53,8 @@
     <ClCompile Include="test-ssearchoption.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-grepinfo.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -50,5 +50,8 @@
     <ClCompile Include="test-editinfo.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-ssearchoption.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -44,5 +44,8 @@
     <ClCompile Include="test-StdControl.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-ccommandline.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# PR の目的
コマンドライン解析のテストを追加します。

テストを追加することにより、今後のオプション追加・オプション変更をやりやすくします。


## カテゴリ
- その他 … リファクタリングと書きたいがリファクタリングじゃないので「その他」。
- 不具合修正 … テストを成立させるために色々直したので「不具合修正」。


## PR の背景
改修効果の確認を行うために単体テストを用意したい、と長いこと言ってきました。

この１年くらい、言うだけで何もしない人、になってたので、
サクラエディタのコードの中でもっとも手を付けやすいコマンドライン解析のテストを書いてみました。

現状のコマンドライン解析にはいろいろ問題があると思っています。

**何がどう問題なのか**

を共有するためには、既存の振る舞いを具体的に示す何かが要ると思います。

前に issue #763 で愚痴ってみましたが、それじゃ足りないような気がします・・・
　(しかも、今読み返してみると所々指摘が間違っとるしｗ)

テストコードに起こしてしまえば、少しの変更で「こうしたらどうなる？」を検証できるようになります。


## PR のメリット
- コマンドライン解析の仕様の一部が明確になります。
  - コマンドライン解析(CCommandLineクラス)のテストが新規追加されます。
  - 編集情報(EditInfo構造体)のテストが新規追加されます。
  - Grepオプション(GrepInfo構造体)のテストが新規追加されます。
  - 検索オプション(SSearchOption構造体)のテストが新規追加されます。
- テスト作成の副次効果で、内部的な改善が行われます。
  - プログラム内からコマンドライン情報にアクセスするためのgetterが改善されます。
    - 従来付加していなかった const 修飾を追加します。
    - c++11から利用できるようになった noexcept を追加します。
    - コマンドラインから指定できる編集情報(EditInfo)のメンバーについてgetterを追加します。
    - コマンドライン解析(CCommandLineクラス)に追加したテストはこれらをカバーしています。
  - 文字列バッファ(CNativeWクラス)に等価比較演算子が実装されます。
    - 文字列バッファ(CNativeWクラス)のテストが追加されます。
  - 編集情報(EditInfo構造体)に存在していたメンバ初期化漏れが修正されます。
    - 編集情報(EditInfo構造体)の初期化をメンバーイニシャライザ方式に移行します。
    - 編集情報(EditInfo構造体)に追加したテストはこれらをカバーしています。


## PR のデメリット (トレードオフとかあれば)
- ほぼテストコードですが、PR全体の修正量がハンパないです。
  - まともに内容を理解してレビューしようとしたら年が暮れると思います。
  - という前提に基づいて書いてるコードなので、細部がテキトーです。
  - 中身がテキトーなテストコードであっても存在しないよりはマシなのでPRします。
- ユニットテストを 74 件追加するので、ビルドにかかる時間が増えます。
  - 現状 94 件に対し 74 件を追加して 178 件になります。
  - 所要時間は 20 秒くらいで、ほとんどは #1074 で追加した DEATH テストの実行時間です。
  - `CCommandLine::ParseCommandLine` の実行効率は良くはないので、ケースが多い分100msくらいかかってます。
- テストコードを書くときは「リファクタリング(=動作を変えない！)」が基本ですが、テストを成立させるために修正を含めています。
  - 初期化しただけの状態同士を比較しようとすると未初期化文字列バッファの比較で落ちるとか。
  - メンバ比較を実装しようとしたら独自構造体に比較演算子が実装されてないとか。
  - 「レガシーコードあるある」ですが、テストを書こうとしたら、そもそもコンパイルできない、とか。
- 途中まで「仕様のあるべき」を真面目にコメントしていましたが、それが邪魔になるかも知れません。
  - 問題なのかそうでないのかの切り分けとか対処とかは別PRで行うべきと考えています。
  - コメントについては、不要であるとするなら削りたいと思います。
- WIP中の #1076 と変更ファイルがかぶる気がします。
  - charset/charcode.h … include関係に問題があってビルドできなかったから。
  - mem/CNativeW … 等価比較演算子を追加したから。


## PR の影響範囲
- コマンドライン解析に影響する変更です。
- メンバー初期化漏れを対処したことによる影響は読めません。
- 等価比較演算子は C++ の文化なので、追加による影響はないと考えられます。
- CCommandLineクラスに追加したメンバーは、アプリコードでの利用を想定していますが、現段階では適用を見送っているため追加による影響はありません。


## 関連チケット

#1078 CNativeWの挙動を仕様化したい
#769 [WIP] grep の除外指定の残件対応
#763 ヘルプ項目「コマンドラインオプション」が現状と合ってない件をどうにかしたい
#419 Grepのコマンドラインオプションを分かりやすくしたい
#403 grep/grep 置換で除外ファイル、除外フォルダを指定できるようにする
#385 GREP置換ダイアログを出すコマンドラインオプションが実装されていない。
#196 [WIP] プロファイル未指定なら-PROF=""を出さない


## 参考資料
ヘルプ項目「[コマンドラインオプション](https://sakura-editor.github.io/help/HLP000109.html)」
http://jagabeeinitialize.hatenablog.com/entry/2018/01/21/192043

