### PR TITLE
PageUp, PageDown 時に描画する必要が無い場合は描画しないようにする判定を追加

### DIFF
--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -735,8 +735,8 @@ void CViewCommander::Command_1PageUp( bool bSelect, CLayoutYInt nScrollNum )
 // 2001.12.03 hor
 //		メモ帳ライクに、画面に対するカーソル位置はそのままで１ページアップ
 	{
-		CLayoutInt nViewTopLine = m_pCommanderView->GetTextArea().GetViewTopLine();
 		const bool bDrawSwitchOld = m_pCommanderView->SetDrawSwitch(false);
+		CLayoutInt nViewTopLine = m_pCommanderView->GetTextArea().GetViewTopLine();
 		if( nScrollNum <= 0 ){
 			nScrollNum = m_pCommanderView->GetTextArea().m_nViewRowNum - 1;
 		}
@@ -744,11 +744,10 @@ void CViewCommander::Command_1PageUp( bool bSelect, CLayoutYInt nScrollNum )
 		auto prevCaretPos = caret.GetCaretLayoutPos();
 		caret.Cursor_UPDOWN( -nScrollNum, bSelect );
 		auto currCaretPos = caret.GetCaretLayoutPos();
-		//	Sep. 11, 2004 genta 同期スクロール処理のため
-		//	m_pCommanderView->RedrawAllではなくScrollAtを使うように
 		CLayoutInt nScrolled = m_pCommanderView->ScrollAtV( nViewTopLine - nScrollNum );
 		m_pCommanderView->SyncScrollV(nScrolled);
 		m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
+		// カーソル位置が変化しなかった、かつ、スクロール行数が0だった場合、描画を省く
 		if (prevCaretPos == currCaretPos && nScrolled == 0) {
 			return;
 		}
@@ -771,8 +770,8 @@ void CViewCommander::Command_1PageDown( bool bSelect, CLayoutYInt nScrollNum )
 // 2001.12.03 hor
 //		メモ帳ライクに、画面に対するカーソル位置はそのままで１ページダウン
 	{
-		CLayoutInt nViewTopLine = m_pCommanderView->GetTextArea().GetViewTopLine();
 		const bool bDrawSwitchOld = m_pCommanderView->SetDrawSwitch(false);
+		CLayoutInt nViewTopLine = m_pCommanderView->GetTextArea().GetViewTopLine();
 		if( nScrollNum <= 0 ){
 			nScrollNum = m_pCommanderView->GetTextArea().m_nViewRowNum - 1;
 		}
@@ -780,11 +779,10 @@ void CViewCommander::Command_1PageDown( bool bSelect, CLayoutYInt nScrollNum )
 		auto prevCaretPos = caret.GetCaretLayoutPos();
 		caret.Cursor_UPDOWN( nScrollNum, bSelect );
 		auto currCaretPos = caret.GetCaretLayoutPos();
-		//	Sep. 11, 2004 genta 同期スクロール処理のため
-		//	m_pCommanderView->RedrawAllではなくScrollAtを使うように
 		CLayoutInt nScrolled = m_pCommanderView->ScrollAtV( nViewTopLine + nScrollNum );
 		m_pCommanderView->SyncScrollV(nScrolled);
 		m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
+		// カーソル位置が変化しなかった、かつ、スクロール行数が0だった場合、描画を省く
 		if (prevCaretPos == currCaretPos && nScrolled == 0) {
 			return;
 		}

--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -735,16 +735,23 @@ void CViewCommander::Command_1PageUp( bool bSelect, CLayoutYInt nScrollNum )
 // 2001.12.03 hor
 //		メモ帳ライクに、画面に対するカーソル位置はそのままで１ページアップ
 	{
-		const bool bDrawSwitchOld = m_pCommanderView->SetDrawSwitch(false);
 		CLayoutInt nViewTopLine = m_pCommanderView->GetTextArea().GetViewTopLine();
+		const bool bDrawSwitchOld = m_pCommanderView->SetDrawSwitch(false);
 		if( nScrollNum <= 0 ){
 			nScrollNum = m_pCommanderView->GetTextArea().m_nViewRowNum - 1;
 		}
-		GetCaret().Cursor_UPDOWN( -nScrollNum, bSelect );
+		auto& caret = GetCaret();
+		auto prevCaretPos = caret.GetCaretLayoutPos();
+		caret.Cursor_UPDOWN( -nScrollNum, bSelect );
+		auto currCaretPos = caret.GetCaretLayoutPos();
 		//	Sep. 11, 2004 genta 同期スクロール処理のため
 		//	m_pCommanderView->RedrawAllではなくScrollAtを使うように
-		m_pCommanderView->SyncScrollV( m_pCommanderView->ScrollAtV( nViewTopLine - nScrollNum ));
+		CLayoutInt nScrolled = m_pCommanderView->ScrollAtV( nViewTopLine - nScrollNum );
+		m_pCommanderView->SyncScrollV(nScrolled);
 		m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
+		if (prevCaretPos == currCaretPos && nScrolled == 0) {
+			return;
+		}
 		m_pCommanderView->RedrawAll();
 	}
 	return;
@@ -764,16 +771,23 @@ void CViewCommander::Command_1PageDown( bool bSelect, CLayoutYInt nScrollNum )
 // 2001.12.03 hor
 //		メモ帳ライクに、画面に対するカーソル位置はそのままで１ページダウン
 	{
-		const bool bDrawSwitchOld = m_pCommanderView->SetDrawSwitch(false);
 		CLayoutInt nViewTopLine = m_pCommanderView->GetTextArea().GetViewTopLine();
+		const bool bDrawSwitchOld = m_pCommanderView->SetDrawSwitch(false);
 		if( nScrollNum <= 0 ){
 			nScrollNum = m_pCommanderView->GetTextArea().m_nViewRowNum - 1;
 		}
-		GetCaret().Cursor_UPDOWN( nScrollNum, bSelect );
+		auto& caret = GetCaret();
+		auto prevCaretPos = caret.GetCaretLayoutPos();
+		caret.Cursor_UPDOWN( nScrollNum, bSelect );
+		auto currCaretPos = caret.GetCaretLayoutPos();
 		//	Sep. 11, 2004 genta 同期スクロール処理のため
 		//	m_pCommanderView->RedrawAllではなくScrollAtを使うように
-		m_pCommanderView->SyncScrollV( m_pCommanderView->ScrollAtV( nViewTopLine + nScrollNum ));
+		CLayoutInt nScrolled = m_pCommanderView->ScrollAtV( nViewTopLine + nScrollNum );
+		m_pCommanderView->SyncScrollV(nScrolled);
 		m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
+		if (prevCaretPos == currCaretPos && nScrolled == 0) {
+			return;
+		}
 		m_pCommanderView->RedrawAll();
 	}
 


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

キャレットが画面の最上行にいる時に PageUp キーを押し続けた場合、もう画面の変化が無い場合にも描画を繰り返し行ってしまいます。キャレットが画面の最下行にいる時に PageDown キーを押し続けた場合も同様です。

このPRの目的は、画面の描画を行う必要が無い場合は行わないように判定する事で、プロセッサが無駄に動かないようにして消費電力を抑える事です。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 速度向上？

## <!-- 自明なら省略可 --> PR のメリット

描画を行う必要が無い場合に描画を省く事でプロセッサの使用率を下げる事が出来ます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

- 描画を行う必要が有るかどうかの判定に不具合があると、本来は描画しなければいけないケースで描画がされない事になります。
- 判定処理が入る分コードが複雑になって読みづらくなります。

## <!-- 必須 --> テスト内容

何かのテキストファイル（自分は `sakura_core\sakura_rc.rc` を使いました）を開いて、エディタのスクロール操作を行いました。

### テスト1

手順

- キャレットを最上行に移動して PageUp キーを押し続けても CPU 使用率が上がらない事を確認（変更前は上がる）
- キャレットを最下行に移動して PageDown キーを押し続けても CPU 使用率が上がらない事を確認（変更前は上がる）
- PageUp, PageDown キー押しによるスクロールの挙動が以前と同じかどうか目視で確認、Shiftキー押しのPageUp, PageDown についても確認

## <!-- わかる範囲で --> PR の影響範囲

PageUp キー、PageDown キー押し時の処理


