### PR TITLE
ワークフローを手動で実行できるようにする

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -3,6 +3,8 @@ name: build sakura
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - master

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -4,7 +4,6 @@ name: build sakura
 # events but only for the master branch
 on:
   workflow_dispatch:
-
   push:
     branches:
       - master
@@ -16,7 +15,6 @@ on:
       - appveyor.yml
       - 'azure-pipelines*.yml'
       - 'ci/azure-pipelines/template*.yml'
-
   pull_request:
     branches:
       - master

--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -3,6 +3,7 @@ name: SonarCloud
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
       - '**/*.md'


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

GitHub Actionsワークフローを手動で実行できるようにします。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - GitHub Actions

## <!-- 自明なら省略可 --> PR の背景

一時的なネットワークトラブルなどの外的要因でCIの実行に失敗することがあります。
こういう時にAppVeyorやAzure Pipelinesでは手動で再実行することができますが、GitHub Actionsではできません。

幸い、2020年7月に`workflow_dispatch`イベントとして手動トリガーが実装されているので、ワークフローをこのイベントに対応させて手動実行できるようにしたいです。

## <!-- 自明なら省略可 --> PR のメリット

何らかの要因でワークフローが失敗したとき、任意のタイミングで再実行できるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

`workflow_dispatch`イベントに対応させます。
デフォルトブランチのワークフロー設定ファイルにこのイベントへの対応があると、[ワークフローの実行一覧ページ](https://github.com/sakura-editor/sakura/actions)に「Run workflow」ボタンが表示されて手動実行できるようになります。
なお、このイベントではパス例外は指定できません。
また、デフォルトブランチ以外は当該ブランチのワークフロー設定でイベントに対応している必要があります。

## <!-- わかる範囲で --> PR の影響範囲

- GitHub Actions で実行されるすべてのジョブ

## <!-- 必須 --> テスト内容

PR前にこのブランチをデフォルトブランチに設定して、ボタンが表示され手動実行できることを確認済みです。
https://github.com/kazasaku/sakura/actions/runs/1801203191
https://github.com/kazasaku/sakura/actions/runs/1801203384

## <!-- なければ省略可 --> 関連 issue, PR

#1787 

## <!-- なければ省略可 --> 参考資料

2020-07-06付: [GitHub Actions: Manual triggers with workflow_dispatch | GitHub Changelog](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
[Manually running a workflow - GitHub Docs](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)