### PR TITLE
ICU4Cによる文字コード検出機能を追加する

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -303,6 +303,7 @@
     <ClInclude Include="..\sakura_core\charset\CUnicodeBe.h" />
     <ClInclude Include="..\sakura_core\charset\CUtf7.h" />
     <ClInclude Include="..\sakura_core\charset\CUtf8.h" />
+    <ClInclude Include="..\sakura_core\charset\icu4c\CharsetDetector.h" />
     <ClInclude Include="..\sakura_core\CHokanMgr.h" />
     <ClInclude Include="..\sakura_core\CKeyWordSetMgr.h" />
     <ClInclude Include="..\sakura_core\CLoadAgent.h" />
@@ -413,6 +414,7 @@
     <ClInclude Include="..\sakura_core\extmodule\CBregexpDll2.h" />
     <ClInclude Include="..\sakura_core\extmodule\CDllHandler.h" />
     <ClInclude Include="..\sakura_core\extmodule\CHtmlHelp.h" />
+    <ClInclude Include="..\sakura_core\extmodule\CIcu4cI18n.h" />
     <ClInclude Include="..\sakura_core\extmodule\CMigemo.h" />
     <ClInclude Include="..\sakura_core\extmodule\CUxTheme.h" />
     <ClInclude Include="..\sakura_core\Funccode_define.h" />
@@ -647,6 +649,7 @@
     <ClCompile Include="..\sakura_core\charset\CUnicodeBe.cpp" />
     <ClCompile Include="..\sakura_core\charset\CUtf7.cpp" />
     <ClCompile Include="..\sakura_core\charset\CUtf8.cpp" />
+    <ClCompile Include="..\sakura_core\charset\icu4c\CharsetDetector.cpp" />
     <ClCompile Include="..\sakura_core\CHokanMgr.cpp" />
     <ClCompile Include="..\sakura_core\CKeyWordSetMgr.cpp" />
     <ClCompile Include="..\sakura_core\CLoadAgent.cpp" />
@@ -776,6 +779,7 @@
     <ClCompile Include="..\sakura_core\extmodule\CBregexpDll2.cpp" />
     <ClCompile Include="..\sakura_core\extmodule\CDllHandler.cpp" />
     <ClCompile Include="..\sakura_core\extmodule\CHtmlHelp.cpp" />
+    <ClCompile Include="..\sakura_core\extmodule\CIcu4cI18n.cpp" />
     <ClCompile Include="..\sakura_core\extmodule\CMigemo.cpp" />
     <ClCompile Include="..\sakura_core\extmodule\CUxTheme.cpp" />
     <ClCompile Include="..\sakura_core\func\CFuncKeyWnd.cpp" />

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -119,6 +119,9 @@
     <Filter Include="Cpp Source Files\uiparts">
       <UniqueIdentifier>{930f3f82-ab3f-49e3-af4a-d4f9c2d51f46}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Cpp Source Files\charset\icu4c">
+      <UniqueIdentifier>{e4629f85-3be8-4dda-80db-1be310929433}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\sakura_core\Funccode_define.h">
@@ -1084,6 +1087,12 @@
     </ClInclude>
     <ClInclude Include="..\sakura_core\mem\CPoolResource.h">
       <Filter>Cpp Source Files\mem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\sakura_core\extmodule\CIcu4cI18n.h">
+      <Filter>Cpp Source Files\extmodule</Filter>
+    </ClInclude>
+    <ClInclude Include="..\sakura_core\charset\icu4c\CharsetDetector.h">
+      <Filter>Cpp Source Files\charset\icu4c</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -2251,6 +2260,12 @@
     </ClCompile>
     <ClCompile Include="..\sakura_core\dlg\CDlgOpenFile_CommonItemDialog.cpp">
       <Filter>Cpp Source Files\dlg</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sakura_core\extmodule\CIcu4cI18n.cpp">
+      <Filter>Cpp Source Files\extmodule</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sakura_core\charset\icu4c\CharsetDetector.cpp">
+      <Filter>Cpp Source Files\charset\icu4c</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -115,6 +115,7 @@ charset/CUnicode.o \
 charset/CUnicodeBe.o \
 charset/CUtf7.o \
 charset/CUtf8.o \
+charset/icu4c/CharsetDetector.o \
 cmd/CViewCommander.o \
 cmd/CViewCommander_Bookmark.o \
 cmd/CViewCommander_Clipboard.o \
@@ -228,6 +229,7 @@ extmodule/CBregexp.o \
 extmodule/CBregexpDll2.o \
 extmodule/CDllHandler.o \
 extmodule/CHtmlHelp.o \
+extmodule/CIcu4cI18n.o \
 extmodule/CMigemo.o \
 extmodule/CUxTheme.o \
 func/CFuncKeyWnd.o \

--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -605,11 +605,7 @@ bool CClipboard::GetClipboradByFormat(CNativeW& mem, const wchar_t* pFormatName,
 		}else{
 			ECodeType eMode = (ECodeType)nMode;
 			if( !IsValidCodeType(eMode) ){
-				// コード不明と99は自動判別
-				ECodeType nBomCode = CCodeMediator::DetectUnicodeBom((const char*)pData, nLength);
-				if( nBomCode != CODE_NONE ){
-					eMode = nBomCode;
-				}else{
+				{
 					const STypeConfig& type = CEditDoc::GetInstance(0)->m_cDocType.GetDocumentAttribute();
 					CCodeMediator mediator(type.m_encoding);
 					eMode = mediator.CheckKanjiCode((const char*)pData, nLength);

--- a/sakura_core/charset/CCodeMediator.cpp
+++ b/sakura_core/charset/CCodeMediator.cpp
@@ -1,6 +1,7 @@
 ﻿/*! @file */
 #include "StdAfx.h"
 #include "charset/CCodeMediator.h"
+#include "charset/icu4c/CharsetDetector.h"
 #include "charset/CESI.h"
 #include "io/CBinaryStream.h"
 
@@ -21,6 +22,13 @@ ECodeType CCodeMediator::CheckKanjiCode(const char* buff, size_t size) noexcept
 	// 0バイトならタイプ別のデフォルト設定
 	if (size == 0) {
 		return m_sEncodingConfig.m_eDefaultCodetype;
+	}
+
+	// ICU4CのDLL群が利用できる場合、ICU4Cによる判定を試みる
+	CharsetDetector csd;
+	if (csd.IsAvailable()) {
+		auto code = csd.Detect(std::string_view(buff, size));
+		if (code != CODE_ERROR) return code;
 	}
 
 	CESI cesi(m_sEncodingConfig);

--- a/sakura_core/charset/CCodeMediator.cpp
+++ b/sakura_core/charset/CCodeMediator.cpp
@@ -1,147 +1,8 @@
 ﻿/*! @file */
 #include "StdAfx.h"
 #include "charset/CCodeMediator.h"
-#include "charset/charcode.h"
 #include "charset/CESI.h"
 #include "io/CBinaryStream.h"
-#include "types/CType.h"
-
-/*!
-	文字列の先頭にUnicode系BOMが付いているか？
-
-	@retval CODE_UNICODE   UTF-16 LE
-	@retval CODE_UTF8      UTF-8
-	@retval CODE_UNICODEBE UTF-16 BE
-	@retval CODE_NONE      未検出
-
-	@date 2007.08.11 charcode.cpp から移動
-*/
-ECodeType CCodeMediator::DetectUnicodeBom( const char* pS, const int nLen )
-{
-	uchar_t *pBuf;
-
-	if( NULL == pS ){ return CODE_NONE; }
-
-	pBuf = (uchar_t *) pS;
-	if( 2 <= nLen ){
-		if( pBuf[0] == 0xff && pBuf[1] == 0xfe ){
-			return CODE_UNICODE;
-		}
-		if( pBuf[0] == 0xfe && pBuf[1] == 0xff ){
-			return CODE_UNICODEBE;
-		}
-		if( 3 <= nLen ){
-			if( pBuf[0] == 0xef && pBuf[1] == 0xbb && pBuf[2] == 0xbf ){
-				return CODE_UTF8;
-			}
-		}
-	}
-#if 0
-// 2015.03.05 Moca UTF-7 BOMは無効に変更
-// もしデータがASCII互換でUTF-7として正しければ、文字コード比較でUTF-7になるはず
-	if( 4 <= nLen ){
-		if( memcmp( pBuf, "+/v", 3 ) == 0
-			&& ( pBuf[3] == '8' || pBuf[3] == '9' || pBuf[3] == '+' || pBuf[3] == '/' ) ){
-			return CODE_UTF7;
-		}
-	}
-#endif
-	return CODE_NONE;
-}
-
-/*!
-	SJIS, JIS, EUCJP, UTF-8, UTF-7 を判定 (改)
-
-	@return SJIS, JIS, EUCJP, UTF-8, UTF-7 の何れかの ID を返す．
-
-	@note 適切な検出が行われた場合は、m_dwStatus に CESI_MB_DETECTED フラグが格納される。
-*/
-ECodeType CCodeMediator::DetectMBCode( CESI* pcesi )
-{
-//	pcesi->m_dwStatus = ESI_NOINFORMATION;
-
-	if( pcesi->GetDataLen() < (pcesi->m_apMbcInfo[0]->nSpecific - pcesi->m_apMbcInfo[0]->nPoints) * 2000 ){
-		// 不正バイトの割合が、全体の 0.05% 未満であることを確認。
-		// 全体の0.05%ほどの不正バイトは、無視する。
-		pcesi->SetStatus( ESI_NODETECTED );
-		return CODE_NONE;
-	}
-	if( pcesi->m_apMbcInfo[0]->nPoints <= 0 ){
-		pcesi->SetStatus( ESI_NODETECTED );
-		return CODE_NONE;
-	}
-
-	/*
-		判定状況を確認
-	*/
-	pcesi->SetStatus( ESI_MBC_DETECTED );
-	return pcesi->m_apMbcInfo[0]->eCodeID;
-}
-
-/*!
-	UTF-16 LE/BE を判定.
-
-	@retval CODE_UNICODE    UTF-16 LE が検出された
-	@retval CODE_UNICODEBE  UTF-16 BE が検出された
-	@retval 0               UTF-16 LE/BE ともに検出されなかった
-
-*/
-ECodeType CCodeMediator::DetectUnicode( CESI* pcesi )
-{
-//	pcesi->m_dwStatus = ESI_NOINFORMATION;
-
-	EBOMType ebom_type = pcesi->GetBOMType();
-	int ndatalen;
-	int nlinebreak;
-
-	if( ebom_type == ESI_BOMTYPE_UNKNOWN ){
-		pcesi->SetStatus( ESI_NODETECTED );
-		return CODE_NONE;
-	}
-
-	// 1行の平均桁数が200を超えている場合はUnicode未検出とする
-	ndatalen = pcesi->GetDataLen();
-	nlinebreak = pcesi->m_aWcInfo[ebom_type].nSpecific;  // 改行数を nlinebreakに取得
-	if( static_cast<double>(ndatalen) / nlinebreak > 200 ){
-		pcesi->SetStatus( ESI_NODETECTED );
-		return CODE_NONE;
-	}
-
-	pcesi->SetStatus( ESI_WC_DETECTED );
-	return pcesi->m_aWcInfo[ebom_type].eCodeID;
-}
-
-/*
-	日本語コードセット判定
-*/
-ECodeType CCodeMediator::CheckKanjiCode( CESI* pcesi )
-{
-	ECodeType nret;
-
-	/*
-		判定状況は、
-		DetectMBCode(), DetectUnicode() 内で
-		cesi.m_dwStatus に記録する。
-	*/
-
-	if( pcesi == NULL ){
-		return CODE_DEFAULT;
-	}
-	if( pcesi->GetMetaName() != CODE_NONE ){
-		return pcesi->GetMetaName();
-	}
-	nret = DetectUnicode( pcesi );
-	if( nret != CODE_NONE && pcesi->GetStatus() != ESI_NODETECTED ){
-		return nret;
-	}
-	nret = DetectMBCode( pcesi );
-	if( nret != CODE_NONE && pcesi->GetStatus() != ESI_NODETECTED ){
-		return nret;
-	}
-
-	// デフォルト文字コードを返す
-	return pcesi->m_pEncodingConfig->m_eDefaultCodetype;
-}
 
 /*
 	日本語コードセット判別
@@ -155,18 +16,15 @@ ECodeType CCodeMediator::CheckKanjiCode( CESI* pcesi )
 	UTF-7		CODE_UTF7
 	UnicodeBE	CODE_UNICODEBE
 */
-ECodeType CCodeMediator::CheckKanjiCode( const char* pBuf, int nBufLen )
+ECodeType CCodeMediator::CheckKanjiCode(const char* buff, size_t size) noexcept
 {
-	CESI cesi(*m_pEncodingConfig);
+	// 0バイトならタイプ別のデフォルト設定
+	if (size == 0) {
+		return m_sEncodingConfig.m_eDefaultCodetype;
+	}
 
-	/*
-		判定状況は、
-		DetectMBCode(), DetectUnicode() 内で
-		cesi.m_dwStatus に記録する。
-	*/
-
-	cesi.SetInformation( pBuf, nBufLen/*, CODE_SJIS*/ );
-	return CheckKanjiCode( &cesi );
+	CESI cesi(m_sEncodingConfig);
+	return cesi.CheckKanjiCode(buff, size);
 }
 
 /*
@@ -182,8 +40,12 @@ ECodeType CCodeMediator::CheckKanjiCode( const char* pBuf, int nBufLen )
 ||	UnicodeBE	CODE_UNICODEBE
 ||	エラー		CODE_ERROR
 */
-ECodeType CCodeMediator::CheckKanjiCodeOfFile( const WCHAR* pszFile )
+ECodeType CCodeMediator::CheckKanjiCodeOfFile(const WCHAR* pszFile)
 {
+	if (!pszFile) {
+		return CODE_ERROR;
+	}
+
 	// オープン
 	CBinaryInputStream in(pszFile);
 	if(!in){
@@ -191,33 +53,21 @@ ECodeType CCodeMediator::CheckKanjiCodeOfFile( const WCHAR* pszFile )
 	}
 
 	// データ長取得
-	int nBufLen = in.GetLength();
-	if( nBufLen > CheckKanjiCode_MAXREADLENGTH ){
-		nBufLen = CheckKanjiCode_MAXREADLENGTH;
+	auto size = std::min<size_t>(in.GetLength(), CheckKanjiCode_MAXREADLENGTH);
+
+	std::unique_ptr<char[]> buff;
+	if (size > 0)
+	{
+		// データ確保
+		buff = std::make_unique<char[]>(size);
+
+		// 読み込み
+		auto ret = in.Read(buff.get(), size);
 	}
-
-	// 0バイトならタイプ別のデフォルト設定
-	if( 0 == nBufLen ){
-		return m_pEncodingConfig->m_eDefaultCodetype;
-	}
-
-	// データ確保
-	CMemory cMem;
-	cMem.AllocBuffer(nBufLen);
-	void* pBuf = cMem.GetRawPtr();
-
-	// 読み込み
-	nBufLen = in.Read(pBuf, nBufLen);
 
 	// クローズ
 	in.Close();
 
 	// 日本語コードセット判別
-	ECodeType nCodeType = DetectUnicodeBom( reinterpret_cast<const char*>(pBuf), nBufLen );
-	if( nCodeType == CODE_NONE ){
-		// Unicode BOM は検出されませんでした．
-		nCodeType = CheckKanjiCode( reinterpret_cast<const char*>(pBuf), nBufLen );
-	}
-
-	return nCodeType;
+	return CheckKanjiCode(buff.get(), size);
 }

--- a/sakura_core/charset/CCodeMediator.h
+++ b/sakura_core/charset/CCodeMediator.h
@@ -24,30 +24,27 @@
 */
 #pragma once
 
-#include "charset/CESI.h"
-class CEditDoc;
+#include "types/CType.h" //SEncodingConfig
 
-class CCodeMediator{
-protected:
-	// CESI.cpp の判定関数をここに移す
-	static ECodeType DetectMBCode( CESI* pcesi );
-	static ECodeType DetectUnicode( CESI* pcesi );
-
+/*!
+ * @brief CCodeMediator クラス
+ * 
+ * 日本語コードセット判別の詳細を隠ぺいするための仲介クラスです。
+ */
+class CCodeMediator final {
 public:
-
-	explicit CCodeMediator( const SEncodingConfig &ref ) : m_pEncodingConfig(&ref) { }
-
-	static ECodeType DetectUnicodeBom( const char* pS, const int nLen );
+	explicit CCodeMediator(const SEncodingConfig &encodingConfig) noexcept
+		: m_sEncodingConfig(encodingConfig)
+	{
+	}
 
 	/* 日本語コードセット判別 */
-	ECodeType CheckKanjiCode( const char* pBuf, int nBufLen );
+	ECodeType CheckKanjiCode(const char* buff, size_t size) noexcept;
 	/* ファイルの日本語コードセット判別 */
-	ECodeType CheckKanjiCodeOfFile( const WCHAR* pszFile );
-
-	static ECodeType CheckKanjiCode( CESI* pcesi );  // CESI 構造体（？）を外部で構築した場合に使用
+	ECodeType CheckKanjiCodeOfFile(const WCHAR* pszFile);
 
 private:
-	const SEncodingConfig* m_pEncodingConfig;
+	const SEncodingConfig& m_sEncodingConfig;
 };
 
 /*[EOF]*/

--- a/sakura_core/charset/icu4c/CharsetDetector.cpp
+++ b/sakura_core/charset/icu4c/CharsetDetector.cpp
@@ -1,0 +1,77 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include "StdAfx.h"
+#include "CharsetDetector.h"
+
+CharsetDetector::CharsetDetector() noexcept
+	: _icuin()
+	, _csd(nullptr)
+{
+	_icuin.InitDll();
+}
+
+CharsetDetector::~CharsetDetector() noexcept
+{
+	if (_icuin.IsAvailable()) {
+		_icuin.ucsdet_close(_csd);
+	}
+}
+
+ECodeType CharsetDetector::Detect(const std::string_view& bytes)
+{
+	UErrorCode status = U_ZERO_ERROR;
+
+	_csd = _icuin.ucsdet_open(&status);
+	if (status != U_ZERO_ERROR) {
+		return CODE_ERROR;
+	}
+
+	_icuin.ucsdet_setText(_csd, bytes.data(), bytes.length(), &status);
+	if (status != U_ZERO_ERROR) {
+		return CODE_ERROR;
+	}
+
+	const auto csm = _icuin.ucsdet_detect(_csd, &status);
+	if (status != U_ZERO_ERROR) {
+		return CODE_ERROR;
+	}
+
+	std::string_view name = _icuin.ucsdet_getName(csm, &status);
+	if (status != U_ZERO_ERROR) {
+		return CODE_ERROR;
+	}
+
+	// 文字セット名⇒サクラエディタ内部コードの変換
+	if (name == "UTF-8") return CODE_UTF8;
+	if (name == "SHIFT_JIS") return CODE_SJIS;
+	if (name == "UTF-16BE") return CODE_UNICODEBE;
+	if (name == "UTF-16LE") return CODE_UNICODE;
+	if (name == "EUC-JP") return CODE_EUC;
+	if (name == "ISO-2022-JP") return CODE_JIS;
+	if (name == "UTF-7") return CODE_UTF7;
+	if (name == "ISO-8859-1") return CODE_LATIN1;
+
+	return CODE_ERROR;
+}

--- a/sakura_core/charset/icu4c/CharsetDetector.h
+++ b/sakura_core/charset/icu4c/CharsetDetector.h
@@ -1,0 +1,48 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#pragma once
+
+#include <string_view>
+
+#include "extmodule/CIcu4cI18n.h"
+
+/*!
+ * @brief 文字コード検出クラス
+ */
+class CharsetDetector final
+{
+	CIcu4cI18n _icuin;
+	UCharsetDetector* _csd;
+
+public:
+	CharsetDetector() noexcept;
+	~CharsetDetector() noexcept;
+
+	bool IsAvailable() const noexcept {
+		return _icuin.IsAvailable();
+	}
+
+	ECodeType Detect(const std::string_view& bytes);
+};

--- a/sakura_core/extmodule/CIcu4cI18n.cpp
+++ b/sakura_core/extmodule/CIcu4cI18n.cpp
@@ -1,0 +1,69 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include "StdAfx.h"
+#include "CIcu4cI18n.h"
+
+CIcu4cI18n::CIcu4cI18n() noexcept
+	: _ucsdet_open(nullptr)
+	, _ucsdet_setText(nullptr)
+	, _ucsdet_detect(nullptr)
+	, _ucsdet_close(nullptr)
+{
+}
+
+CIcu4cI18n::~CIcu4cI18n() noexcept
+{
+}
+
+/*!
+ * @brief DLLの名前を返す
+ */
+LPCWSTR CIcu4cI18n::GetDllNameImp(int index)
+{
+	(void*)index;
+	return L"icuin66.dll"; //バージョンは固定
+}
+
+/*!
+	DLLの初期化
+
+	関数のアドレスを取得してメンバに保管する．
+
+	@retval true 成功
+	@retval false アドレス取得に失敗
+*/
+bool CIcu4cI18n::InitDllImp()
+{
+	//DLL内関数名リスト
+	const ImportTable table[] = {
+		{ &_ucsdet_open,		"ucsdet_open_66" },		//バージョンは固定
+		{ &_ucsdet_setText,		"ucsdet_setText_66" },	//バージョンは固定
+		{ &_ucsdet_detect,		"ucsdet_detect_66" },	//バージョンは固定
+		{ &_ucsdet_getName,		"ucsdet_getName_66" },	//バージョンは固定
+		{ &_ucsdet_close,		"ucsdet_close_66" },	//バージョンは固定
+		{ NULL, 0 }
+	};
+	return RegisterEntries(table);
+}

--- a/sakura_core/extmodule/CIcu4cI18n.h
+++ b/sakura_core/extmodule/CIcu4cI18n.h
@@ -1,0 +1,81 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#pragma once
+
+#include "CDllHandler.h"
+
+//ICU4Cの型定義
+class UCharsetDetector;
+class UCharsetMatch;
+
+typedef enum UErrorCode {
+	U_ZERO_ERROR = 0,     /**< No error, no warning. */
+} UErrorCode;
+
+/*!
+ * ICU4C の i18n ライブラリ(icuin.dll) をラップするクラス
+ */
+class CIcu4cI18n final : public CDllImp
+{
+	// DLL関数型定義
+	typedef UCharsetDetector*		(_cdecl *ucsdet_open_t)(UErrorCode *status);
+	typedef void					(_cdecl *ucsdet_setText_t)(UCharsetDetector *ucsd, const char *textIn, int32_t len, UErrorCode *status);
+	typedef const UCharsetMatch *	(_cdecl *ucsdet_detect_t)(UCharsetDetector *ucsd, UErrorCode *status);
+	typedef const char*				(_cdecl *ucsdet_getName_t)(const UCharsetMatch *ucsm, UErrorCode *status);
+	typedef void					(_cdecl *ucsdet_close_t)(UCharsetDetector *ucsd);
+
+	// メンバ定義
+	ucsdet_open_t		_ucsdet_open;
+	ucsdet_setText_t	_ucsdet_setText;
+	ucsdet_detect_t		_ucsdet_detect;
+	ucsdet_getName_t	_ucsdet_getName;
+	ucsdet_close_t		_ucsdet_close;
+
+public:
+	CIcu4cI18n() noexcept;
+	virtual ~CIcu4cI18n() noexcept;
+
+protected:
+	// CDllImpインタフェース
+	LPCWSTR GetDllNameImp(int nIndex) override;
+	bool InitDllImp() override;
+
+public:
+	inline UCharsetDetector* ucsdet_open(UErrorCode *status) const {
+		return _ucsdet_open(status);
+	}
+	inline void ucsdet_setText(UCharsetDetector *ucsd, const char *textIn, int32_t len, UErrorCode *status) const {
+		return _ucsdet_setText(ucsd, textIn, len, status);
+	}
+	inline const UCharsetMatch* ucsdet_detect(UCharsetDetector *ucsd, UErrorCode *status) const {
+		return _ucsdet_detect(ucsd, status);
+	}
+	inline const char* ucsdet_getName(const UCharsetMatch *ucsm, UErrorCode *status) const {
+		return _ucsdet_getName(ucsm, status);
+	}
+	inline void ucsdet_close(UCharsetDetector *ucsd) const {
+		return _ucsdet_close(ucsd);
+	}
+};

--- a/sakura_core/extmodule/CIcu4cI18n.h
+++ b/sakura_core/extmodule/CIcu4cI18n.h
@@ -40,11 +40,11 @@ typedef enum UErrorCode {
 class CIcu4cI18n final : public CDllImp
 {
 	// DLL関数型定義
-	typedef UCharsetDetector*		(_cdecl *ucsdet_open_t)(UErrorCode *status);
-	typedef void					(_cdecl *ucsdet_setText_t)(UCharsetDetector *ucsd, const char *textIn, int32_t len, UErrorCode *status);
-	typedef const UCharsetMatch *	(_cdecl *ucsdet_detect_t)(UCharsetDetector *ucsd, UErrorCode *status);
-	typedef const char*				(_cdecl *ucsdet_getName_t)(const UCharsetMatch *ucsm, UErrorCode *status);
-	typedef void					(_cdecl *ucsdet_close_t)(UCharsetDetector *ucsd);
+	typedef UCharsetDetector*		(__cdecl *ucsdet_open_t)(UErrorCode *status);
+	typedef void					(__cdecl *ucsdet_setText_t)(UCharsetDetector *ucsd, const char *textIn, int32_t len, UErrorCode *status);
+	typedef const UCharsetMatch *	(__cdecl *ucsdet_detect_t)(UCharsetDetector *ucsd, UErrorCode *status);
+	typedef const char*				(__cdecl *ucsdet_getName_t)(const UCharsetMatch *ucsm, UErrorCode *status);
+	typedef void					(__cdecl *ucsdet_close_t)(UCharsetDetector *ucsd);
 
 	// メンバ定義
 	ucsdet_open_t		_ucsdet_open;

--- a/sakura_core/io/CFileLoad.cpp
+++ b/sakura_core/io/CFileLoad.cpp
@@ -157,7 +157,6 @@ ECodeType CFileLoad::FileOpen( LPCWSTR pFileName, bool bBigFile, ECodeType CharC
 {
 	HANDLE	hFile;
 	ULARGE_INTEGER	fileSize;
-	ECodeType	nBomCode;
 
 	// FileCloseを呼んでからにしてください
 	if( NULL != m_hFile ){
@@ -203,14 +202,9 @@ ECodeType CFileLoad::FileOpen( LPCWSTR pFileName, bool bBigFile, ECodeType CharC
 	// データ読み込み
 	Buffering();
 
-	nBomCode = CCodeMediator::DetectUnicodeBom( m_pReadBuf, m_nReadDataLen );
 	if( CharCode == CODE_AUTODETECT ){
-		if( nBomCode != CODE_NONE ){
-			CharCode = nBomCode;
-		}else{
-			CCodeMediator mediator(*m_pEencoding);
-			CharCode = mediator.CheckKanjiCode( m_pReadBuf, m_nReadDataLen );
-		}
+		CCodeMediator mediator(*m_pEencoding);
+		CharCode = mediator.CheckKanjiCode(m_pReadBuf, m_nReadDataLen);
 	}
 	// To Here Jun. 08, 2003
 	// 不正な文字コードのときはデフォルト(SJIS:無変換)を設定


### PR DESCRIPTION
# PR の目的
ICU4Cによる文字コード検出機能を追加

## カテゴリ
- 機能追加

## PR の背景
`ICU` というライブラリがあります。
http://site.icu-project.org/home

IBMが作ったライブラリで、ほぼすべての文明国のローカル言語を表現できる文字コードセット群をサポートしています。一応、何年も前に IBM の手を離れていて、現在は Unicode コンソーシアムが仕切りをやっているので、最新のUNICODE規格にも対応しているはずです。

c++規格がwchar_tをUNICODE規格に準拠させる対応を積極的に行わない理由。
UNICODE規格は、１プログラム言語の仕様として取り込むには複雑すぎる、らしいです。
その「複雑すぎる仕様」をコードの形に落とし込んであるのが ICU4C です。

試食版として、とりあえず動くように組み込んでみました。
最新版DLL(icuin66.dll, icudt66.dll, icuuc66.dll) はまだダウンロードできないっぽいので、動作させるには https://github.com/unicode-org/icu からソースを落としてビルドする必要があります。


## PR のメリット
- 文字コード判別に ICU4C の DLL を使えるようになります。

## PR のデメリット (トレードオフとかあれば)
- ICU4C はUNIX由来のプロジェクトなので、Windows向けポートが「雑」です。
- ICU4C の DLL には インターフェース関数 がないので、対応バージョンは固定にせざるを得ませんでした。PRの変更では、現時点の最新版(＝66)のみに対応するようになっています。 
- ICU4C の DLL はインターネットで配布するには巨大すぎる (約20MB) ので、インストーラーに同梱する予定はありません。これにより次の問題が発生します。
- この PR による変更を確認するために必要な ICU4C の DLL は icuin66.dll, icudt66.dll, icuuc66.dll の 3つ ですが、これらを github から落としてきて使える状態にする作業は「一般向け」としては難易度が高すぎるように思います。

メリットは **ICU4Cが使えるようになること** なんですが、デメリットは **ICU4Cを使わざるを得ないこと** だったりします。

## PR の影響範囲
- **この PR の恩恵を得るには、ICU4C の DLL が必要です。**
  - ICU4C の DLL を入手しない場合、アプリ（＝サクラエディタ）の機能に影響はありません。
  - 入手した DLL は sakura.exe と同じフォルダに配置する必要があります。。
- (ICU4C の DLL を用意した場合のみ) 文字コード判別に ICU4C が使われるようになります。
  - 主に通常用途(テキストの編集など) では ICU4C のコード判別のほうが有利です。
  - 変態用途(バイナリファイルの編集など) では サクラエディタ のコード判別でないと使い物にならないと考えられます。

## 関連チケット
#487 文字コード自動判定（UTF-8をSJISと誤認）
#989 C++の準拠規格をC++17に更新する

## 参考資料
[Mediatorパターン](https://qiita.com/hikao/items/71fb454ed9b1164daa5b)