### PR TITLE
CNativeW クラスの SetString メソッドに std::wstring_view 型を受け取るものを追加

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -618,7 +618,7 @@ DWORD CGrepAgent::DoGrep(
 				// 解析済みのファイルパターン配列を取得する
 				const auto& vecSearchFileKeys = cGrepEnumKeys.m_vecSearchFileKeys;
 				std::wstring strPatterns = FormatPathList( vecSearchFileKeys );
-				cmemWork.SetString( strPatterns.c_str(), strPatterns.length() );
+				cmemWork.SetString( strPatterns );
 			}
 		}
 	}

--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -199,7 +199,7 @@ int CHokanMgr::Search(
 	if( 1 == m_vKouho.size() ){
 		if(pcmemHokanWord != NULL){
 			m_nCurKouhoIdx = -1;
-			pcmemHokanWord->SetString( m_vKouho[0].c_str() );
+			pcmemHokanWord->SetString( m_vKouho[0] );
 			return 1;
 		}
 	}

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -62,7 +62,7 @@ void CViewCommander::Command_GREP( void )
 	CNativeW		cmWork2;
 	CNativeW		cmWork3;
 	CNativeW		cmWork4;
-	cmWork1.SetString( GetEditWindow()->m_cDlgGrep.m_strText.c_str() );
+	cmWork1.SetString( GetEditWindow()->m_cDlgGrep.m_strText );
 	cmWork2 = GetEditWindow()->m_cDlgGrep.GetPackedGFileString();
 	cmWork3.SetString( GetEditWindow()->m_cDlgGrep.m_szFolder );
 
@@ -167,10 +167,10 @@ void CViewCommander::Command_GREP_REPLACE( void )
 	CNativeW		cmWork4;
 
 	CDlgGrepReplace& cDlgGrepRep = GetEditWindow()->m_cDlgGrepReplace;
-	cmWork1.SetString( cDlgGrepRep.m_strText.c_str() );
+	cmWork1.SetString( cDlgGrepRep.m_strText );
 	cmWork2 = cDlgGrepRep.GetPackedGFileString();
 	cmWork3.SetString( cDlgGrepRep.m_szFolder );
-	cmWork4.SetString( cDlgGrepRep.m_strText2.c_str() );
+	cmWork4.SetString( cDlgGrepRep.m_strText2 );
 
 	/*	今のEditViewにGrep結果を表示する。
 		Grepモードのとき、または未編集で無題かつアウトプットでない場合。

--- a/sakura_core/cmd/CViewCommander_Search.cpp
+++ b/sakura_core/cmd/CViewCommander_Search.cpp
@@ -910,7 +910,7 @@ void CViewCommander::Command_REPLACE_ALL()
 	else
 	{
 		// 2004.05.14 Moca 全置換の途中で他のウィンドウで置換されるとまずいのでコピーする
-		cmemClip.SetString( GetEditWindow()->m_cDlgReplace.m_strText2.c_str() );
+		cmemClip.SetString( GetEditWindow()->m_cDlgReplace.m_strText2 );
 	}
 
 	CLogicInt nREPLACEKEY = cmemClip.GetStringLength();

--- a/sakura_core/convert/CConvert_TabToSpace.cpp
+++ b/sakura_core/convert/CConvert_TabToSpace.cpp
@@ -65,6 +65,6 @@ bool CConvert_TabToSpace::DoConvert(CNativeW* pcData)
 	}
 	if (buffer.empty())
 		return false;
-	pcData->SetString(buffer.c_str(), buffer.length());
+	pcData->SetString(buffer);
 	return true;
 }

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -78,7 +78,7 @@ public:
 	//WCHAR
 	void SetString( const wchar_t* pData, size_t nDataLen );			//!< バッファの内容を置き換える。nDataLenは文字単位。
 	void SetString( const wchar_t* pszData );							//!< バッファの内容を置き換える。
-	void SetString( const std::wstring& str ) { SetString(str.c_str(), str.length()); }
+	void SetString( std::wstring_view str ) { SetString(str.data(), str.length()); }
 	void SetStringHoldBuffer( const wchar_t* pData, size_t nDataLen );
 	void AppendString( const wchar_t* pszData, size_t nDataLen );		//!< バッファの最後にデータを追加する。nLengthは文字単位。成功すればtrue。メモリ確保に失敗したらfalseを返す。
 	void AppendString( std::wstring_view data );						//!< バッファの最後にデータを追加する

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -78,6 +78,7 @@ public:
 	//WCHAR
 	void SetString( const wchar_t* pData, size_t nDataLen );			//!< バッファの内容を置き換える。nDataLenは文字単位。
 	void SetString( const wchar_t* pszData );							//!< バッファの内容を置き換える。
+	void SetString( const std::wstring& str ) { SetString(str.c_str(), str.length()); }
 	void SetStringHoldBuffer( const wchar_t* pData, size_t nDataLen );
 	void AppendString( const wchar_t* pszData, size_t nDataLen );		//!< バッファの最後にデータを追加する。nLengthは文字単位。成功すればtrue。メモリ確保に失敗したらfalseを返す。
 	void AppendString( std::wstring_view data );						//!< バッファの最後にデータを追加する


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

`SetString` メソッドを呼ぶ際に、`std::wstring` 型のインスタンスの `c_str()` メソッドでポインタを引数にして呼びだすと、`CNativeW::SetString( const wchar_t* pszData )` の実装で `std::wstring_view` のコンストラクタで文字列の要素数を調べる処理が走ります。文字列の要素数の情報は `std::wstring` 型の size や length メソッドで定数時間で取得できるので、それを使う方が効率が良いと思い変更しました。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
`.c_str()` の記述が無くせるので記述が短くなります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
特にないと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

https://cpprefjp.github.io/reference/string/basic_string/length.html
https://cpprefjp.github.io/reference/string_view/basic_string_view.html
