### PR TITLE
Combo_GetEditSel 関数の変更

### DIFF
--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -214,15 +214,9 @@ namespace ApiWrap{
 		assert(str.GetStringLength() == actualCount);
 		return true;
 	}
-	inline void Combo_GetEditSel( HWND hwndCombo, int &nSelStart, int &nSelEnd )
+	inline void Combo_GetEditSel( HWND hwndCombo, DWORD* pdwSelStart, DWORD* pdwSelEnd )
 	{
-		DWORD dwSelStart = 0;
-		DWORD dwSelEnd = 0;
-		::SendMessage( hwndCombo, CB_GETEDITSEL, WPARAM( &dwSelStart ), LPARAM( &dwSelEnd ) );
-		assert_warning( 0x7FFFFFFF < dwSelStart );
-		assert_warning( 0x7FFFFFFF < dwSelEnd );
-		nSelStart = static_cast<int>(dwSelStart);
-		nSelEnd = static_cast<int>(dwSelEnd);
+		::SendMessage( hwndCombo, CB_GETEDITSEL, WPARAM( pdwSelStart ), LPARAM( pdwSelEnd ) );
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -214,9 +214,9 @@ namespace ApiWrap{
 		assert(str.GetStringLength() == actualCount);
 		return true;
 	}
-	inline void Combo_GetEditSel( HWND hwndCombo, DWORD* pdwSelStart, DWORD* pdwSelEnd )
+	inline void Combo_GetEditSel( HWND hwndCombo, DWORD& dwSelStart, DWORD& dwSelEnd )
 	{
-		::SendMessage( hwndCombo, CB_GETEDITSEL, WPARAM( pdwSelStart ), LPARAM( pdwSelEnd ) );
+		::SendMessage( hwndCombo, CB_GETEDITSEL, WPARAM( &dwSelStart ), LPARAM( &dwSelEnd ) );
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -724,7 +724,7 @@ static void DeleteRecentItem(
 		// コンボボックスのキャレット位置を取得
 		DWORD dwSelStart = 0;
 		DWORD dwSelEnd = 0;
-		Combo_GetEditSel( hwndCombo, &dwSelStart, &dwSelEnd );
+		Combo_GetEditSel( hwndCombo, dwSelStart, dwSelEnd );
 
 		// アイテムテキストとエディットテキストが異なる、またはエディットが全選択でなかった場合
 		if ( cItemText != cEditText

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -722,14 +722,14 @@ static void DeleteRecentItem(
 		Wnd_GetText( hwndCombo, cEditText );
 
 		// コンボボックスのキャレット位置を取得
-		int nSelStart = 0;
-		int nSelEnd = 0;
-		Combo_GetEditSel( hwndCombo, nSelStart, nSelEnd );
+		DWORD dwSelStart = 0;
+		DWORD dwSelEnd = 0;
+		Combo_GetEditSel( hwndCombo, &dwSelStart, &dwSelEnd );
 
 		// アイテムテキストとエディットテキストが異なる、またはエディットが全選択でなかった場合
 		if ( cItemText != cEditText
-			|| 0 < nSelStart
-			|| nSelEnd < cEditText.GetStringLength()
+			|| 0 < dwSelStart
+			|| dwSelEnd < (DWORD)cEditText.GetStringLength()
 			)
 		{
 			// 履歴削除をスキップする


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

#1460 で報告があった `ApiWrap::Combo_GetEditSel` で assert_warning の記載に誤りがある問題を解消します。

引数の型を int& から ~~DWORD*~~ DWORD& に変更をしました。そうする事でそもそも assert_warning を行う必要も無くなるので削りました。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

`Combo_GetEditSel` 関数は PR #1255 で追加されました。その時にDebugビルドでの動作確認を行っていなかったのか、問題を見過ごしてしまいました。

<!-- PR を行う背景を記載してください -->

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

デバッグ時に assert_warning で引っかかるべきではないのに引っかかってしまう問題が解消されます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

Debugビルドで、コンボボックスのリストアイテムを関連付けられた履歴と共に削除する処理 `DeleteRecentItem` 関数が呼ばれるように操作して、`Combo_GetEditSel` 関数が呼び出されて assert が起きない事や、コンボボックスの履歴削除が問題なく動作する事を確認しました。

### テスト1

手順


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1460

#1255

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

![image](https://user-images.githubusercontent.com/1131125/98563899-0fa60a00-22ef-11eb-9b0d-40e24cac0f7d.png)
