### PR TITLE
C++ファイルのアウトライン解析がトグルで閉じない不具合の修正

### DIFF
--- a/sakura_core/cmd/CViewCommander_Outline.cpp
+++ b/sakura_core/cmd/CViewCommander_Outline.cpp
@@ -64,7 +64,7 @@ BOOL CViewCommander::Command_FUNCLIST(
 		// C/C++はファイル名により判定する
 		if( nOutlineType == OUTLINE_C_CPP
 			&& GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
-			nOutlineType = CheckCppType( GetDocument()->m_cDocFile.GetFilePath() );
+			nOutlineType = GetCLangOutlineType( GetDocument()->m_cDocFile.GetFilePath() );
 		}
 	}
 

--- a/sakura_core/cmd/CViewCommander_Outline.cpp
+++ b/sakura_core/cmd/CViewCommander_Outline.cpp
@@ -61,9 +61,8 @@ BOOL CViewCommander::Command_FUNCLIST(
 	if( nOutlineType == OUTLINE_DEFAULT ){
 		/* タイプ別に設定されたアウトライン解析方法 */
 		nOutlineType = m_pCommanderView->m_pTypeData->m_eDefaultOutline;
-		// C/C++はファイル名により判定する
-		if( nOutlineType == OUTLINE_C_CPP
-			&& GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
+		// C/C++はファイル名(拡張子)により追加判定する
+		if( nOutlineType == OUTLINE_C_CPP ){
 			nOutlineType = GetCLangOutlineType( GetDocument()->m_cDocFile.GetFilePath() );
 		}
 	}

--- a/sakura_core/cmd/CViewCommander_Outline.cpp
+++ b/sakura_core/cmd/CViewCommander_Outline.cpp
@@ -61,6 +61,11 @@ BOOL CViewCommander::Command_FUNCLIST(
 	if( nOutlineType == OUTLINE_DEFAULT ){
 		/* タイプ別に設定されたアウトライン解析方法 */
 		nOutlineType = m_pCommanderView->m_pTypeData->m_eDefaultOutline;
+		// C/C++はファイル名により判定する
+		if( nOutlineType == OUTLINE_C_CPP
+			&& GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
+			nOutlineType = CheckCppType( GetDocument()->m_cDocFile.GetFilePath() );
+		}
 	}
 
 	if( NULL != GetEditWindow()->m_cDlgFuncList.GetHwnd() && nAction != SHOW_RELOAD ){

--- a/sakura_core/types/CType.h
+++ b/sakura_core/types/CType.h
@@ -353,5 +353,5 @@ inline bool C_IsSpace( wchar_t c, bool bExtEol )
 }
 
 //! C/C++のファイル名による判定
-EOutlineType CheckCppType( const wchar_t* pszFileName );
+EOutlineType GetCLangOutlineType( const wchar_t* pszFileName );
 

--- a/sakura_core/types/CType.h
+++ b/sakura_core/types/CType.h
@@ -351,3 +351,7 @@ inline bool C_IsSpace( wchar_t c, bool bExtEol )
 		WCODE::IsLineDelimiter(c, bExtEol)
 	);
 }
+
+//! C/C++のファイル名による判定
+EOutlineType CheckCppType( const wchar_t* pszFileName );
+

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -33,6 +33,22 @@
 #include "view/CEditView.h"
 #include "view/colors/EColorIndexType.h"
 
+// 2015.11.14 C/C++のファイル名による判定
+EOutlineType CheckCppType( const wchar_t* pszFileName )
+{
+	auto nOutlineType = OUTLINE_C;
+	if( CheckEXT( pszFileName, L"cpp" )
+		|| CheckEXT( pszFileName, L"c++" )
+		|| CheckEXT( pszFileName, L"cxx" )
+		|| CheckEXT( pszFileName, L"hpp" )
+		|| CheckEXT( pszFileName, L"h++" )
+		|| CheckEXT( pszFileName, L"hxx" ) )
+	{
+		nOutlineType = OUTLINE_CPP;
+	}
+	return nOutlineType;
+}
+
 //!CPPキーワードで始まっていれば true
 inline bool IsHeadCppKeyword(const wchar_t* pData)
 {
@@ -342,23 +358,9 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 	const wchar_t*	pLine;
 	CLogicInt	nLineLen;
 	CLogicInt	i;
-	// 2015.11.14 C/C++のファイル名による判定
 	if( nOutlineType == OUTLINE_C_CPP ){
-		if( CheckEXT( pszFileName, L"c" ) ){
-			nOutlineType = OUTLINE_C;
-		}else if( CheckEXT( pszFileName, L"cpp" ) ){
-			nOutlineType = OUTLINE_CPP;
-		}else if( CheckEXT( pszFileName, L"c++" ) ){
-			nOutlineType = OUTLINE_CPP;
-		}else if( CheckEXT( pszFileName, L"cxx" ) ){
-			nOutlineType = OUTLINE_CPP;
-		}else if( CheckEXT( pszFileName, L"hpp" ) ){
-			nOutlineType = OUTLINE_CPP;
-		}else if( CheckEXT( pszFileName, L"h++" ) ){
-			nOutlineType = OUTLINE_CPP;
-		}else if( CheckEXT( pszFileName, L"hxx" ) ){
-			nOutlineType = OUTLINE_CPP;
-		}
+		// 2015.11.14 C/C++のファイル名による判定
+		nOutlineType = CheckCppType( pszFileName );
 	}
 
 	// 2002/10/27 frozen　ここから

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -34,19 +34,23 @@
 #include "view/colors/EColorIndexType.h"
 
 // 2015.11.14 C/C++のファイル名による判定
-EOutlineType CheckCppType( const wchar_t* pszFileName )
+EOutlineType GetCLangOutlineType( const wchar_t* pszFileName )
 {
-	auto nOutlineType = OUTLINE_C;
-	if( CheckEXT( pszFileName, L"cpp" )
+	auto eOutlineType = OUTLINE_C_CPP;
+	if( CheckEXT( pszFileName, L"c" ) )
+	{
+		eOutlineType = OUTLINE_C;
+	}
+	else if( CheckEXT( pszFileName, L"cpp" )
 		|| CheckEXT( pszFileName, L"c++" )
 		|| CheckEXT( pszFileName, L"cxx" )
 		|| CheckEXT( pszFileName, L"hpp" )
 		|| CheckEXT( pszFileName, L"h++" )
 		|| CheckEXT( pszFileName, L"hxx" ) )
 	{
-		nOutlineType = OUTLINE_CPP;
+		eOutlineType = OUTLINE_CPP;
 	}
-	return nOutlineType;
+	return eOutlineType;
 }
 
 //!CPPキーワードで始まっていれば true
@@ -360,7 +364,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 	CLogicInt	i;
 	if( nOutlineType == OUTLINE_C_CPP ){
 		// 2015.11.14 C/C++のファイル名による判定
-		nOutlineType = CheckCppType( pszFileName );
+		nOutlineType = GetCLangOutlineType( pszFileName );
 	}
 
 	// 2002/10/27 frozen　ここから

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -33,7 +33,18 @@
 #include "view/CEditView.h"
 #include "view/colors/EColorIndexType.h"
 
-// 2015.11.14 C/C++のファイル名による判定
+/*!
+ * @brief C/C++のファイル名による判定
+ *
+ * @param [in] pszFileName ファイル名(nullptr指定不可、NUL終端すること)
+ * @return アウトライン種別
+ *
+ * @detail
+ * ファイル名(拡張子)に応じたアウトライン種別を取得する。
+ * 拡張子の一致判定は大文字小文字を区別しない。
+ * 現状、拡張子に対応するアウトライン種別はベタ書きで判定している。
+ * 一致する拡張子がない場合、OUTLINE_C_CPPになる。
+ */
 EOutlineType GetCLangOutlineType( const wchar_t* pszFileName )
 {
 	auto eOutlineType = OUTLINE_C_CPP;


### PR DESCRIPTION
# PR の目的

C++ファイルのアウトライン解析がトグルで閉じない不具合を修正します。

## カテゴリ
- 不具合修正

## PR の背景
問題事象、再現方法、調査の経緯については、 https://github.com/sakura-editor/sakura/issues/1175#issuecomment-579767553 を参照してください。

人によって色んな見方があると思いますが、
ぼく自身は「C/C++の自動認識」を導入した際の実装漏れが原因の不具合と考えています。

実装漏れなら実装すりゃいいだけなんで、実装してみた感じです。


## PR のメリット
- タイプ別設定の「C/C++」にリストされる拡張子のファイルで、アウトライン解析（トグル）を使ってアウトラインウインドウの表示切替を行えるようになります。

## PR のデメリット (トレードオフとかあれば)
- とくにありません。
- ~~extractしたCheckCppTypeの関数名がダサい気がします。~~
- 関数の抽出時に判定がキモかったので微妙に書き替えています。
  - 書き替えに関して文句がつく可能性が高いと思っています。
  - そもそも、元の判定条件がツッコミどころ満載なので、無駄な議論になる懸念があります。

## PR の影響範囲
- タイプ別設定「C/C++」のファイルを開いたときの「アウトライン解析（トグル）」の挙動が変わります。
- タイプ別設定「C/C++」のファイルを開いたときに適用されるアウトライン種別の判定ロジックを個別関数に切り出してリファクタリングしています。（動作は変えていません

## 関連チケット
close #1175;「アウトライン解析(トグル) 」でトグルしない場合がある

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
