### PR TITLE
設定値読み込みで発生した変換エラーを検出できるようにする

### DIFF
--- a/sakura_core/CDataProfile.cpp
+++ b/sakura_core/CDataProfile.cpp
@@ -1,3 +1,58 @@
 ﻿/*! @file */
 #include "StdAfx.h"
 #include "CDataProfile.h"
+
+#include <stdexcept>
+
+/*!
+	コンストラクタ
+ */
+StringBufferW::StringBufferW(WCHAR* pData, size_t maxCount)
+	: pszData_(pData)
+	, cchDataSize_(maxCount)
+{
+	if (pszData_ == nullptr) {
+		throw std::invalid_argument("data can't be nullptr");
+	}
+
+	if (cchDataSize_ == 0) {
+		throw std::invalid_argument("count can't be zero");
+	}
+}
+
+/*!
+	代入演算子
+ */
+StringBufferW& StringBufferW::operator = (std::wstring_view rhs)
+{
+	::wcsncpy_s(pszData_, cchDataSize_, rhs.data(), _TRUNCATE);
+
+	return *this;
+}
+
+namespace profile_data {
+
+	//! 設定値を文字列に変換する
+	[[nodiscard]] std::wstring ToString(const StringBufferW& value)
+	{
+		return std::wstring(value.c_str());
+	}
+
+}; // end of namespace profile_data
+
+/*!
+ * 独自定義バッファ参照型(StringBufferW)の入出力(右辺値参照バージョン)
+ *
+ * @retval true	設定値を正しく読み書きできた
+ * @retval false 設定値を読み込めなかった
+ */
+bool CDataProfile::IOProfileData(
+	std::wstring_view		sectionName,	//!< [in] セクション名
+	std::wstring_view		entryKey,		//!< [in] エントリ名
+	StringBufferW&&			refEntryValue	//!< [in,out] エントリ値
+)
+{
+	// 右辺値参照引数(=左辺値)を使って入出力テンプレートを呼び出す
+	auto entryValue(std::move(refEntryValue));
+	return IOProfileData(sectionName, entryKey, entryValue);
+}

--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -26,203 +26,336 @@
 #define SAKURA_CDATAPROFILE_401640FD_5B27_454A_B0DE_098E1C4FAEAD_H_
 #pragma once
 
+#include "CProfile.h"
+
 #include "basis/SakuraBasis.h"
 #include "debug/Debug2.h"
 #include "util/StaticType.h"
-#include "CProfile.h"
 
-//文字列バッファの型
-struct StringBufferW_{
-	WCHAR*    pData;
-	const int nDataCount;
+/*!
+ * バッファ参照型
+ *
+ * 読み書き可能なWCHARバッファとサイズを指定して構築する
+ */
+class StringBufferW {
+	WCHAR*		pszData_;
+	size_t		cchDataSize_;
 
-	StringBufferW_(WCHAR* _pData, int _nDataCount) : pData(_pData), nDataCount(_nDataCount) { }
+public:
+	explicit StringBufferW(WCHAR* pData, size_t maxCount);
 
-	StringBufferW_& operator = (const StringBufferW_& rhs)
-	{
-		wcscpy_s(pData,nDataCount,rhs.pData);
-		return *this;
-	}
+	template <size_t N>
+	explicit StringBufferW(WCHAR (&buffer)[N])
+		: StringBufferW(buffer, N) {}
+
+	[[nodiscard]] const WCHAR* c_str() const noexcept { return pszData_; }
+	[[nodiscard]] size_t capacity() const noexcept { return cchDataSize_; }
+
+	StringBufferW& operator = (std::wstring_view rhs);
 };
-typedef const StringBufferW_ StringBufferW;
 
 //文字列バッファ型インスタンスの生成マクロ
-#define MakeStringBufferW(S) StringBufferW(S,_countof(S))
+#define MakeStringBufferW(S)	StringBufferW(S,_countof(S))
 
-//2007.09.24 kobake データ変換部を子クラスに分離
-//!各種データ変換付きCProfile
-class CDataProfile : public CProfile{
-private:
-	//専用型
-	typedef std::wstring wstring;
+/*!
+ * プロファイル用データ変換
+ */
+namespace profile_data {
 
-protected:
-	static const wchar_t* _work_itow(int n)
+	/*!
+	 * 指定した型の変換に対応しているかどうかを返すインライン関数
+	 */
+	template<class T>
+	constexpr bool is_supported_v = std::is_integral_v<T> || std::is_enum_v<T> || std::is_same_v<T, CLogicInt> || std::is_same_v<T, CLayoutInt> || std::is_same_v<T, StringBufferW>;
+
+	/*!
+	 * 文字列を設定値に変換する
+	 *
+	 * テンプレート定義は、32bit以下の整数型とenum型に対応している。
+	 * それ以外の型で利用したい場合は、特殊化定義を書いて使う。
+	 * 既存コードにあった bool, CLayoutInt, WCHAR, KEYCODE は特殊化済み。
+	 * 独自型 CLogicInt は int に暗黙変換できるので特殊化不要。
+	 */
+	template<class NumType>
+	[[nodiscard]] bool TryParse(std::wstring_view profile, NumType& value) noexcept
 	{
-		static wchar_t buf[32];
-		_itow(n,buf,10);
-		return buf;
-	}
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                       データ変換部                          //
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-protected:
-	//bool
-	void profile_to_value(const wstring& profile, bool* value)
-	{
-		if(profile != L"0")*value=true;
-		else *value=false;
-	}
-	void value_to_profile(const bool& value, wstring* profile)
-	{
-		*profile = _work_itow(value?1:0);
-	}
-	//int
-	void profile_to_value(const wstring& profile, int* value)
-	{
-		*value = _wtoi(profile.c_str());
-	}
-	void value_to_profile(const int& value, wstring* profile)
-	{
-		*profile = _work_itow(value);
+		if (profile.length() > 0) {
+			const WCHAR* pStart = profile.data();
+			WCHAR* pEnd = nullptr;
+			if constexpr (std::is_unsigned_v<NumType>) {
+				if (const auto parsedNum = ::wcstoul(pStart, &pEnd, 10); pStart != pEnd) {
+					value = static_cast<NumType>(parsedNum);
+					return true;
+				}
+			}
+			else {
+				if (const auto parsedNum = ::wcstol(pStart, &pEnd, 10); pStart != pEnd) {
+					value = static_cast<NumType>(parsedNum);
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
-	//int式入出力実装マクロ
-	#define AS_INT(TYPE) \
-		void profile_to_value(const wstring& profile, TYPE* value){ *value = (TYPE)_wtoi(profile.c_str()); } \
-		void value_to_profile(const TYPE& value, wstring* profile){ *profile = _work_itow(value);    }
+	/*!
+	 * 設定値を文字列に変換する
+	 *
+	 * テンプレート定義は、組込の整数型に対応している。
+	 * 整数以外の型で利用したい場合は、特殊化定義を書いて使う。
+	 * 既存コードにあった型 bool, CLayoutInt, WCHAR, KEYCODE は特殊化済み。
+	 * 独自型 CLogicInt は int に暗黙変換できるので特殊化不要。
+	 */
+	template<class NumType, std::enable_if_t<!std::is_enum_v<NumType>, std::nullptr_t> = nullptr>
+	[[nodiscard]] std::wstring ToString(NumType value)
+	{
+		return std::to_wstring(value);
+	}
 
-	//int式
-// CType.hをincludeしないといけないから廃止
-//	AS_INT(EOutlineType) 
-	AS_INT(WORD)
+	//! 設定値を文字列に変換する
+	template<class EnumType, std::enable_if_t<std::is_enum_v<EnumType>, std::nullptr_t> = nullptr>
+	[[nodiscard]] std::wstring ToString(EnumType value)
+	{
+		auto nValue = static_cast<int32_t>(value);
+		return ToString(nValue);
+	}
 
 #ifdef USE_STRICT_INT
-	//CLayoutInt
-	void profile_to_value(const wstring& profile, CLayoutInt* value){ *value = (CLayoutInt)_wtoi(profile.c_str()); }
-	void value_to_profile(const CLayoutInt& value, wstring* profile){ *profile = _work_itow((Int)value);    }
-	//CLogicInt
-	void profile_to_value(const wstring& profile, CLogicInt* value){ *value = (CLogicInt)_wtoi(profile.c_str()); }
-	void value_to_profile(const CLogicInt& value, wstring* profile){ *profile = _work_itow((Int)value);    }
-#endif
-	//ACHAR
-	void profile_to_value(const wstring& profile, ACHAR* value)
+
+	//! 文字列を設定値に変換する
+	template<>
+	[[nodiscard]] inline bool TryParse<CLayoutInt>(std::wstring_view profile, CLayoutInt& value) noexcept
 	{
-		if(profile.length()>0){
-			ACHAR buf[2]={0};
-			int ret=wctomb(buf,profile[0]);
-			assert_warning(ret==1);
-			(void)ret;
-			*value = buf[0];
+		// int型を介して値を読み取る
+		if (int nValue = 0; TryParse(profile, nValue)) {
+			value = CLayoutInt(nValue);
+			return true;
 		}
-		else{
-			*value = '\0';
-		}
-	}
-	void value_to_profile(const ACHAR& value, wstring* profile)
-	{
-		WCHAR buf[2]={0};
-		mbtowc(buf,&value,1);
-		profile->assign(1,buf[0]);
-	}
-	//WCHAR
-	void profile_to_value(const wstring& profile, WCHAR* value)
-	{
-		*value = profile[0];
-	}
-	void value_to_profile(const WCHAR& value, wstring* profile)
-	{
-		profile->assign(1,value);
-	}
-	//StringBufferW
-	void profile_to_value(const wstring& profile, StringBufferW* value)
-	{
-		wcscpy_s(value->pData,value->nDataCount,profile.c_str());
-	}
-	void value_to_profile(const StringBufferW& value, wstring* profile)
-	{
-		*profile = value.pData;
-	}
-	//StaticString<WCHAR,N>
-	template <int N>
-	void profile_to_value(const wstring& profile, StaticString<WCHAR, N>* value)
-	{
-		wcscpy_s(value->GetBufferPointer(),value->GetBufferCount(),profile.c_str());
-	}
-	template <int N>
-	void value_to_profile(const StaticString<WCHAR, N>& value, wstring* profile)
-	{
-		*profile = value.GetBufferPointer();
+		return false;
 	}
 
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	//                         入出力部                            //
-	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
+	//! 設定値を文字列に変換する
+	template<>
+	[[nodiscard]] inline std::wstring ToString<CLayoutInt>(CLayoutInt value)
+	{
+		// int型を介して文字列化する
+		return ToString((Int)value);
+	}
+
+#endif //ifdef USE_STRICT_INT
+
+	//! 文字列を設定値に変換する
+	template<>
+	[[nodiscard]] inline bool TryParse<bool>(std::wstring_view profile, bool& value) noexcept
+	{
+		// int型を介して値を読み取る
+		if (int nValue = 0; TryParse(profile, nValue)) {
+			value = (nValue != 0);
+			return true;
+		}
+		return false;
+	}
+
+	//! 設定値を文字列に変換する
+	template<>
+	[[nodiscard]] inline std::wstring ToString<bool>(bool value)
+	{
+		// int型を介して文字列化する
+		return ToString(value ? 1 : 0);
+	}
+
+	/*!
+	 * 文字列を設定値に変換する
+	 *
+	 * 行番号エリアとテキストエリアを区切るのに使う文字の設定。
+	 *
+	 * @sa STypeConfig::m_cLineTermChar
+	 */
+	template<>
+	[[nodiscard]] inline bool TryParse<WCHAR>(std::wstring_view profile, WCHAR& value) noexcept
+	{
+		// \0は区切り文字「なし」を意味する
+		if (const WCHAR ch = profile.empty() ? L'\0' : profile[0]; (ch & 0xd800) != 0xd800) {
+			// 区切り文字は表示可能な単一文字なので、変換不要。
+			value = ch;
+			return true;
+		}
+		return false;
+	}
+
+	/*!
+	 * 設定値を文字列に変換する
+	 *
+	 * 行番号エリアとテキストエリアを区切るのに使う文字の設定。
+	 *
+	 * @sa STypeConfig::m_cLineTermChar
+	 */
+	template<>
+	[[nodiscard]] inline std::wstring ToString<WCHAR>(WCHAR value)
+	{
+		if (value != L'\0' && (value & 0xd800) != 0xd800) {
+			// 指定された文字1字のみで構成される文字列を返す
+			return std::wstring(1, value);
+		}
+		return std::wstring();
+	}
+
+	/*!
+	 * 文字列を設定値に変換する
+	 *
+	 * 元々ACHAR型の変換メソッドになっていたものを再定義。
+	 * カスタムメニューのニーモニック設定に使われている。
+	 *
+	 * ニーモニックとは、「ファイル(F)」の F のこと。(Fには下線が付く)
+	 * キーボードショートカットとして機能することから、メニューショートカットとも言う。
+	 *
+	 * @sa CommonSetting_CustomMenu::m_nCustMenuItemKeyArr
+	 */
+	template<>
+	[[nodiscard]] inline bool TryParse<KEYCODE>(std::wstring_view profile, KEYCODE& value) noexcept
+	{
+		// \0はニーモニック「なし」を意味する
+		if (const WCHAR ch = profile.empty() ? L'\0' : profile[0]; ch < 0x80) {
+			// ニーモニックはASCIIの印字可能文字なので、CRT関数を使った変換は不要。
+			value = static_cast<KEYCODE>(ch);
+			return true;
+		}
+		return false;
+	}
+
+	//! 設定値を文字列に変換する
+	template<>
+	[[nodiscard]] inline std::wstring ToString<KEYCODE>(KEYCODE value)
+	{
+		// WCHAR型を介して文字列化する
+		const WCHAR ch = value < 0 || value >= 0x80 ? L'\0' : value;
+		return ToString(ch);
+	}
+
+	/*!
+	 * 文字列を設定値に変換する
+	 *
+	 * @sa StringBufferW
+	 */
+	template<>
+	[[nodiscard]] inline bool TryParse<StringBufferW>(std::wstring_view profile, StringBufferW& value) noexcept
+	{
+		if (profile.length() < value.capacity()) {
+			value = profile;
+			return true;
+		}
+		return false;
+	}
+
+	//! 設定値を文字列に変換する
+	[[nodiscard]] std::wstring ToString(const StringBufferW& value);
+
+}; // end of namespace profile_data
+
+/*!
+ * 各種データ変換付きCProfile
+ *
+ * @date 2007/09/24 kobake データ変換部を子クラスに分離
+ */
+class CDataProfile : public CProfile {
 public:
+	using CProfile::GetProfileData;
+	using CProfile::SetProfileData;
+
+	 /*!
+	  * Profileから読み込んだ文字列を設定値に変換して取得する
+	  *
+	  * @retval true 成功
+	  * @retval false 失敗
+	  */
+	template<class T, std::enable_if_t<profile_data::is_supported_v<T>, std::nullptr_t> = nullptr>
+	[[nodiscard]] bool GetProfileData(
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
+		T&						tEntryValue		//!< [out] エントリ値
+	) const
+	{
+		if (std::wstring strEntryValue; GetProfileData(sectionName, entryKey, strEntryValue)) {
+			return profile_data::TryParse(strEntryValue, tEntryValue);
+		}
+		return false;
+	}
+
+	/*!
+	 * 設定値を文字列に変換してProfileへ書き込む
+	 */
+	template<class T, std::enable_if_t<profile_data::is_supported_v<T>, std::nullptr_t> = nullptr>
+	void SetProfileData(
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
+		const T					tEntryValue		//!< [in] エントリ値
+	)
+	{
+		const std::wstring strEntryValue = profile_data::ToString(tEntryValue);
+		SetProfileData(sectionName, entryKey, strEntryValue.data());
+	}
+
 	/*!
 	 * 設定値の入出力テンプレート
 	 *
-	 * 標準stringを介して設定値の入出力を行う。
-	 * @remark StringBufferWはバッファが足りないとabortします。
-	 * @remark StaticStringはバッファが足りないとabortします。
+	 * 設定値の入出力を行う。
+	 *
+	 * @retval true	設定値を正しく読み書きできた
+	 * @retval false 設定値を読み込めなかった
 	 */
-	template <class T> //T=={bool, int, WORD, wchar_t, char, StringBufferW, StaticString}
+	template <class T> //T=={int, bool, WCHAR, KEYCODE, StringBufferW}
 	bool IOProfileData(
 		std::wstring_view		sectionName,	//!< [in] セクション名
 		std::wstring_view		entryKey,		//!< [in] エントリ名
 		T&						tEntryValue		//!< [in,out] エントリ値
-	) noexcept
+	)
 	{
-		// 標準stringに変換して入出力する
-		std::wstring buf;
-
-		bool ret = false;
 		if( IsReadingMode() ){
-			//文字列読み込み
-			if( GetProfileData(sectionName, entryKey, buf) ){
-				//Tに変換
-				profile_to_value(buf, &tEntryValue);
-				ret = true;
-			}
+			return GetProfileData(sectionName, entryKey, tEntryValue);
 		}else{
-			//文字列に変換
-			value_to_profile(tEntryValue, &buf);
-			ret = true; //TODO: 変換成否の反映
-			//文字列書き込み
-			SetProfileData(sectionName, entryKey, buf);
+			SetProfileData(sectionName, entryKey, tEntryValue);
+			return true;
 		}
-		return ret;
 	}
+
+	/*!
+	 * 独自定義文字配列拡張型(StaticString)の入出力
+	 *
+	 * 型引数が合わないために通常入出力と分離。
+	 *
+	 * @retval true	設定値を正しく読み書きできた
+	 * @retval false 設定値を読み込めなかった
+	 */
+	template <int N>
+	bool IOProfileData(
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
+		StaticString<WCHAR, N>&	szEntryValue	//!< [in,out] エントリ値
+	)
+	{
+		// バッファ参照型に変換して入出力する
+		return IOProfileData(sectionName, entryKey, StringBufferW(szEntryValue.GetBufferPointer(), szEntryValue.GetBufferCount()));
+	}
+
+	/*!
+	 * 独自定義バッファ参照型(StringBufferW)の入出力(右辺値参照バージョン)
+	 *
+	 * @retval true	設定値を正しく読み書きできた
+	 * @retval false 設定値を読み込めなかった
+	 */
+	bool IOProfileData(
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
+		StringBufferW&&			refEntryValue	//!< [in,out] エントリ値
+	);
 
 	//2007.08.14 kobake 追加
 	//! intを介して任意型の入出力を行う
 	template <class T>
 	bool IOProfileData_WrapInt( const std::wstring& strSectionName, const std::wstring& strEntryKey, T& nEntryValue)
 	{
-		int n=nEntryValue;
-		bool ret = this->IOProfileData( strSectionName, strEntryKey, n );
-		nEntryValue=(T)n;
-		return ret;
+		return IOProfileData(strSectionName, strEntryKey, nEntryValue);
 	}
 };
 
-/*!
- * 文字列型(標準string)の入出力(無変換)
- */
-template <> inline
-bool CDataProfile::IOProfileData<std::wstring>(
-	std::wstring_view		sectionName,	//!< [in] セクション名
-	std::wstring_view		entryKey,		//!< [in] エントリ名
-	std::wstring&			strEntryValue	//!< [in,out] エントリ値
-) noexcept
-{
-	if( IsReadingMode() ){
-		//文字列読み込み
-		return GetProfileData(sectionName, entryKey, strEntryValue);
-	}else{
-		//文字列書き込み
-		SetProfileData(sectionName, entryKey, strEntryValue);
-		return true;
-	}
-}
 #endif /* SAKURA_CDATAPROFILE_401640FD_5B27_454A_B0DE_098E1C4FAEAD_H_ */

--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -54,9 +54,6 @@ public:
 	StringBufferW& operator = (std::wstring_view rhs);
 };
 
-//文字列バッファ型インスタンスの生成マクロ
-#define MakeStringBufferW(S)	StringBufferW(S,_countof(S))
-
 /*!
  * プロファイル用データ変換
  */

--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -345,14 +345,6 @@ public:
 		std::wstring_view		entryKey,		//!< [in] エントリ名
 		StringBufferW&&			refEntryValue	//!< [in,out] エントリ値
 	);
-
-	//2007.08.14 kobake 追加
-	//! intを介して任意型の入出力を行う
-	template <class T>
-	bool IOProfileData_WrapInt( const std::wstring& strSectionName, const std::wstring& strEntryKey, T& nEntryValue)
-	{
-		return IOProfileData(strSectionName, strEntryKey, nEntryValue);
-	}
 };
 
 #endif /* SAKURA_CDATAPROFILE_401640FD_5B27_454A_B0DE_098E1C4FAEAD_H_ */

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -512,7 +512,7 @@ static bool IOProfSettings( SProfileSettings& settings, bool bWrite )
 	if( settings.m_nDefaultIndex < -1 ){
 		settings.m_nDefaultIndex = -1;
 	}
-	cProf.IOProfileData( pSection, L"szDllLanguage", StringBufferW(settings.m_szDllLanguage, _countof(settings.m_szDllLanguage)) );
+	cProf.IOProfileData(pSection, L"szDllLanguage", StringBufferW(settings.m_szDllLanguage));
 	cProf.IOProfileData( pSection, L"bDefaultSelect", settings.m_bDefaultSelect );
 
 	if( bWrite ){

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -227,7 +227,7 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].nY"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pfiWork->m_ptCursor.y );
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].nCharCode"), i );
-		cProfile.IOProfileData_WrapInt( pszSecName, szKeyName, pfiWork->m_nCharCode );
+		cProfile.IOProfileData(pszSecName, szKeyName, pfiWork->m_nCharCode);
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].szPath"), i );
 		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pfiWork->m_szPath));
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].szMark2"), i );
@@ -507,7 +507,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	// 2002.01.16 hor
 	cProfile.IOProfileData( pszSecName, LTEXT("m_bRestoreBookmarks")	, common.m_sFile.m_bRestoreBookmarks );
 	cProfile.IOProfileData( pszSecName, LTEXT("bAddCRLFWhenCopy")		, common.m_sEdit.m_bAddCRLFWhenCopy );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOpenDialogDir")		, common.m_sEdit.m_eOpenDialogDir );
+	cProfile.IOProfileData(pszSecName, L"eOpenDialogDir", common.m_sEdit.m_eOpenDialogDir );
 	cProfile.IOProfileData(pszSecName, L"szOpenDialogSelDir", common.m_sEdit.m_OpenDialogSelDir);
 	cProfile.IOProfileData( pszSecName, LTEXT("bBoxSelectLock")	, common.m_sEdit.m_bBoxSelectLock );
 	cProfile.IOProfileData( pszSecName, LTEXT("bVistaStyleFileDialog")	, common.m_sEdit.m_bVistaStyleFileDialog );
@@ -536,7 +536,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bGrepBackup")			, common.m_sSearch.m_bGrepBackup );
 	
 	// 2002/09/21 Moca 追加
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nGrepCharSet")	, common.m_sSearch.m_nGrepCharSet );
+	cProfile.IOProfileData(pszSecName, L"nGrepCharSet", common.m_sSearch.m_nGrepCharSet );
 	cProfile.IOProfileData( pszSecName, LTEXT("bGrepRealTime")			, common.m_sSearch.m_bGrepRealTimeView ); // 2003.06.16 Moca
 	cProfile.IOProfileData( pszSecName, LTEXT("bCaretTextForSearch")	, common.m_sSearch.m_bCaretTextForSearch );	// 2006.08.23 ryoji カーソル位置の文字列をデフォルトの検索文字列にする
 	cProfile.IOProfileData( pszSecName, LTEXT("m_bInheritKeyOtherView")	, common.m_sSearch.m_bInheritKeyOtherView );
@@ -586,7 +586,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bBackUpDustBox")			, common.m_sBackup.m_bBackUpDustBox );	//@@@ 2001.12.11 add MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bBackUpPathAdvanced")	, common.m_sBackup.m_bBackUpPathAdvanced );	/* 20051107 aroka */
 	cProfile.IOProfileData( pszSecName, LTEXT("szBackUpPathAdvanced")	, common.m_sBackup.m_szBackUpPathAdvanced );	/* 20051107 aroka */
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nFileShareMode")			, common.m_sFile.m_nFileShareMode );
+	cProfile.IOProfileData(pszSecName, L"nFileShareMode", common.m_sFile.m_nFileShareMode );
 	cProfile.IOProfileData(pszSecName, L"szExtHelp", StringBufferW(common.m_sHelper.m_szExtHelp));
 	cProfile.IOProfileData(pszSecName, L"szExtHtmlHelp", StringBufferW(common.m_sHelper.m_szExtHtmlHelp));
 	
@@ -619,7 +619,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData(pszSecName, L"szTabWndCaption", StringBufferW(common.m_sTabBar.m_szTabWndCaption));	//@@@ 2003.06.13 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bSameTabWidth")			, common.m_sTabBar.m_bSameTabWidth );	// 2006.01.28 ryoji タブを等幅にする
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabIcon")			, common.m_sTabBar.m_bDispTabIcon );	// 2006.01.28 ryoji タブにアイコンを表示する
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bDispTabClose")	, common.m_sTabBar.m_bDispTabClose );	// 2012.04.14 syat
+	cProfile.IOProfileData(pszSecName, L"bDispTabClose", common.m_sTabBar.m_bDispTabClose );	// 2012.04.14 syat
 	cProfile.IOProfileData( pszSecName, LTEXT("bSortTabList")			, common.m_sTabBar.m_bSortTabList );	// 2006.05.10 ryoji タブ一覧をソートする
 	cProfile.IOProfileData( pszSecName, LTEXT("bTab_RetainEmptyWin")	, common.m_sTabBar.m_bTab_RetainEmptyWin );	// 最後のファイルが閉じられたとき(無題)を残す	// 2007.02.11 genta
 	cProfile.IOProfileData( pszSecName, LTEXT("bTab_CloseOneWin")	, common.m_sTabBar.m_bTab_CloseOneWin );	// タブモードでもウィンドウの閉じるボタンで現在のファイルのみ閉じる	// 2007.02.11 genta
@@ -627,7 +627,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bChgWndByWheel")		, common.m_sTabBar.m_bChgWndByWheel );	// 2006.03.26 ryoji マウスホイールでウィンドウ切り替え
 	cProfile.IOProfileData( pszSecName, LTEXT("bNewWindow")			, common.m_sTabBar.m_bNewWindow );	// 外部から起動するときは新しいウインドウで開く
 	cProfile.IOProfileData( pszSecName, L"bTabMultiLine"			, common.m_sTabBar.m_bTabMultiLine );	// タブ多段
-	cProfile.IOProfileData_WrapInt( pszSecName, L"eTabPosition"		, common.m_sTabBar.m_eTabPosition );	// タブ位置
+	cProfile.IOProfileData(pszSecName, L"eTabPosition", common.m_sTabBar.m_eTabPosition );	// タブ位置
 
 	ShareData_IO_Sub_LogFont( cProfile, pszSecName, L"lfTabFont", L"lfTabFontPs", L"lfTabFaceName",
 		common.m_sTabBar.m_lf, common.m_sTabBar.m_nPointSize );
@@ -646,12 +646,12 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	// 2001/06/14 asa-o 補完とキーワードヘルプはタイプ別に移動したので削除：３行
 	// 2002/09/21 Moca bGrepKanjiCode_AutoDetect は bGrepCharSetに統合したので削除
 	// 2001/06/19 asa-o タイプ別に移動したので削除：1行
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bSaveWindowSize"), common.m_sWindow.m_eSaveWindowSize );	//#####フラグ名が激しくきもい
+	cProfile.IOProfileData(pszSecName, L"bSaveWindowSize", common.m_sWindow.m_eSaveWindowSize );	//#####フラグ名が激しくきもい
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinSizeType")			, common.m_sWindow.m_nWinSizeType );
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinSizeCX")				, common.m_sWindow.m_nWinSizeCX );
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinSizeCY")				, common.m_sWindow.m_nWinSizeCY );
 	// 2004.03.30 Moca *nWinPos*を追加
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nSaveWindowPos")	, common.m_sWindow.m_eSaveWindowPos );	//#####フラグ名がきもい
+	cProfile.IOProfileData(pszSecName, L"nSaveWindowPos", common.m_sWindow.m_eSaveWindowPos );	//#####フラグ名がきもい
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinPosX")				, common.m_sWindow.m_nWinPosX );
 	cProfile.IOProfileData( pszSecName, LTEXT("nWinPosY")				, common.m_sWindow.m_nWinPosY );
 	cProfile.IOProfileData( pszSecName, LTEXT("bTaskTrayUse")			, common.m_sGeneral.m_bUseTaskTray );
@@ -743,7 +743,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineDockSet"), common.m_sOutline.m_nOutlineDockSet );
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockSync"), common.m_sOutline.m_bOutlineDockSync );
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockDisp"), common.m_sOutline.m_bOutlineDockDisp );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOutlineDockSide"), common.m_sOutline.m_eOutlineDockSide );
+	cProfile.IOProfileData(pszSecName, L"eOutlineDockSide", common.m_sOutline.m_eOutlineDockSide );
 	{
 		const WCHAR* pszKeyName = LTEXT("xyOutlineDock");
 		const WCHAR* pszForm = LTEXT("%d,%d,%d,%d");
@@ -999,7 +999,7 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 						cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szFuncName));
 					}
 					else {
-						cProfile.IOProfileData_WrapInt( pszSecName, szKeyName, menu.m_nCustMenuItemFuncArr[i][j] );
+						cProfile.IOProfileData(pszSecName, szKeyName, menu.m_nCustMenuItemFuncArr[i][j]);
 					}
 				}
 			}
@@ -1578,7 +1578,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		types.m_id *= -1;
 	}
 	cProfile.IOProfileData(pszSecName, L"szTabViewString", StringBufferW(types.m_szTabViewString));
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bTabArrow")	, types.m_bTabArrow );	//@@@ 2003.03.26 MIK
+	cProfile.IOProfileData(pszSecName, L"bTabArrow", types.m_bTabArrow );	//@@@ 2003.03.26 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bInsSpace")			, types.m_bInsSpace );	// 2001.12.03 hor
 
 	cProfile.IOProfileData( pszSecName, LTEXT("nTextWrapMethod"), types.m_nTextWrapMethod );		// 2008.05.30 nasukoji
@@ -1599,7 +1599,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("cLineTermChar")		, types.m_cLineTermChar );
 
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockDisp")			, types.m_bOutlineDockDisp );/* アウトライン解析表示の有無 */
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOutlineDockSide")	, types.m_eOutlineDockSide );/* アウトライン解析ドッキング配置 */
+	cProfile.IOProfileData(pszSecName, L"eOutlineDockSide", types.m_eOutlineDockSide );/* アウトライン解析ドッキング配置 */
 	{
 		const WCHAR* pszKeyName = LTEXT("xyOutlineDock");
 		const WCHAR* pszForm = LTEXT("%d,%d,%d,%d");
@@ -1625,14 +1625,14 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 			cProfile.IOProfileData(pszSecName, pszKeyName, StringBufferW(szKeyData));
 		}
 	}
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDockOutline")	, 	types.m_nDockOutline );/* アウトライン解析方法 */
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDefaultOutline")	, types.m_eDefaultOutline );/* アウトライン解析方法 */
+	cProfile.IOProfileData(pszSecName, L"nDockOutline", types.m_nDockOutline );/* アウトライン解析方法 */
+	cProfile.IOProfileData(pszSecName, L"nDefaultOutline", types.m_eDefaultOutline );/* アウトライン解析方法 */
 	cProfile.IOProfileData( pszSecName, LTEXT("szOutlineRuleFilename")	, types.m_szOutlineRuleFilename );/* アウトライン解析ルールファイル */
 	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineSortCol")		, types.m_nOutlineSortCol );/* アウトライン解析ソート列番号 */
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineSortDesc")		, types.m_bOutlineSortDesc );/* アウトライン解析ソート降順 */
 	cProfile.IOProfileData( pszSecName, LTEXT("nOutlineSortType")		, types.m_nOutlineSortType );/* アウトライン解析ソート基準 */
 	ShareData_IO_FileTree( cProfile, types.m_sFileTree, pszSecName );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nSmartIndent")		, types.m_eSmartIndent );/* スマートインデント種別 */
+	cProfile.IOProfileData(pszSecName, L"nSmartIndent", types.m_eSmartIndent );/* スマートインデント種別 */
 	cProfile.IOProfileData( pszSecName, LTEXT("bIndentCppStringIgnore")		, types.m_bIndentCppStringIgnore );
 	cProfile.IOProfileData( pszSecName, LTEXT("bIndentCppCommentIgnore")	, types.m_bIndentCppCommentIgnore );
 	cProfile.IOProfileData( pszSecName, LTEXT("bIndentCppUndoSep")	, types.m_bIndentCppUndoSep );
@@ -1659,8 +1659,8 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("bTypeHtmlHelpIsSingle"), types.m_bHtmlHelpIsSingle ); // 2012.06.30 Fix m_bHokanLoHiCase -> m_bHtmlHelpIsSingle
 
 	cProfile.IOProfileData( pszSecName, LTEXT("bPriorCesu8")		, types.m_encoding.m_bPriorCesu8 );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eDefaultCodetype")	, types.m_encoding.m_eDefaultCodetype );
-	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eDefaultEoltype")	, types.m_encoding.m_eDefaultEoltype );
+	cProfile.IOProfileData(pszSecName, L"eDefaultCodetype", types.m_encoding.m_eDefaultCodetype );
+	cProfile.IOProfileData(pszSecName, L"eDefaultEoltype", types.m_encoding.m_eDefaultEoltype );
 	cProfile.IOProfileData( pszSecName, LTEXT("bDefaultBom")		, types.m_encoding.m_bDefaultBom );
 
 	cProfile.IOProfileData( pszSecName, LTEXT("bAutoIndent")			, types.m_bAutoIndent );
@@ -1673,14 +1673,14 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 
 	// 2010.09.17 背景画像
 	cProfile.IOProfileData( pszSecName, L"bgImgPath", types.m_szBackImgPath );
-	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgPos", types.m_backImgPos );
+	cProfile.IOProfileData(pszSecName, L"bgImgPos", types.m_backImgPos );
 	cProfile.IOProfileData( pszSecName, L"bgImgScrollX",   types.m_backImgScrollX );
 	cProfile.IOProfileData( pszSecName, L"bgImgScrollY",   types.m_backImgScrollY );
 	cProfile.IOProfileData( pszSecName, L"bgImgRepeartX",  types.m_backImgRepeatX );
 	cProfile.IOProfileData( pszSecName, L"bgImgRepeartY",  types.m_backImgRepeatY );
-	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgPosOffsetX",  types.m_backImgPosOffset.x );
-	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgPosOffsetY",  types.m_backImgPosOffset.y );
-	cProfile.IOProfileData_WrapInt( pszSecName, L"bgImgOpacity", types.m_backImgOpacity );
+	cProfile.IOProfileData(pszSecName, L"bgImgPosOffsetX", types.m_backImgPosOffset.x );
+	cProfile.IOProfileData(pszSecName, L"bgImgPosOffsetY", types.m_backImgPosOffset.y );
+	cProfile.IOProfileData(pszSecName, L"bgImgOpacity", types.m_backImgOpacity );
 
 	// 2005.11.08 Moca 指定桁縦線
 	for(j = 0; j < MAX_VERTLINES; j++ ){
@@ -1767,7 +1767,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpAllSearch"), types.m_bUseKeyHelpAllSearch );	/* ヒットした次の辞書も検索(&A) */
 		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpKeyDisp"), types.m_bUseKeyHelpKeyDisp );		/* 1行目にキーワードも表示する(&W) */
 		cProfile.IOProfileData( pszSecName, LTEXT("bUseKeyHelpPrefix"), types.m_bUseKeyHelpPrefix );		/* 選択範囲で前方一致検索(&P) */
-		cProfile.IOProfileData_WrapInt(pszSecName, LTEXT("nKeyHelpRMenuShowType"), types.m_eKeyHelpRMenuShowType);
+		cProfile.IOProfileData(pszSecName, L"nKeyHelpRMenuShowType", types.m_eKeyHelpRMenuShowType);
 		for(j = 0; j < MAX_KEYHELP_FILE; j++){
 			auto_sprintf( szKeyName, LTEXT("KDct[%02d]"), j );
 			/* 読み出し */
@@ -2480,7 +2480,7 @@ void CShareData_IO::ShareData_IO_FileTreeItem(
 {
 	WCHAR szKey[64];
 	auto_sprintf( szKey, L"FileTree(%d).eItemType", i );
-	cProfile.IOProfileData_WrapInt( pszSecName, szKey, item.m_eFileTreeItemType );
+	cProfile.IOProfileData(pszSecName, szKey, item.m_eFileTreeItemType);
 	if( cProfile.IsReadingMode() || item.m_eFileTreeItemType == EFileTreeItemType_Grep
 		|| item.m_eFileTreeItemType == EFileTreeItemType_File ){
 		auto_sprintf( szKey, L"FileTree(%d).szTargetPath", i );

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -118,7 +118,7 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 			if (langId != MAKELANGID( LANG_JAPANESE, SUBLANG_JAPANESE_JAPAN )) {
 				DLLSHAREDATA* pShareData = &GetDllShareData();
 				wcscpy(pShareData->m_Common.m_sWindow.m_szLanguageDll, L"sakura_lang_en_US.dll");
-				cProfile.IOProfileData( L"Common", L"szLanguageDll", MakeStringBufferW( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );
+				cProfile.IOProfileData(L"Common", L"szLanguageDll", StringBufferW(pShareData->m_Common.m_sWindow.m_szLanguageDll));
 				std::vector<std::wstring> values;
 				pcShare->ConvertLangValues( values, true );
 				CSelectLang::ChangeLang( pShareData->m_Common.m_sWindow.m_szLanguageDll );
@@ -132,7 +132,7 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 		WCHAR iniVer[256];
 		DWORD mH, mL, lH, lL;
 		mH = mL = lH = lL = 0;	// ※ 古～い ini だと "szVersion" は無い
-		if( cProfile.IOProfileData( LTEXT("Other"), LTEXT("szVersion"), MakeStringBufferW(iniVer) ) )
+		if( cProfile.IOProfileData(LTEXT("Other"), L"szVersion", StringBufferW(iniVer)) )
 			_stscanf( iniVer, L"%u.%u.%u.%u", &mH, &mL, &lH, &lL );
 		DWORD dwMS = (DWORD)MAKELONG(mL, mH);
 		DWORD dwLS = (DWORD)MAKELONG(lL, lH);
@@ -152,7 +152,7 @@ bool CShareData_IO::ShareData_IO_2( bool bRead )
 
 	if( bRead ){
 		DLLSHAREDATA* pShareData = &GetDllShareData();
-		cProfile.IOProfileData( L"Common", L"szLanguageDll", MakeStringBufferW( pShareData->m_Common.m_sWindow.m_szLanguageDll ) );
+		cProfile.IOProfileData(L"Common", L"szLanguageDll", StringBufferW(pShareData->m_Common.m_sWindow.m_szLanguageDll));
 		CSelectLang::ChangeLang( pShareData->m_Common.m_sWindow.m_szLanguageDll );
 		pcShare->RefreshString();
 	}
@@ -229,12 +229,12 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].nCharCode"), i );
 		cProfile.IOProfileData_WrapInt( pszSecName, szKeyName, pfiWork->m_nCharCode );
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].szPath"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pfiWork->m_szPath) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pfiWork->m_szPath));
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].szMark2"), i );
-		if( !cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pfiWork->m_szMarkLines) ) ){
+		if( !cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pfiWork->m_szMarkLines)) ){
 			if( cProfile.IsReadingMode() ){
 				auto_sprintf( szKeyName, LTEXT("MRU[%02d].szMark"), i ); // 旧ver互換
-				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pfiWork->m_szMarkLines) );
+				cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pfiWork->m_szMarkLines));
 			}
 		}
 		auto_sprintf( szKeyName, LTEXT("MRU[%02d].nType"), i );
@@ -438,9 +438,9 @@ void CShareData_IO::ShareData_IO_Nickname( CDataProfile& cProfile )
 	int nSize = pShare->m_Common.m_sFileName.m_nTransformFileNameArrNum;
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, LTEXT("From%02d"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pShare->m_Common.m_sFileName.m_szTransformFileNameFrom[i]) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pShare->m_Common.m_sFileName.m_szTransformFileNameFrom[i]));
 		auto_sprintf( szKeyName, LTEXT("To%02d"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pShare->m_Common.m_sFileName.m_szTransformFileNameTo[i]) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pShare->m_Common.m_sFileName.m_szTransformFileNameTo[i]));
 	}
 	// 読み込み時，残りをNULLで再初期化
 	if( cProfile.IsReadingMode() ){
@@ -457,7 +457,7 @@ static bool ShareData_IO_RECT( CDataProfile& cProfile, const WCHAR* pszSecName, 
 	WCHAR		szKeyData[100];
 	bool		ret = false;
 	if( cProfile.IsReadingMode() ){
-		ret = cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData) );
+		ret = cProfile.IOProfileData(pszSecName, pszKeyName, StringBufferW(szKeyData));
 		if( ret ){
 			int buf[4];
 			scan_ints( szKeyData, pszForm, buf );
@@ -475,7 +475,7 @@ static bool ShareData_IO_RECT( CDataProfile& cProfile, const WCHAR* pszSecName, 
 			rcValue.right,
 			rcValue.bottom
 		);
-		ret = cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData) );
+		ret = cProfile.IOProfileData(pszSecName, pszKeyName, StringBufferW(szKeyData));
 	}
 	return ret;
 }
@@ -508,7 +508,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("m_bRestoreBookmarks")	, common.m_sFile.m_bRestoreBookmarks );
 	cProfile.IOProfileData( pszSecName, LTEXT("bAddCRLFWhenCopy")		, common.m_sEdit.m_bAddCRLFWhenCopy );
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("eOpenDialogDir")		, common.m_sEdit.m_eOpenDialogDir );
-	cProfile.IOProfileData( pszSecName, LTEXT("szOpenDialogSelDir")		, StringBufferW(common.m_sEdit.m_OpenDialogSelDir,_countof2(common.m_sEdit.m_OpenDialogSelDir)) );
+	cProfile.IOProfileData(pszSecName, L"szOpenDialogSelDir", common.m_sEdit.m_OpenDialogSelDir);
 	cProfile.IOProfileData( pszSecName, LTEXT("bBoxSelectLock")	, common.m_sEdit.m_bBoxSelectLock );
 	cProfile.IOProfileData( pszSecName, LTEXT("bVistaStyleFileDialog")	, common.m_sEdit.m_bVistaStyleFileDialog );
 	cProfile.IOProfileData( pszSecName, LTEXT("nRepeatedScrollLineNum")	, common.m_sGeneral.m_nRepeatedScrollLineNum );
@@ -544,7 +544,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("nTagJumpModeKeyword")	, common.m_sSearch.m_nTagJumpModeKeyword );
 	
 	/* 正規表現DLL 2007.08.12 genta */
-	cProfile.IOProfileData( pszSecName, LTEXT("szRegexpLib")			, MakeStringBufferW(common.m_sSearch.m_szRegexpLib) );
+	cProfile.IOProfileData(pszSecName, L"szRegexpLib", StringBufferW(common.m_sSearch.m_szRegexpLib));
 	cProfile.IOProfileData( pszSecName, LTEXT("bGTJW_RETURN")			, common.m_sSearch.m_bGTJW_RETURN );
 	cProfile.IOProfileData( pszSecName, LTEXT("bGTJW_LDBLCLK")			, common.m_sSearch.m_bGTJW_LDBLCLK );
 	cProfile.IOProfileData( pszSecName, LTEXT("bBackUp")				, common.m_sBackup.m_bBackUp );
@@ -587,11 +587,11 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bBackUpPathAdvanced")	, common.m_sBackup.m_bBackUpPathAdvanced );	/* 20051107 aroka */
 	cProfile.IOProfileData( pszSecName, LTEXT("szBackUpPathAdvanced")	, common.m_sBackup.m_szBackUpPathAdvanced );	/* 20051107 aroka */
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nFileShareMode")			, common.m_sFile.m_nFileShareMode );
-	cProfile.IOProfileData( pszSecName, LTEXT("szExtHelp"), MakeStringBufferW(common.m_sHelper.m_szExtHelp) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szExtHtmlHelp"), MakeStringBufferW(common.m_sHelper.m_szExtHtmlHelp) );
+	cProfile.IOProfileData(pszSecName, L"szExtHelp", StringBufferW(common.m_sHelper.m_szExtHelp));
+	cProfile.IOProfileData(pszSecName, L"szExtHtmlHelp", StringBufferW(common.m_sHelper.m_szExtHtmlHelp));
 	
-	cProfile.IOProfileData( pszSecName, LTEXT("szMigemoDll"), MakeStringBufferW(common.m_sHelper.m_szMigemoDll) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szMigemoDict"), MakeStringBufferW(common.m_sHelper.m_szMigemoDict) );
+	cProfile.IOProfileData(pszSecName, L"szMigemoDll", StringBufferW(common.m_sHelper.m_szMigemoDll));
+	cProfile.IOProfileData(pszSecName, L"szMigemoDict", StringBufferW(common.m_sHelper.m_szMigemoDict));
 	
 	// ai 02/05/23 Add S
 	{// Keword Help Font
@@ -609,14 +609,14 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispMiniMap")			, common.m_sWindow.m_bDispMiniMap );
 	cProfile.IOProfileData( pszSecName, LTEXT("nFUNCKEYWND_Place")		, common.m_sWindow.m_nFUNCKEYWND_Place );
 	cProfile.IOProfileData( pszSecName, LTEXT("nFUNCKEYWND_GroupNum")	, common.m_sWindow.m_nFUNCKEYWND_GroupNum );		// 2002/11/04 Moca ファンクションキーのグループボタン数
-	cProfile.IOProfileData( pszSecName, LTEXT("szLanguageDll")			, MakeStringBufferW( common.m_sWindow.m_szLanguageDll ) );
+	cProfile.IOProfileData(pszSecName, L"szLanguageDll", StringBufferW(common.m_sWindow.m_szLanguageDll));
 	cProfile.IOProfileData( pszSecName, LTEXT("nMiniMapFontSize")		, common.m_sWindow.m_nMiniMapFontSize );
 	cProfile.IOProfileData( pszSecName, LTEXT("nMiniMapQuality")		, common.m_sWindow.m_nMiniMapQuality );
 	cProfile.IOProfileData( pszSecName, LTEXT("nMiniMapWidth")			, common.m_sWindow.m_nMiniMapWidth );
 	
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabWnd")			, common.m_sTabBar.m_bDispTabWnd );	//タブウインドウ	//@@@ 2003.05.31 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabWndMultiWin")	, common.m_sTabBar.m_bDispTabWndMultiWin );	//タブウインドウ	//@@@ 2003.05.31 MIK
-	cProfile.IOProfileData( pszSecName, LTEXT("szTabWndCaption")		, MakeStringBufferW(common.m_sTabBar.m_szTabWndCaption) );	//@@@ 2003.06.13 MIK
+	cProfile.IOProfileData(pszSecName, L"szTabWndCaption", StringBufferW(common.m_sTabBar.m_szTabWndCaption));	//@@@ 2003.06.13 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bSameTabWidth")			, common.m_sTabBar.m_bSameTabWidth );	// 2006.01.28 ryoji タブを等幅にする
 	cProfile.IOProfileData( pszSecName, LTEXT("bDispTabIcon")			, common.m_sTabBar.m_bDispTabIcon );	// 2006.01.28 ryoji タブにアイコンを表示する
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bDispTabClose")	, common.m_sTabBar.m_bDispTabClose );	// 2012.04.14 syat
@@ -640,8 +640,8 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bSplitterWndHScroll")	, common.m_sWindow.m_bSplitterWndHScroll );
 	cProfile.IOProfileData( pszSecName, LTEXT("bSplitterWndVScroll")	, common.m_sWindow.m_bSplitterWndVScroll );
 	
-	cProfile.IOProfileData( pszSecName, LTEXT("szMidashiKigou")		, MakeStringBufferW(common.m_sFormat.m_szMidashiKigou) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szInyouKigou")			, MakeStringBufferW(common.m_sFormat.m_szInyouKigou) );
+	cProfile.IOProfileData(pszSecName, L"szMidashiKigou", StringBufferW(common.m_sFormat.m_szMidashiKigou));
+	cProfile.IOProfileData(pszSecName, L"szInyouKigou", StringBufferW(common.m_sFormat.m_szInyouKigou));
 	
 	// 2001/06/14 asa-o 補完とキーワードヘルプはタイプ別に移動したので削除：３行
 	// 2002/09/21 Moca bGrepKanjiCode_AutoDetect は bGrepCharSetに統合したので削除
@@ -702,9 +702,9 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bHokanKey_SPACE")			, common.m_sHelper.m_bHokanKey_SPACE );/* VK_SPACE  補完決定キーが有効/無効 */
 	
 	cProfile.IOProfileData( pszSecName, LTEXT("nDateFormatType")			, common.m_sFormat.m_nDateFormatType );/* 日付書式のタイプ */
-	cProfile.IOProfileData( pszSecName, LTEXT("szDateFormat")				, MakeStringBufferW(common.m_sFormat.m_szDateFormat) );//日付書式
+	cProfile.IOProfileData(pszSecName, L"szDateFormat", StringBufferW(common.m_sFormat.m_szDateFormat));//日付書式
 	cProfile.IOProfileData( pszSecName, LTEXT("nTimeFormatType")			, common.m_sFormat.m_nTimeFormatType );/* 時刻書式のタイプ */
-	cProfile.IOProfileData( pszSecName, LTEXT("szTimeFormat")				, MakeStringBufferW(common.m_sFormat.m_szTimeFormat) );//時刻書式
+	cProfile.IOProfileData(pszSecName, L"szTimeFormat", StringBufferW(common.m_sFormat.m_szTimeFormat));//時刻書式
 	
 	cProfile.IOProfileData( pszSecName, LTEXT("bMenuIcon")					, common.m_sWindow.m_bMenuIcon );//メニューにアイコンを表示する
 	cProfile.IOProfileData( pszSecName, LTEXT("bAutoMIMEdecode")			, common.m_sFile.m_bAutoMIMEdecode );//ファイル読み込み時にMIMEのdecodeを行うか
@@ -729,8 +729,8 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, LTEXT("bFunclistSetFocusOnJump")	, common.m_sOutline.m_bFunclistSetFocusOnJump );
 	
 	//	Apr. 05, 2003 genta ウィンドウキャプションのカスタマイズ
-	cProfile.IOProfileData( pszSecName, LTEXT("szWinCaptionActive") , MakeStringBufferW(common.m_sWindow.m_szWindowCaptionActive) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szWinCaptionInactive"), MakeStringBufferW(common.m_sWindow.m_szWindowCaptionInactive) );
+	cProfile.IOProfileData(pszSecName, L"szWinCaptionActive", StringBufferW(common.m_sWindow.m_szWindowCaptionActive));
+	cProfile.IOProfileData(pszSecName, L"szWinCaptionInactive", StringBufferW(common.m_sWindow.m_szWindowCaptionInactive));
 	
 	// アウトライン/トピックリスト の位置とサイズを記憶  20060201 aroka
 	cProfile.IOProfileData( pszSecName, LTEXT("bRememberOutlineWindowPos"), common.m_sOutline.m_bRememberOutlineWindowPos);
@@ -749,7 +749,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 		const WCHAR* pszForm = LTEXT("%d,%d,%d,%d");
 		WCHAR		szKeyData[1024];
 		if( cProfile.IsReadingMode() ){
-			if( cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData)) ){
+			if( cProfile.IOProfileData(pszSecName, pszKeyName, StringBufferW(szKeyData)) ){
 				int buf[4];
 				scan_ints( szKeyData, pszForm, buf );
 				common.m_sOutline.m_cxOutlineDockLeft	= buf[0];
@@ -766,7 +766,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 				common.m_sOutline.m_cxOutlineDockRight,
 				common.m_sOutline.m_cyOutlineDockBottom
 			);
-			cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData) );
+			cProfile.IOProfileData(pszSecName, pszKeyName, StringBufferW(szKeyData));
 		}
 	}
 	cProfile.IOProfileData( pszSecName, LTEXT("nDockOutline"), common.m_sOutline.m_nDockOutline );
@@ -892,7 +892,7 @@ void CShareData_IO::ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* p
 		// Plugin String Parametor
 		if( cProfile.IsReadingMode() ){
 			//読み込み
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szText) );
+			cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szText));
 			if (wcschr(szText, L'/') == NULL) {
 				// 番号
 				toolbar.m_nToolBarButtonIdxArr[i] = _wtoi( szText );
@@ -920,7 +920,7 @@ void CShareData_IO::ShareData_IO_Toolbar( CDataProfile& cProfile, CMenuDrawer* p
 					cProfile.IOProfileData( pszSecName, szKeyName, nInvalid );	
 				}
 				else if (GetPlugCmdInfoByFuncCode( eFunc, szText )) {
-					cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szText) );	
+					cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szText));	
 				}
 				else {
 					cProfile.IOProfileData( pszSecName, szKeyName, toolbar.m_nToolBarButtonIdxArr[i] );	
@@ -965,7 +965,7 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 
 	for( i = 0; i < MAX_CUSTOM_MENU; ++i ){
 		auto_sprintf( szKeyName, LTEXT("szCMN[%02d]"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(menu.m_szCustMenuNameArr[i]) );	//	Oct. 15, 2001 genta 最大長指定
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(menu.m_szCustMenuNameArr[i]));	//	Oct. 15, 2001 genta 最大長指定
 		auto_sprintf( szKeyName, LTEXT("bCMPOP[%02d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, menu.m_bCustMenuPopupArr[i] );
 		auto_sprintf( szKeyName, LTEXT("nCMIN[%02d]"), i );
@@ -976,14 +976,14 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 			// start マクロ名でも設定できるように 2008/5/24 Uchi
 			auto_sprintf( szKeyName, LTEXT("nCMIF[%02d][%02d]"), i, j );
 			if (cProfile.IsReadingMode()) {
-				cProfile.IOProfileData(pszSecName, szKeyName, MakeStringBufferW(szFuncName));
+				cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szFuncName));
 				n = GetFunctionStrToFunctionCode(szFuncName);
 				menu.m_nCustMenuItemFuncArr[i][j] = n;
 			}
 			else {
 				if (GetPlugCmdInfoByFuncCode( menu.m_nCustMenuItemFuncArr[i][j], szFuncName)) {
 					// Plugin
-					cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szFuncName) );
+					cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szFuncName));
 				}
 				else {
 					if (bOutCmdName) {
@@ -996,7 +996,7 @@ void CShareData_IO::IO_CustMenu( CDataProfile& cProfile, CommonSetting_CustomMen
 						if ( p == NULL ) {
 							auto_sprintf( szFuncName, L"%d", menu.m_nCustMenuItemFuncArr[i][j] );
 						}
-						cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szFuncName) );
+						cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szFuncName));
 					}
 					else {
 						cProfile.IOProfileData_WrapInt( pszSecName, szKeyName, menu.m_nCustMenuItemFuncArr[i][j] );
@@ -1061,7 +1061,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 	int nKeyNameArrUsed = sKeyBind.m_nKeyNameArrNum; // 使用済み領域
 
 	if( cProfile.IsReadingMode() ){ 
-		if (!cProfile.IOProfileData( szSecName, L"KeyBind[000]", MakeStringBufferW(szKeyData) ) ) {
+		if (!cProfile.IOProfileData(szSecName, L"KeyBind[000]", StringBufferW(szKeyData)) ) {
 			bOldVer = true;
 		}
 		else {
@@ -1080,7 +1080,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 			if (bOldVer) {
 				KEYDATA& keydata = sKeyBind.m_pKeyNameArr[i];
 				wcscpy_s( szKeyName, keydata.m_szKeyName );
-				if( cProfile.IOProfileData( szSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+				if( cProfile.IOProfileData(szSecName, szKeyName, StringBufferW(szKeyData)) ){
 					int buf[8];
 					scan_ints( szKeyData, LTEXT("%d,%d,%d,%d,%d,%d,%d,%d"), buf );
 					keydata.m_nFuncCodeArr[0]	= (EFunctionCode)buf[0];
@@ -1096,7 +1096,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 			else {		// 新バージョン(キー割り当てのImport,export の合わせた)	2008/5/25 Uchi
 				KEYDATA tmpKeydata;
 				auto_sprintf(szKeyName, L"KeyBind[%03d]", i);
-				if( cProfile.IOProfileData( szSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+				if( cProfile.IOProfileData(szSecName, szKeyName, StringBufferW(szKeyData)) ){
 					wchar_t	*p;
 					wchar_t	*pn;
 					int		nRes;
@@ -1165,7 +1165,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 		//		keydata.m_nFuncCodeArr[6],
 		//		keydata.m_nFuncCodeArr[7]
 		//	);
-		//	cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+		//	cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData));
 
 // start 新バージョン	2008/5/25 Uchi
 			KEYDATA& keydata = sKeyBind.m_pKeyNameArr[i];
@@ -1208,7 +1208,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 				auto_sprintf(szWork, L",%s", keydata.m_szKeyName);
 			}
 			wcscat(szKeyData, szWork);
-			cProfile.IOProfileData( szSecName, szKeyName, MakeStringBufferW(szKeyData) );
+			cProfile.IOProfileData(szSecName, szKeyName, StringBufferW(szKeyData));
 //
 		}
 	}
@@ -1238,7 +1238,7 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].nInts"), i );
 		static const WCHAR* pszForm = LTEXT("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d");
 		if( cProfile.IsReadingMode() ){
-			if( cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+			if( cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData)) ){
 				int buf[19];
 				scan_ints( szKeyData, pszForm, buf );
 				printsetting.m_nPrintFontWidth			= buf[ 0];
@@ -1283,21 +1283,21 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 				printsetting.m_bFooterUse[1]?1:0,
 				printsetting.m_bFooterUse[2]?1:0
 			);
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+			cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData));
 		}
 
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szSName")	, i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szPrintSettingName) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(printsetting.m_szPrintSettingName));
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szFF")	, i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szPrintFontFaceHan) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(printsetting.m_szPrintFontFaceHan));
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szFFZ")	, i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szPrintFontFaceZen) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(printsetting.m_szPrintFontFaceZen));
 		// ヘッダ/フッタ
 		for( j = 0; j < 3; ++j ){
 			auto_sprintf( szKeyName, LTEXT("PS[%02d].szHF[%d]") , i, j );
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szHeaderForm[j]) );
+			cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(printsetting.m_szHeaderForm[j]));
 			auto_sprintf( szKeyName, LTEXT("PS[%02d].szFTF[%d]"), i, j );
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_szFooterForm[j]) );
+			cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(printsetting.m_szFooterForm[j]));
 		}
 		{ // ヘッダ/フッタ フォント設定
 			WCHAR	szKeyName2[64];
@@ -1315,11 +1315,11 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 		}
 
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szDriver"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_mdmDevMode.m_szPrinterDriverName) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(printsetting.m_mdmDevMode.m_szPrinterDriverName));
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szDevice"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_mdmDevMode.m_szPrinterDeviceName) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(printsetting.m_mdmDevMode.m_szPrinterDeviceName));
 		auto_sprintf( szKeyName, LTEXT("PS[%02d].szOutput"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(printsetting.m_mdmDevMode.m_szPrinterOutputName) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(printsetting.m_mdmDevMode.m_szPrinterOutputName));
 
 		// 2002.02.16 hor とりあえず旧設定を変換しとく
 		if(0==wcscmp(printsetting.m_szHeaderForm[0],_EDITL("&f")) &&
@@ -1427,8 +1427,8 @@ static bool ShareData_IO_BlockComment( CDataProfile& cProfile,
 	}
 
 	bool ret = false;
-	if( cProfile.IOProfileData( pszSectionName, pszEntryKeyFrom, MakeStringBufferW( szFrom ) )
-		&& cProfile.IOProfileData( pszSectionName, pszEntryKeyTo, MakeStringBufferW( szTo ) ) ){
+	if( cProfile.IOProfileData(pszSectionName, pszEntryKeyFrom, StringBufferW(szFrom))
+		&& cProfile.IOProfileData(pszSectionName, pszEntryKeyTo, StringBufferW(szTo)) ){
 		//対になる設定が揃った場合のみ有効
 		ret = true;
 	}
@@ -1465,7 +1465,7 @@ static bool ShareData_IO_LineComment( CDataProfile& cProfile,
 	}
 
 	bool ret = false;
-	if( cProfile.IOProfileData( pszSectionName, pszEntryKeyComment, MakeStringBufferW( lbuf ) )
+	if( cProfile.IOProfileData(pszSectionName, pszEntryKeyComment, StringBufferW(lbuf))
 		&& cProfile.IOProfileData( pszSectionName, pszEntryKeyColumn, pos ) ){
 		//対になる設定が揃った場合のみ有効
 		ret = true;
@@ -1498,7 +1498,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	static const WCHAR* pszForm = LTEXT("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d");	//MIK
 	wcscpy( szKeyName, LTEXT("nInts") );
 	if( cProfile.IsReadingMode() ){
-		if( cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+		if( cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData)) ){
 			int buf[12];
 			scan_ints( szKeyData, pszForm, buf );
 			types.m_nIdx					= buf[ 0];
@@ -1537,7 +1537,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 			types.m_nCurrentPrintSetting,
 			types.m_nTsvMode
 		);
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData));
 	}
 	// 2005.01.13 MIK Keywordset 3-10
 	cProfile.IOProfileData( pszSecName, LTEXT("nKeywordSelect3"),  types.m_nKeyWordSetIdx[2] );
@@ -1571,13 +1571,13 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		}
 	}
 
-	cProfile.IOProfileData( pszSecName, LTEXT("szTypeName"), MakeStringBufferW(types.m_szTypeName) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szTypeExts"), MakeStringBufferW(types.m_szTypeExts) );
+	cProfile.IOProfileData(pszSecName, L"szTypeName", StringBufferW(types.m_szTypeName));
+	cProfile.IOProfileData(pszSecName, L"szTypeExts", StringBufferW(types.m_szTypeExts));
 	cProfile.IOProfileData( pszSecName, LTEXT("id"), types.m_id );
 	if( types.m_id < 0 ){
 		types.m_id *= -1;
 	}
-	cProfile.IOProfileData( pszSecName, LTEXT("szTabViewString"), MakeStringBufferW(types.m_szTabViewString) );
+	cProfile.IOProfileData(pszSecName, L"szTabViewString", StringBufferW(types.m_szTabViewString));
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("bTabArrow")	, types.m_bTabArrow );	//@@@ 2003.03.26 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bInsSpace")			, types.m_bInsSpace );	// 2001.12.03 hor
 
@@ -1595,7 +1595,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment2", L"nLineCommentColumn2", types.m_cLineComment, 1 );
 	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment3", L"nLineCommentColumn3", types.m_cLineComment, 2 );
 
-	cProfile.IOProfileData( pszSecName, LTEXT("szIndentChars")		, MakeStringBufferW(types.m_szIndentChars) );
+	cProfile.IOProfileData(pszSecName, L"szIndentChars", StringBufferW(types.m_szIndentChars));
 	cProfile.IOProfileData( pszSecName, LTEXT("cLineTermChar")		, types.m_cLineTermChar );
 
 	cProfile.IOProfileData( pszSecName, LTEXT("bOutlineDockDisp")			, types.m_bOutlineDockDisp );/* アウトライン解析表示の有無 */
@@ -1605,7 +1605,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		const WCHAR* pszForm = LTEXT("%d,%d,%d,%d");
 		WCHAR		szKeyData[1024];
 		if( cProfile.IsReadingMode() ){
-			if( cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData)) ){
+			if( cProfile.IOProfileData(pszSecName, pszKeyName, StringBufferW(szKeyData)) ){
 				int buf[4];
 				scan_ints( szKeyData, pszForm, buf );
 				types.m_cxOutlineDockLeft	= buf[0];
@@ -1622,7 +1622,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 				types.m_cxOutlineDockRight,
 				types.m_cyOutlineDockBottom
 			);
-			cProfile.IOProfileData( pszSecName, pszKeyName, MakeStringBufferW(szKeyData) );
+			cProfile.IOProfileData(pszSecName, pszKeyName, StringBufferW(szKeyData));
 		}
 	}
 	cProfile.IOProfileData_WrapInt( pszSecName, LTEXT("nDockOutline")	, 	types.m_nDockOutline );/* アウトライン解析方法 */
@@ -1705,7 +1705,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 			if( cProfile.IsReadingMode() )
 			{
 				types.m_RegexKeywordArr[j].m_nColorIndex = COLORIDX_REGEX1;
-				if( cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData)) )
+				if( cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData)) )
 				{
 					p = wcschr(szKeyData, LTEXT(','));
 					if( p )
@@ -1738,7 +1738,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 				auto_sprintf( szKeyData, LTEXT("%ls,%ls"),
 					GetColorNameByIndex( types.m_RegexKeywordArr[j].m_nColorIndex ),
 					&pKeyword[nPos]);
-				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+				cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData));
 				nPos += wcslen(&pKeyword[nPos]) + 1;
 			}
 		}
@@ -1754,9 +1754,9 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, LTEXT("bKinsokuRet")	, types.m_bKinsokuRet );	//@@@ 2002.04.13 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bKinsokuKuto")	, types.m_bKinsokuKuto );	//@@@ 2002.04.17 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("bKinsokuHide")	, types.m_bKinsokuHide );	//2012/11/30 Uchi
-	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuHead")	, MakeStringBufferW(types.m_szKinsokuHead) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuTail")	, MakeStringBufferW(types.m_szKinsokuTail) );
-	cProfile.IOProfileData( pszSecName, LTEXT("szKinsokuKuto")	, MakeStringBufferW(types.m_szKinsokuKuto) );	// 2009.08.07 ryoji
+	cProfile.IOProfileData(pszSecName, L"szKinsokuHead", StringBufferW(types.m_szKinsokuHead));
+	cProfile.IOProfileData(pszSecName, L"szKinsokuTail", StringBufferW(types.m_szKinsokuTail));
+	cProfile.IOProfileData(pszSecName, L"szKinsokuKuto", StringBufferW(types.m_szKinsokuKuto));	// 2009.08.07 ryoji
 	cProfile.IOProfileData( pszSecName, LTEXT("bUseDocumentIcon")	, types.m_bUseDocumentIcon );	// Sep. 19 ,2002 genta 変数名誤り修正
 
 //@@@ 2006.04.10 fon ADD-start
@@ -1775,7 +1775,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 				types.m_KeyHelpArr[j].m_bUse = false;
 				types.m_KeyHelpArr[j].m_szAbout[0] = L'\0';
 				types.m_KeyHelpArr[j].m_szPath[0] = L'\0';
-				if( cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData)) ){
+				if( cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData)) ){
 					pH = szKeyData;
 					if( NULL != (pT=wcschr(pH, L',')) ){
 						*pT = L'\0';
@@ -1800,7 +1800,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 						types.m_KeyHelpArr[j].m_szAbout,
 						types.m_KeyHelpArr[j].m_szPath.c_str()
 					);
-					cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+					cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData));
 				}
 			}
 		}
@@ -1855,7 +1855,7 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 				int nKeyWordNum = 0;
 				//値の取得
 				auto_sprintf( szKeyName, LTEXT("szSN[%02d]"), i );
-				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+				cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData));
 				auto_sprintf( szKeyName, LTEXT("nCASE[%02d]"), i );
 				cProfile.IOProfileData( pszSecName, szKeyName, bKEYWORDCASE );
 				auto_sprintf( szKeyName, LTEXT("nKWN[%02d]"), i );
@@ -1874,7 +1874,7 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 		int nSize = pCKeyWordSetMgr->m_nKeyWordSetNum;
 		for( i = 0; i < nSize; ++i ){
 			auto_sprintf( szKeyName, LTEXT("szSN[%02d]"), i );
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pCKeyWordSetMgr->m_szSetNameArr[i]) );
+			cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pCKeyWordSetMgr->m_szSetNameArr[i]));
 			auto_sprintf( szKeyName, LTEXT("nCASE[%02d]"), i );
 			cProfile.IOProfileData( pszSecName, szKeyName, pCKeyWordSetMgr->m_bKEYWORDCASEArr[i] );
 			auto_sprintf( szKeyName, LTEXT("nKWN[%02d]"), i );
@@ -1899,7 +1899,7 @@ void CShareData_IO::ShareData_IO_KeyWords( CDataProfile& cProfile )
 			}
 			*pMem = L'\0';
 			auto_sprintf( szKeyName, LTEXT("szKW[%02d]"), i );
-			cProfile.IOProfileData( pszSecName, szKeyName, StringBufferW(pszMem,nMemLen) );
+			cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pszMem, nMemLen));
 			delete [] pszMem;
 		}
 	}
@@ -1924,9 +1924,9 @@ void CShareData_IO::ShareData_IO_Macro( CDataProfile& cProfile )
 		// 2002.02.08 hor 未定義値を無視
 		if( !cProfile.IsReadingMode() && macrorec.m_szName[0] == L'\0' && macrorec.m_szFile[0] == L'\0' ) continue;
 		auto_sprintf( szKeyName, LTEXT("Name[%03d]"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(macrorec.m_szName) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(macrorec.m_szName));
 		auto_sprintf( szKeyName, LTEXT("File[%03d]"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(macrorec.m_szFile) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(macrorec.m_szFile));
 		auto_sprintf( szKeyName, LTEXT("ReloadWhenExecute[%03d]"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, macrorec.m_bReloadWhenExecute );
 	}
@@ -1984,9 +1984,9 @@ void CShareData_IO::ShareData_IO_Plugin( CDataProfile& cProfile, CMenuDrawer* pc
 			pluginrec.m_szId[0] = L'\0';
 		}
 		auto_sprintf( szKeyName, LTEXT("P[%02d].Name"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pluginrec.m_szName) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pluginrec.m_szName));
 		auto_sprintf( szKeyName, LTEXT("P[%02d].Id"), i );
-		cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW(pluginrec.m_szId) );
+		cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(pluginrec.m_szId));
 		auto_sprintf( szKeyName, LTEXT("P[%02d].CmdNum"), i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pluginrec.m_nCmdNum );	// 2010/7/4 Uchi
 		pluginrec.m_state = ( pluginrec.m_szId[0] == '\0' ? PLS_NONE : PLS_STOPPED );
@@ -2196,7 +2196,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 			if( pData ){
 				wcscpy(szLine, data[dataNum++].c_str());
 			}else{
-				cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW( szLine ) );
+				cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szLine));
 			}
 
 			// レベル
@@ -2273,7 +2273,7 @@ void CShareData_IO::IO_MainMenu( CDataProfile& cProfile, std::vector<std::wstrin
 				szFuncName, 
 				pcMenu->m_sKey, 
 				pcMenu->m_nFunc == F_NODE ? pcMenu->m_sName : L"" );
-			cProfile.IOProfileData( pszSecName, szKeyName, MakeStringBufferW( szLine ) );
+			cProfile.IOProfileData(pszSecName, szKeyName, StringBufferW(szLine));
 		}
 
 		if (cProfile.IsReadingMode() && pcMenu->m_nLevel == 0) {
@@ -2313,7 +2313,7 @@ void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 	
 	/* CTAGS */	//@@@ 2003.05.12 MIK
 	cProfile.IOProfileData( pszSecName, LTEXT("nTagsOpt")		, pShare->m_nTagsOpt );
-	cProfile.IOProfileData( pszSecName, LTEXT("szTagsCmdLine")	, MakeStringBufferW(pShare->m_szTagsCmdLine) );
+	cProfile.IOProfileData(pszSecName, L"szTagsCmdLine", StringBufferW(pShare->m_szTagsCmdLine));
 	
 	//From Here 2005.04.03 MIK キーワード指定タグジャンプ
 	cProfile.IOProfileData( pszSecName, LTEXT("_TagJumpKeyword_Counts"), pShare->m_sTagJump.m_aTagJumpKeywords._GetSizeRef() );
@@ -2338,7 +2338,7 @@ void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 					LOWORD( pShare->m_sVersion.m_dwProductVersionMS ),
 					HIWORD( pShare->m_sVersion.m_dwProductVersionLS ),
 					LOWORD( pShare->m_sVersion.m_dwProductVersionLS ) );
-		cProfile.IOProfileData( pszSecName, LTEXT("szVersion"), MakeStringBufferW(iniVer) );
+		cProfile.IOProfileData(pszSecName, L"szVersion", StringBufferW(iniVer));
 
 		// 共有メモリバージョン	2010/5/20 Uchi
 		int		nStructureVersion;
@@ -2367,7 +2367,7 @@ void CShareData_IO::IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecNam
 		static const WCHAR* pszForm = LTEXT("%d,%d,%06x,%06x,%d");
 		auto_sprintf( szKeyName, LTEXT("C[%s]"), g_ColorAttributeArr[j].szName );	//Stonee, 2001/01/12, 2001/01/15
 		if( pcProfile->IsReadingMode() ){
-			if( pcProfile->IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) ) ){
+			if( pcProfile->IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData)) ){
 				int buf[5];
 				scan_ints( szKeyData, pszForm, buf);
 				pColorInfoArr[j].m_bDisp                  = (buf[0]!=0);
@@ -2401,7 +2401,7 @@ void CShareData_IO::IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecNam
 				pColorInfoArr[j].m_sColorAttr.m_cBACK,
 				pColorInfoArr[j].m_sFontAttr.m_bUnderLine?1:0
 			);
-			pcProfile->IOProfileData( pszSecName, szKeyName, MakeStringBufferW(szKeyData) );
+			pcProfile->IOProfileData(pszSecName, szKeyName, StringBufferW(szKeyData));
 		}
 	}
 }
@@ -2417,7 +2417,7 @@ void ShareData_IO_Sub_LogFont( CDataProfile& cProfile, const WCHAR* pszSecName,
 
 	cProfile.IOProfileData( pszSecName, pszKeyPointSize, nPointSize );	// 2009.10.01 ryoji
 	if( cProfile.IsReadingMode() ){
-		if( cProfile.IOProfileData( pszSecName, pszKeyLf, MakeStringBufferW(szKeyData) ) ){
+		if( cProfile.IOProfileData(pszSecName, pszKeyLf, StringBufferW(szKeyData)) ){
 			int buf[13];
 			scan_ints( szKeyData, pszForm, buf );
 			lf.lfHeight			= buf[ 0];
@@ -2458,10 +2458,10 @@ void ShareData_IO_Sub_LogFont( CDataProfile& cProfile, const WCHAR* pszSecName,
 			lf.lfQuality,
 			lf.lfPitchAndFamily
 		);
-		cProfile.IOProfileData( pszSecName, pszKeyLf, MakeStringBufferW(szKeyData) );
+		cProfile.IOProfileData(pszSecName, pszKeyLf, StringBufferW(szKeyData));
 	}
 	
-	cProfile.IOProfileData( pszSecName, pszKeyFaceName, MakeStringBufferW(lf.lfFaceName) );
+	cProfile.IOProfileData(pszSecName, pszKeyFaceName, StringBufferW(lf.lfFaceName));
 }
 
 void CShareData_IO::ShareData_IO_FileTree( CDataProfile& cProfile, SFileTree& fileTree, const WCHAR* pszSecName )

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -257,7 +257,7 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 	}
 	if ((unsigned int)nStructureVersion != m_pShareData->m_vStructureVersion) {
 		wcscpy( szKeyVersion, L"?" );
-		m_cProfile.IOProfileData( szSecInfo, szKeyVersion, MakeStringBufferW( szKeyVersion ) );
+		m_cProfile.IOProfileData(szSecInfo, szKeyVersion, StringBufferW(szKeyVersion));
 		int nRet = ConfirmMessage( hwndParent,
 			LS(STR_IMPEXP_VER), 
 			GSTR_APPNAME, szKeyVersion, nStructureVersion );
@@ -277,7 +277,7 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 	List_GetText( m_hwndList, m_nIdx, szLabel );
 	sAscertainInfo.sTypeNameTo = szLabel;
 	szLabel[0] = L'\0';
-	m_cProfile.IOProfileData( szSecTypes, L"szTypeName", MakeStringBufferW( szLabel ));
+	m_cProfile.IOProfileData(szSecTypes, L"szTypeName", StringBufferW(szLabel));
 	sAscertainInfo.sTypeNameFile = szLabel;
 
 	// 確認
@@ -361,7 +361,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 	for (i=0; i < MAX_KEYWORDSET_PER_TYPE; i++) {
 		//types.m_nKeyWordSetIdx[i] = -1;
 		auto_sprintf( szKeyName, szKeyKeywordTemp, i+1 );
-		if (m_cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( szKeyData ))) {
+		if (m_cProfile.IOProfileData(szSecTypeEx, szKeyName, StringBufferW(szKeyData))) {
 			nIdx = cKeyWordSetMgr.SearchKeyWordSet( szKeyData );
 			if (nIdx < 0) {
 				// エントリ作成
@@ -378,7 +378,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 
 				auto_sprintf( szKeyName, szKeyKeywordFileTemp, i+1 );
 				szFileName[0] = L'\0';
-				if (m_cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( szFileName ))) {
+				if (m_cProfile.IOProfileData(szSecTypeEx, szKeyName, StringBufferW(szFileName))) {
 					if( cImpExpKeyWord.Import( cImpExpKeyWord.MakeFullPath( szFileName ), TmpMsg )) {
 						files += wstring(L"\n") + szFileName;
 					} else {
@@ -393,7 +393,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 	// Plugin
 	//  アウトライン解析方法
 	CommonSetting_Plugin& plugin = common.m_sPlugin;
-	if (m_cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineId, MakeStringBufferW( szKeyData ))) {
+	if (m_cProfile.IOProfileData(szSecTypeEx, szKeyPluginOutlineId, StringBufferW(szKeyData))) {
 		nDataLen = wcslen( szKeyData );
 		pSlashPos = wcschr( szKeyData, L'/' );
 		nIdx = -1;
@@ -414,7 +414,7 @@ bool CImpExpType::Import( const wstring& sFileName, wstring& sErrMsg )
 		}
 	}
 	//  スマートインデント
-	if (m_cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentId, MakeStringBufferW( szKeyData ))) {
+	if (m_cProfile.IOProfileData(szSecTypeEx, szKeyPluginSmartIndentId, StringBufferW(szKeyData))) {
 		nDataLen = wcslen( szKeyData );
 		pSlashPos = wcschr( szKeyData, L'/' );
 		nIdx = -1;
@@ -468,7 +468,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 			nIdx = m_Types.m_nKeyWordSetIdx[i];
 			auto_sprintf( szKeyName, szKeyKeywordTemp, i+1 );
 			wcscpy( buff, cKeyWordSetMgr.GetTypeName( nIdx ));
-			cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( buff ));
+			cProfile.IOProfileData(szSecTypeEx, szKeyName, StringBufferW(buff));
 
 			// 大文字小文字区別
 			bCase = common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWordCase( nIdx );
@@ -480,7 +480,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 			if ( cImpExpKeyWord.Export( cImpExpKeyWord.GetFullPath(), sTmpMsg ) ) {
 				wcscpy( szFileName, cImpExpKeyWord.GetFileName().c_str());
 				auto_sprintf( szKeyName, szKeyKeywordFileTemp, i+1 );
-				if (cProfile.IOProfileData( szSecTypeEx, szKeyName, MakeStringBufferW( szFileName ))) {
+				if (cProfile.IOProfileData(szSecTypeEx, szKeyName, StringBufferW(szFileName))) {
 					files += wstring( L"\n" ) + cImpExpKeyWord.GetFileName();
 				}
 			}
@@ -497,25 +497,25 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 	int		nPlug;
 	wchar_t szId[ MAX_PLUGIN_ID + 1 + 2 ];
 	if ((nPIdx = CPlug::GetPluginId( static_cast<EFunctionCode>( m_Types.m_eDefaultOutline ))) >= 0) {
-		cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineName, MakeStringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
+		cProfile.IOProfileData(szSecTypeEx, szKeyPluginOutlineName, StringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
 		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, _countof(szId) );
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eDefaultOutline ))) != 0 ){
 			wchar_t szPlug[8];
 			_swprintf( szPlug, L"/%d", nPlug );
 			wcscat( szId, szPlug );
 		}
-		cProfile.IOProfileData( szSecTypeEx, szKeyPluginOutlineId,   MakeStringBufferW(szId) );
+		cProfile.IOProfileData(szSecTypeEx, szKeyPluginOutlineId, StringBufferW(szId));
 	}
 	//  スマートインデント
 	if ((nPIdx = CPlug::GetPluginId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) >= 0) {
-		cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentName, MakeStringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
+		cProfile.IOProfileData(szSecTypeEx, szKeyPluginSmartIndentName, StringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
 		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, _countof(szId) );
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) != 0 ){
 			wchar_t szPlug[8];
 			_swprintf( szPlug, L"/%d", nPlug );
 			wcscat( szId, szPlug );
 		}
-		cProfile.IOProfileData( szSecTypeEx, szKeyPluginSmartIndentId,   MakeStringBufferW(szId) );
+		cProfile.IOProfileData(szSecTypeEx, szKeyPluginSmartIndentId, StringBufferW(szId));
 	}
 
 	// Version
@@ -527,7 +527,7 @@ bool CImpExpType::Export( const wstring& sFileName, wstring& sErrMsg )
 				LOWORD( pShare->m_sVersion.m_dwProductVersionMS ),
 				HIWORD( pShare->m_sVersion.m_dwProductVersionLS ),
 				LOWORD( pShare->m_sVersion.m_dwProductVersionLS ) );
-	cProfile.IOProfileData( szSecInfo, szKeyVersion, MakeStringBufferW(wbuff) );
+	cProfile.IOProfileData(szSecInfo, szKeyVersion, StringBufferW(wbuff));
 	nStructureVersion = int(pShare->m_vStructureVersion);
 	cProfile.IOProfileData( szSecInfo, szKeyStructureVersion, nStructureVersion );
 
@@ -885,7 +885,7 @@ bool CImpExpKeybind::Import( const wstring& sFileName, wstring& sErrMsg )
 	bVer4 = false;
 	bVer3 = false;
 	bVer2 = false;
-	in.IOProfileData(szSecInfo, L"KEYBIND_VERSION", MakeStringBufferW(szHeader));
+	in.IOProfileData(szSecInfo, L"KEYBIND_VERSION", StringBufferW(szHeader));
 	if(wcscmp(szHeader,WSTR_KEYBIND_HEAD4)==0)	bVer4=true;
 	else if(wcscmp(szHeader,WSTR_KEYBIND_HEAD3)==0)	bVer3=true;
 
@@ -1070,7 +1070,7 @@ bool CImpExpCustMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 
 	//バージョン確認
 	WCHAR szHeader[256];
-	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", MakeStringBufferW(szHeader));
+	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", StringBufferW(szHeader));
 	if(wcscmp(szHeader, WSTR_CUSTMENU_HEAD_V2)!=0) {
 		sErrMsg = wstring(LS(STR_IMPEXP_CUSTMENU_FORMAT)) + sFileName;
 		return false;
@@ -1105,7 +1105,7 @@ bool CImpExpCustMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 	cProfile.SetWritingMode();
 
 	//ヘッダ
-	cProfile.IOProfileData( szSecInfo, L"MENU_VERSION", MakeStringBufferW(WSTR_CUSTMENU_HEAD_V2) );
+	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", StringBufferW(WSTR_CUSTMENU_HEAD_V2));
 	int iWork = MAX_CUSTOM_MENU;
 	cProfile.IOProfileData_WrapInt( szSecInfo, L"MAX_CUSTOM_MENU", iWork );
 	
@@ -1234,7 +1234,7 @@ bool CImpExpMainMenu::Import( const wstring& sFileName, wstring& sErrMsg )
 
 	//バージョン確認
 	WCHAR szHeader[256];
-	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", MakeStringBufferW(szHeader));
+	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", StringBufferW(szHeader));
 	if(wcscmp(szHeader, WSTR_MAINMENU_HEAD_V1)!=0) {
 		sErrMsg = wstring(LS(STR_IMPEXP_MEINMENU)) + sFileName;
 		return false;
@@ -1268,7 +1268,7 @@ bool CImpExpMainMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 	cProfile.SetWritingMode();
 
 	//ヘッダ
-	cProfile.IOProfileData( szSecInfo, L"MENU_VERSION", MakeStringBufferW(WSTR_MAINMENU_HEAD_V1) );
+	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", StringBufferW(WSTR_MAINMENU_HEAD_V1));
 	
 	//内容
 	CShareData_IO::IO_MainMenu(cProfile, *menu, true);

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -1033,7 +1033,7 @@ bool CImpExpKeybind::Export( const wstring& sFileName, wstring& sErrMsg )
 	// ヘッダ
 	StaticString<wchar_t,256> szKeydataHead = WSTR_KEYBIND_HEAD4;
 	cProfile.IOProfileData( szSecInfo, L"KEYBIND_VERSION", szKeydataHead );
-	cProfile.IOProfileData_WrapInt( szSecInfo, L"KEYBIND_COUNT", m_Common.m_sKeyBind.m_nKeyNameArrNum );
+	cProfile.IOProfileData(szSecInfo, L"KEYBIND_COUNT", m_Common.m_sKeyBind.m_nKeyNameArrNum );
 
 	//内容
 	CShareData_IO::IO_KeyBind(cProfile, m_Common.m_sKeyBind, true);
@@ -1107,7 +1107,7 @@ bool CImpExpCustMenu::Export( const wstring& sFileName, wstring& sErrMsg )
 	//ヘッダ
 	cProfile.IOProfileData(szSecInfo, L"MENU_VERSION", StringBufferW(WSTR_CUSTMENU_HEAD_V2));
 	int iWork = MAX_CUSTOM_MENU;
-	cProfile.IOProfileData_WrapInt( szSecInfo, L"MAX_CUSTOM_MENU", iWork );
+	cProfile.IOProfileData(szSecInfo, L"MAX_CUSTOM_MENU", iWork );
 	
 	//内容
 	CShareData_IO::IO_CustMenu(cProfile, *menu, true);

--- a/tests/unittests/test-cprofile.cpp
+++ b/tests/unittests/test-cprofile.cpp
@@ -148,6 +148,121 @@ TEST(CProfile, GetProfileData_NewEntry)
 }
 
 /*!
+ * @brief StringBufferWのテスト
+ */
+TEST(StringBufferW, ctor)
+{
+	WCHAR szBuf[12]{ 0 };
+	StringBufferW buf1(szBuf, _countof(szBuf));
+	StringBufferW buf2(szBuf);
+
+	ASSERT_THROW({ StringBufferW buf3(nullptr, 1); }, std::invalid_argument);
+
+	ASSERT_THROW({ StringBufferW buf4(szBuf, 0); }, std::invalid_argument);
+}
+
+/*!
+ * @brief TryParseのテスト
+ */
+TEST(profile_data, TryParse_int)
+{
+	int value = 0;
+	ASSERT_TRUE(profile_data::TryParse(L"109", value));
+	ASSERT_EQ(109, value);
+
+	ASSERT_FALSE(profile_data::TryParse(L"", value));
+	ASSERT_EQ(109, value);
+
+	ASSERT_FALSE(profile_data::TryParse(L"not a number", value));
+	ASSERT_EQ(109, value);
+
+	ASSERT_TRUE(profile_data::TryParse(L"888", value));
+	ASSERT_EQ(888, value);
+}
+
+/*!
+ * @brief TryParseのテスト
+ */
+TEST(profile_data, TryParse_enum)
+{
+	enum ETest { NONE, RED, GREEN, BLUE, };
+	ETest value = NONE;
+	ASSERT_TRUE(profile_data::TryParse(L"1", value));
+	ASSERT_EQ(RED, value);
+
+	ASSERT_FALSE(profile_data::TryParse(L"", value));
+	ASSERT_EQ(RED, value);
+}
+
+/*!
+ * @brief TryParseのテスト
+ */
+TEST(profile_data, TryParse_bool)
+{
+	bool value = false;
+	ASSERT_TRUE(profile_data::TryParse(L"1", value));
+	ASSERT_TRUE(value);
+
+	ASSERT_FALSE(profile_data::TryParse(L"", value));
+	ASSERT_TRUE(value);
+
+	ASSERT_FALSE(profile_data::TryParse(L"false", value));
+	ASSERT_TRUE(value);
+
+	ASSERT_TRUE(profile_data::TryParse(L"0", value));
+	ASSERT_FALSE(value);
+}
+
+/*!
+ * @brief TryParseのテスト
+ */
+TEST(profile_data, TryParse_WCHAR)
+{
+	WCHAR value = L'\0';
+	ASSERT_TRUE(profile_data::TryParse(L"|", value));
+	ASSERT_EQ(L'|', value);
+
+	ASSERT_FALSE(profile_data::TryParse(L"\U0001F51E", value));
+	ASSERT_EQ(L'|', value);
+
+	ASSERT_TRUE(profile_data::TryParse(L"", value));
+	ASSERT_EQ(L'\0', value);
+}
+
+/*!
+ * @brief TryParseのテスト
+ */
+TEST(profile_data, TryParse_KEYCODE)
+{
+	KEYCODE value = '\0';
+	ASSERT_TRUE(profile_data::TryParse(L"W", value));
+	ASSERT_EQ('W', value);
+
+	ASSERT_FALSE(profile_data::TryParse(L"漢", value));
+	ASSERT_EQ('W', value);
+
+	ASSERT_TRUE(profile_data::TryParse(L"", value));
+	ASSERT_EQ('\0', value);
+}
+
+/*!
+ * @brief TryParseのテスト
+ */
+TEST(profile_data, TryParse_StringBufferW)
+{
+	WCHAR buffer[5]{ 0 };
+	StringBufferW value(buffer);
+	ASSERT_TRUE(profile_data::TryParse(L"test", value));
+	ASSERT_STREQ(L"test", value.c_str());
+
+	ASSERT_FALSE(profile_data::TryParse(L"overflow", value));
+	ASSERT_STREQ(L"test", value.c_str());
+
+	ASSERT_TRUE(profile_data::TryParse(L"", value));
+	ASSERT_STREQ(L"", value.c_str());
+}
+
+/*!
  * @brief IOProfileDataのテスト
  */
 TEST(CDataProfile, IOProfileData)
@@ -174,6 +289,6 @@ TEST(CDataProfile, IOProfileData)
 	ASSERT_TRUE(cProfile.IOProfileData(L"Test", L"nTest", nValue));
 	ASSERT_EQ(109, nValue);
 
-	ASSERT_TRUE(cProfile.IOProfileData(L"Test", L"szTest", nValue));
-	ASSERT_EQ(0, nValue);
+	ASSERT_FALSE(cProfile.IOProfileData(L"Test", L"szTest", nValue));
+	ASSERT_EQ(109, nValue);
 }


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
タイトル通りです。

## <!-- 必須 --> カテゴリ
- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
背景は過去PR #1152 とオーバーラップします。

サクラエディタの設定読込機構にエラー検出機構を付けたいと考えています。

先ほどマージした #1546 の続きでもあります。


## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
設定値の読込失敗を検出できるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
既存コードに影響を与える可能性があります。


## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
従来は、int型などの特定型にエントリが変換できないことを考慮していませんでした。
このPRは、int型などの特定型にエントリが変換できなかったことを検出します。

|基準|エントリなし時戻り値|変換失敗時戻り値|変換失敗時出力値|
|--|--|--|--|
|従来仕様|false|true|0に初期化|
|新仕様|false|false|変更しない|

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
設定値の読み書きに影響する変更です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
変更の基本部分については、追加した単体テストでカバーできると思います。

設定のインポート・エクスポートについては、実行させる方法が分からないのでパスしました。
この部分の修正はWrapIntとMakeStringBufferWの廃止のみなのでテストは不要と思います。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1546
#1152 
#1150 
#1145

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
