### PR TITLE
C++11 in-class initializer 対応 (CControlTray)

### DIFF
--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -195,18 +195,10 @@ static LRESULT CALLBACK CControlTrayWndProc(
 // CControlTray
 //	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 CControlTray::CControlTray()
-//	Apr. 24, 2001 genta
-: m_pcPropertyManager(nullptr)
-, m_hInstance( nullptr )
-, m_hWnd( nullptr )
-, m_bCreatedTrayIcon( FALSE )	//トレイにアイコンを作った
-, m_nCurSearchKeySequence(-1)
-, m_uCreateTaskBarMsg( ::RegisterWindowMessage( TEXT("TaskbarCreated") ) )
+: m_uCreateTaskBarMsg( ::RegisterWindowMessage( L"TaskbarCreated" ) )
 {
 	/* 共有データ構造体のアドレスを返す */
 	m_pShareData = &GetDllShareData();
-
-	m_bUseTrayMenu = false;
 
 	return;
 }

--- a/sakura_core/_main/CControlTray.h
+++ b/sakura_core/_main/CControlTray.h
@@ -113,15 +113,15 @@ protected:
 	*/
 private:
 	CMenuDrawer		m_cMenuDrawer;
-	CPropertyManager*	m_pcPropertyManager;
-	bool			m_bUseTrayMenu;			//トレイメニュー表示中
-	HINSTANCE		m_hInstance;
-	HWND			m_hWnd;
-	BOOL			m_bCreatedTrayIcon;		//!< トレイにアイコンを作った
+	CPropertyManager*	m_pcPropertyManager = nullptr;
+	bool			m_bUseTrayMenu = false;			//トレイメニュー表示中
+	HINSTANCE		m_hInstance = nullptr;
+	HWND			m_hWnd = nullptr;
+	BOOL			m_bCreatedTrayIcon = FALSE;		//!< トレイにアイコンを作った
 
 	DLLSHAREDATA*	m_pShareData;
 	CDlgGrep		m_cDlgGrep;				// Jul. 2, 2001 genta
-	int				m_nCurSearchKeySequence;
+	int				m_nCurSearchKeySequence = -1;
 
 	CImageListMgr	m_hIcons;
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
CControlTray クラスで、メンバ変数をコンストラクタの初期化子リストで初期化している。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
変数宣言時に初期化するようにします。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. デバッガの引数に "-NOWIN" を追加する。
2. 変更前後で、 CControlTray クラスのコンストラクタに break を設定し、メンバ変数を確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2110
https://github.com/sakura-editor/sakura/pull/2134

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
