### PR TITLE
タグジャンプのクラッシュに対処する

### DIFF
--- a/sakura_core/parse/DetectIndentationStyle.cpp
+++ b/sakura_core/parse/DetectIndentationStyle.cpp
@@ -160,8 +160,9 @@ bool glob_matches_extension(std::string_view glob, std::string_view extension)
 
 bool FindEditorConfig(const CEditDoc* pcDoc, IndentationStyle& style)
 {
-	fs::path path = pcDoc->m_cDocFile.GetFilePath();
-	if (!path.has_extension()) {
+	const auto& cFilePath = pcDoc->m_cDocFile.GetFilePathClass();
+	auto path = static_cast<std::filesystem::path>(cFilePath);
+	if (cFilePath.empty() || !path.has_extension()) {
 		return false;
 	}
 	const auto extension = path.extension().string();
@@ -170,7 +171,7 @@ bool FindEditorConfig(const CEditDoc* pcDoc, IndentationStyle& style)
 	while (path.has_parent_path()) {
 		path = path.parent_path();
 		auto configPath = path / ".editorconfig";
-		if (fs::exists(configPath)) {
+		if (fexist(configPath)) {
 			EditorConfig config;
 			if (parser.Parse(configPath.wstring(), config)) {
 				for (auto& section : config.sections) {


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2434

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- 指摘のあった2件について対処します。
  - パスが空のときに抜けていない
  - `std::filesystem::exists` をエラーコードを受け取らないモードで呼び出していて、エラー時にクラッシュしてしまう。

周辺におかしいとこいっぱいありそうだけど対応は見送り。
元のコードにテストなかったのでテスト添付は断念。

本件、勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
