### PR TITLE
JIS<=>SJIS 変換の際、常に日本語ロケールを使用する

### DIFF
--- a/sakura_core/charset/CEuc.h
+++ b/sakura_core/charset/CEuc.h
@@ -84,9 +84,9 @@ inline int CEuc::_EucjpToUni_char( const unsigned char* pSrc, unsigned short* pD
 		czenkaku[0] = (pSrc[0] & 0x7f);
 		czenkaku[1] = (pSrc[1] & 0x7f);
 		// JIS → SJIS
-		ctemp = _mbcjistojms( (static_cast<unsigned int>(czenkaku[0]) << 8) | czenkaku[1] );
+		ctemp = _mbcjistojms_j( (static_cast<unsigned int>(czenkaku[0]) << 8) | czenkaku[1] );
 		if( ctemp != 0 ){
-			// NEC選定IBM拡張コードポイントををIBM拡張コードポイントにに変換
+			// NEC選定IBM拡張コードポイントをIBM拡張コードポイントに変換
 			unsigned int ctemp_ = SjisFilter_nec2ibm( ctemp );
 			ctemp = ctemp_;
 			// SJIS → Unicode
@@ -160,7 +160,7 @@ inline int CEuc::_UniToEucjp_char( const unsigned short* pSrc, unsigned char* pD
 			// SJIS -> JIS
 			unsigned int ctemp_ = SjisFilter_ibm2nec( (static_cast<unsigned int>(cbuf[0]) << 8) | cbuf[1] );
 				// < IBM拡張文字をNEC選定IBM拡張文字に変換
-			ctemp = _mbcjmstojis( ctemp_ );
+			ctemp = _mbcjmstojis_j( ctemp_ );
 			if( ctemp == 0 ){
 				berror = true;
 				pDst[0] = '?';

--- a/sakura_core/charset/CJis.cpp
+++ b/sakura_core/charset/CJis.cpp
@@ -73,7 +73,7 @@ const char* CJis::TABLE_JISESCDATA[] = {
 #endif
 
 /*!
-	JIS の一ブロック（エスケープシーケンスとエスケープシーケンスの間の区間）を変換 
+	JIS の一ブロック（エスケープシーケンスとエスケープシーケンスの間の区間）を変換
 
 	eMyJisesc は、MYJISESC_HANKATA か MYJISESC_ZENKAKU。
 */
@@ -131,7 +131,7 @@ int CJis::_JisToUni_block( const unsigned char* pSrc, const int nSrcLen, unsigne
 		for( ; pr < pSrc+nSrcLen-1; pr += 2 ){
 			if( IsJisZen(reinterpret_cast<const char*>(pr)) ){
 				// JIS -> SJIS
-				ctemp = _mbcjistojms( (static_cast<unsigned int>(pr[0]) << 8) | pr[1] );
+				ctemp = _mbcjistojms_j( (static_cast<unsigned int>(pr[0]) << 8) | pr[1] );
 				if( ctemp != 0 ){
 				// 変換に成功。
 					// SJIS → Unicode
@@ -328,7 +328,7 @@ int CJis::_SjisToJis_char( const unsigned char* pSrc, unsigned char* pDst, EChar
 		// JIS -> SJIS
 		ctemp_ = SjisFilter_basis( static_cast<unsigned int>(pSrc[0] << 8) | pSrc[1] );
 		ctemp_ = SjisFilter_ibm2nec( ctemp_ );
-		ctemp = _mbcjmstojis( ctemp_ );
+		ctemp = _mbcjmstojis_j( ctemp_ );
 		if( ctemp != 0 ){
 			// 変換に成功。
 			pDst[0] = static_cast<char>( (ctemp & 0x0000ff00) >> 8 );
@@ -498,8 +498,8 @@ EConvertResult CJis::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* p
 	CNativeW		cCharBuffer;
 	EConvertResult	res;
 	int				i;
-	WCHAR*			pd; 
-	unsigned char*	ps; 
+	WCHAR*			pd;
+	unsigned char*	ps;
 
 	// 2008/6/21 Uchi
 	if (psStatusbar->m_bDispUniInJis) {

--- a/sakura_core/charset/codeutil.cpp
+++ b/sakura_core/charset/codeutil.cpp
@@ -37,9 +37,9 @@
 
 	Shift_JIS fa40～fc4b の範囲の文字は 8754～879a または ed40～eefc に
 	散在する文字に変換された後に，JISに変換されます．
-	
+
 	@param pszSrc [in] 変換する文字列へのポインタ (Shift JIS)
-	
+
 	@author すい
 	@date 2002.10.03 1文字のみ扱い，変換まで行うように変更 genta
 */
@@ -47,7 +47,7 @@ unsigned int _mbcjmstojis_ex( unsigned int nSrc, bool* pbNonroundtrip )
 {
 	unsigned int	tmpw;	/* ← int が 16 bit 以上である事を期待しています。 */
 	bool bnonrt = false;
-	
+
 	unsigned char c0 = static_cast<unsigned char>((nSrc & 0x0000ff00) >> 8);
 	unsigned char c1 = static_cast<unsigned char>(nSrc & 0x000000ff);
 
@@ -78,11 +78,46 @@ unsigned int _mbcjmstojis_ex( unsigned int nSrc, bool* pbNonroundtrip )
 			else	if( tmpw <= 0xfbfc ) {	tmpw -= 0x0d1c;	}	/* fb9c～fbfc → ee80～eee0 (蕫～髙) */
 			else{							tmpw -= 0x0d5f;	}	/* fc40～fc4b → eee1～eeec (髜～黑) */
 		}
-		return _mbcjmstojis( tmpw );
+		return _mbcjmstojis_j( tmpw );
 	}
 	return 0;
 }
 #endif
+
+static _locale_t ja_locale = nullptr;
+
+static void init_ja_locale()
+{
+	if (ja_locale == nullptr) {
+		ja_locale = _create_locale(LC_ALL, "Japanese_Japan.932");
+	}
+}
+
+/*!
+	@brief 常に日本語ロケールを使うSJIS→JIS変換
+
+	SJISコードをJISに変換する．
+
+	@param c [in] 変換する文字 (Shift JIS)
+*/
+unsigned int _mbcjmstojis_j( unsigned int c )
+{
+	init_ja_locale();
+	return _mbcjmstojis_l(c, ja_locale);
+}
+
+/*!
+	@brief 常に日本語ロケールを使うJIS→SJIS変換
+
+	JISコードをSJISに変換する．
+
+	@param c [in] 変換する文字 (JIS)
+*/
+unsigned int _mbcjistojms_j( unsigned int c )
+{
+	init_ja_locale();
+	return _mbcjistojms_l(c, ja_locale);
+}
 
 /*
 	判別テーブル   WinAPI 関数 WideCharToMultiByte の特殊な変換（相互変換できない変換）か

--- a/sakura_core/charset/codeutil.h
+++ b/sakura_core/charset/codeutil.h
@@ -34,6 +34,8 @@
 //	2008.11.10 引数と戻り値の型を _mbcjmstojis に似せる
 unsigned int _mbcjmstojis_ex( unsigned int );
 #endif
+unsigned int _mbcjmstojis_j( unsigned int );
+unsigned int _mbcjistojms_j( unsigned int );
 
 unsigned int __fastcall SjisFilter_basis( const unsigned int );
 unsigned int __fastcall SjisFilter_ibm2nec( const unsigned int );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

英語版WindowsでEUC-JPのファイルが文字化けするのを修正する。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1103 参照。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
英語版Windowsでの文字化けが直る。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
多少遅くなる可能性あり。
_create_locale() で作成したロケールが解放されない。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
サクラエディタでは _mbcjistojms() と _mbcjmstojis() を JIS<=>SJIS の変換に使用していますが、これらの関数は現在のロケールが日本語の時しか動作しません。
代わりに _mbcjistojms_l() と _mbcjmstojis_l() を使い、日本語ロケールを明示的に指定することで、現在のロケールによらず、常に JIS<=>SJIS の変換を行えるようにします。

別案としては、_mbcjistojms() と _mbcjmstojis() からロケールのチェックを省いた関数を自前で実装する方法が考えられます。この場合、ロケールのチェックがない分、高速に動作する可能性がありますが、 変換ロジックでバグが混入するリスクが高まるでしょう。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
* [x] 日本語版Windowsで、EUC-JPのファイルを読み書きして文字化けしない。
* [x] 日本語版Windowsで、JISのファイルを読み書きして文字化けしない。
* [ ] 英語版Windowsで、EUC-JPのファイルを読み書きして文字化けしない。
* [ ] 英語版Windowsで、JISのファイルを読み書きして文字化けしない。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
Fix #1103

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
