### PR TITLE
CNativeWにnullptrを代入できるようにしたい Take4

### DIFF
--- a/sakura_core/cmd/CViewCommander_Edit.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit.cpp
@@ -46,8 +46,7 @@ void CViewCommander::Command_WCHAR( wchar_t wcChar, bool bConvertEOL )
 	}
 
 	/* 現在位置にデータを挿入 */
-	CNativeW cmemDataW2;
-	cmemDataW2 = wcChar;
+	CNativeW cmemDataW2(&wcChar, 1);
 	if( WCODE::IsLineDelimiter(wcChar, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){ 
 		/* 現在、Enterなどで挿入する改行コードの種類を取得 */
 		if( bConvertEOL ){

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -79,10 +79,9 @@ public:
 	//演算子
 	CNativeW& operator = (const CNativeW& rhs)			{ CNative::operator=(rhs); return *this; }
 	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeW>(rhs)); return *this; }
-	const CNativeW& operator+=(wchar_t wch)				{ AppendString(&wch,1);   return *this; }
-	const CNativeW& operator=(wchar_t wch)				{ SetString(&wch,1);      return *this; }
-	const CNativeW& operator+=(const CNativeW& rhs)		{ AppendNativeData(rhs); return *this; }
-	CNativeW operator+(const CNativeW& rhs) const		{ CNativeW tmp=*this; return tmp+=rhs; }
+	CNativeW  operator + (const CNativeW& rhs) const	{ return std::move(CNativeW(*this) += rhs); }
+	CNativeW& operator += (const CNativeW& rhs)			{ AppendNativeData(rhs); return *this; }
+	CNativeW& operator += (wchar_t ch)					{ return (*this += CNativeW(&ch, 1)); }
 
 	//ネイティブ取得インターフェース
 	wchar_t operator[](int nIndex) const;                    //!< 任意位置の文字取得。nIndexは文字単位。

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -79,7 +79,7 @@ public:
 	//演算子
 	CNativeW& operator = (const CNativeW& rhs)			{ CNative::operator=(rhs); return *this; }
 	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeW>(rhs)); return *this; }
-	CNativeW  operator + (const CNativeW& rhs) const	{ return std::move(CNativeW(*this) += rhs); }
+	CNativeW  operator + (const CNativeW& rhs) const	{ return (CNativeW(*this) += rhs); }
 	CNativeW& operator += (const CNativeW& rhs)			{ AppendNativeData(rhs); return *this; }
 	CNativeW& operator += (wchar_t ch)					{ return (*this += CNativeW(&ch, 1)); }
 

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -206,22 +206,6 @@ TEST(CNativeW, GetCharAtIndex)
 }
 
 /*!
- * @brief 代入演算子(文字指定)の仕様
- * @remark バッファが確保される
- * @remark 文字列長は1になる
- * @remark バッファサイズは1+1以上になる
- */
-TEST(CNativeW, AssignChar)
-{
-	constexpr const wchar_t sz[] = L"X";
-	CNativeW value;
-	value = sz[0];
-	ASSERT_STREQ(sz, value.GetStringPtr());
-	EXPECT_EQ(1, value.GetStringLength());
-	EXPECT_LT(1 + 1, value.capacity());
-}
-
-/*!
  * @brief 代入演算子(文字列指定)の仕様
  * @remark バッファが確保される
  * @remark 文字列長は指定した文字列の文字列長になる
@@ -253,23 +237,15 @@ TEST(CNativeW, AssignStringNullPointer)
 
 /*!
  * @brief 代入演算子(NULL指定)の仕様
- * @remark バッファが確保される
- * @remark 文字列長は1になる
- * @remark バッファサイズは1+1以上になる
- * @note バグですね(^^;
+ * @remark バッファを確保している場合は解放される
+ * @remark 文字列長はゼロになる
  */
 TEST(CNativeW, AssignStringNullLiteral)
 {
-	CNativeW value;
-#ifdef _MSC_VER
-	value = NULL; // operator = (wchar_t) と解釈される
-#else
-	value = static_cast<wchar_t>(NULL);
-#endif
-	ASSERT_STREQ(L"", value.GetStringPtr());
-	EXPECT_EQ(1, value.GetStringLength());
-	EXPECT_LT(1 + 1, value.capacity());
-	EXPECT_EQ(0, value[0]); // 長さ=1なので1文字目を参照できるが、NULが返ってくる
+	CNativeW value(L"test");
+	value = NULL;
+	ASSERT_EQ(NULL, value.GetStringPtr());
+	EXPECT_EQ(0, value.GetStringLength());
 }
 
 /*!
@@ -322,9 +298,7 @@ TEST(CNativeW, AppendStringNullPointer)
 /*!
  * @brief 加算代入演算子(NULL指定)の仕様
  * @remark バッファが確保される
- * @remark 文字列長は1になる
- * @remark バッファサイズは1+1以上になる
- * @note バグですね(^^;
+ * @remark 文字列長は演算子呼出前の文字列長+1になる
  */
 TEST(CNativeW, AppendStringNullLiteral)
 {
@@ -336,7 +310,6 @@ TEST(CNativeW, AppendStringNullLiteral)
 #endif
 	ASSERT_STREQ(L"", value.GetStringPtr());
 	EXPECT_EQ(1, value.GetStringLength());
-	EXPECT_LT(1 + 1, value.capacity());
 }
 
 /*!


### PR DESCRIPTION
# PR の目的
CNativeWの挙動を仕様化した際、疑問があった箇所に「バグじゃね？」とコメントしました。
 現時点で、「バグじゃね？」が2箇所残っているので対応したいです。

### 疑問のある仕様
- CNativeWにNULLを代入したとき、CNativeWのデータは空文字列になる。
  - `operator = (wchar_t)` に関する疑問。⇒演算子を廃止する
- CNativeWにNULLを加算したとき、CNativeWのデータ末尾にNUL文字が追加される。

## カテゴリ
- その他

## PR の背景

### `operator = (wchar_t)` に関する疑問
- CNativeWにNULLを代入したとき、CNativeWのデータは空文字列になる。
  - 指定した文字で構成される1文字分の文字列として処理されるのが原因。
    - 指定した文字が `NULL` だとすると空文字列なので、ソースから0文字コピーしてNUL終端を書き込む挙動になって、結果は空文字列になる。
  - std::wstring には `operator = (wchar_t)` がない。
  - `operator = (wchar_t)` の利用箇所で、この演算子がないとマズいのかどうかチェックした。
    - 利用箇所は1箇所のみ、CNativeWのコンストラクタで代替可能。
      - wchar_tから1文字分のCNativeWを生成して改行記号かどうかを判定する処理っぽい。
  - `operator = (wchar_t)` を廃止することでこの問題に対処した。

### `operator += (wchar_t)` に関する疑問
- CNativeWにNULLを加算したとき、CNativeWのデータ末尾にNUL文字が追加される。
  - CNativeW が NUL を含む文字列を保持できることが原因。
    - 冷静に考えると **仕様通り** な気がする・・・。

## PR のメリット
- `str = NULL` という記述の意味が、 **str をNULLにする** になります。
  - 従来は str を空文字列にしていました。
  - `str.SetString(NULL)` と同じ結果になります。
- `str += NULL` という記述の意味が、  **str の末尾にNUL文字を追加する** になります。
  - 従来通りです。（疑問のある仕様⇒疑問のない仕様）

## PR のデメリット (トレードオフとかあれば)
- とくにありません。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。

## 関連チケット
- #1097 [WIP] CNativeWにnullptrを代入できるようにしたい Take3
- #1086 closed [WIP] CNativeWにnullptrを代入できるようにしたい Take2
- #1087 merged CNativeW::SetString に NULL を指定した場合に wcslen に NULL を渡して落ちてしまう不具合を修正

