### PR TITLE
CNativeW::AppendStringFの文字数制約を外す

### DIFF
--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -115,8 +115,7 @@ void CNativeW::AppendStringF( const wchar_t* pszFormat, ... )
 	int added = 0;
 	if( additional > 0 ){
 		// 追加処理の実体はCRTに委譲。この関数は無効な書式を与えると即死する。
-		// CNativeW::capacity()は確保量を正確に返さないので確保要求した値 + 1を書き込み上限とする。
-		added = ::_vsnwprintf_s( &GetStringPtr()[currentLength], newCapacity + 1, _TRUNCATE, pszFormat, v );
+		added = ::_vsnwprintf_s( &GetStringPtr()[currentLength], additional + 1, _TRUNCATE, pszFormat, v );
 	}
 
 	// 可変長引数のポインタを解放

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -329,13 +329,35 @@ TEST(CNativeW, AppendStringWithFormatting)
 	ASSERT_THROW(value.AppendStringF(NULL), std::invalid_argument);
 
 	// 文字列長を0にして、追加確保が行われないケースをテストする
+	value = L"いちご100%"; //テスト前の初期値(念のため再代入しておく
 	value._SetStringLength(0);
-	value.AppendStringF(L"いちご%d%%", 25);
+	value.AppendStringF(L"いちご%d%%", 25); //1文字短くなるような指定をしている
 	ASSERT_EQ(L"いちご25%", value);
 
 	// 追加フォーマットが空文字列となるケースをテストする
 	value.AppendStringF(L"%s", L"");
 	ASSERT_EQ(L"いちご25%", value);
+
+	// 未確保状態からの書式化をテストする
+	value = NULL; //テスト前の初期値(未確保
+	value.AppendStringF( L"KEY[%03d]", 12 );
+	ASSERT_EQ( L"KEY[012]", value );
+
+	// 文字列連結(書式でmax長指定)をテストする
+	value.AppendStringF( L"%.3s", L"abcdef" );
+	ASSERT_EQ( L"KEY[012]abc", value );
+
+	// 文字列連結(書式で出力長指定)をテストする
+	value.AppendStringF( L"%6s", L"abc" );
+	ASSERT_EQ( L"KEY[012]abc   abc", value );
+
+	// フォーマット出力長2047字を超える条件をテストする
+	{
+		std::wstring longText( 2048, L'=' );
+		value = NULL; //テスト前の初期値(未確保
+		value.AppendStringF( L"%s", longText.c_str() );
+		ASSERT_EQ( longText.c_str(), value );
+	}
 }
 
 /*!

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -315,12 +315,27 @@ TEST(CNativeW, AppendStringNullLiteral)
 /*!
  * @brief 独自関数AppendStringFの仕様
  * @remark 指定したフォーマットで、引数がフォーマットされる
+ * @remark 指定したフォーマットがNULLの場合、例外を投げる
+ * @remark 確保済みメモリが十分な場合、追加確保を行わない
+ * @remark 追加される文字列が空文字列の場合、追加自体を行わない
  */
 TEST(CNativeW, AppendStringWithFormatting)
 {
 	CNativeW value;
 	value.AppendStringF(L"いちご%d%%", 100);
 	ASSERT_STREQ(L"いちご100%", value.GetStringPtr());
+
+	// フォーマットに NULL を渡したケースをテストする
+	ASSERT_THROW(value.AppendStringF(NULL), std::invalid_argument);
+
+	// 文字列長を0にして、追加確保が行われないケースをテストする
+	value._SetStringLength(0);
+	value.AppendStringF(L"いちご%d%%", 25);
+	ASSERT_EQ(L"いちご25%", value);
+
+	// 追加フォーマットが空文字列となるケースをテストする
+	value.AppendStringF(L"%s", L"");
+	ASSERT_EQ(L"いちご25%", value);
 }
 
 /*!


### PR DESCRIPTION
# PR の目的
CNativeW::AppendStringF関数の制約を外して、出力文字列長を気にせず使えるように改良します。

制約
書式化された文字列が2047文字を超えると切り捨てられてしまう

制約の原因
固定長の文字列バッファにフォーマットしたものをコピー(AppendString)しているから。

対策内容
_vscwprintf関数を使って書式化に必要な文字数を計算し、
必要なメモリを動的に(追加)確保するように変更する。

## カテゴリ
- その他

## PR の背景
別PRの指摘で、文字数制約があることが明らかになりました。
https://github.com/sakura-editor/sakura/pull/1133#issuecomment-573336766

[使わないようにする](https://github.com/sakura-editor/sakura/pull/1136) は、新設関数の問題対処として違うような気がします。
※CNativeW::AppendStringFはGitHub移行後に新設された、かなり新しい関数です。

というわけで、実はかなり前から準備していた変更提案なんですが、
PR https://github.com/sakura-editor/sakura/pull/1136 に対するカウンターオファーとして出すことにしました。

話がややこしくなるので、 CNativeW のみを対象とした変更を提案し、CNativeA の同名関数は放置します。

## PR のメリット
- CNativeW::AppendStringFの文字数制約が、実質的になくなります。

## PR のデメリット (トレードオフとかあれば)
- CNativeW::AppendStringFの文字数制約が、なくなるわけではありません。
最大メモリ要求サイズ(`_HEAP_MAXREQ`) の制約で、Max は ~~3万文字くらい~~(920M文字＝9億文字で問題なく動作できることを確認しました。3万は誤りです) です。  
- 書式化に必要なメモリを計算する処理を入れる都合、パフォーマンスが落ちる懸念があります。
代わりに、固定バッファに書式化したデータをコピーする処理が消えますが、速度重視の処理では使わないほうが良いのかも知れません。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響しうる変更です。
- 修正内容が影響を与える範囲はアプリ全域におよびます。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->
#303 CNativeA/CNativeW に対する AppendString のフォーマット書式対応版メソッドを準備
#1136 CNativeW::AppendStringF をなるべく使わないように変更

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
