### PR TITLE
アクティブタブの上部にトップバンドを描画する

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -103,7 +103,7 @@
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;Dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
       <SubSystem>Windows</SubSystem>
       <LargeAddressAware>true</LargeAddressAware>
@@ -147,7 +147,7 @@
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;Dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -188,7 +188,7 @@
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;Dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -229,7 +229,7 @@
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;Dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>

--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -94,6 +94,7 @@ LIBS= \
  -lmpr \
  -limagehlp \
  -lshlwapi \
+ -ldwmapi \
  -lwinmm \
  -lwindowscodecs \
  -lmsimg32 \

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -31,6 +31,7 @@
 #include <sstream>
 #include "apiwrap/StdApi.h"
 #include "config/system_constants.h"
+#include <dwmapi.h>    //DwmGetColorizationColor
 
 int CDPI::nDpiX = 96;
 int CDPI::nDpiY = 96;
@@ -429,4 +430,24 @@ HFONT UpdateDialogFont( HWND hwnd, BOOL force )
 	}
 
 	return hFontDialog;
+}
+
+/*!
+	アクセントカラーを取得
+	@param[out]	pColorOut	アクセントカラーを格納(nullptr許容)
+	@retval		true		取得成功
+	@retval		false		取得失敗
+*/
+bool GetSystemAccentColor( COLORREF* pColorOut )
+{
+	DWORD dwArgb = 0;
+	BOOL bOpaque = FALSE;
+	bool bResult = FALSE;
+	if( SUCCEEDED( ::DwmGetColorizationColor( &dwArgb, &bOpaque ) ) ){
+		if( pColorOut != nullptr ){
+			*pColorOut = RGB( (dwArgb >> 16) & 0xFFU, (dwArgb >> 8) & 0xFFU, dwArgb & 0xFFU );
+		}
+		bResult = TRUE;
+	}
+	return bResult;
 }

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -31,7 +31,7 @@
 #include <sstream>
 #include "apiwrap/StdApi.h"
 #include "config/system_constants.h"
-#include <dwmapi.h>    //DwmGetColorizationColor
+#include <dwmapi.h>	//DwmGetColorizationColor
 
 int CDPI::nDpiX = 96;
 int CDPI::nDpiY = 96;

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -195,4 +195,6 @@ private:
 
 HFONT UpdateDialogFont( HWND hwnd, BOOL force = FALSE );
 
+bool GetSystemAccentColor( COLORREF* pColorOut );
+
 #endif /* SAKURA_WINDOW_A0833476_5E32_46BE_87B6_ECD55F10D34A_H_ */

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -1614,7 +1614,9 @@ void CTabWnd::DrawTopBand( CGraphics& gr, const LPRECT lprcClient, int nTabIndex
 
 	if( rcCurSel.left < rcCurSel.right )
 	{
-		::MyFillRect( gr, rcCurSel, RGB( 255, 128, 0 ) );
+		COLORREF color = RGB( 255, 128, 0 );
+		::GetSystemAccentColor( &color );
+		::MyFillRect( gr, rcCurSel, color );
 	}
 }
 

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -20,8 +20,8 @@
 	warranty. In no event will the authors be held liable for any damages
 	arising from the use of this software.
 
-	Permission is granted to anyone to use this software for any purpose, 
-	including commercial applications, and to alter it and redistribute it 
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
 	freely, subject to the following restrictions:
 
 		1. The origin of this software must not be misrepresented;
@@ -30,7 +30,7 @@
 		   in the product documentation would be appreciated but is
 		   not required.
 
-		2. Altered source versions must be plainly marked as such, 
+		2. Altered source versions must be plainly marked as such,
 		   and must not be misrepresented as being the original software.
 
 		3. This notice may not be removed or altered from any source
@@ -1019,7 +1019,7 @@ void CTabWnd::Close( void )
 			::SetWindowLongPtr( m_hwndTab, GWLP_WNDPROC, (LONG_PTR)gm_pOldWndProc );
 			gm_pOldWndProc = NULL;
 		}
-		
+
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( m_hwndTab, GWLP_USERDATA, (LONG_PTR)NULL );
 
@@ -1086,7 +1086,7 @@ LRESULT CTabWnd::OnDestroy( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 
 	return 0L;
 }
- 
+
 /*! WM_LBUTTONDBLCLK処理
 	@date 2006.03.26 ryoji 新規作成
 */
@@ -1590,14 +1590,14 @@ void CTabWnd::DrawTopBand( CGraphics& gr, const LPRECT lprcClient, int nTabIndex
 	pt.y = 0;
 	::ClientToScreen( m_hwndTab, &pt );
 	::ScreenToClient( GetHwnd(), &pt );
-	rcCurSel.right = pt.x + (rcCurSel.right - rcCurSel.left) - 1;
-	rcCurSel.left = pt.x + 1;
-	rcCurSel.top = lprcClient->top + TAB_MARGIN_TOP - 2;
+	rcCurSel.left = pt.x;
+	rcCurSel.right = pt.x + (rcCurSel.right - rcCurSel.left);
+	rcCurSel.top = lprcClient->top + 1;
 	rcCurSel.bottom = lprcClient->top + TAB_MARGIN_TOP;
 
-	if( rcCurSel.left < lprcClient->left + TAB_MARGIN_LEFT )
-		rcCurSel.left = lprcClient->left + TAB_MARGIN_LEFT;	// 左端限界値
-
+	// 左右の範囲制限
+	// - 左側はそのまま
+	// - 右側は[<][>]ボタンが表示中ならその左端まで
 	HWND hwndUpDown = ::FindWindowEx( m_hwndTab, NULL, UPDOWN_CLASS, 0 );	// タブ内の Up-Down コントロール
 	if( hwndUpDown && ::IsWindowVisible( hwndUpDown ) )
 	{
@@ -1653,7 +1653,7 @@ LRESULT CTabWnd::OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 	}
 
 	// サイズボックスを描画する
-	if (!m_pShareData->m_Common.m_sWindow.m_bDispSTATUSBAR 
+	if (!m_pShareData->m_Common.m_sWindow.m_bDispSTATUSBAR
 		&& !m_pShareData->m_Common.m_sWindow.m_bDispFUNCKEYWND
 		&& m_pShareData->m_Common.m_sTabBar.m_eTabPosition == TabPosition_Bottom) {
 		SizeBox_ONOFF(true);
@@ -1934,7 +1934,7 @@ int CTabWnd::FindTabIndexByHWND( HWND hWnd )
 		tcitem.mask   = TCIF_PARAM;
 		tcitem.lParam = (LPARAM)0;
 		TabCtrl_GetItem( m_hwndTab, i, &tcitem );
-		
+
 		if( (HWND)tcitem.lParam == hWnd ) return i;
 	}
 

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -20,8 +20,8 @@
 	warranty. In no event will the authors be held liable for any damages
 	arising from the use of this software.
 
-	Permission is granted to anyone to use this software for any purpose,
-	including commercial applications, and to alter it and redistribute it
+	Permission is granted to anyone to use this software for any purpose, 
+	including commercial applications, and to alter it and redistribute it 
 	freely, subject to the following restrictions:
 
 		1. The origin of this software must not be misrepresented;
@@ -30,7 +30,7 @@
 		   in the product documentation would be appreciated but is
 		   not required.
 
-		2. Altered source versions must be plainly marked as such,
+		2. Altered source versions must be plainly marked as such, 
 		   and must not be misrepresented as being the original software.
 
 		3. This notice may not be removed or altered from any source
@@ -1019,7 +1019,7 @@ void CTabWnd::Close( void )
 			::SetWindowLongPtr( m_hwndTab, GWLP_WNDPROC, (LONG_PTR)gm_pOldWndProc );
 			gm_pOldWndProc = NULL;
 		}
-
+		
 		// Modified by KEITA for WIN64 2003.9.6
 		::SetWindowLongPtr( m_hwndTab, GWLP_USERDATA, (LONG_PTR)NULL );
 
@@ -1086,7 +1086,7 @@ LRESULT CTabWnd::OnDestroy( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 
 	return 0L;
 }
-
+ 
 /*! WM_LBUTTONDBLCLK処理
 	@date 2006.03.26 ryoji 新規作成
 */
@@ -1649,7 +1649,7 @@ LRESULT CTabWnd::OnPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 	}
 
 	// サイズボックスを描画する
-	if (!m_pShareData->m_Common.m_sWindow.m_bDispSTATUSBAR
+	if (!m_pShareData->m_Common.m_sWindow.m_bDispSTATUSBAR 
 		&& !m_pShareData->m_Common.m_sWindow.m_bDispFUNCKEYWND
 		&& m_pShareData->m_Common.m_sTabBar.m_eTabPosition == TabPosition_Bottom) {
 		SizeBox_ONOFF(true);
@@ -1930,7 +1930,7 @@ int CTabWnd::FindTabIndexByHWND( HWND hWnd )
 		tcitem.mask   = TCIF_PARAM;
 		tcitem.lParam = (LPARAM)0;
 		TabCtrl_GetItem( m_hwndTab, i, &tcitem );
-
+		
 		if( (HWND)tcitem.lParam == hWnd ) return i;
 	}
 

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -147,7 +147,7 @@ protected:
 	void DrawCloseFigure( CGraphics& gr, const RECT &btnRect );			/*!< 閉じるマーク描画処理 */
 	void DrawCloseBtn( CGraphics& gr, const LPRECT lprcClient );			/*!< 閉じるボタン描画処理 */		// 2006.10.21 ryoji
 	void DrawTabCloseBtn( CGraphics& gr, const LPRECT lprcClient, bool selected, bool bHover );	/*!< タブを閉じるボタン描画処理 */		// 2012.04.14 syat
-	void DrawTopBand( CGraphics& gr, const LPRECT lprcClient, int nTabIndex );
+	void DrawTopBand( const CGraphics& gr, const RECT* prcClient, int nTabIndex ) const;
 	void GetListBtnRect( const LPRECT lprcClient, LPRECT lprc );	/*!< 一覧ボタンの矩形取得処理 */
 	void GetCloseBtnRect( const LPRECT lprcClient, LPRECT lprc );	/*!< 閉じるボタンの矩形取得処理 */	// 2006.10.21 ryoji
 	void GetTabCloseBtnRect( const LPRECT lprcClient, LPRECT lprc, bool selected );	/*!< タブを閉じるボタンの矩形取得処理 */	// 2012.04.14 syat

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -147,6 +147,7 @@ protected:
 	void DrawCloseFigure( CGraphics& gr, const RECT &btnRect );			/*!< 閉じるマーク描画処理 */
 	void DrawCloseBtn( CGraphics& gr, const LPRECT lprcClient );			/*!< 閉じるボタン描画処理 */		// 2006.10.21 ryoji
 	void DrawTabCloseBtn( CGraphics& gr, const LPRECT lprcClient, bool selected, bool bHover );	/*!< タブを閉じるボタン描画処理 */		// 2012.04.14 syat
+	void DrawTopBand( CGraphics& gr, const LPRECT lprcClient, int nTabIndex );
 	void GetListBtnRect( const LPRECT lprcClient, LPRECT lprc );	/*!< 一覧ボタンの矩形取得処理 */
 	void GetCloseBtnRect( const LPRECT lprcClient, LPRECT lprc );	/*!< 閉じるボタンの矩形取得処理 */	// 2006.10.21 ryoji
 	void GetTabCloseBtnRect( const LPRECT lprcClient, LPRECT lprc, bool selected );	/*!< タブを閉じるボタンの矩形取得処理 */	// 2012.04.14 syat

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -147,7 +147,7 @@ protected:
 	void DrawCloseFigure( CGraphics& gr, const RECT &btnRect );			/*!< 閉じるマーク描画処理 */
 	void DrawCloseBtn( CGraphics& gr, const LPRECT lprcClient );			/*!< 閉じるボタン描画処理 */		// 2006.10.21 ryoji
 	void DrawTabCloseBtn( CGraphics& gr, const LPRECT lprcClient, bool selected, bool bHover );	/*!< タブを閉じるボタン描画処理 */		// 2012.04.14 syat
-	void DrawTopBand( const CGraphics& gr, const RECT* prcClient, int nTabIndex ) const;
+	void DrawTopBand( const CGraphics& gr, const RECT& rcClient, int nTabIndex ) const;
 	void GetListBtnRect( const LPRECT lprcClient, LPRECT lprc );	/*!< 一覧ボタンの矩形取得処理 */
 	void GetCloseBtnRect( const LPRECT lprcClient, LPRECT lprc );	/*!< 閉じるボタンの矩形取得処理 */	// 2006.10.21 ryoji
 	void GetTabCloseBtnRect( const LPRECT lprcClient, LPRECT lprc, bool selected );	/*!< タブを閉じるボタンの矩形取得処理 */	// 2012.04.14 syat

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -111,6 +111,7 @@ LIBS= \
  -lmpr \
  -limagehlp \
  -lshlwapi \
+ -ldwmapi \
  -lwinmm \
  -lwindowscodecs \
  -lmsimg32 \

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -54,7 +54,7 @@
     </ResourceCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;Imm32.lib;mpr.lib;imagehlp.lib;Shlwapi.lib;Dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

アクティブなタブの上部に目印 (トップバンド) を表示することで、多数のタブの中からでもすぐに発見できるようにします。

変更前 | 変更後
-|-
![image](https://user-images.githubusercontent.com/11252784/119991169-23535c80-c004-11eb-855e-18c2f0be0283.png) | ![image](https://user-images.githubusercontent.com/11252784/119991189-28b0a700-c004-11eb-9075-7bc751c13c95.png)

## <!-- 必須 --> カテゴリ

- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

アクティブタブは他のタブよりも少し明るく/少し大きく表示されてはいますが、多数のタブが表示されている状況ではよく目を凝らさないと発見できません。長時間の作業で疲れた目には応えます。

※ ODSN のフォーラムにも関連しそうな要望がありました。
https://osdn.net/projects/sakura-editor/forums/34071/44160/

## <!-- 自明なら省略可 --> PR のメリット

目的に記載の通りです。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

描画物が増えるので操作レスポンスが悪化する可能性があります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

トップバンドの描画処理は 2006 年頃から存在していたようなのですが、条件判定により「クラシック表示以外」の場合には描画がされないようになっています。

https://github.com/sakura-editor/sakura/blob/5135813a52b3339eb94462c66dab6407ac666a9c/sakura_core/window/CTabWnd.cpp#L1607-L1609

WindowsXP の標準タブコントロールではアクティブタブに自動的に色が付くので、クラシック表示以外ではトップバンドの描画は不要だったと考えられますが、WindowsVista 以降の標準タブコントロールはこの色付けはなくなり、さらにフラットな意匠になっているためトップバンドなしではアクティブタブを見つけづらくなっています。

本 PR ではこの条件を見直してトップバンドが常時描画されるように変更します。

## <!-- わかる範囲で --> PR の影響範囲

タブバーの表示内容・性能への影響があります。

## <!-- 必須 --> テスト内容

トップバンドが正しく表示されることと、性能劣化がないことを確認する予定です。

* タブバーの設定を色々した時にも正しい位置に表示されること。(アイコン有無、等幅/可変、閉じるボタン有無、...)
* ディスプレイ設定の表示スケールを 200% に変更した時に隙間や重なりが起きないこと。
* CTabWnd::OnPaint の処理時間を変更前後で比較すること。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
