### PR TITLE
DetectJisEscseq 関数の第2引数の型を int から size_t に変更

### DIFF
--- a/sakura_core/charset/codechecker.cpp
+++ b/sakura_core/charset/codechecker.cpp
@@ -368,7 +368,7 @@ int _CheckJisAnyPart(
 	pr_end = pS + nLen;
 
 	for( ; pr < pr_end; pr++ ){
-		nesclen = DetectJisEscseq( pr, size_t(pr_end-pr), &emyesc );  // 次のエスケープシーケンスを検索
+		nesclen = DetectJisEscseq( pr, pr_end-pr, &emyesc );  // 次のエスケープシーケンスを検索
 		if( emyesc != MYJISESC_NONE || nesclen > 0 ){
 			// 長さ nesclen の JIS エスケープシーケンス（種類 emyesc）が見つかった
 			break;

--- a/sakura_core/charset/codechecker.cpp
+++ b/sakura_core/charset/codechecker.cpp
@@ -260,7 +260,7 @@ int CheckEucjpChar( const char* pS, const int nLen, ECharSet *peCharset )
 		戻り値がゼロより大きい場合に限り，*pnEscType が更新される．\n
 		pnEscType は NULL でも良い．\n
 */
-int DetectJisEscseq( const char* pS, const int nLen, EMyJisEscseq* peEscType )
+int DetectJisEscseq( const char* pS, const size_t nLen, EMyJisEscseq* peEscType )
 {
 	const char *pr, *pr_end;
 	int expected_esc_len;
@@ -368,7 +368,7 @@ int _CheckJisAnyPart(
 	pr_end = pS + nLen;
 
 	for( ; pr < pr_end; pr++ ){
-		nesclen = DetectJisEscseq( pr, pr_end-pr, &emyesc );  // 次のエスケープシーケンスを検索
+		nesclen = DetectJisEscseq( pr, size_t(pr_end-pr), &emyesc );  // 次のエスケープシーケンスを検索
 		if( emyesc != MYJISESC_NONE || nesclen > 0 ){
 			// 長さ nesclen の JIS エスケープシーケンス（種類 emyesc）が見つかった
 			break;

--- a/sakura_core/charset/codechecker.h
+++ b/sakura_core/charset/codechecker.h
@@ -410,7 +410,7 @@ inline int GuessEucjpCharsz( const char uc_ ){
 /* --- ローカル文字コードチェック */
 int CheckSjisChar( const char*, const int, ECharSet* );
 int CheckEucjpChar( const char*, const int, ECharSet* );
-int DetectJisEscseq( const char*, const int, EMyJisEscseq* ); // JIS エスケープシーケンス検出器
+int DetectJisEscseq( const char*, const size_t, EMyJisEscseq* ); // JIS エスケープシーケンス検出器
 int _CheckJisAnyPart( const char*, const int, const char **ppNextChar, EMyJisEscseq *peNextEsc, int *pnErrorCount, const int nType );
 enum EJisChecker{
 	JISCHECK_ASCII7,


### PR DESCRIPTION
第２引数の型の種類を変更したのと、関数呼び出し時に引数の型が異なる為に出る警告を無くすためにキャストを追加しました。

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

x64 ビルドで警告が大量に出るのでそれを減らす事が目的です。

このPRでは１つの警告しか減りませんが、千里の道も一歩から、という事で少しずつでも減らしていければと思います。

今回変更した関数の呼び出し元の `_CheckJisAnyPart` 関数の第2引数が「チェック対象となるバッファの長さ」ですがこれが `int` です。追っていくと `CESI::SetInformation` 以下の呼び出しがバッファ長の引数の型が `int` なので `size_t` に変えるべきです。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

x64 のビルドで警告が大量に出る事が #430 で話されています。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

ビルド時の警告が１つ減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

あまり色々な型を区別して使いたくない人にとってはコードの可読性は落ちると思います。

`ptrdiff_t` から `size_t` への cast は functional notation で行っていますが、人によって好き嫌いがありそうです。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->


`DetectJisEscseq` 関数は `_CheckJisAnyPart` 関数から呼び出しています。
第2引数に渡す値は `pr_end - pr` というポインタの差分の演算で作られます。
ポインタの差分値の型は `ptrdiff_t` という typedef された型で扱うべきですが、定義は以下のようになっています。

```cpp
// Definitions of common types
#ifdef _WIN64
    typedef unsigned __int64 size_t;
    typedef __int64          ptrdiff_t;
    typedef __int64          intptr_t;
#else
    typedef unsigned int     size_t;
    typedef int              ptrdiff_t;
    typedef int              intptr_t;
#endif
```

`C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29333\include\vcruntime.h` からコピペしました。

for ループの前で `pr` と `pr_end` の値は下記のようにして設定されています。

```cpp
	pr = pS;
	pr_end = pS + nLen;
```

そして `nLen` 変数の型は `int` なので `pr_end - pr` の演算結果の値は必ず `int` に収まるので暗黙的に `int` にキャストしても実質的に問題は無いはずなんですが、コンパイラはそういう背景はお構いなしに警告を出します。

前置きが長くなりましたがこのPRでは `pr_end - pr` の結果を `size_t` にキャストしています。`DetectJisEscseq` 関数の第2引数の型を変更したのに合わせていますが、どうして `int` から `size_t` に変えたかというと一般的にバッファ長等の負の値を取りえない長さの値の型は `size_t` にするからです。処理内容的には文字列の先頭にあるかもしれないエスケープ文字列を検出するだけなので `int` 型で十分サイズは収まって問題はありませんが、警告を取るためだけに変更を行いました。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

`DetectJisEscseq` 関数とそれを呼び出している `_CheckJisAnyPart` 関数です。

呼び出し元をたどっていくと日本語コードセット判定を行う `CESI::CheckKanjiCode` になり、文字コード種別の判定で使われます。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

- サクラエディタを起動する
- `README.md` ファイルを開く
- `README.md` ファイルを文字コードセット JIS でデスクトップに保存（ファイル > 名前を付けて保存）
- サクラエディタを終了する
- サクラエディタを起動する
- JISで保存した `README.md` ファイルを開いて正常に読み込めることを確認する

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#430 #1541
