### PR TITLE
StaticString::Length()の戻り値をintにキャストする

### DIFF
--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -120,7 +120,7 @@ public:
 	Me& operator = (const CHAR_TYPE* src){ Assign(src); return *this; }
 
 	//各種メソッド
-	int Length() const{ return auto_strlen(m_szData); }
+	int Length() const { return static_cast<int>(auto_strnlen(m_szData, BUFFER_COUNT)); }
 
 private:
 	CHAR_TYPE m_szData[N_BUFFER_COUNT];


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
x64対応のために、x64ビルドで発生する警告に対処します。

## <!-- 必須 --> カテゴリ
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1541 で x64 対応ブームが始まったので対応してみます。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
x64 ビルドの警告が 2個減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくにありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
変更対象は、独自定義の拡張配列に格納された文字数を返す関数です。

独自関数auto_strlen()はsize_tの値を返しますが、関数の戻り型定義がintであるため、
暗黙の縮小変換となってコンパイラが警告を吐いています。

|Platform| int型のサイズ | size_t型のサイズ |
|--|--|--|
|Win32|32bit|32bit|
|x64|32bit|64bit|

StaticStringはスタックまたは共有メモリ上に固定サイズの配列を確保するための型です。

文字列長がINT_MAXな場合、配列サイズは4GBになります。
「スタックに4GB確保」はありえないので、問題になる可能性があるのは共有メモリのみになります。
x64化したからといって、共有メモリにそんなバカでかいデータを載せたいかというと、それもありえないと思います。

発生しているのは暗黙の縮小変換に対する警告のみです。

PRでは、より安全性の高い `auto_strnlen` を使うように修正しています。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
実害はありません。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
すでに作成している単体テストがカバーする範囲の修正であるため、追加のテストは不要と考えています。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1563
#1541

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
