### PR TITLE
EEolType::auto_detectをやめてEEolType::noneを使う

### DIFF
--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -50,8 +50,7 @@
 	@date 2021/03/27 berryzplus 定数に意味のある名前を付ける
  */
 enum class EEolType : char {
-	auto_detect = -1,		//!< 行終端子の自動検出
-	none,					//!< 行終端子なし
+	none,					//!< 行終端子なし（改行コード変換では「変換しない」）
 	cr_and_lf,				//!< \x0d\x0a 復帰改行
 	line_feed,				//!< \x0a 改行
 	carriage_return,		//!< \x0d 復帰

--- a/sakura_core/cmd/CViewCommander.h
+++ b/sakura_core/cmd/CViewCommander.h
@@ -216,7 +216,7 @@ public:
 
 	/* クリップボード系 */
 	void Command_CUT( void );						/* 切り取り（選択範囲をクリップボードにコピーして削除）*/
-	void Command_COPY( bool bIgnoreLockAndDisable, bool bAddCRLFWhenCopy, EEolType neweol = EEolType::auto_detect );/* コピー(選択範囲をクリップボードにコピー) */
+	void Command_COPY( bool bIgnoreLockAndDisable, bool bAddCRLFWhenCopy, EEolType neweol = EEolType::none );/* コピー(選択範囲をクリップボードにコピー) */
 	void Command_PASTE( int option );						/* 貼り付け（クリップボードから貼り付け）*/
 	void Command_PASTEBOX( int option );					/* 矩形貼り付け（クリップボードから矩形貼り付け）*/
 	//<< 2002/03/29 Azumaiya

--- a/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
@@ -300,7 +300,7 @@ void CViewCommander::Command_CUT_LINE( void )
 	// 2007.10.04 ryoji 処理簡素化
 	m_pCommanderView->CopyCurLine(
 		GetDllShareData().m_Common.m_sEdit.m_bAddCRLFWhenCopy,
-		EEolType::auto_detect,
+		EEolType::none,
 		GetDllShareData().m_Common.m_sEdit.m_bEnableLineModePaste
 	);
 	Command_DELETE_LINE();

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1802,7 +1802,7 @@ void CEditView::SplitBoxOnOff( BOOL bVert, BOOL bHorz, BOOL bSizeBox )
 */
 bool CEditView::GetSelectedDataSimple( CNativeW &cmemBuf )
 {
-	return GetSelectedData(&cmemBuf, FALSE, NULL, FALSE, false, EEolType::auto_detect);
+	return GetSelectedData(&cmemBuf, FALSE, NULL, FALSE, false, EEolType::none);
 }
 
 /* 選択範囲のデータを取得
@@ -1936,7 +1936,7 @@ bool CEditView::GetSelectedData(
 		}
 
 		// 改行コードについて。
-		if ( neweol == EEolType::auto_detect )
+		if ( neweol == EEolType::none )
 		{
 			nBufSize += wcslen(WCODE::CRLF);
 		}
@@ -1995,7 +1995,7 @@ bool CEditView::GetSelectedData(
 				if( nIdxTo >= nLineLen ){
 					cmemBuf->AppendString( &pLine[nIdxFrom], nLineLen - 1 - nIdxFrom );
 					//	Jul. 25, 2000 genta
-					cmemBuf->AppendString( ( neweol == EEolType::auto_detect ) ?
+					cmemBuf->AppendString( ( neweol == EEolType::none ) ?
 						(pcLayout->GetLayoutEol()).GetValue2() :	//	コード保存
 						appendEol.GetValue2() );			//	新規改行コード
 				}
@@ -2010,7 +2010,7 @@ bool CEditView::GetSelectedData(
 						bWithLineNumber 	/* 行番号を付与する */
 					){
 						//	Jul. 25, 2000 genta
-						cmemBuf->AppendString(( neweol == EEolType::auto_detect ) ?
+						cmemBuf->AppendString(( neweol == EEolType::none ) ?
 							m_pcEditDoc->m_cDocEditor.GetNewLineCode().GetValue2() :	//	コード保存
 							appendEol.GetValue2() );		//	新規改行コード
 					}

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -327,7 +327,7 @@ public:
 	// 2002/01/19 novice public属性に変更
 	bool GetSelectedDataSimple( CNativeW& cmemBuf );// 選択範囲のデータを取得
 	bool GetSelectedDataOne( CNativeW& cmemBuf, int nMaxLen );
-	bool GetSelectedData( CNativeW* cmemBuf, BOOL bLineOnly, const wchar_t* pszQuote, BOOL bWithLineNumber, bool bAddCRLFWhenCopy, EEolType neweol = EEolType::auto_detect);/* 選択範囲のデータを取得 */
+	bool GetSelectedData( CNativeW* cmemBuf, BOOL bLineOnly, const wchar_t* pszQuote, BOOL bWithLineNumber, bool bAddCRLFWhenCopy, EEolType neweol = EEolType::none);/* 選択範囲のデータを取得 */
 	int IsCurrentPositionSelected( CLayoutPoint ptCaretPos );					/* 指定カーソル位置が選択エリア内にあるか */
 	int IsCurrentPositionSelectedTEST( const CLayoutPoint& ptCaretPos, const CLayoutRange& sSelect ) const;/* 指定カーソル位置が選択エリア内にあるか */
 	// 2006.07.09 genta 行桁指定によるカーソル移動(選択領域を考慮)

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -452,12 +452,12 @@ void CEditView::CopyCurLine(
 	cmemBuf.SetString( pcLayout->GetPtr(), pcLayout->GetLengthWithoutEOL() );
 	if( pcLayout->GetLayoutEol().GetLen() != 0 ){
 		cmemBuf.AppendString(
-			( neweol == EEolType::auto_detect ) ?
+			( neweol == EEolType::none ) ?
 				pcLayout->GetLayoutEol().GetValue2() : CEol(neweol).GetValue2()
 		);
 	}else if( bAddCRLFWhenCopy ){	// 2007.10.08 ryoji bAddCRLFWhenCopy対応処理追加
 		cmemBuf.AppendString(
-			( neweol == EEolType::auto_detect ) ?
+			( neweol == EEolType::none ) ?
 				WCODE::CRLF : CEol(neweol).GetValue2()
 		);
 	}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
#1610 の CEol 整理で犯した判断ミスの訂正です。
新設したenum定数EEolType::auto_detectを廃止して分かりやすくします。

## <!-- 必須 --> カテゴリ

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

#1610 で 列挙定数 EEolType を enum class化しました。
その際、改行コード変換で「指定なし」を指定するときの値「auto_detect」を追加しました。
（もともとは EOL_NONE が「指定なし」の意味で使われていました。）

#1710 で改行コード変換を扱ってみたところ、
「かえって分かりづらくなっている」と感じたので auto_detect をやめて none にしたいです。


## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
とくにないと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
#1610 で追加した EEolType::auto_detect を削除して EEolType::none を使うよう修正します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
改行コード変換の処理（無変換の判定）に影響する変更です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
ビルド確認で十分と思います。

### テスト1

手順


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
ammend #1610

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
