### PR TITLE
PRテンプレートで変更対象とカテゴリを分けて書くようにする

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,27 @@
 <!-- PR の目的を記載してください -->
 <!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
 
+## <!-- 必須 --> ターゲット
+
+<!-- 編集 必須 -->
+<!-- 以下はテンプレートなので、追加、削除してください。 -->
+
+- サクラエディタ本体
+  - 正式リリース版
+  - Azure Pipelines ビルド版
+  - AppVeyor ビルド版
+  - GitHub Actions ビルド版
+  - ローカルビルド版
+- ヘルプ
+- インストーラ
+- ビルド関連
+  - ビルド手順
+  - Azure Pipelines
+  - AppVeyor
+  - GitHub Actions
+  - ローカルビルド
+- その他
+
 ## <!-- 必須 --> カテゴリ
 
 <!-- 編集 必須 -->
@@ -17,19 +38,6 @@
 - 速度向上
 - リファクタリング
 - ドキュメント修正
-- プログラムの動作上の問題
-  - 正式リリース版
-  - Azure Pipelines ビルド版
-  - AppVeyor ビルド版
-  - GitHub Actions ビルド版
-  - ローカルビルド版
-- ビルド関連
-  - ビルド手順
-  - Azure Pipelines
-  - AppVeyor
-  - GitHub Actions
-  - ローカルビルド
-- ドキュメントの問題
 - GitHub 関連の問題
 - 実験 (master へのマージを目的としない)
 - その他の問題


### PR DESCRIPTION
# <!-- 必須 --> PR の目的

PRの変更対象と内容のカテゴリを分離します。

## <!-- 必須 --> カテゴリ

- GitHub 関連の問題

## <!-- 自明なら省略可 --> PR の背景

> カテゴリは用意された選択肢の中で必要なものを残すタイプですが
> 「アプリの不具合修正」と明記するか、ビルド関連のなかに「不具合修正」を用意しておいてほしいですね。
> 不具合修正をその他と書くのは抵抗を感じます・・・。

_Originally posted by @dep5 in https://github.com/sakura-editor/sakura/issues/1806#issuecomment-1053564448_

現状は「何に対する」カテゴリなのかよくわからないので、レビュー過程で「その選択は間違っている」と言われることがあります。

## <!-- 自明なら省略可 --> PR のメリット

「何」に対して「どんな変更」をしたいかを書きやすくなります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

## <!-- わかる範囲で --> PR の影響範囲
- pull request template

## <!-- 必須 --> テスト内容

## <!-- なければ省略可 --> 関連 issue, PR
