### PR TITLE
MinGW warning 修正 (-Wreturn-type)

### DIFF
--- a/sakura_core/macro/CPythonMacroManager.cpp
+++ b/sakura_core/macro/CPythonMacroManager.cpp
@@ -956,6 +956,7 @@ struct PyObjectPtr final {
 
 	PyObject* operator = (PyObject* param_op) {
 		this->op = param_op;
+		return this->op;
 	}
 	operator PyObject* () {
 		return op;


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
MinGW build 時に warning が表示される。

```
D:/a/sakura/sakura/sakura_core/macro/CPythonMacroManager.cpp: In member function '{anonymous}::PyObject* PyObjectPtr::operator=({anonymous}::PyObject*)':
D:/a/sakura/sakura/sakura_core/macro/CPythonMacroManager.cpp:959:9: warning: no return statement in function returning non-void [-Wreturn-type]
  959 |         }
      |       
```

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
return 文を追加する。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. MinGW build 時に warning が表示されないことを確認する。
2. 変更前後でasmが同じことを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1866

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://learn.microsoft.com/en-us/cpp/cpp/assignment
