### PR TITLE
コピーライト表記の改定年を2022年に更新する

### DIFF
--- a/HeaderMake/HeaderMake.cpp
+++ b/HeaderMake/HeaderMake.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2007-2008, kobake
 	Copyright (C) 2009, rastiv
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ﻿zlib License
 
-Copyright (C) 2018-2021, Sakura Editor Organization
+Copyright (C) 2018-2022, Sakura Editor Organization
 
 This software is provided 'as-is', without any express or implied
 warranty.  In no event will the authors be held liable for any damages

--- a/sakura_core/CAutoReloadAgent.cpp
+++ b/sakura_core/CAutoReloadAgent.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CAutoReloadAgent.h
+++ b/sakura_core/CAutoReloadAgent.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CAutoSaveAgent.cpp
+++ b/sakura_core/CAutoSaveAgent.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2000-2001, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CAutoSaveAgent.h
+++ b/sakura_core/CAutoSaveAgent.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2000-2001, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CBackupAgent.h
+++ b/sakura_core/CBackupAgent.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CCodeChecker.cpp
+++ b/sakura_core/CCodeChecker.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CCodeChecker.h
+++ b/sakura_core/CCodeChecker.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CDataProfile.cpp
+++ b/sakura_core/CDataProfile.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CDicMgr.cpp
+++ b/sakura_core/CDicMgr.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2003, Moca
 	Copyright (C) 2006, fon
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/CDicMgr.h
+++ b/sakura_core/CDicMgr.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/CEditApp.cpp
+++ b/sakura_core/CEditApp.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CEditApp.h
+++ b/sakura_core/CEditApp.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2000-2001, genta
 	Copyright (C) 2000, Frozen, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2000-2001, genta
 	Copyright (C) 2002, frozen, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CFileExt.cpp
+++ b/sakura_core/CFileExt.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2003, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CFileExt.h
+++ b/sakura_core/CFileExt.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2003, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CGrepAgent.h
+++ b/sakura_core/CGrepAgent.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CGrepEnumFileBase.h
+++ b/sakura_core/CGrepEnumFileBase.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 2008, wakura
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CGrepEnumFiles.h
+++ b/sakura_core/CGrepEnumFiles.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 2008, wakura
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CGrepEnumFilterFiles.h
+++ b/sakura_core/CGrepEnumFilterFiles.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 2008, wakura
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CGrepEnumFilterFolders.h
+++ b/sakura_core/CGrepEnumFilterFolders.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 2008, wakura
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CGrepEnumFolders.h
+++ b/sakura_core/CGrepEnumFolders.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 2008, wakura
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CGrepEnumKeys.h
+++ b/sakura_core/CGrepEnumKeys.h
@@ -8,7 +8,7 @@
 /*
 	Copyright (C) 2008, wakura
 	Copyright (C) 2011, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2003, Moca, KEITA
 	Copyright (C) 2004, genta, Moca, novice
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/CHokanMgr.h
+++ b/sakura_core/CHokanMgr.h
@@ -7,7 +7,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2001, asa-o
 	Copyright (C) 2003, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/CKeyWordSetMgr.cpp
+++ b/sakura_core/CKeyWordSetMgr.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2002, genta, Moca
 	Copyright (C) 2004, Moca
 	Copyright (C) 2005, Moca, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CKeyWordSetMgr.h
+++ b/sakura_core/CKeyWordSetMgr.h
@@ -12,7 +12,7 @@
 	Copyright (C) 2001, jepro
 	Copyright (C) 2004, Moca
 	Copyright (C) 2005, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CLoadAgent.cpp
+++ b/sakura_core/CLoadAgent.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CLoadAgent.h
+++ b/sakura_core/CLoadAgent.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CMarkMgr.cpp
+++ b/sakura_core/CMarkMgr.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2000-2001, genta
 	Copyright (C) 2002, aroka
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CMarkMgr.h
+++ b/sakura_core/CMarkMgr.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2000-2001, genta
 	Copyright (C) 2002, aroka
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/COpe.cpp
+++ b/sakura_core/COpe.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/COpe.h
+++ b/sakura_core/COpe.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/COpeBlk.cpp
+++ b/sakura_core/COpeBlk.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/COpeBlk.h
+++ b/sakura_core/COpeBlk.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/COpeBuf.cpp
+++ b/sakura_core/COpeBuf.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/COpeBuf.h
+++ b/sakura_core/COpeBuf.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/CProfile.cpp
+++ b/sakura_core/CProfile.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, D.S.Koba, MIK, genta
 	Copyright (C) 2006, D.S.Koba, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CProfile.h
+++ b/sakura_core/CProfile.h
@@ -9,7 +9,7 @@
 */
 /*
 	Copyright (C) 2003-2006, D.S.Koba
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CPropertyManager.cpp
+++ b/sakura_core/CPropertyManager.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CPropertyManager.h
+++ b/sakura_core/CPropertyManager.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CReadManager.cpp
+++ b/sakura_core/CReadManager.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CReadManager.h
+++ b/sakura_core/CReadManager.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CRegexKeyword.cpp
+++ b/sakura_core/CRegexKeyword.cpp
@@ -10,7 +10,7 @@
 /*
 	Copyright (C) 2001, MIK
 	Copyright (C) 2002, YAZAKI
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/CRegexKeyword.h
+++ b/sakura_core/CRegexKeyword.h
@@ -9,7 +9,7 @@
 */
 /*
 	Copyright (C) 2001, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/CSaveAgent.cpp
+++ b/sakura_core/CSaveAgent.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CSaveAgent.h
+++ b/sakura_core/CSaveAgent.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CSearchAgent.cpp
+++ b/sakura_core/CSearchAgent.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CSearchAgent.h
+++ b/sakura_core/CSearchAgent.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CSelectLang.cpp
+++ b/sakura_core/CSelectLang.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2011, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/CSelectLang.h
+++ b/sakura_core/CSelectLang.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2011, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/CSortedTagJumpList.cpp
+++ b/sakura_core/CSortedTagJumpList.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2005, MIK, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CSortedTagJumpList.h
+++ b/sakura_core/CSortedTagJumpList.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2005, MIK, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CWriteManager.cpp
+++ b/sakura_core/CWriteManager.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/CWriteManager.h
+++ b/sakura_core/CWriteManager.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/EditInfo.cpp
+++ b/sakura_core/EditInfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/EditInfo.h
+++ b/sakura_core/EditInfo.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/GrepInfo.cpp
+++ b/sakura_core/GrepInfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/GrepInfo.h
+++ b/sakura_core/GrepInfo.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/StdAfx.cpp
+++ b/sakura_core/StdAfx.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/String_define.h
+++ b/sakura_core/String_define.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/_main/CAppMode.cpp
+++ b/sakura_core/_main/CAppMode.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/_main/CAppMode.h
+++ b/sakura_core/_main/CAppMode.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2005, D.S.Koba, genta, susu
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -11,7 +11,7 @@
 	Copyright (C) 2002, genta
 	Copyright (C) 2005, D.S.Koba
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CControlProcess.cpp
+++ b/sakura_core/_main/CControlProcess.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, aroka CProcessより分離, YAZAKI
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CControlProcess.h
+++ b/sakura_core/_main/CControlProcess.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, aroka 新規作成, YAZAKI
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -19,7 +19,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2008, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/_main/CControlTray.h
+++ b/sakura_core/_main/CControlTray.h
@@ -17,7 +17,7 @@
 	Copyright (C) 2003, genta
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CMutex.h
+++ b/sakura_core/_main/CMutex.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2007, ryoji, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2008, Uchi
 	Copyright (C) 2009, syat, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CNormalProcess.h
+++ b/sakura_core/_main/CNormalProcess.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2002, aroka 新規作成
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CProcess.cpp
+++ b/sakura_core/_main/CProcess.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, aroka 新規作成
 	Copyright (C) 2004, Moca
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CProcess.h
+++ b/sakura_core/_main/CProcess.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, aroka 新規作成
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2001, masami shoji
 	Copyright (C) 2002, aroka WinMainより分離
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/CProcessFactory.h
+++ b/sakura_core/_main/CProcessFactory.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, aroka 新規作成
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2002, aroka
 	Copyright (C) 2007, kobake
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/global.cpp
+++ b/sakura_core/_main/global.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, KK
 	Copyright (C) 2003, MIK
 	Copyright (C) 2005, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_main/global.h
+++ b/sakura_core/_main/global.h
@@ -13,7 +13,7 @@
 	Copyright (C) 2005, MIK, Moca, genta
 	Copyright (C) 2006, aroka, ryoji
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/_os/CClipboard.h
+++ b/sakura_core/_os/CClipboard.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/_os/CDropTarget.cpp
+++ b/sakura_core/_os/CDropTarget.cpp
@@ -8,7 +8,7 @@
 	Copyright (C) 2002, aroka
 	Copyright (C) 2008, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/_os/CDropTarget.h
+++ b/sakura_core/_os/CDropTarget.h
@@ -8,7 +8,7 @@
 	Copyright (C) 2002, aroka
 	Copyright (C) 2008, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/_os/OleTypes.h
+++ b/sakura_core/_os/OleTypes.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2003, 鬼, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/apiwrap/CommonControl.h
+++ b/sakura_core/apiwrap/CommonControl.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/apiwrap/StdApi.cpp
+++ b/sakura_core/apiwrap/StdApi.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/apiwrap/StdApi.h
+++ b/sakura_core/apiwrap/StdApi.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/apiwrap/StdControl.cpp
+++ b/sakura_core/apiwrap/StdControl.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CErrorInfo.cpp
+++ b/sakura_core/basis/CErrorInfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CErrorInfo.h
+++ b/sakura_core/basis/CErrorInfo.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CLaxInteger.cpp
+++ b/sakura_core/basis/CLaxInteger.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CLaxInteger.h
+++ b/sakura_core/basis/CLaxInteger.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CMyPoint.cpp
+++ b/sakura_core/basis/CMyPoint.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CMyPoint.h
+++ b/sakura_core/basis/CMyPoint.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CMyRect.cpp
+++ b/sakura_core/basis/CMyRect.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CMyRect.h
+++ b/sakura_core/basis/CMyRect.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CMySize.cpp
+++ b/sakura_core/basis/CMySize.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CMySize.h
+++ b/sakura_core/basis/CMySize.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CMyString.cpp
+++ b/sakura_core/basis/CMyString.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CMyString.h
+++ b/sakura_core/basis/CMyString.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CStrictInteger.cpp
+++ b/sakura_core/basis/CStrictInteger.cpp
@@ -2,7 +2,7 @@
 /*
 	Copyright (C) 2007, kobake
 	Copyright (C) 2007-2017 SAKURA Editor Project
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CStrictInteger.h
+++ b/sakura_core/basis/CStrictInteger.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CStrictPoint.cpp
+++ b/sakura_core/basis/CStrictPoint.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CStrictPoint.h
+++ b/sakura_core/basis/CStrictPoint.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CStrictRange.cpp
+++ b/sakura_core/basis/CStrictRange.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CStrictRange.h
+++ b/sakura_core/basis/CStrictRange.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CStrictRect.cpp
+++ b/sakura_core/basis/CStrictRect.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/CStrictRect.h
+++ b/sakura_core/basis/CStrictRect.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/SakuraBasis.cpp
+++ b/sakura_core/basis/SakuraBasis.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/SakuraBasis.h
+++ b/sakura_core/basis/SakuraBasis.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/TComImpl.hpp
+++ b/sakura_core/basis/TComImpl.hpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/_com_raise_error.cpp
+++ b/sakura_core/basis/_com_raise_error.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/basis/primitive.h
+++ b/sakura_core/basis/primitive.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCesu8.cpp
+++ b/sakura_core/charset/CCesu8.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCesu8.h
+++ b/sakura_core/charset/CCesu8.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCodeBase.cpp
+++ b/sakura_core/charset/CCodeBase.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCodeBase.h
+++ b/sakura_core/charset/CCodeBase.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCodeFactory.cpp
+++ b/sakura_core/charset/CCodeFactory.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCodeFactory.h
+++ b/sakura_core/charset/CCodeFactory.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCodeMediator.cpp
+++ b/sakura_core/charset/CCodeMediator.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCodeMediator.h
+++ b/sakura_core/charset/CCodeMediator.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -5,7 +5,7 @@
 */
 /*
 	Copyright (C) 2010-2012 Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CCodePage.h
+++ b/sakura_core/charset/CCodePage.h
@@ -5,7 +5,7 @@
 */
 /*
 	Copyright (C) 2010-2012 Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CESI.cpp
+++ b/sakura_core/charset/CESI.cpp
@@ -8,7 +8,7 @@
 /*
 	Copyright (C) 2006
 	Copyright (C) 2007
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CESI.h
+++ b/sakura_core/charset/CESI.h
@@ -9,7 +9,7 @@
 /*
 	Copyright (C) 2006
 	Copyright (C) 2007
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CEuc.cpp
+++ b/sakura_core/charset/CEuc.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CEuc.h
+++ b/sakura_core/charset/CEuc.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CJis.cpp
+++ b/sakura_core/charset/CJis.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CJis.h
+++ b/sakura_core/charset/CJis.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CLatin1.cpp
+++ b/sakura_core/charset/CLatin1.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 20010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CLatin1.h
+++ b/sakura_core/charset/CLatin1.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 20010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CShiftJis.cpp
+++ b/sakura_core/charset/CShiftJis.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CShiftJis.h
+++ b/sakura_core/charset/CShiftJis.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CUnicode.cpp
+++ b/sakura_core/charset/CUnicode.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CUnicode.h
+++ b/sakura_core/charset/CUnicode.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CUnicodeBe.cpp
+++ b/sakura_core/charset/CUnicodeBe.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CUnicodeBe.h
+++ b/sakura_core/charset/CUnicodeBe.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CUtf7.cpp
+++ b/sakura_core/charset/CUtf7.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CUtf7.h
+++ b/sakura_core/charset/CUtf7.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CUtf8.cpp
+++ b/sakura_core/charset/CUtf8.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CUtf8.h
+++ b/sakura_core/charset/CUtf8.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CharsetDetector.cpp
+++ b/sakura_core/charset/CharsetDetector.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/CharsetDetector.h
+++ b/sakura_core/charset/CharsetDetector.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/charset.cpp
+++ b/sakura_core/charset/charset.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2010, Uchi
 	Copyright (C) 2012, novice
 	Copyright (C) 2013, Moca, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/charset.h
+++ b/sakura_core/charset/charset.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/codechecker.cpp
+++ b/sakura_core/charset/codechecker.cpp
@@ -9,7 +9,7 @@
 /*
 	Copyright (C) 2006, D. S. Koba, genta
 	Copyright (C) 2007
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/codechecker.h
+++ b/sakura_core/charset/codechecker.h
@@ -10,7 +10,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2006, D. S. Koba, genta
 	Copyright (C) 2007
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/codeutil.cpp
+++ b/sakura_core/charset/codeutil.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/charset/codeutil.h
+++ b/sakura_core/charset/codeutil.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/cmd/CViewCommander.cpp
+++ b/sakura_core/cmd/CViewCommander.cpp
@@ -19,7 +19,7 @@
 	Copyright (C) 2010, ryoji
 	Copyright (C) 2011, ryoji, nasukoji
 	Copyright (C) 2012, Moca, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander.h
+++ b/sakura_core/cmd/CViewCommander.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/cmd/CViewCommander_Bookmark.cpp
+++ b/sakura_core/cmd/CViewCommander_Bookmark.cpp
@@ -8,7 +8,7 @@
 	Copyright (C) 2000-2001, genta
 	Copyright (C) 2002, hor, YAZAKI, MIK
 	Copyright (C) 2006, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Clipboard.cpp
+++ b/sakura_core/cmd/CViewCommander_Clipboard.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2005, genta
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2010, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Convert.cpp
+++ b/sakura_core/cmd/CViewCommander_Convert.cpp
@@ -8,7 +8,7 @@
 	Copyright (C) 2000-2001, jepro
 	Copyright (C) 2001, Stonee, Misaka
 	Copyright (C) 2002, ai
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2006, genta
 	Copyright (C) 2007, kobake, maru
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_CustMenu.cpp
+++ b/sakura_core/cmd/CViewCommander_CustMenu.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2007, ryoji, maru, Uchi
 	Copyright (C) 2008, ryoji, nasukoji
 	Copyright (C) 2009, ryoji, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Diff.cpp
+++ b/sakura_core/cmd/CViewCommander_Diff.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2007, kobake
 	Copyright (C) 2008, kobake
 	Copyright (C) 2008, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Edit.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2008, ryoji, nasukoji
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2010, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
@@ -18,7 +18,7 @@
 	Copyright (C) 2010, ryoji
 	Copyright (C) 2011, ryoji
 	Copyright (C) 2012, Moca, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
@@ -8,7 +8,7 @@
 	Copyright (C) 2003, かろと
 	Copyright (C) 2005, Moca
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2005, genta
 	Copyright (C) 2006, ryoji, maru
 	Copyright (C) 2007, ryoji, maru, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -7,7 +7,7 @@
 	Copyright (C) 2003, MIK
 	Copyright (C) 2005, genta
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Insert.cpp
+++ b/sakura_core/cmd/CViewCommander_Insert.cpp
@@ -6,7 +6,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2006, maru
 	Copyright (C) 2007, ryoji, genta
 	Copyright (C) 2008, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_ModeChange.cpp
+++ b/sakura_core/cmd/CViewCommander_ModeChange.cpp
@@ -8,7 +8,7 @@
 	Copyright (C) 2003, Moca
 	Copyright (C) 2005, genta
 	Copyright (C) 2007, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/cmd/CViewCommander_Outline.cpp
+++ b/sakura_core/cmd/CViewCommander_Outline.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2007, genta, kobake
 	Copyright (C) 2009, genta
 	Copyright (C) 2011, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Search.cpp
+++ b/sakura_core/cmd/CViewCommander_Search.cpp
@@ -16,7 +16,7 @@
 	Copyright (C) 2009, ryoji, genta
 	Copyright (C) 2010, ryoji
 	Copyright (C) 2011, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Select.cpp
+++ b/sakura_core/cmd/CViewCommander_Select.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, YAZAKI
 	Copyright (C) 2005, Moca
 	Copyright (C) 2007, kobake, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Settings.cpp
+++ b/sakura_core/cmd/CViewCommander_Settings.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2008, ryoji, nasukoji
 	Copyright (C) 2009, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Support.cpp
+++ b/sakura_core/cmd/CViewCommander_Support.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2007, kobake, ryoji
 	Copyright (C) 2011, Moca
 	Copyright (C) 2012, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -15,7 +15,7 @@
 	Copyright (C) 2007, ryoji, maru, Uchi
 	Copyright (C) 2008, MIK
 	Copyright (C) 2010, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_Window.cpp
+++ b/sakura_core/cmd/CViewCommander_Window.cpp
@@ -15,7 +15,7 @@
 	Copyright (C) 2008, syat
 	Copyright (C) 2009, syat
 	Copyright (C) 2010, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/cmd/CViewCommander_inline.h
+++ b/sakura_core/cmd/CViewCommander_inline.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2013, novice
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/config/app_constants.h
+++ b/sakura_core/config/app_constants.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/config/build_config.cpp
+++ b/sakura_core/config/build_config.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/config/build_config.h
+++ b/sakura_core/config/build_config.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/config/maxdata.h
+++ b/sakura_core/config/maxdata.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/config/system_constants.h
+++ b/sakura_core/config/system_constants.h
@@ -11,7 +11,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert.cpp
+++ b/sakura_core/convert/CConvert.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert.h
+++ b/sakura_core/convert/CConvert.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_CodeAutoToSjis.cpp
+++ b/sakura_core/convert/CConvert_CodeAutoToSjis.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_CodeAutoToSjis.h
+++ b/sakura_core/convert/CConvert_CodeAutoToSjis.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_CodeFromSjis.cpp
+++ b/sakura_core/convert/CConvert_CodeFromSjis.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_CodeFromSjis.h
+++ b/sakura_core/convert/CConvert_CodeFromSjis.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_CodeToSjis.cpp
+++ b/sakura_core/convert/CConvert_CodeToSjis.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_CodeToSjis.h
+++ b/sakura_core/convert/CConvert_CodeToSjis.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_HaneisuToZeneisu.cpp
+++ b/sakura_core/convert/CConvert_HaneisuToZeneisu.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_HaneisuToZeneisu.h
+++ b/sakura_core/convert/CConvert_HaneisuToZeneisu.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_HankataToZenhira.cpp
+++ b/sakura_core/convert/CConvert_HankataToZenhira.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_HankataToZenhira.h
+++ b/sakura_core/convert/CConvert_HankataToZenhira.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_HankataToZenkata.cpp
+++ b/sakura_core/convert/CConvert_HankataToZenkata.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_HankataToZenkata.h
+++ b/sakura_core/convert/CConvert_HankataToZenkata.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_SpaceToTab.cpp
+++ b/sakura_core/convert/CConvert_SpaceToTab.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_SpaceToTab.h
+++ b/sakura_core/convert/CConvert_SpaceToTab.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_TabToSpace.cpp
+++ b/sakura_core/convert/CConvert_TabToSpace.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_TabToSpace.h
+++ b/sakura_core/convert/CConvert_TabToSpace.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToHankaku.cpp
+++ b/sakura_core/convert/CConvert_ToHankaku.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToHankaku.h
+++ b/sakura_core/convert/CConvert_ToHankaku.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToLower.cpp
+++ b/sakura_core/convert/CConvert_ToLower.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToLower.h
+++ b/sakura_core/convert/CConvert_ToLower.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToUpper.cpp
+++ b/sakura_core/convert/CConvert_ToUpper.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToUpper.h
+++ b/sakura_core/convert/CConvert_ToUpper.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToZenhira.cpp
+++ b/sakura_core/convert/CConvert_ToZenhira.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToZenhira.h
+++ b/sakura_core/convert/CConvert_ToZenhira.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToZenkata.cpp
+++ b/sakura_core/convert/CConvert_ToZenkata.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ToZenkata.h
+++ b/sakura_core/convert/CConvert_ToZenkata.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_Trim.cpp
+++ b/sakura_core/convert/CConvert_Trim.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_Trim.h
+++ b/sakura_core/convert/CConvert_Trim.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ZeneisuToHaneisu.cpp
+++ b/sakura_core/convert/CConvert_ZeneisuToHaneisu.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ZeneisuToHaneisu.h
+++ b/sakura_core/convert/CConvert_ZeneisuToHaneisu.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ZenkataToHankata.cpp
+++ b/sakura_core/convert/CConvert_ZenkataToHankata.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CConvert_ZenkataToHankata.h
+++ b/sakura_core/convert/CConvert_ZenkataToHankata.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CDecode.h
+++ b/sakura_core/convert/CDecode.h
@@ -4,7 +4,7 @@
 	@author
 */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CDecode_Base64Decode.cpp
+++ b/sakura_core/convert/CDecode_Base64Decode.cpp
@@ -5,7 +5,7 @@
 */
 
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CDecode_Base64Decode.h
+++ b/sakura_core/convert/CDecode_Base64Decode.h
@@ -5,7 +5,7 @@
 */
 
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CDecode_UuDecode.cpp
+++ b/sakura_core/convert/CDecode_UuDecode.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/CDecode_UuDecode.h
+++ b/sakura_core/convert/CDecode_UuDecode.h
@@ -5,7 +5,7 @@
 */
 
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/convert_util.cpp
+++ b/sakura_core/convert/convert_util.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/convert_util.h
+++ b/sakura_core/convert/convert_util.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/convert_util2.cpp
+++ b/sakura_core/convert/convert_util2.cpp
@@ -5,7 +5,7 @@
 */
 
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/convert/convert_util2.h
+++ b/sakura_core/convert/convert_util2.h
@@ -5,7 +5,7 @@
 */
 
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/debug/CRunningTimer.cpp
+++ b/sakura_core/debug/CRunningTimer.cpp
@@ -9,7 +9,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/debug/CRunningTimer.h
+++ b/sakura_core/debug/CRunningTimer.h
@@ -9,7 +9,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/debug/Debug1.cpp
+++ b/sakura_core/debug/Debug1.cpp
@@ -10,7 +10,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, aroka
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/debug/Debug1.h
+++ b/sakura_core/debug/Debug1.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/debug/Debug2.cpp
+++ b/sakura_core/debug/Debug2.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/debug/Debug2.h
+++ b/sakura_core/debug/Debug2.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/debug/Debug3.cpp
+++ b/sakura_core/debug/Debug3.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/debug/Debug3.h
+++ b/sakura_core/debug/Debug3.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2011, nasukoji
 	Copyright (C) 2012, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -11,7 +11,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2011, nasukoji
 	Copyright (C) 2012, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2004, Moca
 	Copyright (C) 2005, genta
 	Copyright (C) 2006, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgAbout.h
+++ b/sakura_core/dlg/CDlgAbout.h
@@ -8,7 +8,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2000, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgCancel.cpp
+++ b/sakura_core/dlg/CDlgCancel.cpp
@@ -6,7 +6,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2008, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgCancel.h
+++ b/sakura_core/dlg/CDlgCancel.h
@@ -8,7 +8,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2008, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2003, MIK
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgCompare.h
+++ b/sakura_core/dlg/CDlgCompare.h
@@ -6,7 +6,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2000, jepro
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgCtrlCode.cpp
+++ b/sakura_core/dlg/CDlgCtrlCode.cpp
@@ -8,7 +8,7 @@
 	Copyright (C) 2002-2003, MIK
 	Copyright (C) 2006, ryoji
 +	Copyright (C) 2011, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgCtrlCode.h
+++ b/sakura_core/dlg/CDlgCtrlCode.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2002, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, MIK, genta, じゅうじ
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgDiff.h
+++ b/sakura_core/dlg/CDlgDiff.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, MIK
 	Copyright (C) 2004, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, maru
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgExec.h
+++ b/sakura_core/dlg/CDlgExec.h
@@ -7,7 +7,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -8,7 +8,7 @@
 	Copyright (C) 2003, MIK
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2010, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgFavorite.h
+++ b/sakura_core/dlg/CDlgFavorite.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2003, MIK
 	Copyright (C) 2010, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgFileUpdateQuery.cpp
+++ b/sakura_core/dlg/CDlgFileUpdateQuery.cpp
@@ -8,7 +8,7 @@
 */
 /*
 	Copyright (C) 2002, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgFileUpdateQuery.h
+++ b/sakura_core/dlg/CDlgFileUpdateQuery.h
@@ -8,7 +8,7 @@
 */
 /*
 	Copyright (C) 2002, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgFind.cpp
+++ b/sakura_core/dlg/CDlgFind.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2012, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgFind.h
+++ b/sakura_core/dlg/CDlgFind.h
@@ -8,7 +8,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2010, ryoji
 	Copyright (C) 2012, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -8,7 +8,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2010, ryoji
 	Copyright (C) 2014, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -8,7 +8,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, Moca
 	Copyright (C) 2014, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgInput1.cpp
+++ b/sakura_core/dlg/CDlgInput1.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, MIK
 	Copyright (C) 2003, KEITA
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgInput1.h
+++ b/sakura_core/dlg/CDlgInput1.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgJump.cpp
+++ b/sakura_core/dlg/CDlgJump.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2002, aroka, MIK, YAZAKI
 	Copyright (C) 2004, genta
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgJump.h
+++ b/sakura_core/dlg/CDlgJump.h
@@ -9,7 +9,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2000, jepro
 	Copyright (C) 2002, YAZAKI
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgOpenFile.cpp
+++ b/sakura_core/dlg/CDlgOpenFile.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, novice, ryoji
 	Copyright (C) 2006, ryoji, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgOpenFile.h
+++ b/sakura_core/dlg/CDlgOpenFile.h
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, genta, MIK
 	Copyright (C) 2005, ryoji
 	Copyright (C) 2006, Moca, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, novice, ryoji
 	Copyright (C) 2006, ryoji, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, novice, ryoji
 	Copyright (C) 2006, ryoji, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgPluginOption.cpp
+++ b/sakura_core/dlg/CDlgPluginOption.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgPluginOption.h
+++ b/sakura_core/dlg/CDlgPluginOption.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2002, MIK, aroka, YAZAKI
 	Copyright (C) 2003, かろと
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgPrintSetting.h
+++ b/sakura_core/dlg/CDlgPrintSetting.h
@@ -6,7 +6,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2013, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgProfileMgr.h
+++ b/sakura_core/dlg/CDlgProfileMgr.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2013, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgProperty.cpp
+++ b/sakura_core/dlg/CDlgProperty.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2002, Moca, MIK, YAZAKI
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgProperty.h
+++ b/sakura_core/dlg/CDlgProperty.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgReplace.cpp
+++ b/sakura_core/dlg/CDlgReplace.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2012, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgReplace.h
+++ b/sakura_core/dlg/CDlgReplace.h
@@ -10,7 +10,7 @@
 	Copyright (C) 2002, hor
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgSetCharSet.cpp
+++ b/sakura_core/dlg/CDlgSetCharSet.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgSetCharSet.h
+++ b/sakura_core/dlg/CDlgSetCharSet.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2005, MIK
 	Copyright (C) 2006, genta, ryoji
 	Copyright (C) 2010, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -8,7 +8,7 @@
 	Copyright (C) 2003, MIK
 	Copyright (C) 2005, MIK
 	Copyright (C) 2010, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2003, MIK
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgTagsMake.h
+++ b/sakura_core/dlg/CDlgTagsMake.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2003, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgWinSize.cpp
+++ b/sakura_core/dlg/CDlgWinSize.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2004, genta, Moca
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgWinSize.h
+++ b/sakura_core/dlg/CDlgWinSize.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2004, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2015, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/dlg/CDlgWindowList.h
+++ b/sakura_core/dlg/CDlgWindowList.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2015, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CBlockComment.cpp
+++ b/sakura_core/doc/CBlockComment.cpp
@@ -8,7 +8,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI, Moca
 	Copyright (C) 2005, D.S.Koba
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/CBlockComment.h
+++ b/sakura_core/doc/CBlockComment.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, Yazaki
 	Copyright (C) 2005, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocEditor.h
+++ b/sakura_core/doc/CDocEditor.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocFile.cpp
+++ b/sakura_core/doc/CDocFile.cpp
@@ -2,7 +2,7 @@
 /*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocFile.h
+++ b/sakura_core/doc/CDocFile.h
@@ -2,7 +2,7 @@
 /*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocFileOperation.h
+++ b/sakura_core/doc/CDocFileOperation.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocListener.cpp
+++ b/sakura_core/doc/CDocListener.cpp
@@ -10,7 +10,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocListener.h
+++ b/sakura_core/doc/CDocListener.h
@@ -11,7 +11,7 @@
 /*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocLocker.cpp
+++ b/sakura_core/doc/CDocLocker.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocLocker.h
+++ b/sakura_core/doc/CDocLocker.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocOutline.cpp
+++ b/sakura_core/doc/CDocOutline.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2002, frozen
 	Copyright (C) 2003, zenryaku
 	Copyright (C) 2005, genta, D.S.Koba, じゅうじ
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/doc/CDocOutline.h
+++ b/sakura_core/doc/CDocOutline.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocReader.cpp
+++ b/sakura_core/doc/CDocReader.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocReader.h
+++ b/sakura_core/doc/CDocReader.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocType.cpp
+++ b/sakura_core/doc/CDocType.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocType.h
+++ b/sakura_core/doc/CDocType.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocTypeSetting.cpp
+++ b/sakura_core/doc/CDocTypeSetting.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocTypeSetting.h
+++ b/sakura_core/doc/CDocTypeSetting.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocVisitor.cpp
+++ b/sakura_core/doc/CDocVisitor.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CDocVisitor.h
+++ b/sakura_core/doc/CDocVisitor.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -18,7 +18,7 @@
 	Copyright (C) 2009, nasukoji
 	Copyright (C) 2011, ryoji
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CEditDoc.h
+++ b/sakura_core/doc/CEditDoc.h
@@ -15,7 +15,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji, maru
 	Copyright (C) 2008, ryoji, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/CLineComment.cpp
+++ b/sakura_core/doc/CLineComment.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, Yazaki, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/CLineComment.h
+++ b/sakura_core/doc/CLineComment.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2002, Yazaki
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/layout/CLayout.cpp
+++ b/sakura_core/doc/layout/CLayout.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/layout/CLayout.h
+++ b/sakura_core/doc/layout/CLayout.h
@@ -8,7 +8,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI, aroka
 	Copyright (C) 2009, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/layout/CLayoutExInfo.h
+++ b/sakura_core/doc/layout/CLayoutExInfo.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2011, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/layout/CLayoutMgr.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2004, genta, Moca
 	Copyright (C) 2005, D.S.Koba, Moca
 	Copyright (C) 2009, ryoji, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -14,7 +14,7 @@
 	Copyright (C) 2003, genta
 	Copyright (C) 2005, Moca, genta, D.S.Koba
 	Copyright (C) 2009, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2004, Moca, genta
 	Copyright (C) 2005, D.S.Koba, Moca
 	Copyright (C) 2009, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/layout/CLayoutMgr_New2.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New2.cpp
@@ -7,7 +7,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, MIK, aroka
 	Copyright (C) 2009, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/layout/CTsvModeInfo.cpp
+++ b/sakura_core/doc/layout/CTsvModeInfo.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2015, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/layout/CTsvModeInfo.h
+++ b/sakura_core/doc/layout/CTsvModeInfo.h
@@ -3,7 +3,7 @@
 */
 /*
 	Copyright (C) 2015, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/doc/logic/CDocLine.cpp
+++ b/sakura_core/doc/logic/CDocLine.cpp
@@ -7,7 +7,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2001, hor, genta
 	Copyright (C) 2002, MIK, YAZAKI
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -10,7 +10,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2001, hor
 	Copyright (C) 2002, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/logic/CDocLineMgr.cpp
+++ b/sakura_core/doc/logic/CDocLineMgr.cpp
@@ -15,7 +15,7 @@
 	Copyright (C) 2003, Moca, ryoji, genta, かろと
 	Copyright (C) 2004, genta, Moca
 	Copyright (C) 2005, D.S.Koba, ryoji, かろと
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/doc/logic/CDocLineMgr.h
+++ b/sakura_core/doc/logic/CDocLineMgr.h
@@ -12,7 +12,7 @@
 	Copyright (C) 2001, hor, genta
 	Copyright (C) 2002, aroka, MIK, hor
 	Copyright (C) 2003, Moca, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/docplus/CBookmarkManager.cpp
+++ b/sakura_core/docplus/CBookmarkManager.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/docplus/CBookmarkManager.h
+++ b/sakura_core/docplus/CBookmarkManager.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/docplus/CDiffManager.cpp
+++ b/sakura_core/docplus/CDiffManager.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/docplus/CDiffManager.h
+++ b/sakura_core/docplus/CDiffManager.h
@@ -3,7 +3,7 @@
 //2008.02.23 kobake 大整理
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/docplus/CFuncListManager.cpp
+++ b/sakura_core/docplus/CFuncListManager.cpp
@@ -2,7 +2,7 @@
 /*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2014, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/docplus/CFuncListManager.h
+++ b/sakura_core/docplus/CFuncListManager.h
@@ -2,7 +2,7 @@
 /*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2014, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/docplus/CModifyManager.cpp
+++ b/sakura_core/docplus/CModifyManager.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/docplus/CModifyManager.h
+++ b/sakura_core/docplus/CModifyManager.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CAppNodeManager.cpp
+++ b/sakura_core/env/CAppNodeManager.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2011, syat
 	Copyright (C) 2012, syat, Uchi
 	Copyright (C) 2013, Moca, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CDocTypeManager.h
+++ b/sakura_core/env/CDocTypeManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CFileNameManager.cpp
+++ b/sakura_core/env/CFileNameManager.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CFileNameManager.h
+++ b/sakura_core/env/CFileNameManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CFormatManager.cpp
+++ b/sakura_core/env/CFormatManager.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CFormatManager.h
+++ b/sakura_core/env/CFormatManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CHelpManager.cpp
+++ b/sakura_core/env/CHelpManager.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CHelpManager.h
+++ b/sakura_core/env/CHelpManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -2,7 +2,7 @@
 /*
 	Copyright (C) 2008, kobake, ryoji
 	Copyright (C) 2012, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CSakuraEnvironment.h
+++ b/sakura_core/env/CSakuraEnvironment.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CSearchKeywordManager.cpp
+++ b/sakura_core/env/CSearchKeywordManager.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CSearchKeywordManager.h
+++ b/sakura_core/env/CSearchKeywordManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -18,7 +18,7 @@
 	Copyright (C) 2009, nasukoji, ryoji
 	Copyright (C) 2011, nasukoji
 	Copyright (C) 2012, Moca, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/env/CShareData.h
+++ b/sakura_core/env/CShareData.h
@@ -16,7 +16,7 @@
 	Copyright (C) 2007, ryoji, maru
 	Copyright (C) 2008, ryoji, Uchi
 	Copyright (C) 2011, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -2,7 +2,7 @@
 //2008.XX.XX kobake CShareDataから分離
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CShareData_IO.h
+++ b/sakura_core/env/CShareData_IO.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CTagJumpManager.cpp
+++ b/sakura_core/env/CTagJumpManager.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CTagJumpManager.h
+++ b/sakura_core/env/CTagJumpManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CommonSetting.cpp
+++ b/sakura_core/env/CommonSetting.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/CommonSetting.h
+++ b/sakura_core/env/CommonSetting.h
@@ -2,7 +2,7 @@
 //2007.09.28 kobake Common整理
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/DLLSHAREDATA.cpp
+++ b/sakura_core/env/DLLSHAREDATA.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/env/DLLSHAREDATA.h
+++ b/sakura_core/env/DLLSHAREDATA.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CBregexp.cpp
+++ b/sakura_core/extmodule/CBregexp.cpp
@@ -17,7 +17,7 @@
 	Copyright (C) 2005, かろと
 	Copyright (C) 2006, かろと
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CBregexp.h
+++ b/sakura_core/extmodule/CBregexp.h
@@ -17,7 +17,7 @@
 	Copyright (C) 2005, かろと, aroka
 	Copyright (C) 2006, かろと
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CBregexpDll2.cpp
+++ b/sakura_core/extmodule/CBregexpDll2.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CBregexpDll2.h
+++ b/sakura_core/extmodule/CBregexpDll2.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CDllHandler.cpp
+++ b/sakura_core/extmodule/CDllHandler.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2001, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CDllHandler.h
+++ b/sakura_core/extmodule/CDllHandler.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2001, genta
 	Copyright (C) 2002, YAZAKI, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CHtmlHelp.cpp
+++ b/sakura_core/extmodule/CHtmlHelp.cpp
@@ -8,7 +8,7 @@
 */
 /*
 	Copyright (C) 2001, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CHtmlHelp.h
+++ b/sakura_core/extmodule/CHtmlHelp.h
@@ -8,7 +8,7 @@
 */
 /*
 	Copyright (C) 2001, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CIcu4cI18n.cpp
+++ b/sakura_core/extmodule/CIcu4cI18n.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CIcu4cI18n.h
+++ b/sakura_core/extmodule/CIcu4cI18n.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CMigemo.cpp
+++ b/sakura_core/extmodule/CMigemo.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, miau
 	Copyright (C) 2012, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/extmodule/CMigemo.h
+++ b/sakura_core/extmodule/CMigemo.h
@@ -10,7 +10,7 @@
 	Copyright (C) 2004, isearch
 	Copyright (C) 2005, aroka
 	Copyright (C) 2009, miau
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/extmodule/CUchardet.cpp
+++ b/sakura_core/extmodule/CUchardet.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CUchardet.h
+++ b/sakura_core/extmodule/CUchardet.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CUxTheme.cpp
+++ b/sakura_core/extmodule/CUxTheme.cpp
@@ -8,7 +8,7 @@
 */
 /*
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/extmodule/CUxTheme.h
+++ b/sakura_core/extmodule/CUxTheme.h
@@ -8,7 +8,7 @@
 */
 /*
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/func/CFuncKeyWnd.cpp
+++ b/sakura_core/func/CFuncKeyWnd.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2006, aroka, ryoji
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/func/CFuncKeyWnd.h
+++ b/sakura_core/func/CFuncKeyWnd.h
@@ -8,7 +8,7 @@
 	Copyright (C) 2002, YAZAKI, aroka
 	Copyright (C) 2006, aroka
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/func/CFuncLookup.cpp
+++ b/sakura_core/func/CFuncLookup.cpp
@@ -10,7 +10,7 @@
 /*
 	Copyright (C) 2001, genta
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/func/CFuncLookup.h
+++ b/sakura_core/func/CFuncLookup.h
@@ -10,7 +10,7 @@
 	Copyright (C) 2001, genta
 	Copyright (C) 2002, aroka
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2002, YAZAKI, aroka
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2008, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/func/CKeyBind.h
+++ b/sakura_core/func/CKeyBind.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/func/Funccode.cpp
+++ b/sakura_core/func/Funccode.cpp
@@ -15,7 +15,7 @@
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2008, nasukoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/func/Funccode.h
+++ b/sakura_core/func/Funccode.h
@@ -13,7 +13,7 @@
 	Copyright (C) 2005, genta, MIK, maru
 	Copyright (C) 2006, aroka, かろと, fon, ryoji
 	Copyright (C) 2007, ryoji, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CBinaryStream.cpp
+++ b/sakura_core/io/CBinaryStream.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CBinaryStream.h
+++ b/sakura_core/io/CBinaryStream.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CFile.cpp
+++ b/sakura_core/io/CFile.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CFile.h
+++ b/sakura_core/io/CFile.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CFileLoad.cpp
+++ b/sakura_core/io/CFileLoad.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, Moca, genta
 	Copyright (C) 2003, Moca, ryoji
 	Copyright (C) 2006, rastiv
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CFileLoad.h
+++ b/sakura_core/io/CFileLoad.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, Moca, genta
 	Copyright (C) 2003, Moca, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CIoBridge.cpp
+++ b/sakura_core/io/CIoBridge.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CIoBridge.h
+++ b/sakura_core/io/CIoBridge.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CStream.cpp
+++ b/sakura_core/io/CStream.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CStream.h
+++ b/sakura_core/io/CStream.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CTextStream.cpp
+++ b/sakura_core/io/CTextStream.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CTextStream.h
+++ b/sakura_core/io/CTextStream.h
@@ -8,7 +8,7 @@
 //将来はUTF-8等にすることにより、UNICODEデータの欠落が起こらないようにしたい。
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CZipFile.cpp
+++ b/sakura_core/io/CZipFile.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2011, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/io/CZipFile.h
+++ b/sakura_core/io/CZipFile.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2011, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CCookieManager.cpp
+++ b/sakura_core/macro/CCookieManager.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2012, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CCookieManager.h
+++ b/sakura_core/macro/CCookieManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2012, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CEditorIfObj.cpp
+++ b/sakura_core/macro/CEditorIfObj.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CEditorIfObj.h
+++ b/sakura_core/macro/CEditorIfObj.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CIfObj.cpp
+++ b/sakura_core/macro/CIfObj.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, FILE, zenryaku
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CIfObj.h
+++ b/sakura_core/macro/CIfObj.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, 鬼, genta
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CKeyMacroMgr.cpp
+++ b/sakura_core/macro/CKeyMacroMgr.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2001, aroka
 	Copyright (C) 2002, YAZAKI, aroka, genta
 	Copyright (C) 2004, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/macro/CKeyMacroMgr.h
+++ b/sakura_core/macro/CKeyMacroMgr.h
@@ -7,7 +7,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2001, aroka
 	Copyright (C) 2002, YAZAKI, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -16,7 +16,7 @@
 	Copyright (C) 2008, nasukoji, ryoji
 	Copyright (C) 2009, ryoji, nasukoji
 	Copyright (C) 2011, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CMacro.h
+++ b/sakura_core/macro/CMacro.h
@@ -9,7 +9,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI
 	Copyright (C) 2003, 鬼
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CMacroFactory.cpp
+++ b/sakura_core/macro/CMacroFactory.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, genta
 	Copyright (C) 2004, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CMacroFactory.h
+++ b/sakura_core/macro/CMacroFactory.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, genta
 	Copyright (C) 2004, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CMacroManagerBase.cpp
+++ b/sakura_core/macro/CMacroManagerBase.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2002, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CMacroManagerBase.h
+++ b/sakura_core/macro/CMacroManagerBase.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2002, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CPPA.cpp
+++ b/sakura_core/macro/CPPA.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2001, YAZAKI
 	Copyright (C) 2002, YAZAKI, aroka, genta, Moca
 	Copyright (C) 2003, Moca, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CPPA.h
+++ b/sakura_core/macro/CPPA.h
@@ -10,7 +10,7 @@
 	Copyright (C) 2001, YAZAKI, genta
 	Copyright (C) 2002, YAZAKI, Moca
 	Copyright (C) 2003, genta, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CPPAMacroMgr.cpp
+++ b/sakura_core/macro/CPPAMacroMgr.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, YAZAKI, genta
 	Copyright (C) 2004, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/macro/CPPAMacroMgr.h
+++ b/sakura_core/macro/CPPAMacroMgr.h
@@ -8,7 +8,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2001, aroka
 	Copyright (C) 2002, YAZAKI, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -18,7 +18,7 @@
 	Copyright (C) 2007, ryoji, maru
 	Copyright (C) 2008, nasukoji, ryoji
 	Copyright (C) 2011, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/macro/CSMacroMgr.h
+++ b/sakura_core/macro/CSMacroMgr.h
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, YAZAKI, genta
 	Copyright (C) 2005, FILE
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CWSH.cpp
+++ b/sakura_core/macro/CWSH.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, FILE, zenryaku
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CWSH.h
+++ b/sakura_core/macro/CWSH.h
@@ -10,7 +10,7 @@
 /*
 	Copyright (C) 2002, 鬼, genta
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/macro/CWSHIfObj.cpp
+++ b/sakura_core/macro/CWSHIfObj.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, FILE, zenryaku
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CWSHIfObj.h
+++ b/sakura_core/macro/CWSHIfObj.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, 鬼, genta
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CWSHManager.cpp
+++ b/sakura_core/macro/CWSHManager.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, FILE, zenryaku
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/macro/CWSHManager.h
+++ b/sakura_core/macro/CWSHManager.h
@@ -13,7 +13,7 @@
 */
 /*
 	Copyright (C) 2002, 鬼, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2003, genta, Moca, かろと
 	Copyright (C) 2004, Moca
 	Copyright (C) 2005, Moca, D.S.Koba
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -9,7 +9,7 @@
 	Copyright (C) 2001, jepro, Stonee
 	Copyright (C) 2002, Moca, genta, aroka
 	Copyright (C) 2005, D.S.Koba
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CMemoryIterator.h
+++ b/sakura_core/mem/CMemoryIterator.h
@@ -8,7 +8,7 @@
 	Copyright (C) 2002, Yazaki
 	Copyright (C) 2003, genta
 	Copyright (C) 2005, D.S.Koba
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/mem/CNative.cpp
+++ b/sakura_core/mem/CNative.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CNative.h
+++ b/sakura_core/mem/CNative.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CNativeA.cpp
+++ b/sakura_core/mem/CNativeA.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CNativeA.h
+++ b/sakura_core/mem/CNativeA.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CPoolResource.h
+++ b/sakura_core/mem/CPoolResource.h
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CRecycledBuffer.cpp
+++ b/sakura_core/mem/CRecycledBuffer.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mem/CRecycledBuffer.h
+++ b/sakura_core/mem/CRecycledBuffer.h
@@ -5,7 +5,7 @@
 //取得したメモリブロックはCRecycledBufferの管理下にあるため、解放してはいけない。
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mfclike/CMyWnd.cpp
+++ b/sakura_core/mfclike/CMyWnd.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/mfclike/CMyWnd.h
+++ b/sakura_core/mfclike/CMyWnd.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2010, Uchi
 	Copyright (C) 2014, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/outline/CDlgFileTree.h
+++ b/sakura_core/outline/CDlgFileTree.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2014, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -17,7 +17,7 @@
 	Copyright (C) 2006, genta, ryoji
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2010, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -13,7 +13,7 @@
 	Copyright (C) 2005, genta
 	Copyright (C) 2006, aroka
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/outline/CFuncInfo.cpp
+++ b/sakura_core/outline/CFuncInfo.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/outline/CFuncInfo.h
+++ b/sakura_core/outline/CFuncInfo.h
@@ -8,7 +8,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI
 	Copyright (C) 2003, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/outline/CFuncInfoArr.cpp
+++ b/sakura_core/outline/CFuncInfoArr.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI, aroka
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/outline/CFuncInfoArr.h
+++ b/sakura_core/outline/CFuncInfoArr.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, YAZAKI
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/parse/CWordParse.cpp
+++ b/sakura_core/parse/CWordParse.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/parse/CWordParse.h
+++ b/sakura_core/parse/CWordParse.h
@@ -2,7 +2,7 @@
 //2007.09.30 kobake CDocLineMgr から分離
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CComplementIfObj.h
+++ b/sakura_core/plugin/CComplementIfObj.h
@@ -5,7 +5,7 @@
 /*
 	Copyright (C) 2009, syat
 	Copyright (C) 2011, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CDllPlugin.cpp
+++ b/sakura_core/plugin/CDllPlugin.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CDllPlugin.h
+++ b/sakura_core/plugin/CDllPlugin.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CJackManager.cpp
+++ b/sakura_core/plugin/CJackManager.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CJackManager.h
+++ b/sakura_core/plugin/CJackManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/COutlineIfObj.h
+++ b/sakura_core/plugin/COutlineIfObj.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CPlugin.cpp
+++ b/sakura_core/plugin/CPlugin.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CPlugin.h
+++ b/sakura_core/plugin/CPlugin.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CPluginIfObj.h
+++ b/sakura_core/plugin/CPluginIfObj.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CPluginManager.cpp
+++ b/sakura_core/plugin/CPluginManager.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CPluginManager.h
+++ b/sakura_core/plugin/CPluginManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CSmartIndentIfObj.h
+++ b/sakura_core/plugin/CSmartIndentIfObj.h
@@ -5,7 +5,7 @@
 /*
 	Copyright (C) 2009, syat
 	Copyright (C) 2010, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CWSHPlugin.cpp
+++ b/sakura_core/plugin/CWSHPlugin.cpp
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/plugin/CWSHPlugin.h
+++ b/sakura_core/plugin/CWSHPlugin.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/print/CPrint.cpp
+++ b/sakura_core/print/CPrint.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2001, hor
 	Copyright (C) 2002, MIK
 	Copyright (C) 2003, かろと
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/print/CPrint.h
+++ b/sakura_core/print/CPrint.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2003, かろと
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2008, nasukoji
 	Copyright (C) 2012, ossan (ossan@ongs.net)
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/print/CPrintPreview.h
+++ b/sakura_core/print/CPrintPreview.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, YAZAKI
 	Copyright (C) 2003, かろと
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/prop/CPropComBackup.cpp
+++ b/sakura_core/prop/CPropComBackup.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/prop/CPropComEdit.cpp
+++ b/sakura_core/prop/CPropComEdit.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2003, KEITA
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, genta, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/prop/CPropComFile.cpp
+++ b/sakura_core/prop/CPropComFile.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, YAZAKI, MIK, aroka, hor
 	Copyright (C) 2004, genta, ryoji
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/prop/CPropComFileName.cpp
+++ b/sakura_core/prop/CPropComFileName.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2003, Moca, KEITA
 	Copyright (C) 2004, D.S.Koba
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/prop/CPropComFormat.cpp
+++ b/sakura_core/prop/CPropComFormat.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2002, YAZAKI, MIK, aroka
 	Copyright (C) 2003, KEITA
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/prop/CPropComGeneral.cpp
+++ b/sakura_core/prop/CPropComGeneral.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/prop/CPropComGrep.cpp
+++ b/sakura_core/prop/CPropComGrep.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, YAZAKI, MIK
 	Copyright (C) 2003, KEITA
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/prop/CPropComHelper.cpp
+++ b/sakura_core/prop/CPropComHelper.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2012, Moca
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/prop/CPropComKeyword.cpp
+++ b/sakura_core/prop/CPropComKeyword.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/prop/CPropComMacro.cpp
+++ b/sakura_core/prop/CPropComMacro.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -5,7 +5,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -5,7 +5,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/prop/CPropComStatusbar.cpp
+++ b/sakura_core/prop/CPropComStatusbar.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, genta
 	Copyright (C) 2007, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/prop/CPropComTab.cpp
+++ b/sakura_core/prop/CPropComTab.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2007, genta, ryoji
 	Copyright (C) 2012, Moca
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2005, aroka
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/prop/CPropComWin.cpp
+++ b/sakura_core/prop/CPropComWin.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, Moca
 	Copyright (C) 2006, ryoji, fon
 	Copyright (C) 2007, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -15,7 +15,7 @@
 	Copyright (C) 2009, nasukoji
 	Copyright (C) 2010, Uchi
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/prop/CPropCommon.h
+++ b/sakura_core/prop/CPropCommon.h
@@ -14,7 +14,7 @@
 	Copyright (C) 2007, genta, ryoji
 	Copyright (C) 2010, Uchi
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CMRUFile.cpp
+++ b/sakura_core/recent/CMRUFile.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2002, YAZAKI, Moca, genta
 	Copyright (C) 2003, MIK
 	Copyright (C) 2006, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/recent/CMRUFile.h
+++ b/sakura_core/recent/CMRUFile.h
@@ -10,7 +10,7 @@
 	Copyright (C) 2002, YAZAKI, aroka
 	Copyright (C) 2003, MIK
 	Copyright (C) 2004, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CMRUFolder.cpp
+++ b/sakura_core/recent/CMRUFolder.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2001, YAZAKI
 	Copyright (C) 2002, YAZAKI, Moca, genta
 	Copyright (C) 2003, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/recent/CMRUFolder.h
+++ b/sakura_core/recent/CMRUFolder.h
@@ -9,7 +9,7 @@
 	Copyright (C) 2000, jepro
 	Copyright (C) 2002, YAZAKI, aroka
 	Copyright (C) 2003, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CMruListener.cpp
+++ b/sakura_core/recent/CMruListener.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CMruListener.h
+++ b/sakura_core/recent/CMruListener.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecent.cpp
+++ b/sakura_core/recent/CRecent.cpp
@@ -11,7 +11,7 @@
 /*
 	Copyright (C) 2003, MIK
 	Copyright (C) 2005, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecent.h
+++ b/sakura_core/recent/CRecent.h
@@ -12,7 +12,7 @@
 /*
 	Copyright (C) 2003, MIK
 	Copyright (C) 2005, MIK
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentCmd.cpp
+++ b/sakura_core/recent/CRecentCmd.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentCmd.h
+++ b/sakura_core/recent/CRecentCmd.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentCurDir.cpp
+++ b/sakura_core/recent/CRecentCurDir.cpp
@@ -2,7 +2,7 @@
 /*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2013, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentCurDir.h
+++ b/sakura_core/recent/CRecentCurDir.h
@@ -2,7 +2,7 @@
 /*
 	Copyright (C) 2008, kobake
 	Copyright (C) 2013, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentEditNode.cpp
+++ b/sakura_core/recent/CRecentEditNode.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentEditNode.h
+++ b/sakura_core/recent/CRecentEditNode.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExceptMru.cpp
+++ b/sakura_core/recent/CRecentExceptMru.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExceptMru.h
+++ b/sakura_core/recent/CRecentExceptMru.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFile.cpp
+++ b/sakura_core/recent/CRecentExcludeFile.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file
 
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFile.h
+++ b/sakura_core/recent/CRecentExcludeFile.h
@@ -1,6 +1,6 @@
 ﻿/*! @file
 
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFolder.cpp
+++ b/sakura_core/recent/CRecentExcludeFolder.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file
 
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentExcludeFolder.h
+++ b/sakura_core/recent/CRecentExcludeFolder.h
@@ -1,6 +1,6 @@
 ﻿/*! @file
 
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentFile.cpp
+++ b/sakura_core/recent/CRecentFile.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentFile.h
+++ b/sakura_core/recent/CRecentFile.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentFolder.cpp
+++ b/sakura_core/recent/CRecentFolder.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentFolder.h
+++ b/sakura_core/recent/CRecentFolder.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentGrepFile.cpp
+++ b/sakura_core/recent/CRecentGrepFile.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentGrepFile.h
+++ b/sakura_core/recent/CRecentGrepFile.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentGrepFolder.cpp
+++ b/sakura_core/recent/CRecentGrepFolder.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentGrepFolder.h
+++ b/sakura_core/recent/CRecentGrepFolder.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentImp.cpp
+++ b/sakura_core/recent/CRecentImp.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentImp.h
+++ b/sakura_core/recent/CRecentImp.h
@@ -2,7 +2,7 @@
 // 各CRecent実装クラスのベースクラス
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentReplace.cpp
+++ b/sakura_core/recent/CRecentReplace.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentReplace.h
+++ b/sakura_core/recent/CRecentReplace.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentSearch.cpp
+++ b/sakura_core/recent/CRecentSearch.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentSearch.h
+++ b/sakura_core/recent/CRecentSearch.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentTagjumpKeyword.cpp
+++ b/sakura_core/recent/CRecentTagjumpKeyword.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/CRecentTagjumpKeyword.h
+++ b/sakura_core/recent/CRecentTagjumpKeyword.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/recent/SShare_History.h
+++ b/sakura_core/recent/SShare_History.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/sakura_rc.rc2
+++ b/sakura_core/sakura_rc.rc2
@@ -27,7 +27,7 @@
 #define _GSTR_APPNAME  _APP_NAME_1 _APP_NAME_2 _APP_NAME_3 _APP_NAME_4
 #endif
 
-#define	S_COPYRIGHT	"Copyright (C) 1998-2021  by Norio Nakatani & Collaborators"
+#define	S_COPYRIGHT	"Copyright (C) 1998-2022  by Norio Nakatani & Collaborators"
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/sakura_core/typeprop/CDlgKeywordSelect.cpp
+++ b/sakura_core/typeprop/CDlgKeywordSelect.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2005, MIK
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/typeprop/CDlgKeywordSelect.h
+++ b/sakura_core/typeprop/CDlgKeywordSelect.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2005, MIK, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/typeprop/CDlgSameColor.cpp
+++ b/sakura_core/typeprop/CDlgSameColor.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/typeprop/CDlgSameColor.h
+++ b/sakura_core/typeprop/CDlgSameColor.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/typeprop/CDlgTypeAscertain.cpp
+++ b/sakura_core/typeprop/CDlgTypeAscertain.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/typeprop/CDlgTypeAscertain.h
+++ b/sakura_core/typeprop/CDlgTypeAscertain.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2002, MIK
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2010, Uchi, Beta.Ito, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/typeprop/CDlgTypeList.h
+++ b/sakura_core/typeprop/CDlgTypeList.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/typeprop/CImpExpManager.h
+++ b/sakura_core/typeprop/CImpExpManager.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2010, Uchi, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -16,7 +16,7 @@
 	Copyright (C) 2008, nasukoji
 	Copyright (C) 2009, ryoji, genta
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/typeprop/CPropTypes.h
+++ b/sakura_core/typeprop/CPropTypes.h
@@ -13,7 +13,7 @@
 	Copyright (C) 2005, MIK, aroka, genta
 	Copyright (C) 2006, fon
 	Copyright (C) 2010, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -15,7 +15,7 @@
 	Copyright (C) 2007, ryoji, genta
 	Copyright (C) 2008, nasukoji
 	Copyright (C) 2009, ryoji, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/typeprop/CPropTypesKeyHelp.cpp
+++ b/sakura_core/typeprop/CPropTypesKeyHelp.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2006, fon, ryoji
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/typeprop/CPropTypesRegex.cpp
+++ b/sakura_core/typeprop/CPropTypesRegex.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, MIK
 	Copyright (C) 2003, MIK, KEITA
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/typeprop/CPropTypesScreen.cpp
+++ b/sakura_core/typeprop/CPropTypesScreen.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2007, ryoji, genta
 	Copyright (C) 2008, nasukoji
 	Copyright (C) 2009, ryoji, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/typeprop/CPropTypesSupport.cpp
+++ b/sakura_core/typeprop/CPropTypesSupport.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2007, ryoji, genta
 	Copyright (C) 2008, nasukoji
 	Copyright (C) 2009, ryoji, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/typeprop/CPropTypesWindow.cpp
+++ b/sakura_core/typeprop/CPropTypesWindow.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType.h
+++ b/sakura_core/types/CType.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CTypeSupport.cpp
+++ b/sakura_core/types/CTypeSupport.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CTypeSupport.h
+++ b/sakura_core/types/CTypeSupport.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Asm.cpp
+++ b/sakura_core/types/CType_Asm.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Awk.cpp
+++ b/sakura_core/types/CType_Awk.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Basis.cpp
+++ b/sakura_core/types/CType_Basis.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Cobol.cpp
+++ b/sakura_core/types/CType_Cobol.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_CorbaIdl.cpp
+++ b/sakura_core/types/CType_CorbaIdl.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Dos.cpp
+++ b/sakura_core/types/CType_Dos.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Erlang.cpp
+++ b/sakura_core/types/CType_Erlang.cpp
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 2009, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Html.cpp
+++ b/sakura_core/types/CType_Html.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Ini.cpp
+++ b/sakura_core/types/CType_Ini.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Java.cpp
+++ b/sakura_core/types/CType_Java.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Others.cpp
+++ b/sakura_core/types/CType_Others.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Pascal.cpp
+++ b/sakura_core/types/CType_Pascal.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Perl.cpp
+++ b/sakura_core/types/CType_Perl.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Python.cpp
+++ b/sakura_core/types/CType_Python.cpp
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2007, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Rich.cpp
+++ b/sakura_core/types/CType_Rich.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Sql.cpp
+++ b/sakura_core/types/CType_Sql.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Tex.cpp
+++ b/sakura_core/types/CType_Tex.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Text.cpp
+++ b/sakura_core/types/CType_Text.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/types/CType_Vb.cpp
+++ b/sakura_core/types/CType_Vb.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/uiparts/CGraphics.cpp
+++ b/sakura_core/uiparts/CGraphics.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/uiparts/CGraphics.h
+++ b/sakura_core/uiparts/CGraphics.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/uiparts/CImageListMgr.cpp
+++ b/sakura_core/uiparts/CImageListMgr.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2003, Moca, genta, wmlhq
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2010, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/uiparts/CImageListMgr.h
+++ b/sakura_core/uiparts/CImageListMgr.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2000-2003, genta
 	Copyright (C) 2003, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/uiparts/CMenuDrawer.cpp
+++ b/sakura_core/uiparts/CMenuDrawer.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2006, aroka, fon
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2008, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/uiparts/CMenuDrawer.h
+++ b/sakura_core/uiparts/CMenuDrawer.h
@@ -10,7 +10,7 @@
 	Copyright (C) 2003, MIK
 	Copyright (C) 2005, aroka, genta
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/uiparts/CSoundSet.cpp
+++ b/sakura_core/uiparts/CSoundSet.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/uiparts/CSoundSet.h
+++ b/sakura_core/uiparts/CSoundSet.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/uiparts/CVisualProgress.cpp
+++ b/sakura_core/uiparts/CVisualProgress.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/uiparts/CVisualProgress.h
+++ b/sakura_core/uiparts/CVisualProgress.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/uiparts/CWaitCursor.cpp
+++ b/sakura_core/uiparts/CWaitCursor.cpp
@@ -5,7 +5,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/uiparts/CWaitCursor.h
+++ b/sakura_core/uiparts/CWaitCursor.h
@@ -6,7 +6,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, aroka
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/uiparts/HandCursor.h
+++ b/sakura_core/uiparts/HandCursor.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/MessageBoxF.cpp
+++ b/sakura_core/util/MessageBoxF.cpp
@@ -9,7 +9,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, aroka
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/MessageBoxF.h
+++ b/sakura_core/util/MessageBoxF.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/RegKey.h
+++ b/sakura_core/util/RegKey.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/container.h
+++ b/sakura_core/util/container.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -7,7 +7,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -2,7 +2,7 @@
 	Copyright (C) 2002, SUI
 	Copyright (C) 2003, MIK
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -2,7 +2,7 @@
 /*
 	Copyright (C) 2002, SUI
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/format.cpp
+++ b/sakura_core/util/format.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/format.h
+++ b/sakura_core/util/format.h
@@ -2,7 +2,7 @@
 // 2007.10.20 kobake 書式関連
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/input.cpp
+++ b/sakura_core/util/input.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/input.h
+++ b/sakura_core/util/input.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/module.cpp
+++ b/sakura_core/util/module.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/module.h
+++ b/sakura_core/util/module.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/ole_convert.cpp
+++ b/sakura_core/util/ole_convert.cpp
@@ -3,7 +3,7 @@
 
 */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/ole_convert.h
+++ b/sakura_core/util/ole_convert.h
@@ -3,7 +3,7 @@
 
 */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/relation_tool.cpp
+++ b/sakura_core/util/relation_tool.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/relation_tool.h
+++ b/sakura_core/util/relation_tool.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/shell.h
+++ b/sakura_core/util/shell.h
@@ -3,7 +3,7 @@
 // なんかシェルっぽい機能の関数群
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/std_macro.h
+++ b/sakura_core/util/std_macro.h
@@ -2,7 +2,7 @@
 //2007.10.18 kobake 作成
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/string_ex2.cpp
+++ b/sakura_core/util/string_ex2.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/string_ex2.h
+++ b/sakura_core/util/string_ex2.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/tchar_convert.cpp
+++ b/sakura_core/util/tchar_convert.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/tchar_convert.h
+++ b/sakura_core/util/tchar_convert.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/tchar_template.cpp
+++ b/sakura_core/util/tchar_template.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/tchar_template.h
+++ b/sakura_core/util/tchar_template.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/zoom.cpp
+++ b/sakura_core/util/zoom.cpp
@@ -2,7 +2,7 @@
 	@brief ズーム倍率算出
 */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/util/zoom.h
+++ b/sakura_core/util/zoom.h
@@ -2,7 +2,7 @@
 	@brief ズーム倍率算出
 */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/version.h
+++ b/sakura_core/version.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2011, Moca, syat
 	Copyright (C) 2012, ryoji, Moca
 	Copyright (C) 2013, Moca, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CCaret.h
+++ b/sakura_core/view/CCaret.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -17,7 +17,7 @@
 	Copyright (C) 2007, ryoji, じゅうじ, maru
 	Copyright (C) 2009, nasukoji, ryoji
 	Copyright (C) 2010, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -16,7 +16,7 @@
 	Copyright (C) 2007, ryoji, maru
 	Copyright (C) 2008, ryoji
 	Copyright (C) 2009, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CEditView_CmdHokan.cpp
+++ b/sakura_core/view/CEditView_CmdHokan.cpp
@@ -11,7 +11,7 @@
 	Copyright (C) 2003, Moca
 	Copyright (C) 2004, Moca
 	Copyright (C) 2005, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/view/CEditView_Cmdgrep.cpp
+++ b/sakura_core/view/CEditView_Cmdgrep.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2003, MIK
 	Copyright (C) 2005, genta
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/view/CEditView_Cmdisrch.cpp
+++ b/sakura_core/view/CEditView_Cmdisrch.cpp
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2004, isearch
 	Copyright (C) 2005, genta, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2006, genta, Moca, fon
 	Copyright (C) 2007, ryoji, maru
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/view/CEditView_Diff.cpp
+++ b/sakura_core/view/CEditView_Diff.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2005, maru
 	Copyright (C) 2007, ryoji, kobake
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CEditView_ExecCmd.cpp
+++ b/sakura_core/view/CEditView_ExecCmd.cpp
@@ -15,7 +15,7 @@
 	Copyright (C) 2005, genta, MIK, novice, aroka, D.S.Koba, かろと, Moca
 	Copyright (C) 2006, Moca, aroka, ryoji, fon, genta
 	Copyright (C) 2007, ryoji, じゅうじ, maru
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -15,7 +15,7 @@
 	Copyright (C) 2005, genta, MIK, novice, aroka, D.S.Koba, かろと, Moca
 	Copyright (C) 2006, Moca, aroka, ryoji, fon, genta
 	Copyright (C) 2007, ryoji, じゅうじ, maru
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -15,7 +15,7 @@
 	Copyright (C) 2005, genta, MIK, novice, aroka, D.S.Koba, かろと, Moca
 	Copyright (C) 2006, Moca, aroka, ryoji, fon, genta
 	Copyright (C) 2007, ryoji, じゅうじ, maru
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CEditView_Paint.h
+++ b/sakura_core/view/CEditView_Paint.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CEditView_Paint_Bracket.cpp
+++ b/sakura_core/view/CEditView_Paint_Bracket.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -18,7 +18,7 @@
 	Copyright (C) 2009, nasukoji
 	Copyright (C) 2010, Moca
 	Copyright (C) 2012, ryoji, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/view/CEditView_Search.cpp
+++ b/sakura_core/view/CEditView_Search.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CMiniMapView.cpp
+++ b/sakura_core/view/CMiniMapView.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2012, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CMiniMapView.h
+++ b/sakura_core/view/CMiniMapView.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2012, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CRuler.cpp
+++ b/sakura_core/view/CRuler.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CRuler.h
+++ b/sakura_core/view/CRuler.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CTextArea.cpp
+++ b/sakura_core/view/CTextArea.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CTextArea.h
+++ b/sakura_core/view/CTextArea.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CTextDrawer.cpp
+++ b/sakura_core/view/CTextDrawer.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CTextDrawer.h
+++ b/sakura_core/view/CTextDrawer.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CTextMetrics.cpp
+++ b/sakura_core/view/CTextMetrics.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CTextMetrics.h
+++ b/sakura_core/view/CTextMetrics.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2007, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CViewCalc.cpp
+++ b/sakura_core/view/CViewCalc.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CViewCalc.h
+++ b/sakura_core/view/CViewCalc.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CViewFont.cpp
+++ b/sakura_core/view/CViewFont.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CViewFont.h
+++ b/sakura_core/view/CViewFont.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CViewParser.cpp
+++ b/sakura_core/view/CViewParser.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CViewParser.h
+++ b/sakura_core/view/CViewParser.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CViewSelect.cpp
+++ b/sakura_core/view/CViewSelect.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/CViewSelect.h
+++ b/sakura_core/view/CViewSelect.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/DispPos.cpp
+++ b/sakura_core/view/DispPos.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/DispPos.h
+++ b/sakura_core/view/DispPos.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColorStrategy.cpp
+++ b/sakura_core/view/colors/CColorStrategy.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Comment.cpp
+++ b/sakura_core/view/colors/CColor_Comment.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Comment.h
+++ b/sakura_core/view/colors/CColor_Comment.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Found.cpp
+++ b/sakura_core/view/colors/CColor_Found.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Found.h
+++ b/sakura_core/view/colors/CColor_Found.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Heredoc.cpp
+++ b/sakura_core/view/colors/CColor_Heredoc.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2011, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Heredoc.h
+++ b/sakura_core/view/colors/CColor_Heredoc.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2011, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_KeywordSet.cpp
+++ b/sakura_core/view/colors/CColor_KeywordSet.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_KeywordSet.h
+++ b/sakura_core/view/colors/CColor_KeywordSet.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Numeric.cpp
+++ b/sakura_core/view/colors/CColor_Numeric.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Numeric.h
+++ b/sakura_core/view/colors/CColor_Numeric.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Quote.cpp
+++ b/sakura_core/view/colors/CColor_Quote.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Quote.h
+++ b/sakura_core/view/colors/CColor_Quote.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_RegexKeyword.cpp
+++ b/sakura_core/view/colors/CColor_RegexKeyword.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_RegexKeyword.h
+++ b/sakura_core/view/colors/CColor_RegexKeyword.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Url.cpp
+++ b/sakura_core/view/colors/CColor_Url.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/CColor_Url.h
+++ b/sakura_core/view/colors/CColor_Url.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/colors/EColorIndexType.h
+++ b/sakura_core/view/colors/EColorIndexType.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigureManager.cpp
+++ b/sakura_core/view/figures/CFigureManager.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigureManager.h
+++ b/sakura_core/view/figures/CFigureManager.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigureStrategy.cpp
+++ b/sakura_core/view/figures/CFigureStrategy.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigureStrategy.h
+++ b/sakura_core/view/figures/CFigureStrategy.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_Comma.cpp
+++ b/sakura_core/view/figures/CFigure_Comma.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_Comma.h
+++ b/sakura_core/view/figures/CFigure_Comma.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2015, syat
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_CtrlCode.cpp
+++ b/sakura_core/view/figures/CFigure_CtrlCode.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_CtrlCode.h
+++ b/sakura_core/view/figures/CFigure_CtrlCode.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_Eol.cpp
+++ b/sakura_core/view/figures/CFigure_Eol.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_Eol.h
+++ b/sakura_core/view/figures/CFigure_Eol.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_HanSpace.cpp
+++ b/sakura_core/view/figures/CFigure_HanSpace.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_HanSpace.h
+++ b/sakura_core/view/figures/CFigure_HanSpace.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_Tab.cpp
+++ b/sakura_core/view/figures/CFigure_Tab.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_Tab.h
+++ b/sakura_core/view/figures/CFigure_Tab.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_ZenSpace.cpp
+++ b/sakura_core/view/figures/CFigure_ZenSpace.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/view/figures/CFigure_ZenSpace.h
+++ b/sakura_core/view/figures/CFigure_ZenSpace.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CAutoScrollWnd.cpp
+++ b/sakura_core/window/CAutoScrollWnd.cpp
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2012, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CAutoScrollWnd.h
+++ b/sakura_core/window/CAutoScrollWnd.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2012, Moca
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -18,7 +18,7 @@
 	Copyright (C) 2010, ryoji, Moca、Uchi
 	Copyright (C) 2011, ryoji
 	Copyright (C) 2013, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -17,7 +17,7 @@
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2008, ryoji
 	Copyright (C) 2009, nasukoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CMainStatusBar.h
+++ b/sakura_core/window/CMainStatusBar.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -4,7 +4,7 @@
 	Copyright (C) 2008, kobake
 	Copyright (C) 2010, Uchi, Moca
 	Copyright (C) 2012, aroka, Uchi
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CMainToolBar.h
+++ b/sakura_core/window/CMainToolBar.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CSplitBoxWnd.cpp
+++ b/sakura_core/window/CSplitBoxWnd.cpp
@@ -8,7 +8,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, aroka
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/window/CSplitBoxWnd.h
+++ b/sakura_core/window/CSplitBoxWnd.h
@@ -6,7 +6,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, aroka
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/window/CSplitterWnd.cpp
+++ b/sakura_core/window/CSplitterWnd.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2002, aroka, YAZAKI
 	Copyright (C) 2003, MIK
 	Copyright (C) 2007, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/window/CSplitterWnd.h
+++ b/sakura_core/window/CSplitterWnd.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, aroka, YAZAKI
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2009, ryoji
 	Copyright (C) 2012, Moca, syat, novice, uchi
 	Copyright (C) 2013, Moca, Uchi, aroka, novice, syat, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -12,7 +12,7 @@
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2012, Moca, syat
 	Copyright (C) 2013, Uchi, aroka, novice, syat, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -10,7 +10,7 @@
 	Copyright (C) 2002, GAE
 	Copyright (C) 2005, D.S.Koba
 	Copyright (C) 2006, ryoji, genta
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -9,7 +9,7 @@
 	Copyright (C) 2001, asa-o
 	Copyright (C) 2002, aroka
 	Copyright (C) 2006, genta, fon
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/window/CWnd.cpp
+++ b/sakura_core/window/CWnd.cpp
@@ -9,7 +9,7 @@
 	Copyright (C) 2000, genta
 	Copyright (C) 2003, MIK, KEITA
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_core/window/CWnd.h
+++ b/sakura_core/window/CWnd.h
@@ -9,7 +9,7 @@
 	Copyright (C) 2002, aroka
 	Copyright (C) 2003, MIK
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.

--- a/sakura_lang_en_US/sakura_lang_rc.rc2
+++ b/sakura_lang_en_US/sakura_lang_rc.rc2
@@ -27,8 +27,8 @@
 #define _GSTR_APPNAME  _APP_NAME_1 _APP_NAME_2 _APP_NAME_3 _APP_NAME_4
 #endif
 
-#define	S_COPYRIGHT				"Copyright (C) 1998-2021  by Norio Nakatani & Collaborators"
-#define	S_COPYRIGHT_TRANSLATION	"Copyright (C) 2011-2021  by Lucien & Collaborators"
+#define	S_COPYRIGHT				"Copyright (C) 1998-2022  by Norio Nakatani & Collaborators"
+#define	S_COPYRIGHT_TRANSLATION	"Copyright (C) 2011-2022  by Lucien & Collaborators"
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/tests/compiletests/clayoutint_test.cpp.in
+++ b/tests/compiletests/clayoutint_test.cpp.in
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/StartEditorProcessForTest.h
+++ b/tests/unittests/StartEditorProcessForTest.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/code-main.cpp
+++ b/tests/unittests/code-main.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/coverage.cpp
+++ b/tests/unittests/coverage.cpp
@@ -1,6 +1,6 @@
 /*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-StdControl.cpp
+++ b/tests/unittests/test-StdControl.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cclipboard.cpp
+++ b/tests/unittests/test-cclipboard.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021 Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-ccodebase.cpp
+++ b/tests/unittests/test-ccodebase.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-ccommandline.cpp
+++ b/tests/unittests/test-ccommandline.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cconvert.cpp
+++ b/tests/unittests/test-cconvert.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cdecode.cpp
+++ b/tests/unittests/test-cdecode.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cdlgopenfile.cpp
+++ b/tests/unittests/test-cdlgopenfile.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cdlgprofilemgr.cpp
+++ b/tests/unittests/test-cdlgprofilemgr.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cdocline.cpp
+++ b/tests/unittests/test-cdocline.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cdoclinemgr.cpp
+++ b/tests/unittests/test-cdoclinemgr.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cdoctypemanager.cpp
+++ b/tests/unittests/test-cdoctypemanager.cpp
@@ -1,5 +1,5 @@
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-ceol.cpp
+++ b/tests/unittests/test-ceol.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cerrorinfo.cpp
+++ b/tests/unittests/test-cerrorinfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cfileext.cpp
+++ b/tests/unittests/test-cfileext.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-charcode.cpp
+++ b/tests/unittests/test-charcode.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-clayoutint.cpp
+++ b/tests/unittests/test-clayoutint.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cmemory.cpp
+++ b/tests/unittests/test-cmemory.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cnative.cpp
+++ b/tests/unittests/test-cnative.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cprofile.cpp
+++ b/tests/unittests/test-cprofile.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-crunningtimer.cpp
+++ b/tests/unittests/test-crunningtimer.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-csakuraenvironment.cpp
+++ b/tests/unittests/test-csakuraenvironment.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-csearchagent.cpp
+++ b/tests/unittests/test-csearchagent.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-ctextmetrics.cpp
+++ b/tests/unittests/test-ctextmetrics.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-cwordparse.cpp
+++ b/tests/unittests/test-cwordparse.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-czipfile.cpp
+++ b/tests/unittests/test-czipfile.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021 Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-design_template.cpp
+++ b/tests/unittests/test-design_template.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021 Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-editinfo.cpp
+++ b/tests/unittests/test-editinfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-file.cpp
+++ b/tests/unittests/test-file.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-format.cpp
+++ b/tests/unittests/test-format.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-grepinfo.cpp
+++ b/tests/unittests/test-grepinfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-int2dec.cpp
+++ b/tests/unittests/test-int2dec.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-is_mailaddress.cpp
+++ b/tests/unittests/test-is_mailaddress.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-loadstring.cpp
+++ b/tests/unittests/test-loadstring.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-mydevmode.cpp
+++ b/tests/unittests/test-mydevmode.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-parameterized.cpp
+++ b/tests/unittests/test-parameterized.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-printECodeType.cpp
+++ b/tests/unittests/test-printECodeType.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-printEFunctionCode.cpp
+++ b/tests/unittests/test-printEFunctionCode.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-sample-disabled.cpp
+++ b/tests/unittests/test-sample-disabled.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-sample.cpp
+++ b/tests/unittests/test-sample.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-ssearchoption.cpp
+++ b/tests/unittests/test-ssearchoption.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-statictype.cpp
+++ b/tests/unittests/test-statictype.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021 Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-string_ex.cpp
+++ b/tests/unittests/test-string_ex.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-winmain.cpp
+++ b/tests/unittests/test-winmain.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2021, Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tests/unittests/test-zoom.cpp
+++ b/tests/unittests/test-zoom.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2021, Sakura Editor Organization
+	Copyright (C) 2021-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter.Test/EncoderEscapingFallbackTest.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter.Test/EncoderEscapingFallbackTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2020 Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverterApp.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverterApp.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2020 Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter/EncoderEscapingFallback.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/EncoderEscapingFallback.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2020 Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter/EncoderEscapingFallbackBuffer.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/EncoderEscapingFallbackBuffer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2020 Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter/FileContents.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/FileContents.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2020 Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter/LineEnumerator.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/LineEnumerator.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2020 Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ChmSourceConverter/ChmSourceConverter/Program.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/Program.cs
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2018-2020 Sakura Editor Organization
+	Copyright (C) 2018-2022, Sakura Editor Organization
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/Bmp.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+	Copyright (C) 2020-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/tools/ToolBarTools/ToolBarImageCommon/ReadWriteStructWithAllocGCHandle.cs
+++ b/tools/ToolBarTools/ToolBarImageCommon/ReadWriteStructWithAllocGCHandle.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+	Copyright (C) 2020-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Text;

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpFileComparer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpFileComparer.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+	Copyright (C) 2020-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/BmpMuxer.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+	Copyright (C) 2020-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageMuxer/Program.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+	Copyright (C) 2020-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/BmpSplitter.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+	Copyright (C) 2020-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tools/ToolBarTools/ToolBarImageSplitter/Program.cs
+++ b/tools/ToolBarTools/ToolBarImageSplitter/Program.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+	Copyright (C) 2020-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tools/macro/CopyDirPath/CopyDirPath.js
+++ b/tools/macro/CopyDirPath/CopyDirPath.js
@@ -1,6 +1,6 @@
 ﻿// MIT License
 // 
-// Copyright (c) 2018 Sakura Editor Organization
+// Copyright (C) 2018-2022, Sakura Editor Organization
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/tools/macro/CopyDirPath/CopyDirPath.mac
+++ b/tools/macro/CopyDirPath/CopyDirPath.mac
@@ -1,6 +1,6 @@
 ﻿// MIT License
 // 
-// Copyright (c) 2018 Sakura Editor Organization
+// Copyright (C) 2018-2022, Sakura Editor Organization
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/tools/macro/CopyDirPath/CopyDirPath.vbs
+++ b/tools/macro/CopyDirPath/CopyDirPath.vbs
@@ -1,6 +1,6 @@
 ﻿' MIT License
 ' 
-' Copyright (c) 2018 Sakura Editor Organization
+' Copyright (C) 2018-2022, Sakura Editor Organization
 ' 
 ' Permission is hereby granted, free of charge, to any person obtaining a copy
 ' of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

毎年実施しているコピーライト表記の更新を行います。

## <!-- 必須 --> カテゴリ

- その他の問題

## <!-- 自明なら省略可 --> PR の背景

## <!-- 自明なら省略可 --> PR のメリット

- バージョン情報ダイアログのコピーライト表示が最新になります。
- すべてのC#ソースコードにコピーライト表記が入ります。
  - 今回限りの対応です。以降は「ファイルを更新するとき」に行います。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

昨年（ #1549 ）に示された編集方針の通りに作業を実施しました。

<details>
<summary>前回示された方針</summary>

> ### Copyright 更新対象
>
> 年次更新の必要があるファイルは以下です。
> - LICENSE
> - sakura_core/sakura_rc.rc2
> - sakura_lang_en_US/sakura_lang_rc.rc2
>
> ### C++ソースのCopyrightに関してのルール
>
> 背景で説明している通り、更新年の更新は必須ではありません。
> 今後、新規追加やパッチ取込の際に基準にできるようルールを書き出しておきます。
>
> #### 今後新規に追加するファイル
>
> ```Copyright (C) 2021, Sakura Editor Organization```
>
> #### 上記以外（2020年以前から存在していたファイルの場合）
>
> (既存のCopyright表記の最後に以下を追加)
>
> ```Copyright (C) 2018-2021, Sakura Editor Organization```
>
</details>

なお、その方針の補足情報を[このコメント](https://github.com/sakura-editor/sakura/pull/1786#issuecomment-1030540393)でまとめています。

今回対象としたファイルの内訳は以下の通りです。
- ライセンスファイル`./LICENSE`: 1
- コピーライト表記が存在するソースファイル: 763
  - ダイアログリソースファイル`*.rc2`: 2
  - C++ソースファイル`*.cpp`: 425
  - C#ソースファイル`*.cs`: 7
  - C++ヘッダーファイル`*.h`: 327
  - C++ヘッダーファイル`*.hpp`: 1
  - C++ソーステンプレートファイル`*.in`: 1
- コピーライト表記が存在しないので、今回追加したソースファイル: 7
  - C#ソースファイル`*.cs`: 7
- コピーライト表記が存在するマクロのソースファイル: 3
  - JavaScriptソースファイル`*.js`: 1
  - キーワードマクロファイル`*.mac`: 1
  - VBScriptソースファイル`*.vbs`: 1

<details>
<summary>注：PR本文はレビュー指摘への対応により大幅に改稿されました（クリックして以前の説明文を表示）。</summary>

<del>このPRでは、毎年更新するものに加えて2021年に**全く新たに**追加されたファイルのうち、上記ルールと一致していないファイルに対する表記の修正を含んでいます。対象は次のファイルです。
<del>- ./sakura_core/extmodule/CUchardet.cpp
<del>- ./sakura_core/extmodule/CUchardet.h
<del>- ./tests/unittests/test-cdlgopenfile.cpp
<del>- ./tests/unittests/test-cfileext.cpp
<del>- ./tests/unittests/test-crunningtimer.cpp
<del>
<del>また、C#ソースファイルにはコピーライト表記があるものとないものが混在しているので、今回ないものに対して追記します。
<del>ただ、これらのソースファイルはサクラエディタ本体のソースファイルに比べて更新頻度が低いことが予想されることから、各ファイルがリポジトリにコミットされた年を権利発生年とみなしてその年だけを表記するようにし、今後表記の更新をしなくても済むようにします。
</details>

## <!-- わかる範囲で --> PR の影響範囲

- Gitで管理されている上記拡張子のソースファイル
- バージョン情報ダイアログの表示内容

## <!-- 必須 --> テスト内容

- バージョン情報ダイアログに変更が反映されていることを確認してください。

## <!-- なければ省略可 --> 関連 issue, PR

- #232 … 2018年
- #761 … 2019年
- #1154 … 2020年
- #1549 … 2021年

## <!-- なければ省略可 --> 参考資料

[Copyright(コピーライト：著作権表示)の正しい書き方を知っていますか？：webサイト制作 - webデザイン初心者｜sometimes study](https://serinaishii.hatenablog.com/entry/2015/09/30/Copyright(コピーライト：著作権表示)の正しい書き方を)
