### PR TITLE
プログレスバーの表示切り替え方法を変更して切り替えが正しく反映されるようにする

### DIFF
--- a/sakura_core/uiparts/CVisualProgress.cpp
+++ b/sakura_core/uiparts/CVisualProgress.cpp
@@ -95,7 +95,7 @@ void CVisualProgress::_Begin()
 	//プログレスバー
 	HWND hwndProgress = CEditWnd::getInstance()->m_cStatusBar.GetProgressHwnd();
 	if( hwndProgress ){
-		::ShowWindow( hwndProgress, SW_SHOW );
+		CEditWnd::getInstance()->m_cStatusBar.ShowProgressBar();
 		//範囲設定・リセット
 		Progress_SetRange( hwndProgress, 0, 101 );
 		Progress_SetPos( hwndProgress, 0);
@@ -121,7 +121,7 @@ void CVisualProgress::_End()
 	HWND hwndProgress = CEditWnd::getInstance()->m_cStatusBar.GetProgressHwnd();
 	if( hwndProgress ){
 		Progress_SetPos( hwndProgress, 0);
-		::ShowWindow( hwndProgress, SW_HIDE );
+		CEditWnd::getInstance()->m_cStatusBar.HideProgressBar();
 	}
 
 	//砂時計

--- a/sakura_core/uiparts/CVisualProgress.cpp
+++ b/sakura_core/uiparts/CVisualProgress.cpp
@@ -95,7 +95,7 @@ void CVisualProgress::_Begin()
 	//プログレスバー
 	HWND hwndProgress = CEditWnd::getInstance()->m_cStatusBar.GetProgressHwnd();
 	if( hwndProgress ){
-		CEditWnd::getInstance()->m_cStatusBar.ShowProgressBar();
+		CEditWnd::getInstance()->m_cStatusBar.ShowProgressBar(true);
 		//範囲設定・リセット
 		Progress_SetRange( hwndProgress, 0, 101 );
 		Progress_SetPos( hwndProgress, 0);
@@ -121,7 +121,7 @@ void CVisualProgress::_End()
 	HWND hwndProgress = CEditWnd::getInstance()->m_cStatusBar.GetProgressHwnd();
 	if( hwndProgress ){
 		Progress_SetPos( hwndProgress, 0);
-		CEditWnd::getInstance()->m_cStatusBar.HideProgressBar();
+		CEditWnd::getInstance()->m_cStatusBar.ShowProgressBar(false);
 	}
 
 	//砂時計

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -194,3 +194,31 @@ bool CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 	}
 	return bDraw;
 }
+
+/*!
+	@breif プログレスバーを表示する
+*/
+void CMainStatusBar::ShowProgressBar() const {
+	if (m_hwndStatusBar && m_hwndProgressBar) {
+		RECT rcProgressArea = {};
+		// プログレスバーを表示するステータスバー上の領域を取得
+		ApiWrap::StatusBar_GetRect(m_hwndStatusBar, 0, &rcProgressArea);
+		::ShowWindow(m_hwndProgressBar, SW_SHOW);
+		::InvalidateRect(m_hwndStatusBar, &rcProgressArea, TRUE);
+		::UpdateWindow(m_hwndStatusBar);
+	}
+}
+
+/*!
+	@breif プログレスバーを非表示にする
+*/
+void CMainStatusBar::HideProgressBar() const {
+	if (m_hwndStatusBar && m_hwndProgressBar) {
+		RECT rcProgressArea = {};
+		// プログレスバーが表示されているステータスバー上の領域を取得
+		ApiWrap::StatusBar_GetRect(m_hwndStatusBar, 0, &rcProgressArea);
+		::ShowWindow(m_hwndProgressBar, SW_HIDE);
+		::InvalidateRect(m_hwndStatusBar, &rcProgressArea, TRUE);
+		::UpdateWindow(m_hwndStatusBar);
+	}
+}

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -195,23 +195,18 @@ bool CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 	return bDraw;
 }
 
-void CMainStatusBar::ShowProgressBar() const {
+//! プログレスバーの表示/非表示を切り替える
+void CMainStatusBar::ShowProgressBar(bool bShow) const {
 	if (m_hwndStatusBar && m_hwndProgressBar) {
-		RECT rcProgressArea = {};
 		// プログレスバーを表示するステータスバー上の領域を取得
-		ApiWrap::StatusBar_GetRect(m_hwndStatusBar, 0, &rcProgressArea);
-		::ShowWindow(m_hwndProgressBar, SW_SHOW);
-		::InvalidateRect(m_hwndStatusBar, &rcProgressArea, TRUE);
-		::UpdateWindow(m_hwndStatusBar);
-	}
-}
-
-void CMainStatusBar::HideProgressBar() const {
-	if (m_hwndStatusBar && m_hwndProgressBar) {
 		RECT rcProgressArea = {};
-		// プログレスバーが表示されているステータスバー上の領域を取得
 		ApiWrap::StatusBar_GetRect(m_hwndStatusBar, 0, &rcProgressArea);
-		::ShowWindow(m_hwndProgressBar, SW_HIDE);
+		if (bShow) {
+			::ShowWindow(m_hwndProgressBar, SW_SHOW);
+		} else {
+			::ShowWindow(m_hwndProgressBar, SW_HIDE);
+		}
+		// プログレスバー表示領域を再描画
 		::InvalidateRect(m_hwndStatusBar, &rcProgressArea, TRUE);
 		::UpdateWindow(m_hwndStatusBar);
 	}

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -195,9 +195,6 @@ bool CMainStatusBar::SetStatusText(int nIndex, int nOption, const WCHAR* pszText
 	return bDraw;
 }
 
-/*!
-	@breif プログレスバーを表示する
-*/
 void CMainStatusBar::ShowProgressBar() const {
 	if (m_hwndStatusBar && m_hwndProgressBar) {
 		RECT rcProgressArea = {};
@@ -209,9 +206,6 @@ void CMainStatusBar::ShowProgressBar() const {
 	}
 }
 
-/*!
-	@breif プログレスバーを非表示にする
-*/
 void CMainStatusBar::HideProgressBar() const {
 	if (m_hwndStatusBar && m_hwndProgressBar) {
 		RECT rcProgressArea = {};

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -56,8 +56,7 @@ public:
 
 	//設定
 	bool SetStatusText(int nIndex, int nOption, const WCHAR* pszText, size_t textLen = SIZE_MAX);
-	void ShowProgressBar() const;
-	void HideProgressBar() const;
+	void ShowProgressBar(bool bShow) const;
 private:
 	CEditWnd*	m_pOwner;
 	HWND		m_hwndStatusBar;

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -56,8 +56,8 @@ public:
 
 	//設定
 	bool SetStatusText(int nIndex, int nOption, const WCHAR* pszText, size_t textLen = SIZE_MAX);
-	void ShowProgressBar() const;	// プログレスバーを表示する
-	void HideProgressBar() const;	// プログレスバーを非表示にする
+	void ShowProgressBar() const;
+	void HideProgressBar() const;
 private:
 	CEditWnd*	m_pOwner;
 	HWND		m_hwndStatusBar;

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -56,6 +56,8 @@ public:
 
 	//設定
 	bool SetStatusText(int nIndex, int nOption, const WCHAR* pszText, size_t textLen = SIZE_MAX);
+	void ShowProgressBar() const;	// プログレスバーを表示する
+	void HideProgressBar() const;	// プログレスバーを非表示にする
 private:
 	CEditWnd*	m_pOwner;
 	HWND		m_hwndStatusBar;


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->

プログレスバーの表示/非表示を切り替える方法を変更し、切り替えが画面上に正しく反映されるようにする。

## <!-- 必須 --> カテゴリ

- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

#1601 にてステータスバーの描画処理が改善されましたが、「ファイル読み込み後にプログレスバーが表示されたままになる」問題が発生しています（ #1651 ）。

## <!-- 自明なら省略可 --> PR のメリット

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

今回問題となっているプログレスバーはステータスバーの左端に表示されるもので、内部上はステータスバーの子ウィンドウになっています。どちらも`CMainStatusBar`クラスにウィンドウハンドルが保持されています。

ファイルの読み込み処理では、`CDocFileOperation`クラスから`CDocSubject`を通じて、各クラスの前処理（OnBeforeLoad）・中処理（OnLoad）・後処理（OnAfterLoad）が呼び出されます。`CVisualProgress`クラスもそうして呼び出されるクラスの一つで、前処理と後処理の段階ではプログレスバーの表示/非表示の切り替えを行っています。
また、`CEditView`クラスも後処理でプログレスバーの表示が切り替えられた後に呼び出されており、ここで範囲選択の解除、カーソルの移動、ステータスバーの更新などを実行しています。

プログレスバーはステータスバー上に表示される以上、表示の切り替えを行うとステータスバー上の領域を再描画する必要が生じるはずですが、表示の切り替えを行う各関数には再描画を実施する命令が記述されていません。

このため、以前はステータスバーや編集ウィンドウが描画されるタイミングで再描画されていた領域が、 #1601 で描画範囲とタイミングが調整されたために範囲外となって再描画されなくなったものと推定しました。

そこで、`CMainStatusBar`クラスにプログレスバーの表示を切り替え、ステータスバー上の表示領域を更新するメソッドを新設し、これを`CVisualProgress`から利用するように変更します。

なお、既存コードにおける変更対象である`CVisualProgress`はファイル保存の過程でも利用されるため、この変更はファイル保存時のプログレスバーの取り扱いにも影響します。一方、`CVisualProgress`以外でプログレスバーの表示切り替えを行う各所のコードは変更していません。

## <!-- わかる範囲で --> PR の影響範囲

- ファイル読み込み処理におけるプログレスバーの表示
- ファイル保存処理におけるプログレスバーの表示

## <!-- 必須 --> テスト内容

- ファイルのロード中、プログレスバーが表示されること。
- ファイルのロード完了後、プログレスバーが表示されないこと。
- ファイルの保存中、プログレスバーが表示されること。
- ファイルの保存完了後、プログレスバーが表示されないこと。

## <!-- なければ省略可 --> 関連 issue, PR

#1601
fix: #1651

## <!-- なければ省略可 --> 参考資料
