### PR TITLE
find-tools.batが一時利用する変数の宣言を追加する

### DIFF
--- a/tools/find-tools.bat
+++ b/tools/find-tools.bat
@@ -257,6 +257,7 @@ exit /b
     exit /b
 
 :cmake
+set /a NUM_VSVERSION_NEXT=NUM_VSVERSION + 1
 for /f "usebackq delims=" %%a in (`"%CMD_VSWHERE%" -property installationPath -version [%NUM_VSVERSION%^,%NUM_VSVERSION_NEXT%^)`) do (
     pushd "%%a"
     call "%%a\Common7\Tools\vsdevcmd\ext\cmake.bat"


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

find-tools.batにて、探索時に一時利用する変数を明示的に宣言する。

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 自明なら省略可 --> PR の背景

find-tools.batにおけるCMake探索時に、一時的に利用する変数`NUM_VSVERSION_NEXT`の宣言がありません。
https://github.com/sakura-editor/sakura/blob/0c8db7496c87069c51b857da1af7904fcc22949e/tools/find-tools.bat#L259-L268
これにより、トラブルが生じる可能性が #1806 で指摘されましたので、フォローアップを行います。
（なお、本PRは #1806 のカウンターでもあります。）

## <!-- 自明なら省略可 --> PR のメリット

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

CMake探索時に`NUM_VSVERSION_NEXT`という変数を一時利用していますが、宣言されていません。
なお、現在はそれ以前に実行されたサブルーチンの値が再利用されています。

このPRは当該変数の定義を追加するものです。

## <!-- わかる範囲で --> PR の影響範囲

find-tools.batにおけるCMakeおよびNinjaの探索プロセス

## <!-- 必須 --> テスト内容

バッチファイルを実行して、これまで通り探索に成功すれば問題ないと思います。

## <!-- なければ省略可 --> 関連 issue, PR

#1785 
#1806 

## <!-- なければ省略可 --> 参考資料