### PR TITLE
.gitignore に *.vcxproj.user ファイルを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.iobj
 *.ipdb
 *.pyc
+*.vcxproj.user
 **/packages
 **/TestResults
 .sonarqube


### PR DESCRIPTION
.gitignore ファイルに `*.vcxproj.user` ファイルを除外する設定を追加します。

# <!-- 必須 --> PR対象

- ビルド手順/CI

## <!-- 必須 --> カテゴリ

- 改善