### PR TITLE
コンボボックスのサブクラス化に関連するクラッシュバグの修正

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -808,12 +808,10 @@ LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 
 void CDialog::SetComboBoxDeleter(HWND hwndCtl, CRecent* pRecent)
 {
-	assert(pRecent);
-	assert((::GetWindowLongPtr(hwndCtl, GWL_STYLE) & 0b11) != CBS_DROPDOWNLIST);
-
+	if (!pRecent || (::GetWindowLongPtr(hwndCtl, GWL_STYLE) & 0b11) == CBS_DROPDOWNLIST)
+		return;
 	COMBOBOXINFO info = { sizeof(COMBOBOXINFO) };
 	if (!::GetComboBoxInfo(hwndCtl, &info))
 		return;
-	assert(info.hwndCombo != info.hwndItem);
 	::SetWindowSubclass(info.hwndItem, SubEditProc, 0, (DWORD_PTR)pRecent);
 }

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -809,9 +809,11 @@ LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 void CDialog::SetComboBoxDeleter(HWND hwndCtl, CRecent* pRecent)
 {
 	assert(pRecent);
+	assert((::GetWindowLongPtr(hwndCtl, GWL_STYLE) & 0b11) != CBS_DROPDOWNLIST);
 
 	COMBOBOXINFO info = { sizeof(COMBOBOXINFO) };
 	if (!::GetComboBoxInfo(hwndCtl, &info))
 		return;
+	assert(info.hwndCombo != info.hwndItem);
 	::SetWindowSubclass(info.hwndItem, SubEditProc, 0, (DWORD_PTR)pRecent);
 }

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -115,6 +115,11 @@ public:
 
 	void ResizeItem( HWND hTarget, const POINT& ptDlgDefalut, const POINT& ptDlgNew, const RECT& rcItemDefault, EAnchorStyle anchor, bool bUpdate = true);
 	void GetItemClientRect( int wID, RECT& rc );
+
+	//! @brief コンボボックスに履歴削除・単語削除の機能を追加する
+	//!
+	//! @param hwndCtl コンボボックスのハンドル。CBS_DROPDOWNLISTスタイルのコンボボックスには対応していません。
+	//! @param pRecent 紐づけるCRecentへのポインタ。nullptrは指定できません。
 	static void SetComboBoxDeleter( HWND hwndCtl, CRecent* pRecent );
 public:
 

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -370,9 +370,6 @@ UINT_PTR CALLBACK OFNHookProc(
 
 			/* ビューモードの初期値セット */
 			::CheckDlgButton( pData->m_hwndOpenDlg, chx1, pData->m_bViewMode );
-
-			CDialog::SetComboBoxDeleter(pData->m_hwndComboMRU, &pData->m_cRecentFile);
-			CDialog::SetComboBoxDeleter(pData->m_hwndComboOPENFOLDER, &pData->m_cRecentFolder);
 		}
 		break;
 


### PR DESCRIPTION
# PR の目的

「ファイルを開く」および「名前を付けて保存」ダイアログにて、「最近のファイル」・「最近のフォルダ」コンボボックスにフォーカスがある状態で Ctrl+Backspace を押すとクラッシュします。
#1470 の機能追加による劣化バグで、本PRはその修正が目的です。

## カテゴリ

- 不具合修正

## PR の背景

問題の原因ですが、コンボボックスをサブクラス化する処理が CBS_DROPDOWNLIST （編集できないコンボボックス）を考慮していなかったことです。
SetComboBoxDeleter 関連のコードは、API関数 GetComboBoxInfo を通じて コンボボックス内部の Edit のハンドルを入手できることを前提としています。編集可能なコンボボックスでは期待通りにEditを取得できますが、CBS_DROPDOWNLIST スタイルのコンボボックスに対して同じことをすると結果は ComboBox のハンドルになってしまいます。このケースを考慮できていませんでした。

https://github.com/sakura-editor/sakura/blob/526f51224b5a7c1195bfaf7002f8ab65f55427fb/sakura_core/dlg/CDialog.cpp#L813-L816

hwndCtl が CBS_DROPDOWNLIST スタイルのコンボボックスだった場合、info.hwndItem に ComboBox が入った状態で返ってくるため、Edit をサブクラス化するつもりで ComboBox をサブクラス化することになります。

https://github.com/sakura-editor/sakura/blob/526f51224b5a7c1195bfaf7002f8ab65f55427fb/sakura_core/dlg/CDialog.cpp#L767-L770

ここで Edit の親（＝ComboBox）を取得しようとして ComboBox の親（＝ダイアログ）を取得してます。

https://github.com/sakura-editor/sakura/blob/526f51224b5a7c1195bfaf7002f8ab65f55427fb/sakura_core/dlg/CDialog.cpp#L781-L785

hwndCombo はダイアログです。CB_GETEDITSELには反応してくれません。`selStart`と`selEnd`は未初期化のままです。

https://github.com/sakura-editor/sakura/blob/526f51224b5a7c1195bfaf7002f8ab65f55427fb/sakura_core/dlg/CDialog.cpp#L793-L798

`length` は 0、`text`は`L'\0'`が入った長さ1の配列となります。`selStart`が偶然0になっていなければ`DeletePreviousWord`の中で Access Violation が発生します😢

## 仕様・動作説明

問題に対する対処として、CBS_DROPDOWNLIST スタイルのコンボボックスに SetComboBoxDeleter を適用しないことにします。該当するのは「ファイルを開く」および「名前を付けて保存」ダイアログ下部のそれです。
副作用として履歴削除が機能しなくなる…と思いきや、実は別バグ（後述）により CBS_DROPDOWNLIST スタイルのコンボボックスでは元から機能していなかったため、機能面では退行しないものと思われます。

## PR の影響範囲

以下のダイアログに存在したクラッシュバグを修正します。
- ファイルを開く・名前を付けて保存（Vistaスタイルを除く）

以下の画面に存在するコンボボックスに関係するコードを変更します。
- 検索・置換
- Grep・Grep置換
- 外部コマンド実行
- ツールバーの検索ボックス

## テスト内容

- 「共通設定」→「編集」→「Vistaスタイルのファイルダイアログ」にチェックが**入っていない**状態で、開く・保存ダイアログに対して以下のテストが必要です
  - 「最近のファイル」・「最近のフォルダ」をクリックするなどしてフォーカスを移動させる
  - Ctrl + Backspace を押下する
  - プログラムがクラッシュしないことを確認する

- 他の画面の該当コンボボックス（上記）に対して、履歴削除・単語削除がそれぞれ引き続き機能することの確認が必要です。

## 関連 issue, PR

#1463, #1470

## 参考資料

### 履歴削除の別バグ

https://github.com/sakura-editor/sakura/blob/526f51224b5a7c1195bfaf7002f8ab65f55427fb/sakura_core/dlg/CDialog.cpp#L725-L738

CBS_DROPDOWNLIST スタイルのコンボボックスは CB_GETEDITSEL が送られてきても何もしないようで、`dwSelStart`と`dwSelEnd`は常に0のまま変わりません。`cEditText`は最短でも長さ1（null文字の分）であるため、`dwSelEnd < (DWORD)cEditText.GetStringLength()`の条件式により、履歴削除が実行されることはありません。
本 PR では元から動いていなかったことを理由として機能を削除しますが、対処方針として適切かどうかというと微妙だと思っています。後から追加PRとして修正することも考えていますので、問題があればご指摘ください。