### PR TITLE
標準C++ヘッダーをプリコンパイル済みヘッダーでまとめてインクルードする

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -22,6 +22,7 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
+
 // stdafx.h : 標準のシステム インクルード ファイル、
 //				または参照回数が多く、かつあまり変更されない
 //				プロジェクト専用のインクルード ファイルを記述します。
@@ -42,6 +43,47 @@
 
 // MS Cランタイムの非セキュア関数の使用を容認します
 #define _CRT_SECURE_NO_WARNINGS
+
+// 標準C++ヘッダー（追加するときは昇順で。）
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <climits>
+#include <clocale>
+#include <cmath>
+#include <condition_variable>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <cwchar>
+#include <deque>
+#include <exception>
+#include <filesystem>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <numeric>
+#include <optional>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #ifdef _MSC_VER
 
@@ -73,33 +115,22 @@
 #include <time.h>
 #include <wchar.h>
 
-#include <algorithm>
-#include <array>
-#include <exception>
-#include <functional>
-#include <initializer_list>
-#include <list>
-#include <map>
-#include <unordered_map>
-#include <memory>
-#include <optional>
-#include <string>
-#include <string_view>
-#include <utility>
-#include <vector>
-#include <cstdint>
-
+// Windowsヘッダー(他のSDKヘッダーとは別格。)
 #include <Windows.h>
+
+// windowsx.h (他のSDKヘッダーとは別格。)
 #include <windowsx.h>
+
+// その他のWindows SDK ヘッダー（ファイル名は最新に合わせる。追加するときは昇順で。）
 #include <CommCtrl.h>
 #include <HtmlHelp.h>
 #include <imm.h>
-#include <ObjIdl.h>
+#include <oaidl.h>
 #include <shellapi.h>
 #include <ShlObj.h>
-#include <wrl.h>
-#include <uxtheme.h>
+#include <Uxtheme.h>
 #include <vsstyle.h>
+#include <wrl.h>
 
 // Windows SDKのマクロ定数「NULL」を訂正する。
 // マクロ定数「NULL」は、省略可能なポインタ型パラメータに「省略」を指定するために使う。


### PR DESCRIPTION
標準C++を使うたびにインクルードが必要になる状況を改善する。
ついでに、Windows SDKヘッダーのインクルード方針を追記する。

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
* https://github.com/sakura-editor/sakura/pull/2038#discussion_r2032185012
* #2040

サクラエディタはもともと C言語 で書かれたアプリです。

既に C++化されている部分も多いので誤解されがちですが、
実装でC++を使うには基本的に「標準C++ヘッダー」のインクルードを追加する必要があります。

この現状はたいへんメンドクサイので改善したいです。

解決策： プリコンパイル済みヘッダーで主要な「標準C++ヘッダー」のインクルードを済ませてしまう。

対応により、機能実装時にいちいち「標準C++ヘッダー」をインクルードする必要がなくなり、C++への移行をスムーズに進められるようになります。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
* アプリで利用している標準C++のインクルードを StdAfx.h に追加します。
* 既存の標準C++インクルードの位置が「見方によっては不適切」なのを修正します。（`#inlclude`はファイル先頭に書くべきですが、`#pragma comment` の後になっています。）
* Windows SDKヘッダーの一部ファイルに case誤り があるのを修正します。
* Windows SDKヘッダーのインクルードについてルールを明確にします。

`StdAfx.h` には様々な課題がありますが、触れてない課題については一旦放置します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
プログラム全体に影響しますが、実害はないと考えられます。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
ビルド成否に影響する変更なので、CIビルドが通ったらOKと判断してよいはずです。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
* #2040


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
