### PR TITLE
CIテストが無応答になり終了しない問題に対策する

### DIFF
--- a/.github/workflows/build-on-msys2.yml
+++ b/.github/workflows/build-on-msys2.yml
@@ -45,7 +45,9 @@ jobs:
           submodules: true
 
       - name: Install OpenCppCoverage (winget)
+        id: install_opencppcoverage_winget
         if: ${{ env.Configuration == 'Debug' }}
+        continue-on-error: true
         run: |
           winget install `
             --id OpenCppCoverage.OpenCppCoverage `
@@ -53,6 +55,26 @@ jobs:
             --accept-package-agreements `
             --accept-source-agreements
         shell: pwsh
+
+      # wingetは失敗することがあるので、インストーラー方式も残しておく。
+      - name: Install OpenCppCoverage (installer)
+        if: ${{ env.Configuration == 'Debug' && steps.install_opencppcoverage_winget.outcome == 'failure' }}
+        working-directory: ${{ runner.temp }}
+        run: |
+          $installer = '.\OpenCppCoverageSetup.exe'
+          Invoke-WebRequest `
+            -Uri "https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/release-0.9.9.0/OpenCppCoverageSetup-x64-0.9.9.0.exe" `
+            -OutFile $installer
+          $expectedSha256 = '2295a733da39412c61e4f478677519dd0bb1893d88313ce56b468c9e50517888'
+          $actualSha256 = (Get-FileHash $installer -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualSha256 -ne $expectedSha256.ToLowerInvariant()) {
+            throw "SHA256 mismatch: expected=$expectedSha256 actual=$actualSha256"
+          }
+          Start-Process `
+            -FilePath $installer `
+            -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES" `
+            -Wait
+          echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
 
       - name: Set up MSYS2
         uses: msys2/setup-msys2@v2
@@ -135,7 +157,7 @@ jobs:
             --args ./tests1.exe --gtest_repeat=100 --gtest_throw_on_failure
 
       - name: Mark workflow failed when unit tests fail
-        if: steps.run_unit_tests.outcome == 'failure' && env.Configuration != 'Release'
+        if: steps.run_unit_tests.outcome == 'failure'
         run: |
           echo "Unit tests failed. See the gdb trace above."
           exit 1

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -334,7 +334,8 @@ jobs:
           -Wait
         echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
 
-    - name: Install Ctags (winget)
+    - name: Install CTags (winget)
+      continue-on-error: true
       run: |
         winget install `
           --id UniversalCtags.Ctags `

--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -344,6 +344,7 @@ jobs:
           --accept-source-agreements
 
     - name: Install DiffUtils (winget)
+      continue-on-error: true
       run: |
         winget install `
           --id GnuWin32.DiffUtils `

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -101,7 +101,7 @@ void SelectOpenFileFromFolder(
 	sLoadInfo.eCharCode = CODE_AUTODETECT;	// 文字コード自動判別
 	sLoadInfo.bViewMode = false;
 
-	CDlgOpenFile cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	cDlgOpenFile.Create(
 		unusedArg1,
 		nullptr,

--- a/sakura_core/cmd/CViewCommander.h
+++ b/sakura_core/cmd/CViewCommander.h
@@ -328,7 +328,7 @@ public:
 	/* マクロ系 */
 	void Command_RECKEYMACRO( void );	/* キーマクロの記録開始／終了 */
 	void Command_SAVEKEYMACRO( void );	/* キーマクロの保存 */
-	void Command_LOADKEYMACRO( void );	/* キーマクロの読み込み */
+	void Command_LOADKEYMACRO() const;	/* キーマクロの読み込み */
 	void Command_EXECKEYMACRO( void );	/* キーマクロの実行 */
 	void Command_EXECEXTMACRO( const WCHAR* path, const WCHAR* type );	/* 名前を指定してマクロ実行 */
 //	From Here 2006.12.03 maru 引数の拡張．

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -90,14 +90,14 @@ void CViewCommander::Command_SAVEKEYMACRO( void )
 
 	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	WCHAR			szPath[_MAX_PATH + 1];
-	WCHAR			szInitDir[_MAX_PATH + 1];
+	SFilePath szInitDir;
 	szPath[0] = L'\0';
 	// 2003.06.23 Moca 相対パスは実行ファイルからのパス
 	// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
 	if( _IS_REL_PATH( GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER ) ){
 		GetInidirOrExedir( szInitDir, GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER );
 	}else{
-		wcscpy( szInitDir, GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER );	/* マクロ用フォルダー */
+		szInitDir = GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER.c_str();	/* マクロ用フォルダー */
 	}
 	/* ファイルオープンダイアログの初期化 */
 	cDlgOpenFile.Create(
@@ -126,14 +126,14 @@ void CViewCommander::Command_SAVEKEYMACRO( void )
 /*! キーマクロの読み込み
 	@date 2005.02.20 novice デフォルトの拡張子変更
  */
-void CViewCommander::Command_LOADKEYMACRO( void )
+void CViewCommander::Command_LOADKEYMACRO() const
 {
 	GetDllShareData().m_sFlags.m_bRecordingKeyMacro = FALSE;
 	GetDllShareData().m_sFlags.m_hwndRecordingKeyMacro = nullptr;	/* キーボードマクロを記録中のウィンドウ */
 
 	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
-	WCHAR			szPath[_MAX_PATH + 1];
-	WCHAR			szInitDir[_MAX_PATH + 1];
+	SFilePath szPath;
+	SFilePath szInitDir;
 	const WCHAR*		pszFolder;
 	szPath[0] = L'\0';
 	pszFolder = GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER;
@@ -142,7 +142,7 @@ void CViewCommander::Command_LOADKEYMACRO( void )
 	if( _IS_REL_PATH( pszFolder ) ){
 		GetInidirOrExedir( szInitDir, pszFolder );
 	}else{
-		wcscpy( szInitDir, pszFolder );	/* マクロ用フォルダー */
+		szInitDir = pszFolder;	/* マクロ用フォルダー */
 	}
 	/* ファイルオープンダイアログの初期化 */
 	cDlgOpenFile.Create(
@@ -159,7 +159,7 @@ void CViewCommander::Command_LOADKEYMACRO( void )
 
 	/* キーボードマクロの読み込み */
 	//@@@ 2002.1.24 YAZAKI 読み込みといいつつも、ファイル名をコピーするだけ。実行直前に読み込む
-	wcscpy(GetDllShareData().m_Common.m_sMacro.m_szKeyMacroFileName, szPath);
+	::wcscpy_s(GetDllShareData().m_Common.m_sMacro.m_szKeyMacroFileName, szPath);
 //	GetDllShareData().m_CKeyMacroMgr.LoadKeyMacro( G_AppInstance(), m_pCommanderView->GetHwnd(), szPath );
 	return;
 }
@@ -206,8 +206,8 @@ void CViewCommander::Command_EXECKEYMACRO( void )
 void CViewCommander::Command_EXECEXTMACRO( const WCHAR* pszPath, const WCHAR* pszType )
 {
 	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
-	WCHAR			szPath[_MAX_PATH + 1];
-	WCHAR			szInitDir[_MAX_PATH + 1];	//ファイル選択ダイアログの初期フォルダー
+	SFilePath szPath;
+	SFilePath szInitDir;
 	const WCHAR*	pszFolder;					//マクロフォルダー
 	HWND			hwndRecordingKeyMacro = nullptr;
 
@@ -251,13 +251,13 @@ void CViewCommander::Command_EXECEXTMACRO( const WCHAR* pszPath, const WCHAR* ps
 	//古い一時マクロの退避
 	CMacroManagerBase* oldMacro = m_pcSMacroMgr->SetTempMacro( nullptr );
 
-	BOOL bLoadResult = m_pcSMacroMgr->Load(
+	if (const auto bLoadResult = m_pcSMacroMgr->Load(
 		TEMP_KEYMACRO,
 		G_AppInstance(),
 		pszPath,
 		pszType
 	);
-	if ( !bLoadResult ){
+		!bLoadResult) {
 		ErrorMessage( m_pCommanderView->GetHwnd(), LS(STR_ERR_MACROERR1), pszPath );
 	}
 	else {

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -88,7 +88,7 @@ void CViewCommander::Command_SAVEKEYMACRO( void )
 		ErrorMessage( m_pCommanderView->GetHwnd(), LS(STR_ERR_CEDITVIEW_CMD26) );
 	}
 
-	CDlgOpenFile	cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	WCHAR			szPath[_MAX_PATH + 1];
 	WCHAR			szInitDir[_MAX_PATH + 1];
 	szPath[0] = L'\0';
@@ -131,7 +131,7 @@ void CViewCommander::Command_LOADKEYMACRO( void )
 	GetDllShareData().m_sFlags.m_bRecordingKeyMacro = FALSE;
 	GetDllShareData().m_sFlags.m_hwndRecordingKeyMacro = nullptr;	/* キーボードマクロを記録中のウィンドウ */
 
-	CDlgOpenFile	cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	WCHAR			szPath[_MAX_PATH + 1];
 	WCHAR			szInitDir[_MAX_PATH + 1];
 	const WCHAR*		pszFolder;
@@ -205,7 +205,7 @@ void CViewCommander::Command_EXECKEYMACRO( void )
  */
 void CViewCommander::Command_EXECEXTMACRO( const WCHAR* pszPath, const WCHAR* pszType )
 {
-	CDlgOpenFile	cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	WCHAR			szPath[_MAX_PATH + 1];
 	WCHAR			szInitDir[_MAX_PATH + 1];	//ファイル選択ダイアログの初期フォルダー
 	const WCHAR*	pszFolder;					//マクロフォルダー

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -117,7 +117,7 @@ BOOL CDlgDiff::OnBnClicked( int wID )
 
 	case IDC_BUTTON_DIFF_DST:	/* 参照 */
 		{
-			CDlgOpenFile	cDlgOpenFile;
+			auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 			WCHAR			szPath[_MAX_PATH];
 			wcscpy( szPath, m_szFile2 );
 			/* ファイルオープンダイアログの初期化 */

--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -239,7 +239,7 @@ BOOL CDlgExec::OnBnClicked( int wID )
 	//From Here Mar. 28, 2001 JEPRO
 	case IDC_BUTTON_REFERENCE:	/* ファイル名の「参照...」ボタン */
 		{
-			CDlgOpenFile	cDlgOpenFile;
+			auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 			WCHAR			szPath[_MAX_PATH + 1];
 			wcsncpy_s(szPath, m_szCommand, _TRUNCATE);
 			/* ファイルオープンダイアログの初期化 */

--- a/sakura_core/dlg/CDlgOpenFile.cpp
+++ b/sakura_core/dlg/CDlgOpenFile.cpp
@@ -83,7 +83,7 @@ BOOL CDlgOpenFile::SelectFile(
 	bool resolvePath,
 	EFilter eAddFilter)
 {
-	CDlgOpenFile cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	WCHAR			szFilePath[_MAX_PATH + 1];
 	WCHAR			szPath[_MAX_PATH + 1];
 	::GetWindowText( hwndCtl, szFilePath, int(std::size(szFilePath)) );

--- a/sakura_core/dlg/CDlgOpenFile.h
+++ b/sakura_core/dlg/CDlgOpenFile.h
@@ -86,12 +86,12 @@ public:
 
 /*!	ファイルオープンダイアログボックス
 */
-class CDlgOpenFile final : public IDlgOpenFile
+class CDlgOpenFile : public TSakuraSingleton<CDlgOpenFile>, public IDlgOpenFile
 {
 public:
 	//コンストラクタ・デストラクタ
 	CDlgOpenFile();
-	~CDlgOpenFile() = default;
+	virtual ~CDlgOpenFile() = default;
 
 	void Create(
 		HINSTANCE					hInstance,

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -78,16 +78,16 @@ struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
 
 	void DlgOpenFail(void);
 
-	void InitOfn( OPENFILENAME* ofn );
+	void InitOfn(OPENFILENAME* ofn) const;
 
 	static void InitLayout( HWND hwndOpenDlg, HWND hwndDlg, HWND hwndBaseCtrl );
 	static LRESULT APIENTRY OFNHookProcMain( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam , UINT_PTR uIdSubclass, DWORD_PTR dwRefData );
 	static UINT_PTR CALLBACK OFNHookProc( HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam );
 
 	//! リトライ機能付き GetOpenFileName
-	bool _GetOpenFileNameRecover( OPENFILENAME* ofn );
+	bool _GetOpenFileNameRecover(OPENFILENAME* ofn) const;
 	//! リトライ機能付き GetOpenFileName
-	bool GetSaveFileNameRecover( OPENFILENAME* ofn );
+	bool GetSaveFileNameRecover(OPENFILENAME* ofn) const;
 
 	HINSTANCE		m_hInstance = nullptr;	/* アプリケーションインスタンスのハンドル */
 	HWND			m_hwndParent = nullptr;	/* オーナーウィンドウのハンドル */
@@ -469,7 +469,7 @@ UINT_PTR CALLBACK CDlgOpenFile_CommonFileDialog::OFNHookProc(
 			{
 				wchar_t szFolder[_MAX_PATH];
 				CDlgOpenFileData* pData = (CDlgOpenFileData*)::GetWindowLongPtr(hdlg, DWLP_USER);
-				lRes = CommDlg_OpenSave_GetFolderPath( pData->m_hwndOpenDlg, szFolder, int(std::size(szFolder)) );
+				CommDlg_OpenSave_GetFolderPath( pData->m_hwndOpenDlg, szFolder, int(std::size(szFolder)) );
 			}
 //			MYTRACE( L"\tlRes=%d\pszFolder=[%ls]\n", lRes, szFolder );
 
@@ -1119,7 +1119,7 @@ void CDlgOpenFile_CommonFileDialog::DlgOpenFail(void)
 	@author ryoji
 	@date 2005.10.29
 */
-void CDlgOpenFile_CommonFileDialog::InitOfn( OPENFILENAME* ofn )
+void CDlgOpenFile_CommonFileDialog::InitOfn(OPENFILENAME* ofn) const
 {
 	memset_raw(ofn, 0, sizeof(*ofn));
 
@@ -1206,7 +1206,7 @@ void CDlgOpenFile_CommonFileDialog::InitLayout( HWND hwndOpenDlg, HWND hwndDlg, 
 	@author Moca
 	@date 2006.09.03 新規作成
 */
-bool CDlgOpenFile_CommonFileDialog::_GetOpenFileNameRecover( OPENFILENAME* ofn )
+bool CDlgOpenFile_CommonFileDialog::_GetOpenFileNameRecover(OPENFILENAME* ofn) const
 {
 	BOOL bRet = ::GetOpenFileName( ofn );
 	if( !bRet  ){
@@ -1223,7 +1223,7 @@ bool CDlgOpenFile_CommonFileDialog::_GetOpenFileNameRecover( OPENFILENAME* ofn )
 	@author Moca
 	@date 2006.09.03 新規作成
 */
-bool CDlgOpenFile_CommonFileDialog::GetSaveFileNameRecover( OPENFILENAME* ofn )
+bool CDlgOpenFile_CommonFileDialog::GetSaveFileNameRecover(OPENFILENAME* ofn) const
 {
 	BOOL bRet = ::GetSaveFileName( ofn );
 	if( !bRet  ){

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -67,7 +67,7 @@ bool CDocFileOperation::OpenFileDialog(
 	const WCHAR*		pszOpenFolder,	//!< [in]     NULL以外を指定すると初期フォルダーを指定できる
 	SLoadInfo*			pLoadInfo,		//!< [in,out] ロード情報
 	std::vector<std::wstring>&	files
-)
+) const
 {
 	/* アクティブにする */
 	ActivateFrameWindow( hwndParent );
@@ -203,7 +203,7 @@ void CDocFileOperation::ReloadCurrentFile(
 */
 bool CDocFileOperation::SaveFileDialog(
 	SSaveInfo*	pSaveInfo	//!< [out]
-)
+) const
 {
 	//拡張子指定
 	// 一時適用や拡張子なしの場合の拡張子をタイプ別設定から持ってくる
@@ -297,9 +297,9 @@ bool CDocFileOperation::DoSaveFlow(SSaveInfo* pSaveInfo)
 		// ### 無変更なら上書きしないで抜ける処理はどの CDocListener の OnCheckSave() よりも前に
 		// ### （保存するかどうか問い合わせたりするよりも前に）やるぺきことなので、
 		// ### スマートじゃない？かもしれないけど、とりあえずここに配置しておく
-		if( !GetDllShareData().m_Common.m_sFile.m_bEnableUnmodifiedOverwrite ){
+		if (!GetDllShareData().m_Common.m_sFile.m_bEnableUnmodifiedOverwrite &&
 			// 上書きの場合
-			if(pSaveInfo->bOverwriteMode){
+			pSaveInfo->bOverwriteMode) {
 				// 無変更の場合は警告音を出し、終了
 				if (!m_pcDocRef->m_cDocEditor.IsModified() &&
 					pSaveInfo->cEol.IsNone() &&	//※改行コード指定保存がリクエストされた場合は、「変更があったもの」とみなす
@@ -307,7 +307,7 @@ bool CDocFileOperation::DoSaveFlow(SSaveInfo* pSaveInfo)
 					CEditApp::getInstance()->m_cSoundSet.NeedlessToSaveBeep();
 					throw CFlowInterruption();
 				}
-			}
+
 		}
 
 		//セーブ前チェック

--- a/sakura_core/doc/CDocFileOperation.cpp
+++ b/sakura_core/doc/CDocFileOperation.cpp
@@ -73,7 +73,7 @@ bool CDocFileOperation::OpenFileDialog(
 	ActivateFrameWindow( hwndParent );
 
 	// ファイルオープンダイアログを表示
-	CDlgOpenFile cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	cDlgOpenFile.Create(
 		G_AppInstance(),
 		hwndParent,
@@ -260,7 +260,7 @@ bool CDocFileOperation::SaveFileDialog(
 	}
 
 	// ダイアログを表示
-	CDlgOpenFile cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	cDlgOpenFile.Create(
 		G_AppInstance(),
 		CEditWnd::getInstance()->GetHwnd(),

--- a/sakura_core/doc/CDocFileOperation.h
+++ b/sakura_core/doc/CDocFileOperation.h
@@ -29,7 +29,7 @@ public:
 		const WCHAR*		pszOpenFolder,	//!< [in]  NULL以外を指定すると初期フォルダーを指定できる
 		SLoadInfo*			pLoadInfo,		//!< [in,out] ロード情報
 		std::vector<std::wstring>&	files
-	);
+	) const;
 
 	//ロードフロー
 	bool DoLoadFlow(SLoadInfo* pLoadInfo);
@@ -44,7 +44,7 @@ public:
 	);
 
 	//セーブUI
-	bool SaveFileDialog(SSaveInfo* pSaveInfo);	//!<「ファイル名を付けて保存」ダイアログ
+	bool SaveFileDialog(SSaveInfo* pSaveInfo) const;	//!<「ファイル名を付けて保存」ダイアログ
 	bool SaveFileDialog(LPWSTR szPath);			//!<「ファイル名を付けて保存」ダイアログ
 
 	//セーブフロー

--- a/sakura_core/doc/CDocTypeSetting.h
+++ b/sakura_core/doc/CDocTypeSetting.h
@@ -17,27 +17,28 @@
 
 //! フォント属性
 struct SFontAttr{
-	bool		m_bBoldFont;		//!< 太字
-	bool		m_bUnderLine;		//!< 下線
+	bool		m_bBoldFont = false;		//!< 太字
+	bool		m_bUnderLine = false;		//!< 下線
 };
 
 //! 色属性
 struct SColorAttr{
-	COLORREF	m_cTEXT;			//!< 文字色
-	COLORREF	m_cBACK;			//!< 背景色
+	COLORREF	m_cTEXT = 0;			//!< 文字色
+	COLORREF	m_cBACK = 0;			//!< 背景色
 };
 
 //! 色設定
 struct ColorInfoBase{
-	bool		m_bDisp;			//!< 表示
+	bool		m_bDisp = false;			//!< 表示
 	SFontAttr	m_sFontAttr;		//!< フォント属性
 	SColorAttr	m_sColorAttr;		//!< 色属性
 };
 
 //! 名前とインデックス付き色設定
 struct ColorInfo : public ColorInfoBase{
-	int			m_nColorIdx;		//!< インデックス
-	WCHAR		m_szName[64];		//!< 名前
+	using SName = StaticString<64>;
+	int			m_nColorIdx = 0;		//!< インデックス
+	SName		m_szName;				//!< 名前
 };
 
 //デフォルト色設定
@@ -51,9 +52,11 @@ int		GetDefaultColorInfoCount() noexcept;
 //@@@ 2006.04.10 fon ADD-start
 const int DICT_ABOUT_LEN = 50; /*!< 辞書の説明の最大長 -1 */
 struct KeyHelpInfo {
-	bool		m_bUse;						//!< 辞書を 使用する/しない
-	WCHAR		m_szAbout[DICT_ABOUT_LEN];	//!< 辞書の説明(辞書ファイルの1行目から生成)
+	using SAbout = StaticString<DICT_ABOUT_LEN>;
+	bool		m_bUse = false;				//!< 辞書を 使用する/しない
+	SAbout		m_szAbout;					//!< 辞書の説明(辞書ファイルの1行目から生成)
 	SFilePath	m_szPath;					//!< ファイルパス
 };
 //@@@ 2006.04.10 fon ADD-end
+
 #endif /* SAKURA_CDOCTYPESETTING_87013082_2E52_4683_8CEE_499218F2D584_H_ */

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1865,7 +1865,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, VARIANT *Argument
 				return false;
 			}
 
-			CDlgOpenFile cDlgOpenFile;
+			auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 			cDlgOpenFile.Create(
 				G_AppInstance(), View->GetHwnd(),
 				sFilter.c_str(),

--- a/sakura_core/prop/CPropComPlugin.cpp
+++ b/sakura_core/prop/CPropComPlugin.cpp
@@ -162,7 +162,7 @@ INT_PTR CPropPlugin::DispatchEvent( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPAR
 			case IDC_PLUGIN_INST_ZIP:		// ZIPプラグインを追加
 				{
 					static std::wstring	sTrgDir;
-					CDlgOpenFile	cDlgOpenFile;
+					auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 					WCHAR			szPath[_MAX_PATH + 1];
 					wcscpy( szPath, (sTrgDir.empty() ? CPluginManager::getInstance()->GetBaseDir().c_str() : sTrgDir.c_str()));
 					// ファイルオープンダイアログの初期化

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -109,7 +109,7 @@ static wchar_t* MakeExportFileName(wchar_t* res, const wchar_t* trg, const wchar
 bool CImpExpManager::ImportUI( HINSTANCE hInstance, HWND hwndParent )
 {
 	/* ファイルオープンダイアログの初期化 */
-	CDlgOpenFile	cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	cDlgOpenFile.Create(
 		hInstance,
 		hwndParent,
@@ -156,7 +156,7 @@ bool CImpExpManager::ImportUI( HINSTANCE hInstance, HWND hwndParent )
 bool CImpExpManager::ExportUI( HINSTANCE hInstance, HWND hwndParent )
 {
 	/* ファイルオープンダイアログの初期化 */
-	CDlgOpenFile	cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	cDlgOpenFile.Create(
 		hInstance,
 		hwndParent,

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -853,7 +853,7 @@ bool CImpExpKeyHelp::Export( const std::wstring& sFileName, std::wstring& sErrMs
 			L"KDct[%02d]=%d,%s,%s\n",
 			i,
 			m_Types.m_KeyHelpArr[i].m_bUse?1:0,
-			m_Types.m_KeyHelpArr[i].m_szAbout,
+			m_Types.m_KeyHelpArr[i].m_szAbout.c_str(),
 			m_Types.m_KeyHelpArr[i].m_szPath.c_str()
 		);
 	}

--- a/sakura_core/types/CType.h
+++ b/sakura_core/types/CType.h
@@ -213,8 +213,8 @@ struct STypeConfig{
 //@@@ 2001.11.17 add start MIK
 	bool				m_bUseRegexKeyword;								//!< 正規表現キーワードを使うか
 	DWORD				m_nRegexKeyMagicNumber;							//!< 正規表現キーワード更新マジックナンバー
-	RegexKeywordInfo	m_RegexKeywordArr[MAX_REGEX_KEYWORD];			//!< 正規表現キーワード
-	wchar_t				m_RegexKeywordList[MAX_REGEX_KEYWORDLISTLEN];	//!< 正規表現キーワード
+	RegexKeywordInfo	m_RegexKeywordArr[MAX_REGEX_KEYWORD]{};			//!< 正規表現キーワード
+	wchar_t				m_RegexKeywordList[MAX_REGEX_KEYWORDLISTLEN]{};	//!< 正規表現キーワード
 //@@@ 2001.11.17 add end MIK
 
 //@@@ 2006.04.10 fon ADD-start
@@ -237,7 +237,7 @@ struct STypeConfig{
 	bool				m_bUseDocumentIcon;				//!< ファイルに関連づけられたアイコンを使う
 
 	bool				m_bUseTypeFont;					//!< タイプ別フォントの使用
-	LOGFONT				m_lf;							//!< フォント // 2013.03.18 aroka
+	LOGFONT				m_lf{};							//!< フォント // 2013.03.18 aroka
 	INT					m_nPointSize;					//!< フォントサイズ（1/10ポイント単位）
 
 	STypeConfig()

--- a/sakura_core/util/design_template.h
+++ b/sakura_core/util/design_template.h
@@ -114,6 +114,12 @@ public:
 	template <class U>
 	static void setInstance()
 	{
+		static_assert(
+			std::has_virtual_destructor_v<T> &&
+			std::is_nothrow_destructible_v<T>,
+			"T must have a virtual noexcept destructor"
+		);
+
 		std::unique_lock lock{ gm_Mutex };
 
 		gm_Instance = std::make_unique<U>();

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -155,8 +155,8 @@ void ActivateFrameWindow( HWND hwnd )
 {
 	// 編集ウィンドウでタブまとめ表示の場合は表示位置を復元する
 	DLLSHAREDATA* pShareData = &GetDllShareData();
-	if( pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin ) {
-		if( IsSakuraMainWindow( hwnd ) ){
+	if (pShareData->m_Common.m_sTabBar.m_bDispTabWnd && !pShareData->m_Common.m_sTabBar.m_bDispTabWndMultiWin &&
+		IsSakuraMainWindow(hwnd)) {
 			if( pShareData->m_sFlags.m_bEditWndChanging )
 				return;	// 切替の最中(busy)は要求を無視する
 			pShareData->m_sFlags.m_bEditWndChanging = TRUE;	// 編集ウィンドウ切替中ON	2007.04.03 ryoji
@@ -172,7 +172,7 @@ void ActivateFrameWindow( HWND hwnd )
 				10000,
 				&dwResult
 			);
-		}
+
 	}
 
 	// 対象がdisableのときは最近のポップアップをフォアグラウンド化する

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -294,6 +294,26 @@ int GetUpDownPos(HWND hWndDlg, int nIDDlgItem)
 }
 
 /*!
+ * @brief ウィンドウのテキストを取得する
+ */
+SGetTextResult GetWindowTextW(HWND hWnd)
+{
+	// 必要な文字数を確認する
+	const auto cchRequired = ::GetWindowTextLengthW(hWnd);
+	if (!cchRequired) return SGetTextResult{ std::wstring() };
+
+	// バッファを確保する
+	std::wstring buffer(cchRequired, L'\0');
+
+	// 文字列を取得する
+	const auto actualCopied = ::GetWindowTextW(hWnd, std::data(buffer), cchRequired + 1);
+	buffer.resize(actualCopied);
+
+	// バッファを所有権ごと呼出元に返す
+	return SGetTextResult{ std::move(buffer) };
+}
+
+/*!
  * @brief ボタンがチェックされているか調べる
  *
  * チェックボタンまたはラジオボタンのチェック状態を確認する

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -145,6 +145,8 @@ void	SetUpDownPos(HWND hWndDlg, int nIDDlgItem, WORD pos);
 SGetTextResult	GetDlgItemTextW(HWND hWndDlg, int nIDDlgItem);
 SGetTextResult	GetDlgItemTextW(HWND hWndDlg, int nIDDlgItem, std::span<WCHAR> buffer);
 
+SGetTextResult	GetWindowTextW(HWND hWnd);
+
 bool	SetDlgItemTextW(HWND hWndDlg, int nIDDlgItem, std::wstring_view text);
 
 /*!

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -642,7 +642,7 @@ public:
 
 public:
 	//ウィンドウ
-	HWND			m_hwndParent;		/* 親ウィンドウハンドル */
+	HWND			m_hwndParent = nullptr;		/* 親ウィンドウハンドル */
 	HWND			m_hwndVScrollBar = nullptr;	/* 垂直スクロールバーウィンドウハンドル */
 	int				m_nVScrollRate;		/* 垂直スクロールバーの縮尺 */
 	HWND			m_hwndHScrollBar = nullptr;	/* 水平スクロールバーウィンドウハンドル */
@@ -742,7 +742,7 @@ public:
 
 	// IME
 private:
-	HWND			m_hWnd;
+	HWND			m_hWnd = nullptr;
 	int				m_nLastReconvLine;             //2002.04.09 minfu 再変換情報保存用;
 	int				m_nLastReconvIndex;            //2002.04.09 minfu 再変換情報保存用;
 

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
@@ -7,9 +7,95 @@
 #include "pch.h"
 #include "dlg/ModalDialogCloser.hpp"
 
+#include "cxx/load_string.hpp"
 #include "doc/CDocListener.h"
 
+namespace window {
+
+std::wstring GetClassNameW(_In_ HWND hWnd)
+{
+	// ウィンドウハンドルが有効かどうかチェックする
+	if (!IsWindow(hWnd)) return {};
+
+	// クラス名を受け取るバッファ配列を用意する
+	constexpr auto maxWindowClassName = 256;
+	std::array<wchar_t, maxWindowClassName + 1> buffer{};
+
+	// APIを呼び出してクラス名を取得する
+	const auto actual = ::GetClassNameW(hWnd, std::data(buffer), int(std::size(buffer)));
+	if (actual <= 0) return {};
+
+	// バッファと文字列長からstd::wstringを生成して返す
+	return std::wstring(std::data(buffer), static_cast<size_t>(actual));
+}
+
+bool IsDialog(_In_ HWND hWnd, _In_opt_ LPCWSTR pClassName)
+{
+	if (pClassName && IS_INTRESOURCE(pClassName) && WC_DIALOG == pClassName) return true;
+
+	const auto DIALOG_CLASS = std::format(L"#{:d}", LOWORD(WC_DIALOG));
+	return DIALOG_CLASS == window::GetClassNameW(hWnd);
+}
+
+} // namespace window
+
 namespace dialog {
+
+bool ModalDialogCloser::ExecuteAction(HWND hWnd) noexcept
+{
+	Me* entry = nullptr;
+	if (hWnd) {
+		std::unique_lock lock{ gm_Mutex };
+
+		const auto found = gm_HwndMap.find(hWnd);
+		if (found == gm_HwndMap.end()) return false;
+
+		entry = found->second;
+
+		::KillTimer(hWnd, TIMER_ID_FIRST_IDLE);
+		entry->m_TimerActive = false;
+
+		entry->m_State = State::Running;
+
+		gm_HwndMap.erase(found);
+	}
+
+	try {
+		if (entry) {
+			entry->m_Action(hWnd);
+
+			entry->m_State = State::Handled;
+
+			return true;
+		}
+	}
+	catch (...) {
+		std::unique_lock lock{ gm_Mutex };
+
+		const auto exception = std::current_exception();
+		if (entry) {
+			entry->m_Exception = exception;
+			entry->m_State = State::Failed;
+		}
+
+		try {
+			std::rethrow_exception(exception);
+		}
+		catch (const std::exception& e) {
+			std::clog << "ModalDialogCloser action failed: " << e.what() << std::endl;
+		}
+		catch (...) {
+			std::clog << "ModalDialogCloser action failed with an unknown exception." << std::endl;
+		}
+	}
+
+	return false;
+}
+
+void CALLBACK ModalDialogCloser::TimerProc(HWND hWnd, UINT, UINT_PTR idEvent, DWORD)
+{
+	ExecuteAction(hWnd);
+}
 
 /*!
  * CBTフックプロシージャ
@@ -22,48 +108,145 @@ LRESULT CALLBACK ModalDialogCloser::CBTProc(
   _In_ LPARAM lParam
 )
 {
-	static HWND hWnd = nullptr;
+	const auto hWnd = std::bit_cast<HWND>(wParam);
 
 	// ダイアログボックスの作成イベントを捕捉する
 	if (const auto pCreateWnd = LPCBT_CREATEWND(lParam);
 		HCBT_CREATEWND == nCode &&
 		pCreateWnd &&
 		pCreateWnd->lpcs &&
-		IS_INTRESOURCE(pCreateWnd->lpcs->lpszClass) &&
-		DIALOG_CLASS == LOWORD(pCreateWnd->lpcs->lpszClass))
+		window::IsDialog(hWnd, pCreateWnd->lpcs->lpszClass))
 	{
-		hWnd = std::bit_cast<HWND>(wParam);
-	}
-	else if (HCBT_ACTIVATE == nCode && hWnd == std::bit_cast<HWND>(wParam)) {
-		auto pThis = getInstance();
-		pThis->m_Action(hWnd);
-	}
-	else if (HCBT_DESTROYWND == nCode && hWnd == std::bit_cast<HWND>(wParam)) {
-		hWnd = nullptr;
-	}
+		std::unique_lock lock{ gm_Mutex };
 
-	return ::CallNextHookEx(gm_CbtHook, nCode, wParam, lParam);
+		if (!gm_Entries.empty())
+		{
+			const auto& entry = gm_Entries.front();
+			if (const auto pDialogTitle = pCreateWnd->lpcs->lpszName;
+				!entry->m_DialogTitle.has_value() ||
+				(pDialogTitle && !IS_INTRESOURCE(pDialogTitle) && *entry->m_DialogTitle == pDialogTitle)) {
+				entry->m_State = State::Created;
+				entry->m_hWnd = hWnd;
+
+				// ウィンドウハンドル監視エントリを入れる
+				gm_HwndMap.try_emplace(hWnd, entry);
+
+				// タイトル監視エントリを除去する
+				gm_Entries.pop_front();
+
+				// タイマーをセットする
+				entry->m_TimerActive = 0 != ::SetTimer(hWnd, TIMER_ID_FIRST_IDLE, FALLBACK_DELAY_MILLIS, &TimerProc);
+			}
+		}
+	}
+	else if (HCBT_ACTIVATE == nCode)
+	{
+		if (ExecuteAction(hWnd)) {
+			std::unique_lock lock{ gm_Mutex };
+
+			if (gm_Entries.empty() && gm_HwndMap.empty()) {
+				const auto ret = ::CallNextHookEx(nullptr, nCode, wParam, lParam);
+				CbtHookHolder hook = std::move(gm_CbtHook);
+				return ret;
+			}
+		}
+	}
+	return ::CallNextHookEx(nullptr, nCode, wParam, lParam);
 }
 
-/* static */ void ModalDialogCloser::CloseDialogByCancel(HWND hWndDlg)
+ModalDialogCloser::ModalDialogCloser(
+	const std::optional<std::wstring>& optTitle,
+	const std::function<void(HWND)>& action
+)
+	: m_DialogTitle(optTitle)
+	, m_Action(action)
 {
-	::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDCANCEL, BN_CLICKED), 0);
+	std::unique_lock lock{ gm_Mutex };
+
+	gm_Entries.emplace_back(this);
+
+	if (!gm_CbtHook) {
+
+		::SetLastError(ERROR_SUCCESS);
+		gm_CbtHook = ::SetWindowsHookExW(WH_CBT, &CBTProc, nullptr, ::GetCurrentThreadId());
+		if (!gm_CbtHook) {
+			m_HookError = ::GetLastError();
+		}
+	}
 }
 
-ModalDialogCloser::ModalDialogCloser(const std::function<void(HWND)>& action) noexcept
-	: m_Action(action)
+ModalDialogCloser::ModalDialogCloser(int dialogTitleResourceId, const std::function<void(HWND)>& action)
+	: ModalDialogCloser(std::wstring{ cxx::load_string(dialogTitleResourceId) }, action)
 {
-	gm_CbtHook = ::SetWindowsHookExW(WH_CBT, &CBTProc, nullptr, ::GetCurrentThreadId());
 }
 
-ModalDialogCloser::ModalDialogCloser() noexcept
-	: ModalDialogCloser(&CloseDialogByCancel)
+ModalDialogCloser::ModalDialogCloser(const std::optional<std::wstring>& optTitle, int nIDDlgItem)
+	: ModalDialogCloser(optTitle, [nIDDlgItem] (HWND hWndDlg)
+		{
+			FORWARD_WM_COMMAND(hWndDlg, nIDDlgItem, ::GetDlgItem(hWndDlg, nIDDlgItem), BN_CLICKED, ::SendMessageW);
+		})
 {
 }
 
 ModalDialogCloser::~ModalDialogCloser() noexcept
 {
-	gm_CbtHook = nullptr;
+	const auto state = m_State;
+	const auto hWnd = m_hWnd;
+	const auto timerActive = m_TimerActive;
+	const auto hookError = m_HookError;
+	const auto exception = m_Exception;
+
+	if (ERROR_SUCCESS != hookError) {
+		ADD_FAILURE() << "SetWindowsHookExW failed with error " << hookError << ".";
+
+		return;
+	}
+
+	if (State::Pending == state) {
+		ADD_FAILURE() << (m_DialogTitle.has_value()
+			? testing::Message() << "A dialog box named '" << m_DialogTitle.value() << "' was not created."
+			: testing::Message() << "No dialog box was created.");
+	}
+
+	if (timerActive) {
+		ADD_FAILURE() << "The timer for FIRST_IDLE is still active.";
+	}
+
+	if (State::Handled != state) {
+		ADD_FAILURE() << "m_Action was not handled.";
+	}
+
+	const auto reportException = [] (const char* source, const std::exception_ptr& captured) {
+		if (!captured) return;
+		try {
+			std::rethrow_exception(captured);
+		}
+		catch (const std::exception& e) {
+			ADD_FAILURE() << source << " failed: " << e.what();
+		}
+		catch (...) {
+			ADD_FAILURE() << source << " failed with an unknown exception.";
+		}
+	};
+	reportException("ModalDialogCloser action", exception);
+
+	{
+		std::unique_lock lock{ gm_Mutex };
+
+		std::erase(gm_Entries, this);
+
+		if (const auto found = gm_HwndMap.find(hWnd);
+			found != gm_HwndMap.end() && found->second == this)
+		{
+			gm_HwndMap.erase(found);
+		}
+	}
+
+	m_TimerActive = false;
+
+	m_hWnd = nullptr;
+
+	m_State = State::Detached;
 }
 
 } // namespace dialog

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
@@ -7,6 +7,8 @@
 #include "pch.h"
 #include "dlg/ModalDialogCloser.hpp"
 
+#include "doc/CDocListener.h"
+
 namespace dialog {
 
 /*!
@@ -65,3 +67,61 @@ ModalDialogCloser::~ModalDialogCloser() noexcept
 }
 
 } // namespace dialog
+
+
+/* static */ void MockCDlgOpenFile::_Cleanup([[maybe_unused]] const MockCDlgOpenFile*)
+{
+	gm_Files.clear();
+}
+
+/* static */ bool MockCDlgOpenFile::_GetOpenFileName(std::span<WCHAR> szPath, EFilter eAddFileter)
+{
+	const auto result = !gm_Files.empty();
+	if (result) {
+		::wcscpy_s(std::data(szPath), std::size(szPath), std::data(gm_Files.front()));
+	}
+	return result;
+}
+
+/* static */ bool MockCDlgOpenFile::_GetSaveFileName(std::span<WCHAR> szPath)
+{
+	const auto result = !gm_Files.empty();
+	if (result) {
+		::wcscpy_s(std::data(szPath), std::size(szPath), std::data(gm_Files.front()));
+	}
+	return result;
+}
+
+/* static */ bool MockCDlgOpenFile::_DoModalOpenDlg(
+	SLoadInfo* pLoadInfo,
+	std::vector<std::wstring>* pFilenames,
+	bool bOptions [[maybe_unused]]
+)
+{
+	const auto result = !gm_Files.empty();
+	if (result) {
+		pLoadInfo->cFilePath = gm_Files.front().c_str();
+		*pFilenames = gm_Files;
+	}
+	return result;
+}
+
+/* static */ bool MockCDlgOpenFile::_DoModalSaveDlg(
+	SSaveInfo* pSaveInfo,
+	bool bSimpleMode [[maybe_unused]]
+)
+{
+	const auto result = !gm_Files.empty();
+	if (result) {
+		pSaveInfo->cFilePath = gm_Files.front().c_str();
+	}
+	return result;
+}
+
+MockCDlgOpenFile::MockCDlgOpenFile()
+{
+	ON_CALL(*this, DoModal_GetOpenFileName(_, _)).WillByDefault(&_GetOpenFileName);
+	ON_CALL(*this, DoModal_GetSaveFileName(_)).WillByDefault(&_GetSaveFileName);
+	ON_CALL(*this, DoModalOpenDlg(_, _, _)).WillByDefault(&_DoModalOpenDlg);
+	ON_CALL(*this, DoModalSaveDlg(_, _)).WillByDefault(&_DoModalSaveDlg);
+}

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
@@ -9,24 +9,47 @@
 #include "cxx/ResourceHolder.hpp"
 #include "dlg/CDlgOpenFile.h"
 
+#include <deque>
+#include <exception>
 #include <functional>
+#include <memory>
+#include <mutex>
 
 namespace dialog {
+
+struct ModalDialogCloserTestPeer;
 
 /*!
  * モーダルダイアログテスト用のクラス
  *
- * WindowsHookを使ってダイアログの初期表示を検出して閉じるようにするもの。
+ * WindowsHookを使ってダイアログの初期表示を検出して閉じるもの。
  */
-struct ModalDialogCloser final : public TSingleInstance<ModalDialogCloser> {
+class ModalDialogCloser final {
+private:
+	friend struct ModalDialogCloserTestPeer;
+
 	using CbtHookHolder = cxx::ResourceHolder<&::UnhookWindowsHookEx>;
 
 	using Me = ModalDialogCloser;
 
-	//! ダイアログボックスのウインドウクラス名
-	static constexpr auto DIALOG_CLASS = 32770;
+	static constexpr UINT TIMER_ID_FIRST_IDLE = 9999;
+	static constexpr UINT FALLBACK_DELAY_MILLIS = 500;
+
+	enum class State {
+		Pending,
+		Created,
+		Running,
+		Handled,
+		Failed,
+		Detached,
+	};
 
 	static inline CbtHookHolder gm_CbtHook = nullptr;
+	static inline std::mutex gm_Mutex;
+
+	static inline std::deque<Me*> gm_Entries;
+
+	static inline std::map<HWND, Me*> gm_HwndMap;
 
 	//! Windowsフック関数
 	static LRESULT CALLBACK CBTProc(
@@ -35,16 +58,29 @@ struct ModalDialogCloser final : public TSingleInstance<ModalDialogCloser> {
 		_In_ LPARAM lParam
 	);
 
-	static void CloseDialogByCancel(HWND hWndDlg);
+	static void CALLBACK TimerProc(HWND hWnd, UINT, UINT_PTR idEvent, DWORD);
+	static bool ExecuteAction(HWND hWnd) noexcept;
 
-	ModalDialogCloser() noexcept;
-	explicit ModalDialogCloser(const std::function<void(HWND)>& action) noexcept;
+public:
+	ModalDialogCloser(const std::optional<std::wstring>& optTitle, const std::function<void(HWND)>& action);
+
+	ModalDialogCloser(int dialogTitleResourceId, const std::function<void(HWND)>& action);
+	ModalDialogCloser(const std::optional<std::wstring>& optTitle, int nIDDlgItem = IDCANCEL);
+
 	ModalDialogCloser(const Me&) = delete;
 	Me& operator=(const Me&) = delete;
-	~ModalDialogCloser() noexcept override;
+
+	~ModalDialogCloser() noexcept;
 
 private:
+	std::optional<std::wstring> m_DialogTitle;
 	std::function<void(HWND)> m_Action;
+
+	State m_State = State::Pending;
+	HWND m_hWnd = nullptr;
+	std::exception_ptr m_Exception;
+	DWORD m_HookError = ERROR_SUCCESS;
+	bool m_TimerActive = false;
 };
 
 } // namespace dialog

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "cxx/ResourceHolder.hpp"
-#include "util/design_template.h"
+#include "dlg/CDlgOpenFile.h"
 
 #include <functional>
 
@@ -48,3 +48,39 @@ private:
 };
 
 } // namespace dialog
+
+struct MockCDlgOpenFile final : public CDlgOpenFile {
+	MOCK_METHOD2(DoModal_GetOpenFileName, bool(std::span<WCHAR>, EFilter));
+	MOCK_METHOD1(DoModal_GetSaveFileName, bool(std::span<WCHAR>));
+	MOCK_METHOD3(DoModalOpenDlg, bool(SLoadInfo*, std::vector<std::wstring>*, bool));
+	MOCK_METHOD2(DoModalSaveDlg, bool(SSaveInfo*, bool));
+
+	static inline std::vector<std::wstring> gm_Files;
+
+	static void _Cleanup([[maybe_unused]] const MockCDlgOpenFile*);
+
+	static bool _GetOpenFileName(
+		std::span<WCHAR> szPath,
+		EFilter eAddFileter
+	);
+
+	static bool _GetSaveFileName(
+		std::span<WCHAR> szPath
+	);
+
+	static bool _DoModalOpenDlg(
+		SLoadInfo* pLoadInfo,
+		std::vector<std::wstring>* pFilenames,
+		bool bOptions [[maybe_unused]]
+	);
+
+	static bool _DoModalSaveDlg(
+		SSaveInfo* pSaveInfo,
+		bool bSimpleMode [[maybe_unused]]
+	);
+
+	explicit MockCDlgOpenFile();
+
+	using Holder = cxx::ResourceHolder<&_Cleanup>;
+	Holder m_Holder{ this };
+};

--- a/src/test/cpp/tests1/macro/test-cppa.cpp
+++ b/src/test/cpp/tests1/macro/test-cppa.cpp
@@ -29,7 +29,7 @@ struct CPpaTest : public ::testing::Test, public window::EditorTestSuite, public
 	 */
 	static void SetUpTestSuite()
 	{
-		SetUpUia();
+		SetUpUiaTestSuite();
 
 		SetUpEditor();
 
@@ -48,7 +48,7 @@ struct CPpaTest : public ::testing::Test, public window::EditorTestSuite, public
 
 		TearDownEditor();
 
-		TearDownUia();
+		TearDownUiaTestSuite();
 	}
 };
 

--- a/src/test/cpp/tests1/macro/test-cppa.cpp
+++ b/src/test/cpp/tests1/macro/test-cppa.cpp
@@ -11,6 +11,8 @@
 
 #include "eval_outputs.hpp"
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 namespace macro {
 
 struct CPpaStub : public CPPA
@@ -284,3 +286,5 @@ TEST_F(CPpaTest, ppaStrObj)
 }
 
 } // namespace macro
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)

--- a/src/test/cpp/tests1/macro/test-macro.cpp
+++ b/src/test/cpp/tests1/macro/test-macro.cpp
@@ -76,7 +76,7 @@ struct MacroMgrTest : public ::testing::Test, public window::EditorTestSuite, pu
 	 */
 	static void SetUpTestSuite()
 	{
-		SetUpUia();
+		SetUpUiaTestSuite();
 
 		SetUpEditor();
 	}
@@ -88,7 +88,7 @@ struct MacroMgrTest : public ::testing::Test, public window::EditorTestSuite, pu
 	{
 		TearDownEditor();
 
-		TearDownUia();
+		TearDownUiaTestSuite();
 	}
 };
 

--- a/src/test/cpp/tests1/macro/test-macro.cpp
+++ b/src/test/cpp/tests1/macro/test-macro.cpp
@@ -20,6 +20,8 @@
 
 std::filesystem::path GetTempFilePathWithExt(std::wstring_view prefix, std::wstring_view extension);
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 namespace macro {
 
 std::filesystem::path find_dll_in_the_path(const std::filesystem::path& dllname)
@@ -560,3 +562,5 @@ TEST(CSMacroMgr, GetFuncInfoByName101)
 }
 
 } // namespace macro
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)

--- a/src/test/cpp/tests1/test-cclipboard.cpp
+++ b/src/test/cpp/tests1/test-cclipboard.cpp
@@ -235,6 +235,9 @@ TEST(CClipboard, SetText2) {
 	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(::GlobalAlloc);
 	EXPECT_CALL(clipboard, SetClipboardData(CF_UNICODETEXT, WideStringInGlobalMemory(text)));
 	EXPECT_CALL(clipboard, SetClipboardData(::RegisterClipboardFormat(L"MSDEVColumnSelect"), ByteValueInGlobalMemory(0)));
+	EXPECT_CALL(clipboard, GlobalAlloc(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.SetText(text.data(), text.length(), true, false, CF_UNICODETEXT));
 }
 
@@ -247,6 +250,10 @@ TEST(CClipboard, SetText3) {
 	EXPECT_CALL(clipboard, SetClipboardData(sakuraFormat, SakuraFormatInGlobalMemory(text)));
 	EXPECT_CALL(clipboard, SetClipboardData(::RegisterClipboardFormat(L"MSDEVLineSelect"), ByteValueInGlobalMemory(1)));
 	EXPECT_CALL(clipboard, SetClipboardData(::RegisterClipboardFormat(L"VisualStudioEditorOperationsLineCutCopyClipboardTag"), ByteValueInGlobalMemory(1)));
+	EXPECT_CALL(clipboard, GlobalAlloc(_, _))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.SetText(text.data(), text.length(), false, true, sakuraFormat));
 }
 
@@ -264,6 +271,9 @@ TEST(CClipboard, SetText5) {
 	constexpr std::wstring_view text = L"てすと";
 	MockCClipboard clipboard;
 	ON_CALL(clipboard, GlobalAlloc(_, 1)).WillByDefault(Return(nullptr));
+	EXPECT_CALL(clipboard, GlobalAlloc(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.SetText(text.data(), text.length(), true, false, 0));
 }
 
@@ -272,6 +282,10 @@ TEST(CClipboard, SetText6) {
 	constexpr std::wstring_view text = L"てすと";
 	MockCClipboard clipboard;
 	ON_CALL(clipboard, GlobalAlloc(_, 1)).WillByDefault(Return(nullptr));
+	EXPECT_CALL(clipboard, GlobalAlloc(_, _))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.SetText(text.data(), text.length(), false, true, 0));
 }
 
@@ -301,6 +315,12 @@ protected:
 TEST_F(CClipboardGetText, NoSpecifiedFormat1) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(sakuraFormat)).WillByDefault(Return(sakuraMemory.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, -1));
 	EXPECT_STREQ(buffer.GetStringPtr(), sakuraText.data());
 }
@@ -309,6 +329,12 @@ TEST_F(CClipboardGetText, NoSpecifiedFormat1) {
 TEST_F(CClipboardGetText, NoSpecifiedFormat2) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(FALSE));
 	ON_CALL(clipboard, GetClipboardData(CF_UNICODETEXT)).WillByDefault(Return(unicodeMemory.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, -1));
 	EXPECT_STREQ(buffer.GetStringPtr(), unicodeText.data());
 }
@@ -318,6 +344,13 @@ TEST_F(CClipboardGetText, NoSpecifiedFormat3) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(sakuraFormat)).WillByDefault(Return(nullptr));
 	ON_CALL(clipboard, GetClipboardData(CF_UNICODETEXT)).WillByDefault(Return(unicodeMemory.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, -1));
 	EXPECT_STREQ(buffer.GetStringPtr(), unicodeText.data());
 }
@@ -327,6 +360,13 @@ TEST_F(CClipboardGetText, NoSpecifiedFormat4) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(FALSE));
 	ON_CALL(clipboard, GetClipboardData(CF_UNICODETEXT)).WillByDefault(Return(nullptr));
 	ON_CALL(clipboard, GetClipboardData(CF_OEMTEXT)).WillByDefault(Return(oemMemory.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, -1));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"CF_OEMTEXT");
 }
@@ -340,6 +380,15 @@ TEST_F(CClipboardGetText, NoSpecifiedFormat5) {
 	ON_CALL(clipboard, GetClipboardData(CF_OEMTEXT)).WillByDefault(Return(nullptr));
 	ON_CALL(clipboard, IsClipboardFormatAvailable(CF_HDROP)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(CF_HDROP)).WillByDefault(Return(mem.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(3)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, -1));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"CF_HDROP");
 }
@@ -350,6 +399,14 @@ TEST_F(CClipboardGetText, NoSpecifiedFormat6) {
 	ON_CALL(clipboard, GetClipboardData(CF_UNICODETEXT)).WillByDefault(Return(nullptr));
 	ON_CALL(clipboard, GetClipboardData(CF_OEMTEXT)).WillByDefault(Return(nullptr));
 	ON_CALL(clipboard, IsClipboardFormatAvailable(CF_HDROP)).WillByDefault(Return(FALSE));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetText(&buffer, nullptr, nullptr, eol, -1));
 }
 
@@ -359,6 +416,12 @@ TEST_F(CClipboardGetText, NoSpecifiedFormat6) {
 TEST_F(CClipboardGetText, SakuraFormatSuccess) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(sakuraFormat)).WillByDefault(Return(sakuraMemory.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, sakuraFormat));
 	EXPECT_STREQ(buffer.GetStringPtr(), sakuraText.data());
 }
@@ -366,6 +429,9 @@ TEST_F(CClipboardGetText, SakuraFormatSuccess) {
 // サクラ形式が指定されているが取得に失敗した場合。
 TEST_F(CClipboardGetText, SakuraFormatFailure) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(FALSE));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetText(&buffer, nullptr, nullptr, eol, sakuraFormat));
 }
 
@@ -378,6 +444,12 @@ TEST_F(CClipboardGetText, SakuraFormatBinaryLayout) {
 	ASSERT_TRUE(mem.SetData(bytes));
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(sakuraFormat)).WillByDefault(Return(mem.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, sakuraFormat));
 	EXPECT_EQ(text, std::wstring_view(buffer.GetStringPtr(), buffer.GetStringLength()));
 }
@@ -390,6 +462,12 @@ TEST_F(CClipboardGetText, SakuraFormatBrokenLength) {
 	ASSERT_TRUE(mem.SetData(bytes));
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(sakuraFormat)).WillByDefault(Return(mem.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, sakuraFormat));
 	// 終端ヌルを含む、確保されている文字数で頭打ちになる
 	EXPECT_EQ(text.length() + 1, size_t(buffer.GetStringLength()));
@@ -403,6 +481,12 @@ TEST_F(CClipboardGetText, SakuraFormatNegativeLength) {
 	ASSERT_TRUE(mem.SetData(bytes));
 	ON_CALL(clipboard, IsClipboardFormatAvailable(sakuraFormat)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(sakuraFormat)).WillByDefault(Return(mem.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, sakuraFormat));
 	EXPECT_EQ(0, buffer.GetStringLength());
 }
@@ -410,6 +494,9 @@ TEST_F(CClipboardGetText, SakuraFormatNegativeLength) {
 // CF_UNICODETEXTを指定して取得する。
 TEST_F(CClipboardGetText, UnicodeTextSucces) {
 	ON_CALL(clipboard, GetClipboardData(CF_UNICODETEXT)).WillByDefault(Return(unicodeMemory.Get()));
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, CF_UNICODETEXT));
 	EXPECT_STREQ(buffer.GetStringPtr(), unicodeText.data());
 }
@@ -417,12 +504,18 @@ TEST_F(CClipboardGetText, UnicodeTextSucces) {
 // CF_UNICODETEXTが指定されているが取得に失敗した場合。
 TEST_F(CClipboardGetText, UnicodeTextFailure) {
 	ON_CALL(clipboard, GetClipboardData(CF_UNICODETEXT)).WillByDefault(Return(nullptr));
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetText(&buffer, nullptr, nullptr, eol, CF_UNICODETEXT));
 }
 
 // CF_OEMTEXTを指定して取得する。
 TEST_F(CClipboardGetText, OemTextSuccess) {
 	ON_CALL(clipboard, GetClipboardData(CF_OEMTEXT)).WillByDefault(Return(oemMemory.Get()));
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, CF_OEMTEXT));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"CF_OEMTEXT");
 }
@@ -430,6 +523,9 @@ TEST_F(CClipboardGetText, OemTextSuccess) {
 // CF_OEMTEXTが指定されているが取得に失敗した場合。
 TEST_F(CClipboardGetText, OemTextFailure) {
 	ON_CALL(clipboard, GetClipboardData(CF_OEMTEXT)).WillByDefault(Return(nullptr));
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetText(&buffer, nullptr, nullptr, eol, CF_OEMTEXT));
 }
 
@@ -440,6 +536,12 @@ TEST_F(CClipboardGetText, HDropSuccessSingleFile) {
 	auto mem = cxx::MakeDropFiles(files);
 	ON_CALL(clipboard, IsClipboardFormatAvailable(CF_HDROP)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(CF_HDROP)).WillByDefault(Return(mem.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, CF_HDROP));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"file");
 }
@@ -455,6 +557,12 @@ TEST_F(CClipboardGetText, HDropSuccessMultipleFiles) {
 	EXPECT_THAT(mem.data(), testing::SizeIs(Eq(files.size())));
 	ON_CALL(clipboard, IsClipboardFormatAvailable(CF_HDROP)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(CF_HDROP)).WillByDefault(Return(mem.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetText(&buffer, nullptr, nullptr, eol, CF_HDROP));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"file1\r\nfile2\r\n");
 }
@@ -463,12 +571,29 @@ TEST_F(CClipboardGetText, HDropSuccessMultipleFiles) {
 TEST_F(CClipboardGetText, HDropFailure) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(CF_HDROP)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(CF_HDROP)).WillByDefault(Return(nullptr));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetText(&buffer, nullptr, nullptr, eol, CF_HDROP));
 }
 
 // 矩形選択マーク取得のテスト。
 TEST_F(CClipboardGetText, ColumnSelectIsFalse) {
 	ON_CALL(clipboard, EnumClipboardFormats(0)).WillByDefault(Return(0));
+	EXPECT_CALL(clipboard, EnumClipboardFormats(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	bool column;
 	clipboard.GetText(&buffer, &column, nullptr, eol);
 	EXPECT_FALSE(column);
@@ -477,6 +602,17 @@ TEST_F(CClipboardGetText, ColumnSelectIsFalse) {
 TEST_F(CClipboardGetText, ColumnSelectIsTrue) {
 	UINT format = RegisterClipboardFormatW(L"MSDEVColumnSelect");
 	ON_CALL(clipboard, EnumClipboardFormats(0)).WillByDefault(Return(format));
+	EXPECT_CALL(clipboard, EnumClipboardFormats(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	bool column;
 	clipboard.GetText(&buffer, &column, nullptr, eol);
 	EXPECT_TRUE(column);
@@ -485,6 +621,17 @@ TEST_F(CClipboardGetText, ColumnSelectIsTrue) {
 // 行選択マーク取得のテスト。
 TEST_F(CClipboardGetText, LineSelectIsFalse) {
 	ON_CALL(clipboard, EnumClipboardFormats(0)).WillByDefault(Return(0));
+	EXPECT_CALL(clipboard, EnumClipboardFormats(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	bool line;
 	clipboard.GetText(&buffer, &line, nullptr, eol);
 	EXPECT_FALSE(line);
@@ -493,6 +640,17 @@ TEST_F(CClipboardGetText, LineSelectIsFalse) {
 TEST_F(CClipboardGetText, LineSelectIsTrue1) {
 	UINT format = RegisterClipboardFormatW(L"MSDEVLineSelect");
 	ON_CALL(clipboard, EnumClipboardFormats(0)).WillByDefault(Return(format));
+	EXPECT_CALL(clipboard, EnumClipboardFormats(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	bool line;
 	clipboard.GetText(&buffer, nullptr, &line, eol);
 	EXPECT_TRUE(line);
@@ -501,6 +659,17 @@ TEST_F(CClipboardGetText, LineSelectIsTrue1) {
 TEST_F(CClipboardGetText, LineSelectIsTrue2) {
 	UINT format = RegisterClipboardFormatW(L"VisualStudioEditorOperationsLineCutCopyClipboardTag");
 	ON_CALL(clipboard, EnumClipboardFormats(0)).WillByDefault(Return(format));
+	EXPECT_CALL(clipboard, EnumClipboardFormats(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(2)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
 	bool line;
 	clipboard.GetText(&buffer, nullptr, &line, eol);
 	EXPECT_TRUE(line);
@@ -511,6 +680,14 @@ TEST_F(CClipboardGetText, LineSelectIsTrue2) {
 TEST_F(CClipboardGetText, GetClipboardByFormatSuccess) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(CF_UNICODETEXT)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(CF_UNICODETEXT)).WillByDefault(Return(unicodeMemory.Get()));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(3)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetClipboardByFormat(buffer, L"CF_UNICODETEXT", -2, 0, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), unicodeText.data());
 }
@@ -520,6 +697,14 @@ TEST_F(CClipboardGetText, GetClipboardByFormatFailure1) {
 	buffer.SetString(L"dummy");
 	ON_CALL(clipboard, IsClipboardFormatAvailable(CF_UNICODETEXT)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(_)).WillByDefault(Return(nullptr));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(3)
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault())
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetClipboardByFormat(buffer, L"CF_UNICODETEXT", -2, 0, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"");
 }
@@ -528,6 +713,9 @@ TEST_F(CClipboardGetText, GetClipboardByFormatFailure1) {
 TEST_F(CClipboardGetText, GetClipboardByFormatFailure2) {
 	buffer.SetString(L"dummy");
 	ON_CALL(clipboard, IsClipboardFormatAvailable(CF_UNICODETEXT)).WillByDefault(Return(FALSE));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetClipboardByFormat(buffer, L"CF_UNICODETEXT", -2, 0, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"");
 }
@@ -574,6 +762,8 @@ TEST(CClipboard, IsIncludeClipboardFormat1) {
 	for (auto format : KNOWN_FORMATS) {
 		MockCClipboard clipboard;
 		ON_CALL(clipboard, IsClipboardFormatAvailable(format.id)).WillByDefault(Return(TRUE));
+		EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+			.WillOnce(testing::DoDefault());
 		EXPECT_TRUE(clipboard.IsIncludeClipboardFormat(format.name));
 	}
 }
@@ -582,6 +772,8 @@ TEST(CClipboard, IsIncludeClipboardFormat1) {
 TEST(CClipboard, IsIncludeClipboardFormat2) {
 	MockCClipboard clipboard;
 	ON_CALL(clipboard, IsClipboardFormatAvailable(12345)).WillByDefault(Return(TRUE));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.IsIncludeClipboardFormat(L"12345"));
 }
 
@@ -591,6 +783,8 @@ TEST(CClipboard, IsIncludeClipboardFormat3) {
 
 	MockCClipboard clipboard;
 	ON_CALL(clipboard, IsClipboardFormatAvailable(format)).WillByDefault(Return(TRUE));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.IsIncludeClipboardFormat(UNITTEST_FORMAT_NAME));
 }
 
@@ -598,12 +792,16 @@ TEST(CClipboard, IsIncludeClipboardFormat3) {
 TEST(CClipboard, IsIncludeClipboardFormat4) {
 	MockCClipboard clipboard;
 	ON_CALL(clipboard, IsClipboardFormatAvailable(12345)).WillByDefault(Return(FALSE));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.IsIncludeClipboardFormat(L"12345"));
 }
 
 // フォーマット文字列が空だった場合は失敗する。
 TEST(CClipboard, IsIncludeClipboardFormat5) {
 	MockCClipboard clipboard;
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.IsIncludeClipboardFormat(L""));
 }
 
@@ -626,6 +824,9 @@ TEST(CClipboard, SetClipboardByFormat3) {
 	MockCClipboard clipboard;
 	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(::GlobalAlloc);
 	EXPECT_CALL(clipboard, SetClipboardData(12345, BytesInGlobalMemory("\x00\x01\xfe\xff", 4)));
+	EXPECT_CALL(clipboard, GlobalAlloc(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.SetClipboardByFormat({L"\x00\x01\xfe\xff", 4}, L"12345", -1, 0));
 }
 
@@ -643,6 +844,9 @@ TEST(CClipboard, SetClipboardByFormat5) {
 	MockCClipboard clipboard;
 	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(::GlobalAlloc);
 	EXPECT_CALL(clipboard, SetClipboardData(12345, WideStringInGlobalMemory(L"テスト")));
+	EXPECT_CALL(clipboard, GlobalAlloc(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.SetClipboardByFormat({L"テスト", 3}, L"12345", 3, -1));
 }
 
@@ -671,6 +875,9 @@ TEST(CClipboard, SetClipboardByFormat7) {
 TEST(CClipboard, SetClipboardByFormat8) {
 	MockCClipboard clipboard;
 	ON_CALL(clipboard, GlobalAlloc(_, _)).WillByDefault(Return(nullptr));
+	EXPECT_CALL(clipboard, GlobalAlloc(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.SetClipboardByFormat({L"テスト", 3}, L"12345", 3, -1));
 }
 
@@ -689,6 +896,9 @@ TEST(CClipboard, GetClipboardByFormat2) {
 	CNativeW buffer(L"dummy");
 	CEol eol(EEolType::cr_and_lf);
 	ON_CALL(clipboard, IsClipboardFormatAvailable(12345)).WillByDefault(Return(FALSE));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetClipboardByFormat(buffer, L"12345", -1, 0, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"");
 }
@@ -700,6 +910,12 @@ TEST(CClipboard, GetClipboardByFormat3) {
 	CEol eol(EEolType::cr_and_lf);
 	ON_CALL(clipboard, IsClipboardFormatAvailable(12345)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(12345)).WillByDefault(Return(nullptr));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetClipboardByFormat(buffer, L"12345", -1, 0, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"");
 }
@@ -712,6 +928,15 @@ TEST(CClipboard, GetClipboardByFormat4) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(12345)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(12345)).WillByDefault(Return((HANDLE)67890));
 	ON_CALL(clipboard, GlobalLock((HANDLE)67890)).WillByDefault(Return(nullptr));
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GlobalLock(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_FALSE(clipboard.GetClipboardByFormat(buffer, L"12345", -1, 0, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"");
 }
@@ -728,6 +953,15 @@ TEST(CClipboard, GetClipboardByFormat5) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(12345)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(12345)).WillByDefault(Return(memory.Get()));
 	ON_CALL(clipboard, GlobalLock(_)).WillByDefault(::GlobalLock);
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GlobalLock(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetClipboardByFormat(buffer, L"12345", -1, 0, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"\x00\xff");
 }
@@ -743,6 +977,15 @@ TEST(CClipboard, GetClipboardByFormat6) {
 	ON_CALL(clipboard, IsClipboardFormatAvailable(12345)).WillByDefault(Return(TRUE));
 	ON_CALL(clipboard, GetClipboardData(12345)).WillByDefault(Return(memory.Get()));
 	ON_CALL(clipboard, GlobalLock(_)).WillByDefault(::GlobalLock);
+	EXPECT_CALL(clipboard, IsClipboardFormatAvailable(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GetClipboardData(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(clipboard, GlobalLock(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 	EXPECT_TRUE(clipboard.GetClipboardByFormat(buffer, L"12345", 3, 2, eol));
 	EXPECT_STREQ(buffer.GetStringPtr(), L"テスト");
 }

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -11,6 +11,14 @@
 
 #include <fstream>
 
+namespace uia {
+
+cxx::com_pointer<IUIAutomationElement> GetFocusedElement(
+	IUIAutomation* pAutomation
+);
+
+} // namespace uia
+
 namespace window {
 
 /*!
@@ -75,7 +83,14 @@ struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, pu
 	{
 		// 設定を元に戻す
 		GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = true;
+
+		TearDownUia();
 	}
+
+	/*!
+	 * ファイルを開くダイアログのタイトルを取得する
+	 */
+	std::wstring GetOpenFileNameDialogTitle() const { return GetParam() ? L"開く" : L"ファイルを開く"; }
 };
 
 TEST_P(FileDialogTest, Create001)
@@ -123,6 +138,41 @@ TEST_P(FileDialogTest, Create003_ManyFiltersy)
 /*!
  * ファイルを開くダイアログの表示テスト
  */
+TEST_P(FileDialogTest, DoModalOpenDlg001)
+{
+	const auto path = GetExeFileName().replace_filename(L"test.txt");
+
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+
+	// ファイルが存在しない、のメッセージが出ないようにファイルを作る
+	std::ofstream ofs{ path };
+	ofs.close();
+
+	// 表示されたファイルダイアログを閉じるためのスレッドを起動する
+	auto t = StartDialogCloser(GetOpenFileNameDialogTitle(), [path] (IUIAutomation* pUIAutomation, HWND, std::stop_token) {
+		auto pItem = uia::GetFocusedElement(pUIAutomation);
+		ASSERT_THAT(pItem, NotNull());
+
+		// ファイル名を入力する
+		EmulateSetValue(pItem, path.c_str());
+
+		// Enterキー押下で閉じる
+		EmulateHitEnter();
+	});
+
+	SLoadInfo loadInfo{};
+	std::vector<std::wstring> files;
+	bool bOptions = true;
+	CDlgOpenFile::getInstance()->DoModalOpenDlg(&loadInfo, &files, bOptions);
+
+	// 作成したファイルを削除する
+	std::filesystem::remove(path, ec);
+}
+
+/*!
+ * ファイルを開くダイアログの表示テスト
+ */
 TEST_P(FileDialogTest, DoModalOpenDlg101)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
@@ -131,6 +181,33 @@ TEST_P(FileDialogTest, DoModalOpenDlg101)
 	// コマンドコードで、無理矢理動かす
 	const auto hWnd = pcEditWnd->GetHwnd();
 	FORWARD_WM_COMMAND(hWnd, F_FILEOPEN, nullptr, 0, pcEditWnd->DispatchEvent);
+}
+
+/*!
+ * 名前を付けて保存ダイアログの表示テスト
+ */
+TEST_P(FileDialogTest, DoModalSaveDlg001)
+{
+	const auto path = GetExeFileName().replace_filename(L"test.txt");
+
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+
+	// 表示されたファイルダイアログを閉じるためのスレッドを起動する
+	auto t = StartDialogCloser(L"名前を付けて保存", [path](IUIAutomation* pUIAutomation, HWND, std::stop_token) {
+		auto pItem = uia::GetFocusedElement(pUIAutomation);
+		ASSERT_THAT(pItem, NotNull());
+
+		// ファイル名を入力する
+		EmulateSetValue(pItem, path.c_str());
+
+		// Enterキー押下で閉じる
+		EmulateHitEnter();
+	});
+
+	SSaveInfo saveInfo{};
+	bool bSimpleMode = true;
+	CDlgOpenFile::getInstance()->DoModalSaveDlg(&saveInfo, bSimpleMode);
 }
 
 /*!
@@ -149,6 +226,39 @@ TEST_P(FileDialogTest, DoModalSaveDlg101)
 /*!
  * ファイルを開くダイアログの表示テスト
  */
+TEST_P(FileDialogTest, GetOpenFileName001)
+{
+	const auto path = GetExeFileName().replace_filename(L"test.txt");
+
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+
+	// ファイルが存在しない、のメッセージが出ないようにファイルを作る
+	std::ofstream ofs{ path };
+	ofs.close();
+
+	// 表示されたファイルダイアログを閉じるためのスレッドを起動する
+	auto t = StartDialogCloser(L"開く", [path] (IUIAutomation* pUIAutomation, HWND, std::stop_token) {
+		auto pItem = uia::GetFocusedElement(pUIAutomation);
+		ASSERT_THAT(pItem, NotNull());
+
+		// ファイル名を入力する
+		EmulateSetValue(pItem, path.c_str());
+
+		// Enterキー押下で閉じる
+		EmulateHitEnter();
+	});
+
+	SFilePath szPath{ path.filename().c_str() };
+	CDlgOpenFile::getInstance()->DoModal_GetOpenFileName(szPath, EFilter::EFITER_TEXT);
+
+	// 作成したファイルを削除する
+	std::filesystem::remove(path, ec);
+}
+
+/*!
+ * ファイルを開くダイアログの表示テスト
+ */
 TEST_P(FileDialogTest, GetOpenFileName101)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
@@ -157,6 +267,42 @@ TEST_P(FileDialogTest, GetOpenFileName101)
 	// コマンドコードで、無理矢理動かす
 	const auto hWnd = pcEditWnd->GetHwnd();
 	FORWARD_WM_COMMAND(hWnd, F_LOADKEYMACRO, nullptr, 0, pcEditWnd->DispatchEvent);
+}
+
+/*!
+ * 名前を付けて保存ダイアログの表示テスト
+ */
+TEST_P(FileDialogTest, GetSaveFileName001)
+{
+	const auto path = GetExeFileName().replace_filename(L"test.txt");
+	const auto dummyPath = GetExeFileName().replace_filename(L"dummy.txt");
+
+	std::error_code ec;
+
+	// 上書き確認メッセージが出ないように、事前にパスを削除しておく
+	std::filesystem::remove(path, ec);
+
+	// パス解決でｋるようにファイルを作る
+	std::filesystem::remove(dummyPath, ec);
+	std::ofstream ofs{ dummyPath };
+	ofs.close();
+
+	// 表示されたファイルダイアログを閉じるためのスレッドを起動する
+	auto t = StartDialogCloser(L"名前を付けて保存", [path](IUIAutomation* pUIAutomation, HWND, std::stop_token) {
+		auto pItem = uia::GetFocusedElement(pUIAutomation);
+		ASSERT_THAT(pItem, NotNull());
+
+		// ファイル名を入力する
+		EmulateSetValue(pItem, path.c_str());
+
+		// Enterキー押下で閉じる
+		EmulateHitEnter();
+	});
+
+	SFilePath szPath{ dummyPath.filename().native() };
+	CDlgOpenFile::getInstance()->DoModal_GetSaveFileName(szPath);
+
+	std::filesystem::remove(dummyPath, ec);
 }
 
 /*!
@@ -271,6 +417,8 @@ struct SelectFileTest : public ::testing::Test, public window::EditorTestSuite, 
 	void TearDown() override
 	{
 		CDlgOpenFile::resetInstance();
+
+		TearDownUia();
 	}
 };
 

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -32,7 +32,7 @@ struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, pu
 	 */
 	static void SetUpTestSuite()
 	{
-		SetUpUia();
+		SetUpUiaTestSuite();
 
 		SetUpEditor();
 	}
@@ -44,7 +44,7 @@ struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, pu
 	{
 		TearDownEditor();
 
-		TearDownUia();
+		TearDownUiaTestSuite();
 	}
 
 	/*!
@@ -214,7 +214,7 @@ struct SelectFileTest : public ::testing::Test, public window::EditorTestSuite, 
 	 */
 	static void SetUpTestSuite()
 	{
-		SetUpUia();
+		SetUpUiaTestSuite();
 
 		SetUpEditor();
 
@@ -252,7 +252,7 @@ struct SelectFileTest : public ::testing::Test, public window::EditorTestSuite, 
 
 		TearDownEditor();
 
-		TearDownUia();
+		TearDownUiaTestSuite();
 	}
 
 	/*!

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -48,12 +48,24 @@ struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, pu
 	}
 
 	/*!
-	 * テストが実行された直前に毎回呼ばれる関数
+	 * テストが実行される直前に毎回呼ばれる関数
 	 */
 	void SetUp() override
 	{
 		// テスト設定を反映する
 		GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = GetParam();
+
+		const auto unusedArg1 = G_AppInstance();
+
+		auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
+		cDlgOpenFile.Create(
+			unusedArg1,
+			nullptr,
+			L"*.txt",
+			LR"(C:\Windows\System32)",
+			std::vector<LPCWSTR>(),
+			std::vector<LPCWSTR>()
+		);
 	}
 
 	/*!
@@ -69,7 +81,7 @@ struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, pu
 TEST_P(FileDialogTest, Create001)
 {
 	// 落ちたり例外にならないこと
-	CDlgOpenFile cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	cDlgOpenFile.Create(
 		GetModuleHandle(nullptr),
 		nullptr,
@@ -83,7 +95,7 @@ TEST_P(FileDialogTest, Create001)
 TEST_P(FileDialogTest, Create002_LongFilter)
 {
 	// 落ちたり例外にならないこと
-	CDlgOpenFile cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	cDlgOpenFile.Create(
 		GetModuleHandle(nullptr),
 		nullptr,
@@ -97,7 +109,7 @@ TEST_P(FileDialogTest, Create002_LongFilter)
 TEST_P(FileDialogTest, Create003_ManyFiltersy)
 {
 	// 落ちたり例外にならないこと
-	CDlgOpenFile cDlgOpenFile;
+	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	cDlgOpenFile.Create(
 		GetModuleHandle(nullptr),
 		nullptr,
@@ -242,6 +254,24 @@ struct SelectFileTest : public ::testing::Test, public window::EditorTestSuite, 
 
 		TearDownUia();
 	}
+
+	/*!
+	 * テストが実行される直前に毎回呼ばれる関数
+	 */
+	void SetUp() override
+	{
+		CDlgOpenFile::setInstance<MockCDlgOpenFile>();
+
+		MockCDlgOpenFile::gm_Files.emplace_back(path.native());
+	}
+
+	/*!
+	 * テストが実行された直後に毎回呼ばれる関数
+	 */
+	void TearDown() override
+	{
+		CDlgOpenFile::resetInstance();
+	}
 };
 
 /*!
@@ -251,7 +281,10 @@ TEST_F(SelectFileTest, SelectFile001)
 {
 	constexpr bool resolvePath = true;	// パス解決する場合のテスト
 
-	auto t = StartEnterOpenFileName(path);
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	EXPECT_THAT(CDlgOpenFile::SelectFile(hWndDlg, hWndFolder, L"*.ini", resolvePath, EFITER_NONE), IsTrue());
 
@@ -267,7 +300,10 @@ TEST_F(SelectFileTest, SelectFile002)
 {
 	constexpr bool resolvePath = false;	// パス解決しない場合のテスト
 
-	auto t = StartEnterOpenFileName(path);
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	EXPECT_THAT(CDlgOpenFile::SelectFile(hWndDlg, hWndFolder, L"*.ini", resolvePath, EFITER_NONE), IsTrue());
 
@@ -282,8 +318,12 @@ TEST_F(SelectFileTest, SelectFile101)
 {
 	constexpr bool resolvePath = true;
 
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	MockCDlgOpenFile::gm_Files.clear();
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	EXPECT_THAT(CDlgOpenFile::SelectFile(hWndDlg, hWndFolder, L"*.ini", resolvePath, EFITER_NONE), IsFalse());
 }

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -175,12 +175,25 @@ TEST_P(FileDialogTest, DoModalOpenDlg001)
  */
 TEST_P(FileDialogTest, DoModalOpenDlg101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(std::nullopt);
 
 	// コマンドコードで、無理矢理動かす
 	const auto hWnd = pcEditWnd->GetHwnd();
 	FORWARD_WM_COMMAND(hWnd, F_FILEOPEN, nullptr, 0, pcEditWnd->DispatchEvent);
+}
+
+/*!
+ * ファイルを開くダイアログの表示テスト
+ */
+TEST_P(FileDialogTest, DoModalOpenDlg102)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(std::nullopt);
+
+	SLoadInfo loadInfo{};
+	bool bOptions = false;
+	CDlgOpenFile::getInstance()->DoModalOpenDlg(&loadInfo, nullptr, bOptions);
 }
 
 /*!
@@ -215,8 +228,8 @@ TEST_P(FileDialogTest, DoModalSaveDlg001)
  */
 TEST_P(FileDialogTest, DoModalSaveDlg101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(std::nullopt);
 
 	// コマンドコードで、無理矢理動かす
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -261,12 +274,24 @@ TEST_P(FileDialogTest, GetOpenFileName001)
  */
 TEST_P(FileDialogTest, GetOpenFileName101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(std::nullopt);
 
 	// コマンドコードで、無理矢理動かす
 	const auto hWnd = pcEditWnd->GetHwnd();
 	FORWARD_WM_COMMAND(hWnd, F_LOADKEYMACRO, nullptr, 0, pcEditWnd->DispatchEvent);
+}
+
+/*!
+ * ファイルを開くダイアログの表示テスト
+ */
+TEST_P(FileDialogTest, GetOpenFileName102)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(std::nullopt);
+
+	SFilePath szPath{};
+	CDlgOpenFile::getInstance()->DoModal_GetOpenFileName(szPath, EFilter::EFITER_NONE);
 }
 
 /*!
@@ -321,8 +346,8 @@ TEST_P(FileDialogTest, GetSaveFileName101)
 	LPARAM lParams = 0L;
 	pcSMacroMgr->Append(STAND_KEYMACRO, F_0, &lParams, &pcEditWnd->GetView(0));
 
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(std::nullopt);
 
 	// コマンドコードで、無理矢理動かす
 	const auto hWnd = pcEditWnd->GetHwnd();

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -294,11 +294,18 @@ TEST_P(FileDialogTest, GetOpenFileName102)
 	CDlgOpenFile::getInstance()->DoModal_GetOpenFileName(szPath, EFilter::EFITER_NONE);
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * 名前を付けて保存ダイアログの表示テスト
  */
 TEST_P(FileDialogTest, GetSaveFileName001)
 {
+	if (!GetParam()) {
+		GTEST_SUCCESS_("Legacy Common File Dialog may cause error on GitHub Actions.");
+		return;
+	}
+
 	const auto path = GetExeFileName().replace_filename(L"test.txt");
 	const auto dummyPath = GetExeFileName().replace_filename(L"dummy.txt");
 
@@ -329,6 +336,8 @@ TEST_P(FileDialogTest, GetSaveFileName001)
 
 	std::filesystem::remove(dummyPath, ec);
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * 名前を付けて保存ダイアログの表示テスト

--- a/src/test/cpp/tests1/test-csharedata.cpp
+++ b/src/test/cpp/tests1/test-csharedata.cpp
@@ -191,9 +191,9 @@ MATCHER_P(EqSTypeConfig, expected, "Checks if STypeConfig is equal to the expect
 	EXPECT_THAT(actual.m_bUseKeyWordHelp, expected.m_bUseKeyWordHelp);
 	EXPECT_THAT(actual.m_nKeyHelpNum, expected.m_nKeyHelpNum);
 	for (size_t i = 0; i < std::size(actual.m_KeyHelpArr); ++i) {
-		EXPECT_THAT(actual.m_KeyHelpArr[i].m_bUse,    expected.m_KeyHelpArr[i].m_bUse)                  << L"Unexpected value at index " << i;
-		EXPECT_THAT(actual.m_KeyHelpArr[i].m_szAbout, StrEq(expected.m_KeyHelpArr[i].m_szAbout))        << L"Unexpected value at index " << i;
-		EXPECT_THAT(actual.m_KeyHelpArr[i].m_szPath,  StrEq(expected.m_KeyHelpArr[i].m_szPath.c_str())) << L"Unexpected value at index " << i;
+		EXPECT_THAT(actual.m_KeyHelpArr[i].m_bUse,    expected.m_KeyHelpArr[i].m_bUse)						<< L"Unexpected value at index " << i;
+		EXPECT_THAT(actual.m_KeyHelpArr[i].m_szAbout, StrEq(expected.m_KeyHelpArr[i].m_szAbout.c_str()))	<< L"Unexpected value at index " << i;
+		EXPECT_THAT(actual.m_KeyHelpArr[i].m_szPath,  StrEq(expected.m_KeyHelpArr[i].m_szPath.c_str()))		<< L"Unexpected value at index " << i;
 	}
 	EXPECT_THAT(actual.m_bUseKeyHelpAllSearch, expected.m_bUseKeyHelpAllSearch);
 	EXPECT_THAT(actual.m_bUseKeyHelpKeyDisp, expected.m_bUseKeyHelpKeyDisp);

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -190,6 +190,8 @@ struct TrayWndTest : public ::testing::Test, public env::ShareDataTestSuite, pub
 		while (::PeekMessageW(&msg, nullptr, 0L, 0L, PM_REMOVE)) ;
 
 		CDlgOpenFile::resetInstance();
+
+		TearDownUia();
 	}
 };
 
@@ -926,6 +928,8 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 		CDlgOpenFile::resetInstance();
 
 		mgr = nullptr;
+
+		TearDownUia();
 	}
 
 	/*!
@@ -2772,6 +2776,16 @@ TEST_F(EditWndTest, ShowPropType007)
 	t.join();
 
 	std::filesystem::remove(exportPath, ec);
+}
+
+TEST_F(EditWndTest, DISABLED_Timeout101)
+{
+	StartUiaThread([] (const IUIAutomation*, std::stop_token st) {
+		std::mutex mutex;
+		std::condition_variable_any condition;
+		std::unique_lock lock(mutex);
+		condition.wait_for(lock, st, std::chrono::seconds(31), [] { return false; });
+	});
 }
 
 /*!

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -174,12 +174,22 @@ struct TrayWndTest : public ::testing::Test, public env::ShareDataTestSuite, pub
 	}
 
 	/*!
+	 * テストが実行される直前に毎回呼ばれる関数
+	 */
+	void SetUp() override
+	{
+		CDlgOpenFile::setInstance<MockCDlgOpenFile>();
+	}
+
+	/*!
 	 * テストが実行された直後に毎回呼ばれる関数
 	 */
 	void TearDown() override {
 		// キューに溜まったメッセージは全部捨てる
 		MSG msg{};
 		while (::PeekMessageW(&msg, nullptr, 0L, 0L, PM_REMOVE)) ;
+
+		CDlgOpenFile::resetInstance();
 	}
 };
 
@@ -550,14 +560,15 @@ TEST_F(TrayWndTest, OpenFile101)
 	// 開いているファイルの数を上限値に設定する
 	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
 
-	// 表示されたファイルダイアログを閉じるためのスレッドを起動する
-	auto t1 = StartEnterOpenFileName(path);
+	MockCDlgOpenFile::gm_Files.emplace_back(path.native());
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModalOpenDlg(_, _, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_FILEOPEN);
-
-	// ファイルダイアログが閉じられるのを待つ
-	t1.join();
 
 	// 設定を元に戻す
 	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
@@ -646,12 +657,15 @@ TEST_F(TrayWndTest, SelectAndOpenFilesFromMruFile102)
  */
 TEST_F(TrayWndTest, SelectAndOpenFilesFromMruFolder101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
-
 	GetDllShareData().m_sHistory.m_nOPENFOLDERArrNum = 1;
 
-	// ファイルを開くダイアログを表示する
+	MockCDlgOpenFile::gm_Files.clear();
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModalOpenDlg(_, _, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, IDM_SELOPENFOLDER);
 
@@ -885,11 +899,13 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 	std::unique_ptr<CMacroManagerBase> mgr = nullptr;
 
 	/*!
-	 * テストが実行された直前に毎回呼ばれる関数
+	 * テストが実行される直前に毎回呼ばれる関数
 	 */
 	void SetUp() override
 	{
 		mgr = std::unique_ptr<CMacroManagerBase>(CMacroFactory::getInstance()->Create(L"mac"));
+
+		CDlgOpenFile::setInstance<MockCDlgOpenFile>();
 	}
 
 	/*!
@@ -906,6 +922,8 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 		// キューに溜まったメッセージは全部捨てる
 		MSG msg{};
 		while (::PeekMessageW(&msg, nullptr, 0L, 0L, PM_REMOVE)) ;
+
+		CDlgOpenFile::resetInstance();
 
 		mgr = nullptr;
 	}
@@ -1089,8 +1107,12 @@ TEST_F(EditWndTest, OnCommand101)
 
 TEST_F(EditWndTest, OnCommand102)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	MockCDlgOpenFile::gm_Files.clear();
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModalOpenDlg(_, _, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	GetDllShareData().m_sHistory.m_nOPENFOLDERArrNum = 1;
 
@@ -1834,31 +1856,17 @@ TEST_F(EditWndTest, ShowDlgKeywordSelect101)
 /*!
  * ファイルを開くダイアログの表示テスト
  */
-TEST_F(EditWndTest, ShowDlgOpenFileLegacy101)
-{
-	// Vistaスタイルのファイルダイアログを無効にする
-	GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = false;
-
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
-
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"FileOpen('', 99, 0, '無題1')"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
-
-	// 設定を元に戻す
-	GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = true;
-}
-
-/*!
- * ファイルを開くダイアログの表示テスト
- */
 TEST_F(EditWndTest, ShowDlgOpenFile101)
 {
 	// Vistaスタイルのファイルダイアログを有効にする
 	GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = true;
 
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	MockCDlgOpenFile::gm_Files.clear();
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModalOpenDlg(_, _, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"FileOpen('', 99, 0, '無題1')"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -2300,9 +2308,18 @@ TEST_F(EditWndTest, ShowPropCommon003)
 TEST_F(EditWndTest, ShowPropCommon004)
 {
 	const auto exportPath = GetIniFileName().replace_filename(L"メインメニュー.ini");
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	std::error_code ec;
 	std::filesystem::remove(exportPath, ec);
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	// 表示された共通設定を閉じるためのスレッドを起動する
 	auto t = StartDialogCloser(LS(STR_PROPCOMMON), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
@@ -2310,10 +2327,10 @@ TEST_F(EditWndTest, ShowPropCommon004)
 		const auto hWndPage = GetActivePage(hWndDlg);
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
-		EmulateEnterSaveFileName(pUIAutomation, exportPath, st);
+		// 保存先ファイル名の入力はモックで実現する
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
-		EmulateEnterOpenFileName(pUIAutomation, exportPath, st);
+		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
 		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
@@ -2442,9 +2459,18 @@ TEST_F(EditWndTest, ShowPropCommon014)
 TEST_F(EditWndTest, ShowPropCommon015)
 {
 	const auto exportPath = GetIniFileName().replace_filename(L"カスタムメニュー.mnu");
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	std::error_code ec;
 	std::filesystem::remove(exportPath, ec);
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	// 表示された共通設定を閉じるためのスレッドを起動する
 	auto t = StartDialogCloser(LS(STR_PROPCOMMON), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
@@ -2452,10 +2478,10 @@ TEST_F(EditWndTest, ShowPropCommon015)
 		const auto hWndPage = GetActivePage(hWndDlg);
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
-		EmulateEnterSaveFileName(pUIAutomation, exportPath, st);
+		// 保存先ファイル名の入力はモックで実現する
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
-		EmulateEnterOpenFileName(pUIAutomation, exportPath, st);
+		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
 		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
@@ -2474,9 +2500,18 @@ TEST_F(EditWndTest, ShowPropCommon015)
 TEST_F(EditWndTest, ShowPropCommon016)
 {
 	const auto exportPath = GetIniFileName().replace_filename(L"強調キーワード.kwd");
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	std::error_code ec;
 	std::filesystem::remove(exportPath, ec);
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	// 表示された共通設定を閉じるためのスレッドを起動する
 	auto t = StartDialogCloser(LS(STR_PROPCOMMON), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
@@ -2484,10 +2519,10 @@ TEST_F(EditWndTest, ShowPropCommon016)
 		const auto hWndPage = GetActivePage(hWndDlg);
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
-		EmulateEnterSaveFileName(pUIAutomation, exportPath, st);
+		// 保存先ファイル名の入力はモックで実現する
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
-		EmulateEnterOpenFileName(pUIAutomation, exportPath, st);
+		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
 		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
@@ -2561,9 +2596,18 @@ TEST_F(EditWndTest, ShowPropType002)
 TEST_F(EditWndTest, ShowPropType003)
 {
 	const auto exportPath = GetIniFileName().replace_filename(L"基本.col");
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	std::error_code ec;
 	std::filesystem::remove(exportPath, ec);
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
 	auto t = StartDialogCloser(LS(STR_PROPTYPE), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
@@ -2585,10 +2629,10 @@ TEST_F(EditWndTest, ShowPropType003)
 		}
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_EXPORT, st);	// L"エクスポート(X)..."
-		EmulateEnterSaveFileName(pUIAutomation, exportPath, st);
+		// 保存先ファイル名の入力はモックで実現する
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_IMPORT, st);	// L"インポート(I)..."
-		EmulateEnterOpenFileName(pUIAutomation, exportPath, st);
+		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
 		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
@@ -2654,9 +2698,18 @@ TEST_F(EditWndTest, ShowPropType005)
 TEST_F(EditWndTest, ShowPropType006)
 {
 	const auto exportPath = GetIniFileName().replace_filename(L"テキスト.rkw");
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	std::error_code ec;
 	std::filesystem::remove(exportPath, ec);
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
 	auto t = StartDialogCloser(LS(STR_PROPTYPE), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
@@ -2664,10 +2717,10 @@ TEST_F(EditWndTest, ShowPropType006)
 		const auto hWndPage = GetActivePage(hWndDlg);
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
-		EmulateEnterSaveFileName(pUIAutomation, exportPath, st);
+		// 保存先ファイル名の入力はモックで実現する
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
-		EmulateEnterOpenFileName(pUIAutomation, exportPath, st);
+		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
 		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
@@ -2686,9 +2739,18 @@ TEST_F(EditWndTest, ShowPropType006)
 TEST_F(EditWndTest, ShowPropType007)
 {
 	const auto exportPath = GetIniFileName().replace_filename(L"キーワードヘルプ.txt");
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	std::error_code ec;
 	std::filesystem::remove(exportPath, ec);
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
 
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
 	auto t = StartDialogCloser(LS(STR_PROPTYPE), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
@@ -2696,10 +2758,10 @@ TEST_F(EditWndTest, ShowPropType007)
 		const auto hWndPage = GetActivePage(hWndDlg);
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
-		EmulateEnterSaveFileName(pUIAutomation, exportPath, st);
+		// 保存先ファイル名の入力はモックで実現する
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
-		EmulateEnterOpenFileName(pUIAutomation, exportPath, st);
+		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
 		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -43,6 +43,7 @@
 #include "util/shell.h"
 
 #include <fstream>
+#include <gtest/gtest-spi.h>
 
 #include "config/system_constants.h"
 #include "config/app_constants.h"
@@ -59,6 +60,79 @@ struct MockShell32 final : public Shell32
 {
 	MOCK_CONST_METHOD1(ShellExecuteExW, BOOL (SHELLEXECUTEINFOW*));
 };
+
+namespace dialog {
+
+struct ModalDialogCloserTestPeer {
+	static void NotifyCreate(HWND hWnd, LPCWSTR title)
+	{
+		CREATESTRUCTW createStruct{};
+		createStruct.lpszName = title;
+		createStruct.lpszClass = WC_DIALOG;
+		CBT_CREATEWND createWnd{ &createStruct, HWND_TOP };
+		ModalDialogCloser::CBTProc(HCBT_CREATEWND, std::bit_cast<WPARAM>(hWnd), LPARAM(&createWnd));
+	}
+
+	static void ActivateDialog(HWND hWnd)
+	{
+		ModalDialogCloser::CBTProc(HCBT_ACTIVATE, std::bit_cast<WPARAM>(hWnd), 0);
+	}
+
+	static void RunFallback(HWND hWnd)
+	{
+		ModalDialogCloser::TimerProc(hWnd, WM_TIMER, ModalDialogCloser::TIMER_ID_FIRST_IDLE, 0);
+	}
+};
+
+TEST(ModalDialogCloserTest, RunsActionOnActivateOnlyOnce)
+{
+	const auto hWnd = HWND(1);
+	int actionCount = 0;
+	{
+		dialog::ModalDialogCloser closer(L"Test dialog", [&actionCount] (HWND) { ++actionCount; });
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(hWnd, L"Test dialog");
+		dialog::ModalDialogCloserTestPeer::ActivateDialog(hWnd);
+		dialog::ModalDialogCloserTestPeer::ActivateDialog(hWnd);
+		dialog::ModalDialogCloserTestPeer::RunFallback(hWnd);
+	}
+
+	EXPECT_THAT(actionCount, Eq(1));
+}
+
+TEST(ModalDialogCloserTest, KeepsPendingEntryWhenTitleDoesNotMatch)
+{
+	const auto otherHwnd = HWND(3);
+	const auto expectedHwnd = HWND(4);
+	HWND handledHwnd = nullptr;
+	{
+		dialog::ModalDialogCloser closer(L"Expected dialog", [&handledHwnd] (HWND hWnd) { handledHwnd = hWnd; });
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(otherHwnd, L"Other dialog");
+		dialog::ModalDialogCloserTestPeer::ActivateDialog(otherHwnd);
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(expectedHwnd, L"Expected dialog");
+		dialog::ModalDialogCloserTestPeer::ActivateDialog(expectedHwnd);
+	}
+
+	EXPECT_THAT(handledHwnd, Eq(expectedHwnd));
+}
+
+TEST(ModalDialogCloserTest, HandlesMultipleEntriesInRegistrationOrder)
+{
+	const auto firstHwnd = HWND(5);
+	const auto secondHwnd = HWND(6);
+	std::vector<HWND> handledWindows;
+	{
+		dialog::ModalDialogCloser firstCloser(L"First dialog", [&handledWindows] (HWND hWnd) { handledWindows.emplace_back(hWnd); });
+		dialog::ModalDialogCloser secondCloser(L"Second dialog", [&handledWindows] (HWND hWnd) { handledWindows.emplace_back(hWnd); });
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(firstHwnd, L"First dialog");
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(secondHwnd, L"Second dialog");
+		dialog::ModalDialogCloserTestPeer::ActivateDialog(firstHwnd);
+		dialog::ModalDialogCloserTestPeer::ActivateDialog(secondHwnd);
+	}
+
+	EXPECT_THAT(handledWindows, testing::ElementsAre(firstHwnd, secondHwnd));
+}
+
+} // namespace dialog
 
 namespace env {
 
@@ -504,17 +578,11 @@ TEST_F(TrayWndTest, DoGrep101)
 	// 開いているファイルの数を上限値に設定する
 	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
 
-	// 表示されたGrepダイアログを閉じるためのスレッドを起動する
-	auto t1 = StartDialogCloser(L"Grep", [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
-		// 検索ボタンを押下してGrep実行する
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);	// L"検索(F)"
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"Grep", IDOK);
 
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_GREP_DIALOG);
-
-	// Grepダイアログが閉じられるのを待つ
-	t1.join();
 
 	// 設定を元に戻す
 	GetDllShareData().m_sSearchKeywords.m_aSearchKeys.clear();
@@ -615,18 +683,19 @@ TEST_F(TrayWndTest, OpenNewEditor104)
  */
 TEST_F(TrayWndTest, SelectAndOpenFilesFromMruFile101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 開いているファイルの数を上限値に設定する
+	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
 
 	GetDllShareData().m_Common.m_sFile.m_bRestoreCurPosition = true;
 
 	GetDllShareData().m_sHistory.m_nMRUArrNum = 1;
 
-	// ファイルを開くダイアログを表示する
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, IDM_SELMRU);
 
 	// 設定を元に戻す
+	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
+
 	GetDllShareData().m_sHistory.m_nMRUArrNum = 0;
 
 	GetDllShareData().m_Common.m_sFile.m_bRestoreCurPosition = true;
@@ -637,18 +706,19 @@ TEST_F(TrayWndTest, SelectAndOpenFilesFromMruFile101)
  */
 TEST_F(TrayWndTest, SelectAndOpenFilesFromMruFile102)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 開いているファイルの数を上限値に設定する
+	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
 
 	GetDllShareData().m_Common.m_sFile.m_bRestoreCurPosition = false;
 
 	GetDllShareData().m_sHistory.m_nMRUArrNum = 1;
 
-	// ファイルを開くダイアログを表示する
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, IDM_SELMRU);
 
 	// 設定を元に戻す
+	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
+
 	GetDllShareData().m_sHistory.m_nMRUArrNum = 0;
 
 	GetDllShareData().m_Common.m_sFile.m_bRestoreCurPosition = true;
@@ -688,10 +758,8 @@ TEST_F(TrayWndTest, SaveAllFiles101)
  */
 TEST_F(TrayWndTest, ShowDlgAbout001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"バージョン情報", IDOK);
 
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_ABOUT);
@@ -702,10 +770,8 @@ TEST_F(TrayWndTest, ShowDlgAbout001)
  */
 TEST_F(TrayWndTest, ShowDlgFavorite001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"履歴とお気に入りの管理", IDOK);
 
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_FAVORITE);
@@ -716,8 +782,8 @@ TEST_F(TrayWndTest, ShowDlgFavorite001)
  */
 TEST_F(TrayWndTest, ShowDlgTypeList101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"タイプ別設定一覧");
 
 	// タイプ別設定一覧ダイアログを表示する
 	HWND hWndTray = nullptr;
@@ -729,8 +795,10 @@ TEST_F(TrayWndTest, ShowDlgTypeList101)
  */
 TEST_F(TrayWndTest, ShowDlgWinList101)
 {
-	// 表示されたウィンドウ一覧ダイアログを閉じるためのスレッドを起動する
-	auto t1 = StartDialogCloser(LS(F_WINDOW_LIST_SUBMENU));
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"ウィンドウ一覧", [] (HWND hWndDlg) {
+		::EndDialog(hWndDlg, IDOK);
+	});
 
 	HWND hWndTray = nullptr;
 	EXPECT_THAT(pcTrayWnd->DispatchEvent(hWndTray, MYWM_DLGWINLIST, 0L, 0L), IsFalse());
@@ -761,7 +829,7 @@ TEST_F(TrayWndTest, ShowPropCommon001)
 	CJackManager::getInstance();
 
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t1 = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t1 = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	// 共通設定プロパティーシートを表示する
 	HWND hWndTray = nullptr;
@@ -776,21 +844,15 @@ TEST_F(TrayWndTest, ShowPropCommon001)
  */
 TEST_F(TrayWndTest, ShowPropType001)
 {
-	// 表示されたタイプ別設定一覧を閉じるためのスレッドを起動する
-	auto t1 = StartDialogCloser(L"タイプ別設定一覧");
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"タイプ別設定一覧", IDOK);
 
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t2 = StartDialogCloser(LS(STR_PROPTYPE), [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
-		// キャンセルボタンを押下して閉じる
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDCANCEL, st);
-	});
+	auto t1 = StartPropertySheetCloser(STR_PROPTYPE);
 
 	// タイプ別設定一覧ダイアログを表示する
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_TYPE_LIST);
-
-	t2.join();
-	t1.join();
 }
 
 /*!
@@ -801,11 +863,6 @@ TEST_F(TrayWndTest, ShowPropType001)
  */
 TEST_F(TrayWndTest, ShowTrayMenu001)
 {
-	// 表示された履歴とお気に入りの管理ダイアログを閉じる
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
-
 	// ポップアップメニューは親ウィンドウを指定する必要があるのでダミーウィンドウを作る
 	const auto hInstance = G_AppInstance();
 	const auto hWnd = ::CreateWindowExW(0, WC_STATIC, L"test", 0, 1, 1, 1, 1, HWND(nullptr), HMENU(nullptr), hInstance, nullptr);
@@ -814,6 +871,9 @@ TEST_F(TrayWndTest, ShowTrayMenu001)
 
 	pcTrayWnd->m_hInstance = hInstance;
 	pcTrayWnd->m_hWnd = hWnd;
+
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"履歴とお気に入りの管理", IDOK);
 
 	// ポップアップメニュー項目を選択させる
 	auto t1 = StartPopupMenuSelector(L"履歴の管理(M)...");
@@ -835,11 +895,6 @@ TEST_F(TrayWndTest, ShowTrayMenu001)
  */
 TEST_F(TrayWndTest, ShowContextMenu001)
 {
-	// 表示されたバージョン情報ダイアログを閉じる
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
-
 	// ポップアップメニューは親ウィンドウを指定する必要があるのでダミーウィンドウを作る
 	const auto hInstance = G_AppInstance();
 	const auto hWnd = ::CreateWindowExW(0, WC_STATIC, L"test", 0, 1, 1, 1, 1, HWND(nullptr), HMENU(nullptr), hInstance, nullptr);
@@ -848,6 +903,9 @@ TEST_F(TrayWndTest, ShowContextMenu001)
 
 	pcTrayWnd->m_hInstance = hInstance;
 	pcTrayWnd->m_hWnd = hWnd;
+
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"バージョン情報", IDOK);
 
 	// ポップアップメニュー項目を選択させる
 	auto t1 = StartPopupMenuSelector(L"バージョン情報(A)");
@@ -962,21 +1020,6 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 			EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"OptionType()"), IsTrue());
 			EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 		}
-	}
-
-	HWND GetActivePage(HWND hWndDlg) const
-	{
-		HWND hWndPage = nullptr;
-		const auto startTick = ::GetTickCount64();
-		while ((::GetTickCount64() - startTick) < 1000) {
-			hWndPage = HWND(::SendMessageW(hWndDlg, PSM_GETCURRENTPAGEHWND, 0L, 0L));
-			if (hWndPage != nullptr) {
-				break;
-			}
-			::Sleep(10);
-		}
-		EXPECT_THAT(hWndPage, Ne(nullptr));
-		return hWndPage;
 	}
 };
 
@@ -1447,12 +1490,14 @@ TEST_F(EditWndTest, ShowDlgCancel001)
  */
 TEST_F(EditWndTest, ShowDlgFind001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"検索", IDOK);
 
 	pcEditWnd->m_cDlgFind.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()));
+
+	// キューに溜まったメッセージは全部捨てる
+	BlockingHook(nullptr);
+
 	pcEditWnd->m_cDlgFind.CloseDialog(0);
 }
 
@@ -1497,8 +1542,8 @@ TEST_F(EditWndTest, ShowDlgReplace001)
  */
 TEST_F(EditWndTest, ShowDlgAbout101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([this] (HWND hWndDlg) {
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"バージョン情報", [this] (HWND hWndDlg) {
 		std::vector<INPUT> inputs{};
 		RECT rc{};
 
@@ -1510,7 +1555,7 @@ TEST_F(EditWndTest, ShowDlgAbout101)
 
 		EXPECT_THAT(SendInput(inputs), Eq(std::size(inputs)));
 
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
+		SendDlgCommand(hWndDlg, IDOK);
 	});
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"About()"), IsTrue());
@@ -1522,10 +1567,8 @@ TEST_F(EditWndTest, ShowDlgAbout101)
  */
 TEST_F(EditWndTest, ShowDlgCompare001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ファイル内容比較", IDOK);
 
 	CDlgCompare cDlgCompare;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1539,8 +1582,8 @@ TEST_F(EditWndTest, ShowDlgCompare001)
  */
 TEST_F(EditWndTest, ShowDlgCompare101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ファイル内容比較");
 
 	CDlgCompare cDlgCompare;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1554,10 +1597,8 @@ TEST_F(EditWndTest, ShowDlgCompare101)
  */
 TEST_F(EditWndTest, ShowDlgCtrlCode001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"コントロールコード", IDOK);
 
 	using target = CDlgCtrlCode;
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"CtrlCodeDialog()"), IsTrue());
@@ -1569,8 +1610,8 @@ TEST_F(EditWndTest, ShowDlgCtrlCode001)
  */
 TEST_F(EditWndTest, ShowDlgCtrlCode101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"コントロールコード");
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"CtrlCodeDialog()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -1581,10 +1622,8 @@ TEST_F(EditWndTest, ShowDlgCtrlCode101)
  */
 TEST_F(EditWndTest, ShowDlgDiff001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"DIFF差分表示", IDOK);
 
 	using target = CDlgDiff;
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"DiffDialog()"), IsTrue());
@@ -1596,8 +1635,8 @@ TEST_F(EditWndTest, ShowDlgDiff001)
  */
 TEST_F(EditWndTest, ShowDlgDiff101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"DIFF差分表示");
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"DiffDialog()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -1608,8 +1647,8 @@ TEST_F(EditWndTest, ShowDlgDiff101)
  */
 TEST_F(EditWndTest, ShowDlgExec001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"ファイル名を指定して実行", [] (HWND hWndDlg) {
 		// プログラムを起動させに行く。
 		::SetDlgItemTextW(hWndDlg, IDC_COMBO_m_szCommand, L"ctags.exe --version");
 		::CheckDlgButtonBool(hWndDlg, IDC_CHECK_GETSTDOUT, true);
@@ -1617,7 +1656,7 @@ TEST_F(EditWndTest, ShowDlgExec001)
 		::CheckDlgButtonBool(hWndDlg, IDC_CHECK_CUR_DIR, true);
 		::SetDlgItemTextW(hWndDlg, IDC_COMBO_CUR_DIR, GetExeFileName().parent_path().c_str());
 
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
+		SendDlgCommand(hWndDlg, IDOK);
 	});
 
 	using target = CDlgExec;
@@ -1630,8 +1669,8 @@ TEST_F(EditWndTest, ShowDlgExec001)
  */
 TEST_F(EditWndTest, ShowDlgExec101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ファイル名を指定して実行");
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ExecCommandDialog()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -1642,10 +1681,8 @@ TEST_F(EditWndTest, ShowDlgExec101)
  */
 TEST_F(EditWndTest, ShowDlgFavorite001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"履歴とお気に入りの管理", IDOK);
 
 	using target = CDlgFavorite;
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"OptionFavorite()"), IsTrue());
@@ -1657,8 +1694,8 @@ TEST_F(EditWndTest, ShowDlgFavorite001)
  */
 TEST_F(EditWndTest, ShowDlgFavorite101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"履歴とお気に入りの管理");
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"OptionFavorite()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -1669,10 +1706,8 @@ TEST_F(EditWndTest, ShowDlgFavorite101)
  */
 TEST_F(EditWndTest, ShowDlgFileTree001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ファイルツリー設定", IDOK);
 
 	CDlgFileTree cDlgFileTree;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1685,8 +1720,8 @@ TEST_F(EditWndTest, ShowDlgFileTree001)
  */
 TEST_F(EditWndTest, ShowDlgFileTree101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ファイルツリー設定");
 
 	CDlgFileTree cDlgFileTree;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1699,8 +1734,8 @@ TEST_F(EditWndTest, ShowDlgFileTree101)
  */
 TEST_F(EditWndTest, ShowDlgFileUpdateQuery101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ファイルが更新されました");
 
 	CDlgFileUpdateQuery cDlgFileUpdateQuery(L"", false);
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1712,10 +1747,10 @@ TEST_F(EditWndTest, ShowDlgFileUpdateQuery101)
  */
 TEST_F(EditWndTest, ShowDlgGrep001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDCANCEL, BN_CLICKED), 0);
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"Grep", [] (HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDOK);
+		SendDlgCommand(hWndDlg, IDCANCEL);
 	});
 
 	using target = CDlgGrep;
@@ -1727,8 +1762,8 @@ TEST_F(EditWndTest, ShowDlgGrep001)
  */
 TEST_F(EditWndTest, ShowDlgGrep101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"Grep");
 
 	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_GREP_DIALOG, true, 0, 0, 0, 0);
 }
@@ -1738,10 +1773,10 @@ TEST_F(EditWndTest, ShowDlgGrep101)
  */
 TEST_F(EditWndTest, ShowDlgGrepReplace001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDCANCEL, BN_CLICKED), 0);
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"Grep置換", [] (HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDOK);
+		SendDlgCommand(hWndDlg, IDCANCEL);
 	});
 
 	using target = CDlgGrepReplace;
@@ -1753,8 +1788,8 @@ TEST_F(EditWndTest, ShowDlgGrepReplace001)
  */
 TEST_F(EditWndTest, ShowDlgGrepReplace101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"Grep置換");
 
 	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_GREP_REPLACE_DLG, true, 0, 0, 0, 0);
 }
@@ -1764,18 +1799,18 @@ TEST_F(EditWndTest, ShowDlgGrepReplace101)
  */
 TEST_F(EditWndTest, ShowDlgInputBox001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"汎用入力ダイアログ", [] (HWND hWndDlg) {
 		// 不明なボタンIDで処理中断
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDC_EDIT_INPUT1, BN_CLICKED), LPARAM(::GetDlgItem(hWndDlg, IDC_EDIT_INPUT1)));
+		SendDlgCommand(hWndDlg, IDC_EDIT_INPUT1);
 
 		// 文字数超過で処理中断
 		::SetDlgItemTextW(hWndDlg, IDC_EDIT_INPUT1, L"test");
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
+		SendDlgCommand(hWndDlg, IDOK);
 
 		// 適切な入力なら取り込む
 		::SetDlgItemTextW(hWndDlg, IDC_EDIT_INPUT1, L"tes");
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
+		SendDlgCommand(hWndDlg, IDOK);
 	});
 
 	std::wstring buffer{ L"TES" };
@@ -1791,8 +1826,8 @@ TEST_F(EditWndTest, ShowDlgInputBox001)
  */
 TEST_F(EditWndTest, ShowDlgInputBox101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"汎用入力ダイアログ");
 
 	// マクロ関数を呼ぶためにWSHマクロマネージャーを使う
 	mgr = std::unique_ptr<CMacroManagerBase>(CMacroFactory::getInstance()->Create(L"js"));
@@ -1806,10 +1841,10 @@ TEST_F(EditWndTest, ShowDlgInputBox101)
  */
 TEST_F(EditWndTest, ShowDlgJump001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDC_BUTTON_JUMP, BN_CLICKED), LPARAM(::GetDlgItem(hWndDlg, IDC_BUTTON_JUMP )));
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDCANCEL, BN_CLICKED), 0);
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"指定行へジャンプ", [] (HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDC_BUTTON_JUMP);
+		SendDlgCommand(hWndDlg, IDCANCEL);
 	});
 
 	using target = CDlgJump;
@@ -1821,8 +1856,8 @@ TEST_F(EditWndTest, ShowDlgJump001)
  */
 TEST_F(EditWndTest, ShowDlgJump101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"指定行へジャンプ");
 
 	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_JUMP_DIALOG, true, 0, 0, 0, 0);
 }
@@ -1832,10 +1867,8 @@ TEST_F(EditWndTest, ShowDlgJump101)
  */
 TEST_F(EditWndTest, ShowDlgKeywordSelect001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"強調キーワードの設定", IDOK);
 
 	CDlgKeywordSelect cDlgKeywordSelect;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1848,8 +1881,8 @@ TEST_F(EditWndTest, ShowDlgKeywordSelect001)
  */
 TEST_F(EditWndTest, ShowDlgKeywordSelect101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"強調キーワードの設定");
 
 	CDlgKeywordSelect cDlgKeywordSelect;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1903,20 +1936,27 @@ TEST_F(EditWndTest, ShowDlgPluginOption001)
 	// プラグイン読み込み
 	CPluginManager::getInstance()->LoadAllPlugin();
 
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
-
 	CDlgPluginOption cDlgPluginOption;
 	const auto hWnd = pcEditWnd->GetHwnd();
 	const auto propPlugin = std::make_unique<CPropPlugin>();
+
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"プラグインの設定", [] (HWND hWndDlg) {
+		// "%ls プラグインの設定"
+		const auto title = strprintf(LS(STR_DLGPLUGINOPT_TITLE), L"Test WSH Plugin");
+		EXPECT_THAT(apiwrap::GetWindowTextW(hWndDlg), StrEq(title));
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
 	cDlgPluginOption.DoModal(unusedArg1, hWnd, propPlugin.get(), pluginId);
 
+	// 存在しないプラグイン番号を指定すると、ダイアログは表示されない
 	cDlgPluginOption.DoModal(unusedArg1, hWnd, propPlugin.get(), 0);
 
 	// プラグイン読み込み解除
 	CPluginManager::getInstance()->UnloadAllPlugin();
 
-	if (const auto pluginPath = GetIniFileName().remove_filename().append(L"plugins"); fexist(pluginPath)) {
+	if (fexist(pluginPath)) {
 		std::error_code ec;
 		std::filesystem::remove_all(pluginPath, ec);
 	}
@@ -1927,10 +1967,8 @@ TEST_F(EditWndTest, ShowDlgPluginOption001)
  */
 TEST_F(EditWndTest, ShowDlgPrintSetting001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"印刷ページ設定", IDOK);
 
 	CDlgPrintSetting cDlgPrintSetting;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1944,8 +1982,8 @@ TEST_F(EditWndTest, ShowDlgPrintSetting001)
  */
 TEST_F(EditWndTest, ShowDlgPrintSetting101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"印刷ページ設定");
 
 	CDlgPrintSetting cDlgPrintSetting;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1959,8 +1997,8 @@ TEST_F(EditWndTest, ShowDlgPrintSetting101)
  */
 TEST_F(EditWndTest, ShowDlgProfileMgr101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"プロファイルマネージャ");
 
 	// プロファイルマネージャーを表示するには、CCommandLineのインスタンスが必要。	👈バグです。
 	CCommandLine cmd;
@@ -1973,10 +2011,8 @@ TEST_F(EditWndTest, ShowDlgProfileMgr101)
  */
 TEST_F(EditWndTest, ShowDlgProperty001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ファイルのプロパティ", IDOK);
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"PropertyFile()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -1987,8 +2023,8 @@ TEST_F(EditWndTest, ShowDlgProperty001)
  */
 TEST_F(EditWndTest, ShowDlgProperty101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ファイルのプロパティ");
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"PropertyFile()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -1999,14 +2035,12 @@ TEST_F(EditWndTest, ShowDlgProperty101)
  */
 TEST_F(EditWndTest, ShowDlgSameColor001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"文字色統一", IDOK);
 
 	CDlgSameColor cDlgSameColor;
 	const auto hWnd = pcEditWnd->GetHwnd();
-	const WORD wID = 1;
+	const WORD wID = IDC_BUTTON_SAMETEXTCOLOR;
 	auto m_nCurrentColorType = 1;
 	auto& m_Types = pcEditDoc->m_cDocType.GetDocumentAttributeWrite();
 	COLORREF cr = m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cTEXT;
@@ -2016,11 +2050,28 @@ TEST_F(EditWndTest, ShowDlgSameColor001)
 /*!
  * 文字色／背景色統一ダイアログの表示テスト
  */
+TEST_F(EditWndTest, ShowDlgSameColor002)
+{
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"文字色統一", [] (HWND hWndDlg) {
+		EXPECT_THAT(apiwrap::GetWindowTextW(hWndDlg), StrEq(L"背景色統一"));
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	CDlgSameColor cDlgSameColor;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	const WORD wID = IDC_BUTTON_SAMEBKCOLOR;
+	auto m_nCurrentColorType = 1;
+	auto& m_Types = pcEditDoc->m_cDocType.GetDocumentAttributeWrite();
+	COLORREF cr = m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cBACK;
+	cDlgSameColor.DoModal(unusedArg1, hWnd, wID, &m_Types, cr);
+}
+
+/*!
+ * 文字色／背景色統一ダイアログの表示テスト
+ */
 TEST_F(EditWndTest, ShowDlgSameColor101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
-
 	CDlgSameColor cDlgSameColor;
 	const auto hWnd = pcEditWnd->GetHwnd();
 	const WORD wID = 1;
@@ -2035,10 +2086,8 @@ TEST_F(EditWndTest, ShowDlgSameColor101)
  */
 TEST_F(EditWndTest, ShowDlgSetCharSet001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"文字コードの指定", IDOK);
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ChgCharSet(99, 0)"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -2049,8 +2098,8 @@ TEST_F(EditWndTest, ShowDlgSetCharSet001)
  */
 TEST_F(EditWndTest, ShowDlgSetCharSet101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"文字コードの指定");
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ChgCharSet(99, 0)"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -2061,10 +2110,8 @@ TEST_F(EditWndTest, ShowDlgSetCharSet101)
  */
 TEST_F(EditWndTest, ShowDlgTagJumpList001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ダイレクトタグジャンプ一覧", IDOK);
 
 	bool bDirectTagJump = false;
 	CDlgTagJumpList cDlgTagJumpList(bDirectTagJump);
@@ -2077,8 +2124,8 @@ TEST_F(EditWndTest, ShowDlgTagJumpList001)
  */
 TEST_F(EditWndTest, ShowDlgTagJumpList101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ダイレクトタグジャンプ一覧");
 
 	bool bDirectTagJump = false;
 	CDlgTagJumpList cDlgTagJumpList(bDirectTagJump);
@@ -2091,10 +2138,8 @@ TEST_F(EditWndTest, ShowDlgTagJumpList101)
  */
 TEST_F(EditWndTest, ShowDlgTagsMake001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"タグファイルの作成", IDOK);
 
 	CDlgTagsMake cDlgTagsMake;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2109,8 +2154,8 @@ TEST_F(EditWndTest, ShowDlgTagsMake001)
  */
 TEST_F(EditWndTest, ShowDlgTagsMake101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"タグファイルの作成");
 
 	CDlgTagsMake cDlgTagsMake;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2125,10 +2170,8 @@ TEST_F(EditWndTest, ShowDlgTagsMake101)
  */
 TEST_F(EditWndTest, ShowDlgTypeAscertain001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"インポート確認", IDOK);
 
 	CDlgTypeAscertain cDlgTypeAscertain;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2141,8 +2184,8 @@ TEST_F(EditWndTest, ShowDlgTypeAscertain001)
  */
 TEST_F(EditWndTest, ShowDlgTypeAscertain101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"インポート確認");
 
 	CDlgTypeAscertain cDlgTypeAscertain;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2155,10 +2198,8 @@ TEST_F(EditWndTest, ShowDlgTypeAscertain101)
  */
 TEST_F(EditWndTest, ShowDlgTypeList001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"タイプ別設定一覧", IDOK);
 
 	CDlgTypeList cDlgTypeList;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2171,8 +2212,8 @@ TEST_F(EditWndTest, ShowDlgTypeList001)
  */
 TEST_F(EditWndTest, ShowDlgTypeList101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"タイプ別設定一覧");
 
 	CDlgTypeList cDlgTypeList;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2185,10 +2226,8 @@ TEST_F(EditWndTest, ShowDlgTypeList101)
  */
 TEST_F(EditWndTest, ShowDlgWinSize001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([] (HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
-	});
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ウィンドウの位置と大きさ", IDOK);
 
 	CDlgWinSize cDlgWinSize;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2204,8 +2243,8 @@ TEST_F(EditWndTest, ShowDlgWinSize001)
  */
 TEST_F(EditWndTest, ShowDlgWinSize101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ウィンドウの位置と大きさ");
 
 	CDlgWinSize cDlgWinSize;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2221,9 +2260,9 @@ TEST_F(EditWndTest, ShowDlgWinSize101)
  */
 TEST_F(EditWndTest, ShowDlgWindowList001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([](HWND hWndDlg) {
-		::SendMessageW(hWndDlg, WM_COMMAND, MAKELONG(IDOK, BN_CLICKED), 0);
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ウィンドウ一覧", [] (HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDOK);
 		::EndDialog(hWndDlg, IDOK);
 	});
 
@@ -2237,8 +2276,8 @@ TEST_F(EditWndTest, ShowDlgWindowList001)
  */
 TEST_F(EditWndTest, ShowDlgWindowList101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じるようにする
-	dialog::ModalDialogCloser closer([](HWND hWndDlg){
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ウィンドウ一覧", [] (HWND hWndDlg) {
 		// キャンセルボタンが存在しないので強制的に閉じる
 		::EndDialog(hWndDlg, 0);
 	});
@@ -2279,7 +2318,7 @@ TEST_F(EditWndTest, ShowHokanMgr001)
 TEST_F(EditWndTest, ShowPropCommon001)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON, PSBTN_CANCEL);
 
 	ShowPropCommon();
 }
@@ -2290,7 +2329,7 @@ TEST_F(EditWndTest, ShowPropCommon001)
 TEST_F(EditWndTest, ShowPropCommon002)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_GENERAL);
 }
@@ -2301,7 +2340,7 @@ TEST_F(EditWndTest, ShowPropCommon002)
 TEST_F(EditWndTest, ShowPropCommon003)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_WIN);
 }
@@ -2326,18 +2365,18 @@ TEST_F(EditWndTest, ShowPropCommon004)
 		.WillOnce(testing::DoDefault());
 
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
+	auto t = StartDialogCloser(STR_PROPCOMMON, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
 		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg);
+		const auto hWndPage = GetActivePage(hWndDlg, st);
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_EXPORT, st);	// L"エクスポート(X)..."
 		// 保存先ファイル名の入力はモックで実現する
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_IMPORT, st);	// L"インポート(I)..."
 		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
 	});
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_MAINMENU);
@@ -2353,7 +2392,7 @@ TEST_F(EditWndTest, ShowPropCommon004)
 TEST_F(EditWndTest, ShowPropCommon005)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_TOOLBAR);
 }
@@ -2364,7 +2403,7 @@ TEST_F(EditWndTest, ShowPropCommon005)
 TEST_F(EditWndTest, ShowPropCommon006)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_TAB);
 }
@@ -2375,7 +2414,7 @@ TEST_F(EditWndTest, ShowPropCommon006)
 TEST_F(EditWndTest, ShowPropCommon007)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_STATUSBAR);
 }
@@ -2386,7 +2425,7 @@ TEST_F(EditWndTest, ShowPropCommon007)
 TEST_F(EditWndTest, ShowPropCommon008)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_EDIT);
 }
@@ -2397,7 +2436,7 @@ TEST_F(EditWndTest, ShowPropCommon008)
 TEST_F(EditWndTest, ShowPropCommon009)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_FILE);
 }
@@ -2408,7 +2447,7 @@ TEST_F(EditWndTest, ShowPropCommon009)
 TEST_F(EditWndTest, ShowPropCommon010)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_FILENAME);
 }
@@ -2419,7 +2458,7 @@ TEST_F(EditWndTest, ShowPropCommon010)
 TEST_F(EditWndTest, ShowPropCommon011)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_BACKUP);
 }
@@ -2430,7 +2469,7 @@ TEST_F(EditWndTest, ShowPropCommon011)
 TEST_F(EditWndTest, ShowPropCommon012)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_FORMAT);
 }
@@ -2441,7 +2480,7 @@ TEST_F(EditWndTest, ShowPropCommon012)
 TEST_F(EditWndTest, ShowPropCommon013)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_GREP);
 }
@@ -2452,7 +2491,7 @@ TEST_F(EditWndTest, ShowPropCommon013)
 TEST_F(EditWndTest, ShowPropCommon014)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_KEYBOARD);
 }
@@ -2477,18 +2516,18 @@ TEST_F(EditWndTest, ShowPropCommon015)
 		.WillOnce(testing::DoDefault());
 
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
+	auto t = StartDialogCloser(STR_PROPCOMMON, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
 		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg);
+		const auto hWndPage = GetActivePage(hWndDlg, st);
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_EXPORT, st);	// L"エクスポート(X)..."
 		// 保存先ファイル名の入力はモックで実現する
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_IMPORT, st);	// L"インポート(I)..."
 		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
 	});
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_CUSTMENU);
@@ -2518,18 +2557,18 @@ TEST_F(EditWndTest, ShowPropCommon016)
 		.WillOnce(testing::DoDefault());
 
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
+	auto t = StartDialogCloser(STR_PROPCOMMON, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
 		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg);
+		const auto hWndPage = GetActivePage(hWndDlg, st);
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_EXPORT, st);	// L"エクスポート(X)..."
 		// 保存先ファイル名の入力はモックで実現する
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_IMPORT, st);	// L"インポート(I)..."
 		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
 	});
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_KEYWORD);
@@ -2545,7 +2584,7 @@ TEST_F(EditWndTest, ShowPropCommon016)
 TEST_F(EditWndTest, ShowPropCommon017)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_HELPER);
 }
@@ -2556,7 +2595,7 @@ TEST_F(EditWndTest, ShowPropCommon017)
 TEST_F(EditWndTest, ShowPropCommon018)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_MACRO);
 }
@@ -2567,7 +2606,7 @@ TEST_F(EditWndTest, ShowPropCommon018)
 TEST_F(EditWndTest, ShowPropCommon019)
 {
 	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPCOMMON));
+	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_PLUGIN);
 }
@@ -2578,7 +2617,7 @@ TEST_F(EditWndTest, ShowPropCommon019)
 TEST_F(EditWndTest, ShowPropType001)
 {
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPTYPE));
+	auto t = StartPropertySheetCloser(STR_PROPTYPE, PSBTN_CANCEL);
 
 	ShowPropType();
 }
@@ -2589,7 +2628,7 @@ TEST_F(EditWndTest, ShowPropType001)
 TEST_F(EditWndTest, ShowPropType002)
 {
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPTYPE));
+	auto t = StartPropertySheetCloser(STR_PROPTYPE);
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_SCREEN);
 }
@@ -2614,23 +2653,23 @@ TEST_F(EditWndTest, ShowPropType003)
 		.WillOnce(testing::DoDefault());
 
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPTYPE), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
+	auto t = StartDialogCloser(STR_PROPTYPE, [exportPath] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
 		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg);
+		const auto hWndPage = GetActivePage(hWndDlg, st);
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"文字色統一(<)...", st);
-		if (const auto hWndDlgSameColor = window::WaitForDialog(L"文字色統一", st)) {
-			EmulateInvokeButton(pUIAutomation, hWndDlgSameColor, L"全チェック(A)", st);
-			EmulateInvokeButton(pUIAutomation, hWndDlgSameColor, L"全解除(N)", st);
-			EmulateInvokeButton(pUIAutomation, hWndDlgSameColor, IDOK, st);
-		}
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_SAMETEXTCOLOR, st);	// L"文字色統一(<)..."
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"背景色統一(>)...", st);
-		if (const auto hWndDlgSameColor = window::WaitForDialog(L"背景色統一", st)) {
-			EmulateInvokeButton(pUIAutomation, hWndDlgSameColor, L"全チェック(A)", st);
-			EmulateInvokeButton(pUIAutomation, hWndDlgSameColor, L"全解除(N)", st);
-			EmulateInvokeButton(pUIAutomation, hWndDlgSameColor, IDOK, st);
-		}
+		const auto hWndDlgSameColor1 = window::WaitForWindow(WC_DIALOG, L"文字色統一", st);
+		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor1, IDC_BUTTON_SELALL, st);	// L"全チェック(A)"
+		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor1, IDC_BUTTON_SELNOTING, st);	// L"全解除(N)"
+		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor1, IDOK, st);
+
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_SAMEBKCOLOR, st);	// L"背景色統一(>)..."
+
+		const auto hWndDlgSameColor2 = window::WaitForWindow(WC_DIALOG, L"背景色統一", st);
+		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor2, IDC_BUTTON_SELALL, st);	// L"全チェック(A)"
+		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor2, IDC_BUTTON_SELNOTING, st);	// L"全解除(N)"
+		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor2, IDOK, st);
 
 		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_EXPORT, st);	// L"エクスポート(X)..."
 		// 保存先ファイル名の入力はモックで実現する
@@ -2639,7 +2678,7 @@ TEST_F(EditWndTest, ShowPropType003)
 		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
 	});
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_COLOR);
@@ -2655,9 +2694,9 @@ TEST_F(EditWndTest, ShowPropType003)
 TEST_F(EditWndTest, ShowPropType004)
 {
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPTYPE), [this](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
+	auto t = StartDialogCloser(STR_PROPTYPE, [] (const IUIAutomation*, HWND hWndDlg, std::stop_token st) {
 		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg);
+		const auto hWndPage = GetActivePage(hWndDlg, st);
 
 		// トラックバーのハンドルを取得する
 		const auto hWndTrackbar = ::GetDlgItem(hWndPage, IDC_TRACKBAR_BACKIMG_TRANSPARENCY);
@@ -2679,7 +2718,7 @@ TEST_F(EditWndTest, ShowPropType004)
 		FORWARD_WM_HSCROLL(hWndPage, hWndTrackbar, TB_LINEDOWN, -WHEEL_DELTA, ::SendMessageW);
 
 		// OKボタンを押下して閉じる
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
 	});
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_WINDOW);
@@ -2691,7 +2730,7 @@ TEST_F(EditWndTest, ShowPropType004)
 TEST_F(EditWndTest, ShowPropType005)
 {
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPTYPE));
+	auto t = StartPropertySheetCloser(STR_PROPTYPE);
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_SUPPORT);
 }
@@ -2716,18 +2755,18 @@ TEST_F(EditWndTest, ShowPropType006)
 		.WillOnce(testing::DoDefault());
 
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPTYPE), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
+	auto t = StartDialogCloser(STR_PROPTYPE, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
 		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg);
+		const auto hWndPage = GetActivePage(hWndDlg, st);
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_REGEX_EXPORT, st);	// L"エクスポート(X)..."
 		// 保存先ファイル名の入力はモックで実現する
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_REGEX_IMPORT, st);	// L"インポート(I)..."
 		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
 	});
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_REGEX);
@@ -2757,18 +2796,18 @@ TEST_F(EditWndTest, ShowPropType007)
 		.WillOnce(testing::DoDefault());
 
 	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(LS(STR_PROPTYPE), [&](IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
+	auto t = StartDialogCloser(STR_PROPTYPE, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
 		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg);
+		const auto hWndPage = GetActivePage(hWndDlg, st);
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"エクスポート(X)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_KEYHELP_EXPORT, st);	// L"エクスポート(X)..."
 		// 保存先ファイル名の入力はモックで実現する
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, L"インポート(I)...", st);
+		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_KEYHELP_IMPORT, st);	// L"インポート(I)..."
 		// 開くファイル名の入力はモックで実現する
 
 		// OKボタンを押下して閉じる
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
 	});
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_KEYHELP);

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -1146,11 +1146,15 @@ TEST_F(EditWndTest, OnHelp101)
 	EXPECT_THAT(pcEditWnd->DispatchEvent(hWndEdit, WM_HELP, 0L, LPARAM(&hi)), IsTrue());
 }
 
-TEST_F(EditWndTest, OnCommand101)
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
+TEST_F(EditWndTest, DISABLED_OnCommand101)
 {
 	HWND hWndEdit = nullptr;
 	EXPECT_THAT(pcEditWnd->DispatchEvent(hWndEdit, WM_COMMAND, 0L, 0L), IsFalse());
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 TEST_F(EditWndTest, OnCommand102)
 {
@@ -1212,6 +1216,8 @@ TEST_F(EditWndTest, OnMenuChar101)
 	pcEditWnd->DispatchEvent(hWndEdit, WM_MENUCHAR, 0L, 0L);
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 TEST_F(EditWndTest, OnCopy101)
 {
 	HWND hWndEdit = nullptr;
@@ -1223,6 +1229,8 @@ TEST_F(EditWndTest, OnPaste101)
 	HWND hWndEdit = nullptr;
 	pcEditWnd->DispatchEvent(hWndEdit, WM_PASTE, 0L, 0L);
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 TEST_F(EditWndTest, OnMyWmGetLineData101)
 {
@@ -1282,6 +1290,8 @@ TEST_F(EditWndTest, OnMyWmGetLineCount101)
 	EXPECT_THAT(lineCount, Ge(0));
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 TEST_F(EditWndTest, OnMyWmAddStringLenW101)
 {
 	HWND hWndEdit = nullptr;
@@ -1289,6 +1299,8 @@ TEST_F(EditWndTest, OnMyWmAddStringLenW101)
 	::wcscpy_s(pWork, 4, L"abc");
 	EXPECT_THAT(pcEditWnd->DispatchEvent(hWndEdit, MYWM_ADDSTRINGLEN_W, 3, 0L), IsFalse());
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 TEST_F(EditWndTest, OnLButtonDown101)
 {
@@ -1325,6 +1337,8 @@ TEST_F(EditWndTest, OnLButtonDblClk101)
 	HWND hWndEdit = nullptr;
 	EXPECT_THAT(pcEditWnd->DispatchEvent(hWndEdit, WM_LBUTTONDBLCLK, 0L, MAKELPARAM(10, 20)), IsFalse());
 }
+
+#if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * コマンド：コマンドプロンプトを開く
@@ -1471,6 +1485,8 @@ TEST_F(EditWndTest, GetDocDataObject001)
 	std::filesystem::remove(targetPath, ec);
 }
 
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * キャンセルダイアログの表示テスト
  */
@@ -1484,6 +1500,8 @@ TEST_F(EditWndTest, ShowDlgCancel001)
 
 	cDlgCancel.CloseDialog(0);
 }
+
+#if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * 検索ダイアログの表示テスト
@@ -1562,6 +1580,8 @@ TEST_F(EditWndTest, ShowDlgAbout101)
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 }
 
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * ファイル比較ダイアログの表示テスト
  */
@@ -1591,6 +1611,8 @@ TEST_F(EditWndTest, ShowDlgCompare101)
 	HWND hWndCompareWnd = nullptr;
 	cDlgCompare.DoModal(unusedArg1, hWnd, unusedArg2, L"", &hWndCompareWnd);
 }
+
+#if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * コントロールコード入力ダイアログの表示テスト
@@ -1701,6 +1723,8 @@ TEST_F(EditWndTest, ShowDlgFavorite101)
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 }
 
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * ファイルツリーダイアログの表示テスト
  */
@@ -1741,6 +1765,8 @@ TEST_F(EditWndTest, ShowDlgFileUpdateQuery101)
 	const auto hWnd = pcEditWnd->GetHwnd();
 	cDlgFileUpdateQuery.DoModal(unusedArg1, hWnd, IDD_FILEUPDATEQUERY, 0 );
 }
+
+#if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * Grepダイアログの表示テスト
@@ -1794,6 +1820,8 @@ TEST_F(EditWndTest, ShowDlgGrepReplace101)
 	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_GREP_REPLACE_DLG, true, 0, 0, 0, 0);
 }
 
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * 1行入力ダイアログの表示テスト
  */
@@ -1820,6 +1848,8 @@ TEST_F(EditWndTest, ShowDlgInputBox001)
 
 	EXPECT_THAT(buffer, StrEq(L"tes"));
 }
+
+#if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * 1行入力ダイアログの表示テスト
@@ -1862,6 +1892,8 @@ TEST_F(EditWndTest, ShowDlgJump101)
 	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_JUMP_DIALOG, true, 0, 0, 0, 0);
 }
 
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * 強調キーワード選択ダイアログの表示テスト
  */
@@ -1890,6 +1922,8 @@ TEST_F(EditWndTest, ShowDlgKeywordSelect101)
 	cDlgKeywordSelect.DoModal(unusedArg1, hWnd, nSet.data());
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * ファイルを開くダイアログの表示テスト
  */
@@ -1908,6 +1942,8 @@ TEST_F(EditWndTest, ShowDlgOpenFile101)
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"FileOpen('', 99, 0, '無題1')"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * プラグイン設定ダイアログの表示テスト
@@ -1992,6 +2028,8 @@ TEST_F(EditWndTest, ShowDlgPrintSetting101)
 	cDlgPrintSetting.DoModal(unusedArg1, hWnd, &nCurrentPrintSetting, GetDllShareData().m_PrintSettingArr, nLineNumberColumns);
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * プロファイルマネージャーダイアログの表示テスト
  */
@@ -2029,6 +2067,8 @@ TEST_F(EditWndTest, ShowDlgProperty101)
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"PropertyFile()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * 文字色／背景色統一ダイアログの表示テスト
@@ -2081,6 +2121,8 @@ TEST_F(EditWndTest, ShowDlgSameColor101)
 	cDlgSameColor.DoModal(unusedArg1, hWnd, wID, &m_Types, cr);
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * 文字コードセット設定ダイアログの表示テスト
  */
@@ -2104,6 +2146,8 @@ TEST_F(EditWndTest, ShowDlgSetCharSet101)
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ChgCharSet(99, 0)"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * タグジャンプダイアログの表示テスト
@@ -2287,6 +2331,8 @@ TEST_F(EditWndTest, ShowDlgWindowList101)
 	cDlgWindowList.DoModal(unusedArg1, hWnd, 0);
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * 補完ダイアログの表示テスト
  */
@@ -2311,6 +2357,8 @@ TEST_F(EditWndTest, ShowHokanMgr001)
 
 	pcEditWnd->m_cHokanMgr.CloseDialog(0);
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * 共通設定プロパティーシートの表示テスト
@@ -2638,6 +2686,8 @@ TEST_F(EditWndTest, ShowPropType002)
  */
 TEST_F(EditWndTest, ShowPropType003)
 {
+	RunGuiTest([this] {
+
 	const auto exportPath = GetIniFileName().replace_filename(L"基本.col");
 	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
@@ -2686,6 +2736,8 @@ TEST_F(EditWndTest, ShowPropType003)
 	t.join();
 
 	std::filesystem::remove(exportPath, ec);
+
+	});
 }
 
 /*!

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -134,7 +134,7 @@ struct TrayWndTest : public ::testing::Test, public env::ShareDataTestSuite, pub
 		pCommandLine = std::make_unique<CCommandLine>();
 		pCommandLine->ParseCommandLine(L"-PROF=", false);
 
-		SetUpUia();
+		SetUpUiaTestSuite();
 
 		SetUpShareData();
 
@@ -168,7 +168,7 @@ struct TrayWndTest : public ::testing::Test, public env::ShareDataTestSuite, pub
 
 		TearDownShareData();
 
-		TearDownUia();
+		TearDownUiaTestSuite();
 
 		pCommandLine = nullptr;
 	}
@@ -873,7 +873,7 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 		pCommandLine = std::make_unique<CCommandLine>();
 		pCommandLine->ParseCommandLine(L"-PROF=", false);
 
-		SetUpUia();
+		SetUpUiaTestSuite();
 
 		SetUpEditor();
 
@@ -891,7 +891,7 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 
 		TearDownEditor();
 
-		TearDownUia();
+		TearDownUiaTestSuite();
 
 		pCommandLine = nullptr;
 	}

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -710,18 +710,6 @@ TEST_F(TrayWndTest, ShowDlgFavorite001)
 }
 
 /*!
- * ウィンドウ一覧ダイアログを表示する
- */
-TEST_F(TrayWndTest, ShowDlgWinList101)
-{
-	// 表示されたウィンドウ一覧ダイアログを閉じるためのスレッドを起動する
-	auto t1 = StartDialogCloser(LS(F_WINDOW_LIST_SUBMENU));
-
-	HWND hWndTray = nullptr;
-	EXPECT_THAT(pcTrayWnd->DispatchEvent(hWndTray, MYWM_DLGWINLIST, 0L, 0L), IsFalse());
-}
-
-/*!
  * タイプ別設定一覧ダイアログの表示テスト
  */
 TEST_F(TrayWndTest, ShowDlgTypeList101)
@@ -732,6 +720,18 @@ TEST_F(TrayWndTest, ShowDlgTypeList101)
 	// タイプ別設定一覧ダイアログを表示する
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_TYPE_LIST);
+}
+
+/*!
+ * ウィンドウ一覧ダイアログを表示する
+ */
+TEST_F(TrayWndTest, ShowDlgWinList101)
+{
+	// 表示されたウィンドウ一覧ダイアログを閉じるためのスレッドを起動する
+	auto t1 = StartDialogCloser(LS(F_WINDOW_LIST_SUBMENU));
+
+	HWND hWndTray = nullptr;
+	EXPECT_THAT(pcTrayWnd->DispatchEvent(hWndTray, MYWM_DLGWINLIST, 0L, 0L), IsFalse());
 }
 
 /*!

--- a/src/test/cpp/tests1/test-winmain.cpp
+++ b/src/test/cpp/tests1/test-winmain.cpp
@@ -648,6 +648,8 @@ struct TWinMainTest : public T, public window::UiaTestSuite {
 		if (const std::wstring_view profileName{ GetProfileName() }; !profileName.empty()) {
 			std::filesystem::remove_all(iniPath.parent_path());
 		}
+
+		TearDownUia();
 	}
 
 	/*!

--- a/src/test/cpp/tests1/test-winmain.cpp
+++ b/src/test/cpp/tests1/test-winmain.cpp
@@ -560,7 +560,7 @@ struct TWinMainTest : public T, public window::UiaTestSuite {
 	 */
 	static void SetUpTestSuite() {
 		// UI Automationを初期化する
-		SetUpUia();
+		SetUpUiaTestSuite();
 
 		// テスト用ファイル作成
 		std::wofstream fos(gm_TestDataPath);
@@ -586,7 +586,7 @@ struct TWinMainTest : public T, public window::UiaTestSuite {
 		}
 
 		// UI Automationをシャットダウンする
-		TearDownUia();
+		TearDownUiaTestSuite();
 	}
 
 	/*!

--- a/src/test/cpp/tests1/window/UiaTestSuite.cpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.cpp
@@ -192,7 +192,7 @@ HWND WaitForWindow(
 /*!
  * テストスイートの開始前に1回だけ呼ばれる関数
  */
-/* static */ void UiaTestSuite::SetUpUia()
+/* static */ void UiaTestSuite::SetUpUiaTestSuite()
 {
 	// OLEを初期化する
 	pcOleInit = std::make_unique<cxx::COleInit>();
@@ -204,7 +204,7 @@ HWND WaitForWindow(
 /*!
  * テストスイートの終了後に1回だけ呼ばれる関数
  */
-/* static */ void UiaTestSuite::TearDownUia()
+/* static */ void UiaTestSuite::TearDownUiaTestSuite()
 {
 	// OLEをシャットダウンする
 	pcOleInit = nullptr;

--- a/src/test/cpp/tests1/window/UiaTestSuite.cpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.cpp
@@ -8,42 +8,10 @@
 #include "window/UiaTestSuite.hpp"
 
 #include "config/system_constants.h"
-#include "cxx/type_of_Nth_lambda_arg.hpp"
+#include "cxx/load_string.hpp"
 #include "util/window.h"
 
-namespace cxx {
-
-template<typename TQuery, typename R = cxx::lambda_traits<TQuery>::return_type>
-R WaitForQuery(
-	TQuery query,
-	std::stop_token st,
-	ULONGLONG timeoutMillis,
-	DWORD intervalMillis = 100
-)
-{
-	const auto startTick = ::GetTickCount64();
-
-	while (!st.stop_requested()) {
-		// 脱出条件を満たしたら抜ける
-		auto result = query();
-		if (result) return result;
-
-		// タイムアウトしたら抜ける
-		const auto elapsed = ::GetTickCount64() - startTick;	// 経過時間
-		if (timeoutMillis <= elapsed) return result;
-
-		// 停止要求が来ていたら待機せずに抜ける
-		if (st.stop_requested()) return result;
-
-		// GUI待機なので残り時間を考慮して待機する
-		const auto remaining = timeoutMillis - elapsed;			// 残り時間
-		::Sleep(std::min(intervalMillis, DWORD(remaining)));
-	}
-
-	return {};
-}
-
-} // namespace cxx
+using namespace std::literals::string_literals;
 
 namespace uia {
 
@@ -123,14 +91,7 @@ inline cxx::com_pointer<IUIAutomationCondition> CreateAndCondition(
 
 namespace window {
 
-HWND WaitForDialog(
-	const std::wstring& title,
-	std::stop_token st,
-	ULONGLONG timeoutMillis
-)
-{
-	return WaitForWindow(MAKEINTRESOURCEW(dialog::ModalDialogCloser::DIALOG_CLASS), title, st, timeoutMillis);
-}
+bool IsDialog(_In_ HWND hWnd, _In_opt_ LPCWSTR pClassName);
 
 HWND WaitForPopupMenu(
 	std::stop_token st,
@@ -163,27 +124,24 @@ HWND WaitForWindow(
 	ULONGLONG timeoutMillis
 )
 {
-	LPCWSTR pszTitle = optTitle.has_value() ? optTitle.value().c_str() : nullptr;
+	const auto windowType = IS_INTRESOURCE(targetClass) && WC_DIALOG == targetClass ? "Dialog"s : "Window"s;
+	const auto dispTitle = std::format("'{:s}'", cxx::to_string(optTitle.value_or(L""), CP_UTF8));
 
 	// ウィンドウがVisibleかつEnabledになるのを待つ
-	return cxx::WaitForQuery([targetClass, pszTitle] {
+	return cxx::WaitForQuery([targetClass, optTitle, windowType, dispTitle] {
 		// 全プロセスのトップレベルウィンドウを対象に検索する
-		const auto hWndFound = ::FindWindowW(targetClass, pszTitle);
+		const auto hWndFound = ::FindWindowW(targetClass, optTitle.has_value() ? std::data(optTitle.value()) : nullptr);
 		if (!hWndFound) {
-			std::clog << "window not found. "
-				<< (!IS_INTRESOURCE(targetClass) ? std::format("({})", cxx::to_string(targetClass, CP_UTF8)) : "(Dialog)")
-				<< ", "
-				<< (pszTitle ? std::format("title: '{}'", cxx::to_string(pszTitle, CP_UTF8)) : "no title")
-				<< std::endl;
+			std::clog << std::format("{:s} not found.", windowType) << (optTitle.has_value() ? std::format(" title: {:s}", dispTitle) : "") << std::endl;
 		} else if (!::IsWindowVisible(hWndFound)) {
-			std::clog << "window is not visible." << std::endl;
+			std::clog << std::format("{:s} is not visible.", windowType) << (optTitle.has_value() ? std::format(" title: {:s}", dispTitle) : "") << std::endl;
 			return HWND(nullptr);
 		} else if (!::IsWindowEnabled(hWndFound)) {
-			std::clog << "window is disabled." << std::endl;
+			std::clog << std::format("{:s} is disabled.", windowType) << (optTitle.has_value() ? std::format(" title: {:s}", dispTitle) : "") << std::endl;
 			return HWND(nullptr);
 		} else if (hWndFound != ::GetForegroundWindow()) {
-			std::clog << "window is not foreground." << std::endl;
-			return HWND(nullptr);
+			std::clog << std::format("{:s} is not foreground.", windowType) << (optTitle.has_value() ? std::format(" title: {:s}", dispTitle) : "") << std::endl;
+			::SetForegroundWindow(hWndFound);
 		}
 		return hWndFound;
 	}, st, timeoutMillis);
@@ -213,30 +171,6 @@ HWND WaitForWindow(
 /* static */ void UiaTestSuite::EmulateInvokeButton(
 	IUIAutomation* pAutomation,
 	_In_ HWND hWndDlg,
-	std::wstring_view caption,
-	std::stop_token st
-)
-{
-	// ボタンの検索条件を構築する
-	auto pControlTypeCondition = uia::CreatePropertyCondition(pAutomation, UIA_ControlTypePropertyId, UIA_ButtonControlTypeId);
-	auto pNameCondition = uia::CreatePropertyCondition(pAutomation, UIA_NamePropertyId, _bstr_t{ ::SysAllocStringLen(std::data(caption), UINT(std::size(caption))) });
-	auto pFinalCondition = uia::CreateAndCondition(pAutomation, pControlTypeCondition, pNameCondition);
-
-	// ボタンを検索する
-	auto pItem = uia::FindFirst(pAutomation, hWndDlg, TreeScope_Subtree, pFinalCondition, st);
-	ASSERT_THAT(pItem, NotNull()) << "button not found: " << cxx::to_string(caption);
-
-	if (st.stop_requested()) {
-		return;
-	}
-
-	// ボタンを押下する
-	EmulateInvoke(pItem);
-}
-
-/* static */ void UiaTestSuite::EmulateInvokeButton(
-	IUIAutomation* pAutomation,
-	_In_ HWND hWndDlg,
 	int nIDDlgItem,
 	std::stop_token st
 )
@@ -259,6 +193,39 @@ HWND WaitForWindow(
 
 	// ボタンを押下する
 	EmulateInvoke(pItem);
+}
+
+/*!
+ * @brief スレッド実行をブロックしているウィンドウを列挙するコールバック関数
+ *
+ * @param hWnd 列挙されたウィンドウのハンドル
+ * @param lParam 列挙の呼び出し元から渡されたパラメータ（使用しない）
+ */
+/* static */ BOOL CALLBACK UiaTestSuite::CloseBlockingWindowProc(
+	_In_ HWND   hWnd,
+	_In_ LPARAM lParam [[maybe_unused]]
+)
+{
+	if (hWnd && ::IsWindow(hWnd) && ::IsWindowVisible(hWnd)) {
+		if (window::IsDialog(hWnd, nullptr)) {
+			::EndDialog(hWnd, 0);
+		} else {
+			::DestroyWindow(hWnd);
+		}
+	}
+
+	return TRUE;
+}
+
+/* static */ HWND UiaTestSuite::GetActivePage(
+	HWND hWndDlg,
+	std::stop_token st,
+	ULONGLONG timeoutMillis
+)
+{
+	return cxx::WaitForQuery([hWndDlg] {
+		return HWND(::SendMessageW(hWndDlg, PSM_GETCURRENTPAGEHWND, 0L, 0L));
+	}, st, timeoutMillis);
 }
 
 /* static */ void UiaTestSuite::EmulateInvokeMenuItem(
@@ -285,81 +252,128 @@ HWND WaitForWindow(
 	EmulateInvoke(pItem);
 }
 
-/* static */ std::function<void(IUIAutomation*, HWND, std::stop_token)> UiaTestSuite::EmulateEnterFileName(
-	const std::filesystem::path& path
+/* static */ void UiaTestSuite::SendDlgCommand(
+	_In_ HWND hWndDlg,
+	int nIDDlgItem,
+	int notifyCode
 )
 {
-	return [path] (IUIAutomation* pAutomation, HWND, std::stop_token st) {
-		// ファイル名を入力する
-		EmulateSetValue(uia::GetFocusedElement(pAutomation), path.native());
+	const auto hWndCtrl = ::GetDlgItem(hWndDlg, nIDDlgItem);
+	ASSERT_THAT(hWndCtrl, NotNull()) << "control not found: #" << nIDDlgItem;
+
+	EXPECT_THAT(::SendMessageTimeoutW(hWndDlg, WM_COMMAND, MAKEWPARAM(nIDDlgItem, notifyCode), LPARAM(hWndCtrl), SMTO_ABORTIFHUNG | SMTO_BLOCK | SMTO_NOTIMEOUTIFNOTHUNG, 0, nullptr), IsTrue());
+}
+
+/* static */ void UiaTestSuite::SendPsmPressButton(
+	_In_ HWND hWndPropertySheet,
+	UINT button
+)
+{
+	EXPECT_THAT(::SendMessageTimeoutW(hWndPropertySheet, PSM_PRESSBUTTON, button, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK | SMTO_NOTIMEOUTIFNOTHUNG, 0, nullptr), IsTrue());
+}
+
+/*!
+ * @brief UI Automationを使ったテストを実行する
+ */
+template <class TAction>
+void UiaTestSuite::RunUiaAction(
+	TAction&& action
+) const
+{
+	const auto st = m_StopSource.get_token();
+
+	RunGuiTest([action, st] {
+		// UI Automationオブジェクトを作成する
+		IUIAutomationPtr pAutomation = nullptr;
+		ASSERT_HRESULT_SUCCEEDED(pAutomation.CreateInstance(__uuidof(CUIAutomation), nullptr, CLSCTX_INPROC_SERVER));
 
 		// 停止要求が来ていたら抜ける
 		if (st.stop_requested()) {
 			return;
 		}
 
-		// Enterキーを押下して閉じる
-		EmulateHitEnter();
-	};
+		std::forward<TAction>(action)(pAutomation, st);
+	});
 }
 
-/* static */ void UiaTestSuite::EmulateEnterOpenFileName(
-	IUIAutomation* pAutomation,
-	const std::filesystem::path& path,
-	std::stop_token st
-)
+/*!
+ * UIAテストケースの開始前に自分で呼ぶ関数
+ */
+void UiaTestSuite::SetUpUia()
 {
-	const auto action = EmulateEnterFileName(path);
+	const auto testThreadId = ::GetCurrentThreadId();
 
-	if (const auto hWndDlgOpenFile = window::WaitForDialog(L"開く", st)) {
-		action(pAutomation, hWndDlgOpenFile, st);
+	m_StopSource = std::stop_source{};
+	m_Thread = std::jthread([this, testThreadId] (std::stop_token st) {
+		m_Timeout = true;	// 初期値は「タイムアウト発生」にする
+
+		std::mutex mutex;
+		std::condition_variable_any condition;
+		std::unique_lock lock(mutex);
+		condition.wait_for(lock, st, std::chrono::seconds(30), [] { return false; });
+
+		if (st.stop_requested()) {
+			m_Timeout = false;	// タイムアウトは発生しなかった
+			return;
+		}
+
+		m_StopSource.request_stop();
+
+		// スレッドブロックしているウィンドウを列挙して閉じる
+		::EnumThreadWindows(testThreadId, CloseBlockingWindowProc, 0L);
+	});
+}
+
+/*!
+ * UIAテストケースの終了後に呼ばれる関数
+ */
+void UiaTestSuite::TearDownUia()
+{
+	m_StopSource.request_stop();
+
+	m_Thread.request_stop();
+
+	if (m_Thread.joinable()) {
+		m_Thread.join();
 	}
-}
 
-/* static */ void UiaTestSuite::EmulateEnterSaveFileName(
-	IUIAutomation* pAutomation,
-	const std::filesystem::path& path,
-	std::stop_token st
-)
-{
-	const auto action = EmulateEnterFileName(path);
-
-	if (const auto hWndDlgOpenFile = window::WaitForDialog(L"名前を付けて保存", st)) {
-		action(pAutomation, hWndDlgOpenFile, st);
+	if (m_Timeout) {
+		ADD_FAILURE() << "test case timed out after 30 seconds";
 	}
 }
 
 /*!
  * ダイアログを閉じるスレッドを開始する
  *
- * @param dialogTitle タイトル
+ * @param optTitle タイトル
  * @param action 閉じるアクション
  * @param timeoutMillis タイムアウト時間（ミリ秒）
  * @return ダイアログを閉じるためのスレッド
  */
 std::jthread UiaTestSuite::StartDialogCloser(
-	std::wstring_view dialogTitle,
+	const std::optional<std::wstring>& optTitle,
 	const std::function<void(IUIAutomation*, HWND, std::stop_token)>& action,
 	ULONGLONG timeoutMillis
-) const
+)
 {
-	LPCWSTR targetClass = MAKEINTRESOURCEW(dialog::ModalDialogCloser::DIALOG_CLASS);
-
-	const std::wstring buffer{ dialogTitle };	// 一旦バッファにコピーする
-	return StartWindowCloser(targetClass, buffer, action, timeoutMillis);
+	return StartWindowCloser(WC_DIALOG, optTitle, action, timeoutMillis);
 }
 
 /*!
- * ファイルを開くダイアログを閉じるスレッドを開始する
+ * ダイアログを閉じるスレッドを開始する
  *
- * @param path ファイルパス
- * @return ファイルを開くダイアログを閉じるためのスレッド
+ * @param titleResourceId タイトルのリソースID
+ * @param action 閉じるアクション
+ * @return ダイアログを閉じるためのスレッド
  */
-std::jthread UiaTestSuite::StartEnterOpenFileName(
-	const std::filesystem::path& path
-) const
+std::jthread UiaTestSuite::StartDialogCloser(
+	int titleResourceId,
+	const std::function<void(IUIAutomation*, HWND, std::stop_token)>& action
+)
 {
-	return StartDialogCloser(L"開く", EmulateEnterFileName(path));
+	const std::wstring buffer{ cxx::load_string(titleResourceId) };
+
+	return StartDialogCloser(buffer, action);
 }
 
 /*!
@@ -371,7 +385,7 @@ std::jthread UiaTestSuite::StartEnterOpenFileName(
 std::jthread UiaTestSuite::StartPopupMenuSelector(
 	std::wstring_view menuLabel,
 	ULONGLONG timeoutMillis
-) const
+)
 {
 	// 閉じるアクションを構築する
 	const auto action = [menuLabel] (IUIAutomation* pAutomation, HWND hWndPopupMenu, std::stop_token st) {
@@ -394,6 +408,23 @@ std::jthread UiaTestSuite::StartPopupMenuSelector(
 }
 
 /*!
+ * プロパティーシートを閉じるスレッドを開始する
+ *
+ * @param titleResourceId タイトルのリソースID
+ * @param psButtonId ボタンID
+ * @return プロパティーシートを閉じるためのスレッド
+ */
+std::jthread UiaTestSuite::StartPropertySheetCloser(
+	int titleResourceId,
+	UINT psButtonId
+)
+{
+	return StartDialogCloser(titleResourceId, [psButtonId] (IUIAutomation*, HWND hWndDlg, std::stop_token) {
+		SendPsmPressButton(hWndDlg, psButtonId);
+	});
+}
+
+/*!
  * UI Automationを利用するスレッドを開始する
  *
  * @param action 実行するアクション
@@ -401,8 +432,10 @@ std::jthread UiaTestSuite::StartPopupMenuSelector(
  */
 std::jthread UiaTestSuite::StartUiaThread(
 	const std::function<void(IUIAutomation*, std::stop_token)>& action
-) const
+)
 {
+	SetUpUia();
+
 	return std::jthread([this, action] (std::stop_token st) {
 		// OLEを初期化する
 		cxx::COleInit oleInit;
@@ -413,20 +446,10 @@ std::jthread UiaTestSuite::StartUiaThread(
 			return;
 		}
 
-		// UI Automationオブジェクトを作成する
-		IUIAutomationPtr pAutomation = nullptr;
-		ASSERT_HRESULT_SUCCEEDED(pAutomation.CreateInstance(__uuidof(CUIAutomation), nullptr, CLSCTX_INPROC_SERVER));
-
-		// 停止要求が来ていたら抜ける
-		if (st.stop_requested()) {
-			return;
-		}
-
 		// アクションを実行する
-		RunGuiTest([action, pAutomation, st] {
-			action(pAutomation, st);
-		});
-	});
+		RunUiaAction(action);
+
+	}, m_StopSource.get_token());
 }
 
 /*!
@@ -443,11 +466,11 @@ std::jthread UiaTestSuite::StartWindowCloser(
 	const std::optional<std::wstring>& optTitle,
 	const std::function<void(IUIAutomation*, HWND, std::stop_token)>& action,
 	ULONGLONG timeoutMillis
-) const
+)
 {
-	return StartUiaThread([targetClass, optTitle, action, timeoutMillis] (IUIAutomation* pAutomation, std::stop_token st) {
+	return StartUiaThread([targetClass, has_title = optTitle.has_value(), title = optTitle.value_or(L""), action, timeoutMillis] (IUIAutomation* pAutomation, std::stop_token st) {
 		// テスト対象ウィンドウを検索する
-		const auto hWndFound = window::WaitForWindow(targetClass, optTitle, st, timeoutMillis);
+		const auto hWndFound = window::WaitForWindow(targetClass, has_title ? std::optional(title) : std::nullopt, st, timeoutMillis);
 		ASSERT_THAT(hWndFound, NotNull());
 
 		// 停止要求が来ていたら抜ける
@@ -458,25 +481,6 @@ std::jthread UiaTestSuite::StartWindowCloser(
 		// 閉じるアクションを実行する
 		action(pAutomation, hWndFound, st);
 	});
-}
-
-/*!
- * ダイアログを閉じるスレッドを開始する
- *
- * @param title タイトル
- * @param timeoutMillis タイムアウト時間（ミリ秒）
- * @return ダイアログを閉じるためのスレッド
- */
-std::jthread UiaTestSuite::StartDialogCloser(
-	std::wstring_view title,
-	ULONGLONG timeoutMillis
-) const
-{
-	std::wstring buffer{ title };	// 一旦バッファにコピーする
-	return StartDialogCloser(buffer, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
-		// OKボタンを押下して閉じる
-		EmulateInvokeButton(pUIAutomation, hWndDlg, IDOK, st);
-	}, timeoutMillis);
 }
 
 } // namespace window

--- a/src/test/cpp/tests1/window/UiaTestSuite.hpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.hpp
@@ -7,11 +7,15 @@
 #pragma once
 
 #include "cxx/com_pointer.hpp"
+#include "cxx/type_of_Nth_lambda_arg.hpp"
 #include "dlg/ModalDialogCloser.hpp"
 #include "util/tchar_convert.h"
 
 // UI Automation経由でGUI操作を行う
 #include <UIAutomation.h>
+
+#include "testing/HResultEq.hpp"
+#include "testing/StartEditorProcess.hpp"
 
 namespace cxx {
 
@@ -55,18 +59,42 @@ public:
 	}
 };
 
+template<typename TQuery, typename R = cxx::lambda_traits<TQuery>::return_type>
+R WaitForQuery(
+	TQuery query,
+	std::stop_token st,
+	ULONGLONG timeoutMillis,
+	DWORD intervalMillis = 200
+)
+{
+	const auto startTick = ::GetTickCount64();
+
+	while (!st.stop_requested()) {
+		// 脱出条件を満たしたら抜ける
+		auto result = query();
+		if (result) return result;
+
+		// タイムアウトしたら抜ける
+		const auto elapsed = ::GetTickCount64() - startTick;	// 経過時間
+		if (timeoutMillis <= elapsed) return result;
+
+		// 停止要求が来ていたら待機せずに抜ける
+		if (st.stop_requested()) return result;
+
+		// GUI待機なので残り時間を考慮して待機する
+		const auto remaining = timeoutMillis - elapsed;			// 残り時間
+		::Sleep(std::min(intervalMillis, DWORD(remaining)));
+	}
+
+	return {};
+}
+
 } // namespace cxx
 
 namespace window {
 
 //! デフォルトの待機時間
 static constexpr auto defaultTimeoutMillis = 5000;
-
-HWND WaitForDialog(
-	const std::wstring& title,
-	std::stop_token st = {},
-	ULONGLONG timeoutMillis = defaultTimeoutMillis
-);
 
 HWND WaitForPopupMenu(
 	std::stop_token st,
@@ -94,11 +122,9 @@ struct UiaTestSuite
 
 	static inline std::unique_ptr<cxx::COleInit> pcOleInit = nullptr;
 
-	static void EmulateInvokeButton(
-		IUIAutomation* pAutomation,
-		_In_ HWND hWndDlg,
-		std::wstring_view caption,
-		std::stop_token st
+	static BOOL CALLBACK CloseBlockingWindowProc(
+		_In_ HWND   hWnd,
+		_In_ LPARAM lParam [[maybe_unused]]
 	);
 
 	static void EmulateInvokeButton(
@@ -108,6 +134,13 @@ struct UiaTestSuite
 		std::stop_token st
 	);
 
+	static HWND GetActivePage(
+		HWND hWndDlg,
+		std::stop_token st = {},
+		ULONGLONG timeoutMillis = 5000
+	);
+
+	//! UI Automationでメニュー項目選択を偽装
 	static void EmulateInvokeMenuItem(
 		IUIAutomation* pAutomation,
 		_In_ HWND hWndPopupMenu,
@@ -115,29 +148,22 @@ struct UiaTestSuite
 		std::stop_token st
 	);
 
-	static std::function<void(IUIAutomation*, HWND, std::stop_token)> EmulateEnterFileName(
-		const std::filesystem::path& path
-	);
-
-	static void EmulateEnterOpenFileName(
-		IUIAutomation* pAutomation,
-		const std::filesystem::path& path,
-		std::stop_token st = {}
-	);
-
-	static void EmulateEnterSaveFileName(
-		IUIAutomation* pAutomation,
-		const std::filesystem::path& path,
-		std::stop_token st = {}
-	);
-
-	//! UI AutomationでEnterキー押下を偽装
+	//! SendInputでEnterキー押下を偽装
 	static void EmulateHitEnter()
 	{
 		std::vector<INPUT> inputs{};
 		inputs.emplace_back(MakeKeyboardInput(VK_RETURN, false));
 		inputs.emplace_back(MakeKeyboardInput(VK_RETURN, true));
-		EXPECT_THAT(SendInput(inputs), Eq(std::size(inputs)));
+		ASSERT_THAT(SendInput(inputs), Eq(std::size(inputs)));
+	}
+
+	//! SendInputでESCキー押下を偽装
+	static void EmulateHitEscape()
+	{
+		std::vector<INPUT> inputs{};
+		inputs.emplace_back(MakeKeyboardInput(VK_ESCAPE, false));
+		inputs.emplace_back(MakeKeyboardInput(VK_ESCAPE, true));
+		ASSERT_THAT(SendInput(inputs), Eq(std::size(inputs)));
 	}
 
 	//! UI Automationでボタン押下を偽装
@@ -147,7 +173,7 @@ struct UiaTestSuite
 	{
 		IUIAutomationInvokePatternPtr pInvokePattern;
 		ASSERT_HRESULT_SUCCEEDED(pElement->GetCurrentPatternAs(UIA_InvokePatternId, IID_PPV_ARGS(&pInvokePattern)));
-		ASSERT_HRESULT_SUCCEEDED(pInvokePattern->Invoke());
+		ASSERT_HRESULT_EQ(pInvokePattern->Invoke(), S_OK);
 	}
 
 	//! UI Automationで値設定
@@ -205,11 +231,46 @@ struct UiaTestSuite
 		return input;
 	}
 
+	template <typename TAction>
+	static void RunGuiTest(
+		TAction&& action
+	)
+	{
+#ifdef USE_STACK_TRACE
+		__try
+		{
+#endif
+			std::clog << "RunGuiTest() start" << std::endl;
+
+			std::forward<TAction>(action)();
+
+			std::clog << "RunGuiTest() end" << std::endl;
+
+#ifdef USE_STACK_TRACE
+		}
+		__except (testing::OnUnhandledException(GetExceptionInformation()))
+		{
+			std::clog << "RunGuiTest() crashed." << std::endl;
+		}
+#endif
+	}
+
+	static void SendDlgCommand(
+		_In_ HWND hWndDlg,
+		int nIDDlgItem,
+		int notifyCode = BN_CLICKED
+	);
+
 	template<std::ranges::range T>
 	static UINT SendInput(T& inputs)
 	{
 		return ::SendInput(UINT(std::size(inputs)), std::data(inputs), sizeof(decltype(inputs[0])));
 	}
+
+	static void SendPsmPressButton(
+		_In_ HWND hWndPropertySheet,
+		UINT button
+	);
 
 	/*!
 	 * テストスイートの開始前に1回だけ呼ばれる関数
@@ -221,47 +282,48 @@ struct UiaTestSuite
 	 */
 	static void TearDownUiaTestSuite();
 
-	template <typename Func>
-	static void RunGuiTest(Func&& f)
-	{
-		try {
-			std::forward<Func>(f)();
-		}
-		catch (const std::exception& e) {
-			FAIL() << "std::exception: " << typeid(e).name()
-				<< ": " << e.what();
-		}
-		catch (const _com_error& e) {
-			FAIL() << "_com_error: "
-				<< ": " << cxx::to_string(e.ErrorMessage());
-		}
-		catch (...) {
-			FAIL() << "unknown non-std exception";
-		}
-	}
+	/*!
+	 * UIAテストケースの開始前に自分で呼ぶ関数
+	 */
+	void SetUpUia();
+
+	/*!
+	 * UIAテストケースの終了後に呼ばれる関数
+	 */
+	void TearDownUia();
+
+	/*!
+	 * @brief UI Automationを使ったテストを実行する
+	 */
+	template <class TAction>
+	void RunUiaAction(
+		TAction&& action
+	) const;
 
 	/*!
 	 * ダイアログを閉じるスレッドを開始する
 	 *
-	 * @param title タイトル
+	 * @param optTitle タイトル
 	 * @param action 閉じるアクション
 	 * @return ダイアログを閉じるためのスレッド
 	 */
 	std::jthread StartDialogCloser(
-		std::wstring_view title,
+		const std::optional<std::wstring>& optTitle,
 		const std::function<void(IUIAutomation*, HWND, std::stop_token)>& action,
-		ULONGLONG timeoutMillis = defaultTimeoutMillis
-	) const;
+		ULONGLONG timeoutMillis = defaultTimeoutMillis * 3
+	);
 
 	/*!
-	 * ファイルを開くダイアログを閉じるスレッドを開始する
+	 * ダイアログを閉じるスレッドを開始する
 	 *
-	 * @param path ファイルパス
-	 * @return ファイルを開くダイアログを閉じるためのスレッド
+	 * @param titleResourceId タイトルのリソースID
+	 * @param action 閉じるアクション
+	 * @return ダイアログを閉じるためのスレッド
 	 */
-	std::jthread StartEnterOpenFileName(
-		const std::filesystem::path& path
-	) const;
+	std::jthread StartDialogCloser(
+		int titleResourceId,
+		const std::function<void(IUIAutomation*, HWND, std::stop_token)>& action
+	);
 
 	/*!
 	 * ポップアップメニューを選択するスレッドを開始する
@@ -272,7 +334,19 @@ struct UiaTestSuite
 	std::jthread StartPopupMenuSelector(
 		std::wstring_view menuLabel,
 		ULONGLONG timeoutMillis = defaultTimeoutMillis
-	) const;
+	);
+
+	/*!
+	 * プロパティーシートを閉じるスレッドを開始する
+	 *
+	 * @param titleResourceId タイトルのリソースID
+	 * @param psButtonId ボタンID
+	 * @return プロパティーシートを閉じるためのスレッド
+	 */
+	std::jthread StartPropertySheetCloser(
+		int titleResourceId,
+		UINT psButtonId = PSBTN_OK
+	);
 
 	/*!
 	 * UI Automationを利用するスレッドを開始する
@@ -282,7 +356,7 @@ struct UiaTestSuite
 	 */
 	std::jthread StartUiaThread(
 		const std::function<void(IUIAutomation*, std::stop_token)>& action
-	) const;
+	);
 
 	/*!
 	 * ウィンドウを閉じるスレッドを開始する
@@ -297,18 +371,11 @@ struct UiaTestSuite
 		const std::optional<std::wstring>& optTitle,
 		const std::function<void(IUIAutomation*, HWND, std::stop_token)>& action,
 		ULONGLONG timeoutMillis = defaultTimeoutMillis
-	) const;
+	);
 
-	/*!
-	 * ダイアログを閉じるスレッドを開始する
-	 *
-	 * @param dialogTitle タイトル
-	 * @return ダイアログを閉じるためのスレッド
-	 */
-	std::jthread StartDialogCloser(
-		std::wstring_view dialogTitle,
-		ULONGLONG timeoutMillis = defaultTimeoutMillis
-	) const;
+	std::stop_source m_StopSource;
+	std::jthread m_Thread;
+	bool m_Timeout = false;
 };
 
 } // namespace env

--- a/src/test/cpp/tests1/window/UiaTestSuite.hpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.hpp
@@ -161,6 +161,7 @@ struct UiaTestSuite
 		ASSERT_HRESULT_SUCCEEDED(pValuePattern->SetValue(_bstr_t{ ::SysAllocStringLen(std::data(val), UINT(std::size(val))) }));
 	}
 
+	//! SendInputでマウス移動を偽装するためのデータを作る
 	static INPUT MakeMouseInputMove(LONG x, LONG y)
 	{
 		const auto vx = ::GetSystemMetrics(SM_XVIRTUALSCREEN);
@@ -180,6 +181,7 @@ struct UiaTestSuite
 		return input;
 	}
 
+	//! SendInputでマウスホイールを偽装するためのデータを作る
 	static INPUT MakeMouseInputWheel(int delta)
 	{
 		INPUT input{};
@@ -191,6 +193,7 @@ struct UiaTestSuite
 		return input;
 	}
 
+	//! SendInputでキー押下を偽装するためのデータを作る
 	static INPUT MakeKeyboardInput(WORD virtualKey, bool isKeyUp = false)
 	{
 		INPUT input{};
@@ -201,6 +204,22 @@ struct UiaTestSuite
 
 		return input;
 	}
+
+	template<std::ranges::range T>
+	static UINT SendInput(T& inputs)
+	{
+		return ::SendInput(UINT(std::size(inputs)), std::data(inputs), sizeof(decltype(inputs[0])));
+	}
+
+	/*!
+	 * テストスイートの開始前に1回だけ呼ばれる関数
+	 */
+	static void SetUpUiaTestSuite();
+
+	/*!
+	 * テストスイートの終了後に1回だけ呼ばれる関数
+	 */
+	static void TearDownUiaTestSuite();
 
 	template <typename Func>
 	static void RunGuiTest(Func&& f)
@@ -220,22 +239,6 @@ struct UiaTestSuite
 			FAIL() << "unknown non-std exception";
 		}
 	}
-
-	template<std::ranges::range T>
-	static UINT SendInput(T& inputs)
-	{
-		return ::SendInput(UINT(std::size(inputs)), std::data(inputs), sizeof(decltype(inputs[0])));
-	}
-
-	/*!
-	 * テストスイートの開始前に1回だけ呼ばれる関数
-	 */
-	static void SetUpUia();
-
-	/*!
-	 * テストスイートの終了後に1回だけ呼ばれる関数
-	 */
-	static void TearDownUia();
 
 	/*!
 	 * ダイアログを閉じるスレッドを開始する

--- a/src/test/resources/testing/HResultEq.hpp
+++ b/src/test/resources/testing/HResultEq.hpp
@@ -79,16 +79,17 @@ inline std::string DescribeHResult(HRESULT hr)
 /*!
  * @brief HRESULTの値が期待される値と等しいことを確認するためのアサーション関数
  *
- * @param actual 評価されたHRESULT値。
- * @param expected 期待値。
  * @param actual_expr 評価された式。
  * @param expected_expr 期待値を表す式。
+ * @param actual 評価されたHRESULT値。
+ * @param expected 期待値。
  */
+template <typename T1, typename T2>
 inline ::testing::AssertionResult HResultEq(
-	HRESULT actual,
-	HRESULT expected,
 	const char* actual_expr,
-	const char* expected_expr [[maybe_unused]] // HRESULT値はマクロ定義するので、使い物にならない。
+	const char* expected_expr,  // HRESULT値はマクロ定義するので、使い物にならない。
+	T1 actual,
+	T2 expected
 )
 {
 	if (actual == expected) {
@@ -103,9 +104,9 @@ inline ::testing::AssertionResult HResultEq(
 } // namespace testing
 
 //! @brief HRESULTの値が期待される値と等しいことを確認するためのマクロ
-#define EXPECT_HRESULT_EQ(actual, expected)						\
-	EXPECT_PRED_FORMAT2(										\
-		[](const char* a, const char* e, auto av, auto ev) {	\
-			return testing::HResultEq(av, ev, a, e);			\
-		},														\
-		actual, expected)
+#define EXPECT_HRESULT_EQ(actual, expected) \
+	EXPECT_PRED_FORMAT2(testing::HResultEq, actual, expected)
+
+//! @brief HRESULTの値が期待される値と等しいことを確認するためのマクロ
+#define ASSERT_HRESULT_EQ(actual, expected) \
+	ASSERT_PRED_FORMAT2(testing::HResultEq, actual, expected)

--- a/src/test/resources/testing/StartEditorProcess.hpp
+++ b/src/test/resources/testing/StartEditorProcess.hpp
@@ -34,4 +34,9 @@ int StartEditorProcess(const std::wstring& commandLine);
  */
 [[noreturn]] void OnTerminate();
 
+/*!
+ * @brief テストコード専用SEH構造化例外ハンドラー
+ */
+LONG OnUnhandledException(EXCEPTION_POINTERS* ep);
+
 }


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- #2580

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->

## <!-- わかる範囲で --> PR の影響範囲
- ファイルダイアログの表示テストを削減し、失敗確率を下げます。
- ダイアログの表示テストが空振ったら失敗させます。
- UI Automationのテストを30秒で打ち切るように変更し、打ち切りは失敗とします。
- 各変更ファイルで検知されたSonarQube指摘のうち、安全に対応できるものについては対応を行います。

変更によりCIテストが無応答で終了しない事態は発生しにくくなります。
UI Automationを利用するテストを減らしたので失敗確率は下がる見込みです。
（ポップアップメニューとファイルダイアログ表示、子プロセス起動はUIAでないと実現不可。）

本件、勝手にやります。

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->
ローカル環境で連続30回繰り返し実行して、テストが失敗することはあっても固まることはない、を確認しました。

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- resolves #2580

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
