### PR TITLE
CHMヘルプの表示フォントを元に戻す

### DIFF
--- a/help/plugin/Text/dsk_sakura.css
+++ b/help/plugin/Text/dsk_sakura.css
@@ -1,7 +1,7 @@
 ﻿@charset "utf-8";
 
 BODY {
-	margin: 1em 5%; line-height: 1.4; font-family: "MS UI Gothic", sans-serif, "verdana", "arial", "helvetica"; color: #000; background-color: #fff;
+	margin: 1em 5%; line-height: 1.4; font-family: "MS UI Gothic", sans-serif; color: #000; background-color: #fff;
 }
 A:link {
 	COLOR: #f03; BACKGROUND-COLOR: transparent

--- a/help/sakura/res/HLP000089.html
+++ b/help/sakura/res/HLP000089.html
@@ -12,7 +12,7 @@
 <META NAME="MS-HKWD" CONTENT="量指定子">
 <!-- .がみにくいのでMS ゴシックにする -->
 <style type="text/css">
-	code {font-family: "ＭＳ ゴシック", sans-serif; font-size:100%;}
+	code {font-family: "ＭＳ ゴシック", "MS Gothic", sans-serif; font-size:100%;}
 </style>
 </HEAD>
 <BODY>

--- a/help/sakura/res/dsk_sakura.css
+++ b/help/sakura/res/dsk_sakura.css
@@ -1,7 +1,7 @@
 ﻿@charset "utf-8";
 
 BODY {
-	margin: 1em 5%; line-height: 1.4; font-family: "ＭＳ Ｐゴシック", sans-serif; color: #000; background-color: #fff;
+	margin: 1em 5%; line-height: 1.4; font-family: "ＭＳ Ｐゴシック", "MS PGothic", sans-serif; color: #000; background-color: #fff;
 }
 A:link {
 	COLOR: #f03; BACKGROUND-COLOR: transparent

--- a/help/sakura/res/dsk_sakura.css
+++ b/help/sakura/res/dsk_sakura.css
@@ -1,7 +1,7 @@
 ﻿@charset "utf-8";
 
 BODY {
-	margin: 1em 5%; line-height: 1.4; font-family: "ＭＳ Ｐゴシック", sans-serif, "verdana", "arial", "helvetica"; color: #000; background-color: #fff;
+	margin: 1em 5%; line-height: 1.4; font-family: "ＭＳ Ｐゴシック", sans-serif; color: #000; background-color: #fff;
 }
 A:link {
 	COLOR: #f03; BACKGROUND-COLOR: transparent


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- ドキュメント(md、ヘルプファイル等)

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
* #1884

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
Windows 8以降でヘルプファイルを表示したときの表示フォントが「意図せず変わってしまっている」という事象に対処します。いったん表示を元に戻すを目標に作業しています。

変更前：「ＭＳ Ｐゴシック」をHTML Helpビューアーが解釈できず、フォント表示がメイリオになっています。
変更後：フォントファミリーのIDを併記することでHTML Helpビューアーでも正しいフォントで表示できるようになります。

変更内容は #1884 と同じですが、以下の差分があります。
* 使われていない欧文フォント指定を削るの対象が1か所多い。
* マルチバイトのフォント名に対策するの対象が1か所多い。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
CHMヘルプ(sakura.chm、plugin.chm)をローカルで表示した際の見映えに影響します。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
このPRの変更を適用したsakura.chmと[sakura-tag-v2.4.2-build4203-a3e63915b-Win32-Release-Exe.zip](https://github.com/sakura-editor/sakura/releases/download/v2.4.2/sakura-tag-v2.4.2-build4203-a3e63915b-Win32-Release-Exe.zip)に入っているsakura.chmを比較してフォントが変更されていることを確認しました。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
* close #1884

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
* https://willcloud.jp/knowhow/font-family/