### PR TITLE
タイプ別設定のインポートでバージョンチェックが正しく働いていなかった

### DIFF
--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -251,17 +251,16 @@ bool CImpExpType::ImportAscertain( HINSTANCE hInstance, HWND hwndParent, const w
 
 	// Check Version
 	int		nStructureVersion = 0;
-	wchar_t	szKeyVersion[64];
 	if (!m_cProfile.IOProfileData( szSecInfo, szKeyStructureVersion, nStructureVersion )) {
 		sErrMsg = LS(STR_IMPEXP_ERR_TYPE);
 		return false;
 	}
 	if ((unsigned int)nStructureVersion != m_pShareData->m_vStructureVersion) {
-		wcscpy( szKeyVersion, L"?" );
-		m_cProfile.IOProfileData(szSecInfo, szKeyVersion, StringBufferW(szKeyVersion));
+		std::wstring	strKeyVerValue = L"?";
+		m_cProfile.IOProfileData(szSecInfo, szKeyVersion, strKeyVerValue);
 		int nRet = ConfirmMessage( hwndParent,
 			LS(STR_IMPEXP_VER), 
-			GSTR_APPNAME, szKeyVersion, nStructureVersion );
+			GSTR_APPNAME, strKeyVerValue.c_str(), nStructureVersion );
 		if ( IDYES != nRet ) {
 			return false;
 		}


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
タイプ別設定インポートのときに表示される、iniファイルのバージョン情報が必ず「?」になっていた不具合を修正します。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景
Visual StudioでWarningLevel4のチェックをしていたところ、見つけた不具合のひとつです。
せっかくなので直したいです。

## <!-- 自明なら省略可 --> PR のメリット
バグが修正されます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
読み込みのためにszKeyVersionという変数が宣言されていましたが、これが定数の同名のiniキー名を隠ぺいしていました。
そのため、IOProfileDataの行でキー名「?」を読み込もうとして、必ず失敗していました。
変数名を変更したうえで長さの心配がないstd::wstringに置き換えました。

## <!-- わかる範囲で --> PR の影響範囲

タイプ別設定のインポート時に表示される、バージョンが違う時の警告のダイアログの表示だけです。

## <!-- 必須 --> テスト内容

### テスト1
手順

古いバージョンのタイプ別設定のエクスポートしたiniファイルを用意します。
そうでない場合は、最新版でエクスポートしたiniファイルをエディタで開いて、末尾にある[Info]のszKeyStructureVersionを小さい値に書き換えます。

タイプ別設定一覧でインポートしようとすると、
「エクスポートしたsakura(?/177)とバージョンが異なります。
インポートしてもよろしいですか？」
というようなダイアログが表示されます。
修正前は「?」になっています。
PRの修正後は「2.4.2.0」のようにiniの[Info]szVersionキーの内容が表示されるようになります。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
