### PR TITLE
ツールバー用のビットマップを結合するツール：インデックスカラー画像の場合はなるべく元のパレットを保持して結合するように対処を追加

### DIFF
--- a/build-bmp-tools.bat
+++ b/build-bmp-tools.bat
@@ -55,49 +55,70 @@ set OUT2_BMP2=%~dp0resource\out2-my_icons.bmp
 set OUT_DIR1=%~dp0resource\mytool
 set OUT_DIR2=%~dp0resource\my_icons
 
-@rem merge multiple bmp to one bmp
+@rem merge multiple bmp files to one bmp file
 %MUXER% %DST_DIR1% %OUT1_BMP1%
 if errorlevel 1 (
 	echo fail %MUXER% %DST_DIR1% %OUT1_BMP1%
 	exit /b 1
 )
 
+@rem merge multiple bmp files to one bmp file
 %MUXER% %DST_DIR2% %OUT1_BMP2%
 if errorlevel 1 (
 	echo fail %MUXER% %DST_DIR2% %OUT1_BMP2%
 	exit /b 1
 )
 
+@rem split one bmp file into multiple bmp files
 %SPLITTER% %OUT1_BMP1% %OUT_DIR1%
 if errorlevel 1 (
 	echo fail %SPLITTER% %OUT1_BMP1% %OUT_DIR1%
 	exit /b 1
 )
 
+@rem split one bmp file into multiple bmp files
 %SPLITTER% %OUT1_BMP2% %OUT_DIR2%
 if errorlevel 1 (
 	echo fail %SPLITTER% %OUT1_BMP2% %OUT_DIR2%
 	exit /b 1
 )
 
+@rem merge multiple bmp files to one bmp file
 %MUXER% %OUT_DIR1% %OUT2_BMP1%
 if errorlevel 1 (
 	echo fail %MUXER% %OUT_DIR1% %OUT2_BMP1%
 	exit /b 1
 )
 
+@rem merge multiple bmp files to one bmp file
 %MUXER% %OUT_DIR2% %OUT2_BMP2%
 if errorlevel 1 (
 	echo fail %MUXER% %OUT_DIR2% %OUT2_BMP2%
 	exit /b 1
 )
 
+@rem verify contents of merged bmp file is as same as source bitmap file
+fc /a /b %SRC_BMP1% %OUT1_BMP1% >NUL
+if errorlevel 1 (
+	echo fail fc /a /b %SRC_BMP1% %OUT1_BMP1%
+	exit /b 1
+)
+
+@rem verify contents of merged bmp file is as same as source bitmap file
+fc /a /b %SRC_BMP2% %OUT1_BMP2% >NUL
+if errorlevel 1 (
+	echo fail fc /a /b %SRC_BMP2% %OUT1_BMP2%
+	exit /b 1
+)
+
+@rem verify contents of merged bmp file is as same as source bitmap file
 fc /a /b %OUT1_BMP1% %OUT2_BMP1% >NUL
 if errorlevel 1 (
 	echo fail fc /a /b %OUT1_BMP1% %OUT2_BMP1%
 	exit /b 1
 )
 
+@rem verify contents of merged bmp file is as same as source bitmap file
 fc /a /b %OUT1_BMP2% %OUT2_BMP2% >NUL
 if errorlevel 1 (
 	echo fail fc /a /b %OUT1_BMP2% %OUT2_BMP2%

--- a/build-bmp-tools.bat
+++ b/build-bmp-tools.bat
@@ -28,100 +28,51 @@ set SRC_BMP2=%~dp0resource\my_icons.bmp
 set DST_DIR1=%~dp0resource\mytool
 set DST_DIR2=%~dp0resource\my_icons
 
-if exist %DST_DIR1% rmdir /s /q %DST_DIR1%
-if exist %DST_DIR2% rmdir /s /q %DST_DIR2%
+set OUT_BMP1=%~dp0resource\out-mytool.bmp
+set OUT_BMP2=%~dp0resource\out-my_icons.bmp
+
 if exist %DST_DIR1% rmdir /s /q %DST_DIR1%
 if exist %DST_DIR2% rmdir /s /q %DST_DIR2%
 
-@rem split input bmp
+@rem split input bmp file No.1
 %SPLITTER% %SRC_BMP1% %DST_DIR1%
 if errorlevel 1 (
 	echo fail %SPLITTER% %SRC_BMP1% %DST_DIR1%
 	exit /b 1
 )
 
+@rem split input bmp file No.2
 %SPLITTER% %SRC_BMP2% %DST_DIR2%
 if errorlevel 1 (
 	echo fail %SPLITTER% %SRC_BMP2% %DST_DIR2%
 	exit /b 1
 )
 
-@rem these steps are for tests.
-set OUT1_BMP1=%~dp0resource\out1-mytool.bmp
-set OUT1_BMP2=%~dp0resource\out1-my_icons.bmp
-set OUT2_BMP1=%~dp0resource\out2-mytool.bmp
-set OUT2_BMP2=%~dp0resource\out2-my_icons.bmp
-
-set OUT_DIR1=%~dp0resource\mytool
-set OUT_DIR2=%~dp0resource\my_icons
-
-@rem merge multiple bmp files to one bmp file
-%MUXER% %DST_DIR1% %OUT1_BMP1%
+@rem merge separated bmp files into single bmp file
+%MUXER% %DST_DIR1% %OUT_BMP1%
 if errorlevel 1 (
-	echo fail %MUXER% %DST_DIR1% %OUT1_BMP1%
+	echo fail %MUXER% %DST_DIR1% %OUT_BMP1%
 	exit /b 1
 )
 
-@rem merge multiple bmp files to one bmp file
-%MUXER% %DST_DIR2% %OUT1_BMP2%
+@rem merge separated bmp files into single bmp file
+%MUXER% %DST_DIR2% %OUT_BMP2%
 if errorlevel 1 (
-	echo fail %MUXER% %DST_DIR2% %OUT1_BMP2%
-	exit /b 1
-)
-
-@rem split one bmp file into multiple bmp files
-%SPLITTER% %OUT1_BMP1% %OUT_DIR1%
-if errorlevel 1 (
-	echo fail %SPLITTER% %OUT1_BMP1% %OUT_DIR1%
-	exit /b 1
-)
-
-@rem split one bmp file into multiple bmp files
-%SPLITTER% %OUT1_BMP2% %OUT_DIR2%
-if errorlevel 1 (
-	echo fail %SPLITTER% %OUT1_BMP2% %OUT_DIR2%
-	exit /b 1
-)
-
-@rem merge multiple bmp files to one bmp file
-%MUXER% %OUT_DIR1% %OUT2_BMP1%
-if errorlevel 1 (
-	echo fail %MUXER% %OUT_DIR1% %OUT2_BMP1%
-	exit /b 1
-)
-
-@rem merge multiple bmp files to one bmp file
-%MUXER% %OUT_DIR2% %OUT2_BMP2%
-if errorlevel 1 (
-	echo fail %MUXER% %OUT_DIR2% %OUT2_BMP2%
+	echo fail %MUXER% %DST_DIR2% %OUT_BMP2%
 	exit /b 1
 )
 
 @rem verify contents of merged bmp file is as same as source bitmap file
-fc /a /b %SRC_BMP1% %OUT1_BMP1% >NUL
+fc /a /b %SRC_BMP1% %OUT_BMP1% >NUL
 if errorlevel 1 (
-	echo fail fc /a /b %SRC_BMP1% %OUT1_BMP1%
+	echo fail fc /a /b %SRC_BMP1% %OUT_BMP1%
 	exit /b 1
 )
 
 @rem verify contents of merged bmp file is as same as source bitmap file
-fc /a /b %SRC_BMP2% %OUT1_BMP2% >NUL
+fc /a /b %SRC_BMP2% %OUT_BMP2% >NUL
 if errorlevel 1 (
-	echo fail fc /a /b %SRC_BMP2% %OUT1_BMP2%
-	exit /b 1
-)
-
-@rem verify contents of merged bmp file is as same as source bitmap file
-fc /a /b %OUT1_BMP1% %OUT2_BMP1% >NUL
-if errorlevel 1 (
-	echo fail fc /a /b %OUT1_BMP1% %OUT2_BMP1%
-	exit /b 1
-)
-
-@rem verify contents of merged bmp file is as same as source bitmap file
-fc /a /b %OUT1_BMP2% %OUT2_BMP2% >NUL
-if errorlevel 1 (
-	echo fail fc /a /b %OUT1_BMP2% %OUT2_BMP2%
+	echo fail fc /a /b %SRC_BMP2% %OUT_BMP2%
 	exit /b 1
 )
 

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -62,47 +62,6 @@ namespace ToolBarImageCommon
         public byte rgbReserved;
     }
 
-    // https://smdn.jp/programming/netfx/tips/convert_struct_and_bytearray/
-    /// <summary>
-    /// ポインタを得るためにGCHandle.Allocでバイト配列のピニングを行い、
-    /// Marshal.PtrToStructure・Marshal.StructureToPtrで変換して構造体の読み書きを行う
-    /// </summary>
-    /// <remarks>参照型のフィールドを持つ構造体は読み書きできない</remarks>
-    static class ReadWriteStructWithAllocGCHandle
-    {
-        public static void WriteTo<TStruct>(BinaryWriter writer, TStruct s) where TStruct : struct
-        {
-            var buffer = new byte[Marshal.SizeOf(typeof(TStruct))];
-            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-
-            try
-            {
-                Marshal.StructureToPtr(s, handle.AddrOfPinnedObject(), false);
-            }
-            finally
-            {
-                handle.Free();
-            }
-
-            writer.Write(buffer);
-        }
-
-        public static TStruct ReadFrom<TStruct>(BinaryReader reader) where TStruct : struct
-        {
-            var buffer = reader.ReadBytes(Marshal.SizeOf(typeof(TStruct)));
-            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-
-            try
-            {
-                return (TStruct)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(TStruct));
-            }
-            finally
-            {
-                handle.Free();
-            }
-        }
-    }
-
     public class Bmp
     {
         public BITMAPINFOHEADER bmih;

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -250,7 +250,7 @@ namespace ToolBarImageCommon
                 {
                     ReadWriteStructWithAllocGCHandle.WriteTo<RGBQUAD>(writer, c);
                 }
-                writer.BaseStream.Write(bitmap, 0, bitmap.Count());
+                writer.Write(bitmap);
             }
         }
 

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -274,7 +274,7 @@ namespace ToolBarImageCommon
                         case 1:
                         case 4:
                         case 8:
-                            numQuads = (uint)(2 << bmp.bmih.biBitCount);
+                            numQuads = (uint)(1 << bmp.bmih.biBitCount);
                             break;
                         default:
                             throw new FileFormatException();

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -72,8 +72,8 @@ namespace ToolBarImageCommon
         {
             int bitsPerLine = ((bmih.biWidth * bmih.biBitCount) + 31) & (~31);
             int bytesPerLine = bitsPerLine / 8;
-            if (bmih.biHeight > 0)
-                bytesPerLine = -bytesPerLine;
+            if (IsBottomUp())
+                bytesPerLine = -bytesPerLine; // ボトムアップ形式の場合は行ストライドは負の値になる
             return bytesPerLine;
         }
 

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -174,20 +174,8 @@ namespace ToolBarImageCommon
                     byte scidx = src.bitmap[sidx + j];
                     RGBQUAD sc0 = src.colorTable[scidx >> 4];
                     RGBQUAD sc1 = src.colorTable[scidx & 0xF];
-                    int dcidx0 = 0;
-                    int dcidx1 = 0;
-                    for (int k = 0; k < colorTable.Count(); ++k)
-                    {
-                        RGBQUAD dc = colorTable[k];
-                        if (sc0.Equals(dc))
-                        {
-                            dcidx0 = k;
-                        }
-                        if (sc1.Equals(dc))
-                        {
-                            dcidx1 = k;
-                        }
-                    }
+                    int dcidx0 = Array.IndexOf(colorTable, sc0);
+                    int dcidx1 = Array.IndexOf(colorTable, sc1);
                     bitmap[didx + j] = (byte)((dcidx0 << 4) | dcidx1);
                 }
                 sidx += sLineStride;
@@ -208,14 +196,7 @@ namespace ToolBarImageCommon
                 for (int j = 0; j < sw; ++j)
                 {
                     RGBQUAD sc = src.colorTable[src.bitmap[sidx + j]];
-                    for (int k = 0; k < colorTable.Count(); ++k)
-                    {
-                        if (sc.Equals(colorTable[k]))
-                        {
-                            bitmap[didx + j] = (byte)k;
-                            break;
-                        }
-                    }
+                    bitmap[didx + j] = (byte)Array.IndexOf(colorTable, sc);
                 }
                 sidx += sLineStride;
                 didx += dLineStride;

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -1,0 +1,362 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+namespace ToolBarImageCommon
+{
+    // https://www.pinvoke.net/default.aspx/Enums/BitmapCompressionMode.html
+    public enum BitmapCompressionMode : uint
+    {
+        BI_RGB = 0,
+        BI_RLE8 = 1,
+        BI_RLE4 = 2,
+        BI_BITFIELDS = 3,
+        BI_JPEG = 4,
+        BI_PNG = 5
+    }
+
+    // https://www.pinvoke.net/default.aspx/Structures.BITMAPFILEHEADER
+    [StructLayout(LayoutKind.Sequential, Pack = 2)]
+    public struct BITMAPFILEHEADER
+    {
+        public ushort bfType;
+        public uint bfSize;
+        public ushort bfReserved1;
+        public ushort bfReserved2;
+        public uint bfOffBits;
+    }
+
+    // https://www.pinvoke.net/default.aspx/Structures.BITMAPINFOHEADER
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BITMAPINFOHEADER
+    {
+        public uint biSize;
+        public int biWidth;
+        public int biHeight;
+        public ushort biPlanes;
+        public ushort biBitCount;
+        public BitmapCompressionMode biCompression;
+        public uint biSizeImage;
+        public int biXPelsPerMeter;
+        public int biYPelsPerMeter;
+        public uint biClrUsed;
+        public uint biClrImportant;
+
+        public void Init()
+        {
+            biSize = (uint)Marshal.SizeOf(this);
+        }
+    }
+
+    // https://www.pinvoke.net/default.aspx/Structures.RGBQUAD
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct RGBQUAD
+    {
+        public byte rgbBlue;
+        public byte rgbGreen;
+        public byte rgbRed;
+        public byte rgbReserved;
+    }
+
+    // https://smdn.jp/programming/netfx/tips/convert_struct_and_bytearray/
+    /// <summary>
+    /// ポインタを得るためにGCHandle.Allocでバイト配列のピニングを行い、
+    /// Marshal.PtrToStructure・Marshal.StructureToPtrで変換して構造体の読み書きを行う
+    /// </summary>
+    /// <remarks>参照型のフィールドを持つ構造体は読み書きできない</remarks>
+    static class ReadWriteStructWithAllocGCHandle
+    {
+        public static void WriteTo<TStruct>(BinaryWriter writer, TStruct s) where TStruct : struct
+        {
+            var buffer = new byte[Marshal.SizeOf(typeof(TStruct))];
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+            try
+            {
+                Marshal.StructureToPtr(s, handle.AddrOfPinnedObject(), false);
+            }
+            finally
+            {
+                handle.Free();
+            }
+
+            writer.Write(buffer);
+        }
+
+        public static TStruct ReadFrom<TStruct>(BinaryReader reader) where TStruct : struct
+        {
+            var buffer = reader.ReadBytes(Marshal.SizeOf(typeof(TStruct)));
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+            try
+            {
+                return (TStruct)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(TStruct));
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+    }
+
+    public class Bmp
+    {
+        public BITMAPINFOHEADER bmih;
+        public RGBQUAD[] colorTable;
+        public byte[] bitmap;
+
+        public int GetLineStride()
+        {
+            int bytesPerLine = ((bmih.biWidth * bmih.biBitCount + 31) & (~31)) >> 3;
+            if (bmih.biHeight > 0)
+                bytesPerLine = -bytesPerLine;
+            return bytesPerLine;
+        }
+
+        public bool IsBottomUp()
+        {
+            return bmih.biHeight > 0;
+        }
+
+        public bool IsTopDown()
+        {
+            return bmih.biHeight < 0;
+        }
+
+        // ビットマップ領域中の指定座標がビットマップ配列の先頭から何バイトずれた位置に記録されているかを返す
+        public int GetByteOffset(int x, int y)
+        {
+            int lineStride = GetLineStride();
+            int w = bmih.biWidth;
+            int h = Math.Abs(bmih.biHeight);
+            if (x < 0 || y < 0 || x > w || y > h)
+            {
+                throw new OutOfMemoryException();
+            }
+            int bitCount = bmih.biBitCount;
+            int idx = IsBottomUp() ? ((h - 1 - y) * Math.Abs(lineStride)) : (y * lineStride);
+            if (bitCount == 8)
+            {
+                idx += x;
+            }
+            else if (bitCount == 4)
+            {
+                if ((x & 1) == 1)
+                {
+                    throw new OutOfMemoryException();
+                }
+                idx += x / 2;
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+            return idx;
+        }
+
+        public Bmp Copy(int x, int y, int w, int h)
+        {
+            Bmp ret = new Bmp();
+            ret.bmih = bmih;
+            ret.bmih.biWidth = w;
+            ret.bmih.biHeight = h;
+            ret.colorTable = colorTable;
+            int sLineStride = GetLineStride();
+            int dLineStride = ret.GetLineStride();
+            int sw = bmih.biWidth;
+            int sh = bmih.biHeight;
+            if (x < 0 || y < 0 || x + w > sw || y + h > sh)
+            {
+                throw new NotImplementedException();
+            }
+            int bc = bmih.biBitCount;
+            if (bc == 4)
+            {
+                if ((x & 1) == 1 || (y & 1) == 1 || (w & 1) == 1 || (h & 1) == 1)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            ret.bitmap = new byte[Math.Abs(dLineStride * h)];
+            int sidx = GetByteOffset(x, y);
+            int didx = ret.GetByteOffset(0, 0);
+            int sidx2 = GetByteOffset(x + w, y);
+            int copyLen = sidx2 - sidx;
+            for (int i=0; i<h; ++i)
+            {
+                for (int j=0; j< copyLen; ++j)
+                {
+                    ret.bitmap[didx + j] = bitmap[sidx + j];
+                }
+                sidx += sLineStride;
+                didx += dLineStride;
+            }
+            return ret;
+        }
+
+        public void Paste(int x, int y, Bmp src)
+        {
+            int sbc = src.bmih.biBitCount;
+            int sw = src.bmih.biWidth;
+            int sh = src.bmih.biHeight;
+            int dbc = bmih.biBitCount;
+            int dw = bmih.biWidth;
+            int dh = bmih.biHeight;
+            if (sbc > dbc || x < 0 || y < 0 || x + sw > dw || y + sh > dh || (x & 1) == 1 || (sw & 1) == 1)
+            {
+                throw new NotImplementedException();
+            }
+            int sLineStride = src.GetLineStride();
+            int dLineStride = GetLineStride();
+            if (sbc == 4 && dbc == 4)
+            {
+                int sidx = Math.Abs(sLineStride) * (sh - 1);
+                int didx = Math.Abs(dLineStride) * (dh - 1 - y) + (x / 2);
+                int sw2 = sw / 2;
+                for (int i = 0; i < sh; ++i)
+                {
+                    for (int j = 0; j < sw2; ++j)
+                    {
+                        byte scidx = src.bitmap[sidx + j];
+                        RGBQUAD sc0 = src.colorTable[scidx >> 4];
+                        RGBQUAD sc1 = src.colorTable[scidx & 0xF];
+                        int dcidx0 = 0;
+                        int dcidx1 = 0;
+                        for (int k = 0; k < colorTable.Count(); ++k)
+                        {
+                            RGBQUAD dc = colorTable[k];
+                            if (sc0.Equals(dc))
+                            {
+                                dcidx0 = k;
+                            }
+                            if (sc1.Equals(dc))
+                            {
+                                dcidx1 = k;
+                            }
+                        }
+                        bitmap[didx + j] = (byte)((dcidx0 << 4) | dcidx1);
+                    }
+                    sidx += sLineStride;
+                    didx += dLineStride;
+                }
+            }
+            else if (sbc == 8 && dbc == 8)
+            {
+                int sidx = Math.Abs(sLineStride) * (sh - 1);
+                int didx = Math.Abs(dLineStride) * (dh - 1 - y) + x;
+                for (int i = 0; i < sh; ++i)
+                {
+                    for (int j = 0; j < sw; ++j)
+                    {
+                        RGBQUAD sc = src.colorTable[src.bitmap[sidx + j]];
+                        for (int k = 0; k < colorTable.Count(); ++k)
+                        {
+                            if (sc.Equals(colorTable[k]))
+                            {
+                                bitmap[didx + j] = (byte)k;
+                                break;
+                            }
+                        }
+
+                    }
+                    sidx += sLineStride;
+                    didx += dLineStride;
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public void ToFile(string fileName)
+        {
+            BITMAPFILEHEADER bmfh;
+            bmfh.bfType = 0x4D42;
+            int fileSize = Marshal.SizeOf(typeof(BITMAPFILEHEADER));
+            fileSize += Marshal.SizeOf(typeof(BITMAPINFOHEADER));
+            fileSize += Marshal.SizeOf(typeof(RGBQUAD)) * colorTable.Count();
+            bmfh.bfOffBits = (uint)fileSize;
+            fileSize += bitmap.Count();
+            bmfh.bfSize = (uint)fileSize;
+            bmfh.bfReserved1 = 0;
+            bmfh.bfReserved2 = 0;
+            using (var writer = new BinaryWriter(File.Open(fileName, FileMode.Create)))
+            {
+                ReadWriteStructWithAllocGCHandle.WriteTo<BITMAPFILEHEADER>(writer, bmfh);
+                ReadWriteStructWithAllocGCHandle.WriteTo<BITMAPINFOHEADER>(writer, bmih);
+                foreach (var c in colorTable)
+                {
+                    ReadWriteStructWithAllocGCHandle.WriteTo<RGBQUAD>(writer, c);
+                }
+                writer.BaseStream.Write(bitmap, 0, bitmap.Count());
+            }
+        }
+
+        public static Bmp FromFile(string fileName)
+        {
+            Bmp bmp = new Bmp();
+            using (BinaryReader reader = new BinaryReader(File.Open(fileName, FileMode.Open)))
+            {
+                BITMAPFILEHEADER bmfh;
+                bmfh = ReadWriteStructWithAllocGCHandle.ReadFrom<BITMAPFILEHEADER>(reader);
+                if (bmfh.bfType != 0x4D42)
+                {
+                    throw new OutOfMemoryException();
+                }
+                bmp.bmih = ReadWriteStructWithAllocGCHandle.ReadFrom<BITMAPINFOHEADER>(reader);
+                uint numQuads;
+                if (bmp.bmih.biClrUsed == 0)
+                {
+                    switch (bmp.bmih.biBitCount)
+                    {
+                        case 1:
+                            numQuads = 2;
+                            break;
+                        case 4:
+                            numQuads = 16;
+                            break;
+                        case 8:
+                            numQuads = 256;
+                            break;
+                        default:
+                            throw new OutOfMemoryException();
+                    }
+                }
+                else
+                {
+                    numQuads = bmp.bmih.biClrUsed;
+                }
+
+                if (bmp.bmih.biHeight < 0)
+                {
+                    // TODO: TopDown 形式のサポート
+                    throw new NotImplementedException();
+                }
+
+                bmp.colorTable = new RGBQUAD[numQuads];
+                for (int i = 0; i < numQuads; ++i)
+                {
+                    bmp.colorTable[i] = ReadWriteStructWithAllocGCHandle.ReadFrom<RGBQUAD>(reader);
+                }
+                if (reader.BaseStream.Position != bmfh.bfOffBits)
+                {
+                    throw new OutOfMemoryException();
+                }
+                // https://stackoverflow.com/a/10038017/4699324
+                using (var ms = new MemoryStream())
+                {
+                    reader.BaseStream.CopyTo(ms);
+                    bmp.bitmap = ms.ToArray();
+                }
+            }
+            return bmp;
+        } // FromFile
+    } // class Bmp
+
+
+}

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -70,7 +70,9 @@ namespace ToolBarImageCommon
 
         public int GetLineStride()
         {
-            int bytesPerLine = ((bmih.biWidth * bmih.biBitCount + 31) & (~31)) >> 3;
+            int bitsPerLine = (bmih.biWidth * bmih.biBitCount) + 31;
+            bitsPerLine &= ~31;
+            int bytesPerLine = bitsPerLine / 8;
             if (bmih.biHeight > 0)
                 bytesPerLine = -bytesPerLine;
             return bytesPerLine;

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -95,7 +95,7 @@ namespace ToolBarImageCommon
             int h = Math.Abs(bmih.biHeight);
             if (x < 0 || y < 0 || x > w || y > h)
             {
-                throw new OutOfMemoryException();
+                throw new ArgumentOutOfRangeException();
             }
             int bitCount = bmih.biBitCount;
             int idx = IsBottomUp() ? ((h - 1 - y) * Math.Abs(lineStride)) : (y * lineStride);
@@ -107,7 +107,7 @@ namespace ToolBarImageCommon
             {
                 if ((x & 1) == 1)
                 {
-                    throw new OutOfMemoryException();
+                    throw new ArgumentOutOfRangeException();
                 }
                 idx += x / 2;
             }
@@ -263,7 +263,7 @@ namespace ToolBarImageCommon
                 bmfh = ReadWriteStructWithAllocGCHandle.ReadFrom<BITMAPFILEHEADER>(reader);
                 if (bmfh.bfType != 0x4D42)
                 {
-                    throw new OutOfMemoryException();
+                    throw new FileFormatException();
                 }
                 bmp.bmih = ReadWriteStructWithAllocGCHandle.ReadFrom<BITMAPINFOHEADER>(reader);
                 uint numQuads;
@@ -272,16 +272,12 @@ namespace ToolBarImageCommon
                     switch (bmp.bmih.biBitCount)
                     {
                         case 1:
-                            numQuads = 2;
-                            break;
                         case 4:
-                            numQuads = 16;
-                            break;
                         case 8:
-                            numQuads = 256;
+                            numQuads = (uint)(2 << bmp.bmih.biBitCount);
                             break;
                         default:
-                            throw new OutOfMemoryException();
+                            throw new FileFormatException();
                     }
                 }
                 else
@@ -302,7 +298,7 @@ namespace ToolBarImageCommon
                 }
                 if (reader.BaseStream.Position != bmfh.bfOffBits)
                 {
-                    throw new OutOfMemoryException();
+                    throw new FileFormatException();
                 }
                 // https://stackoverflow.com/a/10038017/4699324
                 using (var ms = new MemoryStream())

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -70,8 +70,7 @@ namespace ToolBarImageCommon
 
         public int GetLineStride()
         {
-            int bitsPerLine = (bmih.biWidth * bmih.biBitCount) + 31;
-            bitsPerLine &= ~31;
+            int bitsPerLine = ((bmih.biWidth * bmih.biBitCount) + 31) & (~31);
             int bytesPerLine = bitsPerLine / 8;
             if (bmih.biHeight > 0)
                 bytesPerLine = -bytesPerLine;

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -163,12 +163,6 @@ namespace ToolBarImageCommon
         {
             int sw = src.bmih.biWidth;
             int sh = src.bmih.biHeight;
-            int dw = bmih.biWidth;
-            int dh = bmih.biHeight;
-            if (x < 0 || y < 0 || x + sw > dw || y + sh > dh || (x & 1) == 1 || (sw & 1) == 1)
-            {
-                throw new NotImplementedException();
-            }
             int sLineStride = src.GetLineStride();
             int dLineStride = GetLineStride();
             int sidx = src.GetByteOffset(0, 0);
@@ -206,12 +200,6 @@ namespace ToolBarImageCommon
         {
             int sw = src.bmih.biWidth;
             int sh = src.bmih.biHeight;
-            int dw = bmih.biWidth;
-            int dh = bmih.biHeight;
-            if (x < 0 || y < 0 || x + sw > dw || y + sh > dh || (x & 1) == 1 || (sw & 1) == 1)
-            {
-                throw new NotImplementedException();
-            }
             int sLineStride = src.GetLineStride();
             int dLineStride = GetLineStride();
             int sidx = src.GetByteOffset(0, 0);
@@ -237,6 +225,15 @@ namespace ToolBarImageCommon
 
         public void Paste(int x, int y, Bmp src)
         {
+            int sw = src.bmih.biWidth;
+            int sh = src.bmih.biHeight;
+            int dw = bmih.biWidth;
+            int dh = bmih.biHeight;
+            if (x < 0 || y < 0 || x + sw > dw || y + sh > dh || (x & 1) == 1 || (sw & 1) == 1)
+            {
+                throw new NotImplementedException();
+            }
+
             int sbc = src.bmih.biBitCount;
             int dbc = bmih.biBitCount;
             if (sbc == 4 && dbc == 4)

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -66,7 +66,7 @@ namespace ToolBarImageCommon
     {
         public BITMAPINFOHEADER bmih;
         public RGBQUAD[] colorTable;
-        public byte[] bitmap;
+        public byte[] imageData;
 
         public int GetLineStride()
         {
@@ -141,7 +141,7 @@ namespace ToolBarImageCommon
                     throw new NotImplementedException();
                 }
             }
-            ret.bitmap = new byte[Math.Abs(dLineStride * h)];
+            ret.imageData = new byte[Math.Abs(dLineStride * h)];
             int sidx = GetByteOffset(x, y);
             int didx = ret.GetByteOffset(0, 0);
             int sidx2 = GetByteOffset(x + w, y);
@@ -150,7 +150,7 @@ namespace ToolBarImageCommon
             {
                 for (int j=0; j< copyLen; ++j)
                 {
-                    ret.bitmap[didx + j] = bitmap[sidx + j];
+                    ret.imageData[didx + j] = imageData[sidx + j];
                 }
                 sidx += sLineStride;
                 didx += dLineStride;
@@ -171,12 +171,12 @@ namespace ToolBarImageCommon
             {
                 for (int j = 0; j < sw2; ++j)
                 {
-                    byte scidx = src.bitmap[sidx + j];
+                    byte scidx = src.imageData[sidx + j];
                     RGBQUAD sc0 = src.colorTable[scidx >> 4];
                     RGBQUAD sc1 = src.colorTable[scidx & 0xF];
                     int dcidx0 = Array.IndexOf(colorTable, sc0);
                     int dcidx1 = Array.IndexOf(colorTable, sc1);
-                    bitmap[didx + j] = (byte)((dcidx0 << 4) | dcidx1);
+                    imageData[didx + j] = (byte)((dcidx0 << 4) | dcidx1);
                 }
                 sidx += sLineStride;
                 didx += dLineStride;
@@ -195,8 +195,8 @@ namespace ToolBarImageCommon
             {
                 for (int j = 0; j < sw; ++j)
                 {
-                    RGBQUAD sc = src.colorTable[src.bitmap[sidx + j]];
-                    bitmap[didx + j] = (byte)Array.IndexOf(colorTable, sc);
+                    RGBQUAD sc = src.colorTable[src.imageData[sidx + j]];
+                    imageData[didx + j] = (byte)Array.IndexOf(colorTable, sc);
                 }
                 sidx += sLineStride;
                 didx += dLineStride;
@@ -238,7 +238,7 @@ namespace ToolBarImageCommon
             fileSize += Marshal.SizeOf(typeof(BITMAPINFOHEADER));
             fileSize += Marshal.SizeOf(typeof(RGBQUAD)) * colorTable.Count();
             bmfh.bfOffBits = (uint)fileSize;
-            fileSize += bitmap.Count();
+            fileSize += imageData.Count();
             bmfh.bfSize = (uint)fileSize;
             bmfh.bfReserved1 = 0;
             bmfh.bfReserved2 = 0;
@@ -250,7 +250,7 @@ namespace ToolBarImageCommon
                 {
                     ReadWriteStructWithAllocGCHandle.WriteTo<RGBQUAD>(writer, c);
                 }
-                writer.Write(bitmap);
+                writer.Write(imageData);
             }
         }
 
@@ -308,7 +308,7 @@ namespace ToolBarImageCommon
                 using (var ms = new MemoryStream())
                 {
                     reader.BaseStream.CopyTo(ms);
-                    bmp.bitmap = ms.ToArray();
+                    bmp.imageData = ms.ToArray();
                 }
             }
             return bmp;

--- a/tools/ToolBarTools/ToolBarImageCommon/Properties/AssemblyInfo.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ToolBarCommon")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ToolBarCommon")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("84e29976-dfdc-4661-9316-f434b42f75c7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/ToolBarTools/ToolBarImageCommon/ReadWriteStructWithAllocGCHandle.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/ReadWriteStructWithAllocGCHandle.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+namespace ToolBarImageCommon
+{
+    // https://smdn.jp/programming/netfx/tips/convert_struct_and_bytearray/
+    /// <summary>
+    /// ポインタを得るためにGCHandle.Allocでバイト配列のピニングを行い、
+    /// Marshal.PtrToStructure・Marshal.StructureToPtrで変換して構造体の読み書きを行う
+    /// </summary>
+    /// <remarks>参照型のフィールドを持つ構造体は読み書きできない</remarks>
+    public class ReadWriteStructWithAllocGCHandle
+    {
+        public static void WriteTo<TStruct>(BinaryWriter writer, TStruct s) where TStruct : struct
+        {
+            var buffer = new byte[Marshal.SizeOf(typeof(TStruct))];
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+            try
+            {
+                Marshal.StructureToPtr(s, handle.AddrOfPinnedObject(), false);
+            }
+            finally
+            {
+                handle.Free();
+            }
+
+            writer.Write(buffer);
+        }
+
+        public static TStruct ReadFrom<TStruct>(BinaryReader reader) where TStruct : struct
+        {
+            var buffer = reader.ReadBytes(Marshal.SizeOf(typeof(TStruct)));
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+            try
+            {
+                return (TStruct)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(TStruct));
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+    }
+}

--- a/tools/ToolBarTools/ToolBarImageCommon/ToolBarImageCommon.csproj
+++ b/tools/ToolBarTools/ToolBarImageCommon/ToolBarImageCommon.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{84E29976-DFDC-4661-9316-F434B42F75C7}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ToolBarCommon</RootNamespace>
-    <AssemblyName>ToolBarCommon</AssemblyName>
+    <RootNamespace>ToolBarImageCommon</RootNamespace>
+    <AssemblyName>ToolBarImageCommon</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bmp.cs" />
+    <Compile Include="ReadWriteStructWithAllocGCHandle.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tools/ToolBarTools/ToolBarImageCommon/ToolBarImageCommon.csproj
+++ b/tools/ToolBarTools/ToolBarImageCommon/ToolBarImageCommon.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bmp.cs" />

--- a/tools/ToolBarTools/ToolBarImageCommon/ToolBarImageCommon.csproj
+++ b/tools/ToolBarTools/ToolBarImageCommon/ToolBarImageCommon.csproj
@@ -4,17 +4,16 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <RootNamespace>ToolBarImageSplitter</RootNamespace>
-    <AssemblyName>ToolBarImageSplitter</AssemblyName>
+    <ProjectGuid>{84E29976-DFDC-4661-9316-F434B42F75C7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ToolBarCommon</RootNamespace>
+    <AssemblyName>ToolBarCommon</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -24,7 +23,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -35,7 +33,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -44,19 +41,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="BmpSplitter.cs" />
-    <Compile Include="Program.cs" />
+    <Compile Include="Bmp.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ToolBarImageCommon\ToolBarImageCommon.csproj">
-      <Project>{84e29976-dfdc-4661-9316-f434b42f75c7}</Project>
-      <Name>ToolBarImageCommon</Name>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -1,22 +1,263 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 
 namespace ToolBarImageMuxer
 {
+
+    // https://www.pinvoke.net/default.aspx/Enums/BitmapCompressionMode.html
+    public enum BitmapCompressionMode : uint
+    {
+        BI_RGB = 0,
+        BI_RLE8 = 1,
+        BI_RLE4 = 2,
+        BI_BITFIELDS = 3,
+        BI_JPEG = 4,
+        BI_PNG = 5
+    }
+
+    // https://www.pinvoke.net/default.aspx/Structures.BITMAPFILEHEADER
+    [StructLayout(LayoutKind.Sequential, Pack = 2)]
+    public struct BITMAPFILEHEADER
+    {
+        public ushort bfType;
+        public uint bfSize;
+        public ushort bfReserved1;
+        public ushort bfReserved2;
+        public uint bfOffBits;
+    }
+
+    // https://www.pinvoke.net/default.aspx/Structures.BITMAPINFOHEADER
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BITMAPINFOHEADER
+    {
+        public uint biSize;
+        public int biWidth;
+        public int biHeight;
+        public ushort biPlanes;
+        public ushort biBitCount;
+        public BitmapCompressionMode biCompression;
+        public uint biSizeImage;
+        public int biXPelsPerMeter;
+        public int biYPelsPerMeter;
+        public uint biClrUsed;
+        public uint biClrImportant;
+
+        public void Init()
+        {
+            biSize = (uint)Marshal.SizeOf(this);
+        }
+    }
+
+    // https://www.pinvoke.net/default.aspx/Structures.RGBQUAD
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct RGBQUAD
+    {
+        public byte rgbBlue;
+        public byte rgbGreen;
+        public byte rgbRed;
+        public byte rgbReserved;
+    }
+
+    // https://smdn.jp/programming/netfx/tips/convert_struct_and_bytearray/
+    /// <summary>
+    /// ポインタを得るためにGCHandle.Allocでバイト配列のピニングを行い、
+    /// Marshal.PtrToStructure・Marshal.StructureToPtrで変換して構造体の読み書きを行う
+    /// </summary>
+    /// <remarks>参照型のフィールドを持つ構造体は読み書きできない</remarks>
+    static class ReadWriteStructWithAllocGCHandle
+    {
+        public static void WriteTo<TStruct>(BinaryWriter writer, TStruct s) where TStruct : struct
+        {
+            var buffer = new byte[Marshal.SizeOf(typeof(TStruct))];
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+            try
+            {
+                Marshal.StructureToPtr(s, handle.AddrOfPinnedObject(), false);
+            }
+            finally
+            {
+                handle.Free();
+            }
+
+            writer.Write(buffer);
+        }
+
+        public static TStruct ReadFrom<TStruct>(BinaryReader reader) where TStruct : struct
+        {
+            var buffer = reader.ReadBytes(Marshal.SizeOf(typeof(TStruct)));
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+            try
+            {
+                return (TStruct)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(TStruct));
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+    }
+
+    public class Bmp
+    {
+        public BITMAPINFOHEADER bmih;
+        public RGBQUAD[] colorTable;
+        public byte[] bitmap;
+
+        public int GetLineStride()
+        {
+            int bytesPerLine = ((bmih.biWidth * bmih.biBitCount + 31) & (~31)) >> 3;
+            if (bmih.biHeight > 0)
+                bytesPerLine = -bytesPerLine;
+            return bytesPerLine;
+        }
+
+        public void Paste(int x, int y, Bmp src)
+        {
+            int sbc = src.bmih.biBitCount;
+            int sw = src.bmih.biWidth;
+            int sh = src.bmih.biHeight;
+            int dbc = bmih.biBitCount;
+            int dw = bmih.biWidth;
+            int dh = bmih.biHeight;
+            if (sbc > dbc || x < 0 || y < 0 || x + sw > dw || y + sh > dh)
+            {
+                throw new OutOfMemoryException();
+            }
+            int sLineStride = src.GetLineStride();
+            int dLineStride = GetLineStride();
+            if (sbc == 8 && dbc == 8)
+            {
+                int sidx = Math.Abs(sLineStride) * (sh - 1);
+                int didx = Math.Abs(dLineStride) * (dh - 1 - y) + x;
+                for (int i=0; i<sh; ++i)
+                {
+                    for (int j=0; j<sw; ++j)
+                    {
+                        RGBQUAD sc = src.colorTable[src.bitmap[sidx + j]];
+                        for (int k=0; k<colorTable.Count(); ++k)
+                        {
+                            if (sc.Equals(colorTable[k]))
+                            {
+                                bitmap[didx + j] = (byte)k;
+                                break;
+                            }
+                        }
+
+                    }
+                    sidx += sLineStride;
+                    didx += dLineStride;
+                }
+            }
+        }
+
+        public void ToFile(string fileName)
+        {
+            BITMAPFILEHEADER bmfh;
+            bmfh.bfType = 0x4D42;
+            int fileSize = Marshal.SizeOf(typeof(BITMAPFILEHEADER));
+            fileSize += Marshal.SizeOf(typeof(BITMAPINFOHEADER));
+            fileSize += Marshal.SizeOf(typeof(RGBQUAD)) * colorTable.Count();
+            bmfh.bfOffBits = (uint)fileSize;
+            fileSize += bitmap.Count();
+            bmfh.bfSize = (uint)fileSize;
+            bmfh.bfReserved1 = 0;
+            bmfh.bfReserved2 = 0;
+            using (var writer = new BinaryWriter(File.OpenWrite(fileName)))
+            {
+                ReadWriteStructWithAllocGCHandle.WriteTo<BITMAPFILEHEADER>(writer, bmfh);
+                ReadWriteStructWithAllocGCHandle.WriteTo<BITMAPINFOHEADER>(writer, bmih);
+                foreach (var c in colorTable)
+                {
+                    ReadWriteStructWithAllocGCHandle.WriteTo<RGBQUAD>(writer, c);
+                }
+                writer.BaseStream.Write(bitmap, 0, bitmap.Count());
+            }
+        }
+
+        public static Bmp FromFile(string fileName)
+        {
+            Bmp bmp = new Bmp();
+            using (BinaryReader reader = new BinaryReader(File.Open(fileName, FileMode.Open)))
+            {
+                BITMAPFILEHEADER bmfh;
+                bmfh = ReadWriteStructWithAllocGCHandle.ReadFrom<BITMAPFILEHEADER>(reader);
+                if (bmfh.bfType != 0x4D42)
+                {
+                    throw new OutOfMemoryException();
+                }
+                bmp.bmih = ReadWriteStructWithAllocGCHandle.ReadFrom<BITMAPINFOHEADER>(reader);
+                uint numQuads;
+                if (bmp.bmih.biClrUsed == 0)
+                {
+                    switch (bmp.bmih.biBitCount)
+                    {
+                        case 1:
+                            numQuads = 2;
+                            break;
+                        case 4:
+                            numQuads = 16;
+                            break;
+                        case 8:
+                            numQuads = 256;
+                            break;
+                        default:
+                            throw new OutOfMemoryException();
+                    }
+                }
+                else
+                {
+                    numQuads = bmp.bmih.biClrUsed;
+                }
+
+                if (bmp.bmih.biHeight < 0)
+                {
+                    // TODO: TopDown 形式のサポート
+                    throw new OutOfMemoryException();
+                }
+
+                bmp.colorTable = new RGBQUAD[numQuads];
+                for (int i=0; i<numQuads; ++i)
+                {
+                    bmp.colorTable[i] = ReadWriteStructWithAllocGCHandle.ReadFrom<RGBQUAD>(reader);
+                }
+                if (reader.BaseStream.Position != bmfh.bfOffBits)
+                {
+                    throw new OutOfMemoryException();
+                }
+                // https://stackoverflow.com/a/10038017/4699324
+                using (var ms = new MemoryStream())
+                {
+                    reader.BaseStream.CopyTo(ms);
+                    bmp.bitmap = ms.ToArray();
+                }
+            }
+            return bmp;
+        }
+    }
+
     public class BmpMuxer
     {
-        static private List<Color> CombinePalettes(List<ColorPalette> palettes)
+        static private List<RGBQUAD> CombinePalettes(List<Bmp> bmps)
         {
-            List<Color> colors = new List<Color>();
-            foreach (var palette in palettes)
+            List<RGBQUAD> colors = new List<RGBQUAD>();
+            foreach (var entry in bmps[0].colorTable)
             {
-                foreach (var entry in palette.Entries)
+                foreach (var color in colors)
+                {
+                    colors.Add(entry);
+                }
+            }
+            for (var i=1; i<bmps.Count; ++i)
+            {
+                var bmp = bmps[i];
+                foreach (var entry in bmp.colorTable)
                 {
                     bool bFound = false;
                     foreach (var color in colors)
@@ -36,157 +277,103 @@ namespace ToolBarImageMuxer
             return colors;
         }
 
-        static private Bitmap CopyToIndexedPixelFormatBitmap(Bitmap inputImage, List<Color> colors)
-        {
-            PixelFormat pixfmt;
-            if (colors.Count <= 2)
-            {
-                pixfmt = PixelFormat.Format1bppIndexed;
-            }
-            if (colors.Count <= 16)
-            {
-                pixfmt = PixelFormat.Format4bppIndexed;
-            }
-            else
-            {
-                pixfmt = PixelFormat.Format8bppIndexed;
-            }
-            var width = inputImage.Width;
-            var height = inputImage.Height;
-            var outputImage = new Bitmap(width, height, pixfmt);
-            var data = outputImage.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, pixfmt);
-            var bytes = new byte[data.Height * data.Stride];
-            switch (pixfmt)
-            {
-                case PixelFormat.Format1bppIndexed:
-                    throw new NotImplementedException();
-                case PixelFormat.Format4bppIndexed:
-                    for (int y = 0; y < height; ++y)
-                    {
-                        int w2 = width / 2;
-                        for (int i = 0; i < w2; ++i)
-                        {
-                            Color c0 = inputImage.GetPixel(i * 2 + 0, y);
-                            Color c1 = inputImage.GetPixel(i * 2 + 1, y);
-                            int idx0 = 0;
-                            int idx1 = 0;
-                            for (int j = 0; j < 16; ++j)
-                            {
-                                Color c = colors[j];
-                                if (c0 == c)
-                                {
-                                    idx0 = j;
-                                }
-                                if (c1 == c)
-                                {
-                                    idx1 = j;
-                                }
-                            }
-                            bytes[data.Stride * y + i] = (byte)(idx0 * 16 + idx1);
-                        }
-                        if (width % 2 == 1)
-                        {
-                            Color c0 = inputImage.GetPixel(width - 1, y);
-                            int idx0 = 0;
-                            for (int j = 0; j < 16; ++j)
-                            {
-                                Color c = colors[j];
-                                if (c0 == c)
-                                {
-                                    idx0 = j;
-                                }
-                            }
-                            bytes[data.Stride * y + w2] = (byte)(idx0 * 16 + idx0);
-                        }
-                    }
-                    break;
-                case PixelFormat.Format8bppIndexed:
-                    for (int y = 0; y < height; ++y)
-                    {
-                        for (int x = 0; x < width; ++x)
-                        {
-                            Color c0 = inputImage.GetPixel(x, y);
-                            for (int i = 0; i < 256; ++i)
-                            {
-                                Color c = colors[i];
-                                if (c0 == c)
-                                {
-                                    bytes[data.Stride * y + x] = (byte)i;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    break;
-            }
-            Marshal.Copy(bytes, 0, data.Scan0, bytes.Length);
-            outputImage.UnlockBits(data);
-            var pal = outputImage.Palette;
-            for (int i = 0; i < colors.Count; ++i)
-            {
-                pal.Entries[i] = colors[i];
-            }
-            outputImage.Palette = pal;
-            return outputImage;
-        }
-
         static public void Mux(string[] fileNames, string outFile, int countPerLine)
         {
-        	// 一番最初の BMP の情報を取得する
-            var bmp = (Bitmap)Image.FromFile(fileNames[0]);
-            var sx = bmp.Size.Width;
-            var sy = bmp.Size.Height;
-
+            List<Bmp> bmps = new List<Bmp>();
             var lines = (fileNames.Length + countPerLine - 1) / countPerLine;
-            var width = sx * countPerLine;
-            var height = sy * lines;
-
-            // フルカラーのビットマップを作成する (Graphics がフルカラーを必要とする)
-            var imgMerge = new Bitmap(width, height);
-            Graphics g = Graphics.FromImage(imgMerge);
-            List<ColorPalette> palettes = new List<ColorPalette>();
-
-            bool palettable = true;
             var index = 0;
-            for (var y = 0; y < height; y += sy)
+            for (var y = 0; y < lines; ++y)
             {
-                for (var x = 0; x < width; x += sx)
+                for (var x = 0; x < countPerLine; ++x)
                 {
-                    using (var bmpTmp = (Bitmap)Image.FromFile(fileNames[index]))
-                    {
-                        if (palettable)
-                        {
-	                        switch (bmpTmp.PixelFormat)
-	                        {
-	                            case PixelFormat.Format1bppIndexed:
-	                            case PixelFormat.Format4bppIndexed:
-	                            case PixelFormat.Format8bppIndexed:
-                                    palettes.Add(bmpTmp.Palette);
-	                                break;
-	                            default:
-	                                // インデックスカラー画像でなくても使われている色数を調べて判断する手もあるが、実装が手間なので行わない
-	                                palettable = false;
-	                                break;
-	                        }
-                        }
-                        var cloneRect = new RectangleF(x, y, sx, sy);
-                        g.DrawImage(bmpTmp, cloneRect);
-                    }
+                    bmps.Add(Bmp.FromFile(fileNames[index]));
                     index++;
                 }
             }
-            Bitmap imgSave = imgMerge;
+            var width = bmps[0].bmih.biWidth;
+            var height = Math.Abs(bmps[0].bmih.biHeight);
+            bool palettable = true;
+            for (var i=1; i<bmps.Count; ++i)
+            {
+                var bmp = bmps[i];
+                var width2 = bmp.bmih.biWidth;
+                var height2 = Math.Abs(bmp.bmih.biHeight);
+                if (width != width2 || height != height2)
+                {
+                    throw new Exception();
+                }
+                if (palettable)
+                {
+                    var biBitCount = bmp.bmih.biBitCount;
+                    if (biBitCount != 1 && biBitCount != 4 && biBitCount != 8)
+                    {
+                        // インデックスカラー画像でなくても使われている色数を調べて判断する手もあるが、実装が手間なので行わない
+                        palettable = false;
+                    }
+                }
+            }
+            List<RGBQUAD> colors = null;
             if (palettable)
             {
                 // パレット統合
-                var colors = CombinePalettes(palettes);
-                if (colors.Count <= 256)
+                colors = CombinePalettes(bmps);
+                if (colors.Count > 256)
                 {
-                	// インデックスカラー画像にコピー
-                    imgSave = CopyToIndexedPixelFormatBitmap(imgMerge, colors);
+                    palettable = false;
                 }
             }
-            imgSave.Save(outFile, System.Drawing.Imaging.ImageFormat.Bmp);
+            if (palettable)
+            {
+                ushort biBitCount = 8;
+                if (colors.Count <= 2)
+                {
+                    biBitCount = 1;
+                }
+                if (colors.Count <= 16)
+                {
+                    biBitCount = 4;
+                }
+                else
+                {
+                    biBitCount = 8;
+                }
+                Bmp bmp = new Bmp();
+                bmp.bmih = bmps[0].bmih;
+                bmp.bmih.biWidth = width * countPerLine;
+                bmp.bmih.biHeight = height * lines;
+                bmp.bmih.biBitCount = biBitCount;
+                if (bmp.bmih.biClrUsed == 0)
+                {
+                    bmp.colorTable = new RGBQUAD[2 << biBitCount];
+                }
+                else
+                {
+                    bmp.bmih.biClrUsed = (uint)(colors.Count);
+                    bmp.bmih.biClrImportant = bmp.bmih.biClrUsed;
+                    bmp.colorTable = new RGBQUAD[bmp.bmih.biClrUsed];
+                }
+                for (int i=0; i<colors.Count; ++i)
+                {
+                    bmp.colorTable[i] = colors[i];
+                }
+
+                int lineStride = bmp.GetLineStride();
+                bmp.bitmap = new byte[Math.Abs(lineStride * bmp.bmih.biHeight)];
+                index = 0;
+                for (var y = 0; y < lines; ++y)
+                {
+                    for (var x = 0; x < countPerLine; ++x)
+                    {
+                        bmp.Paste(x * width, y * height, bmps[index]);
+                        index++;
+                    }
+                }
+                bmp.ToFile(outFile);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -41,6 +41,29 @@ namespace ToolBarImageMuxer
             return colors;
         }
 
+        static protected bool IsPalettable(List<Bmp> bmps)
+        {
+            var width = bmps[0].bmih.biWidth;
+            var height = Math.Abs(bmps[0].bmih.biHeight);
+            for (var i = 1; i < bmps.Count; ++i)
+            {
+                var bmp = bmps[i];
+                var width2 = bmp.bmih.biWidth;
+                var height2 = Math.Abs(bmp.bmih.biHeight);
+                if (width != width2 || height != height2)
+                {
+                    throw new Exception();
+                }
+                var biBitCount = bmp.bmih.biBitCount;
+                if (biBitCount != 1 && biBitCount != 4 && biBitCount != 8)
+                {
+                    // インデックスカラー画像でなくても使われている色数を調べて判断する手もあるが、実装が手間なので行わない
+                    return false;
+                }
+            }
+            return true;
+        }
+
         static public void Mux(string[] fileNames, string outFile, int countPerLine)
         {
             List<Bmp> bmps = new List<Bmp>();
@@ -54,28 +77,7 @@ namespace ToolBarImageMuxer
                     index++;
                 }
             }
-            var width = bmps[0].bmih.biWidth;
-            var height = Math.Abs(bmps[0].bmih.biHeight);
-            bool palettable = true;
-            for (var i=1; i<bmps.Count; ++i)
-            {
-                var bmp = bmps[i];
-                var width2 = bmp.bmih.biWidth;
-                var height2 = Math.Abs(bmp.bmih.biHeight);
-                if (width != width2 || height != height2)
-                {
-                    throw new Exception();
-                }
-                if (palettable)
-                {
-                    var biBitCount = bmp.bmih.biBitCount;
-                    if (biBitCount != 1 && biBitCount != 4 && biBitCount != 8)
-                    {
-                        // インデックスカラー画像でなくても使われている色数を調べて判断する手もあるが、実装が手間なので行わない
-                        palettable = false;
-                    }
-                }
-            }
+            bool palettable = IsPalettable(bmps);
             List<RGBQUAD> colors = null;
             if (palettable)
             {
@@ -103,6 +105,8 @@ namespace ToolBarImageMuxer
                 }
                 Bmp bmp = new Bmp();
                 bmp.bmih = bmps[0].bmih;
+                var width = bmps[0].bmih.biWidth;
+                var height = Math.Abs(bmps[0].bmih.biHeight);
                 bmp.bmih.biWidth = width * countPerLine;
                 bmp.bmih.biHeight = height * lines;
                 bmp.bmih.biBitCount = biBitCount;

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -19,16 +19,7 @@ namespace ToolBarImageMuxer
                 var bmp = bmps[i];
                 foreach (var entry in bmp.colorTable)
                 {
-                    bool bFound = false;
-                    foreach (var color in colors)
-                    {
-                        if (entry.Equals(color))
-                        {
-                            bFound = true;
-                            break;
-                        }
-                    }
-                    if (!bFound)
+                    if (!colors.Contains(entry))
                     {
                         colors.Add(entry);
                     }

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -5,279 +5,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
+using ToolBarImageCommon;
 
 namespace ToolBarImageMuxer
 {
-
-    // https://www.pinvoke.net/default.aspx/Enums/BitmapCompressionMode.html
-    public enum BitmapCompressionMode : uint
-    {
-        BI_RGB = 0,
-        BI_RLE8 = 1,
-        BI_RLE4 = 2,
-        BI_BITFIELDS = 3,
-        BI_JPEG = 4,
-        BI_PNG = 5
-    }
-
-    // https://www.pinvoke.net/default.aspx/Structures.BITMAPFILEHEADER
-    [StructLayout(LayoutKind.Sequential, Pack = 2)]
-    public struct BITMAPFILEHEADER
-    {
-        public ushort bfType;
-        public uint bfSize;
-        public ushort bfReserved1;
-        public ushort bfReserved2;
-        public uint bfOffBits;
-    }
-
-    // https://www.pinvoke.net/default.aspx/Structures.BITMAPINFOHEADER
-    [StructLayout(LayoutKind.Sequential)]
-    public struct BITMAPINFOHEADER
-    {
-        public uint biSize;
-        public int biWidth;
-        public int biHeight;
-        public ushort biPlanes;
-        public ushort biBitCount;
-        public BitmapCompressionMode biCompression;
-        public uint biSizeImage;
-        public int biXPelsPerMeter;
-        public int biYPelsPerMeter;
-        public uint biClrUsed;
-        public uint biClrImportant;
-
-        public void Init()
-        {
-            biSize = (uint)Marshal.SizeOf(this);
-        }
-    }
-
-    // https://www.pinvoke.net/default.aspx/Structures.RGBQUAD
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    public struct RGBQUAD
-    {
-        public byte rgbBlue;
-        public byte rgbGreen;
-        public byte rgbRed;
-        public byte rgbReserved;
-    }
-
-    // https://smdn.jp/programming/netfx/tips/convert_struct_and_bytearray/
-    /// <summary>
-    /// ポインタを得るためにGCHandle.Allocでバイト配列のピニングを行い、
-    /// Marshal.PtrToStructure・Marshal.StructureToPtrで変換して構造体の読み書きを行う
-    /// </summary>
-    /// <remarks>参照型のフィールドを持つ構造体は読み書きできない</remarks>
-    static class ReadWriteStructWithAllocGCHandle
-    {
-        public static void WriteTo<TStruct>(BinaryWriter writer, TStruct s) where TStruct : struct
-        {
-            var buffer = new byte[Marshal.SizeOf(typeof(TStruct))];
-            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-
-            try
-            {
-                Marshal.StructureToPtr(s, handle.AddrOfPinnedObject(), false);
-            }
-            finally
-            {
-                handle.Free();
-            }
-
-            writer.Write(buffer);
-        }
-
-        public static TStruct ReadFrom<TStruct>(BinaryReader reader) where TStruct : struct
-        {
-            var buffer = reader.ReadBytes(Marshal.SizeOf(typeof(TStruct)));
-            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-
-            try
-            {
-                return (TStruct)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(TStruct));
-            }
-            finally
-            {
-                handle.Free();
-            }
-        }
-    }
-
-    public class Bmp
-    {
-        public BITMAPINFOHEADER bmih;
-        public RGBQUAD[] colorTable;
-        public byte[] bitmap;
-
-        public int GetLineStride()
-        {
-            int bytesPerLine = ((bmih.biWidth * bmih.biBitCount + 31) & (~31)) >> 3;
-            if (bmih.biHeight > 0)
-                bytesPerLine = -bytesPerLine;
-            return bytesPerLine;
-        }
-
-        public void Paste(int x, int y, Bmp src)
-        {
-            int sbc = src.bmih.biBitCount;
-            int sw = src.bmih.biWidth;
-            int sh = src.bmih.biHeight;
-            int dbc = bmih.biBitCount;
-            int dw = bmih.biWidth;
-            int dh = bmih.biHeight;
-            if (sbc > dbc || x < 0 || y < 0 || x + sw > dw || y + sh > dh  || (x & 1) == 1 || (sw & 1) == 1)
-            {
-                throw new OutOfMemoryException();
-            }
-            int sLineStride = src.GetLineStride();
-            int dLineStride = GetLineStride();
-            if (sbc == 4 && dbc == 4)
-            {
-                int sidx = Math.Abs(sLineStride) * (sh - 1);
-                int didx = Math.Abs(dLineStride) * (dh - 1 - y) + (x / 2);
-                int sw2 = sw / 2;
-                for (int i = 0; i < sh; ++i)
-                {
-                    for (int j = 0; j < sw2; ++j)
-                    {
-                        byte scidx = src.bitmap[sidx + j];
-                        RGBQUAD sc0 = src.colorTable[scidx >> 4];
-                        RGBQUAD sc1 = src.colorTable[scidx & 0xF];
-                        int dcidx0 = 0;
-                        int dcidx1 = 0;
-                        for (int k = 0; k < colorTable.Count(); ++k)
-                        {
-                            RGBQUAD dc = colorTable[k];
-                            if (sc0.Equals(dc))
-                            {
-                                dcidx0 = k;
-                            }
-                            if (sc1.Equals(dc))
-                            {
-                                dcidx1 = k;
-                            }
-                        }
-                        bitmap[didx + j] = (byte)((dcidx0 << 4) | dcidx1);
-                    }
-                    sidx += sLineStride;
-                    didx += dLineStride;
-                }
-            }
-            else if (sbc == 8 && dbc == 8)
-            {
-                int sidx = Math.Abs(sLineStride) * (sh - 1);
-                int didx = Math.Abs(dLineStride) * (dh - 1 - y) + x;
-                for (int i=0; i<sh; ++i)
-                {
-                    for (int j=0; j<sw; ++j)
-                    {
-                        RGBQUAD sc = src.colorTable[src.bitmap[sidx + j]];
-                        for (int k=0; k<colorTable.Count(); ++k)
-                        {
-                            if (sc.Equals(colorTable[k]))
-                            {
-                                bitmap[didx + j] = (byte)k;
-                                break;
-                            }
-                        }
-
-                    }
-                    sidx += sLineStride;
-                    didx += dLineStride;
-                }
-            }
-            else
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        public void ToFile(string fileName)
-        {
-            BITMAPFILEHEADER bmfh;
-            bmfh.bfType = 0x4D42;
-            int fileSize = Marshal.SizeOf(typeof(BITMAPFILEHEADER));
-            fileSize += Marshal.SizeOf(typeof(BITMAPINFOHEADER));
-            fileSize += Marshal.SizeOf(typeof(RGBQUAD)) * colorTable.Count();
-            bmfh.bfOffBits = (uint)fileSize;
-            fileSize += bitmap.Count();
-            bmfh.bfSize = (uint)fileSize;
-            bmfh.bfReserved1 = 0;
-            bmfh.bfReserved2 = 0;
-            using (var writer = new BinaryWriter(File.OpenWrite(fileName)))
-            {
-                ReadWriteStructWithAllocGCHandle.WriteTo<BITMAPFILEHEADER>(writer, bmfh);
-                ReadWriteStructWithAllocGCHandle.WriteTo<BITMAPINFOHEADER>(writer, bmih);
-                foreach (var c in colorTable)
-                {
-                    ReadWriteStructWithAllocGCHandle.WriteTo<RGBQUAD>(writer, c);
-                }
-                writer.BaseStream.Write(bitmap, 0, bitmap.Count());
-            }
-        }
-
-        public static Bmp FromFile(string fileName)
-        {
-            Bmp bmp = new Bmp();
-            using (BinaryReader reader = new BinaryReader(File.Open(fileName, FileMode.Open)))
-            {
-                BITMAPFILEHEADER bmfh;
-                bmfh = ReadWriteStructWithAllocGCHandle.ReadFrom<BITMAPFILEHEADER>(reader);
-                if (bmfh.bfType != 0x4D42)
-                {
-                    throw new OutOfMemoryException();
-                }
-                bmp.bmih = ReadWriteStructWithAllocGCHandle.ReadFrom<BITMAPINFOHEADER>(reader);
-                uint numQuads;
-                if (bmp.bmih.biClrUsed == 0)
-                {
-                    switch (bmp.bmih.biBitCount)
-                    {
-                        case 1:
-                            numQuads = 2;
-                            break;
-                        case 4:
-                            numQuads = 16;
-                            break;
-                        case 8:
-                            numQuads = 256;
-                            break;
-                        default:
-                            throw new OutOfMemoryException();
-                    }
-                }
-                else
-                {
-                    numQuads = bmp.bmih.biClrUsed;
-                }
-
-                if (bmp.bmih.biHeight < 0)
-                {
-                    // TODO: TopDown 形式のサポート
-                    throw new NotImplementedException();
-                }
-
-                bmp.colorTable = new RGBQUAD[numQuads];
-                for (int i=0; i<numQuads; ++i)
-                {
-                    bmp.colorTable[i] = ReadWriteStructWithAllocGCHandle.ReadFrom<RGBQUAD>(reader);
-                }
-                if (reader.BaseStream.Position != bmfh.bfOffBits)
-                {
-                    throw new OutOfMemoryException();
-                }
-                // https://stackoverflow.com/a/10038017/4699324
-                using (var ms = new MemoryStream())
-                {
-                    reader.BaseStream.CopyTo(ms);
-                    bmp.bitmap = ms.ToArray();
-                }
-            }
-            return bmp;
-        }
-    }
-
     public class BmpMuxer
     {
         static private List<RGBQUAD> CombinePalettes(List<Bmp> bmps)
@@ -285,10 +16,7 @@ namespace ToolBarImageMuxer
             List<RGBQUAD> colors = new List<RGBQUAD>();
             foreach (var entry in bmps[0].colorTable)
             {
-                foreach (var color in colors)
-                {
-                    colors.Add(entry);
-                }
+                colors.Add(entry);
             }
             for (var i=1; i<bmps.Count; ++i)
             {
@@ -380,12 +108,11 @@ namespace ToolBarImageMuxer
                 bmp.bmih.biBitCount = biBitCount;
                 if (bmp.bmih.biClrUsed == 0)
                 {
-                    bmp.colorTable = new RGBQUAD[2 << biBitCount];
+                    bmp.colorTable = new RGBQUAD[1 << biBitCount];
                 }
                 else
                 {
                     bmp.bmih.biClrUsed = (uint)(colors.Count);
-                    bmp.bmih.biClrImportant = bmp.bmih.biClrUsed;
                     bmp.colorTable = new RGBQUAD[bmp.bmih.biClrUsed];
                 }
                 for (int i=0; i<colors.Count; ++i)

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -112,7 +112,7 @@ namespace ToolBarImageMuxer
                 }
 
                 int lineStride = bmp.GetLineStride();
-                bmp.bitmap = new byte[Math.Abs(lineStride * bmp.bmih.biHeight)];
+                bmp.imageData = new byte[Math.Abs(lineStride * bmp.bmih.biHeight)];
                 index = 0;
                 for (var y = 0; y < lines; ++y)
                 {

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -4,11 +4,132 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
 
 namespace ToolBarImageMuxer
 {
     public class BmpMuxer
     {
+        static private List<Color> CombinePalettes(List<ColorPalette> palettes)
+        {
+            List<Color> colors = new List<Color>();
+            foreach (var palette in palettes)
+            {
+                foreach (var entry in palette.Entries)
+                {
+                    bool bFound = false;
+                    foreach (var color in colors)
+                    {
+                        if (entry.Equals(color))
+                        {
+                            bFound = true;
+                            break;
+                        }
+                    }
+                    if (!bFound)
+                    {
+                        colors.Add(entry);
+                    }
+                }
+            }
+            return colors;
+        }
+
+        static private Bitmap CopyToIndexedPixelFormatBitmap(Bitmap inputImage, List<Color> colors)
+        {
+            PixelFormat pixfmt;
+            if (colors.Count <= 2)
+            {
+                pixfmt = PixelFormat.Format1bppIndexed;
+            }
+            if (colors.Count <= 16)
+            {
+                pixfmt = PixelFormat.Format4bppIndexed;
+            }
+            else
+            {
+                pixfmt = PixelFormat.Format8bppIndexed;
+            }
+            var width = inputImage.Width;
+            var height = inputImage.Height;
+            var outputImage = new Bitmap(width, height, pixfmt);
+            var data = outputImage.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, pixfmt);
+            var bytes = new byte[data.Height * data.Stride];
+            switch (pixfmt)
+            {
+                case PixelFormat.Format1bppIndexed:
+                    throw new NotImplementedException();
+                case PixelFormat.Format4bppIndexed:
+                    for (int y = 0; y < height; ++y)
+                    {
+                        int w2 = width / 2;
+                        for (int i = 0; i < w2; ++i)
+                        {
+                            Color c0 = inputImage.GetPixel(i * 2 + 0, y);
+                            Color c1 = inputImage.GetPixel(i * 2 + 1, y);
+                            int idx0 = 0;
+                            int idx1 = 0;
+                            for (int j = 0; j < 16; ++j)
+                            {
+                                Color c = colors[j];
+                                if (c0 == c)
+                                {
+                                    idx0 = j;
+                                }
+                                if (c1 == c)
+                                {
+                                    idx1 = j;
+                                }
+                            }
+                            bytes[data.Stride * y + i] = (byte)(idx0 * 16 + idx1);
+                        }
+                        if (width % 2 == 1)
+                        {
+                            Color c0 = inputImage.GetPixel(width - 1, y);
+                            int idx0 = 0;
+                            for (int j = 0; j < 16; ++j)
+                            {
+                                Color c = colors[j];
+                                if (c0 == c)
+                                {
+                                    idx0 = j;
+                                }
+                            }
+                            bytes[data.Stride * y + w2] = (byte)(idx0 * 16 + idx0);
+                        }
+                    }
+                    break;
+                case PixelFormat.Format8bppIndexed:
+                    for (int y = 0; y < height; ++y)
+                    {
+                        for (int x = 0; x < width; ++x)
+                        {
+                            Color c0 = inputImage.GetPixel(x, y);
+                            for (int i = 0; i < 256; ++i)
+                            {
+                                Color c = colors[i];
+                                if (c0 == c)
+                                {
+                                    bytes[data.Stride * y + x] = (byte)i;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    break;
+            }
+            Marshal.Copy(bytes, 0, data.Scan0, bytes.Length);
+            outputImage.UnlockBits(data);
+            var pal = outputImage.Palette;
+            for (int i = 0; i < colors.Count; ++i)
+            {
+                pal.Entries[i] = colors[i];
+            }
+            outputImage.Palette = pal;
+            return outputImage;
+        }
+
         static public void Mux(string[] fileNames, string outFile, int countPerLine)
         {
         	// 一番最初の BMP の情報を取得する
@@ -23,7 +144,9 @@ namespace ToolBarImageMuxer
             // フルカラーのビットマップを作成する (Graphics がフルカラーを必要とする)
             var imgMerge = new Bitmap(width, height);
             Graphics g = Graphics.FromImage(imgMerge);
+            List<ColorPalette> palettes = new List<ColorPalette>();
 
+            bool palettable = true;
             var index = 0;
             for (var y = 0; y < height; y += sy)
             {
@@ -31,16 +154,38 @@ namespace ToolBarImageMuxer
                 {
                     using (var bmpTmp = (Bitmap)Image.FromFile(fileNames[index]))
                     {
+                        if (palettable)
+                        {
+	                        switch (bmpTmp.PixelFormat)
+	                        {
+	                            case PixelFormat.Format1bppIndexed:
+	                            case PixelFormat.Format4bppIndexed:
+	                            case PixelFormat.Format8bppIndexed:
+	                                break;
+	                            default:
+	                                // インデックスカラー画像でなくても使われている色数を調べて判断する手もあるが、実装が手間なので行わない
+	                                palettable = false;
+	                                break;
+	                        }
+                            palettes.Add(bmpTmp.Palette);
+                        }
                         var cloneRect = new RectangleF(x, y, sx, sy);
                         g.DrawImage(bmpTmp, cloneRect);
                     }
                     index++;
                 }
             }
-
-            // 入力のビットマップと同じ形式で保存する (減色処理含む)
-            var outRect = new RectangleF(0, 0, width, height);
-            var imgSave = imgMerge.Clone(outRect, bmp.PixelFormat);
+            Bitmap imgSave = imgMerge;
+            if (palettable)
+            {
+                // パレット統合
+                var colors = CombinePalettes(palettes);
+                if (colors.Count <= 256)
+                {
+                	// インデックスカラー画像にコピー
+                    imgSave = CopyToIndexedPixelFormatBitmap(imgMerge, colors);
+                }
+            }
             imgSave.Save(outFile, System.Drawing.Imaging.ImageFormat.Bmp);
         }
     }

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -13,11 +13,7 @@ namespace ToolBarImageMuxer
     {
         static private List<RGBQUAD> CombinePalettes(List<Bmp> bmps)
         {
-            List<RGBQUAD> colors = new List<RGBQUAD>();
-            foreach (var entry in bmps[0].colorTable)
-            {
-                colors.Add(entry);
-            }
+            List<RGBQUAD> colors = new List<RGBQUAD>(bmps[0].colorTable);
             for (var i=1; i<bmps.Count; ++i)
             {
                 var bmp = bmps[i];

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -161,13 +161,13 @@ namespace ToolBarImageMuxer
 	                            case PixelFormat.Format1bppIndexed:
 	                            case PixelFormat.Format4bppIndexed:
 	                            case PixelFormat.Format8bppIndexed:
+                                    palettes.Add(bmpTmp.Palette);
 	                                break;
 	                            default:
 	                                // インデックスカラー画像でなくても使われている色数を調べて判断する手もあるが、実装が手間なので行わない
 	                                palettable = false;
 	                                break;
 	                        }
-                            palettes.Add(bmpTmp.Palette);
                         }
                         var cloneRect = new RectangleF(x, y, sx, sy);
                         g.DrawImage(bmpTmp, cloneRect);

--- a/tools/ToolBarTools/ToolBarImageMuxer/ToolBarImageMuxer.csproj
+++ b/tools/ToolBarTools/ToolBarImageMuxer/ToolBarImageMuxer.csproj
@@ -52,5 +52,12 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ToolBarImageCommon\ToolBarImageCommon.csproj">
+      <Project>{84e29976-dfdc-4661-9316-f434b42f75c7}</Project>
+      <Name>ToolBarImageCommon</Name>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.IO;
-using System.Drawing;
 using System.Diagnostics;
+using ToolBarImageCommon;
 
 namespace ToolBarImageSplitter
 {
@@ -18,9 +18,10 @@ namespace ToolBarImageSplitter
                 Directory.CreateDirectory(outDir);
             }
 
-            var bmp = (Bitmap)Image.FromFile(fileName);
-            var width = bmp.Size.Width;
-            var height = bmp.Size.Height;
+            var bmp = Bmp.FromFile(fileName);
+            var width = bmp.bmih.biWidth;
+            var height = Math.Abs(bmp.bmih.biHeight);
+            // 縦横ピクセル数同じ限定
             var sx = width / countPerLine;
             var sy = sx;
 
@@ -30,7 +31,6 @@ namespace ToolBarImageSplitter
                 for (var x = 0; x < width; x += sx)
                 {
                     var outfile = string.Empty;
-                    
                     if (x + sx == width)
                     {
 	                    // 右端の画像はインデックス用
@@ -41,20 +41,9 @@ namespace ToolBarImageSplitter
                         index++;
                         outfile = Path.Combine(outDir, index.ToString() + ".bmp");
                     }
-
-                    var cloneRect = new RectangleF(x, y, sx, sy);
-                    using (var cloneBitmap = bmp.Clone(cloneRect, bmp.PixelFormat))
-                    {
-                        cloneBitmap.Palette = bmp.Palette;
-                        cloneBitmap.Save(outfile, System.Drawing.Imaging.ImageFormat.Bmp);
-                        Console.WriteLine("wrote {0} x={1} y={2}", outfile, x, y);
-                    }
-#if DEBUG
-                    using (var bmpDebug = (Bitmap)Image.FromFile(outfile))
-                    {
-                        Debug.Assert(bmpDebug.Palette.Entries.SequenceEqual(bmp.Palette.Entries));
-                    }
-#endif
+                    var copiedBitmap = bmp.Copy(x, y, sx, sy);
+                    copiedBitmap.ToFile(outfile);
+                    Console.WriteLine("wrote {0} x={1} y={2}", outfile, x, y);
                 }
             }
         }

--- a/tools/ToolBarTools/ToolBarTools.sln
+++ b/tools/ToolBarTools/ToolBarTools.sln
@@ -4,8 +4,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 15.0.28307.960
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolBarImageSplitter", "ToolBarImageSplitter\ToolBarImageSplitter.csproj", "{4F23CE26-8A95-44AD-BE88-45DFE08FE0F7}"
+	ProjectSection(ProjectDependencies) = postProject
+		{84E29976-DFDC-4661-9316-F434B42F75C7} = {84E29976-DFDC-4661-9316-F434B42F75C7}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolBarImageMuxer", "ToolBarImageMuxer\ToolBarImageMuxer.csproj", "{ABF37460-F080-4F1A-9F7A-F166154072FF}"
+	ProjectSection(ProjectDependencies) = postProject
+		{84E29976-DFDC-4661-9316-F434B42F75C7} = {84E29976-DFDC-4661-9316-F434B42F75C7}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolBarImageCommon", "ToolBarImageCommon\ToolBarImageCommon.csproj", "{84E29976-DFDC-4661-9316-F434B42F75C7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +29,10 @@ Global
 		{ABF37460-F080-4F1A-9F7A-F166154072FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ABF37460-F080-4F1A-9F7A-F166154072FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ABF37460-F080-4F1A-9F7A-F166154072FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84E29976-DFDC-4661-9316-F434B42F75C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84E29976-DFDC-4661-9316-F434B42F75C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84E29976-DFDC-4661-9316-F434B42F75C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84E29976-DFDC-4661-9316-F434B42F75C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# PR の目的

このPRでは結合処理の入力画像群のパレット情報を収集して使用色を集め、その使用色をパレットとしたインデックスカラー画像を作成する事を試みます。

## カテゴリ

- その他

## PR の背景

#1130 で `System.Drawing.Bitmap.Clone` メソッドによる PixelFormat 変換だと元のパレットを保ってくれない事を確認しました。https://github.com/sakura-editor/sakura/pull/1130#issuecomment-570812431

## 関連チケット

#1130 
