### PR TITLE
使用されていないCRecentの呼び出し箇所を除去する

### DIFF
--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -44,8 +44,6 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 #include "String_define.h"
-#include "recent/CRecentFile.h"
-#include "recent/CRecentFolder.h"
 
 static const DWORD p_helpids[] = {	//13100
 //	IDOK,					HIDOK_OPENDLG,		//Winのヘルプで勝手に出てくる
@@ -122,9 +120,6 @@ public:
 	SFilePath		m_szPath;	// 拡張子の補完を自前で行ったときのファイルパス	// 2006.11.10 ryoji
 
 	bool			m_bInitCodePage;
-
-	CRecentFile				m_cRecentFile;
-	CRecentFolder			m_cRecentFolder;
 
 	OPENFILENAME*	m_pOf;
 	OPENFILENAME	m_ofn;		/* 2005.10.29 ryoji OPENFILENAME「ファイルを開く」ダイアログ用構造体 */

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -47,7 +47,6 @@
 #include "env/CShareData.h"
 #include "env/CSakuraEnvironment.h"
 #include "uiparts/CGraphics.h"
-#include "recent/CRecentEditNode.h"
 #include "util/os.h" //WM_THEMECHANGED
 #include "util/window.h"
 #include "util/module.h"
@@ -1781,7 +1780,6 @@ void CTabWnd::TabWindowNotify( WPARAM wParam, LPARAM lParam )
 		if( -1 != nIndex )
 		{
 			TCITEM	tcitem;
-			CRecentEditNode	cRecentEditNode;
 			WCHAR	szName[1024];
 			//	Jun. 19, 2004 genta
 			EditNode	*p;


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
CRecentの不要な呼び出し箇所を除去し、当該クラス・関数がCRecentに依存しないことを明確にする

## <!-- 必須 --> カテゴリ
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景
#1697 の対応時にCRecentの利用状況を確認したところ、未使用にも関わらずインスタンスを保持している箇所がありました。
このうち、CDlgOpenFileDataについては、 #1481 のマージ以降未使用になっています。

これら未使用変数の除去を提案するものです。

## <!-- 自明なら省略可 --> PR のメリット
今回変更対象となるクラス・関数とCRecentの間にあった依存関係を取り除くことができます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
特にありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
- CDlgOpenFileDataのメンバから、CRecentFile/CRecentFolderを取り除きました。
- `CTabWnd::TabWindowNotify()`から、未使用のローカル変数となっているCRecentEditNodeを取り除きました。

## <!-- わかる範囲で --> PR の影響範囲
- ファイル選択ダイアログ
- タブウィンドウ

## <!-- 必須 --> テスト内容
動作に変更がなく、使用されていない変数宣言を削除したのみであるため、ビルドの成否を確認できれば良いと思います。

## <!-- なければ省略可 --> 関連 issue, PR
#1481 
#1697 
