### PR TITLE
正規表現DLLに拡張関数がない場合の処理を復活

### DIFF
--- a/sakura_core/env/CRegexKeyword.cpp
+++ b/sakura_core/env/CRegexKeyword.cpp
@@ -202,7 +202,7 @@ BOOL CRegexKeyword::RegexKeyCompile( void )
 			Compile(pKeyword);
 			m_sInfo[i].pPattern = GetPattern();
 
-			if (m_sInfo[i].pPattern)	//エラーがないかチェックする
+			if (m_sInfo[i].pPattern && !m_sInfo[i].pPattern->m_Msg[0])	//エラーがないかチェックする
 			{
 				//先頭以外は検索しなくてよい
 				if( wcsncmp_literal( pKeyword, RK_HEAD_STR1 ) == 0
@@ -337,7 +337,7 @@ BOOL CRegexKeyword::RegexIsKeyword(
 		assert(info.nOffset < nPos);
 
 		const auto &pPattern = info.pPattern;
-		if (!pPattern) {
+		if (!pPattern || pPattern->m_Msg[0]) {
 			continue;
 		}
 

--- a/src/main/cpp/extmodule/CBregOnig.hpp
+++ b/src/main/cpp/extmodule/CBregOnig.hpp
@@ -101,6 +101,8 @@ private:
 	decltype(&::BSubstExW)       m_BSubstEx = nullptr;
 	decltype(&::BRegexpVersionW) m_BRegexpVersion = nullptr;
 	decltype(&::BRegfreeW)       m_BRegfree = nullptr;
+	decltype(&::BMatchW)         m_BMatch = nullptr;
+	decltype(&::BSubstW)         m_BSubst = nullptr;
 };
 
 #endif /* SAKURA_CBREGEXPDLL2_033C910A_6B78_47CB_9993_675C48A2AB64_H_ */

--- a/src/test/cpp/tests1/test-extmodules.cpp
+++ b/src/test/cpp/tests1/test-extmodules.cpp
@@ -16,9 +16,33 @@
 
 #include "env/CShareData.h"
 
+#include "view/colors/EColorIndexType.h"
+
 #include "tests1_rc.h"
 
 void extract_zip_resource(WORD id, const std::optional<std::filesystem::path>& optOutDir);
+
+namespace cxx {
+
+//! CスタイルのNUL区切り配列を作成する
+void make_cstyle_array(
+	std::span<WCHAR> buffer,
+	std::span<LPCWSTR> items
+)
+{
+	// 各要素をNUL区切りで連結した文字列を作成する
+	auto strItems = std::accumulate(items.begin(), items.end(), std::wstring(),
+		[](const std::wstring& a, std::wstring_view b) { return a + L'\0' + std::data(b); }
+	);
+
+	// 末尾にもう一つNULを付ける
+	strItems += L'\0';
+
+	// バッファにコピーする
+	::wmemcpy_s(std::data(buffer), std::size(buffer), std::data(strItems) + 1, std::size(strItems) - 1);
+}
+
+} // namespace cxx
 
 /*!
 	外部DLLの読み込みテスト
@@ -141,7 +165,7 @@ TEST_F(CBregexpTest, test001)
 	// ロード前は正規表現コンパイルできない
 	EXPECT_THAT(pcBregexp->Compile(L"[0-9]+", L"$1d"), IsFalse());
 
-	// C/Migemo設定に値を入れる
+	// 正規表現設定に値を入れる
 	::wcsncpy_s(GetDllShareData().m_Common.m_sSearch.m_szRegexpLib, L"", _TRUNCATE);
 
 	// 名前を指定せずにロードする
@@ -195,7 +219,7 @@ TEST_F(CBregexpTest, test002)
 	// ロード前は検索できない
 	EXPECT_THAT(pcBregexp->Match(L"test123あいう"), IsFalse());
 
-	// C/Migemo設定に値を入れる
+	// 正規表現設定に値を入れる
 	::wcsncpy_s(GetDllShareData().m_Common.m_sSearch.m_szRegexpLib, L"bregonig.dll", _TRUNCATE);
 
 	// 名前を指定せずにロードする
@@ -228,7 +252,7 @@ TEST_F(CBregexpTest, test003)
 	// ロード前は置換できない
 	EXPECT_THAT(pcBregexp->Replace(L"test123あいう"), IsFalse());
 
-	// C/Migemo設定に値を入れる
+	// 正規表現設定に値を入れる
 	::wcsncpy_s(GetDllShareData().m_Common.m_sSearch.m_szRegexpLib, GetIniFileName().replace_filename(L"bregonig.dll").c_str(), _TRUNCATE);
 
 	// 名前を指定せずにロードする
@@ -361,6 +385,34 @@ TEST_F(CBregexpTest, test007)
 	EXPECT_THAT(pcBregexp->Replace(LR"(\o054)"), IsTrue());
 	EXPECT_THAT(pcBregexp->GetLastMessage(), StrEq(L""));
 	EXPECT_THAT(pcBregexp->GetReplacedString(), StrEq(L""));
+}
+
+// 無効化済みテスト: BMatchExWが存在しないDLLを用意するのが困難であるため
+TEST_F(CBregexpTest, DISABLED_test008)
+{
+	using std::string_view_literals::operator""sv;
+
+	// 名前を指定してロードする
+	pcBregexp->InitDll(L"bregexp.dll");
+
+	// ロードされたら利用可能になる
+	EXPECT_THAT(pcBregexp->IsAvailable(), IsTrue());
+
+	// 正規表現コンパイルを成功させる
+	EXPECT_THAT(pcBregexp->Compile(L"^[0-9]+"), IsTrue());
+	EXPECT_THAT(pcBregexp->GetLastMessage(), StrEq(L""));
+
+	EXPECT_THAT(pcBregexp->Match(L"123"), IsTrue());
+	EXPECT_THAT(pcBregexp->GetLastMessage(), StrEq(L""));
+
+	EXPECT_THAT(pcBregexp->Match(L"123"sv, 1), IsFalse());
+	EXPECT_THAT(pcBregexp->GetLastMessage(), StrEq(L""));
+
+	EXPECT_THAT(pcBregexp->Compile(L"^[0-9]+", L""), IsTrue());
+	EXPECT_THAT(pcBregexp->GetLastMessage(), StrEq(L""));
+
+	EXPECT_THAT(pcBregexp->Replace(L"123"), IsTrue());
+	EXPECT_THAT(pcBregexp->GetLastMessage(), StrEq(L""));
 }
 
 TEST_F(CBregexpTest, CheckRegexpSyntax001)
@@ -528,6 +580,233 @@ TEST_F(CMigemoTest, test003)
 
 	// 与えた文字列をSJISに変換できない場合、与えた文字列がそのまま返る
 	EXPECT_THAT(pcMigemo->migemo_query_w(L"\U0001F6B9"), StrEq(L"\U0001F6B9"));
+}
+
+struct CRegexKeywordTest : public ::testing::Test {
+	using CShareDataHolder = std::unique_ptr<CShareData>;
+	using CRegexKeywordHolder = std::unique_ptr<CRegexKeyword>;
+
+	static inline CShareDataHolder pcShareData = nullptr;
+
+	/*!
+	 * テストスイートの開始前に1回だけ呼ばれる関数
+	 */
+	static void SetUpTestSuite()
+	{
+		pcShareData = std::make_unique<CShareData>();
+		EXPECT_THAT( pcShareData->InitShareData(), IsTrue() );
+	}
+
+	/*!
+	 * テストスイートの終了後に1回だけ呼ばれる関数
+	 */
+	static void TearDownTestSuite()
+	{
+		pcShareData = nullptr;
+	}
+
+	CRegexKeywordHolder pcRegexKeyword = nullptr;
+
+	/*!
+	 * テストが起動される直前に毎回呼ばれる関数
+	 */
+	void SetUp() override {
+		// テストクラスをインスタンス化する
+		pcRegexKeyword = std::make_unique<CRegexKeyword>(L"bregonig.dll");
+	}
+
+	/*!
+	 * テストが実行された直後に毎回呼ばれる関数
+	 */
+	void TearDown() override {
+		// テストクラスのインスタンスを破棄する
+		pcRegexKeyword = nullptr;
+	}
+};
+
+TEST_F(CRegexKeywordTest, RegexKeySetTypes101)
+{
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(nullptr), IsFalse());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeySetTypes102)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = false;
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsFalse());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeySetTypes001)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+
+	pTypeConfig->m_bUseRegexKeyword = false;
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsFalse());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeyCompile001)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+
+	std::array regexKeywords = { L"m/^#/k" };
+	cxx::make_cstyle_array(pTypeConfig->m_RegexKeywordList, regexKeywords);
+	pTypeConfig->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_REGEX1;
+	pTypeConfig->m_ColorInfoArr[COLORIDX_REGEX1].m_bDisp = true;
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeyCompile002)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+
+	std::array regexKeywords = { L"m/#/k" };
+	cxx::make_cstyle_array(pTypeConfig->m_RegexKeywordList, regexKeywords);
+	pTypeConfig->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_REGEX1;
+	pTypeConfig->m_ColorInfoArr[COLORIDX_REGEX1].m_bDisp = true;
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeyCompile003)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+
+	std::array regexKeywords = { L"m/^#/k" };
+	cxx::make_cstyle_array(pTypeConfig->m_RegexKeywordList, regexKeywords);
+	pTypeConfig->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_KEYWORD1;
+	pTypeConfig->m_ColorInfoArr[COLORIDX_REGEX1].m_bDisp = true;
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeyCompile004)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+
+	std::array regexKeywords = { L"m/#/k" };
+	cxx::make_cstyle_array(pTypeConfig->m_RegexKeywordList, regexKeywords);
+	pTypeConfig->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_REGEX1;
+	pTypeConfig->m_ColorInfoArr[COLORIDX_REGEX1].m_bDisp = false;
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeyCompile005)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+
+	std::array regexKeywords = { L"m/[...)/k" };
+	cxx::make_cstyle_array(pTypeConfig->m_RegexKeywordList, regexKeywords);
+	pTypeConfig->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_REGEX1;
+	pTypeConfig->m_ColorInfoArr[COLORIDX_REGEX1].m_bDisp = true;
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeyCompile101)
+{
+	pcRegexKeyword->DeinitDll();
+
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeyLineStart001)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+
+	std::array regexKeywords = { L"m/^#/k" };
+	cxx::make_cstyle_array(pTypeConfig->m_RegexKeywordList, regexKeywords);
+	pTypeConfig->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_REGEX1;
+	pTypeConfig->m_ColorInfoArr[COLORIDX_REGEX1].m_bDisp = true;
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeyLineStart(), IsTrue());
+}
+
+TEST_F(CRegexKeywordTest, RegexKeyLineStart101)
+{
+	pcRegexKeyword->DeinitDll();
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeyLineStart(), IsFalse());
+}
+
+TEST_F(CRegexKeywordTest, RegexIsKeyword001)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+
+	std::array regexKeywords = { L"m/^#/k" };
+	cxx::make_cstyle_array(pTypeConfig->m_RegexKeywordList, regexKeywords);
+	pTypeConfig->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_REGEX1;
+	pTypeConfig->m_ColorInfoArr[COLORIDX_REGEX1].m_bDisp = true;
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeyLineStart(), IsTrue());
+
+	int nMatchLen = -1;
+	int nMatchColor = COLORIDX_DEFAULT;
+	EXPECT_THAT(pcRegexKeyword->RegexIsKeyword(L"##test", 0, &nMatchLen, &nMatchColor), IsTrue());
+	EXPECT_THAT(nMatchLen, 0);
+	EXPECT_THAT(nMatchColor, COLORIDX_REGEX1);
+
+	nMatchLen = -1;
+	nMatchColor = COLORIDX_DEFAULT;
+	EXPECT_THAT(pcRegexKeyword->RegexIsKeyword(L"##test", 0, &nMatchLen, &nMatchColor), IsTrue());
+	EXPECT_THAT(nMatchLen, 0);
+	EXPECT_THAT(nMatchColor, COLORIDX_REGEX1);
+
+	EXPECT_THAT(pcRegexKeyword->RegexIsKeyword(L"##test", 1, &nMatchLen, &nMatchColor), IsFalse());
+
+	EXPECT_THAT(pcRegexKeyword->RegexIsKeyword(L"##test", 2, &nMatchLen, &nMatchColor), IsFalse());
+}
+
+TEST_F(CRegexKeywordTest, RegexIsKeyword002)
+{
+	auto pTypeConfig = std::make_unique<STypeConfig>();
+	pTypeConfig->m_bUseRegexKeyword = true;
+
+	std::array regexKeywords = { L"m/^#/k" };
+	cxx::make_cstyle_array(pTypeConfig->m_RegexKeywordList, regexKeywords);
+	pTypeConfig->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_REGEX1;
+	pTypeConfig->m_ColorInfoArr[COLORIDX_REGEX1].m_bDisp = true;
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeySetTypes(pTypeConfig.get()), IsTrue());
+
+	EXPECT_THAT(pcRegexKeyword->RegexKeyLineStart(), IsTrue());
+
+	int nMatchLen = -1;
+	int nMatchColor = COLORIDX_DEFAULT;
+	EXPECT_THAT(pcRegexKeyword->RegexIsKeyword(L"//test", 0, &nMatchLen, &nMatchColor), IsTrue());
+}
+
+TEST_F(CRegexKeywordTest, RegexIsKeyword101)
+{
+	pcRegexKeyword->DeinitDll();
+
+	int nMatchLen = -1;
+	int nMatchColor = COLORIDX_DEFAULT;
+	EXPECT_THAT(pcRegexKeyword->RegexIsKeyword(L"##test", 0, &nMatchLen, &nMatchColor), IsFalse());
+}
+
+TEST_F(CRegexKeywordTest, GetNewMagicNumber101)
+{
+	// 呼ぶだけ
+	CRegexKeyword::GetNewMagicNumber();
 }
 
 } // namespace extmodule


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 追加

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #1943
- #2280
- https://github.com/sakura-editor/sakura/issues/1943#issuecomment-3708245987

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- #2280 で 削った BREGEXP.DLL互換機能 を復活させます。

本件、勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
- 正規表現DLLに BREGEXP互換DLL を指定できるようになります。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
- CRegexKeywordについてもテストケースを用意しました。
- 対応のメイン部分、BMatchExWのないBREGEXP互換DLLを使えるようにする対応については、DLLの用意が難しいため行っていません。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
- 妥当性の判断はCI結果でできると思います。（ただし最近、MinGWビルドがたまにコケます。）

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
