### PR TITLE
言語DLLのMakefileのMYDEFINESの指定方法をシンプルに戻す

### DIFF
--- a/sakura_lang_en_US/Makefile
+++ b/sakura_lang_en_US/Makefile
@@ -13,7 +13,7 @@
 #
 #   Debug build:
 #     $ cd sakura_lang_en_US
-#     $ mingw32-make MYDEFINES="_DEBUG" -j4
+#     $ mingw32-make MYDEFINES="-D_DEBUG" -j4
 
 # Path of "sakura_lang_en_US" directory. Compute it from the path of Makefile.
 SRCDIR = $(patsubst %/,%,$(subst \,/,$(dir $(firstword $(MAKEFILE_LIST)))))
@@ -61,10 +61,10 @@ endif
 CC= $(PREFIX)gcc
 RC= $(RCPREFIX)windres
 
-ifeq (_DEBUG,$(findstring _DEBUG,$(MYDEFINES)))
-else ifeq (NDEBUG,$(findstring NDEBUG,$(MYDEFINES)))
+ifeq (-D_DEBUG,$(findstring -D_DEBUG,$(MYDEFINES)))
+else ifeq (-DNDEBUG,$(findstring -DNDEBUG,$(MYDEFINES)))
 else
-MYDEFINES += NDEBUG
+MYDEFINES += -DNDEBUG
 endif
 
 DEFINES= \
@@ -72,7 +72,7 @@ DEFINES= \
  -D_WIN32_WINNT=_WIN32_WINNT_WIN7 \
  -D_UNICODE \
  -DUNICODE \
- $(addprefix -D,$(MYDEFINES))
+ $(MYDEFINES)
 LDFLAGS= \
  -static \
  -shared \


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
言語DLLのMakefileのMYDEFINESの指定方法をシンプルに戻して、`build-gnu.bat`を修正しなくて済むようにします。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->
- ビルド関連
  - MinGWビルド

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1386 `MinGW: Refactor Makefile for Language DLL`
リソースの`Debug/Release`指定漏れを防止するために、`_DEBUG` か `NDEBUG` が必ず指定されるようにする仕組みを言語DLLのMakefileに入れました。

　　　↓

#1381 `テストバッチの辻褄を合わせる`
> > > Makefileに対するデバッグ/リリース指定に使うMYDEFINESの定義方法を、言語DLL向けMakefileで変えてしまっていたのを本体側Makefileに適用しないといかんです。
> > 
> > この変更を見落としていましたが、本体側の方が素直で分かりやすいと思いますね。
> 
> ではそこは戻す方向で。
> 
_Originally posted by @berryzplus in https://github.com/sakura-editor/sakura/pull/1381#issuecomment-687557373_

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
言語DLLのビルドを`build-gnu.bat`に組み込む際に`build-gnu.bat`を修正しなくて済むようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
たぶん、ないです。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
`MYDEFINES` のチェック方法を変更します。
- 変更前： `_DEBUG` か `NDEBUG` のいずれかが指定されているかチェック、なければ `NDEBUG` 指定とみなす。
- 変更後： `-D_DEBUG` か `-DNDEBUG` のいずれかが指定されているかチェック、なければ `-DNDEBUG` 指定とみなす。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
MYDEFINESの指定を変えてMinGWの言語DLLをビルドして、生成されたDLLを `visual studio` で開き、埋め込まれたアイコンリソースに問題ないことを確認しました。
- `mingw32-make -f ../../../sakura_lang_en_US/Makefile MYDEFINES= SAKURA_CORE=. OUTDIR=. -j8` 
  - `MYDEFINES` 指定なし、Release版になるのでサクラアイコン(ID=210)がピンク。
- `mingw32-make -f ../../../sakura_lang_en_US/Makefile MYDEFINES=-D_DEBUG SAKURA_CORE=. OUTDIR=. -j8` 
  - `MYDEFINES=-D_DEBUG` Debug版になるのでサクラアイコン(ID=210)が青。
- `mingw32-make -f ../../../sakura_lang_en_US/Makefile MYDEFINES=-DNDEBUG SAKURA_CORE=. OUTDIR=. -j8` 
  - `MYDEFINES=-DNDEBUG` Release版になるのでサクラアイコン(ID=210)がピンク。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
MinGWの言語DLLのビルドに影響します。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1386 `MinGW: Refactor Makefile for Language DLL`

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
