### PR TITLE
"-Woverloaded-virtual" 警告修正 (CDlgFuncList::OnTimer)

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -429,7 +429,7 @@ INT_PTR CDialog::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM l
 		m_hWnd = hwndDlg;
 		return OnMove( wParam, lParam );
 	case WM_DRAWITEM:	return OnDrawItem( wParam, lParam );
-	case WM_TIMER:		return OnTimer( wParam );
+	case WM_TIMER:		return OnTimer( hwndDlg, uMsg, wParam, lParam );
 	case WM_KEYDOWN:	return OnKeyDown( wParam, lParam );
 	case WM_KILLFOCUS:	return OnKillFocus( wParam, lParam );
 	case WM_ACTIVATE:	return OnActivate( wParam, lParam );	//@@@ 2003.04.08 MIK

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -21,8 +21,6 @@
 #define SAKURA_CDIALOG_17C8C15C_881C_4C1F_B953_CB11FCC8B70B_H_
 #pragma once
 
-class CDialog;
-
 struct DLLSHAREDATA;
 class CRecent;
 
@@ -93,7 +91,7 @@ public:
 	virtual BOOL OnSize( WPARAM wParam, LPARAM lParam );
 	virtual BOOL OnMove( WPARAM wParam, LPARAM lParam );
 	virtual BOOL OnDrawItem( WPARAM wParam, LPARAM lParam ){return TRUE;}
-	virtual BOOL OnTimer( WPARAM wParam ){return TRUE;}
+	virtual BOOL OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ){return TRUE;}
 	virtual BOOL OnKeyDown( WPARAM wParam, LPARAM lParam ){return TRUE;}
 	virtual BOOL OnDeviceChange( WPARAM wParam, LPARAM lParam ){return TRUE;}
 	virtual int GetData( void ){return 1;}/* ダイアログデータの取得 */

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -664,7 +664,7 @@ BOOL CDlgTagJumpList::OnNotify(NMHDR* pNMHDR)
 
 	タイマーを停止し，候補リストを更新する
 */
-BOOL CDlgTagJumpList::OnTimer( WPARAM wParam )
+BOOL CDlgTagJumpList::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	StopTimer();
 

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -88,7 +88,7 @@ protected:
 	BOOL	OnCbnSelChange( HWND hwndCtl, int wID ) override;
 	BOOL	OnCbnEditChange( HWND hwndCtl, int wID ) override;
 	//BOOL	OnEnChange( HWND hwndCtl, int wID ) override;
-	BOOL	OnTimer( WPARAM wParam ) override;
+	BOOL	OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;
 	LPVOID	GetHelpIdTable( void ) override;
 
 private:

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -277,8 +277,6 @@ INT_PTR CDlgFuncList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 			return 1L;
 		}
 		break;
-	case WM_TIMER:
-		return OnTimer( hWnd, wMsg, wParam, lParam );
 	case WM_GETMINMAXINFO:
 		return OnMinMaxInfo( lParam );
 	case WM_SETTEXT:
@@ -2799,7 +2797,7 @@ INT_PTR CDlgFuncList::OnNcHitTest( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
 /** WM_TIMER 処理
 	@date 2010.06.05 ryoji 新規作成
 */
-INT_PTR CDlgFuncList::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
+BOOL CDlgFuncList::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
 	if( wParam == 2 ){
 		CEditView* pcView = reinterpret_cast<CEditView*>(m_lParam);
@@ -2825,7 +2823,7 @@ INT_PTR CDlgFuncList::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 			}
 		}
 		::KillTimer(hwnd, 2);
-		return 0L;
+		return FALSE;
 	}else if( wParam == 3 ){
 		::KillTimer(hwnd, 3);
 		HWND hwndTree = ::GetDlgItem(hwnd, IDC_TREE_FL);
@@ -2837,7 +2835,7 @@ INT_PTR CDlgFuncList::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 	}
 
 	if( !IsDocking() )
-		return 0L;
+		return FALSE;
 
 	if( wParam == 1 ){
 		// カーソルがウィンドウ外にある場合にも WM_NCMOUSEMOVE を送る
@@ -2850,7 +2848,7 @@ INT_PTR CDlgFuncList::OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 		}
 	}
 
-	return 0L;
+	return FALSE;
 }
 
 /** WM_NCMOUSEMOVE 処理

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -175,7 +175,7 @@ protected:
 	INT_PTR OnNcLButtonDown( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
 	INT_PTR OnLButtonUp( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
 	INT_PTR OnNcPaint( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
-	INT_PTR OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
+	BOOL OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;
 	void GetDockSpaceRect( LPRECT pRect );
 	void GetCaptionRect( LPRECT pRect );
 	bool GetCaptionButtonRect( int nButton, LPRECT pRect );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Clang/LLVM build 時に "-Woverloaded-virtual" の warning が出力される。
CDlgFuncList.h(178,10): warning : 'CDlgFuncList::OnTimer' hides overloaded virtual function [-Woverloaded-virtual]
CDialog.h(96,15): note: hidden overloaded virtual function 'CDialog::OnTimer' declared here: different number of parameters (1 vs 4)

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. CDialog::OnTimer() の引数を変更します。
2. CDlgTagJumpList::OnTimer() の引数を変更します。
3. CDlgFuncList::OnTimer() にoverride を追加します。 

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. Clang/LLVM build 時に "-Woverloaded-virtual" の warning が削減されていることを確認する。
2. 検索 - アウトライン解析 - 右クリック - すべて展開/すべて縮小 を選択して、TreeView_ExpandAll()が呼び出されることを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1987

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
