### PR TITLE
MinGW版CRTでwcsncat_sのC++オーバーロードが未定義になっていることに対策する

### DIFF
--- a/sakura_core/types/CType_Erlang.cpp
+++ b/sakura_core/types/CType_Erlang.cpp
@@ -383,7 +383,7 @@ void COutlineErlang::build_arity( int arity )
 {
 	wchar_t numstr[12];
 	::_snwprintf_s( numstr, _TRUNCATE, L"/%d", arity );
-	::wcsncat_s( m_func, numstr, _TRUNCATE );
+	::wcsncat_s( m_func, _countof(m_func), numstr, _TRUNCATE );
 }
 
 /** Erlang アウトライン解析


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
MinGWビルドの失敗を解消することが目的です。

## <!-- 必須 --> カテゴリ
- ビルド関連
  - MinGW

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1600 で行った修正により、MinGWビルドが失敗するようになりました。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
現在起きているMinGWビルドの失敗が解消します。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
本質的な解決になっていないような気がします。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
MinGW版CRT でセキュア版関数 wcsncat_s の C++ オーバーロードが 定義されていないことが原因です。

この関数には本来、テンプレートを使った C++ 専用のオーバーロードが存在します。
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/strncat-s-strncat-s-l-wcsncat-s-wcsncat-s-l-mbsncat-s-mbsncat-s-l


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->


## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
ビルド確認のみです。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1600

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
