### PR TITLE
x64ビルドでの警告を減らす為に TextOutW 関数の第5引数（int型)に渡す型がintになるように対策

### DIFF
--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -460,19 +460,20 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 		HFONT hFont;
 		HFONT hFontOld;
 		WCHAR szText[512];
+		int txtLength;
 
 		hdc = BeginPaint( hWnd, &ps );
 
 		// 現在のクライアント矩形、テキスト、フォントを取得する
 		GetClientRect( hWnd, &rc );
-		GetWindowText( hWnd, szText, _countof(szText) );
+		txtLength = GetWindowText( hWnd, szText, _countof(szText) );
 		hFont = (HFONT)SendMessageAny( hWnd, WM_GETFONT, (WPARAM)0, (LPARAM)0 );
 
 		// テキスト描画
 		SetBkMode( hdc, TRANSPARENT );
 		SetTextColor( hdc, pUrlWnd->m_bHilighted? RGB( 0x84, 0, 0 ): RGB( 0, 0, 0xff ) );
 		hFontOld = (HFONT)SelectObject( hdc, (HGDIOBJ)hFont );
-		TextOut( hdc, ::DpiScaleX( 2 ), 0, szText, wcslen( szText ) );
+		TextOut( hdc, ::DpiScaleX( 2 ), 0, szText, txtLength );
 		SelectObject( hdc, (HGDIOBJ)hFontOld );
 
 		// フォーカス枠描画

--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -1116,13 +1116,14 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 	gr.FillMyRect(rc1);
 	/* テキスト */
 	::SetBkMode( gr, TRANSPARENT );
-	::TextOut( gr, rc1.left, rc1.top, pColorInfo->m_szName, wcslen( pColorInfo->m_szName ) );
+	int nameLength = static_cast<int>(wcslen(pColorInfo->m_szName));
+	::TextOut( gr, rc1.left, rc1.top, pColorInfo->m_szName, nameLength );
 	if( pColorInfo->m_sFontAttr.m_bBoldFont ){	/* 太字か */
-		::TextOut( gr, rc1.left + 1, rc1.top, pColorInfo->m_szName, wcslen( pColorInfo->m_szName ) );
+		::TextOut( gr, rc1.left + 1, rc1.top, pColorInfo->m_szName, nameLength );
 	}
 	if( pColorInfo->m_sFontAttr.m_bUnderLine ){	/* 下線か */
 		SIZE	sz;
-		::GetTextExtentPoint32( gr, pColorInfo->m_szName, wcslen( pColorInfo->m_szName ), &sz );
+		::GetTextExtentPoint32( gr, pColorInfo->m_szName, nameLength, &sz );
 		::MoveToEx( gr, rc1.left,		rc1.bottom - 2, NULL );
 		::LineTo( gr, rc1.left + sz.cx,	rc1.bottom - 2 );
 		::MoveToEx( gr, rc1.left,		rc1.bottom - 1, NULL );

--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -204,7 +204,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 			wchar_t szColumn[32];
 			apt[idx * 2 + 1] = POINT{nX, 0};
 			_itow( ((Int)keta) / 10, szColumn, 10 );
-			::TextOut( gr, nX + 2 + 0, -1 + 0, szColumn, wcslen( szColumn ) );
+			::TextOut( gr, nX + 2 + 0, -1 + 0, szColumn, static_cast<int>(wcslen( szColumn )) );
 		}
 		//5目盛おきの区切り(中)
 		else if( 0 == keta % 5 ){

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -1213,9 +1213,9 @@ LRESULT CEditWnd::DispatchEvent(
 				TEXTMETRIC tm;
 				::GetTextMetrics( lpdis->hDC, &tm );
 				int y = ( lpdis->rcItem.bottom - lpdis->rcItem.top - tm.tmHeight + 1 ) / 2 + lpdis->rcItem.top;
-				::TextOut( lpdis->hDC, lpdis->rcItem.left, y, L"REC", wcslen( L"REC" ) );
+				::TextOut( lpdis->hDC, lpdis->rcItem.left, y, L"REC", 3 );
 				if( COLOR_BTNTEXT == nColor ){
-					::TextOut( lpdis->hDC, lpdis->rcItem.left + 1, y, L"REC", wcslen( L"REC" ) );
+					::TextOut( lpdis->hDC, lpdis->rcItem.left + 1, y, L"REC", 3 );
 				}
 			}
 			return 0;


### PR DESCRIPTION
WindowsAPI TextOutW 関数の第5引数の型が int なので 渡す値の型がintになるようにする事で x64 ビルドでの警告を減らしました。

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

x64ビルドでの警告を減らすのが目的です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->



## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

x64ビルド時の警告が変更前と比べて7つ減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

コードの記述量が増えます。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

動作的な影響はないという認識です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

x64ビルドしてアプリを起動して変更箇所に関連していそうな動作が問題が無いかをざっと確認しました。

- バージョン情報ダイアログのURL表示
- タイプ別設定のカラータブの色種別リスト
- ルーラーの10目盛おきの数字
- キーマクロの記録時の REC 文字の描画

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1541

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-textoutw
