### PR TITLE
CWndクラスをシェイプアップする

### DIFF
--- a/sakura_core/func/CFuncKeyWnd.h
+++ b/sakura_core/func/CFuncKeyWnd.h
@@ -64,7 +64,6 @@ protected:
 	int CalcButtonSize( void );	/* ボタンのサイズを計算 */
 
 	/* 仮想関数 */
-	void AfterCreateWindow( void ) override{}	// ウィンドウ作成後の処理	// 2007.03.13 ryoji 可視化しない
 
 	/* 仮想関数 メッセージ処理 詳しくは実装を参照 */
 	LRESULT OnTimer(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;	// WM_TIMERタイマーの処理

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -99,7 +99,6 @@ protected:
 	void GetTabName( EditNode* pEditNode, BOOL bFull, BOOL bDupamp, LPWSTR pszName, int nLen );	/* タブ名取得処理 */	// 2007.06.28 ryoji 新規作成
 
 	/* 仮想関数 */
-	void AfterCreateWindow( void ) override{}	/*!< ウィンドウ作成後の処理 */	// 2007.03.13 ryoji 可視化しない
 
 	/* 仮想関数 メッセージ処理 */
 	LRESULT OnSize( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;		/*!< WM_SIZE処理 */

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -95,17 +95,6 @@ void CTipWnd::Create( HINSTANCE hInstance, HWND hwndParent )
 	return;
 }
 
-/*!	CreateWindowの後
-
-	CWnd::AfterCreateWindowでウィンドウを表示するようになっているのを
-	動かなくするための空関数
-
-	@date 2006.01.09 genta 新規作成
-*/
-void CTipWnd::AfterCreateWindow( void )
-{
-}
-
 /* Tipを表示 */
 void CTipWnd::Show( int nX, int nY, RECT* pRect )
 {

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -71,8 +71,6 @@ protected:
 	void DrawTipText( HDC hdc, const RECT& rcPaint );	/* ウィンドウのテキストを表示 */
 
 	/* 仮想関数 */
-	//	Jan. 9, 2006 genta
-	void AfterCreateWindow( void ) override;
 
 	/* 仮想関数 メッセージ処理 詳しくは実装を参照 */
 	LRESULT OnPaint(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) override;/* 描画処理 */

--- a/sakura_core/window/CWnd.cpp
+++ b/sakura_core/window/CWnd.cpp
@@ -180,8 +180,6 @@ HWND CWnd::Create(
 		return NULL;
 	}
 
-	/* ウィンドウ作成後の処理 */
-	AfterCreateWindow();
 	return m_hWnd;
 }
 

--- a/sakura_core/window/CWnd.h
+++ b/sakura_core/window/CWnd.h
@@ -83,7 +83,6 @@ public:
 protected:
 	/* 仮想関数 */
 	virtual LRESULT DispatchEvent_WM_APP( HWND hwnd, UINT msg, WPARAM wp, LPARAM lp );/* アプリケーション定義のメッセージ(WM_APP <= msg <= 0xBFFF) */
-	virtual void AfterCreateWindow( void ){::ShowWindow( m_hWnd, SW_SHOW );}/* ウィンドウ作成後の処理 ( virtual )*/
 
 	/* 仮想関数 メッセージ処理(デフォルト動作) */
 	#define DECLH(method) LRESULT method( HWND hwnd, UINT msg, WPARAM wp, LPARAM lp ){return CallDefWndProc( hwnd, msg, wp, lp );}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
ウインドウの共通基底クラスCWndをシェイプアップして使い勝手をよくします。

## <!-- 必須 --> カテゴリ

- リファクタリング

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
サクラエディタには、ウインドウ実装を簡易化するための共通クラスCWndが定義されています。
しかし、CWndクラスはあまり活用されていません。

CWndを活用してないウインドウ
* CEditWnd　サクラエディタ本体に見えるエディタプロセスのメインウインドウです。
* CEditView　サクラエディタの中核「エディタ機能」を実装するウインドウです。
* CTrayWnd　コントロールプロセス（？）のメインウインドウです。

CWndが活用されてない理由が「活用したくてもできない」にあると考えて、活用しづらい原因になっている基底クラスの定義を削る提案をしてみる次第です。


## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
サクラエディタの仕様・機能に影響を与えない変更です。

* CWndの未使用イベント PreviCreateWindow を削除します。
* CWndのイベント AfterCreateWindow を削除します。
* CWndの未使用のメッセージハンドラを削除します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
CWnd派生クラスの挙動に影響します。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
AfterCreateWindowを削除しても WM_SHOWWINDOW が送出されることを確認しました。

### テスト1

手順


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
