### PR TITLE
引数の文字列コピーに検出したnArgLenを使う

### DIFF
--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -419,22 +419,22 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 				break;
 			case CMDLINEOPT_GKEY:	//	GKEY
 				//	前後の""を取り除く
-				m_gi.cmGrepKey.SetString( arg,  lstrlen( arg ) );
+				m_gi.cmGrepKey.SetString( arg, nArgLen );
 				m_gi.cmGrepKey.Replace( L"\"\"", L"\"" );
 				break;
 			case CMDLINEOPT_GREPR:	//	GREPR
 				//	前後の""を取り除く
-				m_gi.cmGrepRep.SetString( arg,  lstrlen( arg ) );
+				m_gi.cmGrepRep.SetString( arg, nArgLen );
 				m_gi.cmGrepRep.Replace( L"\"\"", L"\"" );
 				m_gi.bGrepReplace = true;
 				break;
 			case CMDLINEOPT_GFILE:	//	GFILE
 				//	前後の""を取り除く
-				m_gi.cmGrepFile.SetString( arg,  lstrlen( arg ) );
+				m_gi.cmGrepFile.SetString( arg, nArgLen );
 				m_gi.cmGrepFile.Replace( L"\"\"", L"\"" );
 				break;
 			case CMDLINEOPT_GFOLDER:	//	GFOLDER
-				m_gi.cmGrepFolder.SetString( arg,  lstrlen( arg ) );
+				m_gi.cmGrepFolder.SetString( arg, nArgLen );
 				m_gi.cmGrepFolder.Replace( L"\"\"", L"\"" );
 				break;
 			case CMDLINEOPT_GOPT:	//	GOPT
@@ -507,14 +507,14 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 				bParseOptDisabled = true;
 				break;
 			case CMDLINEOPT_M:			// 2009.06.14 syat 追加
-				m_cmMacro.SetString( arg );
+				m_cmMacro.SetString( arg, nArgLen );
 				m_cmMacro.Replace( L"\"\"", L"\"" );
 				break;
 			case CMDLINEOPT_MTYPE:		// 2009.06.14 syat 追加
-				m_cmMacroType.SetString( arg );
+				m_cmMacroType.SetString( arg, nArgLen );
 				break;
 			case CMDLINEOPT_PROF:		// 2013.12.20 Moca 追加
-				m_cmProfile.SetString( arg );
+				m_cmProfile.SetString( arg, nArgLen );
 				m_bSetProfile = true;
 				break;
 			case CMDLINEOPT_PROFMGR:


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
`-GKEY` などの文字列を指定できるコマンドラインオプションを内部変数にコピーする処理で、検出した文字列長を使わずに再計算しているのが効率悪いので、検出済みの文字列長を使うように修正します。

## <!-- 必須 --> カテゴリ

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
コマンドラインオプションには、文字列値をパラメータとして指定できるものがあります。

たとえば `-GKEY` の設定はこうなっています。
https://github.com/sakura-editor/sakura/blob/bb83d9da22bb4f7e92904b31549f3e2b4b5048b8/sakura_core/_main/CCommandLine.cpp#L420-L424

このPRでやりたいことは `lstrlen( arg )` をやめることです。

argの宣言はこうなっていて、nArgLenとセットで宣言されています。

https://github.com/sakura-editor/sakura/blob/bb83d9da22bb4f7e92904b31549f3e2b4b5048b8/sakura_core/_main/CCommandLine.cpp#L357-L359

`CCommandLine::CheckCommandLine` は、オプション文字列 `-GKEY="\s+"` を受け取って `\s+` を検出する関数です。  
https://github.com/sakura-editor/sakura/blob/bb83d9da22bb4f7e92904b31549f3e2b4b5048b8/sakura_core/_main/CCommandLine.cpp#L75-L79

検出した文字列長があるのにそれを使わず、lstrlen したり省略して wcslen したりするのは無駄だと思います。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
`CCommandLine::CheckCommandLine` で検出した文字列長を使うことにより、不要な文字列長計算を行わなくてすむようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
`CCommandLine::CheckCommandLine` の文字列長検出に誤りがあった場合、文字列値を指定できるコマンドラインオプションの解析結果に悪影響が出るようになります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
仕様・動作に変更はありません。

## <!-- 必須 --> テスト内容
変更行は全行が単体テスト https://github.com/sakura-editor/sakura/blob/master/tests/unittests/test-ccommandline.cpp の範囲に含まれるため、追加で実施するテストはありません。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
文字列値を指定できるコマンドラインオプションを指定したときの動作に影響します。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1420

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
