### PR TITLE
ブラウザでURLを開く機能の改善

### DIFF
--- a/sakura_core/Makefile
+++ b/sakura_core/Makefile
@@ -98,6 +98,7 @@ LIBS= \
  -lwinmm \
  -lwindowscodecs \
  -lmsimg32 \
+ -lurlmon \
  -mwindows \
  -municode \
  $(MYLIBS)

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -453,7 +453,8 @@ void CViewCommander::Command_BROWSE( void )
 	}
 
 	std::wstring_view path(GetDocument()->m_cDocFile.GetFilePath());
-	OpenWithBrowser(m_pCommanderView->GetHwnd(), path);
+	std::wstring url(strprintf(L"file:///%s", path.data()));
+	OpenWithBrowser(m_pCommanderView->GetHwnd(), url);
 
 	return;
 }

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -115,6 +115,7 @@ LIBS= \
  -lwinmm \
  -lwindowscodecs \
  -lmsimg32 \
+ -lurlmon \
  -lkernel32 \
  -lgdi32 \
  -lcomdlg32 \


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
「ブラウザで（URLを）開く」機能を改善します。

## <!-- 必須 --> カテゴリ

- 仕様変更
- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1702 セキュリティ問題を起こしやすいShellExecute関数を直接呼ばないようにリファクタリングする
　↓
#1705 クリッカブルURL機能から実行可能ファイルを直接実行できるのは仕様かどうか
　↓
関連付けられたプログラム（ブラウザ）で開くという機能定義から見て
仕様ではなさそうなので、不具合として対処します。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
URLが含まれるテキストの編集中に意図せずプログラムを実行してしまう事態を防止できます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
従来の挙動を便利に活用していた人が困るかも知れません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
変更点1、ブラウズ機能から OpenWithBrowser を呼び出す際にローカルファイルパスをそのまま渡していたのを、「file:///」プレフィックスを付けて渡すように変更します。
変更点2、OpenWithBrowserのパラメータ仕様を変更します。変更前はURLとUNCパス、ローカルのフルパスを受け付けていましたが、変更後はURLのみを受け付けるようにします。また、従来は指定されたURLをそのままシェルに渡していましたが、変更後はWindowsのURL解析機能を呼び出してURLスキームをチェックし、「file」プロトコルを開くときに「http」プロトコルに関連付けられたプログラムを使うように変更します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
* ファイル→ブラウズでローカルスクリプトを実行することができなくなります。
  ※従来はbatやcmdの編集中に「ブラウズ」でスクリプト実行できていました。（これも不具合）
  ※ブラウザ上で動くjavascriptの実行確認は可能です。
* クリッカブルURLのダブルクリックでexeファイルを実行することができなくなります。
  ※httpプロトコルに関連付けられたプログラムでexeを開くと対象ファイルが「ダウンロード」されます。
  ※表示するつもりでダウンロードファイルが増えると悲しいので、exeは失敗扱いにします。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
resolve #1705

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://www.glamenv-septzen.net/view/695#ide5cdab
https://newoldthing.wordpress.com/2007/03/23/how-does-your-browsers-know-that-its-not-the-default-browser/
