### PR TITLE
CRuler::DrawRulerBg において TextOutW を呼び出す際に第5引数の型 (int) にキャストする記述を追加して警告回避

### DIFF
--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -204,7 +204,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 			wchar_t szColumn[32];
 			apt[idx * 2 + 1] = POINT{nX, 0};
 			_itow( ((Int)keta) / 10, szColumn, 10 );
-			::TextOut( gr, nX + 2 + 0, -1 + 0, szColumn, wcslen( szColumn ) );
+			::TextOut( gr, nX + 2 + 0, -1 + 0, szColumn, (int)wcslen( szColumn ) );
 		}
 		//5目盛おきの区切り(中)
 		else if( 0 == keta % 5 ){


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

x64 ビルドで警告が出る数を減らす為の変更です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

x64 のビルドで警告が大量に出る事が #430 で話されています。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

`sakura` プロジェクトの x64 Debug ビルド時の警告の数が 601 から 600 になり、1個減ります。
x64 Release ビルド時の警告の数が 566 から 565 になり、1個減ります。
Win32 Debug と Win32 Release ビルド時の警告の数は 0 のままです。
（変更前のコミットは 32cdaf0e855e576b352bac23ff4c2f533b06ff68）

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

キャストの記述の分だけコードの情報量が増える。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

呼び出すWindowsAPIの関数 `TextOutW` の第5引数の型は `int` で第4引数に渡した文字列バッファの長さを指定するとの事です。

https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-textoutw

長さの定義については下記に記載されていますが、-1 を指定する事で呼び出し先の関数でNULL終端文字列の長さを調べてくれるお手軽仕様です。なので長さのパラメータなのに符号付の型になっているようです。

https://docs.microsoft.com/en-us/windows/win32/gdi/specifying-length-of-text-output-string

という事は `wcslen( szColumn )` の記述にキャストを入れるのではなくて -1 に置き換えてしまうのもありかもしれないですね。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

今までは暗黙的に `int` にキャストしていたものを明示的にキャストする記述にしましたが、動作への影響はないと思います。

https://docs.microsoft.com/en-us/cpp/cpp/type-conversions-and-type-safety-modern-cpp?view=msvc-160#narrowing-conversions-coercion

によると

> The compiler performs narrowing conversions implicitly, but it warns you about potential data loss. Take these warnings very seriously. If you are certain that no data loss will occur because the values in the larger variable will always fit in the smaller variable, then add an explicit cast so that the compiler will no longer issue a warning.

という事で、今回はキャスト前の値がキャスト先の型の範囲内に収まる事が明確なので明示的なキャストで何の問題もないと考えます。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1
- タイプ別設定のスクリーンのレイアウトが折り返し桁数 10240、折り返し方法は「折り返さない」でエディタ領域を右端まで横スクロールしてルーラーの10桁おきの数字が正しく描画される事を確認

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#430 #1541

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
