### PR TITLE
PROPSHEETHEADER_V2_SIZE 削除

### DIFF
--- a/sakura_core/StdAfx.h
+++ b/sakura_core/StdAfx.h
@@ -141,18 +141,6 @@
 #endif
 #endif
 
-// Workaround for PROPSHEETHEADER_V2_SIZE
-#ifdef __MINGW32__
-#include <_mingw.h>
-#ifndef DUMMYUNION5_MEMBER
-#ifndef NONAMELESSUNION
-#define DUMMYUNION5_MEMBER(x) x
-#else /* NONAMELESSUNION */
-#define DUMMYUNION5_MEMBER(x) DUMMYUNIONNAME5.x
-#endif
-#endif
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -231,8 +231,8 @@ INT_PTR CPropCommon::DoPropertySheet( int nPageNum, bool bTrayProc )
 	}
 	//	To Here Jun. 2, 2001 genta
 
-	PROPSHEETHEADER psh = { PROPSHEETHEADER_V2_SIZE };
-	psh.dwSize     = PROPSHEETHEADER_V2_SIZE;
+	PROPSHEETHEADER psh = { sizeof(PROPSHEETHEADER) };
+	psh.dwSize     = sizeof(PROPSHEETHEADER);
 	psh.dwFlags    = PSH_NOAPPLYNOW | PSH_PROPSHEETPAGE | PSH_USEPAGELANG;
 	psh.hwndParent = m_hwndParent;
 	psh.hInstance  = CSelectLang::getLangRsrcInstance();

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -163,8 +163,8 @@ INT_PTR CPropTypes::DoPropertySheet( int nPageNum )
 		p->pfnCallback = nullptr;
 	}
 
-	PROPSHEETHEADER psh = { PROPSHEETHEADER_V2_SIZE };
-	psh.dwSize     = PROPSHEETHEADER_V2_SIZE;
+	PROPSHEETHEADER psh = { sizeof(PROPSHEETHEADER) };
+	psh.dwSize     = sizeof(PROPSHEETHEADER);
 	psh.dwFlags    = PSH_NOAPPLYNOW | PSH_PROPSHEETPAGE | PSH_USEPAGELANG;
 	psh.hwndParent = m_hwndParent;
 	psh.hInstance  = CSelectLang::getLangRsrcInstance();


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
1. psh.dwSize = sizeof(PROPSHEETHEADER) で記述されていたが、 PROPSHEETHEADER_V2_SIZE に変更された。
2. Windows10以降対応であれば、sizeof(PROPSHEETHEADER) を使うのが最も自然で安全 (Copilot)。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
1. PROPSHEETHEADER_V2_SIZE を使うのをやめる。
2. StdAfx.h に記述している条件コンパイルを削除する。
3. ログファイルを確認し、条件付きコンパイルの組み合わせが減っていることを確認する (5455->4707)。

## <!-- わかる範囲で --> PR の影響範囲
影響なし。

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
変更前後でasmが同じことを確認する。
## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/545
https://github.com/sakura-editor/sakura/pull/559
https://github.com/sakura-editor/sakura/pull/2354

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
