### PR TITLE
CCodeBaseの変換テストを追加する

### DIFF
--- a/sakura_core/charset/CCodeFactory.h
+++ b/sakura_core/charset/CCodeFactory.h
@@ -27,7 +27,8 @@
 #define SAKURA_CCODEFACTORY_A5C6C204_F9BD_42BA_A5CD_1B086833CCA4_H_
 #pragma once
 
-class CCodeBase;
+#include <memory>
+#include "charset/CCodeBase.h"
 
 class CCodeFactory{
 public:
@@ -36,5 +37,14 @@ public:
 		ECodeType	eCodeType,		//!< 文字コード
 		int			nFlag			//!< bit 0: MIME Encodeされたヘッダをdecodeするかどうか
 	);
+
+	//! eCodeTypeに適合する CCodeBaseインスタンス を生成
+	static std::unique_ptr<CCodeBase> CreateCodeBase(
+		ECodeType	eCodeType		//!< 文字コード
+	)
+	{
+		return std::unique_ptr<CCodeBase>( CreateCodeBase( eCodeType, 0 ) );
+	}
 };
+
 #endif /* SAKURA_CCODEFACTORY_A5C6C204_F9BD_42BA_A5CD_1B086833CCA4_H_ */


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
文字コード変換に関するテストを追加します。

## <!-- 必須 --> カテゴリ

- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
サクラエディタには、各種「文字コード」でエンコードされたファイルを開くための「コード変換機能」があります。

コード変換機能は、各種文字コードの仕様が「やや難解」であることもあり、長いことごく一部の「偉い人」ないし「偉そうな人」による寡占でメンテされてきた経緯があるっぽいです。

ぶっちゃけで言うと間違ってる部分がかなりあるんですけど「誰もが分かるような状態」で誤りを指摘することが大変難しく、「分かっているけど修正できない既知の問題」が溜まってきていると思います。

今回は「コード変換機能」に単体テストを用意することにより、
間違っていたら直す、という当たり前のことができる環境を作ってみます。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
- 文字コード変換のテストが書けるようになります。
- Shift-JISの文字コード変換について、ほぼ完全な仕様を確認できます。
- 今後、挙動の怪しい変換を見つけたら、少しテストコードを追加すれば容易に検証できるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- 実装過程で 3件の不具合 を発見しましたが、あえて修正していません。
- CCodeBaseに対してラッパーインターフェースを追加していますが、これが「従来のインターフェースだとテスト書きにくいんじゃ、ヴォケ」という主張の表れであることを読み取って、心を痛める歴代の開発者がいるかも知れません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
サクラエディタは、編集するテキストファイルを内部的に「拡張UTF16LE」に変換しています。

この変換に使うのが `CCodeBase 派生クラス` で、今回のテスト対象です。

CCodeBase派生クラスは2つの変換メソッドを持っています。

| メソッド名 | 役割 |
|--|--|
|CodeToUnicode|ファイルデータを内部データに変換する。|
|UnicodeToCode|内部データをファイルデータに変換する。|

世の中には色々な文字コードがあります。
| 文字コード名 | 説明 | 表現できる文字の数 |
|--|--|--|
|SHIFT-JIS|Windows 3.1日本語版が世に出るときに作られた文字コード。|約1万文字|
|EUC-JP|拡張UNIXコード。古いLinuxで使われていた文字コード。|約8万文字|
|UTF-8|Unicodeを`8bit`単位で符号化したもの。|約100万文字|
|UTF-16|Unicodeを`16bit`単位で符号化したもの。|約100万文字|

見て分かる通り、Unicodeとそうでないものでは表現できる文字数に圧倒的な差があります。

サクラエディタはこの特性を活用して、すべての文字をUnicodeに変換しようとします。
変換できなかったら、変換できないなりにデータを破壊しないように拡張文字として保持します。

- SHIFT-JIS変換の例
  |変換元文字|変換結果|
  |--|--|
  |普通の文字|Unicode文字に変換。|
  |NEC選定IBM拡張文字|エンコードして保持。|
  |SHIFT-JIS範囲外|エンコードして保持。|

  「エンコードする」ということは「デコードできる」ということです。

本当はテスト追加と同時に既知の不具合を直してしまいたかったんですが、それをやるとレビューが成立しないような気がしたので、いったん無理なく実装できる部分だけに留め、問題解決は先送りすることにしました。


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
このPRは既存処理を変更するものではありません。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
テストで利用するために、本体にラッパーインターフェースを追加しています。
追加コードについては単体テストで利用しているため、追加のテストは不要と考えています。


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
- _byteswap_ushort
  https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/byteswap-uint64-byteswap-ulong-byteswap-ushort
  最新のMinGWなら普通にコンパイルできるようです。
- サクラエディタのx64対応について
  https://github.com/sakura-editor/sakura/issues?q=is%3Aopen+is%3Aissue+label%3Ax64
