### PR TITLE
ブランチ名に関わらずAZP/GHAが実行されるようにする

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -4,9 +4,6 @@ name: build sakura
 # events but only for the master branch
 on:
   push:
-    branches:
-      - master
-      - feature/*
     paths-ignore:
       - '**/*.md'
       - .gitignore
@@ -16,10 +13,6 @@ on:
       - 'ci/azure-pipelines/template*.yml'
 
   pull_request:
-    branches:
-      - master
-      - feature/*
-      - release/*
     paths-ignore:
       - '**/*.md'
       - .gitignore

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,12 +4,6 @@
 #   https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&viewFallbackFrom=vsts&tabs=yaml
 ###############################################################################################################################
 trigger:
-  branches:
-    include:
-      - master
-      - develop
-      - feature/*
-      - revert-*
   paths:
     exclude:
       - .github/*
@@ -45,12 +39,6 @@ trigger:
 #   https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#pull-request-validation
 ###############################################################################################################################
 pr:
-  branches:
-    include:
-      - master
-      - develop
-      - feature/*
-      - revert-*
   paths:
     exclude:
       - .github/*


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

実行対象ブランチの名称に関わらずCIが実行されるようにします。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - Azure Pipelines
  - GitHub Actions

## <!-- 自明なら省略可 --> PR の背景

サクラエディタが利用しているCIのうち、Azure PipelinesとGitHub Actionsでは、あらかじめ想定されるパターンに合致する名称のブランチに対してのみジョブが実行されます。
しかし、この方法ではブランチにつけられる名前に制限が課されるため、自由に名前を付けられず不便です。

過去には想定外のブランチ名でPRが出されたことがあり、それらのPRは事前の確認が不十分な可能性があります。

## <!-- 自明なら省略可 --> PR のメリット

- ブランチ名に関わらず常にすべてのCIが実行されるようになるので、確実にビルド成否を確認できます。
- ブランチ名に利用できる命名パターンの制約がなくなり、自由に名前をつけられるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

イベントトリガーの条件欄からブランチ名の記述を削除します。

## <!-- わかる範囲で --> PR の影響範囲

- Azure Pipelines
- GitHub Actions
  - GHA上でSonarCloudを実行するジョブは影響を受けません。

## <!-- 必須 --> テスト内容

- このブランチから派生した想定外の名前のブランチを作成し、remoteにpushしてCIが実行されることを確認します。

## <!-- なければ省略可 --> 関連 issue, PR
※このPRは #1787 から分割されたものです。

## <!-- なければ省略可 --> 参考資料
