### PR TITLE
セキュリティ問題を起こしやすいShellExecute関数を直接呼ばないようにリファクタリングする

### DIFF
--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -52,6 +52,7 @@
 #include "CWriteManager.h"
 #include "CEditApp.h"
 #include "recent/CMRUFile.h"
+#include "util/shell.h"
 #include "util/window.h"
 #include "charset/CCodeFactory.h"
 #include "plugin/CPlugin.h"
@@ -450,28 +451,9 @@ void CViewCommander::Command_BROWSE( void )
 		ErrorBeep();
 		return;
 	}
-//	char	szURL[MAX_PATH + 64];
-//	auto_sprintf( szURL, L"%ls", GetDocument()->m_cDocFile.GetFilePath() );
-	/* URLを開く */
-//	::ShellExecuteEx( NULL, L"open", szURL, NULL, NULL, SW_SHOW );
 
-    SHELLEXECUTEINFO info; 
-    info.cbSize =sizeof(info);
-    info.fMask = 0;
-    info.hwnd = NULL;
-    info.lpVerb = NULL;
-    info.lpFile = GetDocument()->m_cDocFile.GetFilePath();
-    info.lpParameters = NULL;
-    info.lpDirectory = NULL;
-    info.nShow = SW_SHOWNORMAL;
-    info.hInstApp = 0;
-    info.lpIDList = NULL;
-    info.lpClass = NULL;
-    info.hkeyClass = 0; 
-    info.dwHotKey = 0;
-    info.hIcon =0;
-
-	::ShellExecuteEx(&info);
+	std::wstring_view path(GetDocument()->m_cDocFile.GetFilePath());
+	OpenByBrowser(m_pCommanderView->GetHwnd(), path);
 
 	return;
 }

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -453,7 +453,7 @@ void CViewCommander::Command_BROWSE( void )
 	}
 
 	std::wstring_view path(GetDocument()->m_cDocFile.GetFilePath());
-	OpenByBrowser(m_pCommanderView->GetHwnd(), path);
+	OpenWithBrowser(m_pCommanderView->GetHwnd(), path);
 
 	return;
 }
@@ -524,7 +524,7 @@ void CViewCommander::Command_OPEN_FOLDER_IN_EXPLORER(void)
 
 	// ドキュメントパスを変数に入れてWindowsエクスプローラーで開く
 	if (std::filesystem::path docPath = GetDocument()->m_cDocFile.GetFilePath();
-		!OpenByExplorer(GetMainWindow(), docPath)) {
+		!OpenWithExplorer(GetMainWindow(), docPath)) {
 		ErrorBeep();
 		return;
 	}

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -522,17 +522,9 @@ void CViewCommander::Command_OPEN_FOLDER_IN_EXPLORER(void)
 		return;
 	}
 
-	// ドキュメントパスを変数に入れる
-	LPCWSTR pszDocPath = GetDocument()->m_cDocFile.GetFilePath();
-
-	// Windows Explorerの引数を作る
-	CNativeW explorerCommand;
-	explorerCommand.AppendStringF(L"/select,\"%s\"", pszDocPath);
-	LPCWSTR pszExplorerCommand = explorerCommand.GetStringPtr();
-
-	auto hInstance = ::ShellExecute(GetMainWindow(), L"open", L"explorer.exe", pszExplorerCommand, NULL, SW_SHOWNORMAL);
-	// If the function succeeds, it returns a value greater than 32. 
-	if (hInstance <= (decltype(hInstance))32) {
+	// ドキュメントパスを変数に入れてWindowsエクスプローラーで開く
+	if (std::filesystem::path docPath = GetDocument()->m_cDocFile.GetFilePath();
+		!OpenByExplorer(GetMainWindow(), docPath)) {
 		ErrorBeep();
 		return;
 	}

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -25,6 +25,7 @@
 #include "uiparts/HandCursor.h"
 #include "util/file.h"
 #include "util/module.h"
+#include "util/shell.h"
 #include "util/window.h"
 #include "sakura_rc.h" // 2002/2/10 aroka 復帰
 #include "version.h"
@@ -330,28 +331,28 @@ BOOL CDlgAbout::OnStnClicked( int wID )
 //	case IDC_STATIC_URL_ORG:	del 2008/7/4 Uchi
 		//	Web Browserの起動
 		{
-			WCHAR buf[512];
-			::GetWindowText( GetItemHwnd( wID ), buf, _countof(buf) );
-			::ShellExecute( GetHwnd(), NULL, buf, NULL, NULL, SW_SHOWNORMAL );
+			std::wstring url;
+			ApiWrap::DlgItem_GetText(GetHwnd(), wID, url);
+			OpenByBrowser(GetHwnd(), url);
 			return TRUE;
 		}
 	case IDC_STATIC_URL_CI_BUILD:
 		{
 #if defined(CI_BUILD_URL)
-			::ShellExecute(GetHwnd(), NULL, _T(CI_BUILD_URL), NULL, NULL, SW_SHOWNORMAL);
+			OpenByBrowser(GetHwnd(), _T(CI_BUILD_URL));
 #elif defined(GIT_REMOTE_ORIGIN_URL)
-			::ShellExecute(GetHwnd(), NULL, _T(GIT_REMOTE_ORIGIN_URL), NULL, NULL, SW_SHOWNORMAL);
+			OpenByBrowser(GetHwnd(), _T(GIT_REMOTE_ORIGIN_URL));
 #endif
 			return TRUE;
 		}
 	case IDC_STATIC_URL_GITHUB_COMMIT:
 #if defined(GITHUB_COMMIT_URL)
-		::ShellExecute(GetHwnd(), NULL, _T(GITHUB_COMMIT_URL), NULL, NULL, SW_SHOWNORMAL);
+		OpenByBrowser(GetHwnd(), _T(GITHUB_COMMIT_URL));
 #endif
 		return TRUE;
 	case IDC_STATIC_URL_GITHUB_PR:
 #if defined(GITHUB_PR_HEAD_URL)
-		::ShellExecute(GetHwnd(), NULL, _T(GITHUB_PR_HEAD_URL), NULL, NULL, SW_SHOWNORMAL);
+		OpenByBrowser(GetHwnd(), _T(GITHUB_PR_HEAD_URL));
 #endif
 		return TRUE;
 	}

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -333,26 +333,26 @@ BOOL CDlgAbout::OnStnClicked( int wID )
 		{
 			std::wstring url;
 			ApiWrap::DlgItem_GetText(GetHwnd(), wID, url);
-			OpenByBrowser(GetHwnd(), url);
+			OpenWithBrowser(GetHwnd(), url);
 			return TRUE;
 		}
 	case IDC_STATIC_URL_CI_BUILD:
 		{
 #if defined(CI_BUILD_URL)
-			OpenByBrowser(GetHwnd(), _T(CI_BUILD_URL));
+			OpenWithBrowser(GetHwnd(), _T(CI_BUILD_URL));
 #elif defined(GIT_REMOTE_ORIGIN_URL)
-			OpenByBrowser(GetHwnd(), _T(GIT_REMOTE_ORIGIN_URL));
+			OpenWithBrowser(GetHwnd(), _T(GIT_REMOTE_ORIGIN_URL));
 #endif
 			return TRUE;
 		}
 	case IDC_STATIC_URL_GITHUB_COMMIT:
 #if defined(GITHUB_COMMIT_URL)
-		OpenByBrowser(GetHwnd(), _T(GITHUB_COMMIT_URL));
+		OpenWithBrowser(GetHwnd(), _T(GITHUB_COMMIT_URL));
 #endif
 		return TRUE;
 	case IDC_STATIC_URL_GITHUB_PR:
 #if defined(GITHUB_PR_HEAD_URL)
-		OpenByBrowser(GetHwnd(), _T(GITHUB_PR_HEAD_URL));
+		OpenWithBrowser(GetHwnd(), _T(GITHUB_PR_HEAD_URL));
 #endif
 		return TRUE;
 	}

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -243,7 +243,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 							break;
 						}
 					}
-					::ShellExecute( NULL, L"open", sBaseDir.c_str(), NULL, NULL, SW_SHOW );
+					OpenByExplorer( hwndDlg, sBaseDir );
 				}
 				break;
 			case IDC_PLUGIN_README:		// ReadMe表示	// 2011/11/2 Uchi

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -40,6 +40,7 @@
 #include "io/CTextStream.h"
 #include "io/CZipFile.h"
 #include "CSelectLang.h"
+#include "util/shell.h"
 #include "sakura_rc.h"
 #include "sakura.hh"
 #include "config/app_constants.h"
@@ -267,7 +268,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 					if (sel >= 0){
 						CPlugin* plugin = CPluginManager::getInstance()->GetPlugin(sel);
 						if (plugin != NULL){
-							::ShellExecute(NULL, L"Open", plugin->m_sUrl.c_str(), NULL, NULL, SW_SHOW);
+							OpenByBrowser( hwndDlg, plugin->m_sUrl );
 						}
 					}
 				}

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -243,7 +243,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 							break;
 						}
 					}
-					OpenByExplorer( hwndDlg, sBaseDir );
+					OpenWithExplorer( hwndDlg, sBaseDir );
 				}
 				break;
 			case IDC_PLUGIN_README:		// ReadMe表示	// 2011/11/2 Uchi
@@ -268,7 +268,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 					if (sel >= 0){
 						CPlugin* plugin = CPluginManager::getInstance()->GetPlugin(sel);
 						if (plugin != NULL){
-							OpenByBrowser( hwndDlg, plugin->m_sUrl );
+							OpenWithBrowser( hwndDlg, plugin->m_sUrl );
 						}
 					}
 				}

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -218,36 +218,9 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 			// 選択されたメニューの処理
 			switch( nId ){
 			case 100:	// 設定フォルダを開く
-				WCHAR szPath[_MAX_PATH];
-				GetInidir( szPath );
-
-				// フォルダの ITEMIDLIST を取得して ShellExecuteEx() で開く
-				// Note. MSDN の ShellExecute() の解説にある方法でフォルダを開こうとした場合、
-				//       フォルダと同じ場所に <フォルダ名>.exe があるとうまく動かない。
-				//       verbが"open"やNULLではexeのほうが実行され"explore"では失敗する
-				//       （フォルダ名の末尾に'\\'を付加してもWindows 2000では付加しないのと同じ動作になってしまう）
-				LPSHELLFOLDER pDesktopFolder;
-				if( SUCCEEDED(::SHGetDesktopFolder(&pDesktopFolder)) ){
-					LPMALLOC pMalloc;
-					if( SUCCEEDED(::SHGetMalloc(&pMalloc)) ){
-						LPITEMIDLIST pIDL;
-						WCHAR* pszDisplayName = szPath;
-						if( SUCCEEDED(pDesktopFolder->ParseDisplayName(NULL, NULL, pszDisplayName, NULL, &pIDL, NULL)) ){
-							SHELLEXECUTEINFO si;
-							::ZeroMemory( &si, sizeof(si) );
-							si.cbSize   = sizeof(si);
-							si.fMask    = SEE_MASK_IDLIST;
-							si.lpVerb   = L"open";
-							si.lpIDList = pIDL;
-							si.nShow    = SW_SHOWNORMAL;
-							::ShellExecuteEx( &si );	// フォルダを開く
-							pMalloc->Free( (void*)pIDL );
-						}
-						pMalloc->Release();
-					}
-					pDesktopFolder->Release();
-				}
+				OpenByExplorer(hwnd, GetIniFileName());
 				break;
+
 			case 101:	// インポート／エクスポートの起点リセット（起点を設定フォルダにする）
 				int nMsgResult = MYMESSAGEBOX(
 					hwnd,
@@ -647,6 +620,40 @@ BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool Fixed
 	*piPointSize = cf.iPointSize;
 
 	return TRUE;
+}
+
+//! Windows エクスプローラーで開く
+bool OpenByExplorer(HWND hWnd, const std::filesystem::path& path)
+{
+	if (path.empty()) {
+		return false;
+	}
+
+	std::filesystem::path explorerPath;
+	std::wstring_view verb = L"explore";
+	std::wstring_view file = path.c_str();
+	std::wstring params;
+	const wchar_t* lpParameters = nullptr;
+
+	if (path.filename() != L".") {
+		std::wstring buf(_MAX_PATH, wchar_t());
+		size_t requiredSize;
+		_wgetenv_s(&requiredSize, buf.data(), buf.capacity(), L"windir");
+		verb = L"open";
+		explorerPath = buf.data();
+		explorerPath /= L"explorer.exe";
+		file = explorerPath.c_str();
+		params = strprintf(L"/select,\"%s\"", path.c_str());
+		lpParameters = params.c_str();
+	}
+
+	// If the function succeeds, it returns a value greater than 32. 
+	if (auto hInstance = ::ShellExecuteW(hWnd, verb.data(), file.data(), lpParameters, nullptr, SW_SHOWNORMAL);
+		hInstance <= (decltype(hInstance))32) {
+		return false;
+	}
+
+	return true;
 }
 
 //! ブラウザで開く

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -218,7 +218,7 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 			// 選択されたメニューの処理
 			switch( nId ){
 			case 100:	// 設定フォルダを開く
-				OpenByExplorer(hwnd, GetIniFileName());
+				OpenWithExplorer(hwnd, GetIniFileName());
 				break;
 
 			case 101:	// インポート／エクスポートの起点リセット（起点を設定フォルダにする）
@@ -567,7 +567,7 @@ BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData)
 
 		WCHAR buf[256];
 		swprintf( buf, _countof(buf), L"https://sakura-editor.github.io/help/HLP%06Iu.html", dwData );
-		OpenByBrowser( ::GetActiveWindow(), buf );
+		OpenWithBrowser( ::GetActiveWindow(), buf );
 	}
 
 	return TRUE;
@@ -623,7 +623,7 @@ BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool Fixed
 }
 
 //! Windows エクスプローラーで開く
-bool OpenByExplorer(HWND hWnd, const std::filesystem::path& path)
+bool OpenWithExplorer(HWND hWnd, const std::filesystem::path& path)
 {
 	if (path.empty()) {
 		return false;
@@ -657,7 +657,7 @@ bool OpenByExplorer(HWND hWnd, const std::filesystem::path& path)
 }
 
 //! ブラウザで開く
-bool OpenByBrowser(HWND hWnd, std::wstring_view url)
+bool OpenWithBrowser(HWND hWnd, std::wstring_view url)
 {
 	if (url.empty()) {
 		return false;

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -635,6 +635,9 @@ bool OpenWithExplorer(HWND hWnd, const std::filesystem::path& path)
 	std::wstring params;
 	const wchar_t* lpParameters = nullptr;
 
+	// ファイル名（最後の'\'に続く部分）がドット('.')でない場合、
+	// Windowsエクスプローラーのコマンドを指定してファイルを選択させる。
+	// ※ドットは「フォルダ自身」を表す特殊なファイル名。
 	if (path.filename() != L".") {
 		std::wstring buf(_MAX_PATH, wchar_t());
 		size_t requiredSize;

--- a/sakura_core/util/shell.h
+++ b/sakura_core/util/shell.h
@@ -31,6 +31,7 @@
 
 #include <Windows.h>
 
+#include <filesystem>
 #include <string_view>
 
 BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData);	/* WinHelp のかわりに HtmlHelp を呼び出す */	// 2006.07.22 ryoji
@@ -58,6 +59,9 @@ INT_PTR MyPropertySheet( LPPROPSHEETHEADER lppsph );	// 独自拡張プロパテ
 
 //!フォント選択ダイアログ
 BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool );	// 2009.10.01 ryoji ポイントサイズ（1/10ポイント単位）引数追加
+
+//! Windows エクスプローラーで開く
+bool OpenByExplorer(HWND hWnd, const std::filesystem::path& path);
 
 //! ブラウザで開く
 bool OpenByBrowser(HWND hWnd, std::wstring_view url);

--- a/sakura_core/util/shell.h
+++ b/sakura_core/util/shell.h
@@ -61,9 +61,9 @@ INT_PTR MyPropertySheet( LPPROPSHEETHEADER lppsph );	// 独自拡張プロパテ
 BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool );	// 2009.10.01 ryoji ポイントサイズ（1/10ポイント単位）引数追加
 
 //! Windows エクスプローラーで開く
-bool OpenByExplorer(HWND hWnd, const std::filesystem::path& path);
+bool OpenWithExplorer(HWND hWnd, const std::filesystem::path& path);
 
 //! ブラウザで開く
-bool OpenByBrowser(HWND hWnd, std::wstring_view url);
+bool OpenWithBrowser(HWND hWnd, std::wstring_view url);
 
 #endif /* SAKURA_SHELL_0A8B6454_B007_46E5_9606_8D2FD7993B91_H_ */

--- a/sakura_core/util/shell.h
+++ b/sakura_core/util/shell.h
@@ -29,6 +29,10 @@
 #define SAKURA_SHELL_0A8B6454_B007_46E5_9606_8D2FD7993B91_H_
 #pragma once
 
+#include <Windows.h>
+
+#include <string_view>
+
 BOOL MyWinHelp(HWND hwndCaller, UINT uCommand, DWORD_PTR dwData);	/* WinHelp のかわりに HtmlHelp を呼び出す */	// 2006.07.22 ryoji
 
 /* Shell Interface系(?) */
@@ -54,4 +58,8 @@ INT_PTR MyPropertySheet( LPPROPSHEETHEADER lppsph );	// 独自拡張プロパテ
 
 //!フォント選択ダイアログ
 BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool );	// 2009.10.01 ryoji ポイントサイズ（1/10ポイント単位）引数追加
+
+//! ブラウザで開く
+bool OpenByBrowser(HWND hWnd, std::wstring_view url);
+
 #endif /* SAKURA_SHELL_0A8B6454_B007_46E5_9606_8D2FD7993B91_H_ */

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -772,12 +772,15 @@ LRESULT CEditView::DispatchEvent(
 			m_pcDropTarget->Revoke_DropTarget();
 		}
 
+		/* タイマー終了 */
+		::KillTimer( GetHwnd(), IDT_ROLLMOUSE );
+
+		// 「URLを開く」処理の完了をチェックして必要があれば待機する
+		// 開始後、joinされてないstd::threadを破棄すると例外が起きる。
+		// ダブルクリックで「URLを開く」をしてない場合、このif文には入らない。
 		if (m_threadUrlOpen.joinable()) {
 			m_threadUrlOpen.join();
 		}
-
-		/* タイマー終了 */
-		::KillTimer( GetHwnd(), IDT_ROLLMOUSE );
 
 //		MYTRACE( L"	WM_DESTROY\n" );
 		/*

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -772,6 +772,10 @@ LRESULT CEditView::DispatchEvent(
 			m_pcDropTarget->Revoke_DropTarget();
 		}
 
+		if (m_threadUrlOpen.joinable()) {
+			m_threadUrlOpen.join();
+		}
+
 		/* タイマー終了 */
 		::KillTimer( GetHwnd(), IDT_ROLLMOUSE );
 

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -46,6 +46,9 @@
 #include <Windows.h>
 #include <ObjIdl.h>  // LPDATAOBJECT
 #include <ShellAPI.h>  // HDROP
+
+#include <thread>
+
 #include "CTextMetrics.h"
 #include "CTextDrawer.h"
 #include "CTextArea.h"
@@ -120,6 +123,8 @@ class CEditView
 , public CMyWnd
 , public CDocListenerEx
 {
+	std::thread m_threadUrlOpen;
+
 public:
 	const CEditDoc* GetDocument() const
 	{

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -22,9 +22,15 @@
 */
 
 #include "StdAfx.h"
-#include <process.h> // _beginthreadex
-#include <limits.h>
 #include "CEditView.h"
+
+#include <limits.h>
+
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
+
 #include "_main/CAppMode.h"
 #include "CEditApp.h"
 #include "CGrepAgent.h" // use CEditApp.h
@@ -1530,15 +1536,6 @@ void CEditView::OnLBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 	return;
 }
 
-/* ShellExecuteを呼び出すプロシージャ */
-static unsigned __stdcall ShellExecuteProc( LPVOID lpParameter )
-{
-	LPWSTR pszFile = (LPWSTR)lpParameter;
-	OpenByBrowser( ::GetActiveWindow(), pszFile );
-	free( pszFile );
-	return 0;
-}
-
 // マウス左ボタンダブルクリック
 // 2007.01.18 kobake IsCurrentPositionURL仕様変更に伴い、処理の書き換え
 void CEditView::OnLBUTTONDBLCLK( WPARAM fwKeys, int _xPos , int _yPos )
@@ -1582,20 +1579,33 @@ void CEditView::OnLBUTTONDBLCLK( WPARAM fwKeys, int _xPos , int _yPos )
 				// 2009.05.21 syat UNCパスだと1分以上無応答になることがあるのでスレッド化
 				CWaitCursor cWaitCursor( GetHwnd() );	// カーソルを砂時計にする
 
-				unsigned int nThreadId;
-				LPCWSTR szUrl = strOPEN.c_str();
-				LPWSTR szUrlDup = _wcsdup( szUrl );
-				HANDLE hThread = (HANDLE)_beginthreadex( NULL, 0, ShellExecuteProc, (LPVOID)szUrlDup, 0, &nThreadId );
-				if( hThread != INVALID_HANDLE_VALUE ){
-					// ユーザーのURL起動指示に反応した目印としてちょっとの時間だけ砂時計カーソルを表示しておく
-					// ShellExecute は即座にエラー終了することがちょくちょくあるので WaitForSingleObject ではなく Sleep を使用（ex.存在しないパスの起動）
-					// 【補足】いずれの API でも待ちを長め（2～3秒）にするとなぜか Web ブラウザ未起動からの起動が重くなる模様（PCタイプ, XP/Vista, IE/FireFox に関係なく）
-					::Sleep(200);
-					::CloseHandle(hThread);
-				}else{
-					//スレッド作成失敗
-					free( szUrlDup );
+				if (m_threadUrlOpen.joinable()) {
+					m_threadUrlOpen.join();
 				}
+
+				std::mutex mtx;
+				std::condition_variable cv;
+				bool initialized = false;
+				m_threadUrlOpen = std::thread( [this, strOPEN, &mtx, &cv, &initialized] {
+					// 初期化
+					std::wstring url(strOPEN);
+					if (!initialized)
+					{
+						std::unique_lock lock( mtx );
+						initialized = true;
+						cv.notify_one();
+					}
+
+					// 本処理
+					if( !OpenByBrowser( GetHwnd(), url ) ){
+						// ユーザーのURL起動指示に反応した目印としてちょっとの時間だけ砂時計カーソルを表示しておく
+						// ShellExecute は即座にエラー終了することがちょくちょくあるので WaitForSingleObject ではなく Sleep を使用（ex.存在しないパスの起動）
+						// 【補足】いずれの API でも待ちを長め（2～3秒）にするとなぜか Web ブラウザ未起動からの起動が重くなる模様（PCタイプ, XP/Vista, IE/FireFox に関係なく）
+						::Sleep( 200 );
+					}
+				});
+				std::unique_lock lock( mtx );
+				cv.wait(lock, [&initialized] { return initialized; });
 			}
 			return;
 		}

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -38,6 +38,7 @@
 #include "uiparts/HandCursor.h"
 #include "util/input.h"
 #include "util/os.h"
+#include "util/shell.h"
 #include "charset/CCodeBase.h"
 #include "charset/CCodeFactory.h"
 #include "apiwrap/StdApi.h"
@@ -1533,7 +1534,7 @@ void CEditView::OnLBUTTONUP( WPARAM fwKeys, int xPos , int yPos )
 static unsigned __stdcall ShellExecuteProc( LPVOID lpParameter )
 {
 	LPWSTR pszFile = (LPWSTR)lpParameter;
-	::ShellExecute( NULL, L"open", pszFile, NULL, NULL, SW_SHOW );
+	OpenByBrowser( ::GetActiveWindow(), pszFile );
 	free( pszFile );
 	return 0;
 }

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -1597,7 +1597,7 @@ void CEditView::OnLBUTTONDBLCLK( WPARAM fwKeys, int _xPos , int _yPos )
 					}
 
 					// 本処理
-					if( !OpenByBrowser( GetHwnd(), url ) ){
+					if( !OpenWithBrowser( GetHwnd(), url ) ){
 						// ユーザーのURL起動指示に反応した目印としてちょっとの時間だけ砂時計カーソルを表示しておく
 						// ShellExecute は即座にエラー終了することがちょくちょくあるので WaitForSingleObject ではなく Sleep を使用（ex.存在しないパスの起動）
 						// 【補足】いずれの API でも待ちを長め（2～3秒）にするとなぜか Web ブラウザ未起動からの起動が重くなる模様（PCタイプ, XP/Vista, IE/FireFox に関係なく）


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
CodeFactorで検出されて放置されている、
Possible OS command injection(CWE-78)について対策します。
https://www.codefactor.io/repository/github/sakura-editor/sakura/issues?category=Security&groupId=3670

## <!-- 必須 --> カテゴリ

- 仕様変更
- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
CodeFactorでPossible OS command injection(CWE-78)が検出されています。
https://www.codefactor.io/repository/github/sakura-editor/sakura/issues?category=Security&groupId=3670

CWE-78
https://jvndb.jvn.jp/ja/cwe/CWE-78.html

シェル関数に渡すパラメータのチェックを漏らしているコードが不具合検出対象になります。
それなりに有名なセキュリティ脆弱性で、対策したほうがよいと思います。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
* 検出される警告数を減らすことができます。
  直接呼出を間接呼出に変えるので、減るのは確実です。
  警告が消えるかどうかを検証する方法はありません。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくにありません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
ShellExecute関数の呼び出し箇所を削減するため、独自関数を2つ追加します。

* ~~OpenByBrowser ← ブラウザで開く~~
  OpenWithBrowser ← ブラウザで開く
* ~~OpenByExplorer ← Windows エクスプローラーで開く~~
  OpenWithExplorer ← Windows エクスプローラーで開く

ShellExecuteEx関数の呼び出しについても、デバッグしてみて「Exである必要なし」と判断したため横並びで新規独自関数を使うように変更しています。

残してあるShellExecute関数の呼び出し箇所は、NG検出されていなかったので放置です。

その他、URLリンクのクリック時のスレッド起動をC++のスレッドで書き直し、可読性と信頼性の向上を図ってみました。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
- ブラウザで（URLを）開く処理
- Windowsエクスプローラーで（フォルダを）開く処理

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
- ブラウザで（URLを）開く処理
  - URLリンクをダブルクリックします。
  - 開いているファイル（HTML等）を、ファイル → ブラウズします。
  - ヘルプ → バージョン情報のリンクをシングルクリックします。
  - 設定 → 共通設定のプラグインタブでインストールされたプラグインの「配布サイト」ボタンをクリックします。
  - コンパイル済みヘルプ（sakura.chm）がない状態で、ヘルプを表示します（ヘルプ → 目次）
- Windowsエクスプローラーで（フォルダを）開く処理
  - 保存済みファイルを開いている状態で、タブメニュー → ファイルの場所を開く、します。
  - 設定 → 共通設定のプラグインタブで「フォルダを開く」ボタンをクリックします。
  - sakura.exe.ini でユーザー別設定を有効にした状態で、設定 → 共通設定の左下にある「設定フォルダ」ボタンをクリックして表示されるドロップダウンメニューで「開く」を選択します。
    ※仕様変更：エクスプローラーで設定ファイルが選択されます。変更前は開くだけでした。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
