### PR TITLE
未初期化のout変数を参照しないため戻り値をチェックするようにする

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -1130,8 +1130,10 @@ int CGrepAgent::DoGrepFile(
 	bOutFileName = FALSE;
 	CEol	cEol;
 	int		nEolCodeLen;
-	const STypeConfigMini* type;
-	CDocTypeManager().GetTypeConfigMini( CDocTypeManager().GetDocumentTypeOfPath( pszFile ), &type );
+	const STypeConfigMini* type = NULL;
+	if( !CDocTypeManager().GetTypeConfigMini( CDocTypeManager().GetDocumentTypeOfPath( pszFile ), &type ) ){
+		return -1;
+	}
 	CFileLoad	cfl( type->m_encoding );	// 2012/12/18 Uchi 検査するファイルのデフォルトの文字コードを取得する様に
 	int		nOldPercent = 0;
 
@@ -1678,8 +1680,10 @@ int CGrepAgent::DoGrepReplaceFile(
 	int	nKeyLen = wcslen( pszKey );
 	const WCHAR*	pszCodeName = L"";
 
-	const STypeConfigMini* type;
-	CDocTypeManager().GetTypeConfigMini( CDocTypeManager().GetDocumentTypeOfPath( pszFile ), &type );
+	const STypeConfigMini* type = NULL;
+	if( !CDocTypeManager().GetTypeConfigMini( CDocTypeManager().GetDocumentTypeOfPath( pszFile ), &type ) ){
+		return -1;
+	}
 	CFileLoad	cfl( type->m_encoding );	// 2012/12/18 Uchi 検査するファイルのデフォルトの文字コードを取得する様に
 	bool bBom;
 	// ファイル名表示

--- a/sakura_core/CReadManager.cpp
+++ b/sakura_core/CReadManager.cpp
@@ -49,8 +49,10 @@ EConvertResult CReadManager::ReadFile_To_CDocLineMgr(
 	LPCWSTR pszPath = sLoadInfo.cFilePath.c_str();
 
 	// 文字コード種別
-	const STypeConfigMini* type;
-	CDocTypeManager().GetTypeConfigMini( sLoadInfo.nType, &type );
+	const STypeConfigMini* type = NULL;
+	if( !CDocTypeManager().GetTypeConfigMini( sLoadInfo.nType, &type ) ){
+		return RESULT_FAILURE;
+	}
 	ECodeType	eCharCode = sLoadInfo.eCharCode;
 	if (CODE_AUTODETECT == eCharCode) {
 		CCodeMediator cmediator( type->m_encoding );

--- a/sakura_core/cmd/CViewCommander_Diff.cpp
+++ b/sakura_core/cmd/CViewCommander_Diff.cpp
@@ -223,8 +223,10 @@ void CViewCommander::Command_COMPARE( void )
 
 static ECodeType GetFileCharCode( LPCWSTR pszFile )
 {
-	const STypeConfigMini* typeMini;
-	CDocTypeManager().GetTypeConfigMini( CDocTypeManager().GetDocumentTypeOfPath( pszFile ), &typeMini );
+	const STypeConfigMini* typeMini = NULL;
+	if( !CDocTypeManager().GetTypeConfigMini( CDocTypeManager().GetDocumentTypeOfPath( pszFile ), &typeMini ) ){
+		return CODE_ERROR;
+	}
 	return CCodeMediator(typeMini->m_encoding).CheckKanjiCodeOfFile( pszFile );
 }
 

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -81,8 +81,10 @@ void CViewCommander::Command_GREP( void )
 		// 2011.01.23 Grepタイプ別適用
 		if( !GetDocument()->m_cDocEditor.IsModified() && GetDocument()->m_cDocLineMgr.GetLineCount() == 0 ){
 			CTypeConfig cTypeGrep = CDocTypeManager().GetDocumentTypeOfExt( L"grepout" );
-			const STypeConfigMini* pConfig;
-			CDocTypeManager().GetTypeConfigMini( cTypeGrep, &pConfig );
+			const STypeConfigMini* pConfig = NULL;
+			if( !CDocTypeManager().GetTypeConfigMini( cTypeGrep, &pConfig ) ){
+				return;
+			}
 			GetDocument()->m_cDocType.SetDocumentTypeIdx( pConfig->m_id );
 			GetDocument()->m_cDocType.LockDocumentType();
 			GetDocument()->OnChangeType();

--- a/sakura_core/cmd/CViewCommander_Settings.cpp
+++ b/sakura_core/cmd/CViewCommander_Settings.cpp
@@ -175,8 +175,10 @@ void CViewCommander::Command_CHANGETYPE( int nTypePlusOne )
 		type = GetDocument()->m_cDocType.GetDocumentType();
 	}
 	if( type.IsValidType() && type.GetIndex() < GetDllShareData().m_nTypesCount ){
-		const STypeConfigMini* pConfig;
-		CDocTypeManager().GetTypeConfigMini(type, &pConfig);
+		const STypeConfigMini* pConfig = NULL;
+		if( !CDocTypeManager().GetTypeConfigMini( type, &pConfig ) ){
+			return;
+		}
 		GetDocument()->m_cDocType.SetDocumentTypeIdx(pConfig->m_id, true);
 		GetDocument()->m_cDocType.LockDocumentType();
 		GetDocument()->OnChangeType();

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -884,8 +884,10 @@ bool CDlgOpenFile_CommonFileDialog::DoModalOpenDlg(
 	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME3), L"*.*" );
 	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME2), L"*.txt" );
 	for( int i = 0; i < GetDllShareData().m_nTypesCount; i++ ){
-		const STypeConfigMini* type;
-		CDocTypeManager().GetTypeConfigMini(CTypeConfig(i), &type);
+		const STypeConfigMini* type = NULL;
+		if( !CDocTypeManager().GetTypeConfigMini( CTypeConfig( i ), &type ) ){
+			continue;
+		}
 		cFileExt.AppendExt( type->m_szTypeName, type->m_szTypeExts );
 	}
 

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -701,8 +701,10 @@ bool CDlgOpenFile_CommonItemDialog::DoModalOpenDlg(
 	CDocTypeManager docTypeMgr;
 	WCHAR szWork[_countof(STypeConfigMini::m_szTypeExts) * 3];
 	for( int i = 0; i < nTypesCount; i++ ){
-		const STypeConfigMini* type;
-		docTypeMgr.GetTypeConfigMini(CTypeConfig(i), &type);
+		const STypeConfigMini* type = NULL;
+		if( !docTypeMgr.GetTypeConfigMini( CTypeConfig(i), &type ) ){
+			continue;
+		}
 		specs[2 + i].pszName = type->m_szTypeName;
 		if (CDocTypeManager::ConvertTypesExtToDlgExt(type->m_szTypeExts, NULL, szWork)) {
 			strs[2 + i] = szWork;

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -57,9 +57,9 @@ CTypeConfig CDocTypeManager::GetDocumentTypeOfPath( const WCHAR* pszFilePath )
 	}
 
 	for (i = 0; i < m_pShareData->m_nTypesCount; ++i){
-		const STypeConfigMini* mini;
-		GetTypeConfigMini(CTypeConfig(i), &mini);
-		if (IsFileNameMatch(mini->m_szTypeExts, pszFileName)) {
+		const STypeConfigMini* mini = NULL;
+		if( GetTypeConfigMini( CTypeConfig(i), &mini )
+			&& IsFileNameMatch(mini->m_szTypeExts, pszFileName)) {
 			return CTypeConfig(i);	//	番号
 		}
 	}
@@ -87,9 +87,9 @@ CTypeConfig CDocTypeManager::GetDocumentTypeOfId( int id )
 	int		i;
 
 	for( i = 0; i < m_pShareData->m_nTypesCount; ++i ){
-		const STypeConfigMini* mini;
-		GetTypeConfigMini( CTypeConfig(i), &mini );
-		if( mini->m_id == id ){
+		const STypeConfigMini* mini = NULL;
+		if( GetTypeConfigMini( CTypeConfig(i), &mini )
+			&& mini->m_id == id ){
 			return CTypeConfig(i);
 		}
 	}
@@ -134,7 +134,7 @@ bool CDocTypeManager::SetTypeConfig(CTypeConfig cDocumentType, const STypeConfig
 	@retval true  正常
 	@retval false 異常
 */
-bool CDocTypeManager::GetTypeConfigMini(CTypeConfig cDocumentType, const STypeConfigMini** type)
+[[nodiscard]] bool CDocTypeManager::GetTypeConfigMini(CTypeConfig cDocumentType, const STypeConfigMini** type)
 {
 	int n = cDocumentType.GetIndex();
 	if( 0 <= n && n < m_pShareData->m_nTypesCount ){

--- a/sakura_core/env/CDocTypeManager.h
+++ b/sakura_core/env/CDocTypeManager.h
@@ -42,7 +42,7 @@ public:
 
 	bool GetTypeConfig(CTypeConfig cDocumentType, STypeConfig& type);
 	bool SetTypeConfig(CTypeConfig cDocumentType, const STypeConfig& type);
-	bool GetTypeConfigMini(CTypeConfig cDocumentType, const STypeConfigMini** type);
+	[[nodiscard]] bool GetTypeConfigMini(CTypeConfig cDocumentType, const STypeConfigMini** type);
 	bool AddTypeConfig(CTypeConfig cDocumentType);
 	bool DelTypeConfig(CTypeConfig cDocumentType);
 

--- a/sakura_core/recent/CMruListener.cpp
+++ b/sakura_core/recent/CMruListener.cpp
@@ -77,21 +77,18 @@ void CMruListener::OnBeforeLoad(SLoadInfo* pLoadInfo)
 
 	// 指定のコード -> pLoadInfo->eCharCode
 	if( CODE_AUTODETECT == pLoadInfo->eCharCode ){
-		if( fexist(pLoadInfo->cFilePath) ){
-			// デフォルト文字コード認識のために一時的に読み込み対象ファイルのファイルタイプを適用する
-			const STypeConfigMini* type;
-			CDocTypeManager().GetTypeConfigMini(pLoadInfo->nType, &type);
+		pLoadInfo->eCharCode = ePrevCode;
+		// デフォルト文字コード認識のために一時的に読み込み対象ファイルのファイルタイプを適用する
+		const STypeConfigMini* type = NULL;
+		if( CDocTypeManager().GetTypeConfigMini( pLoadInfo->nType, &type ) && fexist( pLoadInfo->cFilePath ) ){
 			CCodeMediator cmediator( type->m_encoding );
 			pLoadInfo->eCharCode = cmediator.CheckKanjiCodeOfFile( pLoadInfo->cFilePath );
-		}
-		else{
-			pLoadInfo->eCharCode = ePrevCode;
 		}
 	}
 	else if( CODE_NONE == pLoadInfo->eCharCode ){
 		pLoadInfo->eCharCode = ePrevCode;
 	}
-	if(CODE_NONE==pLoadInfo->eCharCode){
+	if( CODE_NONE == pLoadInfo->eCharCode ){
 		const STypeConfigMini* type;
 		if( CDocTypeManager().GetTypeConfigMini(pLoadInfo->nType, &type) ){
 			pLoadInfo->eCharCode = type->m_encoding.m_eDefaultCodetype;	//無効値の回避	// 2011.01.24 ryoji CODE_DEFAULT -> m_eDefaultCodetype

--- a/sakura_core/typeprop/CDlgTypeAscertain.cpp
+++ b/sakura_core/typeprop/CDlgTypeAscertain.cpp
@@ -115,8 +115,10 @@ void CDlgTypeAscertain::SetData( void )
 
 	// エディタ内の設定
 	for (nIdx = 0; nIdx < GetDllShareData().m_nTypesCount; ++nIdx) {
-		const STypeConfigMini* type;
-		CDocTypeManager().GetTypeConfigMini(CTypeConfig(nIdx), &type);
+		const STypeConfigMini* type = NULL;
+		if( !CDocTypeManager().GetTypeConfigMini( CTypeConfig(nIdx), &type ) ){
+			continue;
+		}
 		if (type->m_szTypeExts[0] != L'\0' ) {		/* タイプ属性：拡張子リスト */
 			auto_sprintf( szText, L"%s (%s)",
 				type->m_szTypeName,	/* タイプ属性：名称 */

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -186,7 +186,9 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 		HWND hwndList = GetItemHwnd( IDC_LIST_TYPES );
 		int nIdx = List_GetCurSel( hwndList );
 		const STypeConfigMini* type = NULL;
-		CDocTypeManager().GetTypeConfigMini(CTypeConfig(nIdx), &type);
+		if( !CDocTypeManager().GetTypeConfigMini( CTypeConfig(nIdx), &type ) ){
+			return TRUE; // 何もできないので処理済みとして抜ける。
+		}
 		if( LOWORD(wParam) == IDC_LIST_TYPES )
 		{
 			switch( HIWORD(wParam) )
@@ -323,8 +325,10 @@ void CDlgTypeList::SetData( int selIdx )
 	}
 	List_ResetContent( hwndList );	/* リストを空にする */
 	for( nIdx = 0; nIdx < GetDllShareData().m_nTypesCount; ++nIdx ){
-		const STypeConfigMini* type;
-		CDocTypeManager().GetTypeConfigMini(CTypeConfig(nIdx), &type);
+		const STypeConfigMini* type = NULL;
+		if( !CDocTypeManager().GetTypeConfigMini( CTypeConfig(nIdx), &type ) ){
+			continue;
+		}
 		if( type->m_szTypeExts[0] != L'\0' ){		/* タイプ属性：拡張子リスト */
 			auto_sprintf( szText, L"%s ( %s )",
 				type->m_szTypeName,	/* タイプ属性：名称 */
@@ -413,8 +417,10 @@ bool CDlgTypeList::Import()
 	CDocTypeManager().GetTypeConfig(CTypeConfig(0), type);
 
 	CImpExpType	cImpExpType( nIdx, type, hwndList );
-	const STypeConfigMini* typeMini;
-	CDocTypeManager().GetTypeConfigMini(CTypeConfig(nIdx), &typeMini);
+	const STypeConfigMini* typeMini = NULL;
+	if( !CDocTypeManager().GetTypeConfigMini( CTypeConfig(nIdx), &typeMini ) ){
+		return false;
+	}
 	int id = typeMini->m_id;
 
 	// インポート
@@ -521,8 +527,10 @@ bool CDlgTypeList::InitializeType( void )
 			if( iDocType == i ){
 				continue;
 			}
-			const STypeConfigMini* typeMini2;
-			CDocTypeManager().GetTypeConfigMini(CTypeConfig(i), &typeMini2);
+			const STypeConfigMini* typeMini2 = NULL;
+			if( !CDocTypeManager().GetTypeConfigMini( CTypeConfig(i), &typeMini2 ) ){
+				continue;
+			}
 			if( wcscmp(typeMini2->m_szTypeName, type->m_szTypeName) == 0 ){
 				i = 0;
 				bUpdate = true;
@@ -590,8 +598,10 @@ bool CDlgTypeList::CopyType()
 			wcscat( type.m_szTypeName, szNum );
 			bUpdate = false;
 		}
-		const STypeConfigMini* typeMini;
-		CDocTypeManager().GetTypeConfigMini(CTypeConfig(i), &typeMini);
+		const STypeConfigMini* typeMini = NULL;
+		if( !CDocTypeManager().GetTypeConfigMini( CTypeConfig(i), &typeMini ) ){
+			continue;
+		}
 		if( wcscmp(typeMini->m_szTypeName, type.m_szTypeName) == 0 ){
 			i = -1;
 			bUpdate = true;

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -522,8 +522,10 @@ BOOL CEditView::MakeDiffTmpFile2( WCHAR* tmpName, const WCHAR* orgName, ECodeTyp
 	free( pszTmpName );
 
 	bool bBom = false;
-	const STypeConfigMini* typeMini;
-	CDocTypeManager().GetTypeConfigMini( CDocTypeManager().GetDocumentTypeOfPath( orgName ), &typeMini );
+	const STypeConfigMini* typeMini = NULL;
+	if( !CDocTypeManager().GetTypeConfigMini( CDocTypeManager().GetDocumentTypeOfPath( orgName ), &typeMini ) ){
+		return FALSE;
+	}
 	CFileLoad	cfl( typeMini->m_encoding );
 	CTextOutputStream out(tmpName, saveCode, true, false);
 	if(!out){


### PR DESCRIPTION
# PR の目的
コンパイラの警告（＝未初期化の変数を使っている）に対処します。

## カテゴリ

- ~~リファクタリング~~(処理変わってるので外します https://github.com/sakura-editor/sakura/pull/1120#issuecomment-569478479)
- その他

## PR の背景
SDLチェックを有効化に伴って発生するエラーの対応です。
発生したエラーは #896 に書いてあります。

【経緯】
SDLチェックを有効にしたい
　　↓
単体テスト tests1.exe のリンクでエラーが出たのでやめた。
　　↓
単体テスト tests1.exe のビルド方法を変えた。
　　↓
単体テスト tests1.exe のリンクが通るようになったのでSDLチェックをオンにした。

エラーが発生した部分のコードは変更していないので、
「潜在的な問題」が残っている状態になっているのがキモい感じです。

変更内容
- GetTypeConfigMiniに渡す第2引数をNULLで初期化する
- GetTypeConfigMiniの戻り値（成功or失敗)を見るようにする

## PR のメリット
- コンパイラの警告（＝未初期化の変数を使っている）に対する一旦の対処ができます。

## PR のデメリット (トレードオフとかあれば)
- GetTypeConfigMiniの戻り値（成功or失敗)を見て、
失敗時にout変数を参照しないように変えています。
挿入した分岐が適切かどうかについて、判断しかねる部分があります。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はないと思われます。
- タイプ別設定を使って何かするところ全般。

## 関連チケット
close #896

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
