### PR TITLE
コンボボックスのサブクラス化処理を簡素化する

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -699,8 +699,6 @@ void CDialog::GetItemClientRect( int wID, RECT& rc )
 	rc.bottom = po.y;
 }
 
-static const WCHAR* TSTR_SUBCOMBOBOXDATA = L"SubComboBoxData";
-
 /*! コンボボックスのリストアイテムを関連付けられた履歴と共に削除する
  */
 static void DeleteRecentItem(
@@ -750,7 +748,7 @@ static void DeleteRecentItem(
 LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 	                         UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
-	HWND hwndCombo = (HWND)dwRefData;
+	HWND hwndCombo = GetParent(hwnd);
 	switch( uMsg ){
 	case WM_KEYDOWN:
 	{
@@ -758,27 +756,7 @@ LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 			BOOL bShow = Combo_GetDroppedState(hwndCombo);
 			int nIndex = Combo_GetCurSel(hwndCombo);
 			if( bShow && 0 <= nIndex ){
-				DeleteRecentItem(hwndCombo, nIndex, (CRecent*)::GetProp(hwndCombo, TSTR_SUBCOMBOBOXDATA));
-			}
-		}
-		break;
-	}
-	}
-	return ::DefSubclassProc(hwnd, uMsg, wParam, lParam);
-}
-
-LRESULT CALLBACK SubListBoxProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
-	                            UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
-{
-	HWND hwndCombo = (HWND)dwRefData;
-	switch( uMsg ){
-	case WM_KEYDOWN:
-	{
-		if( wParam == VK_DELETE ){
-			int nIndex = Combo_GetCurSel(hwndCombo);
-			if( 0 <= nIndex ){
-				DeleteRecentItem(hwndCombo, nIndex, (CRecent*)::GetProp(hwndCombo, TSTR_SUBCOMBOBOXDATA));
-				return 0;
+				DeleteRecentItem(hwndCombo, nIndex, (CRecent*)dwRefData);
 			}
 		}
 		break;
@@ -794,7 +772,5 @@ void CDialog::SetComboBoxDeleter(HWND hwndCtl, CRecent* pRecent)
 	COMBOBOXINFO info = { sizeof(COMBOBOXINFO) };
 	if (!::GetComboBoxInfo(hwndCtl, &info))
 		return;
-	::SetProp(hwndCtl, TSTR_SUBCOMBOBOXDATA, pRecent);
-	::SetWindowSubclass(info.hwndItem, SubEditProc, 0, (DWORD_PTR)hwndCtl);
-	::SetWindowSubclass(info.hwndList, SubListBoxProc, 0, (DWORD_PTR)hwndCtl);
+	::SetWindowSubclass(info.hwndItem, SubEditProc, 0, (DWORD_PTR)pRecent);
 }

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -750,16 +750,15 @@ static void DeleteRecentItem(
 LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 	                         UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
-	SComboBoxItemDeleter* data = reinterpret_cast<SComboBoxItemDeleter*>(dwRefData);
+	HWND hwndCombo = reinterpret_cast<HWND>(dwRefData);
 	switch( uMsg ){
 	case WM_KEYDOWN:
 	{
 		if( wParam == VK_DELETE ){
-			HWND hwndCombo = data->hwndCombo;
 			BOOL bShow = Combo_GetDroppedState(hwndCombo);
 			int nIndex = Combo_GetCurSel(hwndCombo);
 			if( bShow && 0 <= nIndex ){
-				DeleteRecentItem(hwndCombo, nIndex, data->pRecent);
+				DeleteRecentItem(hwndCombo, nIndex, reinterpret_cast<CRecent*>(::GetProp(hwndCombo, TSTR_SUBCOMBOBOXDATA)));
 			}
 		}
 		break;
@@ -771,15 +770,14 @@ LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 LRESULT CALLBACK SubListBoxProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 	                            UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
-	SComboBoxItemDeleter* data = reinterpret_cast<SComboBoxItemDeleter*>(dwRefData);
+	HWND hwndCombo = reinterpret_cast<HWND>(dwRefData);
 	switch( uMsg ){
 	case WM_KEYDOWN:
 	{
 		if( wParam == VK_DELETE ){
-			HWND hwndCombo = data->hwndCombo;
 			int nIndex = Combo_GetCurSel(hwndCombo);
 			if( 0 <= nIndex ){
-				DeleteRecentItem(hwndCombo, nIndex, data->pRecent);
+				DeleteRecentItem(hwndCombo, nIndex, reinterpret_cast<CRecent*>(::GetProp(hwndCombo, TSTR_SUBCOMBOBOXDATA)));
 				return 0;
 			}
 		}
@@ -789,16 +787,14 @@ LRESULT CALLBACK SubListBoxProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 	return ::DefSubclassProc(hwnd, uMsg, wParam, lParam);
 }
 
-void CDialog::SetComboBoxDeleter( HWND hwndCtl, SComboBoxItemDeleter* data )
+void CDialog::SetComboBoxDeleter(HWND hwndCtl, CRecent* pRecent)
 {
-	if( NULL == data->pRecent ){
-		return;
-	}
-	data->hwndCombo = hwndCtl;
+	assert(pRecent);
 
 	COMBOBOXINFO info = { sizeof(COMBOBOXINFO) };
 	if (!::GetComboBoxInfo(hwndCtl, &info))
 		return;
-	::SetWindowSubclass(info.hwndItem, SubEditProc, 0, reinterpret_cast<DWORD_PTR>(data));
-	::SetWindowSubclass(info.hwndList, SubListBoxProc, 0, reinterpret_cast<DWORD_PTR>(data));
+	::SetProp(hwndCtl, TSTR_SUBCOMBOBOXDATA, pRecent);
+	::SetWindowSubclass(info.hwndItem, SubEditProc, 0, reinterpret_cast<DWORD_PTR>(hwndCtl));
+	::SetWindowSubclass(info.hwndList, SubListBoxProc, 0, reinterpret_cast<DWORD_PTR>(hwndCtl));
 }

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -750,7 +750,7 @@ static void DeleteRecentItem(
 LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 	                         UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
-	HWND hwndCombo = reinterpret_cast<HWND>(dwRefData);
+	HWND hwndCombo = (HWND)dwRefData;
 	switch( uMsg ){
 	case WM_KEYDOWN:
 	{
@@ -758,7 +758,7 @@ LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 			BOOL bShow = Combo_GetDroppedState(hwndCombo);
 			int nIndex = Combo_GetCurSel(hwndCombo);
 			if( bShow && 0 <= nIndex ){
-				DeleteRecentItem(hwndCombo, nIndex, reinterpret_cast<CRecent*>(::GetProp(hwndCombo, TSTR_SUBCOMBOBOXDATA)));
+				DeleteRecentItem(hwndCombo, nIndex, (CRecent*)::GetProp(hwndCombo, TSTR_SUBCOMBOBOXDATA));
 			}
 		}
 		break;
@@ -770,14 +770,14 @@ LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 LRESULT CALLBACK SubListBoxProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 	                            UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
-	HWND hwndCombo = reinterpret_cast<HWND>(dwRefData);
+	HWND hwndCombo = (HWND)dwRefData;
 	switch( uMsg ){
 	case WM_KEYDOWN:
 	{
 		if( wParam == VK_DELETE ){
 			int nIndex = Combo_GetCurSel(hwndCombo);
 			if( 0 <= nIndex ){
-				DeleteRecentItem(hwndCombo, nIndex, reinterpret_cast<CRecent*>(::GetProp(hwndCombo, TSTR_SUBCOMBOBOXDATA)));
+				DeleteRecentItem(hwndCombo, nIndex, (CRecent*)::GetProp(hwndCombo, TSTR_SUBCOMBOBOXDATA));
 				return 0;
 			}
 		}
@@ -795,6 +795,6 @@ void CDialog::SetComboBoxDeleter(HWND hwndCtl, CRecent* pRecent)
 	if (!::GetComboBoxInfo(hwndCtl, &info))
 		return;
 	::SetProp(hwndCtl, TSTR_SUBCOMBOBOXDATA, pRecent);
-	::SetWindowSubclass(info.hwndItem, SubEditProc, 0, reinterpret_cast<DWORD_PTR>(hwndCtl));
-	::SetWindowSubclass(info.hwndList, SubListBoxProc, 0, reinterpret_cast<DWORD_PTR>(hwndCtl));
+	::SetWindowSubclass(info.hwndItem, SubEditProc, 0, (DWORD_PTR)hwndCtl);
+	::SetWindowSubclass(info.hwndList, SubListBoxProc, 0, (DWORD_PTR)hwndCtl);
 }

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -55,9 +55,7 @@ struct SComboBoxItemDeleter
 {
 	CRecent*	pRecent;
 	HWND		hwndCombo;
-	WNDPROC		pEditWndProc;
-	WNDPROC		pListBoxWndProc;
-	SComboBoxItemDeleter(): pRecent(NULL), hwndCombo(NULL), pEditWndProc(NULL), pListBoxWndProc(NULL){}
+	SComboBoxItemDeleter() : pRecent(NULL), hwndCombo(NULL) {}
 };
 
 /*-----------------------------------------------------------------------

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -51,13 +51,6 @@ struct SAnchorList
 	EAnchorStyle anchor;
 };
 
-struct SComboBoxItemDeleter
-{
-	CRecent*	pRecent;
-	HWND		hwndCombo;
-	SComboBoxItemDeleter() : pRecent(NULL), hwndCombo(NULL) {}
-};
-
 /*-----------------------------------------------------------------------
 クラスの宣言
 -----------------------------------------------------------------------*/
@@ -122,7 +115,7 @@ public:
 
 	void ResizeItem( HWND hTarget, const POINT& ptDlgDefalut, const POINT& ptDlgNew, const RECT& rcItemDefault, EAnchorStyle anchor, bool bUpdate = true);
 	void GetItemClientRect( int wID, RECT& rc );
-	static void SetComboBoxDeleter( HWND hwndCtl, SComboBoxItemDeleter* data );
+	static void SetComboBoxDeleter( HWND hwndCtl, CRecent* pRecent );
 public:
 
 	static bool DirectoryUp(WCHAR* szDir);

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -55,10 +55,9 @@ struct SComboBoxItemDeleter
 {
 	CRecent*	pRecent;
 	HWND		hwndCombo;
-	WNDPROC		pComboBoxWndProc;
 	WNDPROC		pEditWndProc;
 	WNDPROC		pListBoxWndProc;
-	SComboBoxItemDeleter(): pRecent(NULL), hwndCombo(NULL), pComboBoxWndProc(NULL), pEditWndProc(NULL), pListBoxWndProc(NULL){}
+	SComboBoxItemDeleter(): pRecent(NULL), hwndCombo(NULL), pEditWndProc(NULL), pListBoxWndProc(NULL){}
 };
 
 /*-----------------------------------------------------------------------

--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -81,13 +81,8 @@ BOOL CDlgExec::OnInitDialog( HWND hwnd, WPARAM wParam, LPARAM lParam )
 	}
 
 	BOOL bRet = CDialog::OnInitDialog(hwnd, wParam, lParam);
-
-	m_comboDel = SComboBoxItemDeleter();
-	m_comboDel.pRecent = &m_cRecentCmd;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_m_szCommand), &m_comboDel);
-	m_comboDelCur = SComboBoxItemDeleter();
-	m_comboDelCur.pRecent = &m_cRecentCur;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_CUR_DIR), &m_comboDelCur);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_m_szCommand), &m_cRecentCmd);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_CUR_DIR), &m_cRecentCur);
 	return bRet;
 }
 

--- a/sakura_core/dlg/CDlgExec.h
+++ b/sakura_core/dlg/CDlgExec.h
@@ -38,9 +38,7 @@ public:
 	bool	m_bEditable;			/* 編集ウィンドウへの入力可能 */	// 2009.02.21 ryoji
 
 protected:
-	SComboBoxItemDeleter m_comboDel;
 	CRecentCmd m_cRecentCmd;
-	SComboBoxItemDeleter m_comboDelCur;
 	CRecentCurDir m_cRecentCur;
 
 	int GetData( void ) override;	/* ダイアログデータの取得 */

--- a/sakura_core/dlg/CDlgFind.cpp
+++ b/sakura_core/dlg/CDlgFind.cpp
@@ -90,9 +90,7 @@ void CDlgFind::ChangeView( LPARAM pcEditView )
 BOOL CDlgFind::OnInitDialog( HWND hwnd, WPARAM wParam, LPARAM lParam )
 {
 	BOOL bRet = CDialog::OnInitDialog(hwnd, wParam, lParam);
-	m_comboDel = SComboBoxItemDeleter();
-	m_comboDel.pRecent = &m_cRecentSearch;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT), &m_comboDel);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT), &m_cRecentSearch);
 
 	// フォント設定	2012/11/27 Uchi
 	HFONT hFontOld = (HFONT)::SendMessageAny( GetItemHwnd( IDC_COMBO_TEXT ), WM_GETFONT, 0, 0 );

--- a/sakura_core/dlg/CDlgFind.h
+++ b/sakura_core/dlg/CDlgFind.h
@@ -45,7 +45,6 @@ public:
 	CLogicPoint	m_ptEscCaretPos_PHY;	// 検索開始時のカーソル位置退避エリア
 
 	CRecentSearch			m_cRecentSearch;
-	SComboBoxItemDeleter	m_comboDel;
 	CFontAutoDeleter		m_cFontText;
 
 protected:

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -331,23 +331,12 @@ BOOL CDlgGrep::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	g_pOnFolderProc = (WNDPROC)GetWindowLongPtr(hFolder, GWLP_WNDPROC);
 	SetWindowLongPtr(hFolder, GWLP_WNDPROC, (LONG_PTR)OnFolderProc);
 
-	m_comboDelText = SComboBoxItemDeleter();
-	m_comboDelText.pRecent = &m_cRecentSearch;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT), &m_comboDelText);
-	m_comboDelFile = SComboBoxItemDeleter();
-	m_comboDelFile.pRecent = &m_cRecentGrepFile;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_FILE), &m_comboDelFile);
-	m_comboDelFolder = SComboBoxItemDeleter();
-	m_comboDelFolder.pRecent = &m_cRecentGrepFolder;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_FOLDER), &m_comboDelFolder);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT), &m_cRecentSearch);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_FILE), &m_cRecentGrepFile);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_FOLDER), &m_cRecentGrepFolder);
 
-	m_comboDelExcludeFile = SComboBoxItemDeleter();
-	m_comboDelExcludeFile.pRecent = &m_cRecentExcludeFile;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_EXCLUDE_FILE), &m_comboDelExcludeFile);
-
-	m_comboDelExcludeFolder = SComboBoxItemDeleter();
-	m_comboDelExcludeFolder.pRecent = &m_cRecentExcludeFolder;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_EXCLUDE_FOLDER), &m_comboDelExcludeFolder);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_EXCLUDE_FILE), &m_cRecentExcludeFile);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_EXCLUDE_FOLDER), &m_cRecentExcludeFolder);
 
 	BOOL bRet = CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 	if( !bRet ) return bRet;

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -61,19 +61,10 @@ public:
 	SFilePathLong	m_szExcludeFolder;		//!< 除外フォルダ
 	SFilePath	m_szCurrentFilePath;
 protected:
-	SComboBoxItemDeleter	m_comboDelText;
 	CRecentSearch			m_cRecentSearch;
-
-	SComboBoxItemDeleter	m_comboDelFile;
 	CRecentGrepFile			m_cRecentGrepFile;
-
-	SComboBoxItemDeleter	m_comboDelFolder;
 	CRecentGrepFolder		m_cRecentGrepFolder;
-
-	SComboBoxItemDeleter	m_comboDelExcludeFile;
 	CRecentExcludeFile		m_cRecentExcludeFile;
-
-	SComboBoxItemDeleter	m_comboDelExcludeFolder;
 	CRecentExcludeFolder	m_cRecentExcludeFolder;
 
 	std::vector<CFontAutoDeleter>	m_cFontDeleters;

--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -129,9 +129,7 @@ BOOL CDlgGrepReplace::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	/* コンボボックスのユーザー インターフェイスを拡張インターフェースにする */
 	Combo_SetExtendedUI( GetItemHwnd( IDC_COMBO_TEXT2 ), TRUE );
 
-	m_comboDelText2 = SComboBoxItemDeleter();
-	m_comboDelText2.pRecent = &m_cRecentReplace;
-	SetComboBoxDeleter( GetItemHwnd( IDC_COMBO_TEXT2 ), &m_comboDelText2 );
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT2), &m_cRecentReplace);
 
 	BOOL bRet = CDlgGrep::OnInitDialog( hwndDlg, wParam, lParam );
 	if( !bRet ) return bRet;

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -42,7 +42,6 @@ public:
 
 protected:
 	CRecentReplace			m_cRecentReplace;
-	SComboBoxItemDeleter	m_comboDelText2;
 	CFontAutoDeleter		m_cFontText2;
 
 	/*

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -118,9 +118,7 @@ public:
 
 	bool			m_bInitCodePage;
 
-	SComboBoxItemDeleter	m_combDelFile;
 	CRecentFile				m_cRecentFile;
-	SComboBoxItemDeleter	m_combDelFolder;
 	CRecentFolder			m_cRecentFolder;
 
 	OPENFILENAME*	m_pOf;
@@ -373,12 +371,8 @@ UINT_PTR CALLBACK OFNHookProc(
 			/* ビューモードの初期値セット */
 			::CheckDlgButton( pData->m_hwndOpenDlg, chx1, pData->m_bViewMode );
 
-			pData->m_combDelFile = SComboBoxItemDeleter();
-			pData->m_combDelFile.pRecent = &pData->m_cRecentFile;
-			CDialog::SetComboBoxDeleter(pData->m_hwndComboMRU, &pData->m_combDelFile);
-			pData->m_combDelFolder = SComboBoxItemDeleter();
-			pData->m_combDelFolder.pRecent = &pData->m_cRecentFolder;
-			CDialog::SetComboBoxDeleter(pData->m_hwndComboOPENFOLDER, &pData->m_combDelFolder);
+			CDialog::SetComboBoxDeleter(pData->m_hwndComboMRU, &pData->m_cRecentFile);
+			CDialog::SetComboBoxDeleter(pData->m_hwndComboOPENFOLDER, &pData->m_cRecentFolder);
 		}
 		break;
 

--- a/sakura_core/dlg/CDlgReplace.cpp
+++ b/sakura_core/dlg/CDlgReplace.cpp
@@ -343,12 +343,8 @@ BOOL CDlgReplace::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_ALLAREA, TRUE );
 	}
 
-	m_comboDelText = SComboBoxItemDeleter();
-	m_comboDelText.pRecent = &m_cRecentSearch;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT), &m_comboDelText);
-	m_comboDelText2 = SComboBoxItemDeleter();
-	m_comboDelText2.pRecent = &m_cRecentReplace;
-	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT2), &m_comboDelText2);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT), &m_cRecentSearch);
+	SetComboBoxDeleter(GetItemHwnd(IDC_COMBO_TEXT2), &m_cRecentReplace);
 
 	BOOL bRet = CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 	if( !bRet ) return bRet;

--- a/sakura_core/dlg/CDlgReplace.h
+++ b/sakura_core/dlg/CDlgReplace.h
@@ -59,9 +59,7 @@ public:
 
 protected:
 	CRecentSearch			m_cRecentSearch;
-	SComboBoxItemDeleter	m_comboDelText;
 	CRecentReplace			m_cRecentReplace;
-	SComboBoxItemDeleter	m_comboDelText2;
 	CFontAutoDeleter		m_cFontText;
 	CFontAutoDeleter		m_cFontText2;
 

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -522,9 +522,7 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		bRet = FALSE;	//for set focus
 	}
 
-	m_comboDel = SComboBoxItemDeleter();
-	m_comboDel.pRecent = &m_cRecentKeyword;
-	SetComboBoxDeleter(hwndKey, &m_comboDel);
+	SetComboBoxDeleter(hwndKey, &m_cRecentKeyword);
 
 	/* 基底クラスメンバ */
 	CDialog::OnInitDialog( GetHwnd(), wParam, lParam );

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -165,7 +165,6 @@ private:
 	BOOL	m_bOldTagJumpICase;	//!< 前回の大文字小文字を同一視
 	BOOL	m_bOldTagJumpPartialMatch;	//!< 前回の文字列の途中にマッチ
 
-	SComboBoxItemDeleter	m_comboDel;
 	CRecentTagjumpKeyword	m_cRecentKeyword;
 
 	POINT	m_ptDefaultSize;

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -327,9 +327,7 @@ void CMainToolBar::CreateToolBar( void )
 							//検索ボックスを更新	// 関数化 2010/6/6 Uchi
 							AcceptSharedSearchKey();
 
-							m_comboDel = SComboBoxItemDeleter(); // 再表示用の初期化
-							m_comboDel.pRecent = &m_cRecentSearch;
-							CDialog::SetComboBoxDeleter(m_hwndSearchBox, &m_comboDel);
+							CDialog::SetComboBoxDeleter(m_hwndSearchBox, &m_cRecentSearch);
 
 							// コンボボックスの位置と幅を調整する
 							CMyRect rcCombo;

--- a/sakura_core/window/CMainToolBar.h
+++ b/sakura_core/window/CMainToolBar.h
@@ -76,7 +76,6 @@ private:
 	//フォント
 	HFONT		m_hFontSearchBox;	//!< 検索コンボボックスのフォント
 
-	SComboBoxItemDeleter	m_comboDel;
 	CRecentSearch			m_cRecentSearch;
 	CImageListMgr*			m_pcIcons;
 };


### PR DESCRIPTION
# PR の目的

#1311 で要望されている機能の実現に向けた関連コードの整理です。
Windows Vista までに導入された API を活用します。

## カテゴリ

- リファクタリング

## PR の背景

検索ダイアログ等のコンボボックスに単語削除機能の追加を試みる途中、既存のコンボボックスのサブクラス化処理が幾分古く冗長であることが気になりました。
単語削除を追加すると関連コードがより複雑になるため、先に整理しておくことで以後のレビュー負担が軽減できるかと思います。

## PR のメリット

- コンボボックスのサブクラス化に関わるコードの複雑度が減ります。
- `SetComboBoxDeleter` の呼び出し時に構造体を用意する必要がなくなります。

## PR のデメリット (トレードオフとかあれば)

ないはずです。

## 仕様・動作説明

- `GetComboBoxInfo` を使う
既存コードでは Edit と ListBox のハンドルを取得するために `WM_CTLCOLOR*` を目的外利用していましたが 、同じ情報がこの関数で取得できるためハックを除去します。

- `SetWindowSubclass` を使う
元の `WNDPROC` を保存・リストアするコードが除去できます。

- `SComboBoxItemDeleter` 構造体の廃止
構造体のメンバが `HWND` と `CRecent*` のみになったため、プロシージャの引数（`HWND`）とウィンドウプロパティ（`CRecent*`）で代替してしまいます。

## テスト内容

検索ダイアログ等のコンボボックスの既存動作が変更されないことを手動で確認します。
サブクラス化で実現している履歴の削除動作に対して特に確認が必要です。

## PR の影響範囲

`SetComboBoxDeleter` を使用する各ダイアログに影響しますが、動作は変更しません。

## 関連 issue, PR

#1311

## 参考資料

[後ほど PR 予定の完成形](https://github.com/kasumikagari/sakura/tree/ctrl-backspace)