### PR TITLE
CMemory::AppendRawData()でAllocBuffer条件ミスを修正

### DIFF
--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -227,7 +227,7 @@ void CMemory::SetRawDataHoldBuffer( const CMemory& cmemData )
 void CMemory::AppendRawData( const void* pData, size_t nDataLen )
 {
 	// メモリが足りなければ確保する
-	if( m_nDataBufSize <= m_nRawLen + nDataLen ){
+	if( m_nDataBufSize <= m_nRawLen + nDataLen + sizeof(wchar_t) ){
 		AllocBuffer( m_nRawLen + nDataLen );
 	}
 


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
行データが読み込まれないことがある不具合を修正します。

#1618 での変更による不具合です。

5ch情報part19 297-301より

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
CMemory::AppendRawDataでAllocBufferを実行しなければならない条件でsizeof(wchar_t)を足すのが抜けているため、
ぎりぎり既存バッファに入らないと、
後続の文字列データの追加の部分の条件式ではねられて、追加されない状態になります。

ファイル読み込み、およびGrepでは

https://github.com/sakura-editor/sakura/blob/9713af2ebcfa2921846a1b99aed7b63c96b559e2/sakura_core/io/CFileLoad.cpp#L391

ここの呼び出しで発生しています。

## <!-- わかる範囲で --> PR の影響範囲
ファイル読み込み。CMemoryが使われている箇所ほぼすべて。

ファイル読み込みでは、内部行バッファが拡張されるタイミングで発動する不具合なので、上のほうが正常に読み込まれているように見えても、
ファイルの途中の行でも、後半が切れたりする可能性があります。
特定行が空になる場合は、それ以降の全データが切れて読み込まれます。

この不具合を持ったバージョンを使用するのは強く非推奨です。

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1
手順

ASCII5文字+CRLFの合計7Byteが1行のファイルを用意します。
```
ABCDE [CRLF]
FGHIJ [CRLF]
```

UTF-8(BOMなし)/SJISなどで読み込みます。
修正前は「中身が空の状態」でファイルが読み込まれます。
修正後はファイルの中身が表示されます。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1618 #1641

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
