### PR TITLE
デバッグ実行時に外部コマンド実行ダイアログを開くとwarning_point関数で止まる問題を修正する

### DIFF
--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -134,11 +134,11 @@ void CDlgExec::SetData( void )
 	/*****************************
 	*         データ設定         *
 	*****************************/
-	int nCommandsCount = m_pShareData->m_sHistory.m_aCommands.size();
+	hwndCombo = GetItemHwnd( IDC_COMBO_m_szCommand );
+	Combo_ResetContent( hwndCombo );
+	const int nCommandsCount = m_pShareData->m_sHistory.m_aCommands.size();
 	if( 0 < nCommandsCount ){
 		wcscpy( m_szCommand, m_pShareData->m_sHistory.m_aCommands[0] );
-		hwndCombo = GetItemHwnd( IDC_COMBO_m_szCommand );
-		Combo_ResetContent( hwndCombo );
 		::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_szCommand );
 		for( i = 0; i < nCommandsCount; ++i ){
 			Combo_AddString( hwndCombo, m_pShareData->m_sHistory.m_aCommands[i] );
@@ -146,11 +146,11 @@ void CDlgExec::SetData( void )
 		Combo_SetCurSel( hwndCombo, 0 );
 	}
 
-	int nCurDirsCount = m_pShareData->m_sHistory.m_aCurDirs.size();
+	hwndCombo = GetItemHwnd( IDC_COMBO_CUR_DIR );
+	Combo_ResetContent( hwndCombo );
+	const int nCurDirsCount = m_pShareData->m_sHistory.m_aCurDirs.size();
 	if( 0 < nCurDirsCount ){
 		wcscpy( m_szCurDir, m_pShareData->m_sHistory.m_aCurDirs[0] );
-		hwndCombo = GetItemHwnd( IDC_COMBO_CUR_DIR );
-		Combo_ResetContent( hwndCombo );
 		::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_szCurDir );
 		for( i = 0; i < nCurDirsCount; ++i ){
 			Combo_AddString( hwndCombo, m_pShareData->m_sHistory.m_aCurDirs[i] );

--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -134,24 +134,29 @@ void CDlgExec::SetData( void )
 	/*****************************
 	*         データ設定         *
 	*****************************/
-	wcscpy( m_szCommand, m_pShareData->m_sHistory.m_aCommands[0] );
-	hwndCombo = GetItemHwnd( IDC_COMBO_m_szCommand );
-	Combo_ResetContent( hwndCombo );
-	::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_szCommand );
-	int nSize = m_pShareData->m_sHistory.m_aCommands.size();
-	for( i = 0; i < nSize; ++i ){
-		Combo_AddString( hwndCombo, m_pShareData->m_sHistory.m_aCommands[i] );
+	int nCommandsCount = m_pShareData->m_sHistory.m_aCommands.size();
+	if( 0 < nCommandsCount ){
+		wcscpy( m_szCommand, m_pShareData->m_sHistory.m_aCommands[0] );
+		hwndCombo = GetItemHwnd( IDC_COMBO_m_szCommand );
+		Combo_ResetContent( hwndCombo );
+		::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_szCommand );
+		for( i = 0; i < nCommandsCount; ++i ){
+			Combo_AddString( hwndCombo, m_pShareData->m_sHistory.m_aCommands[i] );
+		}
+		Combo_SetCurSel( hwndCombo, 0 );
 	}
-	Combo_SetCurSel( hwndCombo, 0 );
 
-	wcscpy( m_szCurDir, m_pShareData->m_sHistory.m_aCurDirs[0] );
-	hwndCombo = GetItemHwnd( IDC_COMBO_CUR_DIR );
-	Combo_ResetContent( hwndCombo );
-	::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_szCurDir );
-	for( i = 0; i < m_pShareData->m_sHistory.m_aCurDirs.size(); ++i ){
-		Combo_AddString( hwndCombo, m_pShareData->m_sHistory.m_aCurDirs[i] );
+	int nCurDirsCount = m_pShareData->m_sHistory.m_aCurDirs.size();
+	if( 0 < nCurDirsCount ){
+		wcscpy( m_szCurDir, m_pShareData->m_sHistory.m_aCurDirs[0] );
+		hwndCombo = GetItemHwnd( IDC_COMBO_CUR_DIR );
+		Combo_ResetContent( hwndCombo );
+		::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_szCurDir );
+		for( i = 0; i < nCurDirsCount; ++i ){
+			Combo_AddString( hwndCombo, m_pShareData->m_sHistory.m_aCurDirs[i] );
+		}
+		Combo_SetCurSel( hwndCombo, 0 );
 	}
-	Combo_SetCurSel( hwndCombo, 0 );
 	
 	int nOpt;
 	hwndCombo = GetItemHwnd( IDC_COMBO_CODE_GET );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

外部コマンド実行ダイアログを開く時、`StaticVector`の有効範囲外参照 (要素数 0 の時に 0 番目を参照) により`warning_point`関数でブレークしてしまう点を解消します。
この現象は「名前」の履歴がない状態において 100% 発生します。

ただ、有効範囲外ではありますが有効なメモリ領域が参照され空文字列が取得されているために、実動作上の問題にはなっていないようです。

※ https://github.com/sakura-editor/sakura/pull/1421 の確認中に発見しました。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

## <!-- 自明なら省略可 --> PR のメリット

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

* 履歴の数が 0 の場合にはコンボボックスへのデータ設定をスキップします。(コマンド履歴、カレントディレクトリについて)

## <!-- 必須 --> テスト内容

1. VisualStudio でデバッグ実行を開始する。
2. 履歴の管理ダイアログを開き、「コマンド」「カレントディレクトリ」の履歴をそれぞれすべて削除する。
3. 外部コマンド実行ダイアログを開く。
* 確認: `warning_point`関数でブレークしないこと。

## <!-- わかる範囲で --> PR の影響範囲

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
