### PR TITLE
条件判定(KEYCODE)が常にfalseになる警告修正

### DIFF
--- a/sakura_core/CDataProfile.h
+++ b/sakura_core/CDataProfile.h
@@ -30,7 +30,6 @@
 #include "CProfile.h"
 
 #include "basis/SakuraBasis.h"
-#include "debug/Debug2.h"
 #include "util/StaticType.h"
 
 /*!
@@ -226,7 +225,8 @@ namespace profile_data {
 	[[nodiscard]] inline std::wstring ToString<KEYCODE>(KEYCODE value)
 	{
 		// WCHAR型を介して文字列化する
-		const WCHAR ch = value < 0 || value >= 0x80 ? L'\0' : value;
+		static_assert(std::numeric_limits<KEYCODE>::max() < 0x80);
+		const WCHAR ch = (value < 0) ? L'\0' : static_cast<std::make_unsigned_t<KEYCODE>>(value);
 		return ToString(ch);
 	}
 

--- a/tests/unittests/test-cprofile.cpp
+++ b/tests/unittests/test-cprofile.cpp
@@ -263,6 +263,39 @@ TEST(profile_data, TryParse_StringBufferW)
 }
 
 /*!
+ * @brief ToString(KEYCODE)のテスト
+ */
+TEST(profile_data, ToString_KEYCODE)
+{
+	std::wstring str;
+	KEYCODE code;
+
+	code = 0x80;
+	str = profile_data::ToString(code);
+	ASSERT_STREQ(L"", str.c_str());
+
+	code = -1;
+	str = profile_data::ToString(code);
+	ASSERT_STREQ(L"", str.c_str());
+
+	code = 0;
+	str = profile_data::ToString(code);
+	ASSERT_STREQ(L"", str.c_str());
+
+	code = 1;
+	str = profile_data::ToString(code);
+	ASSERT_STREQ(L"\x01", str.c_str());
+
+	code = 0x61;
+	str = profile_data::ToString(code);
+	ASSERT_STREQ(L"a", str.c_str());
+
+	code = 0x7f;
+	str = profile_data::ToString(code);
+	ASSERT_STREQ(L"\x7f", str.c_str());
+}
+
+/*!
  * @brief IOProfileDataのテスト
  */
 TEST(CDataProfile, IOProfileData)


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

Clang/LLVM でbuild時に "-Wtautological-constant-out-of-range-compare" のwarningが出力される。
CDataProfile.h(229,39): warning : result of comparison of constant 128 with expression of type 'KEYCODE' (aka 'char') is always false [-Wtautological-constant-out-of-range-compare]
KEYCODE型(char) の変数の範囲は -128~127、128は範囲外。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. コンパイル時にチェックします。
2. unit test を追加します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
変更前後で unit test が PASS することを確認します。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1548

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://cpprefjp.github.io/reference/limits/numeric_limits.html
