### PR TITLE
CDocLine のテストを追加する

### DIFF
--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -942,14 +942,14 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 					ref._SetStringLength(nWorkPos);
 					ref.AppendString(pInsData, nInsLen);
 					ref.AppendNativeData(pCDocLineNext->_GetDocLineDataWithEOL());
-					pCDocLine->SetEol();
+					pCDocLine->SetEol(GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 				}else{
 					CNativeW tmp;
 					tmp.AllocStringBuffer(nNewLen);
 					tmp.AppendString(pLine, nWorkPos);
 					tmp.AppendString(pInsData, nInsLen);
 					tmp.AppendNativeData(pCDocLineNext->_GetDocLineDataWithEOL());
-					pCDocLine->SetDocLineStringMove(&tmp);
+					pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 				}
 				if( bChangeOneLine ){
 					pArg->nInsSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLine);
@@ -975,7 +975,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 				/* 行内データ削除 */
 				CNativeW tmp;
 				tmp.SetString(pLine, nWorkPos);
-				pCDocLine->SetDocLineStringMove(&tmp);
+				pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 				CModifyVisitor().SetLineModified(pCDocLine, pArg->nDelSeq);	/* 変更フラグ */
 			}
 		}
@@ -1012,7 +1012,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 					tmp.AppendString(pLine, nWorkPos);
 					tmp.AppendString(pInsData, nInsLen);
 					tmp.AppendString(&pLine[nWorkPos + nWorkLen], nAfterLen);
-					pCDocLine->SetDocLineStringMove(&tmp);
+					pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 				}
 			}
 			if( bChangeOneLine ){
@@ -1133,10 +1133,10 @@ prev_line:;
 					tmp.AllocStringBuffer(cPrevLine.GetLength() + cmemLine.GetStringLength());
 					tmp.AppendString(cPrevLine.GetPtr(), cPrevLine.GetLength());
 					tmp.AppendNativeData(cmemLine);
-					pCDocLineNew->SetDocLineStringMove(&tmp);
+					pCDocLineNew->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 				}
 				else{
-					pCDocLineNew->SetDocLineStringMove(&cmemLine);
+					pCDocLineNew->SetDocLineStringMove(&cmemLine, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 				}
 				CModifyVisitor().SetLineModified(pCDocLineNew, (*pArg->pInsData)[nCount].nSeq);
 			}
@@ -1152,21 +1152,21 @@ prev_line:;
 						cmemCurLine.swap(tmp);
 						tmp._SetStringLength(cPrevLine.GetLength());
 						tmp.AppendNativeData(cmemLine);
-						pCDocLine->SetDocLineStringMove(&tmp);
+						pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 						cNextLine = CStringRef(cmemCurLine.GetStringPtr(), cmemCurLine.GetStringLength());
 					}else{
 						CNativeW tmp;
 						tmp.AllocStringBuffer(cPrevLine.GetLength() + cmemLine.GetStringLength());
 						tmp.AppendString(cPrevLine.GetPtr(), cPrevLine.GetLength());
 						tmp.AppendNativeData(cmemLine);
-						pCDocLine->SetDocLineStringMove(&tmp);
+						pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 					}
 					CModifyVisitor().SetLineModified(pCDocLine, (*pArg->pInsData)[nCount].nSeq);
 					pCDocLine = pCDocLine->GetNextLine();
 				}
 				else{
 					CDocLine* pCDocLineNew = m_pcDocLineMgr->InsertNewLine(pCDocLine);	//pCDocLineの前に挿入
-					pCDocLineNew->SetDocLineStringMove(&cmemLine);
+					pCDocLineNew->SetDocLineStringMove(&cmemLine, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 					CModifyVisitor().SetLineModified(pCDocLineNew, (*pArg->pInsData)[nCount].nSeq);
 				}
 			}
@@ -1199,7 +1199,7 @@ prev_line:;
 		tmp.AppendString(cNextLine.GetPtr(), cNextLine.GetLength());
 		if( NULL == pCDocLine ){
 			CDocLine* pCDocLineNew = m_pcDocLineMgr->AddNewLine();	//末尾に追加
-			pCDocLineNew->SetDocLineStringMove(&tmp);
+			pCDocLineNew->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 			pCDocLineNew->m_sMark = markNext;
 			if( !bLastEOLReplace || !bSetMark ){
 				CModifyVisitor().SetLineModified(pCDocLineNew, nSeq);
@@ -1213,7 +1213,7 @@ prev_line:;
 				pCDocLine = m_pcDocLineMgr->InsertNewLine(pCDocLine);	//pCDocLineの前に挿入
 				pCDocLine->m_sMark = markNext;
 			}
-			pCDocLine->SetDocLineStringMove(&tmp);
+			pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 			if( !bLastEOLReplace || !bSetMark ){
 				CModifyVisitor().SetLineModified(pCDocLine, nSeq);
 			}

--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -814,6 +814,8 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 		pArg->pcmemDeleted->reserve( pArg->sDelRange.GetTo().y + CLogicInt(1) - pArg->sDelRange.GetFrom().y );
 	}
 
+	const bool bEnableExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
+
 	// 2012.01.10 行内の削除&挿入のときの操作を1つにする
 	bool bChangeOneLine = false;	// 行内の挿入
 	bool bInsOneLine = false;
@@ -822,7 +824,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 		const CNativeW& cmemLine = pArg->pInsData->back().cmemLine;
 		int nLen = cmemLine.GetStringLength();
 		const wchar_t* pInsLine = cmemLine.GetStringPtr();
-		if( 0 < nLen && WCODE::IsLineDelimiter(pInsLine[nLen - 1], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
+		if( 0 < nLen && WCODE::IsLineDelimiter(pInsLine[nLen - 1], bEnableExtEol) ){
 			// 行挿入
 			bLastEOLReplace = true; // 仮。後で修正
 		}else{
@@ -942,14 +944,14 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 					ref._SetStringLength(nWorkPos);
 					ref.AppendString(pInsData, nInsLen);
 					ref.AppendNativeData(pCDocLineNext->_GetDocLineDataWithEOL());
-					pCDocLine->SetEol(GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+					pCDocLine->SetEol(bEnableExtEol);
 				}else{
 					CNativeW tmp;
 					tmp.AllocStringBuffer(nNewLen);
 					tmp.AppendString(pLine, nWorkPos);
 					tmp.AppendString(pInsData, nInsLen);
 					tmp.AppendNativeData(pCDocLineNext->_GetDocLineDataWithEOL());
-					pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+					pCDocLine->SetDocLineStringMove(&tmp, bEnableExtEol);
 				}
 				if( bChangeOneLine ){
 					pArg->nInsSeq = CModifyVisitor().GetLineModifiedSeq(pCDocLine);
@@ -975,7 +977,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 				/* 行内データ削除 */
 				CNativeW tmp;
 				tmp.SetString(pLine, nWorkPos);
-				pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+				pCDocLine->SetDocLineStringMove(&tmp, bEnableExtEol);
 				CModifyVisitor().SetLineModified(pCDocLine, pArg->nDelSeq);	/* 変更フラグ */
 			}
 		}
@@ -1012,7 +1014,7 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 					tmp.AppendString(pLine, nWorkPos);
 					tmp.AppendString(pInsData, nInsLen);
 					tmp.AppendString(&pLine[nWorkPos + nWorkLen], nAfterLen);
-					pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+					pCDocLine->SetDocLineStringMove(&tmp, bEnableExtEol);
 				}
 			}
 			if( bChangeOneLine ){
@@ -1079,7 +1081,7 @@ prev_line:;
 		CNativeW& cmemLine = pArg->pInsData->back().cmemLine;
 		int nLen = cmemLine.GetStringLength();
 		const wchar_t* pInsLine = cmemLine.GetStringPtr();
-		if( 0 < nLen && WCODE::IsLineDelimiter(pInsLine[nLen - 1], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
+		if( 0 < nLen && WCODE::IsLineDelimiter(pInsLine[nLen - 1], bEnableExtEol) ){
 			if( 0 == pArg->sDelRange.GetFrom().x ){
 				// 挿入データの最後が改行で行頭に挿入するとき、現在行を維持する
 				bInsertLineMode = true;
@@ -1121,7 +1123,7 @@ prev_line:;
 #ifdef _DEBUG
 		int nLen = cmemLine.GetStringLength();
 		const wchar_t* pInsLine = cmemLine.GetStringPtr();
-		assert( 0 < nLen && WCODE::IsLineDelimiter(pInsLine[nLen - 1], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) );
+		assert( 0 < nLen && WCODE::IsLineDelimiter(pInsLine[nLen - 1], bEnableExtEol) );
 #endif
 		{
 			if( NULL == pCDocLine ){
@@ -1133,10 +1135,10 @@ prev_line:;
 					tmp.AllocStringBuffer(cPrevLine.GetLength() + cmemLine.GetStringLength());
 					tmp.AppendString(cPrevLine.GetPtr(), cPrevLine.GetLength());
 					tmp.AppendNativeData(cmemLine);
-					pCDocLineNew->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+					pCDocLineNew->SetDocLineStringMove(&tmp, bEnableExtEol);
 				}
 				else{
-					pCDocLineNew->SetDocLineStringMove(&cmemLine, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+					pCDocLineNew->SetDocLineStringMove(&cmemLine, bEnableExtEol);
 				}
 				CModifyVisitor().SetLineModified(pCDocLineNew, (*pArg->pInsData)[nCount].nSeq);
 			}
@@ -1152,21 +1154,21 @@ prev_line:;
 						cmemCurLine.swap(tmp);
 						tmp._SetStringLength(cPrevLine.GetLength());
 						tmp.AppendNativeData(cmemLine);
-						pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+						pCDocLine->SetDocLineStringMove(&tmp, bEnableExtEol);
 						cNextLine = CStringRef(cmemCurLine.GetStringPtr(), cmemCurLine.GetStringLength());
 					}else{
 						CNativeW tmp;
 						tmp.AllocStringBuffer(cPrevLine.GetLength() + cmemLine.GetStringLength());
 						tmp.AppendString(cPrevLine.GetPtr(), cPrevLine.GetLength());
 						tmp.AppendNativeData(cmemLine);
-						pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+						pCDocLine->SetDocLineStringMove(&tmp, bEnableExtEol);
 					}
 					CModifyVisitor().SetLineModified(pCDocLine, (*pArg->pInsData)[nCount].nSeq);
 					pCDocLine = pCDocLine->GetNextLine();
 				}
 				else{
 					CDocLine* pCDocLineNew = m_pcDocLineMgr->InsertNewLine(pCDocLine);	//pCDocLineの前に挿入
-					pCDocLineNew->SetDocLineStringMove(&cmemLine, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+					pCDocLineNew->SetDocLineStringMove(&cmemLine, bEnableExtEol);
 					CModifyVisitor().SetLineModified(pCDocLineNew, (*pArg->pInsData)[nCount].nSeq);
 				}
 			}
@@ -1199,7 +1201,7 @@ prev_line:;
 		tmp.AppendString(cNextLine.GetPtr(), cNextLine.GetLength());
 		if( NULL == pCDocLine ){
 			CDocLine* pCDocLineNew = m_pcDocLineMgr->AddNewLine();	//末尾に追加
-			pCDocLineNew->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+			pCDocLineNew->SetDocLineStringMove(&tmp, bEnableExtEol);
 			pCDocLineNew->m_sMark = markNext;
 			if( !bLastEOLReplace || !bSetMark ){
 				CModifyVisitor().SetLineModified(pCDocLineNew, nSeq);
@@ -1213,7 +1215,7 @@ prev_line:;
 				pCDocLine = m_pcDocLineMgr->InsertNewLine(pCDocLine);	//pCDocLineの前に挿入
 				pCDocLine->m_sMark = markNext;
 			}
-			pCDocLine->SetDocLineStringMove(&tmp, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
+			pCDocLine->SetDocLineStringMove(&tmp, bEnableExtEol);
 			if( !bLastEOLReplace || !bSetMark ){
 				CModifyVisitor().SetLineModified(pCDocLine, nSeq);
 			}

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -182,5 +182,5 @@ void CDocEditAgent::AddLineStrX( const wchar_t* pData, int nDataLen )
 	CDocLine* pDocLine = m_pcDocLineMgr->AddNewLine();
 
 	//インスタンス設定
-	pDocLine->SetDocLineString(pData, nDataLen);
+	pDocLine->SetDocLineString(pData, nDataLen, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 }

--- a/sakura_core/doc/logic/CDocLine.cpp
+++ b/sakura_core/doc/logic/CDocLine.cpp
@@ -16,7 +16,6 @@
 #include "StdAfx.h"
 #include "CDocLine.h"
 #include "mem/CMemory.h"
-#include "env/DLLSHAREDATA.h"
 
 CDocLine::CDocLine()
 : m_pPrev( NULL ), m_pNext( NULL )
@@ -46,13 +45,13 @@ bool CDocLine::IsEmptyLine() const
 	return true;	//	すべてスペースかタブだけだったらtrue。
 }
 
-void CDocLine::SetEol()
+void CDocLine::SetEol(bool bEnableExtEol)
 {
 	const wchar_t* pData = m_cLine.GetStringPtr();
 	int nLength = m_cLine.GetStringLength();
 	//改行コード設定
 	const wchar_t* p = &pData[nLength] - 1;
-	while(p>=pData && WCODE::IsLineDelimiter(*p, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol))p--;
+	while(p>=pData && WCODE::IsLineDelimiter(*p, bEnableExtEol))p--;
 	p++;
 	if(p>=pData){
 		m_cEol.SetTypeByString(p, &pData[nLength]-p);
@@ -62,21 +61,21 @@ void CDocLine::SetEol()
 	}
 }
 
-void CDocLine::SetDocLineString(const wchar_t* pData, int nLength)
+void CDocLine::SetDocLineString(const wchar_t* pData, int nLength, bool bEnableExtEol)
 {
 	m_cLine.SetString(pData, nLength);
-	SetEol();
+	SetEol(bEnableExtEol);
 }
 
-void CDocLine::SetDocLineString(const CNativeW& cData)
+void CDocLine::SetDocLineString(const CNativeW& cData, bool bEnableExtEol)
 {
-	SetDocLineString(cData.GetStringPtr(), cData.GetStringLength());
+	SetDocLineString(cData.GetStringPtr(), cData.GetStringLength(), bEnableExtEol);
 }
 
-void CDocLine::SetDocLineStringMove(CNativeW* pcDataFrom)
+void CDocLine::SetDocLineStringMove(CNativeW* pcDataFrom, bool bEnableExtEol)
 {
 	m_cLine.swap(*pcDataFrom);
-	SetEol();
+	SetEol(bEnableExtEol);
 }
 
 void CDocLine::SetEol(const CEol& cEol, COpeBlk* pcOpeBlk)

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -98,15 +98,15 @@ public:
 	}
 	const CEol& GetEol() const{ return m_cEol; }
 	void SetEol(const CEol& cEol, COpeBlk* pcOpeBlk);
-	void SetEol(); // 現在のバッファから設定
+	void SetEol(bool bEnableExtEol); // 現在のバッファから設定
 
 	const CNativeW& _GetDocLineDataWithEOL() const { return m_cLine; } //###仮
 	CNativeW& _GetDocLineData() { return m_cLine; }
 
 	//データ設定
-	void SetDocLineString(const wchar_t* pData, int nLength);
-	void SetDocLineString(const CNativeW& cData);
-	void SetDocLineStringMove(CNativeW* pcData);
+	void SetDocLineString(const wchar_t* pData, int nLength, bool bEnableExtEol);
+	void SetDocLineString(const CNativeW& cData, bool bEnableExtEol);
+	void SetDocLineStringMove(CNativeW* pcData, bool bEnableExtEol);
 
 	//チェーン属性
 	CDocLine* GetPrevLine(){ return m_pPrev; }

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -2192,7 +2192,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 					varCopy2.Data.lVal = 1;
 				}
 				CDocLine tmpDocLine;
-				tmpDocLine.SetDocLineString(varCopy.Data.bstrVal, ::SysStringLen(varCopy.Data.bstrVal));
+				tmpDocLine.SetDocLineString(varCopy.Data.bstrVal, ::SysStringLen(varCopy.Data.bstrVal), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 				const int tmpLenWithEol1 = tmpDocLine.GetLengthWithoutEOL() + (0 < tmpDocLine.GetEol().GetLen() ? 1: 0);
 				const CLayoutXInt offset(varCopy2.Data.lVal - 1);
 				const CLayout tmpLayout(

--- a/tests/unittests/test-cdocline.cpp
+++ b/tests/unittests/test-cdocline.cpp
@@ -118,23 +118,23 @@ TEST(CDocLine, GetDocLineStrWithEOL)
 		EXPECT_EQ(CDocLine::GetDocLineStrWithEOL_Safe(&line, &n), line.GetPtr());
 		EXPECT_EQ(n, line.GetLengthWithEOL());
 
-#ifdef USE_STRICT_INT
+		// USE_STRICT_INT 定義時は別の関数が呼ばれる
 		int n2 = 123;
 		EXPECT_EQ(line.GetDocLineStrWithEOL(&n), line.GetPtr());
 		EXPECT_EQ(n, line.GetLengthWithEOL());
-#endif
 	}
 	{
 		CLogicInt n(123);
+		EXPECT_EQ(CDocLine::GetDocLineStrWithEOL_Safe(nullptr, &n), nullptr);
+		EXPECT_EQ(n, CLogicInt(0));
+
+#ifdef _MSC_VER
+		n = 123;
 		CDocLine* p = reinterpret_cast<CDocLine*>(0);
 		EXPECT_EQ(p->GetDocLineStrWithEOL(&n), nullptr);
 		EXPECT_EQ(n, CLogicInt(0));
 
-		n = 123;
-		EXPECT_EQ(CDocLine::GetDocLineStrWithEOL_Safe(nullptr, &n), nullptr);
-		EXPECT_EQ(n, CLogicInt(0));
-
-#ifdef USE_STRICT_INT
+		// USE_STRICT_INT 定義時は別の関数が呼ばれる
 		int n2 = 123;
 		EXPECT_EQ(p->GetDocLineStrWithEOL(&n), nullptr);
 		EXPECT_EQ(n, 0);
@@ -157,14 +157,16 @@ TEST(CDocLine, GetStringRefWithEOL)
 	}
 	{
 		CLogicInt n(123);
-		CDocLine* p = reinterpret_cast<CDocLine*>(0);
-		CStringRef ref = p->GetStringRefWithEOL();
+		CStringRef ref = CDocLine::GetStringRefWithEOL_Safe(nullptr);
 		EXPECT_EQ(ref.GetPtr(), nullptr);
 		EXPECT_EQ(ref.GetLength(), 0);
 
-		ref = CDocLine::GetStringRefWithEOL_Safe(nullptr);
+#ifdef _MSC_VER
+		CDocLine* p = reinterpret_cast<CDocLine*>(0);
+		ref = p->GetStringRefWithEOL();
 		EXPECT_EQ(ref.GetPtr(), nullptr);
 		EXPECT_EQ(ref.GetLength(), 0);
+#endif
 	}
 }
 

--- a/tests/unittests/test-cdocline.cpp
+++ b/tests/unittests/test-cdocline.cpp
@@ -1,0 +1,237 @@
+﻿/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+
+#include <gtest/gtest.h>
+#include "doc/logic/CDocLine.h"
+
+#include <string_view>
+
+TEST(CDocLine, IsEmptyLine)
+{
+	{
+		CDocLine line;
+		EXPECT_TRUE(line.IsEmptyLine());
+	}
+	{
+		CDocLine line;
+		line.SetDocLineString(L"空行ではない\n", 6, false);
+		EXPECT_FALSE(line.IsEmptyLine());
+	}
+	{
+		CDocLine line;
+		line.SetDocLineString(L" \t\r\n", 4, false);
+		EXPECT_TRUE(line.IsEmptyLine());
+	}
+}
+
+TEST(CDocLine, GetLengthWithoutEOL)
+{
+	{
+		CDocLine line;
+		EXPECT_EQ(line.GetLengthWithoutEOL(), CLogicInt(0));
+	}
+	{
+		CDocLine line;
+		line.SetDocLineString(L"改行がありません", 8, false);
+		EXPECT_EQ(line.GetLengthWithoutEOL(), CLogicInt(8));
+	}
+	{
+		CDocLine line;
+		line.SetDocLineString(L"LFがあります\n", 8, false);
+		EXPECT_EQ(line.GetLengthWithoutEOL(), CLogicInt(7));
+	}
+	{
+		CDocLine line;
+		line.SetDocLineString(L"CRLFがあります\r\n", 11, false);
+		EXPECT_EQ(line.GetLengthWithoutEOL(), CLogicInt(9));
+	}
+}
+
+TEST(CDocLine, GetPtr)
+{
+	{
+		CDocLine line;
+		EXPECT_EQ(nullptr, line.GetPtr());
+	}
+	{
+		std::wstring_view s = L"てきとうなもじれつ";
+		CDocLine line;
+		line.SetDocLineString(s.data(), s.length(), false);
+		EXPECT_STREQ(line.GetPtr(), s.data());
+	}
+}
+
+TEST(CDocLine, GetLengthWithEOL)
+{
+	{
+		CDocLine line;
+		EXPECT_EQ(line.GetLengthWithEOL(), CLogicInt(0));
+	}
+	{
+		CDocLine line;
+		line.SetDocLineString(L"改行がありません", 8, false);
+		EXPECT_EQ(line.GetLengthWithEOL(), CLogicInt(8));
+	}
+	{
+		CDocLine line;
+		line.SetDocLineString(L"LFがあります\n", 8, false);
+		EXPECT_EQ(line.GetLengthWithEOL(), CLogicInt(8));
+	}
+	{
+		CDocLine line;
+		line.SetDocLineString(L"CRLFがあります\r\n", 11, false);
+		EXPECT_EQ(line.GetLengthWithEOL(), CLogicInt(11));
+	}
+}
+
+TEST(CDocLine, GetDocLineStrWithEOL)
+{
+	{
+		CDocLine line;
+		line.SetDocLineString(L"もじれつ", 4, false);
+		CLogicInt n(123);
+		EXPECT_EQ(line.GetDocLineStrWithEOL(&n), line.GetPtr());
+		EXPECT_EQ(n, line.GetLengthWithEOL());
+
+		n = 123;
+		EXPECT_EQ(CDocLine::GetDocLineStrWithEOL_Safe(&line, &n), line.GetPtr());
+		EXPECT_EQ(n, line.GetLengthWithEOL());
+
+#ifdef USE_STRICT_INT
+		int n2 = 123;
+		EXPECT_EQ(line.GetDocLineStrWithEOL(&n), line.GetPtr());
+		EXPECT_EQ(n, line.GetLengthWithEOL());
+#endif
+	}
+	{
+		CLogicInt n(123);
+		CDocLine* p = reinterpret_cast<CDocLine*>(0);
+		EXPECT_EQ(p->GetDocLineStrWithEOL(&n), nullptr);
+		EXPECT_EQ(n, CLogicInt(0));
+
+		n = 123;
+		EXPECT_EQ(CDocLine::GetDocLineStrWithEOL_Safe(nullptr, &n), nullptr);
+		EXPECT_EQ(n, CLogicInt(0));
+
+#ifdef USE_STRICT_INT
+		int n2 = 123;
+		EXPECT_EQ(p->GetDocLineStrWithEOL(&n), nullptr);
+		EXPECT_EQ(n, 0);
+#endif
+	}
+}
+
+TEST(CDocLine, GetStringRefWithEOL)
+{
+	{
+		CDocLine line;
+		line.SetDocLineString(L"もじれつ", 4, false);
+		CStringRef ref = line.GetStringRefWithEOL();
+		EXPECT_EQ(ref.GetPtr(), line.GetPtr());
+		EXPECT_EQ(ref.GetLength(), line.GetLengthWithEOL());
+
+		ref = CDocLine::GetStringRefWithEOL_Safe(&line);
+		EXPECT_EQ(ref.GetPtr(), line.GetPtr());
+		EXPECT_EQ(ref.GetLength(), line.GetLengthWithEOL());
+	}
+	{
+		CLogicInt n(123);
+		CDocLine* p = reinterpret_cast<CDocLine*>(0);
+		CStringRef ref = p->GetStringRefWithEOL();
+		EXPECT_EQ(ref.GetPtr(), nullptr);
+		EXPECT_EQ(ref.GetLength(), 0);
+
+		ref = CDocLine::GetStringRefWithEOL_Safe(nullptr);
+		EXPECT_EQ(ref.GetPtr(), nullptr);
+		EXPECT_EQ(ref.GetLength(), 0);
+	}
+}
+
+
+TEST(CDocLine, GetEol)
+{
+	{
+		CDocLine line;
+		CEol eol;
+		EXPECT_EQ(line.GetEol(), eol);
+	}
+	{
+		CDocLine line;
+		line.SetDocLineString(L"\n", 1, false);
+		CEol eol(EEolType::line_feed);
+		EXPECT_EQ(line.GetEol(), eol);
+	}
+}
+
+TEST(CDocLine, SetEol)
+{
+	// 改行コードを再設定するテスト
+	CDocLine line;
+	line.SetDocLineString(L"てすと", 3, false);
+	EXPECT_STREQ(line.GetPtr(), L"てすと");
+
+	line.SetEol(CEol(EEolType::cr_and_lf), nullptr);
+	EXPECT_STREQ(line.GetPtr(), L"てすと\r\n");
+
+	line.SetEol(CEol(EEolType::line_feed), nullptr);
+	EXPECT_STREQ(line.GetPtr(), L"てすと\n");
+
+	line.SetEol(CEol(EEolType::none), nullptr);
+	EXPECT_STREQ(line.GetPtr(), L"てすと");
+}
+
+TEST(CDocLine, GetDocLineData)
+{
+	const CNativeW data(L"データ\n");
+	CDocLine line;
+	line.SetDocLineString(data, false);
+	EXPECT_EQ(line._GetDocLineDataWithEOL(), data);
+	EXPECT_EQ(line._GetDocLineData(), data);
+}
+
+TEST(CDocLine, SetDocLineStringMove)
+{
+	CNativeW data(L"データ\r\n");
+	const wchar_t* originalPtr = data.GetStringPtr();
+
+	CDocLine line;
+	line.SetDocLineStringMove(&data, false);
+	EXPECT_EQ(line.GetPtr(), originalPtr);
+	EXPECT_EQ(line.GetEol(), CEol(EEolType::cr_and_lf));
+	EXPECT_EQ(data.GetStringPtr(), nullptr);
+}
+
+TEST(CDocLine, GetPrevAndNextLine)
+{
+	CDocLine line;
+	EXPECT_EQ(line.GetPrevLine(), nullptr);
+	EXPECT_EQ(line.GetNextLine(), nullptr);
+
+	CDocLine prev;
+	CDocLine next;
+	line._SetPrevLine(&prev);
+	EXPECT_EQ(line.GetPrevLine(), &prev);
+	line._SetNextLine(&next);
+	EXPECT_EQ(line.GetNextLine(), &next);
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -106,6 +106,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="code-main.cpp" />
+    <ClCompile Include="test-cdocline.cpp" />
     <ClCompile Include="test-printEFunctionCode.cpp" />
     <ClCompile Include="test-cclipboard.cpp" />
     <ClCompile Include="test-ccodebase.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -139,6 +139,9 @@
     <ClCompile Include="test-printEFunctionCode.cpp">
       <Filter>Other Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-cdocline.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
# PR の目的

CDocLine に対するテストを追加します。

## カテゴリ

- その他の問題

## PR のメリット

- CDocLine のカバレッジがほぼ100%になります。

## 仕様・動作説明

テストの障害となる CDocLine::SetEol の共有データ依存を除去する変更を含みます。

## PR の影響範囲

CDocLine::SetEol の呼び出し元において自動テストでカバーできない変更が発生しています。以下の機能に影響します。
- エディタへの編集対象ファイルの読み込み
- エディタでの文字の挿入・削除
- GetStrLayoutLength マクロ関数

## テスト内容

- テキストファイルを開き、正しく読み込まれたことを確認する。
- エディタへの文字を挿入・削除が正しく機能することを確認する。

（GetStrLayoutLength の結果が正しいことも確認するのが望ましいですが、適切なテスト内容が浮かばずにいます。）