### PR TITLE
コンストラクタの初期化子リスト修正(CGrepAgent)

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -196,11 +196,6 @@ public:
 };
 
 CGrepAgent::CGrepAgent()
-: m_bGrepMode( false )			/* Grepモードか */
-, m_bGrepRunning( false )		/* Grep処理中 */
-, m_dwTickAddTail( 0 )
-, m_dwTickUICheck( 0 )
-, m_dwTickUIFileName( 0 )
 {
 }
 

--- a/sakura_core/CGrepAgent.h
+++ b/sakura_core/CGrepAgent.h
@@ -188,12 +188,12 @@ private:
 		const SGrepOption&	sGrepOption
 	);
 
-	DWORD m_dwTickAddTail;	// AddTail() を呼び出した時間
-	DWORD m_dwTickUICheck;	// 処理中にユーザーによるUI操作が行われていないか確認した時間
-	DWORD m_dwTickUIFileName;	// Cancelダイアログのファイル名表示更新を行った時間
+	DWORD m_dwTickAddTail = 0;	// AddTail() を呼び出した時間
+	DWORD m_dwTickUICheck = 0;	// 処理中にユーザーによるUI操作が行われていないか確認した時間
+	DWORD m_dwTickUIFileName = 0;	// Cancelダイアログのファイル名表示更新を行った時間
 
 public: //$$ 仮
-	bool	m_bGrepMode;		//!< Grepモードか
-	bool	m_bGrepRunning;		//!< Grep処理中
+	bool	m_bGrepMode = false;		//!< Grepモードか
+	bool	m_bGrepRunning = false;		//!< Grep処理中
 };
 #endif /* SAKURA_CGREPAGENT_97F2B632_71C8_4E4A_AC42_13A6098B248F_H_ */


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Clang/LLVM build 時に "-Wreorder-ctor" の warning が出力される。
CGrepAgent.cpp(200,3): warning : field 'm_bGrepRunning' will be initialized after field 'm_dwTickAddTail' [-Wreorder-ctor]

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
変数宣言時に初期化を行います。

## <!-- わかる範囲で --> PR の影響範囲
影響なし。

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
CGrepAgent のコンストラクタに break を設定して値を確認する。
Clang/LLVM build 時に "-Wreorder-ctor" の warning が削減されていることを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2012

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
