### PR TITLE
[WIP] 履歴コンボのDeleteキー押下動作を変更したい

### DIFF
--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -160,6 +160,47 @@ namespace ApiWrap{
 	inline int Combo_SetDroppedWidth(HWND hwndCtl, int width)			{ return (int)(DWORD)::SendMessage(hwndCtl, CB_SETDROPPEDWIDTH, (WPARAM)width, 0L); }
 	inline BOOL Combo_GetDroppedState(HWND hwndCtl)						{ return (BOOL)(DWORD)::SendMessage(hwndCtl, CB_GETDROPPEDSTATE, 0L, 0L ); }
 
+	inline bool Combo_GetLBText(HWND hwndCombo, int nIndex, CNativeW& str)
+	{
+		// バッファをクリアしておく
+		str.Clear();
+
+		// 範囲外は失敗にする
+		if (nIndex < 0)
+		{
+			return false;
+		}
+
+		// 文字列長を取得する、取得できなければエラー
+		const int length = Combo_GetLBTextLen( hwndCombo, nIndex );
+		if ( length == CB_ERR || length < 0)
+		{
+			return false;
+		}
+
+		// 必要なメモリを確保する
+		const int bufsize = length + 1;
+		str.AllocStringBuffer( bufsize );
+
+		// アイテムテキストを取得する
+		const int actualCount = (int)Combo_GetLBText( hwndCombo, nIndex, str.GetStringPtr() );
+		if (actualCount == CB_ERR || actualCount < 0)
+		{
+			return false;
+		}
+		else if(str.capacity() <= actualCount)
+		{
+			return false;
+		}
+
+		// CNativeW 内部のデータサイズを更新する
+		str._SetStringLength(actualCount);
+
+		// 正しく設定されているはず
+		assert(str.GetStringLength() == actualCount);
+		return true;
+	}
+
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      リストボックス                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -200,6 +200,16 @@ namespace ApiWrap{
 		assert(str.GetStringLength() == actualCount);
 		return true;
 	}
+	inline void Combo_GetEditSel( HWND hwndCombo, int &nSelStart, int &nSelEnd )
+	{
+		DWORD dwSelStart = 0;
+		DWORD dwSelEnd = 0;
+		::SendMessage( hwndCombo, CB_GETEDITSEL, WPARAM( &dwSelStart ), LPARAM( &dwSelEnd ) );
+		assert_warning( 0x7FFFFFFF < dwSelStart );
+		assert_warning( 0x7FFFFFFF < dwSelEnd );
+		nSelStart = static_cast<int>(dwSelStart);
+		nSelEnd = static_cast<int>(dwSelEnd);
+	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      リストボックス                         //

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -724,7 +724,6 @@ LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			BOOL bShow = Combo_GetDroppedState(hwndCombo);
 			if( bShow ){
 				DeleteItem(hwndCombo, data->pRecent);
-				return 0;
 			}
 		}
 		break;

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -698,17 +698,29 @@ void CDialog::GetItemClientRect( int wID, RECT& rc )
 
 static const WCHAR* TSTR_SUBCOMBOBOXDATA = L"SubComboBoxData";
 
-static void DeleteItem(HWND hwnd, CRecent* pRecent)
+/*! コンボボックスのリストアイテムを関連付けられた履歴と共に削除する
+ */
+static void DeleteRecentItem(
+	HWND		hwndCombo,	//!< コンボボックスのハンドル
+	int			nIndex,		//!< 選択中のリストアイテムのインデックス
+	CRecent*	pRecent		//!< コンボに関連付けられた履歴
+)
 {
-	int nIndex = Combo_GetCurSel(hwnd);
-	if( 0 <= nIndex ){
-		std::vector<WCHAR> szText;
-		szText.resize(Combo_GetLBTextLen(hwnd, nIndex) + 1);
-		Combo_GetLBText(hwnd, nIndex, &szText[0]);
-		Combo_DeleteString(hwnd, nIndex);
-		int nRecentIndex = pRecent->FindItemByText(&szText[0]);
+	// アイテムインデックスは0以上の整数である必要がある
+	if( nIndex < 0 ){
+		return;
+	}
+
+	// ドロップダウンリスト内の選択されたテキストを取得
+	CNativeW cItemText;
+	if( Combo_GetLBText( hwndCombo, nIndex, cItemText ) ){
+		// コンボボックスのリストアイテム削除
+		Combo_DeleteString( hwndCombo, nIndex );
+
+		// 履歴項目を削除
+		int nRecentIndex = pRecent->FindItemByText( cItemText.GetStringPtr() );
 		if( 0 <= nRecentIndex ){
-			pRecent->DeleteItem(nRecentIndex);
+			pRecent->DeleteItem( nRecentIndex );
 		}
 	}
 }
@@ -722,8 +734,9 @@ LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		if( wParam == VK_DELETE ){
 			HWND hwndCombo = data->hwndCombo;
 			BOOL bShow = Combo_GetDroppedState(hwndCombo);
-			if( bShow ){
-				DeleteItem(hwndCombo, data->pRecent);
+			int nIndex = Combo_GetCurSel(hwndCombo);
+			if( bShow && 0 <= nIndex ){
+				DeleteRecentItem(hwndCombo, nIndex, data->pRecent);
 			}
 		}
 		break;
@@ -749,9 +762,9 @@ LRESULT CALLBACK SubListBoxProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 	{
 		if( wParam == VK_DELETE ){
 			HWND hwndCombo = data->hwndCombo;
-			BOOL bShow = Combo_GetDroppedState(hwndCombo);
-			if( bShow ){
-				DeleteItem(hwndCombo, data->pRecent);
+			int nIndex = Combo_GetCurSel(hwndCombo);
+			if( 0 <= nIndex ){
+				DeleteRecentItem(hwndCombo, nIndex, data->pRecent);
 				return 0;
 			}
 		}

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -714,13 +714,33 @@ static void DeleteRecentItem(
 	// ドロップダウンリスト内の選択されたテキストを取得
 	CNativeW cItemText;
 	if( Combo_GetLBText( hwndCombo, nIndex, cItemText ) ){
+		// エディットテキストを取得(失敗しても構わないのでエラー処理なし)
+		CNativeW cEditText;
+		Wnd_GetText( hwndCombo, cEditText );
+
+		// コンボボックスのキャレット位置を取得
+		int nSelStart = 0;
+		int nSelEnd = 0;
+		Combo_GetEditSel( hwndCombo, nSelStart, nSelEnd );
+
 		// コンボボックスのリストアイテム削除
 		Combo_DeleteString( hwndCombo, nIndex );
 
 		// 履歴項目を削除
 		int nRecentIndex = pRecent->FindItemByText( cItemText.GetStringPtr() );
 		if( 0 <= nRecentIndex ){
-			pRecent->DeleteItem( nRecentIndex );
+			pRecent->DeleteItem(nRecentIndex);
+		}
+
+		// アイテムテキストとエディットテキストが異なる、またはエディットが全選択でなかった場合
+		if ( cItemText != cEditText
+			|| 0 < nSelStart
+			|| nSelEnd < cEditText.GetStringLength()
+			)
+		{
+			// エディットテキストを復元する
+			Wnd_SetText( hwndCombo, cEditText );
+			Combo_SetEditSel( hwndCombo, nSelStart, nSelEnd );
 		}
 	}
 }

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -723,6 +723,16 @@ static void DeleteRecentItem(
 		int nSelEnd = 0;
 		Combo_GetEditSel( hwndCombo, nSelStart, nSelEnd );
 
+		// アイテムテキストとエディットテキストが異なる、またはエディットが全選択でなかった場合
+		if ( cItemText != cEditText
+			|| 0 < nSelStart
+			|| nSelEnd < cEditText.GetStringLength()
+			)
+		{
+			// 履歴削除をスキップする
+			return;
+		}
+
 		// コンボボックスのリストアイテム削除
 		Combo_DeleteString( hwndCombo, nIndex );
 
@@ -730,17 +740,6 @@ static void DeleteRecentItem(
 		int nRecentIndex = pRecent->FindItemByText( cItemText.GetStringPtr() );
 		if( 0 <= nRecentIndex ){
 			pRecent->DeleteItem(nRecentIndex);
-		}
-
-		// アイテムテキストとエディットテキストが異なる、またはエディットが全選択でなかった場合
-		if ( cItemText != cEditText
-			|| 0 < nSelStart
-			|| nSelEnd < cEditText.GetStringLength()
-			)
-		{
-			// エディットテキストを復元する
-			Wnd_SetText( hwndCombo, cEditText );
-			Combo_SetEditSel( hwndCombo, nSelStart, nSelEnd );
 		}
 	}
 }


### PR DESCRIPTION
# PR の目的
履歴コンボ（＝検索ダイアログなどにある履歴表示機能付きコンボボックス）のDeleteキー押下時の動作仕様を見直し、履歴コンボの使い勝手を向上させます。

## カテゴリ
- 仕様変更

## PR の背景

### 経緯
#1219 検索ダイアログボックスでプルダウンが表示時にDeleteキーで文字の消去が機能しない
　　↓　対策案
#1221 検索ボックスでリストのドロップダウン中にDeleteキーを押したときの挙動を変更したい  
　　↓　いったんボツにして焼き直し
#1223 検索コンボの編集仕様を見直したい
　　↓　情報を整理して焼き直し
このPR。


### 解消したい問題点

- 履歴コンボでDeleteキーが効かないように見える現象を回避したい。
  - 現状、ドロップダウンリストの表示中のDeleteキー押下イベントは、履歴削除の関数に食わせるようになっています。リストで選択中のアイテムがない場合、履歴削除関数は「何もしない」ので、結果としてDeleteキーが効かないように見えています。
- 履歴コンボでDeleteキーを押したときに「予想外のもの」が消える現象を回避したい。
  - Deleteキー押下操作の期待結果は、選択しているアイテム、ないし、キャレットの直後の文字が消える、だと思います。
  - 現状、履歴アイテムを削除するときの挙動は、エディットのテキスト＆選択状態に関係なく「一律でクリアされる」です。このため、「選択されていないテキスト」という「予想外のもの」が消える結果になっています。

ここの内容は #1223 でキモいと表現した「違和感」を分析したものです。
この内容なら十分に「客観的な困りごと」に昇華できていると思うので「主観的」という見解は今回外しておきます。

### 対策内容
- 履歴コンボがDeleteキーの既定動作を無視しないように変更します。
  - 実態は `return 0;` を削るだけです。
  - この変更により、履歴削除の後にEditの既定の動作が実行されるようになります。
- 履歴削除関数に、エディットテキストを復元する処理を追加します。
  - 「予想外のもの」が消える動作は `Combo_DeleteString` がエディットテキストをクリアすることが原因です。
  - 履歴削除関数の既定動作として、「明らかに消しても問題ない場合を除いてエディットテキストを復元する」という処理を含めます。
    - 明らかに消しても問題ない場合＝エディットテキストが削除対象と一致し、全選択の場合

## PR のメリット
- 履歴コンボでDeleteキーが効かないように見える現象を回避できます。
- 履歴コンボでDeleteキーを押したときに「予想外のもの」が消える現象を回避できます。
- Deleteキー押下時の挙動が、一般的な挙動と一致するようになります。
  - エディットボックスに対して、選択されたテキストorキャレット位置にある文字を削除。
  - リストボックスに対して、選択されたリストアイテムを削除。


## PR のデメリット (トレードオフとかあれば)
- とくにありません。


## PR の影響範囲
- アプリ（＝サクラエディタ）の挙動に影響がある変更です。
  - 検索ダイアログの検索ボックス
  - 置換ダイアログの検索ボックス、置換後ボックス
  - Grepダイアログの検索ボックス、ファイルボックス、フォルダボックス、除外ファイルボックス、除外フォルダボックス
  - Grep置換ダイアログの検索ボックス、置換後ボックス、ファイルボックス、フォルダボックス、除外ファイルボックス、除外フォルダボックス
  - ツールバーの検索ボックス
  - ファイル名を指定して実行の名前ボックス
  - ファイルオープンダイアログのファイルボックス、フォルダボックス
  - ダイレクトタグジャンプ一覧ダイアログのキーワードボックス

## 関連チケット
#1219 検索ダイアログボックスでプルダウンが表示時にDeleteキーで文字の消去が機能しない
#1221 検索ボックスでリストのドロップダウン中にDeleteキーを押したときの挙動を変更したい  
#1223 検索コンボの編集仕様を見直したい

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
