### PR TITLE
レイアウト桁位置に対するロジック桁位置の進め方を改善する

### DIFF
--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -873,8 +873,6 @@ void CLayoutMgr::LogicToLayout(
 				else{
 					nCharKetas = GetLayoutXOfChar( pData, nDataLen, i );
 				}
-//				if( nCharKetas == 0 )				// 削除 サロゲートペア対策	2008/7/5 Uchi
-//					nCharKetas = CLayoutInt(1);
 
 				//レイアウト加算
 				nCaretPosX += nCharKetas;
@@ -1007,8 +1005,6 @@ checkloop:;
 		else{
 			nCharKetas = GetLayoutXOfChar( pData, nDataLen, i );
 		}
-//		if( nCharKetas == 0 )				// 削除 サロゲートペア対策	2008/7/5 Uchi
-//			nCharKetas = CLayoutInt(1);
 
 		//レイアウト加算
 		if( nX + nCharKetas > ptLayout.GetX2() && !bEOF ){

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -51,7 +51,6 @@ static bool _GetKeywordLength(
 	while(nPos<cLineStr.GetLength() && IS_KEYWORD_CHAR(cLineStr.At(nPos))){
 		CLogicXInt nCharSize = CNativeW::GetSizeOfChar( cLineStr, nPos );
 		CLayoutInt k = cLayoutMgr.GetLayoutXOfChar(cLineStr, nPos);
-//		if(0 == k)k = CLayoutInt(1);	// 削除 サロゲートペア対策
 
 		nWordLen += nCharSize;
 		nWordKetas+=k;
@@ -317,9 +316,6 @@ void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 			}
 			// 2007.09.07 kobake   ロジック幅とレイアウト幅を区別
 			CLayoutInt nCharKetas = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
-//			if( 0 == nCharKetas ){				// 削除 サロゲートペア対策	2008/7/5 Uchi
-//				nCharKetas = CLayoutInt(1);
-//			}
 
 			if( pWork->nPosX + nCharKetas > GetMaxLineLayout() ){
 				if( pWork->eKinsokuType != KINSOKU_TYPE_KINSOKU_KUTO )

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -49,12 +49,13 @@ static bool _GetKeywordLength(
 	CLogicInt nWordLen = CLogicInt(0);
 	CLayoutInt nWordKetas = CLayoutInt(0);
 	while(nPos<cLineStr.GetLength() && IS_KEYWORD_CHAR(cLineStr.At(nPos))){
+		CLogicXInt nCharSize = CNativeW::GetSizeOfChar( cLineStr, nPos );
 		CLayoutInt k = cLayoutMgr.GetLayoutXOfChar(cLineStr, nPos);
-		if(0 == k)k = CLayoutInt(1);
+//		if(0 == k)k = CLayoutInt(1);	// 削除 サロゲートペア対策
 
-		nWordLen+=1;
+		nWordLen += nCharSize;
 		nWordKetas+=k;
-		nPos++;
+		nPos += nCharSize;
 	}
 	//結果
 	if(nWordLen>0){
@@ -188,7 +189,7 @@ void CLayoutMgr::_DoKutoBurasage(SLayoutWork* pWork) const
 		if( _IsKinsokuPosKuto( GetMaxLineLayout() - pWork->nPosX, nCharKetas ) && IsKinsokuKuto( pWork->cLineStr.At( pWork->nPos ) ) )
 		{
 			pWork->nWordBgn = pWork->nPos;
-			pWork->nWordLen = 1;
+			pWork->nWordLen = CNativeW::GetSizeOfChar( pWork->cLineStr, pWork->nPos );
 			pWork->eKinsokuType = KINSOKU_TYPE_KINSOKU_KUTO;
 		}
 	}
@@ -203,24 +204,17 @@ void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
 		// 2007.09.07 kobake   レイアウトとロジックの区別
-		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
-		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
-		bool bLowSurrogate = false;
+		CLogicXInt nCharSize = CNativeW::GetSizeOfChar( pWork->cLineStr, pWork->nPos );
+		CLayoutXInt nCharKetas1 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
+		CLayoutXInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos + nCharSize );
 
-		if( nCharKetas3 == 0 && pWork->nPos + 2 < pWork->cLineStr.GetLength() )
-		{
-			// サロゲートペア対策(取得した文字幅が0だったら下位側を読み取ったと判断し、次の位置に進ませる)
-			bLowSurrogate = true;
-			nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos + 2 );
-		}
-
-		if( _IsKinsokuPosHead( GetMaxLineLayout() - pWork->nPosX, nCharKetas2, nCharKetas3 )
-		 && IsKinsokuHead( pWork->cLineStr.At( pWork->nPos + ( bLowSurrogate ? 2 : 1 ) ) )
+		if( _IsKinsokuPosHead( GetMaxLineLayout() - pWork->nPosX, nCharKetas1, nCharKetas2 )
+		 && IsKinsokuHead( pWork->cLineStr.At( pWork->nPos + nCharSize ) )
 		 && !IsKinsokuHead( pWork->cLineStr.At( pWork->nPos ) )		// 1字前が行頭禁則の対象でないこと
 		 && !IsKinsokuKuto( pWork->cLineStr.At( pWork->nPos ) ) )	// 1字前が句読点ぶら下げの対象でないこと
 		{
 			pWork->nWordBgn = pWork->nPos;
-			pWork->nWordLen = ( bLowSurrogate ? 3 : 2 );
+			pWork->nWordLen = nCharSize + CNativeW::GetSizeOfChar( pWork->cLineStr, pWork->nPos + nCharSize );
 			pWork->eKinsokuType = KINSOKU_TYPE_KINSOKU_HEAD;
 
 			(this->*pfOnLine)(pWork);
@@ -236,13 +230,14 @@ void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 	 && ( pWork->nPosX > pWork->nIndent )	//	2004.04.09 pWork->nPosXの解釈変更のため，行頭チェックも変更
 	 && (pWork->eKinsokuType == KINSOKU_TYPE_NONE) )
 	{
-		CLayoutInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
-		CLayoutInt nCharKetas3 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos+1 );
+		CLogicXInt nCharSize = CNativeW::GetSizeOfChar( pWork->cLineStr, pWork->nPos );
+		CLayoutXInt nCharKetas1 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
+		CLayoutXInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos + nCharSize );
 
-		if( _IsKinsokuPosTail( GetMaxLineLayout() - pWork->nPosX, nCharKetas2, nCharKetas3 ) && IsKinsokuTail( pWork->cLineStr.At( pWork->nPos ) ) )
+		if( _IsKinsokuPosTail( GetMaxLineLayout() - pWork->nPosX, nCharKetas1, nCharKetas2 ) && IsKinsokuTail( pWork->cLineStr.At( pWork->nPos ) ) )
 		{
 			pWork->nWordBgn = pWork->nPos;
-			pWork->nWordLen = 1;
+			pWork->nWordLen = nCharSize;
 			pWork->eKinsokuType = KINSOKU_TYPE_KINSOKU_TAIL;
 
 			(this->*pfOnLine)(pWork);
@@ -260,7 +255,7 @@ bool CLayoutMgr::_DoTab(SLayoutWork* pWork, PF_OnLine pfOnLine)
 		return true;
 	}
 	pWork->nPosX += nCharKetas;
-	pWork->nPos += CLogicInt(1);
+	pWork->nPos += CNativeW::GetSizeOfChar( pWork->cLineStr, pWork->nPos );
 	return false;
 }
 
@@ -336,7 +331,7 @@ void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 					}
 				}
 			}
-			pWork->nPos += 1;
+			pWork->nPos += CNativeW::GetSizeOfChar( pWork->cLineStr, pWork->nPos );
 			pWork->nPosX += nCharKetas;
 		}
 	}

--- a/sakura_core/mem/CMemoryIterator.h
+++ b/sakura_core/mem/CMemoryIterator.h
@@ -110,8 +110,6 @@ public:
 			if( m_nSpacing ){
 				m_nColumn_Delta += CLayoutXInt(CNativeW::GetKetaOfChar(m_pLine, m_nLineLen, m_nIndex) * m_nSpacing);
 			}
-//			if( 0 == m_nColumn_Delta )				// 削除 サロゲートペア対策	2008/7/5 Uchi
-//				m_nColumn_Delta = CLayoutInt(1);
 		}
 	}
 	

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -160,8 +160,8 @@ public:
 	//! 指定した位置の文字が半角何個分かを返す
 	static CKetaXInt GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx,
 		CCharWidthCache& cache = GetCharWidthCache() );
-	static CKetaXInt GetKetaOfChar( const CStringRef& cStr, int nIdx )
-		{ return GetKetaOfChar( cStr.GetPtr(), cStr.GetLength(), nIdx ); }
+	static CKetaXInt GetKetaOfChar(const CStringRef& cStr, int nIdx, CCharWidthCache& cache = GetCharWidthCache())
+		{ return GetKetaOfChar(cStr.GetPtr(), cStr.GetLength(), nIdx, cache); }
 	static const wchar_t* GetCharNext( const wchar_t* pData, int nDataLen, const wchar_t* pDataCurrent ); //!< ポインタで示した文字の次にある文字の位置を返します
 	static const wchar_t* GetCharPrev(const wchar_t* pData, size_t nDataLen, const wchar_t* pDataCurrent); //!< ポインタで示した文字の直前にある文字の位置を返します
 

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -153,19 +153,20 @@ public:
 
 public:
 	// -- -- staticインターフェース -- -- //
-	static CLogicInt GetSizeOfChar( const wchar_t* pData, int nDataLen, int nIdx ); //!< 指定した位置の文字がwchar_t何個分かを返す
-	static CHabaXInt GetHabaOfChar( const wchar_t* pData, int nDataLen, int nIdx,
-		bool bEnableExtEol, CCharWidthCache& cache = GetCharWidthCache() );
+	//! 指定した位置の文字がwchar_t何個分かを返す
+	static CLogicInt GetSizeOfChar( const wchar_t* pData, int nDataLen, int nIdx );
+	static CLogicInt GetSizeOfChar( const CStringRef& cStr, int nIdx )
+		{ return GetSizeOfChar( cStr.GetPtr(), cStr.GetLength(), nIdx ); }
 	//! 指定した位置の文字が半角何個分かを返す
 	static CKetaXInt GetKetaOfChar( const wchar_t* pData, int nDataLen, int nIdx,
 		CCharWidthCache& cache = GetCharWidthCache() );
+	static CKetaXInt GetKetaOfChar( const CStringRef& cStr, int nIdx )
+		{ return GetKetaOfChar( cStr.GetPtr(), cStr.GetLength(), nIdx ); }
 	static const wchar_t* GetCharNext( const wchar_t* pData, int nDataLen, const wchar_t* pDataCurrent ); //!< ポインタで示した文字の次にある文字の位置を返します
 	static const wchar_t* GetCharPrev(const wchar_t* pData, size_t nDataLen, const wchar_t* pDataCurrent); //!< ポインタで示した文字の直前にある文字の位置を返します
 
-	static CKetaXInt GetKetaOfChar( const CStringRef& cStr, int nIdx ) //!< 指定した位置の文字が半角何個分かを返す
-	{
-		return GetKetaOfChar(cStr.GetPtr(), cStr.GetLength(), nIdx);
-	}
+	static CHabaXInt GetHabaOfChar( const wchar_t* pData, int nDataLen, int nIdx,
+		bool bEnableExtEol, CCharWidthCache& cache = GetCharWidthCache() );
 	static CLayoutXInt GetColmOfChar( const wchar_t* pData,
 		int nDataLen, int nIdx, bool bEnableExtEol )
 		{ return GetHabaOfChar(pData,nDataLen,nIdx, bEnableExtEol); }

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -788,12 +788,16 @@ TEST(CNativeW, GetSizeOfChar)
 {
 	// 基本多言語面の文字ならば1を返す。
 	EXPECT_EQ(CNativeW::GetSizeOfChar(L"a", 1, 0), 1);
+	EXPECT_EQ(CNativeW::GetSizeOfChar(CStringRef(L"a", 1), 0), 1);
 	// 範囲外なら0を返す。
 	EXPECT_EQ(CNativeW::GetSizeOfChar(L"", 0, 0), 0);
+	EXPECT_EQ(CNativeW::GetSizeOfChar(CStringRef(L"", 0), 0), 0);
 	// 上位・下位サロゲートの組み合わせであれば2を返す。
 	EXPECT_EQ(CNativeW::GetSizeOfChar(L"\xd83c\xdf38", 2, 0), 2);
+	EXPECT_EQ(CNativeW::GetSizeOfChar(CStringRef(L"\xd83c\xdf38", 2), 0), 2);
 	// 指定位置が下位サロゲートならその他の文字と同様に1を返す。
 	EXPECT_EQ(CNativeW::GetSizeOfChar(L"\xd83c\xdf38", 2, 1), 1);
+	EXPECT_EQ(CNativeW::GetSizeOfChar(CStringRef(L"\xd83c\xdf38", 2), 1), 1);
 }
 
 /*!
@@ -804,12 +808,16 @@ TEST(CNativeW, GetKetaOfChar)
 {
 	// 範囲外なら0を返す。
 	EXPECT_EQ(CNativeW::GetKetaOfChar(L"", 0, 0), 0);
+	EXPECT_EQ(CNativeW::GetKetaOfChar(CStringRef(L"", 0), 0), 0);
 	// 上位サロゲートなら2を返す。
 	EXPECT_EQ(CNativeW::GetKetaOfChar(L"\xd83c\xdf38", 2, 0), 2);
+	EXPECT_EQ(CNativeW::GetKetaOfChar(CStringRef(L"\xd83c\xdf38", 2), 0), 2);
 	// 上位サロゲートに続く下位サロゲートであれば0を返す。
 	EXPECT_EQ(CNativeW::GetKetaOfChar(L"\xd83c\xdf38", 2, 1), 0);
+	EXPECT_EQ(CNativeW::GetKetaOfChar(CStringRef(L"\xd83c\xdf38", 2), 1), 0);
 	// 下位サロゲートだけなら2を返す。
 	EXPECT_EQ(CNativeW::GetKetaOfChar(L"\xdf38", 1, 0), 2);
+	EXPECT_EQ(CNativeW::GetKetaOfChar(CStringRef(L"\xdf38", 1), 0), 2);
 
 	// サクラエディタでは Unicode で表現できない文字コードの破壊を防ぐため、
 	// 不明バイトを下位サロゲートにマップして保持している。
@@ -819,12 +827,17 @@ TEST(CNativeW, GetKetaOfChar)
 	// https://sourceforge.net/p/sakura-editor/patchunicode/57/
 	// http://sakura-editor.sourceforge.net/cgi-bin/cyclamen/cyclamen.cgi?log=unicode&v=833
 	EXPECT_EQ(CNativeW::GetKetaOfChar(L"\xdbff", 1, 0), 2);
-	for (wchar_t ch = 0xdc00; ch <= 0xdcff; ++ch)
+	EXPECT_EQ(CNativeW::GetKetaOfChar(CStringRef(L"\xdbff", 1), 0), 2);
+	for (wchar_t ch = 0xdc00; ch <= 0xdcff; ++ch) {
 		EXPECT_EQ(CNativeW::GetKetaOfChar(&ch, 1, 0), 1);
+		EXPECT_EQ(CNativeW::GetKetaOfChar(CStringRef(&ch, 1), 0), 1);
+	}
 	EXPECT_EQ(CNativeW::GetKetaOfChar(L"\xdd00", 1, 0), 2);
+	EXPECT_EQ(CNativeW::GetKetaOfChar(CStringRef(L"\xdd00", 1), 0), 2);
 
 	// 文字が半角なら1を返す。
 	EXPECT_EQ(CNativeW::GetKetaOfChar(L"a", 1, 0), 1);
+	EXPECT_EQ(CNativeW::GetKetaOfChar(CStringRef(L"a", 1), 0), 1);
 
 	// 文字が全角なら2を返す。
 	class FakeCache : public CCharWidthCache {
@@ -832,6 +845,7 @@ TEST(CNativeW, GetKetaOfChar)
 		bool CalcHankakuByFont(wchar_t c) override { return false; }
 	} cache;
 	EXPECT_EQ(CNativeW::GetKetaOfChar(L"あ", 1, 0, cache), 2);
+	EXPECT_EQ(CNativeW::GetKetaOfChar(CStringRef(L"あ", 1), 0, cache), 2);
 }
 
 /*!


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
レイアウト情報の作成過程で、ロジック桁位置の進む量を文字に応じて変化させる。

## <!-- 必須 --> カテゴリ
- 仕様変更

## <!-- 自明なら省略可 --> PR の背景
現状のレイアウト作成処理では、レイアウト桁位置に対応するロジック桁を次の数だけ進めるようになっています。
- ワードラップ: 単語の桁数
- 行頭禁則: 禁則対象文字と追い出される文字を合わせた桁数
- その他の禁則処理: 禁則対象文字の桁数
- それ以外: 1文字分の桁数

ここでいう文字の桁数は、1文字が必ずロジック単位で1つであることを想定しているようです。
ロジック行上のデータはUTF-16で表現されるため、サロゲートペアはロジック単位で2つ進めなければなりません。
このため、レイアウト作成フローはサロゲートペアが分割されてしまうリスクを抱えています。

一方、行データのイテレータである CMemoryIterator クラスでは、
以前からロジック・レイアウト単位の増分をそれぞれ CNativeW クラスの静的メンバで計算しており、
サロゲートペアに遭遇しても問題がないようになっています。

## <!-- 自明なら省略可 --> PR のメリット
レイアウト作成時にサロゲートペアが前後に分割処理されることによって発生しうる不具合を防げます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
この PR の変更対象としたクラスには単体テストがなく、共有データ依存のため追加も難しいです。
このため一時的にカバレッジが低下します（全期間で見たカバレッジには影響ありません）。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
レイアウト作成処理において、現在処理している物理データ行上の文字の位置は、 SLayoutWork 構造体のメンバ変数に保持されています。
これまでこの変数にロジック単位で（文字ごとに）1ずつ加算していたところを、各文字毎に`CNativeW::GetSizeOfChar()`で取得した値を加算するように変更します。

なお、既存コードに追加した GetSizeOfChar のオーバーロードを活用できる箇所がいくつかありますが、遡及適用は行っていません。

## <!-- わかる範囲で --> PR の影響範囲
各行のレイアウト作成を行う際の準処理（`CLayoutMgr::_MakeOneLine()`）

## <!-- 必須 --> テスト内容

以下の手順で変更前後の動作に変更がないことを確認してください。

### 手順
指定した内容でタイプ別設定を変更したのち、添付したマクロ実行します。
[テスト用マクロ (test.zip) ](https://github.com/sakura-editor/sakura/files/6414725/test.zip)

1. タイプ別設定一覧ダイアログから、「テキスト」タイプの設定を次のように変更します。  
   （この設定変更を忘れないでください。）
    - 英文ワードラップ：有効
    - 句読点ぶら下げ：有効
    - 改行ぶらさげ：有効
    - 行頭禁則：有効
    - 行末禁則：有効
2. 添付のマクロを実行し、結果を確認します。
    - マクロで挿入されるデータは 329 文字・レイアウト 57 行・ロジック ~~29~~ 27 行です。  

## <!-- なければ省略可 --> 関連 issue, PR
#1543 

## <!-- なければ省略可 --> 参考資料
<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
