### PR TITLE
マウスドラッグ時のスクロール速度を制限する

### DIFF
--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -294,6 +294,39 @@ CLayoutInt CCaret::MoveCursor(
 	}
 	//	To Here 2007.07.28 じゅうじ
 	if( bScroll ){
+		if (abs((Int)nScrollRowNum) < 10) {
+			struct ScrollRowRecord {
+				Int nScrollRowNum;
+				DWORD dwTime;
+			};
+			static ScrollRowRecord s_records[128] = {0};
+			static size_t s_recordPos = 0;
+			DWORD dwNow = GetTickCount();
+			Int nScrollRowsPerTiming = 0;
+			int nRecs = 0;
+			for (size_t i=0; i<_countof(s_records); ++i) {
+				auto& rec = s_records[i];
+				DWORD dwTimeDiff = dwNow - rec.dwTime;
+				if (dwTimeDiff <= 100) {
+					nScrollRowsPerTiming += rec.nScrollRowNum;
+					++nRecs;
+				}
+			}
+			if (abs(nScrollRowsPerTiming) >= 8) {
+				nScrollRowNum = std::min(nScrollRowNum, (CLayoutInt)+1);
+				nScrollRowNum = std::max(nScrollRowNum, (CLayoutInt)-1);
+			}
+			{
+				auto& rec = s_records[s_recordPos];
+				rec.dwTime = dwNow;
+				rec.nScrollRowNum = nScrollRowNum;
+				++s_recordPos;
+				if (s_recordPos >= _countof(s_records)) {
+					s_recordPos = 0;
+				}
+			}
+		}
+		
 		/* スクロール */
 		if( t_abs( nScrollColNum ) >= m_pEditView->GetTextArea().m_nViewColNum ||
 			t_abs( nScrollRowNum ) >= m_pEditView->GetTextArea().m_nViewRowNum ){

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -296,36 +296,34 @@ CLayoutInt CCaret::MoveCursor(
 	if( bScroll ){
 		if( abs( (Int)nScrollRowNum ) < 7 &&
 			( m_pEditView->GetSelectionInfo().IsMouseSelecting() || m_pEditView->m_bDragMode )){
-			struct ScrollRowRecord {
+			struct ScrollRowRecord{
 				Int nScrollRowNum;
 				DWORD dwTime;
 			};
-			static ScrollRowRecord s_records[128] = { 0 };
+			static std::array<ScrollRowRecord, 128> s_records{};
 			static size_t s_recordPos = 0;
 			DWORD dwNow = GetTickCount();
 			Int nScrollRowsPerTiming = 0;
 			DWORD dwPerTiming = 80;
-			if( nScrollRowNum > 0 && m_pEditView->m_bDragMode) {
+			if( nScrollRowNum > 0 && m_pEditView->m_bDragMode ){
 				dwPerTiming = 30;
 			}
-			for( size_t i = 0; i < _countof( s_records ); ++i ){
-				auto& rec = s_records[i];
-				DWORD dwTimeDiff = dwNow - rec.dwTime;
-				if( dwTimeDiff <= dwPerTiming ){
-					nScrollRowsPerTiming += rec.nScrollRowNum;
-				}
-			}
+
+			std::for_each(s_records.begin(), s_records.end(),
+				[ dwNow, dwPerTiming, &nScrollRowsPerTiming ]( ScrollRowRecord rec ){
+					if( ( dwNow - rec.dwTime ) <= dwPerTiming ){
+						nScrollRowsPerTiming += rec.nScrollRowNum;
+					}
+			});
 			if( abs( nScrollRowsPerTiming ) >= 1 ){
 				nScrollRowNum = 0;
 			}
-			{
-				auto& rec = s_records[s_recordPos];
-				rec.dwTime = dwNow;
-				rec.nScrollRowNum = nScrollRowNum;
-				++s_recordPos;
-				if( s_recordPos >= _countof( s_records ) ){
-					s_recordPos = 0;
-				}
+			auto& rec = s_records[s_recordPos];
+			rec.dwTime = dwNow;
+			rec.nScrollRowNum = nScrollRowNum;
+			++s_recordPos;
+			if( s_recordPos >=  s_records.size() ){
+				s_recordPos = 0;
 			}
 		}
 		/* スクロール */

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -300,7 +300,7 @@ CLayoutInt CCaret::MoveCursor(
 				Int nScrollRowNum;
 				DWORD dwTime;
 			};
-			static std::array<ScrollRowRecord, 128> s_records{};
+			static std::array<ScrollRowRecord, 512> s_records{};
 			static size_t s_recordPos = 0;
 			DWORD dwNow = GetTickCount();
 			Int nScrollRowsPerTiming = 0;

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -294,39 +294,40 @@ CLayoutInt CCaret::MoveCursor(
 	}
 	//	To Here 2007.07.28 じゅうじ
 	if( bScroll ){
-		if (abs((Int)nScrollRowNum) < 10) {
+		if( abs( (Int)nScrollRowNum ) < 7 &&
+			( m_pEditView->GetSelectionInfo().IsMouseSelecting() || m_pEditView->m_bDragMode )){
 			struct ScrollRowRecord {
 				Int nScrollRowNum;
 				DWORD dwTime;
 			};
-			static ScrollRowRecord s_records[128] = {0};
+			static ScrollRowRecord s_records[128] = { 0 };
 			static size_t s_recordPos = 0;
 			DWORD dwNow = GetTickCount();
 			Int nScrollRowsPerTiming = 0;
-			int nRecs = 0;
-			for (size_t i=0; i<_countof(s_records); ++i) {
+			DWORD dwPerTiming = 80;
+			if( nScrollRowNum > 0 && m_pEditView->m_bDragMode) {
+				dwPerTiming = 30;
+			}
+			for( size_t i = 0; i < _countof( s_records ); ++i ){
 				auto& rec = s_records[i];
 				DWORD dwTimeDiff = dwNow - rec.dwTime;
-				if (dwTimeDiff <= 100) {
+				if( dwTimeDiff <= dwPerTiming ){
 					nScrollRowsPerTiming += rec.nScrollRowNum;
-					++nRecs;
 				}
 			}
-			if (abs(nScrollRowsPerTiming) >= 8) {
-				nScrollRowNum = std::min(nScrollRowNum, (CLayoutInt)+1);
-				nScrollRowNum = std::max(nScrollRowNum, (CLayoutInt)-1);
+			if( abs( nScrollRowsPerTiming ) >= 1 ){
+				nScrollRowNum = 0;
 			}
 			{
 				auto& rec = s_records[s_recordPos];
 				rec.dwTime = dwNow;
 				rec.nScrollRowNum = nScrollRowNum;
 				++s_recordPos;
-				if (s_recordPos >= _countof(s_records)) {
+				if( s_recordPos >= _countof( s_records ) ){
 					s_recordPos = 0;
 				}
 			}
 		}
-		
 		/* スクロール */
 		if( t_abs( nScrollColNum ) >= m_pEditView->GetTextArea().m_nViewColNum ||
 			t_abs( nScrollRowNum ) >= m_pEditView->GetTextArea().m_nViewRowNum ){

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -1192,7 +1192,7 @@ void CEditView::OnMOUSEMOVE( WPARAM fwKeys, int xPos_, int yPos_ )
 				}
 			}
 		}else{
-			GetCaret().MoveCursorToClientPoint( ptMouse, true, &ptNewCursor );
+			GetCaret().MoveCursorToClientPoint( ptMouse, false, &ptNewCursor );
 		}
 		GetSelectionInfo().m_ptMouseRollPosOld = ptMouse; // マウス範囲選択前回位置(XY座標)
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->
注：このPRでの「スクロール」とは、「ステータスバーを表示中」に
[ドラッグ & ドロップ編集](https://sakura-editor.github.io/help/HLP000135.html)
[マウスによる範囲選択](https://sakura-editor.github.io/help/HLP000007.html)
ここに書かれているドラッグ操作を行った時に起きるスクロールのことを指します。

このPRでは編集部分の「上端」および「下端から２～３行上」にあるマウスドラッグ中に越えるとスクロールが始まるラインのことを「スクロールライン」と呼びます

# <!-- 必須 --> PR の目的

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下はテンプレートなので、追加、削除してください。 -->

- 仕様変更
- プログラムの動作上の問題
  - ローカルビルド版

## <!-- 自明なら省略可 --> PR の背景
　最近のmasterでステータスバーを表示していると、[v2.4.1](https://github.com/sakura-editor/sakura/releases/tag/v2.4.1)に比べスクロールがなめらかになっています。
　スクロールラインを越えた位置でマウスを静止しても、スクロールが続き、減速しなくなっています。快適なスクロールになりました。
　編集画面の行数が20行以上あると、スクロールしすぎてもスクロールライン内にマウスを戻してスクロールを停止し、選択の終点を選ぶことができます。
　しかし、慣れないマウスだったり、ウィンドウを小さくする・フォントを大きくするなど10行以内しか表示していない時はスクロールが進みすぎてしまうことも多く、スクロールがちょっと速いように思います。

<!-- PR を行う背景を記載してください -->

## <!-- 自明なら省略可 --> PR のメリット
- スクロールの時、微調整がしやすくなります
- Windows 8.1でのスクロールが操作可能な速度になります。

<!-- PR のメリットを記載してください。 -->

## <!-- なければ省略可 --> PR のデメリット (トレードオフとかあれば)
- 広いウィンドウで使用している人はスクロールを遅く感じるかもしれません。
- スクロールラインから遠く離すと(速度制限した行を越えると)元のスピードに戻るので、スピード差が気になるかもしれません。
(長い文書の先頭・最後に移動するのは速いですが)
- 「ステータスバーを非表示」の場合についてテスト不足です
<!-- PR のデメリットやトレードオフ等あれば記載してください。 -->

## <!-- 仕様変更/機能追加の場合は必須 --> 仕様・動作説明
スクロールラインを越えた数行に限り、スクロールスピードを制限します。

https://github.com/sakura-editor/sakura/pull/1714#issuecomment-894462762
https://github.com/beru/sakura/commit/f1f084922ebf2b493ccd9807631e21ec16aa9739
beruさんが書いてくださったコードをもとに条件などを追加しています。

beruさんのコードからの変更点と、変更可能な値(必要個所の抜粋)
```
	/sakura_core/view/CCaret.cpp
1		if( abs( (Int)nScrollRowNum ) < 7 &&
2			( m_pEditView->GetSelectionInfo().IsMouseSelecting() || m_pEditView->m_bDragMode )){
3			DWORD dwPerTiming = 80;
4			if( nScrollRowNum > 0 && m_pEditView->m_bDragMode) {
5				nScrollRowNum = 0;
	/sakura_core/view/CEditView_Mouse.cpp
6			GetCaret().MoveCursorToClientPoint( ptMouse, false, &ptNewCursor );
```
5-- スクロール速度を落とせるようになります。
6-- 5の影響で通常の範囲選択でスクロールがストップするので「test(カーソル移動はしない)」をfalseに変更
2-- 矢印キーのキーリピートで不正な描画になるので、マウス選択中・ドラッグアンドドロップ中に限定
4-- ドラッグアンドドロップでは上側のスクロール可能な行がが1行分しかなく増速が見込めないので速度を速めにしています

1-- 数値を変更すると速度制限をするスクロールラインからの行数を変更できます
3-- 数値を増やすと速度制限中の行のスクロール速度が遅くなります

[v2.4.1](https://github.com/sakura-editor/sakura/releases/tag/v2.4.1)に比べ
https://github.com/sakura-editor/sakura/pull/1714#issuecomment-894462762

> ステータスバーの描画を抑制すると WM_MOUSEMOVE メッセージが呼ばれる回数が増えるようです。
> CEditView::OnMOUSEMOVE メソッド内で呼び出す CCaret::MoveCursor メソッドで縦スクロールする処理が頻繁に呼び出されるようになります。
> 

なぜ速度が落ちるのか細かいところまで理解できていないのですが
```
	if( dwTimeDiff <= dwPerTiming ){
```
の間スクロールをストップするのを強制的に挟み込むことでスクロールスピードを落としている…んでしょうか？




<!-- 仕様変更の場合は、変更前後の仕様を記載してください。 -->
<!-- 機能追加の場合は、その仕様や動作を記載してください。 -->
<!-- その他の場合は、必要に応じて処理の仕様や動作説明を記載してください。 -->

## <!-- わかる範囲で --> PR の影響範囲
PR のデメリットを参照
<!-- 既存の処理に対して影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容
いろいろスクロールしてみる。
<!-- PR を投げるにあたってテストした内容を記載してください -->
<!-- PR を投げないとテストできない、or 難しい場合、その旨記載すること     -->
<!-- テストが十分でない場合、Draft PR とする or タイトルに [WIP] とつけること -->

### テスト1

手順


## <!-- なければ省略可 --> 関連 issue, PR
https://github.com/sakura-editor/sakura/pull/1714
<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
