### PR TITLE
Copyright を 2020 にする

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ﻿zlib License
 
-Copyright (C) 2018-2019 Sakura Editor Organization
+Copyright (C) 2018-2020 Sakura Editor Organization
 
 This software is provided 'as-is', without any express or implied
 warranty.  In no event will the authors be held liable for any damages

--- a/sakura_core/EditInfo.cpp
+++ b/sakura_core/EditInfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/GrepInfo.cpp
+++ b/sakura_core/GrepInfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/GrepInfo.h
+++ b/sakura_core/GrepInfo.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/icu4c/CharsetDetector.cpp
+++ b/sakura_core/charset/icu4c/CharsetDetector.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/icu4c/CharsetDetector.h
+++ b/sakura_core/charset/icu4c/CharsetDetector.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CIcu4cI18n.cpp
+++ b/sakura_core/extmodule/CIcu4cI18n.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CIcu4cI18n.h
+++ b/sakura_core/extmodule/CIcu4cI18n.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CPoolResource.h
+++ b/sakura_core/mem/CPoolResource.h
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFile.cpp
+++ b/sakura_core/recent/CRecentExcludeFile.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFile.h
+++ b/sakura_core/recent/CRecentExcludeFile.h
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFolder.cpp
+++ b/sakura_core/recent/CRecentExcludeFolder.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFolder.h
+++ b/sakura_core/recent/CRecentExcludeFolder.h
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -32,7 +32,7 @@
 LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
 #endif //_WIN32
 
-#define	S_COPYRIGHT	"Copyright (C) 1998-2019  by Norio Nakatani & Collaborators"
+#define	S_COPYRIGHT	"Copyright (C) 1998-2020  by Norio Nakatani & Collaborators"
 #define FL_VER		PR_VER
 #define FL_VER_STR	PR_VER_STR
 

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -34,8 +34,8 @@
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
 #endif //_WIN32
 
-#define	S_COPYRIGHT				"Copyright (C) 1998-2019  by Norio Nakatani & Collaborators"
-#define	S_COPYRIGHT_TRANSLATION	"Copyright (C) 2011-2019  by Lucien & Collaborators"
+#define	S_COPYRIGHT				"Copyright (C) 1998-2020  by Norio Nakatani & Collaborators"
+#define	S_COPYRIGHT_TRANSLATION	"Copyright (C) 2011-2020  by Lucien & Collaborators"
 #define FL_VER		PR_VER
 #define FL_VER_STR	PR_VER_STR
 

--- a/tests/unittests/coverage.cpp
+++ b/tests/unittests/coverage.cpp
@@ -1,6 +1,6 @@
 /*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-StdControl.cpp
+++ b/tests/unittests/test-StdControl.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cmemory.cpp
+++ b/tests/unittests/test-cmemory.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-editinfo.cpp
+++ b/tests/unittests/test-editinfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-grepinfo.cpp
+++ b/tests/unittests/test-grepinfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-is_mailaddress.cpp
+++ b/tests/unittests/test-is_mailaddress.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-mydevmode.cpp
+++ b/tests/unittests/test-mydevmode.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-parameterized.cpp
+++ b/tests/unittests/test-parameterized.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-ssearchoption.cpp
+++ b/tests/unittests/test-ssearchoption.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter.Test/EncoderEscapingFallbackTest.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter.Test/EncoderEscapingFallbackTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter.Test/Properties/AssemblyInfo.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter.Test/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("UnitTestProject1")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyCopyright("Copyright ©  2019-2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/tools/ChmSourceConverter/ChmSourceConverter/EncoderEscapingFallback.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/EncoderEscapingFallback.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter/FileContents.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/FileContents.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter/Program.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/Program.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2019 Sakura Editor Organization
+	Copyright (C) 2018-2020 Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter/Properties/AssemblyInfo.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ChmSourceConverter")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyCopyright("Copyright ©  2019-2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
# PR の目的

Copyright を 2020 にする

## カテゴリ

<!-- 編集 必須 -->
<!-- 以下の箇条書きリストから関係するものを残して、関係ないものを削除してください。-->
<!-- 該当するものがない場合は必要に応じて追加してください。                        -->

- ドキュメント修正

## PR の背景

以前 #761 で Copyright に 2019 を追加した。

https://github.com/sakura-editor/management-forum/issues/77 でリリース後に copyright を 2020 にする話題が上がったが、2020 年に入ってから変更が入っているのでリリース前に copyright を 2020 にしてもいいと思う。

Copyright 表記に 2019 を含まないものに関してはそっとしています。

## PR のメリット

Copyright を最新にできる。

## PR のデメリット (トレードオフとかあれば)

特になし

## PR の影響範囲

コメント、ドキュメント

## 関連チケット

#761
https://github.com/sakura-editor/management-forum/issues/77


## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
