### PR TITLE
TSingletonをTSakuraSingletonに移行する(その2)

### DIFF
--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -62,7 +62,7 @@ jobs:
           *-googletest.xml
 
     - name: Analyze with SonarQube Scan action
-      uses: SonarSource/sonarqube-scan-action@v8.2.1
+      uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -55,6 +55,9 @@ CNormalProcess::CNormalProcess( HINSTANCE hInstance, LPCWSTR lpCmdLine )
 
 CNormalProcess::~CNormalProcess()
 {
+	CJackManager::resetInstance();
+	CPluginManager::resetInstance();
+
 	CEditApp::resetInstance();
 }
 

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -60,8 +60,6 @@
 #include "sakura_rc.h"
 #include "config/app_constants.h"
 
-#include "plugin/CJackManager.h"
-
 #pragma comment(lib, "windowscodecs.lib")
 
 #define IDT_ROLLMOUSE	1
@@ -224,7 +222,6 @@ CEditDoc::~CEditDoc()
 {
 	CModifyManager::resetInstance();
 	CCodeChecker::resetInstance();
-	CJackManager::resetInstance();
 	CAppMode::resetInstance();
 
 	if( m_hBackImg ){

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -89,11 +89,10 @@ private:
 	int m_nGroup;
 };
 
-class CAppNodeManager : public TSingleton<CAppNodeManager>{
-	friend class TSingleton<CAppNodeManager>;
-	CAppNodeManager(){}
-
+class CAppNodeManager final : public TSakuraSingleton<CAppNodeManager> {
 public:
+	CAppNodeManager() = default;
+
 	//グループ
 	void ResetGroupId();									/* グループをIDリセットする */
 

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -11,6 +11,7 @@
 
 #include "basis/CMyString.h"
 #include "config/maxdata.h"
+#include "env/CSakuraEnvironment.h"	//env::ShareDataClient
 #include "util/design_template.h"
 
 class CAppNodeGroupHandle;
@@ -89,7 +90,7 @@ private:
 	int m_nGroup;
 };
 
-class CAppNodeManager final : public TSakuraSingleton<CAppNodeManager> {
+class CAppNodeManager final : public TSakuraSingleton<CAppNodeManager>, private env::ShareDataClient {
 public:
 	CAppNodeManager() = default;
 

--- a/sakura_core/env/CAppNodeManager.h
+++ b/sakura_core/env/CAppNodeManager.h
@@ -108,7 +108,7 @@ public:
 	//総合情報
 	int GetOpenedWindowArr(EditNode** ppEditNode, BOOL bSort, BOOL bGSort = FALSE );				/* 現在開いている編集ウィンドウの配列を返す */
 
-protected:
+private:
 	int _GetOpenedWindowArrCore(EditNode** ppEditNode, BOOL bSort, BOOL bGSort = FALSE );			/* 現在開いている編集ウィンドウの配列を返す（コア処理部） */
 
 public:

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -76,6 +76,7 @@ CShareData::CShareData() = default;
 CShareData::~CShareData()
 {
 	CFileNameManager::resetInstance();
+	CAppNodeManager::resetInstance();
 
 	if( m_pShareData ){
 		/* プロセスのアドレス空間から､ すでにマップされているファイル ビューをアンマップします */

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -1169,7 +1169,7 @@ int CShareData::GetMacroFilename( int idx, WCHAR *pszPath, int nBufLen )
 	idxは正確なものでなければならない。
 	YAZAKI
 */
-bool CShareData::BeReloadWhenExecuteMacro( int idx )
+bool CShareData::BeReloadWhenExecuteMacro(int idx) const
 {
 	if( !m_pShareData->m_Common.m_sMacro.m_MacroTable[idx].IsEnabled() )
 		return false;
@@ -1185,7 +1185,7 @@ bool CShareData::BeReloadWhenExecuteMacro( int idx )
 	@date 2005.01.30 genta CShareData::Init()から分離．
 		一つずつ設定しないで一気にデータ転送するように．
 */
-void CShareData::InitToolButtons(DLLSHAREDATA* pShareData)
+void CShareData::InitToolButtons(DLLSHAREDATA* pShareData) const
 {
 		/* ツールバーボタン構造体 */
 //Sept. 16, 2000 JEPRO

--- a/sakura_core/env/CShareData.h
+++ b/sakura_core/env/CShareData.h
@@ -85,7 +85,7 @@ public:
 
 	//マクロ関連
 	int			GetMacroFilename( int idx, WCHAR* pszPath, int nBufLen ); // idxで指定したマクロファイル名（フルパス）を取得する	//	Jun. 14, 2003 genta 引数追加．書式変更
-	bool		BeReloadWhenExecuteMacro( int idx );	//	idxで指定したマクロは、実行するたびにファイルを読み込む設定か？
+	bool		BeReloadWhenExecuteMacro(int idx) const;	//	idxで指定したマクロは、実行するたびにファイルを読み込む設定か？
 
 	//タイプ別設定(コントロールプロセス専用)
 	void CreateTypeSettings();
@@ -107,7 +107,7 @@ protected:
 	void InitKeyword(DLLSHAREDATA* pShareData);
 	bool InitKeyAssign(DLLSHAREDATA* pShareData); // 2007.11.04 genta 起動中止のため値を返す
 	void RefreshKeyAssignString(DLLSHAREDATA* pShareData);
-	void InitToolButtons(DLLSHAREDATA* pShareData);
+	void	InitToolButtons(DLLSHAREDATA* pShareData) const;
 	void InitTypeConfigs(DLLSHAREDATA* pShareData, std::vector<STypeConfig*>& types);
 	void InitPopupMenu(DLLSHAREDATA* pShareData);
 

--- a/sakura_core/macro/CMacroFactory.h
+++ b/sakura_core/macro/CMacroFactory.h
@@ -7,7 +7,7 @@
 /*
 	Copyright (C) 2002, genta
 	Copyright (C) 2004, genta
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -19,6 +19,7 @@
 #include <map>
 #include <list>
 #include <string>
+
 #include "util/design_template.h"
 
 class CMacroManagerBase;
@@ -37,11 +38,10 @@ class CMacroManagerBase;
 
 	Singleton
 */
-class CMacroFactory : public TSingleton<CMacroFactory> {
-	friend class TSingleton<CMacroFactory>;
+class CMacroFactory final : public TSakuraSingleton<CMacroFactory> {
+public:
 	CMacroFactory();
 
-public:
 	typedef CMacroManagerBase* (*Creator)(const WCHAR*);
 
 	bool RegisterCreator(Creator f);
@@ -69,4 +69,5 @@ private:
 	*/
 	MacroEngineRep m_mMacroCreators;
 };
+
 #endif /* SAKURA_CMACROFACTORY_67B6F8F6_0951_4717_84AD_C67E6D5F68AB_H_ */

--- a/sakura_core/plugin/CPluginManager.h
+++ b/sakura_core/plugin/CPluginManager.h
@@ -4,7 +4,7 @@
 */
 /*
 	Copyright (C) 2009, syat
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -12,16 +12,17 @@
 #define SAKURA_CPLUGINMANAGER_CE705DAD_1876_4B21_9052_07A9BFD292DE_H_
 #pragma once
 
-#include "plugin/CPlugin.h"
 #include <list>
 #include <string>
 
-class CPluginManager final : public TSingleton<CPluginManager>{
-	friend class TSingleton<CPluginManager>;
+#include "plugin/CPlugin.h"
+#include "util/design_template.h"
+
+class CPluginManager final : public TSakuraSingleton<CPluginManager> {
+public:
 	CPluginManager();
 
 	// 操作
-public:
 	bool LoadAllPlugin(CommonSetting* common = nullptr);				//全プラグインを読み込む
 	void UnloadAllPlugin();				//全プラグインを解放する
 	bool SearchNewPlugin( CommonSetting& common, HWND hWndOwner );		//新規プラグインを導入する
@@ -50,4 +51,5 @@ private:
 	std::wstring m_sBaseDir;			//pluginsフォルダーのパス
 	std::wstring m_sExePluginDir;		//Exeフォルダー配下pluginsフォルダーのパス
 };
+
 #endif /* SAKURA_CPLUGINMANAGER_CE705DAD_1876_4B21_9052_07A9BFD292DE_H_ */

--- a/sakura_core/plugin/CPluginManager.h
+++ b/sakura_core/plugin/CPluginManager.h
@@ -15,10 +15,11 @@
 #include <list>
 #include <string>
 
+#include "env/CSakuraEnvironment.h"	//env::ShareDataClient
 #include "plugin/CPlugin.h"
 #include "util/design_template.h"
 
-class CPluginManager final : public TSakuraSingleton<CPluginManager> {
+class CPluginManager final : public TSakuraSingleton<CPluginManager>, private env::ShareDataClient {
 public:
 	CPluginManager();
 

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -174,7 +174,7 @@ protected:
 class CColorStrategyPool final : public TSakuraSingleton<CColorStrategyPool>, private env::ShareDataClient {
 public:
 	CColorStrategyPool();
-	virtual ~CColorStrategyPool();
+	~CColorStrategyPool();
 
 	//取得
 	CColorStrategy*	GetStrategy(int nIndex) const noexcept { return m_vStrategiesDisp[nIndex]; }

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -9,6 +9,8 @@
 #define SAKURA_CCOLORSTRATEGY_96B6EB56_C928_4B89_8841_166AAAB8D760_H_
 #pragma once
 
+#include "env/CSakuraEnvironment.h"	//env::ShareDataClient
+
 // 要先行定義
 #include "EColorIndexType.h"
 #include "uiparts/CGraphics.h"
@@ -169,7 +171,7 @@ protected:
 	const STypeConfig* m_pTypeData = nullptr;
 };
 
-class CColorStrategyPool final : public TSakuraSingleton<CColorStrategyPool> {
+class CColorStrategyPool final : public TSakuraSingleton<CColorStrategyPool>, private env::ShareDataClient {
 public:
 	CColorStrategyPool();
 	virtual ~CColorStrategyPool();

--- a/sakura_core/view/colors/CColorStrategy.h
+++ b/sakura_core/view/colors/CColorStrategy.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -169,12 +169,10 @@ protected:
 	const STypeConfig* m_pTypeData = nullptr;
 };
 
-class CColorStrategyPool : public TSingleton<CColorStrategyPool>{
-	friend class TSingleton<CColorStrategyPool>;
+class CColorStrategyPool final : public TSakuraSingleton<CColorStrategyPool> {
+public:
 	CColorStrategyPool();
 	virtual ~CColorStrategyPool();
-
-public:
 
 	//取得
 	CColorStrategy*	GetStrategy(int nIndex) const noexcept { return m_vStrategiesDisp[nIndex]; }

--- a/sakura_core/view/figures/CFigureManager.h
+++ b/sakura_core/view/figures/CFigureManager.h
@@ -18,7 +18,7 @@
 class CFigureManager final : public TSakuraSingleton<CFigureManager>, private env::ShareDataClient {
 public:
 	CFigureManager();
-	virtual ~CFigureManager();
+	~CFigureManager();
 
 	//! 描画するCFigureを取得
 	//	@param	pText	対象文字列の先頭

--- a/sakura_core/view/figures/CFigureManager.h
+++ b/sakura_core/view/figures/CFigureManager.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -10,15 +10,15 @@
 #pragma once
 
 #include <vector>
+
 #include "util/design_template.h"
 #include "CFigureStrategy.h"
 
-class CFigureManager : public TSingleton<CFigureManager>{
-	friend class TSingleton<CFigureManager>;
+class CFigureManager final : public TSakuraSingleton<CFigureManager> {
+public:
 	CFigureManager();
 	virtual ~CFigureManager();
 
-public:
 	//! 描画するCFigureを取得
 	//	@param	pText	対象文字列の先頭
 	//	@param	nTextLen	pTextから行末までの長さ(ただしCRLF==2)
@@ -31,4 +31,5 @@ private:
 	std::vector<CFigure*>	m_vFigures;
 	std::vector<CFigure*>	m_vFiguresDisp;	//!< 色分け表示対象
 };
+
 #endif /* SAKURA_CFIGUREMANAGER_34C07527_BAEA_4B91_A3E0_7FCAFCFBAF0C_H_ */

--- a/sakura_core/view/figures/CFigureManager.h
+++ b/sakura_core/view/figures/CFigureManager.h
@@ -11,10 +11,11 @@
 
 #include <vector>
 
+#include "env/CSakuraEnvironment.h"	//env::ShareDataClient
 #include "util/design_template.h"
-#include "CFigureStrategy.h"
+#include "view/figures/CFigureStrategy.h"
 
-class CFigureManager final : public TSakuraSingleton<CFigureManager> {
+class CFigureManager final : public TSakuraSingleton<CFigureManager>, private env::ShareDataClient {
 public:
 	CFigureManager();
 	virtual ~CFigureManager();

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -60,6 +60,10 @@
 #include "recent/CRecentFolder.h"
 #include "apiwrap/DarkMode.h"
 
+#include "macro/CMacroFactory.h"
+#include "view/colors/CColorStrategy.h"
+#include "view/figures/CFigureManager.h"
+
 //@@@ 2002.01.14 YAZAKI 印刷プレビューをCPrintPreviewに独立させたので
 //	定義を削除
 
@@ -221,6 +225,10 @@ CEditWnd::CEditWnd()
 
 CEditWnd::~CEditWnd()
 {
+	CMacroFactory::resetInstance();
+	CColorStrategyPool::resetInstance();
+	CFigureManager::resetInstance();
+
 	delete[] m_pszLastCaption;
 
 	m_hWnd = nullptr;

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -274,7 +274,7 @@ void CEditWnd::UpdateCaption()
 }
 
 //!< ウィンドウ生成用の矩形を取得
-void CEditWnd::_GetWindowRectForInit(CMyRect* rcResult, [[maybe_unused]] int nGroup, const STabGroupInfo& sTabGroupInfo)
+void CEditWnd::_GetWindowRectForInit(CMyRect* rcResult, [[maybe_unused]] int nGroup, const STabGroupInfo& sTabGroupInfo) const
 {
 	/* ウィンドウサイズ継承 */
 	int	nWinCX, nWinCY;
@@ -384,7 +384,7 @@ HWND CEditWnd::_CreateMainWindow(int nGroup, const STabGroupInfo& sTabGroupInfo)
 	return hwndResult;
 }
 
-void CEditWnd::_GetTabGroupInfo(STabGroupInfo* pTabGroupInfo, int& nGroup)
+void CEditWnd::_GetTabGroupInfo(STabGroupInfo* pTabGroupInfo, int& nGroup) const
 {
 	HWND hwndTop = nullptr;
 	WINDOWPLACEMENT	wpTop = {0};
@@ -2697,7 +2697,7 @@ void CEditWnd::SetMenuFuncSel( HMENU hMenu, EFunctionCode nFunc, const WCHAR* sK
 	m_cMenuDrawer.MyAppendMenu( hMenu, MF_BYPOSITION | MF_STRING, nFunc, sName, sKey );
 }
 
-STDMETHODIMP CEditWnd::DragEnter(  LPDATAOBJECT pDataObject, DWORD dwKeyState, [[maybe_unused]] POINTL pt, LPDWORD pdwEffect )
+STDMETHODIMP CEditWnd::DragEnter( LPDATAOBJECT pDataObject, DWORD dwKeyState, [[maybe_unused]] POINTL pt, LPDWORD pdwEffect) const
 {
 	if( pDataObject == nullptr || pdwEffect == nullptr ){
 		return E_INVALIDARG;
@@ -2719,7 +2719,7 @@ STDMETHODIMP CEditWnd::DragEnter(  LPDATAOBJECT pDataObject, DWORD dwKeyState, [
 	return S_OK;
 }
 
-STDMETHODIMP CEditWnd::DragOver( [[maybe_unused]] DWORD dwKeyState, [[maybe_unused]] POINTL pt, LPDWORD pdwEffect )
+STDMETHODIMP CEditWnd::DragOver([[maybe_unused]] DWORD dwKeyState, [[maybe_unused]] POINTL pt, LPDWORD pdwEffect) const
 {
 	if( pdwEffect == nullptr )
 		return E_INVALIDARG;
@@ -2728,12 +2728,12 @@ STDMETHODIMP CEditWnd::DragOver( [[maybe_unused]] DWORD dwKeyState, [[maybe_unus
 	return S_OK;
 }
 
-STDMETHODIMP CEditWnd::DragLeave( void )
+STDMETHODIMP CEditWnd::DragLeave() const
 {
 	return S_OK;
 }
 
-STDMETHODIMP CEditWnd::Drop( LPDATAOBJECT pDataObject, [[maybe_unused]] DWORD dwKeyState, [[maybe_unused]] POINTL pt, LPDWORD pdwEffect )
+STDMETHODIMP CEditWnd::Drop(LPDATAOBJECT pDataObject, [[maybe_unused]] DWORD dwKeyState, [[maybe_unused]] POINTL pt, LPDWORD pdwEffect)
 {
 	if( pDataObject == nullptr || pdwEffect == nullptr )
 		return E_INVALIDARG;
@@ -2859,7 +2859,7 @@ LRESULT CEditWnd::OnTimer( WPARAM wParam, [[maybe_unused]] LPARAM lParam )
 /*! キャプション更新用タイマーの処理
 	@date 2007.04.03 ryoji 新規
 */
-void CEditWnd::OnCaptionTimer( void )
+void CEditWnd::OnCaptionTimer() const
 {
 	// 編集画面の切替（タブまとめ時）が終わっていたらタイマーを終了してタイトルバーを更新する
 	// まだ切替中ならタイマー継続
@@ -3752,7 +3752,7 @@ int	CEditWnd::CreateFileDropDownMenu( HWND hwnd )
 	@author genta
 	@date 2002.09.10
 */
-void CEditWnd::SetWindowIcon(HICON hIcon, int flag)
+void CEditWnd::SetWindowIcon(HICON hIcon, int flag) const
 {
 	HICON hOld = (HICON)::SendMessage( GetHwnd(), WM_SETICON, flag, (LPARAM)hIcon );
 	if( hOld != nullptr ){
@@ -3952,12 +3952,14 @@ void CEditWnd::SendStatusMessage( const WCHAR* msg )
 	@date 2003.05.31 新規作成
 	@date 2006.01.28 ryoji ファイル名、Grepモードパラメータを追加
 */
-void CEditWnd::ChangeFileNameNotify( const WCHAR* pszTabCaption, const WCHAR* _pszFilePath, bool bIsGrep )
+void CEditWnd::ChangeFileNameNotify(
+	std::wstring_view tabCaption,
+	std::wstring_view tabFilePath,
+	bool bIsGrep
+) const
 {
-	const WCHAR* pszFilePath = _pszFilePath;
-
-	if( nullptr == pszTabCaption ) pszTabCaption = L"";	//ガード
-	if( nullptr == pszFilePath ) pszFilePath = L"";		//ガード 2006.01.28 ryoji
+	const auto pszTabCaption = std::data(tabCaption);
+	const auto pszFilePath = std::data(tabFilePath);
 
 	CRecentEditNode	cRecentEditNode;
 	int nIndex = cRecentEditNode.FindItemByHwnd( GetHwnd() );
@@ -4005,7 +4007,7 @@ void CEditWnd::ChangeFileNameNotify( const WCHAR* pszTabCaption, const WCHAR* _p
 	@param top  0:トグル動作 1:最前面 2:最前面解除 その他:なにもしない
 	@date 2004.09.21 Moca
 */
-void CEditWnd::WindowTopMost( int top )
+void CEditWnd::WindowTopMost(int top) const
 {
 	if( 0 == top ){
 		DWORD dwExstyle = (DWORD)::GetWindowLongPtr( GetHwnd(), GWL_EXSTYLE );
@@ -4050,7 +4052,7 @@ void CEditWnd::WindowTopMost( int top )
 // ツールバー表示はタイマーにより更新しているが、
 // アプリのフォーカスが外れたときにウィンドウからON/OFFを
 //	呼び出してもらうことにより、余計な負荷を停止したい。
-void CEditWnd::Timer_ONOFF( bool bStart )
+void CEditWnd::Timer_ONOFF(bool bStart) const
 {
 	if( nullptr != GetHwnd() ){
 		if( bStart ){

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -1077,11 +1077,10 @@ void CEditWnd::MessageLoop( void )
 		//アクセラレータ
 		else{
 			// 補完ウィンドウが表示されているときはキーボード入力を先に処理させる（カーソル移動／決定／キャンセルの処理）
-			if( msg.message == WM_KEYDOWN ){
-				if( GetActiveView().m_bHokan ){
-					if( -1 == m_cHokanMgr.KeyProc( msg.wParam, msg.lParam ) )
+			if (WM_KEYDOWN == msg.message &&
+				GetActiveView().m_bHokan &&
+				-1 == m_cHokanMgr.KeyProc(msg.wParam, msg.lParam)) {
 						continue;	// 補完ウィンドウが処理を実行した
-				}
 			}
 
 			if( m_hAccel && TranslateAccelerator( msg.hwnd, m_hAccel, &msg ) ){}
@@ -1101,6 +1100,8 @@ LRESULT CEditWnd::DispatchEvent(
 	LPARAM	lParam 	// second message parameter
 )
 {
+	const auto hWnd = GetHwnd();
+
 	int					nRet;
 	LPNMHDR				pnmh;
 	int					nPane;
@@ -1285,8 +1286,9 @@ LRESULT CEditWnd::DispatchEvent(
 	case WM_MOVE:
 		// From Here 2004.05.13 Moca ウィンドウ位置継承
 		//	最後の位置を復元するため，移動されるたびに共有メモリに位置を保存する．
-		if( WINSIZEMODE_SAVE == m_pShareData->m_Common.m_sWindow.m_eSaveWindowPos ){
-			if( !::IsZoomed( GetHwnd() ) && !::IsIconic( GetHwnd() ) ){
+		if (WINSIZEMODE_SAVE == m_pShareData->m_Common.m_sWindow.m_eSaveWindowPos &&
+			!::IsZoomed(hWnd) &&
+			!::IsIconic(hWnd)) {
 				// 2005.11.23 Moca ワークエリア座標だとずれるのでスクリーン座標に変更
 				// Aero Snapで縦方向最大化で終了して次回起動するときは元のサイズにする必要があるので、
 				// GetWindowRect()ではなくGetWindowPlacement()で得たワークエリア座標をスクリーン座標に変換して記憶する	// 2009.09.02 ryoji
@@ -1300,7 +1302,6 @@ LRESULT CEditWnd::DispatchEvent(
 				::OffsetRect(&rcWin, rcWork.left - rcMon.left, rcWork.top - rcMon.top);	// スクリーン座標に変換
 				m_pShareData->m_Common.m_sWindow.m_nWinPosX = rcWin.left;
 				m_pShareData->m_Common.m_sWindow.m_nWinPosY = rcWin.top;
-			}
 		}
 		// To Here 2004.05.13 Moca ウィンドウ位置継承
 		return DefWindowProc( hwnd, uMsg, wParam, lParam );
@@ -2339,16 +2340,13 @@ void CEditWnd::InitMenu( HMENU hMenu, UINT uPos, BOOL fSystemMenu )
 				bool	bInList;		// リストが1個以上ある
 				bInList = InitMenu_Special( hMenu, cMainMenu->m_nFunc );
 				// リストが無い場合の処理
-				if (!bInList) {
-					//分割線に囲まれ、かつリストなし ならば 次の分割線をスキップ
-					if ((i == nIdxStr + 1
-						  || (pcMenu->m_cMainMenuTbl[i-1].m_nType == T_SEPARATOR
-							&& pcMenu->m_cMainMenuTbl[i-1].m_nLevel == cMainMenu->m_nLevel))
-						&& i + 1 < nIdxEnd
-						&& pcMenu->m_cMainMenuTbl[i+1].m_nType == T_SEPARATOR
-						&& pcMenu->m_cMainMenuTbl[i+1].m_nLevel == cMainMenu->m_nLevel) {
+				//分割線に囲まれ、かつリストなし ならば 次の分割線をスキップ
+				if (!bInList &&
+					i + 1 < nIdxEnd &&
+					T_SEPARATOR == pcMenu->m_cMainMenuTbl[i + 1].m_nType &&
+					cMainMenu->m_nLevel == pcMenu->m_cMainMenuTbl[i + 1].m_nLevel &&
+					(i == nIdxStr + 1 || (0 < i && T_SEPARATOR == pcMenu->m_cMainMenuTbl[i - 1].m_nType && cMainMenu->m_nLevel == pcMenu->m_cMainMenuTbl[i - 1].m_nLevel))) {
 						i++;		// スキップ
-					}
 				}
 				break;
 			}
@@ -3183,10 +3181,9 @@ LRESULT CEditWnd::OnSize2( WPARAM wParam, LPARAM lParam, bool bUpdateStatus )
 			if( nullptr != m_cStatusBar.GetStatusHwnd() ){
 				bSizeBox = false;
 			}
-			if( nullptr != m_cFuncKeyWnd.GetHwnd() ){
-				if( m_pShareData->m_Common.m_sWindow.m_nFUNCKEYWND_Place == 1 ){
+			if (1 == m_pShareData->m_Common.m_sWindow.m_nFUNCKEYWND_Place &&
+				m_cFuncKeyWnd.GetHwnd()) {
 					bSizeBox = false;
-				}
 			}
 			if( wParam == SIZE_MAXIMIZED ){
 				bSizeBox = false;

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -112,8 +112,8 @@ public:
 		CImageListMgr*	pcIcons,
 		int				nGroup
 	);
-	void _GetTabGroupInfo(STabGroupInfo* pTabGroupInfo, int& nGroup);
-	void _GetWindowRectForInit(CMyRect* rcResult, int nGroup, const STabGroupInfo& sTabGroupInfo);	//!< ウィンドウ生成用の矩形を取得
+	void	_GetTabGroupInfo(STabGroupInfo* pTabGroupInfo, int& nGroup) const;
+	void	_GetWindowRectForInit(CMyRect* rcResult, int nGroup, const STabGroupInfo& sTabGroupInfo) const;	//!< ウィンドウ生成用の矩形を取得
 	HWND _CreateMainWindow(int nGroup, const STabGroupInfo& sTabGroupInfo);
 	void _AdjustInMonitor(const STabGroupInfo& sTabGroupInfo);
 
@@ -153,7 +153,7 @@ public:
 	BOOL OnPrintPageSetting( void );/* 印刷ページ設定 */
 	LRESULT OnTimer(WPARAM wParam, LPARAM lParam);	// WM_TIMER 処理	// 2007.04.03 ryoji
 	void OnEditTimer( void );	/* タイマーの処理 */
-	void OnCaptionTimer( void );
+	void	OnCaptionTimer() const;
 	void OnSysMenuTimer( void );
 	void OnCommand(WORD wNotifyCode, WORD wID, HWND hwndCtl);
 	LRESULT OnNcLButtonDown(WPARAM wp, LPARAM lp);
@@ -165,7 +165,7 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 	//ファイル名変更通知
-	void ChangeFileNameNotify( const WCHAR* pszTabCaption, const WCHAR* pszFilePath, bool bIsGrep );	//@@@ 2003.05.31 MIK, 2006.01.28 ryoji ファイル名、Grepモードパラメータを追加
+	void	ChangeFileNameNotify(std::wstring_view tabCaption, std::wstring_view tabFilePath, bool bIsGrep) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                         メニュー                            //
@@ -199,7 +199,7 @@ public:
 	void PrintPreviewModeONOFF( void );	/* 印刷プレビューモードのオン/オフ */
 	
 	//アイコン
-	void SetWindowIcon(HICON hIcon, int flag);	//	Sep. 10, 2002 genta
+	void	SetWindowIcon(HICON hIcon, int flag) const;
 	void GetDefaultIcon( HICON* hIconBig, HICON* hIconSmall ) const;	//	Sep. 10, 2002 genta
 	bool GetRelatedIcon(const WCHAR* szFile, HICON* hIconBig, HICON* hIconSmall) const;	//	Sep. 10, 2002 genta
 	void SetPageScrollByWheel( BOOL bState ) { m_bPageScrollByWheel = bState; }		// ホイール操作によるページスクロール有無を設定する（TRUE=あり, FALSE=なし）	// 2009.01.17 nasukoji
@@ -234,7 +234,7 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                      ウィンドウ操作                         //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	void WindowTopMost(int top); // 2004.09.21 Moca
+	void	WindowTopMost(int top) const;
 
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                        ビュー管理                           //
@@ -303,7 +303,7 @@ protected:
 	int	CreateFileDropDownMenu(HWND hwnd);	//開く(ドロップダウン)	//@@@ 2002.06.15 MIK
 
 	//タイマー
-	void Timer_ONOFF(bool bStart); /* 更新の開始／停止 20060128 aroka */
+	void	Timer_ONOFF(bool bStart) const; /* 更新の開始／停止 20060128 aroka */
 
 	// メニュー
 	void CheckFreeSubMenu(HWND hWnd, HMENU hMenu, UINT uPos);		// メニューバーの無効化を検査	2010/6/18 Uchi
@@ -330,9 +330,9 @@ public:
 	const CMyPoint& GetDragPosOrg() const{ return m_ptDragPosOrg; }
 
 	/* IDropTarget実装 */	// 2008.06.20 ryoji
-	STDMETHODIMP DragEnter(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
-	STDMETHODIMP DragOver(DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
-	STDMETHODIMP DragLeave( void );
+	STDMETHODIMP DragEnter(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect) const;
+	STDMETHODIMP DragOver(DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect) const;
+	STDMETHODIMP DragLeave() const;
 	STDMETHODIMP Drop(LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL pt, LPDWORD pdwEffect);
 
 	//フォーカス管理


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2535

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
明らかに移行が必要なものについては #2542 で対応済みです。

残り 6 件の、「何かと一緒に滅ぶべき」について対処を入れます。

また、共有メモリに暗黙で依存している4クラスを env::ShareDataClient の派生クラスに変更し、今後の保守で迷わないようにします。

前回と同様、修正フェイルに対する SonarQube指摘について、可能な限り対応します。
もっとも、CEditWndクラスのカバレッジ測定可能範囲は狭いので 68件中10件分くらいしか対応できていません。

あと、完全に別件ですが #2540 でsonarclientの更新がありました。
単独で Pull Request を作る内容でないように思うので、バージョン識別方法の変更をこれに含めてしまいます。

本件、勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- #2535 
- #2542 
- #2540

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
