### PR TITLE
Azure Pipelinesの不要な警告メッセージを削減する

### DIFF
--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -72,7 +72,7 @@ jobs:
   #     https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml#job-status-functions
   #
   - task: CopyFiles@1
-    condition: succeededOrFailed()
+    condition: and(eq(variables['Configuration'], 'Release'), succeededOrFailed())
     displayName: Copy to ArtifactStagingDirectory
     inputs:
       contents: |
@@ -82,7 +82,7 @@ jobs:
 
   # see https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml
   - task: PublishBuildArtifacts@1
-    condition: succeededOrFailed()
+    condition: and(eq(variables['Configuration'], 'Release'), succeededOrFailed())
     displayName: Publish ArtifactStagingDirectory
     inputs:
        pathtoPublish: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

Azure Pipelines の警告メッセージを削減します。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - Azure Pipelines

## <!-- 自明なら省略可 --> PR の背景

Azure Pipelines でこんな警告メッセージが出ています。
```
##[warning]Directory 'D:\a\1\a' is empty. Nothing will be added to build artifact 'Win32_Debug'.
```
このメッセージはDebug版のビルドとMinGWのビルドで出ていますが、過去の経緯と動作を踏まえると意図したものだと考えられるため、出力させるのは無用だと思いました。

## <!-- 自明なら省略可 --> PR のメリット

余計な警告メッセージが減ります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

### Visual Studioでのビルドジョブ
#1403 以降、CIの成果物作成はRelease版に限定されています。
このため、ビルド過程で作成された実行ファイルやログなどを圧縮ファイルにまとめるバッチ処理はRelease版のビルドでのみ実行されるように設定されています。

一方で、そのバッチ処理で作成された圧縮ファイルをアップロードする処理の実行条件が変更されなかったため、Publishタスクの実行で「対象が存在しない」という状況が生じていました。

このPRで成果物をステージングディレクトリにコピーするタスクと、そのディレクトリからアップロードするタスクの実行もRelease版に限定するよう条件を見直します。

### ~~MinGWでのビルドジョブ~~
~~CIでのMinGWビルドは #494 で導入されたものですが、当時から成果物は作成せずビルドのみ行うことになっているようです。~~
~~作成しないにもかかわらず、コピータスクとアップロードタスクを実行していたため同様の状況が生じていました。~~

~~このPRでこれらの不必要なタスクの利用を一旦取りやめます。~~

## <!-- わかる範囲で --> PR の影響範囲
Azure Pipelinesの次のジョブ
- VS2017
- VS2019
- ~~MinGW~~

## <!-- 必須 --> テスト内容

Azure Pipelinesの実行結果で上記の警告メッセージが表示されないこと。

## <!-- なければ省略可 --> 関連 issue, PR

#1487 … 似たような案件


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
