### PR TITLE
#1302 OSDNより転載： 「タイプ別設定」等ダイアログ内の「ヘルプ」ボタンが機能しない

### DIFF
--- a/build-chm.bat
+++ b/build-chm.bat
@@ -19,7 +19,7 @@ set CHM_PLUGIN=%TMP_HELP%\plugin\plugin.chm
 set CHM_SAKURA=%TMP_HELP%\sakura\sakura.chm
 set HH_SCRIPT=%TMP_HELP%\remove-comment.py
 set HH_INPUT=sakura_core\sakura.hh
-set HH_OUTPUT=help\sakura\sakura.hh
+set HH_OUTPUT=%TMP_HELP%\sakura\sakura.hh
 
 if defined APPVEYOR (
 	if "%PLATFORM%" neq "BuildChm" (

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -19,7 +19,7 @@ set CHM_PLUGIN=%TMP_HELP%\plugin\plugin.chm
 set CHM_SAKURA=%TMP_HELP%\sakura\sakura.chm
 set HH_SCRIPT=%TMP_HELP%\remove-comment.py
 set HH_INPUT=sakura_core\sakura.hh
-set HH_OUTPUT=%TMP_HELP%\sakura\sakura.hh
+set HH_OUTPUT=help\sakura\sakura.hh
 
 if defined APPVEYOR (
 	if "%PLATFORM%" neq "BuildChm" (

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -8,6 +8,7 @@ set SRC_HELP=%~dp0help
 set TMP_HELP=%~dp0temphelp
 
 @rem create sakura.hh before copying because sakura.hh will be uploaded as an artifact.
+set HH_SCRIPT=%SRC_HELP%\remove-comment.py
 set HH_INPUT=sakura_core\sakura.hh
 set HH_OUTPUT=help\sakura\sakura.hh
 
@@ -24,7 +25,6 @@ set HHP_SAKURA=%TMP_HELP%\sakura\sakura.hhp
 set CHM_MACRO=%TMP_HELP%\macro\macro.chm
 set CHM_PLUGIN=%TMP_HELP%\plugin\plugin.chm
 set CHM_SAKURA=%TMP_HELP%\sakura\sakura.chm
-set HH_SCRIPT=%TMP_HELP%\remove-comment.py
 
 if defined APPVEYOR (
 	if "%PLATFORM%" neq "BuildChm" (

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -7,6 +7,13 @@ if not defined CMD_HHC (
 set SRC_HELP=%~dp0help
 set TMP_HELP=%~dp0temphelp
 
+@rem create sakura.hh before copying because sakura.hh will be uploaded as an artifact.
+set HH_INPUT=sakura_core\sakura.hh
+set HH_OUTPUT=help\sakura\sakura.hh
+
+if exist "%HH_OUTPUT%" del /F "%HH_OUTPUT%"
+python "%HH_SCRIPT%" "%HH_INPUT%" "%HH_OUTPUT%"  || (echo error && exit /b 1)
+
 if exist "%TMP_HELP%" rmdir /s /q    "%TMP_HELP%"
 xcopy /i /k /s "%SRC_HELP%" "%TMP_HELP%"
 
@@ -18,8 +25,6 @@ set CHM_MACRO=%TMP_HELP%\macro\macro.chm
 set CHM_PLUGIN=%TMP_HELP%\plugin\plugin.chm
 set CHM_SAKURA=%TMP_HELP%\sakura\sakura.chm
 set HH_SCRIPT=%TMP_HELP%\remove-comment.py
-set HH_INPUT=sakura_core\sakura.hh
-set HH_OUTPUT=help\sakura\sakura.hh
 
 if defined APPVEYOR (
 	if "%PLATFORM%" neq "BuildChm" (
@@ -27,9 +32,6 @@ if defined APPVEYOR (
 		exit /b 0
 	)
 )
-
-if exist "%HH_OUTPUT%" del /F "%HH_OUTPUT%"
-python "%HH_SCRIPT%" "%HH_INPUT%" "%HH_OUTPUT%"  || (echo error && exit /b 1)
 
 set "TOOL_SLN_FILE=%~dp0tools\ChmSourceConverter\ChmSourceConverter.sln"
 @echo "%CMD_MSBUILD%" %TOOL_SLN_FILE% "/p:Platform=Any CPU" /p:Configuration=Release /t:"Build" /v:q


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

#1302 OSDNより転載： 「タイプ別設定」等ダイアログ内の「ヘルプ」ボタンが機能しない
## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

#1129 を入れたために #1302  の不具合が発生した。

<!-- PR を行う背景を記載してください -->

## <!-- 自明なら省略可 --> PR のメリット

 #1302  の不具合が直る

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

なし

## 原因

sakura.hh にコメントが入っているが、コメントがのぞく処理をしたものを hhc.exe に渡す必要があったが、コメントを取り除く処理をしていないものを hhc.exe の入力に与えていた。

## <!-- 必須 --> テスト内容 

### テスト1

1. メニューから設定 → 共通設定 を選ぶ
2. 右下のヘルプボタンを押す
3. ヘルプボタンが起動することを確認する

## <!-- わかる範囲で --> PR の影響範囲

ヘルプ

## <!-- なければ省略可 --> 関連 issue, PR

#1302
#1129
