### PR TITLE
CCodeBase::MIMEHeaderDecode のテストを追加

### DIFF
--- a/sakura_core/charset/CCodeBase.h
+++ b/sakura_core/charset/CCodeBase.h
@@ -27,6 +27,8 @@
 #define SAKURA_CCODEBASE_1AB194FB_933C_495E_A3A3_62E117C72644_H_
 #pragma once
 
+#include "mem/CNativeW.h"
+
 //定数
 enum EConvertResult{
 	RESULT_COMPLETE, //!< データを失うことなく変換が完了した。
@@ -34,8 +36,6 @@ enum EConvertResult{
 	RESULT_FAILURE,  //!< 何らかの原因により失敗した。
 };
 
-class CMemory;
-class CNativeW;
 struct CommonSetting_Statusbar;
 enum EEolType : char;
 

--- a/tests/unittests/test-ccodebase.cpp
+++ b/tests/unittests/test-ccodebase.cpp
@@ -1,0 +1,66 @@
+﻿/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+
+#include <gtest/gtest.h>
+#include <string>
+#include "charset/CCodeBase.h"
+
+TEST(CCodeBase, MIMEHeaderDecode)
+{
+	CMemory m;
+
+	// Base64 JIS
+	std::string source1("From: =?iso-2022-jp?B?GyRCJTUlLyVpGyhC?=");
+	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source1.c_str(), source1.length(), &m, CODE_JIS));
+	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), "From: $B%5%/%i(B");
+
+	// Base64 UTF-8
+	std::string source2("From: =?utf-8?B?44K144Kv44Op?=");
+	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source2.c_str(), source2.length(), &m, CODE_UTF8));
+	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), "From: \xe3\x82\xb5\xe3\x82\xaf\xe3\x83\xa9");
+
+	// QP UTF-8
+	std::string source3("From: =?utf-8?Q?=E3=82=B5=E3=82=AF=E3=83=A9!?=");
+	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source3.c_str(), source3.length(), &m, CODE_UTF8));
+	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), "From: \xe3\x82\xb5\xe3\x82\xaf\xe3\x83\xa9!");
+
+	// 引数の文字コードとヘッダー内の文字コードが異なる場合は変換しない
+	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source1.c_str(), source1.length(), &m, CODE_UTF8));
+	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), source1.c_str());
+
+	// 対応していない文字コードなら変換しない
+	std::string source4("From: =?utf-7?B?+MLUwrzDp-");
+	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source4.c_str(), source4.length(), &m, CODE_UTF7));
+	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), source4.c_str());
+
+	// 謎の符号化方式が指定されていたら何もしない
+	std::string source5("From: =?iso-2022-jp?X?GyRCJTUlLyVpGyhC?=");
+	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source5.c_str(), source5.length(), &m, CODE_JIS));
+	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), source5.c_str());
+
+	// 末尾の ?= がなければ変換しない
+	std::string source6("From: =?iso-2022-jp?B?GyRCJTUlLyVpGyhC");
+	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source6.c_str(), source6.length(), &m, CODE_JIS));
+	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), source6.c_str());
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -107,6 +107,7 @@
   <ItemGroup>
     <ClCompile Include="code-main.cpp" />
     <ClCompile Include="test-cclipboard.cpp" />
+    <ClCompile Include="test-ccodebase.cpp" />
     <ClCompile Include="test-ccommandline.cpp" />
     <ClCompile Include="test-cconvert.cpp" />
     <ClCompile Include="test-cdecode.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -119,6 +119,9 @@
     <ClCompile Include="test-cdecode.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-ccodebase.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
# PR の目的

CCodeBase::MIMEHeaderDecode に対するテストを追加します。

## カテゴリ

- その他の問題

## PR のメリット

- コードカバレッジが向上します。

## PR の影響範囲

動作を変更するものではありません。

## 参考資料

[RFC 2047](https://tools.ietf.org/html/rfc2047)