### PR TITLE
インストーラに sakura_lang_zh_CN.dll を含める

### DIFF
--- a/installer/sakura-common.iss
+++ b/installer/sakura-common.iss
@@ -234,6 +234,7 @@ Name: sakuragrep;  Description: "{cm:sakuragrep}";                        Compon
 [Files]
 Source: "sakura\sakura.exe";           DestDir: "{app}";                  Components: main; Flags: ignoreversion;
 Source: "sakura\sakura_lang_en_US.dll";DestDir: "{app}";                  Components: main; Flags: ignoreversion;
+Source: "sakura\sakura_lang_zh_CN.dll";DestDir: "{app}";                  Components: main; Flags: ignoreversion;
 Source: "sakura\license\LICENSE";      DestDir: "{app}\license";          Components: main
 Source: "sakura\bregonig.dll";         DestDir: "{app}";                  Components: main
 Source: "sakura\license\bregonig\*";   DestDir: "{app}\license\bregonig"; Components: main


### PR DESCRIPTION
## 概要

Fixes #2598

v2.4.3 のリリースノートには「簡体字中国語言語パックを追加」(#2039) とあるが、実際にインストールすると `sakura_lang_zh_CN.dll` が存在せず、共通設定の言語選択肢にも中国語(簡体字)が出てこない。

## 原因

- #2039 で `sakura_lang_zh_CN` のソースが追加されたが、当時のレビューで `sakura.sln` への組み込みは意図的に見送られていた（#2201 参照）。
- その後 #2201 / #2228 等の対応で CMake 経由のビルドが整備され、`sakura_core/sakura.vcxproj` の `GenerateLang_zh_CN` ターゲットにより `sakura_lang_zh_CN.dll` は実際にビルド出力フォルダ (`x64\Release` 等) に生成されるようになった。
- `build-installer.bat` はビルド出力から `*.dll` をワイルドカードコピーしてインストーラ作業フォルダに集めるが、Inno Setup は `[Files]` セクションに明記されたファイルのみをパッケージに含める。
- `installer/sakura-common.iss` の `[Files]` セクションには `sakura_lang_en_US.dll` の行はあるが `sakura_lang_zh_CN.dll` の行が一度も追加されておらず、DLLはビルドされているのにインストーラから漏れていた。

## 変更内容

`installer/sakura-common.iss` の `[Files]` セクションに `sakura_lang_zh_CN.dll` を追加。`sakura-Win32.iss` / `sakura-x64.iss` はいずれも `sakura-common.iss` を `#include` しているため、両プラットフォームに適用される。

## テスト

- [x] CI ビルドでインストーラに `sakura_lang_zh_CN.dll` が含まれることを確認
- [x] インストール後、共通設定の言語一覧に「中国語（簡体字）」が表示されることを確認