### PR TITLE
ユーザー指定ビットマップの縦横比制約を解除する

### DIFF
--- a/sakura_core/uiparts/CImageListMgr.cpp
+++ b/sakura_core/uiparts/CImageListMgr.cpp
@@ -600,10 +600,6 @@ HBITMAP CImageListMgr::ResizeToolIcons(
 	// DIBセクションからサイズを取得する
 	int cx = di.dsBm.bmWidth / cols;
 	int cy = di.dsBm.bmHeight / rows;
-	if ( cx != cy ) {
-		DEBUG_TRACE( L"tool bitmap size is unexpected." );
-		return NULL;
-	}
 
 	const int cxSmIcon = ::GetSystemMetrics( SM_CXSMICON );
 	const int cySmIcon = ::GetSystemMetrics( SM_CYSMICON );


### PR DESCRIPTION
# PR の目的

#1243 の不具合を解消します。


## カテゴリ

- 不具合修正

## PR の背景

v2.3.2（GitHub移行前最終版）。
 　　↓
ツールバーアイコンの拡大・縮小機能を実装。
 　　↓
v2.4.0リリース。
 　　↓
 2chに書き込み。
 　　↓
#1243 ツールバーのアイコン 2.4.0にアップデートしたら今まで使えてたのが使えなくなって全部空白になった
　　↓
#1245 ツールバーのアイコン 2.4.0にアップデートしたら今まで使えてたのが使えなくなって全部空白になったのを対策する
　　↓
このPR。

この問題の原因は、ツールバーアイコンの拡大・縮小機能の実装時に、ツールバーアイコンの縦横比（=aspect ratio)を固定で1:1としていたことにあります。

仕様的にもロジック的にも縦横比が1:1である必然はありませんので、
cx != cy はダメという制約を解除します。

このPRの対応により、今まで使えていたアイコンであればそのまま使えるようになります。

## PR のメリット

<!-- PR のメリットを記載してください。 -->
<!-- 自明な場合は省略してもいいですが、可能なら記載してほしいです。 -->

## PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## PR の影響範囲
- サクラエディタの設定フォルダに配置したmy_icons.bmp(=ユーザー指定ビットマップ)を配置した場合の挙動に影響します。
  - ユーザー指定ビットマップは 32列15行 のアイコン(=小さな画像)のかたまりです。
  - アイコンの縦横比が1:1(=正方形)でなければならない、という制約を撤廃します。

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->
#1243
#1245

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
