### PR TITLE
サクラエディタのコマンドライン引数に超長い文字列を指定するとクラッシュする問題に対処する。

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -431,6 +431,7 @@
     <ClInclude Include="..\sakura_core\io\CStream.h" />
     <ClInclude Include="..\sakura_core\io\CTextStream.h" />
     <ClInclude Include="..\sakura_core\io\CZipFile.h" />
+    <ClInclude Include="..\sakura_core\io\FilePathTooLongError.h" />
     <ClInclude Include="..\sakura_core\macro\CCookieManager.h" />
     <ClInclude Include="..\sakura_core\macro\CEditorIfObj.h" />
     <ClInclude Include="..\sakura_core\macro\CIfObj.h" />
@@ -796,6 +797,7 @@
     <ClCompile Include="..\sakura_core\io\CStream.cpp" />
     <ClCompile Include="..\sakura_core\io\CTextStream.cpp" />
     <ClCompile Include="..\sakura_core\io\CZipFile.cpp" />
+    <ClCompile Include="..\sakura_core\io\FilePathTooLongError.cpp" />
     <ClCompile Include="..\sakura_core\macro\CCookieManager.cpp" />
     <ClCompile Include="..\sakura_core\macro\CEditorIfObj.cpp" />
     <ClCompile Include="..\sakura_core\macro\CIfObj.cpp" />

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1097,6 +1097,9 @@
     <ClInclude Include="..\sakura_core\GrepInfo.h">
       <Filter>Cpp Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\io\FilePathTooLongError.h">
+      <Filter>Cpp Source Files\io</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\resource\auto_scroll_center.cur">
@@ -2275,6 +2278,9 @@
     </ClCompile>
     <ClCompile Include="..\sakura_core\GrepInfo.cpp">
       <Filter>Cpp Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sakura_core\io\FilePathTooLongError.cpp">
+      <Filter>Cpp Source Files\io</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -27,6 +27,7 @@
 #include "debug/CRunningTimer.h"
 #include "charset/charcode.h"  // 2006.06.28 rastiv
 #include "io/CTextStream.h"
+#include "io/FilePathTooLongError.h"
 #include "util/shell.h"
 #include "util/file.h"
 #include "env/CSakuraEnvironment.h"
@@ -265,6 +266,10 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 			}
 			szPath[i] = pszCmdLineSrc[i];
 		}
+
+		if( i == _countof(szPath) ){
+			throw FilePathTooLongError( std::wstring_view( pszCmdLineSrc, ::wcscspn( pszCmdLineSrc, L" " ) ) );
+		}
 	}
 	if( bFind ){
 		CSakuraEnvironment::ResolvePath(szPath);
@@ -308,6 +313,9 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 				if( len > 0 ){
 					cmWork.SetString( &pszToken[1], len - ( pszToken[len] == L'"' ? 1 : 0 ));
 					cmWork.Replace( L"\"\"", L"\"" );
+					if( _countof(szPath) == ::wcsnlen( cmWork.GetStringPtr(), _countof(szPath) ) ){
+						throw FilePathTooLongError( std::wstring_view( cmWork.GetStringPtr() ) );
+					}
 					wcscpy_s( szPath, _countof(szPath), cmWork.GetStringPtr() );	/* ファイル名 */
 				}
 				else {
@@ -315,6 +323,9 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 				}
 			}
 			else{
+				if( _countof(szPath) == ::wcsnlen( pszToken, _countof(szPath) ) ){
+					throw FilePathTooLongError( std::wstring_view( pszToken ) );
+				}
 				wcscpy_s( szPath, _countof(szPath), pszToken );		/* ファイル名 */
 			}
 

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -24,6 +24,7 @@
 #include <locale.h>
 #include "CProcessFactory.h"
 #include "CProcess.h"
+#include "io/FilePathTooLongError.h"
 #include "util/os.h"
 #include "util/module.h"
 #include "debug/CRunningTimer.h"
@@ -100,6 +101,9 @@ int WINAPI wWinMain(
 	try{
 		process = aFactory.Create( hInstance, lpCmdLine );
 		MY_TRACETIME( cRunningTimer, "ProcessObject Created" );
+	}
+	catch( const FilePathTooLongError& ex ){
+		ex.ShowMessage();
 	}
 	catch(...){
 	}

--- a/sakura_core/io/FilePathTooLongError.cpp
+++ b/sakura_core/io/FilePathTooLongError.cpp
@@ -1,0 +1,52 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2020 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include "StdAfx.h"
+#include "io/FilePathTooLongError.h"
+#include "util/MessageBoxF.h"
+#include "CSelectLang.h"
+#include "String_define.h"
+
+/*!
+ * コンストラクタ
+ *
+ * @param path [in] 長過ぎるファイルパス
+ */
+FilePathTooLongError::FilePathTooLongError( const std::wstring_view& path )
+	: std::runtime_error("file path is too long.")
+	, path_buff(std::make_unique<wchar_t[]>(path.length() + 1))
+{
+	path.copy( path_buff.get(), path.length() );
+}
+
+/*!
+ * エラーメッセージを表示する
+ *
+ * @param hwndParent [in,opt] ウインドウハンドル
+ */
+void FilePathTooLongError::ShowMessage( HWND hwndParent ) const
+{
+	// L"%ls\nというファイルを開けません。\nファイルのパスが長すぎます。"
+	ErrorMessage( hwndParent, LS(STR_ERR_FILEPATH_TOO_LONG), path_buff.get() );
+}

--- a/sakura_core/io/FilePathTooLongError.h
+++ b/sakura_core/io/FilePathTooLongError.h
@@ -1,0 +1,54 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2020 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#pragma once
+
+#include <tchar.h>
+#include <Windows.h>
+
+#include <stdexcept>
+#include <memory>
+#include <string>
+
+/*!
+ * ファイルパスが長過ぎるエラー
+ */
+class FilePathTooLongError : std::runtime_error {
+	std::unique_ptr<wchar_t[]> path_buff;
+
+public:
+	/*!
+	 * コンストラクタ
+	 *
+	 * @param path [in] 長過ぎるファイルパス
+	 */
+	FilePathTooLongError( const std::wstring_view& path );
+
+	/*!
+	 * エラーメッセージを表示する
+	 *
+	 * @param hwndParent [in,opt] ウインドウハンドル
+	 */
+	void ShowMessage( HWND hwndParent = NULL ) const;
+};


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
サクラエディタのコマンドライン引数に超長い文字列を指定するとクラッシュする問題(#1406)に対処します。


## <!-- 必須 --> カテゴリ
- 不具合修正
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1406 の対策 PR です。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
* コマンドラインで超長いパスを指定したときにクラッシュする（≒何もメッセージを出さずに異常終了する）不具合を解消できます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
* コマンドライン解析処理に スマートポインタ が導入されます。
* 「ファイルパスが長過ぎるエラー」（＝例外クラス）が追加されます。
* この PR が実現するのは、異常検出時に正しく異常終了させることなので #1406 で期待された挙動の要件（＝発生したエラーを無視して続行させたい）を満たしません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
サクラエディタは`_MAX_PATH(259字)` を超えるファイルパスをサポートしていませんが、サポートされない超長いパスが指定されたときにどうなるかが定義されていませんでした。もともと一部のパス処理用の独自関数には定義があるのですが、肝心のコマンドライン引数の解析処理で「超長いパス」を指定された場合の挙動が未定義でした。このため、現状で「超長いパス」を指定した場合、問答無用でクラッシュしていまいます。

この PR ではとりあえずの対処として、異常を検知したらメッセージを出して終了するようにします。



## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1
`_MAX_PATH(259字)` を超える引数を指定したときに異常終了すること。

#### 手順
1. `sakura.exe 12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789x xxxxx` を実行する。(1つ目の引数は260字)
1. `"12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789x\nというファイルを開けません。\nファイルのパスが長すぎます。"`  と表示されてプログラムが終了すること。(1つ目の引数は260字がファイル名に埋め込まれる)

### テスト2
`_MAX_PATH(259字)` を超えない引数を指定したときに正しく起動できること。

#### 手順
1. sakura.exe を普通に起動する。


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
* サクラエディタの起動パラメータ（≒コマンドライン引数）の解析にルールを追加する変更です。
* コマンドラインからの起動に影響します。
* Windows エクスプローラーからの起動に影響します。（コマンドラインからの起動と実体は同じもの）
* Windows API からの起動に影響します。（コマンドラインからの起動と実体は同じものですが、最大32,766文字を指定できるやり方です）

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1406

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://docs.microsoft.com/ja-jp/cpp/c-runtime-library/reference/strcspn-wcscspn-mbscspn-mbscspn-l?view=vs-2019
https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
