### PR TITLE
MinGWのビルドエラーを修正する(_wcstokのマクロ定義を削除)

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -66,8 +66,6 @@
 #define DUMMYUNION5_MEMBER(x) DUMMYUNIONNAME5.x
 #endif
 #endif
-// MinGW-w64-gcc にない関数をマクロ定義する
-#define _wcstok wcstok
 #endif
 
 #include <io.h>


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- ビルド関連

## <!-- 必須 --> PR の背景

MinGWビルド時に以下のエラーが出るようになっているため直します。
https://dev.azure.com/sakuraeditor/sakura/_build/results?buildId=3617&view=logs&j=b39c645f-42c7-549c-3e61-e6ffdeb72915&t=ea0a0af4-dbfa-5a7a-b1b8-f35f253695ca&l=81
```
D:/a/1/s/sakura_core/StdAfx.h:70:17: error: conflicting declaration of C function 'wchar_t* wcstok(wchar_t*, const wchar_t*)'
   70 | #define _wcstok wcstok
      |                 ^~~~~~
```

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

## <!-- 必須 --> 仕様・動作説明

先々月、MinGW側で下記の変更が入ったようで、
https://github.com/mingw-w64/mingw-w64/commit/bafccb49a0a6b4676f748bb415aabe27212d12d7#diff-bfb0974d3f2e42b77f3ef9ef03229235af8434fa1fc4996cec35fd6a1519f4bc
* `wcstok` の引数が2つから3つ (こちらが標準とのこと) に変更
* 今まで提供されていなかった `_wcstok` が追加

このため以下のマクロ定義は不要になりました。
本PRではこれを削除します。
https://github.com/sakura-editor/sakura/blob/1fcac9451b8c9c0f3114a2681920e262bd620e3f/sakura_core/StdAfx.h#L69-L70

## <!-- わかる範囲で --> PR の影響範囲

本PR適用後、古いMinGW環境ではビルドが通せなくなるため、
ローカルでMinGWビルドしたい人は手持ちのMinGWの最新化が必要です。
[MinGW w64 インストール方法](https://github.com/sakura-editor/sakura/blob/1fcac9451b8c9c0f3114a2681920e262bd620e3f/build.md#mingw-w64-%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95)

## <!-- 必須 --> テスト内容

ローカルビルド、CIビルドそれぞれでMinGWのビルドエラー解消されることを確認します。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
