### PR TITLE
独自関数wcscpynをCランタイム関数で置き換える

### DIFF
--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1696,7 +1696,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 							types.m_RegexKeywordArr[j].m_nColorIndex = _wtoi(szKeyData);
 						p++;
 						if( 0 < nKeywordSize - nPos - 1 ){
-							wcscpyn(&pKeyword[nPos], p, nKeywordSize - nPos - 1 );
+							::wcsncpy_s(&pKeyword[nPos], nKeywordSize - nPos, p, _TRUNCATE);
 						}
 						if( types.m_RegexKeywordArr[j].m_nColorIndex < 0
 						 || types.m_RegexKeywordArr[j].m_nColorIndex >= COLORIDX_LAST )

--- a/sakura_core/func/CFuncLookup.cpp
+++ b/sakura_core/func/CFuncLookup.cpp
@@ -277,17 +277,17 @@ const WCHAR* CFuncLookup::Custmenu2Name( int index, LPWSTR buf, size_t size ) co
 
 	// 共通設定で名称を設定していればそれを返す
 	if ( m_pCommon->m_sCustomMenu.m_szCustMenuNameArr[ index ][0] != '\0' ) {
-		wcscpyn( buf, m_pCommon->m_sCustomMenu.m_szCustMenuNameArr[ index ], bufSize );
+		::wcsncpy_s(buf, size, m_pCommon->m_sCustomMenu.m_szCustMenuNameArr[ index ], _TRUNCATE);
 		return m_pCommon->m_sCustomMenu.m_szCustMenuNameArr[ index ];
 	}
 
 	// 共通設定で未設定の場合、リソースのデフォルト名を返す
 	if( index == 0 ){
-		wcscpyn( buf, LS( STR_CUSTMENU_RIGHT_CLICK ), bufSize );
+		::wcsncpy_s(buf, size, LS(STR_CUSTMENU_RIGHT_CLICK), _TRUNCATE);
 		return buf;
 	}
 	else if( index == CUSTMENU_INDEX_FOR_TABWND ){
-		wcscpyn( buf, LS( STR_CUSTMENU_TAB ), bufSize );
+		::wcsncpy_s(buf, size, LS(STR_CUSTMENU_TAB), _TRUNCATE);
 		return buf;
 	}
 	else {

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -482,7 +482,7 @@ bool CImpExpType::Export( const std::wstring& sFileName, std::wstring& sErrMsg )
 	wchar_t szId[ MAX_PLUGIN_ID + 1 + 2 ];
 	if ((nPIdx = CPlug::GetPluginId( static_cast<EFunctionCode>( m_Types.m_eDefaultOutline ))) >= 0) {
 		cProfile.IOProfileData(szSecTypeEx, szKeyPluginOutlineName, StringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
-		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, int(std::size(szId)) );
+		::wcsncpy_s(szId, plugin.m_PluginTable[nPIdx].m_szId, _TRUNCATE);
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eDefaultOutline ))) != 0 ){
 			wchar_t szPlug[8];
 			_swprintf( szPlug, L"/%d", nPlug );
@@ -493,7 +493,7 @@ bool CImpExpType::Export( const std::wstring& sFileName, std::wstring& sErrMsg )
 	//  スマートインデント
 	if ((nPIdx = CPlug::GetPluginId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) >= 0) {
 		cProfile.IOProfileData(szSecTypeEx, szKeyPluginSmartIndentName, StringBufferW(plugin.m_PluginTable[nPIdx].m_szName));
-		wcscpyn( szId, plugin.m_PluginTable[nPIdx].m_szId, int(std::size(szId)) );
+		::wcsncpy_s(szId, plugin.m_PluginTable[nPIdx].m_szId, _TRUNCATE);
 		if( (nPlug = CPlug::GetPlugId( static_cast<EFunctionCode>( m_Types.m_eSmartIndent ))) != 0 ){
 			wchar_t szPlug[8];
 			_swprintf( szPlug, L"/%d", nPlug );

--- a/sakura_core/types/CType_Text.cpp
+++ b/sakura_core/types/CType_Text.cpp
@@ -52,14 +52,18 @@ void CType_Text::InitTypeConfigImp(STypeConfig* pType)
 	wchar_t* pKeyword = pType->m_RegexKeywordList;
 	pType->m_bUseRegexKeyword = true;							// 正規表現キーワードを使うか
 	pType->m_RegexKeywordArr[0].m_nColorIndex = COLORIDX_URL;	// 色指定番号
-	wcscpyn( &pKeyword[keywordPos],			// 正規表現キーワード
+	::wcsncpy_s(&pKeyword[keywordPos],			// 正規表現キーワード
+		std::size(pType->m_RegexKeywordList) - keywordPos,
 		L"/(?<=\")(\\b[a-zA-Z]:|\\B\\\\\\\\)[^\"\\r\\n]*/k",			//   ""で挟まれた C:\～, \\～ にマッチするパターン
-		int(std::size(pType->m_RegexKeywordList)) - 1 );
+		_TRUNCATE
+	);
 	keywordPos += int(wcslen(&pKeyword[keywordPos]) + 1);
 	pType->m_RegexKeywordArr[1].m_nColorIndex = COLORIDX_URL;	// 色指定番号
-	wcscpyn( &pKeyword[keywordPos],			// 正規表現キーワード
+	::wcsncpy_s(&pKeyword[keywordPos],			// 正規表現キーワード
+		std::size(pType->m_RegexKeywordList) - keywordPos,
 		L"/(\\b[a-zA-Z]:\\\\|\\B\\\\\\\\)[\\w\\-_.\\\\\\/$%~]*/k",		//   C:\～, \\～ にマッチするパターン
-		int(std::size(pType->m_RegexKeywordList)) - keywordPos - 1 );
+		_TRUNCATE
+	);
 	keywordPos += int(wcslen(&pKeyword[keywordPos]) + 1);
 	pKeyword[keywordPos] = L'\0';
 }

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -54,15 +54,6 @@ int __cdecl my_strnicmp( const char *s1, const char *s2, size_t n )
 	return my_internal_icmp( s1, s2, (unsigned int)n, 1, true );
 }
 
-LPWSTR wcscpyn(LPWSTR lpString1,LPCWSTR lpString2,int iMaxLength)
-{
-	size_t len2=wcslen(lpString2);
-	if((int)len2>iMaxLength-1)len2=iMaxLength-1;
-	wmemcpy(lpString1,lpString2,len2);
-	lpString1[len2]=L'\0';
-	return lpString1;
-}
-
 /*
 	WCHAR と WCHAR または ACHAR の変換関数
 */
@@ -105,31 +96,6 @@ WCHAR* strtotcs( WCHAR* dest, const WCHAR* src, size_t count )
 		++pw;
 	}
 	return pw;
-}
-
-/*! 文字数制限機能付きstrncpy
-
-	コピー先のバッファサイズから溢れないようにstrncpyする。
-	バッファが不足する場合には2バイト文字の切断もあり得る。
-	末尾の\0は付与されないが、コピーはコピー先バッファサイズ-1までにしておく。
-
-	@param dst [in] コピー先領域へのポインタ
-	@param dst_count [in] コピー先領域のサイズ
-	@param src [in] コピー元
-	@param src_count [in] コピーする文字列の末尾
-
-	@retval 実際にコピーされたコピー先領域の1つ後を指すポインタ
-
-	@author genta
-	@date 2003.04.03 genta
-*/
-char *strncpy_ex(char *dst, size_t dst_count, const char* src, size_t src_count)
-{
-	if( src_count >= dst_count ){
-		src_count = dst_count - 1;
-	}
-	memcpy( dst, src, src_count );
-	return dst + src_count;
 }
 
 const wchar_t* wcsistr( const wchar_t* s1, const wchar_t* s2 )

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -71,12 +71,6 @@ int skr_towlower( int c );
 //                           拡張・独自実装                    //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-//文字数の上限付きコピー
-LPWSTR wcscpyn(LPWSTR lpString1,LPCWSTR lpString2,int iMaxLength); //iMaxLengthは文字単位。
-
-//	Apr. 03, 2003 genta
-char *strncpy_ex(char *dst, size_t dst_count, const char* src, size_t src_count);
-
 //大文字小文字を区別せずに文字列を検索
 const WCHAR* wcsistr( const WCHAR* s1, const WCHAR* s2 );
 const ACHAR* stristr( const ACHAR* s1, const ACHAR* s2 );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2263

wcscpyを対応しようとして独自実装を見付けました。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- 独自関数 wcscpyn を削除します。
  - 「書き込める最大文字数」を指定していた。
  - 現代のCランタイムは「バッファサイズ」を指定するので混在は危険。
  - Win2k時代の非公開APIを模倣した実装と思われる。
  - ShLwApiの [StrCpyNW](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-strcpynw) が公開実装と思われるが、これも既に非推奨。

本件も勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- #2263 
- #2264 

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
