### PR TITLE
ComCtl32.dll バージョン 6 を使用したコントロールのサブクラス化 (CDlgSameColor)

### DIFF
--- a/sakura_core/typeprop/CDlgSameColor.cpp
+++ b/sakura_core/typeprop/CDlgSameColor.cpp
@@ -41,12 +41,7 @@ LPVOID CDlgSameColor::GetHelpIdTable( void )
 	return (LPVOID)p_helpids;
 }
 
-CDlgSameColor::CDlgSameColor() :
-	m_wpColorStaticProc(NULL),
-	m_wpColorListProc(NULL),
-	m_wID(0),
-	m_pTypes(NULL),
-	m_cr(0)
+CDlgSameColor::CDlgSameColor()
 {
 	return;
 }
@@ -119,10 +114,8 @@ BOOL CDlgSameColor::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	HWND hwndList = GetItemHwnd( IDC_LIST_COLORS );
 
 	// 指定色スタティック、色選択リストをサブクラス化
-	::SetWindowLongPtr( hwndStatic, GWLP_USERDATA, (LONG_PTR)this );
-	m_wpColorStaticProc = (WNDPROC)::SetWindowLongPtr( hwndStatic, GWLP_WNDPROC, (LONG_PTR)ColorStatic_SubclassProc );
-	::SetWindowLongPtr( hwndList, GWLP_USERDATA, (LONG_PTR)this );
-	m_wpColorListProc = (WNDPROC)::SetWindowLongPtr( hwndList, GWLP_WNDPROC, (LONG_PTR)ColorList_SubclassProc );
+	::SetWindowSubclass(hwndStatic, &ColorStatic_SubclassProc, 0, (DWORD_PTR)this);
+	::SetWindowSubclass(hwndList, &ColorList_SubclassProc, 0, 0);
 
 	WCHAR szText[30];
 	int nItem;
@@ -364,13 +357,12 @@ BOOL CDlgSameColor::OnSelChangeListColors( HWND hwndCtl )
 /*! サブクラス化された指定色スタティックのウィンドウプロシージャ
 	@date 2006.04.26 ryoji 新規作成
 */
-LRESULT CALLBACK CDlgSameColor::ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
+LRESULT CALLBACK CDlgSameColor::ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData )
 {
 	HDC			hDC;
 	RECT		rc;
 
-	CDlgSameColor* pCDlgSameColor;
-	pCDlgSameColor = (CDlgSameColor*)::GetWindowLongPtr( hwnd, GWLP_USERDATA );
+	auto pCDlgSameColor = (CDlgSameColor *)dwRefData;
 
 	switch( uMsg ){
 	case WM_PAINT:
@@ -408,30 +400,26 @@ LRESULT CALLBACK CDlgSameColor::ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, 
 
 	case WM_DESTROY:
 		// サブクラス化解除
-		::SetWindowLongPtr( hwnd, GWLP_WNDPROC, (LONG_PTR)pCDlgSameColor->m_wpColorStaticProc );
-		pCDlgSameColor->m_wpColorStaticProc = NULL;
+		::RemoveWindowSubclass(hwnd, &ColorStatic_SubclassProc, uIdSubclass);
 		return (LRESULT)0;
 
 	default:
 		break;
 	}
 
-	return CallWindowProc( pCDlgSameColor->m_wpColorStaticProc, hwnd, uMsg, wParam, lParam );
+	return ::DefSubclassProc(hwnd, uMsg, wParam, lParam);
 }
 
 /*! サブクラス化された色選択リストのウィンドウプロシージャ
 	@date 2006.04.26 ryoji 新規作成
 */
-LRESULT CALLBACK CDlgSameColor::ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
+LRESULT CALLBACK CDlgSameColor::ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, [[maybe_unused]] DWORD_PTR dwRefData )
 {
 	POINT po;
 	RECT rcItem;
 	RECT rc;
 	int nItemNum;
 	int i;
-
-	CDlgSameColor* pCDlgSameColor;
-	pCDlgSameColor = (CDlgSameColor*)::GetWindowLongPtr( hwnd, GWLP_USERDATA );
 
 	switch( uMsg ){
 	case WM_LBUTTONUP:
@@ -471,13 +459,12 @@ LRESULT CALLBACK CDlgSameColor::ColorList_SubclassProc( HWND hwnd, UINT uMsg, WP
 
 	case WM_DESTROY:
 		// サブクラス化解除
-		::SetWindowLongPtr( hwnd, GWLP_WNDPROC, (LONG_PTR)pCDlgSameColor->m_wpColorListProc );
-		pCDlgSameColor->m_wpColorListProc = NULL;
+		::RemoveWindowSubclass(hwnd, &ColorList_SubclassProc, uIdSubclass);
 		return (LRESULT)0;
 
 	default:
 		break;
 	}
 
-	return ::CallWindowProc( pCDlgSameColor->m_wpColorListProc, hwnd, uMsg, wParam, lParam );
+	return ::DefSubclassProc(hwnd, uMsg, wParam, lParam);
 }

--- a/sakura_core/typeprop/CDlgSameColor.h
+++ b/sakura_core/typeprop/CDlgSameColor.h
@@ -40,14 +40,11 @@ protected:
 	BOOL OnDrawItem( WPARAM wParam, LPARAM lParam ) override;	//!< WM_DRAWITEM 処理
 	BOOL OnSelChangeListColors( HWND hwndCtl );					//!< 色選択リストの LBN_SELCHANGE 処理
 
-	static LRESULT CALLBACK ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	//!< サブクラス化された指定色スタティックのウィンドウプロシージャ
-	static LRESULT CALLBACK ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );	//!< サブクラス化された色選択リストのウィンドウプロシージャ
+	static LRESULT CALLBACK ColorStatic_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData );	//!< サブクラス化された指定色スタティックのウィンドウプロシージャ
+	static LRESULT CALLBACK ColorList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData );	//!< サブクラス化された色選択リストのウィンドウプロシージャ
 
-	WNDPROC m_wpColorStaticProc;	//!< サブクラス化以前の指定色スタティックのウィンドウプロシージャ
-	WNDPROC m_wpColorListProc;		//!< サブクラス化以前の色選択リストのウィンドウプロシージャ
-
-	WORD m_wID;			//!< タイプ別設定ダイアログ（親ダイアログ）で押されたボタンID
-	STypeConfig* m_pTypes;	//!< タイプ別設定データ
-	COLORREF m_cr;		//!< 指定色
+	WORD m_wID = 0;			//!< タイプ別設定ダイアログ（親ダイアログ）で押されたボタンID
+	STypeConfig* m_pTypes = nullptr;	//!< タイプ別設定データ
+	COLORREF m_cr = 0;		//!< 指定色
 };
 #endif /* SAKURA_CDLGSAMECOLOR_181C0F46_A420_4A62_A543_FE2B88C20FBE_H_ */

--- a/sakura_core/typeprop/CPropTypesWindow.cpp
+++ b/sakura_core/typeprop/CPropTypesWindow.cpp
@@ -15,7 +15,6 @@
 #include "env/CShareData.h"
 #include "typeprop/CImpExpManager.h"	// 2010/4/23 Uchi
 #include "dlg/CDlgOpenFile.h"
-#include "CDlgSameColor.h"
 #include "CDlgKeywordSelect.h"
 #include "view/colors/EColorIndexType.h"
 #include "charset/CCodePage.h"


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
コントロールのサブクラス化が、ComCtl32.dll バージョン 6 より前の実装になっている。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
SetWindowLongPtr() の代わりに SetWindowSubclass()を使用する。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. 設定 - タイプ別設定 - カラー - 文字色統一 を選択
統一色が正しく表示されることを確認する。
変更対象の色を選択し、SPACEを押してチェックできることを確認する。
キャンセル 実行時に RemoveWindowSubclass() が実行されることを確認する。
2. 設定 - タイプ別設定 - カラー - 背景色統一 を選択
統一色が正しく表示されることを確認する。
変更対象の色を選択し、SPACEを押してチェックできることを確認する。
キャンセル 実行時に RemoveWindowSubclass() が実行されることを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2036

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
