### PR TITLE
Grepダイアログのフォルダ名設定処理でのバッファオーバーラン修正

### DIFF
--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -913,11 +913,9 @@ LPVOID CDlgGrep::GetHelpIdTable(void)
 static void SetGrepFolder( HWND hwndCtrl, LPCWSTR folder )
 {
 	if( wcschr( folder, L';') ){
-		WCHAR szQuoteFolder[MAX_PATH];
-		szQuoteFolder[0] = L'"';
-		wcscpy( szQuoteFolder + 1, folder );
-		wcscat( szQuoteFolder, L"\"" );
-		::SetWindowText( hwndCtrl, szQuoteFolder );
+		CNativeW strQuoteFolder;
+		strQuoteFolder.AppendStringF(L"\"%s\"", folder);
+		::SetWindowText( hwndCtrl, strQuoteFolder.GetStringPtr() );
 	}else{
 		::SetWindowText( hwndCtrl, folder );
 	}

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -913,9 +913,9 @@ LPVOID CDlgGrep::GetHelpIdTable(void)
 static void SetGrepFolder( HWND hwndCtrl, LPCWSTR folder )
 {
 	if( wcschr( folder, L';') ){
-		CNativeW strQuoteFolder;
-		strQuoteFolder.AppendStringF(L"\"%s\"", folder);
-		::SetWindowText( hwndCtrl, strQuoteFolder.GetStringPtr() );
+		std::wstring strQuoteFolder;
+		strQuoteFolder = std::wstring(L"\"") + folder + std::wstring(L"\"");
+		::SetWindowText( hwndCtrl, strQuoteFolder.c_str() );
 	}else{
 		::SetWindowText( hwndCtrl, folder );
 	}


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
見た感じ SetGrepFolder関数のWCHAR[MAX_PATH] の変数で長さを確認せずに、前後をクオートで囲う処理をしていて、パスがぎりぎりの長さの場合にはバッファに入りきりません。
それを修正します。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ
- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

## <!-- 自明なら省略可 --> PR のメリット
バグが減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
特にありません。

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
「現フォルダ」ボタンやフォルダ参照を押すと、パスがエディットコントロールに設定されます。
そのとき、パスに;(セミコロン)が含まれているときはセパレーターと区別するためにパス全体をダブルクォートで囲う処理があります。
これがコード上はバッファオーバーランするように見えるのを、直します。

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- わかる範囲で --> PR の影響範囲
C言語の文字列操作関数は止めて、可変長のCNativeWにしました。パスが長くても安心です。
変更は関数内のみです。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1
手順

長いフォルダのパスはエクスプローラーやCMDでもうまく作れなかったので未確認です。
普通の;セミコロンを含むパスをダブルクォートで囲う処理が動作することは、目視の動作確認で一応しました。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
