### PR TITLE
CI の md ファイルの無視ルールを改善

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -8,14 +8,12 @@ on:
       - master
       - feature/*
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
       - .gitignore
       - .editorconfig
       - appveyor.yml
       - 'azure-pipelines*.yml'
       - 'ci/azure-pipelines/template*.yml'
-      - '.github/*.md'
-      - '.github/ISSUE_TEMPLATE/*.md'
 
   pull_request:
     branches:
@@ -23,14 +21,12 @@ on:
       - feature/*
       - release/*
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
       - .gitignore
       - .editorconfig
       - appveyor.yml
       - 'azure-pipelines*.yml'
       - 'ci/azure-pipelines/template*.yml'
-      - '.github/*.md'
-      - '.github/ISSUE_TEMPLATE/*.md'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,13 +16,11 @@ clone_depth: 5
 # see "Skip commits" at https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only
 skip_commits:
   files:
-    - '*.md'
+    - '**/*.md'
     - .gitignore
     - .editorconfig
     - 'azure-pipelines*.yml'
     - 'ci/azure-pipelines/template*.yml'
-    - '.github/*.md'
-    - '.github/ISSUE_TEMPLATE/*.md'
     - '.github/workflows/*.yml'
 
 install:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,9 +12,7 @@ trigger:
       - revert-*
   paths:
     exclude:
-      - "*.md"
-      - .github/*.md
-      - .github/ISSUE_TEMPLATE/*.md
+      - '**/*.md'
       - .github/workflows/*.yml
       - .gitignore
       - .travis.yml
@@ -34,9 +32,7 @@ pr:
       - revert-*
   paths:
     exclude:
-      - "*.md"
-      - .github/*.md
-      - .github/ISSUE_TEMPLATE/*.md
+      - '**/*.md'
       - .gitignore
       - .travis.yml
       - appveyor.yml


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

CI の md ファイルの無視ルールを改善

## <!-- 必須 --> カテゴリ

- ビルド関連
  - Azure Pipelines
  - AppVeyor
  - GitHub Actions

## <!-- 自明なら省略可 --> PR の背景

https://github.com/sakura-editor/sakura/pull/1294#issuecomment-626274536

## <!-- 自明なら省略可 --> PR のメリット

不要な CI ビルドが走らなくなる
無視ファイルのルールがシンプルになる

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

md ファイルを入力にして CI に何かさせる処理ができなくなる

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- 必須 --> テスト内容

マージしてみて様子見する

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

#1294

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
