### PR TITLE
使用しないメソッド引数のマーキングにmaybe_unused属性を使う

### DIFF
--- a/sakura_core/extmodule/CIcu4cI18n.cpp
+++ b/sakura_core/extmodule/CIcu4cI18n.cpp
@@ -40,9 +40,8 @@ CIcu4cI18n::~CIcu4cI18n() noexcept
 /*!
  * @brief DLLの名前を返す
  */
-LPCWSTR CIcu4cI18n::GetDllNameImp(int index)
+LPCWSTR CIcu4cI18n::GetDllNameImp( [[maybe_unused]] int index )
 {
-	(void*)index;
 	return L"icuin66.dll"; //バージョンは固定
 }
 


### PR DESCRIPTION
# PR の目的
使用しないメソッドパラメータのマーキングに maybe_unused 属性を使うことにより、GCCの警告に対処します。

## カテゴリ
- リファクタリング

## PR の背景

GCCビルドで変な警告が出ています。
```
  [195/391] C:\msys64\mingw64\bin\g++.exe  -DUNICODE -D_DEBUG -D_UNICODE -D_WIN32 -D_WIN32_WINNT=_WIN32_WINNT_WIN7 -IC:/work/sakura/sakura_core -Isakura_core -g   -finput-charset=utf-8 -fexec-charset=cp932 -std=gnu++17 -MD -MT sakura_core/CMakeFiles/sakura_core.dir/extmodule/CIcu4cI18n.cpp.obj -MF sakura_core\CMakeFiles\sakura_core.dir\extmodule\CIcu4cI18n.cpp.obj.d -o sakura_core/CMakeFiles/sakura_core.dir/extmodule/CIcu4cI18n.cpp.obj -c C:/work/sakura/sakura_core/extmodule/CIcu4cI18n.cpp
  C:/work/sakura/sakura_core/extmodule/CIcu4cI18n.cpp: In member function 'virtual const WCHAR* CIcu4cI18n::GetDllNameImp(int)':
C:\work\sakura\sakura_core\extmodule\CIcu4cI18n.cpp(45,9): warning GEDD9F3F9: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     45 |  (void*)index;
        |         ^~~~~
```

これは、メソッド引数の未使用警告を抑制するために書いてる「なにもしない文」です。
やり方が正しいかどうかは別にして、古来から伝わる伝統みたいなもんです。
が、ビルド環境が64bitなのでサイズ警告が出てしまっています。

これ自体、特に問題のある記述ではないと思うんですがせっかくなので、
ここの記述をC++方式に改めたいと思います。

C++には、使用しない引数をマーキングしてコンパイラ警告を抑制するための機構があります。
具体的なやり方は、コードを見れば分かる感じなので省略します。

## PR のメリット
- GCCビルドの警告が1つ減ります。

## PR のデメリット (トレードオフとかあれば)
- とくにありません。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。

## 関連チケット
#1104 ICU4Cによる文字コード検出機能を追加する

## 参考資料
https://cpprefjp.github.io/lang/cpp17/maybe_unused.html
