### PR TITLE
GlobalMemory クラスを本体コードに移動する

### DIFF
--- a/tests/unittests/test-cclipboard.cpp
+++ b/tests/unittests/test-cclipboard.cpp
@@ -44,6 +44,7 @@
 #include "CEol.h"
 #include "mem/CNativeW.h"
 #include "_os/CClipboard.h"
+#include "util/os.h"
 
 using ::testing::_;
 using ::testing::Invoke;
@@ -208,25 +209,6 @@ TEST(CClipboard, SetText6) {
 	ON_CALL(clipboard, GlobalAlloc(_, 1)).WillByDefault(Return(nullptr));
 	EXPECT_FALSE(clipboard.SetText(text.data(), text.length(), false, true, 0));
 }
-
-// グローバルメモリを RAII で管理する簡易ヘルパークラス
-class GlobalMemory {
-public:
-	GlobalMemory(UINT flags, SIZE_T bytes) : handle_(::GlobalAlloc(flags, bytes)) {}
-	GlobalMemory(const GlobalMemory&) = delete;
-	GlobalMemory& operator=(const GlobalMemory&) = delete;
-	~GlobalMemory() {
-		if (handle_)
-			::GlobalFree(handle_);
-	}
-	HGLOBAL Get() { return handle_; }
-	template <typename T> void Lock(std::function<void (T*)> f) {
-		f(reinterpret_cast<T*>(::GlobalLock(handle_)));
-		::GlobalUnlock(handle_);
-	}
-private:
-	HGLOBAL handle_;
-};
 
 // GetText のテストで使用するダミーデータを準備するためのフィクスチャクラス
 class CClipboardGetText : public testing::Test {


### PR DESCRIPTION
# PR の目的

CClipboard のリファクタリング作業の簡便化のため、グローバルメモリーをRAIIパターンで管理するヘルパークラスを本体コードに追加したいと思っています。
 
## カテゴリ

- リファクタリング

## PR の背景

CClipboard の単体テストに続いて、静的解析に基づく本体コード整理を予定しています。CClipboard の実装コードにおける分岐のかなりの割合がグローバルメモリー関係の失敗パスハンドリングによるものであり、現代的なヘルパークラスの適用によってコードを簡潔にできるほか、GlobalLock 失敗パスのハンドリング漏れに対処しやすくなります。

## PR のメリット

- 既存コードへ適用すればコードの品質と簡潔さが向上できるかもしれません。
- CClipboard のリファクタリング作業を行う私が楽になります。

## PR のデメリット

- 新たにサクラエディタの開発に参加したい人にとって理解の妨げになる可能性があります。

## 仕様・動作説明

- コンストラクタで GlobalAlloc し、デストラクタで GlobalFree します。
- GlobalAlloc に失敗した場合は std::bad_alloc を投げます。
- Get 関数で HGLOBAL を取得できます。
- Lock 関数では GlobalLock し、得られたポインタを引数にして std::function を呼び出した後、GlobalUnlock します。
- static 版の Lock 関数はクラス管理外の HGLOBAL に対しても適用できます。