### PR TITLE
SonarCloudで検出されたCDlgTagsMakeの範囲外アクセスをPathAddBackslashを使って解消する

### DIFF
--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -32,6 +32,9 @@
 
 #include "StdAfx.h"
 #include "dlg/CDlgTagsMake.h"
+
+#include <Shlwapi.h>
+
 #include "env/DLLSHAREDATA.h"
 #include "func/Funccode.h"
 #include "util/shell.h"
@@ -125,12 +128,7 @@ void CDlgTagsMake::SelectFolder( HWND hwndDlg )
 	if( SelectDir( hwndDlg, LS(STR_DLGTAGMAK_SELECTDIR), szPath, szPath ) )
 	{
 		//末尾に\\マークを追加する．
-		int pos = wcslen( szPath );
-		if( pos > 0 && szPath[ pos - 1 ] != L'\\' )
-		{
-			szPath[ pos     ] = L'\\';
-			szPath[ pos + 1 ] = L'\0';
-		}
+		::PathAddBackslashW( szPath );
 
 		::DlgItem_SetText( hwndDlg, IDC_EDIT_TAG_MAKE_FOLDER, szPath );
 	}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
SonarScanで検出されたBugsレベル警告に対処します。

## <!-- 必須 --> カテゴリ
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
SonarScanで以下のBugsレベル警告が検出されています。

> Out of bound memory access (accessed memory precedes memory block)
> https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AW0wX_pmNdFAxPJlXmrD&open=AW0wX_pmNdFAxPJlXmrD

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
SonarCloudのBugsレベル警告が1つ解消します。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくにありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
ポインタインデックスを操作するコードに対して警告が出ているようです。

周辺コードでやってることは Windows API で提供されている内容なので置き換えてコードを簡潔にしてしまいます。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
ビルド確認のみです。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1504

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://docs.microsoft.com/ja-jp/windows/win32/api/shlwapi/nf-shlwapi-pathaddbackslashw
