### PR TITLE
表示スケールに合わせて拡大する処理を色々と追加

### DIFF
--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -34,6 +34,7 @@
 #include "debug/CRunningTimer.h"
 #include "charset/charcode.h"
 #include "config/app_constants.h"
+#include "util/window.h"
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                        生成と破棄                           //
@@ -137,7 +138,7 @@ void CLayoutMgr::SetLayoutInfo(
 	if (nTsvModeOld != nTsvMode && nTsvMode != TSV_MODE_NONE) {
 		m_tsvInfo.CalcTabLength(this->m_pcDocLineMgr);
 	}
-	m_nSpacing = refType.m_nColumnSpace;
+	m_nSpacing = DpiScaleX(refType.m_nColumnSpace);
 	if( nCharLayoutXPerKeta == -1 )
 	{
 		// Viewが持ってるフォント情報は古い、しょうがないので自分で作る
@@ -145,8 +146,8 @@ void CLayoutMgr::SetLayoutInfo(
 		HDC hdc = ::GetDC(hwnd);
 		CViewFont viewFont(pLogfont);
 		CTextMetrics temp;
-		temp.Update(hdc, viewFont.GetFontHan(), refType.m_nLineSpace, refType.m_nColumnSpace);
-		m_nCharLayoutXPerKeta = temp.GetHankakuWidth() + m_pTypeConfig->m_nColumnSpace;
+		temp.Update(hdc, viewFont.GetFontHan(), DpiScaleY(refType.m_nLineSpace), DpiScaleX(refType.m_nColumnSpace));
+		m_nCharLayoutXPerKeta = temp.GetHankakuWidth() + DpiScaleX(m_pTypeConfig->m_nColumnSpace);
 		::ReleaseDC(hwnd, hdc);
 	}else{
 		m_nCharLayoutXPerKeta = nCharLayoutXPerKeta;

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -272,7 +272,7 @@ bool CShareData::InitShareData()
 			sWindow.m_bDispMiniMap = false;			// ミニマップを表示する
 			sWindow.m_nFUNCKEYWND_Place = 1;			/* ファンクションキー表示位置／0:上 1:下 */
 			sWindow.m_nFUNCKEYWND_GroupNum = 4;			// 2002/11/04 Moca ファンクションキーのグループボタン数
-			sWindow.m_nMiniMapFontSize = -1;
+			sWindow.m_nMiniMapFontSize = -2;
 			sWindow.m_nMiniMapQuality = NONANTIALIASED_QUALITY;
 			sWindow.m_nMiniMapWidth = 150;
 

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -220,7 +220,7 @@ BOOL CEditView::Create(
 	m_szComposition[0] = L'\0';
 
 	/* ルーラー表示 */
-	GetTextArea().SetAreaTop(GetTextArea().GetAreaTop()+GetDllShareData().m_Common.m_sWindow.m_nRulerHeight);	/* ルーラー高さ */
+	GetTextArea().SetAreaTop(GetTextArea().GetAreaTop()+DpiScaleY(GetDllShareData().m_Common.m_sWindow.m_nRulerHeight));	/* ルーラー高さ */
 	GetRuler().SetRedrawFlag();	// ルーラー全体を描き直す時=true   2002.02.25 Add By KK
 	m_hdcCompatDC = NULL;		/* 再描画用コンパチブルＤＣ */
 	m_hbmpCompatBMP = NULL;		/* 再描画用メモリＢＭＰ */
@@ -274,13 +274,13 @@ BOOL CEditView::Create(
 	m_cRegexKeyword = new CRegexKeyword( GetDllShareData().m_Common.m_sSearch.m_szRegexpLib );	//@@@ 2001.11.17 add MIK
 	m_cRegexKeyword->RegexKeySetTypes(m_pTypeData);	//@@@ 2001.11.17 add MIK
 
-	GetTextArea().SetTopYohaku( GetDllShareData().m_Common.m_sWindow.m_nRulerBottomSpace ); 	/* ルーラーとテキストの隙間 */
+	GetTextArea().SetTopYohaku(DpiScaleY(GetDllShareData().m_Common.m_sWindow.m_nRulerBottomSpace)); 	/* ルーラーとテキストの隙間 */
 	GetTextArea().SetAreaTop( GetTextArea().GetTopYohaku() );								/* 表示域の上端座標 */
 	/* ルーラー表示 */
 	if( m_pTypeData->m_ColorInfoArr[COLORIDX_RULER].m_bDisp && !m_bMiniMap ){
-		GetTextArea().SetAreaTop( GetTextArea().GetAreaTop() + GetDllShareData().m_Common.m_sWindow.m_nRulerHeight);	/* ルーラー高さ */
+		GetTextArea().SetAreaTop(GetTextArea().GetAreaTop() + DpiScaleY(GetDllShareData().m_Common.m_sWindow.m_nRulerHeight));	/* ルーラー高さ */
 	}
-	GetTextArea().SetLeftYohaku( GetDllShareData().m_Common.m_sWindow.m_nLineNumRightSpace );
+	GetTextArea().SetLeftYohaku(DpiScaleX(GetDllShareData().m_Common.m_sWindow.m_nLineNumRightSpace));
 
 	/* ウィンドウクラスの登録 */
 	//	Apr. 27, 2000 genta
@@ -1121,7 +1121,7 @@ void CEditView::SetFont( void )
 	if( m_bMiniMap ){
 		GetTextMetrics().Update(hdc, GetFontset().GetFontHan(), 0, 0);
 	}else{
-		GetTextMetrics().Update(hdc, GetFontset().GetFontHan(), m_pTypeData->m_nLineSpace, m_pTypeData->m_nColumnSpace);
+		GetTextMetrics().Update(hdc, GetFontset().GetFontHan(), DpiScaleY(m_pTypeData->m_nLineSpace), DpiScaleX(m_pTypeData->m_nColumnSpace));
 	}
 
 	::ReleaseDC( GetHwnd(), hdc );
@@ -1690,7 +1690,7 @@ void CEditView::OnChangeSetting()
 	}
 	RECT		rc;
 
-	GetTextArea().SetTopYohaku( GetDllShareData().m_Common.m_sWindow.m_nRulerBottomSpace ); 		/* ルーラーとテキストの隙間 */
+	GetTextArea().SetTopYohaku(DpiScaleY(GetDllShareData().m_Common.m_sWindow.m_nRulerBottomSpace)); 		/* ルーラーとテキストの隙間 */
 	GetTextArea().SetAreaTop( GetTextArea().GetTopYohaku() );									/* 表示域の上端座標 */
 
 	// 文書種別更新
@@ -1698,9 +1698,9 @@ void CEditView::OnChangeSetting()
 
 	/* ルーラー表示 */
 	if( m_pTypeData->m_ColorInfoArr[COLORIDX_RULER].m_bDisp && !m_bMiniMap ){
-		GetTextArea().SetAreaTop(GetTextArea().GetAreaTop() + GetDllShareData().m_Common.m_sWindow.m_nRulerHeight);	/* ルーラー高さ */
+		GetTextArea().SetAreaTop(GetTextArea().GetAreaTop() + DpiScaleY(GetDllShareData().m_Common.m_sWindow.m_nRulerHeight));	/* ルーラー高さ */
 	}
-	GetTextArea().SetLeftYohaku( GetDllShareData().m_Common.m_sWindow.m_nLineNumRightSpace );
+	GetTextArea().SetLeftYohaku(DpiScaleX(GetDllShareData().m_Common.m_sWindow.m_nLineNumRightSpace));
 
 	/* フォントの変更 */
 	SetFont();

--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -123,7 +123,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 	}
 	if (m_hFont == NULL) {
 		LOGFONT	lf = {0};
-		lf.lfHeight			= 1 - DpiScaleY(pCommon->m_sWindow.m_nRulerHeight);	//	2002/05/13 ai
+		lf.lfHeight			= DpiScaleY(1 - pCommon->m_sWindow.m_nRulerHeight);	//	2002/05/13 ai
 		lf.lfWidth			= 0;
 		lf.lfEscapement		= 0;
 		lf.lfOrientation	= 0;

--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -28,6 +28,7 @@
 #include "view/CEditView.h"
 #include "doc/CEditDoc.h"
 #include "types/CTypeSupport.h"
+#include "util/window.h"
 
 CRuler::CRuler(const CEditView* pEditView, const CEditDoc* pEditDoc)
 : m_pEditView(pEditView)
@@ -122,7 +123,7 @@ void CRuler::DrawRulerBg(CGraphics& gr)
 	}
 	if (m_hFont == NULL) {
 		LOGFONT	lf = {0};
-		lf.lfHeight			= 1 - pCommon->m_sWindow.m_nRulerHeight;	//	2002/05/13 ai
+		lf.lfHeight			= 1 - DpiScaleY(pCommon->m_sWindow.m_nRulerHeight);	//	2002/05/13 ai
 		lf.lfWidth			= 0;
 		lf.lfEscapement		= 0;
 		lf.lfOrientation	= 0;

--- a/sakura_core/view/CTextArea.cpp
+++ b/sakura_core/view/CTextArea.cpp
@@ -31,6 +31,7 @@
 #include "env/DLLSHAREDATA.h"
 #include "doc/CEditDoc.h"
 #include "config/app_constants.h"
+#include "util/window.h"
 
 // 2014.07.26 katze
 //#define USE_LOG10			// この行のコメントを外すと行番号の最小桁数の計算にlog10()を用いる
@@ -63,8 +64,8 @@ CTextArea::CTextArea(CEditView* pEditView)
 	m_nViewRowNum = CLayoutInt(0);			/* 表示域の行数 */
 	m_nViewTopLine = CLayoutInt(0);			/* 表示域の一番上の行 */
 	m_nViewLeftCol = CLayoutInt(0);			/* 表示域の一番左の桁 */
-	SetTopYohaku( pShareData->m_Common.m_sWindow.m_nRulerBottomSpace ); 	/* ルーラーとテキストの隙間 */
-	SetLeftYohaku( pShareData->m_Common.m_sWindow.m_nLineNumRightSpace );
+	SetTopYohaku(DpiScaleY(pShareData->m_Common.m_sWindow.m_nRulerBottomSpace)); 	/* ルーラーとテキストの隙間 */
+	SetLeftYohaku(DpiScaleX(pShareData->m_Common.m_sWindow.m_nLineNumRightSpace));
 	m_nViewAlignTop = GetTopYohaku();		/* 表示域の上端座標 */
 }
 

--- a/sakura_core/view/CViewFont.cpp
+++ b/sakura_core/view/CViewFont.cpp
@@ -27,13 +27,14 @@
 #include "StdAfx.h"
 #include "CViewFont.h"
 #include "env/DLLSHAREDATA.h"
+#include "util/window.h"
 
 /*! フォント作成
 */
 void CViewFont::CreateFonts( const LOGFONT *plf )
 {
 	LOGFONT	lf;
-	int miniSize = GetDllShareData().m_Common.m_sWindow.m_nMiniMapFontSize;
+	int miniSize = ::DpiScaleX(GetDllShareData().m_Common.m_sWindow.m_nMiniMapFontSize);
 	int quality = GetDllShareData().m_Common.m_sWindow.m_nMiniMapQuality;
 	int outPrec = OUT_TT_ONLY_PRECIS;	// FixedSys等でMiniMapのフォントが小さくならない修正
 

--- a/sakura_core/view/figures/CFigure_ZenSpace.cpp
+++ b/sakura_core/view/figures/CFigure_ZenSpace.cpp
@@ -27,6 +27,7 @@
 #include "CFigure_ZenSpace.h"
 #include "types/CTypeSupport.h"
 #include "apiwrap/StdApi.h"
+#include "util/window.h"
 
 void Draw_ZenSpace( CGraphics& gr, const CMyRect& rc );
 
@@ -92,7 +93,7 @@ void CFigure_ZenSpace::DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pc
 			CMyRect rcZenSp;
 			// 注：ベースライン無視
 			rcZenSp.SetPos(pDispPos->GetDrawPos().x, pDispPos->GetDrawPos().y);
-			rcZenSp.SetSize(dx[0]- pcView->m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_nColumnSpace,
+			rcZenSp.SetSize(dx[0]- DpiScaleX(pcView->m_pcEditDoc->m_cDocType.GetDocumentAttribute().m_nColumnSpace),
 				pcView->GetTextMetrics().GetHankakuHeight());
 
 			// 描画

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -3303,7 +3303,7 @@ LRESULT CEditWnd::OnSize2( WPARAM wParam, LPARAM lParam, bool bUpdateStatus )
 	// ミニマップ
 	int nMiniMapWidth = 0;
 	if( m_cMiniMapView.GetHwnd() ){
-		nMiniMapWidth = GetDllShareData().m_Common.m_sWindow.m_nMiniMapWidth;
+		nMiniMapWidth = ::DpiScaleX(GetDllShareData().m_Common.m_sWindow.m_nMiniMapWidth);
 		::MoveWindow( m_cMiniMapView.GetHwnd(),
 			(eDockSideFL == DOCKSIDE_RIGHT)? cx - nFuncListWidth - nMiniMapWidth: cx - nMiniMapWidth,
 			(eDockSideFL == DOCKSIDE_TOP)? nTop + nFuncListHeight: nTop,


### PR DESCRIPTION
- ミニマップのウィンドウ横幅とフォントサイズを表示スケールに合わせて拡大する処理を追加
- ミニマップのフォントサイズのデフォルト値を -1 から -2 に変更
- ルーラーの高さ、ルーラーとテキストの隙間、行番号とテキストの隙間を表示スケールに合わせて拡大する処理を追加
- 文字の間隔と行の間隔を表示スケールに合わせて拡大する処理を追加

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

ディスプレイの表示スケールに合わせて見た目がスケールするようにする。

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 仕様変更

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

表示スケールに変更した際に見た目がスケールするので設定値を変更する必要がなくなる。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

dot by dot のピクセル単位では設定出来なくなるので、表示スケールが大きい数値の時にピクセル単位で細かく調整する事が出来なくなります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

変更前はディスプレイの表示スケールを掛けないピクセル単位でした。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->

項目に関連する画面の見た目

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

様々な表示スケールで画面の見た目を確認

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
