### PR TITLE
googletestのビルドをバッチスクリプトで行うように変更したい

### DIFF
--- a/build-sln.bat
+++ b/build-sln.bat
@@ -46,11 +46,11 @@ if errorlevel 1 (
 )
 
 if "%SONAR_QUBE_TOKEN%" == "" (
-	@echo "%CMD_MSBUILD%" %SLN_FILE% %PARAM_VSVERSION% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
-	      "%CMD_MSBUILD%" %SLN_FILE% %PARAM_VSVERSION% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
+	@echo "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
+	      "%CMD_MSBUILD%" %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Build" %EXTRA_CMD% %LOG_OPTION%
 ) else (
-    @echo "%BUILDWRAPPER_EXE%" --out-dir %~dp0bw-output "%CMD_MSBUILD%"  %SLN_FILE% %PARAM_VSVERSION% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Rebuild" %LOG_OPTION%
-          "%BUILDWRAPPER_EXE%" --out-dir %~dp0bw-output "%CMD_MSBUILD%"  %SLN_FILE% %PARAM_VSVERSION% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Rebuild" %LOG_OPTION%
+    @echo "%BUILDWRAPPER_EXE%" --out-dir %~dp0bw-output "%CMD_MSBUILD%"  %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Rebuild" %LOG_OPTION%
+          "%BUILDWRAPPER_EXE%" --out-dir %~dp0bw-output "%CMD_MSBUILD%"  %SLN_FILE% /p:Platform=%platform% /p:Configuration=%configuration%  /t:"Rebuild" %LOG_OPTION%
 )
 if errorlevel 1 (
 	echo ERROR in msbuild.exe errorlevel %errorlevel%

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -25,8 +25,8 @@ if not exist CMakeLists.txt (
 popd
 
 if not exist "%CMD_NINJA%" (
-	set GENERATOR="%CMAKE_G_PARAM%"
-	set GENERATOR_OPTS=-A %PLATFORM% "-DCMAKE_CONFIGURATION_TYPES=Debug;Release"
+  set GENERATOR="%CMAKE_G_PARAM%"
+  set GENERATOR_OPTS=-A %PLATFORM% "-DCMAKE_CONFIGURATION_TYPES=Debug;Release"
   set "MAKE_PROGRAM=%CMD_MSBUILD%"
   set "BUILD_DIR=%BUILD_BASE_DIR%googletest\%platform%"
 ) else (
@@ -75,7 +75,7 @@ goto :EOF
 
 :find_cl_compiler
 for /f "usebackq delims=" %%a in (`where cl.exe`) do (
-	set "CMD_CL=%%a"
-	goto :EOF
+  set "CMD_CL=%%a"
+  goto :EOF
 )
 goto :EOF

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -1,6 +1,6 @@
 setlocal
-set BUILD_BASE_DIR=%~1
-set GOOGLETEST_INSTALL_PATH=%~2
+set BUILD_BASE_DIR=%~dp1
+set GOOGLETEST_INSTALL_PATH=%~dp2
 
 set SOURCE_DIR=%~dp0googletest
 

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -24,7 +24,7 @@ if not exist CMakeLists.txt (
 )
 popd
 
-if exist "%CMD_NINJA%" (
+if not exist "%CMD_NINJA%" (
 	set GENERATOR="%CMAKE_G_PARAM%"
 	set GENERATOR_OPTS=-A %PLATFORM% "-DCMAKE_CONFIGURATION_TYPES=Debug;Release"
   set "MAKE_PROGRAM=%CMD_MSBUILD%"
@@ -75,7 +75,7 @@ goto :EOF
 
 :find_cl_compiler
 for /f "usebackq delims=" %%a in (`where cl.exe`) do (
-    set "CMD_CL=%%a"
-    goto :EOF
+	set "CMD_CL=%%a"
+	goto :EOF
 )
 goto :EOF

--- a/tests/googletest.build.cmd
+++ b/tests/googletest.build.cmd
@@ -9,8 +9,6 @@ if not defined CMD_VSWHERE call %~dp0..\tools\find-tools.bat
 
 set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
 
-call :resolve_cmake_and_ninja
-
 if not exist "%CMD_CMAKE%" (
   echo "no cmake found."
   exit /b 1
@@ -44,34 +42,6 @@ pushd %BUILD_DIR%
 call :run_cmake_install
 
 endlocal && exit /b 0
-
-:resolve_cmake_and_ninja
-for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -property installationPath -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
-    pushd "%%a"
-    call "%%a\Common7\Tools\vsdevcmd\ext\cmake.bat"
-    call :resolve_cmake
-    call :resolve_ninja
-    popd
-    goto :EOF
-)
-goto :EOF
-
-:resolve_cmake
-if exist "%CMD_CMAKE%" goto :EOF
-for /f "usebackq delims=" %%a in (`where cmake.exe`) do (
-    set "CMD_CMAKE=%%a"
-    goto :EOF
-)
-goto :EOF
-
-:resolve_ninja
-if exist "%CMD_NINJA%" goto :EOF
-for /f "usebackq delims=" %%a in (`where ninja.exe`) do (
-    set "CMD_NINJA=%%a"
-    goto :EOF
-)
-goto :EOF
-
 
 :run_cmake_install
 call :run_cmake_configure

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -1,9 +1,11 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="GoogleTest">
-    <GoogleTestSourceDir>$(MSBuildThisFileDirectory)googletest\</GoogleTestSourceDir>
-    <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\$(Platform)\$(Configuration)\googletest</GoogleTestBuildDir>
-    <IncludePath>$(GoogleTestSourceDir)googletest\include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(GoogleTestBuildDir)\lib;$(GoogleTestBuildDir)\lib\$(Configuration);$(LibraryPath)</LibraryPath>
+    <GoogleTestSourceDir>$(MSBuildThisFileDirectory)googletest</GoogleTestSourceDir>
+    <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\</GoogleTestBuildDir>
+    <GoogleTestInstallDir>$([MsBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\tools\googletext'))</GoogleTestInstallDir>
+    <IncludePath>$(GoogleTestInstallDir)\include;$(IncludePath)</IncludePath>
+    <LibraryPath Condition="'$(Platform)' == 'Win32'">$(GoogleTestInstallDir)\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Platform)' == 'x64'">$(GoogleTestInstallDir)\lib64;$(LibraryPath)</LibraryPath>
     <NameSuffix Condition="'$(Configuration)' == 'Debug'">d</NameSuffix>
     <NameSuffix Condition="'$(Configuration)' == 'Release'"></NameSuffix>
   </PropertyGroup>
@@ -18,51 +20,23 @@
       <AdditionalDependencies>gtest_main$(NameSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <Target Name="FindGit" Condition="'$(GitCmd)' == ''">
-    <Message Text="Checking Git for Windows" Importance="high" />
-    <Exec Command="where &quot;$(PATH);$(ProgramW6432)\Git\Cmd;$(ProgramFiles)\Git\Cmd:git&quot;" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitCmd" />
-    </Exec>
-    <PropertyGroup>
-      <GitCmd>$([System.Text.RegularExpressions.Regex]::Replace('$(GitCmd)', '^([^;]+);.*', '$1'))</GitCmd>
-    </PropertyGroup>
-  </Target>
-  <Target Name="UpdateGoogleTest" DependsOnTargets="FindGit" Condition="!Exists('$(GoogleTestSourceDir)\CMakeLists.txt')">
-    <Exec Command="&quot;$(GitCmd)&quot; submodule init" WorkingDirectory="$(GoogleTestSourceDir)" />
-    <Exec Command="&quot;$(GitCmd)&quot; submodule update" WorkingDirectory="$(GoogleTestSourceDir)" />
-  </Target>
   <Target Name="MakeGoogleTestBuildDir" Condition="!Exists('$(GoogleTestBuildDir)')">
     <MakeDir Directories="$(GoogleTestBuildDir)" />
   </Target>
-  <Target Name="BuildGoogleTest" DependsOnTargets="UpdateGoogleTest;MakeGoogleTestBuildDir" BeforeTargets="ClCompile">
-    <PropertyGroup>
-      <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'x86' And '$(PlatformTarget)' == 'x86'">x86</VcVarsArchitecture>
-      <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'x86' And '$(PlatformTarget)' == 'x64'">x86_amd64</VcVarsArchitecture>
-      <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x86'">amd64_x86</VcVarsArchitecture>
-      <VcVarsArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64' And '$(PlatformTarget)' == 'x64'">amd64</VcVarsArchitecture>
-      <NumVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioVersion)', '^(\d+).*', '$1'))</NumVersion>
-      <ProductLineVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioEdition)', '^.* (\d+).*', '$1'))</ProductLineVersion>
-      <GeneratorSuffix Condition="'$(PlatformTarget)' == 'x86'"></GeneratorSuffix>
-      <GeneratorSuffix Condition="'$(PlatformTarget)' == 'x64'"> Win64</GeneratorSuffix>
-      <VsGeneratorName>Visual Studio $(NumVersion) $(ProductLineVersion)$(GeneratorSuffix)</VsGeneratorName>
-    </PropertyGroup>
-    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd $(GoogleTestSourceDir) &quot;$(VsGeneratorName)&quot; $(Configuration) &quot;$(VSInstallRoot)/VC/Auxiliary/Build/vcvarsall.bat&quot; $(VcVarsArchitecture)" WorkingDirectory="$(GoogleTestBuildDir)" />
+  <Target Name="MakeGoogleTestInstallDir" Condition="!Exists('$(GoogleTestInstallDir)')">
+    <MakeDir Directories="$(GoogleTestInstallDir)" />
   </Target>
-  <Target Name="CopyGoogleTestPdb" AfterTargets="BuildGoogleTest">
-    <ItemGroup>
-      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\gtest$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest$(NameSuffix).pdb')" />
-      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\gtest_main$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\gtest_main$(NameSuffix).pdb')" />
-      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest$(NameSuffix).pdb')" />
-      <GoogleTestPdb Include="$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main$(NameSuffix).pdb" Condition="Exists('$(GoogleTestBuildDir)\bin\$(Configuration)\gtest_main$(NameSuffix).pdb')" />
-    </ItemGroup>
-    <Copy SourceFiles="@(GoogleTestPdbFound)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" UseHardlinksIfPossible="true" />
+  <Target Name="BuildGoogleTest" DependsOnTargets="MakeGoogleTestBuildDir;MakeGoogleTestInstallDir" BeforeTargets="ClCompile">
+    <PropertyGroup>
+      <VsVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioVersion)', '^(\d+).*', '$1'))</VsVersion>
+    </PropertyGroup>
+    <SetEnv name="platform" value="$(Platform)" prefix="false" />
+    <SetEnv name="configuration" value="$(Configuration)" prefix="false" />
+    <SetEnv name="NUM_VSVERSION" value="$(VsVersion)" prefix="false" />
+    <Exec Command="$(MSBuildThisFileDirectory)googletest.build.cmd &quot;$(GoogleTestBuildDir)&quot; &quot;$(GoogleTestInstallDir)&quot;" ConsoleToMSBuild="true" />
   </Target>
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
-    <!-- Add files to @Clean just before running CoreClean. -->
-    <ItemGroup>
-      <Clean Include="$(OutDir)gtest$(NameSuffix).pdb" />
-      <Clean Include="$(OutDir)gtest_main$(NameSuffix).pdb" />
-    </ItemGroup>
     <RemoveDir Directories="$(GoogleTestBuildDir)" />
+    <RemoveDir Directories="$(GoogleTestInstallDir)" />
   </Target>
 </Project>

--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -2,10 +2,10 @@
   <PropertyGroup Label="GoogleTest">
     <GoogleTestSourceDir>$(MSBuildThisFileDirectory)googletest</GoogleTestSourceDir>
     <GoogleTestBuildDir>$(MSBuildThisFileDirectory)build\</GoogleTestBuildDir>
-    <GoogleTestInstallDir>$([MsBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\tools\googletext'))</GoogleTestInstallDir>
-    <IncludePath>$(GoogleTestInstallDir)\include;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Platform)' == 'Win32'">$(GoogleTestInstallDir)\lib;$(LibraryPath)</LibraryPath>
-    <LibraryPath Condition="'$(Platform)' == 'x64'">$(GoogleTestInstallDir)\lib64;$(LibraryPath)</LibraryPath>
+    <GoogleTestInstallDir>$([MsBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\tools\googletest\'))</GoogleTestInstallDir>
+    <IncludePath>$(GoogleTestInstallDir)include;$(IncludePath)</IncludePath>
+    <LibraryPath Condition="'$(Platform)' == 'Win32'">$(GoogleTestInstallDir)lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Platform)' == 'x64'">$(GoogleTestInstallDir)lib64;$(LibraryPath)</LibraryPath>
     <NameSuffix Condition="'$(Configuration)' == 'Debug'">d</NameSuffix>
     <NameSuffix Condition="'$(Configuration)' == 'Release'"></NameSuffix>
   </PropertyGroup>

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -77,7 +77,7 @@ exit /b
 
 :7z
 if "%FORCE_POWERSHELL_ZIP%" == "1" (
-	exit /b
+    exit /b
 )
 set APPDIR=7-Zip
 set PATH2=%PATH%;%ProgramFiles%\%APPDIR%\;%ProgramFiles(x86)%\%APPDIR%\;%ProgramW6432%\%APPDIR%\;
@@ -152,77 +152,74 @@ exit /b
 ::     16     => Visual Studio 2019
 :: ---------------------------------------------------------------------------------------------------------------------
 :msbuild
-	:: convert productLineVersion to Internal Major Version
-	if "%ARG_VSVERSION%" == "" (
-		set NUM_VSVERSION=15
-	) else if "%ARG_VSVERSION%" == "2017" (
-		set NUM_VSVERSION=15
-	) else if "%ARG_VSVERSION%" == "2019" (
-		set NUM_VSVERSION=16
-	) else if "%ARG_VSVERSION%" == "latest" (
-		call :check_latest_installed_vsversion
-	) else (
-		set NUM_VSVERSION=%ARG_VSVERSION%
-	)
+    :: convert productLineVersion to Internal Major Version
+    if "%ARG_VSVERSION%" == "" (
+        set NUM_VSVERSION=15
+    ) else if "%ARG_VSVERSION%" == "2017" (
+        set NUM_VSVERSION=15
+    ) else if "%ARG_VSVERSION%" == "2019" (
+        set NUM_VSVERSION=16
+    ) else if "%ARG_VSVERSION%" == "latest" (
+        call :check_latest_installed_vsversion
+    ) else (
+        set NUM_VSVERSION=%ARG_VSVERSION%
+    )
 
-	call :check_installed_vsversion
+    call :check_installed_vsversion
 
-	call :find_msbuild
-	if not exist "%CMD_MSBUILD%" (
-		call :find_msbuild_legacy
-		set NUM_VSVERSION=15
-	)
+    call :find_msbuild
+    if not exist "%CMD_MSBUILD%" (
+        call :find_msbuild_legacy
+        set NUM_VSVERSION=15
+    )
 
-	if "%NUM_VSVERSION%" == "15" (
-		set NUM_VSVERSION=15
-		set CMAKE_G_PARAM=Visual Studio 15 2017
-		
-	) else if "%NUM_VSVERSION%" == "16" (
-		set NUM_VSVERSION=16
-		set CMAKE_G_PARAM=Visual Studio 16 2019
-		
-	) else (
-		echo Visual Studio Version %NUM_VERSION% is not supported.
-		exit /b 1
-		
-	)
-	exit /b
+    if "%NUM_VSVERSION%" == "15" (
+        set NUM_VSVERSION=15
+        set CMAKE_G_PARAM=Visual Studio 15 2017
+    ) else if "%NUM_VSVERSION%" == "16" (
+        set NUM_VSVERSION=16
+        set CMAKE_G_PARAM=Visual Studio 16 2019
+    ) else (
+        echo Visual Studio Version %NUM_VERSION% is not supported.
+        exit /b 1
+    )
+    exit /b
 
 :check_latest_installed_vsversion
-	for /f "usebackq delims=" %%v in (`"%CMD_VSWHERE%" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion -latest`) do (
-		set VSVERSION=%%v
-	)
-	set NUM_VSVERSION=%VSVERSION:~0,2%
-	exit /b
+    for /f "usebackq delims=" %%v in (`"%CMD_VSWHERE%" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion -latest`) do (
+        set VSVERSION=%%v
+    )
+    set NUM_VSVERSION=%VSVERSION:~0,2%
+    exit /b
 
 :check_installed_vsversion
-	set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
-	for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
-		if exist "%%d" exit /b
-	)
-	call :check_latest_installed_vsversion
-	exit /b
+    set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
+    for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
+        if exist "%%d" exit /b
+    )
+    call :check_latest_installed_vsversion
+    exit /b
 
 :find_msbuild
-	set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
-	for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
-	    set "CMD_MSBUILD=%%a"
-	)
-	if exist "%CMD_MSBUILD%" (
-		exit /b
-	)
-	set CMD_MSBUILD=
-	exit /b
+    set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
+    for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
+        set "CMD_MSBUILD=%%a"
+    )
+    if exist "%CMD_MSBUILD%" (
+        exit /b
+    )
+    set CMD_MSBUILD=
+    exit /b
 
 :find_msbuild_legacy
-	for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -requires Microsoft.Component.MSBuild -property installationPath -version [15^,16^)`) do (
-	    set "CMD_MSBUILD=%%d\MSBuild\15.0\Bin\MSBuild.exe"
-	)
-	if exist "%CMD_MSBUILD%" (
-		exit /b
-	)
-	set CMD_MSBUILD=
-	exit /b
+    for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -requires Microsoft.Component.MSBuild -property installationPath -version [15^,16^)`) do (
+        set "CMD_MSBUILD=%%d\MSBuild\15.0\Bin\MSBuild.exe"
+    )
+    if exist "%CMD_MSBUILD%" (
+        exit /b
+    )
+    set CMD_MSBUILD=
+    exit /b
 
 :cmake
 for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -property installationPath -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
@@ -231,7 +228,7 @@ for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -property installationPath -v
     call :resolve_cmake
     call :resolve_ninja
     popd
-	exit /b
+    exit /b
 )
 exit /b
 
@@ -241,7 +238,7 @@ set APPDIR=CMake\bin
 set PATH2=%PATH%;%ProgramFiles%\%APPDIR%\;%ProgramFiles(x86)%\%APPDIR%\;%ProgramW6432%\%APPDIR%\;
 for /f "usebackq delims=" %%a in (`where $PATH2:cmake`) do ( 
     set "CMD_CMAKE=%%a"
-	exit /b
+    exit /b
 )
 exit /b
 
@@ -249,6 +246,6 @@ exit /b
 if exist "%CMD_NINJA%" goto :EOF
 for /f "usebackq delims=" %%a in (`where $PATH:ninja`) do ( 
     set "CMD_NINJA=%%a"
-	exit /b
+    exit /b
 )
 exit /b

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -174,14 +174,23 @@ exit /b
     )
 
     if "%NUM_VSVERSION%" == "15" (
-        set NUM_VSVERSION=15
         set CMAKE_G_PARAM=Visual Studio 15 2017
     ) else if "%NUM_VSVERSION%" == "16" (
-        set NUM_VSVERSION=16
         set CMAKE_G_PARAM=Visual Studio 16 2019
     ) else (
-        echo Visual Studio Version %NUM_VERSION% is not supported.
-        exit /b 1
+        call :set_cmake_gparam_automatically
+    )
+    exit /b
+
+:set_cmake_gparam_automatically
+    call :get_product_line_version
+    set CMAKE_G_PARAM=Visual Studio %NUM_VSVERSION% %VS_PRODUCT_LINE_VERSION%
+    exit /b
+
+:get_product_line_version
+    set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
+    for /f "usebackq delims=" %%v in (`"%CMD_VSWHERE%" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productLineVersion -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
+        set VS_PRODUCT_LINE_VERSION=%%v
     )
     exit /b
 

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -11,12 +11,15 @@ if "%1" equ "clear" (
     set CMD_DOXYGEN=
     set CMD_VSWHERE=
     set CMD_MSBUILD=
-    set FIND_TOOLS_CALLED=
+    set CMD_CMAKE=
+    set CMD_NINJA=
     set NUM_VSVERSION=
-    set PARAM_VSVERSION=
     set CMAKE_G_PARAM=
+    set FIND_TOOLS_CALLED=
     echo find-tools.bat has been cleared
     exit /b
+) else if "%~1" neq "" (
+    set "ARG_VSVERSION=%~1"
 )
 if defined FIND_TOOLS_CALLED (
     echo find-tools.bat already called
@@ -24,15 +27,16 @@ if defined FIND_TOOLS_CALLED (
 )
 
 echo find-tools.bat
-if not defined CMD_GIT call :Git 2> nul
-if not defined CMD_7Z call :7z 2> nul
-if not defined CMD_HHC call :hhc 2> nul
-if not defined CMD_ISCC call :iscc 2> nul
+if not defined CMD_GIT      call :Git      2> nul
+if not defined CMD_7Z       call :7z       2> nul
+if not defined CMD_HHC      call :hhc      2> nul
+if not defined CMD_ISCC     call :iscc     2> nul
 if not defined CMD_CPPCHECK call :cppcheck 2> nul
-if not defined CMD_DOXYGEN call :doxygen 2> nul
-if not defined CMD_VSWHERE call :vswhere 2> nul
-if not defined CMD_MSBUILD call :msbuild 2> nul
-if not defined CMD_CMAKE   call :cmake   2> nul
+if not defined CMD_DOXYGEN  call :doxygen  2> nul
+if not defined CMD_VSWHERE  call :vswhere  2> nul
+if not defined CMD_MSBUILD  call :msbuild  2> nul
+if not defined CMD_CMAKE    call :cmake    2> nul
+if not defined CMD_NINJA    call :cmake    2> nul
 echo ^|- CMD_GIT=%CMD_GIT%
 echo ^|- CMD_7Z=%CMD_7Z%
 echo ^|- CMD_HHC=%CMD_HHC%
@@ -42,7 +46,7 @@ echo ^|- CMD_DOXYGEN=%CMD_DOXYGEN%
 echo ^|- CMD_VSWHERE=%CMD_VSWHERE%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
 echo ^|- CMD_CMAKE=%CMD_CMAKE%
-echo ^|- PARAM_VSVERSION=%PARAM_VSVERSION%
+echo ^|- CMD_NINJA=%CMD_NINJA%
 echo ^|- CMAKE_G_PARAM=%CMAKE_G_PARAM%
 endlocal ^
     && set "CMD_GIT=%CMD_GIT%"                  ^
@@ -54,8 +58,8 @@ endlocal ^
     && set "CMD_VSWHERE=%CMD_VSWHERE%"          ^
     && set "CMD_MSBUILD=%CMD_MSBUILD%"          ^
     && set "CMD_CMAKE=%CMD_CMAKE%"              ^
+    && set "CMD_NINJA=%CMD_NINJA%"              ^
     && set "NUM_VSVERSION=%NUM_VSVERSION%"      ^
-    && set "PARAM_VSVERSION=%PARAM_VSVERSION%"  ^
     && set "CMAKE_G_PARAM=%CMAKE_G_PARAM%"      ^
     && echo end
 
@@ -138,81 +142,113 @@ for /f "usebackq delims=" %%a in (`where $PATH2:vswhere.exe`) do (
 exit /b
 
 :: ---------------------------------------------------------------------------------------------------------------------
-:: sub routine for get latest version
+:: sub routine for finding msbuild
+::
+:: ARG_VSVERSION
+::     latest => the latest version of installed Visual Studio
+::     2017   => Visual Studio 2017
+::     2019   => Visual Studio 2019
+::     15     => Visual Studio 2017
+::     16     => Visual Studio 2019
 :: ---------------------------------------------------------------------------------------------------------------------
+:msbuild
+	:: convert productLineVersion to Internal Major Version
+	if "%ARG_VSVERSION%" == "" (
+		set NUM_VSVERSION=15
+	) else if "%ARG_VSVERSION%" == "2017" (
+		set NUM_VSVERSION=15
+	) else if "%ARG_VSVERSION%" == "2019" (
+		set NUM_VSVERSION=16
+	) else if "%ARG_VSVERSION%" == "latest" (
+		call :check_latest_installed_vsversion
+	) else (
+		set NUM_VSVERSION=%ARG_VSVERSION%
+	)
+
+	call :check_installed_vsversion
+
+	call :find_msbuild
+	if not exist "%CMD_MSBUILD%" (
+		call :find_msbuild_legacy
+		set NUM_VSVERSION=15
+	)
+
+	if "%NUM_VSVERSION%" == "15" (
+		set NUM_VSVERSION=15
+		set CMAKE_G_PARAM=Visual Studio 15 2017
+		
+	) else if "%NUM_VSVERSION%" == "16" (
+		set NUM_VSVERSION=16
+		set CMAKE_G_PARAM=Visual Studio 16 2019
+		
+	) else (
+		echo Visual Studio Version %NUM_VERSION% is not supported.
+		exit /b 1
+		
+	)
+	exit /b
+
+:check_latest_installed_vsversion
+	for /f "usebackq delims=" %%v in (`"%CMD_VSWHERE%" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion -latest`) do (
+		set VSVERSION=%%v
+	)
+	set NUM_VSVERSION=%VSVERSION:~0,2%
+	exit /b
+
+:check_installed_vsversion
+	set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
+	for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
+		if exist "%%d" exit /b
+	)
+	call :check_latest_installed_vsversion
+	exit /b
+
 :find_msbuild
-	for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
+	set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
+	for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
 	    set "CMD_MSBUILD=%%a"
 	)
 	if exist "%CMD_MSBUILD%" (
 		exit /b
 	)
 	set CMD_MSBUILD=
-
-	for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath`) do (
-	    set "Vs2017InstallRoot=%%d"
-	)
-	if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe" (
-	    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe"
-	    if defined CMD_MSBUILD exit /b
-	)
-	if exist "%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe" (
-	    set "CMD_MSBUILD=%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe"
-	    if defined CMD_MSBUILD exit /b
-	)
 	exit /b
 
-:: ---------------------------------------------------------------------------------------------------------------------
-:: sub routine for finding msbuild
-::
-:: ARG_VSVERSION
-::     latest => the latest version of installed Visual Studio
-::     15   => Visual Studio 2017
-::     16   => Visual Studio 2019
-::     2017 => Visual Studio 2017
-::     2019 => Visual Studio 2019
-:: ---------------------------------------------------------------------------------------------------------------------
-:msbuild
-	:: convert productLineVersion to Internal Major Version
-	if "%ARG_VSVERSION%" == "latest" (
-		set NUM_VSVERSION=
-		set CMAKE_G_PARAM=
-		set PARAM_VSVERSION=
-
-	) else if "%ARG_VSVERSION%" == "" (
-		set NUM_VSVERSION=15
-		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
-		set CMAKE_G_PARAM=Visual Studio 15 2017
-
-	) else if "%ARG_VSVERSION%" == "15" (
-		set NUM_VSVERSION=15
-		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
-		set CMAKE_G_PARAM=Visual Studio 15 2017
-		
-	) else if "%ARG_VSVERSION%" == "16" (
-		set NUM_VSVERSION=16
-		set PARAM_VSVERSION=/p:VisualStudioVersion=16.0
-		set CMAKE_G_PARAM=Visual Studio 16 2019
-		
-	) else if "%ARG_VSVERSION%" == "2017" (
-		set NUM_VSVERSION=15
-		set PARAM_VSVERSION=/p:VisualStudioVersion=15.0
-		set CMAKE_G_PARAM=Visual Studio 15 2017
-		
-	) else if "%ARG_VSVERSION%" == "2019" (
-		set NUM_VSVERSION=16
-		set PARAM_VSVERSION=/p:VisualStudioVersion=16.0
-		set CMAKE_G_PARAM=Visual Studio 16 2019
-		
+:find_msbuild_legacy
+	for /f "usebackq delims=" %%d in (`"%CMD_VSWHERE%" -requires Microsoft.Component.MSBuild -property installationPath -version [15^,16^)`) do (
+	    set "CMD_MSBUILD=%%d\MSBuild\15.0\Bin\MSBuild.exe"
 	)
-	call :find_msbuild
+	if exist "%CMD_MSBUILD%" (
+		exit /b
+	)
+	set CMD_MSBUILD=
 	exit /b
 
 :cmake
+for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -property installationPath -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
+    pushd "%%a"
+    call "%%a\Common7\Tools\vsdevcmd\ext\cmake.bat"
+    call :resolve_cmake
+    call :resolve_ninja
+    popd
+	exit /b
+)
+exit /b
+
+:resolve_cmake
+if exist "%CMD_CMAKE%" goto :EOF
 set APPDIR=CMake\bin
 set PATH2=%PATH%;%ProgramFiles%\%APPDIR%\;%ProgramFiles(x86)%\%APPDIR%\;%ProgramW6432%\%APPDIR%\;
 for /f "usebackq delims=" %%a in (`where $PATH2:cmake`) do ( 
     set "CMD_CMAKE=%%a"
-    exit /b
+	exit /b
+)
+exit /b
+
+:resolve_ninja
+if exist "%CMD_NINJA%" goto :EOF
+for /f "usebackq delims=" %%a in (`where $PATH:ninja`) do ( 
+    set "CMD_NINJA=%%a"
+	exit /b
 )
 exit /b

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -1,9 +1,11 @@
-﻿- [ビルド関連ツールのパスを探す](#%E3%83%93%E3%83%AB%E3%83%89%E9%96%A2%E9%80%A3%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AE%E3%83%91%E3%82%B9%E3%82%92%E6%8E%A2%E3%81%99)
-  - [外部ツールの一覧](#%E5%A4%96%E9%83%A8%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AE%E4%B8%80%E8%A6%A7)
-  - [MSBuild以外の探索手順](#msbuild%E4%BB%A5%E5%A4%96%E3%81%AE%E6%8E%A2%E7%B4%A2%E6%89%8B%E9%A0%86)
+﻿- [ビルド関連ツールのパスを探す](#%e3%83%93%e3%83%ab%e3%83%89%e9%96%a2%e9%80%a3%e3%83%84%e3%83%bc%e3%83%ab%e3%81%ae%e3%83%91%e3%82%b9%e3%82%92%e6%8e%a2%e3%81%99)
+  - [外部ツールの一覧](#%e5%a4%96%e9%83%a8%e3%83%84%e3%83%bc%e3%83%ab%e3%81%ae%e4%b8%80%e8%a6%a7)
+  - [MSBuild以外の探索手順](#msbuild%e4%bb%a5%e5%a4%96%e3%81%ae%e6%8e%a2%e7%b4%a2%e6%89%8b%e9%a0%86)
   - [MSBuild](#msbuild)
-    - [参照](#%E5%8F%82%E7%85%A7)
-  - [zipの処理に7zではなくPowerShellを強制する](#zip%E3%81%AE%E5%87%A6%E7%90%86%E3%81%AB7z%E3%81%A7%E3%81%AF%E3%81%AA%E3%81%8Fpowershell%E3%82%92%E5%BC%B7%E5%88%B6%E3%81%99%E3%82%8B)
+    - [ユーザーがビルドに使用する Visual Studio のバージョンを切り替える方法](#%e3%83%a6%e3%83%bc%e3%82%b6%e3%83%bc%e3%81%8c%e3%83%93%e3%83%ab%e3%83%89%e3%81%ab%e4%bd%bf%e7%94%a8%e3%81%99%e3%82%8b-visual-studio-%e3%81%ae%e3%83%90%e3%83%bc%e3%82%b8%e3%83%a7%e3%83%b3%e3%82%92%e5%88%87%e3%82%8a%e6%9b%bf%e3%81%88%e3%82%8b%e6%96%b9%e6%b3%95)
+    - [検索ロジック](#%e6%a4%9c%e7%b4%a2%e3%83%ad%e3%82%b8%e3%83%83%e3%82%af)
+    - [参照](#%e5%8f%82%e7%85%a7)
+  - [zipの処理に7zではなくPowerShellを強制する](#zip%e3%81%ae%e5%87%a6%e7%90%86%e3%81%ab7z%e3%81%a7%e3%81%af%e3%81%aa%e3%81%8fpowershell%e3%82%92%e5%bc%b7%e5%88%b6%e3%81%99%e3%82%8b)
 
 # ビルド関連ツールのパスを探す
 外部ツールの実行ファイルの位置を探し、見つかれば環境変数にセットします。現在パスが通っている場所と、インストーラがデフォルトでインストールする場所が検索されます。詳細は[MSBuild以外の探索手順](#msbuild%E4%BB%A5%E5%A4%96%E3%81%AE%E6%8E%A2%E7%B4%A2%E6%89%8B%E9%A0%86)の項目を参照してください。
@@ -49,18 +51,26 @@ MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。
 
 ### 検索ロジック
 
-1. ```vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe``` で MSBuild.exe を検索する
-2. VS2019 以降の vswhere の場合
-  2.1 MSBuild.exe が見つかる。→ 検索終了
-3. VS2017 の vswhere の場合
-  3.1 ```vswhere -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath``` で VS2017 のインストールパスを検索する
-  3.2 ```%Vs2017InstallRoot%\MSBuild\15.0\Bin\amd64\MSBuild.exe``` が存在する場合そのパスを MSBuild.exe のパスとする
-  3.3 ```%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe``` が存在する場合そのパスを MSBuild.exe のパスとする
-
-### MSBuild.exe の引数
-
-```PARAM_VSVERSION``` の環境変数に ```/p:VisualStudioVersion=XXX``` をセットして MSBuild.exe に渡すことにより
-実際にビルドに使用する Visual Studio のバージョンを切り替える。
+1. `ARG_VSVERSION` から`VC++`のバージョン指定を判断する。
+  1.1.  `ARG_VSVERSION` 未指定の場合、`15`が指定されたものとみなす。
+  1.2.  `ARG_VSVERSION` が`2017`の場合、`15`が指定されたものとみなす。
+  1.3.  `ARG_VSVERSION` が`2019`の場合、`16`が指定されたものとみなす。
+  1.4.  `ARG_VSVERSION` が`latest`の場合、最新バージョンを取得する。
+  1.3.  `ARG_VSVERSION` が上記以外の場合、`ARG_VSVERSION` の値をバージョン指定とみなす。
+2. 指定されたバージョンのVC++がインストールされているかチェックする。  
+  2.1.  ```vswhere -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -version [指定されたバージョン, 指定されたバージョン+1)``` を実行する。
+  2.2.  取得したパスが存在していたら、バージョン指定は正しいとみなす。
+  2.3.  取得したパスが存在していなかったら、最新バージョンを取得する。
+3. インストール済みのVC++の最新バージョンを取得する。
+  3.1.  ```vswhere -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion -latest``` を実行する。
+  3.2.  取得したバージョンが指定されたものとみなす。
+4. ```vswhere -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe -version [指定されたバージョン, 指定されたバージョン+1)``` で MSBuild.exe を検索する
+  4.1. `vswhere` が VS2019 以降の `vswhere` の場合、`MSBuild.exe` が見つかるので検索終了
+  4.2. `vswhere` が VS2017 以前の `vswhere` の場合、エラーになるので検索続行
+5. VS2017 の vswhere の場合
+  5.1 ```vswhere -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath``` で VS2017 のインストールパスを検索する
+  5.2 ```%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe``` が存在する場合そのパスを MSBuild.exe のパスとする
+  5.3 この場合、バージョンは`15`が指定されたものとみなす。
 
 ### 参照
 * https://github.com/Microsoft/vswhere

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -1,11 +1,9 @@
-﻿- [ビルド関連ツールのパスを探す](#%e3%83%93%e3%83%ab%e3%83%89%e9%96%a2%e9%80%a3%e3%83%84%e3%83%bc%e3%83%ab%e3%81%ae%e3%83%91%e3%82%b9%e3%82%92%e6%8e%a2%e3%81%99)
-  - [外部ツールの一覧](#%e5%a4%96%e9%83%a8%e3%83%84%e3%83%bc%e3%83%ab%e3%81%ae%e4%b8%80%e8%a6%a7)
-  - [MSBuild以外の探索手順](#msbuild%e4%bb%a5%e5%a4%96%e3%81%ae%e6%8e%a2%e7%b4%a2%e6%89%8b%e9%a0%86)
+﻿- [ビルド関連ツールのパスを探す](#%E3%83%93%E3%83%AB%E3%83%89%E9%96%A2%E9%80%A3%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AE%E3%83%91%E3%82%B9%E3%82%92%E6%8E%A2%E3%81%99)
+  - [外部ツールの一覧](#%E5%A4%96%E9%83%A8%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AE%E4%B8%80%E8%A6%A7)
+  - [MSBuild以外の探索手順](#msbuild%E4%BB%A5%E5%A4%96%E3%81%AE%E6%8E%A2%E7%B4%A2%E6%89%8B%E9%A0%86)
   - [MSBuild](#msbuild)
-    - [ユーザーがビルドに使用する Visual Studio のバージョンを切り替える方法](#%e3%83%a6%e3%83%bc%e3%82%b6%e3%83%bc%e3%81%8c%e3%83%93%e3%83%ab%e3%83%89%e3%81%ab%e4%bd%bf%e7%94%a8%e3%81%99%e3%82%8b-visual-studio-%e3%81%ae%e3%83%90%e3%83%bc%e3%82%b8%e3%83%a7%e3%83%b3%e3%82%92%e5%88%87%e3%82%8a%e6%9b%bf%e3%81%88%e3%82%8b%e6%96%b9%e6%b3%95)
-    - [検索ロジック](#%e6%a4%9c%e7%b4%a2%e3%83%ad%e3%82%b8%e3%83%83%e3%82%af)
-    - [参照](#%e5%8f%82%e7%85%a7)
-  - [zipの処理に7zではなくPowerShellを強制する](#zip%e3%81%ae%e5%87%a6%e7%90%86%e3%81%ab7z%e3%81%a7%e3%81%af%e3%81%aa%e3%81%8fpowershell%e3%82%92%e5%bc%b7%e5%88%b6%e3%81%99%e3%82%8b)
+    - [参照](#%E5%8F%82%E7%85%A7)
+  - [zipの処理に7zではなくPowerShellを強制する](#zip%E3%81%AE%E5%87%A6%E7%90%86%E3%81%AB7z%E3%81%A7%E3%81%AF%E3%81%AA%E3%81%8Fpowershell%E3%82%92%E5%BC%B7%E5%88%B6%E3%81%99%E3%82%8B)
 
 # ビルド関連ツールのパスを探す
 外部ツールの実行ファイルの位置を探し、見つかれば環境変数にセットします。現在パスが通っている場所と、インストーラがデフォルトでインストールする場所が検索されます。詳細は[MSBuild以外の探索手順](#msbuild%E4%BB%A5%E5%A4%96%E3%81%AE%E6%8E%A2%E7%B4%A2%E6%89%8B%E9%A0%86)の項目を参照してください。
@@ -51,26 +49,27 @@ MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。
 
 ### 検索ロジック
 
-1. `ARG_VSVERSION` から`VC++`のバージョン指定を判断する。
-  1.1.  `ARG_VSVERSION` 未指定の場合、`15`が指定されたものとみなす。
-  1.2.  `ARG_VSVERSION` が`2017`の場合、`15`が指定されたものとみなす。
-  1.3.  `ARG_VSVERSION` が`2019`の場合、`16`が指定されたものとみなす。
-  1.4.  `ARG_VSVERSION` が`latest`の場合、最新バージョンを取得する。
-  1.3.  `ARG_VSVERSION` が上記以外の場合、`ARG_VSVERSION` の値をバージョン指定とみなす。
-2. 指定されたバージョンのVC++がインストールされているかチェックする。  
-  2.1.  ```vswhere -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -version [指定されたバージョン, 指定されたバージョン+1)``` を実行する。
-  2.2.  取得したパスが存在していたら、バージョン指定は正しいとみなす。
-  2.3.  取得したパスが存在していなかったら、最新バージョンを取得する。
-3. インストール済みのVC++の最新バージョンを取得する。
-  3.1.  ```vswhere -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion -latest``` を実行する。
-  3.2.  取得したバージョンが指定されたものとみなす。
-4. ```vswhere -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe -version [指定されたバージョン, 指定されたバージョン+1)``` で MSBuild.exe を検索する
-  4.1. `vswhere` が VS2019 以降の `vswhere` の場合、`MSBuild.exe` が見つかるので検索終了
-  4.2. `vswhere` が VS2017 以前の `vswhere` の場合、エラーになるので検索続行
-5. VS2017 の vswhere の場合
-  5.1 ```vswhere -version [15^,16^) -requires Microsoft.Component.MSBuild -property installationPath``` で VS2017 のインストールパスを検索する
-  5.2 ```%Vs2017InstallRoot%\MSBuild\15.0\Bin\MSBuild.exe``` が存在する場合そのパスを MSBuild.exe のパスとする
-  5.3 この場合、バージョンは`15`が指定されたものとみなす。
+1. `ARG_VSVERSION` から`VC++`のバージョン指定(`NUM_VSVERSION`)を判断する。
+	1. `ARG_VSVERSION` 未指定の場合、`15`が指定されたものとみなす。
+	1. `ARG_VSVERSION` が`2017`の場合、`15`が指定されたものとみなす。
+	1. `ARG_VSVERSION` が`2019`の場合、`16`が指定されたものとみなす。
+	1. `ARG_VSVERSION` が`latest`の場合、最新バージョンを取得する。
+	1. `ARG_VSVERSION` が上記以外の場合、`%ARG_VSVERSION%`が指定されたものとみなす。
+1. 指定されたバージョンのVC++がインストールされているかチェックする。  
+	1. `vswhere -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -version [%NUM_VSVERSION%, %NUM_VSVERSION% + 1)` を実行する。
+	1. 取得したパスが存在していたら、バージョン指定(`NUM_VSVERSION`)は正しいとみなす。
+	1. 取得したパスが存在していなかったら、最新バージョンを取得する。
+1. インストール済み`VC++`の最新バージョンを取得する。
+	1.  `vswhere -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion -latest` を実行する。
+	1.  取得したバージョンが指定されたものとみなす。(`NUM_VSVERSION`に代入する。)
+1. 指定されたバージョンの`MsBuild.exe`を検索する。
+	1. `-find`オプションを付けて`MsBuild.exe`を検索する。(`vswhere -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe -version [%NUM_VSVERSION%, %NUM_VSVERSION% + 1)`)
+	1. `vswhere` が VS2019 以降ver の場合、`MSBuild.exe` が見つかるので検索終了。
+	1. `vswhere` が VS2017 以前ver の場合、`MSBuild.exe` が見つからない(エラーになる)ので検索続行。
+1. VS2017 の `MsBuild.exe` を検索する。
+	1. VS2017 のインストールパスを検索する。(`vswhere -requires Microsoft.Component.MSBuild -property installationPath -version [15^,16^)`)
+	1. VS2017 のインストールパス配下の所定位置(`%Vs2017InstallRoot%\MSBuild\15.0\Bin`)に`MSBuild.exe`が存在する場合、そのパスを `MSBuild.exe` のパスとみなす。
+		この場合、バージョン指定(`NUM_VSVERSION`)に`15`が指定されたものとみなす。
 
 ### 参照
 * https://github.com/Microsoft/vswhere


### PR DESCRIPTION
# PR の目的
tests1プロジェクトで使っているgoogletestのビルドコマンドを書き直して、今後のメンテナンスをやりやすくします。

## カテゴリ
- その他

## PR の背景
サクラエディタはvs2017とvs2019の両方でビルドできるようになっています。

ただ、vs2017とvs2019の両方に対応させることは意外と難しく、
これまでにも色々な問題が発生してきた経緯があります。

当面、vs2017でビルドできないようにする予定はありません。

しかし、もっと簡単にメンテナンスできるようにしたいです。

このPRでは、従来visual studioのMSBuildタスクで行っていたビルド処理をバッチ側に移動してIDEビルドとBatchビルドの差をなくし、バッチさえ読めればtestsビルドのメンテナンスができるように変更します。

### 重要な変更点
- googletest.targetに記述していたビルド処理をgoogletest.build.cmdに移動します。
- googletest.build.cmd から VC++ の `vcvartall.bat` への依存を無くします。
- googletest.build.cmd に `tools\find-tools.bat` への依存を追加します。
- `tools\find-tools.bat` が参照する環境変数パラメータ `ARG_VSVERSION` の意味を変更します。  
旧： `MsBuild` を有効にしてインストールされた、 Visual Studio のバージョン  
新： `C++によるデスクトップ開発` を有効にしてインストールされた、 Visual Studio のバージョン(MsBuildでなくVCToolsetのバージョンを見るように変更します。)
- `tools\find-tools.bat` に `clear` 以外の引数を渡した場合に、その値を`ARG_VSVERSION` とみなすように変更します。
- `tools\find-tools.bat` の cmake 検索機能を強化します。  
旧： PATHが通っている、または、単体インストールした cmake を検索します。  
新： PATHが通っている、または、単体インストールした cmake 、または、Visual Studio に付属する cmake を検索します。
- `tools\find-tools.bat` に ninja 検索機能を追加します。  
PATHが通っている、または、Visual Studio に付属する ninja を検索します。
- googletest のビルド成果物を `tools/` 配下に「インストール」するように変更します。  
cmake generator を変えるとビルド成果物の出力先が変わってしまうトラブルを考慮しなくて済むようになります。(どんなツールを使ってビルドしても、利用するためのフォルダ構成（＝インストール構成）は同じになるから。)

## PR のメリット

<!-- PR のメリットを記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
- ビルド処理がバッチスクリプトに集約され、メンテナンスの難易度が下がります。
- #1164 で報告されているビルドエラーが解消されます。

## PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- #1143 で導入した「インストールされている最新のMsBuild.exeを使うようにし、VC++バージョンは `/p:VisualStudioVersion` で制御する」のコンセプトを覆します。
- 修正内容がかなり高度です。  
自分がレビューするとして、詳細を理解できる自信はありません。  
とりあえず動かしてみて、なんかあったらダメ出しする、で行くしかない気がします。

## PR の影響範囲
- アプリ（＝サクラエディタ）の機能に影響はありません。
- Visual Studio IDEによるビルドに影響します。
- バッチ(`build-sln.bat`)によるビルドに影響します。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->
ommit #1143
close #1164

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk2001
https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line
https://docs.microsoft.com/bs-latn-ba/visualstudio/msbuild/setenv-task
https://devblogs.microsoft.com/cppblog/finding-the-visual-c-compiler-tools-in-visual-studio-2017/
https://gist.github.com/mignonstyle/083c9e1651d7734f84c99b8cf49d57fa
