### PR TITLE
C2131 ビルドエラー対応

### DIFF
--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -55,7 +55,7 @@ CDlgCompare::CDlgCompare()
 	: CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( int(std::size(anchorList)) == int(std::size(m_rcItems)) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	m_bCompareAndTileHorz = TRUE;	/* 左右に並べて表示 */
 

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -88,7 +88,7 @@ CDlgDiff::CDlgDiff()
 	: CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( int(std::size(anchorList)) == int(std::size(m_rcItems)) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	return;
 }

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -95,7 +95,7 @@ CDlgFavorite::CDlgFavorite()
 	m_szMsg[0] = L'\0';
 
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( int(std::size(anchorList)) == int(std::size(m_rcItems)) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	{
 		i = 0;

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -124,7 +124,7 @@ CDlgTagJumpList::CDlgTagJumpList(bool bDirectTagJump)
 	  m_bDirectTagJump(bDirectTagJump)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( int(std::size(anchorList)) == int(std::size(m_rcItems)) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	// 2010.07.22 Moca ページング採用で 最大値を100→50に減らす
 	m_pcList = new CSortedTagJumpList(50);

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -55,7 +55,7 @@ CDlgWindowList::CDlgWindowList()
 	: CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert(int(std::size(anchorList)) == int(std::size(m_rcItems)));
+	static_assert(_countof(anchorList) == _countof(m_rcItems));
 	m_ptDefaultSize.x = -1;
 	m_ptDefaultSize.y = -1;
 	return;

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1686,7 +1686,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 		cProfile.IOProfileData( pszSecName, L"bUseRegexKeyword", types.m_bUseRegexKeyword );/* 正規表現キーワード使用するか？ */
 		wchar_t* pKeyword = types.m_RegexKeywordList;
 		int nPos = 0;
-		constexpr auto nKeywordSize = int(std::size(types.m_RegexKeywordList));
+		constexpr auto nKeywordSize = int(_countof(types.m_RegexKeywordList));
 		for(j = 0; j < int(std::size(types.m_RegexKeywordArr)); j++)
 		{
 			auto_sprintf( szKeyName, L"RxKey[%03d]", j );

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -203,7 +203,7 @@ HINSTANCE CDlgFuncList::m_lastRcInstance = nullptr;
 CDlgFuncList::CDlgFuncList() : CDialog(true)
 {
 	/* サイズ変更時に位置を制御するコントロール数 */
-	static_assert( int(std::size(anchorList)) == int(std::size(m_rcItems)) );
+	static_assert( _countof(anchorList) == _countof(m_rcItems) );
 
 	m_pcFuncInfoArr = nullptr;		/* 関数情報配列 */
 	m_nCurLine = CLayoutInt(0);				/* 現在行 */

--- a/sakura_core/typeprop/CDlgTypeList.cpp
+++ b/sakura_core/typeprop/CDlgTypeList.cpp
@@ -210,7 +210,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 				}else{
 					::EnableWindow( GetItemHwnd( IDC_CHECK_EXT_RMENU ), TRUE );
 					if( !m_bRegistryChecked[ nIdx ] ){
-						WCHAR exts[std::size(type->m_szTypeExts)] = {0};
+						WCHAR exts[_countof(type->m_szTypeExts)] = {0};
 						wcscpy( exts, type->m_szTypeExts );
 						WCHAR *ext = _wcstok( exts, CDocTypeManager::m_typeExtSeps );
 
@@ -244,7 +244,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 				ApiWrap::BtnCtl_SetCheck( hwndRMenu, !checked );
 				break;
 			}
-			WCHAR exts[std::size(type->m_szTypeExts)] = {0};
+			WCHAR exts[_countof(type->m_szTypeExts)] = {0};
 			wcscpy( exts, type->m_szTypeExts );
 			WCHAR *ext = _wcstok( exts, CDocTypeManager::m_typeExtSeps );
 			int nRet;
@@ -283,7 +283,7 @@ INT_PTR CDlgTypeList::DispatchEvent( HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM
 				ApiWrap::BtnCtl_SetCheck( hwndDblClick, !checked );
 				break;
 			}
-			WCHAR exts[std::size(type->m_szTypeExts)] = {0};
+			WCHAR exts[_countof(type->m_szTypeExts)] = {0};
 			wcscpy( exts, type->m_szTypeExts );
 			WCHAR *ext = _wcstok( exts, CDocTypeManager::m_typeExtSeps );
 			int nRet;

--- a/sakura_core/types/CType_Erlang.cpp
+++ b/sakura_core/types/CType_Erlang.cpp
@@ -198,7 +198,7 @@ const wchar_t* COutlineErlang::ScanArgs( const wchar_t* end, const wchar_t* p )
 {
 	assert( m_state == STATE_FUNC_ARGS );
 
-	constexpr auto parptr_max = std::size(m_parenthesis);
+	constexpr auto parptr_max = _countof(m_parenthesis);
 	wchar_t quote = L'\0'; // 先頭位置を保存
 	for(const wchar_t* head = p ; p < end ; p++ ){
 		if( quote ){


### PR DESCRIPTION
## 概要

Visual Studio VS2022 でC2131 ビルドエラーが常に出るので対応をお願いしたいです。

## 原因

`std::size()` を **非静的メンバ変数**（またはポインタ/参照経由のメンバ変数）に対して使い、その結果を定数式が必要なコンテキスト（`static_assert`、`constexpr` 変数、配列サイズ）で使用しています。

MSVC は `std::size(m_rcItems)` を評価する際に暗黙的に `this->m_rcItems` を参照するため、定数式として認めません。`std::size()` のテンプレート自体は `constexpr` ですが、引数の **バインド** が非定数式と見なされます。

---

## エラーパターンは3種類

### パターン1: `static_assert` 内（6箇所）

| ファイル | 行 |
|---|---|
| `sakura_core/dlg/CDlgCompare.cpp` | 58 |
| `sakura_core/dlg/CDlgDiff.cpp` | 91 |
| `sakura_core/dlg/CDlgFavorite.cpp` | 98 |
| `sakura_core/dlg/CDlgWindowList.cpp` | 58 |
| `sakura_core/dlg/CDlgTagJumpList.cpp` | 127 |
| `sakura_core/outline/CDlgFuncList.cpp` | 206 |

```cpp
// 現在のコード:
static_assert( int(std::size(anchorList)) == int(std::size(m_rcItems)) );
```

### パターン2: `constexpr` 変数（2箇所）

| ファイル | 行 |
|---|---|
| `sakura_core/env/CShareData_IO.cpp` | 1689 |
| `sakura_core/types/CType_Erlang.cpp` | 201 |

```cpp
// 現在のコード:
constexpr auto nKeywordSize = int(std::size(types.m_RegexKeywordList));
constexpr auto parptr_max = std::size(m_parenthesis);
```

### パターン3: 配列サイズ（3箇所）

| ファイル | 行 |
|---|---|
| `sakura_core/typeprop/CDlgTypeList.cpp` | 213 |
| `sakura_core/typeprop/CDlgTypeList.cpp` | 247 |
| `sakura_core/typeprop/CDlgTypeList.cpp` | 286 |

```cpp
// 現在のコード:
WCHAR exts[std::size(type->m_szTypeExts)] = {0};
```

---

## 推奨修正方針: `_countof()` に置換

`_countof()` は内部的に `sizeof` ベースで動作するため、`this` のアクセスが問題になりません。
このプロジェクトでは既に15箇所で `_countof` を使用しており、整合性もあります。

### 修正例

**パターン1: `static_assert`**

```cpp
// Before:
static_assert( int(std::size(anchorList)) == int(std::size(m_rcItems)) );

// After:
static_assert( _countof(anchorList) == _countof(m_rcItems) );
```

**パターン2: `constexpr` 変数**

```cpp
// Before:
constexpr auto parptr_max = std::size(m_parenthesis);
constexpr auto nKeywordSize = int(std::size(types.m_RegexKeywordList));

// After:
constexpr auto parptr_max = _countof(m_parenthesis);
constexpr auto nKeywordSize = int(_countof(types.m_RegexKeywordList));
```

**パターン3: 配列サイズ**

```cpp
// Before:
WCHAR exts[std::size(type->m_szTypeExts)] = {0};

// After:
WCHAR exts[_countof(type->m_szTypeExts)] = {0};
```

---

## まとめ

- **修正対象:** 9ファイル、11箇所
- **修正内容:** `std::size(メンバ変数)` → `_countof(メンバ変数)`
- **影響範囲:** 定数式の評価方法のみ変更。実行時の動作に影響なし
