### PR TITLE
サブクラス コールバック削除呼び出し

### DIFF
--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -784,7 +784,7 @@ static int DeletePreviousWord(wchar_t* text, int length, int curPos)
 	return prevWordStartPos;
 }
 
-LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+LRESULT CALLBACK CDialog::SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 	                         UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
 	HWND hwndCombo = GetParent(hwnd);
@@ -822,6 +822,11 @@ LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
 			return 0;
 		}
 		break;
+	case WM_DESTROY:
+		::RemoveWindowSubclass(hwnd, &SubEditProc, uIdSubclass);
+		return 0;
+	default:
+		break;
 	}
 	return ::DefSubclassProc(hwnd, uMsg, wParam, lParam);
 }
@@ -833,5 +838,5 @@ void CDialog::SetComboBoxDeleter(HWND hwndCtl, CRecent* pRecent)
 	COMBOBOXINFO info = { sizeof(COMBOBOXINFO) };
 	if (!::GetComboBoxInfo(hwndCtl, &info))
 		return;
-	::SetWindowSubclass(info.hwndItem, SubEditProc, 0, (DWORD_PTR)pRecent);
+	::SetWindowSubclass(info.hwndItem, &SubEditProc, 0, (DWORD_PTR)pRecent);
 }

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -121,6 +121,7 @@ public:
 	void ResizeItem( HWND hTarget, const POINT& ptDlgDefalut, const POINT& ptDlgNew, const RECT& rcItemDefault, EAnchorStyle anchor, bool bUpdate = true);
 	void GetItemClientRect( int wID, RECT& rc );
 
+	static LRESULT CALLBACK SubEditProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
 	//! @brief コンボボックスに履歴削除・単語削除の機能を追加する
 	//!
 	//! @param hwndCtl コンボボックスのハンドル。CBS_DROPDOWNLISTスタイルのコンボボックスには対応していません。


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
SetComboBoxDeleter() でサブクラス コールバックを登録(SetWindowSubclass)しているが、削除する処理がない。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
WM_DESTROYを受け取ったときに、サブクラス コールバックを削除(RemoveWindowSubclass)します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
SetComboBoxDeleter()を使用する処理をメニューから選択して、WM_DESTROYを受け取ったときにサブクラス コールバックを削除することを確認する。
1. 検索 - 検索 で RemoveWindowSubclass() 1回呼び出し
2. 検索 - Grep  で RemoveWindowSubclass() 5回呼び出し
3. ツール - 外部コマンド実行 で RemoveWindowSubclass() 2回呼び出し

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1463

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://learn.microsoft.com/ja-jp/windows/win32/controls/subclassing-overview
