### PR TITLE
GREPダイアログ内の全コンボボックスに対してフォント設定で指定されたフォントを使用する

### DIFF
--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -351,8 +351,8 @@ BOOL CDlgGrep::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	// フォント設定	2012/11/27 Uchi
 	const int nItemIds[] = { IDC_COMBO_TEXT, IDC_COMBO_FILE, IDC_COMBO_FOLDER, IDC_COMBO_EXCLUDE_FILE, IDC_COMBO_EXCLUDE_FOLDER };
-	m_cFontDeleters.resize( sizeof(nItemIds) / sizeof(nItemIds[0]) );
-	for( i = 0; i < m_cFontDeleters.size(); ++i ){
+	m_cFontDeleters.resize( _countof( nItemIds ) );
+	for( size_t i = 0; i < _countof( nItemIds ); ++i ){
 		HWND hwndItem = GetItemHwnd( nItemIds[i] );
 		HFONT hFontOld = (HFONT)::SendMessageAny( hwndItem, WM_GETFONT, 0, 0 );
 		HFONT hFont = SetMainFont( hwndItem );
@@ -402,7 +402,7 @@ LRESULT CALLBACK OnFolderProc(HWND hwnd,UINT msg,WPARAM wparam,LPARAM lparam)
 
 BOOL CDlgGrep::OnDestroy()
 {
-	for( int i = 0; i < m_cFontDeleters.size(); ++i ){
+	for( size_t i = 0; i < m_cFontDeleters.size(); ++i ){
 		m_cFontDeleters[i].ReleaseOnDestroy();
 	}
 	return CDialog::OnDestroy();

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -350,9 +350,14 @@ BOOL CDlgGrep::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_EXCLUDE_FOLDER), &m_comboDelExcludeFolder);
 
 	// フォント設定	2012/11/27 Uchi
-	HFONT hFontOld = (HFONT)::SendMessageAny( GetItemHwnd( IDC_COMBO_TEXT ), WM_GETFONT, 0, 0 );
-	HFONT hFont = SetMainFont( GetItemHwnd( IDC_COMBO_TEXT ) );
-	m_cFontText.SetFont( hFontOld, hFont, GetItemHwnd( IDC_COMBO_TEXT ) );
+	const int nItemIds[] = { IDC_COMBO_TEXT, IDC_COMBO_FILE, IDC_COMBO_FOLDER, IDC_COMBO_EXCLUDE_FILE, IDC_COMBO_EXCLUDE_FOLDER };
+	m_cFontDeleters.resize( sizeof(nItemIds) / sizeof(nItemIds[0]) );
+	for( i = 0; i < m_cFontDeleters.size(); ++i ){
+		HWND hwndItem = GetItemHwnd( nItemIds[i] );
+		HFONT hFontOld = (HFONT)::SendMessageAny( hwndItem, WM_GETFONT, 0, 0 );
+		HFONT hFont = SetMainFont( hwndItem );
+		m_cFontDeleters[i].SetFont( hFontOld, hFont, hwndItem );
+	}
 
 	/* 基底クラスメンバ */
 //	CreateSizeBox();
@@ -397,7 +402,9 @@ LRESULT CALLBACK OnFolderProc(HWND hwnd,UINT msg,WPARAM wparam,LPARAM lparam)
 
 BOOL CDlgGrep::OnDestroy()
 {
-	m_cFontText.ReleaseOnDestroy();
+	for( int i = 0; i < m_cFontDeleters.size(); ++i ){
+		m_cFontDeleters[i].ReleaseOnDestroy();
+	}
 	return CDialog::OnDestroy();
 }
 

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -76,7 +76,7 @@ protected:
 	SComboBoxItemDeleter	m_comboDelExcludeFolder;
 	CRecentExcludeFolder	m_cRecentExcludeFolder;
 
-	CFontAutoDeleter		m_cFontText;
+	std::vector<CFontAutoDeleter>	m_cFontDeleters;
 
 	/*
 	||  実装ヘルパ関数


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

Grep ダイアログ・Grep 置換ダイアログのコンボボックスの視認性を改善します。

変更前：
![image](https://user-images.githubusercontent.com/11252784/93008872-f3b70e00-f5b4-11ea-9685-f04e2ce20551.png)

**変更後：**
![image](https://user-images.githubusercontent.com/11252784/93008873-f6b1fe80-f5b4-11ea-920c-970b577d222a.png)

## <!-- 必須 --> カテゴリ

- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

Grep ダイアログの除外ファイルなどに表示されているピリオドやセミコロンなどの文字が小さく見づらく、入力間違いをしていても気づけないことが時々あるため。

## <!-- 自明なら省略可 --> PR のメリット

コンボボックス上の文字が少しだけ見やすくなります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

コンボボックスに入力される文字数が多い時に従来よりはみ出しやすくなります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

* Grep ダイアログ・GREP 置換ダイアログのコンボボックス※で使用するフォントを、条件テキストボックスと同じ等幅フォントで統一します。
※ファイル・フォルダ・除外ファイル・除外フォルダが変更の対象です。

## <!-- 必須 --> テスト内容

### テスト1

1. GREP ダイアログを表示する。
* 確認1: ファイル・フォルダ・除外ファイル・除外フォルダのコンボボックスのフォントがそれぞれ等幅になっていること

同様のテストを GREP 置換ダイアログでも実施する。

## <!-- わかる範囲で --> PR の影響範囲

Grep ダイアログ・Grep 置換ダイアログ

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
