### PR TITLE
必要になるまでmutexを作らないようにする

### DIFF
--- a/sakura_core/env/CAppNodeManager.cpp
+++ b/sakura_core/env/CAppNodeManager.cpp
@@ -64,7 +64,7 @@ static BOOL s_bGSort;	// グループ指定
 	@date 2007.07.05 ryoji 新規導入
 	@date 2007.07.07 genta CShareDataのメンバへ移動
 */
-static CMutex g_cEditArrMutex( FALSE, GSTR_MUTEX_SAKURA_EDITARR );
+static CMutex g_cEditArrMutex( GSTR_MUTEX_SAKURA_EDITARR );
 
 // GetOpenedWindowArr用ソート関数
 static int __cdecl cmpGetOpenedWindowArr(const void *e1, const void *e2)

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -35,7 +35,7 @@
 const WCHAR* CDocTypeManager::m_typeExtSeps = L" ;,";	// タイプ別拡張子 区切り文字
 const WCHAR* CDocTypeManager::m_typeExtWildcards = L"*?";	// タイプ別拡張子 ワイルドカード
 
-static CMutex g_cDocTypeMutex( FALSE, GSTR_MUTEX_SAKURA_DOCTYPE );
+static CMutex g_cDocTypeMutex( GSTR_MUTEX_SAKURA_DOCTYPE );
 
 /*!
 	ファイル名から、ドキュメントタイプ（数値）を取得する

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -84,7 +84,7 @@ CShareData::~CShareData()
 	}
 }
 
-static CMutex g_cMutexShareWork( FALSE, GSTR_MUTEX_SAKURA_SHAREWORK );
+static CMutex g_cMutexShareWork( GSTR_MUTEX_SAKURA_SHAREWORK );
  
 CMutex& CShareData::GetMutexShareWork(){
 	return g_cMutexShareWork;

--- a/sakura_core/env/DLLSHAREDATA.cpp
+++ b/sakura_core/env/DLLSHAREDATA.cpp
@@ -35,7 +35,7 @@
 //GetDllShareData用グローバル変数
 DLLSHAREDATA* g_theDLLSHAREDATA = NULL;
 
-static CMutex g_cKeywordMutex( FALSE, GSTR_MUTEX_SAKURA_KEYWORD );
+static CMutex g_cKeywordMutex( GSTR_MUTEX_SAKURA_KEYWORD );
 
 CShareDataLockCounter::CShareDataLockCounter(){
 	LockGuard<CMutex> guard( g_cKeywordMutex );


### PR DESCRIPTION
# PR の目的
必要になるまで グローバルmutexを作らないようにして、プログラム起動時のパフォーマンスを改善します。

## カテゴリ
- 速度向上
- リファクタリング

## PR の背景
とくに経緯めいたものはありません。

起動状態のサクラエディタを [process explorer](https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer) で眺めてみたときに、単なるテキストエディタにしては、開いているシステムハンドルの数が多いのが気になって始めた対応です。

この対応により、プログラム起動時に自動的に確保される、ミューテックスオブジェクトの数が4つ減ります。

ミューテックスオブジェクトは、Windows OSが提供する「同期オブジェクト」というものの一種で、プロセス間の排他制御（**Mut**al **Ex**ecution）を実現するものです。

サクラエディタでは、共有メモリへの書込みアクセスを競合させないためにプロセス間排他の仕組みを使っています。

プロセス間排他が必要になる処理は、キーワード更新やプロセス間通信（タイプ別設定の変更時にエディタ⇒コントロールプロセスの通信がある）などの限られたものです。

この対応では、実際に排他ロックが必要になるタイミングまで、ミューテックスオブジェクトの作成を遅らせることにより、使わないシステムリソースを無駄に確保してしまう状況の発生確率を軽減します。

このPRには含めていない、実施予定の追加変更
- メンバ関数の実装をCMutex.cppに移動する
- 独自定義のLockGuardを廃止してstd::lock_guardを使うようにする
- プロセス起動時に使っている4つの生mutexにCMutexを適用する

## PR のメリット
- 必要になるまでシステムリソースを使わない構造に変更することで、プログラム起動がわずかに速くなります。
- CMutexのメンバに関する説明がPRのレビューに必要と判断した関係で、CMutexのメンバに関する説明コメントが大幅に拡充されます。

## PR のデメリット (トレードオフとかあれば)
- アプリ（＝サクラエディタ）の機能に影響はありません。
- 排他ロックが必要になったときの処理がわずかに遅くなります。
- CMutexクラスが狭義の[RAII](https://ja.wikipedia.org/wiki/RAII)ではなくなります。
- CMutexクラスを使って子プロセスにハンドルを継承できるミューテックスを作れなくなります。（需要はありません。
- CMutexクラスを使って名前なしミューテックスを作れなくなります。（需要はありません。

## PR の影響範囲
- プログラム起動がわずかに速くなります。
- 共有メモリに書き込みを行う処理（共通設定ダイアログの変更適用など）がわずかに遅くなります。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
