### PR TITLE
プロパティシートに対してシステムフォントを設定

### DIFF
--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -381,15 +381,16 @@ void SetFontRecursive( HWND hwnd, HFONT hFont )
 }
 
 /*!
-	ダイアログボックス用のフォントを設定(日本語以外では何もしない)
+	ダイアログボックス用のフォントを設定
 	@param[in]	hwnd		設定対象ダイアログボックスのウィンドウハンドル
+	@param[in]	force		強制設定有無(TRUE:必ず設定 FALSE:日本語の場合は設定しそれ以外では設定しない)
 	@return		ダイアログボックスに設定されたフォントハンドル(破棄禁止)
 */
-HFONT UpdateDialogFont( HWND hwnd )
+HFONT UpdateDialogFont( HWND hwnd, BOOL force )
 {
 	HFONT hFontDialog = (HFONT)::SendMessageAny( hwnd, WM_GETFONT, 0, (LPARAM)NULL );
 
-	if( wcsncmp_literal( CSelectLang::getDefaultLangString(), _T("Japanese") ) != 0 ){
+	if( !force && wcsncmp_literal( CSelectLang::getDefaultLangString(), _T("Japanese") ) != 0 ){
 		return hFontDialog;
 	}
 

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -192,6 +192,6 @@ private:
 	HFONT m_hFont;
 };
 
-HFONT UpdateDialogFont( HWND hwnd );
+HFONT UpdateDialogFont( HWND hwnd, BOOL force = FALSE );
 
 #endif /* SAKURA_WINDOW_A0833476_5E32_46BE_87B6_ECD55F10D34A_H_ */


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

共通設定・タイプ別設定ダイアログのタブと下部にあるボタンについて、言語設定が英語の時のみ文字がギザギザしていて見栄えが悪いため、この部分に Windows のシステムフォントが使われるようにします。
※ https://github.com/sakura-editor/sakura/pull/1421#issuecomment-703183341 で挙げていた問題点

共通設定ダイアログの例：
v2.4.2.0 | 変更後
-|-
![image](https://user-images.githubusercontent.com/11252784/95762308-7e8c4500-0ce8-11eb-9a91-2ae02ff465fa.png) | ![image](https://user-images.githubusercontent.com/11252784/95762328-864be980-0ce8-11eb-8def-6b57771e10e3.png)

## <!-- 必須 --> カテゴリ

- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

## <!-- 自明なら省略可 --> PR のメリット

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

特にないと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

言語設定が英語の時のプロパティシート部のフォントが MS Shell Dlg (MS UI Gothic) から Windows のシステムフォント (Yu Gothic UI 等) に変わります。

## <!-- 必須 --> テスト内容

1. 共通設定->ウィンドウタブの「言語」で「English (United States)」を選択する。
2. ダイアログを閉じ、タイプ別設定を開く。

* 確認1: タブおよび下部のボタンの文字がシステムフォントに変わっていること。

3. ダイアログを閉じ、共通設定を開く。

* 確認2: タブおよび下部のボタンの文字がシステムフォントに変わっていること。

## <!-- わかる範囲で --> PR の影響範囲

* タイプ別設定ダイアログ
* 共通設定ダイアログ

※`MyPropertySheet`関数を呼び出しているもの

## <!-- なければ省略可 --> 関連 issue, PR

https://github.com/sakura-editor/sakura/pull/1421

## <!-- なければ省略可 --> 参考資料

* 現状のプロパティシートのタブやボタンのフォントがどこで指定されているのか調べている中で、以下リンク先の記事が参考になりました。
https://www.codeguru.com/cpp/controls/propertysheet/previoussectionmanager/article.php/c16651/Custom-Font-in-Property-Sheets.htm