### PR TITLE
CWordParseのテストを追加する

### DIFF
--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -296,7 +296,7 @@ void CSearchAgent::CreateWordList(
 {
 	for( CLogicInt pos = CLogicInt(0); pos < nPatternLen; ) {
 		CLogicInt begin, end; // 検索語に含まれる単語?の posを基準とした相対位置。WhereCurrentWord_2()の仕様では空白文字列も単語に含まれる。
-		if( CWordParse::WhereCurrentWord_2( pszPattern + pos, nPatternLen - pos, CLogicInt(0), &begin, &end, NULL, NULL )
+		if( CWordParse::WhereCurrentWord_2( pszPattern + pos, nPatternLen - pos, CLogicInt(0), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol, &begin, &end, NULL, NULL )
 			&& begin == 0 && begin < end
 		) {
 			if( ! WCODE::IsWordDelimiter( pszPattern[pos] ) ) {
@@ -324,7 +324,7 @@ const wchar_t* CSearchAgent::SearchStringWord(
 	CLogicInt nNextWordFrom = CLogicInt(nIdxPos);
 	CLogicInt nNextWordFrom2;
 	CLogicInt nNextWordTo2;
-	while( CWordParse::WhereCurrentWord_2( pLine, CLogicInt(nLineLen), nNextWordFrom, &nNextWordFrom2, &nNextWordTo2, NULL, NULL ) ){
+	while( CWordParse::WhereCurrentWord_2( pLine, CLogicInt(nLineLen), nNextWordFrom, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol, &nNextWordFrom2, &nNextWordTo2, NULL, NULL ) ){
 		size_t nSize = searchWords.size();
 		for( size_t iSW = 0; iSW < nSize; ++iSW ) {
 			if( searchWords[iSW].second == nNextWordTo2 - nNextWordFrom2 ){
@@ -368,7 +368,7 @@ bool CSearchAgent::WhereCurrentWord(
 	const wchar_t*	pLine = pDocLine->GetDocLineStrWithEOL( &nLineLen );
 
 	/* 現在位置の単語の範囲を調べる */
-	return CWordParse::WhereCurrentWord_2( pLine, nLineLen, nIdx, pnIdxFrom, pnIdxTo, pcmcmWord, pcmcmWordLeft );
+	return CWordParse::WhereCurrentWord_2( pLine, nLineLen, nIdx, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol, pnIdxFrom, pnIdxTo, pcmcmWord, pcmcmWordLeft );
 }
 
 // 現在位置の左右の単語の先頭位置を調べる

--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -14,6 +14,7 @@ bool CWordParse::WhereCurrentWord_2(
 	const wchar_t*	pLine,			//!< [in]  調べるメモリ全体の先頭アドレス
 	CLogicInt		nLineLen,		//!< [in]  調べるメモリ全体の有効長
 	CLogicInt		nIdx,			//!< [in]  調査開始地点:pLineからの相対的な位置
+	bool			bEnableExtEol,	//!< [in]  Unicode改行文字を改行とみなすかどうか
 	CLogicInt*		pnIdxFrom,		//!< [out] 単語が見つかった場合は、単語の先頭インデックスを返す。
 	CLogicInt*		pnIdxTo,		//!< [out] 単語が見つかった場合は、単語の終端の次のバイトの先頭インデックスを返す。
 	CNativeW*		pcmcmWord,		//!< [out] 単語が見つかった場合は、現在単語を切り出して指定されたCMemoryオブジェクトに格納する。情報が不要な場合はNULLを指定する。
@@ -33,7 +34,7 @@ bool CWordParse::WhereCurrentWord_2(
 	}
 
 	// 現在位置の文字の種類によっては選択不可
-	if( WCODE::IsLineDelimiter(pLine[nIdx], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
+	if( WCODE::IsLineDelimiter(pLine[nIdx], bEnableExtEol) ){
 		return false;
 	}
 

--- a/sakura_core/parse/CWordParse.h
+++ b/sakura_core/parse/CWordParse.h
@@ -72,7 +72,8 @@ public:
 	static bool WhereCurrentWord_2(
 		const wchar_t*	pLine,			//[in]  調べるメモリ全体の先頭アドレス
 		CLogicInt		nLineLen,		//[in]  調べるメモリ全体の有効長
-		CLogicInt		nIdx,			//[out] 調査開始地点:pLineからの相対的な位置
+		CLogicInt		nIdx,			//[in]  調査開始地点:pLineからの相対的な位置
+		bool			bEnableExtEol,	//[in]  Unicode改行文字を改行とみなすかどうか
 		CLogicInt*		pnIdxFrom,		//[out] 単語が見つかった場合は、単語の先頭インデックスを返す。
 		CLogicInt*		pnIdxTo,		//[out] 単語が見つかった場合は、単語の終端の次のバイトの先頭インデックスを返す。
 		CNativeW*		pcmcmWord,		//[out] 単語が見つかった場合は、現在単語を切り出して指定されたCMemoryオブジェクトに格納する。情報が不要な場合はNULLを指定する。

--- a/sakura_core/view/CEditView_Search.cpp
+++ b/sakura_core/view/CEditView_Search.cpp
@@ -464,7 +464,7 @@ int CEditView::IsSearchString(
 	else if( m_sCurSearchOption.bWordOnly ) { // 単語検索
 		/* 指定位置の単語の範囲を調べる */
 		CLogicInt posWordHead, posWordEnd;
-		if( ! CWordParse::WhereCurrentWord_2( cStr.GetPtr(), CLogicInt(cStr.GetLength()), nPos, &posWordHead, &posWordEnd, NULL, NULL ) ) {
+		if( ! CWordParse::WhereCurrentWord_2( cStr.GetPtr(), CLogicInt(cStr.GetLength()), nPos, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol, &posWordHead, &posWordEnd, NULL, NULL ) ) {
 			return 0; // 指定位置に単語が見つからなかった。
  		}
 		if( nPos != posWordHead ) {
@@ -481,7 +481,7 @@ int CEditView::IsSearchString(
 		const wchar_t* const searchKeyEnd = m_strCurSearchKey.data() + m_strCurSearchKey.size();
 		for( const wchar_t* p = m_strCurSearchKey.data(); p < searchKeyEnd; ) {
 			CLogicInt begin, end; // 検索語に含まれる単語?の位置。WhereCurrentWord_2()の仕様では空白文字列も単語に含まれる。
-			if( CWordParse::WhereCurrentWord_2( p, CLogicInt(searchKeyEnd - p), CLogicInt(0), &begin, &end, NULL, NULL )
+			if( CWordParse::WhereCurrentWord_2( p, CLogicInt(searchKeyEnd - p), CLogicInt(0), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol, &begin, &end, NULL, NULL )
 				&& begin == 0 && begin < end
 			) {
 				if( ! WCODE::IsWordDelimiter( *p ) ) {

--- a/tests/unittests/test-cwordparse.cpp
+++ b/tests/unittests/test-cwordparse.cpp
@@ -1,0 +1,310 @@
+﻿/*! @file */
+/*
+        Copyright (C) 2018-2020 Sakura Editor Organization
+
+        This software is provided 'as-is', without any express or implied
+        warranty. In no event will the authors be held liable for any damages
+        arising from the use of this software.
+
+        Permission is granted to anyone to use this software for any purpose,
+        including commercial applications, and to alter it and redistribute it
+        freely, subject to the following restrictions:
+
+                1. The origin of this software must not be misrepresented;
+                   you must not claim that you wrote the original software.
+                   If you use this software in a product, an acknowledgment
+                   in the product documentation would be appreciated but is
+                   not required.
+
+                2. Altered source versions must be plainly marked as such,
+                   and must not be misrepresented as being the original
+   software.
+
+                3. This notice may not be removed or altered from any source
+                   distribution.
+*/
+
+#include <gtest/gtest.h>
+#include "parse/CWordParse.h"
+
+#include <cstring>
+#include <iostream>
+#include <string_view>
+#include "charset/charcode.h"
+
+std::ostream& operator<<(std::ostream& os, ECharKind kind)
+{
+	static const char* s[] = {"CK_NUL", "CK_TAB", "CK_CR", "CK_LF", "CK_CTR", "CK_SPACE",
+	   	"CK_CSYM", "CK_KATA", "CK_LATIN", "CK_UDEF", "CK_ETC", "CK_ZEN_SPACE",
+	   	"CK_ZEN_NOBASU", "CK_ZEN_DAKU", "CK_ZEN_CSYM", "CK_ZEN_KIGO", "CK_HIRA",
+	   	"CK_ZEN_KATA", "CK_GREEK", "CK_ZEN_ROS", "CK_ZEN_SKIGO", "CK_ZEN_ETC"};
+	return os << s[kind];
+}
+
+ECharKind WhatKindOfChar(wchar_t ch)
+{
+	return CWordParse::WhatKindOfChar(&ch, 1, 0);
+}
+
+void ExpectEqualForEachChars(ECharKind kind, std::wstring_view s)
+{
+	for (wchar_t ch : s) {
+		EXPECT_EQ(kind, WhatKindOfChar(ch));
+	}
+}
+
+TEST(WhatKindOfChar, Null)
+{
+	EXPECT_EQ(CK_NULL, CWordParse::WhatKindOfChar(L"", 0, 0));
+}
+
+TEST(WhatKindOfChar, AsciiChars)
+{
+	ExpectEqualForEachChars(CK_CTRL, L"\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f");
+	EXPECT_EQ(CK_TAB, WhatKindOfChar(L'\t'));
+	EXPECT_EQ(CK_LF, WhatKindOfChar(L'\n'));
+	EXPECT_EQ(CK_CR, WhatKindOfChar(L'\r'));
+	EXPECT_EQ(CK_SPACE, WhatKindOfChar(L' '));
+	ExpectEqualForEachChars(CK_ETC, L"!\"%&'()*+,-./:;<=>?[]^`{|}~");
+	ExpectEqualForEachChars(CK_UDEF, L"#$@\\");
+	ExpectEqualForEachChars(CK_CSYM, L"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz");
+}
+
+TEST(WhatKindOfChar, HankakuKana)
+{
+	ExpectEqualForEachChars(CK_KATA, L"｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞﾟ");
+}
+
+TEST(WhatKindOfChar, Latin1)
+{
+	ExpectEqualForEachChars(CK_LATIN, L"ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ");
+}
+
+TEST(WhatKindOfChar, ZenkakuSpace)
+{
+	EXPECT_EQ(CK_ZEN_SPACE, WhatKindOfChar(L'　'));
+}
+
+TEST(WhatKindOfChar, Nobasu)
+{
+	EXPECT_EQ(CK_ZEN_NOBASU, WhatKindOfChar(L'ー'));
+}
+
+TEST(WhatKindOfChar, Dakuten)
+{
+	EXPECT_EQ(CK_ZEN_DAKU, WhatKindOfChar(L'゛'));
+	EXPECT_EQ(CK_ZEN_DAKU, WhatKindOfChar(L'゜'));
+}
+
+TEST(WhatKindOfChar, ZenkakuSymbols)
+{
+	ExpectEqualForEachChars(CK_ZEN_CSYM, L"＿０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｔｓｔｕｖｗｘｙｚ");
+}
+
+TEST(WhatKindOfChar, ZenkakuKigou)
+{
+	ExpectEqualForEachChars(CK_ZEN_KIGO, L"、。，．・：；？！´｀¨＾￣〃―‐／＼～∥｜…‥‘’“”（）〔〕［］｛｝〈〉《》「」『』【】＋－±×÷＝≠＜＞≦≧∞∴♂♀°′″℃￥＄￠￡％＃＆＊＠§☆★○●◎◇◆□■△▲▽▼※〒→←↑↓〓∈∋⊆⊇⊂⊃∪∩∧∨￢⇒⇔∀∃∠⊥⌒∂∇≡≒≪≫√∽∝∵∫∬Å‰♯♭♪†‡¶◯");
+}
+
+TEST(WhatKindOfChar, Hiragana)
+{
+	ExpectEqualForEachChars(CK_HIRA, L"ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろゎわゐゑをんゔゕゖゝゞ");
+}
+
+TEST(WhatKindOfChar, Katakana)
+{
+	ExpectEqualForEachChars(CK_ZEN_KATA, L"ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロヮワヰヱヲンヴヵヶヷヸヹヺヽヾ");
+}
+
+TEST(WhatKindOfChar, Greek)
+{
+	ExpectEqualForEachChars(CK_GREEK, L"ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩΪΫάέήίΰαβγδεζηθικλμνξοπρςστυφχψω");
+}
+
+TEST(WhatKindOfChar, Cyrillic)
+{
+	ExpectEqualForEachChars(CK_ZEN_ROS, L"ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѠѡѢѣѤѥѦѧѨѩѪѫѬѭѮѯѰѱѲѳѴѵѶѷѸѹѺѻѼѽѾѿҀҁ҂҃҄҅҆҇҈҉ҊҋҌҍҎҏҐґҒғҔҕҖҗҘҙҚқҜҝҞҟҠҡҢңҤҥҦҧҨҩҪҫҬҭҮүҰұҲҳҴҵҶҷҸҹҺһҼҽҾҿӀӁӂӃӄӅӆӇӈӉӊӋӌӍӎӏӐӑӒӓӔӕӖӗӘәӚӛӜӝӞӟӠӡӢӣӤӥӦӧӨөӪӫӬӭӮӯӰӱӲӳӴӵӶӷӸӹӺӻӼӽӾӿԀԁԂԃԄԅԆԇԈԉԊԋԌԍԎԏԐԑԒԓԔԕԖԗԘԙԚԛԜԝԞԟԠԡԢԣԤԥԦԧԨԩԪԫԬԭԮԯ");
+	ExpectEqualForEachChars(CK_ZEN_ROS, L"\x2de0\x2de1\x2de2\x2de3\x2de4\x2de5\x2de6\x2de7\x2de8\x2de9\x2dea\x2deb\x2dec\x2ded\x2dee\x2def\x2df0\x2df1\x2df2\x2df3\x2df4\x2df5\x2df6\x2df7\x2df8\x2df9\x2dfa\x2dfb\x2dfc\x2dfd\x2dfe\x2dff");
+	ExpectEqualForEachChars(CK_ZEN_ROS, L"ꙀꙁꙂꙃꙄꙅꙆꙇꙈꙉꙊꙋꙌꙍꙎꙏꙐꙑꙒꙓꙔꙕꙖꙗꙘꙙꙚꙛꙜꙝꙞꙟꙠꙡꙢꙣꙤꙥꙦꙧꙨꙩꙪꙫꙬꙭꙮ꙯꙰꙱꙲꙳ꙴꙵꙶꙷꙸꙹꙺꙻ꙼꙽꙾ꙿꚀꚁꚂꚃꚄꚅꚆꚇꚈꚉꚊꚋꚌꚍꚎꚏꚐꚑꚒꚓꚔꚕꚖꚗꚘꚙꚚꚛꚜꚝꚞꚟ");
+}
+
+TEST(WhatKindOfChar, BoxDrawing)
+{
+	ExpectEqualForEachChars(CK_ZEN_SKIGO, L"─━│┃┄┅┆┇┈┉┊┋┌┍┎┏┐┑┒┓└┕┖┗┘┙┚┛├┝┞┟┠┡┢┣┤┥┦┧┨┩┪┫┬┭┮┯┰┱┲┳┴┵┶┷┸┹┺┻┼┽┾┿╀╁╂╃╄╅╆╇╈╉╊╋╌╍╎╏═║╒╓╔╕╖╗╘╙╚╛╜╝╞╟╠╡╢╣╤╥╦╧╨╩╪╫╬╭╮╯╰╱╲╳╴╵╶╷╸╹╺╻╼╽╾╿");
+}
+
+TEST(WhatKindOfChar, SurrogatePairs)
+{
+	EXPECT_EQ(CK_ETC, CWordParse::WhatKindOfChar(L"🌸", 2, 0));
+	EXPECT_EQ(CK_ZEN_ETC, CWordParse::WhatKindOfChar(L"𠮷", 2, 0));
+}
+
+TEST(WhatKindOfTwoChars, ReturnsSameKindIfTwoKindsAreIdentical)
+{
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars(CK_HIRA, CK_HIRA));
+	EXPECT_EQ(CK_LATIN, CWordParse::WhatKindOfTwoChars(CK_LATIN, CK_LATIN));
+	EXPECT_EQ(CK_UDEF, CWordParse::WhatKindOfTwoChars(CK_UDEF, CK_UDEF));
+	EXPECT_EQ(CK_CTRL, CWordParse::WhatKindOfTwoChars(CK_CTRL, CK_CTRL));
+}
+
+TEST(WhatKindOfTwoChars, MergesZenkakuNobasuIntoKanas)
+{
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars(CK_ZEN_NOBASU, CK_HIRA));
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars(CK_HIRA, CK_ZEN_NOBASU));
+	EXPECT_EQ(CK_ZEN_KATA, CWordParse::WhatKindOfTwoChars(CK_ZEN_NOBASU, CK_ZEN_KATA));
+	EXPECT_EQ(CK_ZEN_KATA, CWordParse::WhatKindOfTwoChars(CK_ZEN_KATA, CK_ZEN_NOBASU));
+}
+
+TEST(WhatKindOfTwoChars, MergesZenkakuDakutenIntoKanas)
+{
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars(CK_ZEN_DAKU, CK_HIRA));
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars(CK_HIRA, CK_ZEN_DAKU));
+	EXPECT_EQ(CK_ZEN_KATA, CWordParse::WhatKindOfTwoChars(CK_ZEN_DAKU, CK_ZEN_KATA));
+	EXPECT_EQ(CK_ZEN_KATA, CWordParse::WhatKindOfTwoChars(CK_ZEN_KATA, CK_ZEN_DAKU));
+}
+
+TEST(WhatKindOfTwoChars, MergesNobasuAndDakutenTogether)
+{
+	EXPECT_EQ(CK_ZEN_NOBASU, CWordParse::WhatKindOfTwoChars(CK_ZEN_DAKU, CK_ZEN_NOBASU));
+	EXPECT_EQ(CK_ZEN_DAKU, CWordParse::WhatKindOfTwoChars(CK_ZEN_NOBASU, CK_ZEN_DAKU));
+}
+
+TEST(WhatKindOfTwoChars, TreatsLatinAsAlphanumeric)
+{
+	EXPECT_EQ(CK_CSYM, CWordParse::WhatKindOfTwoChars(CK_CSYM, CK_LATIN));
+	EXPECT_EQ(CK_CSYM, CWordParse::WhatKindOfTwoChars(CK_LATIN, CK_CSYM));
+}
+
+TEST(WhatKindOfTwoChars, TreatsUserDefinedAsEtc)
+{
+	EXPECT_EQ(CK_ETC, CWordParse::WhatKindOfTwoChars(CK_ETC, CK_UDEF));
+	EXPECT_EQ(CK_ETC, CWordParse::WhatKindOfTwoChars(CK_UDEF, CK_ETC));
+}
+
+TEST(WhatKindOfTwoChars, TreatsControlCharsAsEtc)
+{
+	EXPECT_EQ(CK_ETC, CWordParse::WhatKindOfTwoChars(CK_ETC, CK_CTRL));
+	EXPECT_EQ(CK_ETC, CWordParse::WhatKindOfTwoChars(CK_CTRL, CK_ETC));
+}
+
+TEST(WhatKindOfTwoChars, ReturnsNullOnIncompatibleKinds)
+{
+	EXPECT_EQ(CK_NULL, CWordParse::WhatKindOfTwoChars(CK_HIRA, CK_LATIN));
+}
+
+TEST(WhatKindOfTwoChars4KW, ReturnsSameKindIfTwoKindsAreIdentical)
+{
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars4KW(CK_HIRA, CK_HIRA));
+	EXPECT_EQ(CK_LATIN, CWordParse::WhatKindOfTwoChars4KW(CK_LATIN, CK_LATIN));
+	EXPECT_EQ(CK_UDEF, CWordParse::WhatKindOfTwoChars4KW(CK_UDEF, CK_UDEF));
+	EXPECT_EQ(CK_CTRL, CWordParse::WhatKindOfTwoChars4KW(CK_CTRL, CK_CTRL));
+}
+
+TEST(WhatKindOfTwoChars4KW, MergesZenkakuNobasuIntoKanas)
+{
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars4KW(CK_ZEN_NOBASU, CK_HIRA));
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars4KW(CK_HIRA, CK_ZEN_NOBASU));
+	EXPECT_EQ(CK_ZEN_KATA, CWordParse::WhatKindOfTwoChars4KW(CK_ZEN_NOBASU, CK_ZEN_KATA));
+	EXPECT_EQ(CK_ZEN_KATA, CWordParse::WhatKindOfTwoChars4KW(CK_ZEN_KATA, CK_ZEN_NOBASU));
+}
+
+TEST(WhatKindOfTwoChars4KW, MergesZenkakuDakutenIntoKanas)
+{
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars4KW(CK_ZEN_DAKU, CK_HIRA));
+	EXPECT_EQ(CK_HIRA, CWordParse::WhatKindOfTwoChars4KW(CK_HIRA, CK_ZEN_DAKU));
+	EXPECT_EQ(CK_ZEN_KATA, CWordParse::WhatKindOfTwoChars4KW(CK_ZEN_DAKU, CK_ZEN_KATA));
+	EXPECT_EQ(CK_ZEN_KATA, CWordParse::WhatKindOfTwoChars4KW(CK_ZEN_KATA, CK_ZEN_DAKU));
+}
+
+TEST(WhatKindOfTwoChars4KW, MergesNobasuAndDakutenTogether)
+{
+	EXPECT_EQ(CK_ZEN_NOBASU, CWordParse::WhatKindOfTwoChars4KW(CK_ZEN_DAKU, CK_ZEN_NOBASU));
+	EXPECT_EQ(CK_ZEN_DAKU, CWordParse::WhatKindOfTwoChars4KW(CK_ZEN_NOBASU, CK_ZEN_DAKU));
+}
+
+TEST(WhatKindOfTwoChars4KW, TreatsLatinAsAlphanumeric)
+{
+	EXPECT_EQ(CK_CSYM, CWordParse::WhatKindOfTwoChars4KW(CK_CSYM, CK_LATIN));
+	EXPECT_EQ(CK_CSYM, CWordParse::WhatKindOfTwoChars4KW(CK_LATIN, CK_CSYM));
+}
+
+TEST(WhatKindOfTwoChars4KW, TreatsUserDefinedAsAlphanumeric)
+{
+	EXPECT_EQ(CK_CSYM, CWordParse::WhatKindOfTwoChars4KW(CK_CSYM, CK_UDEF));
+	EXPECT_EQ(CK_CSYM, CWordParse::WhatKindOfTwoChars4KW(CK_UDEF, CK_CSYM));
+}
+
+TEST(WhatKindOfTwoChars4KW, LeavesControlCharsAsIs)
+{
+	EXPECT_EQ(CK_NULL, CWordParse::WhatKindOfTwoChars4KW(CK_ETC, CK_CTRL));
+	EXPECT_EQ(CK_NULL, CWordParse::WhatKindOfTwoChars4KW(CK_CTRL, CK_ETC));
+}
+
+TEST(WhatKindOfTwoChars4KW, ReturnsNullOnIncompatibleKinds)
+{
+	EXPECT_EQ(CK_NULL, CWordParse::WhatKindOfTwoChars4KW(CK_HIRA, CK_LATIN));
+}
+
+TEST(SearchPrevWordPosition, ReturnsFalseWhenIndexIsZero)
+{
+	EXPECT_FALSE(CWordParse::SearchPrevWordPosition(L"",
+				CLogicInt(0), CLogicInt(0), nullptr, FALSE));
+}
+
+TEST(SearchPrevWordPosition, RespectsBooleanArgument)
+{
+	CLogicInt columnNew;
+	bool result;
+	result = CWordParse::SearchPrevWordPosition(L" sakura !",
+			CLogicInt(9), CLogicInt(8), &columnNew, FALSE);
+	EXPECT_TRUE(result);
+	EXPECT_EQ(1, columnNew);
+
+	result = CWordParse::SearchPrevWordPosition(L" sakura !",
+			CLogicInt(9), CLogicInt(8), &columnNew, TRUE);
+	EXPECT_TRUE(result);
+	EXPECT_EQ(7, columnNew);
+}
+
+TEST(SearchNextWordPosition, ReturnsFalseWhenIndexIsAtEndOfString)
+{
+	EXPECT_FALSE(CWordParse::SearchNextWordPosition(L"",
+				CLogicInt(0), CLogicInt(0), nullptr, FALSE));
+}
+
+TEST(SearchNextWordPosition, StopsAtIncompatibleKinds)
+{
+	CLogicInt columnNew;
+	EXPECT_TRUE(CWordParse::SearchNextWordPosition(L"sakura!",
+				CLogicInt(7), CLogicInt(0), &columnNew, FALSE));
+	EXPECT_EQ(6, columnNew);
+}
+
+TEST(SearchNextWordPosition, RespectsBooleanArgument)
+{
+	CLogicInt columnNew;
+	bool result;
+	result = CWordParse::SearchNextWordPosition(L"sakura editor",
+			CLogicInt(13), CLogicInt(0), &columnNew, FALSE);
+	EXPECT_TRUE(result);
+	EXPECT_EQ(7, columnNew);
+
+	result = CWordParse::SearchNextWordPosition(L"sakura editor",
+			CLogicInt(13), CLogicInt(0), &columnNew, TRUE);
+	EXPECT_TRUE(result);
+	EXPECT_EQ(6, columnNew);
+}
+
+TEST(SearchNextWordPosition4KW, ReturnsFalseWhenIndexIsAtEndOfString)
+{
+	EXPECT_FALSE(CWordParse::SearchNextWordPosition4KW(L"",
+				CLogicInt(0), CLogicInt(0), nullptr, FALSE));
+}
+
+TEST(SearchNextWordPosition4KW, StopsAtIncompatibleKinds)
+{
+	CLogicInt columnNew;
+	EXPECT_TRUE(CWordParse::SearchNextWordPosition4KW(L"@sakura!",
+				CLogicInt(8), CLogicInt(0), &columnNew, FALSE));
+	EXPECT_EQ(7, columnNew);
+}

--- a/tests/unittests/test-cwordparse.cpp
+++ b/tests/unittests/test-cwordparse.cpp
@@ -135,8 +135,11 @@ TEST(WhatKindOfChar, BoxDrawing)
 
 TEST(WhatKindOfChar, SurrogatePairs)
 {
-	EXPECT_EQ(CK_ETC, CWordParse::WhatKindOfChar(L"🌸", 2, 0));
-	EXPECT_EQ(CK_ZEN_ETC, CWordParse::WhatKindOfChar(L"𠮷", 2, 0));
+//	EXPECT_EQ(CK_ETC, CWordParse::WhatKindOfChar(L"🌸", 2, 0));
+//	EXPECT_EQ(CK_ZEN_ETC, CWordParse::WhatKindOfChar(L"𠮷", 2, 0));
+	EXPECT_EQ(CK_ETC, CWordParse::WhatKindOfChar(L"\xd83c\xdf38", 2, 0));
+	EXPECT_EQ(CK_ZEN_ETC, CWordParse::WhatKindOfChar(L"\xd842\xdfb7", 2, 0));
+
 }
 
 TEST(WhatKindOfTwoChars, ReturnsSameKindIfTwoKindsAreIdentical)

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -112,6 +112,7 @@
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />
     <ClCompile Include="test-cprofile.cpp" />
+    <ClCompile Include="test-cwordparse.cpp" />
     <ClCompile Include="test-editinfo.cpp" />
     <ClCompile Include="test-file.cpp" />
     <ClCompile Include="test-grepinfo.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -83,6 +83,9 @@
     <ClCompile Include="test-file.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-cwordparse.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
# PR の目的

`CWordParse`の関数群に対するテストを追加します。

## カテゴリ

- その他の問題

## PR の背景

#1470 で変更を加えた`CWordParse`に対してテストを追加するPRです。
## PR のメリット

- `CWordParse::WhatKindOfChar`や`CWordParse::WhatKindOfTwoChars`が何を判定しているかがテストコードに明文化されます。

## PR のデメリット (トレードオフとかあれば)

- `CWordParse::WhereCurrentWord_2`の引数が増え、呼び出しが煩雑になります。

## 仕様・動作説明

- `CWordParse::WhereCurrentWord_2`が共有データに依存していたため、データを関数の引数として受け取るよう変更し、呼び出し側に依存関係を移動しています。単純に移動しただけですからバグの混入は考えづらいのですが、呼び出しているコードパスが関係する機能について念のための手動テストが必要になるかもしれません。
- `CWordParse::WhatKindOfChar`のテスト対象は条件式で判定している既知のコードポイントに限定しています。不明なコードポイントの文字幅をGDIに問い合わせるコードパスが存在しますが、テスト対象に含めるとグローバル変数であるフォントキャッシュの初期化が必要になること、やることが単体テストからかけ離れていくことを理由として無視しています。

## PR の影響範囲

`CWordParse::WhereCurrentWord_2`内で参照していた[共通設定]→[編集]→[改行コードNEL, LS, PSを有効にする]フラグを関数外に移動したため、各機能に関連するコードが壊れている可能性があります。
- ダブルクリックでの単語選択
- ダブルクリック＆ドラッグによる単語単位の選択
- 単語単位の検索
- 検索ダイアログの初期文字列（現在キャレット位置の単語が自動で入力される）
- [編集]→[高度な操作]以下の単語関連機能
- 入力補完（Ctrl+Space）

（他にもあるかも…。上記が代表例だと思いますが）

## テスト内容

上記の各機能の挙動に異常がないことを確認します。

## 関連 issue, PR

#1470 コンボボックスに Ctrl+Backspace による単語削除機能を追加する
