### PR TITLE
SonarCloud workflow_run の checkout 修正と承認ゲートの追加

### DIFF
--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -18,6 +18,7 @@ jobs:
         ref: ${{ github.event.workflow_run.head_sha }}
         fetch-depth: 0
         submodules: true
+        allow-unsafe-pr-checkout: true
 
     - name: Download sonar-input artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -10,6 +10,7 @@ jobs:
     name: Scan
     runs-on: windows-latest
     if: github.event.workflow_run.conclusion == 'success'
+    environment: sonarcloud
 
     steps:
     - name: Checkout


### PR DESCRIPTION
## 背景
- #2498 (`actions/checkout` v6 → v7) により、v7 で新設された「`workflow_run` 内でフォーク PR の head を既定でチェックアウト拒否する」ガードに引っかかり、SonarCloud ワークフロー ([sonarscan.yml](.github/workflows/sonarscan.yml)) が失敗するようになった (参考: https://github.com/sakura-editor/sakura/actions/runs/28484916894/job/84429147750)
- `allow-unsafe-pr-checkout: true` を設定すればチェックアウト自体は復旧するが、これは v7 で追加された Pwn Request 対策のガードを単に無効化するだけであり、それ単体では secrets が使えるコンテキストでフォーク PR のソースを扱うリスクへの対策にはならない
- 実際、本リポジトリでは2日前 (6f4c8525b 付近) に同種の懸念から `workflow_run` 内の `actions/checkout` を撤廃し `sources.tar.gz` 展開方式に変更する試みがあったが、SonarCloud の SCM 連携 (blame・New Code 判定など) が機能しなくなるため同日中に revert された経緯がある (e31cd6d79)

## 対応
1. Checkout ステップに `allow-unsafe-pr-checkout: true` を追加し、v6 までの挙動を復旧
2. GitHub Environment `sonarcloud` を新規作成し、admin 権限を持つメンテナ (kobake, berryzplus, m-tmatma, KENCHjp) を required reviewers として設定した上で、Scan ジョブに割り当て

これにより、checkout ベースの構成 (SCM 連携含む) を維持したまま、secrets を伴うジョブが実行される前にメンテナの承認を必須にすることで、フォーク PR のソースを信頼できない状態のまま自動実行してしまう Pwn Request の経路を塞ぐ。

## テスト計画
- [ ] マージ後、フォークからの PR に対して SonarCloud ワークフローが Scan ジョブで承認待ちになることを確認
- [ ] reviewer が承認した後、SonarCloud の解析・PR コメント投稿が正常に完了することを確認


https://github.com/sakura-editor/sakura/settings/environments/17465525874/edit

<img width="1293" height="752" alt="image" src="https://github.com/user-attachments/assets/be4256d0-e8ee-4bb6-b68e-08c82ea62394" />




