### PR TITLE
[WIP] CDataProfileの通常変換からStaticStringを切り離す

### DIFF
--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -182,8 +182,9 @@ public:
 	 *
 	 * 型引数が合わないために通常入出力と分離。
 	 * @retval true	設定値を正しく読み書きできた
-	 * @retval false 設定値を読み込めたが長すぎて切り捨てられた
 	 * @retval false 設定値が存在しなかったため読込できなかった
+	 * @retval false 設定値が長すぎて読込できなかった
+	 * @remark 実際の書込みはWriteProfileで行うため、書込みモードでは失敗しない。
 	 */
 	template <int N>
 	bool IOProfileData(
@@ -200,8 +201,10 @@ public:
 			//文字列読み込み
 			if( IOProfileData( pszSectionName, pszEntryKey, buf ) ){
 				//StaticString<WCHAR, N>に変換
-				szEntryValue = buf.c_str();
-				ret = buf.length() < _countof2(szEntryValue);
+				if ( buf.length() < _countof2(szEntryValue) ){
+					szEntryValue = buf.c_str();
+					ret = true;
+				}
 			}
 		}else{
 			//文字列に変換


### PR DESCRIPTION
# PR の目的
CDataProfileの通常のデータ変換からStaticStringを切り離し、変換対象を分かりやすくします。

## カテゴリ
- その他
※戻り値の意味を追加したので、リファクタリングではありません。

## PR の背景
CDataProfile はデータ変換クラスです。

変換に対応する型は IODataProfile のコメントにリストされている通りです。
https://github.com/sakura-editor/sakura/blob/48c5110058744796ba3da38e1567a5de0310ca5a/sakura_core/CDataProfile.h#L159-L169

変換に対応する型の中に、他と違う特性を持った型が2つあります。
- `StaticString<WCHAR, N>`　変換対象型の中で唯一、テンプレートパラメータ要求する型です。
- `StringBufferW`　この型は `typedef const StringBufferW_ StringBufferW;` です（const型です）。

いずれも「文字列」を格納する型なので、ある意味で「無変換」です。
`std::wstring` とは異なり、バッファにサイズ上限があるので、
無変換でも「変換失敗」が起こりうるため「変換が必要」という奇妙な存在です。

今回は先に、`StaticString<WCHAR, N>` を通常変換から切り離します。

型がテンプレートパラメータを要求するということは、
「intやboolとは同列に扱えない」ということでもあります。

`IOProfileData` のオーバーロードテンプレートを用意して、
通常の入出力テンプレートから切り離します。
これにより、通常の入出力テンプレートが対応する変換型は
テンプレートパラメータを要求しない型のみとなります。

## PR のメリット
- ‘StaticString<WCHAR,N>` を切り離すことで通常の入出力テンプレートが分かりやすくなります。
- ‘StaticString<WCHAR,N>` の変換処理が、他の型変換とは異なることが明確になります。
- ‘IOProfileData‘ の戻り値で ‘StaticString<WCHAR,N>` を正しく読み込めたか判断できるようになります。
  - 変更前は桁溢れ時もtrueを返していました。
  - 変更後は桁溢れ時にfalseを返すようになります。
  - 変換失敗時（＝桁溢れ）を検出できるようになります。
  - 変換失敗時（＝桁溢れ）でも読める分だけのデータを読み込むのは変更前と同じです。

## PR のデメリット (トレードオフとかあれば)
- とくにありません。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。
- 修正箇所は、共有メモリに格納する設定値(文字列型)の読み書き処理です。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
