### PR TITLE
単体テストで起きたassert失敗を捕捉できるように、コンソールモードではメッセージボックスを表示しないようにしたい

### DIFF
--- a/sakura_core/debug/Debug1.h
+++ b/sakura_core/debug/Debug1.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <stdarg.h>
+
+#include <Windows.h>
+
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                   メッセージ出力：実装                      //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -47,3 +51,10 @@ void DebugOutW( LPCWSTR lpFmt, ...);
 #else
 	#define RELPRINT   Do_not_define_USE_RELPRINT
 #endif	// USE_RELPRINT
+
+//トレース出力（トレース箇所のファイルパスと行番号を出力してエラー解析を容易にする目的）
+#ifdef _DEBUG
+	#define TRACE( format, ... )	DEBUG_TRACE( _T("%hs(%d): ") _T(format) _T("\n"), __FILE__, __LINE__, __VA_ARGS__ )
+#else
+	#define TRACE( ... )
+#endif

--- a/sakura_core/debug/Debug1.h
+++ b/sakura_core/debug/Debug1.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <stdarg.h>
+#include <vadefs.h>
 
 #include <Windows.h>
 

--- a/sakura_core/debug/Debug2.cpp
+++ b/sakura_core/debug/Debug2.cpp
@@ -2,41 +2,12 @@
 #include "StdAfx.h"
 #include "debug/Debug2.h"
 
-//2007.08.30 kobake 追加
-
-#ifdef _DEBUG
-//!デバッグメッセージ出力
-void debug_output(const char* str, ...)
-{
-	char buf[_MAX_PATH+150];
-	va_list mark;
-	va_start(mark,str);
-	// FILE名, LINE 式 分必要
-	tchar_vsnprintf_s(buf,_countof(buf),str,mark);
-	va_end(mark);
-
-	//デバッガに出力
-	OutputDebugStringA(buf);
-}
-
-//!強制終了
 void debug_exit()
 {
-	MessageBox(NULL,L"assertとかに引っ掛かったぽいです",GSTR_APPNAME,MB_OK);
-	exit(1);
-}
-
-void debug_exit2(const char* file, int line, const char* exp)
-{
-	char szBuffer[1024];
-	wsprintfA(szBuffer, "assert\n%s(%d):\n%s", file, line, exp);
-	MessageBoxA(NULL, szBuffer , "sakura", MB_OK);
-	exit(1);
+	::exit( 1 );
 }
 
 void warning_point()
 {
-	int n;
-	n=0; //※←ここにブレークポイントを設けておくと、任意ワーニングでブレークできる
+	::DebugBreak();
 }
-#endif	// _DEBUG

--- a/sakura_core/debug/Debug2.h
+++ b/sakura_core/debug/Debug2.h
@@ -27,29 +27,32 @@
 */
 #pragma once
 
-//2007.08.30 kobake 追加
-#ifdef assert
+#include <cassert>
+
+#include "debug/Debug1.h"
+#include "util/MessageBoxF.h"
+
+// C Runtime の定義をundefして独自定義に差し替える
 #undef assert
-#endif
 
 #ifdef _DEBUG
-	void debug_output(const char* str, ...);
+
 	void debug_exit();
-	void debug_exit2(const char* file, int line, const char* exp);
 	void warning_point();
 
 	#define assert(exp) \
 	{ \
 		if(!(exp)){ \
-			debug_output("!assert: %hs(%d): %hs\n", __FILE__, __LINE__, #exp); \
-			debug_exit2(__FILE__, __LINE__, #exp); \
+			TRACE( "!assert: " #exp, NULL ); \
+			ErrorMessage( NULL, L"!assert\n%hs(%d):\n%hs", __FILE__, __LINE__, #exp ); \
+			debug_exit(); \
 		} \
 	}
 
 	#define assert_warning(exp) \
 	{ \
 		if(!(exp)){ \
-			debug_output("!warning: %hs(%d): %hs\n", __FILE__, __LINE__, #exp); \
+			TRACE( "!warning: " #exp, NULL ); \
 			warning_point(); \
 		} \
 	}

--- a/sakura_core/util/MessageBoxF.cpp
+++ b/sakura_core/util/MessageBoxF.cpp
@@ -45,6 +45,20 @@ int Wrap_MessageBox(HWND hWnd, LPCWSTR lpText, LPCWSTR lpCaption, UINT uType)
 	// 選択中の言語IDを取得する
 	LANGID wLangId = CSelectLang::getDefaultLangId();
 
+	// 標準エラー出力を取得する
+	HANDLE hStdErr = ::GetStdHandle( STD_ERROR_HANDLE );
+	if( hStdErr ){
+			// lpTextの文字列長を求める
+		DWORD dwTextLen = lpText ? ::wcslen( lpText ) : 0;
+
+		// lpText を標準エラー出力に書き出す
+		DWORD dwWritten = 0;
+		::WriteConsoleW( hStdErr, lpText, dwTextLen, &dwWritten, NULL );
+
+		// いい加減な戻り値を返す。(返り値0は未定義なので本来返らない値を返している)
+		return 0;
+	}
+
 	// lpText, lpCaption をローカルバッファにコピーして MessageBox API を呼び出す
 	// ※ 使い回しのバッファが使用されていてそれが裏で書き換えられた場合でも
 	//    メッセージボックス上の Ctrl+C が文字化けしないように


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
コンソールモードではメッセージボックスを表示しないようにします。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->
- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
このPRは #1351 `デバッグ用のメッセージ出力を改善する` をベースに、修正箇所を最小に抑えて変更内容を分かりやすくしたものです。


### 前提知識
- サクラエディタはエラー情報の表示にメッセージボックスを利用しています。
  - メッセージボックスを使うのは、サクラエディタがGUIプログラムだからです。
  - メッセージボックスを表示するコードは続行するのにユーザー操作が必要になります。
    - ユーザー操作が必要ということは `自動テストできない` ということです。

### 問題点
- メッセージボックスを表示するコードは自動テストができません。

### 考えられる対策
1. 自動テストからメッセージボックスを表示するコードを呼ばないようにする。  
これは、メッセージボックスを表示するコードはテストしない、になるので良くない気がします。
1. 自動テストではメッセージボックスを表示しないようにする。  
メッセージボックス表示関数の呼び出しをラップして、呼ばれても表示しない、を実施する作戦です。  
サクラエディタには既にラッパー関数が存在しているため、多少のカスタムで実現可能です。  
この方式ならば、メッセージボックスを表示するコードの自動テストを書くことができます。

### 経緯
1. #1275 `単体テストで文字列リソースを利用できるようにする`  
`sakura.sln` でビルドした単体テストにリソースが埋め込まれるような修正を実施。
1. #1307 `プロファイルマネージャを表示するかどうかの判定をテスト可能にする`  
 CDlgProfileMgrのテストを導入して、ダイアログ表示の要否判定をテスト可能に。
1. #1334 `単体テストで x64 Debug で CDlgProfileMgr.TrySelectProfile_001 で assert になる`  
バッチから単体テストを実行した場合、MSVC版であってもCMakeでビルドされた単体テストが実行されるようになっていたことにより発生した問題。CMakeLists.txtのMSVC版設定をsakura_rc.resを取り込むように修正して、CMake×MSVCでビルドした単体テストでassertが出る問題は解決済み。単体テストでのassert時にテスト実行が中断されてしまう問題が残課題。
1. #1342 `単体テストで assert が発生したときに MessageBox が表示されないようにする`
#1334 の残課題対策PR。迷走中。
1. #1351 `デバッグ用のメッセージ出力を改善する`
#1334 の残課題対策PR。#1342 のカウンターPRとして作成。push先ブランチが間違っていたため一旦破棄。  
このPRの元ネタ（完全版）。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

|ファイル|シンボル|-|説明|
|--|--|--|--|
|`debug/Debug1.h`|`TRACE(...)`|追加|トレース出力（トレース箇所のファイルパスと行番号を出力してエラー解析を容易にする目的）を追加。|
|`debug/Debug2.h`|`debug_output(...)`|削除|TRACEで置換。|
|`debug/Debug2.h`|`debug_exit()`|変更|処理内容を終了のみに変更。|
|`debug/Debug2.h`|`debug_exit2(...)`|削除|debug_exitに統合。|
|`debug/Debug2.h`|`warning_point()`|変更|処理内容をデバッグブレーク発動に変更。|
|`debug/Debug2.h`|`assert()`|変更|デバッガ出力でTRACEを使うように変更。エラー表示と分かるように赤○に×のアイコンを付加するように変更。|
|`debug/Debug2.h`|`assert_warning()`|変更|デバッガ出力でTRACEを使うように変更。|
|`util/MessageBoxF.cpp`|`Wrap_MessageBox(...)`|変更|コンソールモードではメッセージボックスを表示する代わりに標準エラー出力にメッセージを書き込むように変更。コンソールモードではメッセージボックスの表示結果に0（≒ありえない値）を返すように変更。|

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1
既存メッセージボックスが表示できることの確認手順です。

#### 手順
1. このPRをfetchしてcheckoutし、ビルドします。(ビルド環境は何でも可）
1. visual studioからビルドしたexeを実行します。
1. `aaaa` と打って改行、行ごとコピーして3行以上にします。
1. 全選択して `連続した重複行の削除(Ctrl + M)` します。  
  `N行マージしました。`のメッセージボックスが表示されたらOKです。

### テスト2
変更後仕様のassertが設計通りに動作することの確認手順です。

#### 手順
1. このPRをfetchしてcheckoutし、Debug設定でビルドします。
1. WinMain関数の先頭付近に `assert(false):` を挿入します。  
1. visual studioからビルドしたexeを実行します。
1. 以下のように赤丸に×のエラーダイアログが表示されることを確認します。  
[<img alt="assertダイアログ" src="https://user-images.githubusercontent.com/3253151/88396565-ac56a180-cdfd-11ea-8c2f-c3ade16ab4fb.png" width="400" />](https://user-images.githubusercontent.com/3253151/88396565-ac56a180-cdfd-11ea-8c2f-c3ade16ab4fb.png)
1. エラーダイアログを閉じるとプログラムが終了することを確認します。  
1. 出力ペインにASSERTION FAILEDが出力されていることを確認します。
1. 出力ペインのASSERTION FAILEDの行をダブルクリックして、該当箇所にジャンプできることを確認します。  
[<img alt="出力ペイン" src="https://user-images.githubusercontent.com/3253151/88396625-c1333500-cdfd-11ea-91b9-518d3d86fc3a.png" width="600" />](https://user-images.githubusercontent.com/3253151/88396625-c1333500-cdfd-11ea-91b9-518d3d86fc3a.png)


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
* メッセージボックスを表示するコードについて自動テストを書けるようになります。
* assert失敗時のメッセージボックスにアイコンが付くのでエラーメッセージだと分かりやすくなります。
* デバッガで実行しているときにassertが失敗した場合、問題発生個所のコードに容易にアクセスできるようになります。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
resolves #1334 `単体テストで x64 Debug で CDlgProfileMgr.TrySelectProfile_001 で assert になる`
#1342 `単体テストで assert が発生したときに MessageBox が表示されないようにする`
#1351 `デバッグ用のメッセージ出力を改善する`

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-messagebox
https://docs.microsoft.com/en-us/windows/console/getstdhandle
http://eternalwindows.jp/windevelop/console/console02.html
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/assert-macro-assert-wassert?view=vs-2019
https://c.keicode.com/lib/assert-when-you-should-use.php
