### PR TITLE
メモリバッファクラスをx64対応できるように書き替える

### DIFF
--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -337,7 +337,7 @@ bool CClipboard::GetText(CNativeW* cmemBuf, bool* pbColumnSelect, bool* pbLineSe
 		CMemory cmemSjis( szData, GlobalSize(hText) );
 		CNativeW cmemUni;
 		CShiftJis::SJISToUnicode(cmemSjis, &cmemUni);
-		cmemSjis.Clean();
+		cmemSjis.Reset();
 		// '\0'までを取得
 		cmemUni._SetStringLength(wcslen(cmemUni.GetStringPtr()));
 		cmemUni.swap(*cmemBuf);

--- a/sakura_core/charset/CCodeBase.cpp
+++ b/sakura_core/charset/CCodeBase.cpp
@@ -30,7 +30,7 @@
 #include "CEol.h"
 #include "env/CommonSetting.h"
 
-void CCodeBase::GetBom(CMemory* pcmemBom){ pcmemBom->Clear(); }					//!< BOMデータ取得
+void CCodeBase::GetBom(CMemory* pcmemBom){ pcmemBom->Reset(); }					//!< BOMデータ取得
 
 // 表示用16表示	UNICODE → Hex 変換	2008/6/9 Uchi
 EConvertResult CCodeBase::UnicodeToHex(const wchar_t* cSrc, const int iSLen, WCHAR* pDst, const CommonSetting_Statusbar* psStatusbar)

--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -225,7 +225,7 @@ void CCodePage::GetEol(CMemory* pcmemEol, EEolType eEolType)
 	CodeToUnicode(*pcmemEol, &temp2);
 	// 双方向変換ができる場合だけ設定
 	if( !CNativeW::IsEqual(temp, temp2) ){
-		pcmemEol->Clear();
+		pcmemEol->Reset();
 	}
 }
 
@@ -237,7 +237,7 @@ void CCodePage::GetBom(CMemory* pcmemBom)
 	CNativeW temp2;
 	CodeToUnicode(*pcmemBom, &temp2);
 	if( !CNativeW::IsEqual(temp, temp2) ){
-		pcmemBom->Clear();
+		pcmemBom->Reset();
 	}
 }
 

--- a/sakura_core/charset/CUnicode.cpp
+++ b/sakura_core/charset/CUnicode.cpp
@@ -57,11 +57,9 @@ EConvertResult CUnicode::_UnicodeToUnicode_in( const CMemory& cSrc, CNativeW* pD
 
 	if( bBigEndian ){
 		if( &cSrc != pDstMem2 && !bCopy ){
-			// コピーしつつ UnicodeBe -> Unicode
-			pDstMem2->SwabHLByte(cSrc);
-		}else{
-			pDstMem2->SwapHLByte();  // UnicodeBe -> Unicode
+			pDstMem2->SetRawDataHoldBuffer( cSrc );
 		}
+		pDstMem2->SwapHLByte();  // UnicodeBe -> Unicode
 	}else if( !bCopy ){
 		pDstMem2->SetRawDataHoldBuffer(pSrc, nSrcLen);
 	}
@@ -71,11 +69,10 @@ EConvertResult CUnicode::_UnicodeToUnicode_in( const CMemory& cSrc, CNativeW* pD
 EConvertResult CUnicode::_UnicodeToUnicode_out( const CNativeW& cSrc, CMemory* pDstMem, const bool bBigEndian )
 {
 	if( bBigEndian == true ){
-		if( cSrc._GetMemory() == pDstMem ){
-			pDstMem->SwapHLByte();   // Unicode -> UnicodeBe
-		}else{
-			pDstMem->SwabHLByte(*(cSrc._GetMemory()));
+		if( cSrc._GetMemory() != pDstMem ){
+			pDstMem->SetRawDataHoldBuffer( *(cSrc._GetMemory()) );
 		}
+		pDstMem->SwapHLByte();   // Unicode -> UnicodeBe
 	}else{
 		if( cSrc._GetMemory() != pDstMem ){
 			pDstMem->SetRawDataHoldBuffer(*(cSrc._GetMemory()));

--- a/sakura_core/convert/CDecode_UuDecode.cpp
+++ b/sakura_core/convert/CDecode_UuDecode.cpp
@@ -40,7 +40,7 @@ bool CDecode_UuDecode::DoDecode( const CNativeW& pcSrc, CMemory* pcDst )
 	CEol ceol;
 	bool bsuccess = false;
 
-	pcDst->Clear();
+	pcDst->Reset();
 	psrc = pcSrc.GetStringPtr();
 	nsrclen = pcSrc.GetStringLength();
 
@@ -49,7 +49,7 @@ bool CDecode_UuDecode::DoDecode( const CNativeW& pcSrc, CMemory* pcDst )
 		return false;
 	}
 	pcDst->AllocBuffer( (nsrclen / 4) * 3 + 10 );
-	pw_base = pw = static_cast<char *>( pcDst->GetRawPtr() );
+	pw_base = pw = reinterpret_cast<char *>( pcDst->GetRawPtr() );
 
 	// 先頭の改行・空白文字をスキップ
 	for( ncuridx = 0; ncuridx < nsrclen; ++ncuridx ){

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -36,89 +36,68 @@
 #define SAKURA_CMEMORY_EE37AF3F_6B73_412E_8F0C_8A64F4250AE3_H_
 #pragma once
 
+#include <cstddef>
+#include <string_view>
+
 /*! ファイル文字コードセット判別時の先読み最大サイズ */
 #define CheckKanjiCode_MAXREADLENGTH 16384
 
-//! メモリバッファクラス
+/*!
+	メモリバッファクラス
+
+	ヒープメモリにバッファ領域を確保する
+	内部バッファのサイズは8の倍数に切り上げて確保される。
+	NUL文字(\0)を含むバイナリシーケンスを格納することができる。
+ */
 class CMemory
 {
 	//コンストラクタ・デストラクタ
 public:
-	CMemory() noexcept;
-	CMemory(const void* pData, int nDataLenBytes);
-	CMemory(const CMemory& rhs);
-	CMemory(CMemory&& other) noexcept;
+	CMemory() noexcept = default;
+	CMemory( const void* pData, size_t nDataLen );
+	CMemory( const CMemory& rhs );
+	CMemory( CMemory&& other ) noexcept;
 	// デストラクタを仮想にすると仮想関数テーブルへのポインタを持つ為にインスタンスの容量が増えてしまうので仮想にしない
 	// 仮想デストラクタでは無いので派生クラスでメンバー変数を追加しない事
-	~CMemory();
+	~CMemory() noexcept;
 
 	//インターフェース
 public:
-	void AllocBuffer(int nNewDataLen);                               //!< バッファサイズの調整。必要に応じて拡大する。
-	void SetRawData( const void* pData, int nDataLen );    //!< バッファの内容を置き換える
-	void SetRawData(const CMemory& pcmemData);                     //!< バッファの内容を置き換える
-	void SetRawDataHoldBuffer( const void* pData, int nDataLen );    //!< バッファの内容を置き換える(バッファを保持)
-	void SetRawDataHoldBuffer(const CMemory& pcmemData);                     //!< バッファの内容を置き換える(バッファを保持)
-	void AppendRawData( const void* pData, int nDataLen ); //!< バッファの最後にデータを追加する
-	void AppendRawData(const CMemory* pcmemData);                  //!< バッファの最後にデータを追加する
-	void Clean(){ _Empty(); }
-	void Clear(){ _Empty(); }
+	void AllocBuffer( size_t nNewDataLen );								//!< バッファサイズの調整。必要に応じて拡大する。
+	void SetRawData( const void* pData, size_t nDataLen );				//!< バッファの内容を置き換える
+	void SetRawData( const CMemory& cmemData );							//!< バッファの内容を置き換える
+	void SetRawDataHoldBuffer( const void* pData, size_t nDataLen );	//!< バッファの内容を置き換える(バッファを保持)
+	void SetRawDataHoldBuffer( const CMemory& cmemData );				//!< バッファの内容を置き換える(バッファを保持)
+	void AppendRawData( const void* pData, size_t nDataLen );			//!< バッファの最後にデータを追加する
+	void Reset( void ) noexcept;										//!< バッファをリセットする
 
-	inline const void* GetRawPtr() const{ return m_pRawData; } //!< データへのポインタを返す
-	inline void* GetRawPtr(){ return m_pRawData; }             //!< データへのポインタを返す
-	int GetRawLength() const { return m_nRawLen; }                //!<データ長を返す。バイト単位。
+	[[nodiscard]] const std::byte* GetRawPtr() const noexcept { return m_pRawData; } //!< データへのポインタを返す
+	std::byte* GetRawPtr() noexcept { return m_pRawData; }             //!< データへのポインタを返す
+	[[nodiscard]] int GetRawLength() const noexcept { return static_cast<int>(m_nRawLen); }                //!<データ長を返す。バイト単位。
 
 	// 演算子
-	//! コピー代入演算子
-	CMemory& operator = (const CMemory& rhs) {
-		if (this != &rhs) {
-			SetRawData(rhs);
-		}
-		return *this;
-	}
-	//! ムーブ代入演算子
-	CMemory& operator = (CMemory&& rhs) noexcept {
-		if (this != &rhs) {
-			_Empty();
-			swap(rhs);
-		}
-		return *this;
-	}
+	CMemory& operator = ( const CMemory& rhs );
+	CMemory& operator = ( CMemory&& rhs ) noexcept;
 
 	// 比較
-	static int IsEqual(const CMemory& cmem1, const CMemory& cmem2);	/* 等しい内容か */
+	static bool IsEqual( const CMemory& cmem1, const CMemory& cmem2 );	/* 等しい内容か */
 
 	// 変換関数
-	static void SwapHLByte(char* pData, const int nDataLen); // 下記関数のstatic関数版
-	void SwapHLByte();			// Byteを交換する
-	bool SwabHLByte(const CMemory& mem); // Byteを交換する(コピー版)
+	static void SwapHLByte( char* pData, const size_t nDataLen ) noexcept; // 下記関数のstatic関数版
+	void SwapHLByte() noexcept;		//!< データをWORD値の配列とみなして上下BYTEを交換する
 
-protected:
-	/*
-	||  実装ヘルパ関数
-	*/
-	void _Empty( void ); //!< 解放する。m_pRawDataはNULLになる。
-	void _AddData(const void* pData, int nDataLen);
-public:
-	void _AppendSz(const char* str);
-	void _SetRawLength(int nLength);
-	void swap( CMemory& left ) noexcept {
-		std::swap( m_nDataBufSize, left.m_nDataBufSize );
-		std::swap( m_pRawData, left.m_pRawData );
-		std::swap( m_nRawLen, left.m_nRawLen );
-	}
-	int capacity() const { return m_nDataBufSize ? m_nDataBufSize - 2: 0; }
+	void _AppendSz( std::string_view str );
+	void _SetRawLength( size_t nLength );
+	void swap( CMemory& left ) noexcept;
+	[[nodiscard]] int capacity() const noexcept { return 8 <= m_nDataBufSize ? m_nDataBufSize - 2: 0; }
 
 private: // 2002/2/10 aroka アクセス権変更
 	/*
 	|| メンバ変数
 	*/
-	char*	m_pRawData;		//バッファ
-	int		m_nRawLen;		//データサイズ(m_nDataBufSize以内)。バイト単位。
-	int		m_nDataBufSize;	//バッファサイズ。バイト単位。
+	std::byte*	m_pRawData = nullptr;	//!< バッファ
+	unsigned	m_nRawLen = 0;			//!< データサイズ(m_nDataBufSize未満)。バイト単位。
+	unsigned	m_nDataBufSize = 0;		//!< バッファサイズ。バイト単位。
 };
 
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                     inline関数の実装                        //
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 #endif /* SAKURA_CMEMORY_EE37AF3F_6B73_412E_8F0C_8A64F4250AE3_H_ */

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -89,7 +89,8 @@ public:
 	void _AppendSz( std::string_view str );
 	void _SetRawLength( size_t nLength );
 	void swap( CMemory& left ) noexcept;
-	[[nodiscard]] int capacity() const noexcept { return 8 <= m_nDataBufSize ? m_nDataBufSize - 2: 0; }
+	//! メモリ再確保を行わずに格納できる最大バイト数を求める
+	[[nodiscard]] virtual int capacity() const noexcept { return 8 <= m_nDataBufSize ? m_nDataBufSize - 2: 0; }
 
 private: // 2002/2/10 aroka アクセス権変更
 	/*

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -90,7 +90,7 @@ public:
 	void _SetRawLength( size_t nLength );
 	void swap( CMemory& left ) noexcept;
 	//! メモリ再確保を行わずに格納できる最大バイト数を求める
-	[[nodiscard]] virtual int capacity() const noexcept { return 8 <= m_nDataBufSize ? m_nDataBufSize - 2: 0; }
+	[[nodiscard]] int capacity() const noexcept { return 8 <= m_nDataBufSize ? m_nDataBufSize - 2: 0; }
 
 private: // 2002/2/10 aroka アクセス権変更
 	/*

--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -43,19 +43,24 @@ CNativeA::CNativeA(const char* szData)
 // バッファの内容を置き換える
 void CNativeA::SetString( const char* pszData )
 {
-	SetString(pszData,strlen(pszData));
+	if( pszData != nullptr ){
+		std::string_view data( pszData );
+		SetString( data.data(), data.length() );
+	}else{
+		Reset();
+	}
 }
 
 // バッファの内容を置き換える。nLenは文字単位。
 void CNativeA::SetString( const char* pData, size_t nDataLen )
 {
-	CNative::SetRawData( pData, nDataLen );
+	SetRawData( pData, nDataLen );
 }
 
 // バッファの内容を置き換える
 void CNativeA::SetNativeData( const CNativeA& cNative )
 {
-	CNative::SetRawData( cNative.GetRawPtr(), cNative.GetRawLength() );
+	SetRawData( cNative.GetRawPtr(), cNative.GetRawLength() );
 }
 
 // バッファの最後にデータを追加する
@@ -67,7 +72,7 @@ void CNativeA::AppendString( const char* pszData )
 //! バッファの最後にデータを追加する。nLengthは文字単位。
 void CNativeA::AppendString( const char* pszData, size_t nLength )
 {
-	CNative::AppendRawData( pszData, nLength );
+	AppendRawData( pszData, nLength );
 }
 
 //! バッファの最後にデータを追加する (フォーマット機能付き)
@@ -88,7 +93,7 @@ void CNativeA::AppendStringF(const char* pszData, ...)
 	}
 
 	// 追加
-	this->AppendString(buf, len);
+	AppendString( buf, len );
 }
 
 const CNativeA& CNativeA::operator = ( char cChar )
@@ -103,13 +108,13 @@ const CNativeA& CNativeA::operator = ( char cChar )
 //! バッファの最後にデータを追加する
 void CNativeA::AppendNativeData( const CNativeA& cNative )
 {
-	CNativeA::AppendRawData( cNative.GetRawPtr(), cNative.GetRawLength() );
+	AppendRawData( cNative.GetRawPtr(), cNative.GetRawLength() );
 }
 
 //! (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
 void CNativeA::AllocStringBuffer( size_t nDataLen )
 {
-	CNative::AllocBuffer( nDataLen );
+	AllocBuffer( nDataLen );
 }
 
 const CNativeA& CNativeA::operator += ( char ch )
@@ -125,13 +130,13 @@ const CNativeA& CNativeA::operator += ( char ch )
 
 int CNativeA::GetStringLength() const
 {
-	return CNative::GetRawLength() / sizeof(char);
+	return GetRawLength();
 }
 
 // 任意位置の文字取得。nIndexは文字単位。
 char CNativeA::operator[]( size_t nIndex ) const
 {
-	if( static_cast<int>(nIndex) < GetStringLength() ){
+	if( nIndex < static_cast<size_t>(GetStringLength()) ){
 		return GetStringPtr()[nIndex];
 	}else{
 		return 0;

--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -27,13 +27,11 @@
 #include "debug/Debug1.h"
 
 CNativeA::CNativeA( const char* szData, size_t cchData )
-	: CNative()
 {
 	SetString(szData, cchData);
 }
 
 CNativeA::CNativeA(const char* szData)
-	: CNative()
 {
 	SetString(szData);
 }
@@ -49,16 +47,15 @@ void CNativeA::SetString( const char* pszData )
 }
 
 // バッファの内容を置き換える。nLenは文字単位。
-void CNativeA::SetString( const char* pData, int nDataLen )
+void CNativeA::SetString( const char* pData, size_t nDataLen )
 {
-	int nDataLenBytes = nDataLen * sizeof(char);
-	CNative::SetRawData(pData, nDataLenBytes);
+	CNative::SetRawData( pData, nDataLen );
 }
 
 // バッファの内容を置き換える
-void CNativeA::SetNativeData( const CNativeA& pcNative )
+void CNativeA::SetNativeData( const CNativeA& cNative )
 {
-	CNative::SetRawData(pcNative);
+	CNative::SetRawData( cNative.GetRawPtr(), cNative.GetRawLength() );
 }
 
 // バッファの最後にデータを追加する
@@ -68,9 +65,9 @@ void CNativeA::AppendString( const char* pszData )
 }
 
 //! バッファの最後にデータを追加する。nLengthは文字単位。
-void CNativeA::AppendString( const char* pszData, int nLength )
+void CNativeA::AppendString( const char* pszData, size_t nLength )
 {
-	CNative::AppendRawData(pszData, nLength * sizeof(char));
+	CNative::AppendRawData( pszData, nLength );
 }
 
 //! バッファの最後にデータを追加する (フォーマット機能付き)
@@ -104,15 +101,15 @@ const CNativeA& CNativeA::operator = ( char cChar )
 }
 
 //! バッファの最後にデータを追加する
-void CNativeA::AppendNativeData( const CNativeA& pcNative )
+void CNativeA::AppendNativeData( const CNativeA& cNative )
 {
-	AppendString(pcNative.GetStringPtr(), pcNative.GetStringLength());
+	CNativeA::AppendRawData( cNative.GetRawPtr(), cNative.GetRawLength() );
 }
 
 //! (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
-void CNativeA::AllocStringBuffer( int nDataLen )
+void CNativeA::AllocStringBuffer( size_t nDataLen )
 {
-	CNative::AllocBuffer(nDataLen * sizeof(char));
+	CNative::AllocBuffer( nDataLen );
 }
 
 const CNativeA& CNativeA::operator += ( char ch )
@@ -132,9 +129,9 @@ int CNativeA::GetStringLength() const
 }
 
 // 任意位置の文字取得。nIndexは文字単位。
-char CNativeA::operator[](int nIndex) const
+char CNativeA::operator[]( size_t nIndex ) const
 {
-	if( nIndex < GetStringLength() ){
+	if( static_cast<int>(nIndex) < GetStringLength() ){
 		return GetStringPtr()[nIndex];
 	}else{
 		return 0;

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -32,24 +32,22 @@
 class CNativeA final : public CNative{
 public:
 	CNativeA() noexcept = default;
-	CNativeA( const CNativeA& rhs ) = default;
-	CNativeA( CNativeA&& other ) noexcept = default;
 	CNativeA( const char* szData, size_t cchData );
-	CNativeA( const char* szData);
+	CNativeA( const char* szData );
 
 	//ネイティブ設定
 	void SetString( const char* pszData );                  //!< バッファの内容を置き換える
-	void SetString( const char* pData, int nDataLen );      //!< バッファの内容を置き換える。nDataLenは文字単位。
-	void SetNativeData( const CNativeA& pcNative );         //!< バッファの内容を置き換える
+	void SetString( const char* pData, size_t nDataLen );      //!< バッファの内容を置き換える。nDataLenは文字単位。
+	void SetNativeData( const CNativeA& cNative );         //!< バッファの内容を置き換える
 	void AppendString( const char* pszData );               //!< バッファの最後にデータを追加する
-	void AppendString( const char* pszData, int nLength );  //!< バッファの最後にデータを追加する。nLengthは文字単位。
+	void AppendString( const char* pszData, size_t nLength );  //!< バッファの最後にデータを追加する。nLengthは文字単位。
 	void AppendStringF(const char* pszData, ...);           //!< バッファの最後にデータを追加する (フォーマット機能付き)
-	void AppendNativeData( const CNativeA& pcNative );      //!< バッファの最後にデータを追加する
-	void AllocStringBuffer( int nDataLen );            //!< (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
+	void AppendNativeData( const CNativeA& cNative );      //!< バッファの最後にデータを追加する
+	void AllocStringBuffer( size_t nDataLen );            //!< (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
 
 	//ネイティブ取得
 	int GetStringLength() const;
-	char operator[](int nIndex) const;                 //!< 任意位置の文字取得。nIndexは文字単位。
+	char operator[]( size_t nIndex ) const;                 //!< 任意位置の文字取得。nIndexは文字単位。
 	const char* GetStringPtr() const
 	{
 		return reinterpret_cast<const char*>(GetRawPtr());
@@ -60,9 +58,8 @@ public:
 	}
 
 	//演算子
-	CNativeA& operator = (const CNativeA& rhs)			{ CNative::operator=(rhs); return *this; }
-	CNativeA& operator = (CNativeA&& rhs) noexcept		{ CNative::operator=(std::move(rhs)); return *this; }
 	const CNativeA& operator=( char );
 	const CNativeA& operator+=( char );
 };
+
 #endif /* SAKURA_CNATIVEA_03C02187_A42C_4403_9D24_8B4CA20EEA81_H_ */

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -63,7 +63,7 @@ void CNativeW::SetString( const wchar_t* pszData )
 	if (pszData)
 		CNative::SetRawData(pszData,wcslen(pszData) * sizeof(wchar_t));
 	else
-		CMemory::Clear();
+		CMemory::Reset();
 }
 
 void CNativeW::SetStringHoldBuffer( const wchar_t* pData, int nDataLen )

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -31,18 +31,53 @@
 
 #include "CEol.h"
 
+/*!
+	コンストラクタ
+
+	C文字列の先頭アドレスと有効文字数を指定してCStringRefを構築する。
+ */
+CStringRef::CStringRef( const wchar_t* pData, size_t nDataLen ) noexcept
+	: m_pData(pData)
+	, m_nDataLen(static_cast<decltype(m_nDataLen)>(nDataLen))
+{
+}
+
+/*!
+	コンストラクタ
+
+	指定したCNativeWを参照するCStringRefを構築する。
+ */
+CStringRef::CStringRef( const CNativeW& cmem ) noexcept
+	: m_pData(cmem.GetStringPtr())
+	, m_nDataLen(cmem.GetStringLength())
+{
+}
+
+/*!
+	指定位置の文字を取得する
+
+	標準ライブラリの実装とは異なり、範囲外を指定すると0が返る。
+	サクラエディタの内部データは拡張UTF-16LEなので、
+	取得した値が「1文字」であるとは限らないことに注意。
+ */
+[[nodiscard]] wchar_t CStringRef::At( size_t nIndex ) const noexcept
+{
+	if( m_pData != nullptr && nIndex < m_nDataLen ){
+		return m_pData[nIndex];
+	}
+	return 0;
+}
+
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //               コンストラクタ・デストラクタ                  //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //! nDataLenは文字単位。
-CNativeW::CNativeW( const wchar_t* pData, int nDataLen )
-	: CNative()
+CNativeW::CNativeW( const wchar_t* pData, size_t nDataLen )
 {
-	SetString(pData, nDataLen);
+	SetString( pData, nDataLen );
 }
 
 CNativeW::CNativeW( const wchar_t* pData )
-	: CNative()
 {
 	SetString(pData);
 }
@@ -52,23 +87,25 @@ CNativeW::CNativeW( const wchar_t* pData )
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 // バッファの内容を置き換える
-void CNativeW::SetString( const wchar_t* pData, int nDataLen )
+void CNativeW::SetString( const wchar_t* pData, size_t nDataLen )
 {
-	CNative::SetRawData(pData,nDataLen * sizeof(wchar_t));
+	CMemory::SetRawData( pData,nDataLen * sizeof(wchar_t) );
 }
 
 // バッファの内容を置き換える
 void CNativeW::SetString( const wchar_t* pszData )
 {
-	if (pszData)
-		CNative::SetRawData(pszData,wcslen(pszData) * sizeof(wchar_t));
-	else
+	if( pszData != nullptr ){
+		std::wstring_view data(pszData);
+		SetString( data.data(), data.length() );
+	}else{
 		CMemory::Reset();
+	}
 }
 
-void CNativeW::SetStringHoldBuffer( const wchar_t* pData, int nDataLen )
+void CNativeW::SetStringHoldBuffer( const wchar_t* pData, size_t nDataLen )
 {
-	CNative::SetRawDataHoldBuffer(pData, nDataLen * sizeof(wchar_t));
+	CMemory::SetRawDataHoldBuffer( pData, nDataLen * sizeof(wchar_t) );
 }
 
 // バッファの内容を置き換える
@@ -78,45 +115,45 @@ void CNativeW::SetNativeData( const CNativeW& pcNative )
 }
 
 //! (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
-void CNativeW::AllocStringBuffer( int nDataLen )
+void CNativeW::AllocStringBuffer( size_t nDataLen )
 {
-	CNative::AllocBuffer(nDataLen * sizeof(wchar_t));
-}
-
-//! バッファの最後にデータを追加する
-void CNativeW::AppendString( const wchar_t* pszData )
-{
-	CNative::AppendRawData(pszData,wcslen(pszData) * sizeof(wchar_t));
+	CMemory::AllocBuffer( nDataLen * sizeof(wchar_t) );
 }
 
 //! バッファの最後にデータを追加する。nLengthは文字単位。
-void CNativeW::AppendString( const wchar_t* pszData, int nLength )
+void CNativeW::AppendString( const wchar_t* pszData, size_t nDataLen )
 {
-	CNative::AppendRawData(pszData, nLength * sizeof(wchar_t));
+	CMemory::AppendRawData( pszData, nDataLen * sizeof(wchar_t) );
+}
+
+//! バッファの最後にデータを追加する
+void CNativeW::AppendString( std::wstring_view data )
+{
+	AppendString( data.data(), data.length() );
 }
 
 /*!
  * バッファの最後にデータを追加する (フォーマット機能付き)
  *
- * @param pszFormat フォーマット書式文字列
+ * @param format フォーマット書式文字列
  * @param va_args C-style の可変長引数
- * @throws std::invalid_argument pszFormatがNULL
+ * @throws std::invalid_argument formatがNULL
  * @throws std::bad_alloc メモリ確保に失敗
  * @remark 不正なフォーマットを指定すると無効なパラメータ例外で即死します。
  */
-void CNativeW::AppendStringF( const wchar_t* pszFormat, ... )
+void CNativeW::AppendStringF( std::wstring_view format, ... )
 {
 	// _vscwprintf に NULL を渡してはならないので除外する
-	if( !pszFormat ){
+	if( format.empty() || format.data() == nullptr ){
 		throw std::invalid_argument( "pszFormat can't be nullptr" );
 	}
 
 	// 可変長引数のポインタを取得
 	va_list v;
-	va_start( v, pszFormat );
+	va_start( v, format );
 
 	// 整形によって追加される文字数をカウント
-	const int additional = ::_vscwprintf( pszFormat, v );
+	const int additional = ::_vscwprintf( format.data(), v );
 
 	// 現在の文字列長を取得
 	const auto currentLength = GetStringLength();
@@ -128,7 +165,7 @@ void CNativeW::AppendStringF( const wchar_t* pszFormat, ... )
 	int added = 0;
 	if( additional > 0 ){
 		// 追加処理の実体はCRTに委譲。この関数は無効な書式を与えると即死する。
-		added = ::_vsnwprintf_s( &GetStringPtr()[currentLength], additional + 1, _TRUNCATE, pszFormat, v );
+		added = ::_vsnwprintf_s( &GetStringPtr()[currentLength], static_cast<unsigned>(additional) + 1, _TRUNCATE, format.data(), v );
 	}
 
 	// 可変長引数のポインタを解放
@@ -178,9 +215,9 @@ CNativeW operator + (const wchar_t* lhs, const CNativeW& rhs) noexcept(false)
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 // GetAt()と同機能
-wchar_t CNativeW::operator[](int nIndex) const
+[[nodiscard]] wchar_t CNativeW::operator[]( size_t nIndex ) const
 {
-	if( nIndex < GetStringLength() ){
+	if( static_cast<int>(nIndex) < GetStringLength() ){
 		return GetStringPtr()[nIndex];
 	}else{
 		return 0;
@@ -234,7 +271,7 @@ int CNativeW::Compare(const wchar_t* rhs) const noexcept
 	const int rhsIsValid = rhs ? 1 : 0;
 	if (!rhsIsValid || !lhsIsValid) return lhsIsValid - rhsIsValid;
 	const wchar_t* lhs = GetStringPtr();
-	const int lhsLength = GetStringLength();
+	const size_t lhsLength = GetStringLength();
 	// NUL終端考慮のために終端を拡張し、比較自体はCRTに丸投げする
 	return wcsncmp(lhs, rhs, lhsLength + 1);
 }
@@ -313,28 +350,21 @@ bool operator != (const wchar_t* lhs, const CNativeW& rhs) noexcept
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 //! 文字列置換
-void CNativeW::Replace( const wchar_t* pszFrom, const wchar_t* pszTo )
-{
-	int			nFromLen = wcslen( pszFrom );
-	int			nToLen = wcslen( pszTo );
-	Replace( pszFrom, nFromLen, pszTo, nToLen );
-}
-
-void CNativeW::Replace( const wchar_t* pszFrom, int nFromLen, const wchar_t* pszTo, int nToLen )
+void CNativeW::Replace( std::wstring_view strFrom, std::wstring_view strTo )
 {
 	CNativeW	cmemWork;
-	int			nBgnOld = 0;
-	int			nBgn = 0;
-	while( nBgn <= GetStringLength() - nFromLen ){
-		if( 0 == wmemcmp( &GetStringPtr()[nBgn], pszFrom, nFromLen ) ){
-			if( nBgnOld == 0 && nFromLen <= nToLen ){
+	size_t		nBgnOld = 0;
+	size_t		nBgn = 0;
+	while( nBgn <= GetStringLength() - strFrom.length() ){
+		if( 0 == wmemcmp( &GetStringPtr()[nBgn], strFrom.data(), strFrom.length() ) ){
+			if( nBgnOld == 0 && strFrom.length() <= strTo.length() ){
 				cmemWork.AllocStringBuffer( GetStringLength() );
 			}
 			if( 0  < nBgn - nBgnOld ){
 				cmemWork.AppendString( &GetStringPtr()[nBgnOld], nBgn - nBgnOld );
 			}
-			cmemWork.AppendString( pszTo, nToLen );
-			nBgn = nBgn + nFromLen;
+			cmemWork.AppendString( strTo.data(), strTo.length() );
+			nBgn = nBgn + strFrom.length();
 			nBgnOld = nBgn;
 		}else{
 			nBgn++;
@@ -346,10 +376,15 @@ void CNativeW::Replace( const wchar_t* pszFrom, int nFromLen, const wchar_t* psz
 		}
 		SetNativeData( cmemWork );
 	}else{
-		if( this->GetStringPtr() == NULL ){
-			this->SetString(L"");
+		if( GetStringPtr() == nullptr ){
+			SetString(L"");
 		}
 	}
+}
+
+void CNativeW::Replace( const wchar_t* pszFrom, size_t nFromLen, const wchar_t* pszTo, size_t nToLen )
+{
+	Replace( std::wstring_view( pszFrom, nFromLen ), std::wstring_view( pszTo, nToLen ) );
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -352,15 +352,12 @@ bool operator != (const wchar_t* lhs, const CNativeW& rhs) noexcept
 //! 文字列置換
 void CNativeW::Replace( std::wstring_view strFrom, std::wstring_view strTo )
 {
-	CNativeW	cmemWork;
-	size_t		nBgnOld = 0;
+	CNativeW	cmemWork(L"");
 	size_t		nBgn = 0;
-	while( nBgn <= GetStringLength() - strFrom.length() ){
+	size_t		nBgnOld = 0;
+	while( CLogicInt(nBgn + strFrom.length()) <= GetStringLength() ){
 		if( 0 == wmemcmp( &GetStringPtr()[nBgn], strFrom.data(), strFrom.length() ) ){
-			if( nBgnOld == 0 && strFrom.length() <= strTo.length() ){
-				cmemWork.AllocStringBuffer( GetStringLength() );
-			}
-			if( 0  < nBgn - nBgnOld ){
+			if( nBgnOld  < nBgn ){
 				cmemWork.AppendString( &GetStringPtr()[nBgnOld], nBgn - nBgnOld );
 			}
 			cmemWork.AppendString( strTo.data(), strTo.length() );
@@ -370,16 +367,10 @@ void CNativeW::Replace( std::wstring_view strFrom, std::wstring_view strTo )
 			nBgn++;
 		}
 	}
-	if( nBgnOld != 0 ){
-		if( 0  < GetStringLength() - nBgnOld ){
-			cmemWork.AppendString( &GetStringPtr()[nBgnOld], GetStringLength() - nBgnOld );
-		}
-		SetNativeData( cmemWork );
-	}else{
-		if( GetStringPtr() == nullptr ){
-			SetString(L"");
-		}
+	if( CLogicInt(nBgnOld) < GetStringLength() ){
+		cmemWork.AppendString( &GetStringPtr()[nBgnOld], GetStringLength() - nBgnOld );
 	}
+	SetRawDataHoldBuffer( cmemWork );
 }
 
 void CNativeW::Replace( const wchar_t* pszFrom, size_t nFromLen, const wchar_t* pszTo, size_t nToLen )

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -124,7 +124,9 @@ public:
 		}
 	}
 	//! メモリバッファを入れ替える
-	using CMemory::swap;
+	void swap( CNativeW& left ){
+		CMemory::swap( left );
+	}
 	//! メモリ再確保を行わずに格納できる最大文字数を求める
 	[[nodiscard]] int capacity() const noexcept override {
 		return CMemory::capacity() / sizeof(wchar_t);

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -123,10 +123,10 @@ public:
 			_SetStringLength(n);
 		}
 	}
-	void swap( CNativeW& left ){
-		CMemory::swap( left );
-	}
-	[[nodiscard]] int capacity() const noexcept {
+	//! メモリバッファを入れ替える
+	using CMemory::swap;
+	//! メモリ再確保を行わずに格納できる最大文字数を求める
+	[[nodiscard]] int capacity() const noexcept override {
 		return CMemory::capacity() / sizeof(wchar_t);
 	}
 

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -32,35 +32,26 @@
 #include "charset/charcode.h"
 #include "debug/Debug2.h" //assert
 
-//! 文字列への参照を取得するインターフェース
-class IStringRef{
-public:
-	virtual const wchar_t*	GetPtr()	const = 0;
-	virtual int				GetLength()	const = 0;
-};
+class CNativeW;
 
 //! 文字列への参照を保持するクラス
-class CStringRef final : public IStringRef{
+class CStringRef final{
 public:
-	CStringRef() : m_pData(NULL), m_nDataLen(0) { }
-	CStringRef(const wchar_t* pData, int nDataLen) : m_pData(pData), m_nDataLen(nDataLen) { }
-	const wchar_t*	GetPtr()		const override{ return m_pData;    }
-	int				GetLength()		const override{ return m_nDataLen; }
+	CStringRef() noexcept = default;
+	CStringRef( const wchar_t* pData, size_t nDataLen ) noexcept;
+	CStringRef( const CNativeW& cmem ) noexcept;
 
-	//########補助
-	bool			IsValid()		const{ return m_pData!=NULL; }
-	wchar_t			At(int nIndex)	const
-	{
-		assert(nIndex>=0 && nIndex<m_nDataLen);
-		return m_pData[nIndex];
-	}
+	[[nodiscard]] const wchar_t* GetPtr() const noexcept { return m_pData; }
+	[[nodiscard]] int GetLength() const noexcept { return static_cast<int>(m_nDataLen); }
+	[[nodiscard]] bool IsValid() const noexcept { return m_pData != nullptr; }
+	[[nodiscard]] wchar_t At( size_t nIndex ) const noexcept;
+
 private:
-	const wchar_t*	m_pData;
-	int				m_nDataLen;
+	const wchar_t*	m_pData = nullptr;
+	unsigned		m_nDataLen = 0;
 };
 
 // グローバル演算子の前方宣言
-class CNativeW;
 bool operator == (const CNativeW& lhs, const wchar_t* rhs) noexcept;
 bool operator != (const CNativeW& lhs, const wchar_t* rhs) noexcept;
 bool operator == (const wchar_t* lhs, const CNativeW& rhs) noexcept;
@@ -75,32 +66,28 @@ class CNativeW final : public CNative{
 public:
 	//コンストラクタ・デストラクタ
 	CNativeW() noexcept = default;
-	CNativeW( const CNativeW& rhs ) = default;
-	CNativeW( CNativeW&& other ) noexcept = default;
-	CNativeW( const wchar_t* pData, int nDataLen ); //!< nDataLenは文字単位。
-	CNativeW( const wchar_t* pData);
+	CNativeW( const wchar_t* pData, size_t nDataLen ); //!< nDataLenは文字単位。
+	CNativeW( const wchar_t* pData );
 
 	/*! メモリ確保済みかどうか */
-	bool IsValid() const noexcept { return GetStringPtr() != nullptr; }
+	[[nodiscard]] bool IsValid() const noexcept { return GetStringPtr() != nullptr; }
 
 	//管理
-	void AllocStringBuffer( int nDataLen );                    //!< (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
+	void AllocStringBuffer( size_t nDataLen );                    //!< (重要：nDataLenは文字単位) バッファサイズの調整。必要に応じて拡大する。
 
 	//WCHAR
-	void SetString( const wchar_t* pData, int nDataLen );      //!< バッファの内容を置き換える。nDataLenは文字単位。
-	void SetString( const wchar_t* pszData );                  //!< バッファの内容を置き換える。NULL 指定時はメモリ解放を行い、文字列長はゼロになる
-	void SetStringHoldBuffer( const wchar_t* pData, int nDataLen );
-	void AppendString( const wchar_t* pszData );               //!< バッファの最後にデータを追加する
-	void AppendString( const wchar_t* pszData, int nLength );  //!< バッファの最後にデータを追加する。nLengthは文字単位。成功すればtrue。メモリ確保に失敗したらfalseを返す。
-	void AppendStringF(const wchar_t* pszData, ...);           //!< バッファの最後にデータを追加する (フォーマット機能付き)
+	void SetString( const wchar_t* pData, size_t nDataLen );			//!< バッファの内容を置き換える。nDataLenは文字単位。
+	void SetString( const wchar_t* pszData );							//!< バッファの内容を置き換える。
+	void SetStringHoldBuffer( const wchar_t* pData, size_t nDataLen );
+	void AppendString( const wchar_t* pszData, size_t nDataLen );		//!< バッファの最後にデータを追加する。nLengthは文字単位。成功すればtrue。メモリ確保に失敗したらfalseを返す。
+	void AppendString( std::wstring_view data );						//!< バッファの最後にデータを追加する
+	void AppendStringF( std::wstring_view format, ... );				//!< バッファの最後にデータを追加する (フォーマット機能付き)
 
 	//CNativeW
 	void SetNativeData( const CNativeW& pcNative );            //!< バッファの内容を置き換える
 	void AppendNativeData( const CNativeW& );                  //!< バッファの最後にデータを追加する
 
 	//演算子
-	CNativeW& operator = (const CNativeW& rhs)			{ CNative::operator=(rhs); return *this; }
-	CNativeW& operator = (CNativeW&& rhs) noexcept		{ CNative::operator=(std::move(rhs)); return *this; }
 	CNativeW  operator + (const CNativeW& rhs) const	{ return (CNativeW(*this) += rhs); }
 	CNativeW& operator += (const CNativeW& rhs)			{ AppendNativeData(rhs); return *this; }
 	CNativeW& operator += (wchar_t ch)					{ return (*this += CNativeW(&ch, 1)); }
@@ -108,7 +95,7 @@ public:
 	bool operator != (const CNativeW& rhs) const noexcept { return !(*this == rhs); }
 
 	//ネイティブ取得インターフェース
-	wchar_t operator[](int nIndex) const;                    //!< 任意位置の文字取得。nIndexは文字単位。
+	[[nodiscard]] wchar_t operator[]( size_t nIndex ) const;                    //!< 任意位置の文字取得。nIndexは文字単位。
 	CLogicInt GetStringLength() const                        //!< 文字列長を返す。文字単位。
 	{
 		return CLogicInt(CNative::GetRawLength() / sizeof(wchar_t));
@@ -123,9 +110,9 @@ public:
 	}
 
 	//特殊
-	void _SetStringLength(int nLength)
+	void _SetStringLength( size_t nLength )
 	{
-		CNative::_SetRawLength(nLength*sizeof(wchar_t));
+		CNative::_SetRawLength( nLength * sizeof(wchar_t) );
 	}
 	//末尾を1文字削る
 	void Chop()
@@ -159,8 +146,8 @@ public:
 	//                           変換                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	void Replace( const wchar_t* pszFrom, const wchar_t* pszTo );   //!< 文字列置換
-	void Replace( const wchar_t* pszFrom, int nFromLen, const wchar_t* pszTo, int nToLen );   //!< 文字列置換
+	void Replace( std::wstring_view strFrom, std::wstring_view strTo );   //!< 文字列置換
+	void Replace( const wchar_t* pszFrom, size_t nFromLen, const wchar_t* pszTo, size_t nToLen );   //!< 文字列置換
 
 public:
 	// -- -- staticインターフェース -- -- //
@@ -186,4 +173,5 @@ public:
 
 // 派生クラスでメンバー追加禁止
 static_assert(sizeof(CNativeW) == sizeof(CNative), "size check");
+
 #endif /* SAKURA_CNATIVEW_3B48F63E_5B62_4FAB_9718_0D80114E20C1_H_ */

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -84,8 +84,8 @@ public:
 	void AppendStringF( std::wstring_view format, ... );				//!< バッファの最後にデータを追加する (フォーマット機能付き)
 
 	//CNativeW
-	void SetNativeData( const CNativeW& pcNative );            //!< バッファの内容を置き換える
-	void AppendNativeData( const CNativeW& );                  //!< バッファの最後にデータを追加する
+	void SetNativeData( const CNativeW& cNative );						//!< バッファの内容を置き換える
+	void AppendNativeData( const CNativeW& cNative );					//!< バッファの最後にデータを追加する
 
 	//演算子
 	CNativeW  operator + (const CNativeW& rhs) const	{ return (CNativeW(*this) += rhs); }
@@ -112,7 +112,7 @@ public:
 	//特殊
 	void _SetStringLength( size_t nLength )
 	{
-		CNative::_SetRawLength( nLength * sizeof(wchar_t) );
+		_SetRawLength( nLength * sizeof(wchar_t) );
 	}
 	//末尾を1文字削る
 	void Chop()
@@ -124,10 +124,10 @@ public:
 		}
 	}
 	void swap( CNativeW& left ){
-		CNative::swap(left);
+		CMemory::swap( left );
 	}
-	int capacity() const noexcept {
-		return CNative::capacity() / sizeof(wchar_t);
+	[[nodiscard]] int capacity() const noexcept {
+		return CMemory::capacity() / sizeof(wchar_t);
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -128,7 +128,7 @@ public:
 		CMemory::swap( left );
 	}
 	//! メモリ再確保を行わずに格納できる最大文字数を求める
-	[[nodiscard]] int capacity() const noexcept override {
+	[[nodiscard]] int capacity() const noexcept {
 		return CMemory::capacity() / sizeof(wchar_t);
 	}
 

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -39,7 +39,7 @@ class CStringRef final{
 public:
 	CStringRef() noexcept = default;
 	CStringRef( const wchar_t* pData, size_t nDataLen ) noexcept;
-	CStringRef( const CNativeW& cmem ) noexcept;
+	explicit CStringRef( const CNativeW& cmem ) noexcept;
 
 	[[nodiscard]] const wchar_t* GetPtr() const noexcept { return m_pData; }
 	[[nodiscard]] int GetLength() const noexcept { return static_cast<int>(m_nDataLen); }

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -1547,7 +1547,7 @@ void CDlgFuncList::SetTreeFile()
 		const WCHAR* pszFrom = szPath;
 		if( m_fileTreeSetting.m_szLoadProjectIni[0] != L'\0'){
 			CNativeW strTemp(pszFrom);
-			strTemp.Replace(L"<iniroot>", IniDirPath);
+			strTemp.Replace(L"<iniroot>", IniDirPath.c_str());
 			if( _countof(szPath2) <= strTemp.GetStringLength() ){
 				wcscpy_s(szPath2, _countof(szPath), L"<Error:Long Path>");
 			}else{

--- a/tests/unittests/test-ccodebase.cpp
+++ b/tests/unittests/test-ccodebase.cpp
@@ -34,36 +34,36 @@ TEST(CCodeBase, MIMEHeaderDecode)
 	// Base64 JIS
 	std::string source1("From: =?iso-2022-jp?B?GyRCJTUlLyVpGyhC?=");
 	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source1.c_str(), source1.length(), &m, CODE_JIS));
-	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), "From: $B%5%/%i(B");
+	EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), "From: $B%5%/%i(B");
 
 	// Base64 UTF-8
 	std::string source2("From: =?utf-8?B?44K144Kv44Op?=");
 	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source2.c_str(), source2.length(), &m, CODE_UTF8));
-	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), "From: \xe3\x82\xb5\xe3\x82\xaf\xe3\x83\xa9");
+	EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), "From: \xe3\x82\xb5\xe3\x82\xaf\xe3\x83\xa9");
 
 	// QP UTF-8
 	std::string source3("From: =?utf-8?Q?=E3=82=B5=E3=82=AF=E3=83=A9!?=");
 	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source3.c_str(), source3.length(), &m, CODE_UTF8));
-	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), "From: \xe3\x82\xb5\xe3\x82\xaf\xe3\x83\xa9!");
+	EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), "From: \xe3\x82\xb5\xe3\x82\xaf\xe3\x83\xa9!");
 
 	// 引数の文字コードとヘッダー内の文字コードが異なる場合は変換しない
 	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source1.c_str(), source1.length(), &m, CODE_UTF8));
-	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), source1.c_str());
+	EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), source1.c_str());
 
 	// 対応していない文字コードなら変換しない
 	std::string source4("From: =?utf-7?B?+MLUwrzDp-");
 	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source4.c_str(), source4.length(), &m, CODE_UTF7));
-	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), source4.c_str());
+	EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), source4.c_str());
 
 	// 謎の符号化方式が指定されていたら何もしない
 	std::string source5("From: =?iso-2022-jp?X?GyRCJTUlLyVpGyhC?=");
 	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source5.c_str(), source5.length(), &m, CODE_JIS));
-	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), source5.c_str());
+	EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), source5.c_str());
 
 	// 末尾の ?= がなければ変換しない
 	std::string source6("From: =?iso-2022-jp?B?GyRCJTUlLyVpGyhC");
 	EXPECT_TRUE(CCodeBase::MIMEHeaderDecode(source6.c_str(), source6.length(), &m, CODE_JIS));
-	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), source6.c_str());
+	EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), source6.c_str());
 }
 
 /*!

--- a/tests/unittests/test-cdecode.cpp
+++ b/tests/unittests/test-cdecode.cpp
@@ -50,13 +50,13 @@ TEST(CDecode, Base64)
 	for (const auto& testCase : testCases) {
 		s.SetString(testCase.input);
 		EXPECT_TRUE(CDecode_Base64Decode().DoDecode(s, &m));
-		EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), testCase.output);
+		EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), testCase.output);
 	}
 
 	// 空白は無視する
 	s.SetString(L"c2Fr \t dQ==");
 	EXPECT_TRUE(CDecode_Base64Decode().DoDecode(s, &m));
-	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), "saku");
+	EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), "saku");
 
 	// 異常な文字があったら変換を中止する
 	s.SetString(L"c2Fr?dQ==");
@@ -81,7 +81,7 @@ TEST(CDecode, uuencode)
 
 		CDecode_UuDecode decoder;
 		EXPECT_TRUE(decoder.DoDecode(s, &m));
-		EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), testCase.output);
+		EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), testCase.output);
 
 		wchar_t fileName[_MAX_PATH];
 		decoder.CopyFilename(fileName);
@@ -91,7 +91,7 @@ TEST(CDecode, uuencode)
 	// ヘッダーおよびフッターの先頭と末尾の空白は無視する
 	s.SetString(L"\tbegin 666 test \r\n!<P  \r\n \r\n\tend \r\n");
 	EXPECT_TRUE(CDecode_UuDecode().DoDecode(s, &m));
-	EXPECT_STREQ(static_cast<char*>(m.GetRawPtr()), "s");
+	EXPECT_STREQ(reinterpret_cast<char*>(m.GetRawPtr()), "s");
 
 	// 入力文字列が空の場合
 	s.SetString(L"");

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -29,6 +29,42 @@
 #include "mem/CNativeA.h"
 
 /*!
+	CStringRefのテスト
+ */
+TEST(CStringRef, CStringRef)
+{
+	constexpr const wchar_t sz[] = L"test";
+	constexpr const size_t cch = _countof(sz) - 1;
+
+	CStringRef v1;
+	EXPECT_EQ(nullptr, v1.GetPtr());
+	EXPECT_EQ(0, v1.GetLength());
+	EXPECT_FALSE(v1.IsValid());
+	EXPECT_EQ(L'\0', v1.At(0));
+
+	CStringRef v2(sz, cch);
+	EXPECT_STREQ(sz, v2.GetPtr());
+	EXPECT_EQ(cch, v2.GetLength());
+	EXPECT_TRUE(v2.IsValid());
+	EXPECT_EQ(L't', v2.At(0));
+	EXPECT_EQ(L'e', v2.At(1));
+	EXPECT_EQ(L's', v2.At(2));
+	EXPECT_EQ(L't', v2.At(3));
+	EXPECT_EQ(L'\0', v2.At(4));
+
+	CNativeW cmem(sz, cch);
+	CStringRef v3(cmem);
+	EXPECT_STREQ(sz, v3.GetPtr());
+	EXPECT_EQ(cch, v3.GetLength());
+	EXPECT_TRUE(v3.IsValid());
+	EXPECT_EQ(L't', v3.At(0));
+	EXPECT_EQ(L'e', v3.At(1));
+	EXPECT_EQ(L's', v3.At(2));
+	EXPECT_EQ(L't', v3.At(3));
+	EXPECT_EQ(L'\0', v3.At(4));
+}
+
+/*!
  * @brief コンストラクタ(パラメータなし)の仕様
  * @remark バッファは確保されない
  * @remark 文字列長はゼロになる
@@ -328,7 +364,8 @@ TEST(CNativeW, AppendStringWithFormatting)
 	ASSERT_STREQ(L"いちご100%", value.GetStringPtr());
 
 	// フォーマットに NULL を渡したケースをテストする
-	ASSERT_THROW(value.AppendStringF(NULL), std::invalid_argument);
+	ASSERT_THROW(value.AppendStringF(std::wstring_view(nullptr, 0)), std::invalid_argument);
+	ASSERT_THROW(value.AppendStringF(std::wstring_view(L"ダミー", 0)), std::invalid_argument);
 
 	// 文字列長を0にして、追加確保が行われないケースをテストする
 	value = L"いちご100%"; //テスト前の初期値(念のため再代入しておく


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
CMemoryをリファクタリングして、x64対応作業を始められるようにすることが目的です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->
- その他


## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
CMemoryやCNativeWはサクラエディタの中核に位置するクラスです。

SonarCloudによる静的解析で、以下のBugsレベル警告が検出されています。

- Bugs(Blocker)レベル
  - sakura_core/mem/CMemory.cpp
    > Out of bound memory access (accessed memory precedes memory block)
    > https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AXiZfAqkWWGx2hJc4xkw&open=AXiZfAqkWWGx2hJc4xkw
- Bugs(Critical)レベル
  - sakura_core/mem/CNativeA.h
    > Explicitly define or delete the missing destructor so that it will not be implicitly provided.
    > https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AWnxcx-MO9B58BDk-CXO&open=AWnxcx-MO9B58BDk-CXO
  - sakura_core/mem/CNativeW.h
    > Explicitly define or delete the missing destructor so that it will not be implicitly provided.
    > https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AWnxcx-EO9B58BDk-CXM&open=AWnxcx-EO9B58BDk-CXM

これらのクラスは、依存関係のルート付近にあるヘッダーで定義されているため、修正がしづらいです。
最近マージされた #1615 により、修正のやりづらさはさらに増したと思います。

ただ、ここを修正しないと x64対応 は不可能なので、どこかでなんとかしたいと考えていました。

今回は、思い切ってCMemory/CNativeWの大幅改修をして、x64対応の作業ができる状態を作り出したいと思います。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
- 上記3件のBugsレベル警告を解消できます。
- 現在発生している2万件のCodeSmellsのうち21件を解消できます。
- CMemoryの単体テスト網羅率が100%になります。
-  INT_MAX(＝約2GB) を超えるメモリの確保を試みた場合に確実に「失敗」するようになります。
  ※従来は異常を検出できず、処理が続行されていました。
- `x64 - Debug`ビルドの警告が 576件 から 497件 に減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- CMemoryのpublicメソッドをいくつかリネームしているため、修正量が多くなっています。
- CodeSmellsが新たに18件増えます。
  - うち2件は原因が別クラスの定義にあるので対応不要です。
  - うち7件はCMemoryクラスの仕様的に対応不可です。
  - 残り9件は対応が必要と考えますが、今回は対応しません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
サクラエディタの仕様・機能に変更はありません。

CMemoryで定義されているメソッドの改廃を行っています。
|クラス名|メソッド名|対応|代替|説明|対応理由|
|--|--|--|--|--|--|
|CMemory|Clean|削除|Reset|バッファをリセット(解放)する|同機能の別名メソッドがあり、存在自体が冗長であるため。|
|CMemory|Clear|削除|Reset|バッファをリセット(解放)する|CNativeの同名メソッドと混同する危険があるため。|
|CMemory|_Empty|削除|Reset|バッファをリセット(解放)する|メモリバッファのリセット(解放)はクラス外部から普通に利用する機能であり、非公開にしておく意味がないため。|
|CMemory|Reset|新規| - |バッファをリセット(解放)する|リセット(解放)を意味するメソッド名が存在していなかったため。|
|CMemory|_AddData|削除|AppendRawData|データを追加する|メモリ確保とコピーを統合することにより、メモリ確保失敗時にコピーが強行される事態を防ぐ必要があった。|
|CMemory|SwabHLByte|削除|SwapHLByte|Byteを交換する|`Windows SDK`の[_swab](https://docs.microsoft.com/ja-jp/previous-versions/visualstudio/visual-studio-2013/e8cxb8tk(v=vs.120))を利用するためには、好ましくないキャストをする必要がある。加えて、_swabを利用するメリットはとくにないため。|

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
- CMemoryを利用する機能（エディタ機能全般）に影響する修正です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
影響範囲が広すぎるので、単純な起動確認をしたほうが良さそうです。

1. サクラエディタを起動する。
2. 任意のテキストファイルを開く。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1504
#1541
#1575 
#1605

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
