### PR TITLE
WinMainTestでプロセス起動が失敗する対策

### DIFF
--- a/src/test/cpp/tests1/test-winmain.cpp
+++ b/src/test/cpp/tests1/test-winmain.cpp
@@ -232,37 +232,22 @@ struct WinMainTest : public ::testing::TestWithParam<const wchar_t*> {
 } // namespace winmain
 
 /*!
- * @brief コントロールプロセスの初期化完了を待つ
- *
- * CControlProcess::WaitForInitializedとして実装したいコードです。本体を変えたくないので一時定義しました。
- * 既存CProcessFactory::WaitForInitializedControlProcess()と概ね等価です。
+ * @brief コントロールプロセスを起動する
  */
-void CControlProcess_WaitForInitialized(const std::optional<std::wstring>& optProfileName)
+void CControlProcess_Start(const std::optional<std::wstring>& optProfileName)
 {
-	// 初期化完了イベントを作成する
-	std::wstring strInitEvent{ GSTR_EVENT_SAKURA_CP_INITIALIZED };
+	// 初期化完了イベントの名前を決める
+	SFilePath initEventName{ GSTR_EVENT_SAKURA_CP_INITIALIZED };
 	if (optProfileName.has_value()) {
-		strInitEvent += *optProfileName;
+		initEventName += *optProfileName;
 	}
-	cxx::HandleHolder hEvent = ::CreateEventW(nullptr, TRUE, FALSE, strInitEvent.c_str());
+
+	// プロセス起動前に初期化完了イベントを作成する
+	cxx::HandleHolder hEvent = ::CreateEventW(nullptr, TRUE, FALSE, initEventName);
 	if (!hEvent) {
 		cxx::raise_system_error("create event failed.");
 	}
 
-	// 初期化完了イベントを待つ
-	if (!hEvent.try_lock_for(std::chrono::milliseconds(30000))){
-		cxx::raise_system_error("waitEvent is timeout.");
-	}
-}
-
-/*!
- * @brief コントロールプロセスを起動する
- *
- * CControlProcess::Startとして実装したいコードです。本体を変えたくないので一時定義しました。
- * 既存CProcessFactory::StartControlProcess()と概ね等価です。
- */
-void CControlProcess_Start(const std::optional<std::wstring>& optProfileName)
-{
 	const auto exePath = GetExeFileName();
 	const auto lpszAppName = exePath.c_str();
 
@@ -311,7 +296,9 @@ void CControlProcess_Start(const std::optional<std::wstring>& optProfileName)
 	::CloseHandle(pi.hProcess);
 
 	// コントロールプロセスの初期化完了を待つ
-	CControlProcess_WaitForInitialized(optProfileName);
+	if (!hEvent.try_lock_for(std::chrono::milliseconds(60000))){
+		cxx::raise_system_error("waitEvent is timeout.");
+	}
 }
 
 /*!


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- テストコード
- ビルド手順/CI

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2314

CIでMSVCのテストが失敗しています。
失敗理由は timeout です。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- 待機側でイベント作成してから起動することにより待機失敗が起こらないようにします。
- テスト内で起動させたプロセスを終了させる処理の改善(#2381)も一緒に入れてしまいます。

本件、勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
- CIテストの失敗が減ります。

WinMainTest はローカルでも動かしていますが、ローカルで失敗したのを見たことはありません。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
- #2379 にコミットを積んで timeout が解消されることを確認しました。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- #2381

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
