### PR TITLE
カスタムメニューの追加時に配列の範囲外を書き換えないようにする

### DIFF
--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -492,7 +492,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					}
 					nNum2 = List_GetCount( hwndLIST_RES );
 					if( LB_ERR == nNum2 ){
-						nIdx2 = 0;
+						nNum2 = 0;
 					}
 					nIdx3 = Combo_GetCurSel( hwndCOMBO_FUNCKIND );
 					if( CB_ERR == nIdx3 ){


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

sf.netで指摘されていた潜在バグに対する修正パッチを取り込みます。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

カスタムメニューの設定画面には、メニュー項目を追加する処理において、特定の条件下で実行される処理に誤りがあるため、後続の処理にて配列の範囲外にアクセスする潜在バグが存在します。

メニュー項目の追加処理では、コンボボックスで選択されたメニュー配列のリストアイテム数をnNum2に、そのうち選択されているもののインデックスをnIdx2に格納しています。
ここでそれぞれの数を取得できなかった(=返り値がLB_ERRだった)場合、その配列の先頭に項目を追加するものとして処理を続行しますが、このときnNum2がLB_ERRだった場合に先頭の要素を参照するための値を格納する代入先が正しくないため、その後の配列へのアクセス時に範囲外の領域を参照していました。

bug#13のパッチを取り込んでこの問題を修正します。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- 必須 --> テスト内容

通常の使用ではこの問題の影響はありません。
v2.4.1と修正後のビルドとの間で、カスタムメニューの項目追加・削除の動作とメニューの表示に変わりがないことを確認しました。

## <!-- わかる範囲で --> PR の影響範囲

共通設定ダイアログ → カスタムメニュー → メニュー項目の追加

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

[SAKURA Editor / Bugs / #13 カスタムメニュー設定画面の潜在バグ](https://sourceforge.net/p/sakura-editor/bugs/13/)

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
