### PR TITLE
コピー代入のメソッド名を書き間違っているのを訂正

### DIFF
--- a/sakura_core/macro/CPPAMacroMgr.cpp
+++ b/sakura_core/macro/CPPAMacroMgr.cpp
@@ -73,7 +73,7 @@ BOOL CPPAMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const WCHAR* pszPath )
 */
 BOOL CPPAMacroMgr::LoadKeyMacroStr( HINSTANCE hInstance, const WCHAR* pszCode )
 {
-	m_cBuffer.SetNativeData( pszCode );	//	m_cBufferにコピー
+	m_cBuffer.SetString( pszCode );	//	m_cBufferにコピー
 
 	m_nReady = true;
 	return TRUE;


### PR DESCRIPTION
# PR の目的
コピー代入のメソッド名を書き間違っているのを訂正します。

## カテゴリ
- その他

メソッド名の書き間違いですが、実害はないので「その他」としています。
「不具合修正」にすると変な話になる気がするので。

## PR の背景
`CNativeW` には文字列をコピーするためのメソッドがたくさんあります。

- `CNativeW::SetNativeData(const CNativeW& rhs)`
  - 指定された `CNativeW` をコピーするメソッド。
- `CNativeW::SetString(const WCHAR* rhs)`
  - 指定された `C-String` をコピーするメソッド。

このPRで提案する修正箇所は、
引数で指定された `C-String` をコピーする処理に、
指定された `CNativeW` をコピーするメソッドを使っています。

現状、`CNativeW` のコンストラクタはimplicitなのでコンパイルエラーにはなりませんが、メソッドの利用方法が誤っています。

他の修正と混ぜると説明がめんどくさそうなので先出しで修正提案しておく次第です。

## PR のメリット

<!-- PR のメリットを記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
- `CNativeW::SetNativeData(const CNativeW& rhs)`メソッドの誤用箇所を潰せます。
  - 幸いなことに、誤用はここだけっす。

## PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- 改修箇所の効果確認を実施することがかなり難しいです。
  - 詳細は影響範囲の項を参照。
  - 机上確認できる「単なる誤り」なので「えいやっ！」でやってもいい気はします。

## PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
- アプリ（＝サクラエディタ）の機能に影響はありません。
- 修正箇所は PPA(=Poor Pascal for Application) マクロのコントローラクラスです。
  - PPAマクロを動かすには、`ppa.dll` の動作環境を整える必要があります。
  - `ppa.dll` には 64bit 版がないので、動作は 32bit 版のみとなります。
  - 改修箇所のコードを動かすには、マクロからppaスクリプトを実行する必要があります。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
