### PR TITLE
C++11 in-class initializer 対応 (CDisableWow64FsRedirect)

### DIFF
--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -279,8 +279,6 @@ CCurrentDirectoryBackupPoint::~CCurrentDirectoryBackupPoint()
 }
 
 CDisableWow64FsRedirect::CDisableWow64FsRedirect(BOOL isOn)
-:	m_isSuccess(FALSE)
-,	m_OldValue(nullptr)
 {
 	if (isOn && IsWow64()) {
 		m_isSuccess = Wow64DisableWow64FsRedirection(&m_OldValue);

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -61,8 +61,8 @@ public:
 	CDisableWow64FsRedirect& operator = (CDisableWow64FsRedirect&&) = delete;
 
 private:
-	BOOL	m_isSuccess;
-	PVOID	m_OldValue;
+	BOOL	m_isSuccess = FALSE;
+	PVOID	m_OldValue = nullptr;
 };
 
 //カレントディレクトリユーティリティ。


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
CDisableWow64FsRedirect クラスで、メンバ変数をコンストラクタで初期化している。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
変数宣言時に初期化するようにします。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. "コマンドプロンプトを開く"を、設定 - 共通設定 - メインメニュー から追加する。
2. 変更前後で、 CDisableWow64FsRedirect クラスのコンストラクタに break を設定し、メンバ変数を確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2110
https://github.com/sakura-editor/sakura/pull/2134

MinGW build が fail して確認できないので、下記を cherry-pick して確認する。
https://github.com/sakura-editor/sakura/pull/2324

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
