### PR TITLE
ステータスバーにテキストを設定する処理の調整

### DIFF
--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -832,7 +832,7 @@ void CCaret::ShowCaretPosInfo()
 		}
 
 		auto& statusBar = m_pEditDoc->m_pcEditWnd->m_cStatusBar;
-		::SendMessageAny(statusBar.GetStatusHwnd(), WM_SETREDRAW, (WPARAM)FALSE, 0);
+		::SendMessage(statusBar.GetStatusHwnd(), WM_SETREDRAW, (WPARAM)FALSE, 0);
 		if( m_bClearStatus ){
 			statusBar.SetStatusText( 0, SBT_NOBORDERS, L"" );
 		}
@@ -846,8 +846,8 @@ void CCaret::ShowCaretPosInfo()
 		statusBar.SetStatusText( 4, 0,             pszCodeName );
 		statusBar.SetStatusText( 5, SBT_OWNERDRAW, L"" );
 		statusBar.SetStatusText( 6, 0,             szText_6 );
-		::SendMessageAny(statusBar.GetStatusHwnd(), WM_SETREDRAW, (WPARAM)TRUE, 0);
-		RedrawWindow(statusBar.GetStatusHwnd(), NULL, NULL, RDW_ERASE | RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN);
+		::SendMessage(statusBar.GetStatusHwnd(), WM_SETREDRAW, (WPARAM)TRUE, 0);
+		::RedrawWindow(statusBar.GetStatusHwnd(), NULL, NULL, RDW_ERASE | RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN);
 	}
 }
 

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -832,7 +832,7 @@ void CCaret::ShowCaretPosInfo()
 		}
 
 		auto& statusBar = m_pEditDoc->m_pcEditWnd->m_cStatusBar;
-
+		::SendMessageAny(statusBar.GetStatusHwnd(), WM_SETREDRAW, (WPARAM)FALSE, 0);
 		if( m_bClearStatus ){
 			statusBar.SetStatusText( 0, SBT_NOBORDERS, L"" );
 		}
@@ -846,6 +846,8 @@ void CCaret::ShowCaretPosInfo()
 		statusBar.SetStatusText( 4, 0,             pszCodeName );
 		statusBar.SetStatusText( 5, SBT_OWNERDRAW, L"" );
 		statusBar.SetStatusText( 6, 0,             szText_6 );
+		::SendMessageAny(statusBar.GetStatusHwnd(), WM_SETREDRAW, (WPARAM)TRUE, 0);
+		RedrawWindow(statusBar.GetStatusHwnd(), NULL, NULL, RDW_ERASE | RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN);
 	}
 }
 

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -8,7 +8,6 @@ CMainStatusBar::CMainStatusBar(CEditWnd* pOwner)
 : m_pOwner(pOwner)
 , m_hwndStatusBar( NULL )
 , m_hwndProgressBar( NULL )
-, m_postponeBuffers( 7 )
 {
 }
 
@@ -162,9 +161,10 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 		if (bSendMessage) {
 			::SendMessageW( m_hwndStatusBar, SB_SETTEXT, nIndex | nOption, (LPARAM)pszText );
 		}else {
-			std::vector<wchar_t>& buffer = m_postponeBuffers[nIndex];
-			buffer.assign(pszText, pszText+textLen+1);
-			::PostMessageW( m_hwndStatusBar, SB_SETTEXT, nIndex | nOption, (LPARAM)buffer.data() );
+			std::unique_ptr<wchar_t[]> p(new wchar_t[textLen+1]);
+			std::copy(pszText, pszText+textLen+1, p.get());
+			::PostMessageW( m_hwndStatusBar, SB_SETTEXT, nIndex | nOption, (LPARAM)p.get() );
+			m_postponeBuffers[nIndex] = std::move(p);
 		}
 	};
 }

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -8,6 +8,7 @@ CMainStatusBar::CMainStatusBar(CEditWnd* pOwner)
 : m_pOwner(pOwner)
 , m_hwndStatusBar( NULL )
 , m_hwndProgressBar( NULL )
+, m_postponeBuffers( 7 )
 {
 }
 
@@ -161,10 +162,8 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 		if (bSendMessage) {
 			::SendMessageW( m_hwndStatusBar, SB_SETTEXT, nIndex | nOption, (LPARAM)pszText );
 		}else {
-			static std::vector<std::vector<wchar_t>> s_buffers(7);
-			std::vector<wchar_t>& buffer = s_buffers[nIndex];
-			buffer.resize(textLen+1);
-			std::copy(pszText, pszText+textLen+1, buffer.begin());
+			std::vector<wchar_t>& buffer = m_postponeBuffers[nIndex];
+			buffer.assign(pszText, pszText+textLen+1);
 			::PostMessageW( m_hwndStatusBar, SB_SETTEXT, nIndex | nOption, (LPARAM)buffer.data() );
 		}
 	};

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -113,8 +113,7 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 		assert(m_hwndStatusBar != NULL);
 		return;
 	}
-	// StatusBar_SetText 関数を呼びだすかどうかを判定するラムダ式
-	// （StatusBar_SetText は SB_SETTEXT メッセージを SendMessage で送信する）
+	// SB_SETTEXT メッセージを発行するかどうかを判定するラムダ式
 	bool bNeedsToDraw = [&]() -> bool {
 		// オーナードローの場合は SB_SETTEXT メッセージを無条件に発行するように判定
 		// 本来表示に変化が無い場合には呼び出さない方が表示のちらつきが減るので好ましいが
@@ -150,7 +149,7 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 			return true;
 		}
 		if( prevTextLen > 0 ){
-			::StatusBar_GetText( m_hwndStatusBar, nIndex, prev );
+			StatusBar_GetText( m_hwndStatusBar, nIndex, prev );
 			// 設定済みの文字列と設定する文字列を比較して異なる場合は、SB_SETTEXT メッセージを発行
 			return (wcscmp(prev, pszText) != 0);
 		}
@@ -160,13 +159,13 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 	}();
 	if (bNeedsToDraw) {
 		if (bSendMessage) {
-			SendMessageW( m_hwndStatusBar, SB_SETTEXT, nIndex | nOption, (LPARAM)pszText );
+			::SendMessageW( m_hwndStatusBar, SB_SETTEXT, nIndex | nOption, (LPARAM)pszText );
 		}else {
 			static std::vector<std::vector<wchar_t>> s_buffers(7);
 			std::vector<wchar_t>& buffer = s_buffers[nIndex];
 			buffer.resize(textLen+1);
 			std::copy(pszText, pszText+textLen+1, buffer.begin());
-			PostMessageW( m_hwndStatusBar, SB_SETTEXT, nIndex | nOption, (LPARAM)buffer.data() );
+			::PostMessageW( m_hwndStatusBar, SB_SETTEXT, nIndex | nOption, (LPARAM)buffer.data() );
 		}
 	};
 }

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -52,7 +52,7 @@ public:
 	HWND GetProgressHwnd() const{ return m_hwndProgressBar; }
 
 	//設定
-	void SetStatusText(int nIndex, int nOption, const WCHAR* pszText, size_t textLen = SIZE_MAX);
+	void SetStatusText(int nIndex, int nOption, const WCHAR* pszText, size_t textLen = SIZE_MAX, bool bSendMessage = true);
 private:
 	CEditWnd*	m_pOwner;
 	HWND		m_hwndStatusBar;

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include "doc/CDocListener.h"
+#include <array>
+#include <memory>
 
 class CEditWnd;
 
@@ -57,5 +59,5 @@ private:
 	CEditWnd*	m_pOwner;
 	HWND		m_hwndStatusBar;
 	HWND		m_hwndProgressBar;
-	std::vector<std::vector<wchar_t>> m_postponeBuffers;
+	std::array<std::unique_ptr<wchar_t[]>, 7> m_postponeBuffers;
 };

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -57,4 +57,5 @@ private:
 	CEditWnd*	m_pOwner;
 	HWND		m_hwndStatusBar;
 	HWND		m_hwndProgressBar;
+	std::vector<std::vector<wchar_t>> m_postponeBuffers;
 };


### PR DESCRIPTION
# PR の目的

ステータスバーにテキストを設定する処理の調整を行う事でパフォーマンスの改善を行うのが目的です。

入れた対策は、

- `SB_SETTEXT` を `SendMessage` ではなくて `PostMessage` を使って発行出来るように変更
  - `CMainStatusBar::SetStatusText` のデフォルト引数を増やして通常は `SendMessage` が使われますが、`PostMessage` で送れるようにもしました。
  - `PostMessage` を使う場合は静的変数にコピーしてから送るようにしています。
  - メッセージキューに送られたのが後で処理される場合に実際にCPU負荷が減るのか？とか色々と不明ですが、操作感は改善してる気がします。
- `CCaret::ShowCaretPosInfo` において、ステータスバーにテキストを設定する処理を複数回呼び出す箇所がありますが、その前後で `WM_SETREDRAW` メッセージを発行する事で負荷を下げる試みをしています。

## カテゴリ

- 速度向上

## PR の背景

Visual Studio の Performance Profiler でどの処理に時間が掛かってるかをたまにチェックしていますが、ステータスバーにテキストを設定する `CMainStatusBar::SetStatusText` のパーセンテージが結構高いです。

どんな操作を行うかによってどの部分の処理に時間が掛かるかというのは変わるものですが、大きいテキストファイル、例えば `sakura_core\sakura_rc.rc` を開いてドラッグ操作で選択範囲を広げながらスクロールし続ける操作で確認しました。

このPRの変更を入れた方がスムーズにスクロールが行われるように感じます。

## PR のメリット

- 操作感が軽快になる？

## PR のデメリット (トレードオフとかあれば)

- 実装がややこしくなる。
- メモリを少し追加で消費する

## 関連チケット

#452

## 参考資料

https://docs.microsoft.com/en-us/windows/win32/controls/sb-settext
https://docs.microsoft.com/en-us/windows/win32/gdi/wm-setredraw
