### PR TITLE
補完候補一覧ダイアログの不具合修正

### DIFF
--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -483,7 +483,7 @@ BOOL CHokanMgr::OnSize( WPARAM wParam, LPARAM lParam )
 
 	::GetWindowRect(GetHwnd(), &rcDlg);
 	m_xPos = rcDlg.left;
-	m_xPos = rcDlg.top;
+	m_yPos = rcDlg.top;
 	m_nWidth = rcDlg.right - rcDlg.left;
 	m_nHeight = rcDlg.bottom - rcDlg.top;
 

--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -483,6 +483,12 @@ BOOL CHokanMgr::OnSize( WPARAM wParam, LPARAM lParam )
 	POINT	po;
 	RECT	rcDlg;
 
+	::GetWindowRect(GetHwnd(), &rcDlg);
+	m_xPos = rcDlg.left;
+	m_xPos = rcDlg.top;
+	m_nWidth = rcDlg.right - rcDlg.left;
+	m_nHeight = rcDlg.bottom - rcDlg.top;
+
 	::GetClientRect( GetHwnd(), &rcDlg );
 	nWidth = rcDlg.right - rcDlg.left;  // width of client area
 	nHeight = rcDlg.bottom - rcDlg.top; // height of client area

--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -475,8 +475,6 @@ BOOL CHokanMgr::OnSize( WPARAM wParam, LPARAM lParam )
 		IDC_LIST_WORDS
 	};
 	int		nControls = _countof( Controls );
-	int		nWidth;
-	int		nHeight;
 	int		i;
 	RECT	rc;
 	HWND	hwndCtrl;
@@ -490,8 +488,8 @@ BOOL CHokanMgr::OnSize( WPARAM wParam, LPARAM lParam )
 	m_nHeight = rcDlg.bottom - rcDlg.top;
 
 	::GetClientRect( GetHwnd(), &rcDlg );
-	nWidth = rcDlg.right - rcDlg.left;  // width of client area
-	nHeight = rcDlg.bottom - rcDlg.top; // height of client area
+	int nClientWidth = rcDlg.right - rcDlg.left;  // width of client area
+	int nClientHeight = rcDlg.bottom - rcDlg.top; // height of client area
 
 //	2001/06/18 Start by asa-o: サイズ変更後の位置を保存
 	m_poWin.x = rcDlg.left - 4;
@@ -518,8 +516,8 @@ BOOL CHokanMgr::OnSize( WPARAM wParam, LPARAM lParam )
 				NULL,
 				rc.left,
 				rc.top,
-				nWidth - rc.left * 2,
-				nHeight - rc.top * 2/* - 20*/,
+				nClientWidth - rc.left * 2,
+				nClientHeight - rc.top * 2/* - 20*/,
 				SWP_NOOWNERZORDER | SWP_NOZORDER
 			);
 		}

--- a/sakura_core/apiwrap/StdControl.cpp
+++ b/sakura_core/apiwrap/StdControl.cpp
@@ -108,7 +108,7 @@ namespace ApiWrap{
 		}
 
 		// アイテムテキストを設定するのに必要なバッファを確保する
-		strText.resize( cchRequired );
+		strText.resize(cchRequired + 1);
 
 		// ListBox_GetText() はコピーした文字数を返す。
 		const int actualCopied = ListBox_GetText( hList, nIndex, strText.data() );

--- a/tests/unittests/test-StdControl.cpp
+++ b/tests/unittests/test-StdControl.cpp
@@ -48,3 +48,35 @@ TEST(StdControl, Wnd_GetText2)
 	DestroyWindow(hwnd);
 	ASSERT_STREQ(s.c_str(), text);
 }
+
+TEST(StdControl, List_GetText) {
+	std::wstring text = L"0123456789abcdef";
+	HWND list = ::CreateWindow(L"LISTBOX", nullptr, 0, 1, 1, 1, 1, nullptr, nullptr, nullptr, nullptr);
+	ApiWrap::List_AddString(list, text.c_str());
+	ApiWrap::List_AddString(list, L"");
+
+	std::wstring result1;
+	ASSERT_TRUE(ApiWrap::List_GetText(list, 0, result1));
+	ASSERT_EQ(result1, text);
+
+	result1.clear();
+	ASSERT_TRUE(ApiWrap::List_GetText(list, 1, result1));
+	ASSERT_TRUE(result1.empty());
+
+	ASSERT_FALSE(ApiWrap::List_GetText(list, 2, result1));
+
+	wchar_t result2[15]{};
+	ASSERT_EQ(ApiWrap::List_GetText(list, 0, result2), LB_ERRSPACE);
+
+	wchar_t result3[16]{};
+	ASSERT_EQ(ApiWrap::List_GetText(list, 0, result3), LB_ERRSPACE);
+
+	wchar_t result4[17]{};
+	ASSERT_EQ(ApiWrap::List_GetText(list, 0, result4), text.length());
+	ASSERT_STREQ(result4, text.c_str());
+
+	result4[0] = L'\0';
+	ASSERT_EQ(ApiWrap::List_GetText(list, 2, result4), LB_ERR);
+
+	::DestroyWindow(list);
+}


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

#1749 で指摘された補完候補一覧ダイアログに関する2件の不具合を修正します。
1. 補完候補一覧ダイアログがやけに小さく表示される
2. 補完候補一覧ダイアログで選択した候補が入力されない

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

## <!-- 自明なら省略可 --> PR のメリット

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

### 前者の不具合について

補完候補一覧ダイアログの表示サイズは基底クラスから継承したメンバ変数に格納した値を利用しています。
https://github.com/sakura-editor/sakura/blob/0dd4391776be5530ef4d0a66e8279ace744d3dd6/sakura_core/CHokanMgr.cpp#L241-L244
これらの変数の値は、モニターワークエリアに収まるように調整された上でAPI関数`::MoveWindow()`に渡されます。
このためにメンバ変数にダイアログサイズが記憶されていなければなりません。

以前は`CHokanMgr::DoModeless()`から`CHokanMgr::OnSize()`を通じて呼び出される`CDialog::OnSize()`に当該処理が記述されていましたが、 #1711 で削除されたため、メンバ変数の値が基底クラスのコンストラクタで初期化されたままになっています。

幸い、`CHokanMgr::DispatchEvent()`に記述されたWM_GETMINMAXINFOメッセージに対する処理によって下限値が設定されているため、それより小さい表示になることはありませんでした。

対策として、`CDialog::OnSize()`から失われた当該処理を`CHokanMgr::OnSize()`に追加します。
なお、メンバ変数名と既存のローカル変数名が似ているうえ、それぞれスクリーン座標とクライアント座標で内容が異なることから、念のためローカル変数の名前を変更しました。

### 後者の不具合について

`ApiWrap::List_GetText()`にて、格納先であるバッファのサイズを取得した文字列が収まるように調整する際、ヌル終端を含んだ値が必要な所に含まれない値を渡していたため、文字列が格納できていませんでした。
渡している値はリストボックスのアイテムから文字列を取得するLB_GETTEXTメッセージの戻り値ですが、これは成功時にコピーできた文字列のヌル終端を含まない長さを返します。

対策として、ヌル終端を文字列の長さに加えたうえでサイズ調整を行うようにします。
また、単体テストを追加してList_GetTextの動作確認を実施しています。

## <!-- わかる範囲で --> PR の影響範囲

補完候補一覧ダイアログ (CHokanMgr)

## <!-- 必須 --> テスト内容

手順

1. サクラエディタを起動し、次のように入力して改行しておきます。
```
STR_BACKUP_CONFORM_MSG1
STR_BACKUP_CONFORM_MSG2
```
2. 「STR」と入力し、Ctrl + Spaceを押して候補を表示させます。
   表示された候補一覧のサイズが小さすぎないか確認してください。
3. Enterで候補の選択を確定します。
   選択した候補が入力されることを確認してください。

## <!-- なければ省略可 --> 関連 issue, PR

#1439 ... 問題②のきっかけ
#1711 ... 問題①のきっかけ
#1528 ... 類似案件

fixes #1749

## <!-- なければ省略可 --> 参考資料

