### PR TITLE
UTF-32ビッグエンディアンにて、基本多言語面以外を正しく表示する

### DIFF
--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -617,7 +617,7 @@ int CCodePage::S_UTF32BEToUnicode( const char* pSrc, int nSrcLen, wchar_t* pDst,
 			}else if( pSrcByte[i] == 0x00 && pSrcByte[i+1] <= 0x10 ){
 				nDstUseCharLen = 2;
 				if( nDstUseLen + nDstUseCharLen <= nDstLen ){
-					UINT c = (pSrcByte[i+3] << 16) | (pSrcByte[i+2] << 8) | pSrcByte[i+1];
+					UINT c = (pSrcByte[i+1] << 16) | (pSrcByte[i+2] << 8) | pSrcByte[i+3];
 					UINT x = c - 0x10000;
 					pDst[nDstUseLen]   = static_cast<wchar_t>(0xd800 | (x >> 10));
 					pDst[nDstUseLen+1] = static_cast<wchar_t>(0xdc00 | (x & 0x3ff));


### PR DESCRIPTION
# PR対象
- アプリ(サクラエディタ本体)

## カテゴリ
- 不具合修正

## PR の背景
issueは作成していません。以下、不具合の再現手順です。 
基本多言語面以外の文字(U+10000以降)を入力します。この例では、U+1F604です。
<img width="345" alt="1" src="https://user-images.githubusercontent.com/62864681/220844651-413cb50f-e08b-46c7-9835-b020f6f5c018.png">
12001(UTF-32BE)にて保存します。
<img width="391" alt="2" src="https://user-images.githubusercontent.com/62864681/220845293-2b36365c-7b10-4636-b010-388cc730a457.png">
警告が表示されます。この警告が表示されることが1個目の不具合です。無視して[はい]を押下します。
<img width="307" alt="3" src="https://user-images.githubusercontent.com/62864681/220845687-03b79b1a-654c-44b7-8779-8a3f591cfb37.png">
保存直後、画面表示上は、正しく見えます。
<img width="352" alt="4" src="https://user-images.githubusercontent.com/62864681/220846645-93fad136-a6ed-405d-843e-dffbc8cdceaf.png">
バイナリーエディターで見ても、正しく保存されています。(拡張子の違いは無視してください)
<img width="179" alt="7" src="https://user-images.githubusercontent.com/62864681/220849350-bf4b20e0-5950-4a29-8c7a-86a032e5e060.png">
一度、サクラエディタを閉じて、先ほど保存したファイルを12001(UTF-32BE)にて開きます。
<img width="387" alt="5" src="https://user-images.githubusercontent.com/62864681/220849133-0b798e0f-4bf4-4a4d-bc4e-3b20d0941a7d.png">
文字化けしています。符号位置も間違っています。これが2個目の不具合です。
<img width="375" alt="6" src="https://user-images.githubusercontent.com/62864681/220850505-79e7923d-27cf-4403-8436-8f9ce6cfe2a0.png">
上記手順は、BOM有りの場合でも同様です。また、12000(UTF-32LE)では正しく動作しています。

## 不具合箇所の特定
保存時、 
CCodePage::S_UnicodeToUTF32BE→ 
CCodePage::S_UTF32BEToUnicode→(警告表示)→ 
CCodePage::S_UnicodeToUTF32BE 
の順に呼ばれます。 
開くとき、 
CCodePage::S_UTF32BEToUnicode→ 
CCodePage::S_UTF32BEToUnicode 
の順に呼ばれます。 
それぞれ、なぜ同じ処理が2回呼ばれるのか、リファクタリングしたいですが、今回はパスします。

CCodePage::S_UnicodeToUTF32BE、839～842行目の変換は正しいので、正しく保存できています。

CCodePage::S_UTF32BEToUnicode、617行目の 
if( pSrcByte[i] == 0x00 && pSrcByte[i+1] <= 0x10 ) 
が、U+10000以降の条件になります。 

その後、620行目の 
UINT c = (pSrcByte[i+3] << 16) | (pSrcByte[i+2] << 8) | pSrcByte[i+1]; 
は、UTF-32の1文字分のchar4個(先頭は0x00)を4byteの変数に入れるのですが、 
UTF-32リトルエンディアンの同様箇所、CCodePage::S_UTF32LEToUnicode、530行目 
UINT c = (pSrcByte[i+2] << 16) | (pSrcByte[i+1] << 8) | pSrcByte[i]; 
と比較して、ここではpSrcByteの並びが逆になるだけで、cは同じ値になるはずです。 

UTF-32BE 
0x00,0x01,0xF6,0x04を、c=0x0001F604 

UTF-32LE 
0x04,0xF6,0x01,0x00を、c=0x0001F604 

よって、620行目を
UINT c = (pSrcByte[i+1] << 16) | (pSrcByte[i+2] << 8) | pSrcByte[i+3]; 
のように修正しました。

## テスト内容
不具合再現と同じ手順で、警告無く正しく保存できること、開いたときに文字化けせずに表示できることを確認しました。 
<img width="422" alt="8" src="https://user-images.githubusercontent.com/62864681/220863121-778c7d17-e5a3-417b-b0ba-0f027a68bb03.png">

UTF-32ビッグエンディアンは滅多に使用されることはありませんが、テキストエディターの基本機能に関わることなので、 
関係者の皆さん、よろしくお願いします。