### PR TITLE
SonarCloudで指摘されたCEolの問題に対処する

### DIFF
--- a/sakura_core/CCodeChecker.cpp
+++ b/sakura_core/CCodeChecker.cpp
@@ -42,7 +42,7 @@
 static bool _CheckSavingEolcode(const CDocLineMgr& pcDocLineMgr, CEol cEolType)
 {
 	bool bMix = false;
-	if( cEolType == EOL_NONE ){	//改行コード変換なし
+	if( cEolType == EEolType::none ){	//改行コード変換なし
 		CEol cEolCheck;	//比較対象EOL
 		const CDocLine* pcDocLine = pcDocLineMgr.GetDocLineTop();
 		if( pcDocLine ){
@@ -50,7 +50,7 @@ static bool _CheckSavingEolcode(const CDocLineMgr& pcDocLineMgr, CEol cEolType)
 		}
 		while( pcDocLine ){
 			CEol cEol = pcDocLine->GetEol();
-			if( cEol != cEolCheck && cEol != EOL_NONE ){
+			if( cEol != cEolCheck && cEol != EEolType::none ){
 				bMix = true;
 				break;
 			}

--- a/sakura_core/CCodeChecker.cpp
+++ b/sakura_core/CCodeChecker.cpp
@@ -42,7 +42,7 @@
 static bool _CheckSavingEolcode(const CDocLineMgr& pcDocLineMgr, CEol cEolType)
 {
 	bool bMix = false;
-	if( cEolType == EEolType::none ){	//改行コード変換なし
+	if( cEolType.IsNone() ){	//改行コード変換なし
 		CEol cEolCheck;	//比較対象EOL
 		const CDocLine* pcDocLine = pcDocLineMgr.GetDocLineTop();
 		if( pcDocLine ){
@@ -50,7 +50,7 @@ static bool _CheckSavingEolcode(const CDocLineMgr& pcDocLineMgr, CEol cEolType)
 		}
 		while( pcDocLine ){
 			CEol cEol = pcDocLine->GetEol();
-			if( cEol != cEolCheck && cEol != EEolType::none ){
+			if( cEol != cEolCheck && cEol.IsValid() ){
 				bMix = true;
 				break;
 			}

--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -32,27 +32,16 @@
 #include "StdAfx.h"
 #include "CEol.h"
 
-/*! 行終端子の配列 */
-const EEolType gm_pnEolTypeArr[EOL_TYPE_NUM] = {
-	EEolType::none			,	// == 0
-	EEolType::cr_and_lf			,	// == 2
-	EEolType::line_feed				,	// == 1
-	EEolType::carriage_return				,	// == 1
-	EEolType::next_line				,	// == 1
-	EEolType::line_separator				,	// == 1
-	EEolType::paragraph_separator					// == 1
-};
-
 //-----------------------------------------------
 //	固定データ
 //-----------------------------------------------
 
 const SEolDefinition g_aEolTable[] = {
 	{ L"改行無",	L"",			"",			0 },
-	{ L"CRLF",	L"\x0d\x0a",	"\x0d\x0a",	2 },
+	{ L"CRLF",		L"\x0d\x0a",	"\x0d\x0a",	2 },
 	{ L"LF",		L"\x0a",		"\x0a",		1 },
 	{ L"CR",		L"\x0d",		"\x0d",		1 },
-	{ L"NEL",	L"\x85",		"",			1 },
+	{ L"NEL",		L"\x85",		"",			1 },
 	{ L"LS",		L"\u2028",		"",			1 },
 	{ L"PS",		L"\u2029",		"",			1 },
 };
@@ -88,9 +77,10 @@ static const SEolDefinitionForUniFile g_aEolTable_uni_file[] = {
 template <class T>
 EEolType GetEOLType( const T* pszData, int nDataLen )
 {
-	for( int i = 1; i < EOL_TYPE_NUM; ++i ){
-		if( g_aEolTable[i].StartsWith(pszData, nDataLen) )
-			return gm_pnEolTypeArr[i];
+	for( size_t i = 1; i < EOL_TYPE_NUM; ++i ){
+		if( g_aEolTable[i].StartsWith(pszData, nDataLen) ){
+			return static_cast<EEolType>(i);
+		}
 	}
 	return EEolType::none;
 }
@@ -101,18 +91,20 @@ EEolType GetEOLType( const T* pszData, int nDataLen )
 
 EEolType _GetEOLType_uni( const char* pszData, int nDataLen )
 {
-	for( int i = 1; i < EOL_TYPE_NUM; ++i ){
-		if( g_aEolTable_uni_file[i].StartsWithW(pszData, nDataLen) )
-			return gm_pnEolTypeArr[i];
+	for( size_t i = 1; i < EOL_TYPE_NUM; ++i ){
+		if( g_aEolTable_uni_file[i].StartsWithW(pszData, nDataLen) ){
+			return static_cast<EEolType>(i);
+		}
 	}
 	return EEolType::none;
 }
 
 EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
 {
-	for( int i = 1; i < EOL_TYPE_NUM; ++i ){
-		if( g_aEolTable_uni_file[i].StartsWithWB(pszData, nDataLen) )
-			return gm_pnEolTypeArr[i];
+	for( size_t i = 1; i < EOL_TYPE_NUM; ++i ){
+		if( g_aEolTable_uni_file[i].StartsWithWB(pszData, nDataLen) ){
+			return static_cast<EEolType>(i);
+		}
 	}
 	return EEolType::none;
 }
@@ -147,7 +139,7 @@ EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
 */
 constexpr bool CEol::SetType( EEolType t ) noexcept
 {
-	if( t == EEolType::none || IsValid( t ) ){
+	if( IsNoneOrValid( t ) ){
 		// 正しい値
 		m_eEolType = t;
 		return true;
@@ -176,4 +168,24 @@ void CEol::SetTypeByStringForFile_uni( const char* pszData, int nDataLen )
 void CEol::SetTypeByStringForFile_unibe( const char* pszData, int nDataLen )
 {
 	SetType( _GetEOLType_unibe( pszData, nDataLen ) );
+}
+
+bool operator == ( const CEol& lhs, const CEol& rhs ) noexcept
+{
+	return lhs.operator==(static_cast<EEolType>(rhs));
+}
+
+bool operator != ( const CEol& lhs, const CEol& rhs ) noexcept
+{
+	return !(lhs == rhs);
+}
+
+bool operator == ( EEolType lhs, const CEol& rhs ) noexcept
+{
+	return rhs.operator==(lhs);
+}
+
+bool operator != ( EEolType lhs, const CEol& rhs ) noexcept
+{
+	return !(lhs == rhs);
 }

--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -131,25 +131,6 @@ EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
 	return CLogicInt(g_aEolTable[static_cast<size_t>(m_eEolType)].m_nLen);
 }
 
-/*!
-	行末種別の設定。
-	@param t 行末種別
-	@retval true 正常終了。設定が反映された。
-	@retval false 異常終了。強制的にCRLFに設定。
-*/
-constexpr bool CEol::SetType( EEolType t ) noexcept
-{
-	if( IsNoneOrValid( t ) ){
-		// 正しい値
-		m_eEolType = t;
-		return true;
-	}else{
-		// 異常値
-		m_eEolType = EEolType::cr_and_lf;
-		return false;
-	}
-}
-
 void CEol::SetTypeByString( const wchar_t* pszData, int nDataLen )
 {
 	SetType( GetEOLType( pszData, nDataLen ) );

--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -34,13 +34,13 @@
 
 /*! 行終端子の配列 */
 const EEolType gm_pnEolTypeArr[EOL_TYPE_NUM] = {
-	EOL_NONE			,	// == 0
-	EOL_CRLF			,	// == 2
-	EOL_LF				,	// == 1
-	EOL_CR				,	// == 1
-	EOL_NEL				,	// == 1
-	EOL_LS				,	// == 1
-	EOL_PS					// == 1
+	EEolType::none			,	// == 0
+	EEolType::cr_and_lf			,	// == 2
+	EEolType::line_feed				,	// == 1
+	EEolType::carriage_return				,	// == 1
+	EEolType::next_line				,	// == 1
+	EEolType::line_separator				,	// == 1
+	EEolType::paragraph_separator					// == 1
 };
 
 //-----------------------------------------------
@@ -83,7 +83,7 @@ static const SEolDefinitionForUniFile g_aEolTable_uni_file[] = {
 	行終端子の種類を調べる。
 	@param pszData 調査対象文字列へのポインタ
 	@param nDataLen 調査対象文字列の長さ
-	@return 改行コードの種類。終端子が見つからなかったときはEOL_NONEを返す。
+	@return 改行コードの種類。終端子が見つからなかったときはEEolType::noneを返す。
 */
 template <class T>
 EEolType GetEOLType( const T* pszData, int nDataLen )
@@ -92,7 +92,7 @@ EEolType GetEOLType( const T* pszData, int nDataLen )
 		if( g_aEolTable[i].StartsWith(pszData, nDataLen) )
 			return gm_pnEolTypeArr[i];
 	}
-	return EOL_NONE;
+	return EEolType::none;
 }
 
 /*
@@ -105,7 +105,7 @@ EEolType _GetEOLType_uni( const char* pszData, int nDataLen )
 		if( g_aEolTable_uni_file[i].StartsWithW(pszData, nDataLen) )
 			return gm_pnEolTypeArr[i];
 	}
-	return EOL_NONE;
+	return EEolType::none;
 }
 
 EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
@@ -114,7 +114,7 @@ EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
 		if( g_aEolTable_uni_file[i].StartsWithWB(pszData, nDataLen) )
 			return gm_pnEolTypeArr[i];
 	}
-	return EOL_NONE;
+	return EEolType::none;
 }
 
 //-----------------------------------------------
@@ -147,13 +147,13 @@ EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
 */
 constexpr bool CEol::SetType( EEolType t ) noexcept
 {
-	if( t == EOL_NONE || IsValid( t ) ){
+	if( t == EEolType::none || IsValid( t ) ){
 		// 正しい値
 		m_eEolType = t;
 		return true;
 	}else{
 		// 異常値
-		m_eEolType = EOL_CRLF;
+		m_eEolType = EEolType::cr_and_lf;
 		return false;
 	}
 }

--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -122,15 +122,21 @@ EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
 //-----------------------------------------------
 
 //! 現在のEOLの名称取得
-const WCHAR* CEol::GetName() const
+[[nodiscard]] LPCWSTR CEol::GetName() const noexcept
 {
-	return g_aEolTable[ m_eEolType ].m_szName;
+	return g_aEolTable[static_cast<size_t>(m_eEolType)].m_szName;
 }
 
-//!< 現在のEOL文字列先頭へのポインタを取得
-const wchar_t* CEol::GetValue2() const
+//! 現在のEOL文字列先頭へのポインタを取得
+[[nodiscard]] LPCWSTR CEol::GetValue2() const noexcept
 {
-	return g_aEolTable[ m_eEolType ].m_szDataW;
+	return g_aEolTable[static_cast<size_t>(m_eEolType)].m_szDataW;
+}
+
+//! 現在のEOL文字列長を取得。文字単位。
+[[nodiscard]] CLogicInt	CEol::GetLen() const noexcept
+{
+	return CLogicInt(g_aEolTable[static_cast<size_t>(m_eEolType)].m_nLen);
 }
 
 /*!
@@ -139,16 +145,17 @@ const wchar_t* CEol::GetValue2() const
 	@retval true 正常終了。設定が反映された。
 	@retval false 異常終了。強制的にCRLFに設定。
 */
-bool CEol::SetType( EEolType t )
+constexpr bool CEol::SetType( EEolType t ) noexcept
 {
-	if( t < EOL_NONE || EOL_CODEMAX <= t ){
-		//	異常値
+	if( t == EOL_NONE || IsValid( t ) ){
+		// 正しい値
+		m_eEolType = t;
+		return true;
+	}else{
+		// 異常値
 		m_eEolType = EOL_CRLF;
 		return false;
 	}
-	//	正しい値
-	m_eEolType = t;
-	return true;
 }
 
 void CEol::SetTypeByString( const wchar_t* pszData, int nDataLen )

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -37,18 +37,27 @@
 #include "_main/global.h"
 #include "basis/SakuraBasis.h"
 
-// 2002/09/22 Moca EOL_CRLF_UNICODEを廃止
-/* 行終端子の種類 */
+/*!
+	行終端子の種類
+
+	行末記号の種類を定義する。
+	0より大きい値は、終端の種類に対応する。
+	ファイル末尾の行では「終端がない状態」があり得る。
+	ドキュメントの行末スタイルに合わせて自動付与を行うための値も定義しておく。
+
+	@date 2002/09/22 Moca EOL_CRLF_UNICODEを廃止
+	@date 2021/03/27 berryzplus 定数に意味のある名前を付ける
+ */
 enum EEolType : char {
-	EOL_NONE,			//!< 
-	EOL_CRLF,			//!< 0d0a
-	EOL_LF,				//!< 0a
-	EOL_CR,				//!< 0d
-	EOL_NEL,			//!< 85
-	EOL_LS,				//!< 2028
-	EOL_PS,				//!< 2029
-	EOL_CODEMAX,		//
-	EOL_UNKNOWN = -1	//
+	none,					//!< 行終端子なし
+	cr_and_lf,				//!< \x0d\x0a 復帰改行
+	line_feed,				//!< \x0a 改行
+	carriage_return,		//!< \x0d 復帰
+	next_line,				//!< \u0085 NEL
+	line_separator,			//!< \u2028 LS
+	paragraph_separator,	//!< \u2029 PS
+	code_max,				//!< 範囲外検出用のマーカー(行終端子として使用しないこと)
+	auto_detect = -1		//!< 行終端子の自動検出
 };
 
 struct SEolDefinition{
@@ -62,7 +71,7 @@ struct SEolDefinition{
 };
 extern const SEolDefinition g_aEolTable[];
 
-#define EOL_TYPE_NUM	EOL_CODEMAX // 8
+#define EOL_TYPE_NUM	EEolType::code_max // 8
 
 /* 行終端子の配列 */
 extern const EEolType gm_pnEolTypeArr[EOL_TYPE_NUM];
@@ -75,16 +84,16 @@ extern const EEolType gm_pnEolTypeArr[EOL_TYPE_NUM];
 	クラス内部に閉じこめることができるのでそれなりに意味はあると思う。
 */
 class CEol {
-	EEolType m_eEolType = EOL_NONE;	//!< 改行コードの種類
+	EEolType m_eEolType = EEolType::none;	//!< 改行コードの種類
 
 public:
 	static constexpr bool IsNone( EEolType t ) noexcept
 	{
-		return t == EOL_NONE;
+		return t == EEolType::none;
 	}
 	static constexpr bool IsValid( EEolType t ) noexcept
 	{
-		return EEolType::none < t && t < EOL_CODEMAX;
+		return EEolType::none < t && t < EEolType::code_max;
 	}
 	static constexpr bool IsNoneOrValid( EEolType t ) noexcept
 	{

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -117,8 +117,24 @@ public:
 	//型変換
 	[[nodiscard]] constexpr explicit operator EEolType() const { return GetType(); }
 
-	//設定
-	constexpr bool SetType( EEolType t ) noexcept;
+	/*!
+		行末種別の設定。
+		@param t 行終端子の種別
+		@retval true 正常終了。設定が反映された。
+		@retval false 異常終了。強制的にCRLFに設定。
+	 */
+	constexpr bool SetType( EEolType t ) noexcept
+	{
+		if( IsNoneOrValid( t ) ){
+			// 正しい値
+			m_eEolType = t;
+			return true;
+		}else{
+			// 異常値
+			m_eEolType = EEolType::cr_and_lf;
+			return false;
+		}
+	}
 
 	//代入演算子
 	CEol& operator = ( EEolType t ) noexcept { SetType( t ); return *this; }

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include "_main/global.h"
+#include "basis/SakuraBasis.h"
 
 // 2002/09/22 Moca EOL_CRLF_UNICODEを廃止
 /* 行終端子の種類 */
@@ -65,8 +66,6 @@ extern const SEolDefinition g_aEolTable[];
 
 /* 行終端子の配列 */
 extern const EEolType gm_pnEolTypeArr[EOL_TYPE_NUM];
-
-#include "basis/SakuraBasis.h"
 
 /*!
 	@brief 行末の改行コードを管理

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -48,7 +48,8 @@
 	@date 2002/09/22 Moca EOL_CRLF_UNICODEを廃止
 	@date 2021/03/27 berryzplus 定数に意味のある名前を付ける
  */
-enum EEolType : char {
+enum class EEolType : char {
+	auto_detect = -1,		//!< 行終端子の自動検出
 	none,					//!< 行終端子なし
 	cr_and_lf,				//!< \x0d\x0a 復帰改行
 	line_feed,				//!< \x0a 改行
@@ -57,7 +58,6 @@ enum EEolType : char {
 	line_separator,			//!< \u2028 LS
 	paragraph_separator,	//!< \u2029 PS
 	code_max,				//!< 範囲外検出用のマーカー(行終端子として使用しないこと)
-	auto_detect = -1		//!< 行終端子の自動検出
 };
 
 struct SEolDefinition{
@@ -69,12 +69,8 @@ struct SEolDefinition{
 	bool StartsWith(const WCHAR* pData, int nLen) const{ return m_nLen<=nLen && 0==wmemcmp(pData,m_szDataW,m_nLen); }
 	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==memcmp(pData,m_szDataA,m_nLen); }
 };
-extern const SEolDefinition g_aEolTable[];
 
-#define EOL_TYPE_NUM	EEolType::code_max // 8
-
-/* 行終端子の配列 */
-extern const EEolType gm_pnEolTypeArr[EOL_TYPE_NUM];
+constexpr auto EOL_TYPE_NUM = static_cast<size_t>(EEolType::code_max); // 8
 
 /*!
 	@brief 行末の改行コードを管理
@@ -100,7 +96,7 @@ public:
 		return IsNone( t ) || IsValid( t );
 	}
 
-	constexpr CEol( EEolType t ) noexcept
+	constexpr explicit CEol( EEolType t ) noexcept
 	{
 		SetType( t );
 	}
@@ -119,7 +115,7 @@ public:
 	[[nodiscard]] constexpr bool operator != ( EEolType t ) const noexcept { return !operator == ( t ); }
 
 	//型変換
-	[[nodiscard]] constexpr operator EEolType() const { return GetType(); }
+	[[nodiscard]] constexpr explicit operator EEolType() const { return GetType(); }
 
 	//設定
 	constexpr bool SetType( EEolType t ) noexcept;
@@ -136,5 +132,11 @@ public:
 	void SetTypeByStringForFile_uni( const char* pszData, int nDataLen );
 	void SetTypeByStringForFile_unibe( const char* pszData, int nDataLen );
 };
+
+// グローバル演算子
+bool operator == ( const CEol& lhs, const CEol& rhs ) noexcept;
+bool operator != ( const CEol& lhs, const CEol& rhs ) noexcept;
+bool operator == ( EEolType lhs, const CEol& rhs ) noexcept;
+bool operator != ( EEolType lhs, const CEol& rhs ) noexcept;
 
 #endif /* SAKURA_CEOL_036E1E16_7462_46A4_8F59_51D8E171E657_H_ */

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -74,24 +74,51 @@ extern const EEolType gm_pnEolTypeArr[EOL_TYPE_NUM];
 	オブジェクトに対するメソッドで行えるだけだが、グローバル変数への参照を
 	クラス内部に閉じこめることができるのでそれなりに意味はあると思う。
 */
-class CEol{
+class CEol {
+	EEolType m_eEolType = EOL_NONE;	//!< 改行コードの種類
+
 public:
-	//コンストラクタ・デストラクタ
-	CEol(){ m_eEolType = EOL_NONE; }
-	CEol( EEolType t ){ SetType(t); }
+	static constexpr bool IsNone( EEolType t ) noexcept
+	{
+		return t == EOL_NONE;
+	}
+	static constexpr bool IsValid( EEolType t ) noexcept
+	{
+		return EEolType::none < t && t < EOL_CODEMAX;
+	}
+	static constexpr bool IsNoneOrValid( EEolType t ) noexcept
+	{
+		return IsNone( t ) || IsValid( t );
+	}
+
+	constexpr CEol( EEolType t ) noexcept
+	{
+		SetType( t );
+	}
+	CEol() noexcept = default;
+
+	//取得
+	[[nodiscard]] bool IsNone() const noexcept { return IsNone( m_eEolType ); }			//!< 行終端子がないかどうか
+	[[nodiscard]] bool IsValid() const noexcept { return !IsNone(); }					//!< 行終端子があるかどうか
+	[[nodiscard]] constexpr EEolType GetType() const noexcept { return m_eEolType; }	//!< 現在のTypeを取得
+	[[nodiscard]] LPCWSTR	GetName() const noexcept;	//!< 現在のEOLの名称取得
+	[[nodiscard]] LPCWSTR	GetValue2() const noexcept;	//!< 現在のEOL文字列先頭へのポインタを取得
+	[[nodiscard]] CLogicInt	GetLen() const noexcept;	//!< 現在のEOL長を取得。文字単位。
 
 	//比較
-	bool operator==( EEolType t ) const { return GetType() == t; }
-	bool operator!=( EEolType t ) const { return GetType() != t; }
-
-	//代入
-	const CEol& operator=( const CEol& t ){ m_eEolType = t.m_eEolType; return *this; }
+	[[nodiscard]] constexpr bool operator == ( EEolType t ) const noexcept { return GetType() == t; }
+	[[nodiscard]] constexpr bool operator != ( EEolType t ) const noexcept { return !operator == ( t ); }
 
 	//型変換
-	operator EEolType() const { return GetType(); }
+	[[nodiscard]] constexpr operator EEolType() const { return GetType(); }
 
 	//設定
-	bool SetType( EEolType t);	//	Typeの設定
+	constexpr bool SetType( EEolType t ) noexcept;
+
+	//代入演算子
+	CEol& operator = ( EEolType t ) noexcept { SetType( t ); return *this; }
+
+	//文字列内の行終端子を解析
 	void SetTypeByString( const wchar_t* pszData, int nDataLen );
 	void SetTypeByString( const char* pszData, int nDataLen );
 
@@ -99,20 +126,6 @@ public:
 	void SetTypeByStringForFile( const char* pszData, int nDataLen ){ SetTypeByString( pszData, nDataLen ); }
 	void SetTypeByStringForFile_uni( const char* pszData, int nDataLen );
 	void SetTypeByStringForFile_unibe( const char* pszData, int nDataLen );
-
-	//取得
-	EEolType		GetType()	const{ return m_eEolType; }		//!< 現在のTypeを取得
-	CLogicInt		GetLen()	const { return CLogicInt(g_aEolTable[ m_eEolType ].m_nLen); }	//!< 現在のEOL長を取得。文字単位。
-	const WCHAR*	GetName()	const;	//!< 現在のEOLの名称取得
-	const wchar_t*	GetValue2()	const;	//!< 現在のEOL文字列先頭へのポインタを取得
-	//#####
-
-	bool IsValid() const
-	{
-		return m_eEolType>=EOL_CRLF && m_eEolType<EOL_CODEMAX;
-	}
-
-private:
-	EEolType	m_eEolType;	//!< 改行コードの種類
 };
+
 #endif /* SAKURA_CEOL_036E1E16_7462_46A4_8F59_51D8E171E657_H_ */

--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -871,7 +871,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 			goto prev_line;
 		}
 		/* 改行も削除するんかぃのぉ・・・？ */
-		if( EEolType::none != pCDocLine->GetEol() &&
+		if( pCDocLine->GetEol().IsValid() &&
 			nWorkPos + nWorkLen > nLineLen - pCDocLine->GetEol().GetLen() // 2002/2/10 aroka CMemory変更
 		){
 			/* 削除する長さに改行も含める */

--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -871,7 +871,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 			goto prev_line;
 		}
 		/* 改行も削除するんかぃのぉ・・・？ */
-		if( EOL_NONE != pCDocLine->GetEol() &&
+		if( EEolType::none != pCDocLine->GetEol() &&
 			nWorkPos + nWorkLen > nLineLen - pCDocLine->GetEol().GetLen() // 2002/2/10 aroka CMemory変更
 		){
 			/* 削除する長さに改行も含める */

--- a/sakura_core/charset/CCodeBase.cpp
+++ b/sakura_core/charset/CCodeBase.cpp
@@ -125,5 +125,6 @@ void CCodeBase::S_GetEol(CMemory* pcmemEol, EEolType eEolType)
 		{ "",			0 },	// EEolType::line_separator
 		{ "",			0 },	// EEolType::paragraph_separator
 	};
-	pcmemEol->SetRawData(aEolTable[eEolType].szData,aEolTable[eEolType].nLen);
+	auto& data = aEolTable[static_cast<size_t>(eEolType)];
+	pcmemEol->SetRawData(data.szData, data.nLen);
 }

--- a/sakura_core/charset/CCodeBase.cpp
+++ b/sakura_core/charset/CCodeBase.cpp
@@ -117,13 +117,13 @@ void CCodeBase::S_GetEol(CMemory* pcmemEol, EEolType eEolType)
 		int nLen;
 	}
 	aEolTable[EOL_TYPE_NUM] = {
-		{ "",			0 },	// EOL_NONE
-		{ "\x0d\x0a",	2 },	// EOL_CRLF
-		{ "\x0a",		1 },	// EOL_LF
-		{ "\x0d",		1 },	// EOL_CR
-		{ "",			0 },	// EOL_NEL
-		{ "",			0 },	// EOL_LS
-		{ "",			0 },	// EOL_PS
+		{ "",			0 },	// EEolType::none
+		{ "\x0d\x0a",	2 },	// EEolType::cr_and_lf
+		{ "\x0a",		1 },	// EEolType::line_feed
+		{ "\x0d",		1 },	// EEolType::carriage_return
+		{ "",			0 },	// EEolType::next_line
+		{ "",			0 },	// EEolType::line_separator
+		{ "",			0 },	// EEolType::paragraph_separator
 	};
 	pcmemEol->SetRawData(aEolTable[eEolType].szData,aEolTable[eEolType].nLen);
 }

--- a/sakura_core/charset/CCodeBase.h
+++ b/sakura_core/charset/CCodeBase.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "mem/CNativeW.h"
+#include "CEol.h"
 
 //定数
 enum EConvertResult{
@@ -37,7 +38,6 @@ enum EConvertResult{
 };
 
 struct CommonSetting_Statusbar;
-enum EEolType : char;
 
 /*!
 	文字コード基底クラス。

--- a/sakura_core/charset/CUnicode.cpp
+++ b/sakura_core/charset/CUnicode.cpp
@@ -100,13 +100,13 @@ void CUnicode::GetEol(CMemory* pcmemEol, EEolType eEolType)
 		int nLen;
 	}
 	aEolTable[EOL_TYPE_NUM] = {
-		{ L"",			0 * sizeof(wchar_t) },	// EOL_NONE
-		{ L"\x0d\x0a",	2 * sizeof(wchar_t) },	// EOL_CRLF
-		{ L"\x0a",		1 * sizeof(wchar_t) },	// EOL_LF
-		{ L"\x0d",		1 * sizeof(wchar_t) },	// EOL_CR
-		{ L"\x85",		1 * sizeof(wchar_t) },	// EOL_NEL
-		{ L"\u2028",	1 * sizeof(wchar_t) },	// EOL_LS
-		{ L"\u2029",	1 * sizeof(wchar_t) },	// EOL_PS
+		{ L"",			0 * sizeof(wchar_t) },	// EEolType::none
+		{ L"\x0d\x0a",	2 * sizeof(wchar_t) },	// EEolType::cr_and_lf
+		{ L"\x0a",		1 * sizeof(wchar_t) },	// EEolType::line_feed
+		{ L"\x0d",		1 * sizeof(wchar_t) },	// EEolType::carriage_return
+		{ L"\x85",		1 * sizeof(wchar_t) },	// EEolType::next_line
+		{ L"\u2028",	1 * sizeof(wchar_t) },	// EEolType::line_separator
+		{ L"\u2029",	1 * sizeof(wchar_t) },	// EEolType::paragraph_separator
 	};
 	pcmemEol->SetRawData(aEolTable[eEolType].pData,aEolTable[eEolType].nLen);
 }

--- a/sakura_core/charset/CUnicode.cpp
+++ b/sakura_core/charset/CUnicode.cpp
@@ -108,5 +108,6 @@ void CUnicode::GetEol(CMemory* pcmemEol, EEolType eEolType)
 		{ L"\u2028",	1 * sizeof(wchar_t) },	// EEolType::line_separator
 		{ L"\u2029",	1 * sizeof(wchar_t) },	// EEolType::paragraph_separator
 	};
-	pcmemEol->SetRawData(aEolTable[eEolType].pData,aEolTable[eEolType].nLen);
+	auto& data = aEolTable[static_cast<size_t>(eEolType)];
+	pcmemEol->SetRawData(data.pData, data.nLen);
 }

--- a/sakura_core/charset/CUnicodeBe.cpp
+++ b/sakura_core/charset/CUnicodeBe.cpp
@@ -50,5 +50,6 @@ void CUnicodeBe::GetEol(CMemory* pcmemEol, EEolType eEolType)
 		{ "\x20\x28",			1 * sizeof(wchar_t) },	// EEolType::line_separator
 		{ "\x20\x29",			1 * sizeof(wchar_t) },	// EEolType::paragraph_separator
 	};
-	pcmemEol->SetRawData(aEolTable[eEolType].pData,aEolTable[eEolType].nLen);
+	auto& data = aEolTable[static_cast<size_t>(eEolType)];
+	pcmemEol->SetRawData(data.pData, data.nLen);
 }

--- a/sakura_core/charset/CUnicodeBe.cpp
+++ b/sakura_core/charset/CUnicodeBe.cpp
@@ -42,13 +42,13 @@ void CUnicodeBe::GetEol(CMemory* pcmemEol, EEolType eEolType)
 		int nLen;
 	}
 	aEolTable[EOL_TYPE_NUM] = {
-		{ "",					0 * sizeof(wchar_t) },	// EOL_NONE
-		{ "\x00\x0d\x00\x0a",	2 * sizeof(wchar_t) },	// EOL_CRLF
-		{ "\x00\x0a",			1 * sizeof(wchar_t) },	// EOL_LF
-		{ "\x00\x0d",			1 * sizeof(wchar_t) },	// EOL_CR
-		{ "\x00\x85",			1 * sizeof(wchar_t) },	// EOL_NEL
-		{ "\x20\x28",			1 * sizeof(wchar_t) },	// EOL_LS
-		{ "\x20\x29",			1 * sizeof(wchar_t) },	// EOL_PS
+		{ "",					0 * sizeof(wchar_t) },	// EEolType::none
+		{ "\x00\x0d\x00\x0a",	2 * sizeof(wchar_t) },	// EEolType::cr_and_lf
+		{ "\x00\x0a",			1 * sizeof(wchar_t) },	// EEolType::line_feed
+		{ "\x00\x0d",			1 * sizeof(wchar_t) },	// EEolType::carriage_return
+		{ "\x00\x85",			1 * sizeof(wchar_t) },	// EEolType::next_line
+		{ "\x20\x28",			1 * sizeof(wchar_t) },	// EEolType::line_separator
+		{ "\x20\x29",			1 * sizeof(wchar_t) },	// EEolType::paragraph_separator
 	};
 	pcmemEol->SetRawData(aEolTable[eEolType].pData,aEolTable[eEolType].nLen);
 }

--- a/sakura_core/charset/CUtf7.cpp
+++ b/sakura_core/charset/CUtf7.cpp
@@ -297,5 +297,6 @@ void CUtf7::GetEol(CMemory* pcmemEol, EEolType eEolType)
 		{ "+ICg-",		5 },	// EEolType::line_separator
 		{ "+ICk-",		5 },	// EEolType::paragraph_separator
 	};
-	pcmemEol->SetRawData(aEolTable[eEolType].szData,aEolTable[eEolType].nLen);
+	auto& data = aEolTable[static_cast<size_t>(eEolType)];
+	pcmemEol->SetRawData(data.szData, data.nLen);
 }

--- a/sakura_core/charset/CUtf7.cpp
+++ b/sakura_core/charset/CUtf7.cpp
@@ -289,13 +289,13 @@ void CUtf7::GetEol(CMemory* pcmemEol, EEolType eEolType)
 		int nLen;
 	}
 	aEolTable[EOL_TYPE_NUM] = {
-		{ "",			0 },	// EOL_NONE
-		{ "\x0d\x0a",	2 },	// EOL_CRLF
-		{ "\x0a",		1 },	// EOL_LF
-		{ "\x0d",		1 },	// EOL_CR
-		{ "+AIU-",		5 },	// EOL_NEL
-		{ "+ICg-",		5 },	// EOL_LS
-		{ "+ICk-",		5 },	// EOL_PS
+		{ "",			0 },	// EEolType::none
+		{ "\x0d\x0a",	2 },	// EEolType::cr_and_lf
+		{ "\x0a",		1 },	// EEolType::line_feed
+		{ "\x0d",		1 },	// EEolType::carriage_return
+		{ "+AIU-",		5 },	// EEolType::next_line
+		{ "+ICg-",		5 },	// EEolType::line_separator
+		{ "+ICk-",		5 },	// EEolType::paragraph_separator
 	};
 	pcmemEol->SetRawData(aEolTable[eEolType].szData,aEolTable[eEolType].nLen);
 }

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -53,7 +53,8 @@ void CUtf8::GetEol(CMemory* pcmemEol, EEolType eEolType){
 		"\xe2\x80\xa8",		3,	// EEolType::line_separator
 		"\xe2\x80\xa9",		3,	// EEolType::paragraph_separator
 	};
-	pcmemEol->SetRawData(aEolTable[eEolType].szData,aEolTable[eEolType].nLen);
+	auto& data = aEolTable[static_cast<size_t>(eEolType)];
+	pcmemEol->SetRawData(data.szData, data.nLen);
 }
 
 /*!

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -45,13 +45,13 @@ void CUtf8::GetEol(CMemory* pcmemEol, EEolType eEolType){
 		int nLen;
 	}
 	aEolTable[EOL_TYPE_NUM] = {
-		"",			0,	// EOL_NONE
-		"\x0d\x0a",	2,	// EOL_CRLF
-		"\x0a",		1,	// EOL_LF
-		"\x0d",		1,	// EOL_CR
-		"\xc2\x85",			2,	// EOL_NEL
-		"\xe2\x80\xa8",		3,	// EOL_LS
-		"\xe2\x80\xa9",		3,	// EOL_PS
+		"",			0,	// EEolType::none
+		"\x0d\x0a",	2,	// EEolType::cr_and_lf
+		"\x0a",		1,	// EEolType::line_feed
+		"\x0d",		1,	// EEolType::carriage_return
+		"\xc2\x85",			2,	// EEolType::next_line
+		"\xe2\x80\xa8",		3,	// EEolType::line_separator
+		"\xe2\x80\xa9",		3,	// EEolType::paragraph_separator
 	};
 	pcmemEol->SetRawData(aEolTable[eEolType].szData,aEolTable[eEolType].nLen);
 }

--- a/sakura_core/cmd/CViewCommander.cpp
+++ b/sakura_core/cmd/CViewCommander.cpp
@@ -370,7 +370,7 @@ BOOL CViewCommander::HandleCommand(
 	case F_CUT:						Command_CUT();break;					//切り取り(選択範囲をクリップボードにコピーして削除)
 	case F_COPY:					Command_COPY( false, GetDllShareData().m_Common.m_sEdit.m_bAddCRLFWhenCopy );break;			//コピー(選択範囲をクリップボードにコピー)
 	case F_COPY_ADDCRLF:			Command_COPY( false, true );break;		//折り返し位置に改行をつけてコピー(選択範囲をクリップボードにコピー)
-	case F_COPY_CRLF:				Command_COPY( false, GetDllShareData().m_Common.m_sEdit.m_bAddCRLFWhenCopy, EOL_CRLF );break;	//CRLF改行でコピー(選択範囲をクリップボードにコピー)
+	case F_COPY_CRLF:				Command_COPY( false, GetDllShareData().m_Common.m_sEdit.m_bAddCRLFWhenCopy, EEolType::cr_and_lf );break;	//CRLF改行でコピー(選択範囲をクリップボードにコピー)
 	case F_PASTE:					Command_PASTE( (int)lparam1 );break;				//貼り付け(クリップボードから貼り付け)
 	case F_PASTEBOX:				Command_PASTEBOX( (int)lparam1 );break;				//矩形貼り付け(クリップボードから矩形貼り付け)
 	case F_INSBOXTEXT:				Command_INSBOXTEXT((const wchar_t*)lparam1, (int)lparam2 );break;				//矩形テキスト挿入
@@ -481,9 +481,9 @@ BOOL CViewCommander::HandleCommand(
 	case F_CHG_CHARSET:		Command_CHG_CHARSET( (ECodeType)lparam1, lparam2 != 0 );break;	//文字コードセット指定	2010/6/14 Uchi
 	// From Here 2003.06.23 Moca
 	// F_CHGMOD_EOL_xxx はマクロに記録されないが、F_CHGMOD_EOLはマクロに記録されるので、マクロ関数を統合できるという手はず
-	case F_CHGMOD_EOL_CRLF:	HandleCommand( F_CHGMOD_EOL, bRedraw, EOL_CRLF, 0, 0, 0 );break;	//入力する改行コードをCRLFに設定
-	case F_CHGMOD_EOL_LF:	HandleCommand( F_CHGMOD_EOL, bRedraw, EOL_LF, 0, 0, 0 );break;	//入力する改行コードをLFに設定
-	case F_CHGMOD_EOL_CR:	HandleCommand( F_CHGMOD_EOL, bRedraw, EOL_CR, 0, 0, 0 );break;	//入力する改行コードをCRに設定
+	case F_CHGMOD_EOL_CRLF:	HandleCommand( F_CHGMOD_EOL, bRedraw, EEolType::cr_and_lf, 0, 0, 0 );break;	//入力する改行コードをCRLFに設定
+	case F_CHGMOD_EOL_LF:	HandleCommand( F_CHGMOD_EOL, bRedraw, EEolType::line_feed, 0, 0, 0 );break;	//入力する改行コードをLFに設定
+	case F_CHGMOD_EOL_CR:	HandleCommand( F_CHGMOD_EOL, bRedraw, EEolType::carriage_return, 0, 0, 0 );break;	//入力する改行コードをCRに設定
 	// 2006.09.03 Moca F_CHGMOD_EOLで break 忘れの修正
 	case F_CHGMOD_EOL:		Command_CHGMOD_EOL( (EEolType)lparam1 );break;	//入力する改行コードを設定
 	// To Here 2003.06.23 Moca

--- a/sakura_core/cmd/CViewCommander.cpp
+++ b/sakura_core/cmd/CViewCommander.cpp
@@ -481,9 +481,9 @@ BOOL CViewCommander::HandleCommand(
 	case F_CHG_CHARSET:		Command_CHG_CHARSET( (ECodeType)lparam1, lparam2 != 0 );break;	//文字コードセット指定	2010/6/14 Uchi
 	// From Here 2003.06.23 Moca
 	// F_CHGMOD_EOL_xxx はマクロに記録されないが、F_CHGMOD_EOLはマクロに記録されるので、マクロ関数を統合できるという手はず
-	case F_CHGMOD_EOL_CRLF:	HandleCommand( F_CHGMOD_EOL, bRedraw, EEolType::cr_and_lf, 0, 0, 0 );break;	//入力する改行コードをCRLFに設定
-	case F_CHGMOD_EOL_LF:	HandleCommand( F_CHGMOD_EOL, bRedraw, EEolType::line_feed, 0, 0, 0 );break;	//入力する改行コードをLFに設定
-	case F_CHGMOD_EOL_CR:	HandleCommand( F_CHGMOD_EOL, bRedraw, EEolType::carriage_return, 0, 0, 0 );break;	//入力する改行コードをCRに設定
+	case F_CHGMOD_EOL_CRLF:	HandleCommand( F_CHGMOD_EOL, bRedraw, static_cast<LPARAM>(EEolType::cr_and_lf), 0, 0, 0 );break;	//入力する改行コードをCRLFに設定
+	case F_CHGMOD_EOL_LF:	HandleCommand( F_CHGMOD_EOL, bRedraw, static_cast<LPARAM>(EEolType::line_feed), 0, 0, 0 );break;	//入力する改行コードをLFに設定
+	case F_CHGMOD_EOL_CR:	HandleCommand( F_CHGMOD_EOL, bRedraw, static_cast<LPARAM>(EEolType::carriage_return), 0, 0, 0 );break;	//入力する改行コードをCRに設定
 	// 2006.09.03 Moca F_CHGMOD_EOLで break 忘れの修正
 	case F_CHGMOD_EOL:		Command_CHGMOD_EOL( (EEolType)lparam1 );break;	//入力する改行コードを設定
 	// To Here 2003.06.23 Moca

--- a/sakura_core/cmd/CViewCommander.h
+++ b/sakura_core/cmd/CViewCommander.h
@@ -213,7 +213,7 @@ public:
 
 	/* クリップボード系 */
 	void Command_CUT( void );						/* 切り取り（選択範囲をクリップボードにコピーして削除）*/
-	void Command_COPY( bool bIgnoreLockAndDisable, bool bAddCRLFWhenCopy, EEolType neweol = EOL_UNKNOWN );/* コピー(選択範囲をクリップボードにコピー) */
+	void Command_COPY( bool bIgnoreLockAndDisable, bool bAddCRLFWhenCopy, EEolType neweol = EEolType::auto_detect );/* コピー(選択範囲をクリップボードにコピー) */
 	void Command_PASTE( int option );						/* 貼り付け（クリップボードから貼り付け）*/
 	void Command_PASTEBOX( int option );					/* 矩形貼り付け（クリップボードから矩形貼り付け）*/
 	//<< 2002/03/29 Azumaiya

--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -222,7 +222,7 @@ int CViewCommander::Command_LEFT( bool bSelect, bool bRepeat )
 				}
 			}
 			if (it.end()) {
-				const bool has_eol = EOL_NONE != pcLayout->GetLayoutEol(); // 改行文字で終わっているか。
+				const bool has_eol = EEolType::none != pcLayout->GetLayoutEol(); // 改行文字で終わっているか。
 				const CLayoutXInt dx_default = this->m_pCommanderView->GetTextMetrics().GetLayoutXDefault(); // 文字のない部分の移動量。
 				const CLayoutXInt eol_hosei = has_eol ? CLayoutXInt(-it.getColumnDelta() + dx_default) : CLayoutXInt(0);
 				if (ptCaretMove.GetX2() <= it.getColumn() + eol_hosei) {
@@ -297,8 +297,8 @@ void CViewCommander::Command_RIGHT( bool bSelect, bool bIgnoreCurrentSelection, 
 		{
 			// キャレット位置のレイアウト行について。
 			const CLayoutInt x_wrap = pcLayout->CalcLayoutWidth( GetDocument()->m_cLayoutMgr ); // 改行文字、または折り返しの位置。
-			const bool wrapped = EOL_NONE == pcLayout->GetLayoutEol(); // 折り返しているか、改行文字で終わっているか。これにより x_wrapの意味が変わる。
-			const bool nextline_exists = pcLayout->GetNextLayout() || pcLayout->GetLayoutEol() != EOL_NONE; // EOFのみの行も含め、キャレットが移動可能な次行が存在するか。
+			const bool wrapped = EEolType::none == pcLayout->GetLayoutEol(); // 折り返しているか、改行文字で終わっているか。これにより x_wrapの意味が変わる。
+			const bool nextline_exists = pcLayout->GetNextLayout() || pcLayout->GetLayoutEol() != EEolType::none; // EOFのみの行も含め、キャレットが移動可能な次行が存在するか。
 
 			const CLayoutXInt dx_default = this->m_pCommanderView->GetTextMetrics().GetLayoutXDefault(); // 文字のない部分(※改行マーク部分を含む)の移動量。
 
@@ -1288,7 +1288,7 @@ void CViewCommander::Command_MODIFYLINE_NEXT( bool bSelect )
 			bool bSkip = false;
 			CLogicPoint pos;
 			if( pcDocLineLast != NULL ){
-				if( pcDocLineLast->GetEol() == EOL_NONE ){
+				if( pcDocLineLast->GetEol() == EEolType::none ){
 					// ぶら下がり[EOF]
 					pos.x = pcDocLineLast->GetLengthWithoutEOL();
 					pos.y = GetDocument()->m_cDocLineMgr.GetLineCount() - 1;
@@ -1349,7 +1349,7 @@ void CViewCommander::Command_MODIFYLINE_PREV( bool bSelect )
 	}
 	if( !bLast ){
 		const CDocLine* pcDocLineLast = GetDocument()->m_cDocLineMgr.GetDocLineBottom();
-		if( pcDocLineLast != NULL && pcDocLineLast->GetEol() == EOL_NONE ){
+		if( pcDocLineLast != NULL && pcDocLineLast->GetEol() == EEolType::none ){
 			CLogicPoint pos;
 			pos.x = pcDocLine->GetLengthWithoutEOL();
 			pos.y = GetDocument()->m_cDocLineMgr.GetLineCount() - 1;
@@ -1415,7 +1415,7 @@ void CViewCommander::Command_MODIFYLINE_PREV( bool bSelect )
 			if( CModifyVisitor().IsLineModified(pcDocLineTemp, nSaveSeq) != false ){
 				// 最終行が変更行の場合は、[EOF]に止まる
 				CLogicPoint pos;
-				if( pcDocLineTemp->GetEol() != EOL_NONE ){
+				if( pcDocLineTemp->GetEol() != EEolType::none ){
 					pos.x = 0;
 					pos.y = GetDocument()->m_cDocLineMgr.GetLineCount();
 					pos.y++;

--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -222,7 +222,7 @@ int CViewCommander::Command_LEFT( bool bSelect, bool bRepeat )
 				}
 			}
 			if (it.end()) {
-				const bool has_eol = EEolType::none != pcLayout->GetLayoutEol(); // 改行文字で終わっているか。
+				const bool has_eol = pcLayout->GetLayoutEol().IsValid(); // 改行文字で終わっているか。
 				const CLayoutXInt dx_default = this->m_pCommanderView->GetTextMetrics().GetLayoutXDefault(); // 文字のない部分の移動量。
 				const CLayoutXInt eol_hosei = has_eol ? CLayoutXInt(-it.getColumnDelta() + dx_default) : CLayoutXInt(0);
 				if (ptCaretMove.GetX2() <= it.getColumn() + eol_hosei) {
@@ -297,8 +297,8 @@ void CViewCommander::Command_RIGHT( bool bSelect, bool bIgnoreCurrentSelection, 
 		{
 			// キャレット位置のレイアウト行について。
 			const CLayoutInt x_wrap = pcLayout->CalcLayoutWidth( GetDocument()->m_cLayoutMgr ); // 改行文字、または折り返しの位置。
-			const bool wrapped = EEolType::none == pcLayout->GetLayoutEol(); // 折り返しているか、改行文字で終わっているか。これにより x_wrapの意味が変わる。
-			const bool nextline_exists = pcLayout->GetNextLayout() || pcLayout->GetLayoutEol() != EEolType::none; // EOFのみの行も含め、キャレットが移動可能な次行が存在するか。
+			const bool wrapped = pcLayout->GetLayoutEol().IsNone(); // 折り返しているか、改行文字で終わっているか。これにより x_wrapの意味が変わる。
+			const bool nextline_exists = pcLayout->GetNextLayout() || pcLayout->GetLayoutEol().IsValid(); // EOFのみの行も含め、キャレットが移動可能な次行が存在するか。
 
 			const CLayoutXInt dx_default = this->m_pCommanderView->GetTextMetrics().GetLayoutXDefault(); // 文字のない部分(※改行マーク部分を含む)の移動量。
 
@@ -1288,7 +1288,7 @@ void CViewCommander::Command_MODIFYLINE_NEXT( bool bSelect )
 			bool bSkip = false;
 			CLogicPoint pos;
 			if( pcDocLineLast != NULL ){
-				if( pcDocLineLast->GetEol() == EEolType::none ){
+				if( pcDocLineLast->GetEol().IsNone() ){
 					// ぶら下がり[EOF]
 					pos.x = pcDocLineLast->GetLengthWithoutEOL();
 					pos.y = GetDocument()->m_cDocLineMgr.GetLineCount() - 1;
@@ -1349,7 +1349,7 @@ void CViewCommander::Command_MODIFYLINE_PREV( bool bSelect )
 	}
 	if( !bLast ){
 		const CDocLine* pcDocLineLast = GetDocument()->m_cDocLineMgr.GetDocLineBottom();
-		if( pcDocLineLast != NULL && pcDocLineLast->GetEol() == EEolType::none ){
+		if( pcDocLineLast != NULL && pcDocLineLast->GetEol().IsNone() ){
 			CLogicPoint pos;
 			pos.x = pcDocLine->GetLengthWithoutEOL();
 			pos.y = GetDocument()->m_cDocLineMgr.GetLineCount() - 1;
@@ -1415,7 +1415,7 @@ void CViewCommander::Command_MODIFYLINE_PREV( bool bSelect )
 			if( CModifyVisitor().IsLineModified(pcDocLineTemp, nSaveSeq) != false ){
 				// 最終行が変更行の場合は、[EOF]に止まる
 				CLogicPoint pos;
-				if( pcDocLineTemp->GetEol() != EEolType::none ){
+				if( pcDocLineTemp->GetEol().IsValid() ){
 					pos.x = 0;
 					pos.y = GetDocument()->m_cDocLineMgr.GetLineCount();
 					pos.y++;

--- a/sakura_core/cmd/CViewCommander_Edit.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit.cpp
@@ -791,7 +791,7 @@ void CViewCommander::Command_DELETE( void )
 				CLogicInt nIndex;
 				nIndex = m_pCommanderView->LineColumnToIndex2( pcLayout, GetCaret().GetCaretLayoutPos().GetX2(), &nLineLen );
 				if( nLineLen != 0 ){	// 折り返しや改行コードより右の場合には nLineLen に行全体の表示桁数が入る
-					if( EOL_NONE != pcLayout->GetLayoutEol().GetType() ){	// 行終端は改行コードか?
+					if( EEolType::none != pcLayout->GetLayoutEol().GetType() ){	// 行終端は改行コードか?
 						Command_INSTEXT( true, L"", CLogicInt(0), FALSE );	// カーソル位置まで半角スペース挿入
 					}else{	// 行終端が折り返し
 						// 折り返し行末ではスペース挿入後、次の文字を削除する	// 2009.02.19 ryoji
@@ -880,7 +880,7 @@ void CViewCommander::DelCharForOverwrite( const wchar_t* pszInput, int nLen )
 		CLogicInt nIdxTo = m_pCommanderView->LineColumnToIndex( pcLayout, GetCaret().GetCaretLayoutPos().GetX2() );
 		if( nIdxTo >= pcLayout->GetLengthWithoutEOL() ){
 			bEol = true;	// 現在位置は改行または折り返し以後
-			if( pcLayout->GetLayoutEol() != EOL_NONE ){
+			if( pcLayout->GetLayoutEol() != EEolType::none ){
 				if( GetDllShareData().m_Common.m_sEdit.m_bNotOverWriteCRLF ){	/* 改行は上書きしない */
 					/* 現在位置が改行ならば削除しない */
 					bDelete = FALSE;

--- a/sakura_core/cmd/CViewCommander_Edit.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit.cpp
@@ -791,7 +791,7 @@ void CViewCommander::Command_DELETE( void )
 				CLogicInt nIndex;
 				nIndex = m_pCommanderView->LineColumnToIndex2( pcLayout, GetCaret().GetCaretLayoutPos().GetX2(), &nLineLen );
 				if( nLineLen != 0 ){	// 折り返しや改行コードより右の場合には nLineLen に行全体の表示桁数が入る
-					if( EEolType::none != pcLayout->GetLayoutEol().GetType() ){	// 行終端は改行コードか?
+					if( pcLayout->GetLayoutEol().IsValid() ){	// 行終端は改行コードか?
 						Command_INSTEXT( true, L"", CLogicInt(0), FALSE );	// カーソル位置まで半角スペース挿入
 					}else{	// 行終端が折り返し
 						// 折り返し行末ではスペース挿入後、次の文字を削除する	// 2009.02.19 ryoji
@@ -880,7 +880,7 @@ void CViewCommander::DelCharForOverwrite( const wchar_t* pszInput, int nLen )
 		CLogicInt nIdxTo = m_pCommanderView->LineColumnToIndex( pcLayout, GetCaret().GetCaretLayoutPos().GetX2() );
 		if( nIdxTo >= pcLayout->GetLengthWithoutEOL() ){
 			bEol = true;	// 現在位置は改行または折り返し以後
-			if( pcLayout->GetLayoutEol() != EEolType::none ){
+			if( pcLayout->GetLayoutEol().IsValid() ){
 				if( GetDllShareData().m_Common.m_sEdit.m_bNotOverWriteCRLF ){	/* 改行は上書きしない */
 					/* 現在位置が改行ならば削除しない */
 					bDelete = FALSE;

--- a/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
@@ -215,7 +215,7 @@ void CViewCommander::Command_INDENT( const wchar_t* const pData, const CLogicInt
 				}
 				const bool emptyLine = ! pcLayout || 0 == pcLayout->GetLengthWithoutEOL();
 				const bool selectionIsOutOfLine = reachEndOfLayout && (
-					(pcLayout && pcLayout->GetLayoutEol() != EOL_NONE) ? xLayoutFrom == xLayoutTo : xLayoutTo < rcSel.GetFrom().x
+					(pcLayout && pcLayout->GetLayoutEol() != EEolType::none) ? xLayoutFrom == xLayoutTo : xLayoutTo < rcSel.GetFrom().x
 				);
 
 				// 入力文字の挿入位置
@@ -675,7 +675,7 @@ void CViewCommander::Command_SORT(BOOL bAsc)	//bAsc:TRUE=昇順,FALSE=降順
 		if ( sSelectOld.GetTo().x > 0 ) {
 			// 2006.03.31 Moca nSelectLineToOldは、物理行なのでLayout系からDocLine系に修正
 			const CDocLine* pcDocLine = GetDocument()->m_cDocLineMgr.GetLine( sSelectOld.GetTo().GetY2() );
-			if( NULL != pcDocLine && EOL_NONE != pcDocLine->GetEol() ){
+			if( NULL != pcDocLine && EEolType::none != pcDocLine->GetEol() ){
 				sSelectOld.GetToPointer()->y++;
 			}
 		}
@@ -844,14 +844,14 @@ void CViewCommander::Command_MERGE(void)
 	if ( sSelectOld.GetTo().x > 0 ) {
 #if 0
 		const CLayout* pcLayout=GetDocument()->m_cLayoutMgr.SearchLineByLayoutY(m_pCommanderView->GetSelectionInfo().m_sSelect.GetTo().GetY2()); //2007.10.09 kobake 単位混在バグ修正
-		if( NULL != pcLayout && EOL_NONE != pcLayout->GetLayoutEol() ){
+		if( NULL != pcLayout && EEolType::none != pcLayout->GetLayoutEol() ){
 			sSelectOld.GetToPointer()->y++;
 			//sSelectOld.GetTo().y++;
 		}
 #else
 		// 2010.08.22 Moca ソートと仕様を合わせる
 		const CDocLine* pcDocLine = GetDocument()->m_cDocLineMgr.GetLine( sSelectOld.GetTo().GetY2() );
-		if( NULL != pcDocLine && EOL_NONE != pcDocLine->GetEol() ){
+		if( NULL != pcDocLine && EEolType::none != pcDocLine->GetEol() ){
 			sSelectOld.GetToPointer()->y++;
 		}
 #endif

--- a/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
@@ -215,7 +215,7 @@ void CViewCommander::Command_INDENT( const wchar_t* const pData, const CLogicInt
 				}
 				const bool emptyLine = ! pcLayout || 0 == pcLayout->GetLengthWithoutEOL();
 				const bool selectionIsOutOfLine = reachEndOfLayout && (
-					(pcLayout && pcLayout->GetLayoutEol() != EEolType::none) ? xLayoutFrom == xLayoutTo : xLayoutTo < rcSel.GetFrom().x
+					(pcLayout && pcLayout->GetLayoutEol().IsValid()) ? xLayoutFrom == xLayoutTo : xLayoutTo < rcSel.GetFrom().x
 				);
 
 				// 入力文字の挿入位置
@@ -675,7 +675,7 @@ void CViewCommander::Command_SORT(BOOL bAsc)	//bAsc:TRUE=昇順,FALSE=降順
 		if ( sSelectOld.GetTo().x > 0 ) {
 			// 2006.03.31 Moca nSelectLineToOldは、物理行なのでLayout系からDocLine系に修正
 			const CDocLine* pcDocLine = GetDocument()->m_cDocLineMgr.GetLine( sSelectOld.GetTo().GetY2() );
-			if( NULL != pcDocLine && EEolType::none != pcDocLine->GetEol() ){
+			if( NULL != pcDocLine && pcDocLine->GetEol().IsValid() ){
 				sSelectOld.GetToPointer()->y++;
 			}
 		}
@@ -844,14 +844,14 @@ void CViewCommander::Command_MERGE(void)
 	if ( sSelectOld.GetTo().x > 0 ) {
 #if 0
 		const CLayout* pcLayout=GetDocument()->m_cLayoutMgr.SearchLineByLayoutY(m_pCommanderView->GetSelectionInfo().m_sSelect.GetTo().GetY2()); //2007.10.09 kobake 単位混在バグ修正
-		if( NULL != pcLayout && EEolType::none != pcLayout->GetLayoutEol() ){
+		if( NULL != pcLayout && pcLayout->GetLayoutEol().IsValid() ){
 			sSelectOld.GetToPointer()->y++;
 			//sSelectOld.GetTo().y++;
 		}
 #else
 		// 2010.08.22 Moca ソートと仕様を合わせる
 		const CDocLine* pcDocLine = GetDocument()->m_cDocLineMgr.GetLine( sSelectOld.GetTo().GetY2() );
-		if( NULL != pcDocLine && EEolType::none != pcDocLine->GetEol() ){
+		if( NULL != pcDocLine && pcDocLine->GetEol().IsValid() ){
 			sSelectOld.GetToPointer()->y++;
 		}
 #endif

--- a/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
@@ -166,7 +166,7 @@ void CViewCommander::Command_LineCutToEnd( void )
 
 	CLayoutPoint ptPos;
 
-	if( EOL_NONE == pCLayout->GetDocLineRef()->GetEol() ){	/* 改行コードの種類 */
+	if( EEolType::none == pCLayout->GetDocLineRef()->GetEol() ){	/* 改行コードの種類 */
 		GetDocument()->m_cLayoutMgr.LogicToLayout(
 			CLogicPoint(
 				pCLayout->GetDocLineRef()->GetLengthWithEOL(),
@@ -246,7 +246,7 @@ void CViewCommander::Command_LineDeleteToEnd( void )
 
 	CLayoutPoint ptPos;
 
-	if( EOL_NONE == pCLayout->GetDocLineRef()->GetEol() ){	/* 改行コードの種類 */
+	if( EEolType::none == pCLayout->GetDocLineRef()->GetEol() ){	/* 改行コードの種類 */
 		GetDocument()->m_cLayoutMgr.LogicToLayout(
 			CLogicPoint(
 				pCLayout->GetDocLineRef()->GetLengthWithEOL(),
@@ -300,7 +300,7 @@ void CViewCommander::Command_CUT_LINE( void )
 	// 2007.10.04 ryoji 処理簡素化
 	m_pCommanderView->CopyCurLine(
 		GetDllShareData().m_Common.m_sEdit.m_bAddCRLFWhenCopy,
-		EOL_UNKNOWN,
+		EEolType::auto_detect,
 		GetDllShareData().m_Common.m_sEdit.m_bEnableLineModePaste
 	);
 	Command_DELETE_LINE();
@@ -414,7 +414,7 @@ void CViewCommander::Command_DUPLICATELINE( void )
 	||	・最終行でない
 	||	→折り返しである
 	*/
-	bCRLF = ( EOL_NONE == pcLayout->GetLayoutEol() ) ? FALSE : TRUE;
+	bCRLF = ( EEolType::none == pcLayout->GetLayoutEol() ) ? FALSE : TRUE;
 
 	bAddCRLF = FALSE;
 	if( !bCRLF ){

--- a/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
@@ -166,7 +166,7 @@ void CViewCommander::Command_LineCutToEnd( void )
 
 	CLayoutPoint ptPos;
 
-	if( EEolType::none == pCLayout->GetDocLineRef()->GetEol() ){	/* 改行コードの種類 */
+	if( pCLayout->GetDocLineRef()->GetEol().IsNone() ){	/* 改行コードの種類 */
 		GetDocument()->m_cLayoutMgr.LogicToLayout(
 			CLogicPoint(
 				pCLayout->GetDocLineRef()->GetLengthWithEOL(),
@@ -246,7 +246,7 @@ void CViewCommander::Command_LineDeleteToEnd( void )
 
 	CLayoutPoint ptPos;
 
-	if( EEolType::none == pCLayout->GetDocLineRef()->GetEol() ){	/* 改行コードの種類 */
+	if( pCLayout->GetDocLineRef()->GetEol().IsNone() ){	/* 改行コードの種類 */
 		GetDocument()->m_cLayoutMgr.LogicToLayout(
 			CLogicPoint(
 				pCLayout->GetDocLineRef()->GetLengthWithEOL(),
@@ -414,7 +414,7 @@ void CViewCommander::Command_DUPLICATELINE( void )
 	||	・最終行でない
 	||	→折り返しである
 	*/
-	bCRLF = ( EEolType::none == pcLayout->GetLayoutEol() ) ? FALSE : TRUE;
+	bCRLF = ( pcLayout->GetLayoutEol().IsNone() ) ? FALSE : TRUE;
 
 	bAddCRLF = FALSE;
 	if( !bCRLF ){

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -780,7 +780,7 @@ BOOL CViewCommander::Command_PUTFILE(
 			SSaveInfo(
 				filename,
 				nSaveCharCode,
-				EEolType::none,
+				CEol(EEolType::none),
 				bBom
 			)
 		);

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -188,7 +188,7 @@ bool CViewCommander::Command_FILESAVE( bool warnbeep, bool askname )
 	//セーブ情報
 	SSaveInfo sSaveInfo;
 	pcDoc->GetSaveInfo(&sSaveInfo);
-	sSaveInfo.cEol = EOL_NONE; //改行コード無変換
+	sSaveInfo.cEol = EEolType::none; //改行コード無変換
 	sSaveInfo.bOverwriteMode = true; //上書き要求
 
 	//上書き処理
@@ -389,7 +389,7 @@ void CViewCommander::Command_PLSQL_COMPILE_ON_SQLPLUS( void )
 				nBool = Command_FILESAVE();
 			}else{
 				//nBool = HandleCommand( F_FILESAVEAS_DIALOG, true, 0, 0, 0, 0 );
-				nBool = Command_FILESAVEAS_DIALOG(NULL, CODE_NONE, EOL_NONE);
+				nBool = Command_FILESAVEAS_DIALOG(NULL, CODE_NONE, EEolType::none);
 			}
 			if( !nBool ){
 				return;
@@ -780,7 +780,7 @@ BOOL CViewCommander::Command_PUTFILE(
 			SSaveInfo(
 				filename,
 				nSaveCharCode,
-				EOL_NONE,
+				EEolType::none,
 				bBom
 			)
 		);

--- a/sakura_core/cmd/CViewCommander_ModeChange.cpp
+++ b/sakura_core/cmd/CViewCommander_ModeChange.cpp
@@ -60,7 +60,7 @@ void CViewCommander::Command_CHGMOD_INS( void )
 	@date 2003.06.23 新規作成
 */
 void CViewCommander::Command_CHGMOD_EOL( EEolType e ){
-	if( EOL_NONE < e && e < EOL_CODEMAX  ){
+	if( EEolType::none < e && e < EEolType::code_max  ){
 		GetDocument()->m_cDocEditor.SetNewLineCode( e );
 		// ステータスバーを更新するため
 		// キャレットの行桁位置を表示する関数を呼び出す

--- a/sakura_core/cmd/CViewCommander_ModeChange.cpp
+++ b/sakura_core/cmd/CViewCommander_ModeChange.cpp
@@ -60,7 +60,7 @@ void CViewCommander::Command_CHGMOD_INS( void )
 	@date 2003.06.23 新規作成
 */
 void CViewCommander::Command_CHGMOD_EOL( EEolType e ){
-	if( EEolType::none < e && e < EEolType::code_max  ){
+	if( CEol::IsValid( e ) ){
 		GetDocument()->m_cDocEditor.SetNewLineCode( e );
 		// ステータスバーを更新するため
 		// キャレットの行桁位置を表示する関数を呼び出す

--- a/sakura_core/cmd/CViewCommander_Search.cpp
+++ b/sakura_core/cmd/CViewCommander_Search.cpp
@@ -1191,7 +1191,7 @@ void CViewCommander::Command_REPLACE_ALL()
 				cSelectLogic.SetTo(CLogicPoint(CLogicXInt(0), y + CLogicInt(1))); // 次行の行頭
 				if( GetDocument()->m_cDocLineMgr.GetLineCount() == y + CLogicInt(1) ){
 					const CDocLine* pLine = GetDocument()->m_cDocLineMgr.GetLine(y);
-					if( pLine->GetEol() == EEolType::none ){
+					if( pLine->GetEol().IsNone() ){
 						// EOFは最終データ行にぶら下がりなので、選択終端は行末
 						cSelectLogic.SetTo(CLogicPoint(pLine->GetLengthWithEOL(), y)); // 対象行の行末
 					}

--- a/sakura_core/cmd/CViewCommander_Search.cpp
+++ b/sakura_core/cmd/CViewCommander_Search.cpp
@@ -1191,7 +1191,7 @@ void CViewCommander::Command_REPLACE_ALL()
 				cSelectLogic.SetTo(CLogicPoint(CLogicXInt(0), y + CLogicInt(1))); // 次行の行頭
 				if( GetDocument()->m_cDocLineMgr.GetLineCount() == y + CLogicInt(1) ){
 					const CDocLine* pLine = GetDocument()->m_cDocLineMgr.GetLine(y);
-					if( pLine->GetEol() == EOL_NONE ){
+					if( pLine->GetEol() == EEolType::none ){
 						// EOFは最終データ行にぶら下がりなので、選択終端は行末
 						cSelectLogic.SetTo(CLogicPoint(pLine->GetLengthWithEOL(), y)); // 対象行の行末
 					}

--- a/sakura_core/convert/CDecode_UuDecode.cpp
+++ b/sakura_core/convert/CDecode_UuDecode.cpp
@@ -67,7 +67,7 @@ bool CDecode_UuDecode::DoDecode( const CNativeW& pcSrc, CMemory* pcDst )
 
 	// ボディーを処理
 	while( (pline = GetNextLineW(psrc, nsrclen, &nlinelen, &ncuridx, &ceol, false)) != NULL ){
-		if( ceol.GetType() != EEolType::cr_and_lf ){
+		if( ceol != EEolType::cr_and_lf ){
 			pcDst->_AppendSz("");
 			return false;
 		}

--- a/sakura_core/convert/CDecode_UuDecode.cpp
+++ b/sakura_core/convert/CDecode_UuDecode.cpp
@@ -67,7 +67,7 @@ bool CDecode_UuDecode::DoDecode( const CNativeW& pcSrc, CMemory* pcDst )
 
 	// ボディーを処理
 	while( (pline = GetNextLineW(psrc, nsrclen, &nlinelen, &ncuridx, &ceol, false)) != NULL ){
-		if( ceol.GetType() != EOL_CRLF ){
+		if( ceol.GetType() != EEolType::cr_and_lf ){
 			pcDst->_AppendSz("");
 			return false;
 		}

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -219,10 +219,10 @@ UINT_PTR CALLBACK OFNHookProc(
 
 	//	From Here	Feb. 9, 2001 genta
 	static const int		nEolValueArr[] = {
-		EOL_NONE,
-		EOL_CRLF,
-		EOL_LF,
-		EOL_CR,
+		EEolType::none,
+		EEolType::cr_and_lf,
+		EEolType::line_feed,
+		EEolType::carriage_return,
 	};
 	//	文字列はResource内に入れる
 	static const WCHAR*	const	pEolNameArr[] = {

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -219,10 +219,10 @@ UINT_PTR CALLBACK OFNHookProc(
 
 	//	From Here	Feb. 9, 2001 genta
 	static const int		nEolValueArr[] = {
-		EEolType::none,
-		EEolType::cr_and_lf,
-		EEolType::line_feed,
-		EEolType::carriage_return,
+		static_cast<int>(EEolType::none),
+		static_cast<int>(EEolType::cr_and_lf),
+		static_cast<int>(EEolType::line_feed),
+		static_cast<int>(EEolType::carriage_return),
 	};
 	//	文字列はResource内に入れる
 	static const WCHAR*	const	pEolNameArr[] = {
@@ -303,7 +303,7 @@ UINT_PTR CALLBACK OFNHookProc(
 						nIdx = Combo_AddString( pData->m_hwndComboEOL, pEolNameArr[i] );
 					}
 					Combo_SetItemData( pData->m_hwndComboEOL, nIdx, nEolValueArr[i] );
-					if( nEolValueArr[i] == pData->m_cEol ){
+					if( nEolValueArr[i] == static_cast<int>(pData->m_cEol.GetType()) ){
 						nIdxSel = nIdx;
 					}
 				}

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -564,10 +564,10 @@ HRESULT CDlgOpenFile_CommonItemDialog::Customize()
 	if (m_customizeSetting.bUseEol) {
 		hr = StartVisualGroup(CtrlId::LABEL_EOL, LS(STR_FILEDIALOG_EOL)); RETURN_IF_FAILED
 		hr = AddComboBox(CtrlId::COMBO_EOL); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, EEolType::none, LS(STR_DLGOPNFL1)); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, EEolType::cr_and_lf, L"CR+LF"); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, EEolType::line_feed, L"LF (UNIX)"); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, EEolType::carriage_return, L"CR (Mac)"); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, static_cast<DWORD>(EEolType::none), LS(STR_DLGOPNFL1)); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, static_cast<DWORD>(EEolType::cr_and_lf), L"CR+LF"); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, static_cast<DWORD>(EEolType::line_feed), L"LF (UNIX)"); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, static_cast<DWORD>(EEolType::carriage_return), L"CR (Mac)"); RETURN_IF_FAILED
 		hr = SetSelectedControlItem(CtrlId::COMBO_EOL, 0); RETURN_IF_FAILED
 		hr = EndVisualGroup(); RETURN_IF_FAILED
 	}

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -564,10 +564,10 @@ HRESULT CDlgOpenFile_CommonItemDialog::Customize()
 	if (m_customizeSetting.bUseEol) {
 		hr = StartVisualGroup(CtrlId::LABEL_EOL, LS(STR_FILEDIALOG_EOL)); RETURN_IF_FAILED
 		hr = AddComboBox(CtrlId::COMBO_EOL); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, EOL_NONE, LS(STR_DLGOPNFL1)); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, EOL_CRLF, L"CR+LF"); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, EOL_LF, L"LF (UNIX)"); RETURN_IF_FAILED
-		hr = AddControlItem(CtrlId::COMBO_EOL, EOL_CR, L"CR (Mac)"); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, EEolType::none, LS(STR_DLGOPNFL1)); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, EEolType::cr_and_lf, L"CR+LF"); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, EEolType::line_feed, L"LF (UNIX)"); RETURN_IF_FAILED
+		hr = AddControlItem(CtrlId::COMBO_EOL, EEolType::carriage_return, L"CR (Mac)"); RETURN_IF_FAILED
 		hr = SetSelectedControlItem(CtrlId::COMBO_EOL, 0); RETURN_IF_FAILED
 		hr = EndVisualGroup(); RETURN_IF_FAILED
 	}

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -37,7 +37,7 @@
 
 CDocEditor::CDocEditor(CEditDoc* pcDoc)
 : m_pcDocRef(pcDoc)
-, m_cNewLineCode( EOL_CRLF )		//	New Line Type
+, m_cNewLineCode( EEolType::cr_and_lf )		//	New Line Type
 , m_pcOpeBlk( NULL )
 , m_bInsMode( true )	// Oct. 2, 2005 genta
 , m_bIsDocModified( false )	/* 変更フラグ */ // Jan. 22, 2002 genta 型変更
@@ -86,12 +86,12 @@ void CDocEditor::OnAfterLoad(const SLoadInfo& sLoadInfo)
 			SetNewLineCode( type.m_encoding.m_eDefaultEoltype );	// 2011.01.24 ryoji デフォルトEOL
 		}
 		else{
-			SetNewLineCode( EOL_CRLF );
+			SetNewLineCode( EEolType::cr_and_lf );
 		}
 		CDocLine*	pFirstlineinfo = pcDoc->m_cDocLineMgr.GetLine( CLogicInt(0) );
 		if( pFirstlineinfo != NULL ){
 			EEolType t = pFirstlineinfo->GetEol();
-			if( t != EOL_NONE && t != EOL_UNKNOWN ){
+			if( t != EEolType::none && t != EEolType::auto_detect ){
 				SetNewLineCode( t );
 			}
 		}

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -88,11 +88,9 @@ void CDocEditor::OnAfterLoad(const SLoadInfo& sLoadInfo)
 		else{
 			SetNewLineCode( EEolType::cr_and_lf );
 		}
-		CDocLine*	pFirstlineinfo = pcDoc->m_cDocLineMgr.GetLine( CLogicInt(0) );
-		if( pFirstlineinfo != NULL ){
-			EEolType t = pFirstlineinfo->GetEol();
-			if( t != EEolType::none && t != EEolType::auto_detect ){
-				SetNewLineCode( t );
+		if( CDocLine* pFirstline = pcDoc->m_cDocLineMgr.GetLine( CLogicInt(0) ); pFirstline != nullptr ){
+			if( const auto cEol = pFirstline->GetEol(); cEol.IsValid() ){
+				SetNewLineCode( cEol.GetType() );
 			}
 		}
 	}

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -88,7 +88,7 @@ void CDocEditor::OnAfterLoad(const SLoadInfo& sLoadInfo)
 		else{
 			SetNewLineCode( EEolType::cr_and_lf );
 		}
-		if( CDocLine* pFirstline = pcDoc->m_cDocLineMgr.GetLine( CLogicInt(0) ); pFirstline != nullptr ){
+		if( const CDocLine* pFirstline = pcDoc->m_cDocLineMgr.GetLine( CLogicInt(0) ); pFirstline != nullptr ){
 			if( const auto cEol = pFirstline->GetEol(); cEol.IsValid() ){
 				SetNewLineCode( cEol.GetType() );
 			}

--- a/sakura_core/doc/CDocEditor.h
+++ b/sakura_core/doc/CDocEditor.h
@@ -64,7 +64,8 @@ public:
 
 	//	May 15, 2000 genta
 	CEol  GetNewLineCode() const { return m_cNewLineCode; }
-	void  SetNewLineCode(const CEol& t){ m_cNewLineCode = t; }
+	void  SetNewLineCode( EEolType t ) noexcept { m_cNewLineCode = t; }
+	void  SetNewLineCode( const CEol& cEol ) noexcept { SetNewLineCode( cEol.GetType() ); }
 
 	//	Oct. 2, 2005 genta 挿入モードの設定
 	bool IsInsMode() const { return m_bInsMode; }

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -319,7 +319,7 @@ bool CDocFileOperation::DoSaveFlow(SSaveInfo* pSaveInfo)
 			if(pSaveInfo->bOverwriteMode){
 				// 無変更の場合は警告音を出し、終了
 				if (!m_pcDocRef->m_cDocEditor.IsModified() &&
-					pSaveInfo->cEol==EOL_NONE &&	//※改行コード指定保存がリクエストされた場合は、「変更があったもの」とみなす
+					pSaveInfo->cEol==EEolType::none &&	//※改行コード指定保存がリクエストされた場合は、「変更があったもの」とみなす
 					!pSaveInfo->bChgCodeSet) {		// 文字コードセットの変更が有った場合は、「変更があったもの」とみなす
 					CEditApp::getInstance()->m_cSoundSet.NeedlessToSaveBeep();
 					throw CFlowInterruption();
@@ -388,7 +388,7 @@ bool CDocFileOperation::FileSave()
 	//セーブ情報
 	SSaveInfo sSaveInfo;
 	m_pcDocRef->GetSaveInfo(&sSaveInfo);
-	sSaveInfo.cEol = EOL_NONE; //改行コード無変換
+	sSaveInfo.cEol = EEolType::none; //改行コード無変換
 	sSaveInfo.bOverwriteMode = true; //上書き要求
 
 	//上書き処理
@@ -404,11 +404,11 @@ bool CDocFileOperation::FileSaveAs( const WCHAR* filename,ECodeType eCodeType, E
 	//セーブ情報
 	SSaveInfo sSaveInfo;
 	m_pcDocRef->GetSaveInfo(&sSaveInfo);
-	sSaveInfo.cEol = EOL_NONE; // 初期値は変換しない
+	sSaveInfo.cEol = EEolType::none; // 初期値は変換しない
 	if( filename ){
 		// ダイアログなし保存、またはマクロの引数あり
 		sSaveInfo.cFilePath = filename;
-		if( EOL_NONE <= eEolType && eEolType < EOL_CODEMAX ){
+		if( EEolType::none <= eEolType && eEolType < EEolType::code_max ){
 			sSaveInfo.cEol = eEolType;
 		}
 		if( IsValidCodeType(eCodeType) && eCodeType != sSaveInfo.eCharCode ){

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -319,7 +319,7 @@ bool CDocFileOperation::DoSaveFlow(SSaveInfo* pSaveInfo)
 			if(pSaveInfo->bOverwriteMode){
 				// 無変更の場合は警告音を出し、終了
 				if (!m_pcDocRef->m_cDocEditor.IsModified() &&
-					pSaveInfo->cEol==EEolType::none &&	//※改行コード指定保存がリクエストされた場合は、「変更があったもの」とみなす
+					pSaveInfo->cEol.IsNone() &&	//※改行コード指定保存がリクエストされた場合は、「変更があったもの」とみなす
 					!pSaveInfo->bChgCodeSet) {		// 文字コードセットの変更が有った場合は、「変更があったもの」とみなす
 					CEditApp::getInstance()->m_cSoundSet.NeedlessToSaveBeep();
 					throw CFlowInterruption();
@@ -408,7 +408,7 @@ bool CDocFileOperation::FileSaveAs( const WCHAR* filename,ECodeType eCodeType, E
 	if( filename ){
 		// ダイアログなし保存、またはマクロの引数あり
 		sSaveInfo.cFilePath = filename;
-		if( EEolType::none <= eEolType && eEolType < EEolType::code_max ){
+		if( CEol::IsNoneOrValid( eEolType ) ){
 			sSaveInfo.cEol = eEolType;
 		}
 		if( IsValidCodeType(eCodeType) && eCodeType != sSaveInfo.eCharCode ){

--- a/sakura_core/doc/CDocFileOperation.h
+++ b/sakura_core/doc/CDocFileOperation.h
@@ -67,7 +67,7 @@ public:
 
 	//セーブフロー
 	bool DoSaveFlow(SSaveInfo* pSaveInfo);
-	bool FileSaveAs( const WCHAR* filename = NULL,ECodeType eCodeType = CODE_NONE, EEolType eEolType = EOL_NONE, bool bDialog = true);	//!< ダイアログでファイル名を入力させ、保存。	// 2006.12.30 ryoji
+	bool FileSaveAs( const WCHAR* filename = NULL,ECodeType eCodeType = CODE_NONE, EEolType eEolType = EEolType::none, bool bDialog = true);	//!< ダイアログでファイル名を入力させ、保存。	// 2006.12.30 ryoji
 	bool FileSave();			//!< 上書き保存。ファイル名が指定されていなかったらダイアログで入力を促す。	// 2006.12.30 ryoji
 
 	//クローズ

--- a/sakura_core/doc/CDocListener.h
+++ b/sakura_core/doc/CDocListener.h
@@ -120,7 +120,7 @@ struct SSaveInfo{
 	//モード
 	bool		bOverwriteMode;	//!< 上書き要求
 
-	SSaveInfo() : cFilePath(L""), eCharCode(CODE_AUTODETECT), bBomExist(false), bChgCodeSet(false), cEol(EOL_NONE), bOverwriteMode(false) { }
+	SSaveInfo() : cFilePath(L""), eCharCode(CODE_AUTODETECT), bBomExist(false), bChgCodeSet(false), cEol(EEolType::none), bOverwriteMode(false) { }
 	SSaveInfo(const CFilePath& _cFilePath, ECodeType _eCodeType, const CEol& _cEol, bool _bBomExist)
 		: cFilePath(_cFilePath), eCharCode(_eCodeType), bBomExist(_bBomExist), bChgCodeSet(false), cEol(_cEol), bOverwriteMode(false) { }
 

--- a/sakura_core/doc/CDocVisitor.cpp
+++ b/sakura_core/doc/CDocVisitor.cpp
@@ -59,7 +59,7 @@ void CDocVisitor::SetAllEol(CEol cEol)
 			CDocLine* pcDocLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLine); //#######非効率
 			if(!pcDocLine)break;
 			//改行を置換
-			if(pcDocLine->GetEol()!=EOL_NONE && pcDocLine->GetEol()!=cEol){
+			if(pcDocLine->GetEol()!=EEolType::none && pcDocLine->GetEol()!=cEol){
 				CLogicRange sRange;
 				sRange.SetFrom(CLogicPoint(pcDocLine->GetLengthWithoutEOL(),nLine));
 				sRange.SetTo(CLogicPoint(pcDocLine->GetLengthWithEOL(),nLine));

--- a/sakura_core/doc/CDocVisitor.cpp
+++ b/sakura_core/doc/CDocVisitor.cpp
@@ -59,7 +59,7 @@ void CDocVisitor::SetAllEol(CEol cEol)
 			CDocLine* pcDocLine = m_pcDocRef->m_cDocLineMgr.GetLine(nLine); //#######非効率
 			if(!pcDocLine)break;
 			//改行を置換
-			if(pcDocLine->GetEol()!=EEolType::none && pcDocLine->GetEol()!=cEol){
+			if( pcDocLine->GetEol().IsValid() && pcDocLine->GetEol() != cEol ){
 				CLogicRange sRange;
 				sRange.SetFrom(CLogicPoint(pcDocLine->GetLengthWithoutEOL(),nLine));
 				sRange.SetTo(CLogicPoint(pcDocLine->GetLengthWithEOL(),nLine));

--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -397,15 +397,15 @@ CLayout* CLayoutMgr::CreateLayout(
 		colorInfo
 	);
 
-	if( EOL_NONE == pCDocLine->GetEol() ){
-		pLayout->m_cEol.SetType( EOL_NONE );/* 改行コードの種類 */
+	if( EEolType::none == pCDocLine->GetEol() ){
+		pLayout->m_cEol.SetType( EEolType::none );/* 改行コードの種類 */
 	}else{
 		if( pLayout->GetLogicOffset() + pLayout->GetLengthWithEOL() >
 			pCDocLine->GetLengthWithEOL() - pCDocLine->GetEol().GetLen()
 		){
 			pLayout->m_cEol = pCDocLine->GetEol();/* 改行コードの種類 */
 		}else{
-			pLayout->m_cEol = EOL_NONE;/* 改行コードの種類 */
+			pLayout->m_cEol = EEolType::none;/* 改行コードの種類 */
 		}
 	}
 
@@ -462,7 +462,7 @@ bool CLayoutMgr::IsEndOfLine(
 		return false;
 	}
 
-	if( EOL_NONE == pLayout->GetLayoutEol().GetType() )
+	if( EEolType::none == pLayout->GetLayoutEol().GetType() )
 	{	/* この行に改行はない */
 		/* この行の最後か？ */
 		if( ptLinePos.x == (Int)pLayout->GetLengthWithEOL() ) return true; //$$ 単位混在
@@ -501,7 +501,7 @@ void CLayoutMgr::GetEndLayoutPos(
 	}
 
 	CLayout *btm = m_pLayoutBot;
-	if( btm->m_cEol != EOL_NONE ){
+	if( btm->m_cEol != EEolType::none ){
 		//	末尾に改行がある
 		ptLayoutEnd->Set(CLayoutInt(0), GetLineCount());
 	}

--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -397,7 +397,7 @@ CLayout* CLayoutMgr::CreateLayout(
 		colorInfo
 	);
 
-	if( EEolType::none == pCDocLine->GetEol() ){
+	if( pCDocLine->GetEol().IsNone() ){
 		pLayout->m_cEol.SetType( EEolType::none );/* 改行コードの種類 */
 	}else{
 		if( pLayout->GetLogicOffset() + pLayout->GetLengthWithEOL() >
@@ -462,7 +462,7 @@ bool CLayoutMgr::IsEndOfLine(
 		return false;
 	}
 
-	if( EEolType::none == pLayout->GetLayoutEol().GetType() )
+	if( pLayout->GetLayoutEol().IsNone() )
 	{	/* この行に改行はない */
 		/* この行の最後か？ */
 		if( ptLinePos.x == (Int)pLayout->GetLengthWithEOL() ) return true; //$$ 単位混在
@@ -501,7 +501,7 @@ void CLayoutMgr::GetEndLayoutPos(
 	}
 
 	CLayout *btm = m_pLayoutBot;
-	if( btm->m_cEol != EEolType::none ){
+	if( btm->m_cEol.IsValid() ){
 		//	末尾に改行がある
 		ptLayoutEnd->Set(CLayoutInt(0), GetLineCount());
 	}

--- a/sakura_core/doc/logic/CDocLine.cpp
+++ b/sakura_core/doc/logic/CDocLine.cpp
@@ -57,7 +57,7 @@ void CDocLine::SetEol()
 		m_cEol.SetTypeByString(p, &pData[nLength]-p);
 	}
 	else{
-		m_cEol = EOL_NONE;
+		m_cEol = EEolType::none;
 	}
 }
 

--- a/sakura_core/func/Funccode.cpp
+++ b/sakura_core/func/Funccode.cpp
@@ -1312,9 +1312,9 @@ bool IsFuncChecked( const CEditDoc* pcEditDoc, const DLLSHAREDATA* pShareData, E
 	// Mar. 6, 2002 genta
 	case F_VIEWMODE:			return CAppMode::getInstance()->IsViewMode(); //ビューモード
 	//	From Here 2003.06.23 Moca
-	case F_CHGMOD_EOL_CRLF:		return EOL_CRLF == pcEditDoc->m_cDocEditor.GetNewLineCode();
-	case F_CHGMOD_EOL_LF:		return EOL_LF == pcEditDoc->m_cDocEditor.GetNewLineCode();
-	case F_CHGMOD_EOL_CR:		return EOL_CR == pcEditDoc->m_cDocEditor.GetNewLineCode();
+	case F_CHGMOD_EOL_CRLF:		return EEolType::cr_and_lf == pcEditDoc->m_cDocEditor.GetNewLineCode();
+	case F_CHGMOD_EOL_LF:		return EEolType::line_feed == pcEditDoc->m_cDocEditor.GetNewLineCode();
+	case F_CHGMOD_EOL_CR:		return EEolType::carriage_return == pcEditDoc->m_cDocEditor.GetNewLineCode();
 	//	To Here 2003.06.23 Moca
 	//	2003.07.21 genta
 	case F_CHGMOD_INS:			return pcEditDoc->m_cDocEditor.IsInsMode();	//	Oct. 2, 2005 genta 挿入モードはドキュメント毎に補完するように変更した

--- a/sakura_core/io/CFileLoad.cpp
+++ b/sakura_core/io/CFileLoad.cpp
@@ -243,9 +243,9 @@ ECodeType CFileLoad::FileOpen( LPCWSTR pFileName, bool bBigFile, ECodeType CharC
 	// To Here Jun. 13, 2003 Moca BOMの除去
 	m_eMode = FLMODE_READY;
 //	m_cmemLine.AllocBuffer( 256 );
-	m_pCodeBase->GetEol( &m_memEols[0], EOL_NEL );
-	m_pCodeBase->GetEol( &m_memEols[1], EOL_LS );
-	m_pCodeBase->GetEol( &m_memEols[2], EOL_PS );
+	m_pCodeBase->GetEol( &m_memEols[0], EEolType::next_line );
+	m_pCodeBase->GetEol( &m_memEols[1], EEolType::line_separator );
+	m_pCodeBase->GetEol( &m_memEols[2], EEolType::paragraph_separator );
 	bool bEolEx = false;
 	int  nMaxEolLen = 0;
 	for( int k = 0; k < (int)_countof(m_memEols); k++ ){
@@ -505,7 +505,7 @@ const char* CFileLoad::GetNextLineCharCode(
 	int nbgn = *pnBgn;
 	int i;
 
-	pcEol->SetType( EOL_NONE );
+	pcEol->SetType( EEolType::none );
 	*pnBufferNext = 0;
 
 	if( nDataLen <= nbgn ){
@@ -522,9 +522,9 @@ const char* CFileLoad::GetNextLineCharCode(
 	case ENCODING_TRAIT_ASCII:
 		{
 			static const EEolType eEolEx[] = {
-				EOL_NEL,
-				EOL_LS,
-				EOL_PS,
+				EEolType::next_line,
+				EEolType::line_separator,
+				EEolType::paragraph_separator,
 			};
 			nLen = nDataLen;
 			for( i = nbgn; i < nDataLen; ++i ){
@@ -638,7 +638,7 @@ const char* CFileLoad::GetNextLineCharCode(
 		for( i = nbgn; i < nDataLen; ++i ){
 			if( m_encodingTrait == ENCODING_TRAIT_EBCDIC && bExtEol ){
 				if( pData[i] == '\x15' ){
-					pcEol->SetType(EOL_NEL);
+					pcEol->SetType(EEolType::next_line);
 					neollen = 1;
 					break;
 				}
@@ -666,7 +666,7 @@ const char* CFileLoad::GetNextLineCharCode(
 		}
 	}else{
 		// CRの場合は、CRLFかもしれないので次のバッファへ送る
-		if( *pcEol == EOL_CR ){
+		if( *pcEol == EEolType::carriage_return ){
 			*pnBufferNext = neollen;
 		}
 	}

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -648,7 +648,7 @@ bool CMacro::HandleCommand(
 			case 7:		nEol = EEolType::paragraph_separator; break;
 			default:	nEol = EEolType::none; break;
 			}
-			if( nEol != EEolType::none ){
+			if( !CEol::IsNone( nEol ) ){
 				pcEditView->GetCommander().HandleCommand( Index, true, nEol, 0, 0, 0 );
 			}
 		}

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -271,9 +271,8 @@ void CMacro::AddLParam( const LPARAM* lParams, const CEditView* pcEditView )
 		{
 			// EOLタイプ値をマクロ引数値に変換する	// 2009.08.18 ryoji
 			int nFlag;
-			switch( (int)lParam ){
+			switch( static_cast<EEolType>(lParam) ){
 			case EEolType::cr_and_lf:	nFlag = 1; break;
-//			case EOL_LFCR:	nFlag = 2; break;
 			case EEolType::line_feed:	nFlag = 3; break;
 			case EEolType::carriage_return:	nFlag = 4; break;
 			case EEolType::next_line:	nFlag = 5; break;
@@ -637,10 +636,9 @@ bool CMacro::HandleCommand(
 		}
 		{
 			// マクロ引数値をEOLタイプ値に変換する	// 2009.08.18 ryoji
-			int nEol;
+			EEolType nEol;
 			switch( Argument[0] != NULL ? _wtoi(Argument[0]) : 0 ){
 			case 1:		nEol = EEolType::cr_and_lf; break;
-//			case 2:		nEol = EOL_LFCR; break;
 			case 3:		nEol = EEolType::line_feed; break;
 			case 4:		nEol = EEolType::carriage_return; break;
 			case 5:		nEol = EEolType::next_line; break;
@@ -649,7 +647,7 @@ bool CMacro::HandleCommand(
 			default:	nEol = EEolType::none; break;
 			}
 			if( !CEol::IsNone( nEol ) ){
-				pcEditView->GetCommander().HandleCommand( Index, true, nEol, 0, 0, 0 );
+				pcEditView->GetCommander().HandleCommand( Index, true, static_cast<LPARAM>(nEol), 0, 0, 0 );
 			}
 		}
 		break;
@@ -1648,7 +1646,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		//	2005.08.04 maru マクロ追加
 		{
 			int n = 0;
-			switch( View->m_pcEditDoc->m_cDocEditor.GetNewLineCode() ){
+			switch( View->m_pcEditDoc->m_cDocEditor.GetNewLineCode().GetType() ){
 			case EEolType::cr_and_lf:
 				n = 0;
 				break;
@@ -1666,6 +1664,8 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 				break;
 			case EEolType::paragraph_separator:
 				n = 5;
+				break;
+			default:
 				break;
 			}
 			Wrap( &Result )->Receive( n );

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -272,13 +272,13 @@ void CMacro::AddLParam( const LPARAM* lParams, const CEditView* pcEditView )
 			// EOLタイプ値をマクロ引数値に変換する	// 2009.08.18 ryoji
 			int nFlag;
 			switch( (int)lParam ){
-			case EOL_CRLF:	nFlag = 1; break;
+			case EEolType::cr_and_lf:	nFlag = 1; break;
 //			case EOL_LFCR:	nFlag = 2; break;
-			case EOL_LF:	nFlag = 3; break;
-			case EOL_CR:	nFlag = 4; break;
-			case EOL_NEL:	nFlag = 5; break;
-			case EOL_LS:	nFlag = 6; break;
-			case EOL_PS:	nFlag = 7; break;
+			case EEolType::line_feed:	nFlag = 3; break;
+			case EEolType::carriage_return:	nFlag = 4; break;
+			case EEolType::next_line:	nFlag = 5; break;
+			case EEolType::line_separator:	nFlag = 6; break;
+			case EEolType::paragraph_separator:	nFlag = 7; break;
 			default:		nFlag = 0; break;
 			}
 			AddIntParam( nFlag );
@@ -639,16 +639,16 @@ bool CMacro::HandleCommand(
 			// マクロ引数値をEOLタイプ値に変換する	// 2009.08.18 ryoji
 			int nEol;
 			switch( Argument[0] != NULL ? _wtoi(Argument[0]) : 0 ){
-			case 1:		nEol = EOL_CRLF; break;
+			case 1:		nEol = EEolType::cr_and_lf; break;
 //			case 2:		nEol = EOL_LFCR; break;
-			case 3:		nEol = EOL_LF; break;
-			case 4:		nEol = EOL_CR; break;
-			case 5:		nEol = EOL_NEL; break;
-			case 6:		nEol = EOL_LS; break;
-			case 7:		nEol = EOL_PS; break;
-			default:	nEol = EOL_NONE; break;
+			case 3:		nEol = EEolType::line_feed; break;
+			case 4:		nEol = EEolType::carriage_return; break;
+			case 5:		nEol = EEolType::next_line; break;
+			case 6:		nEol = EEolType::line_separator; break;
+			case 7:		nEol = EEolType::paragraph_separator; break;
+			default:	nEol = EEolType::none; break;
 			}
-			if( nEol != EOL_NONE ){
+			if( nEol != EEolType::none ){
 				pcEditView->GetCommander().HandleCommand( Index, true, nEol, 0, 0, 0 );
 			}
 		}
@@ -1204,11 +1204,11 @@ bool CMacro::HandleCommand(
 			}
 			EEolType eEol;
 			switch (nSaveLineCode){
-			case 0:		eEol = EOL_NONE;	break;
-			case 1:		eEol = EOL_CRLF;	break;
-			case 2:		eEol = EOL_LF;		break;
-			case 3:		eEol = EOL_CR;		break;
-			default:	eEol = EOL_NONE;	break;
+			case 0:		eEol = EEolType::none;	break;
+			case 1:		eEol = EEolType::cr_and_lf;	break;
+			case 2:		eEol = EEolType::line_feed;		break;
+			case 3:		eEol = EEolType::carriage_return;		break;
+			default:	eEol = EEolType::none;	break;
 			}
 			
 			pcEditView->GetCommander().HandleCommand( Index, true, (LPARAM)Argument[0], (LPARAM)nCharCode, (LPARAM)eEol, 0);
@@ -1649,22 +1649,22 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		{
 			int n = 0;
 			switch( View->m_pcEditDoc->m_cDocEditor.GetNewLineCode() ){
-			case EOL_CRLF:
+			case EEolType::cr_and_lf:
 				n = 0;
 				break;
-			case EOL_CR:
+			case EEolType::carriage_return:
 				n = 1;
 				break;
-			case EOL_LF:
+			case EEolType::line_feed:
 				n = 2;
 				break;
-			case EOL_NEL:
+			case EEolType::next_line:
 				n = 3;
 				break;
-			case EOL_LS:
+			case EEolType::line_separator:
 				n = 4;
 				break;
-			case EOL_PS:
+			case EEolType::paragraph_separator:
 				n = 5;
 				break;
 			}

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -272,13 +272,13 @@ void CMacro::AddLParam( const LPARAM* lParams, const CEditView* pcEditView )
 			// EOLタイプ値をマクロ引数値に変換する	// 2009.08.18 ryoji
 			int nFlag;
 			switch( static_cast<EEolType>(lParam) ){
-			case EEolType::cr_and_lf:	nFlag = 1; break;
-			case EEolType::line_feed:	nFlag = 3; break;
-			case EEolType::carriage_return:	nFlag = 4; break;
-			case EEolType::next_line:	nFlag = 5; break;
-			case EEolType::line_separator:	nFlag = 6; break;
+			case EEolType::cr_and_lf:			nFlag = 1; break;
+			case EEolType::line_feed:			nFlag = 3; break;
+			case EEolType::carriage_return:		nFlag = 4; break;
+			case EEolType::next_line:			nFlag = 5; break;
+			case EEolType::line_separator:		nFlag = 6; break;
 			case EEolType::paragraph_separator:	nFlag = 7; break;
-			default:		nFlag = 0; break;
+			default:							nFlag = 0; break;
 			}
 			AddIntParam( nFlag );
 		}
@@ -1645,28 +1645,15 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 	case F_GETLINECODE:
 		//	2005.08.04 maru マクロ追加
 		{
-			int n = 0;
+			int n;
 			switch( View->m_pcEditDoc->m_cDocEditor.GetNewLineCode().GetType() ){
-			case EEolType::cr_and_lf:
-				n = 0;
-				break;
-			case EEolType::carriage_return:
-				n = 1;
-				break;
-			case EEolType::line_feed:
-				n = 2;
-				break;
-			case EEolType::next_line:
-				n = 3;
-				break;
-			case EEolType::line_separator:
-				n = 4;
-				break;
-			case EEolType::paragraph_separator:
-				n = 5;
-				break;
-			default:
-				break;
+			case EEolType::cr_and_lf:			n = 0; break;
+			case EEolType::carriage_return:		n = 1; break;
+			case EEolType::line_feed:			n = 2; break;
+			case EEolType::next_line:			n = 3; break;
+			case EEolType::line_separator:		n = 4; break;
+			case EEolType::paragraph_separator:	n = 5; break;
+			default:							n = 0; break;
 			}
 			Wrap( &Result )->Receive( n );
 		}

--- a/sakura_core/typeprop/CPropTypesWindow.cpp
+++ b/sakura_core/typeprop/CPropTypesWindow.cpp
@@ -102,12 +102,12 @@ static const wchar_t* aszEolStr[] = {
 	L"PS",
 };
 static const EEolType aeEolType[] = {
-	EOL_CRLF,
-	EOL_LF,
-	EOL_CR,
-	EOL_NEL,
-	EOL_LS,
-	EOL_PS,
+	EEolType::cr_and_lf,
+	EEolType::line_feed,
+	EEolType::carriage_return,
+	EEolType::next_line,
+	EEolType::line_separator,
+	EEolType::paragraph_separator,
 };
 
 // IMEのオープン状態復帰用

--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -198,7 +198,7 @@ void _DefaultConfig(STypeConfig* pType)
 	// 文字コード設定
 	pType->m_encoding.m_bPriorCesu8 = false;
 	pType->m_encoding.m_eDefaultCodetype = CODE_UTF8;
-	pType->m_encoding.m_eDefaultEoltype = EOL_CRLF;
+	pType->m_encoding.m_eDefaultEoltype = EEolType::cr_and_lf;
 	pType->m_encoding.m_bDefaultBom = false;
 
 	//@@@2002.2.4 YAZAKI

--- a/sakura_core/util/string_ex2.cpp
+++ b/sakura_core/util/string_ex2.cpp
@@ -175,68 +175,6 @@ const wchar_t* GetNextLineW(
 	*pnLineLen = i - nBgn;
 	return &pData[nBgn];
 }
-#if 0 // 未使用
-/*
-	行端子の種類を調べるUnicodeBE版
-	@param pszData 調査対象文字列へのポインタ
-	@param nDataLen 調査対象文字列の長さ(wchar_tの長さ)
-	@return 改行コードの種類。終端子が見つからなかったときはEOL_NONEを返す。
-*/
-static EEolType GetEOLTypeUniBE( const wchar_t* pszData, int nDataLen )
-{
-	/*! 行終端子のデータの配列(UnicodeBE版) 2000.05.30 Moca */
-	static const wchar_t* aEolTable[EOL_TYPE_NUM] = {
-		L"",									// EOL_NONE
-		(const wchar_t*)"\x00\x0d\x00\x0a\x00",	// EOL_CRLF
-		(const wchar_t*)"\x00\x0a\x00",			// EOL_LF
-		(const wchar_t*)"\x00\x0d\x00"			// EOL_CR
-	};
-
-	/* 改行コードの長さを調べる */
-
-	for( int i = 1; i < EOL_TYPE_NUM; ++i ){
-		CEol cEol((EEolType)i);
-		if( cEol.GetLen()<=nDataLen && 0==wmemcmp(pszData,aEolTable[i],cEol.GetLen()) ){
-			return gm_pnEolTypeArr[i];
-		}
-	}
-	return EOL_NONE;
-}
-
-/*!
-	GetNextLineのwchar_t版(ビックエンディアン用)
-	GetNextLineより作成
-	static メンバ関数
-*/
-const wchar_t* GetNextLineWB(
-	const wchar_t*	pData,	//!< [in]	検索文字列
-	int			nDataLen,	//!< [in]	検索文字列の文字数
-	int*		pnLineLen,	//!< [out]	1行の文字数を返すただしEOLは含まない
-	int*		pnBgn,		//!< [i/o]	検索文字列のオフセット位置
-	CEol*		pcEol		//!< [i/o]	EOL
-)
-{
-	int		i;
-	int		nBgn;
-	nBgn = *pnBgn;
-
-	pcEol->SetType( EOL_NONE );
-	if( *pnBgn >= nDataLen ){
-		return NULL;
-	}
-	for( i = *pnBgn; i < nDataLen; ++i ){
-		// 改行コードがあった
-		if( pData[i] == (wchar_t)0x0a00 || pData[i] == (wchar_t)0x0d00 ){
-			// 行終端子の種類を調べる
-			pcEol->SetType( GetEOLTypeUniBE( &pData[i], nDataLen - i ) );
-			break;
-		}
-	}
-	*pnBgn = i + pcEol->GetLen();
-	*pnLineLen = i - nBgn;
-	return &pData[nBgn];
-}
-#endif
 
 //! データを指定「文字数」以内に切り詰める。戻り値は結果の文字数。
 int LimitStringLengthW(

--- a/sakura_core/util/string_ex2.cpp
+++ b/sakura_core/util/string_ex2.cpp
@@ -124,7 +124,7 @@ const char* GetNextLine(
 	nBgn = *pnBgn;
 
 	//	May 15, 2000 genta
-	pcEol->SetType( EOL_NONE );
+	pcEol->SetType( EEolType::none );
 	if( *pnBgn >= nDataLen ){
 		return NULL;
 	}
@@ -159,7 +159,7 @@ const wchar_t* GetNextLineW(
 	int		nBgn;
 	nBgn = *pnBgn;
 
-	pcEol->SetType( EOL_NONE );
+	pcEol->SetType( EEolType::none );
 	if( *pnBgn >= nDataLen ){
 		return NULL;
 	}

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -435,7 +435,7 @@ BOOL CCaret::GetAdjustCursorPos(
 		if( 0 < nLayoutLineCount ){
 			ptPosXY2.y = nLayoutLineCount - 1;
 			const CLayout* pcLayout = m_pEditDoc->m_cLayoutMgr.SearchLineByLayoutY( ptPosXY2.GetY2() );
-			if( pcLayout->GetLayoutEol() == EEolType::none ){
+			if( pcLayout->GetLayoutEol().IsNone() ){
 				ptPosXY2.x = m_pEditView->LineIndexToColumn( pcLayout, (CLogicInt)pcLayout->GetLengthWithEOL() );
 				// [EOF]のみ折り返すのはやめる	// 2009.02.17 ryoji
 				// 復活するなら ptPosXY2.x に折り返し行インデントを適用するのがよい
@@ -879,7 +879,7 @@ CLayoutInt CCaret::Cursor_UPDOWN( CLayoutInt nMoveLines, bool bSelect )
 
 	// 現在のキャレットY座標 + nMoveLinesが正しいレイアウト行の範囲内に収まるように nMoveLinesを調整する。
 	if( nMoveLines > 0 ) { // 下移動。
-		const bool existsEOFOnlyLine = pLayoutMgr->GetBottomLayout() && pLayoutMgr->GetBottomLayout()->GetLayoutEol() != EEolType::none
+		const bool existsEOFOnlyLine = pLayoutMgr->GetBottomLayout() && pLayoutMgr->GetBottomLayout()->GetLayoutEol().IsValid()
 			|| pLayoutMgr->GetLineCount() == 0;
 		const CLayoutInt maxLayoutLine = pLayoutMgr->GetLineCount() + (existsEOFOnlyLine ? 1 : 0 ) - 1;
 		// 移動先が EOFのみの行を含めたレイアウト行数未満になるように移動量を規正する。
@@ -1095,7 +1095,7 @@ CLayoutInt CCaret::MoveCursorProperly(
 	if( ptNewXY.y >= m_pEditDoc->m_cLayoutMgr.GetLineCount()
 	 && (m_pEditView->GetSelectionInfo().IsMouseSelecting() && m_pEditView->GetSelectionInfo().IsBoxSelecting()) ){
 		const CLayout* layoutEnd = m_pEditDoc->m_cLayoutMgr.GetBottomLayout();
-		bool bEofOnly = (layoutEnd && layoutEnd->GetLayoutEol() != EEolType::none) || NULL == layoutEnd;
+		bool bEofOnly = (layoutEnd && layoutEnd->GetLayoutEol().IsValid()) || NULL == layoutEnd;
 	 	// 2012.01.09 ぴったり[EOF]位置にある場合は位置を維持(1つ上の行にしない)
 	 	if( bEofOnly && ptNewXY.y == m_pEditDoc->m_cLayoutMgr.GetLineCount() && ptNewXY.x == 0 ){
 	 	}else{

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -435,7 +435,7 @@ BOOL CCaret::GetAdjustCursorPos(
 		if( 0 < nLayoutLineCount ){
 			ptPosXY2.y = nLayoutLineCount - 1;
 			const CLayout* pcLayout = m_pEditDoc->m_cLayoutMgr.SearchLineByLayoutY( ptPosXY2.GetY2() );
-			if( pcLayout->GetLayoutEol() == EOL_NONE ){
+			if( pcLayout->GetLayoutEol() == EEolType::none ){
 				ptPosXY2.x = m_pEditView->LineIndexToColumn( pcLayout, (CLogicInt)pcLayout->GetLengthWithEOL() );
 				// [EOF]のみ折り返すのはやめる	// 2009.02.17 ryoji
 				// 復活するなら ptPosXY2.x に折り返し行インデントを適用するのがよい
@@ -879,7 +879,7 @@ CLayoutInt CCaret::Cursor_UPDOWN( CLayoutInt nMoveLines, bool bSelect )
 
 	// 現在のキャレットY座標 + nMoveLinesが正しいレイアウト行の範囲内に収まるように nMoveLinesを調整する。
 	if( nMoveLines > 0 ) { // 下移動。
-		const bool existsEOFOnlyLine = pLayoutMgr->GetBottomLayout() && pLayoutMgr->GetBottomLayout()->GetLayoutEol() != EOL_NONE
+		const bool existsEOFOnlyLine = pLayoutMgr->GetBottomLayout() && pLayoutMgr->GetBottomLayout()->GetLayoutEol() != EEolType::none
 			|| pLayoutMgr->GetLineCount() == 0;
 		const CLayoutInt maxLayoutLine = pLayoutMgr->GetLineCount() + (existsEOFOnlyLine ? 1 : 0 ) - 1;
 		// 移動先が EOFのみの行を含めたレイアウト行数未満になるように移動量を規正する。
@@ -1095,7 +1095,7 @@ CLayoutInt CCaret::MoveCursorProperly(
 	if( ptNewXY.y >= m_pEditDoc->m_cLayoutMgr.GetLineCount()
 	 && (m_pEditView->GetSelectionInfo().IsMouseSelecting() && m_pEditView->GetSelectionInfo().IsBoxSelecting()) ){
 		const CLayout* layoutEnd = m_pEditDoc->m_cLayoutMgr.GetBottomLayout();
-		bool bEofOnly = (layoutEnd && layoutEnd->GetLayoutEol() != EOL_NONE) || NULL == layoutEnd;
+		bool bEofOnly = (layoutEnd && layoutEnd->GetLayoutEol() != EEolType::none) || NULL == layoutEnd;
 	 	// 2012.01.09 ぴったり[EOF]位置にある場合は位置を維持(1つ上の行にしない)
 	 	if( bEofOnly && ptNewXY.y == m_pEditDoc->m_cLayoutMgr.GetLineCount() && ptNewXY.x == 0 ){
 	 	}else{

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1789,7 +1789,7 @@ void CEditView::SplitBoxOnOff( BOOL bVert, BOOL bHorz, BOOL bSizeBox )
 */
 bool CEditView::GetSelectedDataSimple( CNativeW &cmemBuf )
 {
-	return GetSelectedData(&cmemBuf, FALSE, NULL, FALSE, false, EOL_UNKNOWN);
+	return GetSelectedData(&cmemBuf, FALSE, NULL, FALSE, false, EEolType::auto_detect);
 }
 
 /* 選択範囲のデータを取得
@@ -1801,7 +1801,7 @@ bool CEditView::GetSelectedData(
 	const wchar_t*	pszQuote,			/* 先頭に付ける引用符 */
 	BOOL			bWithLineNumber,	/* 行番号を付与する */
 	bool			bAddCRLFWhenCopy,	/* 折り返し位置で改行記号を入れる */
-	EEolType		neweol				//	コピー後の改行コード EOL_NONEはコード保存
+	EEolType		neweol				//	コピー後の改行コード EEolType::noneはコード保存
 )
 {
 	const wchar_t*	pLine;
@@ -1923,7 +1923,7 @@ bool CEditView::GetSelectedData(
 		}
 
 		// 改行コードについて。
-		if ( neweol == EOL_UNKNOWN )
+		if ( neweol == EEolType::auto_detect )
 		{
 			nBufSize += wcslen(WCODE::CRLF);
 		}
@@ -1978,11 +1978,11 @@ bool CEditView::GetSelectedData(
 				cmemBuf->AppendString( pszLineNum );
 			}
 
-			if( EOL_NONE != pcLayout->GetLayoutEol() ){
+			if( EEolType::none != pcLayout->GetLayoutEol() ){
 				if( nIdxTo >= nLineLen ){
 					cmemBuf->AppendString( &pLine[nIdxFrom], nLineLen - 1 - nIdxFrom );
 					//	Jul. 25, 2000 genta
-					cmemBuf->AppendString( ( neweol == EOL_UNKNOWN ) ?
+					cmemBuf->AppendString( ( neweol == EEolType::auto_detect ) ?
 						(pcLayout->GetLayoutEol()).GetValue2() :	//	コード保存
 						appendEol.GetValue2() );			//	新規改行コード
 				}
@@ -1997,7 +1997,7 @@ bool CEditView::GetSelectedData(
 						bWithLineNumber 	/* 行番号を付与する */
 					){
 						//	Jul. 25, 2000 genta
-						cmemBuf->AppendString(( neweol == EOL_UNKNOWN ) ?
+						cmemBuf->AppendString(( neweol == EEolType::auto_detect ) ?
 							m_pcEditDoc->m_cDocEditor.GetNewLineCode().GetValue2() :	//	コード保存
 							appendEol.GetValue2() );		//	新規改行コード
 					}

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1978,7 +1978,7 @@ bool CEditView::GetSelectedData(
 				cmemBuf->AppendString( pszLineNum );
 			}
 
-			if( EEolType::none != pcLayout->GetLayoutEol() ){
+			if( pcLayout->GetLayoutEol().IsValid() ){
 				if( nIdxTo >= nLineLen ){
 					cmemBuf->AppendString( &pLine[nIdxFrom], nLineLen - 1 - nIdxFrom );
 					//	Jul. 25, 2000 genta

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -322,7 +322,7 @@ public:
 	// 2002/01/19 novice public属性に変更
 	bool GetSelectedDataSimple( CNativeW& cmemBuf );// 選択範囲のデータを取得
 	bool GetSelectedDataOne( CNativeW& cmemBuf, int nMaxLen );
-	bool GetSelectedData( CNativeW* cmemBuf, BOOL bLineOnly, const wchar_t* pszQuote, BOOL bWithLineNumber, bool bAddCRLFWhenCopy, EEolType neweol = EOL_UNKNOWN);/* 選択範囲のデータを取得 */
+	bool GetSelectedData( CNativeW* cmemBuf, BOOL bLineOnly, const wchar_t* pszQuote, BOOL bWithLineNumber, bool bAddCRLFWhenCopy, EEolType neweol = EEolType::auto_detect);/* 選択範囲のデータを取得 */
 	int IsCurrentPositionSelected( CLayoutPoint ptCaretPos );					/* 指定カーソル位置が選択エリア内にあるか */
 	int IsCurrentPositionSelectedTEST( const CLayoutPoint& ptCaretPos, const CLayoutRange& sSelect ) const;/* 指定カーソル位置が選択エリア内にあるか */
 	// 2006.07.09 genta 行桁指定によるカーソル移動(選択領域を考慮)

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -432,12 +432,12 @@ void CEditView::CopyCurLine(
 	cmemBuf.SetString( pcLayout->GetPtr(), pcLayout->GetLengthWithoutEOL() );
 	if( pcLayout->GetLayoutEol().GetLen() != 0 ){
 		cmemBuf.AppendString(
-			( neweol == EOL_UNKNOWN ) ?
+			( neweol == EEolType::auto_detect ) ?
 				pcLayout->GetLayoutEol().GetValue2() : CEol(neweol).GetValue2()
 		);
 	}else if( bAddCRLFWhenCopy ){	// 2007.10.08 ryoji bAddCRLFWhenCopy対応処理追加
 		cmemBuf.AppendString(
-			( neweol == EOL_UNKNOWN ) ?
+			( neweol == EEolType::auto_detect ) ?
 				WCODE::CRLF : CEol(neweol).GetValue2()
 		);
 	}

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -138,7 +138,7 @@ void CEditView::InsertData_CEditView(
 			int nSpWidth = GetTextMetrics().CalcTextWidth3(L" ", 1);
 			// 終端直前から挿入位置まで空白を埋める為の処理
 			// 行終端が何らかの改行コードか?
-			if( EOL_NONE != pcLayout->GetLayoutEol() ){
+			if( EEolType::none != pcLayout->GetLayoutEol() ){
 				nIdxFrom = nLineLen - CLogicInt(1);
 				cMem.AllocStringBuffer( (Int)(ptInsertPos.GetX2() - nLineAllColLen + 1)/ nSpWidth + nDataLen );
 				for( int i = 0; i < ptInsertPos.GetX2() - nLineAllColLen + 1; i += nSpWidth ){
@@ -167,7 +167,7 @@ void CEditView::InsertData_CEditView(
 	else{
 		// 更新が前行からになる可能性を調べる	// 2009.02.17 ryoji
 		const CLayout* pcLayoutWk = m_pcEditDoc->m_cLayoutMgr.GetBottomLayout();
-		if( pcLayoutWk && pcLayoutWk->GetLayoutEol() == EOL_NONE && bKinsoku ){	// 折り返しレイアウト行か？（前行の終端で調査）
+		if( pcLayoutWk && pcLayoutWk->GetLayoutEol() == EEolType::none && bKinsoku ){	// 折り返しレイアウト行か？（前行の終端で調査）
 			bHintPrev = true;	// 更新が前行からになる可能性がある
 		}
 		if( 0 < ptInsertPos.GetX2() ){
@@ -647,7 +647,7 @@ void CEditView::DeleteData(
 				goto end_of_func;
 			}
 			/* 改行で終わっているか */
-			if( ( EOL_NONE != pcLayout->GetLayoutEol() ) ){
+			if( ( EEolType::none != pcLayout->GetLayoutEol() ) ){
 				goto end_of_func;
 			}
 			/*ファイルの最後に移動 */

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -138,7 +138,7 @@ void CEditView::InsertData_CEditView(
 			int nSpWidth = GetTextMetrics().CalcTextWidth3(L" ", 1);
 			// 終端直前から挿入位置まで空白を埋める為の処理
 			// 行終端が何らかの改行コードか?
-			if( EEolType::none != pcLayout->GetLayoutEol() ){
+			if( pcLayout->GetLayoutEol().IsValid() ){
 				nIdxFrom = nLineLen - CLogicInt(1);
 				cMem.AllocStringBuffer( (Int)(ptInsertPos.GetX2() - nLineAllColLen + 1)/ nSpWidth + nDataLen );
 				for( int i = 0; i < ptInsertPos.GetX2() - nLineAllColLen + 1; i += nSpWidth ){
@@ -167,7 +167,7 @@ void CEditView::InsertData_CEditView(
 	else{
 		// 更新が前行からになる可能性を調べる	// 2009.02.17 ryoji
 		const CLayout* pcLayoutWk = m_pcEditDoc->m_cLayoutMgr.GetBottomLayout();
-		if( pcLayoutWk && pcLayoutWk->GetLayoutEol() == EEolType::none && bKinsoku ){	// 折り返しレイアウト行か？（前行の終端で調査）
+		if( pcLayoutWk && pcLayoutWk->GetLayoutEol().IsNone() && bKinsoku ){	// 折り返しレイアウト行か？（前行の終端で調査）
 			bHintPrev = true;	// 更新が前行からになる可能性がある
 		}
 		if( 0 < ptInsertPos.GetX2() ){
@@ -647,7 +647,7 @@ void CEditView::DeleteData(
 				goto end_of_func;
 			}
 			/* 改行で終わっているか */
-			if( ( EEolType::none != pcLayout->GetLayoutEol() ) ){
+			if( pcLayout->GetLayoutEol().IsValid() ){
 				goto end_of_func;
 			}
 			/*ファイルの最後に移動 */

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -477,7 +477,7 @@ BOOL CEditView::MakeDiffTmpFile( WCHAR* filename, HWND hWnd, ECodeType code, boo
 			SSaveInfo(
 				filename,
 				code,
-				EEolType::none,
+				CEol(EEolType::none),
 				bBom
 			)
 		);

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -477,7 +477,7 @@ BOOL CEditView::MakeDiffTmpFile( WCHAR* filename, HWND hWnd, ECodeType code, boo
 			SSaveInfo(
 				filename,
 				code,
-				EOL_NONE,
+				EEolType::none,
 				bBom
 			)
 		);

--- a/sakura_core/view/CViewSelect.cpp
+++ b/sakura_core/view/CViewSelect.cpp
@@ -387,7 +387,7 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 				// 2006.10.01 Moca End
 				// 2011.12.26 EOFのぶら下がり行は反転し、EOFのみの行は反転しない
 				const CLayout* pBottom = pView->m_pcEditDoc->m_cLayoutMgr.GetBottomLayout();
-				if( pBottom && pBottom->GetLayoutEol() == EOL_NONE ){
+				if( pBottom && pBottom->GetLayoutEol() == EEolType::none ){
 					ptLast.x = 0;
 					ptLast.y++;
 				}

--- a/sakura_core/view/CViewSelect.cpp
+++ b/sakura_core/view/CViewSelect.cpp
@@ -387,7 +387,7 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 				// 2006.10.01 Moca End
 				// 2011.12.26 EOFのぶら下がり行は反転し、EOFのみの行は反転しない
 				const CLayout* pBottom = pView->m_pcEditDoc->m_cLayoutMgr.GetBottomLayout();
-				if( pBottom && pBottom->GetLayoutEol() == EEolType::none ){
+				if( pBottom && pBottom->GetLayoutEol().IsNone() ){
 					ptLast.x = 0;
 					ptLast.y++;
 				}

--- a/sakura_core/view/figures/CFigure_Eol.cpp
+++ b/sakura_core/view/figures/CFigure_Eol.cpp
@@ -339,7 +339,7 @@ void _DrawEOL(
 	HPEN hPenOld = (HPEN)SelectObject(gr, hPen);
 
 	switch( cEol.GetType() ){
-	case EOL_CRLF:	//	下左矢印
+	case EEolType::cr_and_lf:	//	下左矢印
 		{
 			sx = rcEol.left;						//X左端
 			sy = rcEol.top + ( rcEol.Height() / 2);	//Y中心
@@ -376,7 +376,7 @@ void _DrawEOL(
 			}
 		}
 		break;
-	case EOL_CR:	//	左向き矢印	// 2007.08.17 ryoji EOL_LF -> EOL_CR
+	case EEolType::carriage_return:	//	左向き矢印	// 2007.08.17 ryoji EEolType::line_feed -> EEolType::carriage_return
 		{
 			sx = rcEol.left;
 			sy = rcEol.top + ( rcEol.Height() / 2 );
@@ -409,7 +409,7 @@ void _DrawEOL(
 			}
 		}
 		break;
-	case EOL_LF:	//	下向き矢印	// 2007.08.17 ryoji EOL_CR -> EOL_LF
+	case EEolType::line_feed:	//	下向き矢印	// 2007.08.17 ryoji EEolType::carriage_return -> EEolType::line_feed
 	// 2013.04.22 Moca NEL,LS,PS対応。暫定でLFと同じにする
 		{
 			sx = rcEol.left + ( rcEol.Width() / 2 );
@@ -443,9 +443,9 @@ void _DrawEOL(
 			}
 		}
 		break;
-	case EOL_NEL:
-	case EOL_LS:
-	case EOL_PS:
+	case EEolType::next_line:
+	case EEolType::line_separator:
+	case EEolType::paragraph_separator:
 		{
 			// 左下矢印(折れ曲がりなし)
 			sx = rcEol.left;			//X左端

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -794,7 +794,7 @@ void CEditWnd::SetDocumentTypeWhenCreate(
 		}
 		if( nCharCode == eDefaultCharCode ){	// デフォルト文字コードと同じ文字コードが選択されたとき
 			GetDocument()->SetDocumentEncoding( nCharCode, types.m_encoding.m_bDefaultBom );
-			GetDocument()->m_cDocEditor.m_cNewLineCode = static_cast<EEolType>( types.m_encoding.m_eDefaultEoltype );
+			GetDocument()->m_cDocEditor.m_cNewLineCode = types.m_encoding.m_eDefaultEoltype;
 		}
 		else{
 			GetDocument()->SetDocumentEncoding( nCharCode, CCodeTypeName( nCharCode ).IsBomDefOn() );
@@ -1476,16 +1476,16 @@ LRESULT CEditWnd::DispatchEvent(
 						NULL
 					);
 					::DestroyMenu( hMenuPopUp );
-					int nEOLCode = 0;
+					EEolType nEOLCode;
 					switch(nId){
-					case F_CHGMOD_EOL_CRLF: nEOLCode = EEolType::cr_and_lf; break;
-					case F_CHGMOD_EOL_CR: nEOLCode = EEolType::carriage_return; break;
-					case F_CHGMOD_EOL_LF: nEOLCode = EEolType::line_feed; break;
-					case F_CHGMOD_EOL_NEL: nEOLCode = EEolType::next_line; break;
-					case F_CHGMOD_EOL_PS: nEOLCode = EEolType::paragraph_separator; break;
-					case F_CHGMOD_EOL_LS: nEOLCode = EEolType::line_separator; break;
+					case F_CHGMOD_EOL_CRLF:	nEOLCode = EEolType::cr_and_lf; break;
+					case F_CHGMOD_EOL_CR:	nEOLCode = EEolType::carriage_return; break;
+					case F_CHGMOD_EOL_LF:	nEOLCode = EEolType::line_feed; break;
+					case F_CHGMOD_EOL_NEL:	nEOLCode = EEolType::next_line; break;
+					case F_CHGMOD_EOL_PS:	nEOLCode = EEolType::paragraph_separator; break;
+					case F_CHGMOD_EOL_LS:	nEOLCode = EEolType::line_separator; break;
 					default:
-						nEOLCode = -1;
+						nEOLCode = EEolType::none;
 					}
 					if( !CEol::IsNone( nEOLCode ) ){
 						GetActiveView().GetCommander().HandleCommand( F_CHGMOD_EOL, true, static_cast<LPARAM>(nEOLCode), 0, 0, 0 );

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -1487,8 +1487,8 @@ LRESULT CEditWnd::DispatchEvent(
 					default:
 						nEOLCode = -1;
 					}
-					if( nEOLCode != -1 ){
-						GetActiveView().GetCommander().HandleCommand( F_CHGMOD_EOL, true, nEOLCode, 0, 0, 0 );
+					if( !CEol::IsNone( nEOLCode ) ){
+						GetActiveView().GetCommander().HandleCommand( F_CHGMOD_EOL, true, static_cast<LPARAM>(nEOLCode), 0, 0, 0 );
 					}
 				}
 			}

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -798,7 +798,7 @@ void CEditWnd::SetDocumentTypeWhenCreate(
 		}
 		else{
 			GetDocument()->SetDocumentEncoding( nCharCode, CCodeTypeName( nCharCode ).IsBomDefOn() );
-			GetDocument()->m_cDocEditor.m_cNewLineCode = EOL_CRLF;
+			GetDocument()->m_cDocEditor.m_cNewLineCode = EEolType::cr_and_lf;
 		}
 	}
 
@@ -1478,12 +1478,12 @@ LRESULT CEditWnd::DispatchEvent(
 					::DestroyMenu( hMenuPopUp );
 					int nEOLCode = 0;
 					switch(nId){
-					case F_CHGMOD_EOL_CRLF: nEOLCode = EOL_CRLF; break;
-					case F_CHGMOD_EOL_CR: nEOLCode = EOL_CR; break;
-					case F_CHGMOD_EOL_LF: nEOLCode = EOL_LF; break;
-					case F_CHGMOD_EOL_NEL: nEOLCode = EOL_NEL; break;
-					case F_CHGMOD_EOL_PS: nEOLCode = EOL_PS; break;
-					case F_CHGMOD_EOL_LS: nEOLCode = EOL_LS; break;
+					case F_CHGMOD_EOL_CRLF: nEOLCode = EEolType::cr_and_lf; break;
+					case F_CHGMOD_EOL_CR: nEOLCode = EEolType::carriage_return; break;
+					case F_CHGMOD_EOL_LF: nEOLCode = EEolType::line_feed; break;
+					case F_CHGMOD_EOL_NEL: nEOLCode = EEolType::next_line; break;
+					case F_CHGMOD_EOL_PS: nEOLCode = EEolType::paragraph_separator; break;
+					case F_CHGMOD_EOL_LS: nEOLCode = EEolType::line_separator; break;
 					default:
 						nEOLCode = -1;
 					}

--- a/tests/unittests/test-ceol.cpp
+++ b/tests/unittests/test-ceol.cpp
@@ -1,0 +1,151 @@
+﻿/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+
+#include <gtest/gtest.h>
+#include "CEol.h"
+
+/*!
+	CEolのテスト
+ */
+TEST(CEol, CEol)
+{
+	// 初期値は none 
+	CEol cEol;
+	EXPECT_EQ(EOL_NONE, cEol.GetType());
+	EXPECT_EQ(EOL_NONE, (EEolType)cEol);
+
+	// 代入したら変更できる
+	cEol = EEolType::EOL_LF;
+	EXPECT_EQ(EEolType::EOL_LF, cEol.GetType());
+
+	// コピーの確認
+	CEol cCopied = cEol;
+	EXPECT_EQ(cEol.GetType(), cCopied.GetType());
+
+	// EEolTypeは変な値でも格納できる
+	EEolType eBadValue = static_cast<EEolType>(100);
+	EXPECT_EQ(100, static_cast<int>(eBadValue));
+
+	// CEolは変な値を格納できない（入れようとした場合CRLFになる）
+	cEol = eBadValue;
+	EXPECT_EQ(EEolType::EOL_CRLF, cEol.GetType());
+}
+
+/*!
+	CEolのテスト
+ */
+TEST(CEol, typeNone)
+{
+	CEol cEol(EOL_NONE);
+
+	EXPECT_EQ(EOL_NONE, cEol.GetType());
+	EXPECT_EQ(0, cEol.GetLen());
+	EXPECT_STREQ(L"改行無", cEol.GetName());
+	EXPECT_STREQ(L"", cEol.GetValue2());
+	EXPECT_FALSE(cEol.IsValid());
+}
+
+/*!
+	CEolのテスト
+ */
+TEST(CEol, typeCrlf)
+{
+	CEol cEol(EOL_CRLF);
+
+	EXPECT_EQ(EOL_CRLF, cEol.GetType());
+	EXPECT_EQ(2, cEol.GetLen());
+	EXPECT_STREQ(L"CRLF", cEol.GetName());
+	EXPECT_STREQ(L"\r\n", cEol.GetValue2());
+	EXPECT_TRUE(cEol.IsValid());
+}
+
+/*!
+	CEolのテスト
+ */
+TEST(CEol, typeLf)
+{
+	CEol cEol(EOL_LF);
+
+	EXPECT_EQ(EOL_LF, cEol.GetType());
+	EXPECT_EQ(1, cEol.GetLen());
+	EXPECT_STREQ(L"LF", cEol.GetName());
+	EXPECT_STREQ(L"\n", cEol.GetValue2());
+	EXPECT_TRUE(cEol.IsValid());
+}
+
+/*!
+	CEolのテスト
+ */
+TEST(CEol, typeCr)
+{
+	CEol cEol(EOL_CR);
+
+	EXPECT_EQ(EOL_CR, cEol.GetType());
+	EXPECT_EQ(1, cEol.GetLen());
+	EXPECT_STREQ(L"CR", cEol.GetName());
+	EXPECT_STREQ(L"\r", cEol.GetValue2());
+	EXPECT_TRUE(cEol.IsValid());
+}
+
+/*!
+	CEolのテスト
+ */
+TEST(CEol, typeNel)
+{
+	CEol cEol(EOL_NEL);
+
+	EXPECT_EQ(EOL_NEL, cEol.GetType());
+	EXPECT_EQ(1, cEol.GetLen());
+	EXPECT_STREQ(L"NEL", cEol.GetName());
+	EXPECT_STREQ(L"\x85", cEol.GetValue2());
+	EXPECT_TRUE(cEol.IsValid());
+}
+
+/*!
+	CEolのテスト
+ */
+TEST(CEol, typeLs)
+{
+	CEol cEol(EOL_LS);
+
+	EXPECT_EQ(EOL_LS, cEol.GetType());
+	EXPECT_EQ(1, cEol.GetLen());
+	EXPECT_STREQ(L"LS", cEol.GetName());
+	EXPECT_STREQ(L"\u2028", cEol.GetValue2());
+	EXPECT_TRUE(cEol.IsValid());
+}
+
+/*!
+	CEolのテスト
+ */
+TEST(CEol, typePs)
+{
+	CEol cEol(EOL_PS);
+
+	EXPECT_EQ(EOL_PS, cEol.GetType());
+	EXPECT_EQ(1, cEol.GetLen());
+	EXPECT_STREQ(L"PS", cEol.GetName());
+	EXPECT_STREQ(L"\u2029", cEol.GetValue2());
+	EXPECT_TRUE(cEol.IsValid());
+}

--- a/tests/unittests/test-ceol.cpp
+++ b/tests/unittests/test-ceol.cpp
@@ -32,12 +32,12 @@ TEST(CEol, CEol)
 {
 	// 初期値は none 
 	CEol cEol;
-	EXPECT_EQ(EOL_NONE, cEol.GetType());
-	EXPECT_EQ(EOL_NONE, (EEolType)cEol);
+	EXPECT_EQ(EEolType::none, cEol.GetType());
+	EXPECT_EQ(EEolType::none, (EEolType)cEol);
 
 	// 代入したら変更できる
-	cEol = EEolType::EOL_LF;
-	EXPECT_EQ(EEolType::EOL_LF, cEol.GetType());
+	cEol = EEolType::line_feed;
+	EXPECT_EQ(EEolType::line_feed, cEol.GetType());
 
 	// コピーの確認
 	CEol cCopied = cEol;
@@ -49,7 +49,7 @@ TEST(CEol, CEol)
 
 	// CEolは変な値を格納できない（入れようとした場合CRLFになる）
 	cEol = eBadValue;
-	EXPECT_EQ(EEolType::EOL_CRLF, cEol.GetType());
+	EXPECT_EQ(EEolType::cr_and_lf, cEol.GetType());
 }
 
 /*!
@@ -57,9 +57,9 @@ TEST(CEol, CEol)
  */
 TEST(CEol, typeNone)
 {
-	CEol cEol(EOL_NONE);
+	CEol cEol(EEolType::none);
 
-	EXPECT_EQ(EOL_NONE, cEol.GetType());
+	EXPECT_EQ(EEolType::none, cEol.GetType());
 	EXPECT_EQ(0, cEol.GetLen());
 	EXPECT_STREQ(L"改行無", cEol.GetName());
 	EXPECT_STREQ(L"", cEol.GetValue2());
@@ -71,9 +71,9 @@ TEST(CEol, typeNone)
  */
 TEST(CEol, typeCrlf)
 {
-	CEol cEol(EOL_CRLF);
+	CEol cEol(EEolType::cr_and_lf);
 
-	EXPECT_EQ(EOL_CRLF, cEol.GetType());
+	EXPECT_EQ(EEolType::cr_and_lf, cEol.GetType());
 	EXPECT_EQ(2, cEol.GetLen());
 	EXPECT_STREQ(L"CRLF", cEol.GetName());
 	EXPECT_STREQ(L"\r\n", cEol.GetValue2());
@@ -85,9 +85,9 @@ TEST(CEol, typeCrlf)
  */
 TEST(CEol, typeLf)
 {
-	CEol cEol(EOL_LF);
+	CEol cEol(EEolType::line_feed);
 
-	EXPECT_EQ(EOL_LF, cEol.GetType());
+	EXPECT_EQ(EEolType::line_feed, cEol.GetType());
 	EXPECT_EQ(1, cEol.GetLen());
 	EXPECT_STREQ(L"LF", cEol.GetName());
 	EXPECT_STREQ(L"\n", cEol.GetValue2());
@@ -99,9 +99,9 @@ TEST(CEol, typeLf)
  */
 TEST(CEol, typeCr)
 {
-	CEol cEol(EOL_CR);
+	CEol cEol(EEolType::carriage_return);
 
-	EXPECT_EQ(EOL_CR, cEol.GetType());
+	EXPECT_EQ(EEolType::carriage_return, cEol.GetType());
 	EXPECT_EQ(1, cEol.GetLen());
 	EXPECT_STREQ(L"CR", cEol.GetName());
 	EXPECT_STREQ(L"\r", cEol.GetValue2());
@@ -113,9 +113,9 @@ TEST(CEol, typeCr)
  */
 TEST(CEol, typeNel)
 {
-	CEol cEol(EOL_NEL);
+	CEol cEol(EEolType::next_line);
 
-	EXPECT_EQ(EOL_NEL, cEol.GetType());
+	EXPECT_EQ(EEolType::next_line, cEol.GetType());
 	EXPECT_EQ(1, cEol.GetLen());
 	EXPECT_STREQ(L"NEL", cEol.GetName());
 	EXPECT_STREQ(L"\x85", cEol.GetValue2());
@@ -127,9 +127,9 @@ TEST(CEol, typeNel)
  */
 TEST(CEol, typeLs)
 {
-	CEol cEol(EOL_LS);
+	CEol cEol(EEolType::line_separator);
 
-	EXPECT_EQ(EOL_LS, cEol.GetType());
+	EXPECT_EQ(EEolType::line_separator, cEol.GetType());
 	EXPECT_EQ(1, cEol.GetLen());
 	EXPECT_STREQ(L"LS", cEol.GetName());
 	EXPECT_STREQ(L"\u2028", cEol.GetValue2());
@@ -141,9 +141,9 @@ TEST(CEol, typeLs)
  */
 TEST(CEol, typePs)
 {
-	CEol cEol(EOL_PS);
+	CEol cEol(EEolType::paragraph_separator);
 
-	EXPECT_EQ(EOL_PS, cEol.GetType());
+	EXPECT_EQ(EEolType::paragraph_separator, cEol.GetType());
 	EXPECT_EQ(1, cEol.GetLen());
 	EXPECT_STREQ(L"PS", cEol.GetName());
 	EXPECT_STREQ(L"\u2029", cEol.GetValue2());

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -114,6 +114,7 @@
     <ClCompile Include="test-cdlgopenfile.cpp" />
     <ClCompile Include="test-cdlgprofilemgr.cpp" />
     <ClCompile Include="test-cdoctypemanager.cpp" />
+    <ClCompile Include="test-ceol.cpp" />
     <ClCompile Include="test-cerrorinfo.cpp" />
     <ClCompile Include="test-cfileext.cpp" />
     <ClCompile Include="test-clayoutint.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -91,7 +91,6 @@
     <ClCompile Include="test-cwordparse.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
-    <ClCompile Include="coverage.cpp" />
     <ClCompile Include="test-csakuraenvironment.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
@@ -129,6 +128,9 @@
       <Filter>Test Files</Filter>
     </ClCompile>
     <ClCompile Include="test-cdoctypemanager.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-ceol.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
SonarCloudの警告を減らし、メンテナンスしやすいアプリに近づけることが目的です。

## <!-- 必須 --> カテゴリ

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
SonarCloud解析で、以下のBugs(Critical)レベル警告が検出されています。
> Explicitly define the missing destructor and copy constructor so that they will not be implicitly provided.
> https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AWnxcyPsO9B58BDk-C3r&open=AWnxcyPsO9B58BDk-C3r

超訳：コピー演算子を定義するときは、デストラクタ、コピーコンストラクタ、ムーブコンストラクタ、ムーブ演算子がコンパイラにより意図しない形で自動生成されることを防ぐため、これらを明示的に定義してください。

問題のあるコードはこれです。
https://github.com/sakura-editor/sakura/blob/d65f9865b7450a2dd205a7ed6578834185189382/sakura_core/CEol.h#L88-L89

単純な対処としては、削ってしまうか、他4種類のコンストラクタ・デストラクタ・演算子を追加してあげれば良いです。

CEol型はサクラエディタの中核を成すデータ型です。
  - テキストエディタにとって、データは「文字列」です。
  - テキストエディタのデータは「行」という論理単位で小分けにされます。
  - 「行」とは、「行終端子」で区切られた「文字列」です。
  - CEolはエディタ内で「適切な行終端子」を保持するための型です。

そこで、今回は SonarCloud 指摘を「キッカケ」と考えて、
「行終端子」を扱うコードを全体的にリファクタリングしてみました。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
- 「行終端子」の扱いに関する型定義が明確になり、結果として分かりやすくなります。
- CEolクラスの主要機能に対し、単体テストが追加されます。
- EEolTypeの定数名が「キャラクタ名略称」から「名前」になり、やや分かりやすくなります。
- SonarCloudのBugs(Critical)レベル警告が1つ減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- EEolTypeの定数名を一括置換した影響でテストできない領域のコードを修正しています。
- EEolTypeの定数名が長くなります。
- `enum EEolType` を `enum class` 化する影響で、修正範囲が大変広いです。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
説明されても分からんと思うので、ごく簡単にポイントだけ書きます。

- EEolType型　「行終端子」を表す型です。
  定義には無効な値を含んでいます。
- CEol型　行末記号の種類を保持する型です。
  EEolType型の定数を使って行末記号を保持します。
  保持できる値は、有効な「行終端子」または「行終端子なし」のみです。

- Rule-of-Five　👈 SonarCloud指摘はこれ。
  必要があるなら全部書けルール
- Rule-of-Zero　👈 PRの対処内容はこれ。
  必要がないなら書くなルール

- C++11 を利用できる場合、列挙型には `enum class` を使うべきらしいです。
  - `enum` 型　 EOL_NONEとか書きます。int型と暗黙変換できます。C言語互換です。
  - `enum class` 型　EEolType::noneとか書きます。暗黙変換できません。explicitが使えます。


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
- バイナリシーケンスないし文字列内に含まれる「行終端子」の検出・設定に関わる処理に影響する変更です。
  - ファイルを開くときの改行コード検出に影響します。
  - 「名前を付けて保存」の改行コード指定に影響します。
  - 「行単位」でデータを扱う処理に影響します。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
テキトーなファイルを開いて「名前を付けて保存」してみてください。
「改行コードを変換できること」を確認すれば結合テストになります。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1605
#1504

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
