### PR TITLE
README.mdの誤字を修正 "Visaul -> Visual"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
     - [Visual Studio Install options required](#visual-studio-install-options-required)
     - [Visual Studio 2019 対応に関して](#visual-studio-2019-対応に関して)
     - [.vsconfig に関して](#vsconfig-に関して)
-      - [Visaul Studio 2017/2019 共通](#visaul-studio-20172019-共通)
-      - [Visaul Studio 2019 のみ](#visaul-studio-2019-のみ)
+      - [Visual Studio 2017/2019 共通](#visual-studio-20172019-共通)
+      - [Visual Studio 2019 のみ](#visual-studio-2019-のみ)
       - [参照](#参照)
   - [How to build](#how-to-build)
     - [詳細情報](#詳細情報)
@@ -89,7 +89,7 @@ Sakura Editor のコンパイルに必要なコンポーネントを Visual Stud
 
 [#1162](https://github.com/sakura-editor/sakura/pull/1162) で [.vsconfig](.vsconfig) というファイルを sakura.sln と同じディレクトリに配置しています。
 
-#### Visaul Studio 2017/2019 共通
+#### Visual Studio 2017/2019 共通
 
 `vs_community__XXXXX.exe` でインストールする際に、--config オプションをつけてインストールする。
 あるいは構成変更することにより、必要なコンポーネントを自動的にインストールします。
@@ -98,10 +98,10 @@ Sakura Editor のコンパイルに必要なコンポーネントを Visual Stud
 vs_community__XXXXX.exe --config <.vsconfig のファイルパス>
 ```
 
-#### Visaul Studio 2019 のみ
+#### Visual Studio 2019 のみ
 
 `sakura.sln` と同じディレクトリに [.vsconfig](.vsconfig) が存在するので、
-Visaul Studio 2019 で `sakura.sln` を開くと必要なコンポーネントが足りない場合、インストールを促す表示が出るので、インストールをクリックすると自動的にインストールする。
+Visual Studio 2019 で `sakura.sln` を開くと必要なコンポーネントが足りない場合、インストールを促す表示が出るので、インストールをクリックすると自動的にインストールする。
 
 #### 参照
 

--- a/vcx-props/project-PlatformToolset.md
+++ b/vcx-props/project-PlatformToolset.md
@@ -19,11 +19,11 @@ Visual Studio の各バージョンごとにデフォルトの PlatformToolset (
 |Visual Studio のバージョン|PlatformToolset|
 |--|--|
 |Visual Studio 2017|v141|
-|Visaul Studio 2019|v142|
+|Visual Studio 2019|v142|
 
 ## 異なる Visual Studio のバージョンで開いたときの動作
 
-Visual Studio 2017 で作成したソリューション/プロジェクトを Visual Studio 2019 で開くと Visaul Studio 2019 の標準の v142 に変換するか
+Visual Studio 2017 で作成したソリューション/プロジェクトを Visual Studio 2019 で開くと Visual Studio 2019 の標準の v142 に変換するか
 確認するダイアログが出ます。一度ソリューションを開くとユーザーの選択がローカルに保存されるので同じソリューションを再度開いても再度確認される
 ことはありません。
 
@@ -32,7 +32,7 @@ Visual Studio 2017 で作成したソリューション/プロジェクトを Vi
 ## 解決策
 
 1. `PlatformToolset` の設定を[外部のファイル](vcxcompat.props) にまとめます
-2. そのファイルでは、 `Condition` の指定で開かれた Visaul Studio のバージョンによって、 `デフォルトで 使用する PlatformToolset` を指定します。
+2. そのファイルでは、 `Condition` の指定で開かれた Visual Studio のバージョンによって、 `デフォルトで 使用する PlatformToolset` を指定します。
 3. 各プロジェクトファイルで上記ファイルを [Import Project](https://docs.microsoft.com/ja-jp/visualstudio/msbuild/import-element-msbuild?view=vs-2019) でインクルードします。
 
 ### 参考情報


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

おそらく `Visaul Studio` は `Visual Studio` の打ち間違えだと考えられるので、
`README.md` を含む2箇所を修正しました。

## <!-- 必須 --> カテゴリ

- ドキュメント修正

## <!-- 必須 --> テスト内容

ドキュメントのみの修正です。

