### PR TITLE
modernize-use-nullptr 警告修正 (clang-tidy)

### DIFF
--- a/sakura_core/macro/CPythonMacroManager.cpp
+++ b/sakura_core/macro/CPythonMacroManager.cpp
@@ -435,13 +435,13 @@ EXTERN PyObject* (*PyEval_EvalFrame)(PyFrameObject* f);
 EXTERN PyObject* (*PyEval_EvalFrameEx)(PyFrameObject* f, int throwflag);
 
 inline void Py_XINCREF(PyObject* op) {
-	if (op != NULL) {
+	if (op != nullptr) {
 		Py_IncRef(op);
 	}
 }
 
 inline void Py_XDECREF(PyObject* op) {
-	if (op != NULL) {
+	if (op != nullptr) {
 		Py_DecRef(op);
 	}
 }
@@ -733,7 +733,7 @@ constexpr Symbol symbols[] = {
 #undef X
 
 PyMethodDef g_moduleMethods[] = {
-	{NULL, NULL, 0, NULL}
+	{nullptr, nullptr, 0, nullptr}
 };
 
 PyModuleDef g_moduleDef = {
@@ -782,7 +782,7 @@ PyObject* handleCommand(PyObject* self, PyObject* args)
 		}
 		if (varType == VT_EMPTY) {
 			PyErr_BadArgument();
-			return NULL;
+			return nullptr;
 		}
 
 		if (varType == VT_BSTR) {
@@ -862,7 +862,7 @@ PyObject* handleFunction(PyObject* self, PyObject* args)
 		}
 	}
 
-	PyObject* retObj = NULL;
+	PyObject* retObj = nullptr;
 	if (i == nArgs) {
 		VARIANT vtResult;
 		::VariantInit(&vtResult);
@@ -915,10 +915,10 @@ CPythonMacroManager::CPythonMacroManager()
 		g_functionNames.push_back(to_achar(info.m_pszFuncName));
 	}
 	for (auto& name : g_commandNames) {
-		g_commandDescs.push_back({&name[0], (PyCFunction)handleCommand, METH_VARARGS, NULL});
+		g_commandDescs.push_back({&name[0], (PyCFunction)handleCommand, METH_VARARGS, nullptr});
 	}
 	for (auto& name : g_functionNames) {
-		g_functionDescs.push_back({&name[0], (PyCFunction)handleFunction, METH_VARARGS, NULL});
+		g_functionDescs.push_back({&name[0], (PyCFunction)handleFunction, METH_VARARGS, nullptr});
 	}
 
 	s_initialized = true;
@@ -983,17 +983,17 @@ bool CPythonMacroManager::ExecKeyMacro(CEditView *EditView, int flags [[maybe_un
 			::FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
 				FORMAT_MESSAGE_IGNORE_INSERTS |
 				FORMAT_MESSAGE_FROM_SYSTEM,
-				NULL,
+				nullptr,
 				::GetLastError(),
 				MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
 				(LPWSTR)&pMsg,
 				0,
-				NULL
+				nullptr
 			);
 			CNativeW str(pMsg);
 			::LocalFree((HLOCAL)pMsg);
 			str.Replace(L"%1", dllname);
-			ErrorMessage(NULL, L"%s", str.GetStringPtr());
+			ErrorMessage(nullptr, L"%s", str.GetStringPtr());
 			return false;
 		}
 		for (size_t i = 0; i < _countof(symbols); ++i) {
@@ -1078,11 +1078,11 @@ bool CPythonMacroManager::ExecKeyMacro(CEditView *EditView, int flags [[maybe_un
 inline
 bool wide2utf8(std::string& utf8, const WCHAR* psz)
 {
-	int nbytes = WideCharToMultiByte(CP_UTF8, 0, psz, -1, NULL, 0, NULL, NULL);
+	int nbytes = WideCharToMultiByte(CP_UTF8, 0, psz, -1, nullptr, 0, nullptr, nullptr);
 	if (nbytes == 0)
 		return false;
 	utf8.resize(nbytes);
-	nbytes = WideCharToMultiByte(CP_UTF8, 0, psz, -1, &utf8[0], nbytes, NULL, NULL);
+	nbytes = WideCharToMultiByte(CP_UTF8, 0, psz, -1, &utf8[0], nbytes, nullptr, nullptr);
 	if (nbytes == 0)
 		return false;
 	return true;
@@ -1121,7 +1121,7 @@ CMacroManagerBase* CPythonMacroManager::Creator(const WCHAR* FileExt)
 	if (_wcsicmp( FileExt, L"py" ) == 0) {
 		return new CPythonMacroManager;
 	}
-	return NULL;
+	return nullptr;
 }
 
 // static


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
clang-tidy を実行すると、下記の warning が表示される。

```
C:\work\sakura\sakura_core\macro\CPythonMacroManager.cpp:438:12: warning: use nullptr [modernize-use-nullptr]
  438 |         if (op != NULL) {
      |                   ^~~~
      |                   nullptr
```

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
NULL を nullptr に変更します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. clang-tidy で modernize-use-nullptr の warning が消えていることを確認する。
2. 変更前後でasmが同じことを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/1866
https://github.com/sakura-editor/sakura/pull/2057

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
