### PR TITLE
タグジャンプでプロセスの起動に失敗しましたの対応

### DIFF
--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -50,6 +50,7 @@
 #include "recent/CMRUFile.h"
 #include "recent/CMRUFolder.h"
 #include "_main/CCommandLine.h"
+#include "_main/process_sync.h"
 #include "grep/CGrepEnumKeys.h"
 #include "apiwrap/StdApi.h"
 #include "sakura_rc.h"
@@ -1285,17 +1286,18 @@ bool CControlTray::OpenNewEditor(
 	bool bRet = true;
 	if (sync)
 	{
-		// エディター初期化完了イベントを作成する
+		// エディター初期化完了イベントを作成する（スコープ離脱で確実に閉じる）
 		SFilePath initEventName{ std::format(GSTR_EVENT_SAKURA_EP_INITIALIZED, p.dwThreadId) };
-		HANDLE hEvent = ::CreateEventW(nullptr, TRUE, FALSE, initEventName);
+		using HandleHolder = cxx::ResourceHolder<&::CloseHandle>;
+		HandleHolder hEvent{ ::CreateEventW(nullptr, TRUE, FALSE, initEventName) };
 
 		// エディターのメインスレッドを再開する
 		::ResumeThread(p.hThread);
 
-		// エディター初期化完了を待つ
-		std::array handles{ hEvent, p.hProcess };
-		const auto dwRet = ::WaitForMultipleObjects(DWORD(std::size(handles)), std::data(handles), FALSE, 15000);
-		if (WAIT_OBJECT_0 != dwRet) {
+		// エディター初期化完了を待つ。待機中も送信メッセージ(sent message)は捌く（#2550）。
+		// これを怠ると、初期化中の子が本スレッドのウィンドウへ同期SendMessageした場合に
+		// タイムアウトまでデッドロックする。ポストは意図的に非ディスパッチ。
+		if (WaitEditorInitialized(hEvent.get(), p.hProcess, 15000) != ESyncWaitResult::Initialized) {
 			ErrorMessage(
 				hWndParent,
 				LS(STR_TRAY_CREATEPROC2),

--- a/sakura_core/_main/process_sync.h
+++ b/sakura_core/_main/process_sync.h
@@ -1,0 +1,80 @@
+﻿/*!	@file
+	@brief エディタープロセス起動時の同期待機ヘルパー
+
+	@author Sakura Editor Organization
+	@date 2026/07/27 作成
+*/
+
+/*
+	Copyright (C) 2026, Sakura Editor Organization
+
+	This source code is designed for sakura editor.
+	Please contact the copyright holder to use this code for other purpose.
+*/
+
+#ifndef SAKURA_PROCESS_SYNC_5B8D56A4_D12C_4A6B_8C1B_88A53B98444B_H_
+#define SAKURA_PROCESS_SYNC_5B8D56A4_D12C_4A6B_8C1B_88A53B98444B_H_
+#pragma once
+
+#include <windows.h>
+
+//! 起動同期待機の判定結果
+enum class ESyncWaitResult {
+	Initialized,	//!< 初期化完了イベントがシグナル
+	ChildExited,	//!< 子プロセスが先に終了
+	SentMessage,	//!< 送信メッセージ到着（処理して継続すべき）
+	Failed,			//!< タイムアウト/失敗
+};
+
+//! MsgWaitForMultipleObjectsEx の戻り値を分類する（handleCount は待機ハンドル数＝通常2）
+inline ESyncWaitResult ClassifySyncWait(DWORD dwRet, DWORD handleCount) noexcept
+{
+	if (dwRet == WAIT_OBJECT_0)							return ESyncWaitResult::Initialized;
+	if (handleCount >= 2 && dwRet == WAIT_OBJECT_0 + 1)	return ESyncWaitResult::ChildExited;
+	if (dwRet == WAIT_OBJECT_0 + handleCount)			return ESyncWaitResult::SentMessage;
+	return ESyncWaitResult::Failed;	// WAIT_TIMEOUT / WAIT_FAILED など
+}
+
+//! 残り待機時間(ms)を算出する。deadline を過ぎていれば 0
+inline DWORD CalcRemainMs(ULONGLONG deadlineTick, ULONGLONG nowTick) noexcept
+{
+	return (nowTick < deadlineTick) ? DWORD(deadlineTick - nowTick) : 0u;
+}
+
+//! ハンドルが有効なときのみ SetEvent する。無効(nullptr)なら false を返し何もしない
+inline bool SafeSetEvent(HANDLE hEvent) noexcept
+{
+	return (hEvent != nullptr) && (::SetEvent(hEvent) != FALSE);
+}
+
+//! 子エディタの初期化完了を待つ。
+//! 待機中も送信メッセージ(sent message)は処理し、ポストメッセージはディスパッチしない。
+//! @param hEvent   初期化完了イベント
+//! @param hProcess 子プロセスハンドル（先に終了したら失敗扱い）
+//! @param timeoutMs 全体タイムアウト(ms)
+inline ESyncWaitResult WaitEditorInitialized(HANDLE hEvent, HANDLE hProcess, DWORD timeoutMs) noexcept
+{
+	HANDLE handles[2] = { hEvent, hProcess };
+	const ULONGLONG deadline = ::GetTickCount64() + timeoutMs;
+	for (;;) {
+		const DWORD remain = CalcRemainMs(deadline, ::GetTickCount64());
+		if (remain == 0) {
+			// 期限超過。送信メッセージが届き続けていても打ち切る（ビジーループ回避）
+			return ESyncWaitResult::Failed;
+		}
+		// 第5引数は 0。MWMO_INPUTAVAILABLE はキュー内の未読「入力」に対するフラグであり、
+		// 送信メッセージ(QS_SENDMESSAGE)には作用しないため指定しない。
+		const DWORD dwRet = ::MsgWaitForMultipleObjectsEx(
+			2, handles, remain, QS_SENDMESSAGE, 0);
+		const ESyncWaitResult eResult = ClassifySyncWait(dwRet, 2);
+		if (eResult == ESyncWaitResult::SentMessage) {
+			// 送信メッセージのみ処理し、ポストは残す
+			MSG msg;
+			::PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE | PM_QS_SENDMESSAGE);
+			continue;
+		}
+		return eResult;	// Initialized / ChildExited / Failed
+	}
+}
+
+#endif /* SAKURA_PROCESS_SYNC_5B8D56A4_D12C_4A6B_8C1B_88A53B98444B_H_ */

--- a/sakura_core/tests1.vcxproj
+++ b/sakura_core/tests1.vcxproj
@@ -165,6 +165,7 @@
     <ClCompile Include="..\src\test\cpp\tests1\test-messageboxf.cpp" />
     <ClCompile Include="..\src\test\cpp\tests1\test-mydevmode.cpp" />
     <ClCompile Include="..\src\test\cpp\tests1\test-parameterized.cpp" />
+    <ClCompile Include="..\src\test\cpp\tests1\test-process_sync.cpp" />
     <ClCompile Include="..\src\test\resources\printECodeType.cpp" />
     <ClCompile Include="..\src\test\resources\printEEolType.cpp" />
     <ClCompile Include="..\src\test\cpp\tests1\test-sample-disabled.cpp" />

--- a/sakura_core/tests1.vcxproj.filters
+++ b/sakura_core/tests1.vcxproj.filters
@@ -220,6 +220,9 @@
     <ClCompile Include="..\src\test\cpp\tests1\test-codechecker.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\test\cpp\tests1\test-process_sync.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\test\resources\pch.h">

--- a/src/test/cpp/tests1/test-process_sync.cpp
+++ b/src/test/cpp/tests1/test-process_sync.cpp
@@ -1,0 +1,175 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2026, Sakura Editor Organization
+	@brief エディター起動時の同期待機ヘルパー（process_sync.h）のテスト
+
+	テスト方針:
+	プロセス間の SendMessage 枯渇は「同一プロセス内のスレッド間 SendMessage」で再現する。
+	そのため別プロセスを起動せず、実ウィンドウ・実イベント・別スレッドだけで実挙動を検証する。
+*/
+
+#include "pch.h"
+#include <windows.h>
+#include <thread>
+#include <atomic>
+#include "gtest/gtest.h"
+#include "_main/process_sync.h"
+
+namespace {
+
+	//! 待機中に「送信」されるメッセージ。処理されればポンプが動いている証拠になる
+	constexpr UINT WM_TEST_SENT   = WM_APP + 1;
+	//! 待機中に「ポスト」されるメッセージ。処理されないことを確認するために使う
+	constexpr UINT WM_TEST_POSTED = WM_APP + 2;
+
+	//! WM_TEST_SENT がウィンドウプロシージャまで届いたかを記録する
+	//! （ワーカースレッドと本スレッドの両方から触れるので atomic）
+	std::atomic<bool> g_sentHandled{ false };
+
+	LRESULT CALLBACK TestWndProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
+	{
+		if (msg == WM_TEST_SENT) {
+			// ここに到達する ＝ 待機中に送信メッセージがディスパッチされた
+			g_sentHandled = true;
+			return 0;
+		}
+		return ::DefWindowProcW(hWnd, msg, wp, lp);
+	}
+
+	//! テスト用のメッセージ専用ウィンドウ（HWND_MESSAGE）を作る。
+	//! 画面に出ず、送信・ポストの両方を受け取れるためテストに適する。
+	HWND CreateTestWindow()
+	{
+		static const wchar_t* kClass = L"SakuraProcessSyncTestWnd";
+		static bool registered = false;
+		const HINSTANCE hInst = ::GetModuleHandleW(nullptr);
+		if (!registered) {
+			WNDCLASSEXW wc{};
+			wc.cbSize = sizeof(wc);
+			wc.lpfnWndProc = TestWndProc;
+			wc.hInstance = hInst;
+			wc.lpszClassName = kClass;
+			::RegisterClassExW(&wc);	// 二重登録は失敗するだけで無害
+			registered = true;
+		}
+		return ::CreateWindowExW(0, kClass, L"t", 0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, hInst, nullptr);
+	}
+
+} // namespace
+
+/*!
+	待機中に「送信は捌く／ポストは捌かない」、かつイベントで正常終了することを検証する。
+
+	これが #2550 の再発防止そのもの。以下のいずれかが壊れると落ちる。
+	 - 待機を ::WaitForMultipleObjects に戻した      → 送信が捌かれず worker がブロックし続けてタイムアウト
+	 - 起床マスクから QS_SENDMESSAGE を外した        → 同上
+	 - PeekMessage から PM_QS_SENDMESSAGE を外した   → ポストまで処理してしまい、残存チェックが落ちる
+
+	同期は Sleep に頼らない。SendMessage は相手が捌くまで戻らない性質があるため、
+	worker の Post → Send → SetEvent という並びだけで順序が確定する（フレークしにくい）。
+*/
+TEST(WaitEditorInitialized, PumpsSentButNotPosted)
+{
+	g_sentHandled = false;
+
+	const HWND hWnd = CreateTestWindow();
+	ASSERT_NE(nullptr, hWnd);
+
+	// 初期化完了イベントの代役（手動リセット・初期非シグナル）
+	HANDLE hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
+	ASSERT_NE(nullptr, hEvent);
+
+	// 子プロセスハンドルの代役。決してシグナルしないことで ChildExited 経路に入らないようにする
+	HANDLE hProcStandin = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
+	ASSERT_NE(nullptr, hProcStandin);
+
+	std::thread worker([&]{
+		// 先にポストしておく。待機ループがこれを処理しないことを後で確認する
+		::PostMessageW(hWnd, WM_TEST_POSTED, 0, 0);
+		// 本スレッドが送信を捌くまでここでブロックする（＝ポンプ稼働の証明）
+		::SendMessageW(hWnd, WM_TEST_SENT, 0, 0);
+		// 送信が返った後に初期化完了を通知する
+		::SetEvent(hEvent);
+	});
+
+	const ESyncWaitResult r = WaitEditorInitialized(hEvent, hProcStandin, 5000);
+	worker.join();
+
+	// イベントのシグナルで待機を抜けたこと
+	EXPECT_EQ(ESyncWaitResult::Initialized, r);
+	// 待機中に送信メッセージが処理されたこと（#2550 の確認）
+	EXPECT_TRUE(g_sentHandled.load());
+
+	// ポストは処理されずキューに残っているはず。
+	// PeekMessage が true を返す ＝ 待機ループがポストをディスパッチしなかった証拠
+	MSG msg{};
+	EXPECT_TRUE(::PeekMessageW(&msg, hWnd, WM_TEST_POSTED, WM_TEST_POSTED, PM_REMOVE));
+
+	::CloseHandle(hProcStandin);
+	::CloseHandle(hEvent);
+	::DestroyWindow(hWnd);
+}
+
+/*!
+	子プロセスが初期化完了前に終了した場合、ChildExited として検出できることを検証する。
+
+	ClassifySyncWait の WAIT_OBJECT_0 + 1 の判定を守る。
+	handles の並び順（{ hEvent, hProcess }）を入れ替えると、
+	子の異常終了を「初期化成功」と誤判定するようになり、ここで落ちる。
+*/
+TEST(WaitEditorInitialized, ChildExitReportsFailure)
+{
+	HANDLE hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);	// 初期化完了は通知されない
+	HANDLE hProc  = ::CreateEventW(nullptr, TRUE, TRUE,  nullptr);	// 初期シグナル ＝ 子が終了済みの状態を模す
+	ASSERT_NE(nullptr, hEvent);
+	ASSERT_NE(nullptr, hProc);
+
+	EXPECT_EQ(ESyncWaitResult::ChildExited, WaitEditorInitialized(hEvent, hProc, 5000));
+
+	::CloseHandle(hProc);
+	::CloseHandle(hEvent);
+}
+
+/*!
+	何も起きないまま制限時間を過ぎたら Failed になることを検証する。
+
+	CalcRemainMs が残り時間を正しく減らしていることの実挙動確認も兼ねる。
+	残り時間の計算を誤って毎回フルの timeout を渡すと、待機が期限を超えて伸びる。
+
+	注: 送信もポストも発生しない構成なので、100ms で確実に WAIT_TIMEOUT に落ちる。
+	    このテストだけは意図的に約100ms かかる（異常ではない）。
+*/
+TEST(WaitEditorInitialized, TimeoutReportsFailure)
+{
+	HANDLE hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);	// シグナルしない
+	HANDLE hProc  = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);	// シグナルしない
+	ASSERT_NE(nullptr, hEvent);
+	ASSERT_NE(nullptr, hProc);
+
+	EXPECT_EQ(ESyncWaitResult::Failed, WaitEditorInitialized(hEvent, hProc, 100));
+
+	::CloseHandle(hProc);
+	::CloseHandle(hEvent);
+}
+
+/*!
+	MsgWaitForMultipleObjectsEx の戻り値の分類を固定する（純粋関数・決定的）。
+
+	この API の戻り値は待機ハンドル数 nCount に依存する off-by-one を作り込みやすい。
+	nCount == 2 のとき、WAIT_OBJECT_0 + 2 は「3個目のハンドル」ではなく
+	「送信メッセージの到着」を意味する。ここを取り違えると、
+	送信到着を Failed と誤判定して待機が即座に失敗するようになる。
+
+	CalcRemainMs は期限超過時に 0 を返すこと（負値へ回り込まないこと）を確認する。
+	ULONGLONG の減算で回り込むと、事実上無限待ちになる。
+*/
+TEST(ProcessSyncClassify, Mapping)
+{
+	EXPECT_EQ(ESyncWaitResult::Initialized, ClassifySyncWait(WAIT_OBJECT_0,     2));	// 1個目 ＝ 初期化完了
+	EXPECT_EQ(ESyncWaitResult::ChildExited, ClassifySyncWait(WAIT_OBJECT_0 + 1, 2));	// 2個目 ＝ 子プロセス終了
+	EXPECT_EQ(ESyncWaitResult::SentMessage, ClassifySyncWait(WAIT_OBJECT_0 + 2, 2));	// nCount と同値 ＝ 送信到着
+	EXPECT_EQ(ESyncWaitResult::Failed,      ClassifySyncWait(WAIT_TIMEOUT,      2));	// 時間切れ
+
+	EXPECT_EQ(DWORD(0),   CalcRemainMs(1000, 1000));	// 期限ちょうど ＝ 残り 0
+	EXPECT_EQ(DWORD(500), CalcRemainMs(1000, 500));		// 期限まで 500ms
+}


### PR DESCRIPTION


Fixes #2550

## 概要

タグジャンプで未オープンのファイルを開くと、対象のウィンドウは開くにもかかわらず
ジャンプ元に「プロセスの起動に失敗しました。」が表示され、約15秒フリーズする問題の修正

原因は、同期起動時の待機に `::WaitForMultipleObjects` を使っていたこと。
この待機は**送信メッセージ（sent message）を処理しない**ため、
起動された側が待機側のウィンドウへ同期 `SendMessage` を行うとデッドロックされる。

## 原因の詳細

`CControlTray::OpenNewEditor` は `sync=true` のとき、子プロセスの初期化完了イベントを
`::WaitForMultipleObjects` で最大15秒待ちます。この関数はタグジャンプ経路
（`CEditView::TagJumpSub` → `OpenNewEditor2`）から**ジャンプ元エディタのUIスレッド上で**
呼ばれるため、その間メッセージポンプが停止する。

一方、起動された子プロセスは初期化中に
`CNormalProcess::InitializeProcess` → `CShareData::ActiveAlreadyOpenedWindow`
→ `CShareData::IsPathOpened` で、既存の全エディタウィンドウへ
`SendMessageAny(MYWM_GETFILEINFO)` を同期送信。
`SendMessageAny` は `apiwrap/StdApi.h` の `#define SendMessageAny SendMessage` により
**タイムアウトなしの `SendMessage`** です。

この送信先には待機中の親自身が含まれるため、親がポンプを止めている間は応答できず送信が滞留し、
子は初期化を先に進められません。結果として初期化完了イベントは発生せず、
親は15秒でタイムアウトしてエラーを表示します。その後ポンプが再開して滞留が解けるため、
「エラーは出るがウィンドウは約15秒後に開く」という問題です。

```
[ジャンプ元プロセス]                          [子プロセス（ジャンプ先用に起動）]

 CControlTray::OpenNewEditor2(sync=true)
   CreateProcess ─────────────────────────→ wWinMain
   ↓                                          ↓
 WaitForMultipleObjects(handles, 15000)     CNormalProcess::InitializeProcess
 ★ポンプ停止＝送信を捌けない                  ActiveAlreadyOpenedWindow
   │                                            CShareData::IsPathOpened
   │  ←────────────────────────────────────── SendMessageAny(MYWM_GETFILEINFO)
   │  ✖ 親が処理できず滞留（応答なし）           │  ← 素のSendMessage（timeout無し）
   │                                          ★ここで停止：初期化が先へ進めない
   ↓                                            初期化完了イベントを立てられない
 15秒でタイムアウト → 「プロセスの起動に失敗しました。」
```

## 修正内容

待機を `::MsgWaitForMultipleObjectsEx` + `QS_SENDMESSAGE` のループに変更し、
**待機中も送信メッセージだけは処理する**ようにしました。

ポストメッセージは意図的にディスパッチしません（`PM_QS_SENDMESSAGE` を指定）。
コマンド処理の再入や順序逆転を避けるためです。

```
 MsgWaitForMultipleObjectsEx(handles, 15000, QS_SENDMESSAGE)
 ★送信メッセージは処理して待機
   │  ←────────────────────────────────────── SendMessageAny(MYWM_GETFILEINFO)
   │  MYWM_GETFILEINFO を処理して即応答          │
   ├──────────────────────────────────────→ ★即座に応答が返る
   │                                          初期化を継続 → 初期化完了イベントをシグナル
   ↓
 待機終了（15秒待たずに復帰）→ タグジャンプ成功
```
詳細は後述。

待機ロジックは単体テスト可能にするため、ヘッダオンリーの関数として
`sakura_core/_main/process_sync.h` に切り出しました。
プロダクト側にテスト用の注入シーム（DI）は設けていません。

あわせて、同じ箇所にあった初期化完了イベントのハンドルリーク
（`CreateEventW` の戻り値を `CloseHandle` していなかった）を、
`cxx::ResourceHolder<&::CloseHandle>` によるRAII保持で解消しています。

### 変更ファイル

| ファイル | 内容 |
|---|---|
| `sakura_core/_main/process_sync.h` | 新規。待機ヘルパー（`WaitEditorInitialized` ほか） |
| `sakura_core/_main/CControlTray.cpp` | 待機方式の変更、イベントハンドルのRAII化 |
| `src/test/cpp/tests1/test-process_sync.cpp` | 新規。待機挙動の単体テスト |
| `sakura_core/tests1.vcxproj` / `.filters` | テストファイルの登録 |

## テスト

プロセス間の `SendMessage` 枯渇は、同一プロセス内のスレッド間 `SendMessage` で再現できます。
そのため別プロセスを起動せず、実ウィンドウ・実イベント・別スレッドのみで実挙動を検証しています。

- `WaitEditorInitialized.PumpsSentButNotPosted`
  待機中に送信メッセージが処理されること、ポストメッセージはキューに残ること、
  イベントのシグナルで正常終了することを確認します。本Issueの再発防止そのものです。
- `WaitEditorInitialized.ChildExitReportsFailure`
  子プロセスが先に終了した場合を検出できることを確認します。
- `WaitEditorInitialized.TimeoutReportsFailure`
  制限時間を過ぎた場合に失敗を返すことを確認します。
- `ProcessSyncClassify.Mapping`
  `MsgWaitForMultipleObjectsEx` の戻り値分類（`WAIT_OBJECT_0 + nCount` が送信到着）を固定します。
  この API は待機ハンドル数に依存する off-by-one を作り込みやすいため、明示的に固定しています。

同期は `Sleep` に頼らず、`SendMessage` が相手の処理を待つ性質を利用して順序を確定させています。

### 動作確認

- まとめ表示／分離表示のいずれでも、未オープンファイルへのタグジャンプでエラーが表示されないこと
- 約15秒の遅延が解消し、即座にウィンドウが開くこと
- ジャンプ後にドラッグ選択状態が残らないこと

## 補足

本修正は「どの送信が滞留しても待機側が捌く」という形の対処です。
特定のメッセージ送信元を個別に修正する方式（#2548 など）と比べ、
同種の問題の取り残しが生じにくいと考えています。

待機中は送信メッセージが処理されるため、この区間で待機側のウィンドウプロシージャが
再入する可能性があります。今回滞留していた `MYWM_GETFILEINFO` は
共有バッファへの読み書きのみでウィンドウ状態を変更しないため安全です。
なお `MYWM_CLOSE` など副作用の大きいメッセージが同時に届いた場合の挙動については、
本修正のスコープ外として別途整理しています。

別のプロセス間通信の問題は別PRにします。


### Before（現状：`WaitForMultipleObjects`＝送信を捌けずデッドロック）

```text
[ジャンプ元プロセス]                          [子プロセス（ジャンプ先用に起動）]

 タグジャンプ操作
   ↓
 CEditView::TagJumpSub
   IsPathOpened → 未オープンと判定
   ↓
 CControlTray::OpenNewEditor2(sync=true)
   CreateProcess ─────────────────────────→ wWinMain
   ↓                                          ↓
 WaitForMultipleObjects(                    CProcess::Run
     handles, 15000)                          ↓
 ★ポンプ停止＝送信を捌けない                CNormalProcess::InitializeProcess:129
   │                                          ActiveAlreadyOpenedWindow
   │                                            CShareData::IsPathOpened:899
   │  ←────────────────────────────────────── SendMessageAny(MYWM_GETFILEINFO)
   │  ✖ 親が処理できず滞留（応答なし）           │  ← 素のSendMessage（timeout無し）
   │                                            │
   │                                          ★ここで停止：初期化が先へ進めない
   │                                            CEditApp::Create に到達できない
   │                                            初期化完了イベントを立てられない
   ↓                                            （CNormalProcess.cpp:454 未到達）
 15秒でタイムアウト → 待機終了
   ↓
 「プロセスの起動に失敗しました。」
   ↓
 （その後ポンプ再開で滞留が解け、子は続行して
   ウィンドウを開く＝“約15秒後に開く”）
   ↓
 IsPathOpened が hwndOwner を取得できず
   → Tag Jump Back も不発
```

### After（推奨：`MsgWaitForMultipleObjectsEx` + `QS_SENDMESSAGE`）

```text
[ジャンプ元プロセス]                          [子プロセス（ジャンプ先用に起動）]

 タグジャンプ操作
   ↓
 CEditView::TagJumpSub
   IsPathOpened → 未オープンと判定
   ↓
 CControlTray::OpenNewEditor2(sync=true)
   CreateProcess ─────────────────────────→ wWinMain
   HandleHolder hEvent{ CreateEventW(…) }     ↓        ◀  初期化完了イベントをRAII保持
   ResumeThread(子)                            CProcess::Run
   ↓                                          ↓
 MsgWaitForMultipleObjectsEx(               CNormalProcess::InitializeProcess:129
     hEvent.get(), hProcess,                  ActiveAlreadyOpenedWindow    ◀ handlesにhEvent.get()
     15000, QS_SENDMESSAGE)                    CShareData::IsPathOpened:899
 ★送信メッセージは処理して待機                     │
   │  ←────────────────────────────────────── SendMessageAny(MYWM_GETFILEINFO)
   │  MYWM_GETFILEINFO を処理                   │
   │  （ポストメッセージは非ディスパッチ）         │
   ├──────────────────────────────────────→ ★即座に応答が返る
   │                                            ↓
   │                                          初期化を継続
   │                                            ↓
   │                                          CEditApp::Create（ウィンドウ生成）
   │                                            ↓
   │  ←────────────────────────────────────── 初期化完了イベントをシグナル
   ↓                                          （CNormalProcess.cpp:454）
 待機終了（15秒待たずに復帰）
   ↓
 CloseHandle(初期化完了イベント)                          ◀ コープ離脱で自動解放（リーク解消）
   ↓   （旧・項番1単独では閉じ忘れ＝ハンドルリーク）
 OpenNewEditor2 から復帰
   ↓
 IsPathOpened で hwndOwner を取得
 （CEditView_Command.cpp:153）
   ↓
 タグジャンプ成功／Tag Jump Back も有効
```

