### PR TITLE
IsFileExists()とIsDirectory()でワイルドカードが通過する不具合を修正する

### DIFF
--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -618,13 +618,19 @@ LPCWSTR GetRelPath( LPCWSTR pszPath )
 // しかし「\\?\C:\Program files\」の形式では?が3文字目にあるので除外
 // ストリーム名とのセパレータにはfilename.ext:streamの形式でコロンが使われる
 // コロンは除外文字に入っていない
-bool IsValidPathAvailableChar(const wchar_t* path)
+bool IsValidPathAvailableChar(std::wstring_view path)
 {
-	int pos = 0;
-	if (wcsncmp_literal(path, LR"(\\?\)")) {
-		pos = 4;
+	if (path.empty()) {
+		// 空文字列セーフ
+		return true;
 	}
-	for (int i = pos; path[i] != L'\0'; ++i) {
+	constexpr auto& dos_device_path = LR"(\\?\)";
+	constexpr size_t len = _countof(dos_device_path) - 1;
+	size_t pos = 0;
+	if (wcsncmp(path.data(), dos_device_path, len) == 0) {
+		pos = len;
+	}
+	for (size_t i = pos; i < path.size(); ++i) {
 		if (!WCODE::IsValidFilenameChar(path[i])) {
 			return false;
 		}

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -39,7 +39,7 @@ bool IsFileExists(const WCHAR* path, bool bFileOnly = false);
 bool IsDirectory(LPCWSTR pszPath);	// 2009.08.20 ryoji
 
 bool IsInvalidFilenameChars( const std::wstring_view& strPath );
-[[nodiscard]] bool IsValidPathAvailableChar(const wchar_t* path);
+[[nodiscard]] bool IsValidPathAvailableChar(std::wstring_view path);
 
 //	Apr. 30, 2003 genta
 //	ディレクトリの深さを調べる

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -39,6 +39,7 @@ bool IsFileExists(const WCHAR* path, bool bFileOnly = false);
 bool IsDirectory(LPCWSTR pszPath);	// 2009.08.20 ryoji
 
 bool IsInvalidFilenameChars( const std::wstring_view& strPath );
+[[nodiscard]] bool IsValidPathAvailableChar(const wchar_t* path);
 
 //	Apr. 30, 2003 genta
 //	ディレクトリの深さを調べる

--- a/tests/unittests/test-file.cpp
+++ b/tests/unittests/test-file.cpp
@@ -71,6 +71,53 @@ TEST( file, IsInvalidFilenameChars )
 	EXPECT_TRUE(IsInvalidFilenameChars(L"test|.txt"));
 }
 
+TEST(file, IsValidPathAvailableChar)
+{
+	EXPECT_TRUE(IsValidPathAvailableChar(L"test.txt"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L".\\test.txt"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L"./test.txt"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L"C:\\test.txt"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L"C:/test.txt"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L"C:\\"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L"C:/"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L"C:\\dir\\test.txt"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L"C:\\dir\\dir2\\test.txt"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L"C:dir\\dir2\\test.txt"));
+
+	EXPECT_TRUE(IsValidPathAvailableChar(L"test:001.txt"));
+	EXPECT_TRUE(IsValidPathAvailableChar(L"\\dir\\dir2\\test:001.txt"));
+
+	// 特別考慮：DOSデバイスパスの?はtrue
+	EXPECT_TRUE(IsValidPathAvailableChar(L"\\\\?\\C:\\test.txt"));
+
+	EXPECT_FALSE(IsValidPathAvailableChar(L"test*.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"test?.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"test\".txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"test<.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"test>.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"test|.txt"));
+
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\dir\\test*.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\dir\\test?.txt"));
+
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\dir*\\text.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\dir?\\text.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\dir\"\\text.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\dir<\\text.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\dir>\\text.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\dir|\\text.txt"));
+
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\*dir\\text.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\?dir\\text.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"C:\\di*r\\text.txt"));
+
+
+	EXPECT_FALSE(IsValidPathAvailableChar(L"\\\\?\\C:\\test?.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"\\\\?\\C:\\test*.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"\\\\?\\C:\\d*ir\\test.txt"));
+	EXPECT_FALSE(IsValidPathAvailableChar(L"\\\\?\\C:\\dir*\\test.txt"));
+}
+
 /*!
  * @brief exeファイルパスの取得
  */


### PR DESCRIPTION
タイトルの通りです。
パス検証を導入して、?、\*などパスに使えない文字を事前にはじくようにします。

# <!-- 必須 --> PR の目的
関数の仕様として、微妙そうな動作を修正します。

## <!-- 必須 --> カテゴリ
- 不具合修正

## <!-- 自明なら省略可 --> PR の背景
`IsFileExists()`と`IsDirectory()`では、そのファイル/ディレクトリ確認に、`FindFirstFile`を使用しています。
しかしこのWin32APIは、ワイルドカードを受け付けるので、入力文字列に含まれていると、その文字列そのもののファイル/フォルダが存在していないのに、たまたまマッチしたファイルがあれば`true`を返すことがあります。

## <!-- 自明なら省略可 --> PR のメリット
微妙そうな動作が改善されます。

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
利用箇所の上位のコードで動作が変わるため、新しい問題が発生する可能性もあります。

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

ファイル名/フォルダ名にワイルドカードがある場合には`false`を返すように変更します。

すでに同種の関数`IsInvalidFilenameChars()`があります。しかしファイル名部分らしい部分のみしか確認してくれません。
`WCODE::IsValidFilenameChar`のみでは、`\\?\C:\Windows\`の形式を通過させることができません。
当面の処置として、関数を新設しました。

## <!-- わかる範囲で --> PR の影響範囲

コードの利用箇所を軽く見て回った範囲では、実害はほぼないようです。

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

単体テストが書けそうですが、今のところありません。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
