### PR TITLE
AppveyorのAutoHotKeyのバージョンを固定する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,8 @@ skip_commits:
 
 install:
 - cmd: |
-    cinst locale-emulator -y
+    cinst autohotkey.portable -Version 1.1.36.02 -y
+    cinst locale-emulator -Version 2.5.0.11 -y
     cup vswhere
     py.exe -m pip install openpyxl --user
     cup innosetup


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

- ビルド手順/CI

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Appveyorのビルドが失敗しています。
すぐには外せないので暫定対処策を打ちたいです。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
~~直してみて修正が機能したらちゃんと書きます。~~

想定合ってそうなので詳細書きます。

ある時点からAppveyorのビルドが失敗するようになっています。
Appveyorのログを比較した感じ、chocolateyでインストールしているAutoHotKeyのバージョンが変わっていました。
[appveyor-log_x64_01a4ffb5.txt](https://github.com/sakura-editor/sakura/files/10341221/appveyor-log_x64_01a4ffb5.txt)

### 想定する不具合原因
LEProcのインストールスクリプトがAutoHotKeyの変更に対応していない。
※依存関係でバージョン固定する必要があるが、未対応であるために不具合が発生している。

本筋の対応は「LEProcのchocolateyパッケージが更新されるのを待つ」なんですが、いつ対策されるか分からないので暫定対策を打ちたいです。

### 実施する対策
AutoHotKeyのインストールバージョンを固定し、AutoHotKey最新バージョンが使われないようにする。

### デメリット
LEProcやAutoHotKeyにセキュリティパッチがあたった場合に自動適用されなくなります。

### メリット
とりあえずビルドできるようになります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
Appveyorのビルドに影響します。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
Appveyorのみに影響する修正なので、PR時に実行されるCIの結果で判断します。

ローカルでのテストは実施していません。


<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
