### PR TITLE
Remove SonarCloud cache and threads setup as it is now offered by default

### DIFF
--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -56,7 +56,6 @@ jobs:
       with:
         path: |
           .sonar\cache
-          .sonar\analysis-cache
         key:
           sonar-cache-${{ env.SONAR_QUBE_VERSION }}-${{ github.sha }}
         restore-keys:
@@ -143,10 +142,7 @@ jobs:
         -D"sonar.sourceEncoding=UTF-8" `
         -D"sonar.sources=." `
         -D"sonar.cfamily.build-wrapper-output=bw-output" `
-        -D"sonar.cfamily.cache.enabled=true" `
-        -D"sonar.cfamily.cache.path=.sonar\analysis-cache" `
         -D"sonar.cfamily.cppunit.reportPath=tests1-googletest.xml" `
-        -D"sonar.cfamily.threads=2" `
         -D"sonar.python.version=3" `
         -D"sonar.coverage.exclusions=help\**\*.js,tests\unittests\coverage.cpp,tests\stubs\**\*.cpp,tools\**\*.js" `
         -D"sonar.coverageReportPaths=tests1-coverage.xml" `


### PR DESCRIPTION
No need to configure the cache and threads anymore, SonarCloud now has an automatic analysis caching and threads detection. See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.

Also, the cache was not properly set up with the cache action.