### PR TITLE
DIFF差分とウィンドウ一覧ダイアログでファイル名がMAX_PATHぎりぎりだと落ちてしまう不具合の修正

### DIFF
--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -239,7 +239,7 @@ void CDlgDiff::SetData( void )
 		EditInfo	*pFileInfo;
 		int			i;
 		int			nItem;
-		WIN_CHAR	szName[_MAX_PATH];
+		WCHAR		szName[512];
 		int			count = 0;
 		int			selIndex = 0;
 		ECodeType	code;

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -143,7 +143,7 @@ void CDlgWindowList::SetData()
 			::SendMessageAny(pEditNode[i].GetHwnd(), MYWM_GETFILEINFO, 0, 0);
 			const EditInfo* pEditInfo = &m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
-			WCHAR szName[_MAX_PATH];
+			WCHAR szName[512];
 			CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape(szName, _countof(szName), pEditInfo, pEditNode[i].m_nId, i, calc.GetDC());
 
 			LV_ITEM lvi;


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的
259文字のファイル名のファイルを開いて、ダイアログを表示しても落ちないで表示できるようにします。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景
259文字のフルパスを持ったファイルを開いていると、DIFF差分ダイアログとウィンドウ一覧ダイアログを表示したときに、
セキュリティのバッファ長不足によるハンドラー呼び出しの例外で落っこちます。

<!-- PR を行う背景を記載してください -->

## <!-- 自明なら省略可 --> PR のメリット
このケースでは落ちないようになります。

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
単純に配列長を伸ばしので、スタックを余分に消費します。

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 必須 --> テスト内容

マイドキュメント配下、AppData以下の場合は「ファイル名表示」で短く表示する設定を削除ないしダミー文字を追記などして、無効にします。
「%Personal%」→「★%Personal%」のように書き換えます。
上の「長いパスの省略表示」を無効に設定します。
→フルパスがそのまま表示されるようになります。

もうひとつのサクラエディタで259文字のフルパスのファイルを開いておきます。
DIFF差分表示ダイアログを表示しようとすると、クラッシュします。

差分を適用してコンパイルし、再度表示してみると今度は落ちません。

ウィンドウ一覧ダイアログでも同様に、表示しただけで落ちます。

ローカル変数のバッファ長が[_MAX_PATH]になっています。
しかし表示には「アクセス用文字1文字」「セパレータのスペース」「フルパス」「  [UTF-8]などの文字コード」が
表示されるので、最大では_MAX_PATH+30程度は必要です。

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
