### PR TITLE
CNativeW::AppendStringF をなるべく使わないように変更

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -1586,19 +1586,25 @@ public:
 				if( fexist(oldFile.c_str()) ){
 					if( FALSE == ::DeleteFile( oldFile.c_str() ) ){
 						memMessage.AppendString( LS(STR_GREP_REP_ERR_DELETE) );
-						memMessage.AppendStringF( L"[%s]\r\n", oldFile.c_str());
+						memMessage.AppendString( L"[", 1 );
+						memMessage.AppendString( oldFile.c_str(), oldFile.length() );
+						memMessage.AppendString( L"]\r\n", 3 );
 						return;
 					}
 				}
 				if( FALSE == ::MoveFile( fileName, oldFile.c_str() ) ){
 					memMessage.AppendString( LS(STR_GREP_REP_ERR_REPLACE) );
-					memMessage.AppendStringF( L"[%s]\r\n", oldFile.c_str());
+					memMessage.AppendString( L"[", 1 );
+					memMessage.AppendString( oldFile.c_str(), oldFile.length() );
+					memMessage.AppendString( L"]\r\n", 3 );
 					return;
 				}
 			}else{
 				if( FALSE == ::DeleteFile( fileName ) ){
 					memMessage.AppendString( LS(STR_GREP_REP_ERR_DELETE) );
-					memMessage.AppendStringF( L"[%s]\r\n", fileName );
+					memMessage.AppendString( L"[", 1 );
+					memMessage.AppendString( fileName );
+					memMessage.AppendString( L"]\r\n", 3 );
 					return;
 				}
 			}
@@ -1606,7 +1612,9 @@ public:
 			name += L".skrnew";
 			if( FALSE == ::MoveFile( name.c_str(), fileName ) ){
 				memMessage.AppendString( LS(STR_GREP_REP_ERR_REPLACE) );
-				memMessage.AppendStringF( L"[%s]\r\n", fileName );
+				memMessage.AppendString( L"[", 1 );
+				memMessage.AppendString( fileName );
+				memMessage.AppendString( L"]\r\n", 3 );
 				return;
 			}
 		}

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -138,7 +138,11 @@ static void AppendExcludeFolderPatterns(CNativeW& cFilePattern, const CNativeW& 
 	{
 		const auto & pattern = (*iter);
 		LPCWSTR escapeStr  = GetEscapePattern(pattern);
-		cFilePattern.AppendStringF(L"#%s%s%s;", escapeStr, pattern.c_str(), escapeStr);
+		cFilePattern.AppendString(L"#", 1);
+		cFilePattern.AppendString(escapeStr);
+		cFilePattern.AppendString(pattern.c_str(), pattern.length());
+		cFilePattern.AppendString(escapeStr);
+		cFilePattern.AppendString(L";", 1);
 	}
 }
 
@@ -154,7 +158,11 @@ static void AppendExcludeFilePatterns(CNativeW& cFilePattern, const CNativeW& cm
 	{
 		const auto & pattern = (*iter);
 		LPCWSTR escapeStr  = GetEscapePattern(pattern);
-		cFilePattern.AppendStringF(L"!%s%s%s;", escapeStr, pattern.c_str(), escapeStr);
+		cFilePattern.AppendString(L"!", 1);
+		cFilePattern.AppendString(escapeStr);
+		cFilePattern.AppendString(pattern.c_str(), pattern.length());
+		cFilePattern.AppendString(escapeStr);
+		cFilePattern.AppendString(L";", 1);
 	}
 }
 

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -540,7 +540,9 @@ void CViewCommander::Command_OPEN_FOLDER_IN_EXPLORER(void)
 
 	// Windows Explorerの引数を作る
 	CNativeW explorerCommand;
-	explorerCommand.AppendStringF(L"/select,\"%s\"", pszDocPath);
+	explorerCommand.AppendString(L"/select,\"", 9);
+	explorerCommand.AppendString(pszDocPath);
+	explorerCommand.AppendString(L"\"", 1);
 	LPCWSTR pszExplorerCommand = explorerCommand.GetStringPtr();
 
 	auto hInstance = ::ShellExecute(GetMainWindow(), L"open", L"explorer.exe", pszExplorerCommand, NULL, SW_SHOWNORMAL);
@@ -579,7 +581,9 @@ void CViewCommander::Command_OPEN_COMMAND_PROMPT(BOOL isAdmin)
 		/k で cd コマンドを実行する方法なら、管理者用のコマンドプロンプトでも動作する
 	*/
 	CNativeW cmdExeParam;
-	cmdExeParam.AppendStringF(L"/k cd /d \"%s\"", strFolder.c_str());
+	cmdExeParam.AppendString(L"/k cd /d \"", 10);
+	cmdExeParam.AppendString(strFolder.c_str(), strFolder.size());
+	cmdExeParam.AppendString(L"\"", 1);
 	LPCWSTR pszcmdExeParam = cmdExeParam.GetStringPtr();
 
 	/* 環境変数 COMSPEC から cmd.exe のパスを取得する */
@@ -630,7 +634,9 @@ void CViewCommander::Command_OPEN_POWERSHELL(BOOL isAdmin)
 		(-NoExit がない場合は -Command で指定したコマンドレットが終了すると PowerShellも終了する)
 	*/
 	CNativeW cmdExeParam;
-	cmdExeParam.AppendStringF(L"-NoExit -Command \"Set-Location -Path '%s'\"", strFolder.c_str());
+	cmdExeParam.AppendString(L"-NoExit -Command \"Set-Location -Path '", 38);
+	cmdExeParam.AppendString(strFolder.c_str(), strFolder.length());
+	cmdExeParam.AppendString(L"'\"", 2);
 	LPCWSTR pszcmdExeParam = cmdExeParam.GetStringPtr();
 
 	LPCWSTR pVerb = L"open";


### PR DESCRIPTION
# PR の目的

`CNativeW::AppendStringF` をなるべく使わないように変更するのが目的です。

#1135 と変更範囲が被らないようにしています。

## カテゴリ

- 速度向上

## PR の背景

https://github.com/sakura-editor/sakura/pull/1132#discussion_r365533598

## PR のメリット

`CNativeW::AppendStringF` の文字数制限を使わない事で回避出来ます。
書式文字列の解析が無くなる分だけ処理速度が少し速くなるはずです。

## PR のデメリット (トレードオフとかあれば)

コードの可読性が少し落ちます。

`CNativeW::AppendString` に文字列リテラルを渡す際に文字数をハードコーディングしていますが、テンプレート引数から取るようにした方が記述が楽かなと思います。が、実装が面倒くさいのでやってません。

## 関連チケット

#1132 
