### PR TITLE
charset/charcode.(h|cpp): SonarCloud の警告のうち対処が容易なものを解決する

### DIFF
--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -29,7 +29,7 @@
 #include "env/DLLSHAREDATA.h"
 
 /*! キーワードキャラクタ */
-const unsigned char gm_keyword_char[128] = {
+const std::array<unsigned char, 128> gm_keyword_char = {
  /* 0         1         2         3         4         5         6         7         8         9         A         B         C         D         E         F             : 0123456789ABCDEF */
 	CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_TAB,   CK_LF,    CK_CTRL,  CK_CTRL,  CK_CR,    CK_CTRL,  CK_CTRL,  /* 0: ................ */
 	CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  CK_CTRL,  /* 1: ................ */
@@ -71,15 +71,13 @@ namespace WCODE
 		){
 			wc = 0x4E00; // '一'(0x4E00)の幅で代用
 		}
-		else
 		// ハングルはすべて同一幅とみなす	// 2013.04.08 aroka
-		if ( wc>=0xAC00 && wc<=0xD7A3 )		// Hangul Syllables
+		else if ( wc>=0xAC00 && wc<=0xD7A3 )		// Hangul Syllables
 		{
 			wc = 0xAC00; // (0xAC00)の幅で代用
 		}
-		else
 		// 外字はすべて同一幅とみなす	// 2013.04.08 aroka
-		if (wc>=0xE000 && wc<=0xE8FF) // Private Use Area
+		else if (wc>=0xE000 && wc<=0xE8FF) // Private Use Area
 		{
 			wc = 0xE000; // (0xE000)の幅で代用
 		}
@@ -89,86 +87,38 @@ namespace WCODE
 	}
 
 	//!制御文字であるかどうか
-	bool IsControlCode(wchar_t wc)
+	[[nodiscard]] bool IsControlCode(wchar_t wc)
 	{
-		////改行は制御文字とみなさない
-		//if(IsLineDelimiter(wc))return false;
-
-		////タブは制御文字とみなさない
-		//if(wc==TAB)return false;
-
-		//return iswcntrl(wc)!=0;
-		return (wc<_countof(gm_keyword_char) && gm_keyword_char[wc]==CK_CTRL);
+		return wc < gm_keyword_char.size() && gm_keyword_char[wc] == CK_CTRL;
 	}
 
-#if 0
 	/*!
-		句読点か
-		2008.04.27 kobake CLayoutMgr::IsKutoTen から分離
-
-		@param[in] c1 調べる文字1バイト目
-		@param[in] c2 調べる文字2バイト目
-		@retval true 句読点である
-		@retval false 句読点でない
-	*/
-	bool IsKutoten( wchar_t wc )
-	{
-		//句読点定義
-		static const wchar_t *KUTOTEN=
-			L"｡､,."
-			L"。、，．"
-		;
-
-		const wchar_t* p;
-		for(p=KUTOTEN;*p;p++){
-			if(*p==wc)return true;
-		}
-		return false;
-	}
-#endif
-
-	/*!
-		UNICODE文字情報のキャッシュクラス。
-		1文字当たり2ビットで、値を保存しておく。
-		00:未初期化
-		01:半角
-		10:全角
-		11:-
+		文字幅情報のキャッシュクラス。
+		1文字当たり2バイトで保存しておく。
 	*/
 	class LocalCache{
 	public:
-		LocalCache()
-		{
-			/* LOGFONTの初期化 */
-			memset( &m_lf, 0, sizeof(m_lf) );
-			memset( &m_lf2, 0, sizeof(m_lf2) );
-
-			// HDC の初期化
-			m_hdc = NULL;
-			m_hdcFull = NULL;
-
-			m_hFont =NULL;
-			m_hFontOld =NULL;
-			m_pCache = 0;
-		}
+		LocalCache() = default;
+		LocalCache(const LocalCache&) = delete;
+		LocalCache& operator=(const LocalCache&) = delete;
 		~LocalCache()
 		{
 			// -- -- 後始末 -- -- //
 			DeleteLocalData();
 		}
 		void DeleteLocalData(){
-	 		if (m_hFont != NULL) {
+			if (m_hFont != nullptr) {
 				SelectObject(m_hdc, m_hFontOld);
 				DeleteObject(m_hFont);
-				m_hFont = NULL;
+				m_hFont = nullptr;
 			}
-			if (m_hFontFull != NULL) {
+			if (m_hFontFull != nullptr) {
 				SelectObject(m_hdcFull, m_hFontFullOld);
 				DeleteObject(m_hFontFull);
-				m_hFontFull = NULL;
+				m_hFontFull = nullptr;
 			}
-			if(m_hdc){ DeleteDC(m_hdc); m_hdc = NULL;}
-			if(m_hdcFull){ DeleteDC(m_hdcFull);  m_hdcFull = NULL;}
+			if(m_hdc){ DeleteDC(m_hdc); m_hdc = nullptr;}
+			if(m_hdcFull){ DeleteDC(m_hdcFull);  m_hdcFull = nullptr;}
 		}
 		static bool IsEqual(const LOGFONT &lhs, const LOGFONT &rhs){
 			return &lhs == &rhs ||
@@ -194,15 +144,15 @@ namespace WCODE
 				m_hFontFullOld = (HFONT)SelectObject(m_hdcFull, m_hFontFull);
 			}else{
 				m_bMultiFont = false;
-				m_hdcFull = NULL;
-				m_hFontFull = NULL;
-				m_hFontFullOld = NULL;
+				m_hdcFull = nullptr;
+				m_hFontFull = nullptr;
+				m_hFontFullOld = nullptr;
 			}
 			s_MultiFont = m_bMultiFont;
 
 			// -- -- 半角基準 -- -- //
 			// CTextMetrics::Update と同じでなければならない
-			HDC hdcArr[2] = {m_hdc, m_hdcFull};
+			std::array<HDC, 2> hdcArr = {m_hdc, m_hdcFull};
 			int size = (bFullFont ? 2 : 1);
 			m_han_size.cx = 1;
 			m_han_size.cy = 1;
@@ -228,40 +178,34 @@ namespace WCODE
 		{
 			assert(m_pCache!=0);
 			// キャッシュのクリア
-			memcpy(m_pCache->m_lfFaceName, m_lf.lfFaceName, sizeof(m_lf.lfFaceName));
-			memcpy(m_pCache->m_lfFaceName2, m_lf2.lfFaceName, sizeof(m_lf2.lfFaceName));
-			memset(m_pCache->m_nCharPxWidthCache, 0, sizeof(m_pCache->m_nCharPxWidthCache));
+			memcpy(m_pCache->m_lfFaceName.data(), m_lf.lfFaceName, sizeof(m_lf.lfFaceName));
+			memcpy(m_pCache->m_lfFaceName2.data(), m_lf2.lfFaceName, sizeof(m_lf2.lfFaceName));
+			memset(m_pCache->m_nCharPxWidthCache.data(), 0, sizeof(m_pCache->m_nCharPxWidthCache));
 			m_pCache->m_nCharWidthCacheTest=0x12345678;
-		}
-		bool IsSameFontFace( const LOGFONT &lf1, const LOGFONT &lf2 )
-		{
-			assert(m_pCache!=0);
-			return ( memcmp(m_pCache->m_lfFaceName, lf1.lfFaceName, sizeof(lf1.lfFaceName)) == 0 &&
-				memcmp(m_pCache->m_lfFaceName2, lf2.lfFaceName, sizeof(lf2.lfFaceName)) == 0 );
 		}
 		void SetCachePx(wchar_t c, short cache_pxwidth)
 		{
 			m_pCache->m_nCharPxWidthCache[c] = cache_pxwidth;
 		}
-		short GetCachePx(wchar_t c) const
+		[[nodiscard]] short GetCachePx(wchar_t c) const
 		{
 			return _GetRawPx(c);
 		}
-		bool ExistCache(wchar_t c) const
+		[[nodiscard]] bool ExistCache(wchar_t c) const
 		{
 			assert(m_pCache->m_nCharWidthCacheTest==0x12345678);
 			return _GetRawPx(c)!=0x0;
 		}
-		bool CalcHankakuByFont(wchar_t c)
+		bool CalcHankakuByFont(wchar_t c) const
 		{
 			SIZE size={m_han_size.cx*2,0}; //関数が失敗したときのことを考え、全角幅で初期化しておく
 			GetTextExtentPoint32(SelectHDC(c),&c,1,&size);
 			return (size.cx<=m_han_size.cx);
 		}
-		bool IsHankakuByWidth(int width){
+		[[nodiscard]] bool IsHankakuByWidth(int width) const {
 			return width<=m_han_size.cx;
 		}
-		int CalcPxWidthByFont(wchar_t c)
+		int CalcPxWidthByFont(wchar_t c) const
 		{
 			SIZE size={m_han_size.cx*2,0}; //関数が失敗したときのことを考え、全角幅で初期化しておく
 			// 2014.12.21 コントロールコードの表示・NULが1px幅になるのをスペース幅にする
@@ -275,48 +219,48 @@ namespace WCODE
 			GetTextExtentPoint32(SelectHDC(c),&c,1,&size);
 			return t_max<int>(1,size.cx);
 		}
-		int CalcPxWidthByFont2(const wchar_t* pc2)
+		int CalcPxWidthByFont2(const wchar_t* pc2) const
 		{
 			SIZE size={m_han_size.cx*2,0};
 			// サロゲートは全角フォント
 			GetTextExtentPoint32(m_hdcFull?m_hdcFull:m_hdc,pc2,2,&size);
 			return t_max<int>(1,size.cx);
 		}
-		bool GetMultiFont() const
+		[[nodiscard]] bool GetMultiFont() const
 		{
 			return m_bMultiFont;
 		}
 		
 	protected:
-		int _GetRawPx(wchar_t c) const
+		[[nodiscard]] short _GetRawPx(wchar_t c) const
 		{
 			return m_pCache->m_nCharPxWidthCache[c];
 		}
-		HDC SelectHDC(wchar_t c) const
+		[[nodiscard]] HDC SelectHDC(wchar_t c) const
 		{
 			return m_hdcFull && WCODE::GetFontNo(c) ? m_hdcFull : m_hdc;
 		}
 	private:
-		HDC					m_hdc;
-		HDC					m_hdcFull;
-		HFONT 				m_hFontOld, m_hFontFullOld;
-		HFONT 				m_hFont, m_hFontFull;
+		HDC					m_hdc = nullptr;
+		HDC					m_hdcFull = nullptr;
+		HFONT 				m_hFontOld = nullptr;
+		HFONT				m_hFontFullOld = nullptr;
+		HFONT 				m_hFont = nullptr;
+		HFONT				m_hFontFull = nullptr;
 		bool				m_bMultiFont;
 		SIZE				m_han_size;
-		LOGFONT				m_lf;				// 2008/5/15 Uchi
-		LOGFONT				m_lf2;
-		SCharWidthCache*	m_pCache;
+		LOGFONT				m_lf {};				// 2008/5/15 Uchi
+		LOGFONT				m_lf2 {};
+		SCharWidthCache*	m_pCache = nullptr;
 	};
 
 	class LocalCacheSelector{
 	public:
-		LocalCacheSelector()
+		LocalCacheSelector() : pcache(m_localcache.data())
 		{
-			pcache = &m_localcache[0];
 			for( int i=0; i<CWM_FONT_MAX; i++ ){
 				m_parCache[i] = 0;
 			}
-			m_eLastEditCacheMode = CWM_CACHE_NEUTRAL;
 		}
 		~LocalCacheSelector()
 		{
@@ -348,12 +292,12 @@ namespace WCODE
 			if( fMode==CWM_FONT_EDIT ){ m_eLastEditCacheMode = cmode; }
 			WCODE::s_MultiFont = pcache->GetMultiFont();
 		}
-		LocalCache* GetCache(){ return pcache; }
+		[[nodiscard]] LocalCache* GetCache(){ return pcache; }
 	private:
+		std::array<LocalCache, 3> m_localcache;
+		std::array<SCharWidthCache*, 3> m_parCache;
+		ECharWidthCacheMode m_eLastEditCacheMode = CWM_CACHE_NEUTRAL;
 		LocalCache* pcache;
-		LocalCache m_localcache[3];
-		SCharWidthCache* m_parCache[3];
-		ECharWidthCacheMode m_eLastEditCacheMode;
 		DISALLOW_COPY_AND_ASSIGN(LocalCacheSelector);
 	};
 
@@ -366,38 +310,32 @@ namespace WCODE
 		// -- -- キャッシュが存在すれば、それをそのまま返す -- -- //
 		if(pcache->ExistCache(c))return pcache->GetCachePx(c);
 
-		int width;
-		width = pcache->CalcPxWidthByFont(c);
-
 		// -- -- キャッシュ更新 -- -- //
-		pcache->SetCachePx(c,width);
-
+		pcache->SetCachePx(c, static_cast<short>(pcache->CalcPxWidthByFont(c)));
 		return pcache->GetCachePx(c);
 	}
 
 	int CalcPxWidthByFont2(const wchar_t* pc){
-		LocalCache* pcache = selector.GetCache();
+		const LocalCache* pcache = selector.GetCache();
 		return pcache->CalcPxWidthByFont2(pc);
 	}
 
 	//文字幅の動的計算。半角ならtrue。
 	bool CalcHankakuByFont(wchar_t c)
 	{
-		LocalCache* pcache = selector.GetCache();
+		const LocalCache* pcache = selector.GetCache();
 		return pcache->IsHankakuByWidth(CalcPxWidthByFont(c));
 	}
 
 	// 文字の使用フォントを返す
 	// @return 0:半角用 / 1:全角用
-	int GetFontNo( wchar_t c ){
-		if( s_MultiFont ){
-			if(0x0080 <= c && c <= 0xFFFF){
-				return 1;
-			}
+	[[nodiscard]] int GetFontNo( wchar_t c ){
+		if (s_MultiFont && 0x0080 <= c && c <= 0xFFFF){
+			return 1;
 		}
 		return 0;
 	}
-	int GetFontNo2( wchar_t wc1, wchar_t wc2 ){
+	[[nodiscard]] int GetFontNo2( wchar_t, wchar_t ){
 		if( s_MultiFont ){
 			return 1;
 		}
@@ -408,9 +346,9 @@ namespace WCODE
 //	文字幅の動的計算用キャッシュの初期化。	2007/5/18 Uchi
 void InitCharWidthCache( const LOGFONT &lf, ECharWidthFontMode fMode )
 {
-	HDC hdc = GetDC(NULL);
+	HDC hdc = GetDC(nullptr);
 	WCODE::selector.Init( lf, lf, fMode, hdc );
-	ReleaseDC(NULL, hdc);
+	ReleaseDC(nullptr, hdc);
 }
 
 void InitCharWidthCacheFromDC( const LOGFONT* lfs, ECharWidthFontMode fMode, HDC hdcOrg )

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -27,44 +27,31 @@
 #pragma once
 
 //2007.09.13 kobake 作成
+#include <array>
 #include "parse/CWordParse.h"
 #include "util/std_macro.h"
-
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         判定関数                            //
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-// #include "charset/codechecker.h"
-// SJIS関連コードは codecheker.hに移動
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           定数                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 // SJISのコードページ(CP_ACP では無くこれを使えばおそらく英語版Winでも動くはず。)	2008/5/12 Uchi
-#define CP_SJIS		932
-
-//定数の素 (直接使用は控えてください)
-#define TAB_ 				'\t'
-#define SPACE_				' '
-#define CR_					'\015'
-#define LF_					'\012'
-#define ESC_				'\x1b'
-#define CRLF_				"\015\012"
+constexpr int CP_SJIS = 932;
 
 //UNICODE定数
 namespace WCODE{
 	//文字
-	static const wchar_t TAB   = LCHAR(TAB_);
-	static const wchar_t SPACE = LCHAR(SPACE_);
-	static const wchar_t CR    = LCHAR(CR_);
-	static const wchar_t LF    = LCHAR(LF_);
-	static const wchar_t ESC   = LCHAR(ESC_);
+	constexpr wchar_t TAB   = L'\t';
+	constexpr wchar_t SPACE = L' ';
+	constexpr wchar_t CR    = L'\015';
+	constexpr wchar_t LF    = L'\012';
+	constexpr wchar_t ESC   = L'\x1b';
 
 	//文字列
-	static const wchar_t CRLF[] = LTEXT(CRLF_);
+	constexpr wchar_t CRLF[] = L"\015\012";
 
 	//特殊 (BREGEXP)
 	//$$ UNICODE版の仮デリミタ。bregonigの仕様がよくわかんないので、とりあえずこんな値にしてます。
-	static const wchar_t BREGEXP_DELIMITER = (wchar_t)0xFFFF;
+	constexpr wchar_t BREGEXP_DELIMITER = (wchar_t)0xFFFF;
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -72,15 +59,15 @@ namespace WCODE{
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /*! キーワードキャラクタ */
-extern const unsigned char gm_keyword_char[128];
+extern const std::array<unsigned char, 128> gm_keyword_char;
 
 //Oct. 31, 2000 JEPRO  TeX Keyword のために'\'を追加
 //Nov.  9, 2000 JEPRO  HSP Keyword のために'@'を追加
 //Oct. 18, 2007 kobake UNICODE用に書き直し
 //Nov. 27, 2010 syat   速度改善のためテーブルに変更
-inline bool IS_KEYWORD_CHAR(wchar_t wc)
+[[nodiscard]] inline bool IS_KEYWORD_CHAR(wchar_t wc)
 {
-	if(0 <= wc && wc < _countof(gm_keyword_char) && (gm_keyword_char[wc] == CK_CSYM||gm_keyword_char[wc] == CK_UDEF) )
+	if(wc < gm_keyword_char.size() && (gm_keyword_char[wc] == CK_CSYM||gm_keyword_char[wc] == CK_UDEF) )
 		return true;
 	else
 		return false;
@@ -89,15 +76,15 @@ inline bool IS_KEYWORD_CHAR(wchar_t wc)
 //UNICODE判定関数群
 namespace WCODE
 {
-	inline bool IsAZ(wchar_t wc)
+	[[nodiscard]] inline bool IsAZ(wchar_t wc)
 	{
 		return (wc>=L'A' && wc<=L'Z') || (wc>=L'a' && wc<=L'z');
 	}
-	inline bool Is09(wchar_t wc)
+	[[nodiscard]] inline bool Is09(wchar_t wc)
 	{
 		return (wc>=L'0' && wc<=L'9');
 	}
-	inline bool IsInRange(wchar_t c, wchar_t front, wchar_t back)
+	[[nodiscard]] inline bool IsInRange(wchar_t c, wchar_t front, wchar_t back)
 	{
 		return c>=front && c<=back;
 	}
@@ -117,7 +104,7 @@ namespace WCODE
 	int GetFontNo2(wchar_t wc1, wchar_t wc2);
 
 	//!全角スペースかどうか判定
-	inline bool IsZenkakuSpace(wchar_t wc)
+	[[nodiscard]] inline bool IsZenkakuSpace(wchar_t wc)
 	{
 		return wc == 0x3000; //L'　'
 	}
@@ -126,27 +113,27 @@ namespace WCODE
 	bool IsControlCode(wchar_t wc);
 
 	//!改行文字であるかどうか
-	inline bool IsLineDelimiter(wchar_t wc, bool ext)
+	[[nodiscard]] inline bool IsLineDelimiter(wchar_t wc, bool ext)
 	{
 		return wc==CR || wc==LF || (ext && (wc==0x85 || wc==0x2028 || wc==0x2029));
 	}
-	inline bool IsLineDelimiterBasic(wchar_t wc)
+	[[nodiscard]] inline bool IsLineDelimiterBasic(wchar_t wc)
 	{
 		return wc==CR || wc==LF;
 	}
-	inline bool IsLineDelimiterExt(wchar_t wc)
+	[[nodiscard]] inline bool IsLineDelimiterExt(wchar_t wc)
 	{
 		return wc==CR || wc==LF || wc==0x85 || wc==0x2028 || wc==0x2029;
 	}
 
 	//!単語の区切り文字であるかどうか
-	inline bool IsWordDelimiter(wchar_t wc)
+	[[nodiscard]] inline bool IsWordDelimiter(wchar_t wc)
 	{
 		return wc==SPACE || wc==TAB || IsZenkakuSpace(wc);
 	}
 
 	//!インデント構成要素であるかどうか。bAcceptZenSpace: 全角スペースを含めるかどうか
-	inline bool IsIndentChar(wchar_t wc,bool bAcceptZenSpace)
+	[[nodiscard]] inline bool IsIndentChar(wchar_t wc,bool bAcceptZenSpace)
 	{
 		if(wc==TAB || wc==SPACE)return true;
 		if(bAcceptZenSpace && IsZenkakuSpace(wc))return true;
@@ -154,7 +141,7 @@ namespace WCODE
 	}
 
 	//!空白かどうか
-	inline bool IsBlank(wchar_t wc)
+	[[nodiscard]] inline bool IsBlank(wchar_t wc)
 	{
 		return wc==TAB || wc==SPACE || IsZenkakuSpace(wc);
 	}
@@ -162,14 +149,14 @@ namespace WCODE
 	//!ファイル名に使える文字であるかどうか
 	inline bool IsValidFilenameChar(const wchar_t wc)
 	{
-		static const wchar_t* table = L"<>?\"|*";
+		constexpr wchar_t table[] = L"<>?\"|*";
 
-		if(wcschr(table,wc)!=NULL)return false; //table内の文字が含まれていたら、ダメ。
-		else return true;
+		//table内の文字が含まれていたら、ダメ。
+		return wcschr(table, wc) == nullptr;
 	}
 
 	//!タブ表示に使える文字かどうか
-	inline bool IsTabAvailableCode(wchar_t wc)
+	[[nodiscard]] inline bool IsTabAvailableCode(wchar_t wc)
 	{
 		//$$要検証
 		if(wc==L'\0')return false;
@@ -180,44 +167,44 @@ namespace WCODE
 	}
 
 	//! 半角カナかどうか
-	inline bool IsHankakuKatakana(wchar_t c)
+	[[nodiscard]] inline bool IsHankakuKatakana(wchar_t c)
 	{
 		//参考: http://ash.jp/code/unitbl1.htm
 		return c>=0xFF61 && c<=0xFF9F;
 	}
 
 	//! 全角記号かどうか
-	inline bool IsZenkakuKigou(wchar_t c)
+	[[nodiscard]] inline bool IsZenkakuKigou(wchar_t c)
 	{
 		//$ 他にも全角記号はあると思うけど、とりあえずANSI版時代の判定を踏襲。パフォーマンス悪し。
 		// 2009.06.26 syat 「ゝゞ（ひらがな）」「ヽヾ（カタカナ）」「゛゜（全角濁点）」「仝々〇（漢字）」「ー（長音）」を除外
 		// 2009.10.10 syat ANSI版の修正にあわせて「〆」を記号→漢字にする
-		static const wchar_t* table=L"　、。，．・：；？！´｀¨＾￣＿〃―‐／＼～∥｜…‥‘’“”（）〔〕［］｛｝〈〉《》「」『』【】＋－±×÷＝≠＜＞≦≧∞∴♂♀°′″℃￥＄￠￡％＃＆＊＠§☆★○●◎◇◆□■△▲▽▼※〒→←↑↓〓∈∋⊆⊇⊂⊃∪∩∧∨￢⇒⇔∀∃∠⊥⌒∂∇≡≒≪≫√∽∝∵∫∬Å‰♯♭♪†‡¶◯";
-		return wcschr(table,c)!=NULL;
+		constexpr wchar_t table[] = L"　、。，．・：；？！´｀¨＾￣＿〃―‐／＼～∥｜…‥‘’“”（）〔〕［］｛｝〈〉《》「」『』【】＋－±×÷＝≠＜＞≦≧∞∴♂♀°′″℃￥＄￠￡％＃＆＊＠§☆★○●◎◇◆□■△▲▽▼※〒→←↑↓〓∈∋⊆⊇⊂⊃∪∩∧∨￢⇒⇔∀∃∠⊥⌒∂∇≡≒≪≫√∽∝∵∫∬Å‰♯♭♪†‡¶◯";
+		return wcschr(table,c)!=nullptr;
 	}
 
 	//! ひらがなかどうか
-	inline bool IsHiragana(wchar_t c)
+	[[nodiscard]] inline bool IsHiragana(wchar_t c)
 	{
 		// 2009.06.26 syat 「ゝゞ」を追加
 		return (c>=0x3041 && c<=0x3096) || (c>=0x309D && c<=0x309E);
 	}
 
 	//! カタカナかどうか
-	inline bool IsZenkakuKatakana(wchar_t c)
+	[[nodiscard]] inline bool IsZenkakuKatakana(wchar_t c)
 	{
 		// 2009.06.26 syat 「ヽヾ」を追加
 		return (c>=0x30A1 && c<=0x30FA) || (c>=0x30FD && c<=0x30FE);
 	}
 
 	//! ギリシャ文字かどうか
-	inline bool IsGreek(wchar_t c)
+	[[nodiscard]] inline bool IsGreek(wchar_t c)
 	{
 		return c>=0x0391 && c<=0x03C9;
 	}
 
 	//! キリル文字かどうか
-	inline bool IsCyrillic(wchar_t c)
+	[[nodiscard]] inline bool IsCyrillic(wchar_t c)
 	{
 		return (c>=0x0400 && c<=0x052F)  // Cyrillic, Cyrillic Supplement
 			|| (c>=0x2DE0 && c<=0x2DFF)  // Cyrillic Extended-A
@@ -225,7 +212,7 @@ namespace WCODE
 	}
 
 	//! BOX DRAWING 文字 かどうか
-	inline bool IsBoxDrawing(wchar_t c)
+	[[nodiscard]] inline bool IsBoxDrawing(wchar_t c)
 	{
 		return c>=0x2500 && c<=0x257F;
 	}
@@ -236,29 +223,14 @@ namespace WCODE
 	int  CalcPxWidthByFont(wchar_t c);
 	//!文字のpx幅を取得(DLLSHARE/フォント依存)
 	int  CalcPxWidthByFont2(const wchar_t* c);
-	//! 句読点か
-	//bool IsKutoten( wchar_t wc );
-
-/* codechecker.h へ移動
-	//! 高位サロゲートエリアか？	from ssrc_2004-06-05wchar00703b	2008/5/15 Uchi
-	inline bool IsUTF16High( wchar_t c )
-	{
-		return ( 0xd800 == (0xfc00 & c ));
-	}
-	//! 下位サロゲートエリアか？	from ssrc_2004-06-05wchar00703b	2008/5/15 Uchi
-	inline bool IsUTF16Low( wchar_t c )
-	{
-		return ( 0xdc00 == (0xfc00 & c ));
-	}
-*/
 }
 
 // 文字幅の動的計算用キャッシュ関連
 struct SCharWidthCache {
 	// 文字半角全角キャッシュ
-	WCHAR		m_lfFaceName[LF_FACESIZE];
-	WCHAR		m_lfFaceName2[LF_FACESIZE];
-	short		m_nCharPxWidthCache[0x10000];
+	std::array<WCHAR, LF_FACESIZE> m_lfFaceName;
+	std::array<WCHAR, LF_FACESIZE> m_lfFaceName2;
+	std::array<short, 0x10000> m_nCharPxWidthCache;
 	int			m_nCharWidthCacheTest;				//cache溢れ検出
 };
 

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -42,15 +42,14 @@ namespace WCODE{
 	//文字
 	constexpr wchar_t TAB   = L'\t';
 	constexpr wchar_t SPACE = L' ';
-	constexpr wchar_t CR    = L'\015';
-	constexpr wchar_t LF    = L'\012';
+	constexpr wchar_t CR    = L'\r';
+	constexpr wchar_t LF    = L'\n';
 	constexpr wchar_t ESC   = L'\x1b';
 
 	//文字列
-	constexpr wchar_t CRLF[] = L"\015\012";
+	constexpr wchar_t CRLF[] = L"\r\n";
 
 	//特殊 (BREGEXP)
-	//$$ UNICODE版の仮デリミタ。bregonigの仕様がよくわかんないので、とりあえずこんな値にしてます。
 	constexpr wchar_t BREGEXP_DELIMITER = (wchar_t)0xFFFF;
 }
 
@@ -67,7 +66,7 @@ extern const std::array<unsigned char, 128> gm_keyword_char;
 //Nov. 27, 2010 syat   速度改善のためテーブルに変更
 [[nodiscard]] inline bool IS_KEYWORD_CHAR(wchar_t wc)
 {
-	if(wc < gm_keyword_char.size() && (gm_keyword_char[wc] == CK_CSYM||gm_keyword_char[wc] == CK_UDEF) )
+	if(static_cast<std::size_t>(wc) < gm_keyword_char.size() && (gm_keyword_char[wc] == CK_CSYM||gm_keyword_char[wc] == CK_UDEF) )
 		return true;
 	else
 		return false;
@@ -149,10 +148,10 @@ namespace WCODE
 	//!ファイル名に使える文字であるかどうか
 	inline bool IsValidFilenameChar(const wchar_t wc)
 	{
-		constexpr wchar_t table[] = L"<>?\"|*";
+		constexpr const wchar_t table[] = L"<>?\"|*";
 
 		//table内の文字が含まれていたら、ダメ。
-		return wcschr(table, wc) == nullptr;
+		return !wcschr(table, wc);
 	}
 
 	//!タブ表示に使える文字かどうか
@@ -179,8 +178,8 @@ namespace WCODE
 		//$ 他にも全角記号はあると思うけど、とりあえずANSI版時代の判定を踏襲。パフォーマンス悪し。
 		// 2009.06.26 syat 「ゝゞ（ひらがな）」「ヽヾ（カタカナ）」「゛゜（全角濁点）」「仝々〇（漢字）」「ー（長音）」を除外
 		// 2009.10.10 syat ANSI版の修正にあわせて「〆」を記号→漢字にする
-		constexpr wchar_t table[] = L"　、。，．・：；？！´｀¨＾￣＿〃―‐／＼～∥｜…‥‘’“”（）〔〕［］｛｝〈〉《》「」『』【】＋－±×÷＝≠＜＞≦≧∞∴♂♀°′″℃￥＄￠￡％＃＆＊＠§☆★○●◎◇◆□■△▲▽▼※〒→←↑↓〓∈∋⊆⊇⊂⊃∪∩∧∨￢⇒⇔∀∃∠⊥⌒∂∇≡≒≪≫√∽∝∵∫∬Å‰♯♭♪†‡¶◯";
-		return wcschr(table,c)!=nullptr;
+		constexpr const wchar_t table[] = L"　、。，．・：；？！´｀¨＾￣＿〃―‐／＼～∥｜…‥‘’“”（）〔〕［］｛｝〈〉《》「」『』【】＋－±×÷＝≠＜＞≦≧∞∴♂♀°′″℃￥＄￠￡％＃＆＊＠§☆★○●◎◇◆□■△▲▽▼※〒→←↑↓〓∈∋⊆⊇⊂⊃∪∩∧∨￢⇒⇔∀∃∠⊥⌒∂∇≡≒≪≫√∽∝∵∫∬Å‰♯♭♪†‡¶◯";
+		return wcschr(table,c);
 	}
 
 	//! ひらがなかどうか

--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -93,7 +93,7 @@ inline bool isCSymbol(wchar_t c)
 	//	(c>=L'0' && c<=L'9') ||
 	//	(c>=L'A' && c<=L'Z') ||
 	//	(c>=L'a' && c<=L'z');
-	return (c<_countof(gm_keyword_char) && gm_keyword_char[c]==CK_CSYM);
+	return c < gm_keyword_char.size() && gm_keyword_char[c] == CK_CSYM;
 }
 
 //! 全角版、識別子に使用可能な文字かどうか
@@ -123,7 +123,7 @@ ECharKind CWordParse::WhatKindOfChar(
 		wchar_t c=pData[nIdx];
 
 		//今までの半角
-		if( c<_countof(gm_keyword_char) ) return (ECharKind)gm_keyword_char[c];
+		if( c<gm_keyword_char.size() ) return (ECharKind)gm_keyword_char[c];
 		//if( c == CR              )return CK_CR;
 		//if( c == LF              )return CK_LF;
 		//if( c == TAB             )return CK_TAB;	// タブ

--- a/tests/unittests/test-charcode.cpp
+++ b/tests/unittests/test-charcode.cpp
@@ -187,6 +187,7 @@ TEST(charcode, IS_KEYWORD_CHAR)
 		EXPECT_EQ(IS_KEYWORD_CHAR(ch),
 			gm_keyword_char[ch] == CK_CSYM || gm_keyword_char[ch] == CK_UDEF);
 	}
+	EXPECT_FALSE(IS_KEYWORD_CHAR(static_cast<wchar_t>(-1)));
 }
 
 // 以下、関数が判定している文字がすべてASCII範囲内であれば総当たりテストを実施する。

--- a/tests/unittests/test-charcode.cpp
+++ b/tests/unittests/test-charcode.cpp
@@ -183,7 +183,7 @@ TEST_F(CharWidthCache, FontNo)
 
 TEST(charcode, IS_KEYWORD_CHAR)
 {
-	for (wchar_t ch = 0; ch < _countof(gm_keyword_char); ++ch) {
+	for (wchar_t ch = 0; ch < gm_keyword_char.size(); ++ch) {
 		EXPECT_EQ(IS_KEYWORD_CHAR(ch),
 			gm_keyword_char[ch] == CK_CSYM || gm_keyword_char[ch] == CK_UDEF);
 	}


### PR DESCRIPTION
# PR の目的

SonarCloud が charset/charcode.h と charset/charcode.cpp に出している警告のうち、影響範囲の小さいものに対処します。

## カテゴリ

- リファクタリング

## PR の背景

影響範囲が小さく、レビューが容易なものだけをまとめて対処して警告を減らしていきます。

### 残りの Code Smells と対処方針

|警告内容|方針|
|--|--|
|名前空間名を小文字にすべき|既存コードを書き換えるリスクに見合うメリットがない気がするので放置するかもしれません。対処するなら WCODE 名前空間ごと削除したい。|
|enum class を使うべき|同じ理由で放置するかもしれません。|
|グローバル変数は const にすべき|参照しているコードがあまりにも多いため解決するのは難しそう。|
|new と delete を排除せよ|クラスの設計から見直す必要がありそう。これも放置するかもしれません。|

Code Smells ゼロは目指さず他の部分のカバレッジ向上に手をかけようと思います。

## PR のメリット

- SonarCloud の警告が減ります。

## PR のデメリット (トレードオフとかあれば)

- 警告を消すためのおざなりな対処があるかもしれません。

## 仕様・動作説明

- 使われていないコードを削除します。
- NULL を nullptr に置換します。
- マクロ定数を constexpr にします。
- インライン関数内の static 変数を constexpr にします。
- 配列を std::array にします。
- 副作用のない関数に const と [[nodiscard]] 属性を付与します。
- LocalCache::_GetRawPx の戻り値の型を short にします。

## PR の影響範囲

文字種の判定や文字幅のキャッシュなどに関係するコードに変更がありますが、動作は変更しないものに限ります。

## 関連 issue, PR

#1504, #1514