### PR TITLE
Revert "Merge pull request #2313 from berryzplus/feature/omit_lstrcpy"

### DIFF
--- a/sakura_core/cmd/CViewCommander_Support.cpp
+++ b/sakura_core/cmd/CViewCommander_Support.cpp
@@ -256,6 +256,7 @@ void CViewCommander::Command_EXTHTMLHELP( const WCHAR* _helpfile, const WCHAR* k
 	}
 
 	HWND		hwndHtmlHelp;
+	int			nLen;
 
 	DEBUG_TRACE( L"helpfile=%s\n", helpfile.c_str() );
 
@@ -300,13 +301,14 @@ void CViewCommander::Command_EXTHTMLHELP( const WCHAR* _helpfile, const WCHAR* k
 		// タスクトレイのプロセスにHtmlHelpを起動させる
 		// 2003.06.23 Moca 相対パスは実行ファイルからのパス
 		// 2007.05.21 ryoji 相対パスは設定ファイルからのパスを優先
-		auto szWork = GetDllShareData().m_sWorkBuffer.GetBuffer<WCHAR>();
+		WCHAR* pWork=GetDllShareData().m_sWorkBuffer.GetWorkBuffer<WCHAR>();
 		if( _IS_REL_PATH( filename ) ){
-			GetInidirOrExedir(szWork, filename);
+			GetInidirOrExedir( pWork, filename );
 		}else{
-			::wcsncpy_s(std::data(szWork), std::size(szWork), filename, _TRUNCATE);
+			wcscpy( pWork, filename ); //	Jul. 5, 2002 genta
 		}
-		::wcsncat_s(std::data(szWork), std::size(szWork), cmemCurText.GetStringPtr(), _TRUNCATE);
+		nLen = (int)wcslen( pWork );
+		wcscpy( &pWork[nLen + 1], cmemCurText.GetStringPtr() );
 		hwndHtmlHelp = (HWND)::SendMessageAny(
 			GetDllShareData().m_sHandles.m_hwndTray,
 			MYWM_HTMLHELP,

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -314,7 +314,7 @@ void CEditDoc::SetBackgroundImage()
 	}
 	if( _IS_REL_PATH(path.c_str()) ){
 		CFilePath fullPath;
-		GetInidirOrExedir(fullPath, path);
+		GetInidirOrExedir( &fullPath[0], &path[0] );
 		path = fullPath;
 	}
 

--- a/sakura_core/env/DLLSHAREDATA.h
+++ b/sakura_core/env/DLLSHAREDATA.h
@@ -44,19 +44,18 @@ struct SShare_Flags{
 
 //! 共有ワークバッファ
 struct SShare_WorkBuffer{
-	template <class T>
-	constexpr auto GetBuffer() noexcept { return std::span{ GetWorkBuffer<T>(), GetWorkBufferCount<T>() }; }
-
-	template <class T>
-	constexpr T* GetWorkBuffer() noexcept { return reinterpret_cast<T*>(m_pWork); }
-
-	template <class T>
-	constexpr size_t GetWorkBufferCount() const noexcept { return std::size(m_pWork) / sizeof(T); }
-
 	//2007.09.16 kobake char型だと、常に文字列であるという誤解を招くので、BYTE型に変更。変数名も変更。
 	//           UNICODE版では、余分に領域を使うことが予想されるため、ANSI版の2倍確保。
+private:
 	BYTE				m_pWork[32000*sizeof(WCHAR)];
+public:
+	template <class T>
+	T* GetWorkBuffer(){ return reinterpret_cast<T*>(m_pWork); }
 
+	template <class T>
+	size_t GetWorkBufferCount(){ return sizeof(m_pWork)/sizeof(T); }
+
+public:
 	EditInfo			m_EditInfo_MYWM_GETFILEINFO;	//MYWM_GETFILEINFOデータ受け渡し用	####美しくない
 	CLogicPoint			m_LogicPoint;					//!< カーソル位置
 	STypeConfig			m_TypeConfig;

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3158,9 +3158,9 @@ INT_PTR CDlgFuncList::OnNcPaint( HWND hwnd, [[maybe_unused]] UINT uMsg, [[maybe_
 	memset( &lf, 0, sizeof(LOGFONT) );
 	lf.lfCharSet = DEFAULT_CHARSET;
 	lf.lfHeight = ncm.lfCaptionFont.lfHeight;
-	::wcsncpy_s(lf.lfFaceName, L"Marlett", _TRUNCATE);
+	::lstrcpy( lf.lfFaceName, L"Marlett" );
 	HFONT hFont = ::CreateFontIndirect( &lf );
-	::wcsncpy_s(lf.lfFaceName, L"Webdings", _TRUNCATE);
+	::lstrcpy( lf.lfFaceName, L"Webdings" );
 	HFONT hFont2 = ::CreateFontIndirect( &lf );
 	gr.SetTextBackTransparent( true );
 

--- a/sakura_core/prop/CPropComHelper.cpp
+++ b/sakura_core/prop/CPropComHelper.cpp
@@ -147,7 +147,7 @@ INT_PTR CPropHelper::DispatchEvent(
 					/* 検索フォルダー */
 					// 2007.05.27 ryoji 相対パスは設定ファイルからのパスを優先
 					if( _IS_REL_PATH( m_Common.m_sHelper.m_szMigemoDict ) ){
-						GetInidirOrExedir(szPath, m_Common.m_sHelper.m_szMigemoDict);
+						GetInidirOrExedir( szPath, m_Common.m_sHelper.m_szMigemoDict, TRUE );
 					}else{
 						wcscpy( szPath, m_Common.m_sHelper.m_szMigemoDict );
 					}

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -169,7 +169,6 @@ public:
 	constexpr const WCHAR* c_str() const noexcept { return data(); }
 
 	constexpr operator std::span<WCHAR, N>()       & noexcept { return std::span<WCHAR, N>{ data(), N }; }
-	constexpr operator std::span<WCHAR>()          & noexcept { return std::span<WCHAR, N>{ *this }; }
 	constexpr operator std::wstring_view()   const & noexcept { return std::wstring_view{ data(), length() }; }
 
 	explicit operator std::filesystem::path() const & noexcept { return static_cast<std::wstring_view>(*this); }

--- a/sakura_core/util/file.cpp
+++ b/sakura_core/util/file.cpp
@@ -493,18 +493,24 @@ std::filesystem::path GetExeFileName()
 	@date 2008.05.05 novice GetModuleHandle(NULL)→NULLに変更
 */
 void GetExedir(
-	std::span<WCHAR>							szExeDir,	//!< [out]		EXEファイルのあるディレクトリを返す場所．予め_MAX_PATHのバッファを用意しておくこと．
-	const std::optional<std::filesystem::path>& optFileName	//!< [in, opt]	ディレクトリ名に結合するファイル名．
+	LPWSTR	pDir,	//!< [out] EXEファイルのあるディレクトリを返す場所．予め_MAX_PATHのバッファを用意しておくこと．
+	LPCWSTR	szFile	//!< [in]  ディレクトリ名に結合するファイル名．
 )
 {
-	// exeフォルダーのフルパス、またはexe基準のファイルパスを取得
-	auto exePath = GetExeFileName().remove_filename();
-	if (optFileName.has_value()) {
-		if (const auto& fileName = optFileName.value(); !fileName.empty()) {
-			exePath /= fileName;
-		}
+	if( pDir == nullptr )
+		return;
+
+	std::wstring partialPath;
+	if (szFile != nullptr) {
+		partialPath = szFile;
 	}
-	::wcsncpy_s(std::data(szExeDir), std::size(szExeDir), exePath.c_str(), _TRUNCATE);
+	if (partialPath.empty() || partialPath[0] != L'\\') {
+		partialPath.insert(partialPath.cbegin(), L'\\');
+	}
+
+	// exeフォルダーのフルパス、またはexe基準のファイルパスを取得
+	auto path = GetExeFileName().parent_path().concat(partialPath);
+	::wcsncpy_s(pDir, decltype(DLLSHAREDATA::m_szIniFile)::BUFFER_COUNT, path.c_str(), _TRUNCATE);
 }
 
 /*!
@@ -525,18 +531,24 @@ std::filesystem::path GetIniFileName()
 	@date 2007.05.19 新規作成（GetExedirベース）
 */
 void GetInidir(
-	std::span<WCHAR> szIniDir,								//!< [out]		INIファイルのあるディレクトリを返す場所．予め_MAX_PATHのバッファを用意しておくこと．
-	const std::optional<std::filesystem::path>& optFileName	//!< [in, opt]	ディレクトリ名に結合するファイル名．
+	LPWSTR	pDir,				//!< [out] INIファイルのあるディレクトリを返す場所．予め_MAX_PATHのバッファを用意しておくこと．
+	LPCWSTR szFile	/*=NULL*/	//!< [in] ディレクトリ名に結合するファイル名．
 )
 {
-	// 設定フォルダーのフルパス、またはini基準のファイルパスを取得
-	auto iniPath = GetIniFileName().remove_filename();
-	if (optFileName.has_value()) {
-		if (const auto& fileName = optFileName.value(); !fileName.empty()) {
-			iniPath /= fileName;
-		}
+	if( pDir == nullptr )
+		return;
+	
+	std::wstring partialPath;
+	if (szFile != nullptr) {
+		partialPath = szFile;
 	}
-	::wcsncpy_s(std::data(szIniDir), std::size(szIniDir), iniPath.c_str(), _TRUNCATE);
+	if (partialPath.empty() || partialPath[0] != L'\\') {
+		partialPath.insert(partialPath.cbegin(), L'\\');
+	}
+
+	// 設定フォルダーのフルパス、またはini基準のファイルパスを取得
+	auto path = GetIniFileName().parent_path().concat(partialPath);
+	::wcsncpy_s(pDir, decltype(DLLSHAREDATA::m_szPrivateIniFile)::BUFFER_COUNT, path.c_str(), _TRUNCATE);
 }
 
 /*!
@@ -546,32 +558,36 @@ void GetInidir(
 	@date 2007.05.22 新規作成
 */
 void GetInidirOrExedir(
-	std::span<WCHAR> szIniOrExeDir,						//!< [out] INIファイルまたはEXEファイルのあるディレクトリを返す場所．
-														//         予め_MAX_PATHのバッファを用意しておくこと．
-	const std::optional<std::wstring_view>& optFileName	//!< [in] ディレクトリ名に結合するファイル名．
+	LPWSTR	pDir,								//!< [out] INIファイルまたはEXEファイルのあるディレクトリを返す場所．
+												//         予め_MAX_PATHのバッファを用意しておくこと．
+	LPCWSTR	szFile					/*=NULL*/,	//!< [in] ディレクトリ名に結合するファイル名．
+	BOOL	bRetExedirIfFileEmpty	/*=FALSE*/	//!< [in] ファイル名の指定が空の場合はEXEファイルのフルパスを返す．
 )
 {
-	assert(_MAX_PATH <= std::size(szIniOrExeDir));
+	WCHAR	szInidir[_MAX_PATH];
+	WCHAR	szExedir[_MAX_PATH];
 
-	SFilePath szInidir;
-	SFilePath szExedir;
+	// ファイル名の指定が空の場合はEXEファイルのフルパスを返す（オプション）
+	if( bRetExedirIfFileEmpty && (szFile == nullptr || szFile[0] == L'\0') ){
+		GetExedir( pDir );
+		return;
+	}
 
 	// INI基準のフルパスが実在すればそのパスを返す
-	GetInidir(szInidir, optFileName);
-	if (fexist(szInidir)) {
-		::wcsncpy_s(std::data(szIniOrExeDir), std::size(szIniOrExeDir), szInidir, _TRUNCATE);
+	GetInidir( szInidir, szFile );
+	if( fexist(szInidir) ){
+		::lstrcpy( pDir, szInidir );
 		return;
 	}
 
 	// EXE基準のフルパスが実在すればそのパスを返す
-	GetExedir(szExedir, optFileName);
-	if (fexist(szExedir)) {
-		::wcsncpy_s(std::data(szIniOrExeDir), std::size(szIniOrExeDir), szExedir, _TRUNCATE);
+	if( GetExedir( szExedir, szFile ); fexist(szExedir) ){
+		::wcsncpy_s( pDir, _MAX_PATH - 1, szExedir, _TRUNCATE );
 		return;
 	}
 
 	// どちらにも実在しなければINI基準のフルパスを返す
-	::wcsncpy_s(std::data(szIniOrExeDir), std::size(szIniOrExeDir), szInidir, _TRUNCATE);
+	::lstrcpy( pDir, szInidir );
 }
 
 /*!

--- a/sakura_core/util/file.h
+++ b/sakura_core/util/file.h
@@ -50,9 +50,9 @@ std::filesystem::path GetExeFileName();
 std::filesystem::path GetIniFileName();
 
 //※サクラ依存
-void	GetExedir(std::span<WCHAR> szExeDir, const std::optional<std::filesystem::path>& optFileName = std::nullopt);
-void	GetInidir(std::span<WCHAR> szIniDir, const std::optional<std::filesystem::path>& optFileName = std::nullopt);
-void	GetInidirOrExedir(std::span<WCHAR> szIniOrExeDir, const std::optional<std::wstring_view>& optFileName = std::nullopt);
+void GetExedir( LPWSTR pDir, LPCWSTR szFile = nullptr );
+void GetInidir( LPWSTR pDir, LPCWSTR szFile = nullptr ); // 2007.05.19 ryoji
+void GetInidirOrExedir( LPWSTR pDir, LPCWSTR szFile = nullptr, BOOL bRetExedirIfFileEmpty = FALSE ); // 2007.05.22 ryoji
 
 LPCWSTR GetRelPath( LPCWSTR pszPath );
 

--- a/sakura_core/util/module.cpp
+++ b/sakura_core/util/module.cpp
@@ -20,7 +20,7 @@ void ChangeCurrentDirectoryToExeDir()
 {
 	WCHAR szExeDir[_MAX_PATH];
 	szExeDir[0] = L'\0';
-	GetExedir(szExeDir);
+	GetExedir( szExeDir, nullptr );
 	if( szExeDir[0] ){
 		::SetCurrentDirectory( szExeDir );
 	}else{
@@ -111,25 +111,23 @@ DWORD GetDllVersion(LPCWSTR lpszDllName)
 	@date 2007.05.20 ryoji iniファイルパスを優先
 	@author genta
 */
-HICON GetAppIcon(HINSTANCE hInst, WORD nResource, std::wstring_view fileName, bool bSmall)
+HICON GetAppIcon( HINSTANCE hInst, int nResource, const WCHAR* szFile, bool bSmall )
 {
-	// ファイルパスはini基準を優先
-	SFilePath szPath;
-	GetInidirOrExedir(szPath, fileName);
+	// サイズの設定
+	int size = GetSystemMetrics( bSmall ? SM_CXSMICON : SM_CXICON );
 
-	// アイコンサイズはシステムから取得する（DPIは考慮しない。）
-	const auto cx = ::GetSystemMetrics(bSmall ? SM_CXSMICON : SM_CXICON);
-	const auto cy = ::GetSystemMetrics(bSmall ? SM_CYSMICON : SM_CYICON);
-
+	WCHAR szPath[_MAX_PATH];
 	HICON hIcon;
 
 	// ファイルからの読み込みをまず試みる
+	GetInidirOrExedir( szPath, szFile );
+
 	hIcon = (HICON)::LoadImage(
 		nullptr,
 		szPath,
 		IMAGE_ICON,
-		cx,
-		cy,
+		size,
+		size,
 		LR_SHARED | LR_LOADFROMFILE
 	);
 	if( hIcon != nullptr ){
@@ -141,8 +139,8 @@ HICON GetAppIcon(HINSTANCE hInst, WORD nResource, std::wstring_view fileName, bo
 		hInst,
 		MAKEINTRESOURCE(nResource),
 		IMAGE_ICON,
-		cx,
-		cy,
+		size,
+		size,
 		LR_SHARED
 	);
 	

--- a/sakura_core/util/module.h
+++ b/sakura_core/util/module.h
@@ -12,7 +12,7 @@
 void GetAppVersionInfo( HINSTANCE hInstance, int nVersionResourceID,
 					    DWORD* pdwProductVersionMS, DWORD* pdwProductVersionLS );	/* リソースから製品バージョンの取得 */
 
-HICON GetAppIcon(HINSTANCE hInst, WORD nResource, std::wstring_view fileName, bool bSmall = false);
+HICON GetAppIcon( HINSTANCE hInst, int nResource, const WCHAR* szFile, bool bSmall = false);
 
 DWORD GetDllVersion( LPCWSTR lpszDllName );	// シェルやコモンコントロール DLL のバージョン番号を取得	// 2006.06.17 ryoji
 

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -2140,7 +2140,7 @@ void CEditView::OnMyDropFiles( HDROP hDrop )
 			if( !::GetLongFileName( szPath, szWork ) )
 				continue;
 			if( nId == 100 ){	// パス名
-				::wcsncpy_s(szPath, szWork, _TRUNCATE);
+				::lstrcpy( szPath, szWork );
 			}else if( nId == 101 ){	// ファイル名
 				_wsplitpath_s( szWork, nullptr, 0, nullptr, 0, szPath, std::size(szPath), szExt, std::size(szExt) );
 				::wcsncat_s(szPath, szExt, _TRUNCATE);

--- a/src/test/cpp/tests1/test-file.cpp
+++ b/src/test/cpp/tests1/test-file.cpp
@@ -127,6 +127,9 @@ TEST(file, Deprecated_GetExedir)
 	// 戻り値取得用のバッファ
 	WCHAR szBuf[_MAX_PATH];
 
+	// 戻り値取得用のバッファを指定しない場合、何も起きない
+	GetExedir(nullptr);
+
 	// exeフォルダーの取得
 	GetExedir(szBuf);
 	::wcscat_s(szBuf, filename);
@@ -362,6 +365,9 @@ TEST(file, Deprecated_GetInidir)
 	// 戻り値取得用のバッファ
 	WCHAR szBuf[_MAX_PATH];
 
+	// 戻り値取得用のバッファを指定しない場合、何も起きない
+	GetInidir(nullptr);
+
 	// iniフォルダーの取得
 	GetInidir(szBuf);
 	::wcscat_s(szBuf, filename);
@@ -390,6 +396,9 @@ TEST(file, GetInidirOrExedir)
 
 	std::wstring buf(_MAX_PATH, L'\0');
 
+	GetInidirOrExedir(buf.data(), L"", true);
+	ASSERT_STREQ(GetExeFileName().replace_filename(L"").c_str(), buf.data());
+
 	constexpr auto filename = L"test.txt";
 	auto exeBasePath = GetExeFileName().parent_path().append(filename);
 	auto iniBasePath = GetIniFileName().parent_path().append(filename);
@@ -401,7 +410,7 @@ TEST(file, GetInidirOrExedir)
 	CProfile().WriteProfile(iniBasePath.c_str(), L"file, GetInidirOrExedirのテスト");
 
 	// 両方あるときはINI基準のパスが変える
-	GetInidirOrExedir(buf, filename);
+	GetInidirOrExedir(buf.data(), filename, true);
 	ASSERT_STREQ(iniBasePath.c_str(), buf.data());
 
 	// INI基準パスのファイルを削除する
@@ -409,7 +418,7 @@ TEST(file, GetInidirOrExedir)
 	ASSERT_FALSE(fexist(iniBasePath.c_str()));
 
 	// EXE基準のみ存在するときはEXE基準のパスが変える
-	GetInidirOrExedir(buf, filename);
+	GetInidirOrExedir(buf.data(), filename, true);
 	ASSERT_STREQ(exeBasePath.c_str(), buf.data());
 
 	// EXE基準パスのファイルを削除する
@@ -417,7 +426,7 @@ TEST(file, GetInidirOrExedir)
 	ASSERT_FALSE(fexist(exeBasePath.c_str()));
 
 	// 両方ないときはINI基準のパスが変える
-	GetInidirOrExedir(buf, filename);
+	GetInidirOrExedir(buf.data(), filename, true);
 	ASSERT_STREQ(iniBasePath.c_str(), buf.data());
 }
 


### PR DESCRIPTION
This reverts commit fe5f1895caf8f9a7ed1b8d0bca28345a999eb547, reversing changes made to e58adb12227031be698273951bcbdc371d062a77.

<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
1. 文字列を選択しない状態で、外部HTMLヘルプ を呼び出すと、キーワードのところが?????になる。
2. 文字列を選択した状態で、外部HTMLヘルプ を呼び出すことができない。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
問題の原因となっている Pull Request を Revert します。
https://github.com/sakura-editor/sakura/pull/2313

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
影響なし。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
1. 文字列を選択しない状態で、外部HTMLヘルプ を呼び出すと、キーワードのところが空欄になることを確認する。
2. 文字列を選択した状態で、外部HTMLヘルプ を呼び出すと、キーワードのところに選択した文字列が設定されることを確認する。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
https://github.com/sakura-editor/sakura/pull/2313

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
