### PR TITLE
WINVERを指定する

### DIFF
--- a/src/main/cmake/sakura.cmake
+++ b/src/main/cmake/sakura.cmake
@@ -462,7 +462,8 @@ endfunction(create_language_dll)
 add_compile_definitions(
   UNICODE
   _UNICODE
-  _WIN32_WINNT=_WIN32_WINNT_WIN10
+  WINVER=0x0A00
+  _WIN32_WINNT=0x0A00
   $<$<CONFIG:Debug>:_DEBUG>
   $<$<CONFIG:Release>:NDEBUG>
 )


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 追加

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2549 

2026年07月中旬、MinGW-w64プロジェクトでlocaleヘッダー整理が行われた。
　↓
2026年07月下旬、MinGWビルドが失敗するようになった。
　・ 対象OSバージョンに応じて適切な関数が宣言されるようMinGW-w64がSDKヘッダーを整理した影響。
　・ _create_locale は MSVCRT80 以降に実装された関数 なのでバージョンを指定しないと未定義になる。

サクラエディタでは対象OSバージョンを _WIN32_WINNT_WIN10マクロ で絞り込んでいる。
_WIN32_WINNT_WIN10はMinGWビルドでは定義されないので実質「対象OS未指定」と同じになっていた。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- これまで指定していなかったWINVERを指定する。
-  _WIN32_WINNT を即値 0x0A00 で指定する。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- resolves #2549 


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
- https://sourceforge.net/p/mingw-w64/mailman/mingw-w64-public/thread/1dcdfddd-3496-4667-b381-9948b8a4ac98%40126.com/