### PR TITLE
UNICODE一本化対応で見落としていたA版専用処理を削りたい

### DIFF
--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -278,13 +278,6 @@ public:
 	CPixelXInt GetWidthPerKeta() const { return Int(m_nCharLayoutXPerKeta); }
 	CPixelXInt GetCharSpacing() const { return m_nSpacing; }
 
-protected:
-	/*
-	||  参照系
-	*/
-	const char* GetFirstLinrStr( int* );	/* 順アクセスモード：先頭行を得る */
-	const char* GetNextLinrStr( int* );	/* 順アクセスモード：次の行を得る */
-
 	/*
 	|| 更新系
 	*/

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -755,29 +755,7 @@ static void ConvertLangString( wchar_t* pBuf, size_t chBufSize, std::wstring& or
 	pBuf[chBufSize - 1] = L'\0';
 }
 
-static void ConvertLangString( char* pBuf, size_t chBufSize, std::wstring& org, std::wstring& to )
-{
-	CNativeA mem;
-	mem.SetString(pBuf);
-	mem.Replace_j(to_achar(org.c_str()), to_achar(to.c_str()));
-	strncpy(pBuf, mem.GetStringPtr(), chBufSize);
-	pBuf[chBufSize - 1] = '\0';
-}
-
 static void ConvertLangValueImpl( wchar_t* pBuf, size_t chBufSize, int nStrId, std::vector<std::wstring>& values, int& index, bool setValues, bool bUpdate )
-{
-	if( setValues ){
-		if( bUpdate ){
-			values.push_back( LS(nStrId) );
-		}
-		return;
-	}
-	std::wstring to = LS(nStrId);
-	ConvertLangString( pBuf, chBufSize, values[index], to );
-	index++;
-}
-
-static void ConvertLangValueImpl( char* pBuf, size_t chBufSize, int nStrId, std::vector<std::wstring>& values, int& index, bool setValues, bool bUpdate )
 {
 	if( setValues ){
 		if( bUpdate ){

--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -131,35 +131,3 @@ char CNativeA::operator[](int nIndex) const
 		return 0;
 	}
 }
-
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//              ネイティブ変換インターフェース                 //
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-
-/* 文字列置換（日本語考慮版） */
-void CNativeA::Replace_j( const char* pszFrom, const char* pszTo )
-{
-	CNativeA	cmemWork;
-	int			nFromLen = strlen( pszFrom );
-	int			nToLen = strlen( pszTo );
-	int			nBgnOld = 0;
-	int			nBgn = 0;
-	while( nBgn <= GetStringLength() - nFromLen ){
-		if( 0 == memcmp( &GetStringPtr()[nBgn], pszFrom, nFromLen ) ){
-			if( 0  < nBgn - nBgnOld ){
-				cmemWork.AppendString( &GetStringPtr()[nBgnOld], nBgn - nBgnOld );
-			}
-			cmemWork.AppendString( pszTo, nToLen );
-			nBgn = nBgn + nFromLen;
-			nBgnOld = nBgn;
-		}else{
-			if( _IS_SJIS_1( (unsigned char)GetStringPtr()[nBgn] ) ) nBgn++;
-			nBgn++;
-		}
-	}
-	if( 0  < GetStringLength() - nBgnOld ){
-		cmemWork.AppendString( &GetStringPtr()[nBgnOld], GetStringLength() - nBgnOld );
-	}
-	SetNativeData( cmemWork );
-	return;
-}

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -61,12 +61,4 @@ public:
 	CNativeA& operator = (CNativeA&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeA>(rhs)); return *this; }
 	const CNativeA& operator=( char );
 	const CNativeA& operator+=( char );
-
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                           変換                              //
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-
-	//ネイティブ変換
-	void Replace_j( const char* pszFrom, const char* pszTo ); //!< 文字列置換（日本語考慮版）
-
 };


### PR DESCRIPTION
# PR の目的
UNICODE一本化対応で見落としていたA版専用処理を削って、コードベースをシンプルにします。

## カテゴリ
- リファクタリング(未使用関数の除去、です。)

## PR の背景

- `CShareData.cpp` のリソース文字列置換関数を削除。
  - 言語切替時にメモリに展開したリソース文字列を置換するためのもの。
  - リソースに含まれる文字列のW⇒A変換処理を削ったので現在未使用。
  - `CNativeA::Replace_j` はこの処理のためだけに存在していたので一緒に削る。
- `CLayoutMgr` の未使用の関数宣言を削除。
  - 内部データのUNICODE化はだいぶ前に完了しているので現在未使用。

## PR のメリット

<!-- PR のメリットを記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

## PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- とくにありません。

まぁ、強いて言うと「まだ他にもある（かも」ってことですが、新たに見つかったらそれはその時対応すればいいと思っています。

## PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
- アプリ（＝サクラエディタ）の機能に影響はありません。
- 未使用関数の除去なので、実用上の影響は無視できる程度と思われます。
  - 原理的にはソースコードが減る分だけコンパイル時間が短縮されるはずですが、人間が感知できるほどの差はなさそうに思います。（検証するメリットを感じないので検証してません。
  - コンパイル済みobjectのリンク工程において、参照されないシンボルはリンク対象から外されます。関数削除によって「参照されない」→「ない」の変化が生じますが、この影響も非常に軽微なものと考えられます。（検証するメリットを感じないので検証してません。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->
#1034 Unicode版のみのサポートなので、ANSI/UNICODE両対応を廃止したい 
#1038 Unicode一本化対応の残課題を拾い集めてissueを立てる refactoring  
#1139 CDataProfileの未使用コード(ANSI版)を削除する 

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
