### PR TITLE
アウトライン解析にタイプ別設定フォントを使う

### DIFF
--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -754,6 +754,7 @@ void CEditDoc::OnChangeSetting(
 	// フォント更新
 	m_pcEditWnd->m_pcViewFont->UpdateFont(&m_pcEditWnd->GetLogfont());
 	m_pcEditWnd->m_pcViewFontMiniMap->UpdateFont(&m_pcEditWnd->GetLogfont());
+	m_pcEditWnd->m_cDlgFuncList.UpdateViewFont(m_pcEditWnd->GetLogfont());
 
 	InitCharWidthCache( m_pcEditWnd->m_pcViewFontMiniMap->GetLogfont(), CWM_FONT_MINIMAP );
 	SelectCharWidthCache( CWM_FONT_EDIT, m_pcEditWnd->GetLogfontCacheMode() );

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -1872,7 +1872,14 @@ BOOL CDlgFuncList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		}
 	}
 
-	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
+	BOOL bRet = CDialog::OnInitDialog( hwndDlg, wParam, lParam );
+
+	m_cFontView = CFont( (HFONT)::SendMessageAny( hwndDlg, WM_GETFONT, 0, (LPARAM)NULL ) );
+	if( pcEditView != NULL ){
+		UpdateViewFont( pcEditView->m_pcEditWnd->m_pcViewFont->GetLogfont() );
+	}
+
+	return bRet;
 }
 
 BOOL CDlgFuncList::OnBnClicked( int wID )
@@ -2567,6 +2574,7 @@ void CDlgFuncList::Redraw( int nOutLineType, int nListType, CFuncInfoArr* pcFunc
 	}
 
 	SetData();
+	UpdateViewFont( pcEditView->m_pcEditWnd->m_pcViewFont->GetLogfont() );
 }
 
 //ダイアログタイトルの設定
@@ -3943,6 +3951,19 @@ void CDlgFuncList::NotifyDocModification()
 	m_bFuncInfoArrIsUpToDate = false;
 
 	return;
+}
+
+/*!
+	リスト/ツリービューのフォントを更新
+*/
+void CDlgFuncList::UpdateViewFont( const LOGFONT& logfont )
+{
+	CFont cFontNew = CFont( logfont, m_cFontView.GetLogicalHeight() );
+	const HWND hwnds[] = { GetItemHwnd( IDC_LIST_FL ), GetItemHwnd( IDC_TREE_FL ) };
+	for( size_t i = 0; i < _countof( hwnds ); ++i ){
+		::SendMessage( hwnds[i], WM_SETFONT, (WPARAM)cFontNew.GetHandle(), MAKELPARAM( FALSE, 0 ) );
+	}
+	m_cFontView = std::move( cFontNew );
 }
 
 /*!

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -1874,7 +1874,7 @@ BOOL CDlgFuncList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	BOOL bRet = CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 
-	m_cFontView = CFont( (HFONT)::SendMessageAny( hwndDlg, WM_GETFONT, 0, (LPARAM)NULL ) );
+	m_cViewFont = CGdiFont( GetDialogFont() );
 	if( pcEditView != NULL ){
 		UpdateViewFont( pcEditView->m_pcEditWnd->m_pcViewFont->GetLogfont() );
 	}
@@ -3958,14 +3958,14 @@ void CDlgFuncList::NotifyDocModification()
 */
 void CDlgFuncList::UpdateViewFont( const LOGFONT& logfont )
 {
-	CFont cFontNew = CFont( logfont, m_cFontView.GetLogicalHeight() );
+	CGdiFont cNewFont = CGdiFont( logfont, m_cViewFont.GetLogicalHeight() );
 	const HWND hwnds[] = { GetItemHwnd( IDC_LIST_FL ), GetItemHwnd( IDC_TREE_FL ) };
 	for( size_t i = 0; i < _countof( hwnds ); ++i ){
-		::SendMessage( hwnds[i], WM_SETFONT, (WPARAM)cFontNew.GetHandle(), MAKELPARAM( FALSE, 0 ) );
+		::SendMessage( hwnds[i], WM_SETFONT, (WPARAM)cNewFont.GetHandle(), MAKELPARAM( FALSE, 0 ) );
 		// フォント変更前の文字が一部残ることがあるので再描画
 		InvalidateRect( hwnds[i], NULL, TRUE );
 	}
-	m_cFontView = std::move( cFontNew );
+	m_cViewFont = std::move( cNewFont );
 
 	return;
 }

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3962,8 +3962,12 @@ void CDlgFuncList::UpdateViewFont( const LOGFONT& logfont )
 	const HWND hwnds[] = { GetItemHwnd( IDC_LIST_FL ), GetItemHwnd( IDC_TREE_FL ) };
 	for( size_t i = 0; i < _countof( hwnds ); ++i ){
 		::SendMessage( hwnds[i], WM_SETFONT, (WPARAM)cFontNew.GetHandle(), MAKELPARAM( FALSE, 0 ) );
+		// フォント変更前の文字が一部残ることがあるので再描画
+		InvalidateRect( hwnds[i], NULL, TRUE );
 	}
 	m_cFontView = std::move( cFontNew );
+
+	return;
 }
 
 /*!

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -25,6 +25,7 @@
 #include <Windows.h>
 #include "dlg/CDialog.h"
 #include "doc/CEditDoc.h"
+#include "util/window.h"
 
 class CFuncInfo;
 class CFuncInfoArr; // 2002/2/10 aroka
@@ -103,6 +104,7 @@ public:
 	void LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDirPath );
 	void NotifyCaretMovement( CLayoutInt nCurLine, CLayoutInt nCurCol );
 	void NotifyDocModification();
+	void UpdateViewFont( const LOGFONT& logfont );
 
 protected:
 	bool m_bInChangeLayout;
@@ -230,5 +232,7 @@ private:
 	RECT				m_rcItems[12];
 
 	bool		m_bFuncInfoArrIsUpToDate;
+
+	CFont		m_cFontView;
 };
 #endif /* SAKURA_CDLGFUNCLIST_B22A3877_572A_49B7_B683_50ECA451A6F8_H_ */

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -233,6 +233,6 @@ private:
 
 	bool		m_bFuncInfoArrIsUpToDate;
 
-	CFont		m_cFontView;
+	CGdiFont		m_cViewFont;
 };
 #endif /* SAKURA_CDLGFUNCLIST_B22A3877_572A_49B7_B683_50ECA451A6F8_H_ */

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -192,14 +192,14 @@ private:
 	HFONT m_hFont;
 };
 
-class CFont
+class CGdiFont
 {
 public:
-	CFont() = default;
-	CFont( const CFont& font ) : CFont( font.m_hFont ){}
-	CFont( CFont&& font ) noexcept { *this = std::move( font ); }
-	CFont( HFONT hFont, LONG nLogicalHeight = LONG_MAX ) : CFont( GetLogFont( hFont ), nLogicalHeight ){}
-	CFont( const LOGFONT& logfont, LONG nLogicalHeight = LONG_MAX ){
+	CGdiFont() = default;
+	CGdiFont( const CGdiFont& font ) : CGdiFont( font.m_hFont ){}
+	CGdiFont( CGdiFont&& font ) noexcept { *this = std::move( font ); }
+	CGdiFont( HFONT hFont, LONG nLogicalHeight = LONG_MAX ) : CGdiFont( GetLogFont( hFont ), nLogicalHeight ){}
+	CGdiFont( const LOGFONT& logfont, LONG nLogicalHeight = LONG_MAX ){
 		LOGFONT lf = logfont;
 		if( nLogicalHeight != LONG_MAX ){
 			lf.lfHeight = nLogicalHeight;
@@ -208,24 +208,24 @@ public:
 		m_nLogicalHeight = lf.lfHeight;
 		m_strFaceName.assign( lf.lfFaceName );
 	}
-	~CFont(){
+	~CGdiFont(){
 		if( m_hFont != NULL ){
 			::DeleteObject( m_hFont );
 		}
 	}
-	CFont& operator=(CFont& other) = delete;
-	CFont& operator=(CFont&& other) noexcept {
+	CGdiFont& operator=( const CGdiFont& other ) = delete;
+	CGdiFont& operator=( CGdiFont&& other ) noexcept {
 		std::swap( m_hFont, other.m_hFont );
 		std::swap( m_strFaceName, other.m_strFaceName );
 		std::swap( m_nLogicalHeight, other.m_nLogicalHeight );
 		return *this;
 	}
-	HFONT GetHandle(){ return m_hFont; }
-	LONG GetLogicalHeight(){ return m_nLogicalHeight; }
-	const TCHAR* GetFaceName(){ return m_strFaceName.c_str(); }
+	HFONT GetHandle() const { return m_hFont; }
+	LONG GetLogicalHeight() const { return m_nLogicalHeight; }
+	const TCHAR* GetFaceName() const { return m_strFaceName.c_str(); }
 
 private:
-	LOGFONT GetLogFont( HFONT hFont ){
+	static LOGFONT GetLogFont( HFONT hFont ){
 		LOGFONT lf = {};
 		GetObject( hFont, sizeof( lf ), &lf );
 		return lf;

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -192,6 +192,50 @@ private:
 	HFONT m_hFont;
 };
 
+class CFont
+{
+public:
+	CFont() = default;
+	CFont( const CFont& font ) : CFont( font.m_hFont ){}
+	CFont( CFont&& font ) noexcept { *this = std::move( font ); }
+	CFont( HFONT hFont, LONG nLogicalHeight = LONG_MAX ) : CFont( GetLogFont( hFont ), nLogicalHeight ){}
+	CFont( const LOGFONT& logfont, LONG nLogicalHeight = LONG_MAX ){
+		LOGFONT lf = logfont;
+		if( nLogicalHeight != LONG_MAX ){
+			lf.lfHeight = nLogicalHeight;
+		}
+		m_hFont = ::CreateFontIndirect( &lf );
+		m_nLogicalHeight = lf.lfHeight;
+		m_strFaceName.assign( lf.lfFaceName );
+	}
+	~CFont(){
+		if( m_hFont != NULL ){
+			::DeleteObject( m_hFont );
+		}
+	}
+	CFont& operator=(CFont& other) = delete;
+	CFont& operator=(CFont&& other) noexcept {
+		std::swap( m_hFont, other.m_hFont );
+		std::swap( m_strFaceName, other.m_strFaceName );
+		std::swap( m_nLogicalHeight, other.m_nLogicalHeight );
+		return *this;
+	}
+	HFONT GetHandle(){ return m_hFont; }
+	LONG GetLogicalHeight(){ return m_nLogicalHeight; }
+	const TCHAR* GetFaceName(){ return m_strFaceName.c_str(); }
+
+private:
+	LOGFONT GetLogFont( HFONT hFont ){
+		LOGFONT lf = {};
+		GetObject( hFont, sizeof( lf ), &lf );
+		return lf;
+	}
+
+	HFONT m_hFont = NULL;
+	LONG m_nLogicalHeight = 0;
+	std::wstring m_strFaceName;
+};
+
 HFONT UpdateDialogFont( HWND hwnd, BOOL force = FALSE );
 
 #endif /* SAKURA_WINDOW_A0833476_5E32_46BE_87B6_ECD55F10D34A_H_ */


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

#1326 - OSDNより転載：アウトライン解析のフォント

アウトライン解析のリストビュー / ツリービュー部分に「タイプ別設定」または「フォント設定」のフォントを使うようにします。
※現在は選択言語が日本語の時にはシステムフォント (Yu Gothic UI)、英語の時には Tahoma が使われます。

### 変更前1 (#1421 マージ前)

フォント設定：VL Gothic
![image](https://user-images.githubusercontent.com/11252784/97779983-1cc34a80-1bc5-11eb-932d-20edabf20d46.png)

### 変更前2 (#1421 マージ後)

フォント設定：VL Gothic
![image](https://user-images.githubusercontent.com/11252784/97779997-306eb100-1bc5-11eb-84a1-c3338d4ac362.png)

### 変更後

フォント設定：VL Gothic
![image](https://user-images.githubusercontent.com/11252784/97780040-7cb9f100-1bc5-11eb-9491-4fb8017b6e06.png)

フォント設定：HGP行書体
![image](https://user-images.githubusercontent.com/11252784/97779200-eb944b80-1bbf-11eb-84bb-51a3c955584a.png)

フォント設定：Segoe Script
![image](https://user-images.githubusercontent.com/11252784/97779211-f949d100-1bbf-11eb-836e-8c2b4917cbc1.png)

## <!-- 必須 --> カテゴリ

- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

## <!-- 自明なら省略可 --> PR のメリット

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

アウトライン解析のリストビュー / ツリービューに対してエディタ部分 (CEditWnd) と同じフォントを設定します。
ただしフォントのサイズは元々リストビュー / ツリービューに設定されていたフォントと同じサイズとします。

## <!-- 必須 --> テスト内容

## <!-- わかる範囲で --> PR の影響範囲

## <!-- なければ省略可 --> 関連 issue, PR

#1326 #1400

## <!-- なければ省略可 --> 参考資料
