### PR TITLE
コンパイル時アサート対応 (assert -> static_assert)

### DIFF
--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -55,7 +55,7 @@ CDlgCompare::CDlgCompare()
 	: CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	m_bCompareAndTileHorz = TRUE;	/* 左右に並べて表示 */
 

--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -55,7 +55,7 @@ CDlgCompare::CDlgCompare()
 	: CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
 
 	m_bCompareAndTileHorz = TRUE;	/* 左右に並べて表示 */
 

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -89,7 +89,7 @@ CDlgDiff::CDlgDiff()
 	, m_nIndexSave( 0 )
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	m_nDiffFlgOpt    = 0;
 	m_bIsModifiedDst = false;

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -89,7 +89,7 @@ CDlgDiff::CDlgDiff()
 	, m_nIndexSave( 0 )
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
 
 	m_nDiffFlgOpt    = 0;
 	m_bIsModifiedDst = false;

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -114,7 +114,7 @@ CDlgFavorite::CDlgFavorite()
 	m_szMsg[0] = L'\0';
 
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
 
 	{
 		i = 0;

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -114,7 +114,7 @@ CDlgFavorite::CDlgFavorite()
 	m_szMsg[0] = L'\0';
 
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	{
 		i = 0;

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -156,7 +156,7 @@ CDlgTagJumpList::CDlgTagJumpList(bool bDirectTagJump)
 	  m_strOldKeyword( L"" )
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
 
 	// 2010.07.22 Moca ページング採用で 最大値を100→50に減らす
 	m_pcList = new CSortedTagJumpList(50);

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -156,7 +156,7 @@ CDlgTagJumpList::CDlgTagJumpList(bool bDirectTagJump)
 	  m_strOldKeyword( L"" )
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	// 2010.07.22 Moca ページング採用で 最大値を100→50に減らす
 	m_pcList = new CSortedTagJumpList(50);

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -55,7 +55,7 @@ CDlgWindowList::CDlgWindowList()
 	: CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert(_countof(anchorList) == _countof(m_rcItems));
+	static_assert(_countof(anchorList) == _countof(m_rcItems), "size check" );
 	m_ptDefaultSize.x = -1;
 	m_ptDefaultSize.y = -1;
 	return;

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -55,7 +55,7 @@ CDlgWindowList::CDlgWindowList()
 	: CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert(_countof(anchorList) == _countof(m_rcItems), "size check" );
+	static_assert(_countof(anchorList) == _countof(m_rcItems));
 	m_ptDefaultSize.x = -1;
 	m_ptDefaultSize.y = -1;
 	return;

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1495,7 +1495,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	int		j;
 	WCHAR	szKeyName[64];
 	WCHAR	szKeyData[MAX_REGEX_KEYWORDLEN + 20];
-	assert( 100 < MAX_REGEX_KEYWORDLEN + 20 );
+	static_assert( 100 < MAX_REGEX_KEYWORDLEN + 20, "size check" );
 
 	// 2005.04.07 D.S.Koba
 	static const WCHAR* pszForm = LTEXT("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d");	//MIK

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1495,7 +1495,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	int		j;
 	WCHAR	szKeyName[64];
 	WCHAR	szKeyData[MAX_REGEX_KEYWORDLEN + 20];
-	static_assert( 100 < MAX_REGEX_KEYWORDLEN + 20, "size check" );
+	static_assert( 100 < MAX_REGEX_KEYWORDLEN + 20 );
 
 	// 2005.04.07 D.S.Koba
 	static const WCHAR* pszForm = LTEXT("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d");	//MIK

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -860,6 +860,6 @@ static void SetKeyNameArrVal(
 	if ( 0xFFFF < pKeydataInit->m_nKeyNameId ) {
 		wcscpy( pKeydata->m_szKeyName, pKeydataInit->m_pszKeyName );
 	}
-	static_assert( sizeof(pKeydata->m_nFuncCodeArr) == sizeof(pKeydataInit->m_nFuncCodeArr), "size check" );
+	static_assert( sizeof(pKeydata->m_nFuncCodeArr) == sizeof(pKeydataInit->m_nFuncCodeArr) );
 	memcpy_raw( pKeydata->m_nFuncCodeArr, pKeydataInit->m_nFuncCodeArr, sizeof(pKeydataInit->m_nFuncCodeArr) );
 }

--- a/sakura_core/func/CKeyBind.cpp
+++ b/sakura_core/func/CKeyBind.cpp
@@ -860,6 +860,6 @@ static void SetKeyNameArrVal(
 	if ( 0xFFFF < pKeydataInit->m_nKeyNameId ) {
 		wcscpy( pKeydata->m_szKeyName, pKeydataInit->m_pszKeyName );
 	}
-	assert( sizeof(pKeydata->m_nFuncCodeArr) == sizeof(pKeydataInit->m_nFuncCodeArr) );
+	static_assert( sizeof(pKeydata->m_nFuncCodeArr) == sizeof(pKeydataInit->m_nFuncCodeArr), "size check" );
 	memcpy_raw( pKeydata->m_nFuncCodeArr, pKeydataInit->m_nFuncCodeArr, sizeof(pKeydataInit->m_nFuncCodeArr) );
 }

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -204,7 +204,7 @@ HINSTANCE CDlgFuncList::m_lastRcInstance = 0;
 CDlgFuncList::CDlgFuncList() : CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	assert( _countof(anchorList) == _countof(m_rcItems) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
 
 	m_pcFuncInfoArr = NULL;		/* 関数情報配列 */
 	m_nCurLine = CLayoutInt(0);				/* 現在行 */

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -204,7 +204,7 @@ HINSTANCE CDlgFuncList::m_lastRcInstance = 0;
 CDlgFuncList::CDlgFuncList() : CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( _countof(anchorList) == _countof(m_rcItems), "size check" );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	m_pcFuncInfoArr = NULL;		/* 関数情報配列 */
 	m_nCurLine = CLayoutInt(0);				/* 現在行 */

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -131,24 +131,24 @@ INT_PTR CPropCommon::DlgProc2(
 CPropCommon::CPropCommon()
 {
 	{
-		static_assert( sizeof(CPropGeneral)   - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropWin)       - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropMainMenu)  - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropToolbar)   - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropTab)       - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropStatusbar) - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropEdit)      - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropFile)      - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropFileName)  - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropBackup)    - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropFormat)    - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropGrep)      - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropKeybind)   - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropCustmenu)  - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropKeyword)   - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropHelper)    - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropMacro)     - sizeof(CPropCommon) == 0, "size check" );
-		static_assert( sizeof(CPropPlugin)    - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropGeneral)   - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropWin)       - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropMainMenu)  - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropToolbar)   - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropTab)       - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropStatusbar) - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropEdit)      - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropFile)      - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropFileName)  - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropBackup)    - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropFormat)    - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropGrep)      - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropKeybind)   - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropCustmenu)  - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropKeyword)   - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropHelper)    - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropMacro)     - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropPlugin)    - sizeof(CPropCommon) == 0 );
 	}
 
 	/* 共有データ構造体のアドレスを返す */

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -131,24 +131,24 @@ INT_PTR CPropCommon::DlgProc2(
 CPropCommon::CPropCommon()
 {
 	{
-		assert( sizeof(CPropGeneral)   - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropWin)       - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropMainMenu)  - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropToolbar)   - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropTab)       - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropStatusbar) - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropEdit)      - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropFile)      - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropFileName)  - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropBackup)    - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropFormat)    - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropGrep)      - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropKeybind)   - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropCustmenu)  - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropKeyword)   - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropHelper)    - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropMacro)     - sizeof(CPropCommon) == 0 );
-		assert( sizeof(CPropPlugin)    - sizeof(CPropCommon) == 0 );
+		static_assert( sizeof(CPropGeneral)   - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropWin)       - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropMainMenu)  - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropToolbar)   - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropTab)       - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropStatusbar) - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropEdit)      - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropFile)      - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropFileName)  - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropBackup)    - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropFormat)    - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropGrep)      - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropKeybind)   - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropCustmenu)  - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropKeyword)   - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropHelper)    - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropMacro)     - sizeof(CPropCommon) == 0, "size check" );
+		static_assert( sizeof(CPropPlugin)    - sizeof(CPropCommon) == 0, "size check" );
 	}
 
 	/* 共有データ構造体のアドレスを返す */

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -87,12 +87,12 @@ GEN_PROPTYPES_CALLBACK(PropTypesKeyHelp,	CPropTypesKeyHelp)
 CPropTypes::CPropTypes()
 {
 	{
-		assert( sizeof(CPropTypesScreen)  - sizeof(CPropTypes) == 0 );
-		assert( sizeof(CPropTypesWindow)  - sizeof(CPropTypes) == 0 );
-		assert( sizeof(CPropTypesColor)   - sizeof(CPropTypes) == 0 );
-		assert( sizeof(CPropTypesSupport) - sizeof(CPropTypes) == 0 );
-		assert( sizeof(CPropTypesRegex)   - sizeof(CPropTypes) == 0 );
-		assert( sizeof(CPropTypesKeyHelp) - sizeof(CPropTypes) == 0 );
+		static_assert( sizeof(CPropTypesScreen)  - sizeof(CPropTypes) == 0, "size check" );
+		static_assert( sizeof(CPropTypesWindow)  - sizeof(CPropTypes) == 0, "size check" );
+		static_assert( sizeof(CPropTypesColor)   - sizeof(CPropTypes) == 0, "size check" );
+		static_assert( sizeof(CPropTypesSupport) - sizeof(CPropTypes) == 0, "size check" );
+		static_assert( sizeof(CPropTypesRegex)   - sizeof(CPropTypes) == 0, "size check" );
+		static_assert( sizeof(CPropTypesKeyHelp) - sizeof(CPropTypes) == 0, "size check" );
 	}
 
 	/* 共有データ構造体のアドレスを返す */

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -87,12 +87,12 @@ GEN_PROPTYPES_CALLBACK(PropTypesKeyHelp,	CPropTypesKeyHelp)
 CPropTypes::CPropTypes()
 {
 	{
-		static_assert( sizeof(CPropTypesScreen)  - sizeof(CPropTypes) == 0, "size check" );
-		static_assert( sizeof(CPropTypesWindow)  - sizeof(CPropTypes) == 0, "size check" );
-		static_assert( sizeof(CPropTypesColor)   - sizeof(CPropTypes) == 0, "size check" );
-		static_assert( sizeof(CPropTypesSupport) - sizeof(CPropTypes) == 0, "size check" );
-		static_assert( sizeof(CPropTypesRegex)   - sizeof(CPropTypes) == 0, "size check" );
-		static_assert( sizeof(CPropTypesKeyHelp) - sizeof(CPropTypes) == 0, "size check" );
+		static_assert( sizeof(CPropTypesScreen)  - sizeof(CPropTypes) == 0 );
+		static_assert( sizeof(CPropTypesWindow)  - sizeof(CPropTypes) == 0 );
+		static_assert( sizeof(CPropTypesColor)   - sizeof(CPropTypes) == 0 );
+		static_assert( sizeof(CPropTypesSupport) - sizeof(CPropTypes) == 0 );
+		static_assert( sizeof(CPropTypesRegex)   - sizeof(CPropTypes) == 0 );
+		static_assert( sizeof(CPropTypesKeyHelp) - sizeof(CPropTypes) == 0 );
 	}
 
 	/* 共有データ構造体のアドレスを返す */

--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -88,7 +88,7 @@ void CShareData::InitTypeConfigs(DLLSHAREDATA* pShareData, std::vector<STypeConf
 		new CType_Ini(),	//設定ファイル
 	};
 	types.clear();
-	static_assert( _countof(table) <= MAX_TYPES, "size check" );
+	static_assert( _countof(table) <= MAX_TYPES );
 	for(int i = 0; i < _countof(table) && i < MAX_TYPES; i++){
 		STypeConfig* type = new STypeConfig;
 		types.push_back(type);
@@ -213,7 +213,7 @@ void _DefaultConfig(STypeConfig* pType)
 
 	pType->m_nIndentLayout = 0;	/* 折り返しは2行目以降を字下げ表示 */
 
-	static_assert( COLORIDX_LAST <= _countof(pType->m_ColorInfoArr), "size check" );
+	static_assert( COLORIDX_LAST <= _countof(pType->m_ColorInfoArr) );
 	for( int i = 0; i < COLORIDX_LAST; ++i ){
 		GetDefaultColorInfo(&pType->m_ColorInfoArr[i],i);
 	}

--- a/sakura_core/types/CType.cpp
+++ b/sakura_core/types/CType.cpp
@@ -88,7 +88,7 @@ void CShareData::InitTypeConfigs(DLLSHAREDATA* pShareData, std::vector<STypeConf
 		new CType_Ini(),	//設定ファイル
 	};
 	types.clear();
-	assert( _countof(table) <= MAX_TYPES );
+	static_assert( _countof(table) <= MAX_TYPES, "size check" );
 	for(int i = 0; i < _countof(table) && i < MAX_TYPES; i++){
 		STypeConfig* type = new STypeConfig;
 		types.push_back(type);
@@ -213,7 +213,7 @@ void _DefaultConfig(STypeConfig* pType)
 
 	pType->m_nIndentLayout = 0;	/* 折り返しは2行目以降を字下げ表示 */
 
-	assert( COLORIDX_LAST <= _countof(pType->m_ColorInfoArr) );
+	static_assert( COLORIDX_LAST <= _countof(pType->m_ColorInfoArr), "size check" );
 	for( int i = 0; i < COLORIDX_LAST; ++i ){
 		GetDefaultColorInfo(&pType->m_ColorInfoArr[i],i);
 	}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

assert()の評価を実行時からコンパイル時に前倒します。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
C++11からコンパイル時アサート(static_assert)がサポートされているので、
整数定数式のassert()をstatic_assert()に置き換えます。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
コンパイル時に評価するので、エラーがある場合はコンパイルに失敗します。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

1. GitHub Actionsを実行したときに、buildがpassすること。
2. static_assert()の条件式を変更して、コンパイルエラーになること。
static_assert( COLORIDX_LAST > _countof(pType->m_ColorInfoArr), "size check" );
エラー C2338 static_assert failed: 'size check' sakura sakura_core\types\CType.cpp 216

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://cpprefjp.github.io/lang/cpp11/static_assert.html
