### PR TITLE
GoogleTestを更新する

### DIFF
--- a/tests/googletest.targets
+++ b/tests/googletest.targets
@@ -7,10 +7,8 @@
     <GoogleTestLibInstallDir Condition="'$(Platform)' == 'Win32'">$(GoogleTestInstallDir)lib</GoogleTestLibInstallDir>
     <GoogleTestLibInstallDir Condition="'$(Platform)' == 'x64'">$(GoogleTestInstallDir)lib64</GoogleTestLibInstallDir>
     <LibraryPath>$(GoogleTestLibInstallDir);$(LibraryPath)</LibraryPath>
-    <NameSuffix Condition="'$(Configuration)' == 'Debug'">d</NameSuffix>
-    <NameSuffix Condition="'$(Configuration)' == 'Release'"></NameSuffix>
-    <GTestLibName>gtest$(NameSuffix).lib</GTestLibName>
-    <GTestMainLibName>gtest_main$(NameSuffix).lib</GTestMainLibName>
+    <GTestLibName>gtest.lib</GTestLibName>
+    <GTestMainLibName>gtest_main.lib</GTestMainLibName>
     <GTestLibPath>$(GoogleTestLibInstallDir)\$(GTestLibName)</GTestLibPath>
     <GTestMainLibPath>$(GoogleTestLibInstallDir)\$(GTestMainLibName)</GTestMainLibPath>
   </PropertyGroup>

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -81,8 +81,6 @@ ifeq (,$(findstring -D_DEBUG,$(DEFINES)))
 ifeq (,$(findstring -DNDEBUG,$(DEFINES)))
 DEFINES += -DNDEBUG
 endif
-else
-LIB_SUFFIX = d
 endif
 
 CFLAGS= \
@@ -120,8 +118,8 @@ LIBS= \
  -lgdi32 \
  -lcomdlg32 \
  -L$(GOOGLETEST_INSTALL_DIR)/lib \
- -lgtest$(or $(LIB_SUFFIX),) \
- -lgtest_main$(or $(LIB_SUFFIX),) \
+ -lgtest \
+ -lgtest_main \
  $(MYLIBS)
 
 exe= $(or $(OUTDIR),.)/tests1.exe

--- a/tests/unittests/test-zoom.cpp
+++ b/tests/unittests/test-zoom.cpp
@@ -23,6 +23,7 @@
 		   distribution.
 */
 #include <gtest/gtest.h>
+#include <algorithm>
 #include "util/zoom.h"
 
 /*!


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

CMakeの警告メッセージに対処するため、GoogleTestを更新する。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景
先日find-toolsのログを #1759 に投稿しましたが、その時に次のようなメッセージが出ていることに気が付きました。
```
4>CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
4>  Compatibility with CMake < 2.8.12 will be removed from a future version of
4>  CMake.
4>
4>  Update the VERSION argument <min> value or use a ...<max> suffix to tell
4>  CMake that the project does not need compatibility with older versions.
4>
4>
4>CMake Deprecation Warning at googlemock/CMakeLists.txt:42 (cmake_minimum_required):
4>  Compatibility with CMake < 2.8.12 will be removed from a future version of
4>  CMake.
4>
4>  Update the VERSION argument <min> value or use a ...<max> suffix to tell
4>  CMake that the project does not need compatibility with older versions.
4>
4>
4>CMake Deprecation Warning at googletest/CMakeLists.txt:49 (cmake_minimum_required):
4>  Compatibility with CMake < 2.8.12 will be removed from a future version of
4>  CMake.
4>
4>  Update the VERSION argument <min> value or use a ...<max> suffix to tell
4>  CMake that the project does not need compatibility with older versions.
```
ログにある通りですが、GoogleTest側のCMakeLists.txtの内容に関するものです。

CMakeでは「2.8.12より前のバージョンとの互換性を廃止する」計画があり、3.19以降のバージョンでは予告メッセージが表示されます。
[Deprecated and Removed Features | CMake 3.19 Release Notes](https://cmake.org/cmake/help/latest/release/3.19.html#deprecated-and-removed-features)
現在サクラエディタで使っているGoogleTestは[2018年11月21日版](https://github.com/google/googletest/tree/3cf8f514d859d65b7202e51c662a03a92887b8e2)ですが、この版はCMake 2.8.8に対応しているため予告メッセージの表示対象となりました。
しかし、この仕様変更予告は[2020年12月29日版](https://github.com/google/googletest/tree/389cb68b87193358358ae87cc56d257fd0d80189)ですでに対応済みであり、これ以降の版では表示されません。

これを機に最新のGoogleTestへ更新を行いたいです。

## <!-- 自明なら省略可 --> PR のメリット

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

サブモジュールの更新と、それに伴うビルドエラーへの対処を実施しています。

### targetsファイルとMakefileの変更について

つい先日GoogleTestのビルド設定に変更（ google/googletest@f64cf6b7b8328c6bafdb6352871793a459518ad3 ）があり、CMakeの`DEBUG_POSIFIX`オプションが設定されなくなりました。 
GoogleTestのライブラリファイルはデバッグ版とリリース版でファイル名が異なっていましたが、この変更によりどちらも同じファイル名になります。
サクラエディタ側ではビルド構成に応じてファイル名にプレフィクスを付加する対応を行っていますが、不要になりましたので削除しました。

### 補足情報

Visual Studioに付属するCMakeのバージョンは、手元で確認した限りでは次の通りでした。
- VS 2019 (16.11.9): `cmake version 3.20.21032501-MSVC_2`
- VS 2022 (17.0.5): `cmake version 3.21.21080301-MSVC_2`

## <!-- わかる範囲で --> PR の影響範囲

単体テスト

## <!-- 必須 --> テスト内容

1. PRをチェックアウトし、`git submodule update`を実行してサブモジュールを更新する
2. Visual Studioを起動してソリューションをビルドし、出力ペインに上記メッセージが表示されないこと、ビルドが成功することを確認する
   - リビルドを行って繰り返し確認してください。
3. テストエクスプローラーを使用して単体テストを実行し、テストに成功することを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

#636 前回は2018年11月23日に行いました。

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
