### PR TITLE
プリプロセッサで定義済みのウィンドウクラス名を使うように変更

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -372,7 +372,7 @@ void CDialog::CreateSizeBox( void )
 	/* サイズボックス */
 	m_hwndSizeBox = ::CreateWindowEx(
 		WS_EX_CONTROLPARENT,								/* no extended styles */
-		L"SCROLLBAR",									/* scroll bar control class */
+		WC_SCROLLBAR,										/* scroll bar control class */
 		NULL,												/* text for window title bar */
 		WS_VISIBLE | WS_CHILD | SBS_SIZEBOX | SBS_SIZEGRIP, /* scroll bar styles */
 		0,													/* horizontal position */

--- a/sakura_core/func/CFuncKeyWnd.cpp
+++ b/sakura_core/func/CFuncKeyWnd.cpp
@@ -145,7 +145,7 @@ HWND CFuncKeyWnd::Open( HINSTANCE hInstance, HWND hwndParent, CEditDoc* pCEditDo
 	if( m_bSizeBox ){
 		m_hwndSizeBox = ::CreateWindowEx(
 			0L, 						/* no extended styles			*/
-			L"SCROLLBAR",				/* scroll bar control class		*/
+			WC_SCROLLBAR,				/* scroll bar control class		*/
 			NULL,						/* text for window title bar	*/
 			WS_VISIBLE | WS_CHILD | SBS_SIZEBOX | SBS_SIZEGRIP, /* scroll bar styles */
 			0,							/* horizontal position			*/
@@ -406,7 +406,7 @@ void CFuncKeyWnd::CreateButtons( void )
 
 	for( i = 0; i < _countof( m_hwndButtonArr ); ++i ){
 		m_hwndButtonArr[i] = ::CreateWindow(
-			L"BUTTON",						// predefined class
+			WC_BUTTON,							// predefined class
 			L"",								// button text
 			WS_VISIBLE | WS_CHILD | BS_LEFT,	// styles
 			// Size and position values are given explicitly, because
@@ -443,7 +443,7 @@ void CFuncKeyWnd::SizeBox_ONOFF( bool bSizeBox )
 	}else{
 		m_hwndSizeBox = ::CreateWindowEx(
 			0L, 						/* no extended styles			*/
-			L"SCROLLBAR",				/* scroll bar control class		*/
+			WC_SCROLLBAR,				/* scroll bar control class		*/
 			NULL,						/* text for window title bar	*/
 			WS_VISIBLE | WS_CHILD | SBS_SIZEBOX | SBS_SIZEGRIP, /* scroll bar styles */
 			0,							/* horizontal position			*/

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -1950,7 +1950,7 @@ void CPrintPreview::CreatePrintPreviewControls( void )
 	/* 縦スクロールバーの作成 */
 	m_hwndVScrollBar = ::CreateWindowEx(
 		0L,									/* no extended styles			*/
-		L"SCROLLBAR",						/* scroll bar control class		*/
+		WC_SCROLLBAR,						/* scroll bar control class		*/
 		NULL,								/* text for window title bar	*/
 		WS_VISIBLE | WS_CHILD | SBS_VERT,	/* scroll bar styles			*/
 		0,									/* horizontal position			*/
@@ -1976,7 +1976,7 @@ void CPrintPreview::CreatePrintPreviewControls( void )
 	/* 横スクロールバーの作成 */
 	m_hwndHScrollBar = ::CreateWindowEx(
 		0L,									/* no extended styles			*/
-		L"SCROLLBAR",						/* scroll bar control class		*/
+		WC_SCROLLBAR,						/* scroll bar control class		*/
 		NULL,								/* text for window title bar	*/
 		WS_VISIBLE | WS_CHILD | SBS_HORZ,	/* scroll bar styles			*/
 		0,									/* horizontal position			*/
@@ -2001,7 +2001,7 @@ void CPrintPreview::CreatePrintPreviewControls( void )
 	/* サイズボックスの作成 */
 	m_hwndSizeBox = ::CreateWindowEx(
 		WS_EX_CONTROLPARENT/*0L*/, 							/* no extended styles			*/
-		L"SCROLLBAR",										/* scroll bar control class		*/
+		WC_SCROLLBAR,										/* scroll bar control class		*/
 		NULL,												/* text for window title bar	*/
 		WS_VISIBLE | WS_CHILD | SBS_SIZEBOX | SBS_SIZEGRIP, /* scroll bar styles			*/
 		0,													/* horizontal position			*/

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -261,7 +261,7 @@ static int CALLBACK PropSheetProc( HWND hwndDlg, UINT uMsg, LPARAM lParam )
 	if( uMsg == PSCB_INITIALIZED ){
 		s_pOldPropSheetWndProc = (WNDPROC)::SetWindowLongPtr( hwndDlg, GWLP_WNDPROC, (LONG_PTR)PropSheetWndProc );
 		HINSTANCE hInstance = (HINSTANCE)::GetModuleHandle( NULL );
-		HWND hwndBtn = ::CreateWindowEx( 0, L"BUTTON", LS(STR_SHELL_INIFOLDER), BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 0, 0, 140, 20, hwndDlg, (HMENU)0x02000, hInstance, NULL );
+		HWND hwndBtn = ::CreateWindowEx( 0, WC_BUTTON, LS(STR_SHELL_INIFOLDER), BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 0, 0, 140, 20, hwndDlg, (HMENU)0x02000, hInstance, NULL );
 		::SendMessage( hwndBtn, WM_SETFONT, (WPARAM)::SendMessage( hwndDlg, WM_GETFONT, 0, 0 ), MAKELPARAM( FALSE, 0 ) );
 		::SetWindowPos( hwndBtn, ::GetDlgItem( hwndDlg, IDHELP), 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE );
 	}

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -451,7 +451,7 @@ LRESULT CEditView::DispatchEvent(
 		::SetWindowLongPtr( hwnd, 0, (LONG_PTR) this );
 		m_hwndSizeBox = ::CreateWindowEx(
 			0L,									/* no extended styles */
-			L"SCROLLBAR",					/* scroll bar control class */
+			WC_SCROLLBAR,						/* scroll bar control class */
 			NULL,								/* text for window title bar */
 			WS_CHILD | SBS_SIZEBOX | SBS_SIZEGRIP, /* scroll bar styles */
 			0,									/* horizontal position */
@@ -468,7 +468,7 @@ LRESULT CEditView::DispatchEvent(
 		}
 		m_hwndSizeBoxPlaceholder = ::CreateWindowEx(
 			0L, 								/* no extended styles */
-			L"STATIC",						/* scroll bar control class */
+			WC_STATIC,							/* scroll bar control class */
 			NULL,								/* text for window title bar */
 			WS_CHILD,							/* innocent child */
 			0,									/* horizontal position */

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -2087,7 +2087,7 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 	if( nTid1 != nTid2 ) ::AttachThreadInput( nTid1, nTid2, TRUE );
 
 	// ダミーの STATIC を作ってフォーカスを当てる（エディタが前面に出ないように）
-	HWND hwnd = ::CreateWindow(L"STATIC", L"", 0, 0, 0, 0, 0, NULL, NULL, G_AppInstance(), NULL );
+	HWND hwnd = ::CreateWindow(WC_STATIC, L"", 0, 0, 0, 0, 0, NULL, NULL, G_AppInstance(), NULL );
 	::SetFocus(hwnd);
 
 	// メニューを作成する

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -40,7 +40,7 @@ BOOL CEditView::CreateScrollBar()
 	/* スクロールバーの作成 */
 	m_hwndVScrollBar = ::CreateWindowEx(
 		0L,									/* no extended styles */
-		L"SCROLLBAR",					/* scroll bar control class */
+		WC_SCROLLBAR,						/* scroll bar control class */
 		NULL,								/* text for window title bar */
 		WS_VISIBLE | WS_CHILD | SBS_VERT,	/* scroll bar styles */
 		0,									/* horizontal position */
@@ -67,7 +67,7 @@ BOOL CEditView::CreateScrollBar()
 	if( GetDllShareData().m_Common.m_sWindow.m_bScrollBarHorz && !m_bMiniMap ){	/* 水平スクロールバーを使う */
 		m_hwndHScrollBar = ::CreateWindowEx(
 			0L,									/* no extended styles */
-			L"SCROLLBAR",					/* scroll bar control class */
+			WC_SCROLLBAR,						/* scroll bar control class */
 			NULL,								/* text for window title bar */
 			WS_VISIBLE | WS_CHILD | SBS_HORZ,	/* scroll bar styles */
 			0,									/* horizontal position */

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -290,7 +290,7 @@ void CMainToolBar::CreateToolBar( void )
 						Toolbar_GetItemRect( m_hwndToolBar, count-1, &rc );
 
 						//コンボボックスを作る
-						m_hwndSearchBox = CreateWindow( L"COMBOBOX", L"Combo",
+						m_hwndSearchBox = CreateWindow( WC_COMBOBOX, L"Combo",
 								WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_VSCROLL | CBS_DROPDOWN
 								/*| CBS_SORT*/ | CBS_AUTOHSCROLL /*| CBS_DISABLENOSCROLL*/,
 								rc.left, rc.top, rc.right - rc.left, (rc.bottom - rc.top) * 10,

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -3266,7 +3266,7 @@ void CTabWnd::SizeBox_ONOFF( bool bSizeBox )
 	}else{
 		m_hwndSizeBox = ::CreateWindowEx(
 			0L, 						/* no extended styles			*/
-			L"SCROLLBAR",				/* scroll bar control class		*/
+			WC_SCROLLBAR,				/* scroll bar control class		*/
 			NULL,						/* text for window title bar	*/
 			WS_VISIBLE | WS_CHILD | SBS_SIZEBOX | SBS_SIZEGRIP, /* scroll bar styles */
 			0,							/* horizontal position			*/


### PR DESCRIPTION
標準ウィンドウズコントロール作成時に指定するウィンドウクラス名のパラメータに文字列リテラルをその場で書くのではなく、Windows SDKのヘッダファイルに #define されているプリプロセッサのシンボルを使うように変更しました。

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

文字列リテラルを毎回書くのではなく定義済みのプリプロセッサのシンボルを使う事で、ソースコードの見た目が少し良くなります。また入力間違いを防ぐ事が出来ます。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 必須 --> テスト内容

コードの記述を変更した箇所の個別の動作確認はしていません。ビルドが通る事は確認しました。
