### PR TITLE
次期開発版に向けてバージョン番号を 2.4.4 に上げる

### DIFF
--- a/help/sakura/res/HLP000001.html
+++ b/help/sakura/res/HLP000001.html
@@ -15,7 +15,7 @@
 -->
 <br>
 <hr style="margin: 0 auto;width: 350px" />
-<div style="text-align: center">サクラエディタ   Ver 2.4.3 (開発版)</div>
+<div style="text-align: center">サクラエディタ   Ver 2.4.4 (開発版)</div>
 <div style="text-align: center">ヘルプファイル最終更新日 2026/08/08</div>
 <div style="text-align: center"><a href="https://sakura-editor.github.io/" target="_blank" rel="noopener">https://sakura-editor.github.io/</a></div>
 <hr style="margin: 0 auto;width: 350px" />

--- a/src/main/cmake/version.cmake
+++ b/src/main/cmake/version.cmake
@@ -52,7 +52,7 @@ endfunction()
 # Initialize variables with default values
 set(SAKURA_MAJOR_VERSION "2") # メジャーバージョン(2固定)
 set(SAKURA_MINOR_VERSION "4") # マイナーバージョン(4以降はGitHub版)
-set(SAKURA_PATCH_VERSION "3") # 連番(マージの通し番号)
+set(SAKURA_PATCH_VERSION "4") # 連番(マージの通し番号)
 set(BUILD_VERSION "0")
 
 # CIのビルドページURL(ENVで指定する)


### PR DESCRIPTION
# PR対象

- アプリ(サクラエディタ本体)
- ドキュメント(md、ヘルプファイル等)

## カテゴリ

- 改善

## PR の背景

v2.4.3 リリース後、masterの開発版バージョン表記を次期バージョン (2.4.4) に上げる。

このPRは #2593 の上に積んだスタックPRです。#2593 が先にmasterへマージされた後、本PRは自動的にmasterへの差分のみになります。

## 仕様・動作説明

- `src/main/cmake/version.cmake` : `SAKURA_PATCH_VERSION` を `3` → `4` に変更(`version.h.in` 経由で `VER_C` に反映)
- `help/sakura/res/HLP000001.html` : バージョン表記を `Ver 2.4.3 (開発版)` → `Ver 2.4.4 (開発版)` に変更

## 関連 issue, PR

* #2555
* #2593 (この下に積まれています)