### PR TITLE
マクロMakeStringBufferW0を廃止する

### DIFF
--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -44,7 +44,6 @@ typedef const StringBufferW_ StringBufferW;
 
 //文字列バッファ型インスタンスの生成マクロ
 #define MakeStringBufferW(S) StringBufferW(S,_countof(S))
-#define MakeStringBufferW0(S) StringBufferW(S,0)
 
 //2007.09.24 kobake データ変換部を子クラスに分離
 //!各種データ変換付きCProfile

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1384,6 +1384,81 @@ void CShareData_IO::ShareData_IO_Types( CDataProfile& cProfile )
 }
 
 /*!
+ * ブロックコメントデータの入出力
+ *
+ * @date 2004/10/02 Moca 対になるコメント設定がともに読み込まれたときだけ有効な設定と見なす．
+ * @date 2020/01/01 berryzplus ShareData_IO_Type_Oneから分離
+ */
+static bool ShareData_IO_BlockComment( CDataProfile& cProfile,
+	const WCHAR* pszSectionName,
+	const WCHAR* pszEntryKeyFrom,
+	const WCHAR* pszEntryKeyTo,
+	CBlockComment& cBlockComment
+) noexcept
+{
+	WCHAR szFrom[BLOCKCOMMENT_BUFFERSIZE]{ 0 };
+	WCHAR szTo[BLOCKCOMMENT_BUFFERSIZE]{ 0 };
+
+	// 書き込み準備
+	if( !cProfile.IsReadingMode() ){
+		::wcscpy_s( szFrom, cBlockComment.getBlockCommentFrom() );
+		::wcscpy_s( szTo, cBlockComment.getBlockCommentTo() );
+	}
+
+	bool ret = false;
+	if( cProfile.IOProfileData( pszSectionName, pszEntryKeyFrom, MakeStringBufferW( szFrom ) )
+		&& cProfile.IOProfileData( pszSectionName, pszEntryKeyTo, MakeStringBufferW( szTo ) ) ){
+		//対になる設定が揃った場合のみ有効
+		ret = true;
+	}
+
+	// 読み込み後処理
+	if( cProfile.IsReadingMode() && ret ){
+		cBlockComment.SetBlockCommentRule( szFrom, szTo );
+	}
+
+	return ret;
+}
+
+/*!
+ * 行コメントデータの入出力
+ *
+ * @date 2004/10/02 Moca 対になるコメント設定がともに読み込まれたときだけ有効な設定と見なす．
+ * @date 2020/01/01 berryzplus ShareData_IO_Type_Oneから分離
+ */
+static bool ShareData_IO_LineComment( CDataProfile& cProfile,
+	const WCHAR* pszSectionName,
+	const WCHAR* pszEntryKeyComment,
+	const WCHAR* pszEntryKeyColumn,
+	CLineComment& cLineComment,
+	const int nDataIndex
+) noexcept
+{
+	WCHAR lbuf[COMMENT_DELIMITER_BUFFERSIZE]{ 0 };
+	int pos = -1;
+
+	// 書き込み準備
+	if( !cProfile.IsReadingMode() ){
+		::wcscpy_s( lbuf, cLineComment.getLineComment( nDataIndex ) );
+		pos = cLineComment.getLineCommentPos( nDataIndex );
+	}
+
+	bool ret = false;
+	if( cProfile.IOProfileData( pszSectionName, pszEntryKeyComment, MakeStringBufferW( lbuf ) )
+		&& cProfile.IOProfileData( pszSectionName, pszEntryKeyColumn, pos ) ){
+		//対になる設定が揃った場合のみ有効
+		ret = true;
+	}
+
+	// 読み込み後処理
+	if( cProfile.IsReadingMode() && ret ){
+		cLineComment.CopyTo( nDataIndex, lbuf, pos );
+	}
+
+	return ret;
+}
+
+/*!
 @brief 共有データのSTypeConfigセクションの入出力(１個分)
 	@param[in,out]	cProfile	INIファイル入出力クラス
 	@param[in]		type		タイプ別
@@ -1490,75 +1565,14 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("bStringLineOnly"), types.m_bStringLineOnly );
 	cProfile.IOProfileData( pszSecName, LTEXT("bStringEndLine"), types.m_bStringEndLine );
 
-	// From Here Sep. 28, 2002 genta / YAZAKI
-	if( cProfile.IsReadingMode() ){
-		//	Block Comment
-		wchar_t buffer[2][ BLOCKCOMMENT_BUFFERSIZE ];
-		//	2004.10.02 Moca 対になるコメント設定がともに読み込まれたときだけ有効な設定と見なす．
-		//	ブロックコメントの始まりと終わり．行コメントの記号と桁位置
-		bool bRet1, bRet2;
-		buffer[0][0] = buffer[1][0] = L'\0';
-		bRet1 = cProfile.IOProfileData( pszSecName, LTEXT("szBlockCommentFrom"), MakeStringBufferW(buffer[0]) );			
-		bRet2 = cProfile.IOProfileData( pszSecName, LTEXT("szBlockCommentTo"), MakeStringBufferW(buffer[1]) );
-		if( bRet1 && bRet2 ) types.m_cBlockComments[0].SetBlockCommentRule( buffer[0], buffer[1] );
+	// Block Comment
+	ShareData_IO_BlockComment( cProfile, pszSecName, L"szBlockCommentFrom", L"szBlockCommentTo", types.m_cBlockComments[0] );
+	ShareData_IO_BlockComment( cProfile, pszSecName, L"szBlockCommentFrom2", L"szBlockCommentTo2", types.m_cBlockComments[1] );
 
-		//@@@ 2001.03.10 by MIK
-		buffer[0][0] = buffer[1][0] = L'\0';
-		bRet1 = cProfile.IOProfileData( pszSecName, LTEXT("szBlockCommentFrom2"), MakeStringBufferW(buffer[0]) );
-		bRet2 = cProfile.IOProfileData( pszSecName, LTEXT("szBlockCommentTo2")	, MakeStringBufferW(buffer[1]) );
-		if( bRet1 && bRet2 ) types.m_cBlockComments[1].SetBlockCommentRule( buffer[0], buffer[1] );
-		
-		//	Line Comment
-		wchar_t lbuf[ COMMENT_DELIMITER_BUFFERSIZE ];
-		int  pos;
-
-		lbuf[0] = L'\0'; pos = -1;
-		bRet1 = cProfile.IOProfileData( pszSecName, LTEXT("szLineComment")		, MakeStringBufferW(lbuf) );
-		bRet2 = cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn")	, pos );
-		if( bRet1 && bRet2 ) types.m_cLineComment.CopyTo( 0, lbuf, pos );
-
-		lbuf[0] = L'\0'; pos = -1;
-		bRet1 = cProfile.IOProfileData( pszSecName, LTEXT("szLineComment2")		, MakeStringBufferW(lbuf) );
-		bRet2 = cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn2"), pos );
-		if( bRet1 && bRet2 ) types.m_cLineComment.CopyTo( 1, lbuf, pos );
-
-		lbuf[0] = L'\0'; pos = -1;
-		bRet1 = cProfile.IOProfileData( pszSecName, LTEXT("szLineComment3")		, MakeStringBufferW(lbuf) );	//Jun. 01, 2001 JEPRO 追加
-		bRet2 = cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn3"), pos );	//Jun. 01, 2001 JEPRO 追加
-		if( bRet1 && bRet2 ) types.m_cLineComment.CopyTo( 2, lbuf, pos );
-	}
-	else { // write
-		//	Block Comment
-		cProfile.IOProfileData( pszSecName, LTEXT("szBlockCommentFrom")	,
-			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cBlockComments[0].getBlockCommentFrom())) );
-		cProfile.IOProfileData( pszSecName, LTEXT("szBlockCommentTo")	,
-			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cBlockComments[0].getBlockCommentTo())) );
-
-		//@@@ 2001.03.10 by MIK
-		cProfile.IOProfileData( pszSecName, LTEXT("szBlockCommentFrom2"),
-			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cBlockComments[1].getBlockCommentFrom())) );
-		cProfile.IOProfileData( pszSecName, LTEXT("szBlockCommentTo2")	,
-			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cBlockComments[1].getBlockCommentTo())) );
-
-		//	Line Comment
-		cProfile.IOProfileData( pszSecName, LTEXT("szLineComment")		,
-			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cLineComment.getLineComment(0))) );
-		cProfile.IOProfileData( pszSecName, LTEXT("szLineComment2")		,
-			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cLineComment.getLineComment(1))) );
-		cProfile.IOProfileData( pszSecName, LTEXT("szLineComment3")		,
-			MakeStringBufferW0(const_cast<wchar_t*>(types.m_cLineComment.getLineComment(2))) );	//Jun. 01, 2001 JEPRO 追加
-
-		//	From here May 12, 2001 genta
-		int pos;
-		pos = types.m_cLineComment.getLineCommentPos( 0 );
-		cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn")	, pos );
-		pos = types.m_cLineComment.getLineCommentPos( 1 );
-		cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn2"), pos );
-		pos = types.m_cLineComment.getLineCommentPos( 2 );
-		cProfile.IOProfileData( pszSecName, LTEXT("nLineCommentColumn3"), pos );	//Jun. 01, 2001 JEPRO 追加
-		//	To here May 12, 2001 genta
-	}
-	// To Here Sep. 28, 2002 genta / YAZAKI
+	// Line Comment
+	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment", L"nLineCommentColumn", types.m_cLineComment, 0 );
+	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment2", L"nLineCommentColumn2", types.m_cLineComment, 1 );
+	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment3", L"nLineCommentColumn3", types.m_cLineComment, 2 );
 
 	cProfile.IOProfileData( pszSecName, LTEXT("szIndentChars")		, MakeStringBufferW(types.m_szIndentChars) );
 	cProfile.IOProfileData( pszSecName, LTEXT("cLineTermChar")		, types.m_cLineTermChar );


### PR DESCRIPTION
# PR の目的

文字列バッファ参照 `StringBufferW` を「サイズ指定なし（＝０）」で作成するためのマクロ `MakeStringBufferW0` を廃止します。 変更により、`StringBufferW` のサイズが「不明」であるケースを考慮しなくて良くなります。

https://github.com/sakura-editor/sakura/blob/32f03fd8dcf3986770b27bb7ebe38bd1235ab304/sakura_core/CDataProfile.h#L45-L47

`StringBufferW(S,0)` は書き込める文字が 0 文字（＝不明）ということです。

## カテゴリ
- リファクタリング

## PR の背景

サクラエディタの設定読み取り機構にはなんか問題がある気がする（根拠なし
　↓
#1152  [WIP] CDataProfileクラスの今後のリファクタリング予定を晒してみる  
　↓
#1188 設定項目がなかったらデフォルト設定を使うようにしたい
　↓
CDataProfileで読み取り失敗を検出できるようにする、を作ろうとしてみた
　↓
読み取り失敗の検出と全然関係ない変更をしないといかんことに気付いた（いまここ

PRの中身自体は #1152 で見せた一連のコミットの1つをそのまま使っています。
（しょーもない書き間違いを見つけたので修正して force-push しました :sob: ）

やっていること
- CBlockComentクラスの入出力をCShareData_IO::ShareData_IO_Type_Oneから分離した。
- CLineCommentクラスの入出力をCShareData_IO::ShareData_IO_Type_Oneから分離した。

理由
- CBlockComentクラスのデータは、開始文字と終了文字でセットになっており、両方の設定項目を読み取れた場合にだけ設定を読み取るガードが入っている。（＝データがカプセル化されている）
- CLineComentクラスのデータは、コメントパターンと区切り位置でセットになっており、両方の設定項目を読み取れた場合にだけ設定を読み取るガードが入っている。（＝データがカプセル化されている）

対策内容
- 新設したメソッド内に適切なサイズのローカルバッファを用意し、クラス仕様に基づいた相関チェックを追加、データの設定は元々クラスに用意されていたセッターを使うように変更。

## PR のメリット
- `StringBufferW` のサイズが「不明（＝０）」であるケースを考慮しなくて良くなります。  
読み取ったデータサイズが書き込み可能データサイズを上回っていたら「失敗」にできるようになります。

## PR のデメリット (トレードオフとかあれば)
- とくにありません。

## PR の影響範囲
- このPRはリファクタリングなので、挙動は変えていないつもりです。
- タイプ別設定の「ブロックコメント」、「行コメント」の設定読み書きに影響する変更です。

## 関連チケット
#1152  [WIP] CDataProfileクラスの今後のリファクタリング予定を晒してみる  
#1188 設定項目がなかったらデフォルト設定を使うようにしたい

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
