### PR TITLE
ファイル読み込み高速化(行データ読み出しのマルチスレッド対応)

### DIFF
--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -55,13 +55,13 @@ struct SEolDefinitionForUniFile{
 	bool StartsWithWB(const char* pData, size_t nLen) const{ return m_nLen<=nLen && 0==memcmp(pData,m_szDataWB,m_nLen); }
 };
 static const SEolDefinitionForUniFile g_aEolTable_uni_file[] = {
-	{ "",					"", 					0U },
-	{ "\x0d\x00\x0a\x00",	"\x00\x0d\x00\x0a",		4U },
-	{ "\x0a\x00",			"\x00\x0a",				2U },
-	{ "\x0d\x00",			"\x00\x0d",				2U },
-	{ "\x85\x00",			"\x00\x85",				2U },
-	{ "\x28\x20",			"\x20\x28",				2U },
-	{ "\x29\x20",			"\x20\x29",				2U },
+	{ "",					"", 					0 },
+	{ "\x0d\x00\x0a\x00",	"\x00\x0d\x00\x0a",		4 },
+	{ "\x0a\x00",			"\x00\x0a",				2 },
+	{ "\x0d\x00",			"\x00\x0d",				2 },
+	{ "\x85\x00",			"\x00\x85",				2 },
+	{ "\x28\x20",			"\x20\x28",				2 },
+	{ "\x29\x20",			"\x20\x29",				2 },
 };
 
 //-----------------------------------------------

--- a/sakura_core/CEol.cpp
+++ b/sakura_core/CEol.cpp
@@ -49,19 +49,19 @@ const SEolDefinition g_aEolTable[] = {
 struct SEolDefinitionForUniFile{
 	const char*	m_szDataW;
 	const char* m_szDataWB;
-	int			m_nLen;
+	size_t		m_nLen;
 
-	bool StartsWithW(const char* pData, int nLen) const{ return m_nLen<=nLen && 0==memcmp(pData,m_szDataW,m_nLen); }
-	bool StartsWithWB(const char* pData, int nLen) const{ return m_nLen<=nLen && 0==memcmp(pData,m_szDataWB,m_nLen); }
+	bool StartsWithW(const char* pData, size_t nLen) const{ return m_nLen<=nLen && 0==memcmp(pData,m_szDataW,m_nLen); }
+	bool StartsWithWB(const char* pData, size_t nLen) const{ return m_nLen<=nLen && 0==memcmp(pData,m_szDataWB,m_nLen); }
 };
 static const SEolDefinitionForUniFile g_aEolTable_uni_file[] = {
-	{ "",					"", 					0 },
-	{ "\x0d\x00\x0a\x00",	"\x00\x0d\x00\x0a",		4 },
-	{ "\x0a\x00",			"\x00\x0a",				2 },
-	{ "\x0d\x00",			"\x00\x0d",				2 },
-	{ "\x85\x00",			"\x00\x85",				2 },
-	{ "\x28\x20",			"\x20\x28",				2 },
-	{ "\x29\x20",			"\x20\x29",				2 },
+	{ "",					"", 					0U },
+	{ "\x0d\x00\x0a\x00",	"\x00\x0d\x00\x0a",		4U },
+	{ "\x0a\x00",			"\x00\x0a",				2U },
+	{ "\x0d\x00",			"\x00\x0d",				2U },
+	{ "\x85\x00",			"\x00\x85",				2U },
+	{ "\x28\x20",			"\x20\x28",				2U },
+	{ "\x29\x20",			"\x20\x29",				2U },
 };
 
 //-----------------------------------------------
@@ -75,7 +75,7 @@ static const SEolDefinitionForUniFile g_aEolTable_uni_file[] = {
 	@return 改行コードの種類。終端子が見つからなかったときはEEolType::noneを返す。
 */
 template <class T>
-EEolType GetEOLType( const T* pszData, int nDataLen )
+EEolType GetEOLType( const T* pszData, size_t nDataLen )
 {
 	for( size_t i = 1; i < EOL_TYPE_NUM; ++i ){
 		if( g_aEolTable[i].StartsWith(pszData, nDataLen) ){
@@ -89,7 +89,7 @@ EEolType GetEOLType( const T* pszData, int nDataLen )
 	ファイルを読み込むときに使用するもの
 */
 
-EEolType _GetEOLType_uni( const char* pszData, int nDataLen )
+EEolType _GetEOLType_uni( const char* pszData, size_t nDataLen )
 {
 	for( size_t i = 1; i < EOL_TYPE_NUM; ++i ){
 		if( g_aEolTable_uni_file[i].StartsWithW(pszData, nDataLen) ){
@@ -99,7 +99,7 @@ EEolType _GetEOLType_uni( const char* pszData, int nDataLen )
 	return EEolType::none;
 }
 
-EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
+EEolType _GetEOLType_unibe( const char* pszData, size_t nDataLen )
 {
 	for( size_t i = 1; i < EOL_TYPE_NUM; ++i ){
 		if( g_aEolTable_uni_file[i].StartsWithWB(pszData, nDataLen) ){
@@ -131,22 +131,22 @@ EEolType _GetEOLType_unibe( const char* pszData, int nDataLen )
 	return CLogicInt(g_aEolTable[static_cast<size_t>(m_eEolType)].m_nLen);
 }
 
-void CEol::SetTypeByString( const wchar_t* pszData, int nDataLen )
+void CEol::SetTypeByString( const wchar_t* pszData, size_t nDataLen )
 {
 	SetType( GetEOLType( pszData, nDataLen ) );
 }
 
-void CEol::SetTypeByString( const char* pszData, int nDataLen )
+void CEol::SetTypeByString( const char* pszData, size_t nDataLen )
 {
 	SetType( GetEOLType( pszData, nDataLen ) );
 }
 
-void CEol::SetTypeByStringForFile_uni( const char* pszData, int nDataLen )
+void CEol::SetTypeByStringForFile_uni( const char* pszData, size_t nDataLen )
 {
 	SetType( _GetEOLType_uni( pszData, nDataLen ) );
 }
 
-void CEol::SetTypeByStringForFile_unibe( const char* pszData, int nDataLen )
+void CEol::SetTypeByStringForFile_unibe( const char* pszData, size_t nDataLen )
 {
 	SetType( _GetEOLType_unibe( pszData, nDataLen ) );
 }

--- a/sakura_core/CEol.h
+++ b/sakura_core/CEol.h
@@ -64,10 +64,10 @@ struct SEolDefinition{
 	const WCHAR*	m_szName;
 	const WCHAR*	m_szDataW;
 	const ACHAR*	m_szDataA;
-	int				m_nLen;
+	size_t			m_nLen;
 
-	bool StartsWith(const WCHAR* pData, int nLen) const{ return m_nLen<=nLen && 0==wmemcmp(pData,m_szDataW,m_nLen); }
-	bool StartsWith(const ACHAR* pData, int nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==memcmp(pData,m_szDataA,m_nLen); }
+	bool StartsWith(const WCHAR* pData, size_t nLen) const{ return m_nLen<=nLen && 0==wmemcmp(pData,m_szDataW,m_nLen); }
+	bool StartsWith(const ACHAR* pData, size_t nLen) const{ return m_nLen<=nLen && m_szDataA[0] != '\0' && 0==memcmp(pData,m_szDataA,m_nLen); }
 };
 
 constexpr auto EOL_TYPE_NUM = static_cast<size_t>(EEolType::code_max); // 8
@@ -140,13 +140,13 @@ public:
 	CEol& operator = ( EEolType t ) noexcept { SetType( t ); return *this; }
 
 	//文字列内の行終端子を解析
-	void SetTypeByString( const wchar_t* pszData, int nDataLen );
-	void SetTypeByString( const char* pszData, int nDataLen );
+	void SetTypeByString( const wchar_t* pszData, size_t nDataLen );
+	void SetTypeByString( const char* pszData, size_t nDataLen );
 
 	//設定（ファイル読み込み時に使用）
-	void SetTypeByStringForFile( const char* pszData, int nDataLen ){ SetTypeByString( pszData, nDataLen ); }
-	void SetTypeByStringForFile_uni( const char* pszData, int nDataLen );
-	void SetTypeByStringForFile_unibe( const char* pszData, int nDataLen );
+	void SetTypeByStringForFile( const char* pszData, size_t nDataLen ){ SetTypeByString( pszData, nDataLen ); }
+	void SetTypeByStringForFile_uni( const char* pszData, size_t nDataLen );
+	void SetTypeByStringForFile_unibe( const char* pszData, size_t nDataLen );
 };
 
 // グローバル演算子

--- a/sakura_core/CReadManager.h
+++ b/sakura_core/CReadManager.h
@@ -29,6 +29,8 @@
 
 #include "doc/CDocListener.h" // CProgressSubject
 #include "charset/CCodeBase.h" // EConvertResult
+#include "io/CFileLoad.h"
+#include <atomic>
 
 class CDocLineMgr;
 struct SFileInfo; // doc/CDocFile.h
@@ -41,6 +43,14 @@ public:
 		CDocLineMgr*		pcDocLineMgr,
 		const SLoadInfo&	sLoadInfo,
 		SFileInfo*			pFileInfo
+	);
+
+private:
+	EConvertResult ReadLines(
+		bool				bRunInMainThread,
+		CFileLoad&			cFileLoad,
+		CDocLineMgr&		cDocLineMgr,
+		std::atomic<bool>&	bCanceled
 	);
 };
 #endif /* SAKURA_CREADMANAGER_BF5A195D_BEA1_4508_8BC7_DB5316B5B66E_H_ */

--- a/sakura_core/doc/logic/CDocLineMgr.cpp
+++ b/sakura_core/doc/logic/CDocLineMgr.cpp
@@ -134,6 +134,30 @@ void CDocLineMgr::DeleteLine( CDocLine* pcDocLineDel )
 	}
 }
 
+//! 他のCDocLineMgrの内容を末尾に追加する
+//! 元のCDocLineMgrの内容は空になる
+void CDocLineMgr::AppendAsMove( CDocLineMgr& other )
+{
+	if( other.GetDocLineTop() == nullptr ){ return; }
+
+	// 双方向リンクをつなぐ
+	other.GetDocLineTop()->m_pPrev = m_pDocLineBot;
+	if( m_pDocLineBot != nullptr ){
+		m_pDocLineBot->m_pNext = other.GetDocLineTop();
+	}
+
+	// 先頭/末尾を更新
+	if( m_pDocLineTop == nullptr ){
+		m_pDocLineTop = other.GetDocLineTop();
+	}
+	m_pDocLineBot = other.GetDocLineBottom();
+
+	m_nLines += other.GetLineCount();
+
+	// 所有権が移ったので空っぽにしておく
+	other._Init();
+}
+
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                   行データへのアクセス                      //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/doc/logic/CDocLineMgr.h
+++ b/sakura_core/doc/logic/CDocLineMgr.h
@@ -24,6 +24,7 @@
 
 #include <Windows.h>
 #include <memory_resource>
+#include <memory>
 #include "_main/global.h" // 2002/2/10 aroka
 #include "basis/SakuraBasis.h"
 #include "util/design_template.h"
@@ -71,6 +72,11 @@ public:
 	CDocLine* AddNewLine();						//!< 最下部に新しい行を挿入
 	void DeleteAllLine();						//!< 全ての行を削除する
 	void DeleteLine( CDocLine* );				//!< 行の削除
+	void AppendAsMove( CDocLineMgr& other );	//!< 他のCDocLineMgrの内容を末尾に追加する
+
+	// メモリリソースのアクセス
+	std::shared_ptr<std::pmr::memory_resource> GetMemoryResource() const { return m_docLineMemRes; }
+	void SetMemoryResource(std::shared_ptr<std::pmr::memory_resource> memoryResource) { m_docLineMemRes = memoryResource; }
 
 	//デバッグ
 	void DUMP();
@@ -92,7 +98,7 @@ private:
 	CDocLine*	m_pDocLineTop;		//!< 最初の行
 	CDocLine*	m_pDocLineBot;		//!< 最後の行(※1行しかない場合はm_pDocLineTopと等しくなる)
 	CLogicInt	m_nLines;			//!< 全行数
-	std::unique_ptr<std::pmr::memory_resource> m_docLineMemRes;
+	std::shared_ptr<std::pmr::memory_resource> m_docLineMemRes;
 
 public:
 	//$$ kobake注: 以下、絶対に切り離したい（最低切り離せなくても、変数の意味をコメントで明確に記すべき）変数群

--- a/sakura_core/io/CFileLoad.cpp
+++ b/sakura_core/io/CFileLoad.cpp
@@ -105,7 +105,6 @@ CFileLoad::CFileLoad( const SEncodingConfig& encode )
 	m_pEencoding = &encode;
 
 	m_hFile			= NULL;
-	m_hFileMapping	= NULL;
 	m_nFileSize		= 0;
 	m_nFileDataLen	= 0;
 	m_CharCode		= CODE_DEFAULT;
@@ -116,11 +115,6 @@ CFileLoad::CFileLoad( const SEncodingConfig& encode )
 	m_eMode			= FLMODE_CLOSE;	// Jun. 08, 2003 Moca
 
 	m_nLineIndex	= -1;
-
-	m_pReadBufTop	= NULL;
-	m_nReadBufOffsetCurrent = 0;
-	m_nReadBufOffsetBegin	= 0;
-	m_nReadBufOffsetEnd		= 0;
 }
 
 /*! デストラクタ */

--- a/sakura_core/io/CFileLoad.h
+++ b/sakura_core/io/CFileLoad.h
@@ -92,12 +92,9 @@ public:
 	//! 指定オフセットから末尾に向かって最初に現れる行頭のオフセットを取得
 	size_t GetNextLineOffset( size_t nOffset );
 
-	static const int gm_nBufSizeDef; // ロード用バッファサイズの初期値
-//	static const int gm_nBufSizeMin; // ロード用バッファサイズの設定可能な最低値
-
 protected:
 	// GetLextLine の 文字コード考慮版
-	const char* GetNextLineCharCode(const char*	pData, size_t nDataLen, size_t* pnLineLen, size_t* pnBgn, CEol* pcEol, int* pnEolLen, int* pnBufferNext);
+	const char* GetNextLineCharCode(const char*	pData, size_t nDataLen, size_t* pnLineLen, size_t* pnBgn, CEol* pcEol, size_t* pnEolLen);
 	EConvertResult ReadLine_core(CNativeW* pUnicodeBuffer, CEol* pcEol);
 
 	int Read(void* pBuf, size_t nSize); // inline
@@ -105,6 +102,9 @@ protected:
 
 	/* メンバオブジェクト */
 	const SEncodingConfig* m_pEencoding;
+
+	//! 文字コード自動検出のために読み込む最大サイズ(byte)
+	static constexpr LONGLONG m_nAutoDetectReadLen = 32768LL;
 
 //	LPWSTR	m_pszFileName;	// ファイル名
 	HANDLE	m_hFile;		// ファイルハンドル

--- a/sakura_core/io/CFileLoad.h
+++ b/sakura_core/io/CFileLoad.h
@@ -90,11 +90,6 @@ public:
 //	static const int gm_nBufSizeMin; // ロード用バッファサイズの設定可能な最低値
 
 protected:
-	// Oct. 19, 2002 genta スペルミス修正
-//	void SeekBegin( void );		// ファイルの先頭位置に移動する(BOMを考慮する)
-	void Buffering( void );		// バッファにデータをロードする
-	void ReadBufEmpty( void );	// バッファを空にする
-
 	// GetLextLine の 文字コード考慮版
 	const char* GetNextLineCharCode(const char*	pData, int nDataLen, int* pnLineLen, int* pnBgn, CEol* pcEol, int* pnEolLen, int* pnBufferNext);
 	EConvertResult ReadLine_core(CNativeW* pUnicodeBuffer, CEol* pcEol);
@@ -107,6 +102,7 @@ protected:
 
 //	LPWSTR	m_pszFileName;	// ファイル名
 	HANDLE	m_hFile;		// ファイルハンドル
+	HANDLE	m_hFileMapping;	// メモリマップドファイルハンドル
 	LONGLONG	m_nFileSize;	// ファイルサイズ(64bit)
 	LONGLONG	m_nFileDataLen;	// ファイルデータ長からBOM長を引いたバイト数
 	LONGLONG	m_nReadLength;	// 現在までにロードしたデータの合計バイト数(BOM長を含まない)
@@ -130,11 +126,8 @@ protected:
 	enumFileLoadMode	m_eMode;		// 現在の読み込み状態
 
 	// 読み込みバッファ系
-	char*	m_pReadBuf;			// 読み込みバッファへのポインタ
-	int		m_nReadBufSize;		// 読み込みバッファの実際に確保しているサイズ
-	int		m_nReadDataLen;		// 読み込みバッファの有効データサイズ
-	int		m_nReadBufOffSet;	// 読み込みバッファ中のオフセット(次の行頭位置)
-//	int		m_nReadBufSumSize;	// 今までにバッファに読み込んだデータの合計サイズ
+	const char*	m_pReadBuf;	// 読み込みバッファ(メモリマップドファイル)の先頭を指すポインタ
+	int m_nReadBufOffset;	// 読み込みバッファ中のオフセット(次の行頭位置)
 	CMemory m_cLineBuffer;
 	CNativeW m_cLineTemp;
 	int		m_nReadOffset2;

--- a/sakura_core/io/CFileLoad.h
+++ b/sakura_core/io/CFileLoad.h
@@ -97,9 +97,6 @@ protected:
 	const char* GetNextLineCharCode(const char*	pData, size_t nDataLen, size_t* pnLineLen, size_t* pnBgn, CEol* pcEol, size_t* pnEolLen);
 	EConvertResult ReadLine_core(CNativeW* pUnicodeBuffer, CEol* pcEol);
 
-	int Read(void* pBuf, size_t nSize); // inline
-	DWORD FilePointer(DWORD offset, DWORD origin); // inline
-
 	/* メンバオブジェクト */
 	const SEncodingConfig* m_pEencoding;
 
@@ -108,7 +105,7 @@ protected:
 
 //	LPWSTR	m_pszFileName;	// ファイル名
 	HANDLE	m_hFile;		// ファイルハンドル
-	HANDLE	m_hFileMapping;	// メモリマップドファイルハンドル
+	HANDLE	m_hFileMapping = nullptr;	// メモリマップドファイルハンドル
 	LONGLONG	m_nFileSize;	// ファイルサイズ(64bit)
 	LONGLONG	m_nFileDataLen;	// ファイルデータ長からBOM長を引いたバイト数
 	int		m_nLineIndex;	// 現在ロードしている論理行(0開始)
@@ -131,10 +128,10 @@ protected:
 	enumFileLoadMode	m_eMode;		// 現在の読み込み状態
 
 	// 読み込みバッファ系
-	const char*	m_pReadBufTop;	// 読み込みバッファの先頭を指すポインタ
-	size_t m_nReadBufOffsetBegin;
-	size_t m_nReadBufOffsetEnd;
-	size_t m_nReadBufOffsetCurrent;	// 読み込みバッファ中のオフセット(次の行頭位置)
+	const char*	m_pReadBufTop = nullptr;	// 読み込みバッファの先頭を指すポインタ
+	size_t m_nReadBufOffsetBegin = 0;
+	size_t m_nReadBufOffsetEnd = 0;
+	size_t m_nReadBufOffsetCurrent = 0;		// 読み込みバッファ中のオフセット(次の行頭位置)
 	CMemory m_cLineBuffer;
 	CNativeW m_cLineTemp;
 	int		m_nReadOffset2;
@@ -148,23 +145,5 @@ protected:
 // public
 inline BOOL CFileLoad::GetFileTime( FILETIME* pftCreate, FILETIME* pftLastAccess, FILETIME* pftLastWrite ){
 	return ::GetFileTime( m_hFile, pftCreate, pftLastAccess, pftLastWrite );
-}
-
-// protected
-inline int CFileLoad::Read( void* pBuf, size_t nSize )
-{
-	DWORD ReadSize;
-	if( !::ReadFile( m_hFile, pBuf, (DWORD)nSize, &ReadSize, NULL ) )
-		throw CError_FileRead();
-	return (int)ReadSize;
-}
-
-// protected
-inline DWORD CFileLoad::FilePointer( DWORD offset, DWORD origin )
-{
-	DWORD fp;
-	if( INVALID_SET_FILE_POINTER == ( fp = ::SetFilePointer( m_hFile, offset, NULL, FILE_BEGIN ) ) )
-		throw CError_FileRead();
-	return fp;
 }
 #endif /* SAKURA_CFILELOAD_B9B7A22E_8C14_4913_8B92_3B5ABA6FC0DB_H_ */


### PR DESCRIPTION
# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

- 改善

## <!-- 必須 --> PR の背景

#1988 の第3弾対応です。

今回の変更対象は `CReadManager::ReadFile_To_CDocLineMgr()` で、この関数では主に以下の処理をしています。
* ファイルからテキストデータを読み込む
* それを行単位に分割
* それを内部文字エンコーディング (UTF-16) へ変換 (CIoBridge::FileToImpl の実行)

これらの処理を [yoshinrt/SakuraVz](https://github.com/yoshinrt/SakuraVz) の [1578dc68](https://github.com/yoshinrt/SakuraVz/commit/1578dc68224dc37a2a55975008a2bf9594ac66f5), [e9cbf1b0](https://github.com/yoshinrt/SakuraVz/commit/e9cbf1b04ea5f1bbd84286fd80bc462d8fb6d502) の対応を参考に高速化します。

## <!-- 必須 --> 仕様・動作説明

対応内容：

1. `CFileLoad` のメモリマップドファイル対応
従来は固定長のバッファに対して逐次ファイル内容を読み込みながら処理をしていましたが、
メモリコピーの負荷を減らすことと、後述のマルチスレッド対応の効果を高める (＝マルチスレッド化ができない処理を減らす) ことを目的に、メモリマップドファイルを使ってデータを読み込むよう変更します。

2. `CReadManager::ReadFile_To_CDocLineMgr` のマルチスレッド対応
テキストデータを行単位へ分割する処理と文字コード変換の処理を、複数のスレッドで並列実行するようにします。

3. サイズが2GiB以上のファイルを開いた時に落ちる問題を修正 (参考元の対応にはない修正)
「2」の対応したことで起きるようになったため本PRに含めて対応します。
`CEol::SetTypeByStringForFile()` の引数 `nDataLen` がオーバーフローしていることが分かったため、型を int から size_t に変更します。(関連する変数/引数の型もあわせて直します)

各区間の処理時間 (計測条件などは #1988 を参照)：
区間 | 対応前 (9f9948d5) | 本PR対応後
-|-|-
A. CLoadAgent::OnLoad 開始から ReadFile_To_CDocLineMgr 完了まで | 1458.327 | **502.304** |
B. そこから CLoadAgent::OnLoad 完了まで (レイアウトデータ化処理) | 676.073 | 647.408 |
C. CLoadAgent::OnAfterLoad 開始から完了まで | 16.088 | 89.502 |
合計 | 2150.488 | 1239.214 (-42%) |

## <!-- わかる範囲で --> PR の影響範囲

メモリマップドファイルを使うようにした影響で、ファイル読み込み中の瞬間最大のメモリ使用量が増えます。
読み込んだファイルとほぼ同じサイズ分だけ増加します。

(例) 1GiB のファイルを読み込む時の最大メモリ使用量：
変更前 (9f9948d5) | 本PR対応後
-|-
2.4GB | 3.3GB (+0.9GB)

## <!-- 必須 --> テスト内容

* [test.zip](https://github.com/user-attachments/files/19030559/test.zip) の「test_1000lines.txt」(1000行のテキストファイル) を開き、各行の数字が行番号と一致していること。👈ファイル読み込み処理後のCDocLineMgrの集約が正しい順序でできていることの確認
* [test_4gb.zip](https://github.com/user-attachments/files/19263162/test_4gb.zip) の「test_4gb.txt」(4GBのテキストファイル) を開いた時、エラーのダイアログボックスが表示されないこと。👈対応内容の「3」の修正が効いていることの確認

## <!-- なければ省略可 --> 関連 issue, PR

## <!-- なければ省略可 --> 参考資料
