### PR TITLE
GetEditWnd()関数のNULLチェック削除

### DIFF
--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -49,7 +49,6 @@
 #include "_main/CCommandLine.h"	/// 2003/1/26 aroka
 #include "_main/CAppMode.h"
 #include "_os/CDropTarget.h"
-#include "basis/CErrorInfo.h"
 #include "dlg/CDlgAbout.h"
 #include "dlg/CDlgPrintSetting.h"
 #include "env/CShareData.h"
@@ -178,25 +177,6 @@ static void ShowCodeBox( HWND hWnd, CEditDoc* pcEditDoc )
 		}
 	}
 }
-
-/*!
- * 編集ウインドウのインスタンスを取得します。
- *
- * 編集ウインドウの生存期間ははエディタプロセスと同じなので、
- * ほとんどの場合、このグローバル関数を使ってアクセスできます。
- */
-CEditWnd& GetEditWnd( void )
-{
-	auto pcEditWnd = CEditWnd::getInstance();
-	if( !pcEditWnd )
-	{
-		::_com_raise_error(E_FAIL, MakeMsgError(L"Any CEditWnd has been instantiated."));
-	}
-	return *pcEditWnd;
-}
-
-//	/* メッセージループ */
-//	DWORD MessageLoop_Thread( DWORD pCEditWndObject );
 
 LRESULT CALLBACK CEditWndProc(
 	HWND	hwnd,	// handle of window

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -424,6 +424,15 @@ public:
 	ESelectCountMode	m_nSelectCountMode; // 選択文字カウント方法
 };
 
-CEditWnd& GetEditWnd( void );
+/*!
+ * 編集ウインドウのインスタンスを取得します。
+ *
+ * 編集ウインドウの生存期間ははエディタプロセスと同じなので、
+ * ほとんどの場合、このグローバル関数を使ってアクセスできます。
+ */
+inline CEditWnd& GetEditWnd( void )
+{
+	return *CEditWnd::getInstance();
+}
 
 #endif /* SAKURA_CEDITWND_6C771A35_3CC8_4932_BF15_823C40487A9F_H_ */


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 削除

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
GetEditWnd()関数で、 CEditWnd::getInstance() の戻り値のNULLチェックを行っているが不要。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. CEditWnd::getInstance() の戻り値のNULLチェックを削除します。
2. inline関数にします。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容
TSingleton クラスの getInstance() に下記を追加して build エラーになることを確認する。
static_assert(nullptr == &instance);

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1744

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://cpprefjp.github.io/lang/cpp11/static_initialization_thread_safely.html
