### PR TITLE
C++11 in-class initializer 対応 (CFuncKeyWnd)

### DIFF
--- a/sakura_core/func/CFuncKeyWnd.cpp
+++ b/sakura_core/func/CFuncKeyWnd.cpp
@@ -33,33 +33,14 @@
 #define TIMER_TIMEOUT 100
 #define TIMER_CHECKFUNCENABLE 300
 
-/****
-LRESULT CALLBACK CFuncKeyWndProc(
-	HWND	hwnd,	// handle of window
-	UINT	uMsg,	// message identifier
-	WPARAM	wParam,	// first message parameter
-	LPARAM	lParam 	// second message parameter
-)
-{
-	CFuncKeyWnd*	pCFuncKeyWnd;
-	pCFuncKeyWnd = ( CFuncKeyWnd* )::GetWindowLongPtr( hwnd, GWLP_USERDATA );
-	if( NULL != pCFuncKeyWnd ){
-		return pCFuncKeyWnd->DispatchEvent( hwnd, uMsg, wParam, lParam );
-	}
-	return ::DefWindowProc( hwnd, uMsg, wParam, lParam );
-}
-***/
-
 //	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 CFuncKeyWnd::CFuncKeyWnd()
 : CWnd(L"::CFuncKeyWnd")
 {
 	int		i;
 	LOGFONT	lf;
-	m_pcEditDoc = nullptr;
 	/* 共有データ構造体のアドレスを返す */
 	m_pShareData = &GetDllShareData();
-	m_nCurrentKeyState = -1;
 	for( i = 0; i < int(std::size(m_szFuncNameArr)); ++i ){
 		m_szFuncNameArr[i][0] = L'\0';
 	}
@@ -88,10 +69,6 @@ CFuncKeyWnd::CFuncKeyWnd()
 	lf.lfPitchAndFamily	= 0x31;
 	::wcsncpy_s(lf.lfFaceName, L"ＭＳ Ｐゴシック", _TRUNCATE);
 	m_hFont = ::CreateFontIndirect( &lf );
-
-	m_bSizeBox = false;
-	m_hwndSizeBox = nullptr;
-	m_nTimerCount = 0;
 
 	return;
 }

--- a/sakura_core/func/CFuncKeyWnd.h
+++ b/sakura_core/func/CFuncKeyWnd.h
@@ -45,15 +45,15 @@ public:
 	*/
 private:
 	// 20060126 aroka すべてPrivateにして、初期化順序に合わせて並べ替え
-	CEditDoc*		m_pcEditDoc;
+	CEditDoc*		m_pcEditDoc = nullptr;
 	DLLSHAREDATA*	m_pShareData;
-	int				m_nCurrentKeyState;
+	int				m_nCurrentKeyState = -1;
 	WCHAR			m_szFuncNameArr[12][256];
 	HWND			m_hwndButtonArr[12];
 	HFONT			m_hFont;	/*!< 表示用フォント */
-	bool			m_bSizeBox;
-	HWND			m_hwndSizeBox;
-	int				m_nTimerCount;
+	bool			m_bSizeBox = false;
+	HWND			m_hwndSizeBox = nullptr;
+	int				m_nTimerCount = 0;
 	int				m_nButtonGroupNum; // Openで初期化
 	EFunctionCode	m_nFuncCodeArr[12]; // Open->CreateButtonsで初期化
 protected:


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
CFuncKeyWnd クラスで、メンバ変数をコンストラクタで初期化している。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
変数宣言時に初期化するようにします。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
変更前後で、 CFuncKeyWnd クラスのコンストラクタに break を設定し、メンバ変数を確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2110
https://github.com/sakura-editor/sakura/pull/2134

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
