### PR TITLE
final 指定子 と override 指定子の適用

### DIFF
--- a/sakura_core/CAutoReloadAgent.h
+++ b/sakura_core/CAutoReloadAgent.h
@@ -38,9 +38,9 @@ enum WatchUpdate {
 class CAutoReloadAgent : public CDocListenerEx{
 public:
 	CAutoReloadAgent();
-	void OnBeforeSave(const SSaveInfo& sSaveInfo);
-	void OnAfterSave(const SSaveInfo& sSaveInfo);
-	void OnAfterLoad(const SLoadInfo& sLoadInfo);
+	void OnBeforeSave(const SSaveInfo& sSaveInfo) override;
+	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
+	void OnAfterLoad(const SLoadInfo& sLoadInfo) override;
 
 	//監視の一時停止
 	void PauseWatching(){ m_nPauseCount++; }

--- a/sakura_core/CBackupAgent.h
+++ b/sakura_core/CBackupAgent.h
@@ -29,7 +29,7 @@
 
 class CBackupAgent : public CDocListenerEx{
 public:
-	ECallbackResult OnPreBeforeSave(SSaveInfo* pSaveInfo);
+	ECallbackResult OnPreBeforeSave(SSaveInfo* pSaveInfo) override;
 
 protected:
 	int MakeBackUp( const WCHAR* target_file );								//!< バックアップの作成

--- a/sakura_core/CCodeChecker.h
+++ b/sakura_core/CCodeChecker.h
@@ -34,11 +34,11 @@ class CCodeChecker : public CDocListenerEx, public TSingleton<CCodeChecker>{
 
 public:
 	//セーブ時チェック
-	ECallbackResult OnCheckSave(SSaveInfo* pSaveInfo);
-	void OnFinalSave(ESaveResult eSaveResult);
+	ECallbackResult OnCheckSave(SSaveInfo* pSaveInfo) override;
+	void OnFinalSave(ESaveResult eSaveResult) override;
 
 	//ロード時チェック
-	void OnFinalLoad(ELoadResult eLoadResult);
+	void OnFinalLoad(ELoadResult eLoadResult) override;
 };
 
 #endif /* SAKURA_CCODECHECKER_4EBAEA37_FC62_4206_A9DD_82DDB8CDE44E9_H_ */

--- a/sakura_core/CGrepAgent.h
+++ b/sakura_core/CGrepAgent.h
@@ -70,8 +70,8 @@ public:
 	CGrepAgent();
 
 	// イベント
-	ECallbackResult OnBeforeClose();
-	void OnAfterSave(const SSaveInfo& sSaveInfo);
+	ECallbackResult OnBeforeClose() override;
+	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
 
 	static void CreateFolders( const WCHAR* pszPath, std::vector<std::wstring>& vPaths );
 	static std::wstring ChopYen( const std::wstring& str );

--- a/sakura_core/CGrepEnumFiles.h
+++ b/sakura_core/CGrepEnumFiles.h
@@ -42,7 +42,7 @@ public:
 	virtual ~CGrepEnumFiles(){
 	}
 
-	virtual BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL ) override {
+	BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL ) override {
 		if( ! ( w32fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ) ){
 			if( CGrepEnumFileBase::IsValid( w32fd, pFile ) ){
 				return TRUE;

--- a/sakura_core/CGrepEnumFiles.h
+++ b/sakura_core/CGrepEnumFiles.h
@@ -42,7 +42,7 @@ public:
 	virtual ~CGrepEnumFiles(){
 	}
 
-	virtual BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL ){
+	virtual BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL ) override {
 		if( ! ( w32fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ) ){
 			if( CGrepEnumFileBase::IsValid( w32fd, pFile ) ){
 				return TRUE;

--- a/sakura_core/CGrepEnumFilterFiles.h
+++ b/sakura_core/CGrepEnumFilterFiles.h
@@ -32,7 +32,7 @@
 
 #include "CGrepEnumFiles.h"
 
-class CGrepEnumFilterFiles : public CGrepEnumFiles {
+class CGrepEnumFilterFiles final : public CGrepEnumFiles {
 private:
 
 public:
@@ -45,7 +45,7 @@ public:
 	virtual ~CGrepEnumFilterFiles(){
 	}
 
-	virtual BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL  ){
+	BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL  ) override {
 		if( CGrepEnumFiles::IsValid( w32fd, pFile ) ){
 			if( m_cGrepEnumExceptFiles.IsValid( w32fd, pFile ) ){
 				return TRUE;

--- a/sakura_core/CGrepEnumFilterFolders.h
+++ b/sakura_core/CGrepEnumFilterFolders.h
@@ -32,7 +32,7 @@
 
 #include "CGrepEnumFolders.h"
 
-class CGrepEnumFilterFolders : public CGrepEnumFolders {
+class CGrepEnumFilterFolders final : public CGrepEnumFolders {
 private:
 
 public:
@@ -45,7 +45,7 @@ public:
 	virtual ~CGrepEnumFilterFolders(){
 	}
 
-	virtual BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL ){
+	BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL ) override{
 		if( CGrepEnumFolders::IsValid( w32fd, pFile ) ){
 			if( m_cGrepEnumExceptFolders.IsValid( w32fd, pFile ) ){
 				return TRUE;

--- a/sakura_core/CHokanMgr.h
+++ b/sakura_core/CHokanMgr.h
@@ -23,7 +23,7 @@
 
 	@date 2003.06.25 Moca ファイル内からの補完機能を追加
 */
-class CHokanMgr : public CDialog
+class CHokanMgr final : public CDialog
 {
 public:
 	/*
@@ -56,11 +56,11 @@ public:
 	BOOL DoHokan(int nVKey);
 	void ChangeView(LPARAM pcEditView);/* モードレス時：対象となるビューの変更 */
 
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );
-	BOOL OnInitDialog( HWND, WPARAM wParam, LPARAM lParam );
-	BOOL OnDestroy( void );
-	BOOL OnSize( WPARAM wParam, LPARAM lParam );
-	BOOL OnLbnSelChange( HWND hwndCtl, int wID );
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;
+	BOOL OnInitDialog( HWND, WPARAM wParam, LPARAM lParam ) override;
+	BOOL OnDestroy( void ) override;
+	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
+	BOOL OnLbnSelChange( HWND hwndCtl, int wID ) override;
 
 	int KeyProc(WPARAM wParam, LPARAM lParam);
 
@@ -84,7 +84,7 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/CLoadAgent.h
+++ b/sakura_core/CLoadAgent.h
@@ -29,11 +29,11 @@
 
 class CLoadAgent : public CDocListenerEx{
 public:
-	ECallbackResult OnCheckLoad(SLoadInfo* pLoadInfo);
-	void OnBeforeLoad(SLoadInfo* sLoadInfo);
-	ELoadResult OnLoad(const SLoadInfo& sLoadInfo);
-	void OnAfterLoad(const SLoadInfo& sLoadInfo);
-	void OnFinalLoad(ELoadResult eLoadResult);
+	ECallbackResult OnCheckLoad(SLoadInfo* pLoadInfo) override;
+	void OnBeforeLoad(SLoadInfo* sLoadInfo) override;
+	ELoadResult OnLoad(const SLoadInfo& sLoadInfo) override;
+	void OnAfterLoad(const SLoadInfo& sLoadInfo) override;
+	void OnFinalLoad(ELoadResult eLoadResult) override;
 };
 
 #endif /* SAKURA_CLOADAGENT_780AC971_71A8_4495_BE95_C8786311D1489_H_ */

--- a/sakura_core/CMarkMgr.h
+++ b/sakura_core/CMarkMgr.h
@@ -130,10 +130,10 @@ private:
 
 	CMarkMgr を継承し、動作が規定されていない部分を実装する。
 */
-class CAutoMarkMgr : public CMarkMgr{
+class CAutoMarkMgr final : public CMarkMgr{
 public:
-	virtual void Add(const CMark& m);	//!<	要素の追加
-	virtual void Expire(void);	//!<	要素数の調整
+	void Add(const CMark& m) override;	//!<	要素の追加
+	void Expire(void) override;	//!<	要素数の調整
 };
 
 #endif

--- a/sakura_core/COpe.h
+++ b/sakura_core/COpe.h
@@ -68,13 +68,13 @@ public:
 };
 
 //!削除
-class CDeleteOpe : public COpe{
+class CDeleteOpe final : public COpe{
 public:
 	CDeleteOpe() : COpe(OPE_DELETE)
 	{
 		m_ptCaretPos_PHY_To.Set(CLogicInt(0),CLogicInt(0));
 	}
-	virtual void DUMP( void );	/* 編集操作要素のダンプ */
+	void DUMP( void ) override;	/* 編集操作要素のダンプ */
 public:
 	CLogicPoint	m_ptCaretPos_PHY_To;		//!< 操作前のキャレット位置。文字単位。	[DELETE]
 	COpeLineData	m_cOpeLineData;			//!< 操作に関連するデータ				[DELETE/INSERT]
@@ -82,17 +82,17 @@ public:
 };
 
 //!挿入
-class CInsertOpe : public COpe{
+class CInsertOpe final : public COpe{
 public:
 	CInsertOpe() : COpe(OPE_INSERT) { }
-	virtual void DUMP( void );	/* 編集操作要素のダンプ */
+	void DUMP( void ) override;	/* 編集操作要素のダンプ */
 public:
 	COpeLineData	m_cOpeLineData;			//!< 操作に関連するデータ				[DELETE/INSERT]
 	int				m_nOrgSeq;
 };
 
 //!置換
-class CReplaceOpe : public COpe{
+class CReplaceOpe final : public COpe{
 public:
 	CReplaceOpe() : COpe(OPE_REPLACE)
 	{
@@ -107,7 +107,7 @@ public:
 };
 
 //!キャレット移動
-class CMoveCaretOpe : public COpe{
+class CMoveCaretOpe final : public COpe{
 public:
 	CMoveCaretOpe() : COpe(OPE_MOVECARET) { }
 	CMoveCaretOpe(const CLogicPoint& ptBefore, const CLogicPoint& ptAfter)

--- a/sakura_core/CSaveAgent.h
+++ b/sakura_core/CSaveAgent.h
@@ -28,11 +28,11 @@
 class CSaveAgent : public CDocListenerEx{
 public:
 	CSaveAgent();
-	ECallbackResult OnCheckSave(SSaveInfo* pSaveInfo);
-	void OnBeforeSave(const SSaveInfo& sSaveInfo);
-	void OnSave(const SSaveInfo& sSaveInfo);
-	void OnAfterSave(const SSaveInfo& sSaveInfo);
-	void OnFinalSave(ESaveResult eSaveResult);
+	ECallbackResult OnCheckSave(SSaveInfo* pSaveInfo) override;
+	void OnBeforeSave(const SSaveInfo& sSaveInfo) override;
+	void OnSave(const SSaveInfo& sSaveInfo) override;
+	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
+	void OnFinalSave(ESaveResult eSaveResult) override;
 private:
 	SSaveInfo	m_sSaveInfoForRollback;
 };

--- a/sakura_core/_main/CAppMode.h
+++ b/sakura_core/_main/CAppMode.h
@@ -46,7 +46,7 @@ public:
 	void	SetDebugModeOFF();	//!< デバッグモニタモード解除
 
 	//イベント
-	void OnAfterSave(const SSaveInfo& sSaveInfo);
+	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
 
 protected:
 	void _SetDebugMode(bool bDebugMode){ m_bDebugMode = bDebugMode; }

--- a/sakura_core/_main/CControlProcess.h
+++ b/sakura_core/_main/CControlProcess.h
@@ -30,7 +30,7 @@ class CControlTray;
 	
 	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 */
-class CControlProcess : public CProcess {
+class CControlProcess final : public CProcess {
 public:
 	CControlProcess( HINSTANCE hInstance, LPCWSTR lpCmdLine ) : 
 		CProcess( hInstance, lpCmdLine ),
@@ -41,12 +41,12 @@ public:
 		m_pcTray( 0 )
 	{}
 
-	virtual ~CControlProcess();
+	~CControlProcess() override;
 protected:
 	CControlProcess();
-	virtual bool InitializeProcess();
-	virtual bool MainLoop();
-	virtual void OnExitProcess();
+	bool InitializeProcess() override;
+	bool MainLoop() override;
+	virtual void OnExitProcess() override;
 
 private:
 	HANDLE			m_hMutex;				//!< アプリケーション実行検出用ミューテックス

--- a/sakura_core/_main/CControlProcess.h
+++ b/sakura_core/_main/CControlProcess.h
@@ -41,12 +41,12 @@ public:
 		m_pcTray( 0 )
 	{}
 
-	~CControlProcess() override;
+	~CControlProcess();
 protected:
 	CControlProcess();
 	bool InitializeProcess() override;
 	bool MainLoop() override;
-	virtual void OnExitProcess() override;
+	void OnExitProcess() override;
 
 private:
 	HANDLE			m_hMutex;				//!< アプリケーション実行検出用ミューテックス

--- a/sakura_core/_main/CNormalProcess.h
+++ b/sakura_core/_main/CNormalProcess.h
@@ -33,7 +33,7 @@ class CNormalProcess final : public CProcess {
 public:
 	//コンストラクタ・デストラクタ
 	CNormalProcess( HINSTANCE hInstance, LPCWSTR lpCmdLine );
-	~CNormalProcess() override;
+	~CNormalProcess();
 
 protected:
 	//プロセスハンドラ

--- a/sakura_core/_main/CNormalProcess.h
+++ b/sakura_core/_main/CNormalProcess.h
@@ -29,17 +29,17 @@ class CEditWnd;
 	
 	エディタプロセスはCEditWndクラスのインスタンスを作る。
 */
-class CNormalProcess : public CProcess {
+class CNormalProcess final : public CProcess {
 public:
 	//コンストラクタ・デストラクタ
 	CNormalProcess( HINSTANCE hInstance, LPCWSTR lpCmdLine );
-	virtual ~CNormalProcess();
+	~CNormalProcess() override;
 
 protected:
 	//プロセスハンドラ
-	virtual bool InitializeProcess();
-	virtual bool MainLoop();
-	virtual void OnExitProcess();
+	bool InitializeProcess() override;
+	bool MainLoop() override;
+	void OnExitProcess() override;
 
 protected:
 	//実装補助

--- a/sakura_core/charset/CCesu8.h
+++ b/sakura_core/charset/CCesu8.h
@@ -32,13 +32,13 @@ class CCesu8 : public CCodeBase {
 public:
 
 	//CCodeBaseインターフェース
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){	//!< 特定コード → UNICODE    変換
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{	//!< 特定コード → UNICODE    変換
 		return CUtf8::CESU8ToUnicode(cSrc, pDst);
 	}
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){	//!< UNICODE    → 特定コード 変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{	//!< UNICODE    → 特定コード 変換
 		return CUtf8::UnicodeToCESU8(cSrc, pDst);
 	}
-	void GetBom(CMemory* pcmemBom);																			//!< BOMデータ取得
+	void GetBom(CMemory* pcmemBom) override;																			//!< BOMデータ取得
 // GetEolはCCodeBaseに移動	2010/6/13 Uchi
 	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar){			//!< UNICODE → Hex 変換
 		return CUtf8()._UnicodeToHex( cSrc, iSLen, pDst, psStatusbar, true );

--- a/sakura_core/charset/CCodePage.h
+++ b/sakura_core/charset/CCodePage.h
@@ -55,10 +55,10 @@ public:
 	CCodePage(int codepageEx) : m_nCodePageEx(codepageEx) { }
 	
 	//CCodeBaseインターフェース
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){ return CPToUnicode(cSrc, pDst, m_nCodePageEx); }	//!< 特定コード → UNICODE    変換
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){ return UnicodeToCP(cSrc, pDst, m_nCodePageEx); }	//!< UNICODE    → 特定コード 変換
-	void GetEol(CMemory* pcmemEol, EEolType eEolType);	//!< 改行データ取得
-	void GetBom(CMemory* pcmemBom);	//!< BOMデータ取得
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return CPToUnicode(cSrc, pDst, m_nCodePageEx); }	//!< 特定コード → UNICODE    変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToCP(cSrc, pDst, m_nCodePageEx); }	//!< UNICODE    → 特定コード 変換
+	void GetEol(CMemory* pcmemEol, EEolType eEolType) override;	//!< 改行データ取得
+	void GetBom(CMemory* pcmemBom) override;	//!< BOMデータ取得
 	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
 
 public:

--- a/sakura_core/charset/CEuc.h
+++ b/sakura_core/charset/CEuc.h
@@ -32,8 +32,8 @@
 class CEuc : public CCodeBase{
 public:
 	//CCodeBaseインターフェース
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){ return EUCToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){ return UnicodeToEUC(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return EUCToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToEUC(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
 // GetEolはCCodeBaseに移動	2010/6/13 Uchi
 	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
 

--- a/sakura_core/charset/CJis.h
+++ b/sakura_core/charset/CJis.h
@@ -32,8 +32,8 @@ public:
 	CJis(bool base64decode = true) : m_base64decode(base64decode) { }
 public:
 	//CCodeBaseインターフェース
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){ return JISToUnicode(cSrc, pDst, m_base64decode); }	//!< 特定コード → UNICODE    変換
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){ return UnicodeToJIS(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return JISToUnicode(cSrc, pDst, m_base64decode); }	//!< 特定コード → UNICODE    変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToJIS(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
 // GetEolはCCodeBaseに移動	2010/6/13 Uchi
 	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
 

--- a/sakura_core/charset/CLatin1.h
+++ b/sakura_core/charset/CLatin1.h
@@ -36,9 +36,9 @@ class CLatin1 : public CCodeBase{
 
 public:
 	//CCodeBaseインターフェース
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){ return Latin1ToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){ return UnicodeToLatin1(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
-	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return Latin1ToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToLatin1(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
+	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar) override;			//!< UNICODE → Hex 変換
 
 public:
 	//実装

--- a/sakura_core/charset/CShiftJis.h
+++ b/sakura_core/charset/CShiftJis.h
@@ -34,10 +34,10 @@ class CShiftJis : public CCodeBase{
 
 public:
 	//CCodeBaseインターフェース
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){ return SJISToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){ return UnicodeToSJIS(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return SJISToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToSJIS(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
 // GetEolはCCodeBaseに移動	2010/6/13 Uchi
-	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar);			//!< UNICODE → Hex 変換
+	EConvertResult UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar) override;			//!< UNICODE → Hex 変換
 
 public:
 	//実装

--- a/sakura_core/charset/CUnicode.h
+++ b/sakura_core/charset/CUnicode.h
@@ -31,14 +31,14 @@
 
 class CUnicode : public CCodeBase{
 public:
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){	//!< 特定コード → UNICODE    変換
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{	//!< 特定コード → UNICODE    変換
 		return UnicodeToUnicode_in(cSrc, pDst);
 	}
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){	//!< UNICODE    → 特定コード 変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{	//!< UNICODE    → 特定コード 変換
 		return UnicodeToUnicode_out(cSrc, pDst);
 	}
-	void GetBom(CMemory* pcmemBom);	//!< BOMデータ取得
-	void GetEol(CMemory* pcmemEol, EEolType eEolType);	//!< 改行データ取得
+	void GetBom(CMemory* pcmemBom) override;	//!< BOMデータ取得
+	void GetEol(CMemory* pcmemEol, EEolType eEolType) override;	//!< 改行データ取得
 
 public:
 	//実装

--- a/sakura_core/charset/CUnicodeBe.h
+++ b/sakura_core/charset/CUnicodeBe.h
@@ -32,10 +32,10 @@
 class CUnicodeBe : public CCodeBase{
 public:
 	//CCodeBaseインターフェース
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){ return UnicodeBEToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){ return UnicodeToUnicodeBE(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
-	void GetBom(CMemory* pcmemBom);	//!< BOMデータ取得
-	void GetEol(CMemory* pcmemEol, EEolType eEolType);	//!< 改行データ取得
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return UnicodeBEToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToUnicodeBE(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
+	void GetBom(CMemory* pcmemBom) override;	//!< BOMデータ取得
+	void GetEol(CMemory* pcmemEol, EEolType eEolType) override;	//!< 改行データ取得
 
 public:
 

--- a/sakura_core/charset/CUtf7.h
+++ b/sakura_core/charset/CUtf7.h
@@ -30,10 +30,10 @@
 class CUtf7 : public CCodeBase{
 public:
 	//CCodeBaseインターフェース
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){ return UTF7ToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){ return UnicodeToUTF7(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
-	void GetBom(CMemory* pcmemBom);	//!< BOMデータ取得
-	void GetEol(CMemory* pcmemEol, EEolType eEolType);
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{ return UTF7ToUnicode(cSrc, pDst); }	//!< 特定コード → UNICODE    変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{ return UnicodeToUTF7(cSrc, pDst); }	//!< UNICODE    → 特定コード 変換
+	void GetBom(CMemory* pcmemBom) override;	//!< BOMデータ取得
+	void GetEol(CMemory* pcmemEol, EEolType eEolType) override;
 
 public:
 	//実装

--- a/sakura_core/charset/CUtf8.h
+++ b/sakura_core/charset/CUtf8.h
@@ -34,16 +34,16 @@ class CUtf8 : public CCodeBase{
 public:
 
 	//CCodeBaseインターフェース
-	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst){	//!< 特定コード → UNICODE    変換
+	EConvertResult CodeToUnicode(const CMemory& cSrc, CNativeW* pDst) override{	//!< 特定コード → UNICODE    変換
 		return UTF8ToUnicode(cSrc, pDst);
 	}
-	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst){	//!< UNICODE    → 特定コード 変換
+	EConvertResult UnicodeToCode(const CNativeW& cSrc, CMemory* pDst) override{	//!< UNICODE    → 特定コード 変換
 		return UnicodeToUTF8(cSrc, pDst);
 	}
-	void GetBom(CMemory* pcmemBom);																			//!< BOMデータ取得
-	void GetEol(CMemory* pcmemEol, EEolType eEolType);
+	void GetBom(CMemory* pcmemBom) override;																			//!< BOMデータ取得
+	void GetEol(CMemory* pcmemEol, EEolType eEolType) override;
 	EConvertResult _UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar, const bool CESU8Mode);			//!< UNICODE → Hex 変換
-	EConvertResult UnicodeToHex(const wchar_t* ps, const int nsl, WCHAR* pd, const CommonSetting_Statusbar* psStatusbar){ return _UnicodeToHex(ps, nsl, pd, psStatusbar, false); }
+	EConvertResult UnicodeToHex(const wchar_t* ps, const int nsl, WCHAR* pd, const CommonSetting_Statusbar* psStatusbar) override{ return _UnicodeToHex(ps, nsl, pd, psStatusbar, false); }
 
 public:
 	// UTF-8 / CESU-8 <-> Unicodeコード変換

--- a/sakura_core/convert/CConvert_HaneisuToZeneisu.h
+++ b/sakura_core/convert/CConvert_HaneisuToZeneisu.h
@@ -28,9 +28,9 @@
 #include "CConvert.h"
 
 //!半角英数→全角英数
-class CConvert_HaneisuToZeneisu : public CConvert{
+class CConvert_HaneisuToZeneisu final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 #endif /* SAKURA_CCONVERT_HANEISUTOZENEISU_AA3930A7_12A8_43A0_B7B4_6BF05F3898069_H_ */

--- a/sakura_core/convert/CConvert_HankataToZenhira.h
+++ b/sakura_core/convert/CConvert_HankataToZenhira.h
@@ -28,9 +28,9 @@
 #include "CConvert.h"
 
 //!半角カナ→全角ひらがな
-class CConvert_HankataToZenhira : public CConvert{
+class CConvert_HankataToZenhira final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 #endif /* SAKURA_CCONVERT_HANKATATOZENHIRA_8F5785BC_BD5F_4034_8C71_A645A69FBE3B9_H_ */

--- a/sakura_core/convert/CConvert_HankataToZenkata.h
+++ b/sakura_core/convert/CConvert_HankataToZenkata.h
@@ -28,9 +28,9 @@
 #include "CConvert.h"
 
 //!半角カナ→全角カナ
-class CConvert_HankataToZenkata : public CConvert{
+class CConvert_HankataToZenkata final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 #endif /* SAKURA_CCONVERT_HANKATATOZENKATA_45FB10FC_3254_4F79_A244_077BED31A42B9_H_ */

--- a/sakura_core/convert/CConvert_SpaceToTab.h
+++ b/sakura_core/convert/CConvert_SpaceToTab.h
@@ -27,14 +27,14 @@
 
 #include "CConvert.h"
 
-class CConvert_SpaceToTab : public CConvert{
+class CConvert_SpaceToTab final : public CConvert{
 public:
 	CConvert_SpaceToTab(int nTabWidth, int nStartColumn, bool bExtEol)
 	: m_nTabWidth(nTabWidth), m_nStartColumn(nStartColumn), m_bExtEol(bExtEol)
 	{
 	}
 
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 
 private:
 	int m_nTabWidth;

--- a/sakura_core/convert/CConvert_TabToSpace.h
+++ b/sakura_core/convert/CConvert_TabToSpace.h
@@ -27,14 +27,14 @@
 
 #include "CConvert.h"
 
-class CConvert_TabToSpace : public CConvert{
+class CConvert_TabToSpace final : public CConvert{
 public:
 	CConvert_TabToSpace(int nTabWidth, int nStartColumn, bool bExtEol)
 	: m_nTabWidth(nTabWidth), m_nStartColumn(nStartColumn), m_bExtEol(bExtEol)
 	{
 	}
 
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 
 private:
 	int m_nTabWidth;

--- a/sakura_core/convert/CConvert_ToHankaku.h
+++ b/sakura_core/convert/CConvert_ToHankaku.h
@@ -28,9 +28,9 @@
 #include "CConvert.h"
 
 //!半角にできるものは全部半角に変換
-class CConvert_ToHankaku : public CConvert{
+class CConvert_ToHankaku final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 enum EToHankakuMode{

--- a/sakura_core/convert/CConvert_ToLower.h
+++ b/sakura_core/convert/CConvert_ToLower.h
@@ -27,9 +27,9 @@
 
 #include "CConvert.h"
 
-class CConvert_ToLower : public CConvert{
+class CConvert_ToLower final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 #endif /* SAKURA_CCONVERT_TOLOWER_B0D85F8A_5D8F_44CC_A027_5A452BE56109_H_ */

--- a/sakura_core/convert/CConvert_ToUpper.h
+++ b/sakura_core/convert/CConvert_ToUpper.h
@@ -27,9 +27,9 @@
 
 #include "CConvert.h"
 
-class CConvert_ToUpper : public CConvert{
+class CConvert_ToUpper final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 #endif /* SAKURA_CCONVERT_TOUPPER_98DEA386_E8FA_466B_AE7A_6A708EC39F0D9_H_ */

--- a/sakura_core/convert/CConvert_ToZenhira.h
+++ b/sakura_core/convert/CConvert_ToZenhira.h
@@ -28,9 +28,9 @@
 #include "CConvert.h"
 
 //!できる限り全角ひらがなにする
-class CConvert_ToZenhira : public CConvert{
+class CConvert_ToZenhira final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 #endif /* SAKURA_CCONVERT_TOZENHIRA_A2D60F31_CBF3_427D_A622_A585F1F3E667_H_ */

--- a/sakura_core/convert/CConvert_ToZenkata.h
+++ b/sakura_core/convert/CConvert_ToZenkata.h
@@ -28,9 +28,9 @@
 #include "CConvert.h"
 
 //!できる限り全角カタカナにする
-class CConvert_ToZenkata : public CConvert{
+class CConvert_ToZenkata final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 #endif /* SAKURA_CCONVERT_TOZENKATA_F23E454A_B7B2_4655_910D_EF97F0A98E6A_H_ */

--- a/sakura_core/convert/CConvert_Trim.h
+++ b/sakura_core/convert/CConvert_Trim.h
@@ -27,12 +27,12 @@
 
 #include "CConvert.h"
 
-class CConvert_Trim : public CConvert{
+class CConvert_Trim final : public CConvert{
 public:
 	CConvert_Trim(bool bLeft, bool bExtEol) : m_bLeft(bLeft), m_bExtEol(bExtEol) { }
 
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 
 private:
 	bool m_bLeft;

--- a/sakura_core/convert/CConvert_ZeneisuToHaneisu.h
+++ b/sakura_core/convert/CConvert_ZeneisuToHaneisu.h
@@ -28,9 +28,9 @@
 #include "CConvert.h"
 
 //!全角英数→半角英数
-class CConvert_ZeneisuToHaneisu : public CConvert{
+class CConvert_ZeneisuToHaneisu final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 #endif /* SAKURA_CCONVERT_ZENEISUTOHANEISU_AB71D3F0_338A_4B00_80A1_B11589BE1C759_H_ */

--- a/sakura_core/convert/CConvert_ZenkataToHankata.h
+++ b/sakura_core/convert/CConvert_ZenkataToHankata.h
@@ -28,9 +28,9 @@
 #include "CConvert.h"
 
 //!全角カナ→半角カナ
-class CConvert_ZenkataToHankata : public CConvert{
+class CConvert_ZenkataToHankata final : public CConvert{
 public:
-	bool DoConvert(CNativeW* pcData);
+	bool DoConvert(CNativeW* pcData) override;
 };
 
 #endif /* SAKURA_CCONVERT_ZENKATATOHANKATA_28EBC9B6_53BD_41BA_8D20_140D90CAC3469_H_ */

--- a/sakura_core/convert/CDecode_Base64Decode.h
+++ b/sakura_core/convert/CDecode_Base64Decode.h
@@ -32,9 +32,9 @@
 
 #include "convert/CDecode.h"
 
-class CDecode_Base64Decode : public CDecode{
+class CDecode_Base64Decode final : public CDecode{
 public:
-	bool DoDecode(const CNativeW& cData, CMemory* pcDst);
+	bool DoDecode(const CNativeW& cData, CMemory* pcDst) override;
 };
 
 #endif /* SAKURA_CDECODE_BASE64DECODE_FD175ABC_35B6_470E_850C_3F50E35320FF9_H_ */

--- a/sakura_core/convert/CDecode_UuDecode.h
+++ b/sakura_core/convert/CDecode_UuDecode.h
@@ -32,11 +32,11 @@
 
 #include "convert/CDecode.h"
 
-class CDecode_UuDecode : public CDecode{
+class CDecode_UuDecode final : public CDecode{
 
 	WCHAR m_aFilename[_MAX_PATH];
 public:
-	bool DoDecode(const CNativeW& cData, CMemory* pDst);
+	bool DoDecode(const CNativeW& cData, CMemory* pDst) override;
 	void CopyFilename( WCHAR *pcDst ) const { wcscpy( pcDst, m_aFilename ); }
 };
 

--- a/sakura_core/dlg/CDlgAbout.h
+++ b/sakura_core/dlg/CDlgAbout.h
@@ -44,17 +44,17 @@ protected:
 	WNDPROC m_pOldProc;
 };
 
-class CDlgAbout : public CDialog
+class CDlgAbout final : public CDialog
 {
 public:
 	int DoModal(HINSTANCE hInstance, HWND hwndParent);	/* モーダルダイアログの表示 */
 	//	Nov. 7, 2000 genta	標準以外のメッセージを捕捉する
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;
 protected:
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnBnClicked(int wID);
-	BOOL OnStnClicked(int wID);
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnBnClicked(int wID) override;
+	BOOL OnStnClicked(int wID) override;
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 private:
 	CUrlWnd m_UrlUrWnd;
 	CUrlWnd m_UrlGitWnd;

--- a/sakura_core/dlg/CDlgCancel.h
+++ b/sakura_core/dlg/CDlgCancel.h
@@ -54,7 +54,7 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	virtual BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnBnClicked(int wID) override;
 	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 };

--- a/sakura_core/dlg/CDlgCancel.h
+++ b/sakura_core/dlg/CDlgCancel.h
@@ -41,7 +41,7 @@ public:
 //	HWND Open( LPCWSTR );
 //	void Close( void );	/* モードレスダイアログの削除 */
 	BOOL IsCanceled( void ){ return m_bCANCEL; } /* IDCANCELボタンが押されたか？ */
-	INT_PTR DispatchEvent(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam);	/* ダイアログのメッセージ処理 *//* BOOL->INT_PTR 2008/7/18 Uchi*/
+	INT_PTR DispatchEvent(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam) override;	/* ダイアログのメッセージ処理 *//* BOOL->INT_PTR 2008/7/18 Uchi*/
 	void DeleteAsync( void );	/* 自動破棄を遅延実行する */	// 2008.05.28 ryoji
 
 //	HINSTANCE	m_hInstance;	/* アプリケーションインスタンスのハンドル */
@@ -54,9 +54,9 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnBnClicked(int wID);
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	virtual BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnBnClicked(int wID) override;
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/dlg/CDlgCompare.h
+++ b/sakura_core/dlg/CDlgCompare.h
@@ -20,7 +20,7 @@ class CDlgCompare;
 /*!
 	@brief ファイル比較ダイアログボックス
 */
-class CDlgCompare : public CDialog
+class CDlgCompare final : public CDialog
 {
 public:
 	/*
@@ -43,17 +43,17 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL OnBnClicked(int wID);
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	BOOL OnBnClicked(int wID) override;
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// 標準以外のメッセージを捕捉する
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnSize( WPARAM wParam, LPARAM lParam );
-	BOOL OnMove( WPARAM wParam, LPARAM lParam );
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
+	BOOL OnMove( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
 
-	void SetData( void );	/* ダイアログデータの設定 */
-	int GetData( void );	/* ダイアログデータの取得 */
+	void SetData( void ) override;	/* ダイアログデータの設定 */
+	int GetData( void ) override;	/* ダイアログデータの取得 */
 
 private:
 	POINT			m_ptDefaultSize;

--- a/sakura_core/dlg/CDlgCtrlCode.h
+++ b/sakura_core/dlg/CDlgCtrlCode.h
@@ -38,7 +38,7 @@ class CDlgCtrlCode;
 	@brief コントロールコード入力ダイアログボックス
 */
 //2007.10.18 kobake GetCharCode()を作成。
-class CDlgCtrlCode : public CDialog
+class CDlgCtrlCode final : public CDialog
 {
 public:
 	/*
@@ -57,13 +57,13 @@ private:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL	OnBnClicked(int wID);
-	BOOL	OnNotify( WPARAM wParam, LPARAM lParam );
-	LPVOID	GetHelpIdTable( void );
+	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL	OnBnClicked(int wID) override;
+	BOOL	OnNotify( WPARAM wParam, LPARAM lParam ) override;
+	LPVOID	GetHelpIdTable( void ) override;
 
-	void	SetData( void );	/* ダイアログデータの設定 */
-	int		GetData( void );	/* ダイアログデータの取得 */
+	void	SetData( void ) override;	/* ダイアログデータの設定 */
+	int		GetData( void ) override;	/* ダイアログデータの取得 */
 
 private:
 	/*

--- a/sakura_core/dlg/CDlgDiff.h
+++ b/sakura_core/dlg/CDlgDiff.h
@@ -39,7 +39,7 @@ class CDlgDiff;
 	@brief DIFF差分表示ダイアログボックス
 */
 //	Feb. 28, 2004 genta 最後に選択されていた番号を保存する
-class CDlgDiff : public CDialog
+class CDlgDiff final : public CDialog
 {
 public:
 	/*
@@ -56,19 +56,19 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL	OnBnClicked(int wID);
-	BOOL	OnLbnSelChange( HWND hwndCtl, int wID );
-	BOOL	OnLbnDblclk( int wID );
-	BOOL	OnEnChange( HWND hwndCtl, int wID );
-	LPVOID	GetHelpIdTable(void);
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// 標準以外のメッセージを捕捉する
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnSize( WPARAM wParam, LPARAM lParam );
-	BOOL OnMove( WPARAM wParam, LPARAM lParam );
+	BOOL	OnBnClicked(int wID) override;
+	BOOL	OnLbnSelChange( HWND hwndCtl, int wID ) override;
+	BOOL	OnLbnDblclk( int wID ) override;
+	BOOL	OnEnChange( HWND hwndCtl, int wID ) override;
+	LPVOID	GetHelpIdTable(void) override;
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
+	BOOL OnMove( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
 
-	void	SetData( void );	/* ダイアログデータの設定 */
-	int		GetData( void );	/* ダイアログデータの取得 */
+	void	SetData( void ) override;	/* ダイアログデータの設定 */
+	int		GetData( void ) override;	/* ダイアログデータの取得 */
 
 private:
 	int			m_nIndexSave;		// 最後に選択されていた番号

--- a/sakura_core/dlg/CDlgExec.h
+++ b/sakura_core/dlg/CDlgExec.h
@@ -20,7 +20,7 @@
 /*-----------------------------------------------------------------------
 クラスの宣言
 -----------------------------------------------------------------------*/
-class CDlgExec : public CDialog
+class CDlgExec final : public CDialog
 {
 public:
 	/*
@@ -42,12 +42,11 @@ protected:
 	SComboBoxItemDeleter m_comboDelCur;
 	CRecentCurDir m_cRecentCur;
 
-	/* オーバーライド? */
-	int GetData( void );	/* ダイアログデータの取得 */
-	void SetData( void );	/* ダイアログデータの設定 */
-	BOOL OnInitDialog(HWND hwnd, WPARAM wParam, LPARAM lParam);
-	BOOL OnBnClicked(int wID);
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	int GetData( void ) override;	/* ダイアログデータの取得 */
+	void SetData( void ) override;	/* ダイアログデータの設定 */
+	BOOL OnInitDialog(HWND hwnd, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnBnClicked(int wID) override;
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/dlg/CDlgFavorite.h
+++ b/sakura_core/dlg/CDlgFavorite.h
@@ -37,7 +37,7 @@
 
 //!「履歴とお気に入りの管理」ダイアログ
 //アクセス方法：[設定] - [履歴の管理]
-class CDlgFavorite : public CDialog
+class CDlgFavorite final : public CDialog
 {
 public:
 	/*
@@ -55,18 +55,18 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL	OnBnClicked(int wID);
-	BOOL	OnNotify( WPARAM wParam, LPARAM lParam );
-	BOOL	OnActivate( WPARAM wParam, LPARAM lParam );
-	LPVOID	GetHelpIdTable( void );
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// 標準以外のメッセージを捕捉する
-	BOOL	OnSize( WPARAM wParam, LPARAM lParam );
-	BOOL	OnMove( WPARAM wParam, LPARAM lParam );
+	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL	OnBnClicked(int wID) override;
+	BOOL	OnNotify( WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnActivate( WPARAM wParam, LPARAM lParam ) override;
+	LPVOID	GetHelpIdTable( void ) override;
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
+	BOOL	OnSize( WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnMove( WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnMinMaxInfo( LPARAM lParam );
 
-	void	SetData( void );	/* ダイアログデータの設定 */
-	int		GetData( void );	/* ダイアログデータの取得 */
+	void	SetData( void ) override;	/* ダイアログデータの設定 */
+	int		GetData( void ) override;	/* ダイアログデータの取得 */
 
 	void	TabSelectChange(bool bSetFocus);
 	bool	RefreshList( void );

--- a/sakura_core/dlg/CDlgFileUpdateQuery.h
+++ b/sakura_core/dlg/CDlgFileUpdateQuery.h
@@ -42,15 +42,15 @@ enum EFileUpdateQuery {
 	EFUQ_AUTOLOAD		= 4		//!< 以後未編集で再ロード
 };
 
-class CDlgFileUpdateQuery : public CDialog {
+class CDlgFileUpdateQuery final : public CDialog {
 public:
 	CDlgFileUpdateQuery(const WCHAR* filename, bool IsModified)
 	: m_pFilename( filename )
 	, m_bModified( IsModified )
 	{
 	}
-	virtual BOOL OnInitDialog( HWND hWnd, WPARAM wParam, LPARAM lParam );
-	virtual BOOL OnBnClicked( int id );
+	BOOL OnInitDialog( HWND hWnd, WPARAM wParam, LPARAM lParam ) override;
+	BOOL OnBnClicked( int id ) override;
 
 private:
 	const WCHAR* m_pFilename;

--- a/sakura_core/dlg/CDlgFind.h
+++ b/sakura_core/dlg/CDlgFind.h
@@ -21,7 +21,7 @@
 /*-----------------------------------------------------------------------
 クラスの宣言
 -----------------------------------------------------------------------*/
-class CDlgFind : public CDialog
+class CDlgFind final : public CDialog
 {
 public:
 	/*
@@ -49,18 +49,17 @@ public:
 protected:
 //@@@ 2002.2.2 YAZAKI CShareDataに移動
 //	void AddToSearchKeyArr( const char* );
-	/* オーバーライド? */
-	BOOL OnCbnDropDown( HWND hwndCtl, int wID );
-	int GetData( void );		/* ダイアログデータの取得 */
+	BOOL OnCbnDropDown( HWND hwndCtl, int wID ) override;
+	int GetData( void ) override;		/* ダイアログデータの取得 */
 	void SetCombosList( void );	/* 検索文字列/置換後文字列リストの設定 */
-	void SetData( void );		/* ダイアログデータの設定 */
-	BOOL OnInitDialog(HWND hwnd, WPARAM wParam, LPARAM lParam);
-	BOOL OnDestroy();
-	BOOL OnBnClicked(int wID);
-	BOOL OnActivate( WPARAM wParam, LPARAM lParam );	// 2009.11.29 ryoji
+	void SetData( void ) override;		/* ダイアログデータの設定 */
+	BOOL OnInitDialog(HWND hwnd, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnDestroy() override;
+	BOOL OnBnClicked(int wID) override;
+	BOOL OnActivate( WPARAM wParam, LPARAM lParam ) override;	// 2009.11.29 ryoji
 
-	// virtual BOOL OnKeyDown( WPARAM wParam, LPARAM lParam );
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	// BOOL OnKeyDown( WPARAM wParam, LPARAM lParam ) override;
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -36,7 +36,7 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	BOOL OnCbnDropDown( HWND hwndCtl, int wID );
+	BOOL OnCbnDropDown( HWND hwndCtl, int wID ) override;
 	int DoModal( HINSTANCE, HWND, const WCHAR* );	/* モーダルダイアログの表示 */
 //	HWND DoModeless( HINSTANCE, HWND, const char* );	/* モードレスダイアログの表示 */
 
@@ -80,13 +80,13 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnDestroy();
-	BOOL OnBnClicked(int wID);
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnDestroy() override;
+	BOOL OnBnClicked(int wID) override;
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 
-	void SetData( void );	/* ダイアログデータの設定 */
-	int GetData( void );	/* ダイアログデータの取得 */
+	void SetData( void ) override;	/* ダイアログデータの設定 */
+	int GetData( void ) override;	/* ダイアログデータの取得 */
 	void SetDataFromThisText(bool bChecked);	/* 現在編集中ファイルから検索チェックでの設定 */
 };
 

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -22,7 +22,7 @@ class CDlgGrep;
 #include "dlg/CDlgGrep.h"
 
 //! GREP置換ダイアログボックス
-class CDlgGrepReplace : public CDlgGrep
+class CDlgGrepReplace final : public CDlgGrep
 {
 public:
 	/*
@@ -46,13 +46,13 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnDestroy();
-	BOOL OnBnClicked(int wID);
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnDestroy() override;
+	BOOL OnBnClicked(int wID) override;
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 
-	void SetData( void );	/* ダイアログデータの設定 */
-	int GetData( void );	/* ダイアログデータの取得 */
+	void SetData( void ) override;	/* ダイアログデータの設定 */
+	int GetData( void ) override;	/* ダイアログデータの取得 */
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/dlg/CDlgJump.h
+++ b/sakura_core/dlg/CDlgJump.h
@@ -21,7 +21,7 @@ class CDlgJump;
 
 #include "dlg/CDialog.h"
 //! 指定行へのジャンプダイアログボックス
-class CDlgJump : public CDialog
+class CDlgJump final : public CDialog
 {
 public:
 	/*
@@ -41,12 +41,12 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL OnNotify(WPARAM wParam, LPARAM lParam);	//	Oct. 6, 2000 JEPRO added for Spin control
-	BOOL OnCbnSelChange(HWND hwndCtl, int wID);
-	BOOL OnBnClicked(int wID);
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
-	void SetData( void );	/* ダイアログデータの設定 */
-	int GetData( void );	/* ダイアログデータの取得 */
+	BOOL OnNotify(WPARAM wParam, LPARAM lParam) override;	//	Oct. 6, 2000 JEPRO added for Spin control
+	BOOL OnCbnSelChange(HWND hwndCtl, int wID) override;
+	BOOL OnBnClicked(int wID) override;
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	void SetData( void ) override;	/* ダイアログデータの設定 */
+	int GetData( void ) override;	/* ダイアログデータの取得 */
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/dlg/CDlgPluginOption.h
+++ b/sakura_core/dlg/CDlgPluginOption.h
@@ -52,7 +52,7 @@ static const wstring	OPTION_TYPE_INT  = wstring( L"int" );
 static const wstring	OPTION_TYPE_SEL  = wstring( L"sel" );
 static const wstring	OPTION_TYPE_DIR  = wstring( L"dir" );
 
-class CDlgPluginOption : public CDialog
+class CDlgPluginOption final : public CDialog
 {
 public:
 	/*
@@ -70,16 +70,16 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL	OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam );
-	BOOL	OnBnClicked(int wID);
-	BOOL	OnNotify( WPARAM wParam, LPARAM lParam );
-	BOOL	OnCbnSelChange( HWND hwndCtl, int wID );
-	BOOL	OnEnChange( HWND hwndCtl, int wID );
-	BOOL	OnActivate( WPARAM wParam, LPARAM lParam );
-	LPVOID	GetHelpIdTable( void );
+	BOOL	OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnBnClicked(int wID) override;
+	BOOL	OnNotify( WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnCbnSelChange( HWND hwndCtl, int wID ) override;
+	BOOL	OnEnChange( HWND hwndCtl, int wID ) override;
+	BOOL	OnActivate( WPARAM wParam, LPARAM lParam ) override;
+	LPVOID	GetHelpIdTable( void ) override;
 
-	void	SetData( void );	/* ダイアログデータの設定 */
-	int		GetData( void );	/* ダイアログデータの取得 */
+	void	SetData( void ) override;	/* ダイアログデータの設定 */
+	int		GetData( void ) override;	/* ダイアログデータの取得 */
 
 	void	ChangeListPosition( void );					// 編集領域をリストビューに合せて切替える
 	void	MoveFocusToEdit( void );					// 編集領域にフォーカスを移す

--- a/sakura_core/dlg/CDlgPrintSetting.h
+++ b/sakura_core/dlg/CDlgPrintSetting.h
@@ -38,7 +38,7 @@
 
 	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 */
-class CDlgPrintSetting : public CDialog
+class CDlgPrintSetting final : public CDialog
 {
 public:
 	/*
@@ -63,17 +63,17 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	void SetData( void );	/* ダイアログデータの設定 */
-	int GetData( void );	/* ダイアログデータの取得 */
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnDestroy( void );
-	BOOL OnNotify(WPARAM wParam, LPARAM lParam);
-	BOOL OnCbnSelChange(HWND hwndCtl, int wID);
-	BOOL OnBnClicked(int wID);
-	BOOL OnStnClicked(int wID);
-	BOOL OnEnChange( HWND hwndCtl, int wID );
-	BOOL OnEnKillFocus( HWND hwndCtl, int wID );
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	void SetData( void ) override;	/* ダイアログデータの設定 */
+	int GetData( void ) override;	/* ダイアログデータの取得 */
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnDestroy( void ) override;
+	BOOL OnNotify(WPARAM wParam, LPARAM lParam) override;
+	BOOL OnCbnSelChange(HWND hwndCtl, int wID) override;
+	BOOL OnBnClicked(int wID) override;
+	BOOL OnStnClicked(int wID) override;
+	BOOL OnEnChange( HWND hwndCtl, int wID ) override;
+	BOOL OnEnKillFocus( HWND hwndCtl, int wID ) override;
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 
 	void OnChangeSettingType(BOOL bGetData);	/* 設定のタイプが変わった */
 	void OnSpin(int nCtrlId, BOOL bDown);	/* スピンコントロールの処理 */

--- a/sakura_core/dlg/CDlgProfileMgr.h
+++ b/sakura_core/dlg/CDlgProfileMgr.h
@@ -42,7 +42,7 @@ struct SProfileSettings
 	bool m_bDefaultSelect;
 };
 
-class CDlgProfileMgr : public CDialog
+class CDlgProfileMgr final : public CDialog
 {
 public:
 	/*
@@ -56,14 +56,14 @@ public:
 
 protected:
 
-	BOOL	OnBnClicked(int wID);
-	INT_PTR	DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );
+	BOOL	OnBnClicked(int wID) override;
+	INT_PTR	DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;
 
-	void	SetData();	/* ダイアログデータの設定 */
+	void	SetData() override;	/* ダイアログデータの設定 */
 	void	SetData(int nSelIndex);	/* ダイアログデータの設定 */
-	int		GetData();	/* ダイアログデータの取得 */
+	int		GetData() override;	/* ダイアログデータの取得 */
 	int		GetData(bool bStart);	/* ダイアログデータの取得 */
-	LPVOID	GetHelpIdTable(void);
+	LPVOID	GetHelpIdTable(void) override;
 
 	void	UpdateIni();
 	void	CreateProf();

--- a/sakura_core/dlg/CDlgProperty.h
+++ b/sakura_core/dlg/CDlgProperty.h
@@ -38,7 +38,7 @@ class CDlgProperty;
 /*-----------------------------------------------------------------------
 クラスの宣言
 -----------------------------------------------------------------------*/
-class CDlgProperty : public CDialog
+class CDlgProperty final : public CDialog
 {
 public:
 	int DoModal(HINSTANCE hInstance, HWND hwndParent, LPARAM lParam);	/* モーダルダイアログの表示 */
@@ -46,9 +46,9 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL OnBnClicked(int wID);
-	void SetData( void );	/* ダイアログデータの設定 */
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	BOOL OnBnClicked(int wID) override;
+	void SetData( void ) override;	/* ダイアログデータの設定 */
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 };
 ///////////////////////////////////////////////////////////////////////
 #endif /* _CDLGPROPERTY_H_ */

--- a/sakura_core/dlg/CDlgReplace.h
+++ b/sakura_core/dlg/CDlgReplace.h
@@ -28,7 +28,7 @@
 /*!
 	@brief 置換ダイアログボックス
 */
-class CDlgReplace : public CDialog
+class CDlgReplace final : public CDialog
 {
 public:
 	/*
@@ -67,16 +67,16 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL OnCbnDropDown( HWND hwndCtl, int wID );
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnDestroy();
-	BOOL OnBnClicked(int wID);
-	BOOL OnActivate( WPARAM wParam, LPARAM lParam );	// 2009.11.29 ryoji
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	BOOL OnCbnDropDown( HWND hwndCtl, int wID ) override;
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnDestroy() override;
+	BOOL OnBnClicked(int wID) override;
+	BOOL OnActivate( WPARAM wParam, LPARAM lParam ) override;	// 2009.11.29 ryoji
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 
-	void SetData( void );		/* ダイアログデータの設定 */
+	void SetData( void ) override;		/* ダイアログデータの設定 */
 	void SetCombosList( void );	/* 検索文字列/置換後文字列リストの設定 */
-	int GetData( void );		/* ダイアログデータの取得 */
+	int GetData( void ) override;		/* ダイアログデータの取得 */
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/dlg/CDlgSetCharSet.h
+++ b/sakura_core/dlg/CDlgSetCharSet.h
@@ -17,7 +17,7 @@
 #include "dlg/CDialog.h"
 
 //! 文字コードセット設定ダイアログボックス
-class CDlgSetCharSet : public CDialog
+class CDlgSetCharSet final : public CDialog
 {
 public:
 	/*
@@ -39,13 +39,13 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL	OnBnClicked(int wID);
-	BOOL	OnCbnSelChange(HWND hwndCtl, int wID);
-	LPVOID	GetHelpIdTable( void );
+	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL	OnBnClicked(int wID) override;
+	BOOL	OnCbnSelChange(HWND hwndCtl, int wID) override;
+	LPVOID	GetHelpIdTable( void ) override;
 
-	void	SetData( void );	/* ダイアログデータの設定 */
-	int 	GetData( void );	/* ダイアログデータの取得 */
+	void	SetData( void ) override;	/* ダイアログデータの設定 */
+	int 	GetData( void ) override;	/* ダイアログデータの取得 */
 
 	void	SetBOM( void );		// BOM の設定
 };

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -48,7 +48,7 @@ class CSortedTagJumpList;
 	ダイレクトタグジャンプで複数の候補がある場合及び
 	キーワード指定タグジャンプのためのダイアログボックス制御
 */
-class CDlgTagJumpList : public CDialog
+class CDlgTagJumpList final : public CDialog
 {
 public:
 	/*
@@ -74,19 +74,19 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL	OnBnClicked(int wID);
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );
-	BOOL	OnSize( WPARAM wParam, LPARAM lParam );
-	BOOL	OnMove( WPARAM wParam, LPARAM lParam );
+	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL	OnBnClicked(int wID) override;
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnSize( WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnMove( WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnMinMaxInfo( LPARAM lParam );
-	BOOL	OnNotify( WPARAM wParam, LPARAM lParam );
+	BOOL	OnNotify( WPARAM wParam, LPARAM lParam ) override;
 	//	@@ 2005.03.31 MIK キーワード入力エリアのイベント処理
-	BOOL	OnCbnSelChange( HWND hwndCtl, int wID );
-	BOOL	OnCbnEditChange( HWND hwndCtl, int wID );
-	//BOOL	OnEnChange( HWND hwndCtl, int wID );
-	BOOL	OnTimer( WPARAM wParam );
-	LPVOID	GetHelpIdTable( void );
+	BOOL	OnCbnSelChange( HWND hwndCtl, int wID ) override;
+	BOOL	OnCbnEditChange( HWND hwndCtl, int wID ) override;
+	//BOOL	OnEnChange( HWND hwndCtl, int wID ) override;
+	BOOL	OnTimer( WPARAM wParam ) override;
+	LPVOID	GetHelpIdTable( void ) override;
 
 private:
 	struct STagFindState {
@@ -109,8 +109,8 @@ private:
 	void	StopTimer( void );
 	void	StartTimer(int nDelay);
 
-	void	SetData( void );	/* ダイアログデータの設定 */
-	int		GetData( void );	/* ダイアログデータの取得 */
+	void	SetData( void ) override;	/* ダイアログデータの設定 */
+	int		GetData( void ) override;	/* ダイアログデータの取得 */
 	void	UpdateData(bool bInit);	//	@@ 2005.03.31 MIK
 
 	WCHAR	*GetNameByType( const WCHAR type, const WCHAR *name );	//タイプを名前に変換する。

--- a/sakura_core/dlg/CDlgTagsMake.h
+++ b/sakura_core/dlg/CDlgTagsMake.h
@@ -37,7 +37,7 @@ class CDlgTagsMake;
 /*!
 	@brief タグファイル作成ダイアログボックス
 */
-class CDlgTagsMake : public CDialog
+class CDlgTagsMake final : public CDialog
 {
 public:
 	/*
@@ -58,11 +58,11 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL	OnBnClicked(int wID);
-	LPVOID	GetHelpIdTable(void);
+	BOOL	OnBnClicked(int wID) override;
+	LPVOID	GetHelpIdTable(void) override;
 
-	void	SetData( void );	/* ダイアログデータの設定 */
-	int		GetData( void );	/* ダイアログデータの取得 */
+	void	SetData( void ) override;	/* ダイアログデータの設定 */
+	int		GetData( void ) override;	/* ダイアログデータの取得 */
 
 private:
 	void SelectFolder( HWND hwndDlg );

--- a/sakura_core/dlg/CDlgWinSize.h
+++ b/sakura_core/dlg/CDlgWinSize.h
@@ -39,7 +39,7 @@
 	共通設定のウィンドウ設定で，ウィンドウ位置を指定するために補助的に
 	使用されるダイアログボックス
 */
-class CDlgWinSize : public CDialog
+class CDlgWinSize final : public CDialog
 {
 public:
 	CDlgWinSize();
@@ -49,11 +49,11 @@ public:
 
 protected:
 
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnBnClicked(int wID);
-	int  GetData( void );
-	void SetData( void );
-	LPVOID GetHelpIdTable( void );
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnBnClicked(int wID) override;
+	int  GetData( void ) override;
+	void SetData( void ) override;
+	LPVOID GetHelpIdTable( void ) override;
 
 	void RenewItemState( void );
 

--- a/sakura_core/dlg/CDlgWindowList.h
+++ b/sakura_core/dlg/CDlgWindowList.h
@@ -32,24 +32,24 @@
 #define SAKURA_CWINDOWLIST_H_
 
 #include "dlg/CDialog.h"
-class CDlgWindowList : public CDialog
+class CDlgWindowList final : public CDialog
 {
 public:
 	CDlgWindowList();
 
 	int DoModal(HINSTANCE hInstance, HWND hwndParent, LPARAM lParam);
 protected:
-	BOOL	OnBnClicked(int wID);
-	LPVOID	GetHelpIdTable();
-	INT_PTR DispatchEvent(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam);
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnSize(WPARAM wParam, LPARAM lParam);
-	BOOL OnMove(WPARAM wParam, LPARAM lParam);
+	BOOL	OnBnClicked(int wID) override;
+	LPVOID	GetHelpIdTable() override;
+	INT_PTR DispatchEvent(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnSize(WPARAM wParam, LPARAM lParam) override;
+	BOOL OnMove(WPARAM wParam, LPARAM lParam) override;
 	BOOL OnMinMaxInfo(LPARAM lParam);
-	BOOL OnActivate(WPARAM wParam, LPARAM lParam);
+	BOOL OnActivate(WPARAM wParam, LPARAM lParam) override;
 
-	void SetData();
-	int  GetData();
+	void SetData() override;
+	int  GetData() override;
 
 	void GetDataListView(std::vector<HWND>& aHwndList);
 	void CommandClose();

--- a/sakura_core/doc/CDocEditor.h
+++ b/sakura_core/doc/CDocEditor.h
@@ -40,11 +40,11 @@ public:
 	//                         イベント                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//ロード前後
-	void OnBeforeLoad(SLoadInfo* sLoadInfo);
-	void OnAfterLoad(const SLoadInfo& sLoadInfo);
+	void OnBeforeLoad(SLoadInfo* sLoadInfo) override;
+	void OnAfterLoad(const SLoadInfo& sLoadInfo) override;
 
 	//セーブ前後
-	void OnAfterSave(const SSaveInfo& sSaveInfo);
+	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           状態                              //

--- a/sakura_core/doc/CDocLocker.h
+++ b/sakura_core/doc/CDocLocker.h
@@ -35,11 +35,11 @@ public:
 	void Clear(void) { m_bIsDocWritable = true; }
 
 	//ロード前後
-	void OnAfterLoad(const SLoadInfo& sLoadInfo);
+	void OnAfterLoad(const SLoadInfo& sLoadInfo) override;
 	
 	//セーブ前後
-	void OnBeforeSave(const SSaveInfo& sSaveInfo);
-	void OnAfterSave(const SSaveInfo& sSaveInfo);
+	void OnBeforeSave(const SSaveInfo& sSaveInfo) override;
+	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
 
 	//状態
 	bool IsDocWritable() const{ return m_bIsDocWritable; }

--- a/sakura_core/docplus/CModifyManager.h
+++ b/sakura_core/docplus/CModifyManager.h
@@ -37,7 +37,7 @@ class CModifyManager : public TSingleton<CModifyManager>, public CDocListenerEx{
 	CModifyManager(){}
 
 public:
-	void OnAfterSave(const SSaveInfo& sSaveInfo);
+	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
 };
 
 //! 行に付加するModified情報

--- a/sakura_core/env/DLLSHAREDATA.cpp
+++ b/sakura_core/env/DLLSHAREDATA.cpp
@@ -55,9 +55,9 @@ int CShareDataLockCounter::GetLockCounter(){
 	return GetDllShareData().m_nLockCount;
 }
 
-class CLockCancel: public CDlgCancel{
+class CLockCancel final: public CDlgCancel{
 public:
-	virtual BOOL OnInitDialog( HWND hwnd, WPARAM wParam, LPARAM lParam ){
+	BOOL OnInitDialog( HWND hwnd, WPARAM wParam, LPARAM lParam ) override{
 		BOOL ret = CDlgCancel::OnInitDialog(hwnd, wParam, lParam);
 		HWND hwndCancel = GetHwnd();
 		HWND hwndMsg = ::GetDlgItem(hwndCancel, IDC_STATIC_MSG);

--- a/sakura_core/func/CFuncKeyWnd.h
+++ b/sakura_core/func/CFuncKeyWnd.h
@@ -23,7 +23,7 @@ class CEditDoc; // 2002/2/10 aroka
 
 //! ファンクションキーウィンドウ
 //	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-class CFuncKeyWnd : public CWnd
+class CFuncKeyWnd final : public CWnd
 {
 public:
 	/*
@@ -62,13 +62,13 @@ protected:
 	int CalcButtonSize( void );	/* ボタンのサイズを計算 */
 
 	/* 仮想関数 */
-	virtual void AfterCreateWindow( void ){}	// ウィンドウ作成後の処理	// 2007.03.13 ryoji 可視化しない
+	void AfterCreateWindow( void ) override{}	// ウィンドウ作成後の処理	// 2007.03.13 ryoji 可視化しない
 
 	/* 仮想関数 メッセージ処理 詳しくは実装を参照 */
-	virtual LRESULT OnTimer(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);	// WM_TIMERタイマーの処理
-	virtual LRESULT OnCommand(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);	// WM_COMMAND処理
-	virtual LRESULT OnSize(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);// WM_SIZE処理
-	virtual LRESULT OnDestroy(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);// WM_DESTROY処理
+	LRESULT OnTimer(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;	// WM_TIMERタイマーの処理
+	LRESULT OnCommand(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) override;	// WM_COMMAND処理
+	LRESULT OnSize(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;// WM_SIZE処理
+	LRESULT OnDestroy(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;// WM_DESTROY処理
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/io/CBinaryStream.h
+++ b/sakura_core/io/CBinaryStream.h
@@ -27,7 +27,7 @@
 
 #include "CStream.h"
 
-class CBinaryInputStream : public CStream{
+class CBinaryInputStream final : public CStream{
 public:
 	CBinaryInputStream(LPCWSTR pszFilePath);
 
@@ -39,7 +39,7 @@ public:
 	int Read(void* pBuffer, int nSizeInBytes);
 };
 
-class CBinaryOutputStream : public COutputStream{
+class CBinaryOutputStream final : public COutputStream{
 public:
 	CBinaryOutputStream(LPCWSTR pszFilePath, bool bExceptionMode = false);
 };

--- a/sakura_core/io/CTextStream.h
+++ b/sakura_core/io/CTextStream.h
@@ -54,7 +54,7 @@ private:
 
 //テキスト出力ストリーム
 // 2008.01.26 kobake 出力文字コードを任意で指定できるように変更
-class CTextOutputStream : public COutputStream{
+class CTextOutputStream final : public COutputStream{
 public:
 	//コンストラクタ・デストラクタ
 	CTextOutputStream(const WCHAR* pszPath, ECodeType eCodeType = CODE_UTF8, bool bExceptionMode = false, bool bBom = true);
@@ -72,7 +72,7 @@ private:
 };
 
 //テキスト入力ストリーム。相対パスの場合はINIファイルのパスからの相対パスとして開く。
-class CTextInputStream_AbsIni : public CTextInputStream{
+class CTextInputStream_AbsIni final : public CTextInputStream{
 public:
 	CTextInputStream_AbsIni(const WCHAR* pszPath, bool bOrExedir = true);
 };

--- a/sakura_core/macro/CKeyMacroMgr.h
+++ b/sakura_core/macro/CKeyMacroMgr.h
@@ -50,9 +50,9 @@ public:
 	BOOL SaveKeyMacro( HINSTANCE hInstance, const WCHAR* pszPath) const;	/* CMacroの列を、キーボードマクロに保存 */
 	//@@@2002.2.2 YAZAKI PPA.DLLアリ/ナシ共存のためvirtualに。
 	//	2007.07.20 genta flags追加
-	virtual bool ExecKeyMacro( class CEditView* pcEditView, int flags ) const;	/* キーボードマクロの実行 */
-	virtual BOOL LoadKeyMacro( HINSTANCE hInstance, const WCHAR* pszPath);		/* キーボードマクロをファイルから読み込む */
-	virtual BOOL LoadKeyMacroStr( HINSTANCE hInstance, const WCHAR* pszCode);	/* キーボードマクロを文字列から読み込む */
+	bool ExecKeyMacro( class CEditView* pcEditView, int flags ) const override;	/* キーボードマクロの実行 */
+	BOOL LoadKeyMacro( HINSTANCE hInstance, const WCHAR* pszPath) override;		/* キーボードマクロをファイルから読み込む */
+	BOOL LoadKeyMacroStr( HINSTANCE hInstance, const WCHAR* pszCode) override;	/* キーボードマクロを文字列から読み込む */
 	
 	// Apr. 29, 2002 genta
 	static CMacroManagerBase* Creator(const WCHAR* ext);

--- a/sakura_core/macro/CPPAMacroMgr.h
+++ b/sakura_core/macro/CPPAMacroMgr.h
@@ -24,7 +24,7 @@
 クラスの宣言
 -----------------------------------------------------------------------*/
 //! PPAマクロ
-class CPPAMacroMgr: public CMacroManagerBase
+class CPPAMacroMgr final : public CMacroManagerBase
 {
 public:
 	/*
@@ -36,9 +36,9 @@ public:
 	/*
 	||	PPA.DLLに委譲する部分
 	*/
-	virtual bool ExecKeyMacro( class CEditView* pcEditView, int flags ) const;	/* PPAマクロの実行 */
-	virtual BOOL LoadKeyMacro( HINSTANCE hInstance, const WCHAR* pszPath);		/* キーボードマクロをファイルから読み込み、CMacroの列に変換 */
-	virtual BOOL LoadKeyMacroStr( HINSTANCE hInstance, const WCHAR* pszCode);	/* キーボードマクロを文字列から読み込み、CMacroの列に変換 */
+	bool ExecKeyMacro( class CEditView* pcEditView, int flags ) const override;	/* PPAマクロの実行 */
+	BOOL LoadKeyMacro( HINSTANCE hInstance, const WCHAR* pszPath) override;		/* キーボードマクロをファイルから読み込み、CMacroの列に変換 */
+	BOOL LoadKeyMacroStr( HINSTANCE hInstance, const WCHAR* pszCode) override;	/* キーボードマクロを文字列から読み込み、CMacroの列に変換 */
 
 	static class CPPA m_cPPA;
 

--- a/sakura_core/macro/CWSH.h
+++ b/sakura_core/macro/CWSH.h
@@ -31,7 +31,7 @@ class CInterfaceObject: public ImplementsIUnknown<IDispatch>
  */
 typedef void (*ScriptErrorHandler)(BSTR Description, BSTR Source, void *Data);
 
-class CWSHClient : IWSHClient
+class CWSHClient final : IWSHClient
 {
 public:
 	// 型定義
@@ -46,7 +46,7 @@ public:
 	ScriptErrorHandler m_OnError;
 	void *m_Data;
 	bool m_Valid; ///< trueの場合スクリプトエンジンが使用可能。falseになる場合は ScriptErrorHandlerにエラー内容が通知されている。
-	virtual /*override*/ void* GetData() const { return this->m_Data; }
+	void* GetData() const override{ return this->m_Data; }
 	const List& GetInterfaceObjects() {	return this->m_IfObjArr; }
 
 	// 操作

--- a/sakura_core/macro/CWSHManager.h
+++ b/sakura_core/macro/CWSHManager.h
@@ -31,16 +31,16 @@ class CEditView;
 
 typedef void (*EngineCallback)(wchar_t *Ext, char *EngineName);
 
-class CWSHMacroManager: public CMacroManagerBase
+class CWSHMacroManager final : public CMacroManagerBase
 {
 public:
 	CWSHMacroManager(std::wstring const AEngineName);
 	virtual ~CWSHMacroManager();
 
 	//	2007.07.20 genta : flags追加
-	virtual bool ExecKeyMacro(CEditView *EditView, int flags) const;
-	virtual BOOL LoadKeyMacro(HINSTANCE hInstance, const WCHAR* pszPath);
-	virtual BOOL LoadKeyMacroStr(HINSTANCE hInstance, const WCHAR* pszCode);
+	bool ExecKeyMacro(CEditView *EditView, int flags) const override;
+	BOOL LoadKeyMacro(HINSTANCE hInstance, const WCHAR* pszPath) override;
+	BOOL LoadKeyMacroStr(HINSTANCE hInstance, const WCHAR* pszCode) override;
 
 	static CMacroManagerBase* Creator(const WCHAR* FileExt);
 	static void declare();

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -27,7 +27,7 @@
 
 #include "CNative.h"
 
-class CNativeA : public CNative{
+class CNativeA final : public CNative{
 public:
 	CNativeA() noexcept;
 	CNativeA( const CNativeA& rhs );

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -37,12 +37,12 @@ public:
 };
 
 //! 文字列への参照を保持するクラス
-class CStringRef : public IStringRef{
+class CStringRef final : public IStringRef{
 public:
 	CStringRef() : m_pData(NULL), m_nDataLen(0) { }
 	CStringRef(const wchar_t* pData, int nDataLen) : m_pData(pData), m_nDataLen(nDataLen) { }
-	const wchar_t*	GetPtr()		const{ return m_pData;    }
-	int				GetLength()		const{ return m_nDataLen; }
+	const wchar_t*	GetPtr()		const override{ return m_pData;    }
+	int				GetLength()		const override{ return m_nDataLen; }
 
 	//########補助
 	bool			IsValid()		const{ return m_pData!=NULL; }
@@ -53,7 +53,7 @@ private:
 };
 
 //! UNICODE文字列管理クラス
-class CNativeW : public CNative{
+class CNativeW final : public CNative{
 public:
 	//コンストラクタ・デストラクタ
 	CNativeW() noexcept;

--- a/sakura_core/outline/CDlgFileTree.h
+++ b/sakura_core/outline/CDlgFileTree.h
@@ -37,7 +37,7 @@
 /*!
 	@brief ファイルツリー設定ダイアログ
 */
-class CDlgFileTree : public CDialog
+class CDlgFileTree final : public CDialog
 {
 public:
 	CDlgFileTree();
@@ -45,12 +45,12 @@ public:
 	int DoModal(HINSTANCE hInstance, HWND hwndParent, LPARAM lParam);
 
 private:
-	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL	OnBnClicked(int wID);
-	BOOL	OnNotify(WPARAM wParam, LPARAM lParam);
-	LPVOID	GetHelpIdTable();
-	void	SetData();
-	int		GetData();
+	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL	OnBnClicked(int wID) override;
+	BOOL	OnNotify(WPARAM wParam, LPARAM lParam) override;
+	LPVOID	GetHelpIdTable() override;
+	void	SetData() override;
+	int		GetData() override;
 
 	void	SetDataInit();
 	void	SetDataItem(int nItemIndex);

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -58,7 +58,7 @@ public:
 };
 
 //!	アウトライン解析ダイアログボックス
-class CDlgFuncList : public CDialog
+class CDlgFuncList final : public CDialog
 {
 public:
 	/*
@@ -74,7 +74,7 @@ public:
 	EDockSide GetDockSide() { return m_eDockSide; }
 
 protected:
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	// 2007.11.07 ryoji 標準以外のメッセージを捕捉する
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 2007.11.07 ryoji 標準以外のメッセージを捕捉する
 
 	CommonSetting_OutLine& CommonSet(void){ return m_pShareData->m_Common.m_sOutline; }
 	STypeConfig& TypeSet(void){ return m_type; }
@@ -118,16 +118,16 @@ public:
 	int				m_nOutlineType;		/* アウトライン解析の種別 */
 	bool			m_bEditWndReady;	/* エディタ画面の準備完了 */
 protected:
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnBnClicked(int wID);
-	BOOL OnNotify(WPARAM wParam, LPARAM lParam);
-	BOOL OnSize( WPARAM wParam, LPARAM lParam );
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnBnClicked(int wID) override;
+	BOOL OnNotify(WPARAM wParam, LPARAM lParam) override;
+	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
-	BOOL OnDestroy(void); // 20060201 aroka
+	BOOL OnDestroy(void) override; // 20060201 aroka
 	BOOL OnCbnSelEndOk( HWND hwndCtl, int wID );
-	BOOL OnContextMenu(WPARAM wParam, LPARAM lParam);
-	void SetData();	/* ダイアログデータの設定 */
-	int GetData( void );	/* ダイアログデータの取得 */
+	BOOL OnContextMenu(WPARAM wParam, LPARAM lParam) override;
+	void SetData() override;	/* ダイアログデータの設定 */
+	int GetData( void ) override;	/* ダイアログデータの取得 */
 
 	/*
 	||  実装ヘルパ関数
@@ -156,7 +156,7 @@ protected:
 
 	// 2001.12.03 hor
 //	void SetTreeBookMark( HWND );		/* ツリーコントロールの初期化：ブックマーク */
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 	void Key2Command(WORD KeyCode);		//	キー操作→コマンド変換
 	bool HitTestSplitter( int xPos, int yPos );
 	int HitTestCaptionButton( int xPos, int yPos );

--- a/sakura_core/plugin/CDllPlugin.h
+++ b/sakura_core/plugin/CDllPlugin.h
@@ -35,7 +35,7 @@
 
 typedef void (*DllPlugHandler)();
 
-class CDllPlug
+class CDllPlug final
 	: public CPlug
 {
 public:
@@ -48,7 +48,7 @@ public:
 	DllPlugHandler m_handler;
 };
 
-class CDllPlugin
+class CDllPlugin final
 	: public CPlugin, public CDllImp
 {
 	//コンストラクタ
@@ -62,15 +62,15 @@ public:
 
 	//実装
 public:
-	bool ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang );
-	bool ReadPluginOption( CDataProfile *cProfile ) {
+	bool ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang ) override;
+	bool ReadPluginOption( CDataProfile *cProfile ) override{
 		return true;
 	}
-	CPlug* CreatePlug( CPlugin& plugin, PlugId id, wstring sJack, wstring sHandler, wstring sLabel );
-	CPlug::Array GetPlugs() const{
+	CPlug* CreatePlug( CPlugin& plugin, PlugId id, wstring sJack, wstring sHandler, wstring sLabel ) override;
+	CPlug::Array GetPlugs() const override{
 		return m_plugs;
 	}
-	bool InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& params );
+	bool InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& params ) override;
 
 	bool InitDllImp() {
 		return true;

--- a/sakura_core/plugin/CJackManager.h
+++ b/sakura_core/plugin/CJackManager.h
@@ -71,7 +71,7 @@ enum ERegisterPlugResult {
 };
 
 //ジャック管理クラス
-class CJackManager : public TSingleton<CJackManager>{
+class CJackManager final : public TSingleton<CJackManager>{
 	friend class TSingleton<CJackManager>;
 	CJackManager();
 

--- a/sakura_core/plugin/CPluginManager.h
+++ b/sakura_core/plugin/CPluginManager.h
@@ -32,7 +32,7 @@
 #include <list>
 #include <string>
 
-class CPluginManager : public TSingleton<CPluginManager>{
+class CPluginManager final : public TSingleton<CPluginManager>{
 	friend class TSingleton<CPluginManager>;
 	CPluginManager();
 

--- a/sakura_core/plugin/CSmartIndentIfObj.h
+++ b/sakura_core/plugin/CSmartIndentIfObj.h
@@ -32,7 +32,7 @@
 #include "macro/CWSHIfObj.h"
 
 // スマートインデント用WSHオブジェクト
-class CSmartIndentIfObj : public CWSHIfObj
+class CSmartIndentIfObj final : public CWSHIfObj
 {
 	// 型定義
 	enum FuncId {

--- a/sakura_core/plugin/CWSHPlugin.h
+++ b/sakura_core/plugin/CWSHPlugin.h
@@ -34,7 +34,7 @@
 #define PII_WSH						L"Wsh"			//WSHセクション
 #define PII_WSH_USECACHE			L"UseCache"		//読み込んだスクリプトを再利用する
 
-class CWSHPlug :
+class CWSHPlug final :
 	public CPlug
 {
 public:
@@ -52,7 +52,7 @@ public:
 	CWSHMacroManager* m_Wsh;
 };
 
-class CWSHPlugin :
+class CWSHPlugin final :
 	public CPlugin
 {
 	//コンストラクタ
@@ -67,19 +67,19 @@ public:
 
 	//操作
 	//CPlugインスタンスの作成。ReadPluginDefPlug/Command から呼ばれる。
-	virtual CPlug* CreatePlug( CPlugin& plugin, PlugId id, wstring sJack, wstring sHandler, wstring sLabel )
+	CPlug* CreatePlug( CPlugin& plugin, PlugId id, wstring sJack, wstring sHandler, wstring sLabel ) override
 	{
 		return new CWSHPlug( plugin, id, sJack, sHandler, sLabel );
 	}
 
 	//実装
 public:
-	bool ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang );
-	bool ReadPluginOption( CDataProfile *cProfile );
-	CPlug::Array GetPlugs() const{
+	bool ReadPluginDef( CDataProfile *cProfile, CDataProfile *cProfileMlang ) override;
+	bool ReadPluginOption( CDataProfile *cProfile ) override;
+	CPlug::Array GetPlugs() const override{
 		return m_plugs;
 	}
-	bool InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& params );
+	bool InvokePlug( CEditView* view, CPlug& plug, CWSHIfObj::List& params ) override;
 
 	//メンバ変数
 private:

--- a/sakura_core/prop/CPropCommon.h
+++ b/sakura_core/prop/CPropCommon.h
@@ -191,7 +191,7 @@ protected:
 */
 //==============================================================
 //!	全般ページ
-class CPropGeneral : CPropCommon
+class CPropGeneral final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -206,7 +206,7 @@ protected:
 
 //==============================================================
 //!	ファイルページ
-class CPropFile : CPropCommon
+class CPropFile final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -225,7 +225,7 @@ private:
 
 //==============================================================
 //!	キー割り当てページ
-class CPropKeybind : CPropCommon
+class CPropKeybind final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -246,7 +246,7 @@ private:
 
 //==============================================================
 //!	ツールバーページ
-class CPropToolbar : CPropCommon
+class CPropToolbar final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -264,7 +264,7 @@ private:
 
 //==============================================================
 //!	キーワードページ
-class CPropKeyword : CPropCommon
+class CPropKeyword final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -292,7 +292,7 @@ private:
 
 //==============================================================
 //!	カスタムメニューページ
-class CPropCustmenu : CPropCommon
+class CPropCustmenu final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -310,7 +310,7 @@ protected:
 
 //==============================================================
 //!	書式ページ
-class CPropFormat : CPropCommon
+class CPropFormat final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -332,7 +332,7 @@ private:
 
 //==============================================================
 //!	支援ページ
-class CPropHelper : CPropCommon
+class CPropHelper final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -347,7 +347,7 @@ protected:
 
 //==============================================================
 //!	バックアップページ
-class CPropBackup : CPropCommon
+class CPropBackup final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -368,7 +368,7 @@ private:
 
 //==============================================================
 //!	ウィンドウページ
-class CPropWin : CPropCommon
+class CPropWin final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -387,7 +387,7 @@ private:
 
 //==============================================================
 //!	タブ動作ページ
-class CPropTab : CPropCommon
+class CPropTab final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -405,7 +405,7 @@ private:
 
 //==============================================================
 //!	編集ページ
-class CPropEdit : CPropCommon
+class CPropEdit final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -423,7 +423,7 @@ private:
 
 //==============================================================
 //!	検索ページ
-class CPropGrep : CPropCommon
+class CPropGrep final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -441,7 +441,7 @@ private:
 
 //==============================================================
 //!	マクロページ
-class CPropMacro : CPropCommon
+class CPropMacro final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -465,7 +465,7 @@ private:
 
 //==============================================================
 //!	ファイル名表示ページ
-class CPropFileName : CPropCommon
+class CPropFileName final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -485,7 +485,7 @@ private:
 
 //==============================================================
 //!	ステータスバーページ
-class CPropStatusbar : CPropCommon
+class CPropStatusbar final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -500,7 +500,7 @@ protected:
 
 //==============================================================
 //!	プラグインページ
-class CPropPlugin : CPropCommon
+class CPropPlugin final : CPropCommon
 {
 public:
 	//!	Dialog Procedure
@@ -522,7 +522,7 @@ private:
 
 //==============================================================
 //!	メインメニューページ
-class CPropMainMenu : CPropCommon
+class CPropMainMenu final : CPropCommon
 {
 public:
 	//!	Dialog Procedure

--- a/sakura_core/recent/CMruListener.h
+++ b/sakura_core/recent/CMruListener.h
@@ -30,15 +30,15 @@
 class CMruListener : public CDocListenerEx{
 public:
 	//ロード前後
-//	ECallbackResult OnCheckLoad(SLoadInfo* pLoadInfo);
-	void OnBeforeLoad(SLoadInfo* sLoadInfo);
-	void OnAfterLoad(const SLoadInfo& sLoadInfo);
+//	ECallbackResult OnCheckLoad(SLoadInfo* pLoadInfo) override;
+	void OnBeforeLoad(SLoadInfo* sLoadInfo) override;
+	void OnAfterLoad(const SLoadInfo& sLoadInfo) override;
 
 	//セーブ前後
-	void OnAfterSave(const SSaveInfo& sSaveInfo);
+	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
 
 	//クローズ前後
-	ECallbackResult OnBeforeClose();
+	ECallbackResult OnBeforeClose() override;
 
 protected:
 	//ヘルパ

--- a/sakura_core/recent/CRecentCmd.h
+++ b/sakura_core/recent/CRecentCmd.h
@@ -32,18 +32,18 @@
 typedef StaticString<WCHAR, MAX_CMDLEN> CCmdString;
 
 //! コマンドの履歴を管理 (RECENT_FOR_CMD)
-class CRecentCmd : public CRecentImp<CCmdString, LPCWSTR>{
+class CRecentCmd final : public CRecentImp<CCmdString, LPCWSTR>{
 public:
 	//生成
 	CRecentCmd();
 
 	//オーバーライド
-	int				CompareItem( const CCmdString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CCmdString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CCmdString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CCmdString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CCmdString* src ) const;
-	bool			TextToDataType( CCmdString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CCmdString* src ) const override;
+	bool			TextToDataType( CCmdString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentCurDir.h
+++ b/sakura_core/recent/CRecentCurDir.h
@@ -32,18 +32,18 @@
 typedef StaticString<WCHAR, _MAX_PATH> CCurDirString;
 
 //! コマンドの履歴を管理 (RECENT_FOR_CUR_DIR)
-class CRecentCurDir : public CRecentImp<CCurDirString, LPCWSTR>{
+class CRecentCurDir final : public CRecentImp<CCurDirString, LPCWSTR>{
 public:
 	//生成
 	CRecentCurDir();
 
 	//オーバーライド
-	int				CompareItem( const CCurDirString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CCurDirString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CCurDirString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CCurDirString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CCurDirString* src ) const;
-	bool			TextToDataType( CCurDirString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CCurDirString* src ) const override;
+	bool			TextToDataType( CCurDirString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentEditNode.h
+++ b/sakura_core/recent/CRecentEditNode.h
@@ -29,18 +29,18 @@
 struct EditNode;
 
 //! EditNode(ウィンドウリスト)の履歴を管理 (RECENT_FOR_EDITNODE)
-class CRecentEditNode : public CRecentImp<EditNode>{
+class CRecentEditNode final : public CRecentImp<EditNode>{
 public:
 	//生成
 	CRecentEditNode();
 
 	//オーバーライド
-	int				CompareItem( const EditNode* p1, const EditNode* p2 ) const;
-	void			CopyItem( EditNode* dst, const EditNode* src ) const;
+	int				CompareItem( const EditNode* p1, const EditNode* p2 ) const override;
+	void			CopyItem( EditNode* dst, const EditNode* src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( const EditNode** dst, const EditNode* src ) const;
-	bool			TextToDataType( EditNode* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( const EditNode* ) const;
+	bool			DataToReceiveType( const EditNode** dst, const EditNode* src ) const override;
+	bool			TextToDataType( EditNode* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( const EditNode* ) const override;
 	size_t			GetTextMaxLength() const;
 	//固有インターフェース
 	int FindItemByHwnd(HWND hwnd) const;

--- a/sakura_core/recent/CRecentExceptMru.h
+++ b/sakura_core/recent/CRecentExceptMru.h
@@ -31,18 +31,18 @@
 typedef StaticString<WCHAR, _MAX_PATH> CMetaPath;
 
 //! フォルダの履歴を管理 (RECENT_FOR_FOLDER)
-class CRecentExceptMRU : public CRecentImp<CMetaPath, LPCWSTR>{
+class CRecentExceptMRU final : public CRecentImp<CMetaPath, LPCWSTR>{
 public:
 	//生成
 	CRecentExceptMRU();
 
 	//オーバーライド
-	int				CompareItem( const CMetaPath* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CMetaPath* dst, LPCWSTR src ) const;
+	int				CompareItem( const CMetaPath* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CMetaPath* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CMetaPath* src ) const;
-	bool			TextToDataType( CMetaPath* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CMetaPath* src ) const override;
+	bool			TextToDataType( CMetaPath* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentExcludeFile.h
+++ b/sakura_core/recent/CRecentExcludeFile.h
@@ -30,18 +30,18 @@
 typedef StaticString<WCHAR, MAX_EXCLUDE_PATH> CExcludeFileString;
 
 //! Excludeファイルの履歴を管理 (RECENT_FOR_Exclude_FILE)
-class CRecentExcludeFile : public CRecentImp<CExcludeFileString, LPCWSTR>{
+class CRecentExcludeFile final : public CRecentImp<CExcludeFileString, LPCWSTR>{
 public:
 	//生成
 	CRecentExcludeFile();
 
 	//オーバーライド
-	int				CompareItem( const CExcludeFileString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CExcludeFileString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CExcludeFileString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CExcludeFileString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CExcludeFileString* src ) const;
-	bool			TextToDataType( CExcludeFileString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CExcludeFileString* src ) const override;
+	bool			TextToDataType( CExcludeFileString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentExcludeFolder.h
+++ b/sakura_core/recent/CRecentExcludeFolder.h
@@ -30,18 +30,18 @@
 typedef StaticString<WCHAR, MAX_EXCLUDE_PATH> CExcludeFolderString;
 
 //! Excludeフォルダの履歴を管理 (RECENT_FOR_Exclude_FOLDER)
-class CRecentExcludeFolder : public CRecentImp<CExcludeFolderString, LPCWSTR>{
+class CRecentExcludeFolder final : public CRecentImp<CExcludeFolderString, LPCWSTR>{
 public:
 	//生成
 	CRecentExcludeFolder();
 
 	//オーバーライド
-	int				CompareItem( const CExcludeFolderString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CExcludeFolderString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CExcludeFolderString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CExcludeFolderString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CExcludeFolderString* src ) const;
-	bool			TextToDataType( CExcludeFolderString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CExcludeFolderString* src ) const override;
+	bool			TextToDataType( CExcludeFolderString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentFile.h
+++ b/sakura_core/recent/CRecentFile.h
@@ -29,18 +29,18 @@
 #include "EditInfo.h" //EditInfo
 
 //! EditInfoの履歴を管理 (RECENT_FOR_FILE)
-class CRecentFile : public CRecentImp<EditInfo>{
+class CRecentFile final : public CRecentImp<EditInfo>{
 public:
 	//生成
 	CRecentFile();
 
 	//オーバーライド
-	int				CompareItem( const EditInfo* p1, const EditInfo* p2 ) const;
-	void			CopyItem( EditInfo* dst, const EditInfo* src ) const;
+	int				CompareItem( const EditInfo* p1, const EditInfo* p2 ) const override;
+	void			CopyItem( EditInfo* dst, const EditInfo* src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( const EditInfo** dst, const EditInfo* src ) const;
-	bool			TextToDataType( EditInfo* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( const EditInfo* ) const;
+	bool			DataToReceiveType( const EditInfo** dst, const EditInfo* src ) const override;
+	bool			TextToDataType( EditInfo* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( const EditInfo* ) const override;
 	size_t			GetTextMaxLength() const;
 	//固有インターフェース
 	int FindItemByPath(const WCHAR* pszPath) const;

--- a/sakura_core/recent/CRecentFolder.h
+++ b/sakura_core/recent/CRecentFolder.h
@@ -33,18 +33,18 @@
 typedef StaticString<WCHAR, _MAX_PATH> CPathString;
 
 //! フォルダの履歴を管理 (RECENT_FOR_FOLDER)
-class CRecentFolder : public CRecentImp<CPathString, LPCWSTR>{
+class CRecentFolder final : public CRecentImp<CPathString, LPCWSTR>{
 public:
 	//生成
 	CRecentFolder();
 
 	//オーバーライド
-	int				CompareItem( const CPathString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CPathString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CPathString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CPathString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CPathString* src ) const;
-	bool			TextToDataType( CPathString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CPathString* src ) const override;
+	bool			TextToDataType( CPathString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentGrepFile.h
+++ b/sakura_core/recent/CRecentGrepFile.h
@@ -31,18 +31,18 @@
 typedef StaticString<WCHAR, MAX_GREP_PATH> CGrepFileString;
 
 //! GREPファイルの履歴を管理 (RECENT_FOR_GREP_FILE)
-class CRecentGrepFile : public CRecentImp<CGrepFileString, LPCWSTR>{
+class CRecentGrepFile final : public CRecentImp<CGrepFileString, LPCWSTR>{
 public:
 	//生成
 	CRecentGrepFile();
 
 	//オーバーライド
-	int				CompareItem( const CGrepFileString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CGrepFileString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CGrepFileString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CGrepFileString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CGrepFileString* src ) const;
-	bool			TextToDataType( CGrepFileString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CGrepFileString* src ) const override;
+	bool			TextToDataType( CGrepFileString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentGrepFolder.h
+++ b/sakura_core/recent/CRecentGrepFolder.h
@@ -31,18 +31,18 @@
 typedef StaticString<WCHAR, MAX_GREP_PATH> CGrepFolderString;
 
 //! GREPフォルダの履歴を管理 (RECENT_FOR_GREP_FOLDER)
-class CRecentGrepFolder : public CRecentImp<CGrepFolderString, LPCWSTR>{
+class CRecentGrepFolder final : public CRecentImp<CGrepFolderString, LPCWSTR>{
 public:
 	//生成
 	CRecentGrepFolder();
 
 	//オーバーライド
-	int				CompareItem( const CGrepFolderString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CGrepFolderString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CGrepFolderString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CGrepFolderString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CGrepFolderString* src ) const;
-	bool			TextToDataType( CGrepFolderString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CGrepFolderString* src ) const override;
+	bool			TextToDataType( CGrepFolderString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentReplace.h
+++ b/sakura_core/recent/CRecentReplace.h
@@ -31,18 +31,18 @@
 typedef StaticString<WCHAR, _MAX_PATH> CReplaceString;
 
 //! 置換の履歴を管理 (RECENT_FOR_REPLACE)
-class CRecentReplace : public CRecentImp<CReplaceString, LPCWSTR>{
+class CRecentReplace final : public CRecentImp<CReplaceString, LPCWSTR>{
 public:
 	//生成
 	CRecentReplace();
 
 	//オーバーライド
-	int				CompareItem( const CReplaceString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CReplaceString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CReplaceString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CReplaceString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CReplaceString* src ) const;
-	bool			TextToDataType( CReplaceString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CReplaceString* src ) const override;
+	bool			TextToDataType( CReplaceString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentSearch.h
+++ b/sakura_core/recent/CRecentSearch.h
@@ -31,18 +31,18 @@
 typedef StaticString<WCHAR, _MAX_PATH> CSearchString;
 
 //! 検索の履歴を管理 (RECENT_FOR_SEARCH)
-class CRecentSearch : public CRecentImp<CSearchString, LPCWSTR>{
+class CRecentSearch final : public CRecentImp<CSearchString, LPCWSTR>{
 public:
 	//生成
 	CRecentSearch();
 
 	//オーバーライド
-	int				CompareItem( const CSearchString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CSearchString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CSearchString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CSearchString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CSearchString* src ) const;
-	bool			TextToDataType( CSearchString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CSearchString* src ) const override;
+	bool			TextToDataType( CSearchString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/recent/CRecentTagjumpKeyword.h
+++ b/sakura_core/recent/CRecentTagjumpKeyword.h
@@ -31,18 +31,18 @@
 typedef StaticString<WCHAR, _MAX_PATH> CTagjumpKeywordString;
 
 //! タグジャンプキーワードの履歴を管理 (RECENT_FOR_TAGJUMP_KEYWORD)
-class CRecentTagjumpKeyword : public CRecentImp<CTagjumpKeywordString, LPCWSTR>{
+class CRecentTagjumpKeyword final : public CRecentImp<CTagjumpKeywordString, LPCWSTR>{
 public:
 	//生成
 	CRecentTagjumpKeyword();
 
 	//オーバーライド
-	int				CompareItem( const CTagjumpKeywordString* p1, LPCWSTR p2 ) const;
-	void			CopyItem( CTagjumpKeywordString* dst, LPCWSTR src ) const;
+	int				CompareItem( const CTagjumpKeywordString* p1, LPCWSTR p2 ) const override;
+	void			CopyItem( CTagjumpKeywordString* dst, LPCWSTR src ) const override;
 	const WCHAR*	GetItemText( int nIndex ) const;
-	bool			DataToReceiveType( LPCWSTR* dst, const CTagjumpKeywordString* src ) const;
-	bool			TextToDataType( CTagjumpKeywordString* dst, LPCWSTR pszText ) const;
-	bool			ValidateReceiveType( LPCWSTR p ) const;
+	bool			DataToReceiveType( LPCWSTR* dst, const CTagjumpKeywordString* src ) const override;
+	bool			TextToDataType( CTagjumpKeywordString* dst, LPCWSTR pszText ) const override;
+	bool			ValidateReceiveType( LPCWSTR p ) const override;
 	size_t			GetTextMaxLength() const;
 };
 

--- a/sakura_core/typeprop/CDlgKeywordSelect.h
+++ b/sakura_core/typeprop/CDlgKeywordSelect.h
@@ -45,7 +45,7 @@ class CKeyWordSetMgr;
 //	2005.01.13 genta ShareDataの定義と連動させる
 const int KEYWORD_SELECT_NUM = MAX_KEYWORDSET_PER_TYPE;
 
-class CDlgKeywordSelect : public CDialog
+class CDlgKeywordSelect final : public CDialog
 {
 public:
 	CDlgKeywordSelect();
@@ -54,11 +54,11 @@ public:
 
 protected:
 
-	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
-	BOOL OnBnClicked(int wID);
-	int  GetData( void );
-	void SetData( void );
-	LPVOID GetHelpIdTable( void );
+	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnBnClicked(int wID) override;
+	int  GetData( void ) override;
+	void SetData( void ) override;
+	LPVOID GetHelpIdTable( void ) override;
 
 	int m_nSet[ KEYWORD_SELECT_NUM ];
 	CKeyWordSetMgr*	m_pCKeyWordSetMgr;

--- a/sakura_core/typeprop/CDlgSameColor.h
+++ b/sakura_core/typeprop/CDlgSameColor.h
@@ -40,7 +40,7 @@ struct STypeConfig;
 	タイプ別設定のカラー設定で，文字色／背景色統一の対象色を指定するために補助的に
 	使用されるダイアログボックス
 */
-class CDlgSameColor : public CDialog
+class CDlgSameColor final : public CDialog
 {
 public:
 	CDlgSameColor();
@@ -49,11 +49,11 @@ public:
 
 protected:
 
-	virtual LPVOID GetHelpIdTable( void );
-	virtual INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );	//! ダイアログのメッセージ処理
-	virtual BOOL OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam );			//!< WM_INITDIALOG 処理
-	virtual BOOL OnBnClicked( int wID );							//!< BN_CLICKED 処理
-	virtual BOOL OnDrawItem( WPARAM wParam, LPARAM lParam );	//!< WM_DRAWITEM 処理
+	LPVOID GetHelpIdTable( void ) override;
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	//! ダイアログのメッセージ処理
+	BOOL OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam ) override;			//!< WM_INITDIALOG 処理
+	BOOL OnBnClicked( int wID ) override;							//!< BN_CLICKED 処理
+	BOOL OnDrawItem( WPARAM wParam, LPARAM lParam ) override;	//!< WM_DRAWITEM 処理
 	BOOL OnSelChangeListColors( HWND hwndCtl );					//!< 色選択リストの LBN_SELCHANGE 処理
 
 	static LRESULT CALLBACK ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	//!< サブクラス化された指定色スタティックのウィンドウプロシージャ

--- a/sakura_core/typeprop/CDlgTypeAscertain.h
+++ b/sakura_core/typeprop/CDlgTypeAscertain.h
@@ -41,7 +41,7 @@ using std::wstring;
 /*!
 	@brief ファイルタイプ一覧ダイアログ
 */
-class CDlgTypeAscertain : public CDialog
+class CDlgTypeAscertain final : public CDialog
 {
 public:
 	// 型
@@ -62,9 +62,9 @@ public:
 
 protected:
 	// 実装ヘルパ関数
-	BOOL OnBnClicked(int wID);
-	void SetData();	/* ダイアログデータの設定 */
-	LPVOID GetHelpIdTable(void);
+	BOOL OnBnClicked(int wID) override;
+	void SetData() override;	/* ダイアログデータの設定 */
+	LPVOID GetHelpIdTable(void) override;
 
 private:
 	SAscertainInfo* m_psi;			// インターフェイス

--- a/sakura_core/typeprop/CDlgTypeList.h
+++ b/sakura_core/typeprop/CDlgTypeList.h
@@ -26,7 +26,7 @@ using std::wstring;
 /*!
 	@brief ファイルタイプ一覧ダイアログ
 */
-class CDlgTypeList : public CDialog
+class CDlgTypeList final : public CDialog
 {
 public:
 	// 型
@@ -41,13 +41,13 @@ public:
 
 protected:
 	// 実装ヘルパ関数
-	BOOL OnLbnDblclk(int wID);
-	BOOL OnBnClicked(int wID);
-	BOOL OnActivate( WPARAM wParam, LPARAM lParam );
-	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam );
-	void SetData();	/* ダイアログデータの設定 */
+	BOOL OnLbnDblclk(int wID) override;
+	BOOL OnBnClicked(int wID) override;
+	BOOL OnActivate( WPARAM wParam, LPARAM lParam ) override;
+	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;
+	void SetData() override;	/* ダイアログデータの設定 */
 	void SetData(int selIdx);	/* ダイアログデータの設定 */
-	LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 	bool Import( void );			// 2010/4/12 Uchi
 	bool Export( void );			// 2010/4/12 Uchi
 	bool InitializeType( void );	// 2010/4/12 Uchi

--- a/sakura_core/uiparts/CVisualProgress.h
+++ b/sakura_core/uiparts/CVisualProgress.h
@@ -29,22 +29,22 @@
 #include "util/design_template.h"
 class CWaitCursor;
 
-class CVisualProgress : public CDocListenerEx, public CProgressListener{
+class CVisualProgress final : public CDocListenerEx, public CProgressListener{
 public:
 	//コンストラクタ・デストラクタ
 	CVisualProgress();
 	virtual ~CVisualProgress();
 
 	//ロード前後
-	void OnBeforeLoad(SLoadInfo* sLoadInfo);
-	void OnAfterLoad(const SLoadInfo& sLoadInfo);
+	void OnBeforeLoad(SLoadInfo* sLoadInfo) override;
+	void OnAfterLoad(const SLoadInfo& sLoadInfo) override;
 
 	//セーブ前後
-	void OnBeforeSave(const SSaveInfo& sSaveInfo);
-	void OnFinalSave(ESaveResult eSaveResult);
+	void OnBeforeSave(const SSaveInfo& sSaveInfo) override;
+	void OnFinalSave(ESaveResult eSaveResult) override;
 
 	//プログレス受信
-	void OnProgress(int nPer);
+	void OnProgress(int nPer) override;
 
 protected:
 	//実装補助

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -195,7 +195,7 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	//ドキュメントイベント
-	void OnAfterLoad(const SLoadInfo& sLoadInfo);
+	void OnAfterLoad(const SLoadInfo& sLoadInfo) override;
 	/* メッセージディスパッチャ */
 	LRESULT DispatchEvent(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 	//

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -59,7 +59,7 @@
 
 #define	SAKURA_DIFF_TEMP_PREFIX	L"sakura_diff_"
 
-class COutputAdapterDiff: public COutputAdapter
+class COutputAdapterDiff final : public COutputAdapter
 {
 public:
 	COutputAdapterDiff(CEditView* view, int nFlgFile12_){
@@ -73,10 +73,10 @@ public:
 	}
 	~COutputAdapterDiff(){};
 
-	bool OutputW(const WCHAR* pBuf, int size = -1){ return true; };
-	bool OutputA(const ACHAR* pBuf, int size = -1);
-	bool IsEnableRunningDlg(){ return false; }
-	bool IsActiveDebugWindow(){ return false; }
+	bool OutputW(const WCHAR* pBuf, int size = -1) override{ return true; };
+	bool OutputA(const ACHAR* pBuf, int size = -1) override;
+	bool IsEnableRunningDlg() override{ return false; }
+	bool IsActiveDebugWindow() override{ return false; }
 
 public:
 	bool	bDiffInfo;	//DIFF情報か

--- a/sakura_core/view/CEditView_ExecCmd.cpp
+++ b/sakura_core/view/CEditView_ExecCmd.cpp
@@ -37,7 +37,7 @@
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                       外部コマンド                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-class COutputAdapterDefault: public COutputAdapter
+class COutputAdapterDefault : public COutputAdapter
 {
 public:
 	COutputAdapterDefault(CEditView* view, BOOL bToEditWindow) : m_bWindow(bToEditWindow), m_view(view)
@@ -47,8 +47,8 @@ public:
 	}
 	~COutputAdapterDefault(){};
 
-	bool OutputW(const WCHAR* pBuf, int size = -1);
-	bool OutputA(const ACHAR* pBuf, int size = -1);
+	bool OutputW(const WCHAR* pBuf, int size = -1) override;
+	bool OutputA(const ACHAR* pBuf, int size = -1) override;
 	bool IsActiveDebugWindow(){ return FALSE == m_bWindow; }
 
 protected:
@@ -60,7 +60,7 @@ protected:
 	CViewCommander* m_pCommander;
 };
 
-class COutputAdapterUTF8: public COutputAdapterDefault
+class COutputAdapterUTF8 final : public COutputAdapterDefault
 {
 public:
 	COutputAdapterUTF8(CEditView* view, BOOL bToEditWindow) : COutputAdapterDefault(view, bToEditWindow)
@@ -68,7 +68,7 @@ public:
 	{}
 	~COutputAdapterUTF8(){};
 
-	bool OutputA(const ACHAR* pBuf, int size = -1);
+	bool OutputA(const ACHAR* pBuf, int size = -1) override;
 
 protected:
 	std::unique_ptr<CCodeBase> pcCodeBase;

--- a/sakura_core/view/colors/CColor_Comment.h
+++ b/sakura_core/view/colors/CColor_Comment.h
@@ -31,13 +31,13 @@
 //                        行コメント                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-class CColor_LineComment : public CColorStrategy{
+class CColor_LineComment final : public CColorStrategy{
 public:
-	virtual EColorIndexType GetStrategyColor() const{ return COLORIDX_COMMENT; }
-	virtual void InitStrategyStatus(){}
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const {
+	EColorIndexType GetStrategyColor() const override{ return COLORIDX_COMMENT; }
+	void InitStrategyStatus() override{}
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool EndColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{
 		// タイプ別設定 『カラー』プロパティのコメントのリストアイテムのチェックが付いているか
 		if (!m_pTypeData->m_ColorInfoArr[COLORIDX_COMMENT].m_bDisp)
 			return false;
@@ -55,20 +55,19 @@ public:
 //                    ブロックコメント１                       //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-class CColor_BlockComment : public CColorStrategy{
+class CColor_BlockComment final : public CColorStrategy{
 public:
 	CColor_BlockComment(EColorIndexType nType) : m_nType(nType), m_nCOMMENTEND(0){}
-	virtual void Update(void)
-	{
+	void Update(void) override {
 		const CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
 		m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
 		m_pcBlockComment = &m_pTypeData->m_cBlockComments[m_nType - COLORIDX_BLOCK1];
 	}
-	virtual EColorIndexType GetStrategyColor() const{ return m_nType; }
-	virtual void InitStrategyStatus(){ m_nCOMMENTEND = 0; }
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const {
+	EColorIndexType GetStrategyColor() const override{ return m_nType; }
+	void InitStrategyStatus() override{ m_nCOMMENTEND = 0; }
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool EndColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{
 		// タイプ別設定 『カラー』プロパティのコメントのリストアイテムのチェックが付いているか
 		if (!m_pTypeData->m_ColorInfoArr[COLORIDX_COMMENT].m_bDisp)
 			return false;

--- a/sakura_core/view/colors/CColor_Found.h
+++ b/sakura_core/view/colors/CColor_Found.h
@@ -27,19 +27,19 @@
 
 #include "view/colors/CColorStrategy.h"
 
-class CColor_Select : public CColorStrategy{
+class CColor_Select final : public CColorStrategy{
 public:
-	virtual EColorIndexType GetStrategyColor() const{ return COLORIDX_SELECT; }
+	EColorIndexType GetStrategyColor() const override{ return COLORIDX_SELECT; }
 	//色替え
-	virtual void InitStrategyStatus(){ }
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return true; }
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
+	void InitStrategyStatus() override{ }
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{ return true; }
+	bool EndColor(const CStringRef& cStr, int nPos) override;
 
 	virtual bool BeginColorEx(const CStringRef& cStr, int nPos, CLayoutInt, const CLayout*);
 
 	//イベント
-	virtual void OnStartScanLogic();
+	void OnStartScanLogic() override;
 
 private:
 	CLayoutInt		m_nSelectLine;
@@ -47,18 +47,18 @@ private:
 	CLogicInt		m_nSelectEnd;
 };
 
-class CColor_Found : public CColorStrategy{
+class CColor_Found final : public CColorStrategy{
 public:
 	CColor_Found();
-	virtual EColorIndexType GetStrategyColor() const
+	EColorIndexType GetStrategyColor() const override
 	{ return this->validColorNum != 0 ? this->highlightColors[ (m_nSearchResult - 1) % this->validColorNum ] : COLORIDX_DEFAULT; }
 	//色替え
-	virtual void InitStrategyStatus(){ } //############要検証
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return true; }
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
+	void InitStrategyStatus() override{ } //############要検証
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{ return true; }
+	bool EndColor(const CStringRef& cStr, int nPos) override;
 	//イベント
-	virtual void OnStartScanLogic();
+	void OnStartScanLogic() override;
 
 private:
 	int				m_nSearchResult;

--- a/sakura_core/view/colors/CColor_Heredoc.h
+++ b/sakura_core/view/colors/CColor_Heredoc.h
@@ -27,15 +27,15 @@
 
 #include "view/colors/CColorStrategy.h"
 
-class CColor_Heredoc : public CColorStrategy{
+class CColor_Heredoc final : public CColorStrategy{
 public:
-	virtual EColorIndexType GetStrategyColor() const{ return COLORIDX_HEREDOC; }
-	virtual CLayoutColorInfo* GetStrategyColorInfo() const;
-	virtual void InitStrategyStatus(){ m_nCOMMENTEND = 0; }
-	virtual void SetStrategyColorInfo(const CLayoutColorInfo*);
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return m_pTypeData->m_ColorInfoArr[COLORIDX_HEREDOC].m_bDisp; }
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
+	EColorIndexType GetStrategyColor() const override{ return COLORIDX_HEREDOC; }
+	CLayoutColorInfo* GetStrategyColorInfo() const override;
+	void InitStrategyStatus() override{ m_nCOMMENTEND = 0; }
+	void SetStrategyColorInfo(const CLayoutColorInfo*) override;
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{ return m_pTypeData->m_ColorInfoArr[COLORIDX_HEREDOC].m_bDisp; }
+	bool EndColor(const CStringRef& cStr, int nPos) override;
 private:
 	std::wstring m_id;
 	int	     m_nSize;

--- a/sakura_core/view/colors/CColor_KeywordSet.h
+++ b/sakura_core/view/colors/CColor_KeywordSet.h
@@ -27,14 +27,14 @@
 
 #include "view/colors/CColorStrategy.h"
 
-class CColor_KeywordSet : public CColorStrategy{
+class CColor_KeywordSet final : public CColorStrategy{
 public:
 	CColor_KeywordSet();
-	virtual EColorIndexType GetStrategyColor() const{ return (EColorIndexType)(COLORIDX_KEYWORD1 + m_nKeywordIndex); }
-	virtual void InitStrategyStatus(){ m_nCOMMENTEND = 0; }
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return true; }
+	EColorIndexType GetStrategyColor() const override{ return (EColorIndexType)(COLORIDX_KEYWORD1 + m_nKeywordIndex); }
+	void InitStrategyStatus() override{ m_nCOMMENTEND = 0; }
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool EndColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{ return true; }
 private:
 	int m_nKeywordIndex;
 	int m_nCOMMENTEND;

--- a/sakura_core/view/colors/CColor_Numeric.h
+++ b/sakura_core/view/colors/CColor_Numeric.h
@@ -27,14 +27,14 @@
 
 #include "view/colors/CColorStrategy.h"
 
-class CColor_Numeric : public CColorStrategy{
+class CColor_Numeric final : public CColorStrategy{
 public:
 	CColor_Numeric() : m_nCOMMENTEND(0) { }
-	virtual EColorIndexType GetStrategyColor() const{ return COLORIDX_DIGIT; }
-	virtual void InitStrategyStatus(){ m_nCOMMENTEND = 0; }
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return m_pTypeData->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp; }
+	EColorIndexType GetStrategyColor() const override{ return COLORIDX_DIGIT; }
+	void InitStrategyStatus() override{ m_nCOMMENTEND = 0; }
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool EndColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{ return m_pTypeData->m_ColorInfoArr[COLORIDX_DIGIT].m_bDisp; }
 private:
 	int m_nCOMMENTEND;
 };

--- a/sakura_core/view/colors/CColor_Quote.h
+++ b/sakura_core/view/colors/CColor_Quote.h
@@ -34,14 +34,14 @@ public:
 		m_szQuote[1] = cQuote;
 		m_szQuote[2] = cQuote;
 	}
-	virtual void Update(void);
+	void Update(void) override;
 	virtual EColorIndexType GetStrategyColor() const = 0;
-	virtual CLayoutColorInfo* GetStrategyColorInfo() const;
-	virtual void InitStrategyStatus(){ m_nCOMMENTEND = -1; }
-	virtual void SetStrategyColorInfo(const CLayoutColorInfo*);
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return m_pTypeData->m_ColorInfoArr[this->GetStrategyColor()].m_bDisp; }
+	CLayoutColorInfo* GetStrategyColorInfo() const override;
+	void InitStrategyStatus() override{ m_nCOMMENTEND = -1; }
+	void SetStrategyColorInfo(const CLayoutColorInfo*) override;
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool EndColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{ return m_pTypeData->m_ColorInfoArr[this->GetStrategyColor()].m_bDisp; }
 
 	static bool IsCppRawString(const CStringRef& cStr, int nPos);
 	static int Match_Quote( wchar_t wcQuote, int nPos, const CStringRef& cLineStr, int escapeType, bool* pbEscapeEnd = NULL );
@@ -61,16 +61,16 @@ protected:
 	int m_nColorTypeIndex;
 };
 
-class CColor_SingleQuote : public CColor_Quote{
+class CColor_SingleQuote final : public CColor_Quote{
 public:
 	CColor_SingleQuote() : CColor_Quote(L'\'') { }
-	virtual EColorIndexType GetStrategyColor() const{ return COLORIDX_SSTRING; }
+	EColorIndexType GetStrategyColor() const override{ return COLORIDX_SSTRING; }
 };
 
-class CColor_DoubleQuote : public CColor_Quote{
+class CColor_DoubleQuote final : public CColor_Quote{
 public:
 	CColor_DoubleQuote() : CColor_Quote(L'"') { }
-	virtual EColorIndexType GetStrategyColor() const{ return COLORIDX_WSTRING; }
+	EColorIndexType GetStrategyColor() const override{ return COLORIDX_WSTRING; }
 };
 
 #endif /* SAKURA_CCOLOR_QUOTE_26330E31_5ADC_4753_92DD_7567B7BA4451_H_ */

--- a/sakura_core/view/colors/CColor_RegexKeyword.h
+++ b/sakura_core/view/colors/CColor_RegexKeyword.h
@@ -27,15 +27,15 @@
 
 #include "view/colors/CColorStrategy.h"
 
-class CColor_RegexKeyword : public CColorStrategy{
+class CColor_RegexKeyword final : public CColorStrategy{
 public:
 	CColor_RegexKeyword() : m_nCOMMENTEND(0), m_nCOMMENTMODE(ToColorIndexType_RegularExpression(0)) { }
-	virtual EColorIndexType GetStrategyColor() const{ return m_nCOMMENTMODE; }
-	virtual void InitStrategyStatus(){ m_nCOMMENTEND = 0; m_nCOMMENTMODE = ToColorIndexType_RegularExpression(0); }
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return m_pTypeData->m_bUseRegexKeyword; }
-	virtual void OnStartScanLogic();
+	EColorIndexType GetStrategyColor() const override{ return m_nCOMMENTMODE; }
+	void InitStrategyStatus() override{ m_nCOMMENTEND = 0; m_nCOMMENTMODE = ToColorIndexType_RegularExpression(0); }
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool EndColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{ return m_pTypeData->m_bUseRegexKeyword; }
+	void OnStartScanLogic();
 private:
 	int m_nCOMMENTEND;
 	EColorIndexType m_nCOMMENTMODE;

--- a/sakura_core/view/colors/CColor_Url.h
+++ b/sakura_core/view/colors/CColor_Url.h
@@ -27,14 +27,14 @@
 
 #include "view/colors/CColorStrategy.h"
 
-class CColor_Url : public CColorStrategy{
+class CColor_Url final : public CColorStrategy{
 public:
 	CColor_Url() : m_nCOMMENTEND(0) { }
-	virtual EColorIndexType GetStrategyColor() const{ return COLORIDX_URL; }
-	virtual void InitStrategyStatus(){ m_nCOMMENTEND = 0; }
-	virtual bool BeginColor(const CStringRef& cStr, int nPos);
-	virtual bool EndColor(const CStringRef& cStr, int nPos);
-	virtual bool Disp() const { return m_pTypeData->m_ColorInfoArr[COLORIDX_URL].m_bDisp; }
+	EColorIndexType GetStrategyColor() const override{ return COLORIDX_URL; }
+	void InitStrategyStatus() override{ m_nCOMMENTEND = 0; }
+	bool BeginColor(const CStringRef& cStr, int nPos) override;
+	bool EndColor(const CStringRef& cStr, int nPos) override;
+	bool Disp() const override{ return m_pTypeData->m_ColorInfoArr[COLORIDX_URL].m_bDisp; }
 private:
 	int m_nCOMMENTEND;
 };

--- a/sakura_core/window/CAutoScrollWnd.h
+++ b/sakura_core/window/CAutoScrollWnd.h
@@ -28,7 +28,7 @@
 #include "CWnd.h"
 class CEditView;
 
-class CAutoScrollWnd: public CWnd
+class CAutoScrollWnd final: public CWnd
 {
 public:
 	CAutoScrollWnd();
@@ -44,9 +44,9 @@ protected:
 	/* 仮想関数 */
 
 	/* 仮想関数 メッセージ処理 詳しくは実装を参照 */
-	LRESULT OnLButtonDown(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
-	LRESULT OnRButtonDown(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
-	LRESULT OnMButtonDown(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
-	LRESULT OnPaint(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+	LRESULT OnLButtonDown(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;
+	LRESULT OnRButtonDown(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;
+	LRESULT OnMButtonDown(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;
+	LRESULT OnPaint(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;
 };
 #endif

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -131,7 +131,7 @@ public:
 	//                         イベント                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//ドキュメントイベント
-	void OnAfterSave(const SSaveInfo& sSaveInfo);
+	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
 
 	//管理
 	void MessageLoop( void );								/* メッセージループ */

--- a/sakura_core/window/CSplitBoxWnd.h
+++ b/sakura_core/window/CSplitBoxWnd.h
@@ -24,7 +24,7 @@ class CSplitBoxWnd;
 /*!
 	@brief 分割ボックスウィンドウクラス
 */
-class CSplitBoxWnd : public CWnd
+class CSplitBoxWnd final : public CWnd
 {
 public:
 	/*
@@ -47,11 +47,11 @@ protected:
 	/* 仮想関数 */
 
 	/* 仮想関数 メッセージ処理 詳しくは実装を参照 */
-	LRESULT OnPaint(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);/* 描画処理 */
-	LRESULT OnLButtonDown(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);// WM_LBUTTONDOWN
-	LRESULT OnMouseMove(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);// WM_MOUSEMOVE
-	LRESULT OnLButtonUp(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);//WM_LBUTTONUP
-	LRESULT OnLButtonDblClk(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);//WM_LBUTTONDBLCLK
+	LRESULT OnPaint(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;/* 描画処理 */
+	LRESULT OnLButtonDown(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;// WM_LBUTTONDOWN
+	LRESULT OnMouseMove(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;// WM_MOUSEMOVE
+	LRESULT OnLButtonUp(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;//WM_LBUTTONUP
+	LRESULT OnLButtonDblClk(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;//WM_LBUTTONDBLCLK
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/sakura_core/window/CSplitterWnd.h
+++ b/sakura_core/window/CSplitterWnd.h
@@ -31,7 +31,7 @@ struct DLLSHAREDATA;
 	
 	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 */
-class CSplitterWnd : public CWnd
+class CSplitterWnd final : public CWnd
 {
 public:
 	/*
@@ -74,15 +74,15 @@ public: // 2002/2/3 aroka
 	int GetAllSplitCols(){ return m_nAllSplitCols;} // 2002/2/3 aroka
 protected:
 	/* 仮想関数 */
-	virtual LRESULT DispatchEvent_WM_APP(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);/* アプリケーション定義のメッセージ(WM_APP <= msg <= 0xBFFF) */
+	LRESULT DispatchEvent_WM_APP(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;/* アプリケーション定義のメッセージ(WM_APP <= msg <= 0xBFFF) */
 
 	/* 仮想関数 メッセージ処理 詳しくは実装を参照 */
-	virtual LRESULT OnSize(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);	/* ウィンドウサイズの変更処理 */
-	virtual LRESULT OnPaint(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);	/* 描画処理 */
-	virtual LRESULT OnMouseMove(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam); /* マウス移動時の処理 */
-	virtual LRESULT OnLButtonDown(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);	/* マウス左ボタン押下時の処理 */
-	virtual LRESULT OnLButtonUp(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);	/* マウス左ボタン解放時の処理 */
-	virtual LRESULT OnLButtonDblClk(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);	/* マウス左ボタンダブルクリック時の処理 */
+	LRESULT OnSize(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;	/* ウィンドウサイズの変更処理 */
+	LRESULT OnPaint(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;	/* 描画処理 */
+	LRESULT OnMouseMove(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override; /* マウス移動時の処理 */
+	LRESULT OnLButtonDown(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;	/* マウス左ボタン押下時の処理 */
+	LRESULT OnLButtonUp(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;	/* マウス左ボタン解放時の処理 */
+	LRESULT OnLButtonDblClk(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;	/* マウス左ボタンダブルクリック時の処理 */
 	/*
 	||  実装ヘルパ関数
 	*/

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -45,7 +45,7 @@ struct EditNode;
 struct DLLSHAREDATA;
 
 //! タブバーウィンドウ
-class CTabWnd : public CWnd
+class CTabWnd final : public CWnd
 {
 public:
 	/*
@@ -96,22 +96,22 @@ protected:
 	void GetTabName( EditNode* pEditNode, BOOL bFull, BOOL bDupamp, LPWSTR pszName, int nLen );	/* タブ名取得処理 */	// 2007.06.28 ryoji 新規作成
 
 	/* 仮想関数 */
-	virtual void AfterCreateWindow( void ){}	/*!< ウィンドウ作成後の処理 */	// 2007.03.13 ryoji 可視化しない
+	void AfterCreateWindow( void ) override{}	/*!< ウィンドウ作成後の処理 */	// 2007.03.13 ryoji 可視化しない
 
 	/* 仮想関数 メッセージ処理 */
-	virtual LRESULT OnSize( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_SIZE処理 */
-	virtual LRESULT OnDestroy( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_DSESTROY処理 */
-	virtual LRESULT OnNotify( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_NOTIFY処理 */
-	virtual LRESULT OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_PAINT処理 */
-	virtual LRESULT OnCaptureChanged( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_CAPTURECHANGED 処理 */
-	virtual LRESULT OnLButtonDown( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_LBUTTONDOWN処理 */
-	virtual LRESULT OnLButtonUp( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_LBUTTONUP処理 */
-	virtual LRESULT OnRButtonDown( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_RBUTTONDOWN処理 */
-	virtual LRESULT OnLButtonDblClk( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_LBUTTONDBLCLK処理 */
-	virtual LRESULT OnMouseMove( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_MOUSEMOVE処理 */
-	virtual LRESULT OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_TIMER処理 */
-	virtual LRESULT OnMeasureItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	/*!< WM_MEASUREITEM処理 */
-	virtual LRESULT OnDrawItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );		/*!< WM_DRAWITEM処理 */
+	LRESULT OnSize( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;		/*!< WM_SIZE処理 */
+	LRESULT OnDestroy( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;	/*!< WM_DSESTROY処理 */
+	LRESULT OnNotify( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;		/*!< WM_NOTIFY処理 */
+	LRESULT OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;		/*!< WM_PAINT処理 */
+	LRESULT OnCaptureChanged( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;	/*!< WM_CAPTURECHANGED 処理 */
+	LRESULT OnLButtonDown( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;	/*!< WM_LBUTTONDOWN処理 */
+	LRESULT OnLButtonUp( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;	/*!< WM_LBUTTONUP処理 */
+	LRESULT OnRButtonDown( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;	/*!< WM_RBUTTONDOWN処理 */
+	LRESULT OnLButtonDblClk( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;	/*!< WM_LBUTTONDBLCLK処理 */
+	LRESULT OnMouseMove( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;	/*!< WM_MOUSEMOVE処理 */
+	LRESULT OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;		/*!< WM_TIMER処理 */
+	LRESULT OnMeasureItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;	/*!< WM_MEASUREITEM処理 */
+	LRESULT OnDrawItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;		/*!< WM_DRAWITEM処理 */
 
 	// 2005.09.01 ryoji ドラッグアンドドロップでタブの順序変更を可能に
 	/* サブクラス化した Tab でのメッセージ処理 */

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -24,7 +24,7 @@ class CTipWnd;
 /*-----------------------------------------------------------------------
 クラスの宣言
 -----------------------------------------------------------------------*/
-class CTipWnd : public CWnd
+class CTipWnd final : public CWnd
 {
 public:
 	/*
@@ -69,10 +69,10 @@ protected:
 
 	/* 仮想関数 */
 	//	Jan. 9, 2006 genta
-	virtual void AfterCreateWindow( void );
+	void AfterCreateWindow( void ) override;
 
 	/* 仮想関数 メッセージ処理 詳しくは実装を参照 */
-	LRESULT OnPaint(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);/* 描画処理 */
+	LRESULT OnPaint(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;/* 描画処理 */
 };
 
 ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# PR の目的

final 指定子と override 指定子を付加する事でコードを読みやすくするのが目的です。

## カテゴリ

- リファクタリング

## PR の背景

final 指定子と override 指定子は C++11 から使えるようになったので比較的新しいC++の機能です。

https://ja.cppreference.com/w/cpp/language/final

https://ja.cppreference.com/w/cpp/language/override

## PR のメリット

final 指定子と override 指定子の意味が分かる人にはコードが読みやすくなると思います。

## PR のデメリット (トレードオフとかあれば)

final 指定子と override 指定子の意味を学習していない人にはコードが読みにくくなるかもしれません。

## PR の影響範囲

動作には影響無い筈です。

不必要と判断した virtual 指定子を削っているので、それにミスがあれば影響が出るかもしれません。

## 関連チケット

