### PR TITLE
find-tools.batの無効にしていたログ出力を復活させる

### DIFF
--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -42,6 +42,8 @@ echo ^|- CMD_DOXYGEN=%CMD_DOXYGEN%
 echo ^|- CMD_VSWHERE=%CMD_VSWHERE%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
 echo ^|- CMD_CMAKE=%CMD_CMAKE%
+echo ^|- PARAM_VSVERSION=%PARAM_VSVERSION%
+echo ^|- CMAKE_G_PARAM=%CMAKE_G_PARAM%
 endlocal ^
     && set "CMD_GIT=%CMD_GIT%"                  ^
     && set "CMD_7Z=%CMD_7Z%"                    ^


### PR DESCRIPTION
# PR の目的
find-tools.batの無効にしていたログ出力を復活させます。

## カテゴリ
- その他

## PR の背景

#1148 tools/find-tools.bat にログを入れると ISCC.exe の検索に失敗する

```
echo ^|- NUM_VSVERSION=%NUM_VSVERSION%
echo ^|- PARAM_VSVERSION=%PARAM_VSVERSION%
echo ^|- CMAKE_G_PARAM=%CMAKE_G_PARAM%
```

https://github.com/sakura-editor/sakura/issues/1148#issuecomment-575863598
3行追加はダメだけど、2行ならイケることが分かった。

どれか1行削ればいい話ととらえると、
1行目と3行目は内容がかぶるので、
1行目を出力する必然はないような気がします。

```
|- NUM_VSVERSION=15　★この値、要らなくね？
|- PARAM_VSVERSION=/p:VisualStudioVersion=15.0　★15.0が元の値
|- CMAKE_G_PARAM=Visual Studio 15 2017　★1行目と同じ値を含んでいる
```

出力行を1行あきらめれば #1148 の問題は解決すると思います。


## PR のメリット
- バッチに追加した新規2個の判定値がログ出力されるようになる。

## PR のデメリット (トレードオフとかあれば)
- このPRを適用することにより、「とりあえずの困りごと」がなくなります。
- 問題解決のモチベーションが下がります :cry:
  ~~なので元 issue を close するPRとして出すことにしました。==(撤回)

## PR の影響範囲
- コマンドラインからのビルドに影響します。

## 関連チケット
#1148

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
