### PR TITLE
除外ファイル・除外フォルダの指定をGrep置換でも使えるようにする

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -22,6 +22,7 @@
 #include "debug/CRunningTimer.h"
 #include <deque>
 #include <memory>
+#include <list>
 #include "sakura_rc.h"
 
 #define UICHECK_INTERVAL_MILLISEC 100	// UI確認の時間間隔

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -22,7 +22,6 @@
 #include "debug/CRunningTimer.h"
 #include <deque>
 #include <memory>
-#include <list>
 #include "sakura_rc.h"
 
 #define UICHECK_INTERVAL_MILLISEC 100	// UI確認の時間間隔
@@ -474,13 +473,8 @@ DWORD CGrepAgent::DoGrep(
 
 	cmemMessage.AppendString(LS(STR_GREP_EXCLUDE_FILE));	//L"除外ファイル   "
 	{
-		// 除外ファイルの2つの解析済み配列から1つのリストを作る
-		std::list<LPCWSTR> excludeFiles;
-		const auto& vecExceptFileKeys = cGrepEnumKeys.m_vecExceptFileKeys;
-		excludeFiles.insert( excludeFiles.cend(), vecExceptFileKeys.cbegin(), vecExceptFileKeys.cend() );
-		const auto& vecExceptAbsFileKeys = cGrepEnumKeys.m_vecExceptAbsFileKeys;
-		excludeFiles.insert( excludeFiles.cend(), vecExceptAbsFileKeys.cbegin(), vecExceptAbsFileKeys.cend() );
-
+		// 除外ファイルの解析済みリストを取得る
+		auto excludeFiles = cGrepEnumKeys.GetExcludeFiles();
 		std::wstring strPatterns = FormatPathList( excludeFiles );
 		cmemMessage.AppendString( strPatterns.c_str(), strPatterns.length() );
 	}
@@ -488,13 +482,8 @@ DWORD CGrepAgent::DoGrep(
 
 	cmemMessage.AppendString(LS(STR_GREP_EXCLUDE_FOLDER));	//L"除外フォルダ   "
 	{
-		// 除外フォルダの2つの解析済み配列から1つのリストを作る
-		std::list<LPCWSTR> excludeFolders;
-		const auto& vecExceptFolderKeys = cGrepEnumKeys.m_vecExceptFolderKeys;
-		excludeFolders.insert( excludeFolders.cend(), vecExceptFolderKeys.cbegin(), vecExceptFolderKeys.cend() );
-		const auto& vecExceptAbsFolderKeys = cGrepEnumKeys.m_vecExceptAbsFolderKeys;
-		excludeFolders.insert( excludeFolders.cend(), vecExceptAbsFolderKeys.cbegin(), vecExceptAbsFolderKeys.cend() );
-
+		// 除外フォルダの解析済みリストを取得する
+		auto excludeFolders = cGrepEnumKeys.GetExcludeFolders();
 		std::wstring strPatterns = FormatPathList( excludeFolders );
 		cmemMessage.AppendString( strPatterns.c_str(), strPatterns.length() );
 	}

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -441,7 +441,31 @@ DWORD CGrepAgent::DoGrep(
 	}
 
 	cmemMessage.AppendString( LS( STR_GREP_SEARCH_TARGET ) );	//L"検索対象   "
-	cmemMessage.AppendString( pcmGrepFile->GetStringPtr() );
+	{
+		// 解析済みのファイルパターン配列を取得する
+		const auto& vecSearchFileKeys = cGrepEnumKeys.m_vecSearchFileKeys;
+
+		std::wstring strPatterns;
+		bool firstItem = true;
+		for( const auto& pszPattern : vecSearchFileKeys ){
+			// パスリストは ':' で区切る(2つ目以降の前に付加する)
+			if( firstItem ){
+				firstItem = false;
+			}else{
+				strPatterns += L';';
+			}
+
+			// ';' を含むパス名は引用符で囲む
+			if( auto_strchr( pszPattern, L';' ) ){
+				strPatterns += L'"';
+				strPatterns += pszPattern;
+				strPatterns += L'"';
+			}else{
+				strPatterns += pszPattern;
+			}
+		}
+		cmemMessage.AppendString( strPatterns.c_str(), strPatterns.length() );
+	}
 	cmemMessage.AppendString( L"\r\n" );
 
 	cmemMessage.AppendString( LS( STR_GREP_SEARCH_FOLDER ) );	//L"フォルダ   "
@@ -469,11 +493,67 @@ DWORD CGrepAgent::DoGrep(
 	cmemMessage.AppendString( L"\r\n" );
 
 	cmemMessage.AppendString(LS(STR_GREP_EXCLUDE_FILE));	//L"除外ファイル   "
-	cmemMessage.AppendString( pcmExcludeFile->GetStringPtr() );
+	{
+		// 除外ファイルの2つの解析済み配列から1つのリストを作る
+		std::list<LPCWSTR> excludeFiles;
+		const auto& vecExceptFileKeys = cGrepEnumKeys.m_vecExceptFileKeys;
+		excludeFiles.insert( excludeFiles.cend(), vecExceptFileKeys.cbegin(), vecExceptFileKeys.cend() );
+		const auto& vecExceptAbsFileKeys = cGrepEnumKeys.m_vecExceptAbsFileKeys;
+		excludeFiles.insert( excludeFiles.cend(), vecExceptAbsFileKeys.cbegin(), vecExceptAbsFileKeys.cend() );
+
+		std::wstring strPatterns;
+		bool firstItem = true;
+		for( const auto& pszPattern : excludeFiles ){
+			// パスリストは ':' で区切る(2つ目以降の前に付加する)
+			if( firstItem ){
+				firstItem = false;
+			}else{
+				strPatterns += L';';
+			}
+
+			// ';' を含むパス名は引用符で囲む
+			if( auto_strchr( pszPattern, L';' ) ){
+				strPatterns += L'"';
+				strPatterns += pszPattern;
+				strPatterns += L'"';
+			}else{
+				strPatterns += pszPattern;
+			}
+		}
+		cmemMessage.AppendString( strPatterns.c_str(), strPatterns.length() );
+	}
 	cmemMessage.AppendString(L"\r\n");
 
 	cmemMessage.AppendString(LS(STR_GREP_EXCLUDE_FOLDER));	//L"除外フォルダ   "
-	cmemMessage.AppendString( pcmExcludeFolder->GetStringPtr() );
+	{
+		// 除外フォルダの2つの解析済み配列から1つのリストを作る
+		std::list<LPCWSTR> excludeFolders;
+		const auto& vecExceptFolderKeys = cGrepEnumKeys.m_vecExceptFolderKeys;
+		excludeFolders.insert( excludeFolders.cend(), vecExceptFolderKeys.cbegin(), vecExceptFolderKeys.cend() );
+		const auto& vecExceptAbsFolderKeys = cGrepEnumKeys.m_vecExceptAbsFolderKeys;
+		excludeFolders.insert( excludeFolders.cend(), vecExceptAbsFolderKeys.cbegin(), vecExceptAbsFolderKeys.cend() );
+
+		std::wstring strPatterns;
+		bool firstItem = true;
+		for( const auto& pszPattern : excludeFolders ){
+			// パスリストは ':' で区切る(2つ目以降の前に付加する)
+			if( firstItem ){
+				firstItem = false;
+			}else{
+				strPatterns += L';';
+			}
+
+			// ';' を含むパス名は引用符で囲む
+			if( auto_strchr( pszPattern, L';' ) ){
+				strPatterns += L'"';
+				strPatterns += pszPattern;
+				strPatterns += L'"';
+			}else{
+				strPatterns += pszPattern;
+			}
+		}
+		cmemMessage.AppendString( strPatterns.c_str(), strPatterns.length() );
+	}
 	cmemMessage.AppendString(L"\r\n");
 
 	const wchar_t*	pszWork;

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -190,8 +190,6 @@ DWORD CGrepAgent::DoGrep(
 	const CNativeW*			pcmGrepReplace,
 	const CNativeW*			pcmGrepFile,
 	const CNativeW*			pcmGrepFolder,
-	const CNativeW*			pcmExcludeFile,
-	const CNativeW*			pcmExcludeFolder,
 	bool					bGrepCurFolder,
 	BOOL					bGrepSubFolder,
 	bool					bGrepStdout,
@@ -379,9 +377,7 @@ DWORD CGrepAgent::DoGrep(
 	CGrepEnumKeys cGrepEnumKeys;
 	{
 		int nErrorNo = cGrepEnumKeys.SetFileKeys( pcmGrepFile->GetStringPtr() );
-		int nErrorNo_ExcludeFile   = cGrepEnumKeys.AddExceptFile(pcmExcludeFile->GetStringPtr());
-		int nErrorNo_ExcludeFolder = cGrepEnumKeys.AddExceptFolder(pcmExcludeFolder->GetStringPtr());
-		if( nErrorNo != 0 || nErrorNo_ExcludeFile != 0 || nErrorNo_ExcludeFolder != 0){
+		if( nErrorNo != 0 ){
 			this->m_bGrepRunning = false;
 			pcViewDst->m_bDoing_UndoRedo = false;
 			pcViewDst->SetUndoBuffer();
@@ -391,18 +387,6 @@ DWORD CGrepAgent::DoGrep(
 				pszErrorMessage = LS(STR_GREP_ERR_ENUMKEYS1);
 			}
 			else if( nErrorNo == 2 ){
-				pszErrorMessage = LS(STR_GREP_ERR_ENUMKEYS2);
-			}
-			else if (nErrorNo_ExcludeFile == 1) {
-				pszErrorMessage = LS(STR_GREP_ERR_ENUMKEYS1);
-			}
-			else if (nErrorNo_ExcludeFile == 2) {
-				pszErrorMessage = LS(STR_GREP_ERR_ENUMKEYS2);
-			}
-			else if (nErrorNo_ExcludeFolder == 1) {
-				pszErrorMessage = LS(STR_GREP_ERR_ENUMKEYS1);
-			}
-			else if (nErrorNo_ExcludeFolder == 2) {
 				pszErrorMessage = LS(STR_GREP_ERR_ENUMKEYS2);
 			}
 			ErrorMessage( pcViewDst->m_hwndParent, L"%s", pszErrorMessage );

--- a/sakura_core/CGrepAgent.h
+++ b/sakura_core/CGrepAgent.h
@@ -84,8 +84,6 @@ public:
 		const CNativeW*			pcmGrepReplace,
 		const CNativeW*			pcmGrepFile,
 		const CNativeW*			pcmGrepFolder,
-		const CNativeW*			pcmExcludeFile,
-		const CNativeW*			pcmExcludeFolder,
 		bool					bGrepCurFolder,
 		BOOL					bGrepSubFolder,
 		bool					bGrepStdout,

--- a/sakura_core/CGrepEnumKeys.h
+++ b/sakura_core/CGrepEnumKeys.h
@@ -31,6 +31,7 @@
 */
 #pragma once
 
+#include <list>
 #include <vector>
 #include <windows.h>
 #include <string.h>
@@ -57,6 +58,26 @@ public:
 
 	~CGrepEnumKeys(){
 		ClearItems();
+	}
+
+	// 除外ファイルの2つの解析済み配列から1つのリストを作る
+	auto GetExcludeFiles() const ->  std::list<decltype(m_vecExceptFileKeys)::value_type> {
+		std::list<decltype(m_vecExceptFileKeys)::value_type> excludeFiles;
+		const auto& fileKeys = m_vecExceptFileKeys;
+		excludeFiles.insert( excludeFiles.cend(), fileKeys.cbegin(), fileKeys.cend() );
+		const auto& absFileKeys = m_vecExceptAbsFileKeys;
+		excludeFiles.insert( excludeFiles.cend(), absFileKeys.cbegin(), absFileKeys.cend() );
+		return excludeFiles;
+	}
+
+	// 除外フォルダの2つの解析済み配列から1つのリストを作る
+	auto GetExcludeFolders() const ->  std::list<decltype(m_vecExceptFolderKeys)::value_type> {
+		std::list<decltype(m_vecExceptFolderKeys)::value_type> excludeFolders;
+		const auto& folderKeys = m_vecExceptFolderKeys;
+		excludeFolders.insert( excludeFolders.cend(), folderKeys.cbegin(), folderKeys.cend() );
+		const auto& absFolderKeys = m_vecExceptAbsFolderKeys;
+		excludeFolders.insert( excludeFolders.cend(), absFolderKeys.cbegin(), absFolderKeys.cend() );
+		return excludeFolders;
 	}
 
 	int SetFileKeys( LPCWSTR lpKeys ){

--- a/sakura_core/GrepInfo.cpp
+++ b/sakura_core/GrepInfo.cpp
@@ -34,8 +34,6 @@ GrepInfo::GrepInfo() noexcept
 	, cmGrepRep()
 	, cmGrepFile()
 	, cmGrepFolder()
-	, cmExcludeFile()
-	, cmExcludeFolder()
 	, sGrepSearchOption()
 	, bGrepCurFolder(false)
 	, bGrepStdout(false)

--- a/sakura_core/GrepInfo.h
+++ b/sakura_core/GrepInfo.h
@@ -41,8 +41,6 @@ struct GrepInfo {
 	CNativeW		cmGrepRep;				//!< 置換キー
 	CNativeW		cmGrepFile;				//!< 検索対象ファイル
 	CNativeW		cmGrepFolder;			//!< 検索対象フォルダ
-	CNativeW		cmExcludeFile;			//!< 除外対象ファイル
-	CNativeW		cmExcludeFolder;		//!< 除外対象フォルダ
 	SSearchOption	sGrepSearchOption;		//!< 検索オプション
 	bool			bGrepCurFolder;			//!< カレントディレクトリを維持
 	bool			bGrepStdout;			//!< 標準出力モード

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -108,7 +108,7 @@ void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep&
 	CNativeW		cmWorkExcludeFile;
 	CNativeW		cmWorkExcludeFolder;
 	cmWork1.SetString( cDlgGrep.m_strText.c_str() );
-	cmWork2.SetString( cDlgGrep.GetFile().GetStringPtr() );
+	cmWork2 = cDlgGrep.GetPackedGFileString();
 	cmWork3.SetString( cDlgGrep.m_szFolder );
 
 	cmWorkExcludeFile.SetString(cDlgGrep.m_szExcludeFile);

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -97,67 +97,6 @@ void CControlTray::DoGrep()
 	DoGrepCreateWindow(m_hInstance, GetDllShareData().m_sHandles.m_hwndTray, m_cDlgGrep);
 }
 
-/*
-	@brief ファイル/フォルダの除外パターンをエスケープする必要があるか判断する
-	@param[in]     pattern チェックするパターン
-	@return        true  エスケープする必要がある
-	@return        false エスケープする必要がない
-*/
-static bool IsEscapeRequiredForExcludePattern(const wstring & pattern)
-{
-	const auto NotFound = std::string::npos;
-	if (pattern.find(L'!') != NotFound)
-	{
-		return true;
-	}
-	if (pattern.find(L'#') != NotFound)
-	{
-		return true;
-	}
-	return false;
-}
-
-/*
-	@brief エスケープパターンを取得する
-	@param[in] pattern        エスケープ対象文字列
-*/
-static LPCWSTR GetEscapePattern(const wstring& pattern)
-{
-	return IsEscapeRequiredForExcludePattern(pattern) ? L"\"\"" : L"";
-}
-
-/*
-	@brief フォルダの除外パターンを詰める
-	@param[in,out] cFilePattern        "-GFILE=" に指定する引数用のバッファ (このバッファの末尾に追加する)
-	@param[in]     cmWorkExcludeFolder Grep ダイアログで指定されたフォルダの除外パターン
-*/
-static void AppendExcludeFolderPatterns(CNativeW& cFilePattern, const CNativeW& cmWorkExcludeFolder)
-{
-	auto patterns = CGrepEnumKeys::SplitPattern(cmWorkExcludeFolder.GetStringPtr());
-	for (auto iter = patterns.begin(); iter != patterns.end(); ++iter)
-	{
-		const auto & pattern = (*iter);
-		LPCWSTR escapeStr  = GetEscapePattern(pattern);
-		cFilePattern.AppendStringF(L"#%s%s%s;", escapeStr, pattern.c_str(), escapeStr);
-	}
-}
-
-/*
-	@brief ファイルの除外パターンを詰める
-	@param[in,out] cFilePattern        "-GFILE=" に指定する引数用のバッファ (このバッファの末尾に追加する)
-	@param[in]     cmWorkExcludeFile Grep ダイアログで指定されたファイルの除外パターン
-*/
-static void AppendExcludeFilePatterns(CNativeW& cFilePattern, const CNativeW& cmWorkExcludeFile)
-{
-	auto patterns = CGrepEnumKeys::SplitPattern(cmWorkExcludeFile.GetStringPtr());
-	for (auto iter = patterns.begin(); iter != patterns.end(); ++iter)
-	{
-		const auto & pattern = (*iter);
-		LPCWSTR escapeStr  = GetEscapePattern(pattern);
-		cFilePattern.AppendStringF(L"!%s%s%s;", escapeStr, pattern.c_str(), escapeStr);
-	}
-}
-
 void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep& cDlgGrep)
 {
 	/*======= Grepの実行 =============*/
@@ -169,7 +108,7 @@ void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep&
 	CNativeW		cmWorkExcludeFile;
 	CNativeW		cmWorkExcludeFolder;
 	cmWork1.SetString( cDlgGrep.m_strText.c_str() );
-	cmWork2.SetString( cDlgGrep.m_szFile );
+	cmWork2.SetString( cDlgGrep.GetFile().GetStringPtr() );
 	cmWork3.SetString( cDlgGrep.m_szFolder );
 
 	cmWorkExcludeFile.SetString(cDlgGrep.m_szExcludeFile);
@@ -185,16 +124,10 @@ void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep&
 	CNativeW cCmdLine;
 	WCHAR szTemp[20];
 
-	// 除外ファイル、除外フォルダの設定を "-GFILE=" の設定に pack するためにデータを作る。
-	CNativeW cFilePattern;
-	AppendExcludeFolderPatterns(cFilePattern, cmWorkExcludeFolder);
-	AppendExcludeFilePatterns(cFilePattern, cmWorkExcludeFile);
-	cFilePattern.AppendString(cmWork2.GetStringPtr());
-
 	cCmdLine.AppendString(L"-GREPMODE -GKEY=\"");
 	cCmdLine.AppendString(cmWork1.GetStringPtr());
 	cCmdLine.AppendString(L"\" -GFILE=\"");
-	cCmdLine.AppendString(cFilePattern.GetStringPtr());
+	cCmdLine.AppendString(cmWork2.GetStringPtr());
 	cCmdLine.AppendString(L"\" -GFOLDER=\"");
 	cCmdLine.AppendString(cmWork3.GetStringPtr());
 	cCmdLine.AppendString(L"\" -GCODE=");

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -105,20 +105,14 @@ void CControlTray::DoGrepCreateWindow(HINSTANCE hinst, HWND msgParent, CDlgGrep&
 	CNativeW		cmWork1;
 	CNativeW		cmWork2;
 	CNativeW		cmWork3;
-	CNativeW		cmWorkExcludeFile;
-	CNativeW		cmWorkExcludeFolder;
+
 	cmWork1.SetString( cDlgGrep.m_strText.c_str() );
 	cmWork2 = cDlgGrep.GetPackedGFileString();
 	cmWork3.SetString( cDlgGrep.m_szFolder );
 
-	cmWorkExcludeFile.SetString(cDlgGrep.m_szExcludeFile);
-	cmWorkExcludeFolder.SetString(cDlgGrep.m_szExcludeFolder);
-
 	cmWork1.Replace( L"\"", L"\"\"" );
 	cmWork2.Replace( L"\"", L"\"\"" );
 	cmWork3.Replace( L"\"", L"\"\"" );
-	cmWorkExcludeFile.Replace(  L"\"", L"\"\"");
-	cmWorkExcludeFolder.Replace(L"\"", L"\"\"");
 
 	// -GREPMODE -GKEY="1" -GFILE="*.*;*.c;*.h" -GFOLDER="c:\" -GCODE=0 -GOPT=S
 	CNativeW cCmdLine;

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -210,8 +210,6 @@ bool CNormalProcess::InitializeProcess()
 				&gi.cmGrepRep,
 				&gi.cmGrepFile,
 				&gi.cmGrepFolder,
-				&gi.cmExcludeFile,
-				&gi.cmExcludeFolder,
 				gi.bGrepCurFolder,
 				gi.bGrepSubFolder,
 				gi.bGrepStdout,

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -62,7 +62,7 @@ void CViewCommander::Command_GREP( void )
 	CNativeW		cmWorkExcludeFile;
 	CNativeW		cmWorkExcludeFolder;
 	cmWork1.SetString( GetEditWindow()->m_cDlgGrep.m_strText.c_str() );
-	cmWork2.SetString( GetEditWindow()->m_cDlgGrep.m_szFile );
+	cmWork2.SetString( GetEditWindow()->m_cDlgGrep.GetFile().GetStringPtr() );
 	cmWork3.SetString( GetEditWindow()->m_cDlgGrep.m_szFolder );
 	cmWorkExcludeFile.SetString(GetEditWindow()->m_cDlgGrep.m_szExcludeFile);
 	cmWorkExcludeFolder.SetString(GetEditWindow()->m_cDlgGrep.m_szExcludeFolder);
@@ -173,7 +173,7 @@ void CViewCommander::Command_GREP_REPLACE( void )
 
 	CDlgGrepReplace& cDlgGrepRep = GetEditWindow()->m_cDlgGrepReplace;
 	cmWork1.SetString( cDlgGrepRep.m_strText.c_str() );
-	cmWork2.SetString( cDlgGrepRep.m_szFile );
+	cmWork2.SetString( cDlgGrepRep.GetFile().GetStringPtr() );
 	cmWork3.SetString( cDlgGrepRep.m_szFolder );
 	cmWork4.SetString( cDlgGrepRep.m_strText2.c_str() );
 	cmWorkExcludeFile.SetString(cDlgGrepRep.m_szExcludeFile);

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -62,7 +62,7 @@ void CViewCommander::Command_GREP( void )
 	CNativeW		cmWorkExcludeFile;
 	CNativeW		cmWorkExcludeFolder;
 	cmWork1.SetString( GetEditWindow()->m_cDlgGrep.m_strText.c_str() );
-	cmWork2.SetString( GetEditWindow()->m_cDlgGrep.GetFile().GetStringPtr() );
+	cmWork2 = GetEditWindow()->m_cDlgGrep.GetPackedGFileString();
 	cmWork3.SetString( GetEditWindow()->m_cDlgGrep.m_szFolder );
 	cmWorkExcludeFile.SetString(GetEditWindow()->m_cDlgGrep.m_szExcludeFile);
 	cmWorkExcludeFolder.SetString(GetEditWindow()->m_cDlgGrep.m_szExcludeFolder);
@@ -173,7 +173,7 @@ void CViewCommander::Command_GREP_REPLACE( void )
 
 	CDlgGrepReplace& cDlgGrepRep = GetEditWindow()->m_cDlgGrepReplace;
 	cmWork1.SetString( cDlgGrepRep.m_strText.c_str() );
-	cmWork2.SetString( cDlgGrepRep.GetFile().GetStringPtr() );
+	cmWork2 = cDlgGrepRep.GetPackedGFileString();
 	cmWork3.SetString( cDlgGrepRep.m_szFolder );
 	cmWork4.SetString( cDlgGrepRep.m_strText2.c_str() );
 	cmWorkExcludeFile.SetString(cDlgGrepRep.m_szExcludeFile);

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -59,13 +59,9 @@ void CViewCommander::Command_GREP( void )
 	CNativeW		cmWork2;
 	CNativeW		cmWork3;
 	CNativeW		cmWork4;
-	CNativeW		cmWorkExcludeFile;
-	CNativeW		cmWorkExcludeFolder;
 	cmWork1.SetString( GetEditWindow()->m_cDlgGrep.m_strText.c_str() );
 	cmWork2 = GetEditWindow()->m_cDlgGrep.GetPackedGFileString();
 	cmWork3.SetString( GetEditWindow()->m_cDlgGrep.m_szFolder );
-	cmWorkExcludeFile.SetString(GetEditWindow()->m_cDlgGrep.m_szExcludeFile);
-	cmWorkExcludeFolder.SetString(GetEditWindow()->m_cDlgGrep.m_szExcludeFolder);
 
 	/*	今のEditViewにGrep結果を表示する。
 		Grepモードのとき、または未編集で無題かつアウトプットでない場合。
@@ -97,8 +93,6 @@ void CViewCommander::Command_GREP( void )
 			&cmWork4,
 			&cmWork2,
 			&cmWork3,
-			&cmWorkExcludeFile,
-			&cmWorkExcludeFolder,
 			false,
 			GetEditWindow()->m_cDlgGrep.m_bSubFolder,
 			false,
@@ -168,16 +162,12 @@ void CViewCommander::Command_GREP_REPLACE( void )
 	CNativeW		cmWork2;
 	CNativeW		cmWork3;
 	CNativeW		cmWork4;
-	CNativeW		cmWorkExcludeFile;
-	CNativeW		cmWorkExcludeFolder;
 
 	CDlgGrepReplace& cDlgGrepRep = GetEditWindow()->m_cDlgGrepReplace;
 	cmWork1.SetString( cDlgGrepRep.m_strText.c_str() );
 	cmWork2 = cDlgGrepRep.GetPackedGFileString();
 	cmWork3.SetString( cDlgGrepRep.m_szFolder );
 	cmWork4.SetString( cDlgGrepRep.m_strText2.c_str() );
-	cmWorkExcludeFile.SetString(cDlgGrepRep.m_szExcludeFile);
-	cmWorkExcludeFolder.SetString(cDlgGrepRep.m_szExcludeFolder);
 
 	/*	今のEditViewにGrep結果を表示する。
 		Grepモードのとき、または未編集で無題かつアウトプットでない場合。
@@ -197,8 +187,6 @@ void CViewCommander::Command_GREP_REPLACE( void )
 			&cmWork4,
 			&cmWork2,
 			&cmWork3,
-			&cmWorkExcludeFile,
-			&cmWorkExcludeFolder,
 			false,
 			cDlgGrepRep.m_bSubFolder,
 			false, // Stdout

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -92,7 +92,7 @@ CDlgGrep::CDlgGrep()
 	@param[in]     pattern チェックするパターン
 	@return        true  エスケープする必要がある
 	@return        false エスケープする必要がない
-	@author m_tmatma
+	@author m-tmatma
 */
 static bool IsEscapeRequiredForExcludePattern(const std::wstring & pattern)
 {
@@ -111,7 +111,7 @@ static bool IsEscapeRequiredForExcludePattern(const std::wstring & pattern)
 /*
 	@brief エスケープパターンを取得する
 	@param[in] pattern        エスケープ対象文字列
-	@author m_tmatma
+	@author m-tmatma
 */
 static LPCWSTR GetEscapePattern(const std::wstring& pattern)
 {
@@ -122,7 +122,7 @@ static LPCWSTR GetEscapePattern(const std::wstring& pattern)
 	@brief フォルダの除外パターンを詰める
 	@param[in,out] cFilePattern        "-GFILE=" に指定する引数用のバッファ (このバッファの末尾に追加する)
 	@param[in]     cmWorkExcludeFolder Grep ダイアログで指定されたフォルダの除外パターン
-	@author m_tmatma
+	@author m-tmatma
 */
 static void AppendExcludeFolderPatterns(CNativeW& cFilePattern, const CNativeW& cmWorkExcludeFolder)
 {
@@ -139,7 +139,7 @@ static void AppendExcludeFolderPatterns(CNativeW& cFilePattern, const CNativeW& 
 	@brief ファイルの除外パターンを詰める
 	@param[in,out] cFilePattern        "-GFILE=" に指定する引数用のバッファ (このバッファの末尾に追加する)
 	@param[in]     cmWorkExcludeFile Grep ダイアログで指定されたファイルの除外パターン
-	@author m_tmatma
+	@author m-tmatma
 */
 static void AppendExcludeFilePatterns(CNativeW& cFilePattern, const CNativeW& cmWorkExcludeFile)
 {

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -152,25 +152,29 @@ static void AppendExcludeFilePatterns(CNativeW& cFilePattern, const CNativeW& cm
 	}
 }
 
+/*!
+ * 除外ファイル、除外フォルダの設定を "-GFILE=" の設定に pack する
+ */
 CNativeW CDlgGrep::GetFile() const
 {
-	CNativeW cmWork2( m_szFile );
-	CNativeW cmWorkExcludeFile( m_szExcludeFile );
-	CNativeW cmWorkExcludeFolder( m_szExcludeFolder );
+	// ダイアログデータを取得
+	CNativeW cmFilePattern( m_szFile );
+	CNativeW cmExcludeFiles( m_szExcludeFile );
+	CNativeW cmExcludeFolders( m_szExcludeFolder );
 
-	cmWork2.Replace( L"\"", L"\"\"" );
-	cmWorkExcludeFile.Replace( L"\"", L"\"\"" );
-	cmWorkExcludeFolder.Replace( L"\"", L"\"\"" );
+	// コマンドライン用に二重引用符をエスケープする
+	cmFilePattern.Replace( L"\"", L"\"\"" );
+	cmExcludeFiles.Replace( L"\"", L"\"\"" );
+	cmExcludeFolders.Replace( L"\"", L"\"\"" );
 
 	// 除外ファイル、除外フォルダの設定を "-GFILE=" の設定に pack するためにデータを作る。
-	CNativeW cFilePattern;
-	AppendExcludeFolderPatterns( cFilePattern, cmWorkExcludeFolder );
-	AppendExcludeFilePatterns( cFilePattern, cmWorkExcludeFile );
-	cFilePattern.AppendString( cmWork2.GetStringPtr() );
+	AppendExcludeFolderPatterns( cmFilePattern, cmExcludeFolders );
+	AppendExcludeFilePatterns( cmFilePattern, cmExcludeFiles );
 
-	cFilePattern.Replace( L"\"\"", L"\"" );
+	// コマンドライン用のエスケープを元に戻す
+	cmFilePattern.Replace( L"\"\"", L"\"" );
 
-	return cFilePattern;
+	return cmFilePattern;
 }
 
 /*!

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -87,6 +87,92 @@ CDlgGrep::CDlgGrep()
 	return;
 }
 
+/*
+	@brief ファイル/フォルダの除外パターンをエスケープする必要があるか判断する
+	@param[in]     pattern チェックするパターン
+	@return        true  エスケープする必要がある
+	@return        false エスケープする必要がない
+	@author m_tmatma
+*/
+static bool IsEscapeRequiredForExcludePattern(const std::wstring & pattern)
+{
+	const auto NotFound = std::string::npos;
+	if (pattern.find(L'!') != NotFound)
+	{
+		return true;
+	}
+	if (pattern.find(L'#') != NotFound)
+	{
+		return true;
+	}
+	return false;
+}
+
+/*
+	@brief エスケープパターンを取得する
+	@param[in] pattern        エスケープ対象文字列
+	@author m_tmatma
+*/
+static LPCWSTR GetEscapePattern(const std::wstring& pattern)
+{
+	return IsEscapeRequiredForExcludePattern(pattern) ? L"\"\"" : L"";
+}
+
+/*
+	@brief フォルダの除外パターンを詰める
+	@param[in,out] cFilePattern        "-GFILE=" に指定する引数用のバッファ (このバッファの末尾に追加する)
+	@param[in]     cmWorkExcludeFolder Grep ダイアログで指定されたフォルダの除外パターン
+	@author m_tmatma
+*/
+static void AppendExcludeFolderPatterns(CNativeW& cFilePattern, const CNativeW& cmWorkExcludeFolder)
+{
+	auto patterns = CGrepEnumKeys::SplitPattern(cmWorkExcludeFolder.GetStringPtr());
+	for (auto iter = patterns.begin(); iter != patterns.end(); ++iter)
+	{
+		const auto & pattern = (*iter);
+		LPCWSTR escapeStr  = GetEscapePattern(pattern);
+		cFilePattern.AppendStringF(L"#%s%s%s;", escapeStr, pattern.c_str(), escapeStr);
+	}
+}
+
+/*
+	@brief ファイルの除外パターンを詰める
+	@param[in,out] cFilePattern        "-GFILE=" に指定する引数用のバッファ (このバッファの末尾に追加する)
+	@param[in]     cmWorkExcludeFile Grep ダイアログで指定されたファイルの除外パターン
+	@author m_tmatma
+*/
+static void AppendExcludeFilePatterns(CNativeW& cFilePattern, const CNativeW& cmWorkExcludeFile)
+{
+	auto patterns = CGrepEnumKeys::SplitPattern(cmWorkExcludeFile.GetStringPtr());
+	for (auto iter = patterns.begin(); iter != patterns.end(); ++iter)
+	{
+		const auto & pattern = (*iter);
+		LPCWSTR escapeStr  = GetEscapePattern(pattern);
+		cFilePattern.AppendStringF(L"!%s%s%s;", escapeStr, pattern.c_str(), escapeStr);
+	}
+}
+
+CNativeW CDlgGrep::GetFile() const
+{
+	CNativeW cmWork2( m_szFile );
+	CNativeW cmWorkExcludeFile( m_szExcludeFile );
+	CNativeW cmWorkExcludeFolder( m_szExcludeFolder );
+
+	cmWork2.Replace( L"\"", L"\"\"" );
+	cmWorkExcludeFile.Replace( L"\"", L"\"\"" );
+	cmWorkExcludeFolder.Replace( L"\"", L"\"\"" );
+
+	// 除外ファイル、除外フォルダの設定を "-GFILE=" の設定に pack するためにデータを作る。
+	CNativeW cFilePattern;
+	AppendExcludeFolderPatterns( cFilePattern, cmWorkExcludeFolder );
+	AppendExcludeFilePatterns( cFilePattern, cmWorkExcludeFile );
+	cFilePattern.AppendString( cmWork2.GetStringPtr() );
+
+	cFilePattern.Replace( L"\"\"", L"\"" );
+
+	return cFilePattern;
+}
+
 /*!
 	コンボボックスのドロップダウンメッセージを捕捉する
 

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -155,7 +155,7 @@ static void AppendExcludeFilePatterns(CNativeW& cFilePattern, const CNativeW& cm
 /*!
  * 除外ファイル、除外フォルダの設定を "-GFILE=" の設定に pack する
  */
-CNativeW CDlgGrep::GetFile() const
+CNativeW CDlgGrep::GetPackedGFileString() const
 {
 	// ダイアログデータを取得
 	CNativeW cmFilePattern( m_szFile );
@@ -168,13 +168,15 @@ CNativeW CDlgGrep::GetFile() const
 	cmExcludeFolders.Replace( L"\"", L"\"\"" );
 
 	// 除外ファイル、除外フォルダの設定を "-GFILE=" の設定に pack するためにデータを作る。
-	AppendExcludeFolderPatterns( cmFilePattern, cmExcludeFolders );
-	AppendExcludeFilePatterns( cmFilePattern, cmExcludeFiles );
+	CNativeW cmGFileString;
+	AppendExcludeFolderPatterns( cmGFileString, cmExcludeFolders );
+	AppendExcludeFilePatterns( cmGFileString, cmExcludeFiles );
+	cmGFileString += cmFilePattern;
 
 	// コマンドライン用のエスケープを元に戻す
-	cmFilePattern.Replace( L"\"\"", L"\"" );
+	cmGFileString.Replace( L"\"\"", L"\"" );
 
-	return cmFilePattern;
+	return cmGFileString;
 }
 
 /*!

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -34,6 +34,7 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
+	CNativeW GetFile() const;
 	BOOL OnCbnDropDown( HWND hwndCtl, int wID ) override;
 	int DoModal( HINSTANCE, HWND, const WCHAR* );	/* モーダルダイアログの表示 */
 //	HWND DoModeless( HINSTANCE, HWND, const char* );	/* モードレスダイアログの表示 */

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -34,7 +34,7 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	CNativeW GetFile() const;
+	CNativeW GetPackedGFileString() const;	//!< 除外ファイル、除外フォルダの設定を "-GFILE=" の設定に pack する
 	BOOL OnCbnDropDown( HWND hwndCtl, int wID ) override;
 	int DoModal( HINSTANCE, HWND, const WCHAR* );	/* モーダルダイアログの表示 */
 //	HWND DoModeless( HINSTANCE, HWND, const char* );	/* モードレスダイアログの表示 */

--- a/tests/unittests/test-grepinfo.cpp
+++ b/tests/unittests/test-grepinfo.cpp
@@ -46,8 +46,6 @@ bool operator == (const GrepInfo& lhs, const GrepInfo& rhs) noexcept {
 		&& lhs.cmGrepRep == rhs.cmGrepRep
 		&& lhs.cmGrepFile == rhs.cmGrepFile
 		&& lhs.cmGrepFolder == rhs.cmGrepFolder
-		&& lhs.cmExcludeFile == rhs.cmExcludeFile
-		&& lhs.cmExcludeFolder == rhs.cmExcludeFolder
 		&& lhs.sGrepSearchOption == rhs.sGrepSearchOption
 		&& lhs.bGrepCurFolder == rhs.bGrepCurFolder
 		&& lhs.bGrepStdout == rhs.bGrepStdout
@@ -121,14 +119,6 @@ TEST(GrepInfo, operatorNotEqual)
 	value.cmGrepFolder = L"C:\\work\\sakura";
 	ASSERT_NE(value, other);
 	value.cmGrepFolder = other.cmGrepFolder;
-
-	value.cmExcludeFile = L"除外ファイルの仕様がなんでここに残ってんだっけ？";
-	ASSERT_NE(value, other);
-	value.cmExcludeFile = other.cmExcludeFile;
-
-	value.cmExcludeFolder = L"除外フォルダの仕様がなんで(ry";
-	ASSERT_NE(value, other);
-	value.cmExcludeFolder = other.cmExcludeFolder;
 
 	value.sGrepSearchOption.bRegularExp = true;
 	ASSERT_NE(value, other);


### PR DESCRIPTION
# PR の目的
除外ファイル・除外フォルダの指定をGrep置換でも使えるようにする

## カテゴリ
- 機能追加

## PR の背景

https://github.com/sakura-editor/management-forum/issues/75#issuecomment-586957625
> rep 置換の除外指定の件は、修正する必要があると思います

　↓

https://github.com/sakura-editor/management-forum/issues/78#issuecomment-590218149
> ＞Grep の除外指定の件は、制約事項にリストされてたと思うのでスルーで良いと思っています。
> 
> 了解。 @m-tmatma さんがよければ、このままリリースへ、やっぱり直したいと言われれば、Beta5行こうと思います。
> 
> タグジャンプの件もありますし、来月どうするか考えますかね。

　↓

反応なし。

~~まじめに対処を入れるとレビューが難しくなるので、対症療法で最低限の変更を入れる方法をとってみることにしました。~~【3/12削除】

～～【3/12追加ここから】～～
レビュー対応の結果、まじめに対処を入れた場合とほぼ同等の修正内容となりました。
レビューは難しいと思いますが、できれば対応を入れたいと考えています。
～～【3/12追加ここまで】～～

当座のポイントは、
Grep置換をコマンドライン経由で実行する場合に `-GFILE` に除外情報が渡らない、
に対処することです。

## PR のメリット
- わかりやすくするため「実装漏れに対処しました」の形式にしています。  
難しいことは一切してないので、誰でもレビューできると思われます。
- 【3/12追加】Grep/Grep置換の実行の検索条件の表示内容が改善されます。

## PR のデメリット (トレードオフとかあれば)
- Grep/Grep置換の起動周りには、もともと莫大な課題事項が存在していますが、このPRでは課題事項に一切対処しません。
- ~~Grep結果リストに 除外フォルダ・除外ファイルを正しく表示できていない件(#1134) については対処を入れていません。~~ 【3/12削除】
- 実装漏れを引き起こした原因に対処を入れていません。

## PR の影響範囲
- Grep置換の実行で置換結果が別ウインドウに表示される場合にも除外フォルダ・除外ファイルが適用されるようになります。
- 【3/12追加】Grep/Grep置換の実行で、ファイル検索条件が「ファイル(対象ファイル名のパターン)」、「除外ファイル」、「除外フォルダ」に分かれて表示されるようになります。この分類は旧仕様で「ファイル」欄に入力した場合と新仕様の追加UIから入力した場合のどちらにも適用されます。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

#743 

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
