### PR TITLE
ファイル読み込み高速化(行レイアウト幅算出を1回だけにする)

### DIFF
--- a/sakura_core/cmd/CViewCommander_Edit.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit.cpp
@@ -452,7 +452,8 @@ void CViewCommander::Command_UNDO( void )
 					GetDocument()->m_cLayoutMgr._DoLayout(false);
 					GetEditWindow()->ClearViewCaretPosInfo();
 					if( GetDocument()->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP ){
-						GetDocument()->m_cLayoutMgr.CalculateTextWidth();
+						// CLayoutMgr::_DoLayoutにて長さ算出済みなのでbCalLineLen=FALSE指定
+						GetDocument()->m_cLayoutMgr.CalculateTextWidth(FALSE);
 					}
 					GetDocument()->m_cLayoutMgr.LogicToLayout(
 						pcOpe->m_ptCaretPos_PHY_Before,
@@ -705,7 +706,8 @@ void CViewCommander::Command_REDO( void )
 					GetDocument()->m_cLayoutMgr._DoLayout(false);
 					GetEditWindow()->ClearViewCaretPosInfo();
 					if( GetDocument()->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP ){
-						GetDocument()->m_cLayoutMgr.CalculateTextWidth();
+						// CLayoutMgr::_DoLayoutにて長さ算出済みなのでbCalLineLen=FALSE指定
+						GetDocument()->m_cLayoutMgr.CalculateTextWidth(FALSE);
 					}
 					GetDocument()->m_cLayoutMgr.LogicToLayout(
 						pcOpe->m_ptCaretPos_PHY_After, &ptCaretPos_After );

--- a/sakura_core/cmd/CViewCommander_Settings.cpp
+++ b/sakura_core/cmd/CViewCommander_Settings.cpp
@@ -471,7 +471,9 @@ void CViewCommander::Command_TEXTWRAPMETHOD( int nWrapMethod )
 
 	// 2009.08.28 nasukoji	「折り返さない」ならテキスト最大幅を算出、それ以外は変数をクリア
 	if( pcDoc->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP ){
-		pcDoc->m_cLayoutMgr.CalculateTextWidth();		// テキスト最大幅を算出する
+		// CEditWnd::ChangeLayoutParam->CLayoutMgr::ChangeLayoutParam->
+		// CLayoutMgr::_DoLayoutにて長さ算出済みなのでbCalLineLen=FALSE指定
+		pcDoc->m_cLayoutMgr.CalculateTextWidth(FALSE);		// テキスト最大幅を算出する
 		GetEditWindow()->RedrawAllViews( NULL );		// スクロールバーの更新が必要なので再表示を実行する
 	}else{
 		pcDoc->m_cLayoutMgr.ClearLayoutLineWidth();		// 各行のレイアウト行長の記憶をクリアする

--- a/sakura_core/doc/CDocVisitor.cpp
+++ b/sakura_core/doc/CDocVisitor.cpp
@@ -83,7 +83,8 @@ void CDocVisitor::SetAllEol(CEol cEol)
 		m_pcDocRef->m_cLayoutMgr._DoLayout(false);
 		GetEditWnd().ClearViewCaretPosInfo();
 		if( m_pcDocRef->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP ){
-			m_pcDocRef->m_cLayoutMgr.CalculateTextWidth();
+			// CLayoutMgr::_DoLayoutにて長さ算出済みなのでbCalLineLen=FALSE指定
+			m_pcDocRef->m_cLayoutMgr.CalculateTextWidth(FALSE);
 		}else{
 			m_pcDocRef->m_cLayoutMgr.ClearLayoutLineWidth();
 		}

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -817,7 +817,9 @@ void CEditDoc::OnChangeSetting(
 
 	// 2009.08.28 nasukoji	「折り返さない」ならテキスト最大幅を算出、それ以外は変数をクリア
 	if( m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP )
-		m_cLayoutMgr.CalculateTextWidth();		// テキスト最大幅を算出する
+		// レイアウト情報再生成時(bDoLayout=true)はCLayoutMgr::SetLayoutInfo->
+		// CLayoutMgr::_DoLayoutにて長さ算出済みなのでbCalLineLen=FALSE指定
+		m_cLayoutMgr.CalculateTextWidth(!bDoLayout);		// テキスト最大幅を算出する
 	else
 		m_cLayoutMgr.ClearLayoutLineWidth();	// 各行のレイアウト行長の記憶をクリアする
 

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1590,8 +1590,9 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, VARIANT *Argument
 
 				// 2009.08.28 nasukoji	「折り返さない」選択時にTAB幅が変更されたらテキスト最大幅の再算出が必要
 				if( View->m_pcEditDoc->m_nTextWrapMethodCur == WRAP_NO_TEXT_WRAP ){
-					// 最大幅の再算出時に各行のレイアウト長の計算も行う
-					View->m_pcEditDoc->m_cLayoutMgr.CalculateTextWidth();
+					// CEditWnd::ChangeLayoutParam->CLayoutMgr::ChangeLayoutParam->
+					// CLayoutMgr::_DoLayoutにて長さ算出済みなのでbCalLineLen=FALSE指定
+					View->m_pcEditDoc->m_cLayoutMgr.CalculateTextWidth(FALSE);
 				}
 				GetEditWnd().RedrawAllViews( NULL );		// TAB幅が変わったので再描画が必要
 			}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

- 改善

## <!-- 必須 --> PR の背景

#1988 の第1弾対応です。

以前 #1951 を対応した際、タイプ別設定の折り返し方法に「折り返さない」が選択されている場合において、行ごとのレイアウト幅を求める処理が CLoadAgent::OnLoad と CLoadAgent::OnAfterLoad とで都合2回実行されていることに気づきました。

ファイル読み込み時のフレームグラフ：
![image](https://github.com/user-attachments/assets/88ddfecc-578b-4ac4-a987-4f7c6494c304)

2回やる意味はない (と考えている) ので CLoadAgent::OnAfterLoad 側 (↑の右側の赤枠) ではやらないようにします。

## <!-- 必須 --> 仕様・動作説明

対応内容：

1. CLoadAgent::OnAfterLoad でテキスト最大幅を取得する時、各行のレイアウト幅の再計算をしないようにします。

2. CLayoutMgr::_MakeOneLine のループ処理においてタブ幅を取得する際、TSV/CSVモードを考慮するよう修正します。(従来「1」で算出していたレイアウト幅と同じになるようにする)

3. CLayoutMgr::CalculateTextWidth を呼び出しているすべての箇所を確認し、不要なレイアウト幅の再計算をする箇所があれば「1」同様に修正します。

本PRの効果として、
* 折り返し方法に「折り返さない」が選択されている場合におけるファイルの読み込み時間が 20% ぐらい短くなります。
➡ プログレスバーが二度走った後の謎(？)の待ち時間の分がなくなります。

対応前 (0cef7dac9) | 本PR対応後
-|-
![fileopen_progress_master](https://github.com/user-attachments/assets/2bdb8d7f-3f9f-4fa2-9f37-1bfe627c5d17) | ![fileopen_progress_work](https://github.com/user-attachments/assets/df45e030-3a5b-42e2-b873-952ac4b41f9f)

各区間の処理時間 (計測条件などは #1988 を参照)：
区間 | 対応前 (85cb1bff9) | 本PR対応後
-|-|-
A. CLoadAgent::OnLoad 開始から ReadFile_To_CDocLineMgr 完了まで | 1526.136 | 1528.936
B. そこから CLoadAgent::OnLoad 完了まで (レイアウトデータ化処理) | 4269.241 | 4469.037
C. CLoadAgent::OnAfterLoad 開始から完了まで | 2665.548 | **9.104**
合計 | 8460.925 | 6007.077 (-29%)

また、PRの趣旨とは関係のない副産物として、
* CSV/TSVモードにおいて、折り返し位置がおかしくなってしまう不具合が直りました。
➡ 「2」の変更により、CLayoutMgr::_MakeOneLine でのレイアウト幅計算でCSV/TSVモードが考慮されるようになったため。

対応前 (0cef7dac9) | 本PR対応後
-|-
![image](https://github.com/user-attachments/assets/a9967fa3-7fa3-4113-9016-01ad38af4aee)  | ![image](https://github.com/user-attachments/assets/52253578-a355-4eb0-9971-42f3b11746fd)

## <!-- わかる範囲で --> PR の影響範囲

「2」の変更の影響ですが、折り返し方法が「折り返さない」以外の場合は読み込み時間が少しだけ増えてしまいます。

## <!-- 必須 --> テスト内容

CLayoutMgr::_MakeOneLine の変更によって既存機能に弊害が出ていないことを確認します。
* 折り返し方法が「折り返さない」の時の水平スクロールバーのつまみの位置が正しい※こと。
※最も長い行の右端を100%とした位置につまみが表示されることが期待動作
* 指定桁数での折り返しが正常に動作すること。
* 改行/句読点ぶら下げがそれぞれ正常に動作すること。
* CSV/TSVモードがそれぞれ正常に動作すること。

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
