### PR TITLE
C++11 in-class initializer 対応 (CSortedTagJumpList)

### DIFF
--- a/sakura_core/CSortedTagJumpList.cpp
+++ b/sakura_core/CSortedTagJumpList.cpp
@@ -13,20 +13,16 @@
 
 #include "StdAfx.h"
 #include "CSortedTagJumpList.h"
-
 #include "util/tchar_convert.h"
 
 /*!
 	@date 2005.04.23 genta 管理数の最大値を指定する引数追加
 */
 CSortedTagJumpList::CSortedTagJumpList(int max)
-	: m_pTagjump( nullptr ),
-	  m_nCount( 0 ),
-	  m_bOverflow( false ),
-	  m_MAX_TAGJUMPLIST( max )
+	: m_MAX_TAGJUMPLIST( max )
 {
 	// id==0 を 空文字列にする
-	m_baseDirArr.push_back(L"");
+	m_baseDirArr.emplace_back(L"");
 }
 
 CSortedTagJumpList::~CSortedTagJumpList()

--- a/sakura_core/CSortedTagJumpList.h
+++ b/sakura_core/CSortedTagJumpList.h
@@ -55,10 +55,10 @@ public:
 	int GetCapacity(void) const { return m_MAX_TAGJUMPLIST; }
 
 private:
-	TagJumpInfo*	m_pTagjump;	//!< タグジャンプ情報
+	TagJumpInfo*	m_pTagjump = nullptr;	//!< タグジャンプ情報
 	std::vector<std::wstring> m_baseDirArr;	//!< ベースディレクトリ情報
-	int				m_nCount;	//!< 個数
-	bool			m_bOverflow;	//!< オーバーフロー
+	int				m_nCount = 0;	//!< 個数
+	bool			m_bOverflow = false;	//!< オーバーフロー
 	
 	//	2005.04.22 genta 最大値を可変に
 	const int		m_MAX_TAGJUMPLIST;	//!< 管理する情報の最大数


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
CSortedTagJumpList クラスで、メンバ変数をコンストラクタで初期化している。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. 変数宣言時に初期化するようにします。
2. push_back() -> emplace_back() に変更します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
変更前後で、 CSortedTagJumpList クラスのコンストラクタに break を設定し、メンバ変数を確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2110
https://github.com/sakura-editor/sakura/pull/2134
https://github.com/sakura-editor/sakura/pull/416

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
