### PR TITLE
共有メモリの基底クラスを変更して破棄のテストを書けるようにする

### DIFF
--- a/sakura_core/_main/CProcess.cpp
+++ b/sakura_core/_main/CProcess.cpp
@@ -35,7 +35,6 @@ CProcess::CProcess(
 , m_pfnMiniDumpWriteDump(NULL)
 #endif
 {
-	m_pcShareData = CShareData::getInstance();
 }
 
 /*!
@@ -43,7 +42,7 @@ CProcess::CProcess(
  */
 std::filesystem::path CProcess::GetIniFileName() const
 {
-	if (m_pcShareData->IsPrivateSettings()) {
+	if (m_cShareData.IsPrivateSettings()) {
 		const DLLSHAREDATA *pShareData = &GetDllShareData();
 		return pShareData->m_szPrivateIniFile.c_str();
 	}
@@ -161,5 +160,5 @@ int CProcess::WriteDump( PEXCEPTION_POINTERS pExceptPtrs )
 */
 void CProcess::RefreshString()
 {
-	m_pcShareData->RefreshString();
+	m_cShareData.RefreshString();
 }

--- a/sakura_core/_main/CProcess.h
+++ b/sakura_core/_main/CProcess.h
@@ -56,10 +56,10 @@ protected:
 #endif
 public:
 	HINSTANCE		GetProcessInstance() const{ return m_hInstance; }
-	CShareData&		GetShareData()   { return *m_pcShareData; }
+	CShareData&		GetShareData()   { return m_cShareData; }
 	HWND			GetMainWindow() const{ return m_hWnd; }
 
-	[[nodiscard]] const CShareData* GetShareDataPtr() const { return m_pcShareData; }
+	[[nodiscard]] const CShareData* GetShareDataPtr() const { return &m_cShareData; }
 
 private:
 	HINSTANCE	m_hInstance;
@@ -75,7 +75,7 @@ private:
 		PMINIDUMP_CALLBACK_INFORMATION CallbackParam
 		);
 #endif
-	CShareData*		m_pcShareData;
+	CShareData		m_cShareData;
 
 private:
 };

--- a/sakura_core/env/CShareData.h
+++ b/sakura_core/env/CShareData.h
@@ -59,13 +59,12 @@ struct STypeConfig;
 
 	@date 2002.01.03 YAZAKI m_tbMyButtonなどをCShareDataからCMenuDrawerへ移動したことによる修正。
 */
-class CShareData : public TSingleton<CShareData>
+class CShareData : public TSingleInstance<CShareData>
 {
-	friend class TSingleton<CShareData>;
+public:
 	CShareData();
 	~CShareData();
 
-public:
 	/*
 	||  Attributes & Operations
 	*/


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
共有メモリ管理クラスの基底クラスを変更して、共有メモリに関する検証を行いやすくします。

## <!-- 必須 --> カテゴリ

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1570 で `util/design_template.h` を活用するための変更を行いました。

#1581 とほぼ同件です。

共有メモリは元々「プロセス内に1つのみ」という仕様なので、
変更先の基底クラステンプレートを `TSingleInstance<T>` とします。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
* CShareDataが破棄されるときの挙動をテストできるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくにおもいつきません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
CShareDataの基底クラスを `TSingleton` から `TSingleInstance` に変更します。

* friend 宣言が不要になるので削除します。
* コンストラクタを protected にする必要がなくなるので public に変更します。
* CProcessのメンバ変数を`CShareData*`から`CShareData`に変更します。
  ※変数名がハンガリアンなので修正規模が大きく見えます。

ややこしくなるので、変更により可能となるテストケースの追加は行いません。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
CShareDataに依存するコードに影響を与える修正です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
修正の主要部分が単体テストのカバー範囲であるため、追加のテストは不要と考えています。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1570

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://github.com/sakura-editor/sakura/blob/cf05ed99831560633932ea57a95167d83c394837/sakura_core/env/CShareData.h#L55-L58
変更前はサクラエディタ独自「シングルトンっぽいクラス」を基底クラスとしているため、インスタンスを破棄することができません。ここのコメントの大半は現状の挙動に対して「ウソ」になってるのでこれをもって変更の正当性を騙るのはビミョーですが、当初仕様がら離れていく変更でないことの担保にはなると思います。