### PR TITLE
ファイル名変更通知ブロードキャストの頻度を抑制

### DIFF
--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -21,7 +21,7 @@ struct EditNode {
 	int				m_nGroup;					//!< グループID								//@@@ 2007.06.20 ryoji
 	HWND			m_hWnd;
 	int				m_nId;						//!< 無題Id
-	WCHAR			m_szTabCaption[_MAX_PATH];	//!< タブウインドウ用：キャプション名		//@@@ 2003.05.31 MIK
+	WCHAR			m_szTabCaption[_MAX_PATH]{}; //!< タブウインドウ用：キャプション名		//@@@ 2003.05.31 MIK
 	SFilePath		m_szFilePath;				//!< タブウインドウ用：ファイル名			//@@@ 2006.01.28 ryoji
 	bool			m_bIsGrep;					//!< Grepのウィンドウか						//@@@ 2006.01.28 ryoji
 	UINT			m_showCmdRestore;			//!< 元のサイズに戻すときのサイズ種別		//@@@ 2007.06.20 ryoji

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -4006,29 +4006,42 @@ void CEditWnd::ChangeFileNameNotify( const WCHAR* pszTabCaption, const WCHAR* _p
 
 	CRecentEditNode	cRecentEditNode;
 	int nIndex = cRecentEditNode.FindItemByHwnd( GetHwnd() );
+	bool changed = false;
 	if( -1 != nIndex )
 	{
 		EditNode *p = cRecentEditNode.GetItem( nIndex );
 		if( p )
 		{
-			wcsncpy_s( p->m_szTabCaption, _countof(p->m_szTabCaption), pszTabCaption, _TRUNCATE );
+			decltype(p->m_szTabCaption) caption;
+			wcsncpy_s(caption, _countof(caption), pszTabCaption, _TRUNCATE);
+			if (wcscmp(caption, p->m_szTabCaption) != 0) {
+				wcscpy_s(p->m_szTabCaption, caption);
+				changed = true;
+			}
 
 			// 2006.01.28 ryoji ファイル名、Grepモード追加
-			wcsncpy_s( p->m_szFilePath, _countof2(p->m_szFilePath), pszFilePath, _TRUNCATE );
+			decltype(p->m_szFilePath) filePath;
+			wcsncpy_s(filePath, _countof2(filePath), pszFilePath, _TRUNCATE );
+			if (wcscmp(filePath, p->m_szFilePath) != 0) {
+				p->m_szFilePath = filePath;
+				changed = true;
+			}
 
 			p->m_bIsGrep = bIsGrep;
 		}
 	}
 	cRecentEditNode.Terminate();
 
-	//ファイル名変更通知をブロードキャストする。
-	int nGroup = CAppNodeManager::getInstance()->GetEditNode( GetHwnd() )->GetGroup();
-	CAppNodeGroupHandle(nGroup).PostMessageToAllEditors(
-		MYWM_TAB_WINDOW_NOTIFY,
-		(WPARAM)TWNT_FILE,
-		(LPARAM)GetHwnd(),
-		GetHwnd()
-	);
+	if (changed) {
+		//ファイル名変更通知をブロードキャストする。
+		int nGroup = CAppNodeManager::getInstance()->GetEditNode( GetHwnd() )->GetGroup();
+		CAppNodeGroupHandle(nGroup).PostMessageToAllEditors(
+			MYWM_TAB_WINDOW_NOTIFY,
+			(WPARAM)TWNT_FILE,
+			(LPARAM)GetHwnd(),
+			GetHwnd()
+		);
+	}
 
 	return;
 }


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->

https://github.com/sakura-editor/sakura/pull/2153#issuecomment-3507217326 に記載

タイトルが更新されない場合にも `CEditWnd::ChangeFileNameNotify` の最後でファイル名変更通知をブロードキャストして `CEditWnd::DispatchEvent` の `case MYWM_TAB_WINDOW_NOTIFY` で処理するのが定期的に実行されているのでもったいないなと思いました。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->

タブの見出しやファイル名の内容が変わっていない場合はファイル名変更通知をブロードキャストしないようにしました。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

タブ名が今まで通りと変わらず変更される事を確認

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
