### PR TITLE
文字幅キャッシュを構築するタイミングを修正する

### DIFF
--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -737,9 +737,6 @@ bool CShareData::InitShareData()
 			0
 		);
 
-		SelectCharWidthCache( CWM_FONT_EDIT, CWM_CACHE_SHARE );
-		InitCharWidthCache(m_pShareData->m_Common.m_sView.m_lf);	// 2008/5/15 Uchi
-
 		//	From Here Oct. 27, 2000 genta
 		//	2014.01.08 Moca サイズチェック追加
 		if( m_pShareData->m_vStructureVersion != uShareDataVersion ||
@@ -751,6 +748,9 @@ bool CShareData::InitShareData()
 			return false;
 		}
 		//	To Here Oct. 27, 2000 genta
+
+		SelectCharWidthCache(CWM_FONT_EDIT, CWM_CACHE_SHARE);
+		InitCharWidthCache(m_pShareData->m_Common.m_sView.m_lf);
 	}
 	return true;
 }


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #1802

問題は2つあります。

- 共有データが使えるかどうか判定する仕様なので、「使えないかもしれない」のに更新するコードはマズい。
- 文字幅キャッシュを構築する必要があるかどうかを判断してないコードに見える。

今回対応するのは「使えないかも知れないけど更新はマズい」の部分です。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- 文字幅キャッシュの構築タイミングを「使えるか判定した後」に移動します。

本件は勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- resolves #1802
- #1523

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
