### PR TITLE
マウスドラッグ時のスクロールが速すぎるので描画更新の設定を変更する

### DIFF
--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -860,7 +860,9 @@ void CCaret::ShowCaretPosInfo()
 				::UnionRect(&updatedRect, &updatedRect, &partRect);
 			}
 		};
-		::SendMessage(hWnd, WM_SETREDRAW, FALSE, 0);
+		if (!m_pEditView->GetSelectionInfo().IsMouseSelecting() && !m_pEditView->m_bDragMode) {
+			::SendMessage(hWnd, WM_SETREDRAW, FALSE, 0);
+		}
 		if( m_bClearStatus ){
 			setStatusText( 0, SBT_NOBORDERS, L"" );
 		}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
マウスドラッグ時のスクロールスピードが速くなったようなので修正します

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->
- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
Windows 8.1で、マウスで選択中または選択部分をマウスでドラッグアンドドロップするときに
スクロールが始まる領域までマウスを少しずつ動かしても、高速にスクロールしてしまいます。
数秒で数百行スクロールするので操作できません。
Windows 10では数十行ほどなのでウィンドウサイズが大きければ操作できます。

[正式版](https://github.com/sakura-editor/sakura/releases/tag/v2.4.1)では一行程度のスクロールができました。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
ウィンドウに表示されてない範囲まで選択する際に、微調整できるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
view/CCaret.cppの
::SendMessage(hWnd, WM_SETREDRAW, FALSE, 0);
をコメントアウトすると収まったので、「PRの背景」に書いた条件時に呼び出さないようにします

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1601
#1694


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
