### PR TITLE
ヘルプ向け文字コード変換ツールの不具合修正および改善

### DIFF
--- a/tools/ChmSourceConverter/.vsconfig
+++ b/tools/ChmSourceConverter/.vsconfig
@@ -2,6 +2,6 @@
   "version": "1.0",
   "components": [
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
-    "Microsoft.Net.Component.4.7.2.TargetingPack"
+    "Microsoft.Net.Component.4.8.TargetingPack"
   ]
 }

--- a/tools/ChmSourceConverter/ChmSourceConverter.Test/ChmSourceConverter.Test.csproj
+++ b/tools/ChmSourceConverter/ChmSourceConverter.Test/ChmSourceConverter.Test.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ChmSourceConverter</RootNamespace>
     <AssemblyName>ChmSourceConverter.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>

--- a/tools/ChmSourceConverter/ChmSourceConverter/App.config
+++ b/tools/ChmSourceConverter/ChmSourceConverter/App.config
@@ -28,8 +28,8 @@
             <setting name="OutputEncoding" serializeAs="String">
                 <value>Shift_JIS</value>
             </setting>
-            <setting name="ReplacePattern" serializeAs="String">
-                <value>(&lt;meta http-equiv="Content-type" content="text/html; charset=)UTF-8(" */?&gt;)</value>
+            <setting name="HtmlReplacePattern" serializeAs="String">
+                <value>(&lt;meta http-equiv="Content-type" content="text/html; charset=)&lt;InputEncoding&gt;(" */?&gt;)</value>
             </setting>
             <setting name="MaxDegreeOfParallelism" serializeAs="String">
                 <value>1024</value>

--- a/tools/ChmSourceConverter/ChmSourceConverter/App.config
+++ b/tools/ChmSourceConverter/ChmSourceConverter/App.config
@@ -31,6 +31,9 @@
             <setting name="HtmlReplacePattern" serializeAs="String">
                 <value>(&lt;meta http-equiv="Content-type" content="text/html; charset=)&lt;InputEncoding&gt;(" */?&gt;)</value>
             </setting>
+            <setting name="CssReplacePattern" serializeAs="String">
+                <value>(@charset ")&lt;InputEncoding&gt;(";)</value>
+            </setting>
             <setting name="MaxDegreeOfParallelism" serializeAs="String">
                 <value>1024</value>
             </setting>

--- a/tools/ChmSourceConverter/ChmSourceConverter/App.config
+++ b/tools/ChmSourceConverter/ChmSourceConverter/App.config
@@ -6,7 +6,7 @@
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
     <userSettings>
         <ChmSourceConverter.Properties.Settings>

--- a/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverter.csproj
+++ b/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverter.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ChmSourceConverter</RootNamespace>
     <AssemblyName>ChmSourceConverter</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverterApp.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverterApp.cs
@@ -57,6 +57,11 @@ namespace ChmSourceConverter
         private readonly Regex HtmlCharsetPattern;
 
         /// <summary>
+        /// CSS中に現れる文字セット定義のパターン(正規表現)
+        /// </summary>
+        private readonly Regex CssCharsetPattern;
+
+        /// <summary>
         /// コンストラクタ
         /// </summary>
         public ChmSourceConverterApp(Properties.Settings settings)
@@ -68,6 +73,9 @@ namespace ChmSourceConverter
 
             var htmlCharsetPattern = Settings.HtmlReplacePattern.Replace("<InputEncoding>", Settings.InputEncoding);
             HtmlCharsetPattern = new Regex(htmlCharsetPattern, RegexOptions.IgnoreCase);
+
+            var cssCharsetPattern = Settings.CssReplacePattern.Replace("<InputEncoding>", Settings.InputEncoding);
+            CssCharsetPattern = new Regex(cssCharsetPattern, RegexOptions.IgnoreCase);
         }
 
         /// <summary>
@@ -134,6 +142,7 @@ namespace ChmSourceConverter
         private void ReadLinesIntoMemory(string filename, TextWriter writer)
         {
             bool IsHtml = Path.GetExtension(filename) == ".html";
+            bool IsCss = Path.GetExtension(filename) == ".css";
 
             // 入力ファイルから行データを読み取る
             using (var contents = new FileContents(filename, InputEncoding))
@@ -145,6 +154,12 @@ namespace ChmSourceConverter
                     {
                         IsHtml = false;
                         writer.WriteLine(HtmlCharsetPattern.Replace(line, $"$1{Settings.OutputEncoding}$2"));
+                        continue;
+                    }
+                    if (IsCss && CssCharsetPattern.IsMatch(line))
+                    {
+                        IsCss = false;
+                        writer.WriteLine(CssCharsetPattern.Replace(line, $"$1{Settings.OutputEncoding}$2"));
                         continue;
                     }
                     writer.WriteLine(line);

--- a/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverterApp.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/ChmSourceConverterApp.cs
@@ -65,7 +65,9 @@ namespace ChmSourceConverter
 
             TargetExtensions = Settings.TargetExtensions.Cast<string>().ToList();
             InputEncoding = Encoding.GetEncoding(Settings.InputEncoding);
-            HtmlCharsetPattern = new Regex(Settings.ReplacePattern, RegexOptions.IgnoreCase);
+
+            var htmlCharsetPattern = Settings.HtmlReplacePattern.Replace("<InputEncoding>", Settings.InputEncoding);
+            HtmlCharsetPattern = new Regex(htmlCharsetPattern, RegexOptions.IgnoreCase);
         }
 
         /// <summary>
@@ -131,7 +133,7 @@ namespace ChmSourceConverter
         /// <param name="writer"></param>
         private void ReadLinesIntoMemory(string filename, TextWriter writer)
         {
-            bool IsHtml = Path.GetExtension(filename) == TargetExtensions.FirstOrDefault();
+            bool IsHtml = Path.GetExtension(filename) == ".html";
 
             // 入力ファイルから行データを読み取る
             using (var contents = new FileContents(filename, InputEncoding))

--- a/tools/ChmSourceConverter/ChmSourceConverter/Properties/Settings.Designer.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/Properties/Settings.Designer.cs
@@ -76,13 +76,14 @@ namespace ChmSourceConverter.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("(<meta http-equiv=\"Content-type\" content=\"text/html; charset=)UTF-8(\" */?>)")]
-        public string ReplacePattern {
+        [global::System.Configuration.DefaultSettingValueAttribute("(<meta http-equiv=\"Content-type\" content=\"text/html; charset=)<InputEncoding>(\" *" +
+            "/?>)")]
+        public string HtmlReplacePattern {
             get {
-                return ((string)(this["ReplacePattern"]));
+                return ((string)(this["HtmlReplacePattern"]));
             }
             set {
-                this["ReplacePattern"] = value;
+                this["HtmlReplacePattern"] = value;
             }
         }
         

--- a/tools/ChmSourceConverter/ChmSourceConverter/Properties/Settings.Designer.cs
+++ b/tools/ChmSourceConverter/ChmSourceConverter/Properties/Settings.Designer.cs
@@ -89,6 +89,18 @@ namespace ChmSourceConverter.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("(@charset \")<InputEncoding>(\";)")]
+        public string CssReplacePattern {
+            get {
+                return ((string)(this["CssReplacePattern"]));
+            }
+            set {
+                this["CssReplacePattern"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1024")]
         public int MaxDegreeOfParallelism {
             get {

--- a/tools/ChmSourceConverter/ChmSourceConverter/Properties/Settings.settings
+++ b/tools/ChmSourceConverter/ChmSourceConverter/Properties/Settings.settings
@@ -19,8 +19,8 @@
     <Setting Name="OutputEncoding" Type="System.String" Scope="User">
       <Value Profile="(Default)">Shift_JIS</Value>
     </Setting>
-    <Setting Name="ReplacePattern" Type="System.String" Scope="User">
-      <Value Profile="(Default)">(&lt;meta http-equiv="Content-type" content="text/html; charset=)UTF-8(" */?&gt;)</Value>
+    <Setting Name="HtmlReplacePattern" Type="System.String" Scope="User">
+      <Value Profile="(Default)">(&lt;meta http-equiv="Content-type" content="text/html; charset=)&lt;InputEncoding&gt;(" */?&gt;)</Value>
     </Setting>
     <Setting Name="MaxDegreeOfParallelism" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">1024</Value>

--- a/tools/ChmSourceConverter/ChmSourceConverter/Properties/Settings.settings
+++ b/tools/ChmSourceConverter/ChmSourceConverter/Properties/Settings.settings
@@ -22,6 +22,9 @@
     <Setting Name="HtmlReplacePattern" Type="System.String" Scope="User">
       <Value Profile="(Default)">(&lt;meta http-equiv="Content-type" content="text/html; charset=)&lt;InputEncoding&gt;(" */?&gt;)</Value>
     </Setting>
+    <Setting Name="CssReplacePattern" Type="System.String" Scope="User">
+      <Value Profile="(Default)">(@charset ")&lt;InputEncoding&gt;(";)</Value>
+    </Setting>
     <Setting Name="MaxDegreeOfParallelism" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">1024</Value>
     </Setting>


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- ツール類(サクラエディタ本体以外)

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
* #1894

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
* cssの文字コード指定を置換していなかった不具合を修正します。
  メインの不具合修正です。
* HTMLの文字コード指定を置換する正規表現パターンが「入力文字セット」（設定で変更可能）を考慮していなかった不具合を修正します。
  リポジトリの文字セットはUTF-8固定なので、必ずしも修正する必要はない不具合です。
* .NET Frameworkのバージョンがvs2019のデフォルトになっていたのをvs2022のデフォルトに更新します。
  .vsconfigによりv4.7.2のインストールを促されるようになっているので本質的には対処不要です。
  「分かる人だけ分かる」みたいなムラ社会になっていくのは嫌なので、v4.8に更新しておきたいと思います。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
* CHMビルド、CHMの成果物に影響する変更です。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
このPRの変更を適用してビルドしたsakura.chmと[sakura-tag-v2.4.2-build4203-a3e63915b-Win32-Release-Exe.zip](https://github.com/sakura-editor/sakura/releases/download/v2.4.2/sakura-tag-v2.4.2-build4203-a3e63915b-Win32-Release-Exe.zip)に入っているsakura.chmを比較してフォントが変更されたことを確認しました。

Appveyorビルドが失敗するのはLocale-Emulatorの配布サーバーが落ちているためのようです。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
* close #1894
* #1892

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
