### PR TITLE
GitHub Actions の成果物を別々の ZIP として upload する

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -93,10 +93,10 @@ jobs:
         name: Exe ${{ matrix.platform }} ${{ matrix.config }}
         path: 'sakura-*-Exe.zip'
 
-    - name: Upload Exe md5
+    - name: Upload Exe MD5
       uses: actions/upload-artifact@v2
       with:
-        name: Exe md5 ${{ matrix.platform }} ${{ matrix.config }}
+        name: Exe MD5 ${{ matrix.platform }} ${{ matrix.config }}
         path: 'sakura-*-Exe.zip.md5'
 
     - name: Upload Log

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -75,8 +75,44 @@ jobs:
       shell: cmd
 
     ## see https://github.com/actions/upload-artifact
-    - name: Upload
+    - name: Upload Installer
       uses: actions/upload-artifact@v2
       with:
-        name: exe ${{ matrix.platform }} ${{ matrix.config }}
-        path: '*.zip'
+        name: Installer ${{ matrix.platform }} ${{ matrix.config }}
+        path: 'sakura-*-Installer.zip'
+
+    - name: Upload Installer MD5
+      uses: actions/upload-artifact@v2
+      with:
+        name: Installer MD5 ${{ matrix.platform }} ${{ matrix.config }}
+        path: 'sakura-*-Installer.zip.md5'
+
+    - name: Upload Exe
+      uses: actions/upload-artifact@v2
+      with:
+        name: Exe ${{ matrix.platform }} ${{ matrix.config }}
+        path: 'sakura-*-Exe.zip'
+
+    - name: Upload Exe md5
+      uses: actions/upload-artifact@v2
+      with:
+        name: Exe md5 ${{ matrix.platform }} ${{ matrix.config }}
+        path: 'sakura-*-Exe.zip.md5'
+
+    - name: Upload Log
+      uses: actions/upload-artifact@v2
+      with:
+        name: Log ${{ matrix.platform }} ${{ matrix.config }}
+        path: 'sakura-*-Log.zip'
+
+    - name: Upload Asm
+      uses: actions/upload-artifact@v2
+      with:
+        name: Asm ${{ matrix.platform }} ${{ matrix.config }}
+        path: 'sakura-*-Asm.zip'
+
+    - name: Upload Dev
+      uses: actions/upload-artifact@v2
+      with:
+        name: Dev ${{ matrix.platform }} ${{ matrix.config }}
+        path: 'sakura-*-Dev.zip'


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。  -->
<!-- Preview のシートで見た目のチェックができます。 -->

# (必須) PR の目的

GitHub Actions の成果物を別々の ZIP として upload する

## (必須) カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- ビルド関連
  - GitHub Actions

## (自明なら省略可) PR の背景

#1259 で成果物を上げるときに、個別に上げずにまとめてアップしていた。

## (自明なら省略可) PR のメリット

個別にダウンロードできる。

## (なければ省略可) PR のデメリット (トレードオフとかあれば)

Installer の成果物は存在しないけど項目として存在している。

## (仕様変更/機能追加の場合は必須) 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## (必須) テスト内容

fork に対して push して、個別に成果物が up されること

## (わかる範囲で) PR の影響範囲

GitHub Actions

## (なければ省略可) 関連 issue, PR

#1259
#1263

## (なければ省略可) 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
