### PR TITLE
アーカイブ展開を必要な場合のみに限定する（バラコミットver）

### DIFF
--- a/sakura/ExtractArchives.targets
+++ b/sakura/ExtractArchives.targets
@@ -1,18 +1,24 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="ExtractBregOnig" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer\externals\bregonig\bron420.zip" Outputs="$(OutDir)\bregonig.dll">
-    <Exec Command="7z e &quot;$(SolutionDir)installer\externals\bregonig\bron420.zip&quot; -o$(OutDir) -y x64/bregonig.dll" Condition="'$(Platform)' == 'x64'" />
-    <Exec Command="7z e &quot;$(SolutionDir)installer\externals\bregonig\bron420.zip&quot; -o$(OutDir) -y bregonig.dll" Condition="'$(Platform)' == 'Win32'" />
+  <PropertyGroup Label="ExtractArchives">
+    <BregOnigArchive>$(SolutionDir)installer\externals\bregonig\bron420.zip</BregOnigArchive>
+    <BregOnigInternalPath Condition="'$(Platform)' == 'x64'"  >x64/bregonig.dll</BregOnigInternalPath>
+    <BregOnigInternalPath Condition="'$(Platform)' == 'Win32'">bregonig.dll</BregOnigInternalPath>
+    <BregOnigOutPath>$(OutDir)bregonig.dll</BregOnigOutPath>
+    <CtagsArchive Condition="'$(Platform)' == 'x64'"  >$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x64.zip</CtagsArchive>
+    <CtagsArchive Condition="'$(Platform)' == 'Win32'">$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip</CtagsArchive>
+    <CtagsInternalPath>ctags.exe</CtagsInternalPath>
+    <CtagsOutPath>$(OutDir)ctags.exe</CtagsOutPath>
+  </PropertyGroup>
+  <Target Name="ExtractBregOnig" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(BregOnigArchive)" Outputs="$(BregOnigOutPath)">
+    <Exec Command="7z e &quot;$(BregOnigArchive)&quot; -o$(OutDir) -y $(BregOnigInternalPath)" />
   </Target>
-  <Target Name="ExtractCtags" Condition="'$(Platform)' == 'x64'" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x64.zip" Outputs="$(OutDir)\ctags.exe">
-    <Exec Command="7z e &quot;$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x64.zip&quot; -o$(OutDir) -y ctags.exe" />
-  </Target>
-  <Target Name="ExtractCtags" Condition="'$(Platform)' == 'Win32'" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip" Outputs="$(OutDir)\ctags.exe">
-    <Exec Command="7z e &quot;$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip&quot; -o$(OutDir) -y ctags.exe" />
+  <Target Name="ExtractCtags" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(CtagsArchive)" Outputs="$(CtagsOutPath)">
+    <Exec Command="7z e &quot;$(CtagsArchive)&quot; -o$(OutDir) -y $(CtagsInternalPath)" />
   </Target>
   <Target Name="AppendCleanTargetsForExtractedFiles" BeforeTargets="CoreClean">
     <ItemGroup>
-      <Clean Include="$(OutDir)bregonig.dll" />
-      <Clean Include="$(OutDir)ctags.exe" />
+      <Clean Include="$(BregOnigOutPath)" />
+      <Clean Include="$(CtagsOutPath)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/sakura/ExtractArchives.targets
+++ b/sakura/ExtractArchives.targets
@@ -9,11 +9,46 @@
     <CtagsInternalPath>ctags.exe</CtagsInternalPath>
     <CtagsOutPath>$(OutDir)ctags.exe</CtagsOutPath>
   </PropertyGroup>
-  <Target Name="ExtractBregOnig" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(BregOnigArchive)" Outputs="$(BregOnigOutPath)">
-    <Exec Command="7z e &quot;$(BregOnigArchive)&quot; -o$(OutDir) -y $(BregOnigInternalPath)" />
+  <UsingTask TaskName="ExtractArchive" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <ArchivePath ParameterType="Microsoft.Build.Framework.ITaskItem" Required="true" />
+      <Output ParameterType="Microsoft.Build.Framework.ITaskItem" Required="true" />
+      <InternalPath Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Diagnostics" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+Process p;
+string args;
+
+ProcessStartInfo psInfo = new ProcessStartInfo();
+psInfo.CreateNoWindow = true;
+psInfo.UseShellExecute = false;
+psInfo.RedirectStandardOutput = true;
+
+args = "7z e \"" + ArchivePath.ToString() + "\" -o\"" + Path.GetDirectoryName(Output.ToString()) + "\" -y " + InternalPath;
+psInfo.FileName = "cmd";
+psInfo.Arguments = "/c " + args;
+
+Log.LogMessage(MessageImportance.Normal, args);
+p = Process.Start(psInfo);
+
+Log.LogMessage(MessageImportance.Low, p.StandardOutput.ReadToEnd());
+]]></Code>
+    </Task>
+  </UsingTask>
+  <Target Name="ExtractBregOnig" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus">
+    <ExtractArchive
+      ArchivePath="$(BregOnigArchive)"
+      InternalPath="$(BregOnigInternalPath)"
+      Output="$(BregOnigOutPath)" />
   </Target>
-  <Target Name="ExtractCtags" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(CtagsArchive)" Outputs="$(CtagsOutPath)">
-    <Exec Command="7z e &quot;$(CtagsArchive)&quot; -o$(OutDir) -y $(CtagsInternalPath)" />
+  <Target Name="ExtractCtags" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus">
+    <ExtractArchive
+      ArchivePath="$(CtagsArchive)"
+      InternalPath="$(CtagsInternalPath)"
+      Output="$(CtagsOutPath)" />
   </Target>
   <Target Name="AppendCleanTargetsForExtractedFiles" BeforeTargets="CoreClean">
     <ItemGroup>

--- a/sakura/ExtractArchives.targets
+++ b/sakura/ExtractArchives.targets
@@ -27,14 +27,47 @@ psInfo.CreateNoWindow = true;
 psInfo.UseShellExecute = false;
 psInfo.RedirectStandardOutput = true;
 
-args = "7z e \"" + ArchivePath.ToString() + "\" -o\"" + Path.GetDirectoryName(Output.ToString()) + "\" -y " + InternalPath;
-psInfo.FileName = "cmd";
-psInfo.Arguments = "/c " + args;
+string outputTimestamp = null;
+string sourceTimestamp = null;
 
-Log.LogMessage(MessageImportance.Normal, args);
-p = Process.Start(psInfo);
+if (File.Exists(Output.ToString())) {
+  args = "((Get-ItemPropertyValue -Path '" + Output.ToString() + "' -name LastWriteTime).ToString('u'))";
+  psInfo.FileName = "powershell";
+  psInfo.Arguments = "-NoLogo -ExecutionPolicy RemoteSigned -Command " + args;
 
-Log.LogMessage(MessageImportance.Low, p.StandardOutput.ReadToEnd());
+  Log.LogMessage(MessageImportance.Low, args);
+  p = Process.Start(psInfo);
+  
+  outputTimestamp = p.StandardOutput.ReadToEnd();
+  p.Dispose();
+  p = null;
+
+  if (!string.IsNullOrEmpty(outputTimestamp)) {
+    args = "(((7z l '" + ArchivePath.ToString() + "' " + InternalPath + " | Select-String " + InternalPath + ").ToString().SubString(0, 19) | Get-Date).ToString('u'))";
+    psInfo.Arguments = "-NoLogo -ExecutionPolicy RemoteSigned -Command " + args;
+
+    Log.LogMessage(MessageImportance.Low, args);
+    p = Process.Start(psInfo);
+
+    sourceTimestamp = p.StandardOutput.ReadToEnd();
+    p.Dispose();
+    p = null;
+  }
+}
+
+if (string.IsNullOrEmpty(outputTimestamp) ||
+    string.IsNullOrEmpty(sourceTimestamp) ||
+    outputTimestamp != sourceTimestamp)
+{
+  args = "7z e \"" + ArchivePath.ToString() + "\" -o\"" + Path.GetDirectoryName(Output.ToString()) + "\" -y " + InternalPath;
+  psInfo.FileName = "cmd";
+  psInfo.Arguments = "/c " + args;
+
+  Log.LogMessage(MessageImportance.Normal, args);
+  p = Process.Start(psInfo);
+
+  Log.LogMessage(MessageImportance.Low, p.StandardOutput.ReadToEnd());
+}
 ]]></Code>
     </Task>
   </UsingTask>

--- a/sakura/ExtractArchives.targets
+++ b/sakura/ExtractArchives.targets
@@ -1,0 +1,18 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="ExtractBregOnig" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer\externals\bregonig\bron420.zip" Outputs="$(OutDir)\bregonig.dll">
+    <Exec Command="7z e &quot;$(SolutionDir)installer\externals\bregonig\bron420.zip&quot; -o$(OutDir) -y x64/bregonig.dll" Condition="'$(Platform)' == 'x64'" />
+    <Exec Command="7z e &quot;$(SolutionDir)installer\externals\bregonig\bron420.zip&quot; -o$(OutDir) -y bregonig.dll" Condition="'$(Platform)' == 'Win32'" />
+  </Target>
+  <Target Name="ExtractCtags" Condition="'$(Platform)' == 'x64'" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x64.zip" Outputs="$(OutDir)\ctags.exe">
+    <Exec Command="7z e &quot;$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x64.zip&quot; -o$(OutDir) -y ctags.exe" />
+  </Target>
+  <Target Name="ExtractCtags" Condition="'$(Platform)' == 'Win32'" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip" Outputs="$(OutDir)\ctags.exe">
+    <Exec Command="7z e &quot;$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip&quot; -o$(OutDir) -y ctags.exe" />
+  </Target>
+  <Target Name="AppendCleanTargetsForExtractedFiles" BeforeTargets="CoreClean">
+    <ItemGroup>
+      <Clean Include="$(OutDir)bregonig.dll" />
+      <Clean Include="$(OutDir)ctags.exe" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -914,23 +914,12 @@
   </ImportGroup>
   <Import Project="..\sakura\githash.targets" />
   <Import Project="..\sakura\funccode.targets" />
+  <Import Project="..\sakura\ExtractArchives.targets" />
   <Import Project="..\tests\compiletests.targets" />
-  <Target Name="ExtractBregOnig" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer\externals\bregonig\bron420.zip" Outputs="$(OutDir)\bregonig.dll">
-    <Exec Command="7z e &quot;$(SolutionDir)installer\externals\bregonig\bron420.zip&quot; -o$(OutDir) -y x64/bregonig.dll" Condition="'$(Platform)' == 'x64'" />
-    <Exec Command="7z e &quot;$(SolutionDir)installer\externals\bregonig\bron420.zip&quot; -o$(OutDir) -y bregonig.dll" Condition="'$(Platform)' == 'Win32'" />
-  </Target>
-  <Target Name="ExtractCtags" Condition="'$(Platform)' == 'x64'" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x64.zip" Outputs="$(OutDir)\ctags.exe">
-    <Exec Command="7z e &quot;$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x64.zip&quot; -o$(OutDir) -y ctags.exe" />
-  </Target>
-  <Target Name="ExtractCtags" Condition="'$(Platform)' == 'Win32'" DependsOnTargets="Link" BeforeTargets="FinalizeBuildStatus" Inputs="$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip" Outputs="$(OutDir)\ctags.exe">
-    <Exec Command="7z e &quot;$(SolutionDir)installer/externals/universal-ctags/ctags-2020-01-12_feffe43a-x86.zip&quot; -o$(OutDir) -y ctags.exe" />
-  </Target>
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <!-- Add files to @Clean just before running CoreClean. -->
     <ItemGroup>
       <Clean Include="$(OutDir)sakura.ini" />
-      <Clean Include="$(OutDir)bregonig.dll" />
-      <Clean Include="$(OutDir)ctags.exe" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
#1790 の解決に至るまでの道のりを提示することが目的です。

## <!-- 必須 --> カテゴリ

- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1790 の解決のために #1792 を作成しました。

#1792 にレビューが付きません。

レビューが付かない理由としては、以下が考えられます。
* 興味がない
* そもそも構想に否定的（≒技術的にできないと思っている）
* そもそも構想に否定的（≒ウザくても必要なログだと思っている）
* 世間一般のオープンソースプロジェクトの「コミットの積み方ガイドライン」（１つの目的で行う修正のコミットはsquashしてまとめること、1PRに複数コミットを含めないこと）に照らして不適切だと思っている。（≒日本語読めてないのに分かった気になっている）

「技術的に可能」を示しておくべきと判断して作成します。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
アプリの仕様・機能には影響ありません。

MSVCビルドの完了時に行っているアーカイブ展開を改善するものです。
アーカイブ展開が、ビルド後に毎回行われていたのを、必要な場合のみ行うように修正します。
また、アーカイブ展開時のログを「詳細モード」以上で吐くよう修正します。

CIは、「詳細モード」で書かれるので修正の影響をうけません。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
MSVCビルドに影響する変更です。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
* resolves #1790
* closes #1792
* closes #1795

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
* https://docs.microsoft.com/ja-jp/visualstudio/msbuild/msbuild-inline-tasks