### PR TITLE
印刷ページ設定ダイアログのフォントが巨大化する問題を修正

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -185,12 +185,12 @@ BOOL CDialog::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	// Modified by KEITA for WIN64 2003.9.6
 	::SetWindowLongPtr( m_hWnd, DWLP_USER, lParam );
 
+	m_hFontDialog = UpdateDialogFont( hwndDlg );
+
 	/* ダイアログデータの設定 */
 	SetData();
 
 	SetDialogPosSize();
-
-	m_hFontDialog = UpdateDialogFont( hwndDlg );
 
 	m_bInited = TRUE;
 	return TRUE;

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -160,14 +160,7 @@ BOOL CDlgPrintSetting::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam 
 	//	::SetTimer( GetHwnd(), IDT_PRINTSETTING, 500, NULL );
 	//UpdatePrintableLineAndColumn();
 
-	BOOL bRet = CDialog::OnInitDialog( GetHwnd(), wParam, lParam );
-
-	// ダイアログフォントの寸法を得ておく
-	LOGFONT	lf;
-	::GetObject(GetDialogFont(), sizeof(LOGFONT), &lf);
-	m_nFontHeight = lf.lfHeight;		// フォントサイズ
-
-	return bRet;
+	return CDialog::OnInitDialog( GetHwnd(), wParam, lParam );
 }
 
 BOOL CDlgPrintSetting::OnDestroy( void )
@@ -905,14 +898,17 @@ void CDlgPrintSetting::SetFontName( int idTxt, int idUse, LOGFONT& lf, int nPoin
 	CheckDlgButtonBool( GetHwnd(), idUse, bUseFont);
 	::EnableWindow( GetItemHwnd( idUse ), bUseFont );
 	if (bUseFont) {
-		LOGFONT	lft;
-		lft = lf;
-		lft.lfHeight = m_nFontHeight;		// フォントサイズをダイアログに合せる
+		// サイズだけはダイアログフォントに合わせ
+		// それ以外は引数lfで指定された設定を採用
+		LOGFONT	lfCreate = lf;
+		LOGFONT	lfDialogFont = {};
+		::GetObject( GetDialogFont(), sizeof(LOGFONT), &lfDialogFont );
+		lfCreate.lfHeight = lfDialogFont.lfHeight;
 
 		HFONT	hFontOld = (HFONT)::SendMessage(GetItemHwnd( idTxt ), WM_GETFONT, 0, 0 );
 
 		// 論理フォントを作成
-		HFONT	hFont = ::CreateFontIndirect( &lft );
+		HFONT	hFont = ::CreateFontIndirect( &lfCreate );
 		if (hFont) {
 			// フォントの設定
 			::SendMessage( GetItemHwnd( idTxt ), WM_SETFONT, (WPARAM)hFont, MAKELPARAM(FALSE, 0) );

--- a/sakura_core/dlg/CDlgPrintSetting.h
+++ b/sakura_core/dlg/CDlgPrintSetting.h
@@ -58,7 +58,6 @@ private:
 	PRINTSETTING	m_PrintSettingArr[MAX_PRINTSETTINGARR];
 	int				m_nLineNumberColumns;					// 行番号表示する場合の桁数
 	bool			m_bPrintableLinesAndColumnInvalid;
-	int				m_nFontHeight;							// ダイアログのフォントのサイズ
 
 protected:
 	/*


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

本 PR では #1678 の「再現手順」の操作をした時に起きる以下の問題点を解消します。

1. 印刷ページ設定ダイアログのフォントが巨大化する (#1678 で指摘されている現象)
2. ヘッダー/フッター設定のフォント名の描画に、選択されたフォントが適用されていない
2. ヘッダー/フッター設定のフォント名のサイズが大きすぎる (「1」により表面化していない)

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

目的に記載の通りです。

## <!-- 自明なら省略可 --> PR のメリット

不具合が解消されます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

特にありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

### 1. 印刷ページ設定ダイアログのフォントが巨大化する

CDialog::OnInitDialog における CDialog::m_hFontDialog の設定タイミングに問題があります。
SetData の先 (CDlgPrintSetting::SetFontName) で参照がされる可能性があったにも関わらず、現状はそれよりも後に初期化がされています。

https://github.com/sakura-editor/sakura/blob/81f08b1f02bc3482da0e2771ff6824cbd17ef12e/sakura_core/dlg/CDialog.cpp#L182-L197

対策内容：
* CDialog::m_hFontDialog の初期化タイミングを CDialog::SetData よりも前に移動します。

### 2. ヘッダー/フッター設定のフォント名の描画に、選択されたフォントが適用されていない

CDialog::OnInitDialog における UpdateDialogFont の呼び出しタイミングに問題があります。
SetData の先 (CDlgPrintSetting::SetFontName) で STATIC コントロールに対して専用のフォントが設定される場合があるにも関わらず、その後、UpdateDialogFont -> SetFontRecursive が呼び出されることで、システムフォント相当のフォントで上書き設定されてしまっています。

対策内容：
* UpdateDialogFont の呼び出しタイミングを CDialog::SetData よりも前に移動します。

### 3. ヘッダー/フッターのフォント名のサイズが大きすぎる

CDlgPrintSetting::OnInitDialog における CDlgPrintSetting::m_nFontHeight の設定タイミングに問題があります。
そのため CDlgPrintSetting::SetFontName (CDialog::OnInitDialog を経由して呼ばれる) におけるフォントハンドル作成時の高さ (LOGFONT::lfHeight) に 0 が指定されてしまいます。

https://github.com/sakura-editor/sakura/blob/81f08b1f02bc3482da0e2771ff6824cbd17ef12e/sakura_core/dlg/CDlgPrintSetting.cpp#L163-L168

https://github.com/sakura-editor/sakura/blob/81f08b1f02bc3482da0e2771ff6824cbd17ef12e/sakura_core/dlg/CDlgPrintSetting.cpp#L910-L915

対策内容：
* CDlgPrintSetting::SetFontName でのフォント作成時に指定するサイズを、CDialog::GetDialogFont から得たフォントハンドルを元に取得するようにします。
* それにより不要となる CDlgPrintSetting::m_nFontHeight を廃止します。(使用されていた場所は CDlgPrintSetting::SetFontName のみ)

## <!-- わかる範囲で --> PR の影響範囲

印刷ページ設定ダイアログの見た目に影響があります。

CDialog::m_hFontDialog の初期化タイミングが変化したことで、CDialog クラスを継承しているダイアログボックスのうち、CDialog::GetDialogFont() を呼び出しているものについて動作が変わる可能性がありますが、それに該当するクラスは CDlgPrintSetting のみでした。

## <!-- 必須 --> テスト内容

※見た目の判断が必要なため手作業による確認を行います。

### 効果確認
* #1678 の「再現手順」通りの操作をした時に不具合が発生しないこと。
* 下図赤枠部の STATIC コントロールが、選択したフォント通りの書体かつダイアログフォントと同じサイズで表示されること。
![image](https://user-images.githubusercontent.com/11252784/119377853-8ab59780-bcf8-11eb-88c7-7965a3d41212.png)

### 弊害確認
* 印刷ページ設定ダイアログ上のコントロールのサイズ/位置が変更前後で変化しないこと。(不具合発生しない手順で表示させた場合において)

## <!-- なければ省略可 --> 関連 issue, PR

#1678 
#1421 

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
