### PR TITLE
ビルドに使用する Visual Studio のバージョンを指定できるようにする

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,8 @@ install:
 - cmd: |
     pip install openpyxl --user
 
+    cup vswhere
+
 # to run our custom scripts instead of automatic MSBuild
 build_script:
   - cmd: build-all.bat %PLATFORM% %CONFIGURATION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,10 +28,9 @@ install:
 - cmd: |
     pip install openpyxl --user
 
-    cup vswhere
-
 # to run our custom scripts instead of automatic MSBuild
 build_script:
+  - cmd: cup vswhere
   - cmd: build-all.bat %PLATFORM% %CONFIGURATION%
 
 # to run our custom scripts instead of automatic tests
@@ -57,6 +56,7 @@ for:
     - ps: Start-Sleep -s 10
 
   build_script:
+    - cmd: cup vswhere
     - cmd: build-chm.bat
     - cmd: help\make-artifacts.bat
 

--- a/build-sln.bat
+++ b/build-sln.bat
@@ -46,11 +46,11 @@ if errorlevel 1 (
 )
 
 if "%SONAR_QUBE_TOKEN%" == "" (
-	@echo "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
-	      "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
+	@echo "%CMD_MSBUILD%" %SLN_FILE% %PARAM_VSVERSION% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
+	      "%CMD_MSBUILD%" %SLN_FILE% %PARAM_VSVERSION% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
 ) else (
-    @echo "%BUILDWRAPPER_EXE%" --out-dir %~dp0bw-output "%CMD_MSBUILD%"  %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Rebuild" %LOG_OPTION%
-          "%BUILDWRAPPER_EXE%" --out-dir %~dp0bw-output "%CMD_MSBUILD%"  %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Rebuild" %LOG_OPTION%
+    @echo "%BUILDWRAPPER_EXE%" --out-dir %~dp0bw-output "%CMD_MSBUILD%"  %SLN_FILE% %PARAM_VSVERSION% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Rebuild" %LOG_OPTION%
+          "%BUILDWRAPPER_EXE%" --out-dir %~dp0bw-output "%CMD_MSBUILD%"  %SLN_FILE% %PARAM_VSVERSION% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Rebuild" %LOG_OPTION%
 )
 if errorlevel 1 (
 	echo ERROR in msbuild.exe errorlevel %errorlevel%

--- a/build.md
+++ b/build.md
@@ -94,6 +94,18 @@ build-all.bat <Platform> <Configuration>
 build-all.bat Win32 Release
 ```
 
+#### Visual Studio 2019 を使用してコマンドラインでビルド
+
+```
+set ARG_VSVERSION=16
+build-all.bat Win32 Release
+```
+
+参考
+
+[こちら](tools/find-tools.md#MSBuild) で ```ARG_VSVERSION``` に関して説明しています。
+
+
 ## ビルドの仕組み
 
 ### appveyor でのビルドの仕組み

--- a/tests/create-project.bat
+++ b/tests/create-project.bat
@@ -55,7 +55,12 @@ exit /b
 
 :setenv_Win32
 :setenv_x64
-	set CMAKE_GEN_OPT=-G "Visual Studio 15 2017" -A "%~1" -D BUILD_GTEST=ON
+	if defined CMAKE_G_PARAM (
+		set CMAKE_G_OPTION=-G "%CMAKE_G_PARAM%"
+	) else (
+		set CMAKE_G_OPTION=
+	)
+	set CMAKE_GEN_OPT=%CMAKE_G_OPTION% -A "%~1" -D BUILD_GTEST=ON
 exit /b
 
 :setenv_MinGW

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -13,8 +13,6 @@ if "%1" equ "clear" (
     set CMD_MSBUILD=
     set FIND_TOOLS_CALLED=
     set NUM_VSVERSION=
-    set PARAM_VSVERSION=
-    set CMAKE_G_PARAM=
     echo find-tools.bat has been cleared
     exit /b
 )
@@ -42,9 +40,6 @@ echo ^|- CMD_DOXYGEN=%CMD_DOXYGEN%
 echo ^|- CMD_VSWHERE=%CMD_VSWHERE%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
 echo ^|- CMD_CMAKE=%CMD_CMAKE%
-echo ^|- NUM_VSVERSION=%NUM_VSVERSION%
-echo ^|- PARAM_VSVERSION=%PARAM_VSVERSION%
-echo ^|- CMAKE_G_PARAM=%CMAKE_G_PARAM%
 endlocal ^
     && set "CMD_GIT=%CMD_GIT%"                  ^
     && set "CMD_7Z=%CMD_7Z%"                    ^

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -13,6 +13,8 @@ if "%1" equ "clear" (
     set CMD_MSBUILD=
     set FIND_TOOLS_CALLED=
     set NUM_VSVERSION=
+    set PARAM_VSVERSION=
+    set CMAKE_G_PARAM=
     echo find-tools.bat has been cleared
     exit /b
 )

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -12,6 +12,7 @@ if "%1" equ "clear" (
     set CMD_VSWHERE=
     set CMD_MSBUILD=
     set FIND_TOOLS_CALLED=
+    set NUM_VSVERSION=
     echo find-tools.bat has been cleared
     exit /b
 )
@@ -152,34 +153,37 @@ exit /b
 :: ---------------------------------------------------------------------------------------------------------------------
 :: sub routine for finding msbuild
 ::
-:: NUM_VSVERSION
+:: ARG_VSVERSION
 ::     latest => the latest version of installed Visual Studio
 ::     15   => Visual Studio 2017
 ::     16   => Visual Studio 2019
+::     2017 => Visual Studio 2017
+::     2019 => Visual Studio 2019
 :: ---------------------------------------------------------------------------------------------------------------------
 :msbuild
 	:: convert productLineVersion to Internal Major Version
-	if "%NUM_VSVERSION%" == "latest" (
+	if "%ARG_VSVERSION%" == "latest" (
 		echo %NUM_VSVERSION%
+		set NUM_VSVERSION=
 
-	) else if "%NUM_VSVERSION%" == "" (
+	) else if "%ARG_VSVERSION%" == "" (
 		set NUM_VSVERSION=15
 		set CMAKE_G_PARAM=Visual Studio 15 2017
 
-	) else if "%NUM_VSVERSION%" == "15" (
+	) else if "%ARG_VSVERSION%" == "15" (
 		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
 		set CMAKE_G_PARAM=Visual Studio 15 2017
 		
-	) else if "%NUM_VSVERSION%" == "16" (
+	) else if "%ARG_VSVERSION%" == "16" (
 		set PARAM_VSVERSION=/p:VisualStudioVersion=16.0
 		set CMAKE_G_PARAM=Visual Studio 16 2019
 		
-	) else if "%NUM_VSVERSION%" == "2017" (
+	) else if "%ARG_VSVERSION%" == "2017" (
 		set NUM_VSVERSION=15
 		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
 		set CMAKE_G_PARAM=Visual Studio 15 2017
 		
-	) else if "%NUM_VSVERSION%" == "2019" (
+	) else if "%ARG_VSVERSION%" == "2019" (
 		set NUM_VSVERSION=16
 		set PARAM_VSVERSION=/p:VisualStudioVersion=16.0
 		set CMAKE_G_PARAM=Visual Studio 16 2019

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -121,40 +121,65 @@ for /f "usebackq delims=" %%a in (`where $PATH2:vswhere.exe`) do (
 )
 exit /b
 
+:: ---------------------------------------------------------------------------------------------------------------------
+:: sub routine for get latest version
+:: ---------------------------------------------------------------------------------------------------------------------
+:find_msbuild
+	for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
+	    set "CMD_MSBUILD=%%a"
+	    exit /b
+	)
+	for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath`) do (
+	    set "Vs2017InstallRoot=%%d"
+	)
+	if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe" (
+	    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+	    if defined CMD_MSBUILD exit /b
+	)
+	if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe" (
+	    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe"
+	    if defined CMD_MSBUILD exit /b
+	)
+	exit /b
+
+:: ---------------------------------------------------------------------------------------------------------------------
+:: sub routine for finding msbuild
+::
+:: NUM_VSVERSION
+::     latest => the latest version of installed Visual Studio
+::     15   => Visual Studio 2017
+::     16   => Visual Studio 2019
+:: ---------------------------------------------------------------------------------------------------------------------
 :msbuild
-::find vs2017 install directory
-for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath`) do (
-    set "Vs2017InstallRoot=%%d"
-)
-if not defined Vs2017InstallRoot goto :msbuild_latest
+	:: convert productLineVersion to Internal Major Version
+	if "%NUM_VSVERSION%" == "latest" (
+		echo %NUM_VSVERSION%
 
-::find msbuild under vs2017 install directory
-if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe" (
-    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe"
-    if defined CMD_MSBUILD exit /b
-)
-if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe" (
-    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe"
-    if defined CMD_MSBUILD exit /b
-)
-if not defined USE_LATEST_MSBUILD (
-    if defined CMD_MSBUILD exit /b
-)
-
-:msbuild_latest
-::find msbuild bundled with latest visual studio(vs2019 or lator).
-for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
-    set "CMD_MSBUILD=%%a"
-    exit /b
-)
-
-::find msbuild in $env[PATH].
-for /f "usebackq delims=" %%a in (`where msbuild.exe`) do ( 
-    set "CMD_MSBUILD=%%a"
-    exit /b
-)
-exit /b
-
+	) else if "%NUM_VSVERSION%" == "" (
+		set NUM_VSVERSION=15
+		
+	) else if "%NUM_VSVERSION%" == "15" (
+		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
+		set CMAKE_G_PARAM=Visual Studio 15 2017
+		
+	) else if "%NUM_VSVERSION%" == "16" (
+		set PARAM_VSVERSION=/p:VisualStudioVersion=16.0
+		set CMAKE_G_PARAM=Visual Studio 16 2019
+		
+	) else if "%NUM_VSVERSION%" == "2017" (
+		set NUM_VSVERSION=15
+		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
+		set CMAKE_G_PARAM=Visual Studio 15 2017
+		
+	) else if "%NUM_VSVERSION%" == "2019" (
+		set NUM_VSVERSION=16
+		set PARAM_VSVERSION=/p:VisualStudioVersion=16.0
+		set CMAKE_G_PARAM=Visual Studio 16 2019
+		
+	)
+	echo NUM_VSVERSION %NUM_VSVERSION%
+	call :find_msbuild
+	exit /b
 
 :cmake
 set APPDIR=CMake\bin

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -127,8 +127,12 @@ exit /b
 :find_msbuild
 	for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
 	    set "CMD_MSBUILD=%%a"
-	    exit /b
 	)
+	if exist "%CMD_MSBUILD%" (
+		exit /b
+	)
+	set CMD_MSBUILD=
+
 	for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath`) do (
 	    set "Vs2017InstallRoot=%%d"
 	)

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -13,6 +13,8 @@ if "%1" equ "clear" (
     set CMD_MSBUILD=
     set FIND_TOOLS_CALLED=
     set NUM_VSVERSION=
+    set PARAM_VSVERSION=
+    set CMAKE_G_PARAM=
     echo find-tools.bat has been cleared
     exit /b
 )
@@ -40,6 +42,9 @@ echo ^|- CMD_DOXYGEN=%CMD_DOXYGEN%
 echo ^|- CMD_VSWHERE=%CMD_VSWHERE%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
 echo ^|- CMD_CMAKE=%CMD_CMAKE%
+echo ^|- NUM_VSVERSION=%NUM_VSVERSION%
+echo ^|- PARAM_VSVERSION=%PARAM_VSVERSION%
+echo ^|- CMAKE_G_PARAM=%CMAKE_G_PARAM%
 endlocal ^
     && set "CMD_GIT=%CMD_GIT%"                  ^
     && set "CMD_7Z=%CMD_7Z%"                    ^

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -163,18 +163,22 @@ exit /b
 :msbuild
 	:: convert productLineVersion to Internal Major Version
 	if "%ARG_VSVERSION%" == "latest" (
-		echo %NUM_VSVERSION%
 		set NUM_VSVERSION=
+		set CMAKE_G_PARAM=
+		set PARAM_VSVERSION=
 
 	) else if "%ARG_VSVERSION%" == "" (
 		set NUM_VSVERSION=15
+		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
 		set CMAKE_G_PARAM=Visual Studio 15 2017
 
 	) else if "%ARG_VSVERSION%" == "15" (
+		set NUM_VSVERSION=15
 		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
 		set CMAKE_G_PARAM=Visual Studio 15 2017
 		
 	) else if "%ARG_VSVERSION%" == "16" (
+		set NUM_VSVERSION=16
 		set PARAM_VSVERSION=/p:VisualStudioVersion=16.0
 		set CMAKE_G_PARAM=Visual Studio 16 2019
 		

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -49,6 +49,9 @@ endlocal ^
     && set "CMD_VSWHERE=%CMD_VSWHERE%"          ^
     && set "CMD_MSBUILD=%CMD_MSBUILD%"          ^
     && set "CMD_CMAKE=%CMD_CMAKE%"              ^
+    && set "NUM_VSVERSION=%NUM_VSVERSION%"      ^
+    && set "PARAM_VSVERSION=%PARAM_VSVERSION%"  ^
+    && set "CMAKE_G_PARAM=%CMAKE_G_PARAM%"      ^
     && echo end
 
 set FIND_TOOLS_CALLED=1
@@ -161,7 +164,8 @@ exit /b
 
 	) else if "%NUM_VSVERSION%" == "" (
 		set NUM_VSVERSION=15
-		
+		set CMAKE_G_PARAM=Visual Studio 15 2017
+
 	) else if "%NUM_VSVERSION%" == "15" (
 		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
 		set CMAKE_G_PARAM=Visual Studio 15 2017

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -34,11 +34,33 @@ MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。
 4. 1～3で見つからなければCMD_7Zには何もセットしない
 
 ## MSBuild
-1. CMD_MSBUILDがセットされていればそれを使う
-2. vswhere.exe(Visual Studio 2017に搭載されているバージョン)とwhereコマンド(windows標準)を利用し、Visual Studio 2017のmsbuild.exeを探す
-3. USE_LATEST_MSBUILDがセットされている場合、または、2.でmsbuild.exeが見つからない場合、vswhere.exe(Visual Studio 2019以降に搭載されたバージョン)を利用しmsbuild.exeを探す
-4. 2.および3.でmsbuild.exeが見つからない場合、whereコマンド(windows標準)を利用し、システム標準のmsbuild.exeを探す(MsBuild以外の探索手順にある「パスが通っている」と同じ意味)
-5. 2～4で見つからなければCMD_MSBUILDには何もセットしない
+
+### ユーザーがビルドに使用する Visual Studio のバージョンを切り替える方法
+
+環境変数 ```ARG_VSVERSION``` の値でビルドに使用するバージョンを切り替えられる。
+
+| ARG_VSVERSION  | 使用される Visual Studio のバージョン  |
+| -------------- | ------------------------------------- |
+| 空             | インストールされている Visual Studio の最新   |
+| 15             | Visual Studio 2017                           |
+| 16             | Visual Studio 2019                           |
+| 2017           | Visual Studio 2017                           |
+| 2019           | Visual Studio 2019                           |
+
+### 検索ロジック
+
+1. ```vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe``` で MSBuild.exe を検索する
+2. VS2019 以降の vswhere の場合
+  2.1 MSBuild.exe が見つかる。→ 検索終了
+3. VS2019 の vswhere の場合
+  3.1 ```vswhere -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath``` で VS2017 のインストールパスを検索する
+  3.2 ```%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe``` が存在する場合そのパスを MSBuild.exe のパスとする
+  3.3 ```%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe``` が存在する場合そのパスを MSBuild.exe のパスとする
+
+### MSBuild.exe の引数
+
+```PARAM_VSVERSION``` の環境変数に ```/p:VisualStudioVersion=XXX``` をセットして MSBuild.exe に渡すことにより
+実際にビルドに使用する Visual Studio のバージョンを切り替える。
 
 ### 参照
 * https://github.com/Microsoft/vswhere


### PR DESCRIPTION
# PR の目的

ビルドに使用する Visual Studio のバージョンを指定できるようにする

## カテゴリ

- ビルド手順
- CI関連
  - Appveyor
  - Azure Pipelines
  - その他連携サービス

## PR の背景

#958 のやり直し。
使用する msbuild.exe を切り替えるのではなく、`/p:VisualStudioVersion` で切り替えるようにする。

## PR のメリット

VS2017 がインストールされた環境でも、VS2019 がインストールされた環境でも
両方インストールされた環境でも好きなバージョンの VS でビルドできるようになる。

VS2019 を CI でビルドできるようにするための準備。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

ビルド

## 関連チケット

#1142: VS2019 でビルドするために必要
#698

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
