### PR TITLE
strprintfを改良してナロー文字も扱えるようにする

### DIFF
--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -26,6 +26,7 @@
 #include "string_ex.h"
 
 #include <stdarg.h>
+#include <array>
 
 #include "charset/charcode.h"
 #include "charset/codechecker.h"
@@ -268,7 +269,14 @@ int vstrprintf(std::wstring& strOut, const WCHAR* pszFormat, va_list& argList)
 	::vswprintf_s(strOut.data(), strOut.capacity(), pszFormat, argList);
 
 	// NUL終端する
-	strOut.assign(strOut.data(), cchOut);
+	if (strOut.empty() && cchOut < 8) {
+		std::array<wchar_t, 8> buf;
+		::wcsncpy_s(buf.data(), buf.size(), strOut.data(), cchOut);
+		strOut.assign(buf.data(), cchOut);
+	}
+	else {
+		strOut.assign(strOut.data(), cchOut);
+	}
 
 	return cchOut;
 }
@@ -303,7 +311,15 @@ int vstrprintf(std::string& strOut, const CHAR* pszFormat, va_list& argList)
 	::vsprintf_s(strOut.data(), strOut.capacity(), pszFormat, argList);
 
 	// NUL終端する
-	strOut.assign(strOut.data(), cchOut);
+	if (strOut.empty() && cchOut < 16) {
+		std::array<char, 16> buf;
+		::strncpy_s(buf.data(), buf.size(), strOut.data(), cchOut);
+		strOut.assign(buf.data(), cchOut);
+	}
+	else {
+		strOut.assign(strOut.data(), cchOut);
+	}
+
 
 	return cchOut;
 }

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -240,28 +240,149 @@ const char* stristr_j( const char* s1, const char* s2 )
 
 /*!
 	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
+		事前に確保したバッファに結果を書き込む高速バージョン
+	@param[in, out] strOut	フォーマットされたテキストを受け取る変数
 	@param[in]  pszFormat	フォーマット文字列
 	@param[in]  argList		引数リスト
+	@returns 出力された文字数。NUL終端を含まない。
+	@retval >= 0 正常終了
+	@retval < 0 異常終了
+*/
+int vstrprintf(std::wstring& strOut, const WCHAR* pszFormat, va_list& argList)
+{
+	// _vscwprintf() はフォーマットに必要な文字数を返す。
+	const int cchOut = ::_vscwprintf(pszFormat, argList);
+	// 出力文字数が0なら後続処理は要らない。
+	if (!cchOut) {
+		return 0;
+	}
+
+	// 必要なバッファを確保する
+	if (const size_t required = cchOut + 1;
+		strOut.capacity() <= required)
+	{
+		strOut.resize(required, L'0');
+	}
+
+	// フォーマットする
+	::vswprintf_s(strOut.data(), strOut.capacity(), pszFormat, argList);
+
+	// NUL終端する
+	strOut.assign(strOut.data(), cchOut);
+
+	return cchOut;
+}
+
+/*!
+	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
+		事前に確保したバッファに結果を書き込む高速バージョン
+	@param[in, out] strOut	フォーマットされたテキストを受け取る変数
+	@param[in]  pszFormat	フォーマット文字列
+	@param[in]  argList		引数リスト
+	@returns 出力された文字数。NUL終端を含まない。
+	@retval >= 0 正常終了
+	@retval < 0 異常終了
+*/
+int vstrprintf(std::string& strOut, const CHAR* pszFormat, va_list& argList)
+{
+	// _vscwprintf() はフォーマットに必要な文字数を返す。
+	const int cchOut = ::_vscprintf(pszFormat, argList);
+	// 出力文字数が0なら後続処理は要らない。
+	if (!cchOut) {
+		return 0;
+	}
+
+	// 必要なバッファを確保する
+	if (const size_t required = cchOut + 1;
+		strOut.capacity() <= required)
+	{
+		strOut.resize(required, L'0');
+	}
+
+	// フォーマットする
+	::vsprintf_s(strOut.data(), strOut.capacity(), pszFormat, argList);
+
+	// NUL終端する
+	strOut.assign(strOut.data(), cchOut);
+
+	return cchOut;
+}
+
+/*!
+	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
+		事前に確保したバッファに結果を書き込む高速バージョン
+	@param[in, out] strOut	フォーマットされたテキストを受け取る変数
+	@param[in]  pszFormat	フォーマット文字列
+	@param[in]  argList		引数リスト
+	@returns 出力された文字数。NUL終端を含まない。
+	@retval >= 0 正常終了
+	@retval < 0 異常終了
+*/
+int strprintf(std::wstring& strOut, const WCHAR* pszFormat, ...)
+{
+	va_list argList;
+	va_start(argList, pszFormat);
+
+	const auto nRet = vstrprintf(strOut, pszFormat, argList);
+
+	va_end(argList);
+
+	return nRet;
+}
+
+/*!
+	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
+		事前に確保したバッファに結果を書き込む高速バージョン
+	@param[in, out] strOut	フォーマットされたテキストを受け取る変数
+	@param[in]  pszFormat	フォーマット文字列
+	@param[in]  argList		引数リスト
+	@returns 出力された文字数。NUL終端を含まない。
+	@retval >= 0 正常終了
+	@retval < 0 異常終了
+*/
+int strprintf(std::string& strOut, const CHAR* pszFormat, ...)
+{
+	va_list argList;
+	va_start(argList, pszFormat);
+
+	const auto nRet = vstrprintf(strOut, pszFormat, argList);
+
+	va_end(argList);
+
+	return nRet;
+}
+
+/*!
+	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
+		動的にバッファを確保する簡易バージョン
+	@param[in]  pszFormat	フォーマット文字列
+	@param[in]  ...			引数リスト
 	@returns フォーマットされた文字列
 */
 std::wstring vstrprintf(const WCHAR* pszFormat, va_list& argList)
 {
-	// _vscwprintf() はフォーマットに必要な文字数を返す。
-	const int cchOut = ::_vscwprintf(pszFormat, argList);
-	if (cchOut == 0) {
-		// 出力文字数が0なら後続処理は要らない。
-		return std::wstring();
-	}
-
-	// 必要なバッファを確保してフォーマットする
-	std::wstring strOut(cchOut + 1, L'0');
-	::vswprintf_s(strOut.data(), strOut.capacity(), pszFormat, argList);
-	strOut.resize(cchOut);
+	std::wstring strOut;
+	vstrprintf(strOut, pszFormat, argList);
 	return strOut;
 }
 
 /*!
 	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
+		動的にバッファを確保する簡易バージョン
+	@param[in]  pszFormat	フォーマット文字列
+	@param[in]  ...			引数リスト
+	@returns フォーマットされた文字列
+*/
+std::string vstrprintf(const CHAR* pszFormat, va_list& argList)
+{
+	std::string strOut;
+	vstrprintf(strOut, pszFormat, argList);
+	return strOut;
+}
+
+/*!
+	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
+		動的にバッファを確保する簡易バージョン
 	@param[in]  pszFormat	フォーマット文字列
 	@param[in]  ...			引数リスト
 	@returns フォーマットされた文字列
@@ -271,48 +392,30 @@ std::wstring strprintf(const WCHAR* pszFormat, ...)
 	va_list argList;
 	va_start(argList, pszFormat);
 
-	const auto strRet = vstrprintf(pszFormat, argList);
+	const auto strOut = vstrprintf(pszFormat, argList);
 
 	va_end(argList);
 
-	return strRet;
+	return strOut;
 }
 
 /*!
 	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
-	@param[out] strOut		フォーマットされたテキストを受け取る変数
-	@param[in]  pszFormat	フォーマット文字列
-	@param[in]  argList		引数リスト
-	@returns 出力された文字数。NUL終端を含まない。
-	@retval >= 0 正常終了
-	@retval < 0 異常終了
-*/
-int vstrprintf( std::wstring& strOut, const WCHAR* pszFormat, va_list& argList )
-{
-	// オーバーロードバージョンを呼び出す
-	strOut = vstrprintf(pszFormat, argList);
-	return static_cast<int>(strOut.length());
-}
-
-/*!
-	@brief C-Styleのフォーマット文字列を使ってデータを文字列化する。
-	@param[out] strOut		フォーマットされたテキストを受け取る変数
+		動的にバッファを確保する簡易バージョン
 	@param[in]  pszFormat	フォーマット文字列
 	@param[in]  ...			引数リスト
-	@returns 出力された文字数。NUL終端を含まない。
-	@retval >= 0 正常終了
-	@retval < 0 異常終了
+	@returns フォーマットされた文字列
 */
-int strprintf( std::wstring& strOut, const WCHAR* pszFormat, ... )
+std::string strprintf(const CHAR* pszFormat, ...)
 {
 	va_list argList;
-	va_start( argList, pszFormat );
+	va_start(argList, pszFormat);
 
-	const int nRet = vstrprintf( strOut, pszFormat, argList );
+	const auto strOut = vstrprintf(pszFormat, argList);
 
-	va_end( argList );
+	va_end(argList);
 
-	return nRet;
+	return strOut;
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -205,10 +205,14 @@ inline int auto_vsprintf_s(WCHAR* buf, size_t nBufCount, const WCHAR* format, va
 #define auto_sprintf_s(buf, nBufCount, format, ...)		::_sntprintf_s((buf), nBufCount, _TRUNCATE, (format), __VA_ARGS__)
 #define auto_snprintf_s(buf, nBufCount, format, ...)	::_sntprintf_s((buf), nBufCount, _TRUNCATE, (format), __VA_ARGS__)
 
+int vstrprintf(std::wstring& strOut, const WCHAR* pszFormat, va_list& argList);
+int vstrprintf(std::string& strOut, const CHAR* pszFormat, va_list& argList);
+int strprintf(std::wstring& strOut, const WCHAR* pszFormat, ...);
+int strprintf(std::string& strOut, const CHAR* pszFormat, ...);
 std::wstring vstrprintf(const WCHAR* pszFormat, va_list& argList);
+std::string vstrprintf(const CHAR* pszFormat, va_list& argList);
 std::wstring strprintf(const WCHAR* pszFormat, ...);
-int vstrprintf( std::wstring& strOut, const WCHAR* pszFormat, va_list& argList );
-int strprintf( std::wstring& strOut, const WCHAR* pszFormat, ... );
+std::string strprintf(const CHAR* pszFormat, ...);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                      文字コード変換                         //

--- a/tests/unittests/test-string_ex.cpp
+++ b/tests/unittests/test-string_ex.cpp
@@ -136,6 +136,99 @@ TEST(string_ex, strprintfEmpty)
 }
 
 /*!
+	@brief 独自定義のフォーマット関数(C-Style風)。
+
+	バッファが極端に小さい場合の確認。
+	wtd::wstringのスモールバッファは7文字分。
+ */
+TEST(string_ex, strprintfW_small_output)
+{
+	std::wstring text = strprintf(L"");
+	EXPECT_STREQ(L"", text.c_str());
+
+	text = strprintf(L"%d", 1);
+	EXPECT_STREQ(L"1", text.c_str());
+
+	text = strprintf(L"%d", 12);
+	EXPECT_STREQ(L"12", text.c_str());
+
+	text = strprintf(L"%d", 123);
+	EXPECT_STREQ(L"123", text.c_str());
+
+	text = strprintf(L"%d", 1234);
+	EXPECT_STREQ(L"1234", text.c_str());
+
+	text = strprintf(L"%d", 12345);
+	EXPECT_STREQ(L"12345", text.c_str());
+
+	text = strprintf(L"%d", 123456);
+	EXPECT_STREQ(L"123456", text.c_str());
+
+	text = strprintf(L"%d", 1234567);
+	EXPECT_STREQ(L"1234567", text.c_str());
+}
+
+/*!
+	@brief 独自定義のフォーマット関数(C-Style風)。
+
+	バッファが極端に小さい場合の確認
+	wtd::stringのスモールバッファは15文字分。
+ */
+TEST(string_ex, strprintfA_small_output)
+{
+	std::string text = strprintf("");
+	EXPECT_STREQ("", text.c_str());
+
+	text = strprintf("%d", 1);
+	EXPECT_STREQ("1", text.c_str());
+
+	text = strprintf("%d", 12);
+	EXPECT_STREQ("12", text.c_str());
+
+	text = strprintf("%d", 123);
+	EXPECT_STREQ("123", text.c_str());
+
+	text = strprintf("%d", 1234);
+	EXPECT_STREQ("1234", text.c_str());
+
+	text = strprintf("%d", 12345);
+	EXPECT_STREQ("12345", text.c_str());
+
+	text = strprintf("%d", 123456);
+	EXPECT_STREQ("123456", text.c_str());
+
+	text = strprintf("%d", 1234567);
+	EXPECT_STREQ("1234567", text.c_str());
+
+	text = strprintf("%d", 12345678);
+	EXPECT_STREQ("12345678", text.c_str());
+
+	text = strprintf("%d", 123456789);
+	EXPECT_STREQ("123456789", text.c_str());
+
+	text = strprintf("%d", 1234567890);
+	EXPECT_STREQ("1234567890", text.c_str());
+
+	text = strprintf("1234567890%d", 1);
+	EXPECT_STREQ("12345678901", text.c_str());
+
+	text = strprintf("1234567890%d", 12);
+	EXPECT_STREQ("123456789012", text.c_str());
+
+	text = strprintf("1234567890%d", 123);
+	EXPECT_STREQ("1234567890123", text.c_str());
+
+	text = strprintf("1234567890%d", 1234);
+	EXPECT_STREQ("12345678901234", text.c_str());
+
+	text = strprintf("1234567890%d", 12345);
+	EXPECT_STREQ("123456789012345", text.c_str());
+
+	text = strprintf("1234567890%d", 123456);
+	EXPECT_STREQ("1234567890123456", text.c_str());
+}
+
+/*!
 	@brief 独自定義の文字列比較関数。
  */
 TEST(string_ex, strncmp_literal)

--- a/tests/unittests/test-string_ex.cpp
+++ b/tests/unittests/test-string_ex.cpp
@@ -119,11 +119,21 @@ TEST(string_ex, strprintf)
 /*!
 	@brief 独自定義のフォーマット関数(C-Style風)。
  */
-TEST(string_ex, strprintfOutputToArg)
+TEST(string_ex, strprintfWOutputToArg)
 {
-	std::wstring text;
+	std::wstring text(1024, L'\0');
 	strprintf(text, L"%s-%d", L"test", 101);
 	ASSERT_STREQ(L"test-101", text.c_str());
+}
+
+/*!
+	@brief 独自定義のフォーマット関数(C-Style風)。
+ */
+TEST(string_ex, strprintfAOutputToArg)
+{
+	std::string text(1024, '\0');
+	strprintf(text, "%ls-of-active-codepage-%d", L"test", 101);
+	ASSERT_STREQ("test-of-active-codepage-101", text.c_str());
 }
 
 /*!

--- a/tests/unittests/test-string_ex.cpp
+++ b/tests/unittests/test-string_ex.cpp
@@ -241,25 +241,6 @@ TEST(string_ex, strprintfA_small_output)
 }
 
 /*!
-	@brief 独自定義のフォーマット関数(C-Style風)。
-
-	Cロケールを設定し忘れた場合、SJISバイナリから標準文字列への変換は失敗する。
-	テスト作成時に混乱する可能性があるので、例外を投げるようにしてある。
-	CRT関数が「フォーマットが不正ならクラッシュさせる」という設計なので、
-	フォーマットチェック機構としては役立たずである点に注意すること。
- */
-TEST(string_ex, strprintfA_throws)
-{
-	// Cのロケールを設定し忘れた場合、エラーが返る
-	setlocale(LC_ALL, "English");
-	EXPECT_THROW(strprintf("%ls", L"てすと"), std::invalid_argument);
-
-	// Cのロケールを日本語にした場合、正しく変換できる
-	setlocale(LC_ALL, "Japanese");
-	EXPECT_STREQ("てすと", strprintf("%ls", L"てすと").data());
-}
-
-/*!
 	@brief 独自定義の文字列比較関数。
  */
 TEST(string_ex, strncmp_literal)

--- a/tests/unittests/test-string_ex.cpp
+++ b/tests/unittests/test-string_ex.cpp
@@ -31,6 +31,8 @@
 #include <tchar.h>
 #include <Windows.h>
 
+#include <stdexcept>
+
 #include "basis/primitive.h"
 #include "util/string_ex.h"
 
@@ -236,6 +238,25 @@ TEST(string_ex, strprintfA_small_output)
 
 	text = strprintf("1234567890%d", 123456);
 	EXPECT_STREQ("1234567890123456", text.c_str());
+}
+
+/*!
+	@brief 独自定義のフォーマット関数(C-Style風)。
+
+	Cロケールを設定し忘れた場合、SJISバイナリから標準文字列への変換は失敗する。
+	テスト作成時に混乱する可能性があるので、例外を投げるようにしてある。
+	CRT関数が「フォーマットが不正ならクラッシュさせる」という設計なので、
+	フォーマットチェック機構としては役立たずである点に注意すること。
+ */
+TEST(string_ex, strprintfA_throws)
+{
+	// Cのロケールを設定し忘れた場合、エラーが返る
+	setlocale(LC_ALL, "English");
+	EXPECT_THROW(strprintf("%ls", L"てすと"), std::invalid_argument);
+
+	// Cのロケールを日本語にした場合、正しく変換できる
+	setlocale(LC_ALL, "Japanese");
+	EXPECT_STREQ("てすと", strprintf("%ls", L"てすと").data());
 }
 
 /*!


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
タイトル通りです。
独自関数 strprintf を std::string でも使えるようにします。
これは #1722 の対策に必要と考えています。

## <!-- 必須 --> カテゴリ

- その他の問題
  独自関数 strprintf の機能を拡充します。
  サクラエディタの機能は増えないので、機能追加ではありません。

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1722 で `CPPA` の不具合が報告されています。

修正したいのですが、`CPPA` は narrow 文字列を扱う機能なので、現状の `strprintf` だと対応に困ってしまいます。

対策として、std::wstring のみに対応していた strprintf を、
std::stringでも扱えるように改良したいと思います。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
アプリの仕様・機能に影響を与える変更ではありません。

WCHAR版を以下の4オーバーロードに組みなおし、同機能のCHAR版を追加します。
* `int vstrprintf(std::wstring& strOut, const WCHAR* pszFormat, va_list& argList)` 確保済み文字列を受け取る高速版（va_list）
* `int strprintf(std::wstring& strOut, const WCHAR* pszFormat, ...)` 確保済み文字列を受け取る高速版（可変長引数）
* `std::wstring vstrprintf(const WCHAR* pszFormat, va_list& argList)` 出力先指定不要の簡易版（va_list）
* `std::wstring strprintf(const WCHAR* pszFormat, ...)` 出力先指定不要の簡易版（可変長引数）

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
ユーティリティ系関数の変更なので、あちこちに影響します。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
基本的な機能確認を行えるようにテストケースを ~2件~ 3件 追加しています。
CIビルドが通れば基本的な機能確認は問題ないと考えられます。

### テスト1

手順


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
#1722

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
