### PR TITLE
C++アウトラインでclass x final:base{}と:がfinalにくっついているとクラス名がfinalになる不具合の修正

### DIFF
--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -477,6 +477,11 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 	szItemName[0] = L'\0';
 	szTemplateName[0] = L'\0';
 	nMode = 0;
+
+	// finalで無名ではない
+	auto is_final_context = [](const wchar_t* pszWord, const wchar_t* pszItemName) {
+		return wcscmp(L"final", pszWord) == 0 && wcscmp(LS(STR_OUTLINE_CPP_NONAME), pszItemName) != 0;
+	};
 	
 	//	Aug. 10, 2004 genta プリプロセス処理クラス
 	CCppPreprocessMng cCppPMng;
@@ -586,7 +591,8 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 								// class Klass:base のように:の前にスペースがない場合
 								if(nMode2 == M2_NAMESPACE_SAVE)
 								{
-									if(szWord[0]!='\0')
+									// 2021.3.27 class Klass final: public base{ の:だったら名前を上書きしない
+									if (szWord[0] != '\0' && !is_final_context(szWord, szItemName))
 										wcscpy( szItemName, szWord );
 									nMode2 = M2_NAMESPACE_END;
 								}
@@ -603,7 +609,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 				}else{
 					// 2002/10/27 frozen　ここから
 					if( nMode2 == M2_NAMESPACE_SAVE ){
-						if( wcscmp(L"final", szWord) == 0 && wcscmp(LS(STR_OUTLINE_CPP_NONAME), szItemName) != 0 ){
+						if(is_final_context(szWord, szItemName)){
 							// strcut name final のfinalはクラス名の一部ではない
 							// ただし struct finalは名前
 						}else{


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

C++アウトラインで、class名がfinalになってしまう不具合を修正します。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

## <!-- 自明なら省略可 --> PR のメリット

アウトライン解析が若干正確になります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

特にありません。

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

```C++
class MY_MACRO class_name{};
```
C++アウトライン解析では、クラス名がMY_MACROではなく class_nameになるように後ろの単語が優先されるようです。
その際にfinalキーワードは無視されるようになっています。
しかしサクラエディタの実装では単語単位の解析に:を含んでいてfinalの直後にある:がスペースを挟んでいるかで、実行されるコードが異なります。
そこで、スペース側ではfinalの考慮がされていましたが、くっついている側の処理では抜けていました。

なお無名クラスかのチェックがあり、言語が日本語の時、クラス名が漢字で`無名`だと、無名クラスと認識されてfinalがクラス名にされてしまう制限があります。
```C++
class 無名 final : public base{};
```
本当の無名クラスをfinal指定することは、言語仕様上できません。

## <!-- わかる範囲で --> PR の影響範囲

C++アウトライン解析の該当部分のみです。

## <!-- 必須 --> テスト内容

### テスト1

手順
```C++
class c1 final {};
class c2 final:base{}; //※
class c3 final :base{};
class c4 final: base{}; //※
class c5 final : base{};

class c6 final {};
class c7 final:public base{}; //※
class c8 final :public base{};
class c9 final: public base{}; //※
class c10 final : public base{};

// こちらはクラス名がfinal(後方互換、文脈依存キーワード)
class final{};
class final: public base{};
class final : public base{};
```
このソースコードをサクラエディタに貼り付けて、C++のアウトライン解析を実行します。
PRの修正前は「c2, c4, c7, c9」のクラス名がfinalになってしまっています。
PRの修正適用後は正しく表示されるようになります。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
