### PR TITLE
CheckEucjpChar 関数の第2引数の型を int から size_t に変更

### DIFF
--- a/sakura_core/charset/codechecker.cpp
+++ b/sakura_core/charset/codechecker.cpp
@@ -199,7 +199,7 @@ int CheckSjisChar( const char* pS, const size_t nLen, ECharSet *peCharset )
 
 	@date 2006.09.23 EUCJP 半角カタカナ判別が間違っていたのを修正．genta
 */
-int CheckEucjpChar( const char* pS, const int nLen, ECharSet *peCharset )
+int CheckEucjpChar( const char* pS, const size_t nLen, ECharSet *peCharset )
 {
 	unsigned char uc;
 

--- a/sakura_core/charset/codechecker.h
+++ b/sakura_core/charset/codechecker.h
@@ -409,7 +409,7 @@ inline int GuessEucjpCharsz( const char uc_ ){
 */
 /* --- ローカル文字コードチェック */
 int CheckSjisChar( const char*, const size_t, ECharSet* );
-int CheckEucjpChar( const char*, const int, ECharSet* );
+int CheckEucjpChar( const char*, const size_t, ECharSet* );
 int DetectJisEscseq( const char*, const size_t, EMyJisEscseq* ); // JIS エスケープシーケンス検出器
 int _CheckJisAnyPart( const char*, const int, const char **ppNextChar, EMyJisEscseq *peNextEsc, int *pnErrorCount, const int nType );
 enum EJisChecker{


### PR DESCRIPTION
#1556 とほぼ同じような変更です。変更を小刻みに行っているのはその方が単純化するのでPRの作成とレビューが行いやすいと考えてです。ただしコメントの記載内容がコピペなのでかなり重複します。

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

x64 ビルドで警告が出る数を減らす為の変更です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

x64 のビルドで警告が大量に出る事が #430 で話されています。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

`sakura` プロジェクトの x64 Debug ビルド時の警告の数が 607 から 605 になり、2個減ります。
x64 Release ビルド時の警告の数が 572 から 570 になり、2個減ります。
Win32 Debug と Win32 Release ビルド時の警告の数は 0 のままです。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

意識的に色々な型を使ってコードを書きたくない人にとってはコードの可読性は落ちると思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

関数の呼び出し元では `pr_end-pr` という記述でバッファ長を求めています。この演算の結果の型はいわゆる `ptrdiff_t` ですが、Win32 ビルドでは `int` なので元の実装でも警告は出ませんが、x64 ビルドでは `int64_t` 相当なので引数の型が `int` のままだとビット幅を狭めるデータ変換 (narrowing conversion) になり警告が出ます。

なお呼び出し元における `pr_end` の値の作り方から考えて演算結果が負の値になる事はおそらく無いと考えています。

これに関しては本当に負の値が生じない組み方になっているかをコンパイル時にきちんと検証はしていません（C++言語仕様的にどこまで出来るかは不明、可能だとしても形式的検証を取れる記述が容易とも思えない）。

`boost::numeric_cast` のように実行時に確認するというのも選択肢に上がると思いますが、実行時エラーが絶対に許容されない用途向けのプログラムではないと思うので省きます。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

`CheckEucjpChar` 関数とそれを呼び出している `CESI::GetEncodingInfo_eucjp` と `CEuc::EucjpToUni` です。

`CESI::GetEncodingInfo_sjis` の呼び出し元をたどっていくと日本語コードセット判定を行う `CESI::CheckKanjiCode` になり、文字コード種別の判定で使われます。

`CEuc::EucjpToUni` の呼び出し元をたどっていく文字コード変換処理になります。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

- サクラエディタを起動する
- `README.md` ファイルを開く
- `README.md` ファイルを文字コードセット EUC-JP でデスクトップに保存（ファイル > 名前を付けて保存）
- サクラエディタを終了する
- サクラエディタを起動する
- EUC-JP で保存した `README.md` ファイルを開いて正常に読み込めることを確認する

### テスト2

- サクラエディタを起動する
- EUC-JP で保存した `README.md` ファイルを開いて正常に読み込めることを確認する
- メニューの 変換 > 文字コード変換 > EUC→SJISコード変換 を選んで変換する
- メニューの 変換 > 文字コード変換 > SJIS→EUCコード変換 を選んで再度変換して元の見た目になる事を確認し、別のファイルに保存する
- WinMergeでファイルの内容とコードページが一致する事を確認

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#430 #1541 #1555 #1556
