### PR TITLE
bugprone-switch-missing-default-case 警告修正 (clang-tidy)

### DIFF
--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -484,6 +484,8 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 						m_gi.bGrepPaste = true;	break;
 					case 'O':
 						m_gi.bGrepBackup = true;	break;
+					default:
+						break;
 					}
 				}
 				break;
@@ -516,6 +518,8 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 				break;
 			case CMDLINEOPT_PROFMGR:
 				m_bProfileMgr = true;
+				break;
+			default:
 				break;
 			}
 		}

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -397,6 +397,8 @@ LRESULT CControlTray::DispatchEvent(
 			/* メニューアイテム描画 */
 			m_cMenuDrawer.DrawItem( lpdis );
 			return TRUE;
+		default:
+			break;
 		}
 		return FALSE;
 	case WM_MEASUREITEM:
@@ -410,6 +412,8 @@ LRESULT CControlTray::DispatchEvent(
 				lpmis->itemHeight = nItemHeight;
 			}
 			return TRUE;
+		default:
+			break;
 		}
 		return FALSE;
 	case WM_EXITMENULOOP:
@@ -583,6 +587,8 @@ LRESULT CControlTray::DispatchEvent(
 		switch( lphi->iContextType ){
 		case HELPINFO_MENUITEM:
 			MyWinHelp( hwnd, HELP_CONTEXT, FuncID_To_HelpContextID( (EFunctionCode)lphi->iCtrlId ) );
+			break;
+		default:
 			break;
 		}
 		return TRUE;
@@ -898,6 +904,8 @@ LRESULT CControlTray::DispatchEvent(
 			return 0L;
 		case WM_RBUTTONDBLCLK:
 			return 0L;
+		default:
+			break;
 		}
 		break;
 
@@ -970,6 +978,8 @@ void CControlTray::OnCommand( WORD wNotifyCode, [[maybe_unused]] WORD wID , [[ma
 	switch( wNotifyCode ){
 	/* メニューからのメッセージ */
 	case 0:
+		break;
+	default:
 		break;
 	}
 	return;
@@ -1775,6 +1785,8 @@ INT_PTR CALLBACK CControlTray::ExitingDlgProc(
 	switch( uMsg ){
 	case WM_INITDIALOG:
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/agent/CBackupAgent.cpp
+++ b/sakura_core/agent/CBackupAgent.cpp
@@ -49,6 +49,8 @@ ECallbackResult CBackupAgent::OnPreBeforeSave(SSaveInfo* pSaveInfo)
 				return CALLBACK_INTERRUPT;
 			}
 			break;
+		default:
+			break;
 		}
 	}
 	return CALLBACK_CONTINUE;
@@ -415,6 +417,8 @@ bool CBackupAgent::FormatBackUpPath(
 			if( -1 == auto_snprintf_s( pBase, nBaseCount, _TRUNCATE, L"%s%s", szFname, szExt ) ){
 				return false;
 			}
+			break;
+		default:
 			break;
 		}
 

--- a/sakura_core/charset/CCodePage.cpp
+++ b/sakura_core/charset/CCodePage.cpp
@@ -47,6 +47,8 @@ DWORD GetMultiByteFlgas(UINT codepage){
 	case 65001:
 	case 54936:
 		return 0;
+	default:
+		break;
 	}
 	return nToMultiByteFlags;
 }
@@ -294,6 +296,8 @@ EEncodingTrait CCodePage::GetEncodingTrait(int charcodeEx)
 	case CODE_AUTODETECT:
 	case CODE_ERROR:
 		return ENCODING_TRAIT_ERROR;
+	default:
+		break;
 	}
 
 	UINT codepage = CodePageExToMSCP(charcodeEx);
@@ -307,6 +311,8 @@ EEncodingTrait CCodePage::GetEncodingTrait(int charcodeEx)
 		return ENCODING_TRAIT_UTF32LE;
 	case 12001:
 		return ENCODING_TRAIT_UTF32BE;
+	default:
+		break;
 	}
 	CHAR testCrlf[10];
 	int nRet = ::WideCharToMultiByte(codepage, 0, L"\r\n", 2, testCrlf, sizeof(testCrlf), nullptr, nullptr);

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -332,6 +332,8 @@ BOOL CDialog::OnBnClicked( int wID )
 	case IDOK:
 		CloseDialog( wID );
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }
@@ -429,6 +431,8 @@ INT_PTR CDialog::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM l
 	case WM_CHARTOITEM:	return OnCharToItem( wParam, lParam );
 	case WM_HELP:		return OnPopupHelp( wParam, lParam );	//@@@ 2002.01.18 add
 	case WM_CONTEXTMENU:return OnContextMenu( wParam, lParam );	//@@@ 2002.01.18 add
+	default:
+		break;
 	}
 	return FALSE;
 }
@@ -456,21 +460,29 @@ BOOL CDialog::OnCommand( WPARAM wParam, LPARAM lParam )
 			switch( wNotifyCode ){
 			/* ボタン／チェックボックスがクリックされた */
 			case BN_CLICKED:	return OnBnClicked( wID );
+			default:
+				break;
 			}
 		}else if( ::lstrcmpi(szClass, L"Static") == 0 ){
 			switch( wNotifyCode ){
 			case STN_CLICKED:	return OnStnClicked( wID );
+			default:
+				break;
 			}
 		}else if( ::lstrcmpi(szClass, L"Edit") == 0 ){
 			switch( wNotifyCode ){
 			case EN_CHANGE:		return OnEnChange( hwndCtl, wID );
 			case EN_SETFOCUS:	return OnEnSetFocus( hwndCtl, wID );
 			case EN_KILLFOCUS:	return OnEnKillFocus( hwndCtl, wID );
+			default:
+				break;
 			}
 		}else if( ::lstrcmpi(szClass, L"ListBox") == 0 ){
 			switch( wNotifyCode ){
 			case LBN_SELCHANGE:	return OnLbnSelChange( hwndCtl, wID );
 			case LBN_DBLCLK:	return OnLbnDblclk( wID );
+			default:
+				break;
 			}
 		}else if( ::lstrcmpi(szClass, L"ComboBox") == 0 ){
 			switch( wNotifyCode ){
@@ -481,6 +493,8 @@ BOOL CDialog::OnCommand( WPARAM wParam, LPARAM lParam )
 			case CBN_DROPDOWN:	return OnCbnDropDown( hwndCtl, wID );
 		//	case CBN_CLOSEUP:	return OnCbnCloseUp( hwndCtl, wID );
 			case CBN_SELENDOK:	return OnCbnSelEndOk( hwndCtl, wID );
+			default:
+				break;
 			}
 		}
 	}

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -123,6 +123,8 @@ INT_PTR CDlgAbout::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lP
 			::SetTextColor( (HDC)wParam, RGB( 0, 0, 0 ) );
         }
 		return (INT_PTR)GetStockObject( WHITE_BRUSH );
+	default:
+		break;
 	}
 	return result;
 }
@@ -282,6 +284,8 @@ BOOL CDlgAbout::OnBnClicked( int wID )
 	 		ApiWrap::EditCtl_SetSel( hwndEditVer, -1, 0); 
  		}
 		return TRUE;
+	default:
+		break;
 	}
 	return CDialog::OnBnClicked( wID );
 }
@@ -319,6 +323,8 @@ BOOL CDlgAbout::OnStnClicked( int wID )
 		::ShellExecute(GetHwnd(), nullptr, _T(GITHUB_PR_HEAD_URL), nullptr, nullptr, SW_SHOWNORMAL);
 #endif
 		return TRUE;
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnStnClicked( wID );
@@ -486,6 +492,8 @@ LRESULT CALLBACK CUrlWnd::UrlWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 		return (LRESULT)0;
 	case WM_SETTEXT:
 		return pUrlWnd->OnSetText( (LPCWSTR)lParam ) ? TRUE : FALSE;
+	default:
+		break;
 	}
 
 	return CallWindowProc( pUrlWnd->m_pOldProc, hWnd, msg, wParam, lParam );

--- a/sakura_core/dlg/CDlgCancel.cpp
+++ b/sakura_core/dlg/CDlgCancel.cpp
@@ -42,6 +42,8 @@ INT_PTR CDlgCancel::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM l
 			return TRUE;
 		}
 		break;
+	default:
+		break;
 	}
 	return result;
 }
@@ -91,6 +93,8 @@ BOOL CDlgCancel::OnBnClicked( int wID )
 		m_bCANCEL = TRUE;	/* IDCANCELボタンが押された */
 //		CloseDialog( 0 );
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -118,6 +118,8 @@ BOOL CDlgCompare::OnBnClicked( int wID )
 	case IDCANCEL:
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnBnClicked( wID );

--- a/sakura_core/dlg/CDlgCtrlCode.cpp
+++ b/sakura_core/dlg/CDlgCtrlCode.cpp
@@ -240,6 +240,8 @@ BOOL CDlgCtrlCode::OnBnClicked( int wID )
 	case IDCANCEL:
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */
@@ -287,6 +289,8 @@ BOOL CDlgCtrlCode::OnNotify( NMHDR* pNMHDR )
 					}
 				}
 			}
+			break;
+		default:
 			break;
 		}
 	}

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -186,6 +186,8 @@ BOOL CDlgDiff::OnBnClicked( int wID )
 	case IDC_RADIO_DIFF_FILE2:
 		::CheckDlgButton( GetHwnd(), IDC_RADIO_DIFF_FILE1, FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -577,6 +577,8 @@ BOOL CDlgFavorite::OnBnClicked( int wID )
 			AddItem();
 		}
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */
@@ -597,6 +599,8 @@ BOOL CDlgFavorite::OnNotify(NMHDR* pNMHDR)
 			TabSelectChange(false);
 			return TRUE;
 			//break;
+		default:
+			break;
 		}
 	}else{
 		hwndList = m_aListViewInfo[m_nCurrentTab].hListView;
@@ -627,6 +631,7 @@ BOOL CDlgFavorite::OnNotify(NMHDR* pNMHDR)
 			
 			// ListViewでDeleteキーが押された:削除
 			case LVN_KEYDOWN:
+			{
 				switch( ((NMLVKEYDOWN*)pNMHDR)->wVKey )
 				{
 				case VK_DELETE:
@@ -643,6 +648,8 @@ BOOL CDlgFavorite::OnNotify(NMHDR* pNMHDR)
 						RightMenu( po );
 					}
 					return TRUE;
+				default:
+					break;
 				}
 				int nIdx = getCtrlKeyState();
 				WORD wKey = ((NMLVKEYDOWN*)pNMHDR)->wVKey;
@@ -663,6 +670,9 @@ BOOL CDlgFavorite::OnNotify(NMHDR* pNMHDR)
 					TabSelectChange(true);
 					return FALSE;
 				}
+			}
+			default:
+				break;
 			}
 		}
 	}
@@ -1062,6 +1072,8 @@ void CDlgFavorite::RightMenu(POINT &menuPos)
 		break;
 	case MENU_DELETE_SELECTED:
 		OnBnClicked( IDC_BUTTON_DELETE_SELECTED );
+		break;
+	default:
 		break;
 	}
 }

--- a/sakura_core/dlg/CDlgFind.cpp
+++ b/sakura_core/dlg/CDlgFind.cpp
@@ -70,6 +70,8 @@ BOOL CDlgFind::OnCbnDropDown( HWND hwndCtl, int wID )
 			}
 		}
 		break;
+	default:
+		break;
 	}
 	return CDialog::OnCbnDropDown( hwndCtl, wID );
 }
@@ -381,6 +383,8 @@ BOOL CDlgFind::OnBnClicked( int wID )
 	case IDCANCEL:
 		CloseDialog( 0 );
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -230,6 +230,8 @@ BOOL CDlgGrep::OnCbnDropDown( HWND hwndCtl, int wID )
 			}
 		}
 		break;
+	default:
+		break;
 	}
 	return CDialog::OnCbnDropDown( hwndCtl, wID );
 }
@@ -578,6 +580,8 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 		}
 		CloseDialog( FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */

--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -156,6 +156,8 @@ BOOL CDlgGrepReplace::OnCbnDropDown( HWND hwndCtl, int wID )
 			}
 		}
 		break;
+	default:
+		break;
 	}
 	return CDlgGrep::OnCbnDropDown( hwndCtl, wID );
 }
@@ -188,6 +190,8 @@ BOOL CDlgGrepReplace::OnBnClicked( int wID )
 				return TRUE;
 			}
 		}
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDlgGrep::OnBnClicked( wID );

--- a/sakura_core/dlg/CDlgInput1.cpp
+++ b/sakura_core/dlg/CDlgInput1.cpp
@@ -132,8 +132,12 @@ INT_PTR CDlgInput1::DispatchEvent(
 			case IDCANCEL:
 				::EndDialog( hwndDlg, FALSE );
 				return TRUE;
+			default:
+				break;
 			}
 			break;	//@@@ 2002.01.07 add
+		default:
+			break;
 		}
 		break;	//@@@ 2002.01.07 add
 	//@@@ 2002.01.07 add start
@@ -149,6 +153,8 @@ INT_PTR CDlgInput1::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 	//@@@ 2002.01.07 add end
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/dlg/CDlgJump.cpp
+++ b/sakura_core/dlg/CDlgJump.cpp
@@ -122,6 +122,8 @@ BOOL CDlgJump::OnCbnSelChange( [[maybe_unused]] HWND hwndCtl, int wID )
 		nWorkLine = (int)ApiWrap::Combo_GetItemData( GetItemHwnd( IDC_COMBO_PLSQLBLOCKS ), nIndex );
 		::SetDlgItemInt( GetHwnd(), IDC_EDIT_PLSQL_E1, nWorkLine, FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }
@@ -182,6 +184,8 @@ BOOL CDlgJump::OnBnClicked( int wID )
 	case IDCANCEL:
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnBnClicked( wID );

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -857,6 +857,8 @@ HRESULT CDlgOpenFile_CommonItemDialog::OnItemSelected(
 			m_pFileDialog->SetFolder(psiFolder);
 		}
 		break;
+	default:
+		break;
 	}
 	return S_OK;
 }
@@ -876,6 +878,8 @@ HRESULT CDlgOpenFile_CommonItemDialog::OnCheckButtonToggled(
 		break;
 	case CtrlId::CHECK_BOM:
 		m_bBom = bChecked ? true : false;
+		break;
+	default:
 		break;
 	}
 	return S_OK;

--- a/sakura_core/dlg/CDlgPluginOption.cpp
+++ b/sakura_core/dlg/CDlgPluginOption.cpp
@@ -332,6 +332,8 @@ BOOL CDlgPluginOption::OnNotify(NMHDR* pNMHDR)
 			// リストビューへのダブルクリックで編集領域へ移動	2013/5/23 Uchi
 			MoveFocusToEdit();
 			break;
+		default:
+			break;
 		}
 		return TRUE;
 
@@ -354,6 +356,8 @@ BOOL CDlgPluginOption::OnNotify(NMHDR* pNMHDR)
 		// 編集中のデータの戻し
 		SetFromEdit( m_Line );
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */
@@ -402,6 +406,8 @@ BOOL CDlgPluginOption::OnBnClicked( int wID )
 	case IDCANCEL:
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */
@@ -416,6 +422,8 @@ BOOL CDlgPluginOption::OnCbnSelChange( HWND hwndCtl, int wID )
 		SetFromEdit( m_Line );
 
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */
@@ -432,6 +440,8 @@ BOOL CDlgPluginOption::OnEnChange( HWND hwndCtl, int wID )
 		SetFromEdit( m_Line );
 
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -188,6 +188,8 @@ BOOL CDlgPrintSetting::OnNotify(NMHDR* pNMHDR)
 		OnSpin( idCtrl, bSpinDown );
 		UpdatePrintableLineAndColumn();
 		break;
+	default:
+		break;
 	}
 	return TRUE;
 }
@@ -205,6 +207,8 @@ BOOL CDlgPrintSetting::OnCbnSelChange( [[maybe_unused]] HWND hwndCtl, int wID )
 	case IDC_COMBO_PAPER:
 		UpdatePrintableLineAndColumn();
 		break;	// ここでは行と桁の更新要求のみ。後の処理はCDialogに任せる。
+	default:
+		break;
 	}
 	return FALSE;
 }
@@ -339,6 +343,8 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 	case IDC_CHECK_LINENUMBER:
 		UpdatePrintableLineAndColumn();
 		break;	// ここでは行と桁の更新要求のみ。後の処理はCDialogに任せる。
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnBnClicked( wID );
@@ -356,6 +362,8 @@ BOOL CDlgPrintSetting::OnStnClicked( int wID )
 			CalcPrintableLineAndColumn();
 		}
 		return TRUE;
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnStnClicked( wID );
@@ -378,6 +386,8 @@ BOOL CDlgPrintSetting::OnEnChange( HWND hwndCtl, int wID )
 	case IDC_EDIT_MARGINRX:
 		UpdatePrintableLineAndColumn();
 		break;	// ここでは行と桁の更新要求のみ。後の処理はCDialogに任せる。
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnEnChange( hwndCtl, wID );
@@ -430,6 +440,8 @@ BOOL CDlgPrintSetting::OnEnKillFocus( HWND hwndCtl, int wID )
 	case IDC_EDIT_FOOT3:
 		UpdatePrintableLineAndColumn();
 		break;	// ここでは行と桁の更新要求のみ。後の処理はCDialogに任せる。
+	default:
+		break;
 	}
 
 	if (isImeUndesirable(wID))
@@ -756,6 +768,8 @@ void CDlgPrintSetting::OnSpin( int nCtrlId, BOOL bDown )
 	case IDC_SPIN_MARGINBY:		nIdx = 5;				break;
 	case IDC_SPIN_MARGINLX:		nIdx = 6;				break;
 	case IDC_SPIN_MARGINRX:		nIdx = 7;				break;
+	default:
+		break;
 	}
 	if( nIdx >= 0 ){
 		nCtrlIdEDIT = sDataRange[nIdx].ctrlid;
@@ -784,6 +798,8 @@ int CDlgPrintSetting::DataCheckAndCorrect( int nCtrlId, int nData )
 	case IDC_EDIT_MARGINBY:		nIdx = 5;		break;
 	case IDC_EDIT_MARGINLX:		nIdx = 6;		break;
 	case IDC_EDIT_MARGINRX:		nIdx = 7;		break;
+	default:
+		break;
 	}
 	if( nIdx >= 0 ){
 		if( nData <= sDataRange[nIdx].minval ){

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -252,6 +252,8 @@ BOOL CDlgProfileMgr::OnBnClicked( int wID )
 		GetData(false);
 		CloseDialog( 0 );
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }
@@ -266,14 +268,20 @@ INT_PTR CDlgProfileMgr::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPAR
 			if( LOWORD(wParam) == IDC_LIST_PROFILE ){
 				switch( HIWORD(wParam) ){
 				case LBN_SELCHANGE:
+				{
 					HWND hwndList = (HWND)lParam;
 					int nIdx = ApiWrap::List_GetCurSel( hwndList );
 					DlgItem_Enable( GetHwnd(), IDC_BUTTON_PROF_DELETE, nIdx != 0 );
 					DlgItem_Enable( GetHwnd(), IDC_BUTTON_PROF_RENAME, nIdx != 0 );
 					return TRUE;
 				}
+				default:
+					break;
+				}
 			}
 		}
+	default:
+		break;
 	}
 	return result;
 }

--- a/sakura_core/dlg/CDlgProperty.cpp
+++ b/sakura_core/dlg/CDlgProperty.cpp
@@ -62,6 +62,8 @@ BOOL CDlgProperty::OnBnClicked( int wID )
 //	case IDCANCEL:							// 未使用 del 2008/7/4 Uchi
 //		::EndDialog( GetHwnd(), FALSE );
 //		return TRUE;
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnBnClicked( wID );

--- a/sakura_core/dlg/CDlgReplace.cpp
+++ b/sakura_core/dlg/CDlgReplace.cpp
@@ -94,6 +94,8 @@ BOOL CDlgReplace::OnCbnDropDown( HWND hwndCtl, int wID )
 			}
 		}
 		break;
+	default:
+		break;
 	}
 	return CDialog::OnCbnDropDown( hwndCtl, wID );
 }
@@ -589,6 +591,8 @@ BOOL CDlgReplace::OnBnClicked( int wID )
 //	case IDCANCEL:
 //		::EndDialog( hwndDlg, 0 );
 //		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */

--- a/sakura_core/dlg/CDlgSetCharSet.cpp
+++ b/sakura_core/dlg/CDlgSetCharSet.cpp
@@ -88,6 +88,8 @@ BOOL CDlgSetCharSet::OnBnClicked( int wID )
 	case IDCANCEL:
 		CloseDialog( FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */
@@ -130,6 +132,7 @@ BOOL CDlgSetCharSet::OnCbnSelChange( HWND hwndCtl, int wID )
 	switch (wID) {
 	//	文字コードの変更をBOMチェックボックスに反映
 	case IDC_COMBO_CHARSET:
+	{
 		SetBOM();
 		nIdx = ApiWrap::Combo_GetCurSel( hwndCtl );
 		lRes = ApiWrap::Combo_GetItemData( hwndCtl, nIdx );
@@ -148,6 +151,9 @@ BOOL CDlgSetCharSet::OnCbnSelChange( HWND hwndCtl, int wID )
 			fCheck = BST_UNCHECKED;
 		}
 		ApiWrap::BtnCtl_SetCheck( m_hwndCheckBOM, fCheck );
+		break;
+	}
+	default:
 		break;
 	}
 	return TRUE;

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -558,6 +558,8 @@ BOOL CDlgTagJumpList::OnBnClicked( int wID )
 		StopTimer();
 		FindNext( false );
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */
@@ -620,6 +622,8 @@ BOOL CDlgTagJumpList::OnNotify(NMHDR* pNMHDR)
 			StopTimer();
 			::EndDialog( GetHwnd(), GetData() );
 			return TRUE;
+		default:
+			break;
 		}
 	}
 

--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -91,6 +91,8 @@ BOOL CDlgTagsMake::OnBnClicked( int wID )
 	case IDCANCEL:
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */

--- a/sakura_core/dlg/CDlgWinSize.cpp
+++ b/sakura_core/dlg/CDlgWinSize.cpp
@@ -108,6 +108,8 @@ BOOL CDlgWinSize::OnBnClicked( int wID )
 	case IDOK:
 	case IDCANCEL:
 		GetData();
+	default:
+		break;
 	}
 	return CDialog::OnBnClicked( wID );
 }

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -90,6 +90,8 @@ BOOL CDlgWindowList::OnBnClicked(int wID)
 	case IDCANCEL:
 		::EndDialog(GetHwnd(), FALSE);
 		return TRUE;
+	default:
+		break;
 	}
 	return CDialog::OnBnClicked(wID);
 }

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -172,6 +172,8 @@ void CDocEditor::SetImeMode( int mode )
 		case 4: //	Non-Conversion
 			conv |= IME_CMODE_NOCONVERSION;
 			break;
+		default:
+			break;
 		}
 		ImmSetConversionStatus( hIme, conv, sent );
 	}

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -786,6 +786,8 @@ void CEditDoc::OnChangeSetting(
 		case WRAP_WINDOW_WIDTH:
 			nMaxLineKetas = m_cLayoutMgr.GetMaxLineKetas();	// 現在の折り返し幅
 			break;
+		default:
+			break;
 		}
 
 		if( m_bTabSpaceCurTemp ){

--- a/sakura_core/env/CCodeChecker.cpp
+++ b/sakura_core/env/CCodeChecker.cpp
@@ -155,6 +155,8 @@ ECallbackResult CCodeChecker::OnCheckSave(SSaveInfo* pSaveInfo)
 		case IDYES:		pSaveInfo->cEol = pcDoc->m_cDocEditor.GetNewLineCode(); break; //統一
 		case IDNO:		break; //続行
 		case IDCANCEL:	return CALLBACK_INTERRUPT; //中断
+		default:
+			break;
 		}
 	}
 
@@ -201,6 +203,8 @@ ECallbackResult CCodeChecker::OnCheckSave(SSaveInfo* pSaveInfo)
 				GetEditWnd().GetActiveView().GetCommander().Command_MOVECURSOR(pt, 0);
 			}
 			return CALLBACK_INTERRUPT; //中断
+		default:
+			break;
 		}
 	}
 	return CALLBACK_CONTINUE;

--- a/sakura_core/env/CHokanMgr.cpp
+++ b/sakura_core/env/CHokanMgr.cpp
@@ -53,6 +53,8 @@ LRESULT APIENTRY HokanList_SubclassProc( HWND hwnd, UINT uMsg, WPARAM wParam, LP
 			}
 		}
 		return 0;	// 本来のウィンドウプロシージャは呼ばない（アクティブ化しない）
+	default:
+		break;
 	}
 	return CallWindowProc( gm_wpHokanListProc, hwnd, uMsg, wParam, lParam);
 }
@@ -418,6 +420,8 @@ INT_PTR CHokanMgr::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lP
 							rc.bottom += pt.y - ptStart.y;
 							rc.right += pt.x - ptStart.x;
 							break;
+						default:
+							break;
 						}
 						::MoveWindow( GetHwnd(), rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, TRUE );
 					}
@@ -445,6 +449,8 @@ INT_PTR CHokanMgr::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lP
 		pmmi = (MINMAXINFO*)lParam;
 		pmmi->ptMinTrackSize.x = ::GetSystemMetrics(SM_CXVSCROLL) * 4;
 		pmmi->ptMinTrackSize.y = ::GetSystemMetrics(SM_CYHSCROLL) * 4;
+		break;
+	default:
 		break;
 	}
 	return result;
@@ -641,6 +647,8 @@ int CHokanMgr::KeyProc( WPARAM wParam, LPARAM lParam )
 	case VK_ESCAPE:
 	case VK_LEFT:
 		return -2;
+	default:
+		break;
 	}
 	return -2;
 }

--- a/sakura_core/env/CSakuraEnvironment.cpp
+++ b/sakura_core/env/CSakuraEnvironment.cpp
@@ -593,6 +593,8 @@ const wchar_t* CSakuraEnvironment::_ExParam_SkipCond(const wchar_t* pszSource, i
 					next = false;
 				}
 				break;
+			default:
+				break;
 			}
 		}
 	}

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1800,6 +1800,8 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, VARIANT *Argument
 			case F_YESNOBOX:
 				uType |= MB_YESNO | MB_ICONQUESTION;
 				break;
+			default:
+				break;
 			}
 			int ret = ::MessageBox( View->GetHwnd(), sMessage.c_str(), L"sakura macro", uType );
 			Wrap( &Result )->Receive( ret );

--- a/sakura_core/macro/CPPA.cpp
+++ b/sakura_core/macro/CPPA.cpp
@@ -272,6 +272,8 @@ void __stdcall CPPA::stdStrObj(const char* ObjName, int Index, BYTE GS_Mode, int
 		case omSet:
 			m_CurInstance->m_cMemDebug.SetString(*Value);
 			break;
+		default:
+			break;
 		}
 		break;
 	default:

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -1234,6 +1234,8 @@ BOOL CSMacroMgr::CanFuncIsKeyMacro( int nFuncID )
 
 	/* その他 */
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -918,6 +918,8 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 	case IDCANCEL:
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 
 	/* 基底クラスメンバ */
@@ -959,6 +961,8 @@ BOOL CDlgFileTree::OnNotify(NMHDR* pNMHDR)
 				SetDataItem(-1);
 			}
 		}
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnNotify(pNMHDR);

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -321,6 +321,8 @@ INT_PTR CDlgFuncList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 			}
 		}
 		break;
+	default:
+		break;
 	}
 
 	return result;
@@ -537,6 +539,8 @@ void CDlgFuncList::SetData()
 			break;
 		case OUTLINE_LIST:	// 汎用リスト 2010.03.28 syat
 			::SetWindowText( GetHwnd(), L"" );
+			break;
+		default:
 			break;
 		}
 		//	May 18, 2001 genta
@@ -1843,6 +1847,8 @@ BOOL CDlgFuncList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 			case IDC_LIST_FL:
 			case IDC_TREE_FL:
 				continue;
+			default:
+				break;
 			}
 			ShowWindow( hwndPrev, SW_HIDE );
 		}
@@ -1950,6 +1956,8 @@ BOOL CDlgFuncList::OnBnClicked( int wID )
 				pcEditView->GetCommander().HandleCommand( nFuncCode, true, SHOW_RELOAD, 0, 0, 0 );
 			}
 		}
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnBnClicked( wID );
@@ -2009,6 +2017,8 @@ BOOL CDlgFuncList::OnNotify(NMHDR* pNMHDR)
 				m_bWaitTreeProcess=false;
 			}
 			return TRUE;
+		default:
+			break;
 		}
 	}else
 	if( hwndList == pNMHDR->hwndFrom ){
@@ -2047,6 +2057,8 @@ BOOL CDlgFuncList::OnNotify(NMHDR* pNMHDR)
 			}
 			Key2Command( ((LV_KEYDOWN *)pNMHDR)->wVKey );
 			return TRUE;
+		default:
+			break;
 		}
 	}
 
@@ -2079,6 +2091,8 @@ BOOL CDlgFuncList::OnNotify(NMHDR* pNMHDR)
 						}
 					}
 					::SetWindowLongPtr( GetHwnd(), DWLP_MSGRESULT, CDRF_DODEFAULT );
+					break;
+				default:
 					break;
 				}
 
@@ -2338,6 +2352,8 @@ BOOL CDlgFuncList::OnCbnSelEndOk( HWND hwndCtl, int wID )
 			::SendMessageAny(hWndTree, WM_SETREDRAW, (WPARAM)TRUE, 0);
 		}
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }
@@ -3557,6 +3573,8 @@ void CDlgFuncList::OnOutlineNotify( WPARAM wParam, LPARAM lParam )
 		if( (HWND)lParam == GetEditWnd().GetHwnd() )
 			return;	// 自分からの通知は無視
 		ChangeLayout( OUTLINE_LAYOUT_BACKGROUND );	// アウトライン画面を再配置
+		break;
+	default:
 		break;
 	}
 	return;

--- a/sakura_core/plugin/CPluginManager.cpp
+++ b/sakura_core/plugin/CPluginManager.cpp
@@ -295,6 +295,8 @@ bool CPluginManager::InstZipPluginSub( CommonSetting& common, HWND hWndOwner, co
 				bOk = false;
 				bSkip = true;
 				break;
+			default:
+				break;
 			}
 		}
 	}

--- a/sakura_core/plugin/CSmartIndentIfObj.h
+++ b/sakura_core/plugin/CSmartIndentIfObj.h
@@ -68,6 +68,8 @@ public:
 				Wrap(&Result)->Receive(S);
 			}
 			return true;
+		default:
+			break;
 		}
 		return CWSHIfObj::HandleFunction(View, ID, Arguments, ArgSize, Result);
 	}

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -2161,10 +2161,16 @@ INT_PTR CPrintPreview::DispatchEvent_PPB(
 				/* 印刷プレビューモードのオン/オフ */
 				m_pParentWnd->PrintPreviewModeONOFF();
 				return TRUE;
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
+		default:
+			break;
 		}
 		break;	/* WM_COMMAND */
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComBackup.cpp
+++ b/sakura_core/prop/CPropComBackup.cpp
@@ -121,6 +121,8 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_BACKUP;
 				return TRUE;
+			default:
+				break;
 			}
 			break;
 
@@ -195,8 +197,12 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 				ApiWrap::DlgItem_GetText( hwndDlg, IDC_EDIT_BACKUPFOLDER, m_Common.m_sBackup.m_szBackUpFolder, std::size(m_Common.m_sBackup.m_szBackUpFolder) - 1 );
 				UpdateBackupFile( hwndDlg );
 				break;
+			default:
+				break;
 			}
 			break;	/* EN_CHANGE */
+		default:
+			break;
 		}
 		break;	/* WM_COMMAND */
 
@@ -217,6 +223,8 @@ INT_PTR CPropBackup::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -211,6 +211,8 @@ INT_PTR CPropCustmenu::DispatchEvent(
 				}
 			}
 			return TRUE;
+		default:
+			break;
 		}
 		break;
 
@@ -247,8 +249,12 @@ INT_PTR CPropCustmenu::DispatchEvent(
 				// 削除すると選択が解除されるので，元に戻す
 				ApiWrap::Combo_SetCurSel( hwndCOMBO_MENU, nIdx1 );
 				return TRUE;
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
+		default:
+			break;
 		}
 
 		if( hwndCOMBO_MENU == hwndCtl ){
@@ -260,6 +266,8 @@ INT_PTR CPropCustmenu::DispatchEvent(
 				}
 				SetDataMenuList( hwndDlg, nIdx1 );
 				break;	/* CBN_SELCHANGE */
+			default:
+				break;
 			}
 		}else
 		if( hwndLIST_RES == hwndCtl ){
@@ -340,6 +348,8 @@ INT_PTR CPropCustmenu::DispatchEvent(
 				}else{
 				}
 				break;	/* LBN_SELCHANGE */
+			default:
+				break;
 			}
 		}
 		else if( hwndCOMBO_FUNCKIND == hwndCtl ){
@@ -360,6 +370,8 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					m_cLookup.SetListItem( hwndLIST_FUNC, nIdx3 );
 				}
 				return TRUE;
+			default:
+				break;
 			}
 		}else{
 			EFunctionCode	eFuncCode = F_0;
@@ -600,8 +612,12 @@ INT_PTR CPropCustmenu::DispatchEvent(
 					}
 					m_Common.m_sCustomMenu.m_bCustMenuPopupArr[nIdx1] = IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_SUBMENU );
 					break;
+				default:
+					break;
 				}
 
+				break;
+			default:
 				break;
 			}
 		}
@@ -631,6 +647,8 @@ INT_PTR CPropCustmenu::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComEdit.cpp
+++ b/sakura_core/prop/CPropComEdit.cpp
@@ -127,7 +127,11 @@ INT_PTR CPropEdit::DispatchEvent(
 					}
 				}
 				return TRUE;
+			default:
+				break;
 			}
+			break;
+		default:
 			break;
 		}
 		break;
@@ -148,6 +152,8 @@ INT_PTR CPropEdit::DispatchEvent(
 		case PSN_SETACTIVE: //@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 			m_nPageNum = ID_PROPCOM_PAGENUM_EDIT;
 			return TRUE;
+		default:
+			break;
 		}
 		break;	/* WM_NOTIFY */
 
@@ -168,6 +174,8 @@ INT_PTR CPropEdit::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComFile.cpp
+++ b/sakura_core/prop/CPropComFile.cpp
@@ -152,6 +152,8 @@ INT_PTR CPropFile::DispatchEvent(
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_FILE;
 				return TRUE;
+			default:
+				break;
 			}
 			break;
 		case IDC_SPIN_AUTOLOAD_DELAY:
@@ -249,6 +251,8 @@ INT_PTR CPropFile::DispatchEvent(
 			case IDC_CHECK_ALERT_IF_LARGEFILE:
 				EnableFilePropInput(hwndDlg);
 				break;
+			default:
+				break;
 			}
 			break;
 		case EN_SETFOCUS:
@@ -258,6 +262,8 @@ INT_PTR CPropFile::DispatchEvent(
 		case EN_KILLFOCUS:
 			if (isImeUndesirable(wID))
 				ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
+			break;
+		default:
 			break;
 		}
 		break;
@@ -279,6 +285,8 @@ INT_PTR CPropFile::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComFileName.cpp
+++ b/sakura_core/prop/CPropComFileName.cpp
@@ -76,7 +76,11 @@ INT_PTR CALLBACK CPropFileName::DlgProc_page(
 			if (isImeUndesirable(wID))
 				ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
 			break;
+		default:
+			break;
 		}
+		break;
+	default:
 		break;
 	}
 
@@ -155,6 +159,8 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 					}
 					m_nLastPos_FILENAME = nIndex;
 					break;
+				default:
+					break;
 				}
 				break;
 			default:
@@ -170,6 +176,8 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 				case PSN_SETACTIVE:
 					m_nPageNum = ID_PROPCOM_PAGENUM_FILENAME;
 					return TRUE;
+				default:
+					break;
 				}
 				break;
 			}
@@ -257,10 +265,12 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 						return TRUE;
 					}
 					break;
-				// default:
+				default:
+					break;
 				}
 				break;
-			// default:
+			default:
+				break;
 			}
 		}
 
@@ -280,6 +290,8 @@ INT_PTR CPropFileName::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComFormat.cpp
+++ b/sakura_core/prop/CPropComFormat.cpp
@@ -187,8 +187,12 @@ INT_PTR CPropFormat::DispatchEvent(
 				EnableFormatPropInput( hwndDlg );
 			//	To Here Sept. 10, 2000
 				return 0;
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
+		default:
+			break;
 		}
 		break;	/* WM_COMMAND */
 	case WM_NOTIFY:
@@ -212,6 +216,8 @@ INT_PTR CPropFormat::DispatchEvent(
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_FORMAT;
 				return TRUE;
+			default:
+				break;
 			}
 //			break;	/* default */
 //		}
@@ -240,6 +246,8 @@ INT_PTR CPropFormat::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComGeneral.cpp
+++ b/sakura_core/prop/CPropComGeneral.cpp
@@ -178,6 +178,8 @@ INT_PTR CPropGeneral::DispatchEvent(
 				}
 				InfoMessage( hwndDlg, LS(STR_PROPCOMGEN_DIR2) );
 				return TRUE;
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
 		// 2009.01.12 nasukoji	コンボボックスのリストの項目が選択された
@@ -204,6 +206,8 @@ INT_PTR CPropGeneral::DispatchEvent(
 					ApiWrap::Combo_SetCurSel( hwndCombo, 0 );
 				}
 				return TRUE;
+			default:
+				break;
 			}
 			break;	// CBN_SELENDOK
 		case EN_SETFOCUS:
@@ -213,6 +217,8 @@ INT_PTR CPropGeneral::DispatchEvent(
 		case EN_KILLFOCUS:
 			if (isImeUndesirable(wID))
 				ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
+			break;
+		default:
 			break;
 		}
 		break;	/* WM_COMMAND */
@@ -289,6 +295,8 @@ INT_PTR CPropGeneral::DispatchEvent(
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_GENERAL;	//Oct. 25, 2000 JEPRO ZENPAN1→ZENPAN に変更(参照しているのはCPropCommon.cppのみの1箇所)
 				return TRUE;
+			default:
+				break;
 			}
 			break;
 		}
@@ -317,6 +325,8 @@ INT_PTR CPropGeneral::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComGrep.cpp
+++ b/sakura_core/prop/CPropComGrep.cpp
@@ -94,6 +94,8 @@ INT_PTR CPropGrep::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_GREP;
 				return TRUE;
+			default:
+				break;
 			}
 //			break;	/* default */
 //		}
@@ -122,6 +124,8 @@ INT_PTR CPropGrep::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComHelper.cpp
+++ b/sakura_core/prop/CPropComHelper.cpp
@@ -157,8 +157,12 @@ INT_PTR CPropHelper::DispatchEvent(
 					}
 				}
 				return TRUE;
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
+		default:
+			break;
 		}
 		break;	/* WM_COMMAND */
 	case WM_NOTIFY:
@@ -180,6 +184,8 @@ INT_PTR CPropHelper::DispatchEvent(
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_HELPER;
 				return TRUE;
+			default:
+				break;
 			}
 //			break;	/* default */
 //		}
@@ -216,6 +222,8 @@ INT_PTR CPropHelper::DispatchEvent(
 			m_hKeywordHelpFont = nullptr;
 		}
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComKeybind.cpp
+++ b/sakura_core/prop/CPropComKeybind.cpp
@@ -79,8 +79,8 @@ LRESULT CALLBACK CPropComKeybindWndProc( [[maybe_unused]] HWND hwndDlg, UINT uMs
 	case WM_CTLCOLORSTATIC:
 	// 白色のブラシハンドルを返す
 		return (LRESULT)GetStockObject(WHITE_BRUSH);
-//	default:
-//		break;
+	default:
+		break;
 	}
 	return 0;
 }
@@ -178,6 +178,8 @@ INT_PTR CPropKeybind::DispatchEvent(
 				}
 			}
 			return TRUE;
+		default:
+			break;
 		}
 		break;
 
@@ -240,8 +242,12 @@ INT_PTR CPropKeybind::DispatchEvent(
 				::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_KEY, LBN_SELCHANGE ), (LPARAM)hwndKeyList );
 				::SendMessageCmd( hwndDlg, WM_COMMAND, MAKELONG( IDC_LIST_FUNC, LBN_SELCHANGE ), (LPARAM)hwndFuncList );
 				return TRUE;
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
+		default:
+			break;
 		}
 		if( hwndCheckShift == hwndCtl
 		 || hwndCheckCtrl == hwndCtl
@@ -252,6 +258,8 @@ INT_PTR CPropKeybind::DispatchEvent(
 				ChangeKeyList( hwndDlg );
 
 				return TRUE;
+			default:
+				break;
 			}
 		}else
 		if( hwndKeyList == hwndCtl ){
@@ -278,6 +286,8 @@ INT_PTR CPropKeybind::DispatchEvent(
 				}
 				ApiWrap::Wnd_SetText( hwndEDIT_KEYSFUNC, pszLabel );
 				return TRUE;
+			default:
+				break;
 			}
 		}else
 		if( hwndFuncList == hwndCtl ){
@@ -306,6 +316,8 @@ INT_PTR CPropKeybind::DispatchEvent(
 					delete [] ppcAssignedKeyList;
 				}
 				return TRUE;
+			default:
+				break;
 			}
 		}else
 		if( hwndCombo == hwndCtl){
@@ -315,6 +327,8 @@ INT_PTR CPropKeybind::DispatchEvent(
 				/* 機能一覧に文字列をセット（リストボックス）*/
 				m_cLookup.SetListItem( hwndFuncList, nIndex2 );	//	Oct. 2, 2001 genta
 				return TRUE;
+			default:
+				break;
 			}
 
 //@@@ 2001.11.08 add start MIK
@@ -370,6 +384,8 @@ INT_PTR CPropKeybind::DispatchEvent(
 					}
 					return TRUE;
 				}
+			default:
+				break;
 			}
 //@@@ 2001.11.08 add end MIK
 		}
@@ -405,6 +421,8 @@ INT_PTR CPropKeybind::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.11.07 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComKeyword.cpp
+++ b/sakura_core/prop/CPropComKeyword.cpp
@@ -223,8 +223,12 @@ INT_PTR CPropKeyword::DispatchEvent(
 					/* リスト中で選択されているキーワードを編集する */
 					Edit_List_KeyWord( hwndDlg, hwndLIST_KEYWORD );
 					break;
+				default:
+					break;
 				}
 				return TRUE;
+			default:
+				break;
 			}
 		}else{
 			switch( pNMHDR->code ){
@@ -240,6 +244,8 @@ INT_PTR CPropKeyword::DispatchEvent(
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_KEYWORD;
 				return TRUE;
+			default:
+				break;
 			}
 		}
 		break;
@@ -254,6 +260,8 @@ INT_PTR CPropKeyword::DispatchEvent(
 				/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 				SetKeyWordSet( hwndDlg, nIndex1 );
 				return TRUE;
+			default:
+				break;
 			}
 		}else{
 			switch( wNotifyCode ){
@@ -429,8 +437,12 @@ INT_PTR CPropKeyword::DispatchEvent(
 				case IDCANCEL:
 					EndDialog( hwndDlg, IDCANCEL );
 					break;
+				default:
+					break;
 				}
 				break;	/* BN_CLICKED */
+			default:
+				break;
 			}
 		}
 		break;	/* WM_COMMAND */
@@ -467,6 +479,8 @@ INT_PTR CPropKeyword::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComMacro.cpp
+++ b/sakura_core/prop/CPropComMacro.cpp
@@ -117,6 +117,8 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 			case LVN_ITEMCHANGED:
 				CheckListPosition_Macro( hwndDlg );
 				break;
+			default:
+				break;
 			}
 			break;
 		default:
@@ -132,6 +134,8 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_MACRO;
 				return TRUE;
+			default:
+				break;
 			}
 			break;
 		}
@@ -155,12 +159,16 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 			case IDC_MACRO_REG:		// マクロ設定
 				SetMacro2List_Macro( hwndDlg );
 				break;
+			default:
+				break;
 			}
 			break;
 		case CBN_DROPDOWN:
 			switch( wID ){
 			case IDC_MACROPATH:
 				OnFileDropdown_Macro( hwndDlg );
+				break;
+			default:
 				break;
 			}
 			break;	/* CBN_DROPDOWN */
@@ -182,9 +190,13 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 					}
 				}
 				break;
+			default:
+				break;
 			}
 			break;
 		// To Here 2003.06.23 Moca
+		default:
+			break;
 		}
 
 		break;	/* WM_COMMAND */
@@ -205,6 +217,8 @@ INT_PTR CPropMacro::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -143,6 +143,8 @@ LRESULT CALLBACK CPropMainMenu::TreeViewProc(
 				TreeView_EditLabel( hwndTree, htiItem );
 			}
 			return 0;
+		default:
+			break;
 		}
 		break;
 	case WM_CHAR:
@@ -167,6 +169,8 @@ static LRESULT CALLBACK WindowProcEdit(
 	switch (uMsg) {
 	case WM_GETDLGCODE:
 		return DLGC_WANTALLKEYS;
+	default:
+		break;
 	}
 	return CallWindowProc( m_wpEdit, hwndEdit, uMsg, wParam, lParam );
 }
@@ -393,6 +397,8 @@ INT_PTR CPropMainMenu::DispatchEvent(
 				}
 			}
 			break;
+		default:
+			break;
 		}
 		break;
 
@@ -421,6 +427,8 @@ INT_PTR CPropMainMenu::DispatchEvent(
 				::SendMessage( hwndListFunk, WM_SETREDRAW, TRUE, 0 );
 
 				return TRUE;
+			default:
+				break;
 			}
 		}
 		else{
@@ -646,6 +654,8 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					case IDC_BUTTON_ADD:				// 追加
 						ApiWrap::List_SetCurSel( hwndListFunk, nIdxFunc+1 );
 						break;
+					default:
+						break;
 					}
 					break;
 
@@ -774,8 +784,12 @@ INT_PTR CPropMainMenu::DispatchEvent(
 				case IDC_BUTTON_COLLAPSE:	// ツリー全閉
 					ApiWrap::TreeView_ExpandAll( hwndTreeRes, false );
 					break;
+				default:
+					break;
 				}
 
+				break;
+			default:
 				break;
 			}
 		}
@@ -804,6 +818,8 @@ INT_PTR CPropMainMenu::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );
 
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -120,6 +120,8 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 					DispatchEvent( hwndDlg, WM_COMMAND, MAKEWPARAM(IDC_PLUGIN_OPTION, BN_CLICKED), (LPARAM)::GetDlgItem( hwndDlg, IDC_PLUGIN_OPTION ) );
 				}
 				break;
+			default:
+				break;
 			}
 			break;
 		default:
@@ -134,6 +136,8 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_PLUGIN;
 				return TRUE;
+			default:
+				break;
 			}
 			break;
 		}
@@ -254,6 +258,8 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 					}
 				}
 				break;
+			default:
+				break;
 			}
 			break;
 		case CBN_DROPDOWN:
@@ -267,6 +273,8 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 			//default:
 			//	break;
 			//}
+			break;
+		default:
 			break;
 		}
 
@@ -288,6 +296,8 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComStatusbar.cpp
+++ b/sakura_core/prop/CPropComStatusbar.cpp
@@ -85,6 +85,8 @@ INT_PTR CPropStatusbar::DispatchEvent(
 		case PSN_SETACTIVE: //@@@ 2002.01.03 YAZAKI 最後に表示していたシートを正しく覚えていないバグ修正
 			m_nPageNum = ID_PROPCOM_PAGENUM_STATUSBAR;
 			return TRUE;
+		default:
+			break;
 		}
 		break;	/* WM_NOTIFY */
 
@@ -105,6 +107,8 @@ INT_PTR CPropStatusbar::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComTab.cpp
+++ b/sakura_core/prop/CPropComTab.cpp
@@ -110,6 +110,8 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_TAB;
 				return TRUE;
+			default:
+				break;
 			}
 //			break;	/* default */
 //		}
@@ -126,6 +128,7 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 					EnableTabPropInput( hwndDlg );
 					break;
 				case IDC_BUTTON_TABFONT:
+				{
 					LOGFONT   lf = m_Common.m_sTabBar.m_lf;
 					INT nPointSize = m_Common.m_sTabBar.m_nPointSize;
 
@@ -139,6 +142,9 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 						}
 						m_hTabFont = hFont;
 					}
+					break;
+				}
+				default:
 					break;
 				}
 			}
@@ -169,6 +175,8 @@ INT_PTR CPropTab::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 			m_hTabFont = nullptr;
 		}
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComToolbar.cpp
+++ b/sakura_core/prop/CPropComToolbar.cpp
@@ -236,6 +236,8 @@ INT_PTR CPropToolbar::DispatchEvent(
 		case IDC_LIST_FUNC:	/* ボタン一覧リスト */
 			DrawToolBarItemList( pDis );	/* ツールバーボタンリストのアイテム描画 */
 			return TRUE;
+		default:
+			break;
 		}
 		return TRUE;
 
@@ -255,6 +257,8 @@ INT_PTR CPropToolbar::DispatchEvent(
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPCOM_PAGENUM_TOOLBAR;
 			return TRUE;
+		default:
+			break;
 		}
 		break;
 
@@ -267,6 +271,8 @@ INT_PTR CPropToolbar::DispatchEvent(
 			switch( wNotifyCode ){
 			case LBN_SELCHANGE:
 				return TRUE;
+			default:
+				break;
 			}
 		}else
 		if( hwndCombo == hwndCtl ){
@@ -295,6 +301,8 @@ INT_PTR CPropToolbar::DispatchEvent(
 				}
 				::SendMessage( hwndFuncList, WM_SETREDRAW, TRUE, 0 );
 				return TRUE;
+			default:
+				break;
 			}
 		}else{
 			switch( wNotifyCode ){
@@ -439,8 +447,12 @@ INT_PTR CPropToolbar::DispatchEvent(
 					ApiWrap::List_SetCurSel( hwndResList, nIndex1 );
 					//	To Here Apr. 13, 2002 genta
 					break;
+				default:
+					break;
 				}
 
+				break;
+			default:
 				break;
 			}
 		}
@@ -471,6 +483,8 @@ INT_PTR CPropToolbar::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/prop/CPropComWin.cpp
+++ b/sakura_core/prop/CPropComWin.cpp
@@ -143,6 +143,8 @@ INT_PTR CPropWin::DispatchEvent(
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPCOM_PAGENUM_WIN;
 				return TRUE;
+			default:
+				break;
 			}
 			break;
 		case IDC_SPIN_nRulerHeight:
@@ -254,6 +256,8 @@ INT_PTR CPropWin::DispatchEvent(
 				}
 				break;
 			// To Here 2004.05.13 Moca
+			default:
+				break;
 			}
 			break;
 		case EN_SETFOCUS:
@@ -263,6 +267,8 @@ INT_PTR CPropWin::DispatchEvent(
 		case EN_KILLFOCUS:
 			if (isImeUndesirable(wID))
 				ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
+			break;
+		default:
 			break;
 		}
 		break;
@@ -285,6 +291,8 @@ INT_PTR CPropWin::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.12.22 End
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/typeprop/CDlgKeywordSelect.cpp
+++ b/sakura_core/typeprop/CDlgKeywordSelect.cpp
@@ -97,6 +97,8 @@ BOOL CDlgKeywordSelect::OnBnClicked( int wID )
 		break;
 	case IDCANCEL:
 		break;
+	default:
+		break;
 	}
 	return CDialog::OnBnClicked( wID );
 }

--- a/sakura_core/typeprop/CDlgSameColor.cpp
+++ b/sakura_core/typeprop/CDlgSameColor.cpp
@@ -233,6 +233,8 @@ BOOL CDlgSameColor::OnBnClicked( int wID )
 
 	case IDCANCEL:
 		break;
+	default:
+		break;
 	}
 	return CDialog::OnBnClicked( wID );
 }

--- a/sakura_core/typeprop/CDlgTypeAscertain.cpp
+++ b/sakura_core/typeprop/CDlgTypeAscertain.cpp
@@ -75,6 +75,8 @@ BOOL CDlgTypeAscertain::OnBnClicked( int wID )
 	case IDCANCEL:
 		::EndDialog( GetHwnd(), FALSE );
 		return TRUE;
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnBnClicked( wID );

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -101,6 +101,8 @@ BOOL CDlgTypeList::OnLbnDblclk( int wID )
 			| PROP_TEMPCHANGE_FLAG
 		);
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }
@@ -153,6 +155,8 @@ BOOL CDlgTypeList::OnBnClicked( int wID )
 	case IDC_BUTTON_DEL_TYPE:
 		DelType();
 		return TRUE;
+	default:
+		break;
 	}
 	/* 基底クラスメンバ */
 	return CDialog::OnBnClicked( wID );
@@ -230,6 +234,8 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 					ApiWrap::BtnCtl_SetCheck( hwndDblClick, m_bExtDblClick[ nIdx ] );
 				}
 				return TRUE;
+			default:
+				break;
 			}
 		}
 		else if( LOWORD(wParam) == IDC_CHECK_EXT_RMENU && HIWORD(wParam) == BN_CLICKED )
@@ -300,6 +306,8 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 			return TRUE;
 		}
 		}
+	default:
+		break;
 	}
 	return result;
 }

--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -165,6 +165,8 @@ LRESULT APIENTRY CPropTypesColor::ColorList_SubclassProc( HWND hwnd, UINT uMsg, 
 			}
 		}
 		break;
+	default:
+		break;
 	}
 	switch( uMsg ){
 	case WM_RBUTTONDOWN:
@@ -351,6 +353,8 @@ INT_PTR CPropTypesColor::DispatchEvent(
 				::InvalidateRect( ::GetDlgItem( hwndDlg, IDC_BUTTON_TEXTCOLOR ), nullptr, TRUE );
 				::InvalidateRect( ::GetDlgItem( hwndDlg, IDC_BUTTON_BACKCOLOR ), nullptr, TRUE );
 				return TRUE;
+			default:
+				break;
 			}
 		}
 		switch( wNotifyCode ){
@@ -483,6 +487,8 @@ INT_PTR CPropTypesColor::DispatchEvent(
 						::IsDlgButtonCheckedBool( hwndDlg, IDC_CHECK_STRINGLINEONLY ) );
 					return TRUE;
 				}
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
 		case EN_SETFOCUS:
@@ -492,6 +498,8 @@ INT_PTR CPropTypesColor::DispatchEvent(
 		case EN_KILLFOCUS:
 			if (isImeUndesirable(wID))
 				ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
+			break;
+		default:
 			break;
 		}
 		break;	/* WM_COMMAND */
@@ -572,6 +580,8 @@ INT_PTR CPropTypesColor::DispatchEvent(
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPTYPE_PAGENUM_COLOR;
 				return TRUE;
+			default:
+				break;
 			}
 			break;	/* default */
 		}
@@ -590,6 +600,8 @@ INT_PTR CPropTypesColor::DispatchEvent(
 		case IDC_LIST_COLORS:		/* 色種別リスト */
 			DrawColorListItem( pDis );
 			return TRUE;
+		default:
+			break;
 		}
 		break;
 
@@ -610,6 +622,8 @@ INT_PTR CPropTypesColor::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids2 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.11.17 add end MIK
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/typeprop/CPropTypesKeyHelp.cpp
+++ b/sakura_core/typeprop/CPropTypesKeyHelp.cpp
@@ -434,7 +434,11 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 			case IDC_BUTTON_KEYHELP_EXPORT:	/* エクスポート */
 				Export(hwndDlg);
 				return TRUE;
+			default:
+				break;
 			}
+			break;
+		default:
 			break;
 		}
 		break;
@@ -470,6 +474,8 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 				ApiWrap::DlgItem_SetText( hwndDlg, IDC_EDIT_KEYHELP, szPath );			/* ファイルパス */
 			}
 			break;
+		default:
+			break;
 		}
 		break;
 
@@ -481,6 +487,8 @@ INT_PTR CPropTypesKeyHelp::DispatchEvent(
 	case WM_CONTEXTMENU:	/* Context Menu */
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/typeprop/CPropTypesRegex.cpp
+++ b/sakura_core/typeprop/CPropTypesRegex.cpp
@@ -429,7 +429,11 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 			case IDC_BUTTON_REGEX_EXPORT:	/* エクスポート */
 				Export(hwndDlg);
 				return TRUE;
+			default:
+				break;
 			}
+			break;
+		default:
 			break;
 		}
 		break;
@@ -501,6 +505,8 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 				nPrevIndex = nIndex;
 			}
 			break;
+		default:
+			break;
 		}
 		break;
 
@@ -517,6 +523,8 @@ INT_PTR CPropTypesRegex::DispatchEvent(
 	case WM_CONTEXTMENU:
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/typeprop/CPropTypesScreen.cpp
+++ b/sakura_core/typeprop/CPropTypesScreen.cpp
@@ -245,6 +245,8 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 					}
 				}
 				break;
+			default:
+				break;
 			}
 			break;
 
@@ -322,6 +324,8 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 				::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KINSOKUHIDE ), 
 					::IsDlgButtonChecked( hwndDlg, IDC_CHECK_KINSOKURET ) 
 				 || ::IsDlgButtonChecked( hwndDlg, IDC_CHECK_KINSOKUKUTO ) );
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
 		case EN_SETFOCUS:
@@ -331,6 +335,8 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 		case EN_KILLFOCUS:
 			if (isImeUndesirable(wID))
 				ImeSetOpen(hwndCtl, s_isImmOpenBkup, nullptr);
+			break;
+		default:
 			break;
 		}
 		break;	/* WM_COMMAND */
@@ -431,6 +437,8 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 			case PSN_SETACTIVE:
 				m_nPageNum = ID_PROPTYPE_PAGENUM_SCREEN;
 				return TRUE;
+			default:
+				break;
 			}
 			break;
 		}
@@ -467,6 +475,8 @@ INT_PTR CPropTypesScreen::DispatchEvent(
 			m_hTypeFont = nullptr;
 		}
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/typeprop/CPropTypesSupport.cpp
+++ b/sakura_core/typeprop/CPropTypesSupport.cpp
@@ -122,8 +122,12 @@ INT_PTR CPropTypesSupport::DispatchEvent(
 					CDlgOpenFile::SelectFile(hwndDlg, GetDlgItem(hwndDlg, IDC_EDIT_TYPEEXTHTMLHELP), L"*.chm;*.col", true, EFITER_NONE);
 				}
 				return TRUE;
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
+		default:
+			break;
 		}
 		break;	/* WM_COMMAND */
 	case WM_NOTIFY:
@@ -142,6 +146,8 @@ INT_PTR CPropTypesSupport::DispatchEvent(
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPTYPE_PAGENUM_SUPPORT;
 			return TRUE;
+		default:
+			break;
 		}
 		break;
 
@@ -162,6 +168,8 @@ INT_PTR CPropTypesSupport::DispatchEvent(
 		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids3 );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 //@@@ 2001.11.17 add end MIK
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/typeprop/CPropTypesWindow.cpp
+++ b/sakura_core/typeprop/CPropTypesWindow.cpp
@@ -154,6 +154,8 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 						::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_DEFAULT_BOM ), cCodeTypeName.UseBom() );
 					}
 					break;
+				default:
+					break;
 				}
 			}
 			break;
@@ -183,6 +185,8 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 					CCodePage::AddComboCodePages( hwndDlg, ::GetDlgItem(hwndDlg, IDC_COMBO_DEFAULT_CODETYPE), -1 );
 				}
 				return TRUE;
+			default:
+				break;
 			}
 			break;	/* BN_CLICKED */
 		case EN_SETFOCUS:
@@ -198,6 +202,8 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 				if(nVal > 255) nVal = 255;
 				ApiWrap::TrackBarCtl_SetPos( ::GetDlgItem( hwndDlg, IDC_TRACKBAR_BACKIMG_TRANSPARENCY ), TRUE, nVal );
 			}
+			break;
+		default:
 			break;
 		}
 		break;	/* WM_COMMAND */
@@ -218,12 +224,15 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 		case PSN_SETACTIVE:
 			m_nPageNum = ID_PROPTYPE_PAGENUM_WINDOW;
 			return TRUE;
+		default:
+			break;
 		}
 
 		// switch文追加 2014.08.02 katze
 		pMNUD  = (NM_UPDOWN*)lParam;
 		switch( (int)wParam ) {
 		case IDC_SPIN_LINENUMWIDTH:
+		{
 			/* 行番号の最小桁数 */
 //			MYTRACE( L"IDC_SPIN_LINENUMWIDTH\n" );
 			int nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_LINENUMWIDTH, nullptr, FALSE );
@@ -242,8 +251,12 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_LINENUMWIDTH, nVal, FALSE );
 			return TRUE;
 		}
+		default:
+			break;
+		}
 		switch( (int)wParam ) {
 		case IDC_UPDOWN_BACKIMG_TRANSPARENCY:
+		{
 			int nVal = ::GetDlgItemInt( hwndDlg, IDC_EDIT_BACKIMG_TRANSPARENCY, nullptr, FALSE );
 			if( pMNUD->iDelta < 0 ){
 				if( nVal < 0xFF ){
@@ -257,6 +270,9 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_BACKIMG_TRANSPARENCY, nVal, FALSE );
 			ApiWrap::TrackBarCtl_SetPos( ::GetDlgItem( hwndDlg, IDC_TRACKBAR_BACKIMG_TRANSPARENCY ), TRUE, nVal );
 			return TRUE;
+		}
+		default:
+			break;
 		}
 
 		break;	/* WM_NOTIFY */
@@ -291,6 +307,8 @@ INT_PTR CPropTypesWindow::DispatchEvent(
 			::SetDlgItemInt( hwndDlg, IDC_EDIT_BACKIMG_TRANSPARENCY, pos, FALSE );
 		}
 		return TRUE;
+	default:
+		break;
 	}
 	return FALSE;
 }

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -1332,7 +1332,7 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 	case L')':
 	case L'{':
 	case L'(':
-
+	{
 		wchar_t wcCharOrg = wcChar;
 		nCaretPosX_PHY = GetCaret().GetCaretLogicPos().x;
 
@@ -1505,6 +1505,8 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 							nMode = 0;
 							n++;
 						}
+						break;
+					default:
 						break;
 					}
 				}
@@ -1700,6 +1702,9 @@ void CEditView::SmartIndent_CPP( wchar_t wcChar )
 				)
 			);
 		}
+		break;
+	}
+	default:
 		break;
 	}
 	if( nullptr != pszData ){

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -197,6 +197,7 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 				break;
 
 			case 101:	// インポート／エクスポートの起点リセット（起点を設定フォルダーにする）
+			{
 				int nMsgResult = MYMESSAGEBOX(
 					hwnd,
 					MB_OKCANCEL | MB_ICONINFORMATION,
@@ -209,6 +210,9 @@ static LRESULT CALLBACK PropSheetWndProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 					GetInidir( pShareData->m_sHistory.m_szIMPORTFOLDER );
 					AddLastChar( pShareData->m_sHistory.m_szIMPORTFOLDER, std::size(pShareData->m_sHistory.m_szIMPORTFOLDER), L'\\' );
 				}
+				break;
+			}
+			default:
 				break;
 			}
 		}
@@ -577,6 +581,8 @@ BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool Fixed
 		case CDERR_STRUCTSIZE:		MYTRACE( L"CDERR_STRUCTSIZE \n" );		break;
 		case CFERR_MAXLESSTHANMIN:	MYTRACE( L"CFERR_MAXLESSTHANMIN \n" );	break;
 		case CFERR_NOFONTS:			MYTRACE( L"CFERR_NOFONTS \n" );			break;
+		default:
+			break;
 		}
 #endif
 		return FALSE;

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -635,6 +635,8 @@ LRESULT CEditView::DispatchEvent(
 		case XBUTTON2:
 			OnXRBUTTONDOWN( wParam, (short)LOWORD( lParam ), (short)HIWORD( lParam ) );
 			break;
+		default:
+			break;
 		}
 
 		return TRUE;
@@ -647,6 +649,8 @@ LRESULT CEditView::DispatchEvent(
 			break;
 		case XBUTTON2:
 			OnXRBUTTONUP( wParam, (short)LOWORD( lParam ), (short)HIWORD( lParam ) );
+			break;
+		default:
 			break;
 		}
 

--- a/sakura_core/view/CEditView_Cmdisrch.cpp
+++ b/sakura_core/view/CEditView_Cmdisrch.cpp
@@ -133,6 +133,8 @@ bool CEditView::ProcessCommand_isearch(
 		case F_ISEARCH_MIGEMO_PREV:
 			ISearchEnter(SEARCH_MIGEMO, SEARCH_BACKWARD);	//後方MIGEMOインクリメンタルサーチ    //2004.10.13 isearch
 			return true;
+		default:
+			break;
 	}
 	return false;
 }
@@ -289,6 +291,8 @@ void CEditView::ISearchExec(DWORD wChar)
 			return;
 		//case '\t':
 		//	break;
+		default:
+			break;
 	}
 	
 	if (m_bISearchFirst){
@@ -387,6 +391,8 @@ void CEditView::ISearchExec(bool bNext)
 				//選択範囲の後ろから
 				nLine = GetSelectionInfo().m_sSelect.GetTo().GetY2();
 				nIdx1 = GetSelectionInfo().m_sSelect.GetTo().GetX2();
+				break;
+			default:
 				break;
 		}
 	}else{
@@ -587,6 +593,8 @@ bool CEditView::IsISearchEnabled(int nCommand) const
 		return (m_nISearchMode == SEARCH_MIGEMO) && (m_nISearchDirection == SEARCH_FORWARD);
 	case F_ISEARCH_MIGEMO_PREV:
 		return (m_nISearchMode == SEARCH_MIGEMO) && (m_nISearchDirection == SEARCH_BACKWARD);
+	default:
+		break;
 	}
 	return false;
 }

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -2127,6 +2127,7 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 
 	case 100:	// パス名を貼り付ける
 	case 101:	// ファイル名を貼り付ける
+	{
 		CNativeW cmemBuf;
 		UINT nFiles;
 		WCHAR szPath[_MAX_PATH];
@@ -2184,6 +2185,9 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 		);
 		GetSelectionInfo().SetSelectArea( CLayoutRange(ptSelectFrom, GetCaret().GetCaretLayoutPos()) );	// 2009.07.25 ryoji
 		GetSelectionInfo().DrawSelectArea();
+		break;
+	}
+	default:
 		break;
 	}
 

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -241,6 +241,8 @@ CLayoutInt CEditView::OnHScroll( int nScrollCode, int nPos )
 		//	Aug. 14, 2005 genta 折り返し幅をLayoutMgrから取得するように
 		nScrollVal = ScrollAtH( m_pcEditDoc->m_cLayoutMgr.GetMaxLineKetas() - GetTextArea().m_nViewColNum );
 		break;
+	default:
+		break;
 	}
 	return nScrollVal;
 }

--- a/sakura_core/view/colors/CColor_Quote.cpp
+++ b/sakura_core/view/colors/CColor_Quote.cpp
@@ -167,6 +167,8 @@ bool CColor_Quote::BeginColor(const CStringRef& cStr, int nPos)
 				return true;
 			}
 			break;
+		default:
+			break;
 		}
 		m_bEscapeEnd = false;
 		if( bPreString ){
@@ -219,6 +221,8 @@ bool CColor_Quote::EndColor(const CStringRef& cStr, int nPos)
 			break;
 		case 3:
 			m_nCOMMENTEND = Match_QuoteStr( m_szQuote, 3, nPos, cStr, true );
+			break;
+		default:
 			break;
 		}
 		// -1でEndColorが呼び出されるのは行を超えてきたからなので行内チェックは不要

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -1170,6 +1170,8 @@ LRESULT CEditWnd::DispatchEvent(
 				/* メニューアイテム描画 */
 				m_cMenuDrawer.DrawItem( lpdis );
 				return TRUE;
+			default:
+				break;
 			}
 		}
 		return FALSE;
@@ -1189,6 +1191,8 @@ LRESULT CEditWnd::DispatchEvent(
 				lpmis->itemHeight = nItemHeight;
 			}
 			return TRUE;
+		default:
+			break;
 		}
 		return FALSE;
 
@@ -1206,6 +1210,8 @@ LRESULT CEditWnd::DispatchEvent(
 		switch( lphi->iContextType ){
 		case HELPINFO_MENUITEM:
 			MyWinHelp( hwnd, HELP_CONTEXT, FuncID_To_HelpContextID( (EFunctionCode)lphi->iCtrlId ) );
+			break;
+		default:
 			break;
 		}
 		return TRUE;
@@ -1467,6 +1473,8 @@ LRESULT CEditWnd::DispatchEvent(
 			}
 			break;
 		//	To Here Jul. 21, 2003 genta
+		default:
+			break;
 		}
 		return 0L;
 	case WM_COMMAND:
@@ -1945,6 +1953,8 @@ LRESULT CEditWnd::DispatchEvent(
 			case MYBCN_MINIMAP:
 				LayoutMiniMap();
 				break;
+			default:
+				break;
 			}
 			EndLayoutBars();	// 2006.12.19 ryoji
 		}
@@ -2109,6 +2119,7 @@ void CEditWnd::OnCommand( WORD wNotifyCode, WORD wID , HWND hwndCtl )
 			m_nCurrentFocus = F_SEARCH_BOX;
 			break;
 		case CBN_KILLFOCUS:
+		{
 			m_nCurrentFocus = 0;
 			//フォーカスがはずれたときに検索キーにしてしまう。
 			//検索キーワードを取得
@@ -2123,6 +2134,9 @@ void CEditWnd::OnCommand( WORD wNotifyCode, WORD wID , HWND hwndCtl )
 				GetActiveView().m_bCurSearchUpdate = true;
 				GetActiveView().ChangeCurRegexp();
 			}
+			break;
+		}
+		default:
 			break;
 		}
 		return;	// CBN_SELCHANGE(1) がアクセラレータと誤認されないようにここで抜ける（rev1886 の問題の抜本対策）
@@ -2198,6 +2212,8 @@ void CEditWnd::OnCommand( WORD wNotifyCode, WORD wID , HWND hwndCtl )
 			);
 			GetDocument()->HandleCommand( (EFunctionCode)(nFuncCode | FA_FROMKEYBOARD) );
 		}
+		break;
+	default:
 		break;
 	}
 

--- a/sakura_core/window/CSplitterWnd.cpp
+++ b/sakura_core/window/CSplitterWnd.cpp
@@ -664,6 +664,8 @@ int CSplitterWnd::GetPrevPane( void )
 		case 2:
 			nPane = 0;
 			break;
+		default:
+			break;
 		}
 	}else
 	if( m_nAllSplitRows == 1 &&	m_nAllSplitCols == 2 ){
@@ -673,6 +675,8 @@ int CSplitterWnd::GetPrevPane( void )
 			break;
 		case 1:
 			nPane = 0;
+			break;
+		default:
 			break;
 		}
 	}else{
@@ -688,6 +692,8 @@ int CSplitterWnd::GetPrevPane( void )
 			break;
 		case 3:
 			nPane = 2;
+			break;
+		default:
 			break;
 		}
 	}
@@ -710,6 +716,8 @@ int CSplitterWnd::GetNextPane( void )
 		case 2:
 			nPane = -1;
 			break;
+		default:
+			break;
 		}
 	}else
 	if( m_nAllSplitRows == 1 &&	m_nAllSplitCols == 2 ){
@@ -719,6 +727,8 @@ int CSplitterWnd::GetNextPane( void )
 			break;
 		case 1:
 			nPane = -1;
+			break;
+		default:
 			break;
 		}
 	}else{
@@ -734,6 +744,8 @@ int CSplitterWnd::GetNextPane( void )
 			break;
 		case 3:
 			nPane = -1;
+			break;
+		default:
 			break;
 		}
 	}
@@ -910,6 +922,8 @@ LRESULT CSplitterWnd::OnMouseMove( [[maybe_unused]] HWND hwnd, [[maybe_unused]] 
 	case 3:
 		::SetCursor( ::LoadCursor( nullptr, IDC_SIZEALL ) );
 		break;
+	default:
+		break;
 	}
 	if( 0 != m_bDragging ){		/* 分割バーをドラッグ中か */
 		::GetClientRect( GetHwnd(), &rc );
@@ -1055,6 +1069,8 @@ LRESULT CSplitterWnd::DispatchEvent_WM_APP( [[maybe_unused]] HWND hwnd, UINT uMs
 		break;
 	case MYWM_SETACTIVEPANE:
 		SetActivePane( (int)wParam );
+		break;
+	default:
 		break;
 	}
 	return 0L;

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -153,7 +153,8 @@ LRESULT CTabWnd::TabWndDispatchEvent( [[maybe_unused]] HWND hwnd, UINT uMsg, WPA
 		m_bVisualStyle = ::IsVisualStyle();
 		break;
 
-	//default:
+	default:
+		break;
 	}
 
 	return 1L;	//デフォルトのディスパッチにまわす
@@ -1608,6 +1609,8 @@ LRESULT CTabWnd::OnNotify( [[maybe_unused]] HWND hwnd, [[maybe_unused]] UINT uMs
 				((NMTTDISPINFO*)pnmh)->hinst = nullptr;
 			}
 			return 0L;
+		default:
+			break;
 		}
 	}
 	return 0L;


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
clang-tidy を実行すると、下記の warning が表示される。

```
C:\work\sakura\sakura_core\agent\CBackupAgent.cpp:39:3: warning: switching on non-enum value without default case may not cover all cases [bugprone-switch-missing-default-case]
   39 |                 switch( nBackupResult ){
      |                 ^
C:\work\sakura\sakura_core\agent\CBackupAgent.cpp:327:3: warning: switching on non-enum value without default case may not cover all cases [bugprone-switch-missing-default-case]
  327 |                 switch( bup_setting.GetBackupType() ){
      |                 ^
```

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
default 文を追加します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容
clang-tidy で bugprone-switch-missing-default-case の warning 削減されていることを確認する。

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://learn.microsoft.com/en-us/cpp/code-quality/clang-tidy
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/switch-missing-default-case.html
