### PR TITLE
sakura_core/view/colors/CColor_Quote.cpp ファイル内のx64ビルド時の警告を除去

### DIFF
--- a/sakura_core/view/colors/CColor_Quote.cpp
+++ b/sakura_core/view/colors/CColor_Quote.cpp
@@ -150,7 +150,7 @@ bool CColor_Quote::BeginColor(const CStringRef& cStr, int nPos)
 						}else{
 							m_tag.assign(L")\"", 2);
 						}
-						m_nCOMMENTEND = Match_QuoteStr( m_tag.c_str(), m_tag.size(), i + 1, cStr, false );
+						m_nCOMMENTEND = Match_QuoteStr( m_tag.c_str(), static_cast<int>(m_tag.size()), i + 1, cStr, false );
 						m_nColorTypeIndex = 1;
 						return true;
 					}
@@ -230,7 +230,7 @@ bool CColor_Quote::EndColor(const CStringRef& cStr, int nPos)
 			m_nCOMMENTEND = Match_Quote( m_cQuote, nPos, cStr, m_nEscapeType );
 			break;
 		case 1:
-			m_nCOMMENTEND = Match_QuoteStr( m_tag.c_str(), m_tag.size(), nPos, cStr, false );
+			m_nCOMMENTEND = Match_QuoteStr( m_tag.c_str(), static_cast<int>(m_tag.size()), nPos, cStr, false );
 			break;
 		case 2:
 			m_nCOMMENTEND = Match_Quote( m_cQuote, nPos, cStr, STRING_LITERAL_PLSQL );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

x64ビルドでの警告を減らすのが目的です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->



## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

x64ビルド時の警告が変更前と比べて2つ減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

コードの記述量が増えます。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

動作に影響はないという認識です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

x64ビルドしてアプリを起動して、C++のraw文字列の色付けがされるかを確認しました。

テストに使用したテキスト

```cpp
const char* str = R"aaa(文dsdadasdasdasdadasdadas
dsa字列)aaa"; int hoge; // aaaaa
```

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1541

