### PR TITLE
ツールバーの検索ボックスにフォーカスを当てていないにも関わらず文字列が選択状態として表示される現象が起きないように対策

### DIFF
--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -293,6 +293,9 @@ void CMainToolBar::CreateToolBar( void )
 						//位置とサイズを取得する
 						rc.right = rc.left = rc.top = rc.bottom = 0;
 						Toolbar_GetItemRect( m_hwndToolBar, count-1, &rc );
+						// Social Distance
+						rc.left += cxBorder;
+						rc.right -= cxBorder;
 
 						//コンボボックスを作る
 						m_hwndSearchBox = CreateWindow( WC_COMBOBOX, L"Combo",
@@ -334,15 +337,15 @@ void CMainToolBar::CreateToolBar( void )
 
 							CDialog::SetComboBoxDeleter(m_hwndSearchBox, &m_cRecentSearch);
 
-							// コンボボックスの位置と幅を調整する
+							// コンボボックスの垂直位置を調整する
 							CMyRect rcCombo;
 							::GetWindowRect( m_hwndSearchBox, &rcCombo );
 							::SetWindowPos( m_hwndSearchBox, NULL,
-								rc.left + cxBorder,
+								rc.left,	//作ったときと同じ値を指定
 								rc.top + (rc.bottom - rc.top - rcCombo.Height()) / 2,
-								rcCombo.Width() - cxBorder * 2,
-								rcCombo.Height(),
-								SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSENDCHANGING );
+								0,			//rcCombo.Width()のまま変えない
+								0,			//rcCombo.Height()のまま変えない
+								SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSENDCHANGING );
 						}
 						break;
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

件名の通りです。#1717 で報告された問題です。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

61c5cf849f2cde638cbe4bd33f452fc798af5f94 で、ツールバー上のコンボボックスを作成後に垂直位置を調整する処理が変更されて、位置と横幅を調整する処理に変更されました。この変更が加えられた後に問題の現象が発生するようになりました。

メカニズムは分かりませんがウィンドウ作成後に横幅を変えると問題が起きる事が分かった（そうしないと問題が起きない）ので、代わりにウィンドウ作成のAPIの引数の値を調整して横幅を目的の値にしました。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

ツールバー上のコンボボックス作成直後の位置や幅の調整処理

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順
- サクラエディタ起動
- ツールバー上の検索ボックスのテキストが選択状態になっていない事を確認

### テスト2

- ツールバー上の検索ボックスの検索機能が正常に動作する事を確認
- 検索ダイアログを表示して検索を行った際に、ツールバー上の検索ボックスに検索キーワードが入る事を確認

### テスト3

- ツールバー折り返しの後に検索ボックスを配置しても、検索ボックスが1行目に表示される不具合が再発しない事を確認
（#1343 で報告された不具合）

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1717
#1343, #1345

