### PR TITLE
Grepのファイル列挙まわりの資源解放を直す

### DIFF
--- a/sakura_core/grep/CGrepEnumFileBase.h
+++ b/sakura_core/grep/CGrepEnumFileBase.h
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <tchar.h>
 #include <Shlwapi.h>
+#include "cxx/ResourceHolder.hpp"
 #include "grep/CGrepEnumKeys.h"
 #include "util/string_ex.h"
 
@@ -123,6 +124,9 @@ public:
 			WIN32_FIND_DATA w32fd;
 			HANDLE handle = ::FindFirstFile( lpPath, &w32fd );
 			if( INVALID_HANDLE_VALUE != handle ){
+				// 検索ハンドルをスマートポインタに入れる(途中で抜けても確実に閉じる)
+				using FindFileHolder = cxx::ResourceHolder<&::FindClose>;
+				FindFileHolder handleHolder{ handle };
 				do{
 					if( !::PathMatchSpec(w32fd.cFileName, vecKeys[ i ] + nKeyDirLen) ){
 						continue;
@@ -160,7 +164,6 @@ public:
 					delete [] lpName;
 					delete [] lpFullPath;
 				}while( ::FindNextFile( handle, &w32fd ) );
-				::FindClose( handle );
 			}
 			delete [] lpPath;
 		}

--- a/sakura_core/grep/CGrepEnumKeys.h
+++ b/sakura_core/grep/CGrepEnumKeys.h
@@ -157,11 +157,9 @@ public:
 
 		const WCHAR* WILDCARD_DELIMITER = L" ;,";	//リストの区切り
 		auto nWildCardLen = int(wcslen(lpKeys));
-		WCHAR* pWildCard = new WCHAR[nWildCardLen + 1];
-		if (!pWildCard) {
-			return patterns;
-		}
-		wcscpy(pWildCard, lpKeys);
+		std::vector<WCHAR> vecWildCard(static_cast<size_t>(nWildCardLen) + 1);
+		wcscpy_s(vecWildCard.data(), vecWildCard.size(), lpKeys);
+		WCHAR* pWildCard = vecWildCard.data();
 
 		int nPos = 0;
 		WCHAR*	token;
@@ -184,7 +182,6 @@ public:
 			std::wstring element(token);
 			patterns.push_back(element);
 		}
-		delete[] pWildCard;
 		return patterns;
 	}
 
@@ -194,6 +191,8 @@ private:
 		ClearEnumKeys(m_vecSearchFileKeys);
 		ClearEnumKeys(m_vecExceptFolderKeys);
 		ClearEnumKeys(m_vecSearchFolderKeys);
+		ClearEnumKeys(m_vecExceptAbsFileKeys);
+		ClearEnumKeys(m_vecExceptAbsFolderKeys);
 		return;
 	}
 	void ClearEnumKeys( VGrepEnumKeys& keys ){

--- a/sakura_core/grep/CGrepEnumKeys.h
+++ b/sakura_core/grep/CGrepEnumKeys.h
@@ -157,9 +157,8 @@ public:
 
 		const WCHAR* WILDCARD_DELIMITER = L" ;,";	//リストの区切り
 		auto nWildCardLen = int(wcslen(lpKeys));
-		std::vector<WCHAR> vecWildCard(static_cast<size_t>(nWildCardLen) + 1);
-		wcscpy_s(vecWildCard.data(), vecWildCard.size(), lpKeys);
-		WCHAR* pWildCard = vecWildCard.data();
+		std::wstring strWildCard(lpKeys, nWildCardLen);
+		WCHAR* pWildCard = strWildCard.data();
 
 		int nPos = 0;
 		WCHAR*	token;

--- a/sakura_core/tests1.vcxproj
+++ b/sakura_core/tests1.vcxproj
@@ -147,6 +147,7 @@
     <ClCompile Include="..\src\test\cpp\tests1\test-cerrorinfo.cpp" />
     <ClCompile Include="..\src\test\cpp\tests1\test-cfileext.cpp" />
     <ClCompile Include="..\src\test\cpp\tests1\test-cfuncinfoarr.cpp" />
+    <ClCompile Include="..\src\test\cpp\tests1\test-cgrepenumkeys.cpp" />
     <ClCompile Include="..\src\test\cpp\tests1\test-clayoutint.cpp" />
     <ClCompile Include="..\src\test\cpp\tests1\test-cimagelistmgr.cpp" />
     <ClCompile Include="..\src\test\cpp\tests1\test-cmemory.cpp" />

--- a/sakura_core/tests1.vcxproj.filters
+++ b/sakura_core/tests1.vcxproj.filters
@@ -175,6 +175,9 @@
     <ClCompile Include="..\src\test\cpp\tests1\test-cfuncinfoarr.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\test\cpp\tests1\test-cgrepenumkeys.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\test\cpp\tests1\test-cdoctypemanager.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>

--- a/src/test/cpp/tests1/test-cgrepenumkeys.cpp
+++ b/src/test/cpp/tests1/test-cgrepenumkeys.cpp
@@ -1,0 +1,193 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2026, Sakura Editor Organization
+
+	SPDX-License-Identifier: Zlib
+*/
+#include "pch.h"
+#include "grep/CGrepEnumKeys.h"
+
+/*!
+	@brief 解析結果を std::wstring の配列に変換する
+
+	VGrepEnumKeys の要素型に依存せず比較できるようにするためのヘルパー。
+*/
+static std::vector<std::wstring> ToStrings(const VGrepEnumKeys& keys)
+{
+	return std::vector<std::wstring>(keys.cbegin(), keys.cend());
+}
+
+/*!
+	@brief 区切り文字(空白・セミコロン・カンマ)でパターンが分割されること
+*/
+TEST(CGrepEnumKeys, SplitPattern_Delimiters)
+{
+	const auto patterns = CGrepEnumKeys::SplitPattern(L"*.cpp *.h;*.txt,*.md");
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.cpp", L"*.h", L"*.txt", L"*.md" }), patterns);
+}
+
+/*!
+	@brief 引用符が取り除かれ、引用符内の区切り文字が無視されること
+*/
+TEST(CGrepEnumKeys, SplitPattern_DoubleQuotes)
+{
+	const auto patterns = CGrepEnumKeys::SplitPattern(L"\"a b;c.txt\";*.h");
+	EXPECT_EQ(std::vector<std::wstring>({ L"a b;c.txt", L"*.h" }), patterns);
+}
+
+/*!
+	@brief 空文字列を渡すと空の配列が返ること
+*/
+TEST(CGrepEnumKeys, SplitPattern_Empty)
+{
+	const auto patterns = CGrepEnumKeys::SplitPattern(L"");
+	EXPECT_TRUE(patterns.empty());
+}
+
+/*!
+	@brief 区切り文字だけを渡すと空の配列が返ること
+*/
+TEST(CGrepEnumKeys, SplitPattern_DelimitersOnly)
+{
+	const auto patterns = CGrepEnumKeys::SplitPattern(L" ;,");
+	EXPECT_TRUE(patterns.empty());
+}
+
+/*!
+	@brief 引用符が閉じられていない場合、以降が1つのトークンとして扱われること
+
+	my_strtok() は引用符の中では区切り文字を無視するため、閉じ忘れると末尾まで
+	1トークンになる。現在の挙動を追認するテスト。
+*/
+TEST(CGrepEnumKeys, SplitPattern_UnclosedDoubleQuote)
+{
+	const auto patterns = CGrepEnumKeys::SplitPattern(L"\"*.cpp;*.h");
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.cpp;*.h" }), patterns);
+}
+
+/*!
+	@brief 検索パターン省略時に既定のワイルドカードが補われること
+*/
+TEST(CGrepEnumKeys, SetFileKeys_DefaultWildcard)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(0, keys.SetFileKeys(L""));
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.*" }), ToStrings(keys.m_vecSearchFileKeys));
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.*" }), ToStrings(keys.m_vecSearchFolderKeys));
+}
+
+/*!
+	@brief 接頭辞(なし・!・#)でパターンが振り分けられること
+*/
+TEST(CGrepEnumKeys, SetFileKeys_Classify)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(0, keys.SetFileKeys(L"*.cpp !*.bak #obj"));
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.cpp" }), ToStrings(keys.m_vecSearchFileKeys));
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.bak" }), ToStrings(keys.m_vecExceptFileKeys));
+	EXPECT_EQ(std::vector<std::wstring>({ L"obj" }), ToStrings(keys.m_vecExceptFolderKeys));
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.*" }), ToStrings(keys.m_vecSearchFolderKeys));
+}
+
+/*!
+	@brief 除外指定の絶対パスが専用の配列に振り分けられること
+*/
+TEST(CGrepEnumKeys, SetFileKeys_AbsoluteExcept)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(0, keys.SetFileKeys(L"*.cpp !C:\\work\\*.bak #C:\\work\\obj"));
+	EXPECT_EQ(std::vector<std::wstring>({ L"C:\\work\\*.bak" }), ToStrings(keys.m_vecExceptAbsFileKeys));
+	EXPECT_EQ(std::vector<std::wstring>({ L"C:\\work\\obj" }), ToStrings(keys.m_vecExceptAbsFolderKeys));
+	EXPECT_TRUE(keys.m_vecExceptFileKeys.empty());
+	EXPECT_TRUE(keys.m_vecExceptFolderKeys.empty());
+}
+
+/*!
+	@brief UNCパスの除外指定が絶対パスとして振り分けられること
+*/
+TEST(CGrepEnumKeys, SetFileKeys_UncPathExcept)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(0, keys.SetFileKeys(L"*.cpp !\\\\server\\share\\*.bak"));
+	EXPECT_EQ(std::vector<std::wstring>({ L"\\\\server\\share\\*.bak" }), ToStrings(keys.m_vecExceptAbsFileKeys));
+	EXPECT_TRUE(keys.m_vecExceptFileKeys.empty());
+}
+
+/*!
+	@brief 同じパターンを重複して登録しないこと
+*/
+TEST(CGrepEnumKeys, SetFileKeys_Unique)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(0, keys.SetFileKeys(L"*.cpp *.cpp"));
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.cpp" }), ToStrings(keys.m_vecSearchFileKeys));
+}
+
+/*!
+	@brief フォルダー部分のワイルドカードがエラーになること
+*/
+TEST(CGrepEnumKeys, SetFileKeys_WildcardInFolderIsError)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(1, keys.SetFileKeys(L"*\\file.exe"));
+}
+
+/*!
+	@brief フォルダー部分の '?' ワイルドカードがエラーになること
+*/
+TEST(CGrepEnumKeys, SetFileKeys_QuestionMarkInFolderIsError)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(1, keys.SetFileKeys(L"?\\file.exe"));
+}
+
+/*!
+	@brief 検索対象への絶対パス指定がエラーになること
+*/
+TEST(CGrepEnumKeys, SetFileKeys_AbsoluteSearchIsError)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(2, keys.SetFileKeys(L"C:\\work\\*.cpp"));
+}
+
+/*!
+	@brief 再呼び出し時に絶対パスの除外指定が持ち越されないこと
+
+	ClearItems() が絶対パス用の2配列をクリアしていなかった不具合の回帰テスト。
+*/
+TEST(CGrepEnumKeys, SetFileKeys_ClearsAbsoluteExceptOnReentry)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(0, keys.SetFileKeys(L"*.cpp !C:\\work\\*.bak #C:\\work\\obj"));
+	ASSERT_EQ(1u, keys.m_vecExceptAbsFileKeys.size());
+	ASSERT_EQ(1u, keys.m_vecExceptAbsFolderKeys.size());
+
+	EXPECT_EQ(0, keys.SetFileKeys(L"*.cpp"));
+	EXPECT_TRUE(keys.m_vecExceptAbsFileKeys.empty());
+	EXPECT_TRUE(keys.m_vecExceptAbsFolderKeys.empty());
+}
+
+/*!
+	@brief 除外リストが相対パス・絶対パスの順に連結されること
+*/
+TEST(CGrepEnumKeys, GetExcludeFilesAndFolders)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(0, keys.SetFileKeys(L"*.cpp !*.bak !C:\\work\\*.tmp #obj #C:\\work\\bin"));
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.bak", L"C:\\work\\*.tmp" }), ToStrings(keys.GetExcludeFiles()));
+	EXPECT_EQ(std::vector<std::wstring>({ L"obj", L"C:\\work\\bin" }), ToStrings(keys.GetExcludeFolders()));
+}
+
+/*!
+	@brief 除外パターンの追加が既存の解析結果に積まれること
+*/
+TEST(CGrepEnumKeys, AddExceptFileAndFolder)
+{
+	CGrepEnumKeys keys;
+	EXPECT_EQ(0, keys.SetFileKeys(L"*.cpp !*.bak"));
+	EXPECT_EQ(0, keys.AddExceptFile(L"*.tmp;C:\\work\\*.log"));
+	EXPECT_EQ(0, keys.AddExceptFolder(L"obj"));
+	EXPECT_EQ(std::vector<std::wstring>({ L"*.bak", L"*.tmp" }), ToStrings(keys.m_vecExceptFileKeys));
+	EXPECT_EQ(std::vector<std::wstring>({ L"C:\\work\\*.log" }), ToStrings(keys.m_vecExceptAbsFileKeys));
+	EXPECT_EQ(std::vector<std::wstring>({ L"obj" }), ToStrings(keys.m_vecExceptFolderKeys));
+}


### PR DESCRIPTION
#2596 の PR-A を 3 分割した 1 本目です。型は変えず、資源解放の不備だけを直します。

## 変更内容

1. `CGrepEnumKeys::ClearItems()` が `m_vecExceptAbsFileKeys` / `m_vecExceptAbsFolderKeys` をクリアしていなかったのを修正。`!C:\work\*.bak` のような絶対パス除外を指定するたびに文字列がリークしていました。
2. `SplitPattern()` の作業バッファを `new WCHAR[]` から `std::vector<WCHAR>` に変更。ループ中に例外が飛ぶと `delete[]` に到達しませんでした。あわせて `wcscpy` を `wcscpy_s` に変更。
3. `CGrepEnumFileBase::Enumerates()` の `FindClose` を `cxx::ResourceHolder` による RAII に変更。ループ内の `new WCHAR[]` が投げると検索ハンドルが漏れていました。

## 変更ファイル

- `sakura_core/grep/CGrepEnumKeys.h`
- `sakura_core/grep/CGrepEnumFileBase.h`
- `src/test/cpp/tests1/test-cgrepenumkeys.cpp`（新規・16 件）
- `sakura_core/tests1.vcxproj`、`sakura_core/tests1.vcxproj.filters`

## 影響範囲

`VGrepEnumKeys` / `PairGrepEnumItem` の型は変えていないため、呼び出し側（Grep、Grep 置換、アウトラインのファイルツリー）は無修正です。1 は現行 master に `SetFileKeys()` の再呼び出し経路がないため、動作に差は出ません。

## 確認したいこと

- 1 を本 PR に含めてよいか。後続の `std::wstring` 化でもリーク自体は消えるため、そちらに寄せる選択もあります。
- `cxx::ResourceHolder` を `grep/` 配下から使ってよいか。`CSelectLang.cpp` の `FindFirstFileW` と同じ用法です。
