### PR TITLE
MinGW のコンパイルエラーを修正する

### DIFF
--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -139,10 +139,10 @@ protected:
 	void SetDocLineFuncList();
 
 	void SetTreeFileSub(HTREEITEM hParent, const WCHAR* pszFile);
-	// 2002/11/1 frozen 
+	// 2002/11/1 frozen
 	void SortTree(HWND hWndTree,HTREEITEM htiParent);//!< ツリービューの項目をソートする（ソート基準はm_nSortTypeを使用）
 #if 0
-2002.04.01 YAZAKI SetTreeTxt()、SetTreeTxtNest()は廃止。GetTreeTextNextはもともと使用されていなかった。
+// 2002.04.01 YAZAKI SetTreeTxt()、SetTreeTxtNest()は廃止。GetTreeTextNextはもともと使用されていなかった。
 	void SetTreeTxt( HWND );	/* ツリーコントロールの初期化：テキストトピックツリー */
 	int SetTreeTxtNest( HWND, HTREEITEM, int, int, HTREEITEM*, int );
 	void GetTreeTextNext( HWND, HTREEITEM, int );
@@ -209,7 +209,7 @@ private:
 	bool		m_bHovering;
 	int			m_nHilightedBtn;
 	int			m_nCapturingBtn;
-	
+
 	STypeConfig m_type;
 	CFileTreeSetting	m_fileTreeSetting;
 


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

(Close #1298)
#1298 のコンパイルエラーを修正する。

## <!-- 必須 --> カテゴリ

- 不具合修正
- ビルド関連
  - Azure Pipelines
  - ローカルビルド

## <!-- 自明なら省略可 --> PR の背景

GCC 10.1 を使うとコンパイルエラーになる。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

どうやら GCC では `#if` でコンパイル対象とならない部分も、文法チェックを行うようになった模様。
`#if 0` で無効化されている部分も、正しくコメントを使うようにする。

## <!-- 必須 --> テスト内容

CI が通ることを確認する。

## <!-- わかる範囲で --> PR の影響範囲

`#if 0` で無効化されている部分の修正のため、MinGW ビルド以外には影響なし。

## <!-- なければ省略可 --> 関連 issue, PR

#1298