### PR TITLE
mdファイルのみ変更したときにAzure Pipelinesのビルドが走らないようにする

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,11 +12,32 @@ trigger:
       - revert-*
   paths:
     exclude:
-      - '**/*.md'
       - .github/*
       - .gitignore
       - .travis.yml
       - appveyor.yml
+      - CHANGELOG.md
+      - CONTRIBUTING.md
+      - CPPLINT.md
+      - README.md
+      - SonarQube.md
+      - addDoxygenFileComment.md
+      - appveyor.md
+      - azure-pipelines.md
+      - build.md
+      - ci-build.md
+      - create-big-file.md
+      - debug-tasktray-menu.md
+      - get-PR.md
+      - installer/externals/bregonig/README.md
+      - installer/externals/universal-ctags/README.md
+      - installer/readme.md
+      - remove-redundant-blank-lines.md
+      - tools/find-tools.md
+      - tools/macro/macro.md
+      - tools/zip/readme.md
+      - unittest.md
+      - vcx-props/project-PlatformToolset.md
 
 ###############################################################################################################################
 #   ビルドトリガー (Pull Request)
@@ -32,11 +53,32 @@ pr:
       - revert-*
   paths:
     exclude:
-      - '**/*.md'
       - .github/*
       - .gitignore
       - .travis.yml
       - appveyor.yml
+      - CHANGELOG.md
+      - CONTRIBUTING.md
+      - CPPLINT.md
+      - README.md
+      - SonarQube.md
+      - addDoxygenFileComment.md
+      - appveyor.md
+      - azure-pipelines.md
+      - build.md
+      - ci-build.md
+      - create-big-file.md
+      - debug-tasktray-menu.md
+      - get-PR.md
+      - installer/externals/bregonig/README.md
+      - installer/externals/universal-ctags/README.md
+      - installer/readme.md
+      - remove-redundant-blank-lines.md
+      - tools/find-tools.md
+      - tools/macro/macro.md
+      - tools/zip/readme.md
+      - unittest.md
+      - vcx-props/project-PlatformToolset.md
 
 ###############################################################################################################################
 #   jobs/job 定義


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
タイトル通りです。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - Azure Pipelines

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1501 で報告されている通り、Azure Pipelinesビルドの除外パスの一部が機能していません。

現在、除外パスに `'**/*.md'` と記載しています。

Azure Pipelinesのドキュメントに受け入れるパターンが言及されていないので詳細は不明ですが、どうやら「末尾が`*`」以外のパターンは機能しないようです。

対策として、プロジェクトに存在しているmdファイル22個を個別に記載し、mdファイルを単独で編集した場合のAzure Pipelinesビルドが走らないようにします。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
ドキュメント変更のみのPRで不要なビルドが走る事態を抑止できるようになります。
※AppveyorとGitHub Actionsではmd除外ができてそうです。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
パターン指定ができないので記述が冗長です。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
Azure Pipelinesの除外パスのパターン指定 `'**/*.md'` を、個別指定に置き換えます。

`.github/`配下のファイルは #1500 で除外済みなので、その他22ファイルについて個別指定を入れます。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
ドキュメント変更のみを行うPRでAzure Pipelinesビルドが走るかどうかに影響します。

適用前： ビルドが走る。
適用後： 変更がmdファイルのみであればビルドは走らない。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
このPRが入った状態のブランチにREADME.mdの編集コミットをpushし、Azure Pipelinesビルドが走らないことを確認しました。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1501
#1500

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
