### PR TITLE
GetDateTimeFormatの出力バッファサイズチェックを実装する

### DIFF
--- a/sakura_core/util/format.cpp
+++ b/sakura_core/util/format.cpp
@@ -28,76 +28,88 @@
 
 /*!	日時をフォーマット
 
-	@param[out] 書式変換後の文字列
-	@param[in] バッファサイズ
+	@param[out] szResult 書式変換後の文字列
+	@param[in] size szResultに格納可能な文字数(ヌル文字を含む)
 	@param[in] format 書式
 	@param[in] systime 書式化したい日時
-	@return bool true
+	@retval true  書式文字列の変換が完了
+	@retval false 書式文字列の変換が一部または全部失敗
 
 	@note  %Y %y %m %d %H %M %S の変換に対応
 
 	@author aroka
 	@date 2005.11.21 新規
-	
-	@todo 出力バッファのサイズチェックを行う
 */
-bool GetDateTimeFormat( WCHAR* szResult, int size, const WCHAR* format, const SYSTEMTIME& systime )
+bool GetDateTimeFormat( WCHAR* szResult, size_t size, const WCHAR* format, const SYSTEMTIME& systime )
 {
-	WCHAR szTime[10];
+	WCHAR szTime[10] = {};
 	const WCHAR *p = format;
 	WCHAR *q = szResult;
-	int len;
-	
+	bool ret = false;
+
+	if( szResult == NULL || size == 0 || format == NULL ){
+		return false;
+	}
+
 	while( *p ){
+		const size_t remains = (size - 1) - (q - szResult);
+		if( remains <= 0 ){
+			break;
+		}
+
+		int timeLen = -1;
 		if( *p == L'%' ){
 			++p;
-			switch(*p){
+			switch( *p ){
 			case L'Y':
-				len = wsprintf(szTime,L"%d",systime.wYear);
-				wcscpy( q, szTime );
+				timeLen = wsprintf( szTime, L"%d", systime.wYear );
 				break;
 			case L'y':
-				len = wsprintf(szTime,L"%02d",(systime.wYear%100));
-				wcscpy( q, szTime );
+				timeLen = wsprintf( szTime, L"%02d", (systime.wYear % 100) );
 				break;
 			case L'm':
-				len = wsprintf(szTime,L"%02d",systime.wMonth);
-				wcscpy( q, szTime );
+				timeLen = wsprintf( szTime, L"%02d", systime.wMonth );
 				break;
 			case L'd':
-				len = wsprintf(szTime,L"%02d",systime.wDay);
-				wcscpy( q, szTime );
+				timeLen = wsprintf( szTime, L"%02d", systime.wDay );
 				break;
 			case L'H':
-				len = wsprintf(szTime,L"%02d",systime.wHour);
-				wcscpy( q, szTime );
+				timeLen = wsprintf( szTime, L"%02d", systime.wHour );
 				break;
 			case L'M':
-				len = wsprintf(szTime,L"%02d",systime.wMinute);
-				wcscpy( q, szTime );
+				timeLen = wsprintf( szTime, L"%02d", systime.wMinute );
 				break;
 			case L'S':
-				len = wsprintf(szTime,L"%02d",systime.wSecond);
-				wcscpy( q, szTime );
+				timeLen = wsprintf( szTime, L"%02d", systime.wSecond );
 				break;
 				// A Z
 			case L'%':
 			default:
-				*q = *p;
-				len = 1;
 				break;
 			}
-			q+=len;//q += strlen(szTime);
-			++p;
 		}
-		else{
-			*q = *p;
-			q++;
-			p++;
+
+		if( 0 <= timeLen ){
+			if( remains < timeLen ){
+				break;
+			}
+			wcscpy( q, szTime );
+			++p;
+			q += timeLen;
+		}else{
+			if( *p != L'\0' ){
+				*q++ = *p++;
+			}
 		}
 	}
-	*q = *p;
-	return true;
+
+	*q = L'\0';
+
+	if( *p == L'\0' ){
+		ret = true;
+	}
+
+	return ret;
 }
 
 /*!	バージョン番号の解析

--- a/sakura_core/util/format.cpp
+++ b/sakura_core/util/format.cpp
@@ -55,6 +55,11 @@ bool GetDateTimeFormat( WCHAR* szResult, size_t size, const WCHAR* format, const
 		int timeLen = -1;
 		if( *p == L'%' ){
 			++p;
+
+			if( *p == L'\0' ){
+				break;
+			}
+
 			switch( *p ){
 			case L'Y':
 				timeLen = wsprintf( szTime, L"%d", systime.wYear );
@@ -84,14 +89,14 @@ bool GetDateTimeFormat( WCHAR* szResult, size_t size, const WCHAR* format, const
 
 		const size_t remains = (size - 1) - (q - szResult);
 		if( 0 <= timeLen ){
-			if( remains < timeLen || timeLen == 0 ){
+			if( remains < (size_t)timeLen ){
 				break;
 			}
 			wcscpy( q, szTime );
 			++p;
 			q += timeLen;
 		}else{
-			if( remains <= 0 || *p == L'\0' ){
+			if( remains == 0 ){
 				break;
 			}
 			*q++ = *p++;

--- a/sakura_core/util/format.cpp
+++ b/sakura_core/util/format.cpp
@@ -52,11 +52,6 @@ bool GetDateTimeFormat( WCHAR* szResult, size_t size, const WCHAR* format, const
 	}
 
 	while( *p ){
-		const size_t remains = (size - 1) - (q - szResult);
-		if( remains <= 0 ){
-			break;
-		}
-
 		int timeLen = -1;
 		if( *p == L'%' ){
 			++p;
@@ -82,24 +77,24 @@ bool GetDateTimeFormat( WCHAR* szResult, size_t size, const WCHAR* format, const
 			case L'S':
 				timeLen = wsprintf( szTime, L"%02d", systime.wSecond );
 				break;
-				// A Z
-			case L'%':
 			default:
 				break;
 			}
 		}
 
+		const size_t remains = (size - 1) - (q - szResult);
 		if( 0 <= timeLen ){
-			if( remains < timeLen ){
+			if( remains < timeLen || timeLen == 0 ){
 				break;
 			}
 			wcscpy( q, szTime );
 			++p;
 			q += timeLen;
 		}else{
-			if( *p != L'\0' ){
-				*q++ = *p++;
+			if( remains <= 0 || *p == L'\0' ){
+				break;
 			}
+			*q++ = *p++;
 		}
 	}
 

--- a/sakura_core/util/format.h
+++ b/sakura_core/util/format.h
@@ -28,7 +28,7 @@
 #pragma once
 
 // 20051121 aroka
-bool GetDateTimeFormat( WCHAR* szResult, int size, const WCHAR* format, const SYSTEMTIME& systime );
+bool GetDateTimeFormat( WCHAR* szResult, size_t size, const WCHAR* format, const SYSTEMTIME& systime );
 UINT32 ParseVersion( const WCHAR* ver );	//バージョン番号の解析
 int CompareVersion( const WCHAR* verA, const WCHAR* verB );	//バージョン番号の比較
 #endif /* SAKURA_FORMAT_A006AC9B_ADE2_499D_9CC6_00A649F32B4F_H_ */

--- a/tests/unittests/test-format.cpp
+++ b/tests/unittests/test-format.cpp
@@ -1,0 +1,123 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2020 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+#include <Windows.h>
+#include "util/format.h"
+
+/*!
+ * @brief 入力の妥当性判定に関するテスト
+ */
+TEST( format, CheckInputValidity )
+{
+	SYSTEMTIME time = {};
+	time.wYear = 123;
+	WCHAR buffer[5] = {};
+	EXPECT_FALSE( GetDateTimeFormat( NULL, 0, L"", time ) );
+	EXPECT_FALSE( GetDateTimeFormat( buffer, 0, L"", time ) );
+	EXPECT_FALSE( GetDateTimeFormat( buffer, _countof(buffer), NULL, time ) );
+	EXPECT_FALSE( GetDateTimeFormat( buffer, 3, L"%Y", time ) );
+	EXPECT_TRUE( GetDateTimeFormat( buffer, 4, L"%Y", time ) );
+}
+
+/*!
+ * @brief バッファ書き込み範囲のテスト
+ */
+TEST( format, BufferWriteRange )
+{
+	SYSTEMTIME time = {};
+	time.wYear = 1;
+
+	WCHAR buffer1[] = { L'X', L'X', L'X' };
+	EXPECT_TRUE( GetDateTimeFormat( buffer1, _countof(buffer1), L"", time ) );
+	EXPECT_EQ( L'\0', buffer1[0] );
+	EXPECT_EQ( L'X', buffer1[1] );
+
+	WCHAR buffer2[] = { L'X', L'X', L'X' };
+	EXPECT_TRUE( GetDateTimeFormat( buffer2, _countof(buffer2), L"%", time ) );
+	EXPECT_EQ( L'\0', buffer2[0] );
+	EXPECT_EQ( L'X', buffer2[1] );
+
+	WCHAR buffer3[] = { L'X', L'X', L'X' };
+	EXPECT_TRUE( GetDateTimeFormat( buffer3, _countof(buffer3), L"%Y", time ) );
+	EXPECT_EQ( L'1', buffer3[0] );
+	EXPECT_EQ( L'\0', buffer3[1] );
+	EXPECT_EQ( L'X', buffer3[2] );
+
+	WCHAR buffer4[] = { L'X', L'X', L'X' };
+	EXPECT_FALSE( GetDateTimeFormat( buffer4, _countof(buffer4), L"_%y", time ) );
+	EXPECT_EQ( L'_', buffer4[0] );
+	EXPECT_EQ( L'\0', buffer4[1] );
+	EXPECT_EQ( L'X', buffer4[2] );
+
+	WCHAR buffer5[] = { L'X', L'X', L'X' };
+	EXPECT_TRUE( GetDateTimeFormat( buffer5, _countof(buffer5), L"1", time ) );
+	EXPECT_EQ( L'1', buffer5[0] );
+	EXPECT_EQ( L'\0', buffer5[1] );
+	EXPECT_EQ( L'X', buffer5[2] );
+
+	WCHAR buffer6[] = { L'X', L'X', L'X' };
+	EXPECT_TRUE( GetDateTimeFormat( buffer6, _countof(buffer6), L"11", time ) );
+	EXPECT_EQ( L'1', buffer6[0] );
+	EXPECT_EQ( L'1', buffer6[1] );
+	EXPECT_EQ( L'\0', buffer6[2] );
+
+	WCHAR buffer7[] = { L'X', L'X', L'X' };
+	EXPECT_FALSE( GetDateTimeFormat( buffer7, _countof(buffer7), L"111", time ) );
+	EXPECT_EQ( L'1', buffer7[0] );
+	EXPECT_EQ( L'1', buffer7[1] );
+	EXPECT_EQ( L'\0', buffer7[2] );
+}
+
+/*!
+ * @brief 書式変換のテスト
+ */
+TEST( format, Formatting )
+{
+	SYSTEMTIME time = {};
+
+	WCHAR buffer1[5] = {};
+	EXPECT_TRUE( GetDateTimeFormat( buffer1, _countof(buffer1), L"%%-%1-%", time ) );
+	ASSERT_STREQ( L"%-1-", buffer1 );
+
+	time.wYear = 1;
+	time.wMonth = 2;
+	time.wDay = 3;
+	time.wHour = 1;
+	time.wMinute = 2;
+	time.wSecond = 3;
+	WCHAR buffer2[20] = {};
+	EXPECT_TRUE( GetDateTimeFormat( buffer2, _countof(buffer2), L"%Y-%y-%m-%d %H:%M:%S", time ) );
+	ASSERT_STREQ( L"1-01-02-03 01:02:03", buffer2 );
+
+	time.wYear = 12345;
+	time.wMonth = 12;
+	time.wDay = 23;
+	time.wHour = 12;
+	time.wMinute = 34;
+	time.wSecond = 56;
+	WCHAR buffer3[24] = {};
+	EXPECT_TRUE( GetDateTimeFormat( buffer3, _countof(buffer3), L"%Y-%y-%m-%d %H:%M:%S", time ) );
+	ASSERT_STREQ( L"12345-45-12-23 12:34:56", buffer3 );
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -114,6 +114,7 @@
     <ClCompile Include="test-cprofile.cpp" />
     <ClCompile Include="test-editinfo.cpp" />
     <ClCompile Include="test-file.cpp" />
+    <ClCompile Include="test-format.cpp" />
     <ClCompile Include="test-grepinfo.cpp" />
     <ClCompile Include="test-int2dec.cpp" />
     <ClCompile Include="test-is_mailaddress.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -83,6 +83,9 @@
     <ClCompile Include="test-file.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-format.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

現状未実装となっている GetDateTimeFormat の出力バッファサイズのチェック処理を実装します。

## <!-- 必須 --> カテゴリ

- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

https://github.com/sakura-editor/sakura/pull/1474 で GetDateTimeFormat を利用した際に、出力バッファサイズが未実装であることに気づいたため。

## <!-- 自明なら省略可 --> PR のメリット

十分な容量を持たないバッファが指定された時のバッファオーバーランを防止できます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

特にありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

* 戻り値は、書式文字列の変換を最後までできた場合には`true`、途中までまたは全くできなかった場合には`false`とします。
* 変換途中でバッファサイズが不足する場合でも、そこまでの変換結果は出力バッファに書き込むこととします。

## <!-- わかる範囲で --> PR の影響範囲

GetDateTimeFormat を使用して日時文字列を取得している処理に影響があります。

## <!-- 必須 --> テスト内容

現在 GetDateTimeFormat が使用されている処理を通過するテストパターンを用意し、デグレがないことを確認します。

### テスト1 - 無題の文書のファイル名

1. 無題の文書が開いている状態で「ファイル」→「名前を付けて保存」を選択する。
確認1：名前を付けて保存ダイアログのファイル名に現在日時が付加されていること。

### テスト2 - バックアップファイル名

1. 「共通設定」→「バックアップ」にて「詳細設定する」をチェック、「保存時の日時・時刻を使用」を選択する。
2. 「詳細設定する」直下のテキストボックスに `.\$0_%Y%m%d_%H%M%S.*` を入力する。
3. 任意のファイルを開き、バックアップ付きで上書き保存する。
確認1：保存先ディレクトリに、現在日時が付加されたファイル (バックアップファイル) が作成されていること。
4. バックアップファイルを削除する。
5. 上書き保存したファイル (バックアップではない方) の更新日時をメモする。
6. 「共通設定」→「バックアップ」で「前回のファイル更新時の日付・時刻を使用」を選択する。
7. 再度、バックアップ付きで上書き保存する。
確認2：保存先ディレクトリに、「4」でメモした日時が付加されたファイルが作成されていること。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
