### PR TITLE
chmのビルドにPowershellを使う

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,10 @@ sakura_rc.h text eol=crlf
 *.rc text working-tree-encoding=utf-16le-bom eol=crlf
 *.rc2 text working-tree-encoding=utf-16le-bom eol=crlf
 *.ps1 text working-tree-encoding=utf-16le-bom eol=crlf
+*.hhp      working-tree-encoding=cp932 eol=crlf
+*.hhk      working-tree-encoding=cp932 eol=crlf
+*.hhc      working-tree-encoding=cp932 eol=crlf
+Cshelp.txt working-tree-encoding=cp932 eol=crlf
 *.config text eol=crlf
 *.csproj text eol=crlf
 *.filters text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /cppcheck-*.xml
 /cppcheck-install.log
 /help/sakura/sakura.hh
+/help/**/*.chm
+/help/**/*.chw
+/help/**/Compile.Log
 /build
 /MinGW
 /Win32

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -12,48 +12,10 @@ set HH_INPUT=%~dp0sakura_core\sakura.hh
 set HH_OUTPUT=%~dp0help\sakura\sakura.hh
 
 if exist "%HH_OUTPUT%" del /F "%HH_OUTPUT%"
-powershell "(Get-Content -li %HH_INPUT% -Encoding UTF8) -replace '//.*' | Set-Content -li %HH_OUTPUT% -Encoding UTF8"
-
 if exist "%TMP_HELP%" rmdir /s /q "%TMP_HELP%"
-xcopy /i /k /s "%SRC_HELP%" "%TMP_HELP%"
 
-set HHP_MACRO=%TMP_HELP%\macro\macro.HHP
-set HHP_PLUGIN=%TMP_HELP%\plugin\plugin.hhp
-set HHP_SAKURA=%TMP_HELP%\sakura\sakura.hhp
+powershell.exe -ExecutionPolicy RemoteSigned -File "%~dp0help\build-chm.ps1"
 
-set CHM_MACRO=%TMP_HELP%\macro\macro.chm
-set CHM_PLUGIN=%TMP_HELP%\plugin\plugin.chm
-set CHM_SAKURA=%TMP_HELP%\sakura\sakura.chm
-
-set "TOOL_SLN_FILE=%~dp0tools\ChmSourceConverter\ChmSourceConverter.sln"
-@echo "%CMD_MSBUILD%" %TOOL_SLN_FILE% "/p:Platform=Any CPU" /p:Configuration=Release /t:"Build" /v:q
-      "%CMD_MSBUILD%" %TOOL_SLN_FILE% "/p:Platform=Any CPU" /p:Configuration=Release /t:"Build" /v:q
-if errorlevel 1 exit /b 1
-
-%~dp0tools\ChmSourceConverter\ChmSourceConverter\bin\Release\ChmSourceConverter.exe "%TMP_HELP%"
-if errorlevel 1 exit /b 1
-
-call :BuildChm %HHP_MACRO%  %CHM_MACRO%   || (echo error && exit /b 1)
-call :BuildChm %HHP_PLUGIN% %CHM_PLUGIN%  || (echo error && exit /b 1)
-call :BuildChm %HHP_SAKURA% %CHM_SAKURA%  || (echo error && exit /b 1)
-
-copy /Y %TMP_HELP%\macro\*.chm   %SRC_HELP%\macro\   || (echo error && exit /b 1)
-copy /Y %TMP_HELP%\plugin\*.chm  %SRC_HELP%\plugin\  || (echo error && exit /b 1)
-copy /Y %TMP_HELP%\sakura\*.chm  %SRC_HELP%\sakura\  || (echo error && exit /b 1)
-
-copy /Y %TMP_HELP%\macro\*.Log   %SRC_HELP%\macro\   || (echo error && exit /b 1)
-copy /Y %TMP_HELP%\plugin\*.Log  %SRC_HELP%\plugin\  || (echo error && exit /b 1)
-copy /Y %TMP_HELP%\sakura\*.Log  %SRC_HELP%\sakura\  || (echo error && exit /b 1)
-
-rmdir /s /q %TMP_HELP%
+rmdir /s /q "%TMP_HELP%"
 exit /b 0
 
-@rem ------------------------------------------------------------------------------
-@rem BuildChm
-@rem ------------------------------------------------------------------------------
-:BuildChm
-set PROJECT_HHP=%1
-set PROJECT_CHM=%2
-
-powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0help\CompileChm.ps1 %PROJECT_HHP% %PROJECT_CHM%
-exit /b 0

--- a/help/.gitattributes
+++ b/help/.gitattributes
@@ -1,4 +1,0 @@
-*.hhp      working-tree-encoding=cp932 eol=crlf
-*.hhk      working-tree-encoding=cp932 eol=crlf
-*.hhc      working-tree-encoding=cp932 eol=crlf
-Cshelp.txt working-tree-encoding=cp932 eol=crlf

--- a/help/CompileChm.ps1
+++ b/help/CompileChm.ps1
@@ -16,7 +16,7 @@ function Is-Existing
 		[string]$Path
 	)
 
-    return Test-Path -Path $Path
+    return Test-Path -LiteralPath $Path
 }
 
 # ファイル不存在チェック
@@ -91,7 +91,7 @@ function Copy-Chm
 	{
 		if ($Destination | Is-Missing)
 		{
-			New-Item -Path $Destination -ItemType Directory
+			New-Item -LiteralPath $Destination -ItemType Directory
 		}
 
 		$Destination = [System.IO.Path]::Combine($Destination, [System.IO.Path]::GetFileName($Path))
@@ -107,7 +107,7 @@ function Copy-Chm
 	{
 		echo "`$CompiledHelp is: $Path"
 		echo "`$Destination  is: $Destination"
-		Copy-Item -Path $Path -Destination $Destination
+		Copy-Item -LiteralPath $Path -Destination $Destination
 	}
 	catch #[System.IO.IOException]
 	{
@@ -118,8 +118,7 @@ function Copy-Chm
 	return $true
 }
 
-$HtmlHelpProject = Convert-Path $HtmlHelpProject
-
+$HtmlHelpProject = Convert-Path -LiteralPath $HtmlHelpProject
 if (-not($HtmlHelpProject -imatch '\.hhp$'))
 {
 	throw [System.ArgumentException]::new("Bad filename of `$HtmlHelpProject: $HtmlHelpProject")
@@ -136,17 +135,17 @@ $CompileLog = "$([System.IO.Path]::GetDirectoryName($HtmlHelpProject))\Compile.L
 
 if ($CompileLog | Is-Existing)
 {
-	rm $CompileLog
+	rm -LiteralPath $CompileLog
 }
 
 if ($CompiledHelp | Is-Existing)
 {
-	rm $CompiledHelp
+	rm -LiteralPath $CompiledHelp
 }
 
 if ($Destination | Is-Existing)
 {
-	rm $Destination
+	rm -LiteralPath $Destination
 }
 
 while ($true)

--- a/help/EncoderEscapingFallback.cs
+++ b/help/EncoderEscapingFallback.cs
@@ -61,7 +61,7 @@ namespace ChmSourceConverter
         }
 
         /// <inheritdoc />
-        public override int MaxCharCount => EncoderFallback.ExceptionFallback.MaxCharCount;
+        public override int MaxCharCount { get{ return EncoderFallback.ExceptionFallback.MaxCharCount; }}
 
         /// <inheritdoc />
         public override EncoderFallbackBuffer CreateFallbackBuffer()

--- a/help/EncoderEscapingFallback.cs
+++ b/help/EncoderEscapingFallback.cs
@@ -1,0 +1,72 @@
+﻿/*
+	Copyright (C) 2018-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+using System;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ChmSourceConverter
+{
+    /// <summary>
+    /// Provides a failure handling mechanism, called a fallback,
+    /// for an input character that cannot be converted to an output byte sequence.
+    /// The fallback uses a user-specified replacement string instead of the original input character.
+    /// This class cannot be inherited.
+    /// </summary>
+    public sealed class EncoderEscapingFallback : EncoderFallback
+    {
+        /// <summary>
+        /// the Escaping Format
+        /// </summary>
+        public string Format { get; private set; }
+
+        /// <summary>
+        /// construct the instance
+        /// </summary>
+        /// <param name="format">escaping format, should be including "{0}".</param>
+        public EncoderEscapingFallback(string format)
+            : base()
+        {
+            // validate format string.
+            if (format == null)
+                throw new ArgumentNullException("format");
+            if (!Regex.IsMatch(format, @".*\{0.*\}.*"))
+                throw new ArgumentException("bad format", "format");
+
+            // test formatting
+            string.Format(format, 1);
+
+            // set internal member.
+            Format = format;
+        }
+
+        /// <inheritdoc />
+        public override int MaxCharCount => EncoderFallback.ExceptionFallback.MaxCharCount;
+
+        /// <inheritdoc />
+        public override EncoderFallbackBuffer CreateFallbackBuffer()
+        {
+            return new EncoderEscapingFallbackBuffer(this);
+        }
+    }
+}

--- a/help/EncoderEscapingFallbackBuffer.cs
+++ b/help/EncoderEscapingFallbackBuffer.cs
@@ -25,6 +25,7 @@ using System;
 using System.Linq;
 using System.Security;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace ChmSourceConverter
 {
@@ -38,7 +39,7 @@ namespace ChmSourceConverter
         private EncoderEscapingFallback FallbackRef;
 
         /// <inheritdoc />
-        public override int Remaining => Buffer.Count();
+        public override int Remaining { get{ return Buffer.Count(); }}
 
         /// <summary>
         /// Initializes a new instance of the EncoderEscapingFallbackBuffer class

--- a/help/EncoderEscapingFallbackBuffer.cs
+++ b/help/EncoderEscapingFallbackBuffer.cs
@@ -1,0 +1,128 @@
+﻿/*
+	Copyright (C) 2018-2022, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+using System;
+using System.Linq;
+using System.Security;
+using System.Text;
+
+namespace ChmSourceConverter
+{
+    /// <summary>
+    /// Represents a substitute input string that is used when the original input character cannot be encoded.
+    /// This class cannot be inherited.
+    /// </summary>
+    internal sealed class EncoderEscapingFallbackBuffer : EncoderFallbackBuffer
+    {
+        private ArraySegment<char> Buffer;
+        private EncoderEscapingFallback FallbackRef;
+
+        /// <inheritdoc />
+        public override int Remaining => Buffer.Count();
+
+        /// <summary>
+        /// Initializes a new instance of the EncoderEscapingFallbackBuffer class
+        /// using the value of a EncoderEscapingFallback object.
+        /// </summary>
+        /// <param name="fallback">A EncoderEscapingFallback object.</param>
+        public EncoderEscapingFallbackBuffer(EncoderEscapingFallback fallback)
+        {
+            Buffer = new ArraySegment<char>(Array.Empty<char>());
+            FallbackRef = fallback;
+        }
+
+        /// <summary>
+        /// Prepares the escaping fallback buffer to use the current format string.
+        /// </summary>
+        /// <param name="charUnknown"></param>
+        /// <returns></returns>
+        private bool Fallback(int charUnknown)
+        {
+            var escapedChar = string.Format(FallbackRef.Format, charUnknown);
+            Buffer = new ArraySegment<char>(escapedChar.ToCharArray());
+            return true;
+        }
+
+        /// <inheritdoc />
+        public override bool Fallback(char charUnknown, int index)
+        {
+            if (Buffer.Any())
+            {
+                throw new ArgumentException("This method is called again before the GetNextChar method has read all the replacement string characters.");
+            }
+
+            return Fallback((Int32)charUnknown);
+        }
+
+        /// <inheritdoc />
+        public override bool Fallback(char charUnknownHigh, char charUnknownLow, int index)
+        {
+            if (Buffer.Any())
+            {
+                throw new ArgumentException("This method is called again before the GetNextChar method has read all the replacement string characters.");
+            }
+            if (charUnknownHigh < 0xD800 || charUnknownHigh > 0xD8FF)
+            {
+                throw new ArgumentOutOfRangeException("charUnknownHigh", charUnknownHigh, "The value of charUnknownHigh is out of range");
+            }
+            if (charUnknownLow < 0xDC00 || charUnknownLow > 0xDFFF)
+            {
+                throw new ArgumentOutOfRangeException("charUnknownLow", charUnknownLow, "The value of charUnknownLow is out of range");
+            }
+
+            int charUnknown = Char.ConvertToUtf32(charUnknownHigh, charUnknownLow);
+            return Fallback(charUnknown);
+        }
+
+        /// <inheritdoc />
+        public override char GetNextChar()
+        {
+            char ch = Buffer.FirstOrDefault();
+            if (Buffer.Any())
+            {
+                Buffer = new ArraySegment<char>(Buffer.Array, Buffer.Offset + 1, Buffer.Count - 1);
+            }
+            return ch;
+        }
+
+        /// <inheritdoc />
+        public override bool MovePrevious()
+        {
+            if (Buffer.Offset == 0) return false;
+            Buffer = new ArraySegment<char>(Buffer.Array, Buffer.Offset - 1, Buffer.Count + 1);
+            return true;
+        }
+
+        /// <summary>
+        /// Initializes all internal state information and data in this instance of System.Text.EncoderReplacementFallbackBuffer.
+        /// </summary>
+        [SecuritySafeCritical]
+        public override void Reset()
+        {
+            if (Buffer.Any())
+            {
+                Buffer = new ArraySegment<char>(Buffer.Array, 0, Buffer.Array.Length);
+            }
+        }
+    }
+}

--- a/help/build-chm.ps1
+++ b/help/build-chm.ps1
@@ -1,0 +1,28 @@
+#remove comment
+(Get-Content -LiteralPath $env:HH_INPUT -Encoding UTF8) -replace '//.*' |
+ Set-Content -LiteralPath $env:HH_OUTPUT -Encoding UTF8
+
+$cssrc=(Get-Content -LiteralPath "$env:SRC_HELP\EncoderEscapingFallbackBuffer.cs" -Raw),
+	((Get-Content -LiteralPath "$env:SRC_HELP\EncoderEscapingFallback.cs" -Raw) -replace "using System.+\r\n") -join ""
+Add-Type -TypeDefinition $cssrc -Language CSharp
+$sjis=[Text.Encoding]::GetEncoding("shift_jis",[ChmSourceConverter.EncoderEscapingFallback]::new("&#{0};"),[Text.DecoderFallback]::ExceptionFallback)
+$re=[Regex]::new('(?<=<META http-equiv="Content-Type" content="text/html; charset=|@charset ")UTF-8',"IgnoreCase")
+
+#create a folder tree
+robocopy $env:SRC_HELP $env:TMP_HELP /e /xf *.html *.css *.js *.chm *.chw *.log /r:5 /w:10 > $null
+
+#convert
+dir -LiteralPath $env:SRC_HELP -Recurse -File |
+	%{ 
+		if($_.name -match "\.(?:html|css|js)$"){
+			$utf8=Get-Content -LiteralPath $_.fullname -Encoding UTF8 -Raw
+			$string=$re.Replace($utf8, 'Shift_JIS', 1)
+			$bytes=$sjis.GetBytes($string, 0, $string.Length)
+			[IO.File]::WriteAllBytes(($_.fullname -replace ($env:SRC_HELP -replace "[[\]\\]",'\$&'), $env:TMP_HELP), $bytes)
+		}
+	}
+
+#compile
+&"$env:SRC_HELP\CompileChm.ps1" "$env:TMP_HELP\macro\macro.HHP" "$env:SRC_HELP\macro\macro.chm"
+&"$env:SRC_HELP\CompileChm.ps1" "$env:TMP_HELP\plugin\plugin.HHP" "$env:SRC_HELP\plugin\plugin.chm"
+&"$env:SRC_HELP\CompileChm.ps1" "$env:TMP_HELP\sakura\sakura.HHP" "$env:SRC_HELP\sakura\sakura.chm"

--- a/help/build-chm.ps1
+++ b/help/build-chm.ps1
@@ -3,7 +3,7 @@
  Set-Content -LiteralPath $env:HH_OUTPUT -Encoding UTF8
 
 $cssrc=(Get-Content -LiteralPath "$env:SRC_HELP\EncoderEscapingFallbackBuffer.cs" -Raw),
-	((Get-Content -LiteralPath "$env:SRC_HELP\EncoderEscapingFallback.cs" -Raw) -replace "using System.+\r\n") -join ""
+	((Get-Content -LiteralPath "$env:SRC_HELP\EncoderEscapingFallback.cs" -Raw) -replace "using System.*?\r?\n") -join ""
 Add-Type -TypeDefinition $cssrc -Language CSharp
 $sjis=[Text.Encoding]::GetEncoding("shift_jis",[ChmSourceConverter.EncoderEscapingFallback]::new("&#{0};"),[Text.DecoderFallback]::ExceptionFallback)
 $re=[Regex]::new('(?<=<META http-equiv="Content-Type" content="text/html; charset=|@charset ")UTF-8',"IgnoreCase")

--- a/help/macro/.gitignore
+++ b/help/macro/.gitignore
@@ -1,2 +1,0 @@
-/*.chm
-/Compile.Log

--- a/help/plugin/.gitignore
+++ b/help/plugin/.gitignore
@@ -1,2 +1,0 @@
-/*.chm
-/Compile.Log

--- a/help/sakura/.gitignore
+++ b/help/sakura/.gitignore
@@ -1,2 +1,0 @@
-/*.chm
-/Compile.Log


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- ドキュメント(md、ヘルプファイル等)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 不具合修正

## <!-- 必須 --> PR の背景
chmのビルドの大半をPowershellで処理します。
Powershellにすることにより、

- ヘルプの編集だけしたい人はHTML Help Workshopを持っていればVisual Studio無しでもコンパイルできるようになります。
- batよりは複雑なコードを書けるようになります。

<del>ヘルプファイルで意図しないフォントが使用されるので対処します。</del>
-> #1896 で解消しました。
#1894 はローカルでしか動かなかったので、CIでもコンパイル可能にしました。
<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

## <!-- 必須 --> 仕様・動作説明

- シフトJISに無い文字を数値文字参照に変換することも可能です
- #996 で作られた`EncoderEscapingFallback`クラスから借用しています
- add-typeの制限のためラムダ式、後半のusing句を削除しています
- 変換ツールのビルドに必要だったTargeting Packが必要なくなります
- `build-chm.bat`の処理を`/help/build-chm.ps1`に移動しています
- ヘルプのキーワードタブを開いたときにできる`*.chw`を`.gitignore`に追加しています
- `help`以下にある`.gitattributes`と`.gitignore`をルートにまとめています
- 各`*.chm`コンパイル中のログだけ表示されて、成功のログが表示されていないので対応しています

<!-- ふるまいを変えない変更の場合は省略可。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容
ローカルでシフトJISに無い文字をソースに書き込んでコンパイル後に数値文字参照に変換されているのを確認しました

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR
#1894
#1896
#996

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料
<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
