### PR TITLE
bregonig.dll ロード/利用に失敗した時のエラーメッセージの統一化

### DIFF
--- a/sakura_core/sakura_rc.rc2
+++ b/sakura_core/sakura_rc.rc2
@@ -147,16 +147,8 @@ IDI_ICON_STD            ICON         "../resource/icon_std.ico"
 STRINGTABLE
 BEGIN
 	// CBregexp.cpp
-#if defined(_WIN64)
-	STR_BREGONIG_LOAD				"bregonig.dll のロードに失敗しました。\r\n正規表現を利用するには Unicode/x64 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"
-#else
 	STR_BREGONIG_LOAD				"bregonig.dll のロードに失敗しました。\r\n正規表現を利用するには Unicode 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"
-#endif
-#if defined(_WIN64)
-	STR_BREGONIG_INIT				"bregonig.dll の利用に失敗しました。\r\n正規表現を利用するには Unicode/x64 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"
-#else
 	STR_BREGONIG_INIT				"bregonig.dll の利用に失敗しました。\r\n正規表現を利用するには Unicode 版の bregonig.dll が必要です。\r\n入手方法はヘルプを参照してください。"
-#endif
 	STR_GSTR_APPNAME				_GSTR_APPNAME
 
 	// Select Language

--- a/sakura_lang_en_US/sakura_lang_rc.rc2
+++ b/sakura_lang_en_US/sakura_lang_rc.rc2
@@ -158,15 +158,7 @@ BEGIN
 		//  http://msdn.microsoft.com/en-us/library/dd318693.aspx
 
 	// CBregexp.cpp
-#if defined(_WIN64)
-	STR_BREGONIG_LOAD				"failed to load the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde/x64 ver) to work.\r\nPlease refer to the help for assistance."
-#else
 	STR_BREGONIG_LOAD				"failed to load the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde ver) to work.\r\nPlease refer to the help for assistance."
-#endif
-#if defined(_WIN64)
-	STR_BREGONIG_INIT				"failed to init the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde/x64 ver) to work.\r\nPlease refer to the help for assistance."
-#else
 	STR_BREGONIG_INIT				"failed to init the bregonig.dll.\r\nRegex relies upon bregonig.dll(Uniocde ver) to work.\r\nPlease refer to the help for assistance."
-#endif
 	STR_GSTR_APPNAME				_GSTR_APPNAME
 END

--- a/sakura_lang_zh_CN/sakura_lang_rc.rc2
+++ b/sakura_lang_zh_CN/sakura_lang_rc.rc2
@@ -158,15 +158,7 @@ BEGIN
 		//  http://msdn.microsoft.com/en-us/library/dd318693.aspx
 
 	// CBregexp.cpp
-#if defined(_WIN64)
-	STR_BREGONIG_LOAD "无法加载 bregonig.dll\r\n正则表达式功能需要此文件(Unicode/64位版本)\r\n请参考帮助文档获取更多信息"
-#else
-	STR_BREGONIG_LOAD "无法加载 bregonig.dll\r\n正则表达式功能需要此文件(Unicode/64位版本)\r\n请参考帮助文档获取更多信息"
-#endif
-#if defined(_WIN64)
-	STR_BREGONIG_INIT "初始化 bregonig.dll 失败\r\n正则表达式功能需要此文件(Unicode/64位版本)\r\n请参考帮助文档获取更多信息"
-#else
-	STR_BREGONIG_INIT "初始化 bregonig.dll 失败\r\n正则表达式功能需要此文件(Unicode/64位版本)\r\n请参考帮助文档获取更多信息"
-#endif
+	STR_BREGONIG_LOAD "无法加载 bregonig.dll\r\n正则表达式功能需要此文件(Unicode版本)\r\n请参考帮助文档获取更多信息"
+	STR_BREGONIG_INIT "初始化 bregonig.dll 失败\r\n正则表达式功能需要此文件(Unicode版本)\r\n请参考帮助文档获取更多信息"
 	STR_GSTR_APPNAME				_GSTR_APPNAME
 END


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

このPRでは `bregonig.dll` のロードや利用に失敗した時のエラーメッセージが x86(Win32) と x64 で別々になっているのを統一する変更を行います。

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- その他

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

ターゲットによってエラーメッセージが分かれていると新規ターゲットを追加する際の手間が増えてしまいます。

`bregonig.dll` はインストーラーに同梱されている為、エラーメッセージで区別する必要は無いと判断しました。

https://github.com/sakura-editor/sakura/pull/2046#discussion_r2062781719

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

https://github.com/sakura-editor/sakura/pull/2046#discussion_r2062781719

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
