### PR TITLE
Grep 実行時に「プロセスの起動に失敗しました。」表示される。

### DIFF
--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -27,6 +27,7 @@
 
 #include "StdAfx.h"
 #include <HtmlHelp.h>
+#include "cxx/ResourceHolder.hpp"
 #include "CControlTray.h"
 #include "env/CPropertyManager.h"
 #include "typeprop/CDlgTypeList.h"
@@ -1287,13 +1288,14 @@ bool CControlTray::OpenNewEditor(
 	{
 		// エディター初期化完了イベントを作成する
 		SFilePath initEventName{ std::format(GSTR_EVENT_SAKURA_EP_INITIALIZED, p.dwThreadId) };
-		HANDLE hEvent = ::CreateEventW(nullptr, TRUE, FALSE, initEventName);
+		using HandleHolder = cxx::ResourceHolder<&::CloseHandle>;
+		HandleHolder hEvent{ ::CreateEventW(nullptr, TRUE, FALSE, initEventName) };
 
 		// エディターのメインスレッドを再開する
 		::ResumeThread(p.hThread);
 
 		// エディター初期化完了を待つ
-		std::array handles{ hEvent, p.hProcess };
+		std::array handles{ hEvent.get(), p.hProcess };
 		const auto count = DWORD(std::size(handles));
 
 		const auto startTick = ::GetTickCount64();

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -97,6 +97,13 @@ bool CNormalProcess::InitializeProcess()
 	using InitEventHolder = cxx::ResourceHolder<&::SetEvent>;
 	InitEventHolder initEvent{ hEvent.get() };
 
+	// Grep完了イベントを開く（作成側が存在しない場合はnullptrになる）
+	SFilePath grepEventName{ std::format(GSTR_EVENT_SAKURA_EP_GREP_COMPLETED, ::GetCurrentThreadId()) };
+	HandleHolder hGrepEvent{ ::OpenEventW(STANDARD_RIGHTS_REQUIRED | EVENT_MODIFY_STATE | SYNCHRONIZE, FALSE, grepEventName) };
+
+	// スコープを抜けるとき（＝Grep完了後）シグナル状態になるようにする
+	InitEventHolder grepEvent{ hGrepEvent.get() };
+
 	/* 共有メモリを初期化する */
 	if (!CProcessFactory::IsExistControlProcess() && !CProcessFactory::StartControlProcess() || !CProcess::InitializeProcess()) {
 		return false;
@@ -228,7 +235,8 @@ bool CNormalProcess::InitializeProcess()
 			SetMainWindow( pEditWnd->GetHwnd() );
 			::ReleaseMutex( hMutex );
 			::CloseHandle( hMutex );
-<<<<<<< HEAD
+			// エディター初期化完了を通知する（Grep 実行前）
+			initEvent = nullptr;
 			this->m_pcEditApp->m_pcGrepAgent->DoGrep(
 				&pEditWnd->GetActiveView(),
 				gi.bGrepReplace,
@@ -250,33 +258,6 @@ bool CNormalProcess::InitializeProcess()
 				gi.bGrepPaste,
 				gi.bGrepBackup
 			);
-=======
-			::SetEvent( hEvent.get() );
-			{
-				const SGrepInput grepInput{ &gi.cmGrepKey, &gi.cmGrepRep, &gi.cmGrepFile, &gi.cmGrepFolder };
-				SGrepOption sGrepOption;
-				sGrepOption.bGrepReplace = gi.bGrepReplace;
-				sGrepOption.bGrepSubFolder = gi.bGrepSubFolder != FALSE;
-				sGrepOption.bGrepStdout = gi.bGrepStdout;
-				sGrepOption.bGrepHeader = gi.bGrepHeader;
-				sGrepOption.nGrepCharSet = gi.nGrepCharSet;
-				sGrepOption.nGrepOutputLineType = gi.nGrepOutputLineType;
-				sGrepOption.nGrepOutputStyle = gi.nGrepOutputStyle;
-				sGrepOption.bGrepOutputFileOnly = gi.bGrepOutputFileOnly;
-				sGrepOption.bGrepOutputBaseFolder = gi.bGrepOutputBaseFolder;
-				sGrepOption.bGrepSeparateFolder = gi.bGrepSeparateFolder;
-				sGrepOption.bGrepPaste = gi.bGrepPaste;
-				sGrepOption.bGrepBackup = gi.bGrepBackup;
-				this->m_pcEditApp->m_pcGrepAgent->DoGrep(
-					&pEditWnd->GetActiveView(),
-					grepInput,
-					gi.sGrepSearchOption,
-					sGrepOption,
-					gi.bGrepCurFolder,
-					gi.bGrepExcludeFileRegexp
-				);
-			}
->>>>>>> 9c9c17856 (プロセスエラーの追加対応)
 			pEditWnd->m_cDlgFuncList.Refresh();	// アウトラインを再解析する
 		}
 		else{
@@ -311,7 +292,8 @@ bool CNormalProcess::InitializeProcess()
 			::ReleaseMutex( hMutex );
 			::CloseHandle( hMutex );
 			hMutex = nullptr;
-			::SetEvent( hEvent.get() );
+			// エディター初期化完了を通知する（ダイアログ表示前）
+			initEvent = nullptr;
 			
 			//	Oct. 9, 2003 genta コマンドラインからGERPダイアログを表示させた場合に
 			//	引数の設定がBOXに反映されない

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -228,6 +228,7 @@ bool CNormalProcess::InitializeProcess()
 			SetMainWindow( pEditWnd->GetHwnd() );
 			::ReleaseMutex( hMutex );
 			::CloseHandle( hMutex );
+<<<<<<< HEAD
 			this->m_pcEditApp->m_pcGrepAgent->DoGrep(
 				&pEditWnd->GetActiveView(),
 				gi.bGrepReplace,
@@ -249,6 +250,33 @@ bool CNormalProcess::InitializeProcess()
 				gi.bGrepPaste,
 				gi.bGrepBackup
 			);
+=======
+			::SetEvent( hEvent.get() );
+			{
+				const SGrepInput grepInput{ &gi.cmGrepKey, &gi.cmGrepRep, &gi.cmGrepFile, &gi.cmGrepFolder };
+				SGrepOption sGrepOption;
+				sGrepOption.bGrepReplace = gi.bGrepReplace;
+				sGrepOption.bGrepSubFolder = gi.bGrepSubFolder != FALSE;
+				sGrepOption.bGrepStdout = gi.bGrepStdout;
+				sGrepOption.bGrepHeader = gi.bGrepHeader;
+				sGrepOption.nGrepCharSet = gi.nGrepCharSet;
+				sGrepOption.nGrepOutputLineType = gi.nGrepOutputLineType;
+				sGrepOption.nGrepOutputStyle = gi.nGrepOutputStyle;
+				sGrepOption.bGrepOutputFileOnly = gi.bGrepOutputFileOnly;
+				sGrepOption.bGrepOutputBaseFolder = gi.bGrepOutputBaseFolder;
+				sGrepOption.bGrepSeparateFolder = gi.bGrepSeparateFolder;
+				sGrepOption.bGrepPaste = gi.bGrepPaste;
+				sGrepOption.bGrepBackup = gi.bGrepBackup;
+				this->m_pcEditApp->m_pcGrepAgent->DoGrep(
+					&pEditWnd->GetActiveView(),
+					grepInput,
+					gi.sGrepSearchOption,
+					sGrepOption,
+					gi.bGrepCurFolder,
+					gi.bGrepExcludeFileRegexp
+				);
+			}
+>>>>>>> 9c9c17856 (プロセスエラーの追加対応)
 			pEditWnd->m_cDlgFuncList.Refresh();	// アウトラインを再解析する
 		}
 		else{
@@ -283,6 +311,7 @@ bool CNormalProcess::InitializeProcess()
 			::ReleaseMutex( hMutex );
 			::CloseHandle( hMutex );
 			hMutex = nullptr;
+			::SetEvent( hEvent.get() );
 			
 			//	Oct. 9, 2003 genta コマンドラインからGERPダイアログを表示させた場合に
 			//	引数の設定がBOXに反映されない

--- a/sakura_core/config/system_constants.h
+++ b/sakura_core/config/system_constants.h
@@ -588,6 +588,9 @@
 //! 初期化完了イベント
 inline constexpr std::wstring_view GSTR_EVENT_SAKURA_EP_INITIALIZED = L"EventSakuraEditorEPInitialized_{:d}";
 
+//! Grep完了イベント
+inline constexpr std::wstring_view GSTR_EVENT_SAKURA_EP_GREP_COMPLETED = L"EventSakuraEditorEPGrepCompleted_{:d}";
+
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                     ウィンドウクラス                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/src/test/cpp/tests1/test-winmain.cpp
+++ b/src/test/cpp/tests1/test-winmain.cpp
@@ -460,6 +460,10 @@ cxx::EditorProcessHolder CreateEditorProcess(
 	SFilePath initEventName{ std::format(GSTR_EVENT_SAKURA_EP_INITIALIZED, ep.dwThreadId) };
 	cxx::HandleHolder hEvent{ ::CreateEventW(nullptr, TRUE, FALSE, initEventName) };
 
+	// Grep完了イベントを作成する
+	SFilePath grepEventName{ std::format(GSTR_EVENT_SAKURA_EP_GREP_COMPLETED, ep.dwThreadId) };
+	cxx::HandleHolder hGrepEvent{ ::CreateEventW(nullptr, TRUE, FALSE, grepEventName) };
+
 	// エディターのメインスレッドを再開する
 	::ResumeThread(hThread);
 

--- a/src/test/cpp/tests1/test-winmain.cpp
+++ b/src/test/cpp/tests1/test-winmain.cpp
@@ -1282,4 +1282,88 @@ TEST_F(WinMainFuncTest, ShowDlgProfileMgr101)
 	ep.lock();
 }
 
+/*!
+ * @brief 初期化完了イベントの通知タイミング検証（バグ検知テスト）
+ *
+ *  エディタープロセスは、編集ウインドウ生成完了（＝Grepダイアログを
+ *  表示できる状態）になった時点で初期化完了イベントをシグナルすべき。
+ *  現行実装は InitializeProcess の return 時（Grep/ダイアログ完了後）
+ *  までシグナルしないため、呼出元 CControlTray::OpenNewEditor(sync) が
+ *  15秒でタイムアウトし STR_TRAY_CREATEPROC2 を誤表示する。
+ *  本テストはダイアログ表示中のイベント状態を採取してこれを検知する。
+ *  （現行コードでは FAIL する。シグナル位置修正後に PASS する。）
+ */
+TEST_F(WinMainFuncTest, GrepInitEventSignaledBeforeDialog)
+{
+	// テスト用プロファイル名
+	const auto profileName{ GetProfileName() };
+
+	// エディタープロセスをサスペンド状態で起動する
+	STARTUPINFO si = { sizeof(STARTUPINFO) };
+	si.dwFlags = STARTF_USESHOWWINDOW;
+	si.wShowWindow = SW_SHOWDEFAULT;
+	std::vector<std::wstring> args{
+		LR"(-GREPDLG)",
+		LR"(-GREPMODE)",
+		std::format(LR"(-CODE={})", static_cast<int>(CODE_AUTODETECT)),
+	};
+	auto ep = testing::CreateSakuraProcess(si, args, std::nullopt, profileName,
+		CREATE_DEFAULT_ERROR_MODE | CREATE_SUSPENDED);
+	ASSERT_THAT(ep, NotNull());
+
+	// エディターのメインスレッドを開く
+	cxx::HandleHolder hThread{ ::OpenThread(THREAD_SUSPEND_RESUME, FALSE, ep.dwThreadId) };
+	ASSERT_THAT(hThread, NotNull());
+
+	// 初期化完了イベントを作成する（CControlTray::OpenNewEditor と同手順）
+	SFilePath initEventName{ std::format(GSTR_EVENT_SAKURA_EP_INITIALIZED, ep.dwThreadId) };
+	cxx::HandleHolder hEvent{ ::CreateEventW(nullptr, TRUE, FALSE, initEventName) };
+	ASSERT_THAT(hEvent, NotNull());
+
+	// Grepダイアログ表示時点のイベント状態を採取してから閉じるスレッドを起動する
+	std::atomic<DWORD> probedState{ WAIT_FAILED };
+	auto t = StartDialogCloser(L"Grep",
+		[hProbeEvent = hEvent.get(), &probedState]
+		(IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
+			// ダイアログが表示されている＝編集ウインドウ生成済＝初期化完了済。
+			// この時点でイベントはシグナル済であるべき（猶予2秒）。
+			probedState = ::WaitForSingleObject(hProbeEvent, 2000);
+			// 後始末: ダイアログをキャンセルで閉じる
+			EmulateInvokeButton(pUIAutomation, hWndDlg, IDCANCEL, st);
+		}, 15000);
+
+	// エディターのメインスレッドを再開する
+	::ResumeThread(hThread);
+
+	// ダイアログの検出～クローズ完了を待つ
+	t.join();
+
+	// ★バグ検知ポイント★
+	// 現行コード: ダイアログ表示中はシグナルされないため WAIT_TIMEOUT で FAIL
+	// 修正後　　: DoModal 前に SetEvent 済のため WAIT_OBJECT_0 で PASS
+	EXPECT_EQ(DWORD(WAIT_OBJECT_0), probedState.load())
+		<< "初期化完了イベントがダイアログ表示前にシグナルされていない。"
+		<< "この不備により OpenNewEditor(sync) は15秒タイムアウトし "
+		<< "STR_TRAY_CREATEPROC2 を誤表示する。";
+
+	// --- 以下は後始末 ---
+
+	// ダイアログクローズ後、InitializeProcess の return でイベントは必ずシグナルされる
+	EXPECT_EQ(DWORD(WAIT_OBJECT_0), ::WaitForSingleObject(hEvent.get(), 15000));
+
+	// 編集ウインドウ（無題）を検索してクローズを要求する
+	HWND hWndFound = nullptr;
+	::EnumThreadWindows(ep.dwThreadId, testing::EnumEditorWindowProc, LPARAM(&hWndFound));
+	if (hWndFound) {
+		testing::RequestForeignWindowClose(hWndFound);
+	}
+
+	// プロセスの完全終了を待つ
+	ep.lock();
+
+	// コントロールプロセスに終了指示を出して終了を待つ
+	testing::TerminateControlProcess(profileName);
+}
+
 } // namespace winmain
+


### PR DESCRIPTION
## 概要

Grep 実行時に「プロセスの起動に失敗しました。」（`STR_TRAY_CREATEPROC2`）が誤表示される不具合を修正します。

エディタープロセスの初期化完了イベントが、本来の「初期化完了時点」ではなく `CNormalProcess::InitializeProcess()` の return 時（＝Grep 完了後、または Grep ダイアログを閉じた後）にしかシグナルされていませんでした。このため呼び出し元 `CControlTray::OpenNewEditor()` が 15 秒でタイムアウトし、実際にはプロセス起動も Grep も成功しているにもかかわらずエラーダイアログを表示していました。

## 発生した現象

- Grep 実行中に「'...\sakura.exe' プロセスの起動に失敗しました。」が表示される
- **Grep 結果ウィンドウは正常に表示され、Grep も最後まで正常終了する**（＝表示内容と実態が食い違う）
- 初回の Grep でのみ発生し、**2 回目以降は再現しない**
- エラー表示までの時間はおよそ 15 秒

## 原因

### 呼び出し元（`CControlTray::OpenNewEditor`）

sync 起動時、初期化完了イベント `GSTR_EVENT_SAKURA_EP_INITIALIZED` を最大 15 秒待ち、シグナルされなければエラーを表示します。

```cpp
const ULONGLONG timeoutMillis = 15000;	// タイムアウト時間
...
if (WAIT_OBJECT_0 != dwRet) {
    ErrorMessage( hWndParent, LS(STR_TRAY_CREATEPROC2), szEXE );
    bRet = false;
}
```

### 起動先（`CNormalProcess::InitializeProcess`）

イベントは `InitEventHolder`（RAII）のデストラクタでシグナルされます。ホルダーが関数スコープに置かれているため、シグナルは **関数 return 時** になります。

```cpp
// スコープを抜けるときシグナル状態になるようにする
using InitEventHolder = cxx::ResourceHolder<&::SetEvent>;
InitEventHolder initEvent{ hEvent.get() };
```

ところが Grep モードでは、return より前に長時間ブロックする処理が実行されます。

- `!bGrepDlg`：`DoGrep()` が完了するまで return しない
- `bGrepDlg`：Grep ダイアログの `DoModal()` がユーザー操作まで return しない

結果として、イベントの実際の意味が「初期化完了」ではなく **「Grep 完了」** になっていました。

### 帰結

編集ウィンドウの生成は完了しているのにイベントは未シグナルのままとなり、**Grep 所要時間が 15 秒を超えると必ずエラーダイアログが表示されます**。初回のみ再現するのは、ファイルシステムキャッシュが冷えている初回 Grep だけが 15 秒を超えやすいためです。タイムアウト後も `bRet = false` を返すだけで子プロセスには干渉しないため、Grep は正常に完走します。

## 修正内容

`sakura_core/_main/CNormalProcess.cpp` の Grep モード 2 分岐について、長時間ブロックする処理の直前で初期化完了イベントを明示的にシグナルします。編集ウィンドウ生成と Mutex 解放が完了した時点＝本来の「初期化完了」時点です。

```diff
 			SetMainWindow( pEditWnd->GetHwnd() );
 			::ReleaseMutex( hMutex );
 			::CloseHandle( hMutex );
+			::SetEvent( hEvent.get() );
 			{
 				const SGrepInput grepInput{ ... };
```

```diff
 			::ReleaseMutex( hMutex );
 			::CloseHandle( hMutex );
 			hMutex = nullptr;
+			::SetEvent( hEvent.get() );
```

イベントは manual-reset（`CreateEventW` の第 2 引数が TRUE）で作成されているため、return 時に `InitEventHolder` から再度 `SetEvent` されても影響はありません。通常のファイルオープン経路（else 分岐）は変更していないため、sync 起動の既存挙動には影響しません。

## テスト

`src/test/cpp/tests1/test-winmain.cpp` に検証テスト `WinMainFuncTest.GrepInitEventSignaledBeforeDialog` を追加しました。

`-GREPDLG -GREPMODE` でエディタープロセスを起動し、**Grep ダイアログが表示された時点**（＝編集ウィンドウ生成済み＝初期化完了済み）で初期化完了イベントの状態を採取します。この時点で未シグナルであれば不具合と判定します。ダイアログの `DoModal` によるブロックを利用しているため、実行時間や環境に依存せず決定的に判定できます。

### 実行結果

修正前（バグを検知して失敗する）:

```
[ RUN      ] WinMainFuncTest.GrepInitEventSignaledBeforeDialog
test-winmain.cpp(1344): error: Expected equality of these values:
  DWORD(WAIT_OBJECT_0)
    Which is: 0
  probedState.load()
    Which is: 258        ← WAIT_TIMEOUT
初期化完了イベントがダイアログ表示前にシグナルされていない。
[  FAILED  ] WinMainFuncTest.GrepInitEventSignaledBeforeDialog (3472 ms)
```

修正後:

```
[ RUN      ] WinMainFuncTest.GrepInitEventSignaledBeforeDialog
[       OK ] WinMainFuncTest.GrepInitEventSignaledBeforeDialog (1989 ms)
```

既存テストの回帰確認（`--gtest_filter=WinMainFuncTest.*`）:

```
[==========] 10 tests from 1 test suite ran. (9194 ms total)
[  PASSED  ] 10 tests.
```

## 相談したい点

1. シグナル位置の変更にあたるため、この方針で問題ないかご確認をお願いします。
   代替案として「編集ウィンドウ生成直後に全経路でシグナルする」形も考えられますが、通常オープン経路の sync 挙動（`MYWM_FIRST_IDLE` 待ちの意図）への影響が読み切れないため、Grep モードのみに絞る外科的な修正としています。
2. `CControlTray::OpenNewEditor` 内で `CreateEventW` した `hEvent` が `CloseHandle` されておらず、sync 起動のたびにハンドルリークしています。本 PR とは独立した問題のため別 PR としていますが、まとめた方がよければ対応します。

## 補足

本不具合は `WaitForInputIdle` から初期化完了イベント方式へ置き換えた際に混入したものと考えられます。旧方式は入力待ち状態になった時点で復帰していたため、Grep の所要時間の影響を受けませんでした。
