### PR TITLE
テストカバレッジを少し改善する

### DIFF
--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -108,7 +108,7 @@ jobs:
         --cover_children
         --
         .\tests\build\${{ env.BUILD_PLATFORM }}\${{ env.BUILD_CONFIGURATION }}\unittests\tests1.exe
-        --gtest_output=xml:tests1-googletest.xml
+        --gtest_output=xml:${{ github.workspace }}\tests1-googletest.xml
 
     - name: Set up JDK 11
       uses: actions/setup-java@v1

--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -147,4 +147,4 @@ jobs:
         -D"sonar.cfamily.threads=2" `
         -D"sonar.coverage.exclusions=help\**\*.js,tools\**\*.js" `
         -D"sonar.coverageReportPaths=tests1-coverage.xml" `
-        -D"sonar.exclusions=.sonar\**\*,bw-output\**\*,HeaderMake\**\*,tests\build\**\*,tests\googletest\**\*,**\test-*"
+        -D"sonar.exclusions=.sonar\**\*,bw-output\**\*,HeaderMake\**\*,tests\build\**\*,tests\googletest\**\*,**\test-*,tests*-*.xml"

--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -145,6 +145,6 @@ jobs:
         -D"sonar.cfamily.cache.path=.sonar\analysis-cache" `
         -D"sonar.cfamily.cppunit.reportPath=tests1-googletest.xml" `
         -D"sonar.cfamily.threads=2" `
-        -D"sonar.coverage.exclusions=help\**\*.js,tools\**\*.js" `
+        -D"sonar.coverage.exclusions=help\**\*.js,tests\unittests\coverage.cpp,tools\**\*.js" `
         -D"sonar.coverageReportPaths=tests1-coverage.xml" `
         -D"sonar.exclusions=.sonar\**\*,bw-output\**\*,HeaderMake\**\*,tests\build\**\*,tests\googletest\**\*,**\test-*,tests*-*.xml"

--- a/tests/unittests/coverage.cpp
+++ b/tests/unittests/coverage.cpp
@@ -22,7 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#include <CodeCoverage\CodeCoverage.h>
+#include <CodeCoverage/CodeCoverage.h>
 
 // Exclude all the code from a particular files:
 // see https://docs.microsoft.com/ja-jp/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested

--- a/tests/unittests/coverage.cpp
+++ b/tests/unittests/coverage.cpp
@@ -27,6 +27,6 @@
 // Exclude all the code from a particular files:
 // see https://docs.microsoft.com/ja-jp/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested
 ExcludeSourceFromCodeCoverage(Exclusion1, L"*\\tests\\unittests\\*");
-ExcludeSourceFromCodeCoverage(Exclusion2, L"*\\tests\\googletest\\googletest\\*");
-ExcludeSourceFromCodeCoverage(Exclusion3, L"*\\Windows Kits\\10\\Include\\*\\winrt\\wrl\\client.h");
+ExcludeSourceFromCodeCoverage(Exclusion2, L"*\\googletest\\*");
+ExcludeSourceFromCodeCoverage(Exclusion3, L"*\\Windows Kits\\10\\Include\\*");
 ExcludeSourceFromCodeCoverage(Exclusion4, L"*\\VC\\Tools\\MSVC\\*\\include\\*");

--- a/tests/unittests/test-format.cpp
+++ b/tests/unittests/test-format.cpp
@@ -62,3 +62,94 @@ TEST( format, GetDateTimeFormat )
 	auto result4 = GetDateTimeFormat( std::wstring_view(format4, _countof(format4) - 1), time );
 	ASSERT_STREQ( L"12345-45-12-23", result4.c_str() );
 }
+
+/*!
+ * @brief CompareVersionのテスト
+ * 戻り値が 0ならば: バージョンは等しい
+ */
+TEST(format, CompareVersion_SameVersion)
+{
+	// 2つのバージョン文字列を比較します。
+	// バージョンは4個までの数字を「.」「-」「_」「+」でつなげたものとし、ほかに以下の記号を認識します。
+	// 「a」「alpha」 ＜ 「b」「beta」 ＜ 「rc」「RC」 ＜ （記号なし） ＜ 「p」「pl」
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4.1.0"));
+
+	// 1つ目の区切り文字マトリックス
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4.1.0"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2-4.1.0"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2_4.1.0"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2+4.1.0"));
+
+	// 2つ目の区切り文字マトリックス
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4.1.0"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4-1.0"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4_1.0"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4+1.0"));
+
+	// 3つ目の区切り文字マトリックス
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4.1.0"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4.1-0"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4.1_0"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0", L"2.4.1+0"));
+
+	// 5つ目の値が異なっていても影響を受けない
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0.1", L"2.4.1.0.2"));
+
+	// リビジョン記号は数値扱いなので数値4つ+記号だと影響を受けない
+	ASSERT_EQ(0, CompareVersion(L"2.4.1.0alpha", L"2.4.1.0beta"));
+
+	// 数値に指定できるのは2桁までで、区切り文字を省略できる
+	ASSERT_EQ(0, CompareVersion(L"2.4.1", L"2.0401"));
+
+	// 数値とリビジョン記号のあ緯度の区切り文字はあってもなくてもよい
+	ASSERT_EQ(0, CompareVersion(L"2.4.1alpha", L"2.4.1.alpha"));
+
+	// リビジョン記号の2文字目以降にtypoがあっても先頭文字に一致するレビジョンとして認識される
+	ASSERT_EQ(0, CompareVersion(L"2.4.1a", L"2.4.1alfa"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1b", L"2.4.1bete"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1r", L"2.4.1rp"));
+	ASSERT_EQ(0, CompareVersion(L"2.4.1p", L"2.4.1pp"));
+
+	// リビジョン記号の一覧にない文字を指定した場合はalpha未満と看做す
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0x", L"2.4.0a"));
+
+	// リビジョン記号の一覧にない文字は文字が異なっても同一と看做す
+	ASSERT_EQ(0, CompareVersion(L"2.4.1x", L"2.4.1y"));
+}
+
+/*!
+ * @brief CompareVersionのテスト
+ * 戻り値が 1以上ならば: Aが新しい
+ */
+TEST(format, CompareVersion_NewerIsA)
+{
+	ASSERT_TRUE(1 <= CompareVersion(L"2.4.1.0", L"2.4.0.0"));
+}
+
+/*!
+ * @brief CompareVersionのテスト
+ * 戻り値が -1以下ならば: Bが新しい
+ */
+TEST(format, CompareVersion_NewerIsB)
+{
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0.0", L"2.4.1.0"));
+
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0x", L"2.4.0a"));
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0x", L"2.4.0alpha"));
+
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0a", L"2.4.0b"));
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0alpha", L"2.4.0b"));
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0a", L"2.4.0beta"));
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0alpha", L"2.4.0beta"));
+
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0b", L"2.4.0rc"));
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0beta", L"2.4.0rc"));
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0b", L"2.4.0RC"));
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0beta", L"2.4.0RC"));
+
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0rc", L"2.4.0"));
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0RC", L"2.4.0"));
+
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0", L"2.4.0p"));
+	ASSERT_TRUE(-1 >= CompareVersion(L"2.4.0", L"2.4.0pl"));
+}

--- a/tests/unittests/test-format.cpp
+++ b/tests/unittests/test-format.cpp
@@ -58,6 +58,7 @@ TEST( format, GetDateTimeFormat )
 	ASSERT_STREQ( L"12345-45-12-23 12:34:56", result3.c_str() );
 
 	// 途中にnull文字
-	auto result4 = GetDateTimeFormat( L"%Y-%y-%m-%d\0%H:%M:%S", time );
+	constexpr const wchar_t format4[] = L"%Y-%y-%m-%d\0%H:%M:%S";
+	auto result4 = GetDateTimeFormat( std::wstring_view(format4, _countof(format4) - 1), time );
 	ASSERT_STREQ( L"12345-45-12-23", result4.c_str() );
 }


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
今後のPR作成をやりやすくするために、テストカバレッジを少し改善する変更を行います。

## <!-- 必須 --> カテゴリ
- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
SonarCloud解析の結果を眺めていて、ソースコードの行数が想定より6万行ほど多いことに気付きました。

調べてみたら、解析対象が1ファイル余分でした。
この画像の一番下に出てる `tests1-coverage.xml` が余計です。
[<img alt="sonarcloud_code" src="https://user-images.githubusercontent.com/3253151/104832071-a1bf2580-58d1-11eb-9cc8-8b36631b0d3d.png" width="600" />](https://user-images.githubusercontent.com/3253151/104832071-a1bf2580-58d1-11eb-9cc8-8b36631b0d3d.png)

このことから2点、修正したほうが良さそうな事案があることに気付きました。
1. `tests1-coverage.xml` を除外したほうが良さそうです。
2. 同じ場所に吐いているはずの `tests1-googletest.xml` が出力できていないです。
  なので、出力先を変更する必要がありそうです。

その他、`GetDateTimeFormat`のテストケースの一部が期待したチェックになっていないようなので暫定修正を入れます。

また、`GetDateTimeFormat`と同ファイルに実装されている`CompareVersion`について、比較的簡単にテストを書くことができたので対応ついででテストケースを導入してしまいます。
https://sakura-editor.github.io/help/HLP000268.html#CompareVersion

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
* カバレッジに含めるべきでないファイルが解析対象から除外されます。
* テストケースの一部が修正されて正しい状態になります。
* 新たなテストケースが追加されます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくにないと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
アプリ（＝サクラエディタ）の仕様・機能に変更はありません。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
アプリコードを変更しないのでテストと解析結果のみに影響する変更です。

SonarCloud側の仕様についてはこのへんを参照してください。
https://docs.sonarqube.org/latest/analysis/coverage/

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
berryzplus/sakura を使って事前検証を行いました。
1. テスト結果の出力先変更で、テスト結果が解析対象になること。
2. 解析除外パターンの追加で、テスト結果とカバレッジが解析対象からはずれること
3. coverage.cppの変更で、修正箇所がテスト未実施行にカウントされないこと
4. `GetDateTimeFormat`に渡すフォーマット文字列の途中に`NUL記号(\0)`が含まれていた場合の分岐が実行されること。
5. `sakura_core/util/format.cpp` のテストカバレッジが 100% となること


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1504

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://docs.sonarqube.org/latest/analysis/coverage/
https://sakura-editor.github.io/help/HLP000268.html#CompareVersion
