### PR TITLE
[WIP] HTML Help の `Compatibility`  を 1.0 にすることにより Azure Pipelines および GitHub Actions で chm/installer のビルドできるようにする

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -62,15 +62,14 @@ jobs:
       run: build-sln.bat ${{ matrix.platform }} ${{ matrix.config }}
       shell: cmd
 
-    ## #922 のため無効化
-    #
-    #- name: Build HTML Help
-    #  run: build-chm.bat
-    #  shell: cmd
-    #
-    #- name: Build installer with Inno Setup
-    #  run: build-installer.bat ${{ matrix.platform }} ${{ matrix.config }}
-    #  shell: cmd
+    - name: Build HTML Help
+      run: build-chm.bat
+      shell: cmd
+
+    - name: Build installer with Inno Setup
+      run: build-installer.bat ${{ matrix.platform }} ${{ matrix.config }}
+      shell: cmd
+
     - name: zipArtifacts
       run: zipArtifacts.bat ${{ matrix.platform }} ${{ matrix.config }}
       shell: cmd

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -45,13 +45,13 @@ jobs:
   - script: build-bmp-tools.bat $(Configuration)
     displayName: Bitmap Split/Mux
 
-#  # Build HTML Help
-#  - script: build-chm.bat
-#    displayName: Build HTML Help
-#
-#  # Build installer with Inno Setup
-#  - script: build-installer.bat $(BuildPlatform) $(Configuration)
-#    displayName: Build installer with Inno Setup
+  # Build HTML Help
+  - script: build-chm.bat
+    displayName: Build HTML Help
+
+  # Build installer with Inno Setup
+  - script: build-installer.bat $(BuildPlatform) $(Configuration)
+    displayName: Build installer with Inno Setup
 
   # zip files for artifacts
   - script: zipArtifacts.bat    $(BuildPlatform) $(Configuration)

--- a/help/macro/macro.HHP
+++ b/help/macro/macro.HHP
@@ -1,7 +1,7 @@
 [OPTIONS]
 ;Create CHI file=Yes
 Auto Index=Yes
-Compatibility=1.1 or later
+Compatibility=1.0
 Compiled file=macro.chm
 Contents file=macro.hhc
 Default Font=MS UI Gothic,10,128

--- a/help/plugin/plugin.hhp
+++ b/help/plugin/plugin.hhp
@@ -1,6 +1,6 @@
 [OPTIONS]
 Auto Index=Yes
-Compatibility=1.1 or later
+Compatibility=1.0
 Compiled file=plugin.chm
 Contents file=plugin.hhc
 Default Font=MS UI Gothic,10,128

--- a/help/sakura/sakura.hhp
+++ b/help/sakura/sakura.hhp
@@ -1,6 +1,6 @@
 [OPTIONS]
 Auto Index=Yes
-Compatibility=1.1 or later
+Compatibility=1.0
 Compiled file=sakura.chm
 Contents file=sakura.hhc
 Default Font=‚l‚r ‚oƒSƒVƒbƒN,10,128


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートで見た目のチェックができます。 -->

# (必須) PR の目的

HTML Help の `Compatibility`  を 1.0 にすることにより Azure Pipelines および GitHub Actions で chm/installer のビルドできるようにする

## (必須) カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 仕様変更 (HTML Help)
- ビルド関連
  - Azure Pipelines
  - GitHub Actions
  - ローカルビルド
- ドキュメントの問題

## (自明なら省略可) PR の背景

<!-- PR を行う背景を記載してください -->

英語 OS で chm をビルドした場合 #922 の問題が発生していた。
appveyor では System locale を日本語に設定して再起動しているのでこの問題を回避しているが、
Azure Pipelines および GitHub Actions では回避方法がないので、chm/installer のビルドを無効にしている。

以下の情報をいただいたので、`Compatibility`  を 1.0 にして Azure Pipelines および GitHub Actions で chm/installer をビルドできるようにする

https://github.com/sakura-editor/sakura/issues/906#issuecomment-623967488

@k-takata

> (このissueでいいのかな？)
> 英語環境でhhcを動かすとヘルプのキーワードが化ける件ですが、ヘルプの `Compatibility` を `1.1 or later` から `1.0` に変えてみたら、文字化けは起きないようです。1.1 に依存するような機能を使っていなければ、1.0 に変えるのも手かもしれません。

## (自明なら省略可) PR のメリット

<!-- PR のメリットを記載してください。 -->

以下 CI ビルドで chm のビルドを行っても、文字化け #922 が発生しない

Azure Pipelines
GitHub Actions

## (なければ省略可) PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
特になし

## (わかる範囲で) PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
chm のビルド

## (なければ省略可) 関連 issue, PR

#922
https://github.com/sakura-editor/sakura/issues/906#issuecomment-623967488

## (なければ省略可) 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
