### PR TITLE
MinGW: Refactor Makefile

### DIFF
--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -1,7 +1,7 @@
 # Makefile for MinGW32/MinGW-W64
 
 # Relative path of "sakura_core" directory from the current directory.
-# If you build in a shadow directory, you can specify this.  E.g.
+# Useful when doing out-of-source build.  E.g.
 #   $ cd sakura_core
 #   $ mkdir _build
 #   $ cd _build

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -35,17 +35,13 @@ endif
 ifndef PREFIX
 PREFIX=
 RCPREFIX=
-else
-ifeq ($(PREFIX),x86_64-w64-mingw32-)
+else ifeq ($(PREFIX),x86_64-w64-mingw32-)
 RCPREFIX=$(PREFIX)
-else
-ifeq ($(PREFIX),i686-w64-mingw32-)
+else ifeq ($(PREFIX),i686-w64-mingw32-)
 ifeq ($(OS),Windows_NT)
 RCPREFIX=
 else
 RCPREFIX=$(PREFIX)
-endif
-endif
 endif
 endif
 

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -92,9 +92,7 @@ OBJS = $(SRCS:$(SRCDIR)/%.cpp=%.o) sakura_rc.o
 
 _DIRS = $(filter %/, $(wildcard $(SRCDIR)/*/)) \
         $(filter %/, $(wildcard $(SRCDIR)/*/*/))
-# Filter out the current directory name.
-DIRS = $(patsubst %/,%, \
-       $(filter-out $(notdir $(CURDIR))/%,$(_DIRS:$(SRCDIR)/%/=%/)))
+DIRS = $(_DIRS:$(SRCDIR)/%/=%)
 
 DEPS= $(OBJS:%.o=%.d) StdAfx.h.d
 

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -1,13 +1,17 @@
 # Makefile for MinGW32/MinGW-W64
 
-# Relative path of "sakura_core" directory from the current directory.
-# Useful when doing out-of-source build.  E.g.
-#   $ cd sakura_core
-#   $ mkdir _build
-#   $ cd _build
-#   $ mingw32-make -f ../Makefile SRCDIR=..
-# Normally, this is derived from the path of Makefile.
-SRCDIR = $(patsubst %/,%,$(dir $(word 1,$(MAKEFILE_LIST))))
+# Example usages:
+#   Out-of-source build:
+#     $ mkdir -p build/MinGW/Release
+#     $ cd build/MinGW/Release
+#     $ mingw32-make -f ../../../sakura_core/Makefile MYCFLAGS=-O2 OUTDIR=. -j4
+#
+#   Debug build with coverage:
+#     $ cd sakura_core
+#     $ mingw32-make MYCFLAGS="-g --coverage" MYLIBS=--coverage -j4
+
+# Path of "sakura_core" directory. Compute it from the path of Makefile.
+SRCDIR = $(patsubst %/,%,$(subst \,/,$(dir $(firstword $(MAKEFILE_LIST)))))
 
 # If SRCDIR is different from the current directory, set it to VPATH.
 # (If SRCDIR ends with a backslash, remove it before set to VPATH.)

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -17,11 +17,15 @@ endif
 ifeq ($(SHELL),sh.exe)
 # If cmd.exe is used as a shell.
 MKDIR = md
-RM = cmd /c $(SRCDIR)\..\sakura\mingw32-del.bat
+RM = del
+DIRSEP = \\
+DEVNULL = NUL
 else
 # If unix-like shell is used.
 MKDIR = mkdir -p
 RM = rm -f
+DIRSEP = /
+DEVNULL = /dev/null
 endif
 
 ifndef PREFIX
@@ -115,7 +119,7 @@ githash.h:
 
 StdAfx.h.gch: StdAfx.h githash.h Funccode_enum.h
 ifneq ($(SRCDIR),.)
-	$(MKDIR) $(subst /,\\,$(DIRS))
+	-$(MKDIR) $(subst /,$(DIRSEP),$(DIRS)) > $(DEVNULL) 2>&1
 endif
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
@@ -131,8 +135,8 @@ sakura_rc.o: sakura_rc.rc githash.h Funccode_define.h
 	$(RC) -c utf-8 --language=0411 $(DEFINES) -I. -I$(SRCDIR) $< -o $@
 
 clean:
-	$(RM) $(exe) $(OBJS) $(HEADERMAKE) StdAfx.h.gch $(GENERATED_FILES)
-	$(RM) $(DEPS)
+	-$(RM) $(exe) $(subst /,$(DIRSEP),$(OBJS) $(HEADERMAKE)) StdAfx.h.gch $(GENERATED_FILES)
+	-$(RM) $(subst /,$(DIRSEP),$(DEPS))
 
 .SUFFIXES: .cpp .o .rc
 .PHONY: all clean

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -1,13 +1,13 @@
 # Makefile for MinGW32/MinGW-W64
 
 # Relative path of "sakura_core" directory from the current directory.
-# If you build in a shadow directory, you should specify this.
-# E.g.
+# If you build in a shadow directory, you can specify this.  E.g.
 #   $ cd sakura_code
 #   $ mkdir _build
 #   $ cd _build
 #   $ mingw32-make -f ../Makefile SRCDIR=..
-SRCDIR = .
+# Normally, this is derived from the path of Makefile.
+SRCDIR = $(patsubst %/,%,$(dir $(word 1,$(MAKEFILE_LIST))))
 
 # If SRCDIR is different from the current directory, set it to VPATH.
 ifneq ($(SRCDIR),.)
@@ -89,9 +89,12 @@ SRCS = $(wildcard $(SRCDIR)/*.cpp) \
        $(wildcard $(SRCDIR)/*/*.cpp) \
        $(wildcard $(SRCDIR)/*/*/*.cpp)
 OBJS = $(SRCS:$(SRCDIR)/%.cpp=%.o) sakura_rc.o
+
 _DIRS = $(filter %/, $(wildcard $(SRCDIR)/*/)) \
         $(filter %/, $(wildcard $(SRCDIR)/*/*/))
-DIRS = $(_DIRS:$(SRCDIR)/%/=%)
+# Filter out the current directory name.
+DIRS = $(patsubst %/,%, \
+       $(filter-out $(notdir $(CURDIR))/%,$(_DIRS:$(SRCDIR)/%/=%/)))
 
 DEPS= $(OBJS:%.o=%.d) StdAfx.h.d
 

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -14,6 +14,10 @@ ifneq ($(SRCDIR),.)
 VPATH = $(SRCDIR)
 endif
 
+# The directory where the .exe files will be output.
+# If empty, they will be output to the default directories.
+OUTDIR =
+
 ifeq ($(SHELL),sh.exe)
 # If cmd.exe is used as a shell.
 MKDIR = md
@@ -83,7 +87,7 @@ LIBS= \
  -municode \
  $(MYLIBS)
 
-exe= sakura.exe
+exe= $(or $(OUTDIR),.)/sakura.exe
 
 SRCS = $(wildcard $(SRCDIR)/*.cpp) \
        $(wildcard $(SRCDIR)/*/*.cpp) \
@@ -102,7 +106,7 @@ GENERATED_FILES= \
  githash.h \
 
 HEADERMAKETOOLDIR= $(SRCDIR)/../HeaderMake
-HEADERMAKE= $(HEADERMAKETOOLDIR)/HeaderMake.exe
+HEADERMAKE= $(or $(OUTDIR),$(HEADERMAKETOOLDIR))/HeaderMake.exe
 
 all: $(exe)
 

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -10,8 +10,9 @@
 SRCDIR = $(patsubst %/,%,$(dir $(word 1,$(MAKEFILE_LIST))))
 
 # If SRCDIR is different from the current directory, set it to VPATH.
+# (If SRCDIR ends with a backslash, remove it before set to VPATH.)
 ifneq ($(SRCDIR),.)
-VPATH = $(SRCDIR)
+VPATH = $(patsubst %\,%,$(SRCDIR))
 endif
 
 # The directory where the .exe files will be output.

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -22,7 +22,7 @@ ifeq ($(SHELL),sh.exe)
 # If cmd.exe is used as a shell.
 MKDIR = md
 RM = del
-DIRSEP = \\
+DIRSEP = $(strip \ )
 DEVNULL = NUL
 else
 # If unix-like shell is used.
@@ -120,7 +120,7 @@ Funccode_enum.h: Funccode_x.hsrc $(HEADERMAKE)
 	$(HEADERMAKE) -in=$< -out=$@ -mode=enum -enum=EFunctionCode
 
 githash.h:
-	cmd /c $(SRCDIR)\..\sakura\githash.bat .
+	cmd /c $(subst /,\,$(SRCDIR))\..\sakura\githash.bat .
 
 StdAfx.h.gch: StdAfx.h githash.h Funccode_enum.h
 ifneq ($(SRCDIR),.)
@@ -140,7 +140,7 @@ sakura_rc.o: sakura_rc.rc githash.h Funccode_define.h
 	$(RC) -c utf-8 --language=0411 $(DEFINES) -I. -I$(SRCDIR) $< -o $@
 
 clean:
-	-$(RM) $(exe) $(subst /,$(DIRSEP),$(OBJS) $(HEADERMAKE)) StdAfx.h.gch $(GENERATED_FILES)
+	-$(RM) $(subst /,$(DIRSEP),$(exe) $(OBJS) $(HEADERMAKE)) StdAfx.h.gch $(GENERATED_FILES)
 	-$(RM) $(subst /,$(DIRSEP),$(DEPS))
 
 .SUFFIXES: .cpp .o .rc

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -1,5 +1,29 @@
 # Makefile for MinGW32/MinGW-W64
 
+# Relative path of "sakura_core" directory from the current directory.
+# If you build in a shadow directory, you should specify this.
+# E.g.
+#   $ cd sakura_code
+#   $ mkdir _build
+#   $ cd _build
+#   $ mingw32-make -f ../Makefile SRCDIR=..
+SRCDIR = .
+
+# If SRCDIR is different from the current directory, set it to VPATH.
+ifneq ($(SRCDIR),.)
+VPATH = $(SRCDIR)
+endif
+
+ifeq ($(SHELL),sh.exe)
+# If cmd.exe is used as a shell.
+MKDIR = md
+RM = cmd /c $(SRCDIR)\..\sakura\mingw32-del.bat
+else
+# If unix-like shell is used.
+MKDIR = mkdir -p
+RM = rm -f
+endif
+
 ifndef PREFIX
 PREFIX=
 RCPREFIX=
@@ -20,7 +44,6 @@ endif
 CC= $(PREFIX)gcc
 CXX= $(PREFIX)g++
 RC= $(RCPREFIX)windres
-RM= cmd /c ..\sakura\mingw32-del.bat
 
 DEFINES= \
  -DWIN32 \
@@ -33,6 +56,7 @@ CFLAGS= \
  -fexec-charset=cp932 \
  -MMD \
  -I. \
+ -I$(SRCDIR) \
  $(DEFINES) $(MYCFLAGS)
 CXXFLAGS= $(CFLAGS) \
  -std=c++17 \
@@ -57,389 +81,22 @@ LIBS= \
 
 exe= sakura.exe
 
-# ls *.cpp */*.cpp */*/*.cpp | sed -E -e "s/([[:alnum:]_]+)\.[[:alnum:]]+/\1.o \\\\/"
-OBJS= \
-CAutoReloadAgent.o \
-CAutoSaveAgent.o \
-CBackupAgent.o \
-CCodeChecker.o \
-CDataProfile.o \
-CDicMgr.o \
-CEditApp.o \
-CEol.o \
-CFileExt.o \
-CGrepAgent.o \
-CHokanMgr.o \
-CKeyWordSetMgr.o \
-CLoadAgent.o \
-CMarkMgr.o \
-COpe.o \
-COpeBlk.o \
-COpeBuf.o \
-CProfile.o \
-CPropertyManager.o \
-CReadManager.o \
-CRegexKeyword.o \
-CSaveAgent.o \
-CSearchAgent.o \
-CSelectLang.o \
-CSortedTagJumpList.o \
-CWriteManager.o \
-EditInfo.o \
-GrepInfo.o \
-StdAfx.o \
-apiwrap/StdApi.o \
-apiwrap/StdControl.o \
-basis/CLaxInteger.o \
-basis/CMyPoint.o \
-basis/CMyRect.o \
-basis/CMySize.o \
-basis/CMyString.o \
-basis/CStrictInteger.o \
-basis/CStrictPoint.o \
-basis/CStrictRange.o \
-basis/CStrictRect.o \
-basis/SakuraBasis.o \
-charset/CCesu8.o \
-charset/CCodeBase.o \
-charset/CCodeFactory.o \
-charset/CCodeMediator.o \
-charset/CCodePage.o \
-charset/CESI.o \
-charset/CEuc.o \
-charset/charcode.o \
-charset/charset.o \
-charset/CJis.o \
-charset/CLatin1.o \
-charset/codechecker.o \
-charset/codeutil.o \
-charset/CShiftJis.o \
-charset/CUnicode.o \
-charset/CUnicodeBe.o \
-charset/CUtf7.o \
-charset/CUtf8.o \
-charset/icu4c/CharsetDetector.o \
-cmd/CViewCommander.o \
-cmd/CViewCommander_Bookmark.o \
-cmd/CViewCommander_Clipboard.o \
-cmd/CViewCommander_Convert.o \
-cmd/CViewCommander_Cursor.o \
-cmd/CViewCommander_CustMenu.o \
-cmd/CViewCommander_Diff.o \
-cmd/CViewCommander_Edit.o \
-cmd/CViewCommander_Edit_advanced.o \
-cmd/CViewCommander_Edit_word_line.o \
-cmd/CViewCommander_File.o \
-cmd/CViewCommander_Grep.o \
-cmd/CViewCommander_Insert.o \
-cmd/CViewCommander_Macro.o \
-cmd/CViewCommander_ModeChange.o \
-cmd/CViewCommander_Outline.o \
-cmd/CViewCommander_Search.o \
-cmd/CViewCommander_Select.o \
-cmd/CViewCommander_Settings.o \
-cmd/CViewCommander_Support.o \
-cmd/CViewCommander_TagJump.o \
-cmd/CViewCommander_Window.o \
-config/build_config.o \
-convert/CConvert.o \
-convert/CConvert_HaneisuToZeneisu.o \
-convert/CConvert_HankataToZenhira.o \
-convert/CConvert_HankataToZenkata.o \
-convert/CConvert_SpaceToTab.o \
-convert/CConvert_TabToSpace.o \
-convert/CConvert_ToHankaku.o \
-convert/CConvert_ToLower.o \
-convert/CConvert_ToUpper.o \
-convert/CConvert_ToZenhira.o \
-convert/CConvert_ToZenkata.o \
-convert/CConvert_Trim.o \
-convert/CConvert_ZeneisuToHaneisu.o \
-convert/CConvert_ZenkataToHankata.o \
-convert/CDecode_Base64Decode.o \
-convert/CDecode_UuDecode.o \
-convert/convert_util.o \
-convert/convert_util2.o \
-debug/CRunningTimer.o \
-debug/Debug1.o \
-debug/Debug2.o \
-debug/Debug3.o \
-dlg/CDialog.o \
-dlg/CDlgAbout.o \
-dlg/CDlgCancel.o \
-dlg/CDlgCompare.o \
-dlg/CDlgCtrlCode.o \
-dlg/CDlgDiff.o \
-dlg/CDlgExec.o \
-dlg/CDlgFavorite.o \
-dlg/CDlgFileUpdateQuery.o \
-dlg/CDlgFind.o \
-dlg/CDlgGrep.o \
-dlg/CDlgGrepReplace.o \
-dlg/CDlgInput1.o \
-dlg/CDlgJump.o \
-dlg/CDlgOpenFile.o \
-dlg/CDlgOpenFile_CommonFileDialog.o \
-dlg/CDlgOpenFile_CommonItemDialog.o \
-dlg/CDlgPluginOption.o \
-dlg/CDlgPrintSetting.o \
-dlg/CDlgProfileMgr.o \
-dlg/CDlgProperty.o \
-dlg/CDlgReplace.o \
-dlg/CDlgSetCharSet.o \
-dlg/CDlgTagJumpList.o \
-dlg/CDlgTagsMake.o \
-dlg/CDlgWindowList.o \
-dlg/CDlgWinSize.o \
-doc/CBlockComment.o \
-doc/CDocEditor.o \
-doc/CDocFile.o \
-doc/CDocFileOperation.o \
-doc/CDocListener.o \
-doc/CDocLocker.o \
-doc/CDocOutline.o \
-doc/CDocReader.o \
-doc/CDocType.o \
-doc/CDocTypeSetting.o \
-doc/CDocVisitor.o \
-doc/CEditDoc.o \
-doc/CLineComment.o \
-doc/layout/CLayout.o \
-doc/layout/CLayoutMgr.o \
-doc/layout/CLayoutMgr_DoLayout.o \
-doc/layout/CLayoutMgr_New.o \
-doc/layout/CLayoutMgr_New2.o \
-doc/layout/CTsvModeInfo.o \
-doc/logic/CDocLine.o \
-doc/logic/CDocLineMgr.o \
-docplus/CBookmarkManager.o \
-docplus/CDiffManager.o \
-docplus/CFuncListManager.o \
-docplus/CModifyManager.o \
-env/CAppNodeManager.o \
-env/CDocTypeManager.o \
-env/CFileNameManager.o \
-env/CFormatManager.o \
-env/CHelpManager.o \
-env/CommonSetting.o \
-env/CSakuraEnvironment.o \
-env/CSearchKeywordManager.o \
-env/CShareData.o \
-env/CShareData_IO.o \
-env/CTagJumpManager.o \
-env/DLLSHAREDATA.o \
-extmodule/CBregexp.o \
-extmodule/CBregexpDll2.o \
-extmodule/CDllHandler.o \
-extmodule/CHtmlHelp.o \
-extmodule/CIcu4cI18n.o \
-extmodule/CMigemo.o \
-extmodule/CUxTheme.o \
-func/CFuncKeyWnd.o \
-func/CFuncLookup.o \
-func/CKeyBind.o \
-func/Funccode.o \
-io/CBinaryStream.o \
-io/CFile.o \
-io/CFileLoad.o \
-io/CIoBridge.o \
-io/CStream.o \
-io/CTextStream.o \
-io/CZipFile.o \
-macro/CCookieManager.o \
-macro/CEditorIfObj.o \
-macro/CIfObj.o \
-macro/CKeyMacroMgr.o \
-macro/CMacro.o \
-macro/CMacroFactory.o \
-macro/CMacroManagerBase.o \
-macro/CPPA.o \
-macro/CPPAMacroMgr.o \
-macro/CSMacroMgr.o \
-macro/CWSH.o \
-macro/CWSHIfObj.o \
-macro/CWSHManager.o \
-mem/CMemory.o \
-mem/CNative.o \
-mem/CNativeA.o \
-mem/CNativeW.o \
-mem/CRecycledBuffer.o \
-mfclike/CMyWnd.o \
-outline/CDlgFileTree.o \
-outline/CDlgFuncList.o \
-outline/CFuncInfo.o \
-outline/CFuncInfoArr.o \
-parse/CWordParse.o \
-plugin/CDllPlugin.o \
-plugin/CJackManager.o \
-plugin/CPlugin.o \
-plugin/CPluginManager.o \
-plugin/CWSHPlugin.o \
-print/CPrint.o \
-print/CPrintPreview.o \
-prop/CPropComBackup.o \
-prop/CPropComCustmenu.o \
-prop/CPropComEdit.o \
-prop/CPropComFile.o \
-prop/CPropComFileName.o \
-prop/CPropComFormat.o \
-prop/CPropComGeneral.o \
-prop/CPropComGrep.o \
-prop/CPropComHelper.o \
-prop/CPropComKeybind.o \
-prop/CPropComKeyword.o \
-prop/CPropComMacro.o \
-prop/CPropComMainMenu.o \
-prop/CPropCommon.o \
-prop/CPropComPlugin.o \
-prop/CPropComStatusbar.o \
-prop/CPropComTab.o \
-prop/CPropComToolbar.o \
-prop/CPropComWin.o \
-recent/CMRUFile.o \
-recent/CMRUFolder.o \
-recent/CMruListener.o \
-recent/CRecent.o \
-recent/CRecentCmd.o \
-recent/CRecentCurDir.o \
-recent/CRecentEditNode.o \
-recent/CRecentExceptMru.o \
-recent/CRecentExcludeFile.o \
-recent/CRecentExcludeFolder.o \
-recent/CRecentFile.o \
-recent/CRecentFolder.o \
-recent/CRecentGrepFile.o \
-recent/CRecentGrepFolder.o \
-recent/CRecentImp.o \
-recent/CRecentReplace.o \
-recent/CRecentSearch.o \
-recent/CRecentTagjumpKeyword.o \
-typeprop/CDlgKeywordSelect.o \
-typeprop/CDlgSameColor.o \
-typeprop/CDlgTypeAscertain.o \
-typeprop/CDlgTypeList.o \
-typeprop/CImpExpManager.o \
-typeprop/CPropTypes.o \
-typeprop/CPropTypesColor.o \
-typeprop/CPropTypesKeyHelp.o \
-typeprop/CPropTypesRegex.o \
-typeprop/CPropTypesScreen.o \
-typeprop/CPropTypesSupport.o \
-typeprop/CPropTypesWindow.o \
-types/CType.o \
-types/CTypeSupport.o \
-types/CType_Asm.o \
-types/CType_Awk.o \
-types/CType_Basis.o \
-types/CType_Cobol.o \
-types/CType_CorbaIdl.o \
-types/CType_Cpp.o \
-types/CType_Dos.o \
-types/CType_Erlang.o \
-types/CType_Html.o \
-types/CType_Ini.o \
-types/CType_Java.o \
-types/CType_Others.o \
-types/CType_Pascal.o \
-types/CType_Perl.o \
-types/CType_Python.o \
-types/CType_Rich.o \
-types/CType_Sql.o \
-types/CType_Tex.o \
-types/CType_Text.o \
-types/CType_Vb.o \
-uiparts/CGraphics.o \
-uiparts/CImageListMgr.o \
-uiparts/CMenuDrawer.o \
-uiparts/CSoundSet.o \
-uiparts/CVisualProgress.o \
-uiparts/CWaitCursor.o \
-util/file.o \
-util/format.o \
-util/input.o \
-util/MessageBoxF.o \
-util/module.o \
-util/ole_convert.o \
-util/os.o \
-util/relation_tool.o \
-util/shell.o \
-util/string_ex.o \
-util/string_ex2.o \
-util/tchar_convert.o \
-util/tchar_printf.o \
-util/tchar_template.o \
-util/window.o \
-view/CCaret.o \
-view/CEditView.o \
-view/CEditView_Cmdgrep.o \
-view/CEditView_CmdHokan.o \
-view/CEditView_Cmdisrch.o \
-view/CEditView_Command.o \
-view/CEditView_Command_New.o \
-view/CEditView_Diff.o \
-view/CEditView_ExecCmd.o \
-view/CEditView_Ime.o \
-view/CEditView_Mouse.o \
-view/CEditView_Paint.o \
-view/CEditView_Paint_Bracket.o \
-view/CEditView_Scroll.o \
-view/CEditView_Search.o \
-view/CRuler.o \
-view/CTextArea.o \
-view/CTextDrawer.o \
-view/CTextMetrics.o \
-view/CViewCalc.o \
-view/CViewFont.o \
-view/CViewParser.o \
-view/CViewSelect.o \
-view/DispPos.o \
-view/colors/CColorStrategy.o \
-view/colors/CColor_Comment.o \
-view/colors/CColor_Found.o \
-view/colors/CColor_Heredoc.o \
-view/colors/CColor_KeywordSet.o \
-view/colors/CColor_Numeric.o \
-view/colors/CColor_Quote.o \
-view/colors/CColor_RegexKeyword.o \
-view/colors/CColor_Url.o \
-view/figures/CFigureManager.o \
-view/figures/CFigureStrategy.o \
-view/figures/CFigure_Comma.o \
-view/figures/CFigure_CtrlCode.o \
-view/figures/CFigure_Eol.o \
-view/figures/CFigure_HanSpace.o \
-view/figures/CFigure_Tab.o \
-view/figures/CFigure_ZenSpace.o \
-window/CAutoScrollWnd.o \
-window/CEditWnd.o \
-window/CMainStatusBar.o \
-window/CMainToolBar.o \
-window/CSplitBoxWnd.o \
-window/CSplitterWnd.o \
-window/CTabWnd.o \
-window/CTipWnd.o \
-window/CWnd.o \
-_main/CAppMode.o \
-_main/CCommandLine.o \
-_main/CControlProcess.o \
-_main/CControlTray.o \
-_main/CNormalProcess.o \
-_main/CProcess.o \
-_main/CProcessFactory.o \
-_main/global.o \
-_main/WinMain.o \
-_os/CClipboard.o \
-_os/CDropTarget.o \
-sakura_rc.o \
+SRCS = $(wildcard $(SRCDIR)/*.cpp) \
+       $(wildcard $(SRCDIR)/*/*.cpp) \
+       $(wildcard $(SRCDIR)/*/*/*.cpp)
+OBJS = $(SRCS:$(SRCDIR)/%.cpp=%.o) sakura_rc.o
+_DIRS = $(filter %/, $(wildcard $(SRCDIR)/*/)) \
+        $(filter %/, $(wildcard $(SRCDIR)/*/*/))
+DIRS = $(_DIRS:$(SRCDIR)/%/=%)
 
 DEPS= $(OBJS:%.o=%.d) StdAfx.h.d
 
 GENERATED_FILES= \
-Funccode_define.h \
-Funccode_enum.h \
-githash.h \
+ Funccode_define.h \
+ Funccode_enum.h \
+ githash.h \
 
-HEADERMAKETOOLDIR= ../HeaderMake
+HEADERMAKETOOLDIR= $(SRCDIR)/../HeaderMake
 HEADERMAKE= $(HEADERMAKETOOLDIR)/HeaderMake.exe
 
 all: $(exe)
@@ -447,17 +104,20 @@ all: $(exe)
 $(exe): $(OBJS)
 	$(CXX) -o $@ $(OBJS) $(LIBS)
 
-Funccode_define.h: $(HEADERMAKE) Funccode_x.hsrc
-	$(HEADERMAKE) -in=../sakura_core/Funccode_x.hsrc -out=../sakura_core/Funccode_define.h -mode=define
+Funccode_define.h: Funccode_x.hsrc $(HEADERMAKE)
+	$(HEADERMAKE) -in=$< -out=$@ -mode=define
 
-Funccode_enum.h: $(HEADERMAKE) Funccode_x.hsrc
-	$(HEADERMAKE) -in=../sakura_core/Funccode_x.hsrc -out=../sakura_core/Funccode_enum.h -mode=enum -enum=EFunctionCode
+Funccode_enum.h: Funccode_x.hsrc $(HEADERMAKE)
+	$(HEADERMAKE) -in=$< -out=$@ -mode=enum -enum=EFunctionCode
 
 githash.h:
-	cmd /c ..\sakura\githash.bat ../sakura_core
+	cmd /c $(SRCDIR)\..\sakura\githash.bat .
 
-StdAfx.h.gch: githash.h Funccode_enum.h
-	$(CXX) $(CXXFLAGS) -c StdAfx.h -o $@
+StdAfx.h.gch: StdAfx.h githash.h Funccode_enum.h
+ifneq ($(SRCDIR),.)
+	$(MKDIR) $(subst /,\\,$(DIRS))
+endif
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 .cpp.o:
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
@@ -467,8 +127,8 @@ $(OBJS): StdAfx.h.gch
 $(HEADERMAKE): $(HEADERMAKETOOLDIR)/HeaderMake.cpp
 	$(CXX) $(CXXFLAGS:-MMD=) $(HEADERMAKETOOLDIR)/HeaderMake.cpp -o $@ -static-libgcc
 
-sakura_rc.o: githash.h Funccode_define.h sakura_rc.rc
-	$(RC) -c utf-8 --language=0411 $(DEFINES) sakura_rc.rc -o $@
+sakura_rc.o: sakura_rc.rc githash.h Funccode_define.h
+	$(RC) -c utf-8 --language=0411 $(DEFINES) -I. -I$(SRCDIR) $< -o $@
 
 clean:
 	$(RM) $(exe) $(OBJS) $(HEADERMAKE) StdAfx.h.gch $(GENERATED_FILES)

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -2,7 +2,7 @@
 
 # Relative path of "sakura_core" directory from the current directory.
 # If you build in a shadow directory, you can specify this.  E.g.
-#   $ cd sakura_code
+#   $ cd sakura_core
 #   $ mkdir _build
 #   $ cd _build
 #   $ mingw32-make -f ../Makefile SRCDIR=..

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -134,7 +134,7 @@ endif
 $(OBJS): StdAfx.h.gch
 
 $(HEADERMAKE): $(HEADERMAKETOOLDIR)/HeaderMake.cpp
-	$(CXX) $(CXXFLAGS:-MMD=) $(HEADERMAKETOOLDIR)/HeaderMake.cpp -o $@ -static-libgcc
+	$(CXX) $(CXXFLAGS:-MMD=) $< -o $@ -static-libgcc
 
 sakura_rc.o: sakura_rc.rc githash.h Funccode_define.h
 	$(RC) -c utf-8 --language=0411 $(DEFINES) -I. -I$(SRCDIR) $< -o $@


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

MinGW の Makefile を書き換えて、MakefileMake を不要にし、さらにビルド用ディレクトリをソースコードディレクトリと分けることが出来るようにします。（shadow build、out-of-source build、VPATH build などとも言う）

注: 将来的な CMake 化を否定するものではありません。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - MinGW

## <!-- 自明なら省略可 --> PR のメリット

* MakefileMake が不要になる。
* shadow build が可能になる。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

記述が複雑？

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

* `$(wildcard)` 関数を使用して .cpp ファイルを列挙することで、MakefileMake が不要となりました。
* `VPATH` 機能を使用することで、ソースコードディレクトリとは別のディレクトリでビルドできるようになりました。
  例えば、`sakura_core` ディレクトリの下に、`_build` というディレクトリを作ってビルドする場合、
  ```shell
  $ cd sakura_core
  $ mkdir _build
  $ cd _build
  $ mingw32-make -f ../Makefile
  ```
  のようにできます。（ソースコードディレクトリの位置は `Makefile` のパスから取得、あるいは `SRCDIR` で明示的に指定。）
* SHELL として unix 系の shell が使われている場合、一部の処理に unix 系コマンドを使うようにしました。また、mingw32-del.bat も排除しました。
 （使い方によっては、`make clean` でコマンドラインが長すぎるというエラーが出ることがあったため。）
* `OUTDIR` で sakura.exe と HearderMake.exe の出力先を指定できるようになりました。

## <!-- 必須 --> テスト内容

* sakura_core ディレクトリで `mingw32-make` を実行し、正常にビルドできること。
* sakura_core ディレクトリで `mingw32-make clean` を実行し、正常にクリーンできること。
* sakura_core ディレクトリの下に作業ディレクトリを作成し、その中で正常にビルドできること。
  ```shell
  $ cd sakura_core
  $ mkdir _build
  $ cd _build
  $ mingw32-make -f ../Makefile
  ```
* sakura_core ディレクトリの下の作業ディレクトリで、正常にクリーンできること。
  ```shell
  $ cd sakura_core/_build
  $ mingw32-make -f ../Makefile clean
  ```
いずれもコマンドプロンプトと、MSYS2 の mintty ウィンドウ（MINGW32 または MINGW64）からの両方で確認。

## <!-- わかる範囲で --> PR の影響範囲

MinGW ビルド

## <!-- なければ省略可 --> 関連 issue, PR

#1361