### PR TITLE
C++11 in-class initializer対応(CControlTray) take2

### DIFF
--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -369,6 +369,8 @@ LRESULT CControlTray::DispatchEvent(
 	LPARAM	lParam 	// second message parameter
 )
 {
+	const auto hWnd = hwnd;
+
 	int				nId;
 	HWND			hwndWork;
 	LPHELPINFO		lphi;
@@ -1030,18 +1032,18 @@ LRESULT CControlTray::DispatchEvent(
 	case MYWM_ALLOWACTIVATE:
 		::AllowSetForegroundWindow(wParam);
 		return 0L;
+
 	default:
-// << 20010412 by aroka
-//	Apr. 24, 2001 genta RegisterWindowMessageを使うように修正
-		if( uMsg == m_uCreateTaskBarMsg ){
-			/* TaskTray Iconの再登録を要求するメッセージ．
-				Explorerが再起動したときに送出される．*/
-			CreateTrayIcon( GetTrayHwnd() ) ;
+		// タスクバーが再作成されたときは、トレイアイコンを再登録する
+		if (gm_uMsgTaskbarCreated == uMsg) {
+			CreateTrayIcon(hWnd);
+			break;	//あとはデフォルトに任せる
 		}
 		break;	/* default */
-// >> by aroka
 	}
-	return DefWindowProc( hwnd, uMsg, wParam, lParam );
+
+	//あとはデフォルトに任せる
+	return DefWindowProcW(hWnd, uMsg, wParam, lParam);
 }
 
 /* WM_COMMANDメッセージ処理 */

--- a/sakura_core/_main/CControlTray.h
+++ b/sakura_core/_main/CControlTray.h
@@ -46,6 +46,20 @@ class CPropertyManager;
 */
 class CControlTray
 {
+private:
+	/*!
+	 * トレイアイコン再登録要求のメッセージID。
+	 *
+	 * Windows エクスプローラーが再起動したときに送出される。
+	 *
+	 * 独自メッセージは、システムグローバルな領域に登録される。
+	 * 同じ名前に対しては、同じメッセージIDが返される仕様なので
+	 * init only のグローバル定数とみなすことができる。
+	 *
+	 * @date 2001/04/24 genta
+	 */
+	static inline const UINT gm_uMsgTaskbarCreated = ::RegisterWindowMessageW(L"TaskbarCreated");
+
 public:
 	/*
 	||  Constructors
@@ -124,8 +138,6 @@ private:
 	int				m_nCurSearchKeySequence = -1;
 
 	CImageListMgr	m_hIcons;
-
-	UINT			m_uCreateTaskBarMsg = ::RegisterWindowMessageW(L"TaskbarCreated");	//!< RegisterMessageで得られるMessage IDの保管場所。Apr. 24, 2001 genta
 
 	SFilePath		m_szLanguageDll = nullptr;
 };


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2157  
レビューコメント

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->

- in-class initializeの追加対応（m_uCreateTaskBarMsg）
- 初期化できないメンバー m_szLanguageDll の型を変更。（生配列→SFilePath）
- m_uCreateTaskBarMsgをクラス定数に変更。
- リネーム m_uCreateTaskBarMsg → gm_uMsgTaskbarCreated。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
- プロセス起動時とWindows エクスプローラー再起動時の挙動に影響、実害はなし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
- プログラム構造上、テスト不可。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
