### PR TITLE
等幅フォント使用時に全角文字の文字幅が半角文字のちょうど2倍になるように強制的に設定

### DIFF
--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -182,7 +182,7 @@ int CCharWidthCache::QueryPixelWidth(wchar_t c) const
 		return t_max<int>(nCx, size.cx);
 	}
 	if (m_lf.lfPitchAndFamily & FIXED_PITCH)
-		return (0x0080 <= c && c <= 0xFFFF) ? m_han_size.cx * 2 : m_han_size.cx;
+		return ((0x0 <= c && c <= 0x7f) || (0xFF61 <= c && c <= 0xFFDC) || (0xFFE8 <= c && c <= 0xFFEE)) ? m_han_size.cx : m_han_size.cx * 2;
 	GetTextExtentPoint32(SelectHDC(c),&c,1,&size);
 	return t_max<int>(1,size.cx);
 }

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -49,8 +49,11 @@ namespace WCODE
 
 	bool CalcHankakuByFont(wchar_t);
 
-	bool isSurelyHalfWidth(wchar_t wc)
+	//2007.08.30 kobake 追加
+	bool IsHankaku(wchar_t wc, CCharWidthCache& cache)
 	{
+		//※ほぼ未検証。ロジックが確定したらインライン化すると良い。
+
 		//参考：http://www.swanq.co.jp/blog/archives/000783.html
 		if(
 			   wc<=0x007E //ACODEとか
@@ -62,15 +65,6 @@ namespace WCODE
 		//0x7F ～ 0xA0 も半角とみなす
 		//http://ja.wikipedia.org/wiki/Unicode%E4%B8%80%E8%A6%A7_0000-0FFF を見て、なんとなく
 		if(wc>=0x007F && wc<=0x00A0)return true;	// Control Code ISO/IEC 6429
-
-		return false;
-	}
-
-	//2007.08.30 kobake 追加
-	bool IsHankaku(wchar_t wc, CCharWidthCache& cache)
-	{
-		//※ほぼ未検証。ロジックが確定したらインライン化すると良い。
-		if (isSurelyHalfWidth(wc)) return true;
 
 		// 漢字はすべて同一幅とみなす	// 2013.04.07 aroka
 		if ( wc>=0x4E00 && wc<=0x9FBB		// Unified Ideographs, CJK

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -181,7 +181,7 @@ int CCharWidthCache::QueryPixelWidth(wchar_t c) const
 		GetTextExtentPoint32(SelectHDC(proxyChar),&proxyChar,1,&size);
 		return t_max<int>(nCx, size.cx);
 	}
-	if (m_lf.lfPitchAndFamily & 1)
+	if (m_lf.lfPitchAndFamily & FIXED_PITCH)
 		return (0x0080 <= c && c <= 0xFFFF) ? m_han_size.cx * 2 : m_han_size.cx;
 	GetTextExtentPoint32(SelectHDC(c),&c,1,&size);
 	return t_max<int>(1,size.cx);

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -181,6 +181,8 @@ int CCharWidthCache::QueryPixelWidth(wchar_t c) const
 		GetTextExtentPoint32(SelectHDC(proxyChar),&proxyChar,1,&size);
 		return t_max<int>(nCx, size.cx);
 	}
+	if (m_lf.lfPitchAndFamily & 1)
+		return (0x0080 <= c && c <= 0xFFFF) ? m_han_size.cx * 2 : m_han_size.cx;
 	GetTextExtentPoint32(SelectHDC(c),&c,1,&size);
 	return t_max<int>(1,size.cx);
 }

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -187,10 +187,11 @@ int CCharWidthCache::QueryPixelWidth(wchar_t c) const
 		GetTextExtentPoint32(SelectHDC(proxyChar),&proxyChar,1,&size);
 		return t_max<int>(nCx, size.cx);
 	}
-	// 等幅フォントでも GetTextExtentPoint32 で取得したピクセル幅が半角と全角でぴったし2倍にならない事への対策
-	if ((m_lf.lfPitchAndFamily & FIXED_PITCH))
-		return WCODE::isSurelyHalfWidth(c) ? m_han_size.cx : 2*m_han_size.cx;
 	GetTextExtentPoint32(SelectHDC(c),&c,1,&size);
+	// 等幅フォントでも GetTextExtentPoint32 で取得したピクセル幅が半角と全角でぴったし2倍の違いにならない事がある
+	// 対策として半角より少しでも幅が広い場合は半角幅の2倍に揃える
+	if ((m_lf.lfPitchAndFamily & FIXED_PITCH) && size.cx > m_han_size.cx)
+		size.cx = 2 * m_han_size.cx;
 	return t_max<int>(1,size.cx);
 }
 

--- a/tests/unittests/test-charcode.cpp
+++ b/tests/unittests/test-charcode.cpp
@@ -39,12 +39,6 @@ protected:
 		lf2 = LOGFONT();
 		lf2.lfCharSet = DEFAULT_CHARSET;
 		std::wcscpy(lf2.lfFaceName, L"Meiryo");
-		lf3 = LOGFONT();
-		lf3.lfCharSet = DEFAULT_CHARSET;
-		std::wcscpy(lf3.lfFaceName, L"UD デジタル 教科書体 N-B");
-		lf3.lfPitchAndFamily = FIXED_PITCH;
-		lf3.lfHeight = -19; // 14pt 200%想定
-		lf3.lfWeight = FW_BOLD;
 
 		dc = GetDC(nullptr);
 		font = CreateFontIndirect(&lf1);
@@ -59,7 +53,6 @@ protected:
 
 	LOGFONT lf1;
 	LOGFONT lf2;
-	LOGFONT lf3;
 	HDC dc;
 	HFONT font;
 	HFONT oldFont;
@@ -163,18 +156,6 @@ TEST_F(CharWidthCache, CalcPxWidthByFont2)
 	SIZE size;
 	GetTextExtentPoint32(dc, L"\xd83c\xdf38", 2, &size);
 	EXPECT_EQ(cache.CalcPxWidthByFont2(L"\xd83c\xdf38"), size.cx);
-}
-
-TEST_F(CharWidthCache, CalcPxWidthByFont3)
-{
-	SelectCharWidthCache(CWM_FONT_EDIT, CWM_CACHE_LOCAL);
-	InitCharWidthCache(lf3);
-	CCharWidthCache& cache = GetCharWidthCache();
-
-	constexpr auto halfWidth = 10;
-	constexpr auto fullWidth = halfWidth * 2;
-	EXPECT_EQ(cache.CalcPxWidthByFont(L'a'), halfWidth);
-	EXPECT_EQ(cache.CalcPxWidthByFont(L'あ'), fullWidth);
 }
 
 TEST_F(CharWidthCache, FontNo)

--- a/tests/unittests/test-charcode.cpp
+++ b/tests/unittests/test-charcode.cpp
@@ -39,6 +39,12 @@ protected:
 		lf2 = LOGFONT();
 		lf2.lfCharSet = DEFAULT_CHARSET;
 		std::wcscpy(lf2.lfFaceName, L"Meiryo");
+		lf3 = LOGFONT();
+		lf3.lfCharSet = DEFAULT_CHARSET;
+		std::wcscpy(lf3.lfFaceName, L"UD デジタル 教科書体 N-B");
+		lf3.lfPitchAndFamily = FIXED_PITCH;
+		lf3.lfHeight = -19; // 14pt 200%想定
+		lf3.lfWeight = FW_BOLD;
 
 		dc = GetDC(nullptr);
 		font = CreateFontIndirect(&lf1);
@@ -53,6 +59,7 @@ protected:
 
 	LOGFONT lf1;
 	LOGFONT lf2;
+	LOGFONT lf3;
 	HDC dc;
 	HFONT font;
 	HFONT oldFont;
@@ -156,6 +163,18 @@ TEST_F(CharWidthCache, CalcPxWidthByFont2)
 	SIZE size;
 	GetTextExtentPoint32(dc, L"\xd83c\xdf38", 2, &size);
 	EXPECT_EQ(cache.CalcPxWidthByFont2(L"\xd83c\xdf38"), size.cx);
+}
+
+TEST_F(CharWidthCache, CalcPxWidthByFont3)
+{
+	SelectCharWidthCache(CWM_FONT_EDIT, CWM_CACHE_LOCAL);
+	InitCharWidthCache(lf3);
+	CCharWidthCache& cache = GetCharWidthCache();
+
+	constexpr auto halfWidth = 10;
+	constexpr auto fullWidth = halfWidth * 2;
+	EXPECT_EQ(cache.CalcPxWidthByFont(L'a'), halfWidth);
+	EXPECT_EQ(cache.CalcPxWidthByFont(L'あ'), fullWidth);
 }
 
 TEST_F(CharWidthCache, FontNo)


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->

等幅フォント使用時に全角文字の文字幅が半角文字のちょうど2倍になるように強制的に設定を行うように変更しています。

`CCharWidthCache::QueryPixelWidth` メソッドで `GetTextExtentPoint32` 関数で求める方法だとぴったしちょうど2倍にならない事への対策です。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

文字描画に影響

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

```
ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
あいうえおかきくけこさしすせそたちつてとなにぬねのは
```

という文字列を使った場合に、等幅フォント使用時に1行目と2行目の幅が一致するかどうかを確認。

- UD デジタル 教科書体 N-R
- ＭＳ ゴシック
- BIZ UDゴシック

プロポーショナルフォントでは1行目と2行目の幅が一致しない事も確認

- MS UI Gothic
- ＭＳ Ｐゴシック
- メイリオ
- 游ゴシック

----

```
ｶﾂｵｵﾔﾂﾖ
ｷｮｳﾉｵﾔﾂﾊﾜｶﾒｻﾗﾀﾞﾖ
```

という半角ｶﾀｶﾅ文字列が半角幅で表示される事を確認


## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1250

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

https://ja.osdn.net/projects/sakura-editor/forums/34071/48041/

