### PR TITLE
MinGWのビルドエラーを修正する

### DIFF
--- a/tests/unittests/test-ccodebase.cpp
+++ b/tests/unittests/test-ccodebase.cpp
@@ -815,7 +815,7 @@ TEST(CCodeBase, Utf8ToHex)
 	EXPECT_STREQ(L"F09F9AB9", pCodeBase->CodeToHex(L"\U0001F6B9", sStatusbar).c_str());
 
 	// IVS(Ideographic Variation Sequence) 「葛󠄀」（葛󠄀城市の葛󠄀、下がヒ）
-	EXPECT_STREQ(L"E8919BF3A08480", pCodeBase->CodeToHex(L"葛󠄀", sStatusbar).c_str());
+	EXPECT_STREQ(L"E8919BF3A08480", pCodeBase->CodeToHex(L"\U0000845B\U000E0100"/*葛󠄀*/, sStatusbar).c_str());
 }
 
 /*!
@@ -855,8 +855,8 @@ TEST(CCodeBase, UnicodeToHex)
 	sStatusbar.m_bDispSPCodepoint = false;
 
 	sStatusbar.m_bDispSPCodepoint = true;
-	EXPECT_STREQ(L"845B, U+E0100", pCodeBase->CodeToHex(L"葛󠄀", sStatusbar).c_str());
+	EXPECT_STREQ(L"845B, U+E0100", pCodeBase->CodeToHex(L"\U0000845B\U000E0100"/*葛󠄀*/, sStatusbar).c_str());
 
 	sStatusbar.m_bDispSPCodepoint = false;
-	EXPECT_STREQ(L"845B, DB40DD00", pCodeBase->CodeToHex(L"葛󠄀", sStatusbar).c_str());
+	EXPECT_STREQ(L"845B, DB40DD00", pCodeBase->CodeToHex(L"\U0000845B\U000E0100"/*葛󠄀*/, sStatusbar).c_str());
 }

--- a/tests/unittests/test-cwordparse.cpp
+++ b/tests/unittests/test-cwordparse.cpp
@@ -143,7 +143,7 @@ TEST(WhatKindOfChar, SurrogatePairs)
 TEST(WhatKindOfChar, IVS)
 {
 //	EXPECT_EQ(CK_ETC, CWordParse::WhatKindOfChar(L"葛󠄀", 3, 0));
-	EXPECT_EQ(CK_ZEN_ETC, CWordParse::WhatKindOfChar(L"葛󠄀", 3, 0));
+	EXPECT_EQ(CK_ZEN_ETC, CWordParse::WhatKindOfChar(L"\U0000845B\U000E0100"/*葛󠄀*/, 3, 0));
 }
 
 TEST(WhatKindOfTwoChars, ReturnsSameKindIfTwoKindsAreIdentical)


### PR DESCRIPTION
# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

- ビルド関連

## <!-- 必須 --> PR の背景

MinGWビルド時に以下のエラーが出るため直します。  
(test-ccodebase.cpp で1か所、test-ccodebase.cpp で2か所)
```
D:/a/1/s/tests/unittests/test-ccodebase.cpp:818:88: error: converting to execution character set: Illegal byte sequence
  818 |         EXPECT_STREQ(L"E8919BF3A08480", pCodeBase->CodeToHex(L"葛󠄀", sStatusbar).c_str());
```
修正方法としては、該当の文字を直接書く代わりに `\U...` (ユニバーサル文字名) の形式で指定するようにします。

## <!-- 必須 --> 仕様・動作説明

ビルドエラー修正のみのため省略します。

## <!-- わかる範囲で --> PR の影響範囲

特にありません。

## <!-- 必須 --> テスト内容

「PR の背景」に書いたエラーが、ローカルビルド、CIビルドそれぞれで解消されることを確認します。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
