### PR TITLE
ローカル変数fCheckの宣言型を修正する

### DIFF
--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -215,7 +215,7 @@ UINT_PTR CALLBACK OFNHookProc(
 	int						nIdx;
 	int						nIdxSel;
 	int						nWidth;
-	WPARAM					fCheck;	//	Jul. 26, 2003 ryoji BOM状態用
+	int						fCheck;	//	Jul. 26, 2003 ryoji BOM状態用
 
 	//	From Here	Feb. 9, 2001 genta
 	static const int		nEolValueArr[] = {

--- a/sakura_core/dlg/CDlgSetCharSet.cpp
+++ b/sakura_core/dlg/CDlgSetCharSet.cpp
@@ -101,7 +101,7 @@ void CDlgSetCharSet::SetBOM( void )
 {
 	int 		nIdx;
 	LRESULT		lRes;
-	WPARAM		fCheck;
+	int			fCheck;
 
 	nIdx = Combo_GetCurSel( m_hwndCharSet );
 	lRes = Combo_GetItemData( m_hwndCharSet, nIdx );
@@ -127,7 +127,7 @@ BOOL CDlgSetCharSet::OnCbnSelChange( HWND hwndCtl, int wID )
 {
 	int 		nIdx;
 	LRESULT		lRes;
-	WPARAM		fCheck;
+	int			fCheck;
 
 	switch (wID) {
 	//	文字コードの変更をBOMチェックボックスに反映


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
x64対応のために、x64ビルドの警告に対処します。

## <!-- 必須 --> カテゴリ
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1541 で x64 対応ブームが始まったので対応してみます。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
x64 ビルドの警告が 4個減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
単体テストでカバーされないコードを修正するため、カバレッジが下がります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
チェックボタンのチェック状態を保持するローカル変数の宣言型が正しくないのを修正します。

誤) WPARAM (x64ビルドで64bit型)
正) int (x64ビルドで32bit型)
※Win32ビルドではWPARAMとintのサイズは同じなので、必ずしも誤りではありません。

修正対象は、以下の3関数です。
* CDlgSetCharSet::OnCbnSelChange
* CDlgSetCharSet::SetBOM
* OFNHookProc

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
宣言型の変更なので、変数への代入と変数の利用に影響します。
代入するリテラルはintで表現できる値で、利用はintを渡す箇所のみなので実質的に影響なしです。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
デメリットに記載した通り、動作テストは行っていません。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1541

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
