### PR TITLE
TABバーのリソース文字列の英語dll対応漏れを修正する

### DIFF
--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -1524,14 +1524,12 @@ LRESULT CTabWnd::OnMouseMove( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				}
 				else
 				{
-					::LoadString( GetAppInstance(), F_GROUPCLOSE, szText, _countof(szText) );
-					szText[_countof(szText) - 1] = L'\0';
+					wcsncpy_s(szText, LS(F_GROUPCLOSE), _TRUNCATE);
 				}
 			}
 			else
 			{
-				::LoadString( GetAppInstance(), F_EXITALLEDITORS, szText, _countof(szText) );
-				szText[_countof(szText) - 1] = L'\0';
+					wcsncpy_s(szText, LS(F_EXITALLEDITORS), _TRUNCATE);
 			}
 		}
 	}


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
タブバーの右上の「×」または「××」ボタンのツールチップが日本語リソース直読みで、英語未対応だったのを、修正します。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景
日本語のままなのが気になりました。

## <!-- 自明なら省略可 --> PR のメリット
バグが減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
おそらく特にはないです。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
なぜかここだけ実行ファイルのインスタンスから`LoadString`直書きだったので、他と同じようにLS経由で文字列を取得するように変更しました。

## <!-- わかる範囲で --> PR の影響範囲
タブの右上ボタンのツールチップの表示のみです。

## <!-- 必須 --> テスト内容
(こういうのは自動テスト難しいですね)

### テスト1
手順
・`共通設定`の`タブバー`タブの'`タブバーを表示する`をONにします。
・`ウィンドウ`タブで言語を「`English(United State)`」にします。
・`ウィンドウをまとめてグループ化する(Tab-Group uses common window)`をONにします。
　`ウィンドウの閉じるボタンは現在のファイルのみ閉じる(Closing main window closes only the active file)`をONにします。
　一度確定して表示を確認します。
　→右上が[XX]になりツールチップが「グループを閉じる(Group Close)」になります。修正前は英語にしても日本語で表示されていました。

・`ウィンドウをまとめてグループ化する`をOFFにして、タブ右上のツールチップを確認します。
　→右上が[XX]になりツールチップが「編集の全終了(Quit All Editors)」になります。修正前は英語にしても日本語で表示されていました。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料

