### PR TITLE
プリコンパイル済みヘッダー内の #pragma once をMSVC専用にしてGCCビルドで警告が出ないようにする

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -4,7 +4,9 @@
 //				プロジェクト専用のインクルード ファイルを記述します。
 //
 
+#if defined(_MSC_VER) && _MSC_VER > 1000
 #pragma once
+#endif // _MSC_VER > 1000
 
 // この位置にヘッダーを挿入してください
 // #define WIN32_LEAN_AND_MEAN		// Windows ヘッダーから殆ど使用されないスタッフを除外します


### PR DESCRIPTION
# PR の目的
プリコンパイル済みヘッダー内の#pragma onceをMSVC専用にすることにより、
GCCでプリコンパイル済みヘッダーを使おうとしたときに警告が出ないようにします。

## カテゴリ
- CI関連
  - Azure Pipelines
- その他

## PR の背景
MinGW GCC で プリコンパイル済みヘッダー を有効にすると以下の警告が出ます。

```cmd
C:\work\sakura\sakura_core\StdAfx.h(7,9): warning G22EB126D: #pragma once in main file
      7 | #pragma once
        |         ^~~~
```

なんだろう？と思って調べてみたら、
#1091 で StdAfx.h 内のプリプロセッサ分岐を外していたのが原因でした。

```c
#if defined(_MSC_VER) && _MSC_VER > 1000
#pragma once
#endif // _MSC_VER > 1000
```
　　↓
```c
#pragma once
```

PR #1091 の目的は インクルードガードの代わりに #pragma once を使う、なので、
この部分の変更を元に戻しても PR の目的は達成できそうです。

現在、#994 `MinGWビルドのpch利用を中断する` の対応によりMinGWビルドでプリコンパイル済みヘッダーを使っていませんが、使う時の対応にこの修正をまぜるとややこしくなるので、先にPRしてしまう次第です。


## PR のメリット
- MinGW GCC ビルドで警告が出なくなります。

## PR のデメリット (トレードオフとかあれば)
- 現在 MinGW GCC ビルドのプリコンパイル済みヘッダーの利用を中断しているため、変更の効果をすぐには確認できません。


## PR の影響範囲
- MinGW GCC ビルドで警告が出なくなります。

## 関連チケット
#994 MinGWビルドのpch利用を中断する
#1091 Include guard に #pragma once を使う

## 参考資料
https://kryozahiro.hateblo.jp/entry/20090921/1253534337
https://github.com/EzoeRyou/cpp-intro/blob/master/002-build.md#コンパイル済みヘッダーprecompiled-header
