### PR TITLE
CImageListMgr::Create において読み込んだビットマップの形式を 32bit に変換する処理を追加

### DIFF
--- a/sakura_core/uiparts/CImageListMgr.cpp
+++ b/sakura_core/uiparts/CImageListMgr.cpp
@@ -122,9 +122,11 @@ HBITMAP ConvertTo32bppBMP(HBITMAP hbmpSrc)
 		DeleteObject(hdib);
 		return hbmpSrc;
 	}
-	SelectObject(hdcSrc, hbmpSrc);
-	SelectObject(hdcDst, hdib);
+	HGDIOBJ hbmpSrcOld = SelectObject(hdcSrc, hbmpSrc);
+	HGDIOBJ hbmpDstOld = SelectObject(hdcDst, hdib);
 	BitBlt(hdcDst, 0, 0, bmp.bmWidth, bmp.bmHeight, hdcSrc, 0, 0, SRCCOPY);
+	SelectObject(hdcSrc, hbmpSrcOld);
+	SelectObject(hdcDst, hbmpDstOld);
 	DeleteDC(hdcSrc);
 	DeleteDC(hdcDst);
 	DeleteObject(hbmpSrc);

--- a/sakura_core/uiparts/CImageListMgr.cpp
+++ b/sakura_core/uiparts/CImageListMgr.cpp
@@ -85,6 +85,53 @@ CImageListMgr::~CImageListMgr()
 	}
 }
 
+static
+HBITMAP ConvertTo32bppBMP(HBITMAP hbmpSrc)
+{
+	BITMAP bmp;
+	if (0 == GetObject(hbmpSrc, sizeof(BITMAP), &bmp )) {
+		return hbmpSrc;
+	}
+	if (bmp.bmBitsPixel == 32) {
+		return hbmpSrc;
+	}
+	BITMAPINFO bmi;
+	bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
+	bmi.bmiHeader.biWidth = bmp.bmWidth;
+	bmi.bmiHeader.biHeight = bmp.bmHeight;
+	bmi.bmiHeader.biPlanes = bmp.bmPlanes;
+	bmi.bmiHeader.biBitCount = 32;
+	bmi.bmiHeader.biCompression = BI_RGB;
+	bmi.bmiHeader.biSizeImage = 0;
+	bmi.bmiHeader.biXPelsPerMeter = 0;
+	bmi.bmiHeader.biYPelsPerMeter = 0;
+	bmi.bmiHeader.biClrUsed = 0;
+	bmi.bmiHeader.biClrImportant = 0;
+	HBITMAP hdib = CreateDIBSection(NULL, &bmi, DIB_RGB_COLORS, NULL, NULL, 0);
+	if (hdib == NULL) {
+		return hbmpSrc;
+	}
+	HDC hdcSrc = CreateCompatibleDC(NULL);
+	if (!hdcSrc) {
+		DeleteObject(hdib);
+		return hbmpSrc;
+	}
+	HDC hdcDst = CreateCompatibleDC(NULL);
+	if (!hdcDst) {
+		DeleteDC(hdcSrc);
+		DeleteObject(hdib);
+		return hbmpSrc;
+	}
+	SelectObject(hdcSrc, hbmpSrc);
+	SelectObject(hdcDst, hdib);
+	BitBlt(hdcDst, 0, 0, bmp.bmWidth, bmp.bmHeight, hdcSrc, 0, 0, SRCCOPY);
+	DeleteDC(hdcSrc);
+	DeleteDC(hdcDst);
+	DeleteObject(hbmpSrc);
+	return hdib;
+}
+
+
 /*
 	@brief Image Listの作成
 	
@@ -120,6 +167,9 @@ bool CImageListMgr::Create(HINSTANCE hInstance)
 			return false;
 		}
 	}
+
+	hRscbmp = ConvertTo32bppBMP(hRscbmp);
+
 	//	To Here 2001.7.1 GAE
 
 	//	2003.07.21 genta
@@ -150,6 +200,8 @@ bool CImageListMgr::Create(HINSTANCE hInstance)
 		if( hRscbmp == NULL ){
 			return false;
 		}
+
+		hRscbmp = ConvertTo32bppBMP(hRscbmp);
 
 		// アイコンサイズが異なる場合、拡大縮小する
 		hRscbmp = ResizeToolIcons( hRscbmp, m_cTrans );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

プラグインコマンド用アイコン画像の表示色がツールバーアイコンのパレットに影響されないようにする為

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 仕様変更
- 不具合修正

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

メモリ使用量が増加します。ディスプレイ設定の拡大縮小が 200% の場合に 3MB ほど増加する事を確認しました。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

変更前はリソースまたはファイルから `LoadBitmap` で読み込んだビットマップが使われていましたが、変更後は読み込んだビットマップが 32bit でなかった場合に 32bit のビットマップを作成して置き換えるようにしました。

変換処理の負荷をなるべく小さくするために、ディスプレイ設定の拡大縮小の設定に応じたビットマップの拡大処理を呼ぶ前に変換するようにしました。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

変更後にツールバーやメニューのアイコン画像が正しく表示されている事を確認しました。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1395

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

![image](https://user-images.githubusercontent.com/1131125/92413667-18158380-f18c-11ea-8532-ecc901ae9272.png)
