### PR TITLE
DrawTextW 関数の第3引数の型 int に合わせて呼び出すように記述調整

### DIFF
--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -539,7 +539,7 @@ bool CUrlWnd::OnSetText( _In_opt_z_ LPCWSTR pchText, _In_opt_ size_t cchText ) c
 	// DrawText関数を使ってサイズを計測する
 	// ※この処理は実際には描かない
 	CMyRect rcText;
-	int retDrawText = ::DrawText( hDC, pchText, int(cchText), &rcText, DT_CALCRECT );
+	int retDrawText = ::DrawText( hDC, pchText, static_cast<int>(cchText), &rcText, DT_CALCRECT );
 
 	// DCの後始末
 	::SelectObject( hDC, hObj );

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -539,7 +539,7 @@ bool CUrlWnd::OnSetText( _In_opt_z_ LPCWSTR pchText, _In_opt_ size_t cchText ) c
 	// DrawText関数を使ってサイズを計測する
 	// ※この処理は実際には描かない
 	CMyRect rcText;
-	int retDrawText = ::DrawText( hDC, pchText, cchText, &rcText, DT_CALCRECT );
+	int retDrawText = ::DrawText( hDC, pchText, int(cchText), &rcText, DT_CALCRECT );
 
 	// DCの後始末
 	::SelectObject( hDC, hObj );

--- a/sakura_core/uiparts/CMenuDrawer.cpp
+++ b/sakura_core/uiparts/CMenuDrawer.cpp
@@ -1163,7 +1163,7 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 	::DrawText(
 		hdc,
 		pszItemStr,
-		int(j),
+		static_cast<int>(j),
 		&rcText,
 		DT_LEFT | DT_VCENTER | DT_SINGLELINE
 	);
@@ -1172,7 +1172,7 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 		::DrawText(
 			hdc,
 			&pszItemStr[j + 1],
-			int(nItemStrLen - ( j + 1 )),
+			static_cast<int>(nItemStrLen - ( j + 1 )),
 			&rcText,
 			DT_RIGHT | DT_VCENTER | DT_SINGLELINE
 		);

--- a/sakura_core/uiparts/CMenuDrawer.cpp
+++ b/sakura_core/uiparts/CMenuDrawer.cpp
@@ -1163,7 +1163,7 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 	::DrawText(
 		hdc,
 		pszItemStr,
-		j,
+		int(j),
 		&rcText,
 		DT_LEFT | DT_VCENTER | DT_SINGLELINE
 	);
@@ -1172,7 +1172,7 @@ void CMenuDrawer::DrawItem( DRAWITEMSTRUCT* lpdis )
 		::DrawText(
 			hdc,
 			&pszItemStr[j + 1],
-			nItemStrLen - ( j + 1 ),
+			int(nItemStrLen - ( j + 1 )),
 			&rcText,
 			DT_RIGHT | DT_VCENTER | DT_SINGLELINE
 		);

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -180,7 +180,7 @@ void CTipWnd::ComputeWindowSize(
 				rc.SetXYWH( 0, 0, cxScreen, 0 );
 
 				// テキスト描画に必要な矩形を計測する
-				::DrawText( hdc, &pszText[nLineBgn], i - nLineBgn, &rc,
+				::DrawText( hdc, &pszText[nLineBgn], int(i - nLineBgn), &rc,
 					DT_CALCRECT | DT_WORDBREAK | DT_EXPANDTABS | DT_EXTERNALLEADING
 				);
 
@@ -257,7 +257,7 @@ void CTipWnd::DrawTipText(
 			// 計測対象の文字列がブランクでない場合
 			if ( 0 < i - nLineBgn ) {
 				// 指定されたテキストを描画する
-				nHeight = ::DrawText( hdc, &pszText[nLineBgn], i - nLineBgn, &rc,
+				nHeight = ::DrawText( hdc, &pszText[nLineBgn], int(i - nLineBgn), &rc,
 					DT_WORDBREAK | DT_EXPANDTABS | DT_EXTERNALLEADING
 				);
 			}else{

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -180,7 +180,7 @@ void CTipWnd::ComputeWindowSize(
 				rc.SetXYWH( 0, 0, cxScreen, 0 );
 
 				// テキスト描画に必要な矩形を計測する
-				::DrawText( hdc, &pszText[nLineBgn], int(i - nLineBgn), &rc,
+				::DrawText( hdc, &pszText[nLineBgn], static_cast<int>(i - nLineBgn), &rc,
 					DT_CALCRECT | DT_WORDBREAK | DT_EXPANDTABS | DT_EXTERNALLEADING
 				);
 
@@ -257,7 +257,7 @@ void CTipWnd::DrawTipText(
 			// 計測対象の文字列がブランクでない場合
 			if ( 0 < i - nLineBgn ) {
 				// 指定されたテキストを描画する
-				nHeight = ::DrawText( hdc, &pszText[nLineBgn], int(i - nLineBgn), &rc,
+				nHeight = ::DrawText( hdc, &pszText[nLineBgn], static_cast<int>(i - nLineBgn), &rc,
 					DT_WORDBREAK | DT_EXPANDTABS | DT_EXTERNALLEADING
 				);
 			}else{


### PR DESCRIPTION
WindowsAPI DrawTextW 関数の第3引数の型が int なので size_t 型の変数を渡している箇所では int にキャストする記述を加える事で x64 ビルドでの警告を減らす対応を行いました。

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

x64ビルドでの警告を減らすのが目的です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->



## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

x64ビルド時の警告が変更前と比べて5つ減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

キャストの分だけコードの記述量が増えます。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

暗黙的に縮小変換されるか明示的にするかの違いでしかないので生成されるコードに違いは生じず動作的な影響はないという認識です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

x64ビルドしてアプリを起動して変更箇所に関連していそうな動作が問題が無いかをざっと確認しました。

詳細の記述は省きます。

これだとテストをしていないのと変わりが無いかもしれませんが、変更内容的に処理内容に変化は恐らくないと思うので手抜きします。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1541

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-drawtextw
