### PR TITLE
CDlgInput1で文字列長はNUL終端を含まない長さを指定するはずが1文字多いところがあるのを修正

### DIFF
--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -934,7 +934,7 @@ void CDlgFavorite::AddItem()
 	CDlgInput1	cDlgInput1;
 	std::wstring strTitle = LS( STR_DLGFAV_ADD );
 	std::wstring strMessage = LS( STR_DLGFAV_ADD_PROMPT );
-	if( !cDlgInput1.DoModal( G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size, szAddText ) ){
+	if( !cDlgInput1.DoModal( G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szAddText ) ){
 		return;
 	}
 
@@ -965,7 +965,7 @@ void CDlgFavorite::EditItem()
 			CDlgInput1	cDlgInput1;
 			std::wstring strTitle = LS( STR_DLGFAV_EDIT );
 			std::wstring strMessage = LS( STR_DLGFAV_EDIT_PROMPT );
-			if( !cDlgInput1.DoModal(G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size, szText) ){
+			if( !cDlgInput1.DoModal(G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){
 				return;
 			}
 			GetFavorite(m_nCurrentTab);

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -187,7 +187,6 @@ BOOL CDlgPrintSetting::OnDestroy( void )
 
 BOOL CDlgPrintSetting::OnNotify(NMHDR* pNMHDR)
 {
-	CDlgInput1		cDlgInput1;
 	NM_UPDOWN*		pMNUD;
 	int				idCtrl;
 	BOOL			bSpinDown;

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -343,7 +343,7 @@ void CDlgProfileMgr::CreateProf()
 	std::wstring strTitle = LS(STR_DLGPROFILE_NEW_PROF_TITLE);
 	std::wstring strMessage = LS(STR_DLGPROFILE_NEW_PROF_MSG);
 	szText[0] = L'\0';
-	if( !cDlgInput1.DoModal(::GetModuleHandle(NULL), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size, szText) ){
+	if( !cDlgInput1.DoModal(::GetModuleHandle(NULL), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){
 		return;
 	}
 	if( szText[0] == L'\0' ){
@@ -402,7 +402,7 @@ void CDlgProfileMgr::RenameProf()
 	std::wstring strTitle = LS(STR_DLGPROFILE_RENAME_TITLE);
 	std::wstring strMessage = LS(STR_DLGPROFILE_RENAME_MSG);
 	int max_size = _MAX_PATH;
-	if( !cDlgInput1.DoModal(::GetModuleHandle(NULL), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size, szText) ){
+	if( !cDlgInput1.DoModal(::GetModuleHandle(NULL), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){
 		return;
 	}
 	if( szText[0] == L'\0' ){

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -776,11 +776,11 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 			std::wstring strTitle = LS(STR_DLGREPLC_STR);
 			WCHAR szPathFrom[_MAX_PATH];
 			szPathFrom[0] = L'\0';
-			if( dlgInput.DoModal(G_AppInstance(), GetHwnd(), strTitle.c_str(), strMsg.c_str(), _countof(szPathFrom), szPathFrom) ){
+			if( dlgInput.DoModal(G_AppInstance(), GetHwnd(), strTitle.c_str(), strMsg.c_str(), _countof(szPathFrom) - 1, szPathFrom) ){
 				WCHAR szPathTo[_MAX_PATH];
 				szPathTo[0] = L'\0';
 				strMsg = LS(STR_FILETREE_REPLACE_PATH_TO);
-				if( dlgInput.DoModal( G_AppInstance(), GetHwnd(), strTitle.c_str(), strMsg.c_str(), _countof(szPathTo), szPathTo) ){
+				if( dlgInput.DoModal( G_AppInstance(), GetHwnd(), strTitle.c_str(), strMsg.c_str(), _countof(szPathTo) - 1, szPathTo) ){
 					int nItemsCount = (int)m_fileTreeSetting.m_aItems.size();
 					for( int i = 0; i < nItemsCount; i++ ){
 						SFileTreeItem& item =  m_fileTreeSetting.m_aItems[i];

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -889,7 +889,7 @@ void CPrintPreview::OnPreviewGoDirectPage( void )
 		m_hwndPrintPreviewBar, 
 		LS(STR_ERR_DLGPRNPRVW5),
 		szMessage,
-		INPUT_PAGE_NUM_LEN,
+		_countof(szPageNum) - 1,
 		szPageNum
 	);
 	if( FALSE != bDlgInputPageResult ){


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
タイトルの通り、1行入力ダイアログのいくつかの画面に、1文字分長い文字列制限値を指定しているため、入力画面で限界まで文字を入れると、落ちたり落ちなかったり、動作不良だったり、ちょっと不健康です。
このPRでは、不具合として修正します。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景
異常終了、不安定な動作はなるべく直したいです。

## <!-- 自明なら省略可 --> PR のメリット
バグが減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
特にありません。

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
履歴ダイアログの「検索」などの文字列はダブルクリックか右クリックで「編集」できます。
同、左下の「追加」や右メニューの「新規追加」でも入力画面が出ます。
同じような感じで、プロファイルマネージャの新規作成、名前変更があります。
ファイルツリー設定画面の「パスの一括置換」も同上です。
印刷プレビューのページ番号の「...」の直接指定のダイアログもです。
以上が、1文字多くなっていたところです。

なおCDlgPrintSettingのCDlgInput1の変数は未使用だったので削除しました。

## <!-- わかる範囲で --> PR の影響範囲
上記、ダイアログの入力可能文字数が1文字減ります。

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容
手順
元のコードベースで実行し、履歴ダイアログで新規追加はMAX文字入力すると、履歴に追加されません。
PRのコード修正を適用すると、MAX文字(前より1文字少ない)でも追加されます。

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1
結合テスト的なものなので、単体テストは書くのが難しいため、ありません。
サクラエディタを実行し、各ダイアログ上を操作して、正常動作するか確認します。


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
