### PR TITLE
キャプション文字列の国際化を進める

### DIFF
--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -60,6 +60,13 @@ enum EExpParamName
 	EExpParamName_none = -1,
 	EExpParamName_begin = 0,
 	EExpParamName_profile = 0,
+	EExpParamName_caption_grep,
+	EExpParamName_caption_output,
+	EExpParamName_output,
+	EExpParamName_updated,
+	EExpParamName_viewmode,
+	EExpParamName_protected,
+	EExpParamName_recording,
 	EExpParamName_end
 };
 
@@ -69,8 +76,18 @@ struct SExpParamName
 	int m_nLen;
 };
 static SExpParamName SExpParamNameTable[] = {
-	{L"profile", 7},
+#pragma push_macro("PARAM_ENTRY")
+#define PARAM_ENTRY(name) { (name), _countof((name)) - 1 }
+	PARAM_ENTRY(L"profile"),
+	PARAM_ENTRY(L"caption_grep"),
+	PARAM_ENTRY(L"caption_output"),
+	PARAM_ENTRY(L"output"),
+	PARAM_ENTRY(L"updated"),
+	PARAM_ENTRY(L"viewmode"),
+	PARAM_ENTRY(L"protected"),
+	PARAM_ENTRY(L"recording"),
 	{NULL, 0}
+#pragma pop_macro("PARAM_ENTRY")
 };
 wchar_t* ExParam_LongName( wchar_t* q, wchar_t* q_max, EExpParamName eLongParam );
 
@@ -697,6 +714,41 @@ wchar_t* ExParam_LongName( wchar_t* q, wchar_t* q_max, EExpParamName eLongParam 
 		{
 			LPCWSTR pszProf = CCommandLine::getInstance()->GetProfileName();
 			q = wcs_pushW( q, q_max - q, pszProf );
+		}
+		break;
+	case EExpParamName_caption_grep:
+		{
+			q = wcs_pushW(q, q_max - q, LS(STR_TAB_CAPTION_OUTPUT));
+		}
+		break;
+	case EExpParamName_caption_output:
+		{
+			q = wcs_pushW(q, q_max - q, LS(STR_TAB_CAPTION_GREP));
+		}
+		break;
+	case EExpParamName_output:
+		{
+			q = wcs_pushW(q, q_max - q, LS(STR_CAPTION_ACTIVE_OUTPUT));
+		}
+		break;
+	case EExpParamName_updated:
+		{
+			q = wcs_pushW(q, q_max - q, LS(STR_CAPTION_ACTIVE_UPDATE));
+		}
+		break;
+	case EExpParamName_viewmode:
+		{
+			q = wcs_pushW(q, q_max - q, LS(STR_CAPTION_ACTIVE_VIEW));
+		}
+		break;
+	case EExpParamName_protected:
+		{
+			q = wcs_pushW(q, q_max - q, LS(STR_CAPTION_ACTIVE_OVERWRITE));
+		}
+		break;
+	case EExpParamName_recording:
+		{
+			q = wcs_pushW(q, q_max - q, LS(STR_CAPTION_ACTIVE_KEYMACRO));
 		}
 		break;
 	default:

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -303,12 +303,10 @@ bool CShareData::InitShareData()
 
 			//	Apr. 05, 2003 genta ウィンドウキャプションの初期値
 			//	Aug. 16, 2003 genta $N(ファイル名省略表示)をデフォルトに変更
-			wcscpy( sWindow.m_szWindowCaptionActive, 
-				L"${w?$h$:アウトプット$:${I?$f$n$:$N$n$}$}${U?(更新)$} -"
-				L" $A $V ${R?(ビューモード)$:(上書き禁止)$}${M?  【キーマクロの記録中】$} $<profile>" );
-			wcscpy( sWindow.m_szWindowCaptionInactive, 
-				L"${w?$h$:アウトプット$:$f$n$}${U?(更新)$} -"
-				L" $A $V ${R?(ビューモード)$:(上書き禁止)$}${M?  【キーマクロの記録中】$} $<profile>" );
+			wcscpy_s( sWindow.m_szWindowCaptionActive, 
+				L"${w?$h$:$<output>$:${I?$f$n$:$N$n$}$}${U?$<updated>$} - $A $V ${R?$<viewmode>$:$<protected>$}${M? $<recording>$} $<profile>" );
+			wcscpy_s( sWindow.m_szWindowCaptionInactive, 
+				L"${w?$h$:$<output>$:$f$n$}${U?$<updated>$} - $A $V ${R?$<viewmode>$:$<protected>$}${M? $<recording>$} $<profile>" );
 		}
 
 		// [タブバー]タブ
@@ -317,9 +315,9 @@ bool CShareData::InitShareData()
 
 			sTabBar.m_bDispTabWnd = FALSE;			//タブウインドウ表示	//@@@ 2003.05.31 MIK
 			sTabBar.m_bDispTabWndMultiWin = FALSE;	//タブウインドウ表示	//@@@ 2003.05.31 MIK
-			wcscpy(	//@@@ 2003.06.13 MIK
+			wcscpy_s(	//@@@ 2003.06.13 MIK
 				sTabBar.m_szTabWndCaption,
-				L"${w?【Grep】$h$:【アウトプット】$:$f$n$}${U?(更新)$}${R?(ビューモード)$:(上書き禁止)$}${M?【キーマクロの記録中】$}"
+				L"${w?$<caption_grep>$h$:$<caption_output>$:$f$n$}${U?$<updated>$}${R?$<viewmode>$:$<protected>$}${M?$<recording>$}"
 			);
 			sTabBar.m_bSameTabWidth = FALSE;			//タブを等幅にする			//@@@ 2006.01.28 ryoji
 			sTabBar.m_bDispTabIcon = FALSE;			//タブにアイコンを表示する	//@@@ 2006.01.28 ryoji

--- a/tests/unittests/test-csakuraenvironment.cpp
+++ b/tests/unittests/test-csakuraenvironment.cpp
@@ -41,6 +41,7 @@
 #include "_main/CCommandLine.h"
 #include "_main/CControlProcess.h"
 #include "util/file.h"
+#include "String_define.h"
 
 /*!
  * @brief exeファイルパスの取得
@@ -60,4 +61,53 @@ TEST(CSakuraEnvironment, ExpandParameter_IniFileName)
 	SFilePath szIniFile;
 	CSakuraEnvironment::ExpandParameter(L"$I", szIniFile, _countof2(szIniFile));
 	ASSERT_STREQ(GetIniFileName().c_str(), szIniFile.c_str());
+}
+
+TEST(CSakuraEnvironment, ExpandParameter_CaptionGrep)
+{
+	std::array<WCHAR, 4096> buf;
+	CSakuraEnvironment::ExpandParameter(L"$<caption_grep>", buf.data(), static_cast<int>(buf.size()));
+	ASSERT_STREQ(LS(STR_TAB_CAPTION_OUTPUT), buf.data());
+}
+
+TEST(CSakuraEnvironment, ExpandParameter_CaptionOutput)
+{
+	std::array<WCHAR, 4096> buf;
+	CSakuraEnvironment::ExpandParameter(L"$<caption_output>", buf.data(), static_cast<int>(buf.size()));
+	ASSERT_STREQ(LS(STR_TAB_CAPTION_GREP), buf.data());
+}
+
+TEST(CSakuraEnvironment, ExpandParameter_Output)
+{
+	std::array<WCHAR, 4096> buf;
+	CSakuraEnvironment::ExpandParameter(L"$<output>", buf.data(), static_cast<int>(buf.size()));
+	ASSERT_STREQ(LS(STR_CAPTION_ACTIVE_OUTPUT), buf.data());
+}
+
+TEST(CSakuraEnvironment, ExpandParameter_Updated)
+{
+	std::array<WCHAR, 4096> buf;
+	CSakuraEnvironment::ExpandParameter(L"$<updated>", buf.data(), static_cast<int>(buf.size()));
+	ASSERT_STREQ(LS(STR_CAPTION_ACTIVE_UPDATE), buf.data());
+}
+
+TEST(CSakuraEnvironment, ExpandParameter_ViewMode)
+{
+	std::array<WCHAR, 4096> buf;
+	CSakuraEnvironment::ExpandParameter(L"$<viewmode>", buf.data(), static_cast<int>(buf.size()));
+	ASSERT_STREQ(LS(STR_CAPTION_ACTIVE_VIEW), buf.data());
+}
+
+TEST(CSakuraEnvironment, ExpandParameter_Protected)
+{
+	std::array<WCHAR, 4096> buf;
+	CSakuraEnvironment::ExpandParameter(L"$<protected>", buf.data(), static_cast<int>(buf.size()));
+	ASSERT_STREQ(LS(STR_CAPTION_ACTIVE_OVERWRITE), buf.data());
+}
+
+TEST(CSakuraEnvironment, ExpandParameter_Recording)
+{
+	std::array<WCHAR, 4096> buf;
+	CSakuraEnvironment::ExpandParameter(L"$<recording>", buf.data(), static_cast<int>(buf.size()));
+	ASSERT_STREQ(LS(STR_CAPTION_ACTIVE_KEYMACRO), buf.data());
 }


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
めんどうなので割愛。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
* メインキャプション（アクティブ・非アクティブ）とタブキャプションに含まれる日本語の固定文字列を、プログラム的に埋め込むように改善する。
* グローバル関数 ExpandParameter に、文字列リソースの値を出力するオプションを7つ追加する。
* 現状で未使用となってしまっている「メインキャプション（アクティブ・非アクティブ）」と「タブキャプション」のための文字列リソースについてはいったん放置。」

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
* メインキャプション（アクティブ・非アクティブ）とタブキャプションに影響する変更です。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
* グローバル関数 ExpandParameter に、追加したオプションの機能確認をテストコードを書いて実施しました。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
