### PR TITLE
CNativeW::GetHabaOfChar の共有メモリ依存を明確化する

### DIFF
--- a/sakura_core/dlg/CDlgProfileMgr.h
+++ b/sakura_core/dlg/CDlgProfileMgr.h
@@ -34,6 +34,7 @@
 
 #include "dlg/CDialog.h"
 #include "_main/CCommandLine.h"
+#include <filesystem>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -38,6 +38,7 @@
 #include "COpe.h"
 #include "util/container.h"
 #include "util/design_template.h"
+#include "env/DLLSHAREDATA.h"
 
 class CBregexp;// 2002/2/10 aroka
 class CLayout;// 2002/2/10 aroka
@@ -273,7 +274,8 @@ public:
 		if( m_nSpacing ){
 			nSpace = CLayoutXInt(CNativeW::GetKetaOfChar(pData, nDataLen, i)) * m_nSpacing;
 		}
-		return CNativeW::GetColmOfChar( pData, nDataLen, i ) + nSpace;
+		return CNativeW::GetColmOfChar( pData, nDataLen, i,
+			GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) + nSpace;
 	}
 	CLayoutXInt GetLayoutXOfChar( const CStringRef& str, int i ) const {
 		return GetLayoutXOfChar(str.GetPtr(), str.GetLength(), i);

--- a/sakura_core/env/CShareData.h
+++ b/sakura_core/env/CShareData.h
@@ -33,15 +33,17 @@
 #define SAKURA_CSHAREDATA_B25C0FA2_B810_4327_8EC6_0AF46D49593A_H_
 #pragma once
 
+#include <string>
 #include "CSelectLang.h"		// 2011.04.10 nasukoji
-
-class CShareData;
+#include "charset/charset.h"
+#include "util/design_template.h"
 
 // 2010.04.19 Moca DLLSHAREDATA関連はDLLSHAREDATA.h等最低限必要な場所へ移動
 // CShareData.hは、自分のInterfaceしか提供しません。別にDLLSHAREDATA.hをincludeすること。
-struct DLLSHAREDATA;
-struct STypeConfig;
 class CMutex;
+struct DLLSHAREDATA;
+struct SFileTree;
+struct STypeConfig;
 
 /*!	@brief 共有データの管理
 

--- a/sakura_core/mem/CMemoryIterator.h
+++ b/sakura_core/mem/CMemoryIterator.h
@@ -20,15 +20,16 @@
 //	sakura
 #include "_main/global.h"
 #include "charset/charcode.h"
+#include "doc/layout/CLayout.h"
 #include "doc/layout/CTsvModeInfo.h"
+#include "doc/logic/CDocLine.h"
+#include "env/DLLSHAREDATA.h"
+#include "mem/CNativeW.h"
 
 /*-----------------------------------------------------------------------
 クラスの宣言
 -----------------------------------------------------------------------*/
 // 2007.10.23 kobake テンプレートである必要も無いので、非テンプレートに変更。
-
-#include "doc/layout/CLayout.h"
-#include "doc/logic/CDocLine.h"
 
 //! ブロックコメントデリミタを管理する
 class CMemoryIterator
@@ -104,7 +105,8 @@ public:
 		} else if (m_pLine[m_nIndex] == L',' && m_tsvInfo.m_nTsvMode == TSV_MODE_CSV){
 			m_nColumn_Delta = m_tsvInfo.GetActualTabLength(m_nColumn, m_tsvInfo.m_nMaxCharLayoutX);
 		}else{
-			m_nColumn_Delta = CNativeW::GetColmOfChar( m_pLine, m_nLineLen, m_nIndex );
+			m_nColumn_Delta = CNativeW::GetColmOfChar( m_pLine, m_nLineLen, m_nIndex,
+				GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol );
 			if( m_nSpacing ){
 				m_nColumn_Delta += CLayoutXInt(CNativeW::GetKetaOfChar(m_pLine, m_nLineLen, m_nIndex) * m_nSpacing);
 			}

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -405,7 +405,7 @@ CKetaXInt CNativeW::GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx,
 
 //! 指定した位置の文字の文字幅を返す
 CHabaXInt CNativeW::GetHabaOfChar( const wchar_t* pData, int nDataLen, int nIdx,
-	CCharWidthCache& cache, bool bEnableExtEol )
+	bool bEnableExtEol, CCharWidthCache& cache )
 {
 	//文字列範囲外なら 0
 	if( nIdx >= nDataLen ){

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -31,7 +31,6 @@
 #include "basis/SakuraBasis.h"
 #include "charset/charcode.h"
 #include "debug/Debug2.h" //assert
-#include "env/DLLSHAREDATA.h"
 
 //! 文字列への参照を取得するインターフェース
 class IStringRef{
@@ -167,8 +166,7 @@ public:
 	// -- -- staticインターフェース -- -- //
 	static CLogicInt GetSizeOfChar( const wchar_t* pData, int nDataLen, int nIdx ); //!< 指定した位置の文字がwchar_t何個分かを返す
 	static CHabaXInt GetHabaOfChar( const wchar_t* pData, int nDataLen, int nIdx,
-		CCharWidthCache& cache = GetCharWidthCache(),
-		bool bEnableExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol );
+		bool bEnableExtEol, CCharWidthCache& cache = GetCharWidthCache() );
 	//! 指定した位置の文字が半角何個分かを返す
 	static CKetaXInt GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx,
 		const CCharWidthCache& cache = GetCharWidthCache() );
@@ -179,10 +177,11 @@ public:
 	{
 		return GetKetaOfChar(cStr.GetPtr(), cStr.GetLength(), nIdx);
 	}
-	static CLayoutXInt GetColmOfChar( const wchar_t* pData, int nDataLen, int nIdx )
-		{ return GetHabaOfChar(pData,nDataLen,nIdx);}
-	static CLayoutXInt GetColmOfChar( const CStringRef& cStr, int nIdx )
-		{ return GetHabaOfChar(cStr.GetPtr(), cStr.GetLength(), nIdx);}
+	static CLayoutXInt GetColmOfChar( const wchar_t* pData,
+		int nDataLen, int nIdx, bool bEnableExtEol )
+		{ return GetHabaOfChar(pData,nDataLen,nIdx, bEnableExtEol); }
+	static CLayoutXInt GetColmOfChar( const CStringRef& cStr, int nIdx, bool bEnableExtEol )
+		{ return GetHabaOfChar(cStr.GetPtr(), cStr.GetLength(), nIdx, bEnableExtEol); }
 };
 
 // 派生クラスでメンバー追加禁止

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -33,6 +33,7 @@
 
 #include "_main/CCommandLine.h"
 #include "env/CSakuraEnvironment.h"
+#include "util/string_ex.h"
 
 #include <cstdlib>
 #include <fstream>

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -804,11 +804,11 @@ TEST(CNativeW, GetKetaOfChar)
 TEST(CNativeW, GetHabaOfChar)
 {
 	// 範囲外なら0を返す。
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"", 0, 1, GetCharWidthCache(), false), 0);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"", 0, 1, false, GetCharWidthCache()), 0);
 
 	// 改行コードなら1を返す。
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\r\n", 2, 0, GetCharWidthCache(), false), 1);
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\r\n", 2, 1, GetCharWidthCache(), false), 1);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\r\n", 2, 0, false, GetCharWidthCache()), 1);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\r\n", 2, 1, false, GetCharWidthCache()), 1);
 
 	// CalcPxWidthByFont で計算した結果を返す。
 	class FakeCache1 : public CCharWidthCache {
@@ -819,8 +819,8 @@ TEST(CNativeW, GetHabaOfChar)
 			else return 0;
 		}
 	} cache1;
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"ab", 2, 0, cache1, false), 10000);
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"ab", 2, 1, cache1, false), 20000);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"ab", 2, 0, false, cache1), 10000);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"ab", 2, 1, false, cache1), 20000);
 
 	// サロゲートペアの幅は CalcPxWidthByFont2 で計算する。
 	// 指定された位置が下位サロゲートなら0を返す。
@@ -830,8 +830,8 @@ TEST(CNativeW, GetHabaOfChar)
 			return 20000;
 		}
 	} cache2;
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\xd83c\xdf38", 2, 0, cache2, false), 20000);
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\xd83c\xdf38", 2, 1, cache2, false), 0);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\xd83c\xdf38", 2, 0, false, cache2), 20000);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\xd83c\xdf38", 2, 1, false, cache2), 0);
 
 	// サロゲートペアが片方しかないときは CalcPxWidthByFont で計算している。
 	class FakeCache3 : public CCharWidthCache {
@@ -840,9 +840,9 @@ TEST(CNativeW, GetHabaOfChar)
 			return 10000;
 		}
 	} cache3;
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\xd83cあ", 2, 0, cache3, false), 10000);
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\xdf38あ", 2, 0, cache3, false), 10000);
-	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"あ\xdf38", 2, 1, cache3, false), 10000);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\xd83cあ", 2, 0, false, cache3), 10000);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"\xdf38あ", 2, 0, false, cache3), 10000);
+	EXPECT_EQ((Int)CNativeW::GetHabaOfChar(L"あ\xdf38", 2, 1, false, cache3), 10000);
 }
 
 /*!


### PR DESCRIPTION
# PR の目的

CNativeW::GetHabaOfChar が共有メモリに暗黙的に依存している状態を解消するものです。

## カテゴリ

- リファクタリング

## PR の背景

> 個人的には cache と bEnableExtEol の定義順を逆にして、
> bEnableExtEol のデフォルト指定を外したいっす。
>
> bEnableExtEol のデフォルト指定を外すメリットは、#include "DLLSHAREDATA.h" する必要がなくなる、です。
> また、デフォルト指定を外すことにより、共有メモリ（＝プロセス間をまたがって有効な超グローバル変数）に依存するコードの特定が容易になるっす。共有メモリに依存するコードは現実的にテスト不能なコードなので、テスト可能にできるようにして行ってる認識です。
> 
> もちろん、増やした引数のデフォルト指定をやめるってことは、呼出元を変更する必要が出てくるってことなので無理に対応しなくてよいと思っています。

_Originally posted by @berryzplus in https://github.com/sakura-editor/sakura/pull/1542#discussion_r577559466_

## 仕様説明

共有メモリへの参照を呼び出し側に移動します。

差分中にヘッダーファイルの依存関係に起因するコンパイルエラーの修正を含みます。
## PR の影響範囲

CNativeW::GetHabaOfChar に依存する CLayoutMgr::GetLayoutXOfChar に変更を加えます。共有メモリの参照位置を除く仕様に変更はありません。

## 関連 issue, PR

#1542
