### PR TITLE
設定画面の数値入力用のエディット コントロールにフォーカス時にIMEを使わないように設定

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -446,6 +446,7 @@ BOOL CDialog::OnCommand( WPARAM wParam, LPARAM lParam )
 		}else if( ::lstrcmpi(szClass, L"Edit") == 0 ){
 			switch( wNotifyCode ){
 			case EN_CHANGE:		return OnEnChange( hwndCtl, wID );
+			case EN_SETFOCUS:	return OnEnSetFocus( hwndCtl, wID );
 			case EN_KILLFOCUS:	return OnEnKillFocus( hwndCtl, wID );
 			}
 		}else if( ::lstrcmpi(szClass, L"ListBox") == 0 ){

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -102,6 +102,7 @@ public:
 	virtual BOOL OnBnClicked(int wID);
 	virtual BOOL OnStnClicked( int ){return FALSE;}
 	virtual BOOL OnEnChange( HWND hwndCtl, int wID ){return FALSE;}
+	virtual BOOL OnEnSetFocus( HWND hwndCtl, int wID ){return FALSE;}
 	virtual BOOL OnEnKillFocus( HWND hwndCtl, int wID ){return FALSE;}
 	virtual BOOL OnLbnSelChange( HWND hwndCtl, int wID ){return FALSE;}
 	virtual BOOL OnLbnDblclk( int wID ){return FALSE;}

--- a/sakura_core/dlg/CDlgJump.cpp
+++ b/sakura_core/dlg/CDlgJump.cpp
@@ -22,6 +22,7 @@
 #include "outline/CFuncInfo.h"
 #include "outline/CFuncInfoArr.h"// 2002/2/10 aroka ヘッダ整理
 #include "util/shell.h"
+#include "util/os.h"
 #include "window/CEditWnd.h"
 #include "sakura_rc.h"
 #include "sakura.hh"
@@ -182,6 +183,35 @@ BOOL CDlgJump::OnBnClicked( int wID )
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnBnClicked( wID );
+}
+
+// IMEのオープン状態復帰用
+static BOOL s_isImmOpenBkup;
+
+// IMEを使用したくないコントロールのID判定
+static bool isImeUndesirable(int id)
+{
+	switch (id) {
+	case IDC_EDIT_LINENUM:
+	case IDC_EDIT_PLSQL_E1:
+		return true;
+	default:
+		return false;
+	}
+}
+
+BOOL CDlgJump::OnEnSetFocus(HWND hwndCtl, int wID)
+{
+	if (isImeUndesirable(wID))
+		ImeSetOpen(hwndCtl, FALSE, &s_isImmOpenBkup);
+	return 0;
+}
+
+BOOL CDlgJump::OnEnKillFocus(HWND hwndCtl, int wID)
+{
+	if (isImeUndesirable(wID))
+		ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
+	return 0;
 }
 
 /* ダイアログデータの設定 */

--- a/sakura_core/dlg/CDlgJump.h
+++ b/sakura_core/dlg/CDlgJump.h
@@ -42,6 +42,9 @@ protected:
 	BOOL OnNotify(WPARAM wParam, LPARAM lParam) override;	//	Oct. 6, 2000 JEPRO added for Spin control
 	BOOL OnCbnSelChange(HWND hwndCtl, int wID) override;
 	BOOL OnBnClicked(int wID) override;
+	BOOL OnEnSetFocus(HWND hwndCtl, int wID) override;
+	BOOL OnEnKillFocus(HWND hwndCtl, int wID) override;
+
 	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 	void SetData( void ) override;	/* ダイアログデータの設定 */
 	int GetData( void ) override;	/* ダイアログデータの取得 */

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -39,6 +39,7 @@
 #include "func/Funccode.h"		// Stonee, 2001/03/12
 #include "util/shell.h"
 #include "util/window.h"
+#include "util/os.h"
 #include "sakura_rc.h"	// 2002/2/10 aroka
 #include "sakura.hh"
 
@@ -406,6 +407,34 @@ BOOL CDlgPrintSetting::OnEnChange( HWND hwndCtl, int wID )
 	return CDialog::OnEnChange( hwndCtl, wID );
 }
 
+// IMEのオープン状態復帰用
+static BOOL s_isImmOpenBkup;
+
+// IMEを使用したくないコントロールのID判定
+static bool isImeUndesirable(int id)
+{
+	switch (id) {
+	case IDC_EDIT_FONTHEIGHT:
+	case IDC_EDIT_LINESPACE:
+	case IDC_EDIT_DANSUU:
+	case IDC_EDIT_DANSPACE:
+	case IDC_EDIT_MARGINTY:
+	case IDC_EDIT_MARGINBY:
+	case IDC_EDIT_MARGINLX:
+	case IDC_EDIT_MARGINRX:
+		return true;
+	default:
+		return false;
+	}
+}
+
+BOOL CDlgPrintSetting::OnEnSetFocus(HWND hwndCtl, int wID)
+{
+	if (isImeUndesirable(wID))
+		ImeSetOpen(hwndCtl, FALSE, &s_isImmOpenBkup);
+	return 0;
+}
+
 BOOL CDlgPrintSetting::OnEnKillFocus( HWND hwndCtl, int wID )
 {
 	switch( wID ){
@@ -426,6 +455,10 @@ BOOL CDlgPrintSetting::OnEnKillFocus( HWND hwndCtl, int wID )
 		UpdatePrintableLineAndColumn();
 		break;	// ここでは行と桁の更新要求のみ。後の処理はCDialogに任せる。
 	}
+
+	if (isImeUndesirable(wID))
+		ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
+
 	/* 基底クラスメンバ */
 	return CDialog::OnEnKillFocus( hwndCtl, wID );
 }

--- a/sakura_core/dlg/CDlgPrintSetting.h
+++ b/sakura_core/dlg/CDlgPrintSetting.h
@@ -71,6 +71,7 @@ protected:
 	BOOL OnBnClicked(int wID) override;
 	BOOL OnStnClicked(int wID) override;
 	BOOL OnEnChange( HWND hwndCtl, int wID ) override;
+	BOOL OnEnSetFocus(HWND hwndCtl, int wID) override;
 	BOOL OnEnKillFocus( HWND hwndCtl, int wID ) override;
 	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
 

--- a/sakura_core/dlg/CDlgWinSize.cpp
+++ b/sakura_core/dlg/CDlgWinSize.cpp
@@ -32,6 +32,7 @@
 #include "StdAfx.h"
 #include "dlg/CDlgWinSize.h"
 #include "util/shell.h"
+#include "util/os.h"
 #include "sakura_rc.h"
 #include "sakura.hh"
 
@@ -123,6 +124,37 @@ BOOL CDlgWinSize::OnBnClicked( int wID )
 		GetData();
 	}
 	return CDialog::OnBnClicked( wID );
+}
+
+// IMEのオープン状態復帰用
+static BOOL s_isImmOpenBkup;
+
+// IMEを使用したくないコントロールのID判定
+static bool isImeUndesirable(int id)
+{
+	switch (id) {
+	case IDC_EDIT_WX:
+	case IDC_EDIT_WY:
+	case IDC_EDIT_SX:
+	case IDC_EDIT_SY:
+		return true;
+	default:
+		return false;
+	}
+}
+
+BOOL CDlgWinSize::OnEnSetFocus(HWND hwndCtl, int wID)
+{
+	if (isImeUndesirable(wID))
+		ImeSetOpen(hwndCtl, FALSE, &s_isImmOpenBkup);
+	return 0;
+}
+
+BOOL CDlgWinSize::OnEnKillFocus(HWND hwndCtl, int wID)
+{
+	if (isImeUndesirable(wID))
+		ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
+	return 0;
 }
 
 /*! @brief ダイアログボックスにデータを設定

--- a/sakura_core/dlg/CDlgWinSize.h
+++ b/sakura_core/dlg/CDlgWinSize.h
@@ -50,6 +50,8 @@ protected:
 
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnBnClicked(int wID) override;
+	BOOL OnEnSetFocus(HWND hwndCtl, int wID) override;
+	BOOL OnEnKillFocus(HWND hwndCtl, int wID) override;
 	int  GetData( void ) override;
 	void SetData( void ) override;
 	LPVOID GetHelpIdTable( void ) override;

--- a/sakura_core/prop/CPropComWin.cpp
+++ b/sakura_core/prop/CPropComWin.cpp
@@ -21,6 +21,7 @@
 #include "prop/CPropCommon.h"
 #include "dlg/CDlgWinSize.h"	//	2004.05.13 Moca
 #include "util/shell.h"
+#include "util/os.h"
 #include "sakura_rc.h"
 #include "sakura.hh"
 #include "_main/CProcess.h"
@@ -68,6 +69,23 @@ INT_PTR CALLBACK CPropWin::DlgProc_page(
 }
 //	To Here Jun. 2, 2001 genta
 
+// IMEのオープン状態復帰用
+static BOOL s_isImmOpenBkup;
+
+// IMEを使用したくないコントロールのID判定
+static bool isImeUndesirable(int id)
+{
+	switch (id) {
+	case IDC_EDIT_nRulerHeight:
+	case IDC_EDIT_nRulerBottomSpace:
+	case IDC_EDIT_nLineNumberRightSpace:
+	case IDC_EDIT_FUNCKEYWND_GROUPNUM:
+		return true;
+	default:
+		return false;
+	}
+}
+
 /* メッセージ処理 */
 INT_PTR CPropWin::DispatchEvent(
 	HWND	hwndDlg,	// handle to dialog box
@@ -79,6 +97,7 @@ INT_PTR CPropWin::DispatchEvent(
 // From Here Sept. 9, 2000 JEPRO
 	WORD		wNotifyCode;
 	WORD		wID;
+	HWND		hwndCtl;
 // To Here Sept. 9, 2000
 
 	NMHDR*		pNMHDR;
@@ -197,6 +216,7 @@ INT_PTR CPropWin::DispatchEvent(
 	case WM_COMMAND:
 		wNotifyCode	= HIWORD(wParam);	/* 通知コード */
 		wID			= LOWORD(wParam);	/* 項目ID､ コントロールID､ またはアクセラレータID */
+		hwndCtl		= (HWND) lParam;	/* コントロールのハンドル */
 		switch( wNotifyCode ){
 		/* ボタン／チェックボックスがクリックされた */
 		case BN_CLICKED:
@@ -232,6 +252,14 @@ INT_PTR CPropWin::DispatchEvent(
 				break;
 			// To Here 2004.05.13 Moca
 			}
+			break;
+		case EN_SETFOCUS:
+			if (isImeUndesirable(wID))
+				ImeSetOpen(hwndCtl, FALSE, &s_isImmOpenBkup);
+			break;
+		case EN_KILLFOCUS:
+			if (isImeUndesirable(wID))
+				ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
 			break;
 		}
 		break;

--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -30,6 +30,7 @@
 #include "uiparts/CGraphics.h"
 #include "util/shell.h"
 #include "util/window.h"
+#include "util/os.h"
 #include "sakura_rc.h"
 #include "sakura.hh"
 #include "prop/CPropCommon.h"
@@ -264,6 +265,22 @@ LRESULT APIENTRY ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 	return CallWindowProc( m_wpColorListProc, hwnd, uMsg, wParam, lParam );
 }
 
+// IMEのオープン状態復帰用
+static BOOL s_isImmOpenBkup;
+
+// IMEを使用したくないコントロールのID判定
+static bool isImeUndesirable(int id)
+{
+	switch (id) {
+	case IDC_EDIT_LINECOMMENTPOS:
+	case IDC_EDIT_LINECOMMENTPOS2:
+	case IDC_EDIT_LINECOMMENTPOS3:
+		return true;
+	default:
+		return false;
+	}
+}
+
 /* color メッセージ処理 */
 INT_PTR CPropTypesColor::DispatchEvent(
 	HWND				hwndDlg,	// handle to dialog box
@@ -469,6 +486,14 @@ INT_PTR CPropTypesColor::DispatchEvent(
 				}
 			}
 			break;	/* BN_CLICKED */
+		case EN_SETFOCUS:
+			if (isImeUndesirable(wID))
+				ImeSetOpen(hwndCtl, FALSE, &s_isImmOpenBkup);
+			break;
+		case EN_KILLFOCUS:
+			if (isImeUndesirable(wID))
+				ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
+			break;
 		}
 		break;	/* WM_COMMAND */
 	case WM_NOTIFY:

--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -449,3 +449,24 @@ BOOL IsPowerShellAvailable(void)
 		return FALSE;
 	}
 }
+
+/*!
+	@brief IMEのオープン状態を設定する
+	@param hWnd 設定対象のウィンドウハンドル
+	@param bOpen 設定するオープン状態
+	@param pBackup `nullptr` でなければ設定前のオープン状態を取得
+	@return	手続きが成功したら true 失敗したら false
+*/
+BOOL ImeSetOpen(HWND hWnd, BOOL bOpen, BOOL* pBackup)
+{
+	HIMC hIMC = ImmGetContext(hWnd);
+	if (!hIMC) {
+		return FALSE;
+	}
+	if (pBackup) {
+		*pBackup = ImmGetOpenStatus(hIMC);
+	}
+	BOOL bRet = ImmSetOpenStatus(hIMC, bOpen);
+	bRet &= ImmReleaseContext(hWnd, hIMC);
+	return bRet;
+}

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -99,3 +99,12 @@ private:
 	@brief PowerShell が利用可能か判定する
 */
 BOOL IsPowerShellAvailable(void);
+
+/*!
+	@brief IMEのオープン状態を設定する
+	@param hWnd 設定対象のウィンドウハンドル
+	@param bOpen 設定するオープン状態
+	@param pBackup `nullptr` でなければ設定前のオープン状態を取得
+	@return	手続きが成功したら true 失敗したら false
+*/
+BOOL ImeSetOpen(HWND hWnd, BOOL bOpen, BOOL* pBackup);


### PR DESCRIPTION
# PR の目的

キーボード入力での設定を行いやすくするのが目的です。

## 従来の動作
サクラエディタのエディタ画面でIMEを有効にした状態から、設定画面を開いて数値の入力項目にフォーカスを合わせた後にキーボード入力を行うと、IMEで入力する動作になります。

この状態だとエンターキーを押したりしないと入力が確定されないので入力がしにくいと思います。数値入力ならばIMEを使う必要はないと考えています。

## このPRの動作

このPRでは設定画面の数値入力用のエディット コントロールにフォーカスが合った際にIMEの入力をオープンではない状態(OFF)にする事で設定がしやすいようにしました。

フォーカス消失時はIMEのオープン状態を元に戻す処理を入れる事で、ほかの場所に影響が出ないようにしています。

## カテゴリ

- 仕様変更

## PR のメリット

キーボード入力での設定が少し行いやすくなります。

## PR のデメリット (トレードオフとかあれば)

ユーザーによってはIMEが自動的にオフになる事で使いにくくなったと思うかもしれません。
日常的にIMEの入力を変換する事で特定の数字を入れるようにするなどの変則的な使い方をしていた場合等です。ただおそらくそういうユーザーはいないだろうと考えています…。というかそんな使い方は良くない…。

## 参考資料

https://docs.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immgetcontext
https://docs.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immreleasecontext

https://docs.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immgetopenstatus
https://docs.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immsetopenstatus

https://docs.microsoft.com/en-us/windows/win32/menurc/wm-command

https://docs.microsoft.com/en-us/windows/win32/controls/en-setfocus
https://docs.microsoft.com/en-us/windows/win32/controls/en-killfocus

<details>
<summary>関連項目のリソースID一覧</summary>

```
IDD_JUMP
	IDC_EDIT_LINENUM
	IDC_EDIT_PLSQL_E1

IDD_PRINTSETTING
	IDC_EDIT_FONTHEIGHT
	IDC_EDIT_LINESPACE
	IDC_EDIT_DANSUU
	IDC_EDIT_DANSPACE
	IDC_EDIT_MARGINTY
	IDC_EDIT_MARGINBY
	IDC_EDIT_MARGINLX
	IDC_EDIT_MARGINRX
	
IDD_PROP_COLOR
	IDC_EDIT_LINECOMMENTPOS
	IDC_EDIT_LINECOMMENTPOS2
	IDC_EDIT_LINECOMMENTPOS3
	
IDD_PROP_FILE
	IDC_EDIT_AUTOLOAD_DELAY
	IDC_EDIT_nDropFileNumMax
	IDC_EDIT_ALERT_FILESIZE
	IDC_EDIT_AUTOBACKUP_INTERVAL
	
IDD_PROP_FNAME
	IDC_EDIT_SHORTMAXWIDTH
	
IDD_PROP_GENERAL
	IDC_EDIT_REPEATEDSCROLLLINENUM
	IDD_PROP_GENERAL
	IDC_EDIT_MAX_MRU_FILE
	IDC_EDIT_MAX_MRU_FOLDER
	
IDD_PROP_MACRO
	IDC_MACROCANCELTIMER

IDD_PROP_SCREEN
	IDC_EDIT_MAXLINELEN
	IDC_EDIT_CHARSPACE
	IDC_EDIT_LINESPACE
	IDC_EDIT_TABSPACE
	
IDD_PROP_WIN
	IDC_EDIT_nRulerHeight
	IDC_EDIT_nRulerBottomSpace
	IDC_EDIT_nLineNumberRightSpace
	IDC_EDIT_FUNCKEYWND_GROUPNUM
	
IDD_PROP_WINDOW
	IDC_EDIT_LINENUMWIDTH
	IDC_EDIT_BACKIMG_OFFSET_X
	IDC_EDIT_BACKIMG_OFFSET_Y
	IDC_EDIT_BACKIMG_TRANSPARENCY
	
IDD_WINPOSSIZE
	IDC_EDIT_WX
	IDC_EDIT_WY
	IDC_EDIT_SX
	IDC_EDIT_SY
	
```

</details>
