### PR TITLE
#1117 で入れた修正のうち master に入れるべきではない修正を取り除いて取り込む

### DIFF
--- a/help/sakura/res/HLP000001.html
+++ b/help/sakura/res/HLP000001.html
@@ -15,7 +15,7 @@
 -->
 <br>
 <center><hr width = "350px"></center>
-<center>サクラエディタ   Ver 2.4.0 (ベータ版v3)</center>
+<center>サクラエディタ   Ver 2.4.0 (開発版)</center>
 <center>ヘルプファイル最終更新日 2019/12/21</center>
 <center><a href="https://sakura-editor.github.io/" target=_blank>https://sakura-editor.github.io/</a></center>
 <center><hr width = "350px"></center>

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -197,7 +197,7 @@ if "%APPVEYOR_REPO_NAME%" == "" (
 )
 
 @rem enable 'dev version' macro which will be disabled on release branches
-@rem echo #define APPVEYOR_DEV_VERSION
+echo #define APPVEYOR_DEV_VERSION
 
 if "%APPVEYOR_ACCOUNT_NAME%" == "" (
 	echo // APPVEYOR_ACCOUNT_NAME is not defined


### PR DESCRIPTION
# PR の目的

#1117 で入れた修正のうち master に入れるべきではない修正を取り除いて取り込む

release/v2.4.0-beta3 を master から分岐した feature ブランチにマージして不要な部分を手動で revert して、master にマージする。

## カテゴリ

- ドキュメント修正
- その他

## PR の背景

beta-3 をリリースしたが master のドキュメントが最新に更新されていないため

## PR のメリット

#1117 で入れた修正を master に取り込んでドキュメントを最新にする

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

ドキュメント

## 関連チケット

#1117

## 参考資料

