### PR TITLE
空行描画のオプションが誤っているのを修正する。

### DIFF
--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -257,7 +257,7 @@ void CTipWnd::DrawTipText(
 				);
 			}else{
 				// ダミー文字列の高さを取得する
-				nHeight = ::DrawText( hdc, szDummy, _countof(szDummy) - 1, &rc, DT_CALCRECT );
+				nHeight = ::DrawText( hdc, szDummy, _countof(szDummy) - 1, &rc, DT_EXTERNALLEADING );
 			}
 
 			// 描画領域の上端を1行分ずらす

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -185,7 +185,7 @@ void CTipWnd::ComputeWindowSize(
 				}
 			}else{
 				// ダミー文字列を計測して必要な高さを取得する
-				::DrawText( hdc, szDummy, _countof( szDummy ) - 1, &rc, DT_CALCRECT );
+				::DrawText( hdc, szDummy, _countof( szDummy ) - 1, &rc, DT_CALCRECT | DT_EXTERNALLEADING );
 			}
 
 			// 計測した高さを加算する


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
空行描画のオプションが誤っているのが原因で起きている不具合を修正します。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->
- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1353 `OSDN転載: キーワードヘルプで複数行の説明テキストを入れると2行目以降が表示されない。`

キーワードヘルプを表示させたときに、１行目しか表示されていません。
[<img src="https://user-images.githubusercontent.com/3253151/88997827-a136d080-d32b-11ea-9e54-5aac95a64120.png" width="600" />](https://user-images.githubusercontent.com/3253151/88997827-a136d080-d32b-11ea-9e54-5aac95a64120.png)

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
改修効果確認のテストを行います。

### テスト1

#### 手順
1. バッチファイルを開きます。持ってない人は [build-sln.bat](https://github.com/sakura-editor/sakura/blob/master/build-sln.bat) とかを使えばいいと思います。
1. 設定 ⇒ `タイプ別設定` を開き、キーワードヘルプタブをこんな感じに設定します。  
[<img src="https://user-images.githubusercontent.com/3253151/88997678-2b326980-d32b-11ea-819a-5ff2c2f0b587.png" width="300" />](https://user-images.githubusercontent.com/3253151/88997678-2b326980-d32b-11ea-819a-5ff2c2f0b587.png)
1. 設定 ⇒ `キーワードヘルプを自動表示する` をクリックして自動表示を有効にします。
1. `set` にマウスカーソルを当てます。  
[<img src="https://user-images.githubusercontent.com/3253151/89018280-90e81b00-d356-11ea-9479-e0d99c418949.png" width="600" />](https://user-images.githubusercontent.com/3253151/89018280-90e81b00-d356-11ea-9479-e0d99c418949.png)

説明テキストの2行目以降が表示されていたらOKです。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
複数行の説明テキストを含むキーワードヘルプファイルを使う場合の挙動に影響します。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
fixes #1353 `OSDN転載: キーワードヘルプで複数行の説明テキストを入れると2行目以降が表示されない。`
#647 `辞書Tipの描画改善、およびHighDPI対応`

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
