### PR TITLE
検索条件の文字列をエスケープする処理を関数化する

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -28,6 +28,28 @@
 #define ADDTAIL_INTERVAL_MILLISEC 50	// 結果出力の時間間隔
 #define UIFILENAME_INTERVAL_MILLISEC 15	// Cancelダイアログのファイル名表示更新間隔
 
+/*!
+ * 指定された文字列を出力対象ビューのタイプ別設定に従ってエスケープする
+ */
+inline CNativeW EscapeStringLiteral( const CEditView* pcViewDst, const CNativeW& cmemString )
+{
+	CNativeW cmemWork2( cmemString );
+	const STypeConfig& type = pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute();
+	if( FALSE == type.m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp ){
+		// 2011.11.28 色指定が無効ならエスケープしない
+	}else
+	if( type.m_nStringType == STRING_LITERAL_CPP || type.m_nStringType == STRING_LITERAL_CSHARP
+		|| type.m_nStringType == STRING_LITERAL_PYTHON ){	/* 文字列区切り記号エスケープ方法 */
+		cmemWork2.Replace( L"\\", L"\\\\" );
+		cmemWork2.Replace( L"\'", L"\\\'" );
+		cmemWork2.Replace( L"\"", L"\\\"" );
+	}else if( type.m_nStringType == STRING_LITERAL_PLSQL ){
+		cmemWork2.Replace( L"\'", L"\'\'" );
+		cmemWork2.Replace( L"\"", L"\"\"" );
+	}
+	return cmemWork2;
+}
+
 CGrepAgent::CGrepAgent()
 : m_bGrepMode( false )			/* Grepモードか */
 , m_bGrepRunning( false )		/* Grep処理中 */
@@ -398,52 +420,19 @@ DWORD CGrepAgent::DoGrep(
 	CNativeW	cmemWork;
 	cmemMessage.AppendString( LS( STR_GREP_SEARCH_CONDITION ) );	//L"\r\n□検索条件  "
 	if( 0 < nWork ){
-		CNativeW cmemWork2;
-		cmemWork2.SetNativeData( *pcmGrepKey );
-		const STypeConfig& type = pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute();
-		if( FALSE == type.m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp ){
-			// 2011.11.28 色指定が無効ならエスケープしない
-		}else
-		if( type.m_nStringType == STRING_LITERAL_CPP || type.m_nStringType == STRING_LITERAL_CSHARP
-			|| type.m_nStringType == STRING_LITERAL_PYTHON ){	/* 文字列区切り記号エスケープ方法 */
-			cmemWork2.Replace( L"\\", L"\\\\" );
-			cmemWork2.Replace( L"\'", L"\\\'" );
-			cmemWork2.Replace( L"\"", L"\\\"" );
-		}else if( type.m_nStringType == STRING_LITERAL_PLSQL ){
-			cmemWork2.Replace( L"\'", L"\'\'" );
-			cmemWork2.Replace( L"\"", L"\"\"" );
-		}
-		cmemWork.AppendString( L"\"" );
-		cmemWork.AppendNativeData( cmemWork2 );
-		cmemWork.AppendString( L"\"\r\n" );
+		cmemWork = EscapeStringLiteral( pcViewDst, *pcmGrepKey );
+		cmemMessage.AppendStringF( L"\"%s\"\r\n", cmemWork.GetStringPtr() );
 	}else{
-		cmemWork.AppendString( LS( STR_GREP_SEARCH_FILE ) );	//L"「ファイル検索」\r\n"
+		cmemMessage.AppendString( LS( STR_GREP_SEARCH_FILE ) );	//L"「ファイル検索」\r\n"
 	}
-	cmemMessage += cmemWork;
 
 	if( bGrepReplace ){
 		cmemMessage.AppendString( LS(STR_GREP_REPLACE_TO) );
 		if( bGrepPaste ){
 			cmemMessage.AppendString( LS(STR_GREP_PASTE_CLIPBOAD) );
 		}else{
-			CNativeW cmemWork2;
-			cmemWork2.SetNativeData( cmemReplace );
-			const STypeConfig& type = pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute();
-			if( FALSE == type.m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp ){
-				// 2011.11.28 色指定が無効ならエスケープしない
-			}else
-			if( type.m_nStringType == STRING_LITERAL_CPP || type.m_nStringType == STRING_LITERAL_CSHARP
-				|| type.m_nStringType == STRING_LITERAL_PYTHON ){	/* 文字列区切り記号エスケープ方法 */
-				cmemWork2.Replace( L"\\", L"\\\\" );
-				cmemWork2.Replace( L"\'", L"\\\'" );
-				cmemWork2.Replace( L"\"", L"\\\"" );
-			}else if( type.m_nStringType == STRING_LITERAL_PLSQL ){
-				cmemWork2.Replace( L"\'", L"\'\'" );
-				cmemWork2.Replace( L"\"", L"\"\"" );
-			}
-			cmemMessage.AppendString( L"\"" );
-			cmemMessage.AppendNativeData( cmemWork2 );
-			cmemMessage.AppendString( L"\"\r\n" );
+			cmemWork = EscapeStringLiteral( pcViewDst, cmemReplace );
+			cmemMessage.AppendStringF( L"\"%s\"\r\n", cmemWork.GetStringPtr() );
 		}
 	}
 

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -29,12 +29,11 @@
 #define UIFILENAME_INTERVAL_MILLISEC 15	// Cancelダイアログのファイル名表示更新間隔
 
 /*!
- * 指定された文字列を出力対象ビューのタイプ別設定に従ってエスケープする
+ * 指定された文字列をタイプ別設定に従ってエスケープする
  */
-inline CNativeW EscapeStringLiteral( const CEditView* pcViewDst, const CNativeW& cmemString )
+inline CNativeW EscapeStringLiteral( const STypeConfig& type, const CNativeW& cmemString )
 {
 	CNativeW cmemWork2( cmemString );
-	const STypeConfig& type = pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute();
 	if( FALSE == type.m_ColorInfoArr[COLORIDX_WSTRING].m_bDisp ){
 		// 2011.11.28 色指定が無効ならエスケープしない
 	}else
@@ -411,6 +410,9 @@ DWORD CGrepAgent::DoGrep(
 		}
 	}
 
+	// 出力対象ビューのタイプ別設定(grepout固定)
+	const STypeConfig& type = pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute();
+
 	std::vector<std::wstring> vPaths;
 	CreateFolders( pcmGrepFolder->GetStringPtr(), vPaths );
 
@@ -420,7 +422,7 @@ DWORD CGrepAgent::DoGrep(
 	CNativeW	cmemWork;
 	cmemMessage.AppendString( LS( STR_GREP_SEARCH_CONDITION ) );	//L"\r\n□検索条件  "
 	if( 0 < nWork ){
-		cmemWork = EscapeStringLiteral( pcViewDst, *pcmGrepKey );
+		cmemWork = EscapeStringLiteral( type, *pcmGrepKey );
 		cmemMessage.AppendStringF( L"\"%s\"\r\n", cmemWork.GetStringPtr() );
 	}else{
 		cmemMessage.AppendString( LS( STR_GREP_SEARCH_FILE ) );	//L"「ファイル検索」\r\n"
@@ -431,7 +433,7 @@ DWORD CGrepAgent::DoGrep(
 		if( bGrepPaste ){
 			cmemMessage.AppendString( LS(STR_GREP_PASTE_CLIPBOAD) );
 		}else{
-			cmemWork = EscapeStringLiteral( pcViewDst, cmemReplace );
+			cmemWork = EscapeStringLiteral( type, cmemReplace );
 			cmemMessage.AppendStringF( L"\"%s\"\r\n", cmemWork.GetStringPtr() );
 		}
 	}


### PR DESCRIPTION
# PR の目的
CGrepAgent::DoGrep関数を分かりやすくするために、関数内の重複処理に名前を付けて関数化します。処理に名前が付くことによって「何をしているか」が明確になり、分かりやすくなります。

## カテゴリ
- リファクタリング

## PR の背景
CGrepAgent::DoGrep関数は、Grep検索とGrep置換の実処理を担当する部分です。

長年の機能追加により、処理内容がかなりぐちゃぐちゃになっており、
リファクタリングが必要な関数だと思っています。

サクラエディタのGrep機能は比較的信頼できる部類のツールですが、
Grep処理がシングルスレッドで行われる都合でパフォーマンスがよくありません。

処理のマルチスレッド化を行うにあたっては、
基本的な部分の整理が必要と考え、
まずは「見たら分かる」レベルの簡単なリファクタリングを提案してみることにしました。

## PR のメリット
- 検索条件の文字列リテラルをタイプ別設定に従ってエスケープする処理に名前が付きます。(EscapeStringLiteral)
- 検索対象文字列と置換後文字列のエスケープ処理を共通化するので、今後エスケープ処理を変えたくなったときに、どちらかの変更をし忘れる事態を防ぐことができます。

## PR のデメリット (トレードオフとかあれば)
- 検索対象文字列と置換後文字列のエスケープ処理を共通化してしまうので、今後エスケープ処理を意図的に分けたくなったときに困る可能性があります。
※そういう趣旨の変更がレビューで通る事態は想像できませんが、将来どうするかは分からんので。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。
- 改修箇所は、Grep検索およびGrep置換の「検索条件」と、Grep置換の「置換後」の表示方法に関連する部分です。処理内容は一切変えていないので変更前後比較をしても何も変わりません。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
