### PR TITLE
MinGW: C++ の未定義動作によるクラッシュを修正する

### DIFF
--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -316,7 +316,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 				;
 			if( p >= p_end )
 				break;
-		
+
 			//	Check Path
 			if( IsFilePath( p, &nBgn, &nPathLen ) ){
 				wmemcpy( szJumpToFile, &p[nBgn], nPathLen );
@@ -330,7 +330,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 				;
 		}
 	}
-	
+
 	// 2011.11.29 Grep形式で失敗した後もTagsを検索する
 	if( szJumpToFile[0] == L'\0' ){
 		if( Command_TagJumpByTagsFile(bClose) ){	//@@@ 2003.04.13
@@ -602,7 +602,7 @@ bool CViewCommander::Command_TagJumpByTagsFileMsg( bool bMsg )
 	@author	MIK
 	@date	2003.04.13	新規作成
 	@date	2003.05.12	フォルダ階層も考慮して探す
-	@date	
+	@date
 */
 bool CViewCommander::Command_TagJumpByTagsFile( bool bClose )
 {
@@ -611,13 +611,13 @@ bool CViewCommander::Command_TagJumpByTagsFile( bool bClose )
 	if( 0 == cmemKeyW.GetStringLength() ){
 		return false;
 	}
-	
+
 	WCHAR	szDirFile[1024];
 	if( false == Sub_PreProcTagJumpByTagsFile( szDirFile, _countof(szDirFile) ) ){
 		return false;
 	}
 	CDlgTagJumpList	cDlgTagJumpList(true);	//タグジャンプリスト
-	
+
 	cDlgTagJumpList.SetFileName( szDirFile );
 	cDlgTagJumpList.SetKeyword(cmemKeyW.GetStringPtr());
 
@@ -667,7 +667,7 @@ bool CViewCommander::Command_TagJumpByTagsFileKeyword( const wchar_t* keyword )
 	cDlgTagJumpList.SetFileName( szCurrentPath );
 	cDlgTagJumpList.SetKeyword( keyword );
 
-	if( ! cDlgTagJumpList.DoModal( G_AppInstance(), m_pCommanderView->GetHwnd(), 0 ) ) 
+	if( ! cDlgTagJumpList.DoModal( G_AppInstance(), m_pCommanderView->GetHwnd(), 0 ) )
 	{
 		return true;	//キャンセル
 	}
@@ -698,7 +698,7 @@ bool CViewCommander::Sub_PreProcTagJumpByTagsFile( WCHAR* szCurrentPath, int cou
 		    return false;
 		}
 	}
-	
+
 	// 基準ファイル名の設定
 	if( GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
 		wcscpy( szCurrentPath, GetDocument()->m_cDocFile.GetFilePath() );

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -102,7 +102,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 
 	/* 現在行のデータを取得 */
 	CLogicInt		nLineLen;
-	const wchar_t*	pLine = GetDocument()->m_cDocLineMgr.GetLine(ptXY.GetY2())->GetDocLineStrWithEOL(&nLineLen);
+	const wchar_t*	pLine = CDocLine::GetDocLineStrWithEOL_Safe(GetDocument()->m_cDocLineMgr.GetLine(ptXY.GetY2()), &nLineLen);
 	if( NULL == pLine ){
 		goto can_not_tagjump;
 	}

--- a/sakura_core/doc/layout/CLayout.h
+++ b/sakura_core/doc/layout/CLayout.h
@@ -66,7 +66,12 @@ public:
 	CLayoutInt GetIndent() const {	return m_nIndent;	}	//!< このレイアウト行のインデントサイズを取得。単位は半角文字。	CMemoryIterator用
 
 	//取得インターフェース
-	CLogicInt GetLogicLineNo() const{ if(this)return m_ptLogicPos.GetY2(); else return CLogicInt(-1); } //$$$高速化
+	CLogicInt GetLogicLineNo() const{ return m_ptLogicPos.GetY2(); }
+	static CLogicInt GetLogicLineNo_Safe(const CLayout* layout) {
+		if (layout)
+			return layout->m_ptLogicPos.GetY2();
+		return CLogicInt(-1);
+	}
 	CLogicInt GetLogicOffset() const{ return m_ptLogicPos.GetX2(); }
 	CLogicPoint GetLogicPos() const{ return m_ptLogicPos; }
 	EColorIndexType GetColorTypePrev() const{ return m_nTypePrev; } //#########汚っ
@@ -98,7 +103,7 @@ public:
 	void _SetNextLayout(CLayout* pcLayout){ m_pNext = pcLayout; }
 
 	//実データ参照
-	const CDocLine* GetDocLineRef() const{ if(this)return m_pCDocLine; else return NULL; } //$$note:高速化
+	const CDocLine* GetDocLineRef() const{ return m_pCDocLine; }
 
 	//その他属性参照
 	const CEol& GetLayoutEol() const{ return m_cEol; }

--- a/sakura_core/doc/layout/CLayout.h
+++ b/sakura_core/doc/layout/CLayout.h
@@ -66,7 +66,7 @@ public:
 	CLayoutInt GetIndent() const {	return m_nIndent;	}	//!< このレイアウト行のインデントサイズを取得。単位は半角文字。	CMemoryIterator用
 
 	//取得インターフェース
-	CLogicInt GetLogicLineNo() const{ return m_ptLogicPos.GetY2(); }
+	CLogicInt GetLogicLineNo() const{ if(this)return m_ptLogicPos.GetY2(); else return CLogicInt(-1); } //$$$高速化 // TODO: Remove "this" check
 	static CLogicInt GetLogicLineNo_Safe(const CLayout* layout) {
 		if (layout)
 			return layout->m_ptLogicPos.GetY2();
@@ -103,7 +103,7 @@ public:
 	void _SetNextLayout(CLayout* pcLayout){ m_pNext = pcLayout; }
 
 	//実データ参照
-	const CDocLine* GetDocLineRef() const{ return m_pCDocLine; }
+	const CDocLine* GetDocLineRef() const{ if(this)return m_pCDocLine; else return NULL; } //$$note:高速化 // TODO: Remove "this" check
 
 	//その他属性参照
 	const CEol& GetLayoutEol() const{ return m_cEol; }

--- a/sakura_core/doc/layout/CLayout.h
+++ b/sakura_core/doc/layout/CLayout.h
@@ -57,7 +57,7 @@ public:
 	}
 	~CLayout();
 	void DUMP( void );
-	
+
 	// m_ptLogicPos.xで補正したあとの文字列を得る
 	const wchar_t* GetPtr() const   { return m_pCDocLine->GetPtr() + m_ptLogicPos.x; }
 	CLogicInt GetLengthWithEOL() const    { return m_nLength;	}	//	ただしEOLは常に1文字とカウント？？
@@ -115,7 +115,7 @@ private:
 	const CDocLine*		m_pCDocLine;		//!< 実データへの参照
 	CLogicPoint			m_ptLogicPos;		//!< 対応するロジック参照位置
 	CLogicInt			m_nLength;			//!< このレイアウト行の長さ。文字単位。
-	
+
 	//その他属性
 	EColorIndexType		m_nTypePrev;		//!< タイプ 0=通常 1=行コメント 2=ブロックコメント 3=シングルクォーテーション文字列 4=ダブルクォーテーション文字列
 	CLayoutInt			m_nIndent;			//!< このレイアウト行のインデント数 @@@ 2002.09.23 YAZAKI

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -171,7 +171,7 @@ void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 			pWork->nWordBgn = pWork->nPos;
 			pWork->nWordLen = 1;
 			pWork->eKinsokuType = KINSOKU_TYPE_KINSOKU_TAIL;
-			
+
 			(this->*pfOnLine)(pWork);
 		}
 	}
@@ -311,7 +311,7 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 
 	_Empty();
 	Init();
-	
+
 	//	Nov. 16, 2002 genta
 	//	折り返し幅 <= TAB幅のとき無限ループするのを避けるため，
 	//	TABが折り返し幅以上の時はTAB=4としてしまう
@@ -353,7 +353,7 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 		// 次の行へ
 		pWork->nCurLine++;
 		pWork->pcDocLine = pWork->pcDocLine->GetNextLine();
-		
+
 		// 処理中のユーザー操作を可能にする
 		if( nListenerCount !=0 && 0 < nAllLineNum) {
 			DWORD currTime = GetTickCount();
@@ -417,7 +417,7 @@ void CLayoutMgr::_OnLine2(SLayoutWork* pWork)
 
 /*!
 	指定レイアウト行に対応する論理行の次の論理行から指定論理行数だけ再レイアウトする
-	
+
 	@date 2002.10.07 YAZAKI rename from "DoLayout3_New"
 	@date 2004.04.03 Moca TABが使われると折り返し位置がずれるのを防ぐため，
 		pWork->nPosXがインデントを含む幅を保持するように変更．m_nMaxLineKetasは

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -277,8 +277,8 @@ void CLayoutMgr::_OnLine1(SLayoutWork* pWork)
 {
 	AddLineBottom( pWork->_CreateLayout(this) );
 	pWork->pLayout = m_pLayoutBot;
-	pWork->colorPrev = pWork->pcColorStrategy->GetStrategyColorSafe();
-	pWork->exInfoPrev.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
+	pWork->colorPrev = CColorStrategy::GetStrategyColorSafe(pWork->pcColorStrategy);
+	pWork->exInfoPrev.SetColorInfo(CColorStrategy::GetStrategyColorInfoSafe(pWork->pcColorStrategy));
 	pWork->nBgn = pWork->nPos;
 	// 2004.03.28 Moca pWork->nPosXはインデント幅を含むように変更(TAB位置調整のため)
 	pWork->nPosX = pWork->nIndent = (this->*m_getIndentOffset)( pWork->pLayout );
@@ -346,8 +346,8 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 		if( pWork->nPos - pWork->nBgn > 0 ){
 // 2002/03/13 novice
 			AddLineBottom( pWork->_CreateLayout(this) );
-			pWork->colorPrev = pWork->pcColorStrategy->GetStrategyColorSafe();
-			pWork->exInfoPrev.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
+			pWork->colorPrev = CColorStrategy::GetStrategyColorSafe(pWork->pcColorStrategy);
+			pWork->exInfoPrev.SetColorInfo(CColorStrategy::GetStrategyColorInfoSafe(pWork->pcColorStrategy));
 		}
 
 		// 次の行へ
@@ -371,8 +371,8 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 	}
 
 	// 2011.12.31 Botの色分け情報は最後に設定
-	m_nLineTypeBot = pWork->pcColorStrategy->GetStrategyColorSafe();
-	m_cLayoutExInfoBot.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
+	m_nLineTypeBot = CColorStrategy::GetStrategyColorSafe(pWork->pcColorStrategy);
+	m_cLayoutExInfoBot.SetColorInfo(CColorStrategy::GetStrategyColorInfoSafe(pWork->pcColorStrategy));
 
 	m_nPrevReferLine = CLayoutInt(0);
 	m_pLayoutPrevRefer = NULL;
@@ -402,8 +402,8 @@ void CLayoutMgr::_OnLine2(SLayoutWork* pWork)
 	else {
 		pWork->pLayout = InsertLineNext( pWork->pLayout, pWork->_CreateLayout(this) );
 	}
-	pWork->colorPrev = pWork->pcColorStrategy->GetStrategyColorSafe();
-	pWork->exInfoPrev.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
+	pWork->colorPrev = CColorStrategy::GetStrategyColorSafe(pWork->pcColorStrategy);
+	pWork->exInfoPrev.SetColorInfo(CColorStrategy::GetStrategyColorInfoSafe(pWork->pcColorStrategy));
 
 	pWork->nBgn = pWork->nPos;
 	// 2004.03.28 Moca pWork->nPosXはインデント幅を含むように変更(TAB位置調整のため)
@@ -519,8 +519,8 @@ CLayoutInt CLayoutMgr::DoLayout_Range(
 
 	// 2004.03.28 Moca EOFだけの論理行の直前の行の色分けが確認・更新された
 	if( pWork->nCurLine == m_pcDocLineMgr->GetLineCount() ){
-		m_nLineTypeBot = pWork->pcColorStrategy->GetStrategyColorSafe();
-		m_cLayoutExInfoBot.SetColorInfo(pWork->pcColorStrategy->GetStrategyColorInfoSafe());
+		m_nLineTypeBot = CColorStrategy::GetStrategyColorSafe(pWork->pcColorStrategy);
+		m_cLayoutExInfoBot.SetColorInfo(CColorStrategy::GetStrategyColorInfoSafe(pWork->pcColorStrategy));
 	}
 
 	// 2009.08.28 nasukoji	テキストが編集されたら最大幅を算出する

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -56,10 +56,15 @@ public:
 		return p;
 	}
 #endif
-	const wchar_t*	GetDocLineStrWithEOL(CLogicInt* pnLen) const //###仮の名前、仮の対処
+	const wchar_t* GetDocLineStrWithEOL(CLogicInt* pnLen) const //###仮の名前、仮の対処
 	{
-		if(this){
-			*pnLen = GetLengthWithEOL(); return GetPtr();
+		*pnLen = GetLengthWithEOL();
+		return GetPtr();
+	}
+	static const wchar_t* GetDocLineStrWithEOL_Safe(const CDocLine* docline, CLogicInt* pnLen) //###仮の名前、仮の対処
+	{
+		if(docline){
+			return docline->GetDocLineStrWithEOL(pnLen);
 		}
 		else{
 			*pnLen = 0; return NULL;
@@ -67,11 +72,15 @@ public:
 	}
 	CStringRef GetStringRefWithEOL() const //###仮の名前、仮の対処
 	{
-		if(this){
-			return CStringRef(GetPtr(),GetLengthWithEOL());
+		return CStringRef(GetPtr(), GetLengthWithEOL());
+	}
+	static CStringRef GetStringRefWithEOL_Safe(const CDocLine* docline) //###仮の名前、仮の対処
+	{
+		if(docline){
+			return CStringRef(docline->GetPtr(), docline->GetLengthWithEOL());
 		}
 		else{
-			return CStringRef(NULL,0);
+			return CStringRef(NULL, 0);
 		}
 	}
 	const CEol& GetEol() const{ return m_cEol; }

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -93,7 +93,7 @@ public:
 	const CDocLine* GetNextLine() const { return m_pNext; }
 	void _SetPrevLine(CDocLine* pcDocLine){ m_pPrev = pcDocLine; }
 	void _SetNextLine(CDocLine* pcDocLine){ m_pNext = pcDocLine; }
-	
+
 private: //####
 	CDocLine*	m_pPrev;	//!< 一つ前の要素
 	CDocLine*	m_pNext;	//!< 一つ後の要素

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -56,10 +56,14 @@ public:
 		return p;
 	}
 #endif
-	const wchar_t* GetDocLineStrWithEOL(CLogicInt* pnLen) const //###仮の名前、仮の対処
+	const wchar_t*	GetDocLineStrWithEOL(CLogicInt* pnLen) const //###仮の名前、仮の対処
 	{
-		*pnLen = GetLengthWithEOL();
-		return GetPtr();
+		if(this){ // TODO: Remove "this" check
+			*pnLen = GetLengthWithEOL(); return GetPtr();
+		}
+		else{
+			*pnLen = 0; return NULL;
+		}
 	}
 	static const wchar_t* GetDocLineStrWithEOL_Safe(const CDocLine* docline, CLogicInt* pnLen) //###仮の名前、仮の対処
 	{
@@ -72,12 +76,17 @@ public:
 	}
 	CStringRef GetStringRefWithEOL() const //###仮の名前、仮の対処
 	{
-		return CStringRef(GetPtr(), GetLengthWithEOL());
+		if(this){ // TODO: Remove "this" check
+			return CStringRef(GetPtr(),GetLengthWithEOL());
+		}
+		else{
+			return CStringRef(NULL,0);
+		}
 	}
 	static CStringRef GetStringRefWithEOL_Safe(const CDocLine* docline) //###仮の名前、仮の対処
 	{
 		if(docline){
-			return CStringRef(docline->GetPtr(), docline->GetLengthWithEOL());
+			return docline->GetStringRefWithEOL();
 		}
 		else{
 			return CStringRef(NULL, 0);

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -41,14 +41,14 @@ struct EditNode {
 	UINT			m_showCmdRestore;			//!< 元のサイズに戻すときのサイズ種別		//@@@ 2007.06.20 ryoji
 	BOOL			m_bClosing;					//!< 終了中か（「最後のファイルを閉じても(無題)を残す」用）	//@@@ 2007.06.20 ryoji
 
-	HWND GetHwnd() const{ return m_hWnd; }
-	//static HWND GetSafeHwnd(const EditNode* node) { return node ? node->m_hWnd : NULL; }
-	int GetId() const{ return m_nId; }
-	//static int GetSafeId(const EditNode* node) { return node ? node->m_nId : 0; }
+	HWND GetHwnd() const{ if(this)return m_hWnd; else return NULL; } // TODO: Remove "this" check
+	static HWND GetSafeHwnd(const EditNode* node) { return node ? node->m_hWnd : NULL; }
+	int GetId() const{ if(this)return m_nId; else return 0; } // TODO: Remove "this" check
+	static int GetSafeId(const EditNode* node) { return node ? node->m_nId : 0; }
 	CAppNodeGroupHandle GetGroup() const;
-	//static CAppNodeGroupHandle GetGroup_Safe(const EditNode* node);
+	static CAppNodeGroupHandle GetGroup_Safe(const EditNode* node);
 	bool IsTopInGroup() const;
-	//static bool IsTopInGroup_Safe(const EditNode* node);
+	static bool IsTopInGroup_Safe(const EditNode* node);
 };
 
 //! 拡張構造体
@@ -131,25 +131,21 @@ public:
 	HWND GetNextTab(HWND hWndCur);										// Close した時の次のWindowを取得する(タブまとめ表示の場合)	2013/4/10 Uchi
 };
 
-inline CAppNodeGroupHandle EditNode::GetGroup() const{ return m_nGroup; }
-#if 0
+inline CAppNodeGroupHandle EditNode::GetGroup() const{ if(this)return m_nGroup; else return 0; } // TODO: Remove "this" check
 inline CAppNodeGroupHandle EditNode::GetGroup_Safe(const EditNode* node)
 {
 	if (node)
 		return node->m_nGroup;
 	return 0;
 }
-#endif
 
-inline bool EditNode::IsTopInGroup() const{ return (CAppNodeGroupHandle(m_nGroup).GetEditNodeAt(0) == this); }
-#if 0
+inline bool EditNode::IsTopInGroup() const{ return this && (CAppNodeGroupHandle(m_nGroup).GetEditNodeAt(0) == this); } // TODO: Remove "this" check
 inline bool EditNode::IsTopInGroup_Safe(const EditNode* node)
 {
 	if (node)
 		return node->IsTopInGroup();
 	return false;
 }
-#endif
 
 inline CAppNodeHandle::CAppNodeHandle(HWND hwnd)
 {

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -41,12 +41,14 @@ struct EditNode {
 	UINT			m_showCmdRestore;			//!< 元のサイズに戻すときのサイズ種別		//@@@ 2007.06.20 ryoji
 	BOOL			m_bClosing;					//!< 終了中か（「最後のファイルを閉じても(無題)を残す」用）	//@@@ 2007.06.20 ryoji
 
-	HWND GetHwnd() const{ return GetSafeHwnd(); }
-	HWND GetSafeHwnd() const{ if(this)return m_hWnd; else return NULL; }
-	int GetId() const{ return GetSafeId(); }
-	int GetSafeId() const{ if(this)return m_nId; else return 0; }
+	HWND GetHwnd() const{ return m_hWnd; }
+	//static HWND GetSafeHwnd(const EditNode* node) { return node ? node->m_hWnd : NULL; }
+	int GetId() const{ return m_nId; }
+	//static int GetSafeId(const EditNode* node) { return node ? node->m_nId : 0; }
 	CAppNodeGroupHandle GetGroup() const;
+	//static CAppNodeGroupHandle GetGroup_Safe(const EditNode* node);
 	bool IsTopInGroup() const;
+	//static bool IsTopInGroup_Safe(const EditNode* node);
 };
 
 //! 拡張構造体
@@ -129,9 +131,25 @@ public:
 	HWND GetNextTab(HWND hWndCur);										// Close した時の次のWindowを取得する(タブまとめ表示の場合)	2013/4/10 Uchi
 };
 
-inline CAppNodeGroupHandle EditNode::GetGroup() const{ if(this)return m_nGroup; else return 0; }
+inline CAppNodeGroupHandle EditNode::GetGroup() const{ return m_nGroup; }
+#if 0
+inline CAppNodeGroupHandle EditNode::GetGroup_Safe(const EditNode* node)
+{
+	if (node)
+		return node->m_nGroup;
+	return 0;
+}
+#endif
 
-inline bool EditNode::IsTopInGroup() const{ return this && (CAppNodeGroupHandle(m_nGroup).GetEditNodeAt(0) == this); }
+inline bool EditNode::IsTopInGroup() const{ return (CAppNodeGroupHandle(m_nGroup).GetEditNodeAt(0) == this); }
+#if 0
+inline bool EditNode::IsTopInGroup_Safe(const EditNode* node)
+{
+	if (node)
+		return node->IsTopInGroup();
+	return false;
+}
+#endif
 
 inline CAppNodeHandle::CAppNodeHandle(HWND hwnd)
 {

--- a/sakura_core/mfclike/CMyWnd.h
+++ b/sakura_core/mfclike/CMyWnd.h
@@ -36,7 +36,7 @@ public:
 
 	void SetHwnd(HWND hwnd){ m_hWnd = hwnd; }
 	HWND GetHwnd() const{ return m_hWnd; }
-	//static HWND GetSafeHwnd(const CMyWnd* wnd) { return wnd ? wnd->m_hWnd : NULL; }
+	static HWND GetSafeHwnd(const CMyWnd* wnd) { return wnd ? wnd->m_hWnd : NULL; }
 	void InvalidateRect(LPCRECT lpRect, BOOL bErase = TRUE){ ::InvalidateRect(m_hWnd, lpRect, bErase); }
 	int ScrollWindowEx(int dx, int dy, const RECT* prcScroll, const RECT* prcClip, HRGN hrgnUpdate, RECT* prcUpdate, UINT uFlags)
 	{

--- a/sakura_core/mfclike/CMyWnd.h
+++ b/sakura_core/mfclike/CMyWnd.h
@@ -36,7 +36,7 @@ public:
 
 	void SetHwnd(HWND hwnd){ m_hWnd = hwnd; }
 	HWND GetHwnd() const{ return m_hWnd; }
-	HWND GetSafeHwnd() const{ return this?m_hWnd:NULL; }
+	//static HWND GetSafeHwnd(const CMyWnd* wnd) { return wnd ? wnd->m_hWnd : NULL; }
 	void InvalidateRect(LPCRECT lpRect, BOOL bErase = TRUE){ ::InvalidateRect(m_hWnd, lpRect, bErase); }
 	int ScrollWindowEx(int dx, int dy, const RECT* prcScroll, const RECT* prcClip, HRGN hrgnUpdate, RECT* prcUpdate, UINT uFlags)
 	{

--- a/sakura_core/print/CPrintPreview.h
+++ b/sakura_core/print/CPrintPreview.h
@@ -51,7 +51,7 @@ public:
 	*/
 	CPrintPreview( class CEditWnd* pParentWnd );
 	~CPrintPreview();
-	
+
 	/*
 	||	イベント
 	*/
@@ -80,7 +80,7 @@ public:
 	*/
 	//	スクロールバー
 	void InitPreviewScrollBar( void );
-	
+
 	//	PrintPreviewバー（画面上部のコントロール）
 	void CreatePrintPreviewControls( void );
 	void DestroyPrintPreviewControls( void );
@@ -259,7 +259,7 @@ public:
 protected:
 	STypeConfig m_typePrint;
 
-	// プレビューから出ても現在のプリンタ情報を記憶しておけるようにstaticにする 2003.05.02 かろと 
+	// プレビューから出ても現在のプリンタ情報を記憶しておけるようにstaticにする 2003.05.02 かろと
 	static CPrint	m_cPrint;					//!< 現在のプリンタ情報
 
 	bool			m_bLockSetting;				// 設定のロック

--- a/sakura_core/print/CPrintPreview.h
+++ b/sakura_core/print/CPrintPreview.h
@@ -86,9 +86,13 @@ public:
 	void DestroyPrintPreviewControls( void );
 
 	void SetFocusToPrintPreviewBar( void );
-	HWND GetPrintPreviewBarHANDLE( void ){ return m_hwndPrintPreviewBar;	}
-	HWND GetPrintPreviewBarHANDLE_Safe() const{ if(!this)return NULL; else return m_hwndPrintPreviewBar; } //!< thisがNULLでも実行できる版。2007.10.29 kobake
-	
+	HWND GetPrintPreviewBarHANDLE( void ){ return m_hwndPrintPreviewBar; }
+	static HWND GetPrintPreviewBarHANDLE_Safe(const CPrintPreview *preview) {
+		if (preview)
+			return preview->m_hwndPrintPreviewBar;
+		return NULL;
+	}
+
 	//	PrintPreviewバーのメッセージ処理。
 	//	まずPrintPreviewBar_DlgProcにメッセージが届き、DispatchEvent_PPBに転送する仕組み
 	static INT_PTR CALLBACK PrintPreviewBar_DlgProc(

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1236,7 +1236,7 @@ bool CEditView::IsCurrentPositionURL(
 		&ptXY
 	);
 	CLogicInt		nLineLen;
-	const wchar_t*	pLine = m_pcEditDoc->m_cDocLineMgr.GetLine(ptXY.GetY2())->GetDocLineStrWithEOL(&nLineLen); //2007.10.09 kobake レイアウト・ロジック混在バグ修正
+	const wchar_t*	pLine = CDocLine::GetDocLineStrWithEOL_Safe(m_pcEditDoc->m_cDocLineMgr.GetLine(ptXY.GetY2()), &nLineLen); //2007.10.09 kobake レイアウト・ロジック混在バグ修正
 
 	bool		bMatch;
 	int			nMatchColor;

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -201,7 +201,7 @@ BOOL CEditView::Create(
 
 	m_ptSrchStartPos_PHY.Set(CLogicInt(-1), CLogicInt(-1));	//検索/置換開始時のカーソル位置  (改行単位行先頭からのバイト数(0開始), 改行単位行の行番号(0開始))
 	m_bSearch = FALSE;					// 検索/置換開始位置を登録するか */											// 02/06/26 ai
-	
+
 	m_ptBracketPairPos_PHY.Set(CLogicInt(-1), CLogicInt(-1)); // 対括弧の位置 (改行単位行先頭からのバイト数(0開始), 改行単位行の行番号(0開始))
 	m_ptBracketCaretPos_PHY.Set(CLogicInt(-1), CLogicInt(-1));
 
@@ -210,7 +210,7 @@ BOOL CEditView::Create(
 
 	m_crBack = -1;				/* テキストの背景色 */			// 2006.12.16 ryoji
 	m_crBack2 = -1;
-	
+
 	m_szComposition[0] = L'\0';
 
 	/* ルーラー表示 */
@@ -223,7 +223,7 @@ BOOL CEditView::Create(
 	m_nCompatBMPWidth = -1;
 	m_nCompatBMPHeight = -1;
 	// To Here 2007.09.09 Moca
-	
+
 	m_nOldUnderLineY = -1;
 	m_nOldCursorLineX = -1;
 	m_nOldCursorVLineWidth = 1;
@@ -404,7 +404,7 @@ void CEditView::Close()
 
 	delete m_cRegexKeyword;	//@@@ 2001.11.17 add MIK
 	m_cRegexKeyword = NULL;
-	
+
 	delete m_pcTextArea;
 	m_pcTextArea = NULL;
 	delete m_pcCaret;
@@ -624,7 +624,7 @@ LRESULT CEditView::DispatchEvent(
 			/* アクティブなペインを設定 */
 			m_pcEditWnd->SetActivePane( m_nMyIndex );
 			// カーソルをクリック位置へ移動する
-			OnLBUTTONDOWN( wParam, (short)LOWORD( lParam ), (short)HIWORD( lParam ) );	
+			OnLBUTTONDOWN( wParam, (short)LOWORD( lParam ), (short)HIWORD( lParam ) );
 			// 2007.10.02 nasukoji
 			m_bActivateByMouse = FALSE;		// マウスによるアクティベートを示すフラグをOFF
 		}
@@ -806,25 +806,25 @@ LRESULT CEditView::DispatchEvent(
 		return 0L;
 
 	case WM_IME_REQUEST:  /* 再変換  by minfu 2002.03.27 */ // 20020331 aroka
-		
-		// 2002.04.09 switch case に変更  minfu 
+
+		// 2002.04.09 switch case に変更  minfu
 		switch ( wParam ){
 		case IMR_RECONVERTSTRING:
 			return SetReconvertStruct((PRECONVERTSTRING)lParam, UNICODE_BOOL);
-			
+
 		case IMR_CONFIRMRECONVERTSTRING:
 			return SetSelectionFromReonvert((PRECONVERTSTRING)lParam, UNICODE_BOOL);
-			
+
 		// 2010.03.16 MS-IME 2002 だと「カーソル位置の前後の内容を参照して変換を行う」の機能
 		case IMR_DOCUMENTFEED:
 			return SetReconvertStruct((PRECONVERTSTRING)lParam, UNICODE_BOOL, true);
-			
+
 		default:
 			break;
 		}
 		// 2010.03.16 0LではなくTSFが何かするかもしれないのでDefにまかせる
 		return ::DefWindowProc( hwnd, uMsg, wParam, lParam );
-	
+
 	case MYWM_DROPFILES:	// 独自のドロップファイル通知	// 2008.06.20 ryoji
 		OnMyDropFiles( (HDROP)wParam );
 		return 0L;
@@ -906,7 +906,7 @@ void CEditView::OnMove( int x, int y, int nWidth, int nHeight )
 /* ウィンドウサイズの変更処理 */
 void CEditView::OnSize( int cx, int cy )
 {
-	if( NULL == GetHwnd() 
+	if( NULL == GetHwnd()
 		|| ( cx == 0 && cy == 0 ) ){
 		// From Here 2007.09.09 Moca 互換BMPによる画面バッファ
 		// ウィンドウ無効時にも互換BMPを破棄する
@@ -1168,8 +1168,8 @@ void CEditView::MoveCursorSelecting(
 	GetCaret().GetAdjustCursorPos(&ptWk_CaretPos);
 	if( bSelect ){
 		/*	現在のカーソル位置によって選択範囲を変更．
-		
-			2004.04.02 Moca 
+
+			2004.04.02 Moca
 			キャレット位置が不正だった場合にMoveCursorの移動結果が
 			引数で与えた座標とは異なることがあるため，
 			nPosX, nPosYの代わりに実際の移動結果を使うように．
@@ -1403,7 +1403,7 @@ void CEditView::ConvSelectedArea( EFunctionCode nFuncCode )
 					nDelLen,
 					&cmemBuf
 				);
-				
+
 				{
 					/* 機能種別によるバッファの変換 */
 					int nStartColumn = (Int)sPos.GetX2() / (Int)GetTextMetrics().GetLayoutXDefault();
@@ -2272,7 +2272,7 @@ bool CEditView::MyGetClipboardData( CNativeW& cmemBuf, bool* pbColumnSelect, boo
 
 	if(!CClipboard::HasValidData())
 		return false;
-	
+
 	CClipboard cClipboard(GetHwnd());
 	if(!cClipboard)
 		return false;
@@ -2327,7 +2327,7 @@ void CEditView::CaretUnderLineON( bool bDraw, bool bDrawPaint, bool DisalbeUnder
 //	m_nOldUnderLineY  = -1;
 	// 2011.12.06 Moca IsTextSelected → IsTextSelecting に変更。ロック中も下線を表示しない
 	int bCursorLineBgDraw = false;
-	
+
 	// カーソル行の描画
 	if( bDraw
 	 && bCursorLineBg
@@ -2356,7 +2356,7 @@ void CEditView::CaretUnderLineON( bool bDraw, bool bDrawPaint, bool DisalbeUnder
 			GetCaret().m_cUnderLine.UnLock();
 		}
 	}
-	
+
 	int nCursorVLineX = -1;
 	// From Here 2007.09.09 Moca 互換BMPによる画面バッファ
 	if( bCursorVLine ){
@@ -2394,7 +2394,7 @@ void CEditView::CaretUnderLineON( bool bDraw, bool bDrawPaint, bool DisalbeUnder
 		}	// ReleaseDC の前に gr デストラクト
 		::ReleaseDC( GetHwnd(), hdc );
 	}
-	
+
 	int nUnderLineY = -1;
 	if( bUnderLine ){
 		nUnderLineY = GetTextArea().GetAreaTop() + (Int)(GetCaret().GetCaretLayoutPos().GetY2() - GetTextArea().GetViewTopLine())
@@ -2493,7 +2493,7 @@ void CEditView::CaretUnderLineOFF( bool bDraw, bool bDrawPaint, bool bResetFlag,
 
 			//	選択情報を復元
 			GetCaret().m_cUnderLine.UnLock();
-			
+
 			if( bDrawPaint ){
 				m_nOldUnderLineYBg = -1;
 			}
@@ -2677,7 +2677,7 @@ bool  CEditView::ShowKeywordHelp( POINT po, LPCWSTR pszHelp, LPRECT prcHokanWin)
 	@param[in] ptTo    指定範囲終了
 	@param[in] bSelect    範囲指定
 	@param[in] bBoxSelect 矩形選択
-	
+
 	@retval true  指定位置または指定範囲内にテキストが存在しない
 			false 指定位置または指定範囲内にテキストが存在する
 

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -940,12 +940,12 @@ bool CEditView::DrawLogicLine(
 		bDispEOF = DrawLayoutLine(pInfo);
 
 		//行を進める
-		CLogicInt nOldLogicLineNo = pInfo->m_pDispPos->GetLayoutRef()->GetLogicLineNo();
+		CLogicInt nOldLogicLineNo = CLayout::GetLogicLineNo_Safe(pInfo->m_pDispPos->GetLayoutRef());
 		pInfo->m_pDispPos->ForwardDrawLine(1);		//描画Y座標＋＋
 		pInfo->m_pDispPos->ForwardLayoutLineRef(1);	//レイアウト行＋＋
 
 		// ロジック行を描画し終わったら抜ける
-		if(pInfo->m_pDispPos->GetLayoutRef()->GetLogicLineNo()!=nOldLogicLineNo){
+		if(CLayout::GetLogicLineNo_Safe(pInfo->m_pDispPos->GetLayoutRef()) != nOldLogicLineNo){
 			break;
 		}
 
@@ -979,7 +979,7 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 
 	//文字列参照
 	const CDocLine* pcDocLine = pInfo->GetDocLine();
-	CStringRef cLineStr = pcDocLine->GetStringRefWithEOL();
+	CStringRef cLineStr = CDocLine::GetStringRefWithEOL_Safe(pcDocLine);
 
 	// 描画範囲外の場合は色切替だけで抜ける
 	if(pInfo->m_pDispPos->GetDrawPos().y < GetTextArea().GetAreaTop()){

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -96,7 +96,7 @@ void CEditView::RedrawAll()
 	if( NULL == GetHwnd() ){
 		return;
 	}
-	
+
 	if( GetDrawSwitch() ){
 		// ウィンドウ全体を再描画
 		PAINTSTRUCT	ps;
@@ -270,7 +270,7 @@ void CEditView::DrawBackImage(HDC hdc, RECT& rcPaint, HDC hdcBgImg)
 		}
 	}
 	rcImagePos.SetSize(doc.m_nBackImgWidth, doc.m_nBackImgHeight);
-	
+
 	RECT rc = rcPaint;
 	// rc.left = t_max((int)rc.left, area.GetAreaLeft());
 	rc.top  = t_max((int)rc.top,  area.GetRulerHeight()); // ルーラーを除外
@@ -576,7 +576,7 @@ void CEditView::OnPaint( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp 
 	}
 }
 
-/*! 通常の描画処理 new 
+/*! 通常の描画処理 new
 	@param pPs  pPs.rcPaint は正しい必要がある
 	@param bDrawFromComptibleBmp  TRUE 画面バッファからhdcに作画する(コピーするだけ)。
 			TRUEの場合、pPs.rcPaint領域外は作画されないが、FALSEの場合は作画される事がある。
@@ -604,7 +604,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 		bDrawFromComptibleBmp
 		);
 #endif
-	
+
 	// From Here 2007.09.09 Moca 互換BMPによる画面バッファ
 	// 互換BMPからの転送のみによる作画
 	if( bDrawFromComptibleBmp
@@ -1195,16 +1195,16 @@ bool CEditView::DrawLayoutLine(SColorStrategyInfo* pInfo)
 
 /* テキスト反転
 
-	@param hdc      
-	@param nLineNum 
-	@param x        
-	@param y        
-	@param nX       
+	@param hdc
+	@param nLineNum
+	@param x
+	@param y
+	@param nX
 
 	@note
 	CCEditView::DrawLogicLine() での作画(WM_PAINT)時に、1レイアウト行をまとめて反転処理するための関数。
 	範囲選択の随時更新は、CEditView::DrawSelectArea() が選択・反転解除を行う。
-	
+
 */
 void CEditView::DispTextSelected(
 	HDC				hdc,		//!< 作画対象ビットマップを含むデバイス
@@ -1274,12 +1274,12 @@ void CEditView::DispTextSelected(
 			if( rcClip.right > GetTextArea().GetAreaRight() ){
 				rcClip.right = GetTextArea().GetAreaRight();
 			}
-			
+
 			// 選択色表示なら反転しない
 			if( !bOMatch && CTypeSupport(this, COLORIDX_SELECT).IsDisp() ){
 				return;
 			}
-			
+
 			HBRUSH hBrush    = ::CreateSolidBrush( SELECTEDAREA_RGB );
 
 			int    nROP_Old  = ::SetROP2( hdc, SELECTEDAREA_ROP2 );
@@ -1303,7 +1303,7 @@ void CEditView::DispTextSelected(
 /*!
 	画面の互換ビットマップを作成または更新する。
 		必要の無いときは何もしない。
-	
+
 	@param cx ウィンドウの高さ
 	@param cy ウィンドウの幅
 	@return true: ビットマップを利用可能 / false: ビットマップの作成・更新に失敗
@@ -1373,7 +1373,7 @@ bool CEditView::CreateOrUpdateCompatibleBitmap( int cx, int cy )
 
 	@note 分割ビューが非表示になった場合と
 		親ウィンドウが非表示・最小化された場合に削除される。
-	@date 2007.09.09 Moca 新規作成 
+	@date 2007.09.09 Moca 新規作成
 */
 void CEditView::DeleteCompatibleBitmap()
 {

--- a/sakura_core/view/colors/CColorStrategy.cpp
+++ b/sakura_core/view/colors/CColorStrategy.cpp
@@ -171,13 +171,13 @@ void SColorStrategyInfo::DoChangeColor(CColor3Setting *pcColor)
 	}else if(m_pStrategyFound){
 		m_cIndex.eColorIndex = m_pStrategyFound->GetStrategyColor();
 	}else{
-		m_cIndex.eColorIndex = m_pStrategy->GetStrategyColorSafe();
+		m_cIndex.eColorIndex = CColorStrategy::GetStrategyColorSafe(m_pStrategy);
 	}
 
 	if(m_pStrategyFound){
 		m_cIndex.eColorIndex2 = m_pStrategyFound->GetStrategyColor();
 	}else{
-		m_cIndex.eColorIndex2 = m_pStrategy->GetStrategyColorSafe();
+		m_cIndex.eColorIndex2 = CColorStrategy::GetStrategyColorSafe(m_pStrategy);
 	}
 
 	m_cIndex.eColorIndexBg = m_colorIdxBackLine;

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -124,7 +124,12 @@ struct SColorStrategyInfo{
 	}
 	const CDocLine* GetDocLine() const
 	{
-		return m_pDispPos->GetLayoutRef()->GetDocLineRef();
+		const CLayout* layout = m_pDispPos->GetLayoutRef();
+
+		if (layout) {
+			return layout->GetDocLineRef();
+		}
+		return NULL;
 	}
 	const CLayout* GetLayout() const
 	{
@@ -157,10 +162,15 @@ public:
 	}
 
 	//#######ラップ
-	EColorIndexType GetStrategyColorSafe() const{ if(this)return GetStrategyColor(); else return COLORIDX_TEXT; }
-	CLayoutColorInfo* GetStrategyColorInfoSafe() const{
-		if(this){
-			return GetStrategyColorInfo();
+	static EColorIndexType GetStrategyColorSafe(const CColorStrategy *strategy) {
+		if (strategy) {
+			return strategy->GetStrategyColor();
+		}
+		return COLORIDX_TEXT;
+	}
+	static CLayoutColorInfo* GetStrategyColorInfoSafe(const CColorStrategy *strategy) {
+		if (strategy) {
+			return strategy->GetStrategyColorInfo();
 		}
 		return NULL;
 	}

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -455,7 +455,7 @@ void CEditWnd::_AdjustInMonitor(const STabGroupInfo& sTabGroupInfo)
 		rcOrg.left -= rcOrg.right - rcDesktop.right;
 		rcOrg.right = rcDesktop.right;	//@@@ 2002.01.08
 	}
-	
+
 	if( rcOrg.top < rcDesktop.top ){
 		rcOrg.bottom += rcDesktop.top - rcOrg.top;
 		rcOrg.top = rcDesktop.top;
@@ -837,7 +837,7 @@ void CEditWnd::LayoutMainMenu()
 			// ラベル未設定かつFunctionコードがありならストリングテーブルから取得 2012/10/18 syat 各国語対応
 			pszName = ( cMainMenu->m_sName[0] == L'\0' && cMainMenu->m_nFunc != F_NODE )
 								? LS( cMainMenu->m_nFunc ) : cMainMenu->m_sName;
-			::AppendMenu( hMenu, MF_POPUP | MF_STRING | (nCount<=1 ? MF_GRAYED : 0), (UINT_PTR)CreatePopupMenu(), 
+			::AppendMenu( hMenu, MF_POPUP | MF_STRING | (nCount<=1 ? MF_GRAYED : 0), (UINT_PTR)CreatePopupMenu(),
 				CKeyBind::MakeMenuLabel( pszName, cMainMenu->m_sKey ) );
 			break;
 		case T_LEAF:
@@ -913,7 +913,7 @@ void CEditWnd::LayoutMainMenu()
 				}
 				break;
 			}
-			::AppendMenu( hMenu, MF_POPUP | MF_STRING | (nCount<=0 ? MF_GRAYED : 0), (UINT_PTR)CreatePopupMenu(), 
+			::AppendMenu( hMenu, MF_POPUP | MF_STRING | (nCount<=0 ? MF_GRAYED : 0), (UINT_PTR)CreatePopupMenu(),
 				CKeyBind::MakeMenuLabel( LS(cMainMenu->m_nFunc), cMainMenu->m_sKey ) );
 			break;
 		}
@@ -1207,7 +1207,7 @@ LRESULT CEditWnd::DispatchEvent(
 				}
 				::SetTextColor( lpdis->hDC, ::GetSysColor( nColor ) );
 				::SetBkMode( lpdis->hDC, TRANSPARENT );
-				
+
 				// 2003.08.26 Moca 上下中央位置に作画
 				TEXTMETRIC tm;
 				::GetTextMetrics( lpdis->hDC, &tm );
@@ -1411,7 +1411,7 @@ LRESULT CEditWnd::DispatchEvent(
 
 	case WM_NOTIFY:
 		pnmh = (LPNMHDR) lParam;
-		//	From Here Feb. 15, 2004 genta 
+		//	From Here Feb. 15, 2004 genta
 		//	ステータスバーのダブルクリックでモード切替ができるようにする
 		if( m_cStatusBar.GetStatusHwnd() && pnmh->hwndFrom == m_cStatusBar.GetStatusHwnd() ){
 			if( pnmh->code == NM_DBLCLK ){
@@ -1442,7 +1442,7 @@ LRESULT CEditWnd::DispatchEvent(
 					};
 					m_cMenuDrawer.ResetContents();
 					HMENU hMenuPopUp = ::CreatePopupMenu();
-					m_cMenuDrawer.MyAppendMenu( hMenuPopUp, MF_BYPOSITION | MF_STRING, F_CHGMOD_EOL_CRLF, 
+					m_cMenuDrawer.MyAppendMenu( hMenuPopUp, MF_BYPOSITION | MF_STRING, F_CHGMOD_EOL_CRLF,
 						LS( F_CHGMOD_EOL_CRLF ), L"C" ); // 入力改行コード指定(CRLF)
 					m_cMenuDrawer.MyAppendMenu( hMenuPopUp, MF_BYPOSITION | MF_STRING, F_CHGMOD_EOL_LF,
 						LS( F_CHGMOD_EOL_LF ), L"L" ); // 入力改行コード指定(LF)
@@ -1457,7 +1457,7 @@ LRESULT CEditWnd::DispatchEvent(
 						m_cMenuDrawer.MyAppendMenu( hMenuPopUp, MF_BYPOSITION | MF_STRING, F_CHGMOD_EOL_PS,
 							LS(STR_EDITWND_MENU_PS), L"", TRUE, -2 ); // 入力改行コード指定(PS)
 					}
-					
+
 					//	mp->ptはステータスバー内部の座標なので，スクリーン座標への変換が必要
 					POINT	po = mp->pt;
 					::ClientToScreen( m_cStatusBar.GetStatusHwnd(), &po );
@@ -1493,7 +1493,7 @@ LRESULT CEditWnd::DispatchEvent(
 			}
 			return 0L;
 		}
-		//	To Here Feb. 15, 2004 genta 
+		//	To Here Feb. 15, 2004 genta
 
 		switch( pnmh->code ){
 		// 2007.09.08 kobake TTN_NEEDTEXTの処理をA版とW版に分けて明示的に処理するようにしました。
@@ -1837,7 +1837,7 @@ LRESULT CEditWnd::DispatchEvent(
 				SelectCharWidthCache( CWM_FONT_PRINT, CWM_CACHE_LOCAL );
 			}
 		}
-		return 0L; 
+		return 0L;
 	case MYWM_SETACTIVEPANE:
 		if( -1 == (int)wParam ){
 			if( 0 == lParam ){
@@ -1861,7 +1861,7 @@ LRESULT CEditWnd::DispatchEvent(
 				// 現在の状態をKEEP
 				bSelect = GetActiveView().GetSelectionInfo().m_bSelectingLock;
 			}
-			
+
 			//	2006.07.09 genta 強制解除しない
 			/*
 			カーソル位置変換
@@ -2262,7 +2262,7 @@ void CEditWnd::OnCommand( WORD wNotifyCode, WORD wID , HWND hwndCtl )
 //	キーワード：メニューバー順序
 //	Sept.14, 2000 Jepro note: メニューバーの項目のキャプションや順番設定などは以下で行っているらしい
 //	Sept.16, 2000 Jepro note: アイコンとの関連付けはCShareData_new2.cppファイルで行っている
-//	2010/5/16	Uchi	動的に作成する様に変更	
+//	2010/5/16	Uchi	動的に作成する様に変更
 void CEditWnd::InitMenu( HMENU hMenu, UINT uPos, BOOL fSystemMenu )
 {
 	int			cMenuItems;
@@ -2323,7 +2323,7 @@ void CEditWnd::InitMenu( HMENU hMenu, UINT uPos, BOOL fSystemMenu )
 				}else{
 					pMenuName = cMainMenu->m_sName;
 				}
-				m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING | MF_POPUP, (UINT_PTR)hMenuPopUp , 
+				m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING | MF_POPUP, (UINT_PTR)hMenuPopUp ,
 					pMenuName, cMainMenu->m_sKey );
 				if (hSubMenu.size() > (size_t)nLv) {
 					hSubMenu[nLv] = hMenuPopUp;
@@ -2345,10 +2345,10 @@ void CEditWnd::InitMenu( HMENU hMenu, UINT uPos, BOOL fSystemMenu )
 				if (!bInList) {
 					//分割線に囲まれ、かつリストなし ならば 次の分割線をスキップ
 					if ((i == nIdxStr + 1
-						  || (pcMenu->m_cMainMenuTbl[i-1].m_nType == T_SEPARATOR 
+						  || (pcMenu->m_cMainMenuTbl[i-1].m_nType == T_SEPARATOR
 							&& pcMenu->m_cMainMenuTbl[i-1].m_nLevel == cMainMenu->m_nLevel))
 						&& i + 1 < nIdxEnd
-						&& pcMenu->m_cMainMenuTbl[i+1].m_nType == T_SEPARATOR 
+						&& pcMenu->m_cMainMenuTbl[i+1].m_nType == T_SEPARATOR
 						&& pcMenu->m_cMainMenuTbl[i+1].m_nLevel == cMainMenu->m_nLevel) {
 						i++;		// スキップ
 					}
@@ -2451,56 +2451,56 @@ void CEditWnd::InitMenu_Function(HMENU hMenu, EFunctionCode eFunc, const wchar_t
 		case F_SAVEKEYMACRO:
 		case F_LOADKEYMACRO:
 		case F_EXECKEYMACRO:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				!m_pShareData->m_sFlags.m_bRecordingKeyMacro);
 			break;
-		case F_SPLIT_V:	
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+		case F_SPLIT_V:
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				m_cSplitterWnd.GetAllSplitRows() == 1 );
 			break;
 		case F_SPLIT_H:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				m_cSplitterWnd.GetAllSplitCols() == 1 );
 			break;
 		case F_SPLIT_VH:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				m_cSplitterWnd.GetAllSplitRows() == 1 || m_cSplitterWnd.GetAllSplitCols() == 1 );
 			break;
 		case F_TAB_CLOSEOTHER:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd != 0 );
 			break;
 		case F_TOPMOST:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				((DWORD)::GetWindowLongPtr( GetHwnd(), GWL_EXSTYLE ) & WS_EX_TOPMOST) == 0 );
 			break;
 		case F_BIND_WINDOW:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
-				(!m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
+				(!m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd
 				|| m_pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin) );
 			break;
 		case F_SHOWTOOLBAR:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				!m_pShareData->m_Common.m_sWindow.m_bMenuIcon | !m_cToolbar.GetToolbarHwnd() );
 			break;
 		case F_SHOWFUNCKEY:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				!m_pShareData->m_Common.m_sWindow.m_bMenuIcon | !m_cFuncKeyWnd.GetHwnd() );
 			break;
 		case F_SHOWTAB:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				!m_pShareData->m_Common.m_sWindow.m_bMenuIcon | !m_cTabWnd.GetHwnd() );
 			break;
 		case F_SHOWSTATUSBAR:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				!m_pShareData->m_Common.m_sWindow.m_bMenuIcon | !m_cStatusBar.GetStatusHwnd() );
 			break;
 		case F_SHOWMINIMAP:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				!m_pShareData->m_Common.m_sWindow.m_bMenuIcon | !GetMiniMap().GetHwnd() );
 			break;
 		case F_TOGGLE_KEY_SEARCH:
-			SetMenuFuncSel( hMenu, eFunc, pszKey, 
+			SetMenuFuncSel( hMenu, eFunc, pszKey,
 				!m_pShareData->m_Common.m_sWindow.m_bMenuIcon | !IsFuncChecked( GetDocument(), m_pShareData, F_TOGGLE_KEY_SEARCH ) );
 			break;
 		case F_WRAPWINDOWWIDTH:
@@ -2542,7 +2542,7 @@ void CEditWnd::InitMenu_Function(HMENU hMenu, EFunctionCode eFunc, const wchar_t
 			}
 			break;
 		default:
-			m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, eFunc, 
+			m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, eFunc,
 				pszName, pszKey );
 			break;
 		}
@@ -2822,7 +2822,7 @@ void CEditWnd::OnDropFiles( HDROP hDrop )
 	return;
 }
 
-/*! WM_TIMER 処理 
+/*! WM_TIMER 処理
 	@date 2007.04.03 ryoji 新規
 	@date 2008.04.19 ryoji IDT_FIRST_IDLE での MYWM_FIRST_IDLE ポスト処理を追加
 	@date 2013.06.09 novice コントロールプロセスへの MYWM_FIRST_IDLE ポスト処理を追加
@@ -3283,7 +3283,7 @@ LRESULT CEditWnd::OnSize2( WPARAM wParam, LPARAM lParam, bool bUpdateStatus )
 	int nMiniMapWidth = 0;
 	if( GetMiniMap().GetHwnd() ){
 		nMiniMapWidth = GetDllShareData().m_Common.m_sWindow.m_nMiniMapWidth;
-		::MoveWindow( m_pcEditViewMiniMap->GetHwnd(), 
+		::MoveWindow( m_pcEditViewMiniMap->GetHwnd(),
 			(eDockSideFL == DOCKSIDE_RIGHT)? cx - nFuncListWidth - nMiniMapWidth: cx - nMiniMapWidth,
 			(eDockSideFL == DOCKSIDE_TOP)? nTop + nFuncListHeight: nTop,
 			nMiniMapWidth,
@@ -3761,7 +3761,7 @@ int	CEditWnd::CreateFileDropDownMenu( HWND hwnd )
 		//	アクティブ
 		m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING | MF_POPUP, (UINT_PTR)hMenuPopUp, LS(F_FOLDER_USED_RECENTLY), L"" );
 	}
-	else 
+	else
 	{
 		//	非アクティブ
 		m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING | MF_POPUP | MF_GRAYED, (UINT_PTR)hMenuPopUp, LS(F_FOLDER_USED_RECENTLY), L"" );
@@ -3833,16 +3833,16 @@ void CEditWnd::GetDefaultIcon( HICON* hIconBig, HICON* hIconSmall ) const
 
 /*!
 	アイコンの取得
-	
+
 	指定されたファイル名に対応するアイコン(大・小)を取得して返す．
-	
+
 	@param szFile     [in] ファイル名
 	@param hIconBig   [out] 大きいアイコンのハンドル
 	@param hIconSmall [out] 小さいアイコンのハンドル
-	
+
 	@retval true 関連づけられたアイコンが見つかった
 	@retval false 関連づけられたアイコンが見つからなかった
-	
+
 	@author genta
 	@date 2002.09.10
 */
@@ -3854,7 +3854,7 @@ bool CEditWnd::GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIcon
 
 		// (.で始まる)拡張子の取得
 		_wsplitpath( szFile, NULL, NULL, NULL, szExt );
-		
+
 		if( ReadRegistry(HKEY_CLASSES_ROOT, szExt, NULL, FileType, _countof(FileType) - 13)){
 			wcscat( FileType, L"\\DefaultIcon" );
 			if( ReadRegistry(HKEY_CLASSES_ROOT, FileType, NULL, NULL, 0)){
@@ -3876,9 +3876,9 @@ bool CEditWnd::GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIcon
 
 /*
 	@brief メニューバー表示用フォントの初期化
-	
+
 	メニューバー表示用フォントの初期化を行う．
-	
+
 	@date 2002.12.04 CEditViewのコンストラクタから移動
 */
 void CEditWnd::InitMenubarMessageFont(void)
@@ -3917,10 +3917,10 @@ void CEditWnd::InitMenubarMessageFont(void)
 
 /*
 	@brief メニューバーにメッセージを表示する
-	
+
 	事前にメニューバー表示用フォントが初期化されていなくてはならない．
 	指定できる文字数は最大30文字．それ以上の場合はうち切って表示する．
-	
+
 	@author genta
 	@date 2002.12.04
 */
@@ -3984,10 +3984,10 @@ void CEditWnd::PrintMenubarMessage( const WCHAR* msg )
 
 /*!
 	@brief メッセージの表示
-	
+
 	指定されたメッセージをステータスバーに表示する．
 	ステータスバーが非表示の場合はメニューバーの右端に表示する．
-	
+
 	@param msg [in] 表示するメッセージ
 	@date 2002.01.26 hor 新規作成
 	@date 2002.12.04 genta CEditViewより移動
@@ -4133,7 +4133,7 @@ LRESULT CEditWnd::PopupWinList( bool bMousePos )
 
 	// ポップアップ位置をアクティブビューの上辺に設定
 	RECT rc;
-	
+
 	if( bMousePos ){
 		::GetCursorPos( &pt );	// マウスカーソル位置に変更
 	}
@@ -4170,7 +4170,7 @@ LRESULT CEditWnd::PopupWinList( bool bMousePos )
 	return 0L;
 }
 
-/*! @brief 現在開いている編集窓のリストをメニューにする 
+/*! @brief 現在開いている編集窓のリストをメニューにする
 	@date  2006.03.23 fon CEditWnd::InitMenuから移動。////が元からあるコメント。//>は追加コメントアウト。
 	@date 2009.06.02 ryoji アイテム数が多いときはアクセスキーを 1-9,A-Z の範囲で再使用する（従来は36個未満を仮定）
 */
@@ -4249,9 +4249,9 @@ void CEditWnd::OnEditTimer( void )
 	IncrementTimerCount(6);
 
 	// 2006.01.28 aroka ツールバー更新関連は OnToolbarTimerに移動した。
-	
+
 	//	Aug. 29, 2003 wmlhq, ryoji
-	if( m_nTimerCount == 0 && GetCapture() == NULL ){ 
+	if( m_nTimerCount == 0 && GetCapture() == NULL ){
 		// ファイルのタイムスタンプのチェック処理
 		GetDocument()->m_cAutoReloadAgent.CheckFileTimeStamp();
 
@@ -4630,9 +4630,9 @@ CLogicPointEx* CEditWnd::SavePhysPosOfAllView()
 {
 	const int NUM_OF_VIEW = GetAllViewCount();
 	const int NUM_OF_POS = 6;
-	
+
 	CLogicPointEx* pptPosArray = new CLogicPointEx[NUM_OF_VIEW * NUM_OF_POS];
-	
+
 	for( int i = 0; i < NUM_OF_VIEW; ++i ){
 		CLayoutPoint tmp = CLayoutPoint(CLayoutInt(0), GetView(i).m_pcTextArea->GetViewTopLine());
 		const CLayout* layoutLine = GetDocument()->m_cLayoutMgr.SearchLineByLayoutY(tmp.GetY2());

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -4575,7 +4575,7 @@ BOOL CEditWnd::UpdateTextWrap( void )
 void CEditWnd::ChangeLayoutParam( bool bShowProgress, CKetaXInt nTabSize, int nTsvMode, CKetaXInt nMaxLineKetas )
 {
 	HWND		hwndProgress = NULL;
-	if( bShowProgress ){
+	if( bShowProgress && NULL != this ){ // TODO: Remove "this" check
 		hwndProgress = m_cStatusBar.GetProgressHwnd();
 		//	Status Barが表示されていないときはm_hwndProgressBar == NULL
 	}

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -1077,7 +1077,7 @@ void CEditWnd::MessageLoop( void )
 		if(ret==-1)break; //GetMessage失敗
 
 		//ダイアログメッセージ
-		     if( MyIsDialogMessage( m_pPrintPreview->GetPrintPreviewBarHANDLE_Safe(),	&msg ) ){}	//!< 印刷プレビュー 操作バー
+		     if( MyIsDialogMessage( CPrintPreview::GetPrintPreviewBarHANDLE_Safe(m_pPrintPreview),	&msg ) ){}	//!< 印刷プレビュー 操作バー
 		else if( MyIsDialogMessage( m_cDlgFind.GetHwnd(),								&msg ) ){}	//!<「検索」ダイアログ
 		else if( MyIsDialogMessage( m_cDlgFuncList.GetHwnd(),							&msg ) ){}	//!<「アウトライン」ダイアログ
 		else if( MyIsDialogMessage( m_cDlgReplace.GetHwnd(),							&msg ) ){}	//!<「置換」ダイアログ
@@ -4575,8 +4575,8 @@ BOOL CEditWnd::UpdateTextWrap( void )
 void CEditWnd::ChangeLayoutParam( bool bShowProgress, CKetaXInt nTabSize, int nTsvMode, CKetaXInt nMaxLineKetas )
 {
 	HWND		hwndProgress = NULL;
-	if( bShowProgress && NULL != this ){
-		hwndProgress = this->m_cStatusBar.GetProgressHwnd();
+	if( bShowProgress ){
+		hwndProgress = m_cStatusBar.GetProgressHwnd();
 		//	Status Barが表示されていないときはm_hwndProgressBar == NULL
 	}
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

C++ の未定義動作により、MinGWでビルドしたバイナリ(のRelease版)がクラッシュする問題を修正します。

（gccはNULLポインタに関する未定義動作を積極的に最適化に利用します。NULLポインタに対するメンバ関数の呼び出しは未定義動作であるため、gccは、メンバ関数が `this==NULL` で呼ばれることはないと判断し、メンバ関数内の `if(this)` チェックを最適化で削除してしまいます。これにより、実際に`this==NULL` で呼ばれてしまうと、NULLポインタアクセスが発生してクラッシュしてしまいます。）

~~メンバ関数内での this が NULL かどうかのチェックをやめ、~~ メンバ関数を呼ぶ元でクラスポインタがNULLでないことをチェックするようにします。必要に応じて、チェック用の static 関数を用意し、それに差し替えます。

~~併せて、MinGW 用の Makefile が、msys2 の mintty 内から実行したときに正しく動かない問題があったので、修正しています。また、ヘッダファイルの依存関係の記述を修正し、githash.h, Funccode_enum.h, Funccode_define.h が自動で生成されるようにしました。~~ → #1375 に分離

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正
- ビルド関連
  - MinGWビルド

## <!-- 自明なら省略可 --> PR のメリット

MinGWビルド(Release版)が動くようになる。
(起動するようにはなりましたが、特定の操作で落ちる可能性は依然として残っています。)

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

~~逆にVC++ビルドに影響出る可能性あり。~~

## <!-- 必須 --> テスト内容

MinGWビルド(Release版)が起動すること。
(いろいろ動かして落ちないこと。)
Ctrl+T を押してタグジャンプをしようとしたときに落ちないこと。

## <!-- わかる範囲で --> PR の影響範囲

CDocLine, CColorStrategy, EditNode, CMyWnd, CPrintPreview, CLayout, CEditWnd を使用している箇所に影響の可能性あり。

## <!-- なければ省略可 --> 関連 issue, PR

Fix #601

## 参考資料

* [未定義動作により最適化レベルで結果が変わるコード - Qiita](https://qiita.com/kaityo256/items/d2677e178be0180482e8)