### PR TITLE
C#ツールの.vsconfigを追加する

### DIFF
--- a/tools/ChmSourceConverter/.vsconfig
+++ b/tools/ChmSourceConverter/.vsconfig
@@ -1,22 +1,10 @@
 {
   "version": "1.0",
   "components": [
-    "Microsoft.VisualStudio.Component.CoreEditor",
-    "Microsoft.VisualStudio.Workload.CoreEditor",
-    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
-    "Microsoft.Component.MSBuild",
-    "Microsoft.VisualStudio.Component.Static.Analysis.Tools",
-    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
-    "Microsoft.VisualStudio.Component.PortableLibrary",
-    "Microsoft.Net.Component.4.6.1.SDK",
-    "Microsoft.Net.Component.4.6.1.TargetingPack",
     "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
-    "Microsoft.Component.ClickOnce",
-    "Microsoft.VisualStudio.Component.SQL.CLR",
-    "Microsoft.VisualStudio.Component.VisualStudioData",
-    "Microsoft.VisualStudio.Component.TextTemplating",
-    "Microsoft.VisualStudio.Component.ManagedDesktop.Core",
-    "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
-    "Microsoft.VisualStudio.Workload.ManagedDesktop"
+    "Microsoft.VisualStudio.Workload.ManagedDesktop",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+    "Microsoft.Net.Component.4.6.1.TargetingPack"
   ]
 }

--- a/tools/ChmSourceConverter/.vsconfig
+++ b/tools/ChmSourceConverter/.vsconfig
@@ -1,0 +1,22 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.Component.MSBuild",
+    "Microsoft.VisualStudio.Component.Static.Analysis.Tools",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+    "Microsoft.VisualStudio.Component.PortableLibrary",
+    "Microsoft.Net.Component.4.6.1.SDK",
+    "Microsoft.Net.Component.4.6.1.TargetingPack",
+    "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
+    "Microsoft.Component.ClickOnce",
+    "Microsoft.VisualStudio.Component.SQL.CLR",
+    "Microsoft.VisualStudio.Component.VisualStudioData",
+    "Microsoft.VisualStudio.Component.TextTemplating",
+    "Microsoft.VisualStudio.Component.ManagedDesktop.Core",
+    "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
+    "Microsoft.VisualStudio.Workload.ManagedDesktop"
+  ]
+}

--- a/tools/ToolBarTools/.vsconfig
+++ b/tools/ToolBarTools/.vsconfig
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
+    "Microsoft.VisualStudio.Workload.ManagedDesktop",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+    "Microsoft.Net.Component.4.6.1.TargetingPack"
+  ]
+}


### PR DESCRIPTION
# PR の目的
C#ツールの.vsconfigを追加することにより、ツールをビルドしやすくする。

## カテゴリ
- その他

## PR の背景

https://github.com/sakura-editor/sakura/pull/1195#issuecomment-584589888
> > とりあえず、インストーラのビルドができればいいので この PR でもいいです。
> 
> 了解っす。
> 
> マニュアルをもう一度確認しましたが、「ソリューションのルート」に vsconfig があれば読み込まれるみたいなんで、C# ツール向けの vsconfig を用意しときたいと思っています。
> 
> https://docs.microsoft.com/ja-jp/visualstudio/install/import-export-installation-configurations?view=vs-2019#automatically-install-missing-components


## PR のメリット
- 基本的には、.vsconfigを用意することそのものがメリットになると思っています。
- 必要なコンポーネントが明確になる結果、ビルドしてみようと思った人が迷わなくて済むようになります。

## PR のデメリット (トレードオフとかあれば)
- バージョンを net461 に揃えたの失敗だったかもです :cry:

vsバージョン | 既定の.NETバージョン | 備考
-- | -- | --
vs2017 | .NET Framework 4.6.1 | ここに合わせた。
vs2019 | .NET Framework 4.7.2 | .vsconfigの恩恵を受けられるのはこっち。

前に書いた通り、既定のバージョンを外すとvsの開発ツールが動かなくなるので、
「net461に合わせる」ってことは、vs2019での追加インストールが必須ということになります。

.vsconfigによる自動追加インストールの恩恵を受けられるのは主にvs2019のほうなので、
どこかでvs2019中心で考える方向にシフトしていったほうがよいのかも知れません。

## PR の影響範囲
- C#ツールを使ってみようとした人が初めてソリューションを開いたときに、「デスクトップ開発(C#)」を有効にしていなかった場合の visual studio の挙動に影響します。

## 関連チケット
#1195
#1192

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
