### PR TITLE
tests1.exeのエントリポイントをwmainに変更する。

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -120,6 +120,7 @@ LIBS= \
  -L$(GOOGLETEST_INSTALL_DIR)/lib \
  -lgtest \
  -lgmock \
+ -municode \
  $(MYLIBS)
 
 exe= $(or $(OUTDIR),.)/tests1.exe

--- a/tests/unittests/code-main.cpp
+++ b/tests/unittests/code-main.cpp
@@ -84,7 +84,7 @@ static void InvokeWinMainIfNeeded(std::wstring_view commandLine)
 /*!
  * テストモジュールのエントリポイント
  */
-int main(int argc, char **argv) {
+int wmain(int argc, wchar_t **argv) {
 	// コマンドラインに -PROF 指定がある場合、wWinMainを起動して終了する。
 	InvokeWinMainIfNeeded(::GetCommandLineW());
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
MinGWビルドで tests1.exe のエントリポイントが wWinMain になってしまうことがあります。
この場合 tests1.exe を実行してもテストが実行されません。

tests1.exeは-mconsoleなので通常はmainが検索されます。
しかし、リンクしているobjに-municodeを含むものがあるので
wmainとwWinMainが検索されてしまうようです。
wmainは存在せず、wWinMainが存在するので wWinMain がエントリポイントになってしまうようです。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
tests1.exe のエントリポイント関数を main から wmain に変更します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
tests1.exe のリンクに影響する変更です。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
テスト不能です。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
* #2024

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
