### PR TITLE
共通設定「強調キーワード」の不具合修正

### DIFF
--- a/sakura_core/prop/CPropComKeyword.cpp
+++ b/sakura_core/prop/CPropComKeyword.cpp
@@ -558,7 +558,6 @@ void CPropKeyword::Import_List_KeyWord( HWND hwndDlg, [[maybe_unused]] HWND hwnd
 {
 	bool	bCase = false;
 	int		nIdx = m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx;
-	m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SetKeyWordCase( nIdx, bCase );
 	CImpExpKeyWord	cImpExpKeyWord( m_Common, nIdx, bCase );
 
 	// インポート
@@ -578,8 +577,9 @@ void CPropKeyword::Export_List_KeyWord( HWND hwndDlg, [[maybe_unused]] HWND hwnd
 	/* ダイアログデータの設定 Keyword 指定キーワードセットの設定 */
 	SetKeyWordSet( hwndDlg, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 
-	bool	bCase;
-	CImpExpKeyWord	cImpExpKeyWord( m_Common, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, bCase );
+	int		nIdx = m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx;
+	bool	bCase = m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWordCase( nIdx );
+	CImpExpKeyWord	cImpExpKeyWord( m_Common, nIdx, bCase );
 
 	// エクスポート
 	if (!cImpExpKeyWord.ExportUI( G_AppInstance(), hwndDlg )) {
@@ -636,6 +636,7 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 
 	ListView_DeleteAllItems( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ) );
 	if( 0 <= nIdx ){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYSETRENAME ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELSET ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KEYWORDCASE ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ), TRUE );
@@ -645,17 +646,20 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 		//	なのでここで無効にしておく．
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EDITKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELKEYWORD ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYCLEAN ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_IMPORT ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EXPORT ), TRUE );
 	}else{
 		::CheckDlgButton( hwndDlg, IDC_CHECK_KEYWORDCASE, FALSE );
 
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYSETRENAME ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELSET ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KEYWORDCASE ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADDKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EDITKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELKEYWORD ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYCLEAN ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_IMPORT ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EXPORT ), FALSE );
 		return;

--- a/sakura_core/prop/CPropComKeyword.cpp
+++ b/sakura_core/prop/CPropComKeyword.cpp
@@ -636,9 +636,8 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 	::SendMessage( hwndDlg, WM_SETREDRAW, FALSE, 0 );
 
 	ListView_DeleteAllItems( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ) );
-	::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYSETRENAME ), 0 <= nIdx );
-	::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYCLEAN ), 0 <= nIdx );
 	if( 0 <= nIdx ){
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYSETRENAME ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELSET ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KEYWORDCASE ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ), TRUE );
@@ -648,17 +647,20 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 		//	なのでここで無効にしておく．
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EDITKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELKEYWORD ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYCLEAN ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_IMPORT ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EXPORT ), TRUE );
 	}else{
 		::CheckDlgButton( hwndDlg, IDC_CHECK_KEYWORDCASE, FALSE );
 
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYSETRENAME ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELSET ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KEYWORDCASE ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADDKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EDITKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELKEYWORD ), FALSE );
+		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYCLEAN ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_IMPORT ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EXPORT ), FALSE );
 

--- a/sakura_core/prop/CPropComKeyword.cpp
+++ b/sakura_core/prop/CPropComKeyword.cpp
@@ -13,7 +13,7 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2009, ryoji
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.
@@ -578,6 +578,7 @@ void CPropKeyword::Export_List_KeyWord( HWND hwndDlg, [[maybe_unused]] HWND hwnd
 	SetKeyWordSet( hwndDlg, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx );
 
 	int		nIdx = m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx;
+	// 現在選択されているキーワードセットの英大文字小文字区別設定を取得
 	bool	bCase = m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWordCase( nIdx );
 	CImpExpKeyWord	cImpExpKeyWord( m_Common, nIdx, bCase );
 
@@ -635,8 +636,9 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 	::SendMessage( hwndDlg, WM_SETREDRAW, FALSE, 0 );
 
 	ListView_DeleteAllItems( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ) );
+	::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYSETRENAME ), 0 <= nIdx );
+	::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYCLEAN ), 0 <= nIdx );
 	if( 0 <= nIdx ){
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYSETRENAME ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELSET ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KEYWORDCASE ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ), TRUE );
@@ -646,22 +648,23 @@ void CPropKeyword::SetKeyWordSet( HWND hwndDlg, int nIdx )
 		//	なのでここで無効にしておく．
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EDITKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELKEYWORD ), FALSE );
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYCLEAN ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_IMPORT ), TRUE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EXPORT ), TRUE );
 	}else{
 		::CheckDlgButton( hwndDlg, IDC_CHECK_KEYWORDCASE, FALSE );
 
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYSETRENAME ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELSET ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_CHECK_KEYWORDCASE ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_LIST_KEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_ADDKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EDITKEYWORD ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_DELKEYWORD ), FALSE );
-		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_KEYCLEAN ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_IMPORT ), FALSE );
 		::EnableWindow( ::GetDlgItem( hwndDlg, IDC_BUTTON_EXPORT ), FALSE );
+
+		// 無効化時も描画停止を解除して画面を再描画
+		::SendMessage( hwndDlg, WM_SETREDRAW, TRUE, 0 );
+		InvalidateRect( hwndDlg, nullptr, FALSE );
 		return;
 	}
 

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -2660,6 +2660,53 @@ TEST_F(EditWndTest, ShowPropCommon019)
 }
 
 /*!
+ * 共通設定プロパティーシートの表示テスト
+ *
+ * キーワードセットが0件のとき、セット依存のコントロールが無効化されること
+ */
+TEST_F(EditWndTest, ShowPropCommon020)
+{
+	auto& cKeyWordSetMgr = GetDllShareData().m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr;
+
+	// キーワードセットが0件の状態を作る
+	const auto nKeyWordSetNumOrg = cKeyWordSetMgr.m_nKeyWordSetNum;
+	const auto nCurrentKeyWordSetIdxOrg = cKeyWordSetMgr.m_nCurrentKeyWordSetIdx;
+	cKeyWordSetMgr.m_nKeyWordSetNum = 0;
+	cKeyWordSetMgr.m_nCurrentKeyWordSetIdx = -1;
+
+	// 表示された共通設定を閉じるためのスレッドを起動する
+	auto t = StartDialogCloser(STR_PROPCOMMON, [] (const IUIAutomation*, HWND hWndDlg, std::stop_token st) {
+		// アクティブなプロパティーシートのハンドルを取得する
+		const auto hWndPage = GetActivePage(hWndDlg, st);
+
+		// キーワードセットが選択されていないので、セット依存のコントロールは無効
+		const auto hWndKeySetRename = ::GetDlgItem(hWndPage, IDC_BUTTON_KEYSETRENAME);	// L"変更(H)..."
+		EXPECT_THAT(hWndKeySetRename, Ne(nullptr));
+		EXPECT_THAT(::IsWindowEnabled(hWndKeySetRename), IsFalse());
+
+		const auto hWndKeyClean = ::GetDlgItem(hWndPage, IDC_BUTTON_KEYCLEAN);	// L"整理(O)"
+		EXPECT_THAT(hWndKeyClean, Ne(nullptr));
+		EXPECT_THAT(::IsWindowEnabled(hWndKeyClean), IsFalse());
+
+		// セット追加はセット数0でも押せる必要がある（押せないと復帰できない）
+		const auto hWndAddSet = ::GetDlgItem(hWndPage, IDC_BUTTON_ADDSET);	// L"セット追加(M)..."
+		EXPECT_THAT(hWndAddSet, Ne(nullptr));
+		EXPECT_THAT(::IsWindowEnabled(hWndAddSet), IsTrue());
+
+		// キャンセルボタンを押下して閉じる
+		SendPsmPressButton(hWndDlg, PSBTN_CANCEL);
+	});
+
+	ShowPropCommon(ID_PROPCOM_PAGENUM_KEYWORD);
+
+	t.join();
+
+	// 共有データを元に戻す
+	cKeyWordSetMgr.m_nCurrentKeyWordSetIdx = nCurrentKeyWordSetIdxOrg;
+	cKeyWordSetMgr.m_nKeyWordSetNum = nKeyWordSetNumOrg;
+}
+
+/*!
  * タイプ別設定プロパティーシートの表示テスト
  */
 TEST_F(EditWndTest, ShowPropType001)


### PR DESCRIPTION

共通設定「強調キーワード」タブに、GUI操作だけで再現する不具合が3件ありました。
いずれも `sakura_core/prop/CPropComKeyword.cpp` 内で完結し、ヘッダーやAPIの変更はありません。

### 1. セットが存在しないときに「変更」「整理」ボタンが押せてしまう

`CPropKeyword::SetKeyWordSet()` はキーワードセット未選択時 (`nIdx < 0`) にコントロールを
無効化しますが、対象が8個に限られており、「変更(&H)」(`IDC_BUTTON_KEYSETRENAME`) と
「整理(&O)」(`IDC_BUTTON_KEYCLEAN`) が漏れています。

`CKeyWordSetMgr::DelKeyWordSet()` は最後の1セットを削除したとき `m_nCurrentKeyWordSetIdx` を
意図的に -1 にします (同関数のコメントに記載あり)。この状態で

- 「変更(&H)」を押すと `GetTypeName(-1)` が `nullptr` を返し、`wcscpy( szKeyWord, nullptr )` で
  クラッシュします (再現確認済み)
- 「整理(&O)」を押すと `SortKeyWord(-1)` に入り、`m_bKEYWORDCASEArr[-1]` などの範囲外読みと
  `m_IsSorted[-1] = 1` の範囲外書きが発生します。読み取った不定値が `qsort()` の開始位置と
  要素数として使われます

### 2. キーワードのエクスポートで未初期化値を書き出している

`CPropKeyword::Export_List_KeyWord()` の `bCase` が未初期化のまま `CImpExpKeyWord` へ
`bool&` で渡され、`Export()` がその値を `// CASE=` 行として出力しています。
セットの実際の「英大文字小文字区別」設定はエクスポート結果に反映されません。

出力した .kwd をインポートすると `CImpExpKeyWord::Import()` の末尾の `SetKeyWordCase()` で
インポート先セットの設定が上書きされます。この値は `CKeyWordSetMgr::SearchKeyWord2()` で
`wcsncmp` / `_wcsnicmp` の切り替えに使われ、`CColor_KeywordSet` の色分け判定に影響します。

なお `CImpExpManager.cpp` の別箇所 (タイプ別設定のインポート/エクスポート) では
`GetKeyWordCase()` で正しく取得しています。

### 3. インポートをキャンセルすると大文字小文字区別が失われる

`CPropKeyword::Import_List_KeyWord()` がファイル選択ダイアログの表示前に
`SetKeyWordCase( nIdx, false )` を実行し、キャンセル時に復元せず `return` します。

`CPropKeyword::GetData()` は空実装で、チェックボックスの状態を読み戻しません
(`m_Common` への反映は `BN_CLICKED` 時のみ)。このため画面上はチェックが入ったまま
内部値だけ `false` になり、そのままOKすると設定が失われます。

## テスト内容

単体テストは追加していません (いずれもダイアログプロシージャ内の処理のため)。
以下を手動で確認しました。

### 1 の確認

1. 共通設定 → 「強調キーワード」タブ
2. 「セット削除(&R)...」で既定の17セットをすべて削除
3. コンボが空になった状態で、変更(&H) / セット削除(&R) / 英大文字小文字区別(&C) /
   キーワード一覧 / 追加(&A) / 編集(&E) / 削除(&D) / 整理(&O) / インポート(&I) /
   エクスポート(&X) がすべてグレーアウトすること
4. 「セット追加(&M)...」でセットを1つ追加し、上記がすべて有効に戻ること
5. 「変更(&H)」でセット名が変更でき、「整理(&O)」が動作すること

修正前は手順3で「変更(&H)」「整理(&O)」が押せてしまい、「変更(&H)」でクラッシュします。

### 2 の確認

1. セット「C/C++」を選択 (英大文字小文字区別はON) → 「エクスポート(&X)...」で `on.kwd` を保存
2. 「英大文字小文字区別(C)」のチェックを外す → 「エクスポート(&X)...」で `off.kwd` を保存
3. 2行目が `on.kwd` は `// CASE=True`、`off.kwd` は `// CASE=False` になること

修正前は両方とも同じ値になります (未初期化のため環境依存。確認環境では両方 `// CASE=True`)。

### 3 の確認

1. セット「C/C++」を選択 (英大文字小文字区別はON)
2. 「インポート(&I)...」→ ファイルダイアログでキャンセル
3. OKでダイアログを閉じる
4. 再度開いてセット「C/C++」を選択し、「英大文字小文字区別」がONのままであること

修正前は手順4でチェックが外れています。

## 仕様・動作説明

### 1

`SetKeyWordSet()` の有効化/無効化の対象に `IDC_BUTTON_KEYSETRENAME` と
`IDC_BUTTON_KEYCLEAN` を追加します。セット数が0のときはこの2つもグレーアウトします。

「セット追加(&M)...」(`IDC_BUTTON_ADDSET`) はセット数0でも押せる必要がある
(押せないと復帰できない) ため、制御対象には含めていません。

### 2

`bCase` を `GetKeyWordCase()` の戻り値で初期化します。
エクスポートされる `// CASE=` 行がセットの実際の設定と一致するようになります。

### 3

ファイル選択前の `SetKeyWordCase()` 呼び出しを削除します。

`bCase` はすでに `false` で初期化されており、`CImpExpKeyWord::Import()` は末尾で無条件に
`SetKeyWordCase( m_nIdx, m_bCase )` を呼ぶため、旧形式ファイル (`// CASE=` 行なし) に対する
既定値 `false` の保証は `Import()` 側で成立しています。事前呼び出しは冗長でした。

