### PR TITLE
Visual Studio 2022を使用したローカルビルドに対応する

### DIFF
--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -167,6 +167,8 @@ exit /b
         set NUM_VSVERSION=15
     ) else if "%ARG_VSVERSION%" == "2019" (
         set NUM_VSVERSION=16
+    ) else if "%ARG_VSVERSION%" == "2022" (
+        set NUM_VSVERSION=17
     ) else if "%ARG_VSVERSION%" == "latest" (
         call :check_latest_installed_vsversion
     ) else (
@@ -185,6 +187,8 @@ exit /b
         set CMAKE_G_PARAM=Visual Studio 15 2017
     ) else if "%NUM_VSVERSION%" == "16" (
         set CMAKE_G_PARAM=Visual Studio 16 2019
+    ) else if "%NUM_VSVERSION%" == "17" (
+        set CMAKE_G_PARAM=Visual Studio 17 2022
     ) else (
         call :set_cmake_gparam_automatically
     )

--- a/vcx-props/vcxcompat.props
+++ b/vcx-props/vcxcompat.props
@@ -6,10 +6,16 @@
   <PropertyGroup Label="Globals" Condition="'$(VisualStudioVersion)' == '16.0'">
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
+  <PropertyGroup Label="Globals" Condition="'$(VisualStudioVersion)' == '17.0'">
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '15.0'">
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '16.0'">
     <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '17.0'">
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

タイトルの通りです。

## <!-- 必須 --> カテゴリ
- 機能追加
- ビルド関連
  - ローカルビルド

## <!-- 自明なら省略可 --> PR の背景
#1755 

## <!-- 自明なら省略可 --> PR のメリット
Visual Studio 2022でビルドができるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
ビルド成果物の動作確認中のため、CI対応は後程別のPRで対応します。
それまではVS2019とVS2022の双方でビルドできるコードかどうかを検証できないと思います。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
ソリューションの設定ファイルへツールセットとSDKのバージョン指定を追記したのと、ビルドツールの探索を行うバッチファイルで「2022」及び「17」を引数に指定できるようにしました。

なお、find-tools.batの以下の部分はVS2017に付属するvswhereコマンドが意図通りに機能しない場合のフォールバックだと考えられることから変更していません。
https://github.com/sakura-editor/sakura/blob/f095569e4405b70c47d83bfcffad79b3126ed6ad/tools/find-tools.bat#L231-L232

なお、本年4月中に予定されている.NET Framework 4.6.1以前のサポート終了によるものだとは思いますが、Visual Studio 2022には.NET Framework 4.6.1 Targeting Packが含まれなくなります。
このためヘルプファイルのビルドができなくなりますので、あらかじめ #1756 で2017～2022間で共通して利用できる.NET Framework 4.7.2への再ターゲットを実施済みです。

## <!-- わかる範囲で --> PR の影響範囲
既存のビルド処理（VS上・コマンドラインとも）に影響します。

## <!-- 必須 --> テスト内容
- ローカル環境にインストールしたVisual Studio 2022でsakura.slnを開き、ビルドが通ること。
- build-sln.batを使用したコマンドラインビルドが成功すること。
- find-tools.batでVS2022のMSBuildを発見できること。

## <!-- なければ省略可 --> 関連 issue, PR
#1752 … Azure Pipelinesにおいて、Windows Server 2016（`VS2017-Win2016`）で動いているジョブをWindows Server 2022（`windows-2022`）に移す場合はfind-tools.batの変更が必要になります。

## <!-- なければ省略可 --> 参考資料
- [Visual Studio workload and component IDs](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community?view=vs-2022)
- [.NET Framework 4.5.2, 4.6, 4.6.1 will reach End of Support on April 26, 2022](https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/)
