### PR TITLE
Grep結果のタグジャンプの一部リファクタリングと不具合の修正

### DIFF
--- a/sakura_core/cmd/CViewCommander.h
+++ b/sakura_core/cmd/CViewCommander.h
@@ -295,6 +295,7 @@ public:
 // To Here 2001.12.03 hor
 	// Apr. 03, 2003 genta 引数追加
 	bool Command_TAGJUMP( bool bClose = false );		/* タグジャンプ機能 */
+	bool Command_TagJumpNoMessage( bool bClose );		// タグジャンプ機能(メッセージ通知なし)
 	void Command_TAGJUMPBACK( void );					/* タグジャンプバック機能 */
 	bool Command_TagJumpByTagsFileMsg(bool bMsg);				//ダイレクトタグジャンプ(通知つき)
 	bool Command_TagJumpByTagsFile(bool bClose);				//ダイレクトタグジャンプ	//@@@ 2003.04.13 MIK

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -320,7 +320,7 @@ bool CViewCommander::Command_TagJumpNoMessage( bool bClose )
 					break;
 				}
 				// 相対フォルダorファイル名
-				if (std::wstring strPath = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strFile.empty() == false) {
+				if (std::wstring strPath = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strPath.empty() == false) {
 					if (strFile.empty() == false) {
 						strPath = AddLastYenPath(strPath);
 					}
@@ -328,8 +328,8 @@ bool CViewCommander::Command_TagJumpNoMessage( bool bClose )
 					if( MAX_TAG_PATH <= strPath.size() ){
 						break;
 					}
-					if( IsFileExists2(strFile.c_str()) ){
-						strJumpToFile = strFile;
+					if( IsFileExists2(strPath.c_str()) ){
+						strJumpToFile = strPath;
 						break;
 					}
 					// 相対パスだった→◎”を探す
@@ -339,7 +339,7 @@ bool CViewCommander::Command_TagJumpNoMessage( bool bClose )
 				}
 				break;
 			}else if( 3 <= nLineLen && 0 == wmemcmp( pLine, L"◎\"", 2 ) ){
-				if (std::wstring strPath = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strFile.empty() == false) {
+				if (std::wstring strPath = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strPath.empty() == false) {
 					strPath = AddLastYenPath(strPath);
 					strPath.append(strFile);
 					if (MAX_TAG_PATH <= strPath.size()) {

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -120,19 +120,6 @@ bool CViewCommander::Command_TagJumpNoMessage( bool bClose )
 		return false;
 	}
 
-#ifdef _DEBUG
-	assert(std::wstring(L"abc") == GetQuoteFilePath(L"abc\"def", 100));
-	assert(std::wstring(L"")    == GetQuoteFilePath(L"\"abcdef", 100));
-	assert(std::wstring(L"a")   == GetQuoteFilePath(L"a\"bcdef", 100));
-	assert(std::wstring(L"ab")  == GetQuoteFilePath(L"ab\"cdef", 100));
-	assert(std::wstring(L"abcde") == GetQuoteFilePath(L"abcde\"f", 100));
-	assert(std::wstring(L"abcdef") == GetQuoteFilePath(L"abcdef\"", 100));
-	assert(std::wstring(L"")    == GetQuoteFilePath(L"abcdefg", 100));
-	assert(std::wstring(L"abc") == GetQuoteFilePath(L"abc\"def", 5));
-	assert(std::wstring(L"abc") == GetQuoteFilePath(L"abc\"def", 4));
-	assert(std::wstring(L"")    == GetQuoteFilePath(L"abc\"def", 3));
-#endif
-
 	// ノーマル
 	// C:\RootFolder\SubFolders\FileName.ext(5395,11): str
 

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -391,18 +391,15 @@ bool CViewCommander::Command_TagJumpNoMessage( bool bClose )
 	}
 
 	// 2011.11.29 Grep形式で失敗した後もTagsを検索する
-	if (strJumpToFile.empty()) {
-		if( Command_TagJumpByTagsFile(bClose) ){	//@@@ 2003.04.13
-			return true;
-		}
+	if (strJumpToFile.empty() && Command_TagJumpByTagsFile(bClose) ){	//@@@ 2003.04.13
+		return true;
 		//	From Here Aug. 27, 2001 genta
 	}
 
 	//	Apr. 21, 2003 genta bClose追加
-	if (strJumpToFile.empty() == false) {
-		if( m_pCommanderView->TagJumpSub(strJumpToFile.c_str(), CMyPoint(nJumpToColumn, nJumpToLine), bClose ) ){	//@@@ 2003.04.13
-			return true;
-		}
+	if (strJumpToFile.empty() == false &&
+		m_pCommanderView->TagJumpSub(strJumpToFile.c_str(), CMyPoint(nJumpToColumn, nJumpToLine), bClose ) ){	//@@@ 2003.04.13
+		return true;
 	}
 
 	return false;

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -41,18 +41,20 @@
 #include "config/system_constants.h"
 #include "String_define.h"
 
-// "までを切り取る
-static bool GetQuoteFilePath( const wchar_t* pLine, wchar_t* pFile, size_t size ){
+//! "までを切り取る
+// sizeは切り出し文字列のNULL終端を含む長さ(wstring::length()+1の値)
+static std::wstring GetQuoteFilePath(const wchar_t* pLine, size_t size)
+{
 	const wchar_t* pFileEnd = wcschr( pLine, L'\"' );
-	if( pFileEnd ){
-		int nFileLen = pFileEnd - pLine;
-		if( 0 < nFileLen && nFileLen < (int)size ){
-			wmemcpy( pFile, pLine, nFileLen );
-			pFile[nFileLen] = L'\0';
-			return true;
-		}
+	if (pFileEnd == nullptr) {
+		return L"";
 	}
-	return false;
+	size_t nFileLen = pFileEnd - pLine;
+	if (0 == nFileLen || size <= nFileLen) {
+		return L"";
+	}
+	std::wstring str(pLine, nFileLen);
+	return str;
 }
 
 static bool IsFileExists2( const wchar_t* pszFile )
@@ -78,6 +80,15 @@ static bool IsFileExists2( const wchar_t* pszFile )
 */
 bool CViewCommander::Command_TAGJUMP( bool bClose )
 {
+	bool ret = Command_TagJumpNoMessage(bClose);
+	if(ret == false){
+		m_pCommanderView->SendStatusMessage(LS(STR_ERR_TAGJMP1));	//@@@ 2003.04.13
+	}
+	return ret;
+}
+
+bool CViewCommander::Command_TagJumpNoMessage( bool bClose )
+{
 	//	2004.05.13 Moca 初期値を1ではなく元の位置を継承するように
 	// 0以下は未指定扱い。(1開始)
 	int			nJumpToLine;
@@ -86,11 +97,8 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 	nJumpToColumn = 0;
 
 	//ファイル名バッファ
-	wchar_t		szJumpToFile[1024];
-	wchar_t		szFile[_MAX_PATH] = {L'\0'};
 	size_t		nBgn;
 	size_t		nPathLen;
-	wmemset( szJumpToFile, 0, _countof(szJumpToFile) );
 
 	/*
 	  カーソル位置変換
@@ -109,8 +117,21 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 	CLogicInt		nLineLen;
 	const wchar_t*	pLine = CDocLine::GetDocLineStrWithEOL_Safe(GetDocument()->m_cDocLineMgr.GetLine(ptXY.GetY2()), &nLineLen);
 	if( NULL == pLine ){
-		goto can_not_tagjump;
+		return false;
 	}
+
+#ifdef _DEBUG
+	assert(std::wstring(L"abc") == GetQuoteFilePath(L"abc\"def", 100));
+	assert(std::wstring(L"")    == GetQuoteFilePath(L"\"abcdef", 100));
+	assert(std::wstring(L"a")   == GetQuoteFilePath(L"a\"bcdef", 100));
+	assert(std::wstring(L"ab")  == GetQuoteFilePath(L"ab\"cdef", 100));
+	assert(std::wstring(L"abcde") == GetQuoteFilePath(L"abcde\"f", 100));
+	assert(std::wstring(L"abcdef") == GetQuoteFilePath(L"abcdef\"", 100));
+	assert(std::wstring(L"")    == GetQuoteFilePath(L"abcdefg", 100));
+	assert(std::wstring(L"abc") == GetQuoteFilePath(L"abc\"def", 5));
+	assert(std::wstring(L"abc") == GetQuoteFilePath(L"abc\"def", 4));
+	assert(std::wstring(L"")    == GetQuoteFilePath(L"abc\"def", 3));
+#endif
 
 	// ノーマル
 	// C:\RootFolder\SubFolders\FileName.ext(5395,11): str
@@ -130,6 +151,14 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 	// ・SubFolders\FileName2.ext(5395,11): str
 	// ・SubFolders\FileName2.ext(5396,11): str
 	// ・SubFolders\FileName3.ext(123,11): str
+
+	// ノーマル/フォルダ毎
+	// ■"C:\RootFolder"
+	// ・FileName.cpp(5395,11): str
+	// ■"C:\RootFolder\SubFolders"
+	// ・FileName2.ext(5395,11): str
+	// ・FileName2.ext(5396,11): str
+	// ・FileName3.ext(123,11): str
 
 	// ファイル毎(WZ風)
 	// ■"C:\RootFolder\FileName.ext"
@@ -162,8 +191,41 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 	// ◆"FileName3.ext"
 	// ・(   123,12   ): str
 
+	// ファイル毎/フォルダ毎
+	// ■"C:\RootFolder"
+	// ◆"FileName.ext"
+	// ・(  5395,11   ): str
+	// ■"C:\RootFolder\SubFolders"
+	// ◆"FileName2.ext"
+	// ・(  5395,11   ): str
+	// ・(  5396,11   ): str
+
+
 	// Grep結果のタグジャンプ検索
 	// ・→◆→■→◎ の順に検索してパスを結合する
+
+	// 自動選択を選ぶとエンコード名表示
+	// C:\RootFolder\SubFolders\FileName.ext(150,6)  [UTF-8]: str
+	// ・SubFolders\FileName.ext(150,6)  [UTF-8]: str
+	// ・FileName.ext(150,6)  [UTF-8]: str
+
+	// ■"C:\RootFolder\SubFolders\FileName.ext"  [UTF-8]
+	// ・(   150,6    ): str
+
+	// ◎"C:\RootFolder"
+	// ■"FileName.ext"  [UTF-8]
+	// ・(  5395,11   ): str
+	// ■"SubFolders\FileName2.ext"  [UTF-8]
+	// ・(  5395,11   ): str
+
+	// ■"C:\RootFolder\SubFolders\"
+	// ◆"FileName.ext"  [UTF-8]
+	// ・(   150,60   ): str
+
+	std::wstring	strJumpToFile;
+	std::wstring	strFile;
+	constexpr int MAX_TAG_PATH = MAX_PATH;
+
 	do{
 		enum TagListSeachMode{
 			TAGLIST_FILEPATH,
@@ -173,22 +235,22 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 		if( 0 == wmemcmp( pLine, L"■\"", 2 ) ){
 			/* WZ風のタグリストか */
 			if( IsFilePath( &pLine[2], &nBgn, &nPathLen ) && !_IS_REL_PATH( &pLine[2] ) ){
-				wmemcpy( szJumpToFile, &pLine[2 + nBgn], nPathLen );
+				strJumpToFile.assign(&pLine[2 + nBgn], nPathLen);
 				GetLineColumn( &pLine[2 + nPathLen], &nJumpToLine, &nJumpToColumn );
 				break;
-			}else if( !GetQuoteFilePath( &pLine[2], szFile, _countof(szFile) ) ){
+			}else if (strFile = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strFile.empty()) {
 				break;
 			}
 			searchMode = TAGLIST_ROOT;
 		}else if( 0 == wmemcmp( pLine, L"◆\"", 2 ) ){
-			if( !GetQuoteFilePath( &pLine[2], szFile, _countof(szFile) ) ){
+			if (strFile = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strFile.empty()) {
 				break;
 			}
 			searchMode = TAGLIST_SUBPATH;
 		}else if( 0 == wmemcmp( pLine, L"・", 1 ) ){
 			if( pLine[1] == L'"' ){
 				// ・"FileName.ext"
-				if( !GetQuoteFilePath( &pLine[2], szFile, _countof(szFile) ) ){
+				if (strFile = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strFile.empty()) {
 					break;
 				}
 				searchMode = TAGLIST_SUBPATH;
@@ -224,9 +286,8 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 					for( ; 1 < fileEnd && (L'0' <= pLine[fileEnd] && pLine[fileEnd] <= L'9'); fileEnd-- ){}
 					if(    1 < fileEnd && (L',' == pLine[fileEnd]) ){ fileEnd--; }
 					for( ; 1 < fileEnd && (L'0' <= pLine[fileEnd] && pLine[fileEnd] <= L'9'); fileEnd-- ){}
-					if( 1 < fileEnd && L'(' == pLine[fileEnd] && fileEnd - 1 < (int)_countof(szFile) ){
-						wmemcpy( szFile, pLine + 1, fileEnd - 1 );
-						szFile[fileEnd - 1] = L'\0';
+					if( 1 < fileEnd && L'(' == pLine[fileEnd] && fileEnd - 1 < MAX_TAG_PATH ){
+						strFile.assign(pLine + 1, fileEnd - 1);
 						GetLineColumn( &pLine[fileEnd + 1], &nJumpToLine, &nJumpToColumn );
 						searchMode = TAGLIST_SUBPATH;
 					}else{
@@ -251,7 +312,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 					continue;
 				}
 				// フォルダ毎：ファイル名
-				if( GetQuoteFilePath(&pLine[2], szFile, _countof(szFile)) ){
+				if (strFile = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strFile.empty() == false ){
 					searchMode = TAGLIST_SUBPATH;
 					continue;
 				}
@@ -268,31 +329,37 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 				}
 				// ファイル毎(WZ風)：フルパス
 				if( IsFilePath( &pLine[2], &nBgn, &nPathLen ) && !_IS_REL_PATH( &pLine[2] ) ){
-					wmemcpy( szJumpToFile, &pLine[2 + nBgn], nPathLen );
+					strJumpToFile.assign(&pLine[2 + nBgn], nPathLen);
 					break;
 				}
 				// 相対フォルダorファイル名
-				wchar_t		szPath[_MAX_PATH];
-				if( GetQuoteFilePath( &pLine[2], szPath, _countof(szPath) ) ){
-					if( szFile[0] ){
-						AddLastYenFromDirectoryPath( szPath );
+				if (std::wstring strPath = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strFile.empty() == false) {
+					if (strFile.empty() == false) {
+						strPath = AddLastYenPath(strPath);
 					}
-					wcscat( szPath, szFile );
-					if( IsFileExists2( szPath ) ){
-						wcscpy( szJumpToFile, szPath );
+					strPath.append(strFile);
+					if( MAX_TAG_PATH <= strPath.size() ){
+						break;
+					}
+					if( IsFileExists2(strFile.c_str()) ){
+						strJumpToFile = strFile;
 						break;
 					}
 					// 相対パスだった→◎”を探す
-					wcscpy( szFile, szPath );
+					strFile = strPath;
 					searchMode = TAGLIST_ROOT;
 					continue;
 				}
 				break;
 			}else if( 3 <= nLineLen && 0 == wmemcmp( pLine, L"◎\"", 2 ) ){
-				if( GetQuoteFilePath( &pLine[2], szJumpToFile, _countof(szJumpToFile) ) ){
-					AddLastYenFromDirectoryPath( szJumpToFile );
-					wcscat( szJumpToFile, szFile );
-					if( IsFileExists2( szJumpToFile ) ){
+				if (std::wstring strPath = GetQuoteFilePath(&pLine[2], MAX_TAG_PATH); strFile.empty() == false) {
+					strPath = AddLastYenPath(strPath);
+					strPath.append(strFile);
+					if (MAX_TAG_PATH <= strPath.size()) {
+						break;
+					}
+					if (IsFileExists2(strPath.c_str())) {
+						strJumpToFile = strPath;
 						break;
 					}
 				}
@@ -304,10 +371,10 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 		}
 	}while(0);
 
-	if( szJumpToFile[0] == L'\0' ){
+	if (strJumpToFile.empty()) {
 		pLine = GetDocument()->m_cDocLineMgr.GetLine(ptXYOrg.GetY2())->GetDocLineStrWithEOL(&nLineLen);
 		if( NULL == pLine ){
-			goto can_not_tagjump;
+			return false;
 		}
 		//@@@ 2001.12.31 YAZAKI
 		const wchar_t *p = pLine;
@@ -324,7 +391,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 
 			//	Check Path
 			if( IsFilePath( p, &nBgn, &nPathLen ) ){
-				wmemcpy( szJumpToFile, &p[nBgn], nPathLen );
+				strJumpToFile.assign(&p[nBgn], nPathLen);
 				GetLineColumn( &p[nBgn + nPathLen], &nJumpToLine, &nJumpToColumn );
 				break;
 			}
@@ -337,7 +404,7 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 	}
 
 	// 2011.11.29 Grep形式で失敗した後もTagsを検索する
-	if( szJumpToFile[0] == L'\0' ){
+	if (strJumpToFile.empty()) {
 		if( Command_TagJumpByTagsFile(bClose) ){	//@@@ 2003.04.13
 			return true;
 		}
@@ -345,14 +412,12 @@ bool CViewCommander::Command_TAGJUMP( bool bClose )
 	}
 
 	//	Apr. 21, 2003 genta bClose追加
-	if( szJumpToFile[0] ){
-		if( m_pCommanderView->TagJumpSub( szJumpToFile, CMyPoint(nJumpToColumn, nJumpToLine), bClose ) ){	//@@@ 2003.04.13
+	if (strJumpToFile.empty() == false) {
+		if( m_pCommanderView->TagJumpSub(strJumpToFile.c_str(), CMyPoint(nJumpToColumn, nJumpToLine), bClose ) ){	//@@@ 2003.04.13
 			return true;
 		}
 	}
 
-can_not_tagjump:;
-	m_pCommanderView->SendStatusMessage(LS(STR_ERR_TAGJMP1));	//@@@ 2003.04.13
 	return false;
 }
 

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -298,6 +298,19 @@ void AddLastYenFromDirectoryPath( WCHAR* pszFolder )
 	return;
 }
 
+//! パスらしき文字列の末尾に'\\'または'/'がなかったら'\\'を付加する
+std::wstring AddLastYenPath(std::wstring_view path)
+{
+	std::wstring ret{ path };
+	if (0 == ret.size()) {
+		return ret;
+	}
+	if (auto c = ret.back(); !(c == L'\\' || c == L'/')) {
+		ret.append(L"\\");
+	}
+	return ret;
+}
+
 /* ファイルのフルパスを、フォルダとファイル名に分割 */
 /* [c:\work\test\aaa.txt] → [c:\work\test] + [aaa.txt] */
 void SplitPath_FolderAndFile( const WCHAR* pszFilePath, WCHAR* pszFolder, WCHAR* pszFile )

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -55,6 +55,7 @@ FILE *_wfopen_absini(LPCWSTR fname, LPCWSTR mode, BOOL bOrExedir = TRUE); // 200
 //パス文字列処理
 void CutLastYenFromDirectoryPath( WCHAR* pszFolder );			/* フォルダの最後が半角かつ'\\'の場合は、取り除く "c:\\"等のルートは取り除かない*/
 void AddLastYenFromDirectoryPath( WCHAR* pszFolder );			/* フォルダの最後が半角かつ'\\'でない場合は、付加する */
+std::wstring AddLastYenPath(std::wstring_view path);
 void SplitPath_FolderAndFile( const WCHAR* pszFilePath, WCHAR* pszFolder, WCHAR* pszFile );	/* ファイルのフルパスを、フォルダとファイル名に分割 */
 void Concat_FolderAndFile( const WCHAR* pszDir, const WCHAR* pszTitle, WCHAR* pszPath );/* フォルダ、ファイル名から、結合したパスを作成 */
 BOOL GetLongFileName( const WCHAR* pszFilePathSrc, WCHAR* pszFilePathDes );					/* ロングファイル名を取得する */


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
細工されたり`\\?\`形式の長いパスのGrep結果のタグジャンプで「◆■」がある形式でバッファオーバーフローが発生する不具合の修正です。
同一箇所として、下記の「◎◆■」のタグで、存在しないパスのタグがあると、それに無条件でジャンプしようとする不具合を修正します。

## <!-- 必須 --> カテゴリ

- 不具合修正
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

strcat/strcpy、固定長バッファの一連の点検作業の一部です。

他にも、バグっぽい挙動をする部分が見られましたが、今回はスルーしました。
さらに不具合など修正リファクタリングしたコードも手元にはありますが、単体テストがないため、修正確認が非常に面倒です。
とりあえず、第1弾としたいです。
本格的にリファクタリングしたいなら、どうぞ、お願いします。

## <!-- 自明なら省略可 --> PR のメリット

バグが修正されます。
細工されたGrep結果のタブジャンプでクラッシュしにくくなります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

例のごとく、自動テストがないため、新しい不具合が出る可能性があります。

関数の中身が煩雑で、処理を追うのも難しいため、目で検証するのも大変だと思われます。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

テストの通りです。

ファイル名の固定配列を`std::wstring`で置き換えました。
関連するサブ関数を`wstring`仕様に差し替えました。

`GetQuoteFilePath`ではバッファ長指定が`_countof()`なので`szPath`、`szFile`は最大`MAX_PATH`までコピーを切り出してきます。
`AddLastYenFromDirectoryPath()`の`szPath`が`MAX_PATH`限界だと1文字はみ出します。
`wcscat`は`szPath`が`MAX_PATH`、`szFile`も制限は`MAX_PATH`なので長さを確認しないなら倍は必要です。
https://github.com/sakura-editor/sakura/blob/7e65eab6066b627b6dd64781edc5c0ce3801d754/sakura_core/cmd/CViewCommander_TagJump.cpp#L274-L276

下記も1024文字と長いですが、条件に一致すればバッファオーバーフローします。
またパス文字列の中身をチェックする前に`szJumpToFile`にコピーしてしまっているため、`IsFileExists2()`が`false`になるルートでは本来、タグジャンプ不可のはずが、不正パスでもタグジャンプ扱いになっていました。
https://github.com/sakura-editor/sakura/blob/7e65eab6066b627b6dd64781edc5c0ce3801d754/sakura_core/cmd/CViewCommander_TagJump.cpp#L288-L291

元のコードから、カーソル行の解析では`if (!GetQuoteFilePath())`と否定ですが、後半の上の行にさかのぼる処理のほうは`if (GetQuoteFilePath())`と肯定になっていますので、注意してください。

## <!-- わかる範囲で --> PR の影響範囲

Grep結果からのタグジャンプに関する範囲のみです。

## <!-- 必須 --> テスト内容

### テスト1
手順
「ファイル毎」「フォルダ毎」でGrepした結果のテキストを細工します。
```
■"C:\Users\USERNAME\Documents\git\sakura_rep\sakura_core\dlg"
◆"CDlgOpenFile_long_012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890.cpp" [UTF-8]
・(   967,6    ): grep_result
```
サクラエディタに上記を貼り付け「◆」か「・」の行にカーソルを置き「F12」を押します。
　→フォルダ+ファイルがstrcatで連結されてバッファオーバーフローしていました。
デバッグビルドで実行してジャンプさせるとスタックのエラーかフリーズすることがあります。
修正後は、タグジャンプできなくなります。
(パスのファイルは実在している必要はありません)

### テスト2
手順
「ファイル毎」「フォルダ毎」「ベースフォルダ」でGrepした結果のテキストを細工します。
```
◎"C:\Users\USERNAME\Documents\git\sakura_rep\sakura_core"
■"dlg"
◆"CDlgOpenFile_xxxxx.cpp"  [UTF-8]
・(   967,6    ): grep_result
```

```
◎"C:\Users\USERNAME\Documents\git\sakura_rep\sakura_core"
■"d*g"
◆"CDlgOpenFile_xxxxx.cpp"  [UTF-8]
・(   967,6    ): grep_result
```

サクラエディタに上記を貼り付け「◆」か「・」の行にカーソルを置き「F12」を押します。
　→存在しないファイルとして新規で開かれてしまうバグがありました。
修正するか非常に迷いましたが、同一の箇所であり、ファイル名、フォルダ名に\*や?など任意の文字があってもタブジャンプしてしまうため、これはPRに含めました。

Grep結果には、オプションが「ノーマル/ファイル毎」「フォルダ毎」「ベースフォルダ」と全部で8パターンあります。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料

