### PR TITLE
メッセージボックス表示のテスト方法を改善する

### DIFF
--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -1458,20 +1458,23 @@ void CControlTray::TerminateApplication(
 {
 	const auto pShareData = &GetDllShareData();	/* 共有データ構造体のアドレスを返す */
 
+	const auto bExitConfirm = pShareData->m_Common.m_sGeneral.m_bExitConfirm;
+
 	/* 現在の編集ウィンドウの数を調べる */
-	if (pShareData->m_Common.m_sGeneral.m_bExitConfirm &&	//終了時の確認
-		0 < CAppNodeGroupHandle(0).GetEditorWindowsNum() &&
-		IDYES != ::MessageBoxF(
-				hWndFrom,
-				MB_YESNO | MB_APPLMODAL | MB_ICONQUESTION,
-				GSTR_APPNAME,
-				LS(STR_TRAY_EXITALL)
-			) ){
-				return;
+	if (bExitConfirm &&	//終了時の確認
+		0 < pShareData->m_sNodes.m_nEditArrNum &&
+		IDYES != ::MessageBox(
+			hWndFrom,
+			LS(STR_TRAY_EXITALL),
+			GSTR_APPNAME,
+			MB_YESNO | MB_APPLMODAL | MB_ICONQUESTION
+		))
+	{
+		return;
 	}
 
 	/* 「すべてのウィンドウを閉じる」要求 */	//Oct. 7, 2000 jepro 「編集ウィンドウの全終了」という説明を左記のように変更
-	if (const auto bCheckConfirm = pShareData->m_Common.m_sGeneral.m_bExitConfirm;	// 2006.12.25 ryoji 終了確認済みならそれ以上は確認しない
+	if (const auto bCheckConfirm = bExitConfirm;	// 2006.12.25 ryoji 終了確認済みならそれ以上は確認しない
 		CloseAllEditor(bCheckConfirm, hWndFrom, TRUE, 0)) {	// 2006.12.25, 2007.02.13 ryoji 引数追加
 		::PostMessageAny( pShareData->m_sHandles.m_hwndTray, WM_CLOSE, 0, 0 );
 	}

--- a/sakura_core/util/MessageBoxF.cpp
+++ b/sakura_core/util/MessageBoxF.cpp
@@ -9,7 +9,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, aroka
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -17,38 +17,91 @@
 #include "StdAfx.h"
 #include "MessageBoxF.h"
 
+#include "_main/CProcess.h"
+#include "config/app_constants.h"
+#include "util/os.h"
+#include "util/tchar_convert.h"
+#include "window/CEditWnd.h"
+
+#include "CSelectLang.h"
+
 #include <iostream>
 
-#include "_main/CProcess.h"
-#include "window/CEditWnd.h"
-#include "CSelectLang.h"
-#include "config/app_constants.h"
+HWND GetMessageBoxOwner(HWND hWndOwner);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                 メッセージボックス：実装                    //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-int Wrap_MessageBox(HWND hWnd, LPCWSTR lpText, LPCWSTR lpCaption, UINT uType)
-{
-	// 選択中の言語IDを取得する
-	LANGID wLangId = CSelectLang::getDefaultLangId();
 
+/*!
+ * メッセージボックスを表示します。
+ *
+ * @note 直接呼ばないでください。
+ */
+/* static */ int User32::MessageBoxW(
+	_In_opt_ HWND hWndOwner,
+	const std::optional<std::wstring>& optText,
+	const std::optional<std::wstring>& optCaption,
+	_In_ UINT uType
+)
+{
+	if (!hWndOwner) {
+		hWndOwner = GetMessageBoxOwner(hWndOwner);
+	}
+
+	// 選択中の言語IDを取得する
+	const auto wLangId = CSelectLang::getDefaultLangId();
+
+	return User32::getInstance()->MessageBoxExW(
+		hWndOwner,
+		optText.has_value() ? std::data(*optText) : nullptr,
+		optCaption.has_value() ? std::data(*optCaption) : nullptr,
+		uType,
+		wLangId
+	);
+}
+
+/*!
+ * メッセージボックスを表示します。
+ *
+ * @note 直接呼ばないでください。
+ */
+int User32::MessageBoxExW(
+	_In_opt_ HWND hWnd,
+	_In_opt_ LPCWSTR lpText,
+	_In_opt_ LPCWSTR lpCaption,
+	_In_ UINT uType,
+	_In_ WORD wLanguageId
+) const
+{
 	// 標準エラー出力が存在する場合
 	if(::GetStdHandle(STD_ERROR_HANDLE)){
 		// lpText を標準エラー出力に書き出す
-		std::clog << (lpText ? wcstou8s(lpText) : "") << std::endl;
+		std::clog << (lpText ? cxx::to_string(lpText, CP_UTF8) : "") << std::endl;
 
 		// いい加減な戻り値を返す。(返り値0は未定義なので本来返らない値を返している)
 		return 0;
 	}
 
+	// 本物のAPIを呼ぶ。構造的にテスト不能なので、いつか代替策を考える必要がある。
+	return ::MessageBoxExW(hWnd, lpText, lpCaption, uType, wLanguageId);
+}
+
+/*!
+ * メッセージボックスを表示します。
+ *
+ * @note 直接呼ばないでください。
+ * @note ヘッダー側でWindows SDKのマクロMessageBoxをWrap_MessageBoxに定義し直している。
+ */
+int Wrap_MessageBox(HWND hWnd, LPCWSTR lpText, LPCWSTR lpCaption, UINT uType)
+{
 	// lpText, lpCaption をローカルバッファにコピーして MessageBox API を呼び出す
 	// ※ 使い回しのバッファが使用されていてそれが裏で書き換えられた場合でも
 	//    メッセージボックス上の Ctrl+C が文字化けしないように
-	return ::MessageBoxEx(hWnd,
-		lpText ? std::wstring(lpText).c_str() : nullptr,
-		lpCaption ? std::wstring(lpCaption).c_str() : nullptr,
-		uType,
-		wLangId
+	return User32::MessageBoxW(hWnd,
+		lpText ? std::make_optional(lpText) : std::nullopt,
+		lpCaption ? std::make_optional(lpCaption) : std::nullopt,
+		uType
 	);
 }
 
@@ -87,9 +140,6 @@ int VMessageBoxF(
 )
 {
 	const auto buf = vstrprintf(lpText,v);
-	if (!hwndOwner) {
-		hwndOwner = GetMessageBoxOwner(hwndOwner);
-	}
 	return ::MessageBox(hwndOwner, buf.data(), lpCaption, uType);
 }
 

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -9,9 +9,33 @@
 #define SAKURA_OS_0C5BD7E8_67ED_467C_916F_CCDC1F9A26BF_H_
 #pragma once
 
+#include "util/design_template.h"
 #include "cxx/type_of_Nth_lambda_arg.hpp"
 
-#include <ObjIdl.h> // LPDATAOBJECT
+#include <objidl.h> // LPDATAOBJECT
+
+//! User32.dll呼出をテスト可能にするDIっぽいもの
+struct User32 : public TSakuraSingleton<User32>
+{
+	using Me = User32;
+
+	static int MessageBoxW(
+		_In_opt_ HWND hWnd,
+		const std::optional<std::wstring>& optText,
+		const std::optional<std::wstring>& optCaption,
+		_In_ UINT uType
+	);
+
+	virtual ~User32() = default;
+
+	virtual int	MessageBoxExW(
+		_In_opt_ HWND hWnd,
+		_In_opt_ LPCWSTR lpText,
+		_In_opt_ LPCWSTR lpCaption,
+		_In_ UINT uType,
+		_In_ WORD wLanguageId
+	) const;
+};
 
 //クリップボード
 bool SetClipboardText( HWND hwnd, const WCHAR* pszText, int nLength ); //!< クリープボードにText形式でコピーする。UNICODE版。nLengthは文字単位。

--- a/sakura_core/util/string_ex.cpp
+++ b/sakura_core/util/string_ex.cpp
@@ -418,32 +418,6 @@ std::string strprintf(const CHAR* pszFormat, ...)
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      文字コード変換                         //
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-
-/*!
-	@brief u8文字列を標準文字列に変換する。
-		動的にバッファを確保する簡易バージョン
-	@param[in]  strInput	u8文字列
-	@returns 標準文字列
- */
-std::wstring u8stowcs(std::string_view strInput)
-{
-	return cxx::to_wstring(strInput, CP_UTF8);
-}
-
-/*!
-	@brief 標準文字列をu8文字列に変換する。
-		動的にバッファを確保する簡易バージョン
-	@param[in]  strInput	標準文字列
-	@returns u8文字列
- */
-std::string wcstou8s(std::wstring_view strInput)
-{
-	return cxx::to_string(strInput, CP_UTF8);
-}
-
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                          メモリ                             //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 

--- a/sakura_core/util/string_ex.h
+++ b/sakura_core/util/string_ex.h
@@ -204,13 +204,6 @@ std::wstring strprintf(const WCHAR* pszFormat, ...);
 std::string strprintf(const CHAR* pszFormat, ...);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-//                      文字コード変換                         //
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-
-std::wstring u8stowcs(std::string_view strInput);
-std::string wcstou8s(std::wstring_view strInput);
-
-// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                       リテラル比較                          //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 // リテラルとの文字列比較の際に、手打ちで文字数を入力するのは

--- a/src/test/cpp/tests1/macro/test-cppa.cpp
+++ b/src/test/cpp/tests1/macro/test-cppa.cpp
@@ -52,6 +52,20 @@ struct CPpaTest : public ::testing::Test, public window::EditorTestSuite, public
 
 		TearDownUiaTestSuite();
 	}
+
+	/*!
+	 * テストが起動される直前に毎回呼ばれる関数
+	 */
+	void SetUp() override {
+		User32::setInstance<MockUser32>();
+	}
+
+	/*!
+	 * テストが実行された直後に毎回呼ばれる関数
+	 */
+	void TearDown() override {
+		User32::resetInstance();
+	}
 };
 
 /*!
@@ -151,42 +165,52 @@ TEST_F(CPpaTest, GetDeclarations)
  */
 TEST_F(CPpaTest, ppaErrorProc)
 {
+	auto pUser32 = (MockUser32*)User32::getInstance();
+
 	// 既にエラーフラグが立っていたらメッセージは出さない
 	info->m_bError = true;
 	CPPA::CallErrorProc(*info, int(F_FILENEW) + 1, nullptr);
 
 	// コマンドエラー
 	info->m_bError = false;
-	EXPECT_ERROUT(CPPA::CallErrorProc(*info, int(F_FILENEW) + 1, nullptr), L"関数の実行エラー\nprocedure S_FileNew; index 30101;");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"関数の実行エラー\nprocedure S_FileNew; index 30101;"), _, _, _)).WillOnce(Return(MB_OK));
+	CPPA::CallErrorProc(*info, int(F_FILENEW) + 1, nullptr);
 
 	// 関数エラー
 	info->m_bError = false;
-	EXPECT_ERROUT(CPPA::CallErrorProc(*info, int(F_GETFILENAME) + 1, nullptr), L"関数の実行エラー\nfunction S_GetFilename: string; index 40001;");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"関数の実行エラー\nfunction S_GetFilename: string; index 40001;"), _, _, _)).WillOnce(Return(MB_OK));
+	CPPA::CallErrorProc(*info, int(F_GETFILENAME) + 1, nullptr);
 
 	// 不明な関数エラー
 	info->m_bError = false;
-	EXPECT_ERROUT(CPPA::CallErrorProc(*info, 1 + 1, nullptr), L"不明な関数の実行エラー(バグです)\nFunc_ID=1");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"不明な関数の実行エラー(バグです)\nFunc_ID=1"), _, _, _)).WillOnce(Return(MB_OK));
+	CPPA::CallErrorProc(*info, 1 + 1, nullptr);
 
 	// エラー情報が不正
 	info->m_bError = false;
-	EXPECT_ERROUT(CPPA::CallErrorProc(*info, 0, nullptr), L"エラー情報が不正");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"エラー情報が不正"), _, _, _)).WillOnce(Return(MB_OK));
+	CPPA::CallErrorProc(*info, 0, nullptr);
 
 	// 詳細不明のPPAエラー
 	info->m_bError = false;
-	EXPECT_ERROUT(CPPA::CallErrorProc(*info, 0, ""), L"詳細不明のエラー");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"詳細不明のエラー"), _, _, _)).WillOnce(Return(MB_OK));
+	CPPA::CallErrorProc(*info, 0, "");
 
 	// 詳細ありのPPAエラー
 	info->m_bError = false;
-	EXPECT_ERROUT(CPPA::CallErrorProc(*info, 0, "test"), L"test");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"test"), _, _, _)).WillOnce(Return(MB_OK));
+	CPPA::CallErrorProc(*info, 0, "test");
 
 	// 未定義のエラー
 	info->m_bError = false;
-	EXPECT_ERROUT(CPPA::CallErrorProc(*info, -1, "test"), L"未定義のエラー\nError_CD=-1\ntest");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"未定義のエラー\nError_CD=-1\ntest"), _, _, _)).WillOnce(Return(MB_OK));
+	CPPA::CallErrorProc(*info, -1, "test");
 
 	// デバッグ情報付きのエラー
 	info->m_cMemDebug = "debug";
 	info->m_bError = false;
-	EXPECT_ERROUT(CPPA::CallErrorProc(*info, 0, nullptr), L"エラー情報が不正\ndebug");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"エラー情報が不正\ndebug"), _, _, _)).WillOnce(Return(MB_OK));
+	CPPA::CallErrorProc(*info, 0, nullptr);
 }
 
 /*!

--- a/src/test/cpp/tests1/macro/test-cppa.cpp
+++ b/src/test/cpp/tests1/macro/test-cppa.cpp
@@ -221,13 +221,16 @@ TEST_F(CPpaTest, ppaErrorProc)
  */
 TEST_F(CPpaTest, ppaProc)
 {
-	std::array ppszArgs1 = { "something is wrong." };
-	std::array ppszArgs2 = { LPCSTR(nullptr) };
+	auto pUser32 = (MockUser32*)User32::getInstance();
 
 	// 正常なマクロ呼出
+	std::array ppszArgs1 = { "something is wrong." };
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"something is wrong."), _, _, _)).WillOnce(Return(MB_OK));
 	EXPECT_THAT(CPPA::CallProc(*info, F_OKCANCELBOX, ppszArgs1), Eq(0));
 
 	// パラメーター不足でエラー
+	std::array ppszArgs2 = { LPCSTR(nullptr) };
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"挿入すべき文字コードが指定されていません．"), _, _, _)).WillOnce(Return(MB_OK));
 	EXPECT_THAT(CPPA::CallProc(*info, F_WCHAR, ppszArgs2), Eq(int(F_WCHAR) + 1));
 }
 

--- a/src/test/cpp/tests1/test-ccommandline.cpp
+++ b/src/test/cpp/tests1/test-ccommandline.cpp
@@ -1,19 +1,25 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
 #include "pch.h"
-#include <tchar.h>
-#include <Windows.h>
-
 #include "_main/CCommandLine.h"
+
 #include "env/CSakuraEnvironment.h"
 #include "util/string_ex.h"
 
+#include "CSelectLang.h"
+
 #include <cstdlib>
 #include <fstream>
+
+#include "eval_outputs.hpp"
+
+#include "sakura_rc.h"
+
+using namespace std::literals::string_view_literals;
 
 bool operator == (const EditInfo& lhs, const EditInfo& rhs) noexcept;
 bool operator != (const EditInfo& lhs, const EditInfo& rhs) noexcept;
@@ -878,23 +884,31 @@ TEST(CCommandLine, ParseFileNameIncludesInvalidFilenameChars)
 	// ファイル名に使えない文字 = "\\/:*?\"<>|"
 	// このうち、\\と/はパス区切りのため実質対象外になる。
 	// このうち、:は代替データストリーム(ADS)の識別記号のため対象外とする。
-	const std::wstring_view badNames[] = {
-		L"test*.txt",
-		L"test?.txt",
-		L"test\".txt",
-		L"test<.txt",
-		L"test>.txt",
-		L"test|.txt",
+	const std::array badNames = {
+		L"test*.txt"sv,
+		L"test?.txt"sv,
+		L"test\".txt"sv,
+		L"test<.txt"sv,
+		L"test>.txt"sv,
+		L"test|.txt"sv,
 	};
+
+	User32::setInstance<MockUser32>();
+	auto pUser32 = (MockUser32*)User32::getInstance();
 
 	// ファイル名に使えない文字を含んでいたら、ファイル名としては認識されない。
 	CCommandLine cCommandLine;
 	for (const auto& badName : badNames) {
+		// "%ls\r\n上記のファイル名は不正です。ファイル名に \\ / : * ? "" < > | の文字は使えません。 "
+		const auto expectedMessage = strprintf(LS(STR_CMDLINE_PARSECMD1), std::data(badName));
+		EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(expectedMessage), StrEq(L"FileNameError"), _, _)).WillOnce(Return(MB_OK));
 		cCommandLine.ParseCommandLine( badName.data(), false );
 		EXPECT_STREQ(L"", cCommandLine.GetOpenFile());
 		EXPECT_EQ(NULL, cCommandLine.GetFileName(0));
 		EXPECT_EQ(0, cCommandLine.GetFileNum());
 	}
+
+	User32::resetInstance();
 }
 
 /*!
@@ -903,16 +917,24 @@ TEST(CCommandLine, ParseFileNameIncludesInvalidFilenameChars)
  */
 TEST(CCommandLine, ParseTooLongFilePath)
 {
+	User32::setInstance<MockUser32>();
+	auto pUser32 = (MockUser32*)User32::getInstance();
+
 	// _MAX_PATH - 1を超えるパスは無視される
 	CCommandLine cCommandLine;
 	std::wstring strCmdLine;
 	std::wstring strPath(_MAX_PATH, L'a');
+	// "%ls\nというファイルを開けません。\nファイルのパスが長すぎます。"
+	const auto expectedMessage = strprintf(LS(STR_ERR_FILEPATH_TOO_LONG), std::data(strPath));
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(expectedMessage), StrEq(L"FileNameError"), _, _)).WillOnce(Return(MB_OK));
 	strprintf(strCmdLine, L"%s test.txt", strPath.c_str());
 	cCommandLine.ParseCommandLine(strCmdLine.data(), false);
 	// 以下のチェックはMinGWで動作しないため、コメントアウトしておく
 	//EXPECT_STREQ(GetLocalPath(L"test.txt").data(), cCommandLine.GetOpenFile());
 	EXPECT_EQ(NULL, cCommandLine.GetFileName(0));
 	EXPECT_EQ(0, cCommandLine.GetFileNum());
+
+	User32::resetInstance();
 }
 
 // 以下のチェックはMinGWで動作しないため、コメントアウトしておく
@@ -924,12 +946,18 @@ TEST(CCommandLine, ParseTooLongFilePath)
  */
 TEST(CCommandLine, ParseMaxFilePath)
 {
+	User32::setInstance<MockUser32>();
+	auto pUser32 = (MockUser32*)User32::getInstance();
+
 	// 絶対パスへの変換処理の影響を受けないように、事前に絶対パス化しておく
 	std::wstring strPath = GetLocalPath(L"a");
 	strPath.resize(_MAX_PATH - 1, L'a');
 
 	// _MAX_PATH - 1までのパスは受け付けられる
 	CCommandLine cCommandLine;
+	// "%ls\nというファイルを開けません。\nファイルのパスが長すぎます。"
+	const auto expectedMessage = strprintf(LS(STR_ERR_FILEPATH_TOO_LONG), std::data(strPath));
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(expectedMessage), StrEq(L"FileNameError"), _, _)).Times(0);	// エラーにならないので0回表示。
 	std::wstring strCmdLine;
 	strprintf(strCmdLine, L"%s test.txt", strPath.c_str());
 	cCommandLine.ParseCommandLine(strCmdLine.data(), false);
@@ -937,6 +965,8 @@ TEST(CCommandLine, ParseMaxFilePath)
 	EXPECT_STREQ(GetLocalPath(L"test.txt").data(), cCommandLine.GetFileName(0));
 	EXPECT_EQ(NULL, cCommandLine.GetFileName(1));
 	EXPECT_EQ(1, cCommandLine.GetFileNum());
+
+	User32::resetInstance();
 }
 
 #endif //ifndef __MINGW32__

--- a/src/test/cpp/tests1/test-ccommandline.cpp
+++ b/src/test/cpp/tests1/test-ccommandline.cpp
@@ -911,6 +911,8 @@ TEST(CCommandLine, ParseFileNameIncludesInvalidFilenameChars)
 	User32::resetInstance();
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * @brief 長過ぎるファイルパスに関する仕様
  * @remark _MAX_PATH - 1を超えるファイル名は利用できない
@@ -922,23 +924,21 @@ TEST(CCommandLine, ParseTooLongFilePath)
 
 	// _MAX_PATH - 1を超えるパスは無視される
 	CCommandLine cCommandLine;
-	std::wstring strCmdLine;
 	std::wstring strPath(_MAX_PATH, L'a');
 	// "%ls\nというファイルを開けません。\nファイルのパスが長すぎます。"
 	const auto expectedMessage = strprintf(LS(STR_ERR_FILEPATH_TOO_LONG), std::data(strPath));
-	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(expectedMessage), StrEq(L"FileNameError"), _, _)).WillOnce(Return(MB_OK));
-	strprintf(strCmdLine, L"%s test.txt", strPath.c_str());
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(expectedMessage), StrEq(L"FileNameError"), _, _))
+		.Times(2)
+		.WillOnce(Return(MB_OK))
+		.WillOnce(Return(MB_OK));
+	const auto strCmdLine = std::format(L"{:s} \"{:s}\" test.txt", strPath, strPath);
 	cCommandLine.ParseCommandLine(strCmdLine.data(), false);
-	// 以下のチェックはMinGWで動作しないため、コメントアウトしておく
-	//EXPECT_STREQ(GetLocalPath(L"test.txt").data(), cCommandLine.GetOpenFile());
-	EXPECT_EQ(NULL, cCommandLine.GetFileName(0));
-	EXPECT_EQ(0, cCommandLine.GetFileNum());
+	EXPECT_THAT(cCommandLine.GetOpenFile(), StrEq(GetLocalPath(L"test.txt")));
+	EXPECT_THAT(cCommandLine.GetFileName(0), IsNull());
+	EXPECT_THAT(cCommandLine.GetFileNum(), Eq(0));
 
 	User32::resetInstance();
 }
-
-// 以下のチェックはMinGWで動作しないため、コメントアウトしておく
-#ifndef __MINGW32__
 
 /*!
  * @brief ファイルパスに指定できる上限文字列長に関する仕様
@@ -958,15 +958,14 @@ TEST(CCommandLine, ParseMaxFilePath)
 	// "%ls\nというファイルを開けません。\nファイルのパスが長すぎます。"
 	const auto expectedMessage = strprintf(LS(STR_ERR_FILEPATH_TOO_LONG), std::data(strPath));
 	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(expectedMessage), StrEq(L"FileNameError"), _, _)).Times(0);	// エラーにならないので0回表示。
-	std::wstring strCmdLine;
-	strprintf(strCmdLine, L"%s test.txt", strPath.c_str());
+	const auto strCmdLine = std::format( L"{:s} test.txt", strPath);
 	cCommandLine.ParseCommandLine(strCmdLine.data(), false);
-	EXPECT_STREQ(strPath.data(), cCommandLine.GetOpenFile());
-	EXPECT_STREQ(GetLocalPath(L"test.txt").data(), cCommandLine.GetFileName(0));
-	EXPECT_EQ(NULL, cCommandLine.GetFileName(1));
-	EXPECT_EQ(1, cCommandLine.GetFileNum());
+	EXPECT_THAT(cCommandLine.GetOpenFile(), StrEq(strPath.c_str()));
+	EXPECT_THAT(cCommandLine.GetFileName(0), StrEq(GetLocalPath(L"test.txt")));
+	EXPECT_THAT(cCommandLine.GetFileName(1), IsNull());
+	EXPECT_THAT(cCommandLine.GetFileNum(), Eq(1));
 
 	User32::resetInstance();
 }
 
-#endif //ifndef __MINGW32__
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)

--- a/src/test/cpp/tests1/test-messageboxf.cpp
+++ b/src/test/cpp/tests1/test-messageboxf.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2022, Sakura Editor Organization
+	Copyright (C) 2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -14,8 +14,14 @@
  */
 TEST(MessageBoxF, test)
 {
+	User32::setInstance<MockUser32>();
+	auto pUser32 = (MockUser32*)User32::getInstance();
+
 	const HWND hWnd = nullptr;
-	EXPECT_ERROUT(MessageBoxF(hWnd, MB_OK, L"caption", L"%d行をマージしました。", 2), L"2行をマージしました。");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	MessageBoxF(hWnd, MB_OK, L"caption", L"%d行をマージしました。", 2);
+
+	User32::resetInstance();
 }
 
 /*!
@@ -23,36 +29,56 @@ TEST(MessageBoxF, test)
  */
 TEST(MessageBoxF, customMessageBoxFunctions)
 {
+	User32::setInstance<MockUser32>();
+	auto pUser32 = (MockUser32*)User32::getInstance();
+
 	const HWND hWnd = nullptr;
 
 	//エラー：赤丸に「×」[OK]
-	EXPECT_ERROUT(ErrorMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
-	EXPECT_ERROUT(TopErrorMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	ErrorMessage(hWnd, L"%d行をマージしました。", 2);
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	TopErrorMessage(hWnd, L"%d行をマージしました。", 2);
 
 	//警告：三角に「！」[OK]
-	EXPECT_ERROUT(WarningMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
-	EXPECT_ERROUT(TopWarningMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	WarningMessage(hWnd, L"%d行をマージしました。", 2);
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	TopWarningMessage(hWnd, L"%d行をマージしました。", 2);
 
 	//情報：青丸に「i」[OK]
-	EXPECT_ERROUT(InfoMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
-	EXPECT_ERROUT(TopInfoMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	InfoMessage(hWnd, L"%d行をマージしました。", 2);
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	TopInfoMessage(hWnd, L"%d行をマージしました。", 2);
 
 	//確認：吹き出しの「？」 [はい][いいえ] 戻り値:IDYES,IDNO
-	EXPECT_ERROUT(ConfirmMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
-	EXPECT_ERROUT(TopConfirmMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	ConfirmMessage(hWnd, L"%d行をマージしました。", 2);
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	TopConfirmMessage(hWnd, L"%d行をマージしました。", 2);
 
 	//三択：吹き出しの「？」 [はい][いいえ][キャンセル]  戻り値:ID_YES,ID_NO,ID_CANCEL
-	EXPECT_ERROUT(Select3Message(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
-	EXPECT_ERROUT(TopSelect3Message(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	Select3Message(hWnd, L"%d行をマージしました。", 2);
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	TopSelect3Message(hWnd, L"%d行をマージしました。", 2);
 
 	//その他メッセージ表示用ボックス[OK]
-	EXPECT_ERROUT(OkMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
-	EXPECT_ERROUT(TopOkMessage(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	OkMessage(hWnd, L"%d行をマージしました。", 2);
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	TopOkMessage(hWnd, L"%d行をマージしました。", 2);
 
 	//タイプ指定メッセージ表示用ボックス
-	EXPECT_ERROUT(CustomMessage(hWnd, MB_OK, L"%d行をマージしました。", 2), L"2行をマージしました。");
-	EXPECT_ERROUT(TopCustomMessage(hWnd, MB_OK, L"%d行をマージしました。", 2), L"2行をマージしました。");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	CustomMessage(hWnd, MB_OK, L"%d行をマージしました。", 2);
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	TopCustomMessage(hWnd, MB_OK, L"%d行をマージしました。", 2);
 
 	//作者に教えて欲しいエラー
-	EXPECT_ERROUT(PleaseReportToAuthor(hWnd, L"%d行をマージしました。", 2), L"2行をマージしました。");
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"2行をマージしました。"), _, _, _)).WillOnce(Return(MB_OK));
+	PleaseReportToAuthor(hWnd, L"%d行をマージしました。", 2);
+
+	User32::resetInstance();
 }

--- a/src/test/cpp/tests1/test-string_ex.cpp
+++ b/src/test/cpp/tests1/test-string_ex.cpp
@@ -218,30 +218,6 @@ TEST(string_ex, strprintfA_small_output)
 }
 
 /*!
-	@brief 標準文字列をu8文字列に変換する。
- */
-TEST(string_ex, wcstou8s)
-{
-	// wcs→u8変換ができること
-	ASSERT_STREQ(wcstou8s(L"This is 運命").data(), (LPCSTR)u8"This is 運命");
-
-	// 空文字列も問題なく変換できること
-	ASSERT_STREQ(wcstou8s(L"").data(), (LPCSTR)u8"");
-}
-
-/*!
-	@brief u8文字列を標準文字列に変換する。
- */
-TEST(string_ex, u8stowcs)
-{
-	// u8→wcs変換ができること
-	ASSERT_STREQ(u8stowcs((LPCSTR)u8"This is 運命").data(), L"This is 運命");
-
-	// 空文字列も問題なく変換できること
-	ASSERT_STREQ(u8stowcs((LPCSTR)u8"").data(), L"");
-}
-
-/*!
 	@brief 独自定義の文字列比較関数。
  */
 TEST(string_ex, strncmp_literal)

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -49,6 +49,8 @@
 #include "config/app_constants.h"
 #include "env/CommonSetting.h"
 
+#include "eval_outputs.hpp"
+
 #include "tests1_rc.h"
 
 using namespace std::literals::string_literals;
@@ -291,6 +293,50 @@ TEST_F(TrayWndTest, OpenNewEditor102)
 
 	// 設定を元に戻す
 	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
+}
+
+TEST_F(TrayWndTest, TerminateApplication101)
+{
+	GetDllShareData().m_Common.m_sGeneral.m_bExitConfirm = false;
+
+	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
+
+	User32::setInstance<MockUser32>();
+	auto pUser32 = (MockUser32*)User32::getInstance();
+
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _)).Times(0);
+
+	const HWND hWndFrom = nullptr;
+	CControlTray::TerminateApplication(hWndFrom);
+
+	User32::resetInstance();
+
+	// 設定を元に戻す
+	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
+
+	GetDllShareData().m_Common.m_sGeneral.m_bExitConfirm = false;
+}
+
+TEST_F(TrayWndTest, TerminateApplication102)
+{
+	GetDllShareData().m_Common.m_sGeneral.m_bExitConfirm = true;
+
+	GetDllShareData().m_sNodes.m_nEditArrNum = 1;
+
+	User32::setInstance<MockUser32>();
+	auto pUser32 = (MockUser32*)User32::getInstance();
+
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"現在開いている編集用のウィンドウをすべて閉じて終了しますか?"), _, _, _)).WillOnce(Return(IDNO));
+
+	const HWND hWndFrom = nullptr;
+	CControlTray::TerminateApplication(hWndFrom);
+
+	User32::resetInstance();
+
+	// 設定を元に戻す
+	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
+
+	GetDllShareData().m_Common.m_sGeneral.m_bExitConfirm = false;
 }
 
 TEST_F(TrayWndTest, DISABLED_OnCreate101)	// パラメーター不正の考慮がないので呼べない

--- a/src/test/resources/eval_outputs.hpp
+++ b/src/test/resources/eval_outputs.hpp
@@ -1,12 +1,22 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2022, Sakura Editor Organization
+	Copyright (C) 2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
-#include "pch.h"
-
+#include "util/os.h"
 #include "util/string_ex.h"
+
+struct MockUser32 final : public User32
+{
+	MOCK_CONST_METHOD5(MessageBoxExW, int(
+		_In_opt_ HWND hWnd,
+		_In_opt_ LPCWSTR lpText,
+		_In_opt_ LPCWSTR lpCaption,
+		_In_ UINT uType,
+		_In_ WORD wLanguageId
+	));
+};
 
 // 標準エラー出力に吐き出されたメッセージを評価します
 #define EXPECT_ERROUT(statementExpression, expected) \

--- a/src/test/resources/eval_outputs.hpp
+++ b/src/test/resources/eval_outputs.hpp
@@ -5,7 +5,7 @@
 	SPDX-License-Identifier: Zlib
 */
 #include "util/os.h"
-#include "util/string_ex.h"
+#include "util/tchar_convert.h"
 
 struct MockUser32 final : public User32
 {
@@ -22,4 +22,4 @@ struct MockUser32 final : public User32
 #define EXPECT_ERROUT(statementExpression, expected) \
 	testing::internal::CaptureStderr(); \
 	statementExpression; \
-	EXPECT_STREQ(strprintf(L"%s\n", expected).data(), u8stowcs(testing::internal::GetCapturedStderr()).data())
+	EXPECT_THAT(cxx::to_wstring(testing::internal::GetCapturedStderr(), CP_UTF8), StrEq(std::format(L"{:s}\n", expected)))


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- 先行 issue はとくに作成していません。

メッセージボックス関連の問題

- stdoutに出力させて読み取る構造にしているため、テストログが汚い。
- APIフックもモックも使っていないので~~MB_OK以外の==ルートを確認できない。
（補足：固定戻り値 0 を返してたので、MessageBox の戻り値で分岐するルートを確認できなかった。）

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- MessageBoxExW をモック化して柔軟なテストができるようにします。
- メッセージボックス表示は数が多いので全部は対応しません。

本件、勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->
- #2068

## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
