### PR TITLE
Optimize codebase: improve memory safety and remove dead code

### DIFF
--- a/sakura_core/CCodeChecker.cpp
+++ b/sakura_core/CCodeChecker.cpp
@@ -8,8 +8,9 @@
 #include "CCodeChecker.h"
 #include "charset/CCodePage.h"
 #include "io/CIoBridge.h"
-#include "charset/CCodeFactory.h" ////
+#include "charset/CCodeFactory.h"
 #include "charset/CUnicode.h"
+#include <memory>
 
 #include "doc/CEditDoc.h"
 #include "doc/logic/CDocLineMgr.h"
@@ -50,7 +51,7 @@ static EConvertResult _CheckSavingCharcode(const CDocLineMgr& pcDocLineMgr, ECod
 {
 	const CDocLine*	pcDocLine = pcDocLineMgr.GetDocLineTop();
 	const bool bCodePageMode = IsValidCodeOrCPType(eCodeType) && !IsValidCodeType(eCodeType);
-	CCodeBase* pCodeBase=CCodeFactory::CreateCodeBase(eCodeType,0);
+	std::unique_ptr<CCodeBase> pCodeBase(CCodeFactory::CreateCodeBase(eCodeType,0));
 	CMemory cmemTmp;	// バッファを再利用
 	CNativeW cmemTmp2;
 	CLogicInt nLine = CLogicInt(0);
@@ -89,7 +90,6 @@ static EConvertResult _CheckSavingCharcode(const CDocLineMgr& pcDocLineMgr, ECod
 				point.x = CLogicInt(nPos);
 				// 変換できなかった位置の1文字取得
 				wc.SetString( p + nPos, (Int)CNativeW::GetSizeOfChar( p, nDocLineLen, nPos ) );
-				delete pCodeBase;
 				return RESULT_LOSESOME;
 			}
 		}
@@ -119,7 +119,6 @@ static EConvertResult _CheckSavingCharcode(const CDocLineMgr& pcDocLineMgr, ECod
 					chars = CNativeW::GetSizeOfChar( pLine, nLineLen, nPos );
 				}
 			}
-			delete pCodeBase;
 			return e;
 		}
 
@@ -127,7 +126,6 @@ static EConvertResult _CheckSavingCharcode(const CDocLineMgr& pcDocLineMgr, ECod
 		pcDocLine = pcDocLine->GetNextLine();
 		nLine++;
 	}
-	delete pCodeBase;
 	return RESULT_COMPLETE;
 }
 

--- a/sakura_core/CGrepAgent.cpp
+++ b/sakura_core/CGrepAgent.cpp
@@ -1430,7 +1430,7 @@ int CGrepAgent::DoGrepFile(
 		{
 			if( CODE_AUTODETECT == sGrepOption.nGrepCharSet ){
 				if( IsValidCodeType(nCharCode) ){
-					wcscpy( szCpName, CCodeTypeName(nCharCode).Bracket() );
+					wcscpy_s( szCpName, _countof(szCpName), CCodeTypeName(nCharCode).Bracket() );
 					pszCodeName = szCpName;
 				}else{
 					CCodePage::GetNameBracket(szCpName, nCharCode);
@@ -1879,7 +1879,7 @@ int CGrepAgent::DoGrepReplaceFile(
 		{
 			if( CODE_AUTODETECT == sGrepOption.nGrepCharSet ){
 				if( IsValidCodeType(nCharCode) ){
-					wcscpy( szCpName, CCodeTypeName(nCharCode).Bracket() );
+					wcscpy_s( szCpName, _countof(szCpName), CCodeTypeName(nCharCode).Bracket() );
 					pszCodeName = szCpName;
 				}else{
 					CCodePage::GetNameBracket(szCpName, nCharCode);

--- a/sakura_core/CKeyWordSetMgr.cpp
+++ b/sakura_core/CKeyWordSetMgr.cpp
@@ -537,31 +537,6 @@ bool CKeyWordSetMgr::CanAddKeyWord( int nIdx )
 	return false;
 }
 
-#if 0
-/*!	新しいキーワードセットのキーワード領域を確保する
-	m_nKeyWordSetNumは、呼び出し側が、呼び出した後に+1する
-*/
-bool CKeyWordSetMgr::KeyWordAlloc( int nSize )
-{
-	// assert( m_nKeyWordSetNum < MAX_SETNUM );
-	// assert( 0 <= nSize );
-
-	// ブロックのサイズで整列
-	int nAllocSize = GetAlignmentSize( nSize );
-
-	if( GetFreeSize() < nAllocSize ){
-		// メモリ不足
-		return false;
-	}
-	m_nStartIdx[m_nKeyWordSetNum + 1] = m_nStartIdx[m_nKeyWordSetNum] + nAllocSize;
-	int i;
-	for( i = m_nKeyWordSetNum + 1; i < MAX_SETNUM; i++ ){
-		m_nStartIdx[i + 1] = m_nStartIdx[i];
-	}
-	return true;
-}
-#endif
-
 /*!	初期化済みのキーワードセットのキーワード領域の再割り当て、解放を行う
 
 	@param nIdx [in] キーワードセット番号

--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -502,11 +502,10 @@ bool CClipboard::SetClipboardByFormat(const CStringRef& cstr, const wchar_t* pFo
 			pBuf = (char*)cstr.GetPtr();
 			nTextByteLen = cstr.GetLength() * sizeof(wchar_t);
 		}else{
-			CCodeBase* pCode = CCodeFactory::CreateCodeBase(eMode, GetDllShareData().m_Common.m_sFile.GetAutoMIMEdecode());
+			std::unique_ptr<CCodeBase> pCode(CCodeFactory::CreateCodeBase(eMode, GetDllShareData().m_Common.m_sFile.GetAutoMIMEdecode()));
 			if( RESULT_FAILURE == pCode->UnicodeToCode(cstr, &cmemBuf) ){
 				return false;
 			}
-			delete pCode;
 			pBuf = (char*)cmemBuf.GetRawPtr();
 			nTextByteLen = cmemBuf.GetRawLength();
 		}
@@ -630,12 +629,11 @@ bool CClipboard::GetClipboardByFormat(CNativeW& mem, const wchar_t* pFormatName,
 				CMemory cmem;
 				cmem.SetRawData(pData, nLength);
 				if( nullptr != cmem.GetRawPtr() ){
-					CCodeBase* pCode = CCodeFactory::CreateCodeBase(eMode, GetDllShareData().m_Common.m_sFile.GetAutoMIMEdecode());
+					std::unique_ptr<CCodeBase> pCode(CCodeFactory::CreateCodeBase(eMode, GetDllShareData().m_Common.m_sFile.GetAutoMIMEdecode()));
 					if( RESULT_FAILURE == pCode->CodeToUnicode(cmem, &mem) ){
 						mem.SetString(L"");
 						retVal = false;
 					}
-					delete pCode;
 				}
 			}
 		}

--- a/sakura_core/doc/layout/CLayout.h
+++ b/sakura_core/doc/layout/CLayout.h
@@ -69,7 +69,7 @@ public:
 	CLayoutInt GetIndent() const {	return m_nIndent;	}	//!< このレイアウト行のインデントサイズを取得。単位は半角文字。	CMemoryIterator用
 
 	//取得インターフェース
-	CLogicInt GetLogicLineNo() const{ if(this)return m_ptLogicPos.GetY2(); else return CLogicInt(-1); } //$$$高速化 // TODO: Remove "this" check
+	CLogicInt GetLogicLineNo() const{ return m_ptLogicPos.GetY2(); }
 	static CLogicInt GetLogicLineNo_Safe(const CLayout* layout) {
 		if (layout)
 			return layout->m_ptLogicPos.GetY2();
@@ -106,7 +106,7 @@ public:
 	void _SetNextLayout(CLayout* pcLayout){ m_pNext = pcLayout; }
 
 	//実データ参照
-	const CDocLine* GetDocLineRef() const{ if(this)return m_pCDocLine; else return nullptr; } //$$note:高速化 // TODO: Remove "this" check
+	const CDocLine* GetDocLineRef() const{ return m_pCDocLine; }
 
 	//その他属性参照
 	const CEol& GetLayoutEol() const{ return m_cEol; }

--- a/sakura_core/doc/logic/CDocLine.h
+++ b/sakura_core/doc/logic/CDocLine.h
@@ -62,12 +62,8 @@ public:
 #endif
 	const wchar_t*	GetDocLineStrWithEOL(CLogicInt* pnLen) const //###仮の名前、仮の対処
 	{
-		if(this){ // TODO: Remove "this" check
-			*pnLen = GetLengthWithEOL(); return GetPtr();
-		}
-		else{
-			*pnLen = 0; return nullptr;
-		}
+		*pnLen = GetLengthWithEOL();
+		return GetPtr();
 	}
 	static const wchar_t* GetDocLineStrWithEOL_Safe(const CDocLine* docline, CLogicInt* pnLen) //###仮の名前、仮の対処
 	{
@@ -80,12 +76,7 @@ public:
 	}
 	CStringRef GetStringRefWithEOL() const //###仮の名前、仮の対処
 	{
-		if(this){ // TODO: Remove "this" check
-			return CStringRef(GetPtr(),GetLengthWithEOL());
-		}
-		else{
-			return CStringRef(nullptr,0);
-		}
+		return CStringRef(GetPtr(),GetLengthWithEOL());
 	}
 	static CStringRef GetStringRefWithEOL_Safe(const CDocLine* docline) //###仮の名前、仮の対処
 	{

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -27,9 +27,9 @@ struct EditNode {
 	UINT			m_showCmdRestore;			//!< 元のサイズに戻すときのサイズ種別		//@@@ 2007.06.20 ryoji
 	BOOL			m_bClosing;					//!< 終了中か（「最後のファイルを閉じても(無題)を残す」用）	//@@@ 2007.06.20 ryoji
 
-	HWND GetHwnd() const{ if(this)return m_hWnd; else return nullptr; } // TODO: Remove "this" check
+	HWND GetHwnd() const{ return m_hWnd; }
 	static HWND GetSafeHwnd(const EditNode* node) { return node ? node->m_hWnd : nullptr; }
-	int GetId() const{ if(this)return m_nId; else return 0; } // TODO: Remove "this" check
+	int GetId() const{ return m_nId; }
 	static int GetSafeId(const EditNode* node) { return node ? node->m_nId : 0; }
 	CAppNodeGroupHandle GetGroup() const;
 	static CAppNodeGroupHandle GetGroup_Safe(const EditNode* node);
@@ -117,7 +117,7 @@ public:
 	HWND GetNextTab(HWND hWndCur);										// Close した時の次のWindowを取得する(タブまとめ表示の場合)	2013/4/10 Uchi
 };
 
-inline CAppNodeGroupHandle EditNode::GetGroup() const{ if(this)return m_nGroup; else return 0; } // TODO: Remove "this" check
+inline CAppNodeGroupHandle EditNode::GetGroup() const{ return m_nGroup; }
 inline CAppNodeGroupHandle EditNode::GetGroup_Safe(const EditNode* node)
 {
 	if (node)
@@ -125,7 +125,7 @@ inline CAppNodeGroupHandle EditNode::GetGroup_Safe(const EditNode* node)
 	return 0;
 }
 
-inline bool EditNode::IsTopInGroup() const{ return this && (CAppNodeGroupHandle(m_nGroup).GetEditNodeAt(0) == this); } // TODO: Remove "this" check
+inline bool EditNode::IsTopInGroup() const{ return CAppNodeGroupHandle(m_nGroup).GetEditNodeAt(0) == this; }
 inline bool EditNode::IsTopInGroup_Safe(const EditNode* node)
 {
 	if (node)

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -132,24 +132,22 @@ static void ShowCodeBox( HWND hWnd, CEditDoc* pcEditDoc )
 					if( i == CODE_SJIS || i == CODE_JIS || i == CODE_EUC || i == CODE_LATIN1 || i == CODE_UNICODE || i == CODE_UTF8 || i == CODE_CESU8 ){
 						//auto_sprintf( szCaretChar, L"%04x", );
 						//任意の文字コードからUnicodeへ変換する		2008/6/9 Uchi
-						CCodeBase* pCode = CCodeFactory::CreateCodeBase((ECodeType)i, false);
+						std::unique_ptr<CCodeBase> pCode(CCodeFactory::CreateCodeBase((ECodeType)i, false));
 						EConvertResult ret = pCode->UnicodeToHex(&pLine[nIdx], nLineLen - nIdx, szCode[i], &sStatusbar);
-						delete pCode;
 						if (ret != RESULT_COMPLETE) {
 							// うまくコードが取れなかった
-							wcscpy(szCode[i], L"-");
+							wcscpy_s(szCode[i], _countof(szCode[i]), L"-");
 						}
 					}
 				}
 				// コードポイント部（サロゲートペアも）
 				WCHAR szCodeCP[32];
 				sStatusbar.m_bDispSPCodepoint = true;
-				CCodeBase* pCode = CCodeFactory::CreateCodeBase(CODE_UNICODE, false);
-				EConvertResult ret = pCode->UnicodeToHex(&pLine[nIdx], nLineLen - nIdx, szCodeCP, &sStatusbar);
-				delete pCode;
+				std::unique_ptr<CCodeBase> pCode2(CCodeFactory::CreateCodeBase(CODE_UNICODE, false));
+				EConvertResult ret = pCode2->UnicodeToHex(&pLine[nIdx], nLineLen - nIdx, szCodeCP, &sStatusbar);
 				if (ret != RESULT_COMPLETE) {
 					// うまくコードが取れなかった
-					wcscpy(szCodeCP, L"-");
+					wcscpy_s(szCodeCP, _countof(szCodeCP), L"-");
 				}
 
 				// メッセージボックス表示


### PR DESCRIPTION
- Replace raw new/delete with std::unique_ptr for CCodeBase* pointers in CClipboard.cpp, CEditWnd.cpp, and CCodeChecker.cpp
- Remove unnecessary defensive 'this' null checks from member functions in CAppNodeManager.h, CDocLine.h, and CLayout.h
- Delete unused #if 0 code blocks (dead code) in CKeyWordSetMgr.cpp
- Replace unsafe wcscpy with wcscpy_s in CEditWnd.cpp and CGrepAgent.cpp