### PR TITLE
.NETFramework 4.7.2 の Targeting Pack を  .vs_config に追加する

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -10,6 +10,7 @@
 		"microsoft.visualstudio.component.vc.cmake.project",
 		"microsoft.visualstudio.component.vc.testadapterforboosttest",
 		"microsoft.visualstudio.component.vc.testadapterforgoogletest",
-		"microsoft.visualstudio.componentgroup.nativedesktop.win81"
+		"microsoft.visualstudio.componentgroup.nativedesktop.win81",
+		"microsoft.net.component.4.7.2.targetingpack"
 	]
 }


### PR DESCRIPTION
# PR の目的

.NETFramework 4.7.2 の Targeting Pack を `.vs_config` に追加する

## カテゴリ

- ビルド

## PR の背景

.NETFramework 4.7.2 の Targeting Pack がインストールされていない環境で
build-all Win32 Release でビルドすると以下エラーが出た。

これを修正するために `.vs_config` に追加する

```
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\Microsoft.Common.CurrentVersion.targets(1179,5): 
error MSB3644: フレームワーク ".NETFramework,Version=v4.7.2" の参照アセンブリが見つかりませんでした。

これを解決するには、このフレームワーク バージョンの SDK または T
argeting Pack をインストールするか、SDK または Targeting Pack を
インストールしているフレームワークのバージョンにアプリケーションを
再ターゲットしてください。
アセンブリはグローバル アセンブリ キャッシュ
(GAC) から解決され、参照アセンブリの代わりに使用されるため、アセンブリが
目的のフレームワークに正しくターゲットされない場合もあります。 [D:\gitwork\SakuraEditor\sakura\sakura\tools\Chm
SourceConverter\ChmSourceConverter\ChmSourceConverter.csproj]
```

## PR のメリット

.NETFramework 4.7.2 の Targeting Pack のインストールが必要なことが明確になる

## PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## PR の影響範囲

Visual studio のインストール

## 関連チケット

#996

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
