### PR TITLE
英語リソースに英語の言語IDを使う

### DIFF
--- a/sakura_lang_en_US/sakura_lang_en_US.vcxproj
+++ b/sakura_lang_en_US/sakura_lang_en_US.vcxproj
@@ -81,7 +81,7 @@
   <ItemDefinitionGroup Label="Common Settings">
     <ResourceCompile>
       <AdditionalIncludeDirectories>..\sakura_core;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <Culture>0x0411</Culture>
+      <Culture>0x0409</Culture>
       <AdditionalOptions>/c 65001</AdditionalOptions>
     </ResourceCompile>
     <Link>

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -29,7 +29,7 @@
 
 /* LMP (Lucien Murray-Pitts) : 2011-02-26 Added Basic English Translation Resources */
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 #ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
 #endif //_WIN32

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -2149,7 +2149,7 @@ VS_VERSION_INFO VERSIONINFO
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
-        BLOCK "041104b0"
+        BLOCK "040904b0"
         BEGIN
             VALUE "Comments", "This is free software\0"
             VALUE "CompanyName", "Project: Sakura-Editor\0"
@@ -2165,7 +2165,7 @@ BEGIN
     END
     BLOCK "VarFileInfo"
     BEGIN
-        VALUE "Translation", 0x411, 1200
+        VALUE "Translation", 0x409, 1200
     END
 END
 

--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -31,7 +31,7 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 #ifdef _WIN32
-LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #endif //_WIN32
 
 #define	S_COPYRIGHT				"Copyright (C) 1998-2020  by Norio Nakatani & Collaborators"


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

英語リソースに日本語の言語ID(0x0411)が使用されているのを修正し、英語の言語ID(0x0409)を使うようにする。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正
- 翻訳

## <!-- 自明なら省略可 --> PR の背景

https://github.com/sakura-editor/sakura/issues/1369#issuecomment-674512904
> サクラエディタが各国語リソースの作成に日本語(0x411)を要求すること自体については、おかしい、という見解を何度か出しています。単純には直せない設計的課題なので、当座は我慢してもらうしかないっす。

「単純には直せない」ようには思えなかったので、直してみました。

## <!-- 自明なら省略可 --> PR のメリット

英語リソースが正しく英語として扱われるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

不明

## <!-- 必須 --> テスト内容

* Visual Studio で `sakura_lang_en_US` プロジェクトを開き、リソースエディタで正しく開けることを確認。
  - リソースビューのツリーから、Version リソースを開き、`VS_VERSION_INFO [英語 (米国)]` と表示されていることを確認。
  - `VS_VERSION_INFO [英語 (米国)]` を開いて、Block Header の部分に、`英語 (米国) (040904b0)` と表示されていることを確認。
* `sakura_lang_en_US.dll` がビルドできることを確認。
* エクスプローラから `sakura_lang_en_US.dll` のプロパティを開き、`詳細` タブの `言語` 欄に `英語 (米国)` と表示されていることを確認。
* サクラエディタを起動し、設定→共通設定→ウィンドウ→言語から `English (United States)` を選択して OK を押し、英語表記に切り替わることを確認。

## <!-- わかる範囲で --> PR の影響範囲

英語リソースファイル