### PR TITLE
DoGrep() 引数の構造体化対応

### DIFF
--- a/sakura_core/_main/CNormalProcess.cpp
+++ b/sakura_core/_main/CNormalProcess.cpp
@@ -14,7 +14,7 @@
 	Copyright (C) 2007, ryoji
 	Copyright (C) 2008, Uchi
 	Copyright (C) 2009, syat, ryoji
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -254,27 +254,7 @@ bool CNormalProcess::InitializeProcess()
 
 			initEvent = nullptr;
 
-			this->m_pcEditApp->m_pcGrepAgent->DoGrep(
-				&pEditWnd->GetActiveView(),
-				gi.bGrepReplace,
-				&gi.cmGrepKey,
-				&gi.cmGrepRep,
-				&gi.cmGrepFile,
-				&gi.cmGrepFolder,
-				gi.bGrepCurFolder,
-				gi.bGrepSubFolder,
-				gi.bGrepStdout,
-				gi.bGrepHeader,
-				gi.sGrepSearchOption,
-				gi.nGrepCharSet,	//	2002/09/21 Moca
-				gi.nGrepOutputLineType,
-				gi.nGrepOutputStyle,
-				gi.bGrepOutputFileOnly,
-				gi.bGrepOutputBaseFolder,
-				gi.bGrepSeparateFolder,
-				gi.bGrepPaste,
-				gi.bGrepBackup
-			);
+			this->m_pcEditApp->m_pcGrepAgent->DoGrep( &pEditWnd->GetActiveView(), gi );
 			pEditWnd->m_cDlgFuncList.Refresh();	// アウトラインを再解析する
 		}
 		else{

--- a/sakura_core/agent/CGrepAgent.cpp
+++ b/sakura_core/agent/CGrepAgent.cpp
@@ -1,11 +1,12 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
 #include "StdAfx.h"
 #include "agent/CGrepAgent.h"
+#include "basis/GrepInfo.h"
 #include "grep/CGrepEnumKeys.h"
 #include "grep/CGrepEnumFilterFiles.h"
 #include "grep/CGrepEnumFilterFolders.h"
@@ -317,36 +318,49 @@ int GetHwndTitle(HWND& hWndTarget, CNativeW* pmemTitle, WCHAR* pszWindowName, WC
 }
 
 
+/*!	GrepInfo から出力オプションを取り出す
+
+	@param[in] gi Grep実行の入力一式
+	@return 出力・置換の挙動を決めるオプション
+	@note Grep置換では「一致しなかった行を出力」が成立しないため、行単位出力に落とす。
+*/
+SGrepOption SGrepOption::FromGrepInfo( const GrepInfo& gi )
+{
+	SGrepOption sGrepOption;
+	sGrepOption.bGrepSubFolder = gi.bGrepSubFolder;
+	sGrepOption.bGrepStdout = gi.bGrepStdout;
+	sGrepOption.bGrepHeader = gi.bGrepHeader;
+	sGrepOption.nGrepCharSet = gi.nGrepCharSet;
+	sGrepOption.nGrepOutputLineType = gi.nGrepOutputLineType;
+	sGrepOption.nGrepOutputStyle = gi.nGrepOutputStyle;
+	sGrepOption.bGrepOutputFileOnly = gi.bGrepOutputFileOnly;
+	sGrepOption.bGrepOutputBaseFolder = gi.bGrepOutputBaseFolder;
+	sGrepOption.bGrepSeparateFolder = gi.bGrepSeparateFolder;
+	sGrepOption.bGrepReplace = gi.bGrepReplace;
+	sGrepOption.bGrepPaste = gi.bGrepPaste;
+	sGrepOption.bGrepBackup = gi.bGrepBackup;
+	if( sGrepOption.bGrepReplace ){
+		// Grep否定行はGrep置換では無効
+		if( sGrepOption.nGrepOutputLineType == 2 ){
+			sGrepOption.nGrepOutputLineType = 1; // 行単位
+		}
+	}
+	return sGrepOption;
+}
+
 /*! Grep実行
 
-  @param[in] pcmGrepKey 検索パターン
-  @param[in] pcmGrepFile 検索対象ファイルパターン(!で除外指定))
-  @param[in] pcmGrepFolder 検索対象フォルダー
+  @param[in] pcViewDst Grep結果の出力先
+  @param[in] gi Grep実行の入力一式。検索パターン・検索対象ファイルパターン(!で除外指定)・
+                検索対象フォルダー・検索オプション・出力オプションを含む
 
   @date 2008.12.07 nasukoji	ファイル名パターンのバッファオーバラン対策
   @date 2008.12.13 genta 検索パターンのバッファオーバラン対策
   @date 2012.10.13 novice 検索オプションをクラスごと代入
 */
 DWORD CGrepAgent::DoGrep(
-	CEditView*				pcViewDst,
-	bool					bGrepReplace,
-	const CNativeW*			pcmGrepKey,
-	const CNativeW*			pcmGrepReplace,
-	const CNativeW*			pcmGrepFile,
-	const CNativeW*			pcmGrepFolder,
-	bool					bGrepCurFolder,
-	BOOL					bGrepSubFolder,
-	bool					bGrepStdout,
-	bool					bGrepHeader,
-	const SSearchOption&	sSearchOption,
-	ECodeType				nGrepCharSet,	// 2002/09/21 Moca 文字コードセット選択
-	int						nGrepOutputLineType,
-	int						nGrepOutputStyle,
-	bool					bGrepOutputFileOnly,
-	bool					bGrepOutputBaseFolder,
-	bool					bGrepSeparateFolder,
-	bool					bGrepPaste,
-	bool					bGrepBackup
+	CEditView*				pcViewDst,	//!< [in] Grep結果の出力先
+	const GrepInfo&			gi			//!< [in] Grep実行の入力一式(検索キー・対象・オプション)
 )
 {
 	MY_RUNNINGTIMER( cRunningTimer, L"CEditView::DoGrep" );
@@ -391,14 +405,14 @@ DWORD CGrepAgent::DoGrep(
 	pcViewDst->GetDocument()->m_cDocEditor.m_pcOpeBlk->AddRef();
 
 	pcViewDst->m_bCurSrchKeyMark = true;								/* 検索文字列のマーク */
-	pcViewDst->m_strCurSearchKey = pcmGrepKey->GetStringPtr();				/* 検索文字列 */
-	pcViewDst->m_sCurSearchOption = sSearchOption;						// 検索オプション
+	pcViewDst->m_strCurSearchKey = gi.cmGrepKey.GetStringPtr();				/* 検索文字列 */
+	pcViewDst->m_sCurSearchOption = gi.sGrepSearchOption;						// 検索オプション
 	pcViewDst->m_nCurSearchKeySequence = GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence;
 
 	// 置換後文字列の準備
 	CNativeW cmemReplace;
-	if( bGrepReplace ){
-		if( bGrepPaste ){
+	if( gi.bGrepReplace ){
+		if( gi.bGrepPaste ){
 			// 矩形・ラインモード貼り付けは未サポート
 			bool bColmnSelect;
 			bool bLineSelect = false;
@@ -422,7 +436,7 @@ DWORD CGrepAgent::DoGrep(
 				delete [] pszConvertedText;
 			}
 		}else{
-			cmemReplace = *pcmGrepReplace;
+			cmemReplace = gi.cmGrepRep;
 		}
 	}
 	/* 正規表現 */
@@ -444,11 +458,11 @@ DWORD CGrepAgent::DoGrep(
 	}
 
 	//2014.06.13 別ウィンドウで検索したとき用にGrepダイアログの検索キーを設定
-	GetEditWnd().m_cDlgGrep.m_strText = pcmGrepKey->GetStringPtr();
+	GetEditWnd().m_cDlgGrep.m_strText = gi.cmGrepKey.GetStringPtr();
 	GetEditWnd().m_cDlgGrep.m_bSetText = true;
-	GetEditWnd().m_cDlgGrepReplace.m_strText = pcmGrepKey->GetStringPtr();
-	if( bGrepReplace ){
-		GetEditWnd().m_cDlgGrepReplace.m_strText2 = pcmGrepReplace->GetStringPtr();
+	GetEditWnd().m_cDlgGrepReplace.m_strText = gi.cmGrepKey.GetStringPtr();
+	if( gi.bGrepReplace ){
+		GetEditWnd().m_cDlgGrepReplace.m_strText2 = gi.cmGrepRep.GetStringPtr();
 	}
 	GetEditWnd().m_cDlgGrepReplace.m_bSetText = true;
 	hwndCancel = cDlgCancel.DoModeless( G_AppInstance(), pcViewDst->m_hwndParent, IDD_GREPRUNNING );
@@ -460,7 +474,7 @@ DWORD CGrepAgent::DoGrep(
 	//	2008.12.13 genta パターンが長すぎる場合は登録しない
 	//	(正規表現が途中で途切れると困るので)
 	//	2011.12.10 Moca 表示の際に...に切り捨てられるので登録するように
-	wcsncpy_s( CAppMode::getInstance()->m_szGrepKey, int(std::size(CAppMode::getInstance()->m_szGrepKey)), pcmGrepKey->GetStringPtr(), _TRUNCATE );
+	wcsncpy_s( CAppMode::getInstance()->m_szGrepKey, int(std::size(CAppMode::getInstance()->m_szGrepKey)), gi.cmGrepKey.GetStringPtr(), _TRUNCATE );
 	this->m_bGrepMode = true;
 
 	//	2007.07.22 genta
@@ -469,14 +483,14 @@ DWORD CGrepAgent::DoGrep(
 	{
 		/* 検索パターンのコンパイル */
 		bool bError;
-		if( bGrepReplace && !bGrepPaste ){
+		if( gi.bGrepReplace && !gi.bGrepPaste ){
 			// Grep置換
 			// 2015.03.03 Grep置換がoptGlobalじゃないバグを修正
-			bError = !pattern.SetPattern(pcViewDst->GetHwnd(), pcmGrepKey->GetStringPtr(), pcmGrepKey->GetStringLength(),
-				cmemReplace.GetStringPtr(), sSearchOption, &cRegexp, true);
+			bError = !pattern.SetPattern(pcViewDst->GetHwnd(), gi.cmGrepKey.GetStringPtr(), gi.cmGrepKey.GetStringLength(),
+				cmemReplace.GetStringPtr(), gi.sGrepSearchOption, &cRegexp, true);
 		}else{
-			bError = !pattern.SetPattern(pcViewDst->GetHwnd(), pcmGrepKey->GetStringPtr(), pcmGrepKey->GetStringLength(),
-				sSearchOption, &cRegexp);
+			bError = !pattern.SetPattern(pcViewDst->GetHwnd(), gi.cmGrepKey.GetStringPtr(), gi.cmGrepKey.GetStringLength(),
+				gi.sGrepSearchOption, &cRegexp);
 		}
 		if( bError ){
 			this->m_bGrepRunning = false;
@@ -487,24 +501,7 @@ DWORD CGrepAgent::DoGrep(
 	}
 	
 	// Grepオプションまとめ
-	sGrepOption.bGrepSubFolder = FALSE != bGrepSubFolder;
-	sGrepOption.bGrepStdout = bGrepStdout;
-	sGrepOption.bGrepHeader = bGrepHeader;
-	sGrepOption.nGrepCharSet = nGrepCharSet;
-	sGrepOption.nGrepOutputLineType = nGrepOutputLineType;
-	sGrepOption.nGrepOutputStyle = nGrepOutputStyle;
-	sGrepOption.bGrepOutputFileOnly = bGrepOutputFileOnly;
-	sGrepOption.bGrepOutputBaseFolder = bGrepOutputBaseFolder;
-	sGrepOption.bGrepSeparateFolder = bGrepSeparateFolder;
-	sGrepOption.bGrepReplace = bGrepReplace;
-	sGrepOption.bGrepPaste = bGrepPaste;
-	sGrepOption.bGrepBackup = bGrepBackup;
-	if( sGrepOption.bGrepReplace ){
-		// Grep否定行はGrep置換では無効
-		if( sGrepOption.nGrepOutputLineType == 2 ){
-			sGrepOption.nGrepOutputLineType = 1; // 行単位
-		}
-	}
+	sGrepOption = SGrepOption::FromGrepInfo( gi );
 
 //2002.02.08 Grepアイコンも大きいアイコンと小さいアイコンを別々にする。
 	HICON	hIconBig, hIconSmall;
@@ -520,7 +517,7 @@ DWORD CGrepAgent::DoGrep(
 
 	CGrepEnumKeys cGrepEnumKeys;
 	{
-		int nErrorNo = cGrepEnumKeys.SetFileKeys( pcmGrepFile->GetStringPtr() );
+		int nErrorNo = cGrepEnumKeys.SetFileKeys( gi.cmGrepFile.GetStringPtr() );
 		if( nErrorNo != 0 ){
 			this->m_bGrepRunning = false;
 			pcViewDst->m_bDoing_UndoRedo = false;
@@ -542,24 +539,24 @@ DWORD CGrepAgent::DoGrep(
 	const STypeConfig& type = pcViewDst->m_pcEditDoc->m_cDocType.GetDocumentAttribute();
 
 	std::vector<std::wstring> vPaths;
-	CreateFolders( pcmGrepFolder->GetStringPtr(), vPaths );
+	CreateFolders( gi.cmGrepFolder.GetStringPtr(), vPaths );
 
-	nWork = pcmGrepKey->GetStringLength(); // 2003.06.10 Moca あらかじめ長さを計算しておく
+	nWork = gi.cmGrepKey.GetStringLength(); // 2003.06.10 Moca あらかじめ長さを計算しておく
 
 	/* 最後にテキストを追加 */
 	CNativeW	cmemWork;
 	cmemMessage.AppendString( LS( STR_GREP_SEARCH_CONDITION ) );	//L"\r\n□検索条件  "
 	if( 0 < nWork ){
 		cmemMessage.AppendString( L"\"" );
-		cmemMessage += EscapeStringLiteral(type, *pcmGrepKey);
+		cmemMessage += EscapeStringLiteral(type, gi.cmGrepKey);
 		cmemMessage.AppendString( L"\"\r\n" );
 	}else{
 		cmemMessage.AppendString( LS( STR_GREP_SEARCH_FILE ) );	//L"「ファイル検索」\r\n"
 	}
 
-	if( bGrepReplace ){
+	if( gi.bGrepReplace ){
 		cmemMessage.AppendString( LS(STR_GREP_REPLACE_TO) );
-		if( bGrepPaste ){
+		if( gi.bGrepPaste ){
 			cmemMessage.AppendString( LS(STR_GREP_PASTE_CLIPBOAD) );
 		}else{
 			cmemMessage.AppendString( L"\"" );
@@ -572,7 +569,7 @@ DWORD CGrepAgent::DoGrep(
 	WCHAR szWindowName[_MAX_PATH];
 	WCHAR szWindowPath[_MAX_PATH];
 	{
-		int nHwndRet = GetHwndTitle(hWndTarget, &cmemWork, szWindowName, szWindowPath, pcmGrepFile->GetStringPtr());
+		int nHwndRet = GetHwndTitle(hWndTarget, &cmemWork, szWindowName, szWindowPath, gi.cmGrepFile.GetStringPtr());
 		if( -1 == nHwndRet ){
 			cmemMessage.AppendString(L"HWND handle error.\n");
 			if( sGrepOption.bGrepHeader ){
@@ -629,19 +626,19 @@ DWORD CGrepAgent::DoGrep(
 	cmemMessage.AppendString( pszWork );
 
 	if( 0 < nWork ){ // 2003.06.10 Moca ファイル検索の場合は表示しない // 2004.09.26 条件誤り修正
-		if( sSearchOption.bWordOnly ){
+		if( gi.sGrepSearchOption.bWordOnly ){
 		/* 単語単位で探す */
 			cmemMessage.AppendString( LS( STR_GREP_COMPLETE_WORD ) );	//L"    (単語単位で探す)\r\n"
 		}
 
-		if( sSearchOption.bLoHiCase ){
+		if( gi.sGrepSearchOption.bLoHiCase ){
 			pszWork = LS( STR_GREP_CASE_SENSITIVE );	//L"    (英大文字小文字を区別する)\r\n"
 		}else{
 			pszWork = LS( STR_GREP_IGNORE_CASE );	//L"    (英大文字小文字を区別しない)\r\n"
 		}
 		cmemMessage.AppendString( pszWork );
 
-		if( sSearchOption.bRegularExp ){
+		if( gi.sGrepSearchOption.bRegularExp ){
 			//	2007.07.22 genta : 正規表現ライブラリのバージョンも出力する
 			cmemMessage.AppendString( LS( STR_GREP_REGEX_DLL ) );	//L"    (正規表現:"
 			cmemMessage.AppendString( cRegexp.GetVersionW() );
@@ -667,7 +664,7 @@ DWORD CGrepAgent::DoGrep(
 			// 否該当行
 			pszWork = LS( STR_GREP_SHOW_MATCH_NOHITLINE );	//L"    (一致しなかった行を出力)\r\n"
 		}else{
-			if( bGrepReplace && sSearchOption.bRegularExp && !bGrepPaste ){
+			if( gi.bGrepReplace && gi.sGrepSearchOption.bRegularExp && !gi.bGrepPaste ){
 				pszWork = LS(STR_GREP_SHOW_FIRST_LINE);
 			}else{
 				pszWork = LS( STR_GREP_SHOW_MATCH_AREA );
@@ -728,9 +725,9 @@ DWORD CGrepAgent::DoGrep(
 				pcViewDst,
 				&cDlgCancel,
 				hwnd,
-				pcmGrepKey->GetStringPtr(),
+				gi.cmGrepKey.GetStringPtr(),
 				szWindowName,
-				sSearchOption,
+				gi.sGrepSearchOption,
 				sGrepOption,
 				pattern,
 				&cRegexp,
@@ -765,14 +762,14 @@ DWORD CGrepAgent::DoGrep(
 			int nTreeRet = DoGrepTree(
 				pcViewDst,
 				&cDlgCancel,
-				pcmGrepKey->GetStringPtr(),
+				gi.cmGrepKey.GetStringPtr(),
 				cmemReplace,
 				cGrepEnumKeys,
 				cGrepExceptAbsFiles,
 				cGrepExceptAbsFolders,
 				sPath.c_str(),
 				sPath.c_str(),
-				sSearchOption,
+				gi.sGrepSearchOption,
 				sGrepOption,
 				pattern,
 				&cRegexp,
@@ -801,7 +798,7 @@ DWORD CGrepAgent::DoGrep(
 	}
 	if( sGrepOption.bGrepHeader ){
 		WCHAR szBuffer[128];
-		if( bGrepReplace ){
+		if( gi.bGrepReplace ){
 			auto_sprintf( szBuffer, LS(STR_GREP_REPLACE_COUNT), nHitCount );
 		}else{
 			auto_sprintf( szBuffer, LS( STR_GREP_MATCH_COUNT ), nHitCount );
@@ -839,7 +836,7 @@ DWORD CGrepAgent::DoGrep(
 	if( !pCEditWnd->UpdateTextWrap() )	// 折り返し方法関連の更新	// 2008.06.10 ryoji
 		pCEditWnd->RedrawAllViews( nullptr );
 
-	if( !bGrepCurFolder ){
+	if( !gi.bGrepCurFolder ){
 		// 現行フォルダーを検索したフォルダーに変更
 		if( 0 < vPaths.size() ){
 			::SetCurrentDirectory( vPaths[0].c_str() );

--- a/sakura_core/agent/CGrepAgent.h
+++ b/sakura_core/agent/CGrepAgent.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -16,6 +16,7 @@ class CSearchStringPattern;
 class CGrepEnumKeys;
 class CGrepEnumFiles;
 class CGrepEnumFolders;
+struct GrepInfo;
 
 struct SGrepOption{
 	bool		bGrepReplace;			//!< Grep置換
@@ -45,6 +46,9 @@ struct SGrepOption{
 		,bGrepPaste(false)
 		,bGrepBackup(false)
 	{}
+
+	//! GrepInfo から出力オプションを取り出す(Grep置換では否ヒット行の出力が無効になる)
+	static SGrepOption FromGrepInfo( const GrepInfo& gi );
 };
 
 //	Jun. 26, 2001 genta	正規表現ライブラリの差し替え
@@ -63,25 +67,8 @@ public:
 
 	// Grep実行
 	DWORD DoGrep(
-		CEditView*				pcViewDst,
-		bool					bGrepReplace,
-		const CNativeW*			pcmGrepKey,
-		const CNativeW*			pcmGrepReplace,
-		const CNativeW*			pcmGrepFile,
-		const CNativeW*			pcmGrepFolder,
-		bool					bGrepCurFolder,
-		BOOL					bGrepSubFolder,
-		bool					bGrepStdout,
-		bool					bGrepHeader,
-		const SSearchOption&	sSearchOption,
-		ECodeType				nGrepCharSet,	// 2002/09/21 Moca 文字コードセット選択
-		int						nGrepOutputLineType,
-		int						nGrepOutputStyle,
-		bool					bGrepOutputFileOnly,	//!< [in] ファイル毎最初のみ出力
-		bool					bGrepOutputBaseFolder,	//!< [in] ベースフォルダー表示
-		bool					bGrepSeparateFolder,	//!< [in] フォルダー毎に表示
-		bool					bGrepPaste,
-		bool					bGrepBackup
+		CEditView*				pcViewDst,	//!< [in] Grep結果の出力先
+		const GrepInfo&			gi			//!< [in] Grep実行の入力一式(検索キー・対象・オプション)
 	);
 
 private:

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -7,7 +7,7 @@
 	Copyright (C) 2003, MIK
 	Copyright (C) 2005, genta
 	Copyright (C) 2006, ryoji
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holders to use this code for other purpose.
@@ -19,6 +19,7 @@
 #include "_main/CControlTray.h"
 #include "CEditApp.h"
 #include "agent/CGrepAgent.h"
+#include "basis/GrepInfo.h"
 #include "plugin/CPlugin.h"
 #include "plugin/CJackManager.h"
 #include "CSelectLang.h"
@@ -57,13 +58,6 @@ void CViewCommander::Command_GREP_DIALOG( void )
 */
 void CViewCommander::Command_GREP( void )
 {
-	CNativeW		cmWork1;
-	CNativeW		cmWork2;
-	CNativeW		cmWork3;
-	CNativeW		cmWork4;
-	cmWork1.SetString( GetEditWindow()->m_cDlgGrep.m_strText.c_str() );
-	cmWork2 = GetEditWindow()->m_cDlgGrep.GetPackedGFileString();
-	cmWork3.SetString( GetEditWindow()->m_cDlgGrep.m_szFolder );
 
 	/*	今のEditViewにGrep結果を表示する。
 		Grepモードのとき、または未編集で無題かつアウトプットでない場合。
@@ -88,27 +82,8 @@ void CViewCommander::Command_GREP( void )
 			GetDocument()->OnChangeType();
 		}
 		
-		CEditApp::getInstance()->m_pcGrepAgent->DoGrep(
-			m_pCommanderView,
-			false,
-			&cmWork1,
-			&cmWork4,
-			&cmWork2,
-			&cmWork3,
-			false,
-			GetEditWindow()->m_cDlgGrep.m_bSubFolder,
-			false,
-			true, // Header
-			GetEditWindow()->m_cDlgGrep.m_sSearchOption,
-			GetEditWindow()->m_cDlgGrep.m_nGrepCharSet,
-			GetEditWindow()->m_cDlgGrep.m_nGrepOutputLineType,
-			GetEditWindow()->m_cDlgGrep.m_nGrepOutputStyle,
-			GetEditWindow()->m_cDlgGrep.m_bGrepOutputFileOnly,
-			GetEditWindow()->m_cDlgGrep.m_bGrepOutputBaseFolder,
-			GetEditWindow()->m_cDlgGrep.m_bGrepSeparateFolder,
-			false,
-			false
-		);
+		const GrepInfo gi = GetEditWindow()->m_cDlgGrep.MakeGrepInfo();
+		CEditApp::getInstance()->m_pcGrepAgent->DoGrep( m_pCommanderView, gi );
 
 		//プラグイン：DocumentOpenイベント実行
 		CJackManager::getInstance()->InvokePlugins( PP_DOCUMENT_OPEN, &GetEditWindow()->GetActiveView() );
@@ -182,27 +157,8 @@ void CViewCommander::Command_GREP_REPLACE( void )
 		  !CAppMode::getInstance()->IsDebugMode()
 		)
 	){
-		CEditApp::getInstance()->m_pcGrepAgent->DoGrep(
-			m_pCommanderView,
-			true,
-			&cmWork1,
-			&cmWork4,
-			&cmWork2,
-			&cmWork3,
-			false,
-			cDlgGrepRep.m_bSubFolder,
-			false, // Stdout
-			true, // Header
-			cDlgGrepRep.m_sSearchOption,
-			cDlgGrepRep.m_nGrepCharSet,
-			cDlgGrepRep.m_nGrepOutputLineType,
-			cDlgGrepRep.m_nGrepOutputStyle,
-			cDlgGrepRep.m_bGrepOutputFileOnly,
-			cDlgGrepRep.m_bGrepOutputBaseFolder,
-			cDlgGrepRep.m_bGrepSeparateFolder,
-			cDlgGrepRep.m_bPaste,
-			cDlgGrepRep.m_bBackup
-		);
+		const GrepInfo gi = cDlgGrepRep.MakeGrepInfo();
+		CEditApp::getInstance()->m_pcGrepAgent->DoGrep( m_pCommanderView, gi );
 	}
 	else{
 		// 編集ウィンドウの上限チェック

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -11,13 +11,14 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2010, ryoji
 	Copyright (C) 2012, Uchi
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
 #include "StdAfx.h"
 #include "dlg/CDlgGrep.h"
+#include "basis/GrepInfo.h"
 #include "agent/CGrepAgent.h"
 #include "grep/CGrepEnumKeys.h"
 #include "func/Funccode.h"		// Stonee, 2001/03/12
@@ -180,6 +181,32 @@ CNativeW CDlgGrep::GetPackedGFileString() const
 	AppendExcludeFilePatterns( cmGFileString, cmExcludeFiles );
 
 	return cmGFileString;
+}
+
+/*!
+ * ダイアログの設定内容から Grep 実行の入力一式を作る
+ *
+ * @return Grep を1回実行するのに必要な入力の全体
+ * @note 置換に固有の項目は CDlgGrepReplace::MakeGrepInfo() で足す。
+ */
+GrepInfo CDlgGrep::MakeGrepInfo() const
+{
+	GrepInfo gi;
+	gi.cmGrepKey.SetString( m_strText.c_str() );
+	gi.cmGrepFile = GetPackedGFileString();
+	gi.cmGrepFolder.SetString( m_szFolder );
+	gi.sGrepSearchOption = m_sSearchOption;
+	gi.bGrepCurFolder = false;
+	gi.bGrepStdout = false;
+	gi.bGrepHeader = true;
+	gi.bGrepSubFolder = ( FALSE != m_bSubFolder );
+	gi.nGrepCharSet = m_nGrepCharSet;
+	gi.nGrepOutputStyle = m_nGrepOutputStyle;
+	gi.nGrepOutputLineType = m_nGrepOutputLineType;
+	gi.bGrepOutputFileOnly = m_bGrepOutputFileOnly;
+	gi.bGrepOutputBaseFolder = m_bGrepOutputBaseFolder;
+	gi.bGrepSeparateFolder = m_bGrepSeparateFolder;
+	return gi;
 }
 
 /*!

--- a/sakura_core/dlg/CDlgGrep.h
+++ b/sakura_core/dlg/CDlgGrep.h
@@ -8,7 +8,7 @@
 /*
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, Moca
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -25,6 +25,8 @@
 #include "recent/CRecentExcludeFile.h"
 #include "recent/CRecentExcludeFolder.h"
 
+struct GrepInfo;
+
 #define DEFAULT_EXCLUDE_FILE_PATTERN    L"*.msi;*.exe;*.obj;*.pdb;*.ilk;*.res;*.pch;*.iobj;*.ipdb"
 #define DEFAULT_EXCLUDE_FOLDER_PATTERN  L".git;.svn;.vs"
 
@@ -40,6 +42,8 @@ public:
 	||  Attributes & Operations
 	*/
 	CNativeW GetPackedGFileString() const;	//!< 除外ファイル、除外フォルダーの設定を "-GFILE=" の設定に pack する
+	//! ダイアログの設定内容から Grep 実行の入力一式を作る
+	virtual GrepInfo MakeGrepInfo() const;
 	BOOL OnCbnDropDown( HWND hwndCtl, int wID ) override;
 	int DoModal( HINSTANCE, HWND, const WCHAR* );	/* モーダルダイアログの表示 */
 //	HWND DoModeless( HINSTANCE, HWND, const char* );	/* モードレスダイアログの表示 */

--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -11,13 +11,14 @@
 	Copyright (C) 2006, ryoji
 	Copyright (C) 2010, ryoji
 	Copyright (C) 2014, Moca
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
 */
 #include "StdAfx.h"
 #include "dlg/CDlgGrepReplace.h"
+#include "basis/GrepInfo.h"
 #include "view/CEditView.h"
 #include "func/Funccode.h"		// Stonee, 2001/03/12
 #include "util/module.h"
@@ -71,6 +72,21 @@ CDlgGrepReplace::CDlgGrepReplace()
 		m_strText2 = m_pShareData->m_sSearchKeywords.m_aReplaceKeys[0];
 	}
 	return;
+}
+
+/*!
+ * 置換に固有の項目を足した Grep 実行の入力一式を作る
+ *
+ * @return Grep置換を1回実行するのに必要な入力の全体
+ */
+GrepInfo CDlgGrepReplace::MakeGrepInfo() const
+{
+	GrepInfo gi = CDlgGrep::MakeGrepInfo();
+	gi.cmGrepRep.SetString( m_strText2.c_str() );
+	gi.bGrepReplace = true;
+	gi.bGrepPaste = m_bPaste;
+	gi.bGrepBackup = m_bBackup;
+	return gi;
 }
 
 /* モーダルダイアログの表示 */

--- a/sakura_core/dlg/CDlgGrepReplace.h
+++ b/sakura_core/dlg/CDlgGrepReplace.h
@@ -8,7 +8,7 @@
 	Copyright (C) 1998-2001, Norio Nakatani
 	Copyright (C) 2002, Moca
 	Copyright (C) 2014, Moca
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	This source code is designed for sakura editor.
 	Please contact the copyright holder to use this code for other purpose.
@@ -35,9 +35,11 @@ public:
 	||  Attributes & Operations
 	*/
 	int DoModal( HINSTANCE hInstance, HWND hwndParent, const WCHAR* pszCurrentFilePath, LPARAM lParam );	/* モーダルダイアログの表示 */
+	//! 置換に固有の項目を足した Grep 実行の入力一式を作る
+	GrepInfo MakeGrepInfo() const override;
 
-	bool		m_bPaste;
-	bool		m_bBackup;
+	bool		m_bPaste = false;
+	bool		m_bBackup = false;
 
 	std::wstring	m_strText2;				//!< 置換後
 	int				m_nReplaceKeySequence;	//!< 置換後シーケンス

--- a/src/test/cpp/tests1/test-grepinfo.cpp
+++ b/src/test/cpp/tests1/test-grepinfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -9,6 +9,9 @@
 #include <Windows.h>
 
 #include "basis/GrepInfo.h"
+#include "agent/CGrepAgent.h"
+#include "dlg/CDlgGrepReplace.h"
+#include "env/ShareDataTestSuite.hpp"
 
 /*!
  * 同型との等価比較
@@ -178,4 +181,169 @@ TEST(GrepInfo, operatorEqualAndNotEqual)
 	v2.bGrepBackup = true;
 	EXPECT_FALSE(v1 == v2);
 	EXPECT_TRUE(v1 != v2);
+}
+
+/*!
+ * @brief SGrepOption::FromGrepInfo() のテスト
+ *  GrepInfo の各メンバが SGrepOption の対応するメンバへ移されること
+ */
+TEST(SGrepOption, FromGrepInfo_CopiesMembers)
+{
+	GrepInfo gi;
+	gi.bGrepSubFolder = true;
+	gi.bGrepStdout = true;
+	gi.bGrepHeader = false;
+	gi.nGrepCharSet = CODE_EUC;
+	gi.nGrepOutputLineType = 1;
+	gi.nGrepOutputStyle = 3;
+	gi.bGrepOutputFileOnly = true;
+	gi.bGrepOutputBaseFolder = true;
+	gi.bGrepSeparateFolder = true;
+	gi.bGrepReplace = false;
+	gi.bGrepPaste = true;
+	gi.bGrepBackup = true;
+
+	const SGrepOption option = SGrepOption::FromGrepInfo(gi);
+
+	EXPECT_TRUE(option.bGrepSubFolder);
+	EXPECT_TRUE(option.bGrepStdout);
+	EXPECT_FALSE(option.bGrepHeader);
+	EXPECT_EQ(CODE_EUC, option.nGrepCharSet);
+	EXPECT_EQ(1, option.nGrepOutputLineType);
+	EXPECT_EQ(3, option.nGrepOutputStyle);
+	EXPECT_TRUE(option.bGrepOutputFileOnly);
+	EXPECT_TRUE(option.bGrepOutputBaseFolder);
+	EXPECT_TRUE(option.bGrepSeparateFolder);
+	EXPECT_FALSE(option.bGrepReplace);
+	EXPECT_TRUE(option.bGrepPaste);
+	EXPECT_TRUE(option.bGrepBackup);
+}
+
+/*!
+ * @brief SGrepOption::FromGrepInfo() のテスト
+ *  Grep置換では「一致しなかった行を出力」が行単位出力に落ちること
+ */
+TEST(SGrepOption, FromGrepInfo_ReplaceDisablesNoHitLine)
+{
+	GrepInfo gi;
+	gi.bGrepReplace = true;
+	gi.nGrepOutputLineType = 2;	// 否ヒット行を出力
+
+	const SGrepOption option = SGrepOption::FromGrepInfo(gi);
+
+	EXPECT_TRUE(option.bGrepReplace);
+	EXPECT_EQ(1, option.nGrepOutputLineType);	// 行単位に落ちる
+}
+
+/*!
+ * @brief SGrepOption::FromGrepInfo() のテスト
+ *  Grep置換でなければ「一致しなかった行を出力」がそのまま残ること
+ */
+TEST(SGrepOption, FromGrepInfo_KeepsNoHitLineWhenNotReplace)
+{
+	GrepInfo gi;
+	gi.bGrepReplace = false;
+	gi.nGrepOutputLineType = 2;
+
+	const SGrepOption option = SGrepOption::FromGrepInfo(gi);
+
+	EXPECT_FALSE(option.bGrepReplace);
+	EXPECT_EQ(2, option.nGrepOutputLineType);
+}
+
+/*!
+ * CDlgGrep を構築するテストのためのフィクスチャクラス
+ *
+ * CDlgGrep のコンストラクタはウィンドウを作らずメンバを初期化するだけだが、
+ * 基底の CDialog が共有データの取得を検証するため、先に用意しておく必要がある。
+ */
+class CDlgGrepTest : public ::testing::Test {
+protected:
+	static void SetUpTestSuite() { env::ShareDataTestSuite::SetUpShareData(); }
+	static void TearDownTestSuite() { env::ShareDataTestSuite::TearDownShareData(); }
+};
+
+/*!
+ * @brief CDlgGrep::MakeGrepInfo() のテスト
+ *  ダイアログの設定内容が GrepInfo の対応するメンバへ移されること
+ */
+TEST_F(CDlgGrepTest, MakeGrepInfo_CopiesDialogSettings)
+{
+	CDlgGrep dlg;
+	dlg.m_strText = L"ぐれっぷ";
+	dlg.m_szFile = L"*.cpp";
+	dlg.m_szFolder = L"C:\\work\\sakura";
+	dlg.m_bSubFolder = TRUE;
+	dlg.m_sSearchOption.bRegularExp = true;
+	dlg.m_nGrepCharSet = CODE_EUC;
+	dlg.m_nGrepOutputStyle = 2;
+	dlg.m_nGrepOutputLineType = 2;
+	dlg.m_bGrepOutputFileOnly = true;
+	dlg.m_bGrepOutputBaseFolder = true;
+	dlg.m_bGrepSeparateFolder = true;
+
+	const GrepInfo gi = dlg.MakeGrepInfo();
+
+	EXPECT_STREQ(L"ぐれっぷ", gi.cmGrepKey.GetStringPtr());
+	EXPECT_STREQ(L"*.cpp", gi.cmGrepFile.GetStringPtr());
+	EXPECT_STREQ(L"C:\\work\\sakura", gi.cmGrepFolder.GetStringPtr());
+	EXPECT_TRUE(gi.sGrepSearchOption.bRegularExp);
+	EXPECT_TRUE(gi.bGrepSubFolder);
+	EXPECT_EQ(CODE_EUC, gi.nGrepCharSet);
+	EXPECT_EQ(2, gi.nGrepOutputStyle);
+	EXPECT_EQ(2, gi.nGrepOutputLineType);
+	EXPECT_TRUE(gi.bGrepOutputFileOnly);
+	EXPECT_TRUE(gi.bGrepOutputBaseFolder);
+	EXPECT_TRUE(gi.bGrepSeparateFolder);
+
+	// Grep置換ではないので置換系は落ちている
+	EXPECT_FALSE(gi.bGrepReplace);
+	EXPECT_FALSE(gi.bGrepPaste);
+	EXPECT_FALSE(gi.bGrepBackup);
+
+	// 従来 Command_GREP が直接渡していた既定値
+	EXPECT_FALSE(gi.bGrepCurFolder);
+	EXPECT_FALSE(gi.bGrepStdout);
+	EXPECT_TRUE(gi.bGrepHeader);
+}
+
+/*!
+ * @brief CDlgGrep::MakeGrepInfo() のテスト
+ *  除外ファイル・除外フォルダーがファイルパターンに pack されること
+ */
+TEST_F(CDlgGrepTest, MakeGrepInfo_PacksExcludePatterns)
+{
+	CDlgGrep dlg;
+	dlg.m_szFile = L"*.cpp";
+	dlg.m_szExcludeFile = L"*.bak";
+	dlg.m_szExcludeFolder = L"obj";
+
+	const GrepInfo gi = dlg.MakeGrepInfo();
+
+	// 除外フォルダー(#)が先、除外ファイル(!)が後ろに連結される
+	EXPECT_STREQ(L"*.cpp;#obj;!*.bak", gi.cmGrepFile.GetStringPtr());
+}
+
+/*!
+ * @brief CDlgGrepReplace::MakeGrepInfo() のテスト
+ *  基底の内容に置換固有の項目が足されること
+ */
+TEST_F(CDlgGrepTest, MakeGrepInfo_ReplaceDialogAddsReplaceFields)
+{
+	CDlgGrepReplace dlg;
+	dlg.m_strText = L"before";
+	dlg.m_strText2 = L"after";
+	dlg.m_szFile = L"*.cpp";
+	dlg.m_szFolder = L"C:\\work";
+	dlg.m_bPaste = true;
+	dlg.m_bBackup = true;
+
+	const GrepInfo gi = dlg.MakeGrepInfo();
+
+	EXPECT_STREQ(L"before", gi.cmGrepKey.GetStringPtr());
+	EXPECT_STREQ(L"after", gi.cmGrepRep.GetStringPtr());
+	EXPECT_STREQ(L"*.cpp", gi.cmGrepFile.GetStringPtr());
+	EXPECT_TRUE(gi.bGrepReplace);
+	EXPECT_TRUE(gi.bGrepPaste);
+	EXPECT_TRUE(gi.bGrepBackup);
 }


### PR DESCRIPTION
PR #2631 の続きで、`CGrepAgent::DoGrep()` の 20 個の引数を構造体渡しに変更してます。

## 変更内容

- `DoGrep()` を `DWORD DoGrep( CEditView* pcViewDst, const GrepInfo& gi )` の 2 引数にしました。
- `DoGrep()` 冒頭の「Grepオプションまとめ」18 行を `SGrepOption::FromGrepInfo()` に切り出しました。
- ダイアログの設定から `GrepInfo` を作る `CDlgGrep::MakeGrepInfo()` / `CDlgGrepReplace::MakeGrepInfo()` を追加しました。
- 呼び出し元 3 箇所（`CNormalProcess::InitializeProcess()`、`Command_GREP()`、`Command_GREP_REPLACE()`）を書き換えました。

## 呼び出し側への影響

`Command_GREP()` は実引数を組み立てるための `cmWork1`〜`cmWork4` が不要になったので削除しました。`Command_GREP_REPLACE()` の同名変数は else 側でコマンドライン文字列を作るのに使っているため残しています。

従来ダイアログ経路が固定値で渡していた `bGrepCurFolder = false` / `bGrepStdout = false` / `bGrepHeader = true` は `MakeGrepInfo()` の中で同じ値を設定しています。


## テスト
tests1 は 1,363 件 / 0 failed（#2631 の 1,357 件 +6）、SonarQube の New Code カバレッジは 87.3%、重複 0.0% です。

## 意図的にやっていないこと

- `DoGrepTree()` / `DoGrepFile()` / `DoGrepReplaceFile()` の引数整理。本 PR は `DoGrep()` の入口だけに絞っています。
- 既存の `BOOL` の一括 `bool` 化。PR #2631 でご指摘いただいた件ですが、利用箇所の全数確認が必要なので別途とします。
- I/F の `LPCWSTR` → `std::wstring_view` 移行。Issue #2596 の横断課題として扱います。

## 確認したいこと

`CDlgGrep` に `MakeGrepInfo()` を足した形でよいでしょうか。

呼び出し側で `GrepInfo` を組み立てるとそこは単体テストから叩けず、New Code カバレッジが 46.6% でした。ダイアログ側に寄せると直接構築してテストでき 87.3% になっています。`CDlgGrep::GetData()` まわりの整理でまとめて扱うべきであれば、本 PR からは外して呼び出し側に戻します。
