### PR TITLE
キャレットが改行コードの場合、ステータスバーのファイル改行コードの表示誤りを修正

### DIFF
--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -795,7 +795,7 @@ void CCaret::ShowCaretPosInfo()
 				szLeft,
 				szFormat,
 				pszCodeName,
-				szEolMode,
+				szEolMode.c_str(),
 				szCaretChar[0]? L"[": L" ",	// 文字情報無しなら括弧も省略（EOFやフリーカーソル位置）
 				szCaretChar,
 				szCaretChar[0]? L"]": L" "	// 文字情報無しなら括弧も省略（EOFやフリーカーソル位置）

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -699,7 +699,8 @@ void CCaret::ShowCaretPosInfo()
 	//	May 12, 2000 genta
 	//	改行コードの表示を追加
 	CEol cNlType = m_pEditDoc->m_cDocEditor.GetNewLineCode();
-	const WCHAR* szEolMode = cNlType.GetName();
+	WCHAR szEolMode[5] = {};
+	wcscpy_s(szEolMode, cNlType.GetName());
 
 	// -- -- -- -- キャレット位置 -> ptCaret -- -- -- -- //
 	//

--- a/sakura_core/view/CCaret.cpp
+++ b/sakura_core/view/CCaret.cpp
@@ -699,8 +699,7 @@ void CCaret::ShowCaretPosInfo()
 	//	May 12, 2000 genta
 	//	改行コードの表示を追加
 	CEol cNlType = m_pEditDoc->m_cDocEditor.GetNewLineCode();
-	WCHAR szEolMode[5] = {};
-	wcscpy_s(szEolMode, cNlType.GetName());
+	StaticString<6> szEolMode{ cNlType.GetName() };
 
 	// -- -- -- -- キャレット位置 -> ptCaret -- -- -- -- //
 	//


### PR DESCRIPTION
# PR対象
- アプリ(サクラエディタ本体)

## カテゴリ
- 不具合修正

## PR の背景
Issue [#2457](https://github.com/sakura-editor/sakura/issues/2457)のPRです。

## 再現手順、発生条件等
キャレットが改行コードの場合、ステータスバーのファイル改行コードに「%4.0f %%」が表示される。  
<img width="820" height="293" alt="2" src="https://github.com/user-attachments/assets/f7d24c20-492a-458f-b06d-b2bb488851f2" />
文字またはEOFの場合、ファイル改行コードは正しく表示される。
<img width="820" height="293" alt="1" src="https://github.com/user-attachments/assets/dbd4b68a-eae1-4d75-bdd0-bee21a4ac229" />

## バグの原因
LSマクロ(CLoadString::LoadStringSt)は4個のバッファを持っており、サイクリックに使う。  
ステータスバーの状態表示をするCCaret::ShowCaretPosInfoでは、以下の5箇所でLSマクロを呼び出す。  
(sakura_core\view\CCaret.cpp)
1. 702行目、ファイルの改行コード
1. 772行目、キャレットが改行コードの場合、改行コード
1. 836行目、何行何桁
1. 840/842行目、挿入/上書
1. 847/849行目、フォントサイズ何％

ここで702行目は
```
	const WCHAR* szEolMode = cNlType.GetName();
```
なのでバッファの1個のポインターが入る。(CEol::GetNameでLSマクロ使用)

キャレットが改行コード以外の場合、1,3,4,5なので問題無い。  
キャレットが改行コードの場合、1,2,3,4,5なので、5のフォーマットの「%4.0f %%」が1のバッファに入り、szEolModeが指しているものが変わってしまう。

※そもそも、なぜ4個のバッファが必要なのか？ 直接取るのでは駄目なんだろうか？

## バグの修正方法
702行目を文字列のコピーに変更
```
	WCHAR szEolMode[5] = {};
	wcscpy_s(szEolMode, cNlType.GetName());
```
改行コードの値は以下の通りなので、NULL終端を含めてwchar_tが5個で問題無い。  
(sakura_core\sakura_rc.rc)
```
    IDS_EOLTYPENAME_0 "改行無"
    IDS_EOLTYPENAME_1 "CRLF"
    IDS_EOLTYPENAME_2 "LF"
    IDS_EOLTYPENAME_3 "CR"
    IDS_EOLTYPENAME_4 "NEL"
    IDS_EOLTYPENAME_5 "LS"
    IDS_EOLTYPENAME_6 "PS"
```

## 確認
キャレットが改行コードの場合でも、ファイルの改行コードが正しく表示されることを確認しました。
<img width="820" height="293" alt="3" src="https://github.com/user-attachments/assets/7ac7e924-f704-45ae-a76f-4a267a48e8f7" />