### PR TITLE
デザインテンプレートを活用できるように改良する

### DIFF
--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -33,9 +33,8 @@
 #define SAKURA_DESIGN_TEMPLATE_BBC57590_CED0_40D0_B719_F5A4522B8A56_H_
 #pragma once
 
+#include <stdexcept>
 #include <vector>
-
-#include "debug/Debug2.h"
 
 // http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Copy_Constructors
 // A macro to disallow the copy constructor and operator= functions
@@ -63,6 +62,15 @@ public:
 protected:
 	TSingleton(){}
 	DISALLOW_COPY_AND_ASSIGN(TSingleton);
+};
+
+/*!
+	複数インスタンスを生成しようとしたときのエラー
+ */
+class multi_instance_not_allowed : public std::domain_error {
+public:
+	multi_instance_not_allowed()
+		: std::domain_error("multi instance not allowed.") {}
 };
 
 /*!
@@ -106,7 +114,9 @@ protected:
 	 */
 	TSingleInstance()
 	{
-		assert(gm_instance == nullptr);
+		if (gm_instance != nullptr) {
+			throw multi_instance_not_allowed();
+		}
 		gm_instance = static_cast<T*>(this);
 	}
 

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -80,6 +80,8 @@ protected:
 template <class T>
 class TSingleInstance {
 private:
+	using Me = TSingleInstance<T>;
+
 	static T* gm_instance;				//!< シングルインスタンスを保持するポインタ
 
 public:
@@ -90,6 +92,11 @@ public:
 		@retval nullptr インスタンスが未生成
 	 */
 	[[nodiscard]] static T* getInstance() noexcept { return gm_instance; }
+
+	TSingleInstance(const Me&) = delete;
+	Me& operator = (const Me&) = delete;
+	TSingleInstance(Me&&) noexcept = delete;
+	Me& operator = (Me&&) noexcept = delete;
 
 protected:
 	/*!

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -64,34 +64,62 @@ protected:
 };
 
 /*!
-	1個しかインスタンスが存在しないクラスからのインスタンス取得インターフェースをstaticで提供。
-	Singletonパターンとは異なり、Instance()呼び出しにより、インスタンスが自動生成されない点に注意。
+	シングルインスタンス
 
-	2007.10.23 kobake 作成
-*/
+	1プロセスあたりのインスタンス数を制限するためのテンプレート。
+	シングルインスタンスは複数インスタンスを生成しないクラスに適用する。
+	シングルインスタンスの生成済みのインスタンスはstaticメソッドから取得できる。
+	インスタンス自動生成は行わないので、インスタンス生成は手動で行うこと。
+
+	デザインパターンの「シングルトン」とは関係ないので、派生クラスは「状態」を持って良い。
+
+	@date 2007.10.23 kobake 作成
+ */
 template <class T>
-class TSingleInstance{
+class TSingleInstance {
+private:
+	static T* gm_instance;				//!< シングルインスタンスを保持するポインタ
+
 public:
-	//公開インターフェース
-	static T* getInstance(){ return gm_instance; } //!< 作成済みのインスタンスを返す。インスタンスが存在しなければ NULL。
+	/*!
+		作成済みのインスタンスを取得する
+
+		@returns 作成済みのインスタンス
+		@retval nullptr インスタンスが未生成
+	 */
+	[[nodiscard]] static T* getInstance() noexcept { return gm_instance; }
 
 protected:
-	//※2個以上のインスタンスは想定していません。assertが破綻を検出します。
+	/*!
+		コンストラクタ
+
+		staticメンバにインスタンスを記録する。
+	 */
 	TSingleInstance()
 	{
-		assert(gm_instance==NULL);
-		gm_instance=static_cast<T*>(this);
+		assert(gm_instance == nullptr);
+		gm_instance = static_cast<T*>(this);
 	}
-	~TSingleInstance()
+
+	/*!
+		デストラクタ
+
+		staticメンバのポインタをクリアする。
+	 */
+	virtual ~TSingleInstance() noexcept
 	{
-		assert(gm_instance);
-		gm_instance=NULL;
+		gm_instance = nullptr;
 	}
-private:
-	static T* gm_instance;
 };
+
+/*!
+	シングルインスタンスを保持するポインタ
+
+	1プロセスあたり1つのインスタンスだけを許可する機構で、
+	TSingleInstance<T>以外からはアクセスさせない。
+ */
 template <class T>
-T* TSingleInstance<T>::gm_instance = NULL;
+T* TSingleInstance<T>::gm_instance = nullptr;
 
 //記録もする
 #include <vector>

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -33,6 +33,8 @@
 #define SAKURA_DESIGN_TEMPLATE_BBC57590_CED0_40D0_B719_F5A4522B8A56_H_
 #pragma once
 
+#include "debug/Debug2.h"
+
 // http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Copy_Constructors
 // A macro to disallow the copy constructor and operator= functions
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -170,6 +170,14 @@ public:
 		return gm_table[index];
 	}
 
+	/*!
+		作成済みのインスタンスを取得する
+
+		@returns 作成済みのインスタンス
+		@retval nullptr インスタンスが未生成
+	 */
+	[[nodiscard]] static T* getInstance() noexcept { return GetInstance(0); }
+
 	TInstanceHolder(const Me&) = delete;
 	Me& operator = (const Me&) = delete;
 	TInstanceHolder(Me&&) noexcept = delete;

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -143,6 +143,8 @@ T* TSingleInstance<T>::gm_instance = nullptr;
 template <class T>
 class TInstanceHolder {
 private:
+	using Me = TInstanceHolder<T>;
+
 	static std::vector<T*> gm_table;	//!< インスタンスを保持する動的配列
 
 public:
@@ -167,6 +169,11 @@ public:
 		}
 		return gm_table[index];
 	}
+
+	TInstanceHolder(const Me&) = delete;
+	Me& operator = (const Me&) = delete;
+	TInstanceHolder(Me&&) noexcept = delete;
+	Me& operator = (Me&&) noexcept = delete;
 
 protected:
 	/*!

--- a/tests/unittests/test-design_template.cpp
+++ b/tests/unittests/test-design_template.cpp
@@ -86,6 +86,9 @@ public:
  */
 TEST(CInstanceHolder, CInstanceHolder)
 {
+	// インスタンスが生成される前にgetInstanceするとNULLが返る
+	ASSERT_TRUE(CSingleInstance::getInstance() == nullptr);
+
 	// インスタンスが生成される前にGetInstance(0)するとNULLが返る
 	ASSERT_TRUE(CInstanceHolder::GetInstance(0) == nullptr);
 
@@ -101,6 +104,7 @@ TEST(CInstanceHolder, CInstanceHolder)
 
 		// 返却されるポインタは、ローカルで確保したインスタンスと等しい
 		ASSERT_EQ(&instance, CInstanceHolder::GetInstance(0));
+		ASSERT_EQ(&instance, CInstanceHolder::getInstance());
 
 		// インスタンスの数は1になる
 		ASSERT_EQ(1, CInstanceHolder::GetInstanceCount());
@@ -126,6 +130,7 @@ TEST(CInstanceHolder, CInstanceHolder)
 	}
 
 	// インスタンスが破棄された後は元に戻る
+	ASSERT_TRUE(CSingleInstance::getInstance() == nullptr);
 	ASSERT_TRUE(CInstanceHolder::GetInstance(0) == nullptr);
 	ASSERT_EQ(0, CInstanceHolder::GetInstanceCount());
 }

--- a/tests/unittests/test-design_template.cpp
+++ b/tests/unittests/test-design_template.cpp
@@ -63,8 +63,8 @@ TEST(CSingleInstance, CSingleInstance)
 		// 返却されるポインタは、ローカルで確保したインスタンスと等しい
 		ASSERT_EQ(&instance, CSingleInstance::getInstance());
 
-		// 2つ目のインスタンスを確保しようとするとassertで落ちる
-		ASSERT_EXIT({ CSingleInstance instance; }, ::testing::ExitedWithCode(1), ".*");
+		// 2つ目のインスタンスを確保しようとすると例外が発生する
+		ASSERT_THROW({ CSingleInstance instance; }, std::domain_error);
 	}
 
 	// インスタンスが破棄された後にgetInstanceするとNULLが返る

--- a/tests/unittests/test-design_template.cpp
+++ b/tests/unittests/test-design_template.cpp
@@ -1,0 +1,131 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2021 Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <tchar.h>
+#include <Windows.h>
+#include <Shlwapi.h>
+
+#include "util/design_template.h"
+
+
+/*!
+ * TSingleInstanceの挙動を検証するためのクラス
+ */
+class CSingleInstance : public TSingleInstance<CSingleInstance>
+{
+public:
+	CSingleInstance() = default;
+	virtual ~CSingleInstance() noexcept = default;
+};
+
+/*!
+ * @brief TSingleInstanceの挙動を検証するテスト
+ */
+TEST(CSingleInstance, CSingleInstance)
+{
+	// インスタンスが生成される前にgetInstanceするとNULLが返る
+	ASSERT_TRUE(CSingleInstance::getInstance() == nullptr);
+
+	{
+		// 1つ目のインスタンスを確保する
+		CSingleInstance instance;
+
+		// インスタンスが生成された後にgetInstanceするとNULL以外が返る
+		ASSERT_FALSE(CSingleInstance::getInstance() == nullptr);
+
+		// 返却されるポインタは、ローカルで確保したインスタンスと等しい
+		ASSERT_EQ(&instance, CSingleInstance::getInstance());
+
+		// 2つ目のインスタンスを確保しようとするとassertで落ちる
+		ASSERT_EXIT({ CSingleInstance instance; }, ::testing::ExitedWithCode(1), ".*");
+	}
+
+	// インスタンスが破棄された後にgetInstanceするとNULLが返る
+	ASSERT_TRUE(CSingleInstance::getInstance() == nullptr);
+}
+
+/*!
+ * TInstanceHolderの挙動を検証するためのクラス
+ */
+class CInstanceHolder : public TInstanceHolder<CInstanceHolder>
+{
+public:
+	CInstanceHolder() = default;
+	virtual ~CInstanceHolder() noexcept = default;
+};
+
+/*!
+ * @brief TInstanceHolderの挙動を検証するテスト
+ */
+TEST(CInstanceHolder, CInstanceHolder)
+{
+	// インスタンスが生成される前にGetInstance(0)するとNULLが返る
+	ASSERT_TRUE(CInstanceHolder::GetInstance(0) == nullptr);
+
+	// インスタンスの数は0で開始する
+	ASSERT_EQ(0, CInstanceHolder::GetInstanceCount());
+
+	{
+		// 1つ目のインスタンスを確保する
+		CInstanceHolder instance;
+
+		// インスタンスが生成され後にGetInstance(0)するとNULL以外が返る
+		ASSERT_FALSE(CInstanceHolder::GetInstance(0) == nullptr);
+
+		// 返却されるポインタは、ローカルで確保したインスタンスと等しい
+		ASSERT_EQ(&instance, CInstanceHolder::GetInstance(0));
+
+		// インスタンスの数は1になる
+		ASSERT_EQ(1, CInstanceHolder::GetInstanceCount());
+
+		{
+			// 2つ目のインスタンスを確保する
+			CInstanceHolder instance2;
+
+			// インスタンスが生成された後にGetInstance(1)するとNULL以外が返る
+			ASSERT_FALSE(CInstanceHolder::GetInstance(1) == nullptr);
+
+			// 返却されるポインタは、ローカルで確保したインスタンスと等しい
+			ASSERT_EQ(&instance2, CInstanceHolder::GetInstance(1));
+
+			// インスタンスの数は2になる
+			ASSERT_EQ(2, CInstanceHolder::GetInstanceCount());
+		}
+
+		// インスタンスが破棄された後は元に戻る
+		ASSERT_FALSE(CInstanceHolder::GetInstance(0) == nullptr);
+		ASSERT_EQ(&instance, CInstanceHolder::GetInstance(0));
+		ASSERT_EQ(1, CInstanceHolder::GetInstanceCount());
+	}
+
+	// インスタンスが破棄された後は元に戻る
+	ASSERT_TRUE(CInstanceHolder::GetInstance(0) == nullptr);
+	ASSERT_EQ(0, CInstanceHolder::GetInstanceCount());
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="test-csakuraenvironment.cpp" />
     <ClCompile Include="test-ctextmetrics.cpp" />
     <ClCompile Include="test-cwordparse.cpp" />
+    <ClCompile Include="test-design_template.cpp" />
     <ClCompile Include="test-editinfo.cpp" />
     <ClCompile Include="test-file.cpp" />
     <ClCompile Include="test-charcode.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -110,6 +110,9 @@
     <ClCompile Include="test-cclipboard.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-design_template.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
`util/design_template.h` を改善して、定義済みテンプレートを活用できるようにします。

## <!-- 必須 --> カテゴリ
- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
サクラエディタには「デザインパターンっぽいものを定義する」と主張するヘッダーファイルがあります。

`util/design_template.h`

このファイルで定義されているテンプレートは3つあります。
|クラス名|説明|
|--|--|
|TSingleton|サクラエディタ固有のシングルトンっぽいクラスを実現するテンプレート。|
|TSingleInstance|プロセス内に存在できるインスタンスを制限するテンプレート。CProcessの基底クラス。|
|TInstanceHolder|プロセス内で生成したインスタンスを記録するテンプレート。CEditDocの基底クラス。|

サクラエディタ固有のシングルトンっぽいクラスとして宣言されたクラスをテストするには、テストプロセスを別プロセスとして実行する必要があり「めんどくさい」という問題があります。

一般に言う「シングルトンパターン」で生成するインスタンスには状態を持たせないことが鉄則です。
インスタンスに状態を持たせてしまえば、ただのグローバル変数となってしまい、効果が半減します。

「サクラエディタ固有のシングルトンっぽいクラス」として定義されているのは全部で17種類ですが、これらはメンバ変数に状態を保持しているので、デザインパターンの「シングルトンの鉄則」を犯しています。

何故こんなことが起きているのか調べてみた結果、どうもTSingletonよりも先にTSingleInstanceが存在していたらしいことが分かりました。

独自定義のクラスの本来の用途を誤解して使ってしまう事故の原因として考えられることは、二択だと思います。
* 独自定義クラスの仕様が意味不明（＝作成者がアフォ）。
* 修正実装時の作業ミス（＝修正者がアフォ）。

まぁ、どっちでもいいんですけど。

とりあえず、今後も説明しても理解する気のない人にデザインパターンの解説を書くのはめんどくさいので、間違ったら修正作業ミスだと断言できるように、作成者が考えたと思われる仕様をコメント化する対応を行うことにしました。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
* テンプレートにコメントが追加されることにより、存在意義が明確になります。
* `TSingleInstance` のコンストラクタで行っている2つ目のインスタンス生成を失敗させる方法をassertからexceptionに変更することにより、実装がテスト可能になります。
* `TInstanceHolder::getInstance` が追加されることにより、3つのテンプレートに互換性が生まれます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくにありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
* util/design_template.hのテストを追加します。
* TSingleInstanceにコメントを追加します。
* TInstanceHolderにコメントを追加します。
* TSingleInstanceをコピー禁止にします。
* TInstanceHolderをコピー禁止にします。
* TInstanceHolder::getInstanceを追加します。
* TSingleInstanceのコンストラクタをテスト可能にします。

`TInstanceHolder::getInstance` の追加は、この後 `TSingleton` で定義されているクラス(全17種)の引っ越しに必要になると思います。
> CAppMode
> CAppNodeManager
> CCodeChecker
> CColorStrategyPool
> CCommandLine
> CDiffManager
> CEditApp
> CEditWnd
> CFigureManager
> CFileNameManager
> CJackManager
> CMacroFactory
> CMigemo
> CModifyManager
> CPluginManager
> CShareData
> CUxTheme

クラス名から判断する限り、シングルトンで構わないのは`CMacroFactory`くらいかと思います。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
* シングルインスタンス、インスタンスホルダーで定義されるクラスの挙動に影響を与える可能性があります。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
単体テストを用意して、テンプレートの挙動を確認できるようにしています。
追加のテストは不要と考えています。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
