### PR TITLE
ダイアログの位置が表示するたびにずれていく問題を修正

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -235,25 +235,25 @@ void CDialog::SetDialogPosSize()
 			rc.right = m_xPos + m_nWidth;
 			rc.bottom = m_yPos + m_nHeight;
 			GetMonitorWorkRect(&rc, &rcWork);
-			rcWork.top += 1;
-			rcWork.bottom -= 1;
-			rcWork.left += 1;
-			rcWork.right -= 1;
-			if( rc.bottom > rcWork.bottom ){
-				rc.top -= (rc.bottom - rcWork.bottom);
-				rc.bottom = rcWork.bottom;
+			LONG workHeight = rcWork.bottom - rcWork.top;
+			LONG workWidth = rcWork.right - rcWork.left;
+			if( rc.bottom > workHeight ){
+				LONG diff = rc.bottom - workHeight;
+				rc.top -= diff;
+				rc.bottom -= diff;
 			}
-			if( rc.right > rcWork.right ){
-				rc.left -= (rc.right - rcWork.right);
-				rc.right = rcWork.right;
+			if( rc.right > workWidth ){
+				LONG diff = rc.right - workWidth;
+				rc.left -= diff;
+				rc.right -= diff;
 			}
-			if( rc.top < rcWork.top ){
-				rc.bottom += (rcWork.top - rc.top);
-				rc.top = rcWork.top;
+			if( rc.top < 0 ){
+				rc.bottom += rc.top;
+				rc.top = 0;
 			}
-			if( rc.left < rcWork.left ){
-				rc.right += (rcWork.left - rc.left);
-				rc.left = rcWork.left;
+			if( rc.left < 0 ){
+				rc.right += rc.left;
+				rc.left = 0;
 			}
 			m_xPos = rc.left;
 			m_yPos = rc.top;
@@ -318,12 +318,6 @@ BOOL CDialog::OnSize( WPARAM wParam, LPARAM lParam )
 	RECT	rc;
 	::GetWindowRect( m_hWnd, &rc );
 
-	/* ダイアログのサイズの記憶 */
-	m_xPos = rc.left;
-	m_yPos = rc.top;
-	m_nWidth = rc.right - rc.left;
-	m_nHeight = rc.bottom - rc.top;
-
 	/* サイズボックスの移動 */
 	if( NULL != m_hwndSizeBox ){
 		::GetClientRect( m_hWnd, &rc );
@@ -360,19 +354,6 @@ BOOL CDialog::OnSize( WPARAM wParam, LPARAM lParam )
 
 BOOL CDialog::OnMove( WPARAM wParam, LPARAM lParam )
 {
-	/* ダイアログの位置の記憶 */
-	if( !m_bInited ){
-		return TRUE;
-	}
-	RECT	rc;
-	::GetWindowRect( m_hWnd, &rc );
-
-	/* ダイアログのサイズの記憶 */
-	m_xPos = rc.left;
-	m_yPos = rc.top;
-	m_nWidth = rc.right - rc.left;
-	m_nHeight = rc.bottom - rc.top;
-	DEBUG_TRACE( L"CDialog::OnMove() m_xPos=%d m_yPos=%d\n", m_xPos, m_yPos );
 	return TRUE;
 }
 

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -248,11 +248,11 @@ void CDialog::SetDialogPosSize()
 				rc.right -= diff;
 			}
 			if( rc.top < 0 ){
-				rc.bottom += rc.top;
+				rc.bottom -= rc.top;
 				rc.top = 0;
 			}
 			if( rc.left < 0 ){
-				rc.right += rc.left;
+				rc.right -= rc.left;
 				rc.left = 0;
 			}
 			m_xPos = rc.left;

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -149,16 +149,16 @@ public:
 	BOOL			m_bModal;		/* モーダル ダイアログか */
 	bool			m_bSizable;		// 可変ダイアログかどうか
 	int				m_nShowCmd;		//	最大化/最小化
-	int				m_nWidth;
-	int				m_nHeight;
-	int				m_xPos;
-	int				m_yPos;
 //	void*			m_pcEditView;
 	DLLSHAREDATA*	m_pShareData;
 	BOOL			m_bInited;
 	HINSTANCE		m_hLangRsrcInstance;		// メッセージリソースDLLのインスタンスハンドル	// 2011.04.10 nasukoji
 
 protected:
+	int				m_nWidth;
+	int				m_nHeight;
+	int				m_xPos;
+	int				m_yPos;
 	void CreateSizeBox( void );
 	BOOL OnCommand(WPARAM wParam, LPARAM lParam);
 

--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -265,12 +265,21 @@ BOOL CDlgCompare::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 }
 
+BOOL CDlgCompare::OnDestroy( void )
+{
+	CDialog::OnDestroy();
+	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcCompareDialog;
+	rect.left = m_xPos;
+	rect.top = m_yPos;
+	rect.right = rect.left + m_nWidth;
+	rect.bottom = rect.top + m_nHeight;
+	return TRUE;
+}
+
 BOOL CDlgCompare::OnSize( WPARAM wParam, LPARAM lParam )
 {
 	/* 基底クラスメンバ */
 	CDialog::OnSize( wParam, lParam );
-
-	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcCompareDialog );
 
 	RECT  rc;
 	POINT ptNew;
@@ -283,13 +292,6 @@ BOOL CDlgCompare::OnSize( WPARAM wParam, LPARAM lParam )
 	}
 	::InvalidateRect( GetHwnd(), NULL, TRUE );
 	return TRUE;
-}
-
-BOOL CDlgCompare::OnMove( WPARAM wParam, LPARAM lParam )
-{
-	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcCompareDialog );
-	
-	return CDialog::OnMove( wParam, lParam );
 }
 
 BOOL CDlgCompare::OnMinMaxInfo( LPARAM lParam )

--- a/sakura_core/dlg/CDlgCompare.h
+++ b/sakura_core/dlg/CDlgCompare.h
@@ -49,8 +49,8 @@ protected:
 
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnDestroy() override;
 	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
-	BOOL OnMove( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
 
 	void SetData( void ) override;	/* ダイアログデータの設定 */

--- a/sakura_core/dlg/CDlgCompare.h
+++ b/sakura_core/dlg/CDlgCompare.h
@@ -49,7 +49,7 @@ protected:
 
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
-	BOOL OnDestroy() override;
+	BOOL OnDestroy( void ) override;
 	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
 

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -517,12 +517,21 @@ BOOL CDlgDiff::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 }
 
+BOOL CDlgDiff::OnDestroy()
+{
+	CDialog::OnDestroy();
+	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcDiffDialog;
+	rect.left = m_xPos;
+	rect.top = m_yPos;
+	rect.right = rect.left + m_nWidth;
+	rect.bottom = rect.top + m_nHeight;
+	return TRUE;
+}
+
 BOOL CDlgDiff::OnSize( WPARAM wParam, LPARAM lParam )
 {
 	/* 基底クラスメンバ */
 	CDialog::OnSize( wParam, lParam );
-
-	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcDiffDialog );
 
 	RECT  rc;
 	POINT ptNew;
@@ -535,13 +544,6 @@ BOOL CDlgDiff::OnSize( WPARAM wParam, LPARAM lParam )
 	}
 	::InvalidateRect( GetHwnd(), NULL, TRUE );
 	return TRUE;
-}
-
-BOOL CDlgDiff::OnMove( WPARAM wParam, LPARAM lParam )
-{
-	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcDiffDialog );
-	
-	return CDialog::OnMove( wParam, lParam );
 }
 
 BOOL CDlgDiff::OnMinMaxInfo( LPARAM lParam )

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -517,7 +517,7 @@ BOOL CDlgDiff::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 }
 
-BOOL CDlgDiff::OnDestroy()
+BOOL CDlgDiff::OnDestroy( void )
 {
 	CDialog::OnDestroy();
 	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcDiffDialog;

--- a/sakura_core/dlg/CDlgDiff.h
+++ b/sakura_core/dlg/CDlgDiff.h
@@ -68,7 +68,7 @@ protected:
 	LPVOID	GetHelpIdTable(void) override;
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
-	BOOL OnDestroy() override;
+	BOOL OnDestroy( void ) override;
 	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
 

--- a/sakura_core/dlg/CDlgDiff.h
+++ b/sakura_core/dlg/CDlgDiff.h
@@ -68,8 +68,8 @@ protected:
 	LPVOID	GetHelpIdTable(void) override;
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnDestroy() override;
 	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
-	BOOL OnMove( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
 
 	void	SetData( void ) override;	/* ダイアログデータの設定 */

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -486,6 +486,17 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return CDialog::OnInitDialog( GetHwnd(), wParam, lParam );
 }
 
+BOOL CDlgFavorite::OnDestroy( void )
+{
+	CDialog::OnDestroy();
+	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcFavoriteDialog;
+	rect.left = m_xPos;
+	rect.top = m_yPos;
+	rect.right = rect.left + m_nWidth;
+	rect.bottom = rect.top + m_nHeight;
+	return TRUE;
+}
+
 BOOL CDlgFavorite::OnBnClicked( int wID )
 {
 	switch( wID )
@@ -1189,8 +1200,6 @@ BOOL CDlgFavorite::OnSize( WPARAM wParam, LPARAM lParam )
 	/* 基底クラスメンバ */
 	CDialog::OnSize( wParam, lParam );
 
-	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcFavoriteDialog );
-
 	RECT rc;
 	POINT ptNew;
 	::GetWindowRect( GetHwnd(), &rc );
@@ -1207,13 +1216,6 @@ BOOL CDlgFavorite::OnSize( WPARAM wParam, LPARAM lParam )
 	}
 	::InvalidateRect( GetHwnd(), NULL, TRUE );
 	return TRUE;
-}
-
-BOOL CDlgFavorite::OnMove( WPARAM wParam, LPARAM lParam )
-{
-	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcFavoriteDialog );
-	
-	return CDialog::OnMove( wParam, lParam );
 }
 
 BOOL CDlgFavorite::OnMinMaxInfo( LPARAM lParam )

--- a/sakura_core/dlg/CDlgFavorite.h
+++ b/sakura_core/dlg/CDlgFavorite.h
@@ -66,13 +66,13 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL	OnDestroy( void ) override;
 	BOOL	OnBnClicked(int wID) override;
 	BOOL	OnNotify(NMHDR* pNMHDR) override;
 	BOOL	OnActivate( WPARAM wParam, LPARAM lParam ) override;
 	LPVOID	GetHelpIdTable( void ) override;
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
 	BOOL	OnSize( WPARAM wParam, LPARAM lParam ) override;
-	BOOL	OnMove( WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnMinMaxInfo( LPARAM lParam );
 
 	void	SetData( void ) override;	/* ダイアログデータの設定 */

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -537,6 +537,17 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return bRet;
 }
 
+BOOL CDlgTagJumpList::OnDestroy( void )
+{
+	CDialog::OnDestroy();
+	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcTagJumpDialog;
+	rect.left = m_xPos;
+	rect.top = m_yPos;
+	rect.right = rect.left + m_nWidth;
+	rect.bottom = rect.top + m_nHeight;
+	return TRUE;
+}
+
 BOOL CDlgTagJumpList::OnBnClicked( int wID )
 {
 	switch( wID )
@@ -601,8 +612,6 @@ BOOL CDlgTagJumpList::OnSize( WPARAM wParam, LPARAM lParam )
 	/* 基底クラスメンバ */
 	CDialog::OnSize( wParam, lParam );
 
-	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcTagJumpDialog );
-
 	RECT  rc;
 	POINT ptNew;
 	::GetWindowRect( GetHwnd(), &rc );
@@ -614,13 +623,6 @@ BOOL CDlgTagJumpList::OnSize( WPARAM wParam, LPARAM lParam )
 	}
 	::InvalidateRect( GetHwnd(), NULL, TRUE );
 	return TRUE;
-}
-
-BOOL CDlgTagJumpList::OnMove( WPARAM wParam, LPARAM lParam )
-{
-	::GetWindowRect( GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcTagJumpDialog );
-
-	return CDialog::OnMove( wParam, lParam );
 }
 
 BOOL CDlgTagJumpList::OnMinMaxInfo( LPARAM lParam )

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -78,10 +78,10 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL	OnDestroy( void ) override;
 	BOOL	OnBnClicked(int wID) override;
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnSize( WPARAM wParam, LPARAM lParam ) override;
-	BOOL	OnMove( WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnMinMaxInfo( LPARAM lParam );
 	BOOL	OnNotify(NMHDR* pNMHDR) override;
 	//	@@ 2005.03.31 MIK キーワード入力エリアのイベント処理

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -236,11 +236,20 @@ BOOL CDlgWindowList::OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam)
 	return CDialog::OnInitDialog(hwndDlg, wParam, lParam);
 }
 
+BOOL CDlgWindowList::OnDestroy( void )
+{
+	CDialog::OnDestroy();
+	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcWindowListDialog;
+	rect.left = m_xPos;
+	rect.top = m_yPos;
+	rect.right = rect.left + m_nWidth;
+	rect.bottom = rect.top + m_nHeight;
+	return TRUE;
+}
+
 BOOL CDlgWindowList::OnSize(WPARAM wParam, LPARAM lParam)
 {
 	CDialog::OnSize(wParam, lParam);
-
-	::GetWindowRect(GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcWindowListDialog);
 
 	RECT  rc;
 	POINT ptNew;
@@ -253,13 +262,6 @@ BOOL CDlgWindowList::OnSize(WPARAM wParam, LPARAM lParam)
 	}
 	::InvalidateRect(GetHwnd(), NULL, TRUE);
 	return TRUE;
-}
-
-BOOL CDlgWindowList::OnMove(WPARAM wParam, LPARAM lParam)
-{
-	::GetWindowRect(GetHwnd(), &GetDllShareData().m_Common.m_sOthers.m_rcWindowListDialog);
-	
-	return CDialog::OnMove(wParam, lParam);
 }
 
 BOOL CDlgWindowList::OnMinMaxInfo(LPARAM lParam)

--- a/sakura_core/dlg/CDlgWindowList.h
+++ b/sakura_core/dlg/CDlgWindowList.h
@@ -45,8 +45,8 @@ protected:
 	LPVOID	GetHelpIdTable() override;
 	INT_PTR DispatchEvent(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnDestroy( void ) override;
 	BOOL OnSize(WPARAM wParam, LPARAM lParam) override;
-	BOOL OnMove(WPARAM wParam, LPARAM lParam) override;
 	BOOL OnMinMaxInfo(LPARAM lParam);
 	BOOL OnActivate(WPARAM wParam, LPARAM lParam) override;
 


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

#397 で報告されている問題に対処するのが目的です。#687 の続編です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

ダイアログの位置が表示する度にずれていく問題が解消される。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

- `CDialog::SetDialogPosSize` メソッドにおいてモニターワーク領域に収まるように位置調整する処理を更新
- ダイアログのサイズの記憶を `WM_SIZE` メッセージのハンドラの `CDialog::OnSize` では行わないように変更
- ダイアログのサイズの記憶を `WM_MOVE` メッセージのハンドラの `CDialog::OnMove` では行わないように変更
- ウィンドウ位置の保存・復帰を行うダイアログにおいて `WM_DESTROY` メッセージのハンドラの `OnDestroy` メソッドでウィンドウ位置の保存を行うように変更して、`WM_SIZE`, `WM_MOVE` メッセージのハンドラでは保存しないように変更

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

タイトル | メニュー | 実装クラス
--|--|--
ファイル内容比較 | 検索 > ファイル内容比較 | CDlgCompare
DIFF差分表示 | 検索 > DIFF差分表示 | CDlgDiff
履歴とお気に入りの管理 | 設定 > 履歴の管理 | CDlgFavorite
ダイレクトタグジャンプ一覧 | 検索 > タグジャンプ | CDlgTagJumpList
ウィンドウ一覧  | ウィンドウ > ウィンドウ一覧表示  | CDlgWindowList

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順

- タスクバーの位置を標準の下から左もしくは上に変える
- サクラエディタを起動する
- Ctrl + N キーで新規タブを追加する
- Ctrl + Enter キーでDIFFダイアログを表示する
- 表示されたDiffダイアログを閉じる
- Ctrl + Enter キーでDIFFダイアログを再度表示する
- 表示されたDiffダイアログの位置が前回と変わっていないか確認

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#397, #687

