### PR TITLE
SonarCloud の workflow_run チェックアウトを actions/checkout v7 対応で修正

### DIFF
--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -18,6 +18,7 @@ jobs:
         ref: ${{ github.event.workflow_run.head_sha }}
         fetch-depth: 0
         submodules: true
+        allow-unsafe-pr-checkout: true
 
     - name: Download sonar-input artifact
       uses: actions/download-artifact@v4


### PR DESCRIPTION
## 概要
- #2498 で `actions/checkout` を v6 から v7 に更新した際、v7 で新しく追加された「`workflow_run` 内でフォーク PR の head を既定でチェックアウト拒否する」ガードにより、SonarCloud ワークフロー ([sonarscan.yml](.github/workflows/sonarscan.yml)) が失敗するようになった (参考: https://github.com/sakura-editor/sakura/actions/runs/28484916894/job/84429147750)
- `sonarscan.yml` はコントリビューターのフォークからビルドされた PR のソースを、シークレットが使える `workflow_run` コンテキストでチェックアウトし、SonarQube スキャナのみを実行する構成になっている。ビルド自体は別ワークフロー (`build sakura`, `pull_request` イベント) がシークレットなしで行っており、この構成自体は SonarCloud のフォーク PR 分析における標準的なパターン
- Checkout ステップに `allow-unsafe-pr-checkout: true` を追加し、v6 までの挙動に戻す

## テスト計画
- [ ] master にマージ後、フォークからの PR に対して SonarCloud ワークフローが正常に完了することを確認