### PR TITLE
MinGWビルドで使用するビルドツールを更新する

### DIFF
--- a/ci/azure-pipelines/template.steps.install-mingw-w64-gcc.yml
+++ b/ci/azure-pipelines/template.steps.install-mingw-w64-gcc.yml
@@ -5,5 +5,5 @@
 #       なし
 #############################################################################################################
 steps:
-  - script: echo nothing to do.
-    displayName: nothing to do
+  - script: C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-toolchain"
+    displayName: Install MinGW-w64 build tools via Pacman


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

MinGWビルドで使用しているMinGW-w64-gccを更新します。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - Azure Pipelines

## <!-- 自明なら省略可 --> PR の背景

（ #1752 による対応の第2弾です。）

MinGWビルドを行うジョブはWindows Server 2016の仮想環境で実行されていますが、当該環境は3月中に利用できなくなるため、Windows Server 2022環境へ移行する予定です。

しかし、仮想環境に既定でインストールされているMinGW-w64が古く、Windows Server 2022環境でのビルド時に標準ライブラリ関係のコンパイルエラーが生じます。

例：
```
In file included from C:/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/filesystem:37,
                 from D:/a/1/s/sakura_core/util/file.h:33,
                 from D:/a/1/s/sakura_core/io/CFile.h:31,
                 from D:/a/1/s/sakura_core/env/CommonSetting.h:34,
                 from D:/a/1/s/sakura_core/env/DLLSHAREDATA.h:35,
                 from D:/a/1/s/sakura_core/StdAfx.h:108:
C:/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/bits/fs_path.h: In member function 'std::filesystem::__cxx11::path& std::filesystem::__cxx11::path::operator/=(const std::filesystem::__cxx11::path&)':
C:/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/bits/fs_path.h:237:47: error: no match for 'operator!=' (operand types are 'std::filesystem::__cxx11::path' and 'std::filesystem::__cxx11::path')
    || (__p.has_root_name() && __p.root_name() != root_name()))
                               ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```

## <!-- 自明なら省略可 --> PR のメリット

Windows Server 2022 環境でもMinGWビルドができるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

これはGCC9以降で修正された既存の不具合によるもの（資料参照）ですが、MinGW-w64の開発チームがSourceForgeにバージョン9以降のインストーラを公開していないこともあるのか、仮想環境には修正前のバージョンがインストールされています。

**【2022-01-17T12:52 追記】**
幸い、Windows Server 2016 環境ではMSYS2経由で修正後のバージョンが別にインストールされていたため、この問題を回避できていました。しかし、Windows Server 2022 環境では最低限のパッケージしか含まれないらしく、修正後のバージョンはインストールされていません。
このためにビルド時に修正前のバージョンの方が呼び出されることとなり、上記の問題が生じました。
**【追記ここまで】**

バグチケットの会話でも推奨されている通り、MSYS2経由で最新のツールセット一式を**明示的に**インストールするようにします。
現在の最新バージョンは11.2です。
[Group: mingw-w64-x86_64-toolchain - MSYS2 Packages](https://packages.msys2.org/group/mingw-w64-x86_64-toolchain)
[Package: mingw-w64-x86_64-gcc - MSYS2 Packages](https://packages.msys2.org/package/mingw-w64-x86_64-gcc?repo=mingw64)

~~なお、このPRにより使用するGCCのバージョンが一気に上がりますのでご注意ください。~~

- ~~変更前： `x86_64-w64-mingw32-gcc.exe (x86_64-posix-seh-rev0, Built by MinGW-W64 project) 8.1.0`~~
- ~~変更後（現時点）： `x86_64-w64-mingw32-gcc (Rev5, Built by MSYS2 project) 11.2.0`~~

## <!-- わかる範囲で --> PR の影響範囲
Azure Pipelinesの次のジョブ
- MinGW
   - MinGW_Debug
   - MinGW_Release

## <!-- 必須 --> テスト内容
MinGWビルドで
- 最新のMinGW-w64がインストールされること
- ビルドに成功すること

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
エラーに関するもの
- [-std=c++17オプションをつけて<filesystem>をインクルードするとエラーが発生する](https://qiita.com/takey/questions/87d7a7d0f006c3d3ef36)
- [#737 can't include <filesystem> with mingw-w64 8.1](https://sourceforge.net/p/mingw-w64/bugs/737/)
- [GCC Bugzilla – Bug 78870 Support std::filesystem on Windows](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78870)

仮想環境の構成に関するもの（いずれも `Mingw-w64` は `8.1.0` となっている）
- [Windows Server 2016 (20220110.1)](https://github.com/actions/virtual-environments/blob/37d8c26d314e6799cb74ec8e378d05cbbaaa3b1a/images/win/Windows2016-Readme.md)
- [Windows Server 2019 (20220110.1)](https://github.com/actions/virtual-environments/blob/37d8c26d314e6799cb74ec8e378d05cbbaaa3b1a/images/win/Windows2019-Readme.md)
- [Windows Server 2022 (20211219.1)](https://github.com/actions/virtual-environments/blob/37d8c26d314e6799cb74ec8e378d05cbbaaa3b1a/images/win/Windows2022-Readme.md)