### PR TITLE
IA64サポート削除

### DIFF
--- a/help/sakura/res/HLP000079.html
+++ b/help/sakura/res/HLP000079.html
@@ -45,6 +45,6 @@ XP以降のVisual Styleを有効にする例です。<br>
 &lt;/dependency&gt;
 &lt;/assembly&gt;
 </pre>
-なお x64 版サクラエディタは processorArchitecture を "amd64" 、IA64 版 は "ia64" にしないと起動できません。
+なお x64 版サクラエディタは processorArchitecture を "amd64" にしないと起動できません。
 type は "win32" のままで問題ありません。
 </BODY></HTML>

--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -47,8 +47,6 @@
 
 #if defined _M_IX86
 #pragma comment(linker,"/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='x86' publicKeyToken='6595b64144ccf1df' language='*'\"")
-#elif defined _M_IA64
-#pragma comment(linker,"/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='ia64' publicKeyToken='6595b64144ccf1df' language='*'\"")
 #elif defined _M_X64
 #pragma comment(linker,"/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='amd64' publicKeyToken='6595b64144ccf1df' language='*'\"")
 #else

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -51,9 +51,7 @@ const DWORD p_helpids[] = {	//12900
 //	From Here Feb. 7, 2002 genta
 // 2006.01.17 Moca COMPILER_VERを追加
 // 2010.04.15 Moca icc/dmcを追加しCPUを分離
-#if defined(_M_IA64)
-#  define TARGET_M_SUFFIX "_I64"
-#elif defined(_M_AMD64)
+#if defined(_M_AMD64)
 #  define TARGET_M_SUFFIX "_A64"
 #else
 #  define TARGET_M_SUFFIX ""

--- a/sakura_core/extmodule/CMigemo.cpp
+++ b/sakura_core/extmodule/CMigemo.cpp
@@ -76,7 +76,7 @@ bool CMigemo::InitDllImp()
 	m_migemo_load_s             = (Proc_migemo_load_s)            m_migemo_load;
 	m_migemo_is_enable_s        = (Proc_migemo_is_enable_s)       m_migemo_is_enable;
 
-	// IA64/x64は対応不要
+	// x64は対応不要
 #ifdef _WIN64
 #else
 	// ver 1.3 以降は stdcall

--- a/sakura_core/extmodule/CMigemo.h
+++ b/sakura_core/extmodule/CMigemo.h
@@ -109,7 +109,7 @@ protected:
 	Proc_migemo_is_enable_s           m_migemo_is_enable_s;
 
 	migemo* m_migemo;
-	// IA64/x64は対応不要
+	// x64は対応不要
 #ifdef _WIN64
 	static const bool	m_bStdcall = true;
 #else

--- a/sakura_core/sakura_rc.rc2
+++ b/sakura_core/sakura_rc.rc2
@@ -147,16 +147,12 @@ IDI_ICON_STD            ICON         "../resource/icon_std.ico"
 STRINGTABLE
 BEGIN
 	// CBregexp.cpp
-#ifdef _M_IA64
-	STR_BREGONIG_LOAD				"bregonig.dll のロードに失敗しました。\r\n正規表現を利用するには Unicode/IA64 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"
-#elif defined(_M_AMD64)
+#if defined(_WIN64)
 	STR_BREGONIG_LOAD				"bregonig.dll のロードに失敗しました。\r\n正規表現を利用するには Unicode/x64 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"
 #else
 	STR_BREGONIG_LOAD				"bregonig.dll のロードに失敗しました。\r\n正規表現を利用するには Unicode 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"
 #endif
-#ifdef _M_IA64
-	STR_BREGONIG_INIT				"bregonig.dll の利用に失敗しました。\r\n正規表現を利用するには Unicode/IA64 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"
-#elif defined(_M_AMD64)
+#if defined(_WIN64)
 	STR_BREGONIG_INIT				"bregonig.dll の利用に失敗しました。\r\n正規表現を利用するには Unicode/x64 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"
 #else
 	STR_BREGONIG_INIT				"bregonig.dll の利用に失敗しました。\r\n正規表現を利用するには Unicode 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"

--- a/sakura_lang_en_US/sakura_lang_rc.rc2
+++ b/sakura_lang_en_US/sakura_lang_rc.rc2
@@ -158,16 +158,12 @@ BEGIN
 		//  http://msdn.microsoft.com/en-us/library/dd318693.aspx
 
 	// CBregexp.cpp
-#ifdef _M_IA64
-	STR_BREGONIG_LOAD				"failed to load the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde/IA64 ver) to work.\r\nPlease refer to the help for assistance."
-#elif defined(_M_AMD64)
+#if defined(_WIN64)
 	STR_BREGONIG_LOAD				"failed to load the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde/x64 ver) to work.\r\nPlease refer to the help for assistance."
 #else
 	STR_BREGONIG_LOAD				"failed to load the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde ver) to work.\r\nPlease refer to the help for assistance."
 #endif
-#ifdef _M_IA64
-	STR_BREGONIG_INIT				"failed to init the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde/IA64 ver) to work.\r\nPlease refer to the help for assistance."
-#elif defined(_M_AMD64)
+#if defined(_WIN64)
 	STR_BREGONIG_INIT				"failed to init the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde/x64 ver) to work.\r\nPlease refer to the help for assistance."
 #else
 	STR_BREGONIG_INIT				"failed to init the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde ver) to work.\r\nPlease refer to the help for assistance."


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- ドキュメント(md、ヘルプファイル等)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 不具合修正
- 削除

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

長期間使用されていない、IA64 のサポート削除します。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. _M_IA64 の条件コンパイル部分を削除します。
2. リソースファイルの条件コンパイルが正しく処理されていないので、修正します。
_M_AMD64 はコンパイラの定義済みマクロなので、リソースコンパイラではプリプロセッサで定義している _WIN64 を使います。
3. ソースコード、ヘルプからIA64の記述を削除します。

## <!-- わかる範囲で --> PR の影響範囲
1. IA64のサポートが削除されます。
2. sakura.exe (64bit版) 正規表現ライブラリのエラーメッセージが修正されます。

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. Grep -> 正規表現 をチェックしてエラーメッセージを確認する。
 32bit版 日本語
 32bit版 英語
 64bit版 日本語
 64bit版 英語
2. リソースエディタなどで、埋め込みデータ(34916、マニフェスト)を確認する。
 32bit版 sakura.exe / sakura_lang_en_US.dll 
 64bit版 sakura.exe / sakura_lang_en_US.dll 
3. HELP -> バージョン情報 でコンパイル情報(32bit/64bit)を確認する。
 32bit版
 64bit版

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/179
https://github.com/sakura-editor/sakura/pull/683

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://learn.microsoft.com/ja-jp/cpp/preprocessor/predefined-macros
https://ja.wikipedia.org/wiki/IA-64