### PR TITLE
検索コンボの編集仕様を見直したい

### DIFF
--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -144,6 +144,10 @@ namespace ApiWrap{
 	{
 		return Wnd_GetText(hwndCombo, str);
 	}
+	inline bool Combo_SetText(HWND hwndCombo, const CNativeW& str)
+	{
+		return Wnd_SetText(hwndCombo, str) != FALSE;
+	}
 
 	inline int Combo_DeleteString(HWND hwndCtl, int index)				{ return (int)(DWORD)::SendMessage(hwndCtl, CB_DELETESTRING, (WPARAM)index, 0L); }
 	inline int Combo_FindStringExact(HWND hwndCtl, int indexStart, const WCHAR* lpszFind)	{ return (int)(DWORD)::SendMessage(hwndCtl, CB_FINDSTRINGEXACT, (WPARAM)indexStart, LPARAM(lpszFind) ); }

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -168,6 +168,47 @@ namespace ApiWrap{
 	inline int Combo_SetDroppedWidth(HWND hwndCtl, int width)			{ return (int)(DWORD)::SendMessage(hwndCtl, CB_SETDROPPEDWIDTH, (WPARAM)width, 0L); }
 	inline BOOL Combo_GetDroppedState(HWND hwndCtl)						{ return (BOOL)(DWORD)::SendMessage(hwndCtl, CB_GETDROPPEDSTATE, 0L, 0L ); }
 
+	inline bool Combo_GetLBText(HWND hwndCombo, int nIndex, CNativeW& str)
+	{
+		// バッファをクリアしておく
+		str.Clear();
+
+		// 範囲外は失敗にする
+		if (nIndex < 0)
+		{
+			return false;
+		}
+
+		// 文字列長を取得する、取得できなければエラー
+		const int length = Combo_GetLBTextLen( hwndCombo, nIndex );
+		if ( length == CB_ERR || length < 0)
+		{
+			return false;
+		}
+
+		// 必要なメモリを確保する
+		const int bufsize = length + 1;
+		str.AllocStringBuffer( bufsize );
+
+		// アイテムテキストを取得する
+		const int actualCount = (int)Combo_GetLBText( hwndCombo, nIndex, str.GetStringPtr() );
+		if (actualCount == CB_ERR || actualCount < 0)
+		{
+			return false;
+		}
+		else if(str.capacity() <= actualCount)
+		{
+			return false;
+		}
+
+		// CNativeW 内部のデータサイズを更新する
+		str._SetStringLength(actualCount);
+
+		// 正しく設定されているはず
+		assert(str.GetStringLength() == actualCount);
+		return true;
+	}
+
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      リストボックス                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -140,6 +140,10 @@ namespace ApiWrap{
 	{
 		return ::GetWindowText( hwndCombo, str, cchMax );
 	}
+	inline bool Combo_GetText(HWND hwndCombo, CNativeW& str)
+	{
+		return Wnd_GetText(hwndCombo, str);
+	}
 
 	inline int Combo_DeleteString(HWND hwndCtl, int index)				{ return (int)(DWORD)::SendMessage(hwndCtl, CB_DELETESTRING, (WPARAM)index, 0L); }
 	inline int Combo_FindStringExact(HWND hwndCtl, int indexStart, const WCHAR* lpszFind)	{ return (int)(DWORD)::SendMessage(hwndCtl, CB_FINDSTRINGEXACT, (WPARAM)indexStart, LPARAM(lpszFind) ); }

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -208,6 +208,16 @@ namespace ApiWrap{
 		assert(str.GetStringLength() == actualCount);
 		return true;
 	}
+	inline void Combo_GetEditSel( HWND hwndCombo, int &nSelStart, int &nSelEnd )
+	{
+		DWORD dwSelStart = 0;
+		DWORD dwSelEnd = 0;
+		::SendMessage( hwndCombo, CB_GETEDITSEL, WPARAM( &dwSelStart ), LPARAM( &dwSelEnd ) );
+		assert_warning( 0x7FFFFFFF < dwSelStart );
+		assert_warning( 0x7FFFFFFF < dwSelEnd );
+		nSelStart = static_cast<int>(dwSelStart);
+		nSelEnd = static_cast<int>(dwSelEnd);
+	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      リストボックス                         //


### PR DESCRIPTION
# PR の目的
検索ダイアログなどにある履歴表示機能付き検索コンボの編集仕様を見直し、使い勝手を向上させます。

## カテゴリ
- 仕様変更 (変更の実態は仕様変更です。)
- 不具合修正 (#1219 で報告された「Deleteキーが効かない」を解消します。)

## PR の背景
#1221 と #1219 を参照してください。

## PR のメリット
- Deleteキー押下時の挙動が、一般的な挙動と一致します。
  - エディットボックスに対して、選択されたテキストorキャレット位置にある文字を削除。
  - リストボックスに対して、選択されたリストアイテムを削除。
- キャレット位置にある文字が消えないことはなくなります。  
※キャレット位置に文字がない(＝キャレット位置が末尾の場合）を除く。
- 選択されて見えるリストが消えないことはなくなります。

## PR のデメリット (トレードオフとかあれば)
- レビュー難易度がそれなりに高いです。
- 影響範囲がそれなりに広いです。
- このPRは主観に基づいています。（＝キモいから対処したい、が根っこです。）

## PR の影響範囲
- アプリ（＝サクラエディタ）の挙動に影響がある変更です。
  - 検索ダイアログの検索ボックス
  - 置換ダイアログの検索ボックス、置換後ボックス
  - Grepダイアログの検索ボックス、ファイルボックス、フォルダボックス、除外ファイルボックス、除外フォルダボックス
  - Grep置換ダイアログの検索ボックス、置換後ボックス(※)、ファイルボックス、フォルダボックス、除外ファイルボックス、除外フォルダボックス  
※ #1219 で指摘されている通り、実装漏れがあります。
  - ツールバーの検索ボックス
  - ファイル名を指定して実行の名前ボックス
  - ファイルオープンダイアログのファイルボックス、フォルダボックス
  - ダイレクトタグジャンプ一覧ダイアログのキーワードボックス


## 関連チケット
#1221
#1219

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
