### PR TITLE
UTF32BEの文字コード変換クラスが7bit ASCIIを取り込めない問題に対処する

### DIFF
--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -569,7 +569,7 @@ int CCodePage::S_UTF32BEToUnicode( const char* pSrc, int nSrcLen, wchar_t* pDst,
 		for(; i < nSrcLen; ){
 			if( i + 3 < nSrcLen ){
 				if( pSrcByte[i+1] == 0x00 && pSrcByte[i] == 0x00 ){
-					wchar_t c = static_cast<wchar_t>(pSrcByte[i+1] << 8 | pSrcByte[i]);
+					wchar_t c = static_cast<wchar_t>(pSrcByte[i+2] << 8 | pSrcByte[i+3]);
 					if( IsUtf16SurrogHi(c) || IsUtf16SurrogLow(c) ){
 						// サロゲート断片。バイトごとに出力する)
 						nDstUseLen += 4;
@@ -597,7 +597,7 @@ int CCodePage::S_UTF32BEToUnicode( const char* pSrc, int nSrcLen, wchar_t* pDst,
 	for(; i < nSrcLen; ){
 		if( i + 3 < nSrcLen ){
 			if( pSrcByte[i] == 0x00 && pSrcByte[i+1] == 0x00 ){
-				wchar_t c = static_cast<wchar_t>(pSrcByte[i+1] << 8 | pSrcByte[i]);
+				wchar_t c = static_cast<wchar_t>(pSrcByte[i+2] << 8 | pSrcByte[i+3]);
 				if( IsUtf16SurrogHi(c) || IsUtf16SurrogLow(c) ){
 					nDstUseCharLen = 4;
 					if( nDstUseLen + nDstUseCharLen <= nDstLen ){


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
タイトル通りです。少なくとも 7bit ASCII を取り込めるようにします。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
https://github.com/sakura-editor/sakura/pull/1614#issuecomment-811020906 で書いた通り、UTF32BEの文字コード変換クラスに不具合が見つかっています。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
- UTF32BEの文字コード変換クラスで 7bit ASCII を取り込めるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- UTF32BEの文字コード変換クラスが 7bit ASCII 以外の文字を取り込めることを保証するPRではありません。
  修正コード周辺には不審点がいくつかあるので、直しても結局動かないかも知れません。
- 作成したテストが誤っている可能性がちょっとだけあります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
1. UTF32LEのテストデータ(リトルエンディアン)をエンディアン変換しただけのテストを追加します。
  コード修正を行う前は、このテストに失敗します。
2. 想定する修正を適用します。
  コード修正を行った後は、このテストに成功します。


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
