### PR TITLE
このファイルのパス名とカーソル位置をコピーでのバッファオーバーランの不具合対応

### DIFF
--- a/sakura_core/cmd/CViewCommander_Clipboard.cpp
+++ b/sakura_core/cmd/CViewCommander_Clipboard.cpp
@@ -1145,16 +1145,14 @@ void CViewCommander::Command_COPYDIRPATH( void )
 void CViewCommander::Command_COPYTAG( void )
 {
 	if( GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
-		wchar_t	buf[ MAX_PATH + 20 ];
-
 		CLogicPoint ptColLine;
 
 		//	論理行番号を得る
 		GetDocument()->m_cLayoutMgr.LayoutToLogic( GetCaret().GetCaretLayoutPos(), &ptColLine );
 
 		/* クリップボードにデータを設定 */
-		auto_sprintf( buf, L"%s (%d,%d): ", GetDocument()->m_cDocFile.GetFilePath(), ptColLine.y+1, ptColLine.x+1 );
-		m_pCommanderView->MySetClipboardData( buf, wcslen( buf ), false );
+		std::wstring buffer = strprintf(L"%s (%d,%d): ", GetDocument()->m_cDocFile.GetFilePath(), ptColLine.y+1, ptColLine.x+1 );
+		m_pCommanderView->MySetClipboardData(buffer.c_str(), buffer.length(), false);
 	}
 	else{
 		ErrorBeep();


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
「このファイルのパス名とカーソル位置をコピー」の固定長文字列がバッファオーバーランする可能性に対処します。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正
- プログラムの動作上の問題
  - 正式リリース版

## <!-- 自明なら省略可 --> PR の背景
バグが減ります。

<!-- PR を行う背景を記載してください -->

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
特にはないと思います。

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

```CViewCommander::Command_COPYDIRPATH()
　wchar_t	buf[ MAX_PATH + 20 ];
　auto_sprintf( buf, L"%s (%d,%d): "
```
パスはMAX_PATHに収まり最大MAX_PATH-1としても、%dのintで最大10文字x2で20文字だとすると、最悪ケースでは「スペース、括弧、コロン、\\0」の6文字分ぐらいが足りません。

将来の長いファイル名も考慮し、std::wstringとstrprintfに変更しました。

## PR の影響範囲

## テスト内容
実際にオーバーランしたときのテストは難しいため、試していません。
コード修正後、適当なファイルを開き、ファイル名とタグがコピーできることは目視、手動で確認しました。

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順
・適当なファイルを開く
・「このファイルのパス名とカーソル位置をコピー」を実行
・「貼り付け」でクリップボードの中身を確認

もし可能なら、MAX_PATH近いパスのファイルで、行数が1G文字、最後の行の中身が1G文字の後ろにカーソルを置いて、コマンドを実行します。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
