### PR TITLE
テキスト幅計算に使用する文字間隔配列のコンテナを使いまわす事で負荷を削減

### DIFF
--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -1347,7 +1347,8 @@ void CPrintPreview::DrawHeaderFooter( HDC hdc, const CMyRect& rect, bool bHeader
 			bHeader ? m_pPrintSetting->m_szHeaderForm[POS_CENTER] : m_pPrintSetting->m_szFooterForm[POS_CENTER],
 			szWork, nWorkLen);
 		nLen = wcslen( szWork );
-		nTextWidth = CTextMetrics::CalcTextWidth2(szWork, nLen, nDx, spaceing); //テキスト幅
+		std::vector<int> vDxArray;
+		nTextWidth = CTextMetrics::CalcTextWidth2(szWork, nLen, nDx, spaceing, vDxArray); //テキスト幅
 		Print_DrawLine(
 			hdc,
 			CMyPoint(
@@ -1366,7 +1367,7 @@ void CPrintPreview::DrawHeaderFooter( HDC hdc, const CMyRect& rect, bool bHeader
 			bHeader ? m_pPrintSetting->m_szHeaderForm[POS_RIGHT] : m_pPrintSetting->m_szFooterForm[POS_RIGHT],
 			szWork, nWorkLen);
 		nLen = wcslen( szWork );
-		nTextWidth = CTextMetrics::CalcTextWidth2(szWork, nLen, nDx, spaceing); //テキスト幅
+		nTextWidth = CTextMetrics::CalcTextWidth2(szWork, nLen, nDx, spaceing, vDxArray); //テキスト幅
 		Print_DrawLine(
 			hdc,
 			CMyPoint(

--- a/sakura_core/view/CTextMetrics.cpp
+++ b/sakura_core/view/CTextMetrics.cpp
@@ -237,11 +237,10 @@ int CTextMetrics::CalcTextWidth2(
 	const wchar_t* pText, //!< 文字列
 	int nLength,          //!< 文字列長
 	int nHankakuDx,       //!< 半角文字の文字間隔
-	int nCharSpacing      //!< 文字の隙間
+	int nCharSpacing,     //!< 文字の隙間
+	std::vector<int>& vDxArray //!< [out] 文字間隔配列
 )
 {
-	//文字間隔配列を生成
-	vector<int> vDxArray;
 	const int* pDxArray = CTextMetrics::GenerateDxArray(
 		&vDxArray,
 		pText,
@@ -258,8 +257,8 @@ int CTextMetrics::CalcTextWidth2(
 
 int CTextMetrics::CalcTextWidth3(
 	const wchar_t* pText, //!< 文字列
-	int nLength          //!< 文字列長
+	int nLength           //!< 文字列長
 ) const
 {
-	return CalcTextWidth2(pText, nLength, GetCharPxWidth(), GetCharSpacing());
+	return CalcTextWidth2(pText, nLength, GetCharPxWidth(), GetCharSpacing(), m_vDxArray);
 }

--- a/sakura_core/view/CTextMetrics.h
+++ b/sakura_core/view/CTextMetrics.h
@@ -112,7 +112,8 @@ public:
 		const wchar_t* pText, //!< 文字列
 		int nLength,          //!< 文字列長
 		int nHankakuDx,       //!< 半角文字の文字間隔
-		int nCharSpacing
+		int nCharSpacing,     //!< 文字の隙間
+		std::vector<int>& vDxArray //!< [out] 文字間隔配列
 	);
 
 	int CalcTextWidth3(
@@ -129,5 +130,6 @@ private:
 	int m_anHankakuDx[64]; //!< 半角用文字間隔配列
 	int m_anZenkakuDx[64]; //!< 全角用文字間隔配列
 	std::vector<int> m_aFontHeightMargin;
+	mutable std::vector<int> m_vDxArray; //!< 文字間隔配列
 };
 #endif /* SAKURA_CTEXTMETRICS_7972A864_FDFF_4852_9EA5_A91D39657A7F_H_ */


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

処理の高速化です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 速度向上

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

`CTextMetrics::CalcTextWidth2` メソッド内で文字間隔配列用にローカル変数でSTLコンテナを用意していますが、ローカル変数なのでスコープから抜けるとメモリ解放が行われます。

頻繁に呼び出される処理内でメモリの確保と解放が行われるとそれ自体が負担になってしまうので、引数経由で渡す事でインスタンスを再利用するように変更しました。

## <!-- 自明なら省略可 --> PR のメリット

処理が少しだけ高速化します。

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

`CTextMetrics::CalcTextWidth2` メソッドを呼び出す際に渡す必要のある引数が１つ増える事で使い勝手が悪くなります。
ただし呼び出している箇所は3か所と多く無いので影響は少ないです。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

#1411 で berryzplus さんが用意してくれた `flash_eol_test.js` マクロを使用しました。
`README.md` ファイルを開いてからウィンドウを最大化してマクロを複数回実行しました。
単位は省略していますが ms（ミリ秒）です。

変更前 470a1fff9c5c0097d8d0ea845e689b2394c77c16 : 5467, 5461, 5429, 5436, 5414, 5414, 5429, 
変更後 c4a7fa659ed2ddb439d4a1b309fdfe0734def6d8 : 5336, 5361, 5292, 5345, 5299, 5298, 5261, 

1～2%程度とわずかな変化ですが有意差はあるんじゃないかと思います。CPUクロックのブーストによる影響が無いかとか心配になってしまいますが…。

なお #1405 で使われていた `redrawcounter.js` マクロだと殆ど差を確認出来ませんでした。処理内容の違いが原因なのか、それとも処理時間の数値が小さくて差が表れにくいのかは不明です。

## <!-- なければ省略可 --> 関連 issue, PR

#1405, #1411
