### PR TITLE
独自関数strprintfをC++風に使えるように拡張します。

### DIFF
--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -230,8 +230,9 @@ std::wstring vstrprintf(const WCHAR* pszFormat, va_list& argList)
 	}
 
 	// 必要なバッファを確保してフォーマットする
-	std::wstring strOut(cchOut, L'\0');
+	std::wstring strOut(cchOut + 1, L'0');
 	::vswprintf_s(strOut.data(), strOut.capacity(), pszFormat, argList);
+	strOut.resize(cchOut);
 	return strOut;
 }
 

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -216,6 +216,45 @@ const char* stristr_j( const char* s1, const char* s2 )
 
 /*!
 	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
+	@param[in]  pszFormat	フォーマット文字列
+	@param[in]  argList		引数リスト
+	@returns フォーマットされた文字列
+*/
+std::wstring vstrprintf(const WCHAR* pszFormat, va_list& argList)
+{
+	// _vscwprintf() はフォーマットに必要な文字数を返す。
+	const int cchOut = ::_vscwprintf(pszFormat, argList);
+	if (cchOut == 0) {
+		// 出力文字数が0なら後続処理は要らない。
+		return std::wstring();
+	}
+
+	// 必要なバッファを確保してフォーマットする
+	std::wstring strOut(cchOut, L'\0');
+	::vswprintf_s(strOut.data(), strOut.capacity(), pszFormat, argList);
+	return strOut;
+}
+
+/*!
+	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
+	@param[in]  pszFormat	フォーマット文字列
+	@param[in]  ...			引数リスト
+	@returns フォーマットされた文字列
+*/
+std::wstring strprintf(const WCHAR* pszFormat, ...)
+{
+	va_list argList;
+	va_start(argList, pszFormat);
+
+	const auto strRet = vstrprintf(pszFormat, argList);
+
+	va_end(argList);
+
+	return strRet;
+}
+
+/*!
+	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
 	@param[out] strOut		フォーマットされたテキストを受け取る変数
 	@param[in]  pszFormat	フォーマット文字列
 	@param[in]  argList		引数リスト
@@ -225,27 +264,9 @@ const char* stristr_j( const char* s1, const char* s2 )
 */
 int vstrprintf( std::wstring& strOut, const WCHAR* pszFormat, va_list& argList )
 {
-	// バッファをクリアしておく
-	strOut.clear();
-
-	// _vscwprintf() はフォーマットに必要な文字数を返す。
-	const int cchOut = ::_vscwprintf( pszFormat, argList );
-	if( cchOut <= 0 ){
-		// 出力文字数が0なら後続処理は要らない。また、エラー時は-1が返る。
-		return cchOut;
-	}
-
-	// フォーマットに必要なバッファを確保する
-	strOut.resize( cchOut );
-
-	// vswprintf_s() はコピーした文字数を返す。
-	const int actualCopied = ::vswprintf_s( strOut.data(), strOut.capacity(), pszFormat, argList );
-	if( actualCopied < 0 ){
-		// データサイズを反映する
-		strOut.assign( strOut.data(), cchOut );
-	}
-
-	return actualCopied;
+	// オーバーロードバージョンを呼び出す
+	strOut = vstrprintf(pszFormat, argList);
+	return static_cast<int>(strOut.length());
 }
 
 /*!

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -202,6 +202,8 @@ inline int auto_vsprintf_s(WCHAR* buf, size_t nBufCount, const WCHAR* format, va
 #define auto_sprintf_s(buf, nBufCount, format, ...)		::_sntprintf_s((buf), nBufCount, _TRUNCATE, (format), __VA_ARGS__)
 #define auto_snprintf_s(buf, nBufCount, format, ...)	::_sntprintf_s((buf), nBufCount, _TRUNCATE, (format), __VA_ARGS__)
 
+std::wstring vstrprintf(const WCHAR* pszFormat, va_list& argList);
+std::wstring strprintf(const WCHAR* pszFormat, ...);
 int vstrprintf( std::wstring& strOut, const WCHAR* pszFormat, va_list& argList );
 int strprintf( std::wstring& strOut, const WCHAR* pszFormat, ... );
 

--- a/tests/unittests/test-string_ex.cpp
+++ b/tests/unittests/test-string_ex.cpp
@@ -101,11 +101,38 @@ TEST(string_ex, auto_sprintfW)
 	ASSERT_STREQ(L"test-101", szText);
 }
 
+/*!
+	@brief 独自定義のフォーマット関数。
+
+	C関数をC++に移植する作業を簡便化する目的で作成。
+	CRT関数sprintf_sに関する注意点が全て当てはまるので注意。
+	例)
+		"%b" など、未定義のフォーマット識別子を指定すると落ちます。
+		フォーマットと引数の整合がとれていないとAV例外で落ちます。
+ */
 TEST(string_ex, strprintf)
+{
+	std::wstring text = strprintf(L"%s-%d", L"test", 101);
+	ASSERT_STREQ(L"test-101", text.c_str());
+}
+
+/*!
+	@brief 独自定義のフォーマット関数(C-Style風)。
+ */
+TEST(string_ex, strprintfOutputToArg)
 {
 	std::wstring text;
 	strprintf(text, L"%s-%d", L"test", 101);
 	ASSERT_STREQ(L"test-101", text.c_str());
+}
+
+/*!
+	@brief 独自定義のフォーマット関数(空文字出力テスト)。
+ */
+TEST(string_ex, strprintfEmpty)
+{
+	std::wstring text = strprintf(L"%hs", "");
+	ASSERT_TRUE(text.empty());
 }
 
 /*!


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
タイトル通りです。

## <!-- 必須 --> カテゴリ
- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
ちょっと前に入れた strprintf を拡張してC++っぽいコーディングができるようにしたいです。

* `int strprintf(std::wstring&, const wchar_t*, ...)` = 前に入れた関数です。
* `std::wstring strprintf(const wchar_t*, ...)` = 今回入れたい関数です。

 

以前入れたバージョンだと、出力先変数を事前に宣言する必要があります。
```c++
std::wstring work;
strprintf(work, L"P[%03d]", i);
```

今回のバージョンだと、出力先は関数戻り値になるので事前定義が必要ありません。
```c++
std::map<std::wstring, int> mapSomething;
if (auto key = strprintf(L"P[%03d]", i); mapSomething.find(key) != mapSomething.cend()){
    //何かの処理
}
```

個人的には後者のスタイルのほうがよりC++っぽい書き方だと思います。

strprintf自体がCとC++の隙間を埋めるためのものでCスタイルを許容するものなんですが、可能ならばC++側に近づけたほうが読みやすいコードになるように思います。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
Cスタイルの書式化処理を従来よりC++っぽく書けるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
SonarCloud的に可変長引数(va_listや非テンプレートの...)は「非推奨」らしいので、CodeSmellsが増えます。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
他のsprintf系関数と同様に vswnprintf_s をコアに使います。

* 事前にフォーマット結果が何文字になるかを調べ、
  必要なバッファを確保してからフォーマットします。
* vswnprintf_s は未定義のフォーマット識別子を指定すると落ちますが、あえて対策しません。
* vswnprintf_s は使い方を間違えるとVA例外で落ちますが、あえて対策しません。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
いま動いているコードには影響を与えない変更です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
追加・変更するstrprintfのオーバーロードについてテストを書き直し、従来と挙動が変わってなさそうなことを確認しました。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
