### PR TITLE
wstringをWCHAR[N]にコピーする処理でNUL終端が付かない不具合を修正

### DIFF
--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -630,7 +630,7 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 	{
 		//1行読み込み
 		wstring line=in.ReadLineW();
-		line.copy( buff, line.length(), 0 );
+		line.copy( buff, line.length() + 1, 0 );
 
 		if(count >= MAX_REGEX_KEYWORD){
 			sErrMsg = LS(STR_IMPEXP_REGEX1);

--- a/sakura_core/typeprop/CPropTypesKeyHelp.cpp
+++ b/sakura_core/typeprop/CPropTypesKeyHelp.cpp
@@ -235,7 +235,7 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 					}
 					// 開けたなら1行目を取得してから閉じる -> szAbout
 					std::wstring line=in.ReadLineW();
-					line.copy( szAbout, line.length(), 0 );
+					line.copy( szAbout, line.length() + 1, 0 );
 					in.Close();
 				}
 				strcnv(szAbout);


### PR DESCRIPTION
# PR の目的
PR #1034 で入れた不具合を修正します。

## カテゴリ
- 不具合修正

## PR の背景

https://github.com/sakura-editor/sakura/issues/1234#issuecomment-617474861 参照。

修正対象は正規表現で抽出しました。

`m/\b(.+?)\s*\.\s*copy\s*\(\s*(.+?)\s*,\s*\1\s*\.\s*length\s*\(\s*\)/`

対象は2箇所です。

## PR のメリット

<!-- PR のメリットを記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
- #1234 で報告された不具合が直ります。

## PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- 特にありません。

## PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->
- 以下のアプリ（＝サクラエディタ）の機能に影響します。
  - タイプ別設定 - キーワードヘルプ一覧ダイアログ(プロパティページ)
  - タイプ別設定 インポート処理

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->
close #1234
amend #1034

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
