### PR TITLE
色種別リスト オーナー描画の改善・続

### DIFF
--- a/sakura_core/typeprop/CPropTypes.h
+++ b/sakura_core/typeprop/CPropTypes.h
@@ -115,7 +115,7 @@ protected:
 
 	// フォント表示用データ
 	HFONT			m_hTypeFont;							//!< タイプ別フォント表示ハンドル
-	HFONT			m_hBoldFont = NULL;						//!< 色種別リストの太字フォント表示ハンドル
+	std::shared_ptr<class CViewFont>	m_pViewFont;				//!< 色種別リストのフォント用
 
 	UINT m_uFocusBorderWidth = 1; // cache SPI_GETFOCUSBORDERWIDTH
 	UINT m_uFocusBorderHeight = 1; // cache SPI_GETFOCUSBORDERHEIGHT

--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -324,7 +324,7 @@ INT_PTR CPropTypesColor::DispatchEvent(
 
 		{
 			LOGFONT	lf = {};
-			HFONT hFont = (HFONT)::SendMessageAny(hwndListColor, WM_GETFONT, 0, 0);
+			const auto hFont = (HFONT)::SendMessageAny(hwndListColor, WM_GETFONT, 0, 0);
 			::GetObject(hFont, sizeof(LOGFONT), &lf);
 			m_pViewFont = std::make_shared<CViewFont>(&lf);
 		}

--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -1129,7 +1129,6 @@ void CPropTypesColor::DrawColorListItem( DRAWITEMSTRUCT* pDis )
 	rc1.top += yOffset;
 	rc1.right -= 2 * (colorSampleWidth + xOffset) + DpiScaleX(2);
 	rc1.bottom -= yOffset;
-	int rc1Height = rc1.bottom - rc1.top;
 	/* 選択ハイライト矩形 */
 	gr.FillMyRect(rc1);
 	/* テキスト */


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善
- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

#1882 の変更で色種別リストのオーナー描画を変更しましたが、その変更内容が原因で表示スケールが200%以上の動作環境で下線表示が不自然になってしまいました。https://github.com/sakura-editor/sakura/pull/1882#discussion_r1057617865

それを改善するのが主な目的です。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->

- フォント作成時にダイアログのフォントではなくて色リストのフォントを使うように変更
- フォント作成は CViewFont クラスに任せるように変更
- 下線描画は自前で線を引くのではなくて、下線付きのフォントを使う

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

タイプ別設定のカラーの色指定リストの表示

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

変更後の表示内容が改善されているかを目視で確認し、改善されていると判断しました。

- 表示スケールが200%以上の場合に下線表示に隙間が無くなった
- 太字のフォントが他と揃うようになった

表示スケール | 変更前 | 変更後
------------|--------|-----------------
100% | ![100%_before](https://user-images.githubusercontent.com/1131125/209902300-edd23c33-32ac-45b6-b21a-4cb77ad06640.png) | ![100%_after](https://user-images.githubusercontent.com/1131125/209902312-3358a9b6-b8a5-4aae-99fd-b8ceefc639be.png)
150% | ![150%_before](https://user-images.githubusercontent.com/1131125/209902306-93842ae2-b4f9-42fe-b321-5992d40f5734.png) | ![150%_after](https://user-images.githubusercontent.com/1131125/209902304-d57dace1-61c8-4701-ad50-531d1a381b08.png)
200% | ![200%_before](https://user-images.githubusercontent.com/1131125/209902308-cd87ee17-f19f-4659-856e-52ed9224e473.png) | ![200%_after](https://user-images.githubusercontent.com/1131125/209902307-22024570-0f1a-4432-a8fc-b9b1bd8715fb.png)
300% | ![300%_before](https://user-images.githubusercontent.com/1131125/209902311-125595dd-1d37-43f7-9687-36bbc972ac1b.png) | ![300%_after](https://user-images.githubusercontent.com/1131125/209902310-c846b74c-9e3e-441d-b91b-d04de658cb8d.png)

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1882

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
