### PR TITLE
Visual Studio のインストールオプションの設定ファイルを追加する

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,4 @@
+{
+	"version": "1.0",
+	"components": []
+}

--- a/.vsconfig
+++ b/.vsconfig
@@ -1,4 +1,12 @@
 {
 	"version": "1.0",
-	"components": []
+	"components": [
+		"Microsoft.VisualStudio.Workload.NativeDesktop",
+		"microsoft.visualstudio.component.debugger.justintime",
+		"microsoft.visualstudio.component.vc.diagnostictools",
+		"microsoft.visualstudio.component.vc.cmake.project",
+		"microsoft.visualstudio.component.vc.atl",
+		"microsoft.visualstudio.component.vc.testadapterforboosttest",
+		"microsoft.visualstudio.component.vc.testadapterforgoogletest"
+	]
 }

--- a/.vsconfig
+++ b/.vsconfig
@@ -5,9 +5,9 @@
 		"microsoft.visualstudio.component.debugger.justintime",
 		"microsoft.visualstudio.component.vc.diagnostictools",
 		"microsoft.visualstudio.component.vc.cmake.project",
-		"microsoft.visualstudio.component.vc.atl",
 		"microsoft.visualstudio.component.vc.testadapterforboosttest",
 		"microsoft.visualstudio.component.vc.testadapterforgoogletest",
-		"microsoft.visualstudio.componentgroup.nativedesktop.win81"
+		"microsoft.visualstudio.componentgroup.nativedesktop.win81",
+		"microsoft.visualstudio.component.vc.atlmfc"
 	]
 }

--- a/.vsconfig
+++ b/.vsconfig
@@ -6,6 +6,8 @@
 		"microsoft.visualstudio.component.vc.diagnostictools",
 		"microsoft.visualstudio.component.vc.cmake.project",
 		"microsoft.visualstudio.component.vc.atl",
+		"microsoft.visualstudio.component.windows10sdk.17763",
+		"microsoft.visualstudio.component.vc.cmake.project",
 		"microsoft.visualstudio.component.vc.testadapterforboosttest",
 		"microsoft.visualstudio.component.vc.testadapterforgoogletest",
 		"microsoft.visualstudio.componentgroup.nativedesktop.win81"

--- a/.vsconfig
+++ b/.vsconfig
@@ -7,6 +7,7 @@
 		"microsoft.visualstudio.component.vc.cmake.project",
 		"microsoft.visualstudio.component.vc.atl",
 		"microsoft.visualstudio.component.vc.testadapterforboosttest",
-		"microsoft.visualstudio.component.vc.testadapterforgoogletest"
+		"microsoft.visualstudio.component.vc.testadapterforgoogletest",
+		"microsoft.visualstudio.componentgroup.nativedesktop.win81"
 	]
 }

--- a/.vsconfig
+++ b/.vsconfig
@@ -5,9 +5,9 @@
 		"microsoft.visualstudio.component.debugger.justintime",
 		"microsoft.visualstudio.component.vc.diagnostictools",
 		"microsoft.visualstudio.component.vc.cmake.project",
+		"microsoft.visualstudio.component.vc.atl",
 		"microsoft.visualstudio.component.vc.testadapterforboosttest",
 		"microsoft.visualstudio.component.vc.testadapterforgoogletest",
-		"microsoft.visualstudio.componentgroup.nativedesktop.win81",
-		"microsoft.visualstudio.component.vc.atlmfc"
+		"microsoft.visualstudio.componentgroup.nativedesktop.win81"
 	]
 }


### PR DESCRIPTION
# PR の目的

Visual Studio 2019 では .vsconfig というファイルを sln と同じディレクトリに置いておくと
ソリューションのビルドに必要なコンポーネントが足りないと自動的にユーザーに通知して
クリック一つでインストールすることができる。

## カテゴリ

- ビルド手順

## PR の背景

#518

> サクラエディタをビルドしてみようと Visual Studio Community 2017 を
> クリーンインストールしてみたところ、いくつか追加で必要だったので README.md を修正してみました。

とあり、README.md に必要なコンポーネントの説明を記載しているが、
足りない場合に自動的にユーザーに通知してワンタッチでインストールできたら便利なため。


## PR のメリット

ユーザーが簡単に Sakura Editor のビルド環境を構築できる。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

Visaul Studio のインストール

## 関連チケット

#518
#936
#6

## 残件

~Visaul Studio 2017 での確認~ (完了)

## 参考資料

- [How to extract currently installed Visual Studio component IDs?](https://stackoverflow.com/questions/52946333/how-to-extract-currently-installed-visual-studio-component-ids)
- [Configure Visual Studio across your organization with .vsconfig](https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/)
- [インストール構成をインポートまたはエクスポートする](https://docs.microsoft.com/ja-jp/visualstudio/install/import-export-installation-configurations?view=vs-2019)
- [コマンド ライン パラメーターを使用して Visual Studio をインストールする](https://docs.microsoft.com/ja-jp/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=vs-2019)
