### PR TITLE
タイプ別設定の「カーソル位置縦線」を有効時に、カーソルが先頭行にある状態で PageUp キーを押した後にカーソル左右移動するとカーソル位置縦線が残る問題を修正

### DIFF
--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -745,13 +745,15 @@ void CViewCommander::Command_1PageUp( bool bSelect, CLayoutYInt nScrollNum )
 		}
 		auto& caret = GetCaret();
 		auto prevCaretPos = caret.GetCaretLayoutPos();
+		bool bCursorVLine = m_pCommanderView->m_pTypeData->m_ColorInfoArr[COLORIDX_CURSORVLINE].m_bDisp;
 		caret.Cursor_UPDOWN( -nScrollNum, bSelect );
 		auto currCaretPos = caret.GetCaretLayoutPos();
 		CLayoutInt nScrolled = m_pCommanderView->ScrollAtV( nViewTopLine - nScrollNum );
 		m_pCommanderView->SyncScrollV(nScrolled);
 		m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
 		// カーソル位置が変化しなかった、かつ、スクロール行数が0だった場合、描画を省く
-		if (prevCaretPos == currCaretPos && nScrolled == 0) {
+		// タイプ別設定の「カーソル位置縦線」有効時には省かない
+		if (!bCursorVLine && prevCaretPos == currCaretPos && nScrolled == 0) {
 			return;
 		}
 		m_pCommanderView->RedrawAll();
@@ -780,13 +782,15 @@ void CViewCommander::Command_1PageDown( bool bSelect, CLayoutYInt nScrollNum )
 		}
 		auto& caret = GetCaret();
 		auto prevCaretPos = caret.GetCaretLayoutPos();
+		bool bCursorVLine = m_pCommanderView->m_pTypeData->m_ColorInfoArr[COLORIDX_CURSORVLINE].m_bDisp;
 		caret.Cursor_UPDOWN( nScrollNum, bSelect );
 		auto currCaretPos = caret.GetCaretLayoutPos();
 		CLayoutInt nScrolled = m_pCommanderView->ScrollAtV( nViewTopLine + nScrollNum );
 		m_pCommanderView->SyncScrollV(nScrolled);
 		m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
 		// カーソル位置が変化しなかった、かつ、スクロール行数が0だった場合、描画を省く
-		if (prevCaretPos == currCaretPos && nScrolled == 0) {
+		// タイプ別設定の「カーソル位置縦線」有効時には省かない
+		if (!bCursorVLine && prevCaretPos == currCaretPos && nScrolled == 0) {
 			return;
 		}
 		m_pCommanderView->RedrawAll();

--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -745,7 +745,7 @@ void CViewCommander::Command_1PageUp( bool bSelect, CLayoutYInt nScrollNum )
 		}
 		auto& caret = GetCaret();
 		auto prevCaretPos = caret.GetCaretLayoutPos();
-		bool bCursorVLine = m_pCommanderView->m_pTypeData->m_ColorInfoArr[COLORIDX_CURSORVLINE].m_bDisp;
+		bool bNoDispCursorVLine = m_pCommanderView->m_pTypeData->m_ColorInfoArr[COLORIDX_CURSORVLINE].m_bDisp == false;
 		caret.Cursor_UPDOWN( -nScrollNum, bSelect );
 		auto currCaretPos = caret.GetCaretLayoutPos();
 		CLayoutInt nScrolled = m_pCommanderView->ScrollAtV( nViewTopLine - nScrollNum );
@@ -753,7 +753,7 @@ void CViewCommander::Command_1PageUp( bool bSelect, CLayoutYInt nScrollNum )
 		m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
 		// カーソル位置が変化しなかった、かつ、スクロール行数が0だった場合、描画を省く
 		// タイプ別設定の「カーソル位置縦線」有効時には省かない
-		if (!bCursorVLine && prevCaretPos == currCaretPos && nScrolled == 0) {
+		if (bNoDispCursorVLine && prevCaretPos == currCaretPos && nScrolled == 0) {
 			return;
 		}
 		m_pCommanderView->RedrawAll();
@@ -782,7 +782,7 @@ void CViewCommander::Command_1PageDown( bool bSelect, CLayoutYInt nScrollNum )
 		}
 		auto& caret = GetCaret();
 		auto prevCaretPos = caret.GetCaretLayoutPos();
-		bool bCursorVLine = m_pCommanderView->m_pTypeData->m_ColorInfoArr[COLORIDX_CURSORVLINE].m_bDisp;
+		bool bNoDispCursorVLine = m_pCommanderView->m_pTypeData->m_ColorInfoArr[COLORIDX_CURSORVLINE].m_bDisp == false;
 		caret.Cursor_UPDOWN( nScrollNum, bSelect );
 		auto currCaretPos = caret.GetCaretLayoutPos();
 		CLayoutInt nScrolled = m_pCommanderView->ScrollAtV( nViewTopLine + nScrollNum );
@@ -790,7 +790,7 @@ void CViewCommander::Command_1PageDown( bool bSelect, CLayoutYInt nScrollNum )
 		m_pCommanderView->SetDrawSwitch(bDrawSwitchOld);
 		// カーソル位置が変化しなかった、かつ、スクロール行数が0だった場合、描画を省く
 		// タイプ別設定の「カーソル位置縦線」有効時には省かない
-		if (!bCursorVLine && prevCaretPos == currCaretPos && nScrolled == 0) {
+		if (bNoDispCursorVLine && prevCaretPos == currCaretPos && nScrolled == 0) {
 			return;
 		}
 		m_pCommanderView->RedrawAll();


### PR DESCRIPTION
カーソルが最終行時の PageDown キー後のカーソル左右移動についても同様です。

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

件名の通りです。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

#1617 で不具合報告のIssueが作成されました。
どの時点で不具合が入ったのかを調べたところ #1320 の変更が原因という事が判明しました。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

件名に記載した不具合が修正されます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

判定条件が追加されてコードが読み取りづらくなります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

前のカーソル位置縦線の消去が行われない問題が起きるメカニズムを調べました。

先頭行でPageUpキーを押した際に下記のコールスタックで呼び出しが行われます。

```
>	sakura.exe!CEditView::CaretUnderLineOFF(bool bDraw, bool bDrawPaint, bool bResetFlag, bool DisalbeUnderLine) Line 2534	C++
 	sakura.exe!CCaretUnderLine::CaretUnderLineOFF(bool bDraw, bool bDrawPaint, bool bResetFlag) Line 97	C++
 	sakura.exe!CCaret::MoveCursor(CStrictPoint<SLayoutPoint,CStrictInteger<1,1,1,0,1>,CStrictInteger<1,1,1,0,1>> ptWk_CaretPos, bool bScroll, int nCaretMarginRate, bool bUnderLineDoNotOFF, bool bVertLineDoNotOFF) Line 200	C++
 	sakura.exe!CCaret::Cursor_UPDOWN(CStrictInteger<1,1,1,0,1> nMoveLines, bool bSelect) Line 975	C++
 	sakura.exe!CViewCommander::Command_1PageUp(bool bSelect, CStrictInteger<1,1,1,0,1> nScrollNum) Line 750	C++
```

`CEditView::CaretUnderLineOFF` メソッドで引数の `bDraw` の値が false な為、カーソル位置縦線の消去は行われず `CEditView::m_nOldCursorLineX` の値が -1 に設定されます。

その後のカーソル左右移動時の `CEditView::CaretUnderLineOFF` メソッドでは、 `CEditView::m_nOldCursorLineX` の値が -1 に設定されている為、前のカーソル位置縦線の消去が行われません。

#1320 の変更前は `CViewCommander::Command_1PageUp` から呼び出される `CEditView::RedrawAll` の呼び出し以降の処理で画面全体の再描画を行う際に `CEditView::CaretUnderLineON` が呼び出されてそこで `CEditView::m_nOldCursorLineX` の値が -1 ではない値に設定される為、その後のカーソル左右移動時に問題が発生しませんでした。

このPRでは、カーソル位置縦線を描画する設定の場合には、PageUp, PageDown 時の `CEditView::RedrawAll` 呼び出しを省かないように判定を追加する事で問題を回避しました。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

PageUp, PageDown キー押し時の描画内容

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順
タイプ別設定の「カーソル位置縦線」有効時に、カーソルが先頭行にある状態でPageUpキー、もしくは最終行にいる状態でPageDownキーを押した後にカーソル左右移動をしても前の「カーソル位置縦線」の表示が残らない事を確認

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1320, #1617

