### PR TITLE
冗長な処理を取り除いて記述を簡潔にする

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -445,6 +445,10 @@ DWORD CGrepAgent::DoGrep(
 	{
 		std::wstring grepFolder;
 		for( int i = 0; i < (int)vPaths.size(); i++ ){
+			// パスリストは ':' で区切る(2つ目以降の前に付加する)
+			if( i ){
+				grepFolder += L';';
+			}
 			// 末尾のバックスラッシュを削る
 			std::wstring sPath = ChopYen( vPaths[i] );
 
@@ -456,13 +460,8 @@ DWORD CGrepAgent::DoGrep(
 			}else{
 				grepFolder += sPath;
 			}
-
-			// パスリストは ':' で区切る
-			grepFolder += L';';
 		}
-
-		// 最後のリスト区切りは要らないので length() - 1 を出力する
-		cmemMessage.AppendStringF( L"%.*s\r\n", grepFolder.length() - 1, grepFolder.c_str() );
+		cmemMessage.AppendStringF( L"%s\r\n", grepFolder.c_str() );
 	}
 
 	cmemMessage.AppendString(LS(STR_GREP_EXCLUDE_FILE));	//L"除外ファイル   "

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -439,21 +439,16 @@ DWORD CGrepAgent::DoGrep(
 	}
 
 	cmemMessage.AppendString( LS( STR_GREP_SEARCH_TARGET ) );	//L"検索対象   "
-	if( pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_nStringType == 0 ){	/* 文字列区切り記号エスケープ方法  0=[\"][\'] 1=[""][''] */
-	}else{
-	}
-	cmemWork.SetString( pcmGrepFile->GetStringPtr() );
-	cmemMessage += cmemWork;
+	cmemMessage.AppendStringF( L"%s\r\n", pcmGrepFile->GetStringPtr() );
 
-	cmemMessage.AppendString( L"\r\n" );
 	cmemMessage.AppendString( LS( STR_GREP_SEARCH_FOLDER ) );	//L"フォルダ   "
 	{
 		std::wstring grepFolder;
 		for( int i = 0; i < (int)vPaths.size(); i++ ){
-			if( i ){
-				grepFolder += L';';
-			}
+			// 末尾のバックスラッシュを削る
 			std::wstring sPath = ChopYen( vPaths[i] );
+
+			// ';' を含むパス名は引用符で囲む
 			if( auto_strchr( sPath.c_str(), L';' ) ){
 				grepFolder += L'"';
 				grepFolder += sPath;
@@ -461,32 +456,20 @@ DWORD CGrepAgent::DoGrep(
 			}else{
 				grepFolder += sPath;
 			}
+
+			// パスリストは ':' で区切る
+			grepFolder += L';';
 		}
-		cmemWork.SetString( grepFolder.c_str() );
+
+		// 最後のリスト区切りは要らないので length() - 1 を出力する
+		cmemMessage.AppendStringF( L"%.*s\r\n", grepFolder.length() - 1, grepFolder.c_str() );
 	}
-	if( pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_nStringType == 0 ){	/* 文字列区切り記号エスケープ方法  0=[\"][\'] 1=[""][''] */
-	}else{
-	}
-	cmemMessage += cmemWork;
-	cmemMessage.AppendString( L"\r\n" );
 
 	cmemMessage.AppendString(LS(STR_GREP_EXCLUDE_FILE));	//L"除外ファイル   "
-	if (pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_nStringType == 0) {	/* 文字列区切り記号エスケープ方法  0=[\"][\'] 1=[""][''] */
-	}
-	else {
-	}
-	cmemWork.SetString(pcmExcludeFile->GetStringPtr());
-	cmemMessage += cmemWork;
-	cmemMessage.AppendString(L"\r\n");
+	cmemMessage.AppendStringF( L"%s\r\n", pcmExcludeFile->GetStringPtr() );
 
 	cmemMessage.AppendString(LS(STR_GREP_EXCLUDE_FOLDER));	//L"除外フォルダ   "
-	if (pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_nStringType == 0) {	/* 文字列区切り記号エスケープ方法  0=[\"][\'] 1=[""][''] */
-	}
-	else {
-	}
-	cmemWork.SetString(pcmExcludeFolder->GetStringPtr());
-	cmemMessage += cmemWork;
-	cmemMessage.AppendString(L"\r\n");
+	cmemMessage.AppendStringF( L"%s\r\n", pcmExcludeFolder->GetStringPtr() );
 
 	const wchar_t*	pszWork;
 	if( sGrepOption.bGrepSubFolder ){

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -439,7 +439,8 @@ DWORD CGrepAgent::DoGrep(
 	}
 
 	cmemMessage.AppendString( LS( STR_GREP_SEARCH_TARGET ) );	//L"検索対象   "
-	cmemMessage.AppendStringF( L"%s\r\n", pcmGrepFile->GetStringPtr() );
+	cmemMessage.AppendString( pcmGrepFile->GetStringPtr() );
+	cmemMessage.AppendString( L"\r\n" );
 
 	cmemMessage.AppendString( LS( STR_GREP_SEARCH_FOLDER ) );	//L"フォルダ   "
 	{
@@ -461,14 +462,17 @@ DWORD CGrepAgent::DoGrep(
 				grepFolder += sPath;
 			}
 		}
-		cmemMessage.AppendStringF( L"%s\r\n", grepFolder.c_str() );
+		cmemMessage.AppendString( grepFolder.c_str() );
 	}
+	cmemMessage.AppendString( L"\r\n" );
 
 	cmemMessage.AppendString(LS(STR_GREP_EXCLUDE_FILE));	//L"除外ファイル   "
-	cmemMessage.AppendStringF( L"%s\r\n", pcmExcludeFile->GetStringPtr() );
+	cmemMessage.AppendString( pcmExcludeFile->GetStringPtr() );
+	cmemMessage.AppendString(L"\r\n");
 
 	cmemMessage.AppendString(LS(STR_GREP_EXCLUDE_FOLDER));	//L"除外フォルダ   "
-	cmemMessage.AppendStringF( L"%s\r\n", pcmExcludeFolder->GetStringPtr() );
+	cmemMessage.AppendString( pcmExcludeFolder->GetStringPtr() );
+	cmemMessage.AppendString(L"\r\n");
 
 	const wchar_t*	pszWork;
 	if( sGrepOption.bGrepSubFolder ){


### PR DESCRIPTION
# PR の目的
CGrepAgent::DoGrep関数を分かりやすくするために、関数内の冗長な記述の一部を削除します。

「実は何もしてない処理」を削除することにより、コードを読みやすくします。

【やってることのお品書き】
- 実処理のないif分岐を削除
- 一時変数に文字列をコピーするだけの処理を削除（使わないならコピー自体が無駄だから）
- ~~CNativeW::AppendStringFを使って簡潔な記述に変更~~(取り下げ)

## カテゴリ
- リファクタリング

## PR の背景
CGrepAgent::DoGrep関数は、Grep検索とGrep置換の実処理を担当する部分です。

長年の機能追加により、処理内容がかなりぐちゃぐちゃになっており、
リファクタリングが必要な関数だと思っています。

サクラエディタのGrep機能は比較的信頼できる部類のツールですが、
Grep処理がシングルスレッドで行われる都合でパフォーマンスがよくありません。

処理のマルチスレッド化を行うにあたっては、
 基本的な部分の整理が必要と考え、
まずは「見たら分かる」レベルの簡単なリファクタリングを提案してみることにしました。

## PR のメリット
- 効果のないコードが消えることにより、修正対象部分が何をしているかを把握しやすくなります。

## PR のデメリット (トレードオフとかあれば)
- 該当部分のコードを書いた人が「あとで何か処理を入れよう」と思って残していた目印を消してしまう結果になるかも知れません。
- ~~swprintfの「やや高度な書式設定オプション」 `%.*s` を利用するので、C++オンリーでやってるプログラマーにとっては、難しいコードになってしまいます。※swprintfはC言語のランタイムなので。~~(指摘対応で削除しました)
- 修正部分（パスなどのパターンリストを表示する処理）を分かりやすくすることによって、現状のコードに存在している **些細な問題点** が気になってしまう結果になるかもしれません。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。
- 改修箇所は、Grep検索およびGrep置換の「検索対象」、「フォルダ」、「除外ファイル」、「除外フォルダ」のパスリスト表示に関連する部分です。 ~~「フォルダ」のパスリスト構築過程に少し手を入れていますが、~~ 処理結果は変えていないので変更前後比較をしても何も変わらないと思います。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料
~~https://qiita.com/bamchoh/items/5e6d5435e0f9ed1fe463~~
