### PR TITLE
_wsplitpath() 置換

### DIFF
--- a/sakura_core/agent/CBackupAgent.cpp
+++ b/sakura_core/agent/CBackupAgent.cpp
@@ -219,7 +219,7 @@ int CBackupAgent::MakeBackUp(
 	WCHAR	szDir[_MAX_DIR];
 	WCHAR	szFname[_MAX_FNAME];
 	WCHAR	szExt[_MAX_EXT];
-	_wsplitpath( szPath, szDrive, szDir, szFname, szExt );
+	_wsplitpath_s( szPath, szDrive, szDir, szFname, szExt );
 	WCHAR	szPath2[MAX_PATH];
 	auto_sprintf( szPath2, L"%s%s", szDrive, szDir );
 
@@ -296,7 +296,7 @@ bool CBackupAgent::FormatBackUpPath(
 	const CommonSetting_Backup& bup_setting = GetDllShareData().m_Common.m_sBackup;
 
 	/* パスの分解 */
-	_wsplitpath( target_file, szDrive, szDir, szFname, szExt );
+	_wsplitpath_s( target_file, szDrive, szDir, szFname, szExt );
 
 	if( bup_setting.m_bBackUpFolder
 	  && (!bup_setting.m_bBackUpFolderRM || !IsLocalDrive( target_file ))) {	/* 指定フォルダーにバックアップを作成する */	// m_bBackUpFolderRM 追加	2010/5/27 Uchi

--- a/sakura_core/cmd/CViewCommander_Support.cpp
+++ b/sakura_core/cmd/CViewCommander_Support.cpp
@@ -232,7 +232,7 @@ retry:;
 	}
 	// 2012.09.26 Moca HTMLHELP対応
 	WCHAR	szExt[_MAX_EXT];
-	_wsplitpath( path, nullptr, nullptr, nullptr, szExt );
+	_wsplitpath_s( path, nullptr, 0, nullptr, 0, nullptr, 0, szExt, std::size(szExt) );
 	if( 0 == _wcsicmp(szExt, L".chi") || 0 == _wcsicmp(szExt, L".chm") || 0 == _wcsicmp(szExt, L".col") ){
 		Command_EXTHTMLHELP( path, cmemCurText.GetStringPtr() );
 	}else{

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -405,7 +405,7 @@ UINT_PTR CALLBACK OFNHookProc(
 						::lstrcpyn(pData->m_szPath, pData->m_pOf->lpstrFile, _MAX_PATH);
 					}
 					else{
-						_wsplitpath( pData->m_pOf->lpstrFile, nullptr, nullptr, nullptr, szDefExt );
+						_wsplitpath_s( pData->m_pOf->lpstrFile, nullptr, 0, nullptr, 0, nullptr, 0, szDefExt, std::size(szDefExt) );
 						if( szDefExt[0] == L'.' /* && szDefExt[1] != L'\0' */ ){	// 既に拡張子がついている	2文字目のチェックの削除	2008/6/14 Uchi
 							// .のみの場合にも拡張子付きとみなす。
 							lstrcpyn(pData->m_szPath, pData->m_pOf->lpstrFile, _MAX_PATH);
@@ -655,7 +655,7 @@ CDlgOpenFile_CommonFileDialog::CDlgOpenFile_CommonFileDialog()
 		nullptr,
 		szFile, int(std::size(szFile))
 	);
-	_wsplitpath( szFile, szDrive, szDir, nullptr, nullptr );
+	_wsplitpath_s( szFile, szDrive, std::size(szDrive), szDir, std::size(szDir), nullptr, 0, nullptr, 0 );
 	wcscpy( m_szInitialDir, szDrive );
 	wcscat( m_szInitialDir, szDir );
 

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -386,7 +386,7 @@ CDlgOpenFile_CommonItemDialog::CDlgOpenFile_CommonItemDialog()
 		nullptr,
 		szFile, int(std::size(szFile))
 	);
-	_wsplitpath( szFile, szDrive, szDir, nullptr, nullptr );
+	_wsplitpath_s( szFile, szDrive, std::size(szDrive), szDir, std::size(szDir), nullptr, 0, nullptr, 0 );
 	wcscpy( m_szInitialDir, szDrive );
 	wcscat( m_szInitialDir, szDir );
 

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -867,7 +867,7 @@ int CDlgTagJumpList::SearchBestTag( void )
 	lpPathInfo->szPathSrc[0] = L'\0';
 	lpPathInfo->szFileSrc[0] = L'\0';
 	lpPathInfo->szExtSrc[0] = L'\0';
-	_wsplitpath( m_pszFileName, lpPathInfo->szDriveSrc, lpPathInfo->szPathSrc, lpPathInfo->szFileSrc, lpPathInfo->szExtSrc );
+	_wsplitpath_s( m_pszFileName, lpPathInfo->szDriveSrc, lpPathInfo->szPathSrc, lpPathInfo->szFileSrc, lpPathInfo->szExtSrc );
 	lpPathInfo->nDriveSrc = wcslen(lpPathInfo->szDriveSrc);
 	lpPathInfo->nPathSrc = wcslen(lpPathInfo->szPathSrc);
 	lpPathInfo->nFileSrc = wcslen(lpPathInfo->szFileSrc);
@@ -891,7 +891,7 @@ int CDlgTagJumpList::SearchBestTag( void )
 		lpPathInfo->szPathDst[0] = L'\0';
 		lpPathInfo->szFileDst[0] = L'\0';
 		lpPathInfo->szExtDst[0] = L'\0';
-		_wsplitpath( lpPathInfo->szFileNameDst, lpPathInfo->szDriveDst, lpPathInfo->szPathDst, lpPathInfo->szFileDst, lpPathInfo->szExtDst );
+		_wsplitpath_s( lpPathInfo->szFileNameDst, lpPathInfo->szDriveDst, lpPathInfo->szPathDst, lpPathInfo->szFileDst, lpPathInfo->szExtDst );
 		lpPathInfo->nDriveDst = wcslen(lpPathInfo->szDriveDst);
 		lpPathInfo->nPathDst = wcslen(lpPathInfo->szPathDst);
 		lpPathInfo->nFileDst = wcslen(lpPathInfo->szFileDst);

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -1032,7 +1032,7 @@ void CPrintPreview::OnPrint( void )
 	}else{
 		WCHAR	szFileName[_MAX_FNAME];
 		WCHAR	szExt[_MAX_EXT];
-		_wsplitpath( m_pParentWnd->GetDocument()->m_cDocFile.GetFilePath(), nullptr, nullptr, szFileName, szExt );
+		_wsplitpath_s( m_pParentWnd->GetDocument()->m_cDocFile.GetFilePath(), nullptr, 0, nullptr, 0, szFileName, std::size(szFileName), szExt, std::size(szExt) );
 		auto_snprintf_s(szJobName, std::size(szJobName), L"%s%s", szFileName, szExt );
 	}
 

--- a/sakura_core/recent/CMRUFile.cpp
+++ b/sakura_core/recent/CMRUFile.cpp
@@ -216,7 +216,7 @@ void CMRUFile::Add( EditInfo* pEditInfo )
 	WCHAR	szDir[_MAX_DIR];
 	WCHAR	szFolder[_MAX_PATH + 1];	//	ドライブ＋フォルダー
 
-	_wsplitpath( pEditInfo->m_szPath, szDrive, szDir, nullptr, nullptr );	//	ドライブとフォルダーを取り出す。
+	_wsplitpath_s( pEditInfo->m_szPath, szDrive, std::size(szDrive), szDir, std::size(szDir), nullptr, 0, nullptr, 0 );	//	ドライブとフォルダーを取り出す。
 
 	//	Jan.  10, 2006 genta USBメモリはRemovable mediaと認識されるようなので，
 	//	一応無効化する．

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -312,7 +312,7 @@ void SplitPath_FolderAndFile( const WCHAR* pszFilePath, WCHAR* pszFolder, WCHAR*
 	WCHAR	szExt[_MAX_EXT];
 	int		nFolderLen;
 	int		nCharChars;
-	_wsplitpath( pszFilePath, szDrive, szDir, szFname, szExt );
+	_wsplitpath_s( pszFilePath, szDrive, szDir, szFname, szExt );
 	if( nullptr != pszFolder ){
 		wcscpy( pszFolder, szDrive );
 		wcscat( pszFolder, szDir );
@@ -388,7 +388,7 @@ BOOL CheckEXT( const WCHAR* pszPath, const WCHAR* pszExt )
 {
 	WCHAR	szExt[_MAX_EXT];
 	WCHAR*	pszWork;
-	_wsplitpath( pszPath, nullptr, nullptr, nullptr, szExt );
+	_wsplitpath_s( pszPath, nullptr, 0, nullptr, 0, nullptr, 0, szExt, std::size(szExt) );
 	pszWork = szExt;
 	if( pszWork[0] == L'.' ){
 		pszWork++;

--- a/sakura_core/view/CEditView_Command.cpp
+++ b/sakura_core/view/CEditView_Command.cpp
@@ -204,7 +204,7 @@ open_c:;
 	WCHAR	szExt[_MAX_EXT];
 	HWND	hwndOwner;
 
-	_wsplitpath( GetDocument()->m_cDocFile.GetFilePath(), szDrive, szDir, szFname, szExt );
+	_wsplitpath_s( GetDocument()->m_cDocFile.GetFilePath(), szDrive, szDir, szFname, szExt );
 
 	for( i = 0; i < open_extno; i++ ){
 		_wmakepath( szPath, szDrive, szDir, szFname, open_ext[i] );

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -2141,7 +2141,7 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 			if( nId == 100 ){	// パス名
 				::lstrcpy( szPath, szWork );
 			}else if( nId == 101 ){	// ファイル名
-				_wsplitpath( szWork, nullptr, nullptr, szPath, szExt );
+				_wsplitpath_s( szWork, nullptr, 0, nullptr, 0, szPath, std::size(szPath), szExt, std::size(szExt) );
 				::lstrcat( szPath, szExt );
 			}
 			cmemBuf.AppendString( szPath );

--- a/sakura_core/view/CEditView_Search.cpp
+++ b/sakura_core/view/CEditView_Search.cpp
@@ -130,7 +130,7 @@ BOOL CEditView::KeySearchCore( const CNativeW* pcmemCurText )
 					{
 						WCHAR szFile[MAX_PATH];
 						// 2013.05.08 表示するのはファイル名(拡張子なし)のみにする
-						_wsplitpath( m_pTypeData->m_KeyHelpArr[i].m_szPath, nullptr, nullptr, szFile, nullptr );
+						_wsplitpath_s( m_pTypeData->m_KeyHelpArr[i].m_szPath, nullptr, 0, nullptr, 0, szFile, std::size(szFile), nullptr, 0 );
 						m_cTipWnd.m_cInfo.AppendString( szFile );
 					}
 					m_cTipWnd.m_cInfo.AppendString( L"\n" );

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -3802,7 +3802,7 @@ bool CEditWnd::GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIcon
 		WCHAR FileType[1024];
 
 		// (.で始まる)拡張子の取得
-		_wsplitpath( szFile, nullptr, nullptr, nullptr, szExt );
+		_wsplitpath_s( szFile, nullptr, 0, nullptr, 0, nullptr, 0, szExt, std::size(szExt) );
 
 		if( ReadRegistry(HKEY_CLASSES_ROOT, szExt, nullptr, FileType, int(std::size(FileType)) - 13)){
 			wcscat( FileType, L"\\DefaultIcon" );

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -2417,7 +2417,7 @@ int CTabWnd::GetImageIndex( EditNode* pNode )
 		{
 			// 拡張子を取り出す
 			WCHAR szExt[_MAX_EXT];
-			_wsplitpath( pNode->m_szFilePath, nullptr, nullptr, nullptr, szExt );
+			_wsplitpath_s( pNode->m_szFilePath, nullptr, 0, nullptr, 0, nullptr, 0, szExt, std::size(szExt) );
 
 			// 拡張子に関連付けられたアイコンイメージのインデックスを取得する
 			hImlSys = (HIMAGELIST)::SHGetFileInfo( szExt, FILE_ATTRIBUTE_NORMAL, &sfi, sizeof(sfi), SHGFI_SYSICONINDEX | SHGFI_SMALLICON | SHGFI_USEFILEATTRIBUTES );


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
パスの分割に _wsplitpath() を使用しているが、セキュリティが強化されたバージョンがある。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
_wsplitpath() の代わりに _wsplitpath_s()を使います。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
_wsplitpath_s() を呼び出しているところに break を設定し、変数を確認します。
1. ファイル - 開く
2. 共通 - バックアップ - 保存時にバックアップを作成する をチェック
ファイルを開く - ファイルを保存 を実行
3. ヘルプ - 外部ヘルプ1
4. 検索 - タグジャンプ
5. ファイル - 印刷
6. ファイルをドラッグ - 右クリック - ファイル名貼付
7. 設定 - 共通設定 - タブの外観 - アイコン表示 をチェック
8. タイプ別設定 - ウィンドウ - 文書アイコン をチェック
9. タイプ別設定 - キーワードヘルプ - キーワードヘルプ機能を使う をチェック
辞書ファイルを登録し、キーワードのツールチップを表示する

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1034


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/splitpath-s-wsplitpath-s
