### PR TITLE
インデックス範囲チェックの重複を削減

### DIFF
--- a/sakura_core/cmd/CViewCommander_Edit.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit.cpp
@@ -900,7 +900,7 @@ void CViewCommander::DelCharForOverwrite( const wchar_t* pszInput, int nLen )
 					nPos += CNativeW::GetSizeOfChar(line.GetPtr(), line.GetLength(), nPos);
 					nDelLen = 1;
 					if( nKetaDiff < 0 && nPos < line.GetLength() ){
-						wchar_t c = line.At(nPos);
+						wchar_t c = line[nPos];
 						if( c != WCODE::TAB && !WCODE::IsLineDelimiter(c,
 								GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 							nDelLen = 2;

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -48,7 +48,7 @@ static bool _GetKeywordLength(
 	CLogicInt nWordBgn = nPos;
 	CLogicInt nWordLen = CLogicInt(0);
 	CLayoutInt nWordKetas = CLayoutInt(0);
-	while(nPos<cLineStr.GetLength() && IS_KEYWORD_CHAR(cLineStr.At(nPos))){
+	while(nPos<cLineStr.GetLength() && IS_KEYWORD_CHAR(cLineStr[nPos])){
 		CLogicXInt nCharSize = CNativeW::GetSizeOfChar( cLineStr, nPos );
 		CLayoutInt k = cLayoutMgr.GetLayoutXOfChar(cLineStr, nPos);
 
@@ -209,8 +209,8 @@ void CLayoutMgr::_DoGyotoKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 
 		if( _IsKinsokuPosHead( GetMaxLineLayout() - pWork->nPosX, nCharKetas1, nCharKetas2 )
 		 && IsKinsokuHead( pWork->cLineStr.At( pWork->nPos + nCharSize ) )
-		 && !IsKinsokuHead( pWork->cLineStr.At( pWork->nPos ) )		// 1字前が行頭禁則の対象でないこと
-		 && !IsKinsokuKuto( pWork->cLineStr.At( pWork->nPos ) ) )	// 1字前が句読点ぶら下げの対象でないこと
+		 && !IsKinsokuHead( pWork->cLineStr[ pWork->nPos ] )		// 1字前が行頭禁則の対象でないこと
+		 && !IsKinsokuKuto( pWork->cLineStr[ pWork->nPos ] ) )	// 1字前が句読点ぶら下げの対象でないこと
 		{
 			pWork->nWordBgn = pWork->nPos;
 			pWork->nWordLen = nCharSize + CNativeW::GetSizeOfChar( pWork->cLineStr, pWork->nPos + nCharSize );
@@ -233,7 +233,7 @@ void CLayoutMgr::_DoGyomatsuKinsoku(SLayoutWork* pWork, PF_OnLine pfOnLine)
 		CLayoutXInt nCharKetas1 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos );
 		CLayoutXInt nCharKetas2 = GetLayoutXOfChar( pWork->cLineStr, pWork->nPos + nCharSize );
 
-		if( _IsKinsokuPosTail( GetMaxLineLayout() - pWork->nPosX, nCharKetas1, nCharKetas2 ) && IsKinsokuTail( pWork->cLineStr.At( pWork->nPos ) ) )
+		if( _IsKinsokuPosTail( GetMaxLineLayout() - pWork->nPosX, nCharKetas1, nCharKetas2 ) && IsKinsokuTail( pWork->cLineStr[ pWork->nPos ] ) )
 		{
 			pWork->nWordBgn = pWork->nPos;
 			pWork->nWordLen = nCharSize;
@@ -305,7 +305,7 @@ void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 		//@@@ 2002.09.22 YAZAKI
 		color.CheckColorMODE( &pWork->pcColorStrategy, pWork->nPos, pWork->cLineStr );
 
-		if( pWork->cLineStr.At(pWork->nPos) == WCODE::TAB ){
+		if( pWork->cLineStr[pWork->nPos] == WCODE::TAB ){
 			if(_DoTab(pWork, pfOnLine)){
 				continue;
 			}

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -45,6 +45,7 @@ public:
 	[[nodiscard]] int GetLength() const noexcept { return static_cast<int>(m_nDataLen); }
 	[[nodiscard]] bool IsValid() const noexcept { return m_pData != nullptr; }
 	[[nodiscard]] wchar_t At( size_t nIndex ) const noexcept;
+	[[nodiscard]] wchar_t operator []( size_t nIndex ) const noexcept { return m_pData[nIndex]; }
 
 private:
 	const wchar_t*	m_pData = nullptr;

--- a/sakura_core/view/colors/CColor_Comment.cpp
+++ b/sakura_core/view/colors/CColor_Comment.cpp
@@ -51,7 +51,7 @@ bool CColor_LineComment::EndColor(const CStringRef& cStr, int nPos)
 	}
 
 	//改行
-	if( WCODE::IsLineDelimiter(cStr.At(nPos), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
+	if( WCODE::IsLineDelimiter(cStr[nPos], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 		return true;
 	}
 

--- a/sakura_core/view/colors/CColor_Heredoc.cpp
+++ b/sakura_core/view/colors/CColor_Heredoc.cpp
@@ -78,7 +78,7 @@ bool CColor_Heredoc::BeginColor(const CStringRef& cStr, int nPos)
 		const int length = cStr.GetLength();
 		int nPosIdStart = nPos + 3;
 		for(; nPosIdStart < length; nPosIdStart++ ){
-			if(cStr.At(nPosIdStart) != L'\t' && cStr.At(nPosIdStart) != L' '){
+			if(cStr[nPosIdStart] != L'\t' && cStr[nPosIdStart] != L' '){
 				break;
 			}
 		}
@@ -86,13 +86,13 @@ bool CColor_Heredoc::BeginColor(const CStringRef& cStr, int nPos)
 		if( !(nPosIdStart < length) ){
 			return false;
 		}
-		if( cStr.At(nPosIdStart) == L'\'' || cStr.At(nPosIdStart) == L'"' ){
-			quote = cStr.At(nPosIdStart);
+		if (cStr[nPosIdStart] == L'\'' || cStr[nPosIdStart] == L'"') {
+			quote = cStr[nPosIdStart];
 			nPosIdStart++;
 		}
 		int i = nPosIdStart;
 		for(; i < length; i++ ){
-			if( !(WCODE::IsAZ(cStr.At(i)) || WCODE::Is09(cStr.At(i)) || cStr.At(i) == L'_') ){
+			if( !(WCODE::IsAZ(cStr[i]) || WCODE::Is09(cStr[i]) || cStr[i] == L'_') ){
 				break;
 			}
 		}
@@ -101,13 +101,13 @@ bool CColor_Heredoc::BeginColor(const CStringRef& cStr, int nPos)
 		}
 		const int k = i;
 		if( quote != L'\0' ){
-			if( i < length && cStr.At(i) == quote ){
+			if( i < length && cStr[i] == quote ){
 				i++;
 			}else{
 				return false;
 			}
 		}
-		if( i < length && WCODE::IsLineDelimiter(cStr.At(i), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
+		if( i < length && WCODE::IsLineDelimiter(cStr[i], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 			m_id = std::wstring(cStr.GetPtr()+nPosIdStart, k - nPosIdStart);
 			m_pszId = m_id.c_str();
 			m_nSize = m_id.size();
@@ -129,11 +129,11 @@ bool CColor_Heredoc::EndColor(const CStringRef& cStr, int nPos)
 				return false;
 			}else{
 				int i = m_nSize;
-				if( i + 1 < cStr.GetLength() && cStr.At(i) == L';' && WCODE::IsLineDelimiter(cStr.At(i+1), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
+				if( i + 1 < cStr.GetLength() && cStr[i] == L';' && WCODE::IsLineDelimiter(cStr[i+1], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 					// ID;
 					this->m_nCOMMENTEND = i;
 					return false;
-				}else if( m_nSize < cStr.GetLength() && WCODE::IsLineDelimiter(cStr.At(m_nSize), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
+				}else if( m_nSize < cStr.GetLength() && WCODE::IsLineDelimiter(cStr[m_nSize], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 					// ID
 					this->m_nCOMMENTEND = m_nSize;
 					return false;

--- a/sakura_core/view/colors/CColor_Quote.cpp
+++ b/sakura_core/view/colors/CColor_Quote.cpp
@@ -103,11 +103,11 @@ bool CColor_Quote::IsCppRawString(const CStringRef& cStr, int nPos)
 		// \b = ^|[\s!"#$%&'()=@{};:<>?,.*/\-\+\[\]\]
 		wchar_t c1 = L' ';
 		if( 2 <= nPos ){
-			c1 = cStr.At(nPos-2);
+			c1 = cStr[nPos-2];
 		}
 		wchar_t c2 = L' ';
 		if( 3 <= nPos ){
-			c2 = cStr.At(nPos-3);
+			c2 = cStr[nPos-3];
 		}
 		const wchar_t* pszSep = L" \t!\"#$%&'()=@{};:<>?,.*/-+[]";
 		if( (c1 == 'u' || c1 == 'U' || c1 == 'L') ){
@@ -117,7 +117,7 @@ bool CColor_Quote::IsCppRawString(const CStringRef& cStr, int nPos)
 		}else if( c1 == '8' && c2 == 'u' ){
 			wchar_t c3 = L'\0';
 			if( 4 <= nPos ){
-				c3 = cStr.At(nPos-4);
+				c3 = cStr[nPos-4];
 			}
 			if( NULL != wcschr(pszSep, c3) ){
 				return true;
@@ -142,7 +142,7 @@ bool CColor_Quote::BeginColor(const CStringRef& cStr, int nPos)
 		case STRING_LITERAL_CPP:
 			if( IsCppRawString(cStr, nPos) ){
 				for( int i = nPos + 1; i < cStr.GetLength(); i++ ){
-					if( cStr.At(i) == '(' ){
+					if( cStr[i] == '(' ){
 						if( nPos + 1 < i ){
 							m_tag = L')';
 							m_tag.append( cStr.GetPtr()+nPos+1, i - (nPos + 1) );
@@ -179,7 +179,7 @@ bool CColor_Quote::BeginColor(const CStringRef& cStr, int nPos)
 			break;
 		case STRING_LITERAL_PYTHON:
 			if( nPos + 2 < cStr.GetLength()
-			 && cStr.At(nPos+1) == m_cQuote && cStr.At(nPos+2) == m_cQuote ){
+			 && cStr[nPos+1] == m_cQuote && cStr[nPos+2] == m_cQuote ){
 				m_nCOMMENTEND = Match_QuoteStr( m_szQuote, 3, nPos + 3, cStr, true );
 				m_nColorTypeIndex = 3;
 				return true;
@@ -198,9 +198,9 @@ bool CColor_Quote::BeginColor(const CStringRef& cStr, int nPos)
 			// 終了文字列がない場合は行末までを色分け
 			if( m_pTypeData->m_bStringEndLine ){
 				// 改行コードを除く
-				if( 0 < cStr.GetLength() && WCODE::IsLineDelimiter(cStr.At(cStr.GetLength()-1), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
-					if( 1 < cStr.GetLength() && cStr.At(cStr.GetLength()-2) == WCODE::CR
-							&& cStr.At(cStr.GetLength()-1) == WCODE::LF ){
+				if( 0 < cStr.GetLength() && WCODE::IsLineDelimiter(cStr[cStr.GetLength()-1], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
+					if( 1 < cStr.GetLength() && cStr[cStr.GetLength()-2] == WCODE::CR
+							&& cStr[cStr.GetLength()-1] == WCODE::LF ){
 						m_nCOMMENTEND = cStr.GetLength() - 2;
 					}else{
 						m_nCOMMENTEND = cStr.GetLength() - 1;
@@ -256,21 +256,21 @@ int CColor_Quote::Match_Quote( wchar_t wcQuote, int nPos, const CStringRef& cLin
 		nCharChars = (Int)t_max(CLogicInt(1), CNativeW::GetSizeOfChar( cLineStr.GetPtr(), cLineStr.GetLength(), i ));
 		if( escapeType == STRING_LITERAL_CPP ){
 			// エスケープ \"
-			if( 1 == nCharChars && cLineStr.At(i) == L'\\' ){
+			if( 1 == nCharChars && cLineStr[i] == L'\\' ){
 				++i;
-				if( i < cLineStr.GetLength() && WCODE::IsLineDelimiter(cLineStr.At(i), GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
+				if( i < cLineStr.GetLength() && WCODE::IsLineDelimiter(cLineStr[i], GetDllShareData().m_Common.m_sEdit.m_bEnableExtEol) ){
 					if( pbEscapeEnd ){
 						*pbEscapeEnd = true;
 					}
 				}
 			}else
-			if( 1 == nCharChars && cLineStr.At(i) == wcQuote ){
+			if( 1 == nCharChars && cLineStr[i] == wcQuote ){
 				return i + 1;
 			}
 		}else if( escapeType == STRING_LITERAL_PLSQL ){
 			// エスケープ ""
-			if( 1 == nCharChars && cLineStr.At(i) == wcQuote ){
-				if( i + 1 < cLineStr.GetLength() && cLineStr.At(i + 1) == wcQuote ){
+			if( 1 == nCharChars && cLineStr[i] == wcQuote ){
+				if( i + 1 < cLineStr.GetLength() && cLineStr[i + 1] == wcQuote ){
 					++i;
 				}else{
 					return i + 1;
@@ -278,7 +278,7 @@ int CColor_Quote::Match_Quote( wchar_t wcQuote, int nPos, const CStringRef& cLin
 			}
 		}else{
 			// エスケープなし
-			if( 1 == nCharChars && cLineStr.At(i) == wcQuote ){
+			if( 1 == nCharChars && cLineStr[i] == wcQuote ){
 				return i + 1;
 			}
 		}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

`CStringRef::At` メソッド [link](https://github.com/sakura-editor/sakura/blob/fb0d86a7ea47d955b2af619fc428588ea61b9c51/sakura_core/mem/CNativeW.cpp#L63-L69) はチェック処理を行うため、頻繁に呼び出しが行われる箇所で使うのには適していません。そこでチェック処理を行わない `CStringRef::operator []` メソッドを追加しました。

事前にインデックスの範囲チェックが行われている箇所で、`CStringRef::At` メソッドの代わりに `CStringRef::operator []` メソッドを使用するように変更しました。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
