### PR TITLE
ヘルプのJScriptサンプルのInsTextに()がなかったのを修正

### DIFF
--- a/help/sakura/res/HLP000270.html
+++ b/help/sakura/res/HLP000270.html
@@ -34,7 +34,7 @@ Editor.InsText(<span class="codestr">'&lt;br /&gt;'</span>);<br>
 Editor.InsText(<span class="codestr">"&lt;br /&gt;"</span>);<br>
 InsText(<span class="codestr">"&lt;br /&gt;"</span>);<br>
 var str = Editor.<a href="HLP000284.html">ExpandParameter</a>(<span class="codestr">"$f($x,$y)\r\n"</span>);<br>
-Editor.InsText str;<br>
+Editor.InsText(str);<br>
 Editor.ExecCommand(<span class="codestr">'dir /b'</span>, 3);<br>
 </div><br>
 ■例3: WSH(VBScript)<br>


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->
HTMLヘルプに載っている、JScriptのサンプルでInsTextがVBScript風になっていて()がないため実行するとエラーになる誤記を修正します。

# <!-- 必須 --> PR の目的
ヘルプの誤記を修正したいです。

## <!-- 必須 --> カテゴリ
- ドキュメント修正
## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

JScriptではfunctionの呼び出しには()が必要です。

## <!-- わかる範囲で --> PR の影響範囲
ヘルプファイルのみです。

## <!-- 必須 --> テスト内容

### テスト1
変更後、修正したHTMLを表示してみます。
