### PR TITLE
Azure PipelinesにおけるWindows Server 2016環境の利用を廃止する

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,17 +87,6 @@ pr:
 ###############################################################################################################################
 jobs:
 
-# サクラエディタのビルドを行う JOB (VS2017)
-# * サクラエディタ本体
-# * HTML Help
-# * Installer
-# * 単体テスト
-- template: ci/azure-pipelines/template.job.build-unittest.yml
-  parameters:
-    name: VS2017
-    vmImage: 'VS2017-Win2016'
-    displayName: VS2017
-
 # サクラエディタのビルドを行う JOB (VS2019)
 # * サクラエディタ本体
 # * HTML Help

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,35 +117,35 @@ jobs:
 - template: ci/azure-pipelines/template.job.build-on-msys2.yml
   parameters:
     name: MinGW
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-latest'
     displayName: MinGW
 
 # SonarQube で解析を行う JOB
 - template: ci/azure-pipelines/template.job.SonarQube.yml
   parameters:
     name: SonarQube
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-latest'
     displayName: SonarQube
 
 # Cppcheck を行う JOB
 - template: ci/azure-pipelines/template.job.cppcheck.yml
   parameters:
     name: cppcheck
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-latest'
     displayName: cppcheck
 
 # doxygen を行う JOB
 - template: ci/azure-pipelines/template.job.doxygen.yml
   parameters:
     name: doxygen
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-latest'
     displayName: doxygen
 
 # 文字コードのチェックを行う JOB
 - template: ci/azure-pipelines/template.job.checkEncoding.yml
   parameters:
     name: checkEncoding
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-latest'
 
 #############################################################################################################
 #   Python スクリプトのコンパイル確認を行う job
@@ -153,5 +153,5 @@ jobs:
 - template: ci/azure-pipelines/template.job.python-check.yml
   parameters:
     name: script_check
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-latest'
     displayName: script_check

--- a/ci/azure-pipelines/azure-pipelines.md
+++ b/ci/azure-pipelines/azure-pipelines.md
@@ -76,7 +76,6 @@ https://azure.microsoft.com/ja-jp/services/devops/pipelines/ にアクセスし�
 
 | JOB 名 | 説明 | job を定義する template |
 ----|----|----
-|VS2017 | Visual Studio 2017 でサクラエディタのビルドを行う | [template.job.build-unittest.yml](template.job.build-unittest.yml) |
 |VS2019 | Visual Studio 2019 でサクラエディタのビルドを行う | [template.job.build-unittest.yml](template.job.build-unittest.yml) |
 |MinGW | MinGW でサクラエディタのビルドを行う | [template.job.build-on-msys2.yml](template.job.build-on-msys2.yml) |
 |SonarQube | SonarQube での解析を行う | [template.job.SonarQube.yml](template.job.SonarQube.yml) |


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

Azure PipelinesにてWindows Server 2016環境（`VS2017-Win2016`）を利用を廃止します。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - Azure Pipelines

## <!-- 自明なら省略可 --> PR の背景

（ #1752 による対応の第3弾です。）
（※注：本文中の日付はアップストリーム側の影響で予告なく変更される場合があります。）

Azure PipelinesとGitHub Actionsで利用できるWindows Server 2016仮想環境は、3月15日頃に廃止され利用できなくなります。
（公式アナウンス： actions/virtual-environments#4312 ）

## <!-- 自明なら省略可 --> PR のメリット

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

- Windows Server 2016環境にはVisual Studio 2017が含まれており、今回の措置によりVS2017は利用できなくなります。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

Windows Server 2022環境は[アップストリームの運用方針](https://github.com/actions/virtual-environments/blob/df0e83c8f71990a7dad883fe913b507c8d6b007e/docs/software-and-images-guidelines.md)により、サポートが終了したソフトウェアや利用者の少ないソフトウェアが含まれなくなりましたが、2019と比べて「VSのバージョン以外は特に支障ない」と思えることから、`windows-latest`を設定していったん2019に移行させたのち、アップストリーム側の対応で2022に自動移行させることとしました。

次の変更を行います。
- 2019以降の環境ではVS2017が含まれておらず代替できないため、VS2017ジョブは廃止します。
- VSを利用しないジョブは、最新の Windows 環境（`windows-latest`）を利用するように改めます。
   - この識別子は、時期は不明ながらもドキュメントに追加されており、利用できることも確認済みです。
   - この識別子の指し先は3月8日頃にWindows Server 2019環境からWindows Server 2022環境に変更されます。
      - 公式アナウンス： actions/virtual-environments#4856

なお、変更に備えて事前に2019/2022の両方でジョブが実行できるように次の対応を行いました。
- Python 2を利用しないようにした（ #1766 ）
- MSYS2経由でMinGWビルドが正常に行えるようにした（ #1771 ）
   - Windows Server 2022環境がベータリリースされたときの[アナウンス](https://github.com/actions/virtual-environments/issues/3949)で言及されていましたが、MSYS2では最低限のパッケージだけしか含まれなくなりました。

また、移行によって以下のログが出力されなくなっているはずです。
```
##[warning]A brownout will take place on January, 21 3:00 PM - 5:00 PM UTC to raise awareness of the upcoming windows-2016 environment removal. For more details, see https://github.com/actions/virtual-environments/issues/4312
```

## <!-- わかる範囲で --> PR の影響範囲

Azure Pipelines（…で実行しているVS2019以外のジョブ）

## <!-- 必須 --> テスト内容

- VS2017のビルドジョブが実行されないこと
- 対象となるジョブが、Windows Server 2019環境上で実行されていること
   - 各ジョブの"Initialize job"ステップのログに、「Operating System」が出力されているので、これを確認します。
- ジョブが正常終了すること。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
actions/virtual-environments#4488 … Windows Server 2022環境は昨年11月15日に正式リリースされました。

[Microsoft-hosted agents for Azure Pipelines - Azure Pipelines | Microsoft Docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops)
[Microsoft-hosted agents update. | Microsoft Docs](https://docs.microsoft.com/en-us/azure/devops/release-notes/2022/sprint-198-update) … 2021年12月6日付でWindows Server 2016の廃止告知、2022年1月19日付で`windows-latest`の変更告知がなされました。

各環境のソフトウェア構成とMSYS2のパッケージ構成は以下を参照してください。
- [Windows Server 2016 (Image Version: 20220116.1)](https://github.com/actions/virtual-environments/blob/df0e83c8f71990a7dad883fe913b507c8d6b007e/images/win/Windows2016-Readme.md)
   - [MSYS2のパッケージ構成](https://github.com/actions/virtual-environments/blob/df0e83c8f71990a7dad883fe913b507c8d6b007e/images/win/toolsets/toolset-2016.json#L187-L261)
- [Windows Server 2019 (Image Version: 20220116.1)](https://github.com/actions/virtual-environments/blob/df0e83c8f71990a7dad883fe913b507c8d6b007e/images/win/Windows2019-Readme.md)
   - [MSYS2のパッケージ構成](https://github.com/actions/virtual-environments/blob/df0e83c8f71990a7dad883fe913b507c8d6b007e/images/win/toolsets/toolset-2019.json#L188-L262)
- [Windows Server 2022 (Image Version: 20220116.1)](https://github.com/actions/virtual-environments/blob/df0e83c8f71990a7dad883fe913b507c8d6b007e/images/win/Windows2022-Readme.md)
   - [MSYS2のパッケージ構成](https://github.com/actions/virtual-environments/blob/df0e83c8f71990a7dad883fe913b507c8d6b007e/images/win/toolsets/toolset-2022.json#L158-L161)