### PR TITLE
キャレット位置の文字情報をステータスバーに設定する際の再描画をまとめる

### DIFF
--- a/sakura_core/apiwrap/CommonControl.h
+++ b/sakura_core/apiwrap/CommonControl.h
@@ -46,6 +46,10 @@ namespace ApiWrap
 	{
 		return ::SendMessage( hwndStatus, SB_GETTEXTLENGTH, opt, (LPARAM)0 );
 	}
+	inline LRESULT StatusBar_GetRect(HWND hwndStatus, WPARAM opt, RECT* rect)
+	{
+		return ::SendMessage( hwndStatus, SB_GETRECT, opt, (LPARAM)rect );
+	}
 
 	inline int StatusBar_SetParts(HWND hwndCtl, int num, int* positions)		{ return (int)(DWORD)::SendMessage(hwndCtl, SB_SETPARTS, (WPARAM)num, (LPARAM)positions); }
 

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -141,14 +141,15 @@ bool CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 		assert(m_hwndStatusBar != NULL);
 		return false;
 	}
-	// StatusBar_SetText 関数を呼びだすかどうかを判定するラムダ式
+	// StatusBar_SetText 関数を呼びだすかどうかを判定する
 	// （StatusBar_SetText は SB_SETTEXT メッセージを SendMessage で送信する）
-	return [&]() -> bool {
+	bool bDraw = true;
+	do {
 		// オーナードローの場合は SB_SETTEXT メッセージを無条件に発行するように判定
 		// 本来表示に変化が無い場合には呼び出さない方が表示のちらつきが減るので好ましいが
 		// 判定が難しいので諦める
 		if( nOption == SBT_OWNERDRAW ){
-			return true;
+			break;
 		}
 		// オーナードローではない場合で NULLの場合は空文字に置き換える
 		// NULL を渡しても問題が無いのかどうか公式ドキュメントに記載されていない
@@ -161,13 +162,13 @@ bool CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 		LRESULT res = ::StatusBar_GetTextLength( m_hwndStatusBar, nIndex );
 		// 表示オペレーション値が変化する場合は SB_SETTEXT メッセージを発行
 		if( HIWORD(res) != nOption ){
-			return true;
+			break;
 		}
 		size_t prevTextLen = LOWORD(res);
 		WCHAR prev[1024];
 		// 設定済みの文字列長が長過ぎて取得できない場合は、SB_SETTEXT メッセージを発行
 		if( prevTextLen >= _countof(prev) ){
-			return true;
+			break;
 		}
 		// 設定する文字列長パラメータが SIZE_MAX（引数のデフォルト値）な場合は文字列長を取得
 		if( textLen == SIZE_MAX ){
@@ -175,16 +176,20 @@ bool CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 		}
 		// 設定済みの文字列長と設定する文字列長が異なる場合は、SB_SETTEXT メッセージを発行
 		if( prevTextLen != textLen ){
-			return true;
+			break;
 		}
 		if( prevTextLen > 0 ){
 			::StatusBar_GetText( m_hwndStatusBar, nIndex, prev );
 			// 設定済みの文字列と設定する文字列を比較して異なる場合は、SB_SETTEXT メッセージを発行
-			return (wcscmp(prev, pszText) != 0);
+			bDraw = wcscmp(prev, pszText) != 0;
 		}
 		else {
 			// 設定する文字列長が0の場合は設定する文字列長が0より大きい場合のみ設定する（既に空文字なら空文字を設定する必要は無い為）
-			return textLen > 0;
+			bDraw = textLen > 0;
 		}
-	}() ? (StatusBar_SetText(m_hwndStatusBar, nIndex | nOption, pszText) != FALSE) : false;
+	}while (0);
+	if (bDraw) {
+		StatusBar_SetText(m_hwndStatusBar, nIndex | nOption, pszText);
+	}
+	return bDraw;
 }

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -130,15 +130,15 @@ void CMainStatusBar::SendStatusMessage2( const WCHAR* msg )
 	@param pszText [in] 表示テキスト
 	@param textLen [in] 表示テキストの文字数
 */
-void CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText, size_t textLen /* = SIZE_MAX */)
+bool CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText, size_t textLen /* = SIZE_MAX */)
 {
 	if( !m_hwndStatusBar ){
 		assert(m_hwndStatusBar != NULL);
-		return;
+		return false;
 	}
 	// StatusBar_SetText 関数を呼びだすかどうかを判定するラムダ式
 	// （StatusBar_SetText は SB_SETTEXT メッセージを SendMessage で送信する）
-	[&]() -> bool {
+	return [&]() -> bool {
 		// オーナードローの場合は SB_SETTEXT メッセージを無条件に発行するように判定
 		// 本来表示に変化が無い場合には呼び出さない方が表示のちらつきが減るので好ましいが
 		// 判定が難しいので諦める
@@ -177,8 +177,9 @@ void CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 			// 設定済みの文字列と設定する文字列を比較して異なる場合は、SB_SETTEXT メッセージを発行
 			return (wcscmp(prev, pszText) != 0);
 		}
-		else{
-			return true;
+		else {
+			// 設定する文字列長が0の場合は設定する文字列長が0より大きい場合のみ設定する（既に空文字なら空文字を設定する必要は無い為）
+			return textLen > 0;
 		}
-	}() ? StatusBar_SetText( m_hwndStatusBar, nIndex | nOption, pszText ) : 0;
+	}() ? (StatusBar_SetText(m_hwndStatusBar, nIndex | nOption, pszText) != FALSE) : false;
 }

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -41,11 +41,16 @@ void CMainStatusBar::CreateStatusBar()
 	if( m_hwndStatusBar )return;
 
 	/* ステータスバー */
-	m_hwndStatusBar = ::CreateStatusWindow(
-		WS_CHILD/* | WS_VISIBLE*/ | WS_EX_RIGHT | SBARS_SIZEGRIP,	// 2007.03.08 ryoji WS_VISIBLE 除去
-		L"",
+	m_hwndStatusBar = ::CreateWindowEx(
+		WS_EX_RIGHT | WS_EX_COMPOSITED,
+		STATUSCLASSNAME,
+		NULL,
+		WS_CHILD/* | WS_VISIBLE*/ | SBARS_SIZEGRIP,	// 2007.03.08 ryoji WS_VISIBLE 除去
+		0, 0, 0, 0, // X, Y, nWidth, nHeight
 		m_pOwner->GetHwnd(),
-		IDW_STATUSBAR
+		(HMENU)IDW_STATUSBAR,
+		CEditApp::getInstance()->GetAppInstance(),
+		0
 	);
 
 	/* プログレスバー */

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -44,13 +44,13 @@ void CMainStatusBar::CreateStatusBar()
 	m_hwndStatusBar = ::CreateWindowEx(
 		WS_EX_RIGHT | WS_EX_COMPOSITED,
 		STATUSCLASSNAME,
-		NULL,
+		nullptr,
 		WS_CHILD/* | WS_VISIBLE*/ | SBARS_SIZEGRIP,	// 2007.03.08 ryoji WS_VISIBLE 除去
 		0, 0, 0, 0, // X, Y, nWidth, nHeight
 		m_pOwner->GetHwnd(),
 		(HMENU)IDW_STATUSBAR,
 		CEditApp::getInstance()->GetAppInstance(),
-		0
+		nullptr
 	);
 
 	/* プログレスバー */
@@ -187,7 +187,7 @@ bool CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 			// 設定する文字列長が0の場合は設定する文字列長が0より大きい場合のみ設定する（既に空文字なら空文字を設定する必要は無い為）
 			bDraw = textLen > 0;
 		}
-	}while (0);
+	}while (false);
 	if (bDraw) {
 		StatusBar_SetText(m_hwndStatusBar, nIndex | nOption, pszText);
 	}

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -55,7 +55,7 @@ public:
 	HWND GetProgressHwnd() const{ return m_hwndProgressBar; }
 
 	//設定
-	void SetStatusText(int nIndex, int nOption, const WCHAR* pszText, size_t textLen = SIZE_MAX);
+	bool SetStatusText(int nIndex, int nOption, const WCHAR* pszText, size_t textLen = SIZE_MAX);
 private:
 	CEditWnd*	m_pOwner;
 	HWND		m_hwndStatusBar;


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

カーソルキーを押してキャレット位置を変えるとステータスバーの表示が更新されますが、その処理を効率化するのが目的です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 速度向上
- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

開発環境(Visual Studio)のメニューの Debug > Performance Profiler で CPU Usage にチェックを付けて Start をして、どこの処理に時間が掛かっているのかを確認する事が出来ます。

キャレット位置の文字情報をステータスバーに設定する際に呼び出される `CMainStatusBar::SetStatusText` における `StatusBar_SetText` に結構処理時間が掛かっていたので対策を行いました。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

キャレット位置変更時にステータスバーの更新を行う際の処理が効率化されます。

処理を効率化する事でCPU使用率が下がるのではないかと思います。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

記述が増える事で処理内容が読み取りにくくなります。

元々そこまで目立って重たい処理でも無いので、変更によって処理が軽くなったかを体感できるかというと出来ません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

`StatusBar_SetText` の実装は `SB_SETTEXT` メッセージを `SendMessage` 関数で送るものです。

https://docs.microsoft.com/en-us/windows/win32/controls/sb-settext#remarks

によると、

> The message invalidates the portion of the window that has changed, causing it to display the new text when the window next receives the WM_PAINT message.

と書かれていたのでおそらく内部で `InvalidateRect` しているように思えます。

このPRの変更では `WM_SETREDRAW` メッセージを使う事でステータスバーの各パートに文字列を設定する際に個々に描画を行われる事を防ぎます。また各パートに文字列が設定された場合は各パートのRECT領域を取得して結合し、後で `InvalidateRect` を呼び出す事で再描画をまとめる事で表示処理の効率化を図ります。

~~描画をまとめて行う事で、カーソルキーを押しっぱなしにした場合のステータスバーの表示のちらつきが無くなるかというと、残念ながらそんな事は無いようです。~~
追記：拡張スタイル `WS_EX_COMPOSITED` を使う事でステータスバーの表示のちらつきを解消しました。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順
- テキストファイル（たとえば README.md とか）を開いた後にカーソルキーを押してキャレット位置を変える操作を行い、ステータスバーの表示が更新されるかどうかを確認

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1592, #1265, #1246, #452

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

https://docs.microsoft.com/en-us/windows/win32/controls/sb-getrect

https://docs.microsoft.com/en-us/windows/win32/controls/sb-settext

https://docs.microsoft.com/en-us/windows/win32/gdi/wm-setredraw

https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-invalidaterect

https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-unionrect

https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-createwindowexw

https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles