### PR TITLE
std::swapを特殊化するのをやめる

### DIFF
--- a/sakura_core/COpe.h
+++ b/sakura_core/COpe.h
@@ -13,6 +13,10 @@
 
 #pragma once
 
+#include <vector>
+
+#include "mem/CNativeW.h"
+
 //! アンドゥバッファ用 操作コード
 enum EOpeCode {
 	OPE_UNKNOWN		= 0, //!< 不明(未使用)
@@ -22,23 +26,25 @@ enum EOpeCode {
 	OPE_MOVECARET	= 4, //!< キャレット移動
 };
 
-class CLineData {
+class CLineData final {
 public:
 	CNativeW cmemLine;
 	int nSeq;
-	void swap(CLineData& o){
+	CLineData() = default;
+	CLineData(const CLineData& source) = default;
+	CLineData(CLineData&& other) noexcept {
+		swap(other);
+	}
+	void swap(CLineData& o) noexcept {
 		std::swap(cmemLine, o.cmemLine);
 		std::swap(nSeq, o.nSeq);
 	}
-};
-
-namespace std {
-template <>
-	inline void swap(CLineData& n1, CLineData& n2)
-	{
-		n1.swap(n2);
+	CLineData& operator = (const CLineData& rhs) = default;
+	CLineData& operator = (CLineData&& rhs) noexcept {
+		swap(rhs);
+		return *this;
 	}
-}
+};
 
 typedef std::vector<CLineData> COpeLineData;
 

--- a/sakura_core/COpe.h
+++ b/sakura_core/COpe.h
@@ -35,10 +35,14 @@ public:
 	CLineData(CLineData&& other) noexcept {
 		swap(other);
 	}
+
+private:
 	void swap(CLineData& o) noexcept {
 		std::swap(cmemLine, o.cmemLine);
 		std::swap(nSeq, o.nSeq);
 	}
+
+public:
 	CLineData& operator = (const CLineData& rhs) = default;
 	CLineData& operator = (CLineData&& rhs) noexcept {
 		swap(rhs);

--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -900,8 +900,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 			++(pArg->nDeletedLineNum);
 			/* 行オブジェクトの削除、リスト変更、行数-- */
 			if( pArg->pcmemDeleted ){
-				pArg->pcmemDeleted->emplace_back(CLineData());
-				CLineData& delLine = pArg->pcmemDeleted->back();
+				CLineData& delLine = pArg->pcmemDeleted->emplace_back(CLineData());
 				delLine.cmemLine.swap(pCDocLine->_GetDocLineData()); // CDocLine書き換え
 				delLine.nSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLine);
 			}
@@ -915,14 +914,12 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 					// 1行以内の行末削除のときだけ、次の行のseqが保存されないので必要
 					// 2014.01.07 最後が改行の範囲を最後が改行のデータで置換した場合を変更
 					if( !bLastEOLReplace ){
-						pArg->pcmemDeleted->emplace_back(CLineData());
-						CLineData& delLine =  pArg->pcmemDeleted->back();
+						CLineData& delLine = pArg->pcmemDeleted->emplace_back(CLineData());
 						delLine.cmemLine.SetString(L"");
 						delLine.nSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLineNext);
 					}
 				}
-				pArg->pcmemDeleted->emplace_back(CLineData());
-				CLineData& delLine = pArg->pcmemDeleted->back();
+				CLineData& delLine = pArg->pcmemDeleted->emplace_back(CLineData());
 				delLine.cmemLine.SetString(&pLine[nWorkPos], nWorkLen);
 				delLine.nSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLine);
 			}
@@ -999,8 +996,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 		else{
 			/* 行内だけの削除 */
 			if( pArg->pcmemDeleted ){
-				pArg->pcmemDeleted->emplace_back(CLineData());
-				CLineData& delLine =  pArg->pcmemDeleted->back();
+				CLineData& delLine = pArg->pcmemDeleted->emplace_back(CLineData());
 				delLine.cmemLine.SetString(&pLine[nWorkPos], nWorkLen);
 				delLine.nSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLine);
 			}

--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -900,8 +900,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 			++(pArg->nDeletedLineNum);
 			/* 行オブジェクトの削除、リスト変更、行数-- */
 			if( pArg->pcmemDeleted ){
-				CLineData tmp;
-				pArg->pcmemDeleted->push_back(tmp);
+				pArg->pcmemDeleted->emplace_back(CLineData());
 				CLineData& delLine = pArg->pcmemDeleted->back();
 				delLine.cmemLine.swap(pCDocLine->_GetDocLineData()); // CDocLine書き換え
 				delLine.nSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLine);
@@ -916,15 +915,13 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 					// 1行以内の行末削除のときだけ、次の行のseqが保存されないので必要
 					// 2014.01.07 最後が改行の範囲を最後が改行のデータで置換した場合を変更
 					if( !bLastEOLReplace ){
-						CLineData tmp;
-						pArg->pcmemDeleted->push_back(tmp);
+						pArg->pcmemDeleted->emplace_back(CLineData());
 						CLineData& delLine =  pArg->pcmemDeleted->back();
 						delLine.cmemLine.SetString(L"");
 						delLine.nSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLineNext);
 					}
 				}
-				CLineData tmp;
-				pArg->pcmemDeleted->push_back(tmp);
+				pArg->pcmemDeleted->emplace_back(CLineData());
 				CLineData& delLine = pArg->pcmemDeleted->back();
 				delLine.cmemLine.SetString(&pLine[nWorkPos], nWorkLen);
 				delLine.nSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLine);
@@ -1002,8 +999,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 		else{
 			/* 行内だけの削除 */
 			if( pArg->pcmemDeleted ){
-				CLineData tmp;
-				pArg->pcmemDeleted->push_back(tmp);
+				pArg->pcmemDeleted->emplace_back(CLineData());
 				CLineData& delLine =  pArg->pcmemDeleted->back();
 				delLine.cmemLine.SetString(&pLine[nWorkPos], nWorkLen);
 				delLine.nSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLine);

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -154,12 +154,4 @@ public:
 // 派生クラスでメンバー追加禁止
 static_assert(sizeof(CNativeW) == sizeof(CNative), "size check");
 
-namespace std {
-template <>
-	inline void swap(CNativeW& n1, CNativeW& n2)
-	{
-		n1.swap(n2);
-	}
-}
-
 /*[EOF]*/

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -47,16 +47,14 @@ static void StringToOpeLineData(const wchar_t* pLineData, int nLineDataLen, COpe
 			if( i + 1 < nLineDataLen && WCODE::CR == pLineData[i] && WCODE::LF == pLineData[i + 1] ){
 				i++;
 			}
-			lineData.emplace_back(CLineData());
-			CLineData& insertLine = lineData[lineData.size()-1];
+			CLineData& insertLine = lineData.emplace_back(CLineData());
 			insertLine.cmemLine.SetString(&pLineData[nBegin], i - nBegin + 1);
 			insertLine.nSeq = opeSeq;
 			nBegin = i + 1;
 		}
 	}
 	if( nBegin < i ){
-		lineData.emplace_back(CLineData());
-		CLineData& insertLine = lineData[lineData.size()-1];
+		CLineData& insertLine = lineData.emplace_back(CLineData());
 		insertLine.cmemLine.SetString(&pLineData[nBegin], nLineDataLen - nBegin);
 		insertLine.nSeq = opeSeq;
 	}

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -47,8 +47,7 @@ static void StringToOpeLineData(const wchar_t* pLineData, int nLineDataLen, COpe
 			if( i + 1 < nLineDataLen && WCODE::CR == pLineData[i] && WCODE::LF == pLineData[i + 1] ){
 				i++;
 			}
-			CLineData tmp;
-			lineData.push_back(tmp);
+			lineData.emplace_back(CLineData());
 			CLineData& insertLine = lineData[lineData.size()-1];
 			insertLine.cmemLine.SetString(&pLineData[nBegin], i - nBegin + 1);
 			insertLine.nSeq = opeSeq;
@@ -56,8 +55,7 @@ static void StringToOpeLineData(const wchar_t* pLineData, int nLineDataLen, COpe
 		}
 	}
 	if( nBegin < i ){
-		CLineData tmp;
-		lineData.push_back(tmp);
+		lineData.emplace_back(CLineData());
 		CLineData& insertLine = lineData[lineData.size()-1];
 		insertLine.cmemLine.SetString(&pLineData[nBegin], nLineDataLen - nBegin);
 		insertLine.nSeq = opeSeq;


### PR DESCRIPTION
# PR の目的
std::swapを特殊化するのをやめて実装をシンプルにする

## カテゴリ
- その他

## PR の背景
ソースコードを眺めていたら、こういう状態になってるのを見つけました。
（構文エラーの印がめっちゃ付いてます！）
![2019-11-30 (1)](https://user-images.githubusercontent.com/3253151/69901494-b686e400-13c5-11ea-846e-7c2bf9d0d8fd.png)

**なんでやねんっ！** と思って原因を調べてみました。

- `CNativeW` を定義するヘッダーをインクルードしてない。
- `std::swap` を定義するヘッダーをインクルードしてない。
- **`std::swap` の特殊化定義でシグニチャが現行のシグニチャと異なっている。**
- `std::vector` を定義するヘッダーをインクルードしてない。

PRでは問題点全部に対応しているんですが、重点対応ポイントはstd::swapの特殊化です。

[std::swapのマニュアル](https://cpprefjp.github.io/reference/utility/swap.html) とかを見ると分かるんですが、最近のstd::swapはnoexceptです。
c++17の仕様変更でライブラリのシグニチャが変更されたっぽいです。

で、まぁ今回あらためて `std::swap` の仕様を確認してみたわけです。

> 要件
> 値版：型TはMoveConstructibleかつMoveAssignableでなければならない。

うむ、そうだったのか・・・。

`std::swap` の要件ってのは、 **これを満たせば特殊化実装要らない** ってことらしいです。

・・・。

え？　**特殊化実装要らない** ？ 

というわけで、今回は従来とアプローチを変えて
1. MoveConstractible にする
2. MoveAssignable にする

で攻めてみることにしました。

`std::swap` の特殊化は CNativeW でも行われているんですが、そちらは既にムーバブルフレーム換装済みなので `std::swap` の除去だけする感じです。

## PR のメリット
- ソースコードがちょっとスッキリします。

## PR のデメリット (トレードオフとかあれば)
- 「何がどう変わる」系の具体的な修正じゃないです。
- 多少 c++17 規格に準拠する（のか？）程度の修正なので、触んない方がいいのかもしれません。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。

## 関連チケット
#989 C++の準拠規格をC++17に更新する

## 参考資料
https://cpprefjp.github.io/reference/utility/swap.html
https://cpprefjp.github.io/lang/cpp17.html
