### PR TITLE
batch ファイルのキーワードに setlocal/endlocal を追加

### DIFF
--- a/sakura_core/types/CType_Dos.cpp
+++ b/sakura_core/types/CType_Dos.cpp
@@ -111,6 +111,8 @@ const wchar_t* g_ppszKeywordsBAT[] = {
 	L"LPT3",
 	L"CLOCK",
 	L"CLOCK$",
-	L"CONFIG$"
+	L"CONFIG$",
+	L"SETLOCAL",
+	L"ENDLOCAL"
 };
 int g_nKeywordsBAT = _countof(g_ppszKeywordsBAT);


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートに切り替えることで登録後にどのように見えるか確認することができます -->

# PR の目的

batch ファイルのキーワードに setlocal/endlocal を追加

## カテゴリ

<!-- 編集 必須 -->
<!-- 以下の箇条書きリストから関係するものを残して、関係ないものを削除してください。-->
<!-- 該当するものがない場合は必要に応じて追加してください。                        -->

- 機能追加

## PR の背景

batch ファイルのキーワードで setlocal/endlocal が入っていなかったので追加する

## PR のメリット

setlocal/endlocal  がキーワードとして認識される。

## PR のデメリット (トレードオフとかあれば)

既存の sakura.ini は変更しないので新規インストールのみ有効

## PR の影響範囲

batch ファイルのキーワード表示

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
