### PR TITLE
MYDEVMODE 構造体の使われていないメンバを削除

### DIFF
--- a/sakura_core/config/system_constants.h
+++ b/sakura_core/config/system_constants.h
@@ -541,12 +541,15 @@
 	Version 175:
 	Vistaスタイルのファイルダイアログ（CommonSetting_Edit::m_bVistaStyleFileDialog）を追加
 
+	Version 176:
+	MYDEVMODE の未使用メンバを削除した為、PRINTSETTING や DLLSHAREDATA のメモリレイアウトが変更
+
 	-- 統合されたので元に戻す（1000～1023が使用済み） 	2008.11.16 nasukoji
 	-- Version 1000:
 	-- バージョン1000以降を本家統合までの間、使わせてください。かなり頻繁に構成が変更されると思われるので。by kobake 2008.03.02
 
 */
-#define N_SHAREDATA_VERSION		175
+#define N_SHAREDATA_VERSION		176
 #define STR_SHAREDATA_VERSION	NUM_TO_STR(N_SHAREDATA_VERSION)
 #define	GSTR_SHAREDATA	(L"SakuraShareData" _T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_) _T(STR_SHAREDATA_VERSION))
 

--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -44,22 +44,6 @@ struct	MYDEVMODE {
 	short	dmPaperSize;
 	short	dmPaperLength;
 	short	dmPaperWidth;
-	short	dmScale;
-	short	dmCopies;
-	short	dmDefaultSource;
-	short	dmPrintQuality;
-	short	dmColor;
-	short	dmDuplex;
-	short	dmYResolution;
-	short	dmTTOption;
-	short	dmCollate;
-	BCHAR	dmFormName[CCHFORMNAME];
-	WORD	dmLogPixels;
-	DWORD	dmBitsPerPel;
-	DWORD	dmPelsWidth;
-	DWORD	dmPelsHeight;
-	DWORD	dmDisplayFlags;
-	DWORD	dmDisplayFrequency;
 
 	//! 等価比較演算子
 	bool operator == (const MYDEVMODE& rhs) const noexcept {
@@ -73,22 +57,7 @@ struct	MYDEVMODE {
 			&& dmPaperSize == rhs.dmPaperSize
 			&& dmPaperLength == rhs.dmPaperLength
 			&& dmPaperWidth == rhs.dmPaperWidth
-			&& dmScale == rhs.dmScale
-			&& dmCopies == rhs.dmCopies
-			&& dmDefaultSource == rhs.dmDefaultSource
-			&& dmPrintQuality == rhs.dmPrintQuality
-			&& dmColor == rhs.dmColor
-			&& dmDuplex == rhs.dmDuplex
-			&& dmYResolution == rhs.dmYResolution
-			&& dmTTOption == rhs.dmTTOption
-			&& dmCollate == rhs.dmCollate
-			&& 0 == wcsncmp(dmFormName, rhs.dmFormName, _countof(dmFormName))
-			&& dmLogPixels == rhs.dmLogPixels
-			&& dmBitsPerPel == rhs.dmBitsPerPel
-			&& dmPelsWidth == rhs.dmPelsWidth
-			&& dmPelsHeight == rhs.dmPelsHeight
-			&& dmDisplayFlags == rhs.dmDisplayFlags
-			&& dmDisplayFrequency == rhs.dmDisplayFrequency;
+			;
 	}
 	//! 否定の等価比較演算子
 	bool operator != (const MYDEVMODE& rhs) const noexcept {

--- a/tests/unittests/test-mydevmode.cpp
+++ b/tests/unittests/test-mydevmode.cpp
@@ -50,22 +50,6 @@ static constexpr MYDEVMODE myDevMode = {
 	std::numeric_limits<short>::min(), //short	dmPaperSize;
 	std::numeric_limits<short>::min(), //short	dmPaperLength;
 	std::numeric_limits<short>::min(), //short	dmPaperWidth;
-	std::numeric_limits<short>::min(), //short	dmScale;
-	std::numeric_limits<short>::min(), //short	dmCopies;
-	std::numeric_limits<short>::min(), //short	dmDefaultSource;
-	std::numeric_limits<short>::min(), //short	dmPrintQuality;
-	std::numeric_limits<short>::min(), //short	dmColor;
-	std::numeric_limits<short>::min(), //short	dmDuplex;
-	std::numeric_limits<short>::min(), //short	dmYResolution;
-	std::numeric_limits<short>::min(), //short	dmTTOption;
-	std::numeric_limits<short>::min(), //short	dmCollate;
-	{L"dmFormName"}, //BCHAR	dmFormName[CCHFORMNAME];
-	std::numeric_limits<WORD>::min(), //WORD	dmLogPixels;
-	std::numeric_limits<DWORD>::min(), //DWORD	dmBitsPerPel;
-	std::numeric_limits<DWORD>::min(), //DWORD	dmPelsWidth;
-	std::numeric_limits<DWORD>::min(), //DWORD	dmPelsHeight;
-	std::numeric_limits<DWORD>::min(), //DWORD	dmDisplayFlags;
-	std::numeric_limits<DWORD>::min(), //DWORD	dmDisplayFrequency;
 };
 
 /*!
@@ -175,86 +159,6 @@ TEST(MYDEVMODETest, operatorNotEqual)
 	value.dmPaperWidth = std::numeric_limits<decltype(value.dmPaperWidth)>::max();
 	EXPECT_NE(myDevMode, value);
 	value.dmPaperWidth = myDevMode.dmPaperWidth;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmScale = std::numeric_limits<decltype(value.dmScale)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmScale = myDevMode.dmScale;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmCopies = std::numeric_limits<decltype(value.dmCopies)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmCopies = myDevMode.dmCopies;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmDefaultSource = std::numeric_limits<decltype(value.dmDefaultSource)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmDefaultSource = myDevMode.dmDefaultSource;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmPrintQuality = std::numeric_limits<decltype(value.dmPrintQuality)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmPrintQuality = myDevMode.dmPrintQuality;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmColor = std::numeric_limits<decltype(value.dmColor)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmColor = myDevMode.dmColor;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmDuplex = std::numeric_limits<decltype(value.dmDuplex)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmDuplex = myDevMode.dmDuplex;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmYResolution = std::numeric_limits<decltype(value.dmYResolution)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmYResolution = myDevMode.dmYResolution;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmTTOption = std::numeric_limits<decltype(value.dmTTOption)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmTTOption = myDevMode.dmTTOption;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmCollate = std::numeric_limits<decltype(value.dmCollate)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmCollate = myDevMode.dmCollate;
-	EXPECT_EQ(myDevMode, value);
-
-	::wcscpy_s(value.dmFormName, L"FormName");
-	EXPECT_NE(myDevMode, value);
-	::wcscpy_s(value.dmFormName, myDevMode.dmFormName);
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmLogPixels = std::numeric_limits<decltype(value.dmLogPixels)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmLogPixels = myDevMode.dmLogPixels;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmBitsPerPel = std::numeric_limits<decltype(value.dmBitsPerPel)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmBitsPerPel = myDevMode.dmBitsPerPel;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmPelsWidth = std::numeric_limits<decltype(value.dmPelsWidth)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmPelsWidth = myDevMode.dmPelsWidth;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmPelsHeight = std::numeric_limits<decltype(value.dmPelsHeight)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmPelsHeight = myDevMode.dmPelsHeight;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmDisplayFlags = std::numeric_limits<decltype(value.dmDisplayFlags)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmDisplayFlags = myDevMode.dmDisplayFlags;
-	EXPECT_EQ(myDevMode, value);
-
-	value.dmDisplayFrequency = std::numeric_limits<decltype(value.dmDisplayFrequency)>::max();
-	EXPECT_NE(myDevMode, value);
-	value.dmDisplayFrequency = myDevMode.dmDisplayFrequency;
 	EXPECT_EQ(myDevMode, value);
 }
 


### PR DESCRIPTION
# PR の目的

実質的に使われていないメンバを削除する事でコード量を削減するのが目的です。

## カテゴリ

- その他

## PR のメリット

コード量が減るのでコードの見通しが良くなります。

## PR のデメリット (トレードオフとかあれば)

このPRで削除するメンバ変数は将来的に利用を予定していたものかもしれません。

将来的に誰かがそのメンバを使って機能拡張する際に少し面倒くさくなるかもしれません。

## PR の影響範囲

等値比較オペレータやテストコードに影響があります。それ以外では未参照のメンバなので実質的にアプリの動作に影響は無いと思います。もし有る場合は消したらまずいという事なので指摘お願いします。
