### PR TITLE
バックアップで詳細$0～$9指定を使いMAX_PATH近いパスを保存しようとすると落ちる不具合を修正

### DIFF
--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -502,10 +502,8 @@ bool CBackupAgent::FormatBackUpPath(
 							if (STRUNCATE == wcsncat_s(szNewPath, newPathCount, q2, _TRUNCATE)) {
 								return false;
 							}
-							if( folders[*q-L'0'] != 0 ){
-								if (STRUNCATE == wcsncat_s(szNewPath, newPathCount, folders[*q - L'0'], _TRUNCATE)) {
-									return false;
-								}
+							if (folders[*q-L'0'] != 0 && STRUNCATE == wcsncat_s(szNewPath, newPathCount, folders[*q - L'0'], _TRUNCATE)) {
+								return false;
 							}
 							q2 = q+1;
 						}

--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -502,7 +502,7 @@ bool CBackupAgent::FormatBackUpPath(
 							if (STRUNCATE == wcsncat_s(szNewPath, newPathCount, q2, _TRUNCATE)) {
 								return false;
 							}
-							if (folders[*q-L'0'] != 0 && STRUNCATE == wcsncat_s(szNewPath, newPathCount, folders[*q - L'0'], _TRUNCATE)) {
+							if (folders[*q-L'0'] != nullptr && STRUNCATE == wcsncat_s(szNewPath, newPathCount, folders[*q - L'0'], _TRUNCATE)) {
 								return false;
 							}
 							q2 = q+1;

--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -499,25 +499,22 @@ bool CBackupAgent::FormatBackUpPath(
 						}
 						if( isdigit(*q) ){
 							q[-1] = L'\0';
-							wcscat( szNewPath, q2 );
-//							if( newPathCount <  auto_strlcat( szNewPath, q2, newPathCount ) ){
-//								return false;
-//							}
+							if (STRUNCATE == wcsncat_s(szNewPath, newPathCount, q2, _TRUNCATE)) {
+								return false;
+							}
 							if( folders[*q-L'0'] != 0 ){
-								wcscat( szNewPath, folders[*q-L'0'] );
-//								if( newPathCount < auto_strlcat( szNewPath, folders[*q-L'0'], newPathCount ) ){
-//									return false;
-//								}
+								if (STRUNCATE == wcsncat_s(szNewPath, newPathCount, folders[*q - L'0'], _TRUNCATE)) {
+									return false;
+								}
 							}
 							q2 = q+1;
 						}
 					}
 					++q;
 				}
-				wcscat( szNewPath, q2 );
-//				if( newPathCount < auto_strlcat( szNewPath, q2, newPathCount ) ){
-//					return false;
-//				}
+				if (STRUNCATE == wcsncat_s(szNewPath, newPathCount, q2, _TRUNCATE)) {
+					return false;
+				}
 			}
 		}
 		{


### PR DESCRIPTION
タイトルの通りです。

# <!-- 必須 --> PR の目的
バックアップをしようとすると落ちる不具合の修正です。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景
異常終了は減らしたいです。

## <!-- 自明なら省略可 --> PR のメリット
バックアップで不用意に落ちなくなります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
特にないです。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
ソースコード上では、auto_strlcatによるコメントが書かれていましたが、この箇所でMAX_PATHを超えると、サクラエディタが強制終了することがあります。

## <!-- わかる範囲で --> PR の影響範囲
バックアップのファイル名作成の範囲でエラーになります。

## <!-- 必須 --> テスト内容
### テスト1

手順
「バックアップ」を有効にして「詳細設定」を選び「`$0_back_long_long_name.*`」等と入力します。
「指定フォルダに作成する」で「.\skrtmp」等とファイルに対して有効な260ぎりぎりのパスを入力しておきます。
`C:\Users\abc\Documents\git\sakuratmp\test_long_path\long_245_path_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa012345\b.txt`
などのファイルパスに対して、バックアップ作成を実行します。
「元ファイルのフォルダ+サブフォルダ」が有効なパスの場合で、
元ファイルのフォルダ+サブフォルダのパス+新ファイル名が260を超えると、バッファオーバーランが発生します。

パッチ適用後は、wcsncat_sで検出されて、エラー画面が正常に表示されるようになります。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
