### PR TITLE
SHORTHASH の指定先の誤り修正

### DIFF
--- a/help/make-artifacts.bat
+++ b/help/make-artifacts.bat
@@ -47,7 +47,7 @@ if not "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" (
 )
 
 @echo hash name
-set SHORTHASH=%TEMP_GIT_COMMIT_HASH%
+set SHORTHASH=%TEMP_GIT_SHORT_COMMIT_HASH%
 
 @rem ----------------------------------------------------------------
 @rem build BASENAME

--- a/zipArtifacts.bat
+++ b/zipArtifacts.bat
@@ -71,7 +71,7 @@ if not "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" (
 )
 
 @echo hash name
-set SHORTHASH=%TEMP_GIT_COMMIT_HASH%
+set SHORTHASH=%TEMP_GIT_SHORT_COMMIT_HASH%
 
 if "%ALPHA%" == "1" (
 	set RELEASE_PHASE=alpha


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートに切り替えることで登録後にどのように見えるか確認することができます -->

# PR の目的

SHORTHASH の指定先の誤り修正

## カテゴリ


- CI関連
  - Appveyor


## PR の背景

#1125 でタグ名が含まれないようになっていた。
同時に githash.bat が実行されなくなっていて、成果物のファイル名に含まれる git hash の
値に 8 文字表記ではなくフル形式が使われるようになっていた。

## PR のメリット

成果物のファイル名が長いハッシュ値ではなく 8 文字の省略形になる。
ただしこの修正が適用されるためには、 #1127 が必要

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

成果物のファイル名

## 関連チケット

#1127

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
