### PR TITLE
#1185 での rebase の誤りを修正

### DIFF
--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -112,6 +112,9 @@ exit /b 0
 	if "%BUILD_REPOSITORY_PROVIDER%"=="GitHub" (
 		set GITHUB_ON=1
 	)
+	if "%APPVEYOR_REPO_PROVIDER%"=="gitHub" (
+		set GITHUB_ON=1
+	)
 
 	set PREFIX_GITHUB=https://github.com
 	if "%GITHUB_ON%" == "1" (


### PR DESCRIPTION
# PR の目的

#1185 での rebase の誤りを修正

## カテゴリ

- 不具合修正
- CI関連
  - Appveyor
  - Azure Pipelines

## PR の背景

#1183 で PR を分割して #1185 を作成する際に、rebase 操作で変更を分割する際に
appeyor 側の修正ではなく、あやまって azure pipeline の修正を入れてしまった。

その部分のみ修正する。

## PR のメリット

#1185 がマージされた状態で GitHub コミット URL の機能が動作しなくなる問題が修正される。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

appveyor ビルドでの GitHub コミット URL

## 関連チケット

#1185
#1183 

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
