### PR TITLE
文字幅キャッシュでGetTextExtentPoint32を呼び出す箇所を排他する

### DIFF
--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -144,6 +144,7 @@ void CCharWidthCache::Init(const LOGFONT &lf, const LOGFONT &lfFull, HDC hdcOrg)
 		// KB145994
 		// tmAveCharWidth は不正確(半角か全角なのかも不明な値を返す)
 		SIZE sz;
+		std::lock_guard lock(m_mtx);
 		GetTextExtentPoint32(hdcArr[i], L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", 52, &sz);
 		sz.cx = (sz.cx / 26 + 1) / 2;
 		if( m_han_size.cx < sz.cx ){
@@ -173,6 +174,7 @@ bool CCharWidthCache::CalcHankakuByFont(wchar_t c)
 int CCharWidthCache::QueryPixelWidth(wchar_t c) const
 {
 	SIZE size={m_han_size.cx*2,0}; //関数が失敗したときのことを考え、全角幅で初期化しておく
+	std::lock_guard lock(m_mtx);
 	// 2014.12.21 コントロールコードの表示・NULが1px幅になるのをスペース幅にする
 	if (WCODE::IsControlCode(c)) {
 		GetTextExtentPoint32(SelectHDC(c),&c,1,&size);
@@ -200,6 +202,7 @@ int CCharWidthCache::CalcPxWidthByFont(wchar_t c) {
 int CCharWidthCache::CalcPxWidthByFont2(const wchar_t* pc2) const
 {
 	SIZE size={m_han_size.cx*2,0};
+	std::lock_guard lock(m_mtx);
 	// サロゲートは全角フォント
 	GetTextExtentPoint32(m_hdcFull?m_hdcFull:m_hdc,pc2,2,&size);
 	return t_max<int>(1,size.cx);

--- a/sakura_core/charset/charcode.h
+++ b/sakura_core/charset/charcode.h
@@ -29,6 +29,7 @@
 
 //2007.09.13 kobake 作成
 #include <array>
+#include <mutex>
 #include "parse/CWordParse.h"
 #include "util/std_macro.h"
 
@@ -270,6 +271,7 @@ private:
 	LOGFONT m_lf{};				// 2008/5/15 Uchi
 	LOGFONT m_lf2{};
 	SCharWidthCache* m_pCache = nullptr;
+	mutable std::mutex m_mtx;
 };
 
 // キャッシュの初期化関数群


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 不具合修正

## <!-- 必須 --> PR の背景

#2016 #2022 で報告されている不具合を修正します。

#1994 にて `CLayoutMgr::_DoLayout` の処理をマルチスレッド化した際の弊害で、`CLayoutMgr::_DoLayoutSub` を処理中に `CCharWidthCache` クラスが管理している文字幅のキャッシュに異常な値 (本来の文字幅と異なる値) が入ってしまうことがありました。

文字幅が異常となる原因は、文字幅を取得するGDI関数 `GetTextExtentPoint32` を、本来排他制御が必要な「同一のデバイスコンテキストハンドル」かつ「複数のスレッドから同時に呼び出す」状況で排他制御をしていなかったためです。

一度、文字幅キャッシュに格納された値は残り続けるため、その後の表示処理で同キャッシュを参照した時 (CTextMetrics::GenerateDxArray など) に正しい文字幅が取得できず、報告されている不具合現象が発生しています。

## <!-- 必須 --> 仕様・動作説明

`CCharWidthCache` クラスについて、同一のHDCを入力として `GetTextExtentPoint32` を呼び出す可能性のある箇所を排他制御します。

## <!-- わかる範囲で --> PR の影響範囲

特にありません。

## <!-- 必須 --> テスト内容

全角半角交じりかつ1000行以上のテキストファイル (※1) を読み込んだ時、文字同士が重なったり半角文字の字間が間延びして表示 (※2 赤枠) されることがないこと。
※1 https://github.com/user-attachments/files/19430008/shayo.txt
※2 ![Image](https://github.com/user-attachments/assets/0b59a087-0c8d-480d-baf6-59eea9c54a53)

## <!-- なければ省略可 --> 関連 issue, PR

* 本PRで解消する (はずの) Issue
  * #2016
  * #2022
* 問題の原因を入れ込んだ対応
  * #1994
