### PR TITLE
Feature/2477

### DIFF
--- a/sakura_core/apiwrap/StdControl.cpp
+++ b/sakura_core/apiwrap/StdControl.cpp
@@ -27,6 +27,7 @@ namespace ApiWrap{
 		// GetWindowTextLength() はウィンドウテキスト取得に必要なバッファサイズを返す。
 		// 条件によっては必要なサイズより大きな値を返すことがある模様
 		// https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getwindowtextlengthw
+		::SetLastError(0);
 		const int cchRequired = ::GetWindowTextLength( hWnd );
 		if( cchRequired < 0 ){
 			// ドキュメントには失敗した場合、あるいはテキストが空の場合には 0 を返すとある。
@@ -46,6 +47,7 @@ namespace ApiWrap{
 
 		// GetWindowText() はコピーした文字数を返す。
 		// https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtextw
+		::SetLastError(0);
 		const int actualCopied = ::GetWindowText( hWnd, strText.data(), (int)strText.capacity() );
 		if( actualCopied < 0 ){
 			// 仕様上は負の場合はありえないが、念の為エラーチェックしておく。

--- a/sakura_core/apiwrap/StdControl.h
+++ b/sakura_core/apiwrap/StdControl.h
@@ -71,6 +71,7 @@ namespace ApiWrap{
 		// GetWindowTextLength() はウィンドウテキスト取得に必要なバッファサイズを返す。
 		// 条件によっては必要なサイズより大きな値を返すことがある模様
 		// https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getwindowtextlengtha
+		::SetLastError(0);
 		const int length = ::GetWindowTextLength(hwnd);
 		if (length < 0)
 		{
@@ -89,6 +90,7 @@ namespace ApiWrap{
 			str.AllocStringBuffer(bufsize);
 		}
 
+		::SetLastError(0);
 		int actualCount = ::GetWindowText(hwnd, str.GetStringPtr(), str.capacity());
 		if (actualCount < 0)
 		{

--- a/sakura_core/io/CFile.h
+++ b/sakura_core/io/CFile.h
@@ -52,19 +52,4 @@ private:
 	EShareMode	m_nFileShareModeOld;		//!< ファイルの排他制御モード
 };
 
-//!一時ファイル
-class CTmpFile{
-	using Me = CTmpFile;
-
-public:
-	CTmpFile(){ m_fp = tmpfile(); }
-	CTmpFile(const Me&) = delete;
-	Me& operator = (const Me&) = delete;
-	CTmpFile(Me&&) noexcept = delete;
-	Me& operator = (Me&&) noexcept = delete;
-	~CTmpFile(){ fclose(m_fp); }
-	FILE* GetFilePointer() const{ return m_fp; }
-private:
-	FILE* m_fp;
-};
 #endif /* SAKURA_CFILE_53DA3C63_95C0_49D0_9ED1_1C0131493912_H_ */

--- a/src/test/cpp/tests1/test-StdControl.cpp
+++ b/src/test/cpp/tests1/test-StdControl.cpp
@@ -211,6 +211,26 @@ TEST(ApiWrap, WndTest001)
 	CNativeW cmemText;
 	EXPECT_THAT(ApiWrap::Wnd_GetText(hWnd, cmemText), IsTrue());
 	EXPECT_THAT(cmemText.GetStringPtr(), StrEq(L"test"));
+
+	// GitHub #2476 GetWindowTextLengthが正常値の戻り値0を返すとき最新のエラー情報をクリアしない.
+	// https://learn.microsoft.com/ja-jp/windows/win32/api/winuser/nf-winuser-getwindowtextlengthw
+	// このテストは事前準備データを書き換えるので取得結果がexpectedでなくなる.
+	// 空文字列
+	ApiWrap::SetWindowTextW(hWnd, L"");
+	CNativeW cmemTextEmpty;
+	::SetLastError(1);
+	EXPECT_THAT(ApiWrap::Wnd_GetText(hWnd, cmemTextEmpty), IsTrue());
+	EXPECT_THAT(cmemTextEmpty.GetStringPtr(), StrEq(L""));
+	// エラールート
+	EXPECT_THAT(ApiWrap::Wnd_GetText(NULL, cmemTextEmpty), IsFalse());
+
+	// 空文字列
+	std::wstring strempty;
+	::SetLastError(1);
+	EXPECT_THAT(ApiWrap::Wnd_GetText(hWnd, strempty), IsTrue());
+	EXPECT_STREQ(L"", strempty.c_str());
+	// エラールート
+	EXPECT_THAT(ApiWrap::Wnd_GetText(NULL, strempty), IsFalse());
 }
 
 /*!


### PR DESCRIPTION
# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

- 削除

## <!-- 必須 --> PR の背景

GitHub #2477

## <!-- 必須 --> 仕様・動作説明

CTmpFileのコンストラクタで一時ファイルの作成に失敗した場合にm_fpが不定値(初期化漏れのため)となる。
そのため、デストラクタでは不定値のファイルクローズが動作することになる。
問題を修正すべきであるが、本クラスは現状未使用である。
よって、未使用クラスのCTmpFileを削除する。

## <!-- わかる範囲で --> PR の影響範囲

なし

## <!-- 必須 --> テスト内容

なし

## <!-- なければ省略可 --> 関連 issue, PR


## <!-- なければ省略可 --> 参考資料

