### PR TITLE
CNativeW::AllocStringBufferの失敗時にコピーを中断させる

### DIFF
--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1833,12 +1833,14 @@ bool CEditView::GetSelectedData(
 	if( !GetSelectionInfo().IsTextSelected() ){
 		return false;
 	}
+	std::wstring strLineNum;
 	if( bWithLineNumber ){	/* 行番号を付与する */
 		/* 行番号表示に必要な桁数を計算 */
 		// 2014.11.30 桁はレイアウト単位である必要がある
 		nLineNumCols = GetTextArea().DetectWidthOfLineNumberArea_calculate(&m_pcEditDoc->m_cLayoutMgr, true);
 		nLineNumCols += 1;
-		pszLineNum = new wchar_t[nLineNumCols + 1];
+		strLineNum.assign(nLineNumCols, L'\0');
+		pszLineNum = strLineNum.data();
 	}
 
 	CLayoutRect			rcSel;
@@ -2030,9 +2032,6 @@ bool CEditView::GetSelectedData(
 				break;
 			}
 		}
-	}
-	if( bWithLineNumber ){	/* 行番号を付与する */
-		delete [] pszLineNum;
 	}
 	return true;
 }

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1883,6 +1883,11 @@ bool CEditView::GetSelectedData(
 		cmemBuf->AllocStringBuffer(nBufSize);
 		//>> 2002/04/18 Azumaiya
 
+		// メモリ確保に失敗したら抜ける
+		if( 0 == cmemBuf->GetStringLength() ){
+			return false;
+		}
+
 		bool bExtEol = GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol;
 		nRowNum = 0;
 		for( nLineNum = rcSel.top; nLineNum <= rcSel.bottom; ++nLineNum ){
@@ -1960,6 +1965,11 @@ bool CEditView::GetSelectedData(
 		// 調べた長さ分だけバッファを取っておく。
 		cmemBuf->AllocStringBuffer(nBufSize);
 		//>> 2002/04/18 Azumaiya
+
+		// メモリ確保に失敗したら抜ける
+		if( 0 == cmemBuf->GetStringLength() ){
+			return false;
+		}
 
 		for( nLineNum = GetSelectionInfo().m_sSelect.GetFrom().GetY2(); nLineNum <= GetSelectionInfo().m_sSelect.GetTo().y; ++nLineNum ){
 			pLine = m_pcEditDoc->m_cLayoutMgr.GetLineStr( nLineNum, &nLineLen, &pcLayout );

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1886,7 +1886,7 @@ bool CEditView::GetSelectedData(
 		//>> 2002/04/18 Azumaiya
 
 		// メモリ確保に失敗したら抜ける
-		if( 0 == cmemBuf->GetStringLength() ){
+		if( 0 == cmemBuf->capacity() ){
 			return false;
 		}
 
@@ -1969,7 +1969,7 @@ bool CEditView::GetSelectedData(
 		//>> 2002/04/18 Azumaiya
 
 		// メモリ確保に失敗したら抜ける
-		if( 0 == cmemBuf->GetStringLength() ){
+		if( 0 == cmemBuf->capacity() ){
 			return false;
 		}
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
不具合を修正します。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1575 で報告された不具合の対策 #1710 の焼き直しです。

#### 発生事象
大きなデータをコピーしようとすると固まる。
（データが2GBを超えているかどうかは関係ありません。）

#### 原因
選択範囲のデータを取得するコードで
メモリ確保の失敗が考慮されていません。

CNativeWはメモリ確保に失敗するとバッファが解放されるので、メモリの事前確保が成立せずに超低速になります。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
* 修正量が増えるので横展開を行いません。
  横展開要否を検討すべき箇所が、他に30箇所あります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
仕様変更/機能追加はありません。

#### 対策
メモリ確保が失敗した場合に、データ取得を異常終了させる修正を行います。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
* コピー、カット、ドラッグアンドドロップなど、クリップボードに関連する機能。
* サクラエディタ上の変換機能

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1
#1575 の再現手順で、アプリが固まる不具合が解消することを確認します。

手順
1. このPRをfetchし、x64ビルドします。
2. ビルドした sakura.exe を実行し、#1575 に添付された大きなテキストファイルを開きます。
  ファイルを開くまでにかなり時間がかかります。
3. Ctrl+A、Ctrl+Cの順にキー押下します。（すべて選択、コピー）

アプリが無応答になる事象が解消されているのを確認できます。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1710
#1575

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
