### PR TITLE
WCODE::IsHankaku が文字幅キャッシュを参照しない問題を修正する

### DIFF
--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -50,7 +50,7 @@ namespace WCODE
 	bool CalcHankakuByFont(wchar_t);
 
 	//2007.08.30 kobake 追加
-	bool IsHankaku(wchar_t wc, const CCharWidthCache& cache)
+	bool IsHankaku(wchar_t wc, CCharWidthCache& cache)
 	{
 		//※ほぼ未検証。ロジックが確定したらインライン化すると良い。
 
@@ -165,9 +165,9 @@ void CCharWidthCache::Clear()
 	m_pCache->m_nCharWidthCacheTest=0x12345678;
 }
 
-bool CCharWidthCache::CalcHankakuByFont(wchar_t c) const
+bool CCharWidthCache::CalcHankakuByFont(wchar_t c)
 {
-	return QueryPixelWidth(c) <= m_han_size.cx;
+	return CalcPxWidthByFont(c) <= m_han_size.cx;
 }
 
 int CCharWidthCache::QueryPixelWidth(wchar_t c) const

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -248,7 +248,7 @@ public:
 	[[nodiscard]] bool GetMultiFont() const { return m_bMultiFont; }
 
 	//!文字が半角かどうかを取得(DLLSHARE/フォント依存)
-	virtual bool CalcHankakuByFont(wchar_t c) const;
+	virtual bool CalcHankakuByFont(wchar_t c);
 	//!文字のpx幅を取得(DLLSHARE/フォント依存)
 	virtual int CalcPxWidthByFont(wchar_t c);
 	//!文字のpx幅を取得(DLLSHARE/フォント依存)
@@ -280,9 +280,11 @@ void InitCharWidthCacheFromDC(const LOGFONT* lfs, ECharWidthFontMode fMode, HDC 
 
 namespace WCODE {
 	//!半角文字(縦長長方形)かどうか判定
-	bool IsHankaku(wchar_t wc, const CCharWidthCache& cache = GetCharWidthCache());
+	bool IsHankaku(wchar_t wc, CCharWidthCache& cache = GetCharWidthCache());
 	//!全角文字(正方形)かどうか判定
-	inline bool IsZenkaku(wchar_t wc) { return !IsHankaku(wc); }
+	inline bool IsZenkaku(wchar_t wc, CCharWidthCache& cache = GetCharWidthCache()) {
+		return !IsHankaku(wc, cache);
+	}
 }
 
 #endif /* SAKURA_CHARCODE_4C34C669_0BAB_441A_9B1D_2B9AC1895380_H_ */

--- a/sakura_core/convert/CConvert.cpp
+++ b/sakura_core/convert/CConvert.cpp
@@ -111,7 +111,7 @@ void CConvertMediator::ConvMemory( CNativeW* pCMemory, EFunctionCode nFuncCode, 
 	case F_HANKATATOZENHIRA:		CConvert_HankataToZenhira().CallConvert(pCMemory);	break;	// 半角カタカナ→全角ひらがな
 	//文字種変換、整形
 	case F_TABTOSPACE:				CConvert_TabToSpace((Int)nTabWidth, nStartColumn, bExtEol).CallConvert(pCMemory);break;	// TAB→空白
-	case F_SPACETOTAB:				CConvert_SpaceToTab((Int)nTabWidth, nStartColumn, bExtEol).CallConvert(pCMemory);break;	// 空白→TAB
+	case F_SPACETOTAB:				CConvert_SpaceToTab((Int)nTabWidth, nStartColumn, bExtEol, GetCharWidthCache()).CallConvert(pCMemory);break;	// 空白→TAB
 	case F_LTRIM:					CConvert_Trim(true, bExtEol).CallConvert(pCMemory);		break;	// 2001.12.03 hor
 	case F_RTRIM:					CConvert_Trim(false, bExtEol).CallConvert(pCMemory);	break;	// 2001.12.03 hor
 	//コード変換(xxx2SJIS)

--- a/sakura_core/convert/CConvert_SpaceToTab.cpp
+++ b/sakura_core/convert/CConvert_SpaceToTab.cpp
@@ -100,7 +100,7 @@ bool CConvert_SpaceToTab::DoConvert(CNativeW* pcData)
 						}
 					}
 					nPosX++;
-					if(WCODE::IsZenkaku(pLine[i])) nPosX++;		//全角文字ずれ対応 2008.10.17 matsumo
+					if(WCODE::IsZenkaku(pLine[i], m_cCache)) nPosX++;	//全角文字ずれ対応 2008.10.17 matsumo
 					pDes[nPosDes] = pLine[i];
 					nPosDes++;
 					bSpace = FALSE;

--- a/sakura_core/convert/CConvert_SpaceToTab.h
+++ b/sakura_core/convert/CConvert_SpaceToTab.h
@@ -29,10 +29,13 @@
 
 #include "CConvert.h"
 
+class CCharWidthCache;
+
 class CConvert_SpaceToTab final : public CConvert{
 public:
-	CConvert_SpaceToTab(int nTabWidth, int nStartColumn, bool bExtEol)
-	: m_nTabWidth(nTabWidth), m_nStartColumn(nStartColumn), m_bExtEol(bExtEol)
+	CConvert_SpaceToTab(int nTabWidth, int nStartColumn, bool bExtEol, CCharWidthCache& cache)
+		: m_nTabWidth(nTabWidth), m_nStartColumn(nStartColumn),
+		  m_bExtEol(bExtEol), m_cCache(cache)
 	{
 	}
 
@@ -42,5 +45,6 @@ private:
 	int m_nTabWidth;
 	int m_nStartColumn;
 	bool m_bExtEol;
+	CCharWidthCache& m_cCache;
 };
 #endif /* SAKURA_CCONVERT_SPACETOTAB_AA8D9341_7190_4332_AA23_C0D9AA4DC8D0_H_ */

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -374,7 +374,7 @@ CLogicInt CNativeW::GetSizeOfChar( const wchar_t* pData, int nDataLen, int nIdx 
 }
 
 //! 指定した位置の文字が半角何個分かを返す
-CKetaXInt CNativeW::GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx, const CCharWidthCache& cache)
+CKetaXInt CNativeW::GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx, CCharWidthCache& cache)
 {
 	//文字列範囲外なら 0
 	if( nIdx >= nDataLen )

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -169,7 +169,7 @@ public:
 		bool bEnableExtEol, CCharWidthCache& cache = GetCharWidthCache() );
 	//! 指定した位置の文字が半角何個分かを返す
 	static CKetaXInt GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx,
-		const CCharWidthCache& cache = GetCharWidthCache() );
+		CCharWidthCache& cache = GetCharWidthCache() );
 	static const wchar_t* GetCharNext( const wchar_t* pData, int nDataLen, const wchar_t* pDataCurrent ); //!< ポインタで示した文字の次にある文字の位置を返します
 	static const wchar_t* GetCharPrev(const wchar_t* pData, size_t nDataLen, const wchar_t* pDataCurrent); //!< ポインタで示した文字の直前にある文字の位置を返します
 

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -792,7 +792,7 @@ TEST(CNativeW, GetKetaOfChar)
 	// 文字が全角なら2を返す。
 	class FakeCache : public CCharWidthCache {
 	public:
-		bool CalcHankakuByFont(wchar_t c) const override { return false; }
+		bool CalcHankakuByFont(wchar_t c) override { return false; }
 	} cache;
 	EXPECT_EQ(CNativeW::GetKetaOfChar(L"あ", 1, 0, cache), 2);
 }


### PR DESCRIPTION
# PR の目的

WCODE::IsHankaku が文字の幅を取得する際にキャッシュを経由しなくなっていた問題を修正します。

88524d8 のリファクタリング作業におけるコーディングミスの修正です。

## カテゴリ

- 不具合修正

## PR の背景

CCharWidthCache には目的とシグネチャが同一ながら挙動が異なる関数があります。

|関数名|アクセスレベル|目的|挙動|キャッシュの扱い|
|--|--|--|--|--|
|CalcPxWidthByFont|public|文字のピクセル幅を取得する|キャッシュから検索する|参照する|
|QueryPixelWidth|private|文字のピクセル幅を取得する|GDI に問い合わせる|参照しない|

CalcPxWidthByFont を呼び出す代わりに QueryPixelWidth を呼び出していてもコンパイルエラーになりませんが、キャッシュを参照しない分パフォーマンスが劣化することになります。

コミット 88524d8 において実際にそのような誤った変更を加えてしまっていたため、アプリケーション内での使用頻度の高い WCODE::IsHankaku が文字幅キャッシュを参照せず、毎回 GDI にピクセル幅を問い合わせる状態になっていました。

## PR のメリット

- 劣化していたパフォーマンスが元に戻ります。
- 自動テストの実行時間が1～2秒ほど短くなります。

## 仕様・動作説明

リファクタリング前の正しい挙動に戻すための修正を行います。

- CCharWidthCache::CalcHankakuByFont で CalcPxWidthByFont を使用します。
- CalcPxWidthByFont が非 const であるため、CalcHankakuByFont の const 指定を外します。
- WCODE::IsHankaku の誤った挙動を前提としているテストを修正します。
- WCODE::IsHankaku に依存するクラスをテスト可能な形に変更します。

## PR の影響範囲

WCODE::IsHankaku は使用頻度の高い関数であるため、アプリケーション全体の挙動に影響します。

## テスト内容

修正の妥当性は自動テストで検証できると思います。

## 関連 issue, PR

#1532

