### PR TITLE
GetDateTimeFormatの入出力をWCHAR*からstd::wstring(_view)に変更する

### DIFF
--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -457,11 +457,9 @@ bool CBackupAgent::FormatBackUpPath(
 			break;
 		case 2:	//	現在の日付，時刻
 		default:
-			{
-				// 2012.12.26 aroka	詳細設定のファイル保存日時と現在時刻で書式を合わせる
-				// 2016.07.28 UTC→ローカル時刻に変更
-				::GetLocalTime( &time );			// 現在時刻を取得
-			}
+			// 2012.12.26 aroka	詳細設定のファイル保存日時と現在時刻で書式を合わせる
+			// 2016.07.28 UTC→ローカル時刻に変更
+			::GetLocalTime( &time );			// 現在時刻を取得
 			break;
 		}
 
@@ -502,6 +500,9 @@ bool CBackupAgent::FormatBackUpPath(
 				while( *q ){
 					if( *q==L'$' ){
 						++q;
+						if( *q == L'\0' ){
+							break;
+						}
 						if( isdigit(*q) ){
 							q[-1] = L'\0';
 							wcscat( szNewPath, q2 );

--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -445,34 +445,27 @@ bool CBackupAgent::FormatBackUpPath(
 		}
 
 	}else{ // 詳細設定使用する
-		std::optional<std::wstring> dateTimeString;
-
+		SYSTEMTIME time = {};
 		switch( bup_setting.GetBackupTypeAdv() ){
 		case 4:	//	ファイルの日付，時刻
 			{
 				// 2005.10.20 ryoji FindFirstFileを使うように変更
 				CFileTime ctimeLastWrite;
 				GetLastWriteTimestamp( target_file, &ctimeLastWrite );
-				dateTimeString = GetDateTimeFormat( (const WCHAR*)bup_setting.m_szBackUpPathAdvanced, ctimeLastWrite.GetSYSTEMTIME() );
-				if( !dateTimeString ){
-					return false;
-				}
+				time = ctimeLastWrite.GetSYSTEMTIME();
 			}
 			break;
 		case 2:	//	現在の日付，時刻
 		default:
 			{
 				// 2012.12.26 aroka	詳細設定のファイル保存日時と現在時刻で書式を合わせる
-				SYSTEMTIME	SystemTime;
 				// 2016.07.28 UTC→ローカル時刻に変更
-				::GetLocalTime(&SystemTime);			// 現在時刻を取得
-				dateTimeString = GetDateTimeFormat( (const WCHAR*)bup_setting.m_szBackUpPathAdvanced, SystemTime );
-				if( !dateTimeString ){
-					return false;
-				}
+				::GetLocalTime( &time );			// 現在時刻を取得
 			}
 			break;
 		}
+
+		std::wstring formatString = GetDateTimeFormat( bup_setting.m_szBackUpPathAdvanced.c_str(), time );
 
 		{
 			// make keys
@@ -504,7 +497,7 @@ bool CBackupAgent::FormatBackUpPath(
 			{
 				// $0-$9を置換
 				//wcscpy( szNewPath, L"" );
-				WCHAR *q = dateTimeString.value().data();
+				WCHAR *q = formatString.data();
 				WCHAR *q2 = q;
 				while( *q ){
 					if( *q==L'$' ){

--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -445,7 +445,7 @@ bool CBackupAgent::FormatBackUpPath(
 		}
 
 	}else{ // 詳細設定使用する
-		WCHAR szFormat[1024];
+		std::optional<std::wstring> dateTimeString;
 
 		switch( bup_setting.GetBackupTypeAdv() ){
 		case 4:	//	ファイルの日付，時刻
@@ -453,7 +453,8 @@ bool CBackupAgent::FormatBackUpPath(
 				// 2005.10.20 ryoji FindFirstFileを使うように変更
 				CFileTime ctimeLastWrite;
 				GetLastWriteTimestamp( target_file, &ctimeLastWrite );
-				if( !GetDateTimeFormat( szFormat, _countof(szFormat), bup_setting.m_szBackUpPathAdvanced , ctimeLastWrite.GetSYSTEMTIME() ) ){
+				dateTimeString = GetDateTimeFormat( (const WCHAR*)bup_setting.m_szBackUpPathAdvanced, ctimeLastWrite.GetSYSTEMTIME() );
+				if( !dateTimeString ){
 					return false;
 				}
 			}
@@ -465,8 +466,8 @@ bool CBackupAgent::FormatBackUpPath(
 				SYSTEMTIME	SystemTime;
 				// 2016.07.28 UTC→ローカル時刻に変更
 				::GetLocalTime(&SystemTime);			// 現在時刻を取得
-
-				if( !GetDateTimeFormat( szFormat, _countof(szFormat), bup_setting.m_szBackUpPathAdvanced , SystemTime ) ){
+				dateTimeString = GetDateTimeFormat( (const WCHAR*)bup_setting.m_szBackUpPathAdvanced, SystemTime );
+				if( !dateTimeString ){
 					return false;
 				}
 			}
@@ -503,8 +504,8 @@ bool CBackupAgent::FormatBackUpPath(
 			{
 				// $0-$9を置換
 				//wcscpy( szNewPath, L"" );
-				WCHAR *q= szFormat;
-				WCHAR *q2 = szFormat;
+				WCHAR *q = dateTimeString.value().data();
+				WCHAR *q2 = q;
 				while( *q ){
 					if( *q==L'$' ){
 						++q;

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -269,7 +269,7 @@ bool CDocFileOperation::SaveFileDialog(
 	if( pSaveInfo->cFilePath[0] == L'\0' ){
 		SYSTEMTIME localTime = {};
 		::GetLocalTime( &localTime );
-		auto dateTimeString = GetDateTimeFormat( L"_%Y%m%d_%H%M%S", localTime ).value_or( L"" );
+		auto dateTimeString = GetDateTimeFormat( L"_%Y%m%d_%H%M%S", localTime );
 		const EditNode* node = CAppNodeManager::getInstance()->GetEditNode( m_pcDocRef->m_pcEditWnd->GetHwnd() );
 		const int nId = (node != NULL && 0 < node->m_nId) ? node->m_nId : 0;
 		auto_sprintf_s( pSaveInfo->cFilePath, pSaveInfo->cFilePath.GetBufferCount(), L"%s%.0d%s", LS(STR_NO_TITLE2), nId, dateTimeString.c_str() );

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -269,14 +269,10 @@ bool CDocFileOperation::SaveFileDialog(
 	if( pSaveInfo->cFilePath[0] == L'\0' ){
 		SYSTEMTIME localTime = {};
 		::GetLocalTime( &localTime );
-		WCHAR dateTimeString[20] = {};
-		if( !GetDateTimeFormat( dateTimeString, _countof(dateTimeString), L"_%Y%m%d_%H%M%S", localTime ) ){
-			dateTimeString[0] = L'\0';
-		}
-
+		auto dateTimeString = GetDateTimeFormat( L"_%Y%m%d_%H%M%S", localTime ).value_or( L"" );
 		const EditNode* node = CAppNodeManager::getInstance()->GetEditNode( m_pcDocRef->m_pcEditWnd->GetHwnd() );
 		const int nId = (node != NULL && 0 < node->m_nId) ? node->m_nId : 0;
-		auto_sprintf_s( pSaveInfo->cFilePath, pSaveInfo->cFilePath.GetBufferCount(), L"%s%.0d%s", LS(STR_NO_TITLE2), nId, dateTimeString );
+		auto_sprintf_s( pSaveInfo->cFilePath, pSaveInfo->cFilePath.GetBufferCount(), L"%s%.0d%s", LS(STR_NO_TITLE2), nId, dateTimeString.c_str() );
 	}
 
 	// ダイアログを表示

--- a/sakura_core/util/format.cpp
+++ b/sakura_core/util/format.cpp
@@ -32,7 +32,7 @@
 	@param[in] systime 書式化したい日時
 	@return 書式変換後の文字列
 
-	@note 書式文字列で使用できる変換指定子
+	@note 書式文字列では以下の変換指定子が使用できます。
 	@li "%Y" 西暦
 	@li "%y" 下2桁の西暦
 	@li "%m" 2桁の月
@@ -40,38 +40,39 @@
 	@li "%H" 2桁の時
 	@li "%M" 2桁の分
 	@li "%S" 2桁の秒
+	@note 書式文字列は末尾または最初のnull文字までを変換対象とします。
 */
-std::optional<std::wstring> GetDateTimeFormat( std::wstring_view format, const SYSTEMTIME& systime )
+std::wstring GetDateTimeFormat( std::wstring_view format, const SYSTEMTIME& systime )
 {
 	std::wstring result;
 	wchar_t str[6] = {};
-	bool esc = false;
+	bool inSpecifier = false;
 
 	result.reserve( format.length() * 2 );
 
 	for( const auto f : format ){
-		if( esc ){
-			esc = false;
+		if( inSpecifier ){
+			inSpecifier = false;
 			if( f == L'Y' ){
-				(void)wsprintf( str, L"%d", systime.wYear );
+				swprintf( str, _countof(str), L"%d", systime.wYear );
 			}else if( f == L'y' ){
-				(void)wsprintf( str, L"%02d", systime.wYear % 100 );
+				swprintf( str, _countof(str), L"%02d", systime.wYear % 100 );
 			}else if( f == L'm' ){
-				(void)wsprintf( str, L"%02d", systime.wMonth );
+				swprintf( str, _countof(str), L"%02d", systime.wMonth );
 			}else if( f == L'd' ){
-				(void)wsprintf( str, L"%02d", systime.wDay );
+				swprintf( str, _countof(str), L"%02d", systime.wDay );
 			}else if( f == L'H' ){
-				(void)wsprintf( str, L"%02d", systime.wHour );
+				swprintf( str, _countof(str), L"%02d", systime.wHour );
 			}else if( f == L'M' ){
-				(void)wsprintf( str, L"%02d", systime.wMinute );
+				swprintf( str, _countof(str), L"%02d", systime.wMinute );
 			}else if( f == L'S' ){
-				(void)wsprintf( str, L"%02d", systime.wSecond );
+				swprintf( str, _countof(str), L"%02d", systime.wSecond );
 			}else{
-				(void)wsprintf( str, L"%c", f );
+				swprintf( str, _countof(str), L"%c", f );
 			}
 			result.append( str );
 		}else if( f == L'%' ){
-			esc = true;
+			inSpecifier = true;
 		}else if( f == L'\0' ){
 			break;
 		}else{

--- a/sakura_core/util/format.cpp
+++ b/sakura_core/util/format.cpp
@@ -26,90 +26,60 @@
 #include "StdAfx.h"
 #include "format.h"
 
-/*!	日時をフォーマット
+/*!	書式文字列に従い日時を変換
 
-	@param[out] szResult 書式変換後の文字列
-	@param[in] size szResultに格納可能な文字数(ヌル文字を含む)
-	@param[in] format 書式
+	@param[in] format 書式文字列
 	@param[in] systime 書式化したい日時
-	@retval true  書式文字列の変換が完了
-	@retval false 書式文字列の変換が一部または全部失敗
+	@return 書式変換後の文字列
 
-	@note  %Y %y %m %d %H %M %S の変換に対応
-
-	@author aroka
-	@date 2005.11.21 新規
+	@note 書式文字列で使用できる変換指定子
+	@li "%Y" 西暦
+	@li "%y" 下2桁の西暦
+	@li "%m" 2桁の月
+	@li "%d" 2桁の日
+	@li "%H" 2桁の時
+	@li "%M" 2桁の分
+	@li "%S" 2桁の秒
 */
-bool GetDateTimeFormat( WCHAR* szResult, size_t size, const WCHAR* format, const SYSTEMTIME& systime )
+std::optional<std::wstring> GetDateTimeFormat( std::wstring_view format, const SYSTEMTIME& systime )
 {
-	WCHAR szTime[10] = {};
-	const WCHAR *p = format;
-	WCHAR *q = szResult;
-	bool ret = false;
+	std::wstring result;
+	wchar_t str[6] = {};
+	bool esc = false;
 
-	if( szResult == NULL || size == 0 || format == NULL ){
-		return false;
-	}
+	result.reserve( format.length() * 2 );
 
-	while( *p ){
-		int timeLen = -1;
-		if( *p == L'%' ){
-			++p;
-
-			if( *p == L'\0' ){
-				break;
+	for( const auto f : format ){
+		if( esc ){
+			esc = false;
+			if( f == L'Y' ){
+				(void)wsprintf( str, L"%d", systime.wYear );
+			}else if( f == L'y' ){
+				(void)wsprintf( str, L"%02d", systime.wYear % 100 );
+			}else if( f == L'm' ){
+				(void)wsprintf( str, L"%02d", systime.wMonth );
+			}else if( f == L'd' ){
+				(void)wsprintf( str, L"%02d", systime.wDay );
+			}else if( f == L'H' ){
+				(void)wsprintf( str, L"%02d", systime.wHour );
+			}else if( f == L'M' ){
+				(void)wsprintf( str, L"%02d", systime.wMinute );
+			}else if( f == L'S' ){
+				(void)wsprintf( str, L"%02d", systime.wSecond );
+			}else{
+				(void)wsprintf( str, L"%c", f );
 			}
-
-			switch( *p ){
-			case L'Y':
-				timeLen = wsprintf( szTime, L"%d", systime.wYear );
-				break;
-			case L'y':
-				timeLen = wsprintf( szTime, L"%02d", (systime.wYear % 100) );
-				break;
-			case L'm':
-				timeLen = wsprintf( szTime, L"%02d", systime.wMonth );
-				break;
-			case L'd':
-				timeLen = wsprintf( szTime, L"%02d", systime.wDay );
-				break;
-			case L'H':
-				timeLen = wsprintf( szTime, L"%02d", systime.wHour );
-				break;
-			case L'M':
-				timeLen = wsprintf( szTime, L"%02d", systime.wMinute );
-				break;
-			case L'S':
-				timeLen = wsprintf( szTime, L"%02d", systime.wSecond );
-				break;
-			default:
-				break;
-			}
-		}
-
-		const size_t remains = (size - 1) - (q - szResult);
-		if( 0 <= timeLen ){
-			if( remains < (size_t)timeLen ){
-				break;
-			}
-			wcscpy( q, szTime );
-			++p;
-			q += timeLen;
+			result.append( str );
+		}else if( f == L'%' ){
+			esc = true;
+		}else if( f == L'\0' ){
+			break;
 		}else{
-			if( remains == 0 ){
-				break;
-			}
-			*q++ = *p++;
+			result.push_back( f );
 		}
 	}
 
-	*q = L'\0';
-
-	if( *p == L'\0' ){
-		ret = true;
-	}
-
-	return ret;
+	return result;
 }
 
 /*!	バージョン番号の解析

--- a/sakura_core/util/format.h
+++ b/sakura_core/util/format.h
@@ -27,8 +27,11 @@
 #define SAKURA_FORMAT_A006AC9B_ADE2_499D_9CC6_00A649F32B4F_H_
 #pragma once
 
+#include <optional>
+#include <string>
+
 // 20051121 aroka
-bool GetDateTimeFormat( WCHAR* szResult, size_t size, const WCHAR* format, const SYSTEMTIME& systime );
+std::optional<std::wstring> GetDateTimeFormat( std::wstring_view format, const SYSTEMTIME& systime );
 UINT32 ParseVersion( const WCHAR* ver );	//バージョン番号の解析
 int CompareVersion( const WCHAR* verA, const WCHAR* verB );	//バージョン番号の比較
 #endif /* SAKURA_FORMAT_A006AC9B_ADE2_499D_9CC6_00A649F32B4F_H_ */

--- a/sakura_core/util/format.h
+++ b/sakura_core/util/format.h
@@ -27,11 +27,11 @@
 #define SAKURA_FORMAT_A006AC9B_ADE2_499D_9CC6_00A649F32B4F_H_
 #pragma once
 
-#include <optional>
 #include <string>
+#include <string_view>
 
 // 20051121 aroka
-std::optional<std::wstring> GetDateTimeFormat( std::wstring_view format, const SYSTEMTIME& systime );
+std::wstring GetDateTimeFormat( std::wstring_view format, const SYSTEMTIME& systime );
 UINT32 ParseVersion( const WCHAR* ver );	//バージョン番号の解析
 int CompareVersion( const WCHAR* verA, const WCHAR* verB );	//バージョン番号の比較
 #endif /* SAKURA_FORMAT_A006AC9B_ADE2_499D_9CC6_00A649F32B4F_H_ */

--- a/tests/unittests/test-format.cpp
+++ b/tests/unittests/test-format.cpp
@@ -27,27 +27,17 @@
 #include "util/format.h"
 
 /*!
- * @brief 入力の妥当性判定に関するテスト
+ * @brief GetDateTimeFormatのテスト
  */
-TEST( format, CheckInputValidity )
-{
-	SYSTEMTIME time = {};
-	time.wYear = 123;
-	EXPECT_TRUE( GetDateTimeFormat( L"", time ) );
-	EXPECT_TRUE( GetDateTimeFormat( L"%Y", time ) );
-}
-
-/*!
- * @brief 書式変換のテスト
- */
-TEST( format, Formatting )
+TEST( format, GetDateTimeFormat )
 {
 	SYSTEMTIME time = {};
 
+	// 変換指定子の解釈
 	auto result1 = GetDateTimeFormat( L"%%-%1-%", time );
-	EXPECT_TRUE( result1 );
-	ASSERT_STREQ( L"%-1-", result1.value().c_str() );
+	ASSERT_STREQ( L"%-1-", result1.c_str() );
 
+	// 数字桁数少
 	time.wYear = 1;
 	time.wMonth = 2;
 	time.wDay = 3;
@@ -55,9 +45,9 @@ TEST( format, Formatting )
 	time.wMinute = 2;
 	time.wSecond = 3;
 	auto result2 = GetDateTimeFormat( L"%Y-%y-%m-%d %H:%M:%S", time );
-	EXPECT_TRUE( result2 );
-	ASSERT_STREQ( L"1-01-02-03 01:02:03", result2.value().c_str() );
+	ASSERT_STREQ( L"1-01-02-03 01:02:03", result2.c_str() );
 
+	// 数字桁数多
 	time.wYear = 12345;
 	time.wMonth = 12;
 	time.wDay = 23;
@@ -65,10 +55,9 @@ TEST( format, Formatting )
 	time.wMinute = 34;
 	time.wSecond = 56;
 	auto result3 = GetDateTimeFormat( L"%Y-%y-%m-%d %H:%M:%S", time );
-	EXPECT_TRUE( result3 );
-	ASSERT_STREQ( L"12345-45-12-23 12:34:56", result3.value().c_str() );
+	ASSERT_STREQ( L"12345-45-12-23 12:34:56", result3.c_str() );
 
+	// 途中にnull文字
 	auto result4 = GetDateTimeFormat( L"%Y-%y-%m-%d\0%H:%M:%S", time );
-	EXPECT_TRUE( result4 );
-	ASSERT_STREQ( L"12345-45-12-23", result4.value().c_str() );
+	ASSERT_STREQ( L"12345-45-12-23", result4.c_str() );
 }

--- a/tests/unittests/test-format.cpp
+++ b/tests/unittests/test-format.cpp
@@ -33,61 +33,8 @@ TEST( format, CheckInputValidity )
 {
 	SYSTEMTIME time = {};
 	time.wYear = 123;
-	WCHAR buffer[5] = {};
-	EXPECT_FALSE( GetDateTimeFormat( NULL, 0, L"", time ) );
-	EXPECT_FALSE( GetDateTimeFormat( buffer, 0, L"", time ) );
-	EXPECT_FALSE( GetDateTimeFormat( buffer, _countof(buffer), NULL, time ) );
-	EXPECT_FALSE( GetDateTimeFormat( buffer, 3, L"%Y", time ) );
-	EXPECT_TRUE( GetDateTimeFormat( buffer, 4, L"%Y", time ) );
-}
-
-/*!
- * @brief バッファ書き込み範囲のテスト
- */
-TEST( format, BufferWriteRange )
-{
-	SYSTEMTIME time = {};
-	time.wYear = 1;
-
-	WCHAR buffer1[] = { L'X', L'X', L'X' };
-	EXPECT_TRUE( GetDateTimeFormat( buffer1, _countof(buffer1), L"", time ) );
-	EXPECT_EQ( L'\0', buffer1[0] );
-	EXPECT_EQ( L'X', buffer1[1] );
-
-	WCHAR buffer2[] = { L'X', L'X', L'X' };
-	EXPECT_TRUE( GetDateTimeFormat( buffer2, _countof(buffer2), L"%", time ) );
-	EXPECT_EQ( L'\0', buffer2[0] );
-	EXPECT_EQ( L'X', buffer2[1] );
-
-	WCHAR buffer3[] = { L'X', L'X', L'X' };
-	EXPECT_TRUE( GetDateTimeFormat( buffer3, _countof(buffer3), L"%Y", time ) );
-	EXPECT_EQ( L'1', buffer3[0] );
-	EXPECT_EQ( L'\0', buffer3[1] );
-	EXPECT_EQ( L'X', buffer3[2] );
-
-	WCHAR buffer4[] = { L'X', L'X', L'X' };
-	EXPECT_FALSE( GetDateTimeFormat( buffer4, _countof(buffer4), L"_%y", time ) );
-	EXPECT_EQ( L'_', buffer4[0] );
-	EXPECT_EQ( L'\0', buffer4[1] );
-	EXPECT_EQ( L'X', buffer4[2] );
-
-	WCHAR buffer5[] = { L'X', L'X', L'X' };
-	EXPECT_TRUE( GetDateTimeFormat( buffer5, _countof(buffer5), L"1", time ) );
-	EXPECT_EQ( L'1', buffer5[0] );
-	EXPECT_EQ( L'\0', buffer5[1] );
-	EXPECT_EQ( L'X', buffer5[2] );
-
-	WCHAR buffer6[] = { L'X', L'X', L'X' };
-	EXPECT_TRUE( GetDateTimeFormat( buffer6, _countof(buffer6), L"11", time ) );
-	EXPECT_EQ( L'1', buffer6[0] );
-	EXPECT_EQ( L'1', buffer6[1] );
-	EXPECT_EQ( L'\0', buffer6[2] );
-
-	WCHAR buffer7[] = { L'X', L'X', L'X' };
-	EXPECT_FALSE( GetDateTimeFormat( buffer7, _countof(buffer7), L"111", time ) );
-	EXPECT_EQ( L'1', buffer7[0] );
-	EXPECT_EQ( L'1', buffer7[1] );
-	EXPECT_EQ( L'\0', buffer7[2] );
+	EXPECT_TRUE( GetDateTimeFormat( L"", time ) );
+	EXPECT_TRUE( GetDateTimeFormat( L"%Y", time ) );
 }
 
 /*!
@@ -97,9 +44,9 @@ TEST( format, Formatting )
 {
 	SYSTEMTIME time = {};
 
-	WCHAR buffer1[5] = {};
-	EXPECT_TRUE( GetDateTimeFormat( buffer1, _countof(buffer1), L"%%-%1-%", time ) );
-	ASSERT_STREQ( L"%-1-", buffer1 );
+	auto result1 = GetDateTimeFormat( L"%%-%1-%", time );
+	EXPECT_TRUE( result1 );
+	ASSERT_STREQ( L"%-1-", result1.value().c_str() );
 
 	time.wYear = 1;
 	time.wMonth = 2;
@@ -107,9 +54,9 @@ TEST( format, Formatting )
 	time.wHour = 1;
 	time.wMinute = 2;
 	time.wSecond = 3;
-	WCHAR buffer2[20] = {};
-	EXPECT_TRUE( GetDateTimeFormat( buffer2, _countof(buffer2), L"%Y-%y-%m-%d %H:%M:%S", time ) );
-	ASSERT_STREQ( L"1-01-02-03 01:02:03", buffer2 );
+	auto result2 = GetDateTimeFormat( L"%Y-%y-%m-%d %H:%M:%S", time );
+	EXPECT_TRUE( result2 );
+	ASSERT_STREQ( L"1-01-02-03 01:02:03", result2.value().c_str() );
 
 	time.wYear = 12345;
 	time.wMonth = 12;
@@ -117,7 +64,11 @@ TEST( format, Formatting )
 	time.wHour = 12;
 	time.wMinute = 34;
 	time.wSecond = 56;
-	WCHAR buffer3[24] = {};
-	EXPECT_TRUE( GetDateTimeFormat( buffer3, _countof(buffer3), L"%Y-%y-%m-%d %H:%M:%S", time ) );
-	ASSERT_STREQ( L"12345-45-12-23 12:34:56", buffer3 );
+	auto result3 = GetDateTimeFormat( L"%Y-%y-%m-%d %H:%M:%S", time );
+	EXPECT_TRUE( result3 );
+	ASSERT_STREQ( L"12345-45-12-23 12:34:56", result3.value().c_str() );
+
+	auto result4 = GetDateTimeFormat( L"%Y-%y-%m-%d\0%H:%M:%S", time );
+	EXPECT_TRUE( result4 );
+	ASSERT_STREQ( L"12345-45-12-23", result4.value().c_str() );
 }


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

GetDateTimeFormat の使い勝手を良くしつつ実装を簡素化します。

追記：
バックアップファイル名の書式文字列の末尾が `$` の場合に不正参照するバグが見つかったため、合わせて修正します。
→ https://github.com/sakura-editor/sakura/pull/1489/commits/6b2c49c0176ce68cf09251dc28ac70d2d37bd558

## <!-- 必須 --> カテゴリ

- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

https://github.com/sakura-editor/sakura/pull/1483#issuecomment-747202632 にて提案された内容を元にしています。

## <!-- 自明なら省略可 --> PR のメリット

* GetDateTimeFormat を使う時に必要バッファサイズを計算する必要がなくなります。
* 結果格納用の配列が不要となりソースコードからマジックナンバーを排除できます。
* GetDateTimeFormat の複雑度 (Cyclomatic complexity) が減少します。(18 -> 12)

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

特にないと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

## <!-- わかる範囲で --> PR の影響範囲

GetDateTimeFormat を使用して日時文字列を取得している処理に影響があります。

## <!-- 必須 --> テスト内容

GetDateTimeFormat を使用している処理がデグレしていないことを確認します。
※ #1483 と同じテスト内容です。

### テスト1 - 無題の文書のファイル名

1. 無題の文書が開いている状態で「ファイル」→「名前を付けて保存」を選択する。
確認1：名前を付けて保存ダイアログのファイル名に現在日時が付加されていること。

### テスト2 - バックアップファイル名

1. 「共通設定」→「バックアップ」にて「詳細設定する」をチェック、「保存時の日時・時刻を使用」を選択する。
2. 「詳細設定する」直下のテキストボックスに `.\$0_%Y%m%d_%H%M%S.*` を入力する。
3. 任意のファイルを開き、バックアップ付きで上書き保存する。
確認1：保存先ディレクトリに、現在日時が付加されたファイル (バックアップファイル) が作成されていること。
4. バックアップファイルを削除する。
5. 上書き保存したファイル (バックアップではない方) の更新日時をメモする。
6. 「共通設定」→「バックアップ」で「前回のファイル更新時の日付・時刻を使用」を選択する。
7. 再度、バックアップ付きで上書き保存する。
確認2：保存先ディレクトリに、「4」でメモした日時が付加されたファイルが作成されていること。

## <!-- なければ省略可 --> 関連 issue, PR

#1483

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
