### PR TITLE
C++11 in-class initializer 対応 (CDropTarge)

### DIFF
--- a/sakura_core/_os/CDropTarget.cpp
+++ b/sakura_core/_os/CDropTarget.cpp
@@ -93,16 +93,12 @@ DECLARE_YB_INTERFACEIMPL( IEnumFORMATETC )
 CDropTarget::CDropTarget( CEditWnd* pCEditWnd )
 {
 	m_pcEditWnd = pCEditWnd;	// 2008.06.20 ryoji
-	m_pcEditView = nullptr;
-	m_hWnd_DropTarget = nullptr;
 	return;
 }
 
 CDropTarget::CDropTarget( CEditView* pCEditView )
 {
-	m_pcEditWnd = nullptr;	// 2008.06.20 ryoji
 	m_pcEditView = pCEditView;
-	m_hWnd_DropTarget = nullptr;
 	return;
 }
 

--- a/sakura_core/_os/CDropTarget.h
+++ b/sakura_core/_os/CDropTarget.h
@@ -97,10 +97,9 @@ public:
 	||  Attributes & Operations
 	*/
 private: // 2002/2/10 aroka アクセス権変更
-	CEditWnd*		m_pcEditWnd;	// 2008.06.20 ryoji
-	HWND			m_hWnd_DropTarget;
-	CEditView*		m_pcEditView;
-	//	static REFIID	m_owniid;
+	CEditWnd*		m_pcEditWnd = nullptr;	// 2008.06.20 ryoji
+	HWND			m_hWnd_DropTarget = nullptr;
+	CEditView*		m_pcEditView = nullptr;
 public:
 	BOOL			Register_DropTarget(HWND hWnd);
 	BOOL			Revoke_DropTarget( void );
@@ -135,13 +134,11 @@ private:
 		unsigned int	size;	//データサイズ。バイト単位。
 	} DATA, *PDATA;
 
-	int m_nFormat;
-	PDATA m_pData;
+	int m_nFormat = 0;
+	PDATA m_pData = nullptr;
 
 public:
-	CDataObject (LPCWSTR lpszText, size_t nTextLen, BOOL bColumnSelect ):
-		m_nFormat(0),
-		m_pData(nullptr)
+	CDataObject (LPCWSTR lpszText, size_t nTextLen, BOOL bColumnSelect )
 	{
 		SetText( lpszText, nTextLen, bColumnSelect );
 	}
@@ -166,11 +163,11 @@ public:
 //	2008.03.26 ryoji 新規作成
 class CEnumFORMATETC : public CYbInterfaceImpl<IEnumFORMATETC> {
 private:
-	LONG m_lRef;
-	int m_nIndex;
+	LONG m_lRef = 1;
+	int m_nIndex = 0;
 	CDataObject* m_pcDataObject;
 public:
-	CEnumFORMATETC(CDataObject* pcDataObject) : m_lRef(1), m_nIndex(0), m_pcDataObject(pcDataObject) {}
+	CEnumFORMATETC(CDataObject* pcDataObject) : m_pcDataObject(pcDataObject) {}
 	STDMETHOD_( ULONG, AddRef )( void )
 	{return ::InterlockedIncrement(&m_lRef);}
 	STDMETHOD_( ULONG, Release )( void )


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
CDropTarge / CDataObject / CEnumFORMATETC クラスで、メンバ変数をコンストラクタで初期化している。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
変数宣言時に初期化するようにします。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

1.変更前後で、 CDropTarge クラスのコンストラクタに break を設定し、メンバ変数を確認する。
2.変更前後で、 CDataObject / CEnumFORMATETC クラスのコンストラクタに break を設定し、メンバ変数を確認する。
テキストを選択し、ドラッグ & ドロップ を行います。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2110
https://github.com/sakura-editor/sakura/pull/2134

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
