### PR TITLE
Azure Pipelines/GitHub Actions で HTML Help をビルドできるようにする

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -58,15 +58,18 @@ jobs:
       run: build-sln.bat ${{ matrix.platform }} ${{ matrix.config }}
       shell: cmd
 
-    ## #922 のため無効化
-    #
-    #- name: Build HTML Help
-    #  run: build-chm.bat
-    #  shell: cmd
-    #
-    #- name: Build installer with Inno Setup
-    #  run: build-installer.bat ${{ matrix.platform }} ${{ matrix.config }}
-    #  shell: cmd
+    - name: Install Locale Emulator
+      run: choco install locale-emulator -y
+      shell: cmd
+
+    - name: Build HTML Help
+      run: build-chm.bat
+      shell: cmd
+
+    - name: Build installer with Inno Setup
+      run: build-installer.bat ${{ matrix.platform }} ${{ matrix.config }}
+      shell: cmd
+
     - name: zipArtifacts
       run: zipArtifacts.bat ${{ matrix.platform }} ${{ matrix.config }}
       shell: cmd

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -62,8 +62,10 @@ exit /b 0
 :BuildChm
 set PROJECT_HHP=%1
 set PROJECT_CHM=%2
+set PROJECT_LOG=%~dp2\Compile.log
 
 if exist "%PROJECT_CHM%" del /F "%PROJECT_CHM%"
+if exist "%PROJECT_LOG%" del /F "%PROJECT_LOG%"
 
 if defined CMD_LEPROC (
 	for /L %%j in (1,1,2) do (
@@ -75,12 +77,8 @@ if defined CMD_LEPROC (
 		@rem wait to create chm
 		for /L %%i in (1,1,30) do (
 			ping -n 2 localhost > NUL
-			copy "%PROJECT_CHM%" nul > NUL 2>&1
-			if not errorlevel 1 (
-				@rem additional wait
-				ping -n 5 localhost > NUL
-				exit /b 0
-			)
+			copy "%PROJECT_LOG%" nul > NUL 2>&1
+			if not errorlevel 1 exit /b 0
 		)
 		echo retry creating %PROJECT_CHM%
 	)

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -68,14 +68,10 @@ if exist "%PROJECT_CHM%" del /F "%PROJECT_CHM%"
 if exist "%PROJECT_LOG%" del /F "%PROJECT_LOG%"
 
 if defined CMD_LEPROC (
-	for /L %%j in (1,1,2) do (
+	for /L %%i in (1,1,2) do (
 		"%CMD_LEPROC%" %COMSPEC% /c """%CMD_HHC%"" %PROJECT_HHP%"
-		if errorlevel 1 (
-			echo fail to execute LEProc
-			exit /b 1
-		)
 		@rem wait to create chm
-		for /L %%i in (1,1,30) do (
+		for /L %%j in (1,1,30) do (
 			ping -n 2 localhost > NUL
 			copy "%PROJECT_LOG%" nul > NUL 2>&1
 			if not errorlevel 1 exit /b 0
@@ -83,22 +79,16 @@ if defined CMD_LEPROC (
 		echo retry creating %PROJECT_CHM%
 	)
 	echo fail to create %PROJECT_CHM%
-	exit /b 1
 ) else (
-	@rem hhc.exe returns 1 on success, and returns 0 on failure
-	"%CMD_HHC%" %PROJECT_HHP%
-	if not errorlevel 1 (
-		echo error %PROJECT_HHP% errorlevel %errorlevel%
-
-		del /F "%PROJECT_CHM%"
+	for /L %%i in (1,1,2) do (
+		@rem hhc.exe returns 1 on success, and returns 0 on failure
 		"%CMD_HHC%" %PROJECT_HHP%
+		if errorlevel 1 exit /b 0
+		echo error %PROJECT_HHP% errorlevel %errorlevel%
+		del /F "%PROJECT_CHM%"
 	)
-	if not errorlevel 1 (
-		echo retry error %PROJECT_HHP% errorlevel %errorlevel%
-		exit /b 1
-	)
-	exit /b 0
 )
+exit /b 1
 
 :download_archive
 pwsh.exe -ExecutionPolicy RemoteSigned -File %SRC_HELP%\extract-chm-from-artifact.ps1

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -66,16 +66,23 @@ set PROJECT_CHM=%2
 if exist "%PROJECT_CHM%" del /F "%PROJECT_CHM%"
 
 if defined CMD_LEPROC (
-	"%CMD_LEPROC%" %COMSPEC% /c """%CMD_HHC%"" %PROJECT_HHP%"
-	if errorlevel 1 (
-		echo fail to execute LEProc
-		exit /b 1
-	)
-	@rem wait to create chm
-	for /L %%i in (1,1,30) do (
-		ping -n 2 localhost > NUL
-		copy "%PROJECT_CHM%" nul > NUL 2>&1
-		if not errorlevel 1 exit /b 0
+	for /L %%j in (1,1,2) do (
+		"%CMD_LEPROC%" %COMSPEC% /c """%CMD_HHC%"" %PROJECT_HHP%"
+		if errorlevel 1 (
+			echo fail to execute LEProc
+			exit /b 1
+		)
+		@rem wait to create chm
+		for /L %%i in (1,1,30) do (
+			ping -n 2 localhost > NUL
+			copy "%PROJECT_CHM%" nul > NUL 2>&1
+			if not errorlevel 1 (
+				@rem additional wait
+				ping -n 5 localhost > NUL
+				exit /b 0
+			)
+		)
+		echo retry creating %PROJECT_CHM%
 	)
 	echo fail to create %PROJECT_CHM%
 	exit /b 1

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -45,13 +45,17 @@ jobs:
   - script: build-bmp-tools.bat $(Configuration)
     displayName: Bitmap Split/Mux
 
-#  # Build HTML Help
-#  - script: build-chm.bat
-#    displayName: Build HTML Help
-#
-#  # Build installer with Inno Setup
-#  - script: build-installer.bat $(BuildPlatform) $(Configuration)
-#    displayName: Build installer with Inno Setup
+  # Install Locale Emulator
+  - script: choco install locale-emulator -y
+    displayName: Install Locale Emulator
+
+  # Build HTML Help
+  - script: build-chm.bat
+    displayName: Build HTML Help
+
+  # Build installer with Inno Setup
+  - script: build-installer.bat $(BuildPlatform) $(Configuration)
+    displayName: Build installer with Inno Setup
 
   # zip files for artifacts
   - script: zipArtifacts.bat    $(BuildPlatform) $(Configuration)

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -13,6 +13,7 @@ if "%1" equ "clear" (
     set CMD_MSBUILD=
     set CMD_CMAKE=
     set CMD_NINJA=
+    set CMD_LEPROC=
     set NUM_VSVERSION=
     set CMAKE_G_PARAM=
     set FIND_TOOLS_CALLED=
@@ -37,6 +38,7 @@ if not defined CMD_VSWHERE  call :vswhere  2> nul
 if not defined CMD_MSBUILD  call :msbuild  2> nul
 if not defined CMD_CMAKE    call :cmake    2> nul
 if not defined CMD_NINJA    call :cmake    2> nul
+if not defined CMD_LEPROC   call :leproc   2> nul
 echo ^|- CMD_GIT=%CMD_GIT%
 echo ^|- CMD_7Z=%CMD_7Z%
 echo ^|- CMD_HHC=%CMD_HHC%
@@ -47,6 +49,7 @@ echo ^|- CMD_VSWHERE=%CMD_VSWHERE%
 echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
 echo ^|- CMD_CMAKE=%CMD_CMAKE%
 echo ^|- CMD_NINJA=%CMD_NINJA%
+echo ^|- CMD_LEPROC=%CMD_LEPROC%
 echo ^|- CMAKE_G_PARAM=%CMAKE_G_PARAM%
 endlocal ^
     && set "CMD_GIT=%CMD_GIT%"                  ^
@@ -59,6 +62,7 @@ endlocal ^
     && set "CMD_MSBUILD=%CMD_MSBUILD%"          ^
     && set "CMD_CMAKE=%CMD_CMAKE%"              ^
     && set "CMD_NINJA=%CMD_NINJA%"              ^
+    && set "CMD_LEPROC=%CMD_LEPROC%"            ^
     && set "NUM_VSVERSION=%NUM_VSVERSION%"      ^
     && set "CMAKE_G_PARAM=%CMAKE_G_PARAM%"      ^
     && echo end
@@ -255,6 +259,14 @@ exit /b
 if exist "%CMD_NINJA%" goto :EOF
 for /f "usebackq delims=" %%a in (`where $PATH:ninja`) do ( 
     set "CMD_NINJA=%%a"
+    exit /b
+)
+exit /b
+
+:leproc
+set PATH2=%PATH%
+for /f "usebackq delims=" %%a in (`where $PATH2:LEProc.exe`) do (
+    set "CMD_LEPROC=%%a"
     exit /b
 )
 exit /b

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -21,6 +21,7 @@
 | doxygen            | CMD_DOXYGEN  | doxygen\bin        | doxygen.exe  |
 | vswhere            | CMD_VSWHERE  | Microsoft Visual Studio\Installer | vswhere.exe  |
 | MSBuild            | CMD_MSBUILD  | 特殊               | MSBuild.exe  |
+| Locale Emulator    | CMD_LEPROC   | なし               | LEProc.exe   |
 
 ## MSBuild以外の探索手順
 MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。


### PR DESCRIPTION
# (必須) PR の目的

#922 等で議論されているとおり、英語版 OS 上では HTML Help をビルドすると、キーワードが文字化けしてしまう。Locale Emulator を使うことで、英語版 OS 上でも HTML Help をビルドできるようにする。

## (必須) カテゴリ

- ビルド関連
  - Azure Pipelines
  - GitHub Actions
  - ローカルビルド

## (自明なら省略可) PR の背景

#1269 の方法では、文字化けは解消されるものの、表示されるキーワードが少なくなってしまっていた。

## (わかる範囲で) PR の影響範囲

HTML Help のビルド

## 仕様・動作説明

Locale Emulator には決まったインストール先はないので、find-tools.bat では PATH のみを検索対象とする。
Locale Emulator は、デフォルトでは日本語ロケールで実行するので、特にプロファイルを用意したりはしない。

## (なければ省略可) 関連 issue, PR

#922, #1269