### PR TITLE
MinGW: Fix SEGV

### DIFF
--- a/sakura_core/view/CEditView_Paint_Bracket.cpp
+++ b/sakura_core/view/CEditView_Paint_Bracket.cpp
@@ -321,7 +321,7 @@ bool CEditView::SearchBracket(
 	CLogicPoint ptPos;
 
 	m_pcEditDoc->m_cLayoutMgr.LayoutToLogic( ptLayout, &ptPos );
-	const wchar_t *cline = m_pcEditDoc->m_cDocLineMgr.GetLine(ptPos.GetY2())->GetDocLineStrWithEOL(&len);
+	const wchar_t *cline = CDocLine::GetDocLineStrWithEOL_Safe(m_pcEditDoc->m_cDocLineMgr.GetLine(ptPos.GetY2()), &len);
 
 	//	Jun. 19, 2000 genta
 	if( cline == NULL )	//	最後の行に本文がない場合


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

https://github.com/sakura-editor/sakura/pull/1363#discussion_r475213207 で見つかった MinGW の SEGV を修正する。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 必須 --> テスト内容

./sakura_core ディレクトリで以下のコマンドを実行する:
```
sakura.exe StdAfx.h -MTYPE=js -M="Down();Up();Right();Left();ShowFunckey();ShowMiniMap();ShowTab();SelectAll();GoFileEnd();GoFileTop();ShowFunckey();ShowMiniMap();ShowTab();ExitAll();"
```

これで SEGV が発生しないことを確認。

## <!-- わかる範囲で --> PR の影響範囲

MinGW ビルド

## <!-- なければ省略可 --> 関連 issue, PR

https://github.com/sakura-editor/sakura/pull/1363#discussion_r475213207, #601, #1372