### PR TITLE
設定ファイルの読み込み速度を改善する

### DIFF
--- a/sakura_core/env/CProfile.cpp
+++ b/sakura_core/env/CProfile.cpp
@@ -98,9 +98,11 @@ bool CProfile::ReadProfile(
 	}
 
 	try{
-		while( in ){
+		std::wstring line;
+
+		while (in) {
 			//1行読込
-			std::wstring line=in.ReadLineW();
+			in.ReadLineW(line);
 
 			//解析
 			_ReadOneline(line);

--- a/sakura_core/env/CProfile.cpp
+++ b/sakura_core/env/CProfile.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, D.S.Koba, MIK, genta
 	Copyright (C) 2006, D.S.Koba, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -39,7 +39,7 @@
 	@param line [in] 読み込んだ行
 */
 void CProfile::_ReadOneline(
-	const std::wstring& line
+	std::wstring_view line
 )
 {
 	//	空行を読み飛ばす
@@ -52,15 +52,22 @@ void CProfile::_ReadOneline(
 	}
 
 	// セクション取得
-	if (std::wsmatch m; std::regex_match(line, m, std::wregex(LR"(^\[([^=]+)\]$)"))) {
-		m_ProfileData.emplace_back(static_cast<std::wstring>(m[1]));
+	if (2 < line.length() && L'[' == line.front() && L']' == line.back()) {
+		if (const auto sectionName{ line.substr(1, line.length() - 2) };
+			std::wstring_view::npos == sectionName.find(L'=')) {
+			m_ProfileData.emplace_back(sectionName);
+			return;
+		}
+	}
+
+	// 最初のセクション以前の行のエントリは無視
+	if (m_ProfileData.empty()) {
 		return;
 	}
 
 	// エントリ取得
-	// ※最初のセクション以前の行のエントリは無視
-	if (std::wsmatch m; !m_ProfileData.empty() && std::regex_match(line, m, std::wregex(LR"(^([^=]+)=(.*)$)"))) {
-		m_ProfileData.back().m_Entries.try_emplace(m[1], m[2]);
+	if (const auto pos = line.find(L'='); std::wstring_view::npos != pos && 0 < pos && pos + 1 <= line.length()) {
+		m_ProfileData.back().m_Entries.try_emplace(std::wstring{ line.substr(0, pos) }, line.substr(pos + 1));
 	}
 }
 

--- a/sakura_core/env/CProfile.h
+++ b/sakura_core/env/CProfile.h
@@ -9,7 +9,7 @@
 */
 /*
 	Copyright (C) 2003-2006, D.S.Koba
-	Copyright (C) 2018-2025, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -29,7 +29,7 @@ class CProfile
 private:
 	struct SectionType
 	{
-		using EntriesType = std::map< std::wstring, std::wstring >;
+		using EntriesType = std::map<std::wstring, std::wstring, std::less<>>;
 
 		explicit SectionType(
 			std::wstring_view name
@@ -61,7 +61,7 @@ public:
 	void DUMP( void );
 
 private:
-	void _ReadOneline(const std::wstring& line);
+	void _ReadOneline(std::wstring_view line);
 	bool _WriteFile(const std::filesystem::path& path, std::span<const std::wstring> lines);
 
 	// メンバ変数

--- a/sakura_core/io/CTextStream.cpp
+++ b/sakura_core/io/CTextStream.cpp
@@ -1,17 +1,24 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
 #include "StdAfx.h"
-#include "CTextStream.h"
+#include "io/CTextStream.h"
+
 #include "charset/CCodeFactory.h"
 #include "charset/CShiftJis.h"	// move from CCodeMediator.h	2010/6/14 Uchi
 #include "charset/CUtf8.h"		// move from CCodeMediator.h	2010/6/14 Uchi
 #include "basis/CEol.h"
 #include "util/file.h"			// _IS_REL_PATH
 #include "util/module.h"
+
+namespace cxx {
+
+std::wstring_view MultiByteToWideChar(UINT codePage, std::string_view source, std::wstring& buffer);
+
+} // namespace cxx
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                     CTextInputStream                        //
@@ -20,8 +27,6 @@
 CTextInputStream::CTextInputStream(const WCHAR* pszPath)
 : CStream(pszPath,L"rb")
 {
-	m_bIsUtf8=false;
-
 	if(Good()){
 		//BOM確認 -> m_bIsUtf8
 		static const BYTE UTF8_BOM[]={0xEF,0xBB,0xBF};
@@ -34,9 +39,6 @@ CTextInputStream::CTextInputStream(const WCHAR* pszPath)
 		if(!m_bIsUtf8){
 			fseek(GetFp(),0,SEEK_SET);
 		}
-	}
-	else{
-		m_bIsUtf8 = false;
 	}
 }
 
@@ -52,32 +54,61 @@ CTextInputStream::~CTextInputStream()
 {
 }
 
-std::wstring CTextInputStream::ReadLineW()
+/*!
+ * @brief 1行読込。改行は削る
+ */
+void CTextInputStream::ReadLineW(std::wstring& line)
 {
 	//$$ 非効率だけど今のところは許して。。
-	CNativeW line;
-	line.AllocStringBuffer(60);
-	for (;;) {
-		int c=getc(GetFp());
-		if(c==EOF)break; //EOFで終了
-		if(c=='\r'){ c=getc(GetFp()); if(c!='\n')ungetc(c,GetFp()); break; } //"\r" または "\r\n" で終了
-		if(c=='\n')break; //"\n" で終了
-		if( line._GetMemory()->capacity() < line._GetMemory()->GetRawLength() + 10 ){
-			line._GetMemory()->AllocBuffer( line._GetMemory()->GetRawLength() * 2 );
+
+	// 実は言う程「非効率」でもない。
+	// ・ファイルデータ → 内部バッファ m_Buffer
+	// ・内部バッファ m_Buffer → UNICODE文字列
+
+	// 現在のバッファ書込位置はイテレータで管理する
+	auto it = m_Buffer.begin();
+	for (;; ++it) {
+		int c = ::getc(GetFp());
+		// CRを検出したらCRLFかどうかチェックする
+		if ('\r' == c) {
+			c = ::getc(GetFp());
+			if ('\n' != c) {
+				::ungetc(c, GetFp());
+				c = '\r';
+			}
 		}
-		line._GetMemory()->AppendRawData(&c,sizeof(char));
+
+		// CRLF, LF, CR, EOF で終了
+		if ('\n' == c || '\r' == c || EOF == c) break; //EOFで終了
+
+		// バッファ末尾に到達したら拡張する
+		if (it == m_Buffer.end()) {
+			const auto pos = std::distance(m_Buffer.begin(), it);
+			m_Buffer.resize(m_Buffer.size() * 2);
+			it = m_Buffer.begin() + pos;
+		}
+
+		// バッファに書き込む
+		*it = static_cast<char>(c);
 	}
 
-	//UTF-8 → UNICODE
-	if(m_bIsUtf8){
-		CUtf8::UTF8ToUnicode(*(line._GetMemory()), &line);
-	}
-	//Shift_JIS → UNICODE
-	else{
-		CShiftJis::SJISToUnicode(*(line._GetMemory()), &line);
-	}
+	// 変換に使うコードページを確定させる
+	const auto codePage = m_bIsUtf8 ? CP_UTF8 : CP_SJIS;	// UTF-8ならCP_UTF8、そうでなければShift_JIS(CP932)とする
 
-	return std::wstring(line.GetStringPtr(), line.GetStringLength());	// EOLまで。NUL文字も含める。
+	// 変換を実行する
+	cxx::MultiByteToWideChar(codePage, std::string_view{ m_Buffer.begin(), it }, line);
+}
+
+/*!
+ * @brief 1行読込。改行は削る
+ *
+ * @note 既存コード互換のため残しておく。
+ */
+std::wstring CTextInputStream::ReadLineW()
+{
+	std::wstring line;
+	ReadLineW(line);
+	return line;
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/io/CTextStream.h
+++ b/sakura_core/io/CTextStream.h
@@ -8,7 +8,7 @@
 //将来はUTF-8等にすることにより、UNICODEデータの欠落が起こらないようにしたい。
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -32,10 +32,12 @@ public:
 	virtual ~CTextInputStream();
 
 	//操作
-	std::wstring ReadLineW(); //!< 1行読込。改行は削る
+	void			ReadLineW(std::wstring& line);
+	std::wstring	ReadLineW();
 
 private:
-	bool m_bIsUtf8; //!< UTF-8ならtrue
+	bool			m_bIsUtf8 = false;						//!< UTF-8ならtrue
+	std::string		m_Buffer = std::string(4096, L'\0');	//!< 内部バッファ
 };
 
 //テキスト出力ストリーム
@@ -68,4 +70,5 @@ class CTextInputStream_AbsIni final : public CTextInputStream{
 public:
 	CTextInputStream_AbsIni(const WCHAR* pszPath, bool bOrExedir = true);
 };
+
 #endif /* SAKURA_CTEXTSTREAM_CF4FEC73_4575_4B80_98F7_CFCBC0B433CD_H_ */

--- a/sakura_core/util/tchar_convert.cpp
+++ b/sakura_core/util/tchar_convert.cpp
@@ -95,6 +95,30 @@ int MultiByteToWideChar(UINT codePage, std::string_view source, std::span<WCHAR>
 	);
 }
 
+/*!
+ * ナロー文字列をワイド文字列に変換します。
+ *
+ * @param [in] codePage 変換に使用するコードページ。
+ * @param [in] source 変換元のナロー文字列
+ * @param [in, out] buffer 変換後のワイド文字列を受け取るバッファ
+ */
+std::wstring_view MultiByteToWideChar(UINT codePage, std::string_view source, std::wstring& buffer) {
+	// 変換を実行する
+
+	// 変換に必要な出力バッファサイズを求める
+	const auto required = cxx::CountAsWideChar(codePage, source);
+
+	// 変換に必要な出力バッファを確保する
+	buffer.resize(required);
+
+	// 変換を実行する
+	const auto converted = cxx::MultiByteToWideChar(codePage, source, std::span{ buffer });
+
+	buffer.resize(converted); // MultiByteToWideCharの戻り値は終端NULを含まない
+
+	return buffer;
+}
+
 } // namespace cxx
 
 const WCHAR* to_wchar(const ACHAR* src)
@@ -264,9 +288,7 @@ std::wstring to_wstring(std::string_view source, _In_opt_ UINT codePage) {
 	std::wstring buffer(required, '\0');
 
 	// 変換を実行する
-	const auto converted = cxx::MultiByteToWideChar(codePage, source, buffer);
-
-	buffer.resize(converted); // MultiByteToWideCharの戻り値は終端NULを含まない
+	cxx::MultiByteToWideChar(codePage, source, buffer);
 
 	return buffer;
 }

--- a/src/test/cpp/tests1/test-cprofile.cpp
+++ b/src/test/cpp/tests1/test-cprofile.cpp
@@ -1,21 +1,103 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
 #include "pch.h"
-#include <tchar.h>
-#include <Windows.h>
+#include "env/CDataProfile.h"
+
 #include <Shlwapi.h>
 
-#include "env/CProfile.h"
-
 #include <cstdlib>
-#include <filesystem>
+#include <fstream>
 
 #include "util/file.h"
-#include "env/CDataProfile.h"
+
+using namespace std::literals::string_literals;
+using namespace std::literals::string_view_literals;
+
+/*!
+ * @brief 内部バッファが溢れたら拡張する
+ */
+TEST(CProfile, ReadProfile_ExpandLineBuffer)
+{
+	std::filesystem::path iniPath{ "test.ini" };
+
+	std::error_code ec;
+	std::filesystem::remove(iniPath, ec);
+
+	// ファイル出力ストリームをバイナリモードで開く
+	std::ofstream os(iniPath, std::ios::binary);
+
+	std::vector<std::string> lines{
+		"; test"s,
+		"[test]"s,
+		"test=1"s,
+	};
+
+	constexpr auto& prefix = "too_long_item=";
+	auto tooLongLine = std::format("{}{:x<4083}", prefix, 'x');	// 4096文字を超える行を作る
+	lines.emplace_back(tooLongLine);
+
+	// 各行を書き込む
+	for (const auto& line : lines) {
+		if (!line.empty()) {
+			os.write(LPCSTR(std::data(line)), std::size(line));
+		}
+		os << '\r';
+	}
+
+	os.close();
+
+	CDataProfile cProfile;
+	cProfile.ReadProfile(iniPath);
+
+	bool value = false;
+	EXPECT_THAT(cProfile.GetProfileData(L"test", L"test", value), IsTrue());
+	EXPECT_THAT(value, IsTrue());
+
+	std::filesystem::remove(iniPath, ec);
+}
+
+/*!
+ * @brief 設定ファイルの改行コードがCR
+ */
+TEST(CProfile, ReadProfile_LineTerminatorCr)
+{
+	std::filesystem::path iniPath{ "test.ini" };
+
+	std::error_code ec;
+	std::filesystem::remove(iniPath, ec);
+
+	// ファイル出力ストリームをバイナリモードで開く
+	std::ofstream os(iniPath, std::ios::binary);
+
+	const std::array lines{
+		u8"; test"sv,
+		u8"[test]"sv,
+		u8"test=1"sv,
+	};
+
+	// 各行を書き込む
+	for (const auto& line : lines) {
+		if (!line.empty()) {
+			os.write(LPCSTR(std::data(line)), std::size(line));
+		}
+		os << '\r';
+	}
+
+	os.close();
+
+	CDataProfile cProfile;
+	cProfile.ReadProfile(iniPath);
+
+	bool value = false;
+	EXPECT_THAT(cProfile.GetProfileData(L"test", L"test", value), IsTrue());
+	EXPECT_THAT(value, IsTrue());
+
+	std::filesystem::remove(iniPath, ec);
+}
 
 /*!
  * @brief WriteProfileは指定されたパスに含まれるサブディレクトリを作成する


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2489

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- 行データの読み込みに std::wregex によるマッチングを使っていたのをやめます。
- 行データの読み込みバッファを使い回せるよう変更します。

本件、勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->
- 設定ファイルの読み込みに影響する修正です。

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
- 修正箇所全行をカバーするテストケースを用意しました。
<!-- レビュアーが確認する再現手順があれば記載してください。 -->
- #2489 で提示している WinMainTest.runWithNoWin の実行速度が改善されている（数十秒→数秒）で判断するのが妥当と思います。

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- resolves #2489

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->

- 対応後の x64 / Debug の実行結果
<img width="836" height="169" alt="image" src="https://github.com/user-attachments/assets/643f1bd7-9753-4d5d-94f8-3838cc4b5805" />

