### PR TITLE
静的解析SonarCloudのためのJavaをJDK11に更新する

### DIFF
--- a/SonarQube.md
+++ b/SonarQube.md
@@ -98,7 +98,7 @@ https://sonarcloud.io/account/security/ のページでいつでも Access Token
   https://chocolatey.org/install#install-with-cmdexe を参考にインストールする。
   ※powershellコンソールを「管理者として実行」して、サイトにあるスクリプトをコピペ実行するだけです。
 
-3. SonnarScanner実行環境として Java 11 をインストールする
+3. SonarScanner実行環境として Java 11 をインストールする
   1. JDKを使う場合 https://chocolatey.org/packages/openjdk11
   2. JREを使う場合 https://chocolatey.org/packages/openjdk11jre
   3. Oracleに開発者登録している場合 Oracle JDK/JRE で代替してもよいです。

--- a/SonarQube.md
+++ b/SonarQube.md
@@ -94,19 +94,26 @@ https://sonarcloud.io/account/security/ のページでいつでも Access Token
 
 ### ローカルで実行する場合の環境設定 (事前準備)
 
-1. Oracle JRE8 の **64bit 版のランタイム** をダウンロードしてインストールする
-    1. Oracle JRE8 https://java.com/ja/download/manual.jsp (2019/05/02 現在)
-    1. Open JRE8 は Windows 版はダウンロードできなさそう。
-    1. 参考: [Prerequisites and Overview (Supported Platforms)](https://docs.sonarqube.org/latest/requirements/requirements/#header-3)
-    1. 参考: [SonarQubeの Java 11 対応状況](https://qiita.com/hayao_k/items/2cd81161f8dffd3a178b)
+1. chocolatey をインストールする
+  https://chocolatey.org/install#install-with-cmdexe を参考にインストールする。
+  ※powershellコンソールを「管理者として実行」して、サイトにあるスクリプトをコピペ実行するだけです。
 
-1. `JAVA_HOME` の環境変数を設定する
+3. SonnarScanner実行環境として Java 11 をインストールする
+  1. JDKを使う場合 https://chocolatey.org/packages/openjdk11
+  2. JREを使う場合 https://chocolatey.org/packages/openjdk11jre
+  3. Oracleに開発者登録している場合 Oracle JDK/JRE で代替してもよいです。
+    1. 普通のJava Runtime Envirionment(jre8)は使えません。
+      https://java.com/ja/download/manual.jsp (2019/05/02 現在)
+    2. 参考: [Prerequisites and Overview (Supported Platforms)](https://docs.sonarqube.org/latest/requirements/requirements/#header-3)
+    3. 参考: [SonarQubeの Java 11 対応状況](https://qiita.com/hayao_k/items/2cd81161f8dffd3a178b)
+    4. SonarSource(=SonarQubeの開発元)が方針転換してJava8を使った静的解析ができなくなりました。
+
+4. `JAVA_HOME` の環境変数を設定する
+  ※コマンドプロンプトで `set J` して `JAVA_HOME` が表示されない場合のみ
 
 	例
 
-	`set JAVA_HOME=C:\Program Files\Java\jre1.8.0_211`
-
-1. https://chocolatey.org/install#install-with-cmdexe を参考に chocolatey をインストールする。
+	`set JAVA_HOME=C:\Program Files\Java\jdk11.0.9`
 
 ### 解析手順の流れ (一般論)
 

--- a/ci/azure-pipelines/template.job.SonarQube.yml
+++ b/ci/azure-pipelines/template.job.SonarQube.yml
@@ -37,7 +37,6 @@ jobs:
   - script: choco install "msbuild-sonarqube-runner" -y
     displayName: install msbuild-sonarqube-runner
 
-  # specify java version.
   - task: JavaToolInstaller@0
     inputs:
       versionSpec: '11'

--- a/ci/azure-pipelines/template.job.SonarQube.yml
+++ b/ci/azure-pipelines/template.job.SonarQube.yml
@@ -37,6 +37,13 @@ jobs:
   - script: choco install "msbuild-sonarqube-runner" -y
     displayName: install msbuild-sonarqube-runner
 
+  # specify java version.
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: '11'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+
   # Build solution with SonarQube
   - script: build-sln.bat       $(BuildPlatform) $(Configuration)
     displayName: Build solution with SonarQube


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
Azure Pipelinesで実行するJavaを更新します。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - Azure Pipelines

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
今年の10月頃からSonarCloudの解析結果ページにJava8のサポートが終了する旨の警告が出ています。

> The version of Java (1.8.0_275) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 11. Read more [here](https://sonarcloud.io/documentation/appendices/end-of-support/)

リンクを開くと「2021/02/01からJava11未満のJDKで解析された解析結果の受付を停止するので、それまでにJDKを更新しておいてね」と書いてあります。

Azure PipelinesではデフォルトでいくつかのJava環境がインストールされています。
https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md
https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md

切替用タスクで簡単にJava環境を切り替えることができます。
https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/java-tool-installer?view=azure-devops


## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
* Java8のサポートが終了する前にJava11に切り替えることができます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
* Java8実行環境のサポートが終了するまではJava8で解析できるらしいので、現時点での切替は必須ではありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
仕様・動作の変更はありません。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
プログラムの挙動には影響を与えない変更です。
毎日 00:00JST に走る、artifactを生成しない静的解析専用のビルドに影響します。
通常のAzure Pipelinesビルドにも影響はありません。


## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
SonarCloud上で sakura-editor/sakura のクローンを解析し、このPRの修正によりJDK11が使われるようになってJavaバージョンに関する警告が消えることを確認しています。
https://sonarcloud.io/dashboard?id=berryzplus_sakura
※JDKのバージョンについての警告が消えています。
※検出されている警告が少ない原因は不明です。JRE8でもJDK11でも85でした。
  masterとソースが違うので30個くらい差が出るのは適切ですが、200個以上も差が出る原因は不明です。


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#510
#674
#1476
#1480

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
