### PR TITLE
CProfileを拡張してテストに利用できるようにする

### DIFF
--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -26,6 +26,8 @@
 #define SAKURA_CDATAPROFILE_401640FD_5B27_454A_B0DE_098E1C4FAEAD_H_
 #pragma once
 
+#include "basis/SakuraBasis.h"
+#include "debug/Debug2.h"
 #include "util/StaticType.h"
 #include "CProfile.h"
 
@@ -166,8 +168,8 @@ public:
 	 */
 	template <class T> //T=={bool, int, WORD, wchar_t, char, StringBufferW, StaticString}
 	bool IOProfileData(
-		const std::wstring&		strSectionName,	//!< [in] セクション名
-		const std::wstring&		strEntryKey,	//!< [in] エントリ名
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
 		T&						tEntryValue		//!< [in,out] エントリ値
 	) noexcept
 	{
@@ -177,7 +179,7 @@ public:
 		bool ret = false;
 		if( IsReadingMode() ){
 			//文字列読み込み
-			if( GetProfileDataImp( strSectionName, strEntryKey, buf ) ){
+			if( GetProfileData(sectionName, entryKey, buf) ){
 				//Tに変換
 				profile_to_value(buf, &tEntryValue);
 				ret = true;
@@ -185,8 +187,9 @@ public:
 		}else{
 			//文字列に変換
 			value_to_profile(tEntryValue, &buf);
+			ret = true; //TODO: 変換成否の反映
 			//文字列書き込み
-			ret = SetProfileDataImp( strSectionName, strEntryKey, buf );
+			SetProfileData(sectionName, entryKey, buf);
 		}
 		return ret;
 	}
@@ -208,19 +211,18 @@ public:
  */
 template <> inline
 bool CDataProfile::IOProfileData<std::wstring>(
-	const std::wstring&		strSectionName,	//!< [in] セクション名
-	const std::wstring&		strEntryKey,	//!< [in] エントリ名
+	std::wstring_view		sectionName,	//!< [in] セクション名
+	std::wstring_view		entryKey,		//!< [in] エントリ名
 	std::wstring&			strEntryValue	//!< [in,out] エントリ値
 ) noexcept
 {
-	bool ret = false;
 	if( IsReadingMode() ){
 		//文字列読み込み
-		ret = GetProfileDataImp( strSectionName, strEntryKey, strEntryValue );
+		return GetProfileData(sectionName, entryKey, strEntryValue);
 	}else{
 		//文字列書き込み
-		ret = SetProfileDataImp( strSectionName, strEntryKey, strEntryValue );
+		SetProfileData(sectionName, entryKey, strEntryValue);
+		return true;
 	}
-	return ret;
 }
 #endif /* SAKURA_CDATAPROFILE_401640FD_5B27_454A_B0DE_098E1C4FAEAD_H_ */

--- a/sakura_core/CProfile.h
+++ b/sakura_core/CProfile.h
@@ -37,6 +37,7 @@
 
 #include <Windows.h>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <map>
 
@@ -61,8 +62,8 @@ class CProfile
 	};
 
 public:
-	CProfile() {}
-	~CProfile() {}
+	CProfile() = default;
+	virtual ~CProfile() = default;
 	void Init( void );
 	bool IsReadingMode( void ) { return m_bRead; }
 	void SetReadingMode( void ) { m_bRead = true; }
@@ -70,16 +71,14 @@ public:
 	bool ReadProfile( const WCHAR* );
 	bool ReadProfileRes( const WCHAR*, const WCHAR*, std::vector<std::wstring>* = NULL );				// 200/5/19 Uchi
 	bool WriteProfile( const WCHAR*, const WCHAR* pszComment);
+	bool GetProfileData(std::wstring_view sectionName, std::wstring_view entryKey, std::wstring& strEntryValue) const;
+	void SetProfileData(std::wstring_view sectionName, std::wstring_view entryKey, std::wstring_view entryValue);
 
 	void DUMP( void );
 
 protected:
 	void ReadOneline( const wstring& line );
 	bool _WriteFile( const wstring& strFilename, const std::vector< wstring >& vecLine);
-
-	bool GetProfileDataImp( const wstring& strSectionName, const wstring& strEntryKey, wstring& strEntryValue);
-
-	bool SetProfileDataImp( const wstring& strSectionName, const wstring& strEntryKey, const wstring& strEntryValue );
 
 protected:
 	// メンバ変数

--- a/tests/unittests/test-cdlgprofilemgr.cpp
+++ b/tests/unittests/test-cdlgprofilemgr.cpp
@@ -48,6 +48,7 @@
 #include "env/DLLSHAREDATA.h"
 #include "_main/CCommandLine.h"
 #include "_main/CControlProcess.h"
+#include "CDataProfile.h"
 #include "util/file.h"
 
 /*!
@@ -132,12 +133,16 @@ TEST_F( CDlgProfileMgrTest, TrySelectProfile_003 )
 TEST_F( CDlgProfileMgrTest, TrySelectProfile_004 )
 {
 	// プロファイル設定を作る
-	SProfileSettings settings;
-	settings.m_szDllLanguage[0] = L'\0';
-	settings.m_nDefaultIndex = 3;
-	settings.m_vProfList = { L"保存用", L"鑑賞用", L"使用用" };
-	settings.m_bDefaultSelect = true;
-	CDlgProfileMgr::WriteProfSettings( settings );
+	CDataProfile cProfile;
+	cProfile.SetWritingMode();
+	cProfile.SetProfileData(L"Profile", L"szDllLanguage", L"");
+	cProfile.SetProfileData(L"Profile", L"nDefaultIndex", L"3");
+	cProfile.SetProfileData(L"Profile", L"nCount", L"3");
+	cProfile.SetProfileData(L"Profile", L"P[1]", L"保存用");
+	cProfile.SetProfileData(L"Profile", L"P[2]", L"鑑賞用");
+	cProfile.SetProfileData(L"Profile", L"P[3]", L"使用用");
+	cProfile.SetProfileData(L"Profile", L"bDefaultSelect", L"1");
+	cProfile.WriteProfile(profileMgrIniPath.c_str(), L"Sakura Profile ini");
 
 	// プロファイルマネージャー設定にデフォルト定義があればプロファイルは確定する
 	CCommandLineWrapper cCommandLine;
@@ -150,12 +155,16 @@ TEST_F( CDlgProfileMgrTest, TrySelectProfile_004 )
 TEST_F( CDlgProfileMgrTest, TrySelectProfile_005 )
 {
 	// プロファイル設定を作る
-	SProfileSettings settings;
-	settings.m_szDllLanguage[0] = L'\0';
-	settings.m_nDefaultIndex = 4;
-	settings.m_vProfList = { L"保存用", L"鑑賞用", L"使用用" };
-	settings.m_bDefaultSelect = true;
-	CDlgProfileMgr::WriteProfSettings( settings );
+	CDataProfile cProfile;
+	cProfile.SetWritingMode();
+	cProfile.SetProfileData(L"Profile", L"szDllLanguage", L"");
+	cProfile.SetProfileData(L"Profile", L"nDefaultIndex", L"4");
+	cProfile.SetProfileData(L"Profile", L"nCount", L"3");
+	cProfile.SetProfileData(L"Profile", L"P[1]", L"保存用");
+	cProfile.SetProfileData(L"Profile", L"P[2]", L"鑑賞用");
+	cProfile.SetProfileData(L"Profile", L"P[3]", L"使用用");
+	cProfile.SetProfileData(L"Profile", L"bDefaultSelect", L"1");
+	cProfile.WriteProfile(profileMgrIniPath.c_str(), L"Sakura Profile ini");
 
 	// プロファイルマネージャー設定のデフォルト定義がおかしればプロファイルは確定しない
 	CCommandLineWrapper cCommandLine;
@@ -168,11 +177,12 @@ TEST_F( CDlgProfileMgrTest, TrySelectProfile_005 )
 TEST_F( CDlgProfileMgrTest, TrySelectProfile_006 )
 {
 	// 空のプロファイル設定を作る
-	SProfileSettings settings;
-	settings.m_szDllLanguage[0] = L'\0';
-	settings.m_nDefaultIndex = -1;
-	settings.m_bDefaultSelect = false;
-	CDlgProfileMgr::WriteProfSettings( settings );
+	CDataProfile cProfile;
+	cProfile.SetWritingMode();
+	cProfile.SetProfileData(L"Profile", L"szDllLanguage", L"");
+	cProfile.SetProfileData(L"Profile", L"nDefaultIndex", L"-1");
+	cProfile.SetProfileData(L"Profile", L"bDefaultSelect", L"0");
+	cProfile.WriteProfile(profileMgrIniPath.c_str(), L"Sakura Profile ini");
 
 	// プロファイルマネージャー設定が空定義ならプロファイルは確定しない
 	CCommandLineWrapper cCommandLine;

--- a/tests/unittests/test-file.cpp
+++ b/tests/unittests/test-file.cpp
@@ -43,6 +43,7 @@
 #include "env/DLLSHAREDATA.h"
 #include "_main/CCommandLine.h"
 #include "_main/CControlProcess.h"
+#include "CDataProfile.h"
 #include "util/file.h"
 
 /*!
@@ -387,18 +388,10 @@ TEST(file, GetInidirOrExedir)
 	auto iniBasePath = GetIniFileName().parent_path().append(filename);
 
 	// EXE基準のファイルを作る
-	{
-		std::wofstream ofs(exeBasePath);
-		ofs << L"TEST(file, GetInidirOrExedir)" << std::endl;
-	}
+	CProfile().WriteProfile(exeBasePath.c_str(), L"file, GetInidirOrExedirのテスト");
 
 	// INI基準のファイルを作る
-	{
-		EnsureDirectoryExist(GetIniFileName().replace_filename(L"").c_str());
-
-		std::wofstream ofs(iniBasePath);
-		ofs << L"TEST(file, GetInidirOrExedir)" << std::endl;
-	}
+	CProfile().WriteProfile(iniBasePath.c_str(), L"file, GetInidirOrExedirのテスト");
 
 	// 両方あるときはINI基準のパスが変える
 	GetInidirOrExedir(buf.data(), filename, true);
@@ -440,21 +433,13 @@ TEST(file, GetIniFileNameForIO)
 	ASSERT_STREQ(iniPath.c_str(), GetIniFileNameForIO(false).c_str());
 
 	// 書き込みモードでないがiniファイルが実在するとき
-	{
-		std::wofstream ofs(iniPath);
-		ofs << L"test" << std::endl;
-		ofs.close();
+	CProfile().WriteProfile(iniPath.c_str(), L"file, GetIniFileNameForIOのテスト");
+	ASSERT_TRUE(fexist(iniPath.c_str()));
 
-		// 実在チェック
-		ASSERT_TRUE(fexist(iniPath.c_str()));
+	// テスト実施
+	ASSERT_STREQ(iniPath.c_str(), GetIniFileNameForIO(false).c_str());
 
-		// テスト実施
-		ASSERT_STREQ(iniPath.c_str(), GetIniFileNameForIO(false).c_str());
-
-		// INIファイルを削除する
-		std::filesystem::remove(iniPath);
-
-		// 削除チェック
-		ASSERT_FALSE(fexist(iniPath.c_str()));
-	}
+	// INIファイルを削除する
+	std::filesystem::remove(iniPath);
+	ASSERT_FALSE(fexist(iniPath.c_str()));
 }


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
タイトル通りです。

## <!-- 必須 --> カテゴリ
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
別件で検討中のコード修正を行う中で、単独で提案可能な改善を見つけたため、この部分だけ単独で提案する次第です。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
* 独自定義のINIファイル入出力ユーティリティ CProfile を単体テストで利用できるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくに思いつきません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
文字列エントリを書き込むためのSetProfileDataを公開メソッドとして実装します。

従来のSetProfileDataImplはprotectedだったため、直接利用することができませんでした。

CDataProfile::IOProfileDataで文字列を書き込む場合にはstd::wstringを渡す必要があり、
設定値をリテラルで渡したいテストコードで利用するには不便でした。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
INIファイルの入出力を行うコードに影響します。
文字列値をINIファイルを書き込む処理で、セクションとキーと値を書けば簡単に出力できるようになります。
既存の単体テストで適当なファイルを作成する処理を簡潔に記述できるようになります。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
同時に追加する単体テストだけで十分に検証できると思います。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
