### PR TITLE
MSVCのカスタムターゲットがインクリメンタルビルドに対応できてなかったので対応させたい

### DIFF
--- a/sakura/funccode.targets
+++ b/sakura/funccode.targets
@@ -10,15 +10,72 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-  <Target Name="FuncCodeDefine" BeforeTargets="ResourceCompile" AfterTargets="GitHash"
-      Inputs="@(FuncCodeRes)"
-      Outputs="$(FuncCodeDefine)">
+  <Target Name="_WriteFuncCodeDefineRcTlogs"
+      Condition="'@(FuncCodeRes)' != '' and '@(SelectedFiles)' == ''">
+    <ItemGroup>
+      <_FuncCodeDefineReadTlog Include="^$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(FuncCodeDefine)'));%(FuncCodeRes.FullPath)" 
+         Condition="'%(FuncCodeRes.ExcludedFromBuild)' != 'true' and '$(FuncCodeDefine)' != ''"/>
+      <_FuncCodeDefineWriteTlog Include="^%(FuncCodeRes.FullPath);$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(FuncCodeDefine)'))" 
+         Condition="'%(FuncCodeRes.ExcludedFromBuild)' != 'true' and '$(FuncCodeDefine)' != ''"/>
+    </ItemGroup>
+    <WriteLinesToFile
+      Condition="'@(_FuncCodeDefineReadTlog)' != ''"
+      File="$(TLogLocation)rc.read.1u.tlog"
+      Lines="@(_FuncCodeDefineReadTlog->MetaData('Identity')->ToUpperInvariant());"
+      Overwrite="true"
+      Encoding="Unicode"/>
+    <WriteLinesToFile
+      Condition="'@(_FuncCodeDefineWriteTlog)' != ''"
+      File="$(TLogLocation)rc.write.1u.tlog"
+      Lines="@(_FuncCodeDefineWriteTlog->MetaData('Identity')->ToUpperInvariant());"
+      Overwrite="true"
+      Encoding="Unicode"/>
+    <ItemGroup>
+      <_FuncCodeDefineReadTlog Remove="@(_FuncCodeDefineReadTlog)" />
+      <_FuncCodeDefineWriteTlog Remove="@(_FuncCodeDefineWriteTlog)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="FuncCodeDefine"
+      Condition="'@(FuncCodeRes)' != ''"
+      Inputs="%(FuncCodeRes.Identity);%(FuncCodeRes.AdditionalDependencies);$(MSBuildProjectFile)"
+      Outputs="$(FuncCodeDefine)"
+      DependsOnTargets="_WriteFuncCodeDefineRcTlogs;_SelectedFiles"
+      AfterTargets="SelectClCompile;GenerateGitHash"
+      BeforeTargets="ResourceCompile">
     <Exec Command="$(HeaderMake) -in=@(FuncCodeRes) -out=$(FuncCodeDefine) -mode=define" />
   </Target>
-  <Target Name="FuncCodeEnum" BeforeTargets="ClCompile"
-      Inputs="@(FuncCodeRes)"
+  <Target Name="_WriteFuncCodeEnumClTlogs"
+      Condition="'@(FuncCodeRes)' != '' and '@(SelectedFiles)' == ''">
+    <ItemGroup>
+      <_FuncCodeEnumReadTlog Include="^$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(FuncCodeEnum)'));%(FuncCodeRes.FullPath)" 
+         Condition="'%(FuncCodeRes.ExcludedFromBuild)' != 'true' and '$(FuncCodeEnum)' != ''"/>
+      <_FuncCodeEnumWriteTlog Include="^%(FuncCodeRes.FullPath);$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(FuncCodeEnum)'))" 
+         Condition="'%(FuncCodeRes.ExcludedFromBuild)' != 'true' and '$(FuncCodeEnum)' != ''"/>
+    </ItemGroup>
+    <WriteLinesToFile
+      Condition="'@(_FuncCodeEnumReadTlog)' != ''"
+      File="$(TLogLocation)CL.read.1u.tlog"
+      Lines="@(_FuncCodeEnumReadTlog->MetaData('Identity')->ToUpperInvariant());"
+      Overwrite="true"
+      Encoding="Unicode"/>
+    <WriteLinesToFile
+      Condition="'@(_FuncCodeEnumWriteTlog)' != ''"
+      File="$(TLogLocation)CL.write.1u.tlog"
+      Lines="@(_FuncCodeEnumWriteTlog->MetaData('Identity')->ToUpperInvariant());"
+      Overwrite="true"
+      Encoding="Unicode"/>
+    <ItemGroup>
+      <_FuncCodeEnumReadTlog Remove="@(_FuncCodeEnumReadTlog)" />
+      <_FuncCodeEnumWriteTlog Remove="@(_FuncCodeEnumWriteTlog)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="FuncCodeEnum"
+      Condition="'@(FuncCodeRes)' != ''"
+      Inputs="%(FuncCodeRes.Identity);%(FuncCodeRes.AdditionalDependencies);$(MSBuildProjectFile)"
       Outputs="$(FuncCodeEnum)"
-      Condition="'$(GenerateFuncCodeEnum)'=='true'">
+      DependsOnTargets="_WriteFuncCodeEnumClTlogs;_SelectedFiles"
+      AfterTargets="SelectClCompile;GenerateGitHash"
+      BeforeTargets="ClCompile">
     <Exec Command="$(HeaderMake) -in=@(FuncCodeRes) -out=$(FuncCodeEnum) -mode=enum -enum=EFunctionCode" />
   </Target>
 </Project>

--- a/sakura/githash.targets
+++ b/sakura/githash.targets
@@ -1,20 +1,12 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Label="GitHash">
-    <GitHash>..\sakura_core\githash.h</GitHash>
+  <PropertyGroup Label="GeneratedGitHash">
+    <GeneratedGitHash>..\sakura_core\githash.h</GeneratedGitHash>
   </PropertyGroup>
-  <ItemGroup>
-    <GitHashSource Include="..\.git\HEAD" Condition="Exists('..\.git\HEAD')" />
-    <GitHashSource Include="..\.git\index" Condition="Exists('..\.git\index')" />
-    <GitHashSource Include="..\.git\config" Condition="Exists('..\.git\config')" />
-  </ItemGroup>
-  <Target Name="GitHash" BeforeTargets="ClCompile"
-      Inputs="@(GitHashSource)"
-      Outputs="$(GitHash)">
-    <Exec Command="..\sakura\githash.bat ..\sakura_core $(GitHash)" />
-  </Target>
-  <Target Name="GitHashForZip" BeforeTargets="ClCompile" AfterTargets="GitHash"
-      Condition="!Exists('$(GitHash)')"
-      Outputs="$(GitHash)">
-    <Exec Command="..\sakura\githash.bat ..\sakura_core $(GitHash)" />
+  <Target Name="GenerateGitHash"
+      Condition="!Exists('$(GeneratedGitHash)')"
+      Outputs="$(GeneratedGitHash)"
+      AfterTargets="SelectClCompile"
+      BeforeTargets="ClCompile">
+    <Exec Command="..\sakura\githash.bat ..\sakura_core $(GeneratedGitHash)" />
   </Target>
 </Project>


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
MSVCのカスタムターゲットをインクリメンタルビルドに対応させることにより、MSVCを使ったローカルビルド環境の利便性を向上させます。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->
- ビルド関連
  - ローカルビルド

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1367 `MSVCのターゲット 'sakura/funccode.targets' がインクリメンタルビルドに対応できてない` を参照してください。
 
MSVCのカスタムターゲットがインクリメンタルビルドに対応できてなかったので対応させます。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
以下のようにカスタムターゲットのビルド依存関係を設定します。

|ターゲット|変更前入力|変更後入力|出力|
|--|--|--|--|
|`FuncCodeDefine`|なし|`sakura_core/funccode_x.hsrc`|`sakura_core/Funccode_define.h`|
|`FuncCodeEnum`|なし|`sakura_core/funccode_x.hsrc`|`sakura_core/Funccode_enum.h`|
|`GenerateGitHash`|なし|なし|`sakura_core/githash.h`|

変更前入力がすべて「なし」なのは、`設定してたけど機能してなかった`の意図です。
`GeneratedGitHash` の変更後入力を「なし」としたのは、プロジェクト外のファイル(`.git/HEAD`とか)をソース設定しても機能しなかったためです。

依存関係の設定方法は、公式マニュアルの指示に従い tlogs に依存ファイル名を書き込むことで行います。
https://docs.microsoft.com/en-us/visualstudio/extensibility/visual-cpp-project-extensibility?view=vs-2019#incremental-builds-and-up-to-date-checks

公式マニュアルには `masm.targetsの実装を参考にしろ` と書いてありますが、こんな感じの実装になってます。
https://github.com/jomof/vs2019-msbuild/blob/35ca48fbf5bc5a489f18ceda4dbbcb4c426f1d01/Microsoft/VC/v160/BuildCustomizations/masm.targets#L27

色々試してみた限りポイントは以下の通りです。
1. C/C++ソースの依存関係は `CL.read.1.tlog` に書き込む。
1. リソーススクリプトの依存関係は `rc.read.1.tlog` に書き込む。
1. 依存するファイルは `"^コンパイル対象ファイルパス;依存ファイルパス群"` の形式で書き込む。（`;`を書き込むと改行される。）
1. ファイル名指定に `CL.read.1u.tlog` と書くと `CL.read.1.tlog` に書き込まれる。
1. `*.write.1.tlog` が何に使われてるかは不明。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
1. このリポジトリをcloneしPRをfetchしてcheckoutします。
1. `sakura.sln` を開いてビルドします。（ビルド設定はなんでもよいです。）
1. ビルドが完了したら、もう一度ビルドします。（変更がないので「完了」とだけ表示されます。）
1. `sakura_core/funccode_x.hsrc` を編集します。（コメントの削除とかで構いません。）
1. もう一度ビルドします。（`sakura_core/funccode_x.hsrc` に依存するビルドが実行されます。）

変更前は、`sakura_core/funccode_x.hsrc` を編集しても変更が認識されず、ビルドが走っていませんでした。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
- アプリ（≒サクラエディタ）の機能に影響はありません。
- MSVCまたはMsBuild.exeで `sakura.sln` をビルドした場合の挙動に影響します。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
resolves #1367 `MSVCのターゲット 'sakura/funccode.targets' がインクリメンタルビルドに対応できてない`
 
## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
- https://kyabatalian.hatenablog.com/entry/2019/01/06/170759
- https://docs.microsoft.com/en-us/visualstudio/extensibility/visual-cpp-project-extensibility?view=vs-2019#incremental-builds-and-up-to-date-checks
