### PR TITLE
最終行を矩形選択して削除すると落ちる問題を修正

### DIFF
--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -557,7 +557,7 @@ void CEditView::DeleteData(
 			
 			CLayoutPoint caretOld = CLayoutPoint(rcSel.left, rcSel.top);
 			m_pcEditDoc->m_cLayoutMgr.GetLineStr( rcSel.top, &nLineLen, &pcLayout );
-			if( rcSel.left <= pcLayout->CalcLayoutWidth( m_pcEditDoc->m_cLayoutMgr ) ){
+			if( pcLayout != NULL && rcSel.left <= pcLayout->CalcLayoutWidth( m_pcEditDoc->m_cLayoutMgr ) ){
 				// EOLより左なら文字の単位にそろえる
 				CLogicInt nIdxCaret = LineColumnToIndex( pcLayout, rcSel.left );
 				caretOld.SetX( LineIndexToColumn( pcLayout, nIdxCaret ) );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

最終行の行全体を矩形選択した後、削除操作 (Delキー押下、切り取りなど) をすると、必ずアプリケーションが異常終了することが判明したため修正します。
![sakura_boxselection_crash](https://github.com/sakura-editor/sakura/assets/11252784/d508ac82-ad87-4b67-9c96-aa4f25eda7b0)

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
ユーザーに対するふるまいの変化はありません。

## <!-- わかる範囲で --> PR の影響範囲

特にないと思います。

## <!-- 必須 --> テスト内容

* 「PR の背景」に書いた手順を行ってもアプリケーションが落ちないことを確認します。(効果確認)
* 矩形選択領域を削除した時のキャレット位置を補正する処理が、変更前と同様に機能することを確認します。(弊害確認)

削除前 | 削除後 (期待動作) | (補正がなかった場合の結果)
-|-|-
![image](https://github.com/sakura-editor/sakura/assets/11252784/260894bc-e2e6-4427-87ea-b90667c947b5) | ![image](https://github.com/sakura-editor/sakura/assets/11252784/154489d2-bd88-4dc0-96c1-5aa96b65f5a6) | ![image](https://github.com/sakura-editor/sakura/assets/11252784/99ae1572-5d40-4ebb-a6cb-d27d74a2896e)

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
