### PR TITLE
コンボボックスに Ctrl+Backspace による単語削除機能を追加する

### DIFF
--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -406,48 +406,9 @@ bool CSearchAgent::PrevOrNextWord(
 	}
 	/* 前の単語か？後ろの単語か？ */
 	if( bLEFT ){
-		/* 現在位置の文字の種類を調べる */
-		ECharKind	nCharKind = CWordParse::WhatKindOfChar( pLine, nLineLen, nIdx );
-		if( nIdx == 0 ){
-			return false;
-		}
-
-		/* 文字種類が変わるまで前方へサーチ */
-		/* 空白とタブは無視する */
-		int		nCount = 0;
-		CLogicInt	nIdxNext = nIdx;
-		CLogicInt	nCharChars = CLogicInt(&pLine[nIdxNext] - CNativeW::GetCharPrev( pLine, nLineLen, &pLine[nIdxNext] ));
-		while( nCharChars > 0 ){
-			CLogicInt		nIdxNextPrev = nIdxNext;
-			nIdxNext -= nCharChars;
-			ECharKind nCharKindNext = CWordParse::WhatKindOfChar( pLine, nLineLen, nIdxNext );
-
-			ECharKind nCharKindMerge = CWordParse::WhatKindOfTwoChars( nCharKindNext, nCharKind );
-			if( nCharKindMerge == CK_NULL ){
-				/* サーチ開始位置の文字が空白またはタブの場合 */
-				if( nCharKind == CK_TAB	|| nCharKind == CK_SPACE ){
-					if ( bStopsBothEnds && nCount ){
-						nIdxNext = nIdxNextPrev;
-						break;
-					}
-					nCharKindMerge = nCharKindNext;
-				}else{
-					if( nCount == 0){
-						nCharKindMerge = nCharKindNext;
-					}else{
-						nIdxNext = nIdxNextPrev;
-						break;
-					}
-				}
-			}
-			nCharKind = nCharKindMerge;
-			nCharChars = CLogicInt(&pLine[nIdxNext] - CNativeW::GetCharPrev( pLine, nLineLen, &pLine[nIdxNext] ));
-			++nCount;
-		}
-		*pnColumnNew = nIdxNext;
-	}else{
-		CWordParse::SearchNextWordPosition(pLine, nLineLen, nIdx, pnColumnNew, bStopsBothEnds);
+		return CWordParse::SearchPrevWordPosition(pLine, nLineLen, nIdx, pnColumnNew, bStopsBothEnds);
 	}
+	CWordParse::SearchNextWordPosition(pLine, nLineLen, nIdx, pnColumnNew, bStopsBothEnds);
 	return true;
 }
 

--- a/sakura_core/parse/CWordParse.h
+++ b/sakura_core/parse/CWordParse.h
@@ -116,6 +116,9 @@ public:
 		BOOL			bStopsBothEnds	//	単語の両端で止まる
 	);
 
+	static bool SearchPrevWordPosition(const wchar_t* pLine,
+		CLogicInt nLineLen, CLogicInt nIdx, CLogicInt* pnColumnNew, BOOL bStopsBothEnds);
+
 	template< class CHAR_TYPE >
 	static int GetWord( const CHAR_TYPE* pS, const int nLen, const CHAR_TYPE *pszSplitCharList,
 		CHAR_TYPE **ppWordStart, int *pnWordLen );


### PR DESCRIPTION
# PR の目的

検索ダイアログ等のコンボボックスに Ctrl+Backspace キーでの単語削除機能 (Issue #1311) を追加します。

## カテゴリ

- 機能追加

## PR の背景

サクラエディタのエディタ部において Ctrl+Backspace は直前の単語を削除するショートカットキーとして機能しますが、 検索ダイアログ等で利用している Windows API のコンボボックスはこれを文字の入力と解釈するため、 Ctrl+Backspace が期待通りの動作をしません。
この PR では Ctrl+Backspace をサクラエディタ側で処理するコードを追加し、エディタ部分と同じ動作をするように変更します。

## 仕様・動作説明

動作説明
- コンボボックスのテキストの編集中に Ctrl+Backspace が押されたら単語削除する。テキストが選択されていれば通常の削除処理を行う。
- 単語削除の動作は「共通設定」→「全般」の「単語単位で移動するときに単語の両端に止まる」設定に従う。

コードの概要
- `CSearchAgent::PrevOrNextWord` から前の単語を検索するコードを抽出し、`CWordParse::SearchPrevWordPosition` に移動。
- コンボボックスのサブクラスプロシージャに WM_CHAR のハンドラーを追加。0x7f (ASCII の DEL) が送られてきた場合に単語削除する。単語削除のテキスト処理は `DeletePreviousWord` 関数が受け持つ。
- `DeletePreviousWord` は `CWordParse::SearchPrevWordPosition` で前の単語の先頭位置を検索し、現在のキャレット位置以降のテキストを単語の先頭位置以降に上書きする。

## テスト内容

- 検索ダイアログで Ctrl+Backspace が単語削除として機能すること
- テキストが選択されている場合には、選択されているテキストのみが削除されること
- 「単語の両端に止まる」設定に従った動作を行うこと

## PR の影響範囲

- SetComboBoxDeleter を使用したコンボボックスすべての動作が変更されます。

## 関連 issue, PR

#1311, #1463