### PR TITLE
resolve unavailable Oniguruma URL

### DIFF
--- a/help/sakura/res/HLP000089.html
+++ b/help/sakura/res/HLP000089.html
@@ -48,8 +48,8 @@
 <tr><td><code><span style="color: blue">x</span>-<span style="color: blue">y</span></code></td><td>範囲<br><code>[A-Z]</code>は、「A」から「Z」までの文字のどれか1つとマッチします。</td></tr>
 <tr><td><code>[<span style="color: blue">...</span>]</code></td><td><span style="color: green">(鬼)</span> 文字集合内文字集合</td></tr>
 <tr><td><code><span style="color: blue">..</span>&amp;&amp;<span style="color: blue">..</span></code></td><td><span style="color: green">(鬼)</span> 積演算</td></tr>
-<tr><td><code>[:<span style="color: blue">xxxxx</span>:]</code></td><td><span style="color: green">(鬼)</span> <a href="http://www.geocities.jp/kosako3/oniguruma/doc/RE.ja.txt" target="_blank" rel="noopener">POSIXブラケット</a></td></tr>
-<tr><td><code>[:^<span style="color: blue">xxxxx</span>:]</code></td><td><span style="color: green">(鬼)</span> <a href="http://www.geocities.jp/kosako3/oniguruma/doc/RE.ja.txt" target="_blank" rel="noopener">POSIXブラケット</a>（否定）</td></tr>
+<tr><td><code>[:<span style="color: blue">xxxxx</span>:]</code></td><td><span style="color: green">(鬼)</span> <a href="https://github.com/kkos/oniguruma/blob/master/doc/RE.ja" target="_blank" rel="noopener">POSIXブラケット</a></td></tr>
+<tr><td><code>[:^<span style="color: blue">xxxxx</span>:]</code></td><td><span style="color: green">(鬼)</span> <a href="https://github.com/kkos/oniguruma/blob/master/doc/RE.ja" target="_blank" rel="noopener">POSIXブラケット</a>（否定）</td></tr>
 </table>
 <span style="color: green">(鬼)</span> はbregonig.dllのみ<br>
 <br>
@@ -107,8 +107,8 @@
 <tr><td><code>\S</code></td><td>空白類文字以外</td></tr>
 <tr><td><code>\d</code></td><td>10進数字 <br><span style="color: green">(Unicode版)</span> 2バイト文字=全角数字も含む</td></tr>
 <tr><td><code>\D</code></td><td>10進数字以外</td></tr>
-<tr><td><code>\p{<span style="color: blue">property-name</span>}</code></td><td><span style="color: green">(鬼)</span> <a href="http://www.geocities.jp/kosako3/oniguruma/doc/RE.ja.txt" target="_blank" rel="noopener">キャラクタプロパティ</a></td></tr>
-<tr><td><code>\p{^<span style="color: blue">property-name</span>}<br>\P{<span style="color: blue">property-name</span>}</code></td><td><span style="color: green">(鬼)</span> <a href="http://www.geocities.jp/kosako3/oniguruma/doc/RE.ja.txt" target="_blank" rel="noopener">キャラクタプロパティ</a>（否定）</td></tr>
+<tr><td><code>\p{<span style="color: blue">property-name</span>}</code></td><td><span style="color: green">(鬼)</span> <a href="https://github.com/kkos/oniguruma/blob/master/doc/UNICODE_PROPERTIES" target="_blank" rel="noopener">キャラクタプロパティ</a></td></tr>
+<tr><td><code>\p{^<span style="color: blue">property-name</span>}<br>\P{<span style="color: blue">property-name</span>}</code></td><td><span style="color: green">(鬼)</span> <a href="https://github.com/kkos/oniguruma/blob/master/doc/UNICODE_PROPERTIES" target="_blank" rel="noopener">キャラクタプロパティ</a>（否定）</td></tr>
 </table>
 <span style="color: green">(鬼)</span> はbregonig.dllのみ<br>
 <span style="color: green">(Unicode版)</span> はUnicode版のサクラエディタ<br>


### PR DESCRIPTION
change URL http://www.geocities.jp/kosako3/oniguruma to https://github.com/kkos/oniguruma

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR の目的
- 存在しない鬼車URLリンクの修正

## <!-- 必須 --> カテゴリ
- 不具合修正
  change URL http://www.geocities.jp/kosako3/oniguruma to https://github.com/kkos/oniguruma

