### PR TITLE
Grep 時に uchardet.dll のロードがファイルごとに再試行される問題を修正

### DIFF
--- a/sakura_core/charset/CCodeMediator.cpp
+++ b/sakura_core/charset/CCodeMediator.cpp
@@ -30,7 +30,7 @@ ECodeType CCodeMediator::CheckKanjiCode(const char* buff, size_t size) noexcept
 		return m_sEncodingConfig.m_eDefaultCodetype;
 	}
 
-	CharsetDetector csd;
+	static thread_local CharsetDetector csd;
 	if (csd.IsAvailable()) {
 		auto code = csd.Detect(std::string_view(buff, size));
 		if (code != CODE_ERROR) return code;


### PR DESCRIPTION
## 概要

文字コード自動判別のたびに `uchardet.dll` のロードが再試行され、
`uchardet.dll` が存在しない環境ではファイル 1 件につき数十回の
DLL 検索が空振りしていました。

`CCodeMediator::CheckKanjiCode()` の `CharsetDetector` を
`static thread_local` にすることで、DLL ロードの試行を起動後 1 回に限定します。

判別結果は変わりません。変更は 1 行です。

## 変更内容

`sakura_core/charset/CCodeMediator.cpp`

```diff
-	CharsetDetector csd;
+	static thread_local CharsetDetector csd;
 	if (csd.IsAvailable()) {
 		auto code = csd.Detect(std::string_view(buff, size));
 		if (code != CODE_ERROR) return code;
 	}
```

## 原因

`CDllImp::InitDll()`（`sakura_core/extmodule/CDllHandler.cpp:43`）は
成功時のみ早期リターンし、**失敗をキャッシュしません**。

```cpp
	if( IsAvailable() ){
		//	既に利用可能で有れば何もしない．
		return DLL_SUCCESS;
	}
```

`CharsetDetector` がローカル変数のため、`CheckKanjiCode()` の呼び出しごとに
`m_hInstance == nullptr` の新しいインスタンスが生成され、
`LoadLibraryExedir("uchardet.dll")` が毎回再実行されます。

`uchardet.dll` は本プロジェクトに同梱されておらず（PR #1726 で
「存在したら使う」任意 DLL として実装）、置いていない環境では
以下を毎回実行したうえで必ず失敗し、`CESI` にフォールバックします。

1. `GetCurrentDirectory`（カレントディレクトリ退避）
2. `GetModuleFileName` + `SetCurrentDirectory`（exe フォルダへ移動）
3. `LoadLibrary` による DLL 検索パスの全走査（失敗）
4. `SetCurrentDirectory`（復元）

**判別結果への寄与はゼロです。**

失敗オープンの回数は環境の PATH エントリ数に比例するため、
PATH の長い開発機ほど影響が大きくなります。

## 修正が安全である根拠

`CharsetDetector::Detect()`（`sakura_core/charset/CharsetDetector.cpp:175`）は
既にインスタンスの再利用を前提として実装されています。

```cpp
	if (!_ud) {
		_ud = _uchardet.uchardet_new();
	}
	...
	_uchardet.uchardet_reset(_ud);
```

`_ud` は初回のみ生成され、以降は毎回 `uchardet_reset()` で初期化されます。
長寿命化はこのクラスの設計意図に沿った使い方であり、判別結果は変わりません。

### `thread_local` にした理由

`uchardet_t` はスレッド安全ではないため、単なる `static` にすると
Grep 並列化（#2524）で複数スレッドから同一の `_ud` が同時に使用されます。

また `LoadLibraryExedir()` 内の `SetCurrentDirectory` はプロセス全体に作用するため、
現状の実装では並列化時にカレントディレクトリの競合が発生しえます。
本修正はこの経路を初回 1 回に限定するため、その競合も併せて解消します。

## 計測結果

### 計測条件

| 項目 | 値 |
| --- | --- |
| ビルド | master / Win32 Release（インストール後に実行） |
| 対象 | 8,745 ファイル（1 件 22 バイト、計 0.19MB） |
| 検索条件 | ヒットしない語（ヒット 0 件、出力コストを排除） |
| 文字コード | 自動判別 |
| 計測方法 | Process Monitor（`Process Name is sakura.exe`） |

対象を極小ファイルに統一しているのは、行単位の処理コストを排除し、
ファイル 1 件あたりの固定コストのみを観測するためです。

### 結果

| 項目 | 修正前 | 修正後 |
| --- | --- | --- |
| 所要時間 | 82.7 秒 | **33.8 秒** |
| 総イベント数 | 437,678 | 109,111 |
| `CreateFile` | 367,689 | 18,203 |
| **`uchardet.dll` の検索** | **341,094** | **39** |
| ファイル I/O の Duration 合計 | 5.06 秒 | 0.52 秒 |

修正前はファイル 1 件につき約 39 回の失敗オープンが発生していました。

```
C:\Program Files (x86)\sakura\uchardet.dll      8,746 回
C:\Windows\SysWOW64\uchardet.dll               17,492 回
C:\Windows\uchardet.dll                        17,492 回
C:\Program Files\Git\usr\bin\uchardet.dll      17,492 回
C:\Python314\uchardet.dll                       8,746 回
（以下、PATH の全エントリ）
```

修正後は各パス 1〜2 回のみとなり、**合計 39 件**（DLL 検索パスのエントリ数相当）に
収まっています。起動後 1 回だけ探索し、以降は試みない設計通りの挙動です。

### 補足

上記は Process Monitor を有効にした状態での計測値です。
Process Monitor は全ファイル I/O にフックを挿入するため、
絶対時間は実際より遅く出ています。修正前後で同条件のため比較は成立しますが、
**削減量の絶対値としては参考値**としてお読みください。

なお本修正は DLL ロードの反復のみを解消するもので、
`CESI::ScanCode()` による判別走査そのものは従来どおり実行されます。

## 動作確認

- [ ] CI（`tests1.exe`）がグリーンであること
- [x] Process Monitor で `uchardet.dll` の検索回数が減ることを確認
- [x] Grep の検索結果（ヒット件数）が修正前後で一致すること

## 相談したい点

1. **プロセス終了時の DLL 呼び出しについて。**
   メインスレッドの `thread_local` オブジェクトはプロセス終了時に破棄され、
   `CharsetDetector` のデストラクタから `uchardet_delete()` が呼ばれます。
   終了処理中に DLL の関数を呼ぶことになりますが、問題ないでしょうか。
   なお `uchardet.dll` が存在しない環境では `IsAvailable()` が false のため
   この経路は通りません。

2. **代替案との比較。**
   `CDllImp` 側に「ロード失敗の記録」を持たせる方法も考えられますが、
   `CDllImp` は bregonig / cmigemo など他の DLL でも使用されているため
   影響範囲が広く、本 PR では影響範囲の狭い方を選択しています。

## 影響範囲

`CCodeMediator::CheckKanjiCode()` の呼び出し元は以下です。
いずれも判別結果は変わりません。

- `sakura_core/io/CFileLoad.cpp:204`（ファイル読み込み時の自動判別。Grep を含む）
- `sakura_core/agent/CGrepAgent.cpp:1334`
- `sakura_core/env/CReadManager.cpp:43`
- `sakura_core/recent/CMruListener.cpp:68`
- `sakura_core/_os/CClipboard.cpp:646`
- `sakura_core/convert/CConvert_CodeAutoToSjis.cpp:33`
