### PR TITLE
リリース用に githash.bat / version.h.in を修正、HTMLヘルプ中のバージョン番号を変更

### DIFF
--- a/help/sakura/res/HLP000001.html
+++ b/help/sakura/res/HLP000001.html
@@ -15,8 +15,8 @@
 -->
 <br>
 <hr style="margin: 0 auto;width: 350px" />
-<div style="text-align: center">サクラエディタ   Ver 2.4.3 (開発版)</div>
-<div style="text-align: center">ヘルプファイル最終更新日 2022/12/03</div>
+<div style="text-align: center">サクラエディタ   Ver 2.4.3</div>
+<div style="text-align: center">ヘルプファイル最終更新日 2026/07/26</div>
 <div style="text-align: center"><a href="https://sakura-editor.github.io/" target="_blank" rel="noopener">https://sakura-editor.github.io/</a></div>
 <hr style="margin: 0 auto;width: 350px" />
 サクラエディタ(旧称:テキストエディタ)は、「たけ(竹パンダ)」さんのテキストエディタSAKURAの公開ソース(2000/02/21付)を元に不具合修正および機能拡張を行ったものです。<br>

--- a/help/sakura/res/HLP000001.html
+++ b/help/sakura/res/HLP000001.html
@@ -16,7 +16,7 @@
 <br>
 <hr style="margin: 0 auto;width: 350px" />
 <div style="text-align: center">サクラエディタ   Ver 2.4.3</div>
-<div style="text-align: center">ヘルプファイル最終更新日 2026/07/26</div>
+<div style="text-align: center">ヘルプファイル最終更新日 2026/08/08</div>
 <div style="text-align: center"><a href="https://sakura-editor.github.io/" target="_blank" rel="noopener">https://sakura-editor.github.io/</a></div>
 <hr style="margin: 0 auto;width: 350px" />
 サクラエディタ(旧称:テキストエディタ)は、「たけ(竹パンダ)」さんのテキストエディタSAKURAの公開ソース(2000/02/21付)を元に不具合修正および機能拡張を行ったものです。<br>

--- a/src/main/cmake/version.h.in
+++ b/src/main/cmake/version.h.in
@@ -12,7 +12,7 @@
 #define BUILD_VERSION @BUILD_VERSION@
 
 /* enable 'dev version' macro which will be disabled on release branches */
-#define DEV_VERSION
+/* #define DEV_VERSION */
 
 // バージョン定義 //
 #define VER_A	@SAKURA_MAJOR_VERSION@	// メジャーバージョン(2固定)

--- a/tools/githash.bat
+++ b/tools/githash.bat
@@ -181,7 +181,7 @@ exit /b 0
 	)
 
 	@rem enable 'dev version' macro which will be disabled on release branches
-	echo #define DEV_VERSION
+	@rem echo #define DEV_VERSION
 
 	if "%CI_ACCOUNT_NAME%" == "" (
 		echo // CI_ACCOUNT_NAME is not defined


### PR DESCRIPTION
# PR の目的

v2.4.3リリースのため

## カテゴリ

- リリース作業

## PR の背景

v2.4.3リリースのために version.h.in (旧 githash.h) とヘルプファイルの変更を行います。

## 仕様・動作説明

`release/v2.4.3` ブランチ(内容は最新のmaster)をリリースするためにバージョン表記を変更します。

- `src/main/cmake/version.h.in` / `tools/githash.bat` : `DEV_VERSION` マクロを無効化(「(開発版)」表記を止める)
- `help/sakura/res/HLP000001.html` : バージョン表記から「(開発版)」を外し、ヘルプファイル最終更新日を更新

このPRをマージしたあと、タグを打つとリリース作業自体は完了です。

## 関連 issue, PR

* #2538

## 参考資料

* v2.4.2 リリース時の同種PR: https://github.com/sakura-editor/sakura/pull/1873
