### PR TITLE
ファイル内容比較ダイアログの未使用処理pszCompareLabelを削除

### DIFF
--- a/sakura_core/cmd/CViewCommander_Diff.cpp
+++ b/sakura_core/cmd/CViewCommander_Diff.cpp
@@ -108,7 +108,6 @@ static bool Commander_COMPARE_core(CViewCommander& commander, bool& bDifferent, 
 void CViewCommander::Command_COMPARE( void )
 {
 	HWND		hwndCompareWnd = NULL;
-	WCHAR		szPath[_MAX_PATH + 1];
 	CDlgCompare	cDlgCompare;
 	HWND		hwndMsgBox;	//@@@ 2003.06.12 MIK
 
@@ -119,7 +118,6 @@ void CViewCommander::Command_COMPARE( void )
 		m_pCommanderView->GetHwnd(),
 		(LPARAM)GetDocument(),
 		GetDocument()->m_cDocFile.GetFilePath(),
-		szPath,
 		&hwndCompareWnd
 	);
 	if( !bDlgCompareResult ){

--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -66,12 +66,10 @@ int CDlgCompare::DoModal(
 	HWND			hwndParent,
 	LPARAM			lParam,
 	const WCHAR*	pszPath,
-	WCHAR*			pszCompareLabel,
 	HWND*			phwndCompareWnd
 )
 {
 	m_pszPath = pszPath;
-	m_pszCompareLabel = pszCompareLabel;
 	m_phwndCompareWnd = phwndCompareWnd;
 	return CDialog::DoModal( hInstance, hwndParent, IDD_COMPARE, lParam );
 }
@@ -203,22 +201,13 @@ int CDlgCompare::GetData( void )
 {
 	HWND			hwndList;
 	int				nItem;
-	EditInfo*		pfi;
 	hwndList = GetItemHwnd( IDC_LIST_FILES );
 	nItem = List_GetCurSel( hwndList );
 	if( LB_ERR == nItem ){
 		return FALSE;
 	}else{
 		*m_phwndCompareWnd = (HWND)List_GetItemData( hwndList, nItem );
-		/* トレイからエディタへの編集ファイル名要求通知 */
-		::SendMessageAny( *m_phwndCompareWnd, MYWM_GETFILEINFO, 0, 0 );
-		pfi = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
-		// 2010.07.30 パス名はやめて表示名に変更
-		int nId = CAppNodeManager::getInstance()->GetEditNode( *m_phwndCompareWnd )->GetId();
-		CTextWidthCalc calc(hwndList);
-		CFileNameManager::getInstance()->GetMenuFullLabel_WinListNoEscape( m_pszCompareLabel, _MAX_PATH/*長さ不明*/, pfi, nId, -1, calc.GetDC() );
-	
 		/* 左右に並べて表示 */
 		m_bCompareAndTileHorz = ::IsDlgButtonChecked( GetHwnd(), IDC_CHECK_TILE_H );
 

--- a/sakura_core/dlg/CDlgCompare.h
+++ b/sakura_core/dlg/CDlgCompare.h
@@ -33,10 +33,9 @@ public:
 	||  Attributes & Operations
 	*/
 	int DoModal( HINSTANCE hInstance, HWND hwndParent, LPARAM lParam,
-				 const WCHAR* pszPath, WCHAR* pszCompareLabel, HWND* phwndCompareWnd );	/* モーダルダイアログの表示 */
+				 const WCHAR* pszPath, HWND* phwndCompareWnd );	/* モーダルダイアログの表示 */
 
 	const WCHAR*	m_pszPath;
-	WCHAR*			m_pszCompareLabel;
 	HWND*			m_phwndCompareWnd;
 	BOOL			m_bCompareAndTileHorz;/* 左右に並べて表示 */
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->
# <!-- 必須 --> PR の目的
ファイル内容比較ダイアログの処理、pszCompareLabelを削除します。
この変数は設定されるものの、特に使われていませんでした。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
>GetMenuFullLabel_WinListNoEscape(m_pszCompareLabel, _MAX_PATH/\*長さ不明\*/

という若干怪しい記述を削除できます。
m_pszCompareLabelは呼び出し元の文字列を設定しますが、文字列長を設定する機能がありません。
おそらくファイル名なので、_MAX_PATHだろうなという記述のようです。
一応、動作上は259文字のファイルでもこのGetMenuFullLabelで加工しても文字コードとか付加されず、そのまま戻って来るので、落ちたりはしませんが、若干の気持ち悪さはあります。

## <!-- 自明なら省略可 --> PR のメリット
文字列長の仮定をしているコードが一カ所減ります。

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
特にはないと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
ここの削除したコードは実行されていましたが、バッファ自体は呼び出し元が一切使っていませんので、捨てられているだけでした。

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順

ファイル内容比較ダイアログを表示、実行してみても、特に違いはありません。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
変な感じのするコードが減ります。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
