### PR TITLE
クリップボード独自形式の長さフィールドを32bit固定に戻す

### DIFF
--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -134,25 +134,28 @@ bool CClipboard::SetText(
 	//	1回しか通らない. breakでここまで飛ぶ
 
 	// バイナリ形式のデータ
-	//	(size_t) 「データ」の長さ
+	//	(SAKURAClipW_LengthFieldType) 「データ」の長さ
 	//	「データ」
+	//	長さフィールドで表せない長さのときは独自形式では受け渡さず、CF_UNICODETEXTのみとする
+	const bool bWithinSAKURAClipW_MaxLength = (nDataLen <= SAKURAClipW_MaxLength);
 	HGLOBAL hgClipSakura = nullptr;
 	//サクラエディタ専用フォーマットを取得
 	CLIPFORMAT	uFormatSakuraClip = CClipboard::GetSakuraFormat();
-	bool bSakuraText = (uFormat == (UINT)-1 || uFormat == uFormatSakuraClip);
+	bool bSakuraText = bWithinSAKURAClipW_MaxLength && (uFormat == (UINT)-1 || uFormat == uFormatSakuraClip);
 	while(bSakuraText){
 		if( 0 == uFormatSakuraClip )break;
 
 		//領域確保
 		hgClipSakura = ::GlobalAlloc(
 			GMEM_MOVEABLE | GMEM_DDESHARE,
-			sizeof(size_t) + (nDataLen + 1) * sizeof(wchar_t)
+			sizeof(SAKURAClipW_LengthFieldType) + (nDataLen + 1) * sizeof(wchar_t)
 		);
 		if( !hgClipSakura )break;
 
 		//確保した領域にデータをコピー
 		BYTE* pClip = static_cast<BYTE*>(::GlobalLock(hgClipSakura));
-		*((size_t*)pClip) = nDataLen; pClip += sizeof(nDataLen);						//データの長さ
+		*((SAKURAClipW_LengthFieldType*)pClip) = (SAKURAClipW_LengthFieldType)nDataLen;
+		pClip += sizeof(SAKURAClipW_LengthFieldType);									//データの長さ
 		wmemcpy( (wchar_t*)pClip, pData, nDataLen ); pClip += nDataLen*sizeof(wchar_t);	//データ
 		*((wchar_t*)pClip) = L'\0'; pClip += sizeof(wchar_t);							//終端ヌル
 		::GlobalUnlock( hgClipSakura );
@@ -221,7 +224,7 @@ bool CClipboard::SetText(
 	if( bLineSelect && !(hgClipMSDEVLine && hgClipMSDEVLine2) ){
 		return false;
 	}
-	if( !(hgClipText && hgClipSakura) ){
+	if( !hgClipText || (bWithinSAKURAClipW_MaxLength && !hgClipSakura) ){
 		return false;
 	}
 	return true;
@@ -318,10 +321,17 @@ bool CClipboard::GetText(IWBuffer* cmemBuf, bool* pbColumnSelect, bool* pbLineSe
 		&& IsClipboardFormatAvailable( uFormatSakuraClip ) ){
 		HGLOBAL hSakura = GetClipboardData( uFormatSakuraClip );
 		if (hSakura != nullptr) {
+			const size_t cbSize = ::GlobalSize(hSakura);
 			BYTE* pData = (BYTE*)::GlobalLock(hSakura);
-			size_t nLength        = *((size_t*)pData);
-			const wchar_t* szData = (const wchar_t*)(pData + sizeof(size_t));
-			cmemBuf->Append( szData, nLength );
+			if( pData && cbSize > sizeof(SAKURAClipW_LengthFieldType) ){
+				// 壊れたデータや他バージョンが書き込んだデータを読んでも
+				// 確保領域外を参照しないように、実際のサイズで頭打ちにする
+				const auto nStoredLength = *((const SAKURAClipW_LengthFieldType*)pData);
+				const size_t nMaxLength = (cbSize - sizeof(SAKURAClipW_LengthFieldType)) / sizeof(wchar_t);
+				const size_t nLength = (nStoredLength <= 0) ? 0 : t_min( (size_t)nStoredLength, nMaxLength );
+				const wchar_t* szData = (const wchar_t*)(pData + sizeof(SAKURAClipW_LengthFieldType));
+				cmemBuf->Append( szData, nLength );
+			}
 			::GlobalUnlock(hSakura);
 			return true;
 		}

--- a/sakura_core/_os/CClipboard.h
+++ b/sakura_core/_os/CClipboard.h
@@ -9,6 +9,9 @@
 #define SAKURA_CCLIPBOARD_4E783022_214C_4E51_A2E0_54EC343500F6_H_
 #pragma once
 
+#include <cstdint>
+#include <limits>
+
 #include "mem/CNativeW.h"
 
 class CEol;
@@ -95,6 +98,20 @@ private:
 public:
 	static bool HasValidData();    //!< クリップボード内に、サクラエディタで扱えるデータがあればtrue
 	static CLIPFORMAT GetSakuraFormat(); //!< サクラエディタ独自のクリップボードデータ形式
+
+	//! サクラエディタ独自形式(SAKURAClipW)の先頭に置く文字数フィールドの型
+	//!
+	//! Win32/x64/ARM64 の各ビルド間、及び過去バージョンとの間でクリップボードを
+	//! やり取りするため、ポインタ幅に依存しない32bit固定でなければならない。
+	//! size_t にするとx64/ARM64でデータのレイアウトが変わり、
+	//! 他ビルドで貼り付けたときに文字化けやクラッシュを起こす。(issue #2325)
+	using SAKURAClipW_LengthFieldType = int32_t;
+
+	//! サクラエディタ独自形式(SAKURAClipW)で扱える最大文字数
+	//!
+	//! これを超える長さのテキストは独自形式では受け渡しできないため、
+	//! CF_UNICODETEXT のみで受け渡す。
+	static constexpr size_t SAKURAClipW_MaxLength = std::numeric_limits<SAKURAClipW_LengthFieldType>::max();
 
 protected:
 	// 単体テスト用コンストラクタ

--- a/sakura_core/_os/CDropTarget.cpp
+++ b/sakura_core/_os/CDropTarget.cpp
@@ -200,7 +200,9 @@ void CDataObject::SetText( LPCWSTR lpszText, size_t nTextLen, BOOL bColumnSelect
 		m_nFormat = 0;
 	}
 	if( lpszText != nullptr ){
-		m_nFormat = bColumnSelect? 4: 3;	// 矩形を含めるか
+		// 長さフィールドで表せない長さのときは独自形式では受け渡さない
+		const bool bSakuraFormat = nTextLen <= CClipboard::SAKURAClipW_MaxLength;
+		m_nFormat = 2 + (bSakuraFormat? 1: 0) + (bColumnSelect? 1: 0);	// 独自形式・矩形を含めるか
 		m_pData = new DATA[m_nFormat];
 
 		i = 0;
@@ -216,15 +218,18 @@ void CDataObject::SetText( LPCWSTR lpszText, size_t nTextLen, BOOL bColumnSelect
 		m_pData[i].data = new BYTE[m_pData[i].size];
 		::WideCharToMultiByte( CP_ACP, 0, (LPCWSTR)m_pData[0].data, int(m_pData[0].size / sizeof(wchar_t)), (LPSTR)m_pData[i].data, int(m_pData[i].size), nullptr, nullptr );
 
-		i++;
-		m_pData[i].cfFormat = CClipboard::GetSakuraFormat();
-		m_pData[i].size = sizeof(size_t) + nTextLen * sizeof( wchar_t );
-		m_pData[i].data = new BYTE[m_pData[i].size];
-		*(size_t*)m_pData[i].data = nTextLen;
-		memcpy_raw( m_pData[i].data + sizeof(size_t), lpszText, nTextLen * sizeof( wchar_t ) );
+		if( bSakuraFormat ){
+			using LengthField = CClipboard::SAKURAClipW_LengthFieldType;
+			i++;
+			m_pData[i].cfFormat = CClipboard::GetSakuraFormat();
+			m_pData[i].size = sizeof(LengthField) + nTextLen * sizeof( wchar_t );
+			m_pData[i].data = new BYTE[m_pData[i].size];
+			*(LengthField*)m_pData[i].data = (LengthField)nTextLen;
+			memcpy_raw( m_pData[i].data + sizeof(LengthField), lpszText, nTextLen * sizeof( wchar_t ) );
+		}
 
-		i++;
 		if( bColumnSelect ){
+			i++;
 			m_pData[i].cfFormat = (CLIPFORMAT)::RegisterClipboardFormat( L"MSDEVColumnSelect" );
 			m_pData[i].size = 1;
 			m_pData[i].data = new BYTE[1];

--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -439,7 +439,7 @@ std::vector<std::filesystem::path> GlobalDropFiles::data() const & {
 //文字列を指定して必要サイズを計算する
 /* static */ size_t GlobalSakura::CalcSize(std::wstring_view text) noexcept
 {
-	return sizeof(size_type) + (std::size(text) + 1) * sizeof(WCHAR);
+	return sizeof(LengthFieldType) + (std::size(text) + 1) * sizeof(WCHAR);
 }
 
 //文字列を指定して構築（指定した文字列を確保したメモリにコピーする）
@@ -454,8 +454,10 @@ void GlobalSakura::SetText(std::wstring_view text) const
 {
 	Lock([text](LPWSTR pStr, size_t cbSize) {
 		if (cbSize < CalcSize(text)) throw std::length_error("text length is too long.");
-		*(size_type*)pStr = size_type(std::size(text));
-		std::ranges::copy(text, LPWSTR(pStr + sizeof(size_type) / sizeof(WCHAR)));
+		// 64bitビルドでは長さフィールドで表せない長さの文字列がありうる
+		if (std::size(text) > size_t(std::numeric_limits<LengthFieldType>::max())) throw std::length_error("text length is too long.");
+		*(LengthFieldType*)pStr = LengthFieldType(std::size(text));
+		std::ranges::copy(text, LPWSTR(pStr + sizeof(LengthFieldType) / sizeof(WCHAR)));
 		return true;
 	});
 }
@@ -463,10 +465,10 @@ void GlobalSakura::SetText(std::wstring_view text) const
 //格納されている文字列データのコピーを取得する
 std::wstring GlobalSakura::wstring() const & {
 	return Lock([](LPCWSTR pStr, size_t cbSize) -> std::wstring {
-		if (cbSize < sizeof(size_type) + sizeof(WCHAR)) return L"";
-		const auto length = *(const size_type*)pStr;
-		if (cbSize < sizeof(size_type) + (length + 1) * sizeof(WCHAR)) return L"";
-		return std::wstring(LPCWSTR(pStr + sizeof(size_type) / sizeof(WCHAR)), length);
+		if (cbSize < sizeof(LengthFieldType) + sizeof(WCHAR)) return L"";
+		const auto length = *(const LengthFieldType*)pStr;
+		if (cbSize < sizeof(LengthFieldType) + (length + 1) * sizeof(WCHAR)) return L"";
+		return std::wstring(LPCWSTR(pStr + sizeof(LengthFieldType) / sizeof(WCHAR)), length);
 	});
 }
 

--- a/sakura_core/util/os.cpp
+++ b/sakura_core/util/os.cpp
@@ -436,10 +436,16 @@ std::vector<std::filesystem::path> GlobalDropFiles::data() const & {
 	});
 }
 
+namespace {
+//! SAKURAClipW形式の先頭に置く文字数フィールドの型。
+//! 定義を分散させると異なるビルド間でレイアウトがずれるので、CClipboard の定義を唯一の正とする。(issue #2325)
+using size_type = CClipboard::SAKURAClipW_LengthFieldType;
+} // end of anonymous namespace
+
 //文字列を指定して必要サイズを計算する
 /* static */ size_t GlobalSakura::CalcSize(std::wstring_view text) noexcept
 {
-	return sizeof(LengthFieldType) + (std::size(text) + 1) * sizeof(WCHAR);
+	return sizeof(size_type) + (std::size(text) + 1) * sizeof(WCHAR);
 }
 
 //文字列を指定して構築（指定した文字列を確保したメモリにコピーする）
@@ -454,10 +460,10 @@ void GlobalSakura::SetText(std::wstring_view text) const
 {
 	Lock([text](LPWSTR pStr, size_t cbSize) {
 		if (cbSize < CalcSize(text)) throw std::length_error("text length is too long.");
-		// 64bitビルドでは長さフィールドで表せない長さの文字列がありうる
-		if (std::size(text) > size_t(std::numeric_limits<LengthFieldType>::max())) throw std::length_error("text length is too long.");
-		*(LengthFieldType*)pStr = LengthFieldType(std::size(text));
-		std::ranges::copy(text, LPWSTR(pStr + sizeof(LengthFieldType) / sizeof(WCHAR)));
+		// 64bitビルドでは文字数フィールドで表せない長さの文字列がありうる
+		if (std::size(text) > size_t(std::numeric_limits<size_type>::max())) throw std::length_error("text length is too long.");
+		*(size_type*)pStr = size_type(std::size(text));
+		std::ranges::copy(text, LPWSTR(pStr + sizeof(size_type) / sizeof(WCHAR)));
 		return true;
 	});
 }
@@ -465,10 +471,10 @@ void GlobalSakura::SetText(std::wstring_view text) const
 //格納されている文字列データのコピーを取得する
 std::wstring GlobalSakura::wstring() const & {
 	return Lock([](LPCWSTR pStr, size_t cbSize) -> std::wstring {
-		if (cbSize < sizeof(LengthFieldType) + sizeof(WCHAR)) return L"";
-		const auto length = *(const LengthFieldType*)pStr;
-		if (cbSize < sizeof(LengthFieldType) + (length + 1) * sizeof(WCHAR)) return L"";
-		return std::wstring(LPCWSTR(pStr + sizeof(LengthFieldType) / sizeof(WCHAR)), length);
+		if (cbSize < sizeof(size_type) + sizeof(WCHAR)) return L"";
+		const auto length = *(const size_type*)pStr;
+		if (cbSize < sizeof(size_type) + (length + 1) * sizeof(WCHAR)) return L"";
+		return std::wstring(LPCWSTR(pStr + sizeof(size_type) / sizeof(WCHAR)), length);
 	});
 }
 

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -289,7 +289,9 @@ private:
 	using Base = GlobalMemory;
 	using Me = GlobalSakura;
 
-	using size_type = size_t;	//TODO: int32_t に戻す
+	//! 長さフィールドの型。CClipboard::SAKURAClipW_LengthFieldType と一致させること。
+	//! ビルドのポインタ幅に依存させてはならない。(issue #2325)
+	using LengthFieldType = int32_t;
 
 public:
 	//HGLOBALを指定して構築（メモリ変更は行わない）

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -102,6 +102,8 @@ namespace cxx {
 
 /*!
  * @brief グローバルメモリを RAII で管理するヘルパークラス
+ *
+ * クリップボードや IDataObject でやり取りする HGLOBAL の基底。データ形式ごとに派生クラスを用意する。
  */
 class GlobalMemory : public cxx::ResourceHolder<&::GlobalFree> {
 private:
@@ -154,6 +156,8 @@ public:
 
 /*!
  * @brief グローバルメモリ上の文字列を RAII で管理するヘルパークラス
+ *
+ * 対応形式: CF_UNICODETEXT (終端NUL付きのUTF-16文字列)
  */
 class GlobalWString : public GlobalMemory {
 private:
@@ -179,6 +183,8 @@ public:
 
 /*!
  * @brief グローバルメモリ上の文字列を RAII で管理するヘルパークラス
+ *
+ * 対応形式: CF_TEXT / CF_OEMTEXT / "HTML Format" (終端NUL付きのマルチバイト文字列)
  */
 class GlobalString : public GlobalMemory {
 private:
@@ -204,6 +210,8 @@ public:
 
 /*!
  * @brief グローバルメモリ上のデータを RAII で管理するヘルパークラス
+ *
+ * 対応形式: MSDEVColumnSelect / MSDEVLineSelect 等、型付きの生データを置く形式全般
  */
 template<typename T>
 class GlobalData : public GlobalMemory {
@@ -267,6 +275,8 @@ public:
 
 /*!
  * @brief グローバルメモリ上のデータを RAII で管理するヘルパークラス
+ *
+ * 対応形式: CF_HDROP (DROPFILES ヘッダ + NUL区切りのパス列)
  */
 class GlobalDropFiles : public GlobalMemory {
 private:
@@ -283,15 +293,20 @@ public:
 
 /*!
  * @brief グローバルメモリ上の文字列を RAII で管理するヘルパークラス
+ *
+ * 対応形式: SAKURAClipW (サクラエディタ独自のクリップボード形式)
+ *
+ * バイナリレイアウトは以下の通り。
+ *   [文字数 (CClipboard::SAKURAClipW_LengthFieldType)][本文 (WCHAR × 文字数)][終端NUL]
+ *
+ * 先頭に文字数を持つのは、終端NULに頼らず埋め込みNULを含む本文を正確な長さで受け渡すため。
+ * このレイアウトは Win32/x64/ARM64 の各ビルド間、及び過去バージョンとの間で
+ * 一致していなければならないので、文字数フィールドをポインタ幅に依存する型にしてはならない。(issue #2325)
  */
 class GlobalSakura : public GlobalMemory {
 private:
 	using Base = GlobalMemory;
 	using Me = GlobalSakura;
-
-	//! 長さフィールドの型。CClipboard::SAKURAClipW_LengthFieldType と一致させること。
-	//! ビルドのポインタ幅に依存させてはならない。(issue #2325)
-	using LengthFieldType = int32_t;
 
 public:
 	//HGLOBALを指定して構築（メモリ変更は行わない）

--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -1807,9 +1807,12 @@ STDMETHODIMP CEditView::Drop( LPDATAOBJECT pDataObject, DWORD dwKeyState, POINTL
 	LPVOID pData = ::GlobalLock( hData );
 	SIZE_T nSize = ::GlobalSize( hData );
 	if( cf == CClipboard::GetSakuraFormat() ){
-		if( nSize > sizeof(size_t) ){
-			wchar_t* pszData = (wchar_t*)((BYTE*)pData + sizeof(size_t));
-			cmemBuf.SetString( pszData, t_min( (SIZE_T)*(size_t*)pData, nSize / sizeof(wchar_t) ) );	// 途中のNUL文字も含める
+		using LengthField = CClipboard::SAKURAClipW_LengthFieldType;
+		if( nSize > sizeof(LengthField) ){
+			const auto nStoredLength = *(LengthField*)pData;
+			const SIZE_T nMaxLength = (nSize - sizeof(LengthField)) / sizeof(wchar_t);
+			wchar_t* pszData = (wchar_t*)((BYTE*)pData + sizeof(LengthField));
+			cmemBuf.SetString( pszData, (nStoredLength <= 0)? 0: t_min( (SIZE_T)nStoredLength, nMaxLength ) );	// 途中のNUL文字も含める
 		}
 	}else if( cf == CF_UNICODETEXT ){
 		cmemBuf.SetString( (wchar_t*)pData, wcsnlen( (wchar_t*)pData, nSize / sizeof(wchar_t) ) );

--- a/src/test/cpp/tests1/test-cclipboard.cpp
+++ b/src/test/cpp/tests1/test-cclipboard.cpp
@@ -51,6 +51,33 @@ MATCHER_P(SakuraFormatInGlobalMemory, expected_string, "") {
 	return actual.wstring() == expected_string;
 }
 
+// サクラ独自形式(SAKURAClipW)のバイナリレイアウトは、
+// Win32/x64/ARM64 のどのビルドでも、また過去バージョンとの間でも一致していなければならない。
+// 長さフィールドをポインタ幅に依存する型にすると、
+// 異なるビルド間でのコピー＆ペーストが壊れる。(issue #2325)
+static_assert(sizeof(CClipboard::SAKURAClipW_LengthFieldType) == 4);
+
+// グローバルメモリに書き込まれたサクラ独自形式データのバイナリレイアウトにマッチする述語関数
+MATCHER_P(SakuraFormatLayoutInGlobalMemory, expected_string, "") {
+	const std::wstring_view expected = expected_string;
+	const cxx::GlobalData<BYTE> mem{ arg };
+	const auto bytes = mem.data();
+	CClipboard::SAKURAClipW_LengthFieldType length = 0;
+	if (bytes.size() < sizeof(length) + expected.length() * sizeof(wchar_t)) return false;
+	std::memcpy(&length, bytes.data(), sizeof(length));
+	if (size_t(length) != expected.length()) return false;
+	return 0 == std::memcmp(bytes.data() + sizeof(length), expected.data(), expected.length() * sizeof(wchar_t));
+}
+
+// サクラ独自形式データのバイト列を組み立てる（32bit版・旧バージョンが書き込む形式）
+static std::vector<BYTE> MakeSakuraFormatBytes(std::wstring_view text, int32_t storedLength)
+{
+	std::vector<BYTE> bytes(sizeof(storedLength) + (text.length() + 1) * sizeof(wchar_t), 0);
+	std::memcpy(bytes.data(), &storedLength, sizeof(storedLength));
+	std::memcpy(bytes.data() + sizeof(storedLength), text.data(), text.length() * sizeof(wchar_t));
+	return bytes;
+}
+
 // グローバルメモリに書き込まれた特定のバイト値にマッチする述語関数
 MATCHER_P(ByteValueInGlobalMemory, value, "") {
 	cxx::GlobalData<BYTE> actual{ arg };
@@ -187,6 +214,17 @@ TEST(CClipboard, SetText1) {
 	MockCClipboard clipboard;
 	EXPECT_CALL(clipboard, SetClipboardData(CF_UNICODETEXT, WideStringInGlobalMemory(text)));
 	EXPECT_CALL(clipboard, SetClipboardData(sakuraFormat, SakuraFormatInGlobalMemory(text)));
+	EXPECT_TRUE(clipboard.SetText(text.data(), text.length(), false, false, -1));
+}
+
+// SetText のテスト。サクラ独自形式のバイナリレイアウトを検証する。
+// 長さフィールドは 32bit 固定でなければならない。(issue #2325)
+TEST(CClipboard, SetTextSakuraFormatLayout) {
+	constexpr std::wstring_view text = L"てすと";
+	const CLIPFORMAT sakuraFormat = CClipboard::GetSakuraFormat();
+	MockCClipboard clipboard;
+	EXPECT_CALL(clipboard, SetClipboardData(CF_UNICODETEXT, _));
+	EXPECT_CALL(clipboard, SetClipboardData(sakuraFormat, SakuraFormatLayoutInGlobalMemory(text)));
 	EXPECT_TRUE(clipboard.SetText(text.data(), text.length(), false, false, -1));
 }
 
@@ -329,6 +367,44 @@ TEST_F(CClipboardGetText, SakuraFormatSuccess) {
 TEST_F(CClipboardGetText, SakuraFormatFailure) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(FALSE));
 	EXPECT_FALSE(clipboard.GetText(&buffer, nullptr, nullptr, eol, sakuraFormat));
+}
+
+// 長さフィールドが4バイトで書かれたサクラ形式データを読めることを確認する。
+// 他のビット数のビルドや過去バージョンが書き込んだデータを読む状況に相当する。(issue #2325)
+TEST_F(CClipboardGetText, SakuraFormatBinaryLayout) {
+	constexpr std::wstring_view text = L"サクラ";
+	const auto bytes = MakeSakuraFormatBytes(text, int32_t(text.length()));
+	const cxx::GlobalData<BYTE> mem(int(bytes.size()));
+	ASSERT_TRUE(mem.SetData(bytes));
+	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(TRUE));
+	ON_CALL(clipboard, GetClipboardData(sakuraFormat)).WillByDefault(Return(mem.Get()));
+	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, sakuraFormat));
+	EXPECT_EQ(text, std::wstring_view(buffer.GetStringPtr(), buffer.GetStringLength()));
+}
+
+// 長さフィールドが実データより大きい壊れたデータを読んでも、確保領域外を参照しない。
+TEST_F(CClipboardGetText, SakuraFormatBrokenLength) {
+	constexpr std::wstring_view text = L"サクラ";
+	const auto bytes = MakeSakuraFormatBytes(text, 0x40000000);
+	const cxx::GlobalData<BYTE> mem(int(bytes.size()));
+	ASSERT_TRUE(mem.SetData(bytes));
+	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(TRUE));
+	ON_CALL(clipboard, GetClipboardData(sakuraFormat)).WillByDefault(Return(mem.Get()));
+	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, sakuraFormat));
+	// 終端ヌルを含む、確保されている文字数で頭打ちになる
+	EXPECT_EQ(text.length() + 1, size_t(buffer.GetStringLength()));
+}
+
+// 長さフィールドが負の壊れたデータを読んでも、確保領域外を参照しない。
+TEST_F(CClipboardGetText, SakuraFormatNegativeLength) {
+	constexpr std::wstring_view text = L"サクラ";
+	const auto bytes = MakeSakuraFormatBytes(text, -1);
+	const cxx::GlobalData<BYTE> mem(int(bytes.size()));
+	ASSERT_TRUE(mem.SetData(bytes));
+	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(TRUE));
+	ON_CALL(clipboard, GetClipboardData(sakuraFormat)).WillByDefault(Return(mem.Get()));
+	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, sakuraFormat));
+	EXPECT_EQ(0, buffer.GetStringLength());
 }
 
 // CF_UNICODETEXTを指定して取得する。


### PR DESCRIPTION
自分が #2067 で入れた不具合を放置していてすみません。@hpmy-dev さんが修正PR(#2450, #2453)を作ってくれたのですが差分内容がちょっと過大に感じたので別途PRを作成しました。単純に 2b921e00bf9d14b3392bc7b37dbbd6ba88715437 をrevertで済む問題ではなかったのでClaude Codeに修正してもらいました。

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
#2325

## <!-- 必須 --> 仕様・動作説明

SAKURAClipW形式の先頭に置く文字数フィールドの型がsize_tになっており、x64/ARM64 ビルドでは8バイト、Win32ビルドでは4バイトとレイアウトが食い違っていた。このため異なるビット数のビルド間や過去バージョンとの間でコピー＆ペーストするとデータ位置が4バイトずれ、文字化けやクラッシュを起こしていた。

長さフィールドの型をint32_t固定のSAKURAClipW_LengthFieldTypeとして定義し直し、 クリップボードとドラッグ＆ドロップの読み書きで使う。表現できない長さのときは独自形式を設定せずCF_UNICODETEXTのみとする。読み込み側にはGlobalSizeによる上限クランプを 追加し、壊れたデータや他ビルドが書き込んだデータを読んでも確保領域外を参照しないようにした。

## <!-- 必須 --> テスト内容

32bit版と64bit版を両方起動して相互でコピペが問題無く行える事を確認した。

## <!-- なければ省略可 --> 関連 issue, PR

#2067 #2325 #2331 #2435 #2453 #2556
