### PR TITLE
build-chm.bat を二回実行しても大丈夫にする

### DIFF
--- a/build-chm.bat
+++ b/build-chm.bat
@@ -4,14 +4,20 @@ if not defined CMD_HHC (
 	exit /b 1
 )
 
-set HHP_MACRO=help\macro\macro.HHP
-set HHP_PLUGIN=help\plugin\plugin.hhp
-set HHP_SAKURA=help\sakura\sakura.hhp
+set SRC_HELP=%~dp0help
+set TMP_HELP=%~dp0temphelp
 
-set CHM_MACRO=help\macro\macro.chm
-set CHM_PLUGIN=help\plugin\plugin.chm
-set CHM_SAKURA=help\sakura\sakura.chm
-set HH_SCRIPT=%~dp0help\remove-comment.py
+rmdir /s /q    "%TMP_HELP%"
+xcopy /i /k /s "%SRC_HELP%" "%TMP_HELP%"
+
+set HHP_MACRO=%TMP_HELP%\macro\macro.HHP
+set HHP_PLUGIN=%TMP_HELP%\plugin\plugin.hhp
+set HHP_SAKURA=%TMP_HELP%\sakura\sakura.hhp
+
+set CHM_MACRO=%TMP_HELP%\macro\macro.chm
+set CHM_PLUGIN=%TMP_HELP%\plugin\plugin.chm
+set CHM_SAKURA=%TMP_HELP%\sakura\sakura.chm
+set HH_SCRIPT=%TMP_HELP%\remove-comment.py
 set HH_INPUT=sakura_core\sakura.hh
 set HH_OUTPUT=help\sakura\sakura.hh
 
@@ -30,12 +36,22 @@ set "TOOL_SLN_FILE=%~dp0tools\ChmSourceConverter\ChmSourceConverter.sln"
       "%CMD_MSBUILD%" %TOOL_SLN_FILE% "/p:Platform=Any CPU" /p:Configuration=Release /t:"Build" /v:q
 if errorlevel 1 exit /b 1
 
-%~dp0tools\ChmSourceConverter\ChmSourceConverter\bin\Release\ChmSourceConverter.exe %~dp0help
+%~dp0tools\ChmSourceConverter\ChmSourceConverter\bin\Release\ChmSourceConverter.exe "%TMP_HELP%"
 if errorlevel 1 exit /b 1
 
 call :BuildChm %HHP_MACRO%  %CHM_MACRO%   || (echo error && exit /b 1)
 call :BuildChm %HHP_PLUGIN% %CHM_PLUGIN%  || (echo error && exit /b 1)
 call :BuildChm %HHP_SAKURA% %CHM_SAKURA%  || (echo error && exit /b 1)
+
+copy /Y %TMP_HELP%\macro\*.chm   %SRC_HELP%\macro\   || (echo error && exit /b 1)
+copy /Y %TMP_HELP%\plugin\*.chm  %SRC_HELP%\plugin\  || (echo error && exit /b 1)
+copy /Y %TMP_HELP%\sakura\*.chm  %SRC_HELP%\sakura\  || (echo error && exit /b 1)
+
+copy /Y %TMP_HELP%\macro\*.Log   %SRC_HELP%\macro\   || (echo error && exit /b 1)
+copy /Y %TMP_HELP%\plugin\*.Log  %SRC_HELP%\plugin\  || (echo error && exit /b 1)
+copy /Y %TMP_HELP%\sakura\*.Log  %SRC_HELP%\sakura\  || (echo error && exit /b 1)
+
+rmdir /s /q %TMP_HELP%
 exit /b 0
 
 @rem ------------------------------------------------------------------------------
@@ -62,6 +78,6 @@ if not errorlevel 1 (
 exit /b 0
 
 :download_archive
-pwsh.exe -ExecutionPolicy RemoteSigned -File %~dp0help\extract-chm-from-artifact.ps1
+pwsh.exe -ExecutionPolicy RemoteSigned -File %TMP_HELP%\extract-chm-from-artifact.ps1
 if errorlevel 1 exit /b 1
 exit /b 0

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -78,6 +78,6 @@ if not errorlevel 1 (
 exit /b 0
 
 :download_archive
-pwsh.exe -ExecutionPolicy RemoteSigned -File %TMP_HELP%\extract-chm-from-artifact.ps1
+pwsh.exe -ExecutionPolicy RemoteSigned -File %SRC_HELP%\extract-chm-from-artifact.ps1
 if errorlevel 1 exit /b 1
 exit /b 0

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -7,7 +7,7 @@ if not defined CMD_HHC (
 set SRC_HELP=%~dp0help
 set TMP_HELP=%~dp0temphelp
 
-rmdir /s /q    "%TMP_HELP%"
+if exist "%TMP_HELP%" rmdir /s /q    "%TMP_HELP%"
 xcopy /i /k /s "%SRC_HELP%" "%TMP_HELP%"
 
 set HHP_MACRO=%TMP_HELP%\macro\macro.HHP


### PR DESCRIPTION
#PR の目的

#1126 build-chm.bat を二回実行しても大丈夫にする

## カテゴリ

- ビルド手順

## PR の背景

Html Help のソースを UTF8 で管理するようにして、
Html Help コンパイラに渡すときに Shift-JIS に変換するツールを導入した。

しかし、git に登録するソースをインプレイスで変換するようにしたため、
build-chm.bat を二回実行すると、変換済みのデータに対して変換しようと
してツールが例外をはいていた。

## PR のメリット

ローカルでソースをビルドする際に何度ビルドしても大丈夫になる。
Html のソースをローカルで修正していて、コミットしていない状態のときに意図せずローカルのファイルが更新されてしまうのを防げる。


## PR のデメリット (トレードオフとかあれば)

ちょっとわかりにくい。

## PR の影響範囲

HTML ヘルプ

## 関連チケット

#996
fixes #1126

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
