### PR TITLE
include tchar.h 削除

### DIFF
--- a/sakura_core/CGrepEnumFileBase.h
+++ b/sakura_core/CGrepEnumFileBase.h
@@ -18,7 +18,7 @@
 #include <vector>
 #include <windows.h>
 #include <string.h>
-#include <tchar.h>
+#include <wchar.h>
 #include <Shlwapi.h>
 #include "CGrepEnumKeys.h"
 #include "util/string_ex.h"

--- a/sakura_core/CGrepEnumKeys.h
+++ b/sakura_core/CGrepEnumKeys.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include <windows.h>
 #include <string.h>
-#include <tchar.h>
+#include <wchar.h>
 #include "util/string_ex.h"
 #include "util/file.h"
 

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -21,7 +21,7 @@
 #include "StdAfx.h"
 #include "CCommandLine.h"
 #include "mem/CMemory.h"
-#include <tchar.h>
+#include <wchar.h>
 #include <io.h>
 #include <string.h>
 #include "debug/CRunningTimer.h"

--- a/sakura_core/_main/CProcessFactory.cpp
+++ b/sakura_core/_main/CProcessFactory.cpp
@@ -26,7 +26,7 @@
 #include "debug/CRunningTimer.h"
 #include "util/os.h"
 #include <io.h>
-#include <tchar.h>
+#include <wchar.h>
 #include "CSelectLang.h"
 #include "config/system_constants.h"
 

--- a/sakura_core/_main/global.h
+++ b/sakura_core/_main/global.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include <Windows.h>
-#include <tchar.h>
+#include <wchar.h>
 
 #include "charset/charset.h"
 

--- a/sakura_core/config/system_constants.h
+++ b/sakura_core/config/system_constants.h
@@ -28,19 +28,19 @@
 
 //! デバッグ判別、定数サフィックス 2007.09.20 kobake
 #ifdef _DEBUG
-	#define _DEBUG_SUFFIX_ "_DEBUG"
+	#define _DEBUG_SUFFIX_ L"_DEBUG"
 #else
-	#define _DEBUG_SUFFIX_ ""
+	#define _DEBUG_SUFFIX_ L""
 #endif
 
 //! ビルドコード判別、定数サフィックス 2007.09.20 kobake
-#define _CODE_SUFFIX_ "WP"
+#define _CODE_SUFFIX_ L"WP"
 
 //! ターゲットマシン判別 2010.08.21 Moca 追加
 #ifdef _WIN64
-	#define CON_SKR_MACHINE_SUFFIX_ "M64"
+	#define CON_SKR_MACHINE_SUFFIX_ L"M64"
 #else
-	#define CON_SKR_MACHINE_SUFFIX_ ""
+	#define CON_SKR_MACHINE_SUFFIX_ L""
 #endif
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -550,8 +550,8 @@
 
 */
 #define N_SHAREDATA_VERSION		181
-#define STR_SHAREDATA_VERSION	NUM_TO_STR(N_SHAREDATA_VERSION)
-#define	GSTR_SHAREDATA	(L"SakuraShareData" _T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_) _T(STR_SHAREDATA_VERSION))
+#define STR_SHAREDATA_VERSION	TEXT(NUM_TO_STR(N_SHAREDATA_VERSION))
+#define	GSTR_SHAREDATA	(L"SakuraShareData" CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_ STR_SHAREDATA_VERSION)
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                      ミューテックス                         //
@@ -561,42 +561,42 @@
 #define	GSTR_MUTEX_SAKURA					L"MutexSakuraEditor"
 
 //! コントロールプロセス
-#define	GSTR_MUTEX_SAKURA_CP				(L"MutexSakuraEditorCP"				_T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_)	_T(STR_SHAREDATA_VERSION))
+#define	GSTR_MUTEX_SAKURA_CP				(L"MutexSakuraEditorCP"				CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_ 	STR_SHAREDATA_VERSION)
 
 //! ノーマルプロセス初期化同期
-#define	GSTR_MUTEX_SAKURA_INIT				(L"MutexSakuraEditorInit"			_T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_)	_T(STR_SHAREDATA_VERSION))
+#define	GSTR_MUTEX_SAKURA_INIT				(L"MutexSakuraEditorInit"			CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_	STR_SHAREDATA_VERSION)
 
 //! ノード操作同期
-#define	GSTR_MUTEX_SAKURA_EDITARR			(L"MutexSakuraEditorEditArr"			_T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_)	_T(STR_SHAREDATA_VERSION))
+#define	GSTR_MUTEX_SAKURA_EDITARR			(L"MutexSakuraEditorEditArr"		CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_	STR_SHAREDATA_VERSION)
 
 //DLLSHARE Work操作同期
-#define	GSTR_MUTEX_SAKURA_SHAREWORK			(L"MutexSakuraEditorShareWork"		_T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_)	_T(STR_SHAREDATA_VERSION))
+#define	GSTR_MUTEX_SAKURA_SHAREWORK			(L"MutexSakuraEditorShareWork"		CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_	STR_SHAREDATA_VERSION)
 
 //! 強調キーワードロック
-#define	GSTR_MUTEX_SAKURA_KEYWORD			(L"MutexSakuraEditorKeyword"			_T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_)	_T(STR_SHAREDATA_VERSION))
+#define	GSTR_MUTEX_SAKURA_KEYWORD			(L"MutexSakuraEditorKeyword"		CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_	STR_SHAREDATA_VERSION)
 
 //タイプ別設定転送用
-#define	GSTR_MUTEX_SAKURA_DOCTYPE			(L"MutexSakuraEditorDocType"			_T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_)	_T(STR_SHAREDATA_VERSION))
+#define	GSTR_MUTEX_SAKURA_DOCTYPE			(L"MutexSakuraEditorDocType"		CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_	STR_SHAREDATA_VERSION)
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                         イベント                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 //! 初期化完了イベント
-#define	GSTR_EVENT_SAKURA_CP_INITIALIZED	(L"EventSakuraEditorCPInitialized"	_T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_)	_T(STR_SHAREDATA_VERSION))
+#define	GSTR_EVENT_SAKURA_CP_INITIALIZED	(L"EventSakuraEditorCPInitialized"	CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_	STR_SHAREDATA_VERSION)
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                     ウィンドウクラス                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 //! コントロールトレイ
-#define	GSTR_CEDITAPP		(L"CControlTray" _T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_)		_T(STR_SHAREDATA_VERSION))
+#define	GSTR_CEDITAPP		(L"CControlTray" CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_		STR_SHAREDATA_VERSION)
 
 //! メインウィンドウ
-#define	GSTR_EDITWINDOWNAME	(L"TextEditorWindow" _T(CON_SKR_MACHINE_SUFFIX_) _T(_CODE_SUFFIX_) _T(_DEBUG_SUFFIX_)	_T(STR_SHAREDATA_VERSION))
+#define	GSTR_EDITWINDOWNAME	(L"TextEditorWindow" CON_SKR_MACHINE_SUFFIX_ _CODE_SUFFIX_ _DEBUG_SUFFIX_	STR_SHAREDATA_VERSION)
 
 //! ビュー
-#define	GSTR_VIEWNAME		(L"SakuraView"												_T(STR_SHAREDATA_VERSION))
+#define	GSTR_VIEWNAME		(L"SakuraView"												STR_SHAREDATA_VERSION)
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                         リソース                            //

--- a/sakura_core/debug/Debug1.h
+++ b/sakura_core/debug/Debug1.h
@@ -58,7 +58,7 @@ void DebugOutW( LPCWSTR lpFmt, ...);
 
 //トレース出力（トレース箇所のファイルパスと行番号を出力してエラー解析を容易にする目的）
 #ifdef _DEBUG
-	#define TRACE( format, ... )	DEBUG_TRACE( _T("%hs(%d): ") _T(format) _T("\n"), __FILE__, __LINE__, __VA_ARGS__ )
+	#define TRACE( format, ... )	DEBUG_TRACE( L"%hs(%d): " TEXT(format) L"\n", __FILE__, __LINE__, __VA_ARGS__ )
 #else
 	#define TRACE( ... )
 #endif

--- a/sakura_core/debug/Debug1.h
+++ b/sakura_core/debug/Debug1.h
@@ -20,7 +20,7 @@
 #include <vadefs.h>
 
 #include <Windows.h>
-#include <tchar.h>
+#include <wchar.h>
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                   メッセージ出力：実装                      //

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -52,53 +52,53 @@ const DWORD p_helpids[] = {	//12900
 // 2006.01.17 Moca COMPILER_VERを追加
 // 2010.04.15 Moca icc/dmcを追加しCPUを分離
 #if defined(_M_AMD64)
-#  define TARGET_M_SUFFIX "_A64"
+#  define TARGET_M_SUFFIX L"_A64"
 #else
-#  define TARGET_M_SUFFIX ""
+#  define TARGET_M_SUFFIX L""
 #endif
 
 #if defined(__BORLANDC__)
 // borland c++
 // http://docwiki.embarcadero.com/RADStudio/Rio/en/Predefined_Macros
 // http://docwiki.embarcadero.com/RADStudio/Rio/en/Predefined_Macros#C.2B.2B_Compiler_Versions_in_Predefined_Macros
-#  define COMPILER_TYPE "B"
+#  define COMPILER_TYPE L"B"
 #  define COMPILER_VER  __BORLANDC__ 
 #elif defined(__GNUG__)
 // __GNUG__ = (__GNUC__ && __cplusplus)
 // GNU C++
 // https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
-#  define COMPILER_TYPE "G"
+#  define COMPILER_TYPE L"G"
 #  define COMPILER_VER (__GNUC__ * 10000 + __GNUC_MINOR__  * 100 + __GNUC_PATCHLEVEL__)
 #elif defined(__INTEL_COMPILER)
 // Intel Compiler
 // https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-additional-predefined-macros
-#  define COMPILER_TYPE "I"
+#  define COMPILER_TYPE L"I"
 #  define COMPILER_VER __INTEL_COMPILER
 #elif defined(__DMC__)
 // Digital Mars C/C++
 // https://digitalmars.com/ctg/predefined.html
-#  define COMPILER_TYPE "D"
+#  define COMPILER_TYPE L"D"
 #  define COMPILER_VER __DMC__
 #elif defined(_MSC_VER)
 // https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019
-#  define COMPILER_TYPE "V"
+#  define COMPILER_TYPE L"V"
 #  define COMPILER_VER _MSC_VER
 #else
 // unknown
-#  define COMPILER_TYPE "U"
+#  define COMPILER_TYPE L"U"
 #  define COMPILER_VER 0
 #endif
 //	To Here Feb. 7, 2002 genta
 
-#define TARGET_STRING_MODEL "WP"
+#define TARGET_STRING_MODEL L"WP"
 
 #ifdef _DEBUG
-	#define TARGET_DEBUG_MODE "D"
+	#define TARGET_DEBUG_MODE L"D"
 #else
-	#define TARGET_DEBUG_MODE "R"
+	#define TARGET_DEBUG_MODE L"R"
 #endif
 
-#define TSTR_TARGET_MODE _T(TARGET_STRING_MODEL) _T(TARGET_DEBUG_MODE)
+#define TSTR_TARGET_MODE TARGET_STRING_MODEL TARGET_DEBUG_MODE
 
 #if defined(CI_BUILD_URL)
 #pragma message("CI_BUILD_URL: " CI_BUILD_URL)
@@ -179,12 +179,12 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	// 2行目
 #ifdef GIT_COMMIT_HASH
-	cmemMsg.AppendString( L"(GitHash " _T(GIT_COMMIT_HASH) L")\r\n" );
+	cmemMsg.AppendString( L"(GitHash " TEXT(GIT_COMMIT_HASH) L")\r\n" );
 #endif
 
 	// 3行目
 #ifdef GIT_REMOTE_ORIGIN_URL
-	cmemMsg.AppendString( L"(GitURL " _T(GIT_REMOTE_ORIGIN_URL) L")\r\n");
+	cmemMsg.AppendString( L"(GitURL " TEXT(GIT_REMOTE_ORIGIN_URL) L")\r\n");
 #endif
 
 	// 段落区切り
@@ -192,7 +192,7 @@ BOOL CDlgAbout::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 
 	// コンパイル情報
 	cmemMsg.AppendStringF(
-		L"      Compile Info: " _T(COMPILER_TYPE) _T(TARGET_M_SUFFIX) L"%d " TSTR_TARGET_MODE L" WIN%03x/I%03x/N%03x\r\n",
+		L"      Compile Info: " COMPILER_TYPE TARGET_M_SUFFIX L"%d " TSTR_TARGET_MODE L" WIN%03x/I%03x/N%03x\r\n",
 		COMPILER_VER, WINVER, _WIN32_IE, _WIN32_WINNT
 	);
 
@@ -306,20 +306,20 @@ BOOL CDlgAbout::OnStnClicked( int wID )
 	case IDC_STATIC_URL_CI_BUILD:
 		{
 #if defined(CI_BUILD_URL)
-			::ShellExecute(GetHwnd(), NULL, _T(CI_BUILD_URL), NULL, NULL, SW_SHOWNORMAL);
+			::ShellExecute(GetHwnd(), nullptr, TEXT(CI_BUILD_URL), nullptr, nullptr, SW_SHOWNORMAL);
 #elif defined(GIT_REMOTE_ORIGIN_URL)
-			::ShellExecute(GetHwnd(), NULL, _T(GIT_REMOTE_ORIGIN_URL), NULL, NULL, SW_SHOWNORMAL);
+			::ShellExecute(GetHwnd(), nullptr, TEXT(GIT_REMOTE_ORIGIN_URL), nullptr, nullptr, SW_SHOWNORMAL);
 #endif
 			return TRUE;
 		}
 	case IDC_STATIC_URL_GITHUB_COMMIT:
 #if defined(GITHUB_COMMIT_URL)
-		::ShellExecute(GetHwnd(), NULL, _T(GITHUB_COMMIT_URL), NULL, NULL, SW_SHOWNORMAL);
+		::ShellExecute(GetHwnd(), nullptr, TEXT(GITHUB_COMMIT_URL), nullptr, nullptr, SW_SHOWNORMAL);
 #endif
 		return TRUE;
 	case IDC_STATIC_URL_GITHUB_PR:
 #if defined(GITHUB_PR_HEAD_URL)
-		::ShellExecute(GetHwnd(), NULL, _T(GITHUB_PR_HEAD_URL), NULL, NULL, SW_SHOWNORMAL);
+		::ShellExecute(GetHwnd(), nullptr, TEXT(GITHUB_PR_HEAD_URL), nullptr, nullptr, SW_SHOWNORMAL);
 #endif
 		return TRUE;
 	}

--- a/sakura_core/util/MessageBoxF.h
+++ b/sakura_core/util/MessageBoxF.h
@@ -16,7 +16,7 @@
 #define SAKURA_MESSAGEBOXF_542C25FF_34EB_4920_AC1A_DA32919E101B_H_
 #pragma once
 
-#include <tchar.h>
+#include <wchar.h>
 #include <Windows.h>
 
 #include <cstdarg>

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -408,7 +408,7 @@ HFONT UpdateDialogFont( HWND hwnd, BOOL force )
 {
 	HFONT hFontDialog = (HFONT)::SendMessageAny( hwnd, WM_GETFONT, 0, (LPARAM)NULL );
 
-	if( !force && wcsncmp_literal( CSelectLang::getDefaultLangString(), _T("Japanese") ) != 0 ){
+	if( !force && wcsncmp_literal( CSelectLang::getDefaultLangString(), L"Japanese" ) != 0 ){
 		return hFontDialog;
 	}
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
Unicode版のみ対応だが、tchar.h をincludeしている。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. _T() マクロ(tchar.h) を TEXT() マクロ (winnt.h) に置き換える。
2. tchar.h を wchar.h に置き換える。

## <!-- わかる範囲で --> PR の影響範囲
影響なし。

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. コンパイル設定で、プリプロセッサ - ファイル前の処理 - はい(/P) に設定、前処理済み出力をファイル(*.i)に書き込み、変更前後で同じであることを確認する。
https://github.com/sakura-editor/sakura/commit/5ddb72e7b9a4ef64d7e0f3e04195126d4f2a7c6c
Debug/Win32 build 時のプリプロセッサ処理結果
```
CShareData::InitShareData()
std::wstring strShareDataName = GSTR_SHAREDATA;
std::wstring strShareDataName = (L"SakuraShareData" L"" L"WP" L"_DEBUG" L"181");

CNormalProcess::_GetInitializeMutex()
std::wstring strMutexInitName = GSTR_MUTEX_SAKURA_INIT;
std::wstring strMutexInitName = (L"MutexSakuraEditorInit" L"" L"WP" L"_DEBUG" L"181");
```

2. 変更前後でasmが同じことを確認する。
https://github.com/sakura-editor/sakura/commit/5ddb72e7b9a4ef64d7e0f3e04195126d4f2a7c6c

## <!-- なければ省略可 --> 関連 issue, PR
https://github.com/sakura-editor/sakura/pull/2066

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://learn.microsoft.com/ja-jp/windows/win32/api/winnt/nf-winnt-text
