### PR TITLE
WinMainTest実行中のエラー音を減らす

### DIFF
--- a/src/test/cpp/tests1/test-winmain.cpp
+++ b/src/test/cpp/tests1/test-winmain.cpp
@@ -502,14 +502,6 @@ TEST_P(WinMainTest, runEditorProcess)
 		L"GoFileTop();"sv,
 
 		L"PrintPreview();"sv,			// 印刷プレビュー出す
-		L"WheelDown();"sv,
-		L"WheelUp();"sv,
-		L"WheelRight();"sv,
-		L"WheelLeft();"sv,
-		L"WheelPageDown();"sv,
-		L"WheelPageUp();"sv,
-		L"WheelPageRight();"sv,
-		L"WheelPageLeft();"sv,
 		L"PrintPreview();"sv,			// 印刷プレビュー消す
 
 		L"SplitWinVH();"sv,
@@ -540,9 +532,12 @@ TEST_P(WinMainTest, runEditorProcess)
 		L"ChgmodINS();"sv,
 		L"ChgmodINS();"sv,
 
+		L"GoFileTop();"sv,
 		L"SearchNext('3');"sv,			// 検索(呼ぶだけ)
+		L"GoFileEnd();"sv,
 		L"SearchPrev('3');"sv,			// 検索(呼ぶだけ)
 
+		L"GoFileTop();"sv,
 		// ↓コマンドライン経由なので日本語入れると危険！
 		L"Replace('3', 'threeeee');"sv,	// 置換(呼ぶだけ)
 		L"Undo();"sv,


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->
- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2314
- #2272

#2272 のマージ後から、テスト実行中にビープ音が何度もなるようになった。

（無関係かもしれない。）

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- 無駄なビープ音がならないように対策します。
  - 実行できないコマンドに対してビープが鳴っているもの → コマンドを削除します。
  - 前方検索で前方に一致結果がなくてビープが鳴ってるもの → 文書先頭に移動するコマンドを挿入します。
  - 後方検索で後方に一致結果がなくてビープが鳴ってるもの → 文書末尾に移動するコマンドを挿入します。
  - 全置換で無駄にビープが鳴ってるもの → 放置します。

本件は、勝手にやります。

全置換の無駄ビープは削除したほうがよいかも。

サクラエディタにはビープを抑制する機構 `CSoundSet` があるですが、実装が何と言うか、正しくはなくて、使い物にならんのです。ビープの制御はシステムパラメーターなので、正しく実装することによる弊害もあるんだけど、いつか対応したほうがいいんじゃないかな、みたいに思ってます。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
- ユニットテストの実行が若干静かになります。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
