### PR TITLE
visual studio用テストカバレッジ設定を追加

### DIFF
--- a/tests/unittests/coverage.cpp
+++ b/tests/unittests/coverage.cpp
@@ -1,0 +1,32 @@
+/*! @file */
+/*
+	Copyright (C) 2018-2019 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <CodeCoverage\CodeCoverage.h>
+
+// Exclude all the code from a particular files:
+// see https://docs.microsoft.com/ja-jp/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested
+ExcludeSourceFromCodeCoverage(Exclusion1, L"*\\tests\\unittests\\*");
+ExcludeSourceFromCodeCoverage(Exclusion2, L"*\\tests\\googletest\\googletest\\*");
+ExcludeSourceFromCodeCoverage(Exclusion3, L"*\\Windows Kits\\10\\Include\\*\\winrt\\wrl\\client.h");
+ExcludeSourceFromCodeCoverage(Exclusion4, L"*\\VC\\Tools\\MSVC\\*\\include\\*");

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -116,6 +116,9 @@
   <ItemGroup>
     <Text Include="CMakeLists.txt" />
   </ItemGroup>
+  <ItemGroup Condition="Exists('$(VCInstallDir)\Auxiliary\VS\include\CodeCoverage\CodeCoverage.h')">
+    <ClCompile Include="coverage.cpp" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(ProjectDir)..\..\sakura\sakura.vcxproj">
       <Project>{af03508c-515e-4a0e-87be-67ed1e254bd0}</Project>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -44,5 +44,8 @@
     <ClCompile Include="test-StdControl.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="coverage.cpp">
+      <Filter>Other Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# PR の目的
tests1プロジェクトに visual studio 用テストカバレッジ設定を追加します。

## カテゴリ
- CI関連
  - Azure Pipelines
- その他

## PR の背景
visual studio には、実行したテストのカバレッジ（＝テストによるコード実行の網羅率）を計測する機能が搭載されています。

カバレッジ分析では、デフォルトでは実行されるテストプログラムの全ソースコードが対象になります。C++ネイティブテストには Windows SDK のインラインコード や googletest のコードも含まれているわけですが、これらの「自分たちで作っていないコード」のテスト網羅率が分かってもあまり嬉しくありません。結果的に「未テストのコードの割合」の中に「自分たちで作っていないコード」が含まれてしまうわけですから、できれば除外したいくらいです。

このPRでは、「自分たちで作っていないコード」をテストカバレッジ分析の対象から外すための設定ファイルを追加します。拡張子は.cppなんですけど、これは設定ファイルです。

カバレッジ分析が使えるのは visual studio Enterprise エディションのみらしいので、ほとんどの開発者にとって影響のない変更だと思います。が、CI環境として azure pipelines を採用している都合で、まったくの無関係とも言えない感じの変更になります。

## PR のメリット
- visual studio のカバレッジ分析を行った際に、sakura-editorと関係ないソースファイル(Windows SDKのインラインコードやgoogletestのコード、テストコード等) のカバレッジが除外されるようになります。
- azure pipelines の Microsoft hosted agent にインストールされている visual studio は enterprise エディション なので、テスト実行のオプションでカバレッジ分析を有効した場合にこのPRの恩恵を受けることができます。（現状は未実施、実施予定なし。

## PR のデメリット (トレードオフとかあれば)
- とくにありません。
- visual studio 2017 community 等のカバレッジ機能非対応エディションを使った場合には影響ありません。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。
- visual studio で テスト の カバレッジ分析 を行った場合の結果表示に影響します。
- Appveyor 環境には影響しません。
- azure pipelines 環境には当面影響しません。（カバレッジ分析を有効にしてないから。
- ローカルビルド環境には影響しないと思います。（人によっては影響するかも知れません。


## 関連チケット
ありません。

## 参考資料
- https://docs.microsoft.com/ja-jp/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested?view=vs-2019
- https://docs.microsoft.com/ja-jp/visualstudio/test/customizing-code-coverage-analysis?view=vs-2019
