### PR TITLE
MinGW: プリコンパイルヘッダの依存関係の修正

### DIFF
--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -432,7 +432,7 @@ _os/CClipboard.o \
 _os/CDropTarget.o \
 sakura_rc.o \
 
-DEPS= $(OBJS:%.o=%.d)
+DEPS= $(OBJS:%.o=%.d) StdAfx.h.d
 
 GENERATED_FILES= \
 Funccode_define.h \
@@ -457,7 +457,7 @@ githash.h:
 	cmd /c ..\sakura\githash.bat ../sakura_core
 
 StdAfx.h.gch: githash.h Funccode_enum.h
-	$(CXX) $(CXXFLAGS) -c StdAfx.h
+	$(CXX) $(CXXFLAGS) -c StdAfx.h -o $@
 
 .cpp.o:
 	$(CXX) $(CXXFLAGS) -o $@ -c $<


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

#1378 で MinGW の PCH が復活したが、`-MMD` オプションで自動生成される依存関係を記述した `*.d` ファイルが正しく生成されていなかったので修正する。

## <!-- 必須 --> カテゴリ

- 不具合修正
- ビルド関連
  - MinGW

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

プリコンパイルヘッダとして `StdAfx.h.gch` を作成するとき、依存関係を記述した `StdAfx.d` が自動生成されていたが、次に `StdAfx.cpp` をコンパイルするときに `StdAfx.d` が上書きされてしまい、依存関係が壊されていた。
`StdAfx.h.gch` を作成するときに `-o` オプションでファイル名を指定することで、(`StdAfx.d` ではなく) `StdAfx.h.d` に依存関係を出力するようにし、上書きされないようにする。

## <!-- 必須 --> テスト内容

* MinGW でビルド実行後、`StdAfx.h.d` と `StdAfx.d` が作成されていること。
* `StdAfx.h.d` には、`StdAfx.h` から `StdAfx.h.gch` を作成するための依存関係が記載されていること。
* `StdAfx.d` には、`StdAfx.cpp` から `StdAfx.o` を作成するための依存関係が記載されていること。
* `StdAfx.h.d` に記載されている適当なヘッダファイルを `touch` してタイムスタンプを更新し、`make` を実行すると、`StdAfx.h.gch` が更新されること。（なお、すべての `.o` は `StdAfx.h.gch` に依存しているため、結果的に全コンパイルが走る。）
* `make clean` で `StdAfx.h.d` も削除されること。

## <!-- わかる範囲で --> PR の影響範囲

MinGW ビルド

## <!-- なければ省略可 --> 関連 issue, PR

#1378