### PR TITLE
[WIP] CDataProfileクラスの今後のリファクタリング予定を晒してみる

### DIFF
--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -44,7 +44,6 @@ typedef const StringBufferW_ StringBufferW;
 
 //文字列バッファ型インスタンスの生成マクロ
 #define MakeStringBufferW(S) StringBufferW(S,_countof(S))
-#define MakeStringBufferW0(S) StringBufferW(S,0)
 
 //2007.09.24 kobake データ変換部を子クラスに分離
 //!各種データ変換付きCProfile

--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -61,6 +61,19 @@ public:
 		}
 	}
 
+	/*!
+	 * テンプレートコンストラクタ
+	 *
+	 * StringBufferWのインスタンスを構築する
+	 *
+	 * @param [in] szData 固定長文字配列への参照
+	 */
+	template <uint32_t cchDataCount>
+	StringBufferW( wchar_t( &szData )[cchDataCount] ) noexcept
+		: StringBufferW( szData, cchDataCount )
+	{
+	}
+
 	// このクラスはコピー禁止
 	StringBufferW( const StringBufferW& ) = delete;
 	StringBufferW& operator = ( const StringBufferW& ) = delete;
@@ -107,9 +120,6 @@ public:
 
 	StringBufferW& operator = ( const wchar_t* rhs ) { assign( rhs ); return *this; }
 };
-
-//文字列バッファ型インスタンスの生成マクロ
-#define MakeStringBufferW(S) StringBufferW(S,_countof(S))
 
 //2007.09.24 kobake データ変換部を子クラスに分離
 //!各種データ変換付きCProfile

--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -273,17 +273,6 @@ public:
 		}
 		return ret;
 	}
-
-	//2007.08.14 kobake 追加
-	//! intを介して任意型の入出力を行う
-	template <class T>
-	bool IOProfileData_WrapInt( const WCHAR* pszSectionName, const WCHAR* pszEntryKey, T& nEntryValue)
-	{
-		int n=nEntryValue;
-		bool ret=this->IOProfileData( pszSectionName, pszEntryKey, n );
-		nEntryValue=(T)n;
-		return ret;
-	}
 };
 
 /*!

--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -136,7 +136,7 @@ public:
 	 *
 	 * テンプレート定義は、32bit以下の符号付き整数型とenum型に対応している。
 	 * それ以外の型で利用したい場合は、特殊化定義を書いて使う。
-	 * 既存コードにあった32bit以下の符号なし整数型, bool, CLayoutInt, CLogicInt, wchar_t, KEYCODE は特殊化済み。
+	 * 既存コードにあった32bit以下の符号なし整数型, bool, CLayoutInt, CLogicInt, wchar_t は特殊化済み。
 	 */
 	template<typename NumType, typename = std::enable_if_t<sizeof(NumType) <= sizeof(int32_t)>>
 	static bool TryParse( const std::wstring& profile, NumType& value ) noexcept
@@ -158,7 +158,7 @@ public:
 	 *
 	 * テンプレート定義は、組込の整数型とenum型に対応している。
 	 * 整数以外の型で利用したい場合は、特殊化定義を書いて使う。
-	 * 既存コードにあった型 bool, CLayoutInt, CLogicInt, wchar_t, char は特殊化済み。
+	 * 既存コードにあった型 bool, CLayoutInt, CLogicInt, wchar_t は特殊化済み。
 	 */
 	template<typename NumType>
 	static std::wstring ConvertToString( const NumType value ) noexcept
@@ -179,7 +179,7 @@ public:
 	 *
 	 * 標準stringを介して設定値の入出力を行う。
 	 */
-	template <class T> //T=={整数型, enum型, bool, wchar_t, char}
+	template <class T> //T=={整数型, enum型, bool, wchar_t}
 	bool IOProfileData(
 		const WCHAR*			pszSectionName,	//!< [in] セクション名
 		const WCHAR*			pszEntryKey,	//!< [in] エントリ名
@@ -403,46 +403,6 @@ template<> inline
 std::wstring CDataProfile::ConvertToString<WCHAR>( const WCHAR value ) noexcept
 {
 	return std::wstring( 1, value );
-}
-
-/*!
- * 文字列(標準string)から設定値を読み取る
- *
- * 元々ACHAR型の変換メソッドになっていたものを再定義。
- * カスタムメニューのニーモニック設定に使われている。
- *
- * ニーモニックとは、「ファイル(F)」の F のこと。
- * 
- * @sa CommonSetting_CustomMenu::m_nCustMenuItemKeyArr
- */
-template<>
-static inline
-bool CDataProfile::TryParse<KEYCODE>( const std::wstring& profile, KEYCODE& value ) noexcept
-{
-	bool ret = false;
-	if( profile.length() > 0 ){
-		// ニーモニックなので基本的に印字可能文字だが、
-		// 「なし」を意味する \0 を読み書きしている関係で、
-		// sakura.iniが「バイナリ」になってしまっている。
-		KEYCODE buf[2] = { 0 };
-		int ret = wctomb( buf, profile[0] );
-		assert_warning( ret == 1 );
-		if ( ret == 1 ){
-			value = buf[0];
-			ret = true;
-		}
-	}
-	return ret;
-}
-
-//! 設定値を文字列(標準string)に変換する
-template<>
-static inline
-std::wstring CDataProfile::ConvertToString<KEYCODE>( const ACHAR value ) noexcept
-{
-	WCHAR buf[2] = { 0 };
-	mbtowc( buf, &value, 1 );
-	return std::wstring( buf, 1 );
 }
 
 /*[EOF]*/

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -480,7 +480,7 @@ static bool IOProfSettings( SProfileSettings& settings, bool bWrite )
 	if( settings.m_nDefaultIndex < -1 ){
 		settings.m_nDefaultIndex = -1;
 	}
-	cProf.IOProfileData( pSection, L"szDllLanguage", StringBufferW(settings.m_szDllLanguage, _countof(settings.m_szDllLanguage)) );
+	cProf.IOProfileData( pSection, L"szDllLanguage", StringBufferW( settings.m_szDllLanguage ) );
 	cProf.IOProfileData( pSection, L"bDefaultSelect", settings.m_bDefaultSelect );
 
 	if( bWrite ){

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -100,7 +100,7 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 			if (langId != MAKELANGID( LANG_JAPANESE, SUBLANG_JAPANESE_JAPAN )) {
 				DLLSHAREDATA* pShareData = &GetDllShareData();
 				wcscpy(pShareData->m_Common.m_sWindow.m_szLanguageDll, L"sakura_lang_en_US.dll");
-				cProfile.IOProfileData( L"Common", L"szLanguageDll", MakeStringBufferW( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );
+				cProfile.IOProfileData( L"Common", L"szLanguageDll", StringBufferW( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );
 				CSelectLang::ChangeLang( pShareData->m_Common.m_sWindow.m_szLanguageDll );
 				pcShare->RefreshString();
 			}
@@ -111,7 +111,7 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 		WCHAR iniVer[256];
 		DWORD mH, mL, lH, lL;
 		mH = mL = lH = lL = 0;	// ※ 古～い ini だと "szVersion" は無い
-		if( cProfile.IOProfileData( LTEXT("Other"), LTEXT("szVersion"), MakeStringBufferW(iniVer) ) )
+		if( cProfile.IOProfileData( LTEXT("Other"), LTEXT("szVersion"), StringBufferW( iniVer ) ) )
 			_stscanf( iniVer, L"%u.%u.%u.%u", &mH, &mL, &lH, &lL );
 		DWORD dwMS = (DWORD)MAKELONG(mL, mH);
 		DWORD dwLS = (DWORD)MAKELONG(lL, lH);
@@ -131,7 +131,7 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 
 	if( bRead ){
 		DLLSHAREDATA* pShareData = &GetDllShareData();
-		cProfile.IOProfileData( L"Common", L"szLanguageDll", MakeStringBufferW( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );
+		cProfile.IOProfileData( L"Common", L"szLanguageDll", StringBufferW( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );
 		CSelectLang::ChangeLang( pShareData->m_Common.m_sWindow.m_szLanguageDll );
 		pcShare->RefreshString();
 	}
@@ -208,12 +208,12 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].nCharCode"), i );
 		cProfile.IOProfileData_WrapInt( pszSecName, szKeyName, pfiWork->m_nCharCode );
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].szPath"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pfiWork->m_szPath) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pfiWork->m_szPath ) );
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].szMark2"), i );
-		if( !cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pfiWork->m_szMarkLines) ) ){
+		if( !cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pfiWork->m_szMarkLines ) ) ){
 			if( cProfile.IsReadingMode() ){
 				auto_sprintf( szKeyName, LTEXT("MRU[%02d].szMark"), i ); // 旧ver互換
-				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pfiWork->m_szMarkLines) );
+				cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pfiWork->m_szMarkLines ) );
 			}
 		}
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].nType"), i );
@@ -417,9 +417,9 @@ void CShareData_IO::ShareData_IO_Nickname( CDataProfile& cProfile )
 	int nSize = pShare->m_Common.m_sFileName.m_nTransformFileNameArrNum;
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, LTEXT("From%02d"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pShare->m_Common.m_sFileName.m_szTransformFileNameFrom[i]) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pShare->m_Common.m_sFileName.m_szTransformFileNameFrom[i] ) );
 		auto_sprintf( szKeyName, LTEXT("To%02d"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pShare->m_Common.m_sFileName.m_szTransformFileNameTo[i]) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pShare->m_Common.m_sFileName.m_szTransformFileNameTo[i] ) );
 	}
 	// 読み込み時，残りをNULLで再初期化
 	if( cProfile.IsReadingMode() ){
@@ -436,7 +436,7 @@ static bool ShareData_IO_RECT( CDataProfile& cProfile, const WCHAR* pszSecName, 
 	WCHAR		szKeyData[100];
 	bool		ret = false;
 	if( cProfile.IsReadingMode() ){
-		ret = cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData) );
+		ret = cProfile.IOProfileData( pszSecName, pszKeyName, StringBufferW( szKeyData ) );
 		if( ret ){
 			int buf[4];
 			scan_ints( szKeyData, pszForm, buf );
@@ -454,7 +454,7 @@ static bool ShareData_IO_RECT( CDataProfile& cProfile, const WCHAR* pszSecName, 
 			rcValue.right,
 			rcValue.bottom
 		);
-		ret = cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData) );
+		ret = cProfile.IOProfileData( pszSecName, pszKeyName, StringBufferW( szKeyData ) );
 	}
 	return ret;
 }
@@ -487,7 +487,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("m_bRestoreBookmarks")	, common.m_sFile.m_bRestoreBookmarks );
 	cProfile.IOProfileData( pszSecName, LTEXT("bAddCRLFWhenCopy")		, common.m_sEdit.m_bAddCRLFWhenCopy );
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOpenDialogDir")		, common.m_sEdit.m_eOpenDialogDir );
-	cProfile.IOProfileData( pszSecName, LTEXT("szOpenDialogSelDir")		, StringBufferW(common.m_sEdit.m_OpenDialogSelDir,_countof2(common.m_sEdit.m_OpenDialogSelDir)) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szOpenDialogSelDir")		, common.m_sEdit.m_OpenDialogSelDir );
 	cProfile.IOProfileData( pszSecName, LTEXT("bBoxSelectLock")	, common.m_sEdit.m_bBoxSelectLock );
 	cProfile.IOProfileData( pszSecName, LTEXT("bVistaStyleFileDialog")	, common.m_sEdit.m_bVistaStyleFileDialog );
 	cProfile.IOProfileData( pszSecName, LTEXT("nRepeatedScrollLineNum")	, common.m_sGeneral.m_nRepeatedScrollLineNum );
@@ -523,7 +523,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("nTagJumpModeKeyword")	, common.m_sSearch.m_nTagJumpModeKeyword );
 	
 	/* 正規表現DLL 2007.08.12 genta */
-	cProfile.IOProfileData( pszSecName, LTEXT("szRegexpLib")			, MakeStringBufferW(common.m_sSearch.m_szRegexpLib) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szRegexpLib")			, StringBufferW( common.m_sSearch.m_szRegexpLib ) );
 	cProfile.IOProfileData( pszSecName, LTEXT("bGTJW_RETURN")			, common.m_sSearch.m_bGTJW_RETURN );
 	cProfile.IOProfileData( pszSecName, LTEXT("bGTJW_LDBLCLK")			, common.m_sSearch.m_bGTJW_LDBLCLK );
 	cProfile.IOProfileData( pszSecName, LTEXT("bBackUp")				, common.m_sBackup.m_bBackUp );
@@ -566,11 +566,11 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bBackUpPathAdvanced")	, common.m_sBackup.m_bBackUpPathAdvanced );	/* 20051107 aroka */
 	cProfile.IOProfileData( pszSecName, LTEXT("szBackUpPathAdvanced")	, common.m_sBackup.m_szBackUpPathAdvanced );	/* 20051107 aroka */
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nFileShareMode")			, common.m_sFile.m_nFileShareMode );
-	cProfile.IOProfileData( pszSecName, LTEXT("szExtHelp"), MakeStringBufferW(common.m_sHelper.m_szExtHelp) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szExtHtmlHelp"), MakeStringBufferW(common.m_sHelper.m_szExtHtmlHelp) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szExtHelp"), StringBufferW( common.m_sHelper.m_szExtHelp ) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szExtHtmlHelp"), StringBufferW( common.m_sHelper.m_szExtHtmlHelp ) );
 	
-	cProfile.IOProfileData( pszSecName, LTEXT("szMigemoDll"), MakeStringBufferW(common.m_sHelper.m_szMigemoDll) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szMigemoDict"), MakeStringBufferW(common.m_sHelper.m_szMigemoDict) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szMigemoDll"), StringBufferW( common.m_sHelper.m_szMigemoDll ) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szMigemoDict"), StringBufferW( common.m_sHelper.m_szMigemoDict ) );
 	
 	// ai 02/05/23 Add S
 	{// Keword Help Font
@@ -588,14 +588,14 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispMiniMap")			, common.m_sWindow.m_bDispMiniMap );
 	cProfile.IOProfileData( pszSecName, LTEXT("nFUNCKEYWND_Place")		, common.m_sWindow.m_nFUNCKEYWND_Place );
 	cProfile.IOProfileData( pszSecName, LTEXT("nFUNCKEYWND_GroupNum")	, common.m_sWindow.m_nFUNCKEYWND_GroupNum );		// 2002/11/04 Moca ファンクションキーのグループボタン数
-	cProfile.IOProfileData( pszSecName, LTEXT("szLanguageDll")			, MakeStringBufferW( common.m_sWindow.m_szLanguageDll ) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szLanguageDll")			, StringBufferW( common.m_sWindow.m_szLanguageDll ) );
 	cProfile.IOProfileData( pszSecName, LTEXT("nMiniMapFontSize")		, common.m_sWindow.m_nMiniMapFontSize );
 	cProfile.IOProfileData( pszSecName, LTEXT("nMiniMapQuality")		, common.m_sWindow.m_nMiniMapQuality );
 	cProfile.IOProfileData( pszSecName, LTEXT("nMiniMapWidth")			, common.m_sWindow.m_nMiniMapWidth );
 	
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabWnd")			, common.m_sTabBar.m_bDispTabWnd );	//タブウインドウ	//@@@ 2003.05.31 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabWndMultiWin")	, common.m_sTabBar.m_bDispTabWndMultiWin );	//タブウインドウ	//@@@ 2003.05.31 MIK
-	cProfile.IOProfileData( pszSecName, LTEXT("szTabWndCaption")		, MakeStringBufferW(common.m_sTabBar.m_szTabWndCaption) );	//@@@ 2003.06.13 MIK
+	cProfile.IOProfileData( pszSecName, LTEXT("szTabWndCaption")		, StringBufferW( common.m_sTabBar.m_szTabWndCaption ) );	//@@@ 2003.06.13 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bSameTabWidth")			, common.m_sTabBar.m_bSameTabWidth );	// 2006.01.28 ryoji タブを等幅にする
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabIcon")			, common.m_sTabBar.m_bDispTabIcon );	// 2006.01.28 ryoji タブにアイコンを表示する
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bDispTabClose")	, common.m_sTabBar.m_bDispTabClose );	// 2012.04.14 syat
@@ -619,8 +619,8 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bSplitterWndHScroll")	, common.m_sWindow.m_bSplitterWndHScroll );
 	cProfile.IOProfileData( pszSecName, LTEXT("bSplitterWndVScroll")	, common.m_sWindow.m_bSplitterWndVScroll );
 	
-	cProfile.IOProfileData( pszSecName, LTEXT("szMidashiKigou")		, MakeStringBufferW(common.m_sFormat.m_szMidashiKigou) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szInyouKigou")			, MakeStringBufferW(common.m_sFormat.m_szInyouKigou) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szMidashiKigou")		, StringBufferW( common.m_sFormat.m_szMidashiKigou ) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szInyouKigou")			, StringBufferW( common.m_sFormat.m_szInyouKigou ) );
 	
 	// 2001/06/14 asa-o 補完とキーワードヘルプはタイプ別に移動したので削除：３行
 	// 2002/09/21 Moca bGrepKanjiCode_AutoDetect は bGrepCharSetに統合したので削除
@@ -681,9 +681,9 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_SPACE")			, common.m_sHelper.m_bHokanKey_SPACE );/* VK_SPACE  補完決定キーが有効/無効 */
 	
 	cProfile.IOProfileData( pszSecName, LTEXT("nDateFormatType")			, common.m_sFormat.m_nDateFormatType );/* 日付書式のタイプ */
-	cProfile.IOProfileData( pszSecName, LTEXT("szDateFormat")				, MakeStringBufferW(common.m_sFormat.m_szDateFormat) );//日付書式
+	cProfile.IOProfileData( pszSecName, LTEXT("szDateFormat")				, StringBufferW( common.m_sFormat.m_szDateFormat ) );//日付書式
 	cProfile.IOProfileData( pszSecName, LTEXT("nTimeFormatType")			, common.m_sFormat.m_nTimeFormatType );/* 時刻書式のタイプ */
-	cProfile.IOProfileData( pszSecName, LTEXT("szTimeFormat")				, MakeStringBufferW(common.m_sFormat.m_szTimeFormat) );//時刻書式
+	cProfile.IOProfileData( pszSecName, LTEXT("szTimeFormat")				, StringBufferW( common.m_sFormat.m_szTimeFormat ) );//時刻書式
 	
 	cProfile.IOProfileData( pszSecName, LTEXT("bMenuIcon")					, common.m_sWindow.m_bMenuIcon );//メニューにアイコンを表示する
 	cProfile.IOProfileData( pszSecName, LTEXT("bAutoMIMEdecode")			, common.m_sFile.m_bAutoMIMEdecode );//ファイル読み込み時にMIMEのdecodeを行うか
@@ -708,8 +708,8 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bFunclistSetFocusOnJump")	, common.m_sOutline.m_bFunclistSetFocusOnJump );
 	
 	//	Apr. 05, 2003 genta ウィンドウキャプションのカスタマイズ
-	cProfile.IOProfileData( pszSecName, LTEXT("szWinCaptionActive") , MakeStringBufferW(common.m_sWindow.m_szWindowCaptionActive) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szWinCaptionInactive"), MakeStringBufferW(common.m_sWindow.m_szWindowCaptionInactive) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szWinCaptionActive") , StringBufferW( common.m_sWindow.m_szWindowCaptionActive ) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szWinCaptionInactive"), StringBufferW( common.m_sWindow.m_szWindowCaptionInactive ) );
 	
 	// アウトライン/トピックリスト の位置とサイズを記憶  20060201 aroka
 	cProfile.IOProfileData( pszSecName, LTEXT("bRememberOutlineWindowPos"), common.m_sOutline.m_bRememberOutlineWindowPos);
@@ -728,7 +728,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 		const WCHAR* pszForm = LTEXT("%d,%d,%d,%d");
 		WCHAR		szKeyData[1024];
 		if( cProfile.IsReadingMode() ){
-			if( cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData)) ){
+			if( cProfile.IOProfileData( pszSecName, pszKeyName, StringBufferW( szKeyData ) ) ){
 				int buf[4];
 				scan_ints( szKeyData, pszForm, buf );
 				common.m_sOutline.m_cxOutlineDockLeft	= buf[0];
@@ -745,7 +745,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 				common.m_sOutline.m_cxOutlineDockRight,
 				common.m_sOutline.m_cyOutlineDockBottom
 			);
-			cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData) );
+			cProfile.IOProfileData( pszSecName, pszKeyName, StringBufferW( szKeyData ) );
 		}
 	}
 	cProfile.IOProfileData( pszSecName, LTEXT("nDockOutline"), common.m_sOutline.m_nDockOutline );
@@ -871,7 +871,7 @@ void CShareData_IO::ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* p
 		// Plugin String Parametor
 		if( cProfile.IsReadingMode() ){
 			//読み込み
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szText) );
+			cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szText ) );
 			if (wcschr(szText, L'/') == NULL) {
 				// 番号
 				toolbar.m_nToolBarButtonIdxArr[i] = _wtoi( szText );
@@ -899,7 +899,7 @@ void CShareData_IO::ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* p
 					cProfile.IOProfileData( pszSecName, szKeyName, nInvalid );	
 				}
 				else if (GetPlugCmdInfoByFuncCode( eFunc, szText )) {
-					cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szText) );	
+					cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szText ) );	
 				}
 				else {
 					cProfile.IOProfileData( pszSecName, szKeyName, toolbar.m_nToolBarButtonIdxArr[i] );	
@@ -944,7 +944,7 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 
 	for( i = 0; i < MAX_CUSTOM_MENU; ++i ){
 		auto_sprintf( szKeyName, LTEXT("szCMN[%02d]"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(menu.m_szCustMenuNameArr[i]) );	//	Oct. 15, 2001 genta 最大長指定
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( menu.m_szCustMenuNameArr[i] ) );	//	Oct. 15, 2001 genta 最大長指定
 		auto_sprintf( szKeyName, LTEXT("bCMPOP[%02d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, menu.m_bCustMenuPopupArr[i] );
 		auto_sprintf( szKeyName, LTEXT("nCMIN[%02d]"), i );
@@ -955,14 +955,14 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 			// start マクロ名でも設定できるように 2008/5/24 Uchi
 			auto_sprintf( szKeyName, LTEXT("nCMIF[%02d][%02d]"), i, j );
 			if (cProfile.IsReadingMode()) {
-				cProfile.IOProfileData(pszSecName, szKeyName, MakeStringBufferW(szFuncName));
+				cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW( szFuncName ) );
 				n = GetFunctionStrToFunctionCode(szFuncName);
 				menu.m_nCustMenuItemFuncArr[i][j] = n;
 			}
 			else {
 				if (GetPlugCmdInfoByFuncCode( menu.m_nCustMenuItemFuncArr[i][j], szFuncName)) {
 					// Plugin
-					cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szFuncName) );
+					cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szFuncName ) );
 				}
 				else {
 					if (bOutCmdName) {
@@ -975,7 +975,7 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 						if ( p == NULL ) {
 							auto_sprintf( szFuncName, L"%d", menu.m_nCustMenuItemFuncArr[i][j] );
 						}
-						cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szFuncName) );
+						cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szFuncName ) );
 					}
 					else {
 						cProfile.IOProfileData_WrapInt( pszSecName, szKeyName, menu.m_nCustMenuItemFuncArr[i][j] );
@@ -1040,7 +1040,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 	int nKeyNameArrUsed = sKeyBind.m_nKeyNameArrNum; // 使用済み領域
 
 	if( cProfile.IsReadingMode() ){ 
-		if (!cProfile.IOProfileData( szSecName, L"KeyBind[000]", MakeStringBufferW(szKeyData) ) ) {
+		if (!cProfile.IOProfileData( szSecName, L"KeyBind[000]", StringBufferW( szKeyData ) ) ) {
 			bOldVer = true;
 		}
 		else {
@@ -1059,7 +1059,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 			if (bOldVer) {
 				KEYDATA& keydata = sKeyBind.m_pKeyNameArr[i];
 				wcscpy_s( szKeyName, keydata.m_szKeyName );
-				if( cProfile.IOProfileData( szSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+				if( cProfile.IOProfileData( szSecName, szKeyName, StringBufferW( szKeyData ) ) ){
 					int buf[8];
 					scan_ints( szKeyData, LTEXT("%d,%d,%d,%d,%d,%d,%d,%d"), buf );
 					keydata.m_nFuncCodeArr[0]	= (EFunctionCode)buf[0];
@@ -1075,7 +1075,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 			else {		// 新バージョン(キー割り当てのImport,export の合わせた)	2008/5/25 Uchi
 				KEYDATA tmpKeydata;
 				auto_sprintf(szKeyName, L"KeyBind[%03d]", i);
-				if( cProfile.IOProfileData( szSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+				if( cProfile.IOProfileData( szSecName, szKeyName, StringBufferW( szKeyData ) ) ){
 					wchar_t	*p;
 					wchar_t	*pn;
 					int		nRes;
@@ -1144,7 +1144,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 		//		keydata.m_nFuncCodeArr[6],
 		//		keydata.m_nFuncCodeArr[7]
 		//	);
-		//	cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+		//	cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) );
 
 // start 新バージョン	2008/5/25 Uchi
 			KEYDATA& keydata = sKeyBind.m_pKeyNameArr[i];
@@ -1187,7 +1187,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 				auto_sprintf(szWork, L",%s", keydata.m_szKeyName);
 			}
 			wcscat(szKeyData, szWork);
-			cProfile.IOProfileData( szSecName, szKeyName, MakeStringBufferW(szKeyData) );
+			cProfile.IOProfileData( szSecName, szKeyName, StringBufferW( szKeyData ) );
 //
 		}
 	}
@@ -1217,7 +1217,7 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].nInts"), i );
 		static const WCHAR* pszForm = LTEXT("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d");
 		if( cProfile.IsReadingMode() ){
-			if( cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+			if( cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) ) ){
 				int buf[19];
 				scan_ints( szKeyData, pszForm, buf );
 				printsetting.m_nPrintFontWidth			= buf[ 0];
@@ -1262,21 +1262,21 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 				printsetting.m_bFooterUse[1]?1:0,
 				printsetting.m_bFooterUse[2]?1:0
 			);
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+			cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) );
 		}
 
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szSName")	, i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szPrintSettingName) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( printsetting.m_szPrintSettingName ) );
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szFF")	, i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szPrintFontFaceHan) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( printsetting.m_szPrintFontFaceHan ) );
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szFFZ")	, i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szPrintFontFaceZen) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( printsetting.m_szPrintFontFaceZen ) );
 		// ヘッダ/フッタ
 		for( j = 0; j < 3; ++j ){
 			auto_sprintf( szKeyName, LTEXT("PS[%02d].szHF[%d]") , i, j );
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szHeaderForm[j]) );
+			cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( printsetting.m_szHeaderForm[j] ) );
 			auto_sprintf( szKeyName, LTEXT("PS[%02d].szFTF[%d]"), i, j );
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szFooterForm[j]) );
+			cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( printsetting.m_szFooterForm[j] ) );
 		}
 		{ // ヘッダ/フッタ フォント設定
 			WCHAR	szKeyName2[64];
@@ -1294,11 +1294,11 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 		}
 
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szDriver"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_mdmDevMode.m_szPrinterDriverName) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( printsetting.m_mdmDevMode.m_szPrinterDriverName ) );
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szDevice"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_mdmDevMode.m_szPrinterDeviceName) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( printsetting.m_mdmDevMode.m_szPrinterDeviceName ) );
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szOutput"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_mdmDevMode.m_szPrinterOutputName) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( printsetting.m_mdmDevMode.m_szPrinterOutputName ) );
 
 		// 2002.02.16 hor とりあえず旧設定を変換しとく
 		if(0==wcscmp(printsetting.m_szHeaderForm[0],_EDITL("&f")) &&
@@ -1406,8 +1406,8 @@ static bool ShareData_IO_BlockComment( CDataProfile& cProfile,
 	}
 
 	bool ret = false;
-	if( cProfile.IOProfileData( pszSectionName, pszEntryKeyFrom, MakeStringBufferW( szFrom ) )
-		&& cProfile.IOProfileData( pszSectionName, pszEntryKeyTo, MakeStringBufferW( szTo ) ) ){
+	if( cProfile.IOProfileData( pszSectionName, pszEntryKeyFrom, StringBufferW( szFrom ) )
+		&& cProfile.IOProfileData( pszSectionName, pszEntryKeyTo, StringBufferW( szTo ) ) ){
 		//対になる設定が揃った場合のみ有効
 		ret = true;
 	}
@@ -1444,7 +1444,7 @@ static bool ShareData_IO_LineComment( CDataProfile& cProfile,
 	}
 
 	bool ret = false;
-	if( cProfile.IOProfileData( pszSectionName, pszEntryKeyComment, MakeStringBufferW( lbuf ) )
+	if( cProfile.IOProfileData( pszSectionName, pszEntryKeyComment, StringBufferW( lbuf ) )
 		&& cProfile.IOProfileData( pszSectionName, pszEntryKeyColumn, pos ) ){
 		//対になる設定が揃った場合のみ有効
 		ret = true;
@@ -1477,7 +1477,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	static const WCHAR* pszForm = LTEXT("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d");	//MIK
 	wcscpy( szKeyName, LTEXT("nInts") );
 	if( cProfile.IsReadingMode() ){
-		if( cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+		if( cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) ) ){
 			int buf[12];
 			scan_ints( szKeyData, pszForm, buf );
 			types.m_nIdx					= buf[ 0];
@@ -1516,7 +1516,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 			types.m_nCurrentPrintSetting,
 			types.m_nTsvMode
 		);
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) );
 	}
 	// 2005.01.13 MIK Keywordset 3-10
 	cProfile.IOProfileData( pszSecName, LTEXT("nKeywordSelect3"),  types.m_nKeyWordSetIdx[2] );
@@ -1550,13 +1550,13 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		}
 	}
 
-	cProfile.IOProfileData( pszSecName, LTEXT("szTypeName"), MakeStringBufferW(types.m_szTypeName) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szTypeExts"), MakeStringBufferW(types.m_szTypeExts) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szTypeName"), StringBufferW( types.m_szTypeName ) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szTypeExts"), StringBufferW( types.m_szTypeExts ) );
 	cProfile.IOProfileData( pszSecName, LTEXT("id"), types.m_id );
 	if( types.m_id < 0 ){
 		types.m_id *= -1;
 	}
-	cProfile.IOProfileData( pszSecName, LTEXT("szTabViewString"), MakeStringBufferW(types.m_szTabViewString) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szTabViewString"), StringBufferW( types.m_szTabViewString ) );
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bTabArrow")	, types.m_bTabArrow );	//@@@ 2003.03.26 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bInsSpace")			, types.m_bInsSpace );	// 2001.12.03 hor
 
@@ -1574,7 +1574,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment2", L"nLineCommentColumn2", types.m_cLineComment, 1 );
 	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment3", L"nLineCommentColumn3", types.m_cLineComment, 2 );
 
-	cProfile.IOProfileData( pszSecName, LTEXT("szIndentChars")		, MakeStringBufferW(types.m_szIndentChars) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szIndentChars")		, StringBufferW( types.m_szIndentChars ) );
 	cProfile.IOProfileData( pszSecName, LTEXT("cLineTermChar")		, types.m_cLineTermChar );
 
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockDisp")			, types.m_bOutlineDockDisp );/* アウトライン解析表示の有無 */
@@ -1584,7 +1584,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		const WCHAR* pszForm = LTEXT("%d,%d,%d,%d");
 		WCHAR		szKeyData[1024];
 		if( cProfile.IsReadingMode() ){
-			if( cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData)) ){
+			if( cProfile.IOProfileData( pszSecName, pszKeyName, StringBufferW( szKeyData ) ) ){
 				int buf[4];
 				scan_ints( szKeyData, pszForm, buf );
 				types.m_cxOutlineDockLeft	= buf[0];
@@ -1601,7 +1601,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 				types.m_cxOutlineDockRight,
 				types.m_cyOutlineDockBottom
 			);
-			cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData) );
+			cProfile.IOProfileData( pszSecName, pszKeyName, StringBufferW( szKeyData ) );
 		}
 	}
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDockOutline")	, 	types.m_nDockOutline );/* アウトライン解析方法 */
@@ -1684,7 +1684,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 			if( cProfile.IsReadingMode() )
 			{
 				types.m_RegexKeywordArr[j].m_nColorIndex = COLORIDX_REGEX1;
-				if( cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData)) )
+				if( cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) ) )
 				{
 					p = wcschr(szKeyData, LTEXT(','));
 					if( p )
@@ -1717,7 +1717,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 				auto_sprintf( szKeyData, LTEXT("%ls,%ls"),
 					GetColorNameByIndex( types.m_RegexKeywordArr[j].m_nColorIndex ),
 					&pKeyword[nPos]);
-				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+				cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) );
 				nPos += wcslen(&pKeyword[nPos]) + 1;
 			}
 		}
@@ -1733,9 +1733,9 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("bKinsokuRet")	, types.m_bKinsokuRet );	//@@@ 2002.04.13 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bKinsokuKuto")	, types.m_bKinsokuKuto );	//@@@ 2002.04.17 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bKinsokuHide")	, types.m_bKinsokuHide );	//2012/11/30 Uchi
-	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuHead")	, MakeStringBufferW(types.m_szKinsokuHead) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuTail")	, MakeStringBufferW(types.m_szKinsokuTail) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuKuto")	, MakeStringBufferW(types.m_szKinsokuKuto) );	// 2009.08.07 ryoji
+	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuHead")	, StringBufferW( types.m_szKinsokuHead ) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuTail")	, StringBufferW( types.m_szKinsokuTail ) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuKuto")	, StringBufferW( types.m_szKinsokuKuto ) );	// 2009.08.07 ryoji
 	cProfile.IOProfileData( pszSecName, LTEXT("bUseDocumentIcon")	, types.m_bUseDocumentIcon );	// Sep. 19 ,2002 genta 変数名誤り修正
 
 //@@@ 2006.04.10 fon ADD-start
@@ -1754,7 +1754,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 				types.m_KeyHelpArr[j].m_bUse = false;
 				types.m_KeyHelpArr[j].m_szAbout[0] = L'\0';
 				types.m_KeyHelpArr[j].m_szPath[0] = L'\0';
-				if( cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData)) ){
+				if( cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) ) ){
 					pH = szKeyData;
 					if( NULL != (pT=wcschr(pH, L',')) ){
 						*pT = L'\0';
@@ -1779,7 +1779,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 						types.m_KeyHelpArr[j].m_szAbout,
 						types.m_KeyHelpArr[j].m_szPath.c_str()
 					);
-					cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+					cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) );
 				}
 			}
 		}
@@ -1834,7 +1834,7 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 				int nKeyWordNum = 0;
 				//値の取得
 				auto_sprintf( szKeyName, LTEXT("szSN[%02d]"), i );
-				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+				cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) );
 				auto_sprintf( szKeyName, LTEXT("nCASE[%02d]"), i );
 				cProfile.IOProfileData( pszSecName, szKeyName, bKEYWORDCASE );
 				auto_sprintf( szKeyName, LTEXT("nKWN[%02d]"), i );
@@ -1853,7 +1853,7 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 		int nSize = pCKeyWordSetMgr->m_nKeyWordSetNum;
 		for( i = 0; i < nSize; ++i ){
 			auto_sprintf( szKeyName, LTEXT("szSN[%02d]"), i );
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pCKeyWordSetMgr->m_szSetNameArr[i]) );
+			cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pCKeyWordSetMgr->m_szSetNameArr[i] ) );
 			auto_sprintf( szKeyName, LTEXT("nCASE[%02d]"), i );
 			cProfile.IOProfileData( pszSecName, szKeyName, pCKeyWordSetMgr->m_bKEYWORDCASEArr[i] );
 			auto_sprintf( szKeyName, LTEXT("nKWN[%02d]"), i );
@@ -1878,7 +1878,7 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 			}
 			*pMem = L'\0';
 			auto_sprintf( szKeyName, LTEXT("szKW[%02d]"), i );
-			cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW(pszMem,nMemLen) );
+			cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pszMem,nMemLen ) );
 			delete [] pszMem;
 		}
 	}
@@ -1903,9 +1903,9 @@ void CShareData_IO::ShareData_IO_Macro( CDataProfile& cProfile )
 		// 2002.02.08 hor 未定義値を無視
 		if( !cProfile.IsReadingMode() && macrorec.m_szName[0] == L'\0' && macrorec.m_szFile[0] == L'\0' ) continue;
 		auto_sprintf( szKeyName, LTEXT("Name[%03d]"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(macrorec.m_szName) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( macrorec.m_szName ) );
 		auto_sprintf( szKeyName, LTEXT("File[%03d]"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(macrorec.m_szFile) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( macrorec.m_szFile ) );
 		auto_sprintf( szKeyName, LTEXT("ReloadWhenExecute[%03d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, macrorec.m_bReloadWhenExecute );
 	}
@@ -1963,9 +1963,9 @@ void CShareData_IO::ShareData_IO_Plugin( CDataProfile& cProfile, CMenuDrawer* pc
 			pluginrec.m_szId[0] = L'\0';
 		}
 		auto_sprintf( szKeyName, LTEXT("P[%02d].Name"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pluginrec.m_szName) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pluginrec.m_szName ) );
 		auto_sprintf( szKeyName, LTEXT("P[%02d].Id"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pluginrec.m_szId) );
+		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pluginrec.m_szId ) );
 		auto_sprintf( szKeyName, LTEXT("P[%02d].CmdNum"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pluginrec.m_nCmdNum );	// 2010/7/4 Uchi
 		pluginrec.m_state = ( pluginrec.m_szId[0] == '\0' ? PLS_NONE : PLS_STOPPED );
@@ -2175,7 +2175,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 			if( pData ){
 				wcscpy(szLine, data[dataNum++].c_str());
 			}else{
-				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW( szLine ) );
+				cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szLine ) );
 			}
 
 			// レベル
@@ -2252,7 +2252,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 				szFuncName, 
 				pcMenu->m_sKey, 
 				pcMenu->m_nFunc == F_NODE ? pcMenu->m_sName : L"" );
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW( szLine ) );
+			cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szLine ) );
 		}
 
 		if (cProfile.IsReadingMode() && pcMenu->m_nLevel == 0) {
@@ -2292,7 +2292,7 @@ void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 	
 	/* CTAGS */	//@@@ 2003.05.12 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("nTagsOpt")		, pShare->m_nTagsOpt );
-	cProfile.IOProfileData( pszSecName, LTEXT("szTagsCmdLine")	, MakeStringBufferW(pShare->m_szTagsCmdLine) );
+	cProfile.IOProfileData( pszSecName, LTEXT("szTagsCmdLine")	, StringBufferW( pShare->m_szTagsCmdLine ) );
 	
 	//From Here 2005.04.03 MIK キーワード指定タグジャンプ
 	cProfile.IOProfileData( pszSecName, LTEXT("_TagJumpKeyword_Counts"), pShare->m_sTagJump.m_aTagJumpKeywords._GetSizeRef() );
@@ -2317,7 +2317,7 @@ void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 					LOWORD( pShare->m_sVersion.m_dwProductVersionMS ),
 					HIWORD( pShare->m_sVersion.m_dwProductVersionLS ),
 					LOWORD( pShare->m_sVersion.m_dwProductVersionLS ) );
-		cProfile.IOProfileData( pszSecName, LTEXT("szVersion"), MakeStringBufferW(iniVer) );
+		cProfile.IOProfileData( pszSecName, LTEXT("szVersion"), StringBufferW( iniVer ) );
 
 		// 共有メモリバージョン	2010/5/20 Uchi
 		int		nStructureVersion;
@@ -2346,7 +2346,7 @@ void CShareData_IO::IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecNam
 		static const WCHAR* pszForm = LTEXT("%d,%d,%06x,%06x,%d");
 		auto_sprintf( szKeyName, LTEXT("C[%s]"), g_ColorAttributeArr[j].szName );	//Stonee, 2001/01/12, 2001/01/15
 		if( pcProfile->IsReadingMode() ){
-			if( pcProfile->IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+			if( pcProfile->IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) ) ){
 				int buf[5];
 				scan_ints( szKeyData, pszForm, buf);
 				pColorInfoArr[j].m_bDisp                  = (buf[0]!=0);
@@ -2380,7 +2380,7 @@ void CShareData_IO::IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecNam
 				pColorInfoArr[j].m_sColorAttr.m_cBACK,
 				pColorInfoArr[j].m_sFontAttr.m_bUnderLine?1:0
 			);
-			pcProfile->IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+			pcProfile->IOProfileData( pszSecName, szKeyName, StringBufferW( szKeyData ) );
 		}
 	}
 }
@@ -2396,7 +2396,7 @@ void ShareData_IO_Sub_LogFont( CDataProfile& cProfile, const WCHAR* pszSecName,
 
 	cProfile.IOProfileData( pszSecName, pszKeyPointSize, nPointSize );	// 2009.10.01 ryoji
 	if( cProfile.IsReadingMode() ){
-		if( cProfile.IOProfileData( pszSecName, pszKeyLf, MakeStringBufferW(szKeyData) ) ){
+		if( cProfile.IOProfileData( pszSecName, pszKeyLf, StringBufferW( szKeyData ) ) ){
 			int buf[13];
 			scan_ints( szKeyData, pszForm, buf );
 			lf.lfHeight			= buf[ 0];
@@ -2437,10 +2437,10 @@ void ShareData_IO_Sub_LogFont( CDataProfile& cProfile, const WCHAR* pszSecName,
 			lf.lfQuality,
 			lf.lfPitchAndFamily
 		);
-		cProfile.IOProfileData( pszSecName, pszKeyLf, MakeStringBufferW(szKeyData) );
+		cProfile.IOProfileData( pszSecName, pszKeyLf, StringBufferW( szKeyData ) );
 	}
 	
-	cProfile.IOProfileData( pszSecName, pszKeyFaceName, MakeStringBufferW(lf.lfFaceName) );
+	cProfile.IOProfileData( pszSecName, pszKeyFaceName, StringBufferW( lf.lfFaceName ) );
 }
 
 void CShareData_IO::ShareData_IO_FileTree( CDataProfile& cProfile, SFileTree& fileTree, const WCHAR* pszSecName )

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -206,7 +206,7 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].nY"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pfiWork->m_ptCursor.y );
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].nCharCode"), i );
-		cProfile.IOProfileData_WrapInt( pszSecName, szKeyName, pfiWork->m_nCharCode );
+		cProfile.IOProfileData( pszSecName, szKeyName, pfiWork->m_nCharCode );
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].szPath"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( pfiWork->m_szPath ) );
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].szMark2"), i );
@@ -486,7 +486,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	// 2002.01.16 hor
 	cProfile.IOProfileData( pszSecName, LTEXT("m_bRestoreBookmarks")	, common.m_sFile.m_bRestoreBookmarks );
 	cProfile.IOProfileData( pszSecName, LTEXT("bAddCRLFWhenCopy")		, common.m_sEdit.m_bAddCRLFWhenCopy );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOpenDialogDir")		, common.m_sEdit.m_eOpenDialogDir );
+	cProfile.IOProfileData( pszSecName, LTEXT("eOpenDialogDir")		, common.m_sEdit.m_eOpenDialogDir );
 	cProfile.IOProfileData( pszSecName, LTEXT("szOpenDialogSelDir")		, common.m_sEdit.m_OpenDialogSelDir );
 	cProfile.IOProfileData( pszSecName, LTEXT("bBoxSelectLock")	, common.m_sEdit.m_bBoxSelectLock );
 	cProfile.IOProfileData( pszSecName, LTEXT("bVistaStyleFileDialog")	, common.m_sEdit.m_bVistaStyleFileDialog );
@@ -515,7 +515,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bGrepBackup")			, common.m_sSearch.m_bGrepBackup );
 	
 	// 2002/09/21 Moca 追加
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nGrepCharSet")	, common.m_sSearch.m_nGrepCharSet );
+	cProfile.IOProfileData( pszSecName, LTEXT("nGrepCharSet")	, common.m_sSearch.m_nGrepCharSet );
 	cProfile.IOProfileData( pszSecName, LTEXT("bGrepRealTime")			, common.m_sSearch.m_bGrepRealTimeView ); // 2003.06.16 Moca
 	cProfile.IOProfileData( pszSecName, LTEXT("bCaretTextForSearch")	, common.m_sSearch.m_bCaretTextForSearch );	// 2006.08.23 ryoji カーソル位置の文字列をデフォルトの検索文字列にする
 	cProfile.IOProfileData( pszSecName, LTEXT("m_bInheritKeyOtherView")	, common.m_sSearch.m_bInheritKeyOtherView );
@@ -565,7 +565,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bBackUpDustBox")			, common.m_sBackup.m_bBackUpDustBox );	//@@@ 2001.12.11 add MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bBackUpPathAdvanced")	, common.m_sBackup.m_bBackUpPathAdvanced );	/* 20051107 aroka */
 	cProfile.IOProfileData( pszSecName, LTEXT("szBackUpPathAdvanced")	, common.m_sBackup.m_szBackUpPathAdvanced );	/* 20051107 aroka */
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nFileShareMode")			, common.m_sFile.m_nFileShareMode );
+	cProfile.IOProfileData( pszSecName, LTEXT("nFileShareMode")			, common.m_sFile.m_nFileShareMode );
 	cProfile.IOProfileData( pszSecName, LTEXT("szExtHelp"), StringBufferW( common.m_sHelper.m_szExtHelp ) );
 	cProfile.IOProfileData( pszSecName, LTEXT("szExtHtmlHelp"), StringBufferW( common.m_sHelper.m_szExtHtmlHelp ) );
 	
@@ -598,7 +598,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("szTabWndCaption")		, StringBufferW( common.m_sTabBar.m_szTabWndCaption ) );	//@@@ 2003.06.13 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bSameTabWidth")			, common.m_sTabBar.m_bSameTabWidth );	// 2006.01.28 ryoji タブを等幅にする
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabIcon")			, common.m_sTabBar.m_bDispTabIcon );	// 2006.01.28 ryoji タブにアイコンを表示する
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bDispTabClose")	, common.m_sTabBar.m_bDispTabClose );	// 2012.04.14 syat
+	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabClose")	, common.m_sTabBar.m_bDispTabClose );	// 2012.04.14 syat
 	cProfile.IOProfileData( pszSecName, LTEXT("bSortTabList")			, common.m_sTabBar.m_bSortTabList );	// 2006.05.10 ryoji タブ一覧をソートする
 	cProfile.IOProfileData( pszSecName, LTEXT("bTab_RetainEmptyWin")	, common.m_sTabBar.m_bTab_RetainEmptyWin );	// 最後のファイルが閉じられたとき(無題)を残す	// 2007.02.11 genta
 	cProfile.IOProfileData( pszSecName, LTEXT("bTab_CloseOneWin")	, common.m_sTabBar.m_bTab_CloseOneWin );	// タブモードでもウィンドウの閉じるボタンで現在のファイルのみ閉じる	// 2007.02.11 genta
@@ -606,7 +606,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bChgWndByWheel")		, common.m_sTabBar.m_bChgWndByWheel );	// 2006.03.26 ryoji マウスホイールでウィンドウ切り替え
 	cProfile.IOProfileData( pszSecName, LTEXT("bNewWindow")			, common.m_sTabBar.m_bNewWindow );	// 外部から起動するときは新しいウインドウで開く
 	cProfile.IOProfileData( pszSecName, L"bTabMultiLine"			, common.m_sTabBar.m_bTabMultiLine );	// タブ多段
-	cProfile.IOProfileData_WrapInt( pszSecName, L"eTabPosition"		, common.m_sTabBar.m_eTabPosition );	// タブ位置
+	cProfile.IOProfileData( pszSecName, L"eTabPosition"		, common.m_sTabBar.m_eTabPosition );	// タブ位置
 
 	ShareData_IO_Sub_LogFont( cProfile, pszSecName, L"lfTabFont", L"lfTabFontPs", L"lfTabFaceName",
 		common.m_sTabBar.m_lf, common.m_sTabBar.m_nPointSize );
@@ -625,12 +625,12 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	// 2001/06/14 asa-o 補完とキーワードヘルプはタイプ別に移動したので削除：３行
 	// 2002/09/21 Moca bGrepKanjiCode_AutoDetect は bGrepCharSetに統合したので削除
 	// 2001/06/19 asa-o タイプ別に移動したので削除：1行
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bSaveWindowSize"), common.m_sWindow.m_eSaveWindowSize );	//#####フラグ名が激しくきもい
+	cProfile.IOProfileData( pszSecName, LTEXT("bSaveWindowSize"), common.m_sWindow.m_eSaveWindowSize );	//#####フラグ名が激しくきもい
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinSizeType")			, common.m_sWindow.m_nWinSizeType );
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinSizeCX")				, common.m_sWindow.m_nWinSizeCX );
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinSizeCY")				, common.m_sWindow.m_nWinSizeCY );
 	// 2004.03.30 Moca *nWinPos*を追加
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nSaveWindowPos")	, common.m_sWindow.m_eSaveWindowPos );	//#####フラグ名がきもい
+	cProfile.IOProfileData( pszSecName, LTEXT("nSaveWindowPos")	, common.m_sWindow.m_eSaveWindowPos );	//#####フラグ名がきもい
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinPosX")				, common.m_sWindow.m_nWinPosX );
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinPosY")				, common.m_sWindow.m_nWinPosY );
 	cProfile.IOProfileData( pszSecName, LTEXT("bTaskTrayUse")			, common.m_sGeneral.m_bUseTaskTray );
@@ -722,7 +722,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineDockSet"), common.m_sOutline.m_nOutlineDockSet );
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockSync"), common.m_sOutline.m_bOutlineDockSync );
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockDisp"), common.m_sOutline.m_bOutlineDockDisp );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOutlineDockSide"), common.m_sOutline.m_eOutlineDockSide );
+	cProfile.IOProfileData( pszSecName, LTEXT("eOutlineDockSide"), common.m_sOutline.m_eOutlineDockSide );
 	{
 		const WCHAR* pszKeyName = LTEXT("xyOutlineDock");
 		const WCHAR* pszForm = LTEXT("%d,%d,%d,%d");
@@ -978,7 +978,7 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 						cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW( szFuncName ) );
 					}
 					else {
-						cProfile.IOProfileData_WrapInt( pszSecName, szKeyName, menu.m_nCustMenuItemFuncArr[i][j] );
+						cProfile.IOProfileData( pszSecName, szKeyName, menu.m_nCustMenuItemFuncArr[i][j] );
 					}
 				}
 			}
@@ -1557,7 +1557,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		types.m_id *= -1;
 	}
 	cProfile.IOProfileData( pszSecName, LTEXT("szTabViewString"), StringBufferW( types.m_szTabViewString ) );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bTabArrow")	, types.m_bTabArrow );	//@@@ 2003.03.26 MIK
+	cProfile.IOProfileData( pszSecName, LTEXT("bTabArrow")	, types.m_bTabArrow );	//@@@ 2003.03.26 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bInsSpace")			, types.m_bInsSpace );	// 2001.12.03 hor
 
 	cProfile.IOProfileData( pszSecName, LTEXT("nTextWrapMethod"), types.m_nTextWrapMethod );		// 2008.05.30 nasukoji
@@ -1578,7 +1578,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("cLineTermChar")		, types.m_cLineTermChar );
 
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockDisp")			, types.m_bOutlineDockDisp );/* アウトライン解析表示の有無 */
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOutlineDockSide")	, types.m_eOutlineDockSide );/* アウトライン解析ドッキング配置 */
+	cProfile.IOProfileData( pszSecName, LTEXT("eOutlineDockSide")	, types.m_eOutlineDockSide );/* アウトライン解析ドッキング配置 */
 	{
 		const WCHAR* pszKeyName = LTEXT("xyOutlineDock");
 		const WCHAR* pszForm = LTEXT("%d,%d,%d,%d");
@@ -1604,14 +1604,14 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 			cProfile.IOProfileData( pszSecName, pszKeyName, StringBufferW( szKeyData ) );
 		}
 	}
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDockOutline")	, 	types.m_nDockOutline );/* アウトライン解析方法 */
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDefaultOutline")	, types.m_eDefaultOutline );/* アウトライン解析方法 */
+	cProfile.IOProfileData( pszSecName, LTEXT("nDockOutline")	, 	types.m_nDockOutline );/* アウトライン解析方法 */
+	cProfile.IOProfileData( pszSecName, LTEXT("nDefaultOutline")	, types.m_eDefaultOutline );/* アウトライン解析方法 */
 	cProfile.IOProfileData( pszSecName, LTEXT("szOutlineRuleFilename")	, types.m_szOutlineRuleFilename );/* アウトライン解析ルールファイル */
 	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineSortCol")		, types.m_nOutlineSortCol );/* アウトライン解析ソート列番号 */
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineSortDesc")		, types.m_bOutlineSortDesc );/* アウトライン解析ソート降順 */
 	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineSortType")		, types.m_nOutlineSortType );/* アウトライン解析ソート基準 */
 	ShareData_IO_FileTree( cProfile, types.m_sFileTree, pszSecName );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nSmartIndent")		, types.m_eSmartIndent );/* スマートインデント種別 */
+	cProfile.IOProfileData( pszSecName, LTEXT("nSmartIndent")		, types.m_eSmartIndent );/* スマートインデント種別 */
 	cProfile.IOProfileData( pszSecName, LTEXT("bIndentCppStringIgnore")		, types.m_bIndentCppStringIgnore );
 	cProfile.IOProfileData( pszSecName, LTEXT("bIndentCppCommentIgnore")	, types.m_bIndentCppCommentIgnore );
 	cProfile.IOProfileData( pszSecName, LTEXT("bIndentCppUndoSep")	, types.m_bIndentCppUndoSep );
@@ -1638,8 +1638,8 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("bTypeHtmlHelpIsSingle"), types.m_bHtmlHelpIsSingle ); // 2012.06.30 Fix m_bHokanLoHiCase -> m_bHtmlHelpIsSingle
 
 	cProfile.IOProfileData( pszSecName, LTEXT("bPriorCesu8")		, types.m_encoding.m_bPriorCesu8 );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eDefaultCodetype")	, types.m_encoding.m_eDefaultCodetype );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eDefaultEoltype")	, types.m_encoding.m_eDefaultEoltype );
+	cProfile.IOProfileData( pszSecName, LTEXT("eDefaultCodetype")	, types.m_encoding.m_eDefaultCodetype );
+	cProfile.IOProfileData( pszSecName, LTEXT("eDefaultEoltype")	, types.m_encoding.m_eDefaultEoltype );
 	cProfile.IOProfileData( pszSecName, LTEXT("bDefaultBom")		, types.m_encoding.m_bDefaultBom );
 
 	cProfile.IOProfileData( pszSecName, LTEXT("bAutoIndent")			, types.m_bAutoIndent );
@@ -1652,14 +1652,14 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 
 	// 2010.09.17 背景画像
 	cProfile.IOProfileData( pszSecName, L"bgImgPath", types.m_szBackImgPath );
-	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgPos", types.m_backImgPos );
+	cProfile.IOProfileData( pszSecName, L"bgImgPos", types.m_backImgPos );
 	cProfile.IOProfileData( pszSecName, L"bgImgScrollX",   types.m_backImgScrollX );
 	cProfile.IOProfileData( pszSecName, L"bgImgScrollY",   types.m_backImgScrollY );
 	cProfile.IOProfileData( pszSecName, L"bgImgRepeartX",  types.m_backImgRepeatX );
 	cProfile.IOProfileData( pszSecName, L"bgImgRepeartY",  types.m_backImgRepeatY );
-	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgPosOffsetX",  types.m_backImgPosOffset.x );
-	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgPosOffsetY",  types.m_backImgPosOffset.y );
-	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgOpacity", types.m_backImgOpacity );
+	cProfile.IOProfileData( pszSecName, L"bgImgPosOffsetX",  types.m_backImgPosOffset.x );
+	cProfile.IOProfileData( pszSecName, L"bgImgPosOffsetY",  types.m_backImgPosOffset.y );
+	cProfile.IOProfileData( pszSecName, L"bgImgOpacity", types.m_backImgOpacity );
 
 	// 2005.11.08 Moca 指定桁縦線
 	for(j = 0; j < MAX_VERTLINES; j++ ){
@@ -1746,7 +1746,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpAllSearch"), types.m_bUseKeyHelpAllSearch );	/* ヒットした次の辞書も検索(&A) */
 		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpKeyDisp"), types.m_bUseKeyHelpKeyDisp );		/* 1行目にキーワードも表示する(&W) */
 		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpPrefix"), types.m_bUseKeyHelpPrefix );		/* 選択範囲で前方一致検索(&P) */
-		cProfile.IOProfileData_WrapInt(pszSecName, LTEXT("nKeyHelpRMenuShowType"), types.m_eKeyHelpRMenuShowType);
+		cProfile.IOProfileData(pszSecName, LTEXT("nKeyHelpRMenuShowType"), types.m_eKeyHelpRMenuShowType);
 		for(j = 0; j < MAX_KEYHELP_FILE; j++){
 			auto_sprintf( szKeyName, LTEXT("KDct[%02d]"), j );
 			/* 読み出し */
@@ -2459,7 +2459,7 @@ void CShareData_IO::ShareData_IO_FileTreeItem(
 {
 	WCHAR szKey[64];
 	auto_sprintf( szKey, L"FileTree(%d).eItemType", i );
-	cProfile.IOProfileData_WrapInt( pszSecName, szKey, item.m_eFileTreeItemType );
+	cProfile.IOProfileData( pszSecName, szKey, item.m_eFileTreeItemType );
 	if( cProfile.IsReadingMode() || item.m_eFileTreeItemType == EFileTreeItemType_Grep
 		|| item.m_eFileTreeItemType == EFileTreeItemType_File ){
 		auto_sprintf( szKey, L"FileTree(%d).szTargetPath", i );

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -257,7 +257,7 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 	}
 	if ((unsigned int)nStructureVersion != m_pShareData->m_vStructureVersion) {
 		wcscpy( szKeyVersion, L"?" );
-		m_cProfile.IOProfileData( szSecInfo, szKeyVersion, MakeStringBufferW( szKeyVersion ) );
+		m_cProfile.IOProfileData( szSecInfo, szKeyVersion, StringBufferW( szKeyVersion ) );
 		int nRet = ConfirmMessage( hwndParent,
 			LS(STR_IMPEXP_VER), 
 			GSTR_APPNAME, szKeyVersion, nStructureVersion );
@@ -277,7 +277,7 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 	List_GetText( m_hwndList, m_nIdx, szLabel );
 	sAscertainInfo.sTypeNameTo = szLabel;
 	szLabel[0] = L'\0';
-	m_cProfile.IOProfileData( szSecTypes, L"szTypeName", MakeStringBufferW( szLabel ));
+	m_cProfile.IOProfileData( szSecTypes, L"szTypeName", StringBufferW( szLabel ) );
 	sAscertainInfo.sTypeNameFile = szLabel;
 
 	// 確認
@@ -361,7 +361,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 	for (i=0; i < MAX_KEYWORDSET_PER_TYPE; i++) {
 		//types.m_nKeyWordSetIdx[i] = -1;
 		auto_sprintf( szKeyName, szKeyKeywordTemp, i+1 );
-		if (m_cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( szKeyData ))) {
+		if (m_cProfile.IOProfileData( szSecTypeEx, szKeyName, StringBufferW( szKeyData ) )) {
 			nIdx = cKeyWordSetMgr.SearchKeyWordSet( szKeyData );
 			if (nIdx < 0) {
 				// エントリ作成
@@ -378,7 +378,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 
 				auto_sprintf( szKeyName, szKeyKeywordFileTemp, i+1 );
 				szFileName[0] = L'\0';
-				if (m_cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( szFileName ))) {
+				if (m_cProfile.IOProfileData( szSecTypeEx, szKeyName, StringBufferW( szFileName ) )) {
 					if( cImpExpKeyWord.Import( cImpExpKeyWord.MakeFullPath( szFileName ), TmpMsg )) {
 						files += wstring(L"\n") + szFileName;
 					} else {
@@ -393,7 +393,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 	// Plugin
 	//  アウトライン解析方法
 	CommonSetting_Plugin& plugin = common.m_sPlugin;
-	if (m_cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineId, MakeStringBufferW( szKeyData ))) {
+	if (m_cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineId, StringBufferW( szKeyData ) )) {
 		nDataLen = wcslen( szKeyData );
 		pSlashPos = wcschr( szKeyData, L'/' );
 		nIdx = -1;
@@ -414,7 +414,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 		}
 	}
 	//  スマートインデント
-	if (m_cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentId, MakeStringBufferW( szKeyData ))) {
+	if (m_cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentId, StringBufferW( szKeyData ) )) {
 		nDataLen = wcslen( szKeyData );
 		pSlashPos = wcschr( szKeyData, L'/' );
 		nIdx = -1;
@@ -468,7 +468,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 			nIdx = m_Types.m_nKeyWordSetIdx[i];
 			auto_sprintf( szKeyName, szKeyKeywordTemp, i+1 );
 			wcscpy( buff, cKeyWordSetMgr.GetTypeName( nIdx ));
-			cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( buff ));
+			cProfile.IOProfileData( szSecTypeEx, szKeyName, StringBufferW( buff ) );
 
 			// 大文字小文字区別
 			bCase = common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWordCase( nIdx );
@@ -480,7 +480,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 			if ( cImpExpKeyWord.Export( cImpExpKeyWord.GetFullPath(), sTmpMsg ) ) {
 				wcscpy( szFileName, cImpExpKeyWord.GetFileName().c_str());
 				auto_sprintf( szKeyName, szKeyKeywordFileTemp, i+1 );
-				if (cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( szFileName ))) {
+				if (cProfile.IOProfileData( szSecTypeEx, szKeyName, StringBufferW( szFileName ) )) {
 					files += wstring( L"\n" ) + cImpExpKeyWord.GetFileName();
 				}
 			}
@@ -497,25 +497,25 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 	int		nPlug;
 	wchar_t szId[ MAX_PLUGIN_ID + 1 + 2 ];
 	if ((nPIdx = CPlug::GetPluginId( static_cast<EFunctionCode>( m_Types.m_eDefaultOutline ))) >= 0) {
-		cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineName, MakeStringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
+		cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineName, StringBufferW( plugin.m_PluginTable[nPIdx].m_szName ));
 		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, _countof(szId) );
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eDefaultOutline ))) != 0 ){
 			wchar_t szPlug[8];
 			_swprintf( szPlug, L"/%d", nPlug );
 			wcscat( szId, szPlug );
 		}
-		cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineId,   MakeStringBufferW(szId) );
+		cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineId,   StringBufferW( szId ) );
 	}
 	//  スマートインデント
 	if ((nPIdx = CPlug::GetPluginId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) >= 0) {
-		cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentName, MakeStringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
+		cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentName, StringBufferW( plugin.m_PluginTable[nPIdx].m_szName ));
 		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, _countof(szId) );
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) != 0 ){
 			wchar_t szPlug[8];
 			_swprintf( szPlug, L"/%d", nPlug );
 			wcscat( szId, szPlug );
 		}
-		cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentId,   MakeStringBufferW(szId) );
+		cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentId,   StringBufferW( szId ) );
 	}
 
 	// Version
@@ -527,7 +527,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 				LOWORD( pShare->m_sVersion.m_dwProductVersionMS ),
 				HIWORD( pShare->m_sVersion.m_dwProductVersionLS ),
 				LOWORD( pShare->m_sVersion.m_dwProductVersionLS ) );
-	cProfile.IOProfileData( szSecInfo, szKeyVersion, MakeStringBufferW(wbuff) );
+	cProfile.IOProfileData( szSecInfo, szKeyVersion, StringBufferW( wbuff ) );
 	nStructureVersion = int(pShare->m_vStructureVersion);
 	cProfile.IOProfileData( szSecInfo, szKeyStructureVersion, nStructureVersion );
 
@@ -888,7 +888,7 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 	bVer4 = false;
 	bVer3 = false;
 	bVer2 = false;
-	in.IOProfileData(szSecInfo, L"KEYBIND_VERSION", MakeStringBufferW(szHeader));
+	in.IOProfileData(szSecInfo, L"KEYBIND_VERSION", StringBufferW( szHeader ) );
 	if(wcscmp(szHeader,WSTR_KEYBIND_HEAD4)==0)	bVer4=true;
 	else if(wcscmp(szHeader,WSTR_KEYBIND_HEAD3)==0)	bVer3=true;
 
@@ -1073,7 +1073,7 @@ bool CImpExpCustMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 
 	//バージョン確認
 	WCHAR szHeader[256];
-	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", MakeStringBufferW(szHeader));
+	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", StringBufferW( szHeader ) );
 	if(wcscmp(szHeader, WSTR_CUSTMENU_HEAD_V2)!=0) {
 		sErrMsg = wstring(LS(STR_IMPEXP_CUSTMENU_FORMAT)) + sFileName;
 		return false;
@@ -1108,7 +1108,7 @@ bool CImpExpCustMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 	cProfile.SetWritingMode();
 
 	//ヘッダ
-	cProfile.IOProfileData( szSecInfo, L"MENU_VERSION", MakeStringBufferW(WSTR_CUSTMENU_HEAD_V2) );
+	cProfile.IOProfileData( szSecInfo, L"MENU_VERSION", StringBufferW( WSTR_CUSTMENU_HEAD_V2 ) );
 	int iWork = MAX_CUSTOM_MENU;
 	cProfile.IOProfileData_WrapInt( szSecInfo, L"MAX_CUSTOM_MENU", iWork );
 	
@@ -1237,7 +1237,7 @@ bool CImpExpMainMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 
 	//バージョン確認
 	WCHAR szHeader[256];
-	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", MakeStringBufferW(szHeader));
+	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", StringBufferW( szHeader ) );
 	if(wcscmp(szHeader, WSTR_MAINMENU_HEAD_V1)!=0) {
 		sErrMsg = wstring(LS(STR_IMPEXP_MEINMENU)) + sFileName;
 		return false;
@@ -1271,7 +1271,7 @@ bool CImpExpMainMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 	cProfile.SetWritingMode();
 
 	//ヘッダ
-	cProfile.IOProfileData( szSecInfo, L"MENU_VERSION", MakeStringBufferW(WSTR_MAINMENU_HEAD_V1) );
+	cProfile.IOProfileData( szSecInfo, L"MENU_VERSION", StringBufferW( WSTR_MAINMENU_HEAD_V1 ) );
 	
 	//内容
 	CShareData_IO::IO_MainMenu(cProfile, *menu, true);

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -1036,7 +1036,7 @@ bool CImpExpKeybind::Export( const wstring& sFileName, wstring& sErrMsg )
 	// ヘッダ
 	StaticString<wchar_t,256> szKeydataHead = WSTR_KEYBIND_HEAD4;
 	cProfile.IOProfileData( szSecInfo, L"KEYBIND_VERSION", szKeydataHead );
-	cProfile.IOProfileData_WrapInt( szSecInfo, L"KEYBIND_COUNT", m_Common.m_sKeyBind.m_nKeyNameArrNum );
+	cProfile.IOProfileData( szSecInfo, L"KEYBIND_COUNT", m_Common.m_sKeyBind.m_nKeyNameArrNum );
 
 	//内容
 	CShareData_IO::IO_KeyBind(cProfile, m_Common.m_sKeyBind, true);
@@ -1110,7 +1110,7 @@ bool CImpExpCustMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 	//ヘッダ
 	cProfile.IOProfileData( szSecInfo, L"MENU_VERSION", StringBufferW( WSTR_CUSTMENU_HEAD_V2 ) );
 	int iWork = MAX_CUSTOM_MENU;
-	cProfile.IOProfileData_WrapInt( szSecInfo, L"MAX_CUSTOM_MENU", iWork );
+	cProfile.IOProfileData( szSecInfo, L"MAX_CUSTOM_MENU", iWork );
 	
 	//内容
 	CShareData_IO::IO_CustMenu(cProfile, *menu, true);


### PR DESCRIPTION
# PR の目的
CDataProfileクラスについて予定している今後のリファクタリング目標を共有します。

ここで晒すのは、あくまで現段階の構想で、レビューで改善される可能性があります。

## カテゴリ
- リファクタリング
- マージを目的としない
- その他

## PR の背景
CDataProfileは、データ変換クラスです。
設定ファイル内の設定項目と内部データとの相互変換を取り持つクラスです。

CDataProfileの変換機構は「入出力テンプレート＋変換メソッド」で構成されています。

それはいいんです。

現状で、サクラエディタの設定ファイル読取機構には問題があると思っています。
普通に使っている分には「何の問題もない」と分かったうえで「問題がある」と思います。

言ってる意味がわからんと思うんですが、問題がある気がするんです。

設定ファイルが壊れたとき（手で設定ファイルを触るとたまに壊れる）に、
メニューやツールバーが何も表示されない状態になるんです。

何故メニューやツールバーが空になるか？
　↓
設定ファイルの読込処理で、正しく読み込めたか判定してない処理があるから
　↓
何故正しく読み込めたか判定していないのか？
　↓
正しく読み込めない事態を想定してないから
　↓
**なんでやねんっ！**
　↓
データ変換クラスが「文字列⇒値」の変換失敗を想定してなくて手の打ちようがなかったから
　↓
何故いままで誰もソコを正そうとしなかったのか？
　↓
データ変換クラスの変換機構にかなり高度な技術が使われていて、
全貌を把握して対処するのが難しかったからだと考えられます。

このPRは、目標「設定値を読み込めたかどうか判定できるようにする」に至るまでに必要な（？）コミットをとりあえず積んでみたものです。

おそらくは、ここに積んだコミットを順番に、普通にPRを出す感じで進めていくと思います。

目指している場所がわかるのと分からないのとでは見え方が違ってくると思うので、暫定目標を先に公開しとく感じです。

## PR のメリット
- 設定値の基本的なデータ変換の方法が整理されて分かりやすくなります。
- 設定値の読み取り失敗を検出して、処理を入れるための道が拓けます。
- 複雑な復号設定値の読み取りを、うまいこと制御するための道が拓けます。

## PR のデメリット (トレードオフとかあれば)
- かなり修正量が多いです。
- 技術的な難易度がやや高いです。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。
- 設定ファイルの読み書き処理全般に影響する修正です。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
