### PR TITLE
CEditView に残存するデッドコードを削除する

### DIFF
--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -420,12 +420,6 @@ void CEditView::Close()
 //                         イベント                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//WCHAR→WCHAR変換。
-inline wchar_t tchar_to_wchar(WCHAR tc)
-{
-	return tc;
-}
-
 /*
 || メッセージディスパッチャ
 */

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -93,19 +93,6 @@ class CColor_Found;
 #define IDM_JUMPDICT 2001	// 2006.04.10 fon
 #endif
 
-#if !defined(RECONVERTSTRING) && (WINVER < 0x040A)
-typedef struct tagRECONVERTSTRING {
-    DWORD dwSize;
-    DWORD dwVersion;
-    DWORD dwStrLen;
-    DWORD dwStrOffset;
-    DWORD dwCompStrLen;
-    DWORD dwCompStrOffset;
-    DWORD dwTargetStrLen;
-    DWORD dwTargetStrOffset;
-} RECONVERTSTRING, *PRECONVERTSTRING;
-#endif // RECONVERTSTRING
-
 ///	マウスからコマンドが実行された場合の上位ビット
 ///	@date 2006.05.19 genta
 const int CMD_FROM_MOUSE = 2;


### PR DESCRIPTION
# PR の目的

CEditView に残る使われていない古いコードの削除を目的とします。
~~このPRで削除を提案するのは以下の5点です。~~ 2点になりました。
- ~~CEditView::SetReconvertStruct の bUnicode 引数~~
- ~~CEditView::SetSelectionFrom*Reonvert* の bUnicode 引数。関数名のtypoも同時に直しています。~~
- CEditView.h の RECONVERTSTRING 定義（`#if WINVER < 0x040A` で囲われている）
- CEditView.cpp の使われていない tchar_to_wchar 関数
- ~~UNICODE_BOOL 定数~~

## カテゴリ

- リファクタリング

## PR のメリット

<del>

- 主にIMEに関連するコードがいくぶん簡素化できます。
- 将来的にIME関係の仕様変更を行う際の作業量がわずかに減るかもしれません。

</del>

## PR のデメリット

- 使われていないということは、あえて削除する必要がないとも言えます。

## PR の影響範囲

~~動作を変更しないはずのPRですが、再変換に関係するコードが変更対象に含まれるため、以下にテスト内容を記載しています。~~
参照されていないコードの削除であるため、プログラムの動作には影響しません。

## テスト内容

<del>

1. 何らかの文字列を入力する。
2. 文字列の一部を選択する。
3. [編集]→[再変換]を実行する。
4. 再変換が実行されることを確認する。
5. 文字数が異なる候補を選択して確定し、元文字列が正しく置き換えられることを確認する。
</del>