### PR TITLE
GitHub Actions の環境変数に対応する

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -45,6 +45,10 @@ jobs:
           - Win32
           - x64
 
+    env:
+      GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+      GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     ## see https://github.com/actions/checkout

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -234,9 +234,6 @@ exit /b 0
 		@echo GITHUB_PR_HEAD_COMMIT       : %GITHUB_PR_HEAD_COMMIT%
 		@echo GITHUB_PR_HEAD_URL          : %GITHUB_PR_HEAD_URL%
 		@echo.
-		@echo APPVEYOR_URL          : %APPVEYOR_URL%
-		@echo APPVEYOR_PROJECT_SLUG : %APPVEYOR_PROJECT_SLUG%
-		@echo.
 
 		if exist "%GITHASH_H%" del "%GITHASH_H%"
 		move /y "%GITHASH_H_TMP%" "%GITHASH_H%"
@@ -340,21 +337,5 @@ exit /b 0
 	) else (
 		echo #define CI_BUILD_URL                  "%CI_BUILD_URL%"
 	)
-
-	echo // APPVEYOR specific variables
-
-	if "%APPVEYOR_URL%" == "" (
-		echo // APPVEYOR_URL is not defined
-	) else (
-		echo #define APPVEYOR_URL "%APPVEYOR_URL%"
-	)
-
-	if "%APPVEYOR_PROJECT_SLUG%" == "" (
-		echo // APPVEYOR_PROJECT_SLUG is not defined
-	) else (
-		echo #define APPVEYOR_PROJECT_SLUG "%APPVEYOR_PROJECT_SLUG%"
-	)
-	echo // APPVEYOR specific variables end
-	echo //
 
 	exit /b 0

--- a/sakura/githash.bat
+++ b/sakura/githash.bat
@@ -219,22 +219,24 @@ exit /b 0
 	) else (
 		@echo GIT_SHORT_COMMIT_HASH : %GIT_SHORT_COMMIT_HASH%
 		@echo GIT_COMMIT_HASH       : %GIT_COMMIT_HASH%
-		@echo GIT_REMOTE_ORIGIN_URL : %GIT_REMOTE_ORIGIN_URL%
 		@echo GIT_TAG_NAME          : %GIT_TAG_NAME%
+		@echo GIT_REMOTE_ORIGIN_URL : %GIT_REMOTE_ORIGIN_URL%
 		@echo.
+		@echo CI_ACCOUNT_NAME       : %CI_ACCOUNT_NAME%
 		@echo CI_REPO_NAME          : %CI_REPO_NAME%
-		@echo CI_ACCOUNT_NAME             : %CI_ACCOUNT_NAME%
-		@echo CI_BUILD_VERSION            : %CI_BUILD_VERSION%
-		@echo CI_BUILD_NUMBER             : %CI_BUILD_NUMBER%
-		@echo CI_BUILD_URL                : %CI_BUILD_URL%
+		@echo CI_BUILD_VERSION      : %CI_BUILD_VERSION%
+		@echo CI_BUILD_NUMBER       : %CI_BUILD_NUMBER%
+		@echo CI_BUILD_URL          : %CI_BUILD_URL%
 		@echo.
 		@echo GITHUB_COMMIT_URL           : %GITHUB_COMMIT_URL%
-		@echo GITHUB_PR_HEAD_URL          : %GITHUB_PR_HEAD_URL%
-		@echo GITHUB_PR_HEAD_COMMIT       : %GITHUB_PR_HEAD_COMMIT%
+		@echo GITHUB_PR_NUMBER            : %GITHUB_PR_NUMBER%
 		@echo GITHUB_PR_HEAD_SHORT_COMMIT : %GITHUB_PR_HEAD_SHORT_COMMIT%
+		@echo GITHUB_PR_HEAD_COMMIT       : %GITHUB_PR_HEAD_COMMIT%
+		@echo GITHUB_PR_HEAD_URL          : %GITHUB_PR_HEAD_URL%
 		@echo.
 		@echo APPVEYOR_URL          : %APPVEYOR_URL%
 		@echo APPVEYOR_PROJECT_SLUG : %APPVEYOR_PROJECT_SLUG%
+		@echo.
 
 		if exist "%GITHASH_H%" del "%GITHASH_H%"
 		move /y "%GITHASH_H_TMP%" "%GITHASH_H%"


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
[githash.bat](sakura/githash.bat) を GitHub Actions に対応させます。

## <!-- 必須 --> カテゴリ
- 機能追加
  - GitHub Actions ビルド版
- ビルド関連
  - GitHub Actions

## <!-- 自明なら省略可 --> PR の背景
#1630 でバッチファイルを確認していた際、 githash.bat が GitHub Actions に対応していないことに気が付きました。

経緯を調査したところ、 #1259 にて GitHub Actions を導入した際の残件であり、現在に至るまで対応が行われていません。
（以下、 #1259 の本文より引用）
> ## 未実装なところ
>    - ドキュメント
>    - Azure Pipelines や Appveyor ビルドで取得している各種環境変数 (#1183) には対応していない
>    - #922 には対応できないので、chm および installer のビルドは無効化している
>    - Artifacts が一括して一つの zip にまとめられるが、個別にダウンロードできるようにする
>    - `microsoft/setup-msbuild@v1.0.0` で自動的に Visual Studio 2019 が選択される。
>

この PR で上記のうち「各種環境変数への対応」を行い、 GitHub Actions でのビルドにおいても必要な環境変数が設定されるようにします。

## <!-- 自明なら省略可 --> PR のメリット
- GHA でビルドを行うときも必要な環境変数が定義されるようになります。
    - PR の成果物におけるバージョン情報ダイアログにて、
        - PR 番号が表示されるようになります。
        - PR ページへのリンクが設定されるようになります。
- 成果物をローカルビルドと区別可能になります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
- 特にありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
GitHub Actions の環境変数では、プルリクエストの番号とコミットハッシュが提供されません。
対策として、 PR によるワークフローの実行時に Webhook ペイロードオブジェクトからこれらの情報を取得し、次の環境変数にセットして代替とします。
なお、 PR 以外の Action 実行時は空文字列がセットされます。

| オブジェクトのキー | 説明 | セットされる環境変数 |
| ---- | ---- | ---- |
| github.event.pull_request.number | PR 番号 | GITHUB_PULL_REQUEST_NUMBER |
| github.event.pull_request.head.sha | PR のコミットハッシュ | GITHUB_PULL_REQUEST_HEAD_SHA |

各ジョブの MSBuild ステップにて実行される githash.bat では、 GitHub Actions が提供する環境変数と上記の環境変数からビルドに必要な環境変数を生成し、その値を githash.h として出力します。

| 参照する CI 環境変数 | 説明 | 利用している環境変数 |
| ---- | ---- | ---- |
| GITHUB_REPOSITORY | リポジトリ名 | CI_REPO_NAME <br /> GIT_COMMIT_URL <br /> GITHUB_PR_HEAD_URL <br /> CI_BUILD_URL |
| GITHUB_ACTOR | ワークフローの実行ユーザー名 | CI_ACCOUNT_NAME |
| GITHUB_RUN_NUMBER | ワークフローの一意な実行番号 | CI_BUILD_NUMBER |
| GITHUB_RUN_ID | ワークフローの一意な識別番号 | CI_BUILD_VERSION <br /> CI_BUILD_URL |
| GITHUB_ACTIONS | （ Action の実行中は常に`true`） | GIT_COMMIT_URL <br /> GITHUB_PR_HEAD_URL <br /> CI_BUILD_URL |
| GITHUB_SERVER_URL | GitHub サーバーのURL | GIT_COMMIT_URL <br /> GITHUB_PR_HEAD_URL <br /> CI_BUILD_URL |
| GITHUB_PULL_REQUEST_NUMBER | PR 番号 | GITHUB_PR_NUMBER <br /> GITHUB_PR_HEAD_URL |
| GITHUB_PULL_REQUEST_HEAD_SHA | PR のコミットハッシュ | GITHUB_PR_HEAD_COMMIT <br /> GITHUB_PR_HEAD_SHORT_COMMIT <br /> GITHUB_PR_HEAD_URL |

また、プロジェクト名に相当する情報（ APPVEYOR_PROJECT_SLUG に相当する情報）も提供されませんが、 CI_BUILD_URL の生成にはこの情報がなくても支障がないことから代替策は用意していません。

githash.bat が生成するヘッダファイルには依然として AppVeyor の環境変数が出力されるようになっていましたが、今回コンソールに出力される内容を調整する一環として廃止しています（今後本体側コードで使用する予定があればお申し出ください）。

なお、この PR では #1190 で言及された次の変更は行っていません。リクエストがあれば別途対応しますのでお申し出ください。
- 環境変数の名称変更
    - GITHUB_PR_HEAD_SHORT_COMMIT → GITHUB_PR_SHORT_COMMIT_HASH
    - GITHUB_PR_HEAD_COMMIT → GITHUB_PR_COMMIT_HASH
    - GITHUB_PR_HEAD_URL → GITHUB_PR_URL
- GITHUB_TAG_URL の追加
  定義：`set GIT_TAG_URL=%PREFIX_GITHUB%/%CI_REPO_NAME%/tree/%GIT_TAG_NAME%`

## <!-- わかる範囲で --> PR の影響範囲
（ CI ビルドにおける） githash.h の生成プロセス

## <!-- 必須 --> テスト内容
githash.bat のコンソール出力内容、生成されたヘッダファイル、成果物のファイル名を確認します。

## <!-- なければ省略可 --> 関連 issue, PR
#1259 GitHub Actions を導入
#1271 残件対応①：ヘルプとインストーラのビルド
#1285 残件対応②：成果物を個別に Zip ファイル化

## <!-- なければ省略可 --> 参考資料
- [環境変数の定義](https://docs.github.com/en/actions/reference/environment-variables)
- [ワークフローで利用可能なコンテキストについての説明](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts)
- [pull_request イベントでの Webhook ペイロードの説明](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request)
