### PR TITLE
HeaderMakeに二重起動防止機構を導入する

### DIFF
--- a/HeaderMake/HeaderMake.cpp
+++ b/HeaderMake/HeaderMake.cpp
@@ -55,6 +55,7 @@
 #include <Windows.h>
 
 #include <stdio.h>
+#include <memory>
 #include <string>
 #include <vector>
 #include <time.h>
@@ -113,7 +114,7 @@ inline LPCWSTR getMutexName( const char* mode_name )
 {
 	char szModeUpper[8];
 	::strcpy_s( szModeUpper, mode_name );
-	::_strupr_s( szModeUpper);
+	::_strupr_s( szModeUpper, _countof(szModeUpper) );
 
 	static WCHAR szMutexName[MAX_PATH];
 	::_snwprintf_s( szMutexName, _TRUNCATE, L"SAKURA-Editor.BuildTools.HeaderMake.%hs", szModeUpper );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
HeaderMakeに二重起動防止機構を導入して、#1364 `Funccode_define.hの生成時に発生する競合を解決したい` を解決します。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->
- ビルド関連
  - ローカルビルド

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1364 `Funccode_define.hの生成時に発生する競合を解決したい` を参照。

#1361 `MinGWビルドのMakefileをCMakeによる自動生成に置き換えてビルドをシンプルにしたい` のレビュー評価中に `sakura.sln` のビルドでアクセス競合が発生することが検出されたので対策します。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
- HeaderMakeが排他実行されるようになるのでアクセス競合によるエラーが発生しなくなります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- 他の方法で対応したほうがおそらく簡単です。
  - 例えば、`sakura_lang_en_US.dll` のビルドを `sakura.exe` のビルドに依存させたら問題は起きなくなります。
- Mutex（≒プロセス間排他を実現するAPI）を使うので、HeaderMakeの実行速度が遅くなります。（数百ミリ秒～数秒程度

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
- defineモード時： `SAKURA-Editor.BuildTools.HeaderMake.DEFINE` という名前のミューテックスを作り、主処理が同時に複数走らないように排他制御します。
- enumモード時： `SAKURA-Editor.BuildTools.HeaderMake.ENUM` という名前のミューテックスを作り、主処理が同時に複数走らないように排他制御します。
- 共通： 指定したミューテックスが作成できなかった場合、エラー終了します。
- 共通： 指定したミューテックスが10秒以内に開放されなかった場合、エラー終了します。


## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
手元環境で発生しない現象への対策なので、テスト的なことはやっとらんです。


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
- アプリ（≒サクラエディタ）の機能に影響はありません。
- ビルドシステムが並列処理によりHeaderMakeを同時に2つ以上起動した場合の挙動に影響します。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
resolves #1364 `Funccode_define.hの生成時に発生する競合を解決したい`
#1361 `MinGWビルドのMakefileをCMakeによる自動生成に置き換えてビルドをシンプルにしたい`


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
