### PR TITLE
機能種別によるバッファ変換に単体テストを導入する

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -317,6 +317,7 @@
     <ClInclude Include="..\sakura_core\config\maxdata.h" />
     <ClInclude Include="..\sakura_core\config\system_constants.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert.h" />
+    <ClInclude Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_HaneisuToZeneisu.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_HankataToZenhira.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_HankataToZenkata.h" />
@@ -678,6 +679,7 @@
     <ClCompile Include="..\sakura_core\cmd\CViewCommander_Window.cpp" />
     <ClCompile Include="..\sakura_core\config\build_config.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert.cpp" />
+    <ClCompile Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HaneisuToZeneisu.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HankataToZenhira.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HankataToZenkata.cpp" />

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -319,6 +319,7 @@
     <ClInclude Include="..\sakura_core\convert\CConvert.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_CodeFromSjis.h" />
+    <ClInclude Include="..\sakura_core\convert\CConvert_CodeToSjis.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_HaneisuToZeneisu.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_HankataToZenhira.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_HankataToZenkata.h" />
@@ -682,6 +683,7 @@
     <ClCompile Include="..\sakura_core\convert\CConvert.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_CodeFromSjis.cpp" />
+    <ClCompile Include="..\sakura_core\convert\CConvert_CodeToSjis.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HaneisuToZeneisu.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HankataToZenhira.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HankataToZenkata.cpp" />

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -318,6 +318,7 @@
     <ClInclude Include="..\sakura_core\config\system_constants.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.h" />
+    <ClInclude Include="..\sakura_core\convert\CConvert_CodeFromSjis.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_HaneisuToZeneisu.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_HankataToZenhira.h" />
     <ClInclude Include="..\sakura_core\convert\CConvert_HankataToZenkata.h" />
@@ -680,6 +681,7 @@
     <ClCompile Include="..\sakura_core\config\build_config.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.cpp" />
+    <ClCompile Include="..\sakura_core\convert\CConvert_CodeFromSjis.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HaneisuToZeneisu.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HankataToZenhira.cpp" />
     <ClCompile Include="..\sakura_core\convert\CConvert_HankataToZenkata.cpp" />

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1106,6 +1106,9 @@
     <ClInclude Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.h">
       <Filter>Cpp Source Files\convert</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\convert\CConvert_CodeFromSjis.h">
+      <Filter>Cpp Source Files\convert</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\resource\auto_scroll_center.cur">
@@ -2292,6 +2295,9 @@
       <Filter>Cpp Source Files\basis</Filter>
     </ClCompile>
     <ClCompile Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.cpp">
+      <Filter>Cpp Source Files\convert</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sakura_core\convert\CConvert_CodeFromSjis.cpp">
       <Filter>Cpp Source Files\convert</Filter>
     </ClCompile>
   </ItemGroup>

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1103,6 +1103,9 @@
     <ClInclude Include="..\sakura_core\basis\CErrorInfo.h">
       <Filter>Cpp Source Files\basis</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.h">
+      <Filter>Cpp Source Files\convert</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\resource\auto_scroll_center.cur">
@@ -2287,6 +2290,9 @@
     </ClCompile>
     <ClCompile Include="..\sakura_core\basis\CErrorInfo.cpp">
       <Filter>Cpp Source Files\basis</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sakura_core\convert\CConvert_CodeAutoToSjis.cpp">
+      <Filter>Cpp Source Files\convert</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1109,6 +1109,9 @@
     <ClInclude Include="..\sakura_core\convert\CConvert_CodeFromSjis.h">
       <Filter>Cpp Source Files\convert</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\convert\CConvert_CodeToSjis.h">
+      <Filter>Cpp Source Files\convert</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\resource\auto_scroll_center.cur">
@@ -2298,6 +2301,9 @@
       <Filter>Cpp Source Files\convert</Filter>
     </ClCompile>
     <ClCompile Include="..\sakura_core\convert\CConvert_CodeFromSjis.cpp">
+      <Filter>Cpp Source Files\convert</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sakura_core\convert\CConvert_CodeToSjis.cpp">
       <Filter>Cpp Source Files\convert</Filter>
     </ClCompile>
   </ItemGroup>

--- a/sakura_core/convert/CConvert.cpp
+++ b/sakura_core/convert/CConvert.cpp
@@ -35,6 +35,7 @@
 #include "charset/CUtf8.h"
 #include "charset/CUtf7.h"
 #include "CConvert_CodeAutoToSjis.h"
+#include "CConvert_CodeFromSjis.h"
 #include "CConvert_ToLower.h"
 #include "CConvert_ToUpper.h"
 #include "CConvert_ToHankaku.h"
@@ -58,9 +59,6 @@ void CConvertMediator::ConvMemory( CNativeW* pCMemory, EFunctionCode nFuncCode, 
 	// xxx2SJIS:
 	//   1. バッファの内容がANSI版相当になるよう Unicode→SJIS 変換する
 	//   2. xxx→SJIS 変換後にバッファ内容をUNICODE版相当に戻す（SJIS→Unicode）のと等価な結果を得るために xxx→Unicode 変換する
-	// SJIS2xxx:
-	//   1. バッファ内容をANSI版相当に変換（Unicode→SJIS）後に SJIS→xxx 変換するのと等価な結果を得るために Unicode→xxx 変換する
-	//   2. バッファ内容をUNICODE版相当に戻すために SJIS→Unicode 変換する
 
 	switch( nFuncCode ){
 	//コード変換(xxx2SJIS)
@@ -72,11 +70,6 @@ void CConvertMediator::ConvMemory( CNativeW* pCMemory, EFunctionCode nFuncCode, 
 	case F_CODECNV_UTF72SJIS:
 		CShiftJis::UnicodeToSJIS(*pCMemory, pCMemory->_GetMemory());
 		break;
-	//コード変換(SJIS2xxx)
-	case F_CODECNV_SJIS2JIS:		CJis::UnicodeToJIS(*pCMemory, pCMemory->_GetMemory());			break;
-	case F_CODECNV_SJIS2EUC:		CEuc::UnicodeToEUC(*pCMemory, pCMemory->_GetMemory());			break;
-	case F_CODECNV_SJIS2UTF8:		CUtf8::UnicodeToUTF8(*pCMemory, pCMemory->_GetMemory());		break;
-	case F_CODECNV_SJIS2UTF7:		CUtf7::UnicodeToUTF7(*pCMemory, pCMemory->_GetMemory());		break;
 	}
 
 	bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
@@ -108,12 +101,10 @@ void CConvertMediator::ConvMemory( CNativeW* pCMemory, EFunctionCode nFuncCode, 
 	case F_CODECNV_UTF82SJIS:		CUtf8::UTF8ToUnicode(*(pCMemory->_GetMemory()), pCMemory);		break;
 	case F_CODECNV_UTF72SJIS:		CUtf7::UTF7ToUnicode(*(pCMemory->_GetMemory()), pCMemory);		break;
 	//コード変換(SJIS2xxx)
-	case F_CODECNV_SJIS2JIS:
-	case F_CODECNV_SJIS2EUC:
-	case F_CODECNV_SJIS2UTF8:
-	case F_CODECNV_SJIS2UTF7:
-		CShiftJis::SJISToUnicode(*(pCMemory->_GetMemory()), pCMemory);
-		break;
+	case F_CODECNV_SJIS2JIS:		CConvert_CodeFromSjis(CODE_JIS).CallConvert(pCMemory);				break;
+	case F_CODECNV_SJIS2EUC:		CConvert_CodeFromSjis(CODE_EUC).CallConvert(pCMemory);				break;
+	case F_CODECNV_SJIS2UTF8:		CConvert_CodeFromSjis(CODE_UTF8).CallConvert(pCMemory);				break;
+	case F_CODECNV_SJIS2UTF7:		CConvert_CodeFromSjis(CODE_UTF7).CallConvert(pCMemory);				break;
 	}
 
 	return;

--- a/sakura_core/convert/CConvert.cpp
+++ b/sakura_core/convert/CConvert.cpp
@@ -27,15 +27,9 @@
 #include "func/Funccode.h"
 #include "CEol.h"
 #include "charset/charcode.h"
-#include "charset/CCodeFactory.h"
-#include "charset/CShiftJis.h"
-#include "charset/CJis.h"
-#include "charset/CEuc.h"
-#include "charset/CUnicodeBe.h"
-#include "charset/CUtf8.h"
-#include "charset/CUtf7.h"
 #include "CConvert_CodeAutoToSjis.h"
 #include "CConvert_CodeFromSjis.h"
+#include "CConvert_CodeToSjis.h"
 #include "CConvert_ToLower.h"
 #include "CConvert_ToUpper.h"
 #include "CConvert_ToHankaku.h"
@@ -55,23 +49,6 @@
 /* 機能種別によるバッファの変換 */
 void CConvertMediator::ConvMemory( CNativeW* pCMemory, EFunctionCode nFuncCode, CKetaXInt nTabWidth, int nStartColumn )
 {
-	// コード変換はできるだけANSI版のsakuraと互換の結果が得られるように実装する	// 2009.03.26 ryoji
-	// xxx2SJIS:
-	//   1. バッファの内容がANSI版相当になるよう Unicode→SJIS 変換する
-	//   2. xxx→SJIS 変換後にバッファ内容をUNICODE版相当に戻す（SJIS→Unicode）のと等価な結果を得るために xxx→Unicode 変換する
-
-	switch( nFuncCode ){
-	//コード変換(xxx2SJIS)
-	case F_CODECNV_EMAIL:
-	case F_CODECNV_EUC2SJIS:
-	case F_CODECNV_UNICODE2SJIS:
-	case F_CODECNV_UNICODEBE2SJIS:
-	case F_CODECNV_UTF82SJIS:
-	case F_CODECNV_UTF72SJIS:
-		CShiftJis::UnicodeToSJIS(*pCMemory, pCMemory->_GetMemory());
-		break;
-	}
-
 	bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 	const SEncodingConfig& sEncodingConfig = CEditWnd::getInstance()->GetDocument()->m_cDocType.GetDocumentAttribute().m_encoding;
 
@@ -94,12 +71,12 @@ void CConvertMediator::ConvMemory( CNativeW* pCMemory, EFunctionCode nFuncCode, 
 	case F_RTRIM:					CConvert_Trim(false, bExtEol).CallConvert(pCMemory);	break;	// 2001.12.03 hor
 	//コード変換(xxx2SJIS)
 	case F_CODECNV_AUTO2SJIS:		CConvert_CodeAutoToSjis(sEncodingConfig).CallConvert(pCMemory);		break;
-	case F_CODECNV_EMAIL:			CJis::JISToUnicode(*(pCMemory->_GetMemory()), pCMemory, true);	break;
-	case F_CODECNV_EUC2SJIS:		CEuc::EUCToUnicode(*(pCMemory->_GetMemory()), pCMemory);			break;
-	case F_CODECNV_UNICODE2SJIS:	/* 無変換 */										break;
-	case F_CODECNV_UNICODEBE2SJIS:	CUnicodeBe::UnicodeBEToUnicode(*(pCMemory->_GetMemory()), pCMemory);	break;
-	case F_CODECNV_UTF82SJIS:		CUtf8::UTF8ToUnicode(*(pCMemory->_GetMemory()), pCMemory);		break;
-	case F_CODECNV_UTF72SJIS:		CUtf7::UTF7ToUnicode(*(pCMemory->_GetMemory()), pCMemory);		break;
+	case F_CODECNV_EMAIL:			CConvert_CodeToSjis(CODE_JIS).CallConvert(pCMemory);				break;
+	case F_CODECNV_EUC2SJIS:		CConvert_CodeToSjis(CODE_EUC).CallConvert(pCMemory);				break;
+	case F_CODECNV_UNICODE2SJIS:	CConvert_CodeToSjis(CODE_UNICODE).CallConvert(pCMemory);			break;
+	case F_CODECNV_UNICODEBE2SJIS:	CConvert_CodeToSjis(CODE_UNICODEBE).CallConvert(pCMemory);			break;
+	case F_CODECNV_UTF82SJIS:		CConvert_CodeToSjis(CODE_UTF8).CallConvert(pCMemory);				break;
+	case F_CODECNV_UTF72SJIS:		CConvert_CodeToSjis(CODE_UTF7).CallConvert(pCMemory);				break;
 	//コード変換(SJIS2xxx)
 	case F_CODECNV_SJIS2JIS:		CConvert_CodeFromSjis(CODE_JIS).CallConvert(pCMemory);				break;
 	case F_CODECNV_SJIS2EUC:		CConvert_CodeFromSjis(CODE_EUC).CallConvert(pCMemory);				break;

--- a/sakura_core/convert/CConvert.h
+++ b/sakura_core/convert/CConvert.h
@@ -27,40 +27,55 @@
 #define SAKURA_CCONVERT_781CEC40_5400_4D47_959B_0718AEA82A9B_H_
 #pragma once
 
-//2007.10.02 kobake CEditViewから分離
+#include "Funccode_enum.h"		// EFunctionCode
+#include "basis/SakuraBasis.h"	// CKetaXInt
+#include "charset/charcode.h"	// CCharWidthCache
+#include "mem/CNativeW.h"
+#include "types/CType.h"		// SEncodingConfig
 
-#include "CSelectLang.h"
-#include "Funccode_enum.h"	// EFunctionCode
-#include "String_define.h"
-#include "basis/SakuraBasis.h"
-#include "debug/Debug2.h"
-#include "util/MessageBoxF.h"
+/*!
+	各種変換機能呼出の窓口となるクラス
+ */
+class CConversionFacade {
+	int m_nTabWidth;
+	int m_nStartColumn;
+	bool m_bEnableExtEol;
+	SEncodingConfig m_sEncodingConfig;
+	CCharWidthCache& m_cCharWidthCache;
 
-class CNativeW;
-
-class CConvertMediator{
 public:
-	//! 機能種別によるバッファの変換
-	static void ConvMemory( CNativeW* pCMemory, EFunctionCode nFuncCode, CKetaXInt nTabWidth, int nStartColumn );
+	explicit CConversionFacade(
+		CKetaXInt nTabWidth,
+		int nStartColumn,
+		bool bEnableExtEol,
+		const SEncodingConfig& sEncodingConfig,
+		CCharWidthCache& cCharWidthCache
+	);
 
-protected:
-	static void Command_TRIM2( CNativeW* pCMemory , BOOL bLeft );
+	//! 機能種別によるバッファの変換
+	bool ConvMemory(EFunctionCode eFuncCode, CNativeW& cData) noexcept;
+
+private:
+	//! 変換機能を呼び出す
+	bool CallConvert(EFunctionCode eFuncCode, CNativeW* pcData) noexcept;
 };
 
+/*!
+	各種コンバータの基底クラス
+
+	@date 2007/10/02 kobake CEditViewから分離
+ */
 class CConvert{
 public:
-	virtual ~CConvert(){}
-
-	//インターフェース
-	void CallConvert( CNativeW* pcData )
-	{
-		bool bRet=DoConvert(pcData);
-		if(!bRet){
-			ErrorMessage(NULL,LS(STR_CONVERT_ERR));
-		}
-	}
+	CConvert() noexcept = default;
+	CConvert(const CConvert&) = delete;
+	CConvert& operator = (const CConvert&) = delete;
+	CConvert(CConvert&&) noexcept = delete;
+	CConvert& operator = (CConvert&&) noexcept = delete;
+	virtual ~CConvert() noexcept = default;
 
 	//実装
-	virtual bool DoConvert( CNativeW* pcData )=0;
+	virtual bool DoConvert(CNativeW* pcData) = 0;
 };
+
 #endif /* SAKURA_CCONVERT_781CEC40_5400_4D47_959B_0718AEA82A9B_H_ */

--- a/sakura_core/convert/CConvert_CodeAutoToSjis.cpp
+++ b/sakura_core/convert/CConvert_CodeAutoToSjis.cpp
@@ -1,0 +1,80 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include "StdAfx.h"
+#include "CConvert_CodeAutoToSjis.h"
+
+#include "charset/CCodeFactory.h"
+#include "charset/CCodeMediator.h"
+
+/*!
+	コンストラクタ
+ */
+CConvert_CodeAutoToSjis::CConvert_CodeAutoToSjis(const SEncodingConfig& sEncodingConfig) noexcept
+	: m_sEncodingConfig(sEncodingConfig)
+{
+}
+
+/*!
+	文字コード変換 自動判別→SJIS
+
+	@date 2014/02/10 Moca F_CODECNV_AUTO2SJIS追加。
+ */
+bool CConvert_CodeAutoToSjis::DoConvert(CNativeW* pcData)
+{
+	// Shift-JISに変換する（変換エラーは無視する）
+	const auto bin = CCodeFactory::CreateCodeBase(CODE_SJIS)->UnicodeToCode(*pcData);
+
+	// バイナリシーケンスの文字コードを自動検出する
+	CCodeMediator m(m_sEncodingConfig);
+	ECodeType eCodeType = m.CheckKanjiCode(reinterpret_cast<const char*>(bin.data()), bin.length());
+
+	// 検出された文字コードに基づいて変換に使うCCodeBaseを生成する
+	std::unique_ptr<CCodeBase> pcCodeBase;
+	switch (eCodeType)
+	{
+	case CODE_JIS:
+		// JIS変換はbase64デコードを行うモードを使う
+		pcCodeBase = std::unique_ptr<CCodeBase>(CCodeFactory::CreateCodeBase(CODE_JIS, true));
+		break;
+
+	case CODE_EUC:
+	case CODE_UNICODE:
+	case CODE_UNICODEBE:
+	case CODE_UTF8:
+	case CODE_UTF7:
+		// サポートされているその他の変換
+		pcCodeBase = CCodeFactory::CreateCodeBase(eCodeType);
+		break;
+
+	default:
+		// サポートされていない変換は失敗扱いにする(変換しない)
+		return false;
+	}
+
+	// 検出された文字コードに基づいてUnicode変換する（変換エラーは無視する）
+	*pcData = pcCodeBase->CodeToUnicode(bin);
+
+	return true;
+}

--- a/sakura_core/convert/CConvert_CodeAutoToSjis.h
+++ b/sakura_core/convert/CConvert_CodeAutoToSjis.h
@@ -1,0 +1,37 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#pragma once
+
+#include "CConvert.h"
+#include "types/CType.h"	//SEncodingConfig
+
+//! 文字コード変換 自動判別→SJIS
+class CConvert_CodeAutoToSjis final : public CConvert{
+	SEncodingConfig m_sEncodingConfig;
+
+public:
+	explicit CConvert_CodeAutoToSjis(const SEncodingConfig& sEncodingConfig ) noexcept;
+	bool DoConvert(CNativeW* pcData) override;
+};

--- a/sakura_core/convert/CConvert_CodeFromSjis.cpp
+++ b/sakura_core/convert/CConvert_CodeFromSjis.cpp
@@ -1,0 +1,53 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include "StdAfx.h"
+#include "CConvert_CodeFromSjis.h"
+
+#include "charset/CCodeFactory.h"
+
+/*!
+	コンストラクタ
+ */
+CConvert_CodeFromSjis::CConvert_CodeFromSjis(ECodeType eCodeType) noexcept
+	: m_eCodeType(eCodeType)
+{
+}
+
+/*!
+	文字コード変換 SJIS→xxx
+
+	@date 2009/03/26 ryoji コード変換はできるだけANSI版のsakuraと互換の結果が得られるように実装する
+ */
+bool CConvert_CodeFromSjis::DoConvert(CNativeW* pcData)
+{
+	// バッファ内容をANSI版相当に変換（Unicode→SJIS）後に SJIS→xxx 変換するのと等価な結果を得るために
+	// Unicode→xxx 変換する
+	const auto bin = CCodeFactory::CreateCodeBase(m_eCodeType)->UnicodeToCode(*pcData);
+
+	// バッファ内容をUNICODE版相当に戻すために SJIS→Unicode 変換する
+	*pcData = CCodeFactory::CreateCodeBase(CODE_SJIS)->CodeToUnicode(bin);
+
+	return true;
+}

--- a/sakura_core/convert/CConvert_CodeFromSjis.h
+++ b/sakura_core/convert/CConvert_CodeFromSjis.h
@@ -1,0 +1,37 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#pragma once
+
+#include "CConvert.h"
+#include "charset/charset.h"
+
+//! 文字コード変換 SJIS→xxx
+class CConvert_CodeFromSjis final : public CConvert{
+	ECodeType m_eCodeType;
+
+public:
+	explicit CConvert_CodeFromSjis(ECodeType eCoceType) noexcept;
+	bool DoConvert(CNativeW* pcData) override;
+};

--- a/sakura_core/convert/CConvert_CodeToSjis.cpp
+++ b/sakura_core/convert/CConvert_CodeToSjis.cpp
@@ -1,0 +1,64 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include "StdAfx.h"
+#include "CConvert_CodeToSjis.h"
+
+#include "charset/CCodeFactory.h"
+
+/*!
+	コンストラクタ
+ */
+CConvert_CodeToSjis::CConvert_CodeToSjis(ECodeType eCodeType) noexcept
+	: m_eCodeType(eCodeType)
+{
+}
+
+/*!
+	文字コード変換 xxx→SJIS
+
+	@date 2009/03/26 ryoji コード変換はできるだけANSI版のsakuraと互換の結果が得られるように実装する
+ */
+bool CConvert_CodeToSjis::DoConvert(CNativeW* pcData)
+{
+	// バッファの内容がANSI版相当になるよう Unicode→SJIS 変換する
+	const auto bin = CCodeFactory::CreateCodeBase(CODE_SJIS)->UnicodeToCode(*pcData);
+
+	// xxx→SJIS 変換後にバッファ内容をUNICODE版相当に戻す（SJIS→Unicode）のと等価な結果を得るために
+	// xxx→Unicode 変換する
+	std::unique_ptr<CCodeBase> pcCodeBase;
+	if (m_eCodeType == CODE_JIS) {
+		// JIS変換はbase64デコードを行うモードを使う
+		pcCodeBase = std::unique_ptr<CCodeBase>(CCodeFactory::CreateCodeBase(CODE_JIS, true));
+	}
+	else {
+		// その他の変換
+		pcCodeBase = CCodeFactory::CreateCodeBase(m_eCodeType);
+	}
+
+	// 指定された文字コードに基づいてUnicode変換する（変換エラーは無視する）
+	*pcData = pcCodeBase->CodeToUnicode(bin);
+
+	return true;
+}

--- a/sakura_core/convert/CConvert_CodeToSjis.h
+++ b/sakura_core/convert/CConvert_CodeToSjis.h
@@ -1,0 +1,37 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#pragma once
+
+#include "CConvert.h"
+#include "charset/charset.h"
+
+//! 文字コード変換 xxx→SJIS
+class CConvert_CodeToSjis final : public CConvert{
+	ECodeType m_eCodeType;
+
+public:
+	explicit CConvert_CodeToSjis(ECodeType eCoceType) noexcept;
+	bool DoConvert(CNativeW* pcData) override;
+};

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -55,6 +55,7 @@
 #include "CMarkMgr.h"///
 #include "types/CTypeSupport.h"
 #include "convert/CConvert.h"
+#include "util/MessageBoxF.h"
 #include "util/RegKey.h"
 #include "util/string_ex2.h"
 #include "util/os.h" //WM_MOUSEWHEEL,IMR_RECONVERTSTRING,WM_XBUTTON*,IMR_CONFIRMRECONVERTSTRING
@@ -62,6 +63,9 @@
 #include "debug/CRunningTimer.h"
 #include "apiwrap/StdApi.h"
 #include "config/system_constants.h"
+
+#include "CSelectLang.h"
+#include "String_define.h"
 
 LRESULT CALLBACK EditViewWndProc( HWND, UINT, WPARAM, LPARAM );
 VOID CALLBACK EditViewTimerProc( HWND, UINT, UINT_PTR, DWORD );
@@ -1407,7 +1411,7 @@ void CEditView::ConvSelectedArea( EFunctionCode nFuncCode )
 				{
 					/* 機能種別によるバッファの変換 */
 					int nStartColumn = (Int)sPos.GetX2() / (Int)GetTextMetrics().GetLayoutXDefault();
-					CConvertMediator::ConvMemory( &cmemBuf, nFuncCode, m_pcEditDoc->m_cLayoutMgr.GetTabSpaceKetas(), nStartColumn );
+					CConversionFacade(m_pcEditDoc->m_cLayoutMgr.GetTabSpaceKetas(), nStartColumn, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol, m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_encoding, GetCharWidthCache()).ConvMemory(nFuncCode, cmemBuf);
 
 					/* 現在位置にデータを挿入 */
 					CLayoutPoint ptLayoutNew;	// 挿入された部分の次の位置
@@ -1445,7 +1449,7 @@ void CEditView::ConvSelectedArea( EFunctionCode nFuncCode )
 
 		/* 機能種別によるバッファの変換 */
 		int nStartColum = (Int)GetSelectionInfo().m_sSelect.GetFrom().GetX2() / (Int)GetTextMetrics().GetLayoutXDefault();
-		CConvertMediator::ConvMemory( &cmemBuf, nFuncCode, m_pcEditDoc->m_cLayoutMgr.GetTabSpaceKetas(), nStartColum );
+		CConversionFacade(m_pcEditDoc->m_cLayoutMgr.GetTabSpaceKetas(), nStartColum, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol, m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_encoding, GetCharWidthCache()).ConvMemory(nFuncCode, cmemBuf);
 
 		/* データ置換 削除&挿入にも使える */
 		ReplaceData_CEditView(

--- a/tests/unittests/test-cconvert.cpp
+++ b/tests/unittests/test-cconvert.cpp
@@ -408,14 +408,15 @@ TEST_P(ConvTest, test)
 	const auto eFuncCode = std::get<0>(GetParam());
 	std::wstring_view source = std::get<1>(GetParam());
 	std::wstring_view expected = std::get<2>(GetParam());
-	SEncodingConfig encoding;
+	SEncodingConfig sEncodingConfig;
+	CCharWidthCache cCharWidthCache;
 	CNativeW cmemBuf(source.data(), source.length());
 	CConversionFacade(
 		4,								// タブ幅(タブ幅が半角スペース何個分かを指定する)
 		0,								// 変換開始桁位置
 		false,							// 拡張改行コードを有効にするかどうか
-		encoding,						// 文字コード自動検出のオプション
-		CCharWidthCache()				// 文字幅キャッシュ
+		sEncodingConfig,				// 文字コード自動検出のオプション
+		cCharWidthCache					// 文字幅キャッシュ
 	).ConvMemory(eFuncCode, cmemBuf);
 
 	EXPECT_STREQ(expected.data(), cmemBuf.GetStringPtr());

--- a/tests/unittests/test-cconvert.cpp
+++ b/tests/unittests/test-cconvert.cpp
@@ -23,8 +23,11 @@
 */
 
 #include <gtest/gtest.h>
-#include "charset/charcode.h"
 #include "convert/CConvert.h"
+
+#include <ostream>
+#include <tuple>
+
 #include "convert/CConvert_HaneisuToZeneisu.h"
 #include "convert/CConvert_HankataToZenhira.h"
 #include "convert/CConvert_HankataToZenkata.h"
@@ -38,7 +41,6 @@
 #include "convert/CConvert_Trim.h"
 #include "convert/CConvert_ZeneisuToHaneisu.h"
 #include "convert/CConvert_ZenkataToHankata.h"
-#include "mem/CNativeW.h"
 
 TEST(CConvert, ZenkataToHankata)
 {
@@ -388,3 +390,70 @@ TEST(CConvert, Trim)
 	EXPECT_TRUE(CConvert_Trim(true, false).DoConvert(&actual));
 	EXPECT_EQ(actual, expected);
 }
+
+//! googletestの出力に機能IDを出力させる
+std::ostream& operator << (std::ostream& os, const EFunctionCode& eFuncCode);
+
+//!変換テストのためのテストパラメータ型
+using ConvTestParamType = std::tuple<EFunctionCode, std::wstring_view, std::wstring_view>;
+
+//!変換テストのためのフィクスチャクラス
+class ConvTest : public ::testing::TestWithParam<ConvTestParamType> {};
+
+/*!
+ * @brief 機能コードによるバッファ変換のテスト
+ */
+TEST_P(ConvTest, test)
+{
+	const auto eFuncCode = std::get<0>(GetParam());
+	std::wstring_view source = std::get<1>(GetParam());
+	std::wstring_view expected = std::get<2>(GetParam());
+	SEncodingConfig encoding;
+	CNativeW cmemBuf(source.data(), source.length());
+	CConversionFacade(
+		4,								// タブ幅(タブ幅が半角スペース何個分かを指定する)
+		0,								// 変換開始桁位置
+		false,							// 拡張改行コードを有効にするかどうか
+		encoding,						// 文字コード自動検出のオプション
+		CCharWidthCache()				// 文字幅キャッシュ
+	).ConvMemory(eFuncCode, cmemBuf);
+
+	EXPECT_STREQ(expected.data(), cmemBuf.GetStringPtr());
+}
+
+/*!
+ * @brief パラメータテストをインスタンス化する
+ *  各変換機能の正常系をチェックするパターンで実体化させる
+ */
+INSTANTIATE_TEST_CASE_P(ParameterizedTestConv
+	, ConvTest
+	, ::testing::Values(
+		ConvTestParamType{ F_TOLOWER,					L"AbＣｄ",			L"abｃｄ" },
+		ConvTestParamType{ F_TOUPPER,					L"AbＣｄ",			L"ABＣＤ" },
+		ConvTestParamType{ F_TOHANKAKU,					L"カナかなｶﾅ",		L"ｶﾅｶﾅｶﾅ" },
+		ConvTestParamType{ F_TOHANKATA,					L"カナかなｶﾅ",		L"ｶﾅかなｶﾅ" },
+		ConvTestParamType{ F_TOZENEI,					L"AbＣｄ",			L"ＡｂＣｄ" },
+		ConvTestParamType{ F_TOHANEI,					L"AbＣｄ",			L"AbCd" },
+		ConvTestParamType{ F_TOZENKAKUKATA,				L"カナかなｶﾅ",		L"カナカナカナ" },
+		ConvTestParamType{ F_TOZENKAKUHIRA,				L"カナかなｶﾅ",		L"かなかなかな" },
+		ConvTestParamType{ F_HANKATATOZENKATA,			L"カナかなｶﾅ",		L"カナかなカナ" },
+		ConvTestParamType{ F_HANKATATOZENHIRA,			L"カナかなｶﾅ",		L"カナかなかな" },
+		ConvTestParamType{ F_TABTOSPACE,				L"\t",				L"    " },
+		ConvTestParamType{ F_SPACETOTAB,				L"    ",			L"\t" },
+		ConvTestParamType{ F_LTRIM,						L" x ",				L"x " },
+		ConvTestParamType{ F_RTRIM,						L" x ",				L" x" },
+		ConvTestParamType{ F_CODECNV_EMAIL,				L"\x1b$B2=$1%i%C%?\x1b(B!!",	L"化けラッタ!!" },
+		ConvTestParamType{ F_CODECNV_EUC2SJIS,			L"ｲｽ､ｱ･鬣ﾃ･ｿ!!",				L"化けラッタ!!" },
+		ConvTestParamType{ F_CODECNV_UNICODE2SJIS,		L"",							L"" },							//FIXME: 機能しないため、呼出確認のみ。
+		ConvTestParamType{ F_CODECNV_UNICODEBE2SJIS,	L"",							L"" },							//FIXME: 機能しないため、呼出確認のみ
+		ConvTestParamType{ F_CODECNV_UTF82SJIS,			L"",							L"" },							//FIXME: 機能しないため、呼出確認のみ
+		ConvTestParamType{ F_CODECNV_UTF72SJIS,			L"+UxYwUTDpMMMwvwAhACE-",		L"化けラッタ!!" },
+		ConvTestParamType{ F_CODECNV_AUTO2SJIS,			L"化けラッタ!!",				L"化けラッタ!!" },
+		ConvTestParamType{ F_CODECNV_AUTO2SJIS,			L"\x1b$B2=$1%i%C%?\x1b(B!!",	L"化けラッタ!!" },
+		ConvTestParamType{ F_CODECNV_AUTO2SJIS,			L"ｲｽ､ｱ･鬣ﾃ･ｿ!!",				L"化けラッタ!!" },
+		ConvTestParamType{ F_CODECNV_SJIS2JIS,			L"化けラッタ!!",				L"\x1b$B2=$1%i%C%?\x1b(B!!" },
+		ConvTestParamType{ F_CODECNV_SJIS2EUC,			L"化けラッタ!!",				L"ｲｽ､ｱ･鬣ﾃ･ｿ!!" },
+		ConvTestParamType{ F_CODECNV_SJIS2UTF8,			L"",							L"" },							//FIXME: 機能しないため、呼出確認のみ
+		ConvTestParamType{ F_CODECNV_SJIS2UTF7,			L"化けラッタ!!",				L"+UxYwUTDpMMMwvwAhACE-" }
+	)
+);

--- a/tests/unittests/test-printEFunctionCode.cpp
+++ b/tests/unittests/test-printEFunctionCode.cpp
@@ -1,0 +1,66 @@
+﻿/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <ostream>
+
+#include "Funccode_enum.h"
+
+/*!
+	googletestの出力にEFunctionCodeを出力させる
+
+	パラメータテストのパラメータにEFunctionCodeを渡した場合に文字列を併記して分かりやすくする。
+
+	テストで使用するコード値のみを定義してあるので、必要があれば追加定義すること。
+ */
+std::ostream& operator << (std::ostream& os, const EFunctionCode& eFuncCode)
+{
+	switch( eFuncCode ){
+	case F_TOLOWER:					return os << u8"TOLOWER";
+	case F_TOUPPER:					return os << u8"TOUPPER";
+	case F_TOHANKAKU:				return os << u8"TOHANKAKU";
+	case F_TOHANKATA:				return os << u8"TOHANKATA";
+	case F_TOZENEI:					return os << u8"TOZENEI";
+	case F_TOHANEI:					return os << u8"TOHANEI";
+	case F_TOZENKAKUKATA:			return os << u8"TOZENKAKUKATA";
+	case F_TOZENKAKUHIRA:			return os << u8"TOZENKAKUHIRA";
+	case F_HANKATATOZENKATA:		return os << u8"HANKATATOZENKATA";
+	case F_HANKATATOZENHIRA:		return os << u8"HANKATATOZENHIRA";
+	case F_TABTOSPACE:				return os << u8"TABTOSPACE";
+	case F_SPACETOTAB:				return os << u8"SPACETOTAB";
+	case F_LTRIM:					return os << u8"LTRIM";
+	case F_RTRIM:					return os << u8"RTRIM";
+	case F_CODECNV_AUTO2SJIS:		return os << u8"CODECNV_AUTO2SJIS";
+	case F_CODECNV_EMAIL:			return os << u8"CODECNV_JIS2SJIS";
+	case F_CODECNV_EUC2SJIS:		return os << u8"CODECNV_EUC2SJIS";
+	case F_CODECNV_UNICODE2SJIS:	return os << u8"CODECNV_UTF16LE2SJIS";
+	case F_CODECNV_UNICODEBE2SJIS:	return os << u8"CODECNV_UTF16BE2SJIS";
+	case F_CODECNV_UTF82SJIS:		return os << u8"CODECNV_UTF82SJIS";
+	case F_CODECNV_UTF72SJIS:		return os << u8"CODECNV_UTF72SJIS";
+	case F_CODECNV_SJIS2JIS:		return os << u8"CODECNV_SJIS2JIS";
+	case F_CODECNV_SJIS2EUC:		return os << u8"CODECNV_SJIS2EUC";
+	case F_CODECNV_SJIS2UTF8:		return os << u8"CODECNV_SJIS2UTF8";
+	case F_CODECNV_SJIS2UTF7:		return os << u8"CODECNV_SJIS2UTF7";
+	default:
+		throw std::invalid_argument("unknown functionCode");
+	}
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -106,6 +106,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="code-main.cpp" />
+    <ClCompile Include="test-printEFunctionCode.cpp" />
     <ClCompile Include="test-cclipboard.cpp" />
     <ClCompile Include="test-ccodebase.cpp" />
     <ClCompile Include="test-ccommandline.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClCompile Include="test-ceol.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-printEFunctionCode.cpp">
+      <Filter>Other Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
機能コードによるバッファ変換をテスト可能にします。

## <!-- 必須 --> カテゴリ
- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
サクラエディタには各種変換機能が搭載されています。

アルファベットを大文字にしたり、文字化けした文字列を部分的に別の文字コードで解釈しなおしたりできるこの機能はサクラエディタの目玉でもあります。

重要な機能なので、テスト可能にして確実な動作保証ができるようにしたいです。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
- 「機能コードによるバッファ変換」に単体テストが導入されます。網羅率100%です。
- 文字コード変換機能のためのCConvertクラスが分離されることにより、「変換で何をやっているか？」が明確になります。
- 文字コード変換クラスCCodeBaseの派生クラスを直接利用するコードを削減できます。
- もともと存在していた `CConvertMediator` を `CConversionFacade` にリネームします。
  - [メディエイターパターン](https://www.techscore.com/tech/DesignPattern/Mediator.html)と[ファサードパターン](https://www.techscore.com/tech/DesignPattern/Facade.html)は似ていますが別モノです。
  - デザインパターンを正しく理解している心無い人から、鼻で笑われる危険を回避できます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- 呼出元クラス CEditView がテスト不能であるため、メインルートの単体テストは書けませんでした。
- 25個ある変換機能のうち、4つが機能していませんが対策を行いません。
- `F_CODECNV_UNICODE2SJIS` の変換（機能していないものの1つ）について挙動を変える変更を行っていますが、もともと正しく機能していないため単体テストによる動作確認を行っていません。
- 新規に6件のCodeSmellsが発生します。
  - うち4件は zlib license の定型文言が誤検出される既知の問題なので false positive として消去しました。
  - 残り2件は外部コードが原因であるため今回は対処しません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
サクラエディタの仕様・機能を変更する修正ではありません（一部例外あり、影響範囲を参照。）

- 従来、仲介クラスCConvertMediator::ConvMemory内にベタ書きされていた文字コード変換を変換クラスとして抽出しました。
  - CConvert_CodeAutoToSjis 自動判別→SJIS
  - CConvert_CodeFromSjis SJIS→xxx
  - CConvert_CodeToSjis xxx→SJIS
- 仲介クラスCConvertMediatorの実態は「窓口」であるため、クラス名をCConversionFacadeに変更しました。
- CConvert::CallConvertの実装が窓口機能の一部と解釈できるため、メソッドをCConversionFacadeに移動しました。

文字コード変換クラスに存在するいくつかの不具合のせいで、完全なテストができるとは言えないPRですが、残課題は別途対応していくつもりです。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
変換メニューにある機能に影響する変更です。

処理内容に影響が出ないように修正していますが、変更前コードに明確なバグがあったため1機能のみ挙動を変更しています。

- `F_CODECNV_UNICODE2SJIS`
  https://github.com/sakura-editor/sakura/blob/f62f20957ce0c67eb7b3c017e37bfd16c46b1f76/sakura_core/convert/CConvert.cpp#L127-L129
  ここに来るまでに pCMemory の中身は SJIS 相当のバイナリになっているので、無変換ではマズいです。
  このPRではEUCやUnicodeBEと同様の処理を入れて対策していますが、SJISのUnicodeToCodeに問題があるため対策しても正しく動かないことが分かっています。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
このPRで追加する単体テストが修正範囲をカバーするため、追加テストは行っていません。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1614
#1532

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
