### PR TITLE
CDialog::OnNotify の引数の型を変更して、不要なキャストをなくす

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -395,7 +395,7 @@ INT_PTR CDialog::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM l
 	case WM_INITDIALOG:	return OnInitDialog( hwndDlg, wParam, lParam );
 	case WM_DESTROY:	return OnDestroy();
 	case WM_COMMAND:	return OnCommand( wParam, lParam );
-	case WM_NOTIFY:		return OnNotify( wParam, lParam );
+	case WM_NOTIFY:		return OnNotify( (NMHDR*)lParam );
 	case WM_SIZE:
 		m_hWnd = hwndDlg;
 		return OnSize( wParam, lParam );

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -89,7 +89,7 @@ public:
 	virtual BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
 	virtual void SetDialogPosSize();
 	virtual BOOL OnDestroy( void );
-	virtual BOOL OnNotify( WPARAM wParam, LPARAM lParam ){return FALSE;}
+	virtual BOOL OnNotify(NMHDR* pNMHDR){return FALSE;}
 	BOOL OnSize();
 	virtual BOOL OnSize( WPARAM wParam, LPARAM lParam );
 	virtual BOOL OnMove( WPARAM wParam, LPARAM lParam );

--- a/sakura_core/dlg/CDlgCtrlCode.cpp
+++ b/sakura_core/dlg/CDlgCtrlCode.cpp
@@ -261,12 +261,9 @@ BOOL CDlgCtrlCode::OnBnClicked( int wID )
 	return CDialog::OnBnClicked( wID );
 }
 
-BOOL CDlgCtrlCode::OnNotify( WPARAM wParam, LPARAM lParam )
+BOOL CDlgCtrlCode::OnNotify( NMHDR* pNMHDR )
 {
-	NMHDR*	pNMHDR;
 	HWND	hwndList;
-
-	pNMHDR = (NMHDR*)lParam;
 
 	hwndList = GetItemHwnd( IDC_LIST_CTRLCODE );
 
@@ -281,7 +278,7 @@ BOOL CDlgCtrlCode::OnNotify( WPARAM wParam, LPARAM lParam )
 		case LVN_KEYDOWN:
 			{
 				HWND	hwndList;
-				NMKEY	*p = (NMKEY*)lParam;
+				NMKEY	*p = (NMKEY*)pNMHDR;
 				int		i, j;
 				unsigned int	c;
 				for( i = 0; i < _countof(p_ctrl_list); i++ )
@@ -311,7 +308,7 @@ BOOL CDlgCtrlCode::OnNotify( WPARAM wParam, LPARAM lParam )
 	}
 
 	/* 基底クラスメンバ */
-	return CDialog::OnNotify( wParam, lParam );
+	return CDialog::OnNotify(pNMHDR);
 }
 
 LPVOID CDlgCtrlCode::GetHelpIdTable( void )

--- a/sakura_core/dlg/CDlgCtrlCode.h
+++ b/sakura_core/dlg/CDlgCtrlCode.h
@@ -58,7 +58,7 @@ private:
 	*/
 	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL	OnBnClicked(int wID) override;
-	BOOL	OnNotify( WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnNotify(NMHDR* pNMHDR) override;
 	LPVOID	GetHelpIdTable( void ) override;
 
 	void	SetData( void ) override;	/* ダイアログデータの設定 */

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -586,17 +586,15 @@ BOOL CDlgFavorite::OnBnClicked( int wID )
 	return CDialog::OnBnClicked( wID );
 }
 
-BOOL CDlgFavorite::OnNotify( WPARAM wParam, LPARAM lParam )
+BOOL CDlgFavorite::OnNotify(NMHDR* pNMHDR)
 {
-	LPNMHDR	lpnmhdr;
 	HWND	hwndTab;
 	HWND	hwndList;
 
 	hwndTab = GetItemHwnd( IDC_TAB_FAVORITE );
-	lpnmhdr = (LPNMHDR) lParam;
-	if( lpnmhdr->hwndFrom == hwndTab )
+	if(pNMHDR->hwndFrom == hwndTab )
 	{
-		switch( lpnmhdr->code )
+		switch(pNMHDR->code )
 		{
 		case TCN_SELCHANGE:
 			TabSelectChange(false);
@@ -605,10 +603,10 @@ BOOL CDlgFavorite::OnNotify( WPARAM wParam, LPARAM lParam )
 		}
 	}else{
 		hwndList = m_aListViewInfo[m_nCurrentTab].hListView;
-		if( hwndList == lpnmhdr->hwndFrom )
+		if( hwndList == pNMHDR->hwndFrom )
 		{
-			NM_LISTVIEW* pnlv = (NM_LISTVIEW*)lParam;
-			switch( lpnmhdr->code )
+			NM_LISTVIEW* pnlv = (NM_LISTVIEW*)pNMHDR;
+			switch(pNMHDR->code )
 			{
 			case NM_DBLCLK:
 				EditItem();
@@ -632,7 +630,7 @@ BOOL CDlgFavorite::OnNotify( WPARAM wParam, LPARAM lParam )
 			
 			// ListViewでDeleteキーが押された:削除
 			case LVN_KEYDOWN:
-				switch( ((NMLVKEYDOWN*)lParam)->wVKey )
+				switch( ((NMLVKEYDOWN*)pNMHDR)->wVKey )
 				{
 				case VK_DELETE:
 					DeleteSelected();
@@ -650,7 +648,7 @@ BOOL CDlgFavorite::OnNotify( WPARAM wParam, LPARAM lParam )
 					return TRUE;
 				}
 				int nIdx = getCtrlKeyState();
-				WORD wKey = ((NMLVKEYDOWN*)lParam)->wVKey;
+				WORD wKey = ((NMLVKEYDOWN*)pNMHDR)->wVKey;
 				if( (wKey == VK_NEXT && nIdx == _CTRL) ){
 					int next = m_nCurrentTab + 1;
 					if( _countof(m_aFavoriteInfo) - 1 <= next ){
@@ -673,7 +671,7 @@ BOOL CDlgFavorite::OnNotify( WPARAM wParam, LPARAM lParam )
 	}
 
 	/* 基底クラスメンバ */
-	return CDialog::OnNotify( wParam, lParam );
+	return CDialog::OnNotify(pNMHDR);
 }
 
 void CDlgFavorite::TabSelectChange(bool bSetFocus)

--- a/sakura_core/dlg/CDlgFavorite.h
+++ b/sakura_core/dlg/CDlgFavorite.h
@@ -56,7 +56,7 @@ protected:
 	*/
 	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL	OnBnClicked(int wID) override;
-	BOOL	OnNotify( WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnNotify(NMHDR* pNMHDR) override;
 	BOOL	OnActivate( WPARAM wParam, LPARAM lParam ) override;
 	LPVOID	GetHelpIdTable( void ) override;
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する

--- a/sakura_core/dlg/CDlgJump.cpp
+++ b/sakura_core/dlg/CDlgJump.cpp
@@ -66,13 +66,13 @@ int CDlgJump::DoModal(
 
 // From Here Oct. 6, 2000 JEPRO added 行番号入力ボックスにスピンコントロールを付けるため
 // CDlgPrintSetting.cppのOnNotifyとOnSpin及びCpropComFile.cppのDispatchEvent_p2内のcase WM_NOTIFYを参考にした
-BOOL CDlgJump::OnNotify( WPARAM wParam, LPARAM lParam )
+BOOL CDlgJump::OnNotify(NMHDR* pNMHDR)
 {
 	NM_UPDOWN*		pMNUD;
-	int				idCtrl;
+	UINT_PTR		idCtrl;
 	int				nData;
-	idCtrl = (int)wParam;
-	pMNUD  = (NM_UPDOWN*)lParam;
+	idCtrl = pNMHDR->idFrom;
+	pMNUD  = (NM_UPDOWN*)pNMHDR;
 /* スピンコントロールの処理 */
 	switch( idCtrl ){
 	case IDC_SPIN_LINENUM:

--- a/sakura_core/dlg/CDlgJump.cpp
+++ b/sakura_core/dlg/CDlgJump.cpp
@@ -69,9 +69,9 @@ int CDlgJump::DoModal(
 BOOL CDlgJump::OnNotify(NMHDR* pNMHDR)
 {
 	NM_UPDOWN*		pMNUD;
-	UINT_PTR		idCtrl;
+	int				idCtrl;
 	int				nData;
-	idCtrl = pNMHDR->idFrom;
+	idCtrl = (int)pNMHDR->idFrom;
 	pMNUD  = (NM_UPDOWN*)pNMHDR;
 /* スピンコントロールの処理 */
 	switch( idCtrl ){

--- a/sakura_core/dlg/CDlgJump.h
+++ b/sakura_core/dlg/CDlgJump.h
@@ -39,7 +39,7 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	BOOL OnNotify(WPARAM wParam, LPARAM lParam) override;	//	Oct. 6, 2000 JEPRO added for Spin control
+	BOOL OnNotify(NMHDR* pNMHDR) override;	//	Oct. 6, 2000 JEPRO added for Spin control
 	BOOL OnCbnSelChange(HWND hwndCtl, int wID) override;
 	BOOL OnBnClicked(int wID) override;
 	BOOL OnEnSetFocus(HWND hwndCtl, int wID) override;

--- a/sakura_core/dlg/CDlgPluginOption.cpp
+++ b/sakura_core/dlg/CDlgPluginOption.cpp
@@ -331,15 +331,13 @@ BOOL CDlgPluginOption::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam 
 	return CDialog::OnInitDialog( GetHwnd(), wParam, lParam );
 }
 
-BOOL CDlgPluginOption::OnNotify( WPARAM wParam, LPARAM lParam )
+BOOL CDlgPluginOption::OnNotify(NMHDR* pNMHDR)
 {
-	NMHDR*		pNMHDR;
-	int			idCtrl;
+	UINT_PTR		idCtrl;
 
-	idCtrl = (int)wParam;
+	idCtrl = pNMHDR->idFrom;
 	switch( idCtrl ){
 	case IDC_LIST_PLUGIN_OPTIONS:
-		pNMHDR = (NMHDR*)lParam;
 		switch( pNMHDR->code ){
 		case LVN_ITEMCHANGED:
 			ChangeListPosition( );
@@ -355,7 +353,7 @@ BOOL CDlgPluginOption::OnNotify( WPARAM wParam, LPARAM lParam )
 		int			nVal;
 		NM_UPDOWN*	pMNUD;
 		
-		pMNUD  = (NM_UPDOWN*)lParam;
+		pMNUD  = (NM_UPDOWN*)pNMHDR;
 
 		nVal = ::GetDlgItemInt( GetHwnd(), IDC_EDIT_PLUGIN_OPTION_NUM, NULL, TRUE );
 		if( pMNUD->iDelta < 0 ){
@@ -373,7 +371,7 @@ BOOL CDlgPluginOption::OnNotify( WPARAM wParam, LPARAM lParam )
 	}
 
 	/* 基底クラスメンバ */
-	return CDialog::OnNotify( wParam, lParam );
+	return CDialog::OnNotify(pNMHDR);
 }
 
 BOOL CDlgPluginOption::OnBnClicked( int wID )

--- a/sakura_core/dlg/CDlgPluginOption.cpp
+++ b/sakura_core/dlg/CDlgPluginOption.cpp
@@ -333,9 +333,9 @@ BOOL CDlgPluginOption::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam 
 
 BOOL CDlgPluginOption::OnNotify(NMHDR* pNMHDR)
 {
-	UINT_PTR		idCtrl;
+	int			idCtrl;
 
-	idCtrl = pNMHDR->idFrom;
+	idCtrl = (int)pNMHDR->idFrom;
 	switch( idCtrl ){
 	case IDC_LIST_PLUGIN_OPTIONS:
 		switch( pNMHDR->code ){

--- a/sakura_core/dlg/CDlgPluginOption.h
+++ b/sakura_core/dlg/CDlgPluginOption.h
@@ -71,7 +71,7 @@ protected:
 	*/
 	BOOL	OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnBnClicked(int wID) override;
-	BOOL	OnNotify( WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnNotify(NMHDR* pNMHDR) override;
 	BOOL	OnCbnSelChange( HWND hwndCtl, int wID ) override;
 	BOOL	OnEnChange( HWND hwndCtl, int wID ) override;
 	BOOL	OnActivate( WPARAM wParam, LPARAM lParam ) override;

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -188,9 +188,9 @@ BOOL CDlgPrintSetting::OnNotify(NMHDR* pNMHDR)
 {
 	CDlgInput1		cDlgInput1;
 	NM_UPDOWN*		pMNUD;
-	UINT_PTR		idCtrl;
+	int				idCtrl;
 	BOOL			bSpinDown;
-	idCtrl = pNMHDR->idFrom;
+	idCtrl = (int)pNMHDR->idFrom;
 	pMNUD  = (NM_UPDOWN*)pNMHDR;
 	if( pMNUD->iDelta < 0 ){
 		bSpinDown = FALSE;

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -184,14 +184,14 @@ BOOL CDlgPrintSetting::OnDestroy( void )
 	return CDialog::OnDestroy();
 }
 
-BOOL CDlgPrintSetting::OnNotify( WPARAM wParam, LPARAM lParam )
+BOOL CDlgPrintSetting::OnNotify(NMHDR* pNMHDR)
 {
 	CDlgInput1		cDlgInput1;
 	NM_UPDOWN*		pMNUD;
-	int				idCtrl;
+	UINT_PTR		idCtrl;
 	BOOL			bSpinDown;
-	idCtrl = (int)wParam;
-	pMNUD  = (NM_UPDOWN*)lParam;
+	idCtrl = pNMHDR->idFrom;
+	pMNUD  = (NM_UPDOWN*)pNMHDR;
 	if( pMNUD->iDelta < 0 ){
 		bSpinDown = FALSE;
 	}else{

--- a/sakura_core/dlg/CDlgPrintSetting.h
+++ b/sakura_core/dlg/CDlgPrintSetting.h
@@ -66,7 +66,7 @@ protected:
 	int GetData( void ) override;	/* ダイアログデータの取得 */
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnDestroy( void ) override;
-	BOOL OnNotify(WPARAM wParam, LPARAM lParam) override;
+	BOOL OnNotify(NMHDR* pNMHDR) override;
 	BOOL OnCbnSelChange(HWND hwndCtl, int wID) override;
 	BOOL OnBnClicked(int wID) override;
 	BOOL OnStnClicked(int wID) override;

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -631,13 +631,9 @@ BOOL CDlgTagJumpList::OnMinMaxInfo( LPARAM lParam )
 	return 0;
 }
 
-BOOL CDlgTagJumpList::OnNotify( WPARAM wParam, LPARAM lParam )
+BOOL CDlgTagJumpList::OnNotify(NMHDR* pNMHDR)
 {
-	NMHDR*	pNMHDR;
 	HWND	hwndList;
-
-	pNMHDR = (NMHDR*)lParam;
-
 	hwndList = GetItemHwnd( IDC_LIST_TAGJUMP );
 
 	//	候補一覧リストボックス
@@ -653,7 +649,7 @@ BOOL CDlgTagJumpList::OnNotify( WPARAM wParam, LPARAM lParam )
 	}
 
 	/* 基底クラスメンバ */
-	return CDialog::OnNotify( wParam, lParam );
+	return CDialog::OnNotify(pNMHDR);
 }
 
 /*!

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -79,7 +79,7 @@ protected:
 	BOOL	OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnMove( WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnMinMaxInfo( LPARAM lParam );
-	BOOL	OnNotify( WPARAM wParam, LPARAM lParam ) override;
+	BOOL	OnNotify(NMHDR* pNMHDR) override;
 	//	@@ 2005.03.31 MIK キーワード入力エリアのイベント処理
 	BOOL	OnCbnSelChange( HWND hwndCtl, int wID ) override;
 	BOOL	OnCbnEditChange( HWND hwndCtl, int wID ) override;

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -937,10 +937,9 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 	return CDialog::OnBnClicked( wID );
 }
 
-BOOL CDlgFileTree::OnNotify( WPARAM wParam, LPARAM lParam )
+BOOL CDlgFileTree::OnNotify(NMHDR* pNMHDR)
 {
-	NMHDR* pNMHDR = (NMHDR*)lParam;
-	TV_DISPINFO* ptdi = (TV_DISPINFO*)lParam;
+	TV_DISPINFO* ptdi = (TV_DISPINFO*)pNMHDR;
 	HWND hwndTree = GetItemHwnd(IDC_TREE_FL);
 	HTREEITEM htiItem;
 
@@ -976,7 +975,7 @@ BOOL CDlgFileTree::OnNotify( WPARAM wParam, LPARAM lParam )
 		}
 	}
 	/* 基底クラスメンバ */
-	return CDialog::OnNotify( wParam, lParam );
+	return CDialog::OnNotify(pNMHDR);
 }
 
 LPVOID CDlgFileTree::GetHelpIdTable( void )

--- a/sakura_core/outline/CDlgFileTree.h
+++ b/sakura_core/outline/CDlgFileTree.h
@@ -46,7 +46,7 @@ public:
 private:
 	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL	OnBnClicked(int wID) override;
-	BOOL	OnNotify(WPARAM wParam, LPARAM lParam) override;
+	BOOL	OnNotify(NMHDR* pNMHDR) override;
 	LPVOID	GetHelpIdTable() override;
 	void	SetData() override;
 	int		GetData() override;

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -2100,14 +2100,12 @@ BOOL CDlgFuncList::OnBnClicked( int wID )
 
 BOOL CDlgFuncList::OnNotify(NMHDR* pNMHDR)
 {
-//	UINT_PTR		idCtrl;
 	NM_LISTVIEW*	pnlv;
 	HWND			hwndList;
 	HWND			hwndTree;
 	NM_TREEVIEW*	pnmtv;
 //	int				nLineTo;
 
-//	idCtrl = pNMHDR->idFrom;
 	pnlv = (NM_LISTVIEW*)pNMHDR;
 
 	CEditView* pcEditView=(CEditView*)m_lParam;

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -2098,26 +2098,24 @@ BOOL CDlgFuncList::OnBnClicked( int wID )
 	return CDialog::OnBnClicked( wID );
 }
 
-BOOL CDlgFuncList::OnNotify( WPARAM wParam, LPARAM lParam )
+BOOL CDlgFuncList::OnNotify(NMHDR* pNMHDR)
 {
-//	int				idCtrl;
-	LPNMHDR			pnmh;
+//	UINT_PTR		idCtrl;
 	NM_LISTVIEW*	pnlv;
 	HWND			hwndList;
 	HWND			hwndTree;
 	NM_TREEVIEW*	pnmtv;
 //	int				nLineTo;
 
-//	idCtrl = (int) wParam;
-	pnmh = (LPNMHDR) lParam;
-	pnlv = (NM_LISTVIEW*)lParam;
+//	idCtrl = pNMHDR->idFrom;
+	pnlv = (NM_LISTVIEW*)pNMHDR;
 
 	CEditView* pcEditView=(CEditView*)m_lParam;
 	hwndList = GetItemHwnd( IDC_LIST_FL );
 	hwndTree = GetItemHwnd( IDC_TREE_FL );
 
-	if( hwndTree == pnmh->hwndFrom ){
-		pnmtv = (NM_TREEVIEW *) lParam;
+	if( hwndTree == pNMHDR->hwndFrom ){
+		pnmtv = (NM_TREEVIEW *)pNMHDR;
 		switch( pnmtv->hdr.code ){
 		case NM_CLICK:
 			if( IsDocking() ){
@@ -2141,11 +2139,11 @@ BOOL CDlgFuncList::OnNotify( WPARAM wParam, LPARAM lParam )
 			return TRUE;
 			//return OnJump();
 		case TVN_KEYDOWN:
-			if( ((TV_KEYDOWN *)lParam)->wVKey == VK_SPACE ){
+			if( ((TV_KEYDOWN *)pNMHDR)->wVKey == VK_SPACE ){
 				OnJump( false );
 				return TRUE;
 			}
-			Key2Command( ((TV_KEYDOWN *)lParam)->wVKey );
+			Key2Command( ((TV_KEYDOWN *)pNMHDR)->wVKey );
 			return TRUE;
 		case NM_KILLFOCUS:
 			// 2002.02.16 hor Treeのダブルクリックでフォーカス移動できるように 4/4
@@ -2158,8 +2156,8 @@ BOOL CDlgFuncList::OnNotify( WPARAM wParam, LPARAM lParam )
 			return TRUE;
 		}
 	}else
-	if( hwndList == pnmh->hwndFrom ){
-		switch( pnmh->code ){
+	if( hwndList == pNMHDR->hwndFrom ){
+		switch(pNMHDR->code ){
 		case LVN_COLUMNCLICK:
 //			MYTRACE( L"LVN_COLUMNCLICK\n" );
 			m_nSortCol =  pnlv->iSubItem;
@@ -2188,20 +2186,20 @@ BOOL CDlgFuncList::OnNotify( WPARAM wParam, LPARAM lParam )
 				OnJump();
 			return TRUE;
 		case LVN_KEYDOWN:
-			if( ((LV_KEYDOWN *)lParam)->wVKey == VK_SPACE ){
+			if( ((LV_KEYDOWN *)pNMHDR)->wVKey == VK_SPACE ){
 				OnJump( false );
 				return TRUE;
 			}
-			Key2Command( ((LV_KEYDOWN *)lParam)->wVKey );
+			Key2Command( ((LV_KEYDOWN *)pNMHDR)->wVKey );
 			return TRUE;
 		}
 	}
 
 #ifdef DEFINE_SYNCCOLOR
 	if( IsDocking() ){
-		if( hwndList == pnmh->hwndFrom || hwndTree == pnmh->hwndFrom ){
-			if( pnmh->code == NM_CUSTOMDRAW ){
-				LPNMCUSTOMDRAW lpnmcd = (LPNMCUSTOMDRAW)lParam;
+		if( hwndList == pNMHDR->hwndFrom || hwndTree == pNMHDR->hwndFrom ){
+			if(pNMHDR->code == NM_CUSTOMDRAW ){
+				LPNMCUSTOMDRAW lpnmcd = (LPNMCUSTOMDRAW)pNMHDR;
 				switch( lpnmcd->dwDrawStage ){
 				case CDDS_PREPAINT:
 					::SetWindowLongPtr( GetHwnd(), DWLP_MSGRESULT, CDRF_NOTIFYITEMDRAW );
@@ -2211,7 +2209,7 @@ BOOL CDlgFuncList::OnNotify( WPARAM wParam, LPARAM lParam )
 						const STypeConfig	*TypeDataPtr = &(pcEditView->m_pcEditDoc->m_cDocType.GetDocumentAttribute());
 						COLORREF clrText = TypeDataPtr->m_ColorInfoArr[COLORIDX_TEXT].m_sColorAttr.m_cTEXT;
 						COLORREF clrTextBk = TypeDataPtr->m_ColorInfoArr[COLORIDX_TEXT].m_sColorAttr.m_cBACK;
-						if( hwndList == pnmh->hwndFrom ){
+						if( hwndList == pNMHDR->hwndFrom ){
 							//if( lpnmcd->uItemState & CDIS_SELECTED ){	// 非選択のアイテムもすべて CDIS_SELECTED で来る？
 							if( ListView_GetItemState( hwndList, lpnmcd->dwItemSpec, LVIS_SELECTED ) ){
 								((LPNMLVCUSTOMDRAW)lpnmcd)->clrText = clrText ^ RGB(255, 255, 255);

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -119,7 +119,7 @@ public:
 protected:
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnBnClicked(int wID) override;
-	BOOL OnNotify(WPARAM wParam, LPARAM lParam) override;
+	BOOL OnNotify(NMHDR* pNMHDR) override;
 	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
 	BOOL OnDestroy(void) override; // 20060201 aroka


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートに切り替えることで登録後にどのように見えるか確認することができます -->

# PR の目的

CDialog::OnNotify の引数の型を変更して、不要なキャストをなくす

## カテゴリ

- リファクタリング

## PR の背景

@berryzplus 
https://github.com/sakura-editor/sakura/pull/570#issuecomment-602049972 

> サクラエディタの WM_NOTIFY ハンドラの実装は「正しくない」と思っております。
> 
> WM_NOTIFY というのは「システムからの通知メッセージ」の1種です。
> Windowsには数百種類のシステムメッセージが定義されていて、基本的なメッセージの仕様は公開されています。
> 
> WM_NOTIFYメッセージをハンドルするには、マニュアルに従ってメッセージパラメータを解析して必要なデータを取得する必要があります。
> 
> マニュアル ⇒ https://docs.microsoft.com/en-us/windows/win32/controls/wm-notify
> 
> * 第1パラメータ wparam にはゴミが入っている。（正確には「イベントを送信したウインドウのID(=識別番号）が入ることになっているがIDの一意性は保証されないのでlparamを使え」と書いてある。）
> * 第2パラメータ lparam には通知詳細(NMHDR 構造体) を指すポインタが入っている。
> 
> サクラエディタの WM_NOTIFY ハンドラ実装である `CDialog::OnNotify` のシグニチャは、`BOOL CDialog::OnNotify( WPARAM wParam, LPARAM lParam )` となっています。
> 
> マニュアルをマジメに読んでいたら `BOOL CDialog::OnNotify( NMHDR* pNMHDR )` とかになりそうですが、そうなってはいません。
> 
> 「メンテしやすくする」という観点からすると以下のようなコードがコピペで増えまくるのはどうなんだろうと思うわけです。
> 
> ```
>     NMHDR* pNMHDR = (NMHDR*) lParam;
> ```
> 
> ・・・やばい。結論がない😢
> 
> ま、いいか・・・。

## PR のメリット

WM_NOTIFY の実装が楽になる

## PR のデメリット (トレードオフとかあれば)

なし

## PR の影響範囲

ダイアログの WM_NOTIFY の処理

## 関連チケット

#570

## 参考資料

https://docs.microsoft.com/en-us/windows/win32/controls/wm-notify
