### PR TITLE
Grepのビルド警告に対処する

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -303,11 +303,7 @@ int GetHwndTitle(HWND& hWndTarget, CNativeW* pmemTitle, WCHAR* pszWindowName, WC
 	if( 0 != wcsncmp(L":HWND:", pszFile, 6) ){
 		return 0; // ハンドルGrepではない
 	}
-#ifdef _WIN64
-	_stscanf(pszFile + 6, L"%016I64x", (size_t*)&hWndTarget);
-#else
-	_stscanf(pszFile + 6, L"%08x", (size_t*)&hWndTarget);
-#endif
+	_stscanf(pszFile + 6, L"%x", (size_t*)&hWndTarget);
 	if( pmemTitle ){
 		const wchar_t* p = L"Window:[";
 		pmemTitle->SetStringHoldBuffer(p, 8);

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -304,9 +304,9 @@ int GetHwndTitle(HWND& hWndTarget, CNativeW* pmemTitle, WCHAR* pszWindowName, WC
 		return 0; // ハンドルGrepではない
 	}
 #ifdef _WIN64
-	_stscanf(pszFile + 6, L"%016I64x", &hWndTarget);
+	_stscanf(pszFile + 6, L"%016I64x", (size_t*)&hWndTarget);
 #else
-	_stscanf(pszFile + 6, L"%08x", &hWndTarget);
+	_stscanf(pszFile + 6, L"%08x", (size_t*)&hWndTarget);
 #endif
 	if( pmemTitle ){
 		const wchar_t* p = L"Window:[";

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -300,16 +300,19 @@ void CGrepAgent::AddTail( CEditView* pcEditView, const CNativeW& cmem, bool bAdd
 
 int GetHwndTitle(HWND& hWndTarget, CNativeW* pmemTitle, WCHAR* pszWindowName, WCHAR* pszWindowPath, const WCHAR* pszFile)
 {
-	if( 0 != wcsncmp(L":HWND:", pszFile, 6) ){
+	hWndTarget = nullptr;	//out引数をクリアする
+
+	constexpr auto& szTargetPrefix = L":HWND:";
+	constexpr auto cchTargetPrefix = _countof(szTargetPrefix) - 1;
+	if( 0 != wcsncmp(pszFile, szTargetPrefix, cchTargetPrefix) ){
 		return 0; // ハンドルGrepではない
 	}
-	_stscanf(pszFile + 6, L"%x", (size_t*)&hWndTarget);
+	if( 0 >= ::swscanf_s(pszFile + cchTargetPrefix, L"%x", (size_t*)&hWndTarget) || !IsSakuraMainWindow(hWndTarget) ){
+		return -1; // ハンドルを読み取れなかった、または、対象ウインドウハンドルが存在しない
+	}
 	if( pmemTitle ){
 		const wchar_t* p = L"Window:[";
 		pmemTitle->SetStringHoldBuffer(p, 8);
-	}
-	if( !IsSakuraMainWindow(hWndTarget) ){
-		return -1;
 	}
 	::SendMessageAny(hWndTarget, MYWM_GETFILEINFO, 0, 0);
 	EditInfo* editInfo = &(GetDllShareData().m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO);

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -79,11 +79,7 @@ bool CEditView::TagJumpSub(
 	WCHAR	szJumpToFile[1024];
 	HWND hwndTarget = NULL;
 	if( 0 == wcsncmp(pszFileName, L":HWND:[", 7) ){
-#ifdef _WIN64
-		_stscanf(pszFileName + 7, L"%016I64x", (size_t*)&hwndTarget);
-#else
-		_stscanf(pszFileName + 7, L"%08x", (size_t*)&hwndTarget);
-#endif
+		_stscanf(pszFileName + 7, L"%x", (size_t*)&hwndTarget);
 		if( !IsSakuraMainWindow(hwndTarget) ){
 			return false;
 		}

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -80,9 +80,9 @@ bool CEditView::TagJumpSub(
 	HWND hwndTarget = NULL;
 	if( 0 == wcsncmp(pszFileName, L":HWND:[", 7) ){
 #ifdef _WIN64
-		_stscanf(pszFileName + 7, L"%016I64x", &hwndTarget);
+		_stscanf(pszFileName + 7, L"%016I64x", (size_t*)&hwndTarget);
 #else
-		_stscanf(pszFileName + 7, L"%08x", &hwndTarget);
+		_stscanf(pszFileName + 7, L"%08x", (size_t*)&hwndTarget);
 #endif
 		if( !IsSakuraMainWindow(hwndTarget) ){
 			return false;

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -77,10 +77,11 @@ bool CEditView::TagJumpSub(
 	//	予め絶対パスに変換する．(キーワードヘルプジャンプで用いる)
 	// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
 	WCHAR	szJumpToFile[1024];
-	HWND hwndTarget = NULL;
-	if( 0 == wcsncmp(pszFileName, L":HWND:[", 7) ){
-		_stscanf(pszFileName + 7, L"%x", (size_t*)&hwndTarget);
-		if( !IsSakuraMainWindow(hwndTarget) ){
+	HWND hwndTarget = nullptr;
+	constexpr auto& szTargetPrefix = L":HWND:[";
+	constexpr auto cchTargetPrefix = _countof(szTargetPrefix) - 1;
+	if( 0 == wcsncmp(pszFileName, szTargetPrefix, cchTargetPrefix) ){
+		if( 0 >= ::swscanf_s(pszFileName + cchTargetPrefix, L"%x", (size_t*)&hwndTarget) || !IsSakuraMainWindow(hwndTarget) ){
 			return false;
 		}
 	}else{


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
ビルド警告が出ないように修正します。

## <!-- 必須 --> カテゴリ

- リファクタリング
- ビルド関連
  - Azure Pipelines
  - AppVeyor
  - GitHub Actions
  - ローカルビルド

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1696 をマージして以降、`Win32 - Debug`で変な警告が出ています。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
* 全ビルド構成で、ビルド警告が2件減ります。
* `Win32 - Debug`のビルド警告が0件になります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
* 特にないと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
Grep結果行に埋め込んだウインドウハンドルを読み取る処理でビルド警告が出ています。
https://github.com/sakura-editor/sakura/blob/f706330eec857aaf191787aa05875cb0892ee871/sakura_core/CGrepAgent.cpp#L306-L310

数値を読み取るCRT関数 _stscanf を使って、ウインドウハンドル(`HWND`)を読み取ろうとしているのが原因です。
単純には、`HWND*`の変数を`size_t*`にキャストしてやれば問題の対策になります。
CRT関数はC言語の世界のものなので、C++プログラムとの境界でキャストするのは「アリ」だと思います。

修正箇所は、コンパイラが64bitか32bitかで分岐していますが、
`size_t`の数値を`size_t`のとり得る文字数まで読んで良いなら桁数指定は不要です。
64bitでsize_tを16進数にすると最大16文字です。指定が"%016I64x"であれば"%x"と書いても同じです。
32bitでsize_tを16進数にすると最大8文字です。指定が"%08x"であれば"%x"と書いても同じです。
意味がないなら、まとめても良いだろう、ということで記述をまとめる修正を行います。

最後に、ウインドウハンドルを読み取れたかどうかの判定がやや甘い感じだったので、
周辺コードをリファクタリングしてエラー耐性を上げる試みを行います。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
#1696 で入れた「編集中のテキストファイル」内をGrepする機能に関する修正です。

* Grepダイアログから「編集中のテキストファイル」を指定した場合に、CGrepAgentで読み取る処理を修正します。
* 「編集中のテキストファイル」をGrepした結果からタグジャンプしようとした場合に、タグジャンプ先の編集ウインドウを読み取る処理を修正します。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
* ビルド警告の解消確認を行います。
* 影響箇所の機能確認を行います。（変更前コードが32bit/64bitで分かれているのでそれぞれ必要）

### テスト1
Win32 - Debugのビルド警告がなくなることを確認します。

手順
1. このPRをfetchします。
1. Win32 - Debugでビルドします。

### テスト2
保存されてないファイルのGrepを行ったあと、Grep結果からタグジャンプできることを確認します。(32bit版)

手順
1. このPRをfetchします。
1. Win32 - Debugでビルドします。
1. デバッグ起動してREADME.mdを開き、全選択してコピーします。
1. `Ctrl+N`で新規作成して、貼り付けます。
1. `Ctrl+G`でGrepダイアログを開き、検索文字列に`http`を指定して対象を「編集中のテキストファイル」にし、Grepします。
1. Grep結果行をダブルクリックします。

### テスト3
保存されてないファイルのGrepを行ったあと、Grep結果からタグジャンプできることを確認します。(64bit版)

手順
1. このPRをfetchします。
1. x64 - Debugでビルドします。
1. デバッグ起動してREADME.mdを開き、全選択してコピーします。
1. `Ctrl+N`で新規作成して、貼り付けます。
1. `Ctrl+G`でGrepダイアログを開き、検索文字列に`http`を指定して対象を「編集中のテキストファイル」にし、Grepします。
1. Grep結果行をダブルクリックします。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1696

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://docs.microsoft.com/ja-jp/cpp/c-runtime-library/reference/sscanf-s-sscanf-s-l-swscanf-s-swscanf-s-l?view=msvc-160

