### PR TITLE
メモリDCを利用しない場合はアンダーライン描画を行描画の直後に行う事でちらつきを抑える

### DIFF
--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -762,6 +762,16 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 	//                      全部の行を描画                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
+	/* アクティブペインは、アンダーライン描画 */
+	const bool bDrawUnderLine = m_pcEditWnd->GetActivePane() == m_nMyIndex;
+	// カーソル行アンダーライン描画を行描画ループ内で行うかどうか
+	const bool bDrawUnderLineWithoutDelay =
+		bDrawUnderLine
+		&& !bUseMemoryDC  // メモリDCを利用しない場合はアンダーライン描画を行描画の直後に行う事でちらつきを抑える
+		&& !m_pTypeData->m_ColorInfoArr[COLORIDX_CURSORVLINE].m_bDisp  // カーソル行より下にあるカーソル位置縦線が消えてしまうので、非表示設定でのみ行う
+		&& m_pTypeData->m_nLineSpace > 0  // 行間を0以下にすると、カーソル行アンダーラインの位置が一つ下の行に含まれるようになるため、レンダリングの対象行が変わるので、行間が0より大きい場合のみ行う
+		;
+
 	//必要な行を描画する	// 2009.03.26 ryoji 行番号のみ描画を通常の行描画と分離（効率化）
 	if(pPs->rcPaint.right <= GetTextArea().GetAreaLeft()){
 		while(sPos.GetLayoutLineRef() <= nLayoutLineTo)
@@ -789,8 +799,9 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 			//描画X位置リセット
 			sPos.ResetDrawCol();
 
-			auto nLayoutLine = sPos.GetLayoutLineRef();
-
+			//DrawLogicLineを呼ぶと値が変わるので呼ぶ前に取得
+			auto nCurrLine = sPos.GetLayoutLineRef();
+			
 			//1行描画
 			bool bDispResult = DrawLogicLine(
 				&sInfo,
@@ -815,13 +826,8 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 					DeleteObject(hdcBgImg);
 				}
 			}
-			// メモリDCを利用しない場合はアンダーライン描画を行描画の直後に行う事でちらつきを抑える
-			if (!bUseMemoryDC && nLayoutLine == caretY)
-			{
-				if (m_pcEditWnd->GetActivePane() == m_nMyIndex) {
-					/* アクティブペインは、アンダーライン描画 */
-					GetCaret().m_cUnderLine.CaretUnderLineON(true, false);
-				}
+			if (bDrawUnderLineWithoutDelay && nCurrLine == caretY) {
+				GetCaret().m_cUnderLine.CaretUnderLineON(true, false);
 			}
 		}
 	}
@@ -855,14 +861,15 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 			pPs->rcPaint.top,
 			SRCCOPY
 		);
-		// From Here 2007.09.09 Moca 互換BMPによる画面バッファ
-		//     アンダーライン描画をメモリDCからのコピー前処理から後に移動
-		if ( m_pcEditWnd->GetActivePane() == m_nMyIndex ){
-			/* アクティブペインは、アンダーライン描画 */
-			GetCaret().m_cUnderLine.CaretUnderLineON( true, false );
-		}
-		// To Here 2007.09.09 Moca
 	}
+
+	// From Here 2007.09.09 Moca 互換BMPによる画面バッファ
+	//     アンダーライン描画をメモリDCからのコピー前処理から後に移動
+	if ( bDrawUnderLine && !bDrawUnderLineWithoutDelay ){
+		/* アクティブペインは、アンダーライン描画 */
+		GetCaret().m_cUnderLine.CaretUnderLineON( true, false );
+	}
+	// To Here 2007.09.09 Moca
 
 	/* 03/02/18 対括弧の強調表示(描画) ai */
 	DrawBracketPair( true );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

共通設定の全般の「画面キャッシュを使う」にチェックを入れていない場合に、PageUp/PageDownキーを押してスクロールする際にアンダーライン描画がちらつく現象が起きます。それを回避するのが目的です。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

共通設定の全般の「画面キャッシュを使う」にチェックを入れていない場合はメモリDCが使われません。メモリDCを使わないと描画途中の絵が画面に表示される事がありちらつきが起きやすいです。

このPRでは、アンダーライン位置の行の描画直後にアンダーライン描画を行う事で、同じ位置にある要素が近いタイミングで描画されるように処理を調整してちらつきが起きにくいようにしています。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

表示のちらつきが減る

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

ちらつきを減らす対処を入れた分のコードの記述が増えてしまう。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

アンダーライン描画に影響します。

共通設定の全般の「画面キャッシュを使う」にチェックを入れている場合の動作は従来と変わりません。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順
- 行数が多いファイル、例えば `sakura_core\CGrepAgent.cpp` を開く
- PageUp/PageDownキーを叩いてスクロールする操作を繰り返す
- スクロール時にアンダーラインの表示にちらつきがおきるか目視で確認する

