### PR TITLE
Wnd_GetText が一文字取りこぼす問題に対処

### DIFF
--- a/sakura_core/apiwrap/StdControl.cpp
+++ b/sakura_core/apiwrap/StdControl.cpp
@@ -36,7 +36,7 @@ namespace ApiWrap{
 		}
 
 		// ウィンドウテキストを取得するのに必要なバッファを確保する
-		strText.resize( cchRequired );
+		strText.resize( cchRequired + 1 );
 
 		// GetWindowText() はコピーした文字数を返す。
 		// https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtextw

--- a/tests/unittests/test-StdControl.cpp
+++ b/tests/unittests/test-StdControl.cpp
@@ -32,3 +32,19 @@ TEST(StdControl, Wnd_GetText)
 	CNativeW tempText;
 	ASSERT_FALSE(Wnd_GetText(NULL, tempText));
 }
+
+// GitHub #1528 の退行防止テストケース。
+// 取得する文字列の長さが basic_string::capacity と同じだった場合に一文字取りこぼしていた。
+TEST(StdControl, Wnd_GetText2)
+{
+	wchar_t text[] = L"0123456789012345678901234567890123456789";
+
+	std::wstring s;
+	text[s.capacity()] = L'\0';
+
+	HINSTANCE hinstance = GetModuleHandleW(nullptr);
+	HWND hwnd = CreateWindowExW(0, L"STATIC", text, 0, 1, 1, 1, 1, nullptr, nullptr, hinstance, nullptr);
+	Wnd_GetText(hwnd, s);
+	DestroyWindow(hwnd);
+	ASSERT_STREQ(s.c_str(), text);
+}


### PR DESCRIPTION
# PR の目的

#1525 で報告された問題に対処します。

## カテゴリ

- プログラムの動作上の問題

## 仕様・動作説明

問題の箇所は GetWindowTextLengthW で必要文字長を取得し、必要分のバッファを確保して、 GetWindowTextW にバッファ長を渡しているところです。

ここで問題になるのが API が扱う文字列長にnull文字を含むものと含まないものが混在していることで、GetWindowTextLengthW が返すのはnull文字を含まない長さですが、GetWindowTextW はnull文字を含めた長さを要求するので、どこかで1を足さなければ結果の文字列が1文字不足します。

提案する修正では basic_string::capacity() に1を足して GetWindowTextW に渡します。data() + size() にnullを書き込む操作を行いますが、[C++17 では安全です。](https://qiita.com/yumetodo/items/24d21d97e04977b78b45)

## PR の影響範囲

ApiWrap::Wnd_GetText を利用しているすべての箇所で挙動が変わります。

## テスト内容

#1525 を参照してください。

## 関連 issue, PR

#1439