### PR TITLE
Combo_AddString の戻り値の型を int にする

### DIFF
--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -126,9 +126,12 @@ namespace ApiWrap{
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      コンボボックス                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	inline LRESULT Combo_AddString(HWND hwndCombo, const WCHAR* str)
+	inline int Combo_AddString(HWND hwndCombo, const WCHAR* str)
 	{
-		return ::SendMessage( hwndCombo, CB_ADDSTRING, 0, LPARAM(str) );
+		// CB_ADDSTRING は失敗の時、負の値を返す。
+		// 成功した場合 0 ベースのインデックスを返す。
+		// 64bit 対応時に int で十分
+		return (int)::SendMessage( hwndCombo, CB_ADDSTRING, 0, LPARAM(str) );
 	}
 
 	inline LRESULT Combo_GetLBText(HWND hwndCombo, int nIndex, WCHAR* str)


### PR DESCRIPTION
# (必須) PR の目的

64bit 対応のために警告を減らす対応の一部で Combo_AddString の戻り値の型を int にする

## (必須) カテゴリ

- 64bit 対応

## (自明なら省略可) PR の背景

<!-- PR を行う背景を記載してください -->

## (自明なら省略可) PR のメリット

64bit ビルドで警告が減る

## (なければ省略可) PR のデメリット (トレードオフとかあれば)

なし

## (仕様変更/機能追加の場合は必須) 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## (必須) テスト内容

appveyor で警告の数を比較

release x64 592個 → 572個
debug  x64  623個 → 603個

## (わかる範囲で) PR の影響範囲

combobox への追加操作

## (なければ省略可) 関連 issue, PR

#430

## (なければ省略可) 参考資料

https://docs.microsoft.com/en-us/windows/win32/controls/cb-addstring
