### PR TITLE
CNativeWとCNativeAの自前コンストラクタ実装を削除する

### DIFF
--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -2,16 +2,6 @@
 #include "StdAfx.h"
 #include "CNativeA.h"
 
-CNativeA::CNativeA() noexcept
-	: CNative()
-{
-}
-
-CNativeA::CNativeA(const CNativeA& rhs)
-	: CNative(rhs)
-{
-}
-
 CNativeA::CNativeA( const char* szData, size_t cchData )
 	: CNative()
 {

--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -12,11 +12,6 @@ CNativeA::CNativeA(const CNativeA& rhs)
 {
 }
 
-CNativeA::CNativeA(CNativeA&& other) noexcept
-	: CNative(std::forward<CNativeA>(other))
-{
-}
-
 CNativeA::CNativeA( const char* szData, size_t cchData )
 	: CNative()
 {

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -30,8 +30,8 @@
 
 class CNativeA final : public CNative{
 public:
-	CNativeA() noexcept;
-	CNativeA( const CNativeA& rhs );
+	CNativeA() noexcept = default;
+	CNativeA( const CNativeA& rhs ) = default;
 	CNativeA( CNativeA&& other ) noexcept = default;
 	CNativeA( const char* szData, size_t cchData );
 	CNativeA( const char* szData);

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -32,7 +32,7 @@ class CNativeA final : public CNative{
 public:
 	CNativeA() noexcept;
 	CNativeA( const CNativeA& rhs );
-	CNativeA( CNativeA&& other ) noexcept;
+	CNativeA( CNativeA&& other ) noexcept = default;
 	CNativeA( const char* szData, size_t cchData );
 	CNativeA( const char* szData);
 
@@ -60,7 +60,7 @@ public:
 
 	//演算子
 	CNativeA& operator = (const CNativeA& rhs)			{ CNative::operator=(rhs); return *this; }
-	CNativeA& operator = (CNativeA&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeA>(rhs)); return *this; }
+	CNativeA& operator = (CNativeA&& rhs) noexcept		{ CNative::operator=(std::move(rhs)); return *this; }
 	const CNativeA& operator=( char );
 	const CNativeA& operator+=( char );
 };

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -17,11 +17,6 @@ CNativeW::CNativeW(const CNativeW& rhs)
 {
 }
 
-CNativeW::CNativeW(CNativeW&& other) noexcept
-	: CNative(std::forward<CNativeW>(other))
-{
-}
-
 //! nDataLenは文字単位。
 CNativeW::CNativeW( const wchar_t* pData, int nDataLen )
 	: CNative()

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -7,16 +7,6 @@
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //               コンストラクタ・デストラクタ                  //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-CNativeW::CNativeW() noexcept
-	: CNative()
-{
-}
-
-CNativeW::CNativeW(const CNativeW& rhs)
-	: CNative(rhs)
-{
-}
-
 //! nDataLenは文字単位。
 CNativeW::CNativeW( const wchar_t* pData, int nDataLen )
 	: CNative()

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -72,8 +72,8 @@ class CNativeW final : public CNative{
 
 public:
 	//コンストラクタ・デストラクタ
-	CNativeW() noexcept;
-	CNativeW( const CNativeW& rhs );
+	CNativeW() noexcept = default;
+	CNativeW( const CNativeW& rhs ) = default;
 	CNativeW( CNativeW&& other ) noexcept = default;
 	CNativeW( const wchar_t* pData, int nDataLen ); //!< nDataLenは文字単位。
 	CNativeW( const wchar_t* pData);

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -74,7 +74,7 @@ public:
 	//コンストラクタ・デストラクタ
 	CNativeW() noexcept;
 	CNativeW( const CNativeW& rhs );
-	CNativeW( CNativeW&& other ) noexcept;
+	CNativeW( CNativeW&& other ) noexcept = default;
 	CNativeW( const wchar_t* pData, int nDataLen ); //!< nDataLenは文字単位。
 	CNativeW( const wchar_t* pData);
 
@@ -98,7 +98,7 @@ public:
 
 	//演算子
 	CNativeW& operator = (const CNativeW& rhs)			{ CNative::operator=(rhs); return *this; }
-	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::forward<CNativeW>(rhs)); return *this; }
+	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::move(rhs)); return *this; }
 	CNativeW  operator + (const CNativeW& rhs) const	{ return (CNativeW(*this) += rhs); }
 	CNativeW& operator += (const CNativeW& rhs)			{ AppendNativeData(rhs); return *this; }
 	CNativeW& operator += (wchar_t ch)					{ return (*this += CNativeW(&ch, 1)); }


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
SonarCloud解析でC++関数の誤用が指摘されているので、CNativeWとCNativeAの自前コンストラクタ実装を削除します。

## <!-- 必須 --> カテゴリ
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1477 で対処しようとしていた問題を解決します。

SonarCloudの指摘は `std::forward` の使い方が誤っているなんですが、
`std::forward` を `std::move` に置き換えても警告が残ることが分かっています。

どんな警告が残るかというと、
管理すべきリソースを持たないクラスがmove semantics実装すんなヴォケ！
というものです。

ここで言う「リソース」にはメモリポインタを含みません。メモリポインタ自体は単なるアドレス値であり、プロセス空間内の特定の位置を指し示す数値です。同じメモリでもメモリハンドルなら「リソース」に該当するのでややこしいです。CNativeWとCNativeAはメモリアドレスしか扱わないクラスなのでC++的には「リソース」を持たないクラスに当たるらしいです。


## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
SonarCloudのBugs指摘を数件解消できます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくに思い当たらないです。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
アプリの仕様・動作とは関係ない変更です。

実際にメモリ管理を行っているのはCMemoryなので、CNativeWとCNativeAの独自定義コンストラクタを削っても影響はないと考えられます。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
実際の影響は発生しないと考えられます。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
追加のテストが必要かどうか、PRを投げてから判断します。
　👇
既にある単体テストのみで十分と判断したので追加はなしです。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1477

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
