### PR TITLE
Include guard に #pragma once を使う

### DIFF
--- a/sakura_core/CAutoReloadAgent.h
+++ b/sakura_core/CAutoReloadAgent.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CAUTORELOADAGENT_5B64C473_C8AB_4660_AAA9_3A999953008B_H_
-#define SAKURA_CAUTORELOADAGENT_5B64C473_C8AB_4660_AAA9_3A999953008B_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 
@@ -60,5 +59,4 @@ private:
 	int m_nDelayCount;	//未編集で再ロード時の遅延カウンタ
 };
 
-#endif /* SAKURA_CAUTORELOADAGENT_5B64C473_C8AB_4660_AAA9_3A999953008B_H_ */
 /*[EOF]*/

--- a/sakura_core/CAutoSaveAgent.h
+++ b/sakura_core/CAutoSaveAgent.h
@@ -27,8 +27,8 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef __CAUTOSAVE_H_
-#define __CAUTOSAVE_H_
+#pragma once
+
 #include <Windows.h>
 #include "_main/global.h"
 #include "doc/CDocListener.h"
@@ -76,6 +76,4 @@ public:
 private:
 	CPassiveTimer m_cPassiveTimer;
 };
-
-#endif
 

--- a/sakura_core/CBackupAgent.h
+++ b/sakura_core/CBackupAgent.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CBACKUPAGENT_54267C70_F49D_418B_B1EA_0F98DD5DE4B19_H_
-#define SAKURA_CBACKUPAGENT_54267C70_F49D_418B_B1EA_0F98DD5DE4B19_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 
@@ -36,5 +35,4 @@ protected:
 	bool FormatBackUpPath( WCHAR*, size_t, const WCHAR* );	//!< バックアップパスの作成 2005.11.21 aroka
 };
 
-#endif /* SAKURA_CBACKUPAGENT_54267C70_F49D_418B_B1EA_0F98DD5DE4B19_H_ */
 /*[EOF]*/

--- a/sakura_core/CCodeChecker.h
+++ b/sakura_core/CCodeChecker.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCODECHECKER_4EBAEA37_FC62_4206_A9DD_82DDB8CDE44E9_H_
-#define SAKURA_CCODECHECKER_4EBAEA37_FC62_4206_A9DD_82DDB8CDE44E9_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 #include "util/design_template.h"
@@ -41,5 +40,4 @@ public:
 	void OnFinalLoad(ELoadResult eLoadResult) override;
 };
 
-#endif /* SAKURA_CCODECHECKER_4EBAEA37_FC62_4206_A9DD_82DDB8CDE44E9_H_ */
 /*[EOF]*/

--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDATAPROFILE_2DFA1040_7EC7_4593_983E_093E988F7DCFR_H_
-#define SAKURA_CDATAPROFILE_2DFA1040_7EC7_4593_983E_093E988F7DCFR_H_
+#pragma once
 
 #include "util/StaticType.h"
 #include "CProfile.h"
@@ -239,5 +238,4 @@ public:
 	}
 };
 
-#endif /* SAKURA_CDATAPROFILE_2DFA1040_7EC7_4593_983E_093E988F7DCFR_H_ */
 /*[EOF]*/

--- a/sakura_core/CDicMgr.h
+++ b/sakura_core/CDicMgr.h
@@ -11,8 +11,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CDICMGR_H_
-#define _CDICMGR_H_
+#pragma once
 
 #include <Windows.h>
 #include "util/container.h"
@@ -49,5 +48,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDICMGR_H_ */
-

--- a/sakura_core/CEditApp.h
+++ b/sakura_core/CEditApp.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CEDITAPP_935DB250_AEB5_40A5_BCFF_3B72F8E3D8339_H_
-#define SAKURA_CEDITAPP_935DB250_AEB5_40A5_BCFF_3B72F8E3D8339_H_
+#pragma once
 
 //2007.10.23 kobake 作成
 
@@ -95,5 +94,4 @@ public:
 	const char* what() const throw(){ return "CAppExitException"; }
 };
 
-#endif /* SAKURA_CEDITAPP_935DB250_AEB5_40A5_BCFF_3B72F8E3D8339_H_ */
 /*[EOF]*/

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -29,8 +29,7 @@
 		   distribution.
 */
 
-#ifndef _CEOL_H_
-#define _CEOL_H_
+#pragma once
 
 #include "_main/global.h"
 
@@ -114,6 +113,4 @@ public:
 private:
 	EEolType	m_eEolType;	//!< 改行コードの種類
 };
-
-#endif
 

--- a/sakura_core/CFileExt.h
+++ b/sakura_core/CFileExt.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CFILEEXT_H_
-#define SAKURA_CFILEEXT_H_
+#pragma once
 
 #include "_main/global.h"
 #include "config/maxdata.h"
@@ -69,6 +68,4 @@ private:
 
 	DISALLOW_COPY_AND_ASSIGN(CFileExt);
 };
-
-#endif	//SAKURA_CFILEEXT_H_
 

--- a/sakura_core/CGrepAgent.h
+++ b/sakura_core/CGrepAgent.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CGREPAGENT_89E8C8B7_433B_47F3_A389_75C91E00A4BA9_H_
-#define SAKURA_CGREPAGENT_89E8C8B7_433B_47F3_A389_75C91E00A4BA9_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 class CDlgCancel;
@@ -196,5 +195,4 @@ public: //$$ 仮
 	bool	m_bGrepRunning;		//!< Grep処理中
 };
 
-#endif /* SAKURA_CGREPAGENT_89E8C8B7_433B_47F3_A389_75C91E00A4BA9_H_ */
 /*[EOF]*/

--- a/sakura_core/CHokanMgr.h
+++ b/sakura_core/CHokanMgr.h
@@ -12,8 +12,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CHOKANMGR_H_
-#define _CHOKANMGR_H_
+#pragma once
 
 #include <Windows.h>
 #include "dlg/CDialog.h"
@@ -88,5 +87,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CHOKANMGR_H_ */
-

--- a/sakura_core/CKeyWordSetMgr.h
+++ b/sakura_core/CKeyWordSetMgr.h
@@ -34,8 +34,7 @@
 		   distribution.
 */
 
-#ifndef _CKEYWORDSETMGR_H_
-#define _CKEYWORDSETMGR_H_
+#pragma once
 
 #include <Windows.h>
 #include "_main/global.h"// 2002/2/10 aroka
@@ -164,5 +163,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CKEYWORDSETMGR_H_ */
-

--- a/sakura_core/CLoadAgent.h
+++ b/sakura_core/CLoadAgent.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CLOADAGENT_780AC971_71A8_4495_BE95_C8786311D1489_H_
-#define SAKURA_CLOADAGENT_780AC971_71A8_4495_BE95_C8786311D1489_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 
@@ -36,5 +35,4 @@ public:
 	void OnFinalLoad(ELoadResult eLoadResult) override;
 };
 
-#endif /* SAKURA_CLOADAGENT_780AC971_71A8_4495_BE95_C8786311D1489_H_ */
 /*[EOF]*/

--- a/sakura_core/CMarkMgr.h
+++ b/sakura_core/CMarkMgr.h
@@ -29,8 +29,7 @@
 		   distribution.
 */
 
-#ifndef __CMARKMGR_H_
-#define __CMARKMGR_H_
+#pragma once
 
 #include <vector>
 
@@ -135,6 +134,4 @@ public:
 	void Add(const CMark& m) override;	//!<	要素の追加
 	void Expire(void) override;	//!<	要素数の調整
 };
-
-#endif
 

--- a/sakura_core/COpe.h
+++ b/sakura_core/COpe.h
@@ -11,8 +11,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef SAKURA_COPE_H_
-#define SAKURA_COPE_H_
+#pragma once
 
 //! アンドゥバッファ用 操作コード
 enum EOpeCode {
@@ -125,5 +124,3 @@ public:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_COPE_H_ */
-

--- a/sakura_core/COpeBlk.h
+++ b/sakura_core/COpeBlk.h
@@ -11,10 +11,9 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-class COpeBlk;
+#pragma once
 
-#ifndef _COPEBLK_H_
-#define _COPEBLK_H_
+class COpeBlk;
 
 #include "COpe.h"
 #include <vector>
@@ -58,5 +57,3 @@ private:
 };
 
 //////////////////////////////////////////////////////////////////////12
-#endif /* _COPEBLK_H_ */
-

--- a/sakura_core/COpeBuf.h
+++ b/sakura_core/COpeBuf.h
@@ -11,10 +11,9 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-class COpeBuf;
+#pragma once
 
-#ifndef _COPEBUF_H_
-#define _COPEBUF_H_
+class COpeBuf;
 
 #include <vector>
 #include "_main/global.h"
@@ -58,5 +57,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _COPEBUF_H_ */
-

--- a/sakura_core/CProfile.h
+++ b/sakura_core/CProfile.h
@@ -31,8 +31,7 @@
 		   distribution.
 */
 
-#ifndef _CPROFILE_H_
-#define _CPROFILE_H_
+#pragma once
 
 #include <Windows.h>
 #include <string>
@@ -90,5 +89,3 @@ protected:
 #define _INI_T LTEXT
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CPROFILE_H_ */
-

--- a/sakura_core/CPropertyManager.h
+++ b/sakura_core/CPropertyManager.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CPROPERTYMANAGER_03C7D94F_54C6_4772_86BE_4A00A554FCAE_H_
-#define SAKURA_CPROPERTYMANAGER_03C7D94F_54C6_4772_86BE_4A00A554FCAE_H_
+#pragma once
 
 #include "prop/CPropCommon.h"
 #include "typeprop/CPropTypes.h"
@@ -50,5 +49,4 @@ private:
 	int				m_nPropTypePageNum;
 };
 
-#endif /* SAKURA_CPROPERTYMANAGER_03C7D94F_54C6_4772_86BE_4A00A554FCAE_H_ */
 /*[EOF]*/

--- a/sakura_core/CReadManager.h
+++ b/sakura_core/CReadManager.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CREADMANAGER_1361039A_EFBF_486E_B863_B6C5F9771544_H_
-#define SAKURA_CREADMANAGER_1361039A_EFBF_486E_B863_B6C5F9771544_H_
+#pragma once
 
 #include "doc/CDocListener.h" // CProgressSubject
 #include "charset/CCodeBase.h" // EConvertResult
@@ -42,5 +41,4 @@ public:
 	);
 };
 
-#endif /* SAKURA_CREADMANAGER_1361039A_EFBF_486E_B863_B6C5F9771544_H_ */
 /*[EOF]*/

--- a/sakura_core/CRegexKeyword.h
+++ b/sakura_core/CRegexKeyword.h
@@ -16,8 +16,7 @@
 
 //@@@ 2001.11.17 add start MIK
 
-#ifndef	_REGEX_KEYWORD_H_
-#define	_REGEX_KEYWORD_H_
+#pragma once
 
 #include "_main/global.h"
 #include "extmodule/CBregexp.h"
@@ -81,8 +80,6 @@ private:
 	REGEX_INFO		m_sInfo[MAX_REGEX_KEYWORD];	//!< キーワード一覧(BREGEXPコンパイル対象)
 	wchar_t			m_szMsg[256];				//!< BREGEXP_Wからのメッセージを保持する
 };
-
-#endif	//_REGEX_KEYWORD_H_
 
 //@@@ 2001.11.17 add end MIK
 

--- a/sakura_core/CSaveAgent.h
+++ b/sakura_core/CSaveAgent.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSAVEAGENT_441713C1_707B_4B6D_8DBE_D398BA4EBFA2_H_
-#define SAKURA_CSAVEAGENT_441713C1_707B_4B6D_8DBE_D398BA4EBFA2_H_
+#pragma once
 
 class CSaveAgent : public CDocListenerEx{
 public:
@@ -37,5 +36,4 @@ private:
 	SSaveInfo	m_sSaveInfoForRollback;
 };
 
-#endif /* SAKURA_CSAVEAGENT_441713C1_707B_4B6D_8DBE_D398BA4EBFA2_H_ */
 /*[EOF]*/

--- a/sakura_core/CSearchAgent.h
+++ b/sakura_core/CSearchAgent.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSEARCHAGENT_FC5366A0_91D4_438B_80C6_DDA9791B50009_H_
-#define SAKURA_CSEARCHAGENT_FC5366A0_91D4_438B_80C6_DDA9791B50009_H_
+#pragma once
 
 #include "_main/global.h"
 
@@ -131,5 +130,4 @@ private:
 	CDocLineMgr* m_pcDocLineMgr;
 };
 
-#endif /* SAKURA_CSEARCHAGENT_FC5366A0_91D4_438B_80C6_DDA9791B50009_H_ */
 /*[EOF]*/

--- a/sakura_core/CSelectLang.h
+++ b/sakura_core/CSelectLang.h
@@ -11,8 +11,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CSELECTLANG_H_
-#define _CSELECTLANG_H_
+#pragma once
 
 #include <windows.h>
 #include <vector>
@@ -146,6 +145,4 @@ private:
 #define LS( id ) ( CLoadString::LoadStringSt( id ) )
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CSELECTLANG_H_ */
-
 /*[EOF]*/

--- a/sakura_core/CSortedTagJumpList.h
+++ b/sakura_core/CSortedTagJumpList.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CSORTED_TAGJUMP_LIST_H_
-#define SAKURA_CSORTED_TAGJUMP_LIST_H_
+#pragma once
 
 #include "util/design_template.h"
 
@@ -83,4 +82,3 @@ private:
 	DISALLOW_COPY_AND_ASSIGN(CSortedTagJumpList);
 };
 
-#endif	//SAKURA_CSORTED_TAGJUMP_LIST_H_

--- a/sakura_core/CWriteManager.h
+++ b/sakura_core/CWriteManager.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CWRITEMANAGER_2F063818_9A9D_4BEF_830F_987AEBBCBB07_H_
-#define SAKURA_CWRITEMANAGER_2F063818_9A9D_4BEF_830F_987AEBBCBB07_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 #include "charset/CCodeBase.h"
@@ -41,5 +40,4 @@ public:
 	);
 };
 
-#endif /* SAKURA_CWRITEMANAGER_2F063818_9A9D_4BEF_830F_987AEBBCBB07_H_ */
 /*[EOF]*/

--- a/sakura_core/EditInfo.h
+++ b/sakura_core/EditInfo.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_EDITINFO_38A7E267_160D_4250_9012_AC3FC31993D69_H_
-#define SAKURA_EDITINFO_38A7E267_160D_4250_9012_AC3FC31993D69_H_
+#pragma once
 
 #include "basis/SakuraBasis.h"
 #include "config/maxdata.h"
@@ -91,5 +90,4 @@ struct EditInfo {
 	}
 };
 
-#endif /* SAKURA_EDITINFO_38A7E267_160D_4250_9012_AC3FC31993D69_H_ */
 /*[EOF]*/

--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -4,12 +4,7 @@
 //				プロジェクト専用のインクルード ファイルを記述します。
 //
 
-#if !defined(AFX_STDAFX_H__11490042_E569_11D3_BCE2_444553540001__INCLUDED_)
-#define AFX_STDAFX_H__11490042_E569_11D3_BCE2_444553540001__INCLUDED_
-
-#if defined(_MSC_VER) && _MSC_VER > 1000
 #pragma once
-#endif // _MSC_VER > 1000
 
 // この位置にヘッダーを挿入してください
 // #define WIN32_LEAN_AND_MEAN		// Windows ヘッダーから殆ど使用されないスタッフを除外します
@@ -160,6 +155,4 @@
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ は前行の直前に追加の宣言を挿入します。
-
-#endif // !defined(AFX_STDAFX_H__11490042_E569_11D3_BCE2_444553540001__INCLUDED_)
 

--- a/sakura_core/_main/CAppMode.h
+++ b/sakura_core/_main/CAppMode.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CAPPMODE_22018B3D_FC0F_485B_A72E_DA3DA3B9DDAAR_H_
-#define SAKURA_CAPPMODE_22018B3D_FC0F_485B_A72E_DA3DA3B9DDAAR_H_
+#pragma once
 
 #include "util/design_template.h"
 #include "doc/CDocListener.h"
@@ -58,5 +57,4 @@ public:
 	wchar_t			m_szGrepKey[1024];			//!< Grepモードの場合、その検索キー
 };
 
-#endif /* SAKURA_CAPPMODE_22018B3D_FC0F_485B_A72E_DA3DA3B9DDAAR_H_ */
 /*[EOF]*/

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -16,8 +16,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CCOMMANDLINE_H_
-#define _CCOMMANDLINE_H_
+#pragma once
 
 #include "global.h"
 #include "EditInfo.h"
@@ -122,5 +121,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CCOMMANDLINE_H_ */
-

--- a/sakura_core/_main/CControlProcess.h
+++ b/sakura_core/_main/CControlProcess.h
@@ -12,8 +12,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CCONTROLPROCESS_H_
-#define _CCONTROLPROCESS_H_
+#pragma once
 
 #include "global.h"
 #include "CProcess.h"
@@ -56,5 +55,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CCONTROLPROCESS_H_ */
-

--- a/sakura_core/_main/CControlTray.h
+++ b/sakura_core/_main/CControlTray.h
@@ -22,8 +22,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CCONTROLTRAY_H_
-#define _CCONTROLTRAY_H_
+#pragma once
 
 #include <Windows.h>
 #include "uiparts/CMenuDrawer.h"
@@ -131,5 +130,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CCONTROLTRAY_H_ */
-

--- a/sakura_core/_main/CMutex.h
+++ b/sakura_core/_main/CMutex.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef _CMUTEX_H_
-#define _CMUTEX_H_
+#pragma once
 
 #include <Windows.h>
 
@@ -104,6 +103,4 @@ public:
 		o_.Unlock();
 	}
 };
-
-#endif /* _CMUTEX_H_ */
 

--- a/sakura_core/_main/CNormalProcess.h
+++ b/sakura_core/_main/CNormalProcess.h
@@ -11,8 +11,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CNORMALPROCESS_H_
-#define _CNORMALPROCESS_H_
+#pragma once
 
 #include "global.h"
 #include "CProcess.h"
@@ -51,5 +50,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CNORMALPROCESS_H_ */
-

--- a/sakura_core/_main/CProcess.h
+++ b/sakura_core/_main/CProcess.h
@@ -12,8 +12,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CPROCESS_H_
-#define _CPROCESS_H_
+#pragma once
 
 #include "global.h"
 #include "env/CShareData.h"
@@ -71,5 +70,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CPROCESS_H_ */
-

--- a/sakura_core/_main/CProcessFactory.h
+++ b/sakura_core/_main/CProcessFactory.h
@@ -12,8 +12,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CPROCESSFACTORY_H_
-#define _CPROCESSFACTORY_H_
+#pragma once
 
 #include "global.h"
 
@@ -46,5 +45,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CPROCESSFACTORY_H_ */
-

--- a/sakura_core/_main/global.h
+++ b/sakura_core/_main/global.h
@@ -18,8 +18,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _GLOBAL_H_
-#define _GLOBAL_H_
+#pragma once
 
 //////////////////////////////////////////////////////////////
 #ifndef STRICT
@@ -193,5 +192,3 @@ extern CEditWnd* g_pcEditWnd;
 HINSTANCE G_AppInstance();
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _GLOBAL_H_ */
-

--- a/sakura_core/_os/CClipboard.h
+++ b/sakura_core/_os/CClipboard.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCLIPBOARD_25819BE6_8087_45F7_840E_161DE12E736AR_H_
-#define SAKURA_CCLIPBOARD_25819BE6_8087_45F7_840E_161DE12E736AR_H_
+#pragma once
 
 class CEol;
 
@@ -58,5 +57,4 @@ public:
 	static int GetDataType();      //!< クリップボードデータ形式(CF_UNICODETEXT等)の取得
 };
 
-#endif /* SAKURA_CCLIPBOARD_25819BE6_8087_45F7_840E_161DE12E736AR_H_ */
 /*[EOF]*/

--- a/sakura_core/_os/CDropTarget.h
+++ b/sakura_core/_os/CDropTarget.h
@@ -13,8 +13,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CEDITDROPTARGET_H_
-#define _CEDITDROPTARGET_H_
+#pragma once
 
 #include <Unknwn.h>
 #include "util/design_template.h"
@@ -169,5 +168,3 @@ public:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CEDITDROPTARGET_H_ */
-

--- a/sakura_core/_os/OleTypes.h
+++ b/sakura_core/_os/OleTypes.h
@@ -10,8 +10,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 
 */
-#ifndef __OLE_TYPES_WRAP__
-#define __OLE_TYPES_WRAP__
+#pragma once
 
 #include <Windows.h>
 #include <OleAuto.h>
@@ -119,4 +118,4 @@ inline SysString* Wrap(BSTR *Value)
 {
 	return reinterpret_cast<SysString*>(Value);
 }
-#endif
+

--- a/sakura_core/apiwrap/CommonControl.h
+++ b/sakura_core/apiwrap/CommonControl.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_COMMONCONTROL_D732DE4D_9F3E_4E17_B6B3_0C11AD0D9F4F_H_
-#define SAKURA_COMMONCONTROL_D732DE4D_9F3E_4E17_B6B3_0C11AD0D9F4F_H_
+#pragma once
 
 #include <CommCtrl.h> // コモンコントロール
 
@@ -101,5 +100,4 @@ namespace ApiWrap
 
 using namespace ApiWrap;
 
-#endif /* SAKURA_COMMONCONTROL_D732DE4D_9F3E_4E17_B6B3_0C11AD0D9F4F_H_ */
 /*[EOF]*/

--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_STDAPI_85471C2C_6AEE_410D_BD09_A59056A5BA68_H_
-#define SAKURA_STDAPI_85471C2C_6AEE_410D_BD09_A59056A5BA68_H_
+#pragma once
 
 //ランタイム情報ライブラリにアクセスするWindowsヘッダを参照する
 #include <ImageHlp.h>
@@ -105,5 +104,4 @@ namespace ApiWrap
 }
 using namespace ApiWrap;
 
-#endif /* SAKURA_STDAPI_85471C2C_6AEE_410D_BD09_A59056A5BA68_H_ */
 /*[EOF]*/

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_STDCONTROL_76CB2C84_679D_4A46_B9E3_5325EF85F8E7_H_
-#define SAKURA_STDCONTROL_76CB2C84_679D_4A46_B9E3_5325EF85F8E7_H_
+#pragma once
 
 /*
 2007.09.17 kobake
@@ -246,5 +245,4 @@ namespace ApiWrap{
 }
 using namespace ApiWrap;
 
-#endif /* SAKURA_STDCONTROL_76CB2C84_679D_4A46_B9E3_5325EF85F8E7_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/CLaxInteger.h
+++ b/sakura_core/basis/CLaxInteger.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CLAXINTEGER_A4B639A5_3AD6_4C99_882B_4674CB0C155B9_H_
-#define SAKURA_CLAXINTEGER_A4B639A5_3AD6_4C99_882B_4674CB0C155B9_H_
+#pragma once
 
 //!型チェックの緩い整数型
 class CLaxInteger{
@@ -44,5 +43,4 @@ private:
 	int m_value;
 };
 
-#endif /* SAKURA_CLAXINTEGER_A4B639A5_3AD6_4C99_882B_4674CB0C155B9_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/CMyPoint.h
+++ b/sakura_core/basis/CMyPoint.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CMYPOINT_A1799013_DDEC_472A_850B_6FCA04FC21049_H_
-#define SAKURA_CMYPOINT_A1799013_DDEC_472A_850B_6FCA04FC21049_H_
+#pragma once
 
 #include <Windows.h> //POINT
 
@@ -118,5 +117,4 @@ inline void TwoPointToRect(
 	}
 }
 
-#endif /* SAKURA_CMYPOINT_A1799013_DDEC_472A_850B_6FCA04FC21049_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/CMyRect.h
+++ b/sakura_core/basis/CMyRect.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CMYRECT_25A0FB5F_E06F_4F51_B046_E6951B95B0059_H_
-#define SAKURA_CMYRECT_25A0FB5F_E06F_4F51_B046_E6951B95B0059_H_
+#pragma once
 
 #include <Windows.h> //RECT
 #include "CMyPoint.h"
@@ -100,5 +99,4 @@ public:
 //!CRect合成。rc1,rc2を含む最小の矩形を生成する。
 CMyRect MergeRect(const CMyRect& rc1, const CMyRect& rc2);
 
-#endif /* SAKURA_CMYRECT_25A0FB5F_E06F_4F51_B046_E6951B95B0059_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/CMySize.h
+++ b/sakura_core/basis/CMySize.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CMYSIZE_1885EC13_14C3_4F76_9907_6AEAA9D83A7B9_H_
-#define SAKURA_CMYSIZE_1885EC13_14C3_4F76_9907_6AEAA9D83A7B9_H_
+#pragma once
 
 #include <Windows.h> //SIZE
 
@@ -42,5 +41,4 @@ public:
 	bool operator != (const SIZE& rhs) const{ return !operator==(rhs); }
 };
 
-#endif /* SAKURA_CMYSIZE_1885EC13_14C3_4F76_9907_6AEAA9D83A7B9_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/CMyString.h
+++ b/sakura_core/basis/CMyString.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CMYSTRING_43EB58CF_8782_43AC_AC82_A22DFC99E063_H_
-#define SAKURA_CMYSTRING_43EB58CF_8782_43AC_AC82_A22DFC99E063_H_
+#pragma once
 
 #include <string>
 #include "util/string_ex.h"
@@ -108,5 +107,4 @@ private:
 	WCHAR*	m_pHead;
 };
 
-#endif /* SAKURA_CMYSTRING_43EB58CF_8782_43AC_AC82_A22DFC99E063_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/CStrictInteger.h
+++ b/sakura_core/basis/CStrictInteger.h
@@ -28,8 +28,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSTRICTINTEGER_6F202774_0F82_4BB7_B107_37DE5443309E_H_
-#define SAKURA_CSTRICTINTEGER_6F202774_0F82_4BB7_B107_37DE5443309E_H_
+#pragma once
 
 #include "primitive.h" // for Int
 
@@ -226,5 +225,4 @@ STRICTINT_LEFT_INT_CMP(short)
 STRICTINT_LEFT_INT_CMP(size_t)
 STRICTINT_LEFT_INT_CMP(LONG)
 
-#endif /* SAKURA_CSTRICTINTEGER_6F202774_0F82_4BB7_B107_37DE5443309E_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/CStrictPoint.h
+++ b/sakura_core/basis/CStrictPoint.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSTRICTPOINT_56029CB9_EAD4_489E_9300_5990D582337F_H_
-#define SAKURA_CSTRICTPOINT_56029CB9_EAD4_489E_9300_5990D582337F_H_
+#pragma once
 
 //単位が明示的に区別されたポイント型。※POINTは継承しないことにした
 /*
@@ -113,5 +112,4 @@ public:
 	}
 };
 
-#endif /* SAKURA_CSTRICTPOINT_56029CB9_EAD4_489E_9300_5990D582337F_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/CStrictRange.h
+++ b/sakura_core/basis/CStrictRange.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSTRICTRANGE_01CCFDA1_93B9_4053_BF1E_0CFE0E5F55A1_H_
-#define SAKURA_CSTRICTRANGE_01CCFDA1_93B9_4053_BF1E_0CFE0E5F55A1_H_
+#pragma once
 
 template <class PointType>
 class CRangeBase{
@@ -155,5 +154,4 @@ private:
 	PointType m_ptTo;
 };
 
-#endif /* SAKURA_CSTRICTRANGE_01CCFDA1_93B9_4053_BF1E_0CFE0E5F55A1_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/CStrictRect.h
+++ b/sakura_core/basis/CStrictRect.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSTRICTRECT_F3676246_1D72_4A04_9614_3881BBA67B16_H_
-#define SAKURA_CSTRICTRECT_F3676246_1D72_4A04_9614_3881BBA67B16_H_
+#pragma once
 
 template <class INT_TYPE, class POINT_TYPE> class CStrictRect{
 private:
@@ -66,5 +65,4 @@ public:
 	}
 };
 
-#endif /* SAKURA_CSTRICTRECT_F3676246_1D72_4A04_9614_3881BBA67B16_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/SakuraBasis.h
+++ b/sakura_core/basis/SakuraBasis.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_SAKURABASIS_DA3203FF_3FD7_4AD1_BC64_E85C8171335E9_H_
-#define SAKURA_SAKURABASIS_DA3203FF_3FD7_4AD1_BC64_E85C8171335E9_H_
+#pragma once
 
 #include <Windows.h> //POINT,LONG
 
@@ -145,5 +144,4 @@ inline void TwoPointToRect(
 	}
 }
 
-#endif /* SAKURA_SAKURABASIS_DA3203FF_3FD7_4AD1_BC64_E85C8171335E9_H_ */
 /*[EOF]*/

--- a/sakura_core/basis/primitive.h
+++ b/sakura_core/basis/primitive.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_PRIMITIVE_0AE619F1_2A04_42A0_92F6_72C9B845799E_H_
-#define SAKURA_PRIMITIVE_0AE619F1_2A04_42A0_92F6_72C9B845799E_H_
+#pragma once
 
 // -- -- -- -- 文字 -- -- -- -- //
 
@@ -56,5 +55,4 @@ typedef char KEYCODE;
 	typedef int Int;
 #endif
 
-#endif /* SAKURA_PRIMITIVE_0AE619F1_2A04_42A0_92F6_72C9B845799E_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CCesu8.h
+++ b/sakura_core/charset/CCesu8.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCESU8_5E82F67D_CFE7_4B3D_9BA2_22FD3F31086F_H_
-#define SAKURA_CCESU8_5E82F67D_CFE7_4B3D_9BA2_22FD3F31086F_H_
+#pragma once
 
 #include "CCodeBase.h"
 #include "CUtf8.h"
@@ -45,5 +44,4 @@ public:
 	}
 };
 
-#endif /* SAKURA_CCESU8_5E82F67D_CFE7_4B3D_9BA2_22FD3F31086F_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CCodeBase.h
+++ b/sakura_core/charset/CCodeBase.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCODEBASE_79FA6B92_246A_4427_89C9_92E1F1335EB9_H_
-#define SAKURA_CCODEBASE_79FA6B92_246A_4427_89C9_92E1F1335EB9_H_
+#pragma once
 
 //定数
 enum EConvertResult{
@@ -97,5 +96,4 @@ inline int CCodeBase::TextToBin( const unsigned short cSrc )
 	return static_cast<int>((cSrc - 0xdc00) & 0x00ff);
 }
 
-#endif /* SAKURA_CCODEBASE_79FA6B92_246A_4427_89C9_92E1F1335EB9_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CCodeFactory.h
+++ b/sakura_core/charset/CCodeFactory.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCODEFACTORY_953F01EB_9094_453E_92FC_35456A0E11A9_H_
-#define SAKURA_CCODEFACTORY_953F01EB_9094_453E_92FC_35456A0E11A9_H_
+#pragma once
 
 class CCodeBase;
 
@@ -36,5 +35,4 @@ public:
 	);
 };
 
-#endif /* SAKURA_CCODEFACTORY_953F01EB_9094_453E_92FC_35456A0E11A9_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CCodeMediator.h
+++ b/sakura_core/charset/CCodeMediator.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCODEMEDIATOR_653AC1CB_8935_4F2A_AF03_8FE669F6FA9F_H_
-#define SAKURA_CCODEMEDIATOR_653AC1CB_8935_4F2A_AF03_8FE669F6FA9F_H_
+#pragma once
 
 #include "charset/CESI.h"
 class CEditDoc;
@@ -51,5 +50,4 @@ private:
 	const SEncodingConfig* m_pEncodingConfig;
 };
 
-#endif /* SAKURA_CCODEMEDIATOR_653AC1CB_8935_4F2A_AF03_8FE669F6FA9F_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CCodePage.h
+++ b/sakura_core/charset/CCodePage.h
@@ -26,8 +26,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCODEPAGE_H_
-#define SAKURA_CCODEPAGE_H_
+#pragma once
 
 #include "CCodeBase.h"
 #include <vector>
@@ -96,4 +95,3 @@ protected:
 	static int S_UnicodeToUTF32BE(const wchar_t* pSrc, int nSrcLen, char* pDst, int nDstLen);
 };
 
-#endif // SAKURA_CCODEPAGE_H_

--- a/sakura_core/charset/CESI.h
+++ b/sakura_core/charset/CESI.h
@@ -30,8 +30,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CESI_B70CADC4_E43F_40D7_B87C_0C7C14ABDF41_H_
-#define SAKURA_CESI_B70CADC4_E43F_40D7_B87C_0C7C14ABDF41_H_
+#pragma once
 
 struct SEncodingConfig;
 
@@ -217,5 +216,4 @@ public:
 #endif
 };
 
-#endif /* SAKURA_CESI_B70CADC4_E43F_40D7_B87C_0C7C14ABDF41_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CEuc.h
+++ b/sakura_core/charset/CEuc.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CEUC_13190B0A_A5F1_4CF2_AA8E_E58906DA05AD9_H_
-#define SAKURA_CEUC_13190B0A_A5F1_4CF2_AA8E_E58906DA05AD9_H_
+#pragma once
 
 #include <mbstring.h>
 #include "charset/CCodeBase.h"
@@ -188,5 +187,4 @@ inline int CEuc::_UniToEucjp_char( const unsigned short* pSrc, unsigned char* pD
 	return nret;
 }
 
-#endif /* SAKURA_CEUC_13190B0A_A5F1_4CF2_AA8E_E58906DA05AD9_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CJis.h
+++ b/sakura_core/charset/CJis.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CJIS_3DD8E095_FA6C_46BA_BDD8_00F658818D72_H_
-#define SAKURA_CJIS_3DD8E095_FA6C_46BA_BDD8_00F658818D72_H_
+#pragma once
 
 #include "CCodeBase.h"
 
@@ -106,5 +105,4 @@ enum EJisESCSeqType {
 
 #endif
 
-#endif /* SAKURA_CJIS_3DD8E095_FA6C_46BA_BDD8_00F658818D72_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CLatin1.h
+++ b/sakura_core/charset/CLatin1.h
@@ -27,8 +27,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CLATIN1_H_
-#define SAKURA_CLATIN1_H_
+#pragma once
 
 #include "CCodeBase.h"
 
@@ -100,4 +99,3 @@ inline int CLatin1::_UniToLatin1_char( const unsigned short* pSrc, unsigned char
 	return nret;
 }
 
-#endif /* SAKURA_CLATIN1_H_ */

--- a/sakura_core/charset/CShiftJis.h
+++ b/sakura_core/charset/CShiftJis.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSHIFTJIS_092DD5ED_C21B_4122_8A97_CF4EE64B7EFD_H_
-#define SAKURA_CSHIFTJIS_092DD5ED_C21B_4122_8A97_CF4EE64B7EFD_H_
+#pragma once
 
 #include "CCodeBase.h"
 #include "charset/codeutil.h"
@@ -139,5 +138,4 @@ inline int CShiftJis::_UniToSjis_char( const unsigned short* pSrc, unsigned char
 	return nret;
 }
 
-#endif /* SAKURA_CSHIFTJIS_092DD5ED_C21B_4122_8A97_CF4EE64B7EFD_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CUnicode.h
+++ b/sakura_core/charset/CUnicode.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CUNICODE_95AC7095_F71E_458B_80B3_1AA4036E25109_H_
-#define SAKURA_CUNICODE_95AC7095_F71E_458B_80B3_1AA4036E25109_H_
+#pragma once
 
 // IsUtf16SurrogHi()、IsUtf16SurrogLow() 関数をcharset/codechecker.h に移動
 
@@ -48,5 +47,4 @@ public:
 	inline static EConvertResult UnicodeToUnicode_out(const CNativeW& cSrc, CMemory* pDst){ return _UnicodeToUnicode_out(cSrc, pDst, false); }
 };
 
-#endif /* SAKURA_CUNICODE_95AC7095_F71E_458B_80B3_1AA4036E25109_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CUnicodeBe.h
+++ b/sakura_core/charset/CUnicodeBe.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CUNICODEBE_484B0FE6_3896_4E2E_83BA_CC8718999735_H_
-#define SAKURA_CUNICODEBE_484B0FE6_3896_4E2E_83BA_CC8718999735_H_
+#pragma once
 
 #include "CCodeBase.h"
 #include "CUnicode.h"
@@ -45,5 +44,4 @@ public:
 		{ return CUnicode::_UnicodeToUnicode_out(cSrc, pDst, true); }	// Unicode   → UnicodeBEコード変換
 };
 
-#endif /* SAKURA_CUNICODEBE_484B0FE6_3896_4E2E_83BA_CC8718999735_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CUtf7.h
+++ b/sakura_core/charset/CUtf7.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CUTF7_D489ED48_E52A_43DD_8124_CB439CA30FC8_H_
-#define SAKURA_CUTF7_D489ED48_E52A_43DD_8124_CB439CA30FC8_H_
+#pragma once
 
 #include "CCodeBase.h"
 
@@ -53,5 +52,4 @@ protected:
 	static int UniToUtf7( const wchar_t* pSrc, const int nSrcLen, char* pDst );
 };
 
-#endif /* SAKURA_CUTF7_D489ED48_E52A_43DD_8124_CB439CA30FC8_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CUtf8.h
+++ b/sakura_core/charset/CUtf8.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CUTF8_EDEFA3B8_A37B_4416_9EC5_0A16659C92059_H_
-#define SAKURA_CUTF8_EDEFA3B8_A37B_4416_9EC5_0A16659C92059_H_
+#pragma once
 
 #include "CCodeBase.h"
 #include "charset/codeutil.h"
@@ -158,5 +157,4 @@ inline int CUtf8::_UniToUtf8_char( const unsigned short* pSrc, const int nSrcLen
 	return nret;
 }
 
-#endif /* SAKURA_CUTF8_EDEFA3B8_A37B_4416_9EC5_0A16659C92059_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/CharPointer.h
+++ b/sakura_core/charset/CharPointer.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CHARPOINTER_6EAF62A9_67F6_4CEF_80C2_B7C34014C253_H_
-#define SAKURA_CHARPOINTER_6EAF62A9_67F6_4CEF_80C2_B7C34014C253_H_
+#pragma once
 
 #include "charset/charcode.h"
 
@@ -110,5 +109,4 @@ private:
 
 typedef CharPointerW CharPointerT;
 
-#endif /* SAKURA_CHARPOINTER_6EAF62A9_67F6_4CEF_80C2_B7C34014C253_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CHARCODE_5A887F7C_8E08_4940_AF65_BD6850C3A7B5_H_
-#define SAKURA_CHARCODE_5A887F7C_8E08_4940_AF65_BD6850C3A7B5_H_
+#pragma once
 
 //2007.09.13 kobake 作成
 #include "parse/CWordParse.h"
@@ -344,5 +343,4 @@ void SelectCharWidthCache( ECharWidthFontMode fMode, ECharWidthCacheMode cMode )
 void InitCharWidthCache( const LOGFONT &lf, ECharWidthFontMode fMode=CWM_FONT_EDIT ); //!< フォントを変更したとき
 void InitCharWidthCacheFromDC(const LOGFONT* lfs, ECharWidthFontMode fMode, HDC hdcOrg );
 
-#endif /* SAKURA_CHARCODE_5A887F7C_8E08_4940_AF65_BD6850C3A7B5_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/charset.h
+++ b/sakura_core/charset/charset.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CHARSET_51A8CEE7_80CB_463F_975E_B30715B1C385_H_
-#define SAKURA_CHARSET_51A8CEE7_80CB_463F_975E_B30715B1C385_H_
+#pragma once
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           定数                              //
@@ -141,5 +140,4 @@ public:
 	LPCWSTR		GetName(int nIndex) const;
 };
 
-#endif /* SAKURA_CHARSET_51A8CEE7_80CB_463F_975E_B30715B1C385_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/codechecker.h
+++ b/sakura_core/charset/codechecker.h
@@ -31,8 +31,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CODECHECKER_A8F89832_50E1_4F5F_9306_467062C9E3679_H_
-#define SAKURA_CODECHECKER_A8F89832_50E1_4F5F_9306_467062C9E3679_H_
+#pragma once
 
 #include "_main/global.h"
 #include "convert/convert_util2.h"
@@ -447,5 +446,4 @@ int CheckCesu8Char( const char*, const int, ECharSet*, const int nOption );
 int CheckUtf7DPart( const char*, const int, char **ppNextChar, bool *pbError );
 int CheckUtf7BPart( const char*, const int, char **ppNextChar, bool *pbError, const int nOption, bool *pbNoAddPoint = NULL );
 
-#endif /* SAKURA_CODECHECKER_A8F89832_50E1_4F5F_9306_467062C9E3679_H_ */
 /*[EOF]*/

--- a/sakura_core/charset/codeutil.h
+++ b/sakura_core/charset/codeutil.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CODEUTIL_E12B274F_2A3B_47A0_AFCB_4BAD1B3308AB_H_
-#define SAKURA_CODEUTIL_E12B274F_2A3B_47A0_AFCB_4BAD1B3308AB_H_
+#pragma once
 
 #include <Windows.h>
 
@@ -207,5 +206,4 @@ inline int MyMultiByteToWideChar_JP( const unsigned char* pSrc, const int nSrcLe
 	return nret;
 }
 
-#endif /* SAKURA_CODEUTIL_E12B274F_2A3B_47A0_AFCB_4BAD1B3308AB_H_ */
 /*[EOF]*/

--- a/sakura_core/cmd/CViewCommander.h
+++ b/sakura_core/cmd/CViewCommander.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CVIEWCOMMANDER_5F4F7A80_2BEC_4B1D_A637_B922375FF14C9_H_
-#define SAKURA_CVIEWCOMMANDER_5F4F7A80_2BEC_4B1D_A637_B922375FF14C9_H_
+#pragma once
 
 class CEditView;
 enum EFunctionCode;
@@ -410,5 +409,4 @@ public:
 	void Sub_BoxSelectLock( int flags );
 };
 
-#endif /* SAKURA_CVIEWCOMMANDER_5F4F7A80_2BEC_4B1D_A637_B922375FF14C9_H_ */
 /*[EOF]*/

--- a/sakura_core/cmd/CViewCommander_inline.h
+++ b/sakura_core/cmd/CViewCommander_inline.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CVIEWCOMMANDER_INLINE_265ADE2D_61EE_450A_9B9B_92C5762690A4_H_
-#define SAKURA_CVIEWCOMMANDER_INLINE_265ADE2D_61EE_450A_9B9B_92C5762690A4_H_
+#pragma once
 
 #include "view/CEditView.h"
 #include "doc/CEditDoc.h"
@@ -61,5 +60,4 @@ inline CCaret& CViewCommander::GetCaret()
 	return m_pCommanderView->GetCaret();
 }
 
-#endif /* SAKURA_CVIEWCOMMANDER_INLINE_265ADE2D_61EE_450A_9B9B_92C5762690A4_H_ */
 /*[EOF]*/

--- a/sakura_core/config/app_constants.h
+++ b/sakura_core/config/app_constants.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_APP_CONSTANTS_AD36E2CE_B62E_497D_806F_6B9738310127_H_
-#define SAKURA_APP_CONSTANTS_AD36E2CE_B62E_497D_806F_6B9738310127_H_
+#pragma once
 
 #include "build_config.h"
 
@@ -57,5 +56,4 @@ const int MINLINEKETAS		= 10;		//!< 1行の桁数の最小値
 const int LINENUMWIDTH_MIN = 2;
 const int LINENUMWIDTH_MAX = 11;
 
-#endif /* SAKURA_APP_CONSTANTS_AD36E2CE_B62E_497D_806F_6B9738310127_H_ */
 /*[EOF]*/

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_BUILD_CONFIG_26C6FCD0_99D7_4AF6_89C1_F34581417333_H_
-#define SAKURA_BUILD_CONFIG_26C6FCD0_99D7_4AF6_89C1_F34581417333_H_
+#pragma once
 
 //ビルド(コンパイル)設定
 //2007.10.18 kobake 作成
@@ -112,5 +111,4 @@ static const bool UNICODE_BOOL=true;
 #define ALPHA_VERSION
 #endif
 
-#endif /* SAKURA_BUILD_CONFIG_26C6FCD0_99D7_4AF6_89C1_F34581417333_H_ */
 /*[EOF]*/

--- a/sakura_core/config/maxdata.h
+++ b/sakura_core/config/maxdata.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_MAXDATA_CEFC5993_30DF_4A7C_981A_512B8CE6FD979_H_
-#define SAKURA_MAXDATA_CEFC5993_30DF_4A7C_981A_512B8CE6FD979_H_
+#pragma once
 
 /*! 最大値定義
 	@date 2007.10.19 kobake 新規作成
@@ -89,5 +88,4 @@ enum maxdata{
 	MAX_MAIN_MENU_NAME_LEN		= 40,	// メインメニュー名文字列長
 };
 
-#endif /* SAKURA_MAXDATA_CEFC5993_30DF_4A7C_981A_512B8CE6FD979_H_ */
 /*[EOF]*/

--- a/sakura_core/config/system_constants.h
+++ b/sakura_core/config/system_constants.h
@@ -32,8 +32,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_SYSTEM_CONSTANTS_608BC31D_86C2_4526_B749_70DBD090752A_H_
-#define SAKURA_SYSTEM_CONSTANTS_608BC31D_86C2_4526_B749_70DBD090752A_H_
+#pragma once
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                       定数命名補助                          //
@@ -745,5 +744,4 @@ enum e_PM_SETCARETPOS_SELECTSTATE {
 //! ウィンドウ一覧表示
 #define MYWM_DLGWINLIST (WM_APP+225)
 
-#endif /* SAKURA_SYSTEM_CONSTANTS_608BC31D_86C2_4526_B749_70DBD090752A_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert.h
+++ b/sakura_core/convert/CConvert.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_BF272748_9EF0_4F5A_952C_8BED216658F9_H_
-#define SAKURA_CCONVERT_BF272748_9EF0_4F5A_952C_8BED216658F9_H_
+#pragma once
 
 //2007.10.02 kobake CEditViewから分離
 
@@ -55,5 +54,4 @@ public:
 	virtual bool DoConvert( CNativeW* pcData )=0;
 };
 
-#endif /* SAKURA_CCONVERT_BF272748_9EF0_4F5A_952C_8BED216658F9_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_HaneisuToZeneisu.h
+++ b/sakura_core/convert/CConvert_HaneisuToZeneisu.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_HANEISUTOZENEISU_AA3930A7_12A8_43A0_B7B4_6BF05F3898069_H_
-#define SAKURA_CCONVERT_HANEISUTOZENEISU_AA3930A7_12A8_43A0_B7B4_6BF05F3898069_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -33,5 +32,4 @@ public:
 	bool DoConvert(CNativeW* pcData) override;
 };
 
-#endif /* SAKURA_CCONVERT_HANEISUTOZENEISU_AA3930A7_12A8_43A0_B7B4_6BF05F3898069_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_HankataToZenhira.h
+++ b/sakura_core/convert/CConvert_HankataToZenhira.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_HANKATATOZENHIRA_8F5785BC_BD5F_4034_8C71_A645A69FBE3B9_H_
-#define SAKURA_CCONVERT_HANKATATOZENHIRA_8F5785BC_BD5F_4034_8C71_A645A69FBE3B9_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -33,5 +32,4 @@ public:
 	bool DoConvert(CNativeW* pcData) override;
 };
 
-#endif /* SAKURA_CCONVERT_HANKATATOZENHIRA_8F5785BC_BD5F_4034_8C71_A645A69FBE3B9_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_HankataToZenkata.h
+++ b/sakura_core/convert/CConvert_HankataToZenkata.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_HANKATATOZENKATA_45FB10FC_3254_4F79_A244_077BED31A42B9_H_
-#define SAKURA_CCONVERT_HANKATATOZENKATA_45FB10FC_3254_4F79_A244_077BED31A42B9_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -33,5 +32,4 @@ public:
 	bool DoConvert(CNativeW* pcData) override;
 };
 
-#endif /* SAKURA_CCONVERT_HANKATATOZENKATA_45FB10FC_3254_4F79_A244_077BED31A42B9_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_SpaceToTab.h
+++ b/sakura_core/convert/CConvert_SpaceToTab.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_SPACETOTAB_E17CC2BE_1BD0_4838_ABFD_570B344B99AD_H_
-#define SAKURA_CCONVERT_SPACETOTAB_E17CC2BE_1BD0_4838_ABFD_570B344B99AD_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -42,5 +41,4 @@ private:
 	bool m_bExtEol;
 };
 
-#endif /* SAKURA_CCONVERT_SPACETOTAB_E17CC2BE_1BD0_4838_ABFD_570B344B99AD_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_TabToSpace.h
+++ b/sakura_core/convert/CConvert_TabToSpace.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_TABTOSPACE_186F357B_6A69_4B23_8ABF_887D2A02B287_H_
-#define SAKURA_CCONVERT_TABTOSPACE_186F357B_6A69_4B23_8ABF_887D2A02B287_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -42,5 +41,4 @@ private:
 	bool m_bExtEol;
 };
 
-#endif /* SAKURA_CCONVERT_TABTOSPACE_186F357B_6A69_4B23_8ABF_887D2A02B287_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_ToHankaku.h
+++ b/sakura_core/convert/CConvert_ToHankaku.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_TOHANKAKU_AA990D46_6904_44DF_8162_B2D96E20AE3A_H_
-#define SAKURA_CCONVERT_TOHANKAKU_AA990D46_6904_44DF_8162_B2D96E20AE3A_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -39,5 +38,4 @@ enum EToHankakuMode{
 	TO_EISU		= 0x04, //!< 英数字に影響アリ
 };
 
-#endif /* SAKURA_CCONVERT_TOHANKAKU_AA990D46_6904_44DF_8162_B2D96E20AE3A_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_ToLower.h
+++ b/sakura_core/convert/CConvert_ToLower.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_TOLOWER_B0D85F8A_5D8F_44CC_A027_5A452BE56109_H_
-#define SAKURA_CCONVERT_TOLOWER_B0D85F8A_5D8F_44CC_A027_5A452BE56109_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -32,5 +31,4 @@ public:
 	bool DoConvert(CNativeW* pcData) override;
 };
 
-#endif /* SAKURA_CCONVERT_TOLOWER_B0D85F8A_5D8F_44CC_A027_5A452BE56109_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_ToUpper.h
+++ b/sakura_core/convert/CConvert_ToUpper.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_TOUPPER_98DEA386_E8FA_466B_AE7A_6A708EC39F0D9_H_
-#define SAKURA_CCONVERT_TOUPPER_98DEA386_E8FA_466B_AE7A_6A708EC39F0D9_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -32,5 +31,4 @@ public:
 	bool DoConvert(CNativeW* pcData) override;
 };
 
-#endif /* SAKURA_CCONVERT_TOUPPER_98DEA386_E8FA_466B_AE7A_6A708EC39F0D9_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_ToZenhira.h
+++ b/sakura_core/convert/CConvert_ToZenhira.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_TOZENHIRA_A2D60F31_CBF3_427D_A622_A585F1F3E667_H_
-#define SAKURA_CCONVERT_TOZENHIRA_A2D60F31_CBF3_427D_A622_A585F1F3E667_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -33,5 +32,4 @@ public:
 	bool DoConvert(CNativeW* pcData) override;
 };
 
-#endif /* SAKURA_CCONVERT_TOZENHIRA_A2D60F31_CBF3_427D_A622_A585F1F3E667_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_ToZenkata.h
+++ b/sakura_core/convert/CConvert_ToZenkata.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_TOZENKATA_F23E454A_B7B2_4655_910D_EF97F0A98E6A_H_
-#define SAKURA_CCONVERT_TOZENKATA_F23E454A_B7B2_4655_910D_EF97F0A98E6A_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -33,5 +32,4 @@ public:
 	bool DoConvert(CNativeW* pcData) override;
 };
 
-#endif /* SAKURA_CCONVERT_TOZENKATA_F23E454A_B7B2_4655_910D_EF97F0A98E6A_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_Trim.h
+++ b/sakura_core/convert/CConvert_Trim.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_TRIM_09061551_FDED_4982_A974_FAC9AE9AF040_H_
-#define SAKURA_CCONVERT_TRIM_09061551_FDED_4982_A974_FAC9AE9AF040_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -39,5 +38,4 @@ private:
 	bool m_bExtEol;
 };
 
-#endif /* SAKURA_CCONVERT_TRIM_09061551_FDED_4982_A974_FAC9AE9AF040_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_ZeneisuToHaneisu.h
+++ b/sakura_core/convert/CConvert_ZeneisuToHaneisu.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_ZENEISUTOHANEISU_AB71D3F0_338A_4B00_80A1_B11589BE1C759_H_
-#define SAKURA_CCONVERT_ZENEISUTOHANEISU_AB71D3F0_338A_4B00_80A1_B11589BE1C759_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -33,5 +32,4 @@ public:
 	bool DoConvert(CNativeW* pcData) override;
 };
 
-#endif /* SAKURA_CCONVERT_ZENEISUTOHANEISU_AB71D3F0_338A_4B00_80A1_B11589BE1C759_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CConvert_ZenkataToHankata.h
+++ b/sakura_core/convert/CConvert_ZenkataToHankata.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCONVERT_ZENKATATOHANKATA_28EBC9B6_53BD_41BA_8D20_140D90CAC3469_H_
-#define SAKURA_CCONVERT_ZENKATATOHANKATA_28EBC9B6_53BD_41BA_8D20_140D90CAC3469_H_
+#pragma once
 
 #include "CConvert.h"
 
@@ -33,5 +32,4 @@ public:
 	bool DoConvert(CNativeW* pcData) override;
 };
 
-#endif /* SAKURA_CCONVERT_ZENKATATOHANKATA_28EBC9B6_53BD_41BA_8D20_140D90CAC3469_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CDecode.h
+++ b/sakura_core/convert/CDecode.h
@@ -26,8 +26,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDECODE_D68AE385_FC75_40FC_8BB4_F838CA7A8BB0_H_
-#define SAKURA_CDECODE_D68AE385_FC75_40FC_8BB4_F838CA7A8BB0_H_
+#pragma once
 
 class CDecode {
 public:
@@ -49,5 +48,4 @@ public:
 	virtual bool DoDecode( const CNativeW& pcData, CMemory* pDest )=0;
 };
 
-#endif /* SAKURA_CDECODE_D68AE385_FC75_40FC_8BB4_F838CA7A8BB0_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CDecode_Base64Decode.h
+++ b/sakura_core/convert/CDecode_Base64Decode.h
@@ -27,8 +27,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDECODE_BASE64DECODE_FD175ABC_35B6_470E_850C_3F50E35320FF9_H_
-#define SAKURA_CDECODE_BASE64DECODE_FD175ABC_35B6_470E_850C_3F50E35320FF9_H_
+#pragma once
 
 #include "convert/CDecode.h"
 
@@ -37,5 +36,4 @@ public:
 	bool DoDecode(const CNativeW& cData, CMemory* pcDst) override;
 };
 
-#endif /* SAKURA_CDECODE_BASE64DECODE_FD175ABC_35B6_470E_850C_3F50E35320FF9_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/CDecode_UuDecode.h
+++ b/sakura_core/convert/CDecode_UuDecode.h
@@ -27,8 +27,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDECODE_UUDECODE_2082FDBF_E5F4_4173_87E3_A862FA4F694B_H_
-#define SAKURA_CDECODE_UUDECODE_2082FDBF_E5F4_4173_87E3_A862FA4F694B_H_
+#pragma once
 
 #include "convert/CDecode.h"
 
@@ -40,5 +39,4 @@ public:
 	void CopyFilename( WCHAR *pcDst ) const { wcscpy( pcDst, m_aFilename ); }
 };
 
-#endif /* SAKURA_CDECODE_UUDECODE_2082FDBF_E5F4_4173_87E3_A862FA4F694B_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/convert_util.h
+++ b/sakura_core/convert/convert_util.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CONVERT_UTIL_0B07D622_2EDB_4687_A655_830B20F2BD22_H_
-#define SAKURA_CONVERT_UTIL_0B07D622_2EDB_4687_A655_830B20F2BD22_H_
+#pragma once
 
 //2007.10.18 kobake
 
@@ -67,5 +66,4 @@ void Convert_HankataToZenkata(const wchar_t* pSrc, int nSrcLength, wchar_t* pDst
 */
 void Convert_HankataToZenhira(const wchar_t* pSrc, int nSrcLength, wchar_t* pDst, int* nDstLength);
 
-#endif /* SAKURA_CONVERT_UTIL_0B07D622_2EDB_4687_A655_830B20F2BD22_H_ */
 /*[EOF]*/

--- a/sakura_core/convert/convert_util2.h
+++ b/sakura_core/convert/convert_util2.h
@@ -27,8 +27,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CONVERT_UTIL2_0DBB4338_3B8D_4466_A20D_638B847EB6C9_H_
-#define SAKURA_CONVERT_UTIL2_0DBB4338_3B8D_4466_A20D_638B847EB6C9_H_
+#pragma once
 
 #include "parse/CWordParse.h"
 #include "mem/CMemory.h"
@@ -724,5 +723,4 @@ finish_first_detect:;
 	return nskipped_len;
 }
 
-#endif /* SAKURA_CONVERT_UTIL2_0DBB4338_3B8D_4466_A20D_638B847EB6C9_H_ */
 /*[EOF]*/

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -31,8 +31,7 @@
 		   distribution.
 */
 
-#ifndef _CRUNNINGTIMER_H_
-#define _CRUNNINGTIMER_H_
+#pragma once
 
 #include <windows.h>
 // RunningTimerで経過時間の測定を行う場合にはコメントを外してください
@@ -88,5 +87,4 @@ protected:
 #endif
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CRUNNINGTIMER_H_ */
 

--- a/sakura_core/debug/Debug1.h
+++ b/sakura_core/debug/Debug1.h
@@ -12,8 +12,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef SAKURA_DEBUG1_587B8A50_4B0A_4E5E_A638_40FB1EC301CA_H_
-#define SAKURA_DEBUG1_587B8A50_4B0A_4E5E_A638_40FB1EC301CA_H_
+#pragma once
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                   メッセージ出力：実装                      //
@@ -50,4 +49,3 @@ void DebugOutW( LPCWSTR lpFmt, ...);
 #endif	// USE_RELPRINT
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_DEBUG1_587B8A50_4B0A_4E5E_A638_40FB1EC301CA_H_ */

--- a/sakura_core/debug/Debug2.h
+++ b/sakura_core/debug/Debug2.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_DEBUG2_69DB6343_0580_4F92_98D6_63216724B2D19_H_
-#define SAKURA_DEBUG2_69DB6343_0580_4F92_98D6_63216724B2D19_H_
+#pragma once
 
 //2007.08.30 kobake 追加
 #ifdef assert
@@ -60,5 +59,4 @@
 	#define assert_warning(exp)
 #endif
 
-#endif /* SAKURA_DEBUG2_69DB6343_0580_4F92_98D6_63216724B2D19_H_ */
 /*[EOF]*/

--- a/sakura_core/debug/Debug3.h
+++ b/sakura_core/debug/Debug3.h
@@ -25,13 +25,11 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_DEBUG3_925353B7_B06C_4EA1_8E49_8305796D16DD9_H_
-#define SAKURA_DEBUG3_925353B7_B06C_4EA1_8E49_8305796D16DD9_H_
+#pragma once
 
 #ifdef USE_DEBUGMON
 int DebugMonitor_Output(const wchar_t* szInstanceId, const wchar_t* szText);
 LPCWSTR GetWindowsMessageName(UINT msg);
 #endif
 
-#endif /* SAKURA_DEBUG3_925353B7_B06C_4EA1_8E49_8305796D16DD9_H_ */
 /*[EOF]*/

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -16,8 +16,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CDIALOG_H_
-#define _CDIALOG_H_
+#pragma once
 
 class CDialog;
 
@@ -164,5 +163,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDIALOG_H_ */
-

--- a/sakura_core/dlg/CDlgAbout.h
+++ b/sakura_core/dlg/CDlgAbout.h
@@ -13,8 +13,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CDLGABOUT_H_
-#define _CDLGABOUT_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 /*!
@@ -65,5 +64,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGABOUT_H_ */
-

--- a/sakura_core/dlg/CDlgCancel.h
+++ b/sakura_core/dlg/CDlgCancel.h
@@ -13,10 +13,9 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-class CDlgCancel;
+#pragma once
 
-#ifndef _CDLGCANCEL_H_
-#define _CDLGCANCEL_H_
+class CDlgCancel;
 
 #include "dlg/CDialog.h"
 
@@ -60,5 +59,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGCANCEL_H_ */
-

--- a/sakura_core/dlg/CDlgCompare.h
+++ b/sakura_core/dlg/CDlgCompare.h
@@ -11,10 +11,9 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-class CDlgCompare;
+#pragma once
 
-#ifndef _CDLGCOMPARE_H_
-#define _CDLGCOMPARE_H_
+class CDlgCompare;
 
 #include "dlg/CDialog.h"
 /*!
@@ -61,5 +60,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGCOMPARE_H_ */
-

--- a/sakura_core/dlg/CDlgCtrlCode.h
+++ b/sakura_core/dlg/CDlgCtrlCode.h
@@ -28,10 +28,9 @@
 		   distribution.
 */
 
-class CDlgCtrlCode;
+#pragma once
 
-#ifndef _CDLGCTRLCODE_H_
-#define _CDLGCTRLCODE_H_
+class CDlgCtrlCode;
 
 #include "dlg/CDialog.h"
 /*!
@@ -73,5 +72,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGCTRLCODE_H_ */
-

--- a/sakura_core/dlg/CDlgDiff.h
+++ b/sakura_core/dlg/CDlgDiff.h
@@ -29,10 +29,9 @@
 		   distribution.
 */
 
-class CDlgDiff;
+#pragma once
 
-#ifndef _CDLGDIFF_H_
-#define _CDLGDIFF_H_
+class CDlgDiff;
 
 #include "dlg/CDialog.h"
 /*!
@@ -86,5 +85,3 @@ public:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGDIFF_H_ */
-

--- a/sakura_core/dlg/CDlgExec.h
+++ b/sakura_core/dlg/CDlgExec.h
@@ -11,11 +11,10 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
+#pragma once
+
 #include "dlg/CDialog.h"
 #include "recent/CRecentCmd.h"
-
-#ifndef _CDLGEXEC_H_
-#define _CDLGEXEC_H_
 
 /*-----------------------------------------------------------------------
 クラスの宣言
@@ -50,5 +49,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGEXEC_H_ */
-

--- a/sakura_core/dlg/CDlgFavorite.h
+++ b/sakura_core/dlg/CDlgFavorite.h
@@ -29,8 +29,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CDLGFAVORITE_H_
-#define SAKURA_CDLGFAVORITE_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 #include "recent/CRecent.h"
@@ -138,6 +137,4 @@ private:
 
 	static void  ListViewSort(ListViewSortInfo& info, const CRecent* pRecent, int column, bool bReverse);
 };
-
-#endif	//SAKURA_CDLGFAVORITE_H_
 

--- a/sakura_core/dlg/CDlgFileUpdateQuery.h
+++ b/sakura_core/dlg/CDlgFileUpdateQuery.h
@@ -29,8 +29,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef _DLG_FILE_UPDATE_QUERY_H_
-#define _DLG_FILE_UPDATE_QUERY_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 
@@ -56,6 +55,4 @@ private:
 	const WCHAR* m_pFilename;
 	bool m_bModified;
 };
-
-#endif
 

--- a/sakura_core/dlg/CDlgFind.h
+++ b/sakura_core/dlg/CDlgFind.h
@@ -12,11 +12,11 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
+#pragma once
+
 #include "dlg/CDialog.h"
 #include "recent/CRecentSearch.h"
 #include "util/window.h"
-#ifndef SAKURA_CDLGFIND_H_
-#define SAKURA_CDLGFIND_H_
 
 /*-----------------------------------------------------------------------
 クラスの宣言
@@ -63,5 +63,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CDLGFIND_H_ */
-

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -12,11 +12,9 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
+#pragma once
 
 class CDlgGrep;
-
-#ifndef _CDLGGREP_H_
-#define _CDLGGREP_H_
 
 #include "dlg/CDialog.h"
 #include "recent/CRecent.h"
@@ -91,5 +89,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGGREP_H_ */
-

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -12,11 +12,9 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
+#pragma once
 
 class CDlgGrep;
-
-#ifndef SAKURA_CDLGGREP_REPLACE_H_
-#define SAKURA_CDLGGREP_REPLACE_H_
 
 #include "dlg/CDialog.h"
 #include "dlg/CDlgGrep.h"
@@ -56,5 +54,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CDLGGREP_REPLACE_H_ */
-

--- a/sakura_core/dlg/CDlgInput1.h
+++ b/sakura_core/dlg/CDlgInput1.h
@@ -10,11 +10,9 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
+#pragma once
 
 class CDlgInput1;
-
-#ifndef _CDLGINPUT1_H_
-#define _CDLGINPUT1_H_
 
 /*-----------------------------------------------------------------------
 クラスの宣言
@@ -54,5 +52,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGINPUT1_H_ */
-

--- a/sakura_core/dlg/CDlgJump.h
+++ b/sakura_core/dlg/CDlgJump.h
@@ -13,11 +13,9 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
+#pragma once
 
 class CDlgJump;
-
-#ifndef _CDLGJUMP_H_
-#define _CDLGJUMP_H_
 
 #include "dlg/CDialog.h"
 //! 指定行へのジャンプダイアログボックス
@@ -50,5 +48,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGJUMP_H_ */
-

--- a/sakura_core/dlg/CDlgOpenFile.h
+++ b/sakura_core/dlg/CDlgOpenFile.h
@@ -17,8 +17,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CDLGOPENFILE_H_
-#define _CDLGOPENFILE_H_
+#pragma once
 
 #include <memory>
 #include <vector>
@@ -117,5 +116,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGOPENFILE_H_ */
-

--- a/sakura_core/dlg/CDlgPluginOption.h
+++ b/sakura_core/dlg/CDlgPluginOption.h
@@ -27,8 +27,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDLGPLUGINOPTION_7BD4A901_BC40_4CA1_8311_85B8CAA783F08_H_
-#define SAKURA_CDLGPLUGINOPTION_7BD4A901_BC40_4CA1_8311_85B8CAA783F08_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 #include "plugin/CPluginManager.h"
@@ -97,4 +96,3 @@ private:
 	std::wstring	m_sReadMeName;	// ReadMe ファイル名
 };
 
-#endif /* SAKURA_CDLGPLUGINOPTION_7BD4A901_BC40_4CA1_8311_85B8CAA783F08_H_ */

--- a/sakura_core/dlg/CDlgPrintSetting.h
+++ b/sakura_core/dlg/CDlgPrintSetting.h
@@ -27,8 +27,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDLGPRINTSETTING_9DF803C0_8BBB_41EC_B6A7_AFEBBDBC517D_H_
-#define SAKURA_CDLGPRINTSETTING_9DF803C0_8BBB_41EC_B6A7_AFEBBDBC517D_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 #include "config/maxdata.h" // MAX_PRINTSETTINGARR
@@ -84,4 +83,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CDLGPRINTSETTING_9DF803C0_8BBB_41EC_B6A7_AFEBBDBC517D_H_ */

--- a/sakura_core/dlg/CDlgProfileMgr.h
+++ b/sakura_core/dlg/CDlgProfileMgr.h
@@ -27,8 +27,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDLGPROFILEMGR_H_
-#define SAKURA_CDLGPROFILEMGR_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 #include <string>
@@ -79,5 +78,3 @@ public:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CDLGPROFILEMGR_H_ */
-

--- a/sakura_core/dlg/CDlgProperty.h
+++ b/sakura_core/dlg/CDlgProperty.h
@@ -28,11 +28,9 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
+#pragma once
 
 class CDlgProperty;
-
-#ifndef _CDLGPROPERTY_H_
-#define _CDLGPROPERTY_H_
 
 #include "dlg/CDialog.h"
 /*-----------------------------------------------------------------------
@@ -51,5 +49,3 @@ protected:
 	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 };
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGPROPERTY_H_ */
-

--- a/sakura_core/dlg/CDlgReplace.h
+++ b/sakura_core/dlg/CDlgReplace.h
@@ -15,8 +15,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef SAKURA_CDLGREPLACE_H_
-#define SAKURA_CDLGREPLACE_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 #include "recent/CRecent.h"
@@ -80,5 +79,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CDLGREPLACE_H_ */
-

--- a/sakura_core/dlg/CDlgSetCharSet.h
+++ b/sakura_core/dlg/CDlgSetCharSet.h
@@ -11,8 +11,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CDLGSETCHARSET_H_
-#define _CDLGSETCHARSET_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 
@@ -51,4 +50,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGSETCHARSET_H_ */

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -30,8 +30,7 @@
 		   distribution.
 */
 
-#ifndef	SAKURA_CDLGTAGJUMPLIST_H_
-#define	SAKURA_CDLGTAGJUMPLIST_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 #include "recent/CRecentTagjumpKeyword.h"
@@ -172,6 +171,4 @@ private:
 
 	DISALLOW_COPY_AND_ASSIGN(CDlgTagJumpList);
 };
-
-#endif	//SAKURA_CDLGTAGJUMPLIST_H_
 

--- a/sakura_core/dlg/CDlgTagsMake.h
+++ b/sakura_core/dlg/CDlgTagsMake.h
@@ -28,10 +28,9 @@
 		   distribution.
 */
 
-class CDlgTagsMake;
+#pragma once
 
-#ifndef _CDLGTAGSMAKE_H_
-#define _CDLGTAGSMAKE_H_
+class CDlgTagsMake;
 
 #include "dlg/CDialog.h"
 /*!
@@ -69,5 +68,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGTAGSMAKE_H_ */
-

--- a/sakura_core/dlg/CDlgWinSize.h
+++ b/sakura_core/dlg/CDlgWinSize.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef SC_CDLGWINPOSSIZE_H__
-#define SC_CDLGWINPOSSIZE_H__
+#pragma once
 
 #include "dlg/CDialog.h"
 #include "env/CommonSetting.h"
@@ -63,6 +62,4 @@ private:
 	int				m_nWinSizeType;	//!< ウィンドウ表示方法: 0/標準，1/最大化，2/最小化
 	RECT			m_rc;
 };
-
-#endif
 

--- a/sakura_core/dlg/CDlgWindowList.h
+++ b/sakura_core/dlg/CDlgWindowList.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CWINDOWLIST_H_
-#define SAKURA_CWINDOWLIST_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 class CDlgWindowList final : public CDialog
@@ -59,4 +58,3 @@ private:
 	RECT		m_rcItems[5];
 };
 
-#endif /* SAKURA_CWINDOWLIST_H_ */

--- a/sakura_core/doc/CBlockComment.h
+++ b/sakura_core/doc/CBlockComment.h
@@ -12,8 +12,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CBLOCKCOMMENT_H_
-#define _CBLOCKCOMMENT_H_
+#pragma once
 
 //	sakura
 #include "_main/global.h"
@@ -60,5 +59,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CBLOCKCOMMENT_H_ */
-

--- a/sakura_core/doc/CDocEditor.h
+++ b/sakura_core/doc/CDocEditor.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCEDITOR_1F90937C_B53A_490C_BCCF_74EFAEE628AC_H_
-#define SAKURA_CDOCEDITOR_1F90937C_B53A_490C_BCCF_74EFAEE628AC_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 #include "_os/CClipboard.h"
@@ -110,5 +109,4 @@ private:
 	CDocLineMgr* m_pcDocLineMgr;
 };
 
-#endif /* SAKURA_CDOCEDITOR_1F90937C_B53A_490C_BCCF_74EFAEE628AC_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CDocFile.h
+++ b/sakura_core/doc/CDocFile.h
@@ -23,8 +23,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCFILE_C6DA01C5_5BB2_4361_9B6A_648953CB9CA19_H_
-#define SAKURA_CDOCFILE_C6DA01C5_5BB2_4361_9B6A_648953CB9CA19_H_
+#pragma once
 
 #include "io/CFile.h"
 #include "util/file.h"
@@ -79,5 +78,4 @@ public: //####
 	CFilePath	m_szSaveFilePath;	/* 保存時のファイルのパス（マクロ用） */	// 2006.09.04 ryoji
 };
 
-#endif /* SAKURA_CDOCFILE_C6DA01C5_5BB2_4361_9B6A_648953CB9CA19_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CDocFileOperation.h
+++ b/sakura_core/doc/CDocFileOperation.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCFILEOPERATION_A537A9E9_2400_4A59_9188_3CC3A3966862_H_
-#define SAKURA_CDOCFILEOPERATION_A537A9E9_2400_4A59_9188_3CC3A3966862_H_
+#pragma once
 
 #include "doc/CDocListener.h" // SLoadInfo
 #include "CEol.h"
@@ -80,5 +79,4 @@ private:
 	CEditDoc* m_pcDocRef;
 };
 
-#endif /* SAKURA_CDOCFILEOPERATION_A537A9E9_2400_4A59_9188_3CC3A3966862_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CDocListener.h
+++ b/sakura_core/doc/CDocListener.h
@@ -32,8 +32,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCLISTENER_797F65F5_C90A_4055_944C_AB9256AD8B90_H_
-#define SAKURA_CDOCLISTENER_797F65F5_C90A_4055_944C_AB9256AD8B90_H_
+#pragma once
 
 class CDocListener;
 #include "basis/CMyString.h"
@@ -213,5 +212,4 @@ public:
 	const char* what() const throw(){ return "CFlowInterruption"; }
 };
 
-#endif /* SAKURA_CDOCLISTENER_797F65F5_C90A_4055_944C_AB9256AD8B90_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CDocLocker.h
+++ b/sakura_core/doc/CDocLocker.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCLOCKER_5E410382_D36E_46CE_B212_07F2F346FD3C_H_
-#define SAKURA_CDOCLOCKER_5E410382_D36E_46CE_B212_07F2F346FD3C_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 
@@ -51,5 +50,4 @@ private:
 	bool m_bIsDocWritable;
 };
 
-#endif /* SAKURA_CDOCLOCKER_5E410382_D36E_46CE_B212_07F2F346FD3C_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CDocOutline.h
+++ b/sakura_core/doc/CDocOutline.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCOUTLINE_F40D43DF_FDBE_4758_B015_E9C369A17606_H_
-#define SAKURA_CDOCOUTLINE_F40D43DF_FDBE_4758_B015_E9C369A17606_H_
+#pragma once
 
 class CEditDoc;
 class CFuncInfoArr;
@@ -57,5 +56,4 @@ private:
 	CEditDoc* m_pcDocRef;
 };
 
-#endif /* SAKURA_CDOCOUTLINE_F40D43DF_FDBE_4758_B015_E9C369A17606_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CDocReader.h
+++ b/sakura_core/doc/CDocReader.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCREADER_FFCD10C3_3BA9_4566_94EC_B8DCF7D8F5049_H_
-#define SAKURA_CDOCREADER_FFCD10C3_3BA9_4566_94EC_B8DCF7D8F5049_H_
+#pragma once
 
 class CDocLineMgr;
 
@@ -42,5 +41,4 @@ private:
 	const CDocLineMgr* m_pcDocLineMgr;
 };
 
-#endif /* SAKURA_CDOCREADER_FFCD10C3_3BA9_4566_94EC_B8DCF7D8F5049_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CDocType.h
+++ b/sakura_core/doc/CDocType.h
@@ -27,8 +27,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCTYPE_BB51F346_E9F1_42DD_8B28_2F5BAFCE7CE09_H_
-#define SAKURA_CDOCTYPE_BB51F346_E9F1_42DD_8B28_2F5BAFCE7CE09_H_
+#pragma once
 
 #include "types/CType.h" // CTypeConfig
 #include "env/CDocTypeManager.h"
@@ -69,5 +68,4 @@ private:
 	bool					m_nSettingTypeLocked;		//!< 文書種別の一時設定状態
 };
 
-#endif /* SAKURA_CDOCTYPE_BB51F346_E9F1_42DD_8B28_2F5BAFCE7CE09_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CDocTypeSetting.h
+++ b/sakura_core/doc/CDocTypeSetting.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCTYPESETTING_28058D99_2101_4488_A634_832BD50A2F3C9_H_
-#define SAKURA_CDOCTYPESETTING_28058D99_2101_4488_A634_832BD50A2F3C9_H_
+#pragma once
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                          色設定                             //
@@ -71,5 +70,4 @@ struct KeyHelpInfo {
 };
 //@@@ 2006.04.10 fon ADD-end
 
-#endif /* SAKURA_CDOCTYPESETTING_28058D99_2101_4488_A634_832BD50A2F3C9_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CDocVisitor.h
+++ b/sakura_core/doc/CDocVisitor.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCVISITOR_76607605_5054_45B9_97F2_87A730043C5F_H_
-#define SAKURA_CDOCVISITOR_76607605_5054_45B9_97F2_87A730043C5F_H_
+#pragma once
 
 #include "CEol.h"
 
@@ -38,5 +37,4 @@ private:
 	CEditDoc* m_pcDocRef;
 };
 
-#endif /* SAKURA_CDOCVISITOR_76607605_5054_45B9_97F2_87A730043C5F_H_ */
 /*[EOF]*/

--- a/sakura_core/doc/CEditDoc.h
+++ b/sakura_core/doc/CEditDoc.h
@@ -37,8 +37,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CEDITDOC_CE42530D_FEC1_4B51_9CA3_470856295FEF8_H_
-#define SAKURA_CEDITDOC_CE42530D_FEC1_4B51_9CA3_470856295FEF8_H_
+#pragma once
 
 #include "_main/global.h"
 #include "_main/CAppMode.h"
@@ -167,4 +166,3 @@ public:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CEDITDOC_CE42530D_FEC1_4B51_9CA3_470856295FEF8_H_ */

--- a/sakura_core/doc/CLineComment.h
+++ b/sakura_core/doc/CLineComment.h
@@ -11,8 +11,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CLINECOMMENT_H_
-#define _CLINECOMMENT_H_
+#pragma once
 
 //	sakura
 #include "_main/global.h"
@@ -52,5 +51,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CLINECOMMENT_H_ */
-

--- a/sakura_core/doc/layout/CLayout.h
+++ b/sakura_core/doc/layout/CLayout.h
@@ -13,8 +13,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CLAYOUT_H_
-#define _CLAYOUT_H_
+#pragma once
 
 #include "util/design_template.h"
 #include "CEol.h"// 2002/2/10 aroka
@@ -128,5 +127,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CLAYOUT_H_ */
-

--- a/sakura_core/doc/layout/CLayoutExInfo.h
+++ b/sakura_core/doc/layout/CLayoutExInfo.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CLAYOUTEXINFO_H_
-#define SAKURA_CLAYOUTEXINFO_H_
+#pragma once
 
 #include "util/design_template.h"
 
@@ -61,4 +60,3 @@ private:
 	DISALLOW_COPY_AND_ASSIGN(CLayoutExInfo);
 };
 
-#endif

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -19,8 +19,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CLAYOUTMGR_H_
-#define _CLAYOUTMGR_H_
+#pragma once
 
 #include <Windows.h>// 2002/2/10 aroka
 #include <vector>
@@ -433,5 +432,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CLAYOUTMGR_H_ */
-

--- a/sakura_core/doc/layout/CTsvModeInfo.h
+++ b/sakura_core/doc/layout/CTsvModeInfo.h
@@ -24,8 +24,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CTSVMODEINFO_BC141F5B_325B_4C02_9CC7_633B39FE482E1_H_
-#define SAKURA_CTSVMODEINFO_BC141F5B_325B_4C02_9CC7_633B39FE482E1_H_
+#pragma once
 
 #include <vector>
 #include "basis/SakuraBasis.h"
@@ -51,5 +50,5 @@ public:
 private:
 	std::vector<int> m_tabLength;
 };
-#endif /* SAKURA_CTSVMODEINFO_BC141F5B_325B_4C02_9CC7_633B39FE482E1_H_ */
+
 /*[EOF]*/

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -15,8 +15,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CDOCLINE_H_
-#define _CDOCLINE_H_
+#pragma once
 
 #include "util/design_template.h"
 #include "CEol.h"
@@ -118,5 +117,3 @@ private:
 #pragma pack(pop)
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDOCLINE_H_ */
-

--- a/sakura_core/doc/logic/CDocLineMgr.h
+++ b/sakura_core/doc/logic/CDocLineMgr.h
@@ -17,8 +17,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CDOCLINEMGR_H_
-#define _CDOCLINEMGR_H_
+#pragma once
 
 #include <Windows.h>
 #include <memory_resource>
@@ -102,5 +101,3 @@ public:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDOCLINEMGR_H_ */
-

--- a/sakura_core/docplus/CBookmarkManager.h
+++ b/sakura_core/docplus/CBookmarkManager.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CBOOKMARKMANAGER_0BD65312_87D5_4C0F_AA25_7F077D00E8DC_H_
-#define SAKURA_CBOOKMARKMANAGER_0BD65312_87D5_4C0F_AA25_7F077D00E8DC_H_
+#pragma once
 
 #include "_main/global.h" // ESearchDirection, SSearchOption
 
@@ -76,5 +75,4 @@ private:
 	CDocLineMgr* m_pcDocLineMgr;
 };
 
-#endif /* SAKURA_CBOOKMARKMANAGER_0BD65312_87D5_4C0F_AA25_7F077D00E8DC_H_ */
 /*[EOF]*/

--- a/sakura_core/docplus/CDiffManager.h
+++ b/sakura_core/docplus/CDiffManager.h
@@ -24,8 +24,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDIFFMANAGER_A4D99FE4_A4AB_468A_96FC_00858B04DEA1_H_
-#define SAKURA_CDIFFMANAGER_A4D99FE4_A4AB_468A_96FC_00858B04DEA1_H_
+#pragma once
 
 #include "view/colors/EColorIndexType.h"
 #include "util/design_template.h" //TSingleton
@@ -97,5 +96,4 @@ private:
 	CDocLineMgr* m_pcDocLineMgr;
 };
 
-#endif /* SAKURA_CDIFFMANAGER_A4D99FE4_A4AB_468A_96FC_00858B04DEA1_H_ */
 /*[EOF]*/

--- a/sakura_core/docplus/CFuncListManager.h
+++ b/sakura_core/docplus/CFuncListManager.h
@@ -23,8 +23,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFUNCLISTMANAGER_H_
-#define SAKURA_CFUNCLISTMANAGER_H_
+#pragma once
 
 class CDocLine;
 class CDocLineMgr;
@@ -57,5 +56,4 @@ public:
 	void ResetAllFucListMark(CDocLineMgr* pcDocLineMgr, bool bFlag);	// 関数リストマークをすべてリセット
 };
 
-#endif /* SAKURA_CFUNCLISTMANAGER_H_ */
 /*[EOF]*/

--- a/sakura_core/docplus/CModifyManager.h
+++ b/sakura_core/docplus/CModifyManager.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CMODIFYMANAGER_5129DDF8_A336_4B65_914B_22E626B7B520_H_
-#define SAKURA_CMODIFYMANAGER_5129DDF8_A336_4B65_914B_22E626B7B520_H_
+#pragma once
 
 #include "util/design_template.h" //TSingleton
 #include "doc/CDocListener.h" // CDocListenerEx
@@ -66,5 +65,4 @@ public:
 	void ResetAllModifyFlag(CDocLineMgr* pcDocLineMgr, int nSeq);	// 行変更状態をすべてリセット
 };
 
-#endif /* SAKURA_CMODIFYMANAGER_5129DDF8_A336_4B65_914B_22E626B7B520_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CAPPNODEMANAGER_3F3F3625_BEB8_4EA6_86AD_9497B1D7B061_H_
-#define SAKURA_CAPPNODEMANAGER_3F3F3625_BEB8_4EA6_86AD_9497B1D7B061_H_
+#pragma once
 
 #include "util/design_template.h"
 #include "config/maxdata.h"
@@ -139,5 +138,4 @@ inline CAppNodeHandle::CAppNodeHandle(HWND hwnd)
 	m_pNodeRef = CAppNodeManager::getInstance()->GetEditNode(hwnd);
 }
 
-#endif /* SAKURA_CAPPNODEMANAGER_3F3F3625_BEB8_4EA6_86AD_9497B1D7B061_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CDocTypeManager.h
+++ b/sakura_core/env/CDocTypeManager.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDOCTYPEMANAGER_48534203_AB9B_4C1A_AF78_B76CA88CA0019_H_
-#define SAKURA_CDOCTYPEMANAGER_48534203_AB9B_4C1A_AF78_B76CA88CA0019_H_
+#pragma once
 
 #include "DLLSHAREDATA.h"
 
@@ -58,5 +57,4 @@ private:
 	DLLSHAREDATA* m_pShareData;
 };
 
-#endif /* SAKURA_CDOCTYPEMANAGER_48534203_AB9B_4C1A_AF78_B76CA88CA0019_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CFileNameManager.h
+++ b/sakura_core/env/CFileNameManager.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFILENAMEMANAGER_862D56B4_E24F_49AB_AABD_0924391CB6F4_H_
-#define SAKURA_CFILENAMEMANAGER_862D56B4_E24F_49AB_AABD_0924391CB6F4_H_
+#pragma once
 
 // 要先行定義
 // #include "DLLSHAREDATA.h"
@@ -100,5 +99,4 @@ private:
 	int		m_nTransformFileNameOrgId[MAX_TRANSFORM_FILENAME];
 };
 
-#endif /* SAKURA_CFILENAMEMANAGER_862D56B4_E24F_49AB_AABD_0924391CB6F4_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CFormatManager.h
+++ b/sakura_core/env/CFormatManager.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFORMATMANAGER_7FC73E49_281C_4417_BBBC_DE176142E6BC9_H_
-#define SAKURA_CFORMATMANAGER_7FC73E49_281C_4417_BBBC_DE176142E6BC9_H_
+#pragma once
 
 // 要先行定義
 // #include "DLLSHAREDATA.h"
@@ -50,5 +49,4 @@ private:
 	DLLSHAREDATA* m_pShareData;
 };
 
-#endif /* SAKURA_CFORMATMANAGER_7FC73E49_281C_4417_BBBC_DE176142E6BC9_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CHelpManager.h
+++ b/sakura_core/env/CHelpManager.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CHELPMANAGER_979D10EB_B07B_466F_BB28_AB5A7259E2EA9_H_
-#define SAKURA_CHELPMANAGER_979D10EB_B07B_466F_BB28_AB5A7259E2EA9_H_
+#pragma once
 
 // 要先行定義
 // #include "DLLSHAREDATA.h"
@@ -48,5 +47,4 @@ private:
 	DLLSHAREDATA* m_pShareData;
 };
 
-#endif /* SAKURA_CHELPMANAGER_979D10EB_B07B_466F_BB28_AB5A7259E2EA9_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CSakuraEnvironment.h
+++ b/sakura_core/env/CSakuraEnvironment.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSAKURAENVIRONMENT_95CFC65B_9C67_4ABF_A681_5A4652A3C5D3_H_
-#define SAKURA_CSAKURAENVIRONMENT_95CFC65B_9C67_4ABF_A681_5A4652A3C5D3_H_
+#pragma once
 
 #include <string>
 
@@ -45,5 +44,4 @@ private:
 /* 指定ウィンドウが、編集ウィンドウのフレームウィンドウかどうか調べる */
 BOOL IsSakuraMainWindow( HWND hWnd );
 
-#endif /* SAKURA_CSAKURAENVIRONMENT_95CFC65B_9C67_4ABF_A681_5A4652A3C5D3_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CSearchKeywordManager.h
+++ b/sakura_core/env/CSearchKeywordManager.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSEARCHKEYWORDMANAGER_6D883D8B_3076_423C_BADA_B4C5DCB3E6E5_H_
-#define SAKURA_CSEARCHKEYWORDMANAGER_6D883D8B_3076_423C_BADA_B4C5DCB3E6E5_H_
+#pragma once
 
 // 要先行定義
 // #include "DLLSHAREDATA.h"
@@ -60,5 +59,4 @@ private:
 	DLLSHAREDATA* m_pShareData;
 };
 
-#endif /* SAKURA_CSEARCHKEYWORDMANAGER_6D883D8B_3076_423C_BADA_B4C5DCB3E6E5_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CShareData.h
+++ b/sakura_core/env/CShareData.h
@@ -28,8 +28,7 @@
 //2007.09.23 kobake m_nTagJumpKeywordArrNum, m_szTagJumpKeywordArr を m_aTagJumpKeywords にまとめました
 //2007.12.13 kobake DLLSHAREDATAへの簡易アクセサを用意
 
-#ifndef SAKURA_ENV_CSHAREDATA_H_
-#define SAKURA_ENV_CSHAREDATA_H_
+#pragma once
 
 #include "CSelectLang.h"		// 2011.04.10 nasukoji
 
@@ -118,5 +117,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_ENV_CSHAREDATA_H_ */
-

--- a/sakura_core/env/CShareData_IO.h
+++ b/sakura_core/env/CShareData_IO.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSHAREDATA_IO_AA81C249_631D_40B0_AAFF_2F163748954B9_H_
-#define SAKURA_CSHAREDATA_IO_AA81C249_631D_40B0_AAFF_2F163748954B9_H_
+#pragma once
 
 class CDataProfile;
 class CMenuDrawer;
@@ -83,5 +82,4 @@ public:
 	static void IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecName, ColorInfo* pColorInfoArr );	/* 色設定 I/O */ // Feb. 12, 2006 D.S.Koba
 };
 
-#endif /* SAKURA_CSHAREDATA_IO_AA81C249_631D_40B0_AAFF_2F163748954B9_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CTagJumpManager.h
+++ b/sakura_core/env/CTagJumpManager.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CTAGJUMPMANAGER_A826CC13_50FF_44A9_813D_CC5B918410A7_H_
-#define SAKURA_CTAGJUMPMANAGER_A826CC13_50FF_44A9_813D_CC5B918410A7_H_
+#pragma once
 
 // 要先行定義
 // #define DLLSHAREDATA.h
@@ -70,5 +69,4 @@ private:
 	DLLSHAREDATA* m_pShareData;
 };
 
-#endif /* SAKURA_CTAGJUMPMANAGER_A826CC13_50FF_44A9_813D_CC5B918410A7_H_ */
 /*[EOF]*/

--- a/sakura_core/env/CommonSetting.h
+++ b/sakura_core/env/CommonSetting.h
@@ -23,8 +23,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_COMMONSETTING_7C01A3F3_AD50_4AEA_84D6_0798DB67F40C_H_
-#define SAKURA_COMMONSETTING_7C01A3F3_AD50_4AEA_84D6_0798DB67F40C_H_
+#pragma once
 
 #include "CKeyWordSetMgr.h"
 #include "func/CKeyBind.h"
@@ -746,5 +745,4 @@ struct CommonSetting
 	CommonSetting_MainMenu			m_sMainMenu;		//!< メインメニュー		// 2010/5/15 Uchi
 };
 
-#endif /* SAKURA_COMMONSETTING_7C01A3F3_AD50_4AEA_84D6_0798DB67F40C_H_ */
 /*[EOF]*/

--- a/sakura_core/env/DLLSHAREDATA.h
+++ b/sakura_core/env/DLLSHAREDATA.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_DLLSHAREDATA_3A6DD7E0_90DC_4219_8570_F5C1B8B6A306_H_
-#define SAKURA_DLLSHAREDATA_3A6DD7E0_90DC_4219_8570_F5C1B8B6A306_H_
+#pragma once
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                         アクセサ                            //
@@ -187,5 +186,5 @@ public:
 	static void WaitLock( HWND hwndParent, CShareDataLockCounter** ppLock = NULL );
 private:
 };
-#endif /* SAKURA_DLLSHAREDATA_3A6DD7E0_90DC_4219_8570_F5C1B8B6A306_H_ */
+
 /*[EOF]*/

--- a/sakura_core/extmodule/CBregexp.h
+++ b/sakura_core/extmodule/CBregexp.h
@@ -39,8 +39,7 @@
 		   distribution.
 */
 
-#ifndef _DLL_BREGEXP_H_
-#define _DLL_BREGEXP_H_
+#pragma once
 
 #include "CBregexpDll2.h"
 
@@ -226,6 +225,4 @@ private:
 bool CheckRegexpVersion( HWND hWnd, int nCmpId, bool bShowMsg = false );
 bool CheckRegexpSyntax( const wchar_t* szPattern, HWND hWnd, bool bShowMessage, int nOption = -1, bool bKakomi = false );// 2002/2/1 hor追加
 bool InitRegexp( HWND hWnd, CBregexp& rRegexp, bool bShowMessage );
-
-#endif
 

--- a/sakura_core/extmodule/CBregexpDll2.h
+++ b/sakura_core/extmodule/CBregexpDll2.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CBREGEXPDLL2_850005D4_6AA3_41D2_B541_1EE730935E6B_H_
-#define SAKURA_CBREGEXPDLL2_850005D4_6AA3_41D2_B541_1EE730935E6B_H_
+#pragma once
 
 #include "CDllHandler.h"
 
@@ -115,5 +114,4 @@ private:
 	BREGEXP_BSubstExW2       m_BSubstEx;
 };
 
-#endif /* SAKURA_CBREGEXPDLL2_850005D4_6AA3_41D2_B541_1EE730935E6B_H_ */
 /*[EOF]*/

--- a/sakura_core/extmodule/CDllHandler.h
+++ b/sakura_core/extmodule/CDllHandler.h
@@ -29,8 +29,7 @@
 		   distribution.
 */
 
-#ifndef _LOAD_LIBRARY_H_
-#define _LOAD_LIBRARY_H_
+#pragma once
 
 #include <Windows.h>
 #include <string>
@@ -204,6 +203,4 @@ private:
 	HINSTANCE		m_hInstance;
 	std::wstring	m_strLoadedDllName;
 };
-
-#endif
 

--- a/sakura_core/extmodule/CHtmlHelp.h
+++ b/sakura_core/extmodule/CHtmlHelp.h
@@ -30,8 +30,7 @@
 		   distribution.
 */
 
-#ifndef _SAKURA_HTMLHELP_H_
-#define _SAKURA_HTMLHELP_H_
+#pragma once
 
 #include "CDllHandler.h"
 
@@ -66,6 +65,4 @@ protected:
 	virtual bool InitDllImp();
 	virtual LPCWSTR GetDllNameImp(int nIndex);
 };
-
-#endif
 

--- a/sakura_core/extmodule/CMigemo.h
+++ b/sakura_core/extmodule/CMigemo.h
@@ -18,8 +18,7 @@
 Migemo はローマ字のまま日本語をインクリメンタル検索するためのツールです。
 */
 
-#ifndef _SAKURA_MIGEMO_H_
-#define _SAKURA_MIGEMO_H_
+#pragma once
 
 #define MIGEMO_VERSION "1.1"
 
@@ -135,6 +134,4 @@ public:
 	int migemo_is_enable();
 	int migemo_load_all();
 };
-
-#endif
 

--- a/sakura_core/extmodule/CUxTheme.h
+++ b/sakura_core/extmodule/CUxTheme.h
@@ -30,8 +30,7 @@
 		   distribution.
 */
 
-#ifndef _SAKURA_UXTHEME_H_
-#define _SAKURA_UXTHEME_H_
+#pragma once
 
 #include <vsstyle.h>
 #include "CDllHandler.h"
@@ -72,6 +71,4 @@ public:
 	HRESULT DrawThemeParentBackground( HWND hwnd, HDC hdc, RECT* prc );
 	BOOL IsThemeBackgroundPartiallyTransparent( HTHEME htheme, int iPartId, int iStateId );
 };
-
-#endif
 

--- a/sakura_core/func/CFuncKeyWnd.h
+++ b/sakura_core/func/CFuncKeyWnd.h
@@ -12,8 +12,7 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
-#ifndef SAKURA_CFUNCKEYWND_H_
-#define SAKURA_CFUNCKEYWND_H_
+#pragma once
 
 #include "window/CWnd.h"
 #include "env/DLLSHAREDATA.h"
@@ -72,5 +71,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CFUNCKEYWND_H_ */
-

--- a/sakura_core/func/CFuncLookup.h
+++ b/sakura_core/func/CFuncLookup.h
@@ -32,8 +32,7 @@
 		   distribution.
 */
 
-#ifndef __CNAMELOOKUP_H__
-#define __CNAMELOOKUP_H__
+#pragma once
 
 #include <Windows.h>
 #include "_main/global.h"
@@ -92,5 +91,4 @@ private:
 	CommonSetting* m_pCommon;	//! 共通設定データ領域へのポインタ
 };
 
-#endif
 /* [EOF] */

--- a/sakura_core/func/CKeyBind.h
+++ b/sakura_core/func/CKeyBind.h
@@ -12,8 +12,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CKEYBIND_H_
-#define _CKEYBIND_H_
+#pragma once
 
 #include <Windows.h>
 #include "Funccode_enum.h"
@@ -96,5 +95,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CKEYBIND_H_ */
-

--- a/sakura_core/func/Funccode.h
+++ b/sakura_core/func/Funccode.h
@@ -35,8 +35,7 @@
 		   distribution.
 */
 
-#ifndef _FUNCCODE_H_
-#define _FUNCCODE_H_
+#pragma once
 
 //Oct. 17, 2000 jepro  F_FILECLOSE:「ファイルを閉じる」というキャプションを変更
 //Feb. 28, 2004 genta  F_FILESAVECLOSE
@@ -185,4 +184,3 @@ struct DLLSHAREDATA;
 bool IsFuncEnable( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EFunctionCode nId );	/* 機能が利用可能か調べる */
 bool IsFuncChecked( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, EFunctionCode nId );	/* 機能がチェック状態か調べる */
 
-#endif // _FUNCCODE_H_

--- a/sakura_core/io/CBinaryStream.h
+++ b/sakura_core/io/CBinaryStream.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CBINARYSTREAM_F33600DB_8369_4FB2_B7B1_8B59249B7216_H_
-#define SAKURA_CBINARYSTREAM_F33600DB_8369_4FB2_B7B1_8B59249B7216_H_
+#pragma once
 
 #include "CStream.h"
 
@@ -44,5 +43,4 @@ public:
 	CBinaryOutputStream(LPCWSTR pszFilePath, bool bExceptionMode = false);
 };
 
-#endif /* SAKURA_CBINARYSTREAM_F33600DB_8369_4FB2_B7B1_8B59249B7216_H_ */
 /*[EOF]*/

--- a/sakura_core/io/CFile.h
+++ b/sakura_core/io/CFile.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFILE_4C6F2C6F_75E4_470C_8AB0_0A8567BF032E9_H_
-#define SAKURA_CFILE_4C6F2C6F_75E4_470C_8AB0_0A8567BF032E9_H_
+#pragma once
 
 #include "basis/CMyString.h" //CFilePath
 #include "util/file.h"
@@ -72,5 +71,4 @@ private:
 	FILE* m_fp;
 };
 
-#endif /* SAKURA_CFILE_4C6F2C6F_75E4_470C_8AB0_0A8567BF032E9_H_ */
 /*[EOF]*/

--- a/sakura_core/io/CFileLoad.h
+++ b/sakura_core/io/CFileLoad.h
@@ -28,8 +28,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFILELOAD_H_
-#define SAKURA_CFILELOAD_H_
+#pragma once
 
 #include <Windows.h>
 #include "CStream.h" //CError_FileOpen
@@ -170,6 +169,4 @@ inline DWORD CFileLoad::FilePointer( DWORD offset, DWORD origin )
 		throw CError_FileRead();
 	return fp;
 }
-
-#endif /* SAKURA_CFILELOAD_H_ */
 

--- a/sakura_core/io/CIoBridge.h
+++ b/sakura_core/io/CIoBridge.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CIOBRIDGE_E98C8096_06B2_41EF_AED2_8D9876BF25BA9_H_
-#define SAKURA_CIOBRIDGE_E98C8096_06B2_41EF_AED2_8D9876BF25BA9_H_
+#pragma once
 
 #include "mem/CMemory.h"
 #include "charset/CCodeBase.h"
@@ -46,5 +45,4 @@ public:
 	);
 };
 
-#endif /* SAKURA_CIOBRIDGE_E98C8096_06B2_41EF_AED2_8D9876BF25BA9_H_ */
 /*[EOF]*/

--- a/sakura_core/io/CStream.h
+++ b/sakura_core/io/CStream.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSTREAM_BB8B6415_7CBF_48F0_9454_2AC4D39C7CD1_H_
-#define SAKURA_CSTREAM_BB8B6415_7CBF_48F0_9454_2AC4D39C7CD1_H_
+#pragma once
 
 class CFileAttribute;
 
@@ -99,5 +98,4 @@ public:
 	}
 };
 
-#endif /* SAKURA_CSTREAM_BB8B6415_7CBF_48F0_9454_2AC4D39C7CD1_H_ */
 /*[EOF]*/

--- a/sakura_core/io/CTextStream.h
+++ b/sakura_core/io/CTextStream.h
@@ -29,8 +29,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CTEXTSTREAM_0D3CC877_CA34_4CC8_9596_B120F4F902939_H_
-#define SAKURA_CTEXTSTREAM_0D3CC877_CA34_4CC8_9596_B120F4F902939_H_
+#pragma once
 
 #include <string>
 
@@ -77,5 +76,4 @@ public:
 	CTextInputStream_AbsIni(const WCHAR* pszPath, bool bOrExedir = true);
 };
 
-#endif /* SAKURA_CTEXTSTREAM_0D3CC877_CA34_4CC8_9596_B120F4F902939_H_ */
 /*[EOF]*/

--- a/sakura_core/io/CZipFile.h
+++ b/sakura_core/io/CZipFile.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CZIPFILE_5D06C90F_5043_418e_BA31_FB599CF6FD03_H_
-#define SAKURA_CZIPFILE_5D06C90F_5043_418e_BA31_FB599CF6FD03_H_
+#pragma once
 
 #include <ShlDisp.h>
 
@@ -46,4 +45,4 @@ public:
 	bool	ChkPluginDef(const std::wstring& sDefFile, std::wstring& sFolderName);	// ZIP File 内 フォルダ名取得と定義ファイル検査(Plugin用)
 	bool	Unzip(const std::wstring sOutPath);			// Zip File 解凍
 };
-#endif	// SAKURA_CZIPFILE_5D06C90F_5043_418e_BA31_FB599CF6FD03_H_
+

--- a/sakura_core/macro/CCookieManager.h
+++ b/sakura_core/macro/CCookieManager.h
@@ -26,8 +26,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CCOOKIE_MANAGER_H_
-#define SAKURA_CCOOKIE_MANAGER_H_
+#pragma once
 
 #include <map>
 #include <string>
@@ -53,4 +52,3 @@ private:
 	std::map<wstring, wstring> m_cookieDocument;
 };
 
-#endif

--- a/sakura_core/macro/CEditorIfObj.h
+++ b/sakura_core/macro/CEditorIfObj.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CEDITORIFOBJ_87C246CB_1387_4893_A26F_190155191A96D_H_
-#define SAKURA_CEDITORIFOBJ_87C246CB_1387_4893_A26F_190155191A96D_H_
+#pragma once
 
 #include "_os/OleTypes.h"
 #include "macro/CWSHIfObj.h"
@@ -44,5 +43,4 @@ public:
 	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize);	//コマンドを処理する
 };
 
-#endif /* SAKURA_CEDITORIFOBJ_87C246CB_1387_4893_A26F_190155191A96D_H_ */
 /*[EOF]*/

--- a/sakura_core/macro/CIfObj.h
+++ b/sakura_core/macro/CIfObj.h
@@ -28,8 +28,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CIFOBJ_9DB7E463_B156_4A8D_85C7_44259381BBBF9_H_
-#define SAKURA_CIFOBJ_9DB7E463_B156_4A8D_85C7_44259381BBBF9_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -139,5 +138,4 @@ private:
 	ITypeInfo* m_TypeInfo;
 };
 
-#endif /* SAKURA_CIFOBJ_9DB7E463_B156_4A8D_85C7_44259381BBBF9_H_ */
 /*[EOF]*/

--- a/sakura_core/macro/CKeyMacroMgr.h
+++ b/sakura_core/macro/CKeyMacroMgr.h
@@ -12,8 +12,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CKEYMACROMGR_H_
-#define _CKEYMACROMGR_H_
+#pragma once
 
 #include <Windows.h>
 #include "CMacroManagerBase.h"
@@ -64,5 +63,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CKEYMACROMGR_H_ */
-

--- a/sakura_core/macro/CMacro.h
+++ b/sakura_core/macro/CMacro.h
@@ -31,8 +31,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CMACRO_500D8D68_B51E_4B8B_9752_2B130EA3310B_H_
-#define SAKURA_CMACRO_500D8D68_B51E_4B8B_9752_2B130EA3310B_H_
+#pragma once
 
 #include <Windows.h>
 #include <ObjIdl.h>  // VARIANT等
@@ -132,4 +131,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CMACRO_500D8D68_B51E_4B8B_9752_2B130EA3310B_H_ */

--- a/sakura_core/macro/CMacroFactory.h
+++ b/sakura_core/macro/CMacroFactory.h
@@ -29,8 +29,7 @@
 		   distribution.
 */
 
-#ifndef __CMACROTYPEMGR_H_
-#define __CMACROTYPEMGR_H_
+#pragma once
 
 #include <map>
 #include <list>
@@ -85,4 +84,4 @@ private:
 	*/
 	MacroEngineRep m_mMacroCreators;
 };
-#endif
+

--- a/sakura_core/macro/CMacroManagerBase.h
+++ b/sakura_core/macro/CMacroManagerBase.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef __CMACROMGR_BASE_H_
-#define __CMACROMGR_BASE_H_
+#pragma once
 
 #include <Windows.h>
 class CEditView;
@@ -99,4 +98,3 @@ public:
 	CMacroManagerBase();
 };
 
-#endif

--- a/sakura_core/macro/CPPA.h
+++ b/sakura_core/macro/CPPA.h
@@ -35,8 +35,7 @@
 PPA(Poor-Pascal for Application)はDelphi/C++Builder用のPascalインタプリタコンポーネントです。
 */
 
-#ifndef _DLL_CPPA_H_
-#define _DLL_CPPA_H_
+#pragma once
 
 #include <ObjIdl.h>  // VARIANT等
 #include <stdio.h>
@@ -292,6 +291,4 @@ private:
 	static int					m_nFuncNum;	//	SAKURAエディタ用関数の数
 */
 };
-
-#endif
 

--- a/sakura_core/macro/CPPAMacroMgr.h
+++ b/sakura_core/macro/CPPAMacroMgr.h
@@ -13,8 +13,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CPPAMACROMGR_H_
-#define _CPPAMACROMGR_H_
+#pragma once
 
 #include <Windows.h>
 #include "CKeyMacroMgr.h"
@@ -51,5 +50,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CPPAMACROMGR_H_ */
-

--- a/sakura_core/macro/CSMacroMgr.h
+++ b/sakura_core/macro/CSMacroMgr.h
@@ -31,8 +31,7 @@
 		   distribution.
 */
 
-#ifndef _CSMACROMGR_H_
-#define _CSMACROMGR_H_
+#pragma once
 
 #include <Windows.h>
 #include <WTypes.h> //VARTYPE
@@ -184,5 +183,3 @@ public:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CSMacroMGR_H_ */
-

--- a/sakura_core/macro/CWSH.h
+++ b/sakura_core/macro/CWSH.h
@@ -16,8 +16,7 @@
 
 */
 
-#ifndef __WSH_H__
-#define __WSH_H__
+#pragma once
 
 #include <ActivScp.h>
 //↑Microsoft Platform SDK より
@@ -60,4 +59,3 @@ private:
 	List m_IfObjArr;
 };
 
-#endif

--- a/sakura_core/macro/CWSHIfObj.h
+++ b/sakura_core/macro/CWSHIfObj.h
@@ -28,8 +28,8 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CWSHIFOBJ_EAA6C3E3_1442_4940_B8A3_2AAB324D8788D_H_
-#define SAKURA_CWSHIFOBJ_EAA6C3E3_1442_4940_B8A3_2AAB324D8788D_H_
+#pragma once
+
 #include <list>
 #include <ActivScp.h>
 #include "_os/OleTypes.h"
@@ -77,5 +77,4 @@ protected:
 	CEditView* m_pView;
 };
 
-#endif /* SAKURA_CWSHIFOBJ_EAA6C3E3_1442_4940_B8A3_2AAB324D8788D_H_ */
 /*[EOF]*/

--- a/sakura_core/macro/CWSHManager.h
+++ b/sakura_core/macro/CWSHManager.h
@@ -19,8 +19,7 @@
 
 */
 
-#ifndef __CWSH_Manager_H__
-#define __CWSH_Manager_H__
+#pragma once
 
 #include <Windows.h>
 #include <string>
@@ -56,4 +55,4 @@ protected:
 	////	2007.07.20 genta : flags追加
 	//static void ReadyCommands(CIfObj *Object, MacroFuncInfo *Info, int flags);
 };
-#endif
+

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -31,8 +31,7 @@
 		   distribution.
 */
 
-#ifndef _CMEMORY_H_
-#define _CMEMORY_H_
+#pragma once
 
 /*! ファイル文字コードセット判別時の先読み最大サイズ */
 #define CheckKanjiCode_MAXREADLENGTH 16384
@@ -123,5 +122,3 @@ private: // 2002/2/10 aroka アクセス権変更
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CMEMORY_H_ */
-

--- a/sakura_core/mem/CMemoryIterator.h
+++ b/sakura_core/mem/CMemoryIterator.h
@@ -12,8 +12,7 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
-#ifndef _CMEMORYITERATOR_H_
-#define _CMEMORYITERATOR_H_
+#pragma once
 
 //	sakura
 #include "_main/global.h"
@@ -150,5 +149,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CBLOCKCOMMENT_H_ */
-

--- a/sakura_core/mem/CNative.h
+++ b/sakura_core/mem/CNative.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CNATIVE_211120FF_E38A_4AFA_8270_8927A77F4DA79_H_
-#define SAKURA_CNATIVE_211120FF_E38A_4AFA_8270_8927A77F4DA79_H_
+#pragma once
 
 #include "mem/CMemory.h"
 
@@ -45,5 +44,4 @@ static_assert(sizeof(CNative) == sizeof(CMemory), "size check");
 #include "mem/CNativeA.h"
 #include "mem/CNativeW.h"
 
-#endif /* SAKURA_CNATIVE_211120FF_E38A_4AFA_8270_8927A77F4DA79_H_ */
 /*[EOF]*/

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CNATIVEA_B88E7301_8CD3_4DF8_8750_2FF92F357FA09_H_
-#define SAKURA_CNATIVEA_B88E7301_8CD3_4DF8_8750_2FF92F357FA09_H_
+#pragma once
 
 #include "CNative.h"
 
@@ -72,5 +71,4 @@ public:
 
 };
 
-#endif /* SAKURA_CNATIVEA_B88E7301_8CD3_4DF8_8750_2FF92F357FA09_H_ */
 /*[EOF]*/

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CNATIVEW_59D44E96_F966_471D_A399_73D86F939DDA9_H_
-#define SAKURA_CNATIVEW_59D44E96_F966_471D_A399_73D86F939DDA9_H_
+#pragma once
 
 #include "CNative.h"
 #include "basis/SakuraBasis.h"
@@ -164,5 +163,4 @@ template <>
 	}
 }
 
-#endif /* SAKURA_CNATIVEW_59D44E96_F966_471D_A399_73D86F939DDA9_H_ */
 /*[EOF]*/

--- a/sakura_core/mem/CPoolResource.h
+++ b/sakura_core/mem/CPoolResource.h
@@ -22,8 +22,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CPOOLRESOURCE_H_
-#define SAKURA_CPOOLRESOURCE_H_
+#pragma once
 
 #include <memory_resource>
 #include <Windows.h>
@@ -134,4 +133,3 @@ private:
 	Node* m_currentNode = nullptr; // 要素確保処理時に現在のブロックの中から切り出すNodeを指すポインタ、メモリ確保時に未割当領域が無い場合はここを使う
 };
 
-#endif /* SAKURA_CPOOLRESOURCE_H_ */

--- a/sakura_core/mem/CRecycledBuffer.h
+++ b/sakura_core/mem/CRecycledBuffer.h
@@ -26,8 +26,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECYCLEDBUFFER_865628A4_D60A_4F2E_8021_EA83D0D438819_H_
-#define SAKURA_CRECYCLEDBUFFER_865628A4_D60A_4F2E_8021_EA83D0D438819_H_
+#pragma once
 
 class CRecycledBuffer{
 //コンフィグ
@@ -112,5 +111,4 @@ private:
 	int   m_current;
 };
 
-#endif /* SAKURA_CRECYCLEDBUFFER_865628A4_D60A_4F2E_8021_EA83D0D438819_H_ */
 /*[EOF]*/

--- a/sakura_core/mfclike/CMyWnd.h
+++ b/sakura_core/mfclike/CMyWnd.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CMYWND_2BBCE2D2_F4DC_4809_BFFE_476824F2E0ABR_H_
-#define SAKURA_CMYWND_2BBCE2D2_F4DC_4809_BFFE_476824F2E0ABR_H_
+#pragma once
 
 /*
 	MFCのCWnd的なクラス。
@@ -80,5 +79,4 @@ private:
 	HWND m_hWnd;
 };
 
-#endif /* SAKURA_CMYWND_2BBCE2D2_F4DC_4809_BFFE_476824F2E0ABR_H_ */
 /*[EOF]*/

--- a/sakura_core/outline/CDlgFileTree.h
+++ b/sakura_core/outline/CDlgFileTree.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CDLGFILETREE_H_
-#define SAKURA_CDLGFILETREE_H_
+#pragma once
 
 #include "dlg/CDialog.h"
 #include "outline/CDlgFuncList.h"
@@ -69,6 +68,4 @@ private:
 
 	int					m_bInMove;
 };
-
-#endif /* SAKURA_CDLGFILETREE_H_ */
 

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -18,8 +18,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef SAKURA_CDLGFUNCLIST_H_
-#define SAKURA_CDLGFUNCLIST_H_
+#pragma once
 
 #include <Windows.h>
 #include "dlg/CDialog.h"
@@ -224,5 +223,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CDLGFUNCLIST_H_ */
-

--- a/sakura_core/outline/CFuncInfo.h
+++ b/sakura_core/outline/CFuncInfo.h
@@ -13,10 +13,9 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-class CFuncInfo;
+#pragma once
 
-#ifndef _CFUNCINFO_H_
-#define _CFUNCINFO_H_
+class CFuncInfo;
 
 #include "mem/CMemory.h"
 
@@ -53,5 +52,3 @@ class CFuncInfo {
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CFUNCINFO_H_ */
-

--- a/sakura_core/outline/CFuncInfoArr.h
+++ b/sakura_core/outline/CFuncInfoArr.h
@@ -12,8 +12,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CFUNCINFOARR_H_
-#define _CFUNCINFOARR_H_
+#pragma once
 
 class CFuncInfo;
 #include <string>
@@ -62,5 +61,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CFUNCINFOARR_H_ */
-

--- a/sakura_core/parse/CWordParse.h
+++ b/sakura_core/parse/CWordParse.h
@@ -23,8 +23,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CWORDPARSE_6C07A5B6_49DE_430F_A56F_9F2B003214FC9_H_
-#define SAKURA_CWORDPARSE_6C07A5B6_49DE_430F_A56F_9F2B003214FC9_H_
+#pragma once
 
 #include "basis/SakuraBasis.h"
 class CNativeW;
@@ -231,5 +230,4 @@ end_func:
 	return pr - pS;
 }
 
-#endif /* SAKURA_CWORDPARSE_6C07A5B6_49DE_430F_A56F_9F2B003214FC9_H_ */
 /*[EOF]*/

--- a/sakura_core/plugin/CComplementIfObj.h
+++ b/sakura_core/plugin/CComplementIfObj.h
@@ -26,8 +26,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOMPLEMENTIFOBJ_CE6919C7_F8F8_479E_BC70_7BA4651351D27_H_
-#define SAKURA_CCOMPLEMENTIFOBJ_CE6919C7_F8F8_479E_BC70_7BA4651351D27_H_
+#pragma once
 
 #include "macro/CWSHIfObj.h"
 #include "util/ole_convert.h"
@@ -133,4 +132,3 @@ MacroFuncInfo CComplementIfObj::m_MacroFuncInfoArr[] =
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 
-#endif /* SAKURA_CCOMPLEMENTIFOBJ_CE6919C7_F8F8_479E_BC70_7BA4651351D27_H_ */

--- a/sakura_core/plugin/CDllPlugin.h
+++ b/sakura_core/plugin/CDllPlugin.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CDLLPLUGIN_A62D7B59_C283_4C5A_887F_DA0138E09D2C_H_
-#define SAKURA_CDLLPLUGIN_A62D7B59_C283_4C5A_887F_DA0138E09D2C_H_
+#pragma once
 
 #include "CPlugin.h"
 
@@ -84,5 +83,4 @@ private:
 	wstring m_sDllName;
 };
 
-#endif /* SAKURA_CDLLPLUGIN_A62D7B59_C283_4C5A_887F_DA0138E09D2C_H_ */
 /*[EOF]*/

--- a/sakura_core/plugin/CJackManager.h
+++ b/sakura_core/plugin/CJackManager.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CJACKMANAGER_6CC7B212_130B_46AF_9C88_05F554CDA34BO_H_
-#define SAKURA_CJACKMANAGER_6CC7B212_130B_46AF_9C88_05F554CDA34BO_H_
+#pragma once
 
 #include "plugin/CPlugin.h"
 #include <list>
@@ -102,5 +101,4 @@ private:
 	std::vector<JackDef> m_Jacks;	//ジャック定義の一覧
 };
 
-#endif /* SAKURA_CJACKMANAGER_6CC7B212_130B_46AF_9C88_05F554CDA34BO_H_ */
 /*[EOF]*/

--- a/sakura_core/plugin/COutlineIfObj.h
+++ b/sakura_core/plugin/COutlineIfObj.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_COUTLINEIFOBJ_5C2DD72B_8550_40AB_9C49_2B1C5D17C91FW_H_
-#define SAKURA_COUTLINEIFOBJ_5C2DD72B_8550_40AB_9C49_2B1C5D17C91FW_H_
+#pragma once
 
 #include "macro/CWSHIfObj.h"
 #include "outline/CFuncInfo.h"	// FUNCINFO_INFOMASK
@@ -169,5 +168,4 @@ MacroFuncInfo COutlineIfObj::m_MacroFuncInfoArr[] =
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 
-#endif /* SAKURA_COUTLINEIFOBJ_5C2DD72B_8550_40AB_9C49_2B1C5D17C91FW_H_ */
 /*[EOF]*/

--- a/sakura_core/plugin/CPlugin.h
+++ b/sakura_core/plugin/CPlugin.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CPLUGIN_E837BF6E_3F18_4A7E_89FD_F4DAE8DF9CFFD_H_
-#define SAKURA_CPLUGIN_E837BF6E_3F18_4A7E_89FD_F4DAE8DF9CFFD_H_
+#pragma once
 
 #include <algorithm>
 #include "macro/CWSHIfObj.h"
@@ -302,5 +301,4 @@ public:
 	virtual bool ReadPluginOption( CDataProfile *cProfile ) =0;		//オプションファイルを読み込む
 };
 
-#endif /* SAKURA_CPLUGIN_E837BF6E_3F18_4A7E_89FD_F4DAE8DF9CFFD_H_ */
 /*[EOF]*/

--- a/sakura_core/plugin/CPluginIfObj.h
+++ b/sakura_core/plugin/CPluginIfObj.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CPLUGINIFOBJ_2205DDE8_330B_49AC_AC5E_4C02F07DDCD5D_H_
-#define SAKURA_CPLUGINIFOBJ_2205DDE8_330B_49AC_AC5E_4C02F07DDCD5D_H_
+#pragma once
 
 #include "macro/CWSHIfObj.h"
 #include "_os/OleTypes.h"
@@ -212,5 +211,4 @@ MacroFuncInfo CPluginIfObj::m_MacroFuncInfoArr[] =
 	{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
 };
 
-#endif /* SAKURA_CPLUGINIFOBJ_2205DDE8_330B_49AC_AC5E_4C02F07DDCD5D_H_ */
 /*[EOF]*/

--- a/sakura_core/plugin/CPluginManager.h
+++ b/sakura_core/plugin/CPluginManager.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CPLUGINMANAGER_1015EF83_3B11_47FB_BAAF_63ACAFE32FCAD_H_
-#define SAKURA_CPLUGINMANAGER_1015EF83_3B11_47FB_BAAF_63ACAFE32FCAD_H_
+#pragma once
 
 #include "plugin/CPlugin.h"
 #include <list>
@@ -72,5 +71,4 @@ private:
 	wstring m_sExePluginDir;			//Exeフォルダ配下pluginsフォルダのパス
 };
 
-#endif /* SAKURA_CPLUGINMANAGER_1015EF83_3B11_47FB_BAAF_63ACAFE32FCAD_H_ */
 /*[EOF]*/

--- a/sakura_core/plugin/CSmartIndentIfObj.h
+++ b/sakura_core/plugin/CSmartIndentIfObj.h
@@ -26,8 +26,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSMARTINDENTIFOBJ_5708577D_5A1D_4374_91FD_5E180C9F4E20_H_
-#define SAKURA_CSMARTINDENTIFOBJ_5708577D_5A1D_4374_91FD_5E180C9F4E20_H_
+#pragma once
 
 #include "macro/CWSHIfObj.h"
 
@@ -102,4 +101,3 @@ public:
 	wchar_t m_wcChar;
 };
 
-#endif /* SAKURA_CSMARTINDENTIFOBJ_5708577D_5A1D_4374_91FD_5E180C9F4E20_H_ */

--- a/sakura_core/plugin/CWSHPlugin.h
+++ b/sakura_core/plugin/CWSHPlugin.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CWSHPLUGIN_EBA87CBD_779A_4AD3_AB4D_4BFE8E7E339AD_H_
-#define SAKURA_CWSHPLUGIN_EBA87CBD_779A_4AD3_AB4D_4BFE8E7E339AD_H_
+#pragma once
 
 #include "plugin/CPlugin.h"
 #include "macro/CWSHManager.h"
@@ -86,5 +85,4 @@ private:
 	bool m_bUseCache;
 };
 
-#endif /* SAKURA_CWSHPLUGIN_EBA87CBD_779A_4AD3_AB4D_4BFE8E7E339AD_H_ */
 /*[EOF]*/

--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -29,8 +29,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CPRINT_12337831_217C_40E7_A646_C106350A3E91R_H_
-#define SAKURA_CPRINT_12337831_217C_40E7_A646_C106350A3E91R_H_
+#pragma once
 
 #include <WinSpool.h>
 #include <CommDlg.h> // PRINTDLG
@@ -235,4 +234,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CPRINT_12337831_217C_40E7_A646_C106350A3E91R_H_ */

--- a/sakura_core/print/CPrintPreview.h
+++ b/sakura_core/print/CPrintPreview.h
@@ -29,8 +29,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CPRINTPREVIEW_4FBD8BE8_4E93_4714_A3F2_F69081A2EDBDR_H_
-#define SAKURA_CPRINTPREVIEW_4FBD8BE8_4E93_4714_A3F2_F69081A2EDBDR_H_
+#pragma once
 
 #include <Windows.h> // 2002/2/10 aroka
 #include "basis/SakuraBasis.h"
@@ -269,4 +268,3 @@ protected:
 	DISALLOW_COPY_AND_ASSIGN(CPrintPreview);
 };
 
-#endif /* SAKURA_CPRINTPREVIEW_4FBD8BE8_4E93_4714_A3F2_F69081A2EDBDR_H_ */

--- a/sakura_core/prop/CPropCommon.h
+++ b/sakura_core/prop/CPropCommon.h
@@ -36,8 +36,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CPROPCOMMON_8B67EE84_54E5_4541_A820_EE4FC61CCF0D_H_
-#define SAKURA_CPROPCOMMON_8B67EE84_54E5_4541_A820_EE4FC61CCF0D_H_
+#pragma once
 
 #include "func/CFuncLookup.h"
 #include "env/CommonSetting.h"
@@ -544,4 +543,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CPROPCOMMON_8B67EE84_54E5_4541_A820_EE4FC61CCF0D_H_ */

--- a/sakura_core/recent/CMRUFile.h
+++ b/sakura_core/recent/CMRUFile.h
@@ -32,8 +32,7 @@
 		   distribution.
 */
 
-#ifndef _CMRUFILE_H_
-#define _CMRUFILE_H_
+#pragma once
 
 #include <Windows.h> /// BOOL,HMENU // 2002/2/10 aroka
 #include <vector>
@@ -73,4 +72,3 @@ private:
 	CRecentFile	m_cRecentFile;	//履歴	//@@@ 2003.04.08 MIK
 };
 
-#endif	// _CMRUFILE_H_

--- a/sakura_core/recent/CMRUFolder.h
+++ b/sakura_core/recent/CMRUFolder.h
@@ -31,8 +31,7 @@
 		   distribution.
 */
 
-#ifndef _CMRUFOLDER_H_
-#define _CMRUFOLDER_H_
+#pragma once
 
 #include <Windows.h> /// BOOL,HMENU // 2002/2/10 aroka
 #include "recent/CRecentFolder.h"
@@ -69,4 +68,3 @@ private:
 	CRecentFolder	m_cRecentFolder;	//履歴	//@@@ 2003.04.08 MIK
 };
 
-#endif

--- a/sakura_core/recent/CMruListener.h
+++ b/sakura_core/recent/CMruListener.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CMRULISTENER_7C175242_808A_48BB_A4C2_93FA71274B999_H_
-#define SAKURA_CMRULISTENER_7C175242_808A_48BB_A4C2_93FA71274B999_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 
@@ -45,5 +44,4 @@ protected:
 	void _HoldBookmarks_And_AddToMRU(); // Mar. 30, 2003 genta
 };
 
-#endif /* SAKURA_CMRULISTENER_7C175242_808A_48BB_A4C2_93FA71274B999_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecent.h
+++ b/sakura_core/recent/CRecent.h
@@ -33,8 +33,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENT_E523D9BB_0DBF_4642_846A_990A2B5122CF9_H_
-#define SAKURA_CRECENT_E523D9BB_0DBF_4642_846A_990A2B5122CF9_H_
+#pragma once
 
 #include "_main/global.h"
 #include "env/DLLSHAREDATA.h"
@@ -83,5 +82,4 @@ public:
 
 #include "CRecentImp.h"
 
-#endif /* SAKURA_CRECENT_E523D9BB_0DBF_4642_846A_990A2B5122CF9_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentCmd.h
+++ b/sakura_core/recent/CRecentCmd.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTCMD_606E7B7E_F285_423C_9EB8_C472B010280B_H_
-#define SAKURA_CRECENTCMD_606E7B7E_F285_423C_9EB8_C472B010280B_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -47,5 +46,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTCMD_606E7B7E_F285_423C_9EB8_C472B010280B_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentCurDir.h
+++ b/sakura_core/recent/CRecentCurDir.h
@@ -23,8 +23,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTCURDIR_606E7B1E_F285_4232_92B8_C47260107806_H_
-#define SAKURA_CRECENTCURDIR_606E7B1E_F285_4232_92B8_C47260107806_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -47,5 +46,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTCURDIR_606E7B1E_F285_4232_92B8_C47260107806_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentEditNode.h
+++ b/sakura_core/recent/CRecentEditNode.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTEDITNODE_D86DB1B5_3747_406B_93A6_D5CF59B26BB2_H_
-#define SAKURA_CRECENTEDITNODE_D86DB1B5_3747_406B_93A6_D5CF59B26BB2_H_
+#pragma once
 
 #include "CRecentImp.h"
 struct EditNode;
@@ -47,5 +46,4 @@ public:
 	void DeleteItemByHwnd(HWND hwnd);
 };
 
-#endif /* SAKURA_CRECENTEDITNODE_D86DB1B5_3747_406B_93A6_D5CF59B26BB2_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentExceptMru.h
+++ b/sakura_core/recent/CRecentExceptMru.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTEXCEPTMRU_C30EB710_D560_49A0_99EB_603E335B102A_H_
-#define SAKURA_CRECENTEXCEPTMRU_C30EB710_D560_49A0_99EB_603E335B102A_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -46,5 +45,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTEXCEPTMRU_C30EB710_D560_49A0_99EB_603E335B102A_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentExcludeFile.h
+++ b/sakura_core/recent/CRecentExcludeFile.h
@@ -21,8 +21,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTExcludeFILE_6DFF8FB2_B7D0_4828_8191_744A9580C467_H_
-#define SAKURA_CRECENTExcludeFILE_6DFF8FB2_B7D0_4828_8191_744A9580C467_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -45,5 +44,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTExcludeFILE_6DFF8FB2_B7D0_4828_8191_744A9580C467_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentExcludeFolder.h
+++ b/sakura_core/recent/CRecentExcludeFolder.h
@@ -21,8 +21,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTExcludeFOLDER_6162D952_F009_44DB_9C13_80E73507D8E7_H_
-#define SAKURA_CRECENTExcludeFOLDER_6162D952_F009_44DB_9C13_80E73507D8E7_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -45,5 +44,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTExcludeFOLDER_6162D952_F009_44DB_9C13_80E73507D8E7_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentFile.h
+++ b/sakura_core/recent/CRecentFile.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTFILE_EE3F27C6_A91E_426D_8EB9_2E35D191F4199_H_
-#define SAKURA_CRECENTFILE_EE3F27C6_A91E_426D_8EB9_2E35D191F4199_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "EditInfo.h" //EditInfo
@@ -46,5 +45,4 @@ public:
 	int FindItemByPath(const WCHAR* pszPath) const;
 };
 
-#endif /* SAKURA_CRECENTFILE_EE3F27C6_A91E_426D_8EB9_2E35D191F4199_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentFolder.h
+++ b/sakura_core/recent/CRecentFolder.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTFOLDER_A671E5A1_CE40_4BEF_BA37_B468B056F081_H_
-#define SAKURA_CRECENTFOLDER_A671E5A1_CE40_4BEF_BA37_B468B056F081_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -48,5 +47,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTFOLDER_A671E5A1_CE40_4BEF_BA37_B468B056F081_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentGrepFile.h
+++ b/sakura_core/recent/CRecentGrepFile.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTGREPFILE_6DFF8FB2_B7D0_4828_8191_744A9580C467_H_
-#define SAKURA_CRECENTGREPFILE_6DFF8FB2_B7D0_4828_8191_744A9580C467_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -46,5 +45,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTGREPFILE_6DFF8FB2_B7D0_4828_8191_744A9580C467_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentGrepFolder.h
+++ b/sakura_core/recent/CRecentGrepFolder.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTGREPFOLDER_6162D952_F009_44DB_9C13_80E73507D8E7_H_
-#define SAKURA_CRECENTGREPFOLDER_6162D952_F009_44DB_9C13_80E73507D8E7_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -46,5 +45,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTGREPFOLDER_6162D952_F009_44DB_9C13_80E73507D8E7_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentImp.h
+++ b/sakura_core/recent/CRecentImp.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTIMP_083F499E_59DF_486A_828B_BF7A535B6893_H_
-#define SAKURA_CRECENTIMP_083F499E_59DF_486A_828B_BF7A535B6893_H_
+#pragma once
 
 #include "recent/CRecent.h"
 
@@ -131,5 +130,4 @@ protected:
 #include "CRecentEditNode.h"
 #include "CRecentTagjumpKeyword.h"
 
-#endif /* SAKURA_CRECENTIMP_083F499E_59DF_486A_828B_BF7A535B6893_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentReplace.h
+++ b/sakura_core/recent/CRecentReplace.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTREPLACE_0597B923_7C40_4B6A_BCCE_C35E043E7577_H_
-#define SAKURA_CRECENTREPLACE_0597B923_7C40_4B6A_BCCE_C35E043E7577_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -46,5 +45,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTREPLACE_0597B923_7C40_4B6A_BCCE_C35E043E7577_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentSearch.h
+++ b/sakura_core/recent/CRecentSearch.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTSEARCH_23B8363C_C92F_4506_8803_90ABB9EC0370_H_
-#define SAKURA_CRECENTSEARCH_23B8363C_C92F_4506_8803_90ABB9EC0370_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -46,5 +45,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTSEARCH_23B8363C_C92F_4506_8803_90ABB9EC0370_H_ */
 /*[EOF]*/

--- a/sakura_core/recent/CRecentTagjumpKeyword.h
+++ b/sakura_core/recent/CRecentTagjumpKeyword.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRECENTTAGJUMPKEYWORD_A97C71AE_DADC_47EA_B3A4_E3AAB4F6E217_H_
-#define SAKURA_CRECENTTAGJUMPKEYWORD_A97C71AE_DADC_47EA_B3A4_E3AAB4F6E217_H_
+#pragma once
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
@@ -46,5 +45,4 @@ public:
 	size_t			GetTextMaxLength() const;
 };
 
-#endif /* SAKURA_CRECENTTAGJUMPKEYWORD_A97C71AE_DADC_47EA_B3A4_E3AAB4F6E217_H_ */
 /*[EOF]*/

--- a/sakura_core/typeprop/CDlgKeywordSelect.h
+++ b/sakura_core/typeprop/CDlgKeywordSelect.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef SC_CDLGKEYWORDSELECT_H__
-#define SC_CDLGKEYWORDSELECT_H__
+#pragma once
 
 #include "dlg/CDialog.h"
 #include "config/maxdata.h" // MAX_KEYWORDSET_PER_TYPE
@@ -63,6 +62,4 @@ protected:
 	int m_nSet[ KEYWORD_SELECT_NUM ];
 	CKeyWordSetMgr*	m_pCKeyWordSetMgr;
 };
-
-#endif
 

--- a/sakura_core/typeprop/CDlgSameColor.h
+++ b/sakura_core/typeprop/CDlgSameColor.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef SC_CDLGSAMECOLOR_H__
-#define SC_CDLGSAMECOLOR_H__
+#pragma once
 
 #include "dlg/CDialog.h"
 
@@ -66,6 +65,4 @@ protected:
 	STypeConfig* m_pTypes;	//!< タイプ別設定データ
 	COLORREF m_cr;		//!< 指定色
 };
-
-#endif
 

--- a/sakura_core/typeprop/CDlgTypeAscertain.h
+++ b/sakura_core/typeprop/CDlgTypeAscertain.h
@@ -28,10 +28,10 @@
 		   distribution.
 */
 
+#pragma once
+
 class CDlgTypeAscertain;
 
-#ifndef _CDLGTYPEASCERTAIN_H_
-#define _CDLGTYPEASCERTAIN_H_
 using std::wstring;
 
 #include "dlg/CDialog.h"
@@ -71,5 +71,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGTYPEASCERTAIN_H_ */
-

--- a/sakura_core/typeprop/CDlgTypeList.h
+++ b/sakura_core/typeprop/CDlgTypeList.h
@@ -12,10 +12,9 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-class CDlgTypeList;
+#pragma once
 
-#ifndef _CDLGTYPELIST_H_
-#define _CDLGTYPELIST_H_
+class CDlgTypeList;
 
 #include "dlg/CDialog.h"
 using std::wstring;
@@ -69,5 +68,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CDLGTYPELIST_H_ */
-

--- a/sakura_core/typeprop/CImpExpManager.h
+++ b/sakura_core/typeprop/CImpExpManager.h
@@ -28,8 +28,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CIMPEXPMANAGER_H_
-#define SAKURA_CIMPEXPMANAGER_H_
+#pragma once
 
 #include "CDataProfile.h"
 #include "env/DLLSHAREDATA.h"
@@ -326,4 +325,3 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CIMPEXPMANAGER_H_ */

--- a/sakura_core/typeprop/CPropTypes.h
+++ b/sakura_core/typeprop/CPropTypes.h
@@ -18,8 +18,7 @@
 	Please contact the copyright holders to use this code for other purpose.
 */
 
-#ifndef SAKURA_CPROPTYPES_E8B842DB_7434_4B94_8B6F_52C4FA9D1F3AP_H_
-#define SAKURA_CPROPTYPES_E8B842DB_7434_4B94_8B6F_52C4FA9D1F3AP_H_
+#pragma once
 
 #include "types/CType.h" // STypeConfig
 
@@ -254,4 +253,3 @@ void InitTypeNameId2( std::vector<TYPE_NAME_ID2<T> >& vec, TYPE_NAME_ID<T>* arr,
 }
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CPROPTYPES_E8B842DB_7434_4B94_8B6F_52C4FA9D1F3AP_H_ */

--- a/sakura_core/types/CType.h
+++ b/sakura_core/types/CType.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CTYPE_BF915633_AE38_4C73_8E5B_0411063A1AD89_H_
-#define SAKURA_CTYPE_BF915633_AE38_4C73_8E5B_0411063A1AD89_H_
+#pragma once
 
 #include "CEol.h"
 #include "env/CommonSetting.h"
@@ -353,5 +352,4 @@ inline bool C_IsSpace( wchar_t c, bool bExtEol )
 	);
 }
 
-#endif /* SAKURA_CTYPE_BF915633_AE38_4C73_8E5B_0411063A1AD89_H_ */
 /*[EOF]*/

--- a/sakura_core/types/CTypeSupport.h
+++ b/sakura_core/types/CTypeSupport.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CTYPESUPPORT_21FC7075_96B4_4572_BA60_A6550E11AC0B9_H_
-#define SAKURA_CTYPESUPPORT_21FC7075_96B4_4572_BA60_A6550E11AC0B9_H_
+#pragma once
 
 #include "uiparts/CGraphics.h"
 #include "doc/CEditDoc.h"
@@ -147,5 +146,4 @@ private:
 	CGraphics* m_gr;        //設定を変更したHDC
 };
 
-#endif /* SAKURA_CTYPESUPPORT_21FC7075_96B4_4572_BA60_A6550E11AC0B9_H_ */
 /*[EOF]*/

--- a/sakura_core/uiparts/CGraphics.h
+++ b/sakura_core/uiparts/CGraphics.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CGRAPHICS_BA5156BF_99C6_4854_8131_CE8B091A5EFF9_H_
-#define SAKURA_CGRAPHICS_BA5156BF_99C6_4854_8131_CE8B091A5EFF9_H_
+#pragma once
 
 /*
 2008.05.20 kobake 作成
@@ -329,5 +328,4 @@ private:
 	bool				m_bDynamicBrush;	//m_hbrCurrentを動的に作成した場合はtrue
 };
 
-#endif /* SAKURA_CGRAPHICS_BA5156BF_99C6_4854_8131_CE8B091A5EFF9_H_ */
 /*[EOF]*/

--- a/sakura_core/uiparts/CImageListMgr.h
+++ b/sakura_core/uiparts/CImageListMgr.h
@@ -29,8 +29,7 @@
 		   distribution.
 */
 
-#ifndef _CIMAGELIST_MGR_H_
-#define _CIMAGELIST_MGR_H_
+#pragma once
 
 #include "_main/global.h"
 
@@ -127,6 +126,4 @@ protected:
 	//! ビットマップを一行拡張する
 	void Extend(bool = true);
 };
-
-#endif
 

--- a/sakura_core/uiparts/CMenuDrawer.h
+++ b/sakura_core/uiparts/CMenuDrawer.h
@@ -15,8 +15,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CMENUDRAWER_H_
-#define _CMENUDRAWER_H_
+#pragma once
 
 #include "Funccode_enum.h"
 
@@ -128,5 +127,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CMENUDRAWER_H_ */
-

--- a/sakura_core/uiparts/CSoundSet.h
+++ b/sakura_core/uiparts/CSoundSet.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CSOUNDSET_FFF3DED9_DD53_49CD_B0FF_7A9AB2D2BE719_H_
-#define SAKURA_CSOUNDSET_FFF3DED9_DD53_49CD_B0FF_7A9AB2D2BE719_H_
+#pragma once
 
 class CSoundSet{
 public:
@@ -35,5 +34,4 @@ private:
 	int	m_nMuteCount;
 };
 
-#endif /* SAKURA_CSOUNDSET_FFF3DED9_DD53_49CD_B0FF_7A9AB2D2BE719_H_ */
 /*[EOF]*/

--- a/sakura_core/uiparts/CVisualProgress.h
+++ b/sakura_core/uiparts/CVisualProgress.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CVISUALPROGRESS_64023BB9_BFA3_45B6_9E06_553B0F5EDCC5_H_
-#define SAKURA_CVISUALPROGRESS_64023BB9_BFA3_45B6_9E06_553B0F5EDCC5_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 #include "util/design_template.h"
@@ -58,5 +57,4 @@ private:
 	DISALLOW_COPY_AND_ASSIGN(CVisualProgress);
 };
 
-#endif /* SAKURA_CVISUALPROGRESS_64023BB9_BFA3_45B6_9E06_553B0F5EDCC5_H_ */
 /*[EOF]*/

--- a/sakura_core/uiparts/CWaitCursor.h
+++ b/sakura_core/uiparts/CWaitCursor.h
@@ -11,8 +11,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CWAITCURSOR_H_
-#define _CWAITCURSOR_H_
+#pragma once
 
 #include <Windows.h>
 
@@ -41,5 +40,3 @@ private: // 2002/2/10 aroka
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CWAITCURSOR_H_ */
-

--- a/sakura_core/uiparts/HandCursor.h
+++ b/sakura_core/uiparts/HandCursor.h
@@ -28,12 +28,10 @@
 		   distribution.
 */
 
-#ifndef SAKURA_HANDCURSOR_A545F10D_9F24_4AB5_889F_13732FC0150B_H_
-#define SAKURA_HANDCURSOR_A545F10D_9F24_4AB5_889F_13732FC0150B_H_
+#pragma once
 
 inline void SetHandCursor ()
 {
 	SetCursor( LoadCursor( NULL, IDC_HAND ) );
 }
 
-#endif	// SAKURA_HANDCURSOR_A545F10D_9F24_4AB5_889F_13732FC0150B_H_

--- a/sakura_core/util/MessageBoxF.h
+++ b/sakura_core/util/MessageBoxF.h
@@ -29,8 +29,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_MESSAGEBOX_2D6EF6BC_3D8C_427B_8AFB_E8903838A1ED_H_
-#define SAKURA_MESSAGEBOX_2D6EF6BC_3D8C_427B_8AFB_E8903838A1ED_H_
+#pragma once
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                 メッセージボックス：実装                    //
@@ -90,5 +89,3 @@ int TopCustomMessage(HWND hwnd, UINT uType, LPCWSTR format, ...);	//(TOPMOST)
 int PleaseReportToAuthor(HWND hwnd, LPCWSTR format, ...);
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_MESSAGEBOX_2D6EF6BC_3D8C_427B_8AFB_E8903838A1ED_H_ */
-

--- a/sakura_core/util/RegKey.h
+++ b/sakura_core/util/RegKey.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_REGKEY_9BB6B5D5_D652_4227_9726_ADB94F2CA44E9_H_
-#define SAKURA_REGKEY_9BB6B5D5_D652_4227_9726_ADB94F2CA44E9_H_
+#pragma once
 
 class CRegKey
 {
@@ -189,5 +188,4 @@ public:
 	}
 };
 
-#endif /* SAKURA_REGKEY_9BB6B5D5_D652_4227_9726_ADB94F2CA44E9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_STATICTYPE_4B044731_DE17_46D9_9183_9F2E53F55F36_H_
-#define SAKURA_STATICTYPE_4B044731_DE17_46D9_9183_9F2E53F55F36_H_
+#pragma once
 
 #include "util/string_ex.h"
 
@@ -116,5 +115,4 @@ private:
 
 #define _countof2(s) s.BUFFER_COUNT
 
-#endif /* SAKURA_STATICTYPE_4B044731_DE17_46D9_9183_9F2E53F55F36_H_ */
 /*[EOF]*/

--- a/sakura_core/util/container.h
+++ b/sakura_core/util/container.h
@@ -27,8 +27,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CONTAINER_82819006_7BEE_4D84_82A0_B61B0E0BAFD79_H_
-#define SAKURA_CONTAINER_82819006_7BEE_4D84_82A0_B61B0E0BAFD79_H_
+#pragma once
 
 #include <vector>
 #include <algorithm> //find
@@ -60,5 +59,4 @@ public:
 	}
 };
 
-#endif /* SAKURA_CONTAINER_82819006_7BEE_4D84_82A0_B61B0E0BAFD79_H_ */
 /*[EOF]*/

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -28,8 +28,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_DESIGN_TEMPLATE_8F7F7545_B66E_47C3_AE3A_0E406B3A0B0B_H_
-#define SAKURA_DESIGN_TEMPLATE_8F7F7545_B66E_47C3_AE3A_0E406B3A0B0B_H_
+#pragma once
 
 // http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Copy_Constructors
 // A macro to disallow the copy constructor and operator= functions
@@ -113,5 +112,4 @@ private:
 };
 template <class T> std::vector<T*> TInstanceHolder<T>::gm_table;
 
-#endif /* SAKURA_DESIGN_TEMPLATE_8F7F7545_B66E_47C3_AE3A_0E406B3A0B0B_H_ */
 /*[EOF]*/

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -23,8 +23,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_FILE_2813BD8E_F6B9_400F_AA27_A6DDC372D6B89_H_
-#define SAKURA_FILE_2813BD8E_F6B9_400F_AA27_A6DDC372D6B89_H_
+#pragma once
 
 bool fexist(LPCWSTR pszPath); //!< ファイルまたはディレクトリが存在すればtrue
 
@@ -108,5 +107,4 @@ int FileMatchScoreSepExt( const WCHAR *file1, const WCHAR *file2 );
 void GetStrTrancateWidth( WCHAR* dest, int nSize, const WCHAR* path, HDC hDC, int nPxWidth );
 void GetShortViewPath(WCHAR* dest, int nSize, const WCHAR* path, HDC hDC, int nPxWidth, bool bFitMode );
 
-#endif /* SAKURA_FILE_2813BD8E_F6B9_400F_AA27_A6DDC372D6B89_H_ */
 /*[EOF]*/

--- a/sakura_core/util/format.h
+++ b/sakura_core/util/format.h
@@ -23,13 +23,11 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_FORMAT_2E480672_88BC_482E_B204_52BB5D84F20C9_H_
-#define SAKURA_FORMAT_2E480672_88BC_482E_B204_52BB5D84F20C9_H_
+#pragma once
 
 // 20051121 aroka
 bool GetDateTimeFormat( WCHAR* szResult, int size, const WCHAR* format, const SYSTEMTIME& systime );
 UINT32 ParseVersion( const WCHAR* ver );	//バージョン番号の解析
 int CompareVersion( const WCHAR* verA, const WCHAR* verB );	//バージョン番号の比較
 
-#endif /* SAKURA_FORMAT_2E480672_88BC_482E_B204_52BB5D84F20C9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/input.h
+++ b/sakura_core/util/input.h
@@ -22,12 +22,10 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_INPUT_7F979711_2295_4A97_BF62_75F89729717D9_H_
-#define SAKURA_INPUT_7F979711_2295_4A97_BF62_75F89729717D9_H_
+#pragma once
 
 //キー入力
 // novice 2004/10/10
 int getCtrlKeyState();
 
-#endif /* SAKURA_INPUT_7F979711_2295_4A97_BF62_75F89729717D9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/module.h
+++ b/sakura_core/util/module.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_MODULE_4F382EF5_EF52_47E1_A774_5CDFB545AB25_H_
-#define SAKURA_MODULE_4F382EF5_EF52_47E1_A774_5CDFB545AB25_H_
+#pragma once
 
 void GetAppVersionInfo( HINSTANCE hInstance, int nVersionResourceID,
 					    DWORD* pdwProductVersionMS, DWORD* pdwProductVersionLS );	/* リソースから製品バージョンの取得 */
@@ -37,5 +36,4 @@ void ChangeCurrentDirectoryToExeDir();
 //! カレントディレクトリ移動機能付LoadLibrary
 HMODULE LoadLibraryExedir( LPCWSTR pszDll);
 
-#endif /* SAKURA_MODULE_4F382EF5_EF52_47E1_A774_5CDFB545AB25_H_ */
 /*[EOF]*/

--- a/sakura_core/util/ole_convert.h
+++ b/sakura_core/util/ole_convert.h
@@ -2,8 +2,7 @@
 	@brief OLE型（VARIANT, BSTRなど）の変換関数
 
 */
-#ifndef SAKURA_OLE_CONVERT_208FE8C1_C742_4ED8_9C9C_25841915706BD_H_
-#define SAKURA_OLE_CONVERT_208FE8C1_C742_4ED8_9C9C_25841915706BD_H_
+#pragma once
 
 #include <string>
 #include "_os/OleTypes.h"
@@ -11,5 +10,4 @@
 bool variant_to_wstr( VARIANT v, std::wstring& wstr );	// VARIANT変数をBSTRとみなし、wstringに変換する
 bool variant_to_int( VARIANT v, int& n );	// VARIANT変数を整数とみなし、intに変換する
 
-#endif /* SAKURA_OLE_CONVERT_208FE8C1_C742_4ED8_9C9C_25841915706BD_H_ */
 /*[EOF]*/

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_OS_4EAF837F_94E1_4B90_BF99_5AC3DEC630E79_H_
-#define SAKURA_OS_4EAF837F_94E1_4B90_BF99_5AC3DEC630E79_H_
+#pragma once
 
 #include <ObjIdl.h> // LPDATAOBJECT
 
@@ -101,5 +100,4 @@ private:
 */
 BOOL IsPowerShellAvailable(void);
 
-#endif /* SAKURA_OS_4EAF837F_94E1_4B90_BF99_5AC3DEC630E79_H_ */
 /*[EOF]*/

--- a/sakura_core/util/relation_tool.h
+++ b/sakura_core/util/relation_tool.h
@@ -25,8 +25,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_RELATION_TOOL_333B6596_FCE9_45EE_96B8_50BE6BF997779_H_
-#define SAKURA_RELATION_TOOL_333B6596_FCE9_45EE_96B8_50BE6BF997779_H_
+#pragma once
 
 #include <vector>
 class CSubject;
@@ -86,5 +85,4 @@ public:
 	}
 };
 
-#endif /* SAKURA_RELATION_TOOL_333B6596_FCE9_45EE_96B8_50BE6BF997779_H_ */
 /*[EOF]*/

--- a/sakura_core/util/shell.h
+++ b/sakura_core/util/shell.h
@@ -24,8 +24,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_SHELL_A129670C_6564_4E0D_AF52_E323B0C7CA099_H_
-#define SAKURA_SHELL_A129670C_6564_4E0D_AF52_E323B0C7CA099_H_
+#pragma once
 
 BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData);	/* WinHelp のかわりに HtmlHelp を呼び出す */	// 2006.07.22 ryoji
 
@@ -46,5 +45,4 @@ INT_PTR MyPropertySheet( LPPROPSHEETHEADER lppsph );	// 独自拡張プロパテ
 //!フォント選択ダイアログ
 BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool );	// 2009.10.01 ryoji ポイントサイズ（1/10ポイント単位）引数追加
 
-#endif /* SAKURA_SHELL_A129670C_6564_4E0D_AF52_E323B0C7CA099_H_ */
 /*[EOF]*/

--- a/sakura_core/util/std_macro.h
+++ b/sakura_core/util/std_macro.h
@@ -23,8 +23,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_STD_MACRO_A4AD5AD7_E307_4F40_A051_F4301FC8DA58_H_
-#define SAKURA_STD_MACRO_A4AD5AD7_E307_4F40_A051_F4301FC8DA58_H_
+#pragma once
 
 #define SAFE_DELETE(p) { delete p; p=0; }
 
@@ -82,5 +81,4 @@ T t_unit(T t)
 //ビルド種に関係なく、ANSI。
 #define ATEXT(A) A
 
-#endif /* SAKURA_STD_MACRO_A4AD5AD7_E307_4F40_A051_F4301FC8DA58_H_ */
 /*[EOF]*/

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_
-#define SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_
+#pragma once
 
 // 2007.10.19 kobake
 // string.h で定義されている関数を拡張したようなモノ達
@@ -259,5 +258,4 @@ int strnicmp_literal(const char* strData1, const char (&literalData2)[Size]) {
 	return ::_strnicmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、_countofからマイナス1する
 }
 
-#endif /* SAKURA_STRING_EX_29EB1DD7_7259_4D6C_A651_B9174E5C3D3C9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/string_ex2.h
+++ b/sakura_core/util/string_ex2.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_STRING_EX2_AA243462_59E7_4F55_B206_FD9ED8836A09_H_
-#define SAKURA_STRING_EX2_AA243462_59E7_4F55_B206_FD9ED8836A09_H_
+#pragma once
 
 class CEol;
 class CNativeA;
@@ -154,5 +153,4 @@ ptrdiff_t int2dec(
 	return len;
 }
 
-#endif /* SAKURA_STRING_EX2_AA243462_59E7_4F55_B206_FD9ED8836A09_H_ */
 /*[EOF]*/

--- a/sakura_core/util/tchar_convert.h
+++ b/sakura_core/util/tchar_convert.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_TCHAR_CONVERT_12EEF467_2644_4401_92A6_A0EA26FC78F39_H_
-#define SAKURA_TCHAR_CONVERT_12EEF467_2644_4401_92A6_A0EA26FC78F39_H_
+#pragma once
 
 //WCHARに変換
 const WCHAR* to_wchar(const ACHAR* src);
@@ -38,5 +37,4 @@ const ACHAR* to_achar(const WCHAR* pSrc, int nSrcLength);
 //その他
 const WCHAR* easy_format(const WCHAR* format, ...);
 
-#endif /* SAKURA_TCHAR_CONVERT_12EEF467_2644_4401_92A6_A0EA26FC78F39_H_ */
 /*[EOF]*/

--- a/sakura_core/util/tchar_printf.h
+++ b/sakura_core/util/tchar_printf.h
@@ -45,8 +45,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_TCHAR_PRINTF_DAD4722C_BE9A_420C_BB75_311B6B1EC14E9_H_
-#define SAKURA_TCHAR_PRINTF_DAD4722C_BE9A_420C_BB75_311B6B1EC14E9_H_
+#pragma once
 
 // vsprintf_sラップ
 int tchar_vsprintf_s(ACHAR* buf, size_t nBufCount, const ACHAR* format, va_list& v);
@@ -72,5 +71,4 @@ int tchar_sprintf(WCHAR* buf, const WCHAR* format, ...);
 int tchar_snprintf_s(ACHAR* buf, size_t count, const ACHAR* format, ...);
 int tchar_snprintf_s(WCHAR* buf, size_t count, const WCHAR* format, ...);
 
-#endif /* SAKURA_TCHAR_PRINTF_DAD4722C_BE9A_420C_BB75_311B6B1EC14E9_H_ */
 /*[EOF]*/

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_WINDOW_E7B899CD_2106_4A3B_BBA1_EB29FD9640F39_H_
-#define SAKURA_WINDOW_E7B899CD_2106_4A3B_BBA1_EB29FD9640F39_H_
+#pragma once
 
 /*!
 	@brief 画面 DPI スケーリング
@@ -191,5 +190,4 @@ private:
 	HFONT m_hFont;
 };
 
-#endif /* SAKURA_WINDOW_E7B899CD_2106_4A3B_BBA1_EB29FD9640F39_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CCaret.h
+++ b/sakura_core/view/CCaret.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCARET_EF835ACD_9DB2_4F5A_8513_35034F1894219_H_
-#define SAKURA_CCARET_EF835ACD_9DB2_4F5A_8513_35034F1894219_H_
+#pragma once
 
 #define _CARETMARGINRATE 20
 class CTextArea;
@@ -235,5 +234,4 @@ public:
 	@date 2004.04.09 genta 説明文追加
 */
 
-#endif /* SAKURA_CCARET_EF835ACD_9DB2_4F5A_8513_35034F1894219_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -38,8 +38,7 @@
 		   distribution.
 */
 
-#ifndef _CEDITVIEW_H_
-#define _CEDITVIEW_H_
+#pragma once
 
 #include <Windows.h>
 #include <ObjIdl.h>  // LPDATAOBJECT
@@ -747,5 +746,3 @@ public:
 	virtual bool IsActiveDebugWindow(){ return true; }
 };
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CEDITVIEW_H_ */
-

--- a/sakura_core/view/CEditView_Paint.h
+++ b/sakura_core/view/CEditView_Paint.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CEDITVIEW_PAINT_AFF20D5A_4CE7_4858_89DB_BBF1A21A6BF9_H_
-#define SAKURA_CEDITVIEW_PAINT_AFF20D5A_4CE7_4858_89DB_BBF1A21A6BF9_H_
+#pragma once
 
 class CEditView;
 
@@ -49,5 +48,4 @@ public:
 	);
 };
 
-#endif /* SAKURA_CEDITVIEW_PAINT_AFF20D5A_4CE7_4858_89DB_BBF1A21A6BF9_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CRuler.h
+++ b/sakura_core/view/CRuler.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CRULER_CF213704_1CF6_427E_AD78_D628D2D1F9029_H_
-#define SAKURA_CRULER_CF213704_1CF6_427E_AD78_D628D2D1F9029_H_
+#pragma once
 
 class CTextArea;
 class CEditView;
@@ -74,5 +73,4 @@ private:
 	std::vector<DWORD> m_asz;
 };
 
-#endif /* SAKURA_CRULER_CF213704_1CF6_427E_AD78_D628D2D1F9029_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CTextArea.h
+++ b/sakura_core/view/CTextArea.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CTEXTAREA_BE5C17FA_E8D8_4659_9AA4_552DF90288CC9_H_
-#define SAKURA_CTEXTAREA_BE5C17FA_E8D8_4659_9AA4_552DF90288CC9_H_
+#pragma once
 
 class CViewFont;
 class CEditView;
@@ -246,5 +245,4 @@ public:
 	int		m_nViewAlignLeftCols;	/* 行番号域の桁数 */
 };
 
-#endif /* SAKURA_CTEXTAREA_BE5C17FA_E8D8_4659_9AA4_552DF90288CC9_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CTextDrawer.h
+++ b/sakura_core/view/CTextDrawer.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CTEXTDRAWER_AECD0708_CE8E_489C_A9ED_484CBAB9523E9_H_
-#define SAKURA_CTEXTDRAWER_AECD0708_CE8E_489C_A9ED_484CBAB9523E9_H_
+#pragma once
 
 class CTextMetrics;
 class CTextArea;
@@ -71,5 +70,4 @@ private:
 	const CEditView* m_pEditView;
 };
 
-#endif /* SAKURA_CTEXTDRAWER_AECD0708_CE8E_489C_A9ED_484CBAB9523E9_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CTextMetrics.h
+++ b/sakura_core/view/CTextMetrics.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CTEXTMETRICS_815A7F9E_8E38_4FA5_9F68_7CA776A18F1F_H_
-#define SAKURA_CTEXTMETRICS_815A7F9E_8E38_4FA5_9F68_7CA776A18F1F_H_
+#pragma once
 
 //2007.08.25 kobake 追加
 
@@ -130,5 +129,4 @@ private:
 	std::vector<int> m_aFontHeightMargin;
 };
 
-#endif /* SAKURA_CTEXTMETRICS_815A7F9E_8E38_4FA5_9F68_7CA776A18F1F_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CViewCalc.h
+++ b/sakura_core/view/CViewCalc.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CVIEWCALC_F7EB84D2_C716_4183_AF9C_197AEEC5B7A9_H_
-#define SAKURA_CVIEWCALC_F7EB84D2_C716_4183_AF9C_197AEEC5B7A9_H_
+#pragma once
 
 #include "doc/layout/CTsvModeInfo.h"
 
@@ -59,5 +58,4 @@ private:
 	const CEditView* m_pOwner;
 };
 
-#endif /* SAKURA_CVIEWCALC_F7EB84D2_C716_4183_AF9C_197AEEC5B7A9_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CViewFont.h
+++ b/sakura_core/view/CViewFont.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CVIEWFONT_9E51373D_58BA_4A64_9930_5174F7BF9C929_H_
-#define SAKURA_CVIEWFONT_9E51373D_58BA_4A64_9930_5174F7BF9C929_H_
+#pragma once
 
 #include "doc/CDocTypeSetting.h" // ColorInfo !!
 
@@ -70,5 +69,4 @@ private:
 	bool	m_bMiniMap;
 };
 
-#endif /* SAKURA_CVIEWFONT_9E51373D_58BA_4A64_9930_5174F7BF9C929_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CViewParser.h
+++ b/sakura_core/view/CViewParser.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CVIEWPARSER_7EE1449B_4B78_4C60_BE19_6498574626729_H_
-#define SAKURA_CVIEWPARSER_7EE1449B_4B78_4C60_BE19_6498574626729_H_
+#pragma once
 
 class CEditView;
 
@@ -44,5 +43,4 @@ private:
 	const CEditView* m_pEditView;
 };
 
-#endif /* SAKURA_CVIEWPARSER_7EE1449B_4B78_4C60_BE19_6498574626729_H_ */
 /*[EOF]*/

--- a/sakura_core/view/CViewSelect.h
+++ b/sakura_core/view/CViewSelect.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CVIEWSELECT_F4CBAF6E_90C8_44D2_B6EC_7FE066968A8D9_H_
-#define SAKURA_CVIEWSELECT_F4CBAF6E_90C8_44D2_B6EC_7FE066968A8D9_H_
+#pragma once
 
 class CEditView;
 
@@ -188,5 +187,4 @@ m_sSelectOldについて
 	DrawSelectArea()を呼びだすことで新しい範囲が描かれる．
 */
 
-#endif /* SAKURA_CVIEWSELECT_F4CBAF6E_90C8_44D2_B6EC_7FE066968A8D9_H_ */
 /*[EOF]*/

--- a/sakura_core/view/DispPos.h
+++ b/sakura_core/view/DispPos.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_DISPPOS_5705EE1C_0A31_419D_81A1_07DA95E57D879_H_
-#define SAKURA_DISPPOS_5705EE1C_0A31_419D_81A1_07DA95E57D879_H_
+#pragma once
 
 #include "doc/CEditDoc.h"
 #include "doc/layout/CLayoutMgr.h"
@@ -115,5 +114,4 @@ private:
 	const CLayout*		m_pcLayoutRef;
 };
 
-#endif /* SAKURA_DISPPOS_5705EE1C_0A31_419D_81A1_07DA95E57D879_H_ */
 /*[EOF]*/

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOLORSTRATEGY_BC7B5956_A0AF_4C9C_9C0E_07FE658028AC9_H_
-#define SAKURA_CCOLORSTRATEGY_BC7B5956_A0AF_4C9C_9C0E_07FE658028AC9_H_
+#pragma once
 
 // 要先行定義
 // #include "view/CEditView.h"
@@ -232,5 +231,4 @@ private:
 	bool	m_bSkipBeforeLayoutFound;
 };
 
-#endif /* SAKURA_CCOLORSTRATEGY_BC7B5956_A0AF_4C9C_9C0E_07FE658028AC9_H_ */
 /*[EOF]*/

--- a/sakura_core/view/colors/CColor_Comment.h
+++ b/sakura_core/view/colors/CColor_Comment.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOLOR_COMMENT_5CBF888D_32A3_4713_8967_D6D49F6E569F_H_
-#define SAKURA_CCOLOR_COMMENT_5CBF888D_32A3_4713_8967_D6D49F6E569F_H_
+#pragma once
 
 #include "view/colors/CColorStrategy.h"
 
@@ -80,5 +79,4 @@ private:
 	int m_nCOMMENTEND;
 };
 
-#endif /* SAKURA_CCOLOR_COMMENT_5CBF888D_32A3_4713_8967_D6D49F6E569F_H_ */
 /*[EOF]*/

--- a/sakura_core/view/colors/CColor_Found.h
+++ b/sakura_core/view/colors/CColor_Found.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOLOR_FOUND_60044D4E_3082_4A9D_98C5_2FE626D3DA1E_H_
-#define SAKURA_CCOLOR_FOUND_60044D4E_3082_4A9D_98C5_2FE626D3DA1E_H_
+#pragma once
 
 #include "view/colors/CColorStrategy.h"
 
@@ -68,5 +67,4 @@ private:
 	unsigned validColorNum; ///< highlightColorsの何番目の要素までが有効か。
 };
 
-#endif /* SAKURA_CCOLOR_FOUND_60044D4E_3082_4A9D_98C5_2FE626D3DA1E_H_ */
 /*[EOF]*/

--- a/sakura_core/view/colors/CColor_Heredoc.h
+++ b/sakura_core/view/colors/CColor_Heredoc.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOLOR_HEREDOC_H_
-#define SAKURA_CCOLOR_HEREDOC_H_
+#pragma once
 
 #include "view/colors/CColorStrategy.h"
 
@@ -43,4 +42,3 @@ private:
 	int m_nCOMMENTEND;
 };
 
-#endif

--- a/sakura_core/view/colors/CColor_KeywordSet.h
+++ b/sakura_core/view/colors/CColor_KeywordSet.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOLOR_KEYWORDSET_FA3FF02C_3855_4447_BE0A_5311E0E65822_H_
-#define SAKURA_CCOLOR_KEYWORDSET_FA3FF02C_3855_4447_BE0A_5311E0E65822_H_
+#pragma once
 
 #include "view/colors/CColorStrategy.h"
 
@@ -40,5 +39,4 @@ private:
 	int m_nCOMMENTEND;
 };
 
-#endif /* SAKURA_CCOLOR_KEYWORDSET_FA3FF02C_3855_4447_BE0A_5311E0E65822_H_ */
 /*[EOF]*/

--- a/sakura_core/view/colors/CColor_Numeric.h
+++ b/sakura_core/view/colors/CColor_Numeric.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOLOR_NUMERIC_19741AD7_75D8_455C_9E04_7A8901616E8B_H_
-#define SAKURA_CCOLOR_NUMERIC_19741AD7_75D8_455C_9E04_7A8901616E8B_H_
+#pragma once
 
 #include "view/colors/CColorStrategy.h"
 
@@ -39,5 +38,4 @@ private:
 	int m_nCOMMENTEND;
 };
 
-#endif /* SAKURA_CCOLOR_NUMERIC_19741AD7_75D8_455C_9E04_7A8901616E8B_H_ */
 /*[EOF]*/

--- a/sakura_core/view/colors/CColor_Quote.h
+++ b/sakura_core/view/colors/CColor_Quote.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOLOR_QUOTE_26330E31_5ADC_4753_92DD_7567B7BA4451_H_
-#define SAKURA_CCOLOR_QUOTE_26330E31_5ADC_4753_92DD_7567B7BA4451_H_
+#pragma once
 
 #include "view/colors/CColorStrategy.h"
 
@@ -73,5 +72,4 @@ public:
 	EColorIndexType GetStrategyColor() const override{ return COLORIDX_WSTRING; }
 };
 
-#endif /* SAKURA_CCOLOR_QUOTE_26330E31_5ADC_4753_92DD_7567B7BA4451_H_ */
 /*[EOF]*/

--- a/sakura_core/view/colors/CColor_RegexKeyword.h
+++ b/sakura_core/view/colors/CColor_RegexKeyword.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOLOR_REGEXKEYWORD_70C5BFF3_FC04_450E_BC07_F5E777B205C29_H_
-#define SAKURA_CCOLOR_REGEXKEYWORD_70C5BFF3_FC04_450E_BC07_F5E777B205C29_H_
+#pragma once
 
 #include "view/colors/CColorStrategy.h"
 
@@ -41,5 +40,4 @@ private:
 	EColorIndexType m_nCOMMENTMODE;
 };
 
-#endif /* SAKURA_CCOLOR_REGEXKEYWORD_70C5BFF3_FC04_450E_BC07_F5E777B205C29_H_ */
 /*[EOF]*/

--- a/sakura_core/view/colors/CColor_Url.h
+++ b/sakura_core/view/colors/CColor_Url.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CCOLOR_URL_9D0CC86C_6E3A_4E06_A0A0_F724234EDAEF9_H_
-#define SAKURA_CCOLOR_URL_9D0CC86C_6E3A_4E06_A0A0_F724234EDAEF9_H_
+#pragma once
 
 #include "view/colors/CColorStrategy.h"
 
@@ -39,5 +38,4 @@ private:
 	int m_nCOMMENTEND;
 };
 
-#endif /* SAKURA_CCOLOR_URL_9D0CC86C_6E3A_4E06_A0A0_F724234EDAEF9_H_ */
 /*[EOF]*/

--- a/sakura_core/view/colors/EColorIndexType.h
+++ b/sakura_core/view/colors/EColorIndexType.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_ECOLORINDEXTYPE_H_
-#define SAKURA_ECOLORINDEXTYPE_H_
+#pragma once
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                          色定数                             //
@@ -114,4 +113,3 @@ enum EColorIndexType {
 	COLORIDX_SEARCHTAIL		= COLORIDX_SEARCH5,
 };
 
-#endif

--- a/sakura_core/view/figures/CFigureManager.h
+++ b/sakura_core/view/figures/CFigureManager.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFIGUREMANAGER_470D38ED_45D5_4E64_8D29_FFEA361C59E4_H_
-#define SAKURA_CFIGUREMANAGER_470D38ED_45D5_4E64_8D29_FFEA361C59E4_H_
+#pragma once
 
 #include <vector>
 #include "util/design_template.h"
@@ -48,5 +47,4 @@ private:
 	std::vector<CFigure*>	m_vFiguresDisp;	//!< 色分け表示対象
 };
 
-#endif /* SAKURA_CFIGUREMANAGER_470D38ED_45D5_4E64_8D29_FFEA361C59E4_H_ */
 /*[EOF]*/

--- a/sakura_core/view/figures/CFigureStrategy.h
+++ b/sakura_core/view/figures/CFigureStrategy.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFIGURESTRATEGY_ADBE415F_6FA5_4412_9679_B0045ACE4881_H_
-#define SAKURA_CFIGURESTRATEGY_ADBE415F_6FA5_4412_9679_B0045ACE4881_H_
+#pragma once
 
 #include <vector>
 #include "view/colors/CColorStrategy.h" //SColorStrategyInfo
@@ -102,5 +101,4 @@ protected:
 	EColorIndexType m_nDispColorIndex;
 };
 
-#endif /* SAKURA_CFIGURESTRATEGY_ADBE415F_6FA5_4412_9679_B0045ACE4881_H_ */
 /*[EOF]*/

--- a/sakura_core/view/figures/CFigure_Comma.h
+++ b/sakura_core/view/figures/CFigure_Comma.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFIGURE_COMMA_BE7B2FF5_E07E_4DEC_BE66_C90F628C1ED1_H_
-#define SAKURA_CFIGURE_COMMA_BE7B2FF5_E07E_4DEC_BE66_C90F628C1ED1_H_
+#pragma once
 
 #include "view/figures/CFigureStrategy.h"
 
@@ -42,5 +41,4 @@ public:
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_TAB; }
 };
 
-#endif /* SAKURA_CFigure_Comma_BE7B2FF5_E07E_4DEC_BE66_C90F628C1ED1_H_ */
 /*[EOF]*/

--- a/sakura_core/view/figures/CFigure_CtrlCode.h
+++ b/sakura_core/view/figures/CFigure_CtrlCode.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFIGURE_CTRLCODE_9CEA1624_5811_4A1D_8607_1FA8A8439D15_H_
-#define SAKURA_CFIGURE_CTRLCODE_9CEA1624_5811_4A1D_8607_1FA8A8439D15_H_
+#pragma once
 
 #include "view/figures/CFigureStrategy.h"
 
@@ -63,5 +62,4 @@ public:
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_CTRLCODE; }
 };
 
-#endif /* SAKURA_CFIGURE_CTRLCODE_9CEA1624_5811_4A1D_8607_1FA8A8439D15_H_ */
 /*[EOF]*/

--- a/sakura_core/view/figures/CFigure_Eol.h
+++ b/sakura_core/view/figures/CFigure_Eol.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFIGURE_EOL_F6A22B9F_DDED_4BE9_9A2C_62931DB224F6_H_
-#define SAKURA_CFIGURE_EOL_F6A22B9F_DDED_4BE9_9A2C_62931DB224F6_H_
+#pragma once
 
 #include "view/figures/CFigureStrategy.h"
 
@@ -43,5 +42,4 @@ public:
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_EOL; }
 };
 
-#endif /* SAKURA_CFIGURE_EOL_F6A22B9F_DDED_4BE9_9A2C_62931DB224F6_H_ */
 /*[EOF]*/

--- a/sakura_core/view/figures/CFigure_HanSpace.h
+++ b/sakura_core/view/figures/CFigure_HanSpace.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFIGURE_HANSPACE_5C46367B_9CE4_47DF_A1A1_7AF7BB1D5C92_H_
-#define SAKURA_CFIGURE_HANSPACE_5C46367B_9CE4_47DF_A1A1_7AF7BB1D5C92_H_
+#pragma once
 
 #include "view/figures/CFigureStrategy.h"
 
@@ -38,5 +37,4 @@ public:
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_SPACE; }
 };
 
-#endif /* SAKURA_CFIGURE_HANSPACE_5C46367B_9CE4_47DF_A1A1_7AF7BB1D5C92_H_ */
 /*[EOF]*/

--- a/sakura_core/view/figures/CFigure_Tab.h
+++ b/sakura_core/view/figures/CFigure_Tab.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFIGURE_TAB_BE7B2FF5_E07E_4DEC_BE66_C90F628C1ED1_H_
-#define SAKURA_CFIGURE_TAB_BE7B2FF5_E07E_4DEC_BE66_C90F628C1ED1_H_
+#pragma once
 
 #include "view/figures/CFigureStrategy.h"
 
@@ -42,5 +41,4 @@ public:
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_TAB; }
 };
 
-#endif /* SAKURA_CFIGURE_TAB_BE7B2FF5_E07E_4DEC_BE66_C90F628C1ED1_H_ */
 /*[EOF]*/

--- a/sakura_core/view/figures/CFigure_ZenSpace.h
+++ b/sakura_core/view/figures/CFigure_ZenSpace.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CFIGURE_ZENSPACE_DFBCDF91_0C96_4195_86C4_D0A3D480E1EB_H_
-#define SAKURA_CFIGURE_ZENSPACE_DFBCDF91_0C96_4195_86C4_D0A3D480E1EB_H_
+#pragma once
 
 #include "view/figures/CFigureStrategy.h"
 
@@ -38,5 +37,4 @@ public:
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_ZENSPACE; }
 };
 
-#endif /* SAKURA_CFIGURE_ZENSPACE_DFBCDF91_0C96_4195_86C4_D0A3D480E1EB_H_ */
 /*[EOF]*/

--- a/sakura_core/window/CAutoScrollWnd.h
+++ b/sakura_core/window/CAutoScrollWnd.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CAUTOSCROLLWND_H_
-#define SAKURA_CAUTOSCROLLWND_H_
+#pragma once
 
 #include "CWnd.h"
 class CEditView;
@@ -49,4 +48,4 @@ protected:
 	LRESULT OnMButtonDown(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;
 	LRESULT OnPaint(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;
 };
-#endif
+

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -39,8 +39,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_CEDITWND_E9E9A41A_05E0_48D5_8F66_9C734A98FB30_H_
-#define SAKURA_CEDITWND_E9E9A41A_05E0_48D5_8F66_9C734A98FB30_H_
+#pragma once
 
 #include <ShellAPI.h>// HDROP
 #include "_main/global.h"
@@ -421,4 +420,3 @@ public:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_CEDITWND_E9E9A41A_05E0_48D5_8F66_9C734A98FB30_H_ */

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CMAINSTATUSBAR_2F45F977_E8DD_4787_8EA8_FF15685D114F_H_
-#define SAKURA_CMAINSTATUSBAR_2F45F977_E8DD_4787_8EA8_FF15685D114F_H_
+#pragma once
 
 #include "doc/CDocListener.h"
 
@@ -60,5 +59,4 @@ private:
 	HWND		m_hwndProgressBar;
 };
 
-#endif /* SAKURA_CMAINSTATUSBAR_2F45F977_E8DD_4787_8EA8_FF15685D114F_H_ */
 /*[EOF]*/

--- a/sakura_core/window/CMainToolBar.h
+++ b/sakura_core/window/CMainToolBar.h
@@ -22,8 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#ifndef SAKURA_CMAINTOOLBAR_F8D148A4_02B1_42E7_8B00_B51B3DB49E749_H_
-#define SAKURA_CMAINTOOLBAR_F8D148A4_02B1_42E7_8B00_B51B3DB49E749_H_
+#pragma once
 
 #include "recent/CRecent.h"
 #include "dlg/CDialog.h"
@@ -80,5 +79,4 @@ private:
 	CImageListMgr*			m_pcIcons;
 };
 
-#endif /* SAKURA_CMAINTOOLBAR_F8D148A4_02B1_42E7_8B00_B51B3DB49E749_H_ */
 /*[EOF]*/

--- a/sakura_core/window/CSplitBoxWnd.h
+++ b/sakura_core/window/CSplitBoxWnd.h
@@ -11,10 +11,9 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-class CSplitBoxWnd;
+#pragma once
 
-#ifndef _CSPLITBOXWND_H_
-#define _CSPLITBOXWND_H_
+class CSplitBoxWnd;
 
 #include "CWnd.h"
 
@@ -55,5 +54,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CSPLITBOXWND_H_ */
-

--- a/sakura_core/window/CSplitterWnd.h
+++ b/sakura_core/window/CSplitterWnd.h
@@ -11,8 +11,7 @@
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
-#ifndef SAKURA_WINDOW_CSPLITTERWND_H_
-#define SAKURA_WINDOW_CSPLITTERWND_H_
+#pragma once
 
 #include "CWnd.h"
 
@@ -92,5 +91,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* SAKURA_WINDOW_CSPLITTERWND_H_ */
-

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -34,8 +34,7 @@
 		   distribution.
 */
 
-#ifndef SAKURA_WINDOW_CTABWND_H_
-#define SAKURA_WINDOW_CTABWND_H_
+#pragma once
 
 #include "CWnd.h"
 #include "util/design_template.h"
@@ -205,6 +204,4 @@ private:
 
 	DISALLOW_COPY_AND_ASSIGN(CTabWnd);
 };
-
-#endif /* SAKURA_WINDOW_CTABWND_H_ */
 

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -14,10 +14,9 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-class CTipWnd;
+#pragma once
 
-#ifndef _CTIPWND_H_
-#define _CTIPWND_H_
+class CTipWnd;
 
 #include "CWnd.h"
 #include "mem/CMemory.h"
@@ -76,5 +75,3 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CTIPWND_H_ */
-

--- a/sakura_core/window/CWnd.h
+++ b/sakura_core/window/CWnd.h
@@ -14,8 +14,7 @@
 	Please contact the copyright holder to use this code for other purpose.
 */
 
-#ifndef _CWND_H_
-#define _CWND_H_
+#pragma once
 
 #include <Windows.h>
 #include "_main/global.h"
@@ -132,5 +131,3 @@ private: // 2002/2/10 aroka アクセス権変更
 };
 
 ///////////////////////////////////////////////////////////////////////
-#endif /* _CWND_H_ */
-


### PR DESCRIPTION
# PR の目的

インクルードガードに `#pragma once` を使う事でヘッダファイルの記述をすっきりさせるのが目的です。

## カテゴリ

- リファクタリング

## PR の背景

大分前からメジャーなC++処理系は `#pragma once` をサポートしています。

https://en.wikipedia.org/wiki/Pragma_once#Portability

## PR のメリット

ヘッダファイルの記述がすっきりします。

## PR のデメリット (トレードオフとかあれば)

`#pragma once` に親を殺された人にとっては受け入れられない事かも知れません…。

## PR の影響範囲

恐らく生成物には影響が無い筈…。ビルド時間は短くなっても良さそうです確認してません。

