### PR TITLE
複数のVisual Studioを入れたときの問題に対応

### DIFF
--- a/sakura/githash.targets
+++ b/sakura/githash.targets
@@ -7,6 +7,10 @@
       Outputs="$(GeneratedGitHash)"
       AfterTargets="SelectClCompile"
       BeforeTargets="ClCompile">
+    <PropertyGroup>
+      <VsVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioVersion)', '^(\d+).*', '$1'))</VsVersion>
+    </PropertyGroup>
+    <SetEnv name="NUM_VSVERSION" value="$(VsVersion)" prefix="false" />
     <Exec Command="..\sakura\githash.bat ..\sakura_core $(GeneratedGitHash)" />
   </Target>
 </Project>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -912,10 +912,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Import Project="..\tests\compiletests.targets" />
   <Import Project="..\sakura\githash.targets" />
   <Import Project="..\sakura\funccode.targets" />
   <Import Project="..\sakura\ExtractArchives.targets" />
-  <Import Project="..\tests\compiletests.targets" />
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <!-- Add files to @Clean just before running CoreClean. -->
     <ItemGroup>

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -912,10 +912,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <Import Project="..\tests\compiletests.targets" />
   <Import Project="..\sakura\githash.targets" />
   <Import Project="..\sakura\funccode.targets" />
   <Import Project="..\sakura\ExtractArchives.targets" />
+  <Import Project="..\tests\compiletests.targets" />
   <Target Name="AppendCleanTargets" BeforeTargets="CoreClean">
     <!-- Add files to @Clean just before running CoreClean. -->
     <ItemGroup>

--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -257,6 +257,7 @@ exit /b
     exit /b
 
 :cmake
+set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
 for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -property installationPath -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
     pushd "%%a"
     call "%%a\Common7\Tools\vsdevcmd\ext\cmake.bat"


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
複数のVisual Studioをインストールしている場合
ビルド時に違うバージョンのcmakeなどが選択される問題を修正します
<del>修正案をいただいたので併記しています。(https://github.com/sakura-editor/sakura/pull/1806#issuecomment-1050067663)</del>

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

<del>- 不具合修正</del>
- ビルド関連
  <del>- ビルド手順</del>
  <del>- ローカルビルド</del>
   - その他

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
tools/find-tools.batの探索順が変更になり
NUM_VSVERSION -> VS2022 -> VS2019 -> VS2017
このような優先順で選ばれるようになりました
複数インストールしている場合、
下位のバージョンを使うにはNUM_VSVERSIONを設定する必要があります。
IDEでは使用中のバージョンを (targetsファイルを使って) 環境変数NUM_VSVERSIONに設定する必要があります。

> VS2017も入っている環境で、VS2017のツールを探索した際、CMakeとNinjaのみ異なるバージョンのツールが選択されます。
> ```
> set NUM_VSVERSION=15
> find-tools.bat
> C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe -property installationPath -version [15,)
> |- CMD_MSBUILD=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe
> |- CMD_CMAKE=C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe
> |- CMD_NINJA=C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe
> ```
> https://github.com/sakura-editor/sakura/pull/1807#issuecomment-1050037000
> 

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
<del>呼び出し順を変えるので何か不具合があるかもしれません。</del>

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
例としてVS2022とVS2017をインストールした環境の話です。

１．
IDE/コマンドライン
Visual Studio 2017でビルドすると違うバージョンのツールが選択される
-> tools/find-tools.batでのNUM_VSVERSION_NEXTの設定忘れです。

> #1785 で、VS2017とそれより後のバージョンで、探索処理を行うサブルーチンを分けました。
> VS2019以降の場合、Visual Studio Locatorの引数で、選択したバージョン（NUM_VSVERSION）と、それに1加えた値（NUM_VSVERSION_NEXT）を使って、そのバージョンのMSBuildを探すようになりました。
> 一方、VS2017の場合は、Visual Studio Locatorの引数に固定値（[15,16)）を用います。
> このため、VS2017ではNUM_VSVERSION_NEXT変数が定義されません。
> 
> さて、CMakeおよびNinjaの探索を行う処理でも、Visual Studio Locatorを使っていますが、引数に選択したバージョンとそれに1加えた値を利用しています。
> ここで本来NUM_VSVERSION_NEXTを定義しなければなりませんでしたが、CMakeの探索処理をfind-tools.batに実装した際に定義の漏れがありました。
> #1785 で変更する以前はMSBuild探索時に定義された値が再利用されていたため影響はありませんでしたが、 #1785 でサブルーチンを整理した結果、NUM_VSVERSION_NEXTが定義されないコードパスが生じ、定義漏れの影響が顕在しました。
> 
> このPRでは、漏れている定義を追加して、VS2017との混在環境でもCMake/Ninja探索時に正常に動作するようにします。
> 

２．
IDEのみ
sakura_core\githash.h が存在しない場合
Visual Studio 2017 IDEでビルドすると違うバージョンのツールが<del>選択される。</del>選択されたログが出力される。
-> NUM_VSVERSIONを設定しないままtools/find-tools.batが呼ばれている。

> また、ビルド時にgit関係のヘッダファイルを生成するgithash.batを実行するターゲットでは、NUM_VSVERSIONの設定がありません。
> このため、githash.batの実行ログでは異なるバージョンのツールが選択されているように見えます。
> このPRでは、当該ターゲットでもあらかじめNUM_VSVERSIONを設定するようにして、使用しているVisual Studioと同じバージョンのツールが選択されるようにします。
> 

<del>sakura\githash.targets に環境変数NUM_VSVERSIONを設定する方法と
sakura\sakura.vcxproj の呼び出し順でtests\compiletests.targets を優先させる方法があると思います。</del>

<del>依存関係が無ければ順を変えるほうが
環境変数NUM_VSVERSIONを設定する箇所を
tests\unittests\tests1.vcxproj - tests\googletest.targets - googletest.build.cmd
sakura\sakura.vcxproj - tests\compiletests.targets - compiletests.run.cmd
の二つに固定できるのでいいと思います。</del>


## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
<del>いくつかファイルの呼び出し先を追ってみた感じでは、依存関係が無いように思いましたが、どうでしょうか？</del>

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
2つ以上インストールした最新でないほうのVSを起動し、ビルドを行う。
IDEのテストではsakura_core\githash.hを削除した状態でもテストする。

### テスト1

手順


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
