### PR TITLE
CRunningTimerの使い勝手を改善

### DIFF
--- a/sakura_core/CDicMgr.cpp
+++ b/sakura_core/CDicMgr.cpp
@@ -49,7 +49,7 @@ BOOL CDicMgr::Search(
 )
 {
 #ifdef _DEBUG
-	CRunningTimer cRunningTimer( "CDicMgr::Search" );
+	CRunningTimer cRunningTimer( L"CDicMgr::Search" );
 #endif
 	long	i;
 	const wchar_t*	pszDelimit = L" /// ";

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -239,7 +239,7 @@ DWORD CGrepAgent::DoGrep(
 	bool					bGrepBackup
 )
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CEditView::DoGrep" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CEditView::DoGrep" );
 
 	// 再入不可
 	if( this->m_bGrepRunning ){

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -243,7 +243,7 @@ void CCommandLine::ParseKanjiCodeFromFileName(LPWSTR pszExeFileName, int cchExeF
 */
 void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CCommandLine::Parse" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CCommandLine::Parse" );
 
 	WCHAR	szPath[_MAX_PATH];
 	bool	bFind = false;				// ファイル名発見フラグ

--- a/sakura_core/_main/CControlProcess.cpp
+++ b/sakura_core/_main/CControlProcess.cpp
@@ -115,7 +115,7 @@ std::filesystem::path CControlProcess::GetPrivateIniFileName(const std::wstring&
 */
 bool CControlProcess::InitializeProcess()
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CControlProcess::InitializeProcess" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CControlProcess::InitializeProcess" );
 
 	// アプリケーション実行検出用(インストーラで使用)
 	m_hMutex = ::CreateMutex( NULL, FALSE, GSTR_MUTEX_SAKURA );
@@ -171,12 +171,12 @@ bool CControlProcess::InitializeProcess()
 	CSelectLang::ChangeLang( GetDllShareData().m_Common.m_sWindow.m_szLanguageDll );
 	RefreshString();
 
-	MY_TRACETIME( cRunningTimer, "Before new CControlTray" );
+	MY_TRACETIME( cRunningTimer, L"Before new CControlTray" );
 
 	/* タスクトレイにアイコン作成 */
 	m_pcTray = new CControlTray;
 
-	MY_TRACETIME( cRunningTimer, "After new CControlTray" );
+	MY_TRACETIME( cRunningTimer, L"After new CControlTray" );
 
 	HWND hwnd = m_pcTray->Create( GetProcessInstance() );
 	if( !hwnd ){

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -223,7 +223,7 @@ CControlTray::~CControlTray()
 /* 作成 */
 HWND CControlTray::Create( HINSTANCE hInstance )
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CControlTray::Create" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CControlTray::Create" );
 
 	//同名同クラスのウィンドウが既に存在していたら、失敗
 	m_hInstance = hInstance;

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -73,7 +73,7 @@ CNormalProcess::~CNormalProcess()
 */
 bool CNormalProcess::InitializeProcess()
 {
-	MY_RUNNINGTIMER( cRunningTimer, "NormalProcess::Init" );
+	MY_RUNNINGTIMER( cRunningTimer, L"NormalProcess::Init" );
 
 	/* プロセス初期化の目印 */
 	HANDLE	hMutex = _GetInitializeMutex();	// 2002/2/8 aroka 込み入っていたので分離
@@ -137,15 +137,15 @@ bool CNormalProcess::InitializeProcess()
 	}
 
 	// プラグイン読み込み
-	MY_TRACETIME( cRunningTimer, "Before Init Jack" );
+	MY_TRACETIME( cRunningTimer, L"Before Init Jack" );
 	/* ジャック初期化 */
 	CJackManager::getInstance();
-	MY_TRACETIME( cRunningTimer, "After Init Jack" );
+	MY_TRACETIME( cRunningTimer, L"After Init Jack" );
 
-	MY_TRACETIME( cRunningTimer, "Before Load Plugins" );
+	MY_TRACETIME( cRunningTimer, L"Before Load Plugins" );
 	/* プラグイン読み込み */
 	CPluginManager::getInstance()->LoadAllPlugin();
-	MY_TRACETIME( cRunningTimer, "After Load Plugins" );
+	MY_TRACETIME( cRunningTimer, L"After Load Plugins" );
 
 	// エディタアプリケーションを作成。2007.10.23 kobake
 	// グループIDを取得
@@ -168,7 +168,7 @@ bool CNormalProcess::InitializeProcess()
 	bGrepMode  = CCommandLine::getInstance()->IsGrepMode();
 	bGrepDlg   = CCommandLine::getInstance()->IsGrepDlg();
 
-	MY_TRACETIME( cRunningTimer, "CheckFile" );
+	MY_TRACETIME( cRunningTimer, L"CheckFile" );
 
 	// -1: SetDocumentTypeWhenCreate での強制指定なし
 	const CTypeConfig nType = (fi.m_szDocType[0] == '\0' ? CTypeConfig(-1) : CDocTypeManager().GetDocumentTypeOfExt(fi.m_szDocType));
@@ -478,7 +478,7 @@ void CNormalProcess::OnExitProcess()
 */
 HANDLE CNormalProcess::_GetInitializeMutex() const
 {
-	MY_RUNNINGTIMER( cRunningTimer, "NormalProcess::_GetInitializeMutex" );
+	MY_RUNNINGTIMER( cRunningTimer, L"NormalProcess::_GetInitializeMutex" );
 	HANDLE hMutex;
 	const auto pszProfileName = CCommandLine::getInstance()->GetProfileName();
 	std::wstring strMutexInitName = GSTR_MUTEX_SAKURA_INIT;

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -169,7 +169,7 @@ bool CProcessFactory::IsExistControlProcess()
 */
 bool CProcessFactory::StartControlProcess()
 {
-	MY_RUNNINGTIMER(cRunningTimer,"StartControlProcess" );
+	MY_RUNNINGTIMER(cRunningTimer,L"StartControlProcess" );
 
 	//	プロセスの起動
 	PROCESS_INFORMATION p;

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -85,7 +85,7 @@ int WINAPI wWinMain(
 	::_CrtSetDbgFlag(_CRTDBG_LEAK_CHECK_DF | _CRTDBG_ALLOC_MEM_DF);
 #endif
 
-	MY_RUNNINGTIMER(cRunningTimer, "WinMain" );
+	MY_RUNNINGTIMER(cRunningTimer, L"WinMain" );
 	{
 		// 2014.04.24 DLLの検索パスからカレントディレクトリを削除する
 		::SetDllDirectory( L"" );
@@ -107,7 +107,7 @@ int WINAPI wWinMain(
 	CProcess *process = 0;
 	try{
 		process = aFactory.Create( hInstance, lpCmdLine );
-		MY_TRACETIME( cRunningTimer, "ProcessObject Created" );
+		MY_TRACETIME( cRunningTimer, L"ProcessObject Created" );
 	}
 	catch(...){
 	}

--- a/sakura_core/cmd/CViewCommander_Edit.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit.cpp
@@ -297,7 +297,7 @@ void CViewCommander::Command_UNDO( void )
 		return;
 	}
 
-	MY_RUNNINGTIMER( cRunningTimer, "CViewCommander::Command_UNDO()" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CViewCommander::Command_UNDO()" );
 
 	COpe*		pcOpe = NULL;
 
@@ -554,7 +554,7 @@ void CViewCommander::Command_REDO( void )
 	if( !GetDocument()->m_cDocEditor.IsEnableRedo() ){	/* Redo(やり直し)可能な状態か？ */
 		return;
 	}
-	MY_RUNNINGTIMER( cRunningTimer, "CViewCommander::Command_REDO()" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CViewCommander::Command_REDO()" );
 
 	COpe*		pcOpe = NULL;
 	COpeBlk*	pcOpeBlk;

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -502,7 +502,7 @@ void CViewCommander::Command_PROPERTY_FILE( void )
 		/* 全行データを返すテスト */
 		wchar_t*	pDataAll;
 		int		nDataAllLen;
-		CRunningTimer cRunningTimer( "CViewCommander::Command_PROPERTY_FILE 全行データを返すテスト" );
+		CRunningTimer cRunningTimer( L"CViewCommander::Command_PROPERTY_FILE 全行データを返すテスト" );
 		cRunningTimer.Reset();
 		pDataAll = CDocReader(GetDocument()->m_cDocLineMgr).GetAllData( &nDataAllLen );
 //		MYTRACE( L"全データ取得             (%dバイト) 所要時間(ミリ秒) = %d\n", nDataAllLen, cRunningTimer.Read() );

--- a/sakura_core/debug/CRunningTimer.cpp
+++ b/sakura_core/debug/CRunningTimer.cpp
@@ -23,31 +23,26 @@
 
 #pragma comment(lib, "winmm.lib")
 
-CRunningTimer::TimePoint CRunningTimer::m_initialTime = std::chrono::high_resolution_clock::now();
 int CRunningTimer::m_nNestCount = 0;
+CRunningTimer::TimePoint CRunningTimer::m_initialTime = std::chrono::high_resolution_clock::now();
 
 CRunningTimer::CRunningTimer( std::wstring_view name, OutputStyle style ) :
 	m_timerName( name ),
-	m_nNameOutputWidthMin( 40 ),
 	m_outputStyle( style )
 {
 	Reset();
 
-	if( m_timerName.length() == 0 && m_outputStyle == OutputStyle::Markdown )
-	{
+	if( m_timerName.length() == 0 && m_outputStyle == OutputStyle::Markdown ){
 		// 字下げ位置がわかるように何か文字列を入れておく
 		m_timerName = L"(no name)";
 	}
 
-	m_nNameOutputWidth = m_nNameOutputWidthMin;
-	if( m_nNameOutputWidth < m_timerName.size() )
-	{
+	if( m_nNameOutputWidth < m_timerName.size() ){
 		m_nNameOutputWidth = m_timerName.size();
 	}
 
-	m_nDepth = m_nNestCount++;
-	if( m_nDepth == 0 )
-	{
+	m_nDepth = CRunningTimer::m_nNestCount++;
+	if( m_nDepth == 0 ){
 		OutputHeader();
 	}
 	OutputTrace( m_startTime, TraceType::Enter );
@@ -58,8 +53,7 @@ CRunningTimer::CRunningTimer( std::wstring_view name, OutputStyle style ) :
 CRunningTimer::~CRunningTimer()
 {
 	OutputTrace( GetTime(), TraceType::ExitScope );
-	if( m_nDepth == 0 )
-	{
+	if( m_nDepth == 0 ){
 		OutputFooter();
 	}
 	m_nNestCount--;
@@ -99,59 +93,55 @@ CRunningTimer::TimePoint CRunningTimer::GetTime() const
 
 void CRunningTimer::OutputHeader() const
 {
-	if( m_outputStyle == OutputStyle::Markdown )
-	{
+	if( m_outputStyle == OutputStyle::Markdown ){
 		Output( L"| timestamp (s) | %-*s | time (ms) | diff (ms) | message\n", m_nNameOutputWidth, L"name" );
 		Output( L"|--------------:|-%.*s-|----------:|----------:|--------\n", m_nNameOutputWidth, L"----------------------------------------------------------------------------------------------------" );
-	}
-	else
-	{
-		;
+	}else{
+		// 従来形式では出力するものなし
 	}
 }
 
 void CRunningTimer::OutputFooter() const
 {
-	if( m_outputStyle == OutputStyle::Markdown )
-	{
+	if( m_outputStyle == OutputStyle::Markdown ){
 		Output( L"\n" );
-	}
-	else
-	{
-		;
+	}else{
+		// 従来形式では出力するものなし
 	}
 }
 
 void CRunningTimer::OutputTrace( TimePoint currentTime, TraceType traceType, std::wstring_view msg ) const
 {
-	if( m_outputStyle == OutputStyle::Markdown )
-	{
-		msg =
-			(traceType == TraceType::Enter) ? L"== Enter ==" :
-			(traceType == TraceType::ExitScope) ? L"== Exit Scope ==" :
-			msg;
+	if( m_outputStyle == OutputStyle::Markdown ){
+		if( traceType == TraceType::Enter ){
+			msg = L"== Enter ==";
+		}else if( traceType == TraceType::ExitScope ){
+			msg = L"== Exit Scope ==";
+		}else{
+			//msg = msg;
+		}
+
 		Output( L"| %13.6f | %.*s%-*s | %9.3f | %9.3f | %s\n",
-			GetElapsedTimeInSeconds( m_initialTime, currentTime ),
+			GetElapsedTimeInSeconds( CRunningTimer::m_initialTime, currentTime ),
 			m_nDepth * 2, L"_ _ _ _ _ _ _ _ _ _ ", (m_nNameOutputWidth - (m_nDepth * 2)), m_timerName.c_str(),
 			GetElapsedTimeInSeconds( m_startTime, currentTime ) * 1000.0,
 			GetElapsedTimeInSeconds( m_lastTime, currentTime ) * 1000.0,
 			msg.data() );
-	}
-	else
-	{
-		msg =
-			(traceType == TraceType::Enter) ? L"Enter" :
-			(traceType == TraceType::ExitScope) ? L"Exit Scope" :
-			msg;
-		if( traceType == TraceType::Enter )
-		{
+	}else{
+		if( traceType == TraceType::Enter ){
+			msg = L"Enter";
+		}else if( traceType == TraceType::ExitScope ){
+			msg = L"Exit Scope";
+		}else{
+			//msg = msg;
+		}
+
+		if( traceType == TraceType::Enter ){
 			Output( L"%3d:\"%s\" : %s\n",
 				m_nDepth,
 				m_timerName.c_str(),
 				msg.data() );
-		}
-		else
-		{
+		}else{
 			Output( L"%3d:\"%s\", %d㍉秒 : %s\n",
 				m_nDepth,
 				m_timerName.c_str(),

--- a/sakura_core/debug/CRunningTimer.cpp
+++ b/sakura_core/debug/CRunningTimer.cpp
@@ -21,8 +21,6 @@
 #include "_main/global.h"
 #include "debug/Debug2.h"
 
-#ifdef _DEBUG
-
 #pragma comment(lib, "winmm.lib")
 
 CRunningTimer::TimePoint CRunningTimer::m_initialTime = std::chrono::high_resolution_clock::now();
@@ -175,5 +173,3 @@ void CRunningTimer::Output( std::wstring_view fmt, ... ) const
 
 	OutputDebugStringW( str.data() );
 }
-
-#endif

--- a/sakura_core/debug/CRunningTimer.cpp
+++ b/sakura_core/debug/CRunningTimer.cpp
@@ -17,6 +17,7 @@
 
 #include "StdAfx.h"
 #include "debug/CRunningTimer.h"
+#include <stdarg.h>
 
 int CRunningTimer::m_nNestCount = 0;
 CRunningTimer::TimePoint CRunningTimer::m_initialTime = std::chrono::high_resolution_clock::now();
@@ -63,7 +64,7 @@ void CRunningTimer::Reset()
 	m_lastTime = m_startTime;
 }
 
-uint32_t CRunningTimer::Read()
+uint32_t CRunningTimer::Read() const
 {
 	return (uint32_t)(GetElapsedTimeInSeconds( m_startTime, GetTime() ) * 1000.0);
 }
@@ -79,21 +80,6 @@ void CRunningTimer::WriteTrace( std::wstring_view msg )
 void CRunningTimer::WriteTrace( int32_t n )
 {
 	WriteTraceFormat( L"%d", n );
-}
-
-void CRunningTimer::WriteTraceFormat( std::wstring_view fmt, ... )
-{
-	auto currentTime = GetTime();
-
-	va_list args;
-	va_start( args, fmt );
-
-	std::wstring msg;
-	vstrprintf( msg, fmt.data(), args );
-
-	va_end( args );
-
-	WriteTraceInternal( currentTime, TraceType::Normal, msg );
 }
 
 double CRunningTimer::GetElapsedTimeInSeconds( TimePoint from, TimePoint to )
@@ -154,7 +140,7 @@ void CRunningTimer::OutputTrace( TimePoint currentTime, TraceType traceType, std
 		}else if( traceType == TraceType::ExitScope ){
 			msg = L"== Exit Scope ==";
 		}else{
-			//msg = msg;
+			//msg = msg
 		}
 
 		Output( L"| %13.6f | %.*s%-*s | %9.3f | %9.3f | %s\n",
@@ -169,7 +155,7 @@ void CRunningTimer::OutputTrace( TimePoint currentTime, TraceType traceType, std
 		}else if( traceType == TraceType::ExitScope ){
 			msg = L"Exit Scope";
 		}else{
-			//msg = msg;
+			//msg = msg
 		}
 
 		if( traceType == TraceType::Enter ){

--- a/sakura_core/debug/CRunningTimer.cpp
+++ b/sakura_core/debug/CRunningTimer.cpp
@@ -16,12 +16,7 @@
 */
 
 #include "StdAfx.h"
-#include <MMSystem.h>
 #include "debug/CRunningTimer.h"
-#include "_main/global.h"
-#include "debug/Debug2.h"
-
-#pragma comment(lib, "winmm.lib")
 
 int CRunningTimer::m_nNestCount = 0;
 CRunningTimer::TimePoint CRunningTimer::m_initialTime = std::chrono::high_resolution_clock::now();

--- a/sakura_core/debug/CRunningTimer.cpp
+++ b/sakura_core/debug/CRunningTimer.cpp
@@ -74,7 +74,7 @@ uint32_t CRunningTimer::Read() const
 */
 void CRunningTimer::WriteTrace( std::wstring_view msg )
 {
-	WriteTraceFormat( L"%s", msg );
+	WriteTraceFormat( L"%s", msg.data() );
 }
 
 void CRunningTimer::WriteTrace( int32_t n )
@@ -82,14 +82,14 @@ void CRunningTimer::WriteTrace( int32_t n )
 	WriteTraceFormat( L"%d", n );
 }
 
-double CRunningTimer::GetElapsedTimeInSeconds( TimePoint from, TimePoint to )
-{
-	return (double)std::chrono::duration_cast<std::chrono::nanoseconds>( to - from ).count() / 1000.0 / 1000.0 / 1000.0;
-}
-
-CRunningTimer::TimePoint CRunningTimer::GetTime() const
+CRunningTimer::TimePoint CRunningTimer::GetTime()
 {
 	return std::chrono::high_resolution_clock::now();
+}
+
+double CRunningTimer::GetElapsedTimeInSeconds( TimePoint from, TimePoint to )
+{
+	return std::chrono::duration<double>(to - from).count();
 }
 
 void CRunningTimer::WriteTraceInternal( TimePoint currentTime, TraceType traceType, std::wstring_view msg )

--- a/sakura_core/debug/CRunningTimer.cpp
+++ b/sakura_core/debug/CRunningTimer.cpp
@@ -27,24 +27,21 @@
 
 int CRunningTimer::m_nNestCount = 0;
 
-CRunningTimer::CRunningTimer( const char* pszText )
+CRunningTimer::CRunningTimer( std::wstring_view name ) :
+	m_timerName( name )
 {
 	::QueryPerformanceFrequency( &m_nPerformanceFrequency );
 
 	Reset();
 
-	if( pszText != NULL )
-		strcpy( m_szText, pszText );
-	else
-		m_szText[0] = '\0';
-	m_nDeapth = m_nNestCount++;
-	OutputTrace( m_nStartTime, "Enter", OutputTiming::Enter );
+	m_nDepth = m_nNestCount++;
+	OutputTrace( m_nStartTime, L"Enter", OutputTiming::Enter );
 	return;
 }
 
 CRunningTimer::~CRunningTimer()
 {
-	OutputTrace( GetTime(), "Exit Scope" );
+	OutputTrace( GetTime(), L"Exit Scope" );
 	m_nNestCount--;
 	return;
 }
@@ -62,20 +59,20 @@ DWORD CRunningTimer::Read()
 /*!
 	@date 2002.10.15 genta
 */
-void CRunningTimer::WriteTrace(const char* msg) const
+void CRunningTimer::WriteTrace( std::wstring_view msg ) const
 {
 	OutputTrace( GetTime(), msg );
 }
 
-void CRunningTimer::OutputTrace( double nCurrentTime, const char* msg, OutputTiming timing ) const
+void CRunningTimer::OutputTrace( double nCurrentTime, std::wstring_view msg, OutputTiming timing ) const
 {
 	if( timing == OutputTiming::Enter )
 	{
-		Output( L"%3d:\"%hs\" : %hs \n", m_nDeapth, m_szText, msg );
+		Output( L"%3d:\"%s\" : %s \n", m_nDepth, m_timerName.c_str(), msg.data() );
 	}
 	else
 	{
-		Output( L"%3d:\"%hs\", %d㍉秒 : %hs\n", m_nDeapth, m_szText, (int)(nCurrentTime - m_nStartTime), msg );
+		Output( L"%3d:\"%s\", %d㍉秒 : %s\n", m_nDepth, m_timerName.c_str(), (int)(nCurrentTime - m_nStartTime), msg.data() );
 	}
 }
 

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -104,19 +104,19 @@ public:
 	uint32_t Read() const;
 
 	/*!
-		現在の経過時間に対してログ書き込む
+		現在の経過時間でログを書き込む
 		@param[in]	msg		ログのメッセージ欄に出力する文字列
 	*/
 	void WriteTrace( std::wstring_view msg = L"" );
 
 	/*!
-		現在の経過時間に対してログ書き込む
+		現在の経過時間でログを書き込む
 		@param[in]	n		ログのメッセージ欄に出力する数値
 	*/
 	void WriteTrace( int32_t n );
 
 	/*!
-		現在の経過時間に対してログ書き込む
+		現在の経過時間でログを書き込む
 		@param[in]	fmt		書式文字列
 		@param[in]	...		書式文字列に対応する引数
 	*/
@@ -146,10 +146,11 @@ protected:
 	static int m_nNestCount;
 	static TimePoint m_initialTime;				// タイムスタンプ基準時間
 
+	static TimePoint GetTime();
 	static double GetElapsedTimeInSeconds( TimePoint from, TimePoint to );
+
 	void WriteTraceInternal( TimePoint currentTime, TraceType traceType, std::wstring_view msg = L"" );
 	void FlushPendingTraces();
-	TimePoint GetTime() const;
 	void OutputHeader() const;
 	void OutputFooter() const;
 	void OutputTrace( TimePoint currentTime, TraceType traceType, std::wstring_view msg ) const;

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -41,8 +41,16 @@
 #include <string_view>
 #include <chrono>
 
-// RunningTimerで経過時間の測定を行う場合にはコメントを外してください
+// 本番コードに組み込まれている時間計測の結果を出力ペインに出したい時にコメントを外して下さい
 //#define TIME_MEASURE
+
+#if defined(TIME_MEASURE)
+  #define MY_TRACETIME(c,m) (c).WriteTrace(m)
+  #define MY_RUNNINGTIMER(c,m) CRunningTimer c(m, CRunningTimer::OutputStyle::Conventional)
+#else
+  #define MY_TRACETIME(c,m)
+  #define MY_RUNNINGTIMER(c,m)
+#endif
 
 /*-----------------------------------------------------------------------
 クラスの宣言
@@ -50,9 +58,9 @@
 /*!
 	@brief 処理所要時間の計測クラス
 
-	定義の切り替えのみでタイマーのON/OFFを行えるようにするため，
-	このクラスを直接使わず，後ろにあるMY_RUNNINGTIMERとMY_TRACETIMEを
-	使うこと．
+	本番コードに時間計測箇所を組み込む場合には、
+	このクラスを直接使わず代わりにMY_RUNNINGTIMER,MY_TRACETIMEマクロを使用して下さい。
+	(計測が必要な時以外で出力ペインを計測ログが埋め尽くさないようにするため)
 
 	@date 2002/10/16  genta WriteTrace及びマクロ追加
 */
@@ -99,18 +107,6 @@ protected:
 	void OutputTrace( TimePoint currentTime, TraceType traceType, std::wstring_view msg = L"" ) const;
 	void Output( std::wstring_view fmt, ... ) const;
 
-#ifdef _DEBUG
 	static int m_nNestCount;
-#endif
 };
-
-//	Oct. 16, 2002 genta
-//	#ifdef _DEBUG～#endifで逐一囲まなくても簡単にタイマーのON/OFFを行うためのマクロ
-#if defined(_DEBUG) && defined(TIME_MEASURE)
-  #define MY_TRACETIME(c,m) (c).WriteTrace(m)
-  #define MY_RUNNINGTIMER(c,m) CRunningTimer c(m, CRunningTimer::OutputStyle::Conventional)
-#else
-  #define MY_TRACETIME(c,m)
-  #define MY_RUNNINGTIMER(c,m)
-#endif
 #endif /* SAKURA_CRUNNINGTIMER_B4A1B7C4_EA83_41F2_9132_21DE3A57470D_H_ */

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -36,7 +36,6 @@
 #define SAKURA_CRUNNINGTIMER_B4A1B7C4_EA83_41F2_9132_21DE3A57470D_H_
 #pragma once
 
-#include <windows.h>
 #include <string>
 #include <string_view>
 #include <chrono>
@@ -46,7 +45,7 @@
 
 #if defined(TIME_MEASURE)
   #define MY_TRACETIME(c,m) (c).WriteTrace(m)
-  #define MY_RUNNINGTIMER(c,m) CRunningTimer c(m, CRunningTimer::OutputStyle::Conventional)
+  #define MY_RUNNINGTIMER(c,m) CRunningTimer c(m, CRunningTimer::OutputMode::OnWriteTrace, CRunningTimer::OutputStyle::Conventional)
 #else
   #define MY_TRACETIME(c,m)
   #define MY_RUNNINGTIMER(c,m)
@@ -67,33 +66,83 @@
 class CRunningTimer
 {
 public:
+	/*! @brief ログ出力モード */
+	enum class OutputMode {
+		// WriteTraceを呼び出す度にログ出力します。
+		// 計測オーバーヘッドは大きめです。(Release:200us程度 Debug:400us程度)
+		OnWriteTrace,
+
+		// 計測終了時(インスタンス破棄時)にまとめてログ出力します。
+		// 計測オーバーヘッドは小さめです。(Release:5us程度 Debug:50us程度)
+		// 入れ子で計測する場合においてログの出力順がWriteTraceの呼び出し順とならないため注意して下さい。
+		OnExitScope
+	};
+
+	/*! @brief ログ出力形式 */
 	enum class OutputStyle { Conventional, Markdown };
 
-	/*
-	||  Constructors
+	/*!
+		@param[in]	name	タイマー名称
+		@param[in]	mode	ログの出力モード
+		@param[in]	name	ログの出力形式
 	*/
-	CRunningTimer( std::wstring_view name = L"", OutputStyle style = OutputStyle::Markdown );
+	CRunningTimer( std::wstring_view name = L"", OutputMode mode = OutputMode::OnWriteTrace, OutputStyle style = OutputStyle::Markdown );
 	~CRunningTimer();
 
-	/*
-	|| 関数
+	/*!
+		経過時間を0に戻す
 	*/
 	void Reset();
-	DWORD Read();
+
+	/*!
+		現在の経過時間を取得
+		@return 経過時間(ms)
+	*/
+	uint32_t Read();
+
+	/*!
+		現在の経過時間に対してログ書き込む
+		@param[in]	msg		ログのメッセージ欄に出力する文字列
+	*/
 	void WriteTrace( std::wstring_view msg = L"" );
+
+	/*!
+		現在の経過時間に対してログ書き込む
+		@param[in]	n		ログのメッセージ欄に出力する数値
+	*/
+	void WriteTrace( int32_t n );
+
+	/*!
+		現在の経過時間に対してログ書き込む
+		@param[in]	fmt		書式文字列
+		@param[in]	...		書式文字列に対応する引数
+	*/
+	void WriteTraceFormat( std::wstring_view fmt, ... );
 
 protected:
 	enum class TraceType { Normal, Enter, ExitScope };
 	using TimePoint = std::chrono::high_resolution_clock::time_point;
+	struct TraceEntry {
+		TraceEntry( TimePoint timePoint, TraceType traceType, std::wstring_view msg ) :
+			m_timePoint( timePoint ),
+			m_traceType( traceType ),
+			m_msg( msg )
+		{}
+		TimePoint		m_timePoint;
+		TraceType		m_traceType;
+		std::wstring	m_msg;
+	};
 
 	static int m_nNestCount;
 	static TimePoint m_initialTime;				// タイムスタンプ基準時間
 
 	static double GetElapsedTimeInSeconds( TimePoint from, TimePoint to );
+	void WriteTraceInternal( TimePoint currentTime, TraceType traceType, std::wstring_view msg = L"" );
+	void FlushPendingTraces();
 	TimePoint GetTime() const;
 	void OutputHeader() const;
 	void OutputFooter() const;
-	void OutputTrace( TimePoint currentTime, TraceType traceType, std::wstring_view msg = L"" ) const;
+	void OutputTrace( TimePoint currentTime, TraceType traceType, std::wstring_view msg ) const;
 	void Output( std::wstring_view fmt, ... ) const;
 
 private:
@@ -101,7 +150,9 @@ private:
 	TimePoint		m_lastTime;					// 最後に出力した時間
 	std::wstring	m_timerName;				// タイマー名
 	int				m_nDepth;					// このオブジェクトのネストの深さ
+	OutputMode		m_outputMode;				// ログの出力モード
 	OutputStyle		m_outputStyle;				// ログの出力形式
 	size_t			m_nNameOutputWidth = 40;	// タイマー名出力幅(文字数)(初期値は最小幅)
+	std::vector<TraceEntry> m_pendingTraces;	// 出力保留中の情報
 };
 #endif /* SAKURA_CRUNNINGTIMER_B4A1B7C4_EA83_41F2_9132_21DE3A57470D_H_ */

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -15,8 +15,8 @@
 	warranty. In no event will the authors be held liable for any damages
 	arising from the use of this software.
 
-	Permission is granted to anyone to use this software for any purpose, 
-	including commercial applications, and to alter it and redistribute it 
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
 	freely, subject to the following restrictions:
 
 		1. The origin of this software must not be misrepresented;
@@ -25,7 +25,7 @@
 		   in the product documentation would be appreciated but is
 		   not required.
 
-		2. Altered source versions must be plainly marked as such, 
+		2. Altered source versions must be plainly marked as such,
 		   and must not be misrepresented as being the original software.
 
 		3. This notice may not be removed or altered from any source
@@ -84,21 +84,10 @@ public:
 
 protected:
 	enum class TraceType { Normal, Enter, ExitScope };
-	typedef std::chrono::high_resolution_clock::time_point TimePoint;
+	using TimePoint = std::chrono::high_resolution_clock::time_point;
 
+	static int m_nNestCount;
 	static TimePoint m_initialTime;				// タイムスタンプ基準時間
-
-	const size_t	m_nNameOutputWidthMin;		// タイマー名最低出力幅(文字数)
-
-	TimePoint		m_startTime;				// 計測開始時間
-	TimePoint		m_lastTime;					// 最後に出力した時間
-	std::wstring	m_timerName;				// タイマー名
-	int				m_nDepth;					// このオブジェクトのネストの深さ
-	OutputStyle		m_outputStyle;				// ログの出力形式
-	size_t			m_nNameOutputWidth;			// タイマー名出力幅(文字数)
-	LARGE_INTEGER	m_nPerformanceFrequency;	// 計時用
-
-	enum class OutputTiming { Normal, Enter };
 
 	static double GetElapsedTimeInSeconds( TimePoint from, TimePoint to );
 	TimePoint GetTime() const;
@@ -107,6 +96,12 @@ protected:
 	void OutputTrace( TimePoint currentTime, TraceType traceType, std::wstring_view msg = L"" ) const;
 	void Output( std::wstring_view fmt, ... ) const;
 
-	static int m_nNestCount;
+private:
+	TimePoint		m_startTime;				// 計測開始時間
+	TimePoint		m_lastTime;					// 最後に出力した時間
+	std::wstring	m_timerName;				// タイマー名
+	int				m_nDepth;					// このオブジェクトのネストの深さ
+	OutputStyle		m_outputStyle;				// ログの出力形式
+	size_t			m_nNameOutputWidth = 40;	// タイマー名出力幅(文字数)(初期値は最小幅)
 };
 #endif /* SAKURA_CRUNNINGTIMER_B4A1B7C4_EA83_41F2_9132_21DE3A57470D_H_ */

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -37,6 +37,9 @@
 #pragma once
 
 #include <windows.h>
+#include <string>
+#include <string_view>
+
 // RunningTimerで経過時間の測定を行う場合にはコメントを外してください
 //#define TIME_MEASURE
 
@@ -58,7 +61,7 @@ public:
 	/*
 	||  Constructors
 	*/
-	CRunningTimer( const char* Text = NULL);
+	CRunningTimer( std::wstring_view name = L"" );
 	~CRunningTimer();
 
 	/*
@@ -67,18 +70,18 @@ public:
 	void Reset();
 	DWORD Read();
 	
-	void WriteTrace(const char* msg = "") const;
+	void WriteTrace( std::wstring_view msg = L"" ) const;
 
 protected:
 	double			m_nStartTime;				// 計測開始時間(ms)
-	char			m_szText[100];	//!< タイマー名
-	int				m_nDeapth;	//!< このオブジェクトのネストの深さ
+	std::wstring	m_timerName;				// タイマー名
+	int				m_nDepth;					// このオブジェクトのネストの深さ
 	LARGE_INTEGER	m_nPerformanceFrequency;	// 計時用
 
 	enum class OutputTiming { Normal, Enter };
 
 	double GetTime() const;
-	void OutputTrace( double time, const char* msg, OutputTiming timing = OutputTiming::Normal ) const;
+	void OutputTrace( double time, std::wstring_view msg, OutputTiming timing = OutputTiming::Normal ) const;
 	void Output( std::wstring_view fmt, ... ) const;
 
 #ifdef _DEBUG

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -70,9 +70,16 @@ public:
 	void WriteTrace(const char* msg = "") const;
 
 protected:
-	DWORD	m_nStartTime;
-	char	m_szText[100];	//!< タイマー名
-	int		m_nDeapth;	//!< このオブジェクトのネストの深さ
+	double			m_nStartTime;				// 計測開始時間(ms)
+	char			m_szText[100];	//!< タイマー名
+	int				m_nDeapth;	//!< このオブジェクトのネストの深さ
+	LARGE_INTEGER	m_nPerformanceFrequency;	// 計時用
+
+	enum class OutputTiming { Normal, Enter };
+
+	double GetTime() const;
+	void OutputTrace( double time, const char* msg, OutputTiming timing = OutputTiming::Normal ) const;
+	void Output( std::wstring_view fmt, ... ) const;
 
 #ifdef _DEBUG
 	static int m_nNestCount;

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -36,9 +36,11 @@
 #define SAKURA_CRUNNINGTIMER_B4A1B7C4_EA83_41F2_9132_21DE3A57470D_H_
 #pragma once
 
+#include "util/string_ex.h"
 #include <string>
 #include <string_view>
 #include <chrono>
+#include <vector>
 
 // 本番コードに組み込まれている時間計測の結果を出力ペインに出したい時にコメントを外して下さい
 //#define TIME_MEASURE
@@ -87,6 +89,7 @@ public:
 		@param[in]	name	ログの出力形式
 	*/
 	CRunningTimer( std::wstring_view name = L"", OutputMode mode = OutputMode::OnWriteTrace, OutputStyle style = OutputStyle::Markdown );
+
 	~CRunningTimer();
 
 	/*!
@@ -98,7 +101,7 @@ public:
 		現在の経過時間を取得
 		@return 経過時間(ms)
 	*/
-	uint32_t Read();
+	uint32_t Read() const;
 
 	/*!
 		現在の経過時間に対してログ書き込む
@@ -117,7 +120,14 @@ public:
 		@param[in]	fmt		書式文字列
 		@param[in]	...		書式文字列に対応する引数
 	*/
-	void WriteTraceFormat( std::wstring_view fmt, ... );
+	template <typename... T>
+	void WriteTraceFormat( std::wstring_view fmt, T... args )
+	{
+		auto currentTime = GetTime();
+		std::wstring msg;
+		strprintf( msg, fmt.data(), args... );
+		WriteTraceInternal( currentTime, TraceType::Normal, msg );
+	}
 
 protected:
 	enum class TraceType { Normal, Enter, ExitScope };

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -39,6 +39,7 @@
 #include <windows.h>
 #include <string>
 #include <string_view>
+#include <chrono>
 
 // RunningTimerで経過時間の測定を行う場合にはコメントを外してください
 //#define TIME_MEASURE
@@ -69,19 +70,24 @@ public:
 	*/
 	void Reset();
 	DWORD Read();
-	
+
 	void WriteTrace( std::wstring_view msg = L"" ) const;
 
 protected:
-	double			m_nStartTime;				// 計測開始時間(ms)
+	typedef std::chrono::high_resolution_clock::time_point TimePoint;
+
+	static TimePoint m_initialTime;				// タイムスタンプ基準時間
+
+	TimePoint		m_startTime;				// 計測開始時間
 	std::wstring	m_timerName;				// タイマー名
 	int				m_nDepth;					// このオブジェクトのネストの深さ
 	LARGE_INTEGER	m_nPerformanceFrequency;	// 計時用
 
 	enum class OutputTiming { Normal, Enter };
 
-	double GetTime() const;
-	void OutputTrace( double time, std::wstring_view msg, OutputTiming timing = OutputTiming::Normal ) const;
+	static double GetElapsedTimeInSeconds( TimePoint from, TimePoint to );
+	TimePoint GetTime() const;
+	void OutputTrace( TimePoint currentTime, std::wstring_view msg, OutputTiming timing = OutputTiming::Normal ) const;
 	void Output( std::wstring_view fmt, ... ) const;
 
 #ifdef _DEBUG

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -174,7 +174,7 @@ CEditDoc::CEditDoc(CEditApp* pcApp)
 , m_nCommandExecNum( 0 )			/* コマンド実行回数 */
 , m_hBackImg(NULL)
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CEditDoc::CEditDoc" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CEditDoc::CEditDoc" );
 
 	// レイアウト管理情報の初期化
 	m_cLayoutMgr.Create( this, &m_cDocLineMgr );
@@ -420,7 +420,7 @@ void CEditDoc::InitAllView( void )
 */
 BOOL CEditDoc::Create( CEditWnd* pcEditWnd )
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CEditDoc::Create" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CEditDoc::Create" );
 
 	m_pcEditWnd = pcEditWnd;
 
@@ -429,7 +429,7 @@ BOOL CEditDoc::Create( CEditWnd* pcEditWnd )
 
 	SetBackgroundImage();
 
-	MY_TRACETIME( cRunningTimer, "End: PropSheet" );
+	MY_TRACETIME( cRunningTimer, L"End: PropSheet" );
 
 	return TRUE;
 }

--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -123,7 +123,7 @@ void CLayoutMgr::SetLayoutInfo(
 	CCharWidthCache&	cache
 )
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CLayoutMgr::SetLayoutInfo" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CLayoutMgr::SetLayoutInfo" );
 
 	assert_warning( (!bDoLayout && m_nMaxLineKetas == nMaxLineKetas) || bDoLayout );
 	assert_warning( (!bDoLayout && m_nTabSpace == refType.m_nTabSpace) || bDoLayout );
@@ -616,7 +616,7 @@ CLayout* CLayoutMgr::DeleteLayoutAsLogical(
 /* 論理行が挿入された場合は０より大きい行数 */
 void CLayoutMgr::ShiftLogicalLineNum( CLayout* pLayoutPrev, CLogicInt nShiftLines )
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CLayoutMgr::ShiftLogicalLineNum" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CLayoutMgr::ShiftLogicalLineNum" );
 
 	CLayout* pLayout;
 	if( 0 == nShiftLines ){

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -357,7 +357,7 @@ void CLayoutMgr::_OnLine1(SLayoutWork* pWork)
 */
 void CLayoutMgr::_DoLayout(bool bBlockingHook)
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CLayoutMgr::_DoLayout" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CLayoutMgr::_DoLayout" );
 
 	/*	表示上のX位置
 		2004.03.28 Moca nPosXはインデント幅を含むように変更(TAB位置調整のため)

--- a/sakura_core/doc/logic/CDocLineMgr.cpp
+++ b/sakura_core/doc/logic/CDocLineMgr.cpp
@@ -162,7 +162,7 @@ const CDocLine* CDocLineMgr::GetLine( CLogicInt nLine ) const
 	  || m_nLines - nLine < nPrevToLineNumDiff
 	){
 		if( m_pCodePrevRefer == NULL ){
-			MY_RUNNINGTIMER( cRunningTimer, "CDocLineMgr::GetLine() 	m_pCodePrevRefer == NULL" );
+			MY_RUNNINGTIMER( cRunningTimer, L"CDocLineMgr::GetLine() 	m_pCodePrevRefer == NULL" );
 		}
 
 		if( nLine < (m_nLines / 2) ){

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -110,7 +110,7 @@ CMutex& CShareData::GetMutexShareWork(){
 */
 bool CShareData::InitShareData()
 {
-	MY_RUNNINGTIMER(cRunningTimer,"CShareData::InitShareData" );
+	MY_RUNNINGTIMER(cRunningTimer,L"CShareData::InitShareData" );
 
 	m_hwndTraceOutSource = NULL;	// 2006.06.26 ryoji
 

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -491,7 +491,7 @@ MacroFuncInfo CSMacroMgr::m_MacroFuncInfoArr[] =
 */
 CSMacroMgr::CSMacroMgr()
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CSMacroMgr::CSMacroMgr" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CSMacroMgr::CSMacroMgr" );
 	
 	m_pShareData = &GetDllShareData();
 	

--- a/sakura_core/uiparts/CImageListMgr.cpp
+++ b/sakura_core/uiparts/CImageListMgr.cpp
@@ -148,7 +148,7 @@ HBITMAP ConvertTo32bppBMP(HBITMAP hbmpSrc)
 */
 bool CImageListMgr::Create(HINSTANCE hInstance)
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CImageListMgr::Create" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CImageListMgr::Create" );
 	if( m_hIconBitmap != NULL ){	//	既に構築済みなら無視する
 		return true;
 	}

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1201,7 +1201,7 @@ bool CEditView::IsCurrentPositionURL(
 	std::wstring*		pstrURL		//!< [out] URL文字列受け取り先。NULLを指定した場合はURL文字列を受け取らない。
 )
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CEditView::IsCurrentPositionURL" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CEditView::IsCurrentPositionURL" );
 
 	// URLを強調表示するかどうかチェックする	// 2009.05.27 ryoji
 	bool bDispUrl = CTypeSupport(this,COLORIDX_URL).IsDisp();

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -74,7 +74,7 @@ void CEditView::InsertData_CEditView(
 )
 {
 #ifdef _DEBUG
-	MY_RUNNINGTIMER( cRunningTimer, "CEditView::InsertData_CEditView" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CEditView::InsertData_CEditView" );
 #endif
 
 	//2007.10.18 kobake COpe処理をここにまとめる
@@ -359,7 +359,7 @@ void CEditView::DeleteData2(
 )
 {
 #ifdef _DEBUG
-	MY_RUNNINGTIMER( cRunningTimer, "CEditView::DeleteData(1)" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CEditView::DeleteData(1)" );
 #endif
 	const wchar_t*	pLine;
 	CLogicInt		nLineLen;
@@ -442,7 +442,7 @@ void CEditView::DeleteData(
 )
 {
 #ifdef _DEBUG
-	MY_RUNNINGTIMER( cRunningTimer, "CEditView::DeleteData(2)" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CEditView::DeleteData(2)" );
 #endif
 	const wchar_t*	pLine;
 	CLogicInt		nLineLen;

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -585,7 +585,7 @@ HWND CEditWnd::Create(
 	int				nGroup		//!< [in] グループID
 )
 {
-	MY_RUNNINGTIMER( cRunningTimer, "CEditWnd::Create" );
+	MY_RUNNINGTIMER( cRunningTimer, L"CEditWnd::Create" );
 
 	/* 共有データ構造体のアドレスを返す */
 	m_pShareData = &GetDllShareData();
@@ -683,7 +683,7 @@ HWND CEditWnd::Create(
 	hWndArr[1] = NULL;
 	m_cSplitterWnd.SetChildWndArr( hWndArr );
 
-	MY_TRACETIME( cRunningTimer, "View created" );
+	MY_TRACETIME( cRunningTimer, L"View created" );
 
 	// -- -- -- -- 各種バー作成 -- -- -- -- //
 

--- a/tests/unittests/test-crunningtimer.cpp
+++ b/tests/unittests/test-crunningtimer.cpp
@@ -1,0 +1,59 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+#include "debug/CRunningTimer.h"
+
+/*!
+ * @brief 基本動作
+ */
+TEST( CRunningTimer, Basic )
+{
+	CRunningTimer t0;
+	CRunningTimer t1( L"t1" );
+	CRunningTimer t2( L"t2", CRunningTimer::OutputMode::OnExitScope );
+	CRunningTimer t3( L"t3", CRunningTimer::OutputMode::OnWriteTrace, CRunningTimer::OutputStyle::Conventional );
+	std::vector<CRunningTimer*> vt { &t1, &t2, &t3 };
+	for( auto t : vt ){
+		t->WriteTrace();
+		t->WriteTrace( L"test" );
+		t->WriteTrace( 1234567890 );
+		t->WriteTraceFormat( L"%s:%d", L"test", 1234567890 );
+		t->Read();
+		t->Reset();
+	}
+}
+
+/*!
+ * @brief 長い文字列の入力
+ */
+TEST( CRunningTimer, LongString )
+{
+	auto str = L"012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+	CRunningTimer t( str );
+	t.WriteTrace( str );
+	t.WriteTrace( INT32_MAX );
+	t.WriteTrace( INT32_MIN );
+	t.WriteTraceFormat( L"%s%s%s", str, str, str );
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -109,6 +109,7 @@
     <ClCompile Include="test-cdocline.cpp" />
     <ClCompile Include="test-cdoclinemgr.cpp" />
     <ClCompile Include="test-csearchagent.cpp" />
+    <ClCompile Include="test-crunningtimer.cpp" />
     <ClCompile Include="test-printEFunctionCode.cpp" />
     <ClCompile Include="test-cclipboard.cpp" />
     <ClCompile Include="test-ccodebase.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -148,6 +148,9 @@
     <ClCompile Include="test-csearchagent.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-crunningtimer.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

処理時間計測用クラス CRunningTimer をより使いやすくします。
1. オーバーヘッド削減 (主目的)
2. マイクロ秒単位まで計測できるようにする
3. 計測結果をそのまま GitHub コメントに表として貼り付けられるようにする (Markdown 表形式での出力)
4. 入力文字列のユニコード化 (他のデバッグ用関数の文字列形式と統一)
5. コンストラクタに長い文字列を渡した時にクラッシュする問題を解消
6. Release ビルド時も CRunningTimer を使用できるようにする
7. WriteTrace の入力として数値や書式文字列を受け付けるオーバーロードを追加

## <!-- 必須 --> カテゴリ

- その他 (デバッグ機能の強化)

## <!-- 自明なら省略可 --> PR の背景

CRunningTimer は時間計測とログ出力とが一体となった便利なクラスですが、
オーバーヘッド※が大きいために時間の短い処理の計測には使えない点が不便でした。
※計測ポイント間に何も処理がない場合でも計上されてしまう時間を「オーバーヘッド」と呼ぶこととします。

## <!-- 自明なら省略可 --> PR のメリット

自前で QueryPerformanceCounter 等を使った計測処理を書かなくても、そこそこ正確な計測ができるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

特にありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

### 1. オーバーヘッド削減 (主目的)

#### 1.1. ログ出力に使う関数の変更

ログ出力に使うマクロ/関数を `MYTRACE` (DebugOutW) から `OutputDebugStringW` に変更します。

オーバーヘッドは DebugOutW の内部にある明示的なウェイト (::Sleep(1)) により発生していました。
余計な待ち時間が計測結果に含まれないよう OutputDebugStringW を直接呼ぶようにします。
→15ms 程度あったオーバーヘッドが 0.2ms 程度まで削減されます。

#### 1.2. ログ出力モード追加

オーバーヘッドの少ないログ出力モードを用意して、コンストラクタ引数で指定できるようにします。

ログ出力モード (OutputMode) | 説明 | オーバーヘッド時間目安
-|-|-
OnWriteTrace (既定値) | 従来どおり WriteTrace メソッド呼び出し時に都度ログを出力します。 | 0.2ms 程度
OnExitScope | 計測終了時 (インスタンス破棄時) または Reset メソッド呼び出し時に、まとめてログを出力します。 | 0.005ms 程度

### 2. マイクロ秒単位まで計測できるようにする

時間取得に使う関数を `timeGetTime` から `std::chrono::high_resolution_clock::now` に変更します。
→計測の分解能が 1～5ms から 0.001ms 程度 (環境依存) まで向上します。

### 3. 計測結果をそのまま GitHub コメントに表として貼り付けられるようにする

ログの出力形式を、コンストラクタ引数で従来形式 / Markdown 形式から選択できるようにします。
従来形式をデフォルトとし、すでに master のソースコードに組み込まれている計測箇所の出力形式は変化しないようにします。

Markdown 形式における出力項目：
列名 | 意味
-|-
timestamp (s) | sakura.exe 開始時を起点とするタイムスタンプ (整数部を秒単位とする)
name | コンストラクタに指定されたタイマー名 (字下げにより入れ子の階層を表現する)
time (ms) | タイマー生成時または Reset メソッド呼び出し後からの経過時間 (整数部をミリ秒単位とする)
diff (ms) | 直前の計測ポイントからの経過時間 (整数部をミリ秒単位とする)
message | 計測開始/終了を示すメッセージまたは、WriteTrace で指定された任意のメッセージ

### 4. 入力文字列のユニコード化

CRunningTimer クラスの公開メソッドで、文字列を受け取る引数の型を `const char*` から `std::wstring_view` に変更します。

### 5. コンストラクタに長い名前を渡した時にクラッシュする問題を解消

タイマー名を保持する変数型を `char[100]` から `std::wstring` に変更します。
従来は固定長配列に対して、入力引数を長さチェックなしに strcpy していたためバッファーオーバーフローが発生する可能性がありました。

### 6. Release ビルド時も CRunningTimer を使用できるようにする

CRunningTimer クラスの実装部分を囲んでいた `#ifdef _DEBUG` を撤去します。

### 7. WriteTrace の入力として数値や書式文字列を受け付けるオーバーロードを追加

以下の二種類を追加します。これにより行番号 (`__LINE__`) 等も指定できるようになります。
* WriteTrace( 任意の数値 : int32_t )
* WriteTraceFormat( 書式文字列 : wstring_view, ... )

## <!-- わかる範囲で --> PR の影響範囲

CRunningTimer クラスを使っている箇所に影響があります。
ユーザーに対する動作の変化はありません。

## <!-- 必須 --> テスト内容

* Debugビルドかつ定義 `TIME_MEASURE` を有効にした時に出力されるログの形式が変化していないこと。
* 計測される時間が正しいこと。
* Markdown 形式で出力したログを GitHub コメント欄に貼り付けた時に正しくフォーマットされること。
* 追加したユニットテストがクラッシュしないこと。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料

Acquiring high-resolution time stamps
https://docs.microsoft.com/en-us/windows/win32/sysinfo/acquiring-high-resolution-time-stamps

QueryPerformanceCounter今昔
https://yohhoy.hatenadiary.jp/entry/20130404/p1

cppreference.com - std::chrono::high_resolution_clock
https://en.cppreference.com/w/cpp/chrono/high_resolution_clock