### PR TITLE
キーワードを指定してタグジャンプができないバグを修正

### DIFF
--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -1340,6 +1340,9 @@ bool CDlgTagJumpList::ReadTagsParameter(
 		}
 		else {
 			//巻き戻し
+			if (old_offset < 0) {
+				old_offset = 0; // 異常時はファイル先頭にする。
+			}
 			fsetpos(fp, &old_offset);
 			break;
 		}

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -1255,15 +1255,13 @@ bool CDlgTagJumpList::ReadTagsParameter(
 	ACHAR	s[4][1024];
 	int nLines = 0;
 	int n2;
-	fpos_t old_offset;
-
+	fpos_t old_offset = 0;
 
 	// バッファの後ろから2文字目が\0かどうかで、行末まで読み込んだか確認する
 	const int nLINEDATA_LAST_CHAR = _countof( szLineData ) - 2;
 	szLineData[nLINEDATA_LAST_CHAR] = '\0';
 
-	while( fgets( szLineData, _countof( szLineData ), fp ) )
-	{
+	while( fgets( szLineData, _countof( szLineData ), fp ) ) {
 		nLines++;
 		// fgetsが行すべてを読み込めていない場合の考慮
 		if( '\0' != szLineData[nLINEDATA_LAST_CHAR] && '\n' != szLineData[nLINEDATA_LAST_CHAR] ){
@@ -1336,6 +1334,8 @@ bool CDlgTagJumpList::ReadTagsParameter(
 				}
 			}
 			szLineData[nLINEDATA_LAST_CHAR] = '\0';
+			//巻き戻し用に現在のオフセット位置を退避
+			old_offset = ftell(fp);
 			continue;
 		}
 		else {
@@ -1343,8 +1343,6 @@ bool CDlgTagJumpList::ReadTagsParameter(
 			fsetpos(fp, &old_offset);
 			break;
 		}
-		//巻き戻し用に現在のオフセット位置を退避
-		old_offset = ftell(fp);
 	}
 	return true;
 }

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -1336,13 +1336,12 @@ bool CDlgTagJumpList::ReadTagsParameter(
 			szLineData[nLINEDATA_LAST_CHAR] = '\0';
 			//巻き戻し用に現在のオフセット位置を退避
 			old_offset = ftell(fp);
+			if (old_offset == -1) { //読み取りエラー or ファイル終端に到達時はタグファイルとして扱わない
+				return false;
+			}
 			continue;
 		}
 		else {
-			//巻き戻し
-			if (old_offset < 0) {
-				old_offset = 0; // 異常時はファイル先頭にする。
-			}
 			fsetpos(fp, &old_offset);
 			break;
 		}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートに切り替えることで登録後にどのように見えるか確認することができます -->

# PR の目的
#836 にてデグレしていたため、修正する。
通常のタグジャンプは可能だが、キーワードを指定してタグジャンプ機能ができなくなっていた。

## カテゴリ

- 不具合修正

## PR の背景
#836 で、タグジャンプを高速化するためにtagsファイルのパラメータ(!_TAG_FILE_FORMAT等)の読み込みのための関数ReadTagsParameterを作成しました。

タグジャンプの際にはReadTagsParameter()の後にfind_key_for_BinarySearch() または find_key_for_LinearSearch()にてタグを検索する作りにしていましたが、
find_key_for_LinearSearch()のときに今回のバグが再現します。
→キーワードを指定してタグジャンプの時はfind_key_for_LinearSearch()になりますので、タグジャンプできない状態でした。

細かい話としては、ReadTagsParameter()を抜ける際にはファイルシーク位置はtagsファイルのパラメーター群を読み終わった所にしたいため、old_offsetにて読み込んだ位置を保持しているつもりでした。
しかし、old_offsetの設定は到達不可能な場所で行っていたため、ReadTagsParameter()を抜ける際のファイルシークは初期化していないold_offset(不定値)での位置になっていました。

## PR のメリット
キーワードを指定してタグジャンプ機能が従来通り使えるようになります。

## PR のデメリット (トレードオフとかあれば)
特になし

## PR の影響範囲
タグジャンプ機能のみ

## 関連チケット
#836 

## 参考資料
なし