### PR TITLE
ExtractCtagsのWin32ビルドの依存ターゲット指定をx64ビルドと合わせる

### DIFF
--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -951,7 +951,7 @@
   <Target Name="ExtractCtags" Condition="'$(Platform)' == 'x64'" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x64.zip" Outputs="$(OutDir)\ctags.exe">
     <Exec Command="7z e &quot;$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x64.zip&quot; -o$(OutDir) -y ctags.exe" />
   </Target>
-  <Target Name="ExtractCtags" Condition="'$(Platform)' == 'Win32'" DependsOnTargets="ClCompile" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip" Outputs="$(OutDir)\ctags.exe">
+  <Target Name="ExtractCtags" Condition="'$(Platform)' == 'Win32'" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip" Outputs="$(OutDir)\ctags.exe">
     <Exec Command="7z e &quot;$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip&quot; -o$(OutDir) -y ctags.exe" />
   </Target>
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
タイトル通りです。

## <!-- 必須 --> カテゴリ

- その他の問題

　不具合≒期待通りに動作しない、とは事象が異なるので「その他」としました。

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1772 で報告した通り、ビルド後に行っている ctags.exe の解凍タスクの記述に違和感があります。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

このタスクは、ビルドが完了したら ctags.exe に依存した機能も使えるようにする目的で存在しています。

* ClCompileタスクは、C++のコンパイルを行います。
  コンパイルエラーが起きた場合は sakura.exe が実行できないので、ctags.exe を解凍する意味はありません。
* Linkタスクは、コンパイルで生成されたオブジェクトをリンクして sakura.exe を作ります。
  リンカエラーが起きた場合は sakura.exe が実行できないので、ctags.exe を解凍する意味はありません。

変更前： x64ビルドは Link の後、Win32ビルドは ClCompile の後に解凍タスクを実行するようになっています。
変更後： x64ビルドは Link の後、Win32ビルドも Link の後に解凍タスクを実行するようにします。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
アプリの仕様変更はありません。
ビルドタスクが実行される順番に影響する変更です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
close #1772

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
