### PR TITLE
ヘルプ中のスタイルシートでセミコロンの指定の誤りによる Code Factor の警告を修正する

### DIFF
--- a/help/sakura/res/HLP000089.html
+++ b/help/sakura/res/HLP000089.html
@@ -12,7 +12,7 @@
 <META NAME="MS-HKWD" CONTENT="量指定子">
 <!-- .がみにくいのでMS ゴシックにする -->
 <style type="text/css">
-	code {font-family: "ＭＳ ゴシック"; font-size:100%};
+	code {font-family: "ＭＳ ゴシック"; font-size:100%;}
 </style>
 </HEAD>
 <BODY>


### PR DESCRIPTION
# PR の目的

ヘルプ中のスタイルシートでセミコロンの指定の誤りによる Code Factor の警告を修正する

## カテゴリ

- ドキュメント修正

## PR の背景

https://github.com/sakura-editor/sakura-editor.github.io/issues/22 の誤りを修正するために
https://github.com/sakura-editor/sakura-editor.github.io/issues/52 を投げたが、
Code Factor の警告が検出された。

## PR のメリット

Code Factor の警告が修正される。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

## 関連チケット

https://github.com/sakura-editor/sakura-editor.github.io/issues/52

## 参考資料

https://www.codefactor.io/repository/github/sakura-editor/sakura-editor.github.io/pull/51
