### PR TITLE
std::move を使うべきところで std::forward が使われているので置き換える

### DIFF
--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -13,7 +13,7 @@ CNativeA::CNativeA(const CNativeA& rhs)
 }
 
 CNativeA::CNativeA(CNativeA&& other) noexcept
-	: CNative(std::forward<CNativeA>(other))
+	: CNative(std::move(other))
 {
 }
 

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -60,7 +60,7 @@ public:
 
 	//演算子
 	CNativeA& operator = (const CNativeA& rhs)			{ CNative::operator=(rhs); return *this; }
-	CNativeA& operator = (CNativeA&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeA>(rhs)); return *this; }
+	CNativeA& operator = (CNativeA&& rhs) noexcept		{ CNative::operator=(std::move(rhs)); return *this; }
 	const CNativeA& operator=( char );
 	const CNativeA& operator+=( char );
 };

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -18,7 +18,7 @@ CNativeW::CNativeW(const CNativeW& rhs)
 }
 
 CNativeW::CNativeW(CNativeW&& other) noexcept
-	: CNative(std::forward<CNativeW>(other))
+	: CNative(std::move(other))
 {
 }
 

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -98,7 +98,7 @@ public:
 
 	//演算子
 	CNativeW& operator = (const CNativeW& rhs)			{ CNative::operator=(rhs); return *this; }
-	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeW>(rhs)); return *this; }
+	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::move(rhs)); return *this; }
 	CNativeW  operator + (const CNativeW& rhs) const	{ return (CNativeW(*this) += rhs); }
 	CNativeW& operator += (const CNativeW& rhs)			{ AppendNativeData(rhs); return *this; }
 	CNativeW& operator += (wchar_t ch)					{ return (*this += CNativeW(&ch, 1)); }


### PR DESCRIPTION
# PR の目的

SonarCloud で Blocker Bug として警告されている問題に対処したいです。

## カテゴリ

- リファクタリング

## PR の背景

SonarCloud の警告が多すぎる問題 (#1476) について指摘がありましたが、Blocker Bug とされているものの中に即対処できるものがありましたので PR にしてみました。
[問題はこれです。](https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AW8eyhy4ak1yqJchwkt4&open=AW8eyhy4ak1yqJchwkt4) std::move を使うべき場面で std::forward を使ってるぞ！と警告されてます。
ここを単純に std::move に置き換えることで警告が減らせます。

## PR のメリット

SonarCloud の最高レベルの警告がいくつか減ります。

## PR の影響範囲

PR で変更した個所では std::forward と std::move のどちらを使っても rvalue が返ります。
動作は変更されません。

## <!-- なければ省略可 --> 参考資料

std::move と std::forward ってどう違うのか？という点については解説記事をご参照ください…。（簡潔に説明できない）
基本的には std::forward はテンプレート関数の中で使うもの、という理解で実用上は問題ありません。
- [C++のムーブと完全転送を知る](https://proc-cpuinfo.fixstars.com/2016/03/c-html/)
- [Universal References in C++11](https://isocpp.org/blog/2012/11/universal-references-in-c11-scott-meyers)
