### PR TITLE
SonarQube指摘対応 エラー対策にassertではなく例外を使う

### DIFF
--- a/sakura_core/charset/CESI.cpp
+++ b/sakura_core/charset/CESI.cpp
@@ -83,7 +83,7 @@ void CESI::SetInformation( const char *pS, size_t nLen )
 */
 int CESI::GetIndexById( const ECodeType eCodeType ) const
 {
-	int nret;
+	int nret = 0;
 	if( CODE_UNICODE == eCodeType ){
 		nret = 0;
 	}else if( CODE_UNICODEBE == eCodeType ){
@@ -91,9 +91,10 @@ int CESI::GetIndexById( const ECodeType eCodeType ) const
 	}else if( 0 <= eCodeType && eCodeType < int(std::size(gm_aMbcPriority)) ){
 		nret = gm_aMbcPriority[eCodeType]; // 優先順位表の優先度数をそのまま m_aMbcInfo の添え字として使う。
 	}else{
-		assert(0);
-		nret = -1;
+		// 仕様変更しない限り、ここには来ない
+		throw std::out_of_range("CESI::GetIndexById: eCodeType out of range");
 	}
+	assert(0 <= nret && nret < std::size(m_aMbcInfo));
 	return nret;
 }
 


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- SonarQubeで以下の指摘があがっています。

<img width="917" height="261" alt="image" src="https://github.com/user-attachments/assets/8d474eae-a136-41e0-92d6-7a2a0cdd36ba" />

2件とも同じ内容で、`GetIndexById`が -1 を返した場合に範囲外アクセスが発生する、というものです。
<img width="820" height="166" alt="image" src="https://github.com/user-attachments/assets/00f19293-8836-4469-b59c-cd6ec1ad062b" />

原因は、想定しない引数が与えられた際に `assert(0)` して -1 を返す実装にしていることです。
https://github.com/sakura-editor/sakura/blob/e092b4966f0c0e391504fd4bf727c475f4ae0d68/sakura_core/charset/CESI.cpp#L93-L97

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- 戻り値変数に初期値を与え、エラー時に -1 をセットするのをやめます。
- assertの代わりに例外を投げるようします。
- 返却してよい値範囲を assert で明示します。

もっとスマートな書き方もできるとは思います。

本件も勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
- デッドコードに対する変更なのでアプリ影響はありません。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
- デッドコードに対する変更なのでテストは書きません。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
- コード変更内容で判断できると思います。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- #1504

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
