### PR TITLE
プロポーショナル版で禁則処理を使えるようにする

### DIFF
--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -351,13 +351,7 @@ private:
 	bool IsKinsokuTail( wchar_t wc ) const;	// 行末禁則文字をチェックする
 	bool IsKinsokuKuto( wchar_t wc ) const;	// 句読点文字をチェックする
 	//	2005-08-20 D.S.Koba 禁則関連処理の関数化
-	/*! 句読点ぶら下げの処理位置か
-		@date 2005-08-20 D.S.Koba
-		@date Sep. 3, 2005 genta 最適化
-	*/
-	bool IsKinsokuPosKuto(CLayoutInt nRest, CLayoutInt nCharChars ) const {
-		return nRest < nCharChars;
-	}
+	bool IsKinsokuPosKuto( CLayoutInt nRest, CLayoutInt nCharChars ) const;	// 句読点ぶら下げの処理位置か
 	bool IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const;	// 行頭禁則の処理位置か
 	bool IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const;	// 行末禁則の処理位置か
 private:

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -345,8 +345,6 @@ protected:
 	void _OnLine2(SLayoutWork* pWork);
 
 private:
-	bool _ExistKinsokuKuto(wchar_t wc) const{ return m_pszKinsokuKuto_1.exist(wc); }
-	bool _ExistKinsokuHead(wchar_t wc) const{ return m_pszKinsokuHead_1.exist(wc); }
 	bool IsKinsokuHead( wchar_t wc ) const;	// 行頭禁則文字をチェックする
 	bool IsKinsokuTail( wchar_t wc ) const;	// 行末禁則文字をチェックする
 	bool IsKinsokuKuto( wchar_t wc ) const;	// 句読点文字をチェックする

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -334,7 +334,7 @@ protected:
 	//DoLayout用
 	bool _DoKinsokuSkip(SLayoutWork* pWork, PF_OnLine pfOnLine);
 	void _DoWordWrap(SLayoutWork* pWork, PF_OnLine pfOnLine);
-	void _DoKutoBurasage(SLayoutWork* pWork);
+	void _DoKutoBurasage(SLayoutWork* pWork) const;
 	void _DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine);
 	void _DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine);
 	bool _DoTab(SLayoutWork* pWork, PF_OnLine pfOnLine);

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -347,9 +347,9 @@ protected:
 private:
 	bool _ExistKinsokuKuto(wchar_t wc) const{ return m_pszKinsokuKuto_1.exist(wc); }
 	bool _ExistKinsokuHead(wchar_t wc) const{ return m_pszKinsokuHead_1.exist(wc); }
-	bool IsKinsokuHead( wchar_t wc );	/*!< 行頭禁則文字をチェックする */	//@@@ 2002.04.08 MIK
-	bool IsKinsokuTail( wchar_t wc );	/*!< 行末禁則文字をチェックする */	//@@@ 2002.04.08 MIK
-	bool IsKinsokuKuto( wchar_t wc );	/*!< 句読点文字をチェックする */	//@@@ 2002.04.17 MIK
+	bool IsKinsokuHead( wchar_t wc ) const;	// 行頭禁則文字をチェックする
+	bool IsKinsokuTail( wchar_t wc ) const;	// 行末禁則文字をチェックする
+	bool IsKinsokuKuto( wchar_t wc ) const;	// 句読点文字をチェックする
 	//	2005-08-20 D.S.Koba 禁則関連処理の関数化
 	/*! 句読点ぶら下げの処理位置か
 		@date 2005-08-20 D.S.Koba
@@ -358,8 +358,8 @@ private:
 	bool IsKinsokuPosKuto(CLayoutInt nRest, CLayoutInt nCharChars ) const {
 		return nRest < nCharChars;
 	}
-	bool IsKinsokuPosHead(CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2);	//!< 行頭禁則の処理位置か
-	bool IsKinsokuPosTail(CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2);	//!< 行末禁則の処理位置か
+	bool IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const;	// 行頭禁則の処理位置か
+	bool IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const;	// 行末禁則の処理位置か
 private:
 	//	Oct. 1, 2002 genta インデント幅計算関数群
 	CLayoutInt getIndentOffset_Normal( CLayout* pLayoutPrev );

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -348,11 +348,6 @@ private:
 	bool IsKinsokuHead( wchar_t wc ) const;	// 行頭禁則文字をチェックする
 	bool IsKinsokuTail( wchar_t wc ) const;	// 行末禁則文字をチェックする
 	bool IsKinsokuKuto( wchar_t wc ) const;	// 句読点文字をチェックする
-	//	2005-08-20 D.S.Koba 禁則関連処理の関数化
-	bool IsKinsokuPosKuto( CLayoutInt nRest, CLayoutInt nCharChars ) const;	// 句読点ぶら下げの処理位置か
-	bool IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const;	// 行頭禁則の処理位置か
-	bool IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const;	// 行末禁則の処理位置か
-private:
 	//	Oct. 1, 2002 genta インデント幅計算関数群
 	CLayoutInt getIndentOffset_Normal( CLayout* pLayoutPrev );
 	CLayoutInt getIndentOffset_Tx2x( CLayout* pLayoutPrev );

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -118,7 +118,9 @@ void CLayoutMgr::_DoWordWrap(SLayoutWork* pWork, PF_OnLine pfOnLine)
 
 void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 {
-	if( (GetMaxLineLayout() - pWork->nPosX < 2) && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
+	if(
+//		(GetMaxLineLayout() - pWork->nPosX < 2 * GetWidthPerKeta()) &&
+		(pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
 		// 2007.09.07 kobake   レイアウトとロジックの区別
 		CLayoutInt nCharKetas = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
@@ -135,7 +137,7 @@ void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
 	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji 追加
-	 && (GetMaxLineLayout() - pWork->nPosX < 4)
+//	 && (GetMaxLineLayout() - pWork->nPosX < 4 * GetWidthPerKeta())
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
@@ -160,7 +162,7 @@ void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
 	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji 追加
-	 && (GetMaxLineKetas() - pWork->nPosX < 4)
+//	 && (GetMaxLineKetas() - pWork->nPosX < 4 * GetWidthPerKeta())
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{	/* 行末禁則する && 行末付近 && 行頭でないこと(無限に禁則してしまいそう) */

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -184,7 +184,7 @@ void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
 		bool bLowSurrogate = false;
 
-		if( nCharKetas3 == 0 )
+		if( nCharKetas3 == 0 && pWork->nPos + 2 < pWork->cLineStr.GetLength() )
 		{
 			// サロゲートペア対策(取得した文字幅が0だったら下位側を読み取ったと判断し、次の位置に進ませる)
 			bLowSurrogate = true;

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -53,7 +53,7 @@ static bool _GetKeywordLength(
 	@param[in] nCharKetas2 次の位置にある文字の幅
 	@return 処理が必要な位置ならばtrue
 */
-static bool _IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
+[[nodiscard]] static bool _IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
 {
 	return nRest < nCharKetas + nCharKetas2;
 }
@@ -66,7 +66,7 @@ static bool _IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutI
 	@param[in] nCharKetas2 次の位置にある文字の幅
 	@return 処理が必要な位置ならばtrue
 */
-static bool _IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
+[[nodiscard]] static bool _IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
 {
 	return nRest < nCharKetas + nCharKetas2;
 }
@@ -78,7 +78,7 @@ static bool _IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutI
 	@param[in] nCharChars 現在の位置にある文字の幅
 	@return 処理が必要な位置ならばtrue
 */
-static bool _IsKinsokuPosKuto( CLayoutInt nRest, CLayoutInt nCharChars )
+[[nodiscard]] static bool _IsKinsokuPosKuto( CLayoutInt nRest, CLayoutInt nCharChars )
 {
 	return nRest < nCharChars;
 }
@@ -154,7 +154,7 @@ void CLayoutMgr::_DoWordWrap(SLayoutWork* pWork, PF_OnLine pfOnLine)
 	}
 }
 
-void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
+void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork) const
 {
 	// 現在位置が行末付近で禁則処理の実行中でないこと
 	if( GetMaxLineLayout() - pWork->nPosX < 2 * GetWidthPerKeta() && pWork->eKinsokuType == KINSOKU_TYPE_NONE )

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -118,9 +118,8 @@ void CLayoutMgr::_DoWordWrap(SLayoutWork* pWork, PF_OnLine pfOnLine)
 
 void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 {
-	if(
-//		(GetMaxLineLayout() - pWork->nPosX < 2 * GetWidthPerKeta()) &&
-		(pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
+	if( ( GetMaxLineLayout() - pWork->nPosX < 2 * GetWidthPerKeta() )
+	 && ( pWork->eKinsokuType == KINSOKU_TYPE_NONE ) )
 	{
 		// 2007.09.07 kobake   レイアウトとロジックの区別
 		CLayoutInt nCharKetas = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
@@ -137,7 +136,7 @@ void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
 	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji 追加
-//	 && (GetMaxLineLayout() - pWork->nPosX < 4 * GetWidthPerKeta())
+	 && ( GetMaxLineLayout() - pWork->nPosX < 4 * GetWidthPerKeta() )
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
@@ -162,7 +161,7 @@ void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
 	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji 追加
-//	 && (GetMaxLineKetas() - pWork->nPosX < 4 * GetWidthPerKeta())
+	 && ( GetMaxLineLayout() - pWork->nPosX < 4 * GetWidthPerKeta() )
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{	/* 行末禁則する && 行末付近 && 行頭でないこと(無限に禁則してしまいそう) */

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -118,6 +118,7 @@ void CLayoutMgr::_DoWordWrap(SLayoutWork* pWork, PF_OnLine pfOnLine)
 
 void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 {
+	// 現在位置が行末付近で禁則処理の実行中でないこと
 	if( ( GetMaxLineLayout() - pWork->nPosX < 2 * GetWidthPerKeta() )
 	 && ( pWork->eKinsokuType == KINSOKU_TYPE_NONE ) )
 	{
@@ -135,6 +136,7 @@ void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork)
 
 void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
+	// 現在位置が行末付近かつ行頭ではなく、禁則処理の実行中でないこと
 	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji 追加
 	 && ( GetMaxLineLayout() - pWork->nPosX < 4 * GetWidthPerKeta() )
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
@@ -160,11 +162,12 @@ void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 
 void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 {
+	// 現在位置が行末付近かつ行頭ではなく、禁則処理の実行中でないこと
 	if( (pWork->nPos+1 < pWork->cLineStr.GetLength())	// 2007.02.17 ryoji 追加
 	 && ( GetMaxLineLayout() - pWork->nPosX < 4 * GetWidthPerKeta() )
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
-	{	/* 行末禁則する && 行末付近 && 行頭でないこと(無限に禁則してしまいそう) */
+	{
 		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
 		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
 

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -55,15 +55,7 @@ static bool _GetKeywordLength(
 */
 static bool _IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
 {
-	if( nRest < nCharKetas ){
-		// 次の文字で折り返しの場合
-		return true;
-	}
-	if( nRest < nCharKetas + nCharKetas2 ){
-		// 次の次の文字で折り返しの場合
-		return true;
-	}
-	return false;
+	return nRest < nCharKetas + nCharKetas2;
 }
 
 /*!
@@ -76,15 +68,7 @@ static bool _IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutI
 */
 static bool _IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
 {
-	if( nRest < nCharKetas ){
-		// 次の文字で折り返しの場合
-		return true;
-	}
-	if( nRest < nCharKetas + nCharKetas2 ){
-		// 次の次の文字で折り返しの場合
-		return true;
-	}
-	return false;
+	return nRest < nCharKetas + nCharKetas2;
 }
 
 /*!

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -64,8 +64,8 @@ bool CLayoutMgr::IsKinsokuKuto( wchar_t wc ) const
 	行頭禁則の処理位置であるか調べる
 
 	@param[in] nRest 現在行における残り文字数分の字幅と間隔の合計
-	@param[in] nCharKetas 現在のカーソル位置にある文字の幅と間隔
-	@param[in] nCharKetas2 次のカーソル位置にある文字の幅と間隔
+	@param[in] nCharKetas 現在の位置にある文字の幅と間隔
+	@param[in] nCharKetas2 次の位置にある文字の幅と間隔
 	@return 処理が必要な位置である場合にtrue
 */
 bool CLayoutMgr::IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const
@@ -85,8 +85,8 @@ bool CLayoutMgr::IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLay
 	行末禁則の処理位置であるか調べる
 
 	@param[in] nRest 現在行における残り文字数分の字幅と間隔の合計
-	@param[in] nCharKetas 現在のカーソル位置にある文字の幅と間隔
-	@param[in] nCharKetas2 次のカーソル位置にある文字の幅と間隔
+	@param[in] nCharKetas 現在の位置にある文字の幅と間隔
+	@param[in] nCharKetas2 次の位置にある文字の幅と間隔
 	@return 処理が必要な位置である場合にtrue
 */
 bool CLayoutMgr::IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const
@@ -106,7 +106,7 @@ bool CLayoutMgr::IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLay
 	句読点ぶら下げの処理位置であるか調べる
 
 	@param[in] nRest 現在行における残り文字数分の字幅と間隔の合計
-	@param[in] nCharChars 現在のカーソル位置にある文字の幅と間隔
+	@param[in] nCharChars 現在の位置にある文字の幅と間隔
 	@return 処理が必要な位置である場合にtrue
 */
 bool CLayoutMgr::IsKinsokuPosKuto( CLayoutInt nRest, CLayoutInt nCharChars ) const

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -27,8 +27,7 @@
 /*!
 	行頭禁則文字に該当するかを調べる．
 
-	@param[in] pLine 調べる文字へのポインタ
-	@param[in] length 当該箇所の文字サイズ
+	@param[in] wc 調べる文字
 	@retval true 禁則文字に該当
 	@retval false 禁則文字に該当しない
 */
@@ -40,8 +39,7 @@ bool CLayoutMgr::IsKinsokuHead( wchar_t wc )
 /*!
 	行末禁則文字に該当するかを調べる．
 
-	@param[in] pLine 調べる文字へのポインタ
-	@param[in] length 当該箇所の文字サイズ
+	@param[in] wc 調べる文字
 	@retval true 禁則文字に該当
 	@retval false 禁則文字に該当しない
 */
@@ -53,8 +51,7 @@ bool CLayoutMgr::IsKinsokuTail( wchar_t wc )
 /*!
 	禁則対象句読点に該当するかを調べる．
 
-	@param [in] pLine  調べる文字へのポインタ
-	@param [in] length 当該箇所の文字サイズ
+	@param[in] wc 調べる文字
 	@retval true 禁則文字に該当
 	@retval false 禁則文字に該当しない
 */
@@ -64,13 +61,14 @@ bool CLayoutMgr::IsKinsokuKuto( wchar_t wc )
 }
 
 /*!
-	@date 2005-08-20 D.S.Koba _DoLayout()とDoLayout_Range()から分離
+	行頭禁則の処理位置であるか調べる
+
+	@param[in] nRest 現在行における残り文字数分の字幅と間隔の合計
+	@param[in] nCharKetas 現在のカーソル位置にある文字の幅と間隔
+	@param[in] nCharKetas2 次のカーソル位置にある文字の幅と間隔
+	@return 処理が必要な位置である場合にtrue
 */
-bool CLayoutMgr::IsKinsokuPosHead(
-	CLayoutInt nRest,		//!< [in] 行の残り文字数
-	CLayoutInt nCharKetas,	//!< [in] 現在位置の文字サイズ
-	CLayoutInt nCharKetas2	//!< [in] 現在位置の次の文字サイズ
-)
+bool CLayoutMgr::IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
 {
 	if( nRest < nCharKetas ){
 		// 次の文字で折り返しの場合
@@ -117,13 +115,14 @@ bool CLayoutMgr::IsKinsokuPosHead(
 }
 
 /*!
-	@date 2005-08-20 D.S.Koba _DoLayout()とDoLayout_Range()から分離
+	行末禁則の処理位置であるか調べる
+
+	@param[in] nRest 現在行における残り文字数分の字幅と間隔の合計
+	@param[in] nCharKetas 現在のカーソル位置にある文字の幅と間隔
+	@param[in] nCharKetas2 次のカーソル位置にある文字の幅と間隔
+	@return 処理が必要な位置である場合にtrue
 */
-bool CLayoutMgr::IsKinsokuPosTail(
-	CLayoutInt nRest,		//!< [in] 行の残り文字数
-	CLayoutInt nCharKetas,	//!< [in] 現在位置の文字サイズ
-	CLayoutInt nCharKetas2	//!< [in] 現在位置の次の文字サイズ
-)
+bool CLayoutMgr::IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
 {
 	if( nRest < nCharKetas ){
 		// 次の文字で折り返しの場合

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -72,6 +72,16 @@ bool CLayoutMgr::IsKinsokuPosHead(
 	CLayoutInt nCharKetas2	//!< [in] 現在位置の次の文字サイズ
 )
 {
+	if( nRest < nCharKetas ){
+		// 次の文字で折り返しの場合
+		return true;
+	}
+	if( nRest < nCharKetas + nCharKetas2 ){
+		// 次の次の文字で折り返しの場合
+		return true;
+	}
+	return false;
+#if 0
 	switch( (Int)nRest )
 	{
 	//    321012  ↓マジックナンバー
@@ -103,6 +113,7 @@ bool CLayoutMgr::IsKinsokuPosHead(
 		break;
 	}
 	return false;
+#endif
 }
 
 /*!
@@ -114,6 +125,16 @@ bool CLayoutMgr::IsKinsokuPosTail(
 	CLayoutInt nCharKetas2	//!< [in] 現在位置の次の文字サイズ
 )
 {
+	if( nRest < nCharKetas ){
+		// 次の文字で折り返しの場合
+		return true;
+	}
+	if( nRest < nCharKetas + nCharKetas2 ){
+		// 次の次の文字で折り返しの場合
+		return true;
+	}
+	return false;
+#if 0
 	switch( (Int)nRest )
 	{
 	case 3:	// 3文字前
@@ -140,6 +161,7 @@ bool CLayoutMgr::IsKinsokuPosTail(
 		break;
 	}
 	return false;
+#endif
 }
 
 /*!

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -31,7 +31,7 @@
 	@retval true 禁則文字に該当
 	@retval false 禁則文字に該当しない
 */
-bool CLayoutMgr::IsKinsokuHead( wchar_t wc )
+bool CLayoutMgr::IsKinsokuHead( wchar_t wc ) const
 {
 	return m_pszKinsokuHead_1.exist(wc);
 }
@@ -43,7 +43,7 @@ bool CLayoutMgr::IsKinsokuHead( wchar_t wc )
 	@retval true 禁則文字に該当
 	@retval false 禁則文字に該当しない
 */
-bool CLayoutMgr::IsKinsokuTail( wchar_t wc )
+bool CLayoutMgr::IsKinsokuTail( wchar_t wc ) const
 {
 	return m_pszKinsokuTail_1.exist(wc);
 }
@@ -55,7 +55,7 @@ bool CLayoutMgr::IsKinsokuTail( wchar_t wc )
 	@retval true 禁則文字に該当
 	@retval false 禁則文字に該当しない
 */
-bool CLayoutMgr::IsKinsokuKuto( wchar_t wc )
+bool CLayoutMgr::IsKinsokuKuto( wchar_t wc ) const
 {
 	return m_pszKinsokuKuto_1.exist(wc);
 }
@@ -68,7 +68,7 @@ bool CLayoutMgr::IsKinsokuKuto( wchar_t wc )
 	@param[in] nCharKetas2 次のカーソル位置にある文字の幅と間隔
 	@return 処理が必要な位置である場合にtrue
 */
-bool CLayoutMgr::IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
+bool CLayoutMgr::IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const
 {
 	if( nRest < nCharKetas ){
 		// 次の文字で折り返しの場合
@@ -122,7 +122,7 @@ bool CLayoutMgr::IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLay
 	@param[in] nCharKetas2 次のカーソル位置にある文字の幅と間隔
 	@return 処理が必要な位置である場合にtrue
 */
-bool CLayoutMgr::IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 )
+bool CLayoutMgr::IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const
 {
 	if( nRest < nCharKetas ){
 		// 次の文字で折り返しの場合

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -79,39 +79,6 @@ bool CLayoutMgr::IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLay
 		return true;
 	}
 	return false;
-#if 0
-	switch( (Int)nRest )
-	{
-	//    321012  ↓マジックナンバー
-	// 3 "る）" : 22 "）"の2バイト目で折り返しのとき
-	// 2  "Z）" : 12 "）"の2バイト目で折り返しのとき
-	// 2  "る）": 22 "）"で折り返しのとき
-	// 2  "る)" : 21 ")"で折り返しのとき
-	// 1   "Z）": 12 "）"で折り返しのとき
-	// 1   "Z)" : 11 ")"で折り返しのとき
-	//↑何文字前か？
-	// ※ただし、"るZ"部分が禁則なら処理しない。
-	case 3:	// 3文字前
-		if( nCharKetas == 2 && nCharKetas2 == 2 ){
-			return true;
-		}
-		break;
-	case 2:	// 2文字前
-		if( nCharKetas == 2 ){
-			return true;
-		}
-		else if( nCharKetas == 1 && nCharKetas2 == 2 ){
-			return true;
-		}
-		break;
-	case 1:	// 1文字前
-		if( nCharKetas == 1 ){
-			return true;
-		}
-		break;
-	}
-	return false;
-#endif
 }
 
 /*!
@@ -133,34 +100,6 @@ bool CLayoutMgr::IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLay
 		return true;
 	}
 	return false;
-#if 0
-	switch( (Int)nRest )
-	{
-	case 3:	// 3文字前
-		if( nCharKetas == 2 && nCharKetas2 == 2){
-			// "（あ": "あ"の2バイト目で折り返しのとき
-			return true;
-		}
-		break;
-	case 2:	// 2文字前
-		if( nCharKetas == 2 ){
-			// "（あ": "あ"で折り返しのとき
-			return true;
-		}
-		else if( nCharKetas == 1 && nCharKetas2 == 2){
-			// "(あ": "あ"の2バイト目で折り返しのとき
-			return true;
-		}
-		break;
-	case 1:	// 1文字前
-		if( nCharKetas == 1 ){
-			// "(あ": "あ"で折り返しのとき
-			return true;
-		}
-		break;
-	}
-	return false;
-#endif
 }
 
 /*!

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -164,6 +164,18 @@ bool CLayoutMgr::IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLay
 }
 
 /*!
+	句読点ぶら下げの処理位置であるか調べる
+
+	@param[in] nRest 現在行における残り文字数分の字幅と間隔の合計
+	@param[in] nCharChars 現在のカーソル位置にある文字の幅と間隔
+	@return 処理が必要な位置である場合にtrue
+*/
+bool CLayoutMgr::IsKinsokuPosKuto( CLayoutInt nRest, CLayoutInt nCharChars ) const
+{
+	return nRest < nCharChars;
+}
+
+/*!
 	@brief 行の長さを計算する (2行目以降の字下げ無し)
 	
 	字下げを行わないので，常に0を返す．

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -61,60 +61,6 @@ bool CLayoutMgr::IsKinsokuKuto( wchar_t wc ) const
 }
 
 /*!
-	行頭禁則の処理位置であるか調べる
-
-	@param[in] nRest 現在行における残り文字数分の字幅と間隔の合計
-	@param[in] nCharKetas 現在の位置にある文字の幅と間隔
-	@param[in] nCharKetas2 次の位置にある文字の幅と間隔
-	@return 処理が必要な位置である場合にtrue
-*/
-bool CLayoutMgr::IsKinsokuPosHead( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const
-{
-	if( nRest < nCharKetas ){
-		// 次の文字で折り返しの場合
-		return true;
-	}
-	if( nRest < nCharKetas + nCharKetas2 ){
-		// 次の次の文字で折り返しの場合
-		return true;
-	}
-	return false;
-}
-
-/*!
-	行末禁則の処理位置であるか調べる
-
-	@param[in] nRest 現在行における残り文字数分の字幅と間隔の合計
-	@param[in] nCharKetas 現在の位置にある文字の幅と間隔
-	@param[in] nCharKetas2 次の位置にある文字の幅と間隔
-	@return 処理が必要な位置である場合にtrue
-*/
-bool CLayoutMgr::IsKinsokuPosTail( CLayoutInt nRest, CLayoutInt nCharKetas, CLayoutInt nCharKetas2 ) const
-{
-	if( nRest < nCharKetas ){
-		// 次の文字で折り返しの場合
-		return true;
-	}
-	if( nRest < nCharKetas + nCharKetas2 ){
-		// 次の次の文字で折り返しの場合
-		return true;
-	}
-	return false;
-}
-
-/*!
-	句読点ぶら下げの処理位置であるか調べる
-
-	@param[in] nRest 現在行における残り文字数分の字幅と間隔の合計
-	@param[in] nCharChars 現在の位置にある文字の幅と間隔
-	@return 処理が必要な位置である場合にtrue
-*/
-bool CLayoutMgr::IsKinsokuPosKuto( CLayoutInt nRest, CLayoutInt nCharChars ) const
-{
-	return nRest < nCharChars;
-}
-
-/*!
 	@brief 行の長さを計算する (2行目以降の字下げ無し)
 	
 	字下げを行わないので，常に0を返す．


### PR DESCRIPTION
# PR の目的

禁則処理が使えない問題を解決します。

## カテゴリ

- 不具合修正

## PR の背景

過去に行われたプロポーショナルフォント対応の際、内部で取り扱うレイアウト上の桁数が半角単位からピクセル単位に変更されました。
禁則処理用の関数に対して、これに対応する変更がなされなかったため、条件分岐が正しく判定されなくなっていました。
（※似たような機能で「改行ぶら下げ」がありますが、これは正常に機能しているようです。）

##  PR のメリット

自明だと思います。

## PR のデメリット (トレードオフとかあれば)

## 仕様・動作説明

patchunicode#1034として登録されているパッチをもとに文字幅の換算処理を追加して、以前と同様に「行末付近でのみ判定を行う」ようにしました。
句読点ぶら下げの時は行末の半角2桁、行頭・行末禁則の時は行末の半角4桁の範囲内に達したときに限り禁則処理の実施判定が行われます。
（この範囲に現在位置にある文字と次位の文字が収まらず、折り返しが発生する時に禁則処理が実施されます。）

また`IsKinsokuPosHead()`及び`IsKinsokuPosTail()`は、これまで行の残り桁数と各文字の桁数の組み合わせで判定を行っていましたが、文字幅がピクセル単位の数値となった現在、この方法では正しく判定ができません。
そのため、`IsKinsokuPosKuto()`の条件式と同様に文字幅（注：ここでいう文字幅は現在の仕様では文字間隔を含みます）が行の残り幅より大きいかどうかで判定を行うようにし、単位の違いに関わらず判定できるようにしました。

そのほか、次の変更を含みます。
- 関係する関数に記述されたコメントで内容が現状にそぐわない箇所を更新しました。
- 禁則の判定関数に`const`修飾子の有り/無しが混在していたので有りに統一しました。
- ~~`IsKinsokuPosKuto`関数をヘッダファイルからソースファイル（`CLayoutMgr_New.cpp`）に移動しました。~~
- 処理位置の判定に使われるIsKinsokuPosHead/IsKinsokuPosTail/IsKinsokuPosKutoをstatic関数に変更し、CLayoutMgrクラスのメンバから外しました。
- 未使用の判定関数があったので、パッチによってコメントアウトされるコードとともに除去しました。
  - 除去した`_ExistKinsokuHead()`は`IsKinsokuHead()`と、`_ExistKinsokuKuto()` は`IsKinsokuKuto()`と等価です。
- 行頭禁則対象の直前の文字がサロゲートペアである場合に行頭禁則が動作しないことがある問題を修正しました。

## PR の影響範囲

句読点ぶら下げ・行頭禁則・行末禁則のいずれかが有効になっている環境の次のビュー
- 編集ビュー
- 印刷プレビュー

## テスト内容

- 各禁則処理の動作を以前のバージョンと比べて確認しました。
  - 正常動作する最後のバージョンはv2.2.0.1、動作しなくなったのはv2.3.0.0以降です。
  - ~~比較画像を後で用意しておきます。~~

### テスト1：編集ビューにおける禁則処理

1. タイプ別設定に「テキスト」を一時適用する
   - 「テキスト」であれば、行頭・行末禁則の対象文字に既定値が設定されます。
2. 句読点ぶら下げ・行頭禁則・行末禁則を有効にする
   - 確認を容易にするため、折り返し方法を「指定桁で折り返し」に設定し、適度な桁数を設定するとよいです。
4. 禁則対象文字(下記参照)が行頭・行末にくるようなテキストを入力し、動作を確認する

### テスト2：印刷プレビューにおける禁則処理

1. 印刷ページ設定で句読点ぶら下げ・行頭禁則・行末禁則を有効にする
2. 禁則対象文字(下記参照)が行頭・行末にくるようなテキストを入力する
3. 印刷プレビューを表示して動作を確認する

### 補足：禁則対象文字の既定値（タイプ別設定がテキストの時）
- 句読点ぶら下げ（8種類）
   `、。，．､｡,.`
- 行頭禁則（51種類）
   `!%),.:;?]}\xa2°’”‰′″℃、。々〉》」』】〕゛゜ゝゞ・ヽヾ！％），．：；？］｝｡｣､･ﾞﾟ￠`
   - \xa2は半角セント記号です。
- 行末禁則（22種類）
   `$([\\{\xa3\xa5‘“〈《「『【〔＄（［｛｢￡￥`
   - \xa3は半角ポンド記号、\xa5は半角円記号です。

## 関連 issue, PR

## 参考資料

[patchunicode#1034](https://sourceforge.net/p/sakura-editor/patchunicode/1034/)