### PR TITLE
CNativeW::SetString に NULL を指定した場合に wcslen に NULL を渡して落ちてしまう不具合を修正

### DIFF
--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -50,7 +50,7 @@ void CNativeW::SetString( const wchar_t* pszData )
 	if (pszData)
 		CNative::SetRawData(pszData,wcslen(pszData) * sizeof(wchar_t));
 	else
-		Clear();
+		CMemory::Clear();
 }
 
 void CNativeW::SetStringHoldBuffer( const wchar_t* pData, int nDataLen )

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -47,7 +47,10 @@ void CNativeW::SetString( const wchar_t* pData, int nDataLen )
 // バッファの内容を置き換える
 void CNativeW::SetString( const wchar_t* pszData )
 {
-	CNative::SetRawData(pszData,wcslen(pszData) * sizeof(wchar_t));
+	if (pszData)
+		CNative::SetRawData(pszData,wcslen(pszData) * sizeof(wchar_t));
+	else
+		Clear();
 }
 
 void CNativeW::SetStringHoldBuffer( const wchar_t* pData, int nDataLen )

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -67,7 +67,7 @@ public:
 
 	//WCHAR
 	void SetString( const wchar_t* pData, int nDataLen );      //!< バッファの内容を置き換える。nDataLenは文字単位。
-	void SetString( const wchar_t* pszData );                  //!< バッファの内容を置き換える
+	void SetString( const wchar_t* pszData );                  //!< バッファの内容を置き換える。NULL 指定時はメモリ解放を行い、文字列長はゼロになる
 	void SetStringHoldBuffer( const wchar_t* pData, int nDataLen );
 	void AppendString( const wchar_t* pszData );               //!< バッファの最後にデータを追加する
 	void AppendString( const wchar_t* pszData, int nLength );  //!< バッファの最後にデータを追加する。nLengthは文字単位。成功すればtrue。メモリ確保に失敗したらfalseを返す。

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -91,12 +91,12 @@ TEST(CNativeW, ConstructWithStringEmpty)
 TEST(CNativeW, ConstructWithStringNull)
 {
 	CNativeW value(NULL);
-	EXPECT_EQ(value.GetStringLength(), 0);
-	EXPECT_EQ(value.GetStringPtr(), nullptr);
+	EXPECT_EQ(0, value.GetStringLength());
+	EXPECT_EQ(nullptr, value.GetStringPtr());
 
 	CNativeW value2(nullptr);
-	EXPECT_EQ(value2.GetStringLength(), 0);
-	EXPECT_EQ(value2.GetStringPtr(), nullptr);
+	EXPECT_EQ(0, value2.GetStringLength());
+	EXPECT_EQ(nullptr, value2.GetStringPtr());
 }
 
 /*!
@@ -243,8 +243,8 @@ TEST(CNativeW, AssignStringNullPointer)
 {
 	CNativeW value(L"test");
 	value = nullptr;
-	EXPECT_EQ(value.GetStringLength(), 0);
-	EXPECT_EQ(value.GetStringPtr(), nullptr);
+	EXPECT_EQ(0, value.GetStringLength());
+	EXPECT_EQ(nullptr, value.GetStringPtr());
 }
 
 /*!

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -87,6 +87,8 @@ TEST(CNativeW, ConstructWithStringEmpty)
 
 /*!
  * @brief コンストラクタ(NULL指定)の仕様
+ * @remark バッファは確保されない
+ * @remark 文字列長はゼロになる
  */
 TEST(CNativeW, ConstructWithStringNull)
 {
@@ -238,6 +240,8 @@ TEST(CNativeW, AssignString)
 
 /*!
  * @brief 代入演算子(nullptr指定)の仕様
+ * @remark バッファを確保している場合は解放される
+ * @remark 文字列長はゼロになる
  */
 TEST(CNativeW, AssignStringNullPointer)
 {

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -86,15 +86,17 @@ TEST(CNativeW, ConstructWithStringEmpty)
 }
 
 /*!
- * @brief コンストラクタ(nullptr指定)の仕様
- * @remark 構築できない(実行時エラーになる)
- * @note バグですね(^^;
+ * @brief コンストラクタ(NULL指定)の仕様
  */
 TEST(CNativeW, ConstructWithStringNull)
 {
-	volatile int ret = 0;
-	ASSERT_DEATH({ CNativeW value(NULL); ret = value.capacity(); }, ".*");
-	(void)ret;
+	CNativeW value(NULL);
+	EXPECT_EQ(value.GetStringLength(), 0);
+	EXPECT_EQ(value.GetStringPtr(), nullptr);
+
+	CNativeW value2(nullptr);
+	EXPECT_EQ(value2.GetStringLength(), 0);
+	EXPECT_EQ(value2.GetStringPtr(), nullptr);
 }
 
 /*!
@@ -236,14 +238,13 @@ TEST(CNativeW, AssignString)
 
 /*!
  * @brief 代入演算子(nullptr指定)の仕様
- * @remark 代入できない(実行時エラーになる)
- * @note バグですね(^^;
  */
 TEST(CNativeW, AssignStringNullPointer)
 {
-	volatile int ret = 0;
-	ASSERT_DEATH({ CNativeW value; value = nullptr; ret = value.capacity(); }, ".*");
-	(void)ret;
+	CNativeW value(L"test");
+	value = nullptr;
+	EXPECT_EQ(value.GetStringLength(), 0);
+	EXPECT_EQ(value.GetStringPtr(), nullptr);
 }
 
 /*!
@@ -303,14 +304,15 @@ TEST(CNativeW, AppendString)
 
 /*!
  * @brief 加算代入演算子(nullptr指定)の仕様
- * @remark 加算代入できない(実行時エラーになる)
- * @note バグですね(^^;
+ * @remark 加算代入しても内容に変化無し
  */
 TEST(CNativeW, AppendStringNullPointer)
 {
-	volatile int ret = 0;
-	ASSERT_DEATH({ CNativeW value; value += nullptr; ret = value.capacity(); }, ".*");
-	(void)ret;
+	CNativeW org(L"orz");
+	CNativeW value(org);
+	value += nullptr;
+	EXPECT_EQ(value.GetStringLength(), org.GetStringLength());
+	EXPECT_TRUE(CNativeW::IsEqual(value, org));
 }
 
 /*!


### PR DESCRIPTION
@berryzplus さん、レビューお願いします。

# PR の目的

CNativeW::SetString の引数に NULL が渡ってきた場合に wcslen にそのまま NULL を渡して落ちてしまう不具合を修正するのが目的です。

## カテゴリ

- 不具合修正

## PR の背景

実際に呼ばれるケースが存在するのかは不明ですが（実アプリでの再現手順は不明）起きうるかもしれないので対処を入れました。ユニットテストに落ちる事を確認する DEATH テストが入っていましたが、落ちる動作をわざわざ期待してその挙動を保つ必要も無いのかなと思います。

## PR のメリット

CNativeW::SetString の引数に NULL が渡ってきた場合に落ちる事が無くなります。

## PR のデメリット (トレードオフとかあれば)

CNativeW::SetString の引数の NULL チェックの分だけ処理コストが（わずかに）増えます。

## PR の影響範囲

CNativeW::SetString の呼び出し箇所の動作に影響します。しかし落ちる動作を保つべきという事も無いと思います。

## 関連チケット

#1086 
