### PR TITLE
ヘルプファイルの最終更新日を更新

### DIFF
--- a/help/sakura/res/HLP000001.html
+++ b/help/sakura/res/HLP000001.html
@@ -15,7 +15,7 @@
 -->
 <br>
 <hr style="margin: 0 auto;width: 350px" />
-<div style="text-align: center">サクラエディタ   Ver 2.4.3 (開発版)</div>
+<div style="text-align: center">サクラエディタ   Ver 2.4.4 (開発版)</div>
 <div style="text-align: center">ヘルプファイル最終更新日 2026/08/08</div>
 <div style="text-align: center"><a href="https://sakura-editor.github.io/" target="_blank" rel="noopener">https://sakura-editor.github.io/</a></div>
 <hr style="margin: 0 auto;width: 350px" />

--- a/help/sakura/res/HLP000001.html
+++ b/help/sakura/res/HLP000001.html
@@ -16,7 +16,7 @@
 <br>
 <hr style="margin: 0 auto;width: 350px" />
 <div style="text-align: center">サクラエディタ   Ver 2.4.3 (開発版)</div>
-<div style="text-align: center">ヘルプファイル最終更新日 2022/12/03</div>
+<div style="text-align: center">ヘルプファイル最終更新日 2026/08/08</div>
 <div style="text-align: center"><a href="https://sakura-editor.github.io/" target="_blank" rel="noopener">https://sakura-editor.github.io/</a></div>
 <hr style="margin: 0 auto;width: 350px" />
 サクラエディタ(旧称:テキストエディタ)は、「たけ(竹パンダ)」さんのテキストエディタSAKURAの公開ソース(2000/02/21付)を元に不具合修正および機能拡張を行ったものです。<br>

--- a/src/main/cmake/version.cmake
+++ b/src/main/cmake/version.cmake
@@ -52,7 +52,7 @@ endfunction()
 # Initialize variables with default values
 set(SAKURA_MAJOR_VERSION "2") # メジャーバージョン(2固定)
 set(SAKURA_MINOR_VERSION "4") # マイナーバージョン(4以降はGitHub版)
-set(SAKURA_PATCH_VERSION "3") # 連番(マージの通し番号)
+set(SAKURA_PATCH_VERSION "4") # 連番(マージの通し番号)
 set(BUILD_VERSION "0")
 
 # CIのビルドページURL(ENVで指定する)


### PR DESCRIPTION
# PR対象

- ドキュメント(md、ヘルプファイル等)

## カテゴリ

- 改善

## PR の背景

ヘルプファイルの最終更新日が古いままだったため更新する。

PR #2555 は release/v2.4.3 向けに DEV_VERSION マクロ無効化とバージョン表記から「(開発版)」を外す変更を含んでいたが、これらはリリースブランチ専用のためmasterには適用しない。一方でヘルプファイル最終更新日の更新のみはmasterにも反映が必要なため、本PRで対応する。

## 仕様・動作説明

- `help/sakura/res/HLP000001.html` : ヘルプファイル最終更新日を 2022/12/03 → 2026/08/08 に更新

## 関連 issue, PR

* #2555