### PR TITLE
sakura editor のビルド用の GitHub Actions を導入する

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -7,12 +7,30 @@ on:
     branches:
       - master
       - feature/*
+    paths-ignore:
+      - '*.md'
+      - .gitignore
+      - .editorconfig
+      - appveyor.yml
+      - 'azure-pipelines*.yml'
+      - 'ci/azure-pipelines/template*.yml'
+      - '.github/*.md'
+      - '.github/ISSUE_TEMPLATE/*.md'
 
   pull_request:
     branches:
       - master
       - feature/*
       - release/*
+    paths-ignore:
+      - '*.md'
+      - .gitignore
+      - .editorconfig
+      - appveyor.yml
+      - 'azure-pipelines*.yml'
+      - 'ci/azure-pipelines/template*.yml'
+      - '.github/*.md'
+      - '.github/ISSUE_TEMPLATE/*.md'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -1,0 +1,60 @@
+name: build sakura
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches:
+      - master
+      - feature/*
+
+  pull_request:
+    branches:
+      - master
+      - release/*
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    name: MSBuild
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        config:
+          - Debug
+          - Release
+        platform:
+          - Win32
+          - x64
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.0
+      
+    - name: MSBuild
+      run: build-sln.bat ${{ matrix.platform }} ${{ matrix.config }}
+      shell: cmd
+      
+    - name: Build HTML Help
+      run: build-chm.bat
+      shell: cmd
+      
+    - name: Build installer with Inno Setup
+      run: build-installer.bat ${{ matrix.platform }} ${{ matrix.config }}
+      shell: cmd
+      
+    - name: zipArtifacts
+      run: zipArtifacts.bat ${{ matrix.platform }} ${{ matrix.config }}
+      shell: cmd
+
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: exe ${{ matrix.platform }} ${{ matrix.config }}
+        path: '*.zip'

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -33,8 +33,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+    ## see https://github.com/actions/checkout
     - uses: actions/checkout@v2
 
+    ## see https://github.com/microsoft/setup-msbuild
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.0
       
@@ -56,6 +58,7 @@ jobs:
       run: zipArtifacts.bat ${{ matrix.platform }} ${{ matrix.config }}
       shell: cmd
 
+    ## see https://github.com/actions/upload-artifact
     - name: Upload
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -41,13 +41,15 @@ jobs:
       run: build-sln.bat ${{ matrix.platform }} ${{ matrix.config }}
       shell: cmd
       
-    - name: Build HTML Help
-      run: build-chm.bat
-      shell: cmd
-      
-    - name: Build installer with Inno Setup
-      run: build-installer.bat ${{ matrix.platform }} ${{ matrix.config }}
-      shell: cmd
+    ## #922 のため無効化
+    #
+    #- name: Build HTML Help
+    #  run: build-chm.bat
+    #  shell: cmd
+    #  
+    #- name: Build installer with Inno Setup
+    #  run: build-installer.bat ${{ matrix.platform }} ${{ matrix.config }}
+    #  shell: cmd
       
     - name: zipArtifacts
       run: zipArtifacts.bat ${{ matrix.platform }} ${{ matrix.config }}

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - master
+      - feature/*
       - release/*
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ skip_commits:
     - 'ci/azure-pipelines/template*.yml'
     - '.github/*.md'
     - '.github/ISSUE_TEMPLATE/*.md'
+    - '.github/workflows/*.yml'
 
 install:
 - cmd: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ trigger:
       - "*.md"
       - .github/*.md
       - .github/ISSUE_TEMPLATE/*.md
+      - .github/workflows/*.yml
       - .gitignore
       - .travis.yml
       - appveyor.yml


### PR DESCRIPTION
# PR の目的

sakura editor のビルド用の [GitHub Actions](https://github.co.jp/features/actions) を導入する

## カテゴリ

- CI関連
  - GitHub Actions

## GitHub Actions の特徴

- GitHub Actions は GitHub 製の CI  ツールです。(appveyor や azure pipeline みたいに)
- GitHub Actions は同時に 20 個 workflow の実行が可能
- GitHub Actions はオープンソースに対してはフリー
- GitHub Actions の artifacts の保存期間は 90 日
- GitHub Actions は GitHub アカウントがあれば利用可能
- GitHub Actions は GitHub ユーザー自身が GitHubアクションを作成、公開、利用可能
- GitHub Actions は GitHub 製のGitHubアクションも GitHub で公開されているので必要に応じて PR を送ることも可能

## PR の背景

https://github.com/sakura-editor/sakura-editor.github.io/issues/6 で doxygen の管理をどうするか検討する中で、[GitHub Actions を使えないか検討](https://github.com/sakura-editor/management-forum/issues/81) を行っていた。

その結果、https://github.com/sakura-editor/sakura-editor.github.io/issues/24 や https://github.com/sakura-editor/sakura-editor.github.io/issues/25 でも GitHub Actions で  GitHub Pages に展開できそうなので、GitHub Actions の調査を行っていた。

いろいろ調べたところ  GitHub Actions は非常に強力なので、すでに使われている appveyor や Azure Pipelines に加えて導入してみたらいいんじゃないかと思い、実験してみたところ動作したので、導入してみようと思います。

いろいろ修正したほうがいいところはあると思いますが、最初に導入するレベルとしてはいいのではないかと思います。

## 注意

※ この PR では GitHub Actions のビルドは走っていませんが、いったん master にマージされればこのリポジトリで GitHub Actions が有効になり、以降の PR で有効になると考えられます。

## PR のメリット

* GitHub Actions を使ってみて、いろいろ試すきっかけになる
* Appveyor や Azure Pipelines と異なり、別途アカウントを作成しなくても GitHub ユーザーなら自動的に使える

## PR のデメリット (トレードオフとかあれば)

なし

## 未実装なところ

- ドキュメント
- Azure Pipelines や Appveyor ビルドで取得している各種環境変数 (#1183) には対応していない
- #922 には対応できないので、chm および installer のビルドは無効化している
- Artifacts が一括して一つの zip にまとめられるが、個別にダウンロードできるようにする
- `microsoft/setup-msbuild@v1.0.0` で自動的に Visual Studio 2019 が選択される。
- ~`paths-ignore` を使って md ファイルや appveyor や azure pipelines の固有ファイルの更新無視~

## PR の影響範囲

なし

## 関連チケット

#967
#922
#1183

## 参考資料

https://github.co.jp/features/actions
https://help.github.com/ja/actions/getting-started-with-github-actions/about-github-actions
