### PR TITLE
MYDEFINESに-DNDEBUGが指定されてない対策の改良

### DIFF
--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -60,6 +60,13 @@ DEFINES= \
  -D_UNICODE \
  -DUNICODE \
  $(MYDEFINES)
+
+ifeq (,$(findstring -D_DEBUG,$(DEFINES)))
+ifeq (,$(findstring -DNDEBUG,$(DEFINES)))
+DEFINES += -DNDEBUG
+endif
+endif
+
 CFLAGS= \
  -finput-charset=utf-8 \
  -fexec-charset=cp932 \

--- a/sakura_lang_en_US/Makefile
+++ b/sakura_lang_en_US/Makefile
@@ -61,18 +61,19 @@ endif
 CC= $(PREFIX)gcc
 RC= $(RCPREFIX)windres
 
-ifeq (-D_DEBUG,$(findstring -D_DEBUG,$(MYDEFINES)))
-else ifeq (-DNDEBUG,$(findstring -DNDEBUG,$(MYDEFINES)))
-else
-MYDEFINES += -DNDEBUG
-endif
-
 DEFINES= \
  -DWIN32 \
  -D_WIN32_WINNT=_WIN32_WINNT_WIN7 \
  -D_UNICODE \
  -DUNICODE \
  $(MYDEFINES)
+
+ifeq (,$(findstring -D_DEBUG,$(DEFINES)))
+ifeq (,$(findstring -DNDEBUG,$(DEFINES)))
+DEFINES += -DNDEBUG
+endif
+endif
+
 LDFLAGS= \
  -static \
  -shared \


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
言語DLLのMakefileのビルドでMYDEFINESを指定しなかった場合に`-DNDEBUG`を追加するための条件式を分かりやすくします。
同時に、本体ビルドのMakefileに同様の記述を挿入して記述を揃えます。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->
- ビルド関連
  - MinGWビルド

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
> よく考えたら、`-D_DEBUG` も `-DNDEBUG` も指定されていなければ `-DNDEBUG` を指定するということは、こういう書き方の方が分かりやすいのではと思ったり。
> 
> ```makefile
> ifeq (,$(findstring -D_DEBUG,$(MYDEFINES)))
> ifeq (,$(findstring -DNDEBUG,$(MYDEFINES)))
> MYDEFINES += -DNDEBUG
> endif
> endif
> ```

んではそれで修正しときます。別PRになるので本体側も合わせて変更したいと思います。

_Originally posted by @berryzplus in https://github.com/sakura-editor/sakura/pull/1389#issuecomment-687592313_
## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
- 言語DLLのMakefileに関して、MYDEFINESに -D_DEBUG も -DNDEBUG も指定されていない場合の条件式が読みやすくなります。また、何気に未指定の場合に -DNDEBUG が定義されない問題があったのを修正します。
- 本体ビルドのMakefileに関して、言語DLLと記述が揃います。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
たぶん、ないと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
MYDEFINESの指定を変えてMinGWビルドして、rcとcppのビルドコマンドラインに `-D_DEBUG` か `-DNDEBUG` のいずれかが指定されていることを確認しました。また、生成された実行可能ファイルを `visual studio` で開き、埋め込まれたアイコンリソースに問題ないことを確認しました。
- `mingw32-make -C sakura_core MYDEFINES= -j8`
  - `MYDEFINES` 指定なし、Release版になるのでサクラアイコン(ID=210)がピンク。
- `mingw32-make -C sakura_core MYDEFINES=-D_DEBUG -j8`
  - `MYDEFINES=-D_DEBUG` Debug版になるのでサクラアイコン(ID=210)が青。
- `mingw32-make -C sakura_core MYDEFINES=-DNDEBUG -j8`
  - `MYDEFINES=-DNDEBUG` Release版になるのでサクラアイコン(ID=210)がピンク。
- `mingw32-make -C sakura_lang_en_US MYDEFINES= -j8`
  - `MYDEFINES` 指定なし、Release版になるのでサクラアイコン(ID=210)がピンク。
- `mingw32-make -C sakura_lang_en_US MYDEFINES=-D_DEBUG -j8`
  - `MYDEFINES=-D_DEBUG` Debug版になるのでサクラアイコン(ID=210)が青。
- `mingw32-make -C sakura_lang_en_US MYDEFINES=-DNDEBUG -j8`
  - `MYDEFINES=-DNDEBUG` Release版になるのでサクラアイコン(ID=210)がピンク。


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
MinGWビルド（本体ビルドと言語DLLビルド）

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1389 

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
