### PR TITLE
CEditView/CEditWnd の未初期化PODメンバに既定値を設定する

### DIFF
--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -644,118 +644,118 @@ public:
 	//ウィンドウ
 	HWND			m_hwndParent = nullptr;		/* 親ウィンドウハンドル */
 	HWND			m_hwndVScrollBar = nullptr;	/* 垂直スクロールバーウィンドウハンドル */
-	int				m_nVScrollRate;		/* 垂直スクロールバーの縮尺 */
+	int				m_nVScrollRate = 1;		/* 垂直スクロールバーの縮尺 */
 	HWND			m_hwndHScrollBar = nullptr;	/* 水平スクロールバーウィンドウハンドル */
-	HWND			m_hwndSizeBox;		/* サイズボックスウィンドウハンドル */
-	HWND			m_hwndSizeBoxPlaceholder;	/* サイズボックス代替スタティックウィンドウハンドル */
+	HWND			m_hwndSizeBox = nullptr;		/* サイズボックスウィンドウハンドル */
+	HWND			m_hwndSizeBoxPlaceholder = nullptr;	/* サイズボックス代替スタティックウィンドウハンドル */
 	CSplitBoxWnd*	m_pcsbwVSplitBox = nullptr;	/* 垂直分割ボックス */
 	CSplitBoxWnd*	m_pcsbwHSplitBox = nullptr;	/* 水平分割ボックス */
 	CAutoScrollWnd	m_cAutoScrollWnd;	//!< オートスクロール
 
 public:
 	//描画
-	bool			m_bDrawSWITCH;
-	COLORREF		m_crBack;				/* テキストの背景色 */			// 2006.12.07 ryoji
-	COLORREF		m_crBack2;				// テキストの背景(キャレット用)
-	CLayoutInt		m_nOldUnderLineY;		// 前回作画したカーソルアンダーラインの位置 0未満=非表示
-	CLayoutInt		m_nOldUnderLineYBg;
-	int				m_nOldUnderLineYMargin;
-	int				m_nOldUnderLineYHeight;
-	int				m_nOldUnderLineYHeightReal;
-	int				m_nOldCursorLineX;		/* 前回作画したカーソル位置縦線の位置 */ // 2007.09.09 Moca
-	int				m_nOldCursorVLineWidth;	// カーソル位置縦線の太さ(px)
+	bool			m_bDrawSWITCH = false;
+	COLORREF		m_crBack = COLORREF(-1);				/* テキストの背景色 */			// 2006.12.07 ryoji
+	COLORREF		m_crBack2 = COLORREF(-1);				// テキストの背景(キャレット用)
+	CLayoutInt		m_nOldUnderLineY = CLayoutInt(-1);		// 前回作画したカーソルアンダーラインの位置 0未満=非表示
+	CLayoutInt		m_nOldUnderLineYBg = CLayoutInt(-1);
+	int				m_nOldUnderLineYMargin = 0;
+	int				m_nOldUnderLineYHeight = 0;
+	int				m_nOldUnderLineYHeightReal = 0;
+	int				m_nOldCursorLineX = -1;		/* 前回作画したカーソル位置縦線の位置 */ // 2007.09.09 Moca
+	int				m_nOldCursorVLineWidth = 1;	// カーソル位置縦線の太さ(px)
 
 public:
 	//画面バッファ
-	HDC				m_hdcCompatDC;		/* 再描画用コンパチブルＤＣ */
-	HBITMAP			m_hbmpCompatBMP;	/* 再描画用メモリＢＭＰ */
-	HBITMAP			m_hbmpCompatBMPOld;	/* 再描画用メモリＢＭＰ(OLD) */
-	int				m_nCompatBMPWidth;  /* 再作画用メモリＢＭＰの幅 */	// 2007.09.09 Moca 互換BMPによる画面バッファ
-	int				m_nCompatBMPHeight; /* 再作画用メモリＢＭＰの高さ */	// 2007.09.09 Moca 互換BMPによる画面バッファ
+	HDC				m_hdcCompatDC = nullptr;		/* 再描画用コンパチブルＤＣ */
+	HBITMAP			m_hbmpCompatBMP = nullptr;	/* 再描画用メモリＢＭＰ */
+	HBITMAP			m_hbmpCompatBMPOld = nullptr;	/* 再描画用メモリＢＭＰ(OLD) */
+	int				m_nCompatBMPWidth = -1;  /* 再作画用メモリＢＭＰの幅 */	// 2007.09.09 Moca 互換BMPによる画面バッファ
+	int				m_nCompatBMPHeight = -1; /* 再作画用メモリＢＭＰの高さ */	// 2007.09.09 Moca 互換BMPによる画面バッファ
 
 public:
 	//D&D
 	CDropTarget*	m_pcDropTarget = nullptr;
-	BOOL			m_bDragMode;	/* 選択テキストのドラッグ中か */
-	CLIPFORMAT		m_cfDragData;	/* ドラッグデータのクリップ形式 */	// 2008.06.20 ryoji
-	BOOL			m_bDragBoxData;	/* ドラッグデータは矩形か */
+	BOOL			m_bDragMode = FALSE;	/* 選択テキストのドラッグ中か */
+	CLIPFORMAT		m_cfDragData = 0;	/* ドラッグデータのクリップ形式 */	// 2008.06.20 ryoji
+	BOOL			m_bDragBoxData = FALSE;	/* ドラッグデータは矩形か */
 	CLayoutPoint	m_ptCaretPos_DragEnter;			/* ドラッグ開始時のカーソル位置 */	// 2007.12.09 ryoji
-	CLayoutInt		m_nCaretPosX_Prev_DragEnter;	/* ドラッグ開始時のX座標記憶 */	// 2007.12.09 ryoji
+	CLayoutInt		m_nCaretPosX_Prev_DragEnter = CLayoutInt(0);	/* ドラッグ開始時のX座標記憶 */	// 2007.12.09 ryoji
 
 	//括弧
 	CLogicPoint		m_ptBracketCaretPos_PHY;	// 前カーソル位置の括弧の位置 (改行単位行先頭からのバイト数(0開始), 改行単位行の行番号(0開始))
 	CLogicPoint		m_ptBracketPairPos_PHY;		// 対括弧の位置 (改行単位行先頭からのバイト数(0開始), 改行単位行の行番号(0開始))
-	BOOL			m_bDrawBracketPairFlag;		/* 対括弧の強調表示を行なうか */						// 03/02/18 ai
+	BOOL			m_bDrawBracketPairFlag = FALSE;		/* 対括弧の強調表示を行なうか */						// 03/02/18 ai
 
 	//マウス
 	bool			m_bActivateByMouse = false;		//!< マウスによるアクティベート	//2007.10.02 nasukoji
-	DWORD			m_dwTripleClickCheck;	//!< トリプルクリックチェック用時刻	//2007.10.02 nasukoji
+	DWORD			m_dwTripleClickCheck = 0;	//!< トリプルクリックチェック用時刻	//2007.10.02 nasukoji
 	CMyPoint		m_cMouseDownPos;	//!< クリック時のマウス座標
 	int				m_nWheelDelta = 0;	//!< ホイール変化量
 	EFunctionCode	m_eWheelScroll = F_0; //!< スクロールの種類
 	int				m_nMousePause = 0;	// マウス停止時間
 	CMyPoint		m_cMousePausePos;	// マウスの停止位置
-	bool			m_bHideMouse;
+	bool			m_bHideMouse = false;
 
 	int				m_nAutoScrollMode = 0;		//!< オートスクロールモード
-	bool			m_bAutoScrollDragMode;		//!< ドラッグモード
+	bool			m_bAutoScrollDragMode = false;		//!< ドラッグモード
 	CMyPoint		m_cAutoScrollMousePos;		//!< オートスクロールのマウス基準位置
-	bool			m_bAutoScrollVertical;		//!< 垂直スクロール可
-	bool			m_bAutoScrollHorizontal;	//!< 水平スクロール可
+	bool			m_bAutoScrollVertical = false;		//!< 垂直スクロール可
+	bool			m_bAutoScrollHorizontal = false;	//!< 水平スクロール可
 
 	//検索
 	CSearchStringPattern m_sSearchPattern;
 	mutable CBregexp	m_CurRegexp;				/*!< コンパイルデータ */
-	bool				m_bCurSrchKeyMark;			/* 検索文字列のマーク */
-	bool				m_bCurSearchUpdate;			//!< コンパイルデータ更新要求
-	int					m_nCurSearchKeySequence;	//!< 検索キーシーケンス
+	bool				m_bCurSrchKeyMark = false;			/* 検索文字列のマーク */
+	bool				m_bCurSearchUpdate = false;			//!< コンパイルデータ更新要求
+	int					m_nCurSearchKeySequence = -1;	//!< 検索キーシーケンス
 	std::wstring		m_strCurSearchKey;			//!< 検索文字列
 	SSearchOption		m_sCurSearchOption;			// 検索／置換  オプション
 	CLogicPoint			m_ptSrchStartPos_PHY;		// 検索/置換開始時のカーソル位置 (改行単位行先頭からのバイト数(0開始), 改行単位行の行番号(0開始))
-	BOOL				m_bSearch;					/* 検索/置換開始位置を登録するか */											// 02/06/26 ai
-	ESearchDirection	m_nISearchDirection;		//!< 検索方向
-	ESearchMode			m_nISearchMode;				//!< 検索モード
-	bool				m_bISearchWrap;
-	bool				m_bISearchFlagHistory[256];
-	int					m_nISearchHistoryCount;
-	bool				m_bISearchFirst;
+	BOOL				m_bSearch = FALSE;					/* 検索/置換開始位置を登録するか */											// 02/06/26 ai
+	ESearchDirection	m_nISearchDirection = SEARCH_FORWARD;		//!< 検索方向
+	ESearchMode			m_nISearchMode = SEARCH_NONE;				//!< 検索モード
+	bool				m_bISearchWrap = false;
+	bool				m_bISearchFlagHistory[256] = {};
+	int					m_nISearchHistoryCount = 0;
+	bool				m_bISearchFirst = false;
 	CLayoutRange		m_sISearchHistory[256];
 
 	//マクロ
-	bool			m_bExecutingKeyMacro;		/* キーボードマクロの実行中 */
-	BOOL			m_bCommandRunning;	/* コマンドの実行中 */
+	bool			m_bExecutingKeyMacro = false;		/* キーボードマクロの実行中 */
+	BOOL			m_bCommandRunning = FALSE;	/* コマンドの実行中 */
 
 	// 入力補完
-	BOOL			m_bHokan;			//	補完中か？＝補完ウィンドウが表示されているか？かな？
+	BOOL			m_bHokan = FALSE;			//	補完中か？＝補完ウィンドウが表示されているか？かな？
 
 	//編集
-	bool			m_bDoing_UndoRedo;	/* アンドゥ・リドゥの実行中か */
+	bool			m_bDoing_UndoRedo = false;	/* アンドゥ・リドゥの実行中か */
 
 	// 辞書Tip関連
-	DWORD			m_dwTipTimer;			/* Tip起動タイマー */
+	DWORD			m_dwTipTimer = 0;			/* Tip起動タイマー */
 	CTipWnd			m_cTipWnd;				/* Tip表示ウィンドウ */
-	POINT			m_poTipCurPos;			/* Tip起動時のマウスカーソル位置 */
-	BOOL			m_bInMenuLoop;			/* メニュー モーダル ループに入っています */
+	POINT			m_poTipCurPos{};			/* Tip起動時のマウスカーソル位置 */
+	BOOL			m_bInMenuLoop = FALSE;			/* メニュー モーダル ループに入っています */
 	CDicMgr			m_cDicMgr;				/* 辞書マネージャ */
 
-	WCHAR			m_szComposition[512]; // IMR_DOCUMENTFEED用入力中文字列データ
+	WCHAR			m_szComposition[512] = {}; // IMR_DOCUMENTFEED用入力中文字列データ
 
 	// IME
 private:
 	HWND			m_hWnd = nullptr;
-	int				m_nLastReconvLine;             //2002.04.09 minfu 再変換情報保存用;
-	int				m_nLastReconvIndex;            //2002.04.09 minfu 再変換情報保存用;
+	int				m_nLastReconvLine = -1;             //2002.04.09 minfu 再変換情報保存用;
+	int				m_nLastReconvIndex = -1;            //2002.04.09 minfu 再変換情報保存用;
 
 public:
 	// その他
 	CAutoMarkMgrHolder	m_cHistory = std::make_unique<CAutoMarkMgr>();	//	Jump履歴
 	CRegexKeyword*	m_cRegexKeyword = nullptr;	//@@@ 2001.11.17 add MIK
-	int				m_nMyIndex;	/* 分割状態 */
-	CMigemo*		m_pcmigemo;
-	bool			m_bMiniMap;
-	bool			m_bMiniMapMouseDown;
-	CLayoutInt		m_nPageViewTop;
-	CLayoutInt		m_nPageViewBottom;
+	int				m_nMyIndex = 0;	/* 分割状態 */
+	CMigemo*		m_pcmigemo = nullptr;
+	bool			m_bMiniMap = false;
+	bool			m_bMiniMapMouseDown = false;
+	CLayoutInt		m_nPageViewTop = CLayoutInt(0);
+	CLayoutInt		m_nPageViewBottom = CLayoutInt(0);
 
 	DISALLOW_COPY_AND_ASSIGN(CEditView);
 };

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -398,19 +398,19 @@ private:
 	LPWSTR			m_pszLastCaption = nullptr;
 	SMenubarMessage m_pszMenubarMessage;		//!< メニューバー右端に表示するメッセージ
 public:
-	int				m_nTimerCount;		//!< OnTimer用 2003.08.29 wmlhq
+	int				m_nTimerCount = 0;		//!< OnTimer用 2003.08.29 wmlhq
 	CLogicPointEx*	m_posSaveAry = nullptr;		//!< フォント変更前の座標
 private:
 	int				m_nCurrentFocus = 0;	//!< 現在のフォーカス情報
-	int				m_nWinSizeType;		//!< サイズ変更のタイプ。SIZE_MAXIMIZED, SIZE_MINIMIZED 等。
-	BOOL			m_bPageScrollByWheel;		//!< ホイール操作によるページスクロールあり	// 2009.01.17 nasukoji
-	BOOL			m_bHorizontalScrollByWheel;	//!< ホイール操作による横スクロールあり		// 2009.01.17 nasukoji
+	int				m_nWinSizeType = 0;		//!< サイズ変更のタイプ。SIZE_MAXIMIZED, SIZE_MINIMIZED 等。
+	BOOL			m_bPageScrollByWheel = FALSE;		//!< ホイール操作によるページスクロールあり	// 2009.01.17 nasukoji
+	BOOL			m_bHorizontalScrollByWheel = FALSE;	//!< ホイール操作による横スクロールあり		// 2009.01.17 nasukoji
 	AccelHolder		m_hAccel = nullptr;			//!< ウィンドウ毎のアクセラレータテーブルのハンドル
 
 	//フォント・イメージ
 	FontHolder		m_hFontCaretPosInfo = nullptr;	//!< キャレットの行桁位置表示用フォント
-	int				m_nCaretPosInfoCharWidth;	//!< キャレットの行桁位置表示用フォントの幅
-	int				m_nCaretPosInfoCharHeight;	//!< キャレットの行桁位置表示用フォントの高さ
+	int				m_nCaretPosInfoCharWidth = 0;	//!< キャレットの行桁位置表示用フォントの幅
+	int				m_nCaretPosInfoCharHeight = 0;	//!< キャレットの行桁位置表示用フォントの高さ
 
 	//D&Dフラグ
 	bool			m_bDragMode = false;


### PR DESCRIPTION
# PR対象

- アプリ(サクラエディタ本体)

## カテゴリ

- 不具合修正

## PR の背景

fix #2602

MSYS2(MinGW)ビルドのCIで、単体テスト実行中に `tests1.exe` がプロセスごと異常終了し、ctest が `NUMERICAL` を返す現象がたびたび発生していました。

issue のコメントで berryzplus さんから

> 問題はおそらく CEditView メンバー変数の初期化漏れだと思っています。

とご指摘いただいた点を調査したところ、これが原因であることを確認しました。

`CEditView` は「メンバ初期化を `Create()` まで遅延する」設計ですが、tests1 のテストフィクスチャ `EditorTestSuite` は `CEditWnd` / `CEditView` を **`Create()` を呼ばずに構築**します。そのため約50個のPODメンバが不定値のまま読み取られており、未定義動作となっていました。

特に危険だったのが画面バッファ関連のGDIハンドルです。`~CEditView()` → `Close()` → `UseCompatibleDC(FALSE)` → `DeleteCompatibleBitmap()` の経路で、不定値のハンドルに対して `SelectObject` / `DeleteObject` / `DeleteDC` を呼んでいました。

## 仕様・動作説明

`CEditView.h` と `CEditWnd.h` に既定メンバ初期化子を追加します。`Create()` 側の初期化はそのまま残しているため、**`Create()` を呼ぶ通常のアプリ動作は変わりません**。

既定値の選定にあたり、以下の2点に注意が必要でした。

### `m_bDrawSWITCH` は `false`

`m_bDrawSWITCH` は「このビューを描画するか」を表す値です。`CEditView::Create()` がウィンドウ作成時に `SetDrawSwitch(true)` を呼ぶため、**`Create()` 前 = ウィンドウが存在しない状態の既定値としては `false` が正しい**です。

ここを `true` にすると `CCaret::ShowCaretPosInfo()` 冒頭の

```cpp
if( !m_pEditView->GetDrawSwitch() ){ return; }
```

を通過してしまい、ウィンドウもフォントも無いまま描画系の処理へ進みます。その結果、未初期化の `CTextMetrics::m_nDxBasis` を除数とする除算（`CCaret.cpp` の 721 / 723 / 735 行）に到達し、整数ゼロ除算（SEH `0xc0000094`）を起こします。実際にこの誤りで MSVC の Debug ビルドが 51/51 で落ちることを確認しています。

なお本番でも、ミニマップ無効時は `CEditWnd` の実体メンバ `m_cMiniMapView` が `Create()` されないまま残るため、`false` であることにはテスト以外の意味もあります。

### `CLayoutInt` は明示変換

`USE_STRICT_INT` ビルド（Debug では常時有効）では `CLayoutInt` が `CStrictInteger<...>` となり `int` からの暗黙変換を禁止しているため、`= -1` ではなく `CLayoutInt(-1)` と書く必要があります。

## PR の影響範囲

- 変更はヘッダ2ファイルのみ（60行）で、ロジックの変更はありません
- `Create()` を呼ぶ通常経路では、既定値は直後に `Create()` 側の代入で上書きされるため挙動は不変です
- 影響が出るのは「`Create()` を呼ばずに `CEditView` / `CEditWnd` を使う」経路、すなわち tests1 のテストフィクスチャと、ミニマップ無効時の `m_cMiniMapView` です

## テスト内容

fork の CI で、修正前後それぞれを多数回実行して比較しました。

### MinGW（`build-on-msys2.yml`）

| | コミット | 実行本数 | クラッシュ | 発生率 |
|---|---|---|---|---|
| 修正前 (master) | b4f5219ff95749a6c7fde38edd1f4455f45d60e1 | 150 | **35** | **23.3%** |
| 修正後 (本PR) | 9cb359c9a9d882a49cd6d2421eb1b147da37fa3d | 101 | **0** | **0%** |

Fisher の正確確率検定で **p ≈ 2×10⁻⁹**。

失敗の内訳を分類すると以下のとおりです。

| 分類 | 修正前 150本 | 修正後 101本 |
|---|---|---|
| **ctest が `NUMERICAL`（プロセス異常終了）** | **32** | **0** |
| **SIGSEGV**（うち2件は `WinMainTest.runEditorProcess/0`） | **3** | **0** |
| UI Automation の30秒ウォッチドッグ・タイムアウト | 1 | 1 |
| CI インフラ起因（MSYS2 セットアップ失敗） | 1 | 0 |
| 失敗 合計 | 37 | 1 |

上2行がクラッシュ（本PRの対象）で、修正前 35件 → 修正後 0件です。

3行目のウォッチドッグ・タイムアウトは修正前後で 1件 / 1件と変わっておらず、本PRとは別原因であることが確認できます。

### MSVC（`build-sakura.yml`）

70回実行し、`MSBuild` の4構成（{Debug, Release} × {Win32, x64}）すべてで単体テストが通ることを確認しました。

## 関連 issue, PR

- #2602
- #2416 同種の低頻度失敗を報告（根本原因未特定のままclose）
- #2417 gdbバックトレース取得ステップの追加

## 参考資料

本PRで解消**しない**既知の不安定要因が残っています。いずれも今回の変更とは別原因で、修正前の master でも発生します。

- **UI Automation のウォッチドッグ・タイムアウト** — `TrayWndTest.ShowPropCommon001` / `FileDialogTest.DoModalOpenDlg001` で、ダイアログを閉じる別スレッドとメインスレッドのレースにより30秒タイムアウトします。#2602 の Debug ビルド側の報告はこちらに該当する可能性があります
- **COM 初期化順序** — `CSakuraEnvironmentTest.ResolvePath001` が `CoInitialize has not been called` で失敗することがあります
- **`CTextMetrics` の未初期化メンバ** — `m_nCharWidth` / `m_nCharHeight` / `m_nDxBasis` / `m_nDyBasis` が未初期化のままです。特に `m_nDxBasis` は8箇所で除数として使われます。既定値を与えるとレイアウト計算が変わり別のテストが落ちることを確認したため、本PRでは対象外としています

🤖 Generated with [Claude Code](https://claude.com/claude-code)
