### PR TITLE
SJISエンコードのキーワードヘルプ辞書を設定するとき表示化けする問題への対処

### DIFF
--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -630,7 +630,7 @@ bool CImpExpRegex::Import( const wstring& sFileName, wstring& sErrMsg )
 	{
 		//1行読み込み
 		wstring line=in.ReadLineW();
-		line.copy( buff, line.length() + 1, 0 );
+		wcsncpy_s( buff, line.c_str(), _TRUNCATE );
 
 		if(count >= MAX_REGEX_KEYWORD){
 			sErrMsg = LS(STR_IMPEXP_REGEX1);

--- a/sakura_core/typeprop/CPropTypesKeyHelp.cpp
+++ b/sakura_core/typeprop/CPropTypesKeyHelp.cpp
@@ -235,7 +235,7 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 					}
 					// 開けたなら1行目を取得してから閉じる -> szAbout
 					std::wstring line=in.ReadLineW();
-					line.copy( szAbout, line.length() + 1, 0 );
+					wcsncpy_s(szAbout, line.c_str(), line.size());
 					in.Close();
 				}
 				strcnv(szAbout);

--- a/sakura_core/typeprop/CPropTypesKeyHelp.cpp
+++ b/sakura_core/typeprop/CPropTypesKeyHelp.cpp
@@ -235,7 +235,7 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 					}
 					// 開けたなら1行目を取得してから閉じる -> szAbout
 					std::wstring line=in.ReadLineW();
-					wcsncpy_s(szAbout, line.c_str(), line.size());
+					wcsncpy_s(szAbout, line.c_str(), _TRUNCATE);
 					in.Close();
 				}
 				strcnv(szAbout);


### PR DESCRIPTION
# PR の目的

タイプ別設定ダイアログのキーワードヘルプのタブで、辞書ファイルの更新ボタンを押した際に文字化けする問題への対処です。

## カテゴリ

- 不具合修正

## PR の背景

#1234 のコメントに調査された内容が書かれてますが、元の記述では終端文字が付加されないっぽいです。標準C++ライブラリは分かりづらいので標準Cライブラリの関数を使うように変更しました。

## 関連チケット

#1234 #1235
