### PR TITLE
メニューのスペル間違いを修正

### DIFF
--- a/sakura_lang_en_US/sakura_lang_rc.rc
+++ b/sakura_lang_en_US/sakura_lang_rc.rc
@@ -2297,7 +2297,7 @@ BEGIN
     F_FILE_RCNTFILE_SUBMENU "Recently Used File"
     F_FILE_RCNTFLDR_SUBMENU "Recently Used Folder"
     F_EDIT_INS_SUBMENU      "Insert"
-    F_EDIT_COS_SUBMENU      "Cosmetik"
+    F_EDIT_COS_SUBMENU      "Cosmetic"
     F_EDIT_MOV_SUBMENU      "Cursor Movement"
     F_EDIT_SEL_SUBMENU      "Selection"
     F_EDIT_HLV_SUBMENU      "High Level Editing"


### PR DESCRIPTION
# <!-- 必須 --> PR の目的
メニューバーの英語表記に誤りがありました。
その修正が目的です。

「編集(E) - 整形(K)」の「整形」の英語表記が Cosmetik になっていますが、正しくは Cosmetic だと思われます。
（頻繁に人の目に触れる箇所のため修正させていただきました。）

整形という意味では訳語に Format が使われる事が多いようにも思いますが、
ここでは採用されている訳語の良し悪しには触れません。

## <!-- 必須 --> カテゴリ
- 不具合修正

## <!-- 必須 --> テスト内容
Visual Studio Community 2017で「sakura.exe」と「sakura_lang_en_US.dll」をビルドして動作確認しました。

１．共通設定の言語設定によって対象のメニュー言語が切り替わる。
　・「Japanese」の場合「整形(K)」で表示。
　・「English(United States)」の場合「Cosmetic(K)」で表示
