### PR TITLE
GetInidirOrExedirの振る舞いを元に戻す

### DIFF
--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -482,15 +482,6 @@ std::filesystem::path GetExeFileName()
 }
 
 /*!
-	@brief exeがあるフォルダのフルパス、またはexe基準のファイルパス(フルパス)を返す．
-*/
-std::filesystem::path GetExePath(const std::wstring_view& filename)
-{
-	// sakura.exe のパスのファイル名を指定された文字列で置換
-	return GetExeFileName().replace_filename(filename.data());
-}
-
-/*!
 	@brief exeファイルのあるディレクトリ，または指定されたファイル名のフルパスを返す．
 	
 	@author genta
@@ -528,15 +519,6 @@ std::filesystem::path GetIniFileName()
 		return pProcess->GetIniFileName();
 	}
 	return GetExeFileName().replace_extension(L".ini");
-}
-
-/*!
-	@brief 設定フォルダのフルパス、またはini基準のファイルパス(フルパス)を返す．
-*/
-std::filesystem::path GetIniPath(const std::wstring_view& filename)
-{
-	// iniファイルパスのファイル名を指定された文字列で置換
-	return GetIniFileName().replace_filename(filename.data());
 }
 
 /*!

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -506,14 +506,17 @@ void GetExedir(
 	if( pDir == NULL )
 		return;
 
-	std::wstring_view filename(L"");
+	std::wstring partialPath;
 	if (szFile != nullptr) {
-		filename = szFile;
+		partialPath = szFile;
+	}
+	if (partialPath.empty() || partialPath[0] != L'\\') {
+		partialPath.insert(partialPath.cbegin(), L'\\');
 	}
 
 	// exeフォルダのフルパス、またはexe基準のファイルパスを取得
-	auto path = GetExePath(filename);
-	::wcsncpy_s(pDir, decltype(DLLSHAREDATA::m_szIniFile)::BUFFER_COUNT - 1, path.c_str(), _TRUNCATE);
+	auto path = GetExeFileName().parent_path().concat(partialPath);
+	::wcsncpy_s(pDir, decltype(DLLSHAREDATA::m_szIniFile)::BUFFER_COUNT, path.c_str(), _TRUNCATE);
 }
 
 /*!
@@ -550,14 +553,17 @@ void GetInidir(
 	if( pDir == NULL )
 		return;
 	
-	std::wstring_view filename(L"");
+	std::wstring partialPath;
 	if (szFile != nullptr) {
-		filename = szFile;
+		partialPath = szFile;
+	}
+	if (partialPath.empty() || partialPath[0] != L'\\') {
+		partialPath.insert(partialPath.cbegin(), L'\\');
 	}
 
 	// 設定フォルダのフルパス、またはini基準のファイルパスを取得
-	auto path = GetIniPath(filename);
-	::wcsncpy_s(pDir, decltype(DLLSHAREDATA::m_szPrivateIniFile)::BUFFER_COUNT - 1, path.c_str(), _TRUNCATE);
+	auto path = GetIniFileName().parent_path().concat(partialPath);
+	::wcsncpy_s(pDir, decltype(DLLSHAREDATA::m_szPrivateIniFile)::BUFFER_COUNT, path.c_str(), _TRUNCATE);
 }
 
 /*!

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -62,8 +62,6 @@ bool _IS_REL_PATH(const WCHAR* path);											//!< 相対パスか判定する
 
 std::filesystem::path GetExeFileName();
 std::filesystem::path GetIniFileName();
-std::filesystem::path GetExePath(const std::wstring_view& filename);
-std::filesystem::path GetIniPath(const std::wstring_view& filename);
 
 //※サクラ依存
 void GetExedir( LPWSTR pDir, LPCWSTR szFile = NULL );

--- a/tests/unittests/test-cdlgprofilemgr.cpp
+++ b/tests/unittests/test-cdlgprofilemgr.cpp
@@ -232,7 +232,7 @@ TEST(file, GetProfileMgrFileName_DefaultProfile1)
 	CControlProcess dummy(nullptr, LR"(-PROF="")");
 
 	// 設定フォルダのパスが返る
-	const auto iniDir = GetIniPath(L"").append("a.txt").remove_filename();
+	const auto iniDir = GetExeFileName().replace_filename(L"").append("a.txt").remove_filename();
 	ASSERT_STREQ(iniDir.c_str(), GetProfileMgrFileName(L"").c_str());
 
 	// コマンドラインのグローバル変数を元に戻す
@@ -275,7 +275,7 @@ TEST(file, GetProfileMgrFileName_NamedProfile1)
 	constexpr auto profile = L"profile1";
 
 	// 指定したプロファイルの設定保存先フォルダのパスが返る
-	const auto profileDir = GetIniPath(profile).append("a.txt").remove_filename();
+	const auto profileDir = GetExeFileName().replace_filename(profile).append("a.txt").remove_filename();
 	ASSERT_STREQ(profileDir.c_str(), GetProfileMgrFileName(profile).c_str());
 
 	// コマンドラインのグローバル変数を元に戻す

--- a/tests/unittests/test-file.cpp
+++ b/tests/unittests/test-file.cpp
@@ -85,48 +85,6 @@ TEST(file, GetExeFileName)
 }
 
 /*!
- * @brief exeフォルダのフルパスの取得
- */
-TEST(file, GetExePath_Directory)
-{
-	// テスト対象関数呼び出し
-	auto exeDir = GetExePath(L"");
-
-	// 戻り値はファイル名を含まない
-	ASSERT_FALSE(exeDir.has_filename());
-
-	// パスコンポーネントの最終要素は空になる(\で終わっている)
-	auto lastComponent = *(--exeDir.end());
-	ASSERT_STREQ(L"", lastComponent.c_str());
-
-	// 戻り値はexeファイルパスからファイル名を取り除いたものになる
-	auto exePath = GetExeFileName();
-	ASSERT_STREQ(exePath.remove_filename().c_str(), exeDir.c_str());
-}
-
-/*!
- * @brief exe基準のファイルパス(フルパス)の取得
- */
-TEST(file, GetExePath_FileName)
-{
-	// テストに使うファイル名(空でなければなんでもいい)
-	constexpr const auto filename = L"README.txt";
-
-	// テスト対象関数呼び出し
-	auto exeBasePath = GetExePath(filename);
-
-	// 戻り値はファイル名を含む
-	ASSERT_TRUE(exeBasePath.has_filename());
-
-	// 戻り値のファイル名は指定したものになっている
-	ASSERT_STREQ(filename, exeBasePath.filename().c_str());
-
-	// 戻り値の親フォルダはexeファイルパスの親フォルダと等しい
-	auto exePath = GetExeFileName();
-	ASSERT_STREQ(exePath.parent_path().c_str(), exeBasePath.parent_path().c_str());
-}
-
-/*!
  * @brief 既存コード互換用に残しておく関数のリグレッション
  */
 TEST(file, Deprecated_GetExedir)
@@ -135,7 +93,7 @@ TEST(file, Deprecated_GetExedir)
 	constexpr const auto filename = L"README.txt";
 
 	// 比較用関数呼び出し
-	auto exeBasePath = GetExePath(filename);
+	auto exeBasePath = GetExeFileName().parent_path().append(filename);
 
 	// 戻り値取得用のバッファ
 	WCHAR szBuf[_MAX_PATH];
@@ -376,48 +334,6 @@ TEST(file, GetIniFileName_PrivateDocument)
 }
 
 /*!
- * @brief iniフォルダのフルパスの取得
- */
-TEST(file, GetIniPath_Directory)
-{
-	// テスト対象関数呼び出し
-	auto iniDir = GetIniPath(L"");
-
-	// 戻り値はファイル名を含まない
-	ASSERT_FALSE(iniDir.has_filename());
-
-	// パスコンポーネントの最終要素は空になる(\で終わっている)
-	auto lastComponent = *(--iniDir.end());
-	ASSERT_STREQ(L"", lastComponent.c_str());
-
-	// 戻り値はiniファイルパスからファイル名を取り除いたものになる
-	auto iniPath = GetIniFileName();
-	ASSERT_STREQ(iniPath.remove_filename().c_str(), iniDir.c_str());
-}
-
-/*!
- * @brief ini基準のファイルパス(フルパス)の取得
- */
-TEST(file, GetIniPath_FileName)
-{
-	// テストに使うファイル名(空でなければなんでもいい)
-	constexpr const auto filename = L"README.txt";
-
-	// テスト対象関数呼び出し
-	auto iniBasePath = GetIniPath(filename);
-
-	// 戻り値はファイル名を含む
-	ASSERT_TRUE(iniBasePath.has_filename());
-
-	// 戻り値のファイル名は指定したものになっている
-	ASSERT_STREQ(filename, iniBasePath.filename().c_str());
-
-	// 戻り値の親フォルダはiniファイルパスの親フォルダと等しい
-	auto iniPath = GetIniFileName();
-	ASSERT_STREQ(iniPath.parent_path().c_str(), iniBasePath.parent_path().c_str());
-}
-
-/*!
  * @brief 既存コード互換用に残しておく関数のリグレッション
  */
 TEST(file, Deprecated_GetInidir)
@@ -426,7 +342,7 @@ TEST(file, Deprecated_GetInidir)
 	constexpr const auto filename = L"README.txt";
 
 	// 比較用関数呼び出し
-	auto iniBasePath = GetIniPath(filename);
+	auto iniBasePath = GetIniFileName().parent_path().append(filename);
 
 	// 戻り値取得用のバッファ
 	WCHAR szBuf[_MAX_PATH];
@@ -464,11 +380,11 @@ TEST(file, GetInidirOrExedir)
 	std::wstring buf(_MAX_PATH, L'\0');
 
 	GetInidirOrExedir(buf.data(), L"", true);
-	ASSERT_STREQ(GetExePath(L"").c_str(), buf.data());
+	ASSERT_STREQ(GetExeFileName().replace_filename(L"").c_str(), buf.data());
 
 	constexpr auto filename = L"test.txt";
-	auto exeBasePath = GetExePath(filename);
-	auto iniBasePath = GetIniPath(filename);
+	auto exeBasePath = GetExeFileName().parent_path().append(filename);
+	auto iniBasePath = GetIniFileName().parent_path().append(filename);
 
 	// EXE基準のファイルを作る
 	{
@@ -478,7 +394,7 @@ TEST(file, GetInidirOrExedir)
 
 	// INI基準のファイルを作る
 	{
-		EnsureDirectoryExist(GetIniPath(L"").c_str());
+		EnsureDirectoryExist(GetIniFileName().replace_filename(L"").c_str());
 
 		std::wofstream ofs(iniBasePath);
 		ofs << L"TEST(file, GetInidirOrExedir)" << std::endl;


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
タイトル通りです。

## <!-- 必須 --> カテゴリ
- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1512 でリファクタリングのつもりで入れた修正が、既存関数GetExedirとGetInidirの振る舞いを変えてしまっていたので、元に戻します。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
意図せず変更していた振る舞いの変更が元に戻ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
思いつきません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
#1512 ではGetExedirとGetInidirに渡すszFileに「相対パス」を指定できるように変更していました。

実際のところ、GetExedirとGetInidirが行う操作は基準となるフォルダパスにszFileを「結合するだけ」であったため、`\で始まる部分パス`を指定した場合の振る舞いが変わってしまっていました。

このPRでは、「相対パス」への対応をキャンセルして振る舞いを元に戻します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
GetExedir、GetInidirに依存する処理に影響を与えます。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
追加のテストはとくにありません。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1512

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
