### PR TITLE
選択範囲のドラッグ&ドロップ（移動/コピー）が効かない不具合を修正 (#2606)

### DIFF
--- a/sakura_core/view/CEditView_Mouse.cpp
+++ b/sakura_core/view/CEditView_Mouse.cpp
@@ -2229,7 +2229,7 @@ void CEditView::DragSelection()
 {
 	/* 選択範囲のデータを取得 */
 	CNativeW cmemCurText;
-	if (GetSelectedData(&cmemCurText, FALSE, nullptr, FALSE, GetDllShareData().m_Common.m_sEdit.m_bAddCRLFWhenCopy)) return;
+	if (!GetSelectedData(&cmemCurText, FALSE, nullptr, FALSE, GetDllShareData().m_Common.m_sEdit.m_bAddCRLFWhenCopy)) return;
 
 	// 選択範囲からクリップボードデータを作成する
 	const auto data = std::make_unique<CDataObject>(cmemCurText.GetStringPtr(), cmemCurText.GetStringLength(), GetSelectionInfo().IsBoxSelecting());


### PR DESCRIPTION
## Summary
- v2.4.3 で取り込まれたリファクタリングコミット 516b11b11 (`CEditView::DragSelectionを追加する`、PR #2451「OLEクリップボードのテストを追加する」に含まれる) により、`CEditView::DragSelection()` 内の選択範囲取得の判定条件が反転しており、選択範囲がある通常のケースで即座に `return` してしまいドラッグ&ドロップ（移動/コピー）が開始されなくなっていました。
- `GetSelectedData()` は選択範囲がない場合に `false` を返す仕様（`CEditView.cpp` のコメント参照）のため、ガード条件を `if (!GetSelectedData(...)) return;` に修正し、選択範囲取得に失敗した場合のみ早期returnするようにしました。

Fixes #2606

## Test plan
- [x] `build-sln.bat x64 Debug` でビルドが通ることを確認
- [x] エディタ内でテキストを選択し、ドラッグして別の位置に移動できることを確認
- [x] Ctrl を押しながらドラッグしてコピーできることを確認
- [x] 外部ウィンドウへドラッグして切り取り（移動）した場合に元の選択範囲が削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
