### PR TITLE
Azure Pipelines で VS2019 のビルドを行う

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,7 @@ jobs:
     name: VS2017
     vmImage: 'VS2017-Win2016'
     displayName: VS2017
+    ARG_VSVERSION: 15
 
 # サクラエディタのビルドを行う JOB (VS2019)
 # * サクラエディタ本体
@@ -70,6 +71,7 @@ jobs:
     name: VS2019
     vmImage: 'windows-2019'
     displayName: VS2019
+    ARG_VSVERSION: 16
 
 # サクラエディタのビルドを行う JOB(MinGW)
 # * サクラエディタ本体

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ pr:
 ###############################################################################################################################
 jobs:
 
-# サクラエディタのビルドを行う JOB
+# サクラエディタのビルドを行う JOB (VS2017)
 # * サクラエディタ本体
 # * HTML Help
 # * Installer
@@ -57,6 +57,19 @@ jobs:
     name: VS2017
     vmImage: 'VS2017-Win2016'
     displayName: VS2017
+
+# サクラエディタのビルドを行う JOB (VS2019)
+# * サクラエディタ本体
+# * HTML Help
+# * Installer
+# * 単体テスト
+# https://devblogs.microsoft.com/devops/hosted-pipelines-announcements-vs-2019-mojave-and-more/
+#
+- template: ci/azure-pipelines/template.job.build-unittest.yml
+  parameters:
+    name: VS2019
+    vmImage: 'windows-2019'
+    displayName: VS2019
 
 # サクラエディタのビルドを行う JOB(MinGW)
 # * サクラエディタ本体

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -26,6 +26,10 @@ jobs:
         BuildPlatform: 'x64'
         Configuration: 'Release'
 
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch
+  variables:
+    SELECT_VSVERSION: ${{ parameters.SELECT_VSVERSION }}
+
   steps:
   # show environmental variables for debug.
   - script: set

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -28,7 +28,7 @@ jobs:
 
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch
   variables:
-    SELECT_VSVERSION: ${{ parameters.SELECT_VSVERSION }}
+    ARG_VSVERSION: ${{ parameters.ARG_VSVERSION }}
 
   steps:
   # show environmental variables for debug.

--- a/ci/azure-pipelines/template.steps.install-python-modules.yml
+++ b/ci/azure-pipelines/template.steps.install-python-modules.yml
@@ -5,5 +5,8 @@
 #       なし
 #############################################################################################################
 steps:
+- script: python -m pip install --upgrade pip
+  displayName: python -m pip install --upgrade pip
+
 - script: pip install openpyxl --user
   displayName: install openpyxl --user


### PR DESCRIPTION
# PR の目的

Azure Pipelines で VS2019 のビルドを行う

## カテゴリ

- CI関連
  - Azure Pipelines

## PR の背景

#1142 および #1143 で VS2019 でのビルド対応の準備ができたので Azure Pipelines で
VS2019 のビルドを行う

## PR のメリット

Azure Pipelines でVS2019 でのビルドできるようになる。

## PR のデメリット (トレードオフとかあれば)

ビルドが長くなる。

## PR の影響範囲

Azure Piplelines でのビルド

## 関連チケット

#1142
#1143
#1144
#698

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
