### PR TITLE
ファイルダイアログで出力先バッファサイズを意識する

### DIFF
--- a/sakura_core/dlg/CDlgOpenFile.cpp
+++ b/sakura_core/dlg/CDlgOpenFile.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, novice, ryoji
 	Copyright (C) 2006, ryoji, Moca
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -20,6 +20,7 @@
 
 #include "StdAfx.h"
 #include "dlg/CDlgOpenFile.h"
+
 #include "env/DLLSHAREDATA.h"
 
 extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog();
@@ -45,15 +46,15 @@ void CDlgOpenFile::Create(
 }
 
 inline bool CDlgOpenFile::DoModal_GetOpenFileName(
-	WCHAR* pszPath,
+	std::span<WCHAR> szPath,
 	EFilter eAddFileter)
 {
-	return m_pImpl->DoModal_GetOpenFileName(pszPath, eAddFileter);
+	return m_pImpl->DoModal_GetOpenFileName(szPath, eAddFileter);
 }
 
-inline bool CDlgOpenFile::DoModal_GetSaveFileName( WCHAR* pszPath )
+inline bool CDlgOpenFile::DoModal_GetSaveFileName( std::span<WCHAR> szPath )
 {
-	return m_pImpl->DoModal_GetSaveFileName(pszPath);
+	return m_pImpl->DoModal_GetSaveFileName(szPath);
 }
 
 inline bool CDlgOpenFile::DoModalOpenDlg(

--- a/sakura_core/dlg/CDlgOpenFile.h
+++ b/sakura_core/dlg/CDlgOpenFile.h
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, genta, MIK
 	Copyright (C) 2005, ryoji
 	Copyright (C) 2006, Moca, ryoji
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -52,21 +52,21 @@ public:
 	// 操作
 
 	/*! 開くダイアログ モーダルダイアログの表示
-		@param[in,out] pszPath 初期ファイル名．選択されたファイル名の格納場所
+		@param[in,out] szPath 初期ファイル名．選択されたファイル名の格納場所
 		@param[in] eAddFiler フィルタ設定
 		@retval true ユーザーがファイル名を選択してOKした
 		@retval false ダイアログをユーザーがキャンセル等で閉じたかもしくは開くのに失敗したか
 	*/
 	virtual bool DoModal_GetOpenFileName(
-		WCHAR* pszPath,
+		std::span<WCHAR> szPath,
 		EFilter eAddFilter
 	) = 0;
 
 	/*! 保存ダイアログ モーダルダイアログの表示
-		@param pszPath [i/o] 初期ファイル名．選択されたファイル名の格納場所
+		@param szPath [i/o] 初期ファイル名．選択されたファイル名の格納場所
 	*/
 	virtual bool DoModal_GetSaveFileName(
-		WCHAR* pszPath
+		std::span<WCHAR> szPath
 	) = 0;
 
 	/* 開くダイアログ モーダルダイアログの表示 */
@@ -103,8 +103,8 @@ public:
 	) override;
 
 	//操作
-	bool DoModal_GetOpenFileName(WCHAR* pszPath, EFilter eAddFileter = EFITER_TEXT) override;
-	bool DoModal_GetSaveFileName(WCHAR* pszPath) override;
+	bool DoModal_GetOpenFileName(std::span<WCHAR> szPath, EFilter eAddFileter = EFITER_TEXT) override;
+	bool DoModal_GetSaveFileName(std::span<WCHAR> szPath) override;
 	bool DoModalOpenDlg(SLoadInfo* pLoadInfo,
 		std::vector<std::wstring>* pFilenames,
 		bool bOptions = true) override;
@@ -115,7 +115,9 @@ public:
 						   bool resolvePath, EFilter eAddFilter = EFITER_TEXT);
 
 	DISALLOW_COPY_AND_ASSIGN(CDlgOpenFile);
+
 private:
 	std::shared_ptr<IDlgOpenFile> m_pImpl;
 };
+
 #endif /* SAKURA_CDLGOPENFILE_8084B9DB_6463_4168_BA59_132EB2596AE7_H_ */

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, novice, ryoji
 	Copyright (C) 2006, ryoji, Moca
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -71,8 +71,8 @@ struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
 		const std::vector<LPCWSTR>& vOPENFOLDER
 	) override;
 
-	bool DoModal_GetOpenFileName( WCHAR* pszPath, EFilter eAddFileter ) override;
-	bool DoModal_GetSaveFileName( WCHAR* pszPath ) override;
+	bool DoModal_GetOpenFileName(std::span<WCHAR> szPath, EFilter eAddFileter) override;
+	bool DoModal_GetSaveFileName(std::span<WCHAR> szPath) override;
 	bool DoModalOpenDlg( SLoadInfo* pLoadInfo, std::vector<std::wstring>*, bool bOptions ) override;
 	bool DoModalSaveDlg( SSaveInfo*	pSaveInfo, bool bSimpleMode ) override;
 
@@ -699,8 +699,18 @@ void CDlgOpenFile_CommonFileDialog::Create(
 		拡張子フィルタの管理をCFileExtクラスで行う。
 	@date 2005.02.20 novice 拡張子を省略したら補完する
 */
-bool CDlgOpenFile_CommonFileDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFilter eAddFilter )
+bool CDlgOpenFile_CommonFileDialog::DoModal_GetOpenFileName(
+	std::span<WCHAR> szPath,
+	EFilter eAddFilter
+)
 {
+	const auto cchPath = std::size(szPath);
+
+	assert(_MAX_PATH <= cchPath);
+	assert(cchPath <= UINT_MAX);
+
+	auto pszPath = std::data(szPath);
+
 	//カレントディレクトリを保存。関数から抜けるときに自動でカレントディレクトリは復元される。
 	CCurrentDirectoryBackupPoint cCurDirBackup;
 
@@ -767,7 +777,9 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 	}
 	pData->m_ofn.lpstrFile = pszPath;
 	// To Here Jun. 23, 2002 genta
-	pData->m_ofn.nMaxFile = _MAX_PATH;
+
+	pData->m_ofn.nMaxFile = DWORD(cchPath);
+
 	pData->m_ofn.lpstrInitialDir = m_szInitialDir;
 	pData->m_ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
 	pData->m_ofn.lpstrDefExt = L""; // 2005/02/20 novice 拡張子を省略したら補完する
@@ -793,8 +805,17 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 		拡張子フィルタの管理をCFileExtクラスで行う。
 	@date 2005.02.20 novice 拡張子を省略したら補完する
 */
-bool CDlgOpenFile_CommonFileDialog::DoModal_GetSaveFileName( WCHAR* pszPath )
+bool CDlgOpenFile_CommonFileDialog::DoModal_GetSaveFileName(
+	std::span<WCHAR> szPath
+)
 {
+	const auto cchPath = std::size(szPath);
+
+	assert(_MAX_PATH <= cchPath);
+	assert(cchPath <= UINT_MAX);
+
+	auto pszPath = std::data(szPath);
+
 	//カレントディレクトリを保存。関数から抜けるときに自動でカレントディレクトリは復元される。
 	CCurrentDirectoryBackupPoint cCurDirBackup;
 
@@ -823,7 +844,9 @@ bool CDlgOpenFile_CommonFileDialog::DoModal_GetSaveFileName( WCHAR* pszPath )
 	pData->m_ofn.hInstance = CSelectLang::getLangRsrcInstance();
 	pData->m_ofn.lpstrFilter = cFileExt.GetExtFilter();
 	pData->m_ofn.lpstrFile = pszPath; // 2005/02/20 novice デフォルトのファイル名は何も設定しない
-	pData->m_ofn.nMaxFile = _MAX_PATH;
+
+	pData->m_ofn.nMaxFile = DWORD(cchPath);
+
 	pData->m_ofn.lpstrInitialDir = m_szInitialDir;
 	pData->m_ofn.Flags = OFN_CREATEPROMPT | OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT;
 

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -12,7 +12,7 @@
 	Copyright (C) 2004, genta
 	Copyright (C) 2005, novice, ryoji
 	Copyright (C) 2006, ryoji, Moca
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -50,8 +50,8 @@ struct CDlgOpenFile_CommonItemDialog final
 		const std::vector<LPCWSTR>& vOPENFOLDER
 	) override;
 
-	bool DoModal_GetOpenFileName( WCHAR* pszPath, EFilter eAddFileter ) override;
-	bool DoModal_GetSaveFileName( WCHAR* pszPath ) override;
+	bool DoModal_GetOpenFileName(std::span<WCHAR> szPath, EFilter eAddFileter) override;
+	bool DoModal_GetSaveFileName(std::span<WCHAR> szPath) override;
 	bool DoModalOpenDlg( SLoadInfo* pLoadInfo,
 						 std::vector<std::wstring>* pFileNames,
 						 bool bOptions ) override;
@@ -426,8 +426,17 @@ void CDlgOpenFile_CommonItemDialog::Create(
 	return;
 }
 
-bool CDlgOpenFile_CommonItemDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFilter eAddFilter )
+bool CDlgOpenFile_CommonItemDialog::DoModal_GetOpenFileName(
+	std::span<WCHAR> szPath,
+	EFilter eAddFilter
+)
 {
+	const auto cchPath = std::size(szPath);
+
+	assert(_MAX_PATH <= cchPath);
+
+	auto pszPath = std::data(szPath);
+
 	//	2003.05.12 MIK
 	std::vector<COMDLG_FILTERSPEC> specs;
 	specs.reserve(7);
@@ -464,7 +473,7 @@ bool CDlgOpenFile_CommonItemDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 	std::vector<std::wstring> fileNames;
 	bool ret = DoModalOpenDlgImpl0(false, &fileNames, L"", specs);
 	if (ret) {
-		wcscpy(pszPath, fileNames[0].c_str());
+		::wcscpy_s(pszPath, cchPath, fileNames[0].c_str());
 	}
 	return ret;
 }
@@ -472,8 +481,16 @@ bool CDlgOpenFile_CommonItemDialog::DoModal_GetOpenFileName( WCHAR* pszPath, EFi
 /*! 保存ダイアログ モーダルダイアログの表示
 	@param pszPath [i/o] 初期ファイル名．選択されたファイル名の格納場所
 */
-bool CDlgOpenFile_CommonItemDialog::DoModal_GetSaveFileName( WCHAR* pszPath )
+bool CDlgOpenFile_CommonItemDialog::DoModal_GetSaveFileName(
+	std::span<WCHAR> szPath
+)
 {
+	const auto cchPath = std::size(szPath);
+
+	assert(_MAX_PATH <= cchPath);
+
+	auto pszPath = std::data(szPath);
+
 	// 2010.08.28 カレントディレクトリを移動するのでパス解決する
 	if( pszPath[0] ){
 		WCHAR szFullPath[_MAX_PATH];

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -319,6 +319,17 @@ bool IsDlgItemEnabled(HWND hWndDlg, int nIDDlgItem)
 }
 
 /*!
+ * @brief ダイアログボックス項目のテキストを設定する
+ */
+bool SetDlgItemTextW(HWND hWndDlg, int nIDDlgItem, std::wstring_view text)
+{
+	// コントロールが存在しない場合は失敗とする
+	if (!::GetDlgItem(hWndDlg, nIDDlgItem)) return false;
+
+	return ::SetDlgItemTextW(hWndDlg, nIDDlgItem, std::data(text));
+}
+
+/*!
  * @brief トラックバーの現在位置を変更する
  */
 void SetTrackBarPos(HWND hWndDlg, int nIDDlgItem, WORD pos, bool bRedraw)

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -145,6 +145,8 @@ void	SetUpDownPos(HWND hWndDlg, int nIDDlgItem, WORD pos);
 SGetTextResult	GetDlgItemTextW(HWND hWndDlg, int nIDDlgItem);
 SGetTextResult	GetDlgItemTextW(HWND hWndDlg, int nIDDlgItem, std::span<WCHAR> buffer);
 
+bool	SetDlgItemTextW(HWND hWndDlg, int nIDDlgItem, std::wstring_view text);
+
 /*!
  * @brief トラックバーのデータ範囲を変更する
  */

--- a/src/test/cpp/tests1/test-StdControl.cpp
+++ b/src/test/cpp/tests1/test-StdControl.cpp
@@ -314,6 +314,7 @@ TEST(ApiWrap, DlgItemTest001) {
 
 			// アイテムにテキストを設定しておく
 			ApiWrap::SetDlgItemTextW(hDlg, IDC_COMBO_TEXT, text);
+			apiwrap::SetDlgItemTextW(hDlg, IDC_COMBO_TEXT, text);
 
 			// バッファサイズ指定せずに取得。正常に取得できる
 			EXPECT_THAT(apiwrap::GetDlgItemTextW(hDlg, IDC_COMBO_TEXT), StrEq(text));

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -9,6 +9,8 @@
 
 #include "window/EditorTestSuite.hpp"
 
+#include <fstream>
+
 namespace window {
 
 /*!
@@ -183,5 +185,117 @@ INSTANTIATE_TEST_SUITE_P(FileDialog
 		false
 	)
 );
+
+//! ファイル選択テストのためのフィクスチャクラス
+struct SelectFileTest : public ::testing::Test, public window::EditorTestSuite, public window::UiaTestSuite {
+	static constexpr auto& text = L"test.ini";
+	static inline auto path = GetExeFileName().replace_filename(text);
+
+	static inline HWND hWnd = nullptr;
+	static inline HWND hWndDlg = nullptr;
+	static inline HWND hWndFolder = nullptr;
+
+	static inline std::unique_ptr<CDialog> pcDlg = nullptr;
+
+	/*!
+	 * テストスイートの開始前に1回だけ呼ばれる関数
+	 */
+	static void SetUpTestSuite()
+	{
+		SetUpUia();
+
+		SetUpEditor();
+
+		// ファイルが存在しない、のメッセージが出ないようにファイルを作る
+		std::ofstream ofs{ path };
+		ofs.close();
+
+		constexpr HINSTANCE unusedArg1 = nullptr;
+		hWnd = pcEditWnd->GetHwnd();
+
+		// テスト用ダミーダイアログを作る
+		pcDlg = std::make_unique<CDialog>();
+		hWndDlg = pcDlg->DoModeless(unusedArg1, hWnd, IDD_GREP, 0L, SW_SHOW);
+		EXPECT_THAT(hWndDlg, NotNull());
+
+		// ファイルパスを入力する項目のハンドルを取得する
+		hWndFolder = ::GetDlgItem(hWndDlg, IDC_COMBO_FOLDER);
+		EXPECT_THAT(hWndFolder, NotNull());
+
+		// ファイルパスの初期値に相対パスを入れる
+		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_FOLDER, text);
+	}
+
+	/*!
+	 * テストスイートの終了後に1回だけ呼ばれる関数
+	 */
+	static void TearDownTestSuite()
+	{
+		// テスト用ダミーダイアログを閉じる
+		pcDlg->CloseDialog(0);
+
+		// 作成したファイルを削除する
+		std::error_code ec;
+		std::filesystem::remove(path, ec);
+
+		TearDownEditor();
+
+		TearDownUia();
+	}
+};
+
+/*!
+ * ファイル選択のテスト
+ */
+TEST_F(SelectFileTest, SelectFile001)
+{
+	constexpr bool resolvePath = true;	// パス解決する場合のテスト
+
+	std::jthread j([&] {
+		if (const auto hWndDlgOpenFile = WaitForDialog(L"開く")) {
+			EmulateSetValue(GetFocusedElement(), path.c_str());	// 絶対パスを入れる
+			EmulateHitEnter();
+		}
+	});
+
+	EXPECT_THAT(CDlgOpenFile::SelectFile(hWndDlg, hWndFolder, L"*.ini", resolvePath, EFITER_NONE), IsTrue());
+
+	const auto ret = apiwrap::GetDlgItemTextW(hWndDlg, IDC_COMBO_FOLDER);
+	EXPECT_THAT(ret.c_str(), StrEq(text));	// 相対パスが設定される
+}
+
+
+/*!
+ * ファイル選択のテスト
+ */
+TEST_F(SelectFileTest, SelectFile002)
+{
+	constexpr bool resolvePath = false;	// パス解決しない場合のテスト
+
+	std::jthread j([&] {
+		if (const auto hWndDlgOpenFile = WaitForDialog(L"開く")) {
+			EmulateSetValue(GetFocusedElement(), path.c_str());	// 絶対パスを入れる
+			EmulateHitEnter();
+		}
+	});
+
+	EXPECT_THAT(CDlgOpenFile::SelectFile(hWndDlg, hWndFolder, L"*.ini", resolvePath, EFITER_NONE), IsTrue());
+
+	const auto ret = apiwrap::GetDlgItemTextW(hWndDlg, IDC_COMBO_FOLDER);
+	EXPECT_THAT(ret.c_str(), StrEq(path.c_str()));	// 絶対パスが設定される
+}
+
+/*!
+ * ファイル選択のテスト
+ */
+TEST_F(SelectFileTest, SelectFile101)
+{
+	constexpr bool resolvePath = true;
+
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
+	dialog::ModalDialogCloser closer;
+
+	EXPECT_THAT(CDlgOpenFile::SelectFile(hWndDlg, hWndFolder, L"*.ini", resolvePath, EFITER_NONE), IsFalse());
+}
 
 } // namespace window

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -9,7 +9,22 @@
 
 #include "window/EditorTestSuite.hpp"
 
-struct DlgOpenFileTest : public ::testing::Test, public window::EditorTestSuite, public window::UiaTestSuite {
+namespace window {
+
+/*!
+ * @brief ファイルダイアログテストのパラメーター
+ *
+ * @param bVistaStyleFileDialog Vistaスタイルのファイルダイアログを使うかどうか
+ *
+ * @note 単独パラメーターなので、std::tuple<bool> でなく bool としている。
+ */
+using FileDialogTestParam = bool;
+
+/*!
+ * ファイルダイアログテストのためのフィクスチャクラス
+ *
+ */
+struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, public window::EditorTestSuite, public window::UiaTestSuite {
 	/*!
 	 * テストスイートの開始前に1回だけ呼ばれる関数
 	 */
@@ -29,17 +44,29 @@ struct DlgOpenFileTest : public ::testing::Test, public window::EditorTestSuite,
 
 		TearDownUia();
 	}
+
+	/*!
+	 * テストが実行された直前に毎回呼ばれる関数
+	 */
+	void SetUp() override
+	{
+		// テスト設定を反映する
+		GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = GetParam();
+	}
+
+	/*!
+	 * テストが実行された直後に毎回呼ばれる関数
+	 */
+	void TearDown() override
+	{
+		// 設定を元に戻す
+		GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = true;
+	}
 };
 
-TEST_F(DlgOpenFileTest, Construct)
+TEST_P(FileDialogTest, Create001)
 {
-	CDlgOpenFile cDlgOpenFile;
-}
-
-TEST_F(DlgOpenFileTest, CommonItemDialogCreate)
-{
-	GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = true;
-
+	// 落ちたり例外にならないこと
 	CDlgOpenFile cDlgOpenFile;
 	cDlgOpenFile.Create(
 		GetModuleHandle(nullptr),
@@ -51,25 +78,8 @@ TEST_F(DlgOpenFileTest, CommonItemDialogCreate)
 	);
 }
 
-TEST_F(DlgOpenFileTest, CommonFileDialogCreate)
+TEST_P(FileDialogTest, Create002_LongFilter)
 {
-	GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = false;
-
-	CDlgOpenFile cDlgOpenFile;
-	cDlgOpenFile.Create(
-		GetModuleHandle(nullptr),
-		nullptr,
-		L"*.txt",
-		L"C:\\Windows",
-		std::vector<LPCWSTR>(),
-		std::vector<LPCWSTR>()
-	);
-}
-
-TEST_F(DlgOpenFileTest, CommonItemDialogDefaltFilterLong)
-{
-	GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = true;
-
 	// 落ちたり例外にならないこと
 	CDlgOpenFile cDlgOpenFile;
 	cDlgOpenFile.Create(
@@ -82,26 +92,8 @@ TEST_F(DlgOpenFileTest, CommonItemDialogDefaltFilterLong)
 	);
 }
 
-TEST_F(DlgOpenFileTest, CommonFileDialogDefaltFilterLong)
+TEST_P(FileDialogTest, Create003_ManyFiltersy)
 {
-	GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = false;
-
-	// 落ちたり例外にならないこと
-	CDlgOpenFile cDlgOpenFile;
-	cDlgOpenFile.Create(
-		GetModuleHandle(nullptr),
-		nullptr,
-		L"*.extension_250_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_LONG",
-		L"C:\\Windows",
-		std::vector<LPCWSTR>(),
-		std::vector<LPCWSTR>()
-	);
-}
-
-TEST_F(DlgOpenFileTest, CommonFileDialogDefaltFilterMany)
-{
-	GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = false;
-
 	// 落ちたり例外にならないこと
 	CDlgOpenFile cDlgOpenFile;
 	cDlgOpenFile.Create(
@@ -114,18 +106,82 @@ TEST_F(DlgOpenFileTest, CommonFileDialogDefaltFilterMany)
 	);
 }
 
-TEST_F(DlgOpenFileTest, ommonItemDialogDefaltFilterMany)
+/*!
+ * ファイルを開くダイアログの表示テスト
+ */
+TEST_P(FileDialogTest, DoModalOpenDlg101)
 {
-	GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = true;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
+	dialog::ModalDialogCloser closer;
 
-	// 落ちたり例外にならないこと
-	CDlgOpenFile cDlgOpenFile;
-	cDlgOpenFile.Create(
-		GetModuleHandle(nullptr),
-		nullptr,
-		L"*.extension_50_0_long_long_long_long_long_long_LONG;*.extension_50_1_long_long_long_long_long_long_LONG;*.extension_50_2_long_long_long_long_long_long_LONG;*.extension_50_3_long_long_long_long_long_long_LONG;*.extension_50_4_long_long_long_long_long_long_LONG;*.extension_50_5_long_long_long_long_long_long_LONG;*.extension_50_6_long_long_long_long_long_long_LONG;*.extension_50_7_long_long_long_long_long_long_LONG;*.extension_50_8_long_long_long_long_long_long_LONG;*.extension_50_9_long_long_long_long_long_long_LONG",
-		L"C:\\Windows",
-		std::vector<LPCWSTR>(),
-		std::vector<LPCWSTR>()
-	);
+	// コマンドコードで、無理矢理動かす
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_FILEOPEN, nullptr, 0, pcEditWnd->DispatchEvent);
 }
+
+/*!
+ * 名前を付けて保存ダイアログの表示テスト
+ */
+TEST_P(FileDialogTest, DoModalSaveDlg101)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
+	dialog::ModalDialogCloser closer;
+
+	// コマンドコードで、無理矢理動かす
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_FILESAVEAS_DIALOG, nullptr, 0, pcEditWnd->DispatchEvent);
+}
+
+/*!
+ * ファイルを開くダイアログの表示テスト
+ */
+TEST_P(FileDialogTest, GetOpenFileName101)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
+	dialog::ModalDialogCloser closer;
+
+	// コマンドコードで、無理矢理動かす
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_LOADKEYMACRO, nullptr, 0, pcEditWnd->DispatchEvent);
+}
+
+/*!
+ * 名前を付けて保存ダイアログの表示テスト
+ */
+TEST_P(FileDialogTest, GetSaveFileName101)
+{
+	// 保存先のパスを作る
+	const auto path = GetExeFileName().replace_filename(L"test-save-file.txt");
+
+	// 上書き確認メッセージが出ないように、事前にパスを削除しておく
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+
+	// キーマクロ保存が使えるようにダミーマクロを登録する
+	LPARAM lParams = 0L;
+	pcSMacroMgr->Append(STAND_KEYMACRO, F_0, &lParams, &pcEditWnd->GetView(0));
+
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
+	dialog::ModalDialogCloser closer;
+
+	// コマンドコードで、無理矢理動かす
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_SAVEKEYMACRO, nullptr, 0, pcEditWnd->DispatchEvent);
+
+	// 保存したファイルを削除する
+	std::filesystem::remove(path, ec);
+}
+
+/*!
+ * @brief パラメータテストをインスタンス化する
+ *  Vistaスタイル有効／無効の2パターンで実体化させる
+ */
+INSTANTIATE_TEST_SUITE_P(FileDialog
+	, FileDialogTest
+	, ::testing::Values(
+		true,
+		false
+	)
+);
+
+} // namespace window


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #881

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- C++20で導入された `std::span` を活用して、書き込み先バッファのサイズを渡すようにする。

`LPWSTR`　文字列ポインタ。別途サイズ引数を渡さない限り、サイズ不明。
`std::span<WCHAR>`　配列参照。ポインタ先頭＋サイズをオブジェクト化したもの。

`WCHAR[N]` は `std::span<WCHAR>` に暗黙変換できるので、呼び出し側を変更する必要はなし。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- #881 残件あるのでクローズできない。


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
