### PR TITLE
Grep置換ダイアログの「置換後」の実装を置換ダイアログと合わせる

### DIFF
--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -129,6 +129,10 @@ BOOL CDlgGrepReplace::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	/* コンボボックスのユーザー インターフェイスを拡張インターフェースにする */
 	Combo_SetExtendedUI( GetItemHwnd( IDC_COMBO_TEXT2 ), TRUE );
 
+	m_comboDelText2 = SComboBoxItemDeleter();
+	m_comboDelText2.pRecent = &m_cRecentReplace;
+	SetComboBoxDeleter( GetItemHwnd( IDC_COMBO_TEXT2 ), &m_comboDelText2 );
+
 	HFONT hFontOld = (HFONT)::SendMessageAny( GetItemHwnd( IDC_COMBO_TEXT2 ), WM_GETFONT, 0, 0 );
 	HFONT hFont = SetMainFont( GetItemHwnd( IDC_COMBO_TEXT2 ) );
 	m_cFontText2.SetFont( hFontOld, hFont, GetItemHwnd( IDC_COMBO_TEXT2 ) );

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -39,6 +39,8 @@ public:
 	int				m_nReplaceKeySequence;	//!< 置換後シーケンス
 
 protected:
+	CRecentReplace			m_cRecentReplace;
+	SComboBoxItemDeleter	m_comboDelText2;
 	CFontAutoDeleter		m_cFontText2;
 
 	/*


### PR DESCRIPTION
# PR の目的
Grep置換ダイアログの「置換後」の実装を置換ダイアログと合わせます。

## カテゴリ
- 仕様変更 (Grep置換後ダイアログの置換後ボックスで履歴削除ができるようになります。)
- 不具合修正 (履歴機能付きコンボの共通仕様が実装されていない、という不具合を修正します。)

## PR の背景

#1219 を参照してください。

## PR のメリット
- 明らかな実装漏れを、とりあえず補うことができます。
- 動いている既存コードのコピペなので、安心して使うことができます。
- Grep置換ダイアログの置換後ボックスでDeleteキーによる履歴削除を利用できるようになります。

## PR のデメリット (トレードオフとかあれば)
- 置換ダイアログの実装のコピペです。
  - 置換ダイアログの既存実装を見直す貴重な機会をスルーする変更です。
  - Grep置換ダイアログの実装にそのまま加えて問題ないかの検証をスルーする変更です。

## PR の影響範囲
- アプリ（＝サクラエディタ）の挙動に影響がある変更です。 ◦検索ダイアログの検索ボックス
  - Grep置換ダイアログの置換後ボックス
    - ドロップダウン中にDeleteキーを押下すると選択した履歴を消せるようになります。

## 関連チケット
#1223
#1221
#1219

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
