### PR TITLE
ACODE/TCODE 名前空間を削除する

### DIFF
--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -253,12 +253,6 @@ namespace WCODE
 */
 }
 
-//TCHAR判定関数群
-namespace TCODE
-{
-	using namespace WCODE;
-}
-
 // 文字幅の動的計算用キャッシュ関連
 struct SCharWidthCache {
 	// 文字半角全角キャッシュ

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -52,18 +52,7 @@
 
 //ANSI定数
 namespace ACODE{
-	//文字
-	static const char TAB   = TAB_;
-	static const char SPACE = SPACE_;
-	static const char CR	= CR_;
-	static const char LF	= LF_;
 	static const char ESC	= ESC_;
-
-	//文字列
-	static const char CRLF[] = CRLF_;
-
-	//特殊 (BREGEXP)
-	static const wchar_t BREGEXP_DELIMITER = (wchar_t)0xFF;
 }
 
 //UNICODE定数
@@ -267,51 +256,6 @@ namespace WCODE
 		return ( 0xdc00 == (0xfc00 & c ));
 	}
 */
-}
-
-//ANSI判定関数群
-namespace ACODE
-{
-	inline bool IsAZ(char c)
-	{
-		return (c>='A' && c<='Z') || (c>='a' && c<='z');
-	}
-
-	//!制御文字であるかどうか
-	inline bool IsControlCode(char c)
-	{
-		unsigned char n=(unsigned char)c;
-		if(c==TAB)return false;
-		if(c==CR )return false;
-		if(c==LF )return false;
-		if(n<=0x1F)return true;
-		if(n>=0x7F && n<=0x9F)return true;
-		if(n>=0xE0)return true;
-		return false;
-	}
-
-	//!タブ表示に使える文字かどうか
-	inline bool IsTabAvailableCode(char c)
-	{
-		if(c=='\0')return false;
-		if(c<=0x1f)return false;
-		if(c>=0x7f)return false;
-		return true;
-	}
-
-	//!ファイル名に使える文字であるかどうか
-	inline bool IsValidFilenameChar(const char c)
-	{
-		static const char* table = "<>?\"|*";
-
-		//table内の文字が含まれていて
-		if(strchr(table,c)!=NULL){
-			// 2013.06.01 判定間違いを削除
-			return false;
-		}
-
-		return true;
-	}
 }
 
 //TCHAR判定関数群

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -50,11 +50,6 @@
 #define ESC_				'\x1b'
 #define CRLF_				"\015\012"
 
-//ANSI定数
-namespace ACODE{
-	static const char ESC	= ESC_;
-}
-
 //UNICODE定数
 namespace WCODE{
 	//文字

--- a/sakura_core/charset/codechecker.cpp
+++ b/sakura_core/charset/codechecker.cpp
@@ -276,7 +276,7 @@ int DetectJisEscseq( const char* pS, const int nLen, EMyJisEscseq* peEscType )
 	pr = const_cast<char*>( pS );
 	pr_end = pS + nLen;
 
-	if( pr[0] == ACODE::ESC ){
+	if( pr[0] == '\x1b' ){
 		expected_esc_len++;
 		pr++;
 		if( pr + 1 < pr_end ){

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -404,7 +404,7 @@ void CViewCommander::Command_PLSQL_COMPILE_ON_SQLPLUS( void )
 	if( GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
 		/* ファイルパスに空白が含まれている場合はダブルクォーテーションで囲む */
 		//	2003.10.20 MIK コード簡略化
-		if( wcschr( GetDocument()->m_cDocFile.GetFilePath(), TCODE::SPACE ) ? TRUE : FALSE ){
+		if( wcschr( GetDocument()->m_cDocFile.GetFilePath(), WCODE::SPACE ) ? TRUE : FALSE ){
 			auto_sprintf( szPath, L"@\"%s\"\r\n", GetDocument()->m_cDocFile.GetFilePath() );
 		}else{
 			auto_sprintf( szPath, L"@%s\r\n", GetDocument()->m_cDocFile.GetFilePath() );

--- a/sakura_core/typeprop/CPropTypesScreen.cpp
+++ b/sakura_core/typeprop/CPropTypesScreen.cpp
@@ -685,7 +685,7 @@ int CPropTypesScreen::GetData( HWND hwndDlg )
 		::DlgItem_GetText( hwndDlg, IDC_EDIT_TABVIEWSTRING, szTab, _countof( szTab ) );
 		wcscpy( m_Types.m_szTabViewString, L"^       " );
 		for( int i = 0; i < 8; i++ ){
-			if( !TCODE::IsTabAvailableCode(szTab[i]) )break;
+			if( !WCODE::IsTabAvailableCode(szTab[i]) )break;
 			m_Types.m_szTabViewString[i] = szTab[i];
 		}
 


### PR DESCRIPTION
# PR の目的

ほぼ使われていない状態となっていた ACODE および TCODE 名前空間を廃止します。

## カテゴリ

- リファクタリング

## PR の背景

ANSI/UNICODE 両対応を廃止した際の削り残しだと思いますが、charset/charcode.h に ACODE と TCODE という UNICODE 移植作業由来であろう名前空間が残っています。TCODE は中で `using namespace WCODE;` しているだけであり、ACODE の現在の使用例は定数を1箇所で参照しているのみですので、名前空間ごと廃止してしまいたいと思います。

## PR のメリット

- SonarCloud の警告が減少します。
- コード量が減ります。

## PR のデメリット (トレードオフとかあれば)

おそらくありません。

## 仕様・動作説明

- 3af8917: ACODE 名前空間から使われていないコードを除去します。
- d2da9b2: ACODE 定数の残存使用例をリテラルに置き換えます。
- 85e45bc: 残存している TCODE を WCODE で置き換え、TCODE を廃止します。

## PR の影響範囲

ACODE/TCODE を参照していた部分に変更を加えますが、無害であるはずです。

## 関連 issue, PR

#1034 Unicode版のみのサポートなので、ANSI/UNICODE両対応を廃止したい 
#1504