### PR TITLE
SonarScanner の実行に使用する Java ランタイムを 17 にアップグレードする

### DIFF
--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -111,10 +111,10 @@ jobs:
         $env:CMD_TESTS1 `
         --gtest_output=xml:${{ github.workspace }}\tests1-googletest.xml
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
 
     - name: Fetch SonarScanner
       working-directory: ${{ github.workspace }}\.sonar


### PR DESCRIPTION
GitHub Actions で実行している SonarScanner で使用する Java ランタイムを 17 にアップグレードします。

# PR対象

- ビルド手順/CI

## カテゴリ

- 改善

## PR の背景

[Sonar のサイトで告知されているとおり](https://community.sonarsource.com/t/java-11-is-deprecated-as-a-runtime-env-to-scan-your-projects/96597)、SonarCloud では1月15日より Java 11 上で実行された SonarScanner によるスキャン結果の取り込みが拒否されるようになっています。本 PR は SonarCloud の利用を継続するために最小限の変更をリポジトリに加えるものです。

##  仕様・動作説明

`.github/workflows/sonarscan.yml` に記載されている  Java バージョンを 11 から 17 に変更します。