### PR TITLE
GitHub #2476 APIが正常値の戻り値0を返すとき最新のエラー情報をクリアしない

### DIFF
--- a/sakura_core/apiwrap/StdControl.cpp
+++ b/sakura_core/apiwrap/StdControl.cpp
@@ -27,6 +27,7 @@ namespace ApiWrap{
 		// GetWindowTextLength() はウィンドウテキスト取得に必要なバッファサイズを返す。
 		// 条件によっては必要なサイズより大きな値を返すことがある模様
 		// https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getwindowtextlengthw
+		::SetLastError(0);
 		const int cchRequired = ::GetWindowTextLength( hWnd );
 		if( cchRequired < 0 ){
 			// ドキュメントには失敗した場合、あるいはテキストが空の場合には 0 を返すとある。
@@ -46,6 +47,7 @@ namespace ApiWrap{
 
 		// GetWindowText() はコピーした文字数を返す。
 		// https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtextw
+		::SetLastError(0);
 		const int actualCopied = ::GetWindowText( hWnd, strText.data(), (int)strText.capacity() );
 		if( actualCopied < 0 ){
 			// 仕様上は負の場合はありえないが、念の為エラーチェックしておく。

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -71,6 +71,7 @@ namespace ApiWrap{
 		// GetWindowTextLength() はウィンドウテキスト取得に必要なバッファサイズを返す。
 		// 条件によっては必要なサイズより大きな値を返すことがある模様
 		// https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getwindowtextlengtha
+		::SetLastError(0);
 		const int length = ::GetWindowTextLength(hwnd);
 		if (length < 0)
 		{
@@ -89,6 +90,7 @@ namespace ApiWrap{
 			str.AllocStringBuffer(bufsize);
 		}
 
+		::SetLastError(0);
 		int actualCount = ::GetWindowText(hwnd, str.GetStringPtr(), str.capacity());
 		if (actualCount < 0)
 		{

--- a/src/test/cpp/tests1/test-StdControl.cpp
+++ b/src/test/cpp/tests1/test-StdControl.cpp
@@ -211,6 +211,26 @@ TEST(ApiWrap, WndTest001)
 	CNativeW cmemText;
 	EXPECT_THAT(ApiWrap::Wnd_GetText(hWnd, cmemText), IsTrue());
 	EXPECT_THAT(cmemText.GetStringPtr(), StrEq(L"test"));
+
+	// GitHub #2476 GetWindowTextLengthが正常値の戻り値0を返すとき最新のエラー情報をクリアしない.
+	// https://learn.microsoft.com/ja-jp/windows/win32/api/winuser/nf-winuser-getwindowtextlengthw
+	// このテストは事前準備データを書き換えるので取得結果がexpectedでなくなる.
+	// 空文字列
+	ApiWrap::SetWindowTextW(hWnd, L"");
+	CNativeW cmemTextEmpty;
+	::SetLastError(1);
+	EXPECT_THAT(ApiWrap::Wnd_GetText(hWnd, cmemTextEmpty), IsTrue());
+	EXPECT_THAT(cmemTextEmpty.GetStringPtr(), StrEq(L""));
+	// エラールート
+	EXPECT_THAT(ApiWrap::Wnd_GetText(NULL, cmemTextEmpty), IsFalse());
+
+	// 空文字列
+	std::wstring strempty;
+	::SetLastError(1);
+	EXPECT_THAT(ApiWrap::Wnd_GetText(hWnd, strempty), IsTrue());
+	EXPECT_STREQ(L"", strempty.c_str());
+	// エラールート
+	EXPECT_THAT(ApiWrap::Wnd_GetText(NULL, strempty), IsFalse());
 }
 
 /*!


### PR DESCRIPTION
# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

- 改善
- 不具合修正

## <!-- 必須 --> PR の背景

#2476

## <!-- 必須 --> 仕様・動作説明

空文字列が設定されているテキストボックスの文字列をApiWrap::Wnd_GetText()で取得したとき、
正常値としての戻り値０とエラーとしての戻り値０の区別をするためにGetLastError()でエラー判定しているが、
GetWindowTextLength()関数はエラーが発生しない場合に最新のエラー情報をクリアしない。
本関数を呼び出す前にSetLastErrorでクリアすることで、エラー判定を正常に動作するようにする。

## <!-- わかる範囲で --> PR の影響範囲

GetWindowTextLength()関数がエラーとなるのは主にウインドウハンドルが不正(NULL)な場合であるため、
サクラエディタのソースでは問題となるルートには入らないと予想される。

## <!-- 必須 --> テスト内容

- SetLastError(1)でエラー情報をセットした状態で、正常値０が返る空文字列を取得する。
- ウインドウハンドルにNULLを指定して、異常値０が返るエラールートを通す。

## <!-- なければ省略可 --> 関連 issue, PR


## <!-- なければ省略可 --> 参考資料

GetWindowTextLength
https://learn.microsoft.com/ja-jp/windows/win32/api/winuser/nf-winuser-getwindowtextlengthw
