### PR TITLE
コンストラクタの初期化子リスト並べ替え(SColorStrategyInfo)

### DIFF
--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -28,7 +28,6 @@
 #pragma once
 
 // 要先行定義
-// #include "view/CEditView.h"
 #include "EColorIndexType.h"
 #include "uiparts/CGraphics.h"
 
@@ -89,17 +88,10 @@ struct CColor3Setting {
 };
 
 struct SColorStrategyInfo{
-	SColorStrategyInfo(HDC hDC = NULL)
-		: m_sDispPosBegin(0,0)
-		, m_pStrategy(NULL)
-		, m_pStrategyFound(NULL)
-		, m_pStrategySelect(NULL)
-		, m_colorIdxBackLine(COLORIDX_TEXT)
-		, m_gr(hDC)
+	explicit SColorStrategyInfo(HDC hDC = nullptr)
+		: m_gr(hDC)
+		, m_sDispPosBegin(0,0)
 	{
-		m_cIndex.eColorIndex = COLORIDX_TEXT;
-		m_cIndex.eColorIndex2 = COLORIDX_TEXT;
-		m_cIndex.eColorIndexBg = COLORIDX_TEXT;
 	}
 
 	//参照
@@ -115,11 +107,11 @@ struct SColorStrategyInfo{
 	DispPos			m_sDispPosBegin;
 
 	//色変え
-	CColorStrategy*		m_pStrategy;
-	CColor_Found*		m_pStrategyFound;
-	CColor_Select*		m_pStrategySelect;
-	EColorIndexType		m_colorIdxBackLine;
-	CColor3Setting		m_cIndex;
+	CColorStrategy*		m_pStrategy = nullptr;
+	CColor_Found*		m_pStrategyFound = nullptr;
+	CColor_Select*		m_pStrategySelect = nullptr;
+	EColorIndexType		m_colorIdxBackLine = COLORIDX_TEXT;
+	CColor3Setting		m_cIndex = { COLORIDX_TEXT, COLORIDX_TEXT, COLORIDX_TEXT };
 
 	//! 色の切り替え
 	bool CheckChangeColor(const CStringRef& cLineStr);


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Clang/LLVM build 時に "-Wreorder-ctor" の warning が出力される。
CColorStrategy.h(97,5): warning : field 'm_colorIdxBackLine' will be initialized after field 'm_gr' [-Wreorder-ctor]

## <!-- 必須 --> 仕様・動作説明
<!-- ふるまいを変えない変更の場合は省略可。 -->

1. 初期化子リストを並べ替えます。
2. 変数宣言時に初期化を行います。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. SColorStrategyInfo のコンストラクタに break を設定して値を確認する。
2. Clang/LLVM build 時に "-Wreorder-ctor" の warning が削減されていることを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://cpprefjp.github.io/lang/cpp11/non_static_data_member_initializers.html
