### PR TITLE
GitHub Actionsでデバッグ版インストーラを作成しないようにする

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -72,55 +72,55 @@ jobs:
 
     - name: zipArtifacts
       run: zipArtifacts.bat ${{ matrix.platform }} ${{ matrix.config }}
-      if: ${{ matrix.config }} == 'Release'
+      if: ${{ matrix.config == 'Release' }}
       shell: cmd
 
     ## see https://github.com/actions/upload-artifact
     - name: Upload Installer
       uses: actions/upload-artifact@v2
-      if: ${{ matrix.config }} == 'Release'
+      if: ${{ matrix.config == 'Release' }}
       with:
         name: Installer ${{ matrix.platform }} ${{ matrix.config }}
         path: 'sakura-*-Installer.zip'
 
     - name: Upload Installer MD5
       uses: actions/upload-artifact@v2
-      if: ${{ matrix.config }} == 'Release'
+      if: ${{ matrix.config == 'Release' }}
       with:
         name: Installer MD5 ${{ matrix.platform }} ${{ matrix.config }}
         path: 'sakura-*-Installer.zip.md5'
 
     - name: Upload Exe
       uses: actions/upload-artifact@v2
-      if: ${{ matrix.config }} == 'Release'
+      if: ${{ matrix.config == 'Release' }}
       with:
         name: Exe ${{ matrix.platform }} ${{ matrix.config }}
         path: 'sakura-*-Exe.zip'
 
     - name: Upload Exe MD5
       uses: actions/upload-artifact@v2
-      if: ${{ matrix.config }} == 'Release'
+      if: ${{ matrix.config == 'Release' }}
       with:
         name: Exe MD5 ${{ matrix.platform }} ${{ matrix.config }}
         path: 'sakura-*-Exe.zip.md5'
 
     - name: Upload Log
       uses: actions/upload-artifact@v2
-      if: ${{ matrix.config }} == 'Release'
+      if: ${{ matrix.config == 'Release' }}
       with:
         name: Log ${{ matrix.platform }} ${{ matrix.config }}
         path: 'sakura-*-Log.zip'
 
     - name: Upload Asm
       uses: actions/upload-artifact@v2
-      if: ${{ matrix.config }} == 'Release'
+      if: ${{ matrix.config == 'Release' }}
       with:
         name: Asm ${{ matrix.platform }} ${{ matrix.config }}
         path: 'sakura-*-Asm.zip'
 
     - name: Upload Dev
       uses: actions/upload-artifact@v2
-      if: ${{ matrix.config }} == 'Release'
+      if: ${{ matrix.config == 'Release' }}
       with:
         name: Dev ${{ matrix.platform }} ${{ matrix.config }}
         path: 'sakura-*-Dev.zip'


### PR DESCRIPTION
# PR の目的

GitHub Actions（以下、GHAと呼称）でデバッグ版インストーラがビルドされないようにします。

## カテゴリ

- 不具合修正
- ビルド関連
 - GitHub Actions

## PR の背景

#1486 を受けてワークフローの設定ファイルを確認したところ、Release版でのみ実行されるはずのタスクがDebug版でも実行されるバグが見つかりました。
このバグを修正し、 #1403 の目的が達成されるようにします。

## PR のメリット

- GHAで生成されたDebug版インストーラが使用されるのを防ぐことができます。

## PR のデメリット (トレードオフとかあれば)

- Debug版インストーラが必要な場合は、自分でビルドしなければなりません。
  - このPRにより、すべてのCIビルドで生成されなくなります。

## 仕様・動作説明

if条件で式を使う場合、式全体を式構文（`${{ }}`）で括る必要がありました。
#1403 対応時、コンテキストだけを括ってしまったために判定が正しく行われず、その結果が常にtrueとなっていました。

## PR の影響範囲

- GitHub ActionsによるDebug版のビルド

## テスト内容

次のジョブで、アーティファクトの作成とアップロードを行うタスクがスキップされればOKだと思います。
- MSBuild (Debug, Win32)
- MSBuild (Debug, x64)

生成されるアーティファクトは変更前が28個、変更後が14個になります。

## 関連 issue, PR

https://github.com/sakura-editor/sakura/issues/1288#issuecomment-691463739
#1403
#1486

## 参考資料

[GitHub Actions のコンテキストおよび式の構文](https://docs.github.com/ja/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions)
