### PR TITLE
Visual Studio Community 2019 で tests1 を編集すると意図しない変更が挿入されるの対策

### DIFF
--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -11,6 +11,11 @@
       <UniqueIdentifier>{0eefa0df-ca7f-489c-9844-9a182e1dba18}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
+  <ItemGroup Condition="Exists('$(VCInstallDir)\Auxiliary\VS\include\CodeCoverage\CodeCoverage.h')">
+    <ClCompile Include="coverage.cpp">
+      <Filter>Other Files</Filter>
+    </ClCompile>
+  </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt">
       <Filter>Other Files</Filter>
@@ -55,9 +60,6 @@
     </ClCompile>
     <ClCompile Include="test-grepinfo.cpp">
       <Filter>Test Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coverage.cpp">
-      <Filter>Other Files</Filter>
     </ClCompile>
     <ClCompile Include="test-loadstring.cpp">
       <Filter>Test Files</Filter>


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
issue #1492 で報告されている事象を修正します。
※設定ファイルの不備により開発環境が壊れてしまう問題が見つかりました。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - ローカルビルド

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
issue #1492 を参照してください。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
Community Editionでtests1を変更してもcoverage.cppのフィルタが消える事象が発生しなくなります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくにありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
アプリ本体の仕様変更/機能追加はありません。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
visual studio の Community、Professional を使って tests1 プロジェクトにファイル追加を行った場合の、
`tests/unittests/tests1.vcxproj.filters` の変更内容に影響します。
※PR適用前は、coverage.cpp が消える 事象が発生していました。 

## <!-- 必須 --> テスト内容

1. カバレッジ計測がサポートされていないエディションでファイル追加を行い、余分な変更が発生しないことを確認します。
2. カバレッジ計測がサポートされているエディションでファイル追加を行い、余分な変更が発生しないことを確認します。

### 手順
  1. PRをフェッチしてチェックアウトする
  2. sakura.slnを開く
  3. ソリューションエクスプローラーで tests1 プロジェクトのOther Filesを確認する
  4. tests1プロジェクトに新しいテストを追加してビルドする
  5. チームエクスプローラーで`tests/unittests/tests1.vcxproj.filters`の変更内容を確認する

### 合否基準
* 手順3. でcoverage.cppの表示状態が、Enterprise=表示、Enterprise以外=非表示であること。
* 手順5. でEnterprise以外の変更内容がEnterpriseの変更内容と等しいこと。

### テスト結果
合格
※ カバレッジ計測がサポートされていないエディションは Visual Studio Community 2019 で検証。
※ カバレッジ計測がサポートされているエディションは Visual Studio Enterprise 2017 で検証。

## <!-- なければ省略可 --> 関連 issue, PR
resolves #1492;

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
