### PR TITLE
assert を独立した 1 行で記載する

### DIFF
--- a/sakura_core/CAutoReloadAgent.h
+++ b/sakura_core/CAutoReloadAgent.h
@@ -43,7 +43,11 @@ public:
 
 	//監視の一時停止
 	void PauseWatching(){ m_nPauseCount++; }
-	void ResumeWatching(){ m_nPauseCount--; assert(m_nPauseCount>=0); }
+	void ResumeWatching()
+	{
+		m_nPauseCount--;
+		assert(m_nPauseCount>=0);
+	}
 	bool IsPausing() const{ return m_nPauseCount>=1; }
 
 public://#####仮

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -45,7 +45,11 @@ public:
 
 	//########補助
 	bool			IsValid()		const{ return m_pData!=NULL; }
-	wchar_t			At(int nIndex)	const{ assert(nIndex>=0 && nIndex<m_nDataLen); return m_pData[nIndex]; }
+	wchar_t			At(int nIndex)	const
+	{
+		assert(nIndex>=0 && nIndex<m_nDataLen);
+		return m_pData[nIndex];
+	}
 private:
 	const wchar_t*	m_pData;
 	int				m_nDataLen;

--- a/sakura_core/types/CType.h
+++ b/sakura_core/types/CType.h
@@ -290,7 +290,11 @@ public:
 		m_nType = n;
 	}
 	bool IsValidType() const{ return m_nType>=0 && m_nType<MAX_TYPES; }
-	int GetIndex() const{ /*assert(IsValid());*/ return m_nType; }
+	int GetIndex() const
+	{
+		/*assert(IsValid());*/
+		return m_nType;
+	}
 
 	//共有データへの簡易アクセサ
 //	STypeConfig* operator->(){ return GetTypeConfig(); }

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -41,7 +41,7 @@ public:
 
 	//要素アクセス
 	ElementType&       operator[](int nIndex)
-    {
+	{
 		assert(nIndex<MAX_SIZE);
 		assert_warning(nIndex<m_nCount);
 		return m_aElements[nIndex];

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -40,8 +40,18 @@ public:
 	int max_size() const{ return MAX_SIZE; }
 
 	//要素アクセス
-	ElementType&       operator[](int nIndex)      { assert(nIndex<MAX_SIZE); assert_warning(nIndex<m_nCount); return m_aElements[nIndex]; }
-	const ElementType& operator[](int nIndex) const{ assert(nIndex<MAX_SIZE); assert_warning(nIndex<m_nCount); return m_aElements[nIndex]; }
+	ElementType&       operator[](int nIndex)
+    {
+		assert(nIndex<MAX_SIZE);
+		assert_warning(nIndex<m_nCount);
+		return m_aElements[nIndex];
+	}
+	const ElementType& operator[](int nIndex) const
+	{
+		assert(nIndex<MAX_SIZE);
+		assert_warning(nIndex<m_nCount);
+		return m_aElements[nIndex];
+	}
 
 	//操作
 	void clear(){ m_nCount=0; }

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -72,8 +72,16 @@ public:
 
 protected:
 	//※2個以上のインスタンスは想定していません。assertが破綻を検出します。
-	TSingleInstance(){ assert(gm_instance==NULL); gm_instance=static_cast<T*>(this); }
-	~TSingleInstance(){ assert(gm_instance); gm_instance=NULL; }
+	TSingleInstance()
+	{
+		assert(gm_instance==NULL);
+		gm_instance=static_cast<T*>(this);
+	}
+	~TSingleInstance()
+	{
+		assert(gm_instance);
+		gm_instance=NULL;
+	}
 private:
 	static T* gm_instance;
 };

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -567,12 +567,36 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	//主要構成部品アクセス
-	CTextArea& GetTextArea(){ assert(m_pcTextArea); return *m_pcTextArea; }
-	const CTextArea& GetTextArea() const{ assert(m_pcTextArea); return *m_pcTextArea; }
-	CCaret& GetCaret(){ assert(m_pcCaret); return *m_pcCaret; }
-	const CCaret& GetCaret() const{ assert(m_pcCaret); return *m_pcCaret; }
-	CRuler& GetRuler(){ assert(m_pcRuler); return *m_pcRuler; }
-	const CRuler& GetRuler() const{ assert(m_pcRuler); return *m_pcRuler; }
+	CTextArea& GetTextArea()
+	{
+		assert(m_pcTextArea);
+		return *m_pcTextArea;
+	}
+	const CTextArea& GetTextArea() const
+	{
+		assert(m_pcTextArea);
+		return *m_pcTextArea;
+	}
+	CCaret& GetCaret()
+	{
+		assert(m_pcCaret);
+		return *m_pcCaret;
+	}
+	const CCaret& GetCaret() const
+	{
+		assert(m_pcCaret);
+		return *m_pcCaret;
+	}
+	CRuler& GetRuler()
+	{
+		assert(m_pcRuler);
+		return *m_pcRuler;
+	}
+	const CRuler& GetRuler() const
+	{
+		assert(m_pcRuler);
+		return *m_pcRuler;
+	}
 
 	//主要属性アクセス
 	CTextMetrics& GetTextMetrics(){ return m_cTextMetrics; }
@@ -581,8 +605,16 @@ public:
 	const CViewSelect& GetSelectionInfo() const{ return m_cViewSelect; }
 
 	//主要オブジェクトアクセス
-	CViewFont& GetFontset(){ assert(m_pcViewFont); return *m_pcViewFont; }
-	const CViewFont& GetFontset() const{ assert(m_pcViewFont); return *m_pcViewFont; }
+	CViewFont& GetFontset()
+	{
+		assert(m_pcViewFont);
+		return *m_pcViewFont;
+	}
+	const CViewFont& GetFontset() const
+	{
+		assert(m_pcViewFont);
+		return *m_pcViewFont;
+	}
 
 	//主要ヘルパアクセス
 	const CViewParser& GetParser() const{ return m_cParser; }

--- a/sakura_core/view/figures/CFigure_CtrlCode.h
+++ b/sakura_core/view/figures/CFigure_CtrlCode.h
@@ -36,7 +36,10 @@ public:
 	bool DrawImp(SColorStrategyInfo* pInfo);
 	virtual void DispSpaceEx(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans, int width) const;
 	virtual wchar_t GetAlternateChar() const{ return L'･'; }
-	void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const{assert(0);};
+	void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const
+	{
+		assert(0);
+	};
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_CTRLCODE; }
 };
 

--- a/sakura_core/view/figures/CFigure_CtrlCode.h
+++ b/sakura_core/view/figures/CFigure_CtrlCode.h
@@ -39,7 +39,7 @@ public:
 	void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const
 	{
 		assert(0);
-	};
+	}
 	EColorIndexType GetColorIdx(void) const{ return COLORIDX_CTRLCODE; }
 };
 


### PR DESCRIPTION
# PR の目的

assert を独立した 1 行で記載する



## カテゴリ

<!-- 編集 必須 -->
<!-- 以下の箇条書きリストから関係するものを残して、関係ないものを削除してください。-->
<!-- 該当するものがない場合は必要に応じて追加してください。                        -->

- リファクタリング

## PR の背景

#1179, #1172 で アセンブリ出力の一致を確認するためにコードが変化しないようにするため
に assert をコメントアウトする処理をテスト的に入れた。

https://github.com/sakura-editor/sakura/pull/1179/commits/a1d69d95a4ee369eba926269463ed9bb84985810

しかし、assert が独立した行に書かれていなかったため、一括置換するとビルドエラーに
なったため手動で除外する対応が必要になった。

一括置換で対応できるように (スクリプトで自動化できるために) 独立した行にする

## PR のメリット

#1179, #1172  の対応を行うときに assert をテスト的に無効化する処理をスクリプトで自動化できる。

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

## 関連チケット

#1179 
#1172

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
