### PR TITLE
履歴管理クラスに関するインクルード文を整理する

### DIFF
--- a/sakura_core/dlg/CDlgExec.h
+++ b/sakura_core/dlg/CDlgExec.h
@@ -18,6 +18,7 @@
 
 #include "dlg/CDialog.h"
 #include "recent/CRecentCmd.h"
+#include "recent/CRecentCurDir.h"
 
 /*-----------------------------------------------------------------------
 クラスの宣言

--- a/sakura_core/dlg/CDlgFavorite.h
+++ b/sakura_core/dlg/CDlgFavorite.h
@@ -35,7 +35,15 @@
 #pragma once
 
 #include "dlg/CDialog.h"
-#include "recent/CRecent.h"
+#include "recent/CRecentFile.h"
+#include "recent/CRecentFolder.h"
+#include "recent/CRecentExceptMru.h"
+#include "recent/CRecentSearch.h"
+#include "recent/CRecentReplace.h"
+#include "recent/CRecentGrepFile.h"
+#include "recent/CRecentGrepFolder.h"
+#include "recent/CRecentCmd.h"
+#include "recent/CRecentCurDir.h"
 
 //!「履歴とお気に入りの管理」ダイアログ
 //アクセス方法：[設定] - [履歴の管理]

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -20,8 +20,12 @@
 class CDlgGrep;
 
 #include "dlg/CDialog.h"
-#include "recent/CRecent.h"
 #include "util/window.h"
+#include "recent/CRecentSearch.h"
+#include "recent/CRecentGrepFile.h"
+#include "recent/CRecentGrepFolder.h"
+#include "recent/CRecentExcludeFile.h"
+#include "recent/CRecentExcludeFolder.h"
 
 #define DEFAULT_EXCLUDE_FILE_PATTERN    L"*.msi;*.exe;*.obj;*.pdb;*.ilk;*.res;*.pch;*.iobj;*.ipdb"
 #define DEFAULT_EXCLUDE_FOLDER_PATTERN  L".git;.svn;.vs"

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -21,6 +21,7 @@ class CDlgGrep;
 
 #include "dlg/CDialog.h"
 #include "dlg/CDlgGrep.h"
+#include "recent/CRecentReplace.h"
 
 //! GREP置換ダイアログボックス
 class CDlgGrepReplace final : public CDlgGrep

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -32,7 +32,6 @@
 #include "CEol.h"
 #include "charset/CCodePage.h"
 #include "doc/CDocListener.h"
-#include "recent/CRecent.h"
 #include "util/window.h"
 #include "util/shell.h"
 #include "util/file.h"
@@ -45,6 +44,8 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 #include "String_define.h"
+#include "recent/CRecentFile.h"
+#include "recent/CRecentFolder.h"
 
 static const DWORD p_helpids[] = {	//13100
 //	IDOK,					HIDOK_OPENDLG,		//Winのヘルプで勝手に出てくる

--- a/sakura_core/dlg/CDlgReplace.h
+++ b/sakura_core/dlg/CDlgReplace.h
@@ -21,8 +21,9 @@
 #pragma once
 
 #include "dlg/CDialog.h"
-#include "recent/CRecent.h"
 #include "util/window.h"
+#include "recent/CRecentReplace.h"
+#include "recent/CRecentSearch.h"
 
 /*-----------------------------------------------------------------------
 クラスの宣言

--- a/sakura_core/env/CSearchKeywordManager.cpp
+++ b/sakura_core/env/CSearchKeywordManager.cpp
@@ -31,7 +31,12 @@
 #include "DLLSHAREDATA.h"
 
 #include "CSearchKeywordManager.h"
-#include "recent/CRecent.h"
+#include "recent/CRecentSearch.h"
+#include "recent/CRecentReplace.h"
+#include "recent/CRecentGrepFile.h"
+#include "recent/CRecentGrepFolder.h"
+#include "recent/CRecentExcludeFile.h"
+#include "recent/CRecentExcludeFolder.h"
 
 /*!	m_aSearchKeysにpszSearchKeyを追加する。
 	YAZAKI

--- a/sakura_core/prop/CPropComGeneral.cpp
+++ b/sakura_core/prop/CPropComGeneral.cpp
@@ -26,6 +26,8 @@
 #include "sakura.hh"
 #include "config/app_constants.h"
 #include "String_define.h"
+#include "recent/CRecentFile.h"
+#include "recent/CRecentFolder.h"
 
 //@@@ 2001.02.04 Start by MIK: Popup Help
 TYPE_NAME_ID<int> SpecialScrollModeArr[] = {

--- a/sakura_core/recent/CRecent.h
+++ b/sakura_core/recent/CRecent.h
@@ -83,5 +83,4 @@ public:
 	}
 };
 
-#include "CRecentImp.h"
 #endif /* SAKURA_CRECENT_F4D70310_9FAF_4F07_9431_2B011A47142D_H_ */

--- a/sakura_core/recent/CRecent.h
+++ b/sakura_core/recent/CRecent.h
@@ -38,7 +38,6 @@
 #define SAKURA_CRECENT_F4D70310_9FAF_4F07_9431_2B011A47142D_H_
 #pragma once
 
-#include "_main/global.h"
 #include "env/DLLSHAREDATA.h"
 
 class CRecent{

--- a/sakura_core/recent/CRecentCmd.cpp
+++ b/sakura_core/recent/CRecentCmd.cpp
@@ -26,9 +26,6 @@
 
 #include "StdAfx.h"
 #include "CRecentCmd.h"
-#include "config/maxdata.h"
-#include "env/DLLSHAREDATA.h"
-#include <string.h>
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentCurDir.cpp
+++ b/sakura_core/recent/CRecentCurDir.cpp
@@ -27,8 +27,6 @@
 #include "StdAfx.h"
 #include "CRecentCurDir.h"
 #include "config/maxdata.h"
-#include "env/DLLSHAREDATA.h"
-#include <string.h>
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentEditNode.cpp
+++ b/sakura_core/recent/CRecentEditNode.cpp
@@ -26,8 +26,6 @@
 
 #include "StdAfx.h"
 #include "CRecentEditNode.h"
-#include <string.h>
-#include "env/DLLSHAREDATA.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentExceptMru.cpp
+++ b/sakura_core/recent/CRecentExceptMru.cpp
@@ -24,10 +24,9 @@
 		   distribution.
 */
 
-#include "stdafx.h"
-#include "CRecentExceptMRU.h"
-#include <string.h>
-#include "env/DLLSHAREDATA.h"
+#include "StdAfx.h"
+#include "CRecentExceptMru.h"
+#include "config/maxdata.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentExcludeFile.cpp
+++ b/sakura_core/recent/CRecentExcludeFile.cpp
@@ -1,4 +1,5 @@
-﻿/*
+﻿/*! @file
+
 	Copyright (C) 2018-2021, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
@@ -24,8 +25,6 @@
 
 #include "StdAfx.h"
 #include "CRecentExcludeFile.h"
-#include <string.h>
-#include "env/DLLSHAREDATA.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentExcludeFile.h
+++ b/sakura_core/recent/CRecentExcludeFile.h
@@ -1,4 +1,5 @@
-﻿/*
+﻿/*! @file
+
 	Copyright (C) 2018-2021, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
@@ -27,6 +28,7 @@
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
+#include "config/maxdata.h"
 
 typedef StaticString<WCHAR, MAX_EXCLUDE_PATH> CExcludeFileString;
 

--- a/sakura_core/recent/CRecentExcludeFolder.cpp
+++ b/sakura_core/recent/CRecentExcludeFolder.cpp
@@ -1,4 +1,5 @@
-﻿/*
+﻿/*! @file
+
 	Copyright (C) 2018-2021, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
@@ -23,9 +24,7 @@
 */
 
 #include "StdAfx.h"
-#include <string.h>
 #include "CRecentExcludeFolder.h"
-#include "env/DLLSHAREDATA.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentExcludeFolder.h
+++ b/sakura_core/recent/CRecentExcludeFolder.h
@@ -1,4 +1,5 @@
-﻿/*
+﻿/*! @file
+
 	Copyright (C) 2018-2021, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
@@ -27,6 +28,7 @@
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
+#include "config/maxdata.h"
 
 typedef StaticString<WCHAR, MAX_EXCLUDE_PATH> CExcludeFolderString;
 

--- a/sakura_core/recent/CRecentFile.cpp
+++ b/sakura_core/recent/CRecentFile.cpp
@@ -26,8 +26,7 @@
 
 #include "StdAfx.h"
 #include "recent/CRecentFile.h"
-#include <string.h>
-#include "env/DLLSHAREDATA.h"
+#include "config/maxdata.h"
 
 /*
 	アイテムの比較要素を取得する。

--- a/sakura_core/recent/CRecentFolder.cpp
+++ b/sakura_core/recent/CRecentFolder.cpp
@@ -26,8 +26,7 @@
 
 #include "StdAfx.h"
 #include "CRecentFolder.h"
-#include <string.h>
-#include "env/DLLSHAREDATA.h"
+#include "config/maxdata.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentFolder.h
+++ b/sakura_core/recent/CRecentFolder.h
@@ -30,8 +30,6 @@
 #include "CRecentImp.h"
 #include "util/StaticType.h"
 
-//StaticVector< StaticString<WCHAR, _MAX_PATH>, MAX_GREPFOLDER, const WCHAR*>
-
 typedef StaticString<WCHAR, _MAX_PATH> CPathString;
 
 //! フォルダの履歴を管理 (RECENT_FOR_FOLDER)

--- a/sakura_core/recent/CRecentGrepFile.cpp
+++ b/sakura_core/recent/CRecentGrepFile.cpp
@@ -26,8 +26,6 @@
 
 #include "StdAfx.h"
 #include "CRecentGrepFile.h"
-#include <string.h>
-#include "env/DLLSHAREDATA.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentGrepFile.h
+++ b/sakura_core/recent/CRecentGrepFile.h
@@ -29,6 +29,7 @@
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
+#include "config/maxdata.h"
 
 typedef StaticString<WCHAR, MAX_GREP_PATH> CGrepFileString;
 

--- a/sakura_core/recent/CRecentGrepFolder.cpp
+++ b/sakura_core/recent/CRecentGrepFolder.cpp
@@ -25,9 +25,7 @@
 */
 
 #include "StdAfx.h"
-#include <string.h>
 #include "CRecentGrepFolder.h"
-#include "env/DLLSHAREDATA.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentGrepFolder.h
+++ b/sakura_core/recent/CRecentGrepFolder.h
@@ -29,6 +29,7 @@
 
 #include "CRecentImp.h"
 #include "util/StaticType.h"
+#include "config/maxdata.h"
 
 typedef StaticString<WCHAR, MAX_GREP_PATH> CGrepFolderString;
 

--- a/sakura_core/recent/CRecentImp.cpp
+++ b/sakura_core/recent/CRecentImp.cpp
@@ -559,20 +559,18 @@ bool CRecentImp<T, S>::UpdateView()
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                      インスタンス化                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-template class CRecentImp<CCmdString, LPCWSTR>;				// CRecentCmd
-template class CRecentImp<EditNode>;						// CRecentEditNode
-template class CRecentImp<EditInfo>;						// CRecentFile
-template class CRecentImp<CPathString, LPCWSTR>;			// CRecentFolder
-template class CRecentImp<CGrepFileString, LPCWSTR>;		// CRecentGrepFile
+template class CRecentImp<CCmdString, LPCWSTR>;
+template class CRecentImp<EditNode>;
+template class CRecentImp<EditInfo>;
+template class CRecentImp<CPathString, LPCWSTR>;
+template class CRecentImp<CGrepFileString, LPCWSTR>;
 #ifndef __MINGW32__
-template class CRecentImp<CMetaPath, LPCWSTR>;				// CRecentExceptMRU
-template class CRecentImp<CGrepFolderString, LPCWSTR>;		// CRecentGrepFolder
-template class CRecentImp<CSearchString, LPCWSTR>;			// CRecentSearch
-template class CRecentImp<CTagjumpKeywordString, LPCWSTR>;	// CRecentTagjumpKeyword
-template class CRecentImp<CCurDirString, LPCWSTR>;			// CRecentCurDir
-template class CRecentImp<CExcludeFileString, LPCWSTR>;		// CRecentExcludeFile
-template class CRecentImp<CExcludeFolderString, LPCWSTR>;	// CRecentExcludeFolder
+template class CRecentImp<CMetaPath, LPCWSTR>;
+template class CRecentImp<CGrepFolderString, LPCWSTR>;
+template class CRecentImp<CSearchString, LPCWSTR>;
+template class CRecentImp<CTagjumpKeywordString, LPCWSTR>;
+template class CRecentImp<CCurDirString, LPCWSTR>;
 #endif
 #if !defined(__MINGW32__) || (defined(__MINGW32__) && !defined(UNICODE))
-template class CRecentImp<CReplaceString, LPCWSTR>;			// CRecentReplace
+template class CRecentImp<CReplaceString, LPCWSTR>;
 #endif

--- a/sakura_core/recent/CRecentImp.cpp
+++ b/sakura_core/recent/CRecentImp.cpp
@@ -27,8 +27,19 @@
 #include "StdAfx.h"
 #include "CRecentImp.h"
 
-#include "env/CAppNodeManager.h" // EditNode
-#include "EditInfo.h" // EditInfo
+#include "CRecentCmd.h"
+#include "CRecentCurDir.h"
+#include "CRecentEditNode.h"
+#include "CRecentExceptMru.h"
+#include "CRecentExcludeFile.h"
+#include "CRecentExcludeFolder.h"
+#include "CRecentFile.h"
+#include "CRecentFolder.h"
+#include "CRecentGrepFile.h"
+#include "CRecentGrepFolder.h"
+#include "CRecentReplace.h"
+#include "CRecentSearch.h"
+#include "CRecentTagjumpKeyword.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //
@@ -548,18 +559,20 @@ bool CRecentImp<T, S>::UpdateView()
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                      インスタンス化                         //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-template class CRecentImp<CCmdString, LPCWSTR>;
-template class CRecentImp<EditNode>;
-template class CRecentImp<EditInfo>;
-template class CRecentImp<CPathString, LPCWSTR>;
-template class CRecentImp<CGrepFileString, LPCWSTR>;
+template class CRecentImp<CCmdString, LPCWSTR>;				// CRecentCmd
+template class CRecentImp<EditNode>;						// CRecentEditNode
+template class CRecentImp<EditInfo>;						// CRecentFile
+template class CRecentImp<CPathString, LPCWSTR>;			// CRecentFolder
+template class CRecentImp<CGrepFileString, LPCWSTR>;		// CRecentGrepFile
 #ifndef __MINGW32__
-template class CRecentImp<CMetaPath, LPCWSTR>;
-template class CRecentImp<CGrepFolderString, LPCWSTR>;
-template class CRecentImp<CSearchString, LPCWSTR>;
-template class CRecentImp<CTagjumpKeywordString, LPCWSTR>;
-template class CRecentImp<CCurDirString, LPCWSTR>;
+template class CRecentImp<CMetaPath, LPCWSTR>;				// CRecentExceptMRU
+template class CRecentImp<CGrepFolderString, LPCWSTR>;		// CRecentGrepFolder
+template class CRecentImp<CSearchString, LPCWSTR>;			// CRecentSearch
+template class CRecentImp<CTagjumpKeywordString, LPCWSTR>;	// CRecentTagjumpKeyword
+template class CRecentImp<CCurDirString, LPCWSTR>;			// CRecentCurDir
+template class CRecentImp<CExcludeFileString, LPCWSTR>;		// CRecentExcludeFile
+template class CRecentImp<CExcludeFolderString, LPCWSTR>;	// CRecentExcludeFolder
 #endif
 #if !defined(__MINGW32__) || (defined(__MINGW32__) && !defined(UNICODE))
-template class CRecentImp<CReplaceString, LPCWSTR>;
+template class CRecentImp<CReplaceString, LPCWSTR>;			// CRecentReplace
 #endif

--- a/sakura_core/recent/CRecentImp.h
+++ b/sakura_core/recent/CRecentImp.h
@@ -1,7 +1,5 @@
 ﻿/*! @file */
 // 各CRecent実装クラスのベースクラス
-
-// エディタ系ファイルからincludeするときは CRecent.h をinclude
 /*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2018-2021, Sakura Editor Organization
@@ -123,17 +121,4 @@ protected:
 	size_t		m_nTextMaxLength;		//!< 最大テキスト長(終端含む)
 };
 
-#include "CRecentFile.h"
-#include "CRecentFolder.h"
-#include "CRecentExceptMru.h"
-#include "CRecentSearch.h"
-#include "CRecentReplace.h"
-#include "CRecentGrepFile.h"
-#include "CRecentGrepFolder.h"
-#include "CRecentExcludeFile.h"
-#include "CRecentExcludeFolder.h"
-#include "CRecentCmd.h"
-#include "CRecentCurDir.h"
-#include "CRecentEditNode.h"
-#include "CRecentTagjumpKeyword.h"
 #endif /* SAKURA_CRECENTIMP_B18E6196_5684_44E4_91E0_ADB1542BF7E1_H_ */

--- a/sakura_core/recent/CRecentReplace.cpp
+++ b/sakura_core/recent/CRecentReplace.cpp
@@ -26,8 +26,7 @@
 
 #include "StdAfx.h"
 #include "CRecentReplace.h"
-#include <string.h>
-#include "env/DLLSHAREDATA.h"
+#include "config/maxdata.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentSearch.cpp
+++ b/sakura_core/recent/CRecentSearch.cpp
@@ -27,8 +27,6 @@
 #include "StdAfx.h"
 #include "CRecentSearch.h"
 #include "config/maxdata.h"
-#include "env/DLLSHAREDATA.h"
-#include <string.h>
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/recent/CRecentTagjumpKeyword.cpp
+++ b/sakura_core/recent/CRecentTagjumpKeyword.cpp
@@ -26,8 +26,7 @@
 
 #include "StdAfx.h"
 #include "CRecentTagjumpKeyword.h"
-#include "env/DLLSHAREDATA.h"
-#include <string.h>
+#include "config/maxdata.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                           生成                              //

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -37,11 +37,11 @@
 #include "util/window.h"
 #include "_main/CControlTray.h"
 #include "charset/charcode.h"
-#include "recent/CRecent.h"
 #include "apiwrap/StdApi.h"
 #include "apiwrap/CommonControl.h"
 #include "config/system_constants.h"
 #include "config/app_constants.h"
+#include "recent/CRecentCmd.h"
 
 /*
 	指定ファイルの指定位置にタグジャンプする。

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -75,6 +75,9 @@
 #include "config/system_constants.h"
 #include "config/app_constants.h"
 #include "String_define.h"
+#include "recent/CRecentEditNode.h"
+#include "recent/CRecentFile.h"
+#include "recent/CRecentFolder.h"
 
 //@@@ 2002.01.14 YAZAKI 印刷プレビューをCPrintPreviewに独立させたので
 //	定義を削除

--- a/sakura_core/window/CMainToolBar.h
+++ b/sakura_core/window/CMainToolBar.h
@@ -27,8 +27,8 @@
 #define SAKURA_CMAINTOOLBAR_FEA7E388_DFEC_4E15_94CC_90A7E779797B_H_
 #pragma once
 
-#include "recent/CRecent.h"
 #include "dlg/CDialog.h"
+#include "recent/CRecentSearch.h"
 
 class CEditWnd;
 class CImageListMgr;


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
履歴管理クラス（CRecentインターフェースを実装した各派生クラス）に関するインクルード文を整理します。

## <!-- 必須 --> カテゴリ
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景
SonarQubeによる解析結果で、ヘッダファイルのインクルード文に対してCode Smellが検出されていました。
- Move all #include directives at the very top of the file, before any code.
    - [CRecent.h#L86](https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AWugQ4wiW3oRL9px484c&open=AWugQ4wiW3oRL9px484c)
    - [CRecentImp.h#L126](https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AWugQ4sUW3oRL9px484b&open=AWugQ4sUW3oRL9px484b)
- non-portable path to file '"CRecentExceptMru.h"'; specified path differs in case from file name on disk
    - [CRecentExceptMru.cpp#L28](https://sonarcloud.io/project/issues?id=sakura-editor_sakura&issues=AWdx6FuscrQ7oSxgA4us&open=AWdx6FuscrQ7oSxgA4us)

インクルード文の整理を実施して当該指摘の解消を試みます。

## <!-- 自明なら省略可 --> PR のメリット
- Code Smellが解消されます。
- （CRecentインターフェースを利用する側で、）インクルード文からどの履歴管理クラスを利用しているか判断できるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
特にありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
- CRecent.h及びCRecentImp.hのファイル末尾にある、派生クラスのインクルード文を削除し、CRecent.hをインクルードしていた各ソースファイルでは代わりに各派生クラスのヘッダファイルをインクルードするようにしました。
- 作業過程でCRecentの各派生クラスに不必要なインクルード文があったため、併せて削除しました。

## <!-- わかる範囲で --> PR の影響範囲
履歴データにアクセスする各クラス

## <!-- 必須 --> テスト内容
ビルドの確認のみです。
なお、MinGWビルドは確認できていませんので、Azure Pipelinesの当該ジョブの成否を確認できるまでDraftとします。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
