### PR TITLE
CConvert_TabToSpace::DoConvert で std::wstring を使用する

### DIFF
--- a/sakura_core/convert/CConvert_TabToSpace.cpp
+++ b/sakura_core/convert/CConvert_TabToSpace.cpp
@@ -24,6 +24,9 @@
 */
 #include "StdAfx.h"
 #include "CConvert_TabToSpace.h"
+
+#include <algorithm>
+#include <string_view>
 #include "charset/charcode.h"
 #include "CEol.h"
 #include "util/string_ex2.h"
@@ -32,20 +35,24 @@
 //! TAB→空白
 bool CConvert_TabToSpace::DoConvert(CNativeW* pcData)
 {
+	const std::wstring_view source(pcData->GetStringPtr(), pcData->GetStringLength());
+	const std::ptrdiff_t numOfTabs = std::count(source.begin(), source.end(), L'\t');
 	std::wstring buffer;
+	buffer.reserve(source.length() + numOfTabs * (m_nTabWidth - 1));
+
 	int begin = 0;
 	while (true) {
 		int lineLength;
 		CEol eol;
 		/* CRLFで区切られる「行」を返す。CRLFは行長に加えない */
-		const wchar_t* line = GetNextLineW(pcData->GetStringPtr(),
-			pcData->GetStringLength(), &lineLength, &begin, &eol, m_bExtEol);
+		const wchar_t* line = GetNextLineW(source.data(),
+			source.length(), &lineLength, &begin, &eol, m_bExtEol);
 		if (!line)
 			break;
 		// 先頭行については開始桁位置を考慮する（さらに折り返し関連の対策が必要？）
-		int pos = (pcData->GetStringPtr() == line) ? m_nStartColumn : 0;
+		int pos = (source.data() == line) ? m_nStartColumn : 0;
 		for (int i = 0; i < lineLength; ++i) {
-			if (line[i] == WCODE::TAB) {
+			if (line[i] == L'\t') {
 				const int width = m_nTabWidth - (pos % m_nTabWidth);
 				buffer.append(width, L' ');
 				pos += width;

--- a/sakura_core/convert/CConvert_TabToSpace.cpp
+++ b/sakura_core/convert/CConvert_TabToSpace.cpp
@@ -46,7 +46,7 @@ bool CConvert_TabToSpace::DoConvert(CNativeW* pcData)
 		CEol eol;
 		/* CRLFで区切られる「行」を返す。CRLFは行長に加えない */
 		const wchar_t* line = GetNextLineW(source.data(),
-			source.length(), &lineLength, &begin, &eol, m_bExtEol);
+			static_cast<int>(source.length()), &lineLength, &begin, &eol, m_bExtEol);
 		if (!line)
 			break;
 		// 先頭行については開始桁位置を考慮する（さらに折り返し関連の対策が必要？）

--- a/sakura_core/convert/CConvert_TabToSpace.cpp
+++ b/sakura_core/convert/CConvert_TabToSpace.cpp
@@ -32,70 +32,32 @@
 //! TAB→空白
 bool CConvert_TabToSpace::DoConvert(CNativeW* pcData)
 {
-	using namespace WCODE;
-
-	const wchar_t*	pLine;
-	int			nLineLen;
-	wchar_t*	pDes;
-	int			nBgn;
-	int			i;
-	int			nPosDes;
-	int			nPosX;
-	int			nWork;
-	CEol		cEol;
-	nBgn = 0;
-	nPosDes = 0;
-	/* CRLFで区切られる「行」を返す。CRLFは行長に加えない */
-	while( NULL != ( pLine = GetNextLineW( pcData->GetStringPtr(), pcData->GetStringLength(), &nLineLen, &nBgn, &cEol, m_bExtEol ) ) ){
-		if( 0 < nLineLen ){
-			// 先頭行については開始桁位置を考慮する（さらに折り返し関連の対策が必要？）
-			nPosX = (pcData->GetStringPtr() == pLine)? m_nStartColumn: 0;
-			for( i = 0; i < nLineLen; ++i ){
-				if( TAB == pLine[i]	){
-					nWork = m_nTabWidth - ( nPosX % m_nTabWidth );
-					nPosDes += nWork;
-					nPosX += nWork;
-				}else{
-					nPosDes++;
-					nPosX++;
-					if(WCODE::IsZenkaku(pLine[i])) nPosX++;		//全角文字ずれ対応 2008.10.15 matsumo
-				}
+	std::wstring buffer;
+	int begin = 0;
+	while (true) {
+		int lineLength;
+		CEol eol;
+		/* CRLFで区切られる「行」を返す。CRLFは行長に加えない */
+		const wchar_t* line = GetNextLineW(pcData->GetStringPtr(),
+			pcData->GetStringLength(), &lineLength, &begin, &eol, m_bExtEol);
+		if (!line)
+			break;
+		// 先頭行については開始桁位置を考慮する（さらに折り返し関連の対策が必要？）
+		int pos = (pcData->GetStringPtr() == line) ? m_nStartColumn : 0;
+		for (int i = 0; i < lineLength; ++i) {
+			if (line[i] == WCODE::TAB) {
+				const int width = m_nTabWidth - (pos % m_nTabWidth);
+				buffer.append(width, L' ');
+				pos += width;
+			} else {
+				buffer.push_back(line[i]);
+				pos += WCODE::IsZenkaku(line[i]) ? 2 : 1;  //全角文字ずれ対応 2008.10.15 matsumo
 			}
 		}
-		nPosDes += cEol.GetLen();
+		buffer.append(eol.GetValue2(), eol.GetLen());
 	}
-	if( 0 >= nPosDes ){
+	if (buffer.empty())
 		return false;
-	}
-	pDes = new wchar_t[nPosDes + 1];
-	nBgn = 0;
-	nPosDes = 0;
-	/* CRLFで区切られる「行」を返す。CRLFは行長に加えない */
-	while( NULL != ( pLine = GetNextLineW( pcData->GetStringPtr(), pcData->GetStringLength(), &nLineLen, &nBgn, &cEol, m_bExtEol ) ) ){
-		if( 0 < nLineLen ){
-			// 先頭行については開始桁位置を考慮する（さらに折り返し関連の対策が必要？）
-			nPosX = (pcData->GetStringPtr() == pLine)? m_nStartColumn: 0;
-			for( i = 0; i < nLineLen; ++i ){
-				if( TAB == pLine[i]	){
-					nWork = m_nTabWidth - ( nPosX % m_nTabWidth );
-					wmemset( &pDes[nPosDes], L' ', nWork );
-					nPosDes += nWork;
-					nPosX += nWork;
-				}else{
-					pDes[nPosDes] = pLine[i];
-					nPosDes++;
-					nPosX++;
-					if(WCODE::IsZenkaku(pLine[i])) nPosX++;		//全角文字ずれ対応 2008.10.15 matsumo
-				}
-			}
-		}
-		wmemcpy( &pDes[nPosDes], cEol.GetValue2(), cEol.GetLen() );
-		nPosDes += cEol.GetLen();
-	}
-	pDes[nPosDes] = L'\0';
-
-	pcData->SetString( pDes, nPosDes );
-	delete [] pDes;
-	pDes = NULL;
+	pcData->SetString(buffer.c_str(), buffer.length());
 	return true;
 }


### PR DESCRIPTION
# PR の目的

#1631 の別案です。

##  カテゴリ

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

#1631 を参照ください。

## <!-- 自明なら省略可 --> PR のメリット

- "Bug" が1つ減ります。
- <del>Code Smells が8つ減ります。</del>よく見たら7つでした。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

- あらかじめ計算したバッファ長をまとめて確保する方式から std::wstring へと移行したため、新たにメモリの再確保が発生します。変換対象文字列がGB単位である場合などではパフォーマンスに影響するかもしれません。
- 独断と偏見をもってシステムハンガリアン記法を捨てています。

## <!-- 必須 --> テスト内容

手動テストは不要だと思います。

## <!-- なければ省略可 --> 関連 issue, PR

#1631