### PR TITLE
template 関数を生成しないようにする (wcsncmp_literal)

### DIFF
--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -256,29 +256,25 @@ std::string wcstou8s(std::wstring_view strInput);
 
 //wcsncmpの文字数指定をliteralData2の大きさで取得してくれる版
 template <size_t Size>
-int wcsncmp_literal(const wchar_t* strData1, const wchar_t (&literalData2)[Size]) {
-	assert(literalData2[Size - 1] == 0);
+inline int wcsncmp_literal(const wchar_t* strData1, const wchar_t (&literalData2)[Size]) {
 	return ::wcsncmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、_countofからマイナス1する
 }
 
 //strncmpの文字数指定をliteralData2の大きさで取得してくれる版
 template <size_t Size>
-int strncmp_literal(const char* strData1, const char (&literalData2)[Size]) {
-	assert(literalData2[Size - 1] == 0);
+inline int strncmp_literal(const char* strData1, const char (&literalData2)[Size]) {
 	return ::strncmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、_countofからマイナス1する
 }
 
 //_wcsnicmpの文字数指定をliteralData2の大きさで取得してくれる版
 template <size_t Size>
-int wcsnicmp_literal(const wchar_t* strData1, const wchar_t (&literalData2)[Size]) {
-	assert(literalData2[Size - 1] == 0);
+inline int wcsnicmp_literal(const wchar_t* strData1, const wchar_t (&literalData2)[Size]) {
 	return ::_wcsnicmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、_countofからマイナス1する
 }
 
 //_strnicmpの文字数指定をliteralData2の大きさで取得してくれる版
 template <size_t Size>
-int strnicmp_literal(const char* strData1, const char (&literalData2)[Size]) {
-	assert(literalData2[Size - 1] == 0);
+inline int strnicmp_literal(const char* strData1, const char (&literalData2)[Size]) {
 	return ::_strnicmp(strData1, literalData2, Size - 1 ); //※終端ヌルを含めないので、_countofからマイナス1する
 }
 #endif /* SAKURA_STRING_EX_87282FEB_4B23_4112_9C5A_419F43618705_H_ */


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
wcsncmp_literal() をマクロからtemplate関数に変更したことにより、文字列長ごとに関数が生成される。
sakura.map を wcsncmp_literal で検索した結果
0001:000517f6       ??$wcsnicmp_literal@$0N@@@YAHPB_WAAY0N@$$CB_W@Z 004527f6 f i CDocOutline.obj
0001:00051803       ??$wcsnicmp_literal@$06@@YAHPB_WAAY06$$CB_W@Z 00452803 f i CDocOutline.obj
0001:000be360       ??$wcsnicmp_literal@$02@@YAHPB_WAAY02$$CB_W@Z 004bf360 f i format.obj
0001:000d2a38       ??$wcsnicmp_literal@$05@@YAHPB_WAAY05$$CB_W@Z 004d3a38 f i CEditView_Mouse.obj

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. inline を追加して、元のマクロと同じように直接 wcsncmp() 関数を呼び出しすようにする。
対象となる関数
wcsncmp_literal()
strncmp_literal()
wcsnicmp_literal()
strnicmp_literal()
2. リテラル文字列の文字列長はコンパイル時に決まるので assert() のチェックは不要。削除する。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容
1. sakura.map ファイルを確認して、 wcsnicmp_literal がなくなっていることを確認する。
2. 変更後の asm が元のマクロと同じように直接 wcsncmp() 関数を呼び出していることを確認する。

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1042

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
