### PR TITLE
C++11 in-class initializer 対応 (CDlgSetCharSet)

### DIFF
--- a/sakura_core/dlg/CDlgSetCharSet.cpp
+++ b/sakura_core/dlg/CDlgSetCharSet.cpp
@@ -34,8 +34,6 @@ const DWORD p_helpids[] = {
 
 CDlgSetCharSet::CDlgSetCharSet()
 {
-	m_pnCharSet = nullptr;			// 文字コードセット
-	m_pbBom = nullptr;				// 文字コードセット
 }
 
 /* モーダルダイアログの表示 */

--- a/sakura_core/dlg/CDlgSetCharSet.h
+++ b/sakura_core/dlg/CDlgSetCharSet.h
@@ -33,8 +33,8 @@ public:
 	*/
 	int DoModal( HINSTANCE hInstance, HWND hwndParent, ECodeType* pnCharSet, bool* pbBom );	/* モーダルダイアログの表示 */
 
-	ECodeType*	m_pnCharSet;			// 文字コードセット
-	bool*		m_pbBom;				// BOM
+	ECodeType*	m_pnCharSet = nullptr;			// 文字コードセット
+	bool*		m_pbBom = nullptr;				// BOM
 
 	HWND		m_hwndCharSet;
 	HWND		m_hwndCheckBOM;


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
CDlgSetCharSet クラスで、メンバ変数をコンストラクタで初期化している。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
変数宣言時に初期化するようにします。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
変更前後で、 CDlgSetCharSet クラスのコンストラクタに break を設定し、メンバ変数を確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2110
https://github.com/sakura-editor/sakura/pull/2134

MinGW build が fail して確認できないので、下記を cherry-pick して確認する。
https://github.com/sakura-editor/sakura/pull/2324

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
