### PR TITLE
「ファイル名の簡易表示」設定における更新ボタンの不具合修正

### DIFF
--- a/sakura_core/prop/CPropComFileName.cpp
+++ b/sakura_core/prop/CPropComFileName.cpp
@@ -229,14 +229,14 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 					break;
 
 				case IDC_BUTTON_FNAME_UPD:	// 更新
+					::DlgItem_GetText( hwndDlg, IDC_EDIT_FNAME_FROM, szFrom, _MAX_PATH );
+					::DlgItem_GetText( hwndDlg, IDC_EDIT_FNAME_TO, szTo, _MAX_PATH );
 					if( -1 != nIndex ){
-						::DlgItem_GetText( hwndDlg, IDC_EDIT_FNAME_FROM, szFrom, _MAX_PATH );
-						::DlgItem_GetText( hwndDlg, IDC_EDIT_FNAME_TO,   szTo,   _MAX_PATH );
 						if( -1 != SetListViewItem_FILENAME( hListView, nIndex, szFrom, szTo, false ) ){
 							return TRUE;
 						}
 					}else{
-						// 未選択でリストにひとつも項目がない場合は追加しておく
+						// 項目を選択していない理由が「リストに項目がない」であれば、更新ボタンで項目を追加できるようにする
 						if( 0 == ListView_GetItemCount( hListView ) ){
 							if( -1 != SetListViewItem_FILENAME( hListView, 0, szFrom, szTo, true ) ){
 								return TRUE;


### PR DESCRIPTION
# PR の目的

「ファイル名の簡易表示」設定画面にある更新ボタンに存在するバグを修正します。
（push操作間違いでcloseされてしまった #1478 の焼き直しです。）

## カテゴリ

- 不具合修正

## PR の背景

SonarQubeのissueを眺めていたところ、気になるものがあったので対応しようと思いました。
[The right operand of '==' is a garbage value](https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AWnzBEjGO9B58BDkCdA_&open=AWnzBEjGO9B58BDkCdA_)

指摘のある関数の呼び出し元のうち、更新ボタンのイベント処理から呼ばれるルートの時で、文字列の取得をしないまま（文字列が格納される変数を初期化しないまま）当該関数に引数として渡していました。

## PR のメリット

- Major Bugが1件修正されます。

## PR のデメリット (トレードオフとかあれば)

- 特にありません。

## 仕様・動作説明

共通設定ダイアログの「ファイル名の簡易表示」設定画面にある更新ボタンは、次のように動作しているようでした。
- 選択された項目の内容を、テキストボックスに入力された文字列に更新する
- 項目を何も選択せずにボタンが押された時、リストが空であればリストに項目を追加する。
   - リストが空でなければ何もしない

更新ボタンを押したときに実行されるコードにおいて、テキストボックスに入力された文字列を取得する処理が項目を選択しているかを確認するif文の内側に記述されているため、後者の動作をするときに文字型変数が初期化されていませんでした。
この影響により、現状この追加動作は機能していません。

このPRでは文字列を条件判定を行う前に取得するように変更して、初期化されていない変数が使われるのを防ぎ、追加動作が機能するようにします。

（ #1478 ではリストが空でないのに関わらず何も選択していなかった時はメッセージを出す変更案も入れていましたが、これはキャンセルすることにしました。）

## PR の影響範囲

共通設定ダイアログにある、ファイル名の簡易表示設定

## テスト内容

### テスト1

手順
1. 簡易表示の置換リストをいったん空にする
2. それぞれのテキストボックスにファイル名を入力して更新ボタンを押す
   - 入力したテキストがリストに追加されたか確認する
3. リストの何もないところをクリックして、項目を何も選んでいない状態にする
4. 再び各テキストボックスにファイル名を入力して更新ボタンを押す
   - 項目が追加されないことを確認する。