### PR TITLE
ツールバー用のビットマップ管理を分離、結合するツールを導入する (ただし組み込みはしない)

### DIFF
--- a/build-bmp-tools.bat
+++ b/build-bmp-tools.bat
@@ -1,0 +1,92 @@
+set configuration=%1
+if "%configuration%" == "Release" (
+	@rem OK
+) else if "%configuration%" == "Debug" (
+	@rem OK
+) else (
+	call :showhelp %0
+	exit /b 1
+)
+
+if not defined CMD_MSBUILD call %~dp0tools\find-tools.bat
+if not defined CMD_MSBUILD (
+	echo msbuild.exe was not found.
+	exit /b 1
+)
+
+set "TOOL_SLN_FILE=%~dp0tools\ToolBarTools\ToolBarTools.sln"
+@echo "%CMD_MSBUILD%" %TOOL_SLN_FILE% "/p:Platform=Any CPU" /p:Configuration=%configuration% /t:"Build" /v:q
+      "%CMD_MSBUILD%" %TOOL_SLN_FILE% "/p:Platform=Any CPU" /p:Configuration=%configuration% /t:"Build" /v:q
+if errorlevel 1 exit /b 1
+
+set MUXER=%~dp0tools\ToolBarTools\ToolBarImageMuxer\bin\%configuration%\ToolBarImageMuxer.exe
+set SPLITTER=%~dp0tools\ToolBarTools\ToolBarImageSplitter\bin\%configuration%\ToolBarImageSplitter.exe
+
+set SRC_BMP1=%~dp0resource\mytool.bmp
+set SRC_BMP2=%~dp0resource\my_icons.bmp
+
+set DST_DIR1=%~dp0resource\mytool
+set DST_DIR2=%~dp0resource\my_icons
+
+if exist %DST_DIR1% rmdir /s /q %DST_DIR1%
+if exist %DST_DIR2% rmdir /s /q %DST_DIR2%
+
+@rem split input bmp
+%SPLITTER% %SRC_BMP1% %DST_DIR1%
+if errorlevel 1 exit /b 1
+
+%SPLITTER% %SRC_BMP2% %DST_DIR2%
+if errorlevel 1 exit /b 1
+
+@rem these steps are for tests.
+set OUT1_BMP1=%~dp0resource\out1-mytool.bmp
+set OUT1_BMP2=%~dp0resource\out1-my_icons.bmp
+set OUT2_BMP1=%~dp0resource\out2-mytool.bmp
+set OUT2_BMP2=%~dp0resource\out2-my_icons.bmp
+
+set OUT_DIR1=%~dp0resource\mytool
+set OUT_DIR2=%~dp0resource\my_icons
+
+@rem merge multiple bmp to one bmp
+%MUXER% %DST_DIR1% %OUT1_BMP1%
+if errorlevel 1 exit /b 1
+
+%MUXER% %DST_DIR2% %OUT1_BMP2%
+if errorlevel 1 exit /b 1
+
+%SPLITTER% %OUT1_BMP1% %OUT_DIR1%
+if errorlevel 1 exit /b 1
+
+%SPLITTER% %OUT1_BMP2% %OUT_DIR2%
+if errorlevel 1 exit /b 1
+
+%MUXER% %OUT_DIR1% %OUT2_BMP1%
+if errorlevel 1 exit /b 1
+
+%MUXER% %OUT_DIR2% %OUT2_BMP2%
+if errorlevel 1 exit /b 1
+
+fc /a /b %OUT1_BMP1% %OUT2_BMP1% >NUL
+if errorlevel 1 exit /b 1
+
+fc /a /b %OUT1_BMP2% %OUT2_BMP2% >NUL
+if errorlevel 1 exit /b 1
+
+exit /b 0
+
+@rem ------------------------------------------------------------------------------
+@rem show help
+@rem see http://orangeclover.hatenablog.com/entry/20101004/1286120668
+@rem ------------------------------------------------------------------------------
+:showhelp
+@echo off
+@echo usage
+@echo    %~nx1 configuration
+@echo.
+@echo parameter
+@echo    configuration : Release or Debug
+@echo.
+@echo example
+@echo    %~nx1 Release
+@echo    %~nx1 Debug
+exit /b 0

--- a/build-bmp-tools.bat
+++ b/build-bmp-tools.bat
@@ -30,6 +30,8 @@ set DST_DIR2=%~dp0resource\my_icons
 
 if exist %DST_DIR1% rmdir /s /q %DST_DIR1%
 if exist %DST_DIR2% rmdir /s /q %DST_DIR2%
+if exist %DST_DIR1% rmdir /s /q %DST_DIR1%
+if exist %DST_DIR2% rmdir /s /q %DST_DIR2%
 
 @rem split input bmp
 %SPLITTER% %SRC_BMP1% %DST_DIR1%

--- a/build-bmp-tools.bat
+++ b/build-bmp-tools.bat
@@ -35,10 +35,16 @@ if exist %DST_DIR2% rmdir /s /q %DST_DIR2%
 
 @rem split input bmp
 %SPLITTER% %SRC_BMP1% %DST_DIR1%
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail %SPLITTER% %SRC_BMP1% %DST_DIR1%
+	exit /b 1
+)
 
 %SPLITTER% %SRC_BMP2% %DST_DIR2%
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail %SPLITTER% %SRC_BMP2% %DST_DIR2%
+	exit /b 1
+)
 
 @rem these steps are for tests.
 set OUT1_BMP1=%~dp0resource\out1-mytool.bmp
@@ -51,29 +57,54 @@ set OUT_DIR2=%~dp0resource\my_icons
 
 @rem merge multiple bmp to one bmp
 %MUXER% %DST_DIR1% %OUT1_BMP1%
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail %MUXER% %DST_DIR1% %OUT1_BMP1%
+	exit /b 1
+)
 
 %MUXER% %DST_DIR2% %OUT1_BMP2%
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail %MUXER% %DST_DIR2% %OUT1_BMP2%
+	exit /b 1
+)
 
 %SPLITTER% %OUT1_BMP1% %OUT_DIR1%
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail %SPLITTER% %OUT1_BMP1% %OUT_DIR1%
+	exit /b 1
+)
 
 %SPLITTER% %OUT1_BMP2% %OUT_DIR2%
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail %SPLITTER% %OUT1_BMP2% %OUT_DIR2%
+	exit /b 1
+)
 
 %MUXER% %OUT_DIR1% %OUT2_BMP1%
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail %MUXER% %OUT_DIR1% %OUT2_BMP1%
+	exit /b 1
+)
 
 %MUXER% %OUT_DIR2% %OUT2_BMP2%
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail %MUXER% %OUT_DIR2% %OUT2_BMP2%
+	exit /b 1
+)
 
 fc /a /b %OUT1_BMP1% %OUT2_BMP1% >NUL
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail fc /a /b %OUT1_BMP1% %OUT2_BMP1%
+	exit /b 1
+)
 
 fc /a /b %OUT1_BMP2% %OUT2_BMP2% >NUL
-if errorlevel 1 (echo error && exit /b 1)
+if errorlevel 1 (
+	echo fail fc /a /b %OUT1_BMP2% %OUT2_BMP2%
+	exit /b 1
+)
 
+echo Success
 exit /b 0
 
 @rem ------------------------------------------------------------------------------

--- a/build-bmp-tools.bat
+++ b/build-bmp-tools.bat
@@ -17,7 +17,7 @@ if not defined CMD_MSBUILD (
 set "TOOL_SLN_FILE=%~dp0tools\ToolBarTools\ToolBarTools.sln"
 @echo "%CMD_MSBUILD%" %TOOL_SLN_FILE% "/p:Platform=Any CPU" /p:Configuration=%configuration% /t:"Build" /v:q
       "%CMD_MSBUILD%" %TOOL_SLN_FILE% "/p:Platform=Any CPU" /p:Configuration=%configuration% /t:"Build" /v:q
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 set MUXER=%~dp0tools\ToolBarTools\ToolBarImageMuxer\bin\%configuration%\ToolBarImageMuxer.exe
 set SPLITTER=%~dp0tools\ToolBarTools\ToolBarImageSplitter\bin\%configuration%\ToolBarImageSplitter.exe
@@ -35,10 +35,10 @@ if exist %DST_DIR2% rmdir /s /q %DST_DIR2%
 
 @rem split input bmp
 %SPLITTER% %SRC_BMP1% %DST_DIR1%
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 %SPLITTER% %SRC_BMP2% %DST_DIR2%
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 @rem these steps are for tests.
 set OUT1_BMP1=%~dp0resource\out1-mytool.bmp
@@ -51,28 +51,28 @@ set OUT_DIR2=%~dp0resource\my_icons
 
 @rem merge multiple bmp to one bmp
 %MUXER% %DST_DIR1% %OUT1_BMP1%
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 %MUXER% %DST_DIR2% %OUT1_BMP2%
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 %SPLITTER% %OUT1_BMP1% %OUT_DIR1%
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 %SPLITTER% %OUT1_BMP2% %OUT_DIR2%
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 %MUXER% %OUT_DIR1% %OUT2_BMP1%
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 %MUXER% %OUT_DIR2% %OUT2_BMP2%
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 fc /a /b %OUT1_BMP1% %OUT2_BMP1% >NUL
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 fc /a /b %OUT1_BMP2% %OUT2_BMP2% >NUL
-if errorlevel 1 exit /b 1
+if errorlevel 1 (echo error && exit /b 1)
 
 exit /b 0
 

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -37,6 +37,10 @@ jobs:
   - script: build-sln.bat       $(BuildPlatform) $(Configuration)
     displayName: Build solution
 
+  # Toolbar Bitmap Split/Mux
+  - script: build-bmp-tools.bat $(Configuration)
+    displayName: Bitmap Split/Mux
+
 #  # Build HTML Help
 #  - script: build-chm.bat
 #    displayName: Build HTML Help

--- a/tools/ToolBarTools/.gitattributes
+++ b/tools/ToolBarTools/.gitattributes
@@ -1,0 +1,6 @@
+*.cs text
+*.config text
+*.settings text
+
+*.csproj binary
+*.sln binary

--- a/tools/ToolBarTools/.gitignore
+++ b/tools/ToolBarTools/.gitignore
@@ -1,0 +1,5 @@
+**/bin
+**/obj
+**/packages
+**/TestResults
+.vs

--- a/tools/ToolBarTools/ToolBarImageMuxer/App.config
+++ b/tools/ToolBarTools/ToolBarImageMuxer/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpFileComparer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpFileComparer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections;
+using System.Text.RegularExpressions;
+
+namespace ToolBarImageMuxer
+{
+    public class BmpFileComparer : IComparer<string>
+    {
+        static Regex regex = new Regex(@"(\d+)\.bmp", RegexOptions.Compiled);
+    
+        public int Compare(string x, string y)
+        {
+            var matchX = regex.Match(x);
+            var matchY = regex.Match(y);
+
+            if (matchX.Success && matchY.Success)
+            {
+                var indexX = int.Parse(matchX.Groups[1].Value);
+                var indexY = int.Parse(matchY.Groups[1].Value);
+
+                return indexX.CompareTo(indexY);
+            }
+            return x.CompareTo(y);
+        }
+    }
+}

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpFileComparer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpFileComparer.cs
@@ -10,7 +10,7 @@ namespace ToolBarImageMuxer
 {
     public class BmpFileComparer : IComparer<string>
     {
-        static Regex regex = new Regex(@"(\d+)\.bmp", RegexOptions.Compiled);
+        static Regex regex = new Regex(@"(\d+)(\D*)\.bmp", RegexOptions.Compiled);
     
         public int Compare(string x, string y)
         {
@@ -22,7 +22,13 @@ namespace ToolBarImageMuxer
                 var indexX = int.Parse(matchX.Groups[1].Value);
                 var indexY = int.Parse(matchY.Groups[1].Value);
 
-                return indexX.CompareTo(indexY);
+				// 数値だけのファイルの場合、数値として比較する
+                if (indexX != indexY)
+                {
+                    return indexX - indexY;
+                }
+                
+                // 数値の部分が同じ場合、文字列として比較する。
             }
             return x.CompareTo(y);
         }

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Drawing;
+
+namespace ToolBarImageMuxer
+{
+    public class BmpMuxer
+    {
+        static public void Mux(string[] fileNames, string outFile, int countPerLine)
+        {
+        	// 一番最初の BMP の情報を取得する
+            var bmp = (Bitmap)Image.FromFile(fileNames[0]);
+            var sx = bmp.Size.Width;
+            var sy = bmp.Size.Height;
+
+            var lines = (fileNames.Length + countPerLine - 1) / countPerLine;
+            var width = sx * countPerLine;
+            var height = sy * lines;
+
+            // フルカラーのビットマップを作成する (Graphics がフルカラーを必要とする)
+            var imgMerge = new Bitmap(width, height);
+            Graphics g = Graphics.FromImage(imgMerge);
+
+            var index = 0;
+            for (var y = 0; y < height; y += sy)
+            {
+                for (var x = 0; x < width; x += sx)
+                {
+                    using (var bmpTmp = (Bitmap)Image.FromFile(fileNames[index]))
+                    {
+                        var cloneRect = new RectangleF(x, y, sx, sy);
+                        g.DrawImage(bmpTmp, cloneRect);
+                    }
+                    index++;
+                }
+            }
+
+            // 入力のビットマップと同じ形式で保存する (減色処理含む)
+            var outRect = new RectangleF(0, 0, width, height);
+            var imgSave = imgMerge.Clone(outRect, bmp.PixelFormat);
+            imgSave.Save(outFile, System.Drawing.Imaging.ImageFormat.Bmp);
+        }
+    }
+}

--- a/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
@@ -4,31 +4,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.IO;
-using System.Collections;
-using System.Text.RegularExpressions;
 
 namespace ToolBarImageMuxer
 {
-    public class BmpFileComparer : IComparer<string>
-    {
-        static Regex regex = new Regex(@"(\d+)\.bmp", RegexOptions.Compiled);
-    
-        public int Compare(string x, string y)
-        {
-            var matchX = regex.Match(x);
-            var matchY = regex.Match(y);
-
-            if (matchX.Success && matchY.Success)
-            {
-                var indexX = int.Parse(matchX.Groups[1].Value);
-                var indexY = int.Parse(matchY.Groups[1].Value);
-
-                return indexX.CompareTo(indexY);
-            }
-            return x.CompareTo(y);
-        }
-    }
-
     class Program
     {
         static void Main(string[] args)

--- a/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToolBarImageMuxer
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
@@ -22,7 +22,8 @@ namespace ToolBarImageMuxer
             var compare = new BmpFileComparer();
             Array.Sort<string>(files, compare);
 
-            BmpMuxer.Mux(files, outfile, 33);
+            var countPerLine = 32 + 1;
+            BmpMuxer.Mux(files, outfile, countPerLine);
         }
     }
 }

--- a/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace ToolBarImageMuxer
 {
@@ -10,6 +11,15 @@ namespace ToolBarImageMuxer
     {
         static void Main(string[] args)
         {
+            if (args.Length < 2)
+            {
+                return;
+            }
+            var inputDir = args[0];
+            var outfile = args[1];
+            var files = Directory.GetFiles(inputDir, "*.bmp", SearchOption.TopDirectoryOnly);
+
+            BmpMuxer.Mux(files, outfile, 33);
         }
     }
 }

--- a/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
@@ -4,9 +4,31 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.IO;
+using System.Collections;
+using System.Text.RegularExpressions;
 
 namespace ToolBarImageMuxer
 {
+    public class BmpFileComparer : IComparer<string>
+    {
+        static Regex regex = new Regex(@"(\d+)\.bmp", RegexOptions.Compiled);
+    
+        public int Compare(string x, string y)
+        {
+            var matchX = regex.Match(x);
+            var matchY = regex.Match(y);
+
+            if (matchX.Success && matchY.Success)
+            {
+                var indexX = int.Parse(matchX.Groups[1].Value);
+                var indexY = int.Parse(matchY.Groups[1].Value);
+
+                return indexX.CompareTo(indexY);
+            }
+            return x.CompareTo(y);
+        }
+    }
+
     class Program
     {
         static void Main(string[] args)
@@ -18,6 +40,9 @@ namespace ToolBarImageMuxer
             var inputDir = args[0];
             var outfile = args[1];
             var files = Directory.GetFiles(inputDir, "*.bmp", SearchOption.TopDirectoryOnly);
+
+            var compare = new BmpFileComparer();
+            Array.Sort<string>(files, compare);
 
             BmpMuxer.Mux(files, outfile, 33);
         }

--- a/tools/ToolBarTools/ToolBarImageMuxer/Properties/AssemblyInfo.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ToolBarImageMuxer")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ToolBarImageMuxer")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("abf37460-f080-4f1a-9f7a-f166154072ff")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/ToolBarTools/ToolBarImageMuxer/ToolBarImageMuxer.csproj
+++ b/tools/ToolBarTools/ToolBarImageMuxer/ToolBarImageMuxer.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{ABF37460-F080-4F1A-9F7A-F166154072FF}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ToolBarImageMuxer</RootNamespace>
+    <AssemblyName>ToolBarImageMuxer</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tools/ToolBarTools/ToolBarImageMuxer/ToolBarImageMuxer.csproj
+++ b/tools/ToolBarTools/ToolBarImageMuxer/ToolBarImageMuxer.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -43,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BmpMuxer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/tools/ToolBarTools/ToolBarImageMuxer/ToolBarImageMuxer.csproj
+++ b/tools/ToolBarTools/ToolBarImageMuxer/ToolBarImageMuxer.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BmpFileComparer.cs" />
     <Compile Include="BmpMuxer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tools/ToolBarTools/ToolBarImageSplitter/App.config
+++ b/tools/ToolBarTools/ToolBarImageSplitter/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
@@ -10,7 +10,7 @@ namespace ToolBarImageSplitter
 {
     public class BmpSplitter
     {
-        static public void Split(string fileName, string outDir)
+        static public void Split(string fileName, string outDir, int countPerLine)
         {
             if (!Directory.Exists(outDir))
             {
@@ -20,22 +20,33 @@ namespace ToolBarImageSplitter
             var bmp = (Bitmap)Image.FromFile(fileName);
             var width = bmp.Size.Width;
             var height = bmp.Size.Height;
-            var sx = 16;
-            var sy = 16;
+            var sx = width / countPerLine;
+            var sy = sx;
 
-            var index = 1;
+            var index = 0;
             for (var y = 0; y < height; y += sy)
             {
                 for (var x = 0; x < width; x += sx)
                 {
+                    var outfile = string.Empty;
+                    
+                    if (x + sx == width)
+                    {
+	                    // 右端の画像はインデックス用
+                        outfile = Path.Combine(outDir, index.ToString() + "-index.bmp");
+                    }
+                    else
+                    {
+                        index++;
+                        outfile = Path.Combine(outDir, index.ToString() + ".bmp");
+                    }
+
                     var cloneRect = new RectangleF(x, y, sx, sy);
                     using (var cloneBitmap = bmp.Clone(cloneRect, bmp.PixelFormat))
                     {
-                        var outfile = Path.Combine(outDir, index.ToString() + ".bmp");
                         cloneBitmap.Save(outfile, System.Drawing.Imaging.ImageFormat.Bmp);
                         Console.WriteLine("wrote {0} x={1} y={2}", outfile, x, y);
                     }
-                    index++;
                 }
             }
         }

--- a/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
@@ -33,6 +33,7 @@ namespace ToolBarImageSplitter
                     {
                         var outfile = Path.Combine(outDir, index.ToString() + ".bmp");
                         cloneBitmap.Save(outfile, System.Drawing.Imaging.ImageFormat.Bmp);
+                        Console.WriteLine("{0} {1} {2}", x, y, index);
                     }
                     index++;
                 }

--- a/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
@@ -33,7 +33,7 @@ namespace ToolBarImageSplitter
                     {
                         var outfile = Path.Combine(outDir, index.ToString() + ".bmp");
                         cloneBitmap.Save(outfile, System.Drawing.Imaging.ImageFormat.Bmp);
-                        Console.WriteLine("{0} {1} {2}", x, y, index);
+                        Console.WriteLine("wrote {0} x={1} y={2}", outfile, x, y);
                     }
                     index++;
                 }

--- a/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.IO;
 using System.Drawing;
+using System.Diagnostics;
 
 namespace ToolBarImageSplitter
 {
@@ -44,9 +45,16 @@ namespace ToolBarImageSplitter
                     var cloneRect = new RectangleF(x, y, sx, sy);
                     using (var cloneBitmap = bmp.Clone(cloneRect, bmp.PixelFormat))
                     {
+                        cloneBitmap.Palette = bmp.Palette;
                         cloneBitmap.Save(outfile, System.Drawing.Imaging.ImageFormat.Bmp);
                         Console.WriteLine("wrote {0} x={1} y={2}", outfile, x, y);
                     }
+#if DEBUG
+                    using (var bmpDebug = (Bitmap)Image.FromFile(outfile))
+                    {
+                        Debug.Assert(bmpDebug.Palette.Entries.SequenceEqual(bmp.Palette.Entries));
+                    }
+#endif
                 }
             }
         }

--- a/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using System.Drawing;
+
+namespace ToolBarImageSplitter
+{
+    public class BmpSplitter
+    {
+        static public void Split(string fileName, string outDir)
+        {
+            if (!Directory.Exists(outDir))
+            {
+                Directory.CreateDirectory(outDir);
+            }
+
+            var bmp = (Bitmap)Image.FromFile(fileName);
+            var width = bmp.Size.Width;
+            var height = bmp.Size.Height;
+            var sx = 16;
+            var sy = 16;
+
+            var index = 1;
+            for (var y = 0; y < height; y += sy)
+            {
+                for (var x = 0; x < width; x += sx)
+                {
+                    var cloneRect = new RectangleF(x, y, sx, sy);
+                    using (var cloneBitmap = bmp.Clone(cloneRect, System.Drawing.Imaging.PixelFormat.Format4bppIndexed))
+                    {
+                        var outfile = Path.Combine(outDir, index.ToString() + ".bmp");
+                        cloneBitmap.Save(outfile, System.Drawing.Imaging.ImageFormat.Bmp);
+                    }
+                    index++;
+                }
+            }
+        }
+    }
+}

--- a/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
@@ -29,7 +29,7 @@ namespace ToolBarImageSplitter
                 for (var x = 0; x < width; x += sx)
                 {
                     var cloneRect = new RectangleF(x, y, sx, sy);
-                    using (var cloneBitmap = bmp.Clone(cloneRect, System.Drawing.Imaging.PixelFormat.Format4bppIndexed))
+                    using (var cloneBitmap = bmp.Clone(cloneRect, bmp.PixelFormat))
                     {
                         var outfile = Path.Combine(outDir, index.ToString() + ".bmp");
                         cloneBitmap.Save(outfile, System.Drawing.Imaging.ImageFormat.Bmp);

--- a/tools/ToolBarTools/ToolBarImageSplitter/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/Program.cs
@@ -10,6 +10,14 @@ namespace ToolBarImageSplitter
     {
         static void Main(string[] args)
         {
+            if (args.Length < 2)
+            {
+                return;
+            }
+            var input = args[0];
+            var outdir = args[1];
+
+            BmpSplitter.Split(input, outdir);
         }
     }
 }

--- a/tools/ToolBarTools/ToolBarImageSplitter/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToolBarImageSplitter
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/tools/ToolBarTools/ToolBarImageSplitter/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/Program.cs
@@ -16,8 +16,8 @@ namespace ToolBarImageSplitter
             }
             var input = args[0];
             var outdir = args[1];
-
-            BmpSplitter.Split(input, outdir);
+            var countPerLine = 32 + 1;
+            BmpSplitter.Split(input, outdir, countPerLine);
         }
     }
 }

--- a/tools/ToolBarTools/ToolBarImageSplitter/Properties/AssemblyInfo.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ToolBarImageSplitter")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ToolBarImageSplitter")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4f23ce26-8a95-44ad-be88-45dfe08fe0f7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/ToolBarTools/ToolBarImageSplitter/ToolBarImageSplitter.csproj
+++ b/tools/ToolBarTools/ToolBarImageSplitter/ToolBarImageSplitter.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ToolBarImageSplitter</RootNamespace>
+    <AssemblyName>ToolBarImageSplitter</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tools/ToolBarTools/ToolBarImageSplitter/ToolBarImageSplitter.csproj
+++ b/tools/ToolBarTools/ToolBarImageSplitter/ToolBarImageSplitter.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -43,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BmpSplitter.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/tools/ToolBarTools/ToolBarTools.sln
+++ b/tools/ToolBarTools/ToolBarTools.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28307.960
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolBarImageSplitter", "ToolBarImageSplitter\ToolBarImageSplitter.csproj", "{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolBarImageMuxer", "ToolBarImageMuxer\ToolBarImageMuxer.csproj", "{ABF37460-F080-4F1A-9F7A-F166154072FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ABF37460-F080-4F1A-9F7A-F166154072FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ABF37460-F080-4F1A-9F7A-F166154072FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABF37460-F080-4F1A-9F7A-F166154072FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ABF37460-F080-4F1A-9F7A-F166154072FF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/ToolBarTools/ToolBarTools.sln
+++ b/tools/ToolBarTools/ToolBarTools.sln
@@ -3,7 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.960
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolBarImageSplitter", "ToolBarImageSplitter\ToolBarImageSplitter.csproj", "{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}"
+EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/tools/ToolBarTools/ToolBarTools.sln
+++ b/tools/ToolBarTools/ToolBarTools.sln
@@ -1,0 +1,13 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.960
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EA95D85D-2787-4F17-838E-E564B8693AF8}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
# PR の目的

#733 のために、ツールバー用のビットマップを個別に分離、結合するツールを導入する
(ただし、 **この PR では**  組み込みはしない)

## カテゴリ

- その他

## PR の背景

もともと #680 でツールバー用のビットマップを追加しようとなったときに
管理が煩雑なので #733 でよりよい管理方法を検討しているなかで、
機能ごとにツールバーのビットマップを分離して管理して、ツールで
マージしてコンパイルしたらいいんじゃないかという案があったので
ツールを実装してみた。

## PR のメリット

機能ごとにツールバーのビットマップを分離して管理するためのたたき台になる。

## PR のデメリット (トレードオフとかあれば)

現状は既存のコードは変えないのでなし

## PR の影響範囲

なし

## 関連チケット

#733 
#680

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
