### PR TITLE
タブ幅が半角単位8桁を超える場合でも下線が最後まで描画されるようにする

### DIFF
--- a/sakura_core/view/figures/CFigure_Comma.cpp
+++ b/sakura_core/view/figures/CFigure_Comma.cpp
@@ -28,10 +28,8 @@
 #include "types/CTypeSupport.h"
 #include "apiwrap/StdApi.h"
 
-void _DispTab( CGraphics& gr, DispPos* pDispPos, const CEditView* pcView );
-
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                         CFigure_Comma                         //
+//                        CFigure_Comma                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 bool CFigure_Comma::Match(const wchar_t* pText, int nTextLen) const
@@ -58,51 +56,53 @@ void CFigure_Comma::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcVie
 	DispPos& sPos=*pDispPos;
 
 	//必要なインターフェース
+	const CLayoutMgr& pcLayoutMgr = pcView->GetDocument()->m_cLayoutMgr;
 	const CTextMetrics* pMetrics=&pcView->GetTextMetrics();
 	const CTextArea* pArea=&pcView->GetTextArea();
 
 	int nLineHeight = pMetrics->GetHankakuDy();
-	int nCharWidth = pMetrics->GetCharPxWidth();	// Layout→Px
 
 	CTypeSupport cTabType(pcView,COLORIDX_TAB);
 
 	// これから描画するタブ幅
-	CLayoutXInt tabDispWidthLayout = pcView->m_pcEditDoc->m_cLayoutMgr.GetActualTsvSpace( sPos.GetDrawCol(), L',' );
-	int tabDispWidth = (Int)tabDispWidthLayout;
+	CLayoutXInt nTabLayoutWidth = pcLayoutMgr.GetActualTsvSpace(sPos.GetDrawCol(), L',');
+	size_t nTabDispWidth = static_cast<Int>(nTabLayoutWidth) / pcLayoutMgr.GetWidthPerKeta();
 	if( pcView->m_bMiniMap ){
 		CLayoutMgr mgrTemp;
-		mgrTemp.SetTabSpaceInfo(pcView->m_pcEditDoc->m_cLayoutMgr.GetTabSpaceKetas(),
-			CLayoutXInt(pcView->GetTextMetrics().GetHankakuWidth()) );
-		tabDispWidthLayout = mgrTemp.GetActualTabSpace(sPos.GetDrawCol());
-		tabDispWidth = (Int)tabDispWidthLayout;
+		mgrTemp.SetTabSpaceInfo(pcLayoutMgr.GetTabSpaceKetas(), static_cast<CLayoutXInt>(pMetrics->GetHankakuWidth()));
+		nTabLayoutWidth = mgrTemp.GetActualTabSpace(sPos.GetDrawCol());
+		nTabDispWidth = static_cast<Int>(nTabLayoutWidth) / mgrTemp.GetWidthPerKeta();
 	}
 
 	// タブ記号領域
 	RECT rcClip2;
 	rcClip2.left = sPos.GetDrawPos().x;
-	rcClip2.right = rcClip2.left + nCharWidth * tabDispWidth;
+	rcClip2.right = rcClip2.left + static_cast<Int>(nTabLayoutWidth);
 	if( rcClip2.left < pArea->GetAreaLeft() ){
 		rcClip2.left = pArea->GetAreaLeft();
 	}
 	rcClip2.top = sPos.GetDrawPos().y;
 	rcClip2.bottom = sPos.GetDrawPos().y + nLineHeight;
-	int nLen = wcslen( m_pTypeData->m_szTabViewString );
 
 	if( pArea->IsRectIntersected(rcClip2) ){
 		if( cTabType.IsDisp() ){	//CSVモード
+			std::wstring szViewString = L",";
+			if (szViewString.length() < nTabDispWidth) {
+				szViewString.append(nTabDispWidth - szViewString.length(), L' ');
+			}
 			::ExtTextOut(
 				gr,
 				sPos.GetDrawPos().x,
 				sPos.GetDrawPos().y,
 				ExtTextOutOption() & ~(bTrans? ETO_OPAQUE: 0),
 				&rcClip2,
-				L",       ",
-				tabDispWidth <= 8 ? tabDispWidth : 8, // Sep. 22, 2002 genta
+				szViewString.c_str(),
+				static_cast<UINT>(szViewString.length()),
 				pMetrics->GetDxArray_AllHankaku()
 			);
 		}
 	}
 
 	//Xを進める
-	sPos.ForwardDrawCol(tabDispWidthLayout);
+	sPos.ForwardDrawCol(nTabLayoutWidth);
 }


### PR DESCRIPTION
# PR の目的
タブ記号の描画処理に関する不具合を修正します。

## カテゴリ
- 不具合修正

## 背景
[patchunicode#1053](https://sourceforge.net/p/sakura-editor/patchunicode/1053/) で指摘されている通り、タブ記号に対して下線を描画する設定が有効になっている際、
下線が半角単位8桁分しか描画されない不具合が存在します。
対策を行って、下線がタブ幅いっぱいに描画されるようにします。

### 再現手順
1. タイプ別設定を開く
2. スクリーンタブのレイアウト設定にて、タブ幅に「8」を超える値を設定する
3. カラータブの色指定にて、「TAB記号」を選択し、「下線」のチェックボックスをオンにする
4. タブ文字を入力する

### 参考画像
![スクリーンショット 2021-05-21 203029](https://user-images.githubusercontent.com/67105596/119130625-6b5a0880-ba73-11eb-8144-c28501d2c08c.png)

## PR のメリット
- 下線がタブ幅いっぱいに描画されるようになります。

## PR のデメリット (トレードオフとかあれば)
- 変更箇所は自動化された単体テストのカバー範囲外です。

## 仕様・動作説明
この不具合は、タブ記号の描画幅が最長で8桁に固定されているためです。
なお、タブ幅の上限値は「64」です。

以前よりタブの描画処理ではタブ幅をCLayoutMgrから取得するようになっていましたので、この PR では取得した値を半角単位桁数に換算し、タブ描画文字列の長さが換算値よりも小さければ不足分を補うようにしました。
（以下、前後比較）
- タブ通常表示
    - 前：タブ表示文字列を、その長さ分描画するようになっていた。  
      タブ表示文字列は最大で8字分しかないため、下線はそこまでしか描画されない。
    - 後：タブ表示文字列をstd::wstring型オブジェクトに入れ、タブ幅の長さが足りないときは空白を補うようにした。
- タブ矢印表示
    - 前：矢印の背景として描画される空白の長さが8文字固定でした。  
      なお、長い矢印表示の場合、矢印だけはタブ幅いっぱいに描画されます。
    - 後：タブ幅の長さ分の空白を持つstd::wstring型オブジェクトを作成し、これを描画に使うようにした。
- CSVモード
    - 前：タブの背景として描画される空白の長さが8文字固定でした。
    - 後：タブ幅の長さ分の空白を持つstd::wstring型オブジェクトを作成し、これを描画に使うようにした。

なお、既存パッチでは不具合と関係しない他の変更が同時に実施されているように見えたため、既存パッチは利用していません。

## PR の影響範囲
- タブ記号の描画処理
- CSVモードにおけるカンマ記号の描画処理

## テスト内容
変更後のサクラエディタで前述した手順を再現し、発生しないことを確認します。
TSV/CSVモードでのテストは、添付のファイル（ 6be2aec53e7063fbe4b536b1e584786af5de9d23 のビルドログ）を開いてタイプ別設定を変更し、設定が反映されたときの描画結果を確認します。
各自で用意したカンマ区切り・タブ区切りテキストでも確認できます。
[test-file.zip](https://github.com/sakura-editor/sakura/files/6522209/test-file.zip)

なお、TAB通常表示およびTAB矢印表示における影響は下表の通りです。
TAB表示の設定を切り替えてそれぞれの描画を確認してください。
| TAB表示 → <br /> 表示モード↓ | 文字指定 | 短い矢印 | 長い矢印 |
| ---- | ---- | ---- | ---- |
| 通常モード | 下線の描画に影響 | 下線の描画に影響 | 矢印記号と下線の描画に影響 |
| TSVモード | 下線の描画に影響 | 下線の描画に影響 | 矢印記号と下線の描画に影響 |

### 確認方法

- 通常モード
    1. サクラエディタを開く
    2. タイプ別設定を変更  
      スクリーンタブ：TAB幅に「8」を超える値を設定する
      スクリーンタブ：TAB表示に確認したい表示形式（上記表を参照）を設定
      カラータブ：色指定でTAB記号の下線を有効にする
    3. タブ文字を入力し、描画結果を確認する
- TSV モード
    1. サクラエディタを開く
    2. 添付した圧縮ファイルに含まれる `sample_buildlog_x64_release.txt` を開く
    3. タイプ別設定を変更  
      スクリーンタブ：折り返し方法を「折り返さない」に設定
      スクリーンタブ：TAB表示に確認したい表示形式（上記表を参照）を設定
      スクリーンタブ：レイアウトセクション一番下のコンボボックスを「TSV」に設定する
      カラータブ：色指定でTAB記号の下線を有効にする
    4. 設定変更後のタブ表示を確認する
- CSV モード
    1. サクラエディタを開く
    2. 添付した圧縮ファイルに含まれる `sample_buildlog_x64_release.csv` を開く
    3. タイプ別設定を変更  
      スクリーンタブ：折り返し方法を「折り返さない」に設定
      スクリーンタブ：レイアウトセクション一番下のコンボボックスを「CSV」に設定する
      カラータブ：色指定でTAB記号の下線を有効にする
    4. 設定変更後のタブ表示を確認する

いずれのパターンにおいて、次の2点が確認できれば問題ないと思います。
1. 下線がタブ幅いっぱいに描画されるようになった
2. 長い矢印記号がこれまで通りタブ幅いっぱいに描画されている（CSVモードの時は矢印記号を使わないので確認不要です）

## 関連 issue, PR
close: [patchunicode#1053](https://sourceforge.net/p/sakura-editor/patchunicode/1053/)
#1645 … 単位を桁数に戻した場合はタブ記号描画幅の計算処理も必ず変更しなければなりません。
