### PR TITLE
（#1457 補遺）カスタムメニュー画面でも追加・挿入後に機能リストを送る処理を入れたい

### DIFF
--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -474,6 +474,8 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					}
 					List_SetCurSel( hwndLIST_RES, nIdx2 );
 
+					// 機能リストを1つ進める
+					List_SetCurSel( hwndLIST_FUNC, nIdx4 + 1 );
 					break;
 
 				case IDC_BUTTON_ADD:
@@ -526,6 +528,8 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					}
 					List_SetCurSel( hwndLIST_RES, nIdx2 );
 
+					// 機能リストを1つ進める
+					List_SetCurSel( hwndLIST_FUNC, nIdx4 + 1 );
 					break;
 
 				case IDC_BUTTON_UP:


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

共通設定画面には似たUIを持つ3つのページ（メインメニュー・カスタムメニュー・ツールバー）がありますが、追加・挿入ボタン押下後の動きがメインメニュー画面とその他2つで異なっています。
メインメニュー画面では一つ下の機能が自動的に選択されますが、他2つのページでは選択されません。
UIの挙動が一貫していませんので、メインメニュー画面の動きに合わせる方向でぜひ変更を加えたいと思っています。
ツールバー画面については #1457 で対処予定で、本PRはカスタムメニュー画面分の変更を含みます。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

- 仕様変更
- 不具合修正（？）

同種のUIの挙動が一貫しないのは不具合であるような気がしますが、否定的な意見もあると思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

#1457 を参照ください。
<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR
#1457