### PR TITLE
C++11 in-class initializer 対応 (GrepInfo)

### DIFF
--- a/sakura_core/GrepInfo.cpp
+++ b/sakura_core/GrepInfo.cpp
@@ -12,23 +12,5 @@
  * コンストラクタ
  */
 GrepInfo::GrepInfo() noexcept
-	: cmGrepKey()
-	, cmGrepRep()
-	, cmGrepFile()
-	, cmGrepFolder()
-	, sGrepSearchOption()
-	, bGrepCurFolder(false)
-	, bGrepStdout(false)
-	, bGrepHeader(true)
-	, bGrepSubFolder(false)
-	, nGrepCharSet(CODE_SJIS)
-	, nGrepOutputStyle(1)
-	, nGrepOutputLineType(0)
-	, bGrepOutputFileOnly(false)
-	, bGrepOutputBaseFolder(false)
-	, bGrepSeparateFolder(false)
-	, bGrepReplace(false)
-	, bGrepPaste(false)
-	, bGrepBackup(false)
 {
 }

--- a/sakura_core/GrepInfo.h
+++ b/sakura_core/GrepInfo.h
@@ -21,24 +21,24 @@
  *   memcmp による比較を行ってはならない。
  */
 struct GrepInfo {
-	CNativeW		cmGrepKey;				//!< 検索キー
-	CNativeW		cmGrepRep;				//!< 置換キー
-	CNativeW		cmGrepFile;				//!< 検索対象ファイル
-	CNativeW		cmGrepFolder;			//!< 検索対象フォルダー
-	SSearchOption	sGrepSearchOption;		//!< 検索オプション
-	bool			bGrepCurFolder;			//!< カレントディレクトリを維持
-	bool			bGrepStdout;			//!< 標準出力モード
-	bool			bGrepHeader;			//!< ヘッダー情報表示
-	bool			bGrepSubFolder;			//!< サブフォルダーを検索する
-	ECodeType		nGrepCharSet;			//!< 文字コードセット
-	int				nGrepOutputStyle;		//!< 結果出力形式
-	int				nGrepOutputLineType;	//!< 結果出力：行を出力/該当部分/否マッチ行
-	bool			bGrepOutputFileOnly;	//!< ファイル毎最初のみ検索
-	bool			bGrepOutputBaseFolder;	//!< ベースフォルダー表示
-	bool			bGrepSeparateFolder;	//!< フォルダー毎に表示
-	bool			bGrepReplace;			//!< Grep置換
-	bool			bGrepPaste;				//!< クリップボードから貼り付け
-	bool			bGrepBackup;			//!< 置換でバックアップを保存
+	CNativeW		cmGrepKey = {};					//!< 検索キー
+	CNativeW		cmGrepRep = {};					//!< 置換キー
+	CNativeW		cmGrepFile = {};				//!< 検索対象ファイル
+	CNativeW		cmGrepFolder = {};				//!< 検索対象フォルダー
+	SSearchOption	sGrepSearchOption = {};			//!< 検索オプション
+	bool			bGrepCurFolder = false;			//!< カレントディレクトリを維持
+	bool			bGrepStdout = false;			//!< 標準出力モード
+	bool			bGrepHeader = true;				//!< ヘッダー情報表示
+	bool			bGrepSubFolder = false;			//!< サブフォルダーを検索する
+	ECodeType		nGrepCharSet = CODE_SJIS;		//!< 文字コードセット
+	int				nGrepOutputStyle = 1;			//!< 結果出力形式
+	int				nGrepOutputLineType = 0;		//!< 結果出力：行を出力/該当部分/否マッチ行
+	bool			bGrepOutputFileOnly = false;	//!< ファイル毎最初のみ検索
+	bool			bGrepOutputBaseFolder = false;	//!< ベースフォルダー表示
+	bool			bGrepSeparateFolder = false;	//!< フォルダー毎に表示
+	bool			bGrepReplace = false;			//!< Grep置換
+	bool			bGrepPaste = false;				//!< クリップボードから貼り付け
+	bool			bGrepBackup = false;			//!< 置換でバックアップを保存
 
 	// コンストラクタ
 	GrepInfo() noexcept;

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -94,7 +94,6 @@ bool CNormalProcess::InitializeProcess()
 	bool			bDebugMode;
 	bool			bGrepMode;
 	bool			bGrepDlg;
-	GrepInfo		gi;
 	EditInfo		fi;
 	
 	/* コマンドラインで受け取ったファイルが開かれている場合は */
@@ -199,6 +198,7 @@ bool CNormalProcess::InitializeProcess()
 			::GetClientRect( hEditWnd, &rc );
 			::SendMessageAny( hEditWnd, WM_SIZE, ::IsZoomed( hEditWnd )? SIZE_MAXIMIZED: SIZE_RESTORED, MAKELONG( rc.right - rc.left, rc.bottom - rc.top ) );
 		}
+		GrepInfo gi;
 		CCommandLine::getInstance()->GetGrepInfo(&gi); // 2002/2/8 aroka ここに移動
 		if( !bGrepDlg ){
 			// Grepでは対象パス解析に現在のカレントディレクトリを必要とする


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
GrepInfo クラスで、メンバ変数をコンストラクタの初期化子リストで初期化している。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. 変数宣言時に初期化するようにします。
2. CNormalProcess::InitializeProcess() で 不要なコンストラクタ呼び出しをしないように gi の宣言を移動します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
変更前後で、 GrepInfo クラスのコンストラクタに break を設定し、メンバ変数を確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1116

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://cpprefjp.github.io/lang/cpp11/non_static_data_member_initializers.html