### PR TITLE
C++11 range-based for loop 対応 (CProfile)

### DIFF
--- a/sakura_core/CProfile.cpp
+++ b/sakura_core/CProfile.cpp
@@ -230,12 +230,12 @@ bool CProfile::WriteProfile(
 		vecLine.emplace_back( L";" + std::wstring( pszComment ) );		// //->;	2008/5/24 Uchi
 		vecLine.push_back( LTEXT("") );
 	}
-	for(auto iter = m_ProfileData.cbegin(); iter != m_ProfileData.cend(); iter++ ) {
+	for(const auto& iter : m_ProfileData) {
 		//セクション名を書き込む
-		vecLine.push_back( LTEXT("[") + iter->strSectionName + LTEXT("]") );
-		for(auto mapiter = iter->mapEntries.cbegin(); mapiter != iter->mapEntries.cend(); mapiter++ ) {
+		vecLine.emplace_back( L"[" + iter.strSectionName + L"]" );
+		for(const auto& mapiter : iter.mapEntries) {
 			//エントリを書き込む
-			vecLine.push_back( mapiter->first + LTEXT("=") + mapiter->second );
+			vecLine.emplace_back( mapiter.first + L"=" + mapiter.second );
 		}
 		vecLine.push_back( LTEXT("") );
 	}
@@ -354,10 +354,10 @@ void CProfile::DUMP( void )
 #ifdef _DEBUG
 	//	2006.02.20 ryoji: MAP_STR_STR_ITER削除時の修正漏れによるコンパイルエラー修正
 	MYTRACE( L"\n\nCProfile::DUMP()======================" );
-	for(auto iter = m_ProfileData.cbegin(); iter != m_ProfileData.cend(); iter++ ) {
-		MYTRACE( L"\n■strSectionName=%ls", iter->strSectionName.c_str() );
-		for(auto mapiter = iter->mapEntries.cbegin(); mapiter != iter->mapEntries.cend(); mapiter++ ) {
-			MYTRACE( L"\"%ls\" = \"%ls\"\n", mapiter->first.c_str(), mapiter->second.c_str() );
+	for(const auto& iter : m_ProfileData) {
+		MYTRACE( L"\n■strSectionName=%ls", iter.strSectionName.c_str() );
+		for(const auto& mapiter : iter.mapEntries) {
+			MYTRACE( L"\"%ls\" = \"%ls\"\n", mapiter.first.c_str(), mapiter.second.c_str() );
 		}
 	}
 	MYTRACE( L"========================================\n" );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
C++11 から range-based for loop が使用できるので、簡潔に記述できる。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. range-based for loop に変更
2. push_back() -> emplace_back() に変更

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. 変更前後で、sakura.ini を比較する。
デバッガの引数に "-NOWIN" を追加
タスクトレイから、サクラエディタの全終了を選択
2. CProfile::DUMP() を呼び出してdump内容を確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1733
https://github.com/sakura-editor/sakura/pull/416

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://cpprefjp.github.io/lang/cpp11/range_based_for.html
