### PR TITLE
[WIP] CNativeWにnullptrを代入できるようにしたい Take2

### DIFF
--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -31,7 +31,7 @@ CNativeW::CNativeW( const wchar_t* pData, int nDataLen )
 CNativeW::CNativeW( const wchar_t* pData )
 	: CNative()
 {
-	SetString(pData);
+	*this = pData;
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -80,10 +80,23 @@ public:
 	//演算子
 	CNativeW& operator = (const CNativeW& rhs)			{ CNative::operator=(rhs); return *this; }
 	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeW>(rhs)); return *this; }
-	const CNativeW& operator+=(wchar_t wch)				{ AppendString(&wch,1);   return *this; }
-	const CNativeW& operator=(wchar_t wch)				{ SetString(&wch,1);      return *this; }
-	const CNativeW& operator+=(const CNativeW& rhs)		{ AppendNativeData(rhs); return *this; }
-	CNativeW operator+(const CNativeW& rhs) const		{ CNativeW tmp=*this; return tmp+=rhs; }
+	CNativeW& operator = (std::nullptr_t) noexcept		{ CNative::operator=(CNativeW()); return *this; }
+	CNativeW& operator = (const wchar_t* rhs) {
+		if (rhs == nullptr) return (*this = nullptr);
+		SetString(rhs);
+		return *this;
+	}
+	CNativeW& operator = (const wchar_t ch) {
+		if (ch == L'\0') return (*this = nullptr);
+		const wchar_t sz[]{ ch, 0 };
+		return (*this = sz);
+	}
+	CNativeW& operator += (const wchar_t ch) {
+		const wchar_t sz[]{ ch, 0 };
+		return (*this += sz);
+	}
+	CNativeW& operator += (const CNativeW& rhs)			{ AppendNativeData(rhs); return *this; }
+	CNativeW operator + (const CNativeW& rhs) const		{ CNativeW tmp(*this); return (tmp += rhs); }
 
 	//ネイティブ取得インターフェース
 	wchar_t operator[](int nIndex) const;                    //!< 任意位置の文字取得。nIndexは文字単位。


### PR DESCRIPTION
# PR の目的
`CNativeW` の「困った挙動」に対策して、テスト実行時間を短縮します。

## カテゴリ
- 速度向上 (テストの...)
- その他

## PR の背景

このPRは #1082 の焼き直しです。
（こんな速いタイミングでやれるなら閉じなくてもよかった...orz）

**何に困っているか？** を直観的に把握できるように、
先にテストだけを「あるべき姿」に直して失敗させてみます。

「あるべき姿」は全力で主観なので、よりよい「落としどころ」があればなびきたい感じです。

### 変更したテストの内容
- コンストラクタにnullを指定したら落ちるテストのDEATHテストを外しました。  
コンストラクタは引数にnullを指定できるべきだと思います。  
省略時と同じ挙動にしたいです。
- nullを代入するテストの想定結果を書き替えました。  
nullを代入したらnullになるべきだと思います。  
そうしないと、代入後にnullと比較したときに不一致になってしまいます。  
結果的に、メモリは解放する挙動にしたいです。
- nullを加算するテストの想定結果を書き替えました。  
nullを加算しても何も起こらないべきだと思います。  
メモリ確保すらしない挙動にしたいです。

あと、説明に誤記があったのを直しました...orz

## PR のメリット
- ユニットテストの実行時間が大幅に短縮されます。

## PR のデメリット (トレードオフとかあれば)
- とくにありません。

## PR の影響範囲

- 主にこれから手を加えていくコードの書きっぷりに影響してきます。
- Windows API と文字列をやり取りする処理を改善できる変更です。
  - このPRでは実際の改善を行いません。
- アプリ(=サクラエディタ) の機能に影響はありません。

## 関連チケット

#1082 CNativeWにnullptrを代入できるようにしたい
#1081 コマンドライン解析をテストできるようにしたい
#1078 CNativeWの挙動を仕様化したい

## 参考資料

