### PR TITLE
既知のflaky UIオートメーションテストをCI側でリトライ許容する

### DIFF
--- a/.github/workflows/build-sakura.yml
+++ b/.github/workflows/build-sakura.yml
@@ -446,11 +446,15 @@ jobs:
         path: help
 
     - name: Run unit tests
-      timeout-minutes: 15 # 指定時間を越えたら打ち切る。値は暫定。
+      # 最大3回リトライするため、通常時間(約6分)の3倍以上の余裕を持たせる。値は暫定。
+      timeout-minutes: 30
+      # UI Automationを使うテストがCI環境限定で断続的にタイムアウトすることがある(既知のflaky、#2603)。
+      # 30秒ウォッチドッグで有限失敗に変換した上で、失敗時のみ最大2回まで再試行する。
       run: ctest
         --test-dir build/${{ matrix.platform }}/CMakeTools
         -C ${{ matrix.config }}
         --output-on-failure
+        --repeat until-pass:3
         -V
 
     - name: Upload sonar-input artifact


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->

# PR対象

- ビルド手順/CI

## カテゴリ

- 不具合修正

## PR の背景

- #2603

`UiaTestSuite` を使うモーダルダイアログ系のユニットテスト(`TrayWndTest.ShowPropCommon001`、`FileDialogTest.DoModalOpenDlg001` など)が、GitHub Actions Windows runner環境限定で断続的に30秒タイムアウトしてCIが失敗することがある。#2603 で調査した結果、特定のダイアログAPI(PropertySheet/GetOpenFileName)やOpenCppCoverageのコードカバレッジ計測に限定されない、より一般的な環境要因(モーダルダイアログを開いているスレッドがメッセージポンプを処理できなくなる)と判明し、Sakura側のアプリケーションコードでの確実な根本修正は難しいと判断した。

## 仕様・動作説明

`.github/workflows/build-sakura.yml` の `Run unit tests` ステップで、`ctest` に `--repeat until-pass:3` を追加する。失敗したテストのみ最大3回まで自動的に再試行し、いずれかの試行で成功すればそのテストは成功扱いになる(既存の30秒ウォッチドッグによる「有限失敗への変換」は維持したまま)。

リトライにより所要時間が伸びる可能性があるため、ステップの `timeout-minutes` も15分から30分に引き上げた。

## PR の影響範囲

- `Run unit tests` ステップの実行時間が、リトライが発生した場合に伸びる(通常は変わらない)
- 個別テストの信頼性そのものは変わらない。CI全体の成功率が上がる

## テスト内容

masterから分岐した本ブランチでCIを71回実行して検証した。

| 項目 | 件数 |
|---|---|
| 検証したCI実行 | 71件 |
| 最終結果success | **71/71(100%)** |
| MSBuild Debugジョブ(Win32+x64合計) | 142件 |
| うちタイムアウトを踏んだジョブ | 3件(約2.1%) |
| リトライなしで一発成功 | 139件 |

タイムアウトを踏んだ3件([31465546379](https://github.com/m-tmatma/sakura/actions/runs/31465546379)、[31465460954](https://github.com/m-tmatma/sakura/actions/runs/31465460954)、[31465422901](https://github.com/m-tmatma/sakura/actions/runs/31465422901))は、いずれも `ctest --repeat until-pass:3` によって救済され、最終的にCI成功している。タイムアウト発生率(約2.1%)は #2603 で報告した再現率と同水準であり、今回のサンプルで根本原因を再度誘発できていることも確認できている。

## 関連issue, PR

- resolves #2603
