### PR TITLE
MSVCのCMakeによる単体テストにリソースを埋め込む

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -33,7 +33,7 @@ endif (BUILD_SHARED_LIBS)
 target_compile_definitions(${project_name} PRIVATE WIN32 _WIN32_WINNT=_WIN32_WINNT_WIN7)
 if (MSVC)
 	target_compile_options (${project_name} PRIVATE $<$<CONFIG:Release>:/GL> /MT$<$<CONFIG:Debug>:d> /GF /FD /EHsc /Zi /TP /source-charset:utf-8 /execution-charset:shift_jis)
-	target_link_libraries  (${project_name} PRIVATE $<$<CONFIG:Release>:-LTCG> "${CMAKE_CURRENT_LIST_DIR}/../../sakura/${CMAKE_GENERATOR_PLATFORM}/$<CONFIG>/*.obj")
+	target_link_libraries  (${project_name} PRIVATE $<$<CONFIG:Release>:-LTCG> "${CMAKE_CURRENT_LIST_DIR}/../../sakura/${CMAKE_GENERATOR_PLATFORM}/$<CONFIG>/*.obj" "${CMAKE_CURRENT_LIST_DIR}/../../sakura/${CMAKE_GENERATOR_PLATFORM}/$<CONFIG>/*.res")
 	set_target_properties  (${project_name} PROPERTIES
 		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_GENERATOR_PLATFORM}/$<CONFIG>"
 	)


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
MSVCのCMakeによる単体テストにリソースを埋め込みます。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- プログラムの動作上の問題
  - ローカルビルド版
- ビルド関連
  - ローカルビルド
- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

#1275 `単体テストで文字列リソースを利用できるようにする`
　↓
#1334 `単体テストで x64 Debug で CDlgProfileMgr.TrySelectProfile_001 で assert になる`

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
- #1334 `単体テストで x64 Debug で CDlgProfileMgr.TrySelectProfile_001 で assert になる` の問題が解決します。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- 現状 `build-and-test.bat` はMinGWでしか使っておらず、MSVC版のテストプロジェクトはCMakeで生成しないので、 変更するメリットはそんなにないかもしれません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
仕様変更はありません。

テストモジュールにリソースが埋め込まれていないとassertするコードを走らせているのに、リソースを埋め込まないテストプロジェクトが生成されてしまう余地があるので埋め込むように修正入れるだけです。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
python.exeをインストールしてパスを通し、pipでopenpyxlを入れた端末で、`build-and-test.bat` でMSVC版のビルドとテスト実行を行います。(masterで#1334が再現する環境で、このPRをチェックアウトして再現しなくなることを確認します。)

### テスト1

手順
`tests/build-and-test.bat x64 Debug` を実行する
　↓
正常に実行できてassertダイアログが出なければOK。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
- CMake経由でコンパイラにMSVCを使ったテストモジュールにリソースが埋め込まれます。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1275 `単体テストで文字列リソースを利用できるようにする`
#1334 `単体テストで x64 Debug で CDlgProfileMgr.TrySelectProfile_001 で assert になる`


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
