### PR TITLE
アウトライン解析の選択行追従

### DIFF
--- a/sakura_core/cmd/CViewCommander_Outline.cpp
+++ b/sakura_core/cmd/CViewCommander_Outline.cpp
@@ -70,10 +70,9 @@ BOOL CViewCommander::Command_FUNCLIST(
 	if( NULL != GetEditWindow()->m_cDlgFuncList.GetHwnd() && nAction != SHOW_RELOAD ){
 		switch(nAction ){
 		case SHOW_NORMAL: // アクティブにする
-			// 開いているものと種別が同じかつ内容が最新ならActiveにするだけ．それ以外なら再解析
+			//	開いているものと種別が同じならActiveにするだけ．異なれば再解析
 			GetEditWindow()->m_cDlgFuncList.SyncColor();
-			if( GetEditWindow()->m_cDlgFuncList.CheckListType( nOutlineType )
-				&& GetEditWindow()->m_cDlgFuncList.IsUpToDate() ){
+			if( GetEditWindow()->m_cDlgFuncList.CheckListType( nOutlineType )){
 				if( bForeground ){
 					::SetFocus( GetEditWindow()->m_cDlgFuncList.GetHwnd() );
 				}

--- a/sakura_core/cmd/CViewCommander_Outline.cpp
+++ b/sakura_core/cmd/CViewCommander_Outline.cpp
@@ -70,7 +70,7 @@ BOOL CViewCommander::Command_FUNCLIST(
 	if( NULL != GetEditWindow()->m_cDlgFuncList.GetHwnd() && nAction != SHOW_RELOAD ){
 		switch(nAction ){
 		case SHOW_NORMAL: // アクティブにする
-			//	開いているものと種別が同じならActiveにするだけ．異なれば再解析
+			// 開いているものと種別が同じかつ内容が最新ならActiveにするだけ．それ以外なら再解析
 			GetEditWindow()->m_cDlgFuncList.SyncColor();
 			if( GetEditWindow()->m_cDlgFuncList.CheckListType( nOutlineType )){
 				if( bForeground ){

--- a/sakura_core/cmd/CViewCommander_Outline.cpp
+++ b/sakura_core/cmd/CViewCommander_Outline.cpp
@@ -72,7 +72,8 @@ BOOL CViewCommander::Command_FUNCLIST(
 		case SHOW_NORMAL: // アクティブにする
 			// 開いているものと種別が同じかつ内容が最新ならActiveにするだけ．それ以外なら再解析
 			GetEditWindow()->m_cDlgFuncList.SyncColor();
-			if( GetEditWindow()->m_cDlgFuncList.CheckListType( nOutlineType )){
+			if( GetEditWindow()->m_cDlgFuncList.CheckListType( nOutlineType )
+				&& GetEditWindow()->m_cDlgFuncList.IsUpToDate() ){
 				if( bForeground ){
 					::SetFocus( GetEditWindow()->m_cDlgFuncList.GetHwnd() );
 				}

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -55,7 +55,9 @@ CDocEditor::CDocEditor(CEditDoc* pcDoc)
 */
 void CDocEditor::SetModified( bool flag, bool redraw)
 {
-	m_pcDocRef->m_pcEditWnd->m_cDlgFuncList.NotifyDocModification();
+	if( redraw ){
+		m_pcDocRef->m_pcEditWnd->m_cDlgFuncList.NotifyDocModification();
+	}
 
 	if( m_bIsDocModified == flag )	//	変更がなければ何もしない
 		return;

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -55,6 +55,8 @@ CDocEditor::CDocEditor(CEditDoc* pcDoc)
 */
 void CDocEditor::SetModified( bool flag, bool redraw)
 {
+	m_pcDocRef->m_pcEditWnd->m_cDlgFuncList.NotifyDocModification();
+
 	if( m_bIsDocModified == flag )	//	変更がなければ何もしない
 		return;
 

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -346,6 +346,7 @@ HWND CDlgFuncList::DoModeless(
 	CEditView* pcEditView=(CEditView*)lParam;
 	if( !pcEditView ) return NULL;
 	m_pcFuncInfoArr = pcFuncInfoArr;	/* 関数情報配列 */
+	m_bFuncInfoArrIsUpToDate = true;
 	m_nCurLine = nCurLine;				/* 現在行 */
 	m_nCurCol = nCurCol;				/* 現在桁 */
 	m_nOutlineType = nOutlineType;		/* アウトライン解析の種別 */
@@ -2553,6 +2554,7 @@ void CDlgFuncList::Redraw( int nOutLineType, int nListType, CFuncInfoArr* pcFunc
 	m_nOutlineType = nOutLineType;
 	m_nListType = nListType;
 	m_pcFuncInfoArr = pcFuncInfoArr;	/* 関数情報配列 */
+	m_bFuncInfoArrIsUpToDate = true;
 	m_nCurLine = nCurLine;				/* 現在行 */
 	m_nCurCol = nCurCol;				/* 現在桁 */
 
@@ -3913,6 +3915,14 @@ void CDlgFuncList::NotifyCaretMovement( CLayoutInt nCurLine, CLayoutInt nCurCol 
 		return;
 	}
 
+	if( !m_bFuncInfoArrIsUpToDate ){
+		return;
+	}
+
+	if( m_nCurLine == nCurLine && m_nCurCol == nCurCol ){
+		return;
+	}
+
 	m_nCurLine = nCurLine;
 	m_nCurCol = nCurCol;
 
@@ -3961,11 +3971,15 @@ void CDlgFuncList::SetItemSelection( int nFuncInfoIndex )
 */
 void CDlgFuncList::SetItemSelectionForTreeView( HWND hwndTree, int nFuncInfoIndex )
 {
-	// 関数情報のインデックスに該当するアイテム探してを選択状態に
+	if( nFuncInfoIndex == -1 ){
+		TreeView_SelectItem( hwndTree, NULL );
+		return;
+	}
+
 	std::vector<HTREEITEM> htiStack;
 	htiStack.reserve( TreeView_GetCount( hwndTree ) );
 	htiStack.push_back( TreeView_GetRoot( hwndTree ) );
-	int nStackIndex = 0;
+	size_t nStackIndex = 0;
 	bool bFound = false;
 	while( !bFound && nStackIndex < htiStack.size() ){
 		HTREEITEM htiCurrent = htiStack[nStackIndex];
@@ -4000,8 +4014,12 @@ void CDlgFuncList::SetItemSelectionForTreeView( HWND hwndTree, int nFuncInfoInde
 */
 void CDlgFuncList::SetItemSelectionForListView( HWND hwndList, int nFuncInfoIndex )
 {
-	ListView_SetItemState( hwndList, nFuncInfoIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
-	ListView_EnsureVisible( hwndList, nFuncInfoIndex, FALSE );
+	if( nFuncInfoIndex != -1 ){
+		ListView_SetItemState( hwndList, nFuncInfoIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
+		ListView_EnsureVisible( hwndList, nFuncInfoIndex, FALSE );
+	}else{
+		ListView_SetItemState( hwndList, nFuncInfoIndex, 0, LVIS_SELECTED | LVIS_FOCUSED );
+	}
 
 	return;
 }

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -4032,11 +4032,23 @@ void CDlgFuncList::SetItemSelectionForTreeView( HWND hwndTree, int nFuncInfoInde
 */
 void CDlgFuncList::SetItemSelectionForListView( HWND hwndList, int nFuncInfoIndex )
 {
-	if( nFuncInfoIndex != -1 ){
-		ListView_SetItemState( hwndList, nFuncInfoIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
-		ListView_EnsureVisible( hwndList, nFuncInfoIndex, FALSE );
-	}else{
+	if( nFuncInfoIndex == -1 ){
 		ListView_SetItemState( hwndList, nFuncInfoIndex, 0, LVIS_SELECTED | LVIS_FOCUSED );
+		return;
+	}
+
+	int nCount = ListView_GetItemCount( hwndList );
+	for( int i = 0; i < nCount; ++i ){
+		LVITEM lvItem = {};
+		lvItem.mask = LVIF_PARAM;
+		lvItem.iItem = i;
+		lvItem.iSubItem = 0;
+		ListView_GetItem( hwndList, &lvItem );
+		if( lvItem.lParam == nFuncInfoIndex ){
+			ListView_SetItemState( hwndList, i, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED );
+			ListView_EnsureVisible( hwndList, i, FALSE );
+			break;
+		}
 	}
 
 	return;

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -229,5 +229,7 @@ private:
 	POINT				m_ptDefaultSize;
 	POINT				m_ptDefaultSizeClient;
 	RECT				m_rcItems[12];
+
+	bool		m_bFuncInfoArrIsUpToDate;
 };
 #endif /* SAKURA_CDLGFUNCLIST_B22A3877_572A_49B7_B683_50ECA451A6F8_H_ */

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -103,7 +103,6 @@ public:
 	void LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDirPath );
 	void NotifyCaretMovement( CLayoutInt nCurLine, CLayoutInt nCurCol );
 	void NotifyDocModification();
-	bool IsUpToDate() { return m_bFuncInfoArrIsUpToDate; }
 
 protected:
 	bool m_bInChangeLayout;
@@ -142,10 +141,10 @@ protected:
 	void SetTreeFile();				// ツリーコントロールの初期化：ファイルツリー
 	void SetListVB( void );			/* リストビューコントロールの初期化：VisualBasic */		// Jul 10, 2003  little YOSHI
 	void SetDocLineFuncList();
-	void SetItemSelection( int nSelectItemIndex );
-	void SetItemSelectionForTreeView( HWND hwndTree, int nSelectItemIndex );
+	void SetItemSelection( int nSelectItemIndex, bool bAllowExpand );
+	void SetItemSelectionForTreeView( HWND hwndTree, int nSelectItemIndex, bool bAllowExpand );
 	void SetItemSelectionForListView( HWND hwndList, int nSelectItemIndex );
-	bool GetFuncInfoIndex( CLayoutInt nCurLine, CLayoutInt nCurCol, int* pIndexOut );
+	bool GetFuncInfoIndex( CLayoutInt nCurLine, CLayoutInt nCurCol, int* pnIndexOut );
 
 	void SetTreeFileSub(HTREEITEM hParent, const WCHAR* pszFile);
 	// 2002/11/1 frozen

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -101,6 +101,9 @@ public:
 	void SetWindowText( const WCHAR* szTitle );		//ダイアログタイトルの設定
 	EFunctionCode GetFuncCodeRedraw(int outlineType);
 	void LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDirPath );
+	void NotifyCaretMovement( CLayoutInt nCurLine, CLayoutInt nCurCol );
+	void NotifyDocModification();
+	bool IsUpToDate() { return m_bFuncInfoArrIsUpToDate; }
 
 protected:
 	bool m_bInChangeLayout;
@@ -139,6 +142,10 @@ protected:
 	void SetTreeFile();				// ツリーコントロールの初期化：ファイルツリー
 	void SetListVB( void );			/* リストビューコントロールの初期化：VisualBasic */		// Jul 10, 2003  little YOSHI
 	void SetDocLineFuncList();
+	void SetItemSelection( int nSelectItemIndex );
+	void SetItemSelectionForTreeView( HWND hwndTree, int nSelectItemIndex );
+	void SetItemSelectionForListView( HWND hwndList, int nSelectItemIndex );
+	bool GetFuncInfoIndex( CLayoutInt nCurLine, CLayoutInt nCurCol, int* pIndexOut );
 
 	void SetTreeFileSub(HTREEITEM hParent, const WCHAR* pszFile);
 	// 2002/11/1 frozen

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -376,6 +376,10 @@ CLayoutInt CCaret::MoveCursor(
 	m_pEditView->DrawBracketPair( true );
 // 02/09/18 対括弧の強調表示 ai End		03/02/18 ai mod E
 
+	// アウトライン表示の選択位置を更新
+	CLayoutPoint poCaret = GetCaretLayoutPos();
+	m_pEditDoc->m_pcEditWnd->m_cDlgFuncList.NotifyCaretMovement( poCaret.GetY2() + 1, poCaret.GetX2() + 1 );
+
 	return nScrollRowNum;
 }
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
エディタ上でのキャレット移動にあわせてアウトライン解析の選択行の位置が自動的に更新されるようにします。

動作イメージ：
![outlineauto_demo png](https://user-images.githubusercontent.com/11252784/92990131-881d6400-f514-11ea-82db-5376f402f93f.gif)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 機能追加

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
コードリーディング時、今いる関数を確認するために F11 キーを二連打 (フォーカス→更新) していましたが、これが煩わしいと感じていたため。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
キャレット移動した時、追加の操作なく選択行の位置が更新されるため便利になります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
アウトライン解析表示時におけるキャレット移動時の負荷が増加します。  
が、通常使用時 (数万行程度までのソースコード閲覧等) においてはほぼ無視できる程度かなと考えています。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

* キャレット移動に追従してアウトライン解析・ブックマーク一覧の選択行を更新します。
* テキストの内容が変更された時には追従を解除し、最後の選択位置を維持します。
* 解除された追従は再解析が実行された時に復帰します。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

テスト用ファイル：[test.zip](https://github.com/sakura-editor/sakura/files/5212224/test.zip)

### テスト1 - 追従の確認 (アウトライン解析)

1. test.c を開く。
2. キャレットを "func2" の行まで移動する。
3. F11 キーを押下してアウトライン解析を表示する。
* 確認1: アウトライン解析の func2 の行が選択されていること。
4. ファイル先頭からファイル末尾まで一行ずつキャレットを移動する。
* 確認2: アウトライン解析の選択行が移動に合わせて更新されること。

同様のテストを test.cpp, test.vb, test.txt で実施する。

### テスト2 - 追従の確認 (ブックマーク一覧)

1. test.c を開く。
2. "func" を含む行すべてにブックマークを設定する。
3. ブックマーク一覧を開く。
4. ファイル先頭にキャレットを置いた状態で F2 キーを押下する。
* 確認1: アウトライン解析の選択行が更新されること。

### テスト3 - 追従解除・復帰の確認

1. test.c を開く。
2. func1 の "}" の行にキャレットを置いた状態で Enter キーを 3 回押下する。
* 確認内容1: アウトライン解析の選択行が func1 の位置のまま移動しないこと。
3. "func2" の行までキャレットを移動してアウトライン解析の更新ボタンを押下する。
* 確認2: アウトライン解析の func2 の行数表示が更新されること。
* 確認3: アウトライン解析の選択行が func2 へ移動すること。
4. ファイルを上書き保存する。
5. ファイル先頭からファイル末尾まで一行ずつキャレットを移動する。
* 確認4: アウトライン解析の選択行が移動に合わせて更新されること。

### テスト4 - 性能劣化の確認

1. test_100k.txt を開く。
2. キャレットをファイル末尾まで移動して F11 キーを押下する。
3. アウトライン解析の内容が表示されるまで待つ。
4. キャレットを上下に移動する。
* 確認1: キャレットの移動が極端にもたつかないこと。

### 備考

ファイルツリーについては、今回の変更の前から常に先頭行が選択状態になってしまう？ためテスト対象から除外しました。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
アウトライン解析・ブックマーク一覧・ファイルツリー

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
