### PR TITLE
すでにマージされた PR #877 と PR #1079 を追って出す PR です。

### DIFF
--- a/sakura_core/print/CPrint.cpp
+++ b/sakura_core/print/CPrint.cpp
@@ -38,6 +38,42 @@
 #include "CPrint.h"
 #include "_main/global.h"
 
+/*
+	MYDEVMODE の比較演算子。
+*/
+#define LHS_EQ_RHS(MEMBER) ((lhs.MEMBER)==(rhs.MEMBER))
+#define L_WCSEQL_R(ARYMBR) (0==wcsncmp(lhs.ARYMBR, rhs.ARYMBR, _countof(lhs.ARYMBR)-1))
+bool operator == (const MYDEVMODE& lhs, const MYDEVMODE& rhs)
+{
+	return LHS_EQ_RHS(m_bPrinterNotFound)
+		&& L_WCSEQL_R(m_szPrinterDriverName)
+		&& L_WCSEQL_R(m_szPrinterDeviceName)
+		&& L_WCSEQL_R(m_szPrinterOutputName)
+		&& LHS_EQ_RHS(dmFields)
+		&& LHS_EQ_RHS(dmOrientation)
+		&& LHS_EQ_RHS(dmPaperSize)
+		&& LHS_EQ_RHS(dmPaperLength)
+		&& LHS_EQ_RHS(dmPaperWidth)
+		&& LHS_EQ_RHS(dmScale)
+		&& LHS_EQ_RHS(dmCopies)
+		&& LHS_EQ_RHS(dmDefaultSource)
+		&& LHS_EQ_RHS(dmPrintQuality)
+		&& LHS_EQ_RHS(dmColor)
+		&& LHS_EQ_RHS(dmDuplex)
+		&& LHS_EQ_RHS(dmYResolution)
+		&& LHS_EQ_RHS(dmTTOption)
+		&& LHS_EQ_RHS(dmCollate)
+		&& L_WCSEQL_R(dmFormName)
+		&& LHS_EQ_RHS(dmLogPixels)
+		&& LHS_EQ_RHS(dmBitsPerPel)
+		&& LHS_EQ_RHS(dmPelsWidth)
+		&& LHS_EQ_RHS(dmPelsHeight)
+		&& LHS_EQ_RHS(dmDisplayFlags)
+		&& LHS_EQ_RHS(dmDisplayFrequency);
+}
+#undef LHS_EQ_RHS
+#undef L_WCSEQL_R
+
 // 2006.08.14 Moca 用紙名一覧の重複削除・情報の統合
 const PAPER_INFO CPrint::m_paperInfoArr[] = {
 	// 	用紙ID, 幅

--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -60,41 +60,13 @@ struct	MYDEVMODE {
 	DWORD	dmPelsHeight;
 	DWORD	dmDisplayFlags;
 	DWORD	dmDisplayFrequency;
-
-	//! 等価比較演算子
-	bool operator == (const MYDEVMODE& rhs) const noexcept {
-		if (this == &rhs) return true;
-		return m_bPrinterNotFound == rhs.m_bPrinterNotFound
-			&& 0 == wcsncmp(m_szPrinterDriverName, rhs.m_szPrinterDriverName, _countof(m_szPrinterDriverName))
-			&& 0 == wcsncmp(m_szPrinterDeviceName, rhs.m_szPrinterDeviceName, _countof(m_szPrinterDeviceName))
-			&& 0 == wcsncmp(m_szPrinterOutputName, rhs.m_szPrinterOutputName, _countof(m_szPrinterOutputName))
-			&& dmFields == rhs.dmFields
-			&& dmOrientation == rhs.dmOrientation
-			&& dmPaperSize == rhs.dmPaperSize
-			&& dmPaperLength == rhs.dmPaperLength
-			&& dmPaperWidth == rhs.dmPaperWidth
-			&& dmScale == rhs.dmScale
-			&& dmCopies == rhs.dmCopies
-			&& dmDefaultSource == rhs.dmDefaultSource
-			&& dmPrintQuality == rhs.dmPrintQuality
-			&& dmColor == rhs.dmColor
-			&& dmDuplex == rhs.dmDuplex
-			&& dmYResolution == rhs.dmYResolution
-			&& dmTTOption == rhs.dmTTOption
-			&& dmCollate == rhs.dmCollate
-			&& 0 == wcsncmp(dmFormName, rhs.dmFormName, _countof(dmFormName))
-			&& dmLogPixels == rhs.dmLogPixels
-			&& dmBitsPerPel == rhs.dmBitsPerPel
-			&& dmPelsWidth == rhs.dmPelsWidth
-			&& dmPelsHeight == rhs.dmPelsHeight
-			&& dmDisplayFlags == rhs.dmDisplayFlags
-			&& dmDisplayFrequency == rhs.dmDisplayFrequency;
-	}
-	//! 否定の等価比較演算子
-	bool operator != (const MYDEVMODE& rhs) const noexcept {
-		return !(*this == rhs);
-	}
 };
+
+bool operator == (const MYDEVMODE& lhs, const MYDEVMODE& rhs);
+inline bool operator != (const MYDEVMODE& lhs, const MYDEVMODE& rhs)
+{
+	return ! (lhs == rhs);
+}
 
 // 2006.08.14 Moca 用紙情報の統合 PAPER_INFO新設
 //! 用紙情報

--- a/tests/unittests/test-mydevmode.cpp
+++ b/tests/unittests/test-mydevmode.cpp
@@ -70,49 +70,13 @@ static constexpr MYDEVMODE myDevMode = {
 
 /*!
  * @brief 等価演算子のテスト
- *  コピーコンストラクタ(trivial)でインスタンスを生成し、等価比較を行う
  */
-TEST(MYDEVMODETest, operatorEqualByCopy)
+TEST(MYDEVMODETest, operatorEqual)
 {
-	// コピーコンストラクタ経由で初期化
-	MYDEVMODE value = myDevMode;
-
-	EXPECT_TRUE(value == myDevMode);
-	EXPECT_FALSE(value != myDevMode);
-	ASSERT_EQ(myDevMode, value);
+	ASSERT_EQ(myDevMode, MYDEVMODE(myDevMode)); // コピーと比較
+	ASSERT_EQ(myDevMode, myDevMode); // 自分自身と比較
 }
 
-/*!
- * @brief 等価演算子のテスト
- *  自分自身との等価比較を行う
- */
-TEST(MYDEVMODETest, operatorEqualBySelf)
-{
-	// 初期値はなんでもよいが一応指定しておく
-	MYDEVMODE value = myDevMode;
-
-	EXPECT_TRUE(value == value);
-	EXPECT_FALSE(value != value);
-	ASSERT_EQ(value, value);
-}
-
-/*!
- * @brief 等価演算子のテスト
- *  memcpyでメンバが割当たっていない領域を含めてコピーし、等価比較を行う
- */
-TEST(MYDEVMODETest, operatorEqualByMemCpy)
-{
-	// デフォルトで初期化
-	MYDEVMODE value;
-
-	// メモリ領域全体をコピーしてまったく同じにする
-	assert(sizeof(value) == sizeof(myDevMode));
-	::memcpy_s(&value, sizeof(value), &myDevMode, sizeof(myDevMode));
-
-	EXPECT_TRUE(value == myDevMode);
-	EXPECT_FALSE(value != myDevMode);
-	ASSERT_EQ(myDevMode, value);
-}
 
 /*!
  * @brief 否定の等価演算子のテスト
@@ -122,228 +86,132 @@ TEST(MYDEVMODETest, operatorEqualByMemCpy)
  */
 TEST(MYDEVMODETest, operatorNotEqual)
 {
-	// デフォルトで初期化
-	MYDEVMODE value;
+	MYDEVMODE value = myDevMode;
+	ASSERT_EQ(myDevMode, value);
 
-	// メモリ領域全体をコピーしてまったく同じにする
-	assert(sizeof(value) == sizeof(myDevMode));
-	::memcpy_s(&value, sizeof(value), &myDevMode, sizeof(myDevMode));
-
-	EXPECT_TRUE(value == myDevMode);
-	EXPECT_EQ(myDevMode, value);
-
-	value.m_bPrinterNotFound = TRUE;
-	EXPECT_NE(myDevMode, value);
+	value.m_bPrinterNotFound = ! myDevMode.m_bPrinterNotFound;
+	ASSERT_NE(myDevMode, value);
 	value.m_bPrinterNotFound = myDevMode.m_bPrinterNotFound;
-	EXPECT_EQ(myDevMode, value);
 
-	::wcscpy_s(value.m_szPrinterDriverName, L"PrinterDriverName");
-	EXPECT_NE(myDevMode, value);
-	::wcscpy_s(value.m_szPrinterDriverName, myDevMode.m_szPrinterDriverName);
-	EXPECT_EQ(myDevMode, value);
+	value.m_szPrinterDriverName[0] = myDevMode.m_szPrinterDriverName[0]+1;
+	ASSERT_NE(myDevMode, value);
+	value.m_szPrinterDriverName[0] = myDevMode.m_szPrinterDriverName[0];
 
-	::wcscpy_s(value.m_szPrinterDeviceName, L"PrinterDeviceName");
-	EXPECT_NE(myDevMode, value);
-	::wcscpy_s(value.m_szPrinterDeviceName, myDevMode.m_szPrinterDeviceName);
-	EXPECT_EQ(myDevMode, value);
+	value.m_szPrinterDeviceName[0] = myDevMode.m_szPrinterDeviceName[0]+1;
+	ASSERT_NE(myDevMode, value);
+	value.m_szPrinterDeviceName[0] = myDevMode.m_szPrinterDeviceName[0];
 
-	::wcscpy_s(value.m_szPrinterOutputName, L"PrinterOutputName");
-	EXPECT_NE(myDevMode, value);
-	::wcscpy_s(value.m_szPrinterOutputName, myDevMode.m_szPrinterOutputName);
-	EXPECT_EQ(myDevMode, value);
+	value.m_szPrinterOutputName[0] = myDevMode.m_szPrinterOutputName[0]+1;
+	ASSERT_NE(myDevMode, value);
+	value.m_szPrinterOutputName[0] = myDevMode.m_szPrinterOutputName[0];
 
-	value.dmFields = std::numeric_limits<decltype(value.dmFields)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmFields = myDevMode.dmFields+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmFields = myDevMode.dmFields;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmOrientation = std::numeric_limits<decltype(value.dmOrientation)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmOrientation = myDevMode.dmOrientation+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmOrientation = myDevMode.dmOrientation;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmPaperSize = std::numeric_limits<decltype(value.dmPaperSize)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmPaperSize = myDevMode.dmPaperSize+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmPaperSize = myDevMode.dmPaperSize;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmPaperLength = std::numeric_limits<decltype(value.dmPaperLength)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmPaperLength = myDevMode.dmPaperLength+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmPaperLength = myDevMode.dmPaperLength;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmPaperWidth = std::numeric_limits<decltype(value.dmPaperWidth)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmPaperWidth = myDevMode.dmPaperWidth+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmPaperWidth = myDevMode.dmPaperWidth;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmScale = std::numeric_limits<decltype(value.dmScale)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmScale = myDevMode.dmScale+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmScale = myDevMode.dmScale;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmCopies = std::numeric_limits<decltype(value.dmCopies)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmCopies = myDevMode.dmCopies+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmCopies = myDevMode.dmCopies;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmDefaultSource = std::numeric_limits<decltype(value.dmDefaultSource)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmDefaultSource = myDevMode.dmDefaultSource+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmDefaultSource = myDevMode.dmDefaultSource;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmPrintQuality = std::numeric_limits<decltype(value.dmPrintQuality)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmPrintQuality = myDevMode.dmPrintQuality+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmPrintQuality = myDevMode.dmPrintQuality;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmColor = std::numeric_limits<decltype(value.dmColor)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmColor = myDevMode.dmColor+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmColor = myDevMode.dmColor;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmDuplex = std::numeric_limits<decltype(value.dmDuplex)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmDuplex = myDevMode.dmDuplex+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmDuplex = myDevMode.dmDuplex;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmYResolution = std::numeric_limits<decltype(value.dmYResolution)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmYResolution = myDevMode.dmYResolution+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmYResolution = myDevMode.dmYResolution;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmTTOption = std::numeric_limits<decltype(value.dmTTOption)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmTTOption = myDevMode.dmTTOption+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmTTOption = myDevMode.dmTTOption;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmCollate = std::numeric_limits<decltype(value.dmCollate)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmCollate = myDevMode.dmCollate+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmCollate = myDevMode.dmCollate;
-	EXPECT_EQ(myDevMode, value);
 
-	::wcscpy_s(value.dmFormName, L"FormName");
-	EXPECT_NE(myDevMode, value);
-	::wcscpy_s(value.dmFormName, myDevMode.dmFormName);
-	EXPECT_EQ(myDevMode, value);
+	value.dmFormName[0] = myDevMode.dmFormName[0]+1;
+	ASSERT_NE(myDevMode, value);
+	value.dmFormName[0] = myDevMode.dmFormName[0];
 
-	value.dmLogPixels = std::numeric_limits<decltype(value.dmLogPixels)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmLogPixels = myDevMode.dmLogPixels+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmLogPixels = myDevMode.dmLogPixels;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmBitsPerPel = std::numeric_limits<decltype(value.dmBitsPerPel)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmBitsPerPel = myDevMode.dmBitsPerPel+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmBitsPerPel = myDevMode.dmBitsPerPel;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmPelsWidth = std::numeric_limits<decltype(value.dmPelsWidth)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmPelsWidth = myDevMode.dmPelsWidth+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmPelsWidth = myDevMode.dmPelsWidth;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmPelsHeight = std::numeric_limits<decltype(value.dmPelsHeight)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmPelsHeight = myDevMode.dmPelsHeight+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmPelsHeight = myDevMode.dmPelsHeight;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmDisplayFlags = std::numeric_limits<decltype(value.dmDisplayFlags)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmDisplayFlags = myDevMode.dmDisplayFlags+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmDisplayFlags = myDevMode.dmDisplayFlags;
-	EXPECT_EQ(myDevMode, value);
 
-	value.dmDisplayFrequency = std::numeric_limits<decltype(value.dmDisplayFrequency)>::max();
-	EXPECT_NE(myDevMode, value);
+	value.dmDisplayFrequency = myDevMode.dmDisplayFrequency+1;
+	ASSERT_NE(myDevMode, value);
 	value.dmDisplayFrequency = myDevMode.dmDisplayFrequency;
-	EXPECT_EQ(myDevMode, value);
 }
 
 /*!
- * @brief 否定の等価演算子のテスト
- *  文字列メンバの末尾(通常はNUL文字)が異なるパターンを検出できるかチェックする
+ * @brief 文字列メンバに関する比較演算子のテスト
+ *  バッファ長と文字列長が一致するようなエッジケースの確認
  */
-TEST(MYDEVMODETest, operatorNotEqualAntiLazyCode)
+TEST(MYDEVMODETest, stringMemberComparisonEdgeCase)
 {
-	// デフォルトで初期化
+	// memset で初期化する(手抜き)。
+	// value と other はアドレス以外同一。
+	// ４つの文字列メンバにヌル終端はない。
 	MYDEVMODE value, other;
+	memset(&value, 'a', sizeof value);
+	memset(&other, 'a', sizeof other);
+	ASSERT_EQ(value, other); // 下手な文字列比較をしているとアクセス違反を起こすかも(起こしてはいけない)。
 
-	// スタック変数のアドレスをchar*にキャストしてデータを書き替える
-	char* buf1 = reinterpret_cast<char*>(&value);
-	::memset(buf1, 'a', sizeof(MYDEVMODE));
-	char* buf2 = reinterpret_cast<char*>(&other);
-	::memset(buf2, 'a', sizeof(MYDEVMODE));
+	// 一方の文字列バッファの末尾をNUL終端する。
+	value.m_szPrinterDriverName[_countof(value.m_szPrinterDriverName)-1] =
+	value.m_szPrinterDeviceName[_countof(value.m_szPrinterDeviceName)-1] =
+	value.m_szPrinterOutputName[_countof(value.m_szPrinterOutputName)-1] =
+	value.dmFormName[_countof(value.dmFormName)-1] = L'0';
 
-	// まったく同じなので等価になる
-	EXPECT_TRUE(value == other);
-	EXPECT_FALSE(value != other);
-	EXPECT_EQ(other, value);
-
-	// 文字列メンバをNUL終端する
-	value.m_szPrinterDriverName[_countof(value.m_szPrinterDriverName) - 1] = 0;
-
-	// NUL終端された文字列 != NUL終端されてない文字列、となるはず。
-	EXPECT_FALSE(value == other);
-	EXPECT_TRUE(value != other);
-	EXPECT_NE(other, value);
-}
-
-/*!
- * @brief 等価比較演算子が一般保護違反を犯さないことを保証する非機能要件テスト
- *
- *  通常、ここまでやる必要はないが、修正の理由が「安全のため」なので、
- *  実際にどういうケースで一般保護例外違反となるか、コード的に発生させる方法の共有を兼ねて実装したもの。
- */
-TEST(MYDEVMODETest, StrategyForSegmentationFault)
-{
-	// システムのページサイズを取得する
-	SYSTEM_INFO systemInfo = { 0 };
-	::GetSystemInfo(&systemInfo);
-
-	// システムページサイズ
-	const auto pageSize = systemInfo.dwPageSize;
-	// 確保領域サイズ(2ページ分)
-	const auto allocSize = pageSize * 2;
-
-	// 仮想メモリ範囲を予約する。予約時点では全体をNOACCESS指定にしておく。
-	LPVOID memBlock1 = ::VirtualAlloc(NULL, allocSize, MEM_RESERVE, PAGE_NOACCESS);
-	EXPECT_TRUE(memBlock1 != NULL);
-
-	// 仮想メモリ全域をコミット(=確保)する。
-	wchar_t* buf1 = static_cast<wchar_t*>(::VirtualAlloc(memBlock1, allocSize, MEM_COMMIT, PAGE_READWRITE));
-	EXPECT_TRUE(buf1 != NULL);
-
-	// 確保したメモリ全域をASCII文字'a'で埋める
-	::wmemset(buf1, L'a', pageSize);
-
-	// 2ページ目の保護モードをNOACCESSにする。
-	DWORD flOldProtect = 0;
-	volatile BOOL retVirtualProtect = ::VirtualProtect((char*)buf1 + pageSize, pageSize, PAGE_NOACCESS, &flOldProtect);
-	EXPECT_TRUE(retVirtualProtect);
-
-	// メモリデータをテスト対象型にマップする。実態として配列のように扱えるポインタを取得している。
-	MYDEVMODE* pValues = reinterpret_cast<MYDEVMODE*>(buf1);
-
-	// 例外判定用の巨大な文字列を作る。これは2ページ分のサイズを持つ巨大データ。
-	std::wstring largeString(pageSize, L'a');
-	const auto pLargeStr = largeString.c_str();
-
-	/* DEATHテストで例外ケースの判定を行う。
-	 * pLargeStrには、コミットサイズの倍のデータが入っているので、
-	 * 単純にstrcmpするとreserveしただけの領域にアクセスしてしまい一般保護違反(access violation)が起きる。
-	 *
-	 * 想定結果：一般保護違反で落ちる
-	 * 備考：例外メッセージは無視する(例外が起きたことが検知できればよいから。)
-	 */
-	volatile int ret = 0;
-	ASSERT_DEATH({ ret = ::wcscmp(pValues[0].m_szPrinterDeviceName, pLargeStr); }, ".*");
-	(void)ret;
-
-	// 等価比較演算子を使った場合には落ちないことを確認する
-	EXPECT_TRUE(pValues[0] == pValues[1]);
-	EXPECT_FALSE(pValues[0] != pValues[1]);
-
-	// 仮想メモリをデコミット(=解放)する。
-	::VirtualFree((LPVOID)buf1, pageSize, MEM_DECOMMIT);
-	// 仮想メモリ範囲を解放する。
-	::VirtualFree(memBlock1, 0, MEM_RELEASE);
+	// ヌル終端があるべき場所にある文字の違いにより
+	// 構造体が異なると判断されるなら、比較演算子は読み過ぎている。
+	// 逆に、そこが無視できているならアクセス違反を起こすようなミスはない。
+	ASSERT_EQ(value, other);
 }


### PR DESCRIPTION
日本語では無理だったが C++ でなら理解されるかも、という「[奇妙な](https://github.com/sakura-editor/sakura/pull/1079#issuecomment-557867893)」期待は持っていませんが、PR #1079 のコメント欄に散々書いたことの C++ 版です。

もう何度目かになる内容ですが、PR の概要です。

1. これはすでにマージされた PR #877 と PR #1079 を追って出す PR です。
2. #877 と #1079 にはともに MYDEVMODE 構造体の比較演算に関する実装コードとテストコードが含まれています。
3. #1079 で加えられた実装の修正を取り消し、#877 の実装を回復します。
4. 両方の PR に含まれていたテストの枠と構成を借用しましたが、
	1. 冗長な記述を簡素化しました。
	2. (時間がかかるらしい)デステストを廃止しました。ASSERT_DEATH はテストコードがアクセス違反を起こせることをテストするために存在していましたが、実際にアクセス違反を起こさなくてもテストはできます。
	3. テストが確かめる仕様を整合性のあるものに改めました。

### 「整合性」について

MYDEVMODE の文字列メンバの入出力コードを見たところ、読み込みでも書き込みでもヌル終端されないケースは想定していないようでした。「落ちる」と書いてありましたし、実際に読み書き共に落ちたり暴走したりしそうでした。

ここから理解されることは、文字列メンバがヌル終端されないケースは即刻死につながる、徹底的に排除されるべき例外的状況だということです。入出力コードが実質的な assert として機能します。

#1079 のテストが規定する仕様と、当初は「[気がついていませんでした](https://github.com/sakura-editor/sakura/pull/1079#issuecomment-557451117)」が #877 にも織り込まれていた仕様を「悪しき仕様」と呼ぶ理由について(これまた何度目かになりますが)書きます。

#1079 に含まれるテストのすべてと、#877 に含まれる一部のテストは、**文字列メンバがヌル終端されていない状況を温存し、尊重しなければ通らない** ものになっています。文字列メンバがヌル終端文字列であるという、かつては存在していた前提を捨てさせることを要求するものになっています。

そのような要求は先ほど挙げた入出力コードと整合しませんし、テストの存在が枷となって、例外的状況を排除するような将来の改善(たとえばヌル終端を書き込んで長すぎる文字列を切り詰めるような処理)を妨げます。

----

私は #1079 には疑問を付けましたが、#877 は実装もテストもそのままの形で生き残るものだと最後まで思っていました。「[悪しき仕様がテストに織り込まれていた](https://github.com/sakura-editor/sakura/pull/1079#issuecomment-557451117)」と気がつくまでは。

#877 とは違い、#1079 は「[何をしても落ちない](https://github.com/sakura-editor/sakura/pull/1079#issuecomment-557766206)」ことを助ける内容ではありません。勘違いは「しょうがない」ことかもしれませんが、他人の責任までは負えません。
