### PR TITLE
文字幅キャッシュの管理クラスを CCharWidthCache として公開する

### DIFF
--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -308,3 +308,8 @@ void SelectCharWidthCache( ECharWidthFontMode fMode, ECharWidthCacheMode cMode  
 
 	WCODE::selector.Select( fMode, cMode );
 }
+
+[[nodiscard]] CCharWidthCache& GetCharWidthCache()
+{
+	return *WCODE::selector.GetCache();
+}

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -25,7 +25,7 @@
 
 #include "StdAfx.h"
 #include "charset/charcode.h"
-
+#include <array>
 #include "env/DLLSHAREDATA.h"
 
 /*! キーワードキャラクタ */
@@ -96,12 +96,12 @@ namespace WCODE
 		文字幅情報のキャッシュクラス。
 		1文字当たり2バイトで保存しておく。
 	*/
-	class LocalCache{
+	class CCharWidthCache{
 	public:
-		LocalCache() = default;
-		LocalCache(const LocalCache&) = delete;
-		LocalCache& operator=(const LocalCache&) = delete;
-		~LocalCache()
+		CCharWidthCache() = default;
+		CCharWidthCache(const CCharWidthCache&) = delete;
+		CCharWidthCache& operator=(const CCharWidthCache&) = delete;
+		~CCharWidthCache()
 		{
 			// -- -- 後始末 -- -- //
 			DeleteLocalData();
@@ -235,15 +235,15 @@ namespace WCODE
 		SCharWidthCache*	m_pCache = nullptr;
 	};
 
-	class LocalCacheSelector{
+	class CacheSelector{
 	public:
-		LocalCacheSelector() : pcache(m_localcache.data())
+		CacheSelector() : pcache(m_localcache.data())
 		{
 			for( int i=0; i<CWM_FONT_MAX; i++ ){
 				m_parCache[i] = 0;
 			}
 		}
-		~LocalCacheSelector()
+		~CacheSelector()
 		{
 			for( int i=0; i<CWM_FONT_MAX; i++ ){
 				delete m_parCache[i];
@@ -273,16 +273,16 @@ namespace WCODE
 			if( fMode==CWM_FONT_EDIT ){ m_eLastEditCacheMode = cmode; }
 			WCODE::s_MultiFont = pcache->GetMultiFont();
 		}
-		[[nodiscard]] LocalCache* GetCache(){ return pcache; }
+		[[nodiscard]] CCharWidthCache* GetCache(){ return pcache; }
 	private:
-		std::array<LocalCache, 3> m_localcache;
+		std::array<CCharWidthCache, 3> m_localcache;
 		std::array<SCharWidthCache*, 3> m_parCache;
 		ECharWidthCacheMode m_eLastEditCacheMode = CWM_CACHE_NEUTRAL;
-		LocalCache* pcache;
-		DISALLOW_COPY_AND_ASSIGN(LocalCacheSelector);
+		CCharWidthCache* pcache;
+		DISALLOW_COPY_AND_ASSIGN(CacheSelector);
 	};
 
-	static LocalCacheSelector selector;
+	static CacheSelector selector;
 
 	//文字幅の動的計算。ピクセル幅
 	int CalcPxWidthByFont(wchar_t c)

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -119,7 +119,7 @@ void CCharWidthCache::Init(const LOGFONT &lf, const LOGFONT &lfFull, HDC hdcOrg)
 
 	m_hFont = ::CreateFontIndirect( &lf );
 	m_hFontOld = (HFONT)SelectObject(m_hdc,m_hFont);
-	const bool bFullFont = &lf != &lfFull && std::memcmp(&lf, &lfFull, sizeof(lf)) != 0;
+	const bool bFullFont = &lf != &lfFull && memcmp(&lf, &lfFull, sizeof(lf)) != 0;
 	if( bFullFont ){
 		m_bMultiFont = true;
 		m_hdcFull = CreateCompatibleDC(hdcOrg);

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -245,6 +245,45 @@ enum ECharWidthCacheMode {
 	CWM_CACHE_LOCAL,
 };
 
+/*!
+	文字幅情報のキャッシュクラス。
+	1文字当たり2バイトで文字のピクセル幅を保存しておく。
+*/
+class CCharWidthCache {
+public:
+	CCharWidthCache() = default;
+	CCharWidthCache(const CCharWidthCache&) = delete;
+	CCharWidthCache& operator=(const CCharWidthCache&) = delete;
+	~CCharWidthCache() { DeleteLocalData(); }
+
+	// 再初期化
+	void Init(const LOGFONT& lf, const LOGFONT& lfFull, HDC hdcOrg);
+	void SelectCache(SCharWidthCache* pCache) { m_pCache = pCache; }
+	void Clear();
+	[[nodiscard]] bool GetMultiFont() const { return m_bMultiFont; }
+
+	bool CalcHankakuByFont(wchar_t c) const;
+	int CalcPxWidthByFont(wchar_t c);
+	int CalcPxWidthByFont2(const wchar_t* pc2) const;
+
+private:
+	void DeleteLocalData();
+	int QueryPixelWidth(wchar_t c) const;
+	[[nodiscard]] HDC SelectHDC(wchar_t c) const;
+
+	HDC m_hdc = nullptr;
+	HDC m_hdcFull = nullptr;
+	HFONT m_hFontOld = nullptr;
+	HFONT m_hFontFullOld = nullptr;
+	HFONT m_hFont = nullptr;
+	HFONT m_hFontFull = nullptr;
+	bool m_bMultiFont;
+	SIZE m_han_size;
+	LOGFONT m_lf{};				// 2008/5/15 Uchi
+	LOGFONT m_lf2{};
+	SCharWidthCache* m_pCache = nullptr;
+};
+
 // キャッシュの初期化関数群
 void SelectCharWidthCache( ECharWidthFontMode fMode, ECharWidthCacheMode cMode );  //!< モードを変更したいとき
 void InitCharWidthCache( const LOGFONT &lf, ECharWidthFontMode fMode=CWM_FONT_EDIT ); //!< フォントを変更したとき

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -288,4 +288,6 @@ private:
 void SelectCharWidthCache( ECharWidthFontMode fMode, ECharWidthCacheMode cMode );  //!< モードを変更したいとき
 void InitCharWidthCache( const LOGFONT &lf, ECharWidthFontMode fMode=CWM_FONT_EDIT ); //!< フォントを変更したとき
 void InitCharWidthCacheFromDC(const LOGFONT* lfs, ECharWidthFontMode fMode, HDC hdcOrg );
+[[nodiscard]] CCharWidthCache& GetCharWidthCache();
+
 #endif /* SAKURA_CHARCODE_4C34C669_0BAB_441A_9B1D_2B9AC1895380_H_ */

--- a/sakura_core/view/CTextMetrics.cpp
+++ b/sakura_core/view/CTextMetrics.cpp
@@ -72,7 +72,7 @@ void CTextMetrics::Update(HDC hdc, HFONT hFont, int nLineSpace, int nColmSpace)
 	for( int i = 0; i < size; i++ ){
 		HFONT hFontOld = (HFONT)::SelectObject( hdc, hFontArray[i] );
  		SIZE  sz;
-		// LocalCache::m_han_size と一致していなければならない
+		// CCharWidthCache::m_han_size と一致していなければならない
 		{
 			// KB145994
 			// tmAveCharWidth は不正確(半角か全角なのかも不明な値を返す)

--- a/tests/unittests/test-charcode.cpp
+++ b/tests/unittests/test-charcode.cpp
@@ -181,6 +181,23 @@ TEST_F(CharWidthCache, FontNo)
 	EXPECT_EQ(WCODE::GetFontNo2(0xd83c, 0xdf38), 1);
 }
 
+TEST_F(CharWidthCache, GetCharWidthCache)
+{
+	SelectCharWidthCache(CWM_FONT_EDIT, CWM_CACHE_LOCAL);
+	CCharWidthCache& edit1 = GetCharWidthCache();
+	SelectCharWidthCache(CWM_FONT_MINIMAP, CWM_CACHE_LOCAL);
+	CCharWidthCache& minimap = GetCharWidthCache();
+
+	// 違うキャッシュ
+	EXPECT_NE(&edit1, &minimap);
+
+	SelectCharWidthCache(CWM_FONT_EDIT, CWM_CACHE_LOCAL);
+	CCharWidthCache& edit2 = GetCharWidthCache();
+
+	// 同じキャッシュ
+	EXPECT_EQ(&edit1, &edit2);
+}
+
 TEST(charcode, IS_KEYWORD_CHAR)
 {
 	for (wchar_t ch = 0; ch < gm_keyword_char.size(); ++ch) {


### PR DESCRIPTION
# PR の目的

文字幅キャッシュの管理クラスをアプリ全体に公開し、依存するコードの単体テストを書きやすくします。

## カテゴリ

- リファクタリング

## PR のメリット

現在グローバル関数に依存している処理をオブジェクトへの依存に置き換えられるようになります。
```
WCODE::CalcPxWidthByFont(ch);
```
☝から以下のような形への書き換えが可能です。
```
CCharWidthCache& cache = GetCharWidthCache();
cache.CalcPxWidthByFont(ch);
```

これを利用して今後 CTextMetrics や CNativeW の単体テストの追加を予定しています。

## PR の影響範囲

動作を変更するものではありません。