### PR TITLE
コンテキストメニュー情報の定義漏れを追加

### DIFF
--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -2348,6 +2348,7 @@ BEGIN
     F_EXITALL               "Exit Sakura completely"
     F_OPEN_FOLDER_IN_EXPLORER "Open Containing Folder"
     F_OPEN_COMMAND_PROMPT   "Open Command Prompt"
+	F_OPEN_COMMAND_PROMPT_AS_ADMIN "Open Command Prompt As Admin"
     F_WCHAR                 "Character Input"
     F_IME_CHAR              "Hlf-Width Character Input"
 END


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
コンテキストメニュー「管理者としてコマンドプロンプトを開く(w)」の英語リソースが定義されていなかったため、言語を英語にしても日本語で表示されていました。
その足りないリソースを追加する事が目的です。

<!-- PR の目的を記載してください -->
<!-- 参考: https://github.com/sakura-editor/sakura/wiki/Pull-Request-%E3%82%92%E9%80%81%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F -->

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 必須 --> テスト内容

Visual Studio Community 2017で「sakura.exe」と「sakura_lang_en_US.dll」をビルドして動作確認しました。

１．共通設定の言語設定によって対象のコンテキストメニュー言語が切り替わる。
　・「Japanese」の場合「管理者としてコマンドプロンプトを開く(w)」で表示。
　・「English(United States)」の場合「Open Command Prompt As Admin(w)」で表示

２．それぞれのコンテキストメニューを選択して正しく管理者でコマンドプロンプトが起動する。
