### PR TITLE
Grepのファイル一覧処理から手動メモリ管理を削除

### DIFF
--- a/sakura_core/grep/CGrepEnumFileBase.h
+++ b/sakura_core/grep/CGrepEnumFileBase.h
@@ -15,6 +15,9 @@
 #define SAKURA_CGREPENUMFILEBASE_6B85547E_13E4_4183_AE06_B4D6395ABC88_H_
 #pragma once
 
+#include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 #include <windows.h>
 #include <string.h>
@@ -24,8 +27,8 @@
 #include "grep/CGrepEnumKeys.h"
 #include "util/string_ex.h"
 
-typedef std::pair< LPWSTR, DWORD > PairGrepEnumItem;
-typedef std::vector< PairGrepEnumItem > VPGrepEnumItem;
+using PairGrepEnumItem = std::pair< std::wstring, DWORD >;
+using VPGrepEnumItem = std::vector< PairGrepEnumItem >;
 
 class CGrepEnumOptions {
 public:
@@ -51,23 +54,16 @@ public:
 	Me& operator = (const Me&) = delete;
 	CGrepEnumFileBase(Me&&) noexcept = delete;
 	Me& operator = (Me&&) noexcept = delete;
-	virtual ~CGrepEnumFileBase(){
-		ClearItems();
-	}
+	virtual ~CGrepEnumFileBase() = default;
 
 	void ClearItems( void ){
-		for( int i = 0; i < GetCount(); i++ ){
-			LPWSTR lp = m_vpItems[ i ].first;
-			m_vpItems[ i ].first = nullptr;
-			delete [] lp;
-		}
 		m_vpItems.clear();
 		return;
 	}
 
-	BOOL IsExist( LPCWSTR lpFileName ){
-		for( int i = 0; i < GetCount(); i++ ){
-			if( wcscmp( m_vpItems[ i ].first, lpFileName ) == 0 ){
+	BOOL IsExist( std::wstring_view svFileName ) const {
+		for( const auto& item : m_vpItems ){
+			if( std::wstring_view( item.first ) == svFileName ){
 				return TRUE;
 			}
 		}
@@ -81,16 +77,16 @@ public:
 		return FALSE;
 	}
 
-	int GetCount( void ){
+	int GetCount( void ) const {
 		return (int)m_vpItems.size();
 	}
 
-	LPCWSTR GetFileName( int i ){
+	LPCWSTR GetFileName( int i ) const {
 		if( i < 0 || i >= GetCount() ) return nullptr;
-		return m_vpItems[ i ].first;
+		return m_vpItems[ i ].first.c_str();
 	}
 
-	DWORD GetFileSizeLow( int i ){
+	DWORD GetFileSizeLow( int i ) const {
 		if( i < 0 || i >= GetCount() ) return 0;
 		return m_vpItems[ i ].second;
 	}
@@ -98,74 +94,62 @@ public:
 	int Enumerates( LPCWSTR lpBaseFolder, VGrepEnumKeys& vecKeys, CGrepEnumOptions& option, CGrepEnumFileBase* pExceptItems = nullptr ){
 		int found = 0;
 
-		const auto cchBaseFolder = lpBaseFolder ? wcsnlen_s(lpBaseFolder, 4096 - 1) : 0; // FIXME: パス長の上限は暫定値。
-		for( int i = 0; i < (int)vecKeys.size(); i++ ){
-			const auto baseLen = cchBaseFolder;
-			LPWSTR lpPath = new WCHAR[ baseLen + wcslen( vecKeys[ i ] ) + 2 ];
-			if( nullptr == lpPath ) break;
-			wcscpy( lpPath, lpBaseFolder );
-			wcscpy( lpPath + baseLen, L"\\" );
-			wcscpy( lpPath + baseLen + 1, vecKeys[ i ] );
-			// vecKeys[ i ] ==> "subdir\*.h" 等の場合に後で(ファイル|フォルダー)名に "subdir\" を連結する
-			const WCHAR* keyDirYen = wcsrchr( vecKeys[ i ], L'\\' );
-			const WCHAR* keyDirSlash = wcsrchr( vecKeys[ i ], L'/' );
-			const WCHAR* keyDir;
-			if( keyDirYen == nullptr ){
-				keyDir = keyDirSlash;
-			}else if( keyDirSlash == nullptr ){
-				keyDir = keyDirYen;
-			}else if( keyDirYen < keyDirSlash ){
-				keyDir = keyDirSlash;
-			}else{
-				keyDir = keyDirYen;
-			}
-			const auto nKeyDirLen = keyDir ? keyDir - vecKeys[ i ] + 1 : 0;
+		// 基底フォルダーは長さの上限を設けずに扱う(固定長バッファを使わなくなったため上限が不要)
+		const std::wstring_view svBaseFolder = lpBaseFolder ? std::wstring_view( lpBaseFolder ) : std::wstring_view();
+
+		// 作業用バッファはループの外に置き、確保済みの領域を使い回す
+		std::wstring strPath;
+		std::wstring strName;
+		std::wstring strFullPath;
+
+		for( const auto& strKey : vecKeys ){
+			strPath.assign( svBaseFolder );
+			strPath.append( L"\\" );
+			strPath.append( strKey );
+
+			// strKey ==> "subdir\*.h" 等の場合に後で(ファイル|フォルダー)名に "subdir\" を連結する
+			const auto keyDirPos = strKey.find_last_of( L"\\/" );
+			const auto nKeyDirLen = ( std::wstring::npos != keyDirPos ) ? keyDirPos + 1 : 0;
 
 			WIN32_FIND_DATA w32fd;
-			HANDLE handle = ::FindFirstFile( lpPath, &w32fd );
-			if( INVALID_HANDLE_VALUE != handle ){
-				// 検索ハンドルをスマートポインタに入れる(途中で抜けても確実に閉じる)
-				using FindFileHolder = cxx::ResourceHolder<&::FindClose>;
-				FindFileHolder handleHolder{ handle };
-				do{
-					if( !::PathMatchSpec(w32fd.cFileName, vecKeys[ i ] + nKeyDirLen) ){
-						continue;
-					}
-					if( option.m_bIgnoreHidden && (w32fd.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) ){
-						continue;
-					}
-					if( option.m_bIgnoreReadOnly && (w32fd.dwFileAttributes & FILE_ATTRIBUTE_READONLY) ){
-						continue;
-					}
-					if( option.m_bIgnoreSystem && (w32fd.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) ){
-						continue;
-					}
-					LPWSTR lpName = new WCHAR[ nKeyDirLen + wcslen( w32fd.cFileName ) + 1 ];
-					wcsncpy( lpName, vecKeys[ i ], nKeyDirLen );
-					wcscpy( lpName + nKeyDirLen, w32fd.cFileName );
-					LPWSTR lpFullPath = new WCHAR[ baseLen + wcslen(lpName) + 2 ];
-					wcscpy( lpFullPath, lpBaseFolder );
-					wcscpy( lpFullPath + baseLen, L"\\" );
-					wcscpy( lpFullPath + baseLen + 1, lpName );
-					if( IsValid( w32fd, lpName ) ){
-						if( pExceptItems && pExceptItems->IsExist( lpFullPath ) ){
-						}else{
-							m_vpItems.emplace_back( lpName, w32fd.nFileSizeLow );
-							found++; // 2011.11.19
-							if( pExceptItems && nKeyDirLen ){
-								// フォルダーを含んだパスなら検索済みとして除外指定に追加する
-								pExceptItems->m_vpItems.emplace_back( lpFullPath, w32fd.nFileSizeLow );
-							}else{
-								delete [] lpFullPath;
-							}
-							continue;
-						}
-					}
-					delete [] lpName;
-					delete [] lpFullPath;
-				}while( ::FindNextFile( handle, &w32fd ) );
+			HANDLE handle = ::FindFirstFile( strPath.c_str(), &w32fd );
+			if( INVALID_HANDLE_VALUE == handle ){
+				continue;
 			}
-			delete [] lpPath;
+			// 検索ハンドルをスマートポインタに入れる(途中で抜けても確実に閉じる)
+			using FindFileHolder = cxx::ResourceHolder<&::FindClose>;
+			FindFileHolder handleHolder{ handle };
+			do{
+				if( !::PathMatchSpec( w32fd.cFileName, strKey.c_str() + nKeyDirLen ) ){
+					continue;
+				}
+				if( option.m_bIgnoreHidden && (w32fd.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) ){
+					continue;
+				}
+				if( option.m_bIgnoreReadOnly && (w32fd.dwFileAttributes & FILE_ATTRIBUTE_READONLY) ){
+					continue;
+				}
+				if( option.m_bIgnoreSystem && (w32fd.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) ){
+					continue;
+				}
+				strName.assign( strKey, 0, nKeyDirLen );
+				strName.append( w32fd.cFileName );
+				strFullPath.assign( svBaseFolder );
+				strFullPath.append( L"\\" );
+				strFullPath.append( strName );
+				if( !IsValid( w32fd, strName.c_str() ) ){
+					continue;
+				}
+				if( pExceptItems && pExceptItems->IsExist( strFullPath ) ){
+					continue;
+				}
+				m_vpItems.emplace_back( strName, w32fd.nFileSizeLow );
+				found++; // 2011.11.19
+				if( pExceptItems && nKeyDirLen ){
+					// フォルダーを含んだパスなら検索済みとして除外指定に追加する
+					pExceptItems->m_vpItems.emplace_back( strFullPath, w32fd.nFileSizeLow );
+				}
+			}while( ::FindNextFile( handle, &w32fd ) );
 		}
 		return found;
 	}

--- a/sakura_core/grep/CGrepEnumKeys.h
+++ b/sakura_core/grep/CGrepEnumKeys.h
@@ -16,7 +16,9 @@
 #define SAKURA_CGREPENUMKEYS_FCE5732F_FA0C_4CB2_90D9_D1D440841D5C_H_
 #pragma once
 
+#include <algorithm>
 #include <list>
+#include <string>
 #include <vector>
 #include <windows.h>
 #include <string.h>
@@ -24,7 +26,7 @@
 #include "util/string_ex.h"
 #include "util/file.h"
 
-typedef std::vector< LPCWSTR > VGrepEnumKeys;
+using VGrepEnumKeys = std::vector< std::wstring >;
 
 class CGrepEnumKeys {
 
@@ -46,9 +48,7 @@ public:
 	Me& operator = (const Me&) = delete;
 	CGrepEnumKeys(Me&&) noexcept = delete;
 	Me& operator = (Me&&) noexcept = delete;
-	~CGrepEnumKeys(){
-		ClearItems();
-	}
+	~CGrepEnumKeys() = default;
 
 	// 除外ファイルの2つの解析済み配列から1つのリストを作る
 	auto GetExcludeFiles() const ->  std::vector<decltype(m_vecExceptFileKeys)::value_type> {
@@ -186,36 +186,23 @@ public:
 
 private:
 	void ClearItems( void ){
-		ClearEnumKeys(m_vecExceptFileKeys);
-		ClearEnumKeys(m_vecSearchFileKeys);
-		ClearEnumKeys(m_vecExceptFolderKeys);
-		ClearEnumKeys(m_vecSearchFolderKeys);
-		ClearEnumKeys(m_vecExceptAbsFileKeys);
-		ClearEnumKeys(m_vecExceptAbsFolderKeys);
+		m_vecExceptFileKeys.clear();
+		m_vecSearchFileKeys.clear();
+		m_vecExceptFolderKeys.clear();
+		m_vecSearchFolderKeys.clear();
+		m_vecExceptAbsFileKeys.clear();
+		m_vecExceptAbsFolderKeys.clear();
 		return;
-	}
-	void ClearEnumKeys( VGrepEnumKeys& keys ){
-		for( int i = 0; i < (int)keys.size(); i++ ){
-			delete [] keys[ i ];
-		}
-		keys.clear();
 	}
 
 	void push_back_unique( VGrepEnumKeys& keys, LPCWSTR addKey ){
 		if( ! IsExist( keys, addKey) ){
-			WCHAR* newKey = new WCHAR[ wcslen( addKey ) + 1 ];
-			wcscpy( newKey, addKey );
-			keys.push_back( newKey );
+			keys.emplace_back( addKey );
 		}
 	}
 
-	BOOL IsExist( VGrepEnumKeys& keys, LPCWSTR addKey ){
-		for( int i = 0; i < (int)keys.size(); i++ ){
-			if( wcscmp( keys[ i ], addKey ) == 0 ){
-				return TRUE;
-			}
-		}
-		return FALSE;
+	BOOL IsExist( const VGrepEnumKeys& keys, LPCWSTR addKey ) const {
+		return ( keys.cend() != std::find( keys.cbegin(), keys.cend(), addKey ) ) ? TRUE : FALSE;
 	}
 
 	/*


### PR DESCRIPTION
PR #2626 の続きです。Grep のファイル列挙まわりの `new[]` / `delete[]` を全廃します。振る舞いは変えていません。

## 変更内容

- `VGrepEnumKeys` : `std::vector<LPCWSTR>` → `std::vector<std::wstring>`
- `PairGrepEnumItem` : `std::pair<LPWSTR, DWORD>` → `std::pair<std::wstring, DWORD>`
- 手動解放（`ClearEnumKeys()` と `delete[]`）を全廃。`ClearItems()` は `.clear()` の並びになりました。
- `Enumerates()` の作業バッファをループの外に出し、`assign()` / `append()` で使い回すようにしました。

変更したのは `sakura_core/grep/` の 2 ヘッダのみです。

## 経緯

PR #2626 で頂いた「`Clear～` を呼ばないと漏れる構造自体に問題がある」「正攻法はたぶん `std::vector<std::wstring>` への移行」を、型の変更として実装したものです。

## 呼び出し側への影響

ありません。`GetFileName()` が `LPCWSTR` を返す点、`Enumerates()` と `IsValid()` のシグネチャは維持しています。
`GetExcludeFiles()` / `GetExcludeFolders()` の戻り値の要素型は変わりますが、受け側の `FormatPathList()` が `std::wstring_view` で受けるテンプレートのため無修正で通ります。

## 削除したもの

`// FIXME: パス長の上限は暫定値。` の 4095 文字の上限を削除しました。固定長バッファを使わなくなり、上限が不要になったためです。
あわせて、基底フォルダーが 4095 文字を超えたときに `new WCHAR[]` が不足サイズになり、区切りの `\` がコピー済みのパスの途中に書き込まれていた不具合も解消されます。

## 性能

`Enumerates()` はこれまで、ファイル 1 件ごとに `new WCHAR[]` を 2 回（ファイル名用とフルパス用）していました。パターンや属性で弾かれなかったファイルは、そのあと除外指定でスキップされる場合でも、いったん 2 回確保してすぐ `delete[]` する作りでした。

今回は作業用の `std::wstring` を 3 本ループの外に置き、毎回 `assign()` / `append()` で組み立て直す形にしました。数回で必要な容量に達したあとは確保が起きなくなるため、この 2 回分が消えます。実際に確保が起きるのは、採用したファイルを `m_vpItems` に格納するときだけです。

例として、1 フォルダーに 500 ファイルあり、`*.cpp` に 120 件マッチし、除外指定で 20 件落として 100 件を採用する場合:

- 変更前: 241 回（検索パス 1 回 + 120 件 × 2 回）
- 変更後: 100 回（採用した 100 件の格納のみ）

サブフォルダーの列挙のようにマッチせずに捨てられるファイルが多いほど、差は大きくなります。

## 意図的にやっていないこと

- I/F の `LPCWSTR` → `std::wstring_view` / `const std::wstring&` への移行
  マージ時にご指摘頂いた件ですが、本 PR の範囲を超えるため別途とし、Issue #2596 に方針案を書きます。
- `IsExist()` の索引化（効果の実測が先だと考えているため）

