### PR TITLE
CPPAの単体テストを導入する話の続編

### DIFF
--- a/build-gnu.bat
+++ b/build-gnu.bat
@@ -76,6 +76,9 @@ if errorlevel 1 (
 	exit /b 1
 )
 
+@rem build "ppa_stub".
+call "%~dp0tools\cmake-build-and-install.cmd" "%~dp0tests\stubs\ppa_stub" "%~dp0build\%platform%\%configuration%\ppa_stub" "%OUTDIR%"
+
 @rem build "tests1".
 set TESTS1_MAKEFILE=%~dp0tests\unittests\Makefile
 set TESTS1_BUILD_DIR=%~dp0build\%platform%\%configuration%\tests1

--- a/sakura/sakura.vcxproj
+++ b/sakura/sakura.vcxproj
@@ -310,6 +310,7 @@
     <ClInclude Include="..\sakura_core\env\DLLSHAREDATA.h" />
     <ClInclude Include="..\sakura_core\extmodule\CBregexp.h" />
     <ClInclude Include="..\sakura_core\extmodule\CBregexpDll2.h" />
+    <ClInclude Include="..\sakura_core\extmodule\CDbgHelp.h" />
     <ClInclude Include="..\sakura_core\extmodule\CDllHandler.h" />
     <ClInclude Include="..\sakura_core\extmodule\CHtmlHelp.h" />
     <ClInclude Include="..\sakura_core\extmodule\CIcu4cI18n.h" />
@@ -680,6 +681,7 @@
     <ClCompile Include="..\sakura_core\env\DLLSHAREDATA.cpp" />
     <ClCompile Include="..\sakura_core\extmodule\CBregexp.cpp" />
     <ClCompile Include="..\sakura_core\extmodule\CBregexpDll2.cpp" />
+    <ClCompile Include="..\sakura_core\extmodule\CDbgHelp.cpp" />
     <ClCompile Include="..\sakura_core\extmodule\CDllHandler.cpp" />
     <ClCompile Include="..\sakura_core\extmodule\CHtmlHelp.cpp" />
     <ClCompile Include="..\sakura_core\extmodule\CIcu4cI18n.cpp" />

--- a/sakura/sakura.vcxproj.filters
+++ b/sakura/sakura.vcxproj.filters
@@ -1115,6 +1115,9 @@
     <ClInclude Include="..\sakura_core\view\CMiniMapView.h">
       <Filter>Cpp Source Files\view</Filter>
     </ClInclude>
+    <ClInclude Include="..\sakura_core\extmodule\CDbgHelp.h">
+      <Filter>Cpp Source Files\extmodule</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\resource\auto_scroll_center.cur">
@@ -2314,6 +2317,9 @@
     </ClCompile>
     <ClCompile Include="..\sakura_core\view\CMiniMapView.cpp">
       <Filter>Cpp Source Files\view</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sakura_core\extmodule\CDbgHelp.cpp">
+      <Filter>Cpp Source Files\extmodule</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/sakura_core/CCodeChecker.h
+++ b/sakura_core/CCodeChecker.h
@@ -30,10 +30,7 @@
 #include "doc/CDocListener.h"
 #include "util/design_template.h"
 
-class CCodeChecker : public CDocListenerEx, public TSingleton<CCodeChecker>{
-	friend class TSingleton<CCodeChecker>;
-	CCodeChecker(){}
-
+class CCodeChecker : public CDocListenerEx, public TSingleInstance<CCodeChecker> {
 public:
 	//セーブ時チェック
 	ECallbackResult OnCheckSave(SSaveInfo* pSaveInfo) override;

--- a/sakura_core/CEditApp.cpp
+++ b/sakura_core/CEditApp.cpp
@@ -48,7 +48,7 @@ void CEditApp::Create(HINSTANCE hInst, int nGroupId)
 	m_cIcons.Create( m_hInst );	//	CreateImage List
 
 	//ドキュメントの作成
-	m_pcEditDoc = new CEditDoc(this);
+	m_pcEditDoc = CEditDoc::getInstance();
 
 	//IO管理
 	m_pcLoadAgent = new CLoadAgent();
@@ -92,7 +92,6 @@ CEditApp::~CEditApp()
 	delete m_pcVisualProgress;
 	delete m_pcSaveAgent;
 	delete m_pcLoadAgent;
-	delete m_pcEditDoc;
 }
 
 /*! 共通設定 プロパティシート */

--- a/sakura_core/CEditApp.cpp
+++ b/sakura_core/CEditApp.cpp
@@ -40,6 +40,21 @@
 #include "util/module.h"
 #include "util/shell.h"
 
+CEditApp::CEditApp()
+{
+	// ドキュメントの作成
+	m_pcEditDoc = CEditDoc::getInstance();
+	m_pcEditDoc->Create();
+
+	m_pcLoadAgent = new CLoadAgent();
+	m_pcSaveAgent = new CSaveAgent();
+	m_pcVisualProgress = new CVisualProgress();
+	m_pcGrepAgent = new CGrepAgent();
+	m_pcSMacroMgr = new CSMacroMgr();
+	m_pcMruListener = new CMruListener();
+	m_pcPropertyManager = new CPropertyManager();
+}
+
 void CEditApp::Create(HINSTANCE hInst, int nGroupId)
 {
 	m_hInst = hInst;
@@ -47,35 +62,11 @@ void CEditApp::Create(HINSTANCE hInst, int nGroupId)
 	//ヘルパ作成
 	m_cIcons.Create( m_hInst );	//	CreateImage List
 
-	//ドキュメントの作成
-	m_pcEditDoc = CEditDoc::getInstance();
-
-	//IO管理
-	m_pcLoadAgent = new CLoadAgent();
-	m_pcSaveAgent = new CSaveAgent();
-	m_pcVisualProgress = new CVisualProgress();
-
-	//GREPモード管理
-	m_pcGrepAgent = new CGrepAgent();
-
-	//編集モード
-	CAppMode::getInstance();	//ウィンドウよりも前にイベントを受け取るためにここでインスタンス作成
-
-	//マクロ
-	m_pcSMacroMgr = new CSMacroMgr();
-
-	//ドキュメントの作成
-	m_pcEditDoc->Create();
-
 	//ウィンドウの作成
 	m_pcEditWnd = CEditWnd::getInstance();
 	m_pcEditWnd->Create( m_pcEditDoc, &m_cIcons, nGroupId );
 
-	//MRU管理
-	m_pcMruListener = new CMruListener();
-
 	//プロパティ管理
-	m_pcPropertyManager = new CPropertyManager();
 	m_pcPropertyManager->Create(
 		m_pcEditWnd->GetHwnd(),
 		&GetIcons(),

--- a/sakura_core/CEditApp.h
+++ b/sakura_core/CEditApp.h
@@ -46,12 +46,11 @@ class CGrepAgent;
 enum EFunctionCode;
 
 //!エディタ部分アプリケーションクラス。CNormalProcess1個につき、1個存在。
-class CEditApp : public TSingleton<CEditApp>{
-	friend class TSingleton<CEditApp>;
-	CEditApp(){}
-	virtual ~CEditApp();
-
+class CEditApp final : public TSingleInstance<CEditApp> {
 public:
+	CEditApp();
+	~CEditApp();
+
 	void Create(HINSTANCE hInst, int);
 
 	//モジュール情報

--- a/sakura_core/_main/CAppMode.h
+++ b/sakura_core/_main/CAppMode.h
@@ -30,8 +30,9 @@
 #include "util/design_template.h"
 #include "doc/CDocListener.h"
 
-class CAppMode : public TSingleton<CAppMode>, public CDocListenerEx{ //###仮
-	friend class TSingleton<CAppMode>;
+class CAppMode : public CDocListenerEx, public TSingleInstance<CAppMode> {
+
+public:
 	CAppMode()
 	: m_bViewMode( false )	// ビューモード
 	, m_bDebugMode( false )		// デバッグモニタモード
@@ -39,7 +40,6 @@ class CAppMode : public TSingleton<CAppMode>, public CDocListenerEx{ //###仮
 		m_szGrepKey[0] = L'\0';
 	}
 
-public:
 	//インターフェース
 	bool	IsViewMode() const				{ return m_bViewMode; }			//!< ビューモードを取得
 	void	SetViewMode(bool bViewMode)		{ m_bViewMode = bViewMode; }	//!< ビューモードを設定

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -46,7 +46,6 @@
 
 CNormalProcess::CNormalProcess( HINSTANCE hInstance, LPCWSTR lpCmdLine )
 : CProcess( hInstance, lpCmdLine )
-, m_pcEditApp( NULL )
 {
 }
 
@@ -92,6 +91,15 @@ bool CNormalProcess::InitializeProcess()
 	// ドキュメントのインスタンスを生成する
 	if (m_pcEditDoc = std::make_unique<CEditDoc>(nullptr);
 		m_pcEditDoc == nullptr)
+	{
+		::ReleaseMutex(hMutex);
+		::CloseHandle(hMutex);
+		return false;
+	}
+
+	// エディタアプリのインスタンスを生成
+	if (m_pcEditApp = std::make_unique<CEditApp>();
+		m_pcEditApp == nullptr)
 	{
 		::ReleaseMutex(hMutex);
 		::CloseHandle(hMutex);
@@ -163,7 +171,6 @@ bool CNormalProcess::InitializeProcess()
 		nGroupId = CAppNodeManager::getInstance()->GetFreeGroupId();
 	}
 	// CEditAppを作成
-	m_pcEditApp = CEditApp::getInstance();
 	m_pcEditApp->Create(GetProcessInstance(), nGroupId);
 	CEditWnd* pEditWnd = m_pcEditApp->GetEditWindow();
 	if( NULL == pEditWnd->GetHwnd() ){

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -89,6 +89,15 @@ bool CNormalProcess::InitializeProcess()
 	/* 言語を選択する */
 	CSelectLang::ChangeLang( GetDllShareData().m_Common.m_sWindow.m_szLanguageDll );
 
+	// ドキュメントのインスタンスを生成する
+	if (m_pcEditDoc = std::make_unique<CEditDoc>(nullptr);
+		m_pcEditDoc == nullptr)
+	{
+		::ReleaseMutex(hMutex);
+		::CloseHandle(hMutex);
+		return false;
+	}
+
 	/* コマンドラインオプション */
 	bool			bViewMode = false;
 	bool			bDebugMode;

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -106,6 +106,15 @@ bool CNormalProcess::InitializeProcess()
 		return false;
 	}
 
+	// 編集ウインドウのインスタンスを生成する
+	if (m_pcEditWnd = std::make_unique<CEditWnd>();
+		m_pcEditWnd == nullptr)
+	{
+		::ReleaseMutex(hMutex);
+		::CloseHandle(hMutex);
+		return false;
+	}
+
 	/* コマンドラインオプション */
 	bool			bViewMode = false;
 	bool			bDebugMode;
@@ -172,7 +181,7 @@ bool CNormalProcess::InitializeProcess()
 	}
 	// CEditAppを作成
 	m_pcEditApp->Create(GetProcessInstance(), nGroupId);
-	CEditWnd* pEditWnd = m_pcEditApp->GetEditWindow();
+	CEditWnd* pEditWnd = m_pcEditWnd.get();
 	if( NULL == pEditWnd->GetHwnd() ){
 		::ReleaseMutex( hMutex );
 		::CloseHandle( hMutex );

--- a/sakura_core/_main/CNormalProcess.h
+++ b/sakura_core/_main/CNormalProcess.h
@@ -37,8 +37,10 @@ class CEditWnd;
 class CNormalProcess final : public CProcess {
 private:
 	using CEditDocPtr = std::unique_ptr<CEditDoc>;
+	using CEditAppPtr = std::unique_ptr<CEditApp>;
 
 	CEditDocPtr		m_pcEditDoc = nullptr;
+	CEditAppPtr		m_pcEditApp = nullptr;
 
 public:
 	//コンストラクタ・デストラクタ
@@ -57,7 +59,6 @@ protected:
 	void OpenFiles(HWND hwnd);
 
 private:
-	CEditApp*	m_pcEditApp;	//2007.10.23 kobake
 	CMigemo		m_cMigemo;
 };
 #endif /* SAKURA_CNORMALPROCESS_F2808B31_61DC_4BE0_8661_9626478AC7F9_H_ */

--- a/sakura_core/_main/CNormalProcess.h
+++ b/sakura_core/_main/CNormalProcess.h
@@ -16,15 +16,11 @@
 #define SAKURA_CNORMALPROCESS_F2808B31_61DC_4BE0_8661_9626478AC7F9_H_
 #pragma once
 
-#include <memory>
-
-#include "global.h"
-#include "CProcess.h"
+#include "_main/CProcess.h"
 #include "doc/CEditDoc.h"
 #include "extmodule/CMigemo.h"
 #include "window/CEditWnd.h"
 #include "CEditApp.h"
-#include "util/design_template.h"
 
 /*-----------------------------------------------------------------------
 クラスの宣言
@@ -43,6 +39,7 @@ private:
 	CEditDocPtr		m_pcEditDoc = nullptr;
 	CEditAppPtr		m_pcEditApp = nullptr;
 	CEditWndPtr		m_pcEditWnd = nullptr;
+	CMigemo			m_cMigemo;
 
 public:
 	//コンストラクタ・デストラクタ
@@ -55,12 +52,8 @@ protected:
 	bool MainLoop() override;
 	void OnExitProcess() override;
 
-protected:
 	//実装補助
 	HANDLE _GetInitializeMutex() const; // 2002/2/8 aroka
 	void OpenFiles(HWND hwnd);
-
-private:
-	CMigemo		m_cMigemo;
 };
 #endif /* SAKURA_CNORMALPROCESS_F2808B31_61DC_4BE0_8661_9626478AC7F9_H_ */

--- a/sakura_core/_main/CNormalProcess.h
+++ b/sakura_core/_main/CNormalProcess.h
@@ -16,8 +16,11 @@
 #define SAKURA_CNORMALPROCESS_F2808B31_61DC_4BE0_8661_9626478AC7F9_H_
 #pragma once
 
+#include <memory>
+
 #include "global.h"
 #include "CProcess.h"
+#include "doc/CEditDoc.h"
 #include "extmodule/CMigemo.h"
 #include "CEditApp.h"
 #include "util/design_template.h"
@@ -32,6 +35,11 @@ class CEditWnd;
 	エディタプロセスはCEditWndクラスのインスタンスを作る。
 */
 class CNormalProcess final : public CProcess {
+private:
+	using CEditDocPtr = std::unique_ptr<CEditDoc>;
+
+	CEditDocPtr		m_pcEditDoc = nullptr;
+
 public:
 	//コンストラクタ・デストラクタ
 	CNormalProcess( HINSTANCE hInstance, LPCWSTR lpCmdLine );

--- a/sakura_core/_main/CNormalProcess.h
+++ b/sakura_core/_main/CNormalProcess.h
@@ -22,9 +22,9 @@
 #include "CProcess.h"
 #include "doc/CEditDoc.h"
 #include "extmodule/CMigemo.h"
+#include "window/CEditWnd.h"
 #include "CEditApp.h"
 #include "util/design_template.h"
-class CEditWnd;
 
 /*-----------------------------------------------------------------------
 クラスの宣言
@@ -38,9 +38,11 @@ class CNormalProcess final : public CProcess {
 private:
 	using CEditDocPtr = std::unique_ptr<CEditDoc>;
 	using CEditAppPtr = std::unique_ptr<CEditApp>;
+	using CEditWndPtr = std::unique_ptr<CEditWnd>;
 
 	CEditDocPtr		m_pcEditDoc = nullptr;
 	CEditAppPtr		m_pcEditApp = nullptr;
+	CEditWndPtr		m_pcEditWnd = nullptr;
 
 public:
 	//コンストラクタ・デストラクタ

--- a/sakura_core/_main/CProcess.cpp
+++ b/sakura_core/_main/CProcess.cpp
@@ -72,6 +72,26 @@ bool CProcess::InitializeProcess()
 		return false;
 	}
 
+	if (m_pcAppNodeManager = std::make_unique<CAppNodeManager>();
+		m_pcAppNodeManager == nullptr) {
+		return false;
+	}
+
+	if (m_pcFileNameManager = std::make_unique<CFileNameManager>();
+		m_pcFileNameManager == nullptr) {
+		return false;
+	}
+
+	if (m_pcJackManager = std::make_unique<CJackManager>();
+		m_pcJackManager == nullptr) {
+		return false;
+	}
+
+	if (m_pcPluginManager = std::make_unique<CPluginManager>();
+		m_pcPluginManager == nullptr) {
+		return false;
+	}
+
 	/* リソースから製品バージョンの取得 */
 	//	2004.05.13 Moca 共有データのバージョン情報はコントロールプロセスだけが
 	//	ShareDataで設定するように変更したのでここからは削除

--- a/sakura_core/_main/CProcess.cpp
+++ b/sakura_core/_main/CProcess.cpp
@@ -22,6 +22,7 @@
 #include "env/CShareData.h"
 #include "env/DLLSHAREDATA.h"
 #include "config/app_constants.h"
+#include "extmodule/CDbgHelp.h"
 #include "CSelectLang.h"
 #include "String_define.h"
 
@@ -37,9 +38,6 @@ CProcess::CProcess(
 )
 : m_hInstance( hInstance )
 , m_hWnd( 0 )
-#ifdef USE_CRASHDUMP
-, m_pfnMiniDumpWriteDump(NULL)
-#endif
 {
 	// アプリ名をリソースから読み込む
 	m_strAppName = LS(STR_GSTR_APPNAME);
@@ -110,78 +108,18 @@ bool CProcess::Run()
 	if( InitializeProcess() )
 	{
 #ifdef USE_CRASHDUMP
-		HMODULE hDllDbgHelp = LoadLibraryExedir( L"dbghelp.dll" );
-		m_pfnMiniDumpWriteDump = NULL;
-		if( hDllDbgHelp ){
-			*(FARPROC*)&m_pfnMiniDumpWriteDump = ::GetProcAddress( hDllDbgHelp, "MiniDumpWriteDump" );
-		}
-
-		__try {
+		CDbgHelp cDbgHelp;
+		CDbgHelp.DbgSession([]() {
 #endif
 			MainLoop() ;
 			OnExitProcess();
 #ifdef USE_CRASHDUMP
-		}
-		__except( WriteDump( GetExceptionInformation() ) ){
-		}
-
-		if( hDllDbgHelp ){
-			::FreeLibrary( hDllDbgHelp );
-			m_pfnMiniDumpWriteDump = NULL;
-		}
+		});
 #endif
 		return true;
 	}
 	return false;
 }
-
-#ifdef USE_CRASHDUMP
-/*!
-	@brief クラッシュダンプ
-	
-	@author ryoji
-	@date 2009.01.21
-*/
-int CProcess::WriteDump( PEXCEPTION_POINTERS pExceptPtrs )
-{
-	if( !m_pfnMiniDumpWriteDump )
-		return EXCEPTION_CONTINUE_SEARCH;
-
-	static WCHAR szFile[MAX_PATH];
-	// 出力先はiniと同じ（InitializeProcess()後に確定）
-	// Vista以降では C:\Users\(ユーザ名)\AppData\Local\CrashDumps に出力
-	GetInidirOrExedir( szFile, _APP_NAME_(_T) L".dmp" );
-
-	HANDLE hFile = ::CreateFile(
-		szFile,
-		GENERIC_WRITE,
-		0,
-		NULL,
-		CREATE_ALWAYS,
-		FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH,
-		NULL);
-
-	if( hFile != INVALID_HANDLE_VALUE ){
-		MINIDUMP_EXCEPTION_INFORMATION eInfo;
-		eInfo.ThreadId = GetCurrentThreadId();
-		eInfo.ExceptionPointers = pExceptPtrs;
-		eInfo.ClientPointers = FALSE;
-
-		m_pfnMiniDumpWriteDump(
-			::GetCurrentProcess(),
-			::GetCurrentProcessId(),
-			hFile,
-			MiniDumpNormal,
-			pExceptPtrs ? &eInfo : NULL,
-			NULL,
-			NULL);
-
-		::CloseHandle(hFile);
-	}
-
-	return EXCEPTION_CONTINUE_SEARCH;
-}
-#endif
 
 /*!
 	言語選択後に共有メモリ内の文字列を更新する

--- a/sakura_core/_main/CProcess.h
+++ b/sakura_core/_main/CProcess.h
@@ -18,12 +18,17 @@
 #pragma once
 
 #include <filesystem>
+#include <memory>
 #include <string>
 #include <string_view>
 
 #include "global.h"
 #include "util/design_template.h"
+#include "env/CAppNodeManager.h"
+#include "env/CFileNameManager.h"
 #include "env/CShareData.h"
+#include "plugin/CJackManager.h"
+#include "plugin/CPluginManager.h"
 
 #ifdef MINIDUMP_TYPE
 #define USE_CRASHDUMP
@@ -36,6 +41,17 @@
 	@brief プロセス基底クラス
 */
 class CProcess : public TSingleInstance<CProcess> {
+private:
+	using CAppNodeManagerPtr = std::unique_ptr<CAppNodeManager>;
+	using CFileNameManagerPtr = std::unique_ptr<CFileNameManager>;
+	using CJackManagerPtr = std::unique_ptr<CJackManager>;
+	using CPluginManagerPtr = std::unique_ptr<CPluginManager>;
+
+	CAppNodeManagerPtr		m_pcAppNodeManager = nullptr;
+	CFileNameManagerPtr		m_pcFileNameManager = nullptr;
+	CJackManagerPtr			m_pcJackManager = nullptr;
+	CPluginManagerPtr		m_pcPluginManager = nullptr;
+
 public:
 	CProcess( HINSTANCE hInstance, LPCWSTR lpCmdLine );
 	bool Run();

--- a/sakura_core/_main/CProcess.h
+++ b/sakura_core/_main/CProcess.h
@@ -68,9 +68,7 @@ protected:
 
 protected:
 	void			SetMainWindow(HWND hwnd){ m_hWnd = hwnd; }
-#ifdef USE_CRASHDUMP
-	int				WriteDump( PEXCEPTION_POINTERS pExceptPtrs );
-#endif
+
 public:
 	HINSTANCE		GetProcessInstance() const{ return m_hInstance; }
 	CShareData&		GetShareData()   { return m_cShareData; }
@@ -83,17 +81,6 @@ public:
 private:
 	HINSTANCE	m_hInstance;
 	HWND		m_hWnd;
-#ifdef USE_CRASHDUMP
-	BOOL (WINAPI *m_pfnMiniDumpWriteDump)(
-		HANDLE hProcess,
-		DWORD ProcessId,
-		HANDLE hFile,
-		MINIDUMP_TYPE DumpType,
-		PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
-		PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
-		PMINIDUMP_CALLBACK_INFORMATION CallbackParam
-		);
-#endif
 	CShareData		m_cShareData;
 	std::wstring	m_strAppName;
 };

--- a/sakura_core/_main/CProcess.h
+++ b/sakura_core/_main/CProcess.h
@@ -22,13 +22,13 @@
 #include <string>
 #include <string_view>
 
-#include "global.h"
-#include "util/design_template.h"
+#include "_main/global.h"
 #include "env/CAppNodeManager.h"
 #include "env/CFileNameManager.h"
 #include "env/CShareData.h"
 #include "plugin/CJackManager.h"
 #include "plugin/CPluginManager.h"
+#include "util/design_template.h"
 
 #ifdef MINIDUMP_TYPE
 #define USE_CRASHDUMP
@@ -54,14 +54,14 @@ private:
 
 public:
 	CProcess( HINSTANCE hInstance, LPCWSTR lpCmdLine );
+	virtual ~CProcess() = default;
+
 	bool Run();
-	virtual ~CProcess(){}
 	virtual void RefreshString();
 
 	virtual std::filesystem::path GetIniFileName() const;
 
 protected:
-	CProcess();
 	virtual bool InitializeProcess();
 	virtual bool MainLoop() = 0;
 	virtual void OnExitProcess() = 0;

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -193,12 +193,6 @@ CEditDoc::CEditDoc(CEditApp* pcApp)
 	//	自動保存の設定	//	Aug, 21, 2000 genta
 	m_cAutoSaveAgent.ReloadAutoSaveParam();
 
-	//$$ CModifyManager インスタンスを生成
-	CModifyManager::getInstance();
-
-	//$$ CCodeChecker インスタンスを生成
-	CCodeChecker::getInstance();
-
 	// 2008.06.07 nasukoji	テキストの折り返し方法を初期化
 	m_nTextWrapMethodCur = m_cDocType.GetDocumentAttribute().m_nTextWrapMethod;	// 折り返し方法
 	m_bTextWrapMethodCurTemp = false;									// 一時設定適用中を解除

--- a/sakura_core/doc/CEditDoc.h
+++ b/sakura_core/doc/CEditDoc.h
@@ -52,6 +52,8 @@
 #include "CDocLocker.h"
 #include "layout/CLayoutMgr.h"
 #include "logic/CDocLineMgr.h"
+#include "docplus/CDiffManager.h"
+#include "docplus/CModifyManager.h"
 #include "CBackupAgent.h"
 #include "CAutoSaveAgent.h"
 #include "CAutoReloadAgent.h"
@@ -78,6 +80,10 @@ class CEditDoc
 : public CDocSubject
 , public TInstanceHolder<CEditDoc>
 {
+private:
+	CModifyManager		m_cModifyManager;
+	CDiffManager		m_cDiffManager;
+
 public:
 	//コンストラクタ・デストラクタ
 	CEditDoc(CEditApp* pcApp);

--- a/sakura_core/doc/CEditDoc.h
+++ b/sakura_core/doc/CEditDoc.h
@@ -57,6 +57,7 @@
 #include "CBackupAgent.h"
 #include "CAutoSaveAgent.h"
 #include "CAutoReloadAgent.h"
+#include "CCodeChecker.h"
 #include "func/CFuncLookup.h"
 #include "CEol.h"
 #include "macro/CCookieManager.h"
@@ -81,8 +82,10 @@ class CEditDoc
 , public TInstanceHolder<CEditDoc>
 {
 private:
-	CModifyManager		m_cModifyManager;
+	CAppMode			m_cAppMode;
+	CCodeChecker		m_cCodeChecker;
 	CDiffManager		m_cDiffManager;
+	CModifyManager		m_cModifyManager;
 
 public:
 	//コンストラクタ・デストラクタ

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -214,7 +214,7 @@ public:
 		LogicToLayout( ptLogicEx, pptLayout, nLineHint );
 		if( 0 < ptLogicEx.ext ){
 			// 文字幅換算をする
-			int ext = std::max(0, ::MulDiv((Int)ptLogicEx.ext, (Int)m_nCharLayoutXPerKeta, (Int)ptLogicEx.haba));
+			int ext = std::max<int>(0, ::MulDiv((Int)ptLogicEx.ext, (Int)m_nCharLayoutXPerKeta, (Int)ptLogicEx.haba));
 			pptLayout->x += ext;
 		}
 	}

--- a/sakura_core/docplus/CDiffManager.h
+++ b/sakura_core/docplus/CDiffManager.h
@@ -48,10 +48,7 @@ enum EDiffMark : char {
 };
 
 //! DIFF挙動の管理
-class CDiffManager : public TSingleton<CDiffManager>{
-	friend class TSingleton<CDiffManager>;
-	CDiffManager(){}
-
+class CDiffManager : public TSingleInstance<CDiffManager> {
 public:
 	void SetDiffUse(bool b){ m_bIsDiffUse = b; }
 	bool IsDiffUse() const{ return m_bIsDiffUse; }		//!< DIFF使用中

--- a/sakura_core/docplus/CModifyManager.h
+++ b/sakura_core/docplus/CModifyManager.h
@@ -27,17 +27,14 @@
 #define SAKURA_CMODIFYMANAGER_12000875_531F_42DC_A6B0_231385193CB8_H_
 #pragma once
 
-#include "util/design_template.h" //TSingleton
-#include "doc/CDocListener.h" // CDocListenerEx
+#include "util/design_template.h"
+#include "doc/CDocListener.h"
 
 class CDocLine;
 class CDocLineMgr;
 
 //! Modified管理
-class CModifyManager : public TSingleton<CModifyManager>, public CDocListenerEx{
-	friend class TSingleton<CModifyManager>;
-	CModifyManager(){}
-
+class CModifyManager : public CDocListenerEx, public TSingleInstance<CModifyManager> {
 public:
 	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
 };

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -107,10 +107,7 @@ private:
 	int m_nGroup;
 };
 
-class CAppNodeManager : public TSingleton<CAppNodeManager>{
-	friend class TSingleton<CAppNodeManager>;
-	CAppNodeManager(){}
-
+class CAppNodeManager : public TSingleInstance<CAppNodeManager> {
 public:
 	//グループ
 	void ResetGroupId();									/* グループをIDリセットする */

--- a/sakura_core/env/CFileNameManager.h
+++ b/sakura_core/env/CFileNameManager.h
@@ -40,15 +40,14 @@ struct EditInfo;
 DLLSHAREDATA& GetDllShareData();
 
 //!ファイル名管理
-class CFileNameManager : public TSingleton<CFileNameManager>{
-	friend class TSingleton<CFileNameManager>;
+class CFileNameManager : public TSingleInstance<CFileNameManager> {
+public:
 	CFileNameManager()
 	{
 		m_pShareData = &GetDllShareData();
 		m_nTransformFileNameCount = -1;
 	}
 
-public:
 	//ファイル名関連
 	LPWSTR GetTransformFileNameFast( LPCWSTR, LPWSTR, int nDestLen, HDC hDC, bool bFitMode = true, int cchMaxWidth = 0 );	// 2002.11.24 Moca Add
 	int TransformFileName_MakeCache( void );

--- a/sakura_core/extmodule/CDbgHelp.cpp
+++ b/sakura_core/extmodule/CDbgHelp.cpp
@@ -1,0 +1,107 @@
+﻿/*!	@file */
+/*
+	Copyright (C) 2018-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose, 
+	including commercial applications, and to alter it and redistribute it 
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such, 
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#include "StdAfx.h"
+#include "CDbgHelp.h"
+
+#include "util/file.h"
+
+LPCWSTR CDbgHelp::GetDllNameImp(int nIndex)
+{
+	return L"Dbghelp.dll";
+}
+
+bool CDbgHelp::InitDllImp()
+{
+	MiniDumpWriteDump;
+	const ImportTable table[] = {
+		{ (void*)&m_pfnMiniDumpWriteDump,		"MiniDumpWriteDump" },
+		{ nullptr, 0 }
+	};
+
+	return RegisterEntries(table);
+}
+
+/*!
+	@brief クラッシュダンプ
+	
+	@author ryoji
+	@date 2009.01.21
+ */
+int CDbgHelp::WriteDump( PEXCEPTION_POINTERS pExceptPtrs )
+{
+	if (m_pfnMiniDumpWriteDump) {
+		const auto dumpFile = GetIniFileName().replace_filename(L"sakura.dmp");
+		if (HANDLE hFile = ::CreateFile(
+			dumpFile.c_str(),
+			GENERIC_WRITE,
+			0,
+			nullptr,
+			CREATE_ALWAYS,
+			FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH,
+			nullptr);
+			hFile && hFile != INVALID_HANDLE_VALUE)
+		{
+			MINIDUMP_EXCEPTION_INFORMATION* pInfo = nullptr;
+
+			MINIDUMP_EXCEPTION_INFORMATION eInfo = {};
+			if (pExceptPtrs) {
+				eInfo.ThreadId = GetCurrentThreadId();
+				eInfo.ExceptionPointers = pExceptPtrs;
+				eInfo.ClientPointers = FALSE;
+				pInfo = &eInfo;
+			}
+
+			m_pfnMiniDumpWriteDump(
+				::GetCurrentProcess(),
+				::GetCurrentProcessId(),
+				hFile,
+				MiniDumpNormal,
+				pInfo,
+				nullptr,
+				nullptr);
+
+			::CloseHandle(hFile);
+		}
+	}
+
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+
+/*
+	デバッグセッションを実行します。
+
+	発生した例外は構造化例外で処理され、呼出元に伝播します。
+	例外を握りつぶすわけではないので呼出元でキャッチしなかった場合、そのまま落ちます。
+
+	@param [in] session 実行するコードをラムダで指定します。
+ */
+void CDbgHelp::DbgSession(const std::function<void()>& session)
+{
+	__try {
+		session();
+	}
+	__except (WriteDump(GetExceptionInformation())) {
+	}
+}

--- a/sakura_core/extmodule/CDbgHelp.h
+++ b/sakura_core/extmodule/CDbgHelp.h
@@ -1,0 +1,54 @@
+﻿/*!	@file */
+/*
+	Copyright (C) 2018-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose, 
+	including commercial applications, and to alter it and redistribute it 
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such, 
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#pragma once
+
+#include <minidumpapiset.h>
+
+#include <functional>
+
+#include "CDllHandler.h"
+
+/*!
+	@brief クラッシュダンプサポートクラス
+
+	CProcessから分離。
+ */
+class CDbgHelp : public CDllImp {
+private:
+	decltype(&::MiniDumpWriteDump)	m_pfnMiniDumpWriteDump = nullptr;
+
+public:
+	CDbgHelp() = default;
+	virtual ~CDbgHelp() noexcept = default;
+
+protected:
+	LPCWSTR	GetDllNameImp(int nIndex) override;
+	bool	InitDllImp() override;
+
+	int		WriteDump(PEXCEPTION_POINTERS pExceptPtrs);
+
+public:
+	void	DbgSession(const std::function<void()>& session);
+};

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -24,6 +24,8 @@
 #pragma once
 
 #include <Windows.h>
+#include <CommCtrl.h>
+
 #include "dlg/CDialog.h"
 #include "doc/CEditDoc.h"
 

--- a/sakura_core/plugin/CJackManager.h
+++ b/sakura_core/plugin/CJackManager.h
@@ -74,14 +74,14 @@ enum ERegisterPlugResult {
 };
 
 //ジャック管理クラス
-class CJackManager final : public TSingleton<CJackManager>{
-	friend class TSingleton<CJackManager>;
+class CJackManager final : public TSingleInstance<CJackManager> {
+private:
+	using wstring = std::wstring;
+
+public:
 	CJackManager();
 
-	typedef std::wstring wstring;
-
 	//操作
-public:
 	ERegisterPlugResult RegisterPlug( wstring pszJack, CPlug* plug );	//プラグをジャックに関連付ける
 	bool UnRegisterPlug( wstring pszJack, CPlug* plug );	//プラグの関連付けを解除する
 	bool GetUsablePlug( EJack jack, PlugId plugId, CPlug::Array* plugs );	//利用可能なプラグを検索する

--- a/sakura_core/plugin/CPluginManager.h
+++ b/sakura_core/plugin/CPluginManager.h
@@ -30,12 +30,13 @@
 #define SAKURA_CPLUGINMANAGER_CE705DAD_1876_4B21_9052_07A9BFD292DE_H_
 #pragma once
 
+#include "util/design_template.h"
 #include "plugin/CPlugin.h"
 #include <list>
 #include <string>
 
-class CPluginManager final : public TSingleton<CPluginManager>{
-	friend class TSingleton<CPluginManager>;
+class CPluginManager final : public TSingleInstance<CPluginManager> {
+public:
 	CPluginManager();
 
 	// 型定義

--- a/sakura_core/view/figures/CFigureManager.h
+++ b/sakura_core/view/figures/CFigureManager.h
@@ -31,12 +31,11 @@
 #include "util/design_template.h"
 #include "CFigureStrategy.h"
 
-class CFigureManager : public TSingleton<CFigureManager>{
-	friend class TSingleton<CFigureManager>;
+class CFigureManager : public TSingleInstance<CFigureManager> {
+public:
 	CFigureManager();
 	virtual ~CFigureManager();
 
-public:
 	//! 描画するCFigureを取得
 	//	@param	pText	対象文字列の先頭
 	//	@param	nTextLen	pTextから行末までの長さ(ただしCRLF==2)

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -63,6 +63,7 @@
 #include "util/design_template.h"
 #include "doc/CDocListener.h"
 #include "uiparts/CMenuDrawer.h"
+#include "view/figures/CFigureManager.h"
 #include "view/CViewFont.h"
 #include "view/CMiniMapView.h"
 
@@ -99,6 +100,9 @@ class CEditWnd
 : public TSingleton<CEditWnd>
 , public CDocListenerEx
 {
+private:
+	CFigureManager		m_cFigureManager;
+
 	friend class TSingleton<CEditWnd>;
 	CEditWnd();
 	~CEditWnd();

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -96,18 +96,14 @@ struct STabGroupInfo{
 // 2002.02.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 // 2007.10.30 kobake IsFuncEnable,IsFuncCheckedをFunccode.hに移動
 // 2007.10.30 kobake OnHelp_MenuItemをCEditAppに移動
-class CEditWnd
-: public TSingleton<CEditWnd>
-, public CDocListenerEx
-{
+class CEditWnd : public CDocListenerEx, public TSingleInstance<CEditWnd> {
 private:
 	CFigureManager		m_cFigureManager;
 
-	friend class TSingleton<CEditWnd>;
+public:
 	CEditWnd();
 	~CEditWnd();
 
-public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           作成                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/window/CMainToolBar.h
+++ b/sakura_core/window/CMainToolBar.h
@@ -27,6 +27,9 @@
 #define SAKURA_CMAINTOOLBAR_FEA7E388_DFEC_4E15_94CC_90A7E779797B_H_
 #pragma once
 
+#include <Windows.h>
+#include <CommCtrl.h>
+
 #include "dlg/CDialog.h"
 #include "recent/CRecentSearch.h"
 

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -39,6 +39,9 @@
 #define SAKURA_CTABWND_E95D57BD_51E6_467A_9F6D_2C68BF122449_H_
 #pragma once
 
+#include <Windows.h>
+#include <CommCtrl.h>
+
 #include "CWnd.h"
 #include "util/design_template.h"
 #include "env/CommonSetting.h"

--- a/tests/stubs/ppa_stub/CMakeLists.txt
+++ b/tests/stubs/ppa_stub/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.12)
+
+# define a variable of project name
+set(project_name ppa_stub)
+
+# define a project name
+project (${project_name} LANGUAGES CXX C)
+
+set(CMAKE_CXX_STANDARD 17)    # C++17...
+set(CMAKE_CXX_STANDARD_REQUIRED ON) #...is required...
+
+# define variables by file GLOB
+file(GLOB_RECURSE SOURCES *.cpp)
+file(GLOB_RECURSE DEF_FILES *.def)
+
+# define sources files of an executable
+add_library(${project_name} MODULE ${SOURCES} ${DEF_FILES})
+
+# fix the error 'Missing variable is: CMAKE_RC_CREATE_SHARED_LIBRARY'
+# https://cmake.org/pipermail/cmake/2012-January/048647.html
+set_target_properties(${project_name}
+  PROPERTIES
+    LINKER_LANGUAGE "CXX"
+  )
+
+if(MINGW)
+    # avoid prefixing of DLL name, set PREFIX to blank.
+	# https://cmake.org/cmake/help/v3.12/prop_tgt/PREFIX.html?highlight=prefix
+	set_target_properties(${project_name}
+	  PROPERTIES
+	    PREFIX		""
+    )
+endif()
+
+install(
+    TARGETS ${project_name}
+    EXPORT ${project_name}
+    LIBRARY DESTINATION .
+    RUNTIME DESTINATION .
+)

--- a/tests/stubs/ppa_stub/dllmain.cpp
+++ b/tests/stubs/ppa_stub/dllmain.cpp
@@ -1,0 +1,83 @@
+﻿/*!	@file */
+/*
+	Copyright (C) 2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose, 
+	including commercial applications, and to alter it and redistribute it 
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such, 
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#include <Windows.h>
+
+#include <cassert>
+
+#include "ppa_stub.h"
+
+//! PPAスタブのインスタンス(static)
+std::unique_ptr<CPpaStub> CPpaStub::gm_Instance = nullptr;
+
+//! PPAスタブのインスタンスを生成する
+void CPpaStub::createInstance() {
+	assert(!gm_Instance);
+
+	gm_Instance = std::make_unique<CPpaStub>();
+}
+
+//! PPAスタブのインスタンスを取得する
+CPpaStub* CPpaStub::getInstance() noexcept {
+	assert(gm_Instance);
+
+	return gm_Instance.get();
+}
+
+//! PPAスタブのインスタンスを解放する
+void CPpaStub::releaseInstance() noexcept {
+	gm_Instance.reset();
+}
+
+/*!
+	DLLのエントリポイント
+
+	プロセスのアタッチ時にPPAスタブのインスタンスを生成し、
+	プロセスのデタッチ時にPPAスタブのインスタンスを破棄する。
+ */
+BOOL APIENTRY DllMain(
+	HMODULE hModule,
+	DWORD  ul_reason_for_call,
+	LPVOID lpReserved
+)
+{
+	UNREFERENCED_PARAMETER(lpReserved);
+
+	switch (ul_reason_for_call)
+	{
+	case DLL_PROCESS_ATTACH:
+		CPpaStub::createInstance();
+		break;
+
+	case DLL_THREAD_ATTACH:
+	case DLL_THREAD_DETACH:
+		break;
+
+	case DLL_PROCESS_DETACH:
+	default:
+		CPpaStub::releaseInstance();
+		break;
+	}
+	return TRUE;
+}

--- a/tests/stubs/ppa_stub/ppa.cpp
+++ b/tests/stubs/ppa_stub/ppa.cpp
@@ -1,0 +1,55 @@
+﻿/*!	@file */
+/*
+	Copyright (C) 2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose, 
+	including commercial applications, and to alter it and redistribute it 
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such, 
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#include "ppa.h"
+
+void	APIENTRY AddIntObj(LPCSTR, int, BOOL, int) {}
+void	APIENTRY AddIntVar(LPCSTR, int, int) {}
+void	APIENTRY AddRealObj(LPCSTR, double, BOOL, LONG) {}
+void	APIENTRY AddRealVar(LPCSTR, double, BOOL) {}
+void	APIENTRY AddStrObj(LPCSTR, LPCSTR, BOOL, int) {}
+void	APIENTRY AddStrVar(LPCSTR, LPCSTR, int) {}
+void	APIENTRY DeleteVar(LPCSTR) {}
+void	APIENTRY Execute() {}
+LPSTR	APIENTRY GetArgBStr(int) { return nullptr; }
+int		APIENTRY GetArgInt(int) { return 0; }
+DWORD	APIENTRY GetArgReal(int) { return 0; }
+LPSTR	APIENTRY GetArgStr(int) { return nullptr; }
+LPSTR	APIENTRY GetBStrVar(LPCSTR) { return nullptr; }
+int		APIENTRY GetIntVar(LPCSTR) { return 0; }
+int		APIENTRY GetPpaVersion() { return 124; }
+double	APIENTRY GetRealVar(LPCSTR) { return 0; }
+LPSTR	APIENTRY GetStrVar(LPCSTR) { return nullptr; }
+BYTE	APIENTRY IsRunning() { return FALSE; }
+void	APIENTRY SetDeclare(LPCSTR) {}
+void	APIENTRY SetDefProc(LPCSTR) {}
+void	APIENTRY SetDefine(LPCSTR) {}
+void	APIENTRY SetIntObj(void*) {}
+BOOL	APIENTRY SetIntVar(LPCSTR, int) { return FALSE; }
+void	APIENTRY SetRealFunc(void*) {}
+void	APIENTRY SetRealObj(void*) {}
+BOOL	APIENTRY SetRealVar(LPCSTR, double) { return FALSE; }
+void	APIENTRY SetSource(LPCSTR ss) {}
+BOOL	APIENTRY SetStrVar(LPCSTR, LPCSTR) { return FALSE; }
+void	APIENTRY ppaAbort() {}

--- a/tests/stubs/ppa_stub/ppa.h
+++ b/tests/stubs/ppa_stub/ppa.h
@@ -1,0 +1,80 @@
+﻿/*!	@file */
+/*
+	Copyright (C) 2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose, 
+	including commercial applications, and to alter it and redistribute it 
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such, 
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#pragma once
+
+#include <Windows.h>
+
+// PPAのコールバック関数
+extern "C" {
+	void CALLBACK ppaProc(LPCSTR funcName, int index, LPCSTR* argv, int argc, int* errCd);
+	void CALLBACK ppaIntFunc(LPCSTR funcName, int index, LPCSTR* argv, int argc, int* errCd, int* resultValue);
+	void CALLBACK ppaStrFunc(LPCSTR funcName, int index, LPCSTR* argv, int argc, int* errCd, LPSTR* resultValue);
+	void CALLBACK ppaStrObj(LPCSTR objName, int index, BYTE GS_Mode, int* errCd, LPSTR* value);
+	void CALLBACK ppaErrorProc(int errCd, LPCSTR errMsg);
+	void CALLBACK ppaFinishProc();
+}
+
+// PPAのAPI関数(サクラエディタでコールバックを実装している分)
+extern "C" {
+	void	APIENTRY SetProc(decltype(&ppaProc) proc);
+	void	APIENTRY SetIntFunc(decltype(&ppaIntFunc) proc);
+	void	APIENTRY SetStrFunc(decltype(&ppaStrFunc) proc);
+	void	APIENTRY SetStrObj(decltype(&ppaStrObj) proc);
+	void	APIENTRY SetErrProc(decltype(&ppaErrorProc) proc);
+	void	APIENTRY SetFinishProc(decltype(&ppaFinishProc) proc);
+}
+
+// PPAのAPI関数(未使用関数を含む)
+extern "C" {
+	void	APIENTRY AddIntObj(LPCSTR, int, BOOL, int);
+	void	APIENTRY AddIntVar(LPCSTR, int, int);
+	void	APIENTRY AddRealObj(LPCSTR, double, BOOL, LONG);
+	void	APIENTRY AddRealVar(LPCSTR, double, BOOL);
+	void	APIENTRY AddStrObj(LPCSTR, LPCSTR, BOOL, int);
+	void	APIENTRY AddStrVar(LPCSTR, LPCSTR, int);
+	void	APIENTRY DeleteVar(LPCSTR);
+	void	APIENTRY Execute();
+	LPSTR	APIENTRY GetArgBStr(int);
+	int		APIENTRY GetArgInt(int);
+	DWORD	APIENTRY GetArgReal(int);
+	LPSTR	APIENTRY GetArgStr(int);
+	LPSTR	APIENTRY GetBStrVar(LPCSTR);
+	int		APIENTRY GetIntVar(LPCSTR);
+	int		APIENTRY GetPpaVersion();
+	double	APIENTRY GetRealVar(LPCSTR);
+	LPSTR	APIENTRY GetStrVar(LPCSTR);
+	BYTE	APIENTRY IsRunning();
+	void	APIENTRY SetDeclare(LPCSTR);
+	void	APIENTRY SetDefProc(LPCSTR);
+	void	APIENTRY SetDefine(LPCSTR);
+	void	APIENTRY SetIntObj(void*);
+	BOOL	APIENTRY SetIntVar(LPCSTR, int);
+	void	APIENTRY SetRealFunc(void*);
+	void	APIENTRY SetRealObj(void*);
+	BOOL	APIENTRY SetRealVar(LPCSTR, double);
+	void	APIENTRY SetSource(LPCSTR);
+	BOOL	APIENTRY SetStrVar(LPCSTR, LPCSTR);
+	void	APIENTRY ppaAbort();
+}

--- a/tests/stubs/ppa_stub/ppa_stub.cpp
+++ b/tests/stubs/ppa_stub/ppa_stub.cpp
@@ -1,0 +1,157 @@
+﻿/*!	@file */
+/*
+	Copyright (C) 2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose, 
+	including commercial applications, and to alter it and redistribute it 
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such, 
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#include "ppa_stub.h"
+
+void APIENTRY SetProc(decltype(&ppaProc) proc) {
+	if (auto stub = CPpaStub::getInstance()) {
+		stub->SetProc(proc);
+	}
+}
+
+void CPpaStub::SetProc(decltype(&ppaProc) proc) {
+	m_pfnProc = proc;
+}
+
+void CPpaStub::CallProc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd) const {
+	if (m_pfnProc) {
+		m_pfnProc(funcName, index, argv, argc, errCd);
+	}
+}
+
+void WINAPI CallProc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd) {
+	if (const auto stub = CPpaStub::getInstance()) {
+		stub->CallProc(funcName, index, argv, argc, errCd);
+	}
+}
+
+void APIENTRY SetIntFunc(decltype(&ppaIntFunc) proc) {
+	if (auto stub = CPpaStub::getInstance()) {
+		stub->SetIntFunc(proc);
+	}
+}
+
+void CPpaStub::SetIntFunc(decltype(&ppaIntFunc) proc) {
+	m_pfnIntFunc = proc;
+}
+
+void CPpaStub::CallIntFunc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd, int* resultValue) const {
+	if (m_pfnIntFunc) {
+		m_pfnIntFunc(funcName, index, argv, argc, errCd, resultValue);
+	}
+}
+
+void WINAPI CallIntFunc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd, int* resultValue) {
+	if (auto stub = CPpaStub::getInstance()) {
+		stub->CallIntFunc(funcName, index, argv, argc, errCd, resultValue);
+	}
+}
+
+void APIENTRY SetStrFunc(decltype(&ppaStrFunc) proc) {
+	if (auto stub = CPpaStub::getInstance()) {
+		stub->SetStrFunc(proc);
+	}
+}
+
+void CPpaStub::SetStrFunc(decltype(&ppaStrFunc) proc) {
+	m_pfnStrFunc = proc;
+}
+
+void CPpaStub::CallStrFunc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd, LPSTR* resultValue) const {
+	if (m_pfnStrFunc) {
+		m_pfnStrFunc(funcName, index, argv, argc, errCd, resultValue);
+	}
+}
+
+void WINAPI CallStrFunc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd, LPSTR* resultValue) {
+	if (const auto stub = CPpaStub::getInstance()) {
+		stub->CallStrFunc(funcName, index, argv, argc, errCd, resultValue);
+	}
+}
+
+void APIENTRY SetStrObj(decltype(&ppaStrObj) proc) {
+	if (auto stub = CPpaStub::getInstance()) {
+		stub->SetStrObj(proc);
+	}
+}
+
+void CPpaStub::SetStrObj(decltype(&ppaStrObj) proc) {
+	m_pfnStrObj = proc;
+}
+
+void CPpaStub::CallStrObj(LPCSTR ObjName, int index, BYTE GS_Mode, int* errCd, LPSTR* value) const {
+	if (m_pfnStrObj) {
+		m_pfnStrObj(ObjName, index, GS_Mode, errCd, value);
+	}
+}
+
+void WINAPI CallStrObj(LPCSTR ObjName, int index, BYTE GS_Mode, int* errCd, LPSTR* value) {
+	if (const auto stub = CPpaStub::getInstance()) {
+		stub->CallStrObj(ObjName, index, GS_Mode, errCd, value);
+	}
+}
+
+void APIENTRY SetErrProc(decltype(&ppaErrorProc) proc) {
+	if (auto stub = CPpaStub::getInstance()) {
+		stub->SetErrorProc(proc);
+	}
+}
+
+void CPpaStub::SetErrorProc(decltype(&ppaErrorProc) proc) {
+	m_pfnErrorProc = proc;
+}
+
+void CPpaStub::CallErrorProc(int errCd, LPCSTR errMsg) const {
+	if (m_pfnErrorProc) {
+		m_pfnErrorProc(errCd, errMsg);
+	}
+}
+
+void WINAPI CallErrorProc(int errCd, LPCSTR errMsg) {
+	if (const auto stub = CPpaStub::getInstance()) {
+		stub->CallErrorProc(errCd, errMsg);
+	}
+}
+
+void APIENTRY SetFinishProc(decltype(&ppaFinishProc) proc) {
+	if (auto stub = CPpaStub::getInstance()) {
+		stub->SetFinishProc(proc);
+	}
+}
+
+void CPpaStub::SetFinishProc(decltype(&ppaFinishProc) proc) {
+    m_pfnFinishProc = proc;
+}
+
+void CPpaStub::CallFinishProc() const {
+	if (m_pfnFinishProc) {
+		m_pfnFinishProc();
+	}
+}
+
+void WINAPI CallFinishProc() {
+	if (const auto stub = CPpaStub::getInstance()) {
+		stub->CallFinishProc();
+	}
+}

--- a/tests/stubs/ppa_stub/ppa_stub.def
+++ b/tests/stubs/ppa_stub/ppa_stub.def
@@ -1,0 +1,44 @@
+﻿LIBRARY "PPA_STUB"
+
+EXPORTS
+	AddIntObj                   @18
+	AddIntVar
+	AddRealObj                   @8
+	AddRealVar                   @9
+	AddStrObj                   @17
+	AddStrVar
+	DeleteVar                   @29
+	Execute                     @35
+	GetArgBStr                  @22
+	GetArgInt                   @24
+	GetArgReal                  @3
+	GetArgStr                   @23
+	GetBStrVar                  @13
+	GetIntVar                   @16
+	GetRealVar                   @7
+	GetStrVar                   @14
+	GetVersion=GetPpaVersion    @21
+	IsRunning                    @2
+	SetDeclare                  @37
+	SetDefProc                  @33
+	SetDefine                   @32
+	SetErrProc                  @25
+	SetFinishProc                @1
+	SetIntFunc                  @28
+	SetIntObj                   @11
+	SetIntVar                   @15
+	SetProc                     @26
+	SetRealFunc                  @5
+	SetRealObj                   @4
+	SetRealVar                   @6
+	SetSource                   @36
+	SetStrFunc                  @27
+	SetStrObj                   @10
+	SetStrVar                   @12
+	ppaAbort                    @34
+	CallProc
+	CallIntFunc
+	CallStrFunc
+	CallStrObj
+	CallErrorProc
+	CallFinishProc

--- a/tests/stubs/ppa_stub/ppa_stub.h
+++ b/tests/stubs/ppa_stub/ppa_stub.h
@@ -1,0 +1,77 @@
+﻿/*!	@file */
+/*
+	Copyright (C) 2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose, 
+	including commercial applications, and to alter it and redistribute it 
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such, 
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#pragma once
+
+#include "ppa.h"
+
+#include <memory>
+
+// PPAスタブのAPI関数
+extern "C" {
+	void	APIENTRY CallIntFunc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd, int* resultValue);
+	void	APIENTRY CallStrFunc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd, LPSTR* resultValue);
+	void	APIENTRY CallProc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd);
+	void	APIENTRY CallErrorProc(int errCd, LPCSTR errMsg);
+	void	APIENTRY CallStrObj(LPCSTR ObjName, int index, BYTE GS_Mode, int* errCd, LPSTR* value);
+	void	APIENTRY CallFinishProc();
+}
+
+/*!
+	PPAスタブ
+
+	PPAから呼ばれるコールバック関数をテストするためのもの。
+	DLLロード時に生成し、アンロード時に破棄する。
+	テスト目的なのでマルチスレッドは考慮していない。
+	マルチスレッド考慮が必要と判明したら拡張すること。
+ */
+class CPpaStub {
+private:
+	static std::unique_ptr<CPpaStub> gm_Instance;
+
+	decltype(&ppaProc)			m_pfnProc = nullptr;
+	decltype(&ppaIntFunc)		m_pfnIntFunc = nullptr;
+	decltype(&ppaStrFunc)		m_pfnStrFunc = nullptr;
+	decltype(&ppaStrObj)		m_pfnStrObj = nullptr;
+	decltype(&ppaErrorProc)		m_pfnErrorProc = nullptr;
+	decltype(&ppaFinishProc)	m_pfnFinishProc = nullptr;
+
+public:
+	static void createInstance();
+	static CPpaStub* getInstance() noexcept;
+	static void releaseInstance() noexcept;
+
+	void	SetProc(decltype(&ppaProc) p);
+	void	CallProc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd) const;
+	void	SetIntFunc(decltype(&ppaIntFunc) p);
+	void	CallIntFunc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd, int* resultValue) const;
+	void	SetStrFunc(decltype(&ppaStrFunc) p);
+	void	CallStrFunc(LPCSTR funcName, int index, LPCSTR* argv, const int argc, int* errCd, LPSTR* resultValue) const;
+	void	SetStrObj(decltype(&ppaStrObj) p);
+	void	CallStrObj(LPCSTR ObjName, int index, BYTE GS_Mode, int* errCd, LPSTR* value) const;
+	void	SetErrorProc(decltype(&ppaErrorProc) p);
+	void	CallErrorProc(int errCd, LPCSTR errMsg) const;
+	void	SetFinishProc(decltype(&ppaFinishProc) p);
+	void	CallFinishProc() const;
+};

--- a/tests/stubs/ppa_stub/ppa_stub.targets
+++ b/tests/stubs/ppa_stub/ppa_stub.targets
@@ -1,0 +1,25 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
+  <PropertyGroup Label="PpaStub">
+    <PpaStubBuildDir>$(SolutionDir)build\$(Platform)\$(Configuration)\ppa_stub\</PpaStubBuildDir>
+  </PropertyGroup>
+  <Target Name="MakePpaStubBuildDir" Condition="!Exists('$(PpaStubBuildDir)')">
+    <MakeDir Directories="$(PpaStubBuildDir)" />
+  </Target>
+  <Target Name="BuildPpaStub"
+    DependsOnTargets="MakePpaStubBuildDir;Link"
+    BeforeTargets="FinalizeBuildStatus">
+    <PropertyGroup>
+      <VsVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(VisualStudioVersion)', '^(\d+).*', '$1'))</VsVersion>
+    </PropertyGroup>
+    <SetEnv name="platform" value="$(Platform)" prefix="false" />
+    <SetEnv name="configuration" value="$(Configuration)" prefix="false" />
+    <SetEnv name="NUM_VSVERSION" value="$(VsVersion)" prefix="false" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)..\..\..\tools\cmake-build-and-install.cmd&quot; &quot;$(MSBuildThisFileDirectory)&quot; &quot;$(PpaStubBuildDir)&quot; &quot;$(OutDir)&quot;" ConsoleToMSBuild="true" />
+  </Target>
+  <Target Name="AppendCleanTargetsForPpaStub" BeforeTargets="CoreClean">
+    <ItemGroup>
+      <Clean Include="$(PpaStubRuntime)" />
+    </ItemGroup>
+    <RemoveDir Directories="$(PpaStubBuildDir)" />
+  </Target>
+</Project>

--- a/tests/unittests/CEditorProcessForTest.cpp
+++ b/tests/unittests/CEditorProcessForTest.cpp
@@ -1,0 +1,97 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#include "StdAfx.h"
+#include "CEditorProcessForTest.hpp"
+
+static constexpr auto& EMPTY_STRING = L"";
+
+CEditorProcessForTest::CEditorProcessForTest()
+	: CProcess(::GetModuleHandle(nullptr), EMPTY_STRING)
+{
+	// 共有メモリを初期化するにはコマンドラインのインスタンスが必要
+	m_cCommandLine.ParseCommandLine(EMPTY_STRING, false);
+}
+
+/*!
+	デストラクタ
+ */
+CEditorProcessForTest::~CEditorProcessForTest()
+{
+	// エディタウインドウを解放する
+	m_pcEditWnd = nullptr;
+
+	// エディタアプリを解放する
+	m_pcEditApp = nullptr;
+
+	// ドキュメントは最後に解放する
+	m_pcEditDoc = nullptr;
+
+	if (SUCCEEDED(m_hrCoInit))
+	{
+		::OleUninitialize();
+	}
+}
+
+/*!
+	@brief エディタプロセスを初期化する
+	
+	CEditWndを作成する。
+ */
+bool CEditorProcessForTest::InitializeProcess()
+{
+	if (m_hrCoInit = ::OleInitialize(nullptr);
+		FAILED(m_hrCoInit))
+	{
+		return false;
+	}
+
+	/* 共有メモリを初期化する */
+	if (!CProcess::InitializeProcess()) {
+		return false;
+	}
+
+	// ドキュメントのインスタンスを生成する
+	if (m_pcEditDoc = std::make_unique<CEditDoc>(nullptr);
+		m_pcEditDoc == nullptr)
+	{
+		return false;
+	}
+
+	// エディタアプリのインスタンスを生成
+	if (m_pcEditApp = std::make_unique<CEditApp>();
+		m_pcEditApp == nullptr)
+	{
+		return false;
+	}
+
+	// 編集ウインドウのインスタンスを生成する
+	if (m_pcEditWnd = std::make_unique<CEditWnd>();
+		m_pcEditWnd == nullptr)
+	{
+		return false;
+	}
+
+	return true;
+}

--- a/tests/unittests/CEditorProcessForTest.hpp
+++ b/tests/unittests/CEditorProcessForTest.hpp
@@ -1,0 +1,146 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#pragma once
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif /* #ifndef NOMINMAX */
+
+#include <Windows.h>
+#include <CommCtrl.h>
+
+#include "_main/CCommandLine.h"
+#include "_main/CNormalProcess.h"
+#include "doc/CEditDoc.h"
+#include "window/CEditWnd.h"
+#include "CGrepAgent.h"
+
+/*!
+	テストコード用エディタプロセスクラス
+
+	エディタプロセスはCEditWndクラスのインスタンスを作る。
+ */
+class CEditorProcessForTest final : public CProcess {
+private:
+	using CEditDocPtr = std::unique_ptr<CEditDoc>;
+	using CEditWndPtr = std::unique_ptr<CEditWnd>;
+	using CEditAppPtr = std::unique_ptr<CEditApp>;
+
+	CCommandLine	m_cCommandLine;
+	HRESULT			m_hrCoInit = E_UNEXPECTED;
+	CEditDocPtr		m_pcEditDoc;
+	CEditWndPtr		m_pcEditWnd;
+	CEditAppPtr		m_pcEditApp;
+	CMigemo			m_cMigemo;
+
+public:
+	CEditorProcessForTest();
+	~CEditorProcessForTest();
+
+	bool InitializeProcess() override;
+
+protected:
+	bool MainLoop() override { return false; }
+	void OnExitProcess() override {}
+};
+
+void CControlProcess_Start(std::wstring_view profileName);
+void CControlProcess_Terminate(std::wstring_view profileName);
+
+#include <gtest/gtest.h>
+
+/*!
+ * CEditDocのためのフィクスチャクラス
+ *
+ * 設定ファイルを使うテストは「設定ファイルがない状態」からの始動を想定しているので
+ * 始動前に設定ファイルを削除するようにしている。
+ * テスト実行後に設定ファイルを残しておく意味はないので終了後も削除している。
+ */
+template<typename TargetClass>
+class TEditorProcessTest : public ::testing::Test {
+protected:
+	/*!
+	 * プロファイル名
+	 */
+	static std::wstring_view profileName;
+
+	/*!
+	 * 設定ファイルのパス
+	 *
+	 * GetIniFileNameを使ってtests1.iniのパスを取得する。
+	 */
+	static std::filesystem::path iniPath;
+
+	/*!
+	 * 最初のテストが起動される前に呼ばれる関数
+	 */
+	static void SetUpTestCase() {
+		// INIファイルのパスを取得
+		iniPath = GetIniFileName();
+
+		// INIファイルを削除する
+		if (fexist(iniPath.c_str())) {
+			std::filesystem::remove(iniPath);
+		}
+
+		// コントロールプロセスを起動する
+		CControlProcess_Start(profileName.data());
+	}
+
+	/*!
+	 * 最後のテストが完了した後に呼ばれる関数
+	 */
+	static void TearDownTestCase() {
+		// コントロールプロセスに終了指示を出して終了を待つ
+		CControlProcess_Terminate(profileName.data());
+
+		// INIファイルを削除する
+		if (fexist(iniPath.c_str())) {
+			std::filesystem::remove(iniPath);
+		}
+	}
+
+	/*!
+	 * テストコード用エディタプロセス
+	 */
+	CEditorProcessForTest process;
+
+	/*!
+	 * テストが起動される直前に毎回呼ばれる関数
+	 */
+	void SetUp() override {
+		// テストコード用エディタプロセスを初期化する
+		ASSERT_TRUE(process.InitializeProcess());
+	}
+};
+
+//! プロファイル名
+template<typename TargetClass>
+std::wstring_view TEditorProcessTest<TargetClass>::profileName = L"";
+
+//! INIファイルのパス
+template<typename TargetClass>
+std::filesystem::path TEditorProcessTest<TargetClass>::iniPath;
+

--- a/tests/unittests/TExtModule.hpp
+++ b/tests/unittests/TExtModule.hpp
@@ -54,6 +54,24 @@ public:
 		// 将来的には、適切な戻り値型に変更したい。
 		this->InitDll(nullptr);
 	}
+
+	/*!
+		指定したシグニチャを持つAPI関数を呼び出す
+	 */
+	template<typename ProcType, typename ... Args>
+	void CallDllProc(LPCSTR procName, Args... args) const {
+		if (const auto hModule = this->GetInstance()) {
+			if (const auto pfnProc = (ProcType)::GetProcAddress(hModule, procName)) {
+				pfnProc(args...);
+			}
+			else {
+				FAIL();
+			}
+		}
+		else {
+			FAIL();
+		}
+	}
 };
 
 /*!

--- a/tests/unittests/eval_outputs.hpp
+++ b/tests/unittests/eval_outputs.hpp
@@ -31,3 +31,9 @@
 	testing::internal::CaptureStderr(); \
 	statementExpression; \
 	EXPECT_STREQ(strprintf(L"%s\n", expected).data(), u8stowcs(testing::internal::GetCapturedStderr()).data())
+
+// 標準エラー出力に何も出力されないことを評価します
+#define EXPECT_NOERROUT(statementExpression) \
+	testing::internal::CaptureStderr(); \
+	statementExpression; \
+	EXPECT_STREQ(L"", u8stowcs(testing::internal::GetCapturedStderr()).data())

--- a/tests/unittests/test-cdbghelp.cpp
+++ b/tests/unittests/test-cdbghelp.cpp
@@ -1,0 +1,66 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#include <eh.h>
+
+#include "_main/global.h"
+#include "extmodule/CDbgHelp.h"
+
+#include "util/file.h"
+
+/*!
+	クラッシュダンプのテスト
+ */
+TEST(CDbgHelp, test)
+{
+	const auto dumpFile = GetIniFileName().replace_filename(L"sakura.dmp");
+
+	CDbgHelp cDbgHelp;
+	cDbgHelp.InitDll();
+	ASSERT_TRUE(cDbgHelp.IsAvailable());
+
+	try
+	{
+		// 何もしないセッションを実行させる
+		cDbgHelp.DbgSession([]() {});
+
+		// 例外を発生させる
+		cDbgHelp.DbgSession([]() {
+			throw L"何か問題が起きたぜ！";
+		});
+
+		// 例外をスローできていたらここには来ない
+		FAIL();
+	}
+	// tryブロックで発生したあらゆる例外をキャッチして握りつぶす　←アプリコードでこれをやってはいけない
+	catch (...) {
+		// ダンプファイルが作成されているはず。
+		EXPECT_TRUE(fexist(dumpFile.c_str()));
+
+		// ダンプファイルを削除する
+		std::filesystem::remove(dumpFile);
+	}
+}

--- a/tests/unittests/test-cdoclinemgr.cpp
+++ b/tests/unittests/test-cdoclinemgr.cpp
@@ -26,8 +26,17 @@
 #include "doc/logic/CDocLineMgr.h"
 
 #include <array>
+#include <cstdlib>
+#include <filesystem>
 
-TEST(CDocLineMgr, ListManipulations)
+#include "CEditorProcessForTest.hpp"
+
+/*!
+ * CDocLineMgrのためのフィクスチャクラス
+ */
+using CDocLineMgrTest = TEditorProcessTest<CDocLineMgr>;
+
+TEST_F(CDocLineMgrTest, ListManipulations)
 {
 	CDocLineMgr m;
 
@@ -139,7 +148,7 @@ TEST(CDocLineMgr, ListManipulations)
 	EXPECT_EQ(m.GetDocLineBottom(), nullptr);
 }
 
-TEST(CDocLineMgr, RandomAccess)
+TEST_F(CDocLineMgrTest, RandomAccess)
 {
 	std::array<CDocLine*, 100> lines;
 	CDocLineMgr m;

--- a/tests/unittests/test-ceditdoc.cpp
+++ b/tests/unittests/test-ceditdoc.cpp
@@ -1,0 +1,122 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2018-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+*/
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+
+#include "CEditorProcessForTest.hpp"
+
+/*!
+ * CEditDocのためのフィクスチャクラス
+ */
+using CEditDocTest = TEditorProcessTest<CEditDoc>;
+
+/*!
+ * このウィンドウで新しいファイルを開けるか
+ */
+TEST_F(CEditDocTest, IsAcceptLoad)
+{
+	if (auto pcEditDoc = CEditDoc::getInstance()) {
+		// 初期状態は再利用可能
+		EXPECT_TRUE(pcEditDoc->IsAcceptLoad());
+
+		// デバッグモニタモードは再利用不可
+		CAppMode::getInstance()->SetDebugModeON();
+		EXPECT_FALSE(pcEditDoc->IsAcceptLoad());
+
+		// デバッグモニタモードを解除
+		CAppMode::getInstance()->SetDebugModeOFF();
+		EXPECT_TRUE(pcEditDoc->IsAcceptLoad());
+
+		// GREPモードは再利用不可
+		CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode = true;
+		EXPECT_FALSE(pcEditDoc->IsAcceptLoad());
+
+		// GREPモードを解除
+		CEditApp::getInstance()->m_pcGrepAgent->m_bGrepMode = false;
+		EXPECT_TRUE(pcEditDoc->IsAcceptLoad());
+	}
+}
+
+/*!
+ * 編集可能かどうか
+ */
+TEST_F(CEditDocTest, IsEditable)
+{
+	if (auto pcEditDoc = CEditDoc::getInstance()) {
+		// 初期状態は編集可能
+		EXPECT_TRUE(pcEditDoc->IsEditable());
+
+		// ビューモードは編集不可
+		CAppMode::getInstance()->SetViewMode(true);
+		EXPECT_FALSE(pcEditDoc->IsEditable());
+
+		// ビューモードを解除
+		CAppMode::getInstance()->SetViewMode(false);
+		EXPECT_TRUE(pcEditDoc->IsEditable());
+	}
+}
+
+/*!
+ * 背景画像を読み込み
+ */
+TEST_F(CEditDocTest, SetBackgroundImage)
+{
+	if (auto pcEditDoc = CEditDoc::getInstance()) {
+		// パスが空文字の状態で呼ぶ
+		pcEditDoc->SetBackgroundImage();
+
+		// パスを設定して呼ぶ
+		auto& sTypeConfig = pcEditDoc->m_cDocType.GetDocumentAttributeWrite();
+		sTypeConfig.m_szBackImgPath.Assign(LR"(..\..\resource\my_icons.bmp)");
+		pcEditDoc->SetBackgroundImage();
+
+		// とりあえずもう一回呼ぶ
+		pcEditDoc->SetBackgroundImage();
+
+		// 後処理が面倒なのでクリアしておく
+		sTypeConfig.m_szBackImgPath.Assign(L"");
+	}
+}
+
+/*!
+ * セーブ情報を取得
+ */
+TEST_F(CEditDocTest, GetSaveInfo)
+{
+	SSaveInfo sSaveInfo;
+
+	if (auto pcEditDoc = CEditDoc::getInstance()) {
+		// セーブ情報を取得
+		pcEditDoc->GetSaveInfo(&sSaveInfo);
+
+		EXPECT_STREQ(L"", sSaveInfo.cFilePath.c_str());
+		EXPECT_EQ(CODE_UTF8, sSaveInfo.eCharCode);
+		EXPECT_FALSE(sSaveInfo.bBomExist);
+		EXPECT_FALSE(sSaveInfo.bChgCodeSet);
+		EXPECT_EQ(EEolType::cr_and_lf, sSaveInfo.cEol.GetType());
+	}
+}

--- a/tests/unittests/test-cppa.cpp
+++ b/tests/unittests/test-cppa.cpp
@@ -24,15 +24,200 @@
 */
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+#include <filesystem>
+
+#include "eval_outputs.hpp"
+#include "TExtModule.hpp"
+#include "CEditorProcessForTest.hpp"
+
 #include "macro/CPPA.h"
+#include "macro/CPPAMacroMgr.h"
+
+// PPAのコールバック関数
+extern "C" {
+	void CALLBACK ppaProc(LPCSTR funcName, int index, LPCSTR* argv, int argc, int* errCd);
+	void CALLBACK ppaIntFunc(LPCSTR funcName, int index, LPCSTR* argv, int argc, int* errCd, int* resultValue);
+	void CALLBACK ppaStrFunc(LPCSTR funcName, int index, LPCSTR* argv, int argc, int* errCd, LPSTR* resultValue);
+	void CALLBACK ppaStrObj(LPCSTR objName, int index, BYTE GS_Mode, int* errCd, LPSTR* value);
+	void CALLBACK ppaErrorProc(int errCd, LPCSTR errMsg);
+	void CALLBACK ppaFinishProc();
+}
+
+// PPAの定数
+namespace ppa {
+	constexpr auto omGet = 0;
+	constexpr auto omSet = 1;
+}
+
+/*!
+	スタブを用いてCPPAクラスをテストするためのもの
+ */
+class CPpaStub : public TExtModule<CPPA> {
+public:
+	CPpaStub()
+		: TExtModule(L"ppa_stub.dll") {
+	}
+
+	void CallProc(LPCSTR FuncName, int Index, LPCSTR* Argument, int ArgSize, int* Err_CD) const {
+		CallDllProc<decltype(&ppaProc)>(__func__, FuncName, Index, Argument, ArgSize, Err_CD);
+	}
+
+	void CallIntFunc(LPCSTR FuncName, int Index, LPCSTR* Argument, int ArgSize, int* Err_CD, int* ResultValue) const {
+		CallDllProc<decltype(&ppaIntFunc)>(__func__, FuncName, Index, Argument, ArgSize, Err_CD, ResultValue);
+	}
+
+	void CallStrFunc(LPCSTR FuncName, int Index, LPCSTR* Argument, int ArgSize, int* Err_CD, LPSTR* ResultValue) const {
+		CallDllProc<decltype(&ppaStrFunc)>(__func__, FuncName, Index, Argument, ArgSize, Err_CD, ResultValue);
+	}
+
+	void CallStrObj(LPCSTR ObjName, int Index, BYTE GS_Mode, int* Err_CD, LPSTR* Value) const {
+		CallDllProc<decltype(&ppaStrObj)>(__func__, ObjName, Index, GS_Mode, Err_CD, Value);
+	}
+
+	//! エラーハンドラを呼び出す 
+	void CallErrorProc(int errCd, LPCSTR errMsg) const {
+		if (auto pcEditWnd = CEditWnd::getInstance()) {
+			// PPAの実行コンテキストを用意する
+			PpaExecInfo execInfo;
+			execInfo.m_pcEditView = &pcEditWnd->GetActiveView();
+			const auto execInfoHolder = CPPA::RegisterExecInfo(execInfo);
+
+			// エラーハンドラを呼び出す
+			CallDllProc<decltype(&ppaErrorProc)>(__func__, errCd, errMsg);
+		}
+	}
+
+	LPCWSTR CallGetDllNameImpl() {
+		return CPPA::GetDllNameImp(0);
+	}
+
+	//! 終了ハンドラを呼び出す 
+	void CallFinishProc() const {
+		CallDllProc<decltype(&ppaFinishProc)>(__func__);
+	}
+};
+
+/*!
+	CPPAのためのフィクスチャクラス
+ */
+class CPpaTest : public TEditorProcessTest<CPPA> {
+protected:
+	[[nodiscard]] CEditView* GetActiveView() const noexcept {
+		if (auto pcEditWnd = CEditWnd::getInstance()) {
+			return &pcEditWnd->GetActiveView();
+		}
+		return nullptr;
+	}
+};
 
 /*!
 	CPPA::GetDllNameImpのテスト
  */
-TEST(CPPA, GetDllNameImp)
+TEST_F(CPpaTest, GetDllNameImp)
 {
-	CPPA cPpa;
-	EXPECT_STREQ(L"PPA.DLL", cPpa.GetDllNameImp(0));
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	EXPECT_STREQ(L"PPA.DLL", cPpa.CallGetDllNameImpl());
+}
+
+/*!
+	CPPAのインポート関数テスト
+
+	スタブを使ったテスト。
+ */
+TEST_F(CPpaTest, CallApis)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	// DLL読み込みは成功する
+	EXPECT_TRUE(cPpa.IsAvailable());
+
+	// ひたすら呼ぶだけ。
+	cPpa.SetProc(nullptr);
+	cPpa.SetIntFunc(nullptr);
+	cPpa.SetStrFunc(nullptr);
+	cPpa.SetStrObj(nullptr);
+	cPpa.SetErrProc(nullptr);
+	cPpa.SetFinishProc(nullptr);
+
+	cPpa.AddIntObj("", 0, FALSE, 0);
+	cPpa.AddIntVar("", 0, 0);
+	cPpa.AddRealObj("", 0.0, FALSE, 0L);
+	cPpa.AddRealVar("", 0.0, FALSE);
+	cPpa.AddStrObj("", "", FALSE, 0);
+	cPpa.AddStrVar("", "", 0);
+	cPpa.DeleteVar("");
+	cPpa.GetArgBStr(0);
+	cPpa.GetArgInt(0);
+	cPpa.GetArgReal(0);
+	cPpa.GetArgStr(0);
+	cPpa.GetBStrVar("");
+	cPpa.GetIntVar("");
+	cPpa.GetVersion();
+	cPpa.GetRealVar("");
+	cPpa.GetStrVar("");
+	cPpa.IsRunning();
+	cPpa.SetDeclare("");
+	cPpa.SetDefProc("");
+	cPpa.SetDefine("");
+	cPpa.SetIntObj(nullptr);
+	cPpa.SetIntVar("", 0);
+	cPpa.SetRealFunc(nullptr);
+	cPpa.SetRealObj(nullptr);
+	cPpa.SetRealVar("", 0.0);
+	cPpa.SetSource("");
+	cPpa.SetStrVar("", "");
+	cPpa.Abort();
+}
+
+/*!
+	CPPA::Executeのテスト
+
+	スタブを使ったテスト。
+	ppa_stub.Executeは何もしないのでテストは成功する。
+ */
+TEST_F(CPpaTest, Execute)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	// DLL読み込みは成功する
+	EXPECT_TRUE(cPpa.IsAvailable());
+
+	// Execute呼出は成功する
+	EXPECT_TRUE(cPpa.Execute(GetActiveView(), 0));
+}
+
+/*!
+	CPPA::Executeのテスト
+
+	スタブを使ったテスト。
+	多重実行防止機構をテストする。
+ */
+TEST_F(CPpaTest, Execute_mutex)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	// DLL読み込みは成功する
+	EXPECT_TRUE(cPpa.IsAvailable());
+
+	// PPAの実行コンテキストを用意する
+	PpaExecInfo execInfo;
+	execInfo.m_pcEditView = GetActiveView();
+	const auto execInfoHolder = CPPA::RegisterExecInfo(execInfo);
+
+	// Execute呼出結果
+	bool ret = false;
+
+	// Execute内でエラーメッセージが出力される
+	EXPECT_ERROUT(ret = cPpa.Execute(GetActiveView(), 0), L"PPA実行中に新たにPPAマクロを呼び出すことはできません");
+
+	// Execute呼出は失敗する
+	EXPECT_FALSE(ret);
 }
 
 /*!
@@ -43,11 +228,12 @@ TEST(CPPA, GetDllNameImp)
 	対応する型はintとstringのみ。（PPA1.2は実数型にも対応しているが未対応）
 	引数は最大8個まで指定できる。(PPAは32個まで対応しているが未対応）
  */
-TEST(CPPA, GetDeclarations)
+TEST_F(CPpaTest, GetDeclarations)
 {
-	setlocale(LC_ALL, "Japanese");
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
 
-	CPPA cPpa;
+	setlocale(LC_ALL, "Japanese");
 
 	// バッファ
 	std::string buffer(1024, L'\0');
@@ -93,4 +279,665 @@ TEST(CPPA, GetDeclarations)
 	MacroFuncInfo funcInfo8 = { 8, L"Func4", { VT_I4, VT_BSTR, VT_I4, VT_BSTR }, VT_BSTR, &funcInfoEx8 };
 	cPpa.GetDeclarations(funcInfo8, buffer.data());
 	EXPECT_STREQ("function S_Func4(i0: Integer; s1: string; i2: Integer; s3: string; i4: Integer; s5: string; i6: Integer; s7: string): string; index 8;", buffer.data());
+}
+
+/*!
+	マクロコマンドのテスト
+ */
+TEST_F(CPpaTest, Proc)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	std::string_view msg = "something is wrong.";
+
+	setlocale(LC_ALL, "Japanese");
+
+	// PPAの実行コンテキストを用意する
+	PpaExecInfo execInfo;
+	execInfo.m_pcEditView = GetActiveView();
+	const auto execInfoHolder = CPPA::RegisterExecInfo(execInfo);
+
+	LPCSTR ppszArgs[] = { msg.data() };
+	int errCd = 0;
+	EXPECT_ERROUT(cPpa.CallProc("OkCancelBox", (int)F_OKCANCELBOX, ppszArgs, _countof(ppszArgs), &errCd), L"something is wrong.");
+}
+
+/*!
+	数値を返すマクロ関数のテスト
+ */
+TEST_F(CPpaTest, IntFunc)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	std::string_view msg = "something is wrong.";
+
+	setlocale(LC_ALL, "Japanese");
+
+	// PPAの実行コンテキストを用意する
+	PpaExecInfo execInfo;
+	execInfo.m_pcEditView = GetActiveView();
+	const auto execInfoHolder = CPPA::RegisterExecInfo(execInfo);
+
+	int errCd = 0;
+	int nResultValue = 1234;
+
+	// 数値を返却する関数を呼び出す
+	LPCSTR ppszArgs1[4] = { msg.data(), nullptr };
+	EXPECT_ERROUT(cPpa.CallIntFunc("OkCancelBox", (int)F_OKCANCELBOX, ppszArgs1, _countof(ppszArgs1), &errCd, &nResultValue), L"something is wrong.");
+	EXPECT_EQ(0, nResultValue);
+	EXPECT_EQ(0, errCd);
+
+	// 文字列を返却する関数を呼び出す
+	LPCSTR ppszArgs2[] = { "$I" };
+	cPpa.CallIntFunc("ExpandParameter", (int)F_EXPANDPARAMETER, ppszArgs2, _countof(ppszArgs2), &errCd, &nResultValue);
+	EXPECT_EQ(0, nResultValue);
+	EXPECT_EQ(-2, errCd);
+
+	// コマンドを呼び出す
+	LPCSTR ppszArgs3[] = { nullptr };
+	cPpa.CallIntFunc("FileNew", (int)F_FILENEW, ppszArgs3, _countof(ppszArgs3), &errCd, &nResultValue);
+	EXPECT_EQ(0, nResultValue);
+	EXPECT_EQ((int)F_FILENEW + 1, errCd);
+}
+
+/*!
+	文字列を返すマクロ関数のテスト
+ */
+TEST_F(CPpaTest, StrFunc)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	std::string_view msg = "something is wrong.";
+
+	setlocale(LC_ALL, "Japanese");
+
+	// PPAの実行コンテキストを用意する
+	PpaExecInfo execInfo;
+	execInfo.m_pcEditView = GetActiveView();
+	const auto execInfoHolder = CPPA::RegisterExecInfo(execInfo);
+
+	std::string buffer(256, L'\0');
+	LPSTR pszResultValue = buffer.data();
+	int errCd = 0;
+
+	// 文字列を返却する関数を呼び出す
+	LPCSTR ppszArgs1[] = { "$I" };
+	cPpa.CallStrFunc("ExpandParameter", (int)F_EXPANDPARAMETER, ppszArgs1, _countof(ppszArgs1), &errCd, &pszResultValue);
+	EXPECT_STREQ(iniPath.string().c_str(), pszResultValue);
+	EXPECT_EQ(0, errCd);
+
+	// 数値を返却する関数を呼び出す
+	LPCSTR ppszArgs2[4] = { msg.data(), nullptr };
+	EXPECT_ERROUT(cPpa.CallStrFunc("OkCancelBox", (int)F_OKCANCELBOX, ppszArgs2, _countof(ppszArgs2), &errCd, &pszResultValue), L"something is wrong.");
+	EXPECT_STREQ("", pszResultValue);
+	EXPECT_EQ((int)F_OKCANCELBOX + 1, errCd);
+
+	// コマンドを呼び出す
+	LPCSTR ppszArgs3[] = { nullptr };
+	cPpa.CallStrFunc("FileNew", (int)F_FILENEW, ppszArgs3, _countof(ppszArgs3), &errCd, &pszResultValue);
+	EXPECT_STREQ("", pszResultValue);
+	EXPECT_EQ((int)F_FILENEW + 1, errCd);
+}
+
+/*!
+	文字列ハンドラのテスト
+ */
+TEST_F(CPpaTest, StrObj)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	setlocale(LC_ALL, "Japanese");
+
+	// PPAの実行コンテキストを用意する
+	PpaExecInfo execInfo;
+	execInfo.m_pcEditView = GetActiveView();
+	const auto execInfoHolder = CPPA::RegisterExecInfo(execInfo);
+
+	constexpr auto& objName = "テキトーな名前";
+	constexpr int index = 2;
+	int errCd = 0;
+	LPSTR value = nullptr;
+
+	// 初期値チェック
+	cPpa.CallStrObj(objName, index, ppa::omGet, &errCd, &value);
+	EXPECT_STREQ("", value);
+	EXPECT_EQ(0, errCd);
+
+	// 更新に使う文字列値を用意する
+	std::string testValue = "適当な値";
+	value = testValue.data();
+
+	// 更新
+	cPpa.CallStrObj(objName, index, ppa::omSet, &errCd, &value);
+	EXPECT_EQ(0, errCd);
+
+	// 取得値チェック
+	cPpa.CallStrObj(objName, index, ppa::omSet, &errCd, &value);
+	EXPECT_STREQ(testValue.data(), value);
+	EXPECT_EQ(0, errCd);
+
+	// パラメータ不正時の挙動チェック
+	cPpa.CallStrObj(objName, 0, ppa::omSet, &errCd, &value);
+	EXPECT_EQ(-1, errCd);
+	cPpa.CallStrObj(objName, 1, ppa::omSet, &errCd, &value);
+	EXPECT_EQ(-1, errCd);
+	cPpa.CallStrObj(objName, 3, ppa::omSet, &errCd, &value);
+	EXPECT_EQ(-1, errCd);
+}
+
+/*!
+	エラーハンドラのテスト
+
+	引数に応じてメッセージボックスを表示する。
+ */
+TEST_F(CPpaTest, ErrorProc_funcCode_commands)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	std::string_view msg = "something is wrong.";
+
+	setlocale(LC_ALL, "Japanese");
+
+	// Err_CD > 0 の場合「サクラエディタのエラー」
+	// 機能IDに対応する関数名をメッセージに含める
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILENEW + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileNew", (int)F_FILENEW).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILEOPEN2 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileOpen(s0: string; i1: Integer; i2: Integer; s3: string)", (int)F_FILEOPEN2).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILESAVE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileSave", (int)F_FILESAVE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILESAVEALL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileSaveAll", (int)F_FILESAVEALL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILESAVEAS_DIALOG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileSaveAsDialog(s0: string; i1: Integer; i2: Integer)", (int)F_FILESAVEAS_DIALOG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILESAVEAS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileSaveAs(s0: string; i1: Integer; i2: Integer)", (int)F_FILESAVEAS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILECLOSE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileClose", (int)F_FILECLOSE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILECLOSE_OPEN + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileCloseOpen", (int)F_FILECLOSE_OPEN).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopen(i0: Integer)", (int)F_FILE_REOPEN).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN_SJIS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopenSJIS(i0: Integer)", (int)F_FILE_REOPEN_SJIS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN_JIS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopenJIS(i0: Integer)", (int)F_FILE_REOPEN_JIS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN_EUC + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopenEUC(i0: Integer)", (int)F_FILE_REOPEN_EUC).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN_LATIN1 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopenLatin1(i0: Integer)", (int)F_FILE_REOPEN_LATIN1).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN_UNICODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopenUNICODE(i0: Integer)", (int)F_FILE_REOPEN_UNICODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN_UNICODEBE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopenUNICODEBE(i0: Integer)", (int)F_FILE_REOPEN_UNICODEBE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN_UTF8 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopenUTF8(i0: Integer)", (int)F_FILE_REOPEN_UTF8).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN_CESU8 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopenCESU8(i0: Integer)", (int)F_FILE_REOPEN_CESU8).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILE_REOPEN_UTF7 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FileReopenUTF7(i0: Integer)", (int)F_FILE_REOPEN_UTF7).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PRINT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Print", (int)F_PRINT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PRINT_PREVIEW + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PrintPreview", (int)F_PRINT_PREVIEW).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PRINT_PAGESETUP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PrintPageSetup", (int)F_PRINT_PAGESETUP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_OPEN_HfromtoC + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_OpenHfromtoC", (int)F_OPEN_HfromtoC).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ACTIVATE_SQLPLUS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ActivateSQLPLUS", (int)F_ACTIVATE_SQLPLUS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PLSQL_COMPILE_ON_SQLPLUS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ExecSQLPLUS", (int)F_PLSQL_COMPILE_ON_SQLPLUS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BROWSE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Browse", (int)F_BROWSE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_VIEWMODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ViewMode", (int)F_VIEWMODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PROPERTY_FILE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PropertyFile", (int)F_PROPERTY_FILE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_EXITALLEDITORS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ExitAllEditors", (int)F_EXITALLEDITORS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_EXITALL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ExitAll", (int)F_EXITALL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PUTFILE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PutFile(s0: string; i1: Integer; i2: Integer)", (int)F_PUTFILE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INSFILE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_InsFile(s0: string; i1: Integer; i2: Integer)", (int)F_INSFILE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WCHAR + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Char(i0: Integer)", (int)F_WCHAR).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_IME_CHAR + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CharIme(i0: Integer)", (int)F_IME_CHAR).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UNDO + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Undo", (int)F_UNDO).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_REDO + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Redo", (int)F_REDO).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DELETE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Delete", (int)F_DELETE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DELETE_BACK + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_DeleteBack", (int)F_DELETE_BACK).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WordDeleteToStart + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordDeleteToStart", (int)F_WordDeleteToStart).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WordDeleteToEnd + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordDeleteToEnd", (int)F_WordDeleteToEnd).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WordCut + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordCut", (int)F_WordCut).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WordDelete + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordDelete", (int)F_WordDelete).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LineCutToStart + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_LineCutToStart", (int)F_LineCutToStart).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LineCutToEnd + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_LineCutToEnd", (int)F_LineCutToEnd).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LineDeleteToStart + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_LineDeleteToStart", (int)F_LineDeleteToStart).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LineDeleteToEnd + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_LineDeleteToEnd", (int)F_LineDeleteToEnd).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUT_LINE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CutLine", (int)F_CUT_LINE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DELETE_LINE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_DeleteLine", (int)F_DELETE_LINE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DUPLICATELINE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_DuplicateLine", (int)F_DUPLICATELINE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INDENT_TAB + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_IndentTab", (int)F_INDENT_TAB).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UNINDENT_TAB + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_UnindentTab", (int)F_UNINDENT_TAB).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INDENT_SPACE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_IndentSpace", (int)F_INDENT_SPACE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UNINDENT_SPACE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_UnindentSpace", (int)F_UNINDENT_SPACE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LTRIM + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_LTrim", (int)F_LTRIM).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_RTRIM + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_RTrim", (int)F_RTRIM).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SORT_ASC + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SortAsc", (int)F_SORT_ASC).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SORT_DESC + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SortDesc", (int)F_SORT_DESC).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MERGE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Merge", (int)F_MERGE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Up", (int)F_UP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DOWN + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Down", (int)F_DOWN).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LEFT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Left", (int)F_LEFT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_RIGHT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Right", (int)F_RIGHT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UP2 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Up2", (int)F_UP2).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DOWN2 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Down2", (int)F_DOWN2).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WORDLEFT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordLeft", (int)F_WORDLEFT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WORDRIGHT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordRight", (int)F_WORDRIGHT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOLINETOP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoLineTop(i0: Integer)", (int)F_GOLINETOP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOLINEEND + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoLineEnd(i0: Integer)", (int)F_GOLINEEND).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HalfPageUp + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HalfPageUp(i0: Integer)", (int)F_HalfPageUp).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HalfPageDown + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HalfPageDown(i0: Integer)", (int)F_HalfPageDown).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_1PageUp + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PageUp(i0: Integer)", (int)F_1PageUp).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_1PageDown + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PageDown(i0: Integer)", (int)F_1PageDown).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOFILETOP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoFileTop", (int)F_GOFILETOP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOFILEEND + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoFileEnd", (int)F_GOFILEEND).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CURLINECENTER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CurLineCenter", (int)F_CURLINECENTER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CURLINETOP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CurLineTop", (int)F_CURLINETOP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CURLINEBOTTOM + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CurLineBottom", (int)F_CURLINEBOTTOM).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_JUMPHIST_PREV + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_MoveHistPrev", (int)F_JUMPHIST_PREV).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_JUMPHIST_NEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_MoveHistNext", (int)F_JUMPHIST_NEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_JUMPHIST_SET + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_MoveHistSet", (int)F_JUMPHIST_SET).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WndScrollDown + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_F_WndScrollDown", (int)F_WndScrollDown).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WndScrollUp + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_F_WndScrollUp", (int)F_WndScrollUp).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GONEXTPARAGRAPH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoNextParagraph", (int)F_GONEXTPARAGRAPH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOPREVPARAGRAPH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoPrevParagraph", (int)F_GOPREVPARAGRAPH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MODIFYLINE_NEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoModifyLineNext", (int)F_MODIFYLINE_NEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MODIFYLINE_PREV + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoModifyLinePrev", (int)F_MODIFYLINE_PREV).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MOVECURSOR + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_MoveCursor(i0: Integer; i1: Integer; i2: Integer)", (int)F_MOVECURSOR).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MOVECURSORLAYOUT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_MoveCursorLayout(i0: Integer; i1: Integer; i2: Integer)", (int)F_MOVECURSORLAYOUT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WHEELUP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WheelUp(i0: Integer)", (int)F_WHEELUP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WHEELDOWN + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WheelDown(i0: Integer)", (int)F_WHEELDOWN).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WHEELLEFT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WheelLeft(i0: Integer)", (int)F_WHEELLEFT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WHEELRIGHT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WheelRight(i0: Integer)", (int)F_WHEELRIGHT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WHEELPAGEUP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WheelPageUp(i0: Integer)", (int)F_WHEELPAGEUP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WHEELPAGEDOWN + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WheelPageDown(i0: Integer)", (int)F_WHEELPAGEDOWN).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WHEELPAGELEFT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WheelPageLeft(i0: Integer)", (int)F_WHEELPAGELEFT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WHEELPAGERIGHT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WheelPageRight(i0: Integer)", (int)F_WHEELPAGERIGHT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SELECTWORD + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SelectWord", (int)F_SELECTWORD).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SELECTALL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SelectAll", (int)F_SELECTALL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SELECTLINE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SelectLine(i0: Integer)", (int)F_SELECTLINE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BEGIN_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_BeginSelect", (int)F_BEGIN_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UP_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Up_Sel", (int)F_UP_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DOWN_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Down_Sel", (int)F_DOWN_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LEFT_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Left_Sel", (int)F_LEFT_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_RIGHT_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Right_Sel", (int)F_RIGHT_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UP2_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Up2_Sel", (int)F_UP2_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DOWN2_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Down2_Sel", (int)F_DOWN2_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WORDLEFT_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordLeft_Sel", (int)F_WORDLEFT_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WORDRIGHT_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordRight_Sel", (int)F_WORDRIGHT_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOLINETOP_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoLineTop_Sel(i0: Integer)", (int)F_GOLINETOP_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOLINEEND_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoLineEnd_Sel(i0: Integer)", (int)F_GOLINEEND_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HalfPageUp_Sel + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HalfPageUp_Sel(i0: Integer)", (int)F_HalfPageUp_Sel).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HalfPageDown_Sel + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HalfPageDown_Sel(i0: Integer)", (int)F_HalfPageDown_Sel).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_1PageUp_Sel + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PageUp_Sel(i0: Integer)", (int)F_1PageUp_Sel).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_1PageDown_Sel + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PageDown_Sel(i0: Integer)", (int)F_1PageDown_Sel).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOFILETOP_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoFileTop_Sel", (int)F_GOFILETOP_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOFILEEND_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoFileEnd_Sel", (int)F_GOFILEEND_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GONEXTPARAGRAPH_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoNextParagraph_Sel", (int)F_GONEXTPARAGRAPH_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOPREVPARAGRAPH_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoPrevParagraph_Sel", (int)F_GOPREVPARAGRAPH_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MODIFYLINE_NEXT_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoModifyLineNext_Sel", (int)F_MODIFYLINE_NEXT_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MODIFYLINE_PREV_SEL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoModifyLinePrev_Sel", (int)F_MODIFYLINE_PREV_SEL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BEGIN_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_BeginBoxSelect", (int)F_BEGIN_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UP_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Up_BoxSel(i0: Integer)", (int)F_UP_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DOWN_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Down_BoxSel(i0: Integer)", (int)F_DOWN_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LEFT_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Left_BoxSel(i0: Integer)", (int)F_LEFT_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_RIGHT_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Right_BoxSel(i0: Integer)", (int)F_RIGHT_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UP2_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Up2_BoxSel(i0: Integer)", (int)F_UP2_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DOWN2_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Down2_BoxSel(i0: Integer)", (int)F_DOWN2_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WORDLEFT_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordLeft_BoxSel(i0: Integer)", (int)F_WORDLEFT_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WORDRIGHT_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WordRight_BoxSel(i0: Integer)", (int)F_WORDRIGHT_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOLOGICALLINETOP_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoLogicalLineTop_BoxSel(i0: Integer; i1: Integer)", (int)F_GOLOGICALLINETOP_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOLINETOP_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoLineTop_BoxSel(i0: Integer; i1: Integer)", (int)F_GOLINETOP_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOLINEEND_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoLineEnd_BoxSel(i0: Integer; i1: Integer)", (int)F_GOLINEEND_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HalfPageUp_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HalfPageUp_BoxSel(i0: Integer; i1: Integer)", (int)F_HalfPageUp_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HalfPageDown_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HalfPageDown_BoxSel(i0: Integer; i1: Integer)", (int)F_HalfPageDown_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_1PageUp_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PageUp_BoxSel(i0: Integer; i1: Integer)", (int)F_1PageUp_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_1PageDown_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PageDown_BoxSel(i0: Integer; i1: Integer)", (int)F_1PageDown_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOFILETOP_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoFileTop_BoxSel(i0: Integer)", (int)F_GOFILETOP_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GOFILEEND_BOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GoFileEnd_BoxSel(i0: Integer)", (int)F_GOFILEEND_BOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Cut", (int)F_CUT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPY + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Copy", (int)F_COPY).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PASTE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Paste(i0: Integer)", (int)F_PASTE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPY_ADDCRLF + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyAddCRLF", (int)F_COPY_ADDCRLF).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPY_CRLF + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyCRLF", (int)F_COPY_CRLF).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PASTEBOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PasteBox(i0: Integer)", (int)F_PASTEBOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INSBOXTEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_InsBoxText(s0: string)", (int)F_INSBOXTEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INSTEXT_W + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_InsText(s0: string)", (int)F_INSTEXT_W).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ADDTAIL_W + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_AddTail(s0: string)", (int)F_ADDTAIL_W).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPYLINES + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyLines", (int)F_COPYLINES).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPYLINESASPASSAGE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyLinesAsPassage", (int)F_COPYLINESASPASSAGE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPYLINESWITHLINENUMBER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyLinesWithLineNumber", (int)F_COPYLINESWITHLINENUMBER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPY_COLOR_HTML + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyColorHtml", (int)F_COPY_COLOR_HTML).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPY_COLOR_HTML_LINENUMBER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyColorHtmlWithLineNumber", (int)F_COPY_COLOR_HTML_LINENUMBER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPYPATH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyPath", (int)F_COPYPATH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPYDIRPATH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyDirPath", (int)F_COPYDIRPATH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPYFNAME + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyFilename", (int)F_COPYFNAME).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COPYTAG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyTag", (int)F_COPYTAG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CREATEKEYBINDLIST + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CopyKeyBindList", (int)F_CREATEKEYBINDLIST).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INS_DATE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_InsertDate", (int)F_INS_DATE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INS_TIME + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_InsertTime", (int)F_INS_TIME).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CTRL_CODE_DIALOG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CtrlCodeDialog", (int)F_CTRL_CODE_DIALOG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CTRL_CODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CtrlCode(i0: Integer)", (int)F_CTRL_CODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INS_FILE_USED_RECENTLY + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_InsertFileUsedRecently", (int)F_INS_FILE_USED_RECENTLY).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INS_FOLDER_USED_RECENTLY + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_InsertFolderUsedRecently", (int)F_INS_FOLDER_USED_RECENTLY).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOLOWER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ToLower", (int)F_TOLOWER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOUPPER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ToUpper", (int)F_TOUPPER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOHANKAKU + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ToHankaku", (int)F_TOHANKAKU).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOHANKATA + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ToHankata", (int)F_TOHANKATA).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOZENEI + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ToZenEi", (int)F_TOZENEI).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOHANEI + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ToHanEi", (int)F_TOHANEI).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOZENKAKUKATA + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ToZenKata", (int)F_TOZENKAKUKATA).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOZENKAKUHIRA + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ToZenHira", (int)F_TOZENKAKUHIRA).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HANKATATOZENKATA + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HanKataToZenKata", (int)F_HANKATATOZENKATA).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HANKATATOZENHIRA + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HanKataToZenHira", (int)F_HANKATATOZENHIRA).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TABTOSPACE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TABToSPACE", (int)F_TABTOSPACE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SPACETOTAB + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SPACEToTAB", (int)F_SPACETOTAB).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_AUTO2SJIS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_AutoToSJIS", (int)F_CODECNV_AUTO2SJIS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_EMAIL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_JIStoSJIS", (int)F_CODECNV_EMAIL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_EUC2SJIS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_EUCtoSJIS", (int)F_CODECNV_EUC2SJIS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_UNICODE2SJIS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CodeCnvUNICODEtoSJIS", (int)F_CODECNV_UNICODE2SJIS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_UNICODEBE2SJIS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CodeCnvUNICODEBEtoSJIS", (int)F_CODECNV_UNICODEBE2SJIS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_UTF82SJIS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_UTF8toSJIS", (int)F_CODECNV_UTF82SJIS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_UTF72SJIS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_UTF7toSJIS", (int)F_CODECNV_UTF72SJIS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_SJIS2JIS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SJIStoJIS", (int)F_CODECNV_SJIS2JIS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_SJIS2EUC + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SJIStoEUC", (int)F_CODECNV_SJIS2EUC).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_SJIS2UTF8 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SJIStoUTF8", (int)F_CODECNV_SJIS2UTF8).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CODECNV_SJIS2UTF7 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SJIStoUTF7", (int)F_CODECNV_SJIS2UTF7).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BASE64DECODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Base64Decode", (int)F_BASE64DECODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_UUDECODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Uudecode", (int)F_UUDECODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SEARCH_DIALOG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SearchDialog", (int)F_SEARCH_DIALOG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SEARCH_NEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SearchNext(s0: string; i1: Integer)", (int)F_SEARCH_NEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SEARCH_PREV + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SearchPrev(s0: string; i1: Integer)", (int)F_SEARCH_PREV).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_REPLACE_DIALOG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ReplaceDialog", (int)F_REPLACE_DIALOG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_REPLACE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Replace(s0: string; s1: string; i2: Integer)", (int)F_REPLACE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_REPLACE_ALL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ReplaceAll(s0: string; s1: string; i2: Integer)", (int)F_REPLACE_ALL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SEARCH_CLEARMARK + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SearchClearMark", (int)F_SEARCH_CLEARMARK).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_JUMP_SRCHSTARTPOS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SearchStartPos", (int)F_JUMP_SRCHSTARTPOS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GREP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Grep(s0: string; s1: string; s2: string; i3: Integer; i4: Integer)", (int)F_GREP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GREP_REPLACE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GrepReplace(s0: string; s1: string; s2: string; s3: string; i4: Integer; i5: Integer)", (int)F_GREP_REPLACE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_JUMP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Jump(i0: Integer; i1: Integer)", (int)F_JUMP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_OUTLINE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Outline(i0: Integer)", (int)F_OUTLINE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAGJUMP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TagJump", (int)F_TAGJUMP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAGJUMPBACK + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TagJumpBack", (int)F_TAGJUMPBACK).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAGS_MAKE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TagMake", (int)F_TAGS_MAKE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DIRECT_TAGJUMP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_DirectTagJump", (int)F_DIRECT_TAGJUMP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAGJUMP_KEYWORD + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_KeywordTagJump(s0: string)", (int)F_TAGJUMP_KEYWORD).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COMPARE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Compare", (int)F_COMPARE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DIFF_DIALOG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_DiffDialog", (int)F_DIFF_DIALOG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DIFF + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Diff(s0: string; i1: Integer)", (int)F_DIFF).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DIFF_NEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_DiffNext", (int)F_DIFF_NEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DIFF_PREV + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_DiffPrev", (int)F_DIFF_PREV).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DIFF_RESET + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_DiffReset", (int)F_DIFF_RESET).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BRACKETPAIR + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_BracketPair", (int)F_BRACKETPAIR).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BOOKMARK_SET + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_BookmarkSet", (int)F_BOOKMARK_SET).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BOOKMARK_NEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_BookmarkNext", (int)F_BOOKMARK_NEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BOOKMARK_PREV + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_BookmarkPrev", (int)F_BOOKMARK_PREV).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BOOKMARK_RESET + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_BookmarkReset", (int)F_BOOKMARK_RESET).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BOOKMARK_VIEW + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_BookmarkView", (int)F_BOOKMARK_VIEW).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_BOOKMARK_PATTERN + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_BookmarkPattern(s0: string; i1: Integer)", (int)F_BOOKMARK_PATTERN).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FUNCLIST_NEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FuncListNext", (int)F_FUNCLIST_NEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FUNCLIST_PREV + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_FuncListPrev", (int)F_FUNCLIST_PREV).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CHGMOD_INS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ChgmodINS", (int)F_CHGMOD_INS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CHG_CHARSET + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ChgCharSet(i0: Integer; i1: Integer)", (int)F_CHG_CHARSET).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CHGMOD_EOL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ChgmodEOL(i0: Integer)", (int)F_CHGMOD_EOL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CANCEL_MODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CancelMode", (int)F_CANCEL_MODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_EXECEXTMACRO + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ExecExternalMacro(s0: string; s1: string)", (int)F_EXECEXTMACRO).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SHOWTOOLBAR + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ShowToolbar", (int)F_SHOWTOOLBAR).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SHOWFUNCKEY + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ShowFunckey", (int)F_SHOWFUNCKEY).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SHOWTAB + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ShowTab", (int)F_SHOWTAB).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SHOWSTATUSBAR + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ShowStatusbar", (int)F_SHOWSTATUSBAR).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SHOWMINIMAP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ShowMiniMap", (int)F_SHOWMINIMAP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TYPE_LIST + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TypeList", (int)F_TYPE_LIST).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CHANGETYPE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ChangeType(i0: Integer)", (int)F_CHANGETYPE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_OPTION_TYPE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_OptionType", (int)F_OPTION_TYPE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_OPTION + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_OptionCommon", (int)F_OPTION).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FONT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SelectFont", (int)F_FONT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SETFONTSIZE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SetFontSize(i0: Integer; i1: Integer; i2: Integer)", (int)F_SETFONTSIZE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WRAPWINDOWWIDTH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WrapWindowWidth", (int)F_WRAPWINDOWWIDTH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FAVORITE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_OptionFavorite", (int)F_FAVORITE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SET_QUOTESTRING + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SetMsgQuoteStr(s0: string)", (int)F_SET_QUOTESTRING).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TEXTWRAPMETHOD + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TextWrapMethod(i0: Integer)", (int)F_TEXTWRAPMETHOD).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SELECT_COUNT_MODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SelectCountMode(i0: Integer)", (int)F_SELECT_COUNT_MODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_EXECMD + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ExecCommand(s0: string; i1: Integer; s2: string)", (int)F_EXECMD).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_EXECMD_DIALOG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ExecCommandDialog", (int)F_EXECMD_DIALOG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MENU_RBUTTON + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_RMenu", (int)F_MENU_RBUTTON).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_1 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu1", (int)F_CUSTMENU_1).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_2 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu2", (int)F_CUSTMENU_2).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_3 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu3", (int)F_CUSTMENU_3).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_4 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu4", (int)F_CUSTMENU_4).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_5 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu5", (int)F_CUSTMENU_5).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_6 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu6", (int)F_CUSTMENU_6).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_7 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu7", (int)F_CUSTMENU_7).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_8 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu8", (int)F_CUSTMENU_8).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_9 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu9", (int)F_CUSTMENU_9).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_10 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu10", (int)F_CUSTMENU_10).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_11 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu11", (int)F_CUSTMENU_11).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_12 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu12", (int)F_CUSTMENU_12).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_13 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu13", (int)F_CUSTMENU_13).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_14 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu14", (int)F_CUSTMENU_14).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_15 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu15", (int)F_CUSTMENU_15).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_16 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu16", (int)F_CUSTMENU_16).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_17 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu17", (int)F_CUSTMENU_17).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_18 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu18", (int)F_CUSTMENU_18).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_19 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu19", (int)F_CUSTMENU_19).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_20 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu20", (int)F_CUSTMENU_20).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_21 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu21", (int)F_CUSTMENU_21).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_22 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu22", (int)F_CUSTMENU_22).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_23 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu23", (int)F_CUSTMENU_23).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CUSTMENU_24 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CustMenu24", (int)F_CUSTMENU_24).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SPLIT_V + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SplitWinV", (int)F_SPLIT_V).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SPLIT_H + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SplitWinH", (int)F_SPLIT_H).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SPLIT_VH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SplitWinVH", (int)F_SPLIT_VH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WINCLOSE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WinClose", (int)F_WINCLOSE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WIN_CLOSEALL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WinCloseAll", (int)F_WIN_CLOSEALL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CASCADE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CascadeWin", (int)F_CASCADE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TILE_V + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TileWinV", (int)F_TILE_V).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TILE_H + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TileWinH", (int)F_TILE_H).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_NEXTWINDOW + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_NextWindow", (int)F_NEXTWINDOW).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PREVWINDOW + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PrevWindow", (int)F_PREVWINDOW).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WINLIST + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WindowList", (int)F_WINLIST).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MAXIMIZE_V + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_MaximizeV", (int)F_MAXIMIZE_V).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MAXIMIZE_H + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_MaximizeH", (int)F_MAXIMIZE_H).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MINIMIZE_ALL + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_MinimizeAll", (int)F_MINIMIZE_ALL).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_REDRAW + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ReDraw", (int)F_REDRAW).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WIN_OUTPUT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ActivateWinOutput", (int)F_WIN_OUTPUT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TRACEOUT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TraceOut(s0: string; i1: Integer)", (int)F_TRACEOUT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOPMOST + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_WindowTopMost(i0: Integer)", (int)F_TOPMOST).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GROUPCLOSE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_GroupClose", (int)F_GROUPCLOSE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_NEXTGROUP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_NextGroup", (int)F_NEXTGROUP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_PREVGROUP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_PrevGroup", (int)F_PREVGROUP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAB_MOVERIGHT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TabMoveRight", (int)F_TAB_MOVERIGHT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAB_MOVELEFT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TabMoveLeft", (int)F_TAB_MOVELEFT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAB_SEPARATE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TabSeparate", (int)F_TAB_SEPARATE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAB_JOINTNEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TabJointNext", (int)F_TAB_JOINTNEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAB_JOINTPREV + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TabJointPrev", (int)F_TAB_JOINTPREV).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAB_CLOSEOTHER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TabCloseOther", (int)F_TAB_CLOSEOTHER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAB_CLOSELEFT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TabCloseLeft", (int)F_TAB_CLOSELEFT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TAB_CLOSERIGHT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_TabCloseRight", (int)F_TAB_CLOSERIGHT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HOKAN + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_Complete", (int)F_HOKAN).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_TOGGLE_KEY_SEARCH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ToggleKeyHelpSearch(i0: Integer)", (int)F_TOGGLE_KEY_SEARCH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HELP_CONTENTS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HelpContents", (int)F_HELP_CONTENTS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_HELP_SEARCH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_HelpSearch", (int)F_HELP_SEARCH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MENU_ALLFUNC + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CommandList", (int)F_MENU_ALLFUNC).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_EXTHELP1 + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ExtHelp1", (int)F_EXTHELP1).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_EXTHTMLHELP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ExtHtmlHelp(s0: string; s1: string)", (int)F_EXTHTMLHELP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ABOUT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_About", (int)F_ABOUT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_STATUSMSG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_StatusMsg(s0: string; i1: Integer)", (int)F_STATUSMSG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MSGBEEP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_MsgBeep(i0: Integer)", (int)F_MSGBEEP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COMMITUNDOBUFFER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_CommitUndoBuffer", (int)F_COMMITUNDOBUFFER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ADDREFUNDOBUFFER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_AddRefUndoBuffer", (int)F_ADDREFUNDOBUFFER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SETUNDOBUFFER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SetUndoBuffer", (int)F_SETUNDOBUFFER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_APPENDUNDOBUFFERCURSOR + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_AppendUndoBufferCursor", (int)F_APPENDUNDOBUFFERCURSOR).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CLIPBOARDEMPTY + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_ClipboardEmpty", (int)F_CLIPBOARDEMPTY).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SETVIEWTOP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SetViewTop(i0: Integer)", (int)F_SETVIEWTOP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SETVIEWLEFT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "procedure S_SetViewLeft(i0: Integer)", (int)F_SETVIEWLEFT).data());
+}
+
+/*!
+	エラーハンドラのテスト
+
+	引数に応じてメッセージボックスを表示する。
+ */
+TEST_F(CPpaTest, ErrorProc_funcCode_functions)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	std::string_view msg = "something is wrong.";
+
+	setlocale(LC_ALL, "Japanese");
+
+	// Err_CD > 0 の場合「サクラエディタのエラー」
+	// 機能IDに対応する関数名をメッセージに含める
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETFILENAME + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetFilename: string", (int)F_GETFILENAME).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETSAVEFILENAME + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetSaveFilename: string", (int)F_GETSAVEFILENAME).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETSELECTED + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetSelectedString(i0: Integer): string", (int)F_GETSELECTED).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_EXPANDPARAMETER + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_ExpandParameter(s0: string): string", (int)F_EXPANDPARAMETER).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETLINESTR + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetLineStr(i0: Integer): string", (int)F_GETLINESTR).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETLINECOUNT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetLineCount(i0: Integer): Integer", (int)F_GETLINECOUNT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CHGTABWIDTH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_ChangeTabWidth(i0: Integer): Integer", (int)F_CHGTABWIDTH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ISTEXTSELECTED + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_IsTextSelected: Integer", (int)F_ISTEXTSELECTED).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETSELLINEFROM + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetSelectLineFrom: Integer", (int)F_GETSELLINEFROM).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETSELCOLUMNFROM + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetSelectColmFrom: Integer", (int)F_GETSELCOLUMNFROM).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETSELLINETO + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetSelectLineTo: Integer", (int)F_GETSELLINETO).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETSELCOLUMNTO + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetSelectColmTo: Integer", (int)F_GETSELCOLUMNTO).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ISINSMODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_IsInsMode: Integer", (int)F_ISINSMODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETCHARCODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetCharCode: Integer", (int)F_GETCHARCODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETLINECODE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetLineCode: Integer", (int)F_GETLINECODE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ISPOSSIBLEUNDO + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_IsPossibleUndo: Integer", (int)F_ISPOSSIBLEUNDO).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ISPOSSIBLEREDO + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_IsPossibleRedo: Integer", (int)F_ISPOSSIBLEREDO).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CHGWRAPCOLUMN + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_ChangeWrapColm(i0: Integer): Integer", (int)F_CHGWRAPCOLUMN).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ISCURTYPEEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_IsCurTypeExt(s0: string): Integer", (int)F_ISCURTYPEEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ISSAMETYPEEXT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_IsSameTypeExt(s0: string; s1: string): Integer", (int)F_ISSAMETYPEEXT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INPUTBOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_InputBox(s0: string; s1: string; i2: Integer): string", (int)F_INPUTBOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MESSAGEBOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_MessageBox(s0: string; i1: Integer): Integer", (int)F_MESSAGEBOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ERRORMSG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_ErrorMsg(s0: string): Integer", (int)F_ERRORMSG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_WARNMSG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_WarnMsg(s0: string): Integer", (int)F_WARNMSG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_INFOMSG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_InfoMsg(s0: string): Integer", (int)F_INFOMSG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_OKCANCELBOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_OkCancelBox(s0: string): Integer", (int)F_OKCANCELBOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_YESNOBOX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_YesNoBox(s0: string): Integer", (int)F_YESNOBOX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_COMPAREVERSION + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_CompareVersion(s0: string; s1: string): Integer", (int)F_COMPAREVERSION).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_MACROSLEEP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_Sleep(i0: Integer): Integer", (int)F_MACROSLEEP).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILEOPENDIALOG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_FileOpenDialog(s0: string; s1: string): string", (int)F_FILEOPENDIALOG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FILESAVEDIALOG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_FileSaveDialog(s0: string; s1: string): string", (int)F_FILESAVEDIALOG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_FOLDERDIALOG + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_FolderDialog(s0: string; s1: string): string", (int)F_FOLDERDIALOG).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETCLIPBOARD + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetClipboard(i0: Integer): string", (int)F_GETCLIPBOARD).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SETCLIPBOARD + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_SetClipboard(i0: Integer; s1: string): Integer", (int)F_SETCLIPBOARD).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LAYOUTTOLOGICLINENUM + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_LayoutToLogicLineNum(i0: Integer): Integer", (int)F_LAYOUTTOLOGICLINENUM).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LOGICTOLAYOUTLINENUM + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_LogicToLayoutLineNum(i0: Integer; i1: Integer): Integer", (int)F_LOGICTOLAYOUTLINENUM).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LINECOLUMNTOINDEX + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_LineColumnToIndex(i0: Integer; i1: Integer): Integer", (int)F_LINECOLUMNTOINDEX).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_LINEINDEXTOCOLUMN + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_LineIndexToColumn(i0: Integer; i1: Integer): Integer", (int)F_LINEINDEXTOCOLUMN).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETCOOKIE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetCookie(s0: string; s1: string): string", (int)F_GETCOOKIE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETCOOKIEDEFAULT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetCookieDefault(s0: string; s1: string; s2: string): string", (int)F_GETCOOKIEDEFAULT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SETCOOKIE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_SetCookie(s0: string; s1: string; s2: string): Integer", (int)F_SETCOOKIE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_DELETECOOKIE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_DeleteCookie(s0: string; s1: string): Integer", (int)F_DELETECOOKIE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETCOOKIENAMES + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetCookieNames(s0: string): string", (int)F_GETCOOKIENAMES).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SETDRAWSWITCH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_SetDrawSwitch(i0: Integer): Integer", (int)F_SETDRAWSWITCH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETDRAWSWITCH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetDrawSwitch: Integer", (int)F_GETDRAWSWITCH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ISSHOWNSTATUS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_IsShownStatus: Integer", (int)F_ISSHOWNSTATUS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETSTRWIDTH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetStrWidth(s0: string; i1: Integer): Integer", (int)F_GETSTRWIDTH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETSTRLAYOUTLENGTH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetStrLayoutLength(s0: string; i1: Integer): Integer", (int)F_GETSTRLAYOUTLENGTH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETDEFAULTCHARLENGTH + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetDefaultCharLength: Integer", (int)F_GETDEFAULTCHARLENGTH).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ISINCLUDECLIPBOARDFORMAT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_IsIncludeClipboardFormat(s0: string): Integer", (int)F_ISINCLUDECLIPBOARDFORMAT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETCLIPBOARDBYFORMAT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetClipboardByFormat(s0: string; i1: Integer; i2: Integer): string", (int)F_GETCLIPBOARDBYFORMAT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_SETCLIPBOARDBYFORMAT + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_SetClipboardByFormat(s0: string; s1: string; i2: Integer; i3: Integer): Integer", (int)F_SETCLIPBOARDBYFORMAT).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETLINEATTRIBUTE + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetLineAttribute(i0: Integer; i1: Integer): Integer", (int)F_GETLINEATTRIBUTE).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_ISTEXTSELECTINGLOCK + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_IsTextSelectingLock: Integer", (int)F_ISTEXTSELECTINGLOCK).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETVIEWLINES + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetViewLines: Integer", (int)F_GETVIEWLINES).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETVIEWCOLUMNS + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetViewColumns: Integer", (int)F_GETVIEWCOLUMNS).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_CREATEMENU + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_CreateMenu(i0: Integer; s1: string): Integer", (int)F_CREATEMENU).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(F_GETVIEWTOP + 1, msg.data()), strprintf(L"関数の実行エラー\n%hs; index %d;", "function S_GetViewTop: Integer", (int)F_GETVIEWTOP).data());
+}
+
+/*!
+	エラーハンドラのテスト
+
+	引数に応じてメッセージボックスを表示する。
+ */
+TEST_F(CPpaTest, ErrorProc_funcCode_unknown)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	std::string_view msg = "something is wrong.";
+
+	setlocale(LC_ALL, "Japanese");
+
+	// Err_CD > 0 の場合「サクラエディタのエラー」
+	// 機能IDに対応する関数名をメッセージに含める
+	EXPECT_ERROUT(cPpa.CallErrorProc(55555 + 1, msg.data()), strprintf(L"不明な関数の実行エラー(バグです)\nFunc_ID=%d", 55555).data());
+}
+
+/*!
+	エラーハンドラのテスト
+
+	引数に応じてメッセージボックスを表示する。
+ */
+TEST_F(CPpaTest, ErrorProc_PPA_errors)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	std::string_view msg = "something is wrong.";
+	constexpr char chNul = '\0';
+
+	setlocale(LC_ALL, "Japanese");
+
+	// Err_CD == 0 の場合「PPAのエラー」
+	EXPECT_ERROUT(cPpa.CallErrorProc(0, msg.data()), strprintf(L"%hs", msg.data()).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(0, nullptr), L"エラー情報が不正");
+	EXPECT_ERROUT(cPpa.CallErrorProc(0, &chNul), L"詳細不明のエラー");
+}
+
+/*!
+	エラーハンドラのテスト
+
+	引数に応じてメッセージボックスを表示する。
+ */
+TEST_F(CPpaTest, ErrorProc_user_errors)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	std::string_view msg = "something is wrong.";
+	constexpr char chNul = '\0';
+
+	setlocale(LC_ALL, "Japanese");
+
+	// Err_CD < 0 の場合「ユーザー定義のエラー」
+	EXPECT_ERROUT(cPpa.CallErrorProc(-1, msg.data()), strprintf(L"未定義のエラー\nError_CD=%d\n%hs", -1, msg.data()).data());
+	EXPECT_ERROUT(cPpa.CallErrorProc(-1, nullptr), L"エラー情報が不正");
+	EXPECT_ERROUT(cPpa.CallErrorProc(-1, &chNul), L"未定義のエラー\nError_CD=-1\n");
+}
+
+/*!
+	エラーハンドラのテスト
+
+	引数に応じてメッセージボックスを表示する。
+ */
+TEST_F(CPpaTest, ErrorProc_withDebugStr)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	std::string_view msg = "something is wrong.";
+	std::string_view debugStr = "でばっぐ";
+
+	setlocale(LC_ALL, "Japanese");
+
+	// PPAの実行コンテキストを用意する
+	PpaExecInfo execInfo;
+	execInfo.m_pcEditView = GetActiveView();
+	execInfo.m_cMemDebug = debugStr.data();
+	const auto execInfoHolder = CPPA::RegisterExecInfo(execInfo);
+
+	// Err_CD == 0 の場合「PPAのエラー」
+	EXPECT_ERROUT(cPpa.CallDllProc<decltype(&ppaErrorProc)>("CallErrorProc", 0, msg.data()), strprintf(L"%hs\n%hs", msg.data(), debugStr.data()).data());
+
+	// 2回目の呼出に対するメッセージボックスは表示されない
+	EXPECT_NOERROUT(cPpa.CallDllProc<decltype(&ppaErrorProc)>("CallErrorProc", 0, msg.data()));
+}
+
+/*!
+	終了ハンドラのテスト
+ */
+TEST_F(CPpaTest, FinishProc)
+{
+	// テスト対象はスタブDLL
+	CPpaStub cPpa;
+
+	// PPAの実行コンテキストを用意する
+	PpaExecInfo execInfo;
+	execInfo.m_pcEditView = GetActiveView();
+	const auto execInfoHolder = CPPA::RegisterExecInfo(execInfo);
+
+	// 何もしないハンドラなので呼ぶだけ。
+	cPpa.CallFinishProc();
 }

--- a/tests/unittests/test-csearchagent.cpp
+++ b/tests/unittests/test-csearchagent.cpp
@@ -26,10 +26,19 @@
 #include "CSaveAgent.h"
 
 #include <array>
+#include <cstdlib>
+#include <filesystem>
 #include <initializer_list>
 #include <string_view>
 #include <utility>
 #include "doc/logic/CDocLineMgr.h"
+
+#include "CEditorProcessForTest.hpp"
+
+/*!
+ * CSearchAgentのためのフィクスチャクラス
+ */
+using CSearchAgentTest = TEditorProcessTest<CSearchAgent>;
 
 namespace {
 
@@ -71,7 +80,7 @@ COpeLineData MakeOpeLineData(std::initializer_list<RawLineData> lines)
 
 	行の一部を置き換える。
  */
-TEST(CSearchAgent, ReplaceData1)
+TEST_F(CSearchAgentTest, ReplaceData1)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
@@ -109,7 +118,7 @@ TEST(CSearchAgent, ReplaceData1)
 
 	行全体を置き換える。
  */
-TEST(CSearchAgent, ReplaceData2)
+TEST_F(CSearchAgentTest, ReplaceData2)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
@@ -147,7 +156,7 @@ TEST(CSearchAgent, ReplaceData2)
 
 	行末の改行を削除する。
  */
-TEST(CSearchAgent, ReplaceData3)
+TEST_F(CSearchAgentTest, ReplaceData3)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
@@ -184,7 +193,7 @@ TEST(CSearchAgent, ReplaceData3)
 
 	行末の改行を削除する。削除するデータ長が長いケース。
  */
-TEST(CSearchAgent, ReplaceData4)
+TEST_F(CSearchAgentTest, ReplaceData4)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
@@ -221,7 +230,7 @@ TEST(CSearchAgent, ReplaceData4)
 
 	行末の改行を削除する。対象行がデータ末尾であるケース。
  */
-TEST(CSearchAgent, ReplaceData5)
+TEST_F(CSearchAgentTest, ReplaceData5)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"AAA\n"});
@@ -254,7 +263,7 @@ TEST(CSearchAgent, ReplaceData5)
 
 	文字を挿入して複数行を連結する。
  */
-TEST(CSearchAgent, ReplaceData6)
+TEST_F(CSearchAgentTest, ReplaceData6)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
@@ -293,7 +302,7 @@ TEST(CSearchAgent, ReplaceData6)
 	既存行の間に行を挿入し、次の行の先頭に文字を挿入する。
 	先頭に文字を挿入した行がデータの末尾であるケース。
  */
-TEST(CSearchAgent, ReplaceData7)
+TEST_F(CSearchAgentTest, ReplaceData7)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"AAA\n", L"BBB\n"});
@@ -330,7 +339,7 @@ TEST(CSearchAgent, ReplaceData7)
 	既存行の間に行を挿入し、次の行の先頭に文字を挿入する。
 	先頭に文字を挿入した行がデータの末尾ではないケース。
  */
-TEST(CSearchAgent, ReplaceData8)
+TEST_F(CSearchAgentTest, ReplaceData8)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"AAA\n", L"BBB\n", L"CCC\n"});
@@ -368,7 +377,7 @@ TEST(CSearchAgent, ReplaceData8)
 
 	既存行の末尾に新しい行を追加する。
  */
-TEST(CSearchAgent, ReplaceData9)
+TEST_F(CSearchAgentTest, ReplaceData9)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"AAA\n", L"BBB\n"});
@@ -404,7 +413,7 @@ TEST(CSearchAgent, ReplaceData9)
 
 	置換後の文字列が既存の行バッファの有効長に収まる場合の最適化済みコードパスの検査。
  */
-TEST(CSearchAgent, ReplaceData10)
+TEST_F(CSearchAgentTest, ReplaceData10)
 {
 	CDocLineMgr m;
 	SetLines(m, 1, {L"0123456789\n"});

--- a/tests/unittests/test-extmodules.cpp
+++ b/tests/unittests/test-extmodules.cpp
@@ -27,6 +27,7 @@
 #include "TExtModule.hpp"
 
 #include "extmodule/CBregexpDll2.h"
+#include "extmodule/CDbgHelp.h"
 #include "extmodule/CHtmlHelp.h"
 #include "extmodule/CIcu4cI18n.h"
 #include "extmodule/CMigemo.h"
@@ -91,6 +92,7 @@ REGISTER_TYPED_TEST_SUITE_P(
  */
 using ExtModuleImplementations = ::testing::Types<
 	CBregexpDll2,
+	CDbgHelp,
 	CHtmlHelp,
 	CIcu4cI18n,
 	CMigemo,

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -109,6 +109,7 @@
   <ItemGroup>
     <ClCompile Include="CEditorProcessForTest.cpp" />
     <ClCompile Include="code-main.cpp" />
+    <ClCompile Include="test-cdbghelp.cpp" />
     <ClCompile Include="test-cdocline.cpp" />
     <ClCompile Include="test-cdoclinemgr.cpp" />
     <ClCompile Include="test-ceditdoc.cpp" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -107,9 +107,11 @@
     <Link Include="$(SolutionDir)build\$(Platform)\$(Configuration)\sakura_core\*.res" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="CEditorProcessForTest.cpp" />
     <ClCompile Include="code-main.cpp" />
     <ClCompile Include="test-cdocline.cpp" />
     <ClCompile Include="test-cdoclinemgr.cpp" />
+    <ClCompile Include="test-ceditdoc.cpp" />
     <ClCompile Include="test-cppa.cpp" />
     <ClCompile Include="test-csearchagent.cpp" />
     <ClCompile Include="test-crunningtimer.cpp" />
@@ -159,6 +161,7 @@
     <ClCompile Include="test-winmain.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="CEditorProcessForTest.hpp" />
     <ClInclude Include="eval_outputs.hpp" />
     <ClInclude Include="TExtModule.hpp" />
     <ClInclude Include="tests1_rc.h" />

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -188,6 +188,7 @@
     <ClInclude Include="StartEditorProcessForTest.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="..\stubs\ppa_stub\ppa_stub.targets" />
   <ItemGroup>
     <TestResource Include="test-plugin\plugin.def" />
   </ItemGroup>

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -178,6 +178,9 @@
     <ClCompile Include="test-ceditdoc.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-cdbghelp.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -172,6 +172,12 @@
     <ClCompile Include="test-extmodules.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="CEditorProcessForTest.cpp">
+      <Filter>Other Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-ceditdoc.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">
@@ -181,6 +187,9 @@
       <Filter>Other Files</Filter>
     </ClInclude>
     <ClInclude Include="TExtModule.hpp">
+      <Filter>Other Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CEditorProcessForTest.hpp">
       <Filter>Other Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tools/cmake-build-and-install.cmd
+++ b/tools/cmake-build-and-install.cmd
@@ -1,0 +1,82 @@
+setlocal
+set SOURCE_DIR=%~1
+set BUILD_DIR=%~2
+set INSTALL_DIR=%~3
+set CMAKE_OPTS=%~4
+
+:: using NUM_VSVERSION
+:: using PLATFORM
+:: using CONFIGURATION
+
+:: find generic tools
+if not defined CMD_NINJA call %~dp0find-tools.bat %NUM_VSVERSION%
+
+if not exist "%CMD_NINJA%" (
+  echo "no ninja found."
+  exit /b 1
+)
+
+if not exist "%SOURCE_DIR%\CMakeLists.txt" (
+  echo "CMakeLists.txt was not found."
+  exit /b 1
+)
+
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%" > NUL 2>&1
+pushd "%BUILD_DIR%" || endlocal && exit /b 1
+call :run_cmake_install || endlocal && exit /b 1
+endlocal && exit /b 0
+
+:run_cmake_install
+if not exist "CMakeCache.txt" call :run_cmake_configure
+"%CMD_CMAKE%" --build . --config %CONFIGURATION% --target install || exit /b 1
+goto :EOF
+
+:: run cmake configuration.
+:run_cmake_configure
+if "%PLATFORM%" == "x64"   call :find_msvc
+if "%PLATFORM%" == "Win32" call :find_msvc
+if "%PLATFORM%" == "MinGW" call :find_gcc
+
+"%CMD_CMAKE%" -G Ninja^
+  "-DCMAKE_MAKE_PROGRAM=%CMD_NINJA%"^
+  "-DCMAKE_C_COMPILER=%C_COMPILER%"^
+  "-DCMAKE_CXX_COMPILER=%CXX_COMPILER%"^
+  -DCMAKE_BUILD_TYPE=%CONFIGURATION%^
+  -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR%^
+  %CMAKE_OPTS%^
+  "%SOURCE_DIR%"
+goto :EOF
+
+:find_msvc
+if not defined CMD_CL call :find_cl
+set C_COMPILER=%CMD_CL:\=/%
+set CXX_COMPILER=%CMD_CL:\=/%
+goto :EOF
+
+:find_cl
+for /f "usebackq delims=" %%a in (`where cl.exe`) do (
+  set "CMD_CL=%%a"
+  goto :EOF
+)
+goto :EOF
+
+:find_gcc
+if not defined CMD_CC call :find_cc
+if not defined CMD_CXX call :find_cxx
+set C_COMPILER=%CMD_CC:\=/%
+set CXX_COMPILER=%CMD_CXX:\=/%
+goto :EOF
+
+:find_cc
+for /f "usebackq delims=" %%a in (`where gcc.exe`) do (
+  set "CMD_CC=%%a"
+  goto :EOF
+)
+goto :EOF
+
+:find_cxx
+for /f "usebackq delims=" %%a in (`where g++.exe`) do (
+  set "CMD_CXX=%%a"
+  goto :EOF
+)
+goto :EOF


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->
対応途中で諦めた「CPPAに単体テストを導入する」を断念した理由を共有します。

PRとして出すことで、対応ソースを残すことが目的なのですぐ閉じます。

## <!-- 必須 --> カテゴリ

- その他の問題

## <!-- 自明なら省略可 --> PR の背景

<!-- PR を行う背景を記載してください -->
CPPAの単体テストを可能にする修正を作ってみました。

対応内容としては完成していますがレビュー不能だと思うので、とりあえず共有しときます。


## <!-- 自明なら省略可 --> PR のメリット

<!-- PR のメリットを記載してください。 -->
* CPPAに対する、ほぼ完全な単体テストが利用できるようになります。

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)

<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->
* サクラエディタの中核をなすグローバル変数を削除する修正です。どんな影響があるか分かりません。
* CPPA自体はさほど重要な機能ではないため、頑張って実装を進めるメリットが感じられません。

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明

<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->
対応ポイント
* 「シングルトン」では、生成＆破棄を検証できないので、不必要なシングルトン化を解除しました。
* CPPAの実行コンテキストを外部から設定できない（＝CPPAの挙動を保証する目的で設定できない）不具合を修正しました。
* CPPAの定義関数に対し、未使用のものを除いたすべての関数がテストされるようにしまっした。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 既存の処理に対して影響範囲を記載してください。 -->
シングルトン解除の影響が、アプリ全体におよびます。
修正の妥当性を担保する手段が、現状ではありません。

## <!-- 必須 --> テスト内容

<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->
影響範囲で述べた通り、このPRのテストは不十分であるという見解です。
よって、このPRをマージするつもりはありません。


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
