### PR TITLE
CF_UNICODETEXT形式のクリップボードデータをサクラエディタにペーストしたときに u+0000 が追加される不具合を修正

### DIFF
--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -301,7 +301,7 @@ bool CClipboard::GetText(IWBuffer* cmemBuf, bool* pbColumnSelect, bool* pbLineSe
 	}
 	if( hUnicode != NULL ){
 		wchar_t* szData = static_cast<wchar_t*>(::GlobalLock(hUnicode));
-		cmemBuf->Append( szData, GlobalSize(hUnicode)/2);
+		cmemBuf->Append( szData, GlobalSize(hUnicode) / 2 - 1);
 		::GlobalUnlock(hUnicode);
 		return true;
 	}

--- a/sakura_core/_os/CClipboard.h
+++ b/sakura_core/_os/CClipboard.h
@@ -37,7 +37,7 @@ struct StdWStringBuffer : public IWBuffer {
 		try {
 			wstr->reserve(nDataLen);
 		}
-		catch (std::bad_alloc& exp) {
+		catch (std::bad_alloc&) {
 			;
 		}
 	}

--- a/sakura_core/cmd/CViewCommander_Clipboard.cpp
+++ b/sakura_core/cmd/CViewCommander_Clipboard.cpp
@@ -477,7 +477,7 @@ void CViewCommander::Command_INSTEXT(
 	}
 
 	if( nTextLen < 0 ){
-		nTextLen = CLogicInt(wcslen( pszText ));
+		nTextLen = wcslen( pszText );
 	}
 
 	CWaitCursor cWaitCursor( m_pCommanderView->GetHwnd(),


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 不具合修正

## <!-- 必須 --> PR の背景

#2094

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

#2094

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
