### PR TITLE
桁数の換算処理を追加して禁則処理を再び使えるようにする

### DIFF
--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -118,12 +118,16 @@ void CLayoutMgr::_DoWordWrap(SLayoutWork* pWork, PF_OnLine pfOnLine)
 
 void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 {
-	if( (GetMaxLineLayout() - pWork->nPosX < 2) && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
+	// 基準となる半角の最大文字幅を確認
+	const CPixelXInt nBaseWidth = t_max( GetWidthPerKeta(), WCODE::CalcPxWidthByFont( L'W' ) );
+
+	if( ( GetMaxLineLayout() - pWork->nPosX < 2 * nBaseWidth ) && ( pWork->eKinsokuType == KINSOKU_TYPE_NONE ) )
 	{
 		// 2007.09.07 kobake   レイアウトとロジックの区別
-		CLayoutInt nCharKetas = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
+		CLayoutInt nRemainChars = ( GetMaxLineLayout() - pWork->nPosX ) / nBaseWidth;
+		CLayoutInt nCharKetas = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos ) / nBaseWidth;
 
-		if( IsKinsokuPosKuto(GetMaxLineLayout() - pWork->nPosX, nCharKetas) && IsKinsokuKuto( pWork->cLineStr.At(pWork->nPos) ) )
+		if( IsKinsokuPosKuto( nRemainChars, nCharKetas ) && IsKinsokuKuto( pWork->cLineStr.At( pWork->nPos ) ) )
 		{
 			pWork->nWordBgn = pWork->nPos;
 			pWork->nWordLen = 1;
@@ -134,16 +138,20 @@ void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 
 void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
+	// 基準となる半角の最大文字幅を確認
+	const CPixelXInt nBaseWidth = t_max( GetWidthPerKeta(), WCODE::CalcPxWidthByFont( L'W' ) );
+
 	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji 追加
-	 && (GetMaxLineLayout() - pWork->nPosX < 4)
+	 && ( GetMaxLineLayout() - pWork->nPosX < 4 * nBaseWidth )
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
 		// 2007.09.07 kobake   レイアウトとロジックの区別
-		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
-		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
+		CLayoutInt nRemainChars = ( GetMaxLineLayout() - pWork->nPosX ) / nBaseWidth;
+		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos ) / nBaseWidth;
+		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos + 1 ) / nBaseWidth;
 
-		if( IsKinsokuPosHead( GetMaxLineLayout() - pWork->nPosX, nCharKetas2, nCharKetas3 )
+		if( IsKinsokuPosHead( nRemainChars, nCharKetas2, nCharKetas3 )
 		 && IsKinsokuHead( pWork->cLineStr.At(pWork->nPos+1) )
 		 && ! IsKinsokuHead( pWork->cLineStr.At(pWork->nPos) )	//1文字前が行頭禁則でない
 		 && ! IsKinsokuKuto( pWork->cLineStr.At(pWork->nPos) ) )	//句読点でない
@@ -159,15 +167,19 @@ void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 
 void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
+	// 基準となる半角の最大文字幅を確認
+	const CPixelXInt nBaseWidth = t_max( GetWidthPerKeta(), WCODE::CalcPxWidthByFont( L'W' ) );
+
 	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji 追加
-	 && (GetMaxLineKetas() - pWork->nPosX < 4)
+	 && ( GetMaxLineLayout() - pWork->nPosX < 4 * nBaseWidth )
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{	/* 行末禁則する && 行末付近 && 行頭でないこと(無限に禁則してしまいそう) */
-		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
-		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
+		CLayoutInt nRemainChars = ( GetMaxLineLayout() - pWork->nPosX ) / nBaseWidth;
+		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos ) / nBaseWidth;
+		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos + 1 ) / nBaseWidth;
 
-		if( IsKinsokuPosTail(GetMaxLineLayout() - pWork->nPosX, nCharKetas2, nCharKetas3) && IsKinsokuTail(pWork->cLineStr.At(pWork->nPos)) ){
+		if( IsKinsokuPosTail( nRemainChars, nCharKetas2, nCharKetas3 ) && IsKinsokuTail( pWork->cLineStr.At( pWork->nPos ) ) ){
 			pWork->nWordBgn = pWork->nPos;
 			pWork->nWordLen = 1;
 			pWork->eKinsokuType = KINSOKU_TYPE_KINSOKU_TAIL;


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
以前から指摘されている「禁則処理がおかしい」問題に対応します。

## <!-- 必須 --> カテゴリ
不具合の修正

## <!-- 自明なら省略可 --> PR の背景
過去に行われたプロポーショナルフォントへの対応の際、桁数の単位が半角文字での換算値から変更されたものの、
禁則処理を行う関数ではこれに対応した判定条件の変更が行われませんでした。
これによりピクセル（？）による桁数と従来の半角n個換算の桁数が比較されるようになったため、
処理条件の判定が正しく行われなくなり、句読点ぶら下げと行頭・行末の禁則処理が動作しなくなっていました。
また、印刷レイアウトの禁則処理も同じ関数で処理しているため、こちらも機能していませんでした。

この問題は過去に2度、当時の一般向け掲示板で指摘されていました。

## <!-- 自明なら省略可 --> PR のメリット
禁則処理が再び使えるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
~~ないと思います。~~（追記：ありました。）
禁則処理の知識がなければレビューするのが難しいと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
禁則処理は行の末尾付近に達したときに行われるようになっており、この判定のため半角n個単位の桁数を比較していました。
このPRでは半角1桁当たりの最大レイアウト桁数を取得し、新しい単位に換算してから比較するようにします。

また、処理位置であるかの判定にはこれまで行の残り文字数と現在・次位の文字の幅を半角n個単位で判定関数に渡していました。
~~このPRでは、処理位置であるかの確認は現在のレイアウト行の残りに現在の文字と次の文字が収まるかどうかで判断します。~~
このPRでは、判定を行う関数に渡す文字幅にもレイアウト桁数から半角単位桁数への換算を行うようにします。
これらの変更によって、末尾付近に到達したか・禁則処理を行う位置かの判定が正しく行われるようになります。

なお、サクラエディタの禁則処理は次のように動作しているようでした。
- 英文ワードラップ
   - 単語の手前で自動的に改行処理を行い、単語の分割を防止する。
   - 英数字（大小は問わない）と特定の記号（「#」「$」「@」「\」）だけで構成される文字列を単語とみなす。
（IS_KEYWORD_CHAR関数の実装による）
- 句読点のぶら下げ
   - 句読点に指定した文字が行頭に来ないよう、前の行の末尾に配置する。
   - 既定では「、」「。」「，」「．」「､」「｡」「,」「.」の8文字を句読点として扱う。
（タイプ別設定「基本」の既定値による）
- 改行のぶら下げ
   - 改行文字だけの行が生じないよう、前の行の末尾に配置する。
- 行頭禁則（追い出し）
   - 行頭禁則の対象に指定した文字を直前の文字と合わせて次行に移動し、行頭に配置されないようにする。
      - ただし、句読点ぶら下げの対象である文字を行頭禁則の対象に指定することはできない。
   - 直前の文字が行頭禁則または句読点ぶら下げの対象である場合は処理を行わない。
- 行末禁則
   - 行末禁則の対象に指定した文字を次行の先頭に移動し、行末に配置されないようにする。

## <!-- 必須 --> テスト内容
タイプ別設定で句読点ぶら下げ・行頭禁則・行末禁則をそれぞれ有効にし、禁則処理が動作することを確認してください。

## <!-- わかる範囲で --> PR の影響範囲
- 禁則処理（句読点ぶら下げ・行頭禁則・行末禁則）

## <!-- なければ省略可 --> 関連 issue, PR
- [patchunicode#1034](https://sourceforge.net/p/sakura-editor/patchunicode/1034/)（このPRで置き換えます）
- close: #1410

## <!-- なければ省略可 --> 参考資料
- ユーザーからのバグ報告
   - [一般掲示板 [8106] Ver.2.3.0.0の禁則処理 by phodra (2016-01-23 00:17)](https://sakura-editor.github.io/bbslog/sf/general/8106.html)
   - [一般掲示板 [8255] 句読点ぶら下げが効かない？ by 渡辺真 (2017-07-16 09:55)](https://sakura-editor.github.io/bbslog/sf/general/8255.html)
- 過去の資料
   - [ANSI版開発掲示板 [1508] RE: メモ by みく (2002-02-08 21:48)](https://sakura-editor.github.io/bbslog/sf/ansi/1452.html#1508)
   - [ANSI版開発掲示板 [1830] 禁則処理 by みく (2002-04-08 19:07)](https://sakura-editor.github.io/bbslog/sf/ansi/1830.html)
   - 処理位置の判定ロジックが現在の形になったときのコミット (2005-09-03 12:32)： 2f093d4c96c612088d9f14804e0d4bdf8913641f