### PR TITLE
[WIP] CStrictIntegerと整数を比較するグローバル演算子の実装を修正する

### DIFF
--- a/sakura_core/basis/CStrictInteger.h
+++ b/sakura_core/basis/CStrictInteger.h
@@ -211,10 +211,10 @@ private:
 
 //左辺がint等の場合の演算子
 #define STRICTINT_LEFT_INT_CMP(TYPE) \
-	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <  (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs>=lhs; } \
-	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <= (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs> lhs; } \
-	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator >  (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs<=lhs; } \
-	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator >= (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs< lhs; } \
+	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <  (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs> lhs; } \
+	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <= (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs>=lhs; } \
+	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator >  (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs< lhs; } \
+	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator >= (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs<=lhs; } \
 	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator == (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs==lhs; } \
 	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator != (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs!=lhs; } \
 	template <int N,bool B0,bool B1,bool B2,bool B3> inline CStrictInteger<N,B0,B1,B2,B3> operator + (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return  rhs+lhs; } \

--- a/sakura_core/basis/CStrictInteger.h
+++ b/sakura_core/basis/CStrictInteger.h
@@ -211,10 +211,10 @@ private:
 
 //左辺がint等の場合の演算子
 #define STRICTINT_LEFT_INT_CMP(TYPE) \
-	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <  (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs> lhs; } \
-	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <= (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs>=lhs; } \
-	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator >  (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs< lhs; } \
-	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator >= (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs<=lhs; } \
+	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <  (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs>=lhs; } \
+	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator <= (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs> lhs; } \
+	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator >  (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs<=lhs; } \
+	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator >= (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs< lhs; } \
 	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator == (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs==lhs; } \
 	template <int N,bool B0,bool B1,bool B2,bool B3> inline bool operator != (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return rhs!=lhs; } \
 	template <int N,bool B0,bool B1,bool B2,bool B3> inline CStrictInteger<N,B0,B1,B2,B3> operator + (TYPE lhs, const CStrictInteger<N,B0,B1,B2,B3>& rhs){ return  rhs+lhs; } \

--- a/tests/unittests/test-clayoutint.cpp
+++ b/tests/unittests/test-clayoutint.cpp
@@ -31,6 +31,10 @@
 #include <tchar.h>
 #include <Windows.h>
 
+#ifndef USE_STRICT_INT
+#define USE_STRICT_INT
+#endif /* #ifndef USE_STRICT_INT */
+
 #include "basis/CStrictInteger.h"
 #include "basis/SakuraBasis.h"
 

--- a/tests/unittests/test-clayoutint.cpp
+++ b/tests/unittests/test-clayoutint.cpp
@@ -92,10 +92,10 @@ TEST( CLayoutInt, GlobalOperatorCompareGreaterThan )
 {
 	CLayoutInt a( 1 );
 
-	EXPECT_TRUE( -1 > a );
-	EXPECT_TRUE( 0 > a );
+	EXPECT_FALSE( -1 > a );
+	EXPECT_FALSE( 0 > a );
 	EXPECT_FALSE( 1 > a );
-	EXPECT_FALSE( 2 > a );
+	EXPECT_TRUE( 2 > a );
 }
 
 /*!
@@ -105,10 +105,10 @@ TEST( CLayoutInt, GlobalOperatorCompareGreaterOrEqual )
 {
 	CLayoutInt a( 1 );
 
-	EXPECT_TRUE( -1 >= a );
-	EXPECT_TRUE( 0 >= a );
+	EXPECT_FALSE( -1 >= a );
+	EXPECT_FALSE( 0 >= a );
 	EXPECT_TRUE( 1 >= a );
-	EXPECT_FALSE( 2 >= a );
+	EXPECT_TRUE( 2 >= a );
 }
 
 /*!
@@ -118,10 +118,10 @@ TEST( CLayoutInt, GlobalOperatorCompareLessThan )
 {
 	CLayoutInt a( 1 );
 
-	EXPECT_FALSE( -1 < a );
-	EXPECT_FALSE( 0 < a );
+	EXPECT_TRUE( -1 < a );
+	EXPECT_TRUE( 0 < a );
 	EXPECT_FALSE( 1 < a );
-	EXPECT_TRUE( 2 < a );
+	EXPECT_FALSE( 2 < a );
 }
 
 /*!
@@ -131,9 +131,8 @@ TEST( CLayoutInt, GlobalOperatorCompareLessOrEqual )
 {
 	CLayoutInt a( 1 );
 
-	EXPECT_FALSE( -1 <= a );
-	EXPECT_FALSE( 0 <= a );
+	EXPECT_TRUE( -1 <= a );
+	EXPECT_TRUE( 0 <= a );
 	EXPECT_TRUE( 1 <= a );
-	EXPECT_TRUE( 2 <= a );
+	EXPECT_FALSE( 2 <= a );
 }
-

--- a/tests/unittests/test-clayoutint.cpp
+++ b/tests/unittests/test-clayoutint.cpp
@@ -1,0 +1,139 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2020 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include "basis/SakuraBasis.h"
+
+/*!
+ * @brief 比較演算子のテスト
+ */
+TEST( CLayoutInt, OperatorCompareGreaterThan )
+{
+	CLayoutInt a( 1 );
+
+	EXPECT_TRUE( a > -1 );
+	EXPECT_TRUE( a > 0 );
+	EXPECT_FALSE( a > 1 );
+	EXPECT_FALSE( a > 2 );
+}
+
+/*!
+ * @brief 比較演算子のテスト
+ */
+TEST( CLayoutInt, OperatorCompareGreaterOrEqual )
+{
+	CLayoutInt a( 1 );
+
+	EXPECT_TRUE( a >= -1 );
+	EXPECT_TRUE( a >= 0 );
+	EXPECT_TRUE( a >= 1 );
+	EXPECT_FALSE( a >= 2 );
+}
+
+/*!
+ * @brief 比較演算子のテスト
+ */
+TEST( CLayoutInt, OperatorCompareLessThan )
+{
+	CLayoutInt a( 1 );
+
+	EXPECT_FALSE( a < -1 );
+	EXPECT_FALSE( a < 0 );
+	EXPECT_FALSE( a < 1 );
+	EXPECT_TRUE( a < 2 );
+}
+
+/*!
+ * @brief 比較演算子のテスト
+ */
+TEST( CLayoutInt, OperatorCompareLessOrEqual )
+{
+	CLayoutInt a( 1 );
+
+	EXPECT_FALSE( a <= -1 );
+	EXPECT_FALSE( a <= 0 );
+	EXPECT_TRUE( a <= 1 );
+	EXPECT_TRUE( a <= 2 );
+}
+
+/*!
+ * @brief グローバル比較演算子のテスト
+ */
+TEST( CLayoutInt, GlobalOperatorCompareGreaterThan )
+{
+	CLayoutInt a( 1 );
+
+	EXPECT_TRUE( -1 > a );
+	EXPECT_TRUE( 0 > a );
+	EXPECT_FALSE( 1 > a );
+	EXPECT_FALSE( 2 > a );
+}
+
+/*!
+ * @brief グローバル比較演算子のテスト
+ */
+TEST( CLayoutInt, GlobalOperatorCompareGreaterOrEqual )
+{
+	CLayoutInt a( 1 );
+
+	EXPECT_TRUE( -1 >= a );
+	EXPECT_TRUE( 0 >= a );
+	EXPECT_TRUE( 1 >= a );
+	EXPECT_FALSE( 2 >= a );
+}
+
+/*!
+ * @brief グローバル比較演算子のテスト
+ */
+TEST( CLayoutInt, GlobalOperatorCompareLessThan )
+{
+	CLayoutInt a( 1 );
+
+	EXPECT_FALSE( -1 < a );
+	EXPECT_FALSE( 0 < a );
+	EXPECT_FALSE( 1 < a );
+	EXPECT_TRUE( 2 < a );
+}
+
+/*!
+ * @brief グローバル比較演算子のテスト
+ */
+TEST( CLayoutInt, GlobalOperatorCompareLessOrEqual )
+{
+	CLayoutInt a( 1 );
+
+	EXPECT_FALSE( -1 <= a );
+	EXPECT_FALSE( 0 <= a );
+	EXPECT_TRUE( 1 <= a );
+	EXPECT_TRUE( 2 <= a );
+}
+

--- a/tests/unittests/test-clayoutint.cpp
+++ b/tests/unittests/test-clayoutint.cpp
@@ -31,6 +31,7 @@
 #include <tchar.h>
 #include <Windows.h>
 
+#include "basis/CStrictInteger.h"
 #include "basis/SakuraBasis.h"
 
 /*!
@@ -38,12 +39,11 @@
  */
 TEST( CLayoutInt, OperatorCompareGreaterThan )
 {
-	CLayoutInt a( 1 );
+	CLayoutInt a;
 
+	a = 0;
 	EXPECT_TRUE( a > -1 );
-	EXPECT_TRUE( a > 0 );
-	EXPECT_FALSE( a > 1 );
-	EXPECT_FALSE( a > 2 );
+	EXPECT_FALSE( a > 0 );
 }
 
 /*!
@@ -51,12 +51,11 @@ TEST( CLayoutInt, OperatorCompareGreaterThan )
  */
 TEST( CLayoutInt, OperatorCompareGreaterOrEqual )
 {
-	CLayoutInt a( 1 );
+	CLayoutInt a;
 
-	EXPECT_TRUE( a >= -1 );
+	a = 0;
 	EXPECT_TRUE( a >= 0 );
-	EXPECT_TRUE( a >= 1 );
-	EXPECT_FALSE( a >= 2 );
+	EXPECT_FALSE( a >= 1 );
 }
 
 /*!
@@ -64,12 +63,11 @@ TEST( CLayoutInt, OperatorCompareGreaterOrEqual )
  */
 TEST( CLayoutInt, OperatorCompareLessThan )
 {
-	CLayoutInt a( 1 );
+	CLayoutInt a;
 
-	EXPECT_FALSE( a < -1 );
+	a = 0;
 	EXPECT_FALSE( a < 0 );
-	EXPECT_FALSE( a < 1 );
-	EXPECT_TRUE( a < 2 );
+	EXPECT_TRUE( a < 1 );
 }
 
 /*!
@@ -77,12 +75,11 @@ TEST( CLayoutInt, OperatorCompareLessThan )
  */
 TEST( CLayoutInt, OperatorCompareLessOrEqual )
 {
-	CLayoutInt a( 1 );
+	CLayoutInt a;
 
+	a = 0;
 	EXPECT_FALSE( a <= -1 );
-	EXPECT_FALSE( a <= 0 );
-	EXPECT_TRUE( a <= 1 );
-	EXPECT_TRUE( a <= 2 );
+	EXPECT_TRUE( a <= 0 );
 }
 
 /*!
@@ -90,12 +87,13 @@ TEST( CLayoutInt, OperatorCompareLessOrEqual )
  */
 TEST( CLayoutInt, GlobalOperatorCompareGreaterThan )
 {
-	CLayoutInt a( 1 );
+	CLayoutInt a;
 
-	EXPECT_FALSE( -1 > a );
+	a = 1;
 	EXPECT_FALSE( 0 > a );
 	EXPECT_FALSE( 1 > a );
 	EXPECT_TRUE( 2 > a );
+	EXPECT_TRUE( 3 > a );
 }
 
 /*!
@@ -103,12 +101,13 @@ TEST( CLayoutInt, GlobalOperatorCompareGreaterThan )
  */
 TEST( CLayoutInt, GlobalOperatorCompareGreaterOrEqual )
 {
-	CLayoutInt a( 1 );
+	CLayoutInt a;
 
-	EXPECT_FALSE( -1 >= a );
+	a = 1;
 	EXPECT_FALSE( 0 >= a );
 	EXPECT_TRUE( 1 >= a );
 	EXPECT_TRUE( 2 >= a );
+	EXPECT_TRUE( 3 >= a );
 }
 
 /*!
@@ -116,12 +115,13 @@ TEST( CLayoutInt, GlobalOperatorCompareGreaterOrEqual )
  */
 TEST( CLayoutInt, GlobalOperatorCompareLessThan )
 {
-	CLayoutInt a( 1 );
+	CLayoutInt a;
 
-	EXPECT_TRUE( -1 < a );
+	a = 1;
 	EXPECT_TRUE( 0 < a );
 	EXPECT_FALSE( 1 < a );
 	EXPECT_FALSE( 2 < a );
+	EXPECT_FALSE( 3 < a );
 }
 
 /*!
@@ -129,10 +129,11 @@ TEST( CLayoutInt, GlobalOperatorCompareLessThan )
  */
 TEST( CLayoutInt, GlobalOperatorCompareLessOrEqual )
 {
-	CLayoutInt a( 1 );
+	CLayoutInt a;
 
-	EXPECT_TRUE( -1 <= a );
+	a = 1;
 	EXPECT_TRUE( 0 <= a );
 	EXPECT_TRUE( 1 <= a );
 	EXPECT_FALSE( 2 <= a );
+	EXPECT_FALSE( 3 <= a );
 }

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -104,6 +104,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="test-ccommandline.cpp" />
+    <ClCompile Include="test-clayoutint.cpp" />
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />
     <ClCompile Include="test-editinfo.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -59,5 +59,8 @@
     <ClCompile Include="coverage.cpp">
       <Filter>Other Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-clayoutint.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# PR の目的
CStrictIntegerと整数を比較するためのグローバル演算子の実装が誤っているのを修正します。

## カテゴリ
- 不具合修正

## PR の背景

#524 で `CLogicInt` について説明した際にうっかり既知の不具合情報を公開してしまったので対策を打ちます。

https://github.com/sakura-editor/sakura/pull/524#issuecomment-623243360

> 発覚している問題点がいくつかありますが、NGな変換コードを書けないようにする発想自体は有用だと思っています。
> 
> * 型を分けるためのコード値が `[0,1]` 想定なので2種類の型しか作れない。
>   
>   * サクラエディタ内で取り違えたらマズい数値型は、少なくとも4種類ある。
>   * ロジック位置、レイアウト桁、ロジック行、レイアウト行の4つ。
> * メタクラス定義が重いと考えたのか、デバッグでしか有効にならない。
>   
>   * 通常のint（？）を引数にとる関数とCStrictIntegerな引数をとる関数とでコードが二重化する。
>   * 速度考慮したい処理内では使われない傾向になって、取り違え対策にならない。
>   * デバッグ専用だからチェックが甘かったのか、**グローバルな比較演算子が誤って実装されています。**
> * メタクラスの制約を無効化する `Int` に気付きにくい。
>   
>   * 型制約の~おかしい~(正：厳しい)CStrictIntegerに対して、型制約のゆるい型CLaxIntegerがあります。
>   * 型制約のゆるい型CLaxIntegerは `Int` と定義されています。
> 
> 誤記訂正・・・本音でちゃったのかも

## PR のメリット
- デバッグビルドの不具合を修正できます。
  - 比較演算子の左辺右辺を逆転させた場合の、対応する演算子が間違ってたのが直ります。
- デバッグビルドとリリースビルドの挙動差異がなくなります。

## PR のデメリット (トレードオフとかあれば)
- とくに思いつきません。

## PR の影響範囲
- デバッグビルドのアプリ（＝サクラエディタ）の挙動に影響します。
  - 整数とCLogicInt（またはCLayoutInt)との比較判定に影響する変更です。

## 関連チケット
#524 

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
