### PR TITLE
enum eEolExts 削除

### DIFF
--- a/sakura_core/Funccode_x.hsrc
+++ b/sakura_core/Funccode_x.hsrc
@@ -354,6 +354,9 @@ F_CHG_CHARSET		= 31010,	//文字コードセット指定
 F_CHGMOD_EOL_CRLF	= 31081,	//入力改行コード指定(CRLF)				なし
 F_CHGMOD_EOL_LF		= 31082,	//入力改行コード指定(LF)				なし
 F_CHGMOD_EOL_CR		= 31083,	//入力改行コード指定(CR)				なし
+F_CHGMOD_EOL_NEL    = 31084,	//入力改行コード指定(NEL)				なし
+F_CHGMOD_EOL_PS	    = 31085,	//入力改行コード指定(PS)				なし
+F_CHGMOD_EOL_LS	    = 31086,	//入力改行コード指定(LS)				なし
 F_CANCEL_MODE		= 31099,	//各種モードの取り消し					なし
 
 // 設定系 

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -1454,11 +1454,6 @@ LRESULT CEditWnd::DispatchEvent(
 			else if( pnmh->code == NM_RCLICK ){
 				LPNMMOUSE mp = (LPNMMOUSE) lParam;
 				if( mp->dwItemSpec == 2 ){	//	入力改行モード
-					enum eEolExts {
-						F_CHGMOD_EOL_NEL = F_CHGMOD_EOL_CR + 1,
-						F_CHGMOD_EOL_PS,
-						F_CHGMOD_EOL_LS,
-					};
 					m_cMenuDrawer.ResetContents();
 					HMENU hMenuPopUp = ::CreatePopupMenu();
 					m_cMenuDrawer.MyAppendMenu( hMenuPopUp, MF_BYPOSITION | MF_STRING, F_CHGMOD_EOL_CRLF,


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Clang/LLVM で build したときに "-Wenum-compare-switch" が出力される。
warning : comparison of different enumeration types in switch statement ('EFunctionCode' and 'eEolExts') [-Wenum-compare-switch]

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
enum eEolExts 削除し enum EFunctionCode で定義します。
F_CHGMOD_EOL_NEL
F_CHGMOD_EOL_PS
F_CHGMOD_EOL_LS

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
1. 変更前後で、値が同じであることを確認する。
static_assert(F_CHGMOD_EOL_NEL == 31084);
static_assert(F_CHGMOD_EOL_PS == 31085);
static_assert(F_CHGMOD_EOL_LS == 31086);
2. Clang/LLVM build 時に "-Wenum-compare-switch"  の warning が削減されていることを確認する。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
