### PR TITLE
sakura.iniがない状態で起動した時にマウスホイールでフォントサイズが変更できない問題を修正

### DIFF
--- a/sakura_core/cmd/CViewCommander_Settings.cpp
+++ b/sakura_core/cmd/CViewCommander_Settings.cpp
@@ -296,8 +296,14 @@ void CViewCommander::Command_SETFONTSIZE( int fontSize, int shift, int mode )
 		nCurrentZoom = 1.0;
 	}else if( 0 != shift ){
 		// 現在のフォントに対して、縮小or拡大したフォント選択する場合
+		double nBasePointSizeF = nOriginalPointSize;
+		if( nBasePointSizeF == 0.0 ){
+			// 基準値が無効値の時はLOGFONTのサイズから逆算
+			const LOGFONT& lfBase = (mode == 0) ? GetDllShareData().m_Common.m_sView.m_lf : GetEditWindow()->GetLogfont( false );
+			nBasePointSizeF = (lfBase.lfHeight != 0) ? (std::abs( DpiPixelsToPoints( lfBase.lfHeight ) ) * 10.0) : nPointSizeMin;
+		}
 		double nPointSizeF = 0.0;
-		if( !GetZoomedValue( zoomSetting, nOriginalPointSize, nCurrentZoom, shift, &nPointSizeF, &nCurrentZoom ) ){
+		if( !GetZoomedValue( zoomSetting, nBasePointSizeF, nCurrentZoom, shift, &nPointSizeF, &nCurrentZoom ) ){
 			return;
 		}
 		nPointSize = (int)nPointSizeF;

--- a/tests/unittests/test-winmain.cpp
+++ b/tests/unittests/test-winmain.cpp
@@ -305,6 +305,8 @@ TEST_F( WinMainTest, runEditorProcess )
 		strStartupMacro += L"ShowTab();";		//ShowTab 消す
 		strStartupMacro += L"ExpandParameter('$I');";	// INIファイルパスの取得(呼ぶだけ)
 		// フォントサイズ設定のテスト(ここから)
+		strStartupMacro += L"SetFontSize(0, 1, 0);";	// 相対指定 - 拡大 - 対象：共通設定
+		strStartupMacro += L"SetFontSize(0, -1, 0);";	// 相対指定 - 縮小 - 対象：共通設定
 		strStartupMacro += L"SetFontSize(100, 0, 0);";	// 直接指定 - 対象：共通設定
 		strStartupMacro += L"SetFontSize(100, 0, 1);";	// 直接指定 - 対象：タイプ別設定
 		strStartupMacro += L"SetFontSize(100, 0, 2);";	// 直接指定 - 対象：一時適用


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

sakura.ini が置かれていない状態でサクラエディタを起動した後、Ctrl + マウスホイール操作をしてもフォントサイズが 100% のまま変更できない問題を修正します。

※この問題は https://github.com/sakura-editor/sakura/pull/1513 の反映後 (https://github.com/sakura-editor/sakura/commit/73d4fe783a9a6eb96a520b06dc43b16901c47c72 以降) から発生

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

https://github.com/sakura-editor/sakura/pull/1513#issuecomment-775161148 にて報告頂いた問題の修正です。

## <!-- 自明なら省略可 --> PR のメリット

不具合が解消されます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

特にありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

### Ctrl + マウスホイール操作時の処理概要

`CViewCommander::Command_SETFONTSIZE` にてマウスホイールの回転方向に応じた相対指定によるフォントサイズ設定が行われます。
この相対指定時にはその時点の共通設定またはタイプ別設定のフォントサイズを基準値とし、それにズーム倍率を乗算したものを変更後のフォントサイズ候補として算出します。
算出されたフォントサイズが変更前と異なる場合に限り、そのサイズを一時適用フォントサイズとしてして設定、エディタに反映します。

### フォントサイズ変更ができない理由について

sakura.ini が置かれていない状態でサクラエディタを起動した時には、LOGFONT 構造体のフォントサイズとして 10pt 相当の値が設定される一方、ポイント単位のサイズを保持する変数 `CommonSetting_View::m_nPointSize` には 0 (無効値) が設定されます。

https://github.com/sakura-editor/sakura/blob/73d4fe783a9a6eb96a520b06dc43b16901c47c72/sakura_core/env/CShareData.cpp#L198

https://github.com/sakura-editor/sakura/blob/73d4fe783a9a6eb96a520b06dc43b16901c47c72/sakura_core/env/CShareData.cpp#L561

相対指定時における基準値となる `CommonSetting_View::m_nPointSize` が 0 の場合、ズーム倍率を適用した後のフォントサイズも必ず 0 となるため、サイズ変更なしとしてフォントサイズの反映がスキップされます。
結果、マウスホイール操作に対して何も反応がない状態となります。

### 対策方法

`CViewCommander::Command_SETFONTSIZE` において、相対指定時の基準値が 0 (無効値) の場合には、LOGFONT 構造体の lfHeight の値から pt 単位のフォントサイズを算出してそれを基準値として使うようにします。
また、もし lfHeight から得たフォントサイズも 0 となる場合には、設定可能なフォントサイズの下限値 (=1pt) を基準値とします。

## <!-- わかる範囲で --> PR の影響範囲

* マウスホイールによるフォントサイズ変更動作
* マクロコマンド SetFontSize の振る舞い

## <!-- 必須 --> テスト内容

sakura.ini がない状態で起動させた直後の動作を確認します。
* (起動直後) Ctrl + ホイール操作でフォントサイズの拡大縮小ができること。
* (起動直後) 以下のマクロ (.js) を「名前を指定してマクロ実行」で実行した時にフォントサイズの倍率が 200% に変わること。
```
SetFontSize( 0, 5, 2 );
```

## <!-- なければ省略可 --> 関連 issue, PR

https://github.com/sakura-editor/sakura/pull/1513

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
