### PR TITLE
外部コマンド実行でキャンセルした時のメッセージが異なる問題を修正

### DIFF
--- a/sakura_core/view/CEditView_ExecCmd.cpp
+++ b/sakura_core/view/CEditView_ExecCmd.cpp
@@ -570,7 +570,7 @@ user_cancel:
 		if( bCancelEnd && bOutputExtInfo ){
 			//	2006.12.03 maru アウトプットウィンドウにのみ出力
 			//最後にテキストを追加
-			oa.OutputW( LS(STR_EDITVIEW_EXECCMD_STOP) );
+			oa.OutputW( CLoadString().LoadStringW(STR_EDITVIEW_EXECCMD_STOP) );
 		}
 		
 		{

--- a/sakura_core/view/CEditView_ExecCmd.cpp
+++ b/sakura_core/view/CEditView_ExecCmd.cpp
@@ -570,7 +570,7 @@ user_cancel:
 		if( bCancelEnd && bOutputExtInfo ){
 			//	2006.12.03 maru アウトプットウィンドウにのみ出力
 			//最後にテキストを追加
-			oa.OutputW( CLoadString().LoadStringW(STR_EDITVIEW_EXECCMD_STOP) );
+			oa.OutputW( CLoadString().LoadString(STR_EDITVIEW_EXECCMD_STOP) );
 		}
 		
 		{

--- a/sakura_core/view/CEditView_ExecCmd.cpp
+++ b/sakura_core/view/CEditView_ExecCmd.cpp
@@ -570,7 +570,9 @@ user_cancel:
 		if( bCancelEnd && bOutputExtInfo ){
 			//	2006.12.03 maru アウトプットウィンドウにのみ出力
 			//最後にテキストを追加
-			oa.OutputW( CLoadString().LoadString(STR_EDITVIEW_EXECCMD_STOP) );
+			// L"\r\n中断しました。\r\n"
+			std::wstring msg( LS(STR_EDITVIEW_EXECCMD_STOP) );
+			oa.OutputW( msg.c_str(), (int)msg.length() );
 		}
 		
 		{


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

#1720 で報告された、外部コマンド実行でキャンセルした時のメッセージが異なる問題を修正するのが目的です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順

1.  外部コマンド実行で名前「notepad」「標準出力を得る」「アウトプットウィンドウ」でコマンドを実行します。
2.  アウトプット画面が表示されたら閉じます。
3.  notepadの終了待ちのダイアログをキャンセルします。
4.  2個目の新しくできたアウトプットウィンドウのメッセージが正しいか確認します。

## <!-- なければ省略可 --> 関連 issue, PR

#1720

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


