### PR TITLE
ダイアログテストの待機条件を見直す

### DIFF
--- a/sakura.sln
+++ b/sakura.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2026
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36511.14
+MinimumVisualStudioVersion = 16.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CMake", "CMake", "{1C516A55-AD16-4F8D-B09F-FA99E7C35CFF}"
 	ProjectSection(SolutionItems) = preProject
 		CMakeLists.txt = CMakeLists.txt

--- a/sakura.sln
+++ b/sakura.sln
@@ -5,16 +5,31 @@ MinimumVisualStudioVersion = 16.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CMake", "CMake", "{1C516A55-AD16-4F8D-B09F-FA99E7C35CFF}"
 	ProjectSection(SolutionItems) = preProject
 		CMakeLists.txt = CMakeLists.txt
-		src\main\cmake\manifest.cmake = src\main\cmake\manifest.cmake
-		src\main\cmake\manifest.in = src\main\cmake\manifest.in
+		src\test\cmake\compiletests.cmake = src\test\cmake\compiletests.cmake
 		src\main\cmake\sakura.cmake = src\main\cmake\sakura.cmake
-		src\main\cmake\version.cmake = src\main\cmake\version.cmake
-		src\main\cmake\version.h.in = src\main\cmake\version.h.in
+		src\test\cmake\tests1.cmake = src\test\cmake\tests1.cmake
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sakura", "sakura_core\sakura.vcxproj", "{AF03508C-515E-4A0E-87BE-67ED1E254BD0}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tests1", "sakura_core\tests1.vcxproj", "{701E3407-EC27-49F7-ADC7-520CF2B4B438}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "common", "common", "{DDB4EF12-CC4E-5E88-E6FC-71A802F4DE97}"
+	ProjectSection(SolutionItems) = preProject
+		src\main\cmake\manifest.cmake = src\main\cmake\manifest.cmake
+		src\main\cmake\manifest.in = src\main\cmake\manifest.in
+		src\main\cmake\manifest_resource.cmake = src\main\cmake\manifest_resource.cmake
+		src\main\cmake\manifest_resource.in = src\main\cmake\manifest_resource.in
+		src\main\cmake\version.cmake = src\main\cmake\version.cmake
+		src\main\cmake\version.h.in = src\main\cmake\version.h.in
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "externals", "externals", "{EB395841-D7ED-4A00-8043-49A006CEBD5C}"
+	ProjectSection(SolutionItems) = preProject
+		src\main\cmake\ctags.cmake = src\main\cmake\ctags.cmake
+		src\main\cmake\diffutils.cmake = src\main\cmake\diffutils.cmake
+		src\main\cmake\git_submodule_update_locked.cmake = src\main\cmake\git_submodule_update_locked.cmake
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -43,6 +58,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{DDB4EF12-CC4E-5E88-E6FC-71A802F4DE97} = {1C516A55-AD16-4F8D-B09F-FA99E7C35CFF}
+		{EB395841-D7ED-4A00-8043-49A006CEBD5C} = {1C516A55-AD16-4F8D-B09F-FA99E7C35CFF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {06C18222-C02C-4F04-A17C-2453F9C27866}

--- a/sakura_core/CSelectLang.h
+++ b/sakura_core/CSelectLang.h
@@ -138,7 +138,7 @@ private:
 		std::wstring		m_String;		//!< リソース文字列格納用バッファ
 	};
 
-	static inline std::array<CLoadStrBuffer, 4> gm_Buffers{};		//!< 文字列読み込みバッファの配列（CLoadString::LoadStringSt() が使用する）
+	static inline std::array<CLoadStrBuffer, 16> gm_Buffers{};		//!< 文字列読み込みバッファの配列（CLoadString::LoadStringSt() が使用する）
 	static inline size_t gm_LastUsedIndex = std::size(gm_Buffers);	//!< 最後に使用したバッファのインデックス（CLoadString::LoadStringSt() が使用する）
 
 	using Me = CLoadString;

--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -62,6 +62,62 @@
 #define CMDLINEOPT_PROF			501  //!< プロファイルを選択
 #define CMDLINEOPT_PROFMGR		502  //!< プロファイルマネージャを起動時に表示
 
+std::vector<std::wstring_view> SplitLegacyCommandLine(std::wstring_view s)
+{
+	std::vector<std::wstring_view> args;
+
+	// 正規表現パターン:
+	//   ^(?:-\w+[=:])?  … オプション接頭辞 (-XXX= または -XXX:) は省略可能
+	//   "                … 開き引用符
+	//   (?:              … 引用符内文字の繰り返し
+	//     ""             …   "" → " のエスケープ
+	//     | \"           …   \" → " のエスケープ
+	//     | \\(?!")      …   " が後続しない単独 \ (リテラル)
+	//     | [^"\\]       …   " と \ 以外の通常文字
+	//   )*
+	//   "                … 閉じ引用符
+	std::wregex re(LR"(^(?:-\w+[=:])?"(?:""|\\"|\\(?!")|[^"\\])*")");
+
+	while (!s.empty()) {
+		// 先頭の空白を読み飛ばす
+		if (const auto p0 = s.find_first_not_of(L' '); std::wstring_view::npos == p0) {
+			s = std::wstring_view{};	// 残余が空白のみ → 処理終了
+			continue;
+		} else if (p0) {
+			s = s.substr(p0);
+		}
+
+		// 次の区切り文字を探す
+		const auto p1 = s.find_first_of(L' ');
+
+		if (std::wstring_view::npos == p1) {
+			args.emplace_back(s);	// 残り全部を1つの引数とみなす → 処理終了
+			s = std::wstring_view{};
+			continue;
+		}
+
+		// 引用符を探す
+		if (const auto p2 = s.find_first_of(L'"'); std::wstring_view::npos == p2 || p1 < p2) {
+			args.emplace_back(s.substr(0, p1));
+			s = s.substr(p1);
+			continue;
+		}
+
+		// 引用符の正規表現とマッチさせる
+		std::match_results<std::wstring_view::const_iterator> m;
+		if (!std::regex_search(s.begin(), s.end(), m, re)) {
+			args.emplace_back(s);	// 残り全部を1つの引数とみなす → 処理終了
+			s = std::wstring_view{};
+			continue;
+		}
+
+		args.emplace_back(s.substr(0, m.length()));
+		s = s.substr(m.length());
+	}
+
+	return args;
+}
+
 /*!
 	コマンドラインのチェックを行って、オプション番号と
 	引数がある場合はその先頭アドレスを返す。

--- a/sakura_core/_main/CCommandLine.h
+++ b/sakura_core/_main/CCommandLine.h
@@ -108,4 +108,17 @@ private:
 	CNativeW	m_cmProfile;		//! プロファイル名
 	std::vector<std::wstring> m_vFiles;	//!< ファイル名(複数)
 };
+
+namespace cxx {
+
+constexpr bool iequals(std::wstring_view lhs, std::wstring_view rhs)
+{
+    return lhs.size() == rhs.size() &&
+		std::ranges::equal(lhs, rhs, [] (wchar_t a, wchar_t b) {
+            return std::towupper(a) == std::towupper(b);
+        });
+}
+
+} // namespace cxx
+
 #endif /* SAKURA_CCOMMANDLINE_DF7E2E03_76E1_458C_82AC_7C485EECF677_H_ */

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -66,6 +66,8 @@
 /////////////////////////////////////////////////////////////////////////
 static LRESULT CALLBACK CControlTrayWndProc( HWND, UINT, WPARAM, LPARAM );
 
+std::vector<std::wstring_view> SplitLegacyCommandLine(std::wstring_view s);
+
 namespace cxx {
 
 /*!
@@ -1217,6 +1219,12 @@ bool CControlTray::OpenNewEditor(
 			cCmdLineBuf.AppendF(L" %s", szCmdLineOption);
 		}
 	}
+
+	std::vector<std::wstring_view> additionalOpts;
+	if (szCmdLineOption) {
+		additionalOpts = SplitLegacyCommandLine(szCmdLineOption);
+	}
+
 	// -- -- -- -- プロセス生成 -- -- -- -- //
 
 	// 無効なディレクトリのときはNULLに変更
@@ -1299,9 +1307,25 @@ bool CControlTray::OpenNewEditor(
 	bool bRet = true;
 	if (sync)
 	{
+		const bool isGrepMode = std::ranges::any_of(additionalOpts, [] (std::wstring_view opt) {
+			return cxx::iequals(opt, L"-GREPMODE")
+				|| cxx::iequals(opt, L"-GREPDLG");
+		});
+
 		// エディター初期化完了イベントを作成する
 		SFilePath initEventName{ std::format(GSTR_EVENT_SAKURA_EP_INITIALIZED, p.dwThreadId) };
 		HANDLE hEvent = ::CreateEventW(nullptr, TRUE, FALSE, initEventName);
+
+		using HandleHolder = cxx::ResourceHolder<&::CloseHandle>;
+		HandleHolder initIvent{ hEvent };
+		HandleHolder grepEvent{};
+
+		if (isGrepMode)
+		{
+			// Grep完了イベントを作成する
+			SFilePath grepEventName{ std::format( GSTR_EVENT_SAKURA_GREP_COMPLETED, p.dwThreadId ) };
+			grepEvent = ::CreateEventW(nullptr, TRUE, FALSE, grepEventName);
+		}
 
 		// エディターのメインスレッドを再開する
 		::ResumeThread(p.hThread);
@@ -1338,6 +1362,21 @@ bool CControlTray::OpenNewEditor(
 				szEXE
 			);
 			bRet = false;
+		}
+
+		if (isGrepMode) dwRet = WAIT_TIMEOUT;
+		
+		while (
+			WAIT_OBJECT_0 != dwRet && // Grep完了
+			WAIT_OBJECT_0 + 1 != dwRet // エディタープロセス終了
+		) {
+			std::array handles2{ grepEvent.get(), p.hProcess};
+			dwRet = ::MsgWaitForMultipleObjects(count, std::data(handles2), FALSE, 100, QS_SENDMESSAGE);
+
+			// 自スレッドにメッセージが送られてきた場合
+			if (WAIT_OBJECT_0 + count == dwRet) {
+				BlockingHook(nullptr);	// 溜まったメッセージを処理する
+			}
 		}
 	}
 

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -39,6 +39,7 @@
 #include "plugin/CJackManager.h"
 #include "io/CTextStream.h"
 #include "util/module.h"
+#include "util/os.h"
 #include "util/shell.h"
 #include "util/window.h"
 #include "util/string_ex2.h"
@@ -123,6 +124,19 @@ void SelectOpenFileFromFolder(
 
 		CControlTray::OpenNewEditor(unusedArg1, hWnd, sLoadInfo, nullptr, true, nullptr, bNewWindow);
 	}
+}
+
+BOOL User32::TrackPopupMenu(
+	_In_ HMENU hMenu,
+	_In_ UINT uFlags,
+	_In_ int x,
+	_In_ int y,
+	_Reserved_ int nReserved,
+	_In_ HWND hWnd,
+	_Reserved_ CONST RECT* prcRect
+) const
+{
+	return ::TrackPopupMenu(hMenu, uFlags, x, y, nReserved, hWnd, prcRect);
 }
 
 //Stonee, 2001/03/21
@@ -1613,7 +1627,7 @@ int	CControlTray::CreatePopUpMenu_L( void )
 	rc.bottom = 0;
 
 	::SetForegroundWindow( GetTrayHwnd() );
-	nId = ::TrackPopupMenu(
+	nId = User32::getInstance()->TrackPopupMenu(
 		hMenu,
 		TPM_BOTTOMALIGN
 		| TPM_RIGHTALIGN
@@ -1682,7 +1696,7 @@ int	CControlTray::CreatePopUpMenu_R( void )
 	rc.bottom = 0;
 
 	::SetForegroundWindow( GetTrayHwnd() );
-	nId = ::TrackPopupMenu(
+	nId = User32::getInstance()->TrackPopupMenu(
 		hMenu,
 		TPM_BOTTOMALIGN
 		| TPM_RIGHTALIGN

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -1364,18 +1364,33 @@ bool CControlTray::OpenNewEditor(
 			bRet = false;
 		}
 
-		if (isGrepMode) dwRet = WAIT_TIMEOUT;
-		
-		while (
-			WAIT_OBJECT_0 != dwRet && // Grep完了
-			WAIT_OBJECT_0 + 1 != dwRet // エディタープロセス終了
-		) {
-			std::array handles2{ grepEvent.get(), p.hProcess};
-			dwRet = ::MsgWaitForMultipleObjects(count, std::data(handles2), FALSE, 100, QS_SENDMESSAGE);
+		// プロセス起動正常、かつ、Grepモードの場合
+		if (bRet && isGrepMode) {
+			dwRet = WAIT_TIMEOUT;
 
-			// 自スレッドにメッセージが送られてきた場合
-			if (WAIT_OBJECT_0 + count == dwRet) {
-				BlockingHook(nullptr);	// 溜まったメッセージを処理する
+			constexpr auto waitIntervals = 100; // 100ms
+
+			while (
+				WAIT_OBJECT_0 != dwRet && // Grep完了
+				WAIT_OBJECT_0 + 1 != dwRet // エディタープロセス終了
+			) {
+				std::array handles2{ grepEvent.get(), p.hProcess};
+				dwRet = ::MsgWaitForMultipleObjects(count, std::data(handles2), FALSE, waitIntervals, QS_SENDMESSAGE);
+
+				// 自スレッドにメッセージが送られてきた場合
+				if (WAIT_OBJECT_0 + count == dwRet) {
+					BlockingHook(nullptr);	// 溜まったメッセージを処理する
+				}
+			}
+
+			if (WAIT_OBJECT_0 != dwRet) {
+				// プロセス起動側と同じメッセージを出しておく
+				ErrorMessage(
+					hWndParent,
+					LS(STR_TRAY_CREATEPROC2),
+					szEXE
+				);
+				bRet = false;
 			}
 		}
 	}

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -101,6 +101,9 @@ bool CNormalProcess::InitializeProcess()
 	using InitEventHolder = cxx::ResourceHolder<&::SetEvent>;
 	InitEventHolder initEvent{ hEvent.get() };
 
+	// スコープを抜けるときシグナル状態になるようにする
+	InitEventHolder grepEvent;
+
 	// ミューテックスもスマートポインタに入れておく
 	HandleHolder mutexHolder{ hMutex };
 
@@ -227,6 +230,11 @@ bool CNormalProcess::InitializeProcess()
 		}
 		GrepInfo gi;
 		CCommandLine::getInstance()->GetGrepInfo(&gi); // 2002/2/8 aroka ここに移動
+
+		// Grep完了イベントを開く
+		SFilePath grepEventName{ std::format(GSTR_EVENT_SAKURA_GREP_COMPLETED, ::GetCurrentThreadId()) };
+		grepEvent = ::OpenEventW(EVENT_MODIFY_STATE, FALSE, grepEventName);
+
 		if( !bGrepDlg ){
 			// Grepでは対象パス解析に現在のカレントディレクトリを必要とする
 			// pEditWnd->GetDocument()->SetCurDirNotitle();

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -238,6 +238,8 @@ bool CNormalProcess::InitializeProcess()
 			mutexHolder = nullptr;
 			hMutex = nullptr;
 
+			initEvent = nullptr;
+
 			this->m_pcEditApp->m_pcGrepAgent->DoGrep(
 				&pEditWnd->GetActiveView(),
 				gi.bGrepReplace,
@@ -295,6 +297,8 @@ bool CNormalProcess::InitializeProcess()
 			mutexHolder = nullptr;
 			hMutex = nullptr;
 			
+			initEvent = nullptr;
+
 			//	Oct. 9, 2003 genta コマンドラインからGERPダイアログを表示させた場合に
 			//	引数の設定がBOXに反映されない
 			pEditWnd->m_cDlgGrep.m_strText = gi.cmGrepKey.GetStringPtr();		/* 検索文字列 */
@@ -460,8 +464,6 @@ bool CNormalProcess::InitializeProcess()
 
 	// 複数ファイル読み込み
 	OpenFiles( pEditWnd->GetHwnd() );
-
-	initEvent = nullptr;
 
 	return pEditWnd->GetHwnd() ? true : false;
 }

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -100,12 +100,15 @@ bool CNormalProcess::InitializeProcess()
 	SFilePath initEventName{ std::format(GSTR_EVENT_SAKURA_EP_INITIALIZED, ::GetCurrentThreadId()) };
 	HandleHolder hEvent{ ::OpenEventW(STANDARD_RIGHTS_REQUIRED | EVENT_MODIFY_STATE | SYNCHRONIZE, FALSE, initEventName) };
 
-	// スコープを抜けるときシグナル状態になるようにする
-	using InitEventHolder = cxx::ResourceHolder<&::SetEvent>;
-	InitEventHolder initEvent{ hEvent.get() };
+	// スコープを抜けるときイベントを閉じる
+	HandleHolder grepEventHolder;
 
 	// スコープを抜けるときシグナル状態になるようにする
-	InitEventHolder grepEvent;
+	using EventHolder = cxx::ResourceHolder<&::SetEvent>;
+	EventHolder initEvent{ hEvent.get() };
+
+	// スコープを抜けるときシグナル状態になるようにする
+	EventHolder grepEvent;
 
 	/* 共有メモリを初期化する */
 	if (!CProcessFactory::IsExistControlProcess() && !CProcessFactory::StartControlProcess() || !CProcess::InitializeProcess()) {
@@ -233,7 +236,10 @@ bool CNormalProcess::InitializeProcess()
 
 		// Grep完了イベントを開く
 		SFilePath grepEventName{ std::format(GSTR_EVENT_SAKURA_GREP_COMPLETED, ::GetCurrentThreadId()) };
-		grepEvent = ::OpenEventW(EVENT_MODIFY_STATE, FALSE, grepEventName);
+		grepEventHolder = ::OpenEventW(EVENT_MODIFY_STATE, FALSE, grepEventName);
+
+		// スコープを抜けるときシグナル状態になるようにする
+		grepEvent = grepEventHolder.get();
 
 		if( !bGrepDlg ){
 			// Grepでは対象パス解析に現在のカレントディレクトリを必要とする

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -88,6 +88,10 @@ bool CNormalProcess::InitializeProcess()
 		return false;
 	}
 
+	// スコープを抜けるときミューテックスを解放する
+	using ShareDataLockHolder = cxx::ResourceHolder<&::ReleaseMutex>;
+	ShareDataLockHolder shareDataLock{ hMutex };	// ロック保持中は、他プロセスとの競合を意識しなくてよい。
+
 	// エディター初期化完了イベントを開く
 	SFilePath initEventName{ std::format(GSTR_EVENT_SAKURA_EP_INITIALIZED, ::GetCurrentThreadId()) };
 	using HandleHolder = cxx::ResourceHolder<&::CloseHandle>;
@@ -96,6 +100,9 @@ bool CNormalProcess::InitializeProcess()
 	// スコープを抜けるときシグナル状態になるようにする
 	using InitEventHolder = cxx::ResourceHolder<&::SetEvent>;
 	InitEventHolder initEvent{ hEvent.get() };
+
+	// ミューテックスもスマートポインタに入れておく
+	HandleHolder mutexHolder{ hMutex };
 
 	/* 共有メモリを初期化する */
 	if (!CProcessFactory::IsExistControlProcess() && !CProcessFactory::StartControlProcess() || !CProcess::InitializeProcess()) {
@@ -144,8 +151,10 @@ bool CNormalProcess::InitializeProcess()
 			//	To Here Oct. 19, 2001 genta
 			/* アクティブにする */
 			ActivateFrameWindow( hwndOwner );
-			::ReleaseMutex( hMutex );
-			::CloseHandle( hMutex );
+
+			shareDataLock = nullptr;
+			mutexHolder = nullptr;
+			hMutex = nullptr;
 
 			// 複数ファイル読み込み
 			OpenFiles( hwndOwner );
@@ -178,8 +187,6 @@ bool CNormalProcess::InitializeProcess()
 
 	const auto hEditWnd = pEditWnd->GetHwnd();
 	if (!hEditWnd) {
-		::ReleaseMutex( hMutex );
-		::CloseHandle( hMutex );
 		return false;	// 2009.06.23 ryoji CEditWnd::Create()失敗のため終了
 	}
 
@@ -226,8 +233,11 @@ bool CNormalProcess::InitializeProcess()
 			// 2003.06.23 Moca GREP実行前にMutexを解放
 			//	こうしないとGrepが終わるまで新しいウィンドウを開けない
 			SetMainWindow( pEditWnd->GetHwnd() );
-			::ReleaseMutex( hMutex );
-			::CloseHandle( hMutex );
+
+			shareDataLock = nullptr;
+			mutexHolder = nullptr;
+			hMutex = nullptr;
+
 			this->m_pcEditApp->m_pcGrepAgent->DoGrep(
 				&pEditWnd->GetActiveView(),
 				gi.bGrepReplace,
@@ -280,8 +290,9 @@ bool CNormalProcess::InitializeProcess()
 			// 2003.06.23 Moca GREPダイアログ表示前にMutexを解放
 			//	こうしないとGrepが終わるまで新しいウィンドウを開けない
 			SetMainWindow( pEditWnd->GetHwnd() );
-			::ReleaseMutex( hMutex );
-			::CloseHandle( hMutex );
+
+			shareDataLock = nullptr;
+			mutexHolder = nullptr;
 			hMutex = nullptr;
 			
 			//	Oct. 9, 2003 genta コマンドラインからGERPダイアログを表示させた場合に
@@ -421,10 +432,9 @@ bool CNormalProcess::InitializeProcess()
 	//再描画
 	::InvalidateRect( pEditWnd->GetHwnd(), nullptr, TRUE );
 
-	if( hMutex ){
-		::ReleaseMutex( hMutex );
-		::CloseHandle( hMutex );
-	}
+	shareDataLock = nullptr;
+	mutexHolder = nullptr;
+	hMutex = nullptr;
 
 	//プラグイン：EditorStartイベント実行
 	CJackManager::getInstance()->InvokePlugins(PP_EDITOR_START, &pEditWnd->GetActiveView());

--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -88,13 +88,16 @@ bool CNormalProcess::InitializeProcess()
 		return false;
 	}
 
+	// スコープを抜けるときミューテックスを閉じる
+	using HandleHolder = cxx::ResourceHolder<&::CloseHandle>;
+	HandleHolder mutexHolder{ hMutex };
+
 	// スコープを抜けるときミューテックスを解放する
 	using ShareDataLockHolder = cxx::ResourceHolder<&::ReleaseMutex>;
 	ShareDataLockHolder shareDataLock{ hMutex };	// ロック保持中は、他プロセスとの競合を意識しなくてよい。
 
 	// エディター初期化完了イベントを開く
 	SFilePath initEventName{ std::format(GSTR_EVENT_SAKURA_EP_INITIALIZED, ::GetCurrentThreadId()) };
-	using HandleHolder = cxx::ResourceHolder<&::CloseHandle>;
 	HandleHolder hEvent{ ::OpenEventW(STANDARD_RIGHTS_REQUIRED | EVENT_MODIFY_STATE | SYNCHRONIZE, FALSE, initEventName) };
 
 	// スコープを抜けるときシグナル状態になるようにする
@@ -103,9 +106,6 @@ bool CNormalProcess::InitializeProcess()
 
 	// スコープを抜けるときシグナル状態になるようにする
 	InitEventHolder grepEvent;
-
-	// ミューテックスもスマートポインタに入れておく
-	HandleHolder mutexHolder{ hMutex };
 
 	/* 共有メモリを初期化する */
 	if (!CProcessFactory::IsExistControlProcess() && !CProcessFactory::StartControlProcess() || !CProcess::InitializeProcess()) {

--- a/sakura_core/config/system_constants.h
+++ b/sakura_core/config/system_constants.h
@@ -588,6 +588,9 @@
 //! 初期化完了イベント
 inline constexpr std::wstring_view GSTR_EVENT_SAKURA_EP_INITIALIZED = L"EventSakuraEditorEPInitialized_{:d}";
 
+//! Grep完了イベント
+inline constexpr std::wstring_view GSTR_EVENT_SAKURA_GREP_COMPLETED = L"EventSakuraEditorGrepCompleted_{:d}";
+
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                     ウィンドウクラス                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -937,7 +937,7 @@ void CDlgFavorite::AddItem()
 	WCHAR* szAddText = &vecAddText[0];
 	szAddText[0] = L'\0';
 
-	CDlgInput1	cDlgInput1;
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
 	std::wstring strTitle = LS( STR_DLGFAV_ADD );
 	std::wstring strMessage = LS( STR_DLGFAV_ADD_PROMPT );
 	if( !cDlgInput1.DoModal( G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szAddText ) ){
@@ -968,7 +968,7 @@ void CDlgFavorite::EditItem()
 			std::vector<WCHAR> vecAddText(max_size);
 			WCHAR* szText = &vecAddText[0];
 			wcsncpy_s(szText, max_size, recent.GetItemText(nRecIndex), _TRUNCATE);
-			CDlgInput1	cDlgInput1;
+			auto& cDlgInput1 = *CDlgInput1::getInstance();
 			std::wstring strTitle = LS( STR_DLGFAV_EDIT );
 			std::wstring strMessage = LS( STR_DLGFAV_EDIT_PROMPT );
 			if( !cDlgInput1.DoModal(G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -933,14 +933,18 @@ void CDlgFavorite::AddItem()
 	}
 	CRecent& recent = *(m_aFavoriteInfo[m_nCurrentTab].m_pRecent);
 	size_t max_size = recent.GetTextMaxLength();
-	std::vector<WCHAR> vecAddText(max_size);
-	WCHAR* szAddText = &vecAddText[0];
-	szAddText[0] = L'\0';
+	std::wstring addText(max_size, L'\0');
+	auto szAddText = std::data(addText);
 
-	auto& cDlgInput1 = *CDlgInput1::getInstance();
-	std::wstring strTitle = LS( STR_DLGFAV_ADD );
-	std::wstring strMessage = LS( STR_DLGFAV_ADD_PROMPT );
-	if( !cDlgInput1.DoModal( G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szAddText ) ){
+	if (auto& cDlgInput1 = *CDlgInput1::getInstance();
+		!cDlgInput1.DoModal(
+		GetHwnd(),
+		LS(STR_DLGFAV_ADD),
+		LS(STR_DLGFAV_ADD_PROMPT),
+		addText,
+		CDlgInput1::NoValidation
+	))
+	{
 		return;
 	}
 
@@ -963,15 +967,22 @@ void CDlgFavorite::EditItem()
 		nLvItem = ListView_GetNextItem(hwndList, nLvItem, LVNI_SELECTED);
 		if( -1 != nLvItem ) {
 			int nRecIndex = ListView_GetLParamInt(hwndList, nLvItem);
+
 			CRecent& recent = *(m_aFavoriteInfo[m_nCurrentTab].m_pRecent);
 			size_t max_size = recent.GetTextMaxLength();
-			std::vector<WCHAR> vecAddText(max_size);
-			WCHAR* szText = &vecAddText[0];
-			wcsncpy_s(szText, max_size, recent.GetItemText(nRecIndex), _TRUNCATE);
-			auto& cDlgInput1 = *CDlgInput1::getInstance();
-			std::wstring strTitle = LS( STR_DLGFAV_EDIT );
-			std::wstring strMessage = LS( STR_DLGFAV_EDIT_PROMPT );
-			if( !cDlgInput1.DoModal(G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){
+			std::wstring addText(max_size, L'\0');
+			WCHAR* szText = std::data(addText);
+			::wcsncpy_s(szText, max_size, recent.GetItemText(nRecIndex), _TRUNCATE);
+
+			if (auto& cDlgInput1 = *CDlgInput1::getInstance();
+				!cDlgInput1.DoModal(
+				GetHwnd(),
+				LS(STR_DLGFAV_EDIT),
+				LS(STR_DLGFAV_EDIT_PROMPT),
+				addText,
+				CDlgInput1::NoValidation
+			))
+			{
 				return;
 			}
 			GetFavorite(m_nCurrentTab);

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -933,18 +933,14 @@ void CDlgFavorite::AddItem()
 	}
 	CRecent& recent = *(m_aFavoriteInfo[m_nCurrentTab].m_pRecent);
 	size_t max_size = recent.GetTextMaxLength();
-	std::wstring addText(max_size, L'\0');
-	auto szAddText = std::data(addText);
+	std::vector<WCHAR> vecAddText(max_size);
+	WCHAR* szAddText = &vecAddText[0];
+	szAddText[0] = L'\0';
 
-	if (auto& cDlgInput1 = *CDlgInput1::getInstance();
-		!cDlgInput1.DoModal(
-		GetHwnd(),
-		LS(STR_DLGFAV_ADD),
-		LS(STR_DLGFAV_ADD_PROMPT),
-		addText,
-		CDlgInput1::NoValidation
-	))
-	{
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
+	std::wstring strTitle = LS( STR_DLGFAV_ADD );
+	std::wstring strMessage = LS( STR_DLGFAV_ADD_PROMPT );
+	if( !cDlgInput1.DoModal( G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szAddText ) ){
 		return;
 	}
 
@@ -967,22 +963,15 @@ void CDlgFavorite::EditItem()
 		nLvItem = ListView_GetNextItem(hwndList, nLvItem, LVNI_SELECTED);
 		if( -1 != nLvItem ) {
 			int nRecIndex = ListView_GetLParamInt(hwndList, nLvItem);
-
 			CRecent& recent = *(m_aFavoriteInfo[m_nCurrentTab].m_pRecent);
 			size_t max_size = recent.GetTextMaxLength();
-			std::wstring addText(max_size, L'\0');
-			WCHAR* szText = std::data(addText);
-			::wcsncpy_s(szText, max_size, recent.GetItemText(nRecIndex), _TRUNCATE);
-
-			if (auto& cDlgInput1 = *CDlgInput1::getInstance();
-				!cDlgInput1.DoModal(
-				GetHwnd(),
-				LS(STR_DLGFAV_EDIT),
-				LS(STR_DLGFAV_EDIT_PROMPT),
-				addText,
-				CDlgInput1::NoValidation
-			))
-			{
+			std::vector<WCHAR> vecAddText(max_size);
+			WCHAR* szText = &vecAddText[0];
+			wcsncpy_s(szText, max_size, recent.GetItemText(nRecIndex), _TRUNCATE);
+			auto& cDlgInput1 = *CDlgInput1::getInstance();
+			std::wstring strTitle = LS( STR_DLGFAV_EDIT );
+			std::wstring strMessage = LS( STR_DLGFAV_EDIT_PROMPT );
+			if( !cDlgInput1.DoModal(G_AppInstance(), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){
 				return;
 			}
 			GetFavorite(m_nCurrentTab);

--- a/sakura_core/dlg/CDlgInput1.cpp
+++ b/sakura_core/dlg/CDlgInput1.cpp
@@ -89,6 +89,27 @@ static const DWORD p_helpids[] = {	//13000
 }
 
 /*!
+ * @brief 入力データを検証する関数
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ * @param text [in] 入力データ
+ * @param cchBuffer [in] バッファーサイズ
+ *
+ * @returns データを取り込んでよいか
+ * @retval > 0 取り込んでよい
+ * @retval = 0 データがない
+ * @retval < 0 取り込んではいけない
+ */
+/* static */ int CDlgInput1::NoValidation(
+	HWND /* hWndDlg */,
+	std::wstring_view /* text */,
+	size_t /* cchBuffer */
+)
+{
+	return 1;	// データを取り込んでよい
+}
+
+/*!
  * @brief ウィンドウプロシージャ
  *
  * @param hWnd [in] 宛先ウィンドウのハンドル
@@ -134,12 +155,14 @@ static const DWORD p_helpids[] = {	//13000
 /*!
  * @brief モーダルダイアログの表示
  *
+ * @note 移行元実装。
+ *
  * @param [in, opt] モジュールハンドル。
  * @param hWndOwner [in, opt] オーナーウィンドウのハンドル
  * @param pszTitle [in] タイトル文字列
  * @param pszMessage [in] メッセージ文字列
- * @param cchBuffer [in] 入力値を受け取るバッファのサイズ。NUL終端を含むサイズを指定する。
- * @param pszBuffer [in, out] 入力値を受け取るバッファ
+ * @param cchMaxTextLength [in] 入力可能文字数
+ * @param pszText [in, out] 入力値を受け取るバッファ
  *
  * @note 既存コード互換用に残しておく
  */
@@ -148,21 +171,27 @@ BOOL CDlgInput1::DoModal(
 	_In_opt_ HWND hWndOwner,
 	_In_z_ const WCHAR*	pszTitle,
 	_In_z_ const WCHAR*	pszMessage,
-	size_t cchBuffer,
-	_Inout_updates_z_(cchBuffer) WCHAR* pszBuffer
+	size_t cchMaxTextLength,
+	_Inout_updates_z_(cchMaxTextLength + 1) WCHAR* pszText
 )
 {
+	assert(pszTitle);
+	assert(pszMessage);
+	assert(0 < cchMaxTextLength);
+
+	// 移行先実装を呼び出す
 	return DoModal(
 		hWndOwner,
 		pszTitle,
 		pszMessage,
-		pszBuffer,
-		cchBuffer
+		std::span(pszText, cchMaxTextLength + 1)
 	);
 }
 
 /*!
  * @brief モーダルダイアログの表示
+ *
+ * @note 移行先実装。
  *
  * @param hWndOwner [in, opt] オーナーウィンドウのハンドル
  * @param title [in] タイトル文字列
@@ -177,11 +206,10 @@ BOOL CDlgInput1::DoModal(
 	const std::optional<SFuncType>& optFunc
 )
 {
-	m_Func = optFunc.value_or([buffer] (HWND, std::wstring_view text) {
-		if (text.empty()) return 0;
-		return std::size(text) < std::size(buffer) ? 1 : -1;
-	});
+	// 検証関数を取り出す。指定がなければ「検証なし」とする
+	m_Func = optFunc.value_or(&NoValidation);
 
+	// 内部実装を呼び出す。呼出先はテスト時に差し替え可能。
 	return DoModal(
 		hWndOwner,
 		std::data(title),
@@ -194,23 +222,28 @@ BOOL CDlgInput1::DoModal(
 /*!
  * @brief モーダルダイアログの表示
  *
+ * @note std::wstringをバッファにする版。
+ *
  * @param hWndOwner [in, opt] オーナーウィンドウのハンドル
  * @param title [in] タイトル文字列
  * @param message [in] メッセージ文字列
- * @param buffer [out] 入力値を受け取るバッファ
+ * @param buffer [out] 入力値を受け取るバッファ。呼び出し側で適切なサイズにresizeすること。
  */
 BOOL CDlgInput1::DoModal(
 	_In_opt_ HWND hWndOwner,
 	std::wstring_view title,
 	std::wstring_view message,
-	std::wstring& buffer
+	std::wstring& buffer,
+	const std::optional<SFuncType>& optFunc
 )
 {
+	// 移行先実装を呼び出す
 	return DoModal(
 		hWndOwner,
-		std::data(title),
-		std::data(message),
-		std::span(std::data(buffer), std::size(buffer) + 1)
+		title,
+		message,
+		std::span(std::data(buffer), std::size(buffer) + 1),
+		optFunc
 	);
 }
 
@@ -355,8 +388,8 @@ int CDlgInput1::GetDlgData(HWND hWndDlg)
 	const auto result = apiwrap::GetDlgItemTextW(hWndDlg, IDC_EDIT_INPUT1);
 	if (!result) return -1;
 
-	const auto ret = m_Func(hWndDlg, result.text);
-	if (0 < ret) {
+	const auto ret = m_Func(hWndDlg, result.text, std::size(m_Text));
+	if (0 <= ret) {
 		::wcsncpy_s(std::data(m_Text), std::size(m_Text), std::data(result.text), _TRUNCATE);
 	}
 
@@ -419,8 +452,11 @@ void CDlgInput1::OnCommand(HWND hWnd, int id, HWND, UINT)
 	// OKボタンとキャンセルボタンは通知コードに依らず処理させる
 	switch(id) {
 	case IDOK:
-		GetDlgData(hWnd);
-		::EndDialog(hWnd, TRUE);
+		if (const auto ret = GetDlgData(hWnd);
+			0 <= ret)
+		{
+			::EndDialog(hWnd, static_cast<bool>(ret));
+		}
 		return;
 
 	case IDCANCEL:

--- a/sakura_core/dlg/CDlgInput1.cpp
+++ b/sakura_core/dlg/CDlgInput1.cpp
@@ -9,21 +9,21 @@
 	Copyright (C) 2002, MIK
 	Copyright (C) 2003, KEITA
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
 #include "StdAfx.h"
 #include "dlg/CDlgInput1.h"
-#include "CEditApp.h"
-#include "Funccode_enum.h"	// EFunctionCode
+
 #include "util/shell.h"
+#include "util/window.h"
+
+#include "CSelectLang.h"
+
 #include "sakura_rc.h"
 #include "sakura.hh"
-#include "util/window.h"
-#include "apiwrap/StdControl.h"
-#include "CSelectLang.h"
 
 // 入力 CDlgInput1.cpp	//@@@ 2002.01.07 add start MIK
 static const DWORD p_helpids[] = {	//13000
@@ -35,126 +35,399 @@ static const DWORD p_helpids[] = {	//13000
 	0, 0
 };	//@@@ 2002.01.07 add end MIK
 
-/* ダイアログプロシージャ */
-INT_PTR CALLBACK CDlgInput1Proc(
-	HWND hwndDlg,	// handle to dialog box
-	UINT uMsg,		// message
-	WPARAM wParam,	// first message parameter
-	LPARAM lParam 	// second message parameter
+/*!
+ * @brief ダイアログプロシージャ
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ * @param uMsg [in] メッセージコード
+ * @param wParam [in, opt] 第1パラメーター
+ * @param lParam [in, opt] 第2パラメーター
+ *
+ * @retval 0以外 メッセージは処理済み。システムはDWLP_MSGRESULTを参照する。
+ * @retval 0     メッセージは未処理。システムに処理させる。
+ */
+/* static */ INT_PTR CALLBACK CDlgInput1::DlgProc(
+	HWND hWndDlg,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam
 )
 {
-	CDlgInput1* pCDlgInput1;
-	switch( uMsg ){
-	case WM_INITDIALOG:
-		pCDlgInput1 = ( CDlgInput1* )lParam;
-		if( nullptr != pCDlgInput1 ){
-			UpdateDialogFont( hwndDlg );
-			return pCDlgInput1->DispatchEvent( hwndDlg, uMsg, wParam, lParam );
-		}else{
-			return FALSE;
-		}
-	default:
-		// Modified by KEITA for WIN64 2003.9.6
-		pCDlgInput1 = ( CDlgInput1* )::GetWindowLongPtr( hwndDlg, DWLP_USER );
-		if( nullptr != pCDlgInput1 ){
-			return pCDlgInput1->DispatchEvent( hwndDlg, uMsg, wParam, lParam );
-		}else{
-			return FALSE;
-		}
+	// GetWindowLong/SetWindowLongする都合、NULLはマズい。
+	if (!hWndDlg) return FALSE;	// システムに処理させる
+
+	// WM_INITDIALOGが来たらHWNDにクラスデータを紐づける
+	if (auto pcDlg = std::bit_cast<Me*>(lParam); WM_INITDIALOG == uMsg && pcDlg) {
+		// ウィンドウハンドルを格納する
+		pcDlg->m_hWnd = hWndDlg;
+
+		// lParamをユーザーデータに格納する。（格納方法は改善検討要。）
+		::SetWindowLongPtrW(hWndDlg, DWLP_USER, lParam);
+
+		// ダイアログをカスタマイズする
+		::SetWindowSubclass(hWndDlg, &SubclassProc, 0, DWORD_PTR(lParam));
 	}
+
+	// HWNDに紐づいたクラスを取り出す。
+	if (auto pcDlg = std::bit_cast<Me*>(::GetWindowLongPtrW(hWndDlg, DWLP_USER))) {
+		// HWNDに紐づいたクラスにメッセージを処理させる
+		const auto ret = pcDlg->DispatchDlgEvent(hWndDlg, uMsg, wParam, lParam);
+
+		if (WM_DESTROY == uMsg) {
+			// ユーザーデータの紐付けを解除する
+			::SetWindowLongPtrW(hWndDlg, DWLP_USER, 0L);
+
+			// ウィンドウハンドルの紐付けを解除する
+			pcDlg->m_hWnd = nullptr;
+		}
+
+		// 処理結果を返す。0以外ならシステムはDWLP_MSGRESULTを参照する。
+		return ret;
+	}
+
+	return FALSE;	// システムに処理させる
 }
 
-/* モードレスダイアログの表示 */
+/*!
+ * @brief ウィンドウプロシージャ
+ *
+ * @param hWnd [in] 宛先ウィンドウのハンドル
+ * @param uMsg [in] メッセージコード
+ * @param wParam [in, opt] 第1パラメーター
+ * @param lParam [in, opt] 第2パラメーター
+ * @param uIdSubclass [in] サブクラスID
+ * @param dwRefData [in] サブクラスデータ
+ *
+ * @returns  メッセージ処理結果。値の意味はメッセージ依存。
+ */
+/* static */ LRESULT CALLBACK CDlgInput1::SubclassProc(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam,
+	UINT_PTR uIdSubclass,
+	DWORD_PTR dwRefData
+)
+{
+	LRESULT ret = 0;
+
+	// サブクラスデータを取り出す。（格納方法は改善検討要。）
+	auto pcDlg = std::bit_cast<Me*>(dwRefData);
+	if (pcDlg) {
+		// サブクラスデータにメッセージを処理させる
+		ret = pcDlg->DispatchEvent(hWnd, uMsg, wParam, lParam);
+	}
+
+	if (WM_DESTROY == uMsg) {
+		::RemoveWindowSubclass(hWnd, &SubclassProc, uIdSubclass);
+		return 0;
+	}
+
+	if (pcDlg) {
+		return ret;
+	}
+
+	//あとはデフォルトに任せる
+	return ::DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+/*!
+ * @brief モーダルダイアログの表示
+ *
+ * @param [in, opt] モジュールハンドル。
+ * @param hWndOwner [in, opt] オーナーウィンドウのハンドル
+ * @param pszTitle [in] タイトル文字列
+ * @param pszMessage [in] メッセージ文字列
+ * @param cchBuffer [in] 入力値を受け取るバッファのサイズ。NUL終端を含むサイズを指定する。
+ * @param pszBuffer [in, out] 入力値を受け取るバッファ
+ *
+ * @note 既存コード互換用に残しておく
+ */
 BOOL CDlgInput1::DoModal(
-	HINSTANCE		hInstApp,
-	HWND			hwndParent,
-	const WCHAR*	pszTitle,
-	const WCHAR*	pszMessage,
-	size_t			bufferSize,
-	WCHAR*			pszText
+	_Reserved_ HINSTANCE [[maybe_unused]],
+	_In_opt_ HWND hWndOwner,
+	_In_z_ const WCHAR*	pszTitle,
+	_In_z_ const WCHAR*	pszMessage,
+	size_t cchBuffer,
+	_Inout_updates_z_(cchBuffer) WCHAR* pszBuffer
 )
 {
-	const auto nMaxTextLen = int(bufferSize);
-	BOOL bRet;
-	m_hInstance = hInstApp;		/* アプリケーションインスタンスのハンドル */
-	m_hwndParent = hwndParent;	/* オーナーウィンドウのハンドル */
-	m_pszTitle = pszTitle;		/* ダイアログタイトル */
-	m_pszMessage = pszMessage;		/* メッセージ */
-	m_nMaxTextLen = nMaxTextLen;	/* 入力サイズ上限 */
-//	m_pszText = pszText;			/* テキスト */
-	m_cmemText.SetString( pszText );
-	bRet = (BOOL)::DialogBoxParam(
-		CSelectLang::getLangRsrcInstance(),
-		MAKEINTRESOURCE( IDD_INPUT1 ),
-		m_hwndParent,
-		CDlgInput1Proc,
-		(LPARAM)this
+	return DoModal(
+		hWndOwner,
+		pszTitle,
+		pszMessage,
+		pszBuffer,
+		cchBuffer
 	);
-	wcscpy( pszText, m_cmemText.GetStringPtr() );
-	return bRet;
 }
 
-/* ダイアログのメッセージ処理 */
-INT_PTR CDlgInput1::DispatchEvent(
-	HWND hwndDlg,	// handle to dialog box
-	UINT uMsg,		// message
-	WPARAM wParam,	// first message parameter
-	LPARAM lParam 	// second message parameter
+/*!
+ * @brief モーダルダイアログの表示
+ *
+ * @param hWndOwner [in, opt] オーナーウィンドウのハンドル
+ * @param title [in] タイトル文字列
+ * @param message [in] メッセージ文字列
+ * @param buffer [out] 入力値を受け取るバッファ
+ */
+BOOL CDlgInput1::DoModal(
+	_In_opt_ HWND hWndOwner,
+	std::wstring_view title,
+	std::wstring_view message,
+	std::span<WCHAR> buffer,
+	const std::optional<SFuncType>& optFunc
 )
 {
-	WORD	wNotifyCode;
-	WORD	wID;
-//	int		nRet;
-	switch( uMsg ){
-	case WM_INITDIALOG:
-		/* ダイアログデータの設定 */
-		// Modified by KEITA for WIN64 2003.9.6
-		::SetWindowLongPtr( hwndDlg, DWLP_USER, lParam );
+	m_Func = optFunc.value_or([buffer] (HWND, std::wstring_view text) {
+		if (text.empty()) return 0;
+		return std::size(text) < std::size(buffer) ? 1 : -1;
+	});
 
-		::SetWindowText( hwndDlg, m_pszTitle );	/* ダイアログタイトル */
-		ApiWrap::EditCtl_LimitText( ::GetDlgItem( hwndDlg, IDC_EDIT_INPUT1 ), m_nMaxTextLen );	/* 入力サイズ上限 */
-		ApiWrap::DlgItem_SetText( hwndDlg, IDC_EDIT_INPUT1, m_cmemText.GetStringPtr() );	/* テキスト */
-		::SetWindowText( ::GetDlgItem( hwndDlg, IDC_STATIC_MSG ), m_pszMessage );	/* メッセージ */
+	return DoModal(
+		hWndOwner,
+		std::data(title),
+		std::data(message),
+		std::data(buffer),
+		std::size(buffer)
+	);
+}
 
-		return TRUE;
-	case WM_COMMAND:
-		wNotifyCode = HIWORD(wParam);	/* 通知コード */
-		wID			= LOWORD(wParam);	/* 項目ID、 コントロールID、 またはアクセラレータID */
-		switch( wNotifyCode ){
-		/* ボタン／チェックボックスがクリックされた */
-		case BN_CLICKED:
-			switch( wID ){
-			case IDOK:
-				m_cmemText.AllocStringBuffer( ::GetWindowTextLength( ::GetDlgItem( hwndDlg, IDC_EDIT_INPUT1 ) ) );
-				::GetWindowText( ::GetDlgItem( hwndDlg, IDC_EDIT_INPUT1 ), m_cmemText.GetStringPtr(), m_nMaxTextLen + 1 );	/* テキスト */
-				::EndDialog( hwndDlg, TRUE );
-				return TRUE;
-			case IDCANCEL:
-				::EndDialog( hwndDlg, FALSE );
-				return TRUE;
-			default:
-				break;
-			}
-			break;	//@@@ 2002.01.07 add
-		default:
-			break;
-		}
-		break;	//@@@ 2002.01.07 add
-	//@@@ 2002.01.07 add start
+/*!
+ * @brief モーダルダイアログの表示
+ *
+ * @param hWndOwner [in, opt] オーナーウィンドウのハンドル
+ * @param title [in] タイトル文字列
+ * @param message [in] メッセージ文字列
+ * @param buffer [out] 入力値を受け取るバッファ
+ */
+BOOL CDlgInput1::DoModal(
+	_In_opt_ HWND hWndOwner,
+	std::wstring_view title,
+	std::wstring_view message,
+	std::wstring& buffer
+)
+{
+	return DoModal(
+		hWndOwner,
+		std::data(title),
+		std::data(message),
+		std::span(std::data(buffer), std::size(buffer) + 1)
+	);
+}
+
+/*!
+ * @brief モーダルダイアログの表示
+ *
+ * @param hWndOwner [in, opt] オーナーウィンドウのハンドル
+ * @param pszTitle [in] タイトル文字列
+ * @param pszMessage [in] メッセージ文字列
+ * @param pBuffer [in, out] 入力値を受け取るバッファ
+ * @param cchBuffer [in] 入力値を受け取るバッファのサイズ。NUL終端を含むサイズを指定する。
+ *
+ * @note 直接呼ばないでください。
+ * @note この関数の動作はモックで上書き可能。
+ */
+BOOL CDlgInput1::DoModal(
+	_In_opt_ HWND hWndOwner,
+	_In_z_ LPCWSTR pszTitle,
+	_In_z_ LPCWSTR pszMessage,
+	_Inout_updates_z_(cchBuffer) LPWSTR pBuffer,
+	size_t cchBuffer
+)
+{
+	assert(pszTitle);
+	assert(pszMessage);
+	assert(0 < cchBuffer);
+
+#if 0 // 以下にヒットする場合、バッファが初期化されていない。結構引っかかるので無効化しておく。
+	assert_warning(0 == pBuffer[cchBuffer - 1]);
+#endif
+
+	pBuffer[cchBuffer - 1] = L'\0';
+
+	m_Title = pszTitle;
+	m_Message = pszMessage;
+	m_Text = std::span(pBuffer, cchBuffer);
+
+	return (BOOL)::DialogBoxParamW(
+		CSelectLang::getLangRsrcInstance(),
+		MAKEINTRESOURCE(IDD_INPUT1),
+		hWndOwner,
+		DlgProc,
+		LPARAM(this)
+	);
+}
+
+/*!
+ * @brief ダイアログのメッセージ配送
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ * @param uMsg [in] メッセージコード
+ * @param wParam [in, opt] 第1パラメーター
+ * @param lParam [in, opt] 第2パラメーター
+ *
+ * @retval 0以外 メッセージは処理済み。システムはDWLP_MSGRESULTを参照する。
+ * @retval 0     メッセージは未処理。システムに処理させる。
+ *
+ * @sa SetDlgMsgResult
+ */
+INT_PTR CDlgInput1::DispatchDlgEvent(
+	HWND hWndDlg,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam
+)
+{
+	if (WM_INITDIALOG == uMsg) {
+		// WM_INITDIALOGを処理させる
+		const auto bRet = HANDLE_WM_INITDIALOG(hWndDlg, wParam, lParam, OnInitDialog);
+
+		// 初期データを反映する
+		SetDlgData(hWndDlg);
+
+		return bRet;	// WM_INITDIALOGの戻り値は特殊。DWLP_MSGRESULTに格納しなくてもよい。
+	}
+
+	return FALSE;
+}
+
+/*!
+ * @brief 拡張ウィンドウのメッセージ配送
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ * @param uMsg [in] メッセージコード
+ * @param wParam [in, opt] 第1パラメーター
+ * @param lParam [in, opt] 第2パラメーター
+ *
+ * @returns  メッセージ処理結果。値の意味はメッセージ依存。
+ *
+ * @note 戻り値0は「処理済み」を示すことが多いが、実装時に確認すること。
+ */
+LRESULT CDlgInput1::DispatchEvent(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam
+)
+{
+	assert(m_hWnd == hWnd);
+
+	m_hWnd = hWnd;
+
+	switch (uMsg) {
+// clang-format off
+	HANDLE_MSG(hWnd, WM_COMMAND,						OnCommand);
+// clang-format on
+
 	case WM_HELP:
-		{
-			HELPINFO *p = (HELPINFO *)lParam;
-			MyWinHelp( (HWND)p->hItemHandle, HELP_WM_HELP, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
+		if (const auto p = std::bit_cast<LPHELPINFO>(lParam)) {
+			MyWinHelp(HWND(p->hItemHandle), HELP_WM_HELP, ULONG_PTR(p_helpids));
 		}
-		return TRUE;
+		return 0L;
 
-	//Context Menu
 	case WM_CONTEXTMENU:
-		MyWinHelp( hwndDlg, HELP_CONTEXTMENU, (ULONG_PTR)(LPVOID)p_helpids );	// 2006.10.10 ryoji MyWinHelpに変更に変更
-		return TRUE;
-	//@@@ 2002.01.07 add end
+		MyWinHelp(hWnd, HELP_CONTEXTMENU, ULONG_PTR(p_helpids));
+		return 0L;
+
 	default:
 		break;
 	}
-	return FALSE;
+
+	//あとはデフォルトに任せる
+	return ::DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+/*!
+ * @brief ダイアログからクラスデータを更新する
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ *
+ * @return データを取得できたかどうか。
+ * @retval > 0 正しく取り込めた
+ * @retval = 0 取り込めなかった
+ * @retval < 0 入力エラーを検出した
+ */
+int CDlgInput1::GetDlgData(HWND hWndDlg)
+{
+	assert(m_hWnd == hWndDlg);
+
+	m_hWnd = hWndDlg;
+
+	const auto result = apiwrap::GetDlgItemTextW(hWndDlg, IDC_EDIT_INPUT1);
+	if (!result) return -1;
+
+	const auto ret = m_Func(hWndDlg, result.text);
+	if (0 < ret) {
+		::wcsncpy_s(std::data(m_Text), std::size(m_Text), std::data(result.text), _TRUNCATE);
+	}
+
+	return ret;
+}
+
+/*!
+ * @brief クラスデータをダイアログに反映する
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ */
+void CDlgInput1::SetDlgData(HWND hWndDlg) const
+{
+	apiwrap::SetDlgItemTextW(hWndDlg, IDC_EDIT_INPUT1, std::data(m_Text));
+}
+
+/*!
+ * @brief WM_INITDIALOGハンドラ
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ * @param hWndFocus [in, opt] フォーカスを受け取るコントロールのハンドル
+ * @param lParam [in] ダイアログ作成時に渡されたパラメーター
+ *
+ * @return システムが設定した初期フォーカスを承認するかどうか。
+ * @retval true  初期フォーカスを変更しない。
+ * @retval false 初期フォーカスを変更した。
+ */
+bool CDlgInput1::OnInitDialog(HWND hWndDlg, HWND, LPARAM)
+{
+	assert(m_hWnd == hWndDlg);
+
+	m_hWnd = hWndDlg;
+
+	UpdateDialogFont(hWndDlg);
+
+	apiwrap::SetWindowTextW(hWndDlg, m_Title);
+	apiwrap::SetDlgItemTextW(hWndDlg, IDC_STATIC_MSG, m_Message);
+
+	apiwrap::LimitEditText(hWndDlg, IDC_EDIT_INPUT1, m_Text);
+
+	return true;
+}
+
+/*!
+ * @brief WM_COMMANDハンドラ
+ *
+ * @param hWnd [in] 宛先ウィンドウのハンドル
+ * @param id [in] 送信元コントロールのID
+ * @param hWndCtl [in, opt] 送信元コントロールのハンドル
+ * @param notifyCode [in, opt] 通知コード
+ *
+ * @note このメッセージに戻り値はありません。
+ */
+void CDlgInput1::OnCommand(HWND hWnd, int id, HWND, UINT)
+{
+	assert(m_hWnd == hWnd);
+
+	m_hWnd = hWnd;
+
+	// OKボタンとキャンセルボタンは通知コードに依らず処理させる
+	switch(id) {
+	case IDOK:
+		GetDlgData(hWnd);
+		::EndDialog(hWnd, TRUE);
+		return;
+
+	case IDCANCEL:
+		::EndDialog(hWnd, FALSE);
+		return;
+
+	default:
+		break;
+	}
 }

--- a/sakura_core/dlg/CDlgInput1.h
+++ b/sakura_core/dlg/CDlgInput1.h
@@ -15,8 +15,11 @@
 #define SAKURA_CDLGINPUT1_43CB765B_D257_4DBC_85E9_D2587B7E9D8E_H_
 #pragma once
 
-#include "mem/CNativeW.h"
 #include "util/design_template.h"
+
+#include <span>
+#include <string>
+#include <string_view>
 
 class CDlgInput1;
 
@@ -24,37 +27,85 @@ class CDlgInput1;
 クラスの宣言
 -----------------------------------------------------------------------*/
 /*!
-	@brief １行入力ダイアログボックス
-*/
+ * @brief １行入力ダイアログボックス
+ */
 class CDlgInput1 : public TSakuraSingleton<CDlgInput1>
 {
 private:
+	using SBuffer = std::span<WCHAR>;
+	using SFuncType = std::function<int(HWND, std::wstring_view)>;
+
 	using Me = CDlgInput1;
 
 public:
+	static INT_PTR CALLBACK DlgProc(
+		HWND hWndDlg,
+		UINT uMsg,
+		WPARAM wParam,
+		LPARAM lParam
+	);
+
+	static LRESULT CALLBACK SubclassProc(
+		HWND hWnd,
+		UINT uMsg,
+		WPARAM wParam,
+		LPARAM lParam,
+		UINT_PTR uIdSubclass,
+		DWORD_PTR dwRefData
+	);
+
+	static inline SFuncType NoValidation = [] (HWND, std::wstring_view) { return 1; };	//!< 何もしない評価関数
+
 	virtual ~CDlgInput1() noexcept = default;
 
-	BOOL DoModal( HINSTANCE hInstApp, HWND hwndParent, const WCHAR* pszTitle,
-				  const WCHAR* pszMessage, size_t bufferSize, WCHAR* pszText );
+	BOOL DoModal(
+		_Reserved_ HINSTANCE unusedArg1 [[maybe_unused]],
+		_In_opt_ HWND hWndOwner,
+		_In_z_ const WCHAR* pszTitle,
+		_In_z_ const WCHAR* pszMessage,
+		size_t cchBuffer,
+		_Inout_updates_z_(cchBuffer) WCHAR* pszBuffer
+	);
 
-	/*
-	||  Attributes & Operations
-	*/
-	INT_PTR DispatchEvent(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);	/* ダイアログのメッセージ処理 */
+	BOOL DoModal(
+		_In_opt_ HWND hWndOwner,
+		std::wstring_view title,
+		std::wstring_view message,
+		std::span<WCHAR> buffer,
+		const std::optional<SFuncType>& optFunc = std::nullopt
+	);
 
-	HINSTANCE	m_hInstance;	/* アプリケーションインスタンスのハンドル */
-	HWND		m_hwndParent;	/* オーナーウィンドウのハンドル */
-	HWND		m_hWnd;			/* このダイアログのハンドル */
+	BOOL DoModal(
+		_In_opt_ HWND hWndOwner,
+		std::wstring_view title,
+		std::wstring_view message,
+		std::wstring& buffer
+	);
 
-	const WCHAR*	m_pszTitle;		/* ダイアログタイトル */
-	const WCHAR*	m_pszMessage;	/* メッセージ */
-	int			m_nMaxTextLen;	/* 入力サイズ上限 */
-//	char*		m_pszText;		/* テキスト */
-	CNativeW	m_cmemText;		/* テキスト */
-protected:
-	/*
-	||  実装ヘルパ関数
-	*/
+	virtual BOOL DoModal(
+		_In_opt_ HWND hWndOwner,
+		_In_z_ LPCWSTR pszTitle,
+		_In_z_ LPCWSTR pszMessage,
+		_Inout_updates_z_(cchBuffer) LPWSTR pBuffer,
+		size_t cchBuffer
+	);
+
+	INT_PTR	DispatchDlgEvent(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	LRESULT	DispatchEvent(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+	int		GetDlgData(HWND hWndDlg);
+	void	SetDlgData(HWND hWndDlg) const;
+
+	bool	OnInitDialog(HWND hWndDlg, HWND hWndFocus, LPARAM lParam);
+	void	OnCommand(HWND hWnd, int id, HWND hWndCtl, UINT notifyCode);
+
+	HWND			m_hWnd;		/* このダイアログのハンドル */
+
+	std::wstring	m_Title;	/* ダイアログタイトル */
+	std::wstring	m_Message;	/* メッセージ */
+	SBuffer			m_Text;		/* テキスト */
+
+	SFuncType		m_Func = NoValidation;
 };
 
 #endif /* SAKURA_CDLGINPUT1_43CB765B_D257_4DBC_85E9_D2587B7E9D8E_H_ */

--- a/sakura_core/dlg/CDlgInput1.h
+++ b/sakura_core/dlg/CDlgInput1.h
@@ -33,7 +33,7 @@ class CDlgInput1 : public TSakuraSingleton<CDlgInput1>
 {
 private:
 	using SBuffer = std::span<WCHAR>;
-	using SFuncType = std::function<int(HWND, std::wstring_view)>;
+	using SFuncType = std::function<int(HWND, std::wstring_view, size_t)>;
 
 	using Me = CDlgInput1;
 
@@ -45,6 +45,8 @@ public:
 		LPARAM lParam
 	);
 
+	static int NoValidation(HWND hWndDlg, std::wstring_view text, size_t cchBuffer);
+
 	static LRESULT CALLBACK SubclassProc(
 		HWND hWnd,
 		UINT uMsg,
@@ -54,8 +56,6 @@ public:
 		DWORD_PTR dwRefData
 	);
 
-	static inline SFuncType NoValidation = [] (HWND, std::wstring_view) { return 1; };	//!< 何もしない評価関数
-
 	virtual ~CDlgInput1() noexcept = default;
 
 	BOOL DoModal(
@@ -63,8 +63,8 @@ public:
 		_In_opt_ HWND hWndOwner,
 		_In_z_ const WCHAR* pszTitle,
 		_In_z_ const WCHAR* pszMessage,
-		size_t cchBuffer,
-		_Inout_updates_z_(cchBuffer) WCHAR* pszBuffer
+		size_t cchMaxTextLength,
+		_Inout_updates_z_(cchMaxTextLength + 1) WCHAR* pszText
 	);
 
 	BOOL DoModal(
@@ -79,7 +79,8 @@ public:
 		_In_opt_ HWND hWndOwner,
 		std::wstring_view title,
 		std::wstring_view message,
-		std::wstring& buffer
+		std::wstring& buffer,
+		const std::optional<SFuncType>& optFunc = std::nullopt
 	);
 
 	virtual BOOL DoModal(
@@ -105,7 +106,7 @@ public:
 	std::wstring	m_Message;	/* メッセージ */
 	SBuffer			m_Text;		/* テキスト */
 
-	SFuncType		m_Func = NoValidation;
+	SFuncType		m_Func = &NoValidation;
 };
 
 #endif /* SAKURA_CDLGINPUT1_43CB765B_D257_4DBC_85E9_D2587B7E9D8E_H_ */

--- a/sakura_core/dlg/CDlgInput1.h
+++ b/sakura_core/dlg/CDlgInput1.h
@@ -6,7 +6,7 @@
 */
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "mem/CNativeW.h"
+#include "util/design_template.h"
 
 class CDlgInput1;
 
@@ -25,9 +26,14 @@ class CDlgInput1;
 /*!
 	@brief １行入力ダイアログボックス
 */
-class CDlgInput1
+class CDlgInput1 : public TSakuraSingleton<CDlgInput1>
 {
+private:
+	using Me = CDlgInput1;
+
 public:
+	virtual ~CDlgInput1() noexcept = default;
+
 	BOOL DoModal( HINSTANCE hInstApp, HWND hwndParent, const WCHAR* pszTitle,
 				  const WCHAR* pszMessage, size_t bufferSize, WCHAR* pszText );
 
@@ -50,4 +56,5 @@ protected:
 	||  実装ヘルパ関数
 	*/
 };
+
 #endif /* SAKURA_CDLGINPUT1_43CB765B_D257_4DBC_85E9_D2587B7E9D8E_H_ */

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -42,6 +42,8 @@
 #include "sakura_rc.h"
 #include "sakura.hh"
 
+using namespace std::literals::string_view_literals;
+
 static const DWORD p_helpids[] = {	//13100
 //	IDOK,					HIDOK_OPENDLG,		//Winのヘルプで勝手に出てくる
 //	IDCANCEL,				HIDCANCEL_OPENDLG,		//Winのヘルプで勝手に出てくる
@@ -75,6 +77,84 @@ BOOL Comdlg32::GetSaveFileNameW(
 ) const
 {
 	return ::GetSaveFileNameW(pOfn);
+}
+
+/*!
+ * @brief CommDlgExtendedError() のエラーコードを文字列に変換する
+ *
+ * @retval ""     エラーコードなし
+ * @retval ""以外 エラーコード文字列
+ *
+ * @throws std::out_of_range 未定義のエラーコードを検出した場合
+ */
+std::wstring Comdlg32::CommDlgExtendedErrorString() const
+{
+#pragma push_macro("CD_ERR_ENTRY")
+
+#define CD_ERR_ENTRY(code)	{ code, L ## #code ## sv }
+
+	const std::map<DWORD, std::wstring_view> codeMap{
+		CD_ERR_ENTRY(CDERR_DIALOGFAILURE),
+
+		CD_ERR_ENTRY(CDERR_GENERALCODES),
+		CD_ERR_ENTRY(CDERR_STRUCTSIZE),
+		CD_ERR_ENTRY(CDERR_INITIALIZATION),
+		CD_ERR_ENTRY(CDERR_NOTEMPLATE),
+		CD_ERR_ENTRY(CDERR_NOHINSTANCE),
+		CD_ERR_ENTRY(CDERR_LOADSTRFAILURE),
+		CD_ERR_ENTRY(CDERR_FINDRESFAILURE),
+		CD_ERR_ENTRY(CDERR_LOADRESFAILURE),
+		CD_ERR_ENTRY(CDERR_LOCKRESFAILURE),
+		CD_ERR_ENTRY(CDERR_MEMALLOCFAILURE),
+		CD_ERR_ENTRY(CDERR_MEMLOCKFAILURE),
+		CD_ERR_ENTRY(CDERR_NOHOOK),
+		CD_ERR_ENTRY(CDERR_REGISTERMSGFAIL),
+
+		CD_ERR_ENTRY(PDERR_PRINTERCODES),
+		CD_ERR_ENTRY(PDERR_SETUPFAILURE),
+		CD_ERR_ENTRY(PDERR_PARSEFAILURE),
+		CD_ERR_ENTRY(PDERR_RETDEFFAILURE),
+		CD_ERR_ENTRY(PDERR_LOADDRVFAILURE),
+		CD_ERR_ENTRY(PDERR_GETDEVMODEFAIL),
+		CD_ERR_ENTRY(PDERR_INITFAILURE),
+		CD_ERR_ENTRY(PDERR_NODEVICES),
+		CD_ERR_ENTRY(PDERR_NODEFAULTPRN),
+		CD_ERR_ENTRY(PDERR_DNDMMISMATCH),
+		CD_ERR_ENTRY(PDERR_CREATEICFAILURE),
+		CD_ERR_ENTRY(PDERR_PRINTERNOTFOUND),
+		CD_ERR_ENTRY(PDERR_DEFAULTDIFFERENT),
+
+		CD_ERR_ENTRY(CFERR_CHOOSEFONTCODES),
+		CD_ERR_ENTRY(CFERR_NOFONTS),
+		CD_ERR_ENTRY(CFERR_MAXLESSTHANMIN),
+
+		CD_ERR_ENTRY(FNERR_FILENAMECODES),
+		CD_ERR_ENTRY(FNERR_SUBCLASSFAILURE),
+		CD_ERR_ENTRY(FNERR_INVALIDFILENAME),
+		CD_ERR_ENTRY(FNERR_BUFFERTOOSMALL),
+
+		CD_ERR_ENTRY(FRERR_FINDREPLACECODES),
+		CD_ERR_ENTRY(FRERR_BUFFERLENGTHZERO),
+
+		CD_ERR_ENTRY(CCERR_CHOOSECOLORCODES),
+	};
+
+#pragma pop_macro("CD_ERR_ENTRY")
+
+	// エラーコードを取得する
+	const auto code = CommDlgExtendedError();
+	if (!code) {
+		return {};	// エラーコードなし
+	}
+
+	// コードマップから文字列を取得する
+	if (const auto found = codeMap.find(code);
+		found != codeMap.end())
+	{
+		return std::data(found->second);	// 見付かった値を返す
+	}
+
+	throw std::out_of_range{ std::format("CommDlgExtendedError: unknown error code {}", code) };
 }
 
 namespace apiwrap {
@@ -1120,32 +1200,22 @@ bool CDlgOpenFile_CommonFileDialog::DoModalSaveDlg(
 */
 /* static */ void CDlgOpenFile_CommonFileDialog::DlgOpenFail(void)
 {
-	const auto dwError = Comdlg32::getInstance()->CommDlgExtendedError();
-	if( dwError == 0 ){
+	std::wstring name;
+	try {
+		name = Comdlg32::getInstance()->CommDlgExtendedErrorString();
+	}
+	catch (const std::out_of_range&) {
+		name = L"UNKNOWN_ERRORCODE";
+	}
+
+	if (name.empty()) {
 		//	ユーザーキャンセルによる
 		return;
 	}
 
-	const WCHAR* pszError;
+	const auto formatted = std::format(L"{:<21}", name);
 
-	switch( dwError ){
-	case CDERR_DIALOGFAILURE  : pszError = L"CDERR_DIALOGFAILURE  "; break;
-	case CDERR_FINDRESFAILURE : pszError = L"CDERR_FINDRESFAILURE "; break;
-	case CDERR_NOHINSTANCE    : pszError = L"CDERR_NOHINSTANCE    "; break;
-	case CDERR_INITIALIZATION : pszError = L"CDERR_INITIALIZATION "; break;
-	case CDERR_NOHOOK         : pszError = L"CDERR_NOHOOK         "; break;
-	case CDERR_LOCKRESFAILURE : pszError = L"CDERR_LOCKRESFAILURE "; break;
-	case CDERR_NOTEMPLATE     : pszError = L"CDERR_NOTEMPLATE     "; break;
-	case CDERR_LOADRESFAILURE : pszError = L"CDERR_LOADRESFAILURE "; break;
-	case CDERR_STRUCTSIZE     : pszError = L"CDERR_STRUCTSIZE     "; break;
-	case CDERR_LOADSTRFAILURE : pszError = L"CDERR_LOADSTRFAILURE "; break;
-	case FNERR_BUFFERTOOSMALL : pszError = L"FNERR_BUFFERTOOSMALL "; break;
-	case CDERR_MEMALLOCFAILURE: pszError = L"CDERR_MEMALLOCFAILURE"; break;
-	case FNERR_INVALIDFILENAME: pszError = L"FNERR_INVALIDFILENAME"; break;
-	case CDERR_MEMLOCKFAILURE : pszError = L"CDERR_MEMLOCKFAILURE "; break;
-	case FNERR_SUBCLASSFAILURE: pszError = L"FNERR_SUBCLASSFAILURE"; break;
-	default:					pszError = L"UNKNOWN_ERRORCODE    "; break;
-	}
+	const auto pszError = std::data(formatted);
 
 	ErrorBeep();
 

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -58,6 +58,25 @@ static const DWORD p_helpids[] = {	//13100
 
 static int AddComboCodePages(HWND hdlg, HWND combo, int nSelCode, bool& bInit);
 
+DWORD Comdlg32::CommDlgExtendedError() const
+{
+	return ::CommDlgExtendedError();
+}
+
+BOOL Comdlg32::GetOpenFileNameW(
+	LPOPENFILENAMEW pOfn
+) const
+{
+	return ::GetOpenFileNameW(pOfn);
+}
+
+BOOL Comdlg32::GetSaveFileNameW(
+	LPOPENFILENAMEW pOfn
+) const
+{
+	return ::GetSaveFileNameW(pOfn);
+}
+
 namespace apiwrap {
 
 template <class TFunc>
@@ -69,7 +88,7 @@ bool CallCommDlgFunc(
 	assert(pOfn);
 
 	auto bRet = std::forward<TFunc>(func)();
-	if (!bRet && FNERR_INVALIDFILENAME == ::CommDlgExtendedError()) {
+	if (!bRet && FNERR_INVALIDFILENAME == Comdlg32::getInstance()->CommDlgExtendedError()) {
 		pOfn->lpstrFile[0] = L'\0';
 		pOfn->lpstrInitialDir = L"";
 		bRet = std::forward<TFunc>(func)();
@@ -1230,7 +1249,7 @@ void CDlgOpenFile_CommonFileDialog::InitLayout( HWND hwndOpenDlg, HWND hwndDlg, 
 */
 bool CDlgOpenFile_CommonFileDialog::_GetOpenFileNameRecover(OPENFILENAME* ofn) const
 {
-	return apiwrap::CallCommDlgFunc([ofn] () { return ::GetOpenFileNameW(ofn); }, ofn);
+	return apiwrap::CallCommDlgFunc([ofn] () { return Comdlg32::getInstance()->GetOpenFileNameW(ofn); }, ofn);
 }
 
 /*! リトライ機能付き GetSaveFileName
@@ -1239,7 +1258,7 @@ bool CDlgOpenFile_CommonFileDialog::_GetOpenFileNameRecover(OPENFILENAME* ofn) c
 */
 bool CDlgOpenFile_CommonFileDialog::GetSaveFileNameRecover(OPENFILENAME* ofn) const
 {
-	return apiwrap::CallCommDlgFunc([ofn] () { return ::GetSaveFileNameW(ofn); }, ofn);
+	return apiwrap::CallCommDlgFunc([ofn] () { return Comdlg32::getInstance()->GetSaveFileNameW(ofn); }, ofn);
 }
 
 std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog()

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -58,6 +58,28 @@ static const DWORD p_helpids[] = {	//13100
 
 static int AddComboCodePages(HWND hdlg, HWND combo, int nSelCode, bool& bInit);
 
+namespace apiwrap {
+
+template <class TFunc>
+bool CallCommDlgFunc(
+	TFunc&& func,
+	LPOPENFILENAMEW pOfn
+)
+{
+	assert(pOfn);
+
+	auto bRet = std::forward<TFunc>(func)();
+	if (!bRet && FNERR_INVALIDFILENAME == ::CommDlgExtendedError()) {
+		pOfn->lpstrFile[0] = L'\0';
+		pOfn->lpstrInitialDir = L"";
+		bRet = std::forward<TFunc>(func)();
+	}
+
+	return bRet;
+}
+
+} // namespace apiwrap
+
 struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
 {
 	CDlgOpenFile_CommonFileDialog();
@@ -1208,15 +1230,7 @@ void CDlgOpenFile_CommonFileDialog::InitLayout( HWND hwndOpenDlg, HWND hwndDlg, 
 */
 bool CDlgOpenFile_CommonFileDialog::_GetOpenFileNameRecover(OPENFILENAME* ofn) const
 {
-	BOOL bRet = ::GetOpenFileName( ofn );
-	if( !bRet  ){
-		if( FNERR_INVALIDFILENAME == ::CommDlgExtendedError() ){
-			ofn->lpstrFile[0] = L'\0';
-			ofn->lpstrInitialDir = L"";
-			bRet = ::GetOpenFileName( ofn );
-		}
-	}
-	return bRet!=FALSE;
+	return apiwrap::CallCommDlgFunc([ofn] () { return ::GetOpenFileNameW(ofn); }, ofn);
 }
 
 /*! リトライ機能付き GetSaveFileName
@@ -1225,15 +1239,7 @@ bool CDlgOpenFile_CommonFileDialog::_GetOpenFileNameRecover(OPENFILENAME* ofn) c
 */
 bool CDlgOpenFile_CommonFileDialog::GetSaveFileNameRecover(OPENFILENAME* ofn) const
 {
-	BOOL bRet = ::GetSaveFileName( ofn );
-	if( !bRet  ){
-		if( FNERR_INVALIDFILENAME == ::CommDlgExtendedError() ){
-			ofn->lpstrFile[0] = L'\0';
-			ofn->lpstrInitialDir = L"";
-			bRet = ::GetSaveFileName( ofn );
-		}
-	}
-	return bRet!=FALSE;
+	return apiwrap::CallCommDlgFunc([ofn] () { return ::GetSaveFileNameW(ofn); }, ofn);
 }
 
 std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog()

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -117,7 +117,7 @@ struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
 	bool DoModalOpenDlg( SLoadInfo* pLoadInfo, std::vector<std::wstring>*, bool bOptions ) override;
 	bool DoModalSaveDlg( SSaveInfo*	pSaveInfo, bool bSimpleMode ) override;
 
-	void DlgOpenFail(void);
+	static void DlgOpenFail(void);
 
 	void InitOfn(OPENFILENAME* ofn) const;
 
@@ -1118,15 +1118,16 @@ bool CDlgOpenFile_CommonFileDialog::DoModalSaveDlg(
 	@author genta
 	@date 2004.05.29 genta 元々あった部分をまとめた
 */
-void CDlgOpenFile_CommonFileDialog::DlgOpenFail(void)
+/* static */ void CDlgOpenFile_CommonFileDialog::DlgOpenFail(void)
 {
-	const WCHAR*	pszError;
-	DWORD dwError = ::CommDlgExtendedError();
+	const auto dwError = Comdlg32::getInstance()->CommDlgExtendedError();
 	if( dwError == 0 ){
 		//	ユーザーキャンセルによる
 		return;
 	}
-	
+
+	const WCHAR* pszError;
+
 	switch( dwError ){
 	case CDERR_DIALOGFAILURE  : pszError = L"CDERR_DIALOGFAILURE  "; break;
 	case CDERR_FINDRESFAILURE : pszError = L"CDERR_FINDRESFAILURE "; break;
@@ -1143,11 +1144,14 @@ void CDlgOpenFile_CommonFileDialog::DlgOpenFail(void)
 	case FNERR_INVALIDFILENAME: pszError = L"FNERR_INVALIDFILENAME"; break;
 	case CDERR_MEMLOCKFAILURE : pszError = L"CDERR_MEMLOCKFAILURE "; break;
 	case FNERR_SUBCLASSFAILURE: pszError = L"FNERR_SUBCLASSFAILURE"; break;
-	default: pszError = L"UNKNOWN_ERRORCODE"; break;
+	default:					pszError = L"UNKNOWN_ERRORCODE    "; break;
 	}
 
 	ErrorBeep();
-	TopErrorMessage( m_hwndParent,
+
+	// "ダイアログが開けません。\n\nエラー:%s"
+	TopErrorMessage(
+		nullptr,
 		LS(STR_DLGOPNFL_ERR1),
 		pszError
 	);
@@ -1265,4 +1269,9 @@ std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog()
 {
 	std::shared_ptr<IDlgOpenFile> ret(new CDlgOpenFile_CommonFileDialog());
 	return ret;
+}
+
+void CallDlgOpenFail() //　テスト専用グローバル関数
+{
+	CDlgOpenFile_CommonFileDialog::DlgOpenFail();
 }

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -196,7 +196,7 @@ BOOL CDlgPrintSetting::OnCbnSelChange( [[maybe_unused]] HWND hwndCtl, int wID )
 BOOL CDlgPrintSetting::OnBnClicked( int wID )
 {
 	WCHAR			szWork[256];
-	CDlgInput1		cDlgInput1;
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
 	HWND			hwndComboSettingName;
 	switch( wID ){
 	case IDC_BUTTON_HELP:

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -205,24 +205,17 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_PRINT_PAGESETUP) );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 	case IDC_BUTTON_EDITSETTINGNAME:
-		wcscpy( szWork, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName );
+		if (!cDlgInput1.DoModal(
+			GetHwnd(),
+			LS(STR_DLGPRNST1),
+			LS(STR_DLGPRNST2),
+			m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName,
+			CDlgInput1::NoValidation
+		))
 		{
-			BOOL bDlgInputResult=cDlgInput1.DoModal(
-				m_hInstance,
-				GetHwnd(),
-				LS(STR_DLGPRNST1),
-				LS(STR_DLGPRNST2),
-				_countof( m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName ) - 1,
-				szWork
-			);
-			if( !bDlgInputResult ){
 				return TRUE;
-			}
 		}
 		if( szWork[0] != L'\0' ){
-			int		size = _countof(m_PrintSettingArr[0].m_szPrintSettingName) - 1;
-			wcsncpy( m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName, szWork, size);
-			m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName[size] = L'\0';
 			/* 印刷設定名一覧 */
 			hwndComboSettingName = GetItemHwnd( IDC_COMBO_SETTINGNAME );
 			ApiWrap::Combo_ResetContent( hwndComboSettingName );

--- a/sakura_core/dlg/CDlgPrintSetting.cpp
+++ b/sakura_core/dlg/CDlgPrintSetting.cpp
@@ -205,17 +205,24 @@ BOOL CDlgPrintSetting::OnBnClicked( int wID )
 		MyWinHelp( GetHwnd(), HELP_CONTEXT, ::FuncID_To_HelpContextID(F_PRINT_PAGESETUP) );	// 2006.10.10 ryoji MyWinHelpに変更に変更
 		return TRUE;
 	case IDC_BUTTON_EDITSETTINGNAME:
-		if (!cDlgInput1.DoModal(
-			GetHwnd(),
-			LS(STR_DLGPRNST1),
-			LS(STR_DLGPRNST2),
-			m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName,
-			CDlgInput1::NoValidation
-		))
+		wcscpy( szWork, m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName );
 		{
+			BOOL bDlgInputResult=cDlgInput1.DoModal(
+				m_hInstance,
+				GetHwnd(),
+				LS(STR_DLGPRNST1),
+				LS(STR_DLGPRNST2),
+				_countof( m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName ) - 1,
+				szWork
+			);
+			if( !bDlgInputResult ){
 				return TRUE;
+			}
 		}
 		if( szWork[0] != L'\0' ){
+			int		size = _countof(m_PrintSettingArr[0].m_szPrintSettingName) - 1;
+			wcsncpy( m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName, szWork, size);
+			m_PrintSettingArr[m_nCurrentPrintSetting].m_szPrintSettingName[size] = L'\0';
 			/* 印刷設定名一覧 */
 			hwndComboSettingName = GetItemHwnd( IDC_COMBO_SETTINGNAME );
 			ApiWrap::Combo_ResetContent( hwndComboSettingName );

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -329,7 +329,7 @@ static bool IsProfileDuplicate(HWND hwndList, LPCWSTR szProfName, int skipIndex)
 
 void CDlgProfileMgr::CreateProf()
 {
-	CDlgInput1 cDlgInput1;
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
 	int max_size = _MAX_PATH;
 	WCHAR szText[_MAX_PATH];
 	std::wstring strTitle = LS(STR_DLGPROFILE_NEW_PROF_TITLE);
@@ -385,7 +385,7 @@ void CDlgProfileMgr::DeleteProf()
 void CDlgProfileMgr::RenameProf()
 {
 	HWND hwndList = GetItemHwnd( IDC_LIST_PROFILE );
-	CDlgInput1 cDlgInput1;
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
 	int nCurIndex = ApiWrap::List_GetCurSel(hwndList);
 	WCHAR szText[_MAX_PATH];
 	bool bDefault = MyList_GetText( hwndList, nCurIndex, szText );

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -332,10 +332,15 @@ void CDlgProfileMgr::CreateProf()
 	auto& cDlgInput1 = *CDlgInput1::getInstance();
 	int max_size = _MAX_PATH;
 	WCHAR szText[_MAX_PATH];
-	std::wstring strTitle = LS(STR_DLGPROFILE_NEW_PROF_TITLE);
-	std::wstring strMessage = LS(STR_DLGPROFILE_NEW_PROF_MSG);
 	szText[0] = L'\0';
-	if( !cDlgInput1.DoModal(::GetModuleHandle(nullptr), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){
+	if (!cDlgInput1.DoModal(
+		GetHwnd(),
+		LS(STR_DLGPROFILE_NEW_PROF_TITLE),
+		LS(STR_DLGPROFILE_NEW_PROF_MSG),
+		szText,
+		CDlgInput1::NoValidation
+	))
+	{
 		return;
 	}
 	if( szText[0] == L'\0' ){
@@ -390,11 +395,16 @@ void CDlgProfileMgr::RenameProf()
 	WCHAR szText[_MAX_PATH];
 	bool bDefault = MyList_GetText( hwndList, nCurIndex, szText );
 	WCHAR szTextOld[_MAX_PATH];
-	wcscpy( szTextOld, szText );
-	std::wstring strTitle = LS(STR_DLGPROFILE_RENAME_TITLE);
-	std::wstring strMessage = LS(STR_DLGPROFILE_RENAME_MSG);
+	::wcscpy_s(szTextOld, szText);
 	int max_size = _MAX_PATH;
-	if( !cDlgInput1.DoModal(::GetModuleHandle(nullptr), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){
+	if (!cDlgInput1.DoModal(
+		GetHwnd(),
+		LS(STR_DLGPROFILE_RENAME_TITLE),
+		LS(STR_DLGPROFILE_RENAME_MSG),
+		szText,
+		CDlgInput1::NoValidation
+	))
+	{
 		return;
 	}
 	if( szText[0] == L'\0' ){

--- a/sakura_core/dlg/CDlgProfileMgr.cpp
+++ b/sakura_core/dlg/CDlgProfileMgr.cpp
@@ -332,15 +332,10 @@ void CDlgProfileMgr::CreateProf()
 	auto& cDlgInput1 = *CDlgInput1::getInstance();
 	int max_size = _MAX_PATH;
 	WCHAR szText[_MAX_PATH];
+	std::wstring strTitle = LS(STR_DLGPROFILE_NEW_PROF_TITLE);
+	std::wstring strMessage = LS(STR_DLGPROFILE_NEW_PROF_MSG);
 	szText[0] = L'\0';
-	if (!cDlgInput1.DoModal(
-		GetHwnd(),
-		LS(STR_DLGPROFILE_NEW_PROF_TITLE),
-		LS(STR_DLGPROFILE_NEW_PROF_MSG),
-		szText,
-		CDlgInput1::NoValidation
-	))
-	{
+	if( !cDlgInput1.DoModal(::GetModuleHandle(nullptr), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){
 		return;
 	}
 	if( szText[0] == L'\0' ){
@@ -395,16 +390,11 @@ void CDlgProfileMgr::RenameProf()
 	WCHAR szText[_MAX_PATH];
 	bool bDefault = MyList_GetText( hwndList, nCurIndex, szText );
 	WCHAR szTextOld[_MAX_PATH];
-	::wcscpy_s(szTextOld, szText);
+	wcscpy( szTextOld, szText );
+	std::wstring strTitle = LS(STR_DLGPROFILE_RENAME_TITLE);
+	std::wstring strMessage = LS(STR_DLGPROFILE_RENAME_MSG);
 	int max_size = _MAX_PATH;
-	if (!cDlgInput1.DoModal(
-		GetHwnd(),
-		LS(STR_DLGPROFILE_RENAME_TITLE),
-		LS(STR_DLGPROFILE_RENAME_MSG),
-		szText,
-		CDlgInput1::NoValidation
-	))
-	{
+	if( !cDlgInput1.DoModal(::GetModuleHandle(nullptr), GetHwnd(), strTitle.c_str(), strMessage.c_str(), max_size - 1, szText) ){
 		return;
 	}
 	if( szText[0] == L'\0' ){

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1747,7 +1747,7 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, VARIANT *Argument
 			size_t nLen = t_min( sDefaultValue.length(), (size_t)nMaxLen);
 			wmemcpy( Buffer, sDefaultValue.c_str(), nLen );
 			Buffer[nLen] = L'\0';
-			CDlgInput1 cDlgInput1;
+			auto& cDlgInput1 = *CDlgInput1::getInstance();
 			if( cDlgInput1.DoModal( G_AppInstance(), View->GetHwnd(), L"sakura macro", sMessage.c_str(), nMaxLen, Buffer ) ) {
 				SysString S( Buffer, wcslen(Buffer) );
 				Wrap( &Result )->Receive( S );

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1747,15 +1747,8 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, VARIANT *Argument
 			size_t nLen = t_min( sDefaultValue.length(), (size_t)nMaxLen);
 			wmemcpy( Buffer, sDefaultValue.c_str(), nLen );
 			Buffer[nLen] = L'\0';
-			if (auto& cDlgInput1 = *CDlgInput1::getInstance();
-				cDlgInput1.DoModal(
-				View->GetHwnd(),
-				L"sakura macro",
-				sMessage,
-				std::span(Buffer, nMaxLen + 1),
-				CDlgInput1::NoValidation
-			))
-			{
+			auto& cDlgInput1 = *CDlgInput1::getInstance();
+			if( cDlgInput1.DoModal( G_AppInstance(), View->GetHwnd(), L"sakura macro", sMessage.c_str(), nMaxLen, Buffer ) ) {
 				SysString S( Buffer, wcslen(Buffer) );
 				Wrap( &Result )->Receive( S );
 			}else{

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -1747,8 +1747,15 @@ bool CMacro::HandleFunction(CEditView *View, EFunctionCode ID, VARIANT *Argument
 			size_t nLen = t_min( sDefaultValue.length(), (size_t)nMaxLen);
 			wmemcpy( Buffer, sDefaultValue.c_str(), nLen );
 			Buffer[nLen] = L'\0';
-			auto& cDlgInput1 = *CDlgInput1::getInstance();
-			if( cDlgInput1.DoModal( G_AppInstance(), View->GetHwnd(), L"sakura macro", sMessage.c_str(), nMaxLen, Buffer ) ) {
+			if (auto& cDlgInput1 = *CDlgInput1::getInstance();
+				cDlgInput1.DoModal(
+				View->GetHwnd(),
+				L"sakura macro",
+				sMessage,
+				std::span(Buffer, nMaxLen + 1),
+				CDlgInput1::NoValidation
+			))
+			{
 				SysString S( Buffer, wcslen(Buffer) );
 				Wrap( &Result )->Receive( S );
 			}else{

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3270,7 +3270,7 @@ void CDlgFuncList::DoMenu( POINT pt, HWND hwndFrom )
 	// メニューを表示する
 	RECT rcWork;
 	GetMonitorWorkRect( pt, &rcWork );	// モニタのワークエリア
-	int nId = ::TrackPopupMenu( hMenu, TPM_LEFTALIGN | TPM_TOPALIGN | TPM_LEFTBUTTON | TPM_RETURNCMD,
+	int nId = User32::getInstance()->TrackPopupMenu( hMenu, TPM_LEFTALIGN | TPM_TOPALIGN | TPM_LEFTBUTTON | TPM_RETURNCMD,
 								( pt.x > rcWork.left )? pt.x: rcWork.left,
 								( pt.y < rcWork.bottom )? pt.y: rcWork.bottom,
 								0, GetHwnd(), nullptr);

--- a/sakura_core/print/CPrint.cpp
+++ b/sakura_core/print/CPrint.cpp
@@ -10,17 +10,24 @@
 	Copyright (C) 2001, hor
 	Copyright (C) 2002, MIK
 	Copyright (C) 2003, かろと
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
 
 #include "StdAfx.h"
-#include <WinSpool.h>
-#include "CPrint.h"
+#include "print/CPrint.h"
+
 #include "_main/global.h"
-#include "CSelectLang.h"
 #include "basis/CMyString.h"
+#include "util/os.h"
+
+#include "CSelectLang.h"
+
+BOOL Comdlg32::PrintDlgW(_Inout_ LPPRINTDLGW pPD) const
+{
+	return ::PrintDlgW(pPD);
+}
 
 // 2006.08.14 Moca 用紙名一覧の重複削除・情報の統合
 const PAPER_INFO CPrint::m_paperInfoArr[] = {
@@ -125,7 +132,7 @@ BOOL CPrint::PrintDlg( PRINTDLG *pPD, MYDEVMODE *pMYDEVMODE )
 	pPD->lStructSize = sizeof(*pPD);
 	pPD->hDevMode = m_hDevMode;
 	pPD->hDevNames = m_hDevNames;
-	if( !::PrintDlg( pPD ) ){
+	if (!Comdlg32::getInstance()->PrintDlgW(pPD)) {
 		// プリンターを変更しなかった
 		return FALSE;
 	}
@@ -201,7 +208,7 @@ BOOL CPrint::GetDefaultPrinter( MYDEVMODE* pMYDEVMODE )
 		memset_raw ( &pd, 0, sizeof(pd) );
 		pd.lStructSize	= sizeof(pd);
 		pd.Flags		= PD_RETURNDEFAULT;
-		if( !::PrintDlg( &pd ) ){
+		if (!Comdlg32::getInstance()->PrintDlgW(&pd)) {
 			pMYDEVMODE->m_bPrinterNotFound = TRUE;	/* プリンターがなかったフラグ */
 			return FALSE;
 		}

--- a/sakura_core/print/CPrintPreview.cpp
+++ b/sakura_core/print/CPrintPreview.cpp
@@ -849,7 +849,8 @@ void CPrintPreview::OnPreviewGoDirectPage( void )
 {
 	const int  INPUT_PAGE_NUM_LEN = 12;
 
-	CDlgInput1 cDlgInputPage;
+	auto& cDlgInputPage = *CDlgInput1::getInstance();
+
 	WCHAR      szMessage[512];
 	WCHAR      szPageNum[INPUT_PAGE_NUM_LEN];
 	

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -155,7 +155,7 @@ INT_PTR CPropCustmenu::DispatchEvent(
 	WCHAR		szLabel[300];
 	WCHAR		szLabel2[300+4];
 
-	CDlgInput1	cDlgInput1;
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
 
 	switch( uMsg ){
 	case WM_INITDIALOG:

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -290,14 +290,18 @@ INT_PTR CPropCustmenu::DispatchEvent(
 //			hwndListBox = (HWND) lParam;		// handle of list box
 				WCHAR		szKey[2];
 				auto_sprintf( szKey, L"%hc", m_Common.m_sCustomMenu.m_nCustMenuItemKeyArr[nIdx1][nIdx2] );
-				if (!cDlgInput1.DoModal(
+				{
+					BOOL bDlgInputResult = cDlgInput1.DoModal(
+						G_AppInstance(),
 						hwndDlg,
 						LS(STR_PROPCOMCUSTMENU_AC1),
 						LS(STR_PROPCOMCUSTMENU_AC2),
-					szKey,
-					CDlgInput1::NoValidation
-				)) {
+						1,
+						szKey
+					);
+					if( !bDlgInputResult ){
 						return TRUE;
+					}
 				}
 				//	Oct. 3, 2001 genta
 				m_cLookup.Funccode2Name( m_Common.m_sCustomMenu.m_nCustMenuItemFuncArr[nIdx1][nIdx2], szLabel, 255 );

--- a/sakura_core/prop/CPropComCustmenu.cpp
+++ b/sakura_core/prop/CPropComCustmenu.cpp
@@ -290,18 +290,14 @@ INT_PTR CPropCustmenu::DispatchEvent(
 //			hwndListBox = (HWND) lParam;		// handle of list box
 				WCHAR		szKey[2];
 				auto_sprintf( szKey, L"%hc", m_Common.m_sCustomMenu.m_nCustMenuItemKeyArr[nIdx1][nIdx2] );
-				{
-					BOOL bDlgInputResult = cDlgInput1.DoModal(
-						G_AppInstance(),
+				if (!cDlgInput1.DoModal(
 						hwndDlg,
 						LS(STR_PROPCOMCUSTMENU_AC1),
 						LS(STR_PROPCOMCUSTMENU_AC2),
-						1,
-						szKey
-					);
-					if( !bDlgInputResult ){
+					szKey,
+					CDlgInput1::NoValidation
+				)) {
 						return TRUE;
-					}
 				}
 				//	Oct. 3, 2001 genta
 				m_cLookup.Funccode2Name( m_Common.m_sCustomMenu.m_nCustMenuItemFuncArr[nIdx1][nIdx2], szLabel, 255 );

--- a/sakura_core/prop/CPropComKeyword.cpp
+++ b/sakura_core/prop/CPropComKeyword.cpp
@@ -89,7 +89,7 @@ INT_PTR CPropKeyword::DispatchEvent(
 	static HWND			hwndCOMBO_SET;
 	static HWND			hwndLIST_KEYWORD;
 	RECT				rc;
-	CDlgInput1			cDlgInput1;
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
 	wchar_t				szKeyWord[MAX_KEYWORDLEN + 1];
 	LONG_PTR			lStyle;
 	LV_DISPINFO*		plvdi;
@@ -491,7 +491,7 @@ void CPropKeyword::Edit_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 	int			nIndex1;
 	LV_ITEM		lvi;
 	wchar_t		szKeyWord[MAX_KEYWORDLEN + 1];
-	CDlgInput1	cDlgInput1;
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
 
 	nIndex1 = ListView_GetNextItem( hwndLIST_KEYWORD, -1, LVNI_ALL | LVNI_SELECTED );
 	if( -1 == nIndex1 ){

--- a/sakura_core/prop/CPropComKeyword.cpp
+++ b/sakura_core/prop/CPropComKeyword.cpp
@@ -366,14 +366,18 @@ INT_PTR CPropKeyword::DispatchEvent(
 				case IDC_BUTTON_KEYSETRENAME: // キーワードセットの名称変更
 					// モードレスダイアログの表示
 					wcscpy( szKeyWord, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetTypeName( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx ) );
-					if (!cDlgInput1.DoModal(
+					{
+						BOOL bDlgInputResult = cDlgInput1.DoModal(
+							G_AppInstance(),
 							hwndDlg,
 							LS(STR_PROPCOMKEYWORD_RENAME1),
 							LS(STR_PROPCOMKEYWORD_RENAME2),
-						std::span(szKeyWord, MAX_SETNAMELEN + 1),
-						CDlgInput1::NoValidation
-					)) {
+							MAX_SETNAMELEN,
+							szKeyWord
+						);
+						if( !bDlgInputResult ){
 							return TRUE;
+						}
 					}
 					if( szKeyWord[0] != L'\0' ){
 						m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SetTypeName( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, szKeyWord );
@@ -394,13 +398,7 @@ INT_PTR CPropKeyword::DispatchEvent(
 					}
 					/* モードレスダイアログの表示 */
 					szKeyWord[0] = L'\0';
-					if (!cDlgInput1.DoModal(
-						hwndDlg,
-						LS(STR_PROPCOMKEYWORD_KEYADD1),
-						LS(STR_PROPCOMKEYWORD_KEYADD2),
-						szKeyWord,
-						CDlgInput1::NoValidation
-					)) {
+					if( !cDlgInput1.DoModal( G_AppInstance(), hwndDlg, LS(STR_PROPCOMKEYWORD_KEYADD1), LS(STR_PROPCOMKEYWORD_KEYADD2), MAX_KEYWORDLEN, szKeyWord ) ){
 						return TRUE;
 					}
 					if( szKeyWord[0] != L'\0' ){
@@ -508,13 +506,7 @@ void CPropKeyword::Edit_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 	wcscpy( szKeyWord, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWord( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, lvi.lParam ) );
 
 	/* モードレスダイアログの表示 */
-	if (!cDlgInput1.DoModal(
-		hwndDlg,
-		LS(STR_PROPCOMKEYWORD_KEYEDIT1),
-		LS(STR_PROPCOMKEYWORD_KEYEDIT2),
-		szKeyWord,
-		CDlgInput1::NoValidation
-	)) {
+	if( !cDlgInput1.DoModal( G_AppInstance(), hwndDlg, LS(STR_PROPCOMKEYWORD_KEYEDIT1), LS(STR_PROPCOMKEYWORD_KEYEDIT2), MAX_KEYWORDLEN, szKeyWord ) ){
 		return;
 	}
 	if( szKeyWord[0] != L'\0' ){

--- a/sakura_core/prop/CPropComKeyword.cpp
+++ b/sakura_core/prop/CPropComKeyword.cpp
@@ -366,18 +366,14 @@ INT_PTR CPropKeyword::DispatchEvent(
 				case IDC_BUTTON_KEYSETRENAME: // キーワードセットの名称変更
 					// モードレスダイアログの表示
 					wcscpy( szKeyWord, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetTypeName( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx ) );
-					{
-						BOOL bDlgInputResult = cDlgInput1.DoModal(
-							G_AppInstance(),
+					if (!cDlgInput1.DoModal(
 							hwndDlg,
 							LS(STR_PROPCOMKEYWORD_RENAME1),
 							LS(STR_PROPCOMKEYWORD_RENAME2),
-							MAX_SETNAMELEN,
-							szKeyWord
-						);
-						if( !bDlgInputResult ){
+						std::span(szKeyWord, MAX_SETNAMELEN + 1),
+						CDlgInput1::NoValidation
+					)) {
 							return TRUE;
-						}
 					}
 					if( szKeyWord[0] != L'\0' ){
 						m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.SetTypeName( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, szKeyWord );
@@ -398,7 +394,13 @@ INT_PTR CPropKeyword::DispatchEvent(
 					}
 					/* モードレスダイアログの表示 */
 					szKeyWord[0] = L'\0';
-					if( !cDlgInput1.DoModal( G_AppInstance(), hwndDlg, LS(STR_PROPCOMKEYWORD_KEYADD1), LS(STR_PROPCOMKEYWORD_KEYADD2), MAX_KEYWORDLEN, szKeyWord ) ){
+					if (!cDlgInput1.DoModal(
+						hwndDlg,
+						LS(STR_PROPCOMKEYWORD_KEYADD1),
+						LS(STR_PROPCOMKEYWORD_KEYADD2),
+						szKeyWord,
+						CDlgInput1::NoValidation
+					)) {
 						return TRUE;
 					}
 					if( szKeyWord[0] != L'\0' ){
@@ -506,7 +508,13 @@ void CPropKeyword::Edit_List_KeyWord( HWND hwndDlg, HWND hwndLIST_KEYWORD )
 	wcscpy( szKeyWord, m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.GetKeyWord( m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr.m_nCurrentKeyWordSetIdx, lvi.lParam ) );
 
 	/* モードレスダイアログの表示 */
-	if( !cDlgInput1.DoModal( G_AppInstance(), hwndDlg, LS(STR_PROPCOMKEYWORD_KEYEDIT1), LS(STR_PROPCOMKEYWORD_KEYEDIT2), MAX_KEYWORDLEN, szKeyWord ) ){
+	if (!cDlgInput1.DoModal(
+		hwndDlg,
+		LS(STR_PROPCOMKEYWORD_KEYEDIT1),
+		LS(STR_PROPCOMKEYWORD_KEYEDIT2),
+		szKeyWord,
+		CDlgInput1::NoValidation
+	)) {
 		return;
 	}
 	if( szKeyWord[0] != L'\0' ){

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -249,7 +249,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 	HTREEITEM		htiTemp2;
 	TV_DISPINFO*	ptdi;
 
-	CDlgInput1		cDlgInput1;
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
 
 	static	bool	bInMove;
 	bool			bIsNode;

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -380,12 +380,12 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					auto_sprintf( szKey, L"%ls", pFuncWk->m_sKey);
 
 					if (!cDlgInput1.DoModal(
-							G_AppInstance(),
 							hwndDlg,
 							LS(STR_PROPCOMMAINMENU_ACCKEY1),
 							LS(STR_PROPCOMMAINMENU_ACCKEY2),
-							1,
-							szKey)) {
+						std::span(szKey, 2),
+						CDlgInput1::NoValidation
+					)) {
 						return TRUE;
 					}
 					auto_sprintf( pFuncWk->m_sKey, L"%s", szKey);
@@ -524,7 +524,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 						}
 						if (nIdxFIdx == nSpecialFuncsNum) {
 							// 特殊機能
-							wcscpy( szLabel, LS(nsFuncCode::pnFuncList_Special[nIdxFunc]) );
+							::wcscpy_s( szLabel, LS(nsFuncCode::pnFuncList_Special[nIdxFunc]) );
 							eFuncCode = nsFuncCode::pnFuncList_Special[nIdxFunc];
 						}
 						else if (m_cLookup.Pos2FuncCode( nIdxFIdx, nIdxFunc ) != 0) {
@@ -532,7 +532,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 							eFuncCode = m_cLookup.Pos2FuncCode( nIdxFIdx, nIdxFunc );
 						}
 						else {
-							wcscpy( szLabel, L"?" );
+							::wcscpy_s( szLabel, L"?" );
 							eFuncCode = F_SEPARATOR;
 						}
 						break;

--- a/sakura_core/prop/CPropComMainMenu.cpp
+++ b/sakura_core/prop/CPropComMainMenu.cpp
@@ -380,12 +380,12 @@ INT_PTR CPropMainMenu::DispatchEvent(
 					auto_sprintf( szKey, L"%ls", pFuncWk->m_sKey);
 
 					if (!cDlgInput1.DoModal(
+							G_AppInstance(),
 							hwndDlg,
 							LS(STR_PROPCOMMAINMENU_ACCKEY1),
 							LS(STR_PROPCOMMAINMENU_ACCKEY2),
-						std::span(szKey, 2),
-						CDlgInput1::NoValidation
-					)) {
+							1,
+							szKey)) {
 						return TRUE;
 					}
 					auto_sprintf( pFuncWk->m_sKey, L"%s", szKey);
@@ -524,7 +524,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 						}
 						if (nIdxFIdx == nSpecialFuncsNum) {
 							// 特殊機能
-							::wcscpy_s( szLabel, LS(nsFuncCode::pnFuncList_Special[nIdxFunc]) );
+							wcscpy( szLabel, LS(nsFuncCode::pnFuncList_Special[nIdxFunc]) );
 							eFuncCode = nsFuncCode::pnFuncList_Special[nIdxFunc];
 						}
 						else if (m_cLookup.Pos2FuncCode( nIdxFIdx, nIdxFunc ) != 0) {
@@ -532,7 +532,7 @@ INT_PTR CPropMainMenu::DispatchEvent(
 							eFuncCode = m_cLookup.Pos2FuncCode( nIdxFIdx, nIdxFunc );
 						}
 						else {
-							::wcscpy_s( szLabel, L"?" );
+							wcscpy( szLabel, L"?" );
 							eFuncCode = F_SEPARATOR;
 						}
 						break;

--- a/sakura_core/tests1.vcxproj.filters
+++ b/sakura_core/tests1.vcxproj.filters
@@ -226,6 +226,15 @@
     <ClCompile Include="..\src\test\cpp\tests1\test-codechecker.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\test\cpp\tests1\test-detectindentationstyle.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\test\cpp\tests1\test-cimagelistmgr.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\test\cpp\tests1\test-cmenudrawer.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\test\resources\pch.h">

--- a/sakura_core/typeprop/CPropTypesColor.cpp
+++ b/sakura_core/typeprop/CPropTypesColor.cpp
@@ -94,6 +94,13 @@ struct {
 	{ IDC_EDIT_LINECOMMENT3	, IDC_CHECK_LCPOS3, IDC_EDIT_LINECOMMENTPOS3}
 };
 
+BOOL Comdlg32::ChooseColorW(
+	LPCHOOSECOLORW pCc
+) const
+{
+	return ::ChooseColorW(pCc);
+}
+
 /* 色の設定をインポート */
 // 2010/4/23 Uchi Importの外出し
 bool CPropTypesColor::Import( HWND hwndDlg )
@@ -1157,7 +1164,7 @@ BOOL CPropTypesColor::SelectColor( HWND hwndParent, COLORREF* pColor, DWORD* pCu
 	cc.lpCustColors = pCustColors;
 	cc.Flags = CC_FULLOPEN | CC_RGBINIT | CC_ENABLEHOOK;
 	cc.lpfnHook = static_cast<LPCCHOOKPROC>(DarkMode::HookDlgProc);
-	if( !::ChooseColor( &cc ) ){
+	if (!Comdlg32::getInstance()->ChooseColorW(&cc)) {
 		return FALSE;
 	}
 	*pColor = cc.rgbResult;

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -62,7 +62,8 @@ public:
 	ElementType& operator[](size_t nIndex) noexcept
 	{
 		assert(nIndex<MAX_SIZE);
-		assert_warning(nIndex<m_nCount);
+		assert_warning(0 <= m_nCount);
+		assert_warning(0 == m_nCount || nIndex < size_t(m_nCount));
 		return m_aElements[nIndex];
 	}
 	constexpr const ElementType& operator[](size_t nIndex) const

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -62,6 +62,8 @@ struct Comdlg32 : public TSakuraSingleton<Comdlg32> {
 	virtual BOOL PrintDlgW(
 		_Inout_ LPPRINTDLGW pPD
 	) const;
+
+	std::wstring CommDlgExtendedErrorString() const;
 };
 
 //クリップボード

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -37,6 +37,33 @@ struct User32 : public TSakuraSingleton<User32>
 	) const;
 };
 
+//! Comdlg32.dll呼出をテスト可能にするDIっぽいもの
+struct Comdlg32 : public TSakuraSingleton<Comdlg32> {
+	virtual ~Comdlg32() = default;
+
+	virtual BOOL ChooseColorW(
+		LPCHOOSECOLORW pCc
+	) const;
+
+	virtual BOOL ChooseFontW(
+		LPCHOOSEFONTW pCf
+	) const;
+
+	virtual DWORD CommDlgExtendedError() const;
+
+	virtual BOOL GetOpenFileNameW(
+		LPOPENFILENAMEW pOfn
+	) const;
+
+	virtual BOOL GetSaveFileNameW(
+		LPOPENFILENAMEW pOfn
+	) const;
+
+	virtual BOOL PrintDlgW(
+		_Inout_ LPPRINTDLGW pPD
+	) const;
+};
+
 //クリップボード
 bool SetClipboardText( HWND hwnd, const WCHAR* pszText, int nLength ); //!< クリープボードにText形式でコピーする。UNICODE版。nLengthは文字単位。
 BOOL IsDataAvailable( LPDATAOBJECT pDataObject, CLIPFORMAT cfFormat );

--- a/sakura_core/util/os.h
+++ b/sakura_core/util/os.h
@@ -35,6 +35,16 @@ struct User32 : public TSakuraSingleton<User32>
 		_In_ UINT uType,
 		_In_ WORD wLanguageId
 	) const;
+
+	virtual BOOL TrackPopupMenu(
+		_In_ HMENU hMenu,
+		_In_ UINT uFlags,
+		_In_ int x,
+		_In_ int y,
+		_Reserved_ int nReserved,
+		_In_ HWND hWnd,
+		_Reserved_ CONST RECT* prcRect
+	) const;
 };
 
 //! Comdlg32.dll呼出をテスト可能にするDIっぽいもの

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -580,24 +580,15 @@ BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool Fixed
 	cf.hInstance = GetModuleHandleW(nullptr);
 	if (!Comdlg32::getInstance()->ChooseFontW(&cf)) {
 #ifdef _DEBUG
-		DWORD nErr;
-		nErr = CommDlgExtendedError();
-		switch( nErr ){
-		case CDERR_FINDRESFAILURE:	MYTRACE( L"CDERR_FINDRESFAILURE \n" );	break;
-		case CDERR_INITIALIZATION:	MYTRACE( L"CDERR_INITIALIZATION \n" );	break;
-		case CDERR_LOCKRESFAILURE:	MYTRACE( L"CDERR_LOCKRESFAILURE \n" );	break;
-		case CDERR_LOADRESFAILURE:	MYTRACE( L"CDERR_LOADRESFAILURE \n" );	break;
-		case CDERR_LOADSTRFAILURE:	MYTRACE( L"CDERR_LOADSTRFAILURE \n" );	break;
-		case CDERR_MEMALLOCFAILURE:	MYTRACE( L"CDERR_MEMALLOCFAILURE\n" );	break;
-		case CDERR_MEMLOCKFAILURE:	MYTRACE( L"CDERR_MEMLOCKFAILURE \n" );	break;
-		case CDERR_NOHINSTANCE:		MYTRACE( L"CDERR_NOHINSTANCE \n" );		break;
-		case CDERR_NOHOOK:			MYTRACE( L"CDERR_NOHOOK \n" );			break;
-		case CDERR_NOTEMPLATE:		MYTRACE( L"CDERR_NOTEMPLATE \n" );		break;
-		case CDERR_STRUCTSIZE:		MYTRACE( L"CDERR_STRUCTSIZE \n" );		break;
-		case CFERR_MAXLESSTHANMIN:	MYTRACE( L"CFERR_MAXLESSTHANMIN \n" );	break;
-		case CFERR_NOFONTS:			MYTRACE( L"CFERR_NOFONTS \n" );			break;
-		default:
-			break;
+		std::wstring name;
+		try {
+			name = Comdlg32::getInstance()->CommDlgExtendedErrorString();
+		}
+		catch (const std::out_of_range&) {
+			// 不明なエラー
+		}
+		if (!name.empty()) {
+			TRACE("%s \n", std::data(name));
 		}
 #endif
 		return FALSE;

--- a/sakura_core/util/shell.cpp
+++ b/sakura_core/util/shell.cpp
@@ -31,6 +31,11 @@ BOOL Shell32::ShellExecuteExW(SHELLEXECUTEINFOW* pExecInfo) const
 	return ::ShellExecuteExW(pExecInfo);
 }
 
+BOOL Comdlg32::ChooseFontW(LPCHOOSEFONTW pCf) const
+{
+	return ::ChooseFontW(pCf);
+}
+
 BOOL SelectDir(HWND hWnd, const std::wstring& title, const std::filesystem::path& initialDirectory, WCHAR* strFolderName, size_t nMaxCount)
 {
 	return SelectDir(hWnd, title, initialDirectory, std::span(strFolderName, nMaxCount));
@@ -573,7 +578,7 @@ BOOL MySelectFont( LOGFONT* plf, INT* piPointSize, HWND hwndDlgOwner, bool Fixed
 	cf.lpLogFont = plf;
 	cf.lpfnHook = static_cast<LPCFHOOKPROC>(DarkMode::HookDlgProc);
 	cf.hInstance = GetModuleHandleW(nullptr);
-	if( !ChooseFont( &cf ) ){
+	if (!Comdlg32::getInstance()->ChooseFontW(&cf)) {
 #ifdef _DEBUG
 		DWORD nErr;
 		nErr = CommDlgExtendedError();

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -365,6 +365,16 @@ void SetUpDownPos(HWND hWndDlg, int nIDDlgItem, WORD pos)
 	::SendDlgItemMessageW(hWndDlg, nIDDlgItem, UDM_SETPOS, 0L, LPARAM(pos));
 }
 
+/*!
+ * @brief ウィンドウのテキストを設定する
+ */
+bool SetWindowTextW(HWND hWnd, std::wstring_view text)
+{
+	assert(L'\0' == *(text.data() + text.size()));
+
+	return ::SetWindowTextW(hWnd, std::data(text));
+}
+
 } // namespace apiwrap
 
 /*!

--- a/sakura_core/util/window.cpp
+++ b/sakura_core/util/window.cpp
@@ -350,6 +350,15 @@ bool SetDlgItemTextW(HWND hWndDlg, int nIDDlgItem, std::wstring_view text)
 }
 
 /*!
+ * @brief エディットコントロールに入力文字数を設定する
+ */
+void LimitEditText(HWND hWndDlg, int nIDDlgItem, std::span<WCHAR> buffer)
+{
+	const auto cchLimit = std::size(buffer) - 1;
+	::SendDlgItemMessageW(hWndDlg, nIDDlgItem, EM_LIMITTEXT, WPARAM(cchLimit), 0L);
+}
+
+/*!
  * @brief トラックバーの現在位置を変更する
  */
 void SetTrackBarPos(HWND hWndDlg, int nIDDlgItem, WORD pos, bool bRedraw)

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -139,6 +139,7 @@ WORD	GetTrackBarPos(HWND hWndDlg, int nIDDlgItem);
 int		GetUpDownPos(HWND hWndDlg, int nIDDlgItem);
 bool	IsDlgButtonChecked(HWND hDlg, int nIDButton);
 bool	IsDlgItemEnabled(HWND hWndDlg, int nIDDlgItem);
+void	LimitEditText(HWND hWndDlg, int nIDDlgItem, std::span<WCHAR> buffer);
 void	SetTrackBarPos(HWND hWndDlg, int nIDDlgItem, WORD pos, bool bRedraw = true);
 void	SetUpDownPos(HWND hWndDlg, int nIDDlgItem, WORD pos);
 

--- a/sakura_core/util/window.h
+++ b/sakura_core/util/window.h
@@ -148,6 +148,7 @@ SGetTextResult	GetDlgItemTextW(HWND hWndDlg, int nIDDlgItem, std::span<WCHAR> bu
 SGetTextResult	GetWindowTextW(HWND hWnd);
 
 bool	SetDlgItemTextW(HWND hWndDlg, int nIDDlgItem, std::wstring_view text);
+bool	SetWindowTextW(HWND hWnd, std::wstring_view text);
 
 /*!
  * @brief トラックバーのデータ範囲を変更する

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -125,6 +125,8 @@ CEditView::CEditView( void )
 , m_cTextDrawer(this)			// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 , m_cCommander(this)			// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 {
+	// 設定に従いフォント情報を初期化する
+	SetFont();
 }
 
 // 2007.10.23 kobake コンストラクタ内の処理をすべてCreateに移しました。(初期化処理が不必要に分散していたため)
@@ -310,6 +312,8 @@ BOOL CEditView::Create(
 	/* スクロールバー作成 */
 	CreateScrollBar();		// 2006.12.19 ryoji
 
+	// 設定に従いフォント情報を初期化する
+	// (分割ビューのために残しておく)
 	SetFont();
 
 	if( bShow ){
@@ -1066,9 +1070,10 @@ void CEditView::OnKillFocus( void )
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 /* フォントの変更 */
-void CEditView::SetFont( void )
+void CEditView::SetFont()
 {
-	HDC hdc = ::GetDC( GetHwnd() );
+	using MemDcHolder = cxx::ResourceHolder<&::DeleteDC>;
+	MemDcHolder hdc = ::CreateCompatibleDC(nullptr);
 
 	// メトリクス更新
 	if( m_bMiniMap ){
@@ -1077,7 +1082,7 @@ void CEditView::SetFont( void )
 		GetTextMetrics().Update(hdc, GetFontset().GetFontHan(), DpiScaleY(m_pTypeData->m_nLineSpace), DpiScaleX(m_pTypeData->m_nColumnSpace));
 	}
 
-	::ReleaseDC( GetHwnd(), hdc );
+	hdc = nullptr;
 
 	// エリア情報を更新
 	GetTextArea().UpdateAreaMetrics();

--- a/sakura_core/view/CEditView.cpp
+++ b/sakura_core/view/CEditView.cpp
@@ -125,6 +125,10 @@ CEditView::CEditView( void )
 , m_cTextDrawer(this)			// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 , m_cCommander(this)			// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 {
+	constexpr bool bMiniMap = false;	// TODO: パラメーターで受け取るようにしたい
+
+	m_bMiniMap = bMiniMap;	// SetFont内で使用するため、初期化しておく必要がある
+
 	// 設定に従いフォント情報を初期化する
 	SetFont();
 }

--- a/sakura_core/view/CEditView.h
+++ b/sakura_core/view/CEditView.h
@@ -546,7 +546,7 @@ public:
 	TOGGLE_WRAP_ACTION GetWrapMode( CKetaXInt* newKetas );
 	void SmartIndent_CPP(wchar_t wcChar);	/* C/C++スマートインデント処理 */
 	/* コマンド操作 */
-	void SetFont( void );										/* フォントの変更 */
+	void	SetFont();										/* フォントの変更 */
 	void SplitBoxOnOff(BOOL bVert, BOOL bHorz, BOOL bSizeBox);						/* 縦・横の分割ボックス・サイズボックスのＯＮ／ＯＦＦ */
 
 //	2001/06/18 asa-o

--- a/sakura_lang/sakura_lang.sln
+++ b/sakura_lang/sakura_lang.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.14.36511.14
-MinimumVisualStudioVersion = 10.0.40219.1
+MinimumVisualStudioVersion = 16.0.0.0
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sakura_lang_en_US", "sakura_lang_en_US.vcxproj", "{7A6D0F29-E560-4985-835B-5F92A08EB242}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sakura_lang_zh_CN", "sakura_lang_zh_CN.vcxproj", "{DFC3366C-4D94-46D3-AB74-0D08BA00E52C}"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,10 +13,16 @@ sonar.sources=.
 sonar.exclusions=\
 	build/**,\
 	externals/**,\
+	sakura_core/**/*.txt,\
 	src/main/resources/**,\
 	src/test/**,\
 	tools/vcpkg/**,\
+	help/**/*.ico,\
 	help/**/*.png,\
+	installer/**/*.bmp,\
+	installer/**/*.ico,\
+	installer/**/*.zip,\
+	sakura_core/**/*.txt,\
 	tests*-*.xml
 
 sonar.python.version=3

--- a/src/main/cpp/cxx/load_string.cpp
+++ b/src/main/cpp/cxx/load_string.cpp
@@ -1,5 +1,5 @@
 ﻿/*
-	Copyright (C) 2025, Sakura Editor Organization
+	Copyright (C) 2025-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
  */
@@ -26,6 +26,31 @@ std::wstring_view load_string(UINT id, const std::optional<HMODULE>& optModule)
 		throw std::invalid_argument("string resource id should be in WORD range!");
 	}
 
+	// 文字列リソースを検索して参照を返す
+#if 1
+	// リソースを格納するモジュールを特定する(省略時はアプリリソースから取得)
+	const auto hModule = optModule.value_or(::GetModuleHandleW(nullptr));
+
+	// 文字列の先頭を受け取るためのポインター
+	LPCWSTR lpBuffer = nullptr;
+
+	// バッファサイズに0を指定してLoadStringWを呼び出すと、文字列の長さが返る
+	const auto cchResStr = ::LoadStringW(hModule, id, LPWSTR(&lpBuffer), 0);
+
+#if 0 // 新実装では↓の処理を行わない
+	if (!cchResStr) {
+		throw std::out_of_range("missing resource!");
+	}
+#endif
+
+	// 先頭ポインターと文字列長で文字列参照を構築して返す
+	return std::wstring_view(lpBuffer, cchResStr);
+
+#else
+	// 過去実装（LoadStringWの内部実装を模倣）では、不正な言語DLLを読み込んだときの例外が分かりづらいので辞める
+
+	// 単純削除だとうっかり復活させる懸念があるため、あえて残しておく
+
 	// RT_STRINGリソースのブロック番号を計算
 	const auto block = WORD((id >> 4) + 1);
 	const auto index = id & 0xF;
@@ -51,6 +76,8 @@ std::wstring_view load_string(UINT id, const std::optional<HMODULE>& optModule)
 		RT_STRING,
 		optModule
 	);
+
+#endif
 }
 
 /*!

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
@@ -60,6 +60,40 @@ bool IsTitleMatched(_In_ HWND hWnd, _In_opt_ LPCWSTR pTitle, std::wstring_view e
 
 namespace dialog {
 
+struct FindFileNameEditContext {
+	HWND found = nullptr;
+};
+
+BOOL CALLBACK FindFileNameEditProc(HWND hWndCtl, LPARAM lParam)
+{
+	auto* pCtx = std::bit_cast<FindFileNameEditContext*>(lParam);
+
+	if (1001 != ::GetDlgCtrlID(hWndCtl)) {
+		return TRUE;
+	}
+
+	if (const auto className = window::GetClassNameW(hWndCtl);
+		WC_EDIT == className) {
+		pCtx->found = hWndCtl;
+		return FALSE;   // 検索終了
+	}
+
+	return TRUE;
+}
+
+HWND FindFileNameEdit(HWND hFileDialog)
+{
+	FindFileNameEditContext ctx{};
+
+	::EnumChildWindows(
+		hFileDialog,
+		&FindFileNameEditProc,
+		LPARAM(&ctx)
+	);
+
+	return ctx.found;
+}
+
 bool ModalDialogCloser::ExecuteAction(HWND hWnd) noexcept
 {
 	Me* entry = nullptr;

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
@@ -189,7 +189,8 @@ LRESULT CALLBACK ModalDialogCloser::CBTProc(
 			if (const auto found = std::ranges::find_if(gm_Entries, func);
 				found != gm_Entries.end())
 			{
-				const auto& entry = gm_Entries.front();
+				// 見つかったcloserを取り出す
+				const auto entry = *found;
 
 				// closerの状態を更新する
 				entry->m_State = State::Created;

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
@@ -92,11 +92,6 @@ bool ModalDialogCloser::ExecuteAction(HWND hWnd) noexcept
 	return false;
 }
 
-void CALLBACK ModalDialogCloser::TimerProc(HWND hWnd, UINT, UINT_PTR idEvent, DWORD)
-{
-	ExecuteAction(hWnd);
-}
-
 /*!
  * CBTフックプロシージャ
  *
@@ -152,6 +147,11 @@ LRESULT CALLBACK ModalDialogCloser::CBTProc(
 		}
 	}
 	return ::CallNextHookEx(nullptr, nCode, wParam, lParam);
+}
+
+void CALLBACK ModalDialogCloser::TimerProc(HWND hWnd, UINT, UINT_PTR idEvent, DWORD)
+{
+	ExecuteAction(hWnd);
 }
 
 ModalDialogCloser::ModalDialogCloser(

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.cpp
@@ -9,6 +9,7 @@
 
 #include "cxx/load_string.hpp"
 #include "doc/CDocListener.h"
+#include "util/window.h"
 
 namespace window {
 
@@ -37,6 +38,24 @@ bool IsDialog(_In_ HWND hWnd, _In_opt_ LPCWSTR pClassName)
 	return DIALOG_CLASS == window::GetClassNameW(hWnd);
 }
 
+bool IsTitleMatched(_In_ HWND hWnd, _In_opt_ LPCWSTR pTitle, std::wstring_view expected)
+{
+	std::wstring_view title;
+
+	std::wstring buffer;
+	if (!pTitle || IS_INTRESOURCE(pTitle)) {
+		if (auto ret = apiwrap::GetWindowTextW(hWnd)) {
+			buffer = std::move(ret.buffer);
+			title = buffer;
+		}
+	}
+	else {
+		title = pTitle;
+	}
+
+	return title == expected;
+}
+
 } // namespace window
 
 namespace dialog {
@@ -45,6 +64,10 @@ bool ModalDialogCloser::ExecuteAction(HWND hWnd) noexcept
 {
 	Me* entry = nullptr;
 	if (hWnd) {
+		if (!::IsWindowVisible(hWnd)) return false;
+
+		if (!::IsWindowEnabled(hWnd)) return false;
+
 		std::unique_lock lock{ gm_Mutex };
 
 		const auto found = gm_HwndMap.find(hWnd);
@@ -65,8 +88,6 @@ bool ModalDialogCloser::ExecuteAction(HWND hWnd) noexcept
 			entry->m_Action(hWnd);
 
 			entry->m_State = State::Handled;
-
-			return true;
 		}
 	}
 	catch (...) {
@@ -89,7 +110,15 @@ bool ModalDialogCloser::ExecuteAction(HWND hWnd) noexcept
 		}
 	}
 
-	return false;
+	if (hWnd) {
+		std::unique_lock lock{ gm_Mutex };
+
+		if (gm_Entries.empty() && gm_HwndMap.empty()) {
+			gm_CbtHook = nullptr;
+		}
+	}
+
+	return entry && State::Handled == entry->m_State;
 }
 
 /*!
@@ -116,10 +145,19 @@ LRESULT CALLBACK ModalDialogCloser::CBTProc(
 
 		if (!gm_Entries.empty())
 		{
-			const auto& entry = gm_Entries.front();
-			if (const auto pDialogTitle = pCreateWnd->lpcs->lpszName;
-				!entry->m_DialogTitle.has_value() ||
-				(pDialogTitle && !IS_INTRESOURCE(pDialogTitle) && *entry->m_DialogTitle == pDialogTitle)) {
+			// タイトルが一致するcloserを探す。タイトルが指定されていない場合は最初のエントリを使う。
+			const auto pDialogTitle = pCreateWnd->lpcs->lpszName;
+			const auto func = [hWnd, pDialogTitle]( const auto& entry ) {
+				return !entry->m_DialogTitle.has_value()
+					|| window::IsTitleMatched( hWnd, pDialogTitle, *entry->m_DialogTitle );
+			};
+
+			if (const auto found = std::ranges::find_if(gm_Entries, func);
+				found != gm_Entries.end())
+			{
+				const auto& entry = gm_Entries.front();
+
+				// closerの状態を更新する
 				entry->m_State = State::Created;
 				entry->m_hWnd = hWnd;
 
@@ -127,26 +165,21 @@ LRESULT CALLBACK ModalDialogCloser::CBTProc(
 				gm_HwndMap.try_emplace(hWnd, entry);
 
 				// タイトル監視エントリを除去する
-				gm_Entries.pop_front();
+				gm_Entries.erase(found);
 
 				// タイマーをセットする
-				entry->m_TimerActive = 0 != ::SetTimer(hWnd, TIMER_ID_FIRST_IDLE, FALLBACK_DELAY_MILLIS, &TimerProc);
-			}
-		}
-	}
-	else if (HCBT_ACTIVATE == nCode)
-	{
-		if (ExecuteAction(hWnd)) {
-			std::unique_lock lock{ gm_Mutex };
-
-			if (gm_Entries.empty() && gm_HwndMap.empty()) {
-				const auto ret = ::CallNextHookEx(nullptr, nCode, wParam, lParam);
-				CbtHookHolder hook = std::move(gm_CbtHook);
-				return ret;
+				entry->m_TimerActive = 0 != ::SetTimer(hWnd, TIMER_ID_FIRST_IDLE, SNOOZE_INTERVAL, &TimerProc);
 			}
 		}
 	}
 	return ::CallNextHookEx(nullptr, nCode, wParam, lParam);
+}
+
+bool ModalDialogCloser::IsHandled() noexcept
+{
+	std::unique_lock lock{ gm_Mutex };
+
+	return !gm_CbtHook;
 }
 
 void CALLBACK ModalDialogCloser::TimerProc(HWND hWnd, UINT, UINT_PTR idEvent, DWORD)

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
@@ -33,7 +33,7 @@ private:
 	using Me = ModalDialogCloser;
 
 	static constexpr UINT TIMER_ID_FIRST_IDLE = 9999;
-	static constexpr UINT FALLBACK_DELAY_MILLIS = 500;
+	static constexpr UINT SNOOZE_INTERVAL = 10;
 
 	enum class State {
 		Pending,
@@ -62,6 +62,8 @@ private:
 	static void CALLBACK TimerProc(HWND hWnd, UINT, UINT_PTR idEvent, DWORD);
 
 public:
+	static bool IsHandled() noexcept;
+
 	ModalDialogCloser(const std::optional<std::wstring>& optTitle, const std::function<void(HWND)>& action);
 
 	ModalDialogCloser(int dialogTitleResourceId, const std::function<void(HWND)>& action);

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
@@ -9,6 +9,8 @@
 #include "cxx/ResourceHolder.hpp"
 #include "dlg/CDlgOpenFile.h"
 
+#include "CSelectLang.h"
+
 #include <deque>
 #include <exception>
 #include <functional>
@@ -24,7 +26,7 @@ struct ModalDialogCloserTestPeer;
  *
  * WindowsHookを使ってダイアログの初期表示を検出して閉じるもの。
  */
-class ModalDialogCloser final {
+class ModalDialogCloser {
 private:
 	friend struct ModalDialogCloserTestPeer;
 
@@ -83,6 +85,37 @@ private:
 	std::exception_ptr m_Exception;
 	DWORD m_HookError = ERROR_SUCCESS;
 	bool m_TimerActive = false;
+};
+
+/*!
+ * プロパティシートテスト用のクラス
+ */
+class PropertySheetCloser : public ModalDialogCloser
+{
+public:
+	explicit PropertySheetCloser(const std::function<void(HWND, HWND)>& action)
+		: ModalDialogCloser(std::nullopt, [action] (HWND hWndDlg) {
+			// アクティブなプロパティーシートのハンドルを取得する 
+			const auto hWndPage = HWND(::SendMessageW(hWndDlg, PSM_GETCURRENTPAGEHWND, 0L, 0L));
+
+			// WM_HELPを送信してヘルプ表示処理を空振りさせる
+			HELPINFO hi{};
+			::SendMessageW(hWndPage, WM_HELP, 0L, LPARAM(&hi));
+
+			// コンテキストメニュー表示を空振りさせる
+			FORWARD_WM_CONTEXTMENU(hWndPage, nullptr, 0L, 0L, ::SendMessageW);
+
+			action(hWndDlg, hWndPage);
+		})
+	{
+	}
+
+	explicit PropertySheetCloser(int button = PSBTN_CANCEL)
+		: PropertySheetCloser([button] (HWND hWndDlg, HWND) {
+			::SendMessageW(hWndDlg, PSM_PRESSBUTTON, button, 0L);
+		})
+	{
+	}
 };
 
 } // namespace dialog

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
@@ -16,6 +16,9 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
 
 namespace dialog {
 
@@ -69,7 +72,7 @@ public:
 	ModalDialogCloser(const std::optional<std::wstring>& optTitle, const std::function<void(HWND)>& action);
 
 	ModalDialogCloser(int dialogTitleResourceId, const std::function<void(HWND)>& action);
-	ModalDialogCloser(const std::optional<std::wstring>& optTitle, int nIDDlgItem = IDCANCEL);
+	explicit ModalDialogCloser(const std::optional<std::wstring>& optTitle = std::nullopt, int nIDDlgItem = IDCANCEL);
 
 	ModalDialogCloser(const Me&) = delete;
 	Me& operator=(const Me&) = delete;

--- a/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
+++ b/src/test/cpp/tests1/dlg/ModalDialogCloser.hpp
@@ -58,8 +58,8 @@ private:
 		_In_ LPARAM lParam
 	);
 
-	static void CALLBACK TimerProc(HWND hWnd, UINT, UINT_PTR idEvent, DWORD);
 	static bool ExecuteAction(HWND hWnd) noexcept;
+	static void CALLBACK TimerProc(HWND hWnd, UINT, UINT_PTR idEvent, DWORD);
 
 public:
 	ModalDialogCloser(const std::optional<std::wstring>& optTitle, const std::function<void(HWND)>& action);

--- a/src/test/cpp/tests1/test-ccommandline.cpp
+++ b/src/test/cpp/tests1/test-ccommandline.cpp
@@ -21,6 +21,8 @@
 
 using namespace std::literals::string_view_literals;
 
+std::vector<std::wstring_view> SplitLegacyCommandLine(std::wstring_view s);
+
 bool operator == (const EditInfo& lhs, const EditInfo& rhs) noexcept;
 bool operator != (const EditInfo& lhs, const EditInfo& rhs) noexcept;
 
@@ -43,6 +45,55 @@ std::wstring GetLocalPath(const std::wstring_view& filename)
 	::wcscpy_s(pszResolvedPath, cchBufSize, filename.data());
 	CSakuraEnvironment::ResolvePath(pszResolvedPath);
 	return pszResolvedPath;
+}
+
+/*!
+ * @brief コマンドライン文字列を分割する関数のテスト
+ */
+TEST(SplitLegacyCommandLine, test001)
+{
+	const auto args1 = SplitLegacyCommandLine(LR"(test.exe arg1 -arg2="test arg" "the ""3rd"" arg" finalArg)");
+	EXPECT_THAT(args1[0], StrEq(LR"(test.exe)"));
+	EXPECT_THAT(args1[1], StrEq(LR"(arg1)"));
+	EXPECT_THAT(args1[2], StrEq(LR"(-arg2="test arg")"));
+	EXPECT_THAT(args1[3], StrEq(LR"("the ""3rd"" arg")"));
+	EXPECT_THAT(args1[4], StrEq(LR"(finalArg)"));
+
+	const auto args2 = SplitLegacyCommandLine(L"arg1 arg2 ");
+	EXPECT_THAT(args2, ::testing::SizeIs(2));
+	EXPECT_THAT(args2[0], StrEq(L"arg1"));
+	EXPECT_THAT(args2[1], StrEq(L"arg2"));
+
+	const auto args3 = SplitLegacyCommandLine(L"   ");
+	EXPECT_THAT(args3, ::testing::IsEmpty());
+
+	// "C:\path\to\file" の \ はリテラルとして扱われ、トークン全体が1引数になる
+	const auto args4 = SplitLegacyCommandLine(LR"(exe "C:\path\to\file")");
+	EXPECT_THAT(args4, ::testing::SizeIs(2));
+	EXPECT_THAT(args4[0], StrEq(L"exe"));
+	EXPECT_THAT(args4[1], StrEq(LR"("C:\path\to\file")"));
+
+	// "te\"st" は \" をエスケープとして扱い、トークン全体が1引数になる
+	const auto args5 = SplitLegacyCommandLine(LR"(exe "te\"st")");
+	EXPECT_THAT(args5, ::testing::SizeIs(2));
+	EXPECT_THAT(args5[0], StrEq(L"exe"));
+	EXPECT_THAT(args5[1], StrEq(LR"("te\"st")"));
+
+	// 閉じ引用符なし → 残り全部を最後の引数として扱う
+	const auto args6 = SplitLegacyCommandLine(L"arg1 \"open here arg3");
+	EXPECT_THAT(args6, ::testing::SizeIs(2));
+	EXPECT_THAT(args6[0], StrEq(L"arg1"));
+	EXPECT_THAT(args6[1], StrEq(L"\"open here arg3"));
+
+	EXPECT_THAT( cxx::iequals(L"abc", L"abc"), IsTrue());	// ケース含め一致
+	EXPECT_THAT( cxx::iequals(L"ABC", L"ABC"), IsTrue());	// ケース含め一致
+	EXPECT_THAT( cxx::iequals(L"abc", L"ABC"), IsTrue());	// ケース違い
+	EXPECT_THAT( cxx::iequals(L"ABC", L"abc"), IsTrue());	// ケース違い
+	EXPECT_THAT( cxx::iequals(L"AbC", L"aBc"), IsTrue());	// ケース違い
+
+	EXPECT_THAT( cxx::iequals(L"AbC", L"def"), IsFalse());
+	EXPECT_THAT( cxx::iequals(L"AbC", L"ab"), IsFalse());
+	EXPECT_THAT( cxx::iequals(L"AbC", std::wstring_view{ L"abc", 2 }), IsFalse());
 }
 
 /*!

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -9,7 +9,11 @@
 
 #include "window/EditorTestSuite.hpp"
 
+#include "eval_outputs.hpp"
+
 #include <fstream>
+
+void CallDlgOpenFail();
 
 namespace uia {
 
@@ -218,7 +222,7 @@ TEST_P(FileDialogTest, DoModalOpenDlg101)
 			.Times(1)
 			.WillOnce(Return(FALSE));
 		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
-			.Times(1)
+			.Times(2)
 			.WillRepeatedly(Return(0));
 	}
 
@@ -249,7 +253,7 @@ TEST_P(FileDialogTest, DoModalOpenDlg102)
 			.Times(1)
 			.WillOnce(Return(FALSE));
 		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
-			.Times(1)
+			.Times(2)
 			.WillRepeatedly(Return(0));
 	}
 
@@ -328,7 +332,7 @@ TEST_P(FileDialogTest, DoModalSaveDlg101)
 			.Times(1)
 			.WillOnce(Return(FALSE));
 		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
-			.Times(1)
+			.Times(2)
 			.WillRepeatedly(Return(0));
 	}
 
@@ -410,7 +414,7 @@ TEST_P(FileDialogTest, GetOpenFileName101)
 			.Times(1)
 			.WillOnce(Return(FALSE));
 		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
-			.Times(1)
+			.Times(2)
 			.WillRepeatedly(Return(0));
 	}
 
@@ -441,8 +445,9 @@ TEST_P(FileDialogTest, GetOpenFileName102)
 			.WillOnce(Return(FALSE))
 			.WillOnce(Return(FALSE));
 		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
-			.Times(1)
-			.WillOnce(Return(FNERR_INVALIDFILENAME));
+			.Times(2)
+			.WillOnce(Return(FNERR_INVALIDFILENAME))
+			.WillOnce(Return(0));
 	}
 
 	testAction();
@@ -532,8 +537,9 @@ TEST_P(FileDialogTest, GetSaveFileName101)
 			.WillOnce(Return(FALSE))
 			.WillOnce(Return(FALSE));
 		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
-			.Times(1)
-			.WillOnce(Return(FNERR_INVALIDFILENAME));
+			.Times(2)
+			.WillOnce(Return(FNERR_INVALIDFILENAME))
+			.WillOnce(Return(0));
 	}
 
 	testAction();
@@ -682,5 +688,93 @@ TEST_F(SelectFileTest, SelectFile101)
 
 	EXPECT_THAT(CDlgOpenFile::SelectFile(hWndDlg, hWndFolder, L"*.ini", resolvePath, EFITER_NONE), IsFalse());
 }
+
+/*!
+ * @brief DlgOpenFailテストのパラメーター
+ *
+ * @param code CommDlgのエラーコード
+ * @param name CommDlgのエラー識別子
+ */
+using DlgOpenFailTestParam = std::tuple<DWORD, std::wstring_view>;
+
+/*!
+ * DlgOpenFailテストのためのフィクスチャクラス
+ */
+struct DlgOpenFailTest : public ::testing::TestWithParam<DlgOpenFailTestParam> {
+
+	/*!
+	 * テストが実行される直前に毎回呼ばれる関数
+	 */
+	void SetUp() override
+	{
+		User32::setInstance<MockUser32>();
+		Comdlg32::setInstance<MockComdlg32>();
+	}
+
+	/*!
+	 * テストが実行された直後に毎回呼ばれる関数
+	 */
+	void TearDown() override
+	{
+		Comdlg32::resetInstance();
+		User32::resetInstance();
+	}
+};
+
+/*!
+ * @brief DlgOpenFailのテスト
+ */
+TEST_P(DlgOpenFailTest, test)
+{
+	const auto code = std::get<0>(GetParam());
+	const auto name = std::get<1>(GetParam());
+
+	const auto expected = std::format(L"ダイアログが開けません。\n\nエラー:{:<21s}", name);
+
+	auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+	EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+		.Times(1)
+		.WillOnce(Return(code));
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(expected), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
+
+	CallDlgOpenFail();
+}
+
+#pragma push_macro("CD_ERR_ENTRY")
+
+#define CD_ERR_ENTRY(code)	DlgOpenFailTestParam{ code, L ## #code }
+
+/*!
+ * @brief パラメータテストをインスタンス化する
+ */
+INSTANTIATE_TEST_SUITE_P(CommDlgCodes
+	, DlgOpenFailTest
+	, ::testing::Values(
+		CD_ERR_ENTRY(CDERR_DIALOGFAILURE),
+		CD_ERR_ENTRY(CDERR_FINDRESFAILURE),
+		CD_ERR_ENTRY(CDERR_NOHINSTANCE),
+		CD_ERR_ENTRY(CDERR_INITIALIZATION),
+		CD_ERR_ENTRY(CDERR_NOHOOK),
+		CD_ERR_ENTRY(CDERR_LOCKRESFAILURE),
+		CD_ERR_ENTRY(CDERR_NOTEMPLATE),
+		CD_ERR_ENTRY(CDERR_LOADRESFAILURE),
+		CD_ERR_ENTRY(CDERR_STRUCTSIZE),
+		CD_ERR_ENTRY(CDERR_LOADSTRFAILURE),
+		CD_ERR_ENTRY(FNERR_BUFFERTOOSMALL),
+		CD_ERR_ENTRY(CDERR_MEMALLOCFAILURE),
+		CD_ERR_ENTRY(FNERR_INVALIDFILENAME),
+		CD_ERR_ENTRY(CDERR_MEMLOCKFAILURE),
+		CD_ERR_ENTRY(FNERR_SUBCLASSFAILURE),
+
+		// 未定義のエラーコードは以下固定値。
+		DlgOpenFailTestParam{ 0x6000, L"UNKNOWN_ERRORCODE" }
+	)
+);
+
+#pragma pop_macro("CD_ERR_ENTRY")
 
 } // namespace dialog

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -19,7 +19,7 @@ cxx::com_pointer<IUIAutomationElement> GetFocusedElement(
 
 } // namespace uia
 
-namespace window {
+namespace dialog {
 
 /*!
  * @brief ファイルダイアログテストのパラメーター
@@ -43,6 +43,8 @@ struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, pu
 		SetUpUiaTestSuite();
 
 		SetUpEditor();
+
+		Comdlg32::setInstance<MockComdlg32>();
 	}
 
 	/*!
@@ -50,6 +52,8 @@ struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, pu
 	 */
 	static void TearDownTestSuite()
 	{
+		Comdlg32::resetInstance();
+
 		TearDownEditor();
 
 		TearDownUiaTestSuite();
@@ -60,6 +64,8 @@ struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, pu
 	 */
 	void SetUp() override
 	{
+		MockComdlg32::gm_Files.clear();
+
 		// テスト設定を反映する
 		GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog = GetParam();
 
@@ -140,6 +146,15 @@ TEST_P(FileDialogTest, Create003_ManyFiltersy)
  */
 TEST_P(FileDialogTest, DoModalOpenDlg001)
 {
+	std::jthread t;
+
+	const auto testAction = [] () {
+		SLoadInfo loadInfo{};
+		std::vector<std::wstring> files;
+		bool bOptions = true;
+		CDlgOpenFile::getInstance()->DoModalOpenDlg(&loadInfo, &files, bOptions);
+	};
+
 	const auto path = GetExeFileName().replace_filename(L"test.txt");
 
 	std::error_code ec;
@@ -149,22 +164,31 @@ TEST_P(FileDialogTest, DoModalOpenDlg001)
 	std::ofstream ofs{ path };
 	ofs.close();
 
-	// 表示されたファイルダイアログを閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(GetOpenFileNameDialogTitle(), [path] (IUIAutomation* pUIAutomation, HWND, std::stop_token) {
-		auto pItem = uia::GetFocusedElement(pUIAutomation);
-		ASSERT_THAT(pItem, NotNull());
+	if (GetParam()) {
+		// 表示されたファイルダイアログを閉じるためのスレッドを起動する
+		t = StartDialogCloser(GetOpenFileNameDialogTitle(), [path] (IUIAutomation* pUIAutomation, HWND, std::stop_token) {
+			auto pItem = uia::GetFocusedElement(pUIAutomation);
+			ASSERT_THAT(pItem, NotNull());
 
-		// ファイル名を入力する
-		EmulateSetValue(pItem, path.c_str());
+			// ファイル名を入力する
+			EmulateSetValue(pItem, path.native());
 
-		// Enterキー押下で閉じる
-		EmulateHitEnter();
-	});
+			// Enterキー押下で閉じる
+			EmulateHitEnter();
+		});
 
-	SLoadInfo loadInfo{};
-	std::vector<std::wstring> files;
-	bool bOptions = true;
-	CDlgOpenFile::getInstance()->DoModalOpenDlg(&loadInfo, &files, bOptions);
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetOpenFileNameW(_))
+			.Times(1)
+			.WillOnce(testing::DoDefault());
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(0);
+
+		MockComdlg32::gm_Files.emplace_back(path.native());
+	}
+
+	testAction();
 
 	// 作成したファイルを削除する
 	std::filesystem::remove(path, ec);
@@ -176,11 +200,29 @@ TEST_P(FileDialogTest, DoModalOpenDlg001)
 TEST_P(FileDialogTest, DoModalOpenDlg101)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(std::nullopt);
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
-	// コマンドコードで、無理矢理動かす
-	const auto hWnd = pcEditWnd->GetHwnd();
-	FORWARD_WM_COMMAND(hWnd, F_FILEOPEN, nullptr, 0, pcEditWnd->DispatchEvent);
+	const auto testAction = [] () {
+		// コマンドコードで、無理矢理動かす
+		const auto hWnd = pcEditWnd->GetHwnd();
+		FORWARD_WM_COMMAND(hWnd, F_FILEOPEN, nullptr, 0, pcEditWnd->DispatchEvent);
+	};
+
+	if (GetParam()) {
+		// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>();
+
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetOpenFileNameW(_))
+			.Times(1)
+			.WillOnce(Return(FALSE));
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(1)
+			.WillRepeatedly(Return(0));
+	}
+
+	testAction();
 }
 
 /*!
@@ -189,11 +231,29 @@ TEST_P(FileDialogTest, DoModalOpenDlg101)
 TEST_P(FileDialogTest, DoModalOpenDlg102)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(std::nullopt);
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
-	SLoadInfo loadInfo{};
-	bool bOptions = false;
-	CDlgOpenFile::getInstance()->DoModalOpenDlg(&loadInfo, nullptr, bOptions);
+	const auto testAction = [] () {
+		SLoadInfo loadInfo{};
+		bool bOptions = false;
+		CDlgOpenFile::getInstance()->DoModalOpenDlg(&loadInfo, nullptr, bOptions);
+	};
+
+	if (GetParam()) {
+		// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>();
+
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetOpenFileNameW(_))
+			.Times(1)
+			.WillOnce(Return(FALSE));
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(1)
+			.WillRepeatedly(Return(0));
+	}
+
+	testAction();
 }
 
 /*!
@@ -201,26 +261,47 @@ TEST_P(FileDialogTest, DoModalOpenDlg102)
  */
 TEST_P(FileDialogTest, DoModalSaveDlg001)
 {
+	std::jthread t;
+
+	const auto testAction = [] () {
+		SSaveInfo saveInfo{};
+		bool bSimpleMode = true;
+		CDlgOpenFile::getInstance()->DoModalSaveDlg(&saveInfo, bSimpleMode);
+	};
+
 	const auto path = GetExeFileName().replace_filename(L"test.txt");
 
 	std::error_code ec;
 	std::filesystem::remove(path, ec);
 
-	// 表示されたファイルダイアログを閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(L"名前を付けて保存", [path](IUIAutomation* pUIAutomation, HWND, std::stop_token) {
-		auto pItem = uia::GetFocusedElement(pUIAutomation);
-		ASSERT_THAT(pItem, NotNull());
+	if (GetParam()) {
+		// 表示されたファイルダイアログを閉じるためのスレッドを起動する
+		t = StartDialogCloser(L"名前を付けて保存", [path](IUIAutomation* pUIAutomation, HWND, std::stop_token) {
+			auto pItem = uia::GetFocusedElement(pUIAutomation);
+			ASSERT_THAT(pItem, NotNull());
 
-		// ファイル名を入力する
-		EmulateSetValue(pItem, path.c_str());
+			// ファイル名を入力する
+			EmulateSetValue(pItem, path.native());
 
-		// Enterキー押下で閉じる
-		EmulateHitEnter();
-	});
+			// Enterキー押下で閉じる
+			EmulateHitEnter();
+		});
 
-	SSaveInfo saveInfo{};
-	bool bSimpleMode = true;
-	CDlgOpenFile::getInstance()->DoModalSaveDlg(&saveInfo, bSimpleMode);
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetSaveFileNameW(_))
+			.Times(1)
+			.WillOnce(testing::DoDefault());
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(0);
+
+		MockComdlg32::gm_Files.emplace_back(path.native());
+	}
+
+	testAction();
+
+	// 保存したファイルを削除する
+	std::filesystem::remove( path, ec );
 }
 
 /*!
@@ -229,11 +310,29 @@ TEST_P(FileDialogTest, DoModalSaveDlg001)
 TEST_P(FileDialogTest, DoModalSaveDlg101)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(std::nullopt);
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
-	// コマンドコードで、無理矢理動かす
-	const auto hWnd = pcEditWnd->GetHwnd();
-	FORWARD_WM_COMMAND(hWnd, F_FILESAVEAS_DIALOG, nullptr, 0, pcEditWnd->DispatchEvent);
+	const auto testAction = [] () {
+		// コマンドコードで、無理矢理動かす
+		const auto hWnd = pcEditWnd->GetHwnd();
+		FORWARD_WM_COMMAND(hWnd, F_FILESAVEAS_DIALOG, nullptr, 0, pcEditWnd->DispatchEvent);
+	};
+
+	if (GetParam()) {
+		// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>();
+
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetSaveFileNameW(_))
+			.Times(1)
+			.WillOnce(Return(FALSE));
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(1)
+			.WillRepeatedly(Return(0));
+	}
+
+	testAction();
 }
 
 /*!
@@ -241,6 +340,13 @@ TEST_P(FileDialogTest, DoModalSaveDlg101)
  */
 TEST_P(FileDialogTest, GetOpenFileName001)
 {
+	std::jthread t;
+
+	const auto testAction = [] () {
+		SFilePath szPath{};
+		CDlgOpenFile::getInstance()->DoModal_GetOpenFileName(szPath, EFilter::EFITER_TEXT);
+	};
+
 	const auto path = GetExeFileName().replace_filename(L"test.txt");
 
 	std::error_code ec;
@@ -250,20 +356,31 @@ TEST_P(FileDialogTest, GetOpenFileName001)
 	std::ofstream ofs{ path };
 	ofs.close();
 
-	// 表示されたファイルダイアログを閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(L"開く", [path] (IUIAutomation* pUIAutomation, HWND, std::stop_token) {
-		auto pItem = uia::GetFocusedElement(pUIAutomation);
-		ASSERT_THAT(pItem, NotNull());
+	if (GetParam()) {
+		// 表示されたファイルダイアログを閉じるためのスレッドを起動する
+		t = StartDialogCloser(L"開く", [path] (IUIAutomation* pUIAutomation, HWND, std::stop_token) {
+			auto pItem = uia::GetFocusedElement(pUIAutomation);
+			ASSERT_THAT(pItem, NotNull());
 
-		// ファイル名を入力する
-		EmulateSetValue(pItem, path.c_str());
+			// ファイル名を入力する
+			EmulateSetValue(pItem, path.native());
 
-		// Enterキー押下で閉じる
-		EmulateHitEnter();
-	});
+			// Enterキー押下で閉じる
+			EmulateHitEnter();
+		});
 
-	SFilePath szPath{ path.filename().c_str() };
-	CDlgOpenFile::getInstance()->DoModal_GetOpenFileName(szPath, EFilter::EFITER_TEXT);
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetOpenFileNameW(_))
+			.Times(1)
+			.WillOnce(testing::DoDefault());
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(0);
+
+		MockComdlg32::gm_Files.emplace_back(path.native());
+	}
+
+	testAction();
 
 	// 作成したファイルを削除する
 	std::filesystem::remove(path, ec);
@@ -275,11 +392,29 @@ TEST_P(FileDialogTest, GetOpenFileName001)
 TEST_P(FileDialogTest, GetOpenFileName101)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(std::nullopt);
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
-	// コマンドコードで、無理矢理動かす
-	const auto hWnd = pcEditWnd->GetHwnd();
-	FORWARD_WM_COMMAND(hWnd, F_LOADKEYMACRO, nullptr, 0, pcEditWnd->DispatchEvent);
+	const auto testAction = [] () {
+		// コマンドコードで、無理矢理動かす
+		const auto hWnd = pcEditWnd->GetHwnd();
+		FORWARD_WM_COMMAND(hWnd, F_LOADKEYMACRO, nullptr, 0, pcEditWnd->DispatchEvent);
+	};
+
+	if (GetParam()) {
+		// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>();
+
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetOpenFileNameW(_))
+			.Times(1)
+			.WillOnce(Return(FALSE));
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(1)
+			.WillRepeatedly(Return(0));
+	}
+
+	testAction();
 }
 
 /*!
@@ -288,23 +423,42 @@ TEST_P(FileDialogTest, GetOpenFileName101)
 TEST_P(FileDialogTest, GetOpenFileName102)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(std::nullopt);
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
-	SFilePath szPath{};
-	CDlgOpenFile::getInstance()->DoModal_GetOpenFileName(szPath, EFilter::EFITER_NONE);
+	const auto testAction = [] () {
+		SFilePath szPath{};
+		CDlgOpenFile::getInstance()->DoModal_GetOpenFileName(szPath, EFilter::EFITER_NONE);
+	};
+
+	if (GetParam()) {
+		// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>();
+
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetOpenFileNameW(_))
+			.Times(2)
+			.WillOnce(Return(FALSE))
+			.WillOnce(Return(FALSE));
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(1)
+			.WillOnce(Return(FNERR_INVALIDFILENAME));
+	}
+
+	testAction();
 }
-
-#if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * 名前を付けて保存ダイアログの表示テスト
  */
 TEST_P(FileDialogTest, GetSaveFileName001)
 {
-	if (!GetParam()) {
-		GTEST_SUCCESS_("Legacy Common File Dialog may cause error on GitHub Actions.");
-		return;
-	}
+	std::jthread t;
+
+	const auto testAction = [] () {
+		SFilePath szPath{};
+		CDlgOpenFile::getInstance()->DoModal_GetSaveFileName(szPath);
+	};
 
 	const auto path = GetExeFileName().replace_filename(L"test.txt");
 	const auto dummyPath = GetExeFileName().replace_filename(L"dummy.txt");
@@ -314,56 +468,75 @@ TEST_P(FileDialogTest, GetSaveFileName001)
 	// 上書き確認メッセージが出ないように、事前にパスを削除しておく
 	std::filesystem::remove(path, ec);
 
-	// パス解決でｋるようにファイルを作る
+	// パス解決できるようにファイルを作る
 	std::filesystem::remove(dummyPath, ec);
 	std::ofstream ofs{ dummyPath };
 	ofs.close();
 
-	// 表示されたファイルダイアログを閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(L"名前を付けて保存", [path](IUIAutomation* pUIAutomation, HWND, std::stop_token) {
-		auto pItem = uia::GetFocusedElement(pUIAutomation);
-		ASSERT_THAT(pItem, NotNull());
+	if (GetParam()) {
+		// 表示されたファイルダイアログを閉じるためのスレッドを起動する
+		t = StartDialogCloser(L"名前を付けて保存", [path](IUIAutomation* pUIAutomation, HWND, std::stop_token) {
+			auto pItem = uia::GetFocusedElement(pUIAutomation);
+			ASSERT_THAT(pItem, NotNull());
 
-		// ファイル名を入力する
-		EmulateSetValue(pItem, path.c_str());
+			// ファイル名を入力する
+			EmulateSetValue(pItem, path.native());
 
-		// Enterキー押下で閉じる
-		EmulateHitEnter();
-	});
+			// Enterキー押下で閉じる
+			EmulateHitEnter();
+		});
 
-	SFilePath szPath{ dummyPath.filename().native() };
-	CDlgOpenFile::getInstance()->DoModal_GetSaveFileName(szPath);
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetSaveFileNameW(_))
+			.Times(1)
+			.WillOnce(testing::DoDefault());
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(0);
 
+		MockComdlg32::gm_Files.emplace_back(dummyPath.native());
+	}
+
+	testAction();
+
+	// 保存したファイルを削除する
 	std::filesystem::remove(dummyPath, ec);
 }
-
-#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * 名前を付けて保存ダイアログの表示テスト
  */
 TEST_P(FileDialogTest, GetSaveFileName101)
 {
-	// 保存先のパスを作る
-	const auto path = GetExeFileName().replace_filename(L"test-save-file.txt");
-
-	// 上書き確認メッセージが出ないように、事前にパスを削除しておく
-	std::error_code ec;
-	std::filesystem::remove(path, ec);
-
-	// キーマクロ保存が使えるようにダミーマクロを登録する
-	LPARAM lParams = 0L;
-	pcSMacroMgr->Append(STAND_KEYMACRO, F_0, &lParams, &pcEditWnd->GetView(0));
-
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(std::nullopt);
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
-	// コマンドコードで、無理矢理動かす
-	const auto hWnd = pcEditWnd->GetHwnd();
-	FORWARD_WM_COMMAND(hWnd, F_SAVEKEYMACRO, nullptr, 0, pcEditWnd->DispatchEvent);
+	const auto testAction = [] () {
+		// キーマクロ保存が使えるようにダミーマクロを登録する
+		LPARAM lParams = 0L;
+		pcSMacroMgr->Append(STAND_KEYMACRO, F_0, &lParams, &pcEditWnd->GetView(0));
 
-	// 保存したファイルを削除する
-	std::filesystem::remove(path, ec);
+		// コマンドコードで、無理矢理動かす
+		const auto hWnd = pcEditWnd->GetHwnd();
+		FORWARD_WM_COMMAND(hWnd, F_SAVEKEYMACRO, nullptr, 0, pcEditWnd->DispatchEvent);
+	};
+
+	if (GetParam()) {
+		// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>();
+
+	} else {
+		auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+		EXPECT_CALL(*pComdlg32, GetSaveFileNameW(_))
+			.Times(2)
+			.WillOnce(Return(FALSE))
+			.WillOnce(Return(FALSE));
+		EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+			.Times(1)
+			.WillOnce(Return(FNERR_INVALIDFILENAME));
+	}
+
+	testAction();
 }
 
 /*!
@@ -510,4 +683,4 @@ TEST_F(SelectFileTest, SelectFile101)
 	EXPECT_THAT(CDlgOpenFile::SelectFile(hWndDlg, hWndFolder, L"*.ini", resolvePath, EFITER_NONE), IsFalse());
 }
 
-} // namespace window
+} // namespace dialog

--- a/src/test/cpp/tests1/test-cdlgopenfile.cpp
+++ b/src/test/cpp/tests1/test-cdlgopenfile.cpp
@@ -15,15 +15,9 @@
 
 void CallDlgOpenFail();
 
-namespace uia {
-
-cxx::com_pointer<IUIAutomationElement> GetFocusedElement(
-	IUIAutomation* pAutomation
-);
-
-} // namespace uia
-
 namespace dialog {
+
+HWND FindFileNameEdit(HWND hFileDialog);
 
 /*!
  * @brief ファイルダイアログテストのパラメーター
@@ -39,6 +33,10 @@ using FileDialogTestParam = bool;
  *
  */
 struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, public window::EditorTestSuite, public window::UiaTestSuite {
+	static constexpr auto& openDialogTitle = L"開く";
+	static constexpr auto& saveDialogTitle0 = L"開く";
+	static constexpr auto& saveDialogTitle = L"名前を付けて保存";
+
 	/*!
 	 * テストスイートの開始前に1回だけ呼ばれる関数
 	 */
@@ -96,11 +94,6 @@ struct FileDialogTest : public ::testing::TestWithParam<FileDialogTestParam>, pu
 
 		TearDownUia();
 	}
-
-	/*!
-	 * ファイルを開くダイアログのタイトルを取得する
-	 */
-	std::wstring GetOpenFileNameDialogTitle() const { return GetParam() ? L"開く" : L"ファイルを開く"; }
 };
 
 TEST_P(FileDialogTest, Create001)
@@ -150,7 +143,8 @@ TEST_P(FileDialogTest, Create003_ManyFiltersy)
  */
 TEST_P(FileDialogTest, DoModalOpenDlg001)
 {
-	std::jthread t;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
 	const auto testAction = [] () {
 		SLoadInfo loadInfo{};
@@ -169,16 +163,12 @@ TEST_P(FileDialogTest, DoModalOpenDlg001)
 	ofs.close();
 
 	if (GetParam()) {
-		// 表示されたファイルダイアログを閉じるためのスレッドを起動する
-		t = StartDialogCloser(GetOpenFileNameDialogTitle(), [path] (IUIAutomation* pUIAutomation, HWND, std::stop_token) {
-			auto pItem = uia::GetFocusedElement(pUIAutomation);
-			ASSERT_THAT(pItem, NotNull());
-
-			// ファイル名を入力する
-			EmulateSetValue(pItem, path.native());
-
-			// Enterキー押下で閉じる
-			EmulateHitEnter();
+		// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>(openDialogTitle, [path] (HWND hWndDlg) {
+			// 現状の値を決め打ち
+			// ある日突然機能しなくなる可能性あるので注意
+			apiwrap::SetDlgItemTextW(hWndDlg, 1148, path.c_str());
+			SendDlgCommand(hWndDlg, IDOK);
 		});
 
 	} else {
@@ -265,7 +255,8 @@ TEST_P(FileDialogTest, DoModalOpenDlg102)
  */
 TEST_P(FileDialogTest, DoModalSaveDlg001)
 {
-	std::jthread t;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
 	const auto testAction = [] () {
 		SSaveInfo saveInfo{};
@@ -279,16 +270,15 @@ TEST_P(FileDialogTest, DoModalSaveDlg001)
 	std::filesystem::remove(path, ec);
 
 	if (GetParam()) {
-		// 表示されたファイルダイアログを閉じるためのスレッドを起動する
-		t = StartDialogCloser(L"名前を付けて保存", [path](IUIAutomation* pUIAutomation, HWND, std::stop_token) {
-			auto pItem = uia::GetFocusedElement(pUIAutomation);
-			ASSERT_THAT(pItem, NotNull());
+		// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>(saveDialogTitle0, [path] (HWND hWndDlg) {
+			ASSERT_THAT(apiwrap::GetWindowTextW(hWndDlg), StrEq(saveDialogTitle));
 
-			// ファイル名を入力する
-			EmulateSetValue(pItem, path.native());
-
-			// Enterキー押下で閉じる
-			EmulateHitEnter();
+			// 現状の値を決め打ち
+			// ある日突然機能しなくなる可能性あるので注意
+			const auto hWndEdit = dialog::FindFileNameEdit(hWndDlg);
+			apiwrap::SetWindowTextW(hWndEdit, path.c_str());
+			SendDlgCommand(hWndDlg, IDOK);
 		});
 
 	} else {
@@ -344,7 +334,8 @@ TEST_P(FileDialogTest, DoModalSaveDlg101)
  */
 TEST_P(FileDialogTest, GetOpenFileName001)
 {
-	std::jthread t;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
 	const auto testAction = [] () {
 		SFilePath szPath{};
@@ -361,16 +352,12 @@ TEST_P(FileDialogTest, GetOpenFileName001)
 	ofs.close();
 
 	if (GetParam()) {
-		// 表示されたファイルダイアログを閉じるためのスレッドを起動する
-		t = StartDialogCloser(L"開く", [path] (IUIAutomation* pUIAutomation, HWND, std::stop_token) {
-			auto pItem = uia::GetFocusedElement(pUIAutomation);
-			ASSERT_THAT(pItem, NotNull());
-
-			// ファイル名を入力する
-			EmulateSetValue(pItem, path.native());
-
-			// Enterキー押下で閉じる
-			EmulateHitEnter();
+		// 表示されたモーダルダイアログを閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>(openDialogTitle, [path] (HWND hWndDlg) {
+			// 現状の値を決め打ち
+			// ある日突然機能しなくなる可能性あるので注意
+			apiwrap::SetDlgItemTextW(hWndDlg, 1148, path.c_str());
+			SendDlgCommand(hWndDlg, IDOK);
 		});
 
 	} else {
@@ -458,7 +445,8 @@ TEST_P(FileDialogTest, GetOpenFileName102)
  */
 TEST_P(FileDialogTest, GetSaveFileName001)
 {
-	std::jthread t;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	std::unique_ptr<dialog::ModalDialogCloser> closer = nullptr;
 
 	const auto testAction = [] () {
 		SFilePath szPath{};
@@ -479,16 +467,15 @@ TEST_P(FileDialogTest, GetSaveFileName001)
 	ofs.close();
 
 	if (GetParam()) {
-		// 表示されたファイルダイアログを閉じるためのスレッドを起動する
-		t = StartDialogCloser(L"名前を付けて保存", [path](IUIAutomation* pUIAutomation, HWND, std::stop_token) {
-			auto pItem = uia::GetFocusedElement(pUIAutomation);
-			ASSERT_THAT(pItem, NotNull());
+		// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+		closer = std::make_unique<dialog::ModalDialogCloser>(saveDialogTitle0, [path] (HWND hWndDlg) {
+			ASSERT_THAT(apiwrap::GetWindowTextW(hWndDlg), StrEq(saveDialogTitle));
 
-			// ファイル名を入力する
-			EmulateSetValue(pItem, path.native());
-
-			// Enterキー押下で閉じる
-			EmulateHitEnter();
+			// 現状の値を決め打ち
+			// ある日突然機能しなくなる可能性あるので注意
+			const auto hWndEdit = dialog::FindFileNameEdit(hWndDlg);
+			apiwrap::SetWindowTextW(hWndEdit, path.c_str());
+			SendDlgCommand(hWndDlg, IDOK);
 		});
 
 	} else {

--- a/src/test/cpp/tests1/test-messageboxf.cpp
+++ b/src/test/cpp/tests1/test-messageboxf.cpp
@@ -9,6 +9,27 @@
 
 #include "eval_outputs.hpp"
 
+/* static */ int MockUser32::_MessageBoxExW(
+	_In_opt_ HWND hWnd,
+	_In_opt_ LPCWSTR lpText,
+	_In_opt_ LPCWSTR lpCaption,
+	_In_ UINT uType,
+	_In_ WORD wLanguageId
+)
+{
+	// lpText を標準エラー出力に書き出す
+	std::clog << (lpText ? cxx::to_string(lpText, CP_UTF8) : "") << std::endl;
+
+	// いい加減な戻り値を返す。(返り値0は未定義なので本来返らない値を返している)
+	return 0;
+}
+
+MockUser32::MockUser32()
+{
+	// デフォルトの動作を設定する
+	ON_CALL(*this, MessageBoxExW(_, _, _, _, _)).WillByDefault(&_MessageBoxExW);
+}
+
 /*!
 	MessageBoxFのテスト 
  */

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -63,6 +63,17 @@ struct MockShell32 final : public Shell32
 	MOCK_CONST_METHOD1(ShellExecuteExW, BOOL (SHELLEXECUTEINFOW*));
 };
 
+struct MockCDlgInput1 final : public CDlgInput1
+{
+	MOCK_METHOD5(DoModal, BOOL(
+		_In_opt_ HWND hWndOwner,
+		_In_z_ LPCWSTR pszTitle,
+		_In_z_ LPCWSTR pszMessage,
+		_Out_writes_z_(cchBuffer) LPWSTR pBuffer,
+		size_t cchBuffer
+	));
+};
+
 namespace dialog {
 
 constexpr auto& title1 = L"検索";

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -1413,6 +1413,8 @@ TEST_F(EditWndTest, Command_OPEN_COMMAND_PROMPT101)
 	HWND hWndEdit = nullptr;
 	EXPECT_THAT(pcEditWnd->DispatchEvent(hWndEdit, WM_COMMAND, MAKEWPARAM(F_OPEN_COMMAND_PROMPT, 0), 0L), IsFalse());
 
+	pcEditDoc->m_cDocFile.SetFilePath(L"");
+
 	Shell32::resetInstance();
 
 	std::filesystem::remove(targetPath, ec);
@@ -1485,6 +1487,8 @@ TEST_F(EditWndTest, FileSaveWithBackupAgent001)
 	backupAgent->FormatBackUpPath(newPath, std::size(newPath), backupPath.c_str());
 	EXPECT_THAT(newPath, StrEq(LR"(C:\Users\Public\Desktop\backup-agent-target.bak)"));
 
+	pcEditDoc->m_cDocFile.SetFilePath(L"");
+
 	backupAgent = nullptr;
 
 	sBackup = backupOld;
@@ -1543,6 +1547,8 @@ TEST_F(EditWndTest, GetDocDataObject001)
 
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"FileClose()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+
+	pcEditDoc->m_cDocFile.SetFilePath(L"");
 
 	std::filesystem::remove(targetPath, ec);
 }

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -1797,13 +1797,19 @@ TEST_F(EditWndTest, GetDocDataObject001)
  */
 TEST_F(EditWndTest, ShowDlgCancel001)
 {
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"Grep実行中", [](HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
+
 	CDlgCancel cDlgCancel;
 
 	const auto hWnd = pcEditWnd->GetHwnd();
 
 	cDlgCancel.DoModeless(unusedArg1, hWnd, IDD_GREPRUNNING);
 
-	cDlgCancel.CloseDialog(0);
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
 }
 
 #if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -1816,12 +1822,11 @@ TEST_F(EditWndTest, ShowDlgFind001)
 	// 表示されたモーダルダイアログをOKボタンで閉じる
 	dialog::ModalDialogCloser closer(L"検索", IDOK);
 
+	using target = CDlgFind;
 	pcEditWnd->m_cDlgFind.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()));
 
-	// キューに溜まったメッセージは全部捨てる
-	BlockingHook(nullptr);
-
-	pcEditWnd->m_cDlgFind.CloseDialog(0);
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
 }
 
 /*!
@@ -1829,10 +1834,15 @@ TEST_F(EditWndTest, ShowDlgFind001)
  */
 TEST_F(EditWndTest, ShowDlgFind101)
 {
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"検索");
+
+	using target = CDlgFind;
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"SearchDialog()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 
-	pcEditWnd->m_cDlgFind.CloseDialog(0);
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
 }
 
 /*!
@@ -1840,13 +1850,17 @@ TEST_F(EditWndTest, ShowDlgFind101)
  */
 TEST_F(EditWndTest, ShowDlgFuncList001)
 {
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(std::nullopt, [] (HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
+
+	using target = CDlgFuncList;
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"Outline(0)"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"Outline(1)"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
-
-	pcEditWnd->m_cDlgFuncList.CloseDialog(0);
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
 }
 
 /*!
@@ -1854,10 +1868,15 @@ TEST_F(EditWndTest, ShowDlgFuncList001)
  */
 TEST_F(EditWndTest, ShowDlgReplace001)
 {
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"置換");
+
+	using target = CDlgReplace;
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ReplaceDialog()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 
-	pcEditWnd->m_cDlgReplace.CloseDialog(0);
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
 }
 
 /*!
@@ -2643,6 +2662,14 @@ TEST_F(EditWndTest, ShowDlgWindowList101)
  */
 TEST_F(EditWndTest, ShowHokanMgr001)
 {
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(std::nullopt, [this] (HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	using target = CHokanMgr;
+	const auto& cHokanMgr = pcEditWnd->m_cHokanMgr;
+
 	// データなしだとスカる
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"Complete()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
@@ -2660,7 +2687,11 @@ TEST_F(EditWndTest, ShowHokanMgr001)
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"Complete()"), IsTrue());
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 
-	pcEditWnd->m_cHokanMgr.CloseDialog(0);
+	// 非表示ウィンドウはModalDialogCloserに拾われないので強制的に表示させる
+	::ShowWindow(cHokanMgr.GetHwnd(), SW_SHOW);
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -1922,243 +1922,6 @@ TEST_F(EditWndTest, GetDocDataObject001)
 	EXPECT_THAT(memory.wstring(), StrEq(targetPath.native()));
 }
 
-#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
-
-#if defined(_MSC_VER) &&  defined(_DEBUG)
-
-/*!
- * 検索ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgFind001)
-{
-	// 検索条件
-	CSearchKeywordManager().AddToSearchKeyArr(LR"(localhost)");
-
-	// 表示されたモーダルダイアログを閉じる
-	dialog::ModalDialogCloser closer(L"検索", [](HWND hWndDlg) {
-		// コンテキストメニュー表示を空振りさせる
-		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
-
-		// ボタンID以外でOnCommandを空振りさせる
-		SendDlgCommand(hWndDlg, IDC_STATIC_CURPATH);
-
-		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, false);
-		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
-		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, true);
-		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
-
-		// 検索系ボタンの押下(空振りさせる)
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
-
-		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT, CBN_DROPDOWN);
-
-		// 検索条件をセット
-		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_TEXT, L"test");
-
-		// 検索系ボタンの押下(最後まではいけない)
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
-
-		SendDlgCommand(hWndDlg, IDCANCEL);
-	});
-
-	auto pUser32 = (MockUser32*)User32::getInstance();
-	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
-		.Times(2)
-		.WillOnce(Return(IDOK))		// 検索条件を指定してください。
-		.WillOnce(Return(IDOK));	// 検索条件を指定してください。
-
-	auto& cDlgFind = pcEditWnd->m_cDlgFind;
-	cDlgFind.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()));
-
-	// キューに溜まるメッセージを処理する
-	RunMessageLoop();
-
-	// 設定を元に戻す
-	GetDllShareData().m_sSearchKeywords.m_aSearchKeys.clear();
-}
-
-/*!
- * 検索ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgFind101)
-{
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"検索");
-
-	auto& cDlgFind = pcEditWnd->m_cDlgFind;
-	cDlgFind.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()));
-
-	// キューに溜まるメッセージを処理する
-	RunMessageLoop();
-}
-
-/*!
- * 検索ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgFind102)
-{
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"検索");
-
-	using target = CDlgFind;
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"SearchDialog()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
-
-	// キューに溜まるメッセージを処理する
-	RunMessageLoop();
-}
-
-/*!
- * アウトライン解析ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgFuncList001)
-{
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer1(std::nullopt, [] (HWND hWndDlg) {
-		// コンテキストメニュー表示を空振りさせる
-		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
-
-		SendDlgCommand(hWndDlg, IDC_BUTTON_MENU);
-
-		SendDlgCommand(hWndDlg, IDC_BUTTON_COPY);
-
-		SendDlgCommand(hWndDlg, IDC_BUTTON_WINSIZE);
-
-		SendDlgCommand(hWndDlg, IDC_CHECK_bAutoCloseDlgFuncList);
-
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SETTING);
-
-		CMyRect rc{};
-		::GetClientRect(hWndDlg, &rc);
-		FORWARD_WM_SIZE(hWndDlg, SIZE_RESTORED, rc.right, rc.bottom, ::SendMessageW);
-
-		SendDlgCommand(hWndDlg, IDCANCEL);
-	});
-
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer2(L"ファイルツリー設定");
-
-	auto pUser32 = (MockUser32*)User32::getInstance();
-	EXPECT_CALL(*pUser32, TrackPopupMenu(_, _, _, _, _, _, _))
-		.Times(1)
-		.WillOnce(Return(450));	// 更新
-
-	using target = CDlgFuncList;
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"Outline(0)"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
-
-	// キューに溜まるメッセージを処理する
-	RunMessageLoop();
-}
-
-/*!
- * 置換ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgReplace001)
-{
-	// 検索条件
-	CSearchKeywordManager().AddToSearchKeyArr(LR"(localhost)");
-
-	// 置換文字列
-	CSearchKeywordManager().AddToReplaceKeyArr( LR"(royalhost)" );
-
-	// 表示されたモーダルダイアログを閉じる
-	dialog::ModalDialogCloser closer(L"置換", [](HWND hWndDlg) {
-		// コンテキストメニュー表示を空振りさせる
-		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
-
-		// ボタンID以外でOnCommandを空振りさせる
-		SendDlgCommand(hWndDlg, IDC_STATIC_CURPATH);
-
-		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, false);
-		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
-		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, true);
-		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
-
-		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_PASTE, true);
-		SendDlgCommand(hWndDlg, IDC_CHK_PASTE);
-		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_PASTE, false);
-		SendDlgCommand(hWndDlg, IDC_CHK_PASTE);
-
-		// 検索系ボタンの押下(空振りさせる)
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCE);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCEALL);
-
-		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT, CBN_DROPDOWN);
-		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT2, CBN_DROPDOWN);
-
-		// 検索条件をセット
-		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_TEXT, L"test");
-		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_TEXT2, L"text");
-
-		// 検索系ボタンの押下(最後まではいけない)
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCE);
-		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCEALL);
-
-		SendDlgCommand(hWndDlg, IDCANCEL);
-	});
-
-	auto pUser32 = (MockUser32*)User32::getInstance();
-	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
-		.Times(5)
-		.WillOnce(Return(IDOK))		// 文字列を指定してください。
-		.WillOnce(Return(IDOK))		// 文字列を指定してください。
-		.WillOnce(Return(IDOK))		// 文字列を指定してください。
-		.WillOnce(Return(IDOK))		// 置換条件を指定してください。
-		.WillOnce(Return(IDOK));	// 0箇所を置換しました。
-
-	auto& cDlgReplace = pcEditWnd->m_cDlgReplace;
-	cDlgReplace.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()), false);
-
-	// キューに溜まるメッセージを処理する
-	RunMessageLoop();
-
-	// 設定を元に戻す
-	GetDllShareData().m_sSearchKeywords.m_aSearchKeys.clear();
-	GetDllShareData().m_sSearchKeywords.m_aReplaceKeys.clear();
-}
-
-/*!
- * 置換ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgReplace101)
-{
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"置換");
-
-	auto& cDlgReplace = pcEditWnd->m_cDlgReplace;
-	cDlgReplace.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()), false);
-
-	// キューに溜まるメッセージを処理する
-	RunMessageLoop();
-}
-
-/*!
- * 置換ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgReplace102)
-{
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"置換");
-
-	using target = CDlgReplace;
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ReplaceDialog()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
-
-	// キューに溜まるメッセージを処理する
-	RunMessageLoop();
-}
-
 /*!
  * バージョン情報ダイアログの表示テスト
  */
@@ -2569,6 +2332,137 @@ TEST_F(EditWndTest, ShowDlgFileUpdateQuery101)
 }
 
 #if defined(_MSC_VER) &&  defined(_DEBUG)
+
+/*!
+ * 検索ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgFind001)
+{
+	// 検索条件
+	CSearchKeywordManager().AddToSearchKeyArr(LR"(localhost)");
+
+	GetDllShareData().m_Common.m_sSearch.m_bAutoCloseDlgFind = false;
+
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"検索", [](HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		// ボタンID以外でOnCommandを空振りさせる
+		SendDlgCommand(hWndDlg, IDC_STATIC_CURPATH);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, false);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, true);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+
+		// 検索系ボタンの押下(空振りさせる)
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
+
+		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT, CBN_DROPDOWN);
+
+		// 検索条件をセット
+		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_TEXT, L"test");
+
+		// 前方検索
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
+
+		// 後方検索
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
+
+		// 該当行をマーク
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
+
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
+		.Times(4)
+		.WillOnce(Return(IDOK))		// 検索条件を指定してください。
+		.WillOnce(Return(IDOK))		// 検索条件を指定してください。
+		.WillOnce(Return(IDOK))		// 前方(↓) に文字列 'test' が１つも見つかりません。
+		.WillOnce(Return(IDOK));	// 後方(↓) に文字列 'test' が１つも見つかりません。
+
+	using target = CDlgFind;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_SEARCH_DIALOG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
+
+	// 設定を元に戻す
+	GetDllShareData().m_sSearchKeywords.m_aSearchKeys.clear();
+	GetDllShareData().m_Common.m_sSearch.m_bAutoCloseDlgFind = true;
+}
+
+/*!
+ * 検索ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgFind101)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"検索");
+
+	using target = CDlgFind;
+	EXPECT_THAT(ExecMacroCommand(L"SearchDialog()"), IsTrue());
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
+}
+
+/*!
+ * アウトライン解析ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgFuncList101)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer1(L"x", [] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_MENU);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_COPY);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_WINSIZE);
+
+		SendDlgCommand(hWndDlg, IDC_CHECK_bAutoCloseDlgFuncList);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETTING);
+
+		SendDlgCommand(hWndDlg, IDC_COMBO_nSortType, CBN_SELENDOK);
+
+		CMyRect rc{};
+		::GetClientRect(hWndDlg, &rc);
+		FORWARD_WM_SIZE(hWndDlg, SIZE_RESTORED, rc.right, rc.bottom, ::SendMessageW);
+
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
+
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer2(L"ファイルツリー設定");
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, TrackPopupMenu(_, _, _, _, _, _, _))
+		.Times(1)
+		.WillOnce(Return(450));	// 更新
+
+	using target = CDlgFuncList;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_OUTLINE, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
+}
 
 /*!
  * Grepダイアログの表示テスト
@@ -3103,6 +2997,107 @@ TEST_F(EditWndTest, ShowDlgProperty101)
 
 	using target = CDlgProperty;
 	EXPECT_THAT(ExecMacroCommand(L"PropertyFile()"), IsTrue());
+}
+
+/*!
+ * 置換ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgReplace001)
+{
+	// 検索条件
+	CSearchKeywordManager().AddToSearchKeyArr(LR"(localhost)");
+
+	// 置換文字列
+	CSearchKeywordManager().AddToReplaceKeyArr( LR"(royalhost)" );
+
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"置換", [](HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		// ボタンID以外でOnCommandを空振りさせる
+		SendDlgCommand(hWndDlg, IDC_STATIC_CURPATH);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, false);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, true);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_PASTE, true);
+		SendDlgCommand(hWndDlg, IDC_CHK_PASTE);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_PASTE, false);
+		SendDlgCommand(hWndDlg, IDC_CHK_PASTE);
+
+		// 検索系ボタンの押下(空振りさせる)
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCEALL);
+
+		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT, CBN_DROPDOWN);
+		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT2, CBN_DROPDOWN);
+
+		// 検索条件をセット
+		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_TEXT, L"test");
+		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_TEXT2, L"text");
+
+		// 前方検索
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
+
+		// 後方検索
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
+
+		// 該当行をマーク
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
+
+		// 置換実行
+		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCE);
+
+		// 全置換実行
+		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCEALL);
+	});
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
+		.Times(8)
+		.WillOnce(Return(IDOK))		// 文字列を指定してください。
+		.WillOnce(Return(IDOK))		// 文字列を指定してください。
+		.WillOnce(Return(IDOK))		// 文字列を指定してください。
+		.WillOnce(Return(IDOK))		// 置換条件を指定してください。
+		.WillOnce(Return(IDOK))		// 前方(↓) に文字列 'test' が１つも見つかりません。
+		.WillOnce(Return(IDOK))		// 後方(↑) に文字列 'test' が１つも見つかりません。
+		.WillOnce(Return(IDOK))		// 前方(↓) に文字列 'test' が１つも見つかりません。
+		.WillOnce(Return(IDOK));	// 0箇所を置換しました。
+
+	using target = CDlgReplace;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_REPLACE_DIALOG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
+
+	// 設定を元に戻す
+	GetDllShareData().m_sSearchKeywords.m_aSearchKeys.clear();
+	GetDllShareData().m_sSearchKeywords.m_aReplaceKeys.clear();
+}
+
+/*!
+ * 置換ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgReplace101)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"置換");
+
+	using target = CDlgReplace;
+	EXPECT_THAT(ExecMacroCommand(L"ReplaceDialog()"), IsTrue());
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -1924,31 +1924,6 @@ TEST_F(EditWndTest, GetDocDataObject001)
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
-/*!
- * キャンセルダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgCancel001)
-{
-	// 表示されたモーダルダイアログを閉じる
-	dialog::ModalDialogCloser closer(L"Grep実行中", [](HWND hWndDlg) {
-		// コンテキストメニュー表示を空振りさせる
-		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
-
-		// ボタンID以外でOnCommandを空振りさせる
-		SendDlgCommand(hWndDlg, IDC_STATIC_CURPATH);
-
-		SendDlgCommand(hWndDlg, IDCANCEL);
-	});
-
-	CDlgCancel cDlgCancel;
-
-	const auto hWnd = pcEditWnd->GetHwnd();
-	cDlgCancel.DoModeless(unusedArg1, hWnd, IDD_GREPRUNNING);
-
-	// キューに溜まるメッセージを処理する
-	RunMessageLoop();
-}
-
 #if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
@@ -2205,6 +2180,9 @@ TEST_F(EditWndTest, ShowDlgAbout001)
 		// コンテキストメニュー表示を空振りさせる
 		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
 
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
 		SendDlgCommand(hWndDlg, IDOK);
 	});
 
@@ -2226,6 +2204,33 @@ TEST_F(EditWndTest, ShowDlgAbout101)
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
+
+/*!
+ * キャンセルダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgCancel001)
+{
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"Grep実行中", [](HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		// ボタンID以外でOnCommandを空振りさせる
+		SendDlgCommand(hWndDlg, IDC_STATIC_CURPATH);
+
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
+
+	CDlgCancel cDlgCancel;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	cDlgCancel.DoModeless(unusedArg1, hWnd, IDD_GREPRUNNING);
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
+}
 
 /*!
  * ファイル比較ダイアログの表示テスト

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -382,6 +382,22 @@ TEST(ModalDialogCloserTest, HandlesMultipleEntriesInRegistrationOrder)
 	EXPECT_THAT(handledWindows, testing::SizeIs(2));	// ウィンドウのスタンバイ状態を確認するよう変えたので順序は保証されない
 }
 
+/*!
+ * @brief ダイアログのメッセージ配送
+ */
+TEST(CDialog, DlgProc101)
+{
+	EXPECT_THAT(CDlgInput1::DlgProc(nullptr, WM_NULL, 0L, 0L), IsFalse());
+}
+
+/*!
+ * @brief カスタムウィンドウのメッセージ配送
+ */
+TEST(CDialog, SubclassProc101)
+{
+	CDlgInput1::SubclassProc(nullptr, WM_NULL, 0L, 0L, 0L, 0L);
+}
+
 } // namespace dialog
 
 namespace env {
@@ -2162,12 +2178,27 @@ TEST_F(EditWndTest, ShowDlgGrepReplace101)
  */
 TEST_F(EditWndTest, ShowDlgInputBox001)
 {
-	// 表示されたモーダルダイアログを閉じる
-	dialog::ModalDialogCloser closer(L"汎用入力ダイアログ", [] (HWND hWndDlg) {
-		// 不明なボタンIDで処理中断
-		SendDlgCommand(hWndDlg, IDC_EDIT_INPUT1);
+	// モックを解除してダイアログをテストする
+	CDlgInput1::resetInstance();
 
-		// 文字数超過で処理中断
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
+
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"汎用入力ダイアログ", [&cDlgInput1] (HWND hWndDlg) {
+		// 処理対象でないメッセージを送信して空振りさせる
+		::SendMessageW(hWndDlg, WM_NULL, 0L, 0L);
+
+		// WM_HELPを送信してヘルプ表示処理を空振りさせる
+		HELPINFO hi{};
+		::SendMessageW(hWndDlg, WM_HELP, 0L, LPARAM(&hi));
+
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, ::GetDlgItem(hWndDlg, IDC_EDIT_INPUT1), 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		// 文字数超過の場合は取り込まず、ダイアログは閉じない
 		::SetDlgItemTextW(hWndDlg, IDC_EDIT_INPUT1, L"test");
 		SendDlgCommand(hWndDlg, IDOK);
 
@@ -2178,8 +2209,7 @@ TEST_F(EditWndTest, ShowDlgInputBox001)
 
 	std::wstring buffer{ L"TES" };
 
-	CDlgInput1 dlg{};
-	EXPECT_THAT(dlg.DoModal(unusedArg1, pcEditWnd->GetHwnd(), L"title", L"message", std::size(buffer), std::data(buffer)), IsTrue());
+	EXPECT_THAT(cDlgInput1.DoModal(unusedArg1, pcEditWnd->GetHwnd(), L"title", L"message", std::size(buffer) + 1, std::data(buffer)), IsTrue());
 
 	EXPECT_THAT(buffer, StrEq(L"tes"));
 }
@@ -2191,6 +2221,9 @@ TEST_F(EditWndTest, ShowDlgInputBox001)
  */
 TEST_F(EditWndTest, ShowDlgInputBox101)
 {
+	// モックを解除してダイアログをテストする
+	CDlgInput1::resetInstance();
+
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"汎用入力ダイアログ");
 

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -65,6 +65,9 @@ struct MockShell32 final : public Shell32
 
 namespace dialog {
 
+constexpr auto& title1 = L"検索";
+constexpr auto& title2 = L"置換";
+
 struct ModalDialogCloserTestPeer {
 	static void NotifyCreate(HWND hWnd, LPCWSTR title)
 	{
@@ -86,13 +89,232 @@ struct ModalDialogCloserTestPeer {
 	}
 };
 
+/*!
+ * @brief テスト用テンポラリダイアログ
+ *
+ * @note CDialogのデストラクターが意図していると思われる機能「不要になったタイミングでまだ表示中ならウィンドウを閉じて安全に破棄される」を実現する。
+ * @note そのうち消す
+ */
+class TestDialog
+{
+private:
+	using HwndHolder = cxx::ResourceHolder<&::DestroyWindow>;
+
+	using Me = TestDialog;
+
+	static INT_PTR CALLBACK DlgProc(
+		HWND hWndDlg,
+		UINT uMsg,
+		WPARAM wParam,
+		LPARAM lParam
+	);
+
+	static LRESULT CALLBACK SubclassProc(
+		HWND hWnd,
+		UINT uMsg,
+		WPARAM wParam,
+		LPARAM lParam,
+		UINT_PTR uIdSubclass,
+		DWORD_PTR dwRefData
+	);
+
+public:
+	HWND DoModeless(
+		int dialogTemplateId,
+		_In_opt_ HWND hWndOwnerOrParent = nullptr
+	);
+
+private:
+	INT_PTR	DispatchDlgEvent(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	LRESULT	DispatchEvent(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+	HWND			m_hWnd = nullptr;
+
+	HwndHolder		m_Holder = nullptr;
+};
+
+/*!
+ * @brief ダイアログプロシージャ
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ * @param uMsg [in] メッセージコード
+ * @param wParam [in, opt] 第1パラメーター
+ * @param lParam [in, opt] 第2パラメーター
+ *
+ * @retval 0以外 メッセージは処理済み。システムはDWLP_MSGRESULTを参照する。
+ * @retval 0     メッセージは未処理。システムに処理させる。
+ */
+/* static */ INT_PTR CALLBACK TestDialog::DlgProc(
+	HWND hWndDlg,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam
+)
+{
+	// GetWindowLong/SetWindowLongする都合、NULLはマズい。
+	if (!hWndDlg) return FALSE;	// システムに処理させる
+
+	// WM_INITDIALOGが来たらHWNDにクラスデータを紐づける
+	if (auto pcDlg = std::bit_cast<Me*>(lParam); WM_INITDIALOG == uMsg && pcDlg) {
+		// ウィンドウハンドルを格納する
+		pcDlg->m_hWnd = hWndDlg;
+
+		// lParamをユーザーデータに格納する。（格納方法は改善検討要。）
+		::SetWindowLongPtrW(hWndDlg, DWLP_USER, lParam);
+
+		// ダイアログをカスタマイズする
+		::SetWindowSubclass(hWndDlg, &SubclassProc, 0, DWORD_PTR(lParam));
+	}
+
+	// HWNDに紐づいたクラスを取り出す。
+	if (auto pcDlg = std::bit_cast<Me*>(::GetWindowLongPtrW(hWndDlg, DWLP_USER))) {
+		// HWNDに紐づいたクラスにメッセージを処理させる
+		const auto ret = pcDlg->DispatchDlgEvent(hWndDlg, uMsg, wParam, lParam);
+
+		if (WM_DESTROY == uMsg) {
+			// ユーザーデータの紐付けを解除する
+			::SetWindowLongPtrW(hWndDlg, DWLP_USER, 0L);
+
+			// ウィンドウハンドルの紐付けを解除する
+			pcDlg->m_hWnd = nullptr;
+		}
+
+		// 処理結果を返す。0以外ならシステムはDWLP_MSGRESULTを参照する。
+		return ret;
+	}
+
+	return FALSE;	// システムに処理させる
+}
+
+/*!
+ * @brief ウィンドウプロシージャ
+ *
+ * @param hWnd [in] 宛先ウィンドウのハンドル
+ * @param uMsg [in] メッセージコード
+ * @param wParam [in, opt] 第1パラメーター
+ * @param lParam [in, opt] 第2パラメーター
+ * @param uIdSubclass [in] サブクラスID
+ * @param dwRefData [in] サブクラスデータ
+ *
+ * @returns  メッセージ処理結果。値の意味はメッセージ依存。
+ */
+/* static */ LRESULT CALLBACK TestDialog::SubclassProc(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam,
+	UINT_PTR uIdSubclass,
+	DWORD_PTR dwRefData
+)
+{
+	LRESULT ret = 0;
+
+	// サブクラスデータを取り出す。（格納方法は改善検討要。）
+	auto pcDlg = std::bit_cast<Me*>(dwRefData);
+	if (pcDlg) {
+		// サブクラスデータにメッセージを処理させる
+		ret = pcDlg->DispatchEvent(hWnd, uMsg, wParam, lParam);
+	}
+
+	if (WM_DESTROY == uMsg) {
+		::RemoveWindowSubclass(hWnd, &SubclassProc, uIdSubclass);
+		return 0;
+	}
+
+	if (pcDlg) {
+		return ret;
+	}
+
+	//あとはデフォルトに任せる
+	return ::DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+/*!
+ * @brief モードレスダイアログの表示
+ *
+ * @param dialogTemplateId [in] ダイアログテンプレート
+ * @param hWndOwner [in, opt] オーナーウィンドウのハンドル
+ */
+HWND TestDialog::DoModeless(
+	int dialogTemplateId,
+	_In_opt_ HWND hWndOwnerOrParent
+)
+{
+	return ::CreateDialogParamW(
+		CSelectLang::getLangRsrcInstance(),
+		MAKEINTRESOURCE(dialogTemplateId),
+		hWndOwnerOrParent,
+		DlgProc,
+		LPARAM(this)
+	);
+}
+
+/*!
+ * @brief ダイアログのメッセージ配送
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ * @param uMsg [in] メッセージコード
+ * @param wParam [in, opt] 第1パラメーター
+ * @param lParam [in, opt] 第2パラメーター
+ *
+ * @retval 0以外 メッセージは処理済み。システムはDWLP_MSGRESULTを参照する。
+ * @retval 0     メッセージは未処理。システムに処理させる。
+ *
+ * @sa SetDlgMsgResult
+ */
+INT_PTR TestDialog::DispatchDlgEvent(
+	HWND hWndDlg,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam
+)
+{
+	if (WM_INITDIALOG == uMsg) {
+		m_Holder = hWndDlg;
+
+		return TRUE;	// システムが設定した初期フォーカスを受け入れる
+	}
+
+	return FALSE;	// システムに処理させる
+}
+
+/*!
+ * @brief 拡張ウィンドウのメッセージ配送
+ *
+ * @param hWndDlg [in] 宛先ウィンドウのハンドル
+ * @param uMsg [in] メッセージコード
+ * @param wParam [in, opt] 第1パラメーター
+ * @param lParam [in, opt] 第2パラメーター
+ *
+ * @returns  メッセージ処理結果。値の意味はメッセージ依存。
+ *
+ * @note 戻り値0は「処理済み」を示すことが多いが、実装時に確認すること。
+ */
+LRESULT TestDialog::DispatchEvent(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam
+)
+{
+	if (WM_DESTROY == uMsg) {
+		m_Holder = nullptr;
+
+		return 0L;
+	}
+
+	//あとはデフォルトに任せる
+	return ::DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
 TEST(ModalDialogCloserTest, RunsActionOnActivateOnlyOnce)
 {
-	const auto hWnd = HWND(1);
+	TestDialog dlg1;
+	const auto hWnd = dlg1.DoModeless(IDD_FIND);
 	int actionCount = 0;
 	{
-		dialog::ModalDialogCloser closer(L"Test dialog", [&actionCount] (HWND) { ++actionCount; });
-		dialog::ModalDialogCloserTestPeer::NotifyCreate(hWnd, L"Test dialog");
+		dialog::ModalDialogCloser closer(title1, [&actionCount] (HWND) { ++actionCount; });
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(hWnd, title1);
 		dialog::ModalDialogCloserTestPeer::ActivateDialog(hWnd);
 		dialog::ModalDialogCloserTestPeer::ActivateDialog(hWnd);
 		dialog::ModalDialogCloserTestPeer::RunFallback(hWnd);
@@ -103,15 +325,22 @@ TEST(ModalDialogCloserTest, RunsActionOnActivateOnlyOnce)
 
 TEST(ModalDialogCloserTest, KeepsPendingEntryWhenTitleDoesNotMatch)
 {
-	const auto otherHwnd = HWND(3);
-	const auto expectedHwnd = HWND(4);
+	TestDialog dlg1;
+	TestDialog dlg2;
+	const auto otherHwnd = dlg1.DoModeless(IDD_FIND);
+	const auto expectedHwnd = dlg2.DoModeless(IDD_REPLACE);
 	HWND handledHwnd = nullptr;
 	{
-		dialog::ModalDialogCloser closer(L"Expected dialog", [&handledHwnd] (HWND hWnd) { handledHwnd = hWnd; });
-		dialog::ModalDialogCloserTestPeer::NotifyCreate(otherHwnd, L"Other dialog");
+		dialog::ModalDialogCloser closer(title1, [&handledHwnd] (HWND hWnd) { handledHwnd = hWnd; });
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(otherHwnd, title2);
 		dialog::ModalDialogCloserTestPeer::ActivateDialog(otherHwnd);
-		dialog::ModalDialogCloserTestPeer::NotifyCreate(expectedHwnd, L"Expected dialog");
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(expectedHwnd, title1);
 		dialog::ModalDialogCloserTestPeer::ActivateDialog(expectedHwnd);
+
+		while (!dialog::ModalDialogCloser::IsHandled()) {
+			::BlockingHook(nullptr);
+			::Sleep(10);
+		}
 	}
 
 	EXPECT_THAT(handledHwnd, Eq(expectedHwnd));
@@ -119,19 +348,27 @@ TEST(ModalDialogCloserTest, KeepsPendingEntryWhenTitleDoesNotMatch)
 
 TEST(ModalDialogCloserTest, HandlesMultipleEntriesInRegistrationOrder)
 {
-	const auto firstHwnd = HWND(5);
-	const auto secondHwnd = HWND(6);
+	TestDialog dlg1;
+	TestDialog dlg2;
+	const auto firstHwnd = dlg1.DoModeless(IDD_FIND);
+	const auto secondHwnd = dlg2.DoModeless(IDD_REPLACE);
 	std::vector<HWND> handledWindows;
+	const auto func = [&handledWindows] (HWND hWnd) { handledWindows.emplace_back(hWnd); };
 	{
-		dialog::ModalDialogCloser firstCloser(L"First dialog", [&handledWindows] (HWND hWnd) { handledWindows.emplace_back(hWnd); });
-		dialog::ModalDialogCloser secondCloser(L"Second dialog", [&handledWindows] (HWND hWnd) { handledWindows.emplace_back(hWnd); });
-		dialog::ModalDialogCloserTestPeer::NotifyCreate(firstHwnd, L"First dialog");
-		dialog::ModalDialogCloserTestPeer::NotifyCreate(secondHwnd, L"Second dialog");
+		dialog::ModalDialogCloser firstCloser(title1, func);
+		dialog::ModalDialogCloser secondCloser(title2, func);
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(firstHwnd, title1);
+		dialog::ModalDialogCloserTestPeer::NotifyCreate(secondHwnd, title2);
 		dialog::ModalDialogCloserTestPeer::ActivateDialog(firstHwnd);
 		dialog::ModalDialogCloserTestPeer::ActivateDialog(secondHwnd);
+
+		while (!dialog::ModalDialogCloser::IsHandled()) {
+			::BlockingHook(nullptr);
+			::Sleep(10);
+		}
 	}
 
-	EXPECT_THAT(handledWindows, testing::ElementsAre(firstHwnd, secondHwnd));
+	EXPECT_THAT(handledWindows, testing::SizeIs(2));	// ウィンドウのスタンバイ状態を確認するよう変えたので順序は保証されない
 }
 
 } // namespace dialog

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -11,6 +11,7 @@
 #include "env/ShareDataTestSuite.hpp"
 #include "window/EditorTestSuite.hpp"
 
+#include "dlg/CDlgAbout.h"
 #include "dlg/CDlgCancel.h"
 #include "dlg/CDlgCompare.h"
 #include "dlg/CDlgCtrlCode.h"
@@ -21,6 +22,8 @@
 #include "dlg/CDlgInput1.h"
 #include "dlg/CDlgPluginOption.h"
 #include "dlg/CDlgPrintSetting.h"
+#include "dlg/CDlgProfileMgr.h"
+#include "dlg/CDlgProperty.h"
 #include "dlg/CDlgTagJumpList.h"
 #include "dlg/CDlgTagsMake.h"
 #include "dlg/CDlgWinSize.h"
@@ -461,6 +464,8 @@ namespace window {
 struct TrayWndTest : public ::testing::Test, public env::ShareDataTestSuite, public window::UiaTestSuite {
 	using CControlTrayHolder = std::unique_ptr<CControlTray>;
 
+	static inline const std::filesystem::path dummyPath = GetIniFileName().replace_filename(L"dummy.txt");
+
 	static inline std::unique_ptr<CCommandLine> pCommandLine = nullptr;
 
 	static inline CControlTrayHolder pcTrayWnd = nullptr;
@@ -496,6 +501,14 @@ struct TrayWndTest : public ::testing::Test, public env::ShareDataTestSuite, pub
 			&pcTrayWnd->m_hIcons,
 			&pcTrayWnd->m_cMenuDrawer
 		);
+
+		std::error_code ec;
+		std::filesystem::remove(dummyPath, ec);
+
+		{
+			std::wofstream fos(dummyPath);
+			fos << L"ダミーファイルです" << std::endl;
+		}
 	}
 
 	/*!
@@ -503,6 +516,9 @@ struct TrayWndTest : public ::testing::Test, public env::ShareDataTestSuite, pub
 	 */
 	static void TearDownTestSuite()
 	{
+		std::error_code ec;
+		std::filesystem::remove(dummyPath, ec);
+
 		// トレイウィンドウのインスタンスを破棄する
 		pcTrayWnd = nullptr;
 
@@ -518,6 +534,8 @@ struct TrayWndTest : public ::testing::Test, public env::ShareDataTestSuite, pub
 	 */
 	void SetUp() override
 	{
+		User32::setInstance<MockUser32>();
+
 		CDlgOpenFile::setInstance<MockCDlgOpenFile>();
 	}
 
@@ -531,6 +549,8 @@ struct TrayWndTest : public ::testing::Test, public env::ShareDataTestSuite, pub
 
 		CDlgOpenFile::resetInstance();
 
+		User32::resetInstance();
+
 		TearDownUia();
 	}
 };
@@ -539,6 +559,11 @@ TEST_F(TrayWndTest, OpenNewEditor101)
 {
 	// 開いているファイルの数を上限値に設定する
 	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(strprintf(LS(STR_MAXWINDOW), MAX_EDITWINDOWS)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	SLoadInfo sLoadInfo{};
 	EXPECT_THAT(CControlTray::OpenNewEditor(nullptr, HWND(nullptr), sLoadInfo), IsFalse());
@@ -551,6 +576,11 @@ TEST_F(TrayWndTest, OpenNewEditor102)
 {
 	// 開いているファイルの数を上限値に設定する
 	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(strprintf(LS(STR_MAXWINDOW), MAX_EDITWINDOWS)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	EditInfo fi{};
 	EXPECT_THAT(CControlTray::OpenNewEditor2(nullptr, HWND(nullptr), &fi, false), IsFalse());
@@ -565,15 +595,12 @@ TEST_F(TrayWndTest, TerminateApplication101)
 
 	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
 
-	User32::setInstance<MockUser32>();
 	auto pUser32 = (MockUser32*)User32::getInstance();
-
-	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _)).Times(0);
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
+		.Times(0);
 
 	const HWND hWndFrom = nullptr;
 	CControlTray::TerminateApplication(hWndFrom);
-
-	User32::resetInstance();
 
 	// 設定を元に戻す
 	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
@@ -587,15 +614,13 @@ TEST_F(TrayWndTest, TerminateApplication102)
 
 	GetDllShareData().m_sNodes.m_nEditArrNum = 1;
 
-	User32::setInstance<MockUser32>();
 	auto pUser32 = (MockUser32*)User32::getInstance();
-
-	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"現在開いている編集用のウィンドウをすべて閉じて終了しますか?"), _, _, _)).WillOnce(Return(IDNO));
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(L"現在開いている編集用のウィンドウをすべて閉じて終了しますか?"), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDNO));
 
 	const HWND hWndFrom = nullptr;
 	CControlTray::TerminateApplication(hWndFrom);
-
-	User32::resetInstance();
 
 	// 設定を元に戻す
 	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
@@ -888,8 +913,21 @@ TEST_F(TrayWndTest, DoGrep101)
 	// 開いているファイルの数を上限値に設定する
 	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
 
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(strprintf(LS(STR_MAXWINDOW), MAX_EDITWINDOWS)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
+
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"Grep", IDOK);
+	dialog::ModalDialogCloser closer(L"Grep", [] (HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT, CBN_DROPDOWN);
+		SendDlgCommand(hWndDlg, IDC_COMBO_FILE, CBN_DROPDOWN);
+		SendDlgCommand(hWndDlg, IDC_COMBO_FOLDER, CBN_DROPDOWN);
+		SendDlgCommand(hWndDlg, IDC_COMBO_EXCLUDE_FILE, CBN_DROPDOWN);
+		SendDlgCommand(hWndDlg, IDC_COMBO_EXCLUDE_FOLDER, CBN_DROPDOWN);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
 
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_GREP_DIALOG);
@@ -927,19 +965,10 @@ TEST_F(TrayWndTest, ExitAll101)
  */
 TEST_F(TrayWndTest, OpenFile101)
 {
-	const auto path = GetIniFileName().replace_filename(L"dummy.txt");
-
-	std::error_code ec;
-	std::filesystem::remove(path, ec);
-
-	{
-		std::wofstream fos(path);
-		fos << L"ダミーファイルです" << std::endl;
-	}
-
 	// 開いているファイルの数を上限値に設定する
 	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
 
+	const auto& path = dummyPath;
 	MockCDlgOpenFile::gm_Files.emplace_back(path.native());
 
 	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
@@ -947,13 +976,16 @@ TEST_F(TrayWndTest, OpenFile101)
 		.Times(1)
 		.WillOnce(testing::DoDefault());
 
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(strprintf(LS(STR_MAXWINDOW), MAX_EDITWINDOWS)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
+
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_FILEOPEN);
 
 	// 設定を元に戻す
 	GetDllShareData().m_sNodes.m_nEditArrNum = 0;
-
-	std::filesystem::remove(path, ec);
 }
 
 /*!
@@ -964,6 +996,11 @@ TEST_F(TrayWndTest, OpenNewEditor103)
 {
 	// 開いているファイルの数を上限値に設定する
 	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(strprintf(LS(STR_MAXWINDOW), MAX_EDITWINDOWS)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	// トレイアイコンダブルクリックイベントを発生させる
 	HWND hWndTray = nullptr;
@@ -980,6 +1017,11 @@ TEST_F(TrayWndTest, OpenNewEditor104)
 {
 	// 開いているファイルの数を上限値に設定する
 	GetDllShareData().m_sNodes.m_nEditArrNum = MAX_EDITWINDOWS;
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(strprintf(LS(STR_MAXWINDOW), MAX_EDITWINDOWS)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_FILENEW);
@@ -999,6 +1041,11 @@ TEST_F(TrayWndTest, SelectAndOpenFilesFromMruFile101)
 	GetDllShareData().m_Common.m_sFile.m_bRestoreCurPosition = true;
 
 	GetDllShareData().m_sHistory.m_nMRUArrNum = 1;
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(strprintf(LS(STR_MAXWINDOW), MAX_EDITWINDOWS)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, IDM_SELMRU);
@@ -1022,6 +1069,11 @@ TEST_F(TrayWndTest, SelectAndOpenFilesFromMruFile102)
 	GetDllShareData().m_Common.m_sFile.m_bRestoreCurPosition = false;
 
 	GetDllShareData().m_sHistory.m_nMRUArrNum = 1;
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(strprintf(LS(STR_MAXWINDOW), MAX_EDITWINDOWS)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, IDM_SELMRU);
@@ -1069,7 +1121,17 @@ TEST_F(TrayWndTest, SaveAllFiles101)
 TEST_F(TrayWndTest, ShowDlgAbout001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"バージョン情報", IDOK);
+	dialog::ModalDialogCloser closer(L"バージョン情報", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_COPY);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
 
 	HWND hWndTray = nullptr;
 	pcTrayWnd->ExecCommand(hWndTray, F_ABOUT);
@@ -1090,6 +1152,9 @@ TEST_F(TrayWndTest, ShowDlgFavorite001)
 /*!
  * タイプ別設定一覧ダイアログの表示テスト
  */
+/*!
+ * タイプ別設定一覧ダイアログの表示テスト
+ */
 TEST_F(TrayWndTest, ShowDlgTypeList101)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
@@ -1101,14 +1166,40 @@ TEST_F(TrayWndTest, ShowDlgTypeList101)
 }
 
 /*!
+ * ウインドウ一覧ダイアログの表示テスト
+ */
+TEST_F(TrayWndTest, ShowDlgWindowList001)
+{
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ウィンドウ一覧", [] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SAVE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_CLOSE);
+
+		CMyRect rc{};
+		::GetClientRect(hWndDlg, &rc);
+		FORWARD_WM_SIZE(hWndDlg, SIZE_RESTORED, rc.right, rc.bottom, ::SendMessageW);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	using target = CDlgWindowList;
+	HWND hWndTray = nullptr;
+	EXPECT_THAT(pcTrayWnd->DispatchEvent(hWndTray, MYWM_DLGWINLIST, 0L, 0L), IsFalse());
+}
+
+/*!
  * ウィンドウ一覧ダイアログを表示する
  */
-TEST_F(TrayWndTest, ShowDlgWinList101)
+TEST_F(TrayWndTest, ShowDlgWindowList101)
 {
-	// 表示されたモーダルダイアログを閉じる
-	dialog::ModalDialogCloser closer(L"ウィンドウ一覧", [] (HWND hWndDlg) {
-		::EndDialog(hWndDlg, IDOK);
-	});
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"ウィンドウ一覧");
 
 	HWND hWndTray = nullptr;
 	EXPECT_THAT(pcTrayWnd->DispatchEvent(hWndTray, MYWM_DLGWINLIST, 0L, 0L), IsFalse());
@@ -1138,8 +1229,8 @@ TEST_F(TrayWndTest, ShowPropCommon001)
 	// ジャック初期化
 	CJackManager::getInstance();
 
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t1 = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	// 共通設定プロパティーシートを表示する
 	HWND hWndTray = nullptr;
@@ -1155,10 +1246,26 @@ TEST_F(TrayWndTest, ShowPropCommon001)
 TEST_F(TrayWndTest, ShowPropType001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"タイプ別設定一覧", IDOK);
+	dialog::ModalDialogCloser closer1(L"タイプ別設定一覧", IDOK);
 
-	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t1 = StartPropertySheetCloser(STR_PROPTYPE);
+	// 表示されたタイプ別設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer2(PSBTN_OK);
+
+	// タイプ別設定一覧ダイアログを表示する
+	HWND hWndTray = nullptr;
+	pcTrayWnd->ExecCommand(hWndTray, F_TYPE_LIST);
+}
+
+/*!
+ * タイプ別設定プロパティーシートの表示テスト
+ */
+TEST_F(TrayWndTest, ShowPropType101)
+{
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer1(L"タイプ別設定一覧", IDOK);
+
+	// 表示されたタイプ別設定をキャンセルボタンで閉じる
+	dialog::PropertySheetCloser closer2;
 
 	// タイプ別設定一覧ダイアログを表示する
 	HWND hWndTray = nullptr;
@@ -1173,28 +1280,19 @@ TEST_F(TrayWndTest, ShowPropType001)
  */
 TEST_F(TrayWndTest, ShowTrayMenu001)
 {
-	// ポップアップメニューは親ウィンドウを指定する必要があるのでダミーウィンドウを作る
-	const auto hInstance = G_AppInstance();
-	const auto hWnd = ::CreateWindowExW(0, WC_STATIC, L"test", 0, 1, 1, 1, 1, HWND(nullptr), HMENU(nullptr), hInstance, nullptr);
-	using WindowHolder = cxx::ResourceHolder<&::DestroyWindow>;
-	WindowHolder hWndHolder{ hWnd };
-
-	pcTrayWnd->m_hInstance = hInstance;
-	pcTrayWnd->m_hWnd = hWnd;
-
 	// 表示されたモーダルダイアログをOKボタンで閉じる
 	dialog::ModalDialogCloser closer(L"履歴とお気に入りの管理", IDOK);
 
 	// ポップアップメニュー項目を選択させる
-	auto t1 = StartPopupMenuSelector(L"履歴の管理(M)...");
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, TrackPopupMenu(_, _, _, _, _, _, _))
+		.Times(1)
+		.WillOnce(Return<int>(F_FAVORITE));
 
 	// トレイアイコン左クリックメニューを表示させる
-	HWND hWndTray = hWnd;
+	HWND hWndTray = nullptr;
 	pcTrayWnd->DispatchEvent(hWndTray, MYWM_NOTIFYICON, 0L, WM_LBUTTONDOWN);
 	pcTrayWnd->DispatchEvent(hWndTray, MYWM_NOTIFYICON, 0L, WM_LBUTTONUP);
-
-	pcTrayWnd->m_hWnd = nullptr;
-	pcTrayWnd->m_hInstance = nullptr;
 }
 
 /*!
@@ -1205,32 +1303,36 @@ TEST_F(TrayWndTest, ShowTrayMenu001)
  */
 TEST_F(TrayWndTest, ShowContextMenu001)
 {
-	// ポップアップメニューは親ウィンドウを指定する必要があるのでダミーウィンドウを作る
-	const auto hInstance = G_AppInstance();
-	const auto hWnd = ::CreateWindowExW(0, WC_STATIC, L"test", 0, 1, 1, 1, 1, HWND(nullptr), HMENU(nullptr), hInstance, nullptr);
-	using WindowHolder = cxx::ResourceHolder<&::DestroyWindow>;
-	WindowHolder hWndHolder{ hWnd };
-
-	pcTrayWnd->m_hInstance = hInstance;
-	pcTrayWnd->m_hWnd = hWnd;
-
 	// 表示されたモーダルダイアログをOKボタンで閉じる
 	dialog::ModalDialogCloser closer(L"バージョン情報", IDOK);
 
 	// ポップアップメニュー項目を選択させる
-	auto t1 = StartPopupMenuSelector(L"バージョン情報(A)");
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, TrackPopupMenu(_, _, _, _, _, _, _))
+		.Times(1)
+		.WillOnce(Return<int>(F_ABOUT));
 
 	// トレイアイコン右クリックメニューを表示させる
-	HWND hWndTray = hWnd;
+	HWND hWndTray = nullptr;
 	pcTrayWnd->DispatchEvent(hWndTray, MYWM_NOTIFYICON, 0L, WM_RBUTTONDOWN);
 	pcTrayWnd->DispatchEvent(hWndTray, MYWM_NOTIFYICON, 0L, WM_RBUTTONUP);
-
-	pcTrayWnd->m_hWnd = nullptr;
-	pcTrayWnd->m_hInstance = nullptr;
 }
 
 struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, public window::UiaTestSuite {
 	static constexpr HINSTANCE unusedArg1 = nullptr;
+
+	static inline const std::filesystem::path backupAgentTargetPath = GetIniFileName().replace_filename(L"backup-agent-target.txt");
+	static inline const std::filesystem::path backupPath = backupAgentTargetPath.parent_path() / (backupAgentTargetPath.stem().native() + L".bak");
+	static inline const std::filesystem::path colorizeExportPath = GetIniFileName().replace_filename(L"基本.col");
+	static inline const std::filesystem::path custmenuExportPath = GetIniFileName().replace_filename(L"カスタムメニュー.mnu");
+	static inline const std::filesystem::path dummyPath = GetIniFileName().replace_filename(L"dummy.txt");
+	static inline const std::filesystem::path fileTreeExportPath = GetIniFileName().replace_filename(L"ファイルツリー.ini");
+	static inline const std::filesystem::path keybindExportPath = GetIniFileName().replace_filename(L"キー割り当て.key");
+	static inline const std::filesystem::path keywordExportPath = GetIniFileName().replace_filename(L"強調キーワード.kwd");
+	static inline const std::filesystem::path keywordHelpExportPath = GetIniFileName().replace_filename(L"キーワードヘルプ.txt");
+	static inline const std::filesystem::path mainmenuExportPath = GetIniFileName().replace_filename(L"メインメニュー.ini");
+	static inline const std::filesystem::path regexKeywordExportPath = GetIniFileName().replace_filename(L"テキスト.rkw");
+	static inline const std::filesystem::path typeConfigExportPath = GetIniFileName().replace_filename(L"基本.ini");
 
 	static inline std::unique_ptr<CCommandLine> pCommandLine = nullptr;
 
@@ -1249,6 +1351,30 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 
 		CKeyMacroMgr::declare();
 		CWSHMacroManager::declare();
+
+		std::error_code ec;
+		std::filesystem::remove(backupAgentTargetPath, ec);
+		std::filesystem::remove(backupPath, ec);
+		std::filesystem::remove(colorizeExportPath, ec);
+		std::filesystem::remove(custmenuExportPath, ec);
+		std::filesystem::remove(dummyPath, ec);
+		std::filesystem::remove(fileTreeExportPath, ec);
+		std::filesystem::remove(keybindExportPath, ec);
+		std::filesystem::remove(keywordExportPath, ec);
+		std::filesystem::remove(keywordHelpExportPath, ec);
+		std::filesystem::remove(mainmenuExportPath, ec);
+		std::filesystem::remove(regexKeywordExportPath, ec);
+		std::filesystem::remove(typeConfigExportPath, ec);
+
+		{
+			std::wofstream fos(backupAgentTargetPath);
+			fos << L"line1" << std::endl;
+		}
+
+		{
+			std::wofstream fos(dummyPath);
+			fos << L"ダミーファイルです" << std::endl;
+		}
 	}
 
 	/*!
@@ -1256,6 +1382,20 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 	 */
 	static void TearDownTestSuite()
 	{
+		std::error_code ec;
+		std::filesystem::remove(backupAgentTargetPath, ec);
+		std::filesystem::remove(backupPath, ec);
+		std::filesystem::remove(colorizeExportPath, ec);
+		std::filesystem::remove(custmenuExportPath, ec);
+		std::filesystem::remove(dummyPath, ec);
+		std::filesystem::remove(fileTreeExportPath, ec);
+		std::filesystem::remove(keybindExportPath, ec);
+		std::filesystem::remove(keywordExportPath, ec);
+		std::filesystem::remove(keywordHelpExportPath, ec);
+		std::filesystem::remove(mainmenuExportPath, ec);
+		std::filesystem::remove(regexKeywordExportPath, ec);
+		std::filesystem::remove(typeConfigExportPath, ec);
+
 		CMacroFactory::getInstance()->Unregister(CWSHMacroManager::Creator);
 		CMacroFactory::getInstance()->Unregister(CKeyMacroMgr::Creator);
 
@@ -1273,9 +1413,13 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 	 */
 	void SetUp() override
 	{
+		User32::setInstance<MockUser32>();
+
 		mgr = std::unique_ptr<CMacroManagerBase>(CMacroFactory::getInstance()->Create(L"mac"));
 
 		CDlgOpenFile::setInstance<MockCDlgOpenFile>();
+
+		CDlgInput1::setInstance<MockCDlgInput1>();
 	}
 
 	/*!
@@ -1293,43 +1437,48 @@ struct EditWndTest : public ::testing::Test, public window::EditorTestSuite, pub
 		MSG msg{};
 		while (::PeekMessageW(&msg, nullptr, 0L, 0L, PM_REMOVE)) ;
 
+		// ファイルを閉じたことにする
+		pcEditDoc->m_cDocFile.SetFilePath(L"");
+
+		CDiffManager::resetInstance();
+
+		CDlgInput1::resetInstance();
+
 		CDlgOpenFile::resetInstance();
 
 		mgr = nullptr;
+
+		Comdlg32::resetInstance();
+
+		Shell32::resetInstance();
+
+		User32::resetInstance();
 
 		TearDownUia();
 	}
 
 	/*!
+	 * マクロ経由でコマンドを実行する
+	 */
+	bool ExecMacroCommand(std::wstring_view macroScript) {
+		return mgr->LoadKeyMacroStr(unusedArg1, std::data(macroScript))
+			&& mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0);
+	}
+
+	/*!
 	 * 共通設定プロパティーシートを表示する
 	 */
-	void ShowPropCommon(const std::optional<PropComSheetOrder>& optPageNum = std::nullopt) const
+	void ShowPropCommon(PropComSheetOrder pageNum) const
 	{
-		// シート番号の指定がある場合
-		if (optPageNum.has_value()) {
-			CEditApp::getInstance()->OpenPropertySheet(static_cast<int>(optPageNum.value()));
-		}
-		// シート番号の指定がない場合
-		else {
-			EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"OptionCommon()"), IsTrue());
-			EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
-		}
+		CEditApp::getInstance()->OpenPropertySheet( static_cast<int>(pageNum) );
 	}
 
 	/*!
 	 * タイプ別設定プロパティーシートを表示する
 	 */
-	void ShowPropType(const std::optional<PropTypeSheetOrder>& optPageNum = std::nullopt, const std::optional<CTypeConfig>& optDocType = std::nullopt) const
+	void ShowPropType(PropTypeSheetOrder pageNum) const
 	{
-		// シート番号の指定がある場合
-		if (optPageNum.has_value()) {
-			CEditApp::getInstance()->OpenPropertySheetTypes(static_cast<int>(optPageNum.value()), optDocType.value_or(GetDocument()->m_cDocType.GetDocumentType()));
-		}
-		// シート番号の指定がない場合
-		else {
-			EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"OptionType()"), IsTrue());
-			EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
-		}
+		CEditApp::getInstance()->OpenPropertySheetTypes(static_cast<int>(pageNum), GetDocument()->m_cDocType.GetDocumentType());
 	}
 };
 
@@ -1365,6 +1514,11 @@ TEST_F(EditWndTest, DISABLED_OnSetFocus101)	// パラメーター不正の考慮
 
 TEST_F(EditWndTest, OnEnable101)
 {
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(LS(STR_ERR_DLGDRPTGT1)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
+
 	HWND hWndEdit = nullptr;
 	EXPECT_THAT(pcEditWnd->DispatchEvent(hWndEdit, WM_ENABLE, TRUE, 0L), IsFalse());
 	EXPECT_THAT(pcEditWnd->DispatchEvent(hWndEdit, WM_ENABLE, FALSE, 0L), IsFalse());
@@ -1655,18 +1809,9 @@ TEST_F(EditWndTest, OnLButtonDblClk101)
  */
 TEST_F(EditWndTest, Command_OPEN_COMMAND_PROMPT101)
 {
-	const auto targetPath = GetIniFileName().replace_filename(L"backup-agent-target.txt");
+	const auto& targetPath = dummyPath;
 
-	std::error_code ec;
-	std::filesystem::remove(targetPath, ec);
-
-	{
-		std::wofstream fos(targetPath);
-		fos << L"line1" << std::endl;
-	}
-
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, std::format(L"FileOpen('{}', 99, 0, '無題1')", targetPath.native()).c_str()), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	EXPECT_THAT(ExecMacroCommand(std::format(L"FileOpen('{}', 99, 0, '無題1')", targetPath.native())), IsTrue());
 
 	Shell32::setInstance<MockShell32>();
 	auto pShell32 = (MockShell32*)Shell32::getInstance();
@@ -1674,14 +1819,8 @@ TEST_F(EditWndTest, Command_OPEN_COMMAND_PROMPT101)
 		.Times(1)
 		.WillOnce(Return(FALSE));
 
-	HWND hWndEdit = nullptr;
-	EXPECT_THAT(pcEditWnd->DispatchEvent(hWndEdit, WM_COMMAND, MAKEWPARAM(F_OPEN_COMMAND_PROMPT, 0), 0L), IsFalse());
-
-	pcEditDoc->m_cDocFile.SetFilePath(L"");
-
-	Shell32::resetInstance();
-
-	std::filesystem::remove(targetPath, ec);
+	HWND hWnd = nullptr;
+	FORWARD_WM_COMMAND(hWnd, F_OPEN_COMMAND_PROMPT, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -1705,21 +1844,10 @@ TEST_F(EditWndTest, DiffComponents001)
  */
 TEST_F(EditWndTest, FileSaveWithBackupAgent001)
 {
+	const auto& targetPath = backupAgentTargetPath;
+
 	auto& sBackup = GetDllShareData().m_Common.m_sBackup;
 	const CommonSetting_Backup backupOld = sBackup;
-
-	const auto targetPath = GetIniFileName().replace_filename(L"backup-agent-target.txt");
-	const auto backupPath = targetPath.parent_path() / (targetPath.stem().native() + L".bak");
-
-	std::error_code ec;
-
-	std::filesystem::remove(targetPath, ec);
-	std::filesystem::remove(backupPath, ec);
-
-	{
-		std::wofstream fos(targetPath);
-		fos << L"line1" << std::endl;
-	}
 
 	sBackup.m_bBackUp = true;
 	sBackup.m_bBackUpDialog = false;
@@ -1728,19 +1856,17 @@ TEST_F(EditWndTest, FileSaveWithBackupAgent001)
 	sBackup.m_bBackUpPathAdvanced = false;
 	sBackup.m_bBackUpDustBox = false;
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, std::format(L"FileOpen('{}', 99, 0, '無題1')", targetPath.native()).c_str()), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	// ファイルを開く
+	EXPECT_THAT(ExecMacroCommand(std::format(L"FileOpen('{}', 99, 0, '無題1')", targetPath.native())), IsTrue());
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"Replace('line1', 'line1x')"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	// 編集済みにする
+	pcEditDoc->m_cDocEditor.m_bIsDocModified = true;
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"FileSave()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	// 上書き保存してバックアップを作らせる
+	EXPECT_THAT(ExecMacroCommand(L"FileSave()"), IsTrue());
 
+	// バックアップが作られたことを確認する
 	EXPECT_THAT(fexist(backupPath), IsTrue());
-
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"FileClose()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 
 	auto backupAgent = std::make_unique<CBackupAgent>();
 
@@ -1751,14 +1877,9 @@ TEST_F(EditWndTest, FileSaveWithBackupAgent001)
 	backupAgent->FormatBackUpPath(newPath, std::size(newPath), backupPath.c_str());
 	EXPECT_THAT(newPath, StrEq(LR"(C:\Users\Public\Desktop\backup-agent-target.bak)"));
 
-	pcEditDoc->m_cDocFile.SetFilePath(L"");
-
 	backupAgent = nullptr;
 
 	sBackup = backupOld;
-
-	std::filesystem::remove(targetPath, ec);
-	std::filesystem::remove(backupPath, ec);
 }
 
 /*!
@@ -1766,22 +1887,13 @@ TEST_F(EditWndTest, FileSaveWithBackupAgent001)
  */
 TEST_F(EditWndTest, GetDocDataObject001)
 {
-	const auto targetPath = GetIniFileName().replace_filename(L"backup-agent-target.txt");
-
-	std::error_code ec;
-	std::filesystem::remove(targetPath, ec);
+	const auto& targetPath = dummyPath;
 
 	cxx::com_pointer<IDataObject> pDataObject;
 	EXPECT_HRESULT_SUCCEEDED(GetDocument()->GetDataObject(&pDataObject));
 	EXPECT_THAT(pDataObject, IsNull());
 
-	{
-		std::wofstream fos(targetPath);
-		fos << L"line1" << std::endl;
-	}
-
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, std::format(L"FileOpen('{}', 99, 0, '無題1')", targetPath.native()).c_str()), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	EXPECT_THAT(ExecMacroCommand(std::format(L"FileOpen('{}', 99, 0, '無題1')", targetPath.native())), IsTrue());
 
 	EXPECT_HRESULT_SUCCEEDED(GetDocument()->GetDataObject(&pDataObject));
 	EXPECT_THAT(pDataObject, NotNull());
@@ -1808,13 +1920,6 @@ TEST_F(EditWndTest, GetDocDataObject001)
 	memory = medium.hGlobal;
 
 	EXPECT_THAT(memory.wstring(), StrEq(targetPath.native()));
-
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"FileClose()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
-
-	pcEditDoc->m_cDocFile.SetFilePath(L"");
-
-	std::filesystem::remove(targetPath, ec);
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -1826,13 +1931,18 @@ TEST_F(EditWndTest, ShowDlgCancel001)
 {
 	// 表示されたモーダルダイアログを閉じる
 	dialog::ModalDialogCloser closer(L"Grep実行中", [](HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// ボタンID以外でOnCommandを空振りさせる
+		SendDlgCommand(hWndDlg, IDC_STATIC_CURPATH);
+
 		SendDlgCommand(hWndDlg, IDCANCEL);
 	});
 
 	CDlgCancel cDlgCancel;
 
 	const auto hWnd = pcEditWnd->GetHwnd();
-
 	cDlgCancel.DoModeless(unusedArg1, hWnd, IDD_GREPRUNNING);
 
 	// キューに溜まるメッセージを処理する
@@ -1846,11 +1956,66 @@ TEST_F(EditWndTest, ShowDlgCancel001)
  */
 TEST_F(EditWndTest, ShowDlgFind001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"検索", IDOK);
+	// 検索条件
+	CSearchKeywordManager().AddToSearchKeyArr(LR"(localhost)");
 
-	using target = CDlgFind;
-	pcEditWnd->m_cDlgFind.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()));
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"検索", [](HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// ボタンID以外でOnCommandを空振りさせる
+		SendDlgCommand(hWndDlg, IDC_STATIC_CURPATH);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, false);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, true);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+
+		// 検索系ボタンの押下(空振りさせる)
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
+
+		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT, CBN_DROPDOWN);
+
+		// 検索条件をセット
+		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_TEXT, L"test");
+
+		// 検索系ボタンの押下(最後まではいけない)
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
+
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
+		.Times(2)
+		.WillOnce(Return(IDOK))		// 検索条件を指定してください。
+		.WillOnce(Return(IDOK));	// 検索条件を指定してください。
+
+	auto& cDlgFind = pcEditWnd->m_cDlgFind;
+	cDlgFind.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()));
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
+
+	// 設定を元に戻す
+	GetDllShareData().m_sSearchKeywords.m_aSearchKeys.clear();
+}
+
+/*!
+ * 検索ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgFind101)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"検索");
+
+	auto& cDlgFind = pcEditWnd->m_cDlgFind;
+	cDlgFind.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()));
 
 	// キューに溜まるメッセージを処理する
 	RunMessageLoop();
@@ -1859,7 +2024,7 @@ TEST_F(EditWndTest, ShowDlgFind001)
 /*!
  * 検索ダイアログの表示テスト
  */
-TEST_F(EditWndTest, ShowDlgFind101)
+TEST_F(EditWndTest, ShowDlgFind102)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"検索");
@@ -1878,9 +2043,34 @@ TEST_F(EditWndTest, ShowDlgFind101)
 TEST_F(EditWndTest, ShowDlgFuncList001)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(std::nullopt, [] (HWND hWndDlg) {
+	dialog::ModalDialogCloser closer1(std::nullopt, [] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_MENU);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_COPY);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_WINSIZE);
+
+		SendDlgCommand(hWndDlg, IDC_CHECK_bAutoCloseDlgFuncList);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETTING);
+
+		CMyRect rc{};
+		::GetClientRect(hWndDlg, &rc);
+		FORWARD_WM_SIZE(hWndDlg, SIZE_RESTORED, rc.right, rc.bottom, ::SendMessageW);
+
 		SendDlgCommand(hWndDlg, IDCANCEL);
 	});
+
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer2(L"ファイルツリー設定");
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, TrackPopupMenu(_, _, _, _, _, _, _))
+		.Times(1)
+		.WillOnce(Return(450));	// 更新
 
 	using target = CDlgFuncList;
 	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"Outline(0)"), IsTrue());
@@ -1894,6 +2084,94 @@ TEST_F(EditWndTest, ShowDlgFuncList001)
  * 置換ダイアログの表示テスト
  */
 TEST_F(EditWndTest, ShowDlgReplace001)
+{
+	// 検索条件
+	CSearchKeywordManager().AddToSearchKeyArr(LR"(localhost)");
+
+	// 置換文字列
+	CSearchKeywordManager().AddToReplaceKeyArr( LR"(royalhost)" );
+
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"置換", [](HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// ボタンID以外でOnCommandを空振りさせる
+		SendDlgCommand(hWndDlg, IDC_STATIC_CURPATH);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, false);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, true);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_PASTE, true);
+		SendDlgCommand(hWndDlg, IDC_CHK_PASTE);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_PASTE, false);
+		SendDlgCommand(hWndDlg, IDC_CHK_PASTE);
+
+		// 検索系ボタンの押下(空振りさせる)
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCEALL);
+
+		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT, CBN_DROPDOWN);
+		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT2, CBN_DROPDOWN);
+
+		// 検索条件をセット
+		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_TEXT, L"test");
+		apiwrap::SetDlgItemTextW(hWndDlg, IDC_COMBO_TEXT2, L"text");
+
+		// 検索系ボタンの押下(最後まではいけない)
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHNEXT);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SEARCHPREV);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETMARK);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_REPALCEALL);
+
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
+		.Times(5)
+		.WillOnce(Return(IDOK))		// 文字列を指定してください。
+		.WillOnce(Return(IDOK))		// 文字列を指定してください。
+		.WillOnce(Return(IDOK))		// 文字列を指定してください。
+		.WillOnce(Return(IDOK))		// 置換条件を指定してください。
+		.WillOnce(Return(IDOK));	// 0箇所を置換しました。
+
+	auto& cDlgReplace = pcEditWnd->m_cDlgReplace;
+	cDlgReplace.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()), false);
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
+
+	// 設定を元に戻す
+	GetDllShareData().m_sSearchKeywords.m_aSearchKeys.clear();
+	GetDllShareData().m_sSearchKeywords.m_aReplaceKeys.clear();
+}
+
+/*!
+ * 置換ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgReplace101)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"置換");
+
+	auto& cDlgReplace = pcEditWnd->m_cDlgReplace;
+	cDlgReplace.DoModeless(unusedArg1, pcEditWnd->GetHwnd(), LPARAM(&pcEditWnd->GetActiveView()), false);
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
+}
+
+/*!
+ * 置換ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgReplace102)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"置換");
@@ -1909,7 +2187,7 @@ TEST_F(EditWndTest, ShowDlgReplace001)
 /*!
  * バージョン情報ダイアログの表示テスト
  */
-TEST_F(EditWndTest, ShowDlgAbout101)
+TEST_F(EditWndTest, ShowDlgAbout001)
 {
 	// 表示されたモーダルダイアログを閉じる
 	dialog::ModalDialogCloser closer(L"バージョン情報", [this] (HWND hWndDlg) {
@@ -1924,11 +2202,27 @@ TEST_F(EditWndTest, ShowDlgAbout101)
 
 		EXPECT_THAT(SendInput(inputs), Eq(std::size(inputs)));
 
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
 		SendDlgCommand(hWndDlg, IDOK);
 	});
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"About()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	using target = CDlgAbout;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_ABOUT, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
+}
+
+/*!
+ * バージョン情報ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgAbout101)
+{
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer(L"バージョン情報");
+
+	using target = CDlgAbout;
+	EXPECT_THAT(ExecMacroCommand(L"About()"), IsTrue());
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -1939,7 +2233,19 @@ TEST_F(EditWndTest, ShowDlgAbout101)
 TEST_F(EditWndTest, ShowDlgCompare001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ファイル内容比較", IDOK);
+	dialog::ModalDialogCloser closer(L"ファイル内容比較", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		CMyRect rc{};
+		::GetClientRect(hWndDlg, &rc);
+		FORWARD_WM_SIZE(hWndDlg, SIZE_RESTORED, rc.right, rc.bottom, ::SendMessageW);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
 
 	CDlgCompare cDlgCompare;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -1971,11 +2277,19 @@ TEST_F(EditWndTest, ShowDlgCompare101)
 TEST_F(EditWndTest, ShowDlgCtrlCode001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"コントロールコード", IDOK);
+	dialog::ModalDialogCloser closer(L"コントロールコード", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
 
 	using target = CDlgCtrlCode;
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"CtrlCodeDialog()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_CTRL_CODE_DIALOG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -1986,8 +2300,8 @@ TEST_F(EditWndTest, ShowDlgCtrlCode101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"コントロールコード");
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"CtrlCodeDialog()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	using target = CDlgCtrlCode;
+	EXPECT_THAT(ExecMacroCommand(L"CtrlCodeDialog()"), IsTrue());
 }
 
 /*!
@@ -1996,11 +2310,44 @@ TEST_F(EditWndTest, ShowDlgCtrlCode101)
 TEST_F(EditWndTest, ShowDlgDiff001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"DIFF差分表示", IDOK);
+	dialog::ModalDialogCloser closer(L"DIFF差分表示", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_DIFF_DST);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_DIFF_DST2, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_DIFF_DST2);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_DIFF_DST1, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_DIFF_DST1);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_DIFF_FILE2, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_DIFF_FILE2);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_DIFF_FILE1, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_DIFF_FILE1);
+
+		CMyRect rc{};
+		::GetClientRect(hWndDlg, &rc);
+		FORWARD_WM_SIZE(hWndDlg, SIZE_RESTORED, rc.right, rc.bottom, ::SendMessageW);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
 
 	using target = CDlgDiff;
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"DiffDialog()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+
+	using target = CDlgDiff;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_DIFF_DIALOG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2011,8 +2358,8 @@ TEST_F(EditWndTest, ShowDlgDiff101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"DIFF差分表示");
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"DiffDialog()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	using target = CDlgDiff;
+	EXPECT_THAT(ExecMacroCommand(L"DiffDialog()"), IsTrue());
 }
 
 /*!
@@ -2029,12 +2376,18 @@ TEST_F(EditWndTest, ShowDlgExec001)
 		::CheckDlgButtonBool(hWndDlg, IDC_CHECK_CUR_DIR, true);
 		::SetDlgItemTextW(hWndDlg, IDC_COMBO_CUR_DIR, GetExeFileName().parent_path().c_str());
 
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
 		SendDlgCommand(hWndDlg, IDOK);
 	});
 
 	using target = CDlgExec;
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ExecCommandDialog()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_EXECMD_DIALOG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2045,8 +2398,8 @@ TEST_F(EditWndTest, ShowDlgExec101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"ファイル名を指定して実行");
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ExecCommandDialog()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	using target = CDlgExec;
+	EXPECT_THAT(ExecMacroCommand(L"ExecCommandDialog()"), IsTrue());
 }
 
 /*!
@@ -2055,11 +2408,47 @@ TEST_F(EditWndTest, ShowDlgExec101)
 TEST_F(EditWndTest, ShowDlgFavorite001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"履歴とお気に入りの管理", IDOK);
+	dialog::ModalDialogCloser closer(L"履歴とお気に入りの管理", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		// 初期表示の履歴項目は「編集不可」なので空振る
+		SendDlgCommand(hWndDlg, IDC_BUTTON_ADD_FAVORITE);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_DELETE_NOFAVORATE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_DELETE_NOTFOUND);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_DELETE_SELECTED);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_CLEAR);
+
+		const auto hWndTab = ::GetDlgItem(hWndDlg, IDC_TAB_FAVORITE);
+
+		NMHDR nmhdr{};
+		nmhdr.hwndFrom = hWndTab;
+		nmhdr.idFrom = IDC_TAB_FAVORITE;
+		nmhdr.code = TCN_SELCHANGE;
+		FORWARD_WM_NOTIFY(hWndDlg, IDC_TAB_FAVORITE, &nmhdr,  ::SendMessageW);
+
+		CMyRect rc{};
+		::GetClientRect(hWndDlg, &rc);
+		FORWARD_WM_SIZE(hWndDlg, SIZE_RESTORED, rc.right, rc.bottom, ::SendMessageW);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
+		.Times(3)
+		.WillOnce(Return(IDOK))		// 最近使ったファイルの履歴のお気に入り以外を削除します。\nよろしいですか？
+		.WillOnce(Return(IDOK))		// 最近使ったファイルの存在しないパスを削除します。\nよろしいですか？
+		.WillOnce(Return(IDOK));	// 最近使ったファイルの履歴を削除します。\nよろしいですか？
 
 	using target = CDlgFavorite;
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"OptionFavorite()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_FAVORITE, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2070,8 +2459,8 @@ TEST_F(EditWndTest, ShowDlgFavorite101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"履歴とお気に入りの管理");
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"OptionFavorite()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	using target = CDlgFavorite;
+	EXPECT_THAT(ExecMacroCommand(L"OptionFavorite()"), IsTrue());
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -2081,13 +2470,53 @@ TEST_F(EditWndTest, ShowDlgFavorite101)
  */
 TEST_F(EditWndTest, ShowDlgFileTree001)
 {
-	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ファイルツリー設定", IDOK);
+	// 表示されたモードレスダイアログを閉じる
+	dialog::ModalDialogCloser closer1(L"x", [](HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETTING);
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
 
-	CDlgFileTree cDlgFileTree;
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer2(L"ファイルツリー設定", [](HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_EXPORT);
+		// 保存先ファイル名の入力はモックで実現する
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_IMPORT);
+		// 開くファイル名の入力はモックで実現する
+
+		SendDlgCommand(hWndDlg, IDOK);
+
+		::EndDialog(hWndDlg, IDOK);
+	});
+
+	const auto& exportPath = fileTreeExportPath;
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	const auto exportMsg = std::wstring{ LS(STR_IMPEXP_OK_EXPORT) } + exportPath.native();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(exportMsg), _, _, _))
+		.WillRepeatedly(Return(IDOK));
+
+	using target = CDlgFileTree;
 	const auto hWnd = pcEditWnd->GetHwnd();
-	auto& cDlgFuncList = pcEditWnd->m_cDlgFuncList;
-	cDlgFileTree.DoModal(unusedArg1, hWnd, LPARAM(&cDlgFuncList));
+	FORWARD_WM_COMMAND(hWnd, F_OUTLINE, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
 }
 
 /*!
@@ -2095,13 +2524,22 @@ TEST_F(EditWndTest, ShowDlgFileTree001)
  */
 TEST_F(EditWndTest, ShowDlgFileTree101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ファイルツリー設定");
+	// 表示されたモードレスダイアログを閉じる
+	dialog::ModalDialogCloser closer1(L"x", [](HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SETTING);
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
 
-	CDlgFileTree cDlgFileTree;
-	const auto hWnd = pcEditWnd->GetHwnd();
-	auto& cDlgFuncList = pcEditWnd->m_cDlgFuncList;
-	cDlgFileTree.DoModal(unusedArg1, hWnd, LPARAM(&cDlgFuncList));
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer2(L"ファイルツリー設定", [](HWND hWndDlg) {
+		::EndDialog(hWndDlg, IDCANCEL);
+	});
+
+	using target = CDlgFileTree;
+	EXPECT_THAT(ExecMacroCommand(L"Outline(0)"), IsTrue());
+
+	// キューに溜まるメッセージを処理する
+	RunMessageLoop();
 }
 
 /*!
@@ -2110,7 +2548,15 @@ TEST_F(EditWndTest, ShowDlgFileTree101)
 TEST_F(EditWndTest, ShowDlgFileUpdateQuery101)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ファイルが更新されました");
+	dialog::ModalDialogCloser closer(L"ファイルが更新されました", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
 
 	CDlgFileUpdateQuery cDlgFileUpdateQuery(L"", false);
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2126,12 +2572,38 @@ TEST_F(EditWndTest, ShowDlgGrep001)
 {
 	// 表示されたモーダルダイアログを閉じる
 	dialog::ModalDialogCloser closer(L"Grep", [] (HWND hWndDlg) {
-		SendDlgCommand(hWndDlg, IDOK);
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, false);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_REGULAREXP, true);
+		SendDlgCommand(hWndDlg, IDC_CHK_REGULAREXP);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHECK_CP, true);
+		SendDlgCommand(hWndDlg, IDC_CHECK_CP);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_FROMTHISTEXT, true);
+		SendDlgCommand(hWndDlg, IDC_CHK_FROMTHISTEXT);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHK_FROMTHISTEXT, false);
+		SendDlgCommand(hWndDlg, IDC_CHK_FROMTHISTEXT);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_CURRENTFOLDER);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_FOLDER_UP);
+
+		// OKボタンを押下するとGrepが動いてしまうのでコメントアウトする。
+		// （Grep置換と異なり、動かしても危険はないが余分にテスト時間がかかってしまう）
+		//SendDlgCommand(hWndDlg, IDOK);
+
 		SendDlgCommand(hWndDlg, IDCANCEL);
 	});
 
 	using target = CDlgGrep;
-	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_GREP_DIALOG, true, 0, 0, 0, 0);
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_GREP_DIALOG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2142,7 +2614,9 @@ TEST_F(EditWndTest, ShowDlgGrep101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"Grep");
 
-	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_GREP_DIALOG, true, 0, 0, 0, 0);
+	using target = CDlgGrep;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_GREP_DIALOG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2150,14 +2624,31 @@ TEST_F(EditWndTest, ShowDlgGrep101)
  */
 TEST_F(EditWndTest, ShowDlgGrepReplace001)
 {
+	// 置換文字列
+	CSearchKeywordManager().AddToReplaceKeyArr( LR"(royalhost)" );
+
 	// 表示されたモーダルダイアログを閉じる
 	dialog::ModalDialogCloser closer(L"Grep置換", [] (HWND hWndDlg) {
-		SendDlgCommand(hWndDlg, IDOK);
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDC_COMBO_TEXT2, CBN_DROPDOWN);
+
+		// Grep置換はOKボタンを押下すると危険なのでコメントアウトする。
+		//SendDlgCommand(hWndDlg, IDOK);
+
 		SendDlgCommand(hWndDlg, IDCANCEL);
 	});
 
 	using target = CDlgGrepReplace;
-	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_GREP_REPLACE_DLG, true, 0, 0, 0, 0);
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_GREP_REPLACE_DLG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
+
+	// 設定を元に戻す
+	GetDllShareData().m_sSearchKeywords.m_aReplaceKeys.clear();
 }
 
 /*!
@@ -2168,7 +2659,9 @@ TEST_F(EditWndTest, ShowDlgGrepReplace101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"Grep置換");
 
-	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_GREP_REPLACE_DLG, true, 0, 0, 0, 0);
+	using target = CDlgGrepReplace;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_GREP_REPLACE_DLG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -2193,7 +2686,7 @@ TEST_F(EditWndTest, ShowDlgInputBox001)
 		::SendMessageW(hWndDlg, WM_HELP, 0L, LPARAM(&hi));
 
 		// コンテキストメニュー表示を空振りさせる
-		FORWARD_WM_CONTEXTMENU(hWndDlg, ::GetDlgItem(hWndDlg, IDC_EDIT_INPUT1), 0L, 0L, ::SendMessageW);
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
 
 		// 処理対象でないボタンIDを送信して空振りさせる
 		SendDlgCommand(hWndDlg, 0L);
@@ -2219,6 +2712,22 @@ TEST_F(EditWndTest, ShowDlgInputBox001)
 /*!
  * 1行入力ダイアログの表示テスト
  */
+TEST_F(EditWndTest, ShowDlgInputBox002)
+{
+	// マクロ関数を呼ぶためにWSHマクロマネージャーを使う
+	mgr = std::unique_ptr<CMacroManagerBase>(CMacroFactory::getInstance()->Create(L"js"));
+
+	auto& cDlgInput1 = static_cast<MockCDlgInput1&>(*CDlgInput1::getInstance());
+	EXPECT_CALL(cDlgInput1, DoModal(_, _, _, _, _))
+		.Times(1)
+		.WillOnce(Return(TRUE));
+
+	EXPECT_THAT(ExecMacroCommand(L"InputBox('test1', 'test2', 0)"), IsTrue());
+}
+
+/*!
+ * 1行入力ダイアログの表示テスト
+ */
 TEST_F(EditWndTest, ShowDlgInputBox101)
 {
 	// モックを解除してダイアログをテストする
@@ -2230,8 +2739,7 @@ TEST_F(EditWndTest, ShowDlgInputBox101)
 	// マクロ関数を呼ぶためにWSHマクロマネージャーを使う
 	mgr = std::unique_ptr<CMacroManagerBase>(CMacroFactory::getInstance()->Create(L"js"));
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"InputBox('test1', 'test2', 0)"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	EXPECT_THAT(ExecMacroCommand(L"InputBox('test1', 'test2', 0)"), IsTrue());
 }
 
 /*!
@@ -2241,12 +2749,33 @@ TEST_F(EditWndTest, ShowDlgJump001)
 {
 	// 表示されたモーダルダイアログを閉じる
 	dialog::ModalDialogCloser closer(L"指定行へジャンプ", [] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHECK_PLSQL, true);
+		SendDlgCommand(hWndDlg, IDC_CHECK_PLSQL);
+
+		SendDlgCommand(hWndDlg, IDC_COMBO_PLSQLBLOCKS, CBN_SELCHANGE);
+		SendDlgCommand(hWndDlg, IDC_CHECK_PLSQL, CBN_SELCHANGE);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHECK_PLSQL, false);
+		SendDlgCommand(hWndDlg, IDC_CHECK_PLSQL);
+
 		SendDlgCommand(hWndDlg, IDC_BUTTON_JUMP);
 		SendDlgCommand(hWndDlg, IDCANCEL);
 	});
 
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(LS(STR_DLGJUMP1)), _, _, _))
+		.Times(1)
+		.WillRepeatedly(Return(IDOK));
+
 	using target = CDlgJump;
-	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_JUMP_DIALOG, true, 0, 0, 0, 0);
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_JUMP_DIALOG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2257,7 +2786,9 @@ TEST_F(EditWndTest, ShowDlgJump101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"指定行へジャンプ");
 
-	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_JUMP_DIALOG, true, 0, 0, 0, 0);
+	using target = CDlgJump;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_JUMP_DIALOG, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -2268,7 +2799,15 @@ TEST_F(EditWndTest, ShowDlgJump101)
 TEST_F(EditWndTest, ShowDlgKeywordSelect001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"強調キーワードの設定", IDOK);
+	dialog::ModalDialogCloser closer(L"強調キーワードの設定", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
 
 	CDlgKeywordSelect cDlgKeywordSelect;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2281,13 +2820,19 @@ TEST_F(EditWndTest, ShowDlgKeywordSelect001)
  */
 TEST_F(EditWndTest, ShowDlgKeywordSelect101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"強調キーワードの設定");
+	// 表示されたタイプ別設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
+		SendDlgCommand(hWndPage, IDC_BUTTON_KEYWORD_SELECT);
 
-	CDlgKeywordSelect cDlgKeywordSelect;
-	const auto hWnd = pcEditWnd->GetHwnd();
-	std::array<int, 10> nSet{};
-	cDlgKeywordSelect.DoModal(unusedArg1, hWnd, nSet.data());
+		// OKボタンを押下して閉じる
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
+	});
+
+	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
+	dialog::ModalDialogCloser closer2(L"強調キーワードの設定");
+
+	using target = CDlgKeywordSelect;
+	ShowPropType(ID_PROPTYPE_PAGENUM_COLOR);
 }
 
 #if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -2307,8 +2852,7 @@ TEST_F(EditWndTest, ShowDlgOpenFile101)
 		.Times(1)
 		.WillOnce(testing::DoDefault());
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"FileOpen('', 99, 0, '無題1')"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	EXPECT_THAT(ExecMacroCommand(L"FileOpen('', 99, 0, '無題1')"), IsTrue());
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -2349,13 +2893,17 @@ TEST_F(EditWndTest, ShowDlgPluginOption001)
 		// "%ls プラグインの設定"
 		const auto title = strprintf(LS(STR_DLGPLUGINOPT_TITLE), L"Test WSH Plugin");
 		EXPECT_THAT(apiwrap::GetWindowTextW(hWndDlg), StrEq(title));
+
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
 		SendDlgCommand(hWndDlg, IDOK);
 	});
 
 	cDlgPluginOption.DoModal(unusedArg1, hWnd, propPlugin.get(), pluginId);
-
-	// 存在しないプラグイン番号を指定すると、ダイアログは表示されない
-	cDlgPluginOption.DoModal(unusedArg1, hWnd, propPlugin.get(), 0);
 
 	// プラグイン読み込み解除
 	CPluginManager::getInstance()->UnloadAllPlugin();
@@ -2367,12 +2915,89 @@ TEST_F(EditWndTest, ShowDlgPluginOption001)
 }
 
 /*!
+ * プラグイン設定ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgPluginOption101)
+{
+	CDlgPluginOption cDlgPluginOption;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	const auto propPlugin = std::make_unique<CPropPlugin>();
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(LS(STR_DLGPLUGINOPT_LOAD)), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
+
+	// 存在しないプラグイン番号を指定すると、ダイアログは表示されない
+	cDlgPluginOption.DoModal(unusedArg1, hWnd, propPlugin.get(), 0);
+}
+
+/*!
  * 印刷設定ダイアログの表示テスト
  */
 TEST_F(EditWndTest, ShowDlgPrintSetting001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"印刷ページ設定", IDOK);
+	dialog::ModalDialogCloser closer(L"印刷ページ設定", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHECK_LINENUMBER, true);
+		SendDlgCommand(hWndDlg, IDC_CHECK_LINENUMBER);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_LANDSCAPE, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_LANDSCAPE);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_PORTRAIT, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_PORTRAIT);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_FONT_FOOT);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_FONT_FOOT);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_FONT_HEAD);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_FONT_HEAD);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHECK_USE_FONT_FOOT, true);
+		SendDlgCommand(hWndDlg, IDC_CHECK_USE_FONT_FOOT);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHECK_USE_FONT_HEAD, true);
+		SendDlgCommand(hWndDlg, IDC_CHECK_USE_FONT_HEAD);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_EDITSETTINGNAME);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_EDITSETTINGNAME);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	auto& cDlgInput1 = static_cast<MockCDlgInput1&>(*CDlgInput1::getInstance());
+	EXPECT_CALL(cDlgInput1, DoModal(_, _, _, _, _))
+		.Times(2)
+		.WillOnce(Return(FALSE))
+		.WillOnce(Invoke([] (HWND, LPCWSTR, LPCWSTR, LPWSTR pBuffer, size_t cchBuffer) -> BOOL {
+			::wcscpy_s(pBuffer, cchBuffer, L"test");
+			return TRUE;
+		}));
+
+	Comdlg32::setInstance<MockComdlg32>();
+
+	auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+	EXPECT_CALL(*pComdlg32, ChooseFontW(_))
+		.Times(4)
+		.WillOnce(Return(FALSE))
+		.WillOnce(Invoke([] (LPCHOOSEFONTW pCf) -> BOOL {
+			pCf->iPointSize = 9;
+			return TRUE;
+		}))
+		.WillOnce(Return(FALSE))
+		.WillOnce(Invoke([] (LPCHOOSEFONTW pCf) -> BOOL {
+			pCf->iPointSize = 9;
+			return TRUE;
+		}));
+	EXPECT_CALL(*pComdlg32, CommDlgExtendedError())
+		.WillRepeatedly(Return(0));
 
 	CDlgPrintSetting cDlgPrintSetting;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2389,11 +3014,9 @@ TEST_F(EditWndTest, ShowDlgPrintSetting101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"印刷ページ設定");
 
-	CDlgPrintSetting cDlgPrintSetting;
+	using target = CDlgPrintSetting;
 	const auto hWnd = pcEditWnd->GetHwnd();
-	int nCurrentPrintSetting = -1;
-	int nLineNumberColumns = 10;
-	cDlgPrintSetting.DoModal(unusedArg1, hWnd, &nCurrentPrintSetting, GetDllShareData().m_PrintSettingArr, nLineNumberColumns);
+	FORWARD_WM_COMMAND(hWnd, F_PRINT_PAGESETUP, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 #if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -2404,12 +3027,44 @@ TEST_F(EditWndTest, ShowDlgPrintSetting101)
 TEST_F(EditWndTest, ShowDlgProfileMgr101)
 {
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"プロファイルマネージャ");
+	dialog::ModalDialogCloser closer(L"プロファイルマネージャ", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
 
-	// プロファイルマネージャーを表示するには、CCommandLineのインスタンスが必要。	👈バグです。
-	CCommandLine cmd;
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
 
-	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_PROFILEMGR, true, 0, 0, 0, 0);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_PROF_CREATE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_PROF_CREATE);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_PROF_DEFSET);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_PROF_DEFCLEAR);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_PROF_RENAME);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_PROF_RENAME);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_PROF_DELETE);
+
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
+
+	auto& cDlgInput1 = static_cast<MockCDlgInput1&>(*CDlgInput1::getInstance());
+	EXPECT_CALL(cDlgInput1, DoModal(_, _, _, _, _))
+		.Times(4)
+		.WillOnce(Return(FALSE))
+		.WillOnce(Invoke([] (HWND, LPCWSTR, LPCWSTR, LPWSTR pBuffer, size_t cchBuffer) -> BOOL {
+			::wcscpy_s(pBuffer, cchBuffer, L"test1");
+			return TRUE;
+		}))
+		.WillOnce(Return(FALSE))
+		.WillOnce(Invoke([] (HWND, LPCWSTR, LPCWSTR, LPWSTR pBuffer, size_t cchBuffer) -> BOOL {
+			::wcscpy_s(pBuffer, cchBuffer, L"test2");
+			return TRUE;
+		}));
+
+	using target = CDlgProfileMgr;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_PROFILEMGR, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2418,10 +3073,19 @@ TEST_F(EditWndTest, ShowDlgProfileMgr101)
 TEST_F(EditWndTest, ShowDlgProperty001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ファイルのプロパティ", IDOK);
+	dialog::ModalDialogCloser closer(L"ファイルのプロパティ", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"PropertyFile()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	using target = CDlgProperty;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_PROPERTY_FILE, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2432,8 +3096,8 @@ TEST_F(EditWndTest, ShowDlgProperty101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"ファイルのプロパティ");
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"PropertyFile()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	using target = CDlgProperty;
+	EXPECT_THAT(ExecMacroCommand(L"PropertyFile()"), IsTrue());
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -2444,7 +3108,18 @@ TEST_F(EditWndTest, ShowDlgProperty101)
 TEST_F(EditWndTest, ShowDlgSameColor001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"文字色統一", IDOK);
+	dialog::ModalDialogCloser closer(L"文字色統一", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_SELALL);
+		SendDlgCommand( hWndDlg, IDC_BUTTON_SELNOTING );
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
 
 	CDlgSameColor cDlgSameColor;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2452,26 +3127,6 @@ TEST_F(EditWndTest, ShowDlgSameColor001)
 	auto m_nCurrentColorType = 1;
 	auto& m_Types = pcEditDoc->m_cDocType.GetDocumentAttributeWrite();
 	COLORREF cr = m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cTEXT;
-	cDlgSameColor.DoModal(unusedArg1, hWnd, wID, &m_Types, cr);
-}
-
-/*!
- * 文字色／背景色統一ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgSameColor002)
-{
-	// 表示されたモーダルダイアログを閉じる
-	dialog::ModalDialogCloser closer(L"文字色統一", [] (HWND hWndDlg) {
-		EXPECT_THAT(apiwrap::GetWindowTextW(hWndDlg), StrEq(L"背景色統一"));
-		SendDlgCommand(hWndDlg, IDOK);
-	});
-
-	CDlgSameColor cDlgSameColor;
-	const auto hWnd = pcEditWnd->GetHwnd();
-	const WORD wID = IDC_BUTTON_SAMEBKCOLOR;
-	auto m_nCurrentColorType = 1;
-	auto& m_Types = pcEditDoc->m_cDocType.GetDocumentAttributeWrite();
-	COLORREF cr = m_Types.m_ColorInfoArr[m_nCurrentColorType].m_sColorAttr.m_cBACK;
 	cDlgSameColor.DoModal(unusedArg1, hWnd, wID, &m_Types, cr);
 }
 
@@ -2497,10 +3152,34 @@ TEST_F(EditWndTest, ShowDlgSameColor101)
 TEST_F(EditWndTest, ShowDlgSetCharSet001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"文字コードの指定", IDOK);
+	dialog::ModalDialogCloser closer(L"文字コードの指定", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ChgCharSet(99, 0)"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		// UTF-8を選択している
+		SendDlgCommand(hWndDlg, IDC_COMBO_CHARSET, CBN_SELCHANGE);
+		apiwrap::CheckDlgButton( hWndDlg, IDC_CHECK_BOM, true);
+
+		// SJISを選択する
+		ComboBox_SetCurSel(::GetDlgItem(hWndDlg, IDC_COMBO_CHARSET), CODE_SJIS);
+		SendDlgCommand(hWndDlg, IDC_COMBO_CHARSET, CBN_SELCHANGE);
+
+		// UTF8に戻す
+		ComboBox_SetCurSel(::GetDlgItem(hWndDlg, IDC_COMBO_CHARSET), CODE_UTF8);
+		SendDlgCommand(hWndDlg, IDC_COMBO_CHARSET, CBN_SELCHANGE);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_CHECK_CP, true);
+		SendDlgCommand(hWndDlg, IDC_CHECK_CP);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	using target = CDlgSetCharSet;
+	const auto hWnd = pcEditWnd->GetHwnd();
+	FORWARD_WM_COMMAND(hWnd, F_CHG_CHARSET, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2511,8 +3190,7 @@ TEST_F(EditWndTest, ShowDlgSetCharSet101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"文字コードの指定");
 
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"ChgCharSet(99, 0)"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	EXPECT_THAT(ExecMacroCommand(L"ChgCharSet(99, 0)"), IsTrue());
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -2523,7 +3201,19 @@ TEST_F(EditWndTest, ShowDlgSetCharSet101)
 TEST_F(EditWndTest, ShowDlgTagJumpList001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ダイレクトタグジャンプ一覧", IDOK);
+	dialog::ModalDialogCloser closer(L"ダイレクトタグジャンプ一覧", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		CMyRect rc{};
+		::GetClientRect(hWndDlg, &rc);
+		FORWARD_WM_SIZE(hWndDlg, SIZE_RESTORED, rc.right, rc.bottom, ::SendMessageW);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
 
 	bool bDirectTagJump = false;
 	CDlgTagJumpList cDlgTagJumpList(bDirectTagJump);
@@ -2545,20 +3235,47 @@ TEST_F(EditWndTest, ShowDlgTagJumpList101)
 	cDlgTagJumpList.DoModal(unusedArg1, hWnd, 0L);
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * タグファイル作成ダイアログの表示テスト
  */
 TEST_F(EditWndTest, ShowDlgTagsMake001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"タグファイルの作成", IDOK);
+	dialog::ModalDialogCloser closer1(L"タグファイルの作成", [] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
 
-	CDlgTagsMake cDlgTagsMake;
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		apiwrap::SetDlgItemTextW(hWndDlg, IDC_EDIT_TAG_MAKE_FOLDER, GetIniFileName().parent_path().c_str());
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_TAG_MAKE_REF);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_FOLDER_UP);
+
+		apiwrap::SetDlgItemTextW(hWndDlg, IDC_EDIT_TAG_MAKE_FOLDER, GetIniFileName().parent_path().c_str());
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	// 表示されたフォルダー選択ダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer2(L"開く" /* 指定できない */, [](HWND hWndDlg) {
+		ASSERT_THAT(apiwrap::GetWindowTextW(hWndDlg), StrEq(L"タグ作成フォルダーの選択"));
+
+		SendDlgCommand(hWndDlg, IDOK); // そのままOK押す
+	});
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
+
+	using target = CDlgTagsMake;
 	const auto hWnd = pcEditWnd->GetHwnd();
-	LPARAM lParam = 0;
-	std::filesystem::path path = L"";
-
-	cDlgTagsMake.DoModal(unusedArg1, hWnd, lParam, path.c_str());
+	FORWARD_WM_COMMAND(hWnd, F_TAGS_MAKE, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
 /*!
@@ -2569,12 +3286,8 @@ TEST_F(EditWndTest, ShowDlgTagsMake101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"タグファイルの作成");
 
-	CDlgTagsMake cDlgTagsMake;
-	const auto hWnd = pcEditWnd->GetHwnd();
-	LPARAM lParam = 0;
-	std::filesystem::path path = L"";
-
-	cDlgTagsMake.DoModal(unusedArg1, hWnd, lParam, path.c_str());
+	using target = CDlgTagsMake;
+	EXPECT_THAT(ExecMacroCommand(L"TagMake()"), IsTrue());
 }
 
 /*!
@@ -2583,27 +3296,51 @@ TEST_F(EditWndTest, ShowDlgTagsMake101)
 TEST_F(EditWndTest, ShowDlgTypeAscertain001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"インポート確認", IDOK);
+	dialog::ModalDialogCloser closer1(L"タイプ別設定一覧", [this] (HWND hWndDlg) {
+		SendDlgCommand(hWndDlg, IDC_BUTTON_EXPORT);
+		// 保存先ファイル名の入力はモックで実現する
 
-	CDlgTypeAscertain cDlgTypeAscertain;
+		SendDlgCommand(hWndDlg, IDC_BUTTON_IMPORT);
+		// 開くファイル名の入力はモックで実現する
+
+		SendDlgCommand(hWndDlg, IDCANCEL);
+	});
+
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer2(L"インポート確認", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		// 空振りさせる
+		SendDlgCommand(hWndDlg, IDC_COMBO_COLORS);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	const auto& exportPath = typeConfigExportPath;
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
+		.WillRepeatedly(Return(IDOK));
+
+	using target = CDlgTypeAscertain;
 	const auto hWnd = pcEditWnd->GetHwnd();
-	CDlgTypeAscertain::SAscertainInfo sAscertainInfo{};
-	cDlgTypeAscertain.DoModal(unusedArg1, hWnd, &sAscertainInfo);
+	FORWARD_WM_COMMAND(hWnd, F_TYPE_LIST, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
 
-/*!
- * タイプ別設定インポート確認ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgTypeAscertain101)
-{
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"インポート確認");
-
-	CDlgTypeAscertain cDlgTypeAscertain;
-	const auto hWnd = pcEditWnd->GetHwnd();
-	CDlgTypeAscertain::SAscertainInfo sAscertainInfo{};
-	cDlgTypeAscertain.DoModal(unusedArg1, hWnd, &sAscertainInfo);
-}
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * ファイルタイプ一覧ダイアログの表示テスト
@@ -2611,13 +3348,58 @@ TEST_F(EditWndTest, ShowDlgTypeAscertain101)
 TEST_F(EditWndTest, ShowDlgTypeList001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"タイプ別設定一覧", IDOK);
+	dialog::ModalDialogCloser closer1(L"タイプ別設定一覧", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
 
-	CDlgTypeList cDlgTypeList;
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_EXPORT);
+		// 保存先ファイル名の入力はモックで実現する
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_IMPORT);
+		// 開くファイル名の入力はモックで実現する
+
+		SendDlgCommand(hWndDlg, IDC_BUTTON_UP_TYPE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_DOWN_TYPE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_DEL_TYPE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_ADD_TYPE);
+		SendDlgCommand(hWndDlg, IDC_BUTTON_COPY_TYPE);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer2(L"インポート確認", IDOK);
+
+	// 表示されたタイプ別設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer3(PSBTN_OK);
+
+	const auto& exportPath = typeConfigExportPath;
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, _, _, _, _))
+		.Times(3)
+		.WillOnce(Return(IDOK))
+		.WillOnce(Return(IDOK))
+		.WillOnce(Return(IDYES));
+
+	using target = CDlgTypeList;
 	const auto hWnd = pcEditWnd->GetHwnd();
-	CDlgTypeList::SResult sResult = { CTypeConfig(0), false };
-	cDlgTypeList.DoModal(unusedArg1, hWnd, &sResult);
+	FORWARD_WM_COMMAND(hWnd, F_TYPE_LIST, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
 }
+
+#if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * ファイルタイプ一覧ダイアログの表示テスト
@@ -2627,11 +3409,11 @@ TEST_F(EditWndTest, ShowDlgTypeList101)
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
 	dialog::ModalDialogCloser closer(L"タイプ別設定一覧");
 
-	CDlgTypeList cDlgTypeList;
-	const auto hWnd = pcEditWnd->GetHwnd();
-	CDlgTypeList::SResult sResult = { CTypeConfig(0), false };
-	cDlgTypeList.DoModal(unusedArg1, hWnd, &sResult);
+	using target = CDlgTypeList;
+	EXPECT_THAT(ExecMacroCommand(L"TypeList()"), IsTrue());
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * ウインドウサイズダイアログの表示テスト
@@ -2639,7 +3421,29 @@ TEST_F(EditWndTest, ShowDlgTypeList101)
 TEST_F(EditWndTest, ShowDlgWinSize001)
 {
 	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ウィンドウの位置と大きさ", IDOK);
+	dialog::ModalDialogCloser closer(L"ウィンドウの位置と大きさ", [this] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_WINPOS_SET, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_WINPOS_SET);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_WINPOS_SAVE, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_WINPOS_SAVE);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_WINPOS_DEF, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_WINPOS_DEF);
+
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_WINSIZE_SET, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_WINSIZE_SET);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_WINSIZE_SAVE, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_WINSIZE_SAVE);
+		apiwrap::CheckDlgButton(hWndDlg, IDC_RADIO_WINSIZE_DEF, true);
+		SendDlgCommand(hWndDlg, IDC_RADIO_WINSIZE_DEF);
+
+		SendDlgCommand(hWndDlg, IDOK);
+	});
 
 	CDlgWinSize cDlgWinSize;
 	const auto hWnd = pcEditWnd->GetHwnd();
@@ -2649,57 +3453,26 @@ TEST_F(EditWndTest, ShowDlgWinSize001)
 	RECT rc = {};
 	cDlgWinSize.DoModal(unusedArg1, hWnd, eSaveWinSize, eSaveWinPos, nWinSizeType, rc);
 }
+
+#if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * ウインドウサイズダイアログの表示テスト
  */
 TEST_F(EditWndTest, ShowDlgWinSize101)
 {
-	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ウィンドウの位置と大きさ");
-
-	CDlgWinSize cDlgWinSize;
-	const auto hWnd = pcEditWnd->GetHwnd();
-	EWinSizeMode eSaveWinSize = WINSIZEMODE_DEF;
-	EWinSizeMode eSaveWinPos = WINSIZEMODE_DEF;
-	int nWinSizeType = 0;
-	RECT rc = {};
-	cDlgWinSize.DoModal(unusedArg1, hWnd, eSaveWinSize, eSaveWinPos, nWinSizeType, rc);
-}
-
-/*!
- * ウインドウ一覧ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgWindowList001)
-{
-	// 表示されたモーダルダイアログをOKボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ウィンドウ一覧", [] (HWND hWndDlg) {
-		SendDlgCommand(hWndDlg, IDOK);
-		::EndDialog(hWndDlg, IDOK);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer1([] (HWND hWndDlg, HWND hWndPage) {
+		SendDlgCommand(hWndPage, IDC_BUTTON_WINSIZE);
+		SendPsmPressButton(hWndDlg, PSBTN_CANCEL);
 	});
 
-	CDlgWindowList cDlgWindowList;
-	const auto hWnd = pcEditWnd->GetHwnd();
-	cDlgWindowList.DoModal(unusedArg1, hWnd, 0);
-}
-
-/*!
- * ウインドウ一覧ダイアログの表示テスト
- */
-TEST_F(EditWndTest, ShowDlgWindowList101)
-{
 	// 表示されたモーダルダイアログをキャンセルボタンで閉じる
-	dialog::ModalDialogCloser closer(L"ウィンドウ一覧", [] (HWND hWndDlg) {
-		// キャンセルボタンが存在しないので強制的に閉じる
-		::EndDialog(hWndDlg, 0);
-	});
+	dialog::ModalDialogCloser closer2(L"ウィンドウの位置と大きさ");
 
-	CDlgWindowList cDlgWindowList;
-	const auto hWnd = pcEditWnd->GetHwnd();
-	cDlgWindowList.DoModal(unusedArg1, hWnd, 0);
+	using target = CDlgWinSize;
+	ShowPropCommon(ID_PROPCOM_PAGENUM_WIN);
 }
-
-#if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * 補完ダイアログの表示テスト
@@ -2707,35 +3480,63 @@ TEST_F(EditWndTest, ShowDlgWindowList101)
 TEST_F(EditWndTest, ShowHokanMgr001)
 {
 	// 表示されたモーダルダイアログを閉じる
-	dialog::ModalDialogCloser closer(std::nullopt, [this] (HWND hWndDlg) {
+	dialog::ModalDialogCloser closer(std::nullopt /* タイトルなし */, [] (HWND hWndDlg) {
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
+		SendDlgCommand(hWndDlg, IDC_LIST_WORDS, LBN_SELCHANGE);
+
+		CMyRect rc{};
+		::GetClientRect(hWndDlg, &rc);
+		FORWARD_WM_SIZE(hWndDlg, SIZE_RESTORED, rc.right, rc.bottom, ::SendMessageW);
+
 		SendDlgCommand(hWndDlg, IDOK);
 	});
 
 	using target = CHokanMgr;
 	const auto& cHokanMgr = pcEditWnd->m_cHokanMgr;
+	const auto hWnd = pcEditWnd->GetHwnd();
 
 	// データなしだとスカる
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"Complete()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	EXPECT_THAT(ExecMacroCommand(L"Complete()"), IsTrue());
 
 	// とりあえずデータを入れる
-	const auto& text = L"test\n\ntes";
-	pcEditWnd->GetActiveView().GetCommander().HandleCommand(F_ADDTAIL_W, false, LPARAM(std::data(text)), LPARAM(std::size(text)), 0L, 0L);
+	auto pShareData = GetDllShareDataPtr();
+	auto& sWorkBuffer = pShareData->m_sWorkBuffer;
+	auto buffer = std::span(sWorkBuffer.GetWorkBuffer<WCHAR>(), sWorkBuffer.GetWorkBufferCount<WCHAR>());
 
-	// キャレットを強引に移動させる
-	auto& cCaret = pcEditWnd->GetActiveView().GetCaret();
-	cCaret.SetCaretLayoutPos(CLayoutPoint(15, 2));
-	cCaret.SetCaretLogicPos(CLogicPoint(3, 2));
+	const auto& text = L"test\n\ntes";
+	::wcsncpy_s(std::data(buffer), std::size(buffer), std::data(text), std::size(text));
+
+	pcEditWnd->DispatchEvent(hWnd, MYWM_ADDSTRINGLEN_W, std::size(text), 0L);
 
 	// データありで補完実行
-	EXPECT_THAT(mgr->LoadKeyMacroStr(unusedArg1, L"Complete()"), IsTrue());
-	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
+	EXPECT_THAT(ExecMacroCommand(L"Complete()"), IsTrue());
 
 	// 非表示ウィンドウはModalDialogCloserに拾われないので強制的に表示させる
 	::ShowWindow(cHokanMgr.GetHwnd(), SW_SHOW);
 
 	// キューに溜まるメッセージを処理する
 	RunMessageLoop();
+
+	// 全選択してゴミを削除する
+	FORWARD_WM_COMMAND(hWnd, F_SELECTALL, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
+	FORWARD_WM_COMMAND(hWnd, F_DELETE, nullptr, BN_CLICKED, pcEditWnd->DispatchEvent);
+}
+
+/*!
+ * 共通設定プロパティーシートの表示テスト
+ */
+TEST_F(EditWndTest, ShowPropCommon001)
+{
+	// 表示された共通設定をキャンセルボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_CANCEL);
+
+	// シート番号の指定がない場合
+	EXPECT_THAT(ExecMacroCommand(L"OptionCommon()"), IsTrue());
 }
 
 #endif // if defined(_MSC_VER) &&  defined(_DEBUG)
@@ -2743,21 +3544,10 @@ TEST_F(EditWndTest, ShowHokanMgr001)
 /*!
  * 共通設定プロパティーシートの表示テスト
  */
-TEST_F(EditWndTest, ShowPropCommon001)
-{
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON, PSBTN_CANCEL);
-
-	ShowPropCommon();
-}
-
-/*!
- * 共通設定プロパティーシートの表示テスト
- */
 TEST_F(EditWndTest, ShowPropCommon002)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_GENERAL);
 }
@@ -2767,8 +3557,8 @@ TEST_F(EditWndTest, ShowPropCommon002)
  */
 TEST_F(EditWndTest, ShowPropCommon003)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_WIN);
 }
@@ -2778,11 +3568,20 @@ TEST_F(EditWndTest, ShowPropCommon003)
  */
 TEST_F(EditWndTest, ShowPropCommon004)
 {
-	const auto exportPath = GetIniFileName().replace_filename(L"メインメニュー.ini");
-	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
+	// 表示された共通設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
+		SendDlgCommand(hWndPage, IDC_BUTTON_EXPORT);	// L"エクスポート(X)..."
+		// 保存先ファイル名の入力はモックで実現する
 
-	std::error_code ec;
-	std::filesystem::remove(exportPath, ec);
+		SendDlgCommand(hWndPage, IDC_BUTTON_IMPORT);	// L"インポート(I)..."
+		// 開くファイル名の入力はモックで実現する
+
+		// OKボタンを押下して閉じる
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
+	});
+
+	const auto& exportPath = mainmenuExportPath;
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
 	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
@@ -2792,26 +3591,13 @@ TEST_F(EditWndTest, ShowPropCommon004)
 		.Times(1)
 		.WillOnce(testing::DoDefault());
 
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(STR_PROPCOMMON, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
-		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg, st);
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_EXPORT, st);	// L"エクスポート(X)..."
-		// 保存先ファイル名の入力はモックで実現する
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_IMPORT, st);	// L"インポート(I)..."
-		// 開くファイル名の入力はモックで実現する
-
-		// OKボタンを押下して閉じる
-		SendPsmPressButton(hWndDlg, PSBTN_OK);
-	});
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	const auto exportMsg = std::wstring{ LS(STR_IMPEXP_OK_EXPORT) } + exportPath.native();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(exportMsg), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_MAINMENU);
-
-	t.join();
-
-	std::filesystem::remove(exportPath, ec);
 }
 
 /*!
@@ -2819,8 +3605,8 @@ TEST_F(EditWndTest, ShowPropCommon004)
  */
 TEST_F(EditWndTest, ShowPropCommon005)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_TOOLBAR);
 }
@@ -2830,8 +3616,8 @@ TEST_F(EditWndTest, ShowPropCommon005)
  */
 TEST_F(EditWndTest, ShowPropCommon006)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_TAB);
 }
@@ -2841,8 +3627,8 @@ TEST_F(EditWndTest, ShowPropCommon006)
  */
 TEST_F(EditWndTest, ShowPropCommon007)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_STATUSBAR);
 }
@@ -2852,8 +3638,8 @@ TEST_F(EditWndTest, ShowPropCommon007)
  */
 TEST_F(EditWndTest, ShowPropCommon008)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_EDIT);
 }
@@ -2863,8 +3649,8 @@ TEST_F(EditWndTest, ShowPropCommon008)
  */
 TEST_F(EditWndTest, ShowPropCommon009)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_FILE);
 }
@@ -2874,8 +3660,8 @@ TEST_F(EditWndTest, ShowPropCommon009)
  */
 TEST_F(EditWndTest, ShowPropCommon010)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_FILENAME);
 }
@@ -2885,8 +3671,8 @@ TEST_F(EditWndTest, ShowPropCommon010)
  */
 TEST_F(EditWndTest, ShowPropCommon011)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_BACKUP);
 }
@@ -2896,8 +3682,8 @@ TEST_F(EditWndTest, ShowPropCommon011)
  */
 TEST_F(EditWndTest, ShowPropCommon012)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_FORMAT);
 }
@@ -2907,8 +3693,8 @@ TEST_F(EditWndTest, ShowPropCommon012)
  */
 TEST_F(EditWndTest, ShowPropCommon013)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_GREP);
 }
@@ -2918,8 +3704,34 @@ TEST_F(EditWndTest, ShowPropCommon013)
  */
 TEST_F(EditWndTest, ShowPropCommon014)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
+		SendDlgCommand(hWndPage, IDC_BUTTON_EXPORT);	// L"エクスポート(X)..."
+		// 保存先ファイル名の入力はモックで実現する
+
+		SendDlgCommand(hWndPage, IDC_BUTTON_IMPORT);	// L"インポート(I)..."
+		// 開くファイル名の入力はモックで実現する
+
+		// OKボタンを押下して閉じる
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
+	});
+
+	const auto& exportPath = keybindExportPath;
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
+
+	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+	EXPECT_CALL(cDlgOpenFile, DoModal_GetOpenFileName(_, _))
+		.Times(1)
+		.WillOnce(testing::DoDefault());
+
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	const auto exportMsg = std::wstring{ LS(STR_IMPEXP_OK_EXPORT) } + exportPath.native();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(exportMsg), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_KEYBOARD);
 }
@@ -2929,11 +3741,20 @@ TEST_F(EditWndTest, ShowPropCommon014)
  */
 TEST_F(EditWndTest, ShowPropCommon015)
 {
-	const auto exportPath = GetIniFileName().replace_filename(L"カスタムメニュー.mnu");
-	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
+	// 表示された共通設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
+		SendDlgCommand(hWndPage, IDC_BUTTON_EXPORT);	// L"エクスポート(X)..."
+		// 保存先ファイル名の入力はモックで実現する
 
-	std::error_code ec;
-	std::filesystem::remove(exportPath, ec);
+		SendDlgCommand(hWndPage, IDC_BUTTON_IMPORT);	// L"インポート(I)..."
+		// 開くファイル名の入力はモックで実現する
+
+		// OKボタンを押下して閉じる
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
+	});
+
+	const auto& exportPath = custmenuExportPath;
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
 	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
@@ -2943,26 +3764,13 @@ TEST_F(EditWndTest, ShowPropCommon015)
 		.Times(1)
 		.WillOnce(testing::DoDefault());
 
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(STR_PROPCOMMON, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
-		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg, st);
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_EXPORT, st);	// L"エクスポート(X)..."
-		// 保存先ファイル名の入力はモックで実現する
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_IMPORT, st);	// L"インポート(I)..."
-		// 開くファイル名の入力はモックで実現する
-
-		// OKボタンを押下して閉じる
-		SendPsmPressButton(hWndDlg, PSBTN_OK);
-	});
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	const auto exportMsg = std::wstring{ LS(STR_IMPEXP_OK_EXPORT) } + exportPath.native();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(exportMsg), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_CUSTMENU);
-
-	t.join();
-
-	std::filesystem::remove(exportPath, ec);
 }
 
 /*!
@@ -2970,11 +3778,20 @@ TEST_F(EditWndTest, ShowPropCommon015)
  */
 TEST_F(EditWndTest, ShowPropCommon016)
 {
-	const auto exportPath = GetIniFileName().replace_filename(L"強調キーワード.kwd");
-	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
+	// 表示された共通設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
+		SendDlgCommand(hWndPage, IDC_BUTTON_EXPORT);	// L"エクスポート(X)..."
+		// 保存先ファイル名の入力はモックで実現する
 
-	std::error_code ec;
-	std::filesystem::remove(exportPath, ec);
+		SendDlgCommand(hWndPage, IDC_BUTTON_IMPORT);	// L"インポート(I)..."
+		// 開くファイル名の入力はモックで実現する
+
+		// OKボタンを押下して閉じる
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
+	});
+
+	const auto& exportPath = keywordExportPath;
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
 	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
@@ -2984,26 +3801,13 @@ TEST_F(EditWndTest, ShowPropCommon016)
 		.Times(1)
 		.WillOnce(testing::DoDefault());
 
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(STR_PROPCOMMON, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
-		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg, st);
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_EXPORT, st);	// L"エクスポート(X)..."
-		// 保存先ファイル名の入力はモックで実現する
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_IMPORT, st);	// L"インポート(I)..."
-		// 開くファイル名の入力はモックで実現する
-
-		// OKボタンを押下して閉じる
-		SendPsmPressButton(hWndDlg, PSBTN_OK);
-	});
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	const auto exportMsg = std::wstring{ LS(STR_IMPEXP_OK_EXPORT) } + exportPath.native();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(exportMsg), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_KEYWORD);
-
-	t.join();
-
-	std::filesystem::remove(exportPath, ec);
 }
 
 /*!
@@ -3011,8 +3815,8 @@ TEST_F(EditWndTest, ShowPropCommon016)
  */
 TEST_F(EditWndTest, ShowPropCommon017)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_HELPER);
 }
@@ -3022,8 +3826,8 @@ TEST_F(EditWndTest, ShowPropCommon017)
  */
 TEST_F(EditWndTest, ShowPropCommon018)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_MACRO);
 }
@@ -3033,8 +3837,8 @@ TEST_F(EditWndTest, ShowPropCommon018)
  */
 TEST_F(EditWndTest, ShowPropCommon019)
 {
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPCOMMON);
+	// 表示された共通設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropCommon(ID_PROPCOM_PAGENUM_PLUGIN);
 }
@@ -3046,19 +3850,8 @@ TEST_F(EditWndTest, ShowPropCommon019)
  */
 TEST_F(EditWndTest, ShowPropCommon020)
 {
-	auto& cKeyWordSetMgr = GetDllShareData().m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr;
-
-	// キーワードセットが0件の状態を作る
-	const auto nKeyWordSetNumOrg = cKeyWordSetMgr.m_nKeyWordSetNum;
-	const auto nCurrentKeyWordSetIdxOrg = cKeyWordSetMgr.m_nCurrentKeyWordSetIdx;
-	cKeyWordSetMgr.m_nKeyWordSetNum = 0;
-	cKeyWordSetMgr.m_nCurrentKeyWordSetIdx = -1;
-
-	// 表示された共通設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(STR_PROPCOMMON, [] (const IUIAutomation*, HWND hWndDlg, std::stop_token st) {
-		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg, st);
-
+	// 表示された共通設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
 		// キーワードセットが選択されていないので、セット依存のコントロールは無効
 		const auto hWndKeySetRename = ::GetDlgItem(hWndPage, IDC_BUTTON_KEYSETRENAME);	// L"変更(H)..."
 		EXPECT_THAT(hWndKeySetRename, Ne(nullptr));
@@ -3077,33 +3870,43 @@ TEST_F(EditWndTest, ShowPropCommon020)
 		SendPsmPressButton(hWndDlg, PSBTN_CANCEL);
 	});
 
-	ShowPropCommon(ID_PROPCOM_PAGENUM_KEYWORD);
+	auto& cKeyWordSetMgr = GetDllShareData().m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr;
 
-	t.join();
+	// キーワードセットが0件の状態を作る
+	const auto nKeyWordSetNumOrg = cKeyWordSetMgr.m_nKeyWordSetNum;
+	const auto nCurrentKeyWordSetIdxOrg = cKeyWordSetMgr.m_nCurrentKeyWordSetIdx;
+	cKeyWordSetMgr.m_nKeyWordSetNum = 0;
+	cKeyWordSetMgr.m_nCurrentKeyWordSetIdx = -1;
+
+	ShowPropCommon(ID_PROPCOM_PAGENUM_KEYWORD);
 
 	// 共有データを元に戻す
 	cKeyWordSetMgr.m_nCurrentKeyWordSetIdx = nCurrentKeyWordSetIdxOrg;
 	cKeyWordSetMgr.m_nKeyWordSetNum = nKeyWordSetNumOrg;
 }
 
+#if defined(_MSC_VER) &&  defined(_DEBUG)
+
 /*!
  * タイプ別設定プロパティーシートの表示テスト
  */
 TEST_F(EditWndTest, ShowPropType001)
 {
-	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPTYPE, PSBTN_CANCEL);
+	// 表示されたタイプ別設定をキャンセルボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_CANCEL);
 
-	ShowPropType();
+	EXPECT_THAT(ExecMacroCommand(L"OptionType()"), IsTrue());
 }
+
+#endif // if defined(_MSC_VER) &&  defined(_DEBUG)
 
 /*!
  * タイプ別設定プロパティーシートの表示テスト
  */
 TEST_F(EditWndTest, ShowPropType002)
 {
-	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPTYPE);
+	// 表示されたタイプ別設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_SCREEN);
 }
@@ -3113,13 +3916,36 @@ TEST_F(EditWndTest, ShowPropType002)
  */
 TEST_F(EditWndTest, ShowPropType003)
 {
-	RunGuiTest([this] {
+	// 表示されたタイプ別設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
+		SendDlgCommand(hWndPage, IDC_BUTTON_TEXTCOLOR);
+		SendDlgCommand(hWndPage, IDC_BUTTON_BACKCOLOR);
 
-	const auto exportPath = GetIniFileName().replace_filename(L"基本.col");
+		SendDlgCommand(hWndPage, IDC_BUTTON_SAMETEXTCOLOR);	// L"文字色統一(<)..."
+
+		SendDlgCommand(hWndPage, IDC_BUTTON_SAMEBKCOLOR);	// L"背景色統一(>)..."
+
+		SendDlgCommand(hWndPage, IDC_BUTTON_EXPORT);	// L"エクスポート(X)..."
+		// 保存先ファイル名の入力はモックで実現する
+
+		SendDlgCommand(hWndPage, IDC_BUTTON_IMPORT);	// L"インポート(I)..."
+		// 開くファイル名の入力はモックで実現する
+
+		// OKボタンを押下して閉じる
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
+	});
+
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer2(L"文字色統一", IDOK);
+
+	// 表示されたモーダルダイアログをOKボタンで閉じる
+	dialog::ModalDialogCloser closer3(L"文字色統一", [] (HWND hWndDlg) {
+		ASSERT_THAT(apiwrap::GetWindowTextW(hWndDlg), StrEq(L"背景色統一"));
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	const auto& exportPath = colorizeExportPath;
 	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
-
-	std::error_code ec;
-	std::filesystem::remove(exportPath, ec);
 
 	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
 	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
@@ -3129,42 +3955,27 @@ TEST_F(EditWndTest, ShowPropType003)
 		.Times(1)
 		.WillOnce(testing::DoDefault());
 
-	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(STR_PROPTYPE, [exportPath] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
-		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg, st);
+	Comdlg32::setInstance<MockComdlg32>();
 
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_SAMETEXTCOLOR, st);	// L"文字色統一(<)..."
+	auto pComdlg32 = static_cast<MockComdlg32*>(Comdlg32::getInstance());
+	EXPECT_CALL(*pComdlg32, ChooseColorW(_))
+		.Times(2)
+		.WillOnce(Invoke([] (LPCHOOSECOLORW pCc) -> BOOL {
+			pCc->rgbResult = RGB(0xff, 0xff, 0);
+			return TRUE;
+		}))
+		.WillOnce(Invoke([] (LPCHOOSECOLORW pCc) -> BOOL {
+			pCc->rgbResult = RGB(0xff, 0xff, 0);
+			return TRUE;
+		}));
 
-		const auto hWndDlgSameColor1 = window::WaitForWindow(WC_DIALOG, L"文字色統一", st);
-		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor1, IDC_BUTTON_SELALL, st);	// L"全チェック(A)"
-		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor1, IDC_BUTTON_SELNOTING, st);	// L"全解除(N)"
-		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor1, IDOK, st);
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_SAMEBKCOLOR, st);	// L"背景色統一(>)..."
-
-		const auto hWndDlgSameColor2 = window::WaitForWindow(WC_DIALOG, L"背景色統一", st);
-		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor2, IDC_BUTTON_SELALL, st);	// L"全チェック(A)"
-		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor2, IDC_BUTTON_SELNOTING, st);	// L"全解除(N)"
-		EmulateInvokeButton(pUIAutomation, hWndDlgSameColor2, IDOK, st);
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_EXPORT, st);	// L"エクスポート(X)..."
-		// 保存先ファイル名の入力はモックで実現する
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_IMPORT, st);	// L"インポート(I)..."
-		// 開くファイル名の入力はモックで実現する
-
-		// OKボタンを押下して閉じる
-		SendPsmPressButton(hWndDlg, PSBTN_OK);
-	});
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	const auto exportMsg = std::wstring{ LS(STR_IMPEXP_OK_EXPORT) } + exportPath.native();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(exportMsg), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_COLOR);
-
-	t.join();
-
-	std::filesystem::remove(exportPath, ec);
-
-	});
 }
 
 /*!
@@ -3172,11 +3983,8 @@ TEST_F(EditWndTest, ShowPropType003)
  */
 TEST_F(EditWndTest, ShowPropType004)
 {
-	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(STR_PROPTYPE, [] (const IUIAutomation*, HWND hWndDlg, std::stop_token st) {
-		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg, st);
-
+	// 表示されたタイプ別設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
 		// トラックバーのハンドルを取得する
 		const auto hWndTrackbar = ::GetDlgItem(hWndPage, IDC_TRACKBAR_BACKIMG_TRANSPARENCY);
 		EXPECT_THAT(hWndTrackbar, Ne(nullptr));
@@ -3208,8 +4016,8 @@ TEST_F(EditWndTest, ShowPropType004)
  */
 TEST_F(EditWndTest, ShowPropType005)
 {
-	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartPropertySheetCloser(STR_PROPTYPE);
+	// 表示されたタイプ別設定をOKボタンで閉じる
+	dialog::PropertySheetCloser closer(PSBTN_OK);
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_SUPPORT);
 }
@@ -3219,11 +4027,20 @@ TEST_F(EditWndTest, ShowPropType005)
  */
 TEST_F(EditWndTest, ShowPropType006)
 {
-	const auto exportPath = GetIniFileName().replace_filename(L"テキスト.rkw");
-	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
+	// 表示されたタイプ別設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
+		SendDlgCommand(hWndPage, IDC_BUTTON_REGEX_EXPORT);	// L"エクスポート(X)..."
+		// 保存先ファイル名の入力はモックで実現する
 
-	std::error_code ec;
-	std::filesystem::remove(exportPath, ec);
+		SendDlgCommand(hWndPage, IDC_BUTTON_REGEX_IMPORT);	// L"インポート(I)..."
+		// 開くファイル名の入力はモックで実現する
+
+		// OKボタンを押下して閉じる
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
+	});
+
+	const auto& exportPath = regexKeywordExportPath;
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
 	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
@@ -3233,26 +4050,13 @@ TEST_F(EditWndTest, ShowPropType006)
 		.Times(1)
 		.WillOnce(testing::DoDefault());
 
-	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(STR_PROPTYPE, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
-		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg, st);
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_REGEX_EXPORT, st);	// L"エクスポート(X)..."
-		// 保存先ファイル名の入力はモックで実現する
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_REGEX_IMPORT, st);	// L"インポート(I)..."
-		// 開くファイル名の入力はモックで実現する
-
-		// OKボタンを押下して閉じる
-		SendPsmPressButton(hWndDlg, PSBTN_OK);
-	});
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	const auto exportMsg = std::wstring{ LS(STR_IMPEXP_OK_EXPORT) } + exportPath.native();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(exportMsg), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_REGEX);
-
-	t.join();
-
-	std::filesystem::remove(exportPath, ec);
 }
 
 /*!
@@ -3260,11 +4064,20 @@ TEST_F(EditWndTest, ShowPropType006)
  */
 TEST_F(EditWndTest, ShowPropType007)
 {
-	const auto exportPath = GetIniFileName().replace_filename(L"キーワードヘルプ.txt");
-	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
+	// 表示されたタイプ別設定を閉じる
+	dialog::PropertySheetCloser closer([] (HWND hWndDlg, HWND hWndPage) {
+		SendDlgCommand(hWndPage, IDC_BUTTON_KEYHELP_EXPORT);	// L"エクスポート(X)..."
+		// 保存先ファイル名の入力はモックで実現する
 
-	std::error_code ec;
-	std::filesystem::remove(exportPath, ec);
+		SendDlgCommand(hWndPage, IDC_BUTTON_KEYHELP_IMPORT);	// L"インポート(I)..."
+		// 開くファイル名の入力はモックで実現する
+
+		// OKボタンを押下して閉じる
+		SendPsmPressButton(hWndDlg, PSBTN_OK);
+	});
+
+	const auto& exportPath = keywordHelpExportPath;
+	MockCDlgOpenFile::gm_Files.emplace_back(exportPath.native());
 
 	auto& cDlgOpenFile = static_cast<MockCDlgOpenFile&>(*CDlgOpenFile::getInstance());
 	EXPECT_CALL(cDlgOpenFile, DoModal_GetSaveFileName(_))
@@ -3274,26 +4087,13 @@ TEST_F(EditWndTest, ShowPropType007)
 		.Times(1)
 		.WillOnce(testing::DoDefault());
 
-	// 表示されたタイプ別設定を閉じるためのスレッドを起動する
-	auto t = StartDialogCloser(STR_PROPTYPE, [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
-		// アクティブなプロパティーシートのハンドルを取得する
-		const auto hWndPage = GetActivePage(hWndDlg, st);
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_KEYHELP_EXPORT, st);	// L"エクスポート(X)..."
-		// 保存先ファイル名の入力はモックで実現する
-
-		EmulateInvokeButton(pUIAutomation, hWndPage, IDC_BUTTON_KEYHELP_IMPORT, st);	// L"インポート(I)..."
-		// 開くファイル名の入力はモックで実現する
-
-		// OKボタンを押下して閉じる
-		SendPsmPressButton(hWndDlg, PSBTN_OK);
-	});
+	auto pUser32 = (MockUser32*)User32::getInstance();
+	const auto exportMsg = std::wstring{ LS(STR_IMPEXP_OK_EXPORT) } + exportPath.native();
+	EXPECT_CALL(*pUser32, MessageBoxExW(_, StrEq(exportMsg), _, _, _))
+		.Times(1)
+		.WillOnce(Return(IDOK));
 
 	ShowPropType(ID_PROPTYPE_PAGENUM_KEYHELP);
-
-	t.join();
-
-	std::filesystem::remove(exportPath, ec);
 }
 
 TEST_F(EditWndTest, DISABLED_Timeout101)
@@ -3316,8 +4116,6 @@ TEST(CDiffManager, test001)
 
 	pcDiffManager->SetDiffUse(true);
 	ASSERT_THAT(pcDiffManager->IsDiffUse(), IsTrue());
-
-	CDiffManager::resetInstance();
 }
 
 /*!

--- a/src/test/cpp/tests1/test-window.cpp
+++ b/src/test/cpp/tests1/test-window.cpp
@@ -2590,6 +2590,43 @@ TEST_F(EditWndTest, ShowDlgInputBox001)
 		// 処理対象でないボタンIDを送信して空振りさせる
 		SendDlgCommand(hWndDlg, 0L);
 
+		// 文字数超過していたら切り詰める
+		::SetDlgItemTextW(hWndDlg, IDC_EDIT_INPUT1, L"test");
+		SendDlgCommand(hWndDlg, IDOK);
+	});
+
+	std::wstring buffer{ L"TES" };
+
+	EXPECT_THAT(cDlgInput1.DoModal(unusedArg1, pcEditWnd->GetHwnd(), L"title", L"message", std::size(buffer) + 1, std::data(buffer)), IsTrue());
+
+	EXPECT_THAT(buffer, StrEq(L"tes"));
+}
+
+/*!
+ * 1行入力ダイアログの表示テスト
+ */
+TEST_F(EditWndTest, ShowDlgInputBox002)
+{
+	// モックを解除してダイアログをテストする
+	CDlgInput1::resetInstance();
+
+	auto& cDlgInput1 = *CDlgInput1::getInstance();
+
+	// 表示されたモーダルダイアログを閉じる
+	dialog::ModalDialogCloser closer(L"汎用入力ダイアログ", [&cDlgInput1] (HWND hWndDlg) {
+		// 処理対象でないメッセージを送信して空振りさせる
+		::SendMessageW(hWndDlg, WM_NULL, 0L, 0L);
+
+		// WM_HELPを送信してヘルプ表示処理を空振りさせる
+		HELPINFO hi{};
+		::SendMessageW(hWndDlg, WM_HELP, 0L, LPARAM(&hi));
+
+		// コンテキストメニュー表示を空振りさせる
+		FORWARD_WM_CONTEXTMENU(hWndDlg, nullptr, 0L, 0L, ::SendMessageW);
+
+		// 処理対象でないボタンIDを送信して空振りさせる
+		SendDlgCommand(hWndDlg, 0L);
+
 		// 文字数超過の場合は取り込まず、ダイアログは閉じない
 		::SetDlgItemTextW(hWndDlg, IDC_EDIT_INPUT1, L"test");
 		SendDlgCommand(hWndDlg, IDOK);
@@ -2601,7 +2638,10 @@ TEST_F(EditWndTest, ShowDlgInputBox001)
 
 	std::wstring buffer{ L"TES" };
 
-	EXPECT_THAT(cDlgInput1.DoModal(unusedArg1, pcEditWnd->GetHwnd(), L"title", L"message", std::size(buffer) + 1, std::data(buffer)), IsTrue());
+	EXPECT_THAT(cDlgInput1.DoModal(pcEditWnd->GetHwnd(), L"title", L"message", buffer, [] (HWND, std::wstring_view text, size_t cchBuffer) {
+		if (text.empty()) return 0;
+		return std::size(text) <= cchBuffer ? 1 : -1;
+	}), IsTrue());
 
 	EXPECT_THAT(buffer, StrEq(L"tes"));
 }
@@ -2611,7 +2651,7 @@ TEST_F(EditWndTest, ShowDlgInputBox001)
 /*!
  * 1行入力ダイアログの表示テスト
  */
-TEST_F(EditWndTest, ShowDlgInputBox002)
+TEST_F(EditWndTest, ShowDlgInputBox003)
 {
 	// マクロ関数を呼ぶためにWSHマクロマネージャーを使う
 	mgr = std::unique_ptr<CMacroManagerBase>(CMacroFactory::getInstance()->Create(L"js"));

--- a/src/test/cpp/tests1/test-winmain.cpp
+++ b/src/test/cpp/tests1/test-winmain.cpp
@@ -1235,7 +1235,7 @@ TEST_F(WinMainFuncTest, ShowDlgGrep101)
 	// 表示されたGrepダイアログを閉じるためのスレッドを起動する
 	auto t = StartDialogCloser(L"Grep", [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
 		EmulateInvokeButton(pUIAutomation, hWndDlg, IDCANCEL, st);
-	}, 15000);
+	});
 
 	// エディタープロセスを起動する
 	auto ep = testing::CreateEditorProcess(std::array{ LR"(-GREPDLG)", LR"(-GREPMODE)" }, profileName);
@@ -1269,7 +1269,7 @@ TEST_F(WinMainFuncTest, ShowDlgProfileMgr101)
 	auto t = StartDialogCloser(L"プロファイルマネージャ", [] (IUIAutomation* pUIAutomation, HWND hWndDlg, std::stop_token st) {
 		// プロファイルマネージャを閉じる
 		EmulateInvokeButton(pUIAutomation, hWndDlg, IDCANCEL, st);
-	}, 15000);
+	});
 
 	// エディタープロセスを起動する
 	auto ep = testing::CreateEditorProcess(std::array{ LR"(-PROFMGR)" }, profileName, false);

--- a/src/test/cpp/tests1/test-winmain.cpp
+++ b/src/test/cpp/tests1/test-winmain.cpp
@@ -156,6 +156,12 @@ public:
 	{
 		return true;
 	}
+
+	Me& operator = (HANDLE t)
+	{
+		reset(t);
+		return *this;
+	}
 };
 
 /*!
@@ -456,9 +462,22 @@ cxx::EditorProcessHolder CreateEditorProcess(
 	// エディターのメインスレッドを開く
 	cxx::HandleHolder hThread{ ::OpenThread(THREAD_SUSPEND_RESUME, FALSE, ep.dwThreadId) };
 
+	const bool isGrepMode = std::ranges::any_of(commandArgs, [] (std::wstring_view opt) {
+		return cxx::iequals(opt, L"-GREPMODE")
+			|| cxx::iequals(opt, L"-GREPDLG");
+	});
+
 	// 初期化完了イベントを作成する
 	SFilePath initEventName{ std::format(GSTR_EVENT_SAKURA_EP_INITIALIZED, ep.dwThreadId) };
 	cxx::HandleHolder hEvent{ ::CreateEventW(nullptr, TRUE, FALSE, initEventName) };
+
+	cxx::HandleHolder grepEvent{};
+
+	if (isGrepMode) {
+		// Grep完了イベントを作成する
+		SFilePath grepEventName{ std::format(GSTR_EVENT_SAKURA_GREP_COMPLETED, ep.dwThreadId) };
+		grepEvent = ::CreateEventW(nullptr, TRUE, FALSE, grepEventName);
+	}
 
 	// エディターのメインスレッドを再開する
 	::ResumeThread(hThread);
@@ -467,6 +486,14 @@ cxx::EditorProcessHolder CreateEditorProcess(
 	std::array handles{ hEvent.get(), ep.get() };
 	if (const auto dwRet = ::WaitForMultipleObjects(DWORD(std::size(handles)), std::data(handles), FALSE, 30000); WAIT_OBJECT_0 != dwRet) {
 		return cxx::EditorProcessHolder{ ep.release(), ep.dwProcessId, ep.dwThreadId, nullptr };
+	}
+
+	if (isGrepMode) {
+		// Grep完了を待つ
+		std::array grepHandles{ grepEvent.get(), ep.get() };
+		if (const auto dwRet = ::WaitForMultipleObjects(DWORD(std::size(grepHandles)), std::data(grepHandles), FALSE, 30000); WAIT_OBJECT_0 != dwRet) {
+			return cxx::EditorProcessHolder{ ep.release(), ep.dwProcessId, ep.dwThreadId, nullptr };
+		}
 	}
 
 	// メインウインドウを取得する

--- a/src/test/cpp/tests1/window/EditorTestSuite.cpp
+++ b/src/test/cpp/tests1/window/EditorTestSuite.cpp
@@ -145,3 +145,38 @@ namespace window {
 }
 
 } // namespace window
+
+/* static */ void MockComdlg32::_Cleanup([[maybe_unused]] const MockComdlg32*)
+{
+	gm_Files.clear();
+}
+
+/* static */ BOOL MockComdlg32::_GetOpenFileNameW(
+	LPOPENFILENAMEW pOfn
+)
+{
+	const auto result = !gm_Files.empty();
+	if (result) {
+		::wcscpy_s(pOfn->lpstrFile, pOfn->nMaxFile, std::data(gm_Files.front()));
+	}
+	return result;
+}
+
+/* static */ BOOL MockComdlg32::_GetSaveFileNameW(
+	LPOPENFILENAMEW pOfn
+)
+{
+	const auto result = !gm_Files.empty();
+	if (result) {
+		::wcscpy_s(pOfn->lpstrFile, pOfn->nMaxFile, std::data(gm_Files.front()));
+	}
+	return result;
+}
+
+MockComdlg32::MockComdlg32()
+{
+	ON_CALL(*this, GetOpenFileNameW(_)).WillByDefault(&_GetOpenFileNameW);
+	ON_CALL(*this, GetSaveFileNameW(_)).WillByDefault(&_GetSaveFileNameW);
+
+	ON_CALL(*this, CommDlgExtendedError()).WillByDefault([]() { return 0; });
+}

--- a/src/test/cpp/tests1/window/EditorTestSuite.hpp
+++ b/src/test/cpp/tests1/window/EditorTestSuite.hpp
@@ -53,6 +53,16 @@ struct MockUser32 final : public User32
 		_In_ WORD wLanguageId
 	));
 
+	MOCK_CONST_METHOD7(TrackPopupMenu, BOOL(
+		_In_ HMENU hMenu,
+		_In_ UINT uFlags,
+		_In_ int x,
+		_In_ int y,
+		_Reserved_ int nReserved,
+		_In_ HWND hWnd,
+		_Reserved_ CONST RECT* prcRect
+	));
+
 	static int _MessageBoxExW(
 		_In_opt_ HWND hWnd,
 		_In_opt_ LPCWSTR lpText,

--- a/src/test/cpp/tests1/window/EditorTestSuite.hpp
+++ b/src/test/cpp/tests1/window/EditorTestSuite.hpp
@@ -64,3 +64,29 @@ struct MockUser32 final : public User32
 	MockUser32();
 };
 
+struct MockComdlg32 final : public Comdlg32 {
+	MOCK_CONST_METHOD1(ChooseColorW, BOOL(LPCHOOSECOLORW pCf));
+	MOCK_CONST_METHOD1(ChooseFontW, BOOL(LPCHOOSEFONTW pCf));
+	MOCK_CONST_METHOD0(CommDlgExtendedError, DWORD());
+	MOCK_CONST_METHOD1(GetOpenFileNameW, BOOL(LPOPENFILENAMEW pOfn));
+	MOCK_CONST_METHOD1(GetSaveFileNameW, BOOL(LPOPENFILENAMEW pOfn));
+	MOCK_CONST_METHOD1(PrintDlgW, BOOL(LPPRINTDLGW pPD));
+
+	static inline std::vector<std::wstring> gm_Files;
+
+	static void _Cleanup([[maybe_unused]] const MockComdlg32*);
+
+	static BOOL _GetOpenFileNameW(
+		LPOPENFILENAMEW pOfn
+	);
+
+	static BOOL _GetSaveFileNameW(
+		LPOPENFILENAMEW pOfn
+	);
+
+	MockComdlg32();
+
+	using Holder = cxx::ResourceHolder<&_Cleanup>;
+	Holder m_Holder{ this };
+};
+

--- a/src/test/cpp/tests1/window/EditorTestSuite.hpp
+++ b/src/test/cpp/tests1/window/EditorTestSuite.hpp
@@ -42,3 +42,15 @@ struct EditorTestSuite : public env::ShareDataTestSuite
 };
 
 } // namespace env
+
+struct MockUser32 final : public User32
+{
+	MOCK_CONST_METHOD5(MessageBoxExW, int(
+		_In_opt_ HWND hWnd,
+		_In_opt_ LPCWSTR lpText,
+		_In_opt_ LPCWSTR lpCaption,
+		_In_ UINT uType,
+		_In_ WORD wLanguageId
+	));
+};
+

--- a/src/test/cpp/tests1/window/EditorTestSuite.hpp
+++ b/src/test/cpp/tests1/window/EditorTestSuite.hpp
@@ -52,5 +52,15 @@ struct MockUser32 final : public User32
 		_In_ UINT uType,
 		_In_ WORD wLanguageId
 	));
+
+	static int _MessageBoxExW(
+		_In_opt_ HWND hWnd,
+		_In_opt_ LPCWSTR lpText,
+		_In_opt_ LPCWSTR lpCaption,
+		_In_ UINT uType,
+		_In_ WORD wLanguageId
+	);
+
+	MockUser32();
 };
 

--- a/src/test/cpp/tests1/window/UiaTestSuite.cpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.cpp
@@ -370,21 +370,6 @@ std::jthread UiaTestSuite::StartDialogCloser(
 
 /*!
  * ダイアログを閉じるスレッドを開始する
- *
- * @param titleResourceId タイトルのリソースID
- * @param action 閉じるアクション
- * @return ダイアログを閉じるためのスレッド
- */
-std::jthread UiaTestSuite::StartDialogCloser(
-	int titleResourceId,
-	const std::function<void(IUIAutomation*, HWND, std::stop_token)>& action
-)
-{
-	const std::wstring buffer{ cxx::load_string(titleResourceId) };
-
-	return StartDialogCloser(buffer, action);
-}
-
 /*!
  * ポップアップメニューを選択するスレッドを開始する
  *
@@ -413,23 +398,6 @@ std::jthread UiaTestSuite::StartPopupMenuSelector(
 
 		// 閉じるアクションを実行する
 		action(pAutomation, hWndFound, st);
-	});
-}
-
-/*!
- * プロパティーシートを閉じるスレッドを開始する
- *
- * @param titleResourceId タイトルのリソースID
- * @param psButtonId ボタンID
- * @return プロパティーシートを閉じるためのスレッド
- */
-std::jthread UiaTestSuite::StartPropertySheetCloser(
-	int titleResourceId,
-	UINT psButtonId
-)
-{
-	return StartDialogCloser(titleResourceId, [psButtonId] (IUIAutomation*, HWND hWndDlg, std::stop_token) {
-		SendPsmPressButton(hWndDlg, psButtonId);
 	});
 }
 

--- a/src/test/cpp/tests1/window/UiaTestSuite.cpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.cpp
@@ -483,4 +483,36 @@ std::jthread UiaTestSuite::StartWindowCloser(
 	});
 }
 
+void UiaTestSuite::RunMessageLoop(
+	ULONGLONG timeoutMilli
+)
+{
+	// スレッド同期用フラグ変数
+	std::atomic_bool finished = false;
+
+	// 別スレッドでModalDialogCloserの完了を待機する
+	auto t = StartUiaThread([&finished, timeoutMilli] (const IUIAutomation*, std::stop_token st) {
+		// ModalDialogCloserの完了を待機する
+		cxx::WaitForQuery([] { return dialog::ModalDialogCloser::IsHandled(); }, st, timeoutMilli);
+
+		// 完了フラグを立てる
+		finished.store(true, std::memory_order_release);
+	});
+
+	// 完了フラグが立つまでPeekMessageでループする
+	MSG msg{};
+	while (!finished.load(std::memory_order_acquire)) {
+		// 溜まっているメッセージをすべてウィンドウに配送する
+		while (::PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+			if (::IsDialogMessageW(msg.hwnd, &msg)) continue;
+
+			::TranslateMessage(&msg);
+			::DispatchMessageW(&msg);
+		}
+
+		// Sleepの代わり。
+		::MsgWaitForMultipleObjectsEx(0, nullptr, 10, QS_ALLINPUT, MWMO_INPUTAVAILABLE);
+	}
+}
+
 } // namespace window

--- a/src/test/cpp/tests1/window/UiaTestSuite.cpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.cpp
@@ -258,10 +258,19 @@ HWND WaitForWindow(
 	int notifyCode
 )
 {
+	// 指定されたコントロールのハンドルを取得する
 	const auto hWndCtrl = ::GetDlgItem(hWndDlg, nIDDlgItem);
-	ASSERT_THAT(hWndCtrl, NotNull()) << "control not found: #" << nIDDlgItem;
 
+	// コントロールのハンドルが取れなくても、それ自体は問題でない(ログの要否は今後検討する)
+	//ASSERT_THAT(hWndCtrl, NotNull()) << "control not found: #" << nIDDlgItem;
+
+#if 0
+	// 元々はクロススレッド想定で書いていた
 	EXPECT_THAT(::SendMessageTimeoutW(hWndDlg, WM_COMMAND, MAKEWPARAM(nIDDlgItem, notifyCode), LPARAM(hWndCtrl), SMTO_ABORTIFHUNG | SMTO_BLOCK | SMTO_NOTIMEOUTIFNOTHUNG, 0, nullptr), IsTrue());
+#else
+	// 同スレッドからSendMessageを呼ぶと、DlgProcの直呼びとして処理されるので効率がよい
+	FORWARD_WM_COMMAND(hWndDlg, nIDDlgItem, hWndCtrl, notifyCode, ::SendMessageW);
+#endif
 }
 
 /* static */ void UiaTestSuite::SendPsmPressButton(
@@ -269,7 +278,7 @@ HWND WaitForWindow(
 	UINT button
 )
 {
-	EXPECT_THAT(::SendMessageTimeoutW(hWndPropertySheet, PSM_PRESSBUTTON, button, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK | SMTO_NOTIMEOUTIFNOTHUNG, 0, nullptr), IsTrue());
+	::SendMessageW(hWndPropertySheet, PSM_PRESSBUTTON, button, 0L);
 }
 
 /*!

--- a/src/test/cpp/tests1/window/UiaTestSuite.hpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.hpp
@@ -310,7 +310,7 @@ struct UiaTestSuite
 	std::jthread StartDialogCloser(
 		const std::optional<std::wstring>& optTitle,
 		const std::function<void(IUIAutomation*, HWND, std::stop_token)>& action,
-		ULONGLONG timeoutMillis = defaultTimeoutMillis * 3
+		ULONGLONG timeoutMillis = defaultTimeoutMillis * 4
 	);
 
 	/*!

--- a/src/test/cpp/tests1/window/UiaTestSuite.hpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.hpp
@@ -314,18 +314,6 @@ struct UiaTestSuite
 	);
 
 	/*!
-	 * ダイアログを閉じるスレッドを開始する
-	 *
-	 * @param titleResourceId タイトルのリソースID
-	 * @param action 閉じるアクション
-	 * @return ダイアログを閉じるためのスレッド
-	 */
-	std::jthread StartDialogCloser(
-		int titleResourceId,
-		const std::function<void(IUIAutomation*, HWND, std::stop_token)>& action
-	);
-
-	/*!
 	 * ポップアップメニューを選択するスレッドを開始する
 	 *
 	 * @param menuLabel メニューラベル
@@ -334,18 +322,6 @@ struct UiaTestSuite
 	std::jthread StartPopupMenuSelector(
 		std::wstring_view menuLabel,
 		ULONGLONG timeoutMillis = defaultTimeoutMillis
-	);
-
-	/*!
-	 * プロパティーシートを閉じるスレッドを開始する
-	 *
-	 * @param titleResourceId タイトルのリソースID
-	 * @param psButtonId ボタンID
-	 * @return プロパティーシートを閉じるためのスレッド
-	 */
-	std::jthread StartPropertySheetCloser(
-		int titleResourceId,
-		UINT psButtonId = PSBTN_OK
 	);
 
 	/*!

--- a/src/test/cpp/tests1/window/UiaTestSuite.hpp
+++ b/src/test/cpp/tests1/window/UiaTestSuite.hpp
@@ -373,6 +373,10 @@ struct UiaTestSuite
 		ULONGLONG timeoutMillis = defaultTimeoutMillis
 	);
 
+	void RunMessageLoop(
+		ULONGLONG timeoutMillis = defaultTimeoutMillis * 6
+	);
+
 	std::stop_source m_StopSource;
 	std::jthread m_Thread;
 	bool m_Timeout = false;

--- a/src/test/resources/eval_outputs.hpp
+++ b/src/test/resources/eval_outputs.hpp
@@ -6,17 +6,7 @@
 */
 #include "util/os.h"
 #include "util/tchar_convert.h"
-
-struct MockUser32 final : public User32
-{
-	MOCK_CONST_METHOD5(MessageBoxExW, int(
-		_In_opt_ HWND hWnd,
-		_In_opt_ LPCWSTR lpText,
-		_In_opt_ LPCWSTR lpCaption,
-		_In_ UINT uType,
-		_In_ WORD wLanguageId
-	));
-};
+#include "window/EditorTestSuite.hpp"
 
 // 標準エラー出力に吐き出されたメッセージを評価します
 #define EXPECT_ERROUT(statementExpression, expected) \


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

単体テストの不具合修正。
テストを実行するためのアプリ改善を含むので「改善」に。

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
### メインの背景

- #2589

### 関連する背景
- #2596 
- #2603 
- #2612 

どんどん増えそう

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- システムDLLの一部をモック化して UI Automation のテストを減らします。
- ModalDialogCloserの待機条件を変更して、プロパティシートとモードレスダイアログのテストに流用できるようにします。
- 後続テストに影響を与えるクリーンアップ漏れのいくつかを対処します。
- UiaTestSuite::StartPropertySheetCloserを廃止します。
- Grep完了イベントを導入します。

ほか、わかりづらいやつ多数。

本件、勝手にやります。


## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
