### PR TITLE
"-Wlogical-op-parentheses" 警告修正

### DIFF
--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -351,7 +351,7 @@ INT_PTR CHokanMgr::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lP
 	// 念のため IME 関連のメッセージが来るようならビューに処理させる
 	// 何かの環境依存（常駐ソフト？）によるものかもしれないが、
 	// フォーカスが無くても IME 関連メッセージがこっちに来るケースがあったので、その対策
-	if(wMsg >= WM_IME_STARTCOMPOSITION && wMsg <= WM_IME_KEYLAST || wMsg >= WM_IME_SETCONTEXT && wMsg <= WM_IME_KEYUP){
+	if((wMsg >= WM_IME_STARTCOMPOSITION && wMsg <= WM_IME_KEYLAST) || (wMsg >= WM_IME_SETCONTEXT && wMsg <= WM_IME_KEYUP)){
 		CEditView* pcEditView = (CEditView*)m_lParam;
 		pcEditView->DispatchEvent( pcEditView->GetHwnd(), wMsg, wParam, lParam );
 		return TRUE;

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -286,7 +286,7 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 
 		//	2007.09.09 genta オプション判定ルール変更．オプション解析停止と""で囲まれたオプションを考慮
 		if( ( bParseOptDisabled ||
-			! (pszToken[0] == '-' || pszToken[0] == '"' && pszToken[1] == '-' ) )){
+			! (pszToken[0] == '-' || (pszToken[0] == '"' && pszToken[1] == '-')) )){
 
 			if( pszToken[0] == L'\"' ){
 				CNativeW cmWork;

--- a/sakura_core/charset/CESI.h
+++ b/sakura_core/charset/CESI.h
@@ -178,8 +178,8 @@ public:
 	bool IsAmbiguousEucAndSjis( void ){
 		// EUC と SJIS がトップ2に上がった時
 		// かつ、EUC と SJIS のポイント数が同数のとき
-		if( (m_apMbcInfo[0]->eCodeID == CODE_SJIS && m_apMbcInfo[1]->eCodeID == CODE_EUC
-		     || m_apMbcInfo[1]->eCodeID == CODE_SJIS && m_apMbcInfo[0]->eCodeID == CODE_EUC)
+		if( ((m_apMbcInfo[0]->eCodeID == CODE_SJIS && m_apMbcInfo[1]->eCodeID == CODE_EUC)
+		     || (m_apMbcInfo[1]->eCodeID == CODE_SJIS && m_apMbcInfo[0]->eCodeID == CODE_EUC))
 		 && m_apMbcInfo[0]->nPoints == m_apMbcInfo[1]->nPoints
 		){
 			return true;
@@ -191,8 +191,8 @@ public:
 	bool IsAmbiguousUtf8AndCesu8( void ){
 		// UTF-8 と SJIS がトップ2に上がった時
 		// かつ、UTF-8 と SJIS のポイント数が同数のとき
-		if( (m_apMbcInfo[0]->eCodeID == CODE_UTF8 && m_apMbcInfo[1]->eCodeID == CODE_CESU8
-		     || m_apMbcInfo[1]->eCodeID == CODE_UTF8 && m_apMbcInfo[0]->eCodeID == CODE_CESU8)
+		if( ((m_apMbcInfo[0]->eCodeID == CODE_UTF8 && m_apMbcInfo[1]->eCodeID == CODE_CESU8)
+		     || (m_apMbcInfo[1]->eCodeID == CODE_UTF8 && m_apMbcInfo[0]->eCodeID == CODE_CESU8))
 		 && m_apMbcInfo[0]->nPoints == m_apMbcInfo[1]->nPoints
 		){
 			return true;

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -67,8 +67,8 @@ namespace WCODE
 		if(wc>=0x007F && wc<=0x00A0)return true;	// Control Code ISO/IEC 6429
 
 		// 漢字はすべて同一幅とみなす	// 2013.04.07 aroka
-		if ( wc>=0x4E00 && wc<=0x9FBB		// Unified Ideographs, CJK
-		  || wc>=0x3400 && wc<=0x4DB5		// Unified Ideographs Extension A, CJK
+		if ( (wc>=0x4E00 && wc<=0x9FBB)		// Unified Ideographs, CJK
+		  || (wc>=0x3400 && wc<=0x4DB5)		// Unified Ideographs Extension A, CJK
 		){
 			wc = 0x4E00; // '一'(0x4E00)の幅で代用
 		}

--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -353,9 +353,9 @@ void CViewCommander::Command_RIGHT( bool bSelect, bool bIgnoreCurrentSelection, 
 
 			// キャレットの移動先を決める。
 			if( nextline_exists
-				&& ( on_x_max == MOVE_NEXTLINE_IMMEDIATELY && x_max <= to_x
-					|| on_x_max == MOVE_NEXTLINE_NEXTTIME && x_max < to_x
-					|| on_x_max == MOVE_NEXTLINE_NEXTTIME_AND_MOVE_RIGHT && x_max < to_x
+				&& ( (on_x_max == MOVE_NEXTLINE_IMMEDIATELY && x_max <= to_x)
+					|| (on_x_max == MOVE_NEXTLINE_NEXTTIME && x_max < to_x)
+					|| (on_x_max == MOVE_NEXTLINE_NEXTTIME_AND_MOVE_RIGHT && x_max < to_x)
 				)
 			) {
 				ptTo.y = ptCaret.y + 1;

--- a/sakura_core/env/CAppNodeManager.cpp
+++ b/sakura_core/env/CAppNodeManager.cpp
@@ -846,7 +846,7 @@ HWND CAppNodeManager::GetNextTab(HWND hWndCur)
 						bFound= true;
 					}
 					else {
-						if (!bFound && hWnd == NULL || bFound) {
+						if ((!bFound && hWnd == nullptr) || bFound) {
 							hWnd = p[i].GetHwnd();
 						}
 						if (bFound) {

--- a/sakura_core/macro/CCookieManager.cpp
+++ b/sakura_core/macro/CCookieManager.cpp
@@ -131,9 +131,9 @@ std::map<std::wstring, std::wstring>* CCookieManager::SelectCookieType(LPCWSTR s
 bool CCookieManager::ValidateCookieName(LPCWSTR cookieName) const
 {
 	for(int i = 0; cookieName[i] != L'\0'; i++){
-		if( L'0' <= cookieName[i] && cookieName[i] <= L'9' ||
-			L'a' <= cookieName[i] && cookieName[i] <= L'z' ||
-			L'A' <= cookieName[i] && cookieName[i] <= L'Z' ||
+		if( (L'0' <= cookieName[i] && cookieName[i] <= L'9') ||
+			(L'a' <= cookieName[i] && cookieName[i] <= L'z') ||
+			(L'A' <= cookieName[i] && cookieName[i] <= L'Z') ||
 			L'_' <= cookieName[i] ){
 		}else{
 			return false;

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -615,7 +615,7 @@ void CDocOutline::MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr ,EOutlineType& nOu
 						continue;
 					}else{
 						if( pLine[i] == L':' ){
-							if( pLine[i + 1] == L':' ||  0 < i && pLine[i-1] == L':' ){
+							if( pLine[i + 1] == L':' || (0 < i && pLine[i-1] == L':') ){
 								// name ::class or class :: member
 							}else{
 								// class Klass:base のように:の前にスペースがない場合

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -418,9 +418,9 @@ BOOL CheckEXT( const WCHAR* pszPath, const WCHAR* pszExt )
 bool _IS_REL_PATH(const WCHAR* path)
 {
 	bool ret = true;
-	if( ( L'A' <= path[0] && path[0] <= L'Z' || L'a' <= path[0] && path[0] <= L'z' )
-		&& path[1] == L':' && path[2] == L'\\'
-		|| path[0] == L'\\' && path[1] == L'\\'
+	if( (((L'A' <= path[0] && path[0] <= L'Z') || (L'a' <= path[0] && path[0] <= L'z'))
+		&& path[1] == L':' && path[2] == L'\\')
+		|| (path[0] == L'\\' && path[1] == L'\\')
 		 ){
 		ret = false;
 	}

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -930,7 +930,7 @@ CLayoutInt CCaret::Cursor_UPDOWN( CLayoutInt nMoveLines, bool bSelect )
 
 	// 現在のキャレットY座標 + nMoveLinesが正しいレイアウト行の範囲内に収まるように nMoveLinesを調整する。
 	if( nMoveLines > 0 ) { // 下移動。
-		const bool existsEOFOnlyLine = pLayoutMgr->GetBottomLayout() && pLayoutMgr->GetBottomLayout()->GetLayoutEol().IsValid()
+		const bool existsEOFOnlyLine = (pLayoutMgr->GetBottomLayout() && pLayoutMgr->GetBottomLayout()->GetLayoutEol().IsValid())
 			|| pLayoutMgr->GetLineCount() == 0;
 		const CLayoutInt maxLayoutLine = pLayoutMgr->GetLineCount() + (existsEOFOnlyLine ? 1 : 0 ) - 1;
 		// 移動先が EOFのみの行を含めたレイアウト行数未満になるように移動量を規正する。

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -1010,8 +1010,8 @@ void CEditView::OnSize( int cx, int cy )
 			default:
 				break;
 			}
-			if( bUpdateWidth  && nAreaWidthOld  != GetTextArea().GetAreaWidth() ||
-			    bUpdateHeight && nAreaHeightOld != GetTextArea().GetAreaHeight() ){
+			if( (bUpdateWidth  && nAreaWidthOld  != GetTextArea().GetAreaWidth()) ||
+			    (bUpdateHeight && nAreaHeightOld != GetTextArea().GetAreaHeight()) ){
 				InvalidateRect(NULL, FALSE);
 			}
 		}

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -388,8 +388,8 @@ BOOL CEditView::ChangeCurRegexp( bool bRedrawIfChanged )
 {
 	bool	bChangeState = false;
 
-	if( GetDllShareData().m_Common.m_sSearch.m_bInheritKeyOtherView
-			&& m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence
+	if( (GetDllShareData().m_Common.m_sSearch.m_bInheritKeyOtherView
+			&& m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence)
 		|| 0 == m_strCurSearchKey.size() ){
 		// 履歴の検索キーに更新
 		m_strCurSearchKey = GetDllShareData().m_sSearchKeywords.m_aSearchKeys[0];		// 検索文字列

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -628,7 +628,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 		}
 		return;
 	}
-	if( m_hdcCompatDC && NULL == m_hbmpCompatBMP
+	if( (m_hdcCompatDC && nullptr == m_hbmpCompatBMP)
 		 || m_nCompatBMPWidth < (pPs->rcPaint.right - pPs->rcPaint.left)
 		 || m_nCompatBMPHeight < (pPs->rcPaint.bottom - pPs->rcPaint.top) ){
 		RECT rect;

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -521,8 +521,8 @@ void CEditView::ScrollDraw(CLayoutInt nScrollRowNum, CLayoutInt nScrollColNum, c
 
 	// 背景は画面に対して固定か
 	bool bBackImgFixed = IsBkBitmap() &&
-		(0 != nScrollRowNum && !m_pTypeData->m_backImgScrollY ||
-		 0 != nScrollColNum && !m_pTypeData->m_backImgScrollX);
+		((0 != nScrollRowNum && !m_pTypeData->m_backImgScrollY) ||
+		 (0 != nScrollColNum && !m_pTypeData->m_backImgScrollX));
 	if( bBackImgFixed ){
 		CMyRect rcBody = area.GetAreaRect();
 		rcBody.left = 0; // 行番号も移動
@@ -550,7 +550,7 @@ void CEditView::ScrollDraw(CLayoutInt nScrollRowNum, CLayoutInt nScrollColNum, c
 
 		if( 0 < area.GetTopYohaku() &&
 		  IsBkBitmap() &&
-		  (0 != nScrollRowNum && m_pTypeData->m_backImgScrollY || 0 != nScrollColNum && m_pTypeData->m_backImgScrollX) ){
+		  ((0 != nScrollRowNum && m_pTypeData->m_backImgScrollY) || (0 != nScrollColNum && m_pTypeData->m_backImgScrollX)) ){
 			// Scrollのときにルーラー余白更新
 			CMyRect rcTopYohaku;
 			if( CTypeSupport(this, COLORIDX_TEXT).GetBackColor() == CTypeSupport(this, COLORIDX_GYOU).GetBackColor() ){

--- a/sakura_core/view/CViewSelect.cpp
+++ b/sakura_core/view/CViewSelect.cpp
@@ -594,8 +594,8 @@ void CViewSelect::GetSelectAreaLineFromRange(
 ) const
 {
 	const CEditView& view = *GetEditView();
-	if( nLineNum >= sRange.GetFrom().y && nLineNum <= sRange.GetTo().y ||
-		nLineNum >= sRange.GetTo().y && nLineNum <= sRange.GetFrom().y ){
+	if( (nLineNum >= sRange.GetFrom().y && nLineNum <= sRange.GetTo().y) ||
+		(nLineNum >= sRange.GetTo().y && nLineNum <= sRange.GetFrom().y) ){
 		CLayoutInt	nSelectFrom = sRange.GetFrom().GetX2();
 		CLayoutInt	nSelectTo   = sRange.GetTo().GetX2();
 		if( IsBoxSelecting() ){		/* 矩形範囲選択中 */

--- a/sakura_core/view/figures/CFigureStrategy.cpp
+++ b/sakura_core/view/figures/CFigureStrategy.cpp
@@ -49,14 +49,14 @@ FigureRenderType CFigure_Text::GetRenderType(SColorStrategyInfo* pInfo)
 		// 未合成で一度に描画しても安全そうな文字一覧(その範囲の文字が合成用文字ではないもの)
 		// 合成は未サポート
 		if((0x20 <= code && code <= 0x7f) // ASCII
-			|| 0x2E80 <= code && code <= 0x2FDF // 漢字部首
-			|| 0x3041 <= code && code <= 0x3096 // ひらがな
-			|| 0x30A1 <= code && code <= 0x30FA // カタカナ(合成用濁点などを除く)
-			|| 0x3400 <= code && code <= 0x4DBF // CJK統合漢字拡張A
-			|| 0x4E00 <= code && code <= 0x9FFF // CJK統合漢字
-			|| 0xF900 <= code && code <= 0xFAFF // CJK互換漢字
-			|| 0xFF01 <= code && code <= 0xFF5E // 全角ASCII
-			|| 0xFF61 <= code && code <= 0xFF9F // 半角カナ
+			|| (0x2E80 <= code && code <= 0x2FDF) // 漢字部首
+			|| (0x3041 <= code && code <= 0x3096) // ひらがな
+			|| (0x30A1 <= code && code <= 0x30FA) // カタカナ(合成用濁点などを除く)
+			|| (0x3400 <= code && code <= 0x4DBF) // CJK統合漢字拡張A
+			|| (0x4E00 <= code && code <= 0x9FFF) // CJK統合漢字
+			|| (0xF900 <= code && code <= 0xFAFF) // CJK互換漢字
+			|| (0xFF01 <= code && code <= 0xFF5E) // 全角ASCII
+			|| (0xFF61 <= code && code <= 0xFF9F) // 半角カナ
 		){
 			nType = 1;
 		}

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -2418,7 +2418,7 @@ void CEditWnd::InitMenu_Function(HMENU hMenu, EFunctionCode eFunc, const wchar_t
 	/* メニューラベルの作成 */
 	// カスタムメニュー
 	if (eFunc == F_MENU_RBUTTON
-	  || eFunc >= F_CUSTMENU_1 && eFunc <= F_CUSTMENU_24) {
+	  || (eFunc >= F_CUSTMENU_1 && eFunc <= F_CUSTMENU_24)) {
 		int j;
 		//	右クリックメニュー
 		if (eFunc == F_MENU_RBUTTON) {

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -580,8 +580,8 @@ void CMainToolBar::AcceptSharedSearchKey()
 			Combo_AddString( m_hwndSearchBox, GetDllShareData().m_sSearchKeywords.m_aSearchKeys[i] );
 		}
 		const wchar_t* pszText;
-		if( GetDllShareData().m_Common.m_sSearch.m_bInheritKeyOtherView
-			&& m_pOwner->GetActiveView().m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence
+		if( (GetDllShareData().m_Common.m_sSearch.m_bInheritKeyOtherView
+			&& m_pOwner->GetActiveView().m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence)
 				|| 0 == m_pOwner->GetActiveView().m_strCurSearchKey.size() ){
 			if( 0 < nSize ){
 				pszText = GetDllShareData().m_sSearchKeywords.m_aSearchKeys[0];


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Clang/LLVM build 時に "-Wlogical-op-parentheses" の warning が出力される。
CESI.h(181,45): warning : '&&' within '||' [-Wlogical-op-parentheses]
CESI.h(181,45): note: place parentheses around the '&&' expression to silence this warning
CESI.h(182,48): warning : '&&' within '||' [-Wlogical-op-parentheses]
CESI.h(182,48): note: place parentheses around the '&&' expression to silence this warning
CESI.h(194,45): warning : '&&' within '||' [-Wlogical-op-parentheses]
CESI.h(194,45): note: place parentheses around the '&&' expression to silence this warning
CESI.h(195,48): warning : '&&' within '||' [-Wlogical-op-parentheses]
CESI.h(195,48): note: place parentheses around the '&&' expression to silence this warning

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. warning がある部分に () を追加します。
2. NULL -> nullptr に変更します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容
1. 変更前後でasmが同じことを確認する。
2. Clang/LLVM build 時に "-Wlogical-op-parentheses" の warning が削減されていることを確認する。

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://clang.llvm.org/docs/DiagnosticsReference.html#wlogical-op-parentheses
