### PR TITLE
SHAutoComplete関数を使ったフォルダ位置の入力補完

### DIFF
--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -41,6 +41,7 @@ UNICODE版では問題無いが、ANSI版では設定の前にコード変換す
 
 #include <windows.h>
 #include <Commctrl.h>
+#include <shlwapi.h>
 #include "mem/CNativeW.h"
 #include <vector>
 
@@ -218,6 +219,15 @@ namespace ApiWrap{
 	inline void Combo_GetEditSel( HWND hwndCombo, DWORD& dwSelStart, DWORD& dwSelEnd )
 	{
 		::SendMessage( hwndCombo, CB_GETEDITSEL, WPARAM( &dwSelStart ), LPARAM( &dwSelEnd ) );
+	}
+	inline void Combo_SHAutoComplete( HWND hwndCombo, DWORD dwFlags )
+	{
+		COMBOBOXINFO comboInfo;
+		comboInfo.cbSize = sizeof(comboInfo);
+		if (0 != GetComboBoxInfo(hwndCombo, &comboInfo))
+		{
+			SHAutoComplete(comboInfo.hwndItem, dwFlags);
+		}
 	}
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -323,6 +323,9 @@ BOOL CDlgGrep::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	Combo_SetExtendedUI( GetItemHwnd( IDC_COMBO_EXCLUDE_FILE ), TRUE );
 	Combo_SetExtendedUI( GetItemHwnd( IDC_COMBO_EXCLUDE_FOLDER ), TRUE );
 
+	/* 入力補完を機能させる */
+	Combo_SHAutoComplete(GetItemHwnd( IDC_COMBO_FOLDER ), SHACF_FILESYS_DIRS|SHACF_AUTOAPPEND_FORCE_ON);
+
 	/* ダイアログのアイコン */
 //2002.02.08 Grepアイコンも大きいアイコンと小さいアイコンを別々にする。
 	HICON	hIconBig, hIconSmall;


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

#1968 で提案が行われました。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->

Grepの検索場所（フォルダ位置指定）で入力補間が利くようになります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

- Grep
- Grep置換

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

入力補間が機能する事を確認しました。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#1968

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-shautocomplete
https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getcomboboxinfo

