### PR TITLE
CSV/TSVモードで開いた時に桁位置が揃わないのを修正

### DIFF
--- a/sakura_core/CLoadAgent.cpp
+++ b/sakura_core/CLoadAgent.cpp
@@ -247,8 +247,8 @@ ELoadResult CLoadAgent::OnLoad(const SLoadInfo& sLoadInfo)
 	// この後のSetLayoutInfoの中でもCTsvModeInfo::CalcTabLengthを呼ぶ所があるが
 	// TsvModeの変化がない場合にはそこでは呼ばれないので必要な場合はここでやっておく
 	if (ref.m_nTsvMode != TSV_MODE_NONE) {
-		pcDoc->m_cLayoutMgr.m_tsvInfo.CalcTabLength(pcDoc->m_cLayoutMgr.m_pcDocLineMgr);
 		pcDoc->m_cLayoutMgr.m_tsvInfo.m_nTsvMode = ref.m_nTsvMode;
+		pcDoc->m_cLayoutMgr.m_tsvInfo.CalcTabLength(pcDoc->m_cLayoutMgr.m_pcDocLineMgr);
 	}
 
 	CProgressSubject* pOld = CEditApp::getInstance()->m_pcVisualProgress->CProgressListener::Listen(&pcDoc->m_cLayoutMgr);


### PR DESCRIPTION
# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 必須 --> PR の背景

サクラエディタふぁんくらぶ
https://egg.5ch.net/test/read.cgi/software/1712374843/436
で報告されている問題を修正します。

確認できた発生条件/手順:
* タイプ別設定の「基本」がCSVモードまたはTSVモードになっておらず、
* CSVモードまたはTSVモードが設定されたタイプ別設定が1つ以上登録されている状態で、
* 該当の拡張子のファイルを開くと各行の桁位置が揃っていない状態で表示される

## <!-- 必須 --> 仕様・動作説明

不具合の修正のみで仕様変更はありません。

## <!-- わかる範囲で --> PR の影響範囲

特にありません。

## <!-- 必須 --> テスト内容

効果確認:
* CSVファイルまたはTSVファイルを開く
  →各行の桁位置が揃っていることを確認
* 文字列を追加して一時的に桁位置が揃わない状態にして上書き保存する
* メニューから ファイル > 開きなおす > 開きなおす をクリックする
  →各行の桁位置が再度揃うことを確認

弊害確認:
* 各行にカンマを含むテキストファイル (.txt) を開く
  →カンマが1文字分の幅で表示されることを確認

## <!-- なければ省略可 --> 関連 issue, PR

#1992 (不具合の元になったPR)