### PR TITLE
画面先頭行を取得するマクロ関数 GetViewTop を追加

### DIFF
--- a/help/sakura/res/HLP000268.html
+++ b/help/sakura/res/HLP000268.html
@@ -75,6 +75,7 @@
 <META NAME="MS-HKWD" CONTENT="GetViewLines">
 <META NAME="MS-HKWD" CONTENT="GetViewColumns">
 <META NAME="MS-HKWD" CONTENT="CreateMenu">
+<META NAME="MS-HKWD" CONTENT="GetViewTop">
 </HEAD>
 <BODY>
 <script type="text/javascript" src="item.js"></script>
@@ -167,6 +168,7 @@ sakura: その関数が利用可能なバージョンを示します。<br>
 ・<a href="#GetViewLines">GetViewLines</a>() :Integer<br>
 ・<a href="#GetViewColumns">GetViewColumns</a>() :Integer<br>
 ・<a href="#CreateMenu">CreateMenu</a>( int1 :Integer, str2 :String ) :Integer<br>
+・<a href="#GetViewTop">GetViewTop</a>() :Integer<br>
 <br>
 ■ function <span id="GetFilename">GetFilename</span>(): String; <small>[<a href="#list">↑</a>]</small><br>
 <div class=li200>
@@ -1095,5 +1097,11 @@ str2&nbsp;&nbsp;&nbsp;&nbsp;メニュー文字列<br>
 </div>
 sakura:2.2.0.0以降<br>
 <br>
-
+■ function <span id="GetViewTop">GetViewTop</span>() :Integer; <small>[<a href="#list">↑</a>]</small><br>
+<div class=li200>
+<b>戻り値</b><br>
+画面に表示されている一番上の行のレイアウト行番号(1開始)を取得します。<br>
+</div>
+sakura:2.4.2.0以降<br>
+<br>
 </BODY></HTML>

--- a/sakura_core/Funccode_x.hsrc
+++ b/sakura_core/Funccode_x.hsrc
@@ -578,7 +578,7 @@ F_ISTEXTSELECTINGLOCK	= 40055,	// 選択状態のロックを取得
 F_GETVIEWLINES		= 40056,	// ビューの行数取得
 F_GETVIEWCOLUMNS	= 40057,	// ビューの列数取得
 F_CREATEMENU		= 40058,	// メニュー作成
-
+F_GETVIEWTOP		= 40059,	// 画面に表示される一番上の行番号を取得
 
 //	= 2005,.01.10 genta ISearch用補助コード
 //	2007.07.07 genta 16bit以内に収めないと状況コードと衝突するのでコードを変更

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -2452,6 +2452,12 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			}
 			return false;
 		}
+	case F_GETVIEWTOP:
+		{
+			int nLine = (Int)View->GetTextArea().GetViewTopLine();
+			Wrap( &Result )->Receive( nLine + 1 );
+			return true;
+		}
 	default:
 		return false;
 	}

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -475,6 +475,7 @@ MacroFuncInfo CSMacroMgr::m_MacroFuncInfoArr[] =
 	{F_GETVIEWLINES,			L"GetViewLines",			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //ビューの行数取得
 	{F_GETVIEWCOLUMNS,			L"GetViewColumns",			{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //ビューの列数取得
 	{F_CREATEMENU,				L"CreateMenu",				{VT_I4,    VT_BSTR,  VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //メニュー作成
+	{F_GETVIEWTOP,				L"GetViewTop",				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_I4,		NULL }, //画面に表示される一番上の行番号を取得
 
 	//	終端
 	//	Jun. 27, 2002 genta


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

画面先頭行の行番号を取得するマクロ関数を追加します。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 機能追加

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

マクロ関数の書式は `GetViewTop() :Integer` です。引数は無しで戻り値が画面先頭行の行番号です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

下記のマクロを実行して、画面先頭行の行番号がステータスバーに表示される事を確認しました。

```
StatusMsg(GetViewTop());
```

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1388 
