### PR TITLE
SonarScanで検出されたBugsレベル警告「例外は参照でキャッチすべき」に対応する

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -1501,13 +1501,13 @@ int CGrepAgent::DoGrepFile(
 	// ファイルを明示的に閉じるが、ここで閉じないときはデストラクタで閉じている
 	cfl.FileClose();
 	} // try
-	catch( CError_FileOpen ){
+	catch( const CError_FileOpen& ){
 		CNativeW str(LS(STR_GREP_ERR_FILEOPEN));
 		str.Replace(L"%s", pszFullPath);
 		cmemMessage.AppendNativeData( str );
 		return 0;
 	}
-	catch( CError_FileRead ){
+	catch( const CError_FileRead& ){
 		CNativeW str(LS(STR_GREP_ERR_FILEREAD));
 		str.Replace(L"%s", pszFullPath);
 		cmemMessage.AppendNativeData( str );
@@ -1555,7 +1555,7 @@ public:
 			name += L".skrnew";
 			try{
 				out = new CBinaryOutputStream(name.c_str(), true);
-			}catch( CError_FileOpen ){
+			}catch( const CError_FileOpen& ){
 				throw CError_WriteFileOpen();
 			}
 			if( bBom ){
@@ -1940,18 +1940,18 @@ int CGrepAgent::DoGrepReplaceFile(
 	cfl.FileClose();
 	output.Close();
 	} // try
-	catch( CError_FileOpen ){
+	catch( const CError_FileOpen& ){
 		CNativeW str(LS(STR_GREP_ERR_FILEOPEN));
 		str.Replace(L"%s", pszFullPath);
 		cmemMessage.AppendNativeData( str );
 		return 0;
 	}
-	catch( CError_FileRead ){
+	catch( const CError_FileRead& ){
 		CNativeW str(LS(STR_GREP_ERR_FILEREAD));
 		str.Replace(L"%s", pszFullPath);
 		cmemMessage.AppendNativeData( str );
 	}
-	catch( CError_WriteFileOpen ){
+	catch( const CError_WriteFileOpen& ){
 		std::wstring file = pszFullPath;
 		file += L".skrnew";
 		CNativeW str(LS(STR_GREP_ERR_FILEWRITE));

--- a/sakura_core/CReadManager.cpp
+++ b/sakura_core/CReadManager.cpp
@@ -131,7 +131,7 @@ EConvertResult CReadManager::ReadFile_To_CDocLineMgr(
 		// ファイルをクローズする
 		cfl.FileClose();
 	}
-	catch(CAppExitException){
+	catch(const CAppExitException&){
 		//WM_QUITが発生した
 		return RESULT_FAILURE;
 	}
@@ -169,7 +169,7 @@ EConvertResult CReadManager::ReadFile_To_CDocLineMgr(
 			 );
 		}
 	}
-	catch( CError_FileRead ){
+	catch( const CError_FileRead& ){
 		eRet = RESULT_FAILURE;
 		ErrorMessage(
 			CEditWnd::getInstance()->GetHwnd(),

--- a/sakura_core/CSaveAgent.cpp
+++ b/sakura_core/CSaveAgent.cpp
@@ -80,7 +80,7 @@ ECallbackResult CSaveAgent::OnCheckSave(SSaveInfo* pSaveInfo)
 				::DeleteFile(pSaveInfo->cFilePath);
 			}
 		}
-		catch(CError_FileOpen){
+		catch(const CError_FileOpen&){
 			// ※ たとえ上書き保存の場合でもここでの失敗では書込み禁止へは遷移しない
 			if( bLock ) pcDoc->m_cDocFileOperation.DoFileLock(false);
 			ErrorMessage(

--- a/sakura_core/CSelectLang.cpp
+++ b/sakura_core/CSelectLang.cpp
@@ -335,7 +335,7 @@ int CLoadString::CLoadStrBuffer::LoadString( UINT uid )
 			try{
 				pTemp = new WCHAR[nTemp];
 			}
-			catch(std::bad_alloc){
+			catch(const std::bad_alloc&){
 				// メモリ割り当て例外（例外の発生する環境の場合でも旧来の処理にする）
 				pTemp = NULL;
 			}

--- a/sakura_core/CWriteManager.cpp
+++ b/sakura_core/CWriteManager.cpp
@@ -156,7 +156,7 @@ EConvertResult CWriteManager::WriteFile_From_CDocLineMgr(
 		//ファイルクローズ
 		out.Close();
 	}
-	catch(CError_FileOpen){ //########### 現時点では、この例外が発生した場合は正常に動作できない
+	catch(const CError_FileOpen&){ //########### 現時点では、この例外が発生した場合は正常に動作できない
 		ErrorMessage(
 			CEditWnd::getInstance()->GetHwnd(),
 			LS(STR_SAVEAGENT_OTHER_APP),
@@ -164,10 +164,10 @@ EConvertResult CWriteManager::WriteFile_From_CDocLineMgr(
 		);
 		nRetVal = RESULT_FAILURE;
 	}
-	catch(CError_FileWrite){
+	catch(const CError_FileWrite&){
 		nRetVal = RESULT_FAILURE;
 	}
-	catch(CAppExitException){
+	catch(const CAppExitException&){
 		//中断検出
 		return RESULT_FAILURE;
 	}

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -743,7 +743,7 @@ BOOL CViewCommander::Command_PUTFILE(
 			if( 0 < cDst.GetRawLength() )
 				out.Write(cDst.GetRawPtr(),cDst.GetRawLength());
 		}
-		catch(CError_FileOpen)
+		catch(const CError_FileOpen&)
 		{
 			WarningMessage(
 				NULL,
@@ -752,7 +752,7 @@ BOOL CViewCommander::Command_PUTFILE(
 			);
 			bResult = FALSE;
 		}
-		catch(CError_FileWrite)
+		catch(const CError_FileWrite&)
 		{
 			WarningMessage(
 				NULL,
@@ -902,11 +902,11 @@ BOOL CViewCommander::Command_INSFILE( LPCWSTR filename, ECodeType nCharCode, int
 		// ファイルを明示的に閉じるが、ここで閉じないときはデストラクタで閉じている
 		cfl.FileClose();
 	} // try
-	catch( CError_FileOpen ){
+	catch( const CError_FileOpen& ){
 		WarningMessage( NULL, LS(STR_GREP_ERR_FILEOPEN), filename );
 		bResult = FALSE;
 	}
-	catch( CError_FileRead ){
+	catch( const CError_FileRead& ){
 		WarningMessage( NULL, LS(STR_ERR_DLGEDITVWCMDNW12) );
 		bResult = FALSE;
 	} // 例外処理終わり

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -119,7 +119,7 @@ bool CDocFileOperation::DoLoadFlow(SLoadInfo* pLoadInfo)
 		eLoadResult = m_pcDocRef->NotifyLoad(*pLoadInfo);	//本処理
 		m_pcDocRef->NotifyAfterLoad(*pLoadInfo);			//後処理
 	}
-	catch(CFlowInterruption){
+	catch(const CFlowInterruption&){
 		eLoadResult = LOADED_INTERRUPT;
 	}
 	catch(...){
@@ -355,7 +355,7 @@ bool CDocFileOperation::DoSaveFlow(SSaveInfo* pSaveInfo)
 		//結果
 		eSaveResult = SAVED_OK; //###仮
 	}
-	catch(CFlowInterruption){
+	catch(const CFlowInterruption&){
 		eSaveResult = SAVED_INTERRUPT;
 	}
 	catch(...){


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
SonarScanで検出されたBugsレベル警告に対策して、警告数を減らすことが目的です。

## <!-- 必須 --> カテゴリ
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
SonarScanでBugsレベルの警告が310個検出されています。

Catch the exception by reference.
https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AXb3A6qHl9hBcjvOZ0_P&open=AXb3A6qHl9hBcjvOZ0_P

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
SonarScanの警告がちょっと減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
例外発生時のキャッチ部分の修正なので単体テストを書きづらく、テストを書いていません。
よって、直近30日のカバレッジが下がります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
もともと存在していたtry-catchのcatch節を書き替える変更です。
変更はcatch節に含まれる、変数宣言の無いものを正規表現で一括置換して作成しました。

例外を参照で受けることにより、例外オブジェクトがコピーされる事態を防ぐことができるそうです。

指摘されているのは「参照で受けよ」のみですが、PRではconstも付けています。
constを付けることにより、キャッチ節内で例外オブジェクトの変更を考慮しなくてよくなります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
例外をキャッチする処理に影響する変更です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
処理内容を変えていないので、とくに実施していません。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1504

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
