### PR TITLE
GetLayoutXOfCharの名称とデータ型を変更する

### DIFF
--- a/sakura_core/doc/layout/CLayout.cpp
+++ b/sakura_core/doc/layout/CLayout.cpp
@@ -51,7 +51,7 @@ CLayoutInt CLayout::CalcLayoutWidth(const CLayoutMgr& cLayoutMgr) const
 			nWidth += cLayoutMgr.GetActualTsvSpace(nWidth, pText[i]);
 		}
 		else{
-			nWidth += cLayoutMgr.GetLayoutXOfChar(pText, nTextLen, i);
+			nWidth += cLayoutMgr.GetPixelWidthOfChar( pText, nTextLen, i );
 		}
 		i += t_max(CLogicInt(1), CNativeW::GetSizeOfChar(pText, nTextLen, i));
 	}

--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -867,7 +867,7 @@ void CLayoutMgr::LogicToLayout(
 					nCharKetas = GetActualTsvSpace( nCaretPosX, pData[i] );
 				}
 				else{
-					nCharKetas = GetLayoutXOfChar( pData, nDataLen, i );
+					nCharKetas = GetPixelWidthOfChar( pData, nDataLen, i );
 				}
 //				if( nCharKetas == 0 )				// 削除 サロゲートペア対策	2008/7/5 Uchi
 //					nCharKetas = CLayoutInt(1);
@@ -1001,7 +1001,7 @@ checkloop:;
 			nCharKetas = GetActualTsvSpace( nX, pData[i] );
 		}
 		else{
-			nCharKetas = GetLayoutXOfChar( pData, nDataLen, i );
+			nCharKetas = GetPixelWidthOfChar( pData, nDataLen, i );
 		}
 //		if( nCharKetas == 0 )				// 削除 サロゲートペア対策	2008/7/5 Uchi
 //			nCharKetas = CLayoutInt(1);

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -267,16 +267,19 @@ public:
 
 	BOOL CalculateTextWidth( BOOL bCalLineLen = TRUE, CLayoutInt nStart = CLayoutInt(-1), CLayoutInt nEnd = CLayoutInt(-1) );	/* テキスト最大幅を算出する */		// 2009.08.28 nasukoji
 	void ClearLayoutLineWidth( void );				/* 各行のレイアウト行長の記憶をクリアする */		// 2009.08.28 nasukoji
-	CLayoutXInt GetLayoutXOfChar( const wchar_t* pData, int nDataLen, int i ) const {
-		CLayoutXInt nSpace = CLayoutXInt(0);
+
+	// 文字列中の指定位置にある文字の幅をpx単位で返す
+	CHabaXInt GetPixelWidthOfChar( const wchar_t* pData, int nDataLen, int nIdx ) const {
+		CHabaXInt nSpacing = CHabaXInt( 0 );
 		if( m_nSpacing ){
-			nSpace = CLayoutXInt(CNativeW::GetKetaOfChar(pData, nDataLen, i)) * m_nSpacing;
+			nSpacing = CHabaXInt( CNativeW::GetKetaOfChar( pData, nDataLen, nIdx ) * m_nSpacing );
 		}
-		return CNativeW::GetColmOfChar( pData, nDataLen, i ) + nSpace;
+		return CNativeW::GetHabaOfChar( pData, nDataLen, nIdx ) + nSpacing;
 	}
-	CLayoutXInt GetLayoutXOfChar( const CStringRef& str, int i ) const {
-		return GetLayoutXOfChar(str.GetPtr(), str.GetLength(), i);
+	CHabaXInt GetPixelWidthOfChar( const CStringRef& cStr, int nIdx ) const {
+		return GetPixelWidthOfChar( cStr.GetPtr(), cStr.GetLength(), nIdx );
 	}
+
 	CPixelXInt GetWidthPerKeta() const { return Int(m_nCharLayoutXPerKeta); }
 	CPixelXInt GetCharSpacing() const { return m_nSpacing; }
 

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -26,7 +26,7 @@ static bool _GetKeywordLength(
 	CLogicInt nWordLen = CLogicInt(0);
 	CLayoutInt nWordKetas = CLayoutInt(0);
 	while(nPos<cLineStr.GetLength() && IS_KEYWORD_CHAR(cLineStr.At(nPos))){
-		CLayoutInt k = cLayoutMgr.GetLayoutXOfChar(cLineStr, nPos);
+		CLayoutInt k = cLayoutMgr.GetPixelWidthOfChar( cLineStr, nPos );
 		if(0 == k)k = CLayoutInt(1);
 
 		nWordLen+=1;
@@ -121,7 +121,7 @@ void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 	if( (GetMaxLineLayout() - pWork->nPosX < 2) && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
 		// 2007.09.07 kobake   レイアウトとロジックの区別
-		CLayoutInt nCharKetas = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
+		CLayoutInt nCharKetas = GetPixelWidthOfChar( pWork->cLineStr, pWork->nPos );
 
 		if( IsKinsokuPosKuto(GetMaxLineLayout() - pWork->nPosX, nCharKetas) && IsKinsokuKuto( pWork->cLineStr.At(pWork->nPos) ) )
 		{
@@ -140,8 +140,8 @@ void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
 		// 2007.09.07 kobake   レイアウトとロジックの区別
-		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
-		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
+		CLayoutInt nCharKetas2 = GetPixelWidthOfChar( pWork->cLineStr, pWork->nPos );
+		CLayoutInt nCharKetas3 = GetPixelWidthOfChar( pWork->cLineStr, pWork->nPos + 1 );
 
 		if( IsKinsokuPosHead( GetMaxLineLayout() - pWork->nPosX, nCharKetas2, nCharKetas3 )
 		 && IsKinsokuHead( pWork->cLineStr.At(pWork->nPos+1) )
@@ -164,8 +164,8 @@ void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{	/* 行末禁則する && 行末付近 && 行頭でないこと(無限に禁則してしまいそう) */
-		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
-		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
+		CLayoutInt nCharKetas2 = GetPixelWidthOfChar( pWork->cLineStr, pWork->nPos );
+		CLayoutInt nCharKetas3 = GetPixelWidthOfChar( pWork->cLineStr, pWork->nPos + 1 );
 
 		if( IsKinsokuPosTail(GetMaxLineLayout() - pWork->nPosX, nCharKetas2, nCharKetas3) && IsKinsokuTail(pWork->cLineStr.At(pWork->nPos)) ){
 			pWork->nWordBgn = pWork->nPos;
@@ -248,7 +248,7 @@ void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 				break;
 			}
 			// 2007.09.07 kobake   ロジック幅とレイアウト幅を区別
-			CLayoutInt nCharKetas = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
+			CLayoutInt nCharKetas = GetPixelWidthOfChar( pWork->cLineStr, pWork->nPos );
 //			if( 0 == nCharKetas ){				// 削除 サロゲートペア対策	2008/7/5 Uchi
 //				nCharKetas = CLayoutInt(1);
 //			}

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -562,7 +562,7 @@ void CCaret::ShowEditCaret()
 					nCaretWidth = GetHankakuDx();
 				}
 				else{
-					CLayoutInt nKeta = m_pEditView->m_pcEditDoc->m_cLayoutMgr.GetLayoutXOfChar(pLine, nLineLen, nIdxFrom);
+					CLayoutInt nKeta = m_pEditView->m_pcEditDoc->m_cLayoutMgr.GetPixelWidthOfChar( pLine, nLineLen, nIdxFrom );
 					if( 0 < nKeta ){
 						nCaretWidth = m_pEditView->GetTextMetrics().GetCharPxWidth(nKeta);
 					}
@@ -593,7 +593,7 @@ void CCaret::ShowEditCaret()
 				pLine[nIdxFrom] == TAB ){
 				nCaretWidth = GetHankakuDx();
 			}else{
-				CLayoutXInt nKeta = m_pEditView->m_pcEditDoc->m_cLayoutMgr.GetLayoutXOfChar(pLine, nLineLen, nIdxFrom);
+				CLayoutXInt nKeta = m_pEditView->m_pcEditDoc->m_cLayoutMgr.GetPixelWidthOfChar( pLine, nLineLen, nIdxFrom );
 				if( 0 < nKeta ){
 					nCaretWidth = m_pEditView->GetTextMetrics().GetCharPxWidth(nKeta);
 				}

--- a/sakura_core/view/CEditView_Paint_Bracket.cpp
+++ b/sakura_core/view/CEditView_Paint_Bracket.cpp
@@ -198,7 +198,7 @@ void CEditView::DrawBracketPair( bool bDraw )
 					int nHeight = GetTextMetrics().GetHankakuDy();
 					int nLeft = (GetTextArea().GetDocumentLeftClientPointX()) + GetTextMetrics().GetCharPxWidth(ptColLine.x);
 					int nTop  = (Int)( ptColLine.GetY2() - GetTextArea().GetViewTopLine() ) * nHeight + GetTextArea().GetAreaTop();
-					CLayoutXInt charsWidth = m_pcEditDoc->m_cLayoutMgr.GetLayoutXOfChar(pLine, nLineLen, OutputX);
+					CLayoutXInt charsWidth = m_pcEditDoc->m_cLayoutMgr.GetPixelWidthOfChar( pLine, nLineLen, OutputX );
 
 					//色設定
 					CTypeSupport cTextType(this,COLORIDX_TEXT);

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -95,7 +95,7 @@ void CTextDrawer::DispText( HDC hdc, DispPos* pDispPos, int marginy, const wchar
 			int nLeftLayout = ( 0 - x ) / nDx - 1;
 			CLayoutMgr& layoutMgr = m_pEditView->m_pcEditDoc->m_cLayoutMgr;
 			while (nBeforeLayout < nLeftLayout){
-				nBeforeLayout += layoutMgr.GetLayoutXOfChar(pData, nLength, nBeforeLogic);
+				nBeforeLayout += layoutMgr.GetPixelWidthOfChar( pData, nLength, nBeforeLogic );
 				nBeforeLogic  += CNativeW::GetSizeOfChar( pData, nLength, nBeforeLogic );
 			}
 		}


### PR DESCRIPTION
# PR の目的
レイアウト情報における文字幅の取得に用いる関数について、戻り値の意味に対してデータ型が異なっている問題を修正します。

## カテゴリ
- リファクタリング

## PR の背景
#1464 のレビューで次のような指摘がありました。

> 変数を CLayoutInt で宣言するってことは、値の単位が「桁」であることを意味します。
> LayoutX（文字幅px）をnBaseWidth（1字あたりの幅px）で割った値なので単位は「桁」になります。
>
> 論理的には正しいんですけど「文字幅pxにLayoutX」という「誤った型名」を付けているので超ややこしいです。
>
> 是正すべきはここなんじゃないかな？と思いました。
> おそらく誰も理解できないだろう、と判断して放置してきましたが、
> 対策するならココ（GetLayoutXOfCharが指す「レイアウト単位」がpxを表している誤り）をなんとかしたほうがいい気がします。

_Originally posted by @berryzplus in https://github.com/sakura-editor/sakura/pull/1464#discussion_r527725303_

## PR のメリット
当該関数の目的と取得するデータの意味が明確になると思います。

## PR のデメリット (トレードオフとかあれば)
何が問題なのかが理解しづらいかもしれません。

## 仕様・動作説明
- GetLayoutXOfChar()関数を、GetPixelWidthOfChar()に名称変更しました。
- 戻り値のデータ型をCLayoutXInt（桁数・桁位置）からCHabaXInt（文字幅）に変更しました。

### 変更前：GetLayoutXOfChar
関数名は「1文字分に相当するレイアウト単位のX座標」という意味だと解釈しました。
結果として文字幅を得られるものの、戻り値はCLayoutXInt型であることから、px単位文字幅のデータ型としては適切な用法ではないと思われます。

### 変更後：GetPixelWidthOfChar
関数名で「ピクセル単位の文字幅」が取得できることがわかるようにしました。なお、値には「文字と文字の隙間」の値も含まれます。
また、CNativeWクラスではpx単位文字幅をCHabaXInt型で表現していることから、それに倣ってこの関数も文字幅であることを明確にするためCHabaXInt型に変更しました。
この変更に伴い、呼び出しているCNativeWクラスの関数をCLayoutInt型を返すGetColmOfCharからCHabaXInt型を返すGetHabaOfCharに変更し、不要な型変換が行われないようにしています。

##  テスト内容
次の設定項目の設定値を変更して、一通りの動作を確認しています。
（これらの処理を担当する関数でGetLayoutXOfCharが呼び出されていました。）
- タイプ別設定
   - 英文ワードラップ
   - 文字と文字の隙間（ = 文字間隔）
   - 対括弧の強調表示
- 共通設定
   - カーソル形状
- 挿入モードと上書きモード

このほか、編集ウィンドウの幅を超える文字入力をしたとき（＝横スクロールが必要になる状態）の動作も確認しています。
いずれも、GetLayotuXOfCharを呼び出している関数が処理するものです。

### テスト
- ビルドが成功することを確認する。
- 上記の設定項目を変更して通常使用を試みる。
- 編集ウィンドウの幅を超える長さの文字列を入力してみる。

## PR の影響範囲
- レイアウト情報（CLayoutMgr）経由で文字列中のとある文字の幅を取得している、すべての処理。

## 関連 issue, PR
#1464

## 参考情報
- サロゲートペア対応を行ったときのコミットログ
5b7774daefbcba114d6cbc8027f6a6455daee0e3