### PR TITLE
[WIP] 検索ボックスでリストのドロップダウン中にDeleteキーを押したときの挙動を変更したい

### DIFF
--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -144,6 +144,10 @@ namespace ApiWrap{
 	{
 		return Wnd_GetText(hwndCombo, str);
 	}
+	inline bool Combo_SetText(HWND hwndCombo, const CNativeW& str)
+	{
+		return Wnd_SetText(hwndCombo, str) != FALSE;
+	}
 
 	inline int Combo_DeleteString(HWND hwndCtl, int index)				{ return (int)(DWORD)::SendMessage(hwndCtl, CB_DELETESTRING, (WPARAM)index, 0L); }
 	inline int Combo_FindStringExact(HWND hwndCtl, int indexStart, const WCHAR* lpszFind)	{ return (int)(DWORD)::SendMessage(hwndCtl, CB_FINDSTRINGEXACT, (WPARAM)indexStart, LPARAM(lpszFind) ); }

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -168,6 +168,47 @@ namespace ApiWrap{
 	inline int Combo_SetDroppedWidth(HWND hwndCtl, int width)			{ return (int)(DWORD)::SendMessage(hwndCtl, CB_SETDROPPEDWIDTH, (WPARAM)width, 0L); }
 	inline BOOL Combo_GetDroppedState(HWND hwndCtl)						{ return (BOOL)(DWORD)::SendMessage(hwndCtl, CB_GETDROPPEDSTATE, 0L, 0L ); }
 
+	inline bool Combo_GetLBText(HWND hwndCombo, int nIndex, CNativeW& str)
+	{
+		// バッファをクリアしておく
+		str.Clear();
+
+		// 範囲外は失敗にする
+		if (nIndex < 0)
+		{
+			return false;
+		}
+
+		// 文字列長を取得する、取得できなければエラー
+		const int length = Combo_GetLBTextLen( hwndCombo, nIndex );
+		if ( length == CB_ERR || length < 0)
+		{
+			return false;
+		}
+
+		// 必要なメモリを確保する
+		const int bufsize = length + 1;
+		str.AllocStringBuffer( bufsize );
+
+		// アイテムテキストを取得する
+		const int actualCount = (int)Combo_GetLBText( hwndCombo, nIndex, str.GetStringPtr() );
+		if (actualCount == CB_ERR || actualCount < 0)
+		{
+			return false;
+		}
+		else if(str.capacity() <= actualCount)
+		{
+			return false;
+		}
+
+		// CNativeW 内部のデータサイズを更新する
+		str._SetStringLength(actualCount);
+
+		// 正しく設定されているはず
+		assert(str.GetStringLength() == actualCount);
+		return true;
+	}
+
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      リストボックス                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -140,6 +140,10 @@ namespace ApiWrap{
 	{
 		return ::GetWindowText( hwndCombo, str, cchMax );
 	}
+	inline bool Combo_GetText(HWND hwndCombo, CNativeW& str)
+	{
+		return Wnd_GetText(hwndCombo, str);
+	}
 
 	inline int Combo_DeleteString(HWND hwndCtl, int index)				{ return (int)(DWORD)::SendMessage(hwndCtl, CB_DELETESTRING, (WPARAM)index, 0L); }
 	inline int Combo_FindStringExact(HWND hwndCtl, int indexStart, const WCHAR* lpszFind)	{ return (int)(DWORD)::SendMessage(hwndCtl, CB_FINDSTRINGEXACT, (WPARAM)indexStart, LPARAM(lpszFind) ); }

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -208,6 +208,16 @@ namespace ApiWrap{
 		assert(str.GetStringLength() == actualCount);
 		return true;
 	}
+	inline void Combo_GetEditSel( HWND hwndCombo, int &nSelStart, int &nSelEnd )
+	{
+		DWORD dwSelStart = 0;
+		DWORD dwSelEnd = 0;
+		::SendMessage( hwndCombo, CB_GETEDITSEL, WPARAM( &dwSelStart ), LPARAM( &dwSelEnd ) );
+		assert_warning( 0x7FFFFFFF < dwSelStart );
+		assert_warning( 0x7FFFFFFF < dwSelEnd );
+		nSelStart = static_cast<int>(dwSelStart);
+		nSelEnd = static_cast<int>(dwSelEnd);
+	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      リストボックス                         //

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -168,46 +168,6 @@ namespace ApiWrap{
 	inline int Combo_SetDroppedWidth(HWND hwndCtl, int width)			{ return (int)(DWORD)::SendMessage(hwndCtl, CB_SETDROPPEDWIDTH, (WPARAM)width, 0L); }
 	inline BOOL Combo_GetDroppedState(HWND hwndCtl)						{ return (BOOL)(DWORD)::SendMessage(hwndCtl, CB_GETDROPPEDSTATE, 0L, 0L ); }
 
-	inline bool Combo_GetLBText(HWND hwndCombo, int nIndex, CNativeW& str)
-	{
-		// バッファをクリアしておく
-		str.Clear();
-
-		// 範囲外は失敗にする
-		if (nIndex < 0)
-		{
-			return false;
-		}
-
-		// 文字列長を取得する、取得できなければエラー
-		const int length = Combo_GetLBTextLen( hwndCombo, nIndex );
-		if ( length == CB_ERR || length < 0)
-		{
-			return false;
-		}
-
-		// 必要なメモリを確保する
-		const int bufsize = length + 1;
-		str.AllocStringBuffer( bufsize );
-
-		// アイテムテキストを取得する
-		const int actualCount = (int)Combo_GetLBText( hwndCombo, nIndex, str.GetStringPtr() );
-		if (actualCount == CB_ERR || actualCount < 0)
-		{
-			return false;
-		}
-		else if(str.capacity() <= actualCount)
-		{
-			return false;
-		}
-
-		// CNativeW 内部のデータサイズを更新する
-		str._SetStringLength(actualCount);
-
-		// 正しく設定されているはず
-		assert(str.GetStringLength() == actualCount);
-		return true;
-	}
 	inline void Combo_GetEditSel( HWND hwndCombo, int &nSelStart, int &nSelEnd )
 	{
 		DWORD dwSelStart = 0;

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -734,11 +734,17 @@ static bool DeleteRecentItem(
 	int nSelEnd = 0;
 	Combo_GetEditSel( hwndCombo, nSelStart, nSelEnd );
 
+	// エディットテキストがアイテムテキストと同じで、エディットが全選択でないなら中断する
+	if (cEditText == cItemText && (0 < nSelStart || nSelEnd < cEditText.GetStringLength()))
+	{
+		return false;
+	}
+
 	// コンボボックスのリストアイテム削除
 	Combo_DeleteString( hwndCombo, nIndex );
 
-	// エディットテキストがアイテムテキストと違うか、エディットが全選択でないなら復元する
-	if (cEditText != cItemText || 0 < nSelStart || nSelEnd < cEditText.GetStringLength())
+	// エディットテキストがアイテムテキストと違うなら復元する
+	if (cEditText != cItemText)
 	{
 		Combo_SetText( hwndCombo, cEditText );
 		Combo_SetEditSel( hwndCombo, nSelStart, nSelEnd );

--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -129,6 +129,10 @@ BOOL CDlgGrepReplace::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	/* コンボボックスのユーザー インターフェイスを拡張インターフェースにする */
 	Combo_SetExtendedUI( GetItemHwnd( IDC_COMBO_TEXT2 ), TRUE );
 
+	m_comboDelText2 = SComboBoxItemDeleter();
+	m_comboDelText2.pRecent = &m_cRecentReplace;
+	SetComboBoxDeleter( GetItemHwnd( IDC_COMBO_TEXT2 ), &m_comboDelText2 );
+
 	HFONT hFontOld = (HFONT)::SendMessageAny( GetItemHwnd( IDC_COMBO_TEXT2 ), WM_GETFONT, 0, 0 );
 	HFONT hFont = SetMainFont( GetItemHwnd( IDC_COMBO_TEXT2 ) );
 	m_cFontText2.SetFont( hFontOld, hFont, GetItemHwnd( IDC_COMBO_TEXT2 ) );

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -39,6 +39,8 @@ public:
 	int				m_nReplaceKeySequence;	//!< 置換後シーケンス
 
 protected:
+	CRecentReplace			m_cRecentReplace;
+	SComboBoxItemDeleter	m_comboDelText2;
 	CFontAutoDeleter		m_cFontText2;
 
 	/*


### PR DESCRIPTION
# PR の目的
検索ボックスでリストのドロップダウン中にDeleteキーを押したときの挙動を変更します。

変更前：　ドロップダウンリストの履歴1件とエディット部分のテキストがクリアされる。
変更後：　ドロップダウンリストで選択された履歴1件とエディット部分のテキストがクリアされる（エディット部分のテキストが選択された履歴と異なる場合、エディット部分は残す）。

仕様変更ついでに、関連する実装漏れ不具合1件を修正します。
（Grep置換ダイアログの「置換後」ボックスに履歴削除機能が実装されていませんでした。）

## カテゴリ
- 仕様変更
- 不具合修正

## PR の背景
#1219 「検索ダイアログボックスでプルダウンが表示時にDeleteキーで文字の消去が機能しない」を参照。

## PR のメリット
- 検索ボックスでリストのドロップダウン中にDeleteキーを押したときの挙動が自然になります。
- 明らかな実装漏れが補われます。

## PR のデメリット (トレードオフとかあれば)
- 検索ボックスでリストのドロップダウン中にDeleteキーを押したときの挙動が変わります。
- Grep置換ダイアログの実装漏れを補ったコードは、既存コード置換ダイアログの「コピペ」です。つまり、設計見直しを図る貴重な機会を「見なかったこと」にしてしまう「ダメな変更」を含んでいます。  
既存設計の見直しは、必要があれば別件として対処すべきと考えたので、あえてコピペにしています。

## PR の影響範囲
- 履歴機能の付いたコンボボックスを使用している箇所に影響します。

## 関連チケット
close #1219

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
