### PR TITLE
GitHub #2477 未使用のCTmpFileを削除

### DIFF
--- a/sakura_core/io/CFile.h
+++ b/sakura_core/io/CFile.h
@@ -52,19 +52,4 @@ private:
 	EShareMode	m_nFileShareModeOld;		//!< ファイルの排他制御モード
 };
 
-//!一時ファイル
-class CTmpFile{
-	using Me = CTmpFile;
-
-public:
-	CTmpFile(){ m_fp = tmpfile(); }
-	CTmpFile(const Me&) = delete;
-	Me& operator = (const Me&) = delete;
-	CTmpFile(Me&&) noexcept = delete;
-	Me& operator = (Me&&) noexcept = delete;
-	~CTmpFile(){ fclose(m_fp); }
-	FILE* GetFilePointer() const{ return m_fp; }
-private:
-	FILE* m_fp;
-};
 #endif /* SAKURA_CFILE_53DA3C63_95C0_49D0_9ED1_1C0131493912_H_ */


### PR DESCRIPTION
# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

- 削除

## <!-- 必須 --> PR の背景

GitHub #2477

## <!-- 必須 --> 仕様・動作説明

CTmpFileのコンストラクタで一時ファイルの作成に失敗した場合にm_fpが不定値(初期化漏れのため)となる。
そのため、デストラクタでは不定値のファイルクローズが動作することになる。
問題を修正すべきであるが、本クラスは現状未使用である。
よって、未使用クラスのCTmpFileを削除する。

## <!-- 必須 --> テスト内容

なし

## <!-- なければ省略可 --> 関連 issue, PR

なし

## <!-- なければ省略可 --> 参考資料

