### PR TITLE
マウスドラッグでのスクロール時に表示がおかしくなる問題の修正

### DIFF
--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -300,6 +300,7 @@ CLayoutInt CCaret::MoveCursor(
 			m_pEditView->GetTextArea().OffsetViewTopLine(-nScrollRowNum);
 			if( m_pEditView->GetDrawSwitch() ){
 				m_pEditView->InvalidateRect( NULL );
+				m_pEditView->UpdateWindow();
 				if( m_pEditView->m_pcEditWnd->GetMiniMap().GetHwnd() ){
 					m_pEditView->MiniMapRedraw(true);
 				}

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -417,7 +417,6 @@ CLayoutInt CEditView::ScrollAtV( CLayoutInt nPos, BOOL bRedrawScrollBar )
 		if( GetDrawSwitch() ){
 			RECT rcClip2 = {0,0,0,0};
 			ScrollDraw(nScrollRowNum, CLayoutInt(0), rcScrol, rcClip, rcClip2);
-			::UpdateWindow( GetHwnd() );
 		}
 	}
 
@@ -497,7 +496,6 @@ CLayoutInt CEditView::ScrollAtH( CLayoutInt nPos, BOOL bRedrawScrollBar )
 		if( GetDrawSwitch() ){
 			RECT rcClip = {0,0,0,0};
 			ScrollDraw(CLayoutInt(0), nScrollColNum, rcScrol, rcClip, rcClip2);
-			::UpdateWindow( GetHwnd() );
 		}
 	}
 	//	2006.1.28 aroka 判定条件誤り修正 (バーが消えてもスクロールしない)
@@ -602,6 +600,7 @@ void CEditView::ScrollDraw(CLayoutInt nScrollRowNum, CLayoutInt nScrollColNum, c
 	if( nScrollColNum != 0 ){
 		InvalidateRect( &rcClip2, FALSE );
 	}
+	UpdateWindow();
 }
 
 void CEditView::MiniMapRedraw(bool bUpdateAll)


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

Windows8.1 において、マウスドラッグでスクロールをした時にエディタに表示異常が起きる問題を修正します。
この問題について、#1694 では Windows8.1 に限定した暫定対策が検討されていましたが、条件次第では Windows10 でも発生しうることが分かったことと、真因と思われる箇所が判明したため、本 PR では OS を限定しない修正を行います。

不具合現象：
![image](https://user-images.githubusercontent.com/11252784/124345738-9c525f00-dc15-11eb-8cdf-403a9ccdd2a3.png)
※ https://github.com/sakura-editor/sakura/pull/1246#discussion_r419490862 より引用

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

自明のため省略します。

## <!-- 自明なら省略可 --> PR のメリット

自明のため省略します。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

本来必要な描画を行うためではあるものの、修正前に比べて WM_PAINT メッセージの処理量が増加するため CPU 使用率が高くなるかもしれません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

※以下は Windows10 で再現した同様の現象を調査した結果から書いています。

### 原因

マウスドラッグでスクロールをしている間、CEditView クラスに WM_PAINT が通知されていないためです。
CEditView::ScrollDraw では、必要なスクロール量に応じてエディタウィンドウの描画内容を ScrollWindowEx を呼び出しずらしていますが、ずらした後に残る無効領域は WM_PAINT を処理することで再描画・有効化される必要があります。

### 対策

* CEditView::ScrollDraw の最後で UpdateWindow (CMyWnd::UpdateWindow) を呼び出して必ず WM_PAINT が送られるようにします。
* CCaret::MoveCursor で呼び出す InvalidateRect の直後にも UpdateWindow が不足していたため合わせて追加します。

今回修正する箇所の他にも同様に UpdateWindow の呼び出しが不足していそうな所がありましたが、これらは別途で調査・修正することにしたいと思います。

## <!-- わかる範囲で --> PR の影響範囲

エディタのスクロール動作に影響があります。

## <!-- 必須 --> テスト内容

Windows10, Windows8.1 にてそれぞれ以下の操作をした時に、不具合現象が起きないことを確認します。
(Windows10 の場合は `CViewSelect.cpp#L178 void CViewSelect::DrawSelectArea(bool);` にトレースポイントを設定した状態でデバッグ実行し確認)
* マウスドラッグで選択範囲を拡張するよう下/上方向へスクロール
* マウスドラッグで選択範囲を拡張するよう下/上方向へスクロール (マウスカーソルをエディタ下端/上端からエディタの高さ分以上離す)
* 選択領域をドラッグし下/上方向へスクロール

## <!-- なければ省略可 --> 関連 issue, PR

#1694

## <!-- なければ省略可 --> 参考資料

InvalidateRect, ScrollWindowEx の動作説明：
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-invalidaterect#remarks
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-scrollwindowex#remarks