### PR TITLE
wcsncpy 置換 (CDocTypeManager)

### DIFF
--- a/sakura_core/env/CDocTypeManager.cpp
+++ b/sakura_core/env/CDocTypeManager.cpp
@@ -152,8 +152,7 @@ bool CDocTypeManager::IsFileNameMatch(const WCHAR* pszTypeExts, const WCHAR* psz
 {
 	WCHAR szWork[MAX_TYPES_EXTS];
 
-	wcsncpy(szWork, pszTypeExts, int(std::size(szWork)));
-	szWork[std::size(szWork) - 1] = '\0';
+	wcsncpy_s(szWork, pszTypeExts, _TRUNCATE);
 	WCHAR* token = _wcstok(szWork, m_typeExtSeps);
 	while (token) {
 		if (wcspbrk(token, m_typeExtWildcards) == nullptr) {
@@ -185,13 +184,11 @@ void CDocTypeManager::GetFirstExt(const WCHAR* pszTypeExts, WCHAR szFirstExt[], 
 {
 	WCHAR szWork[MAX_TYPES_EXTS];
 
-	wcsncpy(szWork, pszTypeExts, int(std::size(szWork)));
-	szWork[std::size(szWork) - 1] = '\0';
+	wcsncpy_s(szWork, pszTypeExts, _TRUNCATE);
 	WCHAR* token = _wcstok(szWork, m_typeExtSeps);
 	while (token) {
 		if (wcspbrk(token, m_typeExtWildcards) == nullptr) {
-			wcsncpy(szFirstExt, token, nBuffSize);
-			szFirstExt[nBuffSize - 1] = L'\0';
+			wcsncpy_s(szFirstExt, nBuffSize, token, _TRUNCATE);
 			return;
 		}
 	}


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
CDocTypeManager クラスで で wcsncpy() 呼び出し、null 文字を設定している。
1. CDocTypeManager::IsFileNameMatch()
2. CDocTypeManager::GetFirstExt()

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
wcsncpy() を wcsncpy_s() に置換します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. ファイル - 開く を選択し、szWork 値を確認する。
2. 設定 - タイプ別設定 - テキスト を選択、検索 - ダイレクトタグジャンプ を選択し、szWork/szFirstExt の値を確認する。
一部ソースコードを変更して確認する。
3. szWork のサイズを変更して、szWork の値を確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2153

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
