### PR TITLE
「SAKURA EDITORでGrep」が使えるようにnullチェックを入れる

### DIFF
--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -266,14 +266,16 @@ bool CNormalProcess::InitializeProcess()
 			
 			//	Oct. 9, 2003 genta コマンドラインからGERPダイアログを表示させた場合に
 			//	引数の設定がBOXに反映されない
-			pEditWnd->m_cDlgGrep.m_strText = gi.cmGrepKey.GetStringPtr();		/* 検索文字列 */
-			pEditWnd->m_cDlgGrep.m_bSetText = true;
-			int nSize = _countof2(pEditWnd->m_cDlgGrep.m_szFile);
-			wcsncpy( pEditWnd->m_cDlgGrep.m_szFile, gi.cmGrepFile.GetStringPtr(), nSize );	/* 検索ファイル */
-			pEditWnd->m_cDlgGrep.m_szFile[nSize-1] = L'\0';
-			nSize = _countof2(pEditWnd->m_cDlgGrep.m_szFolder);
-			wcsncpy( pEditWnd->m_cDlgGrep.m_szFolder, cmemGrepFolder.GetStringPtr(), nSize );	/* 検索フォルダ */
-			pEditWnd->m_cDlgGrep.m_szFolder[nSize-1] = L'\0';
+			if( gi.cmGrepKey.IsValid() ){
+				pEditWnd->m_cDlgGrep.m_strText = gi.cmGrepKey.GetStringPtr();		/* 検索文字列 */
+				pEditWnd->m_cDlgGrep.m_bSetText = true;
+			}
+			if( auto& szFile = pEditWnd->m_cDlgGrep.m_szFile; gi.cmGrepFile.IsValid() && gi.cmGrepFile.GetStringLength() < _countof2(szFile) ){
+				szFile = gi.cmGrepFile.GetStringPtr();	/* 検索ファイル */
+			}
+			if( auto& szFolder = pEditWnd->m_cDlgGrep.m_szFolder; gi.cmGrepFolder.IsValid() && gi.cmGrepFolder.GetStringLength() < _countof2(szFolder) ){
+				szFolder = gi.cmGrepFolder.GetStringPtr();	/* 検索ファイル */
+			}
 
 			// Feb. 23, 2003 Moca Owner windowが正しく指定されていなかった
 			int nRet = pEditWnd->m_cDlgGrep.DoModal( GetProcessInstance(), pEditWnd->GetHwnd(),  NULL);


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
#1626 のデグレ解消のキッカケとなることが目的です。

## <!-- 必須 --> カテゴリ

- 不具合修正
- 実験 (master へのマージを目的としない)

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1626 で 「SAKURA EDITORでGrep」が動かないという不具合報告が上がっています。

コードを確認したところ、状況によりNULLとなりうる値のNULLチェックが行われていなかったので追加してみます。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
少なくとも #1626 が解消します。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
- 見えている問題のみに対処するヤッツケ対応です。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
値がNULL（＝指定されない）かもしれないコマンドラインパラメータを扱う処理で、
値がNULLの場合を考慮していないコードになっていたのを対策します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
コマンドラインからGrepダイアログを表示させるオプション`-GREPDLG`を指定した場合に影響します。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
以下のコマンドラインを打って、サクラエディタが起動するかチェックします。

```cmd
sakura.exe -GREPMODE -GREPDLG 
```

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
close #1626 
#1618

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
