### PR TITLE
Grep 置換ダイアログを表示すると，置換前 と 置換後の両方が選択状態になる現象が発生しないように修正

### DIFF
--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -146,6 +146,21 @@ BOOL CDlgGrepReplace::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return bRet;
 }
 
+BOOL CDlgGrepReplace::OnCbnDropDown( HWND hwndCtl, int wID )
+{
+	switch( wID ){
+	case IDC_COMBO_TEXT2:
+		if ( ::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
+			const auto& keys = m_pShareData->m_sSearchKeywords.m_aReplaceKeys;
+			for( int i = 0; i < keys.size(); ++i ){
+				Combo_AddString( hwndCtl, keys[i] );
+			}
+		}
+		break;
+	}
+	return CDlgGrep::OnCbnDropDown( hwndCtl, wID );
+}
+
 BOOL CDlgGrepReplace::OnDestroy()
 {
 	m_cFontText2.ReleaseOnDestroy();
@@ -184,10 +199,6 @@ void CDlgGrepReplace::SetData( void )
 {
 	/* 置換後 */
 	::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT2, m_strText2.c_str() );
-	HWND	hwndCombo = GetItemHwnd( IDC_COMBO_TEXT2 );
-	for( int i = 0; i < m_pShareData->m_sSearchKeywords.m_aReplaceKeys.size(); ++i ){
-		Combo_AddString( hwndCombo, m_pShareData->m_sSearchKeywords.m_aReplaceKeys[i] );
-	}
 	
 	CheckDlgButtonBool( GetHwnd(), IDC_CHK_BACKUP, m_bBackup );
 

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -50,6 +50,7 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
+	BOOL OnCbnDropDown( HWND hwndCtl, int wID ) override;
 	BOOL OnDestroy() override;
 	BOOL OnBnClicked(int wID) override;
 	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

#1717 で報告された問題のうち、Grep置換ダイアログ表示した際に置換前と置換後の両方が選択状態になる現象が発生しないように修正するのが目的です。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正

## <!-- わかる範囲で --> PR の影響範囲

`CDlgGrepReplace::SetData` において置換後のコンボボックスに項目を追加するのではなく、`WM_COMMAND` メッセージの通知コードが `CBN_DROPDOWN` の場合に呼び出される仮想関数 `CDialog::OnCbnDropDown` を override した `CDlgGrepReplace::OnCbnDropDown` で置換後のコンボボックスの項目を追加するようにしました。

新しく追加した `CDlgGrepReplace::OnCbnDropDown` の処理内容は `CDlgGrep::OnCbnDropDown` と同じように、まだコンボボックスに要素が追加されていない場合に設定するようにしています。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順

1.  Grep 置換で何か置換を実行する
2.  再び Grep 置換ダイアログを表示すると，置換前 だけが選択状態、置換後は選択状態ではない

## <!-- なければ省略可 --> 関連 issue, PR

#1717

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
