### PR TITLE
SonarQube指摘対応 wcslen → 安全な長さ計算に置き換え (issue #2505)

### DIFF
--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -794,6 +794,11 @@ bool CImpExpKeyHelp::Import( const std::wstring& sFileName, std::wstring& sErrMs
 			continue;
 		}
 
+		// 2026.06.23 CWE-787 fix: p3 (the dictionary path) is attacker-controlled and unbounded
+		//            (it is the remainder of a line read by CTextInputStream::ReadLineW with no
+		//            length limit). The original wcscpy into m_szPath (StaticString<_MAX_PATH>)
+		//            therefore overflowed the type-settings object on a crafted import file.
+		//            Reject over-long paths, consistent with the About-length handling above.
 		//Path
 		// p3 points into buff; end-p3 gives the remaining length without scanning the string.
 		if (const auto end = std::data(buff) + std::size(buff);

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -782,7 +782,10 @@ bool CImpExpKeyHelp::Import( const std::wstring& sFileName, std::wstring& sErrMs
 			fclose(fp2);
 
 		//About
-		// p3 was advanced past the '\0' placed at the second comma, so
+		// 2026.06.23 CWE-787 fix: the original '>' allowed wcslen(p2)==DICT_ABOUT_LEN, so the
+		//            following copy wrote DICT_ABOUT_LEN+1 WCHAR into m_szAbout[DICT_ABOUT_LEN]
+		//            (a 1-WCHAR overflow). Reject when the value cannot hold its NUL terminator.
+		//  p3 was advanced past the '\0' placed at the second comma, so
 		// (p3 - 1) - p2 gives the exact length of p2 without walking the string.
 		if (DICT_ABOUT_LEN <= (p3 - 1) - p2) {
 			auto_sprintf( msgBuff, LS(STR_IMPEXP_DIC_LENGTH), DICT_ABOUT_LEN - 1 );

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -378,7 +378,7 @@ bool CImpExpType::Import( const std::wstring& sFileName, std::wstring& sErrMsg )
 	//  アウトライン解析方法
 	CommonSetting_Plugin& plugin = common.m_sPlugin;
 	if (m_cProfile.IOProfileData(szSecTypeEx, szKeyPluginOutlineId, StringBufferW(szKeyData))) {
-		nDataLen = (int)wcslen( szKeyData );
+		nDataLen = (int)wcsnlen( szKeyData, _countof(szKeyData) );
 		pSlashPos = wcschr( szKeyData, L'/' );
 		nIdx = -1;
 		for (i = 0; i < MAX_PLUGIN; i++) {
@@ -399,7 +399,7 @@ bool CImpExpType::Import( const std::wstring& sFileName, std::wstring& sErrMsg )
 	}
 	//  スマートインデント
 	if (m_cProfile.IOProfileData(szSecTypeEx, szKeyPluginSmartIndentId, StringBufferW(szKeyData))) {
-		nDataLen = (int)wcslen( szKeyData );
+		nDataLen = (int)wcsnlen( szKeyData, _countof(szKeyData) );
 		pSlashPos = wcschr( szKeyData, L'/' );
 		nIdx = -1;
 		for (i = 0; i < MAX_PLUGIN; i++) {

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -782,10 +782,9 @@ bool CImpExpKeyHelp::Import( const std::wstring& sFileName, std::wstring& sErrMs
 			fclose(fp2);
 
 		//About
-		// 2026.06.23 CWE-787 fix: the original '>' allowed wcslen(p2)==DICT_ABOUT_LEN, so the
-		//            following copy wrote DICT_ABOUT_LEN+1 WCHAR into m_szAbout[DICT_ABOUT_LEN]
-		//            (a 1-WCHAR overflow). Reject when the value cannot hold its NUL terminator.
-		if (wcslen(p2) >= DICT_ABOUT_LEN) {
+		// p3 was advanced past the '\0' placed at the second comma, so
+		// (p3 - 1) - p2 gives the exact length of p2 without walking the string.
+		if (DICT_ABOUT_LEN <= (p3 - 1) - p2) {
 			auto_sprintf( msgBuff, LS(STR_IMPEXP_DIC_LENGTH), DICT_ABOUT_LEN - 1 );
 			sErrMsg = msgBuff;
 			++invalid_record;

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -792,12 +792,9 @@ bool CImpExpKeyHelp::Import( const std::wstring& sFileName, std::wstring& sErrMs
 		}
 
 		//Path
-		// 2026.06.23 CWE-787 fix: p3 (the dictionary path) is attacker-controlled and unbounded
-		//            (it is the remainder of a line read by CTextInputStream::ReadLineW with no
-		//            length limit). The original wcscpy into m_szPath (StaticString<_MAX_PATH>)
-		//            therefore overflowed the type-settings object on a crafted import file.
-		//            Reject over-long paths, consistent with the About-length handling above.
-		if (wcslen(p3) >= m_Types.m_KeyHelpArr[i].m_szPath.size()) {
+		// p3 points into buff; end-p3 gives the remaining length without scanning the string.
+		if (const auto end = std::data(buff) + std::size(buff);
+			std::size(m_Types.m_KeyHelpArr[i].m_szPath) <= end - p3) {
 			auto_sprintf( msgBuff, LS(STR_IMPEXP_DIC_LENGTH), int(m_Types.m_KeyHelpArr[i].m_szPath.size()) - 1 );
 			sErrMsg = msgBuff;
 			++invalid_record;


### PR DESCRIPTION
## 概要

issue #2505 で報告された SonarQube の cpp:S5813 指摘（`wcslen` の安全でない使用）を修正します。

## 変更内容

| 箇所 | 変更前 | 変更後 |
|---|---|---|
| `CImpExpType::Import` L381 | `wcslen(szKeyData)` | `wcsnlen(szKeyData, _countof(szKeyData))` |
| `CImpExpType::Import` L402 | `wcslen(szKeyData)` | `wcsnlen(szKeyData, _countof(szKeyData))` |
| `CImpExpKeyHelp::Import` L788 | `wcslen(p2) >= DICT_ABOUT_LEN` | `DICT_ABOUT_LEN <= (p3 - 1) - p2` |
| `CImpExpKeyHelp::Import` L801 | `wcslen(p3) >= ...size()` | `std::data(buff)+std::size(buff)` によるポインタ演算 |

## 修正方針

- L381/L402: `szKeyData` は `wchar_t[1024]` の固定長配列。`wcsnlen` で上限を明示することで SonarQube の指摘を解消。
- L788: `p3` は第2カンマの直後を指すため `(p3-1)-p2` が `wcslen(p2)` と等価。文字列を走査せずに長さを求められる。
- L801: `std::data(buff)+std::size(buff)` で `buff` の null 終端ポインタを求め、`end-p3` で長さを O(1) で計算。

## 関連

- Closes #2505

🤖 Generated with [Claude Code](https://claude.com/claude-code)