### PR TITLE
CMacro.cppでのconst_castをやめる

### DIFF
--- a/sakura_core/macro/CEditorIfObj.cpp
+++ b/sakura_core/macro/CEditorIfObj.cpp
@@ -43,7 +43,7 @@ MacroFuncInfoArray CEditorIfObj::GetMacroFuncInfo() const
 }
 
 //関数を処理する
-bool CEditorIfObj::HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
+bool CEditorIfObj::HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 {
 	return CMacro::HandleFunction( View, ID, Arguments, ArgSize, Result );
 }

--- a/sakura_core/macro/CEditorIfObj.h
+++ b/sakura_core/macro/CEditorIfObj.h
@@ -42,7 +42,7 @@ public:
 	// 実装
 	MacroFuncInfoArray GetMacroCommandInfo() const;	//コマンド情報を取得する
 	MacroFuncInfoArray GetMacroFuncInfo() const;	//関数情報を取得する
-	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result);	//関数を処理する
+	bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result);	//関数を処理する
 	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize);	//コマンドを処理する
 };
 #endif /* SAKURA_CEDITORIFOBJ_1C8AA37E_D9FB_4C26_AE83_22E62D9B7C3D_H_ */

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1449,14 +1449,14 @@ bool CMacro::HandleCommand(
 	return true;
 }
 
-inline bool VariantToBStr(Variant& varCopy, const VARIANT& arg)
+inline bool VariantToBStr(Variant& varCopy, VARIANT& arg)
 {
-	return VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(arg) ), 0, VT_BSTR) == S_OK;
+	return VariantChangeType(&varCopy.Data, &(arg), 0, VT_BSTR) == S_OK;
 }
 
-inline bool VariantToI4(Variant& varCopy, const VARIANT& arg)
+inline bool VariantToI4(Variant& varCopy, VARIANT& arg)
 {
-	return VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(arg) ), 0, VT_I4) == S_OK;
+	return VariantChangeType(&varCopy.Data, &(arg), 0, VT_I4) == S_OK;
 }
 
 /**	値を返す関数を処理する
@@ -1475,7 +1475,7 @@ inline bool VariantToI4(Variant& varCopy, const VARIANT& arg)
 	@date 2005.08.05 maru,zenryaku 関数追加
 	@date 2005.11.29 FILE VariantChangeType対応
 */
-bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Arguments, int ArgSize, VARIANT &Result)
+bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, VARIANT *Arguments, int ArgSize, VARIANT &Result)
 {
 	Variant varCopy;	// VT_BYREFだと困るのでコピー用
 
@@ -1517,7 +1517,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		// 2003.02.24 Moca
 		{
 			if(ArgSize != 1) return false;
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 			//void ExpandParameter(const char* pszSource, char* pszBuffer, int nBufferLen);
 			//pszSourceを展開して、pszBufferにコピー
 			wchar_t *Source;
@@ -1534,7 +1534,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		//	2003.06.01 Moca マクロ追加
 		{
 			if( ArgSize != 1 ) return false;
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
 			if( -1 < varCopy.Data.lVal ){
 				const wchar_t *Buffer;
 				CLogicInt nLength;
@@ -1561,7 +1561,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		//	2003.06.01 Moca マクロ追加
 		{
 			if( ArgSize != 1 ) return false;
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
 			if( 0 == varCopy.Data.lVal ){
 				int nLineCount;
 				nLineCount = View->m_pcEditDoc->m_cDocLineMgr.GetLineCount();
@@ -1575,7 +1575,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		//	2004.03.16 zenryaku マクロ追加
 		{
 			if( ArgSize != 1 ) return false;
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
 			int nTab = (Int)View->m_pcEditDoc->m_cLayoutMgr.GetTabSpaceKetas();
 			Wrap( &Result )->Receive( nTab );
 			// 2013.04.30 Moca 条件追加。不要な場合はChangeLayoutParamを呼ばない
@@ -1679,7 +1679,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		//	2008.06.19 ryoji マクロ追加
 		{
 			if( ArgSize != 1 ) return false;
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
 			Wrap( &Result )->Receive( (Int)View->m_pcEditDoc->m_cLayoutMgr.GetMaxLineKetas() );
 			if( varCopy.Data.iVal < MINLINEKETAS || varCopy.Data.iVal > MAXLINEKETAS )
 				return true;
@@ -1703,7 +1703,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 
 			int nType1 = View->m_pcEditDoc->m_cDocType.GetDocumentType().GetIndex();	// 現在のタイプ
 
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 			Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 			int nType2 = CDocTypeManager().GetDocumentTypeOfExt(Source).GetIndex();	// 指定拡張子のタイプ
 			delete[] Source;
@@ -1719,12 +1719,12 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			WCHAR *Source;
 			int SourceLength;
 
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 			Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 			int nType1 = CDocTypeManager().GetDocumentTypeOfExt(Source).GetIndex();	// 拡張子１のタイプ
 			delete[] Source;
 
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 			Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 			int nType2 = CDocTypeManager().GetDocumentTypeOfExt(Source).GetIndex();	// 拡張子２のタイプ
 			delete[] Source;
@@ -1739,14 +1739,14 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			WCHAR *Source;
 			int SourceLength;
 
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 			Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 			std::wstring sMessage = Source;	// 表示メッセージ
 			delete[] Source;
 
 			std::wstring sDefaultValue = L"";
 			if( ArgSize >= 2 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+				if(VariantChangeType(&varCopy.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 				Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 				sDefaultValue = Source;	// デフォルト値
 				delete[] Source;
@@ -1754,7 +1754,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 
 			int nMaxLen = _MAX_PATH;
 			if( ArgSize >= 3 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[2]) ), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
+				if(VariantChangeType(&varCopy.Data, &(Arguments[2]), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
 				nMaxLen = varCopy.Data.intVal;	// 最大入力長
 				if( nMaxLen <= 0 ){
 					nMaxLen = _MAX_PATH;
@@ -1788,7 +1788,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			WCHAR *Source;
 			int SourceLength;
 
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 			Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 			std::wstring sMessage = Source;	// 表示文字列
 			delete[] Source;
@@ -1797,7 +1797,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			switch( LOWORD(ID) ) {
 			case F_MESSAGEBOX:
 				if( ArgSize >= 2 ){
-					if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
+					if(VariantChangeType(&varCopy.Data, &(Arguments[1]), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
 					uType = varCopy.Data.uintVal;
 				}else{
 					uType = MB_OK;
@@ -1830,12 +1830,12 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			WCHAR *Source;
 			int SourceLength;
 
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 			Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 			std::wstring sVerA = Source;	// バージョンA
 			delete[] Source;
 
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 			Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 			std::wstring sVerB = Source;	// バージョンB
 			delete[] Source;
@@ -1848,7 +1848,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		{
 			if( ArgSize != 1 ) return false;
 
-			if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_UI4) != S_OK) return false;	// VT_UI4として解釈
+			if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_UI4) != S_OK) return false;	// VT_UI4として解釈
 			CWaitCursor cWaitCursor( View->GetHwnd() );	// カーソルを砂時計にする
 			::Sleep( varCopy.Data.uintVal );
 			Wrap( &Result )->Receive( 0 );	//戻り値は今のところ0固定
@@ -1864,14 +1864,14 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			std::wstring sFilter;
 
 			if( ArgSize >= 1 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+				if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 				Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 				sDefault = Source;	// 既定のファイル名
 				delete[] Source;
 			}
 
 			if( ArgSize >= 2 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+				if(VariantChangeType(&varCopy.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 				Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 				sFilter = Source;	// フィルタ文字列
 				delete[] Source;
@@ -1913,14 +1913,14 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			std::wstring sDefault;
 
 			if( ArgSize >= 1 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+				if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 				Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 				sMessage = Source;	// 表示メッセージ
 				delete[] Source;
 			}
 
 			if( ArgSize >= 2 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+				if(VariantChangeType(&varCopy.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 				Wrap(&varCopy.Data.bstrVal)->GetW(&Source, &SourceLength);
 				sDefault = Source;	// 既定のファイル名
 				delete[] Source;
@@ -1947,7 +1947,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			int nOpt = 0;
 
 			if( ArgSize >= 1 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
+				if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
 				nOpt = varCopy.Data.intVal;	// オプション
 			}
 
@@ -1971,12 +1971,12 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 			int nOpt = 0;
 
 			if( ArgSize >= 1 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
+				if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_I4) != S_OK) return false;	// VT_I4として解釈
 				nOpt = varCopy.Data.intVal;	// オプション
 			}
 
 			if( ArgSize >= 2 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
+				if(VariantChangeType(&varCopy.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;	// VT_BSTRとして解釈
 				Wrap(&varCopy.Data.bstrVal)->GetW(&sValue);
 			}
 
@@ -2070,8 +2070,8 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		{
 			Variant varCopy2;
 			if( ArgSize >= 2 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;
-				if(VariantChangeType(&varCopy2.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy2.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;
 				SysString ret = View->GetDocument()->m_cCookie.GetCookie(varCopy.Data.bstrVal, varCopy2.Data.bstrVal);
 				Wrap( &Result )->Receive( ret );
 				return true;
@@ -2082,9 +2082,9 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		{
 			Variant varCopy2, varCopy3;
 			if( ArgSize >= 3 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;
-				if(VariantChangeType(&varCopy2.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;
-				if(VariantChangeType(&varCopy3.Data, const_cast<VARIANTARG*>( &(Arguments[2]) ), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy2.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy3.Data, &(Arguments[2]), 0, VT_BSTR) != S_OK) return false;
 				SysString ret = View->GetDocument()->m_cCookie.GetCookieDefault(varCopy.Data.bstrVal, varCopy2.Data.bstrVal,
 					varCopy3.Data.bstrVal, SysStringLen(varCopy3.Data.bstrVal) );
 				Wrap( &Result )->Receive( ret );
@@ -2096,9 +2096,9 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		{
 			Variant varCopy2, varCopy3;
 			if( ArgSize >= 3 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;
-				if(VariantChangeType(&varCopy2.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;
-				if(VariantChangeType(&varCopy3.Data, const_cast<VARIANTARG*>( &(Arguments[2]) ), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy2.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy3.Data, &(Arguments[2]), 0, VT_BSTR) != S_OK) return false;
 				int ret = View->GetDocument()->m_cCookie.SetCookie(varCopy.Data.bstrVal, varCopy2.Data.bstrVal,
 					varCopy3.Data.bstrVal, SysStringLen(varCopy3.Data.bstrVal) );
 				Wrap( &Result )->Receive( ret );
@@ -2110,8 +2110,8 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 		{
 			Variant varCopy2;
 			if( ArgSize >= 2 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;
-				if(VariantChangeType(&varCopy2.Data, const_cast<VARIANTARG*>( &(Arguments[1]) ), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy2.Data, &(Arguments[1]), 0, VT_BSTR) != S_OK) return false;
 				int ret = View->GetDocument()->m_cCookie.DeleteCookie(varCopy.Data.bstrVal, varCopy2.Data.bstrVal);
 				Wrap( &Result )->Receive( ret );
 				return true;
@@ -2121,7 +2121,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, const VARIANT *Ar
 	case F_GETCOOKIENAMES:
 		{
 			if( ArgSize >= 1 ){
-				if(VariantChangeType(&varCopy.Data, const_cast<VARIANTARG*>( &(Arguments[0]) ), 0, VT_BSTR) != S_OK) return false;
+				if(VariantChangeType(&varCopy.Data, &(Arguments[0]), 0, VT_BSTR) != S_OK) return false;
 				SysString ret = View->GetDocument()->m_cCookie.GetCookieNames(varCopy.Data.bstrVal);
 				Wrap( &Result )->Receive( ret );
 				return true;

--- a/sakura_core/macro/CMacro.h
+++ b/sakura_core/macro/CMacro.h
@@ -124,7 +124,7 @@ public:
 	int GetParamCount() const;
 
 	static bool HandleCommand( CEditView *View, EFunctionCode ID, const WCHAR* Argument[], const int ArgLengths[], const int ArgSize );
-	static bool HandleFunction( CEditView *View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result);
+	static bool HandleFunction( CEditView *View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result);
 	//2009.10.29 syat HandleCommandとHandleFunctionの引数を少しそろえた
 
 	/*

--- a/sakura_core/macro/CWSHIfObj.h
+++ b/sakura_core/macro/CWSHIfObj.h
@@ -72,7 +72,7 @@ protected:
 	HRESULT MacroCommand(int ID, DISPPARAMS *Arguments, VARIANT* Result, void *Data);
 
 	// 非実装提供
-	virtual bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result) = 0;	//関数を処理する
+	virtual bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result) = 0;	//関数を処理する
 	virtual bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize) = 0;	//コマンドを処理する
 	virtual MacroFuncInfoArray GetMacroCommandInfo() const = 0;	//コマンド情報を取得する
 	virtual MacroFuncInfoArray GetMacroFuncInfo() const = 0;	//関数情報を取得する

--- a/sakura_core/plugin/CComplementIfObj.h
+++ b/sakura_core/plugin/CComplementIfObj.h
@@ -65,7 +65,7 @@ public:
 	//関数情報を取得する
 	MacroFuncInfoArray GetMacroFuncInfo() const{ return m_MacroFuncInfoArr; };
 	//関数を処理する
-	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
+	bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 	{
 		Variant varCopy;	// VT_BYREFだと困るのでコピー用
 

--- a/sakura_core/plugin/COutlineIfObj.h
+++ b/sakura_core/plugin/COutlineIfObj.h
@@ -69,7 +69,7 @@ public:
 	//関数情報を取得する
 	MacroFuncInfoArray GetMacroFuncInfo() const{ return m_MacroFuncInfoArr; }
 	//関数を処理する
-	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
+	bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 	{
 		return false;
 	}

--- a/sakura_core/plugin/CPluginIfObj.h
+++ b/sakura_core/plugin/CPluginIfObj.h
@@ -82,7 +82,7 @@ public:
 		return m_MacroFuncInfoArr;
 	}
 	//関数を処理する
-	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
+	bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 	{
 		Variant varCopy;	// VT_BYREFだと困るのでコピー用
 

--- a/sakura_core/plugin/CSmartIndentIfObj.h
+++ b/sakura_core/plugin/CSmartIndentIfObj.h
@@ -78,7 +78,7 @@ public:
 		return macroFuncInfoNotCommandArr;
 	}
 	//関数を処理する
-	bool HandleFunction(CEditView* View, EFunctionCode ID, const VARIANT *Arguments, const int ArgSize, VARIANT &Result)
+	bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result)
 	{
 		switch ( LOWORD(ID) ) 
 		{


### PR DESCRIPTION
# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

- 改善

## <!-- 必須 --> PR の背景

https://github.com/sakura-editor/sakura/pull/1948 の修正を行った時にSonarCloudで指摘が出た箇所 (下記リンク) に関する修正になります。
https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&pullRequest=1948&id=sakura-editor_sakura

修正方法としては、
* CMacro::HandleFunction とそれに関連する関数の引数 (Arguments) から const を取り除いた上で、
* CMacro.cpp で VariantChangeType を呼び出している箇所の const_cast をすべて削除します。

既存コードの VariantChangeType の呼び出し箇所に const_cast が付いているのは、同じ VariantChangeType でもMinGW環境では第2引数に const が付かないプロトタイプとなっているためのようでした。

Msvc (oleauto.h)
```cpp
WINOLEAUTAPI VariantChangeType(_Inout_ VARIANTARG * pvargDest,
               _In_ const VARIANTARG * pvarSrc, _In_ USHORT wFlags, _In_ VARTYPE vt);
```

MinGW (oleauto.h)
```
WINOLEAUTAPI VariantChangeType(VARIANTARG *pvargDest,VARIANTARG *pvarSrc,USHORT wFlags,VARTYPE vt);
```

## <!-- 必須 --> 仕様・動作説明

静的解析の指摘修正のみのため省略します。

## <!-- わかる範囲で --> PR の影響範囲

特にないと思います。

## <!-- 必須 --> テスト内容

SonarCloudの指摘がなくなることを確認します。

## <!-- なければ省略可 --> 関連 issue, PR

https://github.com/sakura-editor/sakura/pull/1948

## <!-- なければ省略可 --> 参考資料

