### PR TITLE
modernize-use-override 警告修正 (clang-tidy)

### DIFF
--- a/sakura_core/CEditApp.h
+++ b/sakura_core/CEditApp.h
@@ -78,6 +78,6 @@ public:
 //WM_QUIT検出例外
 class CAppExitException : public std::exception{
 public:
-	const char* what() const throw(){ return "CAppExitException"; }
+	const char* what() const throw() override{ return "CAppExitException"; }
 };
 #endif /* SAKURA_CEDITAPP_421797BC_DD8E_4209_AAF7_6BDC4D1CAAE9_H_ */

--- a/sakura_core/CGrepEnumFolders.h
+++ b/sakura_core/CGrepEnumFolders.h
@@ -27,7 +27,7 @@ public:
 	virtual ~CGrepEnumFolders(){
 	}
 
-	virtual BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL ){
+	BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = nullptr ) override{
 		if( ( w32fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY )
 		 && ( 0 != wcscmp( w32fd.cFileName, L"." ) )
 		 && ( 0 != wcscmp( w32fd.cFileName, L".." ) ) ){

--- a/sakura_core/_os/CDropTarget.h
+++ b/sakura_core/_os/CDropTarget.h
@@ -104,10 +104,10 @@ private: // 2002/2/10 aroka アクセス権変更
 public:
 	BOOL			Register_DropTarget(HWND hWnd);
 	BOOL			Revoke_DropTarget( void );
-	STDMETHODIMP	DragEnter(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
-	STDMETHODIMP	DragOver(DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
-	STDMETHODIMP	DragLeave( void );
-	STDMETHODIMP	Drop(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
+	STDMETHODIMP	DragEnter(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect) override;
+	STDMETHODIMP	DragOver(DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect) override;
+	STDMETHODIMP	DragLeave( void ) override;
+	STDMETHODIMP	Drop(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect) override;
 protected:
 	/*
 	||  実装ヘルパ関数

--- a/sakura_core/doc/CDocListener.h
+++ b/sakura_core/doc/CDocListener.h
@@ -194,6 +194,6 @@ public:
 #include <exception>
 class CFlowInterruption : public std::exception{
 public:
-	const char* what() const throw(){ return "CFlowInterruption"; }
+	const char* what() const throw() override{ return "CFlowInterruption"; }
 };
 #endif /* SAKURA_CDOCLISTENER_BEF5B814_A5B8_4D07_9B2F_009A5CB29B2F_H_ */

--- a/sakura_core/extmodule/CHtmlHelp.h
+++ b/sakura_core/extmodule/CHtmlHelp.h
@@ -49,7 +49,7 @@ public:
 	}
 
 protected:
-	virtual bool InitDllImp();
-	virtual LPCWSTR GetDllNameImp(int nIndex);
+	bool InitDllImp() override;
+	LPCWSTR GetDllNameImp(int nIndex) override;
 };
 #endif /* SAKURA_CHTMLHELP_7003298B_3900_42FD_9A02_1BCD4E9A8546_H_ */

--- a/sakura_core/extmodule/CMigemo.h
+++ b/sakura_core/extmodule/CMigemo.h
@@ -117,9 +117,9 @@ protected:
 #endif
 	bool	m_bUtf8;
 
-	LPCWSTR GetDllNameImp(int nIndex);
-	bool InitDllImp();
-	bool DeinitDllImp(void);
+	LPCWSTR GetDllNameImp(int nIndex) override;
+	bool InitDllImp() override;
+	bool DeinitDllImp(void) override;
 
 public:
 	long migemo_open(char* dict);

--- a/sakura_core/macro/CEditorIfObj.h
+++ b/sakura_core/macro/CEditorIfObj.h
@@ -22,9 +22,9 @@ public:
 	CEditorIfObj() : CWSHIfObj( L"Editor", true ){}
 
 	// 実装
-	MacroFuncInfoArray GetMacroCommandInfo() const;	//コマンド情報を取得する
-	MacroFuncInfoArray GetMacroFuncInfo() const;	//関数情報を取得する
-	bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result);	//関数を処理する
-	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize);	//コマンドを処理する
+	MacroFuncInfoArray GetMacroCommandInfo() const override;	//コマンド情報を取得する
+	MacroFuncInfoArray GetMacroFuncInfo() const override;	//関数情報を取得する
+	bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result) override;	//関数を処理する
+	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize) override;	//コマンドを処理する
 };
 #endif /* SAKURA_CEDITORIFOBJ_1C8AA37E_D9FB_4C26_AE83_22E62D9B7C3D_H_ */

--- a/sakura_core/macro/CIfObj.cpp
+++ b/sakura_core/macro/CIfObj.cpp
@@ -38,8 +38,8 @@ private:
 public:
 	CIfObjTypeInfo(const CIfObj::CMethodInfoList& methods, const std::wstring& sName);
 
-	virtual HRESULT STDMETHODCALLTYPE GetTypeAttr(
-					/* [out] */ TYPEATTR __RPC_FAR *__RPC_FAR *ppTypeAttr)
+	HRESULT STDMETHODCALLTYPE GetTypeAttr(
+					/* [out] */ TYPEATTR __RPC_FAR *__RPC_FAR *ppTypeAttr) override
 	{
 #ifdef TEST
 		DEBUG_TRACE( L"GetTypeAttr\n" );
@@ -48,8 +48,8 @@ public:
 		return S_OK;
 	}
         
-	virtual HRESULT STDMETHODCALLTYPE GetTypeComp( 
-					/* [out] */ ITypeComp __RPC_FAR *__RPC_FAR *ppTComp)
+	HRESULT STDMETHODCALLTYPE GetTypeComp(
+					/* [out] */ ITypeComp __RPC_FAR *__RPC_FAR *ppTComp) override
 	{
 #ifdef TEST
 		DEBUG_TRACE( L"GetTypeComp\n" );
@@ -57,63 +57,63 @@ public:
 		return E_NOTIMPL;
 	}
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetFuncDesc( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE GetFuncDesc(
 				/* [in] */ UINT index,
-				/* [out] */ FUNCDESC __RPC_FAR *__RPC_FAR *ppFuncDesc);
+				/* [out] */ FUNCDESC __RPC_FAR *__RPC_FAR *ppFuncDesc) override;
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetVarDesc( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE GetVarDesc(
 	    /* [in] */ UINT index,
-	    /* [out] */ VARDESC __RPC_FAR *__RPC_FAR *ppVarDesc)
+	    /* [out] */ VARDESC __RPC_FAR *__RPC_FAR *ppVarDesc) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetNames( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE GetNames(
 	    /* [in] */ MEMBERID memid,
 	    /* [length_is][size_is][out] */ BSTR __RPC_FAR *rgBstrNames,
 	    /* [in] */ UINT cMaxNames,
-	    /* [out] */ UINT __RPC_FAR *pcNames);
+	    /* [out] */ UINT __RPC_FAR *pcNames) override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetRefTypeOfImplType( 
+	HRESULT STDMETHODCALLTYPE GetRefTypeOfImplType(
 	    /* [in] */ UINT index,
-	    /* [out] */ HREFTYPE __RPC_FAR *pRefType)
+	    /* [out] */ HREFTYPE __RPC_FAR *pRefType) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE GetImplTypeFlags( 
+	HRESULT STDMETHODCALLTYPE GetImplTypeFlags(
 	    /* [in] */ UINT index,
-	    /* [out] */ INT __RPC_FAR *pImplTypeFlags)
+	    /* [out] */ INT __RPC_FAR *pImplTypeFlags) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetIDsOfNames( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE GetIDsOfNames(
 	    /* [size_is][in] */ LPOLESTR __RPC_FAR *rgszNames,
 	    /* [in] */ UINT cNames,
-	    /* [size_is][out] */ MEMBERID __RPC_FAR *pMemId)
+	    /* [size_is][out] */ MEMBERID __RPC_FAR *pMemId) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE Invoke( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE Invoke(
 	    /* [in] */ PVOID pvInstance,
 	    /* [in] */ MEMBERID memid,
 	    /* [in] */ WORD wFlags,
 	    /* [out][in] */ DISPPARAMS __RPC_FAR *pDispParams,
 	    /* [out] */ VARIANT __RPC_FAR *pVarResult,
 	    /* [out] */ EXCEPINFO __RPC_FAR *pExcepInfo,
-	    /* [out] */ UINT __RPC_FAR *puArgErr)
+	    /* [out] */ UINT __RPC_FAR *puArgErr) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetDocumentation( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE GetDocumentation(
 	    /* [in] */ MEMBERID memid,
 	    /* [out] */ BSTR __RPC_FAR *pBstrName,
 	    /* [out] */ BSTR __RPC_FAR *pBstrDocString,
 	    /* [out] */ DWORD __RPC_FAR *pdwHelpContext,
-	    /* [out] */ BSTR __RPC_FAR *pBstrHelpFile)
+	    /* [out] */ BSTR __RPC_FAR *pBstrHelpFile) override
 	{
 		//	Feb. 08, 2004 genta
 		//	とりあえず全部NULLを返す (情報無し)
@@ -141,65 +141,65 @@ public:
 		return S_OK;
 	}
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetDllEntry( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE GetDllEntry(
 	    /* [in] */ MEMBERID memid,
 	    /* [in] */ INVOKEKIND invKind,
 	    /* [out] */ BSTR __RPC_FAR *pBstrDllName,
 	    /* [out] */ BSTR __RPC_FAR *pBstrName,
-	    /* [out] */ WORD __RPC_FAR *pwOrdinal)
+	    /* [out] */ WORD __RPC_FAR *pwOrdinal) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE GetRefTypeInfo( 
+	HRESULT STDMETHODCALLTYPE GetRefTypeInfo(
 	    /* [in] */ HREFTYPE hRefType,
-	    /* [out] */ ITypeInfo __RPC_FAR *__RPC_FAR *ppTInfo)
+	    /* [out] */ ITypeInfo __RPC_FAR *__RPC_FAR *ppTInfo) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE AddressOfMember( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE AddressOfMember(
 	    /* [in] */ MEMBERID memid,
 	    /* [in] */ INVOKEKIND invKind,
-	    /* [out] */ PVOID __RPC_FAR *ppv)
+	    /* [out] */ PVOID __RPC_FAR *ppv) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE CreateInstance( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE CreateInstance(
 	    /* [in] */ IUnknown __RPC_FAR *pUnkOuter,
 	    /* [in] */ REFIID riid,
-	    /* [iid_is][out] */ PVOID __RPC_FAR *ppvObj)
+	    /* [iid_is][out] */ PVOID __RPC_FAR *ppvObj) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE GetMops( 
+	HRESULT STDMETHODCALLTYPE GetMops(
 	    /* [in] */ MEMBERID memid,
-	    /* [out] */ BSTR __RPC_FAR *pBstrMops)
+	    /* [out] */ BSTR __RPC_FAR *pBstrMops) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetContainingTypeLib( 
+	/* [local] */ HRESULT STDMETHODCALLTYPE GetContainingTypeLib(
 	    /* [out] */ ITypeLib __RPC_FAR *__RPC_FAR *ppTLib,
-	    /* [out] */ UINT __RPC_FAR *pIndex)
+	    /* [out] */ UINT __RPC_FAR *pIndex) override
 	{
 		return E_NOTIMPL;
 	}
 
-	virtual /* [local] */ void STDMETHODCALLTYPE ReleaseTypeAttr( 
-					/* [in] */ TYPEATTR __RPC_FAR *pTypeAttr)
+	/* [local] */ void STDMETHODCALLTYPE ReleaseTypeAttr(
+					/* [in] */ TYPEATTR __RPC_FAR *pTypeAttr) override
 	{
 	}
 
-	virtual /* [local] */ void STDMETHODCALLTYPE ReleaseFuncDesc( 
-					/* [in] */ FUNCDESC __RPC_FAR *pFuncDesc)
+	/* [local] */ void STDMETHODCALLTYPE ReleaseFuncDesc(
+					/* [in] */ FUNCDESC __RPC_FAR *pFuncDesc) override
 	{
 	}
 
-	virtual /* [local] */ void STDMETHODCALLTYPE ReleaseVarDesc(
-				/* [in] */ VARDESC __RPC_FAR *pVarDesc)
+	/* [local] */ void STDMETHODCALLTYPE ReleaseVarDesc(
+				/* [in] */ VARDESC __RPC_FAR *pVarDesc) override
 	{
 	}
 };

--- a/sakura_core/macro/CIfObj.h
+++ b/sakura_core/macro/CIfObj.h
@@ -33,12 +33,12 @@ public:
 	#ifdef __BORLANDC__
 	#pragma argsused
 	#endif
-	virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void ** ppvObject) 
+	HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void ** ppvObject) override
 	{ 
 		return E_NOINTERFACE; 
 	}
-	virtual ULONG STDMETHODCALLTYPE AddRef() { ++ m_RefCount; return m_RefCount; }
-	virtual ULONG STDMETHODCALLTYPE Release() { -- m_RefCount; int R = m_RefCount; if(m_RefCount == 0) delete this; return R; }
+	ULONG STDMETHODCALLTYPE AddRef() override { ++ m_RefCount; return m_RefCount; }
+	ULONG STDMETHODCALLTYPE Release() override { -- m_RefCount; int R = m_RefCount; if(m_RefCount == 0) delete this; return R; }
 public:
 	ImplementsIUnknown(): m_RefCount(0) {}
 	virtual ~ImplementsIUnknown() = default;
@@ -94,14 +94,14 @@ public:
 	}
 
 	// 実装
-	virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void ** ppvObject);
-	virtual HRESULT STDMETHODCALLTYPE GetIDsOfNames(
+	HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void ** ppvObject) override;
+	HRESULT STDMETHODCALLTYPE GetIDsOfNames(
 					REFIID riid,
 					OLECHAR FAR* FAR* rgszNames,
 					UINT cNames,
 					LCID lcid,
-					DISPID FAR* rgdispid);
-	virtual HRESULT STDMETHODCALLTYPE Invoke(
+					DISPID FAR* rgdispid) override;
+	HRESULT STDMETHODCALLTYPE Invoke(
 					DISPID dispidMember,
 					REFIID riid,
 					LCID lcid,
@@ -109,13 +109,13 @@ public:
 					DISPPARAMS FAR* pdispparams,
 					VARIANT FAR* pvarResult,
 					EXCEPINFO FAR* pexcepinfo,
-					UINT FAR* puArgErr);
-	virtual HRESULT STDMETHODCALLTYPE GetTypeInfo( 
+					UINT FAR* puArgErr) override;
+	HRESULT STDMETHODCALLTYPE GetTypeInfo(
 					/* [in] */ UINT iTInfo,
 					/* [in] */ LCID lcid,
-					/* [out] */ ITypeInfo __RPC_FAR *__RPC_FAR *ppTInfo);
-	virtual HRESULT STDMETHODCALLTYPE GetTypeInfoCount( 
-					/* [out] */ UINT __RPC_FAR *pctinfo);
+					/* [out] */ ITypeInfo __RPC_FAR *__RPC_FAR *ppTInfo) override;
+	HRESULT STDMETHODCALLTYPE GetTypeInfoCount(
+					/* [out] */ UINT __RPC_FAR *pctinfo) override;
 
 private:
 	// メンバ変数

--- a/sakura_core/macro/CPPA.h
+++ b/sakura_core/macro/CPPA.h
@@ -65,9 +65,9 @@ public:
 protected:
 	//	Jul. 5, 2001 genta インターフェース変更に伴う引数追加
 public:
-	virtual LPCWSTR GetDllNameImp(int nIndex);
+	LPCWSTR GetDllNameImp(int nIndex) override;
 protected:
-	virtual bool InitDllImp();
+	bool InitDllImp() override;
 
 private:
 	//	DLL Interfaceの受け皿

--- a/sakura_core/macro/CWSH.cpp
+++ b/sakura_core/macro/CWSH.cpp
@@ -58,11 +58,11 @@ public:
 	{
 	}
 
-	virtual ULONG STDMETHODCALLTYPE AddRef() {
+	ULONG STDMETHODCALLTYPE AddRef() override {
 		return ++m_RefCount;
 	}
 
-	virtual ULONG STDMETHODCALLTYPE Release() {
+	ULONG STDMETHODCALLTYPE Release() override {
 		if(--m_RefCount == 0)
 		{
 			delete this;
@@ -71,9 +71,9 @@ public:
 		return m_RefCount;
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE QueryInterface(
+	HRESULT STDMETHODCALLTYPE QueryInterface(
 	    /* [in] */ REFIID iid,
-	    /* [out] */ void ** ppvObject)
+	    /* [out] */ void ** ppvObject) override
 	{
 		*ppvObject = NULL;
 
@@ -86,8 +86,8 @@ public:
 		return E_NOTIMPL;
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE GetLCID( 
-	    /* [out] */ LCID *plcid) 
+	HRESULT STDMETHODCALLTYPE GetLCID(
+	    /* [out] */ LCID *plcid) override
 	{ 
 #ifdef TEST
 		cout << "GetLCID" << endl;
@@ -95,11 +95,11 @@ public:
 		return E_NOTIMPL; //システムデフォルトを使用
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE GetItemInfo( 
+	HRESULT STDMETHODCALLTYPE GetItemInfo(
 	    /* [in] */ LPCOLESTR pstrName,
 	    /* [in] */ DWORD dwReturnMask,
 	    /* [out] */ IUnknown **ppiunkItem,
-	    /* [out] */ ITypeInfo **ppti) 
+	    /* [out] */ ITypeInfo **ppti) override
 	{
 #ifdef TEST
 		wcout << L"GetItemInfo:" << pstrName << endl;
@@ -126,8 +126,8 @@ public:
 		return TYPE_E_ELEMENTNOTFOUND;
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE GetDocVersionString( 
-	    /* [out] */ BSTR *pbstrVersion) 
+	HRESULT STDMETHODCALLTYPE GetDocVersionString(
+	    /* [out] */ BSTR *pbstrVersion) override
 	{ 
 #ifdef TEST
 		cout << "GetDocVersionString" << endl;
@@ -135,9 +135,9 @@ public:
 		return E_NOTIMPL; 
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE OnScriptTerminate( 
+	HRESULT STDMETHODCALLTYPE OnScriptTerminate(
 	    /* [in] */ const VARIANT *pvarResult,
-	    /* [in] */ const EXCEPINFO *pexcepinfo) 
+	    /* [in] */ const EXCEPINFO *pexcepinfo) override
 	{ 
 #ifdef TEST
 		cout << "OnScriptTerminate" << endl;
@@ -145,8 +145,8 @@ public:
 		return S_OK; 
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE OnStateChange( 
-	    /* [in] */ SCRIPTSTATE ssScriptState) 
+	HRESULT STDMETHODCALLTYPE OnStateChange(
+	    /* [in] */ SCRIPTSTATE ssScriptState) override
 	{ 
 #ifdef TEST
 		cout << "OnStateChange" << endl;
@@ -156,8 +156,8 @@ public:
 
 	//	Nov. 3, 2002 鬼
 	//	エラー行番号表示対応
-	virtual HRESULT STDMETHODCALLTYPE OnScriptError(
-	  /* [in] */ IActiveScriptError *pscripterror)
+	HRESULT STDMETHODCALLTYPE OnScriptError(
+	  /* [in] */ IActiveScriptError *pscripterror) override
 	{ 
 		EXCEPINFO Info;
 		if(pscripterror->GetExceptionInfo(&Info) == S_OK)
@@ -185,14 +185,14 @@ public:
 		return S_OK;
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE OnEnterScript() {
+	HRESULT STDMETHODCALLTYPE OnEnterScript() override {
 #ifdef TEST
 		cout << "OnEnterScript" << endl;
 #endif
 		return S_OK; 
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE OnLeaveScript() {
+	HRESULT STDMETHODCALLTYPE OnLeaveScript() override {
 #ifdef TEST
 		cout << "OnLeaveScript" << endl;
 #endif
@@ -200,16 +200,16 @@ public:
 	}
 
 	//	Sep. 15, 2005 FILE IActiveScriptSiteWindow実装
-	virtual HRESULT STDMETHODCALLTYPE GetWindow(
-	    /* [out] */ HWND *phwnd)
+	HRESULT STDMETHODCALLTYPE GetWindow(
+	    /* [out] */ HWND *phwnd) override
 	{
 		*phwnd = CEditWnd::getInstance()->m_cSplitterWnd.GetHwnd();
 		return S_OK;
 	}
 
 	//	Sep. 15, 2005 FILE IActiveScriptSiteWindow実装
-	virtual HRESULT STDMETHODCALLTYPE EnableModeless(
-	    /* [in] */ BOOL fEnable)
+	HRESULT STDMETHODCALLTYPE EnableModeless(
+	    /* [in] */ BOOL fEnable) override
 	{
 		return S_OK;
 	}

--- a/sakura_core/plugin/CSmartIndentIfObj.h
+++ b/sakura_core/plugin/CSmartIndentIfObj.h
@@ -41,7 +41,7 @@ public:
 	// 実装
 public:
 	//コマンド情報を取得する
-	MacroFuncInfoArray GetMacroCommandInfo() const{
+	MacroFuncInfoArray GetMacroCommandInfo() const override{
 		static MacroFuncInfo macroFuncInfoArr[] = {
 			//	終端
 			{F_INVALID,	NULL, {VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_EMPTY,	NULL}
@@ -49,7 +49,7 @@ public:
 		return macroFuncInfoArr;
 	}
 	//関数情報を取得する
-	MacroFuncInfoArray GetMacroFuncInfo() const{
+	MacroFuncInfoArray GetMacroFuncInfo() const override{
 		static MacroFuncInfo macroFuncInfoNotCommandArr[] = {
 			//ID									関数名							引数										戻り値の型	m_pszData
 			{EFunctionCode(F_SI_GETCHAR),			LTEXT("GetChar"),				{VT_EMPTY, VT_EMPTY, VT_EMPTY, VT_EMPTY},	VT_BSTR,	NULL }, //押下したキーを取得する
@@ -59,7 +59,7 @@ public:
 		return macroFuncInfoNotCommandArr;
 	}
 	//関数を処理する
-	bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result)
+	bool HandleFunction(CEditView* View, EFunctionCode ID, VARIANT *Arguments, const int ArgSize, VARIANT &Result) override
 	{
 		switch ( LOWORD(ID) ) 
 		{
@@ -75,7 +75,7 @@ public:
 		return false;
 	}
 	//コマンドを処理する
-	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize)
+	bool HandleCommand(CEditView* View, EFunctionCode ID, const WCHAR* Arguments[], const int ArgLengths[], const int ArgSize) override
 	{
 		return false;
 	}

--- a/sakura_core/recent/CRecentImp.h
+++ b/sakura_core/recent/CRecentImp.h
@@ -38,36 +38,36 @@ protected:
 		int*			pnViewCount		//!< 表示個数(NULL許可)
 	);
 public:
-	void Terminate();
+	void Terminate() override;
 	bool IsAvailable() const;
 	void _Recovery();
 
 	//更新
 	bool ChangeViewCount( int nViewCount );	//表示数の変更
-	bool UpdateView();
+	bool UpdateView() override;
 
 	//プロパティ取得系
-	int GetArrayCount() const { return m_nArrayCount; }	//最大要素数
-	int GetItemCount() const { return ( IsAvailable() ? *m_pnUserItemCount : 0); }	//登録アイテム数
-	int GetViewCount() const { return ( IsAvailable() ? (m_pnUserViewCount ? *m_pnUserViewCount : m_nArrayCount) : 0); }	//表示数
+	int GetArrayCount() const override { return m_nArrayCount; }	//最大要素数
+	int GetItemCount() const override { return ( IsAvailable() ? *m_pnUserItemCount : 0); }	//登録アイテム数
+	int GetViewCount() const override { return ( IsAvailable() ? (m_pnUserViewCount ? *m_pnUserViewCount : m_nArrayCount) : 0); }	//表示数
 
 	//お気に入り制御系
-	bool SetFavorite( int nIndex, bool bFavorite = true);	//お気に入りに設定
+	bool SetFavorite( int nIndex, bool bFavorite = true) override;	//お気に入りに設定
 	bool ResetFavorite( int nIndex ) { return SetFavorite( nIndex, false ); }	//お気に入りを解除
 	void ResetAllFavorite();			//お気に入りをすべて解除
-	bool IsFavorite( int nIndex ) const;			//お気に入りか調べる
+	bool IsFavorite( int nIndex ) const override;			//お気に入りか調べる
 
 	//アイテム制御
 	bool AppendItem( ReceiveType pItemData );	//アイテムを先頭に追加
-	bool AppendItemText( LPCWSTR pszText );
-	bool EditItemText( int nIndex, LPCWSTR pszText );
-	bool DeleteItem( int nIndex );				//アイテムをクリア
+	bool AppendItemText( LPCWSTR pszText ) override;
+	bool EditItemText( int nIndex, LPCWSTR pszText ) override;
+	bool DeleteItem( int nIndex ) override;				//アイテムをクリア
 	bool DeleteItem( ReceiveType pItemData )
 	{
 		return DeleteItem( FindItem( pItemData ) );
 	}
-	bool DeleteItemsNoFavorite();			//お気に入り以外のアイテムをクリア
-	void DeleteAllItem();					//アイテムをすべてクリア
+	bool DeleteItemsNoFavorite() override;			//お気に入り以外のアイテムをクリア
+	void DeleteAllItem() override;					//アイテムをすべてクリア
 
 	//アイテム取得
 	const DataType* GetItem( int nIndex ) const;

--- a/sakura_core/typeprop/CImpExpManager.h
+++ b/sakura_core/typeprop/CImpExpManager.h
@@ -80,14 +80,14 @@ public:
 	}
 
 public:
-	bool ImportAscertain( HINSTANCE, HWND, const wstring&, wstring& );
-	bool Import( const wstring&, wstring& );
-	bool Export( const wstring&, wstring& );
+	bool ImportAscertain( HINSTANCE, HWND, const wstring&, wstring& ) override;
+	bool Import( const wstring&, wstring& ) override;
+	bool Export( const wstring&, wstring& ) override;
 
 public:
 	// デフォルト拡張子の取得
-	const WCHAR* GetDefaultExtension()	{ return L"*.ini"; }
-	const wchar_t* GetOriginExtension()	{ return L"ini"; }
+	const WCHAR* GetDefaultExtension() override	{ return L"*.ini"; }
+	const wchar_t* GetOriginExtension() override	{ return L"ini"; }
 	bool IsAddType(){ return m_bAddType; }
 
 private:
@@ -117,13 +117,13 @@ public:
 	}
 
 public:
-	bool Import( const wstring&, wstring& );
-	bool Export( const wstring&, wstring& );
+	bool Import( const wstring&, wstring& ) override;
+	bool Export( const wstring&, wstring& ) override;
 
 public:
 	// デフォルト拡張子の取得
-	const WCHAR* GetDefaultExtension()	{ return L"*.col"; }
-	const wchar_t* GetOriginExtension()	{ return L"col"; }
+	const WCHAR* GetDefaultExtension() override	{ return L"*.col"; }
+	const wchar_t* GetOriginExtension() override	{ return L"col"; }
 
 private:
 	ColorInfo*		m_ColorInfoArr;
@@ -142,13 +142,13 @@ public:
 	}
 
 public:
-	bool Import( const wstring&, wstring& );
-	bool Export( const wstring&, wstring& );
+	bool Import( const wstring&, wstring& ) override;
+	bool Export( const wstring&, wstring& ) override;
 
 public:
 	// デフォルト拡張子の取得
-	const WCHAR* GetDefaultExtension()	{ return L"*.rkw"; }
-	const wchar_t* GetOriginExtension()	{ return L"rkw"; }
+	const WCHAR* GetDefaultExtension() override	{ return L"*.rkw"; }
+	const wchar_t* GetOriginExtension() override	{ return L"rkw"; }
 
 private:
 	STypeConfig&	m_Types;
@@ -167,13 +167,13 @@ public:
 	}
 
 public:
-	bool Import( const wstring&, wstring& );
-	bool Export( const wstring&, wstring& );
+	bool Import( const wstring&, wstring& ) override;
+	bool Export( const wstring&, wstring& ) override;
 
 public:
 	// デフォルト拡張子の取得
-	const WCHAR* GetDefaultExtension()	{ return L"*.txt"; }
-	const wchar_t* GetOriginExtension()	{ return L"txt"; }
+	const WCHAR* GetDefaultExtension() override	{ return L"*.txt"; }
+	const wchar_t* GetOriginExtension() override	{ return L"txt"; }
 
 private:
 	STypeConfig&	m_Types;
@@ -192,13 +192,13 @@ public:
 	}
 
 public:
-	bool Import( const wstring&, wstring& );
-	bool Export( const wstring&, wstring& );
+	bool Import( const wstring&, wstring& ) override;
+	bool Export( const wstring&, wstring& ) override;
 
 public:
 	// デフォルト拡張子の取得
-	const WCHAR* GetDefaultExtension()	{ return L"*.key"; }
-	const wchar_t* GetOriginExtension()	{ return L"key"; }
+	const WCHAR* GetDefaultExtension() override	{ return L"*.key"; }
+	const wchar_t* GetOriginExtension() override	{ return L"key"; }
 
 private:
 	CommonSetting&		m_Common;
@@ -217,13 +217,13 @@ public:
 	}
 
 public:
-	bool Import( const wstring&, wstring& );
-	bool Export( const wstring&, wstring& );
+	bool Import( const wstring&, wstring& ) override;
+	bool Export( const wstring&, wstring& ) override;
 
 public:
 	// デフォルト拡張子の取得
-	const WCHAR* GetDefaultExtension()	{ return L"*.mnu"; }
-	const wchar_t* GetOriginExtension()	{ return L"mnu"; }
+	const WCHAR* GetDefaultExtension() override	{ return L"*.mnu"; }
+	const wchar_t* GetOriginExtension() override	{ return L"mnu"; }
 
 private:
 	CommonSetting&		m_Common;
@@ -244,13 +244,13 @@ public:
 	}
 
 public:
-	bool Import( const wstring&, wstring& );
-	bool Export( const wstring&, wstring& );
+	bool Import( const wstring&, wstring& ) override;
+	bool Export( const wstring&, wstring& ) override;
 
 public:
 	// デフォルト拡張子の取得
-	const WCHAR* GetDefaultExtension()	{ return L"*.kwd"; }
-	const wchar_t* GetOriginExtension()	{ return L"kwd"; }
+	const WCHAR* GetDefaultExtension() override	{ return L"*.kwd"; }
+	const wchar_t* GetOriginExtension() override	{ return L"kwd"; }
 
 private:
 	CommonSetting&		m_Common;
@@ -271,13 +271,13 @@ public:
 	}
 
 public:
-	bool Import( const wstring&, wstring& );
-	bool Export( const wstring&, wstring& );
+	bool Import( const wstring&, wstring& ) override;
+	bool Export( const wstring&, wstring& ) override;
 
 public:
 	// デフォルト拡張子の取得
-	const WCHAR* GetDefaultExtension()	{ return L"*.ini"; }
-	const wchar_t* GetOriginExtension()	{ return L"ini"; }
+	const WCHAR* GetDefaultExtension() override	{ return L"*.ini"; }
+	const wchar_t* GetOriginExtension() override	{ return L"ini"; }
 
 private:
 	CommonSetting&		m_Common;
@@ -296,14 +296,14 @@ public:
 	}
 
 public:
-	bool Import( const wstring&, wstring& );
-	bool Export( const wstring&, wstring& );
+	bool Import( const wstring&, wstring& ) override;
+	bool Export( const wstring&, wstring& ) override;
 	static void IO_FileTreeIni( CDataProfile&, std::vector<SFileTreeItem>& );
 
 public:
 	// デフォルト拡張子の取得
-	const WCHAR* GetDefaultExtension()	{ return L"*.ini"; }
-	const wchar_t* GetOriginExtension()	{ return L"ini"; }
+	const WCHAR* GetDefaultExtension() override	{ return L"*.ini"; }
+	const wchar_t* GetOriginExtension() override	{ return L"ini"; }
 
 private:
 	std::vector<SFileTreeItem>&		m_aFileTreeItems;

--- a/sakura_core/view/colors/CColor_Heredoc.cpp
+++ b/sakura_core/view/colors/CColor_Heredoc.cpp
@@ -13,7 +13,7 @@
 class CLayoutColorHeredocInfo : public CLayoutColorInfo{
 public:
 	std::wstring m_id;
-	bool IsEqual(const CLayoutColorInfo* p) const{
+	bool IsEqual(const CLayoutColorInfo* p) const override{
 		if( !p ){
 			return false;
 		}

--- a/sakura_core/view/colors/CColor_Quote.cpp
+++ b/sakura_core/view/colors/CColor_Quote.cpp
@@ -15,7 +15,7 @@ class CLayoutColorQuoteInfo : public CLayoutColorInfo{
 public:
 	std::wstring m_tag;
 	int m_nColorTypeIndex;
-	bool IsEqual(const CLayoutColorInfo* p) const{
+	bool IsEqual(const CLayoutColorInfo* p) const override{
 		if( !p ){
 			return false;
 		}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
clang-tidy を実行すると、下記の warning が表示される。
```
C:\work\sakura\sakura_core\CGrepEnumFolders.h:30:15: warning: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override]
   30 |         virtual BOOL IsValid( WIN32_FIND_DATA& w32fd, LPCWSTR pFile = NULL ){
      |         ~~~~~~~      ^
      |                                                                              override
```

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
override 指定子を追加します。

## <!-- わかる範囲で --> PR の影響範囲
影響なし。

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容
<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. clang-tidy で modernize-use-override の warning 削減されていることを確認する。
プロジェクト - プロパティ - Code Analysis - 全般 - Clang-tidy の有効化 を "はい" に設定する。
プロジェクト - プロパティ - Code Analysis - 有効または無効にするチェック に "-*,modernize-use-override" を追加する。
分析 - Code Analysis の実行 - sakuraでコード分析を実行 を選択する。
2. 変更前後でasmが同じことを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1987

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://releases.llvm.org/19.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize/use-override.html