### PR TITLE
MinGWビルドバッチの出力先フォルダ指定を訂正する

### DIFF
--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -33,21 +33,21 @@ path=C:\msys64\mingw64\bin;%path:C:\msys64\mingw64\bin;=%
 if not defined CMD_NINJA call %~dp0tools\find-tools.bat
 
 @rem create output directory, all executables will be placed here.
-set OUTDIR=../../../../%platform%/%configuration%
-mkdir "%~dp0%platform%\%configuration%" > NUL 2>&1
+set OUTDIR=%~dp0%platform%\%configuration%
+if not exist "%OUTDIR%" mkdir /p "%OUTDIR%" > NUL 2>&1
 
 @rem build "sakura_core".
 set SAKURA_CORE_MAKEFILE=%~dp0sakura_core\Makefile
 set SAKURA_CORE_BUILD_DIR=%~dp0build\%platform%\%configuration%\sakura_core
 mkdir "%SAKURA_CORE_BUILD_DIR%" > NUL 2>&1
 pushd "%SAKURA_CORE_BUILD_DIR%"
-mingw32-make -f "%SAKURA_CORE_MAKEFILE%" MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" OUTDIR=%OUTDIR% StdAfx.h.gch sakura_rc.o
+mingw32-make -f "%SAKURA_CORE_MAKEFILE%" MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" OUTDIR="%OUTDIR%" StdAfx.h.gch sakura_rc.o
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%
 	popd
 	exit /b 1
 )
-mingw32-make -f "%SAKURA_CORE_MAKEFILE%" MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" OUTDIR=%OUTDIR% -j4
+mingw32-make -f "%SAKURA_CORE_MAKEFILE%" MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" OUTDIR="%OUTDIR%" -j4
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%
 	popd
@@ -60,7 +60,7 @@ set SAKURA_LANG_EN_US_MAKEFILE=%~dp0sakura_lang_en_US\Makefile
 set SAKURA_LANG_EN_US_BUILD_DIR=%~dp0build\%platform%\%configuration%\sakura_lang_en_US
 mkdir "%SAKURA_LANG_EN_US_BUILD_DIR%" > NUL 2>&1
 pushd "%SAKURA_LANG_EN_US_BUILD_DIR%"
-mingw32-make -f "%SAKURA_LANG_EN_US_MAKEFILE%" MYDEFINES="%MYDEFINES%" SAKURA_CORE=../sakura_core OUTDIR=%OUTDIR%
+mingw32-make -f "%SAKURA_LANG_EN_US_MAKEFILE%" MYDEFINES="%MYDEFINES%" SAKURA_CORE=../sakura_core OUTDIR="%OUTDIR%"
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%
 	popd
@@ -93,7 +93,7 @@ if errorlevel 1 (
 	popd
 	exit /b 1
 )
-mingw32-make -f "%TESTS1_MAKEFILE%" MYDEFINES="%MYDEFINES%" SAKURA_CORE=../sakura_core OUTDIR=%OUTDIR% -j4
+mingw32-make -f "%TESTS1_MAKEFILE%" MYDEFINES="%MYDEFINES%" SAKURA_CORE=../sakura_core OUTDIR="%OUTDIR%" -j4
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%
 	popd

--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -33,21 +33,21 @@ path=C:\msys64\mingw64\bin;%path:C:\msys64\mingw64\bin;=%
 if not defined CMD_NINJA call %~dp0tools\find-tools.bat
 
 @rem create output directory, all executables will be placed here.
-set OUTDIR=%~dp0%platform%\%configuration%
-if not exist "%OUTDIR%" mkdir /p "%OUTDIR%" > NUL 2>&1
+set OUTDIR=../../../../%platform%/%configuration%
+mkdir "%~dp0%platform%\%configuration%" > NUL 2>&1
 
 @rem build "sakura_core".
 set SAKURA_CORE_MAKEFILE=%~dp0sakura_core\Makefile
 set SAKURA_CORE_BUILD_DIR=%~dp0build\%platform%\%configuration%\sakura_core
 mkdir "%SAKURA_CORE_BUILD_DIR%" > NUL 2>&1
 pushd "%SAKURA_CORE_BUILD_DIR%"
-mingw32-make -f "%SAKURA_CORE_MAKEFILE%" MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" OUTDIR="%OUTDIR%" StdAfx.h.gch sakura_rc.o
+mingw32-make -f "%SAKURA_CORE_MAKEFILE%" MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" OUTDIR=%OUTDIR% StdAfx.h.gch sakura_rc.o
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%
 	popd
 	exit /b 1
 )
-mingw32-make -f "%SAKURA_CORE_MAKEFILE%" MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" OUTDIR="%OUTDIR%" -j4
+mingw32-make -f "%SAKURA_CORE_MAKEFILE%" MYDEFINES="%MYDEFINES%" MYCFLAGS="%MYCFLAGS%" MYLIBS="%MYLIBS%" OUTDIR=%OUTDIR% -j4
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%
 	popd
@@ -60,7 +60,7 @@ set SAKURA_LANG_EN_US_MAKEFILE=%~dp0sakura_lang_en_US\Makefile
 set SAKURA_LANG_EN_US_BUILD_DIR=%~dp0build\%platform%\%configuration%\sakura_lang_en_US
 mkdir "%SAKURA_LANG_EN_US_BUILD_DIR%" > NUL 2>&1
 pushd "%SAKURA_LANG_EN_US_BUILD_DIR%"
-mingw32-make -f "%SAKURA_LANG_EN_US_MAKEFILE%" MYDEFINES="%MYDEFINES%" SAKURA_CORE=../sakura_core OUTDIR="%OUTDIR%"
+mingw32-make -f "%SAKURA_LANG_EN_US_MAKEFILE%" MYDEFINES="%MYDEFINES%" SAKURA_CORE=../sakura_core OUTDIR=%OUTDIR%
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%
 	popd
@@ -93,7 +93,7 @@ if errorlevel 1 (
 	popd
 	exit /b 1
 )
-mingw32-make -f "%TESTS1_MAKEFILE%" MYDEFINES="%MYDEFINES%" SAKURA_CORE=../sakura_core OUTDIR="%OUTDIR%" -j4
+mingw32-make -f "%TESTS1_MAKEFILE%" MYDEFINES="%MYDEFINES%" SAKURA_CORE=../sakura_core OUTDIR=%OUTDIR% -j4
 if errorlevel 1 (
 	echo error 2 errorlevel %errorlevel%
 	popd

--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -34,7 +34,7 @@ if not defined CMD_NINJA call %~dp0tools\find-tools.bat
 
 @rem create output directory, all executables will be placed here.
 set OUTDIR=%~dp0%platform%\%configuration%
-mkdir "%~dp0%platform%\%configuration%" > NUL 2>&1
+mkdir %OUTDIR% > NUL 2>&1
 
 @rem build "sakura_core".
 set SAKURA_CORE_MAKEFILE=%~dp0sakura_core\Makefile

--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -33,7 +33,7 @@ path=C:\msys64\mingw64\bin;%path:C:\msys64\mingw64\bin;=%
 if not defined CMD_NINJA call %~dp0tools\find-tools.bat
 
 @rem create output directory, all executables will be placed here.
-set OUTDIR=../../../../%platform%/%configuration%
+set OUTDIR=%~dp0%platform%\%configuration%
 mkdir "%~dp0%platform%\%configuration%" > NUL 2>&1
 
 @rem build "sakura_core".


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
タイトル通りです。

## <!-- 必須 --> カテゴリ

- 不具合修正
  ローカルでMinGWビルドを行う場合の不都合を解消します。

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
PPAスタブの導入を検討していて `build-gnu.bat` がおかしいことに気付きました。

## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
ローカルで MinGWビルド を行うための  `build-gnu.bat` の不具合を修正します。

* 定義がカレントフォルダからの相対指定になっていたのを修正します。
* ~~出力フォルダが作成済みかどうかチェックするように修正します。~~
  （対応しなくてもビルドできるので取り消します。）
* ~~パスに空白を含む場合の考慮の有無が混在していたのを「考慮あり」に統一します。~~
  パスに空白を含む場合の考慮の有無が混在していたのを「考慮なし」に統一します。

不都合は、他にも色々あるかも知れません。
今回は`OUTDIR`の宣言に関する不具合のみを対応します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
MinGWビルドに影響します。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
1. サクラエディタをgit cloneしたフォルダをWindowsエクスプローラーで開きます。
2. ファイルメニューからpowershellを開きます。
3. `cmd`と入力してenterキーを叩きます。
4. `build-gnu.bat MinGW Debug`と入力してenterキーを叩きます。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
