### PR TITLE
CNativeWにnullptrを代入できるようにしたい

### DIFF
--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -55,7 +55,7 @@ struct SEolDefinition{
 	int				m_nLen;
 
 	bool StartsWith(const WCHAR* pData, int nLen) const{ return m_nLen<=nLen && 0==wmemcmp(pData,m_szDataW,m_nLen); }
-	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==amemcmp(pData,m_szDataA,m_nLen); }
+	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==memcmp(pData,m_szDataA,m_nLen); }
 };
 extern const SEolDefinition g_aEolTable[];
 

--- a/sakura_core/EditInfo.h
+++ b/sakura_core/EditInfo.h
@@ -72,25 +72,25 @@ struct EditInfo {
 	
 	// Mar. 7, 2002 genta
 	// Constructor 確実に初期化するため
-	EditInfo()
-	: m_nCharCode( CODE_AUTODETECT )
-	, m_bBom( false )
-	, m_nTypeId( -1 )
-	, m_nViewTopLine( -1 )
-	, m_nViewLeftCol( -1 )
-	, m_ptCursor(CLogicInt(-1), CLogicInt(-1))
-	, m_bIsModified( false )
-	, m_bIsGrep( false )
-	, m_szGrepKey{ 0 }
-	, m_bIsDebug( false )
-	, m_nWindowSizeX( -1 )
-	, m_nWindowSizeY( -1 )
-	, m_nWindowOriginX( CW_USEDEFAULT )	//	2004.05.13 Moca “指定無し”を-1からCW_USEDEFAULTに変更
-	, m_nWindowOriginY( CW_USEDEFAULT )
+	EditInfo() noexcept
+		: m_szPath{ 0 }
+		, m_nCharCode( CODE_AUTODETECT )
+		, m_bBom( false )
+		, m_szDocType{ 0 }
+		, m_nTypeId( -1 )
+		, m_nViewTopLine( -1 )
+		, m_nViewLeftCol( -1 )
+		, m_ptCursor{ -1, -1 }
+		, m_bIsModified( false )
+		, m_bIsGrep( false )
+		, m_szGrepKey{ 0 }
+		, m_bIsDebug( false )
+		, m_szMarkLines{ 0 }
+		, m_nWindowSizeX( -1 )
+		, m_nWindowSizeY( -1 )
+		, m_nWindowOriginX( CW_USEDEFAULT )	//	2004.05.13 Moca “指定無し”を-1からCW_USEDEFAULTに変更
+		, m_nWindowOriginY( CW_USEDEFAULT )
 	{
-		m_szPath[0] = '\0';
-		m_szMarkLines[0] = L'\0';
-		m_szDocType[0] = '\0';
 	}
 	bool operator == (const EditInfo& rhs) const noexcept {
 		if (this == &rhs) return true;

--- a/sakura_core/EditInfo.h
+++ b/sakura_core/EditInfo.h
@@ -27,6 +27,8 @@
 
 #include "basis/SakuraBasis.h"
 #include "config/maxdata.h"
+#include "charset/charcode.h"
+#include "mem/CNativeW.h"
 #include "types/CType.h"
 
 /*! ファイル情報
@@ -79,6 +81,7 @@ struct EditInfo {
 	, m_ptCursor(CLogicInt(-1), CLogicInt(-1))
 	, m_bIsModified( false )
 	, m_bIsGrep( false )
+	, m_szGrepKey{ 0 }
 	, m_bIsDebug( false )
 	, m_nWindowSizeX( -1 )
 	, m_nWindowSizeY( -1 )
@@ -89,6 +92,27 @@ struct EditInfo {
 		m_szMarkLines[0] = L'\0';
 		m_szDocType[0] = '\0';
 	}
+	bool operator == (const EditInfo& rhs) const noexcept {
+		if (this == &rhs) return true;
+		return 0 == wcsncmp(m_szPath, rhs.m_szPath, _countof(m_szPath))
+			&& m_nCharCode == rhs.m_nCharCode
+			&& m_bBom == rhs.m_bBom
+			&& 0 == wcsncmp(m_szDocType, rhs.m_szDocType, _countof(m_szDocType))
+			&& m_nTypeId == rhs.m_nTypeId
+			&& m_nViewTopLine == rhs.m_nViewTopLine
+			&& m_nViewLeftCol == rhs.m_nViewLeftCol
+			&& m_ptCursor == rhs.m_ptCursor
+			&& m_bIsModified == rhs.m_bIsModified
+			&& m_bIsGrep == rhs.m_bIsGrep
+			&& 0 == wcsncmp(m_szGrepKey, rhs.m_szGrepKey, _countof(m_szGrepKey))
+			&& m_bIsDebug == rhs.m_bIsDebug
+			&& 0 == wcsncmp(m_szMarkLines, rhs.m_szMarkLines, _countof(m_szMarkLines))
+			&& m_nWindowSizeX == rhs.m_nWindowSizeX
+			&& m_nWindowSizeY == rhs.m_nWindowSizeY
+			&& m_nWindowOriginX == rhs.m_nWindowOriginX
+			&& m_nWindowOriginY == rhs.m_nWindowOriginY;
+	}
+	bool operator != (const EditInfo& rhs) const noexcept { return !(*this == rhs); }
 };
 
 #endif /* SAKURA_EDITINFO_38A7E267_160D_4250_9012_AC3FC31993D69_H_ */

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -19,11 +19,13 @@
 #ifndef _CCOMMANDLINE_H_
 #define _CCOMMANDLINE_H_
 
+#include <vector>
+
 #include "global.h"
+#include "charset/charcode.h"
+#include "mem/CNativeW.h"
 #include "EditInfo.h"
 #include "util/design_template.h"
-
-class CMemory;
 
 /*!	検索オプション
 	20020118 aroka
@@ -60,8 +62,10 @@ struct GrepInfo {
 */
 class CCommandLine  : public TSingleton<CCommandLine> {
 	friend class TSingleton<CCommandLine>;
+public:
 	CCommandLine();
 
+private:
 	static int CheckCommandLine(
 		LPWSTR	str,		//!< [in] 検証する文字列（先頭の-は含まない）
 		WCHAR**	arg,		//!< [out] 引数がある場合はその先頭へのポインタ

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -51,6 +51,55 @@ struct GrepInfo {
 	bool			bGrepReplace;		//!< Grep置換
 	bool			bGrepPaste;			//!< クリップボードから貼り付け
 	bool			bGrepBackup;		//!< 置換でバックアップを保存
+
+	GrepInfo() noexcept
+		: cmGrepKey()
+		, cmGrepRep()
+		, cmGrepFile()
+		, cmGrepFolder()
+		, cmExcludeFile()
+		, cmExcludeFolder()
+		, sGrepSearchOption()
+		, bGrepCurFolder(false)
+		, bGrepStdout(false)
+		, bGrepHeader(true)
+		, bGrepSubFolder(false)
+		, nGrepCharSet(CODE_SJIS)
+		, nGrepOutputStyle(1)
+		, nGrepOutputLineType(0)
+		, bGrepOutputFileOnly(false)
+		, bGrepOutputBaseFolder(false)
+		, bGrepSeparateFolder(false)
+		, bGrepReplace(false)
+		, bGrepPaste(false)
+		, bGrepBackup(false)
+	{
+	}
+
+	bool operator == (const GrepInfo& rhs) const noexcept {
+		if (this == &rhs) return true;
+		return cmGrepKey == rhs.cmGrepKey
+			&& cmGrepRep == rhs.cmGrepRep
+			&& cmGrepFile == rhs.cmGrepFile
+			&& cmGrepFolder == rhs.cmGrepFolder
+			&& cmExcludeFile == rhs.cmExcludeFile
+			&& cmExcludeFolder == rhs.cmExcludeFolder
+			&& sGrepSearchOption == rhs.sGrepSearchOption
+			&& bGrepCurFolder == rhs.bGrepCurFolder
+			&& bGrepStdout == rhs.bGrepStdout
+			&& bGrepHeader == rhs.bGrepHeader
+			&& bGrepSubFolder == rhs.bGrepSubFolder
+			&& nGrepCharSet == rhs.nGrepCharSet
+			&& nGrepOutputStyle == rhs.nGrepOutputStyle
+			&& nGrepOutputLineType == rhs.nGrepOutputLineType
+			&& bGrepOutputFileOnly == rhs.bGrepOutputFileOnly
+			&& bGrepOutputBaseFolder == rhs.bGrepOutputBaseFolder
+			&& bGrepSeparateFolder == rhs.bGrepSeparateFolder
+			&& bGrepReplace == rhs.bGrepReplace
+			&& bGrepPaste == rhs.bGrepPaste
+			&& bGrepBackup == rhs.bGrepBackup;
+	}
+	bool operator != (const GrepInfo& rhs) const noexcept { return !(*this == rhs); }
 };
 
 /*-----------------------------------------------------------------------

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -90,6 +90,7 @@ public:
 	bool IsDebugMode() const noexcept { return m_bDebugMode; }
 	bool IsViewMode() const noexcept { return m_bViewMode; }
 	bool GetEditInfo(EditInfo* fi) const noexcept { *fi = m_fi; return true; }
+	const EditInfo& GetEditInfoRef() const noexcept { return m_fi; }
 	bool GetGrepInfo(GrepInfo* gi) const noexcept { *gi = m_gi; return true; }
 	int GetGroupId() const noexcept { return m_nGroup; }	// 2007.06.26 ryoji
 	LPCWSTR GetMacro() const noexcept { return m_cmMacro.GetStringPtr(); }
@@ -101,9 +102,16 @@ public:
 		m_cmProfile.SetString(s);
 	}
 	bool IsProfileMgr() const noexcept { return m_bProfileMgr; }
+	const CLogicPoint& GetCaretLocation() const noexcept { return m_fi.m_ptCursor; }
+	CLayoutPoint GetViewLocation() const noexcept { return { m_fi.m_nViewLeftCol,  m_fi.m_nViewTopLine }; }
+	tagSIZE GetWindowSize() const noexcept { return { m_fi.m_nWindowSizeX, m_fi.m_nWindowSizeY }; }
+	tagPOINT GetWindowOrigin() const noexcept { return { m_fi.m_nWindowOriginX, m_fi.m_nWindowOriginY }; }
+	LPCWSTR GetOpenFile() const noexcept { return m_fi.m_szPath; }
 	int GetFileNum(void) const noexcept { return m_vFiles.size(); }
 	const WCHAR* GetFileName(int i) const noexcept { return i < GetFileNum() ? m_vFiles[i].c_str() : NULL; }
 	void ClearFile(void) noexcept { m_vFiles.clear(); }
+	LPCWSTR GetDocType() const noexcept { return m_fi.m_szDocType; }
+	ECodeType GetDocCode() const noexcept { return m_fi.m_nCharCode; }
 	void ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse = true );
 
 // member valiables

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -141,6 +141,7 @@ public:
 	bool GetEditInfo(EditInfo* fi) const noexcept { *fi = m_fi; return true; }
 	const EditInfo& GetEditInfoRef() const noexcept { return m_fi; }
 	bool GetGrepInfo(GrepInfo* gi) const noexcept { *gi = m_gi; return true; }
+	const GrepInfo& GetGrepInfoRef() const noexcept { return m_gi; }
 	int GetGroupId() const noexcept { return m_nGroup; }	// 2007.06.26 ryoji
 	LPCWSTR GetMacro() const noexcept { return m_cmMacro.GetStringPtr(); }
 	LPCWSTR GetMacroType() const noexcept { return m_cmMacroType.GetStringPtr(); }

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -83,27 +83,27 @@ private:
 
 // member accessor method
 public:
-	bool IsNoWindow() const {return m_bNoWindow;}
-	bool IsWriteQuit() const {return m_bWriteQuit;}	// 2007.05.19 ryoji sakuext用に追加
-	bool IsGrepMode() const {return m_bGrepMode;}
-	bool IsGrepDlg() const {return m_bGrepDlg;}
-	bool IsDebugMode() const {return m_bDebugMode;}
-	bool IsViewMode() const {return m_bViewMode;}
-	bool GetEditInfo(EditInfo* fi) const { *fi = m_fi; return true; }
-	bool GetGrepInfo(GrepInfo* gi) const { *gi = m_gi; return true; }
-	int GetGroupId() const {return m_nGroup;}	// 2007.06.26 ryoji
-	LPCWSTR GetMacro() const{ return m_cmMacro.GetStringPtr(); }
-	LPCWSTR GetMacroType() const{ return m_cmMacroType.GetStringPtr(); }
-	LPCWSTR GetProfileName() const{ return m_cmProfile.GetStringPtr(); }
-	bool IsSetProfile() const{ return m_bSetProfile; }
+	bool IsNoWindow() const noexcept { return m_bNoWindow; }
+	bool IsWriteQuit() const noexcept { return m_bWriteQuit; }	// 2007.05.19 ryoji sakuext用に追加
+	bool IsGrepMode() const noexcept { return m_bGrepMode; }
+	bool IsGrepDlg() const noexcept { return m_bGrepDlg; }
+	bool IsDebugMode() const noexcept { return m_bDebugMode; }
+	bool IsViewMode() const noexcept { return m_bViewMode; }
+	bool GetEditInfo(EditInfo* fi) const noexcept { *fi = m_fi; return true; }
+	bool GetGrepInfo(GrepInfo* gi) const noexcept { *gi = m_gi; return true; }
+	int GetGroupId() const noexcept { return m_nGroup; }	// 2007.06.26 ryoji
+	LPCWSTR GetMacro() const noexcept { return m_cmMacro.GetStringPtr(); }
+	LPCWSTR GetMacroType() const noexcept { return m_cmMacroType.GetStringPtr(); }
+	LPCWSTR GetProfileName() const noexcept { return m_cmProfile.GetStringPtr(); }
+	bool IsSetProfile() const noexcept { return m_bSetProfile; }
 	void SetProfileName(LPCWSTR s){
 		m_bSetProfile = true;
 		m_cmProfile.SetString(s);
 	}
-	bool IsProfileMgr() { return m_bProfileMgr; }
-	int GetFileNum(void) { return m_vFiles.size(); }
-	const WCHAR* GetFileName(int i) { return i < GetFileNum() ? m_vFiles[i].c_str() : NULL; }
-	void ClearFile(void) { m_vFiles.clear(); }
+	bool IsProfileMgr() const noexcept { return m_bProfileMgr; }
+	int GetFileNum(void) const noexcept { return m_vFiles.size(); }
+	const WCHAR* GetFileName(int i) const noexcept { return i < GetFileNum() ? m_vFiles[i].c_str() : NULL; }
+	void ClearFile(void) noexcept { m_vFiles.clear(); }
 	void ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse = true );
 
 // member valiables

--- a/sakura_core/_main/global.h
+++ b/sakura_core/_main/global.h
@@ -156,15 +156,20 @@ struct SSearchOption{
 	bool	bLoHiCase;		//!< true==英大文字小文字の区別
 	bool	bWordOnly;		//!< true==単語のみ検索
 
-	SSearchOption() : bRegularExp(false), bLoHiCase(false), bWordOnly(false) { }
+	SSearchOption() noexcept
+		: bRegularExp(false)
+		, bLoHiCase(false)
+		, bWordOnly(false)
+	{
+	}
 	SSearchOption(
 		bool _bRegularExp,
 		bool _bLoHiCase,
 		bool _bWordOnly
-	)
-	: bRegularExp(_bRegularExp)
-	, bLoHiCase(_bLoHiCase)
-	, bWordOnly(_bWordOnly)
+	) noexcept
+		: bRegularExp(_bRegularExp)
+		, bLoHiCase(_bLoHiCase)
+		, bWordOnly(_bWordOnly)
 	{
 	}
 	void Reset()
@@ -175,15 +180,13 @@ struct SSearchOption{
 	}
 
 	//演算子
-	bool operator == (const SSearchOption& rhs) const
-	{
-		//とりあえずmemcmpでいいや
-		return memcmp(this,&rhs,sizeof(*this))==0;
+	bool operator == (const SSearchOption& rhs) const noexcept {
+		if (this == &rhs) return true;
+		return bRegularExp == rhs.bRegularExp
+			&& bLoHiCase == rhs.bLoHiCase
+			&& bWordOnly == rhs.bWordOnly;
 	}
-	bool operator != (const SSearchOption& rhs) const
-	{
-		return !operator==(rhs);
-	}
+	bool operator != (const SSearchOption& rhs) const noexcept { return !(*this == rhs); }
 };
 
 //2007.10.02 kobake CEditWndのインスタンスへのポインタをここに保存しておく

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -27,6 +27,7 @@
 
 //2007.09.13 kobake 作成
 #include "parse/CWordParse.h"
+#include "util/std_macro.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                         判定関数                            //

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -31,7 +31,7 @@ CNativeW::CNativeW( const wchar_t* pData, int nDataLen )
 CNativeW::CNativeW( const wchar_t* pData )
 	: CNative()
 {
-	SetString(pData);
+	*this = pData;
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -80,6 +80,12 @@ public:
 	//演算子
 	CNativeW& operator = (const CNativeW& rhs)			{ CNative::operator=(rhs); return *this; }
 	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeW>(rhs)); return *this; }
+	CNativeW& operator = (std::nullptr_t) noexcept		{ CNative::operator=(CNativeW()); return *this; }
+	CNativeW& operator = (const wchar_t* rhs) {
+		if (rhs == nullptr) return (*this = nullptr);
+		SetString(rhs);
+		return *this;
+	}
 	const CNativeW& operator+=(wchar_t wch)				{ AppendString(&wch,1);   return *this; }
 	const CNativeW& operator=(wchar_t wch)				{ SetString(&wch,1);      return *this; }
 	const CNativeW& operator+=(const CNativeW& rhs)		{ AppendNativeData(rhs); return *this; }

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -84,6 +84,20 @@ public:
 	const CNativeW& operator=(wchar_t wch)				{ SetString(&wch,1);      return *this; }
 	const CNativeW& operator+=(const CNativeW& rhs)		{ AppendNativeData(rhs); return *this; }
 	CNativeW operator+(const CNativeW& rhs) const		{ CNativeW tmp=*this; return tmp+=rhs; }
+	bool operator == (const CNativeW& rhs) const noexcept {
+		if (this == &rhs) return true;
+		if (!capacity() || !rhs.capacity()) return (capacity() == rhs.capacity());
+		return GetStringLength() == rhs.GetStringLength()
+			&& 0 == wmemcmp(GetStringPtr(), rhs.GetStringPtr(), GetStringLength() + 1);
+	}
+	bool operator != (const CNativeW& rhs) const noexcept { return !(*this == rhs); }
+	bool operator == (std::nullptr_t) const noexcept { return GetStringPtr() == nullptr; }
+	bool operator != (std::nullptr_t) const noexcept { return !(*this == nullptr); }
+	bool operator == (const wchar_t* rhs) const noexcept {
+		if (rhs == nullptr) return (*this == nullptr);
+		return 0 == wmemcmp(GetStringPtr(), rhs, GetStringLength() + 1);
+	}
+	bool operator != (const wchar_t* rhs) const noexcept { return !(*this == rhs); }
 
 	//ネイティブ取得インターフェース
 	wchar_t operator[](int nIndex) const;                    //!< 任意位置の文字取得。nIndexは文字単位。
@@ -117,7 +131,7 @@ public:
 	void swap( CNativeW& left ){
 		_GetMemory()->swap( *left._GetMemory() );
 	}
-	int capacity(){
+	int capacity() const {
 		return _GetMemory()->capacity() / sizeof(wchar_t);
 	}
 

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -1,0 +1,425 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include "_main/CCommandLine.h"
+
+#include <cstdlib>
+#include <fstream>
+
+/*!
+ * @brief コンストラクタ(パラメータなし)の仕様
+ * @remark パラメータを何も指定しなかった状態になる
+ */
+TEST(CCommandLine, ConstructWithoutParam)
+{
+	CCommandLine cCommandLine;
+	EXPECT_FALSE(cCommandLine.IsNoWindow());
+	EXPECT_FALSE(cCommandLine.IsWriteQuit());
+	EXPECT_FALSE(cCommandLine.IsGrepMode());
+	EXPECT_FALSE(cCommandLine.IsGrepDlg());
+	EXPECT_FALSE(cCommandLine.IsDebugMode());
+	EXPECT_FALSE(cCommandLine.IsViewMode());
+
+	//GetEditInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
+	EditInfo fi;
+	EXPECT_TRUE(cCommandLine.GetEditInfo(&fi));
+	//TODO: EditInfoに等価比較演算子を実装する
+	//EXPECT_EQ(EditInfo(), fi);
+
+	//GetGrepInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
+	GrepInfo gi;
+	EXPECT_TRUE(cCommandLine.GetGrepInfo(&gi));
+	//TODO: GrepInfoに等価比較演算子を実装する
+	//EXPECT_EQ(GrepInfo(), gi);
+
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+	EXPECT_EQ(NULL, cCommandLine.GetMacro());
+	EXPECT_EQ(NULL, cCommandLine.GetMacroType());
+	//1つだけNULLを返さないのはバグの気配がします(^^;
+	EXPECT_STREQ(L"", cCommandLine.GetProfileName());
+	EXPECT_FALSE(cCommandLine.IsSetProfile());
+	EXPECT_FALSE(cCommandLine.IsProfileMgr());
+	EXPECT_EQ(0, cCommandLine.GetFileNum());
+	EXPECT_EQ(NULL, cCommandLine.GetFileName(0));
+}
+
+/*!
+ * @brief パラメータ解析(-NOWIN)の仕様
+ * @remark -NOWINが指定されていなければFALSE
+ * @remark -NOWINが指定されていたらTRUE
+ * @remark -WQが指定された場合、-NOWINがなくてもTRUE
+ */
+TEST(CCommandLine, ParseNoWin)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsNoWindow());
+	cCommandLine.ParseCommandLine(L"-NOWIN", false);
+	ASSERT_TRUE(cCommandLine.IsNoWindow());
+}
+
+/*!
+ * @brief パラメータ解析(-WQ)の仕様
+ * @remark -WQが指定されていなければFALSE
+ * @remark -WQが指定されていたらTRUE
+ * @remark -WQが指定された場合、-NOWINもTRUE
+ */
+TEST(CCommandLine, ParseWriteQuit)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsWriteQuit());
+	cCommandLine.ParseCommandLine(L"-WQ", false);
+	ASSERT_TRUE(cCommandLine.IsWriteQuit());
+	ASSERT_TRUE(cCommandLine.IsNoWindow());
+}
+
+/*!
+ * @brief パラメータ解析(-GREPMODE)の仕様
+ * @remark -GREPMODEが指定されていなければFALSE
+ * @remark -GREPMODEが指定されていたらTRUE
+ * @remark Grepモード時は文書タイプが"grepmode"になる
+ */
+TEST(CCommandLine, ParseGrepMode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsGrepMode());
+	cCommandLine.ParseCommandLine(L"-GREPMODE", false);
+	ASSERT_TRUE(cCommandLine.IsGrepMode());
+
+	//TODO: 現状のコードではテストを書きづらい...
+	//Grepモード時は文書タイプが"grepout"になる
+	//ASSERT_STREQ(L"grepout", cCommandLine.GetDocType());
+}
+
+/*!
+ * @brief パラメータ解析(-GREPDLG)の仕様
+ * @remark -GREPDLGが指定されていなければFALSE
+ * @remark -GREPDLGが指定されていたらTRUE
+ */
+TEST(CCommandLine, ParseGrepDialog)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsGrepDlg());
+	cCommandLine.ParseCommandLine(L"-GREPDLG", false);
+	ASSERT_TRUE(cCommandLine.IsGrepDlg());
+	//FIXME: Grepダイアログ指定時にGrepモードにならないのは不自然な気がする
+}
+
+/*!
+ * @brief パラメータ解析(-DEBUGMODE)の仕様
+ * @remark -DEBUGMODEが指定されていなければFALSE
+ * @remark -DEBUGMODEが指定されていたらTRUE
+ * @remark Debugモード時は文書タイプが"output"になる
+ */
+TEST(CCommandLine, ParseDebugMode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsDebugMode());
+	cCommandLine.ParseCommandLine(L"-DEBUGMODE", false);
+	ASSERT_TRUE(cCommandLine.IsDebugMode());
+
+	//TODO: 現状のコードではテストを書きづらい...
+	//Debugモード時は文書タイプが"output"になる
+	//ASSERT_STREQ(L"output", cCommandLine.GetDocType());
+}
+
+/*!
+ * @brief パラメータ解析(-R)の仕様
+ * @remark -Rが指定されていなければFALSE
+ * @remark -Rが指定されていたらTRUE
+ */
+TEST(CCommandLine, ParseViewMode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsViewMode());
+	cCommandLine.ParseCommandLine(L"-R", false);
+	ASSERT_TRUE(cCommandLine.IsViewMode());
+}
+
+/*!
+ * @brief パラメータ解析(-GROUP)の仕様
+ * @remark -GROUPが指定されていなければ-1
+ * @remark -GROUPが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseGroup)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+	cCommandLine.ParseCommandLine(L"-GROUP=2", false);
+	EXPECT_EQ(2, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief パラメータ解析(-M)の仕様
+ * @remark -Mが指定されていなければNULL
+ * @remark -Mが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseMacroFileName)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetMacro());
+#define TESTLOCAL_MACRO_NAME L"真っ黒.mac"
+	cCommandLine.ParseCommandLine(L"-M=" TESTLOCAL_MACRO_NAME, false);
+	ASSERT_STREQ(TESTLOCAL_MACRO_NAME, cCommandLine.GetMacro());
+#undef TESTLOCAL_MACRO_NAME
+}
+
+/*!
+ * @brief パラメータ解析(-MTYPE)の仕様
+ * @remark -MTYPEが指定されていなければNULL
+ * @remark -MTYPEが指定されていたら指定された文字列
+ * @remark MacroTypeには任意の文字列を指定できる
+ */
+TEST(CCommandLine, ParseMacroType)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetMacroType());
+#define TESTLOCAL_MACRO_TYPE L"PascalScript"
+	cCommandLine.ParseCommandLine(L"-MTYPE=" TESTLOCAL_MACRO_TYPE, false);
+	ASSERT_STREQ(TESTLOCAL_MACRO_TYPE, cCommandLine.GetMacroType());
+#undef TESTLOCAL_MACRO_TYPE
+}
+
+/*!
+ * @brief パラメータ解析(-PROF)の仕様
+ * @remark -PROFが指定されていなければ空文字列
+ * @remark -PROFが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseProfileName)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_STREQ(L"", cCommandLine.GetProfileName());
+	EXPECT_FALSE(cCommandLine.IsSetProfile());
+#define TESTLOCAL_PROFILE_NAME L"執筆用"
+	cCommandLine.ParseCommandLine(L"-PROF=" TESTLOCAL_PROFILE_NAME, false);
+	ASSERT_STREQ(TESTLOCAL_PROFILE_NAME, cCommandLine.GetProfileName());
+	EXPECT_TRUE(cCommandLine.IsSetProfile());
+#undef TESTLOCAL_PROFILE_NAME
+}
+
+/*!
+ * @brief パラメータ解析(-PROFMGR)の仕様
+ * @remark -PROFMGRが指定されていなければFALSE
+ * @remark -PROFMGRが指定されていたらTRUE
+ */
+TEST(CCommandLine, ParseProfileManager)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.IsProfileMgr());
+	cCommandLine.ParseCommandLine(L"-PROFMGR", false);
+	ASSERT_TRUE(cCommandLine.IsProfileMgr());
+}
+
+/*!
+ * @brief パラメータ解析(ファイル名)の仕様
+ * @remark GetFileNumで取得できるのは2つ目以降のファイル数
+ * @remark GetFileName(0)で取得できるのは2つ目のファイル名
+ */
+TEST(CCommandLine, ParseOpenFilename)
+{
+	//TODO: 現状のコードではテストを書きづらい...
+	//・ファイルは複数指定できる
+	//・1つ目のファイルは EditInfo に格納される
+	//・2つ目以降のファイルは vector に格納される
+
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(0, cCommandLine.GetFileNum());
+	EXPECT_EQ(NULL, cCommandLine.GetFileName(0));
+#define TESTLOCAL_OPEN_FILENAME L"test2.txt"
+	cCommandLine.ParseCommandLine(L"test1.txt " TESTLOCAL_OPEN_FILENAME, false);
+	EXPECT_EQ(1, cCommandLine.GetFileNum());
+	std::wstring additionalFile(cCommandLine.GetFileName(0));
+	ASSERT_NE(0, additionalFile.find(TESTLOCAL_OPEN_FILENAME));
+#undef TESTLOCAL_OPEN_FILENAME
+	cCommandLine.ClearFile();
+	EXPECT_EQ(0, cCommandLine.GetFileNum());
+}
+
+/*!
+ * @brief プロファイル指定済みフラグの仕様
+ * @remark SetProfileNameを呼び出したらTRUE
+ */
+TEST(CCommandLine, SetProfileName)
+{
+	CCommandLine cCommandLine;
+	EXPECT_FALSE(cCommandLine.IsSetProfile());
+	cCommandLine.SetProfileName(L"");
+	ASSERT_TRUE(cCommandLine.IsSetProfile());
+}
+
+/*!
+ * @brief パラメータ解析(-@)の仕様
+ * @remark -@が指定されていなければ何もしない
+ * @remark -@が指定されていたら指定されたファイルを読み込む
+ */
+TEST(CCommandLine, ParseFromResponseFile)
+{
+	// レスポンスファイルを作る
+	{
+		std::ofstream resp("test.response");
+		resp << "-R" << std::endl;
+	}
+
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-@=test.response", true);
+	EXPECT_TRUE(cCommandLine.IsViewMode());
+
+	std::remove("test.response");
+}
+
+/*!
+ * @brief オプションの仕様
+ * @remark オプションはダブルクォートで囲んでもよい
+ */
+TEST(CCommandLine, QuotedOption)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"\"-GROUP=1\"", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief オプションの仕様
+ * @remark ダブルクォートは終端記号がなくてもよい
+ */
+TEST(CCommandLine, QuotedOptionWithMissingEndQuote)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"\"-GROUP=1", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark '='または':'に続けて指定する
+ */
+TEST(CCommandLine, OptionWithArgumentAssign)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=1", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark '='または':'に続けて指定する
+ */
+TEST(CCommandLine, OptionWithArgumentColon)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP:1", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 引数はダブルクォートまたはシングルクォートで囲ってもよい
+ */
+TEST(CCommandLine, OptionWithDoubleQuotedArgument)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=\"1\"", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 引数はダブルクォートまたはシングルクォートで囲ってもよい
+ */
+TEST(CCommandLine, OptionWithSingleQuotedArgument)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=\'1\'", false);
+	ASSERT_EQ(1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 引数を指定しなかった場合、無視される
+ */
+TEST(CCommandLine, OptionWithoutNeededArgument)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 無効な引数を指定した場合、無視される
+ */
+TEST(CCommandLine, OptionWithInvalidArgumentEmpty)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+	cCommandLine.ParseCommandLine(L"-GROUP:", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief 引数付きパラメータの仕様
+ * @remark 数値引数に非数を指定した場合、0を指定したものと看做される
+ */
+TEST(CCommandLine, OptionWithInvalidArgumentNAN)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-GROUP=Admin", false);
+	EXPECT_EQ(0, cCommandLine.GetGroupId());
+	cCommandLine.ParseCommandLine(L"-GROUP:Admin", false);
+	EXPECT_EQ(0, cCommandLine.GetGroupId());
+}
+
+/*!
+ * @brief パラメータ終端指定の仕様
+ * @remark "-" で始まるファイルを扱うための仕様
+ * @remark コマンドラインに "--" を含めると、
+ *   以降の"-"で始まる文字列をオプション指定と看做さなくなる。
+ */
+TEST(CCommandLine, EndOfOptionMark)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"-- -GROUP=2", false);
+	EXPECT_EQ(-1, cCommandLine.GetGroupId());
+}

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -52,11 +52,7 @@ TEST(CCommandLine, ConstructWithoutParam)
 
 	EXPECT_EQ(EditInfo(), cCommandLine.GetEditInfoRef());
 
-	//GetGrepInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
-	GrepInfo gi;
-	EXPECT_TRUE(cCommandLine.GetGrepInfo(&gi));
-	//TODO: GrepInfoに等価比較演算子を実装する
-	//EXPECT_EQ(GrepInfo(), gi);
+	EXPECT_EQ(GrepInfo(), cCommandLine.GetGrepInfoRef());
 
 	EXPECT_EQ(-1, cCommandLine.GetGroupId());
 	EXPECT_EQ(NULL, cCommandLine.GetMacro());
@@ -426,6 +422,299 @@ TEST(CCommandLine, SetProfileName)
 	EXPECT_FALSE(cCommandLine.IsSetProfile());
 	cCommandLine.SetProfileName(L"");
 	ASSERT_TRUE(cCommandLine.IsSetProfile());
+}
+
+/*!
+ * @brief パラメータ解析(-GKEY)の仕様
+ * @remark -GKEYが指定されていなければNULL
+ * @remark -GKEYが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseGrepKey)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetGrepInfoRef().cmGrepKey.GetStringPtr());
+#define TESTLOCAL_GREP_KEY L"\\w+"
+	cCommandLine.ParseCommandLine(L"-GKEY=" TESTLOCAL_GREP_KEY, false);
+	ASSERT_STREQ(TESTLOCAL_GREP_KEY, cCommandLine.GetGrepInfoRef().cmGrepKey.GetStringPtr());
+#undef TESTLOCAL_GREP_KEY
+}
+
+/*!
+ * @brief パラメータ解析(-GREPR)の仕様
+ * @remark -GREPRが指定されていなければNULL
+ * @remark -GREPRが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseGrepReplaceKey)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetGrepInfoRef().cmGrepRep.GetStringPtr());
+#define TESTLOCAL_GREP_REPR L"$1。"
+	cCommandLine.ParseCommandLine(L"-GREPR=" TESTLOCAL_GREP_REPR, false);
+	ASSERT_STREQ(TESTLOCAL_GREP_REPR, cCommandLine.GetGrepInfoRef().cmGrepRep.GetStringPtr());
+#undef TESTLOCAL_GREP_REPR
+}
+
+/*!
+ * @brief パラメータ解析(-GFILE)の仕様
+ * @remark -GFILEが指定されていなければNULL
+ * @remark -GFILEが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseGrepFile)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetGrepInfoRef().cmGrepFile.GetStringPtr());
+#define TESTLOCAL_GREP_FILE L"#.git"
+	cCommandLine.ParseCommandLine(L"-GFILE=" TESTLOCAL_GREP_FILE, false);
+	ASSERT_STREQ(TESTLOCAL_GREP_FILE, cCommandLine.GetGrepInfoRef().cmGrepFile.GetStringPtr());
+#undef TESTLOCAL_GREP_FILE
+}
+
+/*!
+ * @brief パラメータ解析(-GFOLDER)の仕様
+ * @remark -GFOLDERが指定されていなければNULL
+ * @remark -GFOLDERが指定されていたら指定された文字列
+ */
+TEST(CCommandLine, ParseGrepFolder)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(NULL, cCommandLine.GetGrepInfoRef().cmGrepFolder.GetStringPtr());
+#define TESTLOCAL_GREP_FOLDER L"C:\\work\\sakura"
+	cCommandLine.ParseCommandLine(L"-GFOLDER=" TESTLOCAL_GREP_FOLDER, false);
+	ASSERT_STREQ(TESTLOCAL_GREP_FOLDER, cCommandLine.GetGrepInfoRef().cmGrepFolder.GetStringPtr());
+#undef TESTLOCAL_GREP_FOLDER
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepCurFolder)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepCurFolder);
+	cCommandLine.ParseCommandLine(L"-GOPT=X", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepCurFolder);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepStdout)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepStdout);
+	cCommandLine.ParseCommandLine(L"-GOPT=U", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepStdout);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければTRUE
+* @remark -GOPTが指定されていたらFALSE
+*/
+TEST(CCommandLine, ParseGrepHeader)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(!cCommandLine.GetGrepInfoRef().bGrepHeader);
+	cCommandLine.ParseCommandLine(L"-GOPT=H", false);
+	EXPECT_TRUE(!cCommandLine.GetGrepInfoRef().bGrepHeader);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepSubFolder)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepSubFolder);
+	cCommandLine.ParseCommandLine(L"-GOPT=S", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepSubFolder);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepCaseSensitive)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bLoHiCase);
+	cCommandLine.ParseCommandLine(L"-GOPT=L", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bLoHiCase);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepUseRegularExpressions)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bRegularExp);
+	cCommandLine.ParseCommandLine(L"-GOPT=R", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bRegularExp);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければSJIS
+* @remark -GOPTが指定されていたら自動検知
+* @note このオプションは特殊
+*/
+TEST(CCommandLine, ParseGrepCodeAutoDetect)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(CODE_SJIS, cCommandLine.GetGrepInfoRef().nGrepCharSet);
+	cCommandLine.ParseCommandLine(L"-GOPT=K", false);
+	EXPECT_EQ(CODE_AUTODETECT, cCommandLine.GetGrepInfoRef().nGrepCharSet);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @note このオプションは特殊
+*/
+TEST(CCommandLine, ParseGrepOutputLineType)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(0, cCommandLine.GetGrepInfoRef().nGrepOutputLineType);
+	cCommandLine.ParseCommandLine(L"-GOPT=P", false); //Positive?
+	EXPECT_EQ(1, cCommandLine.GetGrepInfoRef().nGrepOutputLineType);
+	cCommandLine.ParseCommandLine(L"-GOPT=N", false); //Negative?
+	EXPECT_EQ(2, cCommandLine.GetGrepInfoRef().nGrepOutputLineType);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepUseWordParse)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bWordOnly);
+	cCommandLine.ParseCommandLine(L"-GOPT=W", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().sGrepSearchOption.bWordOnly);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @note このオプションは特殊
+*/
+TEST(CCommandLine, ParseGrepOutputStyle)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(1, cCommandLine.GetGrepInfoRef().nGrepOutputStyle);
+	cCommandLine.ParseCommandLine(L"-GOPT=1", false);
+	EXPECT_EQ(1, cCommandLine.GetGrepInfoRef().nGrepOutputStyle);
+	cCommandLine.ParseCommandLine(L"-GOPT=2", false);
+	EXPECT_EQ(2, cCommandLine.GetGrepInfoRef().nGrepOutputStyle);
+	cCommandLine.ParseCommandLine(L"-GOPT=3", false);
+	EXPECT_EQ(3, cCommandLine.GetGrepInfoRef().nGrepOutputStyle);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepListFileNameOnly)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepOutputFileOnly);
+	cCommandLine.ParseCommandLine(L"-GOPT=F", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepOutputFileOnly);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepDisplayRoot)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepOutputBaseFolder);
+	cCommandLine.ParseCommandLine(L"-GOPT=B", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepOutputBaseFolder);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepSplitResultPerFolder)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepSeparateFolder);
+	cCommandLine.ParseCommandLine(L"-GOPT=D", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepSeparateFolder);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepReplacePasteFromClipBoard)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepPaste);
+	cCommandLine.ParseCommandLine(L"-GOPT=C", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepPaste);
+}
+
+/*!
+* @brief パラメータ解析(-GOPT)の仕様
+* @remark -GOPTが指定されていなければFALSE
+* @remark -GOPTが指定されていたらTRUE
+*/
+TEST(CCommandLine, ParseGrepReplaceCreateBackupFiles)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_FALSE(cCommandLine.GetGrepInfoRef().bGrepBackup);
+	cCommandLine.ParseCommandLine(L"-GOPT=O", false);
+	EXPECT_TRUE(cCommandLine.GetGrepInfoRef().bGrepBackup);
+}
+
+/*!
+ * @brief パラメータ解析(-GCODE)の仕様
+ * @remark -GCODEが指定されていなければSJIS
+ * @remark -GCODEが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseGrepCode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(CODE_SJIS, cCommandLine.GetGrepInfoRef().nGrepCharSet);
+	cCommandLine.ParseCommandLine(L"-GCODE=99", false);
+	EXPECT_EQ(CODE_AUTODETECT, cCommandLine.GetGrepInfoRef().nGrepCharSet);
 }
 
 /*!

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -53,8 +53,7 @@ TEST(CCommandLine, ConstructWithoutParam)
 	//GetEditInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
 	EditInfo fi;
 	EXPECT_TRUE(cCommandLine.GetEditInfo(&fi));
-	//TODO: EditInfoに等価比較演算子を実装する
-	//EXPECT_EQ(EditInfo(), fi);
+	EXPECT_EQ(EditInfo(), fi);
 
 	//GetGrepInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
 	GrepInfo gi;

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -50,10 +50,7 @@ TEST(CCommandLine, ConstructWithoutParam)
 	EXPECT_FALSE(cCommandLine.IsDebugMode());
 	EXPECT_FALSE(cCommandLine.IsViewMode());
 
-	//GetEditInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
-	EditInfo fi;
-	EXPECT_TRUE(cCommandLine.GetEditInfo(&fi));
-	EXPECT_EQ(EditInfo(), fi);
+	EXPECT_EQ(EditInfo(), cCommandLine.GetEditInfoRef());
 
 	//GetGrepInfo: テストしづらい上に戻り値true以外は返らない・・・仕様バグですね(^^;
 	GrepInfo gi;
@@ -117,9 +114,8 @@ TEST(CCommandLine, ParseGrepMode)
 	cCommandLine.ParseCommandLine(L"-GREPMODE", false);
 	ASSERT_TRUE(cCommandLine.IsGrepMode());
 
-	//TODO: 現状のコードではテストを書きづらい...
 	//Grepモード時は文書タイプが"grepout"になる
-	//ASSERT_STREQ(L"grepout", cCommandLine.GetDocType());
+	ASSERT_STREQ(L"grepout", cCommandLine.GetDocType());
 }
 
 /*!
@@ -151,9 +147,8 @@ TEST(CCommandLine, ParseDebugMode)
 	cCommandLine.ParseCommandLine(L"-DEBUGMODE", false);
 	ASSERT_TRUE(cCommandLine.IsDebugMode());
 
-	//TODO: 現状のコードではテストを書きづらい...
 	//Debugモード時は文書タイプが"output"になる
-	//ASSERT_STREQ(L"output", cCommandLine.GetDocType());
+	ASSERT_STREQ(L"output", cCommandLine.GetDocType());
 }
 
 /*!
@@ -250,27 +245,173 @@ TEST(CCommandLine, ParseProfileManager)
 }
 
 /*!
+ * @brief パラメータ解析(-X)の仕様
+ * @remark -Xが指定されていなければ-1
+ * @remark -Xが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseCaretLocationX)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetCaretLocation().x);
+	cCommandLine.ParseCommandLine(L"-X=123", false);
+	ASSERT_EQ(122, cCommandLine.GetCaretLocation().x);
+}
+
+/*!
+ * @brief パラメータ解析(-Y)の仕様
+ * @remark -Yが指定されていなければ-1
+ * @remark -Yが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseCaretLocationY)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetCaretLocation().y);
+	cCommandLine.ParseCommandLine(L"-Y=123", false);
+	ASSERT_EQ(122, cCommandLine.GetCaretLocation().y);
+}
+
+/*!
+ * @brief パラメータ解析(-VX)の仕様
+ * @remark -VXが指定されていなければ-1
+ * @remark -VXが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseViewLeftCol)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetViewLocation().x);
+	cCommandLine.ParseCommandLine(L"-VX=123", false);
+	ASSERT_EQ(122, cCommandLine.GetViewLocation().x);
+}
+
+/*!
+ * @brief パラメータ解析(-VY)の仕様
+ * @remark -VYが指定されていなければ-1
+ * @remark -VYが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseViewTopLine)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetViewLocation().y);
+	cCommandLine.ParseCommandLine(L"-VY=123", false);
+	ASSERT_EQ(122, cCommandLine.GetViewLocation().y);
+}
+
+/*!
+ * @brief パラメータ解析(-SX)の仕様
+ * @remark -SXが指定されていなければ-1
+ * @remark -SXが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseWindowSizeX)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetWindowSize().cx);
+	cCommandLine.ParseCommandLine(L"-SX=123", false);
+	ASSERT_EQ(122, cCommandLine.GetWindowSize().cx);
+}
+
+/*!
+ * @brief パラメータ解析(-SY)の仕様
+ * @remark -SYが指定されていなければ-1
+ * @remark -SYが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseWindowSizeY)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(-1, cCommandLine.GetWindowSize().cy);
+	cCommandLine.ParseCommandLine(L"-SY=123", false);
+	ASSERT_EQ(122, cCommandLine.GetWindowSize().cy);
+}
+
+/*!
+ * @brief パラメータ解析(-WX)の仕様
+ * @remark -WXが指定されていなければCW_USEDEFAULT
+ * @remark -WXが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseWindowOriginX)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(CW_USEDEFAULT, cCommandLine.GetWindowOrigin().x);
+	cCommandLine.ParseCommandLine(L"-WX=123", false);
+	ASSERT_EQ(123, cCommandLine.GetWindowOrigin().x);
+}
+
+/*!
+ * @brief パラメータ解析(-WY)の仕様
+ * @remark -WYが指定されていなければCW_USEDEFAULT
+ * @remark -WYが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseWindowOriginY)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	ASSERT_EQ(CW_USEDEFAULT, cCommandLine.GetWindowOrigin().y);
+	cCommandLine.ParseCommandLine(L"-WY=123", false);
+	ASSERT_EQ(123, cCommandLine.GetWindowOrigin().y);
+}
+
+/*!
+ * @brief パラメータ解析(-TYPE)の仕様
+ * @remark -TYPEが指定されていなければNULL
+ * @remark -TYPEが指定されていたら指定された文字列
+ * @remark DocTypeには任意の文字列を指定できる
+ */
+TEST(CCommandLine, ParseDocType)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_STREQ(L"", cCommandLine.GetDocType());
+#define TESTLOCAL_DOC_TYPE L"C/C++"
+	cCommandLine.ParseCommandLine(L"-TYPE=" TESTLOCAL_DOC_TYPE, false);
+	ASSERT_STREQ(TESTLOCAL_DOC_TYPE, cCommandLine.GetDocType());
+#undef TESTLOCAL_DOC_TYPE
+}
+
+/*!
+ * @brief パラメータ解析(-CODE)の仕様
+ * @remark -CODEが指定されていなければJIS
+ * @remark -CODEが指定されていたら指定された数値
+ */
+TEST(CCommandLine, ParseDocCode)
+{
+	CCommandLine cCommandLine;
+	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_EQ(CODE_JIS, cCommandLine.GetDocCode());
+	cCommandLine.ParseCommandLine(L"-CODE=99", false);
+	EXPECT_EQ(CODE_AUTODETECT, cCommandLine.GetDocCode());
+}
+
+/*!
  * @brief パラメータ解析(ファイル名)の仕様
- * @remark GetFileNumで取得できるのは2つ目以降のファイル数
- * @remark GetFileName(0)で取得できるのは2つ目のファイル名
+ * @remark ファイルは複数指定できる
+ * @remark 1つ目のファイルは EditInfo(m_fi.m_szPath) に格納される
+ * @remark 2つ目以降のファイルは vector(m_vFiles) に格納される
+ * @remark 1つ目のファイルパスは、パス解決されてフルパスになる
+ * @remark 2つ目以降のファイルは、パス解決されない
  */
 TEST(CCommandLine, ParseOpenFilename)
 {
-	//TODO: 現状のコードではテストを書きづらい...
-	//・ファイルは複数指定できる
-	//・1つ目のファイルは EditInfo に格納される
-	//・2つ目以降のファイルは vector に格納される
-
 	CCommandLine cCommandLine;
 	cCommandLine.ParseCommandLine(L"", false);
+	EXPECT_STREQ(L"", cCommandLine.GetOpenFile());
 	EXPECT_EQ(0, cCommandLine.GetFileNum());
 	EXPECT_EQ(NULL, cCommandLine.GetFileName(0));
-#define TESTLOCAL_OPEN_FILENAME L"test2.txt"
-	cCommandLine.ParseCommandLine(L"test1.txt " TESTLOCAL_OPEN_FILENAME, false);
+#define TESTLOCAL_OPEN_FILENAME1 L"test1.txt"
+#define TESTLOCAL_OPEN_FILENAME2 L"test2.txt"
+	cCommandLine.ParseCommandLine(TESTLOCAL_OPEN_FILENAME1 " " TESTLOCAL_OPEN_FILENAME2, false);
+	//EXPECT_STREQ(TESTLOCAL_OPEN_FILENAME1, cCommandLine.GetOpenFile());
+	EXPECT_STRNE(L"", cCommandLine.GetOpenFile());
 	EXPECT_EQ(1, cCommandLine.GetFileNum());
 	std::wstring additionalFile(cCommandLine.GetFileName(0));
-	ASSERT_NE(0, additionalFile.find(TESTLOCAL_OPEN_FILENAME));
-#undef TESTLOCAL_OPEN_FILENAME
+	ASSERT_NE(0, additionalFile.find(TESTLOCAL_OPEN_FILENAME2));
+#undef TESTLOCAL_OPEN_FILENAME2
+#undef TESTLOCAL_OPEN_FILENAME1
 	cCommandLine.ClearFile();
 	EXPECT_EQ(0, cCommandLine.GetFileNum());
 }

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -345,6 +345,199 @@ TEST(CNativeW, AppendStringWithFormatting)
 }
 
 /*!
+ * @brief 等価比較演算子のテスト
+ *  初期値同士の等価比較を行う
+ */
+TEST(CNativeW, operatorEqualNull)
+{
+	CNativeW value, other;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  nullptrとの等価比較を行う
+ */
+TEST(CNativeW, operatorEqualNullptr)
+{
+	CNativeW value;
+
+	EXPECT_TRUE(value == nullptr);
+	EXPECT_FALSE(value != nullptr);
+	ASSERT_EQ(value, nullptr);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  ポインタ(値がNULL)との等価比較を行う
+ */
+TEST(CNativeW, operatorEqualStringNull)
+{
+	CNativeW value;
+	LPCTSTR str = NULL;
+
+	EXPECT_TRUE(value == str);
+	EXPECT_FALSE(value != str);
+	ASSERT_EQ(value, str);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  値あり同士の等価比較を行う
+ */
+TEST(CNativeW, operatorEqualSame)
+{
+	CNativeW value(L"これはテストです。");
+	CNativeW other(L"これはテストです。");
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  自分自身との等価比較を行う
+ */
+TEST(CNativeW, operatorEqualBySelf)
+{
+	CNativeW value;
+
+	EXPECT_TRUE(value == value);
+	EXPECT_FALSE(value != value);
+	ASSERT_EQ(value, value);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *  重要なクラスなので、テスト条件ごとにケースを分ける
+ *
+ *  合格条件：値あり vs NULL の比較で不一致を検出できること
+ */
+TEST(CNativeW, operatorNotEqualSomeValueVsNull)
+{
+	// 値あり vs NULL
+	CNativeW value(L"これはテストです。");
+	CNativeW other;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *  重要なクラスなので、テスト条件ごとにケースを分ける
+ *
+ *  合格条件：NULL vs 値あり の比較で不一致を検出できること
+ */
+TEST(CNativeW, operatorNotEqualNullVsSomeValue)
+{
+	// NULL vs 値あり
+	CNativeW value;
+	CNativeW other(L"これはテストです。");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *  重要なクラスなので、テスト条件ごとにケースを分ける
+ *
+ *  合格条件：長さの異なる場合の比較で不一致を検出できること
+ */
+TEST(CNativeW, operatorNotEqualNotSameLength)
+{
+	// 値あり vs 値あり(文字列長が違う)
+	CNativeW value(L"これはテストです。");
+	CNativeW other(L"これはテスト？");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *  重要なクラスなので、テスト条件ごとにケースを分ける
+ *
+ *  合格条件：長さが等しく内容の異なる場合の比較で不一致を検出できること
+ */
+TEST(CNativeW, operatorNotEqualNotSameContent)
+{
+	// 値あり vs 値あり(値が違う)
+	CNativeW value(L"これはテストです。");
+	CNativeW other(L"これはテストです？");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  ポインタとの等価比較を行う
+ */
+TEST(CNativeW, operatorEqualSameString)
+{
+	constexpr const wchar_t text[] = L"おっす！オラ(ry";
+	CNativeW value(text);
+	LPCTSTR str = text;
+
+	EXPECT_TRUE(value == str);
+	EXPECT_FALSE(value != str);
+	ASSERT_EQ(value, str);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  ポインタとの等価比較を行う
+ */
+TEST(CNativeW, operatorNotEqualAlmostSameString)
+{
+	CNativeW value(L"おっす！オラ(ry");
+	LPCTSTR str = L"おっと！オラ(ry";
+
+	EXPECT_FALSE(value == str);
+	EXPECT_TRUE(value != str);
+	ASSERT_NE(value, str);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  nullptrとの等価比較を行う
+ */
+TEST(CNativeW, operatorNotEqualNullptr)
+{
+	constexpr const wchar_t text[] = L"おっす！オラ(ry";
+	CNativeW value(text);
+
+	EXPECT_FALSE(value == nullptr);
+	EXPECT_TRUE(value != nullptr);
+	ASSERT_NE(value, nullptr);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  ポインタ(値がNULL)との等価比較を行う
+ */
+TEST(CNativeW, operatorNotEqualStringNull)
+{
+	constexpr const wchar_t text[] = L"おっす！オラ(ry";
+	CNativeW value(text);
+	LPCTSTR str = NULL;
+
+	EXPECT_FALSE(value == str);
+	EXPECT_TRUE(value != str);
+	ASSERT_NE(value, str);
+}
+
+/*!
  * @brief 独自関数Replaceの仕様
  * @remark バッファが確保される
  * @remark 文字列長は0になる

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -87,14 +87,18 @@ TEST(CNativeW, ConstructWithStringEmpty)
 
 /*!
  * @brief コンストラクタ(nullptr指定)の仕様
- * @remark 構築できない(実行時エラーになる)
- * @note バグですね(^^;
+ * @remark バッファは確保されない
+ * @remark 文字列長はゼロになる
+ * @remark バッファサイズはゼロになる
  */
 TEST(CNativeW, ConstructWithStringNull)
 {
-	volatile int ret = 0;
-	ASSERT_DEATH({ CNativeW value(NULL); ret = value.capacity(); }, ".*");
-	(void)ret;
+	const wchar_t* str = NULL;
+	CNativeW value(str);
+
+	ASSERT_EQ(NULL, value.GetStringPtr());
+	EXPECT_EQ(0, value.GetStringLength());
+	EXPECT_EQ(0, value.capacity());
 }
 
 /*!
@@ -236,14 +240,18 @@ TEST(CNativeW, AssignString)
 
 /*!
  * @brief 代入演算子(nullptr指定)の仕様
- * @remark 代入できない(実行時エラーになる)
- * @note バグですね(^^;
+ * @remark バッファは解放される
+ * @remark 文字列長はゼロになる
+ * @remark バッファサイズはゼロになる
  */
 TEST(CNativeW, AssignStringNullPointer)
 {
-	volatile int ret = 0;
-	ASSERT_DEATH({ CNativeW value; value = nullptr; ret = value.capacity(); }, ".*");
-	(void)ret;
+	constexpr const wchar_t sz[] = L"test";
+	CNativeW value(sz);
+	value = nullptr;
+	ASSERT_EQ(NULL, value.GetStringPtr());
+	EXPECT_EQ(0, value.GetStringLength());
+	EXPECT_EQ(0, value.capacity());
 }
 
 /*!
@@ -300,14 +308,17 @@ TEST(CNativeW, AppendString)
 
 /*!
  * @brief 加算代入演算子(nullptr指定)の仕様
- * @remark 加算代入できない(実行時エラーになる)
- * @note バグですね(^^;
+ * @remark 空のCNativeWが加算される(何も起きない)
  */
 TEST(CNativeW, AppendStringNullPointer)
 {
-	volatile int ret = 0;
-	ASSERT_DEATH({ CNativeW value; value += nullptr; ret = value.capacity(); }, ".*");
-	(void)ret;
+	constexpr const wchar_t sz[] = L"test";
+	constexpr const size_t cch = _countof(sz) - 1;
+	CNativeW value(sz);
+	value += nullptr;
+	ASSERT_STREQ(sz, value.GetStringPtr());
+	EXPECT_EQ(cch, value.GetStringLength());
+	EXPECT_LT(cch + 1, value.capacity());
 }
 
 /*!

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -256,11 +256,8 @@ TEST(CNativeW, AssignStringNullPointer)
 TEST(CNativeW, AssignStringNullLiteral)
 {
 	CNativeW value;
-#ifdef _MSC_VER
-	value = NULL; // operator = (wchar_t) と解釈される
-#else
+	// operator = (wchar_t) と解釈させる
 	value = static_cast<wchar_t>(NULL);
-#endif
 	ASSERT_STREQ(L"", value.GetStringPtr());
 	EXPECT_EQ(1, value.GetStringLength());
 	EXPECT_LT(1 + 1, value.capacity());
@@ -323,11 +320,8 @@ TEST(CNativeW, AppendStringNullPointer)
 TEST(CNativeW, AppendStringNullLiteral)
 {
 	CNativeW value;
-#ifdef _MSC_VER
-	value += NULL; // operator += (wchar_t) と解釈される
-#else
+	// operator += (wchar_t) と解釈させる
 	value += static_cast<wchar_t>(NULL);
-#endif
 	ASSERT_STREQ(L"", value.GetStringPtr());
 	EXPECT_EQ(1, value.GetStringLength());
 	EXPECT_LT(1 + 1, value.capacity());

--- a/tests/unittests/test-editinfo.cpp
+++ b/tests/unittests/test-editinfo.cpp
@@ -34,7 +34,7 @@
 #include "EditInfo.h"
 
 /*!
- * @brief 等価演算子のテスト
+ * @brief 等価比較演算子のテスト
  *  初期値同士の等価比較を行う
  */
 TEST(EditInfo, operatorEqualSame)
@@ -47,7 +47,7 @@ TEST(EditInfo, operatorEqualSame)
 }
 
 /*!
- * @brief 等価演算子のテスト
+ * @brief 等価比較演算子のテスト
  *  自分自身との等価比較を行う
  */
 TEST(EditInfo, operatorEqualBySelf)
@@ -60,7 +60,7 @@ TEST(EditInfo, operatorEqualBySelf)
 }
 
 /*!
- * @brief 否定の等価演算子のテスト
+ * @brief 否定の等価比較演算子のテスト
  *  メンバの値を変えて、等価比較を行う
  *
  *  合格条件：メンバの値が1つでも違ったら不一致を検出できること。

--- a/tests/unittests/test-editinfo.cpp
+++ b/tests/unittests/test-editinfo.cpp
@@ -1,0 +1,173 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include "EditInfo.h"
+
+/*!
+ * @brief 等価演算子のテスト
+ *  初期値同士の等価比較を行う
+ */
+TEST(EditInfo, operatorEqualSame)
+{
+	EditInfo value, other;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価演算子のテスト
+ *  自分自身との等価比較を行う
+ */
+TEST(EditInfo, operatorEqualBySelf)
+{
+	EditInfo value;
+
+	EXPECT_TRUE(value == value);
+	EXPECT_FALSE(value != value);
+	ASSERT_EQ(value, value);
+}
+
+/*!
+ * @brief 否定の等価演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *
+ *  合格条件：メンバの値が1つでも違ったら不一致を検出できること。
+ */
+TEST(EditInfo, operatorNotEqual)
+{
+	EditInfo value, other;
+
+	wcscpy_s(value.m_szPath, L"test");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_szPath[0] = 0;
+	
+	value.m_nCharCode = CODE_JIS;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nCharCode = other.m_nCharCode;
+
+	value.m_bBom = !other.m_bBom;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_bBom = other.m_bBom;
+
+	wcscpy_s(value.m_szDocType, L"test");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_szDocType[0] = 0;
+
+	value.m_nTypeId = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nTypeId = other.m_nTypeId;
+
+	value.m_nViewTopLine = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nViewTopLine = other.m_nViewTopLine;
+
+	value.m_nViewLeftCol = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nViewLeftCol = other.m_nViewLeftCol;
+
+	value.m_ptCursor = CLogicPoint(1234, 5678);
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_ptCursor = other.m_ptCursor;
+
+	value.m_bIsModified = !other.m_bIsModified;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_bIsModified = other.m_bIsModified;
+
+	value.m_bIsGrep = !other.m_bIsGrep;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_bIsGrep = other.m_bIsGrep;
+
+	wcscpy_s(value.m_szGrepKey, L"test");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_szGrepKey[0] = 0;
+
+	value.m_bIsDebug = !other.m_bIsDebug;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_bIsDebug = other.m_bIsDebug;
+
+	wcscpy_s(value.m_szMarkLines, L"test");
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_szMarkLines[0] = 0;
+
+	value.m_nWindowSizeX = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nWindowSizeX = other.m_nWindowSizeX;
+
+	value.m_nWindowSizeY = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nWindowSizeY = other.m_nWindowSizeY;
+
+	value.m_nWindowOriginX = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nWindowOriginX = other.m_nWindowOriginX;
+
+	value.m_nWindowOriginY = 1234;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.m_nWindowOriginY = other.m_nWindowOriginY;
+}

--- a/tests/unittests/test-grepinfo.cpp
+++ b/tests/unittests/test-grepinfo.cpp
@@ -1,0 +1,203 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include "_main/CCommandLine.h"
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  初期値同士の等価比較を行う
+ */
+TEST(GrepInfo, operatorEqualSame)
+{
+	GrepInfo value, other;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価比較演算子のテスト
+ *  自分自身との等価比較を行う
+ */
+TEST(GrepInfo, operatorEqualBySelf)
+{
+	GrepInfo value;
+
+	EXPECT_TRUE(value == value);
+	EXPECT_FALSE(value != value);
+	ASSERT_EQ(value, value);
+}
+
+/*!
+ * @brief 否定の等価比較演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *
+ *  合格条件：メンバの値が1つでも違ったら不一致を検出できること。
+ */
+TEST(GrepInfo, operatorNotEqual)
+{
+	GrepInfo value, other;
+
+	value.cmGrepKey = L"ぐれっぷ";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmGrepKey = other.cmGrepKey;
+
+	value.cmGrepRep = L"ちかん";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmGrepRep = other.cmGrepRep;
+
+	value.cmGrepFile = L"#.git;*.*";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmGrepFile = other.cmGrepFile;
+
+	value.cmGrepFolder = L"C:\\work\\sakura";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmGrepFolder = other.cmGrepFolder;
+
+	value.cmExcludeFile = L"除外ファイルの仕様がなんでここに残ってんだっけ？";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmExcludeFile = other.cmExcludeFile;
+
+	value.cmExcludeFolder = L"除外フォルダの仕様がなんで(ry";
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.cmExcludeFolder = other.cmExcludeFolder;
+
+	value.sGrepSearchOption.bRegularExp = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.sGrepSearchOption = other.sGrepSearchOption;
+
+	value.sGrepSearchOption.bLoHiCase = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.sGrepSearchOption = other.sGrepSearchOption;
+
+	value.sGrepSearchOption.bWordOnly = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.sGrepSearchOption = other.sGrepSearchOption;
+
+	value.bGrepCurFolder = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepCurFolder = other.bGrepCurFolder;
+
+	value.bGrepStdout = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepStdout = other.bGrepStdout;
+
+	value.bGrepHeader = false;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepHeader = other.bGrepHeader;
+
+	value.bGrepSubFolder = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepSubFolder = other.bGrepSubFolder;
+
+	value.nGrepCharSet = CODE_EUC;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.nGrepCharSet = other.nGrepCharSet;
+
+	value.nGrepOutputStyle = 2;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.nGrepOutputStyle = other.nGrepOutputStyle;
+
+	value.nGrepOutputLineType = 2;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.nGrepOutputLineType = other.nGrepOutputLineType;
+
+	value.bGrepOutputFileOnly = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepOutputFileOnly = other.bGrepOutputFileOnly;
+
+	value.bGrepOutputBaseFolder = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepOutputBaseFolder = other.bGrepOutputBaseFolder;
+
+	value.bGrepSeparateFolder = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepSeparateFolder = other.bGrepSeparateFolder;
+
+	value.bGrepReplace = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepReplace = other.bGrepReplace;
+
+	value.bGrepPaste = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepPaste = other.bGrepPaste;
+
+	value.bGrepBackup = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bGrepBackup = other.bGrepBackup;
+}

--- a/tests/unittests/test-ssearchoption.cpp
+++ b/tests/unittests/test-ssearchoption.cpp
@@ -1,0 +1,93 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include "_main/global.h"
+
+/*!
+ * @brief 等価演算子のテスト
+ *  初期値同士の等価比較を行う
+ */
+TEST(SSearchOption, operatorEqualSame)
+{
+	SSearchOption value, other;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}
+
+/*!
+ * @brief 等価演算子のテスト
+ *  自分自身との等価比較を行う
+ */
+TEST(SSearchOption, operatorEqualBySelf)
+{
+	SSearchOption value;
+
+	EXPECT_TRUE(value == value);
+	EXPECT_FALSE(value != value);
+	ASSERT_EQ(value, value);
+}
+
+/*!
+ * @brief 否定の等価演算子のテスト
+ *  メンバの値を変えて、等価比較を行う
+ *
+ *  合格条件：メンバの値が1つでも違ったら不一致を検出できること。
+ */
+TEST(SSearchOption, operatorNotEqual)
+{
+	SSearchOption value, other;
+
+	value.bRegularExp = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bRegularExp = false;
+
+	value.bLoHiCase = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bLoHiCase = false;
+
+	value.bWordOnly = true;
+	EXPECT_FALSE(value == other);
+	EXPECT_TRUE(value != other);
+	ASSERT_NE(value, other);
+	value.bWordOnly = false;
+
+	EXPECT_TRUE(value == other);
+	EXPECT_FALSE(value != other);
+	ASSERT_EQ(value, other);
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -106,6 +106,7 @@
     <ClCompile Include="test-ccommandline.cpp" />
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />
+    <ClCompile Include="test-editinfo.cpp" />
     <ClCompile Include="test-int2dec.cpp" />
     <ClCompile Include="test-is_mailaddress.cpp" />
     <ClCompile Include="test-mydevmode.cpp" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -103,6 +103,7 @@
     <Link Include="$(SolutionDir)sakura\$(Platform)\$(Configuration)\*.obj" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="test-ccommandline.cpp" />
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />
     <ClCompile Include="test-int2dec.cpp" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -107,6 +107,7 @@
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />
     <ClCompile Include="test-editinfo.cpp" />
+    <ClCompile Include="test-grepinfo.cpp" />
     <ClCompile Include="test-int2dec.cpp" />
     <ClCompile Include="test-is_mailaddress.cpp" />
     <ClCompile Include="test-mydevmode.cpp" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -113,6 +113,7 @@
     <ClCompile Include="test-parameterized.cpp" />
     <ClCompile Include="test-sample-disabled.cpp" />
     <ClCompile Include="test-sample.cpp" />
+    <ClCompile Include="test-ssearchoption.cpp" />
     <ClCompile Include="test-StdControl.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -47,5 +47,8 @@
     <ClCompile Include="test-ccommandline.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-editinfo.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -53,5 +53,8 @@
     <ClCompile Include="test-ssearchoption.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-grepinfo.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -50,5 +50,8 @@
     <ClCompile Include="test-editinfo.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-ssearchoption.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -44,5 +44,8 @@
     <ClCompile Include="test-StdControl.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-ccommandline.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## PR の目的
CNativeWにnullptrを代入できるようにします。
この変更により、ユニットテストの実行時間を大幅に改善できます。


## カテゴリ
- 仕様変更 … 内部仕様変更なので、アプリ動作には影響しないと思われます。


## PR の背景
`CNativeW` の現状の仕様が分かるようなテストが #1078 で入りました。

テストの位置づけは「なんか困ったらテストかコードかを直す」を目的にしています。

で、早速「当面の困りごと」があります。

**ユニットテストの実行が遅い！**

実行に20秒近くかかっています。
1,000件にも満たない小規模テストであるにも関わらず…

原因は分かっているので対処策を書いてみました。


## PR のメリット
- ユニットテストの実行時間が大幅に短縮されます。
  - 「代入式で指定したポインタがNULLだった場合を想定しない（＝クラッシュします。）」という危険な挙動をテストするDEATHテストが要らなくなります。
    - DEATHテストは通常テストの数百倍の時間がかかるため、減らせるならば減らしたほうがよい気がします。
- `CNativeW` に「一度確保したメモリ領域を解放する機能」が追加されます。
  - 影響を受けるのは `operator = (const wchar_t* rhs)` の呼出のみです。
  - 代入演算子は `C++` の文化なので、古くからあるコードには影響を与えません。
- `CNativeW` の特性「無効値も保持できる」を活かしたコードを書けるようになります。
  - 標準ライブラリの `std::wstring` は 無効値(=nullptr) を保持できません。
  - `Windows API` では文字列をポインタとして扱う必要があります。
    - 生ポインタを直接扱うのは一般的に「危険」です。
      - 生ポインタをラップする独自クラスの開発が必要です。
        - おそらくこれが `CNativeW` の存在理由です。



## PR のデメリット (トレードオフとかあれば)
- レビュー中の PR #1081 にガッツリ依存するので、現状でマージ不能です。
- **一度確保したメモリ領域を開放する** という、これまで出来なかった操作ができるようになります。`CNativeW` のこの特性を活かしたロジックが成り立たなくなる危険があります。
  - ただし、既存コードでは **代入演算子を使っていない** ので、ぼくらが「`SetString(str)` を代入演算子に置き替える」とかやらない限り、影響は出ないと思われます。


## PR の影響範囲
- Windows API と文字列をやり取りする処理を改善できる変更です。
  - このPRでは実際の改善を行いません。
- アプリ(=サクラエディタ) の機能に影響はありません。


## 関連チケット
#1081 コマンドライン解析をテストできるようにしたい
#1078 CNativeWの挙動を仕様化したい


## 参考資料
https://ja.cppreference.com/w/cpp/language/operator_assignment
https://ja.cppreference.com/w/cpp/types/nullptr_t
https://docs.microsoft.com/ja-jp/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested
