### PR TITLE
_FT() マクロ削除

### DIFF
--- a/sakura_core/basis/CMyString.h
+++ b/sakura_core/basis/CMyString.h
@@ -32,13 +32,6 @@
 #include "util/StaticType.h"
 #include "config/maxdata.h"
 
-#define m_delete2(p) { if(p){ delete[] p; p=0; } }
-
-#define astring string
-
-//共通マクロ
-#define _FT _T
-
 //共通型
 typedef StaticString<WCHAR,_MAX_PATH> SFilePath;
 typedef StaticString<WCHAR, MAX_GREP_PATH> SFilePathLong;

--- a/sakura_core/types/CType_Vb.cpp
+++ b/sakura_core/types/CType_Vb.cpp
@@ -89,7 +89,7 @@ void CDocOutline::MakeFuncList_VisualBasic( CFuncInfoArr* pcFuncInfoArr )
 	bClass	= false;
 	int filelen = wcslen(m_pcDocRef->m_cDocFile.GetFilePath());
 	if ( 4 < filelen ) {
-		if ( 0 == _wcsicmp((m_pcDocRef->m_cDocFile.GetFilePath() + filelen - 4), _FT(".cls")) ) {
+		if ( 0 == _wcsicmp((m_pcDocRef->m_cDocFile.GetFilePath() + filelen - 4), L".cls") ) {
 			bClass	= true;
 		}
 	}

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -4039,7 +4039,7 @@ void CEditWnd::ChangeFileNameNotify( const WCHAR* pszTabCaption, const WCHAR* _p
 	int		nIndex;
 
 	if( NULL == pszTabCaption ) pszTabCaption = L"";	//ガード
-	if( NULL == pszFilePath )pszFilePath = _FT("");		//ガード 2006.01.28 ryoji
+	if( NULL == pszFilePath ) pszFilePath = L"";		//ガード 2006.01.28 ryoji
 
 	CRecentEditNode	cRecentEditNode;
 	nIndex = cRecentEditNode.FindItemByHwnd( GetHwnd() );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->
- 削除

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Unicode build のみ対応なので _FT() マクロが不要になった。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. リテラル文字列をL プレフィックスが付いた形式に変更して、_FT() マクロを削除します。
2. _FT() マクロの近くにある未使用のマクロ定義を削除します。
m_delete2 : 使っているところなし(CMyStringクラスで使用されていたが削除された)。
astring : 使っているところなし(古いコードで検索したが見つからなかった)。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
コンパイル設定で、プリプロセッサ - ファイル前の処理 - はい(/P) に設定、前処理済み出力をファイル(*.i)に書き込み、変更前後で同じであることを確認する。
または、Visual Studio Code の Macro Expansion機能でマクロ展開を確認する。
 _FT(".cls") -> L".cls"
 _FT("") -> L""

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1034

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
