### PR TITLE
等価比較演算子の実装がラクになる方法を探ってみる

### DIFF
--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -65,9 +65,9 @@ struct	MYDEVMODE {
 	bool operator == (const MYDEVMODE& rhs) const noexcept {
 		if (this == &rhs) return true;
 		return m_bPrinterNotFound == rhs.m_bPrinterNotFound
-			&& std::wstring_view(m_szPrinterDriverName, wcsnlen(m_szPrinterDriverName, _countof(m_szPrinterDriverName))) == std::wstring_view(rhs.m_szPrinterDriverName, wcsnlen(rhs.m_szPrinterDriverName, _countof(m_szPrinterDriverName)))
-			&& std::wstring_view(m_szPrinterDeviceName, wcsnlen(m_szPrinterDeviceName, _countof(m_szPrinterDeviceName))) == std::wstring_view(rhs.m_szPrinterDeviceName, wcsnlen(rhs.m_szPrinterDeviceName, _countof(m_szPrinterDeviceName)))
-			&& std::wstring_view(m_szPrinterOutputName, wcsnlen(m_szPrinterOutputName, _countof(m_szPrinterOutputName))) == std::wstring_view(rhs.m_szPrinterOutputName, wcsnlen(rhs.m_szPrinterOutputName, _countof(m_szPrinterOutputName)))
+			&& 0 == wcsncmp(m_szPrinterDriverName, rhs.m_szPrinterDriverName, _countof(m_szPrinterDriverName))
+			&& 0 == wcsncmp(m_szPrinterDeviceName, rhs.m_szPrinterDeviceName, _countof(m_szPrinterDeviceName))
+			&& 0 == wcsncmp(m_szPrinterOutputName, rhs.m_szPrinterOutputName, _countof(m_szPrinterOutputName))
 			&& dmFields == rhs.dmFields
 			&& dmOrientation == rhs.dmOrientation
 			&& dmPaperSize == rhs.dmPaperSize
@@ -82,7 +82,7 @@ struct	MYDEVMODE {
 			&& dmYResolution == rhs.dmYResolution
 			&& dmTTOption == rhs.dmTTOption
 			&& dmCollate == rhs.dmCollate
-			&& std::wstring_view(dmFormName, wcsnlen(dmFormName, _countof(dmFormName))) == std::wstring_view(rhs.dmFormName, wcsnlen(rhs.dmFormName, _countof(dmFormName)))
+			&& 0 == wcsncmp(dmFormName, rhs.dmFormName, _countof(dmFormName))
 			&& dmLogPixels == rhs.dmLogPixels
 			&& dmBitsPerPel == rhs.dmBitsPerPel
 			&& dmPelsWidth == rhs.dmPelsWidth

--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -65,9 +65,9 @@ struct	MYDEVMODE {
 	bool operator == (const MYDEVMODE& rhs) const noexcept {
 		if (this == &rhs) return true;
 		return m_bPrinterNotFound == rhs.m_bPrinterNotFound
-			&& std::wstring_view(m_szPrinterDriverName) == rhs.m_szPrinterDriverName
-			&& std::wstring_view(m_szPrinterDeviceName) == rhs.m_szPrinterDeviceName
-			&& std::wstring_view(m_szPrinterOutputName) == rhs.m_szPrinterOutputName
+			&& 0 == std::wstring_view(m_szPrinterDriverName).compare(rhs.m_szPrinterDriverName)
+			&& 0 == std::wstring_view(m_szPrinterDeviceName).compare(rhs.m_szPrinterDeviceName)
+			&& 0 == std::wstring_view(m_szPrinterOutputName).compare(rhs.m_szPrinterOutputName)
 			&& dmFields == rhs.dmFields
 			&& dmOrientation == rhs.dmOrientation
 			&& dmPaperSize == rhs.dmPaperSize
@@ -82,7 +82,7 @@ struct	MYDEVMODE {
 			&& dmYResolution == rhs.dmYResolution
 			&& dmTTOption == rhs.dmTTOption
 			&& dmCollate == rhs.dmCollate
-			&& std::wstring_view(dmFormName) == rhs.dmFormName
+			&& 0 == std::wstring_view(dmFormName).compare(rhs.dmFormName)
 			&& dmLogPixels == rhs.dmLogPixels
 			&& dmBitsPerPel == rhs.dmBitsPerPel
 			&& dmPelsWidth == rhs.dmPelsWidth

--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -65,9 +65,9 @@ struct	MYDEVMODE {
 	bool operator == (const MYDEVMODE& rhs) const noexcept {
 		if (this == &rhs) return true;
 		return m_bPrinterNotFound == rhs.m_bPrinterNotFound
-			&& 0 == std::wstring_view(m_szPrinterDriverName).compare(rhs.m_szPrinterDriverName)
-			&& 0 == std::wstring_view(m_szPrinterDeviceName).compare(rhs.m_szPrinterDeviceName)
-			&& 0 == std::wstring_view(m_szPrinterOutputName).compare(rhs.m_szPrinterOutputName)
+			&& std::wstring_view(m_szPrinterDriverName, wcsnlen(m_szPrinterDriverName, _countof(m_szPrinterDriverName))) == std::wstring_view(rhs.m_szPrinterDriverName, wcsnlen(rhs.m_szPrinterDriverName, _countof(m_szPrinterDriverName)))
+			&& std::wstring_view(m_szPrinterDeviceName, wcsnlen(m_szPrinterDeviceName, _countof(m_szPrinterDeviceName))) == std::wstring_view(rhs.m_szPrinterDeviceName, wcsnlen(rhs.m_szPrinterDeviceName, _countof(m_szPrinterDeviceName)))
+			&& std::wstring_view(m_szPrinterOutputName, wcsnlen(m_szPrinterOutputName, _countof(m_szPrinterOutputName))) == std::wstring_view(rhs.m_szPrinterOutputName, wcsnlen(rhs.m_szPrinterOutputName, _countof(m_szPrinterOutputName)))
 			&& dmFields == rhs.dmFields
 			&& dmOrientation == rhs.dmOrientation
 			&& dmPaperSize == rhs.dmPaperSize
@@ -82,7 +82,7 @@ struct	MYDEVMODE {
 			&& dmYResolution == rhs.dmYResolution
 			&& dmTTOption == rhs.dmTTOption
 			&& dmCollate == rhs.dmCollate
-			&& 0 == std::wstring_view(dmFormName).compare(rhs.dmFormName)
+			&& std::wstring_view(dmFormName, wcsnlen(dmFormName, _countof(dmFormName))) == std::wstring_view(rhs.dmFormName, wcsnlen(rhs.dmFormName, _countof(dmFormName)))
 			&& dmLogPixels == rhs.dmLogPixels
 			&& dmBitsPerPel == rhs.dmBitsPerPel
 			&& dmPelsWidth == rhs.dmPelsWidth

--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -65,9 +65,9 @@ struct	MYDEVMODE {
 	bool operator == (const MYDEVMODE& rhs) const noexcept {
 		if (this == &rhs) return true;
 		return m_bPrinterNotFound == rhs.m_bPrinterNotFound
-			&& 0 == wcsncmp(m_szPrinterDriverName, rhs.m_szPrinterDriverName, _countof(m_szPrinterDriverName))
-			&& 0 == wcsncmp(m_szPrinterDeviceName, rhs.m_szPrinterDeviceName, _countof(m_szPrinterDeviceName))
-			&& 0 == wcsncmp(m_szPrinterOutputName, rhs.m_szPrinterOutputName, _countof(m_szPrinterOutputName))
+			&& std::wstring_view(m_szPrinterDriverName) == rhs.m_szPrinterDriverName
+			&& std::wstring_view(m_szPrinterDeviceName) == rhs.m_szPrinterDeviceName
+			&& std::wstring_view(m_szPrinterOutputName) == rhs.m_szPrinterOutputName
 			&& dmFields == rhs.dmFields
 			&& dmOrientation == rhs.dmOrientation
 			&& dmPaperSize == rhs.dmPaperSize
@@ -82,7 +82,7 @@ struct	MYDEVMODE {
 			&& dmYResolution == rhs.dmYResolution
 			&& dmTTOption == rhs.dmTTOption
 			&& dmCollate == rhs.dmCollate
-			&& 0 == wcsncmp(dmFormName, rhs.dmFormName, _countof(dmFormName))
+			&& std::wstring_view(dmFormName) == rhs.dmFormName
 			&& dmLogPixels == rhs.dmLogPixels
 			&& dmBitsPerPel == rhs.dmBitsPerPel
 			&& dmPelsWidth == rhs.dmPelsWidth


### PR DESCRIPTION
# PR の目的
等価比較演算子の実装がラクになる方法を探ってみます。

既に実装済みの等価比較演算子の文字列比較部分を
`std::wstring_view` に移譲するように書き替えてみました。

## カテゴリ
- 実験 (master へのマージを目的としない)

## PR の背景


## PR のメリット
- 今後の等価比較演算子の実装がラクになります。
- https://github.com/sakura-editor/sakura/pull/1079#issuecomment-549045552 で言及した **いまの実装ではマズいかもしれない** の不安を払拭できます。
- 頑張って作りこんだ自作関数よりも、ライブラリ実装が信用できる気がします。


## PR のデメリット (トレードオフとかあれば)
- クラス仕様的に、既製のライブラリを流用できないものも結構あると思います。
- CNativeW/CNativeAについてはこの方法での「手抜き」ができません。
- 判定部分にSTLをブチ込む都合、ファイルサイズの肥大化が懸念されます。
- 仕組みの都合で、既存テストのうち2件が使えなくなります。
  - 対象は Failed になってる2件です。
    - 1件は **異常な値を渡しても落ちないこと** を証明するテストです。  
STL(wstring_view)が落ちるので成立しなくなりました :cry:
    - 1件はNUL終端されていない文字列を識別できることを証明するテストです。  
STL(wstring_view)が落ちるので成立しなくなりました :cry:
  - STLを活用してラクしよう！で異論がなければ、失敗しているテストはdropさせるつもりです。

## PR の影響範囲
- 現状では何の影響もあたえないと考えられます。
- 生配列を使っている構造体に等価比較機能を実装する場合の考え方に影響してきます。

## 関連チケット
#1079 MYDEVMODEの等価比較演算子の隠れバグを修正する

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
