### PR TITLE
static変数 g_pOldToolBarWndProc 削除

### DIFF
--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -81,9 +81,7 @@ void CMainToolBar::ProcSearchBox( MSG *msg )
 	@author ryoji
 	@date 2006.09.06 ryoji
 */
-static WNDPROC g_pOldToolBarWndProc;	// ツールバーの本来のウィンドウプロシージャ
-
-static LRESULT CALLBACK ToolBarWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
+LRESULT CALLBACK CMainToolBar::ToolBarWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, [[maybe_unused]] DWORD_PTR dwRefData )
 {
 	switch( msg )
 	{
@@ -95,10 +93,12 @@ static LRESULT CALLBACK ToolBarWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPAR
 
 	case WM_DESTROY:
 		// サブクラス化解除
-		::SetWindowLongPtr( hWnd, GWLP_WNDPROC, (LONG_PTR)g_pOldToolBarWndProc );
+		::RemoveWindowSubclass(hWnd, &ToolBarWndProc, uIdSubclass);
+		return 0L;
+	default:
 		break;
 	}
-	return ::CallWindowProc( g_pOldToolBarWndProc, hWnd, msg, wParam, lParam );
+	return ::DefSubclassProc( hWnd, msg, wParam, lParam );
 }
 
 /* ツールバー作成
@@ -179,11 +179,7 @@ void CMainToolBar::CreateToolBar( void )
 	}
 	else{
 		// 2006.09.06 ryoji ツールバーをサブクラス化する
-		g_pOldToolBarWndProc = (WNDPROC)::SetWindowLongPtr(
-			m_hwndToolBar,
-			GWLP_WNDPROC,
-			(LONG_PTR)ToolBarWndProc
-		);
+		::SetWindowSubclass(m_hwndToolBar, &ToolBarWndProc, 0, 0);
 
 		// pixel数をベタ書きするとHighDPI環境でずれるのでシステム値を取得して使う
 		const int cxBorder = DpiScaleX( 1 );

--- a/sakura_core/window/CMainToolBar.h
+++ b/sakura_core/window/CMainToolBar.h
@@ -49,6 +49,8 @@ public:
 	void SetFocusSearchBox( void ) const;		/* ツールバー検索ボックスへフォーカスを移動 */	// 2006.06.04 yukihane
 
 private:
+	static LRESULT CALLBACK ToolBarWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData );
+
 	CEditWnd*	m_pOwner;
     HWND		m_hwndToolBar;
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
コントロールのサブクラス化で、static変数 g_pOldToolBarWndProc を使っている。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
SetWindowLongPtr() の代わりに SetWindowSubclass() / RemoveWindowSubclass() を使用する。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
設定 - 表示中のツールバーを隠す 実行時に RemoveWindowSubclass() が実行されることを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2036

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
