### PR TITLE
tag に対するビルドで成果物名にタグ名が含まれないのを修正

### DIFF
--- a/help/make-artifacts.bat
+++ b/help/make-artifacts.bat
@@ -6,6 +6,10 @@ if not defined CMD_7Z (
 	exit /b 1
 )
 
+
+@rem for GIT_TAG_NAME
+call %~dp0sakura\githash.bat %~dp0sakura_core
+
 @rem ----------------------------------------------------------------
 @rem prepare environment variable
 @rem ----------------------------------------------------------------

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -30,6 +30,9 @@ if "%platform%" == "x64" (
 set ZIP_CMD=%~dp0tools\zip\zip.bat
 set LIST_ZIP_CMD=%~dp0tools\zip\listzip.bat
 
+@rem for GIT_TAG_NAME
+call %~dp0sakura\githash.bat %~dp0sakura_core
+
 @rem ----------------------------------------------------------------
 @rem prepare environment variable
 @rem ----------------------------------------------------------------


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートに切り替えることで登録後にどのように見えるか確認することができます -->

# PR の目的

#1125  tag に対するビルドで成果物名にタグ名が含まれないのを修正

## カテゴリ

<!-- 編集 必須 -->
<!-- 以下の箇条書きリストから関係するものを残して、関係ないものを削除してください。-->
<!-- 該当するものがない場合は必要に応じて追加してください。                        -->

- ビルド手順
- CI関連
  - Appveyor

## PR の背景

<!-- PR を行う背景を記載してください -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
<!-- 好みの問題に属する部分に関しては、どちらが正しいということはないので好みの問題かもしれないと明示すること。 -->
<!-- 明示することによって PR を受け入れられやすくなるし、どちらが正しいかという議論が延々続くのを回避できる。   -->

## PR のメリット

- 正式リリース時の zip ファイル名にタグ名 (通常リリースバージョン名) が付与される。
- バージョン情報でタグ名を確認できるようになる。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

## 関連チケット

#1125 
#876 

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
