### PR TITLE
googletest を無視リストに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ sha256.txt
 tags
 testData_*.txt
 UpgradeLog.htm
+/tools/googletest


### PR DESCRIPTION
# PR の目的

googletest を無視リストに追加

## カテゴリ

- その他

## PR の背景

以前は googletest  を submodule で取り込んでいたが、googletest  をバイナリとして取り込むように変更された。その結果 build-sln.bat を実行すると googletest  関連のファイルが未追跡のファイルとなってしまう。

## PR のメリット

googletest  関連のファイルを無視して、本当に追加が必要なファイルを見えやすくする

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

git 操作

## 関連チケット

<!-- 関連するチケットの情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- close #xxx と書くと PR がマージされたときに自動的にチケット xxx がクローズされます。 -->
<!-- close だけでなく他のキーワードでも OK です。↓ に説明があります。-->
<!-- https://help.github.com/en/articles/closing-issues-using-keywords-->

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
