### PR TITLE
クリップボード形式に関するテストを追加する

### DIFF
--- a/src/test/cpp/tests1/test-cclipboard.cpp
+++ b/src/test/cpp/tests1/test-cclipboard.cpp
@@ -1087,5 +1087,74 @@ TEST(CEnumFORMATETC, test001)
 	//生ポインタなのでReleaseして解放する
 	EXPECT_THAT(target->Release(), 0UL);
 }
+/*!
+ * SetText（矩形選択あり）のテスト。
+ *
+ * 矩形選択時は MSDEVColumnSelect 形式が追加され、フォーマット数が 4 になる。
+ * SetText 内のフォーマット数算出とインデックス操作に対する回帰テスト。
+ */
+TEST(CopiedTextData, SetTextColumnSelect)
+{
+	const auto target = std::make_unique<CDataObject>(L"abc", 3, TRUE);
+
+	// CF_UNICODETEXT / CF_TEXT / サクラ形式 / MSDEVColumnSelect の 4 形式になる
+	cxx::com_pointer<IEnumFORMATETC> pEnumFormatEtc = nullptr;
+	EXPECT_HRESULT_SUCCEEDED(target->EnumFormatEtc(DATADIR_GET, &pEnumFormatEtc));
+	EXPECT_THAT(pEnumFormatEtc, NotNull());
+
+	// 4個すべてスキップできる
+	EXPECT_HRESULT_SUCCEEDED(pEnumFormatEtc->Skip(4));
+
+	// 5個目は無いのでスキップに失敗する
+	EXPECT_HRESULT_EQ(pEnumFormatEtc->Skip(1), S_FALSE);
+
+	// MSDEVColumnSelect 形式には 1バイトの 0 が格納される
+	const CLIPFORMAT columnFormat = (CLIPFORMAT)::RegisterClipboardFormat(L"MSDEVColumnSelect");
+	FORMATETC format = { columnFormat, nullptr, DVASPECT_CONTENT, -1, TYMED_HGLOBAL };
+	STGMEDIUM medium = {};
+	EXPECT_HRESULT_SUCCEEDED(target->GetData(&format, &medium));
+	EXPECT_THAT(medium.tymed, TYMED_HGLOBAL);
+	EXPECT_THAT(medium.hGlobal, ByteValueInGlobalMemory(BYTE(0)));
+}
+
+/*!
+ * GetData（サクラ独自形式）のテスト。
+ *
+ * SAKURAClipW のバイナリレイアウトを検証する。
+ * 先頭が固定幅の長さフィールド、続いて本文の wchar_t 列が並ぶ。(issue #2325)
+ *
+ * ※ CDataObject::SetText は終端ヌルを書き込まないため、
+ *    終端ヌルの存在を前提とする cxx::GlobalSakura ではなくバイト列で検証する。
+ */
+TEST(CopiedTextData, GetDataSakuraFormatLayout)
+{
+	const auto text = L"abc"s;
+	const auto target = std::make_unique<CDataObject>(text.data(), text.size(), FALSE);
+
+	const CLIPFORMAT sakuraFormat = CClipboard::GetSakuraFormat();
+	FORMATETC format = { sakuraFormat, nullptr, DVASPECT_CONTENT, -1, TYMED_HGLOBAL };
+	STGMEDIUM medium = {};
+	EXPECT_HRESULT_SUCCEEDED(target->GetData(&format, &medium));
+	EXPECT_THAT(medium.tymed, TYMED_HGLOBAL);
+	EXPECT_THAT(medium.hGlobal, SakuraFormatLayoutInGlobalMemory(text));
+}
+
+/*!
+ * GetData（CF_TEXT）のテスト。
+ *
+ * ANSI 変換された文字列が取得できることを確認する。
+ */
+TEST(CopiedTextData, GetDataAnsiText)
+{
+	const auto text = L"abc"s;
+	const auto target = std::make_unique<CDataObject>(text.data(), text.size(), FALSE);
+
+	FORMATETC format = { CF_TEXT, nullptr, DVASPECT_CONTENT, -1, TYMED_HGLOBAL };
+	STGMEDIUM medium = {};
+	EXPECT_HRESULT_SUCCEEDED(target->GetData(&format, &medium));
+	EXPECT_THAT(medium.tymed, TYMED_HGLOBAL);
+	EXPECT_THAT(medium.hGlobal, AnsiStringInGlobalMemory("abc"s));
+}
 
 } //namespace ole
+


### PR DESCRIPTION
### 概要
#2453 で作成してた`CDataObject`（OLE ドラッグ＆ドロップのデータ提供元）に対するユニットテストを 3 件追加です。テストのみの追加です。

### 背景

#2557 で `SAKURAClipW` 形式の長さフィールドが `int32_t` 固定に統一され、`CClipboard::SetText` / `CClipboard::GetText` については手厚くテストが追加されました。

一方、同じ形式を書き出している `CDataObject::SetText` 側にはテストが追加されていません。既存の `CopiedTextData` テスト群（9 件）を確認したところ、

- すべて `bColumnSelect = FALSE` で `CDataObject` を構築している
- 取得している形式は `CF_UNICODETEXT` のみ

という状態で、**サクラ独自形式のペイロードを検証しているテストも、矩形選択ありの経路を通るテストも 1 件も存在しません**。

#2557 の `CDataObject::SetText` は、長さフィールドの型変更だけでなく、フォーマット数の算出とインデックスの進め方も変更しています。

```cpp
m_nFormat = 2 + (bSakuraFormat? 1: 0) + (bColumnSelect? 1: 0);
...
if( bSakuraFormat ){ i++; ... }
if( bColumnSelect ){ i++; ... }   // i++ が if の内側へ移動した
```

`i++` が `if` の内側に入ったため、条件の組み合わせによってはインデックスがずれ、未初期化の `DATA` を返す形の壊れ方をし得ます。現状これを検出できるテストが無いため、回帰テストとして追加します。

なお、既存の `EnumFormatEtc001` はフォーマット数が 3 であることを確認していますが、`bColumnSelect = FALSE` かつ短い文字列という条件では #2557 の前後で値が変わらないため、この変更に対する検出力はありません。

### 変更内容

`src/test/cpp/tests1/test-cclipboard.cpp` に以下 3 件のテストを追加します。

| テスト名 | 検証内容 |
| --- | --- |
| `CopiedTextData.SetTextColumnSelect` | 矩形選択ありのときフォーマット数が 4 になること。`MSDEVColumnSelect` 形式が取得でき、1 バイトの 0 が格納されていること |
| `CopiedTextData.GetDataSakuraFormatLayout` | サクラ独自形式のバイナリレイアウト（先頭 4 バイトが文字数、続いて本文の `wchar_t` 列）が正しいこと |
| `CopiedTextData.GetDataAnsiText` | `CF_TEXT` 形式が取得でき、ANSI 変換された文字列が格納されていること |

いずれも #2557 で追加された既存のマッチャ（`SakuraFormatLayoutInGlobalMemory` / `ByteValueInGlobalMemory` / `AnsiStringInGlobalMemory`）を再利用しており、新規ヘルパの追加はありません。

### 確認方法

`tests1` の CI がグリーンになることで確認します。

### 補足

`GetDataSakuraFormatLayout` では、あえて `cxx::GlobalSakura` を使わずバイト列を直接検証しています。理由は以下のとおりです。

- `CClipboard::SetText` は終端ヌルを書き込む → サイズは `4 + (文字数 + 1) * 2`
- `CDataObject::SetText` は終端ヌルを書き込まない → サイズは `4 + 文字数 * 2`
- `cxx::GlobalSakura::wstring()` は `cbSize >= 4 + (length + 1) * sizeof(WCHAR)` を満たさない場合に空文字列を返す実装

このため `cxx::GlobalSakura` で `CDataObject` の出力をラップすると、無条件で空文字列が返り、テストが常に失敗します。この終端ヌルの有無の非対称は #2557 で導入されたものではなく従来からの仕様なので、本 PR では現状の仕様に合わせた検証を行っています。


