### PR TITLE
単体テストのビルドの中間ファイル用のディレクトリを無視リストに追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /cppcheck-install.log
 /help/sakura/sakura.hh
 /tests/build
+/tests/unittests/Win32
+/tests/unittests/x64
 /Win32
 /x64
 Backup


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートに切り替えることで登録後にどのように見えるか確認することができます -->

# PR の目的

単体テストのビルドの中間ファイル用のディレクトリを無視リストに追加する

## カテゴリ

- その他

## PR の背景

sakura.sln を開いてビルドすると単体テストの中間ファイル用のディレクトリが無視リストに含まれておらず、Untracked files となるので、無視するようにする。

## PR のメリット

git 管理不要なファイルを無視できる。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

git 操作

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
