### PR TITLE
CIでVS2022を利用したビルドを行うようにする

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -90,8 +90,19 @@ jobs:
       shell: cmd
 
     - name: Install Locale Emulator
-      run: choco install locale-emulator -y
-      shell: cmd
+      run: |
+        choco install autohotkey.install --confirm
+        $LEExpandDir = "${{github.workspace}}\tools\locale-emulator"
+        $LEInitScript = "${{github.workspace}}\ci\init-locale-emulator.ahk"
+        New-Item "${LEExpandDir}" -ItemType Directory
+        Invoke-WebRequest `
+          "https://github.com/xupefei/Locale-Emulator/releases/download/v2.5.0.1/Locale.Emulator.2.5.0.1.zip" `
+          -OutFile "${LEExpandDir}\locale-emulator.zip"
+        Expand-Archive "${LEExpandDir}\locale-emulator.zip" "${LEExpandDir}"
+        Start-Process "AutoHotKey" "${LEInitScript}"
+        Start-Process "${LEExpandDir}\LEInstaller.exe"
+        echo "${LEExpandDir}" >> $env:GITHUB_PATH
+      shell: pwsh
 
     - name: Build HTML Help
       run: build-chm.bat

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -108,6 +108,10 @@ jobs:
       run: build-chm.bat
       shell: cmd
 
+    - name: Update/Install Inno Setup
+      run: choco upgrade innosetup --confirm
+      shell: pwsh
+
     - name: Build installer with Inno Setup
       run: build-installer.bat ${{ matrix.platform }} ${{ matrix.config }}
       shell: cmd

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -92,6 +92,11 @@ jobs:
       run: build-sln.bat ${{ matrix.platform }} ${{ matrix.config }}
       shell: cmd
 
+    - name: Run unit tests
+      run: .\tests1.exe --gtest_output=xml:${{github.workspace}}\tests1.exe-googletest-${{matrix.platform}}-${{matrix.config}}.xml
+      working-directory: ${{github.workspace}}\${{matrix.platform}}\${{matrix.config}}
+      shell: pwsh
+
     - name: Install Locale Emulator
       run: |
         choco install autohotkey.install --confirm

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -34,10 +34,13 @@ jobs:
   build:
     # The type of runner that the job will run on
     name: MSBuild
-    runs-on: windows-latest
+    runs-on: ${{matrix.os}}
 
     strategy:
       matrix:
+        os:
+          - windows-2019
+          - windows-2022
         config:
           - Debug
           - Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,6 +100,13 @@ jobs:
     vmImage: 'windows-2019'
     displayName: VS2019
 
+# サクラエディタのビルドを行う JOB (VS2022)
+- template: ci/azure-pipelines/template.job.build-unittest.yml
+  parameters:
+    name: VS2022
+    vmImage: 'windows-2022'
+    displayName: VS2022
+
 # サクラエディタのビルドを行う JOB(MinGW)
 # * サクラエディタ本体
 # * 単体テスト

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -65,9 +65,9 @@ jobs:
   - script: build-chm.bat
     displayName: Build HTML Help
 
-  # Install/Update Inno Setup
+  # Update/Install Inno Setup
   - pwsh: choco upgrade innosetup --confirm
-    displayName: Install/Update Inno Setup
+    displayName: Update/Install Inno Setup
 
   # Build installer with Inno Setup
   - script: build-installer.bat $(BuildPlatform) $(Configuration)

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -47,7 +47,18 @@ jobs:
     displayName: Bitmap Split/Mux
 
   # Install Locale Emulator
-  - script: choco install locale-emulator -y
+  - pwsh: |
+      choco install autohotkey.install --confirm
+      $LEExpandDir = "$(Build.SourcesDirectory)\tools\locale-emulator"
+      $LEInitScript = "$(Build.SourcesDirectory)\ci\init-locale-emulator.ahk"
+      New-Item "${LEExpandDir}" -ItemType Directory
+      Invoke-WebRequest `
+        "https://github.com/xupefei/Locale-Emulator/releases/download/v2.5.0.1/Locale.Emulator.2.5.0.1.zip" `
+        -OutFile "${LEExpandDir}\locale-emulator.zip"
+      Expand-Archive "${LEExpandDir}\locale-emulator.zip" "${LEExpandDir}"
+      Start-Process "AutoHotKey" "${LEInitScript}"
+      Start-Process "${LEExpandDir}\LEInstaller.exe"
+      echo "##vso[task.prependpath]${LEExpandDir}"
     displayName: Install Locale Emulator
 
   # Build HTML Help

--- a/ci/azure-pipelines/template.job.build-unittest.yml
+++ b/ci/azure-pipelines/template.job.build-unittest.yml
@@ -65,6 +65,10 @@ jobs:
   - script: build-chm.bat
     displayName: Build HTML Help
 
+  # Install/Update Inno Setup
+  - pwsh: choco upgrade innosetup --confirm
+    displayName: Install/Update Inno Setup
+
   # Build installer with Inno Setup
   - script: build-installer.bat $(BuildPlatform) $(Configuration)
     displayName: Build installer with Inno Setup

--- a/ci/init-locale-emulator.ahk
+++ b/ci/init-locale-emulator.ahk
@@ -1,0 +1,7 @@
+#NoEnv
+#NoTrayIcon
+SetTitleMatchMode, 1
+
+window_title = % "LE Context Menu Installer - V"
+WinWait, %window_title%, , 20
+WinClose %window_title%


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

Azure PipelinesとGitHub Actionsで、VS2022を利用したビルドと単体テストを実施したい。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - Azure Pipelines
  - GitHub Actions

## <!-- 自明なら省略可 --> PR の背景

#1764 でVS2022のローカルビルドに対応しました。
CI側でもVS2022を利用したビルドを行い、複数バージョンでビルドが成功することを確認できるようにします。
加えて、ビルドしたテストプロジェクトを使用してテストまで行いたいです。

## <!-- 自明なら省略可 --> PR のメリット

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

本体のビルドに関しては変更点はありませんが、ヘルプファイルとインストーラのビルドに関しては、仮想環境のソフトウェアが構成が変わったことによる影響があります。

### ヘルプファイルのビルド

Locale Emulator v2.4.0.1はビルド19044以降のWindows（Win10 21H2・Win11・Windows 2022）では動作せず、v2.5.0.0以降を使用する必要があります。
chocolateyのリポジトリにはまだv2.5.0.0以降がアップロードされていませんので、Chocolateyを使わずに直接最新版をダウンロードするようにします。

なお、LEProc.exeの実行にはLEInstaller.exeが終了時に生成するdllファイルが必要ですが、同プログラムはコンソールから終了できないので、AutoHotkeyでLEInstaller.exeのウィンドウが表示されたら即座に終了させるスクリプトを実行しています。
（ChocolateyにあるLocale EmulatorがAutoHotkeyに依存しているのはこの仕掛けが必要なためです。）

### インストーラのビルド

Windows Server 2022の仮想環境には、Inno Setupが含まれなくなりましたので、新たにInno Setupの最新版をChocolatey経由でインストールするステップを追加しています。
Windows Server 2019で実行した場合は既存のものを更新するように動作させますので、各ジョブ間で同じバージョンが利用できると思います。

### そのほか

- 単体テストはこれまでGitHub Actionsでは実施していませんでしたが、これを機に実施するようにします。

## <!-- わかる範囲で --> PR の影響範囲

Azure Pipelines および GitHub Actions で実行されるビルドジョブ

## <!-- 必須 --> テスト内容

追加したジョブを含めて、 CI のビルドが成功すれば問題ないと思います。

## <!-- なければ省略可 --> 関連 issue, PR

#1755 
#1764 

#1147 … VS2019の時の類似案件
#1486

## <!-- なければ省略可 --> 参考資料

[Quick Reference | AutoHotkey v2](https://lexikos.github.io/v2/docs/AutoHotkey.htm)