### PR TITLE
CLayoutIntのテストを追加

### DIFF
--- a/tests/unittests/test-clayoutint.cpp
+++ b/tests/unittests/test-clayoutint.cpp
@@ -1,0 +1,273 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2020 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+
+#ifndef USE_STRICT_INT
+#define USE_STRICT_INT
+#endif /* #ifndef USE_STRICT_INT */
+
+#include "basis/SakuraBasis.h"
+
+/*!
+ * @brief 加算演算子のテスト
+ */
+TEST( CLayoutInt, OperatorAddition )
+{
+	CLayoutInt a( 1 ), b( 2 ), c( 3 );
+
+	EXPECT_TRUE( c == a + b );
+	EXPECT_TRUE( c == a + 2 );
+	EXPECT_TRUE( c == 1 + b );
+}
+
+/*!
+ * @brief 減算演算子のテスト
+ */
+TEST( CLayoutInt, OperatorSubtraction )
+{
+	CLayoutInt a( 1 ), b( 2 ), c( 3 );
+
+	EXPECT_TRUE( a == c - b );
+	EXPECT_TRUE( a == c - 2 );
+	EXPECT_TRUE( a == 3 - b );
+}
+
+/*!
+ * @brief 乗算演算子のテスト
+ */
+TEST( CLayoutInt, OperatorMultiplication )
+{
+	// コメントアウトの組み合わせは未実装。
+	CLayoutInt a( 2 ), b( 3 ), c( 6 );
+
+	//EXPECT_TRUE( c == a * b );
+	EXPECT_TRUE( c == a * 3 );
+	EXPECT_TRUE( c == 2 * b );
+}
+
+/*!
+ * @brief 除算演算子のテスト
+ */
+TEST( CLayoutInt, OperatorDivision )
+{
+	// コメントアウトの組み合わせは未実装。
+	CLayoutInt a( 2 ), b( 3 ), c( 6 );
+
+	//EXPECT_TRUE( a == c / b );
+	EXPECT_TRUE( a == c / 3 );
+	//EXPECT_TRUE( a == 6 / b );
+}
+
+/*!
+ * @brief 除余算演算子のテスト
+ */
+TEST( CLayoutInt, OperatorRemainder )
+{
+	// コメントアウトの組み合わせは未実装。
+	CLayoutInt a( 2 ), b( 3 ), c( 8 );
+
+	EXPECT_TRUE( a == c % b );
+	EXPECT_TRUE( a == c % 3 );
+	//EXPECT_TRUE( a == 6 % b );
+}
+
+/*!
+ * @brief 前置インクリメント演算子のテスト
+ */
+TEST( CLayoutInt, OperatorPrefixIncrement )
+{
+	CLayoutInt a( 1 );
+
+	// 前置インクリメントはインクリメントした後の値を返す
+	EXPECT_TRUE( 2 == ++a );
+	EXPECT_TRUE( 2 == a );
+}
+
+/*!
+ * @brief 後置インクリメント演算子のテスト
+ */
+TEST( CLayoutInt, OperatorPostfixIncrement )
+{
+	CLayoutInt a( 1 );
+
+	// 後置インクリメントはインクリメントする前の値を返す
+	EXPECT_TRUE( 1 == a++ );
+	EXPECT_TRUE( 2 == a );
+}
+
+/*!
+ * @brief 後置インクリメント演算子のテスト
+ */
+TEST( CLayoutInt, OperatorPrefixDecrement )
+{
+	CLayoutInt a( 1 );
+
+	// 後置デクリメントはデクリメントした後の値を返す
+	EXPECT_TRUE( 0 == --a );
+	EXPECT_TRUE( 0 == a );
+}
+
+/*!
+ * @brief 後置デクリメント演算子のテスト
+ */
+TEST( CLayoutInt, OperatorPostfixDecrement )
+{
+	CLayoutInt a( 1 );
+
+	// 後置デクリメントはデクリメントする前の値を返す
+	EXPECT_TRUE( 1 == a-- );
+	EXPECT_TRUE( 0 == a );
+}
+
+/*!
+ * @brief 単項マイナス演算子のテスト
+ */
+TEST( CLayoutInt, OperatorUnaryMinus )
+{
+	CLayoutInt a( 1 );
+
+	// 値の正負を引っくり返す
+	EXPECT_TRUE( -1 == -a );
+
+	// 元の値は変わらない
+	EXPECT_TRUE( 1 == a );
+
+	// 裏表なので2回引っくり返すと元に戻る
+	EXPECT_TRUE( 1 == -(-a) );
+}
+
+/*!
+ * @brief 代入演算子のテスト
+ * 等価比較演算子/否定の等価比較演算子のテストも兼ねる
+ */
+TEST( CLayoutInt, OperatorAssignment )
+{
+	CLayoutInt a( 1 ), b( 2 );
+
+	EXPECT_TRUE( a != 2 );
+	EXPECT_FALSE( a == 2 );
+	EXPECT_TRUE( a != b );
+	EXPECT_FALSE( a == b );
+
+	a = b;
+
+	EXPECT_TRUE( a == b );
+	EXPECT_FALSE( a != b );
+	EXPECT_TRUE( a == 2 );
+	EXPECT_FALSE( a != 2 );
+}
+
+/*!
+ * @brief 比較演算子のテスト
+ */
+TEST( CLayoutInt, OperatorCompareGreaterThan )
+{
+	CLayoutInt a;
+
+	EXPECT_TRUE( a > -1 );
+	EXPECT_FALSE( a > 0 );
+	EXPECT_FALSE( 0 < a );
+	EXPECT_TRUE( -1 < a );
+
+	EXPECT_FALSE( a > a );
+	EXPECT_TRUE( a > a - 1 );
+}
+
+/*!
+ * @brief 比較演算子のテスト
+ */
+TEST( CLayoutInt, OperatorCompareGreaterOrEqual )
+{
+	CLayoutInt a;
+
+	EXPECT_TRUE( a >= 0 );
+	EXPECT_FALSE( a >= 1 );
+	EXPECT_FALSE( 1 <= a );
+	EXPECT_TRUE( 0 <= a );
+
+	EXPECT_TRUE( a >= a );
+	EXPECT_FALSE( a >= a + 1);
+}
+
+/*!
+ * @brief 比較演算子のテスト
+ */
+TEST( CLayoutInt, OperatorCompareLessThan )
+{
+	CLayoutInt a;
+
+	EXPECT_TRUE( a < 1 );
+	EXPECT_FALSE( a < 0 );
+	EXPECT_FALSE( 0 > a );
+	EXPECT_TRUE( 1 > a );
+
+	EXPECT_FALSE( a < a );
+	EXPECT_TRUE( a < a + 1 );
+}
+
+/*!
+ * @brief 比較演算子のテスト
+ */
+TEST( CLayoutInt, OperatorCompareLessOrEqual )
+{
+	CLayoutInt a;
+
+	EXPECT_FALSE( a <= -1 );
+	EXPECT_TRUE( a <= 0 );
+	EXPECT_TRUE( 0 >= a );
+	EXPECT_FALSE( -1 >= a );
+
+	EXPECT_TRUE( a <= a );
+	EXPECT_FALSE( a <= a - 1 );
+}
+
+/*!
+ * @brief 暗黙変換演算子のテスト
+ */
+TEST( CLayoutInt, OperatorCastToCLaxInteger )
+{
+	CLayoutInt a( 1 );
+	CLaxInteger la( 0 );
+
+	//CLayoutInt ⇒ CLaxIntegerはキャストなしで変換できる
+	la = a;
+	EXPECT_TRUE( la == 1 );
+
+	// リセット
+	la = 0;
+	EXPECT_TRUE( la == 0 );
+
+	// もちろん、キャストしても変換できる
+	la = (Int) a;
+
+	EXPECT_TRUE( la == 1 );
+}

--- a/tests/unittests/test-clayoutint.cpp
+++ b/tests/unittests/test-clayoutint.cpp
@@ -88,7 +88,9 @@ TEST( CLayoutInt, OperatorDivision )
 }
 
 /*!
- * @brief 除余算演算子のテスト
+ * @brief 剰余算演算子のテスト
+ * 剰余算＝割り算で割った余りを求める計算のこと
+ * nPos + 4 - (nPos % 4) で式の結果は4の倍数になる、とか。 
  */
 TEST( CLayoutInt, OperatorRemainder )
 {

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -105,6 +105,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="test-ccommandline.cpp" />
+    <ClCompile Include="test-clayoutint.cpp" />
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />
     <ClCompile Include="test-editinfo.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -62,5 +62,8 @@
     <ClCompile Include="test-loadstring.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-clayoutint.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# PR の目的

メタクラス `CLayoutInt` の単体テストを追加します。

## カテゴリ

- その他の問題


## PR の背景

#1268 CStrictIntegerと整数を比較するグローバル演算子の実装を修正する

https://github.com/sakura-editor/sakura/pull/1268#issuecomment-625534830
> 作っていただいたテストを、別pr投げてもらえますか？

#1268 で試したのは比較演算子だけだったんですが、せっかくなので他の演算子のテストも実装してみました。

結論だけ言うと `CLayoutInt` って `単なる int` です。

このクラスの主な機能は、暗黙のインスタンス化や許可されない型変換をプログラマにさせないことです。単体テストコードはその性質上、ビルドできることが前提の動作チェックになりますので、そうなった状態の `CLayoutInt` は実態として `int` と変わらなかったりします。

本来の機能に対する `automake` 系のテストもそのうち書きますが、とりあえず挙動確認のたたきを作るのがこのPRの目的になります。

## PR のメリット

- `CLayoutInt` に単体テストが追加される。
  - 今後加えた変更がクラスの挙動に影響を与えるかどうかの判断がラクになる。
  - (副次効果として) どんな機能があるのか把握しやすくなる。

## PR のデメリット (トレードオフとかあれば)

- 単体テストは「ビルドされたコード」をテストするものである都合、`CLayoutInt` の本来の目玉機能である「許可されない変換を行おうとした場合にビルドエラーになる」のテストは実施できない。
- 単体テストはできるだけシンプルに、間違いの起こりにくいように書いているが、これが絶対に正しいという保証はない。


## 仕様・動作説明

- 仕様・既存アプリの動作は変更しません。

## テスト内容

- 追加する対象の単体テストを実行し、passすることを確認しました。

## PR の影響範囲

- 今後の `CLayoutInt` の機能追加・仕様変更に影響を与える可能性があります。 
- アプリ（＝サクラエディタ）の機能に影響しません。

## 関連 issue, PR

#1268 CStrictIntegerと整数を比較するグローバル演算子の実装を修正する


## 参考資料
https://docs.microsoft.com/en-us/cpp/cpp/cpp-built-in-operators-precedence-and-associativity
http://stlalv.la.coocan.jp/Operator.html

