### PR TITLE
enum 先行宣言 (ECodeType)

### DIFF
--- a/sakura_core/charset/charset.h
+++ b/sakura_core/charset/charset.h
@@ -35,7 +35,7 @@
 
 // 文字コードセット種別
 //2007.08.14 kobake CODE_ERROR, CODE_DEFAULT 追加
-enum ECodeType {
+enum ECodeType : int {
 	CODE_SJIS,						//!< SJIS				(MS-CP932(Windows-31J), シフトJIS(Shift_JIS))
 	CODE_JIS,						//!< JIS				(MS-CP5022x(ISO-2022-JP-MS)ではない)
 	CODE_EUC,						//!< EUC				(MS-CP51932, eucJP-ms(eucJP-open)ではない)
@@ -84,19 +84,6 @@ inline bool IsValidCodeTypeExceptSJIS(int code)
 	return IsValidCodeType(code) && code!=CODE_SJIS;
 }
 
-// 2010/6/21 Uchi 削除
-//2007.08.14 kobake 追加
-//!ECodeType型で表せる値ならtrue
-//inline bool IsInECodeType(int code)
-//{
-//	return (code>=0 && code<CODE_CODEMAX) || code==CODE_ERROR || code==CODE_AUTODETECT;
-//}
-
-// 2010/6/21 Uchi 削除
-//inline bool IsConcreteCodeType(ECodeType eCodeType)
-//{
-//	return IsValidCodeType(eCodeType) && eCodeType != CODE_AUTODETECT;
-//}
 inline bool IsValidCodePageEx(int code)
 {
 	return 12000 == code

--- a/sakura_core/charset/codechecker.h
+++ b/sakura_core/charset/codechecker.h
@@ -41,41 +41,6 @@
 #include "basis/primitive.h"
 
 /*!
-	認識する文字コード種別
-*/
-//enum ECodeType;     charset/charset.h に定義されている
-#if 0
-enum ECodeType {
-	CODE_SJIS,				// MS-CP932(Windows-31J), シフトJIS(Shift_JIS)
-	CODE_JIS,				// MS-CP5022x(ISO-2022-JP-MS)
-	CODE_EUC,				// MS-CP51932, eucJP-ms(eucJP-open)
-	CODE_UNICODE,			// UTF-16 LittleEndian(UCS-2)
-	CODE_UTF8,				// UTF-8(UCS-2)
-	CODE_UTF7,				// UTF-7(UCS-2)
-	CODE_UNICODEBE,			// UTF-16 BigEndian(UCS-2)
-	// ...
-	CODE_CODEMAX,
-	CODE_AUTODETECT = 99,	/* 文字コード自動判別 */
-	CODE_DEFAULT    = CODE_SJIS,	/* デフォルトの文字コード */
-
-	/*
-		- MS-CP50220
-			Unicode から cp50220 への変換時に、
-			JIS X 0201 片仮名は JIS X 0208 の片仮名に置換される
-		- MS-CP50221
-			Unicode から cp50221 への変換時に、
-			JIS X 0201 片仮名は、G0 集合への指示のエスケープシーケンス ESC ( I を用いてエンコードされる
-		- MS-CP50222
-			Unicode から cp50222 への変換時に、
-			JIS X 0201 片仮名は、SO/SI を用いてエンコードされる
-
-		参考
-		http://legacy-encoding.sourceforge.jp/wiki/
-	*/
-};
-#endif
-
-/*!
 	内部的に認識する文字集合
 */
 enum ECharSet {

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -28,6 +28,7 @@
 #include "CFileExt.h"
 #include "env/CDocTypeManager.h"
 #include "env/CShareData.h"
+#include "env/DLLSHAREDATA.h"
 #include "CEditApp.h"
 #include "CEol.h"
 #include "charset/CCodePage.h"

--- a/sakura_core/dlg/CDlgSetCharSet.h
+++ b/sakura_core/dlg/CDlgSetCharSet.h
@@ -18,7 +18,7 @@
 
 #include "dlg/CDialog.h"
 
-enum ECodeType;
+enum ECodeType : int;
 
 //! 文字コードセット設定ダイアログボックス
 class CDlgSetCharSet final : public CDialog

--- a/sakura_core/parse/DetectIndentationStyle.h
+++ b/sakura_core/parse/DetectIndentationStyle.h
@@ -1,5 +1,7 @@
 #pragma once
 
+class CEditDoc;
+
 struct IndentationStyle
 {
 	enum class Character {


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Clang/LLVM で build時 に "-Wtautological-constant-out-of-range-compare" のwarningが出力される。
CFileLoad.cpp(299,44): warning : result of comparison of constant 65000 with expression of type 'ECodeType' is always true [-Wtautological-constant-out-of-range-compare]

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. enum ECodeType に基底型を追加します。
2. StdAfx.h から #include "env/DLLSHAREDATA.h" コメントアウト時の build error を修正します。

## <!-- わかる範囲で --> PR の影響範囲
影響なし。

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. Clang/LLVM build 時に "-Wtautological-constant-out-of-range-compare" の warning が削減されていることを確認する。
2. 変更前後でasmが同じことを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://en.cppreference.com/w/cpp/language/enum
