### PR TITLE
bregonig.dll の zip アーカイブ名を明示する必要のない個所を汎用的な表現に変更する

### DIFF
--- a/installer/externals/bregonig/README.md
+++ b/installer/externals/bregonig/README.md
@@ -13,5 +13,5 @@
 
 ## 展開ファイル
 - bron420.zip … 上述サイトから入手したZIPアーカイブ
-- Win32/bregonig.dll … bron420.zip から取り出した 32bit版 bregonig.dll
-- x64/bregonig.dll … bron420.zip から取り出した 64bit版 bregonig.dll
+- Win32/bregonig.dll … zipから取り出した 32bit版 bregonig.dll
+- x64/bregonig.dll   … zipから取り出した 64bit版 bregonig.dll

--- a/sakura/postBuild.bat
+++ b/sakura/postBuild.bat
@@ -20,7 +20,7 @@ set CONFIGURATION=%2
 set DEST_DIR=%PLATFORM%\%CONFIGURATION%
 set OUT_DIR=%~dp0..\%DEST_DIR%
 
-: ---- bron420 ---- :
+: ---- bregonig.dll ---- :
 set BREGONIG_DLL=bregonig.dll
 set BRON_ZIP=..\installer\externals\bregonig\bron420.zip
 set BRON_TMP=..\installer\temp\bron

--- a/tools/zip/readme.md
+++ b/tools/zip/readme.md
@@ -37,7 +37,7 @@ zip.bat <圧縮先Zipファイル> <圧縮するフォルダパス>
 例
 
 ```
-zip.bat bron420-2.zip temp
+zip.bat hogehoge.zip temp
 ```
 
 
@@ -51,7 +51,7 @@ unzip.bat <解凍するZipファイル> <展開先フォルダパス>
 例
 
 ```
-unzip.bat bron420.zip temp
+unzip.bat hogehoge.zip temp
 ```
 
 
@@ -64,5 +64,5 @@ listzip.bat <内容確認するZipファイル>
 例
 
 ```
-listzip.bat bron420.zip
+listzip.bat hogehoge.zip
 ```


### PR DESCRIPTION
# PR の目的

bregonig.dll の zip アーカイブ名を明示する必要のない個所を汎用的な表現に変更する

## カテゴリ

- ドキュメント修正

## PR の背景

https://github.com/sakura-editor/sakura/pull/1158#discussion_r368213274

> メモ：今後の手順省力化を考えて記述修正を検討してはどうかな？と。
> 
> 「bron420.zip から取り出した(ry」
> 　　↓
> 「zip から取り出した(ry」
> 
> 説明からzip名を削ることで、更新のたびに修正する必要がなくなります。
> この文脈で ctag.zip と間違える人とか、「どのzipの話だ！」とキレる人はレアな気がします。
> 
> やるかどうかとか、細かい書きっぷりは実際提案する人におまかせです。

## PR のメリット

bregonig.dll がバージョンアップして zip ファイル名が変更になったときの作業が少なくなる。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

bregonig.dll  関連のドキュメント
postBuild.bat

## 関連チケット

#1158

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
