### PR TITLE
C++11 in-class initializer 対応 (CFuncInfoArr)

### DIFF
--- a/sakura_core/outline/CFuncInfoArr.cpp
+++ b/sakura_core/outline/CFuncInfoArr.cpp
@@ -14,16 +14,12 @@
 */
 
 #include "StdAfx.h"
-#include <stdlib.h>
 #include "outline/CFuncInfoArr.h"
 #include "outline/CFuncInfo.h"
 
 /* CFuncInfoArrクラス構築 */
 CFuncInfoArr::CFuncInfoArr()
 {
-	m_nFuncInfoArrNum = 0;	/* 配列要素数 */
-	m_ppcFuncInfoArr = nullptr;	/* 配列 */
-	m_nAppendTextLenMax = 0;
 	return;
 }
 

--- a/sakura_core/outline/CFuncInfoArr.h
+++ b/sakura_core/outline/CFuncInfoArr.h
@@ -57,10 +57,10 @@ public:
 public:
 	SFilePath	m_szFilePath;	/*!< 解析対象ファイル名 */
 private:
-	int			m_nFuncInfoArrNum;	/*!< 配列要素数 */
-	CFuncInfo**	m_ppcFuncInfoArr;	/*!< 配列 */
+	int			m_nFuncInfoArrNum = 0;	/*!< 配列要素数 */
+	CFuncInfo**	m_ppcFuncInfoArr = nullptr;	/*!< 配列 */
 	std::map<int, std::wstring>	m_AppendTextArr;	// 追加文字列のリスト
-	int			m_nAppendTextLenMax;
+	int			m_nAppendTextLenMax = 0;
 
 	DISALLOW_COPY_AND_ASSIGN(CFuncInfoArr);
 };


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
CFuncInfoArr クラスで、メンバ変数をコンストラクタで初期化している。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
変数宣言時に初期化するようにします。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
変更前後で、 CFuncInfoArr クラスのコンストラクタに break を設定し、メンバ変数を確認する。
検索 - アウトライン解析 で実行で確認できます。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2110
https://github.com/sakura-editor/sakura/pull/2134

MinGW build が fail して確認できないので、下記を cherry-pick して確認する。
https://github.com/sakura-editor/sakura/pull/2324

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
