### PR TITLE
GMockのコンパイル警告に対処する

### DIFF
--- a/src/test/cpp/tests1/test-cclipboard.cpp
+++ b/src/test/cpp/tests1/test-cclipboard.cpp
@@ -142,7 +142,7 @@ TEST(CClipboard, SetText1) {
 TEST(CClipboard, SetText2) {
 	constexpr std::wstring_view text = L"てすと";
 	MockCClipboard clipboard;
-	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(Invoke(::GlobalAlloc));
+	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(::GlobalAlloc);
 	EXPECT_CALL(clipboard, SetClipboardData(CF_UNICODETEXT, WideStringInGlobalMemory(text)));
 	EXPECT_CALL(clipboard, SetClipboardData(::RegisterClipboardFormat(L"MSDEVColumnSelect"), ByteValueInGlobalMemory(0)));
 	EXPECT_FALSE(clipboard.SetText(text.data(), text.length(), true, false, CF_UNICODETEXT));
@@ -153,7 +153,7 @@ TEST(CClipboard, SetText3) {
 	constexpr std::wstring_view text = L"てすと";
 	const CLIPFORMAT sakuraFormat = CClipboard::GetSakuraFormat();
 	MockCClipboard clipboard;
-	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(Invoke(::GlobalAlloc));
+	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(::GlobalAlloc);
 	EXPECT_CALL(clipboard, SetClipboardData(sakuraFormat, SakuraFormatInGlobalMemory(text)));
 	EXPECT_CALL(clipboard, SetClipboardData(::RegisterClipboardFormat(L"MSDEVLineSelect"), ByteValueInGlobalMemory(1)));
 	EXPECT_CALL(clipboard, SetClipboardData(::RegisterClipboardFormat(L"VisualStudioEditorOperationsLineCutCopyClipboardTag"), ByteValueInGlobalMemory(1)));
@@ -537,7 +537,7 @@ TEST(CClipboard, SetClipboardByFormat2) {
 // 終端モード0では文字列中の \0 をバイナリとして扱う（終端として認識しない）。
 TEST(CClipboard, SetClipboardByFormat3) {
 	MockCClipboard clipboard;
-	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(Invoke(::GlobalAlloc));
+	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(::GlobalAlloc);
 	EXPECT_CALL(clipboard, SetClipboardData(12345, BytesInGlobalMemory("\x00\x01\xfe\xff", 4)));
 	EXPECT_TRUE(clipboard.SetClipboardByFormat({L"\x00\x01\xfe\xff", 4}, L"12345", -1, 0));
 }
@@ -554,7 +554,7 @@ TEST(CClipboard, SetClipboardByFormat4) {
 // 終端モードの自動判定を要求する。期待されるモードは2（2バイトの0値で終端する）。
 TEST(CClipboard, SetClipboardByFormat5) {
 	MockCClipboard clipboard;
-	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(Invoke(::GlobalAlloc));
+	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(::GlobalAlloc);
 	EXPECT_CALL(clipboard, SetClipboardData(12345, WideStringInGlobalMemory(L"テスト")));
 	EXPECT_TRUE(clipboard.SetClipboardByFormat({L"テスト", 3}, L"12345", 3, -1));
 }
@@ -642,7 +642,7 @@ TEST(CClipboard, GetClipboardByFormat5) {
 	CEol eol(EEolType::cr_and_lf);
 	ON_CALL(clipboard, IsClipboardFormatAvailable(12345)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(12345)).WillByDefault(Return(memory.Get()));
-	ON_CALL(clipboard, GlobalLock(_)).WillByDefault(Invoke(::GlobalLock));
+	ON_CALL(clipboard, GlobalLock(_)).WillByDefault(::GlobalLock);
 	EXPECT_TRUE(clipboard.GetClipboardByFormat(buffer, L"12345", -1, 0, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"\x00\xff");
 }
@@ -659,7 +659,7 @@ TEST(CClipboard, GetClipboardByFormat6) {
 	CEol eol(EEolType::cr_and_lf);
 	ON_CALL(clipboard, IsClipboardFormatAvailable(12345)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(12345)).WillByDefault(Return(memory.Get()));
-	ON_CALL(clipboard, GlobalLock(_)).WillByDefault(Invoke(::GlobalLock));
+	ON_CALL(clipboard, GlobalLock(_)).WillByDefault(::GlobalLock);
 	EXPECT_TRUE(clipboard.GetClipboardByFormat(buffer, L"12345", 3, 2, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"テスト");
 }


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 削除

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- MinGWビルドのテストコンパイル時に警告が出ています。

<img width="1424" height="703" alt="image" src="https://github.com/user-attachments/assets/a69c49c9-b5af-492c-8134-5e63e62d1552" />
GMock側の仕様変更で Invoke が廃止されたために出てる警告だそうです。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
WillByDefault に続く Invoke を一律で削除します。

```perl
s/(?<=WillByDefault\()Invoke\((::\w+)\)(?=\))/$1/g
```

本件も勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
- MinGWビルドのビルドログから警告が消えます。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
- ローカルビルドにて、警告が消えることを確認しました。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
- CIビルド結果で確認できると思います。

（MinGWビルドのCIが不安定なのは別件として対処が要りそうだと思ってます。）

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
