### PR TITLE
modernize-redundant-void-arg 警告修正 (clang-tidy)

### DIFF
--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -83,9 +83,9 @@ public:
 	tagSIZE GetWindowSize() const noexcept { return { m_fi.m_nWindowSizeX, m_fi.m_nWindowSizeY }; }
 	tagPOINT GetWindowOrigin() const noexcept { return { m_fi.m_nWindowOriginX, m_fi.m_nWindowOriginY }; }
 	LPCWSTR GetOpenFile() const noexcept { return m_fi.m_szPath; }
-	int GetFileNum(void) const noexcept { return static_cast<int>(m_vFiles.size()); }
+	int GetFileNum() const noexcept { return static_cast<int>(m_vFiles.size()); }
 	const WCHAR* GetFileName(int i) const noexcept { return i < GetFileNum() ? m_vFiles[i].c_str() : nullptr; }
-	void ClearFile(void) noexcept { m_vFiles.clear(); }
+	void ClearFile() noexcept { m_vFiles.clear(); }
 	LPCWSTR GetDocType() const noexcept { return m_fi.m_szDocType; }
 	ECodeType GetDocCode() const noexcept { return m_fi.m_nCharCode; }
 	void ParseKanjiCodeFromFileName( LPWSTR pszExeFileName, int cchExeFileName );

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -319,7 +319,7 @@ bool CControlTray::CreateTrayIcon( [[maybe_unused]] HWND hWnd )
 }
 
 /* メッセージループ */
-void CControlTray::MessageLoop( void )
+void CControlTray::MessageLoop( )
 {
 //複数プロセス版
 	MSG	msg;
@@ -1527,7 +1527,7 @@ BOOL CControlTray::CloseAllEditor(
 }
 
 /*! ポップアップメニュー(トレイ左ボタン) */
-int	CControlTray::CreatePopUpMenu_L( void )
+int	CControlTray::CreatePopUpMenu_L( )
 {
 	int			i;
 	int			j;
@@ -1657,7 +1657,7 @@ int	CControlTray::CreatePopUpMenu_L( void )
 //	Oct. 12, 2000 JEPRO ポップアップメニュー(トレイ左ボタン) を参考にして新たに追加した部分
 
 /*! ポップアップメニュー(トレイ右ボタン) */
-int	CControlTray::CreatePopUpMenu_R( void )
+int	CControlTray::CreatePopUpMenu_R( )
 {
 	int		nId;
 	HMENU	hMenuTop;

--- a/sakura_core/_main/CControlTray.h
+++ b/sakura_core/_main/CControlTray.h
@@ -73,10 +73,10 @@ public:
 	HWND Create(HINSTANCE hInstance);	/* 作成 */
 	bool CreateTrayIcon(HWND hWnd);	// 20010412 by aroka
 	LRESULT DispatchEvent(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);	/* メッセージ処理 */
-	void MessageLoop( void );	/* メッセージループ */
-	void OnDestroy( void );		/* WM_DESTROY 処理 */	// 2006.07.09 ryoji
-	int	CreatePopUpMenu_L( void );	/* ポップアップメニュー(トレイ左ボタン) */
-	int	CreatePopUpMenu_R( void );	/* ポップアップメニュー(トレイ右ボタン) */
+	void MessageLoop( );	/* メッセージループ */
+	void OnDestroy( );		/* WM_DESTROY 処理 */	// 2006.07.09 ryoji
+	int	CreatePopUpMenu_L( );	/* ポップアップメニュー(トレイ左ボタン) */
+	int	CreatePopUpMenu_R( );	/* ポップアップメニュー(トレイ右ボタン) */
 
 	//ウィンドウ管理
 	static bool OpenNewEditor(							//!< 新規編集ウィンドウの追加 ver 0

--- a/sakura_core/_main/CProcess.h
+++ b/sakura_core/_main/CProcess.h
@@ -55,7 +55,7 @@ public:
 	HWND			GetMainWindow() const{ return m_hWnd; }
 
 	[[nodiscard]] const CShareData* GetShareDataPtr() const { return &m_cShareData; }
-	[[nodiscard]] LPCWSTR	GetAppName( void ) const { return m_strAppName.c_str(); }
+	[[nodiscard]] LPCWSTR	GetAppName( ) const { return m_strAppName.c_str(); }
 	void UpdateAppName( std::wstring_view appName );
 
 private:

--- a/sakura_core/_main/global.cpp
+++ b/sakura_core/_main/global.cpp
@@ -37,7 +37,7 @@
 
 	@date 2007/09/21 kobake 整理
  */
-LPCWSTR GetAppName( void )
+LPCWSTR GetAppName( )
 {
 	const auto pcProcess = CProcess::getInstance();
 	if( !pcProcess )

--- a/sakura_core/_os/CDropTarget.cpp
+++ b/sakura_core/_os/CDropTarget.cpp
@@ -117,7 +117,7 @@ BOOL CDropTarget::Register_DropTarget( HWND hWnd )
 	return TRUE;
 }
 
-BOOL CDropTarget::Revoke_DropTarget( void )
+BOOL CDropTarget::Revoke_DropTarget( )
 {
 	BOOL bResult = TRUE;
 	if( m_hWnd_DropTarget != nullptr ){
@@ -141,7 +141,7 @@ STDMETHODIMP CDropTarget::DragOver( DWORD dwKeyState, POINTL pt, LPDWORD pdwEffe
 	}
 	return m_pcEditView->DragOver( dwKeyState, pt, pdwEffect );
 }
-STDMETHODIMP CDropTarget::DragLeave( void )
+STDMETHODIMP CDropTarget::DragLeave( )
 {
 	if( m_pcEditWnd ){	// 2008.06.20 ryoji
 		return m_pcEditWnd->DragLeave();
@@ -412,7 +412,7 @@ STDMETHODIMP CEnumFORMATETC::Skip(ULONG celt)
 /** IEnumFORMATETC::Reset
 	@date 2008.03.26 ryoji 新規作成
 */
-STDMETHODIMP CEnumFORMATETC::Reset(void)
+STDMETHODIMP CEnumFORMATETC::Reset()
 {
 	m_nIndex = 0;
 	return S_OK;

--- a/sakura_core/_os/CDropTarget.h
+++ b/sakura_core/_os/CDropTarget.h
@@ -102,10 +102,10 @@ private: // 2002/2/10 aroka アクセス権変更
 	CEditView*		m_pcEditView = nullptr;
 public:
 	BOOL			Register_DropTarget(HWND hWnd);
-	BOOL			Revoke_DropTarget( void );
+	BOOL			Revoke_DropTarget( );
 	STDMETHODIMP	DragEnter(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect) override;
 	STDMETHODIMP	DragOver(DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect) override;
-	STDMETHODIMP	DragLeave( void ) override;
+	STDMETHODIMP	DragLeave( ) override;
 	STDMETHODIMP	Drop(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect) override;
 protected:
 	/*

--- a/sakura_core/agent/CAutoSaveAgent.cpp
+++ b/sakura_core/agent/CAutoSaveAgent.cpp
@@ -88,7 +88,7 @@ void CPassiveTimer::Enable(bool flag)
 	@retval true 所定時間が経過した。このときは測定基準が自動的にリセットされる。
 	@retval false 所定の時間に達していない。
 */
-bool CPassiveTimer::CheckAction(void)
+bool CPassiveTimer::CheckAction()
 {
 	if( !IsEnabled() )	//	有効でなければ何もしない
 		return false;

--- a/sakura_core/agent/CAutoSaveAgent.h
+++ b/sakura_core/agent/CAutoSaveAgent.h
@@ -37,15 +37,15 @@ public:
 
 	//時間間隔
 	void SetInterval(int m);	//!	時間間隔の設定
-	int GetInterval(void) const {return nInterval / MSec2Min; }	//!< 時間間隔の取得
-	void Reset(void){ nLastTick = ::GetTickCount(); }			//!< 基準時刻のリセット
+	int GetInterval() const {return nInterval / MSec2Min; }	//!< 時間間隔の取得
+	void Reset(){ nLastTick = ::GetTickCount(); }			//!< 基準時刻のリセット
 
 	//有効／無効
 	void Enable(bool flag);							//!< 有効／無効の設定
-	bool IsEnabled(void) const { return bEnabled; }	//!< 有効／無効の読み出し
+	bool IsEnabled() const { return bEnabled; }	//!< 有効／無効の読み出し
 
 	//!	規定時間に達したかどうかの判定
-	bool CheckAction(void);
+	bool CheckAction();
 
 private:
 	DWORD	nLastTick;	//!< 最後にチェックしたときの時刻 (GetTickCount()で取得したもの)

--- a/sakura_core/basis/CFileExt.cpp
+++ b/sakura_core/basis/CFileExt.cpp
@@ -54,7 +54,7 @@ const WCHAR *CFileExt::GetExt( int nIndex )
 	return m_vFileExtInfo[nIndex].m_sExt.c_str();
 }
 
-const WCHAR *CFileExt::GetExtFilter( void )
+const WCHAR *CFileExt::GetExtFilter( )
 {
 	CreateExtFilter(m_vstrFilter);
 	return m_vstrFilter.data();

--- a/sakura_core/basis/CFileExt.h
+++ b/sakura_core/basis/CFileExt.h
@@ -31,7 +31,7 @@ public:
 
 	//ダイアログに渡す拡張子フィルタを取得する。(lpstrFilterに直接指定可能)
 	//2回呼び出すと古いバッファが無効になることがあるのに注意
-	const WCHAR *GetExtFilter( void );
+	const WCHAR *GetExtFilter( );
 
 	[[nodiscard]] int GetCount() const { return static_cast<int>(m_vFileExtInfo.size()); }
 

--- a/sakura_core/charset/CESI.cpp
+++ b/sakura_core/charset/CESI.cpp
@@ -152,7 +152,7 @@ void CESI::GetEvaluation( const ECodeType eCodeId, int *pv1, int *pv2 ) const
 	m_pMbInfo に格納される文字コード情報の元々の順番は、m_pMbPriority[] テーブルの添え字に従う。
 	バブルソートは、元あった順序を比較的変更しない。
 */
-void CESI::SortMBCInfo( void )
+void CESI::SortMBCInfo( )
 {
 	MBCODE_INFO *pei_tmp;
 	int i, j;
@@ -668,7 +668,7 @@ void CESI::ScanCode( const char* pS, size_t cchS )
 	@retval CESI_BOMTYPE_UTF16BE   Big-Endian(BE)
 	@retval CESI_BOMTYPE_UNKNOWN   不明
 */
-void CESI::GuessUtf16Bom( void )
+void CESI::GuessUtf16Bom( )
 {
 	int i, j;
 	EBOMType ebom_type;
@@ -696,7 +696,7 @@ void CESI::GuessUtf16Bom( void )
 
 	m_bEucFlag が TRUE のとき EUC, FALSE のとき SJIS
 */
-void CESI::GuessEucOrSjis( void )
+void CESI::GuessEucOrSjis( )
 {
 	if( IsAmbiguousEucAndSjis()
 	 && static_cast<double>(m_nMbcEucZenHirakata) / m_nMbcEucZen >= 0.25 ){ // 0.25 という値は適当です。
@@ -721,7 +721,7 @@ void CESI::GuessEucOrSjis( void )
 
 	m_bCesu8Flag が TRUE のとき CESU-8, FALSE のとき UTF-8
 */
-void CESI::GuessUtf8OrCesu8( void )
+void CESI::GuessUtf8OrCesu8( )
 {
 	if( IsAmbiguousUtf8AndCesu8()
 	 && m_pEncodingConfig->m_bPriorCesu8 ){

--- a/sakura_core/charset/CESI.h
+++ b/sakura_core/charset/CESI.h
@@ -93,7 +93,7 @@ protected:
 	void SetInformation( const char *pS, size_t nLen );
 
 	//! 添え字に使われる優先順位表を作成
-	void InitPriorityTable( void );
+	void InitPriorityTable( );
 
 	//	**** 全般
 	// マルチバイト系とUNICODE系とでそれぞれ情報の格納先が違う。
@@ -114,13 +114,13 @@ public:
 
 	// m_dwStatus のセッター／ゲッター
 	void SetStatus( DWORD inf ){ m_dwStatus |= inf; }
-	DWORD GetStatus( void ) const { return m_dwStatus; }
+	DWORD GetStatus( ) const { return m_dwStatus; }
 
 	// m_nTargetDataLen のセッター／ゲッター
 protected:
 	void SetDataLen(const size_t n) noexcept { if( n < 1 ){ m_nTargetDataLen = 0; }else{ m_nTargetDataLen = static_cast<int>(n); } }
 public:
-	int GetDataLen( void ) const { return m_nTargetDataLen; }
+	int GetDataLen( ) const { return m_nTargetDataLen; }
 
 protected:
 	/*
@@ -154,10 +154,10 @@ public:
 	int m_nMbcEucZen;                        //!< EUC 全角のバイト数
 
 	//! マルチバイト系の捜査結果を、ポイントが大きい順にソート。 ソートした結果は、m_apMbcInfo に格納
-	void SortMBCInfo( void );
+	void SortMBCInfo( );
 
 	//! EUC と SJIS が候補のトップ２に上がっているかどうか
-	bool IsAmbiguousEucAndSjis( void ){
+	bool IsAmbiguousEucAndSjis( ){
 		// EUC と SJIS がトップ2に上がった時
 		// かつ、EUC と SJIS のポイント数が同数のとき
 		if( ((m_apMbcInfo[0]->eCodeID == CODE_SJIS && m_apMbcInfo[1]->eCodeID == CODE_EUC)
@@ -170,7 +170,7 @@ public:
 	}
 
 	//! SJIS と UTF-8 が候補のトップ2に上がっているかどうか
-	bool IsAmbiguousUtf8AndCesu8( void ){
+	bool IsAmbiguousUtf8AndCesu8( ){
 		// UTF-8 と SJIS がトップ2に上がった時
 		// かつ、UTF-8 と SJIS のポイント数が同数のとき
 		if( ((m_apMbcInfo[0]->eCodeID == CODE_UTF8 && m_apMbcInfo[1]->eCodeID == CODE_CESU8)
@@ -183,8 +183,8 @@ public:
 	}
 
 protected:
-	void GuessEucOrSjis( void );	//!< EUC か SJIS かを判定
-	void GuessUtf8OrCesu8( void );	//!< UTF-8 か CESU-8 かを判定
+	void GuessEucOrSjis( );	//!< EUC か SJIS かを判定
+	void GuessUtf8OrCesu8( );	//!< UTF-8 か CESU-8 かを判定
 public:
 	//
 	// 	**** UTF-16 判定関係の変数その他
@@ -193,12 +193,12 @@ public:
 	EBOMType m_eWcBomType;          //!< m_pWcInfo から推測される BOM の種類
 	ECodeType m_eMetaName;          //!< エンコーディング名からの種類判別
 
-	EBOMType GetBOMType(void) const { return m_eWcBomType; }
+	EBOMType GetBOMType() const { return m_eWcBomType; }
 	ECodeType GetMetaName() const { return m_eMetaName; }
 
 protected:
 	//! BOMの種類を推測して m_eWcBomType を設定
-	void GuessUtf16Bom( void );
+	void GuessUtf16Bom( );
 	ECodeType AutoDetectByXML( const char* pBuf, int nSize );
 	ECodeType AutoDetectByHTML( const char* pBuf, int nSize );
 	ECodeType AutoDetectByCoding( const char* pBuf, int nSize );

--- a/sakura_core/cmd/COpe.cpp
+++ b/sakura_core/cmd/COpe.cpp
@@ -32,7 +32,7 @@ COpe::~COpe()
 }
 
 /* 編集操作要素のダンプ */
-void COpe::DUMP( void )
+void COpe::DUMP( )
 {
 	DEBUG_TRACE( L"\t\tm_nOpe                  = [%d]\n", m_nOpe               );
 	DEBUG_TRACE( L"\t\tm_ptCaretPos_PHY_Before = [%d,%d]\n", m_ptCaretPos_PHY_Before.x, m_ptCaretPos_PHY_Before.y   );
@@ -41,7 +41,7 @@ void COpe::DUMP( void )
 }
 
 /* 編集操作要素のダンプ */
-void CDeleteOpe::DUMP( void )
+void CDeleteOpe::DUMP( )
 {
 	COpe::DUMP();
 	DEBUG_TRACE( L"\t\tm_ptCaretPos_PHY_To     = [%d,%d]\n", m_ptCaretPos_PHY_To.x, m_ptCaretPos_PHY_To.y );
@@ -54,7 +54,7 @@ void CDeleteOpe::DUMP( void )
 }
 
 /* 編集操作要素のダンプ */
-void CInsertOpe::DUMP( void )
+void CInsertOpe::DUMP( )
 {
 	COpe::DUMP();
 	DEBUG_TRACE( L"\t\tm_cOpeLineData.size         = [%d]\n", m_cOpeLineData.size() );

--- a/sakura_core/cmd/COpe.h
+++ b/sakura_core/cmd/COpe.h
@@ -49,7 +49,7 @@ public:
 	COpe(EOpeCode eCode);		/* COpeクラス構築 */
 	virtual ~COpe();	/* COpeクラス消滅 */
 
-	virtual void DUMP( void );	/* 編集操作要素のダンプ */
+	virtual void DUMP( );	/* 編集操作要素のダンプ */
 
 	EOpeCode	GetCode() const{ return m_nOpe; }
 
@@ -68,7 +68,7 @@ public:
 	{
 		m_ptCaretPos_PHY_To.Set(CLogicInt(0),CLogicInt(0));
 	}
-	void DUMP( void ) override;	/* 編集操作要素のダンプ */
+	void DUMP( ) override;	/* 編集操作要素のダンプ */
 public:
 	CLogicPoint	m_ptCaretPos_PHY_To;		//!< 操作前のキャレット位置。文字単位。	[DELETE]
 	COpeLineData	m_cOpeLineData;			//!< 操作に関連するデータ				[DELETE/INSERT]
@@ -79,7 +79,7 @@ public:
 class CInsertOpe final : public COpe{
 public:
 	CInsertOpe() : COpe(OPE_INSERT) { }
-	void DUMP( void ) override;	/* 編集操作要素のダンプ */
+	void DUMP( ) override;	/* 編集操作要素のダンプ */
 public:
 	COpeLineData	m_cOpeLineData;			//!< 操作に関連するデータ				[DELETE/INSERT]
 	int				m_nOrgSeq;

--- a/sakura_core/cmd/COpeBlk.cpp
+++ b/sakura_core/cmd/COpeBlk.cpp
@@ -73,7 +73,7 @@ COpe* COpeBlk::GetOpe( int nIndex )
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /* 編集操作要素ブロックのダンプ */
-void COpeBlk::DUMP( void )
+void COpeBlk::DUMP( )
 {
 #ifdef _DEBUG
 	int i;

--- a/sakura_core/cmd/COpeBuf.h
+++ b/sakura_core/cmd/COpeBuf.h
@@ -44,7 +44,7 @@ public:
 	//状態
 	bool IsEnableUndo() const;					//!< Undo可能な状態か
 	bool IsEnableRedo() const;					//!< Redo可能な状態か
-	int GetCurrentPointer( void ) const { return m_nCurrentPointer; }	/* 現在位置を返す */	// 2007.12.09 ryoji
+	int GetCurrentPointer( ) const { return m_nCurrentPointer; }	/* 現在位置を返す */	// 2007.12.09 ryoji
 	int GetNextSeq() const { return m_nCurrentPointer + 1; }
 	int GetNoModifiedSeq() const { return m_nNoModifiedIndex; }
 

--- a/sakura_core/cmd/CViewCommander.h
+++ b/sakura_core/cmd/CViewCommander.h
@@ -65,8 +65,8 @@ public:
 	);
 
 	/* ファイル操作系 */
-	void Command_FILENEW( void );				/* 新規作成 */
-	void Command_FILENEW_NEWWINDOW( void );		/* 新規作成（タブで開く版） */
+	void Command_FILENEW( );				/* 新規作成 */
+	void Command_FILENEW_NEWWINDOW( );		/* 新規作成（タブで開く版） */
 	/* ファイルを開く */
 	// Oct. 2, 2001 genta マクロ用に機能拡張
 	// Mar. 30, 2003 genta 引数追加
@@ -81,8 +81,8 @@ public:
 	bool Command_FILESAVE( bool warnbeep = true, bool askname = true );
 	bool Command_FILESAVEAS_DIALOG(const WCHAR*, ECodeType, EEolType);		/* 名前を付けて保存 */
 	BOOL Command_FILESAVEAS( const WCHAR* filename, EEolType eEolType);	/* 名前を付けて保存 */
-	BOOL Command_FILESAVEALL( void );					/* 全て上書き保存 */ // Jan. 23, 2005 genta
-	void Command_FILECLOSE( void );						/* 開じて(無題) */	//Oct. 17, 2000 jepro 「ファイルを閉じる」というキャプションを変更
+	BOOL Command_FILESAVEALL( );					/* 全て上書き保存 */ // Jan. 23, 2005 genta
+	void Command_FILECLOSE( );						/* 開じて(無題) */	//Oct. 17, 2000 jepro 「ファイルを閉じる」というキャプションを変更
 	/* 閉じて開く*/
 	// Mar. 30, 2003 genta 引数追加
 	void Command_FILECLOSE_OPEN( LPCWSTR filename = nullptr,
@@ -90,44 +90,44 @@ public:
 
 	void Command_FILE_REOPEN( ECodeType nCharCode, bool bNoConfirm );		/* 再オープン */	//Dec. 4, 2002 genta 引数追加
 
-	void Command_PRINT( void );					/* 印刷*/
-	void Command_PRINT_PREVIEW( void );			/* 印刷プレビュー*/
-	void Command_PRINT_PAGESETUP( void );		/* 印刷ページ設定 */	//Sept. 14, 2000 jepro 「印刷のページレイアウトの設定」から変更
+	void Command_PRINT( );					/* 印刷*/
+	void Command_PRINT_PREVIEW( );			/* 印刷プレビュー*/
+	void Command_PRINT_PAGESETUP( );		/* 印刷ページ設定 */	//Sept. 14, 2000 jepro 「印刷のページレイアウトの設定」から変更
 	BOOL Command_OPEN_HfromtoC(BOOL bCheckOnly);			/* 同名のC/C++ヘッダー(ソース)を開く */	//Feb. 7, 2001 JEPRO 追加
 	BOOL Command_OPEN_HHPP( BOOL bCheckOnly, BOOL bBeepWhenMiss );				/* 同名のC/C++ヘッダーファイルを開く */	//Feb. 9, 2001 jepro「.cまたは.cppと同名の.hを開く」から変更
 	BOOL Command_OPEN_CCPP( BOOL bCheckOnly, BOOL bBeepWhenMiss );				/* 同名のC/C++ソースファイルを開く */	//Feb. 9, 2001 jepro「.hと同名の.c(なければ.cpp)を開く」から変更
-	void Command_ACTIVATE_SQLPLUS( void );		/* Oracle SQL*Plusをアクティブ表示 */
-	void Command_PLSQL_COMPILE_ON_SQLPLUS( void );/* Oracle SQL*Plusで実行 */
-	void Command_BROWSE( void );				/* ブラウズ */
-	void Command_VIEWMODE( void );				/* ビューモード */
-	void Command_PROPERTY_FILE( void );			/* ファイルのプロパティ */
-	void Command_OPEN_FOLDER_IN_EXPLORER( void );	/* ファイルの場所を開く */
+	void Command_ACTIVATE_SQLPLUS( );		/* Oracle SQL*Plusをアクティブ表示 */
+	void Command_PLSQL_COMPILE_ON_SQLPLUS( );/* Oracle SQL*Plusで実行 */
+	void Command_BROWSE( );				/* ブラウズ */
+	void Command_VIEWMODE( );				/* ビューモード */
+	void Command_PROPERTY_FILE( );			/* ファイルのプロパティ */
+	void Command_OPEN_FOLDER_IN_EXPLORER( );	/* ファイルの場所を開く */
 	void Command_OPEN_COMMAND_PROMPT( BOOL isAdmin );	/* コマンドプロンプトを開く */
 	void Command_OPEN_POWERSHELL( BOOL isAdmin );	/* PowerShellを開く */
-	void Command_PROFILEMGR( void );			// プロファイルマネージャ
-	void Command_EXITALLEDITORS( void );		/* 編集の全終了 */	// 2007.02.13 ryoji 追加
-	void Command_EXITALL( void );				/* サクラエディタの全終了 */	//Dec. 27, 2000 JEPRO 追加
+	void Command_PROFILEMGR( );			// プロファイルマネージャ
+	void Command_EXITALLEDITORS( );		/* 編集の全終了 */	// 2007.02.13 ryoji 追加
+	void Command_EXITALL( );				/* サクラエディタの全終了 */	//Dec. 27, 2000 JEPRO 追加
 	BOOL Command_PUTFILE(LPCWSTR filename, ECodeType nCharCode, int nFlgOpt);	/* 作業中ファイルの一時出力 maru 2006.12.10 */
 	BOOL Command_INSFILE(LPCWSTR filename, ECodeType nCharCode, int nFlgOpt);	/* キャレット位置にファイル挿入 maru 2006.12.10 */
 
 	/* 編集系 */
 	void Command_WCHAR(wchar_t wcChar, bool bConvertEOL = true );			/* 文字入力 */ //2007.09.02 kobake Command_CHAR(char)→Command_WCHAR(wchar_t)に変更
 	void Command_IME_CHAR(WORD wChar);			/* 全角文字入力 */
-	void Command_UNDO( void );				/* 元に戻す(Undo) */
-	void Command_REDO( void );				/* やり直し(Redo) */
-	void Command_DELETE( void );			/* カーソル位置または選択エリアを削除 */
-	void Command_DELETE_BACK( void );		/* カーソル前を削除 */
-	void Command_WordDeleteToStart( void );	/* 単語の左端まで削除 */
-	void Command_WordDeleteToEnd( void );	/* 単語の右端まで削除 */
-	void Command_WordCut( void );			/* 単語切り取り */
-	void Command_WordDelete( void );		/* 単語削除 */
-	void Command_LineCutToStart( void );	//行頭まで切り取り(改行単位)
-	void Command_LineCutToEnd( void );		//行末まで切り取り(改行単位)
-	void Command_LineDeleteToStart( void );	/* 行頭まで削除(改行単位) */
-	void Command_LineDeleteToEnd( void );  	//行末まで削除(改行単位)
-	void Command_CUT_LINE( void );			/* 行切り取り(折り返し単位) */
-	void Command_DELETE_LINE( void );		/* 行削除(折り返し単位) */
-	void Command_DUPLICATELINE( void );		/* 行の二重化(折り返し単位) */
+	void Command_UNDO( );				/* 元に戻す(Undo) */
+	void Command_REDO( );				/* やり直し(Redo) */
+	void Command_DELETE( );			/* カーソル位置または選択エリアを削除 */
+	void Command_DELETE_BACK( );		/* カーソル前を削除 */
+	void Command_WordDeleteToStart( );	/* 単語の左端まで削除 */
+	void Command_WordDeleteToEnd( );	/* 単語の右端まで削除 */
+	void Command_WordCut( );			/* 単語切り取り */
+	void Command_WordDelete( );		/* 単語削除 */
+	void Command_LineCutToStart( );	//行頭まで切り取り(改行単位)
+	void Command_LineCutToEnd( );		//行末まで切り取り(改行単位)
+	void Command_LineDeleteToStart( );	/* 行頭まで削除(改行単位) */
+	void Command_LineDeleteToEnd( );  	//行末まで削除(改行単位)
+	void Command_CUT_LINE( );			/* 行切り取り(折り返し単位) */
+	void Command_DELETE_LINE( );		/* 行削除(折り返し単位) */
+	void Command_DUPLICATELINE( );		/* 行の二重化(折り返し単位) */
 	void Command_INDENT( wchar_t cChar, EIndentType = INDENT_NONE ); /* インデント ver 1 */
 // From Here 2001.12.03 hor
 //	void Command_INDENT( const char*, int );/* インデント ver0 */
@@ -137,8 +137,8 @@ public:
 //	void Command_WORDSREFERENCE( void );	/* 単語リファレンス */
 	void Command_TRIM(BOOL bLeft);				// 2001.12.03 hor
 	void Command_SORT(BOOL bAsc);				// 2001.12.06 hor
-	void Command_MERGE(void);				// 2001.12.06 hor
-	void Command_Reconvert(void);			/* メニューからの再変換対応 minfu 2002.04.09 */
+	void Command_MERGE();				// 2001.12.06 hor
+	void Command_Reconvert();			/* メニューからの再変換対応 minfu 2002.04.09 */
 
 	/* カーソル移動系 */
 	//	Oct. 24, 2001 genta 機能拡張のため引数追加
@@ -163,14 +163,14 @@ public:
 	void Command_1PageDown( bool bSelect, CLayoutYInt );			//１ページダウン	//Oct. 10, 2000 JEPRO 従来のページダウンを半ページダウンと名称変更し１ページダウンを追加
 	void Command_GOFILETOP( bool bSelect );			/* ファイルの先頭に移動 */
 	void Command_GOFILEEND( bool bSelect );			/* ファイルの最後に移動 */
-	void Command_CURLINECENTER( void );		/* カーソル行をウィンドウ中央へ */
-	void Command_CURLINETOP( void );		/* カーソル行をウィンドウ上部へ */
-	void Command_CURLINEBOTTOM( void );		/* カーソル行をウィンドウ下部へ */
-	void Command_JUMPHIST_PREV(void);		// 移動履歴: 前へ
-	void Command_JUMPHIST_NEXT(void);		// 移動履歴: 次へ
-	void Command_JUMPHIST_SET(void);		// 現在位置を移動履歴に登録
-	void Command_WndScrollDown(void);		// テキストを１行下へスクロール	// 2001/06/20 asa-o
-	void Command_WndScrollUp(void);			// テキストを１行上へスクロール	// 2001/06/20 asa-o
+	void Command_CURLINECENTER( );		/* カーソル行をウィンドウ中央へ */
+	void Command_CURLINETOP( );		/* カーソル行をウィンドウ上部へ */
+	void Command_CURLINEBOTTOM( );		/* カーソル行をウィンドウ下部へ */
+	void Command_JUMPHIST_PREV();		// 移動履歴: 前へ
+	void Command_JUMPHIST_NEXT();		// 移動履歴: 次へ
+	void Command_JUMPHIST_SET();		// 現在位置を移動履歴に登録
+	void Command_WndScrollDown();		// テキストを１行下へスクロール	// 2001/06/20 asa-o
+	void Command_WndScrollUp();			// テキストを１行上へスクロール	// 2001/06/20 asa-o
 	void Command_GONEXTPARAGRAPH( bool bSelect );	// 次の段落へ進む
 	void Command_GOPREVPARAGRAPH( bool bSelect );	// 前の段落へ戻る
 	void Command_AUTOSCROLL();		// オートスクロール
@@ -187,9 +187,9 @@ public:
 
 	/* 選択系 */
 	bool Command_SELECTWORD( CLayoutPoint* pptCaretPos = nullptr );		/* 現在位置の単語選択 */
-	void Command_SELECTALL( void );			/* すべて選択 */
+	void Command_SELECTALL( );			/* すべて選択 */
 	void Command_SELECTLINE(LPARAM lparam1);	/* 1行選択 */	// 2007.10.13 nasukoji
-	void Command_BEGIN_SELECT( void );		/* 範囲選択開始 */
+	void Command_BEGIN_SELECT( );		/* 範囲選択開始 */
 
 	/* 矩形選択系 */
 //	void Command_BOXSELECTALL( void );		/* 矩形ですべて選択 */
@@ -197,7 +197,7 @@ public:
 //	int Command_UP_BOX( BOOL );				/* (矩形選択)カーソル上移動 */
 
 	/* クリップボード系 */
-	void Command_CUT( void );						/* 切り取り（選択範囲をクリップボードにコピーして削除）*/
+	void Command_CUT( );						/* 切り取り（選択範囲をクリップボードにコピーして削除）*/
 	void Command_COPY( bool bIgnoreLockAndDisable, bool bAddCRLFWhenCopy, EEolType neweol = EEolType::none );/* コピー(選択範囲をクリップボードにコピー) */
 	void Command_PASTE( int option );						/* 貼り付け（クリップボードから貼り付け）*/
 	void Command_PASTEBOX( LPARAM option );					/* 矩形貼り付け（クリップボードから矩形貼り付け）*/
@@ -209,127 +209,127 @@ public:
 	void Command_INSTEXT( bool bRedraw, const wchar_t* pszText, ptrdiff_t nTextLen, bool bNoWaitCursor,
 		bool bLinePaste = false, bool bFastMode = false, const CLogicRange*	psDelRangeLogicFast = nullptr ); // 2004.05.14 Moca テキストを貼り付け '\0'対応
 	void Command_ADDTAIL( const wchar_t* pszData, int nDataLen);	/* 最後にテキストを追加 */
-	void Command_COPYFILENAME( void );				/* このファイル名をクリップボードにコピー */ //2002/2/3 aroka
-	void Command_COPYPATH( void );					/* このファイルのパス名をクリップボードにコピー */
-	void Command_COPYDIRPATH( void );				/* このファイルのフォルダー名をクリップボードにコピー */
-	void Command_COPYTAG( void );					/* このファイルのパス名とカーソル位置をコピー */
-	void Command_COPYLINES( void );					/* 選択範囲内全行コピー */
-	void Command_COPYLINESASPASSAGE( void );		/* 選択範囲内全行引用符付きコピー */
-	void Command_COPYLINESWITHLINENUMBER( void );	/* 選択範囲内全行行番号付きコピー */
+	void Command_COPYFILENAME( );				/* このファイル名をクリップボードにコピー */ //2002/2/3 aroka
+	void Command_COPYPATH( );					/* このファイルのパス名をクリップボードにコピー */
+	void Command_COPYDIRPATH( );				/* このファイルのフォルダー名をクリップボードにコピー */
+	void Command_COPYTAG( );					/* このファイルのパス名とカーソル位置をコピー */
+	void Command_COPYLINES( );					/* 選択範囲内全行コピー */
+	void Command_COPYLINESASPASSAGE( );		/* 選択範囲内全行引用符付きコピー */
+	void Command_COPYLINESWITHLINENUMBER( );	/* 選択範囲内全行行番号付きコピー */
 	void Command_COPY_COLOR_HTML(bool bLineNumber = false);	//選択範囲内全行行番号付きコピー
-	void Command_COPY_COLOR_HTML_LINENUMBER( void );		//選択範囲内色付きHTMLコピー
+	void Command_COPY_COLOR_HTML_LINENUMBER( );		//選択範囲内色付きHTMLコピー
 	CColorStrategy* GetColorStrategyHTML(const CStringRef&	cStringLine, int iLogic, const CColorStrategyPool*	pool, CColorStrategy**	ppStrategy, CColorStrategy** pStrategyFound, bool& bChange);
-	void Command_CREATEKEYBINDLIST( void );			// キー割り当て一覧をコピー //Sept. 15, 2000 JEPRO	Command_の作り方がわからないので殺してある
+	void Command_CREATEKEYBINDLIST( );			// キー割り当て一覧をコピー //Sept. 15, 2000 JEPRO	Command_の作り方がわからないので殺してある
 
 	/* 挿入系 */
-	void Command_INS_DATE( void );	//日付挿入
-	void Command_INS_TIME( void );	//時刻挿入
-	void Command_CtrlCode_Dialog(void);		/* コントロールコードの入力(ダイアログ) */	//@@@ 2002.06.02 MIK
-	void Command_INS_FILE_USED_RECENTLY( void );	//最近使ったファイル挿入
-	void Command_INS_FOLDER_USED_RECENTLY( void );	//最近使ったフォルダー挿入
+	void Command_INS_DATE( );	//日付挿入
+	void Command_INS_TIME( );	//時刻挿入
+	void Command_CtrlCode_Dialog();		/* コントロールコードの入力(ダイアログ) */	//@@@ 2002.06.02 MIK
+	void Command_INS_FILE_USED_RECENTLY( );	//最近使ったファイル挿入
+	void Command_INS_FOLDER_USED_RECENTLY( );	//最近使ったフォルダー挿入
 
 	/* 変換系 */
-	void Command_TOLOWER( void );				/* 小文字 */
-	void Command_TOUPPER( void );				/* 大文字 */
-	void Command_TOZENKAKUKATA( void );			/* 半角＋全ひら→全角・カタカナ */	//Sept. 17, 2000 jepro 説明を「半角→全角カタカナ」から変更
-	void Command_TOZENKAKUHIRA( void );			/* 半角＋全カタ→全角・ひらがな */	//Sept. 17, 2000 jepro 説明を「半角→全角ひらがな」から変更
-	void Command_TOHANKAKU( void );				/* 全角→半角 */
-	void Command_TOHANKATA( void );				/* 全角カタカナ→半角カタカナ */	//Aug. 29, 2002 ai
-	void Command_TOZENEI( void );				/* 半角英数→全角英数 */ //July. 30, 2001 Misaka
-	void Command_TOHANEI( void );				/* 全角英数→半角英数 */ //@@@ 2002.2.11 YAZAKI
-	void Command_HANKATATOZENKAKUKATA( void );	/* 半角カタカナ→全角カタカナ */
-	void Command_HANKATATOZENKAKUHIRA( void );	/* 半角カタカナ→全角ひらがな */
-	void Command_TABTOSPACE( void );			/* TAB→空白 */
-	void Command_SPACETOTAB( void );			/* 空白→TAB */  //---- Stonee, 2001/05/27
-	void Command_CODECNV_AUTO2SJIS( void );		/* 自動判別→SJISコード変換 */
-	void Command_CODECNV_EMAIL( void );			/* E-Mail(JIS→SJIS)コード変換 */
-	void Command_CODECNV_EUC2SJIS( void );		/* EUC→SJISコード変換 */
-	void Command_CODECNV_UNICODE2SJIS( void );	/* Unicode→SJISコード変換 */
-	void Command_CODECNV_UNICODEBE2SJIS( void );	/* UnicodeBE→SJISコード変換 */
-	void Command_CODECNV_UTF82SJIS( void );		/* UTF-8→SJISコード変換 */
-	void Command_CODECNV_UTF72SJIS( void );		/* UTF-7→SJISコード変換 */
-	void Command_CODECNV_SJIS2JIS( void );		/* SJIS→JISコード変換 */
-	void Command_CODECNV_SJIS2EUC( void );		/* SJIS→EUCコード変換 */
-	void Command_CODECNV_SJIS2UTF8( void );		/* SJIS→UTF-8コード変換 */
-	void Command_CODECNV_SJIS2UTF7( void );		/* SJIS→UTF-7コード変換 */
-	void Command_BASE64DECODE( void );			/* Base64デコードして保存 */
-	void Command_UUDECODE( void );				/* uudecodeして保存 */	//Oct. 17, 2000 jepro 説明を「選択部分をUUENCODEデコード」から変更
+	void Command_TOLOWER( );				/* 小文字 */
+	void Command_TOUPPER( );				/* 大文字 */
+	void Command_TOZENKAKUKATA( );			/* 半角＋全ひら→全角・カタカナ */	//Sept. 17, 2000 jepro 説明を「半角→全角カタカナ」から変更
+	void Command_TOZENKAKUHIRA( );			/* 半角＋全カタ→全角・ひらがな */	//Sept. 17, 2000 jepro 説明を「半角→全角ひらがな」から変更
+	void Command_TOHANKAKU( );				/* 全角→半角 */
+	void Command_TOHANKATA( );				/* 全角カタカナ→半角カタカナ */	//Aug. 29, 2002 ai
+	void Command_TOZENEI( );				/* 半角英数→全角英数 */ //July. 30, 2001 Misaka
+	void Command_TOHANEI( );				/* 全角英数→半角英数 */ //@@@ 2002.2.11 YAZAKI
+	void Command_HANKATATOZENKAKUKATA( );	/* 半角カタカナ→全角カタカナ */
+	void Command_HANKATATOZENKAKUHIRA( );	/* 半角カタカナ→全角ひらがな */
+	void Command_TABTOSPACE( );			/* TAB→空白 */
+	void Command_SPACETOTAB( );			/* 空白→TAB */  //---- Stonee, 2001/05/27
+	void Command_CODECNV_AUTO2SJIS( );		/* 自動判別→SJISコード変換 */
+	void Command_CODECNV_EMAIL( );			/* E-Mail(JIS→SJIS)コード変換 */
+	void Command_CODECNV_EUC2SJIS( );		/* EUC→SJISコード変換 */
+	void Command_CODECNV_UNICODE2SJIS( );	/* Unicode→SJISコード変換 */
+	void Command_CODECNV_UNICODEBE2SJIS( );	/* UnicodeBE→SJISコード変換 */
+	void Command_CODECNV_UTF82SJIS( );		/* UTF-8→SJISコード変換 */
+	void Command_CODECNV_UTF72SJIS( );		/* UTF-7→SJISコード変換 */
+	void Command_CODECNV_SJIS2JIS( );		/* SJIS→JISコード変換 */
+	void Command_CODECNV_SJIS2EUC( );		/* SJIS→EUCコード変換 */
+	void Command_CODECNV_SJIS2UTF8( );		/* SJIS→UTF-8コード変換 */
+	void Command_CODECNV_SJIS2UTF7( );		/* SJIS→UTF-7コード変換 */
+	void Command_BASE64DECODE( );			/* Base64デコードして保存 */
+	void Command_UUDECODE( );				/* uudecodeして保存 */	//Oct. 17, 2000 jepro 説明を「選択部分をUUENCODEデコード」から変更
 
 	/* 検索系 */
-	void Command_SEARCH_BOX( void );					/* 検索(ボックス) */	// 2006.06.04 yukihane
-	void Command_SEARCH_DIALOG( void );					/* 検索(単語検索ダイアログ) */
+	void Command_SEARCH_BOX( );					/* 検索(ボックス) */	// 2006.06.04 yukihane
+	void Command_SEARCH_DIALOG( );					/* 検索(単語検索ダイアログ) */
 	void Command_SEARCH_NEXT(bool bChangeCurRegexp, bool bRedraw, bool bReplaceAll, HWND hwndParent, const WCHAR* pszNotFoundMessage, CLogicRange*	pcSelectLogic = nullptr); /* 次を検索 */
 	void Command_SEARCH_PREV(bool bReDraw, HWND hwndParent);		/* 前を検索 */
-	void Command_REPLACE_DIALOG( void );				/* 置換(置換ダイアログ) */
+	void Command_REPLACE_DIALOG( );				/* 置換(置換ダイアログ) */
 	void Command_REPLACE( HWND hwndParent );			/* 置換(実行) 2002/04/08 YAZAKI 親ウィンドウを指定するように変更 */
 	void Command_REPLACE_ALL();							/* すべて置換(実行) */
-	void Command_SEARCH_CLEARMARK( void );				/* 検索マークのクリア */
-	void Command_JUMP_SRCHSTARTPOS( void );				/* 検索開始位置へ戻る */	// 02/06/26 ai
+	void Command_SEARCH_CLEARMARK( );				/* 検索マークのクリア */
+	void Command_JUMP_SRCHSTARTPOS( );				/* 検索開始位置へ戻る */	// 02/06/26 ai
 
-	void Command_GREP_DIALOG( void );					/* Grepダイアログの表示 */
-	void Command_GREP( void );							/* Grep */
-	void Command_GREP_REPLACE_DLG( void );				/* Grep置換ダイアログの表示 */
-	void Command_GREP_REPLACE( void );					/* Grep置換 */
-	void Command_JUMP_DIALOG( void );					/* 指定行ヘジャンプダイアログの表示 */
-	void Command_JUMP( void );							/* 指定行ヘジャンプ */
+	void Command_GREP_DIALOG( );					/* Grepダイアログの表示 */
+	void Command_GREP( );							/* Grep */
+	void Command_GREP_REPLACE_DLG( );				/* Grep置換ダイアログの表示 */
+	void Command_GREP_REPLACE( );					/* Grep置換 */
+	void Command_JUMP_DIALOG( );					/* 指定行ヘジャンプダイアログの表示 */
+	void Command_JUMP( );							/* 指定行ヘジャンプ */
 // From Here 2001.12.03 hor
 	BOOL Command_FUNCLIST( int nAction, EOutlineType nOutlineType );	/* アウトライン解析 */ // 20060201 aroka
 // To Here 2001.12.03 hor
 	// Apr. 03, 2003 genta 引数追加
 	bool Command_TAGJUMP( bool bClose = false );		/* タグジャンプ機能 */
 	bool Command_TagJumpNoMessage( bool bClose );		// タグジャンプ機能(メッセージ通知なし)
-	void Command_TAGJUMPBACK( void );					/* タグジャンプバック機能 */
+	void Command_TAGJUMPBACK( );					/* タグジャンプバック機能 */
 	bool Command_TagJumpByTagsFileMsg(bool bMsg);				//ダイレクトタグジャンプ(通知つき)
 	bool Command_TagJumpByTagsFile(bool bClose);				//ダイレクトタグジャンプ	//@@@ 2003.04.13 MIK
 
-	bool Command_TagsMake( void );						//タグファイルの作成	//@@@ 2003.04.13 MIK
+	bool Command_TagsMake( );						//タグファイルの作成	//@@@ 2003.04.13 MIK
 	bool Command_TagJumpByTagsFileKeyword( const wchar_t* keyword );	//	@@ 2005.03.31 MIK
-	void Command_COMPARE( void );						/* ファイル内容比較 */
-	void Command_Diff_Dialog( void );					/* DIFF差分表示ダイアログ */	//@@@ 2002.05.25 MIK
+	void Command_COMPARE( );						/* ファイル内容比較 */
+	void Command_Diff_Dialog( );					/* DIFF差分表示ダイアログ */	//@@@ 2002.05.25 MIK
 	void Command_Diff( const WCHAR* szTmpFile2, int nFlgOpt );	/* DIFF差分表示 */	//@@@ 2002.05.25 MIK	// 2005.10.03 maru
-	void Command_Diff_Next( void );						/* 次の差分へ */	//@@@ 2002.05.25 MIK
-	void Command_Diff_Prev( void );						/* 前の差分へ */	//@@@ 2002.05.25 MIK
-	void Command_Diff_Reset( void );					/* 差分の全解除 */	//@@@ 2002.05.25 MIK
-	void Command_BRACKETPAIR( void );					/* 対括弧の検索 */
+	void Command_Diff_Next( );						/* 次の差分へ */	//@@@ 2002.05.25 MIK
+	void Command_Diff_Prev( );						/* 前の差分へ */	//@@@ 2002.05.25 MIK
+	void Command_Diff_Reset( );					/* 差分の全解除 */	//@@@ 2002.05.25 MIK
+	void Command_BRACKETPAIR( );					/* 対括弧の検索 */
 // From Here 2001.12.03 hor
-	void Command_BOOKMARK_SET( void );					/* ブックマーク設定・解除 */
-	void Command_BOOKMARK_NEXT( void );					/* 次のブックマークへ */
-	void Command_BOOKMARK_PREV( void );					/* 前のブックマークへ */
-	void Command_BOOKMARK_RESET( void );				/* ブックマークの全解除 */
+	void Command_BOOKMARK_SET( );					/* ブックマーク設定・解除 */
+	void Command_BOOKMARK_NEXT( );					/* 次のブックマークへ */
+	void Command_BOOKMARK_PREV( );					/* 前のブックマークへ */
+	void Command_BOOKMARK_RESET( );				/* ブックマークの全解除 */
 // To Here 2001.12.03 hor
-	void Command_BOOKMARK_PATTERN( void );				// 2002.01.16 hor 指定パターンに一致する行をマーク
-	void Command_FUNCLIST_NEXT( void );					// 次の関数リストマーク	2014.01.05
-	void Command_FUNCLIST_PREV( void );					// 前の関数リストマーク	2014.01.05
+	void Command_BOOKMARK_PATTERN( );				// 2002.01.16 hor 指定パターンに一致する行をマーク
+	void Command_FUNCLIST_NEXT( );					// 次の関数リストマーク	2014.01.05
+	void Command_FUNCLIST_PREV( );					// 前の関数リストマーク	2014.01.05
 
 	/* モード切り替え系 */
-	void Command_CHGMOD_INS( void );	/* 挿入／上書きモード切り替え */
+	void Command_CHGMOD_INS( );	/* 挿入／上書きモード切り替え */
 	void Command_CHG_CHARSET(ECodeType	eCharSet, bool bBom); /* 文字コードセット指定 */	// 2010/6/15 Uchi
 	void Command_CHGMOD_EOL(EEolType e);	/* 入力する改行コードを設定 2003.06.23 moca */
 	void Command_CANCEL_MODE( int whereCursorIs = 0 );	/* 各種モードの取り消し */
 
 	/* 設定系 */
-	void Command_SHOWTOOLBAR( void );		/* ツールバーの表示/非表示 */
-	void Command_SHOWFUNCKEY( void );		/* ファンクションキーの表示/非表示 */
-	void Command_SHOWTAB( void );			/* タブの表示/非表示 */	//@@@ 2003.06.10 MIK
-	void Command_SHOWSTATUSBAR( void );		/* ステータスバーの表示/非表示 */
-	void Command_SHOWMINIMAP( void );		// ミニマップの表示/非表示
-	void Command_TYPE_LIST( void );			/* タイプ別設定一覧 */
+	void Command_SHOWTOOLBAR( );		/* ツールバーの表示/非表示 */
+	void Command_SHOWFUNCKEY( );		/* ファンクションキーの表示/非表示 */
+	void Command_SHOWTAB( );			/* タブの表示/非表示 */	//@@@ 2003.06.10 MIK
+	void Command_SHOWSTATUSBAR( );		/* ステータスバーの表示/非表示 */
+	void Command_SHOWMINIMAP( );		// ミニマップの表示/非表示
+	void Command_TYPE_LIST( );			/* タイプ別設定一覧 */
 	void Command_CHANGETYPE( int nTypePlusOne );	// タイプ別設定一時適用
-	void Command_OPTION_TYPE( void );		/* タイプ別設定 */
-	void Command_OPTION( void );			/* 共通設定 */
-	void Command_FONT( void );				/* フォント設定 */
+	void Command_OPTION_TYPE( );		/* タイプ別設定 */
+	void Command_OPTION( );			/* 共通設定 */
+	void Command_FONT( );				/* フォント設定 */
 	void Command_SETFONTSIZE(int fontSize, int shift, int mode);	/* フォントサイズ設定 */
-	void Command_WRAPWINDOWWIDTH( void );	/* 現在のウィンドウ幅で折り返し */	//Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH を WRAPWINDOWWIDTH に変更
-	void Command_Favorite( void );			//履歴の管理	//@@@ 2003.04.08 MIK
+	void Command_WRAPWINDOWWIDTH( );	/* 現在のウィンドウ幅で折り返し */	//Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH を WRAPWINDOWWIDTH に変更
+	void Command_Favorite( );			//履歴の管理	//@@@ 2003.04.08 MIK
 	void Command_SET_QUOTESTRING(const wchar_t* quotestr);	//	Jan. 29, 2005 genta 引用符の設定
 	void Command_TEXTWRAPMETHOD(int nWrapMethod);				/* テキストの折り返し方法を変更する */		// 2008.05.30 nasukoji
 	void Command_SELECT_COUNT_MODE( int nMode );	/* 文字カウント方法 */	//2009.07.06 syat
 
 	/* マクロ系 */
-	void Command_RECKEYMACRO( void );	/* キーマクロの記録開始／終了 */
-	void Command_SAVEKEYMACRO( void );	/* キーマクロの保存 */
-	void Command_LOADKEYMACRO( void );	/* キーマクロの読み込み */
-	void Command_EXECKEYMACRO( void );	/* キーマクロの実行 */
+	void Command_RECKEYMACRO( );	/* キーマクロの記録開始／終了 */
+	void Command_SAVEKEYMACRO( );	/* キーマクロの保存 */
+	void Command_LOADKEYMACRO( );	/* キーマクロの読み込み */
+	void Command_EXECKEYMACRO( );	/* キーマクロの実行 */
 	void Command_EXECEXTMACRO( const WCHAR* path, const WCHAR* type );	/* 名前を指定してマクロ実行 */
 //	From Here 2006.12.03 maru 引数の拡張．
 //	From Here Sept. 20, 2000 JEPRO 名称CMMANDをCOMMANDに変更
@@ -337,57 +337,57 @@ public:
 	//	Oct. 9, 2001 genta マクロ対応のため機能拡張
 //	void Command_EXECCOMMAND_DIALOG( const WCHAR* cmd );	/* 外部コマンド実行ダイアログ表示 */
 //	void Command_EXECCOMMAND( const WCHAR* cmd );	/* 外部コマンド実行 */
-	void Command_EXECCOMMAND_DIALOG( void );	/* 外部コマンド実行ダイアログ表示 */	//	引数使ってないみたいなので
+	void Command_EXECCOMMAND_DIALOG( );	/* 外部コマンド実行ダイアログ表示 */	//	引数使ってないみたいなので
 	//	マクロからの呼び出しではオプションを保存させないため、Command_EXECCOMMAND_DIALOG内で処理しておく．
 	void Command_EXECCOMMAND(LPCWSTR cmd_string, const int nFlgOpt, LPCWSTR pszCurDir);	/* 外部コマンド実行 */
 //	To Here Sept. 20, 2000
 //	To Here 2006.12.03 maru 引数の拡張
 
 	/* カスタムメニュー */
-	void Command_MENU_RBUTTON( void );	/* 右クリックメニュー */
+	void Command_MENU_RBUTTON( );	/* 右クリックメニュー */
 	int Command_CUSTMENU(int nMenuIdx);		/* カスタムメニュー表示 */
 
 	/* ウィンドウ系 */
-	void Command_SPLIT_V( void );		/* 上下に分割 */	//Sept. 17, 2000 jepro 説明の「縦」を「上下に」に変更
-	void Command_SPLIT_H( void );		/* 左右に分割 */	//Sept. 17, 2000 jepro 説明の「横」を「左右に」に変更
-	void Command_SPLIT_VH( void );		/* 縦横に分割 */	//Sept. 17, 2000 jepro 説明に「に」を追加
-	void Command_WINCLOSE( void );		/* ウィンドウを閉じる */
-	void Command_FILECLOSEALL( void );	/* すべてのウィンドウを閉じる */	//Oct. 7, 2000 jepro 「編集ウィンドウの全終了」という説明を左記のように変更
-	void Command_BIND_WINDOW( void );	/* 結合して表示 */	//2004.07.14 Kazika 新規追加
-	void Command_CASCADE( void );		/* 重ねて表示 */
-	void Command_TILE_V( void );		/* 上下に並べて表示 */
-	void Command_TILE_H( void );		/* 左右に並べて表示 */
-	void Command_MAXIMIZE_V( void );	/* 縦方向に最大化 */
-	void Command_MAXIMIZE_H( void );	/* 横方向に最大化 */  //2001.02.10 by MIK
-	void Command_MINIMIZE_ALL( void );	/* すべて最小化 */
-	void Command_REDRAW( void );		/* 再描画 */
-	void Command_WIN_OUTPUT( void );	//アウトプットウィンドウ表示
+	void Command_SPLIT_V( );		/* 上下に分割 */	//Sept. 17, 2000 jepro 説明の「縦」を「上下に」に変更
+	void Command_SPLIT_H( );		/* 左右に分割 */	//Sept. 17, 2000 jepro 説明の「横」を「左右に」に変更
+	void Command_SPLIT_VH( );		/* 縦横に分割 */	//Sept. 17, 2000 jepro 説明に「に」を追加
+	void Command_WINCLOSE( );		/* ウィンドウを閉じる */
+	void Command_FILECLOSEALL( );	/* すべてのウィンドウを閉じる */	//Oct. 7, 2000 jepro 「編集ウィンドウの全終了」という説明を左記のように変更
+	void Command_BIND_WINDOW( );	/* 結合して表示 */	//2004.07.14 Kazika 新規追加
+	void Command_CASCADE( );		/* 重ねて表示 */
+	void Command_TILE_V( );		/* 上下に並べて表示 */
+	void Command_TILE_H( );		/* 左右に並べて表示 */
+	void Command_MAXIMIZE_V( );	/* 縦方向に最大化 */
+	void Command_MAXIMIZE_H( );	/* 横方向に最大化 */  //2001.02.10 by MIK
+	void Command_MINIMIZE_ALL( );	/* すべて最小化 */
+	void Command_REDRAW( );		/* 再描画 */
+	void Command_WIN_OUTPUT( );	//アウトプットウィンドウ表示
 	void Command_TRACEOUT(const wchar_t* outputstr, int nLen, int nFlgOpt);	//マクロ用アウトプットウィンドウに表示 maru 2006.04.26
 	void Command_WINTOPMOST(LPARAM lparam);		// 常に手前に表示 2004.09.21 Moca
 	void Command_WINLIST( int nCommandFrom );		/* ウィンドウ一覧ポップアップ表示処理 */	// 2006.03.23 fon // 2006.05.19 genta 引数追加
-	void Command_DLGWINLIST( void );	// ウィンドウ一覧ダイアログ // 2015.03.07 Moca
-	void Command_GROUPCLOSE( void );	/* グループを閉じる */		// 2007.06.20 ryoji
-	void Command_NEXTGROUP( void );		/* 次のグループ */			// 2007.06.20 ryoji
-	void Command_PREVGROUP( void );		/* 前のグループ */			// 2007.06.20 ryoji
-	void Command_TAB_MOVERIGHT( void );	/* タブを右に移動 */		// 2007.06.20 ryoji
-	void Command_TAB_MOVELEFT( void );	/* タブを左に移動 */		// 2007.06.20 ryoji
-	void Command_TAB_SEPARATE( void );	/* 新規グループ */			// 2007.06.20 ryoji
-	void Command_TAB_JOINTNEXT( void );	/* 次のグループに移動 */	// 2007.06.20 ryoji
-	void Command_TAB_JOINTPREV( void );	/* 前のグループに移動 */	// 2007.06.20 ryoji
-	void Command_TAB_CLOSEOTHER( void );/* このタブ以外を閉じる */	// 2008.11.22 syat
-	void Command_TAB_CLOSELEFT( void );	/* 左をすべて閉じる */		// 2008.11.22 syat
-	void Command_TAB_CLOSERIGHT( void );/* 右をすべて閉じる */		// 2008.11.22 syat
+	void Command_DLGWINLIST( );	// ウィンドウ一覧ダイアログ // 2015.03.07 Moca
+	void Command_GROUPCLOSE( );	/* グループを閉じる */		// 2007.06.20 ryoji
+	void Command_NEXTGROUP( );		/* 次のグループ */			// 2007.06.20 ryoji
+	void Command_PREVGROUP( );		/* 前のグループ */			// 2007.06.20 ryoji
+	void Command_TAB_MOVERIGHT( );	/* タブを右に移動 */		// 2007.06.20 ryoji
+	void Command_TAB_MOVELEFT( );	/* タブを左に移動 */		// 2007.06.20 ryoji
+	void Command_TAB_SEPARATE( );	/* 新規グループ */			// 2007.06.20 ryoji
+	void Command_TAB_JOINTNEXT( );	/* 次のグループに移動 */	// 2007.06.20 ryoji
+	void Command_TAB_JOINTPREV( );	/* 前のグループに移動 */	// 2007.06.20 ryoji
+	void Command_TAB_CLOSEOTHER( );/* このタブ以外を閉じる */	// 2008.11.22 syat
+	void Command_TAB_CLOSELEFT( );	/* 左をすべて閉じる */		// 2008.11.22 syat
+	void Command_TAB_CLOSERIGHT( );/* 右をすべて閉じる */		// 2008.11.22 syat
 
 	void Command_ToggleKeySearch(int option);	/* キャレット位置の単語を辞書検索する機能ON-OFF */	// 2006.03.24 fon
 
-	void Command_HOKAN( void );			/* 入力補完 */
-	void Command_HELP_CONTENTS( void );	/* ヘルプ目次 */			//Nov. 25, 2000 JEPRO added
-	void Command_HELP_SEARCH( void );	/* ヘルプキーワード検索 */	//Nov. 25, 2000 JEPRO added
-	void Command_MENU_ALLFUNC( void );	/* コマンド一覧 */
-	void Command_EXTHELP1( void );		/* 外部ヘルプ１ */
+	void Command_HOKAN( );			/* 入力補完 */
+	void Command_HELP_CONTENTS( );	/* ヘルプ目次 */			//Nov. 25, 2000 JEPRO added
+	void Command_HELP_SEARCH( );	/* ヘルプキーワード検索 */	//Nov. 25, 2000 JEPRO added
+	void Command_MENU_ALLFUNC( );	/* コマンド一覧 */
+	void Command_EXTHELP1( );		/* 外部ヘルプ１ */
 	//	Jul. 5, 2002 genta
 	void Command_EXTHTMLHELP( const WCHAR* helpfile = nullptr, const WCHAR* kwd = nullptr );	/* 外部HTMLヘルプ */
-	void Command_ABOUT( void );			/* バージョン情報 */	//Dec. 24, 2000 JEPRO 追加
+	void Command_ABOUT( );			/* バージョン情報 */	//Dec. 24, 2000 JEPRO 追加
 
 	/* その他 */
 

--- a/sakura_core/cmd/CViewCommander_Bookmark.cpp
+++ b/sakura_core/cmd/CViewCommander_Bookmark.cpp
@@ -25,7 +25,7 @@
 	@author	ai
 	@date	02/06/26
 */
-void CViewCommander::Command_JUMP_SRCHSTARTPOS(void)
+void CViewCommander::Command_JUMP_SRCHSTARTPOS()
 {
 	if( m_pCommanderView->m_ptSrchStartPos_PHY.BothNatural() )
 	{
@@ -48,7 +48,7 @@ void CViewCommander::Command_JUMP_SRCHSTARTPOS(void)
 /*! 指定行へジャンプダイアログの表示
 	2002.2.2 YAZAKI
 */
-void CViewCommander::Command_JUMP_DIALOG( void )
+void CViewCommander::Command_JUMP_DIALOG( )
 {
 	if( !GetEditWindow()->m_cDlgJump.DoModal(
 		G_AppInstance(), m_pCommanderView->GetHwnd(), (LPARAM)GetDocument()
@@ -58,7 +58,7 @@ void CViewCommander::Command_JUMP_DIALOG( void )
 }
 
 /* 指定行ヘジャンプ */
-void CViewCommander::Command_JUMP( void )
+void CViewCommander::Command_JUMP( )
 {
 	const wchar_t*	pLine;
 	int			nMode;
@@ -251,7 +251,7 @@ void CViewCommander::Command_JUMP( void )
 
 //	from CViewCommander_New.cpp
 //! ブックマークの設定・解除を行う(トグル動作)
-void CViewCommander::Command_BOOKMARK_SET(void)
+void CViewCommander::Command_BOOKMARK_SET()
 {
 	CDocLine*	pCDocLine;
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() && m_pCommanderView->GetSelectionInfo().m_sSelect.GetFrom().y<m_pCommanderView->GetSelectionInfo().m_sSelect.GetTo().y ){
@@ -287,7 +287,7 @@ void CViewCommander::Command_BOOKMARK_SET(void)
 
 //	from CViewCommander_New.cpp
 //! 次のブックマークを探し，見つかったら移動する
-void CViewCommander::Command_BOOKMARK_NEXT(void)
+void CViewCommander::Command_BOOKMARK_NEXT()
 {
 	int			nYOld;				// hor
 	BOOL		bFound	=	FALSE;	// hor
@@ -328,7 +328,7 @@ re_do:;								// hor
 
 //	from CViewCommander_New.cpp
 //! 前のブックマークを探し，見つかったら移動する．
-void CViewCommander::Command_BOOKMARK_PREV(void)
+void CViewCommander::Command_BOOKMARK_PREV()
 {
 	int			nYOld;				// hor
 	BOOL		bFound	=	FALSE;	// hor
@@ -370,7 +370,7 @@ re_do:;								// hor
 
 //	from CViewCommander_New.cpp
 //! ブックマークをクリアする
-void CViewCommander::Command_BOOKMARK_RESET(void)
+void CViewCommander::Command_BOOKMARK_RESET()
 {
 	CBookmarkManager(&GetDocument()->m_cDocLineMgr).ResetAllBookMark();
 	// 2002.01.16 hor 分割したビューも更新
@@ -380,7 +380,7 @@ void CViewCommander::Command_BOOKMARK_RESET(void)
 //	from CViewCommander_New.cpp
 //指定パターンに一致する行をマーク 2002.01.16 hor
 //キーマクロで記録できるように	2002.02.08 hor
-void CViewCommander::Command_BOOKMARK_PATTERN( void )
+void CViewCommander::Command_BOOKMARK_PATTERN( )
 {
 	//検索or置換ダイアログから呼び出された
 	if( !m_pCommanderView->ChangeCurRegexp(false) ) return;
@@ -393,7 +393,7 @@ void CViewCommander::Command_BOOKMARK_PATTERN( void )
 }
 
 //! 次の関数リストマークを探し，見つかったら移動する
-void CViewCommander::Command_FUNCLIST_NEXT(void)
+void CViewCommander::Command_FUNCLIST_NEXT()
 {
 	CLogicPoint	ptXY(0, GetCaret().GetCaretLogicPos().y);
 	int			nYOld = ptXY.y;
@@ -421,7 +421,7 @@ void CViewCommander::Command_FUNCLIST_NEXT(void)
 }
 
 //! 前のブックマークを探し，見つかったら移動する．
-void CViewCommander::Command_FUNCLIST_PREV(void)
+void CViewCommander::Command_FUNCLIST_PREV()
 {
 	CLogicPoint	ptXY(0,GetCaret().GetCaretLogicPos().y);
 	int			nYOld = ptXY.y;

--- a/sakura_core/cmd/CViewCommander_Clipboard.cpp
+++ b/sakura_core/cmd/CViewCommander_Clipboard.cpp
@@ -32,7 +32,7 @@
 
 	@date 2007.11.18 ryoji 「選択なしでコピーを可能にする」オプション処理追加
 */
-void CViewCommander::Command_CUT( void )
+void CViewCommander::Command_CUT( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsMouseSelecting() ){	/* マウスによる範囲選択中 */
 		ErrorBeep();
@@ -636,7 +636,7 @@ void CViewCommander::Command_ADDTAIL(
 }
 
 //選択範囲内全行コピー
-void CViewCommander::Command_COPYLINES( void )
+void CViewCommander::Command_COPYLINES( )
 {
 	/* 選択範囲内の全行をクリップボードにコピーする */
 	m_pCommanderView->CopySelectedAllLines(
@@ -647,7 +647,7 @@ void CViewCommander::Command_COPYLINES( void )
 }
 
 //選択範囲内全行引用符付きコピー
-void CViewCommander::Command_COPYLINESASPASSAGE( void )
+void CViewCommander::Command_COPYLINESASPASSAGE( )
 {
 	/* 選択範囲内の全行をクリップボードにコピーする */
 	m_pCommanderView->CopySelectedAllLines(
@@ -658,7 +658,7 @@ void CViewCommander::Command_COPYLINESASPASSAGE( void )
 }
 
 //選択範囲内全行行番号付きコピー
-void CViewCommander::Command_COPYLINESWITHLINENUMBER( void )
+void CViewCommander::Command_COPYLINESWITHLINENUMBER( )
 {
 	/* 選択範囲内の全行をクリップボードにコピーする */
 	m_pCommanderView->CopySelectedAllLines(
@@ -1087,7 +1087,7 @@ void CViewCommander::Command_COPY_COLOR_HTML_LINENUMBER()
 /*!	現在編集中のファイル名をクリップボードにコピー
 	2002/2/3 aroka
 */
-void CViewCommander::Command_COPYFILENAME( void )
+void CViewCommander::Command_COPYFILENAME( )
 {
 	if( GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
 		/* クリップボードにデータを設定 */
@@ -1100,7 +1100,7 @@ void CViewCommander::Command_COPYFILENAME( void )
 }
 
 /* 現在編集中のファイルのパス名をクリップボードにコピー */
-void CViewCommander::Command_COPYPATH( void )
+void CViewCommander::Command_COPYPATH( )
 {
 	if( GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
 		/* クリップボードにデータを設定 */
@@ -1113,7 +1113,7 @@ void CViewCommander::Command_COPYPATH( void )
 }
 
 /* 現在編集中のファイルのフォルダー名をクリップボードにコピー */
-void CViewCommander::Command_COPYDIRPATH( void )
+void CViewCommander::Command_COPYDIRPATH( )
 {
 	if (!GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath()) {
 		ErrorBeep();
@@ -1135,7 +1135,7 @@ void CViewCommander::Command_COPYDIRPATH( void )
 
 //	May 9, 2000 genta
 /* 現在編集中のファイルのパス名とカーソル位置をクリップボードにコピー */
-void CViewCommander::Command_COPYTAG( void )
+void CViewCommander::Command_COPYTAG( )
 {
 	if( GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
 		CLogicPoint ptColLine;
@@ -1154,7 +1154,7 @@ void CViewCommander::Command_COPYTAG( void )
 
 ////キー割り当て一覧をコピー
 	//Dec. 26, 2000 JEPRO //Jan. 24, 2001 JEPRO debug version (directed by genta)
-void CViewCommander::Command_CREATEKEYBINDLIST( void )
+void CViewCommander::Command_CREATEKEYBINDLIST( )
 {
 	CNativeW		cMemKeyList;
 

--- a/sakura_core/cmd/CViewCommander_Convert.cpp
+++ b/sakura_core/cmd/CViewCommander_Convert.cpp
@@ -24,7 +24,7 @@
 #include "CSelectLang.h"
 
 /* 小文字 */
-void CViewCommander::Command_TOLOWER( void )
+void CViewCommander::Command_TOLOWER( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_TOLOWER );
@@ -32,7 +32,7 @@ void CViewCommander::Command_TOLOWER( void )
 }
 
 /* 大文字 */
-void CViewCommander::Command_TOUPPER( void )
+void CViewCommander::Command_TOUPPER( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_TOUPPER );
@@ -40,7 +40,7 @@ void CViewCommander::Command_TOUPPER( void )
 }
 
 /* 全角→半角 */
-void CViewCommander::Command_TOHANKAKU( void )
+void CViewCommander::Command_TOHANKAKU( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_TOHANKAKU );
@@ -48,7 +48,7 @@ void CViewCommander::Command_TOHANKAKU( void )
 }
 
 /* 半角＋全ひら→全角・カタカナ */	//Sept. 17, 2000 jepro 説明を「半角→全角カタカナ」から変更
-void CViewCommander::Command_TOZENKAKUKATA( void )
+void CViewCommander::Command_TOZENKAKUKATA( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_TOZENKAKUKATA );
@@ -56,7 +56,7 @@ void CViewCommander::Command_TOZENKAKUKATA( void )
 }
 
 /* 半角＋全カタ→全角・ひらがな */	//Sept. 17, 2000 jepro 説明を「半角→全角ひらがな」から変更
-void CViewCommander::Command_TOZENKAKUHIRA( void )
+void CViewCommander::Command_TOZENKAKUHIRA( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_TOZENKAKUHIRA );
@@ -64,7 +64,7 @@ void CViewCommander::Command_TOZENKAKUHIRA( void )
 }
 
 /*! 半角英数→全角英数 */			//July. 30, 2001 Misaka
-void CViewCommander::Command_TOZENEI( void )
+void CViewCommander::Command_TOZENEI( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_TOZENEI );
@@ -72,7 +72,7 @@ void CViewCommander::Command_TOZENEI( void )
 }
 
 /*! 全角英数→半角英数 */
-void CViewCommander::Command_TOHANEI( void )
+void CViewCommander::Command_TOHANEI( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_TOHANEI );
@@ -80,7 +80,7 @@ void CViewCommander::Command_TOHANEI( void )
 }
 
 /* 全角カタカナ→半角カタカナ */		//Aug. 29, 2002 ai
-void CViewCommander::Command_TOHANKATA( void )
+void CViewCommander::Command_TOHANKATA( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_TOHANKATA );
@@ -88,7 +88,7 @@ void CViewCommander::Command_TOHANKATA( void )
 }
 
 /* 半角カタカナ→全角カタカナ */
-void CViewCommander::Command_HANKATATOZENKAKUKATA( void )
+void CViewCommander::Command_HANKATATOZENKAKUKATA( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_HANKATATOZENKATA );
@@ -96,7 +96,7 @@ void CViewCommander::Command_HANKATATOZENKAKUKATA( void )
 }
 
 /* 半角カタカナ→全角ひらがな */
-void CViewCommander::Command_HANKATATOZENKAKUHIRA( void )
+void CViewCommander::Command_HANKATATOZENKAKUHIRA( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_HANKATATOZENHIRA );
@@ -104,7 +104,7 @@ void CViewCommander::Command_HANKATATOZENKAKUHIRA( void )
 }
 
 /* TAB→空白 */
-void CViewCommander::Command_TABTOSPACE( void )
+void CViewCommander::Command_TABTOSPACE( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_TABTOSPACE );
@@ -112,7 +112,7 @@ void CViewCommander::Command_TABTOSPACE( void )
 }
 
 /* 空白→TAB */ //---- Stonee, 2001/05/27
-void CViewCommander::Command_SPACETOTAB( void )
+void CViewCommander::Command_SPACETOTAB( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_SPACETOTAB );
@@ -120,7 +120,7 @@ void CViewCommander::Command_SPACETOTAB( void )
 }
 
 /* 自動判別→SJISコード変換 */
-void CViewCommander::Command_CODECNV_AUTO2SJIS( void )
+void CViewCommander::Command_CODECNV_AUTO2SJIS( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_AUTO2SJIS );
@@ -128,7 +128,7 @@ void CViewCommander::Command_CODECNV_AUTO2SJIS( void )
 }
 
 /* E-Mail(JIS→SJIS)コード変換 */
-void CViewCommander::Command_CODECNV_EMAIL( void )
+void CViewCommander::Command_CODECNV_EMAIL( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_EMAIL );
@@ -136,7 +136,7 @@ void CViewCommander::Command_CODECNV_EMAIL( void )
 }
 
 /* EUC→SJISコード変換 */
-void CViewCommander::Command_CODECNV_EUC2SJIS( void )
+void CViewCommander::Command_CODECNV_EUC2SJIS( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_EUC2SJIS );
@@ -144,7 +144,7 @@ void CViewCommander::Command_CODECNV_EUC2SJIS( void )
 }
 
 /* Unicode→SJISコード変換 */
-void CViewCommander::Command_CODECNV_UNICODE2SJIS( void )
+void CViewCommander::Command_CODECNV_UNICODE2SJIS( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_UNICODE2SJIS );
@@ -152,7 +152,7 @@ void CViewCommander::Command_CODECNV_UNICODE2SJIS( void )
 }
 
 /* UnicodeBE→SJISコード変換 */
-void CViewCommander::Command_CODECNV_UNICODEBE2SJIS( void )
+void CViewCommander::Command_CODECNV_UNICODEBE2SJIS( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_UNICODEBE2SJIS );
@@ -160,7 +160,7 @@ void CViewCommander::Command_CODECNV_UNICODEBE2SJIS( void )
 }
 
 /* UTF-8→SJISコード変換 */
-void CViewCommander::Command_CODECNV_UTF82SJIS( void )
+void CViewCommander::Command_CODECNV_UTF82SJIS( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_UTF82SJIS );
@@ -168,7 +168,7 @@ void CViewCommander::Command_CODECNV_UTF82SJIS( void )
 }
 
 /* UTF-7→SJISコード変換 */
-void CViewCommander::Command_CODECNV_UTF72SJIS( void )
+void CViewCommander::Command_CODECNV_UTF72SJIS( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_UTF72SJIS );
@@ -176,7 +176,7 @@ void CViewCommander::Command_CODECNV_UTF72SJIS( void )
 }
 
 /* SJIS→JISコード変換 */
-void CViewCommander::Command_CODECNV_SJIS2JIS( void )
+void CViewCommander::Command_CODECNV_SJIS2JIS( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_SJIS2JIS );
@@ -184,7 +184,7 @@ void CViewCommander::Command_CODECNV_SJIS2JIS( void )
 }
 
 /* SJIS→EUCコード変換 */
-void CViewCommander::Command_CODECNV_SJIS2EUC( void )
+void CViewCommander::Command_CODECNV_SJIS2EUC( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_SJIS2EUC );
@@ -192,7 +192,7 @@ void CViewCommander::Command_CODECNV_SJIS2EUC( void )
 }
 
 /* SJIS→UTF-8コード変換 */
-void CViewCommander::Command_CODECNV_SJIS2UTF8( void )
+void CViewCommander::Command_CODECNV_SJIS2UTF8( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_SJIS2UTF8 );
@@ -200,7 +200,7 @@ void CViewCommander::Command_CODECNV_SJIS2UTF8( void )
 }
 
 /* SJIS→UTF-7コード変換 */
-void CViewCommander::Command_CODECNV_SJIS2UTF7( void )
+void CViewCommander::Command_CODECNV_SJIS2UTF7( )
 {
 	/* 選択エリアのテキストを指定方法で変換 */
 	m_pCommanderView->ConvSelectedArea( F_CODECNV_SJIS2UTF7 );
@@ -208,7 +208,7 @@ void CViewCommander::Command_CODECNV_SJIS2UTF7( void )
 }
 
 /* Base64デコードして保存 */
-void CViewCommander::Command_BASE64DECODE( void )
+void CViewCommander::Command_BASE64DECODE( )
 {
 	/* テキストが選択されているか */
 	if( !m_pCommanderView->GetSelectionInfo().IsTextSelected() ){
@@ -254,7 +254,7 @@ err:
 }
 
 /* uudecodeして保存 */
-void CViewCommander::Command_UUDECODE( void )
+void CViewCommander::Command_UUDECODE( )
 {
 	/* テキストが選択されているか */
 	if( !m_pCommanderView->GetSelectionInfo().IsTextSelected() ){

--- a/sakura_core/cmd/CViewCommander_Cursor.cpp
+++ b/sakura_core/cmd/CViewCommander_Cursor.cpp
@@ -863,7 +863,7 @@ void CViewCommander::MoveViewTopLine(CLayoutInt nViewTopLine)
 }
 
 /* カーソル行をウィンドウ中央へ */
-void CViewCommander::Command_CURLINECENTER( void )
+void CViewCommander::Command_CURLINECENTER( )
 {
 	CLayoutInt		nViewTopLine;
 	nViewTopLine = GetCaret().GetCaretLayoutPos().GetY2() - ( m_pCommanderView->GetTextArea().m_nViewRowNum / 2 );
@@ -872,7 +872,7 @@ void CViewCommander::Command_CURLINECENTER( void )
 }
 
 /* カーソル行をウィンドウ上部へ */
-void CViewCommander::Command_CURLINETOP(void)
+void CViewCommander::Command_CURLINETOP()
 {
 	CLayoutInt		nViewTopLine;
 	nViewTopLine = GetCaret().GetCaretLayoutPos().GetY2();
@@ -881,7 +881,7 @@ void CViewCommander::Command_CURLINETOP(void)
 }
 
 /* カーソル行をウィンドウ下部へ */
-void CViewCommander::Command_CURLINEBOTTOM(void)
+void CViewCommander::Command_CURLINEBOTTOM()
 {
 	CLayoutInt		nViewTopLine;
 	nViewTopLine = GetCaret().GetCaretLayoutPos().GetY2() - (m_pCommanderView->GetTextArea().m_nViewRowNum);
@@ -891,7 +891,7 @@ void CViewCommander::Command_CURLINEBOTTOM(void)
 
 //	移動履歴を前へたどる
 //
-void CViewCommander::Command_JUMPHIST_PREV( void )
+void CViewCommander::Command_JUMPHIST_PREV( )
 {
 	// 2001.12.13 hor
 	// 移動履歴の最後に現在の位置を記憶する
@@ -916,7 +916,7 @@ void CViewCommander::Command_JUMPHIST_PREV( void )
 }
 
 //	移動履歴を次へたどる
-void CViewCommander::Command_JUMPHIST_NEXT( void )
+void CViewCommander::Command_JUMPHIST_NEXT( )
 {
 	if( m_pCommanderView->m_cHistory->CheckNext() ){
 		if( ! m_pCommanderView->m_cHistory->NextValid() ){
@@ -933,7 +933,7 @@ void CViewCommander::Command_JUMPHIST_NEXT( void )
 }
 
 //	現在位置を移動履歴に登録する
-void CViewCommander::Command_JUMPHIST_SET( void )
+void CViewCommander::Command_JUMPHIST_SET( )
 {
 	m_pCommanderView->AddCurrentLineToHistory();
 }
@@ -942,7 +942,7 @@ void CViewCommander::Command_JUMPHIST_SET( void )
 
 //	from CViewCommander_New.cpp
 // テキストを１行下へスクロール
-void CViewCommander::Command_WndScrollDown( void )
+void CViewCommander::Command_WndScrollDown( )
 {
 	CLayoutInt	nCaretMarginY;
 
@@ -981,7 +981,7 @@ void CViewCommander::Command_WndScrollDown( void )
 
 //	from CViewCommander_New.cpp
 // テキストを１行上へスクロール
-void CViewCommander::Command_WndScrollUp(void)
+void CViewCommander::Command_WndScrollUp()
 {
 	CLayoutInt	nCaretMarginY;
 

--- a/sakura_core/cmd/CViewCommander_CustMenu.cpp
+++ b/sakura_core/cmd/CViewCommander_CustMenu.cpp
@@ -24,7 +24,7 @@
 #include "apiwrap/StdApi.h"
 
 /* 右クリックメニュー */
-void CViewCommander::Command_MENU_RBUTTON( void )
+void CViewCommander::Command_MENU_RBUTTON( )
 {
 	/* ポップアップメニュー(右クリック) */
 	auto nId = m_pCommanderView->CreatePopUpMenu_R();

--- a/sakura_core/cmd/CViewCommander_Diff.cpp
+++ b/sakura_core/cmd/CViewCommander_Diff.cpp
@@ -106,7 +106,7 @@ static bool Commander_COMPARE_core(CViewCommander& commander, bool& bDifferent, 
 }
 
 /* ファイル内容比較 */
-void CViewCommander::Command_COMPARE( void )
+void CViewCommander::Command_COMPARE( )
 {
 	HWND		hwndCompareWnd = nullptr;
 	CDlgCompare	cDlgCompare;
@@ -315,7 +315,7 @@ void CViewCommander::Command_Diff( const WCHAR* _szDiffFile2, int nFlgOpt )
 	@date	2002/11/09 編集中ファイルを許可
 	@date	2005/10/29 maru 一時ファイル作成処理をm_pCommanderView->MakeDiffTmpFileへ移動
 */
-void CViewCommander::Command_Diff_Dialog( void )
+void CViewCommander::Command_Diff_Dialog( )
 {
 	CDlgDiff	cDlgDiff;
 	bool	bTmpFile1 = false, bTmpFile2 = false;
@@ -402,7 +402,7 @@ void CViewCommander::Command_Diff_Dialog( void )
 
 /*!	次の差分を探し，見つかったら移動する
 */
-void CViewCommander::Command_Diff_Next( void )
+void CViewCommander::Command_Diff_Next( )
 {
 	BOOL		bFound = FALSE;
 	BOOL		bRedo = TRUE;
@@ -452,7 +452,7 @@ re_do:;
 
 /*!	前の差分を探し，見つかったら移動する
 */
-void CViewCommander::Command_Diff_Prev( void )
+void CViewCommander::Command_Diff_Prev( )
 {
 	BOOL		bFound = FALSE;
 	BOOL		bRedo = TRUE;
@@ -505,7 +505,7 @@ re_do:;
 	@author	MIK
 	@date	2002/05/26
 */
-void CViewCommander::Command_Diff_Reset( void )
+void CViewCommander::Command_Diff_Reset( )
 {
 	CDiffLineMgr(&GetDocument()->m_cDocLineMgr).ResetAllDiffMark();
 

--- a/sakura_core/cmd/CViewCommander_Edit.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit.cpp
@@ -273,7 +273,7 @@ void CViewCommander::Command_IME_CHAR( WORD wChar )
 
 //	from CViewCommander_New.cpp
 /* Undo 元に戻す */
-void CViewCommander::Command_UNDO( void )
+void CViewCommander::Command_UNDO( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsMouseSelecting() ){	/* マウスによる範囲選択中 */
 		ErrorBeep();
@@ -533,7 +533,7 @@ void CViewCommander::Command_UNDO( void )
 
 //	from CViewCommander_New.cpp
 /* Redo やり直し */
-void CViewCommander::Command_REDO( void )
+void CViewCommander::Command_REDO( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsMouseSelecting() ){	/* マウスによる範囲選択中 */
 		ErrorBeep();
@@ -782,7 +782,7 @@ void CViewCommander::Command_REDO( void )
 }
 
 //カーソル位置または選択エリアを削除
-void CViewCommander::Command_DELETE( void )
+void CViewCommander::Command_DELETE( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsMouseSelecting() ){		/* マウスによる範囲選択中 */
 		ErrorBeep();
@@ -830,7 +830,7 @@ void CViewCommander::Command_DELETE( void )
 }
 
 //カーソル前を削除
-void CViewCommander::Command_DELETE_BACK( void )
+void CViewCommander::Command_DELETE_BACK( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsMouseSelecting() ){	/* マウスによる範囲選択中 */
 		ErrorBeep();

--- a/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_advanced.cpp
@@ -820,7 +820,7 @@ void CViewCommander::Command_SORT(BOOL bAsc)	//bAsc:TRUE=昇順,FALSE=降順
 	@date 2001.12.03 hor 新規作成
 	@date 2001.12.21 hor 選択範囲の調整ロジックを訂正
 */
-void CViewCommander::Command_MERGE(void)
+void CViewCommander::Command_MERGE()
 {
 	CLayoutInt		nCaretPosYOLD;
 	const wchar_t*	pLinew;
@@ -950,7 +950,7 @@ void CViewCommander::Command_MERGE(void)
 	@date 2010.03.17 ATOK用はSCS_SETRECONVERTSTRING => ATRECONVERTSTRING_SETに変更
 		2002.11.20 Stoneeさんの情報
 */
-void CViewCommander::Command_Reconvert(void)
+void CViewCommander::Command_Reconvert()
 {
 	//サイズを取得
 	LRESULT nSize = m_pCommanderView->SetReconvertStruct(nullptr);

--- a/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
+++ b/sakura_core/cmd/CViewCommander_Edit_word_line.cpp
@@ -19,7 +19,7 @@
 #include "CViewCommander_inline.h"
 
 //単語の左端まで削除
-void CViewCommander::Command_WordDeleteToStart( void )
+void CViewCommander::Command_WordDeleteToStart( )
 {
 	/* 矩形選択状態では実行不能(★★もろ手抜き★★) */
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() ){
@@ -54,7 +54,7 @@ void CViewCommander::Command_WordDeleteToStart( void )
 }
 
 //単語の右端まで削除
-void CViewCommander::Command_WordDeleteToEnd( void )
+void CViewCommander::Command_WordDeleteToEnd( )
 {
 	/* 矩形選択状態では実行不能((★★もろ手抜き★★)) */
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() ){
@@ -85,7 +85,7 @@ void CViewCommander::Command_WordDeleteToEnd( void )
 }
 
 //単語切り取り
-void CViewCommander::Command_WordCut( void )
+void CViewCommander::Command_WordCut( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() ){
 		/* 切り取り(選択範囲をクリップボードにコピーして削除) */
@@ -104,7 +104,7 @@ void CViewCommander::Command_WordCut( void )
 }
 
 //単語削除
-void CViewCommander::Command_WordDelete( void )
+void CViewCommander::Command_WordDelete( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() ){
 		/* 削除 */
@@ -119,7 +119,7 @@ void CViewCommander::Command_WordDelete( void )
 }
 
 //行頭まで切り取り(改行単位)
-void CViewCommander::Command_LineCutToStart( void )
+void CViewCommander::Command_LineCutToStart( )
 {
 	const CLayout*	pCLayout;
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() ){	/* テキストが選択されているか */
@@ -150,7 +150,7 @@ void CViewCommander::Command_LineCutToStart( void )
 }
 
 //行末まで切り取り(改行単位)
-void CViewCommander::Command_LineCutToEnd( void )
+void CViewCommander::Command_LineCutToEnd( )
 {
 	const CLayout*	pCLayout;
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() ){	/* テキストが選択されているか */
@@ -200,7 +200,7 @@ void CViewCommander::Command_LineCutToEnd( void )
 }
 
 //行頭まで削除(改行単位)
-void CViewCommander::Command_LineDeleteToStart( void )
+void CViewCommander::Command_LineDeleteToStart( )
 {
 	const CLayout*	pCLayout;
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() ){	/* テキストが選択されているか */
@@ -231,7 +231,7 @@ void CViewCommander::Command_LineDeleteToStart( void )
 }
 
 //行末まで削除(改行単位)
-void CViewCommander::Command_LineDeleteToEnd( void )
+void CViewCommander::Command_LineDeleteToEnd( )
 {
 	const CLayout*	pCLayout;
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() ){	/* テキストが選択されているか */
@@ -279,7 +279,7 @@ void CViewCommander::Command_LineDeleteToEnd( void )
 }
 
 //行切り取り(折り返し単位)
-void CViewCommander::Command_CUT_LINE( void )
+void CViewCommander::Command_CUT_LINE( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsMouseSelecting() ){	/* マウスによる範囲選択中 */
 		ErrorBeep();
@@ -308,7 +308,7 @@ void CViewCommander::Command_CUT_LINE( void )
 }
 
 /* 行削除(折り返し単位) */
-void CViewCommander::Command_DELETE_LINE( void )
+void CViewCommander::Command_DELETE_LINE( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsMouseSelecting() ){	/* マウスによる範囲選択中 */
 		ErrorBeep();
@@ -365,7 +365,7 @@ void CViewCommander::Command_DELETE_LINE( void )
 }
 
 /* 行の二重化(折り返し単位) */
-void CViewCommander::Command_DUPLICATELINE( void )
+void CViewCommander::Command_DUPLICATELINE( )
 {
 	int				bCRLF;
 	int				bAddCRLF;

--- a/sakura_core/cmd/CViewCommander_File.cpp
+++ b/sakura_core/cmd/CViewCommander_File.cpp
@@ -48,7 +48,7 @@
 #include "config/app_constants.h"
 
 /* 新規作成 */
-void CViewCommander::Command_FILENEW( void )
+void CViewCommander::Command_FILENEW( )
 {
 	/* 新たな編集ウィンドウを起動 */
 	SLoadInfo sLoadInfo;
@@ -61,7 +61,7 @@ void CViewCommander::Command_FILENEW( void )
 }
 
 /* 新規作成（新しいウインドウで開く） */
-void CViewCommander::Command_FILENEW_NEWWINDOW( void )
+void CViewCommander::Command_FILENEW_NEWWINDOW( )
 {
 	/* 新たな編集ウィンドウを起動 */
 	SLoadInfo sLoadInfo;
@@ -208,7 +208,7 @@ BOOL CViewCommander::Command_FILESAVEAS( const WCHAR* filename, EEolType eEolTyp
 
 	@date 2005.01.24 genta 新規作成
 */
-BOOL CViewCommander::Command_FILESAVEALL( void )
+BOOL CViewCommander::Command_FILESAVEALL( )
 {
 	CAppNodeGroupHandle(0).SendMessageToAllEditors(
 		WM_COMMAND,
@@ -220,7 +220,7 @@ BOOL CViewCommander::Command_FILESAVEALL( void )
 }
 
 /* 閉じて(無題) */	//Oct. 17, 2000 jepro 「ファイルを閉じる」というキャプションを変更
-void CViewCommander::Command_FILECLOSE( void )
+void CViewCommander::Command_FILECLOSE( )
 {
 	GetDocument()->m_cDocFileOperation.FileClose();
 }
@@ -265,7 +265,7 @@ void CViewCommander::Command_FILE_REOPEN(
 }
 
 /* 印刷 */
-void CViewCommander::Command_PRINT( void )
+void CViewCommander::Command_PRINT( )
 {
 	// 使っていない処理を削除 2003.05.04 かろと
 	Command_PRINT_PREVIEW();
@@ -275,7 +275,7 @@ void CViewCommander::Command_PRINT( void )
 }
 
 /* 印刷プレビュー */
-void CViewCommander::Command_PRINT_PREVIEW( void )
+void CViewCommander::Command_PRINT_PREVIEW( )
 {
 	/* 印刷プレビューモードのオン/オフ */
 	GetEditWindow()->PrintPreviewModeONOFF();
@@ -283,7 +283,7 @@ void CViewCommander::Command_PRINT_PREVIEW( void )
 }
 
 /* 印刷のページレイアウトの設定 */
-void CViewCommander::Command_PRINT_PAGESETUP( void )
+void CViewCommander::Command_PRINT_PAGESETUP( )
 {
 	/* 印刷ページ設定 */
 	GetEditWindow()->OnPrintPageSetting();
@@ -329,7 +329,7 @@ BOOL CViewCommander::Command_OPEN_CCPP( BOOL bCheckOnly, BOOL bBeepWhenMiss )
 }
 
 /* Oracle SQL*Plusをアクティブ表示 */
-void CViewCommander::Command_ACTIVATE_SQLPLUS( void )
+void CViewCommander::Command_ACTIVATE_SQLPLUS( )
 {
 	HWND		hwndSQLPLUS;
 	hwndSQLPLUS = ::FindWindow( L"SqlplusWClass", L"Oracle SQL*Plus" );
@@ -344,7 +344,7 @@ void CViewCommander::Command_ACTIVATE_SQLPLUS( void )
 }
 
 /* Oracle SQL*Plusで実行 */
-void CViewCommander::Command_PLSQL_COMPILE_ON_SQLPLUS( void )
+void CViewCommander::Command_PLSQL_COMPILE_ON_SQLPLUS( )
 {
 //	HGLOBAL		hgClip;
 //	char*		pszClip;
@@ -426,7 +426,7 @@ void CViewCommander::Command_PLSQL_COMPILE_ON_SQLPLUS( void )
 }
 
 /* ブラウズ */
-void CViewCommander::Command_BROWSE( void )
+void CViewCommander::Command_BROWSE( )
 {
 	if( !GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath() ){
 		ErrorBeep();
@@ -459,7 +459,7 @@ void CViewCommander::Command_BROWSE( void )
 }
 
 /* ビューモード */
-void CViewCommander::Command_VIEWMODE( void )
+void CViewCommander::Command_VIEWMODE( )
 {
 	//ビューモードを反転
 	CAppMode::getInstance()->SetViewMode(!CAppMode::getInstance()->IsViewMode());
@@ -477,7 +477,7 @@ void CViewCommander::Command_VIEWMODE( void )
 }
 
 /* ファイルのプロパティ */
-void CViewCommander::Command_PROPERTY_FILE( void )
+void CViewCommander::Command_PROPERTY_FILE( )
 {
 #ifdef _DEBUG
 	{
@@ -500,7 +500,7 @@ void CViewCommander::Command_PROPERTY_FILE( void )
 	return;
 }
 
-void CViewCommander::Command_PROFILEMGR( void )
+void CViewCommander::Command_PROFILEMGR( )
 {
 	CDlgProfileMgr profMgr;
 	if( profMgr.DoModal( G_AppInstance(), m_pCommanderView->GetHwnd(), 0 ) ){
@@ -515,7 +515,7 @@ void CViewCommander::Command_PROFILEMGR( void )
 }
 
 /* ファイルの場所を開く */
-void CViewCommander::Command_OPEN_FOLDER_IN_EXPLORER(void)
+void CViewCommander::Command_OPEN_FOLDER_IN_EXPLORER()
 {
 	if (!GetDocument()->m_cDocFile.GetFilePathClass().IsValidPath()) {
 		ErrorBeep();
@@ -645,14 +645,14 @@ void CViewCommander::Command_OPEN_POWERSHELL(BOOL isAdmin)
 }
 
 /* 編集の全終了 */	// 2007.02.13 ryoji 追加
-void CViewCommander::Command_EXITALLEDITORS( void )
+void CViewCommander::Command_EXITALLEDITORS( )
 {
 	CControlTray::CloseAllEditor( TRUE, GetMainWindow(), TRUE, 0 );
 	return;
 }
 
 /* サクラエディタの全終了 */	//Dec. 27, 2000 JEPRO 追加
-void CViewCommander::Command_EXITALL( void )
+void CViewCommander::Command_EXITALL( )
 {
 	CControlTray::TerminateApplication( GetMainWindow() );	// 2006.12.25 ryoji 引数追加
 	return;

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -28,7 +28,7 @@
 	@date 2005.01.10 genta CEditView_Commandより移動
 	@author Yazaki
 */
-void CViewCommander::Command_GREP_DIALOG( void )
+void CViewCommander::Command_GREP_DIALOG( )
 {
 	CNativeW	cmemCurText;
 	// 2014.07.01 複数Grepウィンドウを使い分けている場合などに影響しないように、未設定のときだけHistoryを見る
@@ -55,7 +55,7 @@ void CViewCommander::Command_GREP_DIALOG( void )
 
 	@date 2005.01.10 genta CEditView_Commandより移動
 */
-void CViewCommander::Command_GREP( void )
+void CViewCommander::Command_GREP( )
 {
 	CNativeW		cmWork1;
 	CNativeW		cmWork2;
@@ -129,7 +129,7 @@ void CViewCommander::Command_GREP( void )
 
 /*! GREP置換ダイアログの表示
 */
-void CViewCommander::Command_GREP_REPLACE_DLG( void )
+void CViewCommander::Command_GREP_REPLACE_DLG( )
 {
 	CNativeW	cmemCurText;
 	CDlgGrepReplace& cDlgGrepRep = GetEditWindow()->m_cDlgGrepReplace;
@@ -158,7 +158,7 @@ void CViewCommander::Command_GREP_REPLACE_DLG( void )
 
 /*! GREP置換実行
 */
-void CViewCommander::Command_GREP_REPLACE( void )
+void CViewCommander::Command_GREP_REPLACE( )
 {
 	CNativeW		cmWork1;
 	CNativeW		cmWork2;

--- a/sakura_core/cmd/CViewCommander_Insert.cpp
+++ b/sakura_core/cmd/CViewCommander_Insert.cpp
@@ -22,7 +22,7 @@
 #include "recent/CMRUFolder.h"
 
 //日付挿入
-void CViewCommander::Command_INS_DATE( void )
+void CViewCommander::Command_INS_DATE( )
 {
 	// 日付をフォーマット
 	WCHAR szText[1024];
@@ -35,7 +35,7 @@ void CViewCommander::Command_INS_DATE( void )
 }
 
 //時刻挿入
-void CViewCommander::Command_INS_TIME( void )
+void CViewCommander::Command_INS_TIME( )
 {
 	// 時刻をフォーマット
 	WCHAR szText[1024];
@@ -52,7 +52,7 @@ void CViewCommander::Command_INS_TIME( void )
 	@author	MIK
 	@date	2002/06/02
 */
-void CViewCommander::Command_CtrlCode_Dialog( void )
+void CViewCommander::Command_CtrlCode_Dialog( )
 {
 	CDlgCtrlCode	cDlgCtrlCode;
 
@@ -67,7 +67,7 @@ void CViewCommander::Command_CtrlCode_Dialog( void )
 }
 
 // 最近使ったファイル挿入
-void CViewCommander::Command_INS_FILE_USED_RECENTLY( void )
+void CViewCommander::Command_INS_FILE_USED_RECENTLY( )
 {
 	std::wstring eol = GetDocument()->m_cDocEditor.GetNewLineCode().GetValue2();
 	std::wstring s;
@@ -81,7 +81,7 @@ void CViewCommander::Command_INS_FILE_USED_RECENTLY( void )
 }
 
 // 最近使ったフォルダー挿入
-void CViewCommander::Command_INS_FOLDER_USED_RECENTLY( void )
+void CViewCommander::Command_INS_FOLDER_USED_RECENTLY( )
 {
 	std::wstring eol = GetDocument()->m_cDocEditor.GetNewLineCode().GetValue2();
 	std::wstring s;

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -34,7 +34,7 @@
 #include "env/CSakuraEnvironment.h"
 
 /* キーマクロの記録開始／終了 */
-void CViewCommander::Command_RECKEYMACRO( void )
+void CViewCommander::Command_RECKEYMACRO( )
 {
 	if( GetDllShareData().m_sFlags.m_bRecordingKeyMacro ){									/* キーボードマクロの記録中 */
 		GetDllShareData().m_sFlags.m_bRecordingKeyMacro = FALSE;
@@ -77,7 +77,7 @@ void CViewCommander::Command_RECKEYMACRO( void )
 }
 
 /* キーマクロの保存 */
-void CViewCommander::Command_SAVEKEYMACRO( void )
+void CViewCommander::Command_SAVEKEYMACRO( )
 {
 	GetDllShareData().m_sFlags.m_bRecordingKeyMacro = FALSE;
 	GetDllShareData().m_sFlags.m_hwndRecordingKeyMacro = nullptr;	/* キーボードマクロを記録中のウィンドウ */
@@ -126,7 +126,7 @@ void CViewCommander::Command_SAVEKEYMACRO( void )
 /*! キーマクロの読み込み
 	@date 2005.02.20 novice デフォルトの拡張子変更
  */
-void CViewCommander::Command_LOADKEYMACRO( void )
+void CViewCommander::Command_LOADKEYMACRO( )
 {
 	GetDllShareData().m_sFlags.m_bRecordingKeyMacro = FALSE;
 	GetDllShareData().m_sFlags.m_hwndRecordingKeyMacro = nullptr;	/* キーボードマクロを記録中のウィンドウ */
@@ -165,7 +165,7 @@ void CViewCommander::Command_LOADKEYMACRO( void )
 }
 
 /* キーマクロの実行 */
-void CViewCommander::Command_EXECKEYMACRO( void )
+void CViewCommander::Command_EXECKEYMACRO( )
 {
 	//@@@ 2002.1.24 YAZAKI 記録中は終了してから実行
 	if (GetDllShareData().m_sFlags.m_bRecordingKeyMacro){
@@ -281,7 +281,7 @@ void CViewCommander::Command_EXECEXTMACRO( const WCHAR* pszPath, const WCHAR* ps
 /*! 外部コマンド実行ダイアログ表示
 	@date 2002.02.02 YAZAKI.
 */
-void CViewCommander::Command_EXECCOMMAND_DIALOG( void )
+void CViewCommander::Command_EXECCOMMAND_DIALOG( )
 {
 	CDlgExec cDlgExec;
 

--- a/sakura_core/cmd/CViewCommander_ModeChange.cpp
+++ b/sakura_core/cmd/CViewCommander_ModeChange.cpp
@@ -21,7 +21,7 @@
 
 	@date 2005.10.02 genta InsMode関数化
 */
-void CViewCommander::Command_CHGMOD_INS( void )
+void CViewCommander::Command_CHGMOD_INS( )
 {
 	/* 挿入モードか？ */
 	if( m_pCommanderView->IsInsMode() ){

--- a/sakura_core/cmd/CViewCommander_Search.cpp
+++ b/sakura_core/cmd/CViewCommander_Search.cpp
@@ -42,13 +42,13 @@
 ツールバーの検索ボックスにフォーカスを移動する.
 	@date 2006.06.04 yukihane 新規作成
 */
-void CViewCommander::Command_SEARCH_BOX( void )
+void CViewCommander::Command_SEARCH_BOX( )
 {
 	GetEditWindow()->m_cToolbar.SetFocusSearchBox();
 }
 
 /* 検索(単語検索ダイアログ) */
-void CViewCommander::Command_SEARCH_DIALOG( void )
+void CViewCommander::Command_SEARCH_DIALOG( )
 {
 	/* 現在カーソル位置単語または選択範囲より検索等のキーを取得 */
 	CNativeW		cmemCurText;
@@ -484,7 +484,7 @@ end_of_func:;
 }
 
 //置換(置換ダイアログ)
-void CViewCommander::Command_REPLACE_DIALOG( void )
+void CViewCommander::Command_REPLACE_DIALOG( )
 {
 	BOOL		bSelected = FALSE;
 
@@ -1507,7 +1507,7 @@ void CViewCommander::Command_REPLACE_ALL()
 }
 
 //検索マークの切替え	// 2001.12.03 hor クリア を 切替え に変更
-void CViewCommander::Command_SEARCH_CLEARMARK( void )
+void CViewCommander::Command_SEARCH_CLEARMARK( )
 {
 // From Here 2001.12.03 hor
 
@@ -1552,7 +1552,7 @@ void CViewCommander::Command_SEARCH_CLEARMARK( void )
 
 //	Jun. 16, 2000 genta
 //	対括弧の検索
-void CViewCommander::Command_BRACKETPAIR( void )
+void CViewCommander::Command_BRACKETPAIR( )
 {
 	CLayoutPoint ptColLine;
 	//int nLine, nCol;

--- a/sakura_core/cmd/CViewCommander_Select.cpp
+++ b/sakura_core/cmd/CViewCommander_Select.cpp
@@ -66,7 +66,7 @@ bool CViewCommander::Command_SELECTWORD( CLayoutPoint* pptCaretPos )
 }
 
 /* すべて選択 */
-void CViewCommander::Command_SELECTALL( void )
+void CViewCommander::Command_SELECTALL( )
 {
 	if( m_pCommanderView->GetSelectionInfo().IsTextSelected() ){	/* テキストが選択されているか */
 		/* 現在の選択範囲を非選択状態に戻す */
@@ -141,7 +141,7 @@ void CViewCommander::Command_SELECTLINE([[maybe_unused]] LPARAM lparam1)
 }
 
 /* 範囲選択開始 */
-void CViewCommander::Command_BEGIN_SELECT( void )
+void CViewCommander::Command_BEGIN_SELECT( )
 {
 	if( !m_pCommanderView->GetSelectionInfo().IsTextSelected() ){	/* テキストが選択されているか */
 		/* 現在のカーソル位置から選択を開始する */

--- a/sakura_core/cmd/CViewCommander_Settings.cpp
+++ b/sakura_core/cmd/CViewCommander_Settings.cpp
@@ -36,7 +36,7 @@
 
 	@date 2006.12.19 ryoji 表示切替は CEditWnd::LayoutToolBar(), CEditWnd::EndLayoutBars() で行うように変更
 */
-void CViewCommander::Command_SHOWTOOLBAR( void )
+void CViewCommander::Command_SHOWTOOLBAR( )
 {
 	CEditWnd*	pCEditWnd = GetEditWindow();	//	Sep. 10, 2002 genta
 
@@ -57,7 +57,7 @@ void CViewCommander::Command_SHOWTOOLBAR( void )
 
 	@date 2006.12.19 ryoji 表示切替は CEditWnd::LayoutFuncKey(), CEditWnd::EndLayoutBars() で行うように変更
 */
-void CViewCommander::Command_SHOWFUNCKEY( void )
+void CViewCommander::Command_SHOWFUNCKEY( )
 {
 	CEditWnd*	pCEditWnd = GetEditWindow();	//	Sep. 10, 2002 genta
 
@@ -81,7 +81,7 @@ void CViewCommander::Command_SHOWFUNCKEY( void )
 	@date 2006.12.19 ryoji 表示切替は CEditWnd::LayoutTabBar(), CEditWnd::EndLayoutBars() で行うように変更
 	@date 2007.06.20 ryoji グループIDリセット
  */
-void CViewCommander::Command_SHOWTAB( void )
+void CViewCommander::Command_SHOWTAB( )
 {
 	CEditWnd*	pCEditWnd = GetEditWindow();	//	Sep. 10, 2002 genta
 
@@ -111,7 +111,7 @@ void CViewCommander::Command_SHOWTAB( void )
 
 	@date 2006.12.19 ryoji 表示切替は CEditWnd::LayoutStatusBar(), CEditWnd::EndLayoutBars() で行うように変更
 */
-void CViewCommander::Command_SHOWSTATUSBAR( void )
+void CViewCommander::Command_SHOWSTATUSBAR( )
 {
 	CEditWnd*	pCEditWnd = GetEditWindow();	//	Sep. 10, 2002 genta
 
@@ -132,7 +132,7 @@ void CViewCommander::Command_SHOWSTATUSBAR( void )
 
 	@date 2014.07.14 新規作成
 */
-void CViewCommander::Command_SHOWMINIMAP( void )
+void CViewCommander::Command_SHOWMINIMAP( )
 {
 	CEditWnd*	pCEditWnd = GetEditWindow();	//	Sep. 10, 2002 genta
 
@@ -150,7 +150,7 @@ void CViewCommander::Command_SHOWMINIMAP( void )
 }
 
 /* タイプ別設定一覧 */
-void CViewCommander::Command_TYPE_LIST( void )
+void CViewCommander::Command_TYPE_LIST( )
 {
 	CDlgTypeList			cDlgTypeList;
 	CDlgTypeList::SResult	sResult;
@@ -189,20 +189,20 @@ void CViewCommander::Command_CHANGETYPE( int nTypePlusOne )
 }
 
 /* タイプ別設定 */
-void CViewCommander::Command_OPTION_TYPE( void )
+void CViewCommander::Command_OPTION_TYPE( )
 {
 	CEditApp::getInstance()->OpenPropertySheetTypes( -1, GetDocument()->m_cDocType.GetDocumentType() );
 }
 
 /* 共通設定 */
-void CViewCommander::Command_OPTION( void )
+void CViewCommander::Command_OPTION( )
 {
 	/* 設定プロパティシート テスト用 */
 	CEditApp::getInstance()->OpenPropertySheet( -1 );
 }
 
 /* フォント設定 */
-void CViewCommander::Command_FONT( void )
+void CViewCommander::Command_FONT( )
 {
 	HWND	hwndFrame;
 	hwndFrame = GetMainWindow();
@@ -374,7 +374,7 @@ void CViewCommander::Command_SETFONTSIZE( int fontSize, int shift, int mode )
 	@note 変更する順序を変更したときはCEditWnd::InitMenu()も変更すること
 	@sa CEditWnd::InitMenu()
 */
-void CViewCommander::Command_WRAPWINDOWWIDTH( void )	//	Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH を WRAPWINDOWWIDTH に変更
+void CViewCommander::Command_WRAPWINDOWWIDTH( )	//	Oct. 7, 2000 JEPRO WRAPWINDIWWIDTH を WRAPWINDOWWIDTH に変更
 {
 	// Jan. 8, 2006 genta 判定処理をm_pCommanderView->GetWrapMode()へ移動
 	CEditView::TOGGLE_WRAP_ACTION nWrapMode;
@@ -405,7 +405,7 @@ void CViewCommander::Command_WRAPWINDOWWIDTH( void )	//	Oct. 7, 2000 JEPRO WRAPW
 	@author	MIK
 	@date	2003/04/07
 */
-void CViewCommander::Command_Favorite( void )
+void CViewCommander::Command_Favorite( )
 {
 	CDlgFavorite	cDlgFavorite;
 

--- a/sakura_core/cmd/CViewCommander_Support.cpp
+++ b/sakura_core/cmd/CViewCommander_Support.cpp
@@ -47,7 +47,7 @@
 	@date 2000/09/15 JEPRO [Esc]キーと[x]ボタンでも中止できるように変更
 	@date 2005/01/10 genta CEditView_Commandから移動
 */
-void CViewCommander::Command_HOKAN( void )
+void CViewCommander::Command_HOKAN( )
 {
 #if 0
 // 2011.06.24 Moca Plugin導入に従い未設定の確認をやめる
@@ -101,21 +101,21 @@ void CViewCommander::Command_ToggleKeySearch( int option )
 }
 
 /* ヘルプ目次 */
-void CViewCommander::Command_HELP_CONTENTS( void )
+void CViewCommander::Command_HELP_CONTENTS( )
 {
 	ShowWinHelpContents( m_pCommanderView->GetHwnd() );	//	目次を表示する
 	return;
 }
 
 /* ヘルプキーワード検索 */
-void CViewCommander::Command_HELP_SEARCH( void )
+void CViewCommander::Command_HELP_SEARCH( )
 {
 	MyWinHelp( m_pCommanderView->GetHwnd(), HELP_KEY, (ULONG_PTR)L"" );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 	return;
 }
 
 /* コマンド一覧 */
-void CViewCommander::Command_MENU_ALLFUNC( void )
+void CViewCommander::Command_MENU_ALLFUNC( )
 {
 	UINT	uFlags;
 	POINT	po;
@@ -193,7 +193,7 @@ void CViewCommander::Command_MENU_ALLFUNC( void )
 /* 外部ヘルプ１
 	@date 2012.09.26 Moca HTMLHELP対応
 */
-void CViewCommander::Command_EXTHELP1( void )
+void CViewCommander::Command_EXTHELP1( )
 {
 retry:;
 	if( CHelpManager().ExtWinHelpIsSet( &(GetDocument()->m_cDocType.GetDocumentAttribute()) ) == false){
@@ -358,7 +358,7 @@ void CViewCommander::Command_EXTHTMLHELP( const WCHAR* _helpfile, const WCHAR* k
 }
 
 /* バージョン情報 */
-void CViewCommander::Command_ABOUT( void )
+void CViewCommander::Command_ABOUT( )
 {
 	CDlgAbout cDlgAbout;
 	cDlgAbout.DoModal( G_AppInstance(), m_pCommanderView->GetHwnd() );

--- a/sakura_core/cmd/CViewCommander_TagJump.cpp
+++ b/sakura_core/cmd/CViewCommander_TagJump.cpp
@@ -474,7 +474,7 @@ bool CViewCommander::Command_TagJumpNoMessage( bool bClose )
 }
 
 /* タグジャンプバック */
-void CViewCommander::Command_TAGJUMPBACK( void )
+void CViewCommander::Command_TAGJUMPBACK( )
 {
 // 2004/06/21 novice タグジャンプ機能追加
 	TagJump tagJump;
@@ -505,7 +505,7 @@ void CViewCommander::Command_TAGJUMPBACK( void )
 	@date	2003.05.12	ダイアログ表示でフォルダー等を細かく指定できるようにした。
 	@date 2008.05.05 novice GetModuleHandle(NULL)→NULLに変更
 */
-bool CViewCommander::Command_TagsMake( void )
+bool CViewCommander::Command_TagsMake( )
 {
 #define	CTAGS_COMMAND	L"ctags.exe"
 

--- a/sakura_core/cmd/CViewCommander_Window.cpp
+++ b/sakura_core/cmd/CViewCommander_Window.cpp
@@ -32,28 +32,28 @@
 #include "config/system_constants.h"
 
 /* 上下に分割 */	//Sept. 17, 2000 jepro 説明の「縦」を「上下に」に変更
-void CViewCommander::Command_SPLIT_V( void )
+void CViewCommander::Command_SPLIT_V( )
 {
 	GetEditWindow()->m_cSplitterWnd.VSplitOnOff();
 	return;
 }
 
 /* 左右に分割 */	//Sept. 17, 2000 jepro 説明の「横」を「左右に」に変更
-void CViewCommander::Command_SPLIT_H( void )
+void CViewCommander::Command_SPLIT_H( )
 {
 	GetEditWindow()->m_cSplitterWnd.HSplitOnOff();
 	return;
 }
 
 /* 縦横に分割 */	//Sept. 17, 2000 jepro 説明に「に」を追加
-void CViewCommander::Command_SPLIT_VH( void )
+void CViewCommander::Command_SPLIT_VH( )
 {
 	GetEditWindow()->m_cSplitterWnd.VHSplitOnOff();
 	return;
 }
 
 /* ウィンドウを閉じる */
-void CViewCommander::Command_WINCLOSE( void )
+void CViewCommander::Command_WINCLOSE( )
 {
 	/* 閉じる */
 	::PostMessage( GetMainWindow(), MYWM_CLOSE, 0, 								// 2007.02.13 ryoji WM_CLOSE→MYWM_CLOSEに変更
@@ -62,7 +62,7 @@ void CViewCommander::Command_WINCLOSE( void )
 }
 
 /* すべてのウィンドウを閉じる */	//Oct. 7, 2000 jepro 「編集ウィンドウの全終了」という説明を左記のように変更
-void CViewCommander::Command_FILECLOSEALL( void )
+void CViewCommander::Command_FILECLOSEALL( )
 {
 	int nGroup = CAppNodeManager::getInstance()->GetEditNode( GetMainWindow() )->GetGroup();
 	CControlTray::CloseAllEditor( TRUE, GetMainWindow(), FALSE, nGroup );	// 2006.12.25, 2007.02.13 ryoji 引数追加
@@ -71,7 +71,7 @@ void CViewCommander::Command_FILECLOSEALL( void )
 
 /* このタブ以外を閉じる */	// 2008.11.22 syat
 // 2009.12.26 syat このウィンドウ以外を閉じるとの兼用化
-void CViewCommander::Command_TAB_CLOSEOTHER( void )
+void CViewCommander::Command_TAB_CLOSEOTHER( )
 {
 	int nGroup = 0;
 
@@ -107,7 +107,7 @@ void CViewCommander::Command_WINLIST( int nCommandFrom )
 
 /*! ウィンドウ一覧表示
 */
-void CViewCommander::Command_DLGWINLIST( void )
+void CViewCommander::Command_DLGWINLIST( )
 {
 	DWORD dwPid;
 	HWND hwnd = GetDllShareData().m_sHandles.m_hwndTray;
@@ -126,7 +126,7 @@ void CViewCommander::Command_DLGWINLIST( void )
 	@date 2004.03.20 genta Z-Orderの上から順に並べていくように．(SetWindowPosを利用)
 	@date 2007.06.20 ryoji タブモードは解除せずグループ単位で並べる
 */
-void CViewCommander::Command_CASCADE( void )
+void CViewCommander::Command_CASCADE( )
 {
 	int i;
 
@@ -266,7 +266,7 @@ void CViewCommander::Command_CASCADE( void )
 }
 
 //上下に並べて表示
-void CViewCommander::Command_TILE_V( void )
+void CViewCommander::Command_TILE_V( )
 {
 	int i;
 
@@ -325,7 +325,7 @@ void CViewCommander::Command_TILE_V( void )
 }
 
 //左右に並べて表示
-void CViewCommander::Command_TILE_H( void )
+void CViewCommander::Command_TILE_H( )
 {
 	int i;
 
@@ -400,7 +400,7 @@ void CViewCommander::Command_WINTOPMOST( LPARAM lparam )
 	@date 2004.07.14 Kazika 新規作成
 	@date 2007.06.20 ryoji GetDllShareData().m_TabWndWndplの廃止，グループIDリセット
 */
-void CViewCommander::Command_BIND_WINDOW( void )
+void CViewCommander::Command_BIND_WINDOW( )
 {
 	//タブモードであるならば
 	if (GetDllShareData().m_Common.m_sTabBar.m_bDispTabWnd)
@@ -430,7 +430,7 @@ void CViewCommander::Command_BIND_WINDOW( void )
 //End 2004.07.14 Kazika
 
 /* グループを閉じる */	// 2007.06.20 ryoji 追加
-void CViewCommander::Command_GROUPCLOSE( void )
+void CViewCommander::Command_GROUPCLOSE( )
 {
 	if( GetDllShareData().m_Common.m_sTabBar.m_bDispTabWnd && !GetDllShareData().m_Common.m_sTabBar.m_bDispTabWndMultiWin ){
 		int nGroup = CAppNodeManager::getInstance()->GetEditNode( GetMainWindow() )->GetGroup();
@@ -440,7 +440,7 @@ void CViewCommander::Command_GROUPCLOSE( void )
 }
 
 /* 次のグループ */			// 2007.06.20 ryoji
-void CViewCommander::Command_NEXTGROUP( void )
+void CViewCommander::Command_NEXTGROUP( )
 {
 	CTabWnd* pcTabWnd = &GetEditWindow()->m_cTabWnd;
 	if( pcTabWnd->GetHwnd() == nullptr )
@@ -449,7 +449,7 @@ void CViewCommander::Command_NEXTGROUP( void )
 }
 
 /* 前のグループ */			// 2007.06.20 ryoji
-void CViewCommander::Command_PREVGROUP( void )
+void CViewCommander::Command_PREVGROUP( )
 {
 	CTabWnd* pcTabWnd = &GetEditWindow()->m_cTabWnd;
 	if( pcTabWnd->GetHwnd() == nullptr )
@@ -458,7 +458,7 @@ void CViewCommander::Command_PREVGROUP( void )
 }
 
 /* タブを右に移動 */		// 2007.06.20 ryoji
-void CViewCommander::Command_TAB_MOVERIGHT( void )
+void CViewCommander::Command_TAB_MOVERIGHT( )
 {
 	CTabWnd* pcTabWnd = &GetEditWindow()->m_cTabWnd;
 	if( pcTabWnd->GetHwnd() == nullptr )
@@ -467,7 +467,7 @@ void CViewCommander::Command_TAB_MOVERIGHT( void )
 }
 
 /* タブを左に移動 */		// 2007.06.20 ryoji
-void CViewCommander::Command_TAB_MOVELEFT( void )
+void CViewCommander::Command_TAB_MOVELEFT( )
 {
 	CTabWnd* pcTabWnd = &GetEditWindow()->m_cTabWnd;
 	if( pcTabWnd->GetHwnd() == nullptr )
@@ -476,7 +476,7 @@ void CViewCommander::Command_TAB_MOVELEFT( void )
 }
 
 /* 新規グループ */			// 2007.06.20 ryoji
-void CViewCommander::Command_TAB_SEPARATE( void )
+void CViewCommander::Command_TAB_SEPARATE( )
 {
 	CTabWnd* pcTabWnd = &GetEditWindow()->m_cTabWnd;
 	if( pcTabWnd->GetHwnd() == nullptr )
@@ -485,7 +485,7 @@ void CViewCommander::Command_TAB_SEPARATE( void )
 }
 
 /* 次のグループに移動 */	// 2007.06.20 ryoji
-void CViewCommander::Command_TAB_JOINTNEXT( void )
+void CViewCommander::Command_TAB_JOINTNEXT( )
 {
 	CTabWnd* pcTabWnd = &GetEditWindow()->m_cTabWnd;
 	if( pcTabWnd->GetHwnd() == nullptr )
@@ -494,7 +494,7 @@ void CViewCommander::Command_TAB_JOINTNEXT( void )
 }
 
 /* 前のグループに移動 */	// 2007.06.20 ryoji
-void CViewCommander::Command_TAB_JOINTPREV( void )
+void CViewCommander::Command_TAB_JOINTPREV( )
 {
 	CTabWnd* pcTabWnd = &GetEditWindow()->m_cTabWnd;
 	if( pcTabWnd->GetHwnd() == nullptr )
@@ -503,7 +503,7 @@ void CViewCommander::Command_TAB_JOINTPREV( void )
 }
 
 /* 左をすべて閉じる */		// 2008.11.22 syat
-void CViewCommander::Command_TAB_CLOSELEFT( void )
+void CViewCommander::Command_TAB_CLOSELEFT( )
 {
 	if( GetDllShareData().m_Common.m_sTabBar.m_bDispTabWnd ){
 		int nGroup = 0;
@@ -532,7 +532,7 @@ void CViewCommander::Command_TAB_CLOSELEFT( void )
 }
 
 /* 右をすべて閉じる */		// 2008.11.22 syat
-void CViewCommander::Command_TAB_CLOSERIGHT( void )
+void CViewCommander::Command_TAB_CLOSERIGHT( )
 {
 	if( GetDllShareData().m_Common.m_sTabBar.m_bDispTabWnd ){
 		int nGroup = 0;
@@ -561,7 +561,7 @@ void CViewCommander::Command_TAB_CLOSERIGHT( void )
 }
 
 //縦方向に最大化
-void CViewCommander::Command_MAXIMIZE_V( void )
+void CViewCommander::Command_MAXIMIZE_V( )
 {
 	HWND	hwndFrame;
 	RECT	rcOrg;
@@ -581,7 +581,7 @@ void CViewCommander::Command_MAXIMIZE_V( void )
 
 //2001.02.10 Start by MIK: 横方向に最大化
 //横方向に最大化
-void CViewCommander::Command_MAXIMIZE_H( void )
+void CViewCommander::Command_MAXIMIZE_H( )
 {
 	HWND	hwndFrame;
 	RECT	rcOrg;
@@ -602,7 +602,7 @@ void CViewCommander::Command_MAXIMIZE_H( void )
 //2001.02.10 End: 横方向に最大化
 
 /* すべて最小化 */	//	Sept. 17, 2000 jepro 説明の「全て」を「すべて」に統一
-void CViewCommander::Command_MINIMIZE_ALL( void )
+void CViewCommander::Command_MINIMIZE_ALL( )
 {
 	HWND*	phWndArr;
 	int		i;
@@ -627,7 +627,7 @@ void CViewCommander::Command_MINIMIZE_ALL( void )
 }
 
 /* 再描画 */
-void CViewCommander::Command_REDRAW( void )
+void CViewCommander::Command_REDRAW( )
 {
 	/* フォーカス移動時の再描画 */
 	m_pCommanderView->RedrawAll();
@@ -635,7 +635,7 @@ void CViewCommander::Command_REDRAW( void )
 }
 
 //アウトプットウィンドウ表示
-void CViewCommander::Command_WIN_OUTPUT( void )
+void CViewCommander::Command_WIN_OUTPUT( )
 {
 	// 2010.05.11 Moca CShareData::OpenDebugWindow()に統合
 	// メッセージ表示ウィンドウをViewから親に変更

--- a/sakura_core/config/app_constants.h
+++ b/sakura_core/config/app_constants.h
@@ -15,7 +15,7 @@
 //                           名前                              //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-LPCWSTR GetAppName( void );
+LPCWSTR GetAppName( );
 
 #define GSTR_APPNAME_W  GetAppName()		//!< アプリ名の文字列
 #define GSTR_APPNAME    GSTR_APPNAME_W

--- a/sakura_core/dlg/CDialog.cpp
+++ b/sakura_core/dlg/CDialog.cpp
@@ -300,7 +300,7 @@ void CDialog::SetDialogPosSize()
 	}
 }
 
-BOOL CDialog::OnDestroy( void )
+BOOL CDialog::OnDestroy( )
 {
 	/* ウィンドウ位置・サイズを記憶 */
 	WINDOWPLACEMENT cWindowPlacement;
@@ -387,7 +387,7 @@ BOOL CDialog::OnMove( [[maybe_unused]] WPARAM wParam, [[maybe_unused]] LPARAM lP
 	return TRUE;
 }
 
-void CDialog::CreateSizeBox( void )
+void CDialog::CreateSizeBox( )
 {
 	/* サイズボックス */
 	m_hwndSizeBox = ::CreateWindowEx(
@@ -520,7 +520,7 @@ const DWORD p_helpids[] = {
 	0, 0
 };
 
-LPVOID CDialog::GetHelpIdTable(void)
+LPVOID CDialog::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -85,7 +85,7 @@ public:
 
 	virtual BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam);
 	virtual void SetDialogPosSize();
-	virtual BOOL OnDestroy( void );
+	virtual BOOL OnDestroy( );
 	virtual BOOL OnNotify([[maybe_unused]] NMHDR* pNMHDR) { return FALSE; }
 	BOOL OnSize();
 	virtual BOOL OnSize( WPARAM wParam, LPARAM lParam );
@@ -94,8 +94,8 @@ public:
 	virtual BOOL OnTimer( [[maybe_unused]] HWND hwnd, [[maybe_unused]] UINT uMsg, [[maybe_unused]] WPARAM wParam, [[maybe_unused]] LPARAM lParam ) { return TRUE; }
 	virtual BOOL OnKeyDown( [[maybe_unused]] WPARAM wParam, [[maybe_unused]] LPARAM lParam ) { return TRUE; }
 	virtual BOOL OnDeviceChange( [[maybe_unused]] WPARAM wParam, [[maybe_unused]] LPARAM lParam ) { return TRUE; }
-	virtual int GetData( void ){return 1;}/* ダイアログデータの取得 */
-	virtual void SetData( void ){return;}/* ダイアログデータの設定 */
+	virtual int GetData( ){return 1;}/* ダイアログデータの取得 */
+	virtual void SetData( ){return;}/* ダイアログデータの設定 */
 	virtual BOOL OnBnClicked(int wID);
 	virtual BOOL OnStnClicked( [[maybe_unused]] int wID ) { return FALSE; }
 	virtual BOOL OnEnChange( [[maybe_unused]] HWND hwndCtl, [[maybe_unused]] int wID )     { return FALSE; }
@@ -115,7 +115,7 @@ public:
 	virtual LRESULT OnCharToItem( [[maybe_unused]] WPARAM wParam, [[maybe_unused]] LPARAM lParam ) { return -1; }
 	virtual BOOL OnPopupHelp(WPARAM wPara, LPARAM lParam);	//@@@ 2002.01.18 add
 	virtual BOOL OnContextMenu(WPARAM wPara, LPARAM lParam);	//@@@ 2002.01.18 add
-	virtual LPVOID GetHelpIdTable(void);	//@@@ 2002.01.18 add
+	virtual LPVOID GetHelpIdTable();	//@@@ 2002.01.18 add
 
 	void ResizeItem( HWND hTarget, const POINT& ptDlgDefalut, const POINT& ptDlgNew, const RECT& rcItemDefault, EAnchorStyle anchor, bool bUpdate = true);
 	void GetItemClientRect( int wID, RECT& rc );
@@ -156,7 +156,7 @@ protected:
 	int				m_nHeight = -1;
 	int				m_xPos = -1;
 	int				m_yPos = -1;
-	void CreateSizeBox( void );
+	void CreateSizeBox( );
 	BOOL OnCommand(WPARAM wParam, LPARAM lParam);
 
 	HWND GetItemHwnd(int nID){ return ::GetDlgItem( GetHwnd(), nID ); }

--- a/sakura_core/dlg/CDlgAbout.cpp
+++ b/sakura_core/dlg/CDlgAbout.cpp
@@ -331,7 +331,7 @@ BOOL CDlgAbout::OnStnClicked( int wID )
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgAbout::GetHelpIdTable(void)
+LPVOID CDlgAbout::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgAbout.h
+++ b/sakura_core/dlg/CDlgAbout.h
@@ -55,7 +55,7 @@ protected:
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnBnClicked(int wID) override;
 	BOOL OnStnClicked(int wID) override;
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 private:
 	CUrlWnd m_UrlUrWnd;
 	CUrlWnd m_UrlGitWnd;

--- a/sakura_core/dlg/CDlgCancel.cpp
+++ b/sakura_core/dlg/CDlgCancel.cpp
@@ -51,7 +51,7 @@ INT_PTR CDlgCancel::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM l
 /** 自動破棄を遅延実行する
 	@date 2008.05.28 ryoji 新規作成
 */
-void CDlgCancel::DeleteAsync( void )
+void CDlgCancel::DeleteAsync( )
 {
 	m_bAutoCleanup = true;
 	::PostMessageAny( GetHwnd(), WM_CLOSE, 0, 0 );
@@ -104,7 +104,7 @@ const DWORD p_helpids[] = {
 	0, 0
 };
 
-LPVOID CDlgCancel::GetHelpIdTable(void)
+LPVOID CDlgCancel::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgCancel.h
+++ b/sakura_core/dlg/CDlgCancel.h
@@ -42,9 +42,9 @@ public:
 
 //	HWND Open( LPCWSTR );
 //	void Close( void );	/* モードレスダイアログの削除 */
-	BOOL IsCanceled( void ){ return m_bCANCEL; } /* IDCANCELボタンが押されたか？ */
+	BOOL IsCanceled( ){ return m_bCANCEL; } /* IDCANCELボタンが押されたか？ */
 	INT_PTR DispatchEvent(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam) override;	/* ダイアログのメッセージ処理 *//* BOOL->INT_PTR 2008/7/18 Uchi*/
-	void DeleteAsync( void );	/* 自動破棄を遅延実行する */	// 2008.05.28 ryoji
+	void DeleteAsync( );	/* 自動破棄を遅延実行する */	// 2008.05.28 ryoji
 
 //	HINSTANCE	m_hInstance;	/* アプリケーションインスタンスのハンドル */
 //	HWND		m_hwndParent;	/* オーナーウィンドウのハンドル */
@@ -58,6 +58,6 @@ protected:
 	*/
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnBnClicked(int wID) override;
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 };
 #endif /* SAKURA_CDLGCANCEL_D62561A1_41F6_4904_99B0_18EE33734269_H_ */

--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -126,7 +126,7 @@ BOOL CDlgCompare::OnBnClicked( int wID )
 }
 
 /* ダイアログデータの設定 */
-void CDlgCompare::SetData( void )
+void CDlgCompare::SetData( )
 {
 	HWND			hwndList;
 	int				nRowNum;
@@ -203,7 +203,7 @@ void CDlgCompare::SetData( void )
 
 /* ダイアログデータの取得 */
 /* TRUE==正常  FALSE==入力エラー */
-int CDlgCompare::GetData( void )
+int CDlgCompare::GetData( )
 {
 	HWND			hwndList;
 	int				nItem;
@@ -222,7 +222,7 @@ int CDlgCompare::GetData( void )
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgCompare::GetHelpIdTable(void)
+LPVOID CDlgCompare::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }
@@ -267,7 +267,7 @@ BOOL CDlgCompare::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 }
 
-BOOL CDlgCompare::OnDestroy( void )
+BOOL CDlgCompare::OnDestroy( )
 {
 	CDialog::OnDestroy();
 	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcCompareDialog;

--- a/sakura_core/dlg/CDlgCompare.h
+++ b/sakura_core/dlg/CDlgCompare.h
@@ -45,16 +45,16 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	BOOL OnBnClicked(int wID) override;
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
-	BOOL OnDestroy( void ) override;
+	BOOL OnDestroy( ) override;
 	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
 
-	void SetData( void ) override;	/* ダイアログデータの設定 */
-	int GetData( void ) override;	/* ダイアログデータの取得 */
+	void SetData( ) override;	/* ダイアログデータの設定 */
+	int GetData( ) override;	/* ダイアログデータの取得 */
 
 private:
 	POINT			m_ptDefaultSize;

--- a/sakura_core/dlg/CDlgCtrlCode.cpp
+++ b/sakura_core/dlg/CDlgCtrlCode.cpp
@@ -95,7 +95,7 @@ int CDlgCtrlCode::DoModal(
 }
 
 /* ダイアログデータの設定 */
-void CDlgCtrlCode::SetData( void )
+void CDlgCtrlCode::SetData( )
 {
 	HWND	hwndWork;
 	int		i, count;
@@ -165,7 +165,7 @@ void CDlgCtrlCode::SetData( void )
 
 /* ダイアログデータの取得 */
 /* TRUE==正常  FALSE==入力エラー */
-int CDlgCtrlCode::GetData( void )
+int CDlgCtrlCode::GetData( )
 {
 	int		nIndex;
 	HWND	hwndList;
@@ -299,7 +299,7 @@ BOOL CDlgCtrlCode::OnNotify( NMHDR* pNMHDR )
 	return CDialog::OnNotify(pNMHDR);
 }
 
-LPVOID CDlgCtrlCode::GetHelpIdTable( void )
+LPVOID CDlgCtrlCode::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgCtrlCode.h
+++ b/sakura_core/dlg/CDlgCtrlCode.h
@@ -44,10 +44,10 @@ private:
 	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL	OnBnClicked(int wID) override;
 	BOOL	OnNotify(NMHDR* pNMHDR) override;
-	LPVOID	GetHelpIdTable( void ) override;
+	LPVOID	GetHelpIdTable( ) override;
 
-	void	SetData( void ) override;	/* ダイアログデータの設定 */
-	int		GetData( void ) override;	/* ダイアログデータの取得 */
+	void	SetData( ) override;	/* ダイアログデータの設定 */
+	int		GetData( ) override;	/* ダイアログデータの取得 */
 
 private:
 	/*

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -195,7 +195,7 @@ BOOL CDlgDiff::OnBnClicked( int wID )
 }
 
 /* ダイアログデータの設定 */
-void CDlgDiff::SetData( void )
+void CDlgDiff::SetData( )
 {
 	//オプション
 	m_nDiffFlgOpt = m_pShareData->m_nDiffFlgOpt;
@@ -339,7 +339,7 @@ void CDlgDiff::SetData( void )
 
 /* ダイアログデータの取得 */
 /* TRUE==正常  FALSE==入力エラー */
-int CDlgDiff::GetData( void )
+int CDlgDiff::GetData( )
 {
 	BOOL	ret = TRUE;
 
@@ -458,7 +458,7 @@ BOOL CDlgDiff::OnEnChange( HWND hwndCtl, int wID )
 	return CDialog::OnEnChange( hwndCtl, wID );
 }
 
-LPVOID CDlgDiff::GetHelpIdTable( void )
+LPVOID CDlgDiff::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }
@@ -510,7 +510,7 @@ BOOL CDlgDiff::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 }
 
-BOOL CDlgDiff::OnDestroy( void )
+BOOL CDlgDiff::OnDestroy( )
 {
 	CDialog::OnDestroy();
 	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcDiffDialog;

--- a/sakura_core/dlg/CDlgDiff.h
+++ b/sakura_core/dlg/CDlgDiff.h
@@ -47,15 +47,15 @@ protected:
 	BOOL	OnLbnSelChange( HWND hwndCtl, int wID ) override;
 	BOOL	OnLbnDblclk( int wID ) override;
 	BOOL	OnEnChange( HWND hwndCtl, int wID ) override;
-	LPVOID	GetHelpIdTable(void) override;
+	LPVOID	GetHelpIdTable() override;
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
-	BOOL OnDestroy( void ) override;
+	BOOL OnDestroy( ) override;
 	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
 
-	void	SetData( void ) override;	/* ダイアログデータの設定 */
-	int		GetData( void ) override;	/* ダイアログデータの取得 */
+	void	SetData( ) override;	/* ダイアログデータの設定 */
+	int		GetData( ) override;	/* ダイアログデータの取得 */
 
 private:
 	int			m_nIndexSave = 0;		// 最後に選択されていた番号

--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -90,7 +90,7 @@ BOOL CDlgExec::OnInitDialog( HWND hwnd, WPARAM wParam, LPARAM lParam )
 }
 
 /* ダイアログデータの設定 */
-void CDlgExec::SetData( void )
+void CDlgExec::SetData( )
 {
 //	MYTRACE( L"CDlgExec::SetData()" );
 	int		i;
@@ -177,7 +177,7 @@ void CDlgExec::SetData( void )
 }
 
 /* ダイアログデータの取得 */
-int CDlgExec::GetData( void )
+int CDlgExec::GetData( )
 {
 	ApiWrap::DlgItem_GetText( GetHwnd(), IDC_COMBO_m_szCommand, m_szCommand, int(std::size(m_szCommand)));
 	if( IsDlgButtonCheckedBool( GetHwnd(), IDC_CHECK_CUR_DIR ) ){
@@ -280,7 +280,7 @@ BOOL CDlgExec::OnBnClicked( int wID )
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgExec::GetHelpIdTable(void)
+LPVOID CDlgExec::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgExec.h
+++ b/sakura_core/dlg/CDlgExec.h
@@ -43,10 +43,10 @@ protected:
 	CRecentCmd m_cRecentCmd;
 	CRecentCurDir m_cRecentCur;
 
-	int GetData( void ) override;	/* ダイアログデータの取得 */
-	void SetData( void ) override;	/* ダイアログデータの設定 */
+	int GetData( ) override;	/* ダイアログデータの取得 */
+	void SetData( ) override;	/* ダイアログデータの設定 */
 	BOOL OnInitDialog(HWND hwnd, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnBnClicked(int wID) override;
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 };
 #endif /* SAKURA_CDLGEXEC_4A4BE162_D6C9_4E28_B1AC_091DFFE7DD72_H_ */

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -239,7 +239,7 @@ int CDlgFavorite::DoModal(
 }
 
 /* ダイアログデータの設定 */
-void CDlgFavorite::SetData( void )
+void CDlgFavorite::SetData( )
 {
 	int		nTab;
 
@@ -329,7 +329,7 @@ void CDlgFavorite::SetDataOne( int nIndex, int nLvItemIndex )
 	
 	@retval TRUE 正常(今のところFALSEは返さない)
 */
-int CDlgFavorite::GetData( void )
+int CDlgFavorite::GetData( )
 {
 	int		nTab;
 
@@ -467,7 +467,7 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return CDialog::OnInitDialog( GetHwnd(), wParam, lParam );
 }
 
-BOOL CDlgFavorite::OnDestroy( void )
+BOOL CDlgFavorite::OnDestroy( )
 {
 	CDialog::OnDestroy();
 	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcFavoriteDialog;
@@ -728,7 +728,7 @@ BOOL CDlgFavorite::OnActivate( WPARAM wParam, LPARAM lParam )
 	return CDialog::OnActivate( wParam, lParam );
 }
 
-LPVOID CDlgFavorite::GetHelpIdTable( void )
+LPVOID CDlgFavorite::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }
@@ -736,7 +736,7 @@ LPVOID CDlgFavorite::GetHelpIdTable( void )
 /*
 	リストを更新する。
 */
-bool CDlgFavorite::RefreshList( void )
+bool CDlgFavorite::RefreshList( )
 {
 	int		nTab;
 	bool	bret;

--- a/sakura_core/dlg/CDlgFavorite.h
+++ b/sakura_core/dlg/CDlgFavorite.h
@@ -48,20 +48,20 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
-	BOOL	OnDestroy( void ) override;
+	BOOL	OnDestroy( ) override;
 	BOOL	OnBnClicked(int wID) override;
 	BOOL	OnNotify(NMHDR* pNMHDR) override;
 	BOOL	OnActivate( WPARAM wParam, LPARAM lParam ) override;
-	LPVOID	GetHelpIdTable( void ) override;
+	LPVOID	GetHelpIdTable( ) override;
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 標準以外のメッセージを捕捉する
 	BOOL	OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnMinMaxInfo( LPARAM lParam );
 
-	void	SetData( void ) override;	/* ダイアログデータの設定 */
-	int		GetData( void ) override;	/* ダイアログデータの取得 */
+	void	SetData( ) override;	/* ダイアログデータの設定 */
+	int		GetData( ) override;	/* ダイアログデータの取得 */
 
 	void	TabSelectChange(bool bSetFocus);
-	bool	RefreshList( void );
+	bool	RefreshList( );
 	void	SetDataOne( int nIndex, int nLvItemIndex );	/* ダイアログデータの設定 */
 	bool	RefreshListOne( int nIndex );
 	//void	ChangeSlider( int nIndex );

--- a/sakura_core/dlg/CDlgFind.cpp
+++ b/sakura_core/dlg/CDlgFind.cpp
@@ -112,7 +112,7 @@ BOOL CDlgFind::OnDestroy()
 }
 
 /* ダイアログデータの設定 */
-void CDlgFind::SetData( void )
+void CDlgFind::SetData( )
 {
 //	MYTRACE( L"CDlgFind::SetData()" );
 
@@ -177,7 +177,7 @@ void CDlgFind::SetData( void )
 
 // 検索文字列リストの設定
 //	2010/5/28 Uchi
-void CDlgFind::SetCombosList( void )
+void CDlgFind::SetCombosList( )
 {
 	HWND	hwndCombo;
 
@@ -193,7 +193,7 @@ void CDlgFind::SetCombosList( void )
 }
 
 /* ダイアログデータの取得 */
-int CDlgFind::GetData( void )
+int CDlgFind::GetData( )
 {
 //	MYTRACE( L"CDlgFind::GetData()" );
 
@@ -401,7 +401,7 @@ BOOL CDlgFind::OnActivate( WPARAM wParam, LPARAM lParam )
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgFind::GetHelpIdTable(void)
+LPVOID CDlgFind::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgFind.h
+++ b/sakura_core/dlg/CDlgFind.h
@@ -52,15 +52,15 @@ protected:
 //@@@ 2002.2.2 YAZAKI CShareDataに移動
 //	void AddToSearchKeyArr( const char* );
 	BOOL OnCbnDropDown( HWND hwndCtl, int wID ) override;
-	int GetData( void ) override;		/* ダイアログデータの取得 */
-	void SetCombosList( void );	/* 検索文字列/置換後文字列リストの設定 */
-	void SetData( void ) override;		/* ダイアログデータの設定 */
+	int GetData( ) override;		/* ダイアログデータの取得 */
+	void SetCombosList( );	/* 検索文字列/置換後文字列リストの設定 */
+	void SetData( ) override;		/* ダイアログデータの設定 */
 	BOOL OnInitDialog(HWND hwnd, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnDestroy() override;
 	BOOL OnBnClicked(int wID) override;
 	BOOL OnActivate( WPARAM wParam, LPARAM lParam ) override;	// 2009.11.29 ryoji
 
 	// BOOL OnKeyDown( WPARAM wParam, LPARAM lParam ) override;
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 };
 #endif /* SAKURA_CDLGFIND_AF260AA4_6075_4B87_9F03_2CEEDAD64094_H_ */

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -595,7 +595,7 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 }
 
 /* ダイアログデータの設定 */
-void CDlgGrep::SetData( void )
+void CDlgGrep::SetData( )
 {
 	/* 検索文字列 */
 	ApiWrap::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_strText.c_str() );
@@ -765,7 +765,7 @@ void CDlgGrep::SetDataFromThisText( bool bChecked )
 	@retval TRUE  正常
 	@retval FALSE 入力エラー
 */
-int CDlgGrep::GetData( void )
+int CDlgGrep::GetData( )
 {
 	/* サブフォルダーからも検索する*/
 	m_bSubFolder = ::IsDlgButtonChecked( GetHwnd(), IDC_CHK_SUBFOLDER );
@@ -960,7 +960,7 @@ int CDlgGrep::GetData( void )
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgGrep::GetHelpIdTable(void)
+LPVOID CDlgGrep::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -80,10 +80,10 @@ protected:
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnDestroy() override;
 	BOOL OnBnClicked(int wID) override;
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 
-	void SetData( void ) override;	/* ダイアログデータの設定 */
-	int GetData( void ) override;	/* ダイアログデータの取得 */
+	void SetData( ) override;	/* ダイアログデータの設定 */
+	int GetData( ) override;	/* ダイアログデータの取得 */
 	void SetDataFromThisText(bool bChecked);	/* 現在編集中ファイルから検索チェックでの設定 */
 	static LRESULT CALLBACK OnFolderProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
 };

--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -198,7 +198,7 @@ BOOL CDlgGrepReplace::OnBnClicked( int wID )
 }
 
 /* ダイアログデータの設定 */
-void CDlgGrepReplace::SetData( void )
+void CDlgGrepReplace::SetData( )
 {
 	/* 置換後 */
 	ApiWrap::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT2, m_strText2.c_str() );
@@ -214,7 +214,7 @@ void CDlgGrepReplace::SetData( void )
 /*! ダイアログデータの取得
 	TRUE==正常  FALSE==入力エラー
 */
-int CDlgGrepReplace::GetData( void )
+int CDlgGrepReplace::GetData( )
 {
 	m_bPaste = IsDlgButtonCheckedBool( GetHwnd(), IDC_CHK_PASTE );
 
@@ -241,7 +241,7 @@ int CDlgGrepReplace::GetData( void )
 	return TRUE;
 }
 
-LPVOID CDlgGrepReplace::GetHelpIdTable(void)
+LPVOID CDlgGrepReplace::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -53,9 +53,9 @@ protected:
 	BOOL OnCbnDropDown( HWND hwndCtl, int wID ) override;
 	BOOL OnDestroy() override;
 	BOOL OnBnClicked(int wID) override;
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 
-	void SetData( void ) override;	/* ダイアログデータの設定 */
-	int GetData( void ) override;	/* ダイアログデータの取得 */
+	void SetData( ) override;	/* ダイアログデータの設定 */
+	int GetData( ) override;	/* ダイアログデータの取得 */
 };
 #endif /* SAKURA_CDLGGREPREPLACE_D97F4D2D_9963_40FB_91C1_5A6FF0407E99_H_ */

--- a/sakura_core/dlg/CDlgJump.cpp
+++ b/sakura_core/dlg/CDlgJump.cpp
@@ -221,7 +221,7 @@ BOOL CDlgJump::OnEnKillFocus(HWND hwndCtl, int wID)
 }
 
 /* ダイアログデータの設定 */
-void CDlgJump::SetData( void )
+void CDlgJump::SetData( )
 {
 	CEditDoc*		pCEditDoc = (CEditDoc*)m_lParam;
 	CFuncInfoArr	cFuncInfoArr;
@@ -344,7 +344,7 @@ void CDlgJump::SetData( void )
 
 /* ダイアログデータの取得 */
 /*   TRUE==正常   FALSE==入力エラー  */
-int CDlgJump::GetData( void )
+int CDlgJump::GetData( )
 {
 	BOOL	pTranslated;
 
@@ -376,7 +376,7 @@ int CDlgJump::GetData( void )
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgJump::GetHelpIdTable(void)
+LPVOID CDlgJump::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgJump.h
+++ b/sakura_core/dlg/CDlgJump.h
@@ -48,8 +48,8 @@ protected:
 	BOOL OnEnSetFocus(HWND hwndCtl, int wID) override;
 	BOOL OnEnKillFocus(HWND hwndCtl, int wID) override;
 
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
-	void SetData( void ) override;	/* ダイアログデータの設定 */
-	int GetData( void ) override;	/* ダイアログデータの取得 */
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
+	void SetData( ) override;	/* ダイアログデータの設定 */
+	int GetData( ) override;	/* ダイアログデータの取得 */
 };
 #endif /* SAKURA_CDLGJUMP_13AD9DC8_92E0_43AB_81D4_A0FBA28EE2D8_H_ */

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -76,7 +76,7 @@ struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
 	bool DoModalOpenDlg( SLoadInfo* pLoadInfo, std::vector<std::wstring>*, bool bOptions ) override;
 	bool DoModalSaveDlg( SSaveInfo*	pSaveInfo, bool bSimpleMode ) override;
 
-	void DlgOpenFail(void);
+	void DlgOpenFail();
 
 	void InitOfn( OPENFILENAME* ofn );
 
@@ -1054,7 +1054,7 @@ bool CDlgOpenFile_CommonFileDialog::DoModalSaveDlg(
 	@author genta
 	@date 2004.05.29 genta 元々あった部分をまとめた
 */
-void CDlgOpenFile_CommonFileDialog::DlgOpenFail(void)
+void CDlgOpenFile_CommonFileDialog::DlgOpenFail()
 {
 	const WCHAR*	pszError;
 	DWORD dwError = ::CommDlgExtendedError();

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -271,7 +271,7 @@ struct CDlgOpenFile_CommonItemDialog final
 		return m_pFileDialogCustomize->StartVisualGroup(dwIDCtl, pszLabel);
 	}
 	
-	HRESULT STDMETHODCALLTYPE EndVisualGroup(void) {
+	HRESULT STDMETHODCALLTYPE EndVisualGroup() {
 		assert(m_pFileDialogCustomize);
 		return m_pFileDialogCustomize->EndVisualGroup();
 	}

--- a/sakura_core/dlg/CDlgPluginOption.cpp
+++ b/sakura_core/dlg/CDlgPluginOption.cpp
@@ -85,7 +85,7 @@ int CDlgPluginOption::DoModal(
 }
 
 /* ダイアログデータの設定 */
-void CDlgPluginOption::SetData( void )
+void CDlgPluginOption::SetData( )
 {
 	HWND	hwndList;
 	int		i;
@@ -195,7 +195,7 @@ void CDlgPluginOption::SetData( void )
 
 /* ダイアログデータの取得 */
 /* TRUE==正常  FALSE==入力エラー */
-int CDlgPluginOption::GetData( void )
+int CDlgPluginOption::GetData( )
 {
 	// .ini ファイルへの書き込み
 	HWND	hwndList;
@@ -466,12 +466,12 @@ BOOL CDlgPluginOption::OnActivate( WPARAM wParam, LPARAM lParam )
 	return CDialog::OnActivate( wParam, lParam );
 }
 
-LPVOID CDlgPluginOption::GetHelpIdTable( void )
+LPVOID CDlgPluginOption::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }
 
-void CDlgPluginOption::ChangeListPosition( void )
+void CDlgPluginOption::ChangeListPosition( )
 {
 	HWND hwndList = GetItemHwnd( IDC_LIST_PLUGIN_OPTIONS );
 
@@ -506,7 +506,7 @@ void CDlgPluginOption::ChangeListPosition( void )
 	ApiWrap::DlgItem_SetText( GetHwnd(), IDC_EDIT_PLUGIN_OPTION, buf );
 }
 
-void CDlgPluginOption::MoveFocusToEdit( void )
+void CDlgPluginOption::MoveFocusToEdit( )
 {
 	//	現在のFocus取得
 	int		iLine = ListView_GetNextItem( GetItemHwnd( IDC_LIST_PLUGIN_OPTIONS ), -1, LVNI_SELECTED);

--- a/sakura_core/dlg/CDlgPluginOption.h
+++ b/sakura_core/dlg/CDlgPluginOption.h
@@ -58,13 +58,13 @@ protected:
 	BOOL	OnCbnSelChange( HWND hwndCtl, int wID ) override;
 	BOOL	OnEnChange( HWND hwndCtl, int wID ) override;
 	BOOL	OnActivate( WPARAM wParam, LPARAM lParam ) override;
-	LPVOID	GetHelpIdTable( void ) override;
+	LPVOID	GetHelpIdTable( ) override;
 
-	void	SetData( void ) override;	/* ダイアログデータの設定 */
-	int		GetData( void ) override;	/* ダイアログデータの取得 */
+	void	SetData( ) override;	/* ダイアログデータの設定 */
+	int		GetData( ) override;	/* ダイアログデータの取得 */
 
-	void	ChangeListPosition( void );					// 編集領域をリストビューに合せて切替える
-	void	MoveFocusToEdit( void );					// 編集領域にフォーカスを移す
+	void	ChangeListPosition( );					// 編集領域をリストビューに合せて切替える
+	void	MoveFocusToEdit( );					// 編集領域にフォーカスを移す
 	void	SetToEdit(int iLine);
 	void	SetFromEdit(int iLine);
 	void	SelectEdit(int IDCenable);							// 編集領域の切り替え

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -144,7 +144,7 @@ BOOL CDlgPrintSetting::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam 
 	return CDialog::OnInitDialog( GetHwnd(), wParam, lParam );
 }
 
-BOOL CDlgPrintSetting::OnDestroy( void )
+BOOL CDlgPrintSetting::OnDestroy( )
 {
 	::KillTimer( GetHwnd(), IDT_PRINTSETTING );
 
@@ -454,7 +454,7 @@ BOOL CDlgPrintSetting::OnEnKillFocus( HWND hwndCtl, int wID )
 }
 
 /* ダイアログデータの設定 */
-void CDlgPrintSetting::SetData( void )
+void CDlgPrintSetting::SetData( )
 {
 	HDC		hdc;
 	HWND	hwndComboFont;
@@ -508,7 +508,7 @@ void CDlgPrintSetting::SetData( void )
 
 /* ダイアログデータの取得 */
 /* TRUE==正常 FALSE==入力エラー */
-int CDlgPrintSetting::GetData( void )
+int CDlgPrintSetting::GetData( )
 {
 	HWND	hwndCtrl;
 	int		nIdx1;
@@ -880,7 +880,7 @@ void CDlgPrintSetting::UpdatePrintableLineAndColumn()
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgPrintSetting::GetHelpIdTable(void)
+LPVOID CDlgPrintSetting::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgPrintSetting.h
+++ b/sakura_core/dlg/CDlgPrintSetting.h
@@ -45,10 +45,10 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	void SetData( void ) override;	/* ダイアログデータの設定 */
-	int GetData( void ) override;	/* ダイアログデータの取得 */
+	void SetData( ) override;	/* ダイアログデータの設定 */
+	int GetData( ) override;	/* ダイアログデータの取得 */
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
-	BOOL OnDestroy( void ) override;
+	BOOL OnDestroy( ) override;
 	BOOL OnNotify(NMHDR* pNMHDR) override;
 	BOOL OnCbnSelChange(HWND hwndCtl, int wID) override;
 	BOOL OnBnClicked(int wID) override;
@@ -56,7 +56,7 @@ protected:
 	BOOL OnEnChange( HWND hwndCtl, int wID ) override;
 	BOOL OnEnSetFocus(HWND hwndCtl, int wID) override;
 	BOOL OnEnKillFocus( HWND hwndCtl, int wID ) override;
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 
 	void OnChangeSettingType(BOOL bGetData);	/* 設定のタイプが変わった */
 	void OnSpin(int nCtrlId, BOOL bDown);	/* スピンコントロールの処理 */

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -531,7 +531,7 @@ bool CDlgProfileMgr::WriteProfSettings( SProfileSettings& settings )
 	return IOProfSettings( settings, true );
 }
 
-LPVOID CDlgProfileMgr::GetHelpIdTable(void)
+LPVOID CDlgProfileMgr::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgProfileMgr.h
+++ b/sakura_core/dlg/CDlgProfileMgr.h
@@ -53,7 +53,7 @@ protected:
 	void	SetData(int nSelIndex);	/* ダイアログデータの設定 */
 	int		GetData() override;	/* ダイアログデータの取得 */
 	int		GetData(bool bStart);	/* ダイアログデータの取得 */
-	LPVOID	GetHelpIdTable(void) override;
+	LPVOID	GetHelpIdTable() override;
 
 	void	UpdateIni();
 	void	CreateProf();

--- a/sakura_core/dlg/CDlgProperty.cpp
+++ b/sakura_core/dlg/CDlgProperty.cpp
@@ -73,7 +73,7 @@ BOOL CDlgProperty::OnBnClicked( int wID )
 
 	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 */
-void CDlgProperty::SetData( void )
+void CDlgProperty::SetData( )
 {
 	CEditDoc*		pCEditDoc = (CEditDoc*)m_lParam;
 	CNativeW		cmemProp;
@@ -263,7 +263,7 @@ end_of_CodeTest:;
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgProperty::GetHelpIdTable(void)
+LPVOID CDlgProperty::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgProperty.h
+++ b/sakura_core/dlg/CDlgProperty.h
@@ -30,7 +30,7 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	BOOL OnBnClicked(int wID) override;
-	void SetData( void ) override;	/* ダイアログデータの設定 */
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	void SetData( ) override;	/* ダイアログデータの設定 */
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 };
 #endif /* SAKURA_CDLGPROPERTY_FF915918_FBA0_4D89_9A72_5E1409D7F88A_H_ */

--- a/sakura_core/dlg/CDlgReplace.cpp
+++ b/sakura_core/dlg/CDlgReplace.cpp
@@ -121,7 +121,7 @@ void CDlgReplace::ChangeView( LPARAM pcEditView )
 }
 
 /* ダイアログデータの設定 */
-void CDlgReplace::SetData( void )
+void CDlgReplace::SetData( )
 {
 	// 検索文字列/置換後文字列リストの設定(関数化)	2010/5/26 Uchi
 	SetCombosList();
@@ -191,7 +191,7 @@ void CDlgReplace::SetData( void )
 
 // 検索文字列/置換後文字列リストの設定
 //	2010/5/26 Uchi
-void CDlgReplace::SetCombosList( void )
+void CDlgReplace::SetCombosList( )
 {
 	HWND	hwndCombo;
 
@@ -218,7 +218,7 @@ void CDlgReplace::SetCombosList( void )
 
 /* ダイアログデータの取得 */
 /* 0==条件未入力  0より大きい==正常   0より小さい==入力エラー */
-int CDlgReplace::GetData( void )
+int CDlgReplace::GetData( )
 {
 	/* 英大文字と英小文字を区別する */
 	m_sSearchOption.bLoHiCase = (0!=IsDlgButtonChecked( GetHwnd(), IDC_CHK_LOHICASE ));
@@ -611,7 +611,7 @@ BOOL CDlgReplace::OnActivate( WPARAM wParam, LPARAM lParam )
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgReplace::GetHelpIdTable(void)
+LPVOID CDlgReplace::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgReplace.h
+++ b/sakura_core/dlg/CDlgReplace.h
@@ -73,10 +73,10 @@ protected:
 	BOOL OnDestroy() override;
 	BOOL OnBnClicked(int wID) override;
 	BOOL OnActivate( WPARAM wParam, LPARAM lParam ) override;	// 2009.11.29 ryoji
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 
-	void SetData( void ) override;		/* ダイアログデータの設定 */
-	void SetCombosList( void );	/* 検索文字列/置換後文字列リストの設定 */
-	int GetData( void ) override;		/* ダイアログデータの取得 */
+	void SetData( ) override;		/* ダイアログデータの設定 */
+	void SetCombosList( );	/* 検索文字列/置換後文字列リストの設定 */
+	int GetData( ) override;		/* ダイアログデータの取得 */
 };
 #endif /* SAKURA_CDLGREPLACE_37D62C07_5DAB_4CAC_A8B2_83C75329F8B7_H_ */

--- a/sakura_core/dlg/CDlgSetCharSet.cpp
+++ b/sakura_core/dlg/CDlgSetCharSet.cpp
@@ -98,7 +98,7 @@ BOOL CDlgSetCharSet::OnBnClicked( int wID )
 }
 
 // BOM の設定
-void CDlgSetCharSet::SetBOM( void )
+void CDlgSetCharSet::SetBOM( )
 {
 	int 		nIdx;
 	LRESULT		lRes;
@@ -160,13 +160,13 @@ BOOL CDlgSetCharSet::OnCbnSelChange( HWND hwndCtl, int wID )
 	return TRUE;
 }
 
-LPVOID CDlgSetCharSet::GetHelpIdTable(void)
+LPVOID CDlgSetCharSet::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }
 
 /* ダイアログデータの設定 */
-void CDlgSetCharSet::SetData( void )
+void CDlgSetCharSet::SetData( )
 {
 	// 文字コードセット
 	int		nIdx, nCurIdx, nIdxOld;
@@ -197,7 +197,7 @@ void CDlgSetCharSet::SetData( void )
 
 /* ダイアログデータの取得 */
 /* TRUE==正常  FALSE==入力エラー  */
-int CDlgSetCharSet::GetData( void )
+int CDlgSetCharSet::GetData( )
 {
 	// 文字コードセット
 	int		nIdx;

--- a/sakura_core/dlg/CDlgSetCharSet.h
+++ b/sakura_core/dlg/CDlgSetCharSet.h
@@ -46,11 +46,11 @@ protected:
 	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL	OnBnClicked(int wID) override;
 	BOOL	OnCbnSelChange(HWND hwndCtl, int wID) override;
-	LPVOID	GetHelpIdTable( void ) override;
+	LPVOID	GetHelpIdTable( ) override;
 
-	void	SetData( void ) override;	/* ダイアログデータの設定 */
-	int 	GetData( void ) override;	/* ダイアログデータの取得 */
+	void	SetData( ) override;	/* ダイアログデータの設定 */
+	int 	GetData( ) override;	/* ダイアログデータの取得 */
 
-	void	SetBOM( void );		// BOM の設定
+	void	SetBOM( );		// BOM の設定
 };
 #endif /* SAKURA_CDLGSETCHARSET_82E8A81C_64D0_45DE_BECC_4721CCC93FEB_H_ */

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -156,7 +156,7 @@ CDlgTagJumpList::~CDlgTagJumpList()
 	@author MIK
 	@date 2005.03.31 新規作成
 */
-void CDlgTagJumpList::StopTimer( void )
+void CDlgTagJumpList::StopTimer( )
 {
 	if( m_nTimerId != 0 ){
 		::KillTimer( GetHwnd(), m_nTimerId );
@@ -185,7 +185,7 @@ void CDlgTagJumpList::StartTimer( int nDelay = TAGJUMP_TIMER_DELAY )
 	@author MIK
 	@date 2005.03.31 新規作成
 */
-void CDlgTagJumpList::Empty( void )
+void CDlgTagJumpList::Empty( )
 {
 	m_nIndex = -1;
 	m_pcList->Empty();
@@ -208,7 +208,7 @@ int CDlgTagJumpList::DoModal(
 }
 
 /* ダイアログデータの設定 */
-void CDlgTagJumpList::SetData( void )
+void CDlgTagJumpList::SetData( )
 {
 	if( IsDirectTagJump() ){
 		m_bTagJumpICase = FALSE;
@@ -356,7 +356,7 @@ void CDlgTagJumpList::UpdateData( bool bInit )
 
 	@date 2005.04.03 MIK 設定値の保存処理追加
 */
-int CDlgTagJumpList::GetData( void )
+int CDlgTagJumpList::GetData( )
 {
 	HWND	hwndList;
 
@@ -505,7 +505,7 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return bRet;
 }
 
-BOOL CDlgTagJumpList::OnDestroy( void )
+BOOL CDlgTagJumpList::OnDestroy( )
 {
 	CDialog::OnDestroy();
 	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcTagJumpDialog;
@@ -676,7 +676,7 @@ BOOL CDlgTagJumpList::OnEnChange( HWND hwndCtl, int wID )
 }
 #endif
 
-LPVOID CDlgTagJumpList::GetHelpIdTable( void )
+LPVOID CDlgTagJumpList::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }
@@ -850,7 +850,7 @@ typedef struct tagTagPathInfo {
 
 	@date 2014.06.14 ファイル名・拡張子以外にドライブ・パスも考慮するように
 */
-int CDlgTagJumpList::SearchBestTag( void )
+int CDlgTagJumpList::SearchBestTag( )
 {
 	if( m_pcList->GetCount() <= 0 ) return -1;	//選べません。
 	if( nullptr == m_pszFileName ) return 0;
@@ -1563,7 +1563,7 @@ next_line:
 /*!
 	パスからファイル名部分のみを取り出す．(2バイト対応)
 */
-const WCHAR* CDlgTagJumpList::GetFileName( void )
+const WCHAR* CDlgTagJumpList::GetFileName( )
 {
 	return GetFileTitlePointer(GetFilePath());
 }

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -60,7 +60,7 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	BOOL	OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
-	BOOL	OnDestroy( void ) override;
+	BOOL	OnDestroy( ) override;
 	BOOL	OnBnClicked(int wID) override;
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;
 	BOOL	OnSize( WPARAM wParam, LPARAM lParam ) override;
@@ -71,7 +71,7 @@ protected:
 	BOOL	OnCbnEditChange( HWND hwndCtl, int wID ) override;
 	//BOOL	OnEnChange( HWND hwndCtl, int wID ) override;
 	BOOL	OnTimer( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam ) override;
-	LPVOID	GetHelpIdTable( void ) override;
+	LPVOID	GetHelpIdTable( ) override;
 
 private:
 	struct STagFindState {
@@ -91,19 +91,19 @@ private:
 		int nTop;
 	};
 
-	void	StopTimer( void );
+	void	StopTimer( );
 	void	StartTimer(int nDelay);
 
-	void	SetData( void ) override;	/* ダイアログデータの設定 */
-	int		GetData( void ) override;	/* ダイアログデータの取得 */
+	void	SetData( ) override;	/* ダイアログデータの設定 */
+	int		GetData( ) override;	/* ダイアログデータの取得 */
 	void	UpdateData(bool bInit);	//	@@ 2005.03.31 MIK
 
 	WCHAR	*GetNameByType( const WCHAR type, const WCHAR *name );	//タイプを名前に変換する。
-	int		SearchBestTag( void );	//もっとも確率の高そうなインデックスを返す。
+	int		SearchBestTag( );	//もっとも確率の高そうなインデックスを返す。
 	//	@@ 2005.03.31 MIK
-	const WCHAR *GetFileName( void );
-	const WCHAR *GetFilePath( void ){ return m_pszFileName != nullptr ? m_pszFileName : L""; }
-	void Empty( void );
+	const WCHAR *GetFileName( );
+	const WCHAR *GetFilePath( ){ return m_pszFileName != nullptr ? m_pszFileName : L""; }
+	void Empty( );
 	void SetTextDir();
 	void FindNext(bool bNewFind);
 	void find_key( const wchar_t* keyword );

--- a/sakura_core/dlg/CDlgTagsMake.cpp
+++ b/sakura_core/dlg/CDlgTagsMake.cpp
@@ -121,7 +121,7 @@ void CDlgTagsMake::SelectFolder( HWND hwndDlg )
 }
 
 /* ダイアログデータの設定 */
-void CDlgTagsMake::SetData( void )
+void CDlgTagsMake::SetData( )
 {
 	//作成フォルダー
 	ApiWrap::Combo_LimitText( GetItemHwnd( IDC_EDIT_TAG_MAKE_FOLDER ), int(std::size(m_szPath)) );
@@ -141,7 +141,7 @@ void CDlgTagsMake::SetData( void )
 
 /* ダイアログデータの取得 */
 /* TRUE==正常  FALSE==入力エラー */
-int CDlgTagsMake::GetData( void )
+int CDlgTagsMake::GetData( )
 {
 	//フォルダー
 	ApiWrap::DlgItem_GetText( GetHwnd(), IDC_EDIT_TAG_MAKE_FOLDER, m_szPath, int(std::size(m_szPath)) );
@@ -163,7 +163,7 @@ int CDlgTagsMake::GetData( void )
 	return TRUE;
 }
 
-LPVOID CDlgTagsMake::GetHelpIdTable( void )
+LPVOID CDlgTagsMake::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgTagsMake.h
+++ b/sakura_core/dlg/CDlgTagsMake.h
@@ -43,10 +43,10 @@ protected:
 	||  実装ヘルパ関数
 	*/
 	BOOL	OnBnClicked(int wID) override;
-	LPVOID	GetHelpIdTable(void) override;
+	LPVOID	GetHelpIdTable() override;
 
-	void	SetData( void ) override;	/* ダイアログデータの設定 */
-	int		GetData( void ) override;	/* ダイアログデータの取得 */
+	void	SetData( ) override;	/* ダイアログデータの設定 */
+	int		GetData( ) override;	/* ダイアログデータの取得 */
 
 private:
 	void SelectFolder( HWND hwndDlg );

--- a/sakura_core/dlg/CDlgWinSize.cpp
+++ b/sakura_core/dlg/CDlgWinSize.cpp
@@ -147,7 +147,7 @@ BOOL CDlgWinSize::OnEnKillFocus(HWND hwndCtl, int wID)
 
 /*! @brief ダイアログボックスにデータを設定
 */
-void CDlgWinSize::SetData( void )
+void CDlgWinSize::SetData( )
 {
 	switch( m_eSaveWinSize ){
 	case 1:
@@ -192,7 +192,7 @@ void CDlgWinSize::SetData( void )
 
 /*! ダイアログボックスのデータを読み出す
 */
-int CDlgWinSize::GetData( void )
+int CDlgWinSize::GetData( )
 {
 	if( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_WINSIZE_DEF ) ){
 		m_eSaveWinSize = WINSIZEMODE_DEF;
@@ -235,7 +235,7 @@ int CDlgWinSize::GetData( void )
 
 /*! 利用可能・不可の状態を更新する
 */
-void CDlgWinSize::RenewItemState( void )
+void CDlgWinSize::RenewItemState( )
 {
 	BOOL state;
 	if( BST_CHECKED == ::IsDlgButtonChecked( GetHwnd(), IDC_RADIO_WINPOS_SET ) ){
@@ -256,7 +256,7 @@ void CDlgWinSize::RenewItemState( void )
 	::EnableWindow( GetItemHwnd( IDC_EDIT_SY ), state );
 }
 
-LPVOID CDlgWinSize::GetHelpIdTable( void )
+LPVOID CDlgWinSize::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/dlg/CDlgWinSize.h
+++ b/sakura_core/dlg/CDlgWinSize.h
@@ -37,11 +37,11 @@ protected:
 	BOOL OnBnClicked(int wID) override;
 	BOOL OnEnSetFocus(HWND hwndCtl, int wID) override;
 	BOOL OnEnKillFocus(HWND hwndCtl, int wID) override;
-	int  GetData( void ) override;
-	void SetData( void ) override;
-	LPVOID GetHelpIdTable( void ) override;
+	int  GetData( ) override;
+	void SetData( ) override;
+	LPVOID GetHelpIdTable( ) override;
 
-	void RenewItemState( void );
+	void RenewItemState( );
 
 private:
 	EWinSizeMode	m_eSaveWinSize;	//!< ウィンドウサイズの保存: 0/デフォルト，1/継承，2/指定

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -238,7 +238,7 @@ BOOL CDlgWindowList::OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam)
 	return CDialog::OnInitDialog(hwndDlg, wParam, lParam);
 }
 
-BOOL CDlgWindowList::OnDestroy( void )
+BOOL CDlgWindowList::OnDestroy( )
 {
 	CDialog::OnDestroy();
 	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcWindowListDialog;

--- a/sakura_core/dlg/CDlgWindowList.h
+++ b/sakura_core/dlg/CDlgWindowList.h
@@ -27,7 +27,7 @@ protected:
 	LPVOID	GetHelpIdTable() override;
 	INT_PTR DispatchEvent(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
-	BOOL OnDestroy( void ) override;
+	BOOL OnDestroy( ) override;
 	BOOL OnSize(WPARAM wParam, LPARAM lParam) override;
 	BOOL OnMinMaxInfo(LPARAM lParam);
 	BOOL OnActivate(WPARAM wParam, LPARAM lParam) override;

--- a/sakura_core/doc/CDocEditor.h
+++ b/sakura_core/doc/CDocEditor.h
@@ -53,19 +53,19 @@ public:
 	void SetInsMode(bool mode) { m_bInsMode = mode; }
 
 	//! Undo(元に戻す)可能な状態か？ */
-	bool IsEnableUndo( void ) const
+	bool IsEnableUndo( ) const
 	{
 		return m_cOpeBuf.IsEnableUndo();
 	}
 
 	//! Redo(やり直し)可能な状態か？
-	bool IsEnableRedo( void ) const
+	bool IsEnableRedo( ) const
 	{
 		return m_cOpeBuf.IsEnableRedo();
 	}
 
 	//! クリップボードから貼り付け可能か？
-	bool IsEnablePaste( void ) const;
+	bool IsEnablePaste( ) const;
 
 public:
 	CEditDoc*		m_pcDocRef;

--- a/sakura_core/doc/CDocFile.cpp
+++ b/sakura_core/doc/CDocFile.cpp
@@ -14,7 +14,7 @@
 
 	2017/5/17 CFile.hから移動
 */
-const WCHAR* CDocFile::GetSaveFilePath(void) const
+const WCHAR* CDocFile::GetSaveFilePath() const
 {
 	if (m_szSaveFilePath.IsValidPath()) {
 		return m_szSaveFilePath;

--- a/sakura_core/doc/CDocFile.h
+++ b/sakura_core/doc/CDocFile.h
@@ -57,7 +57,7 @@ public:
 	void			SetFileTime( FILETIME& Time )	{ m_sFileInfo.cFileTime.SetFILETIME( Time ); }
 
 	const WCHAR*	GetFileName() const{ return GetFileTitlePointer(GetFilePath()); }	//!< ファイル名(パスなし)を取得
-	const WCHAR*	GetSaveFilePath(void) const;
+	const WCHAR*	GetSaveFilePath() const;
 	void			SetSaveFilePath(LPCWSTR pszPath){ m_szSaveFilePath.Assign(pszPath); }
 public: //####
 	CEditDoc*	m_pcDocRef;

--- a/sakura_core/doc/CDocLocker.h
+++ b/sakura_core/doc/CDocLocker.h
@@ -16,7 +16,7 @@ public:
 	CDocLocker();
 
 	//クリア
-	void Clear(void) { m_bIsDocWritable = true; }
+	void Clear() { m_bIsDocWritable = true; }
 
 	//ロード前後
 	void OnAfterLoad(const SLoadInfo& sLoadInfo) override;

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -383,7 +383,7 @@ void CEditDoc::SetBackgroundImage()
 }
 
 /* 全ビューの初期化：ファイルオープン/クローズ時等に、ビューを初期化する */
-void CEditDoc::InitAllView( void )
+void CEditDoc::InitAllView( )
 {
 	m_nCommandExecNum = 0;	/* コマンド実行回数 */
 
@@ -410,7 +410,7 @@ void CEditDoc::InitAllView( void )
 	@date 2001.09.29 genta マクロクラスを渡すように
 	@date 2002.01.03 YAZAKI m_tbMyButtonなどをCShareDataからCMenuDrawerへ移動したことによる修正。
 */
-BOOL CEditDoc::Create( void )
+BOOL CEditDoc::Create( )
 {
 	MY_RUNNINGTIMER( cRunningTimer, L"CEditDoc::Create" );
 

--- a/sakura_core/doc/CEditDoc.h
+++ b/sakura_core/doc/CEditDoc.h
@@ -66,7 +66,7 @@ public:
 	~CEditDoc();
 
 	//初期化
-	BOOL Create( void );
+	BOOL Create( );
 	void InitDoc();	/* 既存データのクリア */
 	void InitAllView();	/* 全ビューの初期化：ファイルオープン/クローズ時等に、ビューを初期化する */
 	void Clear();

--- a/sakura_core/doc/layout/CLayout.cpp
+++ b/sakura_core/doc/layout/CLayout.cpp
@@ -23,7 +23,7 @@ CLayout::~CLayout()
 	return;
 }
 
-void CLayout::DUMP( void )
+void CLayout::DUMP( )
 {
 	DEBUG_TRACE( L"\n\n■CLayout::DUMP()======================\n" );
 	DEBUG_TRACE( L"m_ptLogicPos.y=%d\t\t対応する論理行番号\n", m_ptLogicPos.y );

--- a/sakura_core/doc/layout/CLayout.h
+++ b/sakura_core/doc/layout/CLayout.h
@@ -59,7 +59,7 @@ public:
 		m_cExInfo.SetColorInfo(pColorInfo);
 	}
 	~CLayout();
-	void DUMP( void );
+	void DUMP( );
 
 	// m_ptLogicPos.xで補正したあとの文字列を得る
 	const wchar_t* GetPtr() const   { return m_pCDocLine->GetPtr() + m_ptLogicPos.x; }

--- a/sakura_core/doc/layout/CLayoutMgr.h
+++ b/sakura_core/doc/layout/CLayoutMgr.h
@@ -193,7 +193,7 @@ public:
 	// Jul. 29, 2006 genta
 	void GetEndLayoutPos(CLayoutPoint* ptLayoutEnd);
 
-	CLayoutInt GetMaxTextWidth(void) const { return m_nTextWidth; }		// 2009.08.28 nasukoji	テキスト最大幅を返す
+	CLayoutInt GetMaxTextWidth() const { return m_nTextWidth; }		// 2009.08.28 nasukoji	テキスト最大幅を返す
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           検索                              //
@@ -272,7 +272,7 @@ public:
 	);
 
 	BOOL CalculateTextWidth( BOOL bCalLineLen = TRUE, CLayoutInt nStart = CLayoutInt(-1), CLayoutInt nEnd = CLayoutInt(-1) );	/* テキスト最大幅を算出する */		// 2009.08.28 nasukoji
-	void ClearLayoutLineWidth( void );				/* 各行のレイアウト行長の記憶をクリアする */		// 2009.08.28 nasukoji
+	void ClearLayoutLineWidth( );				/* 各行のレイアウト行長の記憶をクリアする */		// 2009.08.28 nasukoji
 	CLayoutXInt GetLayoutXOfChar( const wchar_t* pData, int nDataLen, int i ) const {
 		CLayoutXInt nSpace = CLayoutXInt(0);
 		if( m_nSpacing ){

--- a/sakura_core/doc/layout/CLayoutMgr_New.cpp
+++ b/sakura_core/doc/layout/CLayoutMgr_New.cpp
@@ -314,7 +314,7 @@ BOOL CLayoutMgr::CalculateTextWidth( BOOL bCalLineLen, CLayoutInt nStart, CLayou
 
 	@date 2009.08.28 nasukoji	新規作成
 */
-void CLayoutMgr::ClearLayoutLineWidth( void )
+void CLayoutMgr::ClearLayoutLineWidth( )
 {
 	CLayout* pLayout = m_pLayoutTop;
 

--- a/sakura_core/docplus/CBookmarkManager.cpp
+++ b/sakura_core/docplus/CBookmarkManager.cpp
@@ -18,7 +18,7 @@ void CBookmarkSetter::SetBookmark(bool bFlag){ m_pcDocLine->m_sMark.m_cBookmarke
 /*
 	@date 2001.12.03 hor
 */
-void CBookmarkManager::ResetAllBookMark( void )
+void CBookmarkManager::ResetAllBookMark( )
 {
 	CDocLine* pDocLine = m_pcDocLineMgr->GetDocLineTop();
 	while( pDocLine ){

--- a/sakura_core/env/CAppNodeManager.cpp
+++ b/sakura_core/env/CAppNodeManager.cpp
@@ -784,7 +784,7 @@ bool CAppNodeManager::IsSameGroup( HWND hWnd1, HWND hWnd2 )
 }
 
 /* 空いているグループ番号を取得する */
-int CAppNodeManager::GetFreeGroupId( void )
+int CAppNodeManager::GetFreeGroupId( )
 {
 	DLLSHAREDATA* pShare = &GetDllShareData();
 

--- a/sakura_core/env/CFileNameManager.cpp
+++ b/sakura_core/env/CFileNameManager.cpp
@@ -81,7 +81,7 @@ LPWSTR CFileNameManager::GetTransformFileNameFast( LPCWSTR pszSrc, LPWSTR pszDes
 	@date 2003.01.27 Moca 新規作成
 	@date 2003.06.23 Moca 関数名変更
 */
-int CFileNameManager::TransformFileName_MakeCache( void ){
+int CFileNameManager::TransformFileName_MakeCache( ){
 	int i;
 	int nCount = 0;
 	for( i = 0; i < m_pShareData->m_Common.m_sFileName.m_nTransformFileNameArrNum; i++ ){

--- a/sakura_core/env/CHokanMgr.cpp
+++ b/sakura_core/env/CHokanMgr.cpp
@@ -92,7 +92,7 @@ void CHokanMgr::ChangeView( LPARAM pcEditView )
 	return;
 }
 
-void CHokanMgr::Hide( void )
+void CHokanMgr::Hide( )
 {
 	::ShowWindow( GetHwnd(), SW_HIDE );
 	m_nCurKouhoIdx = -1;
@@ -464,7 +464,7 @@ BOOL CHokanMgr::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	return CDialog::OnInitDialog( hwndDlg, wParam, lParam );
 }
 
-BOOL CHokanMgr::OnDestroy( void )
+BOOL CHokanMgr::OnDestroy( )
 {
 	/* 基底クラスメンバ */
 	CreateSizeBox();
@@ -707,7 +707,7 @@ const DWORD p_helpids[] = {
 	0, 0
 };
 
-LPVOID CHokanMgr::GetHelpIdTable(void)
+LPVOID CHokanMgr::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/env/CHokanMgr.h
+++ b/sakura_core/env/CHokanMgr.h
@@ -36,7 +36,7 @@ public:
 	~CHokanMgr();
 
 	HWND DoModeless(HINSTANCE hInstance, HWND hwndParent, LPARAM lParam);/* モードレスダイアログの表示 */
-	void Hide( void );
+	void Hide( );
 	/* 初期化 */
 	size_t Search(
 		POINT*			ppoWin,
@@ -61,7 +61,7 @@ public:
 
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnInitDialog( HWND, WPARAM wParam, LPARAM lParam ) override;
-	BOOL OnDestroy( void ) override;
+	BOOL OnDestroy( ) override;
 	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnLbnSelChange( HWND hwndCtl, int wID ) override;
 
@@ -87,6 +87,6 @@ protected:
 	/*
 	||  実装ヘルパ関数
 	*/
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 };
 #endif /* SAKURA_CHOKANMGR_0CB0AF1A_1F22_482E_9221_B9FAE4F0D8A0_H_ */

--- a/sakura_core/env/CKeyWordSetMgr.cpp
+++ b/sakura_core/env/CKeyWordSetMgr.cpp
@@ -34,7 +34,7 @@ inline int GetAlignmentSize( int nSize )
 	@note CKeyWordSetMgrは共有メモリ構造体に埋め込まれているため，
 	そのままではコンストラクタが動かないことに注意．
 */
-CKeyWordSetMgr::CKeyWordSetMgr( void )
+CKeyWordSetMgr::CKeyWordSetMgr( )
 {
 	m_nCurrentKeyWordSetIdx = 0;
 	m_nKeyWordSetNum = 0;
@@ -51,7 +51,7 @@ CKeyWordSetMgr::CKeyWordSetMgr( void )
 	
 	@date 2004.07.29 Moca 可変長記憶
 */
-void CKeyWordSetMgr::ResetAllKeyWordSet( void )
+void CKeyWordSetMgr::ResetAllKeyWordSet( )
 {
 	m_nKeyWordSetNum = 0;
 	int i;
@@ -622,7 +622,7 @@ int CKeyWordSetMgr::GetAllocSize( int nIdx ) const
 	
 	@return 共有空き領域(キーワード数)
  */
-int CKeyWordSetMgr::GetFreeSize( void ) const 
+int CKeyWordSetMgr::GetFreeSize( ) const 
 {
 	return MAX_KEYWORDNUM - m_nStartIdx[m_nKeyWordSetNum];
 }

--- a/sakura_core/env/CMarkMgr.cpp
+++ b/sakura_core/env/CMarkMgr.cpp
@@ -38,7 +38,7 @@ void CMarkMgr::SetMax(int max)
 	@retval true	有効
 	@retval false	無効
 */
-bool CMarkMgr::CheckCurrent(void) const
+bool CMarkMgr::CheckCurrent() const
 {
 	if( m_nCurpos < Count() )
 		return m_cMarkChain[ m_nCurpos ].IsValid();
@@ -52,7 +52,7 @@ bool CMarkMgr::CheckCurrent(void) const
 	@retval true	有る
 	@retval false	無い
 */
-bool CMarkMgr::CheckPrev(void) const
+bool CMarkMgr::CheckPrev() const
 {
 	for( int i = m_nCurpos - 1; i >= 0; i-- ){
 		if( m_cMarkChain[ i ].IsValid() )
@@ -67,7 +67,7 @@ bool CMarkMgr::CheckPrev(void) const
 	@retval true	有る
 	@retval false	無い
 */
-bool CMarkMgr::CheckNext(void) const
+bool CMarkMgr::CheckNext() const
 {
 	for( int i = m_nCurpos + 1; i < Count(); i++ ){
 		if( m_cMarkChain[ i ].IsValid() )
@@ -82,7 +82,7 @@ bool CMarkMgr::CheckNext(void) const
 	@retval true	正常終了。現在位置は1つ前の有効な要素に移動した。
 	@retval false	有効な要素が見つからなかった。現在位置は移動していない。
 */
-bool CMarkMgr::PrevValid(void)
+bool CMarkMgr::PrevValid()
 {
 	for( int i = m_nCurpos - 1; i >= 0; i-- ){
 		if( m_cMarkChain[ i ].IsValid() ){
@@ -98,7 +98,7 @@ bool CMarkMgr::PrevValid(void)
 	@retval true	正常終了。現在位置は1つ後の有効な要素に移動した。
 	@retval false	有効な要素が見つからなかった。現在位置は移動していない。
 */
-bool CMarkMgr::NextValid(void)
+bool CMarkMgr::NextValid()
 {
 	for( int i = m_nCurpos + 1; i < Count(); i++ ){
 		if( m_cMarkChain[ i ].IsValid() ){
@@ -116,7 +116,7 @@ bool CMarkMgr::NextValid(void)
 	@par history
 	Apr. 1, 2001 genta 新規追加
 */
-void CMarkMgr::Flush(void)
+void CMarkMgr::Flush()
 {
 	m_cMarkChain.erase( m_cMarkChain.begin(), m_cMarkChain.end() );
 	m_nCurpos = 0;
@@ -153,7 +153,7 @@ void CAutoMarkMgr::Add(const CMark& m)
 	要素数が最大値を超えている場合に要素数が範囲内に収まるよう、
 	古い方(番号の若い方)から削除する。
 */
-void CAutoMarkMgr::Expire(void)
+void CAutoMarkMgr::Expire()
 {
 	if (std::ssize(m_cMarkChain) <= m_nMaxitem) {
 		return;

--- a/sakura_core/env/CMarkMgr.h
+++ b/sakura_core/env/CMarkMgr.h
@@ -49,7 +49,7 @@ public:
 		CLogicPoint GetPosition() const { return m_ptLogic; }
 		void SetPosition(const CLogicPoint& pt) { m_ptLogic = pt; }
 
-		bool IsValid(void) const { return true; }
+		bool IsValid() const { return true; }
 
 		bool operator==(CMark &r) const { return m_ptLogic.y == r.m_ptLogic.y; }
 		bool operator!=(CMark &r) const { return m_ptLogic.y != r.m_ptLogic.y; }
@@ -69,26 +69,26 @@ public:
 	CMarkMgr() : m_nCurpos(0), m_nMaxitem(10){}
 	// CMarkMgr(const CDocLineMgr *p) : doc(p) {}
 
-	int Count(void) const { return (int)m_cMarkChain.size(); }	//!<	項目数を返す
-	int GetMax(void) const { return m_nMaxitem; }	//!<	最大項目数を返す
+	int Count() const { return (int)m_cMarkChain.size(); }	//!<	項目数を返す
+	int GetMax() const { return m_nMaxitem; }	//!<	最大項目数を返す
 	void SetMax(int max);	//!<	最大項目数を設定
 
 	virtual void Add(const CMark& m) = 0;	//!<	要素の追加
 
 	//	Apr. 1, 2001 genta
-	virtual void Flush(void);	//!<	要素の全消去
+	virtual void Flush();	//!<	要素の全消去
 
 	//!	要素の取得
-	const CMark& GetCurrent(void) const { return m_cMarkChain[m_nCurpos]; }
+	const CMark& GetCurrent() const { return m_cMarkChain[m_nCurpos]; }
 
 	//	有効性の確認
-	bool  CheckCurrent(void) const;
-	bool  CheckPrev(void) const;
-	bool  CheckNext(void) const;
+	bool  CheckCurrent() const;
+	bool  CheckPrev() const;
+	bool  CheckNext() const;
 
 	//	現在位置の移動
-	bool NextValid(void);
-	bool PrevValid(void);
+	bool NextValid();
+	bool PrevValid();
 
 	const CMark& operator[](int index) const { return m_cMarkChain[index]; }
 
@@ -98,7 +98,7 @@ public:
 //	CMarkIterator End(void) const { return (CMarkIterator)m_cMarkChain.end(); }
 
 protected:
-	virtual void Expire(void) = 0;
+	virtual void Expire() = 0;
 
 	// CMarkFactory m_factory;	//	Factory Class (マクロで生成される）
 	CMarkChain m_cMarkChain;	//	マークデータ本体
@@ -118,6 +118,6 @@ private:
 class CAutoMarkMgr final : public CMarkMgr{
 public:
 	void Add(const CMark& m) override;	//!<	要素の追加
-	void Expire(void) override;	//!<	要素数の調整
+	void Expire() override;	//!<	要素数の調整
 };
 #endif /* SAKURA_CMARKMGR_7A2BB103_5584_4393_A8E9_7639E3C7D787_H_ */

--- a/sakura_core/env/CProfile.cpp
+++ b/sakura_core/env/CProfile.cpp
@@ -337,7 +337,7 @@ void CProfile::SetProfileData(
 	foundSection->m_Entries[entryKey] = entryValue;
 }
 
-void CProfile::DUMP( void )
+void CProfile::DUMP( )
 {
 #ifdef _DEBUG
 	//	2006.02.20 ryoji: MAP_STR_STR_ITER削除時の修正漏れによるコンパイルエラー修正

--- a/sakura_core/env/CProfile.h
+++ b/sakura_core/env/CProfile.h
@@ -58,7 +58,7 @@ public:
 	bool GetProfileData(const std::wstring& sectionName, const std::wstring& entryKey, std::wstring& strEntryValue) const;
 	void SetProfileData(const std::wstring& sectionName, const std::wstring& entryKey, std::wstring_view entryValue);
 
-	void DUMP( void );
+	void DUMP( );
 
 private:
 	void _ReadOneline(const std::wstring& line);

--- a/sakura_core/env/CRegexKeyword.cpp
+++ b/sakura_core/env/CRegexKeyword.cpp
@@ -113,7 +113,7 @@ CRegexKeyword::~CRegexKeyword()
 
 	@retval TRUE 成功
 */
-BOOL CRegexKeyword::RegexKeyInit( void )
+BOOL CRegexKeyword::RegexKeyInit( )
 {
 	int	i;
 
@@ -190,7 +190,7 @@ BOOL CRegexKeyword::RegexKeySetTypes( const STypeConfig *pTypesPtr )
 	キーワードはコンパイルデータとして内部変数にコピーする。
 	先頭指定、色指定側の使用・未使用をチェックする。
 */
-BOOL CRegexKeyword::RegexKeyCompile( void )
+BOOL CRegexKeyword::RegexKeyCompile( )
 {
 	int	i;
 	static const wchar_t dummy[2] = L"\0";
@@ -306,7 +306,7 @@ BOOL CRegexKeyword::RegexKeyCompile( void )
 	@note それぞれの行検索の最初に実行する。
 	タイプ設定等が変更されている場合はリロードする。
 */
-BOOL CRegexKeyword::RegexKeyLineStart( void )
+BOOL CRegexKeyword::RegexKeyLineStart( )
 {
 	int	i;
 

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -1066,7 +1066,7 @@ bool CShareData::OpenDebugWindow( HWND hwnd, bool bAllwaysActive )
 
 	iniファイルの保存先がユーザー別設定フォルダーかどうか 2007.05.25 ryoji
 */
-[[nodiscard]]  bool CShareData::IsPrivateSettings( void ) const noexcept
+[[nodiscard]]  bool CShareData::IsPrivateSettings( ) const noexcept
 {
 	return m_pShareData != nullptr && 0 != ::wcscmp(m_pShareData->m_szPrivateIniFile, m_pShareData->m_szIniFile);
 }

--- a/sakura_core/env/CShareData.h
+++ b/sakura_core/env/CShareData.h
@@ -81,7 +81,7 @@ public:
 	void SetTraceOutSource( HWND hwnd ){ m_hwndTraceOutSource = hwnd; }	/* TraceOut起動元ウィンドウの設定 */
 	bool OpenDebugWindow( HWND hwnd, bool bAllwaysActive );	//!<  デバッグウィンドウを開く
 
-	[[nodiscard]] bool IsPrivateSettings( void ) const noexcept;
+	[[nodiscard]] bool IsPrivateSettings( ) const noexcept;
 
 	//マクロ関連
 	int			GetMacroFilename( int idx, WCHAR* pszPath, int nBufLen ); // idxで指定したマクロファイル名（フルパス）を取得する	//	Jun. 14, 2003 genta 引数追加．書式変更

--- a/sakura_core/env/CSortedTagJumpList.cpp
+++ b/sakura_core/env/CSortedTagJumpList.cpp
@@ -47,7 +47,7 @@ void CSortedTagJumpList::Free( TagJumpInfo* item )
 /*
 	リストをすべて解放する。
 */
-void CSortedTagJumpList::Empty( void )
+void CSortedTagJumpList::Empty( )
 {
 	TagJumpInfo*	p;
 	TagJumpInfo*	next;

--- a/sakura_core/env/CSortedTagJumpList.h
+++ b/sakura_core/env/CSortedTagJumpList.h
@@ -31,9 +31,9 @@ public:
 	int		AddBaseDir(std::wstring_view baseDir);
 	BOOL AddParamA( const ACHAR* keyword, const ACHAR* filename, int no, ACHAR type, const ACHAR* note, int depth, const int baseDirId );
 	BOOL GetParam( int index, WCHAR* keyword, WCHAR* filename, int* no, WCHAR* type, WCHAR* note, int* depth, WCHAR* baseDir );
-	int GetCount( void ){ return m_nCount; }
-	void Empty( void );
-	bool IsOverflow( void ){ return m_bOverflow; }
+	int GetCount( ){ return m_nCount; }
+	void Empty( );
+	bool IsOverflow( ){ return m_bOverflow; }
 
 	typedef struct tagjump_info_t {
 		struct tagjump_info_t*	next;	//!< 次のリスト
@@ -52,7 +52,7 @@ public:
 
 		@date 2005.04.22 genta 最大値を可変に
 	*/
-	int GetCapacity(void) const { return m_MAX_TAGJUMPLIST; }
+	int GetCapacity() const { return m_MAX_TAGJUMPLIST; }
 
 private:
 	TagJumpInfo*	m_pTagjump = nullptr;	//!< タグジャンプ情報

--- a/sakura_core/extmodule/CMigemo.cpp
+++ b/sakura_core/extmodule/CMigemo.cpp
@@ -73,7 +73,7 @@ bool CMigemo::InitDllImp()
 	return m_migemo != nullptr;
 }
 
-bool CMigemo::DeinitDllImp(void)
+bool CMigemo::DeinitDllImp()
 {
 	if (IsAvailable() && m_migemo) {
 		(*m_migemo_close)(m_migemo);

--- a/sakura_core/extmodule/CMigemo.h
+++ b/sakura_core/extmodule/CMigemo.h
@@ -58,7 +58,7 @@ protected:
 
 private:
 	bool InitDllImp() override;
-	bool DeinitDllImp(void) override;
+	bool DeinitDllImp() override;
 
 	std::string_view _migemo_query(const std::string& query) noexcept;
 	void _migemo_release(std::string_view found) noexcept;

--- a/sakura_core/extmodule/CUchardet.h
+++ b/sakura_core/extmodule/CUchardet.h
@@ -17,7 +17,7 @@ class CUchardet : public CDllImp
 {
 public:
 	// DLL関数ポインタ
-	uchardet_t (*_uchardet_new)(void) = nullptr;
+	uchardet_t (*_uchardet_new)() = nullptr;
 	void (*_uchardet_delete)(uchardet_t ud) = nullptr;
 	int (*_uchardet_handle_data)(uchardet_t ud, const char * data, size_t len) = nullptr;
 	void (*_uchardet_data_end)(uchardet_t ud) = nullptr;
@@ -30,7 +30,7 @@ protected:
 	bool InitDllImp() override;
 
 public:
-	uchardet_t uchardet_new(void) const { return _uchardet_new(); }
+	uchardet_t uchardet_new() const { return _uchardet_new(); }
 	void uchardet_delete(uchardet_t ud) const { _uchardet_delete(ud); }
 	int uchardet_handle_data(uchardet_t ud, const char * data, size_t len) const { return _uchardet_handle_data(ud, data, len); }
 	void uchardet_data_end(uchardet_t ud) const { _uchardet_data_end(ud); }

--- a/sakura_core/func/CFuncKeyWnd.cpp
+++ b/sakura_core/func/CFuncKeyWnd.cpp
@@ -149,7 +149,7 @@ HWND CFuncKeyWnd::Open( HINSTANCE hInstance, HWND hwndParent, CEditDoc* pCEditDo
 }
 
 /* ウィンドウ クローズ */
-void CFuncKeyWnd::Close( void )
+void CFuncKeyWnd::Close( )
 {
 	this->DestroyWindow();
 }
@@ -343,7 +343,7 @@ LRESULT CFuncKeyWnd::OnDestroy( [[maybe_unused]] HWND hwnd, [[maybe_unused]] UIN
 }
 
 /*! ボタンのサイズを計算 */
-int CFuncKeyWnd::CalcButtonSize( void )
+int CFuncKeyWnd::CalcButtonSize( )
 {
 	int			nButtonNum;
 	RECT		rc;
@@ -371,7 +371,7 @@ int CFuncKeyWnd::CalcButtonSize( void )
 /*! ボタンの生成
 	@date 2007.02.05 ryoji ボタンの水平位置・幅の設定処理を削除（OnSizeで再配置されるので不要）
 */
-void CFuncKeyWnd::CreateButtons( void )
+void CFuncKeyWnd::CreateButtons( )
 {
 	RECT	rcParent;
 	int		nButtonHeight;

--- a/sakura_core/func/CFuncKeyWnd.h
+++ b/sakura_core/func/CFuncKeyWnd.h
@@ -37,7 +37,7 @@ public:
 	|| メンバ関数
 	*/
 	HWND Open( HINSTANCE, HWND, CEditDoc*, bool );	/* ウィンドウ オープン */
-	void Close( void );	/* ウィンドウ クローズ */
+	void Close( );	/* ウィンドウ クローズ */
 	void SizeBox_ONOFF(bool bSizeBox);	/* サイズボックスの表示／非表示切り替え */
 	void Timer_ONOFF(bool bStart); /* 更新の開始／停止 20060126 aroka */
 	/*
@@ -60,8 +60,8 @@ protected:
 	/*
 	|| 実装ヘルパ系
 	*/
-	void CreateButtons( void );	/* ボタンの生成 */
-	int CalcButtonSize( void );	/* ボタンのサイズを計算 */
+	void CreateButtons( );	/* ボタンの生成 */
+	int CalcButtonSize( );	/* ボタンのサイズを計算 */
 
 	/* 仮想関数 */
 

--- a/sakura_core/grep/CGrepEnumFileBase.h
+++ b/sakura_core/grep/CGrepEnumFileBase.h
@@ -54,7 +54,7 @@ public:
 		ClearItems();
 	}
 
-	void ClearItems( void ){
+	void ClearItems( ){
 		for( int i = 0; i < GetCount(); i++ ){
 			LPWSTR lp = m_vpItems[ i ].first;
 			m_vpItems[ i ].first = nullptr;
@@ -80,7 +80,7 @@ public:
 		return FALSE;
 	}
 
-	int GetCount( void ){
+	int GetCount( ){
 		return (int)m_vpItems.size();
 	}
 

--- a/sakura_core/grep/CGrepEnumKeys.h
+++ b/sakura_core/grep/CGrepEnumKeys.h
@@ -189,7 +189,7 @@ public:
 	}
 
 private:
-	void ClearItems( void ){
+	void ClearItems( ){
 		ClearEnumKeys(m_vecExceptFileKeys);
 		ClearEnumKeys(m_vecSearchFileKeys);
 		ClearEnumKeys(m_vecExceptFolderKeys);

--- a/sakura_core/io/CFileLoad.cpp
+++ b/sakura_core/io/CFileLoad.cpp
@@ -100,7 +100,7 @@ CFileLoad::CFileLoad( const SEncodingConfig& encode )
 }
 
 /*! デストラクタ */
-CFileLoad::~CFileLoad( void )
+CFileLoad::~CFileLoad( )
 {
 	FileClose();
 }
@@ -269,7 +269,7 @@ ECodeType CFileLoad::FileOpen( LPCWSTR pFileName, bool bBigFile, ECodeType CharC
 	ファイルを閉じる
 	読み込み用バッファとm_memLineもクリアされる
 */
-void CFileLoad::FileClose( void )
+void CFileLoad::FileClose( )
 {
 	if( m_hFile != nullptr ){
 		if( m_pReadBufTop != nullptr ){
@@ -408,7 +408,7 @@ EConvertResult CFileLoad::ReadLine_core(
 	 現在の進行率を取得する
 	 @return 0% - 100%  若干誤差が出る
 */
-int CFileLoad::GetPercent( void ){
+int CFileLoad::GetPercent( ){
 	int nRet;
 	const size_t nSize = (m_nReadBufOffsetEnd - m_nReadBufOffsetBegin);
 	if( 0 == nSize || m_nReadBufOffsetEnd <= m_nReadBufOffsetCurrent ){

--- a/sakura_core/io/CFileLoad.h
+++ b/sakura_core/io/CFileLoad.h
@@ -39,13 +39,13 @@ public:
 public:
 	CFileLoad() : CFileLoad( SEncodingConfig{} ) {};
 	CFileLoad( const SEncodingConfig& encode );
-	~CFileLoad( void );
+	~CFileLoad( );
 
 	void Prepare( const CFileLoad& other, size_t nOffsetBegin, size_t nOffsetEnd );
 
 	//	Jul. 26, 2003 ryoji BOM引数追加
 	ECodeType FileOpen( LPCWSTR, bool bBigFile, ECodeType, int, bool* pbBomExist = nullptr );		// 指定文字コードでファイルをオープンする
-	void FileClose( void );					// 明示的にファイルをクローズする
+	void FileClose( );					// 明示的にファイルをクローズする
 
 	//! 1行データをロードする 順アクセス用
 	EConvertResult ReadLine(
@@ -63,13 +63,13 @@ public:
 
 	//	Jun. 08, 2003 Moca
 	//! 開いたファイルにはBOMがあるか？
-	bool IsBomExist( void ){ return m_bBomExist; }
+	bool IsBomExist( ){ return m_bBomExist; }
 
 	//! 現在の進行率を取得する(0% - 100%) 若干誤差が出る
-	int GetPercent( void );
+	int GetPercent( );
 
 	//! ファイルサイズを取得する
-	inline LONGLONG GetFileSize( void ){ return m_nFileSize; }
+	inline LONGLONG GetFileSize( ){ return m_nFileSize; }
 
 	//! 指定オフセットから末尾に向かって最初に現れる行頭のオフセットを取得
 	size_t GetNextLineOffset( size_t nOffset );

--- a/sakura_core/macro/CKeyMacroMgr.cpp
+++ b/sakura_core/macro/CKeyMacroMgr.cpp
@@ -51,7 +51,7 @@ CKeyMacroMgr::~CKeyMacroMgr()
 }
 
 /*! キーマクロのバッファをクリアする */
-void CKeyMacroMgr::ClearAll( void )
+void CKeyMacroMgr::ClearAll( )
 {
 	CMacro* p = m_pTop;
 	CMacro* del_p;
@@ -478,7 +478,7 @@ CMacroManagerBase* CKeyMacroMgr::Creator(const WCHAR* ext)
 
 	@date 2004.01.31 genta RegisterExtの廃止のためRegisterCreatorに置き換え
 */
-void CKeyMacroMgr::declare (void)
+void CKeyMacroMgr::declare ()
 {
 	//	常に実行
 	CMacroFactory::getInstance()->RegisterCreator( Creator );

--- a/sakura_core/macro/CKeyMacroMgr.h
+++ b/sakura_core/macro/CKeyMacroMgr.h
@@ -50,7 +50,7 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	void ClearAll( void );				/* キーマクロのバッファをクリアする */
+	void ClearAll( );				/* キーマクロのバッファをクリアする */
 	void Append( EFunctionCode nFuncID, const LPARAM* lParams, class CEditView* pcEditView );		/* キーマクロのバッファにデータ追加 */
 	void Append( class CMacro* macro );		/* キーマクロのバッファにデータ追加 */
 	
@@ -64,7 +64,7 @@ public:
 	
 	// Apr. 29, 2002 genta
 	static CMacroManagerBase* Creator(const WCHAR* ext);
-	static void declare(void);
+	static void declare();
 
 protected:
 	CMacro*	m_pTop;	//	先頭と終端を保持

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -51,7 +51,7 @@ CMacro::CMacro( EFunctionCode nFuncID )
 	m_pParamTop = m_pParamBot = nullptr;
 }
 
-CMacro::~CMacro( void )
+CMacro::~CMacro( )
 {
 	ClearMacroParam();
 }

--- a/sakura_core/macro/CPPA.h
+++ b/sakura_core/macro/CPPA.h
@@ -57,7 +57,7 @@ public:
 	}
 
 	//! PPAメッセージを取得する
-	const char* GetLastMessage(void) const { return m_szMsg; }
+	const char* GetLastMessage() const { return m_szMsg; }
 
 	static std::string GetDeclarations(const MacroFuncInfo& cMacroFuncInfo);
 

--- a/sakura_core/macro/CPPAMacroMgr.cpp
+++ b/sakura_core/macro/CPPAMacroMgr.cpp
@@ -104,7 +104,7 @@ CMacroManagerBase* CPPAMacroMgr::Creator(const WCHAR* ext)
 
 	@date 2004.01.31 genta RegisterExtの廃止のためRegisterCreatorに置き換え
 */
-void CPPAMacroMgr::declare (void)
+void CPPAMacroMgr::declare ()
 {
 	if( DLL_SUCCESS == m_cPPA.InitDll() ){
 		CMacroFactory::getInstance()->RegisterCreator( Creator );

--- a/sakura_core/macro/CPPAMacroMgr.h
+++ b/sakura_core/macro/CPPAMacroMgr.h
@@ -47,7 +47,7 @@ public:
 
 	// Apr. 29, 2002 genta
 	static CMacroManagerBase* Creator(const WCHAR* ext);
-	static void declare(void);
+	static void declare();
 
 protected:
 	CNativeW m_cBuffer;

--- a/sakura_core/macro/CPythonMacroManager.cpp
+++ b/sakura_core/macro/CPythonMacroManager.cpp
@@ -51,7 +51,7 @@ struct PyMethodDef
 struct PyModuleDef_Base
 {
 	PyObject_HEAD
-		PyObject* (*m_init)(void);
+		PyObject* (*m_init)();
 	Py_ssize_t m_index;
 	PyObject* m_copy;
 };
@@ -125,12 +125,12 @@ inline Py_ssize_t PyTuple_GET_SIZE(const void* op) {
 
 EXTERN void (*Py_Initialize)();
 EXTERN void (*Py_InitializeEx)(int);
-EXTERN void (*Py_Finalize)(void);
-EXTERN int (*Py_FinalizeEx)(void); // >= 3.6
-EXTERN int (*Py_IsInitialized)(void);
+EXTERN void (*Py_Finalize)();
+EXTERN int (*Py_FinalizeEx)(); // >= 3.6
+EXTERN int (*Py_IsInitialized)();
 
-EXTERN const char* (*Py_GetVersion)(void);
-EXTERN const char* (*Py_GetCompiler)(void);
+EXTERN const char* (*Py_GetVersion)();
+EXTERN const char* (*Py_GetCompiler)();
 EXTERN wchar_t* (*Py_GetProgramFullPath)();
 
 EXTERN void (*Py_IncRef)(PyObject*);
@@ -244,9 +244,9 @@ EXTERN int (*PyState_AddModule)(PyObject* module, PyModuleDef* def);
 EXTERN int (*PyState_RemoveModule)(PyModuleDef* def);
 
 EXTERN void (*PyErr_PrintEx)(int set_sys_last_vars);
-EXTERN void (*PyErr_Print)(void);
-EXTERN int (*PyErr_BadArgument)(void);
-EXTERN PyObject* (*PyErr_Occurred)(void);
+EXTERN void (*PyErr_Print)();
+EXTERN int (*PyErr_BadArgument)();
+EXTERN PyObject* (*PyErr_Occurred)();
 EXTERN void (*PyErr_Fetch)(PyObject** ptype, PyObject** pvalue, PyObject** ptraceback);
 EXTERN void (*PyErr_Restore)(PyObject* type, PyObject* value, PyObject* traceback);
 EXTERN void (*PyErr_NormalizeException)(PyObject** exc, PyObject** val, PyObject** tb);
@@ -311,7 +311,7 @@ EXTERN PyObject* (*PyImport_GetModule)(PyObject* name);
 EXTERN PyObject* (*PyImport_GetImporter)(PyObject* path);
 EXTERN int (*PyImport_ImportFrozenModuleObject)(PyObject* name);
 EXTERN int (*PyImport_ImportFrozenModule)(const char* name);
-EXTERN int (*PyImport_AppendInittab)(const char* name, PyObject* (*initfunc)(void));
+EXTERN int (*PyImport_AppendInittab)(const char* name, PyObject* (*initfunc)());
 
 // API Functions
 EXTERN int (*PyArg_ParseTuple)(PyObject* args, const char* format, ...);
@@ -333,11 +333,11 @@ EXTERN double (*PyOS_string_to_double)(const char* s, char** endptr, PyObject* o
 EXTERN char* (*PyOS_double_to_string)(double val, char format_code, int precision, int flags, int* ptype);
 
 // Reflection
-EXTERN PyObject* (*PyEval_GetBuiltins)(void);
-EXTERN PyObject* (*PyEval_GetLocals)(void);
-EXTERN PyObject* (*PyEval_GetGlobals)(void);
+EXTERN PyObject* (*PyEval_GetBuiltins)();
+EXTERN PyObject* (*PyEval_GetLocals)();
+EXTERN PyObject* (*PyEval_GetGlobals)();
 struct PyFrameObject;
-EXTERN PyFrameObject* (*PyEval_GetFrame)(void);
+EXTERN PyFrameObject* (*PyEval_GetFrame)();
 EXTERN PyFrameObject* (*PyFrame_GetBack)(PyFrameObject* frame);
 struct PyCodeObject;
 EXTERN PyCodeObject* (*PyFrame_GetCode)(PyFrameObject* frame);
@@ -744,7 +744,7 @@ PyModuleDef g_moduleDef = {
 	g_moduleMethods,
 };
 
-PyObject* PyInit_SakuraEditor(void)
+PyObject* PyInit_SakuraEditor()
 {
 	auto module = PyModule_Create(&g_moduleDef);
 	return module;

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -534,7 +534,7 @@ CSMacroMgr::~CSMacroMgr()
 }
 
 /*! キーマクロのバッファをクリアする */
-void CSMacroMgr::ClearAll( void )
+void CSMacroMgr::ClearAll( )
 {
 	int i;
 	for (i = 0; i < MAX_CUSTMACRO; i++){
@@ -723,7 +723,7 @@ BOOL CSMacroMgr::Load( int idx, HINSTANCE hInstance, const WCHAR* pszPath, const
 
 	@date 2007.10.19 genta 新規作成
 */
-void CSMacroMgr::UnloadAll(void)
+void CSMacroMgr::UnloadAll()
 {
 	for ( int idx = 0; idx < MAX_CUSTMACRO; idx++ ){
 		delete m_cSavedKeyMacro[idx];
@@ -1270,7 +1270,7 @@ CMacroManagerBase** CSMacroMgr::Idx2Ptr(int idx)
 	@retval true 保存可能
 	@retval false 保存不可
 */
-bool CSMacroMgr::IsSaveOk(void)
+bool CSMacroMgr::IsSaveOk()
 {
 	return dynamic_cast<CKeyMacroMgr*>( m_pKeyMacro ) == nullptr ? false : true;
 }

--- a/sakura_core/macro/CSMacroMgr.h
+++ b/sakura_core/macro/CSMacroMgr.h
@@ -79,7 +79,7 @@ public:
 	||  Attributes & Operations
 	*/
 	void Clear( int idx );
-	void ClearAll( void );	/* キーマクロのバッファをクリアする */
+	void ClearAll( );	/* キーマクロのバッファをクリアする */
 
 	//! キーボードマクロの実行
 	BOOL Exec( int idx, HINSTANCE hInstance, CEditView* pcEditView, int flags );
@@ -119,7 +119,7 @@ public:
 	/*! キーボードマクロの読み込み */
 	BOOL Load( int idx, HINSTANCE hInstance, const WCHAR* pszPath, const WCHAR* pszType );
 	BOOL Save( int idx, HINSTANCE hInstance, const WCHAR* pszPath );
-	void UnloadAll(void);
+	void UnloadAll();
 
 	/*! キーマクロのバッファにデータ追加 */
 	int Append( int idx, EFunctionCode nFuncID, const LPARAM* lParams, CEditView* pcEditView );
@@ -134,10 +134,10 @@ public:
 	//	Jun. 16, 2002 genta
 	static const MacroFuncInfo* GetFuncInfoByID( int nFuncID );
 	
-	bool IsSaveOk(void);
+	bool IsSaveOk();
 
 	//	Sep. 15, 2005 FILE	実行中マクロのインデックス番号操作 (INVALID_MACRO_IDX:無効)
-	int GetCurrentIdx( void ) const {
+	int GetCurrentIdx( ) const {
 		return m_CurrentIdx;
 	}
 	int SetCurrentIdx( int idx ) {

--- a/sakura_core/mem/CMemory.cpp
+++ b/sakura_core/mem/CMemory.cpp
@@ -108,7 +108,7 @@ void CMemory::SwapHLByte( char* pData, const size_t nDataLen ) noexcept
 	
 	@note サイズが2の倍数でないときは、最後の1バイトは交換されない
 */
-void CMemory::SwapHLByte( void ) noexcept
+void CMemory::SwapHLByte( ) noexcept
 {
 	auto p0 = reinterpret_cast<uint16_t*>(GetRawPtr());
 	const auto p1 = p0 + GetRawLength() / 2;
@@ -219,7 +219,7 @@ void CMemory::AppendRawData( const void* pData, size_t nDataLen )
 	}
 }
 
-void CMemory::Reset( void ) noexcept
+void CMemory::Reset( ) noexcept
 {
 	::free( m_pRawData );
 	m_pRawData = nullptr;

--- a/sakura_core/mem/CMemory.h
+++ b/sakura_core/mem/CMemory.h
@@ -51,7 +51,7 @@ public:
 	void SetRawDataHoldBuffer( const void* pData, size_t nDataLen );	//!< バッファの内容を置き換える(バッファを保持)
 	void SetRawDataHoldBuffer( const CMemory& cmemData );				//!< バッファの内容を置き換える(バッファを保持)
 	void AppendRawData( const void* pData, size_t nDataLen );			//!< バッファの最後にデータを追加する
-	void Reset( void ) noexcept;										//!< バッファをリセットする
+	void Reset( ) noexcept;										//!< バッファをリセットする
 
 	[[nodiscard]] const std::byte* GetRawPtr() const noexcept { return m_pRawData; } //!< データへのポインタを返す
 	std::byte* GetRawPtr() noexcept { return m_pRawData; }             //!< データへのポインタを返す

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -968,7 +968,7 @@ BOOL CDlgFileTree::OnNotify(NMHDR* pNMHDR)
 	return CDialog::OnNotify(pNMHDR);
 }
 
-LPVOID CDlgFileTree::GetHelpIdTable( void )
+LPVOID CDlgFileTree::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -818,7 +818,7 @@ static int TreeDummylParamToFuncInfoIndex(std::vector<int>& vec, LPARAM lParam)
 
 /* ダイアログデータの取得 */
 /* 0==条件未入力   0より大きい==正常   0より小さい==入力エラー */
-int CDlgFuncList::GetData( void )
+int CDlgFuncList::GetData( )
 {
 	HWND			hwndList;
 	HWND			hwndTree;
@@ -1168,7 +1168,7 @@ void CDlgFuncList::SetTreeJava( [[maybe_unused]] HWND hwndDlg, HTREEITEM hInsert
   @date Jul 10, 2003  little YOSHI
   @date 2020.09.12 選択処理をGetFuncInfoIndex,SetItemSelectionへ移動
 */
-void CDlgFuncList::SetListVB (void)
+void CDlgFuncList::SetListVB ()
 {
 	int				i;
 	WCHAR			szType[64];
@@ -2280,7 +2280,7 @@ static int CALLBACK Compare_by_ItemTextDesc(LPARAM lParam1, LPARAM lParam2, LPAR
 	return Compare_by_ItemText(lParam2, lParam1, lParamSort);
 }
 
-BOOL CDlgFuncList::OnDestroy( void )
+BOOL CDlgFuncList::OnDestroy( )
 {
 	CDialog::OnDestroy();
 
@@ -2512,7 +2512,7 @@ BOOL CDlgFuncList::OnJump( bool bCheckAutoClose, bool bFileJump )	//2002.02.08 h
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgFuncList::GetHelpIdTable(void)
+LPVOID CDlgFuncList::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }
@@ -2596,7 +2596,7 @@ void CDlgFuncList::SetWindowText( const WCHAR* szTitle )
 /** 配色適用処理
 	@date 2010.06.05 ryoji 新規作成
 */
-void CDlgFuncList::SyncColor( void )
+void CDlgFuncList::SyncColor( )
 {
 	if( !IsDocking() )
 		return;
@@ -3415,7 +3415,7 @@ void CDlgFuncList::DoMenu( POINT pt, HWND hwndFrom )
 /** 現在の設定に応じて表示を刷新する
 	@date 2010.06.05 ryoji 新規作成
 */
-void CDlgFuncList::Refresh( void )
+void CDlgFuncList::Refresh( )
 {
 	CEditWnd* pcEditWnd = &GetEditWnd();
 	BOOL bReloaded = ChangeLayout( OUTLINE_LAYOUT_FILECHANGED );	// 現在設定に従ってアウトライン画面を再配置する

--- a/sakura_core/outline/CDlgFuncList.h
+++ b/sakura_core/outline/CDlgFuncList.h
@@ -78,8 +78,8 @@ public:
 protected:
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	// 2007.11.07 ryoji 標準以外のメッセージを捕捉する
 
-	CommonSetting_OutLine& CommonSet(void){ return m_pShareData->m_Common.m_sOutline; }
-	STypeConfig& TypeSet(void){ return m_type; }
+	CommonSetting_OutLine& CommonSet(){ return m_pShareData->m_Common.m_sOutline; }
+	STypeConfig& TypeSet(){ return m_type; }
 	int& ProfDockSet() { return CommonSet().m_nOutlineDockSet; }
 	BOOL& ProfDockSync() { return CommonSet().m_bOutlineDockSync; }
 	BOOL& ProfDockDisp() { return (ProfDockSet() == 0)? CommonSet().m_bOutlineDockDisp: TypeSet().m_bOutlineDockDisp; }
@@ -95,10 +95,10 @@ public:
 	*/
 	bool CheckListType( int nOutLineType ) const { return nOutLineType == m_nOutlineType; }
 	void Redraw( int nOutLineType, int nListType, CFuncInfoArr*, CLayoutInt nCurLine, CLayoutInt nCurCol );
-	void Refresh( void );
+	void Refresh( );
 	bool ChangeLayout( int nId );
 	void OnOutlineNotify( WPARAM wParam, LPARAM lParam );
-	void SyncColor( void );
+	void SyncColor( );
 	void SetWindowText( const WCHAR* szTitle );		//ダイアログタイトルの設定
 	EFunctionCode GetFuncCodeRedraw(int outlineType);
 	void LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDirPath );
@@ -127,11 +127,11 @@ protected:
 	BOOL OnNotify(NMHDR* pNMHDR) override;
 	BOOL OnSize( WPARAM wParam, LPARAM lParam ) override;
 	BOOL OnMinMaxInfo( LPARAM lParam );
-	BOOL OnDestroy(void) override; // 20060201 aroka
+	BOOL OnDestroy() override; // 20060201 aroka
 	BOOL OnCbnSelEndOk( HWND hwndCtl, int wID ) override;
 	BOOL OnContextMenu(WPARAM wParam, LPARAM lParam) override;
 	void SetData() override;	/* ダイアログデータの設定 */
-	int GetData( void ) override;	/* ダイアログデータの取得 */
+	int GetData( ) override;	/* ダイアログデータの取得 */
 
 	/*
 	||  実装ヘルパ関数
@@ -140,7 +140,7 @@ protected:
 	void SetTreeJava(HWND hwndDlg, HTREEITEM hInsertAfter, BOOL bAddClass);	/* ツリーコントロールの初期化：Javaメソッドツリー */
 	void SetTree(HTREEITEM hInsertAfter, bool tagjump = false, bool nolabel = false);		/* ツリーコントロールの初期化：汎用品 */
 	void SetTreeFile();				// ツリーコントロールの初期化：ファイルツリー
-	void SetListVB( void );			/* リストビューコントロールの初期化：VisualBasic */		// Jul 10, 2003  little YOSHI
+	void SetListVB( );			/* リストビューコントロールの初期化：VisualBasic */		// Jul 10, 2003  little YOSHI
 	void SetDocLineFuncList();
 	void SetItemSelection( int nSelectItemIndex, bool bAllowExpand );
 	void SetItemSelectionForTreeView( HWND hwndTree, int nSelectItemIndex, bool bAllowExpand );
@@ -164,7 +164,7 @@ protected:
 
 	// 2001.12.03 hor
 //	void SetTreeBookMark( HWND );		/* ツリーコントロールの初期化：ブックマーク */
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
 	void Key2Command(WORD KeyCode);		//	キー操作→コマンド変換
 	bool HitTestSplitter( int xPos, int yPos );
 	int HitTestCaptionButton( int xPos, int yPos );

--- a/sakura_core/outline/CFuncInfo.h
+++ b/sakura_core/outline/CFuncInfo.h
@@ -40,7 +40,7 @@ class CFuncInfo {
 
 		//! クリップボードに追加する要素か？
 		//	2003.06.27 Moca
-		inline bool IsAddClipText( void ) const{
+		inline bool IsAddClipText( ) const{
 			return ( FUNCINFO_NOCLIPTEXT != ( m_nInfo & FUNCINFO_NOCLIPTEXT ) );
 		}
 

--- a/sakura_core/outline/CFuncInfoArr.cpp
+++ b/sakura_core/outline/CFuncInfoArr.cpp
@@ -30,7 +30,7 @@ CFuncInfoArr::~CFuncInfoArr()
 	return;
 }
 
-void CFuncInfoArr::Empty( void )
+void CFuncInfoArr::Empty( )
 {
 	int i;
 	if( m_nFuncInfoArrNum > 0 && nullptr != m_ppcFuncInfoArr ){
@@ -104,7 +104,7 @@ void CFuncInfoArr::AppendData(
 	return;
 }
 
-void CFuncInfoArr::DUMP( void )
+void CFuncInfoArr::DUMP( )
 {
 #ifdef _DEBUG
 	int i;

--- a/sakura_core/outline/CFuncInfoArr.h
+++ b/sakura_core/outline/CFuncInfoArr.h
@@ -47,9 +47,9 @@ public:
 	void AppendData( CLogicInt nFuncLineCRLF, CLayoutInt nFuncLineLAYOUT, const WCHAR* pszFuncName,
 					 int nInfo, int nDepth = 0 );	/* 配列の最後にデータを追加する 2002.04.01 YAZAKI 深さ導入*/
 	void AppendData( CLogicInt nLogicLine, CLogicInt nLogicCol, CLayoutInt nLayoutLine, CLayoutInt nLayoutCol, const WCHAR*, const WCHAR*, int, int nDepth = 0 );	/* 配列の最後にデータを追加する 2010.03.01 syat 桁導入*/
-	int	GetNum( void ){	return m_nFuncInfoArrNum; }	/* 配列要素数を返す */
-	void Empty( void );
-	void DUMP( void );
+	int	GetNum( ){	return m_nFuncInfoArrNum; }	/* 配列要素数を返す */
+	void Empty( );
+	void DUMP( );
 	void SetAppendText( int info, std::wstring s, bool overwrite );
 	std::wstring GetAppendText( int info );
 	int AppendTextLenMax(){ return m_nAppendTextLenMax; }

--- a/sakura_core/plugin/CDllPlugin.cpp
+++ b/sakura_core/plugin/CDllPlugin.cpp
@@ -15,7 +15,7 @@
 #include "CSelectLang.h"
 
 // デストラクタ
-CDllPlugin::~CDllPlugin(void)
+CDllPlugin::~CDllPlugin()
 {
 	for( CPlug::ArrayIter it = m_plugs.begin(); it != m_plugs.end(); it++ ){
 		delete (CDllPlug*)(*it);

--- a/sakura_core/plugin/CDllPlugin.h
+++ b/sakura_core/plugin/CDllPlugin.h
@@ -42,7 +42,7 @@ public:
 
 	//デストラクタ
 public:
-	~CDllPlugin(void);
+	~CDllPlugin();
 
 	//実装
 public:

--- a/sakura_core/plugin/CPlugin.cpp
+++ b/sakura_core/plugin/CPlugin.cpp
@@ -33,7 +33,7 @@ CPlugin::CPlugin(std::wstring_view baseDir)
 }
 
 //デストラクタ
-CPlugin::~CPlugin(void)
+CPlugin::~CPlugin()
 {
 	for( CPluginOption::ArrayIter it = m_options.begin(); it != m_options.end(); it++ ){
 		delete *it;

--- a/sakura_core/plugin/CPlugin.h
+++ b/sakura_core/plugin/CPlugin.h
@@ -180,13 +180,13 @@ public:
 
 	//操作
 public:
-	std::wstring	GetLabel( void ) const  { return m_sLabel; }
+	std::wstring	GetLabel( ) const  { return m_sLabel; }
 	void	GetKey( std::wstring* sectin, std::wstring* key ) const {
 		*sectin = m_sSection; 
 		*key = m_sKey;
 	}
-	std::wstring	GetType( void ) const	{ return m_sType; }
-	int 	GetIndex( void ) const	{ return m_index; }
+	std::wstring	GetType( ) const	{ return m_sType; }
+	int 	GetIndex( ) const	{ return m_index; }
 	std::vector<std::wstring>	GetSelects() const
 	{
 		return (wstring_split(m_sSelects, L'|'));
@@ -225,7 +225,7 @@ public:
 
 	//デストラクタ
 public:
-	virtual ~CPlugin(void);
+	virtual ~CPlugin();
 
 	//操作
 public:

--- a/sakura_core/plugin/CWSHPlugin.cpp
+++ b/sakura_core/plugin/CWSHPlugin.cpp
@@ -15,7 +15,7 @@
 #include "CSelectLang.h"
 
 // デストラクタ
-CWSHPlugin::~CWSHPlugin(void)
+CWSHPlugin::~CWSHPlugin()
 {
 	for( CPlug::ArrayIter it = m_plugs.begin(); it != m_plugs.end(); it++ ){
 		delete *it;

--- a/sakura_core/plugin/CWSHPlugin.h
+++ b/sakura_core/plugin/CWSHPlugin.h
@@ -59,7 +59,7 @@ public:
 
 	//デストラクタ
 public:
-	~CWSHPlugin(void);
+	~CWSHPlugin();
 
 	//操作
 	//CPlugインスタンスの作成。ReadPluginDefPlug/Command から呼ばれる。

--- a/sakura_core/print/CPrint.cpp
+++ b/sakura_core/print/CPrint.cpp
@@ -70,12 +70,12 @@ const PAPER_INFO CPrint::m_paperInfoArr[] = {
 
 const int CPrint::m_nPaperInfoArrNum = int(std::size(m_paperInfoArr));
 
-CPrint::CPrint( void )
+CPrint::CPrint( )
 {
 	return;
 }
 
-CPrint::~CPrint( void )
+CPrint::~CPrint( )
 {
 	// メモリ割り当て済みならば、解放する
 	// 2003.05.18 かろと

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -669,7 +669,7 @@ void CPrintPreview::OnChangeSetting()
 	OnChangePrintSetting();
 }
 
-void CPrintPreview::OnChangePrintSetting( void )
+void CPrintPreview::OnChangePrintSetting( )
 {
 	HDC		hdc = ::GetDC( m_pParentWnd->GetHwnd() );
 	::SetMapMode( hdc, MM_LOMETRIC ); //MM_HIMETRIC それぞれの論理単位は、0.01 mm にマップされます
@@ -844,7 +844,7 @@ void CPrintPreview::OnChangePrintSetting( void )
 
 	@author Moca
 **/
-void CPrintPreview::OnPreviewGoDirectPage( void )
+void CPrintPreview::OnPreviewGoDirectPage( )
 {
 	const int  INPUT_PAGE_NUM_LEN = 12;
 
@@ -987,7 +987,7 @@ void CPrintPreview::OnPreviewZoom( BOOL bZoomUp )
 	滑らか
 	チェック時、2倍(COMPAT_BMP_SCALE/COMPAT_BMP_BASE)サイズでレンダリングする
 */
-void CPrintPreview::OnCheckAntialias( void )
+void CPrintPreview::OnCheckAntialias( )
 {
 	/* WM_SIZE 処理 */
 	RECT	rc;
@@ -998,7 +998,7 @@ void CPrintPreview::OnCheckAntialias( void )
 /*!
 	印刷
 */
-void CPrintPreview::OnPrint( void )
+void CPrintPreview::OnPrint( )
 {
 	HDC			hdc;
 	WCHAR		szJobName[256 + 1];
@@ -1550,7 +1550,7 @@ CColorStrategy* CPrintPreview::DrawPageText(
 }
 
 /* 印刷プレビュー スクロールバー初期化 */
-void CPrintPreview::InitPreviewScrollBar( void )
+void CPrintPreview::InitPreviewScrollBar( )
 {
 	SCROLLINFO	si;
 	RECT		rc;
@@ -1907,7 +1907,7 @@ int CALLBACK CPrintPreview::MyEnumFontFamProc(
 /*!
 	印刷プレビューに必要なコントロールを作成する
 */
-void CPrintPreview::CreatePrintPreviewControls( void )
+void CPrintPreview::CreatePrintPreviewControls( )
 {
 	/* 印刷プレビュー 操作バー */
 	m_hwndPrintPreviewBar = ::CreateDialogParam(
@@ -1996,7 +1996,7 @@ void CPrintPreview::CreatePrintPreviewControls( void )
 /*!
 	印刷プレビューに必要だったコントロールを破棄する
 */
-void CPrintPreview::DestroyPrintPreviewControls( void )
+void CPrintPreview::DestroyPrintPreviewControls( )
 {
 	/* 印刷プレビュー 操作バー 削除 */
 	if ( m_hwndPrintPreviewBar ){
@@ -2054,7 +2054,7 @@ INT_PTR CALLBACK CPrintPreview::PrintPreviewBar_DlgProc(
 }
 
 /* 印刷プレビュー 操作バーにフォーカスを当てる */
-void CPrintPreview::SetFocusToPrintPreviewBar( void )
+void CPrintPreview::SetFocusToPrintPreviewBar( )
 {
 	if( nullptr != m_hwndPrintPreviewBar ){
 		::SetFocus( m_hwndPrintPreviewBar );

--- a/sakura_core/print/CPrintPreview.h
+++ b/sakura_core/print/CPrintPreview.h
@@ -55,28 +55,28 @@ public:
 
 	//	User Messages
 	void OnChangeSetting();
-	void OnChangePrintSetting( void );
+	void OnChangePrintSetting( );
 	void OnPreviewGoPage( int nPage );	/* プレビュー ページ指定 */
 	void OnPreviewGoPreviousPage(){ OnPreviewGoPage( m_nCurPageNum - 1 ); }		//	前のページへ
 	void OnPreviewGoNextPage(){ OnPreviewGoPage( m_nCurPageNum + 1 ); }		//	前のページへ
-	void OnPreviewGoDirectPage( void );
+	void OnPreviewGoDirectPage( );
 	void OnPreviewZoom( BOOL bZoomUp );
-	void OnPrint( void );	/* 印刷実行 */
-	BOOL OnPrintPageSetting( void );
-	void OnCheckAntialias( void );
+	void OnPrint( );	/* 印刷実行 */
+	BOOL OnPrintPageSetting( );
+	void OnCheckAntialias( );
 
 	/*
 	||	コントロール
 	*/
 	//	スクロールバー
-	void InitPreviewScrollBar( void );
+	void InitPreviewScrollBar( );
 
 	//	PrintPreviewバー（画面上部のコントロール）
-	void CreatePrintPreviewControls( void );
-	void DestroyPrintPreviewControls( void );
+	void CreatePrintPreviewControls( );
+	void DestroyPrintPreviewControls( );
 
-	void SetFocusToPrintPreviewBar( void );
-	HWND GetPrintPreviewBarHANDLE( void ){ return m_hwndPrintPreviewBar; }
+	void SetFocusToPrintPreviewBar( );
+	HWND GetPrintPreviewBarHANDLE( ){ return m_hwndPrintPreviewBar; }
 	static HWND GetPrintPreviewBarHANDLE_Safe(const CPrintPreview *preview) {
 		if (preview)
 			return preview->m_hwndPrintPreviewBar;

--- a/sakura_core/recent/CMRUFile.cpp
+++ b/sakura_core/recent/CMRUFile.cpp
@@ -129,7 +129,7 @@ std::vector<LPCWSTR> CMRUFile::GetPathList() const
 }
 
 /*! アイテム数を返す */
-int CMRUFile::Length(void) const
+int CMRUFile::Length() const
 {
 	return m_cRecentFile.GetItemCount();
 }
@@ -137,7 +137,7 @@ int CMRUFile::Length(void) const
 /*!
 	ファイル履歴のクリア
 */
-void CMRUFile::ClearAll(void)
+void CMRUFile::ClearAll()
 {
 	m_cRecentFile.DeleteAllItem();
 }

--- a/sakura_core/recent/CMRUFile.h
+++ b/sakura_core/recent/CMRUFile.h
@@ -48,9 +48,9 @@ public:
 	std::vector<LPCWSTR> GetPathList() const;
 
 	//	アクセス関数
-	int Length(void) const;	//	アイテムの数。
-	int MenuLength(void) const { return t_min(Length(), m_cRecentFile.GetViewCount()); }	//	メニューに表示されるアイテムの数
-	void ClearAll(void);//	アイテムを削除～。
+	int Length() const;	//	アイテムの数。
+	int MenuLength() const { return t_min(Length(), m_cRecentFile.GetViewCount()); }	//	メニューに表示されるアイテムの数
+	void ClearAll();//	アイテムを削除～。
 	bool GetEditInfo( int num, EditInfo* pfi ) const;				//	番号で指定したEditInfo（情報をまるごと）
 	bool GetEditInfo( const WCHAR* pszPath, EditInfo* pfi ) const;	//	ファイル名で指定したEditInfo（情報をまるごと）
 	void Add( EditInfo* pEditInfo );		//	*pEditInfoを追加する。

--- a/sakura_core/recent/CMRUFolder.h
+++ b/sakura_core/recent/CMRUFolder.h
@@ -46,7 +46,7 @@ public:
 
 	//	アクセス関数
 	int Length() const;	//	アイテムの数。
-	int MenuLength(void) const{ return t_min(Length(), m_cRecentFolder.GetViewCount()); }	//	メニューに表示されるアイテムの数
+	int MenuLength() const{ return t_min(Length(), m_cRecentFolder.GetViewCount()); }	//	メニューに表示されるアイテムの数
 	void ClearAll();					//	アイテムを削除～。
 	void Add( const WCHAR* pszFolder );	//	pszFolderを追加する。
 	const WCHAR* GetPath(int num) const;

--- a/sakura_core/typeprop/CDlgKeywordSelect.cpp
+++ b/sakura_core/typeprop/CDlgKeywordSelect.cpp
@@ -105,7 +105,7 @@ BOOL CDlgKeywordSelect::OnBnClicked( int wID )
 
 /*! ダイアログデータの設定
 */
-void CDlgKeywordSelect::SetData( void )
+void CDlgKeywordSelect::SetData( )
 {
 	HWND	hwndCombo;
 	int		i;
@@ -144,7 +144,7 @@ void CDlgKeywordSelect::SetData( void )
 
 /*! ダイアログデータの設定
 */
-int CDlgKeywordSelect::GetData( void )
+int CDlgKeywordSelect::GetData( )
 {
 	HWND	hwndCombo;
 	int		index;
@@ -168,7 +168,7 @@ int CDlgKeywordSelect::GetData( void )
 	return TRUE;
 }
 
-LPVOID CDlgKeywordSelect::GetHelpIdTable( void )
+LPVOID CDlgKeywordSelect::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/typeprop/CDlgKeywordSelect.h
+++ b/sakura_core/typeprop/CDlgKeywordSelect.h
@@ -40,9 +40,9 @@ protected:
 
 	BOOL OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam) override;
 	BOOL OnBnClicked(int wID) override;
-	int  GetData( void ) override;
-	void SetData( void ) override;
-	LPVOID GetHelpIdTable( void ) override;
+	int  GetData( ) override;
+	void SetData( ) override;
+	LPVOID GetHelpIdTable( ) override;
 
 	int m_nSet[ KEYWORD_SELECT_NUM ];
 	CKeyWordSetMgr*	m_pCKeyWordSetMgr;

--- a/sakura_core/typeprop/CDlgSameColor.cpp
+++ b/sakura_core/typeprop/CDlgSameColor.cpp
@@ -35,7 +35,7 @@ static const DWORD p_helpids[] = {	// 2006.10.10 ryoji
 	0, 0
 };
 
-LPVOID CDlgSameColor::GetHelpIdTable( void )
+LPVOID CDlgSameColor::GetHelpIdTable( )
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/typeprop/CDlgSameColor.h
+++ b/sakura_core/typeprop/CDlgSameColor.h
@@ -33,7 +33,7 @@ public:
 
 protected:
 
-	LPVOID GetHelpIdTable( void ) override;
+	LPVOID GetHelpIdTable( ) override;
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;	//! ダイアログのメッセージ処理
 	BOOL OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam ) override;			//!< WM_INITDIALOG 処理
 	BOOL OnBnClicked( int wID ) override;							//!< BN_CLICKED 処理

--- a/sakura_core/typeprop/CDlgTypeAscertain.cpp
+++ b/sakura_core/typeprop/CDlgTypeAscertain.cpp
@@ -83,7 +83,7 @@ BOOL CDlgTypeAscertain::OnBnClicked( int wID )
 }
 
 /* ダイアログデータの設定 */
-void CDlgTypeAscertain::SetData( void )
+void CDlgTypeAscertain::SetData( )
 {
 	// タイプ名設定
 	std::wstring typeNameTo = m_psi->sTypeNameTo + L"(&B)";
@@ -144,7 +144,7 @@ void CDlgTypeAscertain::SetData( void )
 	return;
 }
 
-LPVOID CDlgTypeAscertain::GetHelpIdTable(void)
+LPVOID CDlgTypeAscertain::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }

--- a/sakura_core/typeprop/CDlgTypeAscertain.h
+++ b/sakura_core/typeprop/CDlgTypeAscertain.h
@@ -45,7 +45,7 @@ protected:
 	// 実装ヘルパ関数
 	BOOL OnBnClicked(int wID) override;
 	void SetData() override;	/* ダイアログデータの設定 */
-	LPVOID GetHelpIdTable(void) override;
+	LPVOID GetHelpIdTable() override;
 
 private:
 	SAscertainInfo* m_psi;			// インターフェース

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -310,7 +310,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 }
 
 /* ダイアログデータの設定 */
-void CDlgTypeList::SetData( void )
+void CDlgTypeList::SetData( )
 {
 	SetData(m_nSettingType.GetIndex());
 }
@@ -380,7 +380,7 @@ void CDlgTypeList::SetData( int selIdx )
 }
 
 //@@@ 2002.01.18 add start
-LPVOID CDlgTypeList::GetHelpIdTable(void)
+LPVOID CDlgTypeList::GetHelpIdTable()
 {
 	return (LPVOID)p_helpids;
 }
@@ -493,7 +493,7 @@ bool CDlgTypeList::Export()
 	@retval true  正常
 	@retval false 異常
 */
-bool CDlgTypeList::InitializeType( void )
+bool CDlgTypeList::InitializeType( )
 {
 	HWND hwndDlg = GetHwnd();
 	HWND hwndList = GetItemHwnd( IDC_LIST_TYPES );

--- a/sakura_core/typeprop/CDlgTypeList.h
+++ b/sakura_core/typeprop/CDlgTypeList.h
@@ -46,10 +46,10 @@ protected:
 	INT_PTR DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam ) override;
 	void SetData() override;	/* ダイアログデータの設定 */
 	void SetData(int selIdx);	/* ダイアログデータの設定 */
-	LPVOID GetHelpIdTable(void) override;	//@@@ 2002.01.18 add
-	bool Import( void );			// 2010/4/12 Uchi
-	bool Export( void );			// 2010/4/12 Uchi
-	bool InitializeType( void );	// 2010/4/12 Uchi
+	LPVOID GetHelpIdTable() override;	//@@@ 2002.01.18 add
+	bool Import( );			// 2010/4/12 Uchi
+	bool Export( );			// 2010/4/12 Uchi
+	bool InitializeType( );	// 2010/4/12 Uchi
 	bool CopyType();
 	bool UpType();
 	bool DownType();

--- a/sakura_core/types/CType_Cpp.cpp
+++ b/sakura_core/types/CType_Cpp.cpp
@@ -179,7 +179,7 @@ static bool CPP_IsFunctionAfterKeyword( const wchar_t* s )
 
 class CCppPreprocessMng {
 public:
-	CCppPreprocessMng(void) = default;
+	CCppPreprocessMng() = default;
 
 	CLogicInt ScanLine(const wchar_t*, CLogicInt);
 

--- a/sakura_core/types/CType_Python.cpp
+++ b/sakura_core/types/CType_Python.cpp
@@ -82,7 +82,7 @@ struct COutlinePython {
 	int EnterString( const wchar_t* data, int linelen, int start_offset );
 	void DoScanLine( const wchar_t* data, int linelen, int start_offset );
 	
-	bool IsLogicalLineTop(void) const { return STATE_NORMAL == m_state; }
+	bool IsLogicalLineTop() const { return STATE_NORMAL == m_state; }
 };
 
 void CType_Python::InitTypeConfigImp(STypeConfig* pType)

--- a/sakura_core/uiparts/CImageListMgr.cpp
+++ b/sakura_core/uiparts/CImageListMgr.cpp
@@ -249,7 +249,7 @@ struct MyRGBQUAD : tagRGBQUAD
 	{
 		return !(*this == rhs);
 	}
-	operator COLORREF ( void ) const noexcept
+	operator COLORREF ( ) const noexcept
 	{
 		return RGB( rgbRed, rgbGreen, rgbBlue );
 	}

--- a/sakura_core/uiparts/CImageListMgr.h
+++ b/sakura_core/uiparts/CImageListMgr.h
@@ -64,12 +64,12 @@ public:
 		int imageNo, DWORD fStyle, LONG cx, LONG cy ) const;
 
 	//! アイコン数を返す
-	int  Count(void) const;	//	アイコン数
+	int  Count() const;	//	アイコン数
 	
 	//! アイコンの幅
-	int  cx(void) const { return m_cx; }
+	int  cx() const { return m_cx; }
 	//! アイコンの高さ
-	int  cy(void) const { return m_cy; }
+	int  cy() const { return m_cy; }
 	
 	//! アイコンを追加する
 	int Add(const WCHAR* szPath);

--- a/sakura_core/uiparts/CMenuDrawer.cpp
+++ b/sakura_core/uiparts/CMenuDrawer.cpp
@@ -725,7 +725,7 @@ void CMenuDrawer::Create( HINSTANCE hInstance, HWND hWndOwner, CImageListMgr* pc
 	return;
 }
 
-void CMenuDrawer::ResetContents( void )
+void CMenuDrawer::ResetContents( )
 {
 	LOGFONT	lf;
 	m_menuItems.clear();

--- a/sakura_core/uiparts/CMenuDrawer.h
+++ b/sakura_core/uiparts/CMenuDrawer.h
@@ -64,7 +64,7 @@ public:
 	/*
 	||  Attributes & Operations
 	*/
-	void ResetContents( void );
+	void ResetContents( );
 	void MyAppendMenu( HMENU hMenu, int nFlag, UINT_PTR nFuncId, const WCHAR*     pszLabel, const WCHAR*     pszKey, BOOL bAddKeyStr = TRUE, int nForceIconId = -1 );	/* メニュー項目を追加 */	//お気に入り	//@@@ 2003.04.08 MIK	// add pszKey	2010/5/17 Uchi
 	void MyAppendMenuSep( HMENU hMenu, int nFlag, int nFuncId, const WCHAR* pszLabel, BOOL bAddKeyStr = TRUE, int nForceIconId = -1 )
 	{

--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -295,7 +295,7 @@ CDisableWow64FsRedirect::~CDisableWow64FsRedirect()
 	}
 }
 
-BOOL IsPowerShellAvailable(void)
+BOOL IsPowerShellAvailable()
 {
 #ifndef _WIN64
 	/*

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -85,7 +85,7 @@ private:
 /*!
 	@brief PowerShell が利用可能か判定する
 */
-BOOL IsPowerShellAvailable(void);
+BOOL IsPowerShellAvailable();
 
 /*!
 	@brief IMEのオープン状態を設定する

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -117,7 +117,7 @@ VOID CALLBACK EditViewTimerProc(
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 //	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-CEditView::CEditView( void )
+CEditView::CEditView( )
 : CViewCalc(this)				// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 , m_cViewSelect(this)			// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 , m_cParser(this)				// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
@@ -983,7 +983,7 @@ void CEditView::OnSize( int cx, int cy )
 }
 
 /* 入力フォーカスを受け取ったときの処理 */
-void CEditView::OnSetFocus( void )
+void CEditView::OnSetFocus( )
 {
 	if( m_bMiniMap ){
 		return;
@@ -1022,7 +1022,7 @@ void CEditView::OnSetFocus( void )
 }
 
 /* 入力フォーカスを失ったときの処理 */
-void CEditView::OnKillFocus( void )
+void CEditView::OnKillFocus( )
 {
 	if( m_bMiniMap ){
 		return;
@@ -1062,7 +1062,7 @@ void CEditView::OnKillFocus( void )
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /* フォントの変更 */
-void CEditView::SetFont( void )
+void CEditView::SetFont( )
 {
 	HDC hdc = ::GetDC( GetHwnd() );
 
@@ -1444,7 +1444,7 @@ void CEditView::ConvSelectedArea( EFunctionCode nFuncCode )
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /* ポップアップメニュー(右クリック) */
-int	CEditView::CreatePopUpMenu_R( void )
+int	CEditView::CreatePopUpMenu_R( )
 {
 	HMENU		hMenu;
 	int			nMenuIdx;
@@ -2579,7 +2579,7 @@ void CEditView::SendStatusMessage( const WCHAR* msg )
 
 	@date 2005.10.02 genta 管理方法変更のため関数化
 */
-bool CEditView::IsInsMode(void) const
+bool CEditView::IsInsMode() const
 {
 	return m_pcEditDoc->m_cDocEditor.IsInsMode();
 }
@@ -2619,7 +2619,7 @@ void CEditView::OnAfterLoad([[maybe_unused]] const SLoadInfo& sLoadInfo)
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 //!	現在のカーソル行位置を履歴に登録する
-void CEditView::AddCurrentLineToHistory( void )
+void CEditView::AddCurrentLineToHistory( )
 {
 	CLogicPoint ptPos;
 

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -139,7 +139,7 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	/* Constructors */
-	CEditView( void );
+	CEditView( );
 	~CEditView();
 	void Close();
 	/* 初期化系メンバ関数 */
@@ -198,8 +198,8 @@ public:
 	void OnSize(int cx, int cy);							/* ウィンドウサイズの変更処理 */
 	void OnMove(int x, int y, int nWidth, int nHeight);
 	//フォーカス
-	void OnSetFocus( void );
-	void OnKillFocus( void );
+	void OnSetFocus( );
+	void OnKillFocus( );
 	//スクロール
 	CLayoutInt  OnVScroll(int nScrollCode, int nPos);							/* 垂直スクロールバーメッセージ処理 */
 	CLayoutInt  OnHScroll(int nScrollCode, int nPos);							/* 水平スクロールバーメッセージ処理 */
@@ -277,16 +277,16 @@ public:
 	void AdjustScrollBars( BOOL bRedraw = TRUE );						/* スクロールバーの状態を更新する */
 	BOOL CreateScrollBar();												/* スクロールバー作成 */	// 2006.12.19 ryoji
 	void DestroyScrollBar();											/* スクロールバー破棄 */	// 2006.12.19 ryoji
-	CLayoutInt GetWrapOverhang( void ) const;							/* 折り返し桁以後のぶら下げ余白計算 */	// 2008.06.08 ryoji
+	CLayoutInt GetWrapOverhang( ) const;							/* 折り返し桁以後のぶら下げ余白計算 */	// 2008.06.08 ryoji
 	CKetaXInt ViewColNumToWrapColNum( CLayoutXInt nViewColNum ) const;	/* 「右端で折り返す」用にビューの桁数から折り返し桁数を計算する */	// 2008.06.08 ryoji
-	CLayoutInt GetRightEdgeForScrollBar( void );								/* スクロールバー制御用に右端座標を取得する */		// 2009.08.28 nasukoji
+	CLayoutInt GetRightEdgeForScrollBar( );								/* スクロールバー制御用に右端座標を取得する */		// 2009.08.28 nasukoji
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           IME                               //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	//	Aug. 25, 2002 genta protected->publicに移動
-	bool IsImeON( void );	// IME ONか	// 2006.12.04 ryoji
+	bool IsImeON( );	// IME ONか	// 2006.12.04 ryoji
 	
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                        スクロール                           //
@@ -313,8 +313,8 @@ public:
 	//                        過去の遺産                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
-	void SetIMECompFormPos( void );								/* IME編集エリアの位置を変更 */
-	void SetIMECompFormFont( void );							/* IME編集エリアの表示フォントを変更 */
+	void SetIMECompFormPos( );								/* IME編集エリアの位置を変更 */
+	void SetIMECompFormFont( );							/* IME編集エリアの表示フォントを変更 */
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                       テキスト選択                          //
@@ -355,13 +355,13 @@ public: /* テスト用にアクセス属性を変更 */
 	/* IDropTarget実装 */
 	STDMETHODIMP DragEnter(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
 	STDMETHODIMP DragOver(DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
-	STDMETHODIMP DragLeave( void );
+	STDMETHODIMP DragLeave( );
 	STDMETHODIMP Drop(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
 	STDMETHODIMP PostMyDropFiles( LPDATAOBJECT pDataObject );		/* 独自ドロップファイルメッセージをポストする */	// 2008.06.20 ryoji
 	void OnMyDropFiles( HDROP hDrop );								/* 独自ドロップファイルメッセージ処理 */	// 2008.06.20 ryoji
 	CLIPFORMAT GetAvailableClipFormat( LPDATAOBJECT pDataObject );
 	DWORD TranslateDropEffect( CLIPFORMAT cf, DWORD dwKeyState, POINTL pt, DWORD dwEffect );
-	bool IsDragSource( void );
+	bool IsDragSource( );
 
 	void _SetDragMode(BOOL b)
 	{
@@ -420,7 +420,7 @@ public:
 		bool			bFastMode = false,
 		const CLogicRange*	psDelRangeLogicFast = nullptr
 	);
-	void RTrimPrevLine( void );		/* 2005.10.11 ryoji 前の行にある末尾の空白を削除 */
+	void RTrimPrevLine( );		/* 2005.10.11 ryoji 前の行にある末尾の空白を削除 */
 
 	//	Oct. 2, 2005 genta 挿入モードの設定・取得
 	bool IsInsMode() const;
@@ -465,8 +465,8 @@ private:
 	void ISearchExec(DWORD wChar);
 	void ISearchExec(LPCWSTR pszText);
 	void ISearchExec(bool bNext);
-	void ISearchBack(void) ;
-	void ISearchWordMake(void);
+	void ISearchBack() ;
+	void ISearchWordMake();
 	void ISearchSetStatusMsg(CNativeW* msg) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -489,7 +489,7 @@ public:
 	/* 支援 */
 	//	Jan. 10, 2005 genta HandleCommandから補完関連処理を分離
 	void PreprocessCommand_hokan( int nCommand );
-	void PostprocessCommand_hokan(void);
+	void PostprocessCommand_hokan();
 
 	// 補完ウィンドウを表示する。Ctrl+Spaceや、文字の入力/削除時に呼び出されます。 YAZAKI 2002/03/11
 	void ShowHokanMgr( CNativeW& cmemData, BOOL bAutoDecided );
@@ -509,7 +509,7 @@ public:
 	//                         メニュー                            //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-	int	CreatePopUpMenu_R( void );		/* ポップアップメニュー(右クリック) */
+	int	CreatePopUpMenu_R( );		/* ポップアップメニュー(右クリック) */
 	int	CreatePopUpMenuSub( HMENU hMenu, int nMenuIdx, int* pParentMenus, EKeyHelpRMenuType eRmenuType );		/* ポップアップメニュー */
 	void AddKeyHelpMenu(HMENU hMenu, EKeyHelpRMenuType eRmenuType);
 
@@ -527,7 +527,7 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 public:
 	//	Aug. 31, 2000 genta
-	void AddCurrentLineToHistory(void);	//現在行を履歴に追加する
+	void AddCurrentLineToHistory();	//現在行を履歴に追加する
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                          その他                             //
@@ -546,7 +546,7 @@ public:
 	TOGGLE_WRAP_ACTION GetWrapMode( CKetaXInt* newKetas );
 	void SmartIndent_CPP(wchar_t wcChar);	/* C/C++スマートインデント処理 */
 	/* コマンド操作 */
-	void SetFont( void );										/* フォントの変更 */
+	void SetFont( );										/* フォントの変更 */
 	void SplitBoxOnOff(BOOL bVert, BOOL bHorz, BOOL bSizeBox);						/* 縦・横の分割ボックス・サイズボックスのＯＮ／ＯＦＦ */
 
 //	2001/06/18 asa-o

--- a/sakura_core/view/CEditView_CmdHokan.cpp
+++ b/sakura_core/view/CEditView_CmdHokan.cpp
@@ -53,7 +53,7 @@ void CEditView::PreprocessCommand_hokan( int nCommand )
 	@author Moca
 	@date 2005.01.10 genta 関数化
 */
-void CEditView::PostprocessCommand_hokan(void)
+void CEditView::PostprocessCommand_hokan()
 {
 	if( m_bHokan && !m_bExecutingKeyMacro ){ /* キーボードマクロの実行中 */
 		CNativeW	cmemData;

--- a/sakura_core/view/CEditView_Cmdisrch.cpp
+++ b/sakura_core/view/CEditView_Cmdisrch.cpp
@@ -458,7 +458,7 @@ void CEditView::ISearchExec(bool bNext)
 }
 
 //!	バックスペースを押されたときの処理
-void CEditView::ISearchBack(void) {
+void CEditView::ISearchBack() {
 	if(m_nISearchHistoryCount==0) return;
 	
 	if(m_nISearchHistoryCount==1){
@@ -507,7 +507,7 @@ void CEditView::ISearchBack(void) {
 }
 
 //!	入力文字から、検索文字を生成する。
-void CEditView::ISearchWordMake(void)
+void CEditView::ISearchWordMake()
 {
 	switch ( m_nISearchMode ) {
 	case SEARCH_NORMAL: // 通常インクリメンタルサーチ

--- a/sakura_core/view/CEditView_Command_New.cpp
+++ b/sakura_core/view/CEditView_Command_New.cpp
@@ -955,7 +955,7 @@ bool CEditView::ReplaceData_CEditView3(
 }
 
 // 2005.10.11 ryoji 前の行にある末尾の空白を削除
-void CEditView::RTrimPrevLine( void )
+void CEditView::RTrimPrevLine( )
 {
 	int			nCharChars;
 

--- a/sakura_core/view/CEditView_Ime.cpp
+++ b/sakura_core/view/CEditView_Ime.cpp
@@ -36,7 +36,7 @@
 
 	@date  2006.12.04 ryoji 新規作成（関数化）
 */
-bool CEditView::IsImeON( void )
+bool CEditView::IsImeON( )
 {
 	bool bRet;
 	HIMC	hIme;
@@ -63,7 +63,7 @@ bool CEditView::IsImeON( void )
 }
 
 /* IME編集エリアの位置を変更 */
-void CEditView::SetIMECompFormPos( void )
+void CEditView::SetIMECompFormPos( )
 {
 	//
 	// If current composition form mode is near caret operation,
@@ -88,7 +88,7 @@ void CEditView::SetIMECompFormPos( void )
 }
 
 /* IME編集エリアの表示フォントを変更 */
-void CEditView::SetIMECompFormFont( void )
+void CEditView::SetIMECompFormFont( )
 {
 	//
 	// If current composition form mode is near caret operation,

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -1753,7 +1753,7 @@ STDMETHODIMP CEditView::DragOver( DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect
 	return S_OK;
 }
 
-STDMETHODIMP CEditView::DragLeave( void )
+STDMETHODIMP CEditView::DragLeave( )
 {
 	DEBUG_TRACE( L"CEditView::DragLeave()\n" );
 	/* 選択テキストのドラッグ中か */
@@ -2238,7 +2238,7 @@ DWORD CEditView::TranslateDropEffect( CLIPFORMAT cf, DWORD dwKeyState, [[maybe_u
 	return dwEffect;
 }
 
-bool CEditView::IsDragSource( void )
+bool CEditView::IsDragSource( )
 {
 	return ( this == GetEditWnd().GetDragSourceView() );
 }

--- a/sakura_core/view/CEditView_Scroll.cpp
+++ b/sakura_core/view/CEditView_Scroll.cpp
@@ -738,7 +738,7 @@ void CEditView::SyncScrollH( CLayoutInt col )
 /** 折り返し桁以後のぶら下げ余白計算
 	@date 2008.06.08 ryoji 新規作成
 */
-CLayoutInt CEditView::GetWrapOverhang( void ) const
+CLayoutInt CEditView::GetWrapOverhang( ) const
 {
 	CLayoutInt nMargin = GetTextMetrics().GetLayoutXDefault(CKetaXInt(1));	// 折り返し記号
 	if (!m_pTypeData->m_bKinsokuHide) {	// ぶら下げを隠す時はスキップ	2012/11/30 Uchi
@@ -790,7 +790,7 @@ CKetaXInt CEditView::ViewColNumToWrapColNum( CLayoutXInt nViewColNum ) const
 
 	@date 2009.08.28 nasukoji	新規作成
 */
-CLayoutInt CEditView::GetRightEdgeForScrollBar( void )
+CLayoutInt CEditView::GetRightEdgeForScrollBar( )
 {
 	// 折り返し桁以後のぶら下げ余白計算
 	CLayoutXInt nWidth = m_pcEditDoc->m_cLayoutMgr.GetMaxLineLayout() + GetWrapOverhang();

--- a/sakura_core/view/CViewFont.h
+++ b/sakura_core/view/CViewFont.h
@@ -49,7 +49,7 @@ public:
 
 private:
 	void CreateFonts( const LOGFONT *plf );
-	void DeleteFonts( void );
+	void DeleteFonts( );
 
 	HFONT	m_hFont_HAN;			/* 現在のフォントハンドル */
 	HFONT	m_hFont_HAN_BOLD;		/* 現在のフォントハンドル(太字) */

--- a/sakura_core/view/colors/CColorStrategy.cpp
+++ b/sakura_core/view/colors/CColorStrategy.cpp
@@ -259,7 +259,7 @@ void CColorStrategyPool::CheckColorMODE(
 
 /*! 設定更新
 */
-void CColorStrategyPool::OnChangeSetting(void)
+void CColorStrategyPool::OnChangeSetting()
 {
 	m_vStrategiesDisp.clear();
 
@@ -348,7 +348,7 @@ bool CColorStrategyPool::IsSkipBeforeLayout()
 	return true;
 }
 
-bool CColorStrategyPool::HasRangeBasedColorStrategies(void) const noexcept
+bool CColorStrategyPool::HasRangeBasedColorStrategies() const noexcept
 {
 	return (m_pcLineComment != nullptr)
 		|| (m_pcBlockComment1 != nullptr)

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -145,7 +145,7 @@ public:
 	virtual void OnStartScanLogic(){}
 
 	//! 設定更新
-	virtual void Update(void)
+	virtual void Update()
 	{
 		const CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
 		m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
@@ -197,10 +197,10 @@ public:
 	bool IsSkipBeforeLayout();	// レイアウトが行頭からチェックしなくていいか判定
 
 	//設定変更
-	void OnChangeSetting(void);
+	void OnChangeSetting();
 
 	//ビューの設定・取得
-	CEditView* GetCurrentView(void) const noexcept { return m_pcView; }
+	CEditView* GetCurrentView() const noexcept { return m_pcView; }
 	void SetCurrentView(CEditView* pcView) { m_pcView = pcView; }
 
 	//範囲を持つ色分けがあるかどうか

--- a/sakura_core/view/colors/CColor_Comment.h
+++ b/sakura_core/view/colors/CColor_Comment.h
@@ -42,7 +42,7 @@ public:
 class CColor_BlockComment final : public CColorStrategy{
 public:
 	CColor_BlockComment(EColorIndexType nType) : m_nType(nType), m_nCOMMENTEND(0){}
-	void Update(void) override {
+	void Update() override {
 		const CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
 		m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
 		m_pcBlockComment = &m_pTypeData->m_cBlockComments[m_nType - COLORIDX_BLOCK1];

--- a/sakura_core/view/colors/CColor_Quote.cpp
+++ b/sakura_core/view/colors/CColor_Quote.cpp
@@ -27,7 +27,7 @@ public:
 	}
 };
 
-void CColor_Quote::Update(void)
+void CColor_Quote::Update()
 {
 	const CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
 	m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();

--- a/sakura_core/view/colors/CColor_Quote.h
+++ b/sakura_core/view/colors/CColor_Quote.h
@@ -18,7 +18,7 @@ public:
 		m_szQuote[1] = cQuote;
 		m_szQuote[2] = cQuote;
 	}
-	void Update(void) override;
+	void Update() override;
 	CLayoutColorInfo* GetStrategyColorInfo() const override;
 	void InitStrategyStatus() override{ m_nCOMMENTEND = -1; }
 	void SetStrategyColorInfo(const CLayoutColorInfo*) override;

--- a/sakura_core/view/figures/CFigureManager.cpp
+++ b/sakura_core/view/figures/CFigureManager.cpp
@@ -56,7 +56,7 @@ CFigure& CFigureManager::GetFigure(const wchar_t* pText, int nTextLen)
 
 /*! 設定更新
 */
-void CFigureManager::OnChangeSetting(void)
+void CFigureManager::OnChangeSetting()
 {
 	m_vFiguresDisp.clear();
 

--- a/sakura_core/view/figures/CFigureManager.h
+++ b/sakura_core/view/figures/CFigureManager.h
@@ -25,7 +25,7 @@ public:
 	CFigure& GetFigure(const wchar_t* pText, int nTextLen);
 
 	// 設定変更
-	void OnChangeSetting(void);
+	void OnChangeSetting();
 
 private:
 	std::vector<CFigure*>	m_vFigures;

--- a/sakura_core/view/figures/CFigureStrategy.h
+++ b/sakura_core/view/figures/CFigureStrategy.h
@@ -20,10 +20,10 @@ public:
 	virtual bool Match(const wchar_t* pText, int nTextLen) const = 0;
 
 	//! 色分け表示対象判定
-	virtual bool Disp(void) const = 0;
+	virtual bool Disp() const = 0;
 
 	//! 設定更新
-	virtual void Update(void)
+	virtual void Update()
 	{
 		CEditDoc* pCEditDoc = CEditDoc::GetInstance(0);
 		m_pTypeData = &pCEditDoc->m_cDocType.GetDocumentAttribute();
@@ -55,7 +55,7 @@ public:
 	}
 
 	//! 色分け表示対象判定
-	bool Disp(void) const override
+	bool Disp() const override
 	{
 		return true;
 	}
@@ -68,17 +68,17 @@ public:
 
 protected:
 	virtual void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const = 0;
-	virtual EColorIndexType GetColorIdx(void) const = 0;
+	virtual EColorIndexType GetColorIdx() const = 0;
 
 public:
 	//! 色分け表示対象判定
-	bool Disp(void) const override
+	bool Disp() const override
 	{
 		EColorIndexType nColorIndex = GetColorIdx();
 		return m_pTypeData->m_ColorInfoArr[nColorIndex].m_bDisp;
 	}
 
-	void Update(void) override
+	void Update() override
 	{
 		CFigure::Update();
 
@@ -91,7 +91,7 @@ public:
 	}
 
 protected:
-	EColorIndexType GetDispColorIdx(void) const{ return m_nDispColorIndex; }
+	EColorIndexType GetDispColorIdx() const{ return m_nDispColorIndex; }
 
 	// 実装補助
 	bool DrawImp_StyleSelect(SColorStrategyInfo* pInfo);

--- a/sakura_core/view/figures/CFigure_Comma.cpp
+++ b/sakura_core/view/figures/CFigure_Comma.cpp
@@ -22,7 +22,7 @@ bool CFigure_Comma::Match(const wchar_t* pText, [[maybe_unused]] int nTextLen) c
 	return false;
 }
 
-bool CFigure_Comma::Disp(void) const
+bool CFigure_Comma::Disp() const
 {
 	return m_pTypeData->m_nTsvMode == TSV_MODE_CSV;
 }

--- a/sakura_core/view/figures/CFigure_Comma.h
+++ b/sakura_core/view/figures/CFigure_Comma.h
@@ -16,10 +16,10 @@ class CFigure_Comma final : public CFigureSpace{
 public:
 	//traits
 	bool Match(const wchar_t* pText, int nTextLen) const override;
-	bool Disp(void) const override;
+	bool Disp() const override;
 
 	//action
 	void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const override;
-	EColorIndexType GetColorIdx(void) const override { return COLORIDX_TAB; }
+	EColorIndexType GetColorIdx() const override { return COLORIDX_TAB; }
 };
 #endif /* SAKURA_CFIGURE_COMMA_DE8237CD_24C0_4A21_8599_5BE8B04BF7E6_H_ */

--- a/sakura_core/view/figures/CFigure_CtrlCode.h
+++ b/sakura_core/view/figures/CFigure_CtrlCode.h
@@ -25,7 +25,7 @@ public:
 	{
 		assert(0);
 	}
-	EColorIndexType GetColorIdx(void) const override { return COLORIDX_CTRLCODE; }
+	EColorIndexType GetColorIdx() const override { return COLORIDX_CTRLCODE; }
 };
 
 #endif /* SAKURA_CFIGURE_CTRLCODE_53EB409B_17F7_4B7F_9AD2_A00C29CDC792_H_ */

--- a/sakura_core/view/figures/CFigure_Eol.h
+++ b/sakura_core/view/figures/CFigure_Eol.h
@@ -29,7 +29,7 @@ public:
 	}
 	//traits
 	bool Match(const wchar_t* pText, int nTextLen) const override;
-	bool Disp(void) const override
+	bool Disp() const override
 	{
 		return true;
 	}
@@ -39,7 +39,7 @@ public:
 	void DispSpace([[maybe_unused]] CGraphics& gr, [[maybe_unused]] DispPos* pDispPos, [[maybe_unused]] CEditView* pcView, [[maybe_unused]] bool bTrans) const  override
 	{
 	}
-	EColorIndexType GetColorIdx(void) const override { return COLORIDX_EOL; }
+	EColorIndexType GetColorIdx() const override { return COLORIDX_EOL; }
 
 private:
 	HPEN m_hPen = nullptr;

--- a/sakura_core/view/figures/CFigure_HanSpace.h
+++ b/sakura_core/view/figures/CFigure_HanSpace.h
@@ -19,6 +19,6 @@ public:
 
 	//action
 	void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool trans) const override;
-	EColorIndexType GetColorIdx(void) const override { return COLORIDX_SPACE; }
+	EColorIndexType GetColorIdx() const override { return COLORIDX_SPACE; }
 };
 #endif /* SAKURA_CFIGURE_HANSPACE_38751BA0_6F58_4929_A24D_1937F2FB3E6A_H_ */

--- a/sakura_core/view/figures/CFigure_Tab.h
+++ b/sakura_core/view/figures/CFigure_Tab.h
@@ -16,13 +16,13 @@ class CFigure_Tab final : public CFigureSpace{
 public:
 	//traits
 	bool Match(const wchar_t* pText, int nTextLen) const override;
-	bool Disp(void) const override
+	bool Disp() const override
 	{
 		return true;
 	}
 
 	//action
 	void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const override;
-	EColorIndexType GetColorIdx(void) const override { return COLORIDX_TAB; }
+	EColorIndexType GetColorIdx() const override { return COLORIDX_TAB; }
 };
 #endif /* SAKURA_CFIGURE_TAB_4401678E_D165_4130_A973_CC40038CDE8E_H_ */

--- a/sakura_core/view/figures/CFigure_ZenSpace.h
+++ b/sakura_core/view/figures/CFigure_ZenSpace.h
@@ -19,6 +19,6 @@ public:
 
 	//action
 	void DispSpace(CGraphics& gr, DispPos* pDispPos, CEditView* pcView, bool bTrans) const override;
-	EColorIndexType GetColorIdx(void) const override { return COLORIDX_ZENSPACE; }
+	EColorIndexType GetColorIdx() const override { return COLORIDX_ZENSPACE; }
 };
 #endif /* SAKURA_CFIGURE_ZENSPACE_6176BBA4_68C9_41A1_B944_7F6EE0E5E4A4_H_ */

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -884,7 +884,7 @@ void CEditWnd::LayoutMainMenu()
 /*! ツールバーの配置処理
 	@date 2006.12.19 ryoji 新規作成
 */
-void CEditWnd::LayoutToolBar( void )
+void CEditWnd::LayoutToolBar( )
 {
 	if( m_pShareData->m_Common.m_sWindow.m_bDispTOOLBAR ){	/* ツールバーを表示する */
 		m_cToolbar.CreateToolBar();
@@ -897,7 +897,7 @@ void CEditWnd::LayoutToolBar( void )
 /*! ステータスバーの配置処理
 	@date 2006.12.19 ryoji 新規作成
 */
-void CEditWnd::LayoutStatusBar( void )
+void CEditWnd::LayoutStatusBar( )
 {
 	if( m_pShareData->m_Common.m_sWindow.m_bDispSTATUSBAR ){	/* ステータスバーを表示する */
 		/* ステータスバー作成 */
@@ -912,7 +912,7 @@ void CEditWnd::LayoutStatusBar( void )
 /*! ファンクションキーの配置処理
 	@date 2006.12.19 ryoji 新規作成
 */
-void CEditWnd::LayoutFuncKey( void )
+void CEditWnd::LayoutFuncKey( )
 {
 	if( m_pShareData->m_Common.m_sWindow.m_bDispFUNCKEYWND ){	/* ファンクションキーを表示する */
 		if( nullptr == m_cFuncKeyWnd.GetHwnd() ){
@@ -936,7 +936,7 @@ void CEditWnd::LayoutFuncKey( void )
 /*! タブバーの配置処理
 	@date 2006.12.19 ryoji 新規作成
 */
-void CEditWnd::LayoutTabBar( void )
+void CEditWnd::LayoutTabBar( )
 {
 	if( m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd ){	/* タブバーを表示する */
 		if( nullptr == m_cTabWnd.GetHwnd() ){
@@ -953,7 +953,7 @@ void CEditWnd::LayoutTabBar( void )
 /*! ミニマップの配置処理
 	@date 2014.07.14 新規作成
 */
-void CEditWnd::LayoutMiniMap( void )
+void CEditWnd::LayoutMiniMap( )
 {
 	if( m_pShareData->m_Common.m_sWindow.m_bDispMiniMap ){	/* タブバーを表示する */
 		if( !m_cMiniMapView.GetHwnd() ){
@@ -1018,7 +1018,7 @@ static inline BOOL MyIsDialogMessage(HWND hwnd, MSG* msg)
 //複数プロセス版
 /* メッセージループ */
 //2004.02.17 Moca GetMessageのエラーチェック
-void CEditWnd::MessageLoop( void )
+void CEditWnd::MessageLoop( )
 {
 	MSG	msg;
 	int ret;
@@ -2700,7 +2700,7 @@ STDMETHODIMP CEditWnd::DragOver( [[maybe_unused]] DWORD dwKeyState, [[maybe_unus
 	return S_OK;
 }
 
-STDMETHODIMP CEditWnd::DragLeave( void )
+STDMETHODIMP CEditWnd::DragLeave( )
 {
 	return S_OK;
 }
@@ -2831,7 +2831,7 @@ LRESULT CEditWnd::OnTimer( WPARAM wParam, [[maybe_unused]] LPARAM lParam )
 /*! キャプション更新用タイマーの処理
 	@date 2007.04.03 ryoji 新規
 */
-void CEditWnd::OnCaptionTimer( void )
+void CEditWnd::OnCaptionTimer( )
 {
 	// 編集画面の切替（タブまとめ時）が終わっていたらタイマーを終了してタイトルバーを更新する
 	// まだ切替中ならタイマー継続
@@ -2845,7 +2845,7 @@ void CEditWnd::OnCaptionTimer( void )
 	@date 2007.04.03 ryoji パラメータ無しにした
 	                       以前はコールバック関数でやっていたKillTimer()をここで行うようにした
 */
-void CEditWnd::OnSysMenuTimer( void ) //by 鬼(2)
+void CEditWnd::OnSysMenuTimer( ) //by 鬼(2)
 {
 	::KillTimer( GetHwnd(), IDT_SYSMENU );	// 2007.04.03 ryoji
 
@@ -2875,7 +2875,7 @@ void CEditWnd::OnSysMenuTimer( void ) //by 鬼(2)
 //@@@ 2002.01.14 YAZAKI 印刷プレビューをCPrintPreviewに独立させたことによる変更
 
 /* 印刷プレビューモードのオン/オフ */
-void CEditWnd::PrintPreviewModeONOFF( void )
+void CEditWnd::PrintPreviewModeONOFF( )
 {
 	HMENU	hMenu;
 	HWND	hwndToolBar;
@@ -3548,7 +3548,7 @@ BOOL CEditWnd::DoMouseWheel( WPARAM wParam, LPARAM lParam )
 /* 印刷ページ設定
 	印刷プレビュー時にも、そうでないときでも呼ばれる可能性がある。
 */
-BOOL CEditWnd::OnPrintPageSetting( void )
+BOOL CEditWnd::OnPrintPageSetting( )
 {
 	/* 印刷設定（CANCEL押したときに破棄するための領域） */
 	CDlgPrintSetting	cDlgPrintSetting;
@@ -3851,7 +3851,7 @@ bool CEditWnd::GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIcon
 
 	@date 2002.12.04 CEditViewのコンストラクタから移動
 */
-void CEditWnd::InitMenubarMessageFont(void)
+void CEditWnd::InitMenubarMessageFont()
 {
 	TEXTMETRIC	tm;
 	LOGFONT		lf;
@@ -4217,7 +4217,7 @@ void CEditWnd::GetTooltipText(WCHAR* pszBuf, size_t nBufCount, UINT_PTR idFrom) 
 	@date 2006.01.28 aroka ツールバー更新を OnToolbarTimerに移動した
 	@date 2007.04.03 ryoji パラメータ無しにした
 */
-void CEditWnd::OnEditTimer( void )
+void CEditWnd::OnEditTimer( )
 {
 	//static	int	nLoopCount = 0; // wmlhq m_nTimerCountに移行
 	// タイマーの呼び出し間隔を 500msに変更。300*10→500*6にする。 20060128 aroka
@@ -4519,7 +4519,7 @@ BOOL CEditWnd::WrapWindowWidth( int nPane )
 	@retval 画面更新したかどうか
 	@date 2008.06.10 ryoji 新規作成
 */
-BOOL CEditWnd::UpdateTextWrap( void )
+BOOL CEditWnd::UpdateTextWrap( )
 {
 	// この関数はコマンド実行ごとに処理の最終段階で利用する
 	// （アンドゥ登録＆全ビュー更新のタイミング）
@@ -4727,7 +4727,7 @@ void CEditWnd::RestorePhysPosOfAllView( CLogicPointEx* pptPosArray )
 
 	@date 2009.01.17 nasukoji	新規作成
 */
-void CEditWnd::ClearMouseState( void )
+void CEditWnd::ClearMouseState( )
 {
 	SetPageScrollByWheel( FALSE );		// ホイール操作によるページスクロール有無
 	SetHScrollByWheel( FALSE );			// ホイール操作による横スクロール有無
@@ -4741,7 +4741,7 @@ void CEditWnd::ClearMouseState( void )
 	      IsWine()によりプロセス毎にアクセラレータテーブルが作成されるようになる
 	      ため、ショートカットキーやカーソルキーが正常に処理されるようになる。
 */
-void CEditWnd::CreateAccelTbl( void )
+void CEditWnd::CreateAccelTbl( )
 {
 	m_hAccel = CKeyBind::CreateAccerelator(
 		m_pShareData->m_Common.m_sKeyBind.m_nKeyNameArrNum,
@@ -4759,7 +4759,7 @@ void CEditWnd::CreateAccelTbl( void )
 /*! ウィンドウ毎に作成したアクセラレータテーブルを破棄する
 	@datet 2009.08.15 Hidetaka Sakai, nasukoji
 */
-void CEditWnd::DeleteAccelTbl( void )
+void CEditWnd::DeleteAccelTbl( )
 {
 	if( m_hAccel ){
 		m_hAccel = nullptr;

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -134,7 +134,7 @@ public:
 	void OnAfterSave(const SSaveInfo& sSaveInfo) override;
 
 	//管理
-	void MessageLoop( void );								/* メッセージループ */
+	void MessageLoop( );								/* メッセージループ */
 	LRESULT DispatchEvent(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);	/* メッセージ処理 */
 
 	//各種イベント
@@ -150,11 +150,11 @@ public:
 	LRESULT OnVScroll(WPARAM wParam, LPARAM lParam);
 	int	OnClose(HWND hWndActive, bool bGrepNoConfirm);	/* 終了時の処理 */
 	void OnDropFiles(HDROP hDrop);	/* ファイルがドロップされた */
-	BOOL OnPrintPageSetting( void );/* 印刷ページ設定 */
+	BOOL OnPrintPageSetting( );/* 印刷ページ設定 */
 	LRESULT OnTimer(WPARAM wParam, LPARAM lParam);	// WM_TIMER 処理	// 2007.04.03 ryoji
-	void OnEditTimer( void );	/* タイマーの処理 */
-	void OnCaptionTimer( void );
-	void OnSysMenuTimer( void );
+	void OnEditTimer( );	/* タイマーの処理 */
+	void OnCaptionTimer( );
+	void OnSysMenuTimer( );
 	void OnCommand(WORD wNotifyCode, WORD wID, HWND hwndCtl);
 	LRESULT OnNcLButtonDown(WPARAM wp, LPARAM lp);
 	LRESULT OnNcLButtonUp(WPARAM wp, LPARAM lp);
@@ -173,7 +173,7 @@ public:
 	void InitMenu(HMENU hMenu, UINT uPos, BOOL fSystemMenu);
 	void InitMenu_Function(HMENU hMenu, EFunctionCode eFunc, const wchar_t* pszName, const wchar_t* pszKey);
 	bool InitMenu_Special(HMENU hMenu, EFunctionCode eFunc);
-	void InitMenubarMessageFont(void);	//	メニューバーへのメッセージ表示機能をCEditWndより移管	//	Dec. 4, 2002 genta
+	void InitMenubarMessageFont();	//	メニューバーへのメッセージ表示機能をCEditWndより移管	//	Dec. 4, 2002 genta
 	LRESULT WinListMenu(HMENU hMenu, EditNode* pEditNodeArr, int nRowNum, BOOL bFull);	/*!< ウィンドウ一覧メニュー作成処理 */	// 2006.03.23 fon
 	LRESULT PopupWinList( bool bMousePos );	/*!< ウィンドウ一覧ポップアップ表示処理 */	// 2006.03.23 fon	// 2007.02.28 ryoji フルパス指定のパラメータを削除
 	void RegisterPluginCommand();			//プラグインコマンドをエディタに登録する
@@ -185,18 +185,18 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           整形                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	void LayoutMainMenu( void );		// メインメニュー					// 2010/5/16 Uchi
-	void LayoutToolBar( void );			/* ツールバーの配置処理 */			// 2006.12.19 ryoji
-	void LayoutFuncKey( void );			/* ファンクションキーの配置処理 */	// 2006.12.19 ryoji
-	void LayoutTabBar( void );			/* タブバーの配置処理 */			// 2006.12.19 ryoji
-	void LayoutStatusBar( void );		/* ステータスバーの配置処理 */		// 2006.12.19 ryoji
+	void LayoutMainMenu( );		// メインメニュー					// 2010/5/16 Uchi
+	void LayoutToolBar( );			/* ツールバーの配置処理 */			// 2006.12.19 ryoji
+	void LayoutFuncKey( );			/* ファンクションキーの配置処理 */	// 2006.12.19 ryoji
+	void LayoutTabBar( );			/* タブバーの配置処理 */			// 2006.12.19 ryoji
+	void LayoutStatusBar( );		/* ステータスバーの配置処理 */		// 2006.12.19 ryoji
 	void LayoutMiniMap();				// ミニマップの配置処理
 	void EndLayoutBars( BOOL bAdjust = TRUE );	/* バーの配置終了処理 */	// 2006.12.19 ryoji
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           設定                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	void PrintPreviewModeONOFF( void );	/* 印刷プレビューモードのオン/オフ */
+	void PrintPreviewModeONOFF( );	/* 印刷プレビューモードのオン/オフ */
 	
 	//アイコン
 	void SetWindowIcon(HICON hIcon, int flag);	//	Sep. 10, 2002 genta
@@ -204,7 +204,7 @@ public:
 	bool GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIconSmall) const;	//	Sep. 10, 2002 genta
 	void SetPageScrollByWheel( BOOL bState ) { m_bPageScrollByWheel = bState; }		// ホイール操作によるページスクロール有無を設定する（TRUE=あり, FALSE=なし）	// 2009.01.17 nasukoji
 	void SetHScrollByWheel( BOOL bState ) { m_bHorizontalScrollByWheel = bState; }	// ホイール操作による横スクロール有無を設定する（TRUE=あり, FALSE=なし）	// 2009.01.17 nasukoji
-	void ClearMouseState( void );		// 2009.01.17 nasukoji	マウスの状態をクリアする（ホイールスクロール有無状態をクリア）
+	void ClearMouseState( );		// 2009.01.17 nasukoji	マウスの状態をクリアする（ホイールスクロール有無状態をクリア）
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                           情報                              //
@@ -245,13 +245,13 @@ public:
 	void Views_RedrawAll();
 	void Views_Redraw();
 	void SetActivePane(int nIndex);	/* アクティブなペインを設定 */
-	int GetActivePane( void ) const { return m_nActivePaneIndex; }	/* アクティブなペインを取得 */ //2007.08.26 kobake const追加
+	int GetActivePane( ) const { return m_nActivePaneIndex; }	/* アクティブなペインを取得 */ //2007.08.26 kobake const追加
 	bool SetDrawSwitchOfAllViews( bool bDraw );					/* すべてのペインの描画スイッチを設定する */	// 2008.06.08 ryoji
 	void RedrawAllViews( CEditView* pcViewExclude );				/* すべてのペインをRedrawする */
 	void Views_DisableSelectArea(bool bRedraw);
 	BOOL DetectWidthOfLineNumberAreaAllPane( bool bRedraw );	/* すべてのペインで、行番号表示に必要な幅を再設定する（必要なら再描画する） */
 	BOOL WrapWindowWidth( int nPane );	/* 右端で折り返す */	// 2008.06.08 ryoji
-	BOOL UpdateTextWrap( void );		/* 折り返し方法関連の更新 */	// 2008.06.10 ryoji
+	BOOL UpdateTextWrap( );		/* 折り返し方法関連の更新 */	// 2008.06.10 ryoji
 	//	Aug. 14, 2005 genta TAB幅と折り返し位置の更新
 	void ChangeLayoutParam( bool bShowProgress, CKetaXInt nTabSize, int nTsvMode, CKetaXInt nMaxLineKetas );
 	//	Aug. 14, 2005 genta
@@ -273,7 +273,7 @@ public:
 	CEditView&			GetActiveView()       { return *m_pcEditView; }
 	const CEditView&    GetView(int n) const { return *m_pcEditViewArr[n]; }
 	CEditView&          GetView(int n)       { return *m_pcEditViewArr[n]; }
-	CMiniMapView&       GetMiniMap( void ) { return m_cMiniMapView; }
+	CMiniMapView&       GetMiniMap( ) { return m_cMiniMapView; }
 	bool                IsEnablePane(int n) const { return 0 <= n && n < m_nEditViewCount; }
 	int                 GetAllViewCount() const { return m_nEditViewCount; }
 
@@ -319,8 +319,8 @@ protected:
 		}
 	}
 
-	void CreateAccelTbl( void ); // ウィンドウ毎のアクセラレータテーブル作成(Wine用)
-	void DeleteAccelTbl( void ); // ウィンドウ毎のアクセラレータテーブル破棄(Wine用)
+	void CreateAccelTbl( ); // ウィンドウ毎のアクセラレータテーブル作成(Wine用)
+	void DeleteAccelTbl( ); // ウィンドウ毎のアクセラレータテーブル破棄(Wine用)
 
 public:
 	//D&Dフラグ管理
@@ -332,7 +332,7 @@ public:
 	/* IDropTarget実装 */	// 2008.06.20 ryoji
 	STDMETHODIMP DragEnter(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
 	STDMETHODIMP DragOver(DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
-	STDMETHODIMP DragLeave( void );
+	STDMETHODIMP DragLeave( );
 	STDMETHODIMP Drop(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
 
 	//フォーカス管理

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -100,7 +100,7 @@ LRESULT CALLBACK CMainToolBar::ToolBarWndProc( HWND hWnd, UINT msg, WPARAM wPara
 	@date 2005.08.29 aroka ツールバーの折り返し
 	@date 2006.06.17 ryoji ビジュアルスタイルが有効の場合はツールバーを Rebar に入れてサイズ変更時のちらつきを無くす
 */
-void CMainToolBar::CreateToolBar( void )
+void CMainToolBar::CreateToolBar( )
 {
 	if( m_hwndToolBar )return;
 
@@ -370,7 +370,7 @@ void CMainToolBar::CreateToolBar( void )
 	return;
 }
 
-void CMainToolBar::DestroyToolBar( void )
+void CMainToolBar::DestroyToolBar( )
 {
 	if( m_hwndToolBar )
 	{
@@ -485,7 +485,7 @@ LPARAM CMainToolBar::ToolBarOwnerDraw( LPNMCUSTOMDRAW pnmh )
 	@date 2008.10.05 nasukoji ツールバー更新部分を外に出した
 	@date 2012.11.29 aroka OnTimerから分離したときのバグ修正
 */
-void CMainToolBar::OnToolbarTimer( void )
+void CMainToolBar::OnToolbarTimer( )
 {
 	// 2012.11.29 aroka ここではカウントアップ不要
 	//m_pOwner->IncrementTimerCount(10);
@@ -499,7 +499,7 @@ void CMainToolBar::OnToolbarTimer( void )
 	
 	@date 2008.10.05 nasukoji
 */
-void CMainToolBar::UpdateToolbar( void )
+void CMainToolBar::UpdateToolbar( )
 {
 	// 印刷プレビュー中なら、何もしない。
 	if( m_pOwner->IsInPreviewMode() )return;
@@ -584,7 +584,7 @@ size_t CMainToolBar::GetSearchKey(std::wstring& strText)
 ツールバーの検索ボックスにフォーカスを移動する.
 	@date 2006.06.04 yukihane 新規作成
 */
-void CMainToolBar::SetFocusSearchBox( void ) const
+void CMainToolBar::SetFocusSearchBox( ) const
 {
 	if( m_hwndSearchBox ){
 		::SetFocus(m_hwndSearchBox);

--- a/sakura_core/window/CMainToolBar.h
+++ b/sakura_core/window/CMainToolBar.h
@@ -21,16 +21,16 @@ public:
 	void Create( CImageListMgr* pcIcons );
 
 	//作成・破棄
-	void CreateToolBar( void );		//!< ツールバー作成
-	void DestroyToolBar( void );	//!< ツールバー破棄
+	void CreateToolBar( );		//!< ツールバー作成
+	void DestroyToolBar( );	//!< ツールバー破棄
 
 	//メッセージ
 	bool EatMessage(MSG* msg);		//!< メッセージ処理。なんか処理したなら true を返す。
 	void ProcSearchBox( MSG* );		//!< 検索コンボボックスのメッセージ処理
 
 	//イベント
-	void OnToolbarTimer( void );	//!< タイマーの処理 20060128 aroka
-	void UpdateToolbar( void );		//!< ツールバーの表示を更新する		// 2008.09.23 nasukoji
+	void OnToolbarTimer( );	//!< タイマーの処理 20060128 aroka
+	void UpdateToolbar( );		//!< ツールバーの表示を更新する		// 2008.09.23 nasukoji
 
 	//描画
 	LPARAM ToolBarOwnerDraw( LPNMCUSTOMDRAW pnmh );
@@ -45,7 +45,7 @@ public:
 	size_t GetSearchKey(std::wstring& buffer); //!< 検索キーを取得。戻り値は検索キーの文字数。
 
 	//操作
-	void SetFocusSearchBox( void ) const;		/* ツールバー検索ボックスへフォーカスを移動 */	// 2006.06.04 yukihane
+	void SetFocusSearchBox( ) const;		/* ツールバー検索ボックスへフォーカスを移動 */	// 2006.06.04 yukihane
 
 private:
 	static LRESULT CALLBACK ToolBarWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData );

--- a/sakura_core/window/CSplitterWnd.cpp
+++ b/sakura_core/window/CSplitterWnd.cpp
@@ -581,7 +581,7 @@ void CSplitterWnd::SetActivePane( int nIndex )
 }
 
 /* 縦分割ＯＮ／ＯＦＦ */
-void CSplitterWnd::VSplitOnOff( void )
+void CSplitterWnd::VSplitOnOff( )
 {
 	RECT		rc;
 	::GetClientRect( GetHwnd(), &rc );
@@ -601,7 +601,7 @@ void CSplitterWnd::VSplitOnOff( void )
 }
 
 /* 横分割ＯＮ／ＯＦＦ */
-void CSplitterWnd::HSplitOnOff( void )
+void CSplitterWnd::HSplitOnOff( )
 {
 	RECT		rc;
 	::GetClientRect( GetHwnd(), &rc );
@@ -621,7 +621,7 @@ void CSplitterWnd::HSplitOnOff( void )
 }
 
 /* 縦横分割ＯＮ／ＯＦＦ */
-void CSplitterWnd::VHSplitOnOff( void )
+void CSplitterWnd::VHSplitOnOff( )
 {
 	int		nX;
 	int		nY;
@@ -649,7 +649,7 @@ void CSplitterWnd::VHSplitOnOff( void )
 }
 
 /* 前のペインを返す */
-int CSplitterWnd::GetPrevPane( void )
+int CSplitterWnd::GetPrevPane( )
 {
 	int		nPane;
 	nPane = -1;
@@ -701,7 +701,7 @@ int CSplitterWnd::GetPrevPane( void )
 }
 
 /* 次のペインを返す */
-int CSplitterWnd::GetNextPane( void )
+int CSplitterWnd::GetNextPane( )
 {
 	int		nPane;
 	nPane = -1;
@@ -753,13 +753,13 @@ int CSplitterWnd::GetNextPane( void )
 }
 
 /* 最初のペインを返す */
-int CSplitterWnd::GetFirstPane( void )
+int CSplitterWnd::GetFirstPane( )
 {
 	return 0;
 }
 
 /* 最後のペインを返す */
-int CSplitterWnd::GetLastPane( void )
+int CSplitterWnd::GetLastPane( )
 {
 	int		nPane;
 	if( m_nAllSplitRows == 1 &&	m_nAllSplitCols == 1 ){

--- a/sakura_core/window/CSplitterWnd.h
+++ b/sakura_core/window/CSplitterWnd.h
@@ -63,14 +63,14 @@ public: // 2002/2/3 aroka
 	void SetChildWndArr(HWND* hwndEditViewArr);	/* 子ウィンドウの設定 */
 	void DoSplit(int nHorizontal, int nVertical);	/* ウィンドウの分割 */
 	void SetActivePane(int nIndex);	/* アクティブペインの設定 */
-	int GetPrevPane( void );	/* 前のペインを返す */
-	int GetNextPane( void );	/* 次のペインを返す */
-	int GetFirstPane( void );	/* 最初のペインを返す */
-	int GetLastPane( void );	/* 最後のペインを返す */
+	int GetPrevPane( );	/* 前のペインを返す */
+	int GetNextPane( );	/* 次のペインを返す */
+	int GetFirstPane( );	/* 最初のペインを返す */
+	int GetLastPane( );	/* 最後のペインを返す */
 
-	void VSplitOnOff( void );	/* 縦分割ＯＮ／ＯＦＦ */
-	void HSplitOnOff( void );	/* 横分割ＯＮ／ＯＦＦ */
-	void VHSplitOnOff( void );	/* 縦横分割ＯＮ／ＯＦＦ */
+	void VSplitOnOff( );	/* 縦分割ＯＮ／ＯＦＦ */
+	void HSplitOnOff( );	/* 横分割ＯＮ／ＯＦＦ */
+	void VHSplitOnOff( );	/* 縦横分割ＯＮ／ＯＦＦ */
 //	LRESULT DispatchEvent( HWND, UINT, WPARAM, LPARAM );	/* ダイアログのメッセージ処理 */
 	int GetAllSplitRows(){ return m_nAllSplitRows;} // 2002/2/3 aroka
 	int GetAllSplitCols(){ return m_nAllSplitCols;} // 2002/2/3 aroka

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -970,7 +970,7 @@ void CTabWnd::UpdateStyle()
 }
 
 /* ウィンドウ クローズ */
-void CTabWnd::Close( void )
+void CTabWnd::Close( )
 {
 	if( GetHwnd() )
 	{
@@ -2001,7 +2001,7 @@ void CTabWnd::Refresh( BOOL bEnsureVisible/* = TRUE*/, BOOL bRebuild/* = FALSE*/
 	@author ryoji
 	@date 2007.04.03 新規作成
 */
-void CTabWnd::AdjustWindowPlacement( void )
+void CTabWnd::AdjustWindowPlacement( )
 {
 	// タブまとめ表示の場合は編集ウィンドウの表示位置を復元する
 	if( m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !m_pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin )
@@ -2216,7 +2216,7 @@ void CTabWnd::TabWnd_ActivateFrameWindow( HWND hwnd, bool bForeground )
 /*! タブのレイアウト調整処理
 	@date 2006.01.28 ryoji 新規作成
 */
-void CTabWnd::LayoutTab( void )
+void CTabWnd::LayoutTab( )
 {
 	// フォントを切り替える 2011.12.01 Moca
 	bool bChgFont = (0 != memcmp( &m_lf, &m_pShareData->m_Common.m_sTabBar.m_lf, sizeof(m_lf) ));
@@ -2337,7 +2337,7 @@ void CTabWnd::LayoutTab( void )
 /*! イメージリストの初期化処理
 	@date 2006.02.22 ryoji 新規作成
 */
-HIMAGELIST CTabWnd::InitImageList( void )
+HIMAGELIST CTabWnd::InitImageList( )
 {
 	SHFILEINFO sfi;
 	HIMAGELIST hImlSys;
@@ -2979,7 +2979,7 @@ LRESULT CTabWnd::TabListMenu( POINT pt, BOOL bSel/* = TRUE*/, BOOL bFull/* = FAL
 /** 次のグループの先頭ウィンドウを探す
 	@date 2007.06.20 ryoji 新規作成
 */
-HWND CTabWnd::GetNextGroupWnd( void )
+HWND CTabWnd::GetNextGroupWnd( )
 {
 	HWND hwndRet = nullptr;
 
@@ -3029,7 +3029,7 @@ HWND CTabWnd::GetNextGroupWnd( void )
 /** 前のグループの先頭ウィンドウを探す
 	@date 2007.06.20 ryoji 新規作成
 */
-HWND CTabWnd::GetPrevGroupWnd( void )
+HWND CTabWnd::GetPrevGroupWnd( )
 {
 	HWND hwndRet = nullptr;
 	if( m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !m_pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin )
@@ -3078,7 +3078,7 @@ HWND CTabWnd::GetPrevGroupWnd( void )
 /** 次のグループをアクティブにする
 	@date 2007.06.20 ryoji 新規作成
 */
-void CTabWnd::NextGroup( void )
+void CTabWnd::NextGroup( )
 {
 	HWND hWnd = GetNextGroupWnd();
 	if( hWnd )
@@ -3090,7 +3090,7 @@ void CTabWnd::NextGroup( void )
 /** 前のグループをアクティブにする
 	@date 2007.06.20 ryoji 新規作成
 */
-void CTabWnd::PrevGroup( void )
+void CTabWnd::PrevGroup( )
 {
 	HWND hWnd = GetPrevGroupWnd();
 	if( hWnd )
@@ -3102,7 +3102,7 @@ void CTabWnd::PrevGroup( void )
 /** タブを右に移動する
 	@date 2007.06.20 ryoji 新規作成
 */
-void CTabWnd::MoveRight( void )
+void CTabWnd::MoveRight( )
 {
 	if( m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd )
 	{
@@ -3123,7 +3123,7 @@ void CTabWnd::MoveRight( void )
 /** タブを左に移動する
 	@date 2007.06.20 ryoji 新規作成
 */
-void CTabWnd::MoveLeft( void )
+void CTabWnd::MoveLeft( )
 {
 	if( m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd )
 	{
@@ -3144,7 +3144,7 @@ void CTabWnd::MoveLeft( void )
 	@date 2007.06.20 ryoji 新規作成
 	@date 2007.11.30 ryoji 最大化時の分離対応
 */
-void CTabWnd::Separate( void )
+void CTabWnd::Separate( )
 {
 	if( m_pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !m_pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin )
 	{
@@ -3197,7 +3197,7 @@ void CTabWnd::Separate( void )
 /** 次のグループに移動する（現在のグループから分離、結合）
 	@date 2007.06.20 ryoji 新規作成
 */
-void CTabWnd::JoinNext( void )
+void CTabWnd::JoinNext( )
 {
 	HWND hWnd = GetNextGroupWnd();
 	if( hWnd )
@@ -3212,7 +3212,7 @@ void CTabWnd::JoinNext( void )
 /** 前のグループに移動する（現在のグループから分離、結合）
 	@date 2007.06.20 ryoji 新規作成
 */
-void CTabWnd::JoinPrev( void )
+void CTabWnd::JoinPrev( )
 {
 	HWND hWnd = GetPrevGroupWnd();
 	if( hWnd )

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -43,16 +43,16 @@ public:
 	|| メンバ関数
 	*/
 	HWND Open( HINSTANCE hInstance, HWND hwndParent );		/*!< ウィンドウ オープン */
-	void Close( void );					/*!< ウィンドウ クローズ */
+	void Close( );					/*!< ウィンドウ クローズ */
 	void TabWindowNotify( WPARAM wParam, LPARAM lParam );
 	void Refresh( BOOL bEnsureVisible = TRUE, BOOL bRebuild = FALSE );			// 2006.02.06 ryoji 引数削除
-	void NextGroup( void );			/* 次のグループ */			// 2007.06.20 ryoji
-	void PrevGroup( void );			/* 前のグループ */			// 2007.06.20 ryoji
-	void MoveRight( void );			/* タブを右に移動 */		// 2007.06.20 ryoji
-	void MoveLeft( void );			/* タブを左に移動 */		// 2007.06.20 ryoji
-	void Separate( void );			/* 新規グループ */			// 2007.06.20 ryoji
-	void JoinNext( void );			/* 次のグループに移動 */	// 2007.06.20 ryoji
-	void JoinPrev( void );			/* 前のグループに移動 */	// 2007.06.20 ryoji
+	void NextGroup( );			/* 次のグループ */			// 2007.06.20 ryoji
+	void PrevGroup( );			/* 前のグループ */			// 2007.06.20 ryoji
+	void MoveRight( );			/* タブを右に移動 */		// 2007.06.20 ryoji
+	void MoveLeft( );			/* タブを左に移動 */		// 2007.06.20 ryoji
+	void Separate( );			/* 新規グループ */			// 2007.06.20 ryoji
+	void JoinNext( );			/* 次のグループに移動 */	// 2007.06.20 ryoji
+	void JoinPrev( );			/* 前のグループに移動 */	// 2007.06.20 ryoji
 
 	LRESULT TabWndDispatchEvent( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
 	LRESULT TabListMenu( POINT pt, BOOL bSel = TRUE, BOOL bFull = FALSE, BOOL bOtherGroup = TRUE );	/*!< タブ一覧メニュー作成処理 */	// 2006.03.23 fon
@@ -70,14 +70,14 @@ protected:
 	|| 実装ヘルパ系
 	*/
 	int FindTabIndexByHWND( HWND hWnd );
-	void AdjustWindowPlacement( void );							/*!< 編集ウィンドウの位置合わせ */	// 2007.04.03 ryoji
+	void AdjustWindowPlacement( );							/*!< 編集ウィンドウの位置合わせ */	// 2007.04.03 ryoji
 	int SetCarmWindowPlacement( HWND hwnd, const WINDOWPLACEMENT* pWndpl );	/* アクティブ化の少ない SetWindowPlacement() を実行する */	// 2007.11.30 ryoji
 	void ShowHideWindow( HWND hwnd, BOOL bDisp );
 	void HideOtherWindows( HWND hwndExclude );					/*!< 他の編集ウィンドウを隠す */	// 2007.05.17 ryoji
 	void ForceActiveWindow( HWND hwnd );
 	void TabWnd_ActivateFrameWindow( HWND hwnd, bool bForce = true );	//2004.08.27 Kazika 引数追加
-	HWND GetNextGroupWnd( void );	/* 次のグループの先頭ウィンドウを探す */	// 2007.06.20 ryoji
-	HWND GetPrevGroupWnd( void );	/* 前のグループの先頭ウィンドウを探す */	// 2007.06.20 ryoji
+	HWND GetNextGroupWnd( );	/* 次のグループの先頭ウィンドウを探す */	// 2007.06.20 ryoji
+	HWND GetPrevGroupWnd( );	/* 前のグループの先頭ウィンドウを探す */	// 2007.06.20 ryoji
 	void GetTabName( EditNode* pEditNode, BOOL bFull, BOOL bDupamp, LPWSTR pszName, int nLen );	/* タブ名取得処理 */	// 2007.06.28 ryoji 新規作成
 
 	/* 仮想関数 */
@@ -111,14 +111,14 @@ protected:
 	LRESULT OnTabNotify( WPARAM wParam, LPARAM lParam );		/*!< タブ部 WM_NOTIFY 処理 */
 
 	//実装補助インターフェース
-	void BreakDrag( void ) { if( ::GetCapture() == m_hwndTab ) ::ReleaseCapture(); m_eDragState = DRAG_NONE; m_nTabCloseCapture = -1; }	/*!< ドラッグ状態解除処理 */
+	void BreakDrag( ) { if( ::GetCapture() == m_hwndTab ) ::ReleaseCapture(); m_eDragState = DRAG_NONE; m_nTabCloseCapture = -1; }	/*!< ドラッグ状態解除処理 */
 	BOOL ReorderTab( int nSrcTab, int nDstTab );	/*!< タブ順序変更処理 */
-	void BroadcastRefreshToGroup( void );
+	void BroadcastRefreshToGroup( );
 	BOOL SeparateGroup( HWND hwndSrc, HWND hwndDst, POINT ptDrag, POINT ptDrop );	/*!< タブ分離処理 */	// 2007.06.20 ryoji
 	LRESULT ExecTabCommand( int nId, POINTS pts );	/*!< タブ部 コマンド実行処理 */
-	void LayoutTab( void );							/*!< タブのレイアウト調整処理 */
+	void LayoutTab( );							/*!< タブのレイアウト調整処理 */
 
-	HIMAGELIST InitImageList( void );				/*!< イメージリストの初期化処理 */
+	HIMAGELIST InitImageList( );				/*!< イメージリストの初期化処理 */
 	int GetImageIndex( EditNode* pNode );			/*!< イメージリストのインデックス取得処理 */
 	HIMAGELIST ImageList_Duplicate( HIMAGELIST himl );	/*!< イメージリストの複製処理 */
 
@@ -133,7 +133,7 @@ protected:
 	void GetCloseBtnRect( const LPRECT lprcClient, LPRECT lprc );	/*!< 閉じるボタンの矩形取得処理 */	// 2006.10.21 ryoji
 	void GetTabCloseBtnRect( const LPRECT lprcClient, LPRECT lprc, bool selected );	/*!< タブを閉じるボタンの矩形取得処理 */	// 2012.04.14 syat
 
-	HFONT CreateMenuFont( void )
+	HFONT CreateMenuFont( )
 	{
 		// メニュー用フォント作成
 		NONCLIENTMETRICS	ncm;

--- a/sakura_core/window/CTipWnd.cpp
+++ b/sakura_core/window/CTipWnd.cpp
@@ -277,7 +277,7 @@ void CTipWnd::DrawTipText(
 }
 
 /* Tipを消す */
-void CTipWnd::Hide( void )
+void CTipWnd::Hide( )
 {
 	::ShowWindow( GetHwnd(), SW_HIDE );
 //	::DestroyWindow( GetHwnd() );

--- a/sakura_core/window/CTipWnd.h
+++ b/sakura_core/window/CTipWnd.h
@@ -41,7 +41,7 @@ public:
 	||  Attributes & Operations
 	*/
 	void Show( int nX, int nY, RECT* pRect = nullptr );	/* Tipを表示 */
-	void Hide( void );	/* Tipを消す */
+	void Hide( );	/* Tipを消す */
 	void GetWindowSize(LPRECT pRect);		// 2001/06/19 asa-o ウィンドウのサイズを得る
 
 	void ChangeFont( LOGFONT* lf ){


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
clang-tidy を実行すると、下記の warning が表示される。

```
C:\work\sakura\sakura_core\agent\CAutoSaveAgent.cpp:91:33: warning: redundant void argument list in function definition [modernize-redundant-void-arg]
   91 | bool CPassiveTimer::CheckAction(void)
      |                                 ^~~~
```

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
clang-tidy で void を削除します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. clang-tidy で modernize-redundant-void-arg の warning が消えていることを確認する。
2. 変更前後でasmが同じことを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
https://clang.llvm.org/extra/clang-tidy/checks/modernize/redundant-void-arg.html
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#nl25-dont-use-void-as-an-argument-type