### PR TITLE
[要望]ツールバー編集画面においてボタン挿入・追加時に機能リストのフォーカスを1つ下にずらしてほしい

### DIFF
--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -474,8 +474,6 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					}
 					List_SetCurSel( hwndLIST_RES, nIdx2 );
 
-					// 機能リストを1つ進める
-					List_SetCurSel( hwndLIST_FUNC, nIdx4 + 1 );
 					break;
 
 				case IDC_BUTTON_ADD:
@@ -528,8 +526,6 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					}
 					List_SetCurSel( hwndLIST_RES, nIdx2 );
 
-					// 機能リストを1つ進める
-					List_SetCurSel( hwndLIST_FUNC, nIdx4 + 1 );
 					break;
 
 				case IDC_BUTTON_UP:

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -474,6 +474,8 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					}
 					List_SetCurSel( hwndLIST_RES, nIdx2 );
 
+					// 機能リストを1つ進める
+					List_SetCurSel( hwndLIST_FUNC, nIdx4 + 1 );
 					break;
 
 				case IDC_BUTTON_ADD:
@@ -526,6 +528,8 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					}
 					List_SetCurSel( hwndLIST_RES, nIdx2 );
 
+					// 機能リストを1つ進める
+					List_SetCurSel( hwndLIST_FUNC, nIdx4 + 1 );
 					break;
 
 				case IDC_BUTTON_UP:

--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -366,10 +366,8 @@ INT_PTR CPropToolbar::DispatchEvent(
 					//	To Here Apr. 13, 2002 genta
 					List_SetCurSel( hwndResList, nIndex1 + 1 );
 
-					// 機能リストのフォーカスを一つ下にずらす
-					if( nIndex2 + 1 < List_GetCount(hwndFuncList) ) {
-						List_SetCurSel( hwndFuncList, nIndex2 + 1 );
-					}
+					// 機能リストを1つ進める
+					List_SetCurSel( hwndFuncList, nIndex2 + 1 );
 					break;
 
 				case IDC_BUTTON_ADD:
@@ -389,10 +387,8 @@ INT_PTR CPropToolbar::DispatchEvent(
 					//	To Here Apr. 13, 2002 genta
 					List_SetCurSel( hwndResList, nIndex1 );
 
-					// 機能リストのフォーカスを一つ下にずらす
-					if( nIndex2 + 1 < List_GetCount(hwndFuncList) ) {
-						List_SetCurSel( hwndFuncList, nIndex2 + 1 );
-					}
+					// 機能リストを1つ進める
+					List_SetCurSel( hwndFuncList, nIndex2 + 1 );
 					break;
 
 				case IDC_BUTTON_UP:

--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -365,6 +365,12 @@ INT_PTR CPropToolbar::DispatchEvent(
 					}
 					//	To Here Apr. 13, 2002 genta
 					List_SetCurSel( hwndResList, nIndex1 + 1 );
+
+					// 機能リストのフォーカスを一つ下にずらす
+					nNum = List_GetCount( hwndFuncList );
+					if( nIndex2 + 1 < nNum ) {
+						List_SetCurSel( hwndFuncList, nIndex2 + 1 );
+					}
 					break;
 
 				case IDC_BUTTON_ADD:
@@ -383,6 +389,12 @@ INT_PTR CPropToolbar::DispatchEvent(
 					}
 					//	To Here Apr. 13, 2002 genta
 					List_SetCurSel( hwndResList, nIndex1 );
+
+					// 機能リストのフォーカスを一つ下にずらす
+					nNum = List_GetCount( hwndFuncList );
+					if( nIndex2 + 1 < nNum ) {
+						List_SetCurSel( hwndFuncList, nIndex2 + 1 );
+					}
 					break;
 
 				case IDC_BUTTON_UP:

--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -367,8 +367,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 					List_SetCurSel( hwndResList, nIndex1 + 1 );
 
 					// 機能リストのフォーカスを一つ下にずらす
-					nNum = List_GetCount( hwndFuncList );
-					if( nIndex2 + 1 < nNum ) {
+					if( nIndex2 + 1 < List_GetCount(hwndFuncList) ) {
 						List_SetCurSel( hwndFuncList, nIndex2 + 1 );
 					}
 					break;
@@ -391,8 +390,7 @@ INT_PTR CPropToolbar::DispatchEvent(
 					List_SetCurSel( hwndResList, nIndex1 );
 
 					// 機能リストのフォーカスを一つ下にずらす
-					nNum = List_GetCount( hwndFuncList );
-					if( nIndex2 + 1 < nNum ) {
+					if( nIndex2 + 1 < List_GetCount(hwndFuncList) ) {
 						List_SetCurSel( hwndFuncList, nIndex2 + 1 );
 					}
 					break;


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

機能改善の提案と要望ですが、コードが用意できる軽微な変更であるためいきなりPRとしています。
ツールバーボタンの編集画面において、「→」ボタン・「>>」ボタンの押下時に機能リストのフォーカスを一つ下にずらす動作を追加するものです。
細かい部分の提案で恐縮ですが、開発メンバーの皆様のご検討をいただければありがたく思います。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

共通設定ダイアログ内のツールバータブにあるツールバーボタン編集画面において、ボタン挿入・追加操作時に左に位置する機能リストのアイテムのフォーカスが一つ下のものに移動するようになると少しうれしいです。
現状の「→」・「>>」ボタンはフォーカスの移動を行いませんが、この動作では複数のボタンを追加するとき、挿入・追加ボタンとリストとの間でマウスポインタの往復を強いられます。（同じ機能のボタンを連続して配置する場合を除きます）
機能リストでは関連する機能がおおむね隣接しており、普通は隣接する機能をまとめて配置したいものと思いますので、フォーカスが自動で下に移動してくれると編集が楽になります。

## <!-- 自明なら省略可 --> PR のメリット

- 機能リスト中で隣接する機能を追加・挿入する操作においてクリック数が半分に減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

- 同じ機能を追加・挿入する操作では逆に選択しなおす手間が増えます。とはいえツールバーに同じ機能のボタンを連続して配置する操作というのが一般的に行われるかどうかは疑問です。
- ボタンのラベル等から自明とは言えないため、ユーザーにとって予期しない挙動となる可能性があります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

- [変更前] 「→」（INSERTボタン）および「>>」（ADDボタン）は、機能リストで選択されている機能をツールバーリストに配置する。
- [変更後] 「→」（INSERTボタン）および「>>」（ADDボタン）は、機能リストで選択されている機能をツールバーリストに配置*し、機能リストのフォーカスを一つ下に移動する。既に最下部であれば移動しない。*

## <!-- 必須 --> テスト内容

ダイアログのUIの挙動変更ですので手動でテストするほかにないと思われます。

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順

- 「→」・「>>」ボタン押下時に機能リストのフォーカスが下に移動することを確認する。
- 最下部の場合は移動しないこと、また異常な挙動を行わないことを確認する。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- なければ省略可 --> 参考資料

変更後の挙動
![toolbar-pane-resized](https://user-images.githubusercontent.com/36005663/98371758-095e2680-2080-11eb-8821-4b21fb350789.gif)

