### PR TITLE
文字幅キャッシュのグローバル関数を削除する

### DIFF
--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -256,23 +256,6 @@ namespace WCODE {
 
 	static CacheSelector selector;
 
-	//文字幅の動的計算。ピクセル幅
-	int CalcPxWidthByFont(wchar_t c)
-	{
-		return selector.GetCache()->CalcPxWidthByFont(c);
-	}
-
-	int CalcPxWidthByFont2(const wchar_t* pc)
-	{
-		return selector.GetCache()->CalcPxWidthByFont2(pc);
-	}
-
-	//文字幅の動的計算。半角ならtrue。
-	bool CalcHankakuByFont(wchar_t c)
-	{
-		return selector.GetCache()->CalcHankakuByFont(c);
-	}
-
 	// 文字の使用フォントを返す
 	// @return 0:半角用 / 1:全角用
 	[[nodiscard]] int GetFontNo( wchar_t c ){

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -207,13 +207,6 @@ namespace WCODE
 	{
 		return c>=0x2500 && c<=0x257F;
 	}
-
-	//!文字が半角かどうかを取得(DLLSHARE/フォント依存)
-	bool CalcHankakuByFont(wchar_t c);
-	//!文字のpx幅を取得(DLLSHARE/フォント依存)
-	int  CalcPxWidthByFont(wchar_t c);
-	//!文字のpx幅を取得(DLLSHARE/フォント依存)
-	int  CalcPxWidthByFont2(const wchar_t* c);
 }
 
 // 文字幅の動的計算用キャッシュ関連
@@ -254,8 +247,11 @@ public:
 	void Clear();
 	[[nodiscard]] bool GetMultiFont() const { return m_bMultiFont; }
 
+	//!文字が半角かどうかを取得(DLLSHARE/フォント依存)
 	virtual bool CalcHankakuByFont(wchar_t c) const;
+	//!文字のpx幅を取得(DLLSHARE/フォント依存)
 	virtual int CalcPxWidthByFont(wchar_t c);
+	//!文字のpx幅を取得(DLLSHARE/フォント依存)
 	virtual int CalcPxWidthByFont2(const wchar_t* pc2) const;
 
 private:

--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -32,6 +32,7 @@
 #include "basis/SakuraBasis.h"
 #include "CSearchAgent.h"
 #include "debug/CRunningTimer.h"
+#include "charset/charcode.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                        生成と破棄                           //
@@ -117,7 +118,8 @@ void CLayoutMgr::SetLayoutInfo(
 	int					nTsvMode,
 	CKetaXInt			nMaxLineKetas,
 	CLayoutXInt			nCharLayoutXPerKeta,
-	const LOGFONT*		pLogfont
+	const LOGFONT*		pLogfont,
+	CCharWidthCache&	cache
 )
 {
 	MY_RUNNINGTIMER( cRunningTimer, "CLayoutMgr::SetLayoutInfo" );
@@ -149,7 +151,7 @@ void CLayoutMgr::SetLayoutInfo(
 		m_nCharLayoutXPerKeta = nCharLayoutXPerKeta;
 	}
 	// 最大文字幅の計算
-	m_tsvInfo.m_nMaxCharLayoutX = WCODE::CalcPxWidthByFont(L'W');
+	m_tsvInfo.m_nMaxCharLayoutX = cache.CalcPxWidthByFont(L'W');
 	if (m_tsvInfo.m_nMaxCharLayoutX < m_nCharLayoutXPerKeta) {
 		m_tsvInfo.m_nMaxCharLayoutX = m_nCharLayoutXPerKeta;
 	}

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -38,6 +38,7 @@
 #include "COpe.h"
 #include "util/container.h"
 #include "util/design_template.h"
+#include "charset/charcode.h"
 #include "env/DLLSHAREDATA.h"
 
 class CBregexp;// 2002/2/10 aroka
@@ -259,7 +260,8 @@ public:
 		int				nTsvMode,
 		CKetaXInt		nMaxLineKetas,
 		CLayoutXInt		nCharLayoutXPerKeta,
-		const LOGFONT*	pLogfont
+		const LOGFONT*	pLogfont,
+		CCharWidthCache& cache = GetCharWidthCache()
 	);
 
 	/* 文字列置換 */

--- a/tests/unittests/test-charcode.cpp
+++ b/tests/unittests/test-charcode.cpp
@@ -76,29 +76,30 @@ TEST_F(CharWidthCache, IsHankaku)
 	// ここからは実行時のフォントを基に計算する文字。
 	SelectCharWidthCache(CWM_FONT_EDIT, CWM_CACHE_LOCAL);
 	InitCharWidthCache(lf1);
+	CCharWidthCache& cache = GetCharWidthCache();
 
 	// 漢字・ハングル・外字の場合、コード表の一番目の文字の幅がすべての文字に適用される。
-	bool kanjiWidth = WCODE::CalcHankakuByFont(L'一');
+	bool kanjiWidth = cache.CalcHankakuByFont(L'一');
 
 	// CJK統合漢字。Unicode 5.1 以降の文字には未対応。
 	for (wchar_t ch = 0x4e00; ch <= 0x9fbb; ++ch) {
-		EXPECT_EQ(WCODE::IsHankaku(ch), kanjiWidth);
+		EXPECT_EQ(WCODE::IsHankaku(ch, cache), kanjiWidth);
 	}
 	// CJK統合漢字拡張A。Unicode 13.0 の追加分には対応していない。
 	for (wchar_t ch = 0x3400; ch <= 0x4d85; ++ch) {
-		EXPECT_EQ(WCODE::IsHankaku(ch), kanjiWidth);
+		EXPECT_EQ(WCODE::IsHankaku(ch, cache), kanjiWidth);
 	}
 
 	// ハングル
-	bool hangulWidth = WCODE::CalcHankakuByFont(L'가');
+	bool hangulWidth = cache.CalcHankakuByFont(L'가');
 	for (wchar_t ch = 0xac00; ch <= 0xd7a3; ++ch) {
-		EXPECT_EQ(WCODE::IsHankaku(ch), hangulWidth);
+		EXPECT_EQ(WCODE::IsHankaku(ch, cache), hangulWidth);
 	}
 
 	// 外字
-	bool privateUseWidth = WCODE::CalcHankakuByFont(0xe000);
+	bool privateUseWidth = cache.CalcHankakuByFont(0xe000);
 	for (wchar_t ch = 0xe000; ch <= 0xe8ff; ++ch) {
-		EXPECT_EQ(WCODE::IsHankaku(ch), privateUseWidth);
+		EXPECT_EQ(WCODE::IsHankaku(ch, cache), privateUseWidth);
 	}
 }
 
@@ -114,21 +115,23 @@ TEST_F(CharWidthCache, CalcHankakuByFont)
 {
 	SelectCharWidthCache(CWM_FONT_EDIT, CWM_CACHE_LOCAL);
 	InitCharWidthCache(lf1);
+	CCharWidthCache& cache = GetCharWidthCache();
 
-	EXPECT_TRUE(WCODE::CalcHankakuByFont(L'a'));
-	EXPECT_FALSE(WCODE::CalcHankakuByFont(L'あ'));
+	EXPECT_TRUE(cache.CalcHankakuByFont(L'a'));
+	EXPECT_FALSE(cache.CalcHankakuByFont(L'あ'));
 }
 
 TEST_F(CharWidthCache, CalcPxWidthByFont)
 {
 	SelectCharWidthCache(CWM_FONT_EDIT, CWM_CACHE_LOCAL);
 	InitCharWidthCache(lf1);
+	CCharWidthCache& cache = GetCharWidthCache();
 
 	SIZE size;
 	GetTextExtentPoint32(dc, L"a", 1, &size);
-	EXPECT_EQ(WCODE::CalcPxWidthByFont(L'a'), size.cx);
+	EXPECT_EQ(cache.CalcPxWidthByFont(L'a'), size.cx);
 	GetTextExtentPoint32(dc, L"あ", 1, &size);
-	EXPECT_EQ(WCODE::CalcPxWidthByFont(L'あ'), size.cx);
+	EXPECT_EQ(cache.CalcPxWidthByFont(L'あ'), size.cx);
 
 	// コントロールコードの幅を普通に計算すると1pxになることがあるため、
 	// スペース・中黒の幅と比較して大きい方をとることになっている。
@@ -139,19 +142,20 @@ TEST_F(CharWidthCache, CalcPxWidthByFont)
 
 	// 理由はわからないが、NULとそれ以外で違う文字の幅を採用している。
 	GetTextExtentPoint32(dc, L"\0", 1, &size);
-	EXPECT_EQ(WCODE::CalcPxWidthByFont('\0'), std::max(size.cx, sizeOfSpace.cx));
+	EXPECT_EQ(cache.CalcPxWidthByFont('\0'), std::max(size.cx, sizeOfSpace.cx));
 	GetTextExtentPoint32(dc, L"\x01", 1, &size);
-	EXPECT_EQ(WCODE::CalcPxWidthByFont('\x01'), std::max(size.cx, sizeOfNakaguro.cx));
+	EXPECT_EQ(cache.CalcPxWidthByFont('\x01'), std::max(size.cx, sizeOfNakaguro.cx));
 }
 
 TEST_F(CharWidthCache, CalcPxWidthByFont2)
 {
 	SelectCharWidthCache(CWM_FONT_EDIT, CWM_CACHE_LOCAL);
 	InitCharWidthCache(lf1);
+	CCharWidthCache& cache = GetCharWidthCache();
 
 	SIZE size;
 	GetTextExtentPoint32(dc, L"\xd83c\xdf38", 2, &size);
-	EXPECT_EQ(WCODE::CalcPxWidthByFont2(L"\xd83c\xdf38"), size.cx);
+	EXPECT_EQ(cache.CalcPxWidthByFont2(L"\xd83c\xdf38"), size.cx);
 }
 
 TEST_F(CharWidthCache, FontNo)


### PR DESCRIPTION
# PR の目的

残存する文字幅キャッシュのグローバル関数への依存を除去し、グローバル関数を削除します。

## カテゴリ

- リファクタリング

## PR のメリット

- 文字幅キャッシュの公開インターフェースが理解しやすいものになります。
- コード量が減ります。

## テスト内容

自動テストで検証可能と思われるため、手動テストについては検討していません。
