### PR TITLE
未使用 private 変数削除

### DIFF
--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -1741,7 +1741,6 @@ public:
 		:nHitCount(hit)
 		,fileName(name_)
 		,name(name_)
-		,code(code_)
 		,bBom(bBom_)
 		,bOldSave(bOldSave_)
 		,bufferSize(0)
@@ -1840,7 +1839,6 @@ private:
 	int& nHitCount;
 	LPCWSTR fileName;
 	std::wstring name;
-	ECodeType code;
 	bool bBom;
 	bool bOldSave;
 	size_t bufferSize;

--- a/sakura_core/macro/CWSH.cpp
+++ b/sakura_core/macro/CWSH.cpp
@@ -73,7 +73,6 @@ class CWSHSite: public IActiveScriptSite, public IActiveScriptSiteWindow
 {
 private:
 	CWSHClient *m_Client;
-	ITypeInfo *m_TypeInfo;
 	ULONG m_RefCount;
 public:
 	CWSHSite(CWSHClient *AClient): m_Client(AClient), m_RefCount(0)

--- a/sakura_core/outline/CDlgFileTree.h
+++ b/sakura_core/outline/CDlgFileTree.h
@@ -66,7 +66,6 @@ private:
 	CDlgFuncList*		m_pcDlgFuncList;
 	CFileTreeSetting	m_fileTreeSetting;
 	std::vector<int>	m_aItemRemoveList;
-	int					m_nlParamCount;
 	int					m_nDocType;
 
 	int					m_bInMove;

--- a/sakura_core/plugin/CPlugin.h
+++ b/sakura_core/plugin/CPlugin.h
@@ -295,8 +295,6 @@ public:
 	wstring m_sLangName;		//!< 言語名
 	CPluginOption::Array m_options;		// オプション	// 2010/3/24 Uchi
 	std::vector<std::wstring> m_aStrings;	// 文字列
-private:
-	bool m_bLoaded;
 protected:
 	CPlug::Array m_plugs;
 	int m_nCommandCount;

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -349,9 +349,6 @@ private:
 	//自ウィンドウ
 	HWND			m_hWnd;
 
-	//親ウィンドウ
-	HWND			m_hwndParent;
-
 public:
 	//子ウィンドウ
 	CMainToolBar	m_cToolbar;			//!< ツールバー


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Clang/LLVM build 時に "-Wunused-private-field" の warning が出力される。
CGrepAgent.cpp(1843,12): warning : private field 'code' is not used [-Wunused-private-field]

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
クラスに定義している未使用 private 変数を削除します。

## <!-- わかる範囲で --> PR の影響範囲
影響なし。

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
Clang/LLVM build 時に "-Wunused-private-field" の warning が削減されていることを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://learn.microsoft.com/ja-jp/cpp/build/clang-support-msbuild
