### PR TITLE
C++11 in-class initializer 対応 (CWnd)

### DIFF
--- a/sakura_core/window/CWnd.cpp
+++ b/sakura_core/window/CWnd.cpp
@@ -80,12 +80,9 @@ next:
 
 CWnd::CWnd(const WCHAR* pszInheritanceAppend)
 {
-	m_hInstance = nullptr;	/* アプリケーションインスタンスのハンドル */
-	m_hwndParent = nullptr;	/* オーナーウィンドウのハンドル */
-	m_hWnd = nullptr;			/* このウィンドウのハンドル */
 #ifdef _DEBUG
-	wcscpy( m_szClassInheritances, L"CWnd" );
-	wcscat( m_szClassInheritances, pszInheritanceAppend );
+	wcsncpy_s( m_szClassInheritances, _countof(m_szClassInheritances), L"CWnd", _TRUNCATE );
+	wcsncat_s( m_szClassInheritances, _countof(m_szClassInheritances), pszInheritanceAppend, _TRUNCATE );
 #endif
 }
 

--- a/sakura_core/window/CWnd.h
+++ b/sakura_core/window/CWnd.h
@@ -119,9 +119,9 @@ public:
 	void DestroyWindow();
 
 private: // 2002/2/10 aroka アクセス権変更
-	HINSTANCE	m_hInstance;	// アプリケーションインスタンスのハンドル
-	HWND		m_hwndParent;	// オーナーウィンドウのハンドル
-	HWND		m_hWnd;			// このダイアログのハンドル
+	HINSTANCE	m_hInstance = nullptr;	// アプリケーションインスタンスのハンドル
+	HWND		m_hwndParent = nullptr;	// オーナーウィンドウのハンドル
+	HWND		m_hWnd = nullptr;		// このダイアログのハンドル
 #ifdef _DEBUG
 	WCHAR		m_szClassInheritances[1024];
 #endif


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
CWnd クラスで、メンバ変数をコンストラクタの初期化子リストで初期化している。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. 変数宣言時に初期化するようにします。
2. wcscpy -> wcsncpy_s に置き換えます。
3. wcscat -> wcsncat_s に置き換えます。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
変更前後で、 CWnd クラスのコンストラクタに break を設定し、メンバ変数を確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2110
https://github.com/sakura-editor/sakura/pull/2134

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
