### PR TITLE
新しい行を挿入した後に CDocLineMgr::GetLine が誤った行を返す問題に対処する

### DIFF
--- a/sakura_core/doc/logic/CDocLineMgr.cpp
+++ b/sakura_core/doc/logic/CDocLineMgr.cpp
@@ -275,6 +275,10 @@ void CDocLineMgr::_InsertBeforePos(CDocLine* pDocLineNew, CDocLine* pPos)
 	if(pPos){
 		pDocLineNew->m_pPrev = pPos->GetPrevLine();
 		pPos->m_pPrev = pDocLineNew;
+
+		//前回参照位置をリセット
+		m_pCodePrevRefer = nullptr;
+		m_nPrevReferLine = 0;
 	}
 	else{
 		pDocLineNew->m_pPrev = m_pDocLineBot;

--- a/tests/unittests/test-cdoclinemgr.cpp
+++ b/tests/unittests/test-cdoclinemgr.cpp
@@ -53,8 +53,8 @@ TEST(CDocLineMgr, ListManipulations)
 	ASSERT_NE(b, nullptr);
 	b->SetDocLineString(L"B", 1, false);
 	EXPECT_EQ(m.GetLineCount(), 2);
-	//EXPECT_EQ(m.GetLine(CLogicInt(0)), b);
-	//EXPECT_EQ(m.GetLine(CLogicInt(1)), a);
+	EXPECT_EQ(m.GetLine(CLogicInt(0)), b);
+	EXPECT_EQ(m.GetLine(CLogicInt(1)), a);
 	EXPECT_EQ(m.GetLine(CLogicInt(2)), nullptr);
 	EXPECT_EQ(m.GetDocLineTop(), b);
 	EXPECT_EQ(m.GetDocLineBottom(), a);
@@ -64,8 +64,8 @@ TEST(CDocLineMgr, ListManipulations)
 	ASSERT_NE(c, nullptr);
 	c->SetDocLineString(L"C", 1, false);
 	EXPECT_EQ(m.GetLineCount(), 3);
-	//EXPECT_EQ(m.GetLine(CLogicInt(0)), b);
-	//EXPECT_EQ(m.GetLine(CLogicInt(1)), c);
+	EXPECT_EQ(m.GetLine(CLogicInt(0)), b);
+	EXPECT_EQ(m.GetLine(CLogicInt(1)), c);
 	EXPECT_EQ(m.GetLine(CLogicInt(2)), a);
 	EXPECT_EQ(m.GetDocLineTop(), b);
 	EXPECT_EQ(m.GetDocLineBottom(), a);


### PR DESCRIPTION
# PR の目的

CDocLineMgr が保持する行リストに新しい行を挿入した後に CDocLineMgr::GetLine が正しい行を検索できない問題を修正します。

## カテゴリ

- 仕様変更

ユーザーに影響する何らかの不具合が疑われるものの確認できていないため仕様変更とします。

## PR の背景

CDocLineMgr::GetLine は行リストから特定位置の行バッファを検索する関数です。CDocLineMgr が行バッファである CDocLine のリストを双方向連結リストとして保持しているため、GetLine による任意行の検索は線形時間となります。これを効率化する目的で CDocLineMgr は最後に参照した行のインデックスとポインタを記憶し、先頭・前回参照位置・末尾のうち最も目的の行番号に近い位置からの検索を行います。

今回発見した問題は、リストに新しい行を追加した後に GetLine が正しい行を検索できなくなるものです。原因はリストへの新しい行の挿入後に前回参照位置を更新する処理が行われていないことで、挿入後に更新前の前回参照位置を使って検索を始めた場合に結果が誤った行となります。

対策として、新しい行の挿入を行う関数 InsertNewLine に前回参照位置をクリアする処理を追加します。

## PR のメリット

- 潜在的な不具合が解消できます。

## PR のデメリット

- この不具合に依存したコードが存在している可能性を排除できません。

## PR の影響範囲

CDocLineMgr::GetLine を使用する処理。エディタの主な機能は CDocLine をレイアウトを経由して取得するため、この関数の呼び出し元は以下のファイルに限定されます。
- cmd/CViewCommander_Diff.cpp
- doc/CDocReader.cpp
- docplus/CFuncListManager.cpp
- types/CType_Tex.cpp
- view/CEditView_Diff.cpp

## テスト内容

単体テストで検証可能だと思います。

## 関連 issue, PR

#1657