### PR TITLE
ChmSourceConverterのターゲットバージョンを下げる

### DIFF
--- a/tools/ChmSourceConverter/ChmSourceConverter.Test/ChmSourceConverter.Test.csproj
+++ b/tools/ChmSourceConverter/ChmSourceConverter.Test/ChmSourceConverter.Test.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ChmSourceConverter</RootNamespace>
     <AssemblyName>ChmSourceConverter.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>

--- a/tools/ChmSourceConverter/ChmSourceConverter.Test/packages.config
+++ b/tools/ChmSourceConverter/ChmSourceConverter.Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net472" />
-  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net472" />
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net461" />
 </packages>

--- a/tools/ChmSourceConverter/ChmSourceConverter/App.config
+++ b/tools/ChmSourceConverter/ChmSourceConverter/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
@@ -6,7 +6,7 @@
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
     <userSettings>
         <ChmSourceConverter.Properties.Settings>

--- a/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverter.csproj
+++ b/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverter.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ChmSourceConverter</RootNamespace>
     <AssemblyName>ChmSourceConverter</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
# PR の目的
ChmSourceConverterのターゲットフレームワークバージョン(net472)をvs2017標準搭載バージョン(net461)に下げることにより、追加コンポーネントをインストールすることなくツールのビルドを行えるようにする。

## カテゴリ
- その他

## PR の背景
#1192 で報告された通り、ChmSourceConverter のターゲットは net472 になっている。

これは、もともと appveyor 専用ツールとして作成した ChmSourceConverter の稼働フレームワークとして当時の最新安定verを選択したことが原因です。

元issue #1192 ではターゲット net472 をビルド要件に含める提案がなされています。

個人的に、サクラエディタのビルド要件に .NET Framework の特定バージョンを含めるのには違和感を覚えています。何故かといえば、サクラエディタは .NET Framework での開発に対応していないからです。現状のサクラエディタは Windows API を直接駆使して動作するネイティブCアプリなので、共通言語ランタイムを介して Windows を操作する .NET アプリとは根本的に別モノです。共通言語ランタイムを介してサクラエディタの機能拡張を行える目途が立つまでは、.NET Frameworkに依存しているかのような設定を入れるべきじゃないような気がします。

しかし、その間HTMLヘルプのビルドができない状態を放置してよいのか？というと、それはそれで違うような気がします。

最近追加されたC#のツールの設定を見ると、net461向けになっています。
これらに文句がでていないってことは、net461ならOKってことなんだと思います。

ChmSourceConverter のターゲットフレームワークバージョンをこれらに合わせれば、ビルドができない問題は解決すると思います。

バージョンを下げることにより、すっかり忘れていましたが「できるだけデフォルトインストールで開発できるものを作ろう！」って方針にも合致します。


## PR のメリット
- コンパイル済みHTMLヘルプをビルドする際に必要な visual stdio のコンポーネントが減る。
- 最近追加された C# で書かれたツールとターゲットフレームワークバージョンが揃う。

## PR のデメリット (トレードオフとかあれば)
- なし

## PR の影響範囲
- ローカルでコンパイル済みHTMLヘルプをビルドしたい場合の手順が一つ減る。

## 関連チケット
#1192 ←これの代替案です。

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
