### PR TITLE
[WIP] CNativeWにnullptrを代入できるようにしたい Take3

### DIFF
--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -79,10 +79,19 @@ public:
 	//演算子
 	CNativeW& operator = (const CNativeW& rhs)			{ CNative::operator=(rhs); return *this; }
 	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeW>(rhs)); return *this; }
-	const CNativeW& operator+=(wchar_t wch)				{ AppendString(&wch,1);   return *this; }
-	const CNativeW& operator=(wchar_t wch)				{ SetString(&wch,1);      return *this; }
-	const CNativeW& operator+=(const CNativeW& rhs)		{ AppendNativeData(rhs); return *this; }
-	CNativeW operator+(const CNativeW& rhs) const		{ CNativeW tmp=*this; return tmp+=rhs; }
+	CNativeW  operator + (const CNativeW& rhs) const	{ return std::move(CNativeW(*this) += rhs); }
+	CNativeW& operator += (const CNativeW& rhs)			{ AppendNativeData(rhs); return *this; }
+
+	CNativeW& operator = (wchar_t ch)
+	{
+		if (!ch) return (*this = nullptr);
+		return (*this = CNativeW(&ch, 1));
+	}
+	CNativeW& operator += (wchar_t ch)
+	{
+		const wchar_t sz[]{ ch, 0 };
+		return (*this += sz);
+	}
 
 	//ネイティブ取得インターフェース
 	wchar_t operator[](int nIndex) const;                    //!< 任意位置の文字取得。nIndexは文字単位。

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -253,23 +253,19 @@ TEST(CNativeW, AssignStringNullPointer)
 
 /*!
  * @brief 代入演算子(NULL指定)の仕様
- * @remark バッファが確保される
- * @remark 文字列長は1になる
- * @remark バッファサイズは1+1以上になる
- * @note バグですね(^^;
+ * @remark バッファを確保している場合は解放される
+ * @remark 文字列長はゼロになる
  */
 TEST(CNativeW, AssignStringNullLiteral)
 {
-	CNativeW value;
+	CNativeW value(L"test");
 #ifdef _MSC_VER
 	value = NULL; // operator = (wchar_t) と解釈される
 #else
 	value = static_cast<wchar_t>(NULL);
 #endif
-	ASSERT_STREQ(L"", value.GetStringPtr());
-	EXPECT_EQ(1, value.GetStringLength());
-	EXPECT_LT(1 + 1, value.capacity());
-	EXPECT_EQ(0, value[0]); // 長さ=1なので1文字目を参照できるが、NULが返ってくる
+	ASSERT_EQ(NULL, value.GetStringPtr());
+	EXPECT_EQ(0, value.GetStringLength());
 }
 
 /*!
@@ -321,10 +317,7 @@ TEST(CNativeW, AppendStringNullPointer)
 
 /*!
  * @brief 加算代入演算子(NULL指定)の仕様
- * @remark バッファが確保される
- * @remark 文字列長は1になる
- * @remark バッファサイズは1+1以上になる
- * @note バグですね(^^;
+ * @remark 加算代入しても内容に変化無し
  */
 TEST(CNativeW, AppendStringNullLiteral)
 {
@@ -334,9 +327,8 @@ TEST(CNativeW, AppendStringNullLiteral)
 #else
 	value += static_cast<wchar_t>(NULL);
 #endif
-	ASSERT_STREQ(L"", value.GetStringPtr());
-	EXPECT_EQ(1, value.GetStringLength());
-	EXPECT_LT(1 + 1, value.capacity());
+	ASSERT_EQ(NULL, value.GetStringPtr());
+	EXPECT_EQ(0, value.GetStringLength());
 }
 
 /*!


### PR DESCRIPTION
# PR の目的
CNativeWの挙動を仕様化した際、疑問があった箇所に「バグじゃね？」とコメントしました。
現時点で、「バグじゃね？」が2箇所残っているので対応したいです。

疑問のある仕様
- CNativeWにNULLを代入したとき、CNativeWのデータは空文字列になる。
- CNativeWにNULLを加算したとき、CNativeWのデータ末尾にNUL文字が追加される。

## カテゴリ

- その他

## PR の背景

自分のなかで結論が出せてないので、作成途中のものを一旦公開します。


## PR のメリット
- `str = NULL` という記述の意味が、str をNULLにする、になります。
  - 従来は str を空文字列にしていました。
- `str += NULL` という記述の意味が、 **なにもしない** になります。
  - 従来は str の末尾にNUL文字を加算していました。

## PR のデメリット (トレードオフとかあれば)
- `operator = (wchar_t)` の存在意義を問うべきなのかもしれません。
- `str += NULL` という記述の意味が、従来通りで正しい可能性があります。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。

## 関連チケット

- #1086 closed [WIP] CNativeWにnullptrを代入できるようにしたい Take2
- #1087 merged CNativeW::SetString に NULL を指定した場合に wcslen に NULL を渡して落ちてしまう不具合を修正
