### PR TITLE
ファイルダイアログとフォルダ選択ダイアログでのバッファオーバーランを修正

### DIFF
--- a/sakura_core/CFileExt.cpp
+++ b/sakura_core/CFileExt.cpp
@@ -37,7 +37,6 @@
 
 CFileExt::CFileExt()
 {
-	m_puFileExtInfo = NULL;
 	m_nCount = 0;
 	m_vstrFilter.resize( 1 );
 	m_vstrFilter[0] = L'\0';
@@ -49,14 +48,12 @@ CFileExt::CFileExt()
 
 CFileExt::~CFileExt()
 {
-	if( m_puFileExtInfo ) free( m_puFileExtInfo );
-	m_puFileExtInfo = NULL;
 	m_nCount = 0;
 }
 
 bool CFileExt::AppendExt( const WCHAR *pszName, const WCHAR *pszExt )
 {
-	WCHAR	szWork[_countof(m_puFileExtInfo[0].m_szExt) + 10];
+	WCHAR	szWork[MAX_PATH];
 
 	if( !CDocTypeManager::ConvertTypesExtToDlgExt( pszExt, NULL, szWork ) ) return false;
 	return AppendExtRaw( pszName, szWork );
@@ -64,26 +61,15 @@ bool CFileExt::AppendExt( const WCHAR *pszName, const WCHAR *pszExt )
 
 bool CFileExt::AppendExtRaw( const WCHAR *pszName, const WCHAR *pszExt )
 {
-	FileExtInfoTag	*p;
-
 	if( NULL == pszName || pszName[0] == L'\0' ) return false;
 	if( NULL == pszExt  || pszExt[0] == L'\0' ) return false;
 
-	if( NULL == m_puFileExtInfo )
-	{
-		p = (FileExtInfoTag*)malloc( sizeof( FileExtInfoTag ) * 1 );
-		if( NULL == p ) return false;
-	}
-	else
-	{
-		p = (FileExtInfoTag*)realloc( m_puFileExtInfo, sizeof( FileExtInfoTag ) * ( m_nCount + 1 ) );
-		if( NULL == p ) return false;
-	}
-	m_puFileExtInfo = p;
+	SFileExtInfo info;
+	info.m_sTypeName = pszName;
+	info.m_sExt = pszExt;
 
-	wcscpy( m_puFileExtInfo[m_nCount].m_szName, pszName );
-	wcscpy( m_puFileExtInfo[m_nCount].m_szExt, pszExt );
-	m_nCount++;
+	m_vFileExtInfo.push_back(std::move(info));
+	m_nCount = static_cast<int>(m_vFileExtInfo.size());
 
 	return true;
 }
@@ -92,14 +78,14 @@ const WCHAR *CFileExt::GetName( int nIndex )
 {
 	if( nIndex < 0 || nIndex >= m_nCount ) return NULL;
 
-	return m_puFileExtInfo[nIndex].m_szName;
+	return m_vFileExtInfo[nIndex].m_sTypeName.c_str();
 }
 
 const WCHAR *CFileExt::GetExt( int nIndex )
 {
 	if( nIndex < 0 || nIndex >= m_nCount ) return NULL;
 
-	return m_puFileExtInfo[nIndex].m_szExt;
+	return m_vFileExtInfo[nIndex].m_sExt.c_str();
 }
 
 const WCHAR *CFileExt::GetExtFilter( void )
@@ -113,12 +99,12 @@ const WCHAR *CFileExt::GetExtFilter( void )
 	for( i = 0; i < m_nCount; i++ )
 	{
 		// "%s (%s)\0%s\0"
-		work = m_puFileExtInfo[i].m_szName;
+		work = m_vFileExtInfo[i].m_sTypeName;
 		work.append(L" (");
-		work.append(m_puFileExtInfo[i].m_szExt);
+		work.append(m_vFileExtInfo[i].m_sExt);
 		work.append(L")");
 		work.append(L"\0", 1);
-		work.append(m_puFileExtInfo[i].m_szExt);
+		work.append(m_vFileExtInfo[i].m_sExt);
 		work.append(L"\0", 1);
 
 		int i = (int)m_vstrFilter.size();

--- a/sakura_core/CFileExt.cpp
+++ b/sakura_core/CFileExt.cpp
@@ -47,9 +47,10 @@ CFileExt::CFileExt()
 
 bool CFileExt::AppendExt( const WCHAR *pszName, const WCHAR *pszExt )
 {
-	std::wstring workExt;
-
-	if( !CDocTypeManager::ConvertTypesExtToDlgExt( pszExt, nullptr, workExt ) ) return false;
+	std::wstring workExt = CDocTypeManager::ConvertTypesExtToDlgExt(pszExt, nullptr);
+	if (workExt.empty()) {
+		return false;
+	}
 	return AppendExtRaw( pszName, workExt.c_str() );
 }
 

--- a/sakura_core/CFileExt.cpp
+++ b/sakura_core/CFileExt.cpp
@@ -83,11 +83,17 @@ const WCHAR *CFileExt::GetExt( int nIndex )
 
 const WCHAR *CFileExt::GetExtFilter( void )
 {
+	CreateExtFilter(m_vstrFilter);
+	return m_vstrFilter.data();
+}
+
+void CFileExt::CreateExtFilter(std::vector<WCHAR>& output) const
+{
 	int		i;
 	std::wstring work;
 
 	/* 拡張子フィルタの作成 */
-	m_vstrFilter.resize(0);
+	output.resize(0);
 
 	for( i = 0; i < GetCount(); i++ )
 	{
@@ -100,14 +106,12 @@ const WCHAR *CFileExt::GetExtFilter( void )
 		work.append(m_vFileExtInfo[i].m_sExt);
 		work.append(L"\0", 1);
 
-		int i = (int)m_vstrFilter.size();
-		m_vstrFilter.resize( i + work.length() );
-		wmemcpy( &m_vstrFilter[i], &work[0], work.length() );
+		int pos = static_cast<int>(output.size());
+		output.resize(pos + work.length());
+		wmemcpy(&output[pos], &work[0], work.length());
 	}
 	if( 0 == GetCount() ){
-		m_vstrFilter.push_back( L'\0' );
+		output.push_back( L'\0' );
 	}
-	m_vstrFilter.push_back( L'\0' );
-
-	return &m_vstrFilter[0];
+	output.push_back( L'\0' );
 }

--- a/sakura_core/CFileExt.cpp
+++ b/sakura_core/CFileExt.cpp
@@ -47,10 +47,10 @@ CFileExt::CFileExt()
 
 bool CFileExt::AppendExt( const WCHAR *pszName, const WCHAR *pszExt )
 {
-	WCHAR	szWork[MAX_PATH];
+	std::wstring workExt;
 
-	if( !CDocTypeManager::ConvertTypesExtToDlgExt( pszExt, NULL, szWork ) ) return false;
-	return AppendExtRaw( pszName, szWork );
+	if( !CDocTypeManager::ConvertTypesExtToDlgExt( pszExt, NULL, workExt ) ) return false;
+	return AppendExtRaw( pszName, workExt.c_str() );
 }
 
 bool CFileExt::AppendExtRaw( const WCHAR *pszName, const WCHAR *pszExt )

--- a/sakura_core/CFileExt.cpp
+++ b/sakura_core/CFileExt.cpp
@@ -49,7 +49,7 @@ bool CFileExt::AppendExt( const WCHAR *pszName, const WCHAR *pszExt )
 {
 	std::wstring workExt;
 
-	if( !CDocTypeManager::ConvertTypesExtToDlgExt( pszExt, NULL, workExt ) ) return false;
+	if( !CDocTypeManager::ConvertTypesExtToDlgExt( pszExt, nullptr, workExt ) ) return false;
 	return AppendExtRaw( pszName, workExt.c_str() );
 }
 
@@ -69,14 +69,14 @@ bool CFileExt::AppendExtRaw( const WCHAR *pszName, const WCHAR *pszExt )
 
 const WCHAR *CFileExt::GetName( int nIndex )
 {
-	if( nIndex < 0 || nIndex >= GetCount() ) return NULL;
+	if( nIndex < 0 || nIndex >= GetCount() ) return nullptr;
 
 	return m_vFileExtInfo[nIndex].m_sTypeName.c_str();
 }
 
 const WCHAR *CFileExt::GetExt( int nIndex )
 {
-	if( nIndex < 0 || nIndex >= GetCount() ) return NULL;
+	if( nIndex < 0 || nIndex >= GetCount() ) return nullptr;
 
 	return m_vFileExtInfo[nIndex].m_sExt.c_str();
 }
@@ -89,13 +89,12 @@ const WCHAR *CFileExt::GetExtFilter( void )
 
 void CFileExt::CreateExtFilter(std::vector<WCHAR>& output) const
 {
-	int		i;
 	std::wstring work;
 
 	/* 拡張子フィルタの作成 */
 	output.resize(0);
 
-	for( i = 0; i < GetCount(); i++ )
+	for (int i = 0; i < GetCount(); i++)
 	{
 		// "%s (%s)\0%s\0"
 		work = m_vFileExtInfo[i].m_sTypeName;
@@ -106,7 +105,7 @@ void CFileExt::CreateExtFilter(std::vector<WCHAR>& output) const
 		work.append(m_vFileExtInfo[i].m_sExt);
 		work.append(L"\0", 1);
 
-		int pos = static_cast<int>(output.size());
+		size_t pos = output.size();
 		output.resize(pos + work.length());
 		wmemcpy(&output[pos], &work[0], work.length());
 	}

--- a/sakura_core/CFileExt.cpp
+++ b/sakura_core/CFileExt.cpp
@@ -37,18 +37,12 @@
 
 CFileExt::CFileExt()
 {
-	m_nCount = 0;
 	m_vstrFilter.resize( 1 );
 	m_vstrFilter[0] = L'\0';
 
 //	//テキストエディタとして、既定でリストに載ってほしい拡張子
 //	AppendExt( "すべてのファイル", "*" );
 //	AppendExt( "テキストファイル", "txt" );
-}
-
-CFileExt::~CFileExt()
-{
-	m_nCount = 0;
 }
 
 bool CFileExt::AppendExt( const WCHAR *pszName, const WCHAR *pszExt )
@@ -69,21 +63,20 @@ bool CFileExt::AppendExtRaw( const WCHAR *pszName, const WCHAR *pszExt )
 	info.m_sExt = pszExt;
 
 	m_vFileExtInfo.push_back(std::move(info));
-	m_nCount = static_cast<int>(m_vFileExtInfo.size());
 
 	return true;
 }
 
 const WCHAR *CFileExt::GetName( int nIndex )
 {
-	if( nIndex < 0 || nIndex >= m_nCount ) return NULL;
+	if( nIndex < 0 || nIndex >= GetCount() ) return NULL;
 
 	return m_vFileExtInfo[nIndex].m_sTypeName.c_str();
 }
 
 const WCHAR *CFileExt::GetExt( int nIndex )
 {
-	if( nIndex < 0 || nIndex >= m_nCount ) return NULL;
+	if( nIndex < 0 || nIndex >= GetCount() ) return NULL;
 
 	return m_vFileExtInfo[nIndex].m_sExt.c_str();
 }
@@ -96,7 +89,7 @@ const WCHAR *CFileExt::GetExtFilter( void )
 	/* 拡張子フィルタの作成 */
 	m_vstrFilter.resize(0);
 
-	for( i = 0; i < m_nCount; i++ )
+	for( i = 0; i < GetCount(); i++ )
 	{
 		// "%s (%s)\0%s\0"
 		work = m_vFileExtInfo[i].m_sTypeName;
@@ -111,7 +104,7 @@ const WCHAR *CFileExt::GetExtFilter( void )
 		m_vstrFilter.resize( i + work.length() );
 		wmemcpy( &m_vstrFilter[i], &work[0], work.length() );
 	}
-	if( 0 == m_nCount ){
+	if( 0 == GetCount() ){
 		m_vstrFilter.push_back( L'\0' );
 	}
 	m_vstrFilter.push_back( L'\0' );

--- a/sakura_core/CFileExt.cpp
+++ b/sakura_core/CFileExt.cpp
@@ -35,16 +35,6 @@
 #include "CFileExt.h"
 #include "env/CDocTypeManager.h"
 
-CFileExt::CFileExt()
-{
-	m_vstrFilter.resize( 1 );
-	m_vstrFilter[0] = L'\0';
-
-//	//テキストエディタとして、既定でリストに載ってほしい拡張子
-//	AppendExt( "すべてのファイル", "*" );
-//	AppendExt( "テキストファイル", "txt" );
-}
-
 bool CFileExt::AppendExt( const WCHAR *pszName, const WCHAR *pszExt )
 {
 	std::wstring workExt = CDocTypeManager::ConvertTypesExtToDlgExt(pszExt, nullptr);

--- a/sakura_core/CFileExt.h
+++ b/sakura_core/CFileExt.h
@@ -60,13 +60,13 @@ protected:
 
 private:
 
-	typedef struct {
-		WCHAR	m_szName[64];		//名前(64文字以下のはず→m_szTypeName)
-		WCHAR	m_szExt[MAX_TYPES_EXTS*3+1];	//拡張子(64文字以下のはず→m_szTypeExts) なお "*." を追加するのでそれなりに必要
-	} FileExtInfoTag;
+	struct SFileExtInfo {
+		std::wstring	m_sTypeName;	//名前
+		std::wstring	m_sExt;			//拡張子
+	};
 
 	int				m_nCount;
-	FileExtInfoTag	*m_puFileExtInfo;
+	std::vector<SFileExtInfo>	m_vFileExtInfo;
 	std::vector<WCHAR>	m_vstrFilter;
 
 	DISALLOW_COPY_AND_ASSIGN(CFileExt);

--- a/sakura_core/CFileExt.h
+++ b/sakura_core/CFileExt.h
@@ -52,7 +52,7 @@ public:
 	//2回呼び出すと古いバッファが無効になることがあるのに注意
 	const WCHAR *GetExtFilter( void );
 
-	int GetCount() const { return static_cast<int>(m_vFileExtInfo.size()); }
+	[[nodiscard]] int GetCount() const { return static_cast<int>(m_vFileExtInfo.size()); }
 
 protected:
 	// 2014.10.30 syat ConvertTypesExtToDlgExtをCDocTypeManagerに移動

--- a/sakura_core/CFileExt.h
+++ b/sakura_core/CFileExt.h
@@ -40,8 +40,7 @@
 class CFileExt
 {
 public:
-	CFileExt();
-	~CFileExt() = default;
+	CFileExt() = default;
 
 	bool AppendExt( const WCHAR *pszName, const WCHAR *pszExt );
 	bool AppendExtRaw( const WCHAR *pszName, const WCHAR *pszExt );

--- a/sakura_core/CFileExt.h
+++ b/sakura_core/CFileExt.h
@@ -41,7 +41,7 @@ class CFileExt
 {
 public:
 	CFileExt();
-	~CFileExt();
+	~CFileExt() = default;
 
 	bool AppendExt( const WCHAR *pszName, const WCHAR *pszExt );
 	bool AppendExtRaw( const WCHAR *pszName, const WCHAR *pszExt );
@@ -52,7 +52,7 @@ public:
 	//2回呼び出すと古いバッファが無効になることがあるのに注意
 	const WCHAR *GetExtFilter( void );
 
-	int GetCount( void ) { return m_nCount; }
+	int GetCount() const { return static_cast<int>(m_vFileExtInfo.size()); }
 
 protected:
 	// 2014.10.30 syat ConvertTypesExtToDlgExtをCDocTypeManagerに移動
@@ -65,7 +65,6 @@ private:
 		std::wstring	m_sExt;			//拡張子
 	};
 
-	int				m_nCount;
 	std::vector<SFileExtInfo>	m_vFileExtInfo;
 	std::vector<WCHAR>	m_vstrFilter;
 

--- a/sakura_core/CFileExt.h
+++ b/sakura_core/CFileExt.h
@@ -59,6 +59,7 @@ protected:
 	//bool ConvertTypesExtToDlgExt( const WCHAR *pszSrcExt, WCHAR *pszDstExt );
 
 private:
+	void CreateExtFilter(std::vector<WCHAR>& output) const;
 
 	struct SFileExtInfo {
 		std::wstring	m_sTypeName;	//名前

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -739,7 +739,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 		break;
 	}
 
-	if( 0 != wcscmp(m_strDefaultWildCard.c_str(), L"*.*") ){
+	if (m_strDefaultWildCard != L"*.*") {
 		cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME3), L"*.*" );
 	}
 

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -93,7 +93,7 @@ struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
 
 	DLLSHAREDATA*	m_pShareData;
 
-	std::wstring	m_strDefaultWildCard;	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
+	std::wstring	m_strDefaultWildCard{ L"*.*" };	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 	SFilePath		m_szInitialDir;			/* 「開く」での初期ディレクトリ */
 
 	std::vector<LPCWSTR>	m_vMRU;
@@ -649,7 +649,6 @@ int AddComboCodePages(HWND hdlg, HWND combo, int nSelCode, bool& bInit)
 	@date 2008.05.05 novice GetModuleHandle(NULL)→NULLに変更
 */
 CDlgOpenFile_CommonFileDialog::CDlgOpenFile_CommonFileDialog()
- :m_strDefaultWildCard(L"*.*")	//「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される）
 {
 	m_hInstance = NULL;		/* アプリケーションインスタンスのハンドル */
 	m_hwndParent = NULL;	/* オーナーウィンドウのハンドル */

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -93,7 +93,7 @@ struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
 
 	DLLSHAREDATA*	m_pShareData;
 
-	SFilePath		m_szDefaultWildCard;	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
+	std::wstring	m_strDefaultWildCard;	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 	SFilePath		m_szInitialDir;			/* 「開く」での初期ディレクトリ */
 
 	std::vector<LPCWSTR>	m_vMRU;
@@ -418,7 +418,7 @@ UINT_PTR CALLBACK OFNHookProc(
 						else{
 							switch( pData->m_pOf->nFilterIndex ){	// 選択されているファイルの種類
 							case 1:		// ユーザー定義
-								pszCur = pData->m_pcDlgOpenFile->m_szDefaultWildCard;
+								pszCur = pData->m_pcDlgOpenFile->m_strDefaultWildCard.data();
 								while( *pszCur != L'.' && *pszCur != L'\0' )	// '.'まで読み飛ばす
 									pszCur = ::CharNext(pszCur);
 								i = 0;
@@ -667,7 +667,7 @@ CDlgOpenFile_CommonFileDialog::CDlgOpenFile_CommonFileDialog()
 	wcscpy( m_szInitialDir, szDrive );
 	wcscat( m_szInitialDir, szDir );
 
-	wcscpy( m_szDefaultWildCard, L"*.*" );	/*「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
+	m_strDefaultWildCard = L"*.*";	/*「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 
 	return;
 }
@@ -687,7 +687,7 @@ void CDlgOpenFile_CommonFileDialog::Create(
 
 	/* ユーザー定義ワイルドカード（保存時の拡張子補完でも使用される） */
 	if( NULL != pszUserWildCard ){
-		wcscpy( m_szDefaultWildCard, pszUserWildCard );
+		m_strDefaultWildCard = pszUserWildCard;
 	}
 
 	/* 「開く」での初期フォルダ */
@@ -722,7 +722,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 
 	//	2003.05.12 MIK
 	CFileExt	cFileExt;
-	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME1), m_szDefaultWildCard );
+	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME1), m_strDefaultWildCard.c_str() );
 
 	switch( eAddFilter ){
 	case EFITER_TEXT:
@@ -740,7 +740,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 		break;
 	}
 
-	if( 0 != wcscmp(m_szDefaultWildCard, L"*.*") ){
+	if( 0 != wcscmp(m_strDefaultWildCard.c_str(), L"*.*") ){
 		cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME3), L"*.*" );
 	}
 
@@ -815,7 +815,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetSaveFileName( WCHAR* pszPath )
 
 	//	2003.05.12 MIK
 	CFileExt	cFileExt;
-	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME1), m_szDefaultWildCard );
+	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME1), m_strDefaultWildCard.c_str() );
 	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME2), L"*.txt" );
 	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME3), L"*.*" );
 	
@@ -979,7 +979,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModalSaveDlg(
 
 	//	2003.05.12 MIK
 	CFileExt	cFileExt;
-	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME1), m_szDefaultWildCard );
+	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME1), m_strDefaultWildCard.c_str() );
 	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME2), L"*.txt" );
 	cFileExt.AppendExtRaw( LS(STR_DLGOPNFL_EXTNAME3), L"*.*" );
 

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -649,6 +649,7 @@ int AddComboCodePages(HWND hdlg, HWND combo, int nSelCode, bool& bInit)
 	@date 2008.05.05 novice GetModuleHandle(NULL)→NULLに変更
 */
 CDlgOpenFile_CommonFileDialog::CDlgOpenFile_CommonFileDialog()
+ :m_strDefaultWildCard(L"*.*")	//「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される）
 {
 	m_hInstance = NULL;		/* アプリケーションインスタンスのハンドル */
 	m_hwndParent = NULL;	/* オーナーウィンドウのハンドル */
@@ -666,8 +667,6 @@ CDlgOpenFile_CommonFileDialog::CDlgOpenFile_CommonFileDialog()
 	_wsplitpath( szFile, szDrive, szDir, NULL, NULL );
 	wcscpy( m_szInitialDir, szDrive );
 	wcscat( m_szInitialDir, szDir );
-
-	m_strDefaultWildCard = L"*.*";	/*「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 
 	return;
 }

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -77,7 +77,7 @@ struct CDlgOpenFile_CommonItemDialog final
 
 	DLLSHAREDATA*	m_pShareData;
 
-	std::wstring	m_strDefaultWildCard;	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
+	std::wstring	m_strDefaultWildCard{ L"*.*" };	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 	SFilePath		m_szInitialDir;			/* 「開く」での初期ディレクトリ */
 
 	std::vector<LPCWSTR>	m_vMRU;

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -484,7 +484,7 @@ bool CDlgOpenFile_CommonItemDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 		break;
 	}
 
-	if( 0 != wcscmp(m_strDefaultWildCard.c_str(), L"*.*") ){
+	if (m_strDefaultWildCard != L"*.*") {
 		strs.push_back(LS(STR_DLGOPNFL_EXTNAME3));
 		specs.push_back(COMDLG_FILTERSPEC{strs.back().c_str(), L"*.*"});
 	}

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -700,15 +700,15 @@ bool CDlgOpenFile_CommonItemDialog::DoModalOpenDlg(
 	specs[1].pszName = strs[1].c_str();
 	specs[1].pszSpec = L"*.txt";
 	CDocTypeManager docTypeMgr;
-	WCHAR szWork[_countof(STypeConfigMini::m_szTypeExts) * 3];
+	std::wstring worksString;
 	for( int i = 0; i < nTypesCount; i++ ){
 		const STypeConfigMini* type = NULL;
 		if( !docTypeMgr.GetTypeConfigMini( CTypeConfig(i), &type ) ){
 			continue;
 		}
 		specs[2 + i].pszName = type->m_szTypeName;
-		if (CDocTypeManager::ConvertTypesExtToDlgExt(type->m_szTypeExts, NULL, szWork)) {
-			strs[2 + i] = szWork;
+		if (CDocTypeManager::ConvertTypesExtToDlgExt(type->m_szTypeExts, NULL, worksString)) {
+			strs[2 + i] = worksString;
 			specs[2 + i].pszSpec = strs[2 + i].c_str();
 		}
 		else {

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -398,6 +398,7 @@ enum CtrlId {
 };
 
 CDlgOpenFile_CommonItemDialog::CDlgOpenFile_CommonItemDialog()
+ :m_strDefaultWildCard(L"*.*")	//「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される）
 {
 	m_hInstance = NULL;		/* アプリケーションインスタンスのハンドル */
 	m_hwndParent = NULL;	/* オーナーウィンドウのハンドル */
@@ -416,7 +417,6 @@ CDlgOpenFile_CommonItemDialog::CDlgOpenFile_CommonItemDialog()
 	wcscpy( m_szInitialDir, szDrive );
 	wcscat( m_szInitialDir, szDir );
 
-	m_strDefaultWildCard = L"*.*";	/*「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 
 	return;
 }

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -398,7 +398,6 @@ enum CtrlId {
 };
 
 CDlgOpenFile_CommonItemDialog::CDlgOpenFile_CommonItemDialog()
- :m_strDefaultWildCard(L"*.*")	//「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される）
 {
 	m_hInstance = NULL;		/* アプリケーションインスタンスのハンドル */
 	m_hwndParent = NULL;	/* オーナーウィンドウのハンドル */

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -707,7 +707,8 @@ bool CDlgOpenFile_CommonItemDialog::DoModalOpenDlg(
 			continue;
 		}
 		specs[2 + i].pszName = type->m_szTypeName;
-		if (CDocTypeManager::ConvertTypesExtToDlgExt(type->m_szTypeExts, NULL, worksString)) {
+		worksString = CDocTypeManager::ConvertTypesExtToDlgExt(type->m_szTypeExts, nullptr);
+		if (!worksString.empty()) {
 			strs[2 + i] = worksString;
 			specs[2 + i].pszSpec = strs[2 + i].c_str();
 		}

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -77,7 +77,7 @@ struct CDlgOpenFile_CommonItemDialog final
 
 	DLLSHAREDATA*	m_pShareData;
 
-	SFilePath		m_szDefaultWildCard;	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
+	std::wstring	m_strDefaultWildCard;	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 	SFilePath		m_szInitialDir;			/* 「開く」での初期ディレクトリ */
 
 	std::vector<LPCWSTR>	m_vMRU;
@@ -416,7 +416,7 @@ CDlgOpenFile_CommonItemDialog::CDlgOpenFile_CommonItemDialog()
 	wcscpy( m_szInitialDir, szDrive );
 	wcscat( m_szInitialDir, szDir );
 
-	wcscpy( m_szDefaultWildCard, L"*.*" );	/*「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
+	m_strDefaultWildCard = L"*.*";	/*「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 
 	return;
 }
@@ -435,7 +435,7 @@ void CDlgOpenFile_CommonItemDialog::Create(
 
 	/* ユーザー定義ワイルドカード（保存時の拡張子補完でも使用される） */
 	if( NULL != pszUserWildCard ){
-		wcscpy( m_szDefaultWildCard, pszUserWildCard );
+		m_strDefaultWildCard = pszUserWildCard;
 	}
 
 	/* 「開く」での初期フォルダ */
@@ -465,7 +465,7 @@ bool CDlgOpenFile_CommonItemDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 	strs.reserve(8);
 
 	strs.push_back(LS(STR_DLGOPNFL_EXTNAME1));
-	specs.push_back(COMDLG_FILTERSPEC{strs.back().c_str(), m_szDefaultWildCard});
+	specs.push_back(COMDLG_FILTERSPEC{strs.back().c_str(), m_strDefaultWildCard.c_str()});
 
 	switch( eAddFilter ){
 	case EFITER_TEXT:
@@ -484,7 +484,7 @@ bool CDlgOpenFile_CommonItemDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 		break;
 	}
 
-	if( 0 != wcscmp(m_szDefaultWildCard, L"*.*") ){
+	if( 0 != wcscmp(m_strDefaultWildCard.c_str(), L"*.*") ){
 		strs.push_back(LS(STR_DLGOPNFL_EXTNAME3));
 		specs.push_back(COMDLG_FILTERSPEC{strs.back().c_str(), L"*.*"});
 	}
@@ -747,7 +747,7 @@ HRESULT CDlgOpenFile_CommonItemDialog::DoModalSaveDlgImpl1(
 	strs[1] = LS(STR_DLGOPNFL_EXTNAME2);
 	strs[2] = LS(STR_DLGOPNFL_EXTNAME3);
 	specs[0].pszName = strs[0].c_str();
-	specs[0].pszSpec = m_szDefaultWildCard;
+	specs[0].pszSpec = m_strDefaultWildCard.c_str();
 	specs[1].pszName = strs[1].c_str();
 	specs[1].pszSpec = L"*.txt";
 	specs[2].pszName = strs[2].c_str();

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -225,7 +225,8 @@ bool CDocFileOperation::SaveFileDialog(
 	//拡張子指定
 	// 一時適用や拡張子なしの場合の拡張子をタイプ別設定から持ってくる
 	// 2008/6/14 大きく改造 Uchi
-	WCHAR	szDefaultWildCard[_MAX_PATH + 10];	// ユーザー指定拡張子
+	std::wstring strDefaultWildCard;	// ユーザー指定拡張子
+	
 	{
 		LPCWSTR	szExt;
 
@@ -241,28 +242,27 @@ bool CDocFileOperation::SaveFileDialog(
 			// 基本
 			if (szExt[0] == L'\0') { 
 				// ファイルパスが無いまたは拡張子なし
-				wcscpy(szDefaultWildCard, L"*.txt");
+				strDefaultWildCard = L"*.txt";
 			}
 			else {
 				// 拡張子あり
-				wcscpy(szDefaultWildCard, L"*");
-				wcscat(szDefaultWildCard, szExt);
+				strDefaultWildCard = L"*";
+				strDefaultWildCard += szExt;
 			}
 		}
 		else {
-			szDefaultWildCard[0] = L'\0'; 
-			CDocTypeManager::ConvertTypesExtToDlgExt(type.m_szTypeExts, szExt, szDefaultWildCard);
+			CDocTypeManager::ConvertTypesExtToDlgExt(type.m_szTypeExts, szExt, strDefaultWildCard);
 		}
 
 		if(!this->m_pcDocRef->m_cDocFile.GetFilePathClass().IsValidPath()){
 			//「新規から保存時は全ファイル表示」オプション	// 2008/6/15 バグフィックス Uchi
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveNew )
-				wcscat(szDefaultWildCard, L";*.*");	// 全ファイル表示
+				strDefaultWildCard += L";*.*";	// 全ファイル表示
 		}
 		else {
 			//「新規以外から保存時は全ファイル表示」オプション
 			if( GetDllShareData().m_Common.m_sFile.m_bNoFilterSaveFile )
-				wcscat(szDefaultWildCard, L";*.*");	// 全ファイル表示
+				strDefaultWildCard += L";*.*";	// 全ファイル表示
 		}
 	}
 
@@ -281,7 +281,7 @@ bool CDocFileOperation::SaveFileDialog(
 	cDlgOpenFile.Create(
 		G_AppInstance(),
 		CEditWnd::getInstance()->GetHwnd(),
-		szDefaultWildCard,
+		strDefaultWildCard.c_str(),
 		CSakuraEnvironment::GetDlgInitialDir().c_str(),	// 初期フォルダ
 		CMRUFile().GetPathList(),		//	最近のファイル
 		CMRUFolder().GetPathList()	//	最近のフォルダ

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -251,7 +251,7 @@ bool CDocFileOperation::SaveFileDialog(
 			}
 		}
 		else {
-			CDocTypeManager::ConvertTypesExtToDlgExt(type.m_szTypeExts, szExt, strDefaultWildCard);
+			strDefaultWildCard = CDocTypeManager::ConvertTypesExtToDlgExt(type.m_szTypeExts, szExt);
 		}
 
 		if(!this->m_pcDocRef->m_cDocFile.GetFilePathClass().IsValidPath()){

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -221,11 +221,11 @@ void CDocTypeManager::GetFirstExt(const WCHAR* pszTypeExts, WCHAR szFirstExt[], 
 
 	@date 2014.12.06 syat CFileExtから移動
 */
-bool CDocTypeManager::ConvertTypesExtToDlgExt(const WCHAR *pszSrcExt, const WCHAR* szExt, std::wstring& destExt)
+std::wstring CDocTypeManager::ConvertTypesExtToDlgExt(const WCHAR *pszSrcExt, const WCHAR* szExt)
 {
-	destExt.resize(0);
+	std::wstring destExt;
 	//	2003.08.14 MIK NULLじゃなくてfalse
-	if( NULL == pszSrcExt ) return false;
+	if( NULL == pszSrcExt ) return L"";
 
 	if (szExt != NULL && szExt[0] != L'\0') {
 		// ファイルパスがあり、拡張子ありの場合、トップに指定
@@ -255,5 +255,5 @@ bool CDocTypeManager::ConvertTypesExtToDlgExt(const WCHAR *pszSrcExt, const WCHA
 		}
 		token = wcstok_s(nullptr, m_typeExtSeps, &context);
 	}
-	return true;
+	return destExt;
 }

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -217,7 +217,7 @@ void CDocTypeManager::GetFirstExt(const WCHAR* pszTypeExts, WCHAR szFirstExt[], 
 /*! タイプ別設定の拡張子リストをダイアログ用リストに変換する
 	@param pszSrcExt [in]  拡張子リスト 例「.c cpp;.h」(ドットはオプション)
 	@param szExt [in] リストの先頭にする拡張子 例「.h」(ドット必須)
-	@param destExt [out] 拡張子リスト 例「*.h;*.c;*.cpp」
+	@return 拡張子リスト 例「*.h;*.c;*.cpp」
 
 	@date 2014.12.06 syat CFileExtから移動
 */

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -215,45 +215,45 @@ void CDocTypeManager::GetFirstExt(const WCHAR* pszTypeExts, WCHAR szFirstExt[], 
 }
 
 /*! タイプ別設定の拡張子リストをダイアログ用リストに変換する
-	@param pszSrcExt [in]  拡張子リスト 例「.c .cpp;.h」
-	@param pszDstExt [out] 拡張子リスト 例「*.c;*.cpp;*.h」
-	@param szExt [in] リストの先頭にする拡張子 例「.h」
+	@param pszSrcExt [in]  拡張子リスト 例「.c cpp;.h」(ドットはオプション)
+	@param szExt [in] リストの先頭にする拡張子 例「.h」(ドット必須)
+	@param destExt [out] 拡張子リスト 例「*.h;*.c;*.cpp」
 
 	@date 2014.12.06 syat CFileExtから移動
 */
-bool CDocTypeManager::ConvertTypesExtToDlgExt( const WCHAR *pszSrcExt, const WCHAR* szExt, WCHAR *pszDstExt )
+bool CDocTypeManager::ConvertTypesExtToDlgExt(const WCHAR *pszSrcExt, const WCHAR* szExt, std::wstring& destExt)
 {
-	WCHAR	*token;
-	WCHAR	*p;
-
+	destExt.resize(0);
 	//	2003.08.14 MIK NULLじゃなくてfalse
 	if( NULL == pszSrcExt ) return false;
-	if( NULL == pszDstExt ) return false;
-
-	p = _wcsdup( pszSrcExt );
-	pszDstExt[0] = L'\0';
 
 	if (szExt != NULL && szExt[0] != L'\0') {
 		// ファイルパスがあり、拡張子ありの場合、トップに指定
-		wcscpy(pszDstExt, L"*");
-		wcscat(pszDstExt, szExt);
+		destExt.assign(L"*");
+		destExt.append(szExt);
 	}
 
-	token = _wcstok(p, m_typeExtSeps);
+	std::wstring strSrcTokens = pszSrcExt;
+	WCHAR* context = nullptr;
+	WCHAR* token = wcstok_s(strSrcTokens.data(), m_typeExtSeps, &context);
 	while( token )
 	{
 		if (szExt == NULL || szExt[0] == L'\0' || wmemicmp(token, szExt + 1) != 0) {
-			if( pszDstExt[0] != '\0' ) wcscat( pszDstExt, L";" );
+			if (0 < destExt.length()) {
+				destExt.append(L";");
+			}
 			// 拡張子指定なし、またはマッチした拡張子でない
 			if (wcspbrk(token, m_typeExtWildcards) == NULL) {
-				if (L'.' == *token) wcscat(pszDstExt, L"*");
-				else                 wcscat(pszDstExt, L"*.");
+				if (L'.' == *token) {
+					destExt.append(L"*");
+				}
+				else {
+					destExt.append(L"*.");
+				}
 			}
-			wcscat(pszDstExt, token);
+			destExt.append(token);
 		}
-
-		token = _wcstok( NULL, m_typeExtSeps );
+		token = wcstok_s(nullptr, m_typeExtSeps, &context);
 	}
-	free( p );	// 2003.05.20 MIK メモリ解放漏れ
 	return true;
 }

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -223,10 +223,10 @@ void CDocTypeManager::GetFirstExt(const WCHAR* pszTypeExts, WCHAR szFirstExt[], 
 */
 std::wstring CDocTypeManager::ConvertTypesExtToDlgExt(const WCHAR *pszSrcExt, const WCHAR* szExt)
 {
-	std::wstring destExt;
 	//	2003.08.14 MIK NULLじゃなくてfalse
-	if( NULL == pszSrcExt ) return L"";
+	if (pszSrcExt == nullptr) return L"";
 
+	std::wstring destExt;
 	if (szExt != NULL && szExt[0] != L'\0') {
 		// ファイルパスがあり、拡張子ありの場合、トップに指定
 		destExt.assign(L"*");

--- a/sakura_core/env/CDocTypeManager.h
+++ b/sakura_core/env/CDocTypeManager.h
@@ -51,7 +51,7 @@ public:
 
 	static bool IsFileNameMatch(const WCHAR* pszTypeExts, const WCHAR* pszFileName);	// タイプ別拡張子にファイル名がマッチするか
 	static void GetFirstExt(const WCHAR* pszTypeExts, WCHAR szFirstExt[], int nBuffSize);	// タイプ別拡張子の先頭拡張子を取得する
-	static bool ConvertTypesExtToDlgExt(const WCHAR *pszSrcExt, const WCHAR* szExt, std::wstring& destExt);	// タイプ別設定の拡張子リストをダイアログ用リストに変換する
+	static std::wstring ConvertTypesExtToDlgExt(const WCHAR *pszSrcExt, const WCHAR* szExt);	// タイプ別設定の拡張子リストをダイアログ用リストに変換する
 
 	static const WCHAR* m_typeExtSeps;			// タイプ別拡張子の区切り文字
 	static const WCHAR* m_typeExtWildcards;		// タイプ別拡張子のワイルドカード

--- a/sakura_core/env/CDocTypeManager.h
+++ b/sakura_core/env/CDocTypeManager.h
@@ -51,7 +51,7 @@ public:
 
 	static bool IsFileNameMatch(const WCHAR* pszTypeExts, const WCHAR* pszFileName);	// タイプ別拡張子にファイル名がマッチするか
 	static void GetFirstExt(const WCHAR* pszTypeExts, WCHAR szFirstExt[], int nBuffSize);	// タイプ別拡張子の先頭拡張子を取得する
-	static bool ConvertTypesExtToDlgExt( const WCHAR *pszSrcExt, const WCHAR* szExt, WCHAR *pszDstExt );	// タイプ別設定の拡張子リストをダイアログ用リストに変換する
+	static bool ConvertTypesExtToDlgExt(const WCHAR *pszSrcExt, const WCHAR* szExt, std::wstring& destExt);	// タイプ別設定の拡張子リストをダイアログ用リストに変換する
 
 	static const WCHAR* m_typeExtSeps;			// タイプ別拡張子の区切り文字
 	static const WCHAR* m_typeExtWildcards;		// タイプ別拡張子のワイルドカード

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1888,10 +1888,6 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			if (MAX_PATH <= sDefault.length()) {
 				return false;
 			}
-			// sFilterの先はSFilePath型
-			if (MAX_PATH <= sFilter.length()) {
-				return false;
-			}
 
 			CDlgOpenFile cDlgOpenFile;
 			cDlgOpenFile.Create(

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1884,6 +1884,14 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 				sFilter = Source;	// フィルタ文字列
 				delete[] Source;
 			}
+			// sDefaultの先はSFilePath型
+			if (MAX_PATH <= sDefault.length()) {
+				return false;
+			}
+			// sFilterの先はSFilePath型
+			if (MAX_PATH <= sFilter.length()) {
+				return false;
+			}
 
 			CDlgOpenFile cDlgOpenFile;
 			cDlgOpenFile.Create(
@@ -1928,6 +1936,10 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 				Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 				sDefault = Source;	// 既定のファイル名
 				delete[] Source;
+			}
+			// sDefaultは[MAX_PATH]
+			if (MAX_PATH <= sDefault.length()) {
+				return false;
 			}
 
 			WCHAR szPath[ _MAX_PATH ];

--- a/tests/unittests/test-cdlgopenfile.cpp
+++ b/tests/unittests/test-cdlgopenfile.cpp
@@ -1,0 +1,126 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+#ifndef STRICT
+#define STRICT 1
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+#include <vector>
+#include <tchar.h>
+#include <Windows.h>
+#include "util/design_template.h"
+#include "dlg/CDlgOpenFile.h"
+
+extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog();
+extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonItemDialog();
+
+TEST(CDlgOpenFile, Construct)
+{
+	CDlgOpenFile cDlgOpenFile;
+}
+
+TEST(CDlgOpenFile, CommonItemDialogCreate)
+{
+	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonItemDialog();
+	impl->Create(
+		GetModuleHandle(nullptr),
+		nullptr,
+		L"*.txt",
+		L"C:\\Windows",
+		std::vector<LPCWSTR>(),
+		std::vector<LPCWSTR>()
+	);
+}
+
+TEST(CDlgOpenFile, CommonFileDialogCreate)
+{
+	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonFileDialog();
+	impl->Create(
+		GetModuleHandle(nullptr),
+		nullptr,
+		L"*.txt",
+		L"C:\\Windows",
+		std::vector<LPCWSTR>(),
+		std::vector<LPCWSTR>()
+	);
+}
+
+TEST(CDlgOpenFile, CommonItemDialogDefaltFilterLong)
+{
+	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonItemDialog();
+	// 落ちたり例外にならないこと
+	impl->Create(
+		GetModuleHandle(nullptr),
+		nullptr,
+		L".extension_250_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_LONG",
+		L"C:\\Windows",
+		std::vector<LPCWSTR>(),
+		std::vector<LPCWSTR>()
+	);
+}
+
+TEST(CDlgOpenFile, CommonFileDialogDefaltFilterLong)
+{
+	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonFileDialog();
+	// 落ちたり例外にならないこと
+	impl->Create(
+		GetModuleHandle(nullptr),
+		nullptr,
+		L"*.extension_250_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_LONG",
+		L"C:\\Windows",
+		std::vector<LPCWSTR>(),
+		std::vector<LPCWSTR>()
+	);
+}
+
+TEST(CDlgOpenFile, CommonFileDialogDefaltFilterMany)
+{
+	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonFileDialog();
+	// 落ちたり例外にならないこと
+	impl->Create(
+		GetModuleHandle(nullptr),
+		nullptr,
+		L"*.extension_50_0_long_long_long_long_long_long_LONG;*.extension_50_1_long_long_long_long_long_long_LONG;*.extension_50_2_long_long_long_long_long_long_LONG;*.extension_50_3_long_long_long_long_long_long_LONG;*.extension_50_4_long_long_long_long_long_long_LONG;*.extension_50_5_long_long_long_long_long_long_LONG;*.extension_50_6_long_long_long_long_long_long_LONG;*.extension_50_7_long_long_long_long_long_long_LONG;*.extension_50_8_long_long_long_long_long_long_LONG;*.extension_50_9_long_long_long_long_long_long_LONG",
+		L"C:\\Windows",
+		std::vector<LPCWSTR>(),
+		std::vector<LPCWSTR>()
+	);
+}
+
+TEST(CDlgOpenFile, CommonItemDialogDefaltFilterMany)
+{
+	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonItemDialog();
+	// 落ちたり例外にならないこと
+	impl->Create(
+		GetModuleHandle(nullptr),
+		nullptr,
+		L"*.extension_50_0_long_long_long_long_long_long_LONG;*.extension_50_1_long_long_long_long_long_long_LONG;*.extension_50_2_long_long_long_long_long_long_LONG;*.extension_50_3_long_long_long_long_long_long_LONG;*.extension_50_4_long_long_long_long_long_long_LONG;*.extension_50_5_long_long_long_long_long_long_LONG;*.extension_50_6_long_long_long_long_long_long_LONG;*.extension_50_7_long_long_long_long_long_long_LONG;*.extension_50_8_long_long_long_long_long_long_LONG;*.extension_50_9_long_long_long_long_long_long_LONG",
+		L"C:\\Windows",
+		std::vector<LPCWSTR>(),
+		std::vector<LPCWSTR>()
+	);
+}

--- a/tests/unittests/test-cdlgopenfile.cpp
+++ b/tests/unittests/test-cdlgopenfile.cpp
@@ -43,7 +43,7 @@ TEST(CDlgOpenFile, Construct)
 	CDlgOpenFile cDlgOpenFile;
 }
 
-TEST(CDlgOpenFile, CommonItemDialogCreate)
+TEST(CDlgOpenFile, DISABLED_CommonItemDialogCreate)
 {
 	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonItemDialog();
 	impl->Create(
@@ -56,7 +56,7 @@ TEST(CDlgOpenFile, CommonItemDialogCreate)
 	);
 }
 
-TEST(CDlgOpenFile, CommonFileDialogCreate)
+TEST(CDlgOpenFile, DISABLED_CommonFileDialogCreate)
 {
 	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonFileDialog();
 	impl->Create(
@@ -69,7 +69,7 @@ TEST(CDlgOpenFile, CommonFileDialogCreate)
 	);
 }
 
-TEST(CDlgOpenFile, CommonItemDialogDefaltFilterLong)
+TEST(CDlgOpenFile, DISABLED_CommonItemDialogDefaltFilterLong)
 {
 	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonItemDialog();
 	// 落ちたり例外にならないこと
@@ -83,7 +83,7 @@ TEST(CDlgOpenFile, CommonItemDialogDefaltFilterLong)
 	);
 }
 
-TEST(CDlgOpenFile, CommonFileDialogDefaltFilterLong)
+TEST(CDlgOpenFile, DISABLED_CommonFileDialogDefaltFilterLong)
 {
 	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonFileDialog();
 	// 落ちたり例外にならないこと
@@ -97,7 +97,7 @@ TEST(CDlgOpenFile, CommonFileDialogDefaltFilterLong)
 	);
 }
 
-TEST(CDlgOpenFile, CommonFileDialogDefaltFilterMany)
+TEST(CDlgOpenFile, DISABLED_CommonFileDialogDefaltFilterMany)
 {
 	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonFileDialog();
 	// 落ちたり例外にならないこと
@@ -111,7 +111,7 @@ TEST(CDlgOpenFile, CommonFileDialogDefaltFilterMany)
 	);
 }
 
-TEST(CDlgOpenFile, CommonItemDialogDefaltFilterMany)
+TEST(CDlgOpenFile, DISABLED_CommonItemDialogDefaltFilterMany)
 {
 	std::shared_ptr<IDlgOpenFile>impl = New_CDlgOpenFile_CommonItemDialog();
 	// 落ちたり例外にならないこと

--- a/tests/unittests/test-cdoctypemanager.cpp
+++ b/tests/unittests/test-cdoctypemanager.cpp
@@ -91,6 +91,20 @@ TEST(CDocTypeManager, ConvertTypesExtToDlgExtTopNullptr)
 	EXPECT_EQ(expected, actual);
 }
 
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtMerge)
+{
+	const std::wstring expected = { L"*.txt;*.cpp;*.h" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"txt,cpp,h", L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtMerge2)
+{
+	const std::wstring expected = { L"*.txt;*.cpp;*.h" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"cpp,h,txt", L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
 TEST(CDocTypeManager, ConvertTypesExtToDlgExtExts64)
 {
 	const std::wstring expected = { L"*.txt;*.a;*.b;*.c;*.d;*.e;*.f;*.g;*.h;*.i;*.j;*.k;*.l;*.m;*.n;*.o;*.p;*.q;*.r;*.s;*.t;*.u;*.v;*.w;*.x;*.y;*.z;*.1;*.2;*.3;*.4;*.5;*.6" };

--- a/tests/unittests/test-cdoctypemanager.cpp
+++ b/tests/unittests/test-cdoctypemanager.cpp
@@ -1,0 +1,106 @@
+/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+
+#include <gtest/gtest.h>
+#include <windows.h>
+#include <string>
+#include "mem/CNativeW.h"
+#include "env/CDocTypeManager.h"
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtNullptr1)
+{
+	const std::wstring expected = { L"" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(nullptr, nullptr);
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtNullptr2)
+{
+	const std::wstring expected = { L"" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(nullptr, L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtOnce)
+{
+	const std::wstring expected = { L"*.txt;*.cpp" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"cpp", L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtTwo)
+{
+	const std::wstring expected = { L"*.txt;*.cpp;*.h" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"cpp;h", L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtThree)
+{
+	const std::wstring expected = { L"*.txt;*.cpp;*.h;*.hpp" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"cpp;h;hpp", L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtAppendPeriod)
+{
+	const std::wstring expected = { L"*.txt;*.cpp;*.h" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L".cpp;.h", L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtSeparatorSpace)
+{
+	const std::wstring expected = { L"*.txt;*.cpp;*.h" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"cpp h", L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtSeparatorComma)
+{
+	const std::wstring expected = { L"*.txt;*.cpp;*.h" } ;
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"cpp,h", L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtTopNullptr)
+{
+	const std::wstring expected = { L"*.cpp;*.h" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"cpp,h", nullptr);
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtExts64)
+{
+	const std::wstring expected = { L"*.txt;*.a;*.b;*.c;*.d;*.e;*.f;*.g;*.h;*.i;*.j;*.k;*.l;*.m;*.n;*.o;*.p;*.q;*.r;*.s;*.t;*.u;*.v;*.w;*.x;*.y;*.z;*.1;*.2;*.3;*.4;*.5;*.6" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,1,2,3,4,5,6", L".txt");
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CDocTypeManager, ConvertTypesExtToDlgExtExts64LongFileExt)
+{
+	const std::wstring expected = { L"*.extension_260_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;*.a;*.b;*.c;*.d;*.e;*.f;*.g;*.h;*.i;*.j;*.k;*.l;*.m;*.n;*.o;*.p;*.q;*.r;*.s;*.t;*.u;*.v;*.w;*.x;*.y;*.z;*.1;*.2;*.3;*.4;*.5;*.6" };
+	std::wstring actual = CDocTypeManager::ConvertTypesExtToDlgExt(L"a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,1,2,3,4,5,6", L".extension_260_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long");
+	EXPECT_EQ(expected, actual);
+}

--- a/tests/unittests/test-cfileext.cpp
+++ b/tests/unittests/test-cfileext.cpp
@@ -1,0 +1,91 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <Windows.h>
+#include "CFileExt.h"
+
+
+static size_t GetFilterLength(const wchar_t* filter)
+{
+	size_t length = 0;
+	size_t i = 0;
+	while (!(filter[i] == L'\0' && filter[i+1] == L'\0')) {
+		++i;
+	}
+	return i + 2;
+}
+
+TEST(CFileExt, Construct)
+{
+	CFileExt cFileExt;
+}
+
+TEST(CFileExt, CreateFilter)
+{
+	wchar_t result[] = L"ユーザー設定 (*.cpp;*.h;*.*)\0*.cpp;*.h;*.*\0テキスト (*.txt)\0*.txt\0すべてのファイル (*.*)\0*.*\0";
+
+	CFileExt cFileExt;
+	cFileExt.AppendExtRaw(L"ユーザー設定", L"*.cpp;*.h;*.*");
+	cFileExt.AppendExtRaw(L"テキスト", L"*.txt");
+	cFileExt.AppendExtRaw(L"すべてのファイル", L"*.*");
+
+	const wchar_t* filter = cFileExt.GetExtFilter();
+	size_t length = GetFilterLength(filter);
+	std::wstring expected = {result, _countof(result)};
+	std::wstring actual = {filter, length};
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(CFileExt, RawLongFilter)
+{
+	CFileExt cFileExt;
+	cFileExt.AppendExtRaw(
+		L"ユーザ設定",
+		L"*.extensin_250_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_longX"
+	);
+}
+
+TEST(CFileExt, RawManyFilter)
+{
+	CFileExt cFileExt;
+	cFileExt.AppendExtRaw(
+		L"ユーザ指定",
+		L"*.extensin_50_0_long_long_long_long_long_long_long_l;*.extensin_50_1_long_long_long_long_long_long_long_l;*.extensin_50_2_long_long_long_long_long_long_long_l;*.extensin_50_3_long_long_long_long_long_long_long_l;*.extensin_50_4_long_long_long_long_long_long_long_l;*.extensin_50_5_long_long_long_long_long_long_long_l;*.extensin_50_6_long_long_long_long_long_long_long_l;*.extensin_50_7_long_long_long_long_long_long_long_l;*.extensin_50_8_long_long_long_long_long_long_long_l;*.extensin_50_9_long_long_long_long_long_long_long_l"
+	);
+}
+
+TEST(CFileExt, LongFilter)
+{
+	CFileExt cFileExt;
+	cFileExt.AppendExt(
+		L"ユーザ設定",
+		L"*.extensin_250_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_longX"
+	);
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -111,8 +111,10 @@
     <ClCompile Include="test-ccommandline.cpp" />
     <ClCompile Include="test-cconvert.cpp" />
     <ClCompile Include="test-cdecode.cpp" />
+    <ClCompile Include="test-cdlgopenfile.cpp" />
     <ClCompile Include="test-cdlgprofilemgr.cpp" />
     <ClCompile Include="test-cerrorinfo.cpp" />
+    <ClCompile Include="test-cfileext.cpp" />
     <ClCompile Include="test-clayoutint.cpp" />
     <ClCompile Include="test-cmemory.cpp" />
     <ClCompile Include="test-cnative.cpp" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -113,6 +113,7 @@
     <ClCompile Include="test-cdecode.cpp" />
     <ClCompile Include="test-cdlgopenfile.cpp" />
     <ClCompile Include="test-cdlgprofilemgr.cpp" />
+    <ClCompile Include="test-cdoctypemanager.cpp" />
     <ClCompile Include="test-cerrorinfo.cpp" />
     <ClCompile Include="test-cfileext.cpp" />
     <ClCompile Include="test-clayoutint.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -122,6 +122,12 @@
     <ClCompile Include="test-ccodebase.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-cdlgopenfile.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-cfileext.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -128,6 +128,9 @@
     <ClCompile Include="test-cfileext.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-cdoctypemanager.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
ファイルダイアログ、フォルダダイアログへ長い文字列を指定するとバッファオーバーランする不具合の修正をします。

## <!-- 必須 --> カテゴリ

- 不具合修正
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景
極限値までいかなくても、ちょっと拡張子リストが長かったりすると、おかしいようなので、対策をします。

## <!-- 自明なら省略可 --> PR のメリット
バグが減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
ほとんどないと思います。

自動テストがないので、コードレビューが面倒です。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
「名前を付けて保存」ダイアログで、ファイルの種類の拡張子リストが正常に表示されないまたはクラッシュするのが修正されます。
保存ダイアログでは「ファイルの種類」で「ユーザ指定(\*.txt:\*.type;\*.\*)」と「テキストファイル(\*.\*)」と「すべてのファイル(\*.\*)」が選べます。
そのユーザ指定には今、開いているファイルの拡張子と現在のタイプ別設定が「ユーザ指定(\*.open_file_ext:\*.txt;\*.log;\*.\*)」のように一度に表示されますが、長さ制限が足りていません。
開いているファイルの拡張子と、タイプ別設定に登録された拡張子リストが合わせてかなり長い場合、異常終了していました。

また同様に以下のマクロを実行する時も異常終了していました。
以前は落ちていたので実質的な影響はないと思います。
`Editor.FileOpenDialog` / `FileSaveDialog("file_name")`の指定に`MAX_PATH`制限を導入します。
`Editor.FileOpenDialog("file_name.txt", "*.ext_filter")`の`ext_filter`が190文字前後以上長いとバッファオーバーランしてどこかおかしな動作をするのが修正されます。
`Editor.FolderDialog("説明","default_folder")`の`default_folder`に`MAX_PATH`制限を導入します。

## <!-- わかる範囲で --> PR の影響範囲
<!-- 既存の処理に対して影響範囲を記載してください。 -->
元の制限は
`CFileExt::FileExtInfoTag::m_szExt[MAX_TYPES_EXTS*3+1]`
`MAX_TYPES_EXTS`は64なので193文字(NULL含む)まで入力可能でした。
それ以上はチェックされずにオーバーランします。
こちらは保持する配列ごと`std::vector'とstd::wstring`によりリファクタリングしました。
https://github.com/sakura-editor/sakura/blob/95d9b032a9db57778dea10fb09626f6fb83be675/sakura_core/CFileExt.cpp#L85

`CDlgOpenFile_CommonFileDialog`と`CDlgOpenFile_CommonItemDialog`の`m_szDefaultWildCard`は`SFilePath`なので`MAX_PATH`制限があります。
こちらも異常終了する原因です。
こちらも`std::wstring`に変更しました。
https://github.com/sakura-editor/sakura/blob/95d9b032a9db57778dea10fb09626f6fb83be675/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp#L438
https://github.com/sakura-editor/sakura/blob/95d9b032a9db57778dea10fb09626f6fb83be675/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp#L690

呼び出し側の関連処理では
`CDocFileOperation.cpp`の`CDocFileOperation::SaveFileDialog()`では`_MAX_PATH+10`文字の制限がありました。
https://github.com/sakura-editor/sakura/blob/95d9b032a9db57778dea10fb09626f6fb83be675/sakura_core/doc/CDocFileOperation.cpp#L228-L254
`ConvertTypesExtToDlgExt(type.m_szTypeExts, szExt, szDefaultWildCard)`
`szExt`にファイルの拡張子を指定して、タイプ別設定と一緒にデフォルトフィルターに指定しています。
ローカル変数`szDefaultWildCard`に必要とされる最大値は`MAX_PATH+MAX_TYPES_EXTS*2`前後で足りていません。
m_szTypeExtsは「`a;b;c`」「`.a;.b;.c`」→「`*.a;*.b;*.c`」のように展開されるので最大でも約2倍必要です。
PRでは細かいことは気にせず`std::wstring`に変更しています。

`CDocTypeManager::ConvertTypesExtToDlgExt`では書き込みバッファの最大値がわからないため、`std::wstring`で返すようにリファクタリングしました。

## <!-- 必須 --> テスト内容
共通設定ー編集「Vistaスタイルのファイルダイアログ」をON/OFFすると表示に使う実装クラスが異なるため、ON/OFF2回ずつテストが必要です。
自動テストがなくて申し訳ないです。


### テスト1
手順
下記マクロを実行して、異常終了しないことを確認します。

マクロで`FileOpenDialog`/`FileSaveDialog`のファイル名のデフォルト指定が長いと異常終了していたのが、マクロ中断のエラーダイアログが表示されるようになります。

```JavaScript
var s = FileOpenDialog("file_name_long_long_0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456.js", "*.js");
```

### テスト2
手順
同マクロで、拡張子フィルターが長いと異常終了していたのが、直ります。
特にいまのところ拡張子フィルターの文字列長に制限はありません、

```JavaScript
var s = FileOpenDialog("file_name.js", "*.js;*.long_long_ext_filter_012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567");
```

### テスト3
手順
フォルダを開くマクロのデフォルト指定がMAX_PATHを超えていたときに落ちていたのが、マクロ中断のエラーダイアログが表示されるようになります。

```JavaScript
FolderDialog("バッファチェックのテスト", "C:\Program files\デフォルト表示フォルダ名123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678900123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890")
```

### テスト4

タイプ別設定の拡張子に以下を設定：
`a;b;c;d;e;f;g;h;i;j;k;l;m;n;o;p;q;r;s;t;u;v;w;x;y;z;0;1;2;3;4;5`

拡張子が異常に長いファイル(存在していなくてもいい)を開きます。
ファイル名例：
`D:\testfile.long_long_ext_filter_01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234`

上記のタイプ別を一時適用します。

「名前を付けて保存」でダイアログを表示します。
落ちないか確認します。
また拡張子リストが正しく表示されるか確認します。

ダイアログを閉じた後に異常終了することがありました、のでそこまで確認します。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
