### PR TITLE
トリプルクリック時に次の行の先頭にURLがあるとそれが選択されてしまう現象が起きないように対策

### DIFF
--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -289,6 +289,7 @@ normal_action:;
 				GetSelectionInfo().BeginSelectArea();				// 現在のカーソル位置から選択を開始する
 				GetSelectionInfo().m_bBeginLineSelect = false;		// 行単位選択中 OFF
 			}
+			return;
 		}else
 		/* 選択開始処理 */
 		/* SHIFTキーが押されていたか */


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

#1745 で報告された問題が起きないようにするのが目的です。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

トリプルクリック時に次の行が選択されてしまうのは挙動として不自然です。

それが起きないようにする事で予期しない挙動が発生するのを防ぎます。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

マウス左ボタン押下に対応する `CEditView::OnLBUTTONDOWN` の処理を途中で中断するように `return;` を入れたけれど、その事によって本来行うべき処理が行われなくなる恐れがある。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

マウス左ボタン押下に対応する `CEditView::OnLBUTTONDOWN` の処理で、トリプルクリックを処理する記述の最後に `return;` するように記述を追加しました。こうする事でトリプルクリック処理の後に、後続に記述されている処理が実行されないようにして問題の現象を発生する事を回避しました。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順
- 1行目に文字列、2行目にURLを書く。
- 1行目をトリプルクリックする。
- 1行目が選択される事を確認

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1745

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
