### PR TITLE
エディター起動時のハングアップに暫定対処を入れる

### DIFF
--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -1294,7 +1294,28 @@ bool CControlTray::OpenNewEditor(
 
 		// エディター初期化完了を待つ
 		std::array handles{ hEvent, p.hProcess };
-		const auto dwRet = ::WaitForMultipleObjects(DWORD(std::size(handles)), std::data(handles), FALSE, 15000);
+		const auto count = DWORD(std::size(handles));
+
+		const auto startTick = ::GetTickCount64();
+		const ULONGLONG timeoutMillis = 15000;	// タイムアウト時間
+
+		DWORD dwRet = 0;
+		do {
+			// 残り時間を考慮して待機する
+			const auto elapsed = ::GetTickCount64() - startTick;	// 経過時間
+			const auto remaining = DWORD(timeoutMillis - elapsed);			// 残り時間
+			dwRet = ::MsgWaitForMultipleObjects(count, std::data(handles), FALSE, remaining, QS_SENDMESSAGE);
+
+			// 自スレッドにメッセージが送られてきた場合
+			if (count == dwRet) {
+				BlockingHook(nullptr);	// 溜まったメッセージを処理する
+			}
+		}
+		while (::GetTickCount64() - startTick < timeoutMillis && // タイムアウト発生
+			WAIT_OBJECT_0 != dwRet && // エディター初期化完了
+			WAIT_OBJECT_0 + 1 != dwRet // エディタープロセス終了
+		);
+
 		if (WAIT_OBJECT_0 != dwRet) {
 			ErrorMessage(
 				hWndParent,

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -896,7 +896,8 @@ BOOL CShareData::IsPathOpened( const WCHAR* pszPath, HWND* phwndOwner )
 	for( int i = 0; i < m_pShareData->m_sNodes.m_nEditArrNum; ++i ){
 		if( IsSakuraMainWindow( m_pShareData->m_sNodes.m_pEditArr[i].m_hWnd ) ){
 			// トレイからエディタへの編集ファイル名要求通知
-			::SendMessageAny( m_pShareData->m_sNodes.m_pEditArr[i].m_hWnd, MYWM_GETFILEINFO, 1, 0 );
+			if (!::SendMessageTimeoutW(m_pShareData->m_sNodes.m_pEditArr[i].m_hWnd, MYWM_GETFILEINFO, 1, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 3000, nullptr)) continue;
+
 			pfi = (EditInfo*)&m_pShareData->m_sWorkBuffer.m_EditInfo_MYWM_GETFILEINFO;
 
 			// 同一パスのファイルが既に開かれているか


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2550

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
以下の暫定対処を入れます。

- [SendMessageTimeoutWを使う](https://github.com/sakura-editor/sakura/commit/e118d2b18752cfbf6110f123ef0c612a8920da9e) CShareData::IsPathOpened の SendMessage を3秒で打ち切ります。
- [MsgWaitForMultipleObjectsを使う](https://github.com/sakura-editor/sakura/commit/a0924ca134ce8bad893b2a84261ad7c81bb4339f) CControlTray::OpenNewEditor で 自スレッドに送られてきたメッセージに応答します。

残課題はあるものの、問題は一旦解消する見込み。

残課題
- SendMessageTimeoutWのタイムアウト値、 3秒でよいのか問題
- CNormalProcess::OpenFilesの呼出がメッセージループの開始前、問題。

本件、勝手にやります。

なお、CI上でテストが完了しない問題が発生しているので、そちらの対処を先に入れる可能性があります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->
WinMainFuncTest.CreateEditorProcess001のテスト実行時間が短くなっていることが分かりやすいと思います。

Before) 15秒のタイムアウト × 2 で 30秒以上かかる
After) 3秒のタイムアウト × 2 で 10秒以内に終わる

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- #2550 （閉じられません。）


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
