### PR TITLE
tools/find-tools.batにpython検出機能を追加する

### DIFF
--- a/build-chm.bat
+++ b/build-chm.bat
@@ -6,7 +6,7 @@ if not defined CMD_HHC (
 
 if not defined CMD_PYTHON call %~dp0tools\find-tools.bat
 if not defined CMD_PYTHON (
-	@echo py.exe was not found.
+	@echo python was not found.
 	exit /b 1
 )
 

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -4,6 +4,12 @@ if not defined CMD_HHC (
 	exit /b 1
 )
 
+if not defined CMD_PYTHON call %~dp0tools\find-tools.bat
+if not defined CMD_PYTHON (
+	@echo py.exe was not found.
+	exit /b 1
+)
+
 set SRC_HELP=%~dp0help
 set TMP_HELP=%~dp0temphelp
 
@@ -13,7 +19,7 @@ set HH_INPUT=sakura_core\sakura.hh
 set HH_OUTPUT=help\sakura\sakura.hh
 
 if exist "%HH_OUTPUT%" del /F "%HH_OUTPUT%"
-python "%HH_SCRIPT%" "%HH_INPUT%" "%HH_OUTPUT%"  || (echo error && exit /b 1)
+%CMD_PYTHON% "%HH_SCRIPT%" "%HH_INPUT%" "%HH_OUTPUT%"  || (echo error && exit /b 1)
 
 if exist "%TMP_HELP%" rmdir /s /q    "%TMP_HELP%"
 xcopy /i /k /s "%SRC_HELP%" "%TMP_HELP%"

--- a/calc-hash-res.bat
+++ b/calc-hash-res.bat
@@ -17,11 +17,11 @@ if not exist "%SRCDIR%" (
 	exit /b 1
 )
 
-where python --version 1>nul 2>&1
-if errorlevel 1 (
+if not defined CMD_PYTHON call %~dp0tools\find-tools.bat
+if not defined CMD_PYTHON (
 	@echo NOTE: No python command
 ) else (
-	python calc-hash.py %OUTHASHFILE% %SRCDIR% .res
+	%CMD_PYTHON% calc-hash.py %OUTHASHFILE% %SRCDIR% .res
 )
 exit /b 0
 

--- a/calc-hash.bat
+++ b/calc-hash.bat
@@ -17,11 +17,11 @@ if not exist "%SRCDIR%" (
 	exit /b 1
 )
 
-where python --version 1>nul 2>&1
-if errorlevel 1 (
+if not defined CMD_PYTHON call %~dp0tools\find-tools.bat
+if not defined CMD_PYTHON (
 	@echo NOTE: No python command
 ) else (
-	python calc-hash.py %OUTHASHFILE% %SRCDIR%
+	%CMD_PYTHON% calc-hash.py %OUTHASHFILE% %SRCDIR%
 )
 exit /b 0
 

--- a/parse-buildlog.bat
+++ b/parse-buildlog.bat
@@ -15,12 +15,12 @@ if not exist "%LOGFILE%" (
 )
 
 set ERROR_RESULT=0
-where python --version 1>nul 2>&1
-if errorlevel 1 (
+if not defined CMD_PYTHON call %~dp0tools\find-tools.bat
+if not defined CMD_PYTHON (
 	@echo NOTE: No python command
 ) else (
-	python appveyor_env.py
-	python parse-buildlog.py %LOGFILE% || set ERROR_RESULT=1
+	%CMD_PYTHON% appveyor_env.py
+	%CMD_PYTHON% parse-buildlog.py %LOGFILE% || set ERROR_RESULT=1
 )
 exit /b %ERROR_RESULT%
 

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -14,6 +14,7 @@ if "%1" equ "clear" (
     set CMD_CMAKE=
     set CMD_NINJA=
     set CMD_LEPROC=
+    set CMD_PYTHON=
     set NUM_VSVERSION=
     set CMAKE_G_PARAM=
     set FIND_TOOLS_CALLED=
@@ -39,6 +40,7 @@ if not defined CMD_MSBUILD  call :msbuild  2> nul
 if not defined CMD_CMAKE    call :cmake    2> nul
 if not defined CMD_NINJA    call :cmake    2> nul
 if not defined CMD_LEPROC   call :leproc   2> nul
+if not defined CMD_PYTHON   call :python   2> nul
 echo ^|- CMD_GIT=%CMD_GIT%
 echo ^|- CMD_7Z=%CMD_7Z%
 echo ^|- CMD_HHC=%CMD_HHC%
@@ -50,6 +52,7 @@ echo ^|- CMD_MSBUILD=%CMD_MSBUILD%
 echo ^|- CMD_CMAKE=%CMD_CMAKE%
 echo ^|- CMD_NINJA=%CMD_NINJA%
 echo ^|- CMD_LEPROC=%CMD_LEPROC%
+echo ^|- CMD_PYTHON=%CMD_PYTHON%
 echo ^|- CMAKE_G_PARAM=%CMAKE_G_PARAM%
 endlocal ^
     && set "CMD_GIT=%CMD_GIT%"                  ^
@@ -63,6 +66,7 @@ endlocal ^
     && set "CMD_CMAKE=%CMD_CMAKE%"              ^
     && set "CMD_NINJA=%CMD_NINJA%"              ^
     && set "CMD_LEPROC=%CMD_LEPROC%"            ^
+    && set "CMD_PYTHON=%CMD_PYTHON%"            ^
     && set "NUM_VSVERSION=%NUM_VSVERSION%"      ^
     && set "CMAKE_G_PARAM=%CMAKE_G_PARAM%"      ^
     && echo end
@@ -270,3 +274,37 @@ for /f "usebackq delims=" %%a in (`where $PATH2:LEProc.exe`) do (
     exit /b
 )
 exit /b
+
+:python
+call :find_py
+call :check_python_version
+if defined CMD_PYTHON (
+	exit /b 0
+)
+
+set PATH2=%PATH%
+for /f "usebackq delims=" %%a in (`where $PATH2:python.exe`) do (
+    set "CMD_PYTHON=%%a"
+    call :check_python_version
+    exit /b 0
+)
+call :check_python_version
+exit /b 0
+
+:find_py
+set PATH2=%PATH%
+for /f "usebackq delims=" %%a in (`where $PATH2:py.exe`) do (
+    set "CMD_PYTHON=%%a"
+    exit /b 0
+)
+exit /b 0
+
+:check_python_version
+set PYTHON_VERSION=
+for /F "usebackq tokens=2*" %%v in (`"%CMD_PYTHON%" --version`) do (
+    set PYTHON_VERSION=%%v
+)
+if not defined PYTHON_VERSION (
+    set CMD_PYTHON=
+)
+exit /b 0

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -282,18 +282,21 @@ if defined CMD_PYTHON (
 	exit /b 0
 )
 
-set PATH2=%PATH%
-for /f "usebackq delims=" %%a in (`where $PATH2:python.exe`) do (
-    set "CMD_PYTHON=%%a"
-    call :check_python_version
-    exit /b 0
-)
+call :find_python
 call :check_python_version
 exit /b 0
 
 :find_py
 set PATH2=%PATH%
 for /f "usebackq delims=" %%a in (`where $PATH2:py.exe`) do (
+    set "CMD_PYTHON=%%a"
+    exit /b 0
+)
+exit /b 0
+
+:find_python
+set PATH2=%PATH%
+for /f "usebackq delims=" %%a in (`where $PATH2:python.exe`) do (
     set "CMD_PYTHON=%%a"
     exit /b 0
 )

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -22,6 +22,7 @@
 | vswhere            | CMD_VSWHERE  | Microsoft Visual Studio\Installer | vswhere.exe  |
 | MSBuild            | CMD_MSBUILD  | 特殊               | MSBuild.exe  |
 | Locale Emulator    | CMD_LEPROC   | なし               | LEProc.exe   |
+| python             | CMD_PYTHON   | なし               | py.exe(python.exe) |
 
 ## MSBuild以外の探索手順
 MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。
@@ -75,6 +76,17 @@ MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。
 ### 参照
 * https://github.com/Microsoft/vswhere
 * https://github.com/Microsoft/vswhere/wiki/Find-MSBuild
+
+## python
+
+ビルドバッチで利用するpythonインタープリターの存在確認をします。
+適切なpythonインタープリターが見つかると、環境変数 `CMD_PYTHON` が定義されます。
+適切なpythonインタープリターが見つからない場合、`CMD_PYTHON` は定義されません。
+pythonインタープリターはビルド要件ではないのでpythonを利用するバッチには `CMD_PYTHON` チェックを挟む必要があります。
+
+1. python Launcher(py.exe)が存在していたら、それを使う。
+1. パスが通っているpython.exeで`python.exe --version`してバージョンが取れたら、それを使う。
+
 
 ## zipの処理に7zではなくPowerShellを強制する
 事前に環境変数の`FORCE_POWERSHELL_ZIP`を1にセットすることで、7zの検索をスキップできます。

--- a/tools/find-tools.md
+++ b/tools/find-tools.md
@@ -84,7 +84,7 @@ MSBuild以外の探索手順は同一であり、7-Zipを例に説明する。
 適切なpythonインタープリターが見つからない場合、`CMD_PYTHON` は定義されません。
 pythonインタープリターはビルド要件ではないのでpythonを利用するバッチには `CMD_PYTHON` チェックを挟む必要があります。
 
-1. python Launcher(py.exe)が存在していたら、それを使う。
+1. python Launcher(py.exe)が存在し、`py.exe --version`でバージョンが取れたら、それを使う。
 1. パスが通っているpython.exeで`python.exe --version`してバージョンが取れたら、それを使う。
 
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
`tools/find-tools.bat` にpython検出機能を追加することにより、pythonインタープリターが未インストールな環境でもバッチビルドが失敗しないようにします。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->
- ビルド関連
  - AppVeyor
  - ローカルビルド


## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1322 `CLogicIntに基本型を指定できるようにする` のビルドエラー対応の過程で、ローカル環境でのバッチビルドがうまく行ってないことに気づきました。対応内容を精査して必要最低限の変更を抽出してPRを作成した次第です。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
従来はPATHに存在するpythonインタープリターを使っていました。このPRの変更により、pythonインタープリターを起動する際に可能であれば `python Launcher` を使うようになります。

~~なお、Appveyor環境には `python Launcher(py.exe)` が正しくインストールされていないらしいので、従来通りPATHに存在するpythonインタープリターを使う動作になります。~~

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
以下のテスト条件でビルドバッチが正常終了するかどうかを表にまとめました。pythonインストール無の○は、pythonを利用するコードブロックを `正常にスキップした` という意味になります。
|OS|条件|maseter|このPR|
|--|--|--|--|
|Windows 8.1 pro|pythonインストール無|×|○|
|Windows 8.1 pro|pythonインストール済|○|○|
|Windows 10 1903 pro|pythonインストール無、pythonに対するアプリ実行エイリアス有効|×|○|
|Windows 10 1903 pro|pythonインストール無、pythonに対するアプリ実行エイリアス無効|○|○|
|Windows 10 1903 pro|pythonインストール済、pythonに対するアプリ実行エイリアス有効|○|○|
|Windows 10 1903 pro|pythonインストール済、pythonに対するアプリ実行エイリアス無効|○|○|

pythonインタープリターには以下のpython公式のインストーラーを使用しています。
https://www.python.org/ftp/python/3.8.4/python-3.8.4-amd64.exe

### 手順
1. `build-sln.bat Win32 Release`を実行する。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
python未インストールのローカル環境でのビルドが成功するようになります。
このPRで対策したいビルドバッチのエラーは、ビルド後のログ解析(pythonを使用)が失敗するだけなので生成されるexeの機能には影響ありません。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1322 `CLogicIntに基本型を指定できるようにする` 
resolves #1347 `ローカル環境でビルドバッチの実行が失敗する`（python未検出がエラーでなくなるため解決します。）


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://www.python.org/downloads/windows/
https://www.atmarkit.co.jp/ait/articles/1810/19/news038.html
http://eorf.hatenablog.com/entry/2019/12/04/054423 (Windows 10の不具合報告)
https://www.atmarkit.co.jp/ait/articles/2003/09/news021.html
