### PR TITLE
modernize-use-nullptr 警告修正 (clang-tidy)

### DIFF
--- a/sakura_core/CBackupAgent.cpp
+++ b/sakura_core/CBackupAgent.cpp
@@ -473,7 +473,7 @@ bool CBackupAgent::FormatBackUpPath(
 				//	Jan. 9, 2006 genta VC6対策
 				int idx;
 				for( idx=0; idx<10; ++idx ){
-					folders[idx] = 0;
+					folders[idx] = nullptr;
 				}
 				folders[0] = szFname;
 

--- a/sakura_core/CProfile.cpp
+++ b/sakura_core/CProfile.cpp
@@ -181,10 +181,10 @@ bool CProfile::ReadProfileRes( const WCHAR* pName, const WCHAR* pType, std::vect
 	CNativeW cmLineW;
 	m_strProfileName = L"-Res-";
 
-	if (( hRsrc = ::FindResource( 0, pName, pType )) != NULL
-	 && ( hGlobal = ::LoadResource( 0, hRsrc )) != NULL
+	if (( hRsrc = ::FindResource( nullptr, pName, pType )) != nullptr
+	 && ( hGlobal = ::LoadResource( nullptr, hRsrc )) != nullptr
 	 && ( psMMres = (char *)::LockResource(hGlobal)) != NULL
-	 && ( nSize = (size_t)::SizeofResource( 0, hRsrc )) != 0) {
+	 && ( nSize = (size_t)::SizeofResource( nullptr, hRsrc )) != 0) {
 		p    = psMMres;
 		if (nSize >= sizeof(UTF8_BOM) && memcmp( p, UTF8_BOM, sizeof(UTF8_BOM) )==0) {
 			// Skip BOM

--- a/sakura_core/_main/CControlProcess.h
+++ b/sakura_core/_main/CControlProcess.h
@@ -42,7 +42,7 @@ public:
 		m_hMutex( NULL ),
 		m_hMutexCP( NULL ),
 		m_hEventCPInitialized( NULL ),
-		m_pcTray( 0 )
+		m_pcTray( nullptr )
 	{}
 
 	~CControlProcess();

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -1291,7 +1291,7 @@ bool CControlTray::OpenNewEditor(
 		for( i = 0; i < 200; i++ ){
 			MSG msg;
 			DWORD dwExitCode;
-			if( ::PeekMessage( &msg, 0, MYWM_FIRST_IDLE, MYWM_FIRST_IDLE, PM_REMOVE ) ){
+			if( ::PeekMessage( &msg, nullptr, MYWM_FIRST_IDLE, MYWM_FIRST_IDLE, PM_REMOVE ) ){
 				if( msg.message == WM_QUIT ){	// 指定範囲外でも WM_QUIT は取り出される
 					::PostQuitMessage( msg.wParam );
 					break;
@@ -1696,7 +1696,7 @@ int	CControlTray::CreatePopUpMenu_R( void )
 */
 void CControlTray::OnDestroy()
 {
-	HWND hwndExitingDlg = 0;
+	HWND hwndExitingDlg = nullptr;
 
 	if (GetTrayHwnd() == NULL)
 		return;	// 既に破棄されている

--- a/sakura_core/_main/CProcess.cpp
+++ b/sakura_core/_main/CProcess.cpp
@@ -36,7 +36,7 @@ CProcess::CProcess(
 	LPCWSTR		lpCmdLine		//!< pointer to command line
 )
 : m_hInstance( hInstance )
-, m_hWnd( 0 )
+, m_hWnd( nullptr )
 {
 	// アプリ名をリソースから読み込む
 	m_strAppName = LS(STR_GSTR_APPNAME);

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -51,12 +51,12 @@ CProcess* CProcessFactory::Create( HINSTANCE hInstance, LPCWSTR lpCmdLine )
 	CSelectLang::InitializeLanguageEnvironment();
 
 	if( !ProfileSelect( hInstance, lpCmdLine ) ){
-		return 0;
+		return nullptr;
 	}
 
-	CProcess* process = 0;
+	CProcess* process = nullptr;
 	if( !IsValidVersion() ){
-		return 0;
+		return nullptr;
 	}
 
 	// プロセスクラスを生成する

--- a/sakura_core/_main/WinMain.cpp
+++ b/sakura_core/_main/WinMain.cpp
@@ -76,14 +76,14 @@ int WINAPI wWinMain(
 
 	//プロセスの生成とメッセージループ
 	CProcessFactory aFactory;
-	CProcess *process = 0;
+	CProcess *process = nullptr;
 	try{
 		process = aFactory.Create( hInstance, lpCmdLine );
 		MY_TRACETIME( cRunningTimer, L"ProcessObject Created" );
 	}
 	catch(...){
 	}
-	if( 0 != process ){
+	if( nullptr != process ){
 		process->Run();
 		delete process;
 	}

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -158,7 +158,7 @@ void CCharWidthCache::Init(const LOGFONT &lf, const LOGFONT &lfFull, HDC hdcOrg)
 
 void CCharWidthCache::Clear()
 {
-	assert(m_pCache!=0);
+	assert(m_pCache!=nullptr);
 	// キャッシュのクリア
 	memcpy(m_pCache->m_lfFaceName.data(), m_lf.lfFaceName, sizeof(m_lf.lfFaceName));
 	memcpy(m_pCache->m_lfFaceName2.data(), m_lf2.lfFaceName, sizeof(m_lf2.lfFaceName));

--- a/sakura_core/cmd/CViewCommander_Diff.cpp
+++ b/sakura_core/cmd/CViewCommander_Diff.cpp
@@ -188,7 +188,7 @@ void CViewCommander::Command_COMPARE( void )
 		int width = (rcDesktop.right - rcDesktop.left ) / 2;
 		for( i = 1; i >= 0; i-- ){
 			::SetWindowPos(
-				phwndArr[i], 0,
+				phwndArr[i], nullptr,
 				width * i + rcDesktop.left, rcDesktop.top, // Oct. 18, 2003 genta タスクバーが左にある場合を考慮
 				width, rcDesktop.bottom - rcDesktop.top,
 				SWP_NOOWNERZORDER | SWP_NOZORDER

--- a/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
@@ -198,7 +198,7 @@ void CViewCommander::Command_INDENT( const wchar_t* const pData, const CLogicInt
 					} sortedKetas[] = {
 						{ rcSel.GetFrom().x, &nIdxFrom, &xLayoutFrom },
 						{ rcSel.GetTo().x, &nIdxTo, &xLayoutTo },
-						{ CLayoutInt(-1), 0, 0 }
+						{ CLayoutInt(-1), nullptr, nullptr }
 					};
 					CMemoryIterator it = GetDocument()->m_cLayoutMgr.CreateCMemoryIterator(pcLayout);
 					for( int i = 0; 0 <= sortedKetas[i].keta; ++i ) {

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -465,12 +465,12 @@ void CViewCommander::Command_BROWSE( void )
     info.lpParameters = NULL;
     info.lpDirectory = NULL;
     info.nShow = SW_SHOWNORMAL;
-    info.hInstApp = 0;
+    info.hInstApp = nullptr;
     info.lpIDList = NULL;
     info.lpClass = NULL;
-    info.hkeyClass = 0; 
+    info.hkeyClass = nullptr;
     info.dwHotKey = 0;
-    info.hIcon =0;
+    info.hIcon = nullptr;
 
 	::ShellExecuteEx(&info);
 

--- a/sakura_core/cmd/CViewCommander_Search.cpp
+++ b/sakura_core/cmd/CViewCommander_Search.cpp
@@ -852,7 +852,7 @@ void CViewCommander::Command_REPLACE_ALL()
 
 	CLogicRange cSelectLogic;	// 置換文字列GetSelect()のLogic単位版
 	/* 次を検索 */
-	Command_SEARCH_NEXT( true, bDisplayUpdate, true, 0, NULL, bFastMode ? &cSelectLogic : NULL );
+	Command_SEARCH_NEXT( true, bDisplayUpdate, true, nullptr, nullptr, bFastMode ? &cSelectLogic : nullptr );
 	// To Here 2001.12.03 hor
 
 	//<< 2002/03/26 Azumaiya
@@ -1119,7 +1119,7 @@ void CViewCommander::Command_REPLACE_ALL()
 						ptNewFrom.y + CLayoutInt(firstLeft < sRangeA.GetFrom().x ? 0 : 1)
 					));
 					// 2004.05.30 Moca 現在の検索文字列を使って検索する
-					Command_SEARCH_NEXT( false, bDisplayUpdate, true, 0, NULL );
+					Command_SEARCH_NEXT( false, bDisplayUpdate, true, nullptr, nullptr );
 					continue;
 				}
 			}
@@ -1431,7 +1431,7 @@ void CViewCommander::Command_REPLACE_ALL()
 
 		/* 次を検索 */
 		// 2004.05.30 Moca 現在の検索文字列を使って検索する
-		Command_SEARCH_NEXT( false, bDisplayUpdate, true, 0, NULL, bFastMode ? &cSelectLogic : NULL );
+		Command_SEARCH_NEXT( false, bDisplayUpdate, true, nullptr, nullptr, bFastMode ? &cSelectLogic : nullptr );
 	}
 
 	if( bFastMode ){

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -553,7 +553,7 @@ bool CViewCommander::Command_TagsMake( void )
 	sa.nLength              = sizeof(sa);
 	sa.bInheritHandle       = TRUE;
 	sa.lpSecurityDescriptor = NULL;
-	hStdOutRead = hStdOutWrite = 0;
+	hStdOutRead = hStdOutWrite = nullptr;
 	if( CreatePipe( &hStdOutRead, &hStdOutWrite, &sa, 1000 ) == FALSE )
 	{
 		//エラー

--- a/sakura_core/cmd/CViewCommander_Window.cpp
+++ b/sakura_core/cmd/CViewCommander_Window.cpp
@@ -308,7 +308,7 @@ void CViewCommander::Command_TILE_V( void )
 			//	Jul. 21, 2002 genta
 			::ShowWindow( phwndArr[i], SW_RESTORE );
 			::SetWindowPos(
-				phwndArr[i], 0,
+				phwndArr[i], nullptr,
 				rcDesktop.left, rcDesktop.top + height * i, //Mar. 19, 2004 crayonzen 上端調整
 				rcDesktop.right - rcDesktop.left, height,
 				SWP_NOOWNERZORDER | SWP_NOZORDER
@@ -367,7 +367,7 @@ void CViewCommander::Command_TILE_H( void )
 			//	Jul. 21, 2002 genta
 			::ShowWindow( phwndArr[i], SW_RESTORE );
 			::SetWindowPos(
-				phwndArr[i], 0,
+				phwndArr[i], nullptr,
 				width * i + rcDesktop.left, rcDesktop.top, // Oct. 18, 2003 genta タスクバーが左にある場合を考慮
 				width, rcDesktop.bottom - rcDesktop.top,
 				SWP_NOOWNERZORDER | SWP_NOZORDER
@@ -569,7 +569,7 @@ void CViewCommander::Command_MAXIMIZE_V( void )
 	//	May 01, 2004 genta マルチモニタ対応
 	::GetMonitorWorkRect( hwndFrame, &rcDesktop );
 	::SetWindowPos(
-		hwndFrame, 0,
+		hwndFrame, nullptr,
 		rcOrg.left, rcDesktop.top,
 		rcOrg.right - rcOrg.left, rcDesktop.bottom - rcDesktop.top,
 		SWP_NOOWNERZORDER | SWP_NOZORDER
@@ -590,7 +590,7 @@ void CViewCommander::Command_MAXIMIZE_H( void )
 	//	May 01, 2004 genta マルチモニタ対応
 	::GetMonitorWorkRect( hwndFrame, &rcDesktop );
 	::SetWindowPos(
-		hwndFrame, 0,
+		hwndFrame, nullptr,
 		rcDesktop.left, rcOrg.top,
 		rcDesktop.right - rcDesktop.left, rcOrg.bottom - rcOrg.top,
 		SWP_NOOWNERZORDER | SWP_NOZORDER

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -231,7 +231,7 @@ CDlgFavorite::CDlgFavorite()
 		assert( i < _countof(m_aFavoriteInfo) );
 	}
 	for( i = 0; i < FAVORITE_INFO_MAX; i++ ){
-		m_aListViewInfo[i].hListView   = 0;
+		m_aListViewInfo[i].hListView   = nullptr;
 		m_aListViewInfo[i].nSortColumn = -1;
 		m_aListViewInfo[i].bSortAscending = false;
 	}

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -250,8 +250,8 @@ UINT_PTR CALLBACK OFNHookProc(
 			po.x = rc.left;
 			po.y = rc.top;
 			::ScreenToClient( hdlg, &po );
-			::SetWindowPos( pData->m_hwndComboMRU, 0, 0, 0, nWidth - po.x - nRightMargin, rc.bottom - rc.top, SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER );
-			::SetWindowPos( pData->m_hwndComboOPENFOLDER, 0, 0, 0, nWidth - po.x - nRightMargin, rc.bottom - rc.top, SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER );
+			::SetWindowPos( pData->m_hwndComboMRU, nullptr, 0, 0, nWidth - po.x - nRightMargin, rc.bottom - rc.top, SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER );
+			::SetWindowPos( pData->m_hwndComboOPENFOLDER, nullptr, 0, 0, nWidth - po.x - nRightMargin, rc.bottom - rc.top, SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER );
 			return 0;
 		}
 	case WM_INITDIALOG:
@@ -1162,7 +1162,7 @@ void CDlgOpenFile_CommonFileDialog::InitLayout( HWND hwndOpenDlg, HWND hwndDlg, 
 			po.x = ( rc.right < rcBase.left )? nLeft: rc.left + nShift;
 			po.y = rc.top;
 			::ScreenToClient( hwndDlg, &po );
-			::SetWindowPos( hwndCtrl, 0, po.x, po.y, 0, 0, SWP_NOSIZE | SWP_NOOWNERZORDER | SWP_NOZORDER );
+			::SetWindowPos( hwndCtrl, nullptr, po.x, po.y, 0, 0, SWP_NOSIZE | SWP_NOOWNERZORDER | SWP_NOZORDER );
 		}
 		hwndCtrl = ::GetWindow( hwndCtrl, GW_HWNDNEXT );
 	}
@@ -1179,12 +1179,12 @@ void CDlgOpenFile_CommonFileDialog::InitLayout( HWND hwndOpenDlg, HWND hwndDlg, 
 	// 標準コントロールプレースフォルダーの幅を変更する
 	hwndCtrl = ::GetDlgItem( hwndDlg, stc32 );
 	::GetWindowRect( hwndCtrl, &rc );
-	::SetWindowPos( hwndCtrl, 0, 0, 0, nWidth, rc.bottom - rc.top, SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER );
+	::SetWindowPos( hwndCtrl, nullptr, 0, 0, nWidth, rc.bottom - rc.top, SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER );
 
 	// 子ダイアログの幅を変更する
 	// ※この SetWindowPos() の中で WM_SIZE が発生する
 	::GetWindowRect( hwndDlg, &rc );
-	::SetWindowPos( hwndDlg, 0, 0, 0, nWidth, rc.bottom - rc.top, SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER );
+	::SetWindowPos( hwndDlg, nullptr, 0, 0, nWidth, rc.bottom - rc.top, SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER );
 }
 
 /*! リトライ機能付き GetOpenFileName

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -112,7 +112,7 @@ struct CDlgOpenFile_CommonItemDialog final
 		static const QITAB qit[] = {
 			QITABENT(CDlgOpenFile_CommonItemDialog, IFileDialogEvents),
 			QITABENT(CDlgOpenFile_CommonItemDialog, IFileDialogControlEvents),
-			{ 0 },
+			{ },
 		};
 		return QISearch(this, qit, iid, ppvObject);
 	}

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -854,7 +854,7 @@ static EFunctionCode GetFunctionStrToFunctionCode(const WCHAR* pszFuncName)
 	  && (pszFuncName[1] == L'\0' || WCODE::Is09(pszFuncName[1]))) {
 		n = (EFunctionCode)_wtol(pszFuncName);
 	}else {
-		n = CSMacroMgr::GetFuncInfoByName(0, pszFuncName, NULL);
+		n = CSMacroMgr::GetFuncInfoByName(nullptr, pszFuncName, nullptr);
 	}
 	if (n == F_INVALID) {
 		n = F_DEFAULT;
@@ -1183,7 +1183,7 @@ void CShareData_IO::IO_KeyBind( CDataProfile& cProfile, CommonSetting_KeyBind& s
 						//@@@ 2002.2.2 YAZAKI マクロをCSMacroMgrに統一
 						// 2010.06.30 Moca 日本語名を取得しないように
 						WCHAR	*p = CSMacroMgr::GetFuncInfoByID(
-							0,
+							nullptr,
 							keydata.m_nFuncCodeArr[j],
 							szFuncName,
 							NULL

--- a/sakura_core/extmodule/CBregexpDll2.cpp
+++ b/sakura_core/extmodule/CBregexpDll2.cpp
@@ -66,7 +66,7 @@ bool CBregexpDll2::InitDllImp()
 		{ &m_BRegexpVersion,	"BRegexpVersionW" },
 		{ &m_BMatchEx,			"BMatchExW" },
 		{ &m_BSubstEx,			"BSubstExW" },
-		{ NULL, 0 }
+		{ nullptr, nullptr }
 	};
 	
 	if( ! RegisterEntries( table )){

--- a/sakura_core/extmodule/CHtmlHelp.cpp
+++ b/sakura_core/extmodule/CHtmlHelp.cpp
@@ -52,7 +52,7 @@ bool CHtmlHelp::InitDllImp()
 	//DLL内関数名リスト
 	const ImportTable table[] = {
 		{ (void*)&m_pfnHtmlHelp,		"HtmlHelpW" },
-		{ NULL, 0 }
+		{ nullptr, nullptr }
 	};
 
 	if (!RegisterEntries(table)) {

--- a/sakura_core/extmodule/CIcu4cI18n.cpp
+++ b/sakura_core/extmodule/CIcu4cI18n.cpp
@@ -58,7 +58,7 @@ bool CIcu4cI18n::InitDllImp()
 		{ &_ucsdet_detect,		"ucsdet_detect_66" },	//バージョンは固定
 		{ &_ucsdet_getName,		"ucsdet_getName_66" },	//バージョンは固定
 		{ &_ucsdet_close,		"ucsdet_close_66" },	//バージョンは固定
-		{ NULL, 0 }
+		{ nullptr, nullptr }
 	};
 	return RegisterEntries(table);
 }

--- a/sakura_core/extmodule/CMigemo.cpp
+++ b/sakura_core/extmodule/CMigemo.cpp
@@ -58,7 +58,7 @@ bool CMigemo::InitDllImp()
 		{ &m_migemo_setproc_int2char  ,"migemo_setproc_int2char"  },
 		{ &m_migemo_load              ,"migemo_load"              },
 		{ &m_migemo_is_enable         ,"migemo_is_enable"         },
-		{ NULL, 0                                                 }
+		{ nullptr, nullptr                                        }
 	};
 	
 	if( ! RegisterEntries(table) ){

--- a/sakura_core/extmodule/CUchardet.cpp
+++ b/sakura_core/extmodule/CUchardet.cpp
@@ -51,7 +51,7 @@ bool CUchardet::InitDllImp()
 		{ &_uchardet_data_end,		"uchardet_data_end" },
 		{ &_uchardet_reset,			"uchardet_reset" },
 		{ &_uchardet_get_charset,	"uchardet_get_charset" },
-		{ nullptr, 0 }
+		{ nullptr, nullptr }
 	};
 	return RegisterEntries(table);
 }

--- a/sakura_core/macro/CIfObj.cpp
+++ b/sakura_core/macro/CIfObj.cpp
@@ -261,7 +261,7 @@ HRESULT STDMETHODCALLTYPE CIfObjTypeInfo::GetNames(
 
 //コンストラクタ
 CIfObj::CIfObj(const wchar_t* name, bool isGlobal)
-: ImplementsIUnknown<IDispatch>(), m_sName(name), m_isGlobal(isGlobal), m_Owner(0), m_Methods(), m_TypeInfo(NULL)
+: ImplementsIUnknown<IDispatch>(), m_sName(name), m_isGlobal(isGlobal), m_Owner(nullptr), m_Methods(), m_TypeInfo(nullptr)
 { 
 };
 

--- a/sakura_core/macro/CPPA.cpp
+++ b/sakura_core/macro/CPPA.cpp
@@ -159,7 +159,7 @@ bool CPPA::InitDllImp()
 		{ &m_fnSetFinishProc, "SetFinishProc"}, // 2003.06.23 Moca
 #endif
 
-		{ NULL, 0 }
+		{ nullptr, nullptr }
 	};
 
 	//	Apr. 15, 2002 genta

--- a/sakura_core/macro/CWSH.cpp
+++ b/sakura_core/macro/CWSH.cpp
@@ -255,7 +255,7 @@ CWSHClient::CWSHClient(const wchar_t *AEngine, ScriptErrorHandler AErrorHandler,
 			ClassID = CLSID_JSScript9;
 		}
 #endif
-		if(CoCreateInstance(ClassID, 0, CLSCTX_INPROC_SERVER, IID_IActiveScript, reinterpret_cast<void **>(&m_Engine)) != S_OK)
+		if(CoCreateInstance(ClassID, nullptr, CLSCTX_INPROC_SERVER, IID_IActiveScript, reinterpret_cast<void **>(&m_Engine)) != S_OK)
 			Error(LS(STR_ERR_CWSH02));
 		else
 		{
@@ -395,7 +395,7 @@ bool CWSHClient::Execute(const wchar_t *AScript)
 					Error(LS(STR_ERR_CWSH07));
 				else
 				{
-					HRESULT hr = Parser->ParseScriptText(AScript, 0, 0, 0, 0, 0, SCRIPTTEXT_ISVISIBLE, 0, 0);
+					HRESULT hr = Parser->ParseScriptText(AScript, nullptr, nullptr, nullptr, 0, 0, SCRIPTTEXT_ISVISIBLE, nullptr, nullptr);
 					if (hr == SCRIPT_E_REPORTED) {
 					/*
 						IActiveScriptSite->OnScriptErrorに通知済み。

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -198,7 +198,7 @@ static EOutlineType GetOutlineTypeRedraw(int outlineType)
 
 LPDLGTEMPLATE CDlgFuncList::m_pDlgTemplate = NULL;
 DWORD CDlgFuncList::m_dwDlgTmpSize = 0;
-HINSTANCE CDlgFuncList::m_lastRcInstance = 0;
+HINSTANCE CDlgFuncList::m_lastRcInstance = nullptr;
 
 CDlgFuncList::CDlgFuncList() : CDialog(true)
 {

--- a/sakura_core/plugin/CDllPlugin.cpp
+++ b/sakura_core/plugin/CDllPlugin.cpp
@@ -87,7 +87,7 @@ bool CDllPlugin::InvokePlug( CEditView* view, CPlug& plug_raw, CWSHIfObj::List& 
 		//DLL関数の取得
 		ImportTable imp[2] = {
 			{ &plug.m_handler, to_achar( plug.m_sHandler.c_str() ) },
-			{ NULL, 0 }
+			{ nullptr, nullptr }
 		};
 		if( ! RegisterEntries( imp ) ){
 //			DWORD err = GetLastError();

--- a/sakura_core/types/CType_Erlang.cpp
+++ b/sakura_core/types/CType_Erlang.cpp
@@ -87,7 +87,7 @@ private:
 
 	bool IS_SPACE( wchar_t wc )
 	{
-		return ( wcschr( L" \t\r\n", wc ) != 0 );
+		return ( wcschr( L" \t\r\n", wc ) != nullptr );
 	}
 	
 	void build_arity(int);

--- a/sakura_core/types/CType_Tex.cpp
+++ b/sakura_core/types/CType_Tex.cpp
@@ -234,10 +234,10 @@ public:
 				break;
 			}
 
-			const wchar_t *pTag      = 0, // \section{dddd} または \section*{dddd} の、s を指すポインタ。
-			              *pTagEnd   = 0, // \section{dddd} または \section*{dddd} の、{ を指すポインタ。
-			              *pTitle    = 0, // \section{dddd} または \section*{dddd} の、先頭の d を指すポインタ。
-			              *pTitleEnd = 0; // \section{dddd} または \section*{dddd} の、} を指すポインタ。
+			const wchar_t *pTag      = nullptr; // \section{dddd} または \section*{dddd} の、s を指すポインタ。
+			const wchar_t *pTagEnd   = nullptr; // \section{dddd} または \section*{dddd} の、{ を指すポインタ。
+			const wchar_t *pTitle    = nullptr; // \section{dddd} または \section*{dddd} の、先頭の d を指すポインタ。
+			const wchar_t *pTitleEnd = nullptr; // \section{dddd} または \section*{dddd} の、} を指すポインタ。
 
 			const wchar_t Meta[] = { L'\\', L'%' };
 			const wchar_t* p = pLine;

--- a/sakura_core/uiparts/CImageListMgr.cpp
+++ b/sakura_core/uiparts/CImageListMgr.cpp
@@ -422,7 +422,7 @@ void CImageListMgr::MyDitherBlt( HDC drawdc, int nXDest, int nYDest,
 	bmih.biYPelsPerMeter = 0;
 	bmih.biClrUsed = 0;
 	bmih.biClrImportant = 0;
-	HBITMAP bmpWork = ::CreateDIBSection((HDC)0, &bmi, DIB_RGB_COLORS, (void**)&pBits, NULL, 0);
+	HBITMAP bmpWork = ::CreateDIBSection(nullptr, &bmi, DIB_RGB_COLORS, (void**)&pBits, nullptr, 0);
 	HGDIOBJ bmpWorkOld = ::SelectObject( hdcWork, bmpWork );
 
 	// 作業DCに転送
@@ -644,7 +644,7 @@ HBITMAP CImageListMgr::ResizeToolIcons(
 	const int cy = cx;
 
 	// 仮想DCを作成
-	HDC hdcSrc = ::CreateCompatibleDC( 0 );	//	転送元用
+	HDC hdcSrc = ::CreateCompatibleDC( nullptr );	//	転送元用
 	if( hdcSrc == NULL ){
 
 		// 変換前Bmpを削除する
@@ -748,7 +748,7 @@ void CImageListMgr::Extend(bool bExtend)
 	if( curY < MAX_Y )
 		curY = MAX_Y;
 
-	HDC hSrcDC = ::CreateCompatibleDC( 0 );
+	HDC hSrcDC = ::CreateCompatibleDC( nullptr );
 	HBITMAP hSrcBmpOld = (HBITMAP)::SelectObject( hSrcDC, m_hIconBitmap );
 
 	//1行拡張したビットマップを作成

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -313,7 +313,7 @@ DWORD NetConnect ( const WCHAR strNetWorkPass[] )
 	nr.lpRemoteName  = sTemp;
 
 	//ユーザー認証ダイアログを表示
-	dwRet = WNetAddConnection3(0, &nr, NULL, NULL, CONNECT_UPDATE_PROFILE | CONNECT_INTERACTIVE);
+	dwRet = WNetAddConnection3(nullptr, &nr, nullptr, nullptr, CONNECT_UPDATE_PROFILE | CONNECT_INTERACTIVE);
 
 	return dwRet;
 }

--- a/sakura_core/util/std_macro.h
+++ b/sakura_core/util/std_macro.h
@@ -28,7 +28,7 @@
 #define SAKURA_STD_MACRO_ED0953D9_582D_40D6_8190_3FFA9344819D_H_
 #pragma once
 
-#define SAFE_DELETE(p) { delete p; p=0; }
+#define SAFE_DELETE(p) { delete p; p=nullptr; }
 
 /*
 	2007.10.18 kobake

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -202,7 +202,7 @@ CTextWidthCalc::CTextWidthCalc(HWND hwndThis)
 
 CTextWidthCalc::CTextWidthCalc(HFONT font)
 {
-	hwnd = 0;
+	hwnd = nullptr;
 	HDC hDCTemp = ::GetDC( NULL ); // Desktop
 	hDC = ::CreateCompatibleDC( hDCTemp );
 	::ReleaseDC( NULL, hDCTemp );
@@ -217,7 +217,7 @@ CTextWidthCalc::CTextWidthCalc(HFONT font)
 
 CTextWidthCalc::CTextWidthCalc(HDC hdc)
 {
-	hwnd = 0;
+	hwnd = nullptr;
 	hDC = hdc;
 	assert(hDC);
 	nCx = 0;
@@ -235,8 +235,8 @@ CTextWidthCalc::~CTextWidthCalc()
 		}else{
 			::ReleaseDC(hwnd, hDC);
 		}
-		hwnd = 0;
-		hDC = 0;
+		hwnd = nullptr;
+		hDC = nullptr;
 	}
 }
 

--- a/sakura_core/view/CEditView_Paint.cpp
+++ b/sakura_core/view/CEditView_Paint.cpp
@@ -659,7 +659,7 @@ void CEditView::OnPaint2( HDC _hdc, PAINTSTRUCT *pPs, BOOL bDrawFromComptibleBmp
 
 	bool bTransText = IsBkBitmap();
 	// メモリＤＣを利用した再描画の場合は描画先のＤＣを切り替える
-	HDC hdcOld = 0;
+	HDC hdcOld = nullptr;
 	// 2007.09.09 Moca bUseMemoryDCを有効化。
 	// bUseMemoryDC = FALSE;
 	BOOL bUseMemoryDC = (m_hdcCompatDC != NULL);

--- a/sakura_core/view/CViewSelect.cpp
+++ b/sakura_core/view/CViewSelect.cpp
@@ -302,7 +302,7 @@ void CViewSelect::DrawSelectArea2( HDC hdc ) const
 	HBRUSH      hBrushOld = (HBRUSH)::SelectObject( hdc, hBrush );
 	int         nROP_Old = ::SetROP2( hdc, SELECTEDAREA_ROP2 );
 	// From Here 2007.09.09 Moca 互換BMPによる画面バッファ
-	HBRUSH		hBrushCompatOld = 0;
+	HBRUSH		hBrushCompatOld = nullptr;
 	int			nROPCompatOld = 0;
 	bool bCompatBMP = pView->m_hbmpCompatBMP && hdc != pView->m_hdcCompatDC;
 	if( bCompatBMP ){

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -560,7 +560,7 @@ void CEditWnd::_AdjustInMonitor(const STabGroupInfo& sTabGroupInfo)
 	else
 	{
 		::SetWindowPos(
-			GetHwnd(), 0,
+			GetHwnd(), nullptr,
 			rcOrg.left, rcOrg.top,
 			rcOrg.right - rcOrg.left, rcOrg.bottom - rcOrg.top,
 			SWP_NOOWNERZORDER | SWP_NOZORDER
@@ -1527,7 +1527,7 @@ LRESULT CEditWnd::DispatchEvent(
 			{
 				int	nId;
 				nId = CreateFileDropDownMenu( pnmh->hwndFrom );
-				if( nId != 0 ) OnCommand( (WORD)0 /*メニュー*/, (WORD)nId, (HWND)0 );
+				if( nId != 0 ) OnCommand( (WORD)0 /*メニュー*/, (WORD)nId, nullptr );
 			}
 			return FALSE;
 		//	From Here Jul. 21, 2003 genta
@@ -2635,7 +2635,7 @@ bool CEditWnd::InitMenu_Special(HMENU hMenu, EFunctionCode eFunc)
 		{
 			const CJackManager* pcJackManager = CJackManager::getInstance();
 			const CPlugin* prevPlugin = NULL;
-			HMENU hMenuPlugin = 0;
+			HMENU hMenuPlugin = nullptr;
 
 			CPlug::Array plugs = pcJackManager->GetPlugs( PP_COMMAND );
 			for( CPlug::ArrayIter it = plugs.cbegin(); it != plugs.cend(); it++ ){
@@ -3439,15 +3439,15 @@ LRESULT CEditWnd::OnMouseMove( WPARAM wParam, LPARAM lParam )
 					SHGetMalloc(&Malloc);
 					SHGetDesktopFolder(&Desktop);
 					DWORD Eaten, Attribs;
-					if(SUCCEEDED(Desktop->ParseDisplayName(0, NULL, cmemDir.GetStringPtr(), &Eaten, &PathID, &Attribs)))
+					if(SUCCEEDED(Desktop->ParseDisplayName(nullptr, nullptr, cmemDir.GetStringPtr(), &Eaten, &PathID, &Attribs)))
 					{
 						Desktop->BindToObject(PathID, NULL, IID_IShellFolder, (void**)&Folder);
 						Malloc->Free(PathID);
-						if(SUCCEEDED(Folder->ParseDisplayName(0, NULL, cmemTitle.GetStringPtr(), &Eaten, &ItemID, &Attribs)))
+						if(SUCCEEDED(Folder->ParseDisplayName(nullptr, nullptr, cmemTitle.GetStringPtr(), &Eaten, &ItemID, &Attribs)))
 						{
 							LPCITEMIDLIST List[1];
 							List[0] = ItemID;
-							Folder->GetUIObjectOf(0, 1, List, IID_IDataObject, NULL, (void**)&DataObject);
+							Folder->GetUIObjectOf(nullptr, 1, List, IID_IDataObject, nullptr, (void**)&DataObject);
 							Malloc->Free(ItemID);
 #define DDASTEXT
 #ifdef  DDASTEXT

--- a/sakura_core/window/CMainStatusBar.cpp
+++ b/sakura_core/window/CMainStatusBar.cpp
@@ -67,7 +67,7 @@ void CMainStatusBar::CreateStatusBar()
 		m_hwndStatusBar,
 		NULL,
 		CEditApp::getInstance()->GetAppInstance(),
-		0
+		nullptr
 	);
 
 	if( NULL != m_pOwner->m_cFuncKeyWnd.GetHwnd() ){

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -83,7 +83,7 @@ void CMainToolBar::ProcSearchBox( MSG *msg )
 				// 02/07/28 ai end
 
 				//次を検索
-				m_pOwner->OnCommand( (WORD)0 /*メニュー*/, (WORD)F_SEARCH_NEXT, (HWND)0 );
+				m_pOwner->OnCommand( (WORD)0 /*メニュー*/, (WORD)F_SEARCH_NEXT, nullptr );
 			}
 		}
 		else if( msg->wParam == VK_TAB )	//タブキー

--- a/sakura_core/window/CSplitterWnd.cpp
+++ b/sakura_core/window/CSplitterWnd.cpp
@@ -335,7 +335,7 @@ void CSplitterWnd::DoSplit( int nHorizontal, int nVertical )
 //		if( NULL != pcViewArr[2] ) pcViewArr[2]->SplitBoxOnOff( FALSE, FALSE, FALSE );	/* 縦・横の分割ボックスのＯＮ／ＯＦＦ */
 //		if( NULL != pcViewArr[3] ) pcViewArr[3]->SplitBoxOnOff( FALSE, FALSE, FALSE );	/* 縦・横の分割ボックスのＯＮ／ＯＦＦ */
 
-		OnSize( 0, 0, 0, 0 );
+		OnSize( nullptr, 0, 0, 0 );
 
 		if( nAllSplitRowsOld == 1 && nAllSplitColsOld == 1 ){
 		}else
@@ -407,7 +407,7 @@ void CSplitterWnd::DoSplit( int nHorizontal, int nVertical )
 		if( NULL != pcViewArr[2] ) pcViewArr[2]->SplitBoxOnOff( FALSE, TRUE, bSizeBox );	/* 縦・横の分割ボックスのＯＮ／ＯＦＦ */
 //		if( NULL != pcViewArr[3] ) pcViewArr[3]->SplitBoxOnOff( FALSE, FALSE, FALSE );	/* 縦・横の分割ボックスのＯＮ／ＯＦＦ */
 
-		OnSize( 0, 0, 0, 0 );
+		OnSize( nullptr, 0, 0, 0 );
 
 		if( nAllSplitRowsOld == 1 && nAllSplitColsOld == 1 ){
 			/* 上下に分割したとき */
@@ -484,7 +484,7 @@ void CSplitterWnd::DoSplit( int nHorizontal, int nVertical )
 //		if( NULL != pcViewArr[2] ) pcViewArr[2]->SplitBoxOnOff( FALSE, FALSE );	/* 縦・横の分割ボックスのＯＮ／ＯＦＦ */
 //		if( NULL != pcViewArr[3] ) pcViewArr[3]->SplitBoxOnOff( FALSE, FALSE );	/* 縦・横の分割ボックスのＯＮ／ＯＦＦ */
 
-		OnSize( 0, 0, 0, 0 );
+		OnSize( nullptr, 0, 0, 0 );
 
 		if( nAllSplitRowsOld == 1 && nAllSplitColsOld == 1 ){
 			/* ペインの表示状態を他のビューにコピー */
@@ -536,7 +536,7 @@ void CSplitterWnd::DoSplit( int nHorizontal, int nVertical )
 		if( NULL != pcViewArr[2] ){ pcViewArr[2]->SplitBoxOnOff( FALSE, FALSE, FALSE );}	/* 縦・横の分割ボックスのＯＮ／ＯＦＦ */
 		if( NULL != pcViewArr[3] ){ pcViewArr[3]->SplitBoxOnOff( FALSE, FALSE, bSizeBox );}	/* 縦・横の分割ボックスのＯＮ／ＯＦＦ */
 
-		OnSize( 0, 0, 0, 0 );
+		OnSize( nullptr, 0, 0, 0 );
 
 		if( nAllSplitRowsOld == 1 && nAllSplitColsOld == 1 ){
 			/* ペインの表示状態を他のビューにコピー */
@@ -575,7 +575,7 @@ void CSplitterWnd::DoSplit( int nHorizontal, int nVertical )
 		}
 		nActivePane = m_nActivePane;
 	}
-	OnSize( 0, 0, 0, 0 );
+	OnSize( nullptr, 0, 0, 0 );
 
 	/* アクティブになったことをペインに通知 */
 	if( m_ChildWndArr[nActivePane] != NULL ){

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -1729,7 +1729,7 @@ void CTabWnd::TabWindowNotify( WPARAM wParam, LPARAM lParam )
 
 			// 2005.09.01 ryoji スクロール位置調整
 			// （右端のほうのタブアイテムを削除したとき、スクロール可能なのに右に余白ができることへの対策）
-			hwndUpDown = ::FindWindowEx( m_hwndTab, NULL, UPDOWN_CLASS, 0 );	// タブ内の Up-Down コントロール
+			hwndUpDown = ::FindWindowEx( m_hwndTab, nullptr, UPDOWN_CLASS, nullptr );	// タブ内の Up-Down コントロール
 			if( hwndUpDown != NULL && ::IsWindowVisible( hwndUpDown ) )	// 2007.09.24 ryoji hwndUpDown可視の条件追加
 			{
 				nScrollPos = LOWORD( UpDown_GetPos( hwndUpDown ) );
@@ -1755,7 +1755,7 @@ void CTabWnd::TabWindowNotify( WPARAM wParam, LPARAM lParam )
 
 				// 自タブアイテムを強制的に可視位置にするために、
 				// 自タブアイテム選択前に一時的に画面左端のタブアイテムを選択する
-				hwndUpDown = ::FindWindowEx( m_hwndTab, NULL, UPDOWN_CLASS, 0 );	// タブ内の Up-Down コントロール
+				hwndUpDown = ::FindWindowEx( m_hwndTab, nullptr, UPDOWN_CLASS, nullptr );	// タブ内の Up-Down コントロール
 				nScrollPos = ( hwndUpDown != NULL && ::IsWindowVisible( hwndUpDown ) )? LOWORD( UpDown_GetPos( hwndUpDown ) ): 0;	// 2007.09.24 ryoji hwndUpDown可視の条件追加
 				TabCtrl_SetCurSel( m_hwndTab, nScrollPos );
 				TabCtrl_SetCurSel( m_hwndTab, nIndex );
@@ -2183,7 +2183,7 @@ void CTabWnd::ForceActiveWindow( HWND hwnd )
 	::AttachThreadInput( nId1, nId2, TRUE );
 
 	::SystemParametersInfo( SPI_GETFOREGROUNDLOCKTIMEOUT, 0, &dwTime, 0 );
-	::SystemParametersInfo( SPI_SETFOREGROUNDLOCKTIMEOUT, 0, (LPVOID)0, 0 );
+	::SystemParametersInfo( SPI_SETFOREGROUNDLOCKTIMEOUT, 0, nullptr, 0 );
 
 	//ウィンドウをフォアグラウンドにする
 	::SetForegroundWindow( hwnd );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
clang-tidy を実行すると、下記の warning が表示される。
```
C:\work\sakura\sakura_core\CBackupAgent.cpp(476,21): warning G97CD0FBF: use nullptr [modernize-use-nullptr]
  476 |                                         folders[idx] = 0;
      |                                                        ^
      |                                                        nullptr
```

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. 0 を nullptr に変更します。
2. 変更行の NULL を nullptr に変更します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
1. clang-tidy で modernize-use-nullptr の warning が消えていることを確認する。
プロジェクト - プロパティ - Code Analysis - 全般 - Clang-tidy の有効化 を "はい" に設定する。
プロジェクト - プロパティ - Code Analysis - 有効または無効にするチェック に "-*,modernize-use-nullptr" を追加する。
分析 - Code Analysis の実行 - sakuraでコード分析を実行 を選択する。
2. 変更前後でasmが同じことを確認する。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://learn.microsoft.com/ja-jp/cpp/code-quality/clang-tidy
https://releases.llvm.org/19.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize/use-nullptr.html
