### PR TITLE
_countof の代わりに std::size を使う

### DIFF
--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -106,7 +106,7 @@ int CBackupAgent::MakeBackUp(
 	const CommonSetting_Backup& bup_setting = GetDllShareData().m_Common.m_sBackup;
 
 	WCHAR	szPath[_MAX_PATH]; // バックアップ先パス名
-	if( !FormatBackUpPath( szPath, _countof(szPath), target_file ) ){
+	if( !FormatBackUpPath( szPath, std::size(szPath), target_file ) ){
 		int nMsgResult = ::TopConfirmMessage(
 			CEditWnd::getInstance()->GetHwnd(),
 			LS(STR_BACKUP_ERR_PATH_CRETE)
@@ -319,7 +319,7 @@ bool CBackupAgent::FormatBackUpPath(
 	if( bup_setting.m_bBackUpFolder
 	  && (!bup_setting.m_bBackUpFolderRM || !IsLocalDrive( target_file ))) {	/* 指定フォルダにバックアップを作成する */	// m_bBackUpFolderRM 追加	2010/5/27 Uchi
 		WCHAR selDir[_MAX_PATH];
-		CFileNameManager::ExpandMetaToFolder( bup_setting.m_szBackUpFolder, selDir, _countof(selDir) );
+		CFileNameManager::ExpandMetaToFolder( bup_setting.m_szBackUpFolder, selDir, std::size(selDir) );
 		if (GetFullPathName(selDir, _MAX_PATH, szNewPath, &psNext) == 0) {
 			// うまく取れなかった
 			wcscpy( szNewPath, selDir );
@@ -381,7 +381,7 @@ bool CBackupAgent::FormatBackUpPath(
 				wcscat( szForm, L"%S" );
 			}
 			/* YYYYMMDD時分秒 形式に変換 */
-			wcsftime( szTime, _countof( szTime ) - 1, szForm, &result );
+			wcsftime( szTime, std::size( szTime ) - 1, szForm, &result );
 			if( -1 == auto_snprintf_s( pBase, nBaseCount, L"%s_%ls%s", szFname, szTime, szExt ) ){
 				return false;
 			}
@@ -453,7 +453,7 @@ bool CBackupAgent::FormatBackUpPath(
 				// 2005.10.20 ryoji FindFirstFileを使うように変更
 				CFileTime ctimeLastWrite;
 				GetLastWriteTimestamp( target_file, &ctimeLastWrite );
-				if( !GetDateTimeFormat( szFormat, _countof(szFormat), bup_setting.m_szBackUpPathAdvanced , ctimeLastWrite.GetSYSTEMTIME() ) ){
+				if( !GetDateTimeFormat( szFormat, std::size(szFormat), bup_setting.m_szBackUpPathAdvanced , ctimeLastWrite.GetSYSTEMTIME() ) ){
 					return false;
 				}
 			}
@@ -466,7 +466,7 @@ bool CBackupAgent::FormatBackUpPath(
 				// 2016.07.28 UTC→ローカル時刻に変更
 				::GetLocalTime(&SystemTime);			// 現在時刻を取得
 
-				if( !GetDateTimeFormat( szFormat, _countof(szFormat), bup_setting.m_szBackUpPathAdvanced , SystemTime ) ){
+				if( !GetDateTimeFormat( szFormat, std::size(szFormat), bup_setting.m_szBackUpPathAdvanced , SystemTime ) ){
 					return false;
 				}
 			}
@@ -536,7 +536,7 @@ bool CBackupAgent::FormatBackUpPath(
 			WCHAR *cp;
 			//	2006.03.25 Aroka szExt[0] == '\0'のときのオーバラン問題を修正
 			WCHAR *ep = (szExt[0]!=0) ? &szExt[1] : &szExt[0];
-			assert( newPathCount <= _countof(temp) );
+			assert( newPathCount <= std::size(temp) );
 
 			// * を拡張子にする
 			while( wcschr( szNewPath, L'*' ) ){

--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -45,7 +45,7 @@ struct StringBufferW_{
 typedef const StringBufferW_ StringBufferW;
 
 //文字列バッファ型インスタンスの生成マクロ
-#define MakeStringBufferW(S) StringBufferW(S,_countof(S))
+#define MakeStringBufferW(S) StringBufferW(S,std::size(S))
 
 //2007.09.24 kobake データ変換部を子クラスに分離
 //!各種データ変換付きCProfile

--- a/sakura_core/CDicMgr.cpp
+++ b/sakura_core/CDicMgr.cpp
@@ -73,9 +73,9 @@ BOOL CDicMgr::Search(
 	for(int line=1 ; in; line++ ){	// 2006.04.10 fon
 		//1行読み込み
 		{
-			wstring tmp = in.ReadLineW(); //NULL != fgetws( szLine, _countof(szLine), pFile );
-			wcsncpy_s(szLine,_countof(szLine),tmp.c_str(), _TRUNCATE);
-			// auto_strlcpy(szLine,tmp.c_str(), _countof(szLine));
+			wstring tmp = in.ReadLineW(); //NULL != fgetws( szLine, std::size(szLine), pFile );
+			wcsncpy_s(szLine,std::size(szLine),tmp.c_str(), _TRUNCATE);
+			// auto_strlcpy(szLine,tmp.c_str(), std::size(szLine));
 		}
 
 		pszWork = wcsstr( szLine, pszDelimit );

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -345,7 +345,7 @@ DWORD CGrepAgent::DoGrep(
 	//	2008.12.13 genta パターンが長すぎる場合は登録しない
 	//	(正規表現が途中で途切れると困るので)
 	//	2011.12.10 Moca 表示の際に...に切り捨てられるので登録するように
-	wcsncpy_s( CAppMode::getInstance()->m_szGrepKey, _countof(CAppMode::getInstance()->m_szGrepKey), pcmGrepKey->GetStringPtr(), _TRUNCATE );
+	wcsncpy_s( CAppMode::getInstance()->m_szGrepKey, std::size(CAppMode::getInstance()->m_szGrepKey), pcmGrepKey->GetStringPtr(), _TRUNCATE );
 	this->m_bGrepMode = true;
 
 	//	2007.07.22 genta

--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -471,7 +471,7 @@ BOOL CHokanMgr::OnSize( WPARAM wParam, LPARAM lParam )
 	int	Controls[] = {
 		IDC_LIST_WORDS
 	};
-	int		nControls = _countof( Controls );
+	int		nControls = std::size( Controls );
 	int		nWidth;
 	int		nHeight;
 	int		i;

--- a/sakura_core/CKeyWordSetMgr.cpp
+++ b/sakura_core/CKeyWordSetMgr.cpp
@@ -128,8 +128,8 @@ bool CKeyWordSetMgr::AddKeyWordSet(
 		--m_nKeyWordSetNum;	//	キーワードセットの追加をキャンセルする
 		return false;
 	}
-	wcsncpy( m_szSetNameArr[nIdx], pszSetName, _countof(m_szSetNameArr[nIdx]) - 1 );
-	m_szSetNameArr[nIdx][_countof(m_szSetNameArr[nIdx]) - 1] = L'\0';
+	wcsncpy( m_szSetNameArr[nIdx], pszSetName, std::size(m_szSetNameArr[nIdx]) - 1 );
+	m_szSetNameArr[nIdx][std::size(m_szSetNameArr[nIdx]) - 1] = L'\0';
 	m_bKEYWORDCASEArr[nIdx] = bKEYWORDCASE;
 	m_nKeyWordNumArr[nIdx] = 0;
 	m_IsSorted[nIdx] = 0;	//MIK 2000.12.01 binary search

--- a/sakura_core/CProfile.cpp
+++ b/sakura_core/CProfile.cpp
@@ -239,9 +239,9 @@ bool CProfile::WriteProfile(
 	szMirrorFile[0] = L'\0';
 	WCHAR szPath[_MAX_PATH];
 	LPWSTR lpszName;
-	DWORD nLen = ::GetFullPathName(m_strProfileName.c_str(), _countof(szPath), szPath, &lpszName);
-	if( 0 < nLen && nLen < _countof(szPath)
-		&& (lpszName - szPath + 11) < _countof(szMirrorFile) )	// path\preuuuu.TMP
+	DWORD nLen = ::GetFullPathName(m_strProfileName.c_str(), std::size(szPath), szPath, &lpszName);
+	if( 0 < nLen && nLen < std::size(szPath)
+		&& (lpszName - szPath + 11) < std::size(szMirrorFile) )	// path\preuuuu.TMP
 	{
 		*lpszName = L'\0';
 		::GetTempFileName(szPath, L"sak", 0, szMirrorFile);

--- a/sakura_core/CSelectLang.cpp
+++ b/sakura_core/CSelectLang.cpp
@@ -99,14 +99,14 @@ HINSTANCE CSelectLang::InitializeLanguageEnvironment( void )
 		psLangInfo->hInstance = GetModuleHandle(NULL);
 		
 		// 言語情報ダイアログで "System default" に表示する文字列を作成する
-		auto nCount = ::LoadString( psLangInfo->hInstance, STR_SELLANG_NAME, psLangInfo->szLangName, _countof(psLangInfo->szLangName) );
+		auto nCount = ::LoadString( psLangInfo->hInstance, STR_SELLANG_NAME, psLangInfo->szLangName, std::size(psLangInfo->szLangName) );
 		assert(0 < nCount);
 
 		// 言語IDを取得
 		WCHAR szBuf[7];		// "0x" + 4桁 + 番兵
-		nCount = ::LoadString( psLangInfo->hInstance, STR_SELLANG_LANGID, szBuf, _countof(szBuf));
-		assert(nCount == _countof(szBuf) - 1);
-		szBuf[_countof(szBuf) - 1] = L'\0';
+		nCount = ::LoadString( psLangInfo->hInstance, STR_SELLANG_LANGID, szBuf, std::size(szBuf));
+		assert(nCount == std::size(szBuf) - 1);
+		szBuf[std::size(szBuf) - 1] = L'\0';
 
 		psLangInfo->wLangId = (WORD)wcstoul(szBuf, NULL, 16);		// 言語IDを数値化
 		assert(0 < psLangInfo->wLangId);
@@ -194,13 +194,13 @@ HINSTANCE CSelectLang::LoadLangRsrcLibrary( SSelLangInfo& lang )
 
 	if( hInstance ){
 		// 言語名を取得
-		nCount = ::LoadString( hInstance, STR_SELLANG_NAME, lang.szLangName, _countof(lang.szLangName) );
+		nCount = ::LoadString( hInstance, STR_SELLANG_NAME, lang.szLangName, std::size(lang.szLangName) );
 
 		if( nCount > 0 ){
 			// 言語IDを取得
 			WCHAR szBuf[7];		// "0x" + 4桁 + 番兵
-			nCount = ::LoadString( hInstance, STR_SELLANG_LANGID, szBuf, _countof(szBuf) );
-			szBuf[_countof(szBuf) - 1] = L'\0';
+			nCount = ::LoadString( hInstance, STR_SELLANG_LANGID, szBuf, std::size(szBuf) );
+			szBuf[std::size(szBuf) - 1] = L'\0';
 
 			if( nCount > 0 ){
 				lang.wLangId = (WORD)wcstoul( szBuf, NULL, 16 );		// 言語IDを数値化
@@ -240,7 +240,7 @@ int CLoadString::m_nDataTempArrayIndex = 0;							// 最後に使用したバッ
 LPCWSTR CLoadString::LoadStringSt( UINT uid )
 {
 	// 使用するバッファの現在位置を進める
-	m_nDataTempArrayIndex = (m_nDataTempArrayIndex + 1) % _countof(m_acLoadStrBufferTemp);
+	m_nDataTempArrayIndex = (m_nDataTempArrayIndex + 1) % std::size(m_acLoadStrBufferTemp);
 
 	m_acLoadStrBufferTemp[m_nDataTempArrayIndex].LoadString( uid );
 
@@ -296,7 +296,7 @@ int CLoadString::CLoadStrBuffer::LoadString( UINT uid )
 	if( !m_pszString ){
 		// バッファポインタが設定されていない場合初期化する（普通はあり得ない）
 		m_pszString = m_szString;					// 変数内に準備したバッファを接続
-		m_nBufferSize = _countof(m_szString);		// 配列個数
+		m_nBufferSize = std::size(m_szString);		// 配列個数
 		m_szString[m_nBufferSize - 1] = 0;
 		m_nLength = wcslen(m_szString);			// 文字数
 	}

--- a/sakura_core/CSelectLang.h
+++ b/sakura_core/CSelectLang.h
@@ -84,7 +84,7 @@ protected:
 		CLoadStrBuffer()
 		{
 			m_pszString   = m_szString;				// 変数内に準備したバッファを接続
-			m_nBufferSize = _countof(m_szString);	// 配列個数
+			m_nBufferSize = std::size(m_szString);	// 配列個数
 			m_nLength     = 0;
 			m_szString[0] = L'\0';
 		}

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -250,7 +250,7 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 	int		nPos;
 	int		i = 0;
 	if( pszCmdLineSrc[0] != L'-' ){
-		for( i = 0; i < _countof( szPath ); ++i ){
+		for( i = 0; i < std::size( szPath ); ++i ){
 			if( pszCmdLineSrc[i] == L' ' || pszCmdLineSrc[i] == L'\0' ){
 				/* ファイルの存在をチェック */
 				szPath[i] = L'\0';	// 終端文字
@@ -302,14 +302,14 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 				if( len > 0 ){
 					cmWork.SetString( &pszToken[1], len - ( pszToken[len] == L'"' ? 1 : 0 ));
 					cmWork.Replace( L"\"\"", L"\"" );
-					wcscpy_s( szPath, _countof(szPath), cmWork.GetStringPtr() );	/* ファイル名 */
+					wcscpy_s( szPath, std::size(szPath), cmWork.GetStringPtr() );	/* ファイル名 */
 				}
 				else {
 					szPath[0] = L'\0';
 				}
 			}
 			else{
-				wcscpy_s( szPath, _countof(szPath), pszToken );		/* ファイル名 */
+				wcscpy_s( szPath, std::size(szPath), pszToken );		/* ファイル名 */
 			}
 
 			// Nov. 11, 2005 susu
@@ -323,7 +323,7 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 				if ( !TCODE::IsValidFilenameChar(szPath[i]) ){
 					WCHAR msg_str[_MAX_PATH + 1];
 					swprintf(
-						msg_str, _countof(msg_str),
+						msg_str, std::size(msg_str),
 						LS(STR_CMDLINE_PARSECMD1),
 						szPath
 					);

--- a/sakura_core/_main/CControlProcess.cpp
+++ b/sakura_core/_main/CControlProcess.cpp
@@ -82,7 +82,7 @@ bool CControlProcess::InitializeProcess()
 
 	// コントロールプロセスのカレントディレクトリをシステムディレクトリに変更
 	WCHAR szDir[_MAX_PATH];
-	::GetSystemDirectory( szDir, _countof(szDir) );
+	::GetSystemDirectory( szDir, std::size(szDir) );
 	::SetCurrentDirectory( szDir );
 
 	/* 共有データのロード */

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -308,7 +308,7 @@ bool CControlTray::CreateTrayIcon( HWND hWnd )
 			profname = L" ";
 			profname += CCommandLine::getInstance()->GetProfileName();
 		}
-		auto_snprintf_s( pszTips, _countof(pszTips), L"%s %d.%d.%d.%d%ls",		//Jul. 06, 2001 jepro UR はもう付けなくなったのを忘れていた
+		auto_snprintf_s( pszTips, std::size(pszTips), L"%s %d.%d.%d.%d%ls",		//Jul. 06, 2001 jepro UR はもう付けなくなったのを忘れていた
 			GSTR_APPNAME,
 			HIWORD( dwVersionMS ),
 			LOWORD( dwVersionMS ),
@@ -353,7 +353,7 @@ BOOL CControlTray::TrayMessage( HWND hDlg, DWORD dwMessage, UINT uID, HICON hIco
 	tnd.uCallbackMessage	= MYWM_NOTIFYICON;
 	tnd.hIcon				= hIcon;
 	if( pszTip ){
-		lstrcpyn( tnd.szTip, pszTip, _countof( tnd.szTip ) );
+		lstrcpyn( tnd.szTip, pszTip, std::size( tnd.szTip ) );
 	}else{
 		tnd.szTip[0] = L'\0';
 	}
@@ -430,8 +430,8 @@ LRESULT CControlTray::DispatchEvent(
 
 			hwndWork = ::GetForegroundWindow();
 			szClassName[0] = L'\0';
-			::GetClassName( hwndWork, szClassName, _countof( szClassName ) - 1 );
-			::GetWindowText( hwndWork, szText, _countof( szText ) - 1 );
+			::GetClassName( hwndWork, szClassName, std::size( szClassName ) - 1 );
+			::GetWindowText( hwndWork, szText, std::size( szText ) - 1 );
 			if( 0 == wcscmp( szText, LS(STR_PROPCOMMON) ) ){
 				return -1;
 			}
@@ -1117,7 +1117,7 @@ bool CControlTray::OpenNewEditor(
 
 	//アプリケーションパス
 	WCHAR szEXE[MAX_PATH + 1];
-	::GetModuleFileName( NULL, szEXE, _countof( szEXE ) );
+	::GetModuleFileName( NULL, szEXE, std::size( szEXE ) );
 	cCmdLineBuf.AppendF( L"\"%s\"", szEXE );
 
 	// ファイル名
@@ -1217,7 +1217,7 @@ bool CControlTray::OpenNewEditor(
 #ifdef _DEBUG
 //	dwCreationFlag |= DEBUG_PROCESS; //2007.09.22 kobake デバッグ用フラグ
 #endif
-	WCHAR szCmdLine[1024]; wcscpy_s(szCmdLine, _countof(szCmdLine), cCmdLineBuf.c_str());
+	WCHAR szCmdLine[1024]; wcscpy_s(szCmdLine, std::size(szCmdLine), cCmdLineBuf.c_str());
 	BOOL bCreateResult = CreateProcess(
 		szEXE,					// 実行可能モジュールの名前
 		szCmdLine,				// コマンドラインの文字列
@@ -1563,7 +1563,7 @@ int	CControlTray::CreatePopUpMenu_L( void )
 				pfi = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
 				// メニューラベル。1からアクセスキーを振る
-				CFileNameManager::getInstance()->GetMenuFullLabel_WinList( szMenu, _countof(szMenu), pfi, m_pShareData->m_sNodes.m_pEditArr[i].m_nId, i, dcFont.GetHDC() );
+				CFileNameManager::getInstance()->GetMenuFullLabel_WinList( szMenu, std::size(szMenu), pfi, m_pShareData->m_sNodes.m_pEditArr[i].m_nId, i, dcFont.GetHDC() );
 				m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, IDM_SELWINDOW + i, szMenu, L"", FALSE );
 				++j;
 			}

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -243,7 +243,7 @@ bool CNormalProcess::InitializeProcess()
 				// 2013.05.21 指定なしの場合はカレントフォルダにする
 				if( cmemGrepFolder.GetStringLength() == 0 ){
 					WCHAR szCurDir[_MAX_PATH];
-					::GetCurrentDirectory( _countof(szCurDir), szCurDir );
+					::GetCurrentDirectory( std::size(szCurDir), szCurDir );
 					cmemGrepFolder.SetString( szCurDir );
 				}
 			}

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -89,7 +89,7 @@ bool CProcessFactory::ProfileSelect( HINSTANCE hInstance, LPCWSTR lpCmdLine )
 	//	May 30, 2000 genta
 	//	実行ファイル名をもとに漢字コードを固定する．
 	WCHAR szExeFileName[MAX_PATH];
-	const int cchExeFileName = ::GetModuleFileName(NULL, szExeFileName, _countof(szExeFileName));
+	const int cchExeFileName = ::GetModuleFileName(NULL, szExeFileName, std::size(szExeFileName));
 	CCommandLine::getInstance()->ParseKanjiCodeFromFileName(szExeFileName, cchExeFileName);
 
 	CCommandLine::getInstance()->ParseCommandLine(lpCmdLine);
@@ -187,7 +187,7 @@ bool CProcessFactory::StartControlProcess()
 	WCHAR szCmdLineBuf[1024];	//	コマンドライン
 	WCHAR szEXE[MAX_PATH + 1];	//	アプリケーションパス名
 
-	::GetModuleFileName( NULL, szEXE, _countof( szEXE ));
+	::GetModuleFileName( NULL, szEXE, std::size( szEXE ));
 	if( CCommandLine::getInstance()->IsSetProfile() ){
 		::auto_sprintf( szCmdLineBuf, L"\"%s\" -NOWIN -PROF=\"%ls\"",
 			szEXE, CCommandLine::getInstance()->GetProfileName() );

--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -280,7 +280,7 @@ bool CClipboard::GetText(CNativeW* cmemBuf, bool* pbColumnSelect, bool* pbLineSe
 		while( ( uFormat = ::EnumClipboardFormats( uFormat ) ) != 0 ){
 			// Jul. 2, 2005 genta : check return value of GetClipboardFormatName
 			WCHAR szFormatName[128];
-			if( ::GetClipboardFormatName( uFormat, szFormatName, _countof(szFormatName) - 1 ) ){
+			if( ::GetClipboardFormatName( uFormat, szFormatName, std::size(szFormatName) - 1 ) ){
 				if( NULL != pbColumnSelect && 0 == lstrcmpi( L"MSDEVColumnSelect", szFormatName ) ){
 					*pbColumnSelect = true;
 					break;
@@ -356,7 +356,7 @@ bool CClipboard::GetText(CNativeW* cmemBuf, bool* pbColumnSelect, bool* pbLineSe
 			const int nMaxCnt = DragQueryFile(hDrop, 0xFFFFFFFF, NULL, 0);
 
 			for(int nLoop = 0; nLoop < nMaxCnt; nLoop++){
-				DragQueryFile(hDrop, nLoop, sTmpPath, _countof(sTmpPath) - 1);
+				DragQueryFile(hDrop, nLoop, sTmpPath, std::size(sTmpPath) - 1);
 				// 2012.10.05 Moca ANSI版に合わせて最終行にも改行コードをつける
 				cmemBuf->AppendString(sTmpPath);
 				if(nMaxCnt > 1){
@@ -402,7 +402,7 @@ static CLIPFORMAT GetClipFormat(const wchar_t* pFormatName)
 	if( pFormatName[0] == L'\0' ){
 		return uFormat;
 	}
-	for(int i = 0; i < _countof(sClipFormatNames); i++){
+	for(int i = 0; i < std::size(sClipFormatNames); i++){
 		if( 0 == _wcsicmp(pFormatName, sClipFormatNames[i].m_pszName) ){
 			uFormat = sClipFormatNames[i].m_nClipFormat;
 		}

--- a/sakura_core/apiwrap/StdApi.cpp
+++ b/sakura_core/apiwrap/StdApi.cpp
@@ -41,7 +41,7 @@ namespace ApiWrap{
 
 			//先頭からpまでの部分文字列 -> szBuf
 			wchar_t szBuf[_MAX_PATH];
-			wcsncpy_s(szBuf,_countof(szBuf),szDirPath,p-szDirPath);
+			wcsncpy_s(szBuf,std::size(szBuf),szDirPath,p-szDirPath);
 
 			//存在するか
 			int nAcc = _waccess(szBuf,0);

--- a/sakura_core/basis/CMyString.h
+++ b/sakura_core/basis/CMyString.h
@@ -89,7 +89,7 @@ public:
 	{
 		va_list v;
 		va_start(v,szFormat);
-		m_pHead+=auto_vsprintf_s(m_pHead,_countof(m_szCmdLine)-(m_pHead-m_szCmdLine),szFormat,v);
+		m_pHead+=auto_vsprintf_s(m_pHead,std::size(m_szCmdLine)-(m_pHead-m_szCmdLine),szFormat,v);
 		va_end(v);
 	}
 	const WCHAR* c_str() const
@@ -102,7 +102,7 @@ public:
 	}
 	size_t max_size() const
 	{
-		return _countof(m_szCmdLine) - 1;
+		return std::size(m_szCmdLine) - 1;
 	}
 private:
 	WCHAR	m_szCmdLine[1024];

--- a/sakura_core/charset/CESI.h
+++ b/sakura_core/charset/CESI.h
@@ -241,19 +241,19 @@ ECodeType CESI::DetectUnicodeBom(const char* buff, size_t size) noexcept
 
 	// バイト列の先頭が \ufeff の utf8 表現と一致するか判定
 	constexpr const BYTE utf8BOM[]{ 0xef, 0xbb, 0xbf };
-	if (size >= _countof(utf8BOM) && 0 == ::memcmp(buff, utf8BOM, _countof(utf8BOM))) {
+	if (size >= std::size(utf8BOM) && 0 == ::memcmp(buff, utf8BOM, std::size(utf8BOM))) {
 		return CODE_UTF8;
 	}
 
 	// バイト列の先頭が \ufeff の utf16BE 表現と一致するか判定
 	constexpr const BYTE utf16BeBOM[]{ 0xfe, 0xff };
-	if (size >= _countof(utf16BeBOM) && 0 == ::memcmp(buff, utf16BeBOM, _countof(utf16BeBOM))) {
+	if (size >= std::size(utf16BeBOM) && 0 == ::memcmp(buff, utf16BeBOM, std::size(utf16BeBOM))) {
 		return CODE_UNICODEBE;
 	}
 
 	// バイト列の先頭が \ufeff の utf16LE 表現と一致するか判定
 	constexpr const BYTE utf16LeBOM[]{ 0xff, 0xfe };
-	if (size >= _countof(utf16LeBOM) && 0 == ::memcmp(buff, utf16LeBOM, _countof(utf16LeBOM))) {
+	if (size >= std::size(utf16LeBOM) && 0 == ::memcmp(buff, utf16LeBOM, std::size(utf16LeBOM))) {
 		return CODE_UNICODE;
 	}
 

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -98,7 +98,7 @@ namespace WCODE
 		//if(wc==TAB)return false;
 
 		//return iswcntrl(wc)!=0;
-		return (wc<_countof(gm_keyword_char) && gm_keyword_char[wc]==CK_CTRL);
+		return (wc<std::size(gm_keyword_char) && gm_keyword_char[wc]==CK_CTRL);
 	}
 
 #if 0

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -96,7 +96,7 @@ extern const unsigned char gm_keyword_char[128];
 //Nov. 27, 2010 syat   速度改善のためテーブルに変更
 inline bool IS_KEYWORD_CHAR(wchar_t wc)
 {
-	if(0 <= wc && wc < _countof(gm_keyword_char) && (gm_keyword_char[wc] == CK_CSYM||gm_keyword_char[wc] == CK_UDEF) )
+	if(0 <= wc && wc < std::size(gm_keyword_char) && (gm_keyword_char[wc] == CK_CSYM||gm_keyword_char[wc] == CK_UDEF) )
 		return true;
 	else
 		return false;

--- a/sakura_core/charset/charset.cpp
+++ b/sakura_core/charset/charset.cpp
@@ -77,7 +77,7 @@ void InitCodeSet()
 {
 	if (msCodeSet.empty()) {
 		int 	i;
-		for (i = 0; i < _countof(ASCodeSet); i++) {
+		for (i = 0; i < std::size(ASCodeSet); i++) {
 			vDispIdx.push_back( ASCodeSet[i].m_eCodeSet );
 			if (i > 0) {
 				msCodeSet[ASCodeSet[i].m_eCodeSet] = ASCodeSet[i];

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -324,7 +324,7 @@ BOOL CViewCommander::Command_OPEN_HHPP( BOOL bCheckOnly, BOOL bBeepWhenMiss )
 	static const WCHAR* header_ext[] = { L"h", L"hpp", L"hxx", L"hh", L"hp", L"h++" };
 	return m_pCommanderView->OPEN_ExtFromtoExt(
 		bCheckOnly, bBeepWhenMiss, source_ext, header_ext,
-		_countof(source_ext), _countof(header_ext),
+		std::size(source_ext), std::size(header_ext),
 		LS(STR_ERR_CEDITVIEW_CMD08) );
 }
 
@@ -337,7 +337,7 @@ BOOL CViewCommander::Command_OPEN_CCPP( BOOL bCheckOnly, BOOL bBeepWhenMiss )
 	static const WCHAR* header_ext[] = { L"h", L"hpp", L"hxx", L"hh", L"hp", L"h++" };
 	return m_pCommanderView->OPEN_ExtFromtoExt(
 		bCheckOnly, bBeepWhenMiss, header_ext, source_ext,
-		_countof(header_ext), _countof(source_ext),
+		std::size(header_ext), std::size(source_ext),
 		LS(STR_ERR_CEDITVIEW_CMD09));
 }
 
@@ -584,7 +584,7 @@ void CViewCommander::Command_OPEN_COMMAND_PROMPT(BOOL isAdmin)
 
 	/* 環境変数 COMSPEC から cmd.exe のパスを取得する */
 	WCHAR szCmdExePathBuf[MAX_PATH];
-	if (::GetEnvironmentVariableW(L"COMSPEC", szCmdExePathBuf, _countof(szCmdExePathBuf)) == 0) {
+	if (::GetEnvironmentVariableW(L"COMSPEC", szCmdExePathBuf, std::size(szCmdExePathBuf)) == 0) {
 		ErrorBeep();
 		return;
 	}

--- a/sakura_core/cmd/CViewCommander_Insert.cpp
+++ b/sakura_core/cmd/CViewCommander_Insert.cpp
@@ -27,7 +27,7 @@ void CViewCommander::Command_INS_DATE( void )
 	WCHAR szText[1024];
 	SYSTEMTIME systime;
 	::GetLocalTime( &systime );
-	CFormatManager().MyGetDateFormat( systime, szText, _countof( szText ) - 1 );
+	CFormatManager().MyGetDateFormat( systime, szText, std::size( szText ) - 1 );
 
 	// テキストを貼り付け ver1
 	Command_INSTEXT( true, szText, CLogicInt(-1), TRUE );
@@ -40,7 +40,7 @@ void CViewCommander::Command_INS_TIME( void )
 	WCHAR szText[1024];
 	SYSTEMTIME systime;
 	::GetLocalTime( &systime );
-	CFormatManager().MyGetTimeFormat( systime, szText, _countof( szText ) - 1 );
+	CFormatManager().MyGetTimeFormat( systime, szText, std::size( szText ) - 1 );
 
 	// テキストを貼り付け ver1
 	Command_INSTEXT( true, szText, CLogicInt(-1), TRUE );

--- a/sakura_core/cmd/CViewCommander_Settings.cpp
+++ b/sakura_core/cmd/CViewCommander_Settings.cpp
@@ -275,7 +275,7 @@ void CViewCommander::Command_SETFONTSIZE( int fontSize, int shift, int mode )
 
 	if( 0 != fontSize ){
 		// フォントサイズを直接選択する場合
-		nPointSize = t_max(sizeTable[0], t_min(sizeTable[_countof(sizeTable)-1], fontSize));
+		nPointSize = t_max(sizeTable[0], t_min(sizeTable[std::size(sizeTable)-1], fontSize));
 	} else if( 0 != shift ) {
 		// 現在のフォントに対して、縮小or拡大したフォント選択する場合
 		nPointSize = (mode == 0 ? GetDllShareData().m_Common.m_sView.m_nPointSize
@@ -283,9 +283,9 @@ void CViewCommander::Command_SETFONTSIZE( int fontSize, int shift, int mode )
 
 		// フォントの拡大or縮小するためのサイズ検索
 		int i;
-		for( i = 0; i < _countof(sizeTable); i++) {
+		for( i = 0; i < std::size(sizeTable); i++) {
 			if( nPointSize <= sizeTable[i] ){
-				int index = t_max(0, t_min((int)_countof(sizeTable) - 1, (int)(i + shift)));
+				int index = t_max(0, t_min((int)std::size(sizeTable) - 1, (int)(i + shift)));
 				int nNewPointSize = sizeTable[index];
 				// フォントサイズが変わらないので終了
 				if (nPointSize == nNewPointSize) {
@@ -503,7 +503,7 @@ void CViewCommander::Command_SET_QUOTESTRING( const wchar_t* quotestr )
 		return;
 
 	wcsncpy( GetDllShareData().m_Common.m_sFormat.m_szInyouKigou, quotestr,
-		_countof( GetDllShareData().m_Common.m_sFormat.m_szInyouKigou ));
+		std::size( GetDllShareData().m_Common.m_sFormat.m_szInyouKigou ));
 	
-	GetDllShareData().m_Common.m_sFormat.m_szInyouKigou[ _countof( GetDllShareData().m_Common.m_sFormat.m_szInyouKigou ) - 1 ] = L'\0';
+	GetDllShareData().m_Common.m_sFormat.m_szInyouKigou[ std::size( GetDllShareData().m_Common.m_sFormat.m_szInyouKigou ) - 1 ] = L'\0';
 }

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -85,7 +85,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 	wchar_t		szFile[_MAX_PATH] = {L'\0'};
 	size_t		nBgn;
 	size_t		nPathLen;
-	wmemset( szJumpToFile, 0, _countof(szJumpToFile) );
+	wmemset( szJumpToFile, 0, std::size(szJumpToFile) );
 
 	/*
 	  カーソル位置変換
@@ -171,19 +171,19 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 				wmemcpy( szJumpToFile, &pLine[2 + nBgn], nPathLen );
 				GetLineColumn( &pLine[2 + nPathLen], &nJumpToLine, &nJumpToColumn );
 				break;
-			}else if( !GetQuoteFilePath( &pLine[2], szFile, _countof(szFile) ) ){
+			}else if( !GetQuoteFilePath( &pLine[2], szFile, std::size(szFile) ) ){
 				break;
 			}
 			searchMode = TAGLIST_ROOT;
 		}else if( 0 == wmemcmp( pLine, L"◆\"", 2 ) ){
-			if( !GetQuoteFilePath( &pLine[2], szFile, _countof(szFile) ) ){
+			if( !GetQuoteFilePath( &pLine[2], szFile, std::size(szFile) ) ){
 				break;
 			}
 			searchMode = TAGLIST_SUBPATH;
 		}else if( 0 == wmemcmp( pLine, L"・", 1 ) ){
 			if( pLine[1] == L'"' ){
 				// ・"FileName.ext"
-				if( !GetQuoteFilePath( &pLine[2], szFile, _countof(szFile) ) ){
+				if( !GetQuoteFilePath( &pLine[2], szFile, std::size(szFile) ) ){
 					break;
 				}
 				searchMode = TAGLIST_SUBPATH;
@@ -219,7 +219,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 					for( ; 1 < fileEnd && (L'0' <= pLine[fileEnd] && pLine[fileEnd] <= L'9'); fileEnd-- ){}
 					if(    1 < fileEnd && (L',' == pLine[fileEnd]) ){ fileEnd--; }
 					for( ; 1 < fileEnd && (L'0' <= pLine[fileEnd] && pLine[fileEnd] <= L'9'); fileEnd-- ){}
-					if( 1 < fileEnd && L'(' == pLine[fileEnd] && fileEnd - 1 < (int)_countof(szFile) ){
+					if( 1 < fileEnd && L'(' == pLine[fileEnd] && fileEnd - 1 < (int)std::size(szFile) ){
 						wmemcpy( szFile, pLine + 1, fileEnd - 1 );
 						szFile[fileEnd - 1] = L'\0';
 						GetLineColumn( &pLine[fileEnd + 1], &nJumpToLine, &nJumpToColumn );
@@ -246,7 +246,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 					continue;
 				}
 				// フォルダ毎：ファイル名
-				if( GetQuoteFilePath(&pLine[2], szFile, _countof(szFile)) ){
+				if( GetQuoteFilePath(&pLine[2], szFile, std::size(szFile)) ){
 					searchMode = TAGLIST_SUBPATH;
 					continue;
 				}
@@ -268,7 +268,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 				}
 				// 相対フォルダorファイル名
 				wchar_t		szPath[_MAX_PATH];
-				if( GetQuoteFilePath( &pLine[2], szPath, _countof(szPath) ) ){
+				if( GetQuoteFilePath( &pLine[2], szPath, std::size(szPath) ) ){
 					if( szFile[0] ){
 						AddLastYenFromDirectoryPath( szPath );
 					}
@@ -284,7 +284,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 				}
 				break;
 			}else if( 3 <= nLineLen && 0 == wmemcmp( pLine, L"◎\"", 2 ) ){
-				if( GetQuoteFilePath( &pLine[2], szJumpToFile, _countof(szJumpToFile) ) ){
+				if( GetQuoteFilePath( &pLine[2], szJumpToFile, std::size(szJumpToFile) ) ){
 					AddLastYenFromDirectoryPath( szJumpToFile );
 					wcscat( szJumpToFile, szFile );
 					if( IsFileExists2( szJumpToFile ) ){
@@ -396,7 +396,7 @@ bool CViewCommander::Command_TagsMake( void )
 	else
 	{
 		// 20100722 Moca サクラのフォルダからカレントディレクトリに変更
-		::GetCurrentDirectory( _countof(szTargetPath), szTargetPath );
+		::GetCurrentDirectory( std::size(szTargetPath), szTargetPath );
 	}
 
 	//ダイアログを表示する
@@ -468,7 +468,7 @@ bool CViewCommander::Command_TagsMake( void )
 	{
 		// 2010.08.28 Moca システムディレクトリ付加
 		WCHAR szCmdDir[_MAX_PATH];
-		::GetSystemDirectory(szCmdDir, _countof(szCmdDir));
+		::GetSystemDirectory(szCmdDir, std::size(szCmdDir));
 		//	2006.08.04 genta add /D to disable autorun
 		auto_sprintf( cmdline, L"\"%s\\cmd.exe\" /D /C \"\"%s\\%s\" %s\"",
 				szCmdDir,
@@ -536,9 +536,9 @@ bool CViewCommander::Command_TagsMake( void )
 			{
 				if( new_cnt > 0 )												//待機中のものがある
 				{
-					if( new_cnt >= _countof(work) - 2 )							//パイプから読み出す量を調整
+					if( new_cnt >= std::size(work) - 2 )							//パイプから読み出す量を調整
 					{
-						new_cnt = _countof(work) - 2;
+						new_cnt = std::size(work) - 2;
 					}
 					::ReadFile( hStdOutRead, &work[0], new_cnt, &read_cnt, NULL );	//パイプから読み出し
 					if( read_cnt == 0 )
@@ -613,7 +613,7 @@ bool CViewCommander::Command_TagJumpByTagsFile( bool bClose )
 	}
 
 	WCHAR	szDirFile[1024];
-	if( false == Sub_PreProcTagJumpByTagsFile( szDirFile, _countof(szDirFile) ) ){
+	if( false == Sub_PreProcTagJumpByTagsFile( szDirFile, std::size(szDirFile) ) ){
 		return false;
 	}
 	CDlgTagJumpList	cDlgTagJumpList(true);	//タグジャンプリスト
@@ -637,7 +637,7 @@ bool CViewCommander::Command_TagJumpByTagsFile( bool bClose )
 		WCHAR fileName[1024];
 		int   fileLine;
 
-		if( false == cDlgTagJumpList.GetSelectedFullPathAndLine( fileName, _countof(fileName), &fileLine , NULL ) ){
+		if( false == cDlgTagJumpList.GetSelectedFullPathAndLine( fileName, std::size(fileName), &fileLine , NULL ) ){
 			return false;
 		}
 		return m_pCommanderView->TagJumpSub( fileName, CMyPoint(0, fileLine), bClose );
@@ -660,7 +660,7 @@ bool CViewCommander::Command_TagJumpByTagsFileKeyword( const wchar_t* keyword )
 	int		fileLine;	// 行番号
 	WCHAR	szCurrentPath[1024];
 
-	if( false == Sub_PreProcTagJumpByTagsFile( szCurrentPath, _countof(szCurrentPath) ) ){
+	if( false == Sub_PreProcTagJumpByTagsFile( szCurrentPath, std::size(szCurrentPath) ) ){
 		return false;
 	}
 
@@ -673,7 +673,7 @@ bool CViewCommander::Command_TagJumpByTagsFileKeyword( const wchar_t* keyword )
 	}
 
 	//タグジャンプする。
-	if( false == cDlgTagJumpList.GetSelectedFullPathAndLine( fileName, _countof(fileName), &fileLine, NULL ) )
+	if( false == cDlgTagJumpList.GetSelectedFullPathAndLine( fileName, std::size(fileName), &fileLine, NULL ) )
 	{
 		return false;
 	}
@@ -703,13 +703,13 @@ bool CViewCommander::Sub_PreProcTagJumpByTagsFile( WCHAR* szCurrentPath, int cou
 	if( GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
 		wcscpy( szCurrentPath, GetDocument()->m_cDocFile.GetFilePath() );
 	}else{
-		if( 0 == ::GetCurrentDirectory( count - _countof(L"\\dmy") - MAX_TYPES_EXTS, szCurrentPath ) ){
+		if( 0 == ::GetCurrentDirectory( count - std::size(L"\\dmy") - MAX_TYPES_EXTS, szCurrentPath ) ){
 			return false;
 		}
 		// (無題)でもファイル名を要求してくるのでダミーをつける
 		// 現在のタイプ別の1番目の拡張子を拝借
 		WCHAR szExts[MAX_TYPES_EXTS];
-		CDocTypeManager::GetFirstExt(m_pCommanderView->m_pTypeData->m_szTypeExts, szExts, _countof(szExts));
+		CDocTypeManager::GetFirstExt(m_pCommanderView->m_pTypeData->m_szTypeExts, szExts, std::size(szExts));
 		int nExtLen = wcslen( szExts );
 		wcscat( szCurrentPath, L"\\dmy" );
 		if( nExtLen ){

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -433,7 +433,7 @@ BOOL CDialog::OnCommand( WPARAM wParam, LPARAM lParam )
 
 	// 通知元がコントロールだった場合の処理
 	if( hwndCtl ){
-		::GetClassName(hwndCtl, szClass, _countof(szClass));
+		::GetClassName(hwndCtl, szClass, std::size(szClass));
 		if( ::lstrcmpi(szClass, L"Button") == 0 ){
 			switch( wNotifyCode ){
 			/* ボタン／チェックボックスがクリックされた */
@@ -623,7 +623,7 @@ HFONT CDialog::SetMainFont( HWND hTarget )
 	//lf.lfClipPrecision	= lf.lfClipPrecision;
 	//lf.lfQuality		= lf.lfQuality;
 	//lf.lfPitchAndFamily	= lf.lfPitchAndFamily;
-	//wcsncpy( lf.lfFaceName, lf.lfFaceName, _countof(lf.lfFaceName));	// 画面のフォントに設定	2012/11/27 Uchi
+	//wcsncpy( lf.lfFaceName, lf.lfFaceName, std::size(lf.lfFaceName));	// 画面のフォントに設定	2012/11/27 Uchi
 
 	// フォントを作成
 	hFont = ::CreateFontIndirect(&lf);

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -155,7 +155,7 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	WCHAR			szFile[_MAX_PATH];
 
 	/* この実行ファイルの情報 */
-	::GetModuleFileName( NULL, szFile, _countof( szFile ) );
+	::GetModuleFileName( NULL, szFile, std::size( szFile ) );
 	
 	//	Oct. 22, 2005 genta タイムスタンプ取得の共通関数利用
 
@@ -240,7 +240,7 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 #ifdef SKR_PATCH_INFO
 	cmemMsg.AppendString( L"      " );
 	const WCHAR szPatchInfo[] = SKR_PATCH_INFO;
-	size_t patchInfoLen = _countof(szPatchInfo) - 1;
+	size_t patchInfoLen = std::size(szPatchInfo) - 1;
 	cmemMsg.AppendString( szPatchInfo, t_min(80, patchInfoLen) );
 #endif
 	cmemMsg.AppendString( L"\r\n");
@@ -253,8 +253,8 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	LPCWSTR pszDesc = LS( IDS_ABOUT_DESCRIPTION );
 	WCHAR szMsg[2048];
 	if( wcslen(pszDesc) > 0 ){
-		wcsncpy( szMsg, pszDesc, _countof(szMsg) - 1 );
-		szMsg[_countof(szMsg) - 1] = 0;
+		wcsncpy( szMsg, pszDesc, std::size(szMsg) - 1 );
+		szMsg[std::size(szMsg) - 1] = 0;
 		::DlgItem_SetText( GetHwnd(), IDC_EDIT_ABOUT, szMsg );
 	}
 	//	To Here Jun. 8, 2001 genta
@@ -325,7 +325,7 @@ BOOL CDlgAbout::OnStnClicked( int wID )
 		//	Web Browserの起動
 		{
 			WCHAR buf[512];
-			::GetWindowText( GetItemHwnd( wID ), buf, _countof(buf) );
+			::GetWindowText( GetItemHwnd( wID ), buf, std::size(buf) );
 			::ShellExecute( GetHwnd(), NULL, buf, NULL, NULL, SW_SHOWNORMAL );
 			return TRUE;
 		}
@@ -464,7 +464,7 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 
 		// 現在のクライアント矩形、テキスト、フォントを取得する
 		GetClientRect( hWnd, &rc );
-		GetWindowText( hWnd, szText, _countof(szText) );
+		GetWindowText( hWnd, szText, std::size(szText) );
 		hFont = (HFONT)SendMessageAny( hWnd, WM_GETFONT, (WPARAM)0, (LPARAM)0 );
 
 		// テキスト描画

--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -51,7 +51,7 @@ CDlgCompare::CDlgCompare()
 	: CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	assert( std::size(anchorList) == std::size(m_rcItems) );
 
 	m_bCompareAndTileHorz = TRUE;	/* 左右に並べて表示 */
 
@@ -155,12 +155,12 @@ void CDlgCompare::SetData( void )
 //@@@ 2001.12.26 YAZAKI ファイル名で比較すると(無題)だったときに問題同士の比較ができない
 			if (pEditNodeArr[i].GetHwnd() == CEditWnd::getInstance()->GetHwnd()){
 				// 2010.07.30 自分の名前もここから設定する
-				CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szMenu, _countof(szMenu), pfi, pEditNodeArr[i].m_nId, -1, calc.GetDC() );
+				CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szMenu, std::size(szMenu), pfi, pEditNodeArr[i].m_nId, -1, calc.GetDC() );
 				::DlgItem_SetText( GetHwnd(), IDC_STATIC_COMPARESRC, szMenu );
 				continue;
 			}
 			// 番号は ウィンドウリストと同じになるようにする
-			CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szMenu, _countof(szMenu), pfi, pEditNodeArr[i].m_nId, i, calc.GetDC() );
+			CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szMenu, std::size(szMenu), pfi, pEditNodeArr[i].m_nId, i, calc.GetDC() );
 
 			nItem = ::List_AddString( hwndList, szMenu );
 			List_SetItemData( hwndList, nItem, pEditNodeArr[i].GetHwnd() );
@@ -256,7 +256,7 @@ BOOL CDlgCompare::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	m_ptDefaultSize.x = rc.right - rc.left;
 	m_ptDefaultSize.y = rc.bottom - rc.top;
 
-	for( int i = 0; i < _countof(anchorList); i++ ){
+	for( int i = 0; i < std::size(anchorList); i++ ){
 		GetItemClientRect( anchorList[i].id, m_rcItems[i] );
 	}
 
@@ -285,7 +285,7 @@ BOOL CDlgCompare::OnSize( WPARAM wParam, LPARAM lParam )
 	ptNew.x = rc.right - rc.left;
 	ptNew.y = rc.bottom - rc.top;
 
-	for( int i = 0 ; i < _countof(anchorList); i++ ){
+	for( int i = 0 ; i < std::size(anchorList); i++ ){
 		ResizeItem( GetItemHwnd(anchorList[i].id), m_ptDefaultSize, ptNew, m_rcItems[i], anchorList[i].anchor );
 	}
 	::InvalidateRect( GetHwnd(), NULL, TRUE );

--- a/sakura_core/dlg/CDlgCtrlCode.cpp
+++ b/sakura_core/dlg/CDlgCtrlCode.cpp
@@ -92,7 +92,7 @@ struct ctrl_info_t {
 // Feb. 12, 2003 MIK longが抜けていた
 
 // LMP: Added, nasukoji changed
-static CLoadString cLabel_jname[ _countof(p_ctrl_list) ];
+static CLoadString cLabel_jname[ std::size(p_ctrl_list) ];
 
 CDlgCtrlCode::CDlgCtrlCode()
 {
@@ -129,7 +129,7 @@ void CDlgCtrlCode::SetData( void )
 	/* データ表示 */
 	WCHAR	tmp[10];
 	count = 0;
-	for( i = 0; i < _countof(p_ctrl_list); i++ )
+	for( i = 0; i < std::size(p_ctrl_list); i++ )
 	{
 		if( p_ctrl_list[i].jname == NULL ) continue;
 		
@@ -281,12 +281,12 @@ BOOL CDlgCtrlCode::OnNotify( NMHDR* pNMHDR )
 				NMKEY	*p = (NMKEY*)pNMHDR;
 				int		i, j;
 				unsigned int	c;
-				for( i = 0; i < _countof(p_ctrl_list); i++ )
+				for( i = 0; i < std::size(p_ctrl_list); i++ )
 				{
 					c = p_ctrl_list[i].vKey;
 					if( c == (p->nVKey & 0xffff) )
 					{
-						for( j = 0; j < _countof(p_ctrl_list); j++ )
+						for( j = 0; j < std::size(p_ctrl_list); j++ )
 						{
 							if( p_ctrl_list[i].code == p_ctrl_list[j].code )
 							{

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -85,7 +85,7 @@ CDlgDiff::CDlgDiff()
 	, m_nIndexSave( 0 )
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	assert( std::size(anchorList) == std::size(m_rcItems) );
 
 	m_nDiffFlgOpt    = 0;
 	m_bIsModifiedDst = false;
@@ -272,13 +272,13 @@ void CDlgDiff::SetData( void )
 				if ( pEditNode[i].GetHwnd() == CEditWnd::getInstance()->GetHwnd() )
 				{
 					// 同じ形式にしておく。ただしアクセスキー番号はなし
-					CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szName, _countof(szName), pFileInfo, pEditNode[i].m_nId, -1, calc.GetDC() );
+					CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szName, std::size(szName), pFileInfo, pEditNode[i].m_nId, -1, calc.GetDC() );
 					::DlgItem_SetText( GetHwnd(), IDC_STATIC_DIFF_SRC, szName );
 					continue;
 				}
 
 				// 番号はウィンドウ一覧と同じ番号を使う
-				CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szName, _countof(szName), pFileInfo, pEditNode[i].m_nId, i, calc.GetDC() );
+				CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( szName, std::size(szName), pFileInfo, pEditNode[i].m_nId, i, calc.GetDC() );
 
 				/* リストに登録する */
 				nItem = ::List_AddString( hwndList, szName );
@@ -497,7 +497,7 @@ BOOL CDlgDiff::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	m_ptDefaultSize.x = rc.right - rc.left;
 	m_ptDefaultSize.y = rc.bottom - rc.top;
 
-	for( int i = 0; i < _countof(anchorList); i++){
+	for( int i = 0; i < std::size(anchorList); i++){
 		GetItemClientRect( anchorList[i].id, m_rcItems[i] );
 	}
 
@@ -526,7 +526,7 @@ BOOL CDlgDiff::OnSize( WPARAM wParam, LPARAM lParam )
 	ptNew.x = rc.right - rc.left;
 	ptNew.y = rc.bottom - rc.top;
 
-	for( int i = 0; i < _countof(anchorList); i++){
+	for( int i = 0; i < std::size(anchorList); i++){
 		ResizeItem( GetItemHwnd(anchorList[i].id), m_ptDefaultSize, ptNew, m_rcItems[i], anchorList[i].anchor );
 	}
 	::InvalidateRect( GetHwnd(), NULL, TRUE );

--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -72,11 +72,11 @@ BOOL CDlgExec::OnInitDialog( HWND hwnd, WPARAM wParam, LPARAM lParam )
 	HWND hwndCombo;
 	int i;
 	hwndCombo = GetItemHwnd( IDC_COMBO_CODE_GET );
-	for( i = 0; i < _countof(codes); ++i ){
+	for( i = 0; i < std::size(codes); ++i ){
 		Combo_AddString( hwndCombo, CCodeTypeName(codes[i]).Normal() );
 	}
 	hwndCombo = GetItemHwnd( IDC_COMBO_CODE_SEND );
-	for( i = 0; i < _countof(codes); ++i ){
+	for( i = 0; i < std::size(codes); ++i ){
 		Combo_AddString( hwndCombo, CCodeTypeName(codes[i]).Normal() );
 	}
 
@@ -102,7 +102,7 @@ void CDlgExec::SetData( void )
 	*           初期             *
 	*****************************/
 	/* ユーザーがコンボ ボックスのエディット コントロールに入力できるテキストの長さを制限する */
-	Combo_LimitText( GetItemHwnd( IDC_COMBO_m_szCommand ), _countof( m_szCommand ) - 1 );
+	Combo_LimitText( GetItemHwnd( IDC_COMBO_m_szCommand ), std::size( m_szCommand ) - 1 );
 	Combo_LimitText( GetItemHwnd( IDC_COMBO_CUR_DIR ), _countof2( m_szCurDir ) - 1 );
 	/* コンボボックスのユーザー インターフェイスを拡張インターフェースにする */
 	Combo_SetExtendedUI( GetItemHwnd( IDC_COMBO_m_szCommand ), TRUE );
@@ -156,7 +156,7 @@ void CDlgExec::SetData( void )
 	int nOpt;
 	hwndCombo = GetItemHwnd( IDC_COMBO_CODE_GET );
 	nOpt = m_pShareData->m_nExecFlgOpt & 0x88;
-	for( i = 0; _countof(codeTable1); i++ ){
+	for( i = 0; std::size(codeTable1); i++ ){
 		if( codeTable1[i] == nOpt ){
 			Combo_SetCurSel( hwndCombo, i );
 			break;
@@ -164,7 +164,7 @@ void CDlgExec::SetData( void )
 	}
 	hwndCombo = GetItemHwnd( IDC_COMBO_CODE_SEND );
 	nOpt = m_pShareData->m_nExecFlgOpt & 0x110;
-	for( i = 0; _countof(codeTable2); i++ ){
+	for( i = 0; std::size(codeTable2); i++ ){
 		if( codeTable2[i] == nOpt ){
 			Combo_SetCurSel( hwndCombo, i );
 			break;
@@ -176,7 +176,7 @@ void CDlgExec::SetData( void )
 /* ダイアログデータの取得 */
 int CDlgExec::GetData( void )
 {
-	DlgItem_GetText( GetHwnd(), IDC_COMBO_m_szCommand, m_szCommand, _countof( m_szCommand ));
+	DlgItem_GetText( GetHwnd(), IDC_COMBO_m_szCommand, m_szCommand, std::size( m_szCommand ));
 	if( IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_CUR_DIR ) ){
 		DlgItem_GetText( GetHwnd(), IDC_COMBO_CUR_DIR, &m_szCurDir[0], _countof2( m_szCurDir ));
 	}else{
@@ -238,7 +238,7 @@ BOOL CDlgExec::OnBnClicked( int wID )
 		{
 			CDlgOpenFile	cDlgOpenFile;
 			WCHAR			szPath[_MAX_PATH + 1];
-			int				size = _countof(szPath) - 1;
+			int				size = std::size(szPath) - 1;
 			wcsncpy( szPath, m_szCommand, size);
 			szPath[size] = L'\0';
 			/* ファイルオープンダイアログの初期化 */

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -109,7 +109,7 @@ CDlgFavorite::CDlgFavorite()
 	m_szMsg[0] = L'\0';
 
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	assert( std::size(anchorList) == std::size(m_rcItems) );
 
 	{
 		i = 0;
@@ -223,7 +223,7 @@ CDlgFavorite::CDlgFavorite()
 		m_aFavoriteInfo[i].m_bAddExcept = false;
 
 		/* これ以上増やすときはテーブルサイズも書き換えてね */
-		assert( i < _countof(m_aFavoriteInfo) );
+		assert( i < std::size(m_aFavoriteInfo) );
 	}
 	for( i = 0; i < FAVORITE_INFO_MAX; i++ ){
 		m_aListViewInfo[i].hListView   = 0;
@@ -292,7 +292,7 @@ void CDlgFavorite::SetDataOne( int nIndex, int nLvItemIndex )
 	WCHAR	tmp[1024];
 	for( int i = 0; i < nItemCount; i++ )
 	{
-		FormatFavoriteColumn( tmp, _countof(tmp), i, i < nViewCount );
+		FormatFavoriteColumn( tmp, std::size(tmp), i, i < nViewCount );
 		lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 		lvi.pszText  = tmp;
 		lvi.iItem    = i;
@@ -301,7 +301,7 @@ void CDlgFavorite::SetDataOne( int nIndex, int nLvItemIndex )
 		ListView_InsertItem( hwndList, &lvi );
 
 		const WCHAR	*p = pRecent->GetItemText( i );
-		auto_snprintf_s( tmp, _countof(tmp), L"%s", p ? p : L"" );
+		auto_snprintf_s( tmp, std::size(tmp), L"%s", p ? p : L"" );
 		lvi.mask     = LVIF_TEXT;
 		lvi.iItem    = i;
 		lvi.iSubItem = 1;
@@ -380,7 +380,7 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	m_ptDefaultSize.x = rc.right - rc.left;
 	m_ptDefaultSize.y = rc.bottom - rc.top;
 
-	for( int i = 0; i < _countof(anchorList); i++ ){
+	for( int i = 0; i < std::size(anchorList); i++ ){
 		GetItemClientRect( anchorList[i].id, m_rcItems[i] );
 	}
 
@@ -429,7 +429,7 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		WCHAR szBuf[200];
 		for(int i = 0; i < 40; i++ ){
 			// 「M (非表示)」等の幅を求める
-			FormatFavoriteColumn( szBuf, _countof(szBuf), i, false);
+			FormatFavoriteColumn( szBuf, std::size(szBuf), i, false);
 			calc.SetTextWidthIfMax( szBuf, CTextWidthCalc::WIDTH_LV_ITEM_CHECKBOX );
 		}
 		
@@ -651,7 +651,7 @@ BOOL CDlgFavorite::OnNotify(NMHDR* pNMHDR)
 				WORD wKey = ((NMLVKEYDOWN*)pNMHDR)->wVKey;
 				if( (wKey == VK_NEXT && nIdx == _CTRL) ){
 					int next = m_nCurrentTab + 1;
-					if( _countof(m_aFavoriteInfo) - 1 <= next ){
+					if( std::size(m_aFavoriteInfo) - 1 <= next ){
 						next = 0;
 					}
 					TabCtrl_SetCurSel( GetItemHwnd(IDC_TAB_FAVORITE), next );
@@ -660,7 +660,7 @@ BOOL CDlgFavorite::OnNotify(NMHDR* pNMHDR)
 				}else if( (wKey == VK_PRIOR && nIdx == _CTRL) ){
 					int prev = m_nCurrentTab - 1;
 					if( prev < 0 ){
-						prev = _countof(m_aFavoriteInfo) - 2;
+						prev = std::size(m_aFavoriteInfo) - 2;
 					}
 					TabCtrl_SetCurSel( GetItemHwnd(IDC_TAB_FAVORITE), prev );
 					TabSelectChange(true);
@@ -754,7 +754,7 @@ bool CDlgFavorite::RefreshList( void )
 
 	if( ret_val )
 	{
-		auto_snprintf_s( m_szMsg, _countof(m_szMsg),
+		auto_snprintf_s( m_szMsg, std::size(m_szMsg),
 			LS( STR_DLGFAV_FAV_REFRESH ),	// "履歴(%s)が更新されたため編集中情報を破棄し再表示しました。"
 			msg );
 	}
@@ -790,11 +790,11 @@ bool CDlgFavorite::RefreshListOne( int nIndex )
 	for( i = 0; i < nCount; i++ )
 	{
 		WCHAR	szText[1024];
-		wmemset( szText, 0, _countof( szText ) );
+		wmemset( szText, 0, std::size( szText ) );
 		memset_raw( &lvitem, 0, sizeof( lvitem ) );
 		lvitem.mask       = LVIF_TEXT | LVIF_PARAM;
 		lvitem.pszText    = szText;
-		lvitem.cchTextMax = _countof( szText );
+		lvitem.cchTextMax = std::size( szText );
 		lvitem.iItem      = i;
 		lvitem.iSubItem   = 1;
 		bret = ListView_GetItem( hwndList, &lvitem );
@@ -1121,7 +1121,7 @@ void CDlgFavorite::ListViewSort(ListViewSortInfo& info, const CRecent* pRecent, 
 		// 元のソートの「 ▼」を取り除く
 		col.mask = LVCF_TEXT;
 		col.pszText = szHeader;
-		col.cchTextMax = _countof(szHeader);
+		col.cchTextMax = std::size(szHeader);
 		col.iSubItem = 0;
 		ListView_GetColumn( info.hListView, info.nSortColumn, &col );
 		int nLen = (int)wcslen(szHeader) - wcslen(L"▼");
@@ -1136,7 +1136,7 @@ void CDlgFavorite::ListViewSort(ListViewSortInfo& info, const CRecent* pRecent, 
 	// 「▼」を付加
 	col.mask = LVCF_TEXT;
 	col.pszText = szHeader;
-	col.cchTextMax = _countof(szHeader) - 4;
+	col.cchTextMax = std::size(szHeader) - 4;
 	col.iSubItem = 0;
 	ListView_GetColumn( info.hListView, column, &col );
 	wcscat(szHeader, info.bSortAscending ? L"▼" : L"▲");
@@ -1192,7 +1192,7 @@ BOOL CDlgFavorite::OnSize( WPARAM wParam, LPARAM lParam )
 	ptNew.x = rc.right - rc.left;
 	ptNew.y = rc.bottom - rc.top;
 
-	for( int i = 0 ; i < _countof(anchorList); i++ ){
+	for( int i = 0 ; i < std::size(anchorList); i++ ){
 		ResizeItem( GetItemHwnd(anchorList[i].id), m_ptDefaultSize, ptNew, m_rcItems[i], anchorList[i].anchor );
 	}
 

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -424,7 +424,7 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 		else{
 			/* 現在のプロセスのカレントディレクトリを取得します */
 			WCHAR	szWorkFolder[MAX_PATH];
-			::GetCurrentDirectory( _countof( szWorkFolder ) - 1, szWorkFolder );
+			::GetCurrentDirectory( std::size( szWorkFolder ) - 1, szWorkFolder );
 			SetGrepFolder( GetItemHwnd(IDC_COMBO_FOLDER), szWorkFolder );
 		}
 		return TRUE;
@@ -433,7 +433,7 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 			HWND hwnd = GetItemHwnd( IDC_COMBO_FOLDER );
 			const int nMaxPath = MAX_GREP_PATH;
 			WCHAR szFolder[nMaxPath];
-			::GetWindowText( hwnd, szFolder, _countof(szFolder) );
+			::GetWindowText( hwnd, szFolder, std::size(szFolder) );
 			std::vector<std::wstring> vPaths;
 			CGrepAgent::CreateFolders( szFolder, vPaths );
 			if( 0 < vPaths.size() ){

--- a/sakura_core/dlg/CDlgOpenFile.cpp
+++ b/sakura_core/dlg/CDlgOpenFile.cpp
@@ -85,7 +85,7 @@ BOOL CDlgOpenFile::SelectFile(
 	CDlgOpenFile cDlgOpenFile;
 	WCHAR			szFilePath[_MAX_PATH + 1];
 	WCHAR			szPath[_MAX_PATH + 1];
-	::GetWindowText( hwndCtl, szFilePath, _countof(szFilePath) );
+	::GetWindowText( hwndCtl, szFilePath, std::size(szFilePath) );
 	// 2003.06.23 Moca 相対パスは実行ファイルからのパスとして開く
 	// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
 	if( resolvePath && _IS_REL_PATH( szFilePath ) ){

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -232,7 +232,7 @@ UINT_PTR CALLBACK OFNHookProc(
 		L"LF (UNIX)",
 		L"CR (Mac)",
 	};
-	int nEolNameArrNum = (int)_countof(pEolNameArr);
+	int nEolNameArrNum = (int)std::size(pEolNameArr);
 
 //	To Here	Feb. 9, 2001 genta
 	int	nRightMargin = 24;
@@ -491,7 +491,7 @@ UINT_PTR CALLBACK OFNHookProc(
 			{
 				wchar_t szFolder[_MAX_PATH];
 				CDlgOpenFileData* pData = (CDlgOpenFileData*)::GetWindowLongPtr(hdlg, DWLP_USER);
-				lRes = CommDlg_OpenSave_GetFolderPath( pData->m_hwndOpenDlg, szFolder, _countof( szFolder ) );
+				lRes = CommDlg_OpenSave_GetFolderPath( pData->m_hwndOpenDlg, szFolder, std::size( szFolder ) );
 			}
 //			MYTRACE( L"\tlRes=%d\pszFolder=[%ls]\n", lRes, szFolder );
 
@@ -667,7 +667,7 @@ CDlgOpenFile_CommonFileDialog::CDlgOpenFile_CommonFileDialog()
 	WCHAR	szDir[_MAX_DIR];
 	::GetModuleFileName(
 		NULL,
-		szFile, _countof( szFile )
+		szFile, std::size( szFile )
 	);
 	_wsplitpath( szFile, szDrive, szDir, NULL, NULL );
 	wcscpy( m_szInitialDir, szDrive );

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -409,7 +409,7 @@ CDlgOpenFile_CommonItemDialog::CDlgOpenFile_CommonItemDialog()
 	WCHAR	szDir[_MAX_DIR];
 	::GetModuleFileName(
 		NULL,
-		szFile, _countof( szFile )
+		szFile, std::size( szFile )
 	);
 	_wsplitpath( szFile, szDrive, szDir, NULL, NULL );
 	wcscpy( m_szInitialDir, szDrive );

--- a/sakura_core/dlg/CDlgPluginOption.cpp
+++ b/sakura_core/dlg/CDlgPluginOption.cpp
@@ -124,7 +124,7 @@ void CDlgPluginOption::SetData( void )
 	for( i=0, it = m_cPlugin->m_options.begin(); it != m_cPlugin->m_options.end(); i++, it++ ){
 		cOpt = *it;
 
-		auto_snprintf_s( buf, _countof(buf), L"%ls", cOpt->GetLabel().c_str());
+		auto_snprintf_s( buf, std::size(buf), L"%ls", cOpt->GetLabel().c_str());
 		lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 		lvi.pszText  = buf;
 		lvi.iItem    = i;
@@ -172,13 +172,13 @@ void CDlgPluginOption::SetData( void )
 			for (auto it = selects.begin(); it != selects.end(); it++) {
 				SepSelect(*it, &sView, &sTrg);
 				if (sValue == sTrg) {
-					auto_snprintf_s( buf, _countof(buf), L"%ls", sView.c_str());
+					auto_snprintf_s( buf, std::size(buf), L"%ls", sView.c_str());
 					break;
 				}
 			}
 		}
 		else {
-			auto_snprintf_s( buf, _countof(buf), L"%ls", sValue.c_str());
+			auto_snprintf_s( buf, std::size(buf), L"%ls", sValue.c_str());
 		}
 		lvi.mask     = LVIF_TEXT;
 		lvi.iItem    = i;
@@ -707,7 +707,7 @@ void CDlgPluginOption::SelectDirectory( int iLine )
 	WCHAR	szDir[_MAX_PATH+1];
 
 	/* 検索フォルダ */
-	::DlgItem_GetText( GetHwnd(), IDC_EDIT_PLUGIN_OPTION_DIR, szDir, _countof(szDir) );
+	::DlgItem_GetText( GetHwnd(), IDC_EDIT_PLUGIN_OPTION_DIR, szDir, std::size(szDir) );
 
 	if (_IS_REL_PATH( szDir )) {
 		WCHAR	folder[_MAX_PATH];
@@ -731,7 +731,7 @@ void CDlgPluginOption::SelectDirectory( int iLine )
 	auto_sprintf( sTitle, LS(STR_DLGPLUGINOPT_SELECT), buf);
 	if (SelectDir( GetHwnd(), (const WCHAR*)sTitle /*L"ディレクトリの選択"*/, szDir, szDir )) {
 		//	末尾に\マークを追加する．
-		AddLastChar( szDir, _countof(szDir), L'\\' );
+		AddLastChar( szDir, std::size(szDir), L'\\' );
 		::DlgItem_SetText( GetHwnd(), IDC_EDIT_PLUGIN_OPTION_DIR, szDir );
 	}
 }

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -250,7 +250,7 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 				GetHwnd(),
 				LS(STR_DLGPRNST1),
 				LS(STR_DLGPRNST2),
-				_countof( m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName ) - 1,
+				std::size( m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName ) - 1,
 				szWork
 			);
 			if( !bDlgInputResult ){
@@ -258,7 +258,7 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 			}
 		}
 		if( szWork[0] != L'\0' ){
-			int		size = _countof(m_PrintSettingArr[0].m_szPrintSettingName) - 1;
+			int		size = std::size(m_PrintSettingArr[0].m_szPrintSettingName) - 1;
 			wcsncpy( m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName, szWork, size);
 			m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName[size] = L'\0';
 			/* 印刷設定名一覧 */
@@ -864,7 +864,7 @@ BOOL CDlgPrintSetting::CalcPrintableLineAndColumn()
 	// 1pt = 1/72in = 25.4/72mm
 	int		nFontPoints = pPS->m_nPrintFontHeight * 720 / 254;
 	WCHAR	szFontPoints[20];
-	auto_sprintf_s( szFontPoints, _countof(szFontPoints), L"%d.%dpt", nFontPoints/10, nFontPoints%10 );
+	auto_sprintf_s( szFontPoints, std::size(szFontPoints), L"%d.%dpt", nFontPoints/10, nFontPoints%10 );
 	::DlgItem_SetText( GetHwnd(), IDC_STATIC_FONTSIZE, szFontPoints );
 
 	// 印字可能領域がない場合は OK を押せなくする 2013.5.10 aroka

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -115,7 +115,7 @@ static std::wstring GetProfileMgrFileName(LPCWSTR profName = NULL)
 	if( profName == NULL ){
 		WCHAR szExePath[_MAX_PATH];
 		WCHAR szFname[_MAX_FNAME];
-		::GetModuleFileName( NULL, szExePath, _countof(szExePath) );
+		::GetModuleFileName( NULL, szExePath, std::size(szExePath) );
 		_wsplitpath( szExePath, NULL, NULL, szFname, NULL );
 		auto_snprintf_s( szIniFile, _MAX_PATH - 1, L"%s\\%s_prof%s", szDir, szFname, L".ini" );
 	}else{
@@ -348,7 +348,7 @@ void CDlgProfileMgr::CreateProf()
 	}
 	std::wstring strText = szText;
 	static const WCHAR szReservedChars[] = L"/\\*?<>&|:\"'\t";
-	for( int x = 0; x < _countof(szReservedChars); ++x ){
+	for( int x = 0; x < std::size(szReservedChars); ++x ){
 		if( strText.npos != strText.find(szReservedChars[x]) ){
 			ErrorMessage( GetHwnd(), LS(STR_DLGPROFILE_ERR_INVALID_CHAR) );
 			return;
@@ -410,7 +410,7 @@ void CDlgProfileMgr::RenameProf()
 	}
 	std::wstring strText = szText;
 	static const WCHAR szReservedChars[] = L"/\\*?<>&|:\"'\t";
-	for( int x = 0; x < _countof(szReservedChars); ++x ){
+	for( int x = 0; x < std::size(szReservedChars); ++x ){
 		if( strText.npos != strText.find(szReservedChars[x]) ){
 			ErrorMessage( GetHwnd(), LS(STR_DLGPROFILE_ERR_INVALID_CHAR) );
 			return;
@@ -510,7 +510,7 @@ static bool IOProfSettings( SProfileSettings& settings, bool bWrite )
 	if( settings.m_nDefaultIndex < -1 ){
 		settings.m_nDefaultIndex = -1;
 	}
-	cProf.IOProfileData( pSection, L"szDllLanguage", StringBufferW(settings.m_szDllLanguage, _countof(settings.m_szDllLanguage)) );
+	cProf.IOProfileData( pSection, L"szDllLanguage", StringBufferW(settings.m_szDllLanguage, std::size(settings.m_szDllLanguage)) );
 	cProf.IOProfileData( pSection, L"bDefaultSelect", settings.m_bDefaultSelect );
 
 	if( bWrite ){

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -149,7 +149,7 @@ CDlgTagJumpList::CDlgTagJumpList(bool bDirectTagJump)
 	  m_strOldKeyword( L"" )
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	assert( std::size(anchorList) == std::size(m_rcItems) );
 
 	// 2010.07.22 Moca ページング採用で 最大値を100→50に減らす
 	m_pcList = new CSortedTagJumpList(50);
@@ -399,7 +399,7 @@ int CDlgTagJumpList::GetData( void )
 		}
 		wchar_t	tmp[MAX_TAG_STRING_LENGTH];
 		tmp[0] = L'\0';
-		::DlgItem_GetText( GetHwnd(), IDC_KEYWORD, tmp, _countof( tmp ) );
+		::DlgItem_GetText( GetHwnd(), IDC_KEYWORD, tmp, std::size( tmp ) );
 		SetKeyword( tmp );
 
 		//設定を保存
@@ -435,7 +435,7 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	m_ptDefaultSize.x = rc.right - rc.left;
 	m_ptDefaultSize.y = rc.bottom - rc.top;
 
-	for( int i = 0; i < _countof(anchorList); i++ ){
+	for( int i = 0; i < std::size(anchorList); i++ ){
 		GetItemClientRect( anchorList[i].id, m_rcItems[i] );
 	}
 
@@ -604,7 +604,7 @@ BOOL CDlgTagJumpList::OnSize( WPARAM wParam, LPARAM lParam )
 	ptNew.x = rc.right - rc.left;
 	ptNew.y = rc.bottom - rc.top;
 
-	for( int i = 0 ; i < _countof(anchorList); i++ ){
+	for( int i = 0 ; i < std::size(anchorList); i++ ){
 		ResizeItem( GetItemHwnd(anchorList[i].id), m_ptDefaultSize, ptNew, m_rcItems[i], anchorList[i].anchor );
 	}
 	::InvalidateRect( GetHwnd(), NULL, TRUE );
@@ -910,7 +910,7 @@ int CDlgTagJumpList::SearchBestTag( void )
 		lpPathInfo->szFileNameDst[0] = L'\0';
 		{
 			WCHAR szPath[_MAX_PATH];
-			GetFullPathAndLine( i, szPath, _countof(szPath), NULL, NULL );
+			GetFullPathAndLine( i, szPath, std::size(szPath), NULL, NULL );
 			if( FALSE == GetLongFileName( szPath, lpPathInfo->szFileNameDst ) ){
 				wcscpy( lpPathInfo->szFileNameDst, szPath );
 			}
@@ -1001,7 +1001,7 @@ void CDlgTagJumpList::FindNext( bool bNewFind )
 {
 	wchar_t	szKey[ MAX_TAG_STRING_LENGTH ];
 	szKey[0] = L'\0';
-	::DlgItem_GetText( GetHwnd(), IDC_KEYWORD, szKey, _countof( szKey ) );
+	::DlgItem_GetText( GetHwnd(), IDC_KEYWORD, szKey, std::size( szKey ) );
 	if( bNewFind ){
 		// 前回のキーワードからの絞込検索のときで、tagsをスキップできるときはスキップ
 		if( -1 < m_psFind0Match->m_nDepth
@@ -1254,10 +1254,10 @@ bool CDlgTagJumpList::ReadTagsParameter(
 	fpos_t old_offset = 0;
 
 	// バッファの後ろから2文字目が\0かどうかで、行末まで読み込んだか確認する
-	const int nLINEDATA_LAST_CHAR = _countof( szLineData ) - 2;
+	const int nLINEDATA_LAST_CHAR = std::size( szLineData ) - 2;
 	szLineData[nLINEDATA_LAST_CHAR] = '\0';
 
-	while( fgets( szLineData, _countof( szLineData ), fp ) ) {
+	while( fgets( szLineData, std::size( szLineData ), fp ) ) {
 		nLines++;
 		// fgetsが行すべてを読み込めていない場合の考慮
 		if( '\0' != szLineData[nLINEDATA_LAST_CHAR] && '\n' != szLineData[nLINEDATA_LAST_CHAR] ){
@@ -1403,7 +1403,7 @@ void CDlgTagJumpList::find_key_for_BinarySearch(
 	SearchState eSearchState = STATE_BINARY;
 	
 	// バッファの後ろから2文字目が\0かどうかで、行末まで読み込んだか確認する
-	const int nLINEDATA_LAST_CHAR = _countof( szLineData ) - 2;
+	const int nLINEDATA_LAST_CHAR = std::size( szLineData ) - 2;
 	szLineData[nLINEDATA_LAST_CHAR] = '\0';
 
 	// 初期設定 tagsファイルの中央のキーまでシーク
@@ -1415,9 +1415,9 @@ void CDlgTagJumpList::find_key_for_BinarySearch(
 	curr_offset = low_offset + ((high_offset - low_offset) / 2);
 	fsetpos(fp, &curr_offset);
 	// 改行コードまでを捨てる
-	fgets(szLineData, _countof(szLineData), fp);
+	fgets(szLineData, std::size(szLineData), fp);
 
-	while( fgets( szLineData, _countof( szLineData ), fp ) ) {
+	while( fgets( szLineData, std::size( szLineData ), fp ) ) {
 		// fgetsが行すべてを読み込めていない場合の考慮
 		if( '\0' != szLineData[nLINEDATA_LAST_CHAR] && '\n' != szLineData[nLINEDATA_LAST_CHAR] ){
 			SkipLine(fp);
@@ -1483,7 +1483,7 @@ void CDlgTagJumpList::find_key_for_BinarySearch(
 			}
 			curr_offset = temp;
 			fsetpos(fp, &curr_offset);
-			fgets(szLineData, _countof(szLineData), fp);
+			fgets(szLineData, std::size(szLineData), fp);
 		}
 		else if (eSearchState == STATE_SKIP_BACK) {
 			curr_offset -= 1024 * 2;
@@ -1492,7 +1492,7 @@ void CDlgTagJumpList::find_key_for_BinarySearch(
 				eSearchState = STATE_STEP_FORWARD;
 			}
 			fsetpos(fp, &curr_offset);
-			fgets(szLineData, _countof(szLineData), fp);
+			fgets(szLineData, std::size(szLineData), fp);
 		}
 
 next_line:
@@ -1521,10 +1521,10 @@ void CDlgTagJumpList::find_key_for_LinearSearch(
 	int		n2;
 	
 	// バッファの後ろから2文字目が\0かどうかで、行末まで読み込んだか確認する
-	const int nLINEDATA_LAST_CHAR = _countof( szLineData ) - 2;
+	const int nLINEDATA_LAST_CHAR = std::size( szLineData ) - 2;
 	szLineData[nLINEDATA_LAST_CHAR] = '\0';
 
-	while( fgets( szLineData, _countof( szLineData ), fp ) ) {
+	while( fgets( szLineData, std::size( szLineData ), fp ) ) {
 		// fgetsが行すべてを読み込めていない場合の考慮
 		if( '\0' != szLineData[nLINEDATA_LAST_CHAR] && '\n' != szLineData[nLINEDATA_LAST_CHAR] ){
 			SkipLine(fp);

--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -88,7 +88,7 @@ BOOL CDlgTagsMake::OnBnClicked( int wID )
 		{
 			WCHAR szDir[_MAX_PATH];
 			HWND hwnd = GetItemHwnd( IDC_EDIT_TAG_MAKE_FOLDER );
-			::GetWindowText( hwnd, szDir, _countof(szDir) );
+			::GetWindowText( hwnd, szDir, std::size(szDir) );
 			if( DirectoryUp( szDir ) ){
 				::SetWindowText( hwnd, szDir );
 			}
@@ -139,7 +139,7 @@ void CDlgTagsMake::SelectFolder( HWND hwndDlg )
 void CDlgTagsMake::SetData( void )
 {
 	//作成フォルダ
-	Combo_LimitText( GetItemHwnd( IDC_EDIT_TAG_MAKE_FOLDER ), _countof( m_szPath ) );
+	Combo_LimitText( GetItemHwnd( IDC_EDIT_TAG_MAKE_FOLDER ), std::size( m_szPath ) );
 	::DlgItem_SetText( GetHwnd(), IDC_EDIT_TAG_MAKE_FOLDER, m_szPath );
 
 	//オプション
@@ -147,7 +147,7 @@ void CDlgTagsMake::SetData( void )
 	if( m_nTagsOpt & 0x0001 ) ::CheckDlgButton( GetHwnd(), IDC_CHECK_TAG_MAKE_RECURSE, TRUE );
 
 	//コマンドライン
-	Combo_LimitText( GetItemHwnd( IDC_EDIT_TAG_MAKE_CMDLINE ), _countof( m_pShareData->m_szTagsCmdLine ) );
+	Combo_LimitText( GetItemHwnd( IDC_EDIT_TAG_MAKE_CMDLINE ), std::size( m_pShareData->m_szTagsCmdLine ) );
 	wcscpy( m_szTagsCmdLine, m_pShareData->m_szTagsCmdLine );
 	::DlgItem_SetText( GetHwnd(), IDC_EDIT_TAG_MAKE_CMDLINE, m_pShareData->m_szTagsCmdLine );
 
@@ -159,7 +159,7 @@ void CDlgTagsMake::SetData( void )
 int CDlgTagsMake::GetData( void )
 {
 	//フォルダ
-	::DlgItem_GetText( GetHwnd(), IDC_EDIT_TAG_MAKE_FOLDER, m_szPath, _countof( m_szPath ) );
+	::DlgItem_GetText( GetHwnd(), IDC_EDIT_TAG_MAKE_FOLDER, m_szPath, std::size( m_szPath ) );
 	int length = wcslen( m_szPath );
 	if( length > 0 )
 	{
@@ -172,7 +172,7 @@ int CDlgTagsMake::GetData( void )
 	m_pShareData->m_nTagsOpt = m_nTagsOpt;
 
 	//コマンドライン
-	::DlgItem_GetText( GetHwnd(), IDC_EDIT_TAG_MAKE_CMDLINE, m_szTagsCmdLine, _countof( m_szTagsCmdLine ) );
+	::DlgItem_GetText( GetHwnd(), IDC_EDIT_TAG_MAKE_CMDLINE, m_szTagsCmdLine, std::size( m_szTagsCmdLine ) );
 	wcscpy( m_pShareData->m_szTagsCmdLine, m_szTagsCmdLine );
 
 	return TRUE;

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -46,7 +46,7 @@ CDlgWindowList::CDlgWindowList()
 	: CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert(_countof(anchorList) == _countof(m_rcItems));
+	assert(std::size(anchorList) == std::size(m_rcItems));
 	m_ptDefaultSize.x = -1;
 	m_ptDefaultSize.y = -1;
 	return;
@@ -144,7 +144,7 @@ void CDlgWindowList::SetData()
 			const EditInfo* pEditInfo = &m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
 			WCHAR szName[_MAX_PATH];
-			CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape(szName, _countof(szName), pEditInfo, pEditNode[i].m_nId, i, calc.GetDC());
+			CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape(szName, std::size(szName), pEditInfo, pEditNode[i].m_nId, i, calc.GetDC());
 
 			LV_ITEM lvi;
 			lvi.mask     = LVIF_TEXT | LVIF_PARAM;
@@ -192,7 +192,7 @@ BOOL CDlgWindowList::OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam)
 	m_ptDefaultSize.x = rc.right - rc.left;
 	m_ptDefaultSize.y = rc.bottom - rc.top;
 
-	for (int i = 0; i < _countof(anchorList); i++) {
+	for (int i = 0; i < std::size(anchorList); i++) {
 		GetItemClientRect(anchorList[i].id, m_rcItems[i]);
 	}
 
@@ -239,7 +239,7 @@ BOOL CDlgWindowList::OnSize(WPARAM wParam, LPARAM lParam)
 	ptNew.x = rc.right - rc.left;
 	ptNew.y = rc.bottom - rc.top;
 
-	for (int i = 0; i < _countof(anchorList); i++) {
+	for (int i = 0; i < std::size(anchorList); i++) {
 		ResizeItem(GetItemHwnd(anchorList[i].id), m_ptDefaultSize, ptNew, m_rcItems[i], anchorList[i].anchor);
 	}
 	::InvalidateRect(GetHwnd(), NULL, TRUE);

--- a/sakura_core/doc/CDocOutline.cpp
+++ b/sakura_core/doc/CDocOutline.cpp
@@ -118,10 +118,10 @@ int CDocOutline::ReadRuleFile( const WCHAR* pszFilename, SOneRule* pcOneRule, in
 						// pszWork = 「titleRep /// group」
 						// pszGroupDel = 「 /// group」
 						int nTitleLen = pszGroupDel - pszWork; // Len == 0 OK
-						if( nTitleLen < _countof(szText) ){
-							wcsncpy_s(szText, _countof(szText), pszWork, nTitleLen);
+						if( nTitleLen < std::size(szText) ){
+							wcsncpy_s(szText, std::size(szText), pszWork, nTitleLen);
 						}else{
-							wcsncpy_s(szText, _countof(szText), pszWork, _TRUNCATE);
+							wcsncpy_s(szText, std::size(szText), pszWork, _TRUNCATE);
 						}
 						pszTextReplace = szText;
 						bRegexRep2 = true;
@@ -142,7 +142,7 @@ int CDocOutline::ReadRuleFile( const WCHAR* pszFilename, SOneRule* pcOneRule, in
 			}
 			while( NULL != pszToken ){
 				wcsncpy( pcOneRule[nCount].szMatch, pszToken, 255 );
-				wcsncpy_s( pcOneRule[nCount].szText, _countof(pcOneRule[0].szText), pszTextReplace, _TRUNCATE );
+				wcsncpy_s( pcOneRule[nCount].szText, std::size(pcOneRule[0].szText), pszTextReplace, _TRUNCATE );
 				wcsncpy( pcOneRule[nCount].szGroupName, pszWork, 255 );
 				pcOneRule[nCount].szMatch[255] = L'\0';
 				pcOneRule[nCount].szGroupName[255] = L'\0';

--- a/sakura_core/doc/CDocTypeSetting.cpp
+++ b/sakura_core/doc/CDocTypeSetting.cpp
@@ -101,7 +101,7 @@ static ColorInfoIni ColorInfo_DEFAULT[] = {
 
 void GetDefaultColorInfo( ColorInfo* pColorInfo, int nIndex )
 {
-	assert( nIndex < _countof(ColorInfo_DEFAULT) );
+	assert( nIndex < std::size(ColorInfo_DEFAULT) );
 
 	ColorInfoBase* p = pColorInfo;
 	*p = ColorInfo_DEFAULT[nIndex].m_sColorInfo; //ColorInfoBase
@@ -111,12 +111,12 @@ void GetDefaultColorInfo( ColorInfo* pColorInfo, int nIndex )
 
 void GetDefaultColorInfoName( ColorInfo* pColorInfo, int nIndex )
 {
-	assert( nIndex < _countof(ColorInfo_DEFAULT) );
+	assert( nIndex < std::size(ColorInfo_DEFAULT) );
 
 	wcscpy(pColorInfo->m_szName, LS( ColorInfo_DEFAULT[nIndex].m_nNameId ) );
 }
 
 int GetDefaultColorInfoCount()
 {
-	return _countof(ColorInfo_DEFAULT);
+	return std::size(ColorInfo_DEFAULT);
 }

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -215,7 +215,7 @@ CEditDoc::CEditDoc(CEditApp* pcApp)
 	{
 		// 編集禁止コマンドの並びをチェック
 		int i;
-		for ( i = 0; i < _countof(EIsModificationForbidden) - 1; i++){
+		for ( i = 0; i < std::size(EIsModificationForbidden) - 1; i++){
 			assert( EIsModificationForbidden[i] <  EIsModificationForbidden[i+1] );
 		}
 	}
@@ -534,7 +534,7 @@ bool CEditDoc::IsModificationForbidden( EFunctionCode nCommand ) const
 	//	編集禁止の場合(バイナリサーチ)
 	{
 		int lbound = 0;
-		int ubound = _countof(EIsModificationForbidden) - 1;
+		int ubound = std::size(EIsModificationForbidden) - 1;
 
 		while( lbound <= ubound ){
 			int mid = ( lbound + ubound ) / 2;
@@ -1018,7 +1018,7 @@ void CEditDoc::SetCurDirNotitle()
 			}
 		}
 	}else if( eOpenDialogDir == OPENDIALOGDIR_SEL ){
-		CFileNameManager::ExpandMetaToFolder( GetDllShareData().m_Common.m_sEdit.m_OpenDialogSelDir, szSelDir, _countof(szSelDir) );
+		CFileNameManager::ExpandMetaToFolder( GetDllShareData().m_Common.m_sEdit.m_OpenDialogSelDir, szSelDir, std::size(szSelDir) );
 		pszDir = szSelDir;
 	}
 	if( pszDir != NULL ){

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -166,8 +166,8 @@ bool CDocTypeManager::IsFileNameMatch(const WCHAR* pszTypeExts, const WCHAR* psz
 {
 	WCHAR szWork[MAX_TYPES_EXTS];
 
-	wcsncpy(szWork, pszTypeExts, _countof(szWork));
-	szWork[_countof(szWork) - 1] = '\0';
+	wcsncpy(szWork, pszTypeExts, std::size(szWork));
+	szWork[std::size(szWork) - 1] = '\0';
 	WCHAR* token = _wcstok(szWork, m_typeExtSeps);
 	while (token) {
 		if (wcspbrk(token, m_typeExtWildcards) == NULL) {
@@ -199,8 +199,8 @@ void CDocTypeManager::GetFirstExt(const WCHAR* pszTypeExts, WCHAR szFirstExt[], 
 {
 	WCHAR szWork[MAX_TYPES_EXTS];
 
-	wcsncpy(szWork, pszTypeExts, _countof(szWork));
-	szWork[_countof(szWork) - 1] = '\0';
+	wcsncpy(szWork, pszTypeExts, std::size(szWork));
+	szWork[std::size(szWork) - 1] = '\0';
 	WCHAR* token = _wcstok(szWork, m_typeExtSeps);
 	while (token) {
 		if (wcspbrk(token, m_typeExtWildcards) == NULL) {

--- a/sakura_core/env/CFileNameManager.cpp
+++ b/sakura_core/env/CFileNameManager.cpp
@@ -272,11 +272,11 @@ bool CFileNameManager::ExpandMetaToFolder( LPCWSTR pszSrc, LPWSTR pszDes, int nD
 				szPath[0] = L'\0';
 				bFolderPath = ReadRegistry( HKEY_CURRENT_USER,
 					L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders",
-					szMeta, szPath, _countof( szPath ) );
+					szMeta, szPath, std::size( szPath ) );
 				if( false == bFolderPath || L'\0' == szPath[0] ){
 					bFolderPath = ReadRegistry( HKEY_LOCAL_MACHINE,
 						L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders",
-						szMeta, szPath, _countof( szPath ) );
+						szMeta, szPath, std::size( szPath ) );
 				}
 				if( false == bFolderPath || L'\0' == szPath[0] ){
 					pStr = _tgetenv( szMeta );
@@ -504,7 +504,7 @@ void CFileNameManager::GetIniFileNameDirect( LPWSTR pszPrivateIniFile, LPWSTR ps
 
 	::GetModuleFileName(
 		NULL,
-		szPath, _countof(szPath)
+		szPath, std::size(szPath)
 	);
 	_wsplitpath( szPath, szDrive, szDir, szFname, szExt );
 

--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -264,7 +264,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				met.cbSize = CCSIZEOF_STRUCT(NONCLIENTMETRICS, lfMessageFont);
 				::SystemParametersInfo(SPI_GETNONCLIENTMETRICS, met.cbSize, &met, 0);
 				CDCFont dcFont(met.lfCaptionFont, GetMainWindow()->GetHwnd());
-				CFileNameManager::getInstance()->GetTransformFileNameFast( buff, szText, _countof(szText)-1, dcFont.GetHDC(), true );
+				CFileNameManager::getInstance()->GetTransformFileNameFast( buff, szText, std::size(szText)-1, dcFont.GetHDC(), true );
 				q = wcs_pushW( q, q_max - q, szText);
 			}
 			++p;
@@ -356,7 +356,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				WCHAR szText[1024];
 				SYSTEMTIME systime;
 				::GetLocalTime( &systime );
-				CFormatManager().MyGetDateFormat( systime, szText, _countof( szText ) - 1 );
+				CFormatManager().MyGetDateFormat( systime, szText, std::size( szText ) - 1 );
 				q = wcs_pushW( q, q_max - q, szText);
 				++p;
 			}
@@ -366,7 +366,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				WCHAR szText[1024];
 				SYSTEMTIME systime;
 				::GetLocalTime( &systime );
-				CFormatManager().MyGetTimeFormat( systime, szText, _countof( szText ) - 1 );
+				CFormatManager().MyGetTimeFormat( systime, szText, std::size( szText ) - 1 );
 				q = wcs_pushW( q, q_max - q, szText);
 				++p;
 			}
@@ -407,7 +407,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				CFormatManager().MyGetDateFormat(
 					pcDoc->m_cDocFile.GetFileSysTime(),
 					szText,
-					_countof( szText ) - 1
+					std::size( szText ) - 1
 				);
 				q = wcs_pushW( q, q_max - q, szText);
 				++p;
@@ -423,7 +423,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				CFormatManager().MyGetTimeFormat(
 					pcDoc->m_cDocFile.GetFileSysTime(),
 					szText,
-					_countof( szText ) - 1
+					std::size( szText ) - 1
 				);
 				q = wcs_pushW( q, q_max - q, szText);
 				++p;
@@ -504,7 +504,7 @@ void CSakuraEnvironment::ExpandParameter(const wchar_t* pszSource, wchar_t* pszB
 				default:
 					{
 						WCHAR szMacroFilePath[_MAX_PATH * 2];
-						int n = CShareData::getInstance()->GetMacroFilename( pcSMacroMgr->GetCurrentIdx(), szMacroFilePath, _countof(szMacroFilePath) );
+						int n = CShareData::getInstance()->GetMacroFilename( pcSMacroMgr->GetCurrentIdx(), szMacroFilePath, std::size(szMacroFilePath) );
 						if ( 0 < n ){
 							q = wcs_pushW( q, q_max - q, szMacroFilePath );
 						}
@@ -728,7 +728,7 @@ std::wstring CSakuraEnvironment::GetDlgInitialDir(bool bControlProcess)
 		{
 			// 2002.10.25 Moca
 			WCHAR szCurDir[_MAX_PATH];
-			int nCurDir = ::GetCurrentDirectory( _countof(szCurDir), szCurDir );
+			int nCurDir = ::GetCurrentDirectory( std::size(szCurDir), szCurDir );
 			if( 0 == nCurDir || _MAX_PATH < nCurDir ){
 				return L"";
 			}
@@ -750,7 +750,7 @@ std::wstring CSakuraEnvironment::GetDlgInitialDir(bool bControlProcess)
 			}
 
 			WCHAR szCurDir[_MAX_PATH];
-			int nCurDir = ::GetCurrentDirectory( _countof(szCurDir), szCurDir );
+			int nCurDir = ::GetCurrentDirectory( std::size(szCurDir), szCurDir );
 			if( 0 == nCurDir || _MAX_PATH < nCurDir ){
 				return L"";
 			}
@@ -762,7 +762,7 @@ std::wstring CSakuraEnvironment::GetDlgInitialDir(bool bControlProcess)
 	case OPENDIALOGDIR_SEL:
 		{
 			WCHAR szSelDir[_MAX_PATH];
-			CFileNameManager::ExpandMetaToFolder( GetDllShareData().m_Common.m_sEdit.m_OpenDialogSelDir, szSelDir, _countof(szSelDir) );
+			CFileNameManager::ExpandMetaToFolder( GetDllShareData().m_Common.m_sEdit.m_OpenDialogSelDir, szSelDir, std::size(szSelDir) );
 			return szSelDir;
 		}
 		break;
@@ -809,7 +809,7 @@ BOOL IsSakuraMainWindow( HWND hWnd )
 	if( !::IsWindow( hWnd ) ){
 		return FALSE;
 	}
-	if( 0 == ::GetClassName( hWnd, szClassName, _countof(szClassName) - 1 ) ){
+	if( 0 == ::GetClassName( hWnd, szClassName, std::size(szClassName) - 1 ) ){
 		return FALSE;
 	}
 	if(0 == wcscmp( GSTR_EDITWINDOWNAME, szClassName ) ){

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -172,7 +172,7 @@ bool CShareData::InitShareData()
 		m_pShareData->m_sHandles.m_hAccel = NULL;
 		m_pShareData->m_sHandles.m_hwndDebug = NULL;
 
-		for( int i = 0; i < _countof(m_pShareData->m_dwCustColors); i++ ){
+		for( int i = 0; i < std::size(m_pShareData->m_dwCustColors); i++ ){
 			m_pShareData->m_dwCustColors[i] = RGB( 255, 255, 255 );
 		}
 
@@ -768,8 +768,8 @@ static void ConvertLangValueImpl( wchar_t* pBuf, size_t chBufSize, int nStrId, s
 	index++;
 }
 
-#define ConvertLangValue(buf, id)  ConvertLangValueImpl(buf, _countof(buf), id, values, index, bSetValues, true);
-#define ConvertLangValue2(buf, id) ConvertLangValueImpl(buf, _countof(buf), id, values, index, bSetValues, false);
+#define ConvertLangValue(buf, id)  ConvertLangValueImpl(buf, std::size(buf), id, values, index, bSetValues, true);
+#define ConvertLangValue2(buf, id) ConvertLangValueImpl(buf, std::size(buf), id, values, index, bSetValues, false);
 
 /*!
 	国際化対応のための文字列を変更する
@@ -1239,7 +1239,7 @@ void CShareData::InitToolButtons(DLLSHAREDATA* pShareData)
 
 	//	ツールバーアイコン数の最大値を超えないためのおまじない
 	//	最大値を超えて定義しようとするとここでコンパイルエラーになります．
-	char dummy[ _countof(DEFAULT_TOOL_BUTTONS) < MAX_TOOLBAR_BUTTON_ITEMS ? 1:0 ];
+	char dummy[ std::size(DEFAULT_TOOL_BUTTONS) < MAX_TOOLBAR_BUTTON_ITEMS ? 1:0 ];
 	dummy[0]=0;
 
 	memcpy_raw(
@@ -1249,7 +1249,7 @@ void CShareData::InitToolButtons(DLLSHAREDATA* pShareData)
 	);
 
 	/* ツールバーボタンの数 */
-	pShareData->m_Common.m_sToolBar.m_nToolBarButtonNum = _countof(DEFAULT_TOOL_BUTTONS);
+	pShareData->m_Common.m_sToolBar.m_nToolBarButtonNum = std::size(DEFAULT_TOOL_BUTTONS);
 	pShareData->m_Common.m_sToolBar.m_bToolBarIsFlat = !IsVisualStyle();			/* フラットツールバーにする／しない */	// 2006.06.23 ryoji ビジュアルスタイルでは初期値をノーマルにする
 }
 
@@ -1484,7 +1484,7 @@ std::vector<STypeConfig*>& CShareData::GetTypeSettings()
 void CShareData::InitFileTree( SFileTree* setting )
 {
 	setting->m_bProject = true;
-	for(int i = 0; i < (int)_countof(setting->m_aItems); i++){
+	for(int i = 0; i < (int)std::size(setting->m_aItems); i++){
 		SFileTreeItem& item = setting->m_aItems[i];
 		item.m_eFileTreeItemType = EFileTreeItemType_Grep;
 		item.m_szTargetPath = L"";

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -122,7 +122,7 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 		if( pShareData->m_sVersion.m_dwProductVersionMS > dwMS
 			|| (pShareData->m_sVersion.m_dwProductVersionMS == dwMS && pShareData->m_sVersion.m_dwProductVersionLS > dwLS) )
 		{
-			WCHAR szBkFileName[_countof(szIniFileName) + 4];
+			WCHAR szBkFileName[std::size(szIniFileName) + 4];
 			::lstrcpy(szBkFileName, szIniFileName);
 			::lstrcat(szBkFileName, L".bak");
 			::CopyFile(szIniFileName, szBkFileName, FALSE);
@@ -952,7 +952,7 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 		cProfile.IOProfileData( pszSecName, szKeyName, menu.m_bCustMenuPopupArr[i] );
 		auto_sprintf( szKeyName, LTEXT("nCMIN[%02d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, menu.m_nCustMenuItemNumArr[i] );
-		SetValueLimit( menu.m_nCustMenuItemNumArr[i], _countof(menu.m_nCustMenuItemFuncArr[0]) );
+		SetValueLimit( menu.m_nCustMenuItemNumArr[i], std::size(menu.m_nCustMenuItemFuncArr[0]) );
 		int nSize = menu.m_nCustMenuItemNumArr[i];
 		for( j = 0; j < nSize; ++j ){
 			// start マクロ名でも設定できるように 2008/5/24 Uchi
@@ -1039,7 +1039,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 //	int		nSize = m_pShareData->m_nKeyNameArrNum;
 	WCHAR	szWork[MAX_PLUGIN_ID+20+4];
 	bool	bOldVer = false;
-	const int KEYNAME_SIZE = _countof(sKeyBind.m_pKeyNameArr)-1;// 最後の１要素はダミー用に予約 2012.11.25 aroka
+	const int KEYNAME_SIZE = std::size(sKeyBind.m_pKeyNameArr)-1;// 最後の１要素はダミー用に予約 2012.11.25 aroka
 	int nKeyNameArrUsed = sKeyBind.m_nKeyNameArrNum; // 使用済み領域
 
 	if( cProfile.IsReadingMode() ){ 
@@ -1107,8 +1107,8 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 						p = pn+1;
 					}
 					// KeyName
-					wcsncpy(tmpKeydata.m_szKeyName, p, _countof(tmpKeydata.m_szKeyName)-1);
-					tmpKeydata.m_szKeyName[_countof(tmpKeydata.m_szKeyName)-1] = '\0';
+					wcsncpy(tmpKeydata.m_szKeyName, p, std::size(tmpKeydata.m_szKeyName)-1);
+					tmpKeydata.m_szKeyName[std::size(tmpKeydata.m_szKeyName)-1] = '\0';
 
 					if( tmpKeydata.m_nKeyCode <= 0 ){ // マウスコードは先頭に固定されている KeyCodeが同じなのでKeyNameで判別
 						// 2013.10.23 syat マウスのキーコードを拡張仮想キーコードに変更。以下は互換性のため残す。
@@ -1622,7 +1622,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("nImeState")			, types.m_nImeState );	//	IME制御
 
 	//	2001/06/14 Start By asa-o: タイプ別の補完ファイル
-	//	Oct. 5, 2002 genta _countof()で誤ってポインタのサイズを取得していたのを修正
+	//	Oct. 5, 2002 genta std::size()で誤ってポインタのサイズを取得していたのを修正
 	cProfile.IOProfileData( pszSecName, LTEXT("szHokanFile")		, types.m_szHokanFile );		//	補完ファイル
 	//	2001/06/14 End
 	cProfile.IOProfileData( pszSecName, LTEXT("nHokanType")			, types.m_nHokanType );		//	補完種別
@@ -1680,8 +1680,8 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		cProfile.IOProfileData( pszSecName, LTEXT("bUseRegexKeyword"), types.m_bUseRegexKeyword );/* 正規表現キーワード使用するか？ */
 		wchar_t* pKeyword = types.m_RegexKeywordList;
 		int nPos = 0;
-		int nKeywordSize = _countof(types.m_RegexKeywordList);
-		for(j = 0; j < _countof(types.m_RegexKeywordArr); j++)
+		int nKeywordSize = std::size(types.m_RegexKeywordList);
+		for(j = 0; j < std::size(types.m_RegexKeywordArr); j++)
 		{
 			auto_sprintf( szKeyName, LTEXT("RxKey[%03d]"), j );
 			if( cProfile.IsReadingMode() )
@@ -2039,7 +2039,7 @@ void CShareData_IO::ShareData_IO_MainMenu( CDataProfile& cProfile )
 			{1, F_MODIFYLINE_PREV_SEL, F_MODIFYLINE_NEXT_SEL, L'\0', false, false}, 	// (選択)前の変更行へ
 			{2, F_DLGWINLIST, F_WIN_OUTPUT, L'D', false, false}, 	// ウインドウ一覧表示
 		};
-		for( int i = 0; i < _countof(addInfos); i++ ){
+		for( int i = 0; i < std::size(addInfos); i++ ){
 			SMainMenuAddItemInfo& item = addInfos[i];
 			if( item.m_nVer <= nVersion ){
 				continue;
@@ -2058,7 +2058,7 @@ void CShareData_IO::ShareData_IO_MainMenu( CDataProfile& cProfile )
 			if( item.m_bAddNextSeparete ){
 				nAddSep++;
 			}
-			if( k == mainmenu.m_nMainMenuNum && mainmenu.m_nMainMenuNum + nAddSep < _countof(mainmenu.m_cMainMenuTbl) ){
+			if( k == mainmenu.m_nMainMenuNum && mainmenu.m_nMainMenuNum + nAddSep < std::size(mainmenu.m_cMainMenuTbl) ){
 				// メニュー内にまだ追加されていないので追加する
 				for( int r = 0; r < mainmenu.m_nMainMenuNum; r++ ){
 					if( pcMenuTlb[r].m_nFunc == item.m_nPrevFuncCode && 0 < pcMenuTlb[r].m_nLevel ){
@@ -2451,7 +2451,7 @@ void CShareData_IO::ShareData_IO_FileTree( CDataProfile& cProfile, SFileTree& fi
 	cProfile.IOProfileData( pszSecName, L"bFileTreeProject", fileTree.m_bProject );
 	cProfile.IOProfileData( pszSecName, L"szFileTreeProjectIni", fileTree.m_szProjectIni );
 	cProfile.IOProfileData( pszSecName, L"nFileTreeItemCount", fileTree.m_nItemCount );
-	SetValueLimit( fileTree.m_nItemCount, _countof(fileTree.m_aItems) );
+	SetValueLimit( fileTree.m_nItemCount, std::size(fileTree.m_aItems) );
 	for( int i = 0;i < fileTree.m_nItemCount; i++ ){
 		ShareData_IO_FileTreeItem( cProfile, fileTree.m_aItems[i], pszSecName, i );
 	}

--- a/sakura_core/env/CommonSetting.cpp
+++ b/sakura_core/env/CommonSetting.cpp
@@ -44,7 +44,7 @@ struct CommonValueInfo{
 	CommonValueInfo(void* pValue, int nValueSize, const char* szEntryKey, EType eType=TYPE_UNKNOWN)
 	: m_pValue(pValue), m_nValueSize(nValueSize), m_eType(eType)
 	{
-		strcpy_s(m_szEntryKey,_countof(m_szEntryKey),szEntryKey);
+		strcpy_s(m_szEntryKey,std::size(m_szEntryKey),szEntryKey);
 	}
 
 	void Save()

--- a/sakura_core/extmodule/CMigemo.cpp
+++ b/sakura_core/extmodule/CMigemo.cpp
@@ -258,7 +258,7 @@ int CMigemo::migemo_load_a(int dict_id, const char* dict_file)
 int CMigemo::migemo_load_w(int dict_id, const wchar_t* dict_file)
 {
 	char szBuf[_MAX_PATH];
-	wcstombs2(szBuf,dict_file,_countof(szBuf));
+	wcstombs2(szBuf,dict_file,std::size(szBuf));
 	return migemo_load_a(dict_id,szBuf);
 }
 

--- a/sakura_core/func/CFuncKeyWnd.cpp
+++ b/sakura_core/func/CFuncKeyWnd.cpp
@@ -57,13 +57,13 @@ CFuncKeyWnd::CFuncKeyWnd()
 	/* 共有データ構造体のアドレスを返す */
 	m_pShareData = &GetDllShareData();
 	m_nCurrentKeyState = -1;
-	for( i = 0; i < _countof(m_szFuncNameArr); ++i ){
+	for( i = 0; i < std::size(m_szFuncNameArr); ++i ){
 		m_szFuncNameArr[i][0] = LTEXT('\0');
 	}
 //	2002.11.04 Moca Open()側で設定
 //	m_nButtonGroupNum = 4;
 
-	for( i = 0; i < _countof( m_hwndButtonArr ); ++i ){
+	for( i = 0; i < std::size( m_hwndButtonArr ); ++i ){
 		m_hwndButtonArr[i] = NULL;
 	}
 
@@ -194,7 +194,7 @@ LRESULT CFuncKeyWnd::OnSize( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam 
 		return 0L;
 	}
 
-	nButtonNum = _countof( m_hwndButtonArr );
+	nButtonNum = std::size( m_hwndButtonArr );
 
 	/* ボタンのサイズを計算 */
 	nButtonWidth = CalcButtonSize();
@@ -251,7 +251,7 @@ LRESULT CFuncKeyWnd::OnCommand( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 	hwndCtl = (HWND) lParam;		// handle of control
 //	switch( wNotifyCode ){
 //	case BN_PUSHED:
-		for( i = 0; i < _countof( m_hwndButtonArr ); ++i ){
+		for( i = 0; i < std::size( m_hwndButtonArr ); ++i ){
 			if( hwndCtl == m_hwndButtonArr[i] ){
 				if( 0 != m_nFuncCodeArr[i] ){
 					::SendMessageCmd( GetParentHwnd(), WM_COMMAND, MAKELONG( m_nFuncCodeArr[i], 0 ),  (LPARAM)hwnd );
@@ -294,7 +294,7 @@ LRESULT CFuncKeyWnd::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 		m_nTimerCount = TIMER_CHECKFUNCENABLE + 1;
 
 		/* ファンクションキーの機能名を取得 */
-		for( i = 0; i < _countof( m_szFuncNameArr ); ++i ){
+		for( i = 0; i < std::size( m_szFuncNameArr ); ++i ){
 			// 2007.02.22 ryoji CKeyBind::GetFuncCode()を使う
 			EFunctionCode	nFuncCode = CKeyBind::GetFuncCode(
 					(WORD)(((VK_F1 + i) | ((WORD)((BYTE)(nIdx))) << 8)),
@@ -310,7 +310,7 @@ LRESULT CFuncKeyWnd::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 					m_pcEditDoc->m_cFuncLookup.Funccode2Name(
 						m_nFuncCodeArr[i],
 						m_szFuncNameArr[i],
-						_countof(m_szFuncNameArr[i]) - 1
+						std::size(m_szFuncNameArr[i]) - 1
 					);
 				}
 				Wnd_SetText( m_hwndButtonArr[i], m_szFuncNameArr[i] );
@@ -323,7 +323,7 @@ LRESULT CFuncKeyWnd::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 	){
 		m_nTimerCount = 0;
 		/* 機能が利用可能か調べる */
-		for( i = 0; i < _countof(	m_szFuncNameArr ); ++i ){
+		for( i = 0; i < std::size(	m_szFuncNameArr ); ++i ){
 			if( IsFuncEnable( (CEditDoc*)m_pcEditDoc, m_pShareData, m_nFuncCodeArr[i]  ) ){
 				::EnableWindow( m_hwndButtonArr[i], TRUE );
 			}else{
@@ -344,7 +344,7 @@ LRESULT CFuncKeyWnd::OnDestroy( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 	Timer_ONOFF( false ); // 20060126 aroka
 
 	/* ボタンを削除 */
-	for( i = 0; i < _countof( m_hwndButtonArr ); ++i ){
+	for( i = 0; i < std::size( m_hwndButtonArr ); ++i ){
 		if( NULL != m_hwndButtonArr[i] ){
 			::DestroyWindow( m_hwndButtonArr[i]	);
 			m_hwndButtonArr[i] = NULL;
@@ -371,7 +371,7 @@ int CFuncKeyWnd::CalcButtonSize( void )
 	int			nCxVScroll;
 	::GetWindowRect( GetHwnd(), &rc );
 
-	nButtonNum = _countof( m_hwndButtonArr );
+	nButtonNum = std::size( m_hwndButtonArr );
 
 	if( NULL == m_hwndSizeBox ){
 //		return ( rc.right - rc.left - nButtonNum - ( (nButtonNum + m_nButtonGroupNum - 1) / m_nButtonGroupNum - 1 ) * 12 ) / nButtonNum;
@@ -400,11 +400,11 @@ void CFuncKeyWnd::CreateButtons( void )
 	::GetWindowRect( GetHwnd(), &rcParent );
 	nButtonHeight = rcParent.bottom - rcParent.top - 2;
 
-	for( i = 0; i < _countof(	m_nFuncCodeArr ); ++i ){
+	for( i = 0; i < std::size(	m_nFuncCodeArr ); ++i ){
 		m_nFuncCodeArr[i] = F_0;
 	}
 
-	for( i = 0; i < _countof( m_hwndButtonArr ); ++i ){
+	for( i = 0; i < std::size( m_hwndButtonArr ); ++i ){
 		m_hwndButtonArr[i] = ::CreateWindow(
 			WC_BUTTON,							// predefined class
 			L"",								// button text

--- a/sakura_core/func/CFuncLookup.cpp
+++ b/sakura_core/func/CFuncLookup.cpp
@@ -240,7 +240,7 @@ void CFuncLookup::SetListItem( HWND hListBox, int category ) const
 	for( i = 0; i < n; i++ ){
 		if( Pos2FuncCode( category, i ) == F_DISABLE )
 			continue;
-		Pos2FuncName( category, i, pszLabel, _countof(pszLabel) );
+		Pos2FuncName( category, i, pszLabel, std::size(pszLabel) );
 		List_AddString( hListBox, pszLabel );
 	}
 }

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -397,27 +397,27 @@ WCHAR*	CKeyBind::MakeMenuLabel(const WCHAR* sName, const WCHAR* sKey)
 		if( !GetDllShareData().m_Common.m_sMainMenu.m_bMainMenuKeyParentheses
 			  && (((p = wcschr( sName, sKey[0])) != NULL) || ((p = wcschr( sName, _totlower(sKey[0]))) != NULL)) ){
 			// 欧文風、使用している文字をアクセスキーに
-			wcscpy_s( sLabel, _countof(sLabel), sName );
+			wcscpy_s( sLabel, std::size(sLabel), sName );
 			sLabel[p-sName] = L'&';
-			wcscpy_s( sLabel + (p-sName) + 1, _countof(sLabel), p );
+			wcscpy_s( sLabel + (p-sName) + 1, std::size(sLabel), p );
 		}
 		else if( (p = wcschr( sName, L'(' )) != NULL
 			  && (p = wcschr( p, sKey[0] )) != NULL) {
 			// (付その後にアクセスキー
-			wcscpy_s( sLabel, _countof(sLabel), sName );
+			wcscpy_s( sLabel, std::size(sLabel), sName );
 			sLabel[p-sName] = L'&';
-			wcscpy_s( sLabel + (p-sName) + 1, _countof(sLabel), p );
+			wcscpy_s( sLabel + (p-sName) + 1, std::size(sLabel), p );
 		}
 		else if (wcscmp( sName + wcslen(sName) - 3, L"..." ) == 0) {
 			// 末尾...
-			wcscpy_s( sLabel, _countof(sLabel), sName );
+			wcscpy_s( sLabel, std::size(sLabel), sName );
 			sLabel[wcslen(sName) - 3] = '\0';						// 末尾の...を取る
 			wcscat_s( sLabel, L"(&" );
 			wcscat_s( sLabel, sKey );
 			wcscat_s( sLabel, L")..." );
 		}
 		else {
-			auto_sprintf_s( sLabel, _countof(sLabel), L"%s(&%s)", sName, sKey );
+			auto_sprintf_s( sLabel, std::size(sLabel), L"%s(&%s)", sName, sKey );
 		}
 
 		return sLabel;
@@ -779,7 +779,7 @@ const WCHAR* jpVKEXNames[] = {
 	L"ホイール左",
 	L"ホイール右"
 };
-const int jpVKEXNamesLen = _countof( jpVKEXNames );
+const int jpVKEXNamesLen = std::size( jpVKEXNames );
 
 /*!	@brief 共有メモリ初期化/キー割り当て
 
@@ -793,8 +793,8 @@ bool CShareData::InitKeyAssign(DLLSHAREDATA* pShareData)
 	/********************/
 	/* 共通設定の規定値 */
 	/********************/
-	const int	nKeyDataInitNum = _countof( KeyDataInit );
-	const int	KEYNAME_SIZE = _countof( pShareData->m_Common.m_sKeyBind.m_pKeyNameArr ) -1;// 最後の１要素はダミー用に予約 2012.11.25 aroka
+	const int	nKeyDataInitNum = std::size( KeyDataInit );
+	const int	KEYNAME_SIZE = std::size( pShareData->m_Common.m_sKeyBind.m_pKeyNameArr ) -1;// 最後の１要素はダミー用に予約 2012.11.25 aroka
 	//	From Here 2007.11.04 genta バッファオーバーラン防止
 	assert( !(nKeyDataInitNum > KEYNAME_SIZE) );
 //	if( nKeyDataInitNum > KEYNAME_SIZE ) {
@@ -811,7 +811,7 @@ bool CShareData::InitKeyAssign(DLLSHAREDATA* pShareData)
 	// インデックス用ダミー作成
 	SetKeyNameArrVal( pShareData, KEYNAME_SIZE, &dummy[0] );
 	// インデックス作成 重複した場合は先頭にあるものを優先
-	for( int ii = 0; ii< _countof(pShareData->m_Common.m_sKeyBind.m_VKeyToKeyNameArr); ii++ ){
+	for( int ii = 0; ii< std::size(pShareData->m_Common.m_sKeyBind.m_VKeyToKeyNameArr); ii++ ){
 		pShareData->m_Common.m_sKeyBind.m_VKeyToKeyNameArr[ii] = KEYNAME_SIZE;
 	}
 	for( int i=nKeyDataInitNum-1; i>=0; i-- ){
@@ -828,7 +828,7 @@ bool CShareData::InitKeyAssign(DLLSHAREDATA* pShareData)
 /*!	@brief 言語選択後の文字列更新処理 */
 void CShareData::RefreshKeyAssignString(DLLSHAREDATA* pShareData)
 {
-	const int	nKeyDataInitNum = _countof( KeyDataInit );
+	const int	nKeyDataInitNum = std::size( KeyDataInit );
 
 	for( int i = 0; i < nKeyDataInitNum; ++i ){
 		KEYDATA* pKeydata = &pShareData->m_Common.m_sKeyBind.m_pKeyNameArr[i];

--- a/sakura_core/func/Funccode.cpp
+++ b/sakura_core/func/Funccode.cpp
@@ -83,7 +83,7 @@ const uint16_t nsFuncCode::ppszFuncKind[] = {
 	STR_ERR_DLGFUNCLKUP17,	//L"支援",
 	STR_ERR_DLGFUNCLKUP18	//L"その他"
 };
-const int nsFuncCode::nFuncKindNum = _countof(nsFuncCode::ppszFuncKind);
+const int nsFuncCode::nFuncKindNum = std::size(nsFuncCode::ppszFuncKind);
 
 /* ファイル操作系 */
 const EFunctionCode pnFuncList_File[] = {	//Oct. 16, 2000 JEPRO 変数名変更(List5→List_File)
@@ -128,7 +128,7 @@ const EFunctionCode pnFuncList_File[] = {	//Oct. 16, 2000 JEPRO 変数名変更(
 	F_EXITALLEDITORS	,	//編集の全終了	// 2007.02.13 ryoji F_WIN_CLOSEALL→F_EXITALLEDITORS
 	F_EXITALL				//サクラエディタの全終了	//Dec. 27, 2000 JEPRO 追加
 };
-const int nFincList_File_Num = _countof( pnFuncList_File );	//Oct. 16, 2000 JEPRO 配列名変更(FuncList5→FuncList_File)
+const int nFincList_File_Num = std::size( pnFuncList_File );	//Oct. 16, 2000 JEPRO 配列名変更(FuncList5→FuncList_File)
 
 /* 編集系 */
 const EFunctionCode pnFuncList_Edit[] = {	//Oct. 16, 2000 JEPRO 変数名変更(List3→List_Edit)
@@ -159,7 +159,7 @@ const EFunctionCode pnFuncList_Edit[] = {	//Oct. 16, 2000 JEPRO 変数名変更(
 	F_RECONVERT				//再変換 				2002.04.09 minfu
 //		F_WORDSREFERENCE		//単語リファレンス
 };
-const int nFincList_Edit_Num = _countof( pnFuncList_Edit );	//Oct. 16, 2000 JEPRO 変数名変更(List3→List_Edit)
+const int nFincList_Edit_Num = std::size( pnFuncList_Edit );	//Oct. 16, 2000 JEPRO 変数名変更(List3→List_Edit)
 
 /* カーソル移動系 */
 const EFunctionCode pnFuncList_Move[] = {	//Oct. 16, 2000 JEPRO 変数名変更(List1→List_Move)
@@ -205,7 +205,7 @@ const EFunctionCode pnFuncList_Move[] = {	//Oct. 16, 2000 JEPRO 変数名変更(
 	F_MODIFYLINE_NEXT	,	//次の変更行へ移動
 	F_MODIFYLINE_PREV	,	//前の変更行へ移動
 };
-const int nFincList_Move_Num = _countof( pnFuncList_Move );	//Oct. 16, 2000 JEPRO 変数名変更(List1→List_Move)
+const int nFincList_Move_Num = std::size( pnFuncList_Move );	//Oct. 16, 2000 JEPRO 変数名変更(List1→List_Move)
 
 /* 選択系 */	//Oct. 15, 2000 JEPRO 「カーソル移動系」から(選択)を移動
 const EFunctionCode pnFuncList_Select[] = {
@@ -236,7 +236,7 @@ const EFunctionCode pnFuncList_Select[] = {
 	F_MODIFYLINE_NEXT_SEL	,	//(範囲選択)次の変更行へ移動
 	F_MODIFYLINE_PREV_SEL	,	//(範囲選択)前の変更行へ移動
 };
-const int nFincList_Select_Num = _countof( pnFuncList_Select );
+const int nFincList_Select_Num = std::size( pnFuncList_Select );
 
 /* 矩形選択系 */	//Oct. 17, 2000 JEPRO (矩形選択)が新設され次第ここにおく
 const EFunctionCode pnFuncList_Box[] = {
@@ -260,7 +260,7 @@ const EFunctionCode pnFuncList_Box[] = {
 	F_GOFILETOP_BOX		,	//(矩形選択)ファイルの先頭に移動
 	F_GOFILEEND_BOX			//(矩形選択)ファイルの最後に移動
 };
-const int nFincList_Box_Num = _countof( pnFuncList_Box );
+const int nFincList_Box_Num = std::size( pnFuncList_Box );
 
 /* クリップボード系 */
 const EFunctionCode pnFuncList_Clip[] = {	//Oct. 16, 2000 JEPRO 変数名変更(List2→List_Clip)
@@ -283,7 +283,7 @@ const EFunctionCode pnFuncList_Clip[] = {	//Oct. 16, 2000 JEPRO 変数名変更(
 	F_COPYTAG					,	//このファイルのパス名とカーソル位置をコピー	//Sept. 14, 2000 JEPRO メニューに合わせて下に移動
 	F_CREATEKEYBINDLIST				//キー割り当て一覧をコピー	//Sept. 15, 2000 JEPRO IDM_TESTのままではうまくいかないのでFに変えて登録	//Dec. 25, 2000 復活
 };
-const int nFincList_Clip_Num = _countof( pnFuncList_Clip );	//Oct. 16, 2000 JEPRO 変数名変更(List1→List_Move)
+const int nFincList_Clip_Num = std::size( pnFuncList_Clip );	//Oct. 16, 2000 JEPRO 変数名変更(List1→List_Move)
 
 /* 挿入系 */
 const EFunctionCode pnFuncList_Insert[] = {
@@ -293,7 +293,7 @@ const EFunctionCode pnFuncList_Insert[] = {
 	F_INS_FILE_USED_RECENTLY,	// 最近使ったファイル挿入
 	F_INS_FOLDER_USED_RECENTLY,	// 最近使ったフォルダ挿入
 };
-const int nFincList_Insert_Num = _countof( pnFuncList_Insert );
+const int nFincList_Insert_Num = std::size( pnFuncList_Insert );
 
 /* 変換系 */
 const EFunctionCode pnFuncList_Convert[] = {	//Oct. 16, 2000 JEPRO 変数名変更(List6→List_Convert)
@@ -327,7 +327,7 @@ const EFunctionCode pnFuncList_Convert[] = {	//Oct. 16, 2000 JEPRO 変数名変�
 	//Sept. 30, 2000JEPRO コメントアウトされてあったのを復活させた(動作しないのかも？)
 	//Oct. 17, 2000 jepro 説明を「選択部分をUUENCODEデコード」から変更
 };
-const int nFincList_Convert_Num = _countof( pnFuncList_Convert );	//Oct. 16, 2000 JEPRO 変数名変更(List6→List_Convert)
+const int nFincList_Convert_Num = std::size( pnFuncList_Convert );	//Oct. 16, 2000 JEPRO 変数名変更(List6→List_Convert)
 
 /* 検索系 */
 const EFunctionCode pnFuncList_Search[] = {	//Oct. 16, 2000 JEPRO 変数名変更(List4→List_Search)
@@ -370,7 +370,7 @@ const EFunctionCode pnFuncList_Search[] = {	//Oct. 16, 2000 JEPRO 変数名変�
 	F_FUNCLIST_NEXT		,	//次の関数リストマーク
 	F_FUNCLIST_PREV		,	//前の関数リストマーク
 };
-const int nFincList_Search_Num = _countof( pnFuncList_Search );	//Oct. 16, 2000 JEPRO 変数名変更(List4→List_Search)
+const int nFincList_Search_Num = std::size( pnFuncList_Search );	//Oct. 16, 2000 JEPRO 変数名変更(List4→List_Search)
 
 /* モード切り替え系 */	//Oct. 16, 2000 JEPRO 変数名変更(List8→List_Mode)
 const EFunctionCode pnFuncList_Mode[] = {
@@ -381,7 +381,7 @@ const EFunctionCode pnFuncList_Mode[] = {
 	F_CHGMOD_EOL_CR		,	//入力改行コード指定(CR)	2003.06.23 Moca
 	F_CANCEL_MODE			//各種モードの取り消し
 };
-const int nFincList_Mode_Num = _countof( pnFuncList_Mode );	//Oct. 16, 2000 JEPRO 変数名変更(List8→List_Mode)
+const int nFincList_Mode_Num = std::size( pnFuncList_Mode );	//Oct. 16, 2000 JEPRO 変数名変更(List8→List_Mode)
 
 /* 設定系 */
 const EFunctionCode pnFuncList_Set[] = {	//Oct. 16, 2000 JEPRO 変数名変更(List9→List_Set)
@@ -404,7 +404,7 @@ const EFunctionCode pnFuncList_Set[] = {	//Oct. 16, 2000 JEPRO 変数名変更(L
 	F_TMPWRAPWINDOW		,	//右端で折り返す（一時設定）		// 2008.05.30 nasukoji
 	F_SELECT_COUNT_MODE		//文字カウント設定	// 2009.07.06 syat
 };
-int		nFincList_Set_Num = _countof( pnFuncList_Set );	//Oct. 16, 2000 JEPRO 変数名変更(List9→List_Set)
+int		nFincList_Set_Num = std::size( pnFuncList_Set );	//Oct. 16, 2000 JEPRO 変数名変更(List9→List_Set)
 
 /* マクロ系 */
 const EFunctionCode pnFuncList_Macro[] = {	//Oct. 16, 2000 JEPRO 変数名変更(List10→List_Macro)
@@ -418,7 +418,7 @@ const EFunctionCode pnFuncList_Macro[] = {	//Oct. 16, 2000 JEPRO 変数名変更
 	F_EXECMD_DIALOG		/* 外部コマンド実行 */
 //	To Here Sept. 20, 2000
 };
-const int nFincList_Macro_Num = _countof( pnFuncList_Macro);	//Oct. 16, 2000 JEPRO 変数名変更(List10→List_Macro)
+const int nFincList_Macro_Num = std::size( pnFuncList_Macro);	//Oct. 16, 2000 JEPRO 変数名変更(List10→List_Macro)
 
 /* カスタムメニュー */	//Oct. 21, 2000 JEPRO 「その他」から分離独立化
 #if 0
@@ -451,7 +451,7 @@ const EFunctionCode pnFuncList_Menu[] = {
 	F_CUSTMENU_23				,	/* カスタムメニュー23 */
 	F_CUSTMENU_24				 	/* カスタムメニュー24 */
 };
-const int nFincList_Menu_Num = _countof( pnFuncList_Menu );	//Oct. 21, 2000 JEPRO 「その他」から分離独立化
+const int nFincList_Menu_Num = std::size( pnFuncList_Menu );	//Oct. 21, 2000 JEPRO 「その他」から分離独立化
 #endif
 
 /* ウィンドウ系 */
@@ -487,7 +487,7 @@ const EFunctionCode pnFuncList_Win[] = {	//Oct. 16, 2000 JEPRO 変数名変更(L
 	F_REDRAW			,	//再描画
 	F_WIN_OUTPUT		,	//アウトプットウィンドウ表示
 };
-const int nFincList_Win_Num = _countof( pnFuncList_Win );	//Oct. 16, 2000 JEPRO 変数名変更(List7→List_Win)
+const int nFincList_Win_Num = std::size( pnFuncList_Win );	//Oct. 16, 2000 JEPRO 変数名変更(List7→List_Win)
 
 /* 支援 */
 const EFunctionCode pnFuncList_Support[] = {	//Oct. 16, 2000 JEPRO 変数名変更(List11→List_Support)
@@ -501,13 +501,13 @@ const EFunctionCode pnFuncList_Support[] = {	//Oct. 16, 2000 JEPRO 変数名変�
 	F_EXTHTMLHELP				,	/* 外部HTMLヘルプ */
 	F_ABOUT							/* バージョン情報 */	//Dec. 24, 2000 JEPRO 追加
 };
-const int nFincList_Support_Num = _countof( pnFuncList_Support );	//Oct. 16, 2000 JEPRO 変数名変更(List11→List_Support)
+const int nFincList_Support_Num = std::size( pnFuncList_Support );	//Oct. 16, 2000 JEPRO 変数名変更(List11→List_Support)
 
 /* その他 */	//Oct. 16, 2000 JEPRO 変数名変更(List12→List_Others)
 const EFunctionCode pnFuncList_Others[] = {
 	F_DISABLE				//Oct. 21, 2000 JEPRO 何もないとエラーになってしまうのでダミーで[未定義]を入れておく
 };
-const int nFincList_Others_Num = _countof( pnFuncList_Others );	//Oct. 16, 2000 JEPRO 変数名変更(List12→List_Others)
+const int nFincList_Others_Num = std::size( pnFuncList_Others );	//Oct. 16, 2000 JEPRO 変数名変更(List12→List_Others)
 
 // 特殊機能
 const EFunctionCode nsFuncCode::pnFuncList_Special[] = {
@@ -518,7 +518,7 @@ const EFunctionCode nsFuncCode::pnFuncList_Special[] = {
 	F_USERMACRO_LIST,
 	F_PLUGIN_LIST,
 };
-const int nsFuncCode::nFuncList_Special_Num = (int)_countof(nsFuncCode::pnFuncList_Special);
+const int nsFuncCode::nFuncList_Special_Num = (int)std::size(nsFuncCode::pnFuncList_Special);
 
 const int nsFuncCode::pnFuncListNumArr[] = {
 //	nFincList_Undef_Num,	//Oct. 14, 2000 JEPRO 「--未定義--」を表示させないように変更	//Oct. 16, 2000 JEPRO 変数名変更(List0→List_Undef)
@@ -560,7 +560,7 @@ const EFunctionCode* nsFuncCode::ppnFuncListArr[] = {
 	pnFuncList_Support,/* 支援 */				//Oct. 16, 2000 JEPRO 変数名変更(List11→List_Support)
 	pnFuncList_Others	/* その他 */			//Oct. 16, 2000 JEPRO 変数名変更(List12→List_Others)
 };
-const int nsFuncCode::nFincListNumArrNum = _countof( nsFuncCode::pnFuncListNumArr );
+const int nsFuncCode::nFincListNumArrNum = std::size( nsFuncCode::pnFuncListNumArr );
 
 //! 機能番号に応じてヘルプトピック番号を返す
 /*!

--- a/sakura_core/io/CFileLoad.cpp
+++ b/sakura_core/io/CFileLoad.cpp
@@ -90,7 +90,7 @@ std::wstring CFileLoad::GetSizeStringForHuman(ULONGLONG size)
 
 	// to string
 	wchar_t buf[32];
-	swprintf_s(buf, _countof(buf), L"%I64u", megabytes);
+	swprintf_s(buf, std::size(buf), L"%I64u", megabytes);
 	std::wstring str = buf;
 
 	// https://stackoverflow.com/questions/7276826/c-format-number-with-commas
@@ -247,7 +247,7 @@ ECodeType CFileLoad::FileOpen( LPCWSTR pFileName, bool bBigFile, ECodeType CharC
 	m_pCodeBase->GetEol( &m_memEols[2], EOL_PS );
 	bool bEolEx = false;
 	int  nMaxEolLen = 0;
-	for( int k = 0; k < (int)_countof(m_memEols); k++ ){
+	for( int k = 0; k < (int)std::size(m_memEols); k++ ){
 		if( 0 != m_memEols[k].GetRawLength() ){
 			bEolEx = true;
 			nMaxEolLen = t_max(nMaxEolLen, m_memEols[k].GetRawLength());
@@ -534,7 +534,7 @@ const char* CFileLoad::GetNextLineCharCode(
 				}
 				if( m_bEolEx ){
 					int k;
-					for( k = 0; k < (int)_countof(eEolEx); k++ ){
+					for( k = 0; k < (int)std::size(eEolEx); k++ ){
 						if( 0 != m_memEols[k].GetRawLength() && i + m_memEols[k].GetRawLength() - 1 < nDataLen
 								&& 0 == memcmp( m_memEols[k].GetRawPtr(), pData + i, m_memEols[k].GetRawLength()) ){
 							pcEol->SetType(eEolEx[k]);
@@ -542,7 +542,7 @@ const char* CFileLoad::GetNextLineCharCode(
 							break;
 						}
 					}
-					if( k != (int)_countof(eEolEx) ){
+					if( k != (int)std::size(eEolEx) ){
 						break;
 					}
 				}
@@ -552,7 +552,7 @@ const char* CFileLoad::GetNextLineCharCode(
 				for( i = t_max(0, nDataLen - m_nMaxEolLen - 1); i < nDataLen; i++ ){
 					int k;
 					bool bSet = false;
-					for( k = 0; k < (int)_countof(eEolEx); k++ ){
+					for( k = 0; k < (int)std::size(eEolEx); k++ ){
 						int nCompLen = t_min(nDataLen - i, m_memEols[k].GetRawLength());
 						if( 0 != nCompLen && 0 == memcmp(m_memEols[k].GetRawPtr(), pData + i, nCompLen) ){
 							*pnBufferNext = t_max(*pnBufferNext, nCompLen);

--- a/sakura_core/io/CTextStream.cpp
+++ b/sakura_core/io/CTextStream.cpp
@@ -157,7 +157,7 @@ void CTextOutputStream::WriteF(const wchar_t* format, ...)
 	static wchar_t buf[16*1024]; //$$ 確保しすぎかも？
 	va_list v;
 	va_start(v,format);
-	auto_vsprintf_s(buf,_countof(buf),format,v);
+	auto_vsprintf_s(buf,std::size(buf),format,v);
 	va_end(v);
 
 	//出力

--- a/sakura_core/macro/CIfObj.cpp
+++ b/sakura_core/macro/CIfObj.cpp
@@ -376,7 +376,7 @@ void CIfObj::AddMethod(
 	Info->Desc.cParams = (SHORT)ArgumentCount + 1; //戻り値の分
 	Info->Desc.lprgelemdescParam = Info->Arguments;
 	//	Nov. 10, 2003 FILE Win9Xでは、[lstrcpyW]が無効のため、[wcscpy]に修正
-	assert( wcslen(Name)<_countof(Info->Name) );
+	assert( wcslen(Name)<std::size(Info->Name) );
 	wcscpy(Info->Name, Name);
 	Info->Method = Method;
 	Info->ID = ID;

--- a/sakura_core/macro/CKeyMacroMgr.cpp
+++ b/sakura_core/macro/CKeyMacroMgr.cpp
@@ -191,7 +191,7 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const WCHAR* pszPath )
 		szFuncName[0]='\0';// 初期化
 		for( ; i < nLineLen; ++i ){
 			//# バッファオーバーランチェック
-			if( szLine[i] == LTEXT('(') && (i - nBgn)< _countof(szFuncName) ){
+			if( szLine[i] == LTEXT('(') && (i - nBgn)< std::size(szFuncName) ){
 				wmemcpy( szFuncName, &szLine[nBgn], i - nBgn );
 				szFuncName[i - nBgn] = L'\0';
 				++i;
@@ -209,7 +209,7 @@ BOOL CKeyMacroMgr::LoadKeyMacro( HINSTANCE hInstance, const WCHAR* pszPath )
 			// Jun. 16, 2002 genta プロトタイプチェック用に追加
 			int nArgs;
 			const MacroFuncInfo* mInfo= CSMacroMgr::GetFuncInfoByID( nFuncID );
-			int nArgSizeMax = _countof( mInfo->m_varArguments );
+			int nArgSizeMax = std::size( mInfo->m_varArguments );
 			if( mInfo->m_pData  ){
 				nArgSizeMax = mInfo->m_pData->m_nArgMaxSize;
 			}

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -614,7 +614,7 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 		//	Jun. 08, 2003 Moca 呼び出し側でパス名を用意
 		//	Jun. 16, 2003 genta 書式をちょっと変更
 		WCHAR ptr[_MAX_PATH * 2];
-		int n = CShareData::getInstance()->GetMacroFilename( idx, ptr, _countof(ptr) );
+		int n = CShareData::getInstance()->GetMacroFilename( idx, ptr, std::size(ptr) );
 		if ( n <= 0 ){
 			return FALSE;
 		}

--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -72,7 +72,7 @@ void CNativeA::AppendStringF(const char* pszData, ...)
 	// 整形
 	va_list v;
 	va_start(v, pszData);
-	int len = _vsnprintf_s(buf, _countof(buf), _TRUNCATE, pszData, v);
+	int len = _vsnprintf_s(buf, std::size(buf), _TRUNCATE, pszData, v);
 	int e = errno;
 	va_end(v);
 

--- a/sakura_core/mem/CRecycledBuffer.h
+++ b/sakura_core/mem/CRecycledBuffer.h
@@ -79,13 +79,13 @@ public:
 	CRecycledBufferDynamic()
 	{
 		m_current=0;
-		for(int i=0;i<_countof(m_buf);i++){
+		for(int i=0;i<std::size(m_buf);i++){
 			m_buf[i]=NULL;
 		}
 	}
 	~CRecycledBufferDynamic()
 	{
-		for(int i=0;i<_countof(m_buf);i++){
+		for(int i=0;i<std::size(m_buf);i++){
 			if(m_buf[i])delete[] m_buf[i];
 		}
 	}

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -138,7 +138,7 @@ void CDlgFileTree::SetData()
 	TreeView_DeleteAllItems(hwndTree);
 	bool bSaveShareData = (m_fileTreeSetting.m_szLoadProjectIni[0] == L'\0');
 	for( int i = 0; i < (int)m_fileTreeSetting.m_aItems.size(); i++ ){
-		int nMaxCount = _countof(GetDllShareData().m_Common.m_sOutline.m_sFileTree.m_aItems);
+		int nMaxCount = std::size(GetDllShareData().m_Common.m_sOutline.m_sFileTree.m_aItems);
 		if( bSaveShareData && nMaxCount < i + 1 ){
 			::InfoMessage(GetHwnd(), LS(STR_FILETREE_MAXCOUNT), nMaxCount);
 		}
@@ -228,7 +228,7 @@ void CDlgFileTree::ChangeEnableAddInsert()
 	if( bSaveShareData ){
 		int nCount = TreeView_GetCount(GetItemHwnd(IDC_TREE_FL));
 		bool bEnable = true;
-		int nMaxCount = _countof(GetDllShareData().m_Common.m_sOutline.m_sFileTree.m_aItems);
+		int nMaxCount = std::size(GetDllShareData().m_Common.m_sOutline.m_sFileTree.m_aItems);
 		if( nMaxCount < nCount ){
 			bEnable = false;
 		}
@@ -258,7 +258,7 @@ int CDlgFileTree::GetData()
 	}
 	bool bSaveShareData = (m_fileTreeSetting.m_szLoadProjectIni[0] == L'\0');
 	std::vector<SFileTreeItem> items;
-	if( !GetDataTree(items, TreeView_GetRoot(GetItemHwnd(IDC_TREE_FL)), 0, (bSaveShareData ? _countof(pFileTree->m_aItems) : 0) ) ){
+	if( !GetDataTree(items, TreeView_GetRoot(GetItemHwnd(IDC_TREE_FL)), 0, (bSaveShareData ? std::size(pFileTree->m_aItems) : 0) ) ){
 		InfoMessage(GetHwnd(), LS(STR_FILETREE_MAXCOUNT));
 	}
 	if( pFileTree ){
@@ -266,7 +266,7 @@ int CDlgFileTree::GetData()
 		DlgItem_GetText(hwndDlg, IDC_EDIT_DEFINI, pFileTree->m_szProjectIni, pFileTree->m_szProjectIni.GetBufferCount());
 		if( bSaveShareData ){
 			pFileTree->m_nItemCount = (int)items.size();
-			assert(pFileTree->m_nItemCount <= _countof(pFileTree->m_aItems));
+			assert(pFileTree->m_nItemCount <= std::size(pFileTree->m_aItems));
 			for( int i = 0; i < pFileTree->m_nItemCount; i++ ){
 				pFileTree->m_aItems[i] = items[i];
 			}
@@ -388,7 +388,7 @@ void CDlgFileTree::SetDataInit()
 		const int xWidth = calc.GetTextWidth(L"x");
 		const int ctrlWidth = rc.right - rc.left;
 		int nMaxCch = ctrlWidth / xWidth;
-		CFileNameManager::getInstance()->GetTransformFileNameFast(pFile, szFilePath, _countof(szFilePath), calc.GetDC(), true, nMaxCch);
+		CFileNameManager::getInstance()->GetTransformFileNameFast(pFile, szFilePath, std::size(szFilePath), calc.GetDC(), true, nMaxCch);
 		wsprintf(szMsg, LS(STR_FILETREE_FROM_FILE), szFilePath);
 		::SetWindowText(GetItemHwnd(IDC_STATIC_SETTFING_FROM), szMsg);
 		bEnableDefIni = FALSE;
@@ -437,7 +437,7 @@ static HTREEITEM FileTreeCopy( HWND hwndTree, HTREEITEM dst, HTREEITEM src, bool
 		tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_PARAM | TVIF_CHILDREN;
 		tvi.hItem = s;
 		tvi.pszText = szLabel;
-		tvi.cchTextMax = _countof(szLabel);
+		tvi.cchTextMax = std::size(szLabel);
 		if (!TreeView_GetItem( hwndTree, &tvi )) {
 			// Error
 			break;
@@ -535,7 +535,7 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 			if( IsDlgButtonCheckedBool(hwndDlg, IDC_RADIO_GREP) ){
 				// RADIO_GREP == folder
 				WCHAR szDir[MAX_PATH];
-				DlgItem_GetText(GetHwnd(), IDC_EDIT_PATH, szDir, _countof(szDir) );
+				DlgItem_GetText(GetHwnd(), IDC_EDIT_PATH, szDir, std::size(szDir) );
 				if( SelectDir(hwndDlg, LS(STR_DLGGREP1), szDir, szDir) ){
 					DlgItem_SetText(GetHwnd(), IDC_EDIT_PATH, szDir );
 				}
@@ -775,11 +775,11 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 			std::wstring strTitle = LS(STR_DLGREPLC_STR);
 			WCHAR szPathFrom[_MAX_PATH];
 			szPathFrom[0] = L'\0';
-			if( dlgInput.DoModal(G_AppInstance(), GetHwnd(), strTitle.c_str(), strMsg.c_str(), _countof(szPathFrom), szPathFrom) ){
+			if( dlgInput.DoModal(G_AppInstance(), GetHwnd(), strTitle.c_str(), strMsg.c_str(), std::size(szPathFrom), szPathFrom) ){
 				WCHAR szPathTo[_MAX_PATH];
 				szPathTo[0] = L'\0';
 				strMsg = LS(STR_FILETREE_REPLACE_PATH_TO);
-				if( dlgInput.DoModal( G_AppInstance(), GetHwnd(), strTitle.c_str(), strMsg.c_str(), _countof(szPathTo), szPathTo) ){
+				if( dlgInput.DoModal( G_AppInstance(), GetHwnd(), strTitle.c_str(), strMsg.c_str(), std::size(szPathTo), szPathTo) ){
 					int nItemsCount = (int)m_fileTreeSetting.m_aItems.size();
 					for( int i = 0; i < nItemsCount; i++ ){
 						SFileTreeItem& item =  m_fileTreeSetting.m_aItems[i];

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -197,7 +197,7 @@ HINSTANCE CDlgFuncList::m_lastRcInstance = 0;
 CDlgFuncList::CDlgFuncList() : CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	assert( std::size(anchorList) == std::size(m_rcItems) );
 
 	m_pcFuncInfoArr = NULL;		/* 関数情報配列 */
 	m_nCurLine = CLayoutInt(0);				/* 現在行 */
@@ -792,7 +792,7 @@ bool CDlgFuncList::GetTreeFileFullName(HWND hwndTree, HTREEITEM target, std::wst
 		WCHAR szFileName[_MAX_PATH];
 		tvItem.mask = TVIF_HANDLE | TVIF_TEXT;
 		tvItem.pszText = szFileName;
-		tvItem.cchTextMax = _countof(szFileName);
+		tvItem.cchTextMax = std::size(szFileName);
 		tvItem.hItem = target;
 		TreeView_GetItem( hwndTree, &tvItem );
 		if( ((-tvItem.lParam) % 10) == 3 ){
@@ -1325,9 +1325,9 @@ void CDlgFuncList::SetListVB (void)
 
 		// 2001/06/23 N.Nakatani for Visual Basic
 		//	Jun. 26, 2001 genta 半角かな→全角に
-		wmemset(szText, L'\0', _countof(szText));
-		wmemset(szType, L'\0', _countof(szType));
-		wmemset(szOption, L'\0', _countof(szOption));
+		wmemset(szText, L'\0', std::size(szText));
+		wmemset(szType, L'\0', std::size(szType));
+		wmemset(szOption, L'\0', std::size(szOption));
 		if( 1 == ((pcFuncInfo->m_nInfo >> 8) & 0x01) ){
 			// スタティック宣言(Static)
 			// 2006.12.12 Moca 末尾にスペース追加
@@ -1335,15 +1335,15 @@ void CDlgFuncList::SetListVB (void)
 		}
 		switch ((pcFuncInfo->m_nInfo >> 4) & 0x0f) {
 			case 2  :	// プライベート(Private)
-				wcsncat(szOption, LS(STR_DLGFNCLST_VB_PRIVATE), _countof(szOption) - wcslen(szOption)); //	2006.12.17 genta サイズ誤り修正
+				wcsncat(szOption, LS(STR_DLGFNCLST_VB_PRIVATE), std::size(szOption) - wcslen(szOption)); //	2006.12.17 genta サイズ誤り修正
 				break;
 
 			case 3  :	// フレンド(Friend)
-				wcsncat(szOption, LS(STR_DLGFNCLST_VB_FRIEND), _countof(szOption) - wcslen(szOption)); //	2006.12.17 genta サイズ誤り修正
+				wcsncat(szOption, LS(STR_DLGFNCLST_VB_FRIEND), std::size(szOption) - wcslen(szOption)); //	2006.12.17 genta サイズ誤り修正
 				break;
 
 			default :	// パブリック(Public)
-				wcsncat(szOption, LS(STR_DLGFNCLST_VB_PUBLIC), _countof(szOption) - wcslen(szOption)); //	2006.12.17 genta サイズ誤り修正
+				wcsncat(szOption, LS(STR_DLGFNCLST_VB_PUBLIC), std::size(szOption) - wcslen(szOption)); //	2006.12.17 genta サイズ誤り修正
 		}
 		int nInfo = pcFuncInfo->m_nInfo;
 		switch (nInfo & 0x0f) {
@@ -1389,7 +1389,7 @@ void CDlgFuncList::SetListVB (void)
 		}
 		if ( 2 == ((nInfo >> 8) & 0x02) ) {
 			// 宣言(Declareなど)
-			wcsncat(szType, LS(STR_DLGFNCLST_VB_DECL), _countof(szType) - wcslen(szType));
+			wcsncat(szType, LS(STR_DLGFNCLST_VB_DECL), std::size(szType) - wcslen(szType));
 		}
 
 		WCHAR szTypeOption[256]; // 2006.12.12 Moca auto_sprintfの入出力で同一変数を使わないための作業領域追加
@@ -1674,18 +1674,18 @@ void CDlgFuncList::SetTreeFile()
 		WCHAR szPath2[_MAX_PATH];
 		const SFileTreeItem& item = m_fileTreeSetting.m_aItems[i];
 		// item.m_szTargetPath => szPath メタ文字の展開
-		if( !CFileNameManager::ExpandMetaToFolder(item.m_szTargetPath, szPath, _countof(szPath)) ){
-			wcscpy_s(szPath, _countof(szPath), L"<Error:Long Path>");
+		if( !CFileNameManager::ExpandMetaToFolder(item.m_szTargetPath, szPath, std::size(szPath)) ){
+			wcscpy_s(szPath, std::size(szPath), L"<Error:Long Path>");
 		}
 		// szPath => szPath2 <iniroot>展開
 		const WCHAR* pszFrom = szPath;
 		if( m_fileTreeSetting.m_szLoadProjectIni[0] != L'\0'){
 			CNativeW strTemp(pszFrom);
 			strTemp.Replace(L"<iniroot>", IniDirPath);
-			if( _countof(szPath2) <= strTemp.GetStringLength() ){
-				wcscpy_s(szPath2, _countof(szPath), L"<Error:Long Path>");
+			if( std::size(szPath2) <= strTemp.GetStringLength() ){
+				wcscpy_s(szPath2, std::size(szPath), L"<Error:Long Path>");
 			}else{
-				wcscpy_s(szPath2, _countof(szPath), strTemp.GetStringPtr());
+				wcscpy_s(szPath2, std::size(szPath), strTemp.GetStringPtr());
 			}
 		}else{
 			wcscpy(szPath2, pszFrom);
@@ -2001,7 +2001,7 @@ BOOL CDlgFuncList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	m_ptDefaultSizeClient.x = rc.right;
 	m_ptDefaultSizeClient.y = rc.bottom;
 
-	for( int i = 0; i < _countof(anchorList); i++ ){
+	for( int i = 0; i < std::size(anchorList); i++ ){
 		GetItemClientRect( anchorList[i].id, m_rcItems[i] );
 		// ドッキング中はウィンドウ幅いっぱいまで伸ばす
 		if( IsDocking() ){
@@ -2334,7 +2334,7 @@ BOOL CDlgFuncList::OnSize( WPARAM wParam, LPARAM lParam )
 	ptNew.x = rcDlg.right - rcDlg.left;
 	ptNew.y = rcDlg.bottom - rcDlg.top;
 
-	for( int i = 0 ; i < _countof(anchorList); i++ ){
+	for( int i = 0 ; i < std::size(anchorList); i++ ){
 		HWND hwndCtrl = GetItemHwnd(anchorList[i].id);
 		ResizeItem( hwndCtrl, m_ptDefaultSizeClient, ptNew, m_rcItems[i], anchorList[i].anchor, (anchorList[i].anchor != ANCHOR_ALL));
 //	2013.2.6 aroka ちらつき防止用の試行錯誤

--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -92,7 +92,7 @@ inline bool isCSymbol(wchar_t c)
 	//	(c>=L'0' && c<=L'9') ||
 	//	(c>=L'A' && c<=L'Z') ||
 	//	(c>=L'a' && c<=L'z');
-	return (c<_countof(gm_keyword_char) && gm_keyword_char[c]==CK_CSYM);
+	return (c<std::size(gm_keyword_char) && gm_keyword_char[c]==CK_CSYM);
 }
 
 //! 全角版、識別子に使用可能な文字かどうか
@@ -122,7 +122,7 @@ ECharKind CWordParse::WhatKindOfChar(
 		wchar_t c=pData[nIdx];
 
 		//今までの半角
-		if( c<_countof(gm_keyword_char) ) return (ECharKind)gm_keyword_char[c];
+		if( c<std::size(gm_keyword_char) ) return (ECharKind)gm_keyword_char[c];
 		//if( c == CR              )return CK_CR;
 		//if( c == LF              )return CK_LF;
 		//if( c == TAB             )return CK_TAB;	// タブ

--- a/sakura_core/plugin/CPluginManager.cpp
+++ b/sakura_core/plugin/CPluginManager.cpp
@@ -46,7 +46,7 @@ CPluginManager::CPluginManager()
 	WCHAR	szFolder[_MAX_PATH];
 	WCHAR	szFname[_MAX_PATH];
 
-	::GetModuleFileName( NULL, szPath, _countof(szPath)	);
+	::GetModuleFileName( NULL, szPath, std::size(szPath)	);
 	SplitPath_FolderAndFile(szPath, szFolder, szFname);
 	Concat_FolderAndFile(szFolder, L"plugins\\", szPluginPath);
 
@@ -212,7 +212,7 @@ bool CPluginManager::InstZipPlugin( CommonSetting& common, HWND hWndOwner, const
 
 	// ZIPファイルが扱えるか
 	if (!cZipFile.IsOk()) {
-		wcsncpy_s( msg, _countof(msg), LS(STR_PLGMGR_ERR_ZIP), _TRUNCATE );
+		wcsncpy_s( msg, std::size(msg), LS(STR_PLGMGR_ERR_ZIP), _TRUNCATE );
 		InfoMessage( hWndOwner, L"%s", msg);
 		return false;
 	}
@@ -255,14 +255,14 @@ bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, co
 
 	// Plugin フォルダ名の取得,定義ファイルの確認
 	if (bOk && !cZipFile.SetZip(sZipFile)) {
-		auto_snprintf_s( msg, _countof(msg), LS(STR_PLGMGR_INST_ZIP_ACCESS), sDispName.c_str() );
+		auto_snprintf_s( msg, std::size(msg), LS(STR_PLGMGR_INST_ZIP_ACCESS), sDispName.c_str() );
 		bOk = false;
 		bSkip = bInSearch;
 	}
 
 	// Plgin フォルダ名の取得,定義ファイルの確認
 	if (bOk && !cZipFile.ChkPluginDef(PII_FILENAME, sFolderName)) {
-		auto_snprintf_s( msg, _countof(msg), LS(STR_PLGMGR_INST_ZIP_DEF), sDispName.c_str() );
+		auto_snprintf_s( msg, std::size(msg), LS(STR_PLGMGR_INST_ZIP_DEF), sDispName.c_str() );
 		bOk = false;
 		bSkip = bInSearch;
 	}
@@ -317,13 +317,13 @@ bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, co
 
 	// Zip解凍
 	if (bOk && !cZipFile.Unzip(m_sBaseDir)) {
-		auto_snprintf_s( msg, _countof(msg), LS(STR_PLGMGR_INST_ZIP_UNZIP), sDispName.c_str() );
+		auto_snprintf_s( msg, std::size(msg), LS(STR_PLGMGR_INST_ZIP_UNZIP), sDispName.c_str() );
 		bOk = false;
 	}
 	if (bOk) {
 		int pluginNo = InstallPlugin( common, sFolderName.c_str(), hWndOwner, errMsg, true );
 		if( pluginNo < 0 ){
-			auto_snprintf_s( msg, _countof(msg), LS(STR_PLGMGR_INST_ZIP_ERR), sDispName.c_str(), errMsg.c_str() );
+			auto_snprintf_s( msg, std::size(msg), LS(STR_PLGMGR_INST_ZIP_ERR), sDispName.c_str(), errMsg.c_str() );
 			bOk = false;
 		}
 	}
@@ -363,7 +363,7 @@ int CPluginManager::InstallPlugin( CommonSetting& common, const WCHAR* pszPlugin
 	//2010.08.04 ID使用不可の文字を確認
 	//  後々ファイル名やiniで使うことを考えていくつか拒否する
 	static const WCHAR szReservedChars[] = L"/\\,[]*?<>&|;:=\" \t";
-	for( int x = 0; x < _countof(szReservedChars); ++x ){
+	for( int x = 0; x < std::size(szReservedChars); ++x ){
 		if( sId.npos != sId.find(szReservedChars[x]) ){
 			errorMsg = LS(STR_PLGMGR_INST_RESERVE1);
 			errorMsg += szReservedChars;

--- a/sakura_core/print/CPrint.cpp
+++ b/sakura_core/print/CPrint.cpp
@@ -84,7 +84,7 @@ const PAPER_INFO CPrint::m_paperInfoArr[] = {
 	{DMPAPER_FANFOLD_LGL_GERMAN,  2159,  3302, L"German Legal Fanfold (8 1/2 x 13 inch)"},
 };
 
-const int CPrint::m_nPaperInfoArrNum = _countof( m_paperInfoArr );
+const int CPrint::m_nPaperInfoArrNum = std::size( m_paperInfoArr );
 
 CPrint::CPrint( void )
 {
@@ -157,19 +157,19 @@ BOOL CPrint::PrintDlg( PRINTDLG *pPD, MYDEVMODE *pMYDEVMODE )
 	// プリンタドライバ名
 	wcscpy_s(
 		pMYDEVMODE->m_szPrinterDriverName,
-		_countof(pMYDEVMODE->m_szPrinterDriverName),
+		std::size(pMYDEVMODE->m_szPrinterDriverName),
 		(const WCHAR*)pDEVNAMES + pDEVNAMES->wDriverOffset
 	);
 	// プリンタデバイス名
 	wcscpy_s(
 		pMYDEVMODE->m_szPrinterDeviceName,
-		_countof(pMYDEVMODE->m_szPrinterDeviceName),
+		std::size(pMYDEVMODE->m_szPrinterDeviceName),
 		(const WCHAR*)pDEVNAMES + pDEVNAMES->wDeviceOffset
 	);
 	// プリンタポート名
 	wcscpy_s(
 		pMYDEVMODE->m_szPrinterOutputName,
-		_countof(pMYDEVMODE->m_szPrinterOutputName),
+		std::size(pMYDEVMODE->m_szPrinterOutputName),
 		(const WCHAR*)pDEVNAMES + pDEVNAMES->wOutputOffset
 	);
 
@@ -238,19 +238,19 @@ BOOL CPrint::GetDefaultPrinter( MYDEVMODE* pMYDEVMODE )
 	// プリンタドライバ名
 	wcscpy_s(
 		pMYDEVMODE->m_szPrinterDriverName,
-		_countof(pMYDEVMODE->m_szPrinterDriverName),
+		std::size(pMYDEVMODE->m_szPrinterDriverName),
 		(const WCHAR*)pDEVNAMES + pDEVNAMES->wDriverOffset
 	);
 	// プリンタデバイス名
 	wcscpy_s(
 		pMYDEVMODE->m_szPrinterDeviceName,
-		_countof(pMYDEVMODE->m_szPrinterDeviceName),
+		std::size(pMYDEVMODE->m_szPrinterDeviceName),
 		(const WCHAR*)pDEVNAMES + pDEVNAMES->wDeviceOffset
 	);
 	// プリンタポート名
 	wcscpy_s(
 		pMYDEVMODE->m_szPrinterOutputName,
-		_countof(pMYDEVMODE->m_szPrinterOutputName),
+		std::size(pMYDEVMODE->m_szPrinterOutputName),
 		(const WCHAR*)pDEVNAMES + pDEVNAMES->wOutputOffset
 	);
 

--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -51,9 +51,9 @@ struct	MYDEVMODE {
 	bool operator == (const MYDEVMODE& rhs) const noexcept {
 		if (this == &rhs) return true;
 		return m_bPrinterNotFound == rhs.m_bPrinterNotFound
-			&& 0 == wcsncmp(m_szPrinterDriverName, rhs.m_szPrinterDriverName, _countof(m_szPrinterDriverName))
-			&& 0 == wcsncmp(m_szPrinterDeviceName, rhs.m_szPrinterDeviceName, _countof(m_szPrinterDeviceName))
-			&& 0 == wcsncmp(m_szPrinterOutputName, rhs.m_szPrinterOutputName, _countof(m_szPrinterOutputName))
+			&& 0 == wcsncmp(m_szPrinterDriverName, rhs.m_szPrinterDriverName, std::size(m_szPrinterDriverName))
+			&& 0 == wcsncmp(m_szPrinterDeviceName, rhs.m_szPrinterDeviceName, std::size(m_szPrinterDeviceName))
+			&& 0 == wcsncmp(m_szPrinterOutputName, rhs.m_szPrinterOutputName, std::size(m_szPrinterOutputName))
 			&& dmFields == rhs.dmFields
 			&& dmOrientation == rhs.dmOrientation
 			&& dmPaperSize == rhs.dmPaperSize

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -1048,7 +1048,7 @@ void CPrintPreview::OnPrint( void )
 		WCHAR	szFileName[_MAX_FNAME];
 		WCHAR	szExt[_MAX_EXT];
 		_wsplitpath( m_pParentWnd->GetDocument()->m_cDocFile.GetFilePath(), NULL, NULL, szFileName, szExt );
-		auto_snprintf_s( szJobName, _countof(szJobName), L"%s%s", szFileName, szExt );
+		auto_snprintf_s( szJobName, std::size(szJobName), L"%s%s", szFileName, szExt );
 	}
 
 	/* 印刷範囲を指定できるプリンタダイアログを作成 */

--- a/sakura_core/prop/CPropComBackup.cpp
+++ b/sakura_core/prop/CPropComBackup.cpp
@@ -171,7 +171,7 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 				{
 					/* バックアップを作成するフォルダ */
 					WCHAR		szFolder[_MAX_PATH];
-					::DlgItem_GetText( hwndDlg, IDC_EDIT_BACKUPFOLDER, szFolder, _countof( szFolder ));
+					::DlgItem_GetText( hwndDlg, IDC_EDIT_BACKUPFOLDER, szFolder, std::size( szFolder ));
 
 					if( SelectDir( hwndDlg, LS(STR_PROPCOMBK_SEL_FOLDER), szFolder, szFolder ) ){
 						wcscpy( m_Common.m_sBackup.m_szBackUpFolder, szFolder );

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -242,7 +242,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 				//	Combo Boxも変更 削除＆再登録
 				Combo_DeleteString( hwndCOMBO_MENU, nIdx1 );
 				Combo_InsertString( hwndCOMBO_MENU, nIdx1,
-					m_cLookup.Custmenu2Name( nIdx1, buf, _countof(buf) ) );
+					m_cLookup.Custmenu2Name( nIdx1, buf, std::size(buf) ) );
 				// 削除すると選択が解除されるので，元に戻す
 				Combo_SetCurSel( hwndCOMBO_MENU, nIdx1 );
 				return TRUE;
@@ -648,7 +648,7 @@ void CPropCustmenu::SetData( HWND hwndDlg )
 	/* メニュー一覧に文字列をセット（コンボボックス）*/
 	hwndCOMBO_MENU = ::GetDlgItem( hwndDlg, IDC_COMBO_MENU );
 	for( i = 0; i < MAX_CUSTOM_MENU; ++i ){
-		Combo_AddString( hwndCOMBO_MENU, m_cLookup.Custmenu2Name( i, buf, _countof( buf ) ) );
+		Combo_AddString( hwndCOMBO_MENU, m_cLookup.Custmenu2Name( i, buf, std::size( buf ) ) );
 	}
 	/* メニュー一覧の先頭の項目を選択（コンボボックス）*/
 	Combo_SetCurSel( hwndCOMBO_MENU, 0 );
@@ -671,8 +671,8 @@ void CPropCustmenu::SetDataMenuList(HWND hwndDlg, int nIdx)
 	List_ResetContent( hwndLIST_RES );
 	for( i = 0; i < m_Common.m_sCustomMenu.m_nCustMenuItemNumArr[nIdx]; ++i ){
 		if( 0 == m_Common.m_sCustomMenu.m_nCustMenuItemFuncArr[nIdx][i] ){
-			wcsncpy( szLabel, LS(STR_PROPCOMCUSTMENU_SEP), _countof(szLabel) - 1 );	//Oct. 18, 2000 JEPRO 「ツールバー」タブで使っているセパレータと同じ線種に統一した
-			szLabel[_countof(szLabel) - 1] = L'\0';
+			wcsncpy( szLabel, LS(STR_PROPCOMCUSTMENU_SEP), std::size(szLabel) - 1 );	//Oct. 18, 2000 JEPRO 「ツールバー」タブで使っているセパレータと同じ線種に統一した
+			szLabel[std::size(szLabel) - 1] = L'\0';
 		}else{
 			EFunctionCode code = m_Common.m_sCustomMenu.m_nCustMenuItemFuncArr[nIdx][i];
 			//	Oct. 3, 2001 genta

--- a/sakura_core/prop/CPropComEdit.cpp
+++ b/sakura_core/prop/CPropComEdit.cpp
@@ -115,8 +115,8 @@ INT_PTR CPropEdit::DispatchEvent(
 				{
 					WCHAR szMetaPath[_MAX_PATH];
 					WCHAR szPath[_MAX_PATH];
-					::DlgItem_GetText( hwndDlg, IDC_EDIT_FILEOPENDIR, szMetaPath, _countof(szMetaPath) );
-					CFileNameManager::ExpandMetaToFolder( szMetaPath, szPath, _countof(szPath) );
+					::DlgItem_GetText( hwndDlg, IDC_EDIT_FILEOPENDIR, szMetaPath, std::size(szMetaPath) );
+					CFileNameManager::ExpandMetaToFolder( szMetaPath, szPath, std::size(szPath) );
 					if( SelectDir( hwndDlg, LS(STR_PROPEDIT_SELECT_DIR), szPath, szPath ) ){
 						CNativeW cmem(szPath);
 						cmem.Replace(L"%", L"%%");

--- a/sakura_core/prop/CPropComFile.cpp
+++ b/sakura_core/prop/CPropComFile.cpp
@@ -295,7 +295,7 @@ void CPropFile::SetData( HWND hwndDlg )
 	HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_FILESHAREMODE );
 	Combo_ResetContent( hwndCombo );
 	int		nSelPos = 0;
-	for( int i = 0; i < _countof( ShareModeArr ); ++i ){
+	for( int i = 0; i < std::size( ShareModeArr ); ++i ){
 		Combo_InsertString( hwndCombo, i, LS( ShareModeArr[i].nNameId ) );
 		if( ShareModeArr[i].nMethod == m_Common.m_sFile.m_nFileShareMode ){
 			nSelPos = i;

--- a/sakura_core/prop/CPropComFormat.cpp
+++ b/sakura_core/prop/CPropComFormat.cpp
@@ -93,7 +93,7 @@ void CPropFormat::ChangeDateExample( HWND hwndDlg )
 	WCHAR szText[1024];
 	SYSTEMTIME systime;
 	::GetLocalTime( &systime );
-	CFormatManager().MyGetDateFormat( systime, szText, _countof( szText ) - 1, m_Common.m_sFormat.m_nDateFormatType, m_Common.m_sFormat.m_szDateFormat );
+	CFormatManager().MyGetDateFormat( systime, szText, std::size( szText ) - 1, m_Common.m_sFormat.m_nDateFormatType, m_Common.m_sFormat.m_szDateFormat );
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_DFORM_EX, szText );
 	return;
 }
@@ -106,7 +106,7 @@ void CPropFormat::ChangeTimeExample( HWND hwndDlg )
 	WCHAR szText[1024];
 	SYSTEMTIME systime;
 	::GetLocalTime( &systime );
-	CFormatManager().MyGetTimeFormat( systime, szText, _countof( szText ) - 1, m_Common.m_sFormat.m_nTimeFormatType, m_Common.m_sFormat.m_szTimeFormat );
+	CFormatManager().MyGetTimeFormat( systime, szText, std::size( szText ) - 1, m_Common.m_sFormat.m_nTimeFormatType, m_Common.m_sFormat.m_szTimeFormat );
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_TFORM_EX, szText );
 	return;
 }
@@ -137,16 +137,16 @@ INT_PTR CPropFormat::DispatchEvent(
 		ChangeTimeExample( hwndDlg );
 
 		/* 見出し記号 */
-		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_MIDASHIKIGOU ), _countof(m_Common.m_sFormat.m_szMidashiKigou) - 1 );
+		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_MIDASHIKIGOU ), std::size(m_Common.m_sFormat.m_szMidashiKigou) - 1 );
 
 		/* 引用符 */
-		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_INYOUKIGOU ), _countof(m_Common.m_sFormat.m_szInyouKigou) - 1 );
+		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_INYOUKIGOU ), std::size(m_Common.m_sFormat.m_szInyouKigou) - 1 );
 
 		/* 日付書式 */
-		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_DFORM ), _countof(m_Common.m_sFormat.m_szDateFormat) - 1 );
+		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_DFORM ), std::size(m_Common.m_sFormat.m_szDateFormat) - 1 );
 
 		/* 時刻書式 */
-		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_TFORM ), _countof(m_Common.m_sFormat.m_szTimeFormat) - 1 );
+		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_TFORM ), std::size(m_Common.m_sFormat.m_szTimeFormat) - 1 );
 
 		return TRUE;
 	case WM_COMMAND:
@@ -282,7 +282,7 @@ void CPropFormat::SetData( HWND hwndDlg )
 int CPropFormat::GetData( HWND hwndDlg )
 {
 	/* 見出し記号 */
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_MIDASHIKIGOU, m_Common.m_sFormat.m_szMidashiKigou, _countof(m_Common.m_sFormat.m_szMidashiKigou) );
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_MIDASHIKIGOU, m_Common.m_sFormat.m_szMidashiKigou, std::size(m_Common.m_sFormat.m_szMidashiKigou) );
 
 //	/* 外部ヘルプ１ */
 //	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHELP1, m_Common.m_sFormat.m_szExtHelp1, MAX_PATH - 1 );
@@ -291,7 +291,7 @@ int CPropFormat::GetData( HWND hwndDlg )
 //	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHTMLHELP, m_Common.m_sFormat.m_szExtHtmlHelp, MAX_PATH - 1 );
 
 	/* 引用符 */
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_INYOUKIGOU, m_Common.m_sFormat.m_szInyouKigou, _countof(m_Common.m_sFormat.m_szInyouKigou) );
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_INYOUKIGOU, m_Common.m_sFormat.m_szInyouKigou, std::size(m_Common.m_sFormat.m_szInyouKigou) );
 
 	//日付書式のタイプ
 	if( BST_CHECKED == ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_DFORM_0 ) ){
@@ -300,7 +300,7 @@ int CPropFormat::GetData( HWND hwndDlg )
 		m_Common.m_sFormat.m_nDateFormatType = 1;
 	}
 	//日付書式
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_DFORM, m_Common.m_sFormat.m_szDateFormat, _countof( m_Common.m_sFormat.m_szDateFormat ));
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_DFORM, m_Common.m_sFormat.m_szDateFormat, std::size( m_Common.m_sFormat.m_szDateFormat ));
 
 	//時刻書式のタイプ
 	if( BST_CHECKED == ::IsDlgButtonChecked( hwndDlg, IDC_RADIO_TFORM_0 ) ){
@@ -310,7 +310,7 @@ int CPropFormat::GetData( HWND hwndDlg )
 	}
 
 	//時刻書式
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_TFORM, m_Common.m_sFormat.m_szTimeFormat, _countof( m_Common.m_sFormat.m_szTimeFormat ));
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_TFORM, m_Common.m_sFormat.m_szTimeFormat, std::size( m_Common.m_sFormat.m_szTimeFormat ));
 
 	return TRUE;
 }

--- a/sakura_core/prop/CPropComGeneral.cpp
+++ b/sakura_core/prop/CPropComGeneral.cpp
@@ -358,7 +358,7 @@ void CPropGeneral::SetData( HWND hwndDlg )
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WHEEL_PAGESCROLL );
 	Combo_ResetContent( hwndCombo );
 	nSelPos = 0;
-	for( i = 0; i < _countof( SpecialScrollModeArr ); ++i ){
+	for( i = 0; i < std::size( SpecialScrollModeArr ); ++i ){
 		Combo_InsertString( hwndCombo, i, LS( SpecialScrollModeArr[i].nNameId ) );
 		if( SpecialScrollModeArr[i].nMethod == m_Common.m_sGeneral.m_nPageScrollByWheel ){	// ページスクロールとする組み合わせ操作
 			nSelPos = i;
@@ -370,7 +370,7 @@ void CPropGeneral::SetData( HWND hwndDlg )
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WHEEL_HSCROLL );
 	Combo_ResetContent( hwndCombo );
 	nSelPos = 0;
-	for( i = 0; i < _countof( SpecialScrollModeArr ); ++i ){
+	for( i = 0; i < std::size( SpecialScrollModeArr ); ++i ){
 		Combo_InsertString( hwndCombo, i, LS( SpecialScrollModeArr[i].nNameId ) );
 		if( SpecialScrollModeArr[i].nMethod == m_Common.m_sGeneral.m_nHorizontalScrollByWheel ){	// 横スクロールとする組み合わせ操作
 			nSelPos = i;

--- a/sakura_core/prop/CPropComGrep.cpp
+++ b/sakura_core/prop/CPropComGrep.cpp
@@ -149,7 +149,7 @@ void CPropGrep::SetData( HWND hwndDlg )
 	::CheckDlgButton( hwndDlg, IDC_CHECK_GTJW_LDBLCLK, m_Common.m_sSearch.m_bGTJW_LDBLCLK );
 
 	//	2007.08.12 genta 正規表現DLL
-	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_REGEXPLIB ), _countof(m_Common.m_sSearch.m_szRegexpLib ) - 1 );
+	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_REGEXPLIB ), std::size(m_Common.m_sSearch.m_szRegexpLib ) - 1 );
 	::DlgItem_SetText( hwndDlg, IDC_EDIT_REGEXPLIB, m_Common.m_sSearch.m_szRegexpLib);
 	SetRegexpVersion( hwndDlg );
 
@@ -162,7 +162,7 @@ void CPropGrep::SetData( HWND hwndDlg )
 	HWND hwndCombo = ::GetDlgItem(hwndDlg, IDC_COMBO_TAGJUMP);
 	Combo_ResetContent(hwndCombo);
 	int nSelPos = 0;
-	for(int i = 0; i < _countof(TagJumpMode1Arr); ++i){
+	for(int i = 0; i < std::size(TagJumpMode1Arr); ++i){
 		Combo_InsertString(hwndCombo, i, LS(TagJumpMode1Arr[i].m_nNameID));
 		Combo_SetItemData(hwndCombo, i, TagJumpMode1Arr[i].m_nMethod);
 		if(TagJumpMode1Arr[i].m_nMethod == m_Common.m_sSearch.m_nTagJumpMode ){
@@ -180,7 +180,7 @@ void CPropGrep::SetData( HWND hwndDlg )
 	hwndCombo = ::GetDlgItem(hwndDlg, IDC_COMBO_KEYWORD_TAGJUMP);
 	Combo_ResetContent(hwndCombo);
 	nSelPos = 0;
-	for(int i = 0; i < _countof(TagJumpMode2Arr); ++i){
+	for(int i = 0; i < std::size(TagJumpMode2Arr); ++i){
 		Combo_InsertString(hwndCombo, i, LS(TagJumpMode2Arr[i].m_nNameID));
 		Combo_SetItemData(hwndCombo, i, TagJumpMode2Arr[i].m_nMethod);
 		if(TagJumpMode2Arr[i].m_nMethod == m_Common.m_sSearch.m_nTagJumpModeKeyword ){
@@ -213,7 +213,7 @@ int CPropGrep::GetData( HWND hwndDlg )
 	m_Common.m_sSearch.m_bGTJW_LDBLCLK = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_GTJW_LDBLCLK );
 
 	//	2007.08.12 genta 正規表現DLL
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_REGEXPLIB, m_Common.m_sSearch.m_szRegexpLib, _countof( m_Common.m_sSearch.m_szRegexpLib ));
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_REGEXPLIB, m_Common.m_sSearch.m_szRegexpLib, std::size( m_Common.m_sSearch.m_szRegexpLib ));
 
 	HWND hwndCombo = ::GetDlgItem(hwndDlg, IDC_COMBO_TAGJUMP);
 	int nSelPos = Combo_GetCurSel(hwndCombo);
@@ -230,7 +230,7 @@ void CPropGrep::SetRegexpVersion( HWND hwndDlg )
 {
 	WCHAR regexp_dll[_MAX_PATH];
 	
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_REGEXPLIB, regexp_dll, _countof( regexp_dll ));
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_REGEXPLIB, regexp_dll, std::size( regexp_dll ));
 	CBregexp breg;
 	if( DLL_SUCCESS != breg.InitDll( regexp_dll ) ){
 		::DlgItem_SetText( hwndDlg, IDC_LABEL_REGEXP_VER, LS(STR_PROPCOMGREP_DLL) );

--- a/sakura_core/prop/CPropComHelper.cpp
+++ b/sakura_core/prop/CPropComHelper.cpp
@@ -270,17 +270,17 @@ int CPropHelper::GetData( HWND hwndDlg )
 	m_Common.m_sHelper.m_bHokanKey_RIGHT = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_m_bHokanKey_RIGHT );	//VK_RIGHT  補完決定キーが有効/無効
 
 	/* 外部ヘルプ１ */
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHELP1, m_Common.m_sHelper.m_szExtHelp, _countof( m_Common.m_sHelper.m_szExtHelp ));
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHELP1, m_Common.m_sHelper.m_szExtHelp, std::size( m_Common.m_sHelper.m_szExtHelp ));
 
 	/* 外部HTMLヘルプ */
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHTMLHELP, m_Common.m_sHelper.m_szExtHtmlHelp, _countof( m_Common.m_sHelper.m_szExtHtmlHelp ));
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_EXTHTMLHELP, m_Common.m_sHelper.m_szExtHtmlHelp, std::size( m_Common.m_sHelper.m_szExtHtmlHelp ));
 
 	/* HtmlHelpビューアはひとつ */
 	m_Common.m_sHelper.m_bHtmlHelpIsSingle = ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_HTMLHELPISSINGLE ) != 0;
 
 	//migemo dict
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_MIGEMO_DLL, m_Common.m_sHelper.m_szMigemoDll, _countof( m_Common.m_sHelper.m_szMigemoDll ));
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_MIGEMO_DICT, m_Common.m_sHelper.m_szMigemoDict, _countof( m_Common.m_sHelper.m_szMigemoDict ));
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_MIGEMO_DLL, m_Common.m_sHelper.m_szMigemoDll, std::size( m_Common.m_sHelper.m_szMigemoDll ));
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_MIGEMO_DICT, m_Common.m_sHelper.m_szMigemoDict, std::size( m_Common.m_sHelper.m_szMigemoDict ));
 
 	return TRUE;
 }

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -268,8 +268,8 @@ INT_PTR CPropKeybind::DispatchEvent(
 				// Oct. 2, 2001 genta
 				// 2007.11.02 ryoji F_DISABLEなら未割付
 				if( nFuncCode == F_DISABLE ){
-					wcsncpy( pszLabel, LS(STR_PROPCOMKEYBIND_UNASSIGN), _countof(pszLabel) - 1 );
-					pszLabel[_countof(pszLabel) - 1] = L'\0';
+					wcsncpy( pszLabel, LS(STR_PROPCOMKEYBIND_UNASSIGN), std::size(pszLabel) - 1 );
+					pszLabel[std::size(pszLabel) - 1] = L'\0';
 				}else{
 					m_cLookup.Funccode2Name( nFuncCode, pszLabel, 255 );
 				}
@@ -325,7 +325,7 @@ INT_PTR CPropKeybind::DispatchEvent(
 					int	ret;
 
 					nIndex = List_GetCurSel( hwndAssignedkeyList );
-					wmemset(buff, 0, _countof(buff));
+					wmemset(buff, 0, std::size(buff));
 					ret = List_GetText( hwndAssignedkeyList, nIndex, buff);
 					if( ret != LB_ERR )
 					{

--- a/sakura_core/prop/CPropComMacro.cpp
+++ b/sakura_core/prop/CPropComMacro.cpp
@@ -114,8 +114,8 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
 		//	Oct. 5, 2002 genta エディット コントロールに入力できるテキストの長さを制限する
-		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_MACRONAME ), _countof( m_Common.m_sMacro.m_MacroTable[0].m_szName ) - 1 );
-		Combo_LimitText( ::GetDlgItem( hwndDlg, IDC_MACROPATH ), _countof( m_Common.m_sMacro.m_MacroTable[0].m_szFile ) - 1 );
+		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_MACRONAME ), std::size( m_Common.m_sMacro.m_MacroTable[0].m_szName ) - 1 );
+		Combo_LimitText( ::GetDlgItem( hwndDlg, IDC_MACROPATH ), std::size( m_Common.m_sMacro.m_MacroTable[0].m_szFile ) - 1 );
 		// 2003.06.23 Moca
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_MACRODIR ), _countof2( m_Common.m_sMacro.m_szMACROFOLDER ) - 1 );
 		EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_MACROCANCELTIMER ), 4 );
@@ -351,7 +351,7 @@ int CPropMacro::GetData( HWND hwndDlg )
 		sItem.iSubItem = 4;
 		WCHAR szText[8];
 		sItem.pszText = szText;
-		sItem.cchTextMax = _countof(szText);
+		sItem.cchTextMax = std::size(szText);
 		ListView_GetItem( hListView, &sItem );
 		int i;
 		int nLen;
@@ -375,7 +375,7 @@ int CPropMacro::GetData( HWND hwndDlg )
 	
 	//	マクロ停止ダイアログ表示待ち時間
 	WCHAR szCancelTimer[16] = {0};
-	::DlgItem_GetText( hwndDlg, IDC_MACROCANCELTIMER, szCancelTimer, _countof(szCancelTimer) );
+	::DlgItem_GetText( hwndDlg, IDC_MACROCANCELTIMER, szCancelTimer, std::size(szCancelTimer) );
 	m_Common.m_sMacro.m_nMacroCancelTimer = _wtoi(szCancelTimer);
 
 	return TRUE;
@@ -409,7 +409,7 @@ void CPropMacro::InitDialog( HWND hwndDlg )
 	::GetWindowRect( hListView, &rc );
 	int width = rc.right - rc.left - ::GetSystemMetrics(SM_CXHSCROLL);
 	
-	for( pos = 0; pos < _countof( ColumnList ); ++pos ){
+	for( pos = 0; pos < std::size( ColumnList ); ++pos ){
 		
 		memset_raw( &sColumn, 0, sizeof( sColumn ));
 		sColumn.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_SUBITEM | LVCF_FMT;
@@ -516,7 +516,7 @@ void CPropMacro::SetMacro2List_Macro( HWND hwndDlg )
 		sItem.mask = LVIF_TEXT;
 		sItem.iSubItem = 4;
 		sItem.pszText = szText;
-		sItem.cchTextMax = _countof(szText);
+		sItem.cchTextMax = std::size(szText);
 		ListView_GetItem( hListView, &sItem );
 		int i;
 		int nLen;
@@ -570,7 +570,7 @@ void CPropMacro::SelectBaseDir_Macro( HWND hwndDlg )
 	WCHAR szDir[_MAX_PATH];
 
 	/* 検索フォルダ */
-	::DlgItem_GetText( hwndDlg, IDC_MACRODIR, szDir, _countof(szDir) );
+	::DlgItem_GetText( hwndDlg, IDC_MACRODIR, szDir, std::size(szDir) );
 
 	// 2003.06.23 Moca 相対パスは実行ファイルからのパス
 	// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
@@ -582,7 +582,7 @@ void CPropMacro::SelectBaseDir_Macro( HWND hwndDlg )
 
 	if( SelectDir( hwndDlg, LS(STR_PROPCOMMACR_SEL_DIR), szDir, szDir ) ){
 		//	末尾に\\マークを追加する．
-		AddLastChar( szDir, _countof(szDir), L'\\' );
+		AddLastChar( szDir, std::size(szDir), L'\\' );
 		::DlgItem_SetText( hwndDlg, IDC_MACRODIR, GetRelPath(szDir) ); // 2015.03.03 可能なら相対パスにする
 	}
 }
@@ -599,7 +599,7 @@ void CPropMacro::OnFileDropdown_Macro( HWND hwndDlg )
 	HWND hCombo = ::GetDlgItem( hwndDlg, IDC_MACROPATH );
 
 	WCHAR path[_MAX_PATH * 2];
-	::DlgItem_GetText( hwndDlg, IDC_MACRODIR, path, _countof(path) );
+	::DlgItem_GetText( hwndDlg, IDC_MACRODIR, path, std::size(path) );
 
 	// 2003.06.23 Moca 相対パスは実行ファイルからのパス
 	// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
@@ -695,7 +695,7 @@ void CPropMacro::CheckListPosition_Macro( HWND hwndDlg )
 	sItem.iSubItem = 4;
 	WCHAR szText[8];
 	sItem.pszText = szText;
-	sItem.cchTextMax = _countof(szText);
+	sItem.cchTextMax = std::size(szText);
 	ListView_GetItem( hListView, &sItem );
 	int i;
 	int nLen;

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -507,13 +507,13 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					case IDC_BUTTON_INSERT_NODE:		// ノード挿入
 						eFuncCode = F_NODE;
 						bIsNode = true;
-						wcsncpy( szLabel , LS(STR_PROPCOMMAINMENU_EDIT), _countof(szLabel) - 1 );
-						szLabel[_countof(szLabel) - 1] = L'\0';
+						wcsncpy( szLabel , LS(STR_PROPCOMMAINMENU_EDIT), std::size(szLabel) - 1 );
+						szLabel[std::size(szLabel) - 1] = L'\0';
 						break;
 					case IDC_BUTTON_INSERTSEPARATOR:	// 区切線挿入
 						eFuncCode = F_SEPARATOR;
-						wcsncpy( szLabel , LS(STR_PROPCOMMAINMENU_SEP), _countof(szLabel) - 1 );
-						szLabel[_countof(szLabel) - 1] = L'\0';
+						wcsncpy( szLabel , LS(STR_PROPCOMMAINMENU_SEP), std::size(szLabel) - 1 );
+						szLabel[std::size(szLabel) - 1] = L'\0';
 						break;
 					case IDC_BUTTON_INSERT:				// 挿入
 					case IDC_BUTTON_INSERT_A:			// 挿入

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -477,7 +477,7 @@ void CPropPlugin::InitDialog( HWND hwndDlg )
 	::GetWindowRect( hListView, &rc );
 	int width = rc.right - rc.left;
 	
-	for( pos = 0; pos < _countof( ColumnList ); ++pos ){
+	for( pos = 0; pos < std::size( ColumnList ); ++pos ){
 		
 		memset_raw( &sColumn, 0, sizeof( sColumn ));
 		sColumn.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_SUBITEM | LVCF_FMT;
@@ -560,7 +560,7 @@ bool CPropPlugin::BrowseReadMe(const std::wstring& sReadMeName)
 
 	//アプリケーションパス
 	WCHAR szExePath[MAX_PATH + 1];
-	::GetModuleFileName( NULL, szExePath, _countof( szExePath ) );
+	::GetModuleFileName( NULL, szExePath, std::size( szExePath ) );
 	cCmdLineBuf.AppendF( L"\"%s\"", szExePath );
 
 	// ファイル名
@@ -583,7 +583,7 @@ bool CPropPlugin::BrowseReadMe(const std::wstring& sReadMeName)
 	ZeroMemory( &pi, sizeof(pi) );
 
 	WCHAR	szCmdLine[1024];
-	wcscpy_s(szCmdLine, _countof(szCmdLine), cCmdLineBuf.c_str());
+	wcscpy_s(szCmdLine, std::size(szCmdLine), cCmdLineBuf.c_str());
 	//リソースリーク対策
 	BOOL bRet = ::CreateProcess( NULL, szCmdLine, NULL, NULL, TRUE,
 		CREATE_NEW_CONSOLE, NULL, NULL, &sui, &pi );

--- a/sakura_core/prop/CPropComTab.cpp
+++ b/sakura_core/prop/CPropComTab.cpp
@@ -198,13 +198,13 @@ void CPropTab::SetData( HWND hwndDlg )
 	::CheckDlgButton( hwndDlg, IDC_CHECK_SortTabList, m_Common.m_sTabBar.m_bSortTabList );			//@@@ 2006.03.23 fon
 	CheckDlgButtonBool( hwndDlg, IDC_CHECK_TAB_MULTILINE, m_Common.m_sTabBar.m_bTabMultiLine );
 	::CheckDlgButton( hwndDlg, IDC_CHECK_DispTabWndMultiWin, ! m_Common.m_sTabBar.m_bDispTabWndMultiWin ); //@@@ 2003.05.31 MIK
-	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_TABWND_CAPTION ), _countof( m_Common.m_sTabBar.m_szTabWndCaption ) - 1 );
+	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_TABWND_CAPTION ), std::size( m_Common.m_sTabBar.m_szTabWndCaption ) - 1 );
 	::DlgItem_SetText( hwndDlg, IDC_TABWND_CAPTION, m_Common.m_sTabBar.m_szTabWndCaption );
 
 	HWND hwndCombo = ::GetDlgItem( hwndDlg, IDC_CHECK_DispTabClose );
 	Combo_ResetContent( hwndCombo );
 	int nSelPos = 0;
-	for( int i = 0; i < _countof( DispTabCloseArr ); ++i ){
+	for( int i = 0; i < std::size( DispTabCloseArr ); ++i ){
 		Combo_InsertString( hwndCombo, i, LS(DispTabCloseArr[i].nNameId) );
 		if( DispTabCloseArr[i].nMethod == m_Common.m_sTabBar.m_bDispTabClose ){
 			nSelPos = i;
@@ -215,7 +215,7 @@ void CPropTab::SetData( HWND hwndDlg )
 	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_TAB_POSITION );
 	Combo_ResetContent( hwndCombo );
 	nSelPos = 0;
-	for( int i = 0; i < _countof( TabPosArr ); ++i ){
+	for( int i = 0; i < std::size( TabPosArr ); ++i ){
 		Combo_InsertString( hwndCombo, i, LS(TabPosArr[i].nNameId) );
 		if( TabPosArr[i].nMethod == m_Common.m_sTabBar.m_eTabPosition ){
 			nSelPos = i;
@@ -247,7 +247,7 @@ int CPropTab::GetData( HWND hwndDlg )
 	m_Common.m_sTabBar.m_bTabMultiLine = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_TAB_MULTILINE );
 	m_Common.m_sTabBar.m_bDispTabWndMultiWin =
 		( ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_DispTabWndMultiWin ) == BST_CHECKED ) ? FALSE : TRUE;
-	::DlgItem_GetText( hwndDlg, IDC_TABWND_CAPTION, m_Common.m_sTabBar.m_szTabWndCaption, _countof( m_Common.m_sTabBar.m_szTabWndCaption ) );
+	::DlgItem_GetText( hwndDlg, IDC_TABWND_CAPTION, m_Common.m_sTabBar.m_szTabWndCaption, std::size( m_Common.m_sTabBar.m_szTabWndCaption ) );
 
 	HWND hwndCombo = ::GetDlgItem( hwndDlg, IDC_CHECK_DispTabClose );
 	int nSelPos = Combo_GetCurSel( hwndCombo );

--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -588,15 +588,15 @@ void CPropToolbar::DrawToolBarItemList( DRAWITEMSTRUCT* pDis )
 	if( tbb.fsStyle & TBSTYLE_SEP ){
 		// テキストだけ表示する
 		if( tbb.idCommand == F_SEPARATOR ){
-			wcsncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM1), _countof(szLabel) - 1 );	// nLength 未使用 2003/01/09 Moca
-			szLabel[_countof(szLabel) - 1] = L'\0';
+			wcsncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM1), std::size(szLabel) - 1 );	// nLength 未使用 2003/01/09 Moca
+			szLabel[std::size(szLabel) - 1] = L'\0';
 		}else if( tbb.idCommand == F_MENU_NOT_USED_FIRST ){
 			// ツールバー折返
-			wcsncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM2), _countof(szLabel) - 1 );
-			szLabel[_countof(szLabel) - 1] = L'\0';
+			wcsncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM2), std::size(szLabel) - 1 );
+			szLabel[std::size(szLabel) - 1] = L'\0';
 		}else{
-			wcsncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM3), _countof(szLabel) - 1 );
-			szLabel[_countof(szLabel) - 1] = L'\0';
+			wcsncpy( szLabel, LS(STR_PROPCOMTOOL_ITEM3), std::size(szLabel) - 1 );
+			szLabel[std::size(szLabel) - 1] = L'\0';
 		}
 	}else{
 		// アイコンとテキストを表示する
@@ -609,7 +609,7 @@ void CPropToolbar::DrawToolBarItemList( DRAWITEMSTRUCT* pDis )
 			cxSmIcon,
 			cySmIcon
 		);
-		m_cLookup.Funccode2Name( tbb.idCommand, szLabel, _countof( szLabel ) );
+		m_cLookup.Funccode2Name( tbb.idCommand, szLabel, std::size( szLabel ) );
 	}
 
 	// 微調整 フォーカス枠の分へこませる

--- a/sakura_core/prop/CPropComWin.cpp
+++ b/sakura_core/prop/CPropComWin.cpp
@@ -345,8 +345,8 @@ void CPropWin::SetData( HWND hwndDlg )
 	//	2001/06/20 End
 
 	//	Apr. 05, 2003 genta ウィンドウキャプションのカスタマイズ
-	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_WINCAPTION_ACTIVE   ), _countof( m_Common.m_sWindow.m_szWindowCaptionActive   ) - 1 );	//@@@ 2003.06.13 MIK
-	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_WINCAPTION_INACTIVE ), _countof( m_Common.m_sWindow.m_szWindowCaptionInactive ) - 1 );	//@@@ 2003.06.13 MIK
+	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_WINCAPTION_ACTIVE   ), std::size( m_Common.m_sWindow.m_szWindowCaptionActive   ) - 1 );	//@@@ 2003.06.13 MIK
+	EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_WINCAPTION_INACTIVE ), std::size( m_Common.m_sWindow.m_szWindowCaptionInactive ) - 1 );	//@@@ 2003.06.13 MIK
 	::DlgItem_SetText( hwndDlg, IDC_WINCAPTION_ACTIVE, m_Common.m_sWindow.m_szWindowCaptionActive );
 	::DlgItem_SetText( hwndDlg, IDC_WINCAPTION_INACTIVE, m_Common.m_sWindow.m_szWindowCaptionInactive );
 
@@ -452,16 +452,16 @@ int CPropWin::GetData( HWND hwndDlg )
 
 	//	Apr. 05, 2003 genta ウィンドウキャプションのカスタマイズ
 	::DlgItem_GetText( hwndDlg, IDC_WINCAPTION_ACTIVE, m_Common.m_sWindow.m_szWindowCaptionActive,
-		_countof( m_Common.m_sWindow.m_szWindowCaptionActive ) );
+		std::size( m_Common.m_sWindow.m_szWindowCaptionActive ) );
 	::DlgItem_GetText( hwndDlg, IDC_WINCAPTION_INACTIVE, m_Common.m_sWindow.m_szWindowCaptionInactive,
-		_countof( m_Common.m_sWindow.m_szWindowCaptionInactive ) );
+		std::size( m_Common.m_sWindow.m_szWindowCaptionInactive ) );
 
 	// 言語選択
 	HWND hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_LANGUAGE );
 	int nSelPos = Combo_GetCurSel( hwndCombo );
 	CSelectLang::SSelLangInfo *psLangInfo = CSelectLang::m_psLangInfoList.at( nSelPos );
 	if ( wcscmp( m_Common.m_sWindow.m_szLanguageDll, psLangInfo->szDllName ) != 0 ) {
-		wcsncpy( m_Common.m_sWindow.m_szLanguageDll, psLangInfo->szDllName, _countof(m_Common.m_sWindow.m_szLanguageDll) );
+		wcsncpy( m_Common.m_sWindow.m_szLanguageDll, psLangInfo->szDllName, std::size(m_Common.m_sWindow.m_szLanguageDll) );
 	}
 
 	return TRUE;

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -228,9 +228,9 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 		{ STR_PROPCOMMON_PLUGIN,	IDD_PROP_PLUGIN,	CPropPlugin::DlgProc_page },
 	};
 
-	std::wstring		sTabname[_countof(ComPropSheetInfoList)];
-	PROPSHEETPAGE		psp[_countof(ComPropSheetInfoList)];
-	for( nIdx = 0; nIdx < _countof(ComPropSheetInfoList); nIdx++ ){
+	std::wstring		sTabname[std::size(ComPropSheetInfoList)];
+	PROPSHEETPAGE		psp[std::size(ComPropSheetInfoList)];
+	for( nIdx = 0; nIdx < std::size(ComPropSheetInfoList); nIdx++ ){
 		sTabname[nIdx] = LS(ComPropSheetInfoList[nIdx].m_nTabNameId);
 
 		PROPSHEETPAGE *p = &psp[nIdx];

--- a/sakura_core/recent/CMRUFile.cpp
+++ b/sakura_core/recent/CMRUFile.cpp
@@ -95,7 +95,7 @@ HMENU CMRUFile::CreateMenu( HMENU	hMenuPopUp, CMenuDrawer* pCMenuDrawer ) const
 		const EditInfo	*p = m_cRecentFile.GetItem( i );
 		bFavorite = m_cRecentFile.IsFavorite( i );
 		bool bFavoriteLabel = bFavorite && !bMenuIcon;
-		CFileNameManager::getInstance()->GetMenuFullLabel_MRU( szMenu, _countof(szMenu), p, -1, bFavoriteLabel, i, dcFont.GetHDC() );
+		CFileNameManager::getInstance()->GetMenuFullLabel_MRU( szMenu, std::size(szMenu), p, -1, bFavoriteLabel, i, dcFont.GetHDC() );
 
 		//	メニューに追加。
 		pCMenuDrawer->MyAppendMenu( hMenuPopUp, MF_BYPOSITION | MF_STRING, IDM_SELMRU + i, szMenu, L"", TRUE,
@@ -202,7 +202,7 @@ void CMRUFile::Add( EditInfo* pEditInfo )
 		int nSize = m_pShareData->m_sHistory.m_aExceptMRU.size();
 		for( int i = 0 ; i < nSize; i++ ){
 			WCHAR szExceptMRU[_MAX_PATH];
-			CFileNameManager::ExpandMetaToFolder( m_pShareData->m_sHistory.m_aExceptMRU[i], szExceptMRU, _countof(szExceptMRU) );
+			CFileNameManager::ExpandMetaToFolder( m_pShareData->m_sHistory.m_aExceptMRU[i], szExceptMRU, std::size(szExceptMRU) );
 			if( NULL != wcsistr( pEditInfo->m_szPath,  szExceptMRU) ){
 				return;
 			}

--- a/sakura_core/recent/CMRUFolder.cpp
+++ b/sakura_core/recent/CMRUFolder.cpp
@@ -84,7 +84,7 @@ HMENU CMRUFolder::CreateMenu( HMENU	hMenuPopUp, CMenuDrawer* pCMenuDrawer ) cons
 		const WCHAR* pszFolder = m_cRecentFolder.GetItemText( i );
 		bFavorite = m_cRecentFolder.IsFavorite( i );
 		bool bFavoriteLabel = bFavorite && !m_pShareData->m_Common.m_sWindow.m_bMenuIcon;
-		CFileNameManager::getInstance()->GetMenuFullLabel( szMenu, _countof(szMenu), true, pszFolder, -1, false, CODE_NONE, bFavoriteLabel, i, true, dcFont.GetHDC() );
+		CFileNameManager::getInstance()->GetMenuFullLabel( szMenu, std::size(szMenu), true, pszFolder, -1, false, CODE_NONE, bFavoriteLabel, i, true, dcFont.GetHDC() );
 
 		//	メニューに追加
 		pCMenuDrawer->MyAppendMenu( hMenuPopUp, MF_BYPOSITION | MF_STRING, IDM_SELOPENFOLDER + i, szMenu, L"", TRUE,
@@ -131,7 +131,7 @@ void CMRUFolder::Add( const WCHAR* pszFolder )
 		int nSize = m_pShareData->m_sHistory.m_aExceptMRU.size();
 		for( int i = 0 ; i < nSize; i++ ){
 			WCHAR szExceptMRU[_MAX_PATH];
-			CFileNameManager::ExpandMetaToFolder( m_pShareData->m_sHistory.m_aExceptMRU[i], szExceptMRU, _countof(szExceptMRU) );
+			CFileNameManager::ExpandMetaToFolder( m_pShareData->m_sHistory.m_aExceptMRU[i], szExceptMRU, std::size(szExceptMRU) );
 			if( NULL != wcsistr( pszFolder, szExceptMRU ) ){
 				return;
 			}

--- a/sakura_core/recent/CRecentFile.cpp
+++ b/sakura_core/recent/CRecentFile.cpp
@@ -46,7 +46,7 @@ CRecentFile::CRecentFile()
 {
 	Create(
 		GetShareData()->m_sHistory.m_fiMRUArr,
-		_countof(GetShareData()->m_sHistory.m_fiMRUArr[0].m_szPath),
+		std::size(GetShareData()->m_sHistory.m_fiMRUArr[0].m_szPath),
 		&GetShareData()->m_sHistory.m_nMRUArrNum,
 		GetShareData()->m_sHistory.m_bMRUArrFavorite,
 		MAX_MRU,
@@ -62,7 +62,7 @@ bool CRecentFile::DataToReceiveType( const EditInfo** dst, const EditInfo* src )
 
 bool CRecentFile::TextToDataType( EditInfo* dst, LPCWSTR pszText ) const
 {
-	if( _countof(dst->m_szPath) < wcslen(pszText) + 1 ){
+	if( std::size(dst->m_szPath) < wcslen(pszText) + 1 ){
 		return false;
 	}
 	wcscpy(dst->m_szPath, pszText);

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -245,7 +245,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 						if( (nRet = RegistExt( ext, true )) != 0 )
 						{
 							WCHAR buf[BUFFER_SIZE] = {0};
-							::FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM, NULL, nRet, 0, buf, _countof(buf), NULL );
+							::FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM, NULL, nRet, 0, buf, std::size(buf), NULL );
 							::MessageBox( GetHwnd(), (wstring(LS(STR_DLGTYPELIST_ERR1)) + buf).c_str(), GSTR_APPNAME, MB_OK );
 							break;
 						}
@@ -253,7 +253,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 						if( (nRet = UnregistExt( ext )) != 0 )
 						{
 							WCHAR buf[BUFFER_SIZE] = {0};
-							::FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM, NULL, nRet, 0, buf, _countof(buf), NULL );
+							::FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM, NULL, nRet, 0, buf, std::size(buf), NULL );
 							::MessageBox( GetHwnd(), (wstring(LS(STR_DLGTYPELIST_ERR2)) + buf).c_str(), GSTR_APPNAME, MB_OK );
 							break;
 						}
@@ -283,7 +283,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 					if( (nRet = RegistExt( ext, checked )) != 0 )
 					{
 						WCHAR buf[BUFFER_SIZE] = {0};
-						::FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM, NULL, nRet, 0, buf, _countof(buf), NULL );
+						::FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM, NULL, nRet, 0, buf, std::size(buf), NULL );
 						::MessageBox( GetHwnd(), (wstring(LS(STR_DLGTYPELIST_ERR1)) + buf).c_str(), GSTR_APPNAME, MB_OK );
 						break;
 					}
@@ -588,12 +588,12 @@ bool CDlgTypeList::CopyType()
 			WCHAR szNum[12];
 			auto_sprintf( szNum, L"%d", n );
 			int nLen = wcslen( szNum );
-			WCHAR szTemp[_countof(type.m_szTypeName) + 12];
+			WCHAR szTemp[std::size(type.m_szTypeName) + 12];
 			wcscpy( szTemp, type.m_szTypeName );
 			int nTempLen = wcslen( szTemp );
 			CNativeW cmem;
 			// バッファをはみ出さないように
-			LimitStringLengthW( szTemp, nTempLen, _countof(type.m_szTypeName) - nLen - 1, cmem );
+			LimitStringLengthW( szTemp, nTempLen, std::size(type.m_szTypeName) - nLen - 1, cmem );
 			wcscpy( type.m_szTypeName, cmem.GetStringPtr() );
 			wcscat( type.m_szTypeName, szNum );
 			bUpdate = false;
@@ -728,7 +728,7 @@ int CopyRegistry(HKEY srcRoot, const wstring& srcPath, HKEY destRoot, const wstr
 		DWORD dwDataLen;
 		DWORD dwType;
 
-		errorCode = keySrc.EnumValue(index, szValue, _countof(szValue), &dwType, data, _countof(data), &dwDataLen );
+		errorCode = keySrc.EnumValue(index, szValue, std::size(szValue), &dwType, data, std::size(data), &dwDataLen );
 		if( errorCode == ERROR_NO_MORE_ITEMS ){
 			errorCode = 0;
 			break;
@@ -745,7 +745,7 @@ int CopyRegistry(HKEY srcRoot, const wstring& srcPath, HKEY destRoot, const wstr
 	WCHAR szSubKey[ BUFFER_SIZE ] = {0};
 	for (;;)
 	{
-		errorCode = keySrc.EnumKey(index, szSubKey, _countof(szSubKey));
+		errorCode = keySrc.EnumKey(index, szSubKey, std::size(szSubKey));
 		if( errorCode == ERROR_NO_MORE_ITEMS ){
 			errorCode = 0;
 			break;
@@ -772,7 +772,7 @@ int DeleteRegistry(HKEY root, const wstring& path)
 	WCHAR szSubKey[ BUFFER_SIZE ] = {0};
 	for (;;)
 	{
-		errorCode = keySrc.EnumKey(index, szSubKey, _countof(szSubKey));
+		errorCode = keySrc.EnumKey(index, szSubKey, std::size(szSubKey));
 		if( errorCode == ERROR_NO_MORE_ITEMS ){
 			errorCode = 0;
 			break;
@@ -835,7 +835,7 @@ int RegistExt(LPCWSTR sExt, bool bDefProg)
 	WCHAR szProgID_HKLM[ BUFFER_SIZE ] = {0};
 	if( ( errorCode = keyExt_HKLM.Open(HKEY_LOCAL_MACHINE, sDotExt.c_str(), KEY_READ) ) == 0 )
 	{
-		keyExt_HKLM.GetValue(NULL, szProgID_HKLM, _countof(szProgID_HKLM));
+		keyExt_HKLM.GetValue(NULL, szProgID_HKLM, std::size(szProgID_HKLM));
 	}
 
 	CRegKey keyExt;
@@ -845,7 +845,7 @@ int RegistExt(LPCWSTR sExt, bool bDefProg)
 	}
 
 	WCHAR szProgID[ BUFFER_SIZE ] = {0};
-	keyExt.GetValue(NULL, szProgID, _countof(szProgID));
+	keyExt.GetValue(NULL, szProgID, std::size(szProgID));
 
 	if(wcscmp( sGenProgID.c_str(), szProgID ) != 0) {
 		if( szProgID[0] != L'\0' )
@@ -876,7 +876,7 @@ int RegistExt(LPCWSTR sExt, bool bDefProg)
 	}
 
 	WCHAR sExePath[_MAX_PATH] = {0};
-	::GetModuleFileName( NULL, sExePath, _countof(sExePath) );
+	::GetModuleFileName( NULL, sExePath, std::size(sExePath) );
 	wstring sCommandPathArg = wstring() + L"\"" + sExePath + L"\" \"%1\"";
 	if( (errorCode = keyShellActionCommand.SetValue(NULL, sCommandPathArg.c_str())) != 0 ){ return errorCode; }
 
@@ -887,7 +887,7 @@ int RegistExt(LPCWSTR sExt, bool bDefProg)
 	CRegKey keyShell;
 	if( (errorCode = keyShell.Open(HKEY_CURRENT_USER, sShellPath.c_str(), KEY_READ | KEY_WRITE)) != 0 ){ return errorCode; }
 	WCHAR szShellValue[ BUFFER_SIZE ] = {0};
-	keyShell.GetValue(NULL, szShellValue, _countof(szShellValue));
+	keyShell.GetValue(NULL, szShellValue, std::size(szShellValue));
 	if(bDefProg)
 	{
 		if( wcscmp(szShellValue, ACTION_NAME) != 0 )
@@ -914,7 +914,7 @@ int RegistExt(LPCWSTR sExt, bool bDefProg)
 		else
 		{
 			WCHAR sBackupValue[ BUFFER_SIZE ] = {0};
-			keyBackup.GetValue(NULL, sBackupValue, _countof(sBackupValue));
+			keyBackup.GetValue(NULL, sBackupValue, std::size(sBackupValue));
 			keyShell.SetValue(NULL, sBackupValue);
 		}
 	}
@@ -958,7 +958,7 @@ int UnregistExt(LPCWSTR sExt)
 	}
 
 	WCHAR szProgID[ BUFFER_SIZE ] = {0};
-	keyExt.GetValue(NULL, szProgID, _countof(szProgID));
+	keyExt.GetValue(NULL, szProgID, std::size(szProgID));
 
 	if( szProgID[0] == L'\0' )
 	{
@@ -987,7 +987,7 @@ int UnregistExt(LPCWSTR sExt)
 	else
 	{
 		WCHAR szBackupValue[ BUFFER_SIZE ] = {0};
-		keyBackup.GetValue(NULL, szBackupValue, _countof(szBackupValue));
+		keyBackup.GetValue(NULL, szBackupValue, std::size(szBackupValue));
 		keyShell.SetValue(NULL, szBackupValue);
 	}
 
@@ -998,7 +998,7 @@ int UnregistExt(LPCWSTR sExt)
 		if( (errorCode = DeleteRegistry(HKEY_CURRENT_USER, sProgIDPath)) != 0 ){ return errorCode; }
 
 		WCHAR szBackupValue[ BUFFER_SIZE ] = {0};
-		keyExt.GetValue(PROGID_BACKUP_NAME, szBackupValue, _countof(szBackupValue));
+		keyExt.GetValue(PROGID_BACKUP_NAME, szBackupValue, std::size(szBackupValue));
 		if( szBackupValue[0] != L'\0' ){
 			keyExt.SetValue(NULL, szBackupValue);
 		}else{
@@ -1050,7 +1050,7 @@ int CheckExt(LPCWSTR sExt, bool *pbRMenu, bool *pbDblClick)
 	}
 
 	WCHAR szProgID[ BUFFER_SIZE ] = {0};
-	keyExt.GetValue(NULL, szProgID, _countof(szProgID));
+	keyExt.GetValue(NULL, szProgID, std::size(szProgID));
 
 	if(szProgID[0] == L'\0')
 	{
@@ -1068,7 +1068,7 @@ int CheckExt(LPCWSTR sExt, bool *pbRMenu, bool *pbDblClick)
 	CRegKey keyShell;
 	if( (errorCode = keyShell.Open(HKEY_CURRENT_USER, sShellPath.c_str(), KEY_READ)) != 0 ){ return errorCode; }
 	WCHAR szShellValue[ BUFFER_SIZE ] = {0};
-	keyShell.GetValue(NULL, szShellValue, _countof(szShellValue));
+	keyShell.GetValue(NULL, szShellValue, std::size(szShellValue));
 	if( wcscmp( szShellValue, ACTION_NAME ) == 0 )
 	{
 		*pbDblClick = true;

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -337,7 +337,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 	// 色の設定
 	if (m_nColorType >= 0 ) {
 		// 色指定あり
-		for (i = 0; i < _countof(colorInfoArr); i++) {
+		for (i = 0; i < std::size(colorInfoArr); i++) {
 			bool bDisp = m_Types.m_ColorInfoArr[i].m_bDisp;
 			m_Types.m_ColorInfoArr[i] = colorInfoArr[i];
 			m_Types.m_ColorInfoArr[i].m_bDisp = bDisp;		// 表示フラグはファイルのものを使用する
@@ -498,7 +498,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 	wchar_t szId[ MAX_PLUGIN_ID + 1 + 2 ];
 	if ((nPIdx = CPlug::GetPluginId( static_cast<EFunctionCode>( m_Types.m_eDefaultOutline ))) >= 0) {
 		cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineName, MakeStringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
-		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, _countof(szId) );
+		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, std::size(szId) );
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eDefaultOutline ))) != 0 ){
 			wchar_t szPlug[8];
 			_swprintf( szPlug, L"/%d", nPlug );
@@ -509,7 +509,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 	//  スマートインデント
 	if ((nPIdx = CPlug::GetPluginId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) >= 0) {
 		cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentName, MakeStringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
-		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, _countof(szId) );
+		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, std::size(szId) );
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) != 0 ){
 			wchar_t szPlug[8];
 			_swprintf( szPlug, L"/%d", nPlug );
@@ -814,7 +814,7 @@ bool CImpExpKeyHelp::Import( const wstring& sFileName, wstring& sErrMsg )
 	in.Close();
 
 	// 空きがあるなら番兵を設定
-	if( i < _countof(m_Types.m_KeyHelpArr) ){
+	if( i < std::size(m_Types.m_KeyHelpArr) ){
 		m_Types.m_KeyHelpArr[i].m_bUse = false;
 		m_Types.m_KeyHelpArr[i].m_szAbout[0] = L'\0';
 		m_Types.m_KeyHelpArr[i].m_szPath[0]  = L'\0';
@@ -865,7 +865,7 @@ bool CImpExpKeyHelp::Export( const wstring& sFileName, wstring& sErrMsg )
 bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 {
 	const auto& strPath = sFileName;
-	const int KEYNAME_SIZE = _countof(m_Common.m_sKeyBind.m_pKeyNameArr)-1;// 最後の１要素はダミー用に予約 2012.11.25 aroka
+	const int KEYNAME_SIZE = std::size(m_Common.m_sKeyBind.m_pKeyNameArr)-1;// 最後の１要素はダミー用に予約 2012.11.25 aroka
 	CommonSetting_KeyBind sKeyBind = m_Common.m_sKeyBind;
 
 	//オープン
@@ -929,8 +929,8 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 				int n, kc, nc;
 				//値 -> szData
 				wchar_t szData[1024];
-				wcsncpy(szData, in.ReadLineW().c_str(), _countof(szData) - 1);
-				szData[_countof(szData) - 1] = L'\0';
+				wcsncpy(szData, in.ReadLineW().c_str(), std::size(szData) - 1);
+				szData[std::size(szData) - 1] = L'\0';
 
 				//解析開始
 				cnt = swscanf(szData, L"KeyBind[%03d]=%04x,%n",
@@ -965,8 +965,8 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 					p = q + 1;
 				}
 
-				wcsncpy(sKeyBind.m_pKeyNameArr[i].m_szKeyName, p, _countof(sKeyBind.m_pKeyNameArr[i].m_szKeyName)-1);
-				sKeyBind.m_pKeyNameArr[i].m_szKeyName[_countof(sKeyBind.m_pKeyNameArr[i].m_szKeyName)-1] = '\0';
+				wcsncpy(sKeyBind.m_pKeyNameArr[i].m_szKeyName, p, std::size(sKeyBind.m_pKeyNameArr[i].m_szKeyName)-1);
+				sKeyBind.m_pKeyNameArr[i].m_szKeyName[std::size(sKeyBind.m_pKeyNameArr[i].m_szKeyName)-1] = '\0';
 			}
 		}
 	}

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -146,10 +146,10 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 	m_dwCustColors[0] = m_Types.m_ColorInfoArr[COLORIDX_TEXT].m_sColorAttr.m_cTEXT;
 	m_dwCustColors[1] = m_Types.m_ColorInfoArr[COLORIDX_TEXT].m_sColorAttr.m_cBACK;
 
-	std::wstring		sTabname[_countof(TypePropSheetInfoList)];
+	std::wstring		sTabname[std::size(TypePropSheetInfoList)];
 	m_bChangeKeyWordSet = false;
-	PROPSHEETPAGE		psp[_countof(TypePropSheetInfoList)];
-	for( nIdx = 0; nIdx < _countof(TypePropSheetInfoList); nIdx++ ){
+	PROPSHEETPAGE		psp[std::size(TypePropSheetInfoList)];
+	for( nIdx = 0; nIdx < std::size(TypePropSheetInfoList); nIdx++ ){
 		sTabname[nIdx] = LS(TypePropSheetInfoList[nIdx].m_nTabNameId);
 
 		PROPSHEETPAGE *p = &psp[nIdx];

--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -661,7 +661,7 @@ void CPropTypesColor::SetData( HWND hwndDlg )
 	HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_STRINGLITERAL );
 	Combo_ResetContent( hwndCombo );
 	int		nSelPos = 0;
-	for( i = 0; i < _countof( StringLitteralArr ); ++i ){
+	for( i = 0; i < std::size( StringLitteralArr ); ++i ){
 		Combo_InsertString( hwndCombo, i, LS(StringLitteralArr[i].nNameId) );
 		if( StringLitteralArr[i].nMethod == m_Types.m_nStringType ){		// テキストの折り返し方法
 			nSelPos = i;

--- a/sakura_core/typeprop/CPropTypesKeyHelp.cpp
+++ b/sakura_core/typeprop/CPropTypesKeyHelp.cpp
@@ -207,16 +207,16 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 					}
 				}
 				/* 更新するキー情報を取得する。 */
-				wmemset(szPath, 0, _countof(szPath));
-				::DlgItem_GetText( hwndDlg, IDC_EDIT_KEYHELP, szPath, _countof(szPath) );
+				wmemset(szPath, 0, std::size(szPath));
+				::DlgItem_GetText( hwndDlg, IDC_EDIT_KEYHELP, szPath, std::size(szPath) );
 				if( szPath[0] == L'\0' ) return FALSE;
 				/* 重複検査 */
 				nIndex2 = ListView_GetItemCount(hwndList);
 				WCHAR szPath2[_MAX_PATH];
 				int i;
 				for(i = 0; i < nIndex2; i++){
-					wmemset(szPath2, 0, _countof(szPath2));
-					ListView_GetItemText(hwndList, i, 2, szPath2, _countof(szPath2));
+					wmemset(szPath2, 0, std::size(szPath2));
+					ListView_GetItemText(hwndList, i, 2, szPath2, std::size(szPath2));
 					if( wcscmp(szPath, szPath2) == 0 ){
 						if( (wID ==IDC_BUTTON_KEYHELP_UPD) && (i == nIndex) ){	/* 更新時、変わっていなかったら何もしない */
 						}else{
@@ -302,8 +302,8 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 				if( 0 == nIndex ) return TRUE;	/* すでに先頭にある。 */
 				nIndex2 = 0;
 				bUse = ListView_GetCheckState(hwndList, nIndex);
-				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
-				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
+				ListView_GetItemText(hwndList, nIndex, 1, szAbout, std::size(szAbout));
+				ListView_GetItemText(hwndList, nIndex, 2, szPath, std::size(szPath));
 				ListView_DeleteItem(hwndList, nIndex);	/* 古いキーを削除 */
 				/* ON-OFF */
 				lvi.mask     = LVIF_TEXT;
@@ -335,8 +335,8 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 				nIndex2 = ListView_GetItemCount(hwndList);
 				if( nIndex2 - 1 == nIndex ) return TRUE;	/* すでに最終にある。 */
 				bUse = ListView_GetCheckState(hwndList, nIndex);
-				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
-				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
+				ListView_GetItemText(hwndList, nIndex, 1, szAbout, std::size(szAbout));
+				ListView_GetItemText(hwndList, nIndex, 2, szPath, std::size(szPath));
 				/* キーを追加する。 */
 				/* ON-OFF */
 				lvi.mask     = LVIF_TEXT;
@@ -371,8 +371,8 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 				if( nIndex2 <= 1 ) return TRUE;
 				nIndex2 = nIndex - 1;
 				bUse = ListView_GetCheckState(hwndList, nIndex);
-				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
-				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
+				ListView_GetItemText(hwndList, nIndex, 1, szAbout, std::size(szAbout));
+				ListView_GetItemText(hwndList, nIndex, 2, szPath, std::size(szPath));
 				ListView_DeleteItem(hwndList, nIndex);	/* 古いキーを削除 */
 				/* キーを追加する。 */
 				/* ON-OFF */
@@ -407,8 +407,8 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 				if( nIndex2 <= 1 ) return TRUE;
 				nIndex2 = nIndex + 2;
 				bUse = ListView_GetCheckState(hwndList, nIndex);
-				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
-				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
+				ListView_GetItemText(hwndList, nIndex, 1, szAbout, std::size(szAbout));
+				ListView_GetItemText(hwndList, nIndex, 2, szPath, std::size(szPath));
 				/* キーを追加する。 */
 				/* ON-OFF */
 				lvi.mask     = LVIF_TEXT;
@@ -481,8 +481,8 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 					nIndex = ListView_GetNextItem( hwndList, -1, LVNI_ALL | LVNI_FOCUSED );
 					return FALSE;
 				}
-				ListView_GetItemText(hwndList, nIndex, 1, szAbout, _countof(szAbout));
-				ListView_GetItemText(hwndList, nIndex, 2, szPath, _countof(szPath));
+				ListView_GetItemText(hwndList, nIndex, 1, szAbout, std::size(szAbout));
+				ListView_GetItemText(hwndList, nIndex, 2, szPath, std::size(szPath));
 				::DlgItem_SetText( hwndDlg, IDC_LABEL_KEYHELP_ABOUT, szAbout );	/* 辞書の説明 */
 				::DlgItem_SetText( hwndDlg, IDC_EDIT_KEYHELP, szPath );			/* ファイルパス */
 			}
@@ -528,7 +528,7 @@ void CPropTypesKeyHelp::SetData( HWND hwndDlg )
 
 	HWND hwndCombo = GetDlgItem(hwndDlg, IDC_COMBO_MENU);
 	Combo_ResetContent(hwndCombo);
-	for( i = 0; i < (int)_countof(nKeyHelpRMenuType); i++ ){
+	for( i = 0; i < (int)std::size(nKeyHelpRMenuType); i++ ){
 		Combo_AddString(hwndCombo, LS(nKeyHelpRMenuType[i]));
 	}
 	Combo_SetCurSel(hwndCombo, m_Types.m_eKeyHelpRMenuShowType);
@@ -602,8 +602,8 @@ int CPropTypesKeyHelp::GetData( HWND hwndDlg )
 			/* チェックボックス状態を取得してbUseにセット */
 			if(ListView_GetCheckState(hwndList, i))
 				bUse = true;
-			ListView_GetItemText( hwndList, i, 1, szAbout, _countof(szAbout) );
-			ListView_GetItemText( hwndList, i, 2, szPath, _countof(szPath) );
+			ListView_GetItemText( hwndList, i, 1, szAbout, std::size(szAbout) );
+			ListView_GetItemText( hwndList, i, 2, szPath, std::size(szPath) );
 			m_Types.m_KeyHelpArr[i].m_bUse = bUse;
 			wcscpy(m_Types.m_KeyHelpArr[i].m_szAbout, szAbout);
 			wcscpy(m_Types.m_KeyHelpArr[i].m_szPath, szPath);

--- a/sakura_core/typeprop/CPropTypesRegex.cpp
+++ b/sakura_core/typeprop/CPropTypesRegex.cpp
@@ -205,8 +205,8 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				}
 				
 				//挿入するキー情報を取得する。
-				wmemset(szColorIndex, 0, _countof(szColorIndex));
-				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, _countof(szColorIndex) );
+				wmemset(szColorIndex, 0, std::size(szColorIndex));
+				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, std::size(szColorIndex) );
 				//キー情報を挿入する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
@@ -244,8 +244,8 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 					return FALSE;
 				}
 				//追加するキー情報を取得する。
-				wmemset(szColorIndex, 0, _countof(szColorIndex));
-				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, _countof(szColorIndex) );
+				wmemset(szColorIndex, 0, std::size(szColorIndex));
+				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, std::size(szColorIndex) );
 				//キーを追加する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
@@ -282,8 +282,8 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 					return FALSE;
 				}
 				//追加するキー情報を取得する。
-				wmemset(szColorIndex, 0, _countof(szColorIndex));
-				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, _countof(szColorIndex) );
+				wmemset(szColorIndex, 0, std::size(szColorIndex));
+				::DlgItem_GetText( hwndDlg, IDC_COMBO_REGEX_COLOR, szColorIndex, std::size(szColorIndex) );
 				//キーを更新する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
@@ -325,7 +325,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				if( 0 == nIndex ) return TRUE;	//すでに先頭にある。
 				nIndex2 = 0;
 				ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
-				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
+				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, std::size(szColorIndex));
 				ListView_DeleteItem(hwndList, nIndex);	//古いキーを削除
 				//キーを追加する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
@@ -354,7 +354,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				nIndex2 = ListView_GetItemCount(hwndList);
 				if( nIndex2 - 1 == nIndex ) return TRUE;	//すでに最終にある。
 				ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
-				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
+				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, std::size(szColorIndex));
 				//キーを追加する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
@@ -385,7 +385,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				if( nIndex2 <= 1 ) return TRUE;
 				nIndex2 = nIndex - 1;
 				ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
-				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
+				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, std::size(szColorIndex));
 				ListView_DeleteItem(hwndList, nIndex);	//古いキーを削除
 				//キーを追加する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
@@ -416,7 +416,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				if( nIndex2 <= 1 ) return TRUE;
 				nIndex2 = nIndex + 2;
 				ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
-				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
+				ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, std::size(szColorIndex));
 				//キーを追加する。
 				lvi.mask     = LVIF_TEXT | LVIF_PARAM;
 				lvi.pszText  = &szKeyWord[0];
@@ -497,7 +497,7 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 					auto szKeyWord = std::make_unique<WCHAR[]>(nKeyWordSize);
 					szKeyWord[0] = L'\0';
 					ListView_GetItemText(hwndList, nIndex, 0, &szKeyWord[0], nKeyWordSize);
-					ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, _countof(szColorIndex));
+					ListView_GetItemText(hwndList, nIndex, 1, szColorIndex, std::size(szColorIndex));
 					::DlgItem_SetText( hwndDlg, IDC_EDIT_REGEX, &szKeyWord[0] );	/* 正規表現 */
 					hwndCombo = GetDlgItem( hwndDlg, IDC_COMBO_REGEX_COLOR );
 					for(i = 0, j = 0; i < COLORIDX_LAST; i++)
@@ -616,7 +616,7 @@ int CPropTypesRegex::GetData( HWND hwndDlg )
 {
 	HWND	hwndList;
 	int	nIndex, i, j;
-	const int szKeyWordSize = _countof(m_Types.m_RegexKeywordList) * 2 + 1;
+	const int szKeyWordSize = std::size(m_Types.m_RegexKeywordList) * 2 + 1;
 	auto szKeyWord = std::make_unique<WCHAR[]>(szKeyWordSize);
 	WCHAR	szColorIndex[256];
 
@@ -630,7 +630,7 @@ int CPropTypesRegex::GetData( HWND hwndDlg )
 	hwndList = GetDlgItem( hwndDlg, IDC_LIST_REGEX );
 	nIndex = ListView_GetItemCount(hwndList);
 	wchar_t* pKeyword = &m_Types.m_RegexKeywordList[0];
-	wchar_t* pKeywordLast = pKeyword + _countof(m_Types.m_RegexKeywordList) - 1;
+	wchar_t* pKeywordLast = pKeyword + std::size(m_Types.m_RegexKeywordList) - 1;
 	// key1\0key2\0\0 の形式
 	for(i = 0; i < MAX_REGEX_KEYWORD; i++)
 	{
@@ -639,7 +639,7 @@ int CPropTypesRegex::GetData( HWND hwndDlg )
 			szKeyWord[0]    = L'\0';
 			szColorIndex[0] = L'\0';
 			ListView_GetItemText(hwndList, i, 0, &szKeyWord[0], szKeyWordSize );
-			ListView_GetItemText(hwndList, i, 1, szColorIndex, _countof(szColorIndex));
+			ListView_GetItemText(hwndList, i, 1, szColorIndex, std::size(szColorIndex));
 			if( pKeyword < pKeywordLast - 1 ){
 				wcsncpy_s( pKeyword, pKeywordLast - pKeyword, &szKeyWord[0], _TRUNCATE );
 			}
@@ -720,7 +720,7 @@ bool CPropTypesRegex::CheckKeywordList(HWND hwndDlg, const WCHAR* szNewKeyWord, 
 			}
 			// 長さには\0も含む
 			nKeywordLen += wcsnlen(&szKeyWord[0], nKeyWordSize) + 1;
-			if( _countof(m_Types.m_RegexKeywordList) - 1 < nKeywordLen ){
+			if( std::size(m_Types.m_RegexKeywordList) - 1 < nKeywordLen ){
 				ErrorMessage( hwndDlg, LS(STR_PROPTYPEREGEX_FULL) );
 				return false;
 			}

--- a/sakura_core/typeprop/CPropTypesScreen.cpp
+++ b/sakura_core/typeprop/CPropTypesScreen.cpp
@@ -156,10 +156,10 @@ void CPropTypesScreen::CPropTypes_Screen()
 {
 	//プラグイン無効の場合、ここで静的メンバを初期化する。プラグイン有効の場合はAddXXXMethod内で初期化する。
 	if( m_OlmArr.empty() ){
-		InitTypeNameId2(m_OlmArr, OlmArr, _countof(OlmArr));	//アウトライン解析ルール
+		InitTypeNameId2(m_OlmArr, OlmArr, std::size(OlmArr));	//アウトライン解析ルール
 	}
 	if( m_SIndentArr.empty() ){
-		InitTypeNameId2(m_SIndentArr, SmartIndentArr, _countof(SmartIndentArr));	//スマートインデントルール
+		InitTypeNameId2(m_SIndentArr, SmartIndentArr, std::size(SmartIndentArr));	//スマートインデントルール
 	}
 }
 
@@ -206,10 +206,10 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
 
 		// エディットコントロールの入力文字数制限
-		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_TYPENAME        ), _countof( m_Types.m_szTypeName      ) - 1 );
-		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_TYPEEXTS        ), _countof( m_Types.m_szTypeExts      ) - 1 );
-		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_INDENTCHARS     ), _countof( m_Types.m_szIndentChars   ) - 1 );
-		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_TABVIEWSTRING   ), _countof( m_Types.m_szTabViewString ) - 1 );
+		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_TYPENAME        ), std::size( m_Types.m_szTypeName      ) - 1 );
+		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_TYPEEXTS        ), std::size( m_Types.m_szTypeExts      ) - 1 );
+		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_INDENTCHARS     ), std::size( m_Types.m_szIndentChars   ) - 1 );
+		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_TABVIEWSTRING   ), std::size( m_Types.m_szTabViewString ) - 1 );
 		EditCtl_LimitText( GetDlgItem( hwndDlg, IDC_EDIT_OUTLINERULEFILE ), _countof2( m_Types.m_szOutlineRuleFilename ) - 1 );	//	Oct. 5, 2002 genta 画面上でも入力制限
 
 		if( 0 == m_Types.m_nIdx ){
@@ -477,7 +477,7 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 		HWND	hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_WRAPMETHOD );
 		Combo_ResetContent( hwndCombo );
 		int		nSelPos = 0;
-		for( int i = 0; i < _countof( WrapMethodArr ); ++i ){
+		for( int i = 0; i < std::size( WrapMethodArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS( WrapMethodArr[i].nNameId ) );
 			if( WrapMethodArr[i].nMethod == m_Types.m_nTextWrapMethod ){		// テキストの折り返し方法
 				nSelPos = i;
@@ -496,7 +496,7 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_CHECK_TAB_ARROW );
 		Combo_ResetContent( hwndCombo );
 		nSelPos = 0;
-		for( int i = 0; i < _countof( TabArrowArr ); ++i ){
+		for( int i = 0; i < std::size( TabArrowArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS( TabArrowArr[i].nNameId ) );
 			if( TabArrowArr[i].nMethod == m_Types.m_bTabArrow ){
 				nSelPos = i;
@@ -510,7 +510,7 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_TSV_MODE );
 		Combo_ResetContent( hwndCombo );
 		nSelPos = 0;
-		for( int i = 0; i < _countof( TsvModeArr ); ++i ){
+		for( int i = 0; i < std::size( TsvModeArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS( TsvModeArr[i].nNameId ) );
 			if( TsvModeArr[i].nMethod == m_Types.m_nTsvMode ){
 				nSelPos = i;
@@ -551,7 +551,7 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_INDENTLAYOUT );
 		Combo_ResetContent( hwndCombo );
 		nSelPos = 0;
-		for( int i = 0; i < _countof( IndentTypeArr ); ++i ){
+		for( int i = 0; i < std::size( IndentTypeArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS( IndentTypeArr[i].nNameId ) );
 			if( IndentTypeArr[i].nMethod == m_Types.m_nIndentLayout ){	/* 折り返しインデント種別 */
 				nSelPos = i;
@@ -630,9 +630,9 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKURET,  m_Types.m_bKinsokuRet  );	/* 改行文字をぶら下げる */	//@@@ 2002.04.13 MIK
 			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKUKUTO, m_Types.m_bKinsokuKuto );	/* 句読点をぶら下げる */	//@@@ 2002.04.17 MIK
 			::CheckDlgButtonBool( hwndDlg, IDC_CHECK_KINSOKUHIDE, m_Types.m_bKinsokuHide );	// ぶら下げを隠す			// 2011/11/30 Uchi
-			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KINSOKUHEAD ), _countof(m_Types.m_szKinsokuHead) - 1 );
-			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KINSOKUTAIL ), _countof(m_Types.m_szKinsokuTail) - 1 );
-			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KINSOKUKUTO ), _countof(m_Types.m_szKinsokuKuto) - 1 );	// 2009.08.07 ryoji
+			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KINSOKUHEAD ), std::size(m_Types.m_szKinsokuHead) - 1 );
+			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KINSOKUTAIL ), std::size(m_Types.m_szKinsokuTail) - 1 );
+			EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_KINSOKUKUTO ), std::size(m_Types.m_szKinsokuKuto) - 1 );	// 2009.08.07 ryoji
 			::DlgItem_SetText( hwndDlg, IDC_EDIT_KINSOKUHEAD, m_Types.m_szKinsokuHead );
 			::DlgItem_SetText( hwndDlg, IDC_EDIT_KINSOKUTAIL, m_Types.m_szKinsokuTail );
 			::DlgItem_SetText( hwndDlg, IDC_EDIT_KINSOKUKUTO, m_Types.m_szKinsokuKuto );	// 2009.08.07 ryoji
@@ -644,8 +644,8 @@ void CPropTypesScreen::SetData( HWND hwndDlg )
 /* ダイアログデータの取得 Screen */
 int CPropTypesScreen::GetData( HWND hwndDlg )
 {
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_TYPENAME, m_Types.m_szTypeName, _countof( m_Types.m_szTypeName ) );	// 設定の名前
-	::DlgItem_GetText( hwndDlg, IDC_EDIT_TYPEEXTS, m_Types.m_szTypeExts, _countof( m_Types.m_szTypeExts ) );	// ファイル拡張子
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_TYPENAME, m_Types.m_szTypeName, std::size( m_Types.m_szTypeName ) );	// 設定の名前
+	::DlgItem_GetText( hwndDlg, IDC_EDIT_TYPEEXTS, m_Types.m_szTypeExts, std::size( m_Types.m_szTypeExts ) );	// ファイル拡張子
 
 	//レイアウト
 	{
@@ -682,7 +682,7 @@ int CPropTypesScreen::GetData( HWND hwndDlg )
 
 		/* TAB表示文字列 */
 		WIN_CHAR szTab[8+1]; /* +1. happy */
-		::DlgItem_GetText( hwndDlg, IDC_EDIT_TABVIEWSTRING, szTab, _countof( szTab ) );
+		::DlgItem_GetText( hwndDlg, IDC_EDIT_TABVIEWSTRING, szTab, std::size( szTab ) );
 		wcscpy( m_Types.m_szTabViewString, L"^       " );
 		for( int i = 0; i < 8; i++ ){
 			if( !TCODE::IsTabAvailableCode(szTab[i]) )break;
@@ -719,7 +719,7 @@ int CPropTypesScreen::GetData( HWND hwndDlg )
 		}
 
 		/* その他のインデント対象文字 */
-		::DlgItem_GetText( hwndDlg, IDC_EDIT_INDENTCHARS, m_Types.m_szIndentChars, _countof( m_Types.m_szIndentChars ) );
+		::DlgItem_GetText( hwndDlg, IDC_EDIT_INDENTCHARS, m_Types.m_szIndentChars, std::size( m_Types.m_szIndentChars ) );
 
 		// 折り返し行インデント	//	Oct. 1, 2002 genta コンボボックスに変更
 		hwndCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_INDENTLAYOUT );
@@ -774,9 +774,9 @@ int CPropTypesScreen::GetData( HWND hwndDlg )
 			m_Types.m_bKinsokuRet  = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKURET  );	// 改行文字をぶら下げる	//@@@ 2002.04.13 MIK
 			m_Types.m_bKinsokuKuto = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKUKUTO );	// 句読点をぶら下げる	//@@@ 2002.04.17 MIK
 			m_Types.m_bKinsokuHide = ::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_KINSOKUHIDE );	// ぶら下げを隠す		// 2011/11/30 Uchi
-			::DlgItem_GetText( hwndDlg, IDC_EDIT_KINSOKUHEAD, m_Types.m_szKinsokuHead, _countof( m_Types.m_szKinsokuHead ) );
-			::DlgItem_GetText( hwndDlg, IDC_EDIT_KINSOKUTAIL, m_Types.m_szKinsokuTail, _countof( m_Types.m_szKinsokuTail ) );
-			::DlgItem_GetText( hwndDlg, IDC_EDIT_KINSOKUKUTO, m_Types.m_szKinsokuKuto, _countof( m_Types.m_szKinsokuKuto ) );	// 2009.08.07 ryoji
+			::DlgItem_GetText( hwndDlg, IDC_EDIT_KINSOKUHEAD, m_Types.m_szKinsokuHead, std::size( m_Types.m_szKinsokuHead ) );
+			::DlgItem_GetText( hwndDlg, IDC_EDIT_KINSOKUTAIL, m_Types.m_szKinsokuTail, std::size( m_Types.m_szKinsokuTail ) );
+			::DlgItem_GetText( hwndDlg, IDC_EDIT_KINSOKUKUTO, m_Types.m_szKinsokuKuto, std::size( m_Types.m_szKinsokuKuto ) );	// 2009.08.07 ryoji
 		}	//@@@ 2002.04.08 MIK end
 	}
 
@@ -787,7 +787,7 @@ int CPropTypesScreen::GetData( HWND hwndDlg )
 void CPropTypesScreen::AddOutlineMethod(int nMethod, const WCHAR* pszName)
 {
 	if( m_OlmArr.empty() ){
-		InitTypeNameId2(m_OlmArr, OlmArr, _countof(OlmArr));	//アウトライン解析ルール
+		InitTypeNameId2(m_OlmArr, OlmArr, std::size(OlmArr));	//アウトライン解析ルール
 	}
 	TYPE_NAME_ID2<EOutlineType> method;
 	method.nMethod = (EOutlineType)nMethod;
@@ -812,7 +812,7 @@ void CPropTypesScreen::RemoveOutlineMethod(int nMethod, const WCHAR* szName)
 void CPropTypesScreen::AddSIndentMethod(int nMethod, const WCHAR* pszName)
 {
 	if( m_SIndentArr.empty() ){
-		InitTypeNameId2(m_SIndentArr, SmartIndentArr, _countof(SmartIndentArr));	//スマートインデントルール
+		InitTypeNameId2(m_SIndentArr, SmartIndentArr, std::size(SmartIndentArr));	//スマートインデントルール
 	}
 	TYPE_NAME_ID2<ESmartIndentType> method;
 	method.nMethod = (ESmartIndentType)nMethod;

--- a/sakura_core/typeprop/CPropTypesWindow.cpp
+++ b/sakura_core/typeprop/CPropTypesWindow.cpp
@@ -316,7 +316,7 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 		Combo_ResetContent( hwndCombo );
 		ime = m_Types.m_nImeState & 3;
 		int		nSelPos = 0;
-		for( int i = 0; i < _countof( ImeSwitchArr ); ++i ){
+		for( int i = 0; i < std::size( ImeSwitchArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS(ImeSwitchArr[i].nNameId) );
 			if( ImeSwitchArr[i].nMethod == ime ){	/* IME状態 */
 				nSelPos = i;
@@ -329,7 +329,7 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 		Combo_ResetContent( hwndCombo );
 		ime = m_Types.m_nImeState >> 2;
 		nSelPos = 0;
-		for( int i = 0; i < _countof( ImeStateArr ); ++i ){
+		for( int i = 0; i < std::size( ImeStateArr ); ++i ){
 			Combo_InsertString( hwndCombo, i, LS(ImeStateArr[i].nNameId) );
 			if( ImeStateArr[i].nMethod == ime ){	/* IME状態 */
 				nSelPos = i;
@@ -382,15 +382,15 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 
 		// デフォルト改行タイプのコンボボックス設定
 		hCombo = ::GetDlgItem( hwndDlg, IDC_COMBO_DEFAULT_EOLTYPE );
-		for( i = 0; i < _countof(aszEolStr); ++i ){
+		for( i = 0; i < std::size(aszEolStr); ++i ){
 			ApiWrap::Combo_AddString( hCombo, aszEolStr[i] );
 		}
-		for( i = 0; i < _countof(aeEolType); ++i ){
+		for( i = 0; i < std::size(aeEolType); ++i ){
 			if( m_Types.m_encoding.m_eDefaultEoltype == aeEolType[i] ){
 				break;
 			}
 		}
-		if( i == _countof(aeEolType) ){
+		if( i == std::size(aeEolType) ){
 			i = 0;
 		}
 		Combo_SetCurSel( hCombo, i );
@@ -430,7 +430,7 @@ void CPropTypesWindow::SetData( HWND hwndDlg )
 			STR_IMAGE_POS9,
 		};
 		/*BGIMAGE_TOP_LEFT .. */
-		int nCount = _countof(posNameId);
+		int nCount = std::size(posNameId);
 		SetCombobox( ::GetDlgItem(hwndDlg, IDC_COMBO_BACKIMG_POS), posNameId, nCount, m_Types.m_backImgPos);
 	}
 	CheckDlgButtonBool(hwndDlg, IDC_CHECK_BACKIMG_REP_X, m_Types.m_backImgRepeatX);

--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -86,8 +86,8 @@ void CShareData::InitTypeConfigs(DLLSHAREDATA* pShareData, std::vector<STypeConf
 		new CType_Ini(),	//設定ファイル
 	};
 	types.clear();
-	assert( _countof(table) <= MAX_TYPES );
-	for(int i = 0; i < _countof(table) && i < MAX_TYPES; i++){
+	assert( std::size(table) <= MAX_TYPES );
+	for(int i = 0; i < std::size(table) && i < MAX_TYPES; i++){
 		STypeConfig* type = new STypeConfig;
 		types.push_back(type);
 		table[i]->InitTypeConfig(i, *type);
@@ -211,7 +211,7 @@ void _DefaultConfig(STypeConfig* pType)
 
 	pType->m_nIndentLayout = 0;	/* 折り返しは2行目以降を字下げ表示 */
 
-	assert( COLORIDX_LAST <= _countof(pType->m_ColorInfoArr) );
+	assert( COLORIDX_LAST <= std::size(pType->m_ColorInfoArr) );
 	for( int i = 0; i < COLORIDX_LAST; ++i ){
 		GetDefaultColorInfo(&pType->m_ColorInfoArr[i],i);
 	}
@@ -260,7 +260,7 @@ void _DefaultConfig(STypeConfig* pType)
 	pType->m_bUseDocumentIcon = false;				// 文書に関連づけられたアイコンを使う
 
 //@@@ 2001.11.17 add start MIK
-	for(int i = 0; i < _countof(pType->m_RegexKeywordArr); i++)
+	for(int i = 0; i < std::size(pType->m_RegexKeywordArr); i++)
 	{
 		pType->m_RegexKeywordArr[i].m_nColorIndex = COLORIDX_REGEX1;
 	}

--- a/sakura_core/types/CType_Awk.cpp
+++ b/sakura_core/types/CType_Awk.cpp
@@ -127,4 +127,4 @@ const wchar_t* g_ppszKeywordsAWK[] = {
 	L"strftime",
 	L"systime"
 };
-int g_nKeywordsAWK = _countof(g_ppszKeywordsAWK);
+int g_nKeywordsAWK = std::size(g_ppszKeywordsAWK);

--- a/sakura_core/types/CType_Cobol.cpp
+++ b/sakura_core/types/CType_Cobol.cpp
@@ -243,4 +243,4 @@ const wchar_t* g_ppszKeywordsCOBOL[] = {
 	L"WRITTEN",
 	L"ZERO"
 };
-int g_nKeywordsCOBOL = _countof(g_ppszKeywordsCOBOL);
+int g_nKeywordsCOBOL = std::size(g_ppszKeywordsCOBOL);

--- a/sakura_core/types/CType_CorbaIdl.cpp
+++ b/sakura_core/types/CType_CorbaIdl.cpp
@@ -65,4 +65,4 @@ const wchar_t* g_ppszKeywordsCORBA_IDL[] = {
 	L"wchar_t",
 	L"wstring"
 };
-int g_nKeywordsCORBA_IDL = _countof(g_ppszKeywordsCORBA_IDL);
+int g_nKeywordsCORBA_IDL = std::size(g_ppszKeywordsCORBA_IDL);

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -548,7 +548,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 				// operator "" _userliteral
 				if( nMode2 == M2_OPERATOR_WORD ){
 					int nLen = wcslen(szWordPrev);
-					if( nLen + 1 < _countof(szWordPrev) ){
+					if( nLen + 1 < std::size(szWordPrev) ){
 						szWordPrev[nLen] = pLine[i];
 						szWordPrev[nLen + 1] = L'\0';
 					}
@@ -772,7 +772,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					int nLen = (int)wcslen(szWordPrev);
 					if( nMode2 == M2_NORMAL && C_IsOperator(szWordPrev, nLen) ){
 						// 演算子のオペレータだった operator ""i
-						if( nLen + 1 < _countof(szWordPrev) ){
+						if( nLen + 1 < std::size(szWordPrev) ){
 							szWordPrev[nLen] = pLine[i];
 							szWordPrev[nLen + 1] = L'\0';
 						}
@@ -789,7 +789,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							for( int k = i + 1; k < nLineLen; k++ ){
 								if( pLine[k] == L'(' ){
 									// i = 1, k = 5, len = 5-1-1=3
-									CLogicInt tagLen = t_min(k - i - 1, CLogicInt(_countof(szRawStringTag) - 1));
+									CLogicInt tagLen = t_min(k - i - 1, CLogicInt(std::size(szRawStringTag) - 1));
 									nRawStringTagLen = tagLen + 1;
 									szRawStringTag[0] = L')';
 									wcsncpy( szRawStringTag + 1, &pLine[i+1], tagLen );
@@ -931,7 +931,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 							for( k++; k < nLineLen && C_IsSpace(pLine[k], bExtEol); k++){}
 							if( k < nLineLen && (pLine[k] == L'<' || pLine[k] == L'(' ) ){
 								// オペレータだった operator()( / operator()<;
-								if( nLen + 1 < _countof(szWordPrev) ){
+								if( nLen + 1 < std::size(szWordPrev) ){
 									szWordPrev[nLen] = pLine[i];
 									szWordPrev[nLen + 1] = L'\0';
 								}
@@ -1009,7 +1009,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					//  2002/10/27 frozen ここまで
 					if( nMode2 == M2_OPERATOR_WORD ){
 						int nLen = wcslen(szWordPrev);
-						if( nLen + 1 < _countof(szWordPrev) ){
+						if( nLen + 1 < std::size(szWordPrev) ){
 							szWordPrev[nLen] = pLine[i];
 							szWordPrev[nLen + 1] = L'\0';
 						}
@@ -1027,7 +1027,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					int nLen = (int)wcslen(szWordPrev);
 					if( nMode2 == M2_NORMAL && C_IsOperator(szWordPrev, nLen) ){
 						// 演算子のオペレータだった operator []
-						if( nLen + 1 < _countof(szWordPrev) ){
+						if( nLen + 1 < std::size(szWordPrev) ){
 							szWordPrev[nLen] = pLine[i];
 							szWordPrev[nLen + 1] = L'\0';
 						}
@@ -1050,7 +1050,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 					}
 					if( nMode2 == M2_OPERATOR_WORD ){
 						int nLen = wcslen(szWordPrev);
-						if( nLen + 1 < _countof(szWordPrev) ){
+						if( nLen + 1 < std::size(szWordPrev) ){
 							szWordPrev[nLen] = pLine[i];
 							szWordPrev[nLen + 1] = L'\0';
 						}
@@ -1629,7 +1629,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 		ptCP.y = GetCaret().GetCaretLogicPos().y;
 
 		nSrcLen = sRangeA.GetTo().x - sRangeA.GetFrom().x;
-		if( nSrcLen >= _countof( pszSrc ) - 1 ){
+		if( nSrcLen >= std::size( pszSrc ) - 1 ){
 			//	Sep. 18, 2002 genta メモリリーク対策
 			delete [] pszData;
 			return;
@@ -1845,4 +1845,4 @@ const wchar_t* g_ppszKeywordsCPP[] = {
 	L"xor",
 	L"xor_eq",
 };
-int g_nKeywordsCPP = _countof(g_ppszKeywordsCPP);
+int g_nKeywordsCPP = std::size(g_ppszKeywordsCPP);

--- a/sakura_core/types/CType_Dos.cpp
+++ b/sakura_core/types/CType_Dos.cpp
@@ -115,4 +115,4 @@ const wchar_t* g_ppszKeywordsBAT[] = {
 	L"SETLOCAL",
 	L"ENDLOCAL"
 };
-int g_nKeywordsBAT = _countof(g_ppszKeywordsBAT);
+int g_nKeywordsBAT = std::size(g_ppszKeywordsBAT);

--- a/sakura_core/types/CType_Erlang.cpp
+++ b/sakura_core/types/CType_Erlang.cpp
@@ -129,7 +129,7 @@ const wchar_t* COutlineErlang::ScanFuncName( const wchar_t* buf, const wchar_t* 
 		} while( IS_ALNUM( *p ) && p < end );
 	}
 	
-	int buf_len = _countof( m_func );
+	int buf_len = std::size( m_func );
 	int len = p - buf;
 	if( buf[0] == L'\'' ){
 		++buf;
@@ -224,7 +224,7 @@ const wchar_t* COutlineErlang::ScanArgs( const wchar_t* end, const wchar_t* p )
 {
 	assert( m_state == STATE_FUNC_ARGS );
 
-	const int parptr_max = _countof( m_parenthesis );
+	const int parptr_max = std::size( m_parenthesis );
 	wchar_t quote = L'\0'; // 先頭位置を保存
 	for(const wchar_t* head = p ; p < end ; p++ ){
 		if( quote ){
@@ -390,7 +390,7 @@ bool COutlineErlang::parse( const wchar_t* buf, int linelen, CLogicInt linenum )
 */ 
 void COutlineErlang::build_arity( int arity )
 {
-	const int buf_size = _countof( m_func );
+	const int buf_size = std::size( m_func );
 	int len = wcsnlen( m_func, buf_size );
 	wchar_t *p = &m_func[len];
 	wchar_t numstr[12];

--- a/sakura_core/types/CType_Html.cpp
+++ b/sakura_core/types/CType_Html.cpp
@@ -139,7 +139,7 @@ void CDocOutline::MakeTopicList_html(CFuncInfoArr* pcFuncInfoArr, bool bXml)
 				pLine++; i++;
 				bEndTag = true;
 			}
-			for(j=0;i+j<nLineLen && j<_countof(szTitle)-1; )
+			for(j=0;i+j<nLineLen && j<std::size(szTitle)-1; )
 			{
 				// タグ名を切り出す
 				// スペース、タブ、「_:-.英数」以外の半角文字、１文字目の「-.数字」は認めない。
@@ -312,12 +312,12 @@ void CDocOutline::MakeTopicList_html(CFuncInfoArr* pcFuncInfoArr, bool bXml)
 								}
 							}
 						}
-						if (x < _countof(szTitle) - 3) {
+						if (x < std::size(szTitle) - 3) {
 							if(!bEndTag)
 							{
 								szTitle[k++]	=	L' ';
 								bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
-								for (; i+j < nLineLen && k < _countof(szTitle) -1 ; k++, j++) {
+								for (; i+j < nLineLen && k < std::size(szTitle) -1 ; k++, j++) {
 									if (pLine[j]==L'<' || WCODE::IsLineDelimiter(pLine[j], bExtEol)){
 										j--;
 										break;
@@ -331,7 +331,7 @@ void CDocOutline::MakeTopicList_html(CFuncInfoArr* pcFuncInfoArr, bool bXml)
 					}
 					else
 					{
-						for(;i+j<nLineLen && j<_countof(szTitle)-1;j++)
+						for(;i+j<nLineLen && j<std::size(szTitle)-1;j++)
 						{
 							if(pLine[j]==L'>')
 							{
@@ -641,4 +641,4 @@ const wchar_t* g_ppszKeywordsHTML[] = {
 	L"WRAP",
 	L"XMP"
 };
-int g_nKeywordsHTML = _countof(g_ppszKeywordsHTML);
+int g_nKeywordsHTML = std::size(g_ppszKeywordsHTML);

--- a/sakura_core/types/CType_Java.cpp
+++ b/sakura_core/types/CType_Java.cpp
@@ -174,7 +174,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 							&ptPosXY_Layout
 						);
 						wchar_t szWork[256];
-						if( 0 < auto_snprintf_s( szWork, _countof(szWork), L"%ls::%ls", szClass, LS(STR_OUTLINE_JAVA_DEFPOS) ) ){
+						if( 0 < auto_snprintf_s( szWork, std::size(szWork), L"%ls::%ls", szClass, LS(STR_OUTLINE_JAVA_DEFPOS) ) ){
 							pcFuncInfoArr->AppendData( ptPosXY_Logic.GetY2() + CLogicInt(1), ptPosXY_Layout.GetY2() + CLayoutInt(1), szWork, nFuncId ); //2007.10.09 kobake レイアウト・ロジックの混在バグ修正
 						}
 					}
@@ -276,7 +276,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 								&ptPosXY
 							);
 							wchar_t szWork[256];
-							if( 0 < auto_snprintf_s( szWork, _countof(szWork), L"%ls::%ls", szClass, szFuncName ) ){
+							if( 0 < auto_snprintf_s( szWork, std::size(szWork), L"%ls::%ls", szClass, szFuncName ) ){
 								pcFuncInfoArr->AppendData( nFuncLine, ptPosXY.GetY2() + CLayoutInt(1), szWork, nFuncId );
 							}
 						}
@@ -417,7 +417,7 @@ void CDocOutline::MakeFuncList_Java( CFuncInfoArr* pcFuncInfoArr )
 								&ptPosXY
 							);
 							wchar_t szWork[256];
-							if( 0 < auto_snprintf_s( szWork, _countof(szWork), L"%ls::%ls", szClass, szFuncName ) ){
+							if( 0 < auto_snprintf_s( szWork, std::size(szWork), L"%ls::%ls", szClass, szFuncName ) ){
 								pcFuncInfoArr->AppendData( nFuncLine, ptPosXY.GetY2() + CLayoutInt(1), szWork, nFuncId );
 							}
 						}
@@ -503,4 +503,4 @@ const wchar_t* g_ppszKeywordsJAVA[] = {
 	L"volatile",
 	L"while"
 };
-int g_nKeywordsJAVA = _countof(g_ppszKeywordsJAVA);
+int g_nKeywordsJAVA = std::size(g_ppszKeywordsJAVA);

--- a/sakura_core/types/CType_Pascal.cpp
+++ b/sakura_core/types/CType_Pascal.cpp
@@ -117,4 +117,4 @@ const wchar_t* g_ppszKeywordsPASCAL[] = {
 	L"protected",
 	L"override"
 };
-int g_nKeywordsPASCAL = _countof(g_ppszKeywordsPASCAL);
+int g_nKeywordsPASCAL = std::size(g_ppszKeywordsPASCAL);

--- a/sakura_core/types/CType_Perl.cpp
+++ b/sakura_core/types/CType_Perl.cpp
@@ -411,7 +411,7 @@ const wchar_t* g_ppszKeywordsPERL[] = {
 	L"warn",
 	L"write"
 };
-int g_nKeywordsPERL = _countof(g_ppszKeywordsPERL);
+int g_nKeywordsPERL = std::size(g_ppszKeywordsPERL);
 
 //Jul. 10, 2001 JEPRO	変数を第２強調キーワードとして分離した
 // 2008/05/05 novice 重複文字列削除
@@ -518,4 +518,4 @@ const wchar_t* g_ppszKeywordsPERL2[] = {
 	L"$ENV",
 	L"$SIG"
 };
-int g_nKeywordsPERL2 = _countof(g_ppszKeywordsPERL2);
+int g_nKeywordsPERL2 = std::size(g_ppszKeywordsPERL2);

--- a/sakura_core/types/CType_Python.cpp
+++ b/sakura_core/types/CType_Python.cpp
@@ -510,8 +510,8 @@ void CDocOutline::MakeFuncList_python( CFuncInfoArr* pcFuncInfoArr )
 			int len = w_end - col;
 			
 			if( len > 0 ){
-				if( len > _countof( szWord ) - 1){
-					len = _countof( szWord ) - 1;
+				if( len > std::size( szWord ) - 1){
+					len = std::size( szWord ) - 1;
 				}
 				wcsncpy( szWord, pLine + col, len );
 				szWord[ len ] = L'\0';
@@ -521,9 +521,9 @@ void CDocOutline::MakeFuncList_python( CFuncInfoArr* pcFuncInfoArr )
 				len = 8;
 			}
 			if( nItemFuncId == 4  ){
-				if( _countof( szWord ) - 8  < len ){
+				if( std::size( szWord ) - 8  < len ){
 					//	後ろを削って入れる
-					len = _countof( szWord ) - 8;
+					len = std::size( szWord ) - 8;
 				}
 				// class
 				wcscpy( szWord + len, LS(STR_OUTLINE_PYTHON_CLASS) );
@@ -591,4 +591,4 @@ const wchar_t* g_ppszKeywordsPython[] = {
 	L"yield",
 	L"self",
 };
-int g_nKeywordsPython = _countof(g_ppszKeywordsPython);
+int g_nKeywordsPython = std::size(g_ppszKeywordsPython);

--- a/sakura_core/types/CType_Rich.cpp
+++ b/sakura_core/types/CType_Rich.cpp
@@ -131,4 +131,4 @@ const wchar_t* g_ppszKeywordsRTF[] = {
 	L"eml",
 	L"emr"
 };
-int g_nKeywordsRTF = _countof(g_ppszKeywordsRTF);
+int g_nKeywordsRTF = std::size(g_ppszKeywordsRTF);

--- a/sakura_core/types/CType_Sql.cpp
+++ b/sakura_core/types/CType_Sql.cpp
@@ -455,4 +455,4 @@ const wchar_t* g_ppszKeywordsPLSQL[] = {
 	L"OTHERS",
 	L"SQLCODE"
 };
-int g_nKeywordsPLSQL = _countof(g_ppszKeywordsPLSQL);
+int g_nKeywordsPLSQL = std::size(g_ppszKeywordsPLSQL);

--- a/sakura_core/types/CType_Tex.cpp
+++ b/sakura_core/types/CType_Tex.cpp
@@ -172,7 +172,7 @@ public:
 
 		// トピック文字列を作成する(1)。トビック番号をバッファに埋め込む。
 		if (bAddNumber) {
-			assert(4 * HierarchyCount + 2 <= _countof(szTopic)); // 4 はトピック番号「ddd.」のドットを含む最大桁数。+2 はヌル文字を含む " " の分。
+			assert(4 * HierarchyCount + 2 <= std::size(szTopic)); // 4 はトピック番号「ddd.」のドットを含む最大桁数。+2 はヌル文字を含む " " の分。
 			int i = 0;
 			while (i <= tagDepth && serials[i] == 0) {
 				i += 1; // "0." プリフィックスを表示しないようにスキップする。
@@ -184,10 +184,10 @@ public:
 			*pTopicEnd++ = L' ';
 			*pTopicEnd   = L'\0';
 		}
-		assert(pTopicEnd < szTopic + _countof(szTopic));
+		assert(pTopicEnd < szTopic + std::size(szTopic));
 
 		// トピック文字列を作成する(2)。タイトルをバッファに埋め込む。
-		const ptrdiff_t copyLen = t_min(szTopic + _countof(szTopic) - 1 - pTopicEnd, pTitleEnd - pTitle);
+		const ptrdiff_t copyLen = t_min(szTopic + std::size(szTopic) - 1 - pTopicEnd, pTitleEnd - pTitle);
 		wmemcpy(pTopicEnd, pTitle, copyLen);
 		pTopicEnd += copyLen;
 		*pTopicEnd = L'\0';
@@ -240,7 +240,7 @@ public:
 
 			const wchar_t Meta[] = { L'\\', L'%' };
 			const wchar_t* p = pLine;
-			while (pLineEnd != (p = std::find_first_of(p, pLineEnd, Meta, Meta + _countof(Meta)))) {
+			while (pLineEnd != (p = std::find_first_of(p, pLineEnd, Meta, Meta + std::size(Meta)))) {
 				if (*p == L'%') {
 					break; // コメントなので以降はいらない。
 				}
@@ -811,7 +811,7 @@ const wchar_t* g_ppszKeywordsTEX[] = {
 //			"\\}",
 //			"\\~",
 };
-int g_nKeywordsTEX = _countof(g_ppszKeywordsTEX);
+int g_nKeywordsTEX = std::size(g_ppszKeywordsTEX);
 
 //Jan. 19, 2001 JEPRO	TeX のキーワード2として新規追加 & 一部復活 --環境コマンドとオプション名が中心
 const wchar_t* g_ppszKeywordsTEX2[] = {
@@ -935,4 +935,4 @@ const wchar_t* g_ppszKeywordsTEX2[] = {
 //		"zh",
 //		"zw"
 };
-int g_nKeywordsTEX2 = _countof(g_ppszKeywordsTEX2);
+int g_nKeywordsTEX2 = std::size(g_ppszKeywordsTEX2);

--- a/sakura_core/types/CType_Text.cpp
+++ b/sakura_core/types/CType_Text.cpp
@@ -70,12 +70,12 @@ void CType_Text::InitTypeConfigImp(STypeConfig* pType)
 	pType->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_URL;	// 色指定番号
 	wcscpyn( &pKeyword[keywordPos],			// 正規表現キーワード
 		L"/(?<=\")(\\b[a-zA-Z]:|\\B\\\\\\\\)[^\"\\r\\n]*/k",			//   ""で挟まれた C:\～, \\～ にマッチするパターン
-		_countof(pType->m_RegexKeywordList) - 1 );
+		std::size(pType->m_RegexKeywordList) - 1 );
 	keywordPos += wcslen(&pKeyword[keywordPos]) + 1;
 	pType->m_RegexKeywordArr[1].m_nColorIndex = COLORIDX_URL;	// 色指定番号
 	wcscpyn( &pKeyword[keywordPos],			// 正規表現キーワード
 		L"/(\\b[a-zA-Z]:\\\\|\\B\\\\\\\\)[\\w\\-_.\\\\\\/$%~]*/k",		//   C:\～, \\～ にマッチするパターン
-		_countof(pType->m_RegexKeywordList) - keywordPos - 1 );
+		std::size(pType->m_RegexKeywordList) - keywordPos - 1 );
 	keywordPos += wcslen(&pKeyword[keywordPos]) + 1;
 	pKeyword[keywordPos] = L'\0';
 }
@@ -298,7 +298,7 @@ void CDocOutline::MakeTopicList_wztxt(CFuncInfoArr* pcFuncInfoArr)
 			nLength = auto_sprintf(szTitle,L"%d - ", level );
 			
 			wchar_t *pDest = szTitle + nLength; // 書き込み先
-			wchar_t *pDestEnd = szTitle + _countof(szTitle) - 2;
+			wchar_t *pDestEnd = szTitle + std::size(szTitle) - 2;
 			
 			while( pDest < pDestEnd )
 			{

--- a/sakura_core/types/CType_Vb.cpp
+++ b/sakura_core/types/CType_Vb.cpp
@@ -521,7 +521,7 @@ const wchar_t* g_ppszKeywordsVB[] = {
 	//Short
 	//Structure
 };
-int g_nKeywordsVB = _countof(g_ppszKeywordsVB);
+int g_nKeywordsVB = std::size(g_ppszKeywordsVB);
 
 //Jul. 10, 2001 JEPRO 追加
 const wchar_t* g_ppszKeywordsVB2[] = {
@@ -721,4 +721,4 @@ const wchar_t* g_ppszKeywordsVB2[] = {
 	L"VarPrtArray",
 	L"VarPtrStringArray"
 };
-int g_nKeywordsVB2 = _countof(g_ppszKeywordsVB2);
+int g_nKeywordsVB2 = std::size(g_ppszKeywordsVB2);

--- a/sakura_core/uiparts/CMenuDrawer.cpp
+++ b/sakura_core/uiparts/CMenuDrawer.cpp
@@ -628,7 +628,7 @@ CMenuDrawer::CMenuDrawer()
 
 /* 481 */		F_DISABLE			/*, TBSTATE_ENABLED, TBSTYLE_BUTTON, 0, 0 */	//最終行用ダミー(Jepro note: 最終行末にはカンマを付けないこと)
 	};
-	int tbd_num = _countof( tbd );
+	int tbd_num = std::size( tbd );
 
 	// m_tbMyButton[0]にはセパレータが入っているため、アイコン番号とボタン番号は１つずれる
 	const int INDEX_GAP = 1;
@@ -790,8 +790,8 @@ void CMenuDrawer::MyAppendMenu(
 
 	szLabel[0] = L'\0';
 	if( NULL != pszLabel ){
-		wcsncpy( szLabel, pszLabel, _countof( szLabel ) - 1 );
-		szLabel[ _countof( szLabel ) - 1 ] = L'\0';
+		wcsncpy( szLabel, pszLabel, std::size( szLabel ) - 1 );
+		szLabel[ std::size( szLabel ) - 1 ] = L'\0';
 	}
 	wcscpy( szKey, pszKey); 
 	if( nFuncId != 0 ){
@@ -804,7 +804,7 @@ void CMenuDrawer::MyAppendMenu(
 			szLabel,
 			szKey,
 			bAddKeyStr,
-			_countof(szLabel)
+			std::size(szLabel)
 		 );
 
 		/* アイコン用ビットマップを持つものは、オーナードロウにする */
@@ -1465,7 +1465,7 @@ LRESULT CMenuDrawer::OnMenuChar( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 		mii.fType = MFT_STRING;
 		wcscpy( szText, L"--unknown--" );
 		mii.dwTypeData = szText;
-		mii.cch = _countof( szText ) - 1;
+		mii.cch = std::size( szText ) - 1;
 		if( 0 == ::GetMenuItemInfo( hmenu, i, TRUE, &mii ) ){
 			continue;
 		}

--- a/sakura_core/util/MessageBoxF.cpp
+++ b/sakura_core/util/MessageBoxF.cpp
@@ -97,7 +97,7 @@ int VMessageBoxF(
 	hwndOwner=GetMessageBoxOwner(hwndOwner);
 	//整形
 	static WCHAR szBuf[16000];
-	tchar_vsnprintf_s(szBuf,_countof(szBuf),lpText,v);
+	tchar_vsnprintf_s(szBuf,std::size(szBuf),lpText,v);
 	//API呼び出し
 	return ::MessageBox( hwndOwner, szBuf, lpCaption, uType);
 }

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -115,7 +115,7 @@ public:
 	CHAR_TYPE At(int nIndex) const{ return m_szData[nIndex]; }
 
 	//簡易コピー
-	void Assign(const CHAR_TYPE* src){ if(!src) m_szData[0]=0; else wcscpy_s(m_szData,_countof(m_szData),src); }
+	void Assign(const CHAR_TYPE* src){ if(!src) m_szData[0]=0; else wcscpy_s(m_szData,std::size(m_szData),src); }
 	Me& operator = (const CHAR_TYPE* src){ Assign(src); return *this; }
 
 	//各種メソッド

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -65,7 +65,7 @@ bool IsFilePath(
 )
 {
 	wchar_t	szJumpToFile[_MAX_PATH];
-	wmemset( szJumpToFile, 0, _countof( szJumpToFile ) );
+	wmemset( szJumpToFile, 0, std::size( szJumpToFile ) );
 
 	size_t	nLineLen = wcslen( pLine );
 
@@ -97,7 +97,7 @@ bool IsFilePath(
 	*pnBgn = i;
 	size_t cur_pos = 0;
 	size_t tmp_end = 0;
-	for( ; i <= nLineLen && cur_pos + 1 < _countof(szJumpToFile); ++i ){
+	for( ; i <= nLineLen && cur_pos + 1 < std::size(szJumpToFile); ++i ){
 		//ファイル名終端を検知する
 		if( WCODE::IsLineDelimiterExt(pLine[i]) || pLine[i] == L'\0' ){
 			break;
@@ -462,7 +462,7 @@ void GetExedir(
 	
 	WCHAR	szPath[_MAX_PATH];
 	// sakura.exe のパスを取得
-	::GetModuleFileName( NULL, szPath, _countof(szPath) );
+	::GetModuleFileName( NULL, szPath, std::size(szPath) );
 	if( szFile == NULL ){
 		SplitPath_FolderAndFile( szPath, pDir, NULL );
 	}

--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -383,8 +383,8 @@ BOOL IsWow64()
 
 CCurrentDirectoryBackupPoint::CCurrentDirectoryBackupPoint()
 {
-	int n = ::GetCurrentDirectory(_countof(m_szCurDir),m_szCurDir);
-	if(n>0 && n<_countof(m_szCurDir)){
+	int n = ::GetCurrentDirectory(std::size(m_szCurDir),m_szCurDir);
+	if(n>0 && n<std::size(m_szCurDir)){
 		//ok
 	}
 	else{

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -566,7 +566,7 @@ BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData)
 			dwData = 1;	// 目次ページ
 
 		WCHAR buf[256];
-		swprintf( buf, _countof(buf), L"https://sakura-editor.github.io/help/HLP%06Iu.html", dwData );
+		swprintf( buf, std::size(buf), L"https://sakura-editor.github.io/help/HLP%06Iu.html", dwData );
 		ShellExecute( ::GetActiveWindow(), NULL, buf, NULL, NULL, SW_SHOWNORMAL );
 	}
 

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -236,27 +236,27 @@ void	wcstombs_vector(const wchar_t* pSrc, int nSrcLen, std::vector<char>* ret); 
 template <size_t Size>
 int wcsncmp_literal(const wchar_t* strData1, const wchar_t (&literalData2)[Size]) {
 	assert(literalData2[Size - 1] == 0);
-	return ::wcsncmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、_countofからマイナス1する
+	return ::wcsncmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、std::sizeからマイナス1する
 }
 
 //strncmpの文字数指定をliteralData2の大きさで取得してくれる版
 template <size_t Size>
 int strncmp_literal(const char* strData1, const char (&literalData2)[Size]) {
 	assert(literalData2[Size - 1] == 0);
-	return ::strncmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、_countofからマイナス1する
+	return ::strncmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、std::sizeからマイナス1する
 }
 
 //_wcsnicmpの文字数指定をliteralData2の大きさで取得してくれる版
 template <size_t Size>
 int wcsnicmp_literal(const wchar_t* strData1, const wchar_t (&literalData2)[Size]) {
 	assert(literalData2[Size - 1] == 0);
-	return ::_wcsnicmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、_countofからマイナス1する
+	return ::_wcsnicmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、std::sizeからマイナス1する
 }
 
 //_strnicmpの文字数指定をliteralData2の大きさで取得してくれる版
 template <size_t Size>
 int strnicmp_literal(const char* strData1, const char (&literalData2)[Size]) {
 	assert(literalData2[Size - 1] == 0);
-	return ::_strnicmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、_countofからマイナス1する
+	return ::_strnicmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、std::sizeからマイナス1する
 }
 #endif /* SAKURA_STRING_EX_87282FEB_4B23_4112_9C5A_419F43618705_H_ */

--- a/sakura_core/util/string_ex2.cpp
+++ b/sakura_core/util/string_ex2.cpp
@@ -251,12 +251,12 @@ void GetLineColumn( const wchar_t* pLine, int* pnJumpToLine, int* pnJumpToColumn
 			break;
 		}
 	}
-	wmemset( szNumber, 0, _countof( szNumber ) );
+	wmemset( szNumber, 0, std::size( szNumber ) );
 	if( i >= nLineLen ){
 	}else{
 		/* 行位置 改行単位行番号(1起点)の抽出 */
 		j = 0;
-		for( ; i < nLineLen && j + 1 < _countof( szNumber ); ){
+		for( ; i < nLineLen && j + 1 < std::size( szNumber ); ){
 			szNumber[j] = pLine[i];
 			j++;
 			++i;
@@ -270,10 +270,10 @@ void GetLineColumn( const wchar_t* pLine, int* pnJumpToLine, int* pnJumpToColumn
 
 		/* 桁位置 改行単位行先頭からのバイト数(1起点)の抽出 */
 		if( i < nLineLen && pLine[i] == ',' ){
-			wmemset( szNumber, 0, _countof( szNumber ) );
+			wmemset( szNumber, 0, std::size( szNumber ) );
 			j = 0;
 			++i;
-			for( ; i < nLineLen && j + 1 < _countof( szNumber ); ){
+			for( ; i < nLineLen && j + 1 < std::size( szNumber ); ){
 				szNumber[j] = pLine[i];
 				j++;
 				++i;

--- a/sakura_core/util/string_ex2.h
+++ b/sakura_core/util/string_ex2.h
@@ -81,7 +81,7 @@ constexpr size_t int2dec_destBufferSufficientLength();
 template <>
 constexpr size_t int2dec_destBufferSufficientLength<int32_t>()
 {
-	return _countof(L"-2147483648");
+	return std::size(L"-2147483648");
 }
 
 /*!
@@ -91,7 +91,7 @@ constexpr size_t int2dec_destBufferSufficientLength<int32_t>()
 template <>
 constexpr size_t int2dec_destBufferSufficientLength<int64_t>()
 {
-	return _countof(L"-9223372036854775808");
+	return std::size(L"-9223372036854775808");
 }
 
 /*! @brief 整数を10進数の文字列に変換

--- a/sakura_core/util/tchar_printf.cpp
+++ b/sakura_core/util/tchar_printf.cpp
@@ -257,7 +257,7 @@ int tchar_vsprintf_s_imp(T* buf, size_t nBufCount, const T* format, va_list& v, 
 
 				//フィールドを一時変数にコピー
 				T field[64];
-				if(field_end-field_begin>=_countof(field))field_end=field_begin+_countof(field)-1; //フィールド長制限
+				if(field_end-field_begin>=std::size(field))field_end=field_begin+std::size(field)-1; //フィールド長制限
 				auto_strncpy(field,field_begin,field_end-field_begin);
 				field[field_end-field_begin] = 0;
 				

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -758,7 +758,7 @@ void CCaret::ShowCaretPosInfo()
 				}
 			}
 			else{
-				wcscpy_s(szCaretChar, _countof(szCaretChar), pcLayout->GetLayoutEol().GetName());
+				wcscpy_s(szCaretChar, std::size(szCaretChar), pcLayout->GetLayoutEol().GetName());
 			}
 		}
 	}

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1590,7 +1590,7 @@ int	CEditView::CreatePopUpMenuSub( HMENU hMenu, int nMenuIdx, int* pParentMenus,
 			}
 			if( !bMenuLoop ){
 				WCHAR buf[ MAX_CUSTOM_MENU_NAME_LEN + 1 ];
-				LPCWSTR p = GetDocument()->m_cFuncLookup.Custmenu2Name( nCustIdx, buf, _countof(buf) );
+				LPCWSTR p = GetDocument()->m_cFuncLookup.Custmenu2Name( nCustIdx, buf, std::size(buf) );
 				wchar_t keys[2];
 				keys[0] = GetDllShareData().m_Common.m_sCustomMenu.m_nCustMenuItemKeyArr[nMenuIdx][i];
 				keys[1] = 0;

--- a/sakura_core/view/CEditView_ExecCmd.cpp
+++ b/sakura_core/view/CEditView_ExecCmd.cpp
@@ -241,7 +241,7 @@ bool CEditView::ExecCmd( const WCHAR* pszCmd, int nFlgOpt, const WCHAR* pszCurDi
 
 		// 2010.08.27 Moca システムディレクトリ付加
 		WCHAR szCmdDir[_MAX_PATH];
-		::GetSystemDirectory(szCmdDir, _countof(szCmdDir));
+		::GetSystemDirectory(szCmdDir, std::size(szCmdDir));
 
 		//コマンドライン文字列作成
 		auto_sprintf(
@@ -308,15 +308,15 @@ bool CEditView::ExecCmd( const WCHAR* pszCmd, int nFlgOpt, const WCHAR* pszCurDi
 			WCHAR szTextDate[1024], szTextTime[1024];
 			SYSTEMTIME systime;
 			::GetLocalTime( &systime );
-			CFormatManager().MyGetDateFormat( systime, szTextDate, _countof( szTextDate ) - 1 );
-			CFormatManager().MyGetTimeFormat( systime, szTextTime, _countof( szTextTime ) - 1 );
+			CFormatManager().MyGetDateFormat( systime, szTextDate, std::size( szTextDate ) - 1 );
+			CFormatManager().MyGetTimeFormat( systime, szTextTime, std::size( szTextTime ) - 1 );
 			WCHAR szOutTemp[1024*2+100];
 			oa.OutputW( L"\r\n" );
 			oa.OutputW( L"#============================================================\r\n" );
-			int len = auto_snprintf_s( szOutTemp, _countof(szOutTemp),
+			int len = auto_snprintf_s( szOutTemp, std::size(szOutTemp),
 				L"#DateTime : %s %s\r\n", szTextDate, szTextTime );
 			oa.OutputW( szOutTemp, len );
-			len = auto_snprintf_s( szOutTemp, _countof(szOutTemp),
+			len = auto_snprintf_s( szOutTemp, std::size(szOutTemp),
 				L"#CmdLine  : %s\r\n", pszCmd );
 			oa.OutputW( szOutTemp, len );
 			oa.OutputW( L"#============================================================\r\n" );

--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -262,8 +262,8 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bUnicode, b
 			if( !hIMC ){
 				return 0;
 			}
-			wmemset(m_szComposition, L'\0', _countof(m_szComposition));
-			LONG immRet = ::ImmGetCompositionString(hIMC, GCS_COMPSTR, m_szComposition, _countof(m_szComposition));
+			wmemset(m_szComposition, L'\0', std::size(m_szComposition));
+			LONG immRet = ::ImmGetCompositionString(hIMC, GCS_COMPSTR, m_szComposition, std::size(m_szComposition));
 			if( immRet == IMM_ERROR_NODATA || immRet == IMM_ERROR_GENERAL ){
 				m_szComposition[0] = L'\0';
 			}

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -1331,7 +1331,7 @@ LRESULT CEditView::OnMOUSEWHEEL2( WPARAM wParam, LPARAM lParam, bool bHorizontal
 		// 2006.06.03 Moca ReadRegistry に書き換え
 		unsigned int uDataLen;	// size of value data
 		WCHAR szValStr[256];
-		uDataLen = _countof(szValStr) - 1;
+		uDataLen = std::size(szValStr) - 1;
 		if( !bExecCmd ){
 			bool bGetParam = false;
 			if( bHorizontal ){
@@ -2130,7 +2130,7 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 
 		nFiles = ::DragQueryFile( hDrop, 0xFFFFFFFF, NULL, 0 );
 		for( UINT i = 0; i < nFiles; i++ ){
-			::DragQueryFile( hDrop, i, szPath, _countof(szPath) );
+			::DragQueryFile( hDrop, i, szPath, std::size(szPath) );
 			if( !::GetLongFileName( szPath, szWork ) )
 				continue;
 			if( nId == 100 ){	// パス名

--- a/sakura_core/view/CTextMetrics.cpp
+++ b/sakura_core/view/CTextMetrics.cpp
@@ -135,8 +135,8 @@ void CTextMetrics::SetHankakuHeight(int nHankakuHeight)
 void CTextMetrics::SetHankakuDx(int nDxBasis)
 {
 	m_nDxBasis=nDxBasis;
-	for(int i=0;i<_countof(m_anHankakuDx);i++)m_anHankakuDx[i]=GetHankakuDx();
-	for(int i=0;i<_countof(m_anZenkakuDx);i++)m_anZenkakuDx[i]=GetZenkakuDx();
+	for(int i=0;i<std::size(m_anHankakuDx);i++)m_anHankakuDx[i]=GetHankakuDx();
+	for(int i=0;i<std::size(m_anZenkakuDx);i++)m_anZenkakuDx[i]=GetZenkakuDx();
 }
 void CTextMetrics::SetHankakuDy(int nDyBasis)
 {

--- a/sakura_core/view/colors/CColorStrategy.cpp
+++ b/sakura_core/view/colors/CColorStrategy.cpp
@@ -323,7 +323,7 @@ void CColorStrategyPool::OnChangeSetting(void)
 	m_bSkipBeforeLayoutGeneral = true;
 	int nKeyword1;
 	int bUnuseKeyword = false;
-	for(int n = 0; n < _countof(bSkipColorTypeTable); n++ ){
+	for(int n = 0; n < std::size(bSkipColorTypeTable); n++ ){
 		if( COLORIDX_KEYWORD1 == bSkipColorTypeTable[n] ){
 			nKeyword1 = n;
 		}

--- a/sakura_core/view/figures/CFigure_Eol.cpp
+++ b/sakura_core/view/figures/CFigure_Eol.cpp
@@ -232,7 +232,7 @@ void _DispEOF(
 
 	//定数
 	static const wchar_t	szEof[] = L"[EOF]";
-	const int		nEofLen = _countof(szEof) - 1;
+	const int		nEofLen = std::size(szEof) - 1;
 
 	cEofType.SetGraphicsState_WhileThisObj(gr);
 	int fontNo = WCODE::GetFontNo('E');
@@ -347,7 +347,7 @@ void _DrawEOL(
 			pt[4].y = sy;
 			pt[5].x = sx + rcEol.Height() / 4;	//	先頭から上へ
 			pt[5].y = sy - rcEol.Height() / 4;
-			::PolyPolyline( gr, pt, pp, _countof(pp));
+			::PolyPolyline( gr, pt, pp, std::size(pp));
 
 			if ( bBold ) {
 				pt[0].x += 1;	//	上へ（右へずらす）
@@ -362,7 +362,7 @@ void _DrawEOL(
 				pt[4].y += 1;
 				pt[5].x += 0;	//	先頭から上へ
 				pt[5].y += 1;
-				::PolyPolyline( gr, pt, pp, _countof(pp));
+				::PolyPolyline( gr, pt, pp, std::size(pp));
 			}
 		}
 		break;
@@ -382,7 +382,7 @@ void _DrawEOL(
 			pt[3].y = sy;
 			pt[4].x = sx + rcEol.Height() / 4;	//	先頭から上へ
 			pt[4].y = sy - rcEol.Height() / 4;
-			::PolyPolyline( gr, pt, pp, _countof(pp));
+			::PolyPolyline( gr, pt, pp, std::size(pp));
 
 			if ( bBold ) {
 				pt[0].x += 0;	//	右へ
@@ -395,7 +395,7 @@ void _DrawEOL(
 				pt[3].y += 1;
 				pt[4].x += 0;	//	先頭から上へ
 				pt[4].y += 1;
-				::PolyPolyline( gr, pt, pp, _countof(pp));
+				::PolyPolyline( gr, pt, pp, std::size(pp));
 			}
 		}
 		break;
@@ -416,7 +416,7 @@ void _DrawEOL(
 			pt[3].y = sy;
 			pt[4].x = sx + rcEol.Height() / 4;	//	そして右上へ
 			pt[4].y = sy - rcEol.Height() / 4;
-			::PolyPolyline( gr, pt, pp, _countof(pp));
+			::PolyPolyline( gr, pt, pp, std::size(pp));
 
 			if( bBold ){
 				pt[0].x += 1;	//	上へ
@@ -429,7 +429,7 @@ void _DrawEOL(
 				pt[3].y += 0;
 				pt[4].x += 1;	//	そして右上へ
 				pt[4].y += 0;
-				::PolyPolyline( gr, pt, pp, _countof(pp));
+				::PolyPolyline( gr, pt, pp, std::size(pp));
 			}
 		}
 		break;
@@ -453,7 +453,7 @@ void _DrawEOL(
 			pt[3].y = sy;
 			pt[4].x = sx;	//	先頭から上へ
 			pt[4].y = sy - nWidth;
-			::PolyPolyline( gr, pt, pp, _countof(pp));
+			::PolyPolyline( gr, pt, pp, std::size(pp));
 
 			if ( bBold ) {
 				pt[0].x += 0;	//	右上から
@@ -466,7 +466,7 @@ void _DrawEOL(
 				pt[3].y -= 1;
 				pt[4].x += 1;	//	先頭から上へ
 				pt[4].y += 0;
-				::PolyPolyline( gr, pt, pp, _countof(pp));
+				::PolyPolyline( gr, pt, pp, std::size(pp));
 			}
 		}
 		break;

--- a/sakura_core/view/figures/CFigure_Tab.cpp
+++ b/sakura_core/view/figures/CFigure_Tab.cpp
@@ -179,7 +179,7 @@ void _DrawTabArrow(
 	pt[3].y = sy;
 	pt[4].x = sx - sa;
 	pt[4].y = sy - sa;
-	::PolyPolyline( gr, pt, pp, _countof(pp));
+	::PolyPolyline( gr, pt, pp, std::size(pp));
 
 	if( bBold ){
 		pt[0].x += 0;	//「─」左端から右端
@@ -192,7 +192,7 @@ void _DrawTabArrow(
 		pt[3].y += 1;
 		pt[4].x += 0;
 		pt[4].y += 1;
-		::PolyPolyline( gr, pt, pp, _countof(pp));
+		::PolyPolyline( gr, pt, pp, std::size(pp));
 	}
 
 	gr.PopPen();

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -196,7 +196,7 @@ CEditWnd::CEditWnd()
 , m_pcDragSourceView( NULL )
 , m_nActivePaneIndex( 0 )
 , m_nEditViewCount( 1 )
-, m_nEditViewMaxCount( _countof(m_pcEditViewArr) )	// 今のところ最大値は固定
+, m_nEditViewMaxCount( std::size(m_pcEditViewArr) )	// 今のところ最大値は固定
 , m_bIsActiveApp( false )
 , m_pszLastCaption( NULL )
 , m_pszMenubarMessage( new WCHAR[MENUBAR_MESSAGE_MAX_LEN] )
@@ -278,11 +278,11 @@ void CEditWnd::UpdateCaption()
 	wchar_t	pszCap[1024];
 
 	//キャプション更新
-	CSakuraEnvironment::ExpandParameter( pszWindowCaptionFormat, pszCap, _countof( pszCap ) );
+	CSakuraEnvironment::ExpandParameter( pszWindowCaptionFormat, pszCap, std::size( pszCap ) );
 	::SetWindowText( GetHwnd(), pszCap );
 
 	//タブウインドウのファイル名を通知
-	CSakuraEnvironment::ExpandParameter( pszTabCaptionFormat, pszCap, _countof( pszCap ) );
+	CSakuraEnvironment::ExpandParameter( pszTabCaptionFormat, pszCap, std::size( pszCap ) );
 	ChangeFileNameNotify( pszCap,
 		GetListeningDoc()->m_cDocFile.GetFilePath(),
 		CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode ); // 2006.01.28 ryoji ファイル名、Grepモードパラメータを追加
@@ -590,7 +590,7 @@ HWND CEditWnd::Create(
 		m_pcEditDoc->m_cLayoutMgr.GetTabSpaceKetas(), m_pcEditDoc->m_cLayoutMgr.m_tsvInfo.m_nTsvMode,
 		m_pcEditDoc->m_cLayoutMgr.GetMaxLineKetas(), CLayoutXInt(-1), &GetLogfont() );
 
-	for( int i = 0; i < _countof(m_pcEditViewArr); i++ ){
+	for( int i = 0; i < std::size(m_pcEditViewArr); i++ ){
 		m_pcEditViewArr[i] = NULL;
 	}
 	// [0] - [3] まで作成・初期化していたものを[0]だけ作る。ほかは分割されるまで何もしない
@@ -843,7 +843,7 @@ void CEditWnd::LayoutMainMenu()
 		case T_LEAF:
 			/* メニューラベルの作成 */
 			// 2014.05.04 Moca プラグイン/マクロ等を置けるようにFunccode2Nameを使うように
-			GetDocument()->m_cFuncLookup.Funccode2Name( cMainMenu->m_nFunc, szLabel, _countof(szLabel) );
+			GetDocument()->m_cFuncLookup.Funccode2Name( cMainMenu->m_nFunc, szLabel, std::size(szLabel) );
 			wcscpy( szKey, cMainMenu->m_sKey );
 			if (CKeyBind::GetMenuLabel(
 				G_AppInstance(),
@@ -853,7 +853,7 @@ void CEditWnd::LayoutMainMenu()
 				szLabel,
 				cMainMenu->m_sKey,
 				FALSE,
-				_countof(szLabel)) == NULL) {
+				std::size(szLabel)) == NULL) {
 				wcscpy( szLabel, L"?" );
 			}
 			::AppendMenu( hMenu, MF_STRING, cMainMenu->m_nFunc, szLabel );
@@ -1506,7 +1506,7 @@ LRESULT CEditWnd::DispatchEvent(
 
 				//ツールチップテキスト取得、設定
 				LPTOOLTIPTEXT lptip = (LPTOOLTIPTEXT)pnmh;
-				GetTooltipText(szText, _countof(szText), lptip->hdr.idFrom);
+				GetTooltipText(szText, std::size(szText), lptip->hdr.idFrom);
 				lptip->lpszText = szText;
 			}
 			break;
@@ -2318,7 +2318,7 @@ void CEditWnd::InitMenu( HMENU hMenu, UINT uPos, BOOL fSystemMenu )
 				hMenuPopUp = ::CreatePopupMenu();
 				if (cMainMenu->m_nFunc != 0 && cMainMenu->m_sName[0] == L'\0') {
 					// ストリングテーブルから読み込み
-					wcsncpy_s(tmpMenuName, _countof(tmpMenuName), LS( cMainMenu->m_nFunc ), _TRUNCATE);
+					wcsncpy_s(tmpMenuName, std::size(tmpMenuName), LS( cMainMenu->m_nFunc ), _TRUNCATE);
 					pMenuName = tmpMenuName;
 				}else{
 					pMenuName = cMainMenu->m_sName;
@@ -2416,7 +2416,7 @@ void CEditWnd::InitMenu_Function(HMENU hMenu, EFunctionCode eFunc, const wchar_t
 		}
 		WCHAR buf[ MAX_CUSTOM_MENU_NAME_LEN + 1 ];
 		m_cMenuDrawer.MyAppendMenu( hMenu, nFlag,
-			eFunc, GetDocument()->m_cFuncLookup.Custmenu2Name( j, buf, _countof(buf) ), pszKey );
+			eFunc, GetDocument()->m_cFuncLookup.Custmenu2Name( j, buf, std::size(buf) ), pszKey );
 	}
 	// マクロ
 	else if (eFunc >= F_USERMACRO_0 && eFunc < F_USERMACRO_0+MAX_CUSTMACRO) {
@@ -2435,7 +2435,7 @@ void CEditWnd::InitMenu_Function(HMENU hMenu, EFunctionCode eFunc, const wchar_t
 	// プラグインコマンド
 	else if (eFunc >= F_PLUGCOMMAND_FIRST && eFunc < F_PLUGCOMMAND_LAST) {
 		WCHAR szLabel[256];
-		if( 0 < CJackManager::getInstance()->GetCommandName( eFunc, szLabel, _countof(szLabel) ) ){
+		if( 0 < CJackManager::getInstance()->GetCommandName( eFunc, szLabel, std::size(szLabel) ) ){
 			m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING,
 				eFunc, szLabel, pszKey,
 				TRUE, eFunc );
@@ -2588,14 +2588,14 @@ bool CEditWnd::InitMenu_Special(HMENU hMenu, EFunctionCode eFunc)
 		//	右クリックメニュー
 		if( m_pShareData->m_Common.m_sCustomMenu.m_nCustMenuItemNumArr[0] > 0 ){
 			 m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING,
-				 F_MENU_RBUTTON, GetDocument()->m_cFuncLookup.Custmenu2Name( 0, buf, _countof(buf) ), L"" );
+				 F_MENU_RBUTTON, GetDocument()->m_cFuncLookup.Custmenu2Name( 0, buf, std::size(buf) ), L"" );
 			bInList = true;
 		}
 		//	カスタムメニュー
 		for( j = 1; j < MAX_CUSTOM_MENU; ++j ){
 			if( m_pShareData->m_Common.m_sCustomMenu.m_nCustMenuItemNumArr[j] > 0 ){
 				 m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING,
-			 		F_CUSTMENU_BASE + j, GetDocument()->m_cFuncLookup.Custmenu2Name( j, buf, _countof(buf) ), L""  );
+			 		F_CUSTMENU_BASE + j, GetDocument()->m_cFuncLookup.Custmenu2Name( j, buf, std::size(buf) ), L""  );
 				bInList = true;
 			}
 		}
@@ -2688,7 +2688,7 @@ void CEditWnd::SetMenuFuncSel( HMENU hMenu, EFunctionCode nFunc, const WCHAR* sK
 {
 	int				i;
 	const WCHAR*	sName = L"";
-	for (i = 0; i < _countof(sFuncMenuName) ;i++) {
+	for (i = 0; i < std::size(sFuncMenuName) ;i++) {
 		if (sFuncMenuName[i].eFunc == nFunc) {
 			sName = flag ? LS( sFuncMenuName[i].nNameId[0] ) : LS( sFuncMenuName[i].nNameId[1] );
 		}
@@ -2769,7 +2769,7 @@ void CEditWnd::OnDropFiles( HDROP hDrop )
 	for( i = 0; i < cFiles; i++ ) {
 		//ファイルパス取得、解決。
 		WCHAR		szFile[_MAX_PATH + 1];
-		::DragQueryFile( hDrop, i, szFile, _countof(szFile) );
+		::DragQueryFile( hDrop, i, szFile, std::size(szFile) );
 		CSakuraEnvironment::ResolvePath(szFile);
 
 		/* 指定ファイルが開かれているか調べる */
@@ -3855,7 +3855,7 @@ bool CEditWnd::GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIcon
 		// (.で始まる)拡張子の取得
 		_wsplitpath( szFile, NULL, NULL, NULL, szExt );
 
-		if( ReadRegistry(HKEY_CLASSES_ROOT, szExt, NULL, FileType, _countof(FileType) - 13)){
+		if( ReadRegistry(HKEY_CLASSES_ROOT, szExt, NULL, FileType, std::size(FileType) - 13)){
 			wcscat( FileType, L"\\DefaultIcon" );
 			if( ReadRegistry(HKEY_CLASSES_ROOT, FileType, NULL, NULL, 0)){
 				// 関連づけられたアイコンを取得する
@@ -3970,7 +3970,7 @@ void CEditWnd::PrintMenubarMessage( const WCHAR* msg )
 		GCP_RESULTS results = { sizeof(GCP_RESULTS) };
 		results.lpDx = vDx;
 		results.lpGlyphs = vGlyphs;
-		results.nGlyphs = _countof(vGlyphs);
+		results.nGlyphs = std::size(vGlyphs);
 		results.nMaxFit = cchText;
 		auto placement = ::GetCharacterPlacement(hdc, pchText, cchText, nMaxExtent, &results, dwFlags);
 
@@ -4027,7 +4027,7 @@ void CEditWnd::ChangeFileNameNotify( const WCHAR* pszTabCaption, const WCHAR* _p
 		p = cRecentEditNode.GetItem( nIndex );
 		if( p )
 		{
-			int	size = _countof( p->m_szTabCaption ) - 1;
+			int	size = std::size( p->m_szTabCaption ) - 1;
 			wcsncpy( p->m_szTabCaption, pszTabCaption, size );
 			p->m_szTabCaption[ size ] = L'\0';
 
@@ -4192,7 +4192,7 @@ LRESULT CEditWnd::WinListMenu( HMENU hMenu, EditNode* pEditNodeArr, int nRowNum,
 			::SendMessage( pEditNodeArr[i].GetHwnd(), MYWM_GETFILEINFO, 0, 0 );
 ////	From Here Oct. 4, 2000 JEPRO commented out & modified	開いているファイル数がわかるように履歴とは違って1から数える
 			pfi = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
-			CFileNameManager::getInstance()->GetMenuFullLabel_WinList( szMenu, _countof(szMenu), pfi, pEditNodeArr[i].m_nId, i, dcFont.GetHDC() );
+			CFileNameManager::getInstance()->GetMenuFullLabel_WinList( szMenu, std::size(szMenu), pfi, pEditNodeArr[i].m_nId, i, dcFont.GetHDC() );
 			m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, IDM_SELWINDOW + pEditNodeArr[i].m_nIndex, szMenu, L"" );
 			if( GetHwnd() == pEditNodeArr[i].GetHwnd() ){
 				::CheckMenuItem( hMenu, IDM_SELWINDOW + pEditNodeArr[i].m_nIndex, MF_BYCOMMAND | MF_CHECKED );

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -138,7 +138,7 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 		size_t prevTextLen = LOWORD(res);
 		WCHAR prev[1024];
 		// 設定済みの文字列長が長過ぎて取得できない場合は、SB_SETTEXT メッセージを発行
-		if( prevTextLen >= _countof(prev) ){
+		if( prevTextLen >= std::size(prev) ){
 			return true;
 		}
 		// 設定する文字列長パラメータが SIZE_MAX（引数のデフォルト値）な場合は文字列長を取得

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -314,7 +314,7 @@ void CMainToolBar::CreateToolBar( void )
 							//lf.lfClipPrecision	= GetDllShareData().m_Common.m_sView.m_lf.lfClipPrecision;
 							//lf.lfQuality		= GetDllShareData().m_Common.m_sView.m_lf.lfQuality;
 							//lf.lfPitchAndFamily	= GetDllShareData().m_Common.m_sView.m_lf.lfPitchAndFamily;
-							//wcsncpy( lf.lfFaceName, GetDllShareData().m_Common.m_sView.m_lf.lfFaceName, _countof(lf.lfFaceName));	// 画面のフォントに設定	2012/11/27 Uchi
+							//wcsncpy( lf.lfFaceName, GetDllShareData().m_Common.m_sView.m_lf.lfFaceName, std::size(lf.lfFaceName));	// 画面のフォントに設定	2012/11/27 Uchi
 							m_hFontSearchBox = ::CreateFontIndirect( &lf );
 							if( m_hFontSearchBox )
 							{

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -735,7 +735,7 @@ BOOL CTabWnd::SeparateGroup( HWND hwndSrc, HWND hwndDst, POINT ptDrag, POINT ptD
 
 	// 再表示メッセージをブロードキャストする。
 	//	2007.07.07 genta 2回ループに
-	for( int group = 0; group < _countof( notifygroups ); group++ ){
+	for( int group = 0; group < std::size( notifygroups ); group++ ){
 		CAppNodeGroupHandle(notifygroups[group]).PostMessageToAllEditors(
 			MYWM_TAB_WINDOW_NOTIFY,
 			(WPARAM)TWNT_REFRESH,
@@ -1333,7 +1333,7 @@ LRESULT CTabWnd::OnDrawItem( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam 
 
 		item.mask = TCIF_TEXT | TCIF_PARAM | TCIF_IMAGE;
 		item.pszText = szBuf;
-		item.cchTextMax = _countof(szBuf);
+		item.cchTextMax = std::size(szBuf);
 		TabCtrl_GetItem(hwndItem, nTabIndex, &item);
 
 		//描画対象
@@ -1523,14 +1523,14 @@ LRESULT CTabWnd::OnMouseMove( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				}
 				else
 				{
-					::LoadString( GetAppInstance(), F_GROUPCLOSE, szText, _countof(szText) );
-					szText[_countof(szText) - 1] = L'\0';
+					::LoadString( GetAppInstance(), F_GROUPCLOSE, szText, std::size(szText) );
+					szText[std::size(szText) - 1] = L'\0';
 				}
 			}
 			else
 			{
-				::LoadString( GetAppInstance(), F_EXITALLEDITORS, szText, _countof(szText) );
-				szText[_countof(szText) - 1] = L'\0';
+				::LoadString( GetAppInstance(), F_EXITALLEDITORS, szText, std::size(szText) );
+				szText[std::size(szText) - 1] = L'\0';
 			}
 		}
 	}
@@ -1679,7 +1679,7 @@ LRESULT CTabWnd::OnNotify( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 			{
 				EditNode* pEditNode;
 				pEditNode = CAppNodeManager::getInstance()->GetEditNode( (HWND)tcitem.lParam );
-				GetTabName( pEditNode, TRUE, FALSE, m_szTextTip, _countof(m_szTextTip) );
+				GetTabName( pEditNode, TRUE, FALSE, m_szTextTip, std::size(m_szTextTip) );
 				((NMTTDISPINFO*)pnmh)->lpszText = m_szTextTip;	// NMTTDISPINFO::szText[80]では短い
 				((NMTTDISPINFO*)pnmh)->hinst = NULL;
 			}
@@ -1821,12 +1821,12 @@ void CTabWnd::TabWindowNotify( WPARAM wParam, LPARAM lParam )
 			//	Jun. 19, 2004 genta
 			EditNode	*p;
 			p = CAppNodeManager::getInstance()->GetEditNode( (HWND)lParam );
-			GetTabName( p, FALSE, TRUE, szName, _countof(szName) );
+			GetTabName( p, FALSE, TRUE, szName, std::size(szName) );
 
 			tcitem.mask    = TCIF_TEXT | TCIF_IMAGE;
 			WCHAR	szNameOld[1024];
 			tcitem.pszText = szNameOld;
-			tcitem.cchTextMax = _countof(szNameOld);
+			tcitem.cchTextMax = std::size(szNameOld);
 			TabCtrl_GetItem( m_hwndTab, nIndex, &tcitem );
 			if( 0 != wcscmp( szNameOld, szName )
 				|| tcitem.iImage != GetImageIndex( p ) ){
@@ -2038,7 +2038,7 @@ void CTabWnd::Refresh( BOOL bEnsureVisible/* = TRUE*/, BOOL bRebuild/* = FALSE*/
 			if( pEditNode[i].m_bClosing )	// このあとすぐに閉じるウィンドウなのでタブ表示しない
 				continue;
 
-			GetTabName( &pEditNode[i], FALSE, TRUE, szName, _countof(szName) );
+			GetTabName( &pEditNode[i], FALSE, TRUE, szName, std::size(szName) );
 
 			tcitem.mask    = TCIF_TEXT | TCIF_PARAM;
 			tcitem.pszText = szName;
@@ -2615,12 +2615,12 @@ void CTabWnd::DrawListBtn( CGraphics& gr, const LPRECT lprcClient )
 	int nIndex = m_bListBtnHilighted? COLOR_MENUTEXT: COLOR_BTNTEXT;
 	gr.SetPen( ::GetSysColor( nIndex ) );
 	gr.SetBrushColor( ::GetSysColor( nIndex ) ); //$$ GetSysColorBrushを用いた実装のほうが効率は良い
-	for( int i = 0; i < _countof(ptBase); i++ )
+	for( int i = 0; i < std::size(ptBase); i++ )
 	{
 		pt[i].x = ptBase[i].x + rcBtn.left;
 		pt[i].y = ptBase[i].y + rcBtn.top;
 	}
-	::Polygon( gr, pt, _countof(pt) );
+	::Polygon( gr, pt, std::size(pt) );
 }
 
 /*! 閉じるマーク描画処理 */
@@ -2639,7 +2639,7 @@ void CTabWnd::DrawCloseFigure( CGraphics& gr, const RECT& rcBtn )
 	int i;
 
 	// [x]を描画（直線6本）
-	for( i = 0; i < _countof(ptBase1); i++ )
+	for( i = 0; i < std::size(ptBase1); i++ )
 	{
 		pt[0].x = ptBase1[i][0].x + rcBtn.left;
 		pt[0].y = ptBase1[i][0].y + rcBtn.top;
@@ -2703,7 +2703,7 @@ void CTabWnd::DrawCloseBtn( CGraphics& gr, const LPRECT lprcClient )
 	else
 	{
 		 // [xx]を描画（矩形10個）
-		for( i = 0; i < _countof(ptBase2); i++ )
+		for( i = 0; i < std::size(ptBase2); i++ )
 		{
 			pt[0].x = ptBase2[i][0].x + rcBtn.left;
 			pt[0].y = ptBase2[i][0].y + rcBtn.top;
@@ -2892,7 +2892,7 @@ LRESULT CTabWnd::TabListMenu( POINT pt, BOOL bSel/* = TRUE*/, BOOL bFull/* = FAL
 					continue;
 				if( pEditNode[i].m_bClosing )	// このあとすぐに閉じるウィンドウなのでタブ表示しない
 					continue;
-				GetTabName( &pEditNode[i], bFull, TRUE, pData[nSelfTab].szText, _countof(pData[0].szText) );
+				GetTabName( &pEditNode[i], bFull, TRUE, pData[nSelfTab].szText, std::size(pData[0].szText) );
 				pData[nSelfTab].hwnd = pEditNode[i].m_hWnd;
 				pData[nSelfTab].iItem = i;
 				pData[nSelfTab].iImage = GetImageIndex( &pEditNode[i] );
@@ -2911,7 +2911,7 @@ LRESULT CTabWnd::TabListMenu( POINT pt, BOOL bSel/* = TRUE*/, BOOL bFull/* = FAL
 				continue;
 			if( pEditNode[i].m_bClosing )	// このあとすぐに閉じるウィンドウなのでタブ表示しない
 				continue;
-			GetTabName( &pEditNode[i], bFull, TRUE, pData[nTab].szText, _countof(pData[0].szText) );
+			GetTabName( &pEditNode[i], bFull, TRUE, pData[nTab].szText, std::size(pData[0].szText) );
 			pData[nTab].hwnd = pEditNode[i].m_hWnd;
 			pData[nTab].iItem = i;
 			pData[nTab].iImage = GetImageIndex( &pEditNode[i] );

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -185,7 +185,7 @@ void CTipWnd::ComputeWindowSize(
 				}
 			}else{
 				// ダミー文字列を計測して必要な高さを取得する
-				::DrawText( hdc, szDummy, _countof( szDummy ) - 1, &rc, DT_CALCRECT | DT_EXTERNALLEADING );
+				::DrawText( hdc, szDummy, std::size( szDummy ) - 1, &rc, DT_CALCRECT | DT_EXTERNALLEADING );
 			}
 
 			// 計測した高さを加算する
@@ -257,7 +257,7 @@ void CTipWnd::DrawTipText(
 				);
 			}else{
 				// ダミー文字列の高さを取得する
-				nHeight = ::DrawText( hdc, szDummy, _countof(szDummy) - 1, &rc, DT_EXTERNALLEADING );
+				nHeight = ::DrawText( hdc, szDummy, std::size(szDummy) - 1, &rc, DT_EXTERNALLEADING );
 			}
 
 			// 描画領域の上端を1行分ずらす


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

VC++ には固定長配列の要素数を取得する `_countof` マクロが存在します。

```c
#define _countof(array) (sizeof(array) / sizeof(array[0]))
```

C++17 から `std::size` が追加されたので、それに置き換えるのが目的です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 自明なら省略可 --> PR のメリット

- C++の標準により準拠している気分になれる。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

- `_countof` より `std::size` の方がタイプ量が多く可読性が低い。
- 動いているコードを変えるのは良くない。
- コンパイル時の警告が増える？（`std::ssize` を使えば回避出来るかもしれないけれど…）

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

挙動の変更は無い筈です。

## <!-- 必須 --> テスト内容

ビルドが通って起動して色々な操作が通常通り出来る事を確認しました。

ソースコード上の変更箇所が多いですが、それぞれの変更箇所毎の動作確認はしていません。

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/countof-macro?view=vs-2019

https://en.cppreference.com/w/cpp/iterator/size
