### PR TITLE
SonarCloud静的解析でスタブDLLのソースを除外する

### DIFF
--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -149,4 +149,4 @@ jobs:
         -D"sonar.cfamily.threads=2" `
         -D"sonar.coverage.exclusions=help\**\*.js,tests\unittests\coverage.cpp,tools\**\*.js" `
         -D"sonar.coverageReportPaths=tests1-coverage.xml" `
-        -D"sonar.exclusions=.sonar\**\*,build\**\*,bw-output\**\*,HeaderMake\**\*,tests\build\**\*,tests\googletest\**\*,**\test-*,tests*-*.xml"
+        -D"sonar.exclusions=.sonar\**\*,build\**\*,bw-output\**\*,HeaderMake\**\*,tests\googletest\**\*,**\test-*,tests*-*.xml"

--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -147,6 +147,7 @@ jobs:
         -D"sonar.cfamily.cache.path=.sonar\analysis-cache" `
         -D"sonar.cfamily.cppunit.reportPath=tests1-googletest.xml" `
         -D"sonar.cfamily.threads=2" `
+        -D"sonar.python.version=3" `
         -D"sonar.coverage.exclusions=help\**\*.js,tests\unittests\coverage.cpp,tests\stubs\**\*.cpp,tools\**\*.js" `
         -D"sonar.coverageReportPaths=tests1-coverage.xml" `
         -D"sonar.exclusions=.sonar\**\*,build\**\*,bw-output\**\*,HeaderMake\**\*,tests\googletest\**\,**\test-*,tests\stubs\**\*,tests*-*.xml*"

--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -147,6 +147,6 @@ jobs:
         -D"sonar.cfamily.cache.path=.sonar\analysis-cache" `
         -D"sonar.cfamily.cppunit.reportPath=tests1-googletest.xml" `
         -D"sonar.cfamily.threads=2" `
-        -D"sonar.coverage.exclusions=help\**\*.js,tests\unittests\coverage.cpp,tools\**\*.js" `
+        -D"sonar.coverage.exclusions=help\**\*.js,tests\unittests\coverage.cpp,tests\stubs\**\*.cpp,tools\**\*.js" `
         -D"sonar.coverageReportPaths=tests1-coverage.xml" `
-        -D"sonar.exclusions=.sonar\**\*,build\**\*,bw-output\**\*,HeaderMake\**\*,tests\googletest\**\*,**\test-*,tests*-*.xml"
+        -D"sonar.exclusions=.sonar\**\*,build\**\*,bw-output\**\*,HeaderMake\**\*,tests\googletest\**\,**\test-*,tests\stubs\**\*,tests*-*.xml*"


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
SonarCloud静的解析の設定を変更します。

## <!-- 必須 --> カテゴリ

- ビルド関連
  - GitHub Actions

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
#1815 で外部DLLの動的アクセスクラスの自動テスト導入を検討した際に、
テスト用に追加するスタブDLLのソースコードが静的解析されると不都合だと分かりました。

テスト専用のコードだからって気を抜かずにちゃんと書けよ！
ってツッコミはあると思うんですが、
テストコード`(test-*.cpp)`は現状で既に除外対象になってるので、
レベルを合わせるためにもスタブDLLのソースコードを除外対象としたいです。

同時に、除外設定の見直しを行って設定を健全化したいと思います。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
SonarCloud静的解析の設定を変更します。
アプリの仕様・機能には影響しません。

変更点
* 使われなくなった中間フォルダの除外指定を外します。
* スタブDLLのソースがおかれるフォルダを静的解析の除外対象にします。
* スタブDLLのソースファイルをカバレッジ測定の対象から外します。
* Pythonスクリプトの静的解析をver3想定で行うようにします。
  「ver未指定だとちゃんとした警告が出せない」というワーニングが出ていました。
  Python ver2系のサポートは終了している認識なので、ver3ということにします。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
SonarCloud静的解析の結果に影響します。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
変更結果はマージ後に反映される仕組みなため、事前にテストすることはできません。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
* #1815

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
