### PR TITLE
StdAfx.h に定義されている malloc と GlobalLock の型変換マクロを削除する

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -109,10 +109,6 @@
 
 //その他
 #define malloc_char (char*)malloc
-#define GlobalLockChar  (char*)::GlobalLock
-#define GlobalLockUChar (unsigned char*)::GlobalLock
-#define GlobalLockWChar (wchar_t*)::GlobalLock
-#define GlobalLockBYTE  (BYTE*)::GlobalLock
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ は前行の直前に追加の宣言を挿入します。

--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -107,8 +107,5 @@
 // プリコンパイルの有無がビルドパフォーマンスに大きく影響するため。
 #include "env/DLLSHAREDATA.h"
 
-//その他
-#define malloc_char (char*)malloc
-
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ は前行の直前に追加の宣言を挿入します。

--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -86,7 +86,7 @@ bool CClipboard::SetText(
 		nTextLen + 1
 	);
 	if( hgClipText ){
-		char* pszClip = GlobalLockChar( hgClipText );
+		char* pszClip = static_cast<char*>(::GlobalLock(hgClipText));
 		memcpy( pszClip, pszText, nTextLen );
 		pszClip[nTextLen] = '\0';
 		::GlobalUnlock( hgClipText );
@@ -106,7 +106,7 @@ bool CClipboard::SetText(
 		if( !hgClipText )break;
 
 		//確保した領域にデータをコピー
-		wchar_t* pszClip = GlobalLockWChar( hgClipText );
+		wchar_t* pszClip = static_cast<wchar_t*>(::GlobalLock(hgClipText));
 		wmemcpy( pszClip, pData, nDataLen );	//データ
 		pszClip[nDataLen] = L'\0';				//終端ヌル
 		::GlobalUnlock( hgClipText );
@@ -135,7 +135,7 @@ bool CClipboard::SetText(
 		if( !hgClipSakura )break;
 
 		//確保した領域にデータをコピー
-		BYTE* pClip = GlobalLockBYTE( hgClipSakura );
+		BYTE* pClip = static_cast<BYTE*>(::GlobalLock(hgClipSakura));
 		*((int*)pClip) = nDataLen; pClip += sizeof(int);								//データの長さ
 		wmemcpy( (wchar_t*)pClip, pData, nDataLen ); pClip += nDataLen*sizeof(wchar_t);	//データ
 		*((wchar_t*)pClip) = L'\0'; pClip += sizeof(wchar_t);							//終端ヌル
@@ -157,7 +157,7 @@ bool CClipboard::SetText(
 				1
 			);
 			if( hgClipMSDEVColumn ){
-				BYTE* pClip = GlobalLockBYTE( hgClipMSDEVColumn );
+				BYTE* pClip = static_cast<BYTE*>(::GlobalLock(hgClipMSDEVColumn));
 				pClip[0] = 0;
 				::GlobalUnlock( hgClipMSDEVColumn );
 				SetClipboardData( uFormat, hgClipMSDEVColumn );
@@ -241,7 +241,7 @@ bool CClipboard::SetHtmlText(const CNativeW& cmemBUf)
 	if( !hgClipText ) return false;
 
 	//確保した領域にデータをコピー
-	char* pszClip = GlobalLockChar( hgClipText );
+	char* pszClip = static_cast<char*>(::GlobalLock(hgClipText));
 	memcpy_raw( pszClip, cmemHeader.GetStringPtr(), cmemHeader.GetStringLength() );	//データ
 	memcpy_raw( pszClip + cmemHeader.GetStringLength(), cmemUtf8.GetStringPtr(), cmemUtf8.GetStringLength() );	//データ
 	memcpy_raw( pszClip + cmemHeader.GetStringLength() + cmemUtf8.GetStringLength(), cmemFooter.GetStringPtr(), cmemFooter.GetStringLength() );	//データ
@@ -319,7 +319,7 @@ bool CClipboard::GetText(CNativeW* cmemBuf, bool* pbColumnSelect, bool* pbLineSe
 	}
 	if( hUnicode != NULL ){
 		//DWORD nLen = GlobalSize(hUnicode);
-		wchar_t* szData = GlobalLockWChar(hUnicode);
+		wchar_t* szData = static_cast<wchar_t*>(::GlobalLock(hUnicode));
 		cmemBuf->SetString( szData );
 		::GlobalUnlock(hUnicode);
 		return true;
@@ -332,7 +332,7 @@ bool CClipboard::GetText(CNativeW* cmemBuf, bool* pbColumnSelect, bool* pbLineSe
 		hText = GetClipboardData( CF_OEMTEXT );
 	}
 	if( hText != NULL ){
-		char* szData = GlobalLockChar(hText);
+		char* szData = static_cast<char*>(::GlobalLock(hText));
 		//SJIS→UNICODE
 		CMemory cmemSjis( szData, GlobalSize(hText) );
 		CNativeW cmemUni;
@@ -515,7 +515,7 @@ bool CClipboard::SetClipboradByFormat(const CStringRef& cstr, const wchar_t* pFo
 	if( !hgClipText ){
 		return false;
 	}
-	char* pszClip = GlobalLockChar( hgClipText );
+	char* pszClip = static_cast<char*>(::GlobalLock(hgClipText));
 	memcpy( pszClip, pBuf, nTextByteLen );
 	if( nulLen ){
 		memset( &pszClip[nTextByteLen], 0, nulLen );

--- a/sakura_core/dlg/CDlgProperty.cpp
+++ b/sakura_core/dlg/CDlgProperty.cpp
@@ -259,7 +259,7 @@ void CDlgProperty::SetData( void )
 		in.Close();
 		goto end_of_CodeTest;
 	}
-	pBuf = GlobalLockChar( hgData );
+	pBuf = static_cast<char*>(::GlobalLock(hgData));
 	in.Read( pBuf, nBufLen );
 	in.Close();
 


### PR DESCRIPTION
# PR の目的

現在 StdAfx.h には malloc と GlobalLock にキャストを付加するマクロが計5つ定義されています。コード中におけるマクロの存在は開発作業を複雑化させるため、特に意義のないこれらのマクロを削除したいと思います。

##  カテゴリ

- リファクタリング

## 仕様・動作説明

以下のマクロを削除します。

- GlobalLockChar
- GlobalLockUChar
- GlobalLockWChar
- GlobalLockBYTE
  - 以上4つの使用箇所にキャストを追加します。
- malloc_char
  - コード中で使用されていないため定義を削除します。

## 関連 issue, PR

#1800
