### PR TITLE
const修飾修正

### DIFF
--- a/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
@@ -956,7 +956,7 @@ void CViewCommander::Command_MERGE(void)
 void CViewCommander::Command_Reconvert(void)
 {
 	//サイズを取得
-	int nSize = m_pCommanderView->SetReconvertStruct(NULL);
+	LRESULT nSize = m_pCommanderView->SetReconvertStruct(nullptr);
 	if( 0 == nSize )  // サイズ０の時は何もしない
 		return ;
 
@@ -981,7 +981,7 @@ void CViewCommander::Command_Reconvert(void)
 	
 	//構造体設定
 	// Sizeはバッファ確保側が設定
-	pReconv->dwSize = nSize;
+	pReconv->dwSize = static_cast<DWORD>(nSize);
 	pReconv->dwVersion = 0;
 	m_pCommanderView->SetReconvertStruct( pReconv);
 	

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -344,7 +344,7 @@ public:
 	BOOL ChangeCurRegexp(bool bRedrawIfChanged= true);									// 2002.01.16 hor 正規表現の検索パターンを必要に応じて更新する(ライブラリが使用できないときはFALSEを返す)
 	void SendStatusMessage( const WCHAR* msg );					// 2002.01.26 hor 検索／置換／ブックマーク検索時の状態をステータスバーに表示する
 	LRESULT SetReconvertStruct(PRECONVERTSTRING pReconv, bool bDocumentFeed = false);	/* 再変換用構造体を設定する 2002.04.09 minfu */
-	LRESULT SetSelectionFromReonvert(const PRECONVERTSTRING pReconv);				/* 再変換用構造体の情報を元に選択範囲を変更する 2002.04.09 minfu */
+	LRESULT SetSelectionFromReonvert(const RECONVERTSTRING* pReconv);				/* 再変換用構造体の情報を元に選択範囲を変更する 2002.04.09 minfu */
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           D&D                               //

--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -358,8 +358,8 @@ LRESULT CEditView::SetReconvertStruct(PRECONVERTSTRING pReconv, bool bDocumentFe
 }
 
 /*再変換用 エディタ上の選択範囲を変更する 2002.04.09 minfu */
-LRESULT CEditView::SetSelectionFromReonvert(const PRECONVERTSTRING pReconv){
-	
+LRESULT CEditView::SetSelectionFromReonvert(const RECONVERTSTRING* pReconv)
+{
 	// 再変換情報が保存されているか
 	if ( (m_nLastReconvIndex < 0) || (m_nLastReconvLine < 0))
 		return 0;


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
SetSelectionFromReonvert()関数の引数について、
const PRECONVERTSTRING pReconv
と宣言してあるが、
pReconv->dwVersion = 1;
を記述しても build エラーにならない。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. const修飾を修正します。
const PRECONVERTSTRING pReconv -> const RECONVERTSTRING* pReconv
2. SetReconvertStruct()関数の戻り値の型と、格納する変数の型を合わせます。
int nSize -> LRESULT nSize

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
SetSelectionFromReonvert()関数に
pReconv->dwVersion = 1;
を記述して build エラーになることを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://www.jpcert.or.jp/sc-rules/c-dcl05-c.html
