### PR TITLE
CSearchAgent::ReplaceData のテストを追加する

### DIFF
--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -747,7 +747,7 @@ end_of_func:;
   Fromを含む位置からToの直前を含むデータを削除する
   Fromの位置へテキストを挿入する
 */
-void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
+void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg, bool bEnableExtEol )
 {
 //	MY_RUNNINGTIMER( cRunningTimer, "CDocLineMgr::ReplaceData()" );
 
@@ -796,7 +796,8 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 	CDLgCandelCloser closer(pCDlgCancel);
 	const CLogicInt nDelLines = pArg->sDelRange.GetTo().y - pArg->sDelRange.GetFrom().y;
 	const CLogicInt nEditLines = std::max<CLogicInt>(CLogicInt(1), nDelLines + CLogicInt(pArg->pInsData ? pArg->pInsData->size(): 0));
-	if( !CEditApp::getInstance()->m_pcGrepAgent->m_bGrepRunning ){
+	if( const CGrepAgent *pcGrepAgent = CEditApp::getInstance()->m_pcGrepAgent;
+	    pcGrepAgent && !pcGrepAgent->m_bGrepRunning ){
 		if( 3000 < nEditLines ){
 			/* 進捗ダイアログの表示 */
 			pCDlgCancel = new CDlgCancel;
@@ -813,8 +814,6 @@ void CSearchAgent::ReplaceData( DocLineReplaceArg* pArg )
 	if( pArg->pcmemDeleted ){
 		pArg->pcmemDeleted->reserve( pArg->sDelRange.GetTo().y + CLogicInt(1) - pArg->sDelRange.GetFrom().y );
 	}
-
-	const bool bEnableExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 
 	// 2012.01.10 行内の削除&挿入のときの操作を1つにする
 	bool bChangeOneLine = false;	// 行内の挿入

--- a/sakura_core/CSearchAgent.h
+++ b/sakura_core/CSearchAgent.h
@@ -131,7 +131,7 @@ public:
 	//	Jun. 26, 2001 genta	正規表現ライブラリの差し替え
 	int SearchWord( CLogicPoint ptSerachBegin, ESearchDirection eDirection, CLogicRange* pMatchRange, const CSearchStringPattern& pattern ); /* 単語検索 */
 
-	void ReplaceData( DocLineReplaceArg* pArg );
+	void ReplaceData( DocLineReplaceArg* pArg, bool bEnableExtEol );
 private:
 	CDocLineMgr* m_pcDocLineMgr;
 };

--- a/sakura_core/basis/primitive.h
+++ b/sakura_core/basis/primitive.h
@@ -27,6 +27,7 @@
 #define SAKURA_PRIMITIVE_C8059DE4_C986_492E_9C09_7F044049C481_H_
 #pragma once
 
+#include <Windows.h>
 #include "config/build_config.h"
 
 // -- -- -- -- 文字 -- -- -- -- //

--- a/sakura_core/doc/layout/CLayoutMgr_New2.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New2.cpp
@@ -67,7 +67,7 @@ void CLayoutMgr::ReplaceData_CLayoutMgr(
 	DLRArg.pInsData = pArg->pInsData;			// 挿入するデータ
 	DLRArg.nDelSeq = pArg->nDelSeq;
 	CSearchAgent(m_pcDocLineMgr).ReplaceData(
-		&DLRArg
+		&DLRArg, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol
 	);
 	pArg->nInsSeq = DLRArg.nInsSeq;
 

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -821,7 +821,8 @@ bool CEditView::ReplaceData_CEditView3(
 		DLRArg.pInsData = pInsData;
 		DLRArg.nDelSeq = nDelSeq;
 		// DLRArg.ptNewPos;
-		CSearchAgent(&GetDocument()->m_cDocLineMgr).ReplaceData( &DLRArg );
+		CSearchAgent(&GetDocument()->m_cDocLineMgr).ReplaceData(
+			&DLRArg, GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol);
 	}else{
 		LRArg.sDelRange    = sDelRange;		//!< 削除範囲レイアウト
 		LRArg.pcmemDeleted = pcMemDeleted;	//!< [out] 削除されたデータ

--- a/tests/unittests/test-csearchagent.cpp
+++ b/tests/unittests/test-csearchagent.cpp
@@ -1,0 +1,435 @@
+﻿/*
+	Copyright (C) 2021, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+
+#include <gtest/gtest.h>
+#include "CSaveAgent.h"
+
+#include <array>
+#include <initializer_list>
+#include <string_view>
+#include <utility>
+#include "doc/logic/CDocLineMgr.h"
+
+namespace {
+
+template <typename T> void SetLines(CDocLineMgr& m, int seq, T begin, T end)
+{
+	for (auto it = begin; it != end; ++it) {
+		CDocLine* line = m.AddNewLine();
+		line->SetDocLineString(it->data(), it->length());
+		line->m_sMark.m_cModified = seq;
+	}
+}
+
+void SetLines(CDocLineMgr& m, int seq, std::initializer_list<std::wstring_view> args)
+{
+	SetLines(m, seq, args.begin(), args.end());
+}
+
+struct RawLineData {
+	const wchar_t* line;
+	int seq;
+};
+
+COpeLineData MakeOpeLineData(std::initializer_list<RawLineData> lines)
+{
+	COpeLineData data;
+	for (RawLineData rawLine : lines) {
+		CLineData line;
+		line.cmemLine = rawLine.line;
+		line.nSeq = rawLine.seq;
+		data.push_back(line);
+	}
+	return data;
+}
+
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	行の一部を置き換える。
+ */
+TEST(CSearchAgent, ReplaceData1)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
+
+	COpeLineData insData = MakeOpeLineData({{L"DDD", 2}});
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(0, 1), CLogicPoint(3, 1));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = &insData;
+	arg.nDelSeq = 1;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 3);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"AAA\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(1))->GetPtr(), L"DDD\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(1))->m_sMark.m_cModified.GetSeq(), 2);
+	EXPECT_STREQ(m.GetLine(CLogicInt(2))->GetPtr(), L"CCC\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(2))->m_sMark.m_cModified.GetSeq(), 1);
+
+	EXPECT_EQ(arg.nInsSeq, 1);
+	EXPECT_EQ(arg.pcmemDeleted->size(), 1);
+	EXPECT_STREQ(arg.pcmemDeleted->at(0).cmemLine.GetStringPtr(), L"BBB");
+	EXPECT_EQ(arg.pcmemDeleted->at(0).nSeq, 1);
+	EXPECT_EQ(arg.nDeletedLineNum, 0);
+	EXPECT_EQ(arg.nInsLineNum, 0);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(3, 1));
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	行全体を置き換える。
+ */
+TEST(CSearchAgent, ReplaceData2)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
+
+	COpeLineData insData = MakeOpeLineData({{L"DDD\n", 2}});
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(0, 1), CLogicPoint(4, 1));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = &insData;
+	arg.nDelSeq = 1;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 3);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"AAA\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(1))->GetPtr(), L"DDD\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(1))->m_sMark.m_cModified.GetSeq(), 2);
+	EXPECT_STREQ(m.GetLine(CLogicInt(2))->GetPtr(), L"CCC\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(2))->m_sMark.m_cModified.GetSeq(), 1);
+
+	EXPECT_EQ(arg.nInsSeq, 0);
+	EXPECT_EQ(arg.pcmemDeleted->size(), 1);
+	EXPECT_STREQ(arg.pcmemDeleted->at(0).cmemLine.GetStringPtr(), L"BBB\n");
+	EXPECT_EQ(arg.pcmemDeleted->at(0).nSeq, 1);
+	EXPECT_EQ(arg.nDeletedLineNum, 1);
+	EXPECT_EQ(arg.nInsLineNum, 1);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(0, 2));
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	行末の改行を削除する。
+ */
+TEST(CSearchAgent, ReplaceData3)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
+
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(3, 1), CLogicPoint(4, 1));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = nullptr;
+	arg.nDelSeq = 1;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 2);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"AAA\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(1))->GetPtr(), L"BBBCCC\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(1))->m_sMark.m_cModified.GetSeq(), 1);
+
+	EXPECT_EQ(arg.nInsSeq, 0);
+	EXPECT_EQ(arg.pcmemDeleted->size(), 2);
+	EXPECT_STREQ(arg.pcmemDeleted->at(0).cmemLine.GetStringPtr(), L"\n");
+	EXPECT_EQ(arg.pcmemDeleted->at(0).nSeq, 1);
+	EXPECT_STREQ(arg.pcmemDeleted->at(1).cmemLine.GetStringPtr(), L"");
+	EXPECT_EQ(arg.pcmemDeleted->at(1).nSeq, 1);
+	EXPECT_EQ(arg.nDeletedLineNum, 1);
+	EXPECT_EQ(arg.nInsLineNum, 0);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(3, 1));
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	行末の改行を削除する。削除するデータ長が長いケース。
+ */
+TEST(CSearchAgent, ReplaceData4)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
+
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(1, 1), CLogicPoint(4, 1));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = nullptr;
+	arg.nDelSeq = 1;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 2);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"AAA\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(1))->GetPtr(), L"BCCC\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(1))->m_sMark.m_cModified.GetSeq(), 1);
+
+	EXPECT_EQ(arg.nInsSeq, 0);
+	EXPECT_EQ(arg.pcmemDeleted->size(), 2);
+	EXPECT_STREQ(arg.pcmemDeleted->at(0).cmemLine.GetStringPtr(), L"BB\n");
+	EXPECT_EQ(arg.pcmemDeleted->at(0).nSeq, 1);
+	EXPECT_STREQ(arg.pcmemDeleted->at(1).cmemLine.GetStringPtr(), L"");
+	EXPECT_EQ(arg.pcmemDeleted->at(1).nSeq, 1);
+	EXPECT_EQ(arg.nDeletedLineNum, 1);
+	EXPECT_EQ(arg.nInsLineNum, 0);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(1, 1));
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	行末の改行を削除する。対象行がデータ末尾であるケース。
+ */
+TEST(CSearchAgent, ReplaceData5)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"AAA\n"});
+
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(3, 0), CLogicPoint(4, 0));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = nullptr;
+	arg.nDelSeq = 1;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"AAA");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 1);
+
+	EXPECT_EQ(arg.nInsSeq, 0);
+	EXPECT_EQ(arg.pcmemDeleted->size(), 1);
+	EXPECT_STREQ(arg.pcmemDeleted->at(0).cmemLine.GetStringPtr(), L"\n");
+	EXPECT_EQ(arg.pcmemDeleted->at(0).nSeq, 1);
+	EXPECT_EQ(arg.nDeletedLineNum, 0);
+	EXPECT_EQ(arg.nInsLineNum, 0);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(3, 0));
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	文字を挿入して複数行を連結する。
+ */
+TEST(CSearchAgent, ReplaceData6)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
+
+	COpeLineData insData = MakeOpeLineData({{L" ", 2}});
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(2, 1), CLogicPoint(1, 2));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = &insData;
+	arg.nDelSeq = 1;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 2);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"AAA\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(1))->GetPtr(), L"BB CC\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(1))->m_sMark.m_cModified.GetSeq(), 2);
+
+	EXPECT_EQ(arg.nInsSeq, 1);
+	EXPECT_EQ(arg.pcmemDeleted->size(), 2);
+	EXPECT_STREQ(arg.pcmemDeleted->at(0).cmemLine.GetStringPtr(), L"B\n");
+	EXPECT_EQ(arg.pcmemDeleted->at(0).nSeq, 1);
+	EXPECT_STREQ(arg.pcmemDeleted->at(1).cmemLine.GetStringPtr(), L"C");
+	EXPECT_EQ(arg.pcmemDeleted->at(1).nSeq, 1);
+	EXPECT_EQ(arg.nDeletedLineNum, 1);
+	EXPECT_EQ(arg.nInsLineNum, 0);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(3, 1));
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	既存行の間に行を挿入し、次の行の先頭に文字を挿入する。
+	先頭に文字を挿入した行がデータの末尾であるケース。
+ */
+TEST(CSearchAgent, ReplaceData7)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"AAA\n", L"BBB\n"});
+
+	COpeLineData insData = MakeOpeLineData({{L"CCC\n", 2}, {L"DDD", 3}});
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(0, 1), CLogicPoint(0, 1));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = &insData;
+	arg.nDelSeq = 0;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 3);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"AAA\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(1))->GetPtr(), L"CCC\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(1))->m_sMark.m_cModified.GetSeq(), 2);
+	EXPECT_STREQ(m.GetLine(CLogicInt(2))->GetPtr(), L"DDDBBB\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(2))->m_sMark.m_cModified.GetSeq(), 3);
+
+	EXPECT_EQ(arg.nInsSeq, 1);
+	EXPECT_TRUE(arg.pcmemDeleted->empty());
+	EXPECT_EQ(arg.nDeletedLineNum, 0);
+	EXPECT_EQ(arg.nInsLineNum, 1);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(3, 2));
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	既存行の間に行を挿入し、次の行の先頭に文字を挿入する。
+	先頭に文字を挿入した行がデータの末尾ではないケース。
+ */
+TEST(CSearchAgent, ReplaceData8)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
+
+	COpeLineData insData = MakeOpeLineData({{L"DDD\n", 2}, {L"EEE", 3}});
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(0, 1), CLogicPoint(0, 1));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = &insData;
+	arg.nDelSeq = 0;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 4);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"AAA\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(1))->GetPtr(), L"DDD\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(1))->m_sMark.m_cModified.GetSeq(), 2);
+	EXPECT_STREQ(m.GetLine(CLogicInt(2))->GetPtr(), L"EEEBBB\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(2))->m_sMark.m_cModified.GetSeq(), 3);
+	EXPECT_STREQ(m.GetLine(CLogicInt(3))->GetPtr(), L"CCC\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(3))->m_sMark.m_cModified.GetSeq(), 1);
+
+	EXPECT_EQ(arg.nInsSeq, 1);
+	EXPECT_TRUE(arg.pcmemDeleted->empty());
+	EXPECT_EQ(arg.nDeletedLineNum, 0);
+	EXPECT_EQ(arg.nInsLineNum, 1);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(3, 2));
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	既存行の末尾に新しい行を追加する。
+ */
+TEST(CSearchAgent, ReplaceData9)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"AAA\n", L"BBB\n"});
+
+	COpeLineData insData = MakeOpeLineData({{L"CCC\n", 2}});
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(0, 2), CLogicPoint(0, 2));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = &insData;
+	arg.nDelSeq = 0;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 3);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"AAA\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(1))->GetPtr(), L"BBB\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(1))->m_sMark.m_cModified.GetSeq(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(2))->GetPtr(), L"CCC\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(2))->m_sMark.m_cModified.GetSeq(), 2);
+
+	EXPECT_EQ(arg.nInsSeq, 0);
+	EXPECT_TRUE(arg.pcmemDeleted->empty());
+	EXPECT_EQ(arg.nDeletedLineNum, 0);
+	EXPECT_EQ(arg.nInsLineNum, 1);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(0, 3));
+}
+
+/*!
+	CSearchAgent::ReplaceData のテスト
+
+	置換後の文字列が既存の行バッファの有効長に収まる場合の最適化済みコードパスの検査。
+ */
+TEST(CSearchAgent, ReplaceData10)
+{
+	CDocLineMgr m;
+	SetLines(m, 1, {L"0123456789\n"});
+	m.GetLine(CLogicInt(0))->_GetDocLineData().AllocStringBuffer(15);
+
+	COpeLineData insData = MakeOpeLineData({{L"0123", 2}});
+	COpeLineData delData;
+
+	DocLineReplaceArg arg;
+	arg.sDelRange = CLogicRange(CLogicPoint(9, 0), CLogicPoint(10, 0));
+	arg.pcmemDeleted = &delData;
+	arg.pInsData = &insData;
+	arg.nDelSeq = 0;
+	arg.nInsSeq = -1;
+	CSearchAgent(&m).ReplaceData(&arg, false);
+
+	EXPECT_EQ(m.GetLineCount(), 1);
+	EXPECT_STREQ(m.GetLine(CLogicInt(0))->GetPtr(), L"0123456780123\n");
+	EXPECT_EQ(m.GetLine(CLogicInt(0))->m_sMark.m_cModified.GetSeq(), 2);
+
+	EXPECT_EQ(arg.nInsSeq, 1);
+	EXPECT_EQ(arg.pcmemDeleted->size(), 1);
+	EXPECT_STREQ(arg.pcmemDeleted->at(0).cmemLine.GetStringPtr(), L"9");
+	EXPECT_EQ(arg.pcmemDeleted->at(0).nSeq, 1);
+	EXPECT_EQ(arg.nDeletedLineNum, 0);
+	EXPECT_EQ(arg.nInsLineNum, 0);
+	EXPECT_EQ(arg.ptNewPos, CLogicPoint(13, 0));
+}

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -108,6 +108,7 @@
     <ClCompile Include="code-main.cpp" />
     <ClCompile Include="test-cdocline.cpp" />
     <ClCompile Include="test-cdoclinemgr.cpp" />
+    <ClCompile Include="test-csearchagent.cpp" />
     <ClCompile Include="test-printEFunctionCode.cpp" />
     <ClCompile Include="test-cclipboard.cpp" />
     <ClCompile Include="test-ccodebase.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -145,6 +145,9 @@
     <ClCompile Include="test-cdoclinemgr.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-csearchagent.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
# PR の目的

CSearchAgent::ReplaceData に対する自動テストを追加します。

## カテゴリ

- その他の問題

## PR のメリット

- コードカバレッジが向上します。

## 仕様・動作説明

- 例によって bEnableExtEol フラグへの参照を関数外に追い出す変更を行います。
- 細かな最適化コードに対するカバレッジが完全ではありません。
- 実行条件が判然としなかった一部のコードパスをカバーしていません。

カバレッジの不足については追々対処していきます。

## PR の影響範囲

CSearchAgent::ReplaceData と呼び出し元のコードに影響します。
