### PR TITLE
MinGWビルドシステムの改善

### DIFF
--- a/HeaderMake/.gitignore
+++ b/HeaderMake/.gitignore
@@ -2,3 +2,6 @@
 /*.user
 # /*.vcxproj
 /Win32
+
+# MinGW files
+/HeaderMake.exe

--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -29,12 +29,6 @@ if "%configuration%" == "Release" (
 path=C:\msys64\mingw64\bin;%path%
 
 @echo mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%"
-mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" githash.h Funccode_enum.h Funccode_define.h
-if errorlevel 1 (
-	echo error 1 errorlevel %errorlevel%
-	exit /b 1
-)
-
 mingw32-make -C sakura_core MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" -j4
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%

--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -24,11 +24,6 @@ if "%configuration%" == "Release" (
 	exit /b 1
 )
 
-@rem  remove sh.exe in the PATH(for azure pipelines).
-PATH=%PATH:C:\Program Files\Git\cmd;=%
-PATH=%PATH:C:\Program Files\Git\usr\bin;=%
-PATH=%PATH:C:\Program Files\Git\bin;=%
-
 @rem https://www.appveyor.com/docs/environment-variables/
 @rem path=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%path%
 path=C:\msys64\mingw64\bin;%path%

--- a/build.md
+++ b/build.md
@@ -195,6 +195,5 @@ x86_64 | posix | sjlj | pthreadのDLLが必要
 
 ```
 path=C:\msys64\mingw64\bin;%path%
-mingw32-make -C sakura_core githash.h Funccode_enum.h Funccode_define.h
 mingw32-make -C sakura_core -j4
 ```

--- a/sakura_core/.gitignore
+++ b/sakura_core/.gitignore
@@ -2,3 +2,8 @@
 /githash.h.tmp
 /Funccode_define.h
 /Funccode_enum.h
+
+# MinGW files
+/sakura.exe
+*.d
+*.o

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -453,8 +453,10 @@ Funccode_enum.h: $(HEADERMAKE) Funccode_x.hsrc
 githash.h:
 	cmd /c ..\sakura\githash.bat ../sakura_core
 
-.cpp.o: githash.h Funccode_enum.h
+.cpp.o:
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+$(OBJS): githash.h Funccode_enum.h
 
 $(HEADERMAKE): $(HEADERMAKETOOLDIR)/HeaderMake.cpp
 	$(CXX) $(CXXFLAGS) $(HEADERMAKETOOLDIR)/HeaderMake.cpp -o $@ -static-libgcc

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -31,6 +31,7 @@ DEFINES= \
 CFLAGS= \
  -finput-charset=utf-8 \
  -fexec-charset=cp932 \
+ -MMD \
  -I. \
  $(DEFINES) $(MYCFLAGS)
 CXXFLAGS= $(CFLAGS) \
@@ -431,6 +432,8 @@ _os/CClipboard.o \
 _os/CDropTarget.o \
 sakura_rc.o \
 
+DEPS= $(OBJS:%.o=%.d)
+
 GENERATED_FILES= \
 Funccode_define.h \
 Funccode_enum.h \
@@ -459,18 +462,16 @@ githash.h:
 $(OBJS): githash.h Funccode_enum.h
 
 $(HEADERMAKE): $(HEADERMAKETOOLDIR)/HeaderMake.cpp
-	$(CXX) $(CXXFLAGS) $(HEADERMAKETOOLDIR)/HeaderMake.cpp -o $@ -static-libgcc
+	$(CXX) $(CXXFLAGS:-MMD=) $(HEADERMAKETOOLDIR)/HeaderMake.cpp -o $@ -static-libgcc
 
 sakura_rc.o: githash.h Funccode_define.h sakura_rc.rc
 	$(RC) -c utf-8 --language=0411 $(DEFINES) sakura_rc.rc -o $@
 
 clean:
-	$(RM) $(exe) $(OBJS) $(HEADERMAKE) StdAfx.h.gch $(GENERATED_FILES) depend.mak
-
-depend: githash.h Funccode_enum.h
-	$(CXX) -E -MM -w $(DEFINES) $(CXXFLAGS) *.cpp > depend.mak
+	$(RM) $(exe) $(OBJS) $(HEADERMAKE) StdAfx.h.gch $(GENERATED_FILES)
+	$(RM) $(DEPS)
 
 .SUFFIXES: .cpp .o .rc
-.PHONY: all clean depend
+.PHONY: all clean
 
--include depend.mak
+-include $(DEPS)

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -20,7 +20,7 @@ endif
 CC= $(PREFIX)gcc
 CXX= $(PREFIX)g++
 RC= $(RCPREFIX)windres
-RM= "$(CURDIR)/../sakura/mingw32-del.bat"
+RM= cmd /c ..\sakura\mingw32-del.bat
 
 DEFINES= \
  -DWIN32 \
@@ -451,7 +451,7 @@ Funccode_enum.h: $(HEADERMAKE) Funccode_x.hsrc
 	$(HEADERMAKE) -in=../sakura_core/Funccode_x.hsrc -out=../sakura_core/Funccode_enum.h -mode=enum -enum=EFunctionCode
 
 githash.h:
-	"$(CURDIR)/../sakura/githash.bat" ../sakura_core
+	cmd /c ..\sakura\githash.bat ../sakura_core
 
 .cpp.o: githash.h Funccode_enum.h
 	$(CXX) $(CXXFLAGS) -o $@ -c $<


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

MinGWのビルドシステムを改善します。(#1372 からの派生)

## <!-- 必須 --> カテゴリ

- ビルド関連
  - MinGW

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

* `mingw32-make -C sakura_core githash.h Funccode_enum.h Funccode_define.h` を実行せずとも、`mingw32-make -C sakura_core` だけでビルドできるようにする。
  Makefile の `.cpp.o: githash.h Funccode_enum.h` の行で、`warning: ignoring prerequisites on suffix rule definition` という警告が表示されていました。
  suffix rule に依存関係を書くことはできないため、依存関係を分離することで、ヘッダファイルを先に生成しておく必要がなくなりました。
* sh.exe が PATH 上にあり、それが shell として使われた場合でもビルドできるようにする。
  バッチファイルは `cmd /c` を介して実行するようにしました。
* `mingw32-make -C sakura_core depend` を実行せずとも、ビルド時に自動で依存関係を出力し、次回からはその結果を利用するようにする。
  `make depend` を実行すると、依存関係を記載した `depend.mak` というファイルを出力するようになっていましたが、わざわざ手動で実行する必要があり、さらに `sakura_core/` 直下の cpp ファイルの依存関係しか見ていませんでした。
  gcc の `-MMD` オプションを使うことで、コンパイルと同時に依存関係を記した `*.d` ファイルを生成し、それを次回以降のビルドで使うようにしました。`sakura_core/` 以下のすべての cpp ファイルの依存関係が生成されます。
* MinGW でビルドしたときに生成されるファイルを `.gitignore` に追加し、`git status` で余計なファイルが表示されないようにする。
  `*.o`, `*.d`, `/sakura.exe` などを追加しました。

## <!-- 必須 --> テスト内容

* `mingw32-make -C sakura_core` を実行し、`sakura_core/sakura.exe` が作成されること。
* Git for Windows の sh.exe に PATH が通った状態でも問題なくビルドできること。
* ビルド後 `git status` を実行し、余計なファイルが表示されないこと。

## <!-- わかる範囲で --> PR の影響範囲

MinGWビルド

## <!-- なければ省略可 --> 関連 issue, PR

Issue #1372

## 参考資料

* [Error Messages (GNU make)](https://www.gnu.org/software/make/manual/html_node/Error-Messages.html)
* [Makeでヘッダファイルの依存関係に対応する - wagavulin's blog](https://www.wagavulin.jp/entry/20120405/1333629926)