### PR TITLE
stdafx.h から charcode.h と codechecker.h を除去する

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -122,8 +122,6 @@
 
 //TCHARユーティリティ
 #include "util/tchar_convert.h"
-#include "charset/charcode.h"
-#include "charset/codechecker.h"
 
 // 2010.04.19 Moca includeの大規模整理
 #ifndef SAKURA_PCH_MODE_MIN

--- a/sakura_core/charset/CEuc.h
+++ b/sakura_core/charset/CEuc.h
@@ -28,6 +28,7 @@
 
 #include <mbstring.h>
 #include "charset/CCodeBase.h"
+#include "charset/codechecker.h"
 #include "charset/codeutil.h"
 
 class CEuc : public CCodeBase{

--- a/sakura_core/charset/CJis.h
+++ b/sakura_core/charset/CJis.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "CCodeBase.h"
+#include "charset/codechecker.h"
 
 class CJis : public CCodeBase{
 public:

--- a/sakura_core/charset/CLatin1.h
+++ b/sakura_core/charset/CLatin1.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "CCodeBase.h"
+#include "charset/codechecker.h"
 
 class CLatin1 : public CCodeBase{
 

--- a/sakura_core/charset/CShiftJis.h
+++ b/sakura_core/charset/CShiftJis.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "CCodeBase.h"
+#include "charset/codechecker.h"
 #include "charset/codeutil.h"
 
 struct CommonSetting_Statusbar;

--- a/sakura_core/charset/CharPointer.h
+++ b/sakura_core/charset/CharPointer.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "charset/charcode.h"
+#include "charset/codechecker.h"
 
 //!< ディレクトリを除いた、ファイル名だけを取得する
 class CharPointerA{

--- a/sakura_core/convert/convert_util2.h
+++ b/sakura_core/convert/convert_util2.h
@@ -31,6 +31,7 @@
 #define SAKURA_CONVERT_UTIL2_9F00219B_A2FC_4096_BB26_197A667DFD25_H_
 #pragma once
 
+#include "charset/charcode.h"
 #include "parse/CWordParse.h"
 #include "mem/CMemory.h"
 

--- a/sakura_core/extmodule/CMigemo.cpp
+++ b/sakura_core/extmodule/CMigemo.cpp
@@ -20,6 +20,7 @@
 #include "env/CShareData.h"
 #include "env/DLLSHAREDATA.h"
 #include "charset/CUtf8.h"
+#include "charset/codechecker.h"
 #include "util/module.h"
 #include "util/file.h"
 

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -1,6 +1,7 @@
 ﻿/*! @file */
 #include "StdAfx.h"
 #include <stdexcept>
+#include "charset/codechecker.h"
 #include "mem/CNativeW.h"
 #include "CEol.h"
 

--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -2,6 +2,7 @@
 #include "StdAfx.h"
 #include "CWordParse.h"
 #include "charset/charcode.h"
+#include "charset/codechecker.h"
 
 //@@@ 2001.06.23 N.Nakatani
 /*!

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -5,6 +5,7 @@
 #include <stdarg.h>
 
 #include "charset/charcode.h"
+#include "charset/codechecker.h"
 #include "util/std_macro.h"
 #include <limits.h>
 #include <locale.h>

--- a/sakura_core/view/CEditView_Cmdisrch.cpp
+++ b/sakura_core/view/CEditView_Cmdisrch.cpp
@@ -14,6 +14,7 @@
 #include "StdAfx.h"
 #include "view/CEditView.h"
 #include "window/CEditWnd.h"
+#include "charset/codechecker.h"
 #include "doc/CEditDoc.h"
 #include "doc/logic/CDocLine.h"
 #include "extmodule/CMigemo.h"


### PR DESCRIPTION
# PR の目的

stdafx.h から charset/charcode.h と charset/codechecker.h を削除するものです。

先日より charcode.h のリファクタリング作業を行っています。必然的に修正してビルドする作業を繰り返し行うわけですが、charcode.h がプリコンパイル済みヘッダーファイル stdafx.h にインクルードされているために、修正の軽重に関わらず毎回プロジェクト全体のリビルドを待たねばなりません。SonarScanner の実行時間はよりひどい問題で、事実上キャッシュが機能しないため毎回1時間以上をかけてスキャンしている状態です。

特に SonarScanner が遅いことが心理的につらい感じです。現在私が作業しているファイルである charcode.h と、間接的に charcode.h に依存している codechecker.h を stdafx.h から除去できれば…、というのが提案の動機です。

（そもそもプロジェクト内のファイルを stdafx.h に入れるのってどうなの？という点についても議論があっていい気もしますが、これは別の問題ですね）

## カテゴリ

- その他の問題

## PR のメリット

charcode.h 他を変更した際のビルド時間を削減できます。

## PR のデメリット (トレードオフとかあれば)

- 全体のビルド時間が増加します。
  - とはいえ、今回除去するファイルに含まれる定義は単純なものばかりであること、参照しているファイルが多くないことから、おそらく誤差の範囲です。

