### PR TITLE
ファイル読み込み高速化(行レイアウト化処理のマルチスレッド対応)

### DIFF
--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -292,6 +292,7 @@ public:
 	// 2005.11.21 Moca 引用符の色分け情報を引数から除去
 public:
 	void _DoLayout(bool bBlockingHook);	/* 現在の折り返し文字数に合わせて全データのレイアウト情報を再生成します */
+	void _DoLayoutSub(CDocLine* pDocLineBegin, CDocLine* pDocLineEnd, int nLineIndexBegin, int nLineCount, std::atomic<bool>* pbCanceled);
 protected:
 	// 2005.11.21 Moca 引用符の色分け情報を引数から除去
 	// 2009.08.28 nasukoji	テキスト最大幅算出用引数追加
@@ -358,6 +359,8 @@ private:
 	CLayoutInt getIndentOffset_Normal( CLayout* pLayoutPrev );
 	CLayoutInt getIndentOffset_Tx2x( CLayout* pLayoutPrev );
 	CLayoutInt getIndentOffset_LeftSpace( CLayout* pLayoutPrev );
+	void _Prepare( const CLayoutMgr& other );
+	void _AppendAsMove( CLayoutMgr& other );
 
 protected:
 	/*
@@ -387,7 +390,7 @@ protected:
 	//実データ
 	CLayout*				m_pLayoutTop;
 	CLayout*				m_pLayoutBot;
-	std::unique_ptr<std::pmr::memory_resource> m_layoutMemRes;
+	std::shared_ptr<std::pmr::memory_resource> m_layoutMemRes;
 
 	//タイプ別設定
 	const STypeConfig*		m_pTypeConfig;

--- a/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_DoLayout.cpp
@@ -260,12 +260,19 @@ void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 	if(pWork->pcColorStrategy)pWork->pcColorStrategy->InitStrategyStatus();
 	CColorStrategyPool& color = *CColorStrategyPool::getInstance();
 
+	const bool bCheckColorEnabled = color.HasRangeBasedColorStrategies();
+	const bool bKinsokuEnabled = m_pTypeConfig->m_bWordWrap
+		|| m_pTypeConfig->m_bKinsokuKuto
+		|| m_pTypeConfig->m_bKinsokuHead
+		|| m_pTypeConfig->m_bKinsokuTail;
+
 	//1ロジック行を消化するまでループ
 	while( pWork->nPos < nLength ){
 		// インデント幅は_OnLineで計算済みなのでここからは削除
 
-		//禁則処理中ならスキップする	@@@ 2002.04.20 MIK
-		if(_DoKinsokuSkip(pWork, pfOnLine)){ }
+		// 禁則処理中ならスキップする	@@@ 2002.04.20 MIK
+		// 禁則関係の設定が全部OFFの場合もスキップ
+		if(!bKinsokuEnabled || _DoKinsokuSkip(pWork, pfOnLine)){ }
 		else{
 			// 英文ワードラップをする
 			if( m_pTypeConfig->m_bWordWrap ){
@@ -288,8 +295,10 @@ void CLayoutMgr::_MakeOneLine(SLayoutWork* pWork, PF_OnLine pfOnLine)
 			}
 		}
 
-		//@@@ 2002.09.22 YAZAKI
-		color.CheckColorMODE( &pWork->pcColorStrategy, pWork->nPos, pWork->cLineStr );
+		if( bCheckColorEnabled ){
+			//@@@ 2002.09.22 YAZAKI
+			color.CheckColorMODE( &pWork->pcColorStrategy, pWork->nPos, pWork->cLineStr );
+		}
 
 		const auto& ch = pWork->cLineStr[pWork->nPos];
 		CLayoutInt nCharKetas {0};
@@ -340,22 +349,94 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 {
 	MY_RUNNINGTIMER( cRunningTimer, L"CLayoutMgr::_DoLayout" );
 
-	/*	表示上のX位置
-		2004.03.28 Moca nPosXはインデント幅を含むように変更(TAB位置調整のため)
-	*/
-	const int nAllLineNum = m_pcDocLineMgr->GetLineCount();
+	_Empty();
+	Init();
+
+	const CLogicInt nAllLineCount = m_pcDocLineMgr->GetLineCount();
+
+	int nWorkerThreadCount = 0;
+	if (nAllLineCount < 1000) {
+		// 行数が多くなければマルチスレッド処理するまでもない
+		nWorkerThreadCount = 0;
+	} else if (CColorStrategyPool::getInstance()->HasRangeBasedColorStrategies()) {
+		// 行をまたぐ可能性のある色分け (例：/*...*/) が有効の場合、途中で処理単位が
+		// 分割されてしまうと色分けがおかしくなってしまうためやむなくマルチスレッド処理の対象外とする
+		nWorkerThreadCount = 0;
+	} else {
+		nWorkerThreadCount = (std::max)(1, (int)std::thread::hardware_concurrency()) - 1;
+	}
+
+	// 末尾側の行から順番にワーカースレッドに割り当てていき最後 (先頭行～) はメインスレッドで実行
+	// nWorkerThreadCount = 0 の場合は全行をメインスレッドが実行
+	//
+	// 1000行のテキストを10スレッドで処理する場合のイメージ：
+	// 行番号
+	//    1 ┐
+	//  ... ├ メインスレッドで処理 (i = 0)
+	//  100 ┘
+	//  101 ┐
+	//  ... ├ ワーカースレッド1で処理 (i = 1)
+	//  200 ┘
+	//  ... ...
+	//  901 ┐
+	//  ... ├ ワーカースレッド9で処理 (i = 9) ↑こっちからループ
+	// 1000 ┘
+
+	std::vector<std::thread> vecWorkerThreads;
+	std::vector<CLayoutMgr> vecWorkerLayoutMgrs(nWorkerThreadCount);
+	std::atomic<bool> bCanceled = false;
+	auto pbCanceled = bBlockingHook ? &bCanceled : nullptr;
+	int nLineIndexEnd = nAllLineCount;
+	CDocLine* pDocLineEnd = nullptr;
+	for (int i = nWorkerThreadCount; i >= 0; i--) {
+		const int nLineIndexBegin = (int)((double)nAllLineCount / (nWorkerThreadCount + 1) * i);
+		const int nLineCount = nLineIndexEnd - nLineIndexBegin;
+		CDocLine* pDocLineBegin = m_pcDocLineMgr->GetLine(CLogicInt(nLineIndexBegin));
+
+		if (i == 0) {
+			// 最後はメインスレッドで処理
+			_DoLayoutSub(pDocLineBegin, pDocLineEnd, nLineIndexBegin, nLineCount, pbCanceled);
+		} else {
+			// ワーカースレッドを起こして処理
+			auto pcLayoutMgr = &vecWorkerLayoutMgrs[nWorkerThreadCount - i];
+			pcLayoutMgr->_Prepare(*this);
+			vecWorkerThreads.emplace_back([pcLayoutMgr, pDocLineBegin, pDocLineEnd, nLineIndexBegin, nLineCount, pbCanceled]{
+				pcLayoutMgr->_DoLayoutSub(pDocLineBegin, pDocLineEnd, nLineIndexBegin, nLineCount, pbCanceled);
+			});
+		}
+		nLineIndexEnd = nLineIndexBegin;
+		pDocLineEnd = pDocLineBegin;
+	}
+
+	// 各々の結果をまとめる
+	// 処理が途中で中断されていた場合でもワーカースレッドのjoinは必要なのでここはやる
+	for (int i = (nWorkerThreadCount - 1); i >= 0; i--) {
+		vecWorkerThreads[i].join();
+		_AppendAsMove(vecWorkerLayoutMgrs[i]);
+	}
+}
+
+/*!
+	@brief 指定された行範囲をレイアウトします
+*/
+void CLayoutMgr::_DoLayoutSub(CDocLine* pDocLineBegin, CDocLine* pDocLineEnd, int nLineIndex, int nLineCount, std::atomic<bool>* pbCanceled)
+{
 	const int nListenerCount = GetListenerCount();
 
 	if( nListenerCount != 0 ){
-		NotifyProgress(0);
-		/* 処理中のユーザー操作を可能にする */
-		if( bBlockingHook ){
-			if( !::BlockingHook( NULL ) )return;
+		if( nLineIndex == 0 ){
+			// メインスレッドは進捗更新とユーザー操作受け付け
+			NotifyProgress(0);
+			if( pbCanceled != nullptr && !::BlockingHook( NULL )){
+				// 中断された
+				pbCanceled->store(true);
+				return;
+			}
+		}else{
+			// ワーカースレッドは中断検知のみ
+			if( pbCanceled != nullptr && pbCanceled->load() ){ return; }
 		}
 	}
-
-	_Empty();
-	Init();
 
 	//	Nov. 16, 2002 genta
 	//	折り返し幅 <= TAB幅のとき無限ループするのを避けるため，
@@ -367,16 +448,16 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 
 	SLayoutWork	_sWork;
 	SLayoutWork* pWork = &_sWork;
-	pWork->pcDocLine				= m_pcDocLineMgr->GetDocLineTop(); // 2002/2/10 aroka CDocLineMgr変更
+	pWork->pcDocLine				= pDocLineBegin;
 	pWork->pLayout					= NULL;
 	pWork->pcColorStrategy			= NULL;
 	pWork->colorPrev				= COLORIDX_DEFAULT;
-	pWork->nCurLine					= CLogicInt(0);
+	pWork->nCurLine					= CLogicInt( nLineIndex );
 
 	constexpr DWORD userInterfaceInterval = 33;
-	DWORD prevTime = GetTickCount() + userInterfaceInterval;
+	ULONGLONG prevTime = GetTickCount64() + userInterfaceInterval;
 
-	while( NULL != pWork->pcDocLine ){
+	while( pWork->pcDocLine != pDocLineEnd ){
 		pWork->cLineStr		= pWork->pcDocLine->GetStringRefWithEOL();
 		pWork->eKinsokuType	= KINSOKU_TYPE_NONE;	//@@@ 2002.04.20 MIK
 		pWork->nBgn			= CLogicInt(0);
@@ -400,15 +481,20 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 		pWork->pcDocLine = pWork->pcDocLine->GetNextLine();
 
 		// 処理中のユーザー操作を可能にする
-		if( nListenerCount !=0 && 0 < nAllLineNum) {
-			DWORD currTime = GetTickCount();
-			DWORD diffTime = currTime - prevTime;
-			if( diffTime >= userInterfaceInterval ){
-				prevTime = currTime;
-				NotifyProgress(::MulDiv( pWork->nCurLine, 100 , nAllLineNum ) );
-				if( bBlockingHook ){
-					if( !::BlockingHook( NULL ) )return;
+		if( nListenerCount != 0 && 0 < nLineCount ) {
+			if( nLineIndex == 0 ){
+				const ULONGLONG currTime = GetTickCount64();
+				const ULONGLONG diffTime = currTime - prevTime;
+				if( diffTime >= userInterfaceInterval ){
+					prevTime = currTime;
+					NotifyProgress( ::MulDiv( pWork->nCurLine, 100, nLineCount ) );
+					if( pbCanceled != nullptr && !::BlockingHook( NULL ) ){
+						pbCanceled->store( true );
+						return;
+					}
 				}
+			}else{
+				if( pbCanceled != nullptr && pbCanceled->load() ){ return; }
 			}
 		}
 
@@ -422,11 +508,15 @@ void CLayoutMgr::_DoLayout(bool bBlockingHook)
 	m_nPrevReferLine = CLayoutInt(0);
 	m_pLayoutPrevRefer = NULL;
 
-	if( nListenerCount !=0 ){
-		NotifyProgress(0);
-		/* 処理中のユーザー操作を可能にする */
-		if( bBlockingHook ){
-			if( !::BlockingHook( NULL ) )return;
+	if( nListenerCount != 0 ){
+		if( nLineIndex == 0 ){
+			NotifyProgress(0);
+			if( pbCanceled != nullptr && !::BlockingHook( NULL ) ){
+				pbCanceled->store(true);
+				return;
+			}
+		}else{
+			if( pbCanceled != nullptr && pbCanceled->load() ){ return; }
 		}
 	}
 }
@@ -647,4 +737,64 @@ void CLayoutMgr::CalculateTextWidth_Range( const CalTextWidthArg* pctwArg )
 			CalculateTextWidth( FALSE, nCalTextWidthLinesFrom, nCalTextWidthLinesTo );
 #endif
 	}
+}
+
+/*!
+	@brief otherの内容を元にレイアウト処理の準備をする
+
+	@note _DoLayoutのマルチスレッド対応のために作成 (それ以外の用途での使用は想定していない)
+*/
+void CLayoutMgr::_Prepare( const CLayoutMgr& other )
+{
+	_Empty();
+	Init();
+
+	m_pcDocLineMgr			= other.m_pcDocLineMgr;
+	m_tsvInfo				= other.m_tsvInfo;
+	m_pcEditDoc				= other.m_pcEditDoc;
+
+	// 設定関係
+	m_pTypeConfig			= other.m_pTypeConfig;
+	m_nMaxLineKetas			= other.m_nMaxLineKetas;
+	m_nTabSpace				= other.m_nTabSpace;
+	m_nCharLayoutXPerKeta	= other.m_nCharLayoutXPerKeta;
+	m_nSpacing				= other.m_nSpacing;
+	m_pszKinsokuHead_1		= other.m_pszKinsokuHead_1;
+	m_pszKinsokuTail_1		= other.m_pszKinsokuTail_1;
+	m_pszKinsokuKuto_1		= other.m_pszKinsokuKuto_1;
+	m_getIndentOffset		= other.m_getIndentOffset;
+
+	// メモリプールは共用する
+	m_layoutMemRes			= other.m_layoutMemRes;
+
+	// Initで初期化されないので念のため
+	m_nTextWidth			= CLayoutInt(0);
+	m_nTextWidthMaxLine		= CLayoutInt(0);
+}
+
+/*!
+	@brief	otherの内容を末尾に連結する (連結後はotherの内容は空になる)
+
+	@note　_DoLayoutのマルチスレッド対応のために作成 (それ以外の用途での使用は想定していない)
+*/
+void CLayoutMgr::_AppendAsMove( CLayoutMgr& other )
+{
+	if (other.GetTopLayout() == nullptr) { return; }
+
+	// 双方向リンクをつなぐ
+	other.GetTopLayout()->m_pPrev = m_pLayoutBot;
+	if (m_pLayoutBot != nullptr) {
+		m_pLayoutBot->m_pNext = other.GetTopLayout();
+	}
+
+	// 先頭/末尾を更新
+	if (m_pLayoutTop == nullptr) {
+		m_pLayoutTop = other.GetTopLayout();
+	}
+	m_pLayoutBot = other.GetBottomLayout();
+
+	m_nLines += other.GetLineCount();
+
+	// 所有権が移ったので空っぽにしておく
+	other.Init();
 }

--- a/sakura_core/mem/CPoolResource.h
+++ b/sakura_core/mem/CPoolResource.h
@@ -65,6 +65,8 @@ protected:
  	void* do_allocate([[maybe_unused]] std::size_t bytes,
  					  [[maybe_unused]] std::size_t alignment) override
 	{
+		std::lock_guard<std::mutex> lock(mtx);
+
 		// メモリ確保時には未割当領域から使用していく
 		if (m_unassignedNode) {
 			T* ret = reinterpret_cast<T*>(m_unassignedNode);
@@ -91,6 +93,8 @@ protected:
 					   [[maybe_unused]] std::size_t alignment) override
 	{
 		if (p) {
+			std::lock_guard<std::mutex> lock(mtx);
+
 			// メモリ解放した領域を未割当領域として自己参照共用体の片方向連結リストで繋げる
 			// 次回のメモリ確保時にその領域を再利用する
 			Node* next = m_unassignedNode;
@@ -140,5 +144,7 @@ private:
 	Node* m_unassignedNode = nullptr; // 未割当領域の先頭
 	Node* m_currentBlock = nullptr; // 現在のブロック
 	Node* m_currentNode = nullptr; // 要素確保処理時に現在のブロックの中から切り出すNodeを指すポインタ、メモリ確保時に未割当領域が無い場合はここを使う
+
+	std::mutex mtx;
 };
 #endif /* SAKURA_CPOOLRESOURCE_4DEA6BEC_4D80_408F_9AEE_67AAF95BFE90_H_ */

--- a/sakura_core/view/colors/CColorStrategy.cpp
+++ b/sakura_core/view/colors/CColorStrategy.cpp
@@ -366,6 +366,16 @@ bool CColorStrategyPool::IsSkipBeforeLayout()
 	return true;
 }
 
+bool CColorStrategyPool::HasRangeBasedColorStrategies(void) const noexcept
+{
+	return (m_pcLineComment != nullptr)
+		|| (m_pcBlockComment1 != nullptr)
+		|| (m_pcBlockComment2 != nullptr)
+		|| (m_pcSingleQuote != nullptr)
+		|| (m_pcDoubleQuote != nullptr)
+		|| (m_pcHeredoc != nullptr);
+}
+
 /*!
   iniの色設定を番号でなく文字列で書き出す。(added by Stonee, 2001/01/12, 2001/01/15)
   配列の順番は共有メモリ中のデータの順番と一致している。

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -233,12 +233,17 @@ public:
 	CEditView* GetCurrentView(void) const{ return m_pcView; }
 	void SetCurrentView(CEditView* pcView) { m_pcView = pcView; }
 
+	//範囲を持つ色分けがあるかどうか
+	bool HasRangeBasedColorStrategies() const noexcept;
+
 private:
 	std::vector<CColorStrategy*>	m_vStrategies;
 	std::vector<CColorStrategy*>	m_vStrategiesDisp;	//!< 色分け表示対象
 	CColor_Found*					m_pcFoundStrategy;
 	CColor_Select*					m_pcSelectStrategy;
 
+	// 範囲を持つ色分け
+	// 追加/削除した時はHasRangeBasedColorStrategiesをメンテして下さい
 	CColor_LineComment*				m_pcLineComment;
 	CColor_BlockComment*			m_pcBlockComment1;
 	CColor_BlockComment*			m_pcBlockComment2;


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

#1988 の第2弾対応です。

ファイル読み込み時の処理で一番時間の掛かっている `CLayoutMgr::_DoLayout` の処理時間の短縮を図ります。

`CLayoutMgr::_DoLayout` では、前段の処理にて改行単位で分割されたテキストデータを入力として、見た目上の行単位 (レイアウト行) に分割する処理を主にやっていますが、その部分を [yoshinrt/SakuraVz](https://github.com/yoshinrt/SakuraVz) の [34d5593d](https://github.com/yoshinrt/SakuraVz/commit/ec611ac130bdc935bff8f7689e6ff9fdad3775b1#diff-34d5593d67d75e50e7eb3db6eba862a33a37d3e568a87a21d13970626dab8335) の対応を参考に複数のスレッドで並列実行できるようにします。

## <!-- 必須 --> 仕様・動作説明

対応内容：

1. `CLayoutMgr::_DoLayout` のマルチスレッド対応
`CLayoutMgr::_DoLayout` の実質の処理を `CLayoutMgr::_DoLayoutSub` (新規) に移し、それを複数スレッドから実行できるようにします。

2. `CLayoutMgr::_MakeOneLine` の高速化
ループ処理の手間で色分けや禁則関係の設定有無をあらかじめ確認、フラグに保持しておくことで、ループ内での不要な関数呼び出しをスキップします。

3. `CPoolResource` クラスの排他制御対応
対応「1」により、`CLayoutMgr` クラスが持つ1つのメモリプールを複数スレッドから同時に操作することになるため、`CPoolResource` の `do_allocate`, `do_deallocate` メソッドに対して std::mutex を使った排他制御を追加します。

4スレッドで処理する場合のイメージ：
![image](https://github.com/user-attachments/assets/544f41a9-5eb8-4a2f-b1f3-69421e389a54)

参考元対応から変えた主な点：
* 行をまたぐ色分け設定 (`/*...*/` など) のいずれかが有効の時はマルチスレッド処理を無効化
有効時はひとつ前の行の色分け状態を連鎖的に考慮する必要があり、色分け区間の途中で処理が分割されると正しく色分けできなくなる懸念があったため、設定有効時は従来通りシングルスレッドで処理させます。
(巨大となりがちなログファイルなどの拡張子に対して、行をまたぐ色分けの設定がされることはまれだろう・・・という想定とします)
(参考元ではマルチスレッド処理するのは一部機能制限があるとする「巨大ファイルモード」の場合に限定)

* `CLayoutMgr` クラスにおけるメモリプール (`CPoolResource`) の使用を継続
排他制御を追加したとしてもメモリプールを使った方が直接 new/delete するよりも処理時間が短くなることが確認できたので引き続き使うことにしています。
(参考元では [4f5c0285](https://github.com/yoshinrt/SakuraVz/commit/e8fda0268386dfafa72c634ded137cc68a7654d9#diff-4f5c028519f67a2a224e347977974df2b927ec08337f29f3dd52b5ceb02d6260) にてメモリプールを廃止)

各区間の処理時間 (計測条件などは #1988 を参照)：
区間 | 対応前 (d9d32424) | 本PR対応後
-|-|-
A. CLoadAgent::OnLoad 開始から ReadFile_To_CDocLineMgr 完了まで | 1528.936 | 1458.327
B. そこから CLoadAgent::OnLoad 完了まで (レイアウトデータ化処理) | 4469.037 | **676.073**
C. CLoadAgent::OnAfterLoad 開始から完了まで | 9.104 | 16.088
合計 | 6007.077 | 2150.488 (-64%)

## <!-- わかる範囲で --> PR の影響範囲

* 巨大なファイルを読み込む時のCPU使用率が増えますが、その分処理時間は短くなるので消費電力は変わらないと思います。

## <!-- 必須 --> テスト内容

...

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
