### PR TITLE
シングルクォートで囲まれたメールアドレスを認識できるようにする

### DIFF
--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -413,9 +413,14 @@ BOOL IsURL(
 		return FALSE;
 	}
 
-	if( wc_to_c(*begin)==0 ) return FALSE;	/* 2バイト文字 */
-	if( 0 < url_char[wc_to_c(*begin)] ){	/* URL開始文字 */
-		for(urlp = &url_table[url_char[wc_to_c(*begin)]-1]; urlp->name[0] == wc_to_c(*begin); urlp++){	/* URLテーブルを探索 */
+	// 検査範囲の先頭文字を取得する(ASCII文字でなければNULになる)
+	const auto headChar = wc_to_c( *begin );
+
+	// 検査範囲の先頭文字がASCII文字でなければ、URLではないと判定する
+	if( headChar == 0 ) return FALSE;
+
+	if( 0 < url_char[headChar] ){
+		for(urlp = &url_table[url_char[headChar]-1]; urlp->name[0] == headChar; urlp++){	/* URLテーブルを探索 */
 			if( (urlp->length <= end - begin) && (wmemcmp(urlp->name, begin, urlp->length) == 0) ){	/* URLヘッダは一致した */
 				if( urlp->is_mail ){	/* メール専用の解析へ */
 					if( IsMailAddress(begin, urlp->length, end - begin - urlp->length, pnMatchLen) ){

--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -419,8 +419,13 @@ BOOL IsURL(
 	// 検査範囲の先頭文字がASCII文字でなければ、URLではないと判定する
 	if( headChar == 0 ) return FALSE;
 
-	if( 0 < url_char[headChar] ){
-		for(urlp = &url_table[url_char[headChar]-1]; urlp->name[0] == headChar; urlp++){	/* URLテーブルを探索 */
+	// 検査範囲の先頭文字に対応するURL種類のテーブルインデックスを取得する
+	const auto urlTypeIndex = url_char[headChar];
+
+	// URL種類のテーブルインデックスを取得できた場合
+	if( 0 < urlTypeIndex ){
+		// URL種類のテーブルインデックスから順番に走査する
+		for(urlp = &url_table[urlTypeIndex-1]; urlp->name[0] == headChar; urlp++ ){	/* URLテーブルを探索 */
 			if( (urlp->length <= end - begin) && (wmemcmp(urlp->name, begin, urlp->length) == 0) ){	/* URLヘッダは一致した */
 				if( urlp->is_mail ){	/* メール専用の解析へ */
 					if( IsMailAddress(begin, urlp->length, end - begin - urlp->length, pnMatchLen) ){

--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -395,7 +395,8 @@ BOOL IsURL(
 	const wchar_t*	pszLine,	//!< [in]  文字列バッファ(=行データ)の先頭アドレス
 	const int		offset,		//!< [in]  検査を開始する位置。
 	const int		nLineLen,	//!< [in]  文字列バッファの長さ。wchar_tの個数。
-	int*			pnMatchLen	//!< [opt,out] URLの長さを受け取る変数を指すポインタ。wchar_tの個数。省略可能。
+	int*			pnMatchLen,	//!< [opt,out] URLの長さを受け取る変数を指すポインタ。wchar_tの個数。省略可能。
+	std::wstring*	pstrUrl		//!< [opt,out] アクセス可能なURL文字列を受け取る変数のアドレス。省略可能。
 )
 {
 	int matchedLength = 0;
@@ -437,6 +438,9 @@ BOOL IsURL(
 			if( pnMatchLen != NULL ){
 				*pnMatchLen = entry.length() + matchedLength;
 			}
+			if( pstrUrl != NULL ){
+				*pstrUrl = std::wstring( begin, matchedLength );
+			}
 			return TRUE;
 		}else{
 			/* 通常の解析へ */
@@ -446,6 +450,15 @@ BOOL IsURL(
 			if( matchedLength == (int)entry.length() ) return FALSE;	/* URLヘッダだけ */
 			if( pnMatchLen != NULL ){
 				*pnMatchLen = matchedLength;
+			}
+			if( pstrUrl != NULL ){
+				if( urlTypeIndex == urT && entry == L"ttp://" ){
+					*pstrUrl = L"h" + std::wstring( begin, matchedLength );
+				}else if( urlTypeIndex == urT && entry == L"tp://" ){
+					*pstrUrl = L"ht" + std::wstring( begin, matchedLength );
+				}else{
+					*pstrUrl = std::wstring( begin, matchedLength );
+				}
 			}
 			return TRUE;
 		}
@@ -462,6 +475,9 @@ BOOL IsURL(
 	if( isMailAddress ){
 		if( pnMatchLen != NULL ){
 			*pnMatchLen = matchedLength;
+		}
+		if( pstrUrl != NULL ){
+			*pstrUrl = L"mailto:" + std::wstring( begin, matchedLength );
 		}
 	}
 	return isMailAddress;

--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -495,6 +495,9 @@ BOOL IsMailAddress( const wchar_t* pszBuf, int offset, int nBufLen, int* pnAddre
 		}
 	} IsValidChar;
 
+	// 検査範囲の先頭文字を取得する
+	const auto headChar = offset < 0 || nBufLen <= offset ? 0 : pszBuf[offset];
+
 	pszBuf  += offset;
 	nBufLen -= offset;
 	offset   = 0;
@@ -551,6 +554,13 @@ BOOL IsMailAddress( const wchar_t* pszBuf, int offset, int nBufLen, int* pnAddre
 			nDotCount++;
 			j++;
 		}
+	}
+	// シングルクォートで囲まれたメールアドレスの引用開始がアドレスの一部と誤検知される対策
+	if( headChar == L'\x27'
+		&& j < nBufLen
+		&& headChar == pszBuf[j] )
+	{
+		return FALSE;
 	}
 	if( NULL != pnAddressLength){
 		*pnAddressLength = j;

--- a/sakura_core/parse/CWordParse.h
+++ b/sakura_core/parse/CWordParse.h
@@ -124,13 +124,11 @@ protected:
 	static bool _match_charlist( const WCHAR c, const WCHAR *pszList );
 };
 
-/** 指定アドレスが URL の先頭ならば TRUE とその長さを返す。
+/** 指定された文字列内の位置が URL の先頭か検査する。
     @param[in]  pszLine    文字列バッファの先頭アドレス
-    @param[in]  offset     URL 判定開始文字を示す、pszLine からの相対位置。
-    @param[in]  nLineLen   URL 判定最終文字の次を示す、pszLine からの相対位置。
-    @param[out] pnMatchLen URL の長さを受け取る変数のアドレス。NULL可。長さとは pszLine + offset からの距離。
-
-    境界判定はメールアドレスの先頭でのみ行われ、URL の先頭ではこれまで通り行われません。
+    @param[in]  offset     検査を開始する位置。
+    @param[in]  nLineLen   文字列バッファの長さ。wchar_tの個数。
+    @param[opt,out] pnMatchLen URL の長さを受け取る変数のアドレス。wchar_tの個数。省略可能。
 */
 BOOL IsURL( const wchar_t* pszLine, int offset, int nLineLen, int* pnMatchLen);
 
@@ -142,15 +140,14 @@ BOOL IsURL( const wchar_t* pszLine, int nLineLen, int* pnMatchLen)
 	return IsURL(pszLine, 0, nLineLen, pnMatchLen);
 }
 
-/** 指定アドレスがメールアドレスの先頭ならば TRUE とその長さを返す。
+/** 指定された文字列内の位置が メールアドレス の先頭であるか検査する。
     @param[in]  pszBuf          文字列バッファの先頭アドレス
     @param[in]  offset          メールアドレス判定開始文字を示す、pszBuf からの相対位置。
     @param[in]  nBufLen         メールアドレス判定最終文字の次を示す、pszBuf からの相対位置。
     @param[out] pnAddressLength メールアドレスの長さを受け取る変数のアドレス。NULL可。長さとは pszBuf + offset からの距離。
 
-    正の offset が与えられた場合は、その場合に限り、判定開始位置直前の文字との間で境界判定を行います。
-    途中から切り出したメールアドレスの一部をメールアドレスであると誤って判定しないために
-    pszBuf を固定し offset を０以上の範囲で変化させるのが望ましい使用方法です。
+	この関数は先頭の境界検出を行わないません。
+	この関数は直接呼び出さず、IsURL関数を利用してください。
 */
 BOOL IsMailAddress( const wchar_t* pszBuf, int offset, int nBufLen, int* pnAddressLength);
 

--- a/sakura_core/parse/CWordParse.h
+++ b/sakura_core/parse/CWordParse.h
@@ -129,16 +129,9 @@ protected:
     @param[in]  offset     検査を開始する位置。
     @param[in]  nLineLen   文字列バッファの長さ。wchar_tの個数。
     @param[opt,out] pnMatchLen URL の長さを受け取る変数のアドレス。wchar_tの個数。省略可能。
+	@param[opt,out] pstrUrl アクセス可能なURL文字列を受け取る変数のアドレス。省略可能。
 */
-BOOL IsURL( const wchar_t* pszLine, int offset, int nLineLen, int* pnMatchLen);
-
-/** @deprecated 互換性のために残されています。offset 引数が追加されたものを使用してください。
-*/
-inline
-BOOL IsURL( const wchar_t* pszLine, int nLineLen, int* pnMatchLen)
-{
-	return IsURL(pszLine, 0, nLineLen, pnMatchLen);
-}
+BOOL IsURL( const wchar_t* pszLine, int offset, int nLineLen, int* pnMatchLen, std::wstring* pstrUrl = NULL );
 
 /** 指定された文字列内の位置が メールアドレス の先頭であるか検査する。
     @param[in]  pszBuf          文字列バッファの先頭アドレス

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1194,7 +1194,7 @@ void CEditView::MoveCursorSelecting(
 bool CEditView::IsCurrentPositionURL(
 	const CLayoutPoint&	ptCaretPos,		//!< [in]  カーソル位置
 	CLogicRange*		pUrlRange,		//!< [out] URL範囲。ロジック単位。
-	std::wstring*		pstrURL		//!< [out] URL文字列受け取り先。NULLを指定した場合はURL文字列を受け取らない。
+	std::wstring*		pstrURL			//!< [out] URL文字列受け取り先。NULLを指定した場合はURL文字列を受け取らない。
 )
 {
 	MY_RUNNINGTIMER( cRunningTimer, "CEditView::IsCurrentPositionURL" );
@@ -1242,15 +1242,12 @@ bool CEditView::IsCurrentPositionURL(
 	int			nMatchColor;
 	int			nUrlLen = 0;
 	CLogicInt	i = CLogicInt(t_max(CLogicInt(0), ptXY.GetX2() - _MAX_PATH));	// 2009.05.22 ryoji 200->_MAX_PATH
-	//nLineLen = CLogicInt(__min(nLineLen, ptXY.GetX2() + _MAX_PATH));
 	while( i <= ptXY.GetX2() && i < nLineLen ){
 		bMatch = ( bUseRegexKeyword
 					&& m_cRegexKeyword->RegexIsKeyword( CStringRef(pLine, nLineLen), i, &nUrlLen, &nMatchColor )
 					&& nMatchColor == COLORIDX_URL );
-		if( !bMatch ){
-			bMatch = ( bDispUrl
-						&& (i == 0 || !IS_KEYWORD_CHAR(pLine[i - 1]))	// 2009.05.22 ryoji CColor_Url::BeginColor()と同条件に
-						&& IsURL(&pLine[i], (Int)(nLineLen - i), &nUrlLen) );	/* 指定アドレスがURLの先頭ならばTRUEとその長さを返す */
+		if( !bMatch && bDispUrl ){
+			bMatch = IsURL( pLine, i, nLineLen, &nUrlLen, pstrURL );
 		}
 		if( bMatch ){
 			if( i <= ptXY.GetX2() && ptXY.GetX2() < i + CLogicInt(nUrlLen) ){

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -1540,38 +1540,20 @@ void CEditView::OnLBUTTONDBLCLK( WPARAM fwKeys, int _xPos , int _yPos )
 {
 	CMyPoint ptMouse(_xPos,_yPos);
 
-	CLogicRange		cUrlRange;	// URL範囲
-	std::wstring	strURL;
-	const wchar_t*	pszMailTo = L"mailto:";
-
 	// 2007.10.06 nasukoji	クアドラプルクリック時はチェックしない
 	if(! m_dwTripleClickCheck){
+		CLogicRange		cUrlRange;	// URL範囲
+		std::wstring	strURL;
 		/* カーソル位置にURLが有る場合のその範囲を調べる */
 		if(
 			IsCurrentPositionURL(
 				GetCaret().GetCaretLayoutPos(),	// カーソル位置
-				&cUrlRange,				// URL範囲
-				&strURL				// URL受け取り先
+				&cUrlRange,						// URL範囲
+				&strURL							// URL受け取り先
 			)
 		){
-			std::wstring strOPEN;
-
 			// URLを開く
-		 	// 現在位置がメールアドレスならば、NULL以外と、その長さを返す
-			if( IsMailAddress( strURL.c_str(), strURL.length(), NULL ) ){
-				strOPEN = pszMailTo + strURL;
-			}
-			else{
-				if( wcsnicmp_literal( strURL.c_str(), L"ttp://" ) == 0 ){	//抑止URL
-					strOPEN = L"h" + strURL;
-				}
-				else if( wcsnicmp_literal( strURL.c_str(), L"tp://" ) == 0 ){	//抑止URL
-					strOPEN = L"ht" + strURL;
-				}
-				else{
-					strOPEN = strURL;
-				}
-			}
+			std::wstring strOPEN( strURL );
 			{
 				// URLを開く
 				// 2009.05.21 syat UNCパスだと1分以上無応答になることがあるのでスレッド化

--- a/sakura_core/view/colors/CColor_Url.cpp
+++ b/sakura_core/view/colors/CColor_Url.cpp
@@ -15,17 +15,10 @@ bool CColor_Url::BeginColor(const CStringRef& cStr, int nPos)
 {
 	if(!cStr.IsValid())return false;
 
-	// なんかの条件
-	const bool someCondition = _IsPosKeywordHead( cStr, nPos );
-	//　↓
-	// return (nPos == 0 || !IS_KEYWORD_CHAR( cStr.At( nPos - 1 ) ));
-	//　↓
-	// nPos が 行頭、または、nPos の 直前の文字が キーワードに使える文字 でも ユーザー定義キーワード文字 でもない
-
 	int	nUrlLen;
 
 	// nPos が URL の先頭である場合
-	if( someCondition && IsURL( cStr.GetPtr(), nPos, cStr.GetLength(), &nUrlLen ) )
+	if( IsURL( cStr.GetPtr(), nPos, cStr.GetLength(), &nUrlLen ) )
 	{
 		this->m_nCOMMENTEND = nPos + nUrlLen;
 		return true;

--- a/sakura_core/view/colors/CColor_Url.cpp
+++ b/sakura_core/view/colors/CColor_Url.cpp
@@ -15,11 +15,18 @@ bool CColor_Url::BeginColor(const CStringRef& cStr, int nPos)
 {
 	if(!cStr.IsValid())return false;
 
+	// なんかの条件
+	const bool someCondition = _IsPosKeywordHead( cStr, nPos );
+	//　↓
+	// return (nPos == 0 || !IS_KEYWORD_CHAR( cStr.At( nPos - 1 ) ));
+	//　↓
+	// nPos が 行頭、または、nPos の 直前の文字が キーワードに使える文字 でも ユーザー定義キーワード文字 でもない
+
 	int	nUrlLen;
 
-	if( _IsPosKeywordHead(cStr,nPos) /* URLを表示する */
-	 && IsURL( cStr.GetPtr(), nPos, cStr.GetLength(), &nUrlLen )	/* 指定アドレスがURLの先頭ならばTRUEとその長さを返す */
-	){
+	// nPos が URL の先頭である場合
+	if( someCondition && IsURL( cStr.GetPtr(), nPos, cStr.GetLength(), &nUrlLen ) )
+	{
 		this->m_nCOMMENTEND = nPos + nUrlLen;
 		return true;
 	}

--- a/tests/unittests/test-is_mailaddress.cpp
+++ b/tests/unittests/test-is_mailaddress.cpp
@@ -38,6 +38,7 @@
 // テスト対象関数のヘッダファイル
 //#include "util/string_ex.h" //依存関係が多いのでテスト対象の関数定義のみ抜き出し
 BOOL IsMailAddress(const wchar_t* pszBuf, int nBufLen, int* pnAddressLength);
+BOOL IsURL( const wchar_t* pszBuf, int nBufLen, int* pnAddressLength );
 
 //////////////////////////////////////////////////////////////////////
 // テストマクロ
@@ -205,7 +206,7 @@ TEST(testIsMailAddress, CheckAwithAtmark)
 	ASSERT_SAME(FALSE, szTest, _countof(szTest) - 1, NULL);
 }
 
-TEST(testIsMailAddress, OffsetParameter)
+TEST(testIsURL, OffsetParameter)
 {
 	/*
 	   Prepare test cases.
@@ -218,40 +219,40 @@ TEST(testIsMailAddress, OffsetParameter)
 	const wchar_t* const BufferEnd = Buffer + wcslen(Buffer);
 	const struct {
 		bool           expected;
-		const wchar_t* address;         // to be tested by IsMailAddress.
-		int            offset;          // passed to IsMailAddress as 2nd param.
-		const wchar_t* buffer() const { // passed to IsMailAddress as 1st param.
+		const wchar_t* address;         // to be tested by IsURL.
+		int            offset;          // passed to IsURL as 2nd param.
+		const wchar_t* buffer() const { // passed to IsURL as 1st param.
 			return this->address - this->offset;
 		}
 	} testCases[] = {
 		{ true,  Buffer+1,  0 }, // true is OK. Buffer+1 is a mail address.
 		{ true,  Buffer+1,  1 }, // true is OK. Buffer+1 is a mail address.
 		{ true,  Buffer+1, -1 }, // true is OK. Buffer+1 is a mail address.
-		{ true,  Buffer+2,  0 }, // Limitation: Non positive offset prevents IsMailAddress from looking behind of a possible head of a mail address.
+		{ true,  Buffer+2,  0 }, // Limitation: Non positive offset prevents IsURL from looking behind of a possible head of a mail address.
 		{ false, Buffer+2,  1 }, // false is OK. Buffer+2 is not a head of a mail adderss.
-		{ true,  Buffer+2, -1 }  // Limitation: Non positive offset prevents IsMailAddress from looking behind of a possible head of a mail address.
+		{ true,  Buffer+2, -1 }  // Limitation: Non positive offset prevents IsURL from looking behind of a possible head of a mail address.
 	};
 	for (auto& aCase: testCases) {
 		assert(Buffer <= aCase.buffer());
 	}
 
 	/*
-	   Apply IsMailAddress to the cases.
+	   Apply IsURL to the cases.
 	*/
 	for (auto& aCase: testCases) {
 		EXPECT_EQ(
 			aCase.expected,
-			bool(IsMailAddress(aCase.buffer(), aCase.offset, BufferEnd - aCase.buffer(), NULL))
-		) << "1st param of IsMailAddress: pszBuf is \"" << aCase.buffer() << "\"\n"
-		  << "2nd param of IsMailAddress: offset is "   << aCase.offset;
+			bool(IsURL(aCase.buffer(), aCase.offset, BufferEnd - aCase.buffer(), NULL))
+		) << "1st param of IsURL: pszBuf is \"" << aCase.buffer() << "\"\n"
+		  << "2nd param of IsURL: offset is "   << aCase.offset;
 	}
 }
 
-TEST(testIsMailAddress, OffsetParameter2)
+TEST(testIsURL, OffsetParameter2)
 {
 	const wchar_t* const Text             = L"   test@example.com   ";
 	const wchar_t* const Address          = Text +  3; // Address is "test@example.com"
-	const wchar_t* const PseudoAddress    = Text +  6; // PseudoAddress is "t@example.c", shortest form recognized by IsMailAddress.
+	const wchar_t* const PseudoAddress    = Text +  6; // PseudoAddress is "t@example.c", shortest form recognized by IsURL.
 	const wchar_t* const PseudoAddressEnd = Text + 17;
 	const wchar_t* const AddressEnd       = Text + 19;
 	const wchar_t* const TextEnd          = Text + 22;
@@ -279,42 +280,42 @@ TEST(testIsMailAddress, OffsetParameter2)
 			if (AddressEnd <= p3) {
 				return Result{true, static_cast<int>(AddressEnd - Address)}; // 文句なしの TRUE 判定。
 			} else {
-				return Result{true, static_cast<int>(p3 - Address)}; // アドレスの終端が切り詰められているが、IsMailAddress には知る由がない。ゆえに問題なし。
+				return Result{true, static_cast<int>(p3 - Address)}; // アドレスの終端が切り詰められているが、IsURL には知る由がない。ゆえに問題なし。
 			}
 		} else if (p2 <= p1) {
 			if (AddressEnd <= p3) {
-				return Result{true, static_cast<int>(AddressEnd - p2)}; // アドレスの先端が切り詰められているが、IsMailAddress には知る由がない。ゆえに問題なし。
+				return Result{true, static_cast<int>(AddressEnd - p2)}; // アドレスの先端が切り詰められているが、IsURL には知る由がない。ゆえに問題なし。
 			} else {
-				return Result{true, static_cast<int>(p3 - p2)}; // アドレスの先端と終端が切り詰められているが、IsMailAddress には知る由がない。ゆえに問題なし。
+				return Result{true, static_cast<int>(p3 - p2)}; // アドレスの先端と終端が切り詰められているが、IsURL には知る由がない。ゆえに問題なし。
 			}
 		} else {
-			return FalseResult; // アドレスの先端が切り詰められ、IsMailAddress が境界判定によりそれを検知した。文句なしの FALSE 判定。
+			return FalseResult; // アドレスの先端が切り詰められ、IsURL が境界判定によりそれを検知した。文句なしの FALSE 判定。
 		}
 	};
 	auto IsEqualResult = [](const Result& expected, const Result& actual) -> testing::AssertionResult
 	{
 		if (expected.is_address != actual.is_address) {
-			return testing::AssertionFailure() << "IsMailAddress returned " << (actual.is_address?"TRUE":"FALSE") << " but expected " << (expected.is_address?"TRUE":"FALSE") << ".";
+			return testing::AssertionFailure() << "IsURL returned " << (actual.is_address?"TRUE":"FALSE") << " but expected " << (expected.is_address?"TRUE":"FALSE") << ".";
 		}
 		if (expected.length != actual.length) {
-			return testing::AssertionFailure() << "IsMailAddress returned the address length " << (actual.length) << " but expected " << (expected.length) << ".";
+			return testing::AssertionFailure() << "IsURL returned the address length " << (actual.length) << " but expected " << (expected.length) << ".";
 		}
 		return testing::AssertionSuccess();
 	};
 
 	/*
-	   Text...TextEnd の範囲の文字配列に対して、IsMailAddress の３つの
+	   Text...TextEnd の範囲の文字配列に対して、IsURL の３つの
 	   引数(pszBuf, offset, nBufLen)がとりうるすべての値を総当たりで試す。
 	*/
 	for (const wchar_t* p1 = Text; p1 != TextEnd; ++p1)   // p1 is a pointer to buffer.
 	for (const wchar_t* p2 = Text; p2 != TextEnd; ++p2)   // p2 is a pointer to address.
 	for (const wchar_t* p3 = Text; p3 != TextEnd; ++p3) { // p3 is a pointer to the end of buffer.
 		Result actual = {false, 0};
-		actual.is_address = IsMailAddress(p1, p2 - p1, p3 - p1, &(actual.length));
+		actual.is_address = IsURL(p1, p2 - p1, p3 - p1, &(actual.length));
 
 		EXPECT_TRUE(IsEqualResult(ExpectedResult(p1, p2, p3), actual))
-		<< "1st param of IsMailAddress: pszBuf is \"" << (p1 <= p3 ? std::wstring(p1, p3) : L"") << "\"\n"
-		<< "2nd param of IsMailAddress: offset is "   << (p2 - p1) << "\n"
+		<< "1st param of IsURL: pszBuf is \"" << (p1 <= p3 ? std::wstring(p1, p3) : L"") << "\"\n"
+		<< "2nd param of IsURL: offset is "   << (p2 - p1) << "\n"
 		<< "pszBuf + offset is \"" << (p2 <= p3 ? std::wstring(p2, p3) : L"") << "\"";
 	}
 }

--- a/tests/unittests/test-is_mailaddress.cpp
+++ b/tests/unittests/test-is_mailaddress.cpp
@@ -240,9 +240,10 @@ TEST(testIsURL, OffsetParameter)
 	   Apply IsURL to the cases.
 	*/
 	for (auto& aCase: testCases) {
+		int nMatchLen = 0;
 		EXPECT_EQ(
 			aCase.expected,
-			bool(IsURL(aCase.buffer(), aCase.offset, BufferEnd - aCase.buffer(), NULL))
+			bool(IsURL(aCase.buffer(), aCase.offset, BufferEnd - aCase.buffer(), &nMatchLen))
 		) << "1st param of IsURL: pszBuf is \"" << aCase.buffer() << "\"\n"
 		  << "2nd param of IsURL: offset is "   << aCase.offset;
 	}


### PR DESCRIPTION
# PR の目的

シングルクォートで囲まれたメールアドレスを認識できるようにします。

## カテゴリ

- 仕様変更

## PR の背景

#1260 シングルクォートで囲まれたメールアドレスの選択

## PR のメリット

- #1260 の問題を解決できます。

## PR のデメリット (トレードオフとかあれば)

- IsMailAddressの単体テストを廃止していいのかわからんので放置しています。
  - ビルドがNGになるのは単体テストを触っていないことが理由です。
- 対応内容が根治策ではありません。
- シングルクォートで始まるアドレスをシングルクォートで囲った場合、正しく検出できません。

## 仕様・動作説明

|  | 仕様内容 |
|--|--|
| 変更前 | シングルクォートはメールアドレスに使える文字なので、常にメールアドレスの一部として認識する。 |
| 変更後 | シングルクォートはメールアドレスに使える文字だが、メールアドレスがシングルクォートで囲まれている場合に限り、先頭のシングルクォートをメールアドレスの一部と認識しない。|

シングルクォートで囲まれたメールアドレスを認識できるようにする、です。

## テスト内容
### 確認内容
1. シングルクォートで囲まれたメールアドレスを認識できているか。
2. パフォーマンスに深刻な悪影響を与えていないか。

### 手順
1. 以下のテスト資材ファイルをsakura.exeで開く。
2. 表示(URL強調の範囲)を確認する。
3. エディタビュー上でマウスポインタをグリグリ移動させる。(マウスムーブのパフォーマンス確認)

### テスト資材
[url_test.zip](https://github.com/sakura-editor/sakura/files/4603145/url_test.zip)

| ファイル名 | テスト目的 | 現master | このPR |
|--|--|--|--|
| `issue-1260-sample.txt` | 改修効果確認 | × | ○ |
| `testNG23000.txt` | リグレッションテスト| ○ | ○ |
| `too_many_slash.txt` | 機能テスト| × | × |

`too_many_slash.txt`は100万個の連続スラッシュを含むファイルで、しつこくグリグリmouse moveさせると「応答なし」になります。

### テスト判定
OK

## PR の影響範囲
- アプリ（＝サクラエディタ）の挙動に影響します。
  - シングルクォートで囲まれたメールアドレスを認識できるようになります。
  - エディタビュー描画時の色替え判定のパフォーマンスに影響します。
  - エディタビューにマウスポインタがあるときのmouse moveイベントのパフォーマンスに影響します。


## 関連 issue, PR

#1260 シングルクォートで囲まれたメールアドレスの選択
#808 PR 421 によって導入されたけど revert された IsMailAddress の単体テストを復活する
#792 #398 に対する回避策 (特定のファイルで描画が遅くなる)
#421 メールアドレスの色替え判定を高速化すると同時にRFCに準拠させる
#398 特定のファイルで描画が遅くなる。  

## 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
